### PR TITLE
feat(phase-3a): playground shell dev server

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -56,6 +56,7 @@
     "node_modules/**",
     "fixtures/**",
     "**/*.svelte",
+    "scripts/playground/**/*.svelte",
     "*.lock"
   ],
   "overrides": [

--- a/package.json
+++ b/package.json
@@ -128,7 +128,7 @@
     "lint": "oxlint --type-aware --tsconfig ./tsconfig.json",
     "lint:fix": "oxlint --fix --type-aware --tsconfig ./tsconfig.json",
     "prepack": "bun run build",
-    "playground": "echo 'Playground lands in Phase 3a.' && exit 0",
+    "playground": "bun --hot run scripts/playground/server.ts",
     "prepare": "husky",
     "prepublishOnly": "bun run validate && bun run build",
     "start": "echo 'No direct runtime start entrypoint is configured for this package.' && exit 1",
@@ -137,6 +137,7 @@
     "typecheck": "tsc --noEmit -p tsconfig.check.json && bunx svelte-check --tsconfig tsconfig.json --threshold error",
     "validate": "bun run lint && bun run typecheck && bun run test && bun run validate:workflow && bun run validate:consumer",
     "validate:consumer": "bun run scripts/validate-consumers.ts",
+    "validate:playground": "bun run scripts/playground/validate-playground.ts",
     "validate:workflow": "bun run scripts/validate-commit-workflow.ts",
     "verify:release-version": "bun run scripts/verify-release-version.ts"
   },

--- a/package.json
+++ b/package.json
@@ -128,7 +128,7 @@
     "lint": "oxlint --type-aware --tsconfig ./tsconfig.json",
     "lint:fix": "oxlint --fix --type-aware --tsconfig ./tsconfig.json",
     "prepack": "bun run build",
-    "playground": "bun --hot run scripts/playground/server.ts",
+    "playground": "bun --watch run scripts/playground/server.ts",
     "prepare": "husky",
     "prepublishOnly": "bun run validate && bun run build",
     "start": "echo 'No direct runtime start entrypoint is configured for this package.' && exit 1",

--- a/scripts/playground/app.svelte
+++ b/scripts/playground/app.svelte
@@ -5,5 +5,3 @@
   // eslint-disable-next-line no-console
   console.info(signal);
 </script>
-
-// @ts-nocheck

--- a/scripts/playground/app.svelte
+++ b/scripts/playground/app.svelte
@@ -1,0 +1,9 @@
+<script>
+  // Phase 3a stub — the interactive sidebar shell expands in Phase 3b.
+  // This signal confirms the Svelte bundle compiled and mounted successfully.
+  const signal = '[cinder playground] ready';
+  // eslint-disable-next-line no-console
+  console.info(signal);
+</script>
+
+// @ts-nocheck

--- a/scripts/playground/component-page.svelte
+++ b/scripts/playground/component-page.svelte
@@ -68,7 +68,6 @@
           const Component = module.default;
           if (typeof Component !== 'function') return;
 
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
           const app = mount(Component, { target: container }) as { destroy?: () => void };
           localApps.push(app);
         } catch (error) {

--- a/scripts/playground/component-page.svelte
+++ b/scripts/playground/component-page.svelte
@@ -1,6 +1,6 @@
 <!-- dev-only playground scaffold; window.__CINDER_EXAMPLES__ is injected server-side -->
 <script lang="ts">
-  import { mount, onDestroy } from 'svelte';
+  import { mount } from 'svelte';
 
   type CinderExampleDescriptor = { scenario: string; title: string; description?: string };
   type CinderWindow = Window &
@@ -8,10 +8,13 @@
 
   // The server injects window.__CINDER_EXAMPLES__ before the bundle script tag.
   // Fall back to an empty array so the component doesn't crash if the global is missing.
-  const examples: CinderExampleDescriptor[] =
-    typeof window !== 'undefined' && Array.isArray((window as CinderWindow).__CINDER_EXAMPLES__)
-      ? ((window as CinderWindow).__CINDER_EXAMPLES__ ?? [])
-      : [];
+  function readExamples(): CinderExampleDescriptor[] {
+    if (typeof window === 'undefined') return [];
+    const raw = (window as CinderWindow).__CINDER_EXAMPLES__;
+    return Array.isArray(raw) ? raw : [];
+  }
+
+  const examples: CinderExampleDescriptor[] = readExamples();
 
   // Extract the component name from the current URL path: /c/<name>
   const componentName: string = window.location.pathname.replace(/^\/c\//, '').split('/')[0] ?? '';
@@ -44,49 +47,49 @@
   // .example.svelte into its own bundle at /bundle/<name>/<scenario>.js (separate
   // from the component-page bundle itself). We dynamically import them so the
   // component-page doesn't need to know the module graph at compile time.
-  //
-  // Mounted instances collected for cleanup. Svelte 5's mount() returns
-  // Record<string, any> in practice; we cast to get the destroy() call.
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const mountedApps: Array<{ destroy?: () => void }> = [];
-
   $effect(() => {
+    // Per-run local collection so the cleanup only destroys this run's mounts.
+    const localApps: Array<{ destroy?: () => void }> = [];
+    let cancelled = false;
+
     for (const { scenario } of examples) {
       const containerId = `example-mount-${scenario}`;
 
       // Use a microtask so the DOM element rendered by the template is
       // guaranteed to exist before we try to mount into it.
       queueMicrotask(async () => {
+        if (cancelled) return;
         const container = document.getElementById(containerId);
         if (!container) return;
 
         try {
           const module = await import(`/bundle/${componentName}/${scenario}.js`);
+          if (cancelled) return;
           const Component = module.default;
           if (typeof Component !== 'function') return;
 
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          const app = mount(Component, { target: container }) as any;
-          mountedApps.push(app as { destroy?: () => void });
+          const app = mount(Component, { target: container }) as { destroy?: () => void };
+          localApps.push(app);
         } catch (error) {
           console.error(`[cinder playground] failed to mount example "${scenario}":`, error);
         }
       });
     }
-  });
 
-  onDestroy(() => {
-    for (const app of mountedApps) {
-      try {
-        app.destroy?.();
-      } catch {
-        // Suppress — best-effort cleanup only.
+    return () => {
+      cancelled = true;
+      for (const app of localApps) {
+        try {
+          app.destroy?.();
+        } catch {
+          // Suppress — best-effort cleanup only.
+        }
       }
-    }
+    };
   });
 </script>
 
-// @ts-nocheck
 <div class="example-list">
   {#if examples.length === 0}
     <p class="no-examples">No examples found for <code>{componentName}</code>.</p>

--- a/scripts/playground/component-page.svelte
+++ b/scripts/playground/component-page.svelte
@@ -1,0 +1,217 @@
+<!-- dev-only playground scaffold; window.__CINDER_EXAMPLES__ is injected server-side -->
+<script lang="ts">
+  import { mount, onDestroy } from 'svelte';
+
+  type CinderExampleDescriptor = { scenario: string; title: string; description?: string };
+  type CinderWindow = Window &
+    typeof globalThis & { __CINDER_EXAMPLES__?: CinderExampleDescriptor[] };
+
+  // The server injects window.__CINDER_EXAMPLES__ before the bundle script tag.
+  // Fall back to an empty array so the component doesn't crash if the global is missing.
+  const examples: CinderExampleDescriptor[] =
+    typeof window !== 'undefined' && Array.isArray((window as CinderWindow).__CINDER_EXAMPLES__)
+      ? ((window as CinderWindow).__CINDER_EXAMPLES__ ?? [])
+      : [];
+
+  // Extract the component name from the current URL path: /c/<name>
+  const componentName: string = window.location.pathname.replace(/^\/c\//, '').split('/')[0] ?? '';
+
+  // Track which <details> elements have had their source fetched so we only
+  // hit /example-src once per scenario regardless of how many times the user
+  // opens and closes the disclosure.
+  const fetchedSource: Record<string, string | null> = $state({});
+  const loadingSource: Record<string, boolean> = $state({});
+
+  async function handleDetailsToggle(event: Event, scenario: string): Promise<void> {
+    const details = event.currentTarget as HTMLDetailsElement;
+
+    if (!details.open) return;
+    if (fetchedSource[scenario] !== undefined) return;
+
+    loadingSource[scenario] = true;
+
+    try {
+      const response = await fetch(`/example-src/${componentName}/${scenario}`);
+      fetchedSource[scenario] = response.ok ? await response.text() : null;
+    } catch {
+      fetchedSource[scenario] = null;
+    } finally {
+      loadingSource[scenario] = false;
+    }
+  }
+
+  // Mount each example bundle into its target element. The server compiles each
+  // .example.svelte into its own bundle at /bundle/<name>/<scenario>.js (separate
+  // from the component-page bundle itself). We dynamically import them so the
+  // component-page doesn't need to know the module graph at compile time.
+  //
+  // Mounted instances collected for cleanup. Svelte 5's mount() returns
+  // Record<string, any> in practice; we cast to get the destroy() call.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const mountedApps: Array<{ destroy?: () => void }> = [];
+
+  $effect(() => {
+    for (const { scenario } of examples) {
+      const containerId = `example-mount-${scenario}`;
+
+      // Use a microtask so the DOM element rendered by the template is
+      // guaranteed to exist before we try to mount into it.
+      queueMicrotask(async () => {
+        const container = document.getElementById(containerId);
+        if (!container) return;
+
+        try {
+          const module = await import(`/bundle/${componentName}/${scenario}.js`);
+          const Component = module.default;
+          if (typeof Component !== 'function') return;
+
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          const app = mount(Component, { target: container }) as any;
+          mountedApps.push(app as { destroy?: () => void });
+        } catch (error) {
+          console.error(`[cinder playground] failed to mount example "${scenario}":`, error);
+        }
+      });
+    }
+  });
+
+  onDestroy(() => {
+    for (const app of mountedApps) {
+      try {
+        app.destroy?.();
+      } catch {
+        // Suppress — best-effort cleanup only.
+      }
+    }
+  });
+</script>
+
+// @ts-nocheck
+<div class="example-list">
+  {#if examples.length === 0}
+    <p class="no-examples">No examples found for <code>{componentName}</code>.</p>
+  {/if}
+
+  {#each examples as { scenario, title, description } (scenario)}
+    <section class="example-card">
+      <header class="example-card-header">
+        <h2 class="example-title">{title}</h2>
+        {#if description}
+          <p class="example-description">{description}</p>
+        {/if}
+      </header>
+
+      <div class="example-preview" id="example-mount-{scenario}"></div>
+
+      <details class="example-source" ontoggle={(event) => handleDetailsToggle(event, scenario)}>
+        <summary class="example-source-toggle">View source</summary>
+
+        <div class="example-source-body">
+          {#if loadingSource[scenario]}
+            <p class="source-loading">Loading…</p>
+          {:else if fetchedSource[scenario] === null}
+            <p class="source-error">Could not load source.</p>
+          {:else if fetchedSource[scenario] !== undefined}
+            <pre class="source-code"><code>{fetchedSource[scenario]}</code></pre>
+          {/if}
+        </div>
+      </details>
+    </section>
+  {/each}
+</div>
+
+<style>
+  .example-list {
+    display: flex;
+    flex-direction: column;
+    gap: var(--cinder-space-8);
+  }
+
+  .no-examples {
+    color: var(--cinder-text-muted);
+    font-style: italic;
+    margin: 0;
+  }
+
+  .example-card {
+    background-color: var(--cinder-surface);
+    border: 1px solid var(--cinder-border);
+    border-radius: var(--cinder-radius-lg);
+    overflow: hidden;
+  }
+
+  .example-card-header {
+    padding: var(--cinder-space-4) var(--cinder-space-6);
+    border-bottom: 1px solid var(--cinder-border-muted);
+  }
+
+  .example-title {
+    margin: 0 0 var(--cinder-space-1) 0;
+    font-size: var(--cinder-text-lg);
+    font-weight: var(--cinder-font-semibold);
+    line-height: var(--cinder-leading-snug);
+    color: var(--cinder-text);
+  }
+
+  .example-description {
+    margin: 0;
+    font-size: var(--cinder-text-sm);
+    color: var(--cinder-text-muted);
+    line-height: var(--cinder-leading-normal);
+  }
+
+  .example-preview {
+    padding: var(--cinder-space-6);
+    min-height: 4rem;
+    display: flex;
+    align-items: flex-start;
+    flex-wrap: wrap;
+    gap: var(--cinder-space-4);
+  }
+
+  .example-source {
+    border-top: 1px solid var(--cinder-border-muted);
+  }
+
+  .example-source-toggle {
+    display: block;
+    padding: var(--cinder-space-2) var(--cinder-space-6);
+    font-size: var(--cinder-text-sm);
+    font-weight: var(--cinder-font-medium);
+    color: var(--cinder-text-subtle);
+    cursor: pointer;
+    user-select: none;
+    transition: color var(--cinder-duration-fast) var(--cinder-ease-standard);
+  }
+
+  .example-source-toggle:hover {
+    color: var(--cinder-text);
+  }
+
+  .example-source-body {
+    padding: 0 var(--cinder-space-6) var(--cinder-space-4);
+  }
+
+  .source-loading,
+  .source-error {
+    margin: 0;
+    font-size: var(--cinder-text-sm);
+    color: var(--cinder-text-subtle);
+    font-style: italic;
+  }
+
+  .source-code {
+    margin: 0;
+    padding: var(--cinder-space-4);
+    background-color: var(--cinder-surface-inset);
+    border: 1px solid var(--cinder-border-muted);
+    border-radius: var(--cinder-radius-md);
+    font-family: var(--cinder-font-mono);
+    font-size: var(--cinder-text-xs);
+    line-height: var(--cinder-leading-relaxed);
+    color: var(--cinder-text);
+    overflow-x: auto;
+    white-space: pre;
+    tab-size: 2;
+  }
+</style>

--- a/scripts/playground/discover.test.ts
+++ b/scripts/playground/discover.test.ts
@@ -53,9 +53,10 @@ describe('discoverComponents', () => {
 });
 
 describe('discoverExamples', () => {
-  it("returns ['primary'] for the button component", async () => {
+  it('returns at least one example for the button component', async () => {
     const examples = await discoverExamples('button');
-    expect(examples).toEqual(['primary']);
+    expect(examples.length).toBeGreaterThanOrEqual(1);
+    expect(examples).toContain('primary');
   });
 
   it('returns an empty array for a nonexistent component without throwing', async () => {
@@ -88,11 +89,11 @@ describe('discoverAll', () => {
     }
   });
 
-  it('reports exampleCount: 1 for button', async () => {
+  it('reports exampleCount >= 1 for button', async () => {
     const results = await discoverAll();
     const buttonEntry = results.find((entry) => entry.name === 'button');
     expect(buttonEntry).toBeDefined();
-    expect(buttonEntry!.exampleCount).toBe(1);
+    expect(buttonEntry!.exampleCount).toBeGreaterThanOrEqual(1);
   });
 
   it('covers at least 21 components', async () => {

--- a/scripts/playground/discover.test.ts
+++ b/scripts/playground/discover.test.ts
@@ -1,0 +1,110 @@
+/**
+ * Unit tests for `scripts/playground/discover.ts`.
+ *
+ * Must be run from the repo root so that `process.cwd()` resolves to
+ * `/Users/stevekinney/Developer/cinder` and the globs find the real
+ * `src/components/` and `scripts/playground/examples/` trees.
+ */
+
+import { describe, expect, it } from 'bun:test';
+
+import { discoverAll, discoverComponents, discoverExamples } from './discover.ts';
+
+describe('discoverComponents', () => {
+  it('returns an array of component kebab names', async () => {
+    const components = await discoverComponents();
+    expect(Array.isArray(components)).toBe(true);
+    expect(components.length).toBeGreaterThan(0);
+  });
+
+  it('includes button, alert, and modal', async () => {
+    const components = await discoverComponents();
+    expect(components).toContain('button');
+    expect(components).toContain('alert');
+    expect(components).toContain('modal');
+  });
+
+  it('does not include anything from _internal/', async () => {
+    const components = await discoverComponents();
+    // All names should be plain kebab identifiers with no path separator
+    for (const name of components) {
+      expect(name).not.toContain('/');
+      expect(name).not.toContain('_internal');
+    }
+  });
+
+  it('returns names without a .svelte extension', async () => {
+    const components = await discoverComponents();
+    for (const name of components) {
+      expect(name).not.toMatch(/\.svelte$/);
+    }
+  });
+
+  it('returns a sorted list', async () => {
+    const components = await discoverComponents();
+    const sorted = [...components].toSorted();
+    expect(components).toEqual(sorted);
+  });
+
+  it('returns at least 21 components', async () => {
+    const components = await discoverComponents();
+    expect(components.length).toBeGreaterThanOrEqual(21);
+  });
+});
+
+describe('discoverExamples', () => {
+  it("returns ['primary'] for the button component", async () => {
+    const examples = await discoverExamples('button');
+    expect(examples).toEqual(['primary']);
+  });
+
+  it('returns an empty array for a nonexistent component without throwing', async () => {
+    const examples = await discoverExamples('nonexistent');
+    expect(examples).toEqual([]);
+  });
+
+  it('returns names without the .example.svelte extension', async () => {
+    const examples = await discoverExamples('button');
+    for (const example of examples) {
+      expect(example).not.toMatch(/\.example\.svelte$/);
+    }
+  });
+
+  it('returns a sorted list', async () => {
+    const examples = await discoverExamples('button');
+    const sorted = [...examples].toSorted();
+    expect(examples).toEqual(sorted);
+  });
+});
+
+describe('discoverAll', () => {
+  it('returns an array of { name, exampleCount } objects', async () => {
+    const results = await discoverAll();
+    expect(Array.isArray(results)).toBe(true);
+    for (const entry of results) {
+      expect(typeof entry.name).toBe('string');
+      expect(typeof entry.exampleCount).toBe('number');
+      expect(entry.exampleCount).toBeGreaterThanOrEqual(0);
+    }
+  });
+
+  it('reports exampleCount: 1 for button', async () => {
+    const results = await discoverAll();
+    const buttonEntry = results.find((entry) => entry.name === 'button');
+    expect(buttonEntry).toBeDefined();
+    expect(buttonEntry!.exampleCount).toBe(1);
+  });
+
+  it('covers at least 21 components', async () => {
+    const results = await discoverAll();
+    expect(results.length).toBeGreaterThanOrEqual(21);
+  });
+
+  it('includes entries for button, alert, and modal', async () => {
+    const results = await discoverAll();
+    const names = results.map((entry) => entry.name);
+    expect(names).toContain('button');
+    expect(names).toContain('alert');
+    expect(names).toContain('modal');
+  });
+});

--- a/scripts/playground/discover.ts
+++ b/scripts/playground/discover.ts
@@ -1,0 +1,53 @@
+/**
+ * Discovery utilities for the cinder component playground.
+ *
+ * Scans `src/components/` for public Svelte components and
+ * `scripts/playground/examples/` for their associated scenario files.
+ * All scanning uses `Bun.Glob` relative to `process.cwd()` (repo root).
+ */
+
+/** Returns a sorted array of component kebab names from `src/components/*.svelte` (top-level only, no `_internal/`). */
+export async function discoverComponents(): Promise<string[]> {
+  const glob = new Bun.Glob('src/components/*.svelte');
+  const names: string[] = [];
+
+  for await (const file of glob.scan({ cwd: process.cwd() })) {
+    // file is like "src/components/button.svelte"
+    const basename = file.split('/').pop()!;
+    const name = basename.replace(/\.svelte$/, '');
+    names.push(name);
+  }
+
+  return names.toSorted();
+}
+
+/**
+ * Returns a sorted array of scenario names (basename without `.example.svelte`)
+ * for a given component name.
+ */
+export async function discoverExamples(componentName: string): Promise<string[]> {
+  const glob = new Bun.Glob(`scripts/playground/examples/${componentName}/*.example.svelte`);
+  const scenarios: string[] = [];
+
+  for await (const file of glob.scan({ cwd: process.cwd() })) {
+    const basename = file.split('/').pop()!;
+    const scenario = basename.replace(/\.example\.svelte$/, '');
+    scenarios.push(scenario);
+  }
+
+  return scenarios.toSorted();
+}
+
+/** Returns all components paired with their example count. */
+export async function discoverAll(): Promise<Array<{ name: string; exampleCount: number }>> {
+  const components = await discoverComponents();
+
+  const results = await Promise.all(
+    components.map(async (name) => {
+      const examples = await discoverExamples(name);
+      return { name, exampleCount: examples.length };
+    }),
+  );
+
+  return results;
+}

--- a/scripts/playground/examples/accordion/basic.example.svelte
+++ b/scripts/playground/examples/accordion/basic.example.svelte
@@ -1,0 +1,22 @@
+<script lang="ts" module>
+  export const title = 'Basic accordion';
+  export const description = 'Single-select: opening one item closes the others.';
+</script>
+
+<script lang="ts">
+  import { Accordion, AccordionItem } from '../../../../src/index.ts';
+
+  let expandedIds = $state<string[]>([]);
+</script>
+
+<Accordion bind:expandedIds>
+  <AccordionItem id="item-1" title="What is Cinder?">
+    Cinder is a Svelte 5 design system built for composability and accessibility.
+  </AccordionItem>
+  <AccordionItem id="item-2" title="How do I install it?">
+    Run <code>bun add cinder</code> and import components from <code>cinder</code> or via subpath imports.
+  </AccordionItem>
+  <AccordionItem id="item-3" title="Does it support SSR?">
+    Yes — every component is SSR-safe and renders meaningful HTML before hydration.
+  </AccordionItem>
+</Accordion>

--- a/scripts/playground/examples/accordion/disabled.example.svelte
+++ b/scripts/playground/examples/accordion/disabled.example.svelte
@@ -1,0 +1,18 @@
+<script lang="ts" module>
+  export const title = 'Disabled item';
+  export const description = 'A disabled AccordionItem cannot be toggled.';
+</script>
+
+<script lang="ts">
+  import { Accordion, AccordionItem } from '../../../../src/index.ts';
+
+  let expandedIds = $state<string[]>([]);
+</script>
+
+<Accordion bind:expandedIds>
+  <AccordionItem id="a" title="Available">This item can be toggled normally.</AccordionItem>
+  <AccordionItem id="b" title="Disabled (locked)" disabled>
+    This content is never shown because the item is disabled.
+  </AccordionItem>
+  <AccordionItem id="c" title="Also available">This one too.</AccordionItem>
+</Accordion>

--- a/scripts/playground/examples/accordion/multiple.example.svelte
+++ b/scripts/playground/examples/accordion/multiple.example.svelte
@@ -1,0 +1,22 @@
+<script lang="ts" module>
+  export const title = 'Multiple open';
+  export const description = 'With multiple={true}, any number of items can be open at once.';
+</script>
+
+<script lang="ts">
+  import { Accordion, AccordionItem } from '../../../../src/index.ts';
+
+  let expandedIds = $state<string[]>(['faq-1', 'faq-3']);
+</script>
+
+<Accordion multiple bind:expandedIds>
+  <AccordionItem id="faq-1" title="Can I use multiple themes?">
+    Yes — swap the CSS variables or layer your own tokens on top.
+  </AccordionItem>
+  <AccordionItem id="faq-2" title="Is it tree-shakeable?">
+    Every component is individually importable via subpath exports.
+  </AccordionItem>
+  <AccordionItem id="faq-3" title="What browsers are supported?">
+    Modern evergreen browsers. IE is not supported.
+  </AccordionItem>
+</Accordion>

--- a/scripts/playground/examples/alert/dismissible.example.svelte
+++ b/scripts/playground/examples/alert/dismissible.example.svelte
@@ -1,0 +1,18 @@
+<script lang="ts" module>
+  export const title = 'Dismissible alert';
+  export const description = 'An alert with a close button that fires onDismiss.';
+</script>
+
+<script lang="ts">
+  import { Alert } from '../../../../src/index.ts';
+
+  let dismissed = $state(false);
+</script>
+
+{#if !dismissed}
+  <Alert variant="info" dismissible onDismiss={() => (dismissed = true)}>
+    You have 3 unread notifications.
+  </Alert>
+{:else}
+  <p style="color: var(--cinder-text-muted); font-style: italic;">Alert dismissed.</p>
+{/if}

--- a/scripts/playground/examples/alert/variants.example.svelte
+++ b/scripts/playground/examples/alert/variants.example.svelte
@@ -1,0 +1,15 @@
+<script lang="ts" module>
+  export const title = 'Alert variants';
+  export const description = 'Info, success, warning, and error alerts.';
+</script>
+
+<script lang="ts">
+  import { Alert } from '../../../../src/index.ts';
+</script>
+
+<div style="display: flex; flex-direction: column; gap: 1rem;">
+  <Alert variant="info">Your account sync is in progress.</Alert>
+  <Alert variant="success">Changes saved successfully.</Alert>
+  <Alert variant="warning">Your trial expires in 3 days.</Alert>
+  <Alert variant="error">Failed to connect to the server.</Alert>
+</div>

--- a/scripts/playground/examples/alert/with-icon.example.svelte
+++ b/scripts/playground/examples/alert/with-icon.example.svelte
@@ -1,0 +1,26 @@
+<script lang="ts" module>
+  export const title = 'Alert with icon';
+  export const description = 'Custom icon slot alongside the alert message.';
+</script>
+
+<script lang="ts">
+  import { Alert } from '../../../../src/index.ts';
+</script>
+
+<Alert variant="success">
+  {#snippet icon()}
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="16"
+      height="16"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      stroke-width="2"
+      aria-hidden="true"
+    >
+      <polyline points="20 6 9 17 4 12"></polyline>
+    </svg>
+  {/snippet}
+  Deployment complete — all systems nominal.
+</Alert>

--- a/scripts/playground/examples/badge/sizes.example.svelte
+++ b/scripts/playground/examples/badge/sizes.example.svelte
@@ -1,0 +1,13 @@
+<script lang="ts" module>
+  export const title = 'Badge sizes';
+  export const description = 'Small and medium sizes.';
+</script>
+
+<script lang="ts">
+  import { Badge } from '../../../../src/index.ts';
+</script>
+
+<div style="display: flex; flex-wrap: wrap; gap: 0.5rem; align-items: center;">
+  <Badge size="sm">Small</Badge>
+  <Badge size="md">Medium</Badge>
+</div>

--- a/scripts/playground/examples/badge/variants.example.svelte
+++ b/scripts/playground/examples/badge/variants.example.svelte
@@ -1,0 +1,16 @@
+<script lang="ts" module>
+  export const title = 'Badge variants';
+  export const description = 'All five semantic variant styles.';
+</script>
+
+<script lang="ts">
+  import { Badge } from '../../../../src/index.ts';
+</script>
+
+<div style="display: flex; flex-wrap: wrap; gap: 0.5rem; align-items: center;">
+  <Badge variant="neutral">Neutral</Badge>
+  <Badge variant="success">Success</Badge>
+  <Badge variant="warning">Warning</Badge>
+  <Badge variant="danger">Danger</Badge>
+  <Badge variant="info">Info</Badge>
+</div>

--- a/scripts/playground/examples/button/as-link.example.svelte
+++ b/scripts/playground/examples/button/as-link.example.svelte
@@ -1,0 +1,13 @@
+<script lang="ts" module>
+  export const title = 'Button as link';
+  export const description = 'Passing href renders an anchor element with button styling.';
+</script>
+
+<script lang="ts">
+  import { Button } from '../../../../src/index.ts';
+</script>
+
+<div style="display: flex; flex-wrap: wrap; gap: 0.5rem;">
+  <Button href="https://svelte.dev" target="_blank" rel="noopener noreferrer" label="Svelte docs" />
+  <Button href="#" variant="ghost" label="Internal link" />
+</div>

--- a/scripts/playground/examples/button/loading.example.svelte
+++ b/scripts/playground/examples/button/loading.example.svelte
@@ -1,0 +1,18 @@
+<script lang="ts" module>
+  export const title = 'Loading state';
+  export const description = 'Click to toggle loading; the button is disabled while loading.';
+</script>
+
+<script lang="ts">
+  import { Button } from '../../../../src/index.ts';
+
+  let loading = $state(false);
+
+  async function handleClick() {
+    loading = true;
+    await new Promise((resolve) => setTimeout(resolve, 2000));
+    loading = false;
+  }
+</script>
+
+<Button variant="primary" label="Save changes" {loading} onclick={handleClick} />

--- a/scripts/playground/examples/button/primary.example.svelte
+++ b/scripts/playground/examples/button/primary.example.svelte
@@ -1,0 +1,10 @@
+<script lang="ts" module>
+  export const title = 'Primary button';
+  export const description = 'The default button variant.';
+</script>
+
+<script lang="ts">
+  import { Button } from '../../../../src/index.ts';
+</script>
+
+<Button label="Click me" />

--- a/scripts/playground/examples/button/sizes.example.svelte
+++ b/scripts/playground/examples/button/sizes.example.svelte
@@ -1,0 +1,15 @@
+<script lang="ts" module>
+  export const title = 'Button sizes';
+  export const description = 'xs, sm, md, and lg sizes.';
+</script>
+
+<script lang="ts">
+  import { Button } from '../../../../src/index.ts';
+</script>
+
+<div style="display: flex; flex-wrap: wrap; gap: 0.5rem; align-items: center;">
+  <Button size="xs" label="Extra Small" />
+  <Button size="sm" label="Small" />
+  <Button size="md" label="Medium" />
+  <Button size="lg" label="Large" />
+</div>

--- a/scripts/playground/examples/button/variants.example.svelte
+++ b/scripts/playground/examples/button/variants.example.svelte
@@ -1,0 +1,15 @@
+<script lang="ts" module>
+  export const title = 'Button variants';
+  export const description = 'Primary, secondary, danger, and ghost styles.';
+</script>
+
+<script lang="ts">
+  import { Button } from '../../../../src/index.ts';
+</script>
+
+<div style="display: flex; flex-wrap: wrap; gap: 0.5rem; align-items: center;">
+  <Button variant="primary" label="Primary" />
+  <Button variant="secondary" label="Secondary" />
+  <Button variant="danger" label="Danger" />
+  <Button variant="ghost" label="Ghost" />
+</div>

--- a/scripts/playground/examples/card/with-header-snippet.example.svelte
+++ b/scripts/playground/examples/card/with-header-snippet.example.svelte
@@ -1,0 +1,21 @@
+<script lang="ts" module>
+  export const title = 'Card with header snippet';
+  export const description = 'Full control over the header via the header snippet.';
+</script>
+
+<script lang="ts">
+  import { Badge, Card } from '../../../../src/index.ts';
+</script>
+
+<Card>
+  {#snippet header()}
+    <div style="display: flex; justify-content: space-between; align-items: center;">
+      <strong>Open issues</strong>
+      <Badge variant="danger">12</Badge>
+    </div>
+  {/snippet}
+  <p>These issues require attention before the next release.</p>
+  {#snippet footer()}
+    <a href="#">View all →</a>
+  {/snippet}
+</Card>

--- a/scripts/playground/examples/card/with-title.example.svelte
+++ b/scripts/playground/examples/card/with-title.example.svelte
@@ -1,0 +1,13 @@
+<script lang="ts" module>
+  export const title = 'Card with title';
+  export const description = 'Simple API: title + description string props.';
+</script>
+
+<script lang="ts">
+  import { Card } from '../../../../src/index.ts';
+</script>
+
+<Card title="Monthly summary" description="Revenue and activity for April 2026.">
+  <p>Total revenue: $12,400</p>
+  <p>New users: 284</p>
+</Card>

--- a/scripts/playground/examples/data-list/basic.example.svelte
+++ b/scripts/playground/examples/data-list/basic.example.svelte
@@ -1,0 +1,23 @@
+<script lang="ts" module>
+  export const title = 'Basic data list';
+  export const description = 'Renders each item using the parameterized children snippet.';
+</script>
+
+<script lang="ts">
+  import { DataList } from '../../../../src/index.ts';
+
+  const users = [
+    { name: 'Alice Chen', role: 'Engineer' },
+    { name: 'Bob Osei', role: 'Designer' },
+    { name: 'Carol Mwangi', role: 'Product' },
+  ];
+</script>
+
+<DataList items={users}>
+  {#snippet children(user)}
+    <div style="display: flex; justify-content: space-between; padding: 0.5rem 0;">
+      <strong>{user.name}</strong>
+      <span style="color: var(--cinder-text-muted);">{user.role}</span>
+    </div>
+  {/snippet}
+</DataList>

--- a/scripts/playground/examples/data-list/empty.example.svelte
+++ b/scripts/playground/examples/data-list/empty.example.svelte
@@ -1,0 +1,17 @@
+<script lang="ts" module>
+  export const title = 'Empty state fallback';
+  export const description = 'The empty snippet renders when items is an empty array.';
+</script>
+
+<script lang="ts">
+  import { DataList } from '../../../../src/index.ts';
+</script>
+
+<DataList items={[]}>
+  {#snippet children(item)}
+    <span>{item}</span>
+  {/snippet}
+  {#snippet empty()}
+    <p style="color: var(--cinder-text-muted); font-style: italic;">No items to display.</p>
+  {/snippet}
+</DataList>

--- a/scripts/playground/examples/dropdown/basic.example.svelte
+++ b/scripts/playground/examples/dropdown/basic.example.svelte
@@ -1,0 +1,26 @@
+<script lang="ts" module>
+  export const title = 'Basic dropdown';
+  export const description = 'A button trigger with a list of menu items.';
+</script>
+
+<script lang="ts">
+  import { Dropdown } from '../../../../src/index.ts';
+
+  let open = $state(false);
+</script>
+
+<Dropdown bind:open>
+  {#snippet trigger()}
+    <button type="button">Options ▾</button>
+  {/snippet}
+  <ul role="menu" style="list-style: none; margin: 0; padding: 0.5rem 0; min-width: 160px;">
+    <li role="menuitem" style="padding: 0.5rem 1rem; cursor: pointer;">Edit</li>
+    <li role="menuitem" style="padding: 0.5rem 1rem; cursor: pointer;">Duplicate</li>
+    <li
+      role="menuitem"
+      style="padding: 0.5rem 1rem; cursor: pointer; color: var(--cinder-text-danger);"
+    >
+      Delete
+    </li>
+  </ul>
+</Dropdown>

--- a/scripts/playground/examples/dropdown/placement.example.svelte
+++ b/scripts/playground/examples/dropdown/placement.example.svelte
@@ -1,0 +1,27 @@
+<script lang="ts" module>
+  export const title = 'Placement';
+  export const description = 'bottom-start and bottom-end placement options.';
+</script>
+
+<script lang="ts">
+  import { Dropdown } from '../../../../src/index.ts';
+
+  let openStart = $state(false);
+  let openEnd = $state(false);
+</script>
+
+<div style="display: flex; gap: 1rem;">
+  <Dropdown bind:open={openStart} placement="bottom-start">
+    {#snippet trigger()}
+      <button type="button">Bottom-start ▾</button>
+    {/snippet}
+    <div style="padding: 0.5rem 1rem; min-width: 140px;">Aligned to left edge</div>
+  </Dropdown>
+
+  <Dropdown bind:open={openEnd} placement="bottom-end">
+    {#snippet trigger()}
+      <button type="button">Bottom-end ▾</button>
+    {/snippet}
+    <div style="padding: 0.5rem 1rem; min-width: 140px;">Aligned to right edge</div>
+  </Dropdown>
+</div>

--- a/scripts/playground/examples/empty-state/basic.example.svelte
+++ b/scripts/playground/examples/empty-state/basic.example.svelte
@@ -1,0 +1,14 @@
+<script lang="ts" module>
+  export const title = 'Basic empty state';
+  export const description = 'Title, description, and an action button.';
+</script>
+
+<script lang="ts">
+  import { Button, EmptyState } from '../../../../src/index.ts';
+</script>
+
+<EmptyState title="No results found" description="Try adjusting your filters or search query.">
+  {#snippet action()}
+    <Button variant="primary" label="Clear filters" />
+  {/snippet}
+</EmptyState>

--- a/scripts/playground/examples/empty-state/with-icon.example.svelte
+++ b/scripts/playground/examples/empty-state/with-icon.example.svelte
@@ -1,0 +1,26 @@
+<script lang="ts" module>
+  export const title = 'With icon';
+  export const description = 'An icon snippet above the title.';
+</script>
+
+<script lang="ts">
+  import { EmptyState } from '../../../../src/index.ts';
+</script>
+
+<EmptyState title="No documents" description="Upload your first document to get started.">
+  {#snippet icon()}
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="48"
+      height="48"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      stroke-width="1.5"
+      aria-hidden="true"
+    >
+      <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"></path>
+      <polyline points="14 2 14 8 20 8"></polyline>
+    </svg>
+  {/snippet}
+</EmptyState>

--- a/scripts/playground/examples/input/basic.example.svelte
+++ b/scripts/playground/examples/input/basic.example.svelte
@@ -1,0 +1,15 @@
+<script lang="ts" module>
+  export const title = 'Basic input';
+  export const description = 'Text input with label and bound value.';
+</script>
+
+<script lang="ts">
+  import { Input } from '../../../../src/index.ts';
+
+  let name = $state('');
+</script>
+
+<Input id="name" bind:value={name} label="Full name" placeholder="Jane Smith" />
+{#if name}
+  <p style="margin-top: 0.5rem; color: var(--cinder-text-muted);">Hello, {name}!</p>
+{/if}

--- a/scripts/playground/examples/input/types.example.svelte
+++ b/scripts/playground/examples/input/types.example.svelte
@@ -1,0 +1,20 @@
+<script lang="ts" module>
+  export const title = 'Input types';
+  export const description = 'Text, email, password, search, tel, and url types.';
+</script>
+
+<script lang="ts">
+  import { Input } from '../../../../src/index.ts';
+
+  let text = $state('');
+  let email = $state('');
+  let password = $state('');
+  let search = $state('');
+</script>
+
+<div style="display: flex; flex-direction: column; gap: 1rem;">
+  <Input id="t-text" type="text" bind:value={text} label="Text" placeholder="Plain text" />
+  <Input id="t-email" type="email" bind:value={email} label="Email" placeholder="you@example.com" />
+  <Input id="t-password" type="password" bind:value={password} label="Password" />
+  <Input id="t-search" type="search" bind:value={search} label="Search" placeholder="Search…" />
+</div>

--- a/scripts/playground/examples/input/with-error.example.svelte
+++ b/scripts/playground/examples/input/with-error.example.svelte
@@ -1,0 +1,20 @@
+<script lang="ts" module>
+  export const title = 'Input with error';
+  export const description = 'Error message wired via aria-invalid and aria-describedby.';
+</script>
+
+<script lang="ts">
+  import { Input } from '../../../../src/index.ts';
+
+  let email = $state('not-an-email');
+  const hasError = $derived(!email.includes('@'));
+</script>
+
+<Input
+  id="email"
+  type="email"
+  bind:value={email}
+  label="Email address"
+  description="We'll never share your email."
+  {...hasError ? { error: 'Enter a valid email address.' } : {}}
+/>

--- a/scripts/playground/examples/modal/basic.example.svelte
+++ b/scripts/playground/examples/modal/basic.example.svelte
@@ -1,0 +1,23 @@
+<script lang="ts" module>
+  export const title = 'Basic modal';
+  export const description = 'A dialog opened by a button; Escape key closes it.';
+</script>
+
+<script lang="ts">
+  import { Button, Modal } from '../../../../src/index.ts';
+
+  let open = $state(false);
+  let triggerRef: HTMLButtonElement | undefined = $state();
+</script>
+
+<button bind:this={triggerRef} type="button" onclick={() => (open = true)}>Open modal</button>
+
+<Modal bind:open title="Confirm action" {triggerRef}>
+  <p>Are you sure you want to proceed? This action cannot be undone.</p>
+  {#snippet footer()}
+    <div style="display: flex; gap: 0.5rem; justify-content: flex-end;">
+      <Button variant="secondary" label="Cancel" onclick={() => (open = false)} />
+      <Button variant="danger" label="Confirm" onclick={() => (open = false)} />
+    </div>
+  {/snippet}
+</Modal>

--- a/scripts/playground/examples/modal/with-form.example.svelte
+++ b/scripts/playground/examples/modal/with-form.example.svelte
@@ -1,0 +1,24 @@
+<script lang="ts" module>
+  export const title = 'Modal with form';
+  export const description = 'A modal containing an input that receives focus on open.';
+</script>
+
+<script lang="ts">
+  import { Button, Input, Modal } from '../../../../src/index.ts';
+
+  let open = $state(false);
+  let name = $state('');
+  let triggerRef: HTMLButtonElement | undefined = $state();
+</script>
+
+<button bind:this={triggerRef} type="button" onclick={() => (open = true)}>Rename item</button>
+
+<Modal bind:open title="Rename item" {triggerRef}>
+  <Input id="modal-name" bind:value={name} label="New name" placeholder="Enter a name…" />
+  {#snippet footer()}
+    <div style="display: flex; gap: 0.5rem; justify-content: flex-end;">
+      <Button variant="secondary" label="Cancel" onclick={() => (open = false)} />
+      <Button variant="primary" label="Save" onclick={() => (open = false)} />
+    </div>
+  {/snippet}
+</Modal>

--- a/scripts/playground/examples/navigation-bar/basic.example.svelte
+++ b/scripts/playground/examples/navigation-bar/basic.example.svelte
@@ -1,0 +1,30 @@
+<script lang="ts" module>
+  export const title = 'Basic navigation bar';
+  export const description = 'Brand, nav items, and an action in the trailing slot.';
+</script>
+
+<script lang="ts">
+  import { Button, NavigationBar, NavigationItem } from '../../../../src/index.ts';
+
+  let active = $state('home');
+</script>
+
+<NavigationBar>
+  {#snippet brand()}
+    <strong style="font-size: 1.1rem;">Acme</strong>
+  {/snippet}
+  {#snippet items()}
+    <NavigationItem onClick={() => (active = 'home')} active={active === 'home'}>
+      Home
+    </NavigationItem>
+    <NavigationItem onClick={() => (active = 'docs')} active={active === 'docs'}>
+      Docs
+    </NavigationItem>
+    <NavigationItem onClick={() => (active = 'blog')} active={active === 'blog'}>
+      Blog
+    </NavigationItem>
+  {/snippet}
+  {#snippet actions()}
+    <Button variant="primary" size="sm" label="Sign up" />
+  {/snippet}
+</NavigationBar>

--- a/scripts/playground/examples/navigation-item/button.example.svelte
+++ b/scripts/playground/examples/navigation-item/button.example.svelte
@@ -1,0 +1,22 @@
+<script lang="ts" module>
+  export const title = 'Button navigation item';
+  export const description = 'Renders a button element when onClick is provided instead of href.';
+</script>
+
+<script lang="ts">
+  import { NavigationItem } from '../../../../src/index.ts';
+
+  let active = $state('dashboard');
+</script>
+
+<nav style="display: flex; gap: 0.5rem;">
+  <NavigationItem onClick={() => (active = 'dashboard')} active={active === 'dashboard'}>
+    Dashboard
+  </NavigationItem>
+  <NavigationItem onClick={() => (active = 'settings')} active={active === 'settings'}>
+    Settings
+  </NavigationItem>
+  <NavigationItem onClick={() => (active = 'billing')} active={active === 'billing'}>
+    Billing
+  </NavigationItem>
+</nav>

--- a/scripts/playground/examples/navigation-item/link.example.svelte
+++ b/scripts/playground/examples/navigation-item/link.example.svelte
@@ -1,0 +1,14 @@
+<script lang="ts" module>
+  export const title = 'Link navigation item';
+  export const description = 'Renders an anchor element; active item shows aria-current="page".';
+</script>
+
+<script lang="ts">
+  import { NavigationItem } from '../../../../src/index.ts';
+</script>
+
+<nav style="display: flex; gap: 0.5rem;">
+  <NavigationItem href="/home" active>Home</NavigationItem>
+  <NavigationItem href="/about">About</NavigationItem>
+  <NavigationItem href="/contact" disabled>Contact (coming soon)</NavigationItem>
+</nav>

--- a/scripts/playground/examples/page-layout/basic.example.svelte
+++ b/scripts/playground/examples/page-layout/basic.example.svelte
@@ -1,0 +1,15 @@
+<script lang="ts" module>
+  export const title = 'Page layout';
+  export const description = 'Title, optional actions slot, and page content.';
+</script>
+
+<script lang="ts">
+  import { Button, PageLayout } from '../../../../src/index.ts';
+</script>
+
+<PageLayout title="Team members">
+  {#snippet actions()}
+    <Button variant="primary" size="sm" label="Invite member" />
+  {/snippet}
+  <p>Manage your team's access and roles here.</p>
+</PageLayout>

--- a/scripts/playground/examples/pagination/basic.example.svelte
+++ b/scripts/playground/examples/pagination/basic.example.svelte
@@ -1,0 +1,13 @@
+<script lang="ts" module>
+  export const title = 'Basic pagination';
+  export const description = 'Navigate through pages with previous/next and numbered buttons.';
+</script>
+
+<script lang="ts">
+  import { Pagination } from '../../../../src/index.ts';
+
+  let currentPage = $state(1);
+</script>
+
+<Pagination bind:currentPage totalPages={10} />
+<p style="margin-top: 0.5rem; color: var(--cinder-text-muted);">Page {currentPage} of 10</p>

--- a/scripts/playground/examples/pagination/with-total.example.svelte
+++ b/scripts/playground/examples/pagination/with-total.example.svelte
@@ -1,0 +1,12 @@
+<script lang="ts" module>
+  export const title = 'Pagination with total count';
+  export const description = 'totalCount prop shows formatted record count.';
+</script>
+
+<script lang="ts">
+  import { Pagination } from '../../../../src/index.ts';
+
+  let currentPage = $state(3);
+</script>
+
+<Pagination bind:currentPage totalPages={20} totalCount={384} />

--- a/scripts/playground/examples/select/basic.example.svelte
+++ b/scripts/playground/examples/select/basic.example.svelte
@@ -1,0 +1,20 @@
+<script lang="ts" module>
+  export const title = 'Basic select';
+  export const description = 'Native select with label and bound string value.';
+</script>
+
+<script lang="ts">
+  import { Select } from '../../../../src/index.ts';
+
+  const options = [
+    { value: 'us', label: 'United States' },
+    { value: 'ca', label: 'Canada' },
+    { value: 'gb', label: 'United Kingdom' },
+    { value: 'au', label: 'Australia' },
+  ];
+
+  let country = $state(options[0]?.value ?? 'us');
+</script>
+
+<Select id="country" bind:value={country} {options} label="Country" />
+<p style="margin-top: 0.5rem; color: var(--cinder-text-muted);">Selected: {country}</p>

--- a/scripts/playground/examples/select/disabled-option.example.svelte
+++ b/scripts/playground/examples/select/disabled-option.example.svelte
@@ -1,0 +1,18 @@
+<script lang="ts" module>
+  export const title = 'Select with disabled option';
+  export const description = 'Individual options can be marked disabled.';
+</script>
+
+<script lang="ts">
+  import { Select } from '../../../../src/index.ts';
+
+  const options = [
+    { value: 'free', label: 'Free' },
+    { value: 'pro', label: 'Pro' },
+    { value: 'enterprise', label: 'Enterprise (contact sales)', disabled: true },
+  ];
+
+  let plan = $state(options[0]?.value ?? 'free');
+</script>
+
+<Select id="plan" bind:value={plan} {options} label="Plan" />

--- a/scripts/playground/examples/skeleton/basic.example.svelte
+++ b/scripts/playground/examples/skeleton/basic.example.svelte
@@ -1,0 +1,21 @@
+<script lang="ts" module>
+  export const title = 'Skeleton placeholders';
+  export const description = 'Animated loading placeholders for text and avatars.';
+</script>
+
+<script lang="ts">
+  import { Skeleton } from '../../../../src/index.ts';
+</script>
+
+<div style="display: flex; flex-direction: column; gap: 0.75rem;">
+  <Skeleton height="1rem" width="60%" />
+  <Skeleton height="1rem" width="80%" />
+  <Skeleton height="1rem" width="40%" />
+  <div style="display: flex; align-items: center; gap: 1rem; margin-top: 0.5rem;">
+    <Skeleton width="3rem" height="3rem" radius="50%" />
+    <div style="flex: 1; display: flex; flex-direction: column; gap: 0.5rem;">
+      <Skeleton height="0.875rem" width="50%" />
+      <Skeleton height="0.875rem" width="30%" />
+    </div>
+  </div>
+</div>

--- a/scripts/playground/examples/spinner/inline.example.svelte
+++ b/scripts/playground/examples/spinner/inline.example.svelte
@@ -1,0 +1,13 @@
+<script lang="ts" module>
+  export const title = 'Inline spinner';
+  export const description = 'Spinner used inline alongside text.';
+</script>
+
+<script lang="ts">
+  import { Spinner } from '../../../../src/index.ts';
+</script>
+
+<div style="display: flex; align-items: center; gap: 0.5rem;">
+  <Spinner size="sm" />
+  <span>Saving changes…</span>
+</div>

--- a/scripts/playground/examples/spinner/sizes.example.svelte
+++ b/scripts/playground/examples/spinner/sizes.example.svelte
@@ -1,0 +1,14 @@
+<script lang="ts" module>
+  export const title = 'Spinner sizes';
+  export const description = 'Small, medium, and large loading spinners.';
+</script>
+
+<script lang="ts">
+  import { Spinner } from '../../../../src/index.ts';
+</script>
+
+<div style="display: flex; align-items: center; gap: 1.5rem;">
+  <Spinner size="sm" label="Loading small" />
+  <Spinner size="md" label="Loading medium" />
+  <Spinner size="lg" label="Loading large" />
+</div>

--- a/scripts/playground/examples/textarea/basic.example.svelte
+++ b/scripts/playground/examples/textarea/basic.example.svelte
@@ -1,0 +1,21 @@
+<script lang="ts" module>
+  export const title = 'Basic textarea';
+  export const description = 'Multi-line text input with label and bound value.';
+</script>
+
+<script lang="ts">
+  import { Textarea } from '../../../../src/index.ts';
+
+  let bio = $state('');
+</script>
+
+<Textarea
+  id="bio"
+  bind:value={bio}
+  label="Bio"
+  description="Tell us a little about yourself."
+  placeholder="I'm a designer who…"
+/>
+{#if bio.length > 0}
+  <p style="margin-top: 0.5rem; color: var(--cinder-text-muted);">{bio.length} characters</p>
+{/if}

--- a/scripts/playground/examples/textarea/with-error.example.svelte
+++ b/scripts/playground/examples/textarea/with-error.example.svelte
@@ -1,0 +1,20 @@
+<script lang="ts" module>
+  export const title = 'Textarea with error';
+  export const description = 'Validation error wired via aria-invalid and aria-describedby.';
+</script>
+
+<script lang="ts">
+  import { Textarea } from '../../../../src/index.ts';
+
+  let message = $state('');
+  const hasError = $derived(message.length > 0 && message.length < 20);
+</script>
+
+<Textarea
+  id="message"
+  bind:value={message}
+  label="Message"
+  rows={5}
+  placeholder="Write at least 20 characters…"
+  {...hasError ? { error: 'Minimum 20 characters.' } : {}}
+/>

--- a/scripts/playground/examples/toggle/basic.example.svelte
+++ b/scripts/playground/examples/toggle/basic.example.svelte
@@ -1,0 +1,15 @@
+<script lang="ts" module>
+  export const title = 'Basic toggle';
+  export const description = 'Toggle button with aria-pressed reflecting the pressed state.';
+</script>
+
+<script lang="ts">
+  import { Toggle } from '../../../../src/index.ts';
+
+  let muted = $state(false);
+</script>
+
+<Toggle id="mute" bind:pressed={muted} label={muted ? 'Unmute' : 'Mute'} />
+<p style="margin-top: 0.5rem; color: var(--cinder-text-muted);">
+  {muted ? '🔇 Muted' : '🔊 Unmuted'}
+</p>

--- a/scripts/playground/examples/toggle/group.example.svelte
+++ b/scripts/playground/examples/toggle/group.example.svelte
@@ -1,0 +1,18 @@
+<script lang="ts" module>
+  export const title = 'Toggle group';
+  export const description = 'Multiple independent toggle buttons.';
+</script>
+
+<script lang="ts">
+  import { Toggle } from '../../../../src/index.ts';
+
+  let bold = $state(false);
+  let italic = $state(false);
+  let underline = $state(false);
+</script>
+
+<div style="display: flex; gap: 0.5rem;">
+  <Toggle id="bold" bind:pressed={bold} label="Bold" />
+  <Toggle id="italic" bind:pressed={italic} label="Italic" />
+  <Toggle id="underline" bind:pressed={underline} label="Underline" />
+</div>

--- a/scripts/playground/examples/tooltip/basic.example.svelte
+++ b/scripts/playground/examples/tooltip/basic.example.svelte
@@ -1,0 +1,12 @@
+<script lang="ts" module>
+  export const title = 'Basic tooltip';
+  export const description = 'Hover or focus the trigger to show the tooltip text.';
+</script>
+
+<script lang="ts">
+  import { Tooltip } from '../../../../src/index.ts';
+</script>
+
+<Tooltip text="This is a helpful explanation.">
+  <button type="button">Hover me</button>
+</Tooltip>

--- a/scripts/playground/examples/tooltip/placements.example.svelte
+++ b/scripts/playground/examples/tooltip/placements.example.svelte
@@ -1,0 +1,23 @@
+<script lang="ts" module>
+  export const title = 'Tooltip placements';
+  export const description = 'Top, right, bottom, and left placement options.';
+</script>
+
+<script lang="ts">
+  import { Tooltip } from '../../../../src/index.ts';
+</script>
+
+<div style="display: flex; gap: 1.5rem; flex-wrap: wrap; padding: 1rem;">
+  <Tooltip text="Appears above" placement="top">
+    <button type="button">Top</button>
+  </Tooltip>
+  <Tooltip text="Appears to the right" placement="right">
+    <button type="button">Right</button>
+  </Tooltip>
+  <Tooltip text="Appears below" placement="bottom">
+    <button type="button">Bottom</button>
+  </Tooltip>
+  <Tooltip text="Appears to the left" placement="left">
+    <button type="button">Left</button>
+  </Tooltip>
+</div>

--- a/scripts/playground/index.html
+++ b/scripts/playground/index.html
@@ -1,0 +1,40 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>{{COMPONENT_NAME}} — cinder playground</title>
+    <link rel="stylesheet" href="/styles.css" />
+    <style>
+      *,
+      *::before,
+      *::after {
+        box-sizing: border-box;
+      }
+
+      html,
+      body {
+        margin: 0;
+        padding: 0;
+        min-height: 100%;
+      }
+
+      body {
+        background-color: var(--cinder-bg);
+        color: var(--cinder-text);
+        font-family: var(--cinder-font-sans);
+        font-size: var(--cinder-text-base);
+        line-height: var(--cinder-leading-normal);
+        padding: var(--cinder-space-6);
+      }
+
+      #app {
+        display: contents;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/bundle/{{COMPONENT_NAME}}.js"></script>
+  </body>
+</html>

--- a/scripts/playground/render-shell.ts
+++ b/scripts/playground/render-shell.ts
@@ -1,0 +1,145 @@
+/**
+ * Renders the full HTML shell for the cinder component playground.
+ *
+ * Returns a plain HTML string — no framework, no bundler dependency.
+ * The shell consists of a fixed sidebar nav listing all components
+ * alphabetically and a main area containing an iframe for the active component.
+ * A small inline script establishes a Server-Sent Events connection to `/events`
+ * and reloads the page on a `reload` message.
+ */
+export function renderShell(activeComponent: string | null, components: string[]): string {
+  const title = activeComponent ? `cinder playground — ${activeComponent}` : 'cinder playground';
+
+  const navItems = components
+    .map((name) => {
+      const isActive = name === activeComponent;
+      const ariaCurrent = isActive ? ' aria-current="page"' : '';
+      return `      <li><a href="/c/${name}"${ariaCurrent}>${name}</a></li>`;
+    })
+    .join('\n');
+
+  const mainContent = activeComponent
+    ? `<iframe src="/c/${activeComponent}" title="${activeComponent} preview"></iframe>`
+    : `<div class="placeholder"><p>Select a component from the sidebar to preview it.</p></div>`;
+
+  return `<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>${title}</title>
+    <style>
+      *, *::before, *::after {
+        box-sizing: border-box;
+        margin: 0;
+        padding: 0;
+      }
+
+      html, body {
+        height: 100%;
+      }
+
+      body {
+        display: flex;
+        font-family: system-ui, -apple-system, sans-serif;
+        font-size: 14px;
+        background: #f5f5f5;
+        color: #111;
+      }
+
+      nav {
+        width: 220px;
+        min-width: 220px;
+        height: 100vh;
+        position: fixed;
+        top: 0;
+        left: 0;
+        background: #fff;
+        border-right: 1px solid #e5e5e5;
+        overflow-y: auto;
+        display: flex;
+        flex-direction: column;
+      }
+
+      nav .nav-header {
+        padding: 16px;
+        font-weight: 700;
+        font-size: 13px;
+        letter-spacing: 0.04em;
+        text-transform: uppercase;
+        color: #666;
+        border-bottom: 1px solid #e5e5e5;
+      }
+
+      nav ul {
+        list-style: none;
+        padding: 8px 0;
+        flex: 1;
+      }
+
+      nav ul li a {
+        display: block;
+        padding: 6px 16px;
+        text-decoration: none;
+        color: #333;
+        border-radius: 4px;
+        margin: 1px 8px;
+        transition: background 0.1s;
+      }
+
+      nav ul li a:hover {
+        background: #f0f0f0;
+      }
+
+      nav ul li a[aria-current="page"] {
+        background: #e8f0fe;
+        color: #1a56db;
+        font-weight: 600;
+      }
+
+      main {
+        margin-left: 220px;
+        flex: 1;
+        height: 100vh;
+        display: flex;
+        flex-direction: column;
+      }
+
+      main iframe {
+        flex: 1;
+        width: 100%;
+        height: 100%;
+        border: none;
+        background: #fff;
+      }
+
+      main .placeholder {
+        flex: 1;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        color: #888;
+      }
+
+      main .placeholder p {
+        font-size: 16px;
+      }
+    </style>
+  </head>
+  <body>
+    <nav>
+      <div class="nav-header">cinder</div>
+      <ul>
+${navItems}
+      </ul>
+    </nav>
+    <main>
+      ${mainContent}
+    </main>
+    <script>
+      const es = new EventSource('/events');
+      es.addEventListener('reload', () => location.reload());
+    </script>
+  </body>
+</html>`;
+}

--- a/scripts/playground/render-shell.ts
+++ b/scripts/playground/render-shell.ts
@@ -26,13 +26,15 @@ export function renderShell(activeComponent: string | null, components: string[]
     .map((name) => {
       const isActive = name === activeComponent;
       const ariaCurrent = isActive ? ' aria-current="page"' : '';
-      const safeName = escapeHtml(name);
-      return `      <li><a href="/c/${safeName}"${ariaCurrent}>${safeName}</a></li>`;
+      // Component names are validated by isSafeSegment (/^[a-z0-9][a-z0-9-]*$/),
+      // so they're safe in URL paths. Escape only the visible text node.
+      return `      <li><a href="/c/${name}"${ariaCurrent}>${escapeHtml(name)}</a></li>`;
     })
     .join('\n');
 
+  // Component names are path-safe; escaping is only needed in title attribute and visible text.
   const mainContent = activeComponent
-    ? `<iframe src="/c/${escapeHtml(activeComponent)}" title="${escapeHtml(activeComponent)} preview"></iframe>`
+    ? `<iframe src="/c/${activeComponent}" title="${escapeHtml(activeComponent)} preview"></iframe>`
     : `<div class="placeholder"><p>Select a component from the sidebar to preview it.</p></div>`;
 
   return `<!DOCTYPE html>

--- a/scripts/playground/render-shell.ts
+++ b/scripts/playground/render-shell.ts
@@ -1,3 +1,13 @@
+/** Escape a string for safe use in HTML text content and attribute values. */
+function escapeHtml(text: string): string {
+  return text
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
 /**
  * Renders the full HTML shell for the cinder component playground.
  *
@@ -8,18 +18,21 @@
  * and reloads the page on a `reload` message.
  */
 export function renderShell(activeComponent: string | null, components: string[]): string {
-  const title = activeComponent ? `cinder playground — ${activeComponent}` : 'cinder playground';
+  const title = activeComponent
+    ? `cinder playground — ${escapeHtml(activeComponent)}`
+    : 'cinder playground';
 
   const navItems = components
     .map((name) => {
       const isActive = name === activeComponent;
       const ariaCurrent = isActive ? ' aria-current="page"' : '';
-      return `      <li><a href="/c/${name}"${ariaCurrent}>${name}</a></li>`;
+      const safeName = escapeHtml(name);
+      return `      <li><a href="/c/${safeName}"${ariaCurrent}>${safeName}</a></li>`;
     })
     .join('\n');
 
   const mainContent = activeComponent
-    ? `<iframe src="/c/${activeComponent}" title="${activeComponent} preview"></iframe>`
+    ? `<iframe src="/c/${escapeHtml(activeComponent)}" title="${escapeHtml(activeComponent)} preview"></iframe>`
     : `<div class="placeholder"><p>Select a component from the sidebar to preview it.</p></div>`;
 
   return `<!DOCTYPE html>

--- a/scripts/playground/server.test.ts
+++ b/scripts/playground/server.test.ts
@@ -3,14 +3,41 @@
  *
  * Uses handleRequest directly (no live server) for route-level coverage.
  * The triggerReload / SSE integration path is covered by validate-playground.ts.
+ *
+ * Tests that hit /bundle/button/primary.js and /example-src/button/primary rely
+ * on scripts/playground/examples/button/primary.example.svelte existing. A
+ * beforeAll guard asserts this up front so failures are diagnosable.
  */
 
-import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import { beforeAll, describe, expect, it } from 'bun:test';
+import { join } from 'node:path';
 
-import { handleRequest, triggerReload } from './server.ts';
+import { PORT, handleRequest, triggerReload } from './server.ts';
+
+const ROOT = process.cwd();
+const FIXTURE_COMPONENT = 'button';
+const FIXTURE_SCENARIO = 'primary';
+const FIXTURE_PATH = join(
+  ROOT,
+  'scripts',
+  'playground',
+  'examples',
+  FIXTURE_COMPONENT,
+  `${FIXTURE_SCENARIO}.example.svelte`,
+);
+
+beforeAll(async () => {
+  const exists = await Bun.file(FIXTURE_PATH).exists();
+  if (!exists) {
+    throw new Error(
+      `[server.test] Required fixture missing: ${FIXTURE_PATH}\n` +
+        `Create scripts/playground/examples/${FIXTURE_COMPONENT}/${FIXTURE_SCENARIO}.example.svelte before running these tests.`,
+    );
+  }
+});
 
 function req(path: string, options?: RequestInit): Request {
-  return new Request(`http://localhost:4173${path}`, options);
+  return new Request(`http://localhost:${PORT}${path}`, options);
 }
 
 describe('/ping', () => {
@@ -24,7 +51,6 @@ describe('/ping', () => {
 describe('/styles.css', () => {
   it('returns 200 with text/css when src/styles/index.css exists', async () => {
     const response = await handleRequest(req('/styles.css'));
-    // The file exists in this repo, so we expect 200.
     expect(response.status).toBe(200);
     expect(response.headers.get('Content-Type')).toBe('text/css');
   });
@@ -59,9 +85,8 @@ describe('/c/:name', () => {
     expect(response.status).toBe(404);
   });
 
-  it('returns 404 for segments starting with a digit in wrong pattern', async () => {
-    // Component names must match /^[a-z0-9][a-z0-9-]*$/ and exist in allowlist.
-    const response = await handleRequest(req('/c/9button'));
+  it('returns 404 for segments starting with a hyphen', async () => {
+    const response = await handleRequest(req('/c/-bad'));
     expect(response.status).toBe(404);
   });
 });
@@ -73,22 +98,32 @@ describe('/bundle/:name/:scenario.js', () => {
   });
 
   it('returns 404 for segments with uppercase (blocked by isSafeSegment)', async () => {
-    // URL parser normalizes .. away, so test actual unsafe chars instead.
     const response = await handleRequest(req('/bundle/Button/primary.js'));
     expect(response.status).toBe(404);
   });
 
   it('returns 200 application/javascript for a known example', async () => {
-    // button/primary.example.svelte exists in this repo
-    const response = await handleRequest(req('/bundle/button/primary.js'));
+    const response = await handleRequest(
+      req(`/bundle/${FIXTURE_COMPONENT}/${FIXTURE_SCENARIO}.js`),
+    );
     expect(response.status).toBe(200);
     expect(response.headers.get('Content-Type')).toBe('application/javascript');
+  });
+
+  it('returns the same bundle on repeated requests (cache hit)', async () => {
+    const r1 = await handleRequest(req(`/bundle/${FIXTURE_COMPONENT}/${FIXTURE_SCENARIO}.js`));
+    const r2 = await handleRequest(req(`/bundle/${FIXTURE_COMPONENT}/${FIXTURE_SCENARIO}.js`));
+    expect(r1.status).toBe(200);
+    expect(r2.status).toBe(200);
+    expect(await r1.text()).toBe(await r2.text());
   });
 });
 
 describe('/example-src/:name/:scenario', () => {
   it('returns 200 text/plain for a known example', async () => {
-    const response = await handleRequest(req('/example-src/button/primary'));
+    const response = await handleRequest(
+      req(`/example-src/${FIXTURE_COMPONENT}/${FIXTURE_SCENARIO}`),
+    );
     expect(response.status).toBe(200);
     expect(response.headers.get('Content-Type')).toBe('text/plain');
     const source = await response.text();
@@ -107,15 +142,15 @@ describe('/example-src/:name/:scenario', () => {
 });
 
 describe('/events (SSE)', () => {
-  it('returns 200 with text/event-stream', async () => {
+  it('returns 200 with text/event-stream and sends initial handshake', async () => {
     const response = await handleRequest(req('/events'));
     expect(response.status).toBe(200);
     expect(response.headers.get('Content-Type')).toBe('text/event-stream');
     // Consume and verify the initial handshake comment.
     const reader = response.body!.getReader();
     const { value } = await reader.read();
-    // The controller enqueues strings; coerce to string regardless of chunk type.
-    const text = typeof value === 'string' ? value : new TextDecoder().decode(value as Uint8Array);
+    // The stream enqueues strings; Bun may deliver them as string or Uint8Array.
+    const text = value instanceof Uint8Array ? new TextDecoder().decode(value) : String(value);
     expect(text).toContain(': connected');
     reader.cancel();
   });
@@ -127,14 +162,10 @@ describe('triggerReload', () => {
   });
 
   it('removes dead controllers from sseClients without throwing', async () => {
-    // Connect a client, then immediately close the stream and trigger reload.
     const response = await handleRequest(req('/events'));
     const reader = response.body!.getReader();
-    // Consume the initial handshake.
     await reader.read();
-    // Cancel the reader (simulates client disconnect).
     await reader.cancel();
-    // triggerReload should not throw even though the controller is dead.
     expect(() => triggerReload()).not.toThrow();
   });
 });
@@ -154,37 +185,8 @@ describe('isSafeSegment (via route behavior)', () => {
     expect(r2.status).toBe(404);
   });
 
-  it('rejects segments starting with a hyphen', async () => {
-    const response = await handleRequest(req('/c/-bad'));
-    expect(response.status).toBe(404);
-  });
-
   it('rejects segments containing special characters', async () => {
     const response = await handleRequest(req('/c/bad%20name'));
     expect(response.status).toBe(404);
-  });
-});
-
-describe('beforeEach/afterEach cleanup', () => {
-  // Verify the bundle cache doesn't leak between tests by checking
-  // that repeated requests for the same bundle produce the same content.
-  let firstResponse: string;
-
-  beforeEach(async () => {
-    const r = await handleRequest(req('/bundle/button/primary.js'));
-    if (r.status === 200) {
-      firstResponse = await r.text();
-    }
-  });
-
-  afterEach(() => {
-    firstResponse = '';
-  });
-
-  it('serves the same bundle content on repeated requests (cache hit)', async () => {
-    const r = await handleRequest(req('/bundle/button/primary.js'));
-    if (r.status === 200) {
-      expect(await r.text()).toBe(firstResponse);
-    }
   });
 });

--- a/scripts/playground/server.test.ts
+++ b/scripts/playground/server.test.ts
@@ -1,0 +1,190 @@
+/**
+ * Unit tests for `scripts/playground/server.ts` route handlers.
+ *
+ * Uses handleRequest directly (no live server) for route-level coverage.
+ * The triggerReload / SSE integration path is covered by validate-playground.ts.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+
+import { handleRequest, triggerReload } from './server.ts';
+
+function req(path: string, options?: RequestInit): Request {
+  return new Request(`http://localhost:4173${path}`, options);
+}
+
+describe('/ping', () => {
+  it('returns 200 pong', async () => {
+    const response = await handleRequest(req('/ping'));
+    expect(response.status).toBe(200);
+    expect(await response.text()).toBe('pong');
+  });
+});
+
+describe('/styles.css', () => {
+  it('returns 200 with text/css when src/styles/index.css exists', async () => {
+    const response = await handleRequest(req('/styles.css'));
+    // The file exists in this repo, so we expect 200.
+    expect(response.status).toBe(200);
+    expect(response.headers.get('Content-Type')).toBe('text/css');
+  });
+});
+
+describe('/', () => {
+  it('redirects to /c/<first-component>', async () => {
+    const response = await handleRequest(req('/'));
+    expect(response.status).toBe(302);
+    const location = response.headers.get('Location');
+    expect(location).toMatch(/^\/c\//);
+  });
+});
+
+describe('/c/:name', () => {
+  it('returns 200 HTML for a known component', async () => {
+    const response = await handleRequest(req('/c/button'));
+    expect(response.status).toBe(200);
+    expect(response.headers.get('Content-Type')).toBe('text/html');
+    const html = await response.text();
+    expect(html).toContain('<!DOCTYPE html>');
+    expect(html).toContain('<nav>');
+  });
+
+  it('returns 404 for an unknown component', async () => {
+    const response = await handleRequest(req('/c/does-not-exist'));
+    expect(response.status).toBe(404);
+  });
+
+  it('returns 404 for segments with uppercase (not in safe-segment pattern)', async () => {
+    const response = await handleRequest(req('/c/Button'));
+    expect(response.status).toBe(404);
+  });
+
+  it('returns 404 for segments starting with a digit in wrong pattern', async () => {
+    // Component names must match /^[a-z0-9][a-z0-9-]*$/ and exist in allowlist.
+    const response = await handleRequest(req('/c/9button'));
+    expect(response.status).toBe(404);
+  });
+});
+
+describe('/bundle/:name/:scenario.js', () => {
+  it('returns 404 for a nonexistent example', async () => {
+    const response = await handleRequest(req('/bundle/button/nonexistent.js'));
+    expect(response.status).toBe(404);
+  });
+
+  it('returns 404 for segments with uppercase (blocked by isSafeSegment)', async () => {
+    // URL parser normalizes .. away, so test actual unsafe chars instead.
+    const response = await handleRequest(req('/bundle/Button/primary.js'));
+    expect(response.status).toBe(404);
+  });
+
+  it('returns 200 application/javascript for a known example', async () => {
+    // button/primary.example.svelte exists in this repo
+    const response = await handleRequest(req('/bundle/button/primary.js'));
+    expect(response.status).toBe(200);
+    expect(response.headers.get('Content-Type')).toBe('application/javascript');
+  });
+});
+
+describe('/example-src/:name/:scenario', () => {
+  it('returns 200 text/plain for a known example', async () => {
+    const response = await handleRequest(req('/example-src/button/primary'));
+    expect(response.status).toBe(200);
+    expect(response.headers.get('Content-Type')).toBe('text/plain');
+    const source = await response.text();
+    expect(source).toContain('Button');
+  });
+
+  it('returns 404 for a nonexistent example', async () => {
+    const response = await handleRequest(req('/example-src/button/nonexistent'));
+    expect(response.status).toBe(404);
+  });
+
+  it('returns 404 for segments with uppercase (blocked by isSafeSegment)', async () => {
+    const response = await handleRequest(req('/example-src/Button/primary'));
+    expect(response.status).toBe(404);
+  });
+});
+
+describe('/events (SSE)', () => {
+  it('returns 200 with text/event-stream', async () => {
+    const response = await handleRequest(req('/events'));
+    expect(response.status).toBe(200);
+    expect(response.headers.get('Content-Type')).toBe('text/event-stream');
+    // Consume and verify the initial handshake comment.
+    const reader = response.body!.getReader();
+    const { value } = await reader.read();
+    // The controller enqueues strings; coerce to string regardless of chunk type.
+    const text = typeof value === 'string' ? value : new TextDecoder().decode(value as Uint8Array);
+    expect(text).toContain(': connected');
+    reader.cancel();
+  });
+});
+
+describe('triggerReload', () => {
+  it('does not throw when no clients are connected', () => {
+    expect(() => triggerReload()).not.toThrow();
+  });
+
+  it('removes dead controllers from sseClients without throwing', async () => {
+    // Connect a client, then immediately close the stream and trigger reload.
+    const response = await handleRequest(req('/events'));
+    const reader = response.body!.getReader();
+    // Consume the initial handshake.
+    await reader.read();
+    // Cancel the reader (simulates client disconnect).
+    await reader.cancel();
+    // triggerReload should not throw even though the controller is dead.
+    expect(() => triggerReload()).not.toThrow();
+  });
+});
+
+describe('unknown routes', () => {
+  it('returns 404 for arbitrary paths', async () => {
+    const response = await handleRequest(req('/not-a-real-path'));
+    expect(response.status).toBe(404);
+  });
+});
+
+describe('isSafeSegment (via route behavior)', () => {
+  it('rejects segments with uppercase letters', async () => {
+    const r1 = await handleRequest(req('/c/Button'));
+    expect(r1.status).toBe(404);
+    const r2 = await handleRequest(req('/bundle/Button/primary.js'));
+    expect(r2.status).toBe(404);
+  });
+
+  it('rejects segments starting with a hyphen', async () => {
+    const response = await handleRequest(req('/c/-bad'));
+    expect(response.status).toBe(404);
+  });
+
+  it('rejects segments containing special characters', async () => {
+    const response = await handleRequest(req('/c/bad%20name'));
+    expect(response.status).toBe(404);
+  });
+});
+
+describe('beforeEach/afterEach cleanup', () => {
+  // Verify the bundle cache doesn't leak between tests by checking
+  // that repeated requests for the same bundle produce the same content.
+  let firstResponse: string;
+
+  beforeEach(async () => {
+    const r = await handleRequest(req('/bundle/button/primary.js'));
+    if (r.status === 200) {
+      firstResponse = await r.text();
+    }
+  });
+
+  afterEach(() => {
+    firstResponse = '';
+  });
+
+  it('serves the same bundle content on repeated requests (cache hit)', async () => {
+    const r = await handleRequest(req('/bundle/button/primary.js'));
+    if (r.status === 200) {
+      expect(await r.text()).toBe(firstResponse);
+    }
+  });
+});

--- a/scripts/playground/server.ts
+++ b/scripts/playground/server.ts
@@ -21,7 +21,7 @@ import { sveltePlugin } from '../svelte-plugin.ts';
 import { discoverComponents } from './discover.ts';
 import { renderShell } from './render-shell.ts';
 
-const PORT = 4173;
+export const PORT = 4173;
 const ROOT = process.cwd();
 
 /** Compiled bundle cache: "componentName/scenario" → JS source string. */
@@ -53,6 +53,10 @@ function startWatcher(): void {
   watch(srcPath, { recursive: true }, (_event, filename) => {
     if (filename) {
       // Invalidate example bundle cache for any changed component.
+      // Note: changes to .example.svelte files under scripts/playground/examples/
+      // are NOT watched here — the SSE reload still triggers a page reload which
+      // will fetch and recompile the bundle fresh on next request. Revisit if
+      // Phase 3b concurrent example authoring surfaces stale-bundle issues.
       const match = filename.match(/^components\/([^/]+)\.svelte$/);
       if (match) {
         const componentName = match[1]!;

--- a/scripts/playground/server.ts
+++ b/scripts/playground/server.ts
@@ -47,16 +47,12 @@ export function triggerReload(): void {
   }
 }
 
-/** Start watching `src/` recursively and fire `triggerReload` on any change. */
+/** Start watching `src/` and `scripts/playground/examples/` for live reload. */
 function startWatcher(): void {
   const srcPath = join(ROOT, 'src');
   watch(srcPath, { recursive: true }, (_event, filename) => {
     if (filename) {
       // Invalidate example bundle cache for any changed component.
-      // Note: changes to .example.svelte files under scripts/playground/examples/
-      // are NOT watched here — the SSE reload still triggers a page reload which
-      // will fetch and recompile the bundle fresh on next request. Revisit if
-      // Phase 3b concurrent example authoring surfaces stale-bundle issues.
       const match = filename.match(/^components\/([^/]+)\.svelte$/);
       if (match) {
         const componentName = match[1]!;
@@ -65,6 +61,19 @@ function startWatcher(): void {
             bundleCache.delete(key);
           }
         }
+      }
+      triggerReload();
+    }
+  });
+
+  // Watch the examples directory so edits to .example.svelte files invalidate
+  // the cached bundle and trigger a browser reload.
+  const examplesPath = join(ROOT, 'scripts', 'playground', 'examples');
+  watch(examplesPath, { recursive: true }, (_event, filename) => {
+    if (filename) {
+      const match = filename.match(/^([^/]+)\/([^/]+)\.example\.svelte$/);
+      if (match) {
+        bundleCache.delete(`${match[1]}/${match[2]}`);
       }
       triggerReload();
     }
@@ -225,18 +234,19 @@ export async function handleRequest(request: Request): Promise<Response> {
   return notFound();
 }
 
-/** Start the playground server. */
-export function main(): void {
+/** Start the playground server on the given port and return the Bun.Server instance. */
+export function startServer(port: number = PORT): ReturnType<typeof Bun.serve> {
   startWatcher();
 
   const server = Bun.serve({
-    port: PORT,
+    port,
     fetch: handleRequest,
   });
 
   process.stdout.write(`[playground] Listening at http://localhost:${server.port}\n`);
+  return server;
 }
 
 if (import.meta.main) {
-  main();
+  startServer();
 }

--- a/scripts/playground/server.ts
+++ b/scripts/playground/server.ts
@@ -243,7 +243,7 @@ export type PlaygroundServer = {
 };
 
 /** Start the playground server on the given port. Returns a handle with dispose() to stop everything. */
-export function startServer(port: number = PORT): PlaygroundServer {
+export async function startServer(port: number = PORT): Promise<PlaygroundServer> {
   // Start the HTTP server first — if Bun.serve throws (e.g. EADDRINUSE),
   // no watchers are leaked.
   const server = Bun.serve({
@@ -251,7 +251,14 @@ export function startServer(port: number = PORT): PlaygroundServer {
     fetch: handleRequest,
   });
 
-  const watchers = startWatcher();
+  let watchers: FSWatcher[];
+  try {
+    watchers = startWatcher();
+  } catch (error) {
+    // startWatcher() failed — stop the already-listening server before rethrowing.
+    await server.stop(true);
+    throw error;
+  }
 
   async function dispose(): Promise<void> {
     for (const watcher of watchers) {
@@ -266,5 +273,5 @@ export function startServer(port: number = PORT): PlaygroundServer {
 }
 
 if (import.meta.main) {
-  startServer();
+  await startServer();
 }

--- a/scripts/playground/server.ts
+++ b/scripts/playground/server.ts
@@ -238,24 +238,26 @@ export async function handleRequest(request: Request): Promise<Response> {
 
 export type PlaygroundServer = {
   port: number;
-  /** Stop the HTTP server and all file watchers. */
-  dispose: () => void;
+  /** Stop the HTTP server and all file watchers. Awaitable. */
+  dispose: () => Promise<void>;
 };
 
 /** Start the playground server on the given port. Returns a handle with dispose() to stop everything. */
 export function startServer(port: number = PORT): PlaygroundServer {
-  const watchers = startWatcher();
-
+  // Start the HTTP server first — if Bun.serve throws (e.g. EADDRINUSE),
+  // no watchers are leaked.
   const server = Bun.serve({
     port,
     fetch: handleRequest,
   });
 
-  function dispose(): void {
+  const watchers = startWatcher();
+
+  async function dispose(): Promise<void> {
     for (const watcher of watchers) {
       watcher.close();
     }
-    void server.stop(true);
+    await server.stop(true);
   }
 
   const actualPort = server.port ?? port;

--- a/scripts/playground/server.ts
+++ b/scripts/playground/server.ts
@@ -14,7 +14,7 @@
  * whenever a file changes. Use `triggerReload()` directly in tests.
  */
 
-import { watch } from 'node:fs';
+import { watch, type FSWatcher } from 'node:fs';
 import { join } from 'node:path';
 
 import { sveltePlugin } from '../svelte-plugin.ts';
@@ -48,9 +48,9 @@ export function triggerReload(): void {
 }
 
 /** Start watching `src/` and `scripts/playground/examples/` for live reload. */
-function startWatcher(): void {
+function startWatcher(): FSWatcher[] {
   const srcPath = join(ROOT, 'src');
-  watch(srcPath, { recursive: true }, (_event, filename) => {
+  const srcWatcher = watch(srcPath, { recursive: true }, (_event, filename) => {
     if (filename) {
       // Invalidate example bundle cache for any changed component.
       const match = filename.match(/^components\/([^/]+)\.svelte$/);
@@ -69,7 +69,7 @@ function startWatcher(): void {
   // Watch the examples directory so edits to .example.svelte files invalidate
   // the cached bundle and trigger a browser reload.
   const examplesPath = join(ROOT, 'scripts', 'playground', 'examples');
-  watch(examplesPath, { recursive: true }, (_event, filename) => {
+  const examplesWatcher = watch(examplesPath, { recursive: true }, (_event, filename) => {
     if (filename) {
       const match = filename.match(/^([^/]+)\/([^/]+)\.example\.svelte$/);
       if (match) {
@@ -78,6 +78,8 @@ function startWatcher(): void {
       triggerReload();
     }
   });
+
+  return [srcWatcher, examplesWatcher];
 }
 
 /** Compile an example bundle and cache the result. */
@@ -234,17 +236,31 @@ export async function handleRequest(request: Request): Promise<Response> {
   return notFound();
 }
 
-/** Start the playground server on the given port and return the Bun.Server instance. */
-export function startServer(port: number = PORT): ReturnType<typeof Bun.serve> {
-  startWatcher();
+export type PlaygroundServer = {
+  port: number;
+  /** Stop the HTTP server and all file watchers. */
+  dispose: () => void;
+};
+
+/** Start the playground server on the given port. Returns a handle with dispose() to stop everything. */
+export function startServer(port: number = PORT): PlaygroundServer {
+  const watchers = startWatcher();
 
   const server = Bun.serve({
     port,
     fetch: handleRequest,
   });
 
-  process.stdout.write(`[playground] Listening at http://localhost:${server.port}\n`);
-  return server;
+  function dispose(): void {
+    for (const watcher of watchers) {
+      watcher.close();
+    }
+    void server.stop(true);
+  }
+
+  const actualPort = server.port ?? port;
+  process.stdout.write(`[playground] Listening at http://localhost:${actualPort}\n`);
+  return { port: actualPort, dispose };
 }
 
 if (import.meta.main) {

--- a/scripts/playground/server.ts
+++ b/scripts/playground/server.ts
@@ -4,7 +4,7 @@
  * Runs at http://localhost:4173. Routes:
  *   GET /              → 302 redirect to /c/<first-component>
  *   GET /c/:name       → full shell HTML for the named component
- *   GET /bundle/:name.js → compiled Svelte client bundle (cached)
+ *   GET /bundle/:name/:scenario.js → compiled example bundle (cached)
  *   GET /styles.css    → raw contents of src/styles/index.css
  *   GET /example-src/:name/:scenario → raw .example.svelte source
  *   GET /events        → Server-Sent Events stream for live reload
@@ -24,22 +24,26 @@ import { renderShell } from './render-shell.ts';
 const PORT = 4173;
 const ROOT = process.cwd();
 
-/** Compiled bundle cache: component name → JS source string. */
+/** Compiled bundle cache: "componentName/scenario" → JS source string. */
 const bundleCache = new Map<string, string>();
 
 /** Set of active SSE stream controllers. */
-const sseClients = new Set<ReadableStreamDefaultController>();
+const sseClients = new Set<ReadableStreamDefaultController<string>>();
 
 /** Send a `reload` event to every connected SSE client. */
 export function triggerReload(): void {
   const message = 'event: reload\ndata: {}\n\n';
+  const dead: ReadableStreamDefaultController<string>[] = [];
   for (const controller of sseClients) {
     try {
       controller.enqueue(message);
     } catch {
-      // Client already closed — remove it.
-      sseClients.delete(controller);
+      // Client already closed — collect for removal after iteration.
+      dead.push(controller);
     }
+  }
+  for (const controller of dead) {
+    sseClients.delete(controller);
   }
 }
 
@@ -48,36 +52,49 @@ function startWatcher(): void {
   const srcPath = join(ROOT, 'src');
   watch(srcPath, { recursive: true }, (_event, filename) => {
     if (filename) {
-      // Invalidate the bundle cache for any changed component.
+      // Invalidate example bundle cache for any changed component.
       const match = filename.match(/^components\/([^/]+)\.svelte$/);
       if (match) {
-        bundleCache.delete(match[1]!);
+        const componentName = match[1]!;
+        for (const key of bundleCache.keys()) {
+          if (key.startsWith(`${componentName}/`)) {
+            bundleCache.delete(key);
+          }
+        }
       }
       triggerReload();
     }
   });
 }
 
-/** Compile a component bundle and cache the result. */
-async function buildBundle(componentName: string): Promise<string | null> {
-  if (bundleCache.has(componentName)) {
-    return bundleCache.get(componentName)!;
+/** Compile an example bundle and cache the result. */
+async function buildBundle(componentName: string, scenario: string): Promise<string | null> {
+  const cacheKey = `${componentName}/${scenario}`;
+  if (bundleCache.has(cacheKey)) {
+    return bundleCache.get(cacheKey)!;
   }
 
-  const componentPath = join(ROOT, 'src', 'components', `${componentName}.svelte`);
-  const file = Bun.file(componentPath);
+  const examplePath = join(
+    ROOT,
+    'scripts',
+    'playground',
+    'examples',
+    componentName,
+    `${scenario}.example.svelte`,
+  );
+  const file = Bun.file(examplePath);
   const exists = await file.exists();
   if (!exists) return null;
 
   const result = await Bun.build({
-    entrypoints: [componentPath],
+    entrypoints: [examplePath],
     plugins: [sveltePlugin({ generate: 'client' })],
     target: 'browser',
     format: 'esm',
   });
 
   if (!result.success) {
-    console.error(`[playground] Bundle failed for ${componentName}:`, result.logs);
+    console.error(`[playground] Bundle failed for ${componentName}/${scenario}:`, result.logs);
     return null;
   }
 
@@ -85,8 +102,13 @@ async function buildBundle(componentName: string): Promise<string | null> {
   if (!output) return null;
 
   const code = await output.text();
-  bundleCache.set(componentName, code);
+  bundleCache.set(cacheKey, code);
   return code;
+}
+
+/** Verify a path segment is a safe identifier (no path traversal). */
+function isSafeSegment(segment: string): boolean {
+  return /^[a-z0-9][a-z0-9-]*$/.test(segment);
 }
 
 /** Build a plain-text 404 response. */
@@ -94,8 +116,8 @@ function notFound(message = 'Not Found'): Response {
   return new Response(message, { status: 404, headers: { 'Content-Type': 'text/plain' } });
 }
 
-/** Main request handler for Bun.serve. */
-async function handleRequest(request: Request): Promise<Response> {
+/** Main request handler — exported for testing. */
+export async function handleRequest(request: Request): Promise<Response> {
   const url = new URL(request.url);
   const { pathname } = url;
 
@@ -106,16 +128,16 @@ async function handleRequest(request: Request): Promise<Response> {
 
   // GET /events
   if (pathname === '/events') {
-    let controller!: ReadableStreamDefaultController;
-    const stream = new ReadableStream({
+    let controller: ReadableStreamDefaultController<string> | undefined;
+    const stream = new ReadableStream<string>({
       start(c) {
         controller = c;
-        sseClients.add(controller);
+        sseClients.add(c);
         // Send an initial comment to establish the connection.
-        controller.enqueue(': connected\n\n');
+        c.enqueue(': connected\n\n');
       },
       cancel() {
-        sseClients.delete(controller);
+        if (controller) sseClients.delete(controller);
       },
     });
 
@@ -137,12 +159,15 @@ async function handleRequest(request: Request): Promise<Response> {
     return new Response(css, { headers: { 'Content-Type': 'text/css' } });
   }
 
-  // GET /bundle/:name.js
-  const bundleMatch = pathname.match(/^\/bundle\/([^/]+)\.js$/);
+  // GET /bundle/:name/:scenario.js
+  const bundleMatch = pathname.match(/^\/bundle\/([^/]+)\/([^/]+)\.js$/);
   if (bundleMatch) {
     const componentName = bundleMatch[1]!;
-    const code = await buildBundle(componentName);
-    if (code === null) return notFound(`Component "${componentName}" not found or failed to build`);
+    const scenario = bundleMatch[2]!;
+    if (!isSafeSegment(componentName) || !isSafeSegment(scenario)) return notFound();
+    const code = await buildBundle(componentName, scenario);
+    if (code === null)
+      return notFound(`Example "${componentName}/${scenario}" not found or failed to build`);
     return new Response(code, { headers: { 'Content-Type': 'application/javascript' } });
   }
 
@@ -151,6 +176,7 @@ async function handleRequest(request: Request): Promise<Response> {
   if (exampleSrcMatch) {
     const componentName = exampleSrcMatch[1]!;
     const scenario = exampleSrcMatch[2]!;
+    if (!isSafeSegment(componentName) || !isSafeSegment(scenario)) return notFound();
     const examplePath = join(
       ROOT,
       'scripts',
@@ -170,6 +196,7 @@ async function handleRequest(request: Request): Promise<Response> {
   const componentMatch = pathname.match(/^\/c\/([^/]+)$/);
   if (componentMatch) {
     const componentName = componentMatch[1]!;
+    if (!isSafeSegment(componentName)) return notFound();
     const allComponents = await discoverComponents();
     if (!allComponents.includes(componentName))
       return notFound(`Component "${componentName}" not found`);
@@ -195,7 +222,7 @@ async function handleRequest(request: Request): Promise<Response> {
 }
 
 /** Start the playground server. */
-function main(): void {
+export function main(): void {
   startWatcher();
 
   const server = Bun.serve({
@@ -206,4 +233,6 @@ function main(): void {
   process.stdout.write(`[playground] Listening at http://localhost:${server.port}\n`);
 }
 
-main();
+if (import.meta.main) {
+  main();
+}

--- a/scripts/playground/server.ts
+++ b/scripts/playground/server.ts
@@ -1,0 +1,209 @@
+/**
+ * Cinder component playground dev server.
+ *
+ * Runs at http://localhost:4173. Routes:
+ *   GET /              → 302 redirect to /c/<first-component>
+ *   GET /c/:name       → full shell HTML for the named component
+ *   GET /bundle/:name.js → compiled Svelte client bundle (cached)
+ *   GET /styles.css    → raw contents of src/styles/index.css
+ *   GET /example-src/:name/:scenario → raw .example.svelte source
+ *   GET /events        → Server-Sent Events stream for live reload
+ *   GET /ping          → health check ("pong")
+ *
+ * A file watcher on `src/` triggers a reload event to all connected SSE clients
+ * whenever a file changes. Use `triggerReload()` directly in tests.
+ */
+
+import { watch } from 'node:fs';
+import { join } from 'node:path';
+
+import { sveltePlugin } from '../svelte-plugin.ts';
+import { discoverComponents } from './discover.ts';
+import { renderShell } from './render-shell.ts';
+
+const PORT = 4173;
+const ROOT = process.cwd();
+
+/** Compiled bundle cache: component name → JS source string. */
+const bundleCache = new Map<string, string>();
+
+/** Set of active SSE stream controllers. */
+const sseClients = new Set<ReadableStreamDefaultController>();
+
+/** Send a `reload` event to every connected SSE client. */
+export function triggerReload(): void {
+  const message = 'event: reload\ndata: {}\n\n';
+  for (const controller of sseClients) {
+    try {
+      controller.enqueue(message);
+    } catch {
+      // Client already closed — remove it.
+      sseClients.delete(controller);
+    }
+  }
+}
+
+/** Start watching `src/` recursively and fire `triggerReload` on any change. */
+function startWatcher(): void {
+  const srcPath = join(ROOT, 'src');
+  watch(srcPath, { recursive: true }, (_event, filename) => {
+    if (filename) {
+      // Invalidate the bundle cache for any changed component.
+      const match = filename.match(/^components\/([^/]+)\.svelte$/);
+      if (match) {
+        bundleCache.delete(match[1]!);
+      }
+      triggerReload();
+    }
+  });
+}
+
+/** Compile a component bundle and cache the result. */
+async function buildBundle(componentName: string): Promise<string | null> {
+  if (bundleCache.has(componentName)) {
+    return bundleCache.get(componentName)!;
+  }
+
+  const componentPath = join(ROOT, 'src', 'components', `${componentName}.svelte`);
+  const file = Bun.file(componentPath);
+  const exists = await file.exists();
+  if (!exists) return null;
+
+  const result = await Bun.build({
+    entrypoints: [componentPath],
+    plugins: [sveltePlugin({ generate: 'client' })],
+    target: 'browser',
+    format: 'esm',
+  });
+
+  if (!result.success) {
+    console.error(`[playground] Bundle failed for ${componentName}:`, result.logs);
+    return null;
+  }
+
+  const output = result.outputs[0];
+  if (!output) return null;
+
+  const code = await output.text();
+  bundleCache.set(componentName, code);
+  return code;
+}
+
+/** Build a plain-text 404 response. */
+function notFound(message = 'Not Found'): Response {
+  return new Response(message, { status: 404, headers: { 'Content-Type': 'text/plain' } });
+}
+
+/** Main request handler for Bun.serve. */
+async function handleRequest(request: Request): Promise<Response> {
+  const url = new URL(request.url);
+  const { pathname } = url;
+
+  // GET /ping
+  if (pathname === '/ping') {
+    return new Response('pong', { headers: { 'Content-Type': 'text/plain' } });
+  }
+
+  // GET /events
+  if (pathname === '/events') {
+    let controller!: ReadableStreamDefaultController;
+    const stream = new ReadableStream({
+      start(c) {
+        controller = c;
+        sseClients.add(controller);
+        // Send an initial comment to establish the connection.
+        controller.enqueue(': connected\n\n');
+      },
+      cancel() {
+        sseClients.delete(controller);
+      },
+    });
+
+    return new Response(stream, {
+      headers: {
+        'Content-Type': 'text/event-stream',
+        'Cache-Control': 'no-cache',
+        Connection: 'keep-alive',
+      },
+    });
+  }
+
+  // GET /styles.css
+  if (pathname === '/styles.css') {
+    const cssPath = join(ROOT, 'src', 'styles', 'index.css');
+    const cssFile = Bun.file(cssPath);
+    if (!(await cssFile.exists())) return notFound('styles.css not found');
+    const css = await cssFile.text();
+    return new Response(css, { headers: { 'Content-Type': 'text/css' } });
+  }
+
+  // GET /bundle/:name.js
+  const bundleMatch = pathname.match(/^\/bundle\/([^/]+)\.js$/);
+  if (bundleMatch) {
+    const componentName = bundleMatch[1]!;
+    const code = await buildBundle(componentName);
+    if (code === null) return notFound(`Component "${componentName}" not found or failed to build`);
+    return new Response(code, { headers: { 'Content-Type': 'application/javascript' } });
+  }
+
+  // GET /example-src/:name/:scenario
+  const exampleSrcMatch = pathname.match(/^\/example-src\/([^/]+)\/([^/]+)$/);
+  if (exampleSrcMatch) {
+    const componentName = exampleSrcMatch[1]!;
+    const scenario = exampleSrcMatch[2]!;
+    const examplePath = join(
+      ROOT,
+      'scripts',
+      'playground',
+      'examples',
+      componentName,
+      `${scenario}.example.svelte`,
+    );
+    const exampleFile = Bun.file(examplePath);
+    if (!(await exampleFile.exists()))
+      return notFound(`Example "${componentName}/${scenario}" not found`);
+    const source = await exampleFile.text();
+    return new Response(source, { headers: { 'Content-Type': 'text/plain' } });
+  }
+
+  // GET /c/:name
+  const componentMatch = pathname.match(/^\/c\/([^/]+)$/);
+  if (componentMatch) {
+    const componentName = componentMatch[1]!;
+    const allComponents = await discoverComponents();
+    if (!allComponents.includes(componentName))
+      return notFound(`Component "${componentName}" not found`);
+    const html = renderShell(componentName, allComponents);
+    return new Response(html, { headers: { 'Content-Type': 'text/html' } });
+  }
+
+  // GET / → redirect to first component
+  if (pathname === '/') {
+    const allComponents = await discoverComponents();
+    if (allComponents.length === 0) {
+      const html = renderShell(null, []);
+      return new Response(html, { headers: { 'Content-Type': 'text/html' } });
+    }
+    const first = allComponents[0];
+    return new Response(null, {
+      status: 302,
+      headers: { Location: `/c/${first}` },
+    });
+  }
+
+  return notFound();
+}
+
+/** Start the playground server. */
+function main(): void {
+  startWatcher();
+
+  const server = Bun.serve({
+    port: PORT,
+    fetch: handleRequest,
+  });
+
+  process.stdout.write(`[playground] Listening at http://localhost:${server.port}\n`);
+}
+
+main();

--- a/scripts/playground/server.ts
+++ b/scripts/playground/server.ts
@@ -49,37 +49,51 @@ export function triggerReload(): void {
 
 /** Start watching `src/` and `scripts/playground/examples/` for live reload. */
 function startWatcher(): FSWatcher[] {
-  const srcPath = join(ROOT, 'src');
-  const srcWatcher = watch(srcPath, { recursive: true }, (_event, filename) => {
-    if (filename) {
-      // Invalidate example bundle cache for any changed component.
-      const match = filename.match(/^components\/([^/]+)\.svelte$/);
-      if (match) {
-        const componentName = match[1]!;
-        for (const key of bundleCache.keys()) {
-          if (key.startsWith(`${componentName}/`)) {
-            bundleCache.delete(key);
+  const created: FSWatcher[] = [];
+
+  try {
+    const srcPath = join(ROOT, 'src');
+    created.push(
+      watch(srcPath, { recursive: true }, (_event, filename) => {
+        if (filename) {
+          // Invalidate example bundle cache for any changed component.
+          const match = filename.match(/^components\/([^/]+)\.svelte$/);
+          if (match) {
+            const componentName = match[1]!;
+            for (const key of bundleCache.keys()) {
+              if (key.startsWith(`${componentName}/`)) {
+                bundleCache.delete(key);
+              }
+            }
           }
+          triggerReload();
         }
-      }
-      triggerReload();
-    }
-  });
+      }),
+    );
 
-  // Watch the examples directory so edits to .example.svelte files invalidate
-  // the cached bundle and trigger a browser reload.
-  const examplesPath = join(ROOT, 'scripts', 'playground', 'examples');
-  const examplesWatcher = watch(examplesPath, { recursive: true }, (_event, filename) => {
-    if (filename) {
-      const match = filename.match(/^([^/]+)\/([^/]+)\.example\.svelte$/);
-      if (match) {
-        bundleCache.delete(`${match[1]}/${match[2]}`);
-      }
-      triggerReload();
+    // Watch the examples directory so edits to .example.svelte files invalidate
+    // the cached bundle and trigger a browser reload.
+    const examplesPath = join(ROOT, 'scripts', 'playground', 'examples');
+    created.push(
+      watch(examplesPath, { recursive: true }, (_event, filename) => {
+        if (filename) {
+          const match = filename.match(/^([^/]+)\/([^/]+)\.example\.svelte$/);
+          if (match) {
+            bundleCache.delete(`${match[1]}/${match[2]}`);
+          }
+          triggerReload();
+        }
+      }),
+    );
+  } catch (error) {
+    // Close any watchers already created before rethrowing.
+    for (const watcher of created) {
+      watcher.close();
     }
-  });
+    throw error;
+  }
 
-  return [srcWatcher, examplesWatcher];
+  return created;
 }
 
 /** Compile an example bundle and cache the result. */

--- a/scripts/playground/tsconfig.json
+++ b/scripts/playground/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "."
+  },
+  "include": ["./**/*", "../../src/**/*"]
+}

--- a/scripts/playground/validate-playground.ts
+++ b/scripts/playground/validate-playground.ts
@@ -13,7 +13,7 @@
  */
 
 import { discoverComponents } from './discover.ts';
-import { main as startServer, triggerReload } from './server.ts';
+import { PORT, main as startServer, triggerReload } from './server.ts';
 
 class PlaygroundValidationError extends Error {
   constructor(message: string) {
@@ -29,7 +29,6 @@ function fail(message: string): never {
 /** Minimum number of public components expected in src/components/. */
 const MINIMUM_COMPONENT_COUNT = 21;
 
-const PORT = 4173;
 const BASE_URL = `http://127.0.0.1:${PORT}`;
 
 /** Wait for the server to become ready by polling /ping. */

--- a/scripts/playground/validate-playground.ts
+++ b/scripts/playground/validate-playground.ts
@@ -178,10 +178,10 @@ try {
   await validateSseReload(BASE_URL);
 
   process.stdout.write('[validate:playground] all checks passed.\n');
-  server.dispose();
+  await server.dispose();
   process.exit(0);
 } catch (error) {
-  server?.dispose();
+  await server?.dispose();
   if (error instanceof PlaygroundValidationError) {
     process.stderr.write(`[validate:playground] FAILED: ${error.message}\n`);
     process.exit(1);

--- a/scripts/playground/validate-playground.ts
+++ b/scripts/playground/validate-playground.ts
@@ -13,7 +13,7 @@
  */
 
 import { discoverComponents } from './discover.ts';
-import { PORT, main as startServer, triggerReload } from './server.ts';
+import { PORT, startServer, triggerReload } from './server.ts';
 
 class PlaygroundValidationError extends Error {
   constructor(message: string) {
@@ -159,8 +159,10 @@ async function validateSseReload(baseUrl: string): Promise<void> {
   process.stdout.write('[validate:playground] SSE reload event received.\n');
 }
 
+let server: ReturnType<typeof startServer> | undefined;
+
 try {
-  startServer();
+  server = startServer(PORT);
   process.stdout.write(`[validate:playground] waiting for playground server on port ${PORT}…\n`);
   await waitForPing(10_000);
   process.stdout.write(`[validate:playground] server ready at ${BASE_URL}\n`);
@@ -176,8 +178,10 @@ try {
   await validateSseReload(BASE_URL);
 
   process.stdout.write('[validate:playground] all checks passed.\n');
+  void server.stop(true);
   process.exit(0);
 } catch (error) {
+  void server?.stop(true);
   if (error instanceof PlaygroundValidationError) {
     process.stderr.write(`[validate:playground] FAILED: ${error.message}\n`);
     process.exit(1);

--- a/scripts/playground/validate-playground.ts
+++ b/scripts/playground/validate-playground.ts
@@ -1,7 +1,7 @@
 /**
  * Validation script for the cinder component playground server.
  *
- * Starts the playground server in-process by calling main() from server.ts
+ * Starts the playground server in-process by calling startServer() from server.ts
  * (guarded by import.meta.main so importing it here does not auto-start it),
  * crawls every /c/<name> route for all discovered components, validates HTTP
  * status codes and page content, and tests the SSE reload path.
@@ -13,7 +13,7 @@
  */
 
 import { discoverComponents } from './discover.ts';
-import { PORT, startServer, triggerReload } from './server.ts';
+import { type PlaygroundServer, PORT, startServer, triggerReload } from './server.ts';
 
 class PlaygroundValidationError extends Error {
   constructor(message: string) {
@@ -159,7 +159,7 @@ async function validateSseReload(baseUrl: string): Promise<void> {
   process.stdout.write('[validate:playground] SSE reload event received.\n');
 }
 
-let server: ReturnType<typeof startServer> | undefined;
+let server: PlaygroundServer | undefined;
 
 try {
   server = startServer(PORT);
@@ -178,10 +178,10 @@ try {
   await validateSseReload(BASE_URL);
 
   process.stdout.write('[validate:playground] all checks passed.\n');
-  void server.stop(true);
+  server.dispose();
   process.exit(0);
 } catch (error) {
-  void server?.stop(true);
+  server?.dispose();
   if (error instanceof PlaygroundValidationError) {
     process.stderr.write(`[validate:playground] FAILED: ${error.message}\n`);
     process.exit(1);

--- a/scripts/playground/validate-playground.ts
+++ b/scripts/playground/validate-playground.ts
@@ -1,0 +1,229 @@
+/**
+ * Validation script for the cinder component playground server.
+ *
+ * Starts the playground server on an ephemeral port by spawning a subprocess,
+ * crawls every /c/<name> route for all discovered components, validates HTTP
+ * status codes and page content, and tests the SSE reload path using
+ * `triggerReload()` imported in-process from a minimal server instance.
+ *
+ * Usage:
+ *   bun run scripts/playground/validate-playground.ts
+ *
+ * Exit 0 on success, non-zero with a descriptive error on failure.
+ */
+
+import { createServer } from 'node:net';
+
+import { discoverComponents } from './discover.ts';
+import { triggerReload } from './server.ts';
+
+class PlaygroundValidationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'PlaygroundValidationError';
+  }
+}
+
+function fail(message: string): never {
+  throw new PlaygroundValidationError(message);
+}
+
+/**
+ * Allocate an ephemeral port by briefly binding to :0 and reading the OS-assigned port.
+ *
+ * Brief TOCTOU window between probe close and caller bind — accepted tradeoff.
+ * Pattern mirrors `scripts/validate-consumers.ts`.
+ */
+async function pickEphemeralPort(): Promise<number> {
+  return await new Promise<number>((resolve, reject) => {
+    const probeServer = createServer();
+    probeServer.once('error', reject);
+    probeServer.listen(0, '127.0.0.1', () => {
+      const address = probeServer.address();
+      if (address === null || typeof address === 'string') {
+        probeServer.close();
+        reject(new Error('unexpected server address shape'));
+        return;
+      }
+      const port = address.port;
+      probeServer.close(() => resolve(port));
+    });
+  });
+}
+
+/**
+ * Validate that every /c/<name> route returns HTTP 200 and renders an HTML page.
+ * When the page contains `class="example-card"` elements (populated examples),
+ * asserts at least one is present. For now asserts the page renders without error.
+ */
+async function validateComponentRoutes(baseUrl: string, components: string[]): Promise<void> {
+  process.stdout.write(`[validate:playground] crawling ${components.length} component routes…\n`);
+
+  for (const name of components) {
+    const url = `${baseUrl}/c/${name}`;
+    let response: Response;
+    try {
+      response = await fetch(url, { signal: AbortSignal.timeout(5_000) });
+    } catch (error) {
+      fail(`fetch ${url} threw: ${String(error)}`);
+    }
+
+    if (response.status !== 200) {
+      fail(`GET ${url} returned ${response.status}, expected 200`);
+    }
+
+    const body = await response.text();
+    if (!body.includes('<!DOCTYPE html>')) {
+      fail(`GET ${url} did not return HTML (missing DOCTYPE)`);
+    }
+
+    // When examples are present, assert at least one example-card renders.
+    // For now we assert the page rendered without an error shell.
+    if (body.includes('class="example-card"')) {
+      // Already satisfied — examples are present and rendered.
+    } else {
+      // No examples yet: assert the shell itself is present (nav + main).
+      if (!body.includes('<nav>')) {
+        fail(`GET ${url} HTML is missing the expected <nav> shell element`);
+      }
+    }
+  }
+
+  process.stdout.write(
+    `[validate:playground] all ${components.length} component routes returned 200.\n`,
+  );
+}
+
+/**
+ * Validate the SSE reload path:
+ *   1. Connect to /events.
+ *   2. Call `triggerReload()` (imported from server.ts — runs in this process).
+ *   3. Assert a `reload` event arrives within 1 000 ms.
+ *
+ * Because `triggerReload()` broadcasts to SSE clients tracked in server.ts's
+ * module-level `sseClients` Set, and `server.ts` auto-started on import, the
+ * SSE client connected to that server instance is reachable here.
+ */
+async function validateSseReload(baseUrl: string): Promise<void> {
+  process.stdout.write('[validate:playground] testing SSE reload path…\n');
+
+  const reloadReceived = new Promise<void>((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      reject(new PlaygroundValidationError('SSE reload event not received within 1000ms'));
+    }, 1_000);
+
+    // Use a manual fetch + ReadableStream reader instead of EventSource so we
+    // can control the abort and avoid browser-only API assumptions.
+    const abortController = new AbortController();
+
+    const ssePromise = fetch(`${baseUrl}/events`, {
+      signal: abortController.signal,
+      headers: { Accept: 'text/event-stream' },
+    })
+      .then(async (response) => {
+        if (!response.body) {
+          clearTimeout(timeout);
+          abortController.abort();
+          reject(new PlaygroundValidationError('/events response has no body'));
+          return null;
+        }
+
+        const reader = response.body.getReader();
+        const decoder = new TextDecoder();
+
+        try {
+          while (true) {
+            const { done, value } = await reader.read();
+            if (done) break;
+
+            const chunk = decoder.decode(value, { stream: true });
+            if (chunk.includes('event: reload')) {
+              clearTimeout(timeout);
+              abortController.abort();
+              resolve();
+              return null;
+            }
+          }
+        } catch (error) {
+          // AbortError is expected when we abort after receiving the event.
+          if (error instanceof Error && error.name === 'AbortError') return null;
+          clearTimeout(timeout);
+          reject(error);
+        }
+        return null;
+      })
+      .catch((error: unknown) => {
+        if (error instanceof Error && error.name === 'AbortError') return null;
+        clearTimeout(timeout);
+        reject(error);
+        return null;
+      });
+
+    // Give the SSE connection a moment to establish before triggering reload.
+    void Bun.sleep(100).then(() => {
+      triggerReload();
+      return null;
+    });
+
+    void ssePromise;
+  });
+
+  await reloadReceived;
+  process.stdout.write('[validate:playground] SSE reload event received.\n');
+}
+
+// ---------------------------------------------------------------------------
+// The playground server auto-starts when server.ts is imported (module side
+// effect: `main()` is called at the bottom of server.ts). It binds to the
+// default port (4173). We use pickEphemeralPort only to verify a port is
+// available for documentation parity with validate-consumers.ts; actual HTTP
+// requests go to the server that started on import.
+// ---------------------------------------------------------------------------
+
+const PORT = 4173;
+const BASE_URL = `http://127.0.0.1:${PORT}`;
+
+// Verify the port is at least reachable before validation (the server started
+// on import). Confirm readiness via /ping.
+async function waitForPing(timeoutMs: number): Promise<void> {
+  const startTime = Date.now();
+  while (Date.now() - startTime < timeoutMs) {
+    try {
+      const response = await fetch(`${BASE_URL}/ping`, { signal: AbortSignal.timeout(500) });
+      if (response.status === 200) return;
+    } catch {
+      // Not ready yet.
+    }
+    await Bun.sleep(100);
+  }
+  fail(`playground server did not respond on port ${PORT} within ${timeoutMs}ms`);
+}
+
+// Demonstrate that pickEphemeralPort is available (mirrors validate-consumers.ts pattern).
+const _ephemeralPortDemo = await pickEphemeralPort();
+process.stdout.write(
+  `[validate:playground] ephemeral port allocation works (sampled port: ${_ephemeralPortDemo}).\n`,
+);
+
+try {
+  process.stdout.write(`[validate:playground] waiting for playground server on port ${PORT}…\n`);
+  await waitForPing(10_000);
+  process.stdout.write(`[validate:playground] server ready at ${BASE_URL}\n`);
+
+  const components = await discoverComponents();
+  if (components.length < 21) {
+    fail(`expected at least 21 components but discoverComponents returned ${components.length}`);
+  }
+
+  await validateComponentRoutes(BASE_URL, components);
+  await validateSseReload(BASE_URL);
+
+  process.stdout.write('[validate:playground] all checks passed.\n');
+  process.exit(0);
+} catch (error) {
+  if (error instanceof PlaygroundValidationError) {
+    process.stderr.write(`[validate:playground] FAILED: ${error.message}\n`);
+    process.exit(1);
+  }
+  throw error;
+}

--- a/scripts/playground/validate-playground.ts
+++ b/scripts/playground/validate-playground.ts
@@ -162,7 +162,7 @@ async function validateSseReload(baseUrl: string): Promise<void> {
 let server: PlaygroundServer | undefined;
 
 try {
-  server = startServer(PORT);
+  server = await startServer(PORT);
   process.stdout.write(`[validate:playground] waiting for playground server on port ${PORT}…\n`);
   await waitForPing(10_000);
   process.stdout.write(`[validate:playground] server ready at ${BASE_URL}\n`);

--- a/scripts/playground/validate-playground.ts
+++ b/scripts/playground/validate-playground.ts
@@ -1,10 +1,10 @@
 /**
  * Validation script for the cinder component playground server.
  *
- * Starts the playground server on an ephemeral port by spawning a subprocess,
+ * Starts the playground server in-process by calling main() from server.ts
+ * (guarded by import.meta.main so importing it here does not auto-start it),
  * crawls every /c/<name> route for all discovered components, validates HTTP
- * status codes and page content, and tests the SSE reload path using
- * `triggerReload()` imported in-process from a minimal server instance.
+ * status codes and page content, and tests the SSE reload path.
  *
  * Usage:
  *   bun run scripts/playground/validate-playground.ts
@@ -12,10 +12,8 @@
  * Exit 0 on success, non-zero with a descriptive error on failure.
  */
 
-import { createServer } from 'node:net';
-
 import { discoverComponents } from './discover.ts';
-import { triggerReload } from './server.ts';
+import { main as startServer, triggerReload } from './server.ts';
 
 class PlaygroundValidationError extends Error {
   constructor(message: string) {
@@ -28,33 +26,30 @@ function fail(message: string): never {
   throw new PlaygroundValidationError(message);
 }
 
-/**
- * Allocate an ephemeral port by briefly binding to :0 and reading the OS-assigned port.
- *
- * Brief TOCTOU window between probe close and caller bind — accepted tradeoff.
- * Pattern mirrors `scripts/validate-consumers.ts`.
- */
-async function pickEphemeralPort(): Promise<number> {
-  return await new Promise<number>((resolve, reject) => {
-    const probeServer = createServer();
-    probeServer.once('error', reject);
-    probeServer.listen(0, '127.0.0.1', () => {
-      const address = probeServer.address();
-      if (address === null || typeof address === 'string') {
-        probeServer.close();
-        reject(new Error('unexpected server address shape'));
-        return;
-      }
-      const port = address.port;
-      probeServer.close(() => resolve(port));
-    });
-  });
+/** Minimum number of public components expected in src/components/. */
+const MINIMUM_COMPONENT_COUNT = 21;
+
+const PORT = 4173;
+const BASE_URL = `http://127.0.0.1:${PORT}`;
+
+/** Wait for the server to become ready by polling /ping. */
+async function waitForPing(timeoutMs: number): Promise<void> {
+  const startTime = Date.now();
+  while (Date.now() - startTime < timeoutMs) {
+    try {
+      const response = await fetch(`${BASE_URL}/ping`, { signal: AbortSignal.timeout(500) });
+      if (response.status === 200) return;
+    } catch {
+      // Not ready yet.
+    }
+    await Bun.sleep(100);
+  }
+  fail(`playground server did not respond on port ${PORT} within ${timeoutMs}ms`);
 }
 
 /**
- * Validate that every /c/<name> route returns HTTP 200 and renders an HTML page.
- * When the page contains `class="example-card"` elements (populated examples),
- * asserts at least one is present. For now asserts the page renders without error.
+ * Validate that every /c/<name> route returns HTTP 200 and renders an HTML page
+ * with the expected <nav> shell element.
  */
 async function validateComponentRoutes(baseUrl: string, components: string[]): Promise<void> {
   process.stdout.write(`[validate:playground] crawling ${components.length} component routes…\n`);
@@ -77,15 +72,8 @@ async function validateComponentRoutes(baseUrl: string, components: string[]): P
       fail(`GET ${url} did not return HTML (missing DOCTYPE)`);
     }
 
-    // When examples are present, assert at least one example-card renders.
-    // For now we assert the page rendered without an error shell.
-    if (body.includes('class="example-card"')) {
-      // Already satisfied — examples are present and rendered.
-    } else {
-      // No examples yet: assert the shell itself is present (nav + main).
-      if (!body.includes('<nav>')) {
-        fail(`GET ${url} HTML is missing the expected <nav> shell element`);
-      }
+    if (!body.includes('<nav>')) {
+      fail(`GET ${url} HTML is missing the expected <nav> shell element`);
     }
   }
 
@@ -96,13 +84,9 @@ async function validateComponentRoutes(baseUrl: string, components: string[]): P
 
 /**
  * Validate the SSE reload path:
- *   1. Connect to /events.
- *   2. Call `triggerReload()` (imported from server.ts — runs in this process).
+ *   1. Connect to /events and wait for the ': connected' handshake.
+ *   2. Call `triggerReload()` once the connection is confirmed.
  *   3. Assert a `reload` event arrives within 1 000 ms.
- *
- * Because `triggerReload()` broadcasts to SSE clients tracked in server.ts's
- * module-level `sseClients` Set, and `server.ts` auto-started on import, the
- * SSE client connected to that server instance is reachable here.
  */
 async function validateSseReload(baseUrl: string): Promise<void> {
   process.stdout.write('[validate:playground] testing SSE reload path…\n');
@@ -130,6 +114,7 @@ async function validateSseReload(baseUrl: string): Promise<void> {
 
         const reader = response.body.getReader();
         const decoder = new TextDecoder();
+        let connected = false;
 
         try {
           while (true) {
@@ -137,6 +122,15 @@ async function validateSseReload(baseUrl: string): Promise<void> {
             if (done) break;
 
             const chunk = decoder.decode(value, { stream: true });
+
+            // Wait for the server's initial handshake comment before triggering
+            // reload — this guarantees the controller is registered in sseClients.
+            if (!connected && chunk.includes(': connected')) {
+              connected = true;
+              triggerReload();
+              continue;
+            }
+
             if (chunk.includes('event: reload')) {
               clearTimeout(timeout);
               abortController.abort();
@@ -159,12 +153,6 @@ async function validateSseReload(baseUrl: string): Promise<void> {
         return null;
       });
 
-    // Give the SSE connection a moment to establish before triggering reload.
-    void Bun.sleep(100).then(() => {
-      triggerReload();
-      return null;
-    });
-
     void ssePromise;
   });
 
@@ -172,47 +160,17 @@ async function validateSseReload(baseUrl: string): Promise<void> {
   process.stdout.write('[validate:playground] SSE reload event received.\n');
 }
 
-// ---------------------------------------------------------------------------
-// The playground server auto-starts when server.ts is imported (module side
-// effect: `main()` is called at the bottom of server.ts). It binds to the
-// default port (4173). We use pickEphemeralPort only to verify a port is
-// available for documentation parity with validate-consumers.ts; actual HTTP
-// requests go to the server that started on import.
-// ---------------------------------------------------------------------------
-
-const PORT = 4173;
-const BASE_URL = `http://127.0.0.1:${PORT}`;
-
-// Verify the port is at least reachable before validation (the server started
-// on import). Confirm readiness via /ping.
-async function waitForPing(timeoutMs: number): Promise<void> {
-  const startTime = Date.now();
-  while (Date.now() - startTime < timeoutMs) {
-    try {
-      const response = await fetch(`${BASE_URL}/ping`, { signal: AbortSignal.timeout(500) });
-      if (response.status === 200) return;
-    } catch {
-      // Not ready yet.
-    }
-    await Bun.sleep(100);
-  }
-  fail(`playground server did not respond on port ${PORT} within ${timeoutMs}ms`);
-}
-
-// Demonstrate that pickEphemeralPort is available (mirrors validate-consumers.ts pattern).
-const _ephemeralPortDemo = await pickEphemeralPort();
-process.stdout.write(
-  `[validate:playground] ephemeral port allocation works (sampled port: ${_ephemeralPortDemo}).\n`,
-);
-
 try {
+  startServer();
   process.stdout.write(`[validate:playground] waiting for playground server on port ${PORT}…\n`);
   await waitForPing(10_000);
   process.stdout.write(`[validate:playground] server ready at ${BASE_URL}\n`);
 
   const components = await discoverComponents();
-  if (components.length < 21) {
-    fail(`expected at least 21 components but discoverComponents returned ${components.length}`);
+  if (components.length < MINIMUM_COMPONENT_COUNT) {
+    fail(
+      `expected at least ${MINIMUM_COMPONENT_COUNT} components but discoverComponents returned ${components.length}`,
+    );
   }
 
   await validateComponentRoutes(BASE_URL, components);


### PR DESCRIPTION
## Summary

Adds a Bun.serve component playground at http://localhost:4173 (`bun run playground`).

- **Discovery**: `discoverComponents()` globs `src/components/*.svelte`; `discoverExamples()` globs `scripts/playground/examples/<name>/*.example.svelte`
- **Server** (`server.ts`): routes `/ping`, `/events` (SSE), `/styles.css`, `/bundle/:name/:scenario.js` (compiled example bundles, cached), `/example-src/:name/:scenario` (raw source), `/c/:name` (shell HTML), `/` (302 redirect)
- **Live reload**: `fs.watch` on both `src/` and `scripts/playground/examples/`; invalidates bundle cache per component/scenario; broadcasts `event: reload` via SSE to connected browsers
- **Shell** (`render-shell.ts`): server-side HTML with sidebar nav + iframe; SSE reconnect script
- **Component page** (`component-page.svelte`): reads `window.__CINDER_EXAMPLES__` (server-injected), mounts each example via dynamic `import('/bundle/:name/:scenario.js')`, `$effect` cleanup prevents double-mount
- **Security**: `isSafeSegment()` validates all URL path segments; `escapeHtml()` in shell rendering
- **Lifecycle**: `startServer()` returns `{ port, dispose() }` — dispose closes all FSWatchers and awaits server shutdown; exception-safe startup order (HTTP first, then watchers)
- **Validation**: `scripts/playground/validate-playground.ts` crawls all component routes + tests SSE reload via `: connected` handshake
- **Tests**: 34 unit tests in `server.test.ts` covering all routes, SSE, isSafeSegment, cache hits

## Review committee

Pre-reviewed by: typescript-expert, testing-expert, dx-engineer, simplicity-engineer, junior-engineer, Codex

- Codex (gpt-5.4, xhigh reasoning) — 7 rounds of adversarial review
- All must-fix items addressed (12 from round 1, plus lifecycle issues surfaced in rounds 3–6)

Notable fixes driven by committee review:
- Bundle route mismatch (critical: examples would have 404'd)
- Path traversal protection via isSafeSegment
- XSS via HTML-escaping in render-shell.ts
- $effect cleanup to prevent double-mount
- SSE test handshake (was a 100ms sleep race)
- import.meta.main guard (no auto-start on import)
- Watcher lifecycle: exception-safe construction, async dispose

## Test plan

```bash
bun run playground          # starts at http://localhost:4173
bun run validate:playground # smoke-validates all routes + SSE reload
bun test scripts/playground # 34 unit tests
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new local dev server with file watching, dynamic bundling, and SSE reload, which touches build/runtime behavior and could introduce stability issues or resource leaks during development.
> 
> **Overview**
> Adds a **Phase 3a component playground** runnable via `bun run playground`, including a Bun HTTP server that serves a shell UI, component routes, compiled example bundles, raw example source, and an SSE endpoint for live reload.
> 
> Introduces discovery + validation tooling (`discover*.ts`, `validate-playground.ts`) and unit tests to cover routing, caching, path-safety checks, and the SSE reload handshake.
> 
> Updates repo config to support the playground: ignores playground `.svelte` files in `oxlint`, adds `validate:playground`, and seeds the playground with initial per-component `.example.svelte` scenarios.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c32a276df88b6a0ecedad682933e707a951703fa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->