### PR TITLE
feat(phase-4): static analysis + auto-generated playground controls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -100,3 +100,6 @@ repomix-output.xml
 .env.local
 .env.*.local
 tmp/
+
+# Playground server temporary wrapper files
+scripts/playground/.controls-*.svelte

--- a/README.md
+++ b/README.md
@@ -92,6 +92,26 @@ cinder's compiled server output is coupled to the Svelte minor it was built agai
 - **Variants** use `data-cinder-*` attributes: `data-cinder-variant`, `data-cinder-size`.
 - **Design tokens** use `--cinder-*` for the public surface and `--_cinder-*` for internal-only custom properties.
 
+## Playground
+
+`bun run playground` starts the playground dev server at http://localhost:4173. The sidebar lists all 21 components—click any one to open its page in the main frame. Each component page shows curated examples with live controls.
+
+Those controls aren't hardcoded. The playground reads your component's `Props` type and generates form inputs automatically—text fields for strings, toggles for booleans, dropdowns for string unions. Change a `.svelte` file and the playground reloads via Server-Sent Events; no manual refresh needed.
+
+## Analyzer conventions
+
+The static analyzer (`scripts/playground/analyze.ts`) relies on five structural conventions—already enforced by `src/convention.test.ts` and required to ship a component in Phase 2 or later. None of this is magic; it's just how the analyzer finds what it needs.
+
+Every component's module script must export a `${PascalName}Props` type alias. The analyzer reads the exported name to find the type definition; a Props export with any other name is silently ignored.
+
+Your instance script must destructure from `$props()`—not assign to a variable like `const props = $props()`. Destructuring lets the analyzer walk the object pattern directly and know exactly which props exist.
+
+Every prop you destructure must have either a default value or a type annotation. The analyzer needs the type to infer control kinds (text, boolean, dropdown); the default value seeds the control's initial state.
+
+When you use `$bindable()`, its argument must be a JSON-serializable literal—strings, numbers, booleans, empty arrays, empty objects, or nothing at all. No function calls, no identifiers, no dynamic expressions. The playground initializes form state from your defaults and can only do that with values it can serialize.
+
+Snippet props must be typed as `Snippet` or `Snippet<[T]>`, never `Snippet | undefined`. Use `Snippet?` for optional snippets instead. The analyzer skips snippets entirely when generating controls—they can't be represented as form inputs.
+
 ## Working on cinder
 
 ### Environment

--- a/scripts/playground/analyze.test.ts
+++ b/scripts/playground/analyze.test.ts
@@ -1,0 +1,207 @@
+import { describe, expect, it } from 'bun:test';
+import { join } from 'node:path';
+
+import { analyzeAll, analyzeComponent } from './analyze.ts';
+
+const COMPONENTS_DIR = join(import.meta.dirname, '../../src/components');
+
+function componentPath(name: string): string {
+  return join(COMPONENTS_DIR, `${name}.svelte`);
+}
+
+// ---------------------------------------------------------------------------
+// Button
+// ---------------------------------------------------------------------------
+
+describe('analyzeComponent — button.svelte', () => {
+  it('returns the correct name and kebabName', async () => {
+    const manifest = await analyzeComponent(componentPath('button'));
+    expect(manifest.name).toBe('Button');
+    expect(manifest.kebabName).toBe('button');
+  });
+
+  it('sets importPath correctly', async () => {
+    const manifest = await analyzeComponent(componentPath('button'));
+    expect(manifest.importPath).toBe('cinder/button');
+  });
+
+  it('includes a variant prop as a select control', async () => {
+    const manifest = await analyzeComponent(componentPath('button'));
+    const variant = manifest.props.find((p) => p.name === 'variant');
+    expect(variant).toBeDefined();
+    expect(variant?.control.kind).toBe('select');
+    if (variant?.control.kind === 'select') {
+      expect(variant.control.options).toContain('primary');
+      expect(variant.control.options).toContain('secondary');
+      expect(variant.control.options).toContain('danger');
+      expect(variant.control.options).toContain('ghost');
+    }
+  });
+
+  it('includes a size prop as a select control', async () => {
+    const manifest = await analyzeComponent(componentPath('button'));
+    const size = manifest.props.find((p) => p.name === 'size');
+    expect(size).toBeDefined();
+    expect(size?.control.kind).toBe('select');
+  });
+
+  it('includes a loading prop as a boolean control', async () => {
+    const manifest = await analyzeComponent(componentPath('button'));
+    const loading = manifest.props.find((p) => p.name === 'loading');
+    expect(loading).toBeDefined();
+    expect(loading?.control.kind).toBe('boolean');
+  });
+
+  it('includes a fullWidth prop as a boolean control', async () => {
+    const manifest = await analyzeComponent(componentPath('button'));
+    const fullWidth = manifest.props.find((p) => p.name === 'fullWidth');
+    expect(fullWidth).toBeDefined();
+    expect(fullWidth?.control.kind).toBe('boolean');
+  });
+
+  it('does not include the class prop', async () => {
+    const manifest = await analyzeComponent(componentPath('button'));
+    expect(manifest.props.find((p) => p.name === 'class')).toBeUndefined();
+  });
+
+  it('file is the absolute path to the svelte file', async () => {
+    const manifest = await analyzeComponent(componentPath('button'));
+    expect(manifest.file).toBe(componentPath('button'));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Spinner
+// ---------------------------------------------------------------------------
+
+describe('analyzeComponent — spinner.svelte', () => {
+  it('returns the correct name', async () => {
+    const manifest = await analyzeComponent(componentPath('spinner'));
+    expect(manifest.name).toBe('Spinner');
+    expect(manifest.kebabName).toBe('spinner');
+  });
+
+  it('has a size prop as select with options sm, md, lg', async () => {
+    const manifest = await analyzeComponent(componentPath('spinner'));
+    const size = manifest.props.find((p) => p.name === 'size');
+    expect(size).toBeDefined();
+    expect(size?.control.kind).toBe('select');
+    if (size?.control.kind === 'select') {
+      expect(size.control.options).toEqual(['sm', 'md', 'lg']);
+    }
+  });
+
+  it('has a label prop as text', async () => {
+    const manifest = await analyzeComponent(componentPath('spinner'));
+    const label = manifest.props.find((p) => p.name === 'label');
+    expect(label).toBeDefined();
+    expect(label?.control.kind).toBe('text');
+  });
+
+  it('has default value for size', async () => {
+    const manifest = await analyzeComponent(componentPath('spinner'));
+    const size = manifest.props.find((p) => p.name === 'size');
+    expect(size?.defaultValue).toBe('md');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Input
+// ---------------------------------------------------------------------------
+
+describe('analyzeComponent — input.svelte', () => {
+  it('has an id prop as text', async () => {
+    const manifest = await analyzeComponent(componentPath('input'));
+    const id = manifest.props.find((p) => p.name === 'id');
+    expect(id).toBeDefined();
+    expect(id?.control.kind).toBe('text');
+  });
+
+  it('has a value prop as text and bindable', async () => {
+    const manifest = await analyzeComponent(componentPath('input'));
+    const value = manifest.props.find((p) => p.name === 'value');
+    expect(value).toBeDefined();
+    expect(value?.control.kind).toBe('text');
+    expect(value?.bindable).toBe(true);
+  });
+
+  it('has a disabled prop as boolean', async () => {
+    const manifest = await analyzeComponent(componentPath('input'));
+    const disabled = manifest.props.find((p) => p.name === 'disabled');
+    expect(disabled).toBeDefined();
+    expect(disabled?.control.kind).toBe('boolean');
+  });
+
+  it('does not include class prop', async () => {
+    const manifest = await analyzeComponent(componentPath('input'));
+    expect(manifest.props.find((p) => p.name === 'class')).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Accordion — bindable expandedIds
+// ---------------------------------------------------------------------------
+
+describe('analyzeComponent — accordion.svelte', () => {
+  it('has expandedIds as bindable', async () => {
+    const manifest = await analyzeComponent(componentPath('accordion'));
+    const expandedIds = manifest.props.find((p) => p.name === 'expandedIds');
+    expect(expandedIds).toBeDefined();
+    expect(expandedIds?.bindable).toBe(true);
+  });
+
+  it('has multiple as boolean with default false', async () => {
+    const manifest = await analyzeComponent(componentPath('accordion'));
+    const multiple = manifest.props.find((p) => p.name === 'multiple');
+    expect(multiple).toBeDefined();
+    expect(multiple?.control.kind).toBe('boolean');
+    expect(multiple?.defaultValue).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// analyzeAll
+// ---------------------------------------------------------------------------
+
+describe('analyzeAll', () => {
+  it('returns at least 21 entries', async () => {
+    const manifests = await analyzeAll(COMPONENTS_DIR);
+    expect(manifests.length).toBeGreaterThanOrEqual(21);
+  });
+
+  it('all entries have a non-empty file path', async () => {
+    const manifests = await analyzeAll(COMPONENTS_DIR);
+    for (const manifest of manifests) {
+      expect(typeof manifest.file).toBe('string');
+      expect(manifest.file.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('all entries have a props array', async () => {
+    const manifests = await analyzeAll(COMPONENTS_DIR);
+    for (const manifest of manifests) {
+      expect(Array.isArray(manifest.props)).toBe(true);
+    }
+  });
+
+  it('results are sorted by kebabName', async () => {
+    const manifests = await analyzeAll(COMPONENTS_DIR);
+    const names = manifests.map((m) => m.kebabName);
+    const sorted = [...names].toSorted((a, b) => a.localeCompare(b));
+    expect(names).toEqual(sorted);
+  });
+
+  it('button appears in the results', async () => {
+    const manifests = await analyzeAll(COMPONENTS_DIR);
+    const button = manifests.find((m) => m.kebabName === 'button');
+    expect(button).toBeDefined();
+    expect(button?.name).toBe('Button');
+  });
+
+  it('excludes files from _internal/', async () => {
+    const manifests = await analyzeAll(COMPONENTS_DIR);
+    for (const manifest of manifests) {
+      expect(manifest.file).not.toContain('_internal');
+    }
+  });
+});

--- a/scripts/playground/analyze.test.ts
+++ b/scripts/playground/analyze.test.ts
@@ -205,3 +205,56 @@ describe('analyzeAll', () => {
     }
   });
 });
+
+// ---------------------------------------------------------------------------
+// NavigationItem — non-destructuring $props() returns empty props array
+// ---------------------------------------------------------------------------
+
+describe('analyzeComponent — navigation-item.svelte (non-destructuring $props)', () => {
+  it('returns an empty props array when $props() is not destructured', async () => {
+    const manifest = await analyzeComponent(componentPath('navigation-item'));
+    // NavigationItem uses `const props: NavigationItemProps = $props()` (no destructuring),
+    // so extractPropsFromSvelteAst returns [] and the manifest has no props.
+    expect(manifest.props).toEqual([]);
+  });
+
+  it('still returns the correct name and kebabName', async () => {
+    const manifest = await analyzeComponent(componentPath('navigation-item'));
+    expect(manifest.name).toBe('NavigationItem');
+    expect(manifest.kebabName).toBe('navigation-item');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Card — discriminated union Props (CardWithHeader | CardWithTitle)
+// ---------------------------------------------------------------------------
+
+describe('analyzeComponent — card.svelte (discriminated union Props)', () => {
+  it('returns a manifest without throwing', async () => {
+    await expect(analyzeComponent(componentPath('card'))).resolves.toBeDefined();
+  });
+
+  it('includes the children prop present in both arms', async () => {
+    const manifest = await analyzeComponent(componentPath('card'));
+    const children = manifest.props.find((p) => p.name === 'children');
+    expect(children).toBeDefined();
+    expect(children?.control.kind).toBe('snippet');
+  });
+
+  it('marks arm-only props as optional (header is only in CardWithHeader)', async () => {
+    const manifest = await analyzeComponent(componentPath('card'));
+    const header = manifest.props.find((p) => p.name === 'header');
+    // header appears in CardWithHeader but not CardWithTitle → optional across arms
+    if (header !== undefined) {
+      expect(header.optional).toBe(true);
+    }
+  });
+
+  it('marks arm-only props as optional (title is only in CardWithTitle)', async () => {
+    const manifest = await analyzeComponent(componentPath('card'));
+    const title = manifest.props.find((p) => p.name === 'title');
+    if (title !== undefined) {
+      expect(title.optional).toBe(true);
+    }
+  });
+});

--- a/scripts/playground/analyze.ts
+++ b/scripts/playground/analyze.ts
@@ -1,0 +1,498 @@
+/**
+ * Component manifest analyzer for the cinder playground.
+ *
+ * Combines two sources of truth:
+ *  1. svelte/compiler.parse — reads the $props() destructuring to extract prop names,
+ *     bindability ($bindable), and default values.
+ *  2. ts-morph — reads the exported `${Name}Props` type alias to determine each
+ *     prop's type (and therefore control kind), optionality, and JSDoc description.
+ *
+ * The $props() destructuring is canonical: only props that appear there are included in
+ * the manifest. If the Props type has a property not in the destructuring, it is skipped.
+ */
+
+import { readFileSync } from 'node:fs';
+import { basename, join } from 'node:path';
+
+import { parse } from 'svelte/compiler';
+import { Project, type PropertySignature, SyntaxKind, type TypeNode } from 'ts-morph';
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+export type ControlKind =
+  | { kind: 'text' }
+  | { kind: 'number' }
+  | { kind: 'boolean' }
+  | { kind: 'select'; options: string[] }
+  | { kind: 'snippet' }
+  | { kind: 'unknown'; rawType: string };
+
+export type PropManifest = {
+  name: string;
+  control: ControlKind;
+  defaultValue?: unknown;
+  bindable: boolean;
+  optional: boolean;
+  description?: string;
+};
+
+export type ComponentManifest = {
+  name: string;
+  kebabName: string;
+  file: string;
+  importPath: string;
+  props: PropManifest[];
+};
+
+// ---------------------------------------------------------------------------
+// Internal types for AST nodes (svelte/compiler returns untyped objects)
+// ---------------------------------------------------------------------------
+
+type AstNode = Record<string, unknown>;
+
+// ---------------------------------------------------------------------------
+// Control kind inference from ts-morph TypeNode
+// ---------------------------------------------------------------------------
+
+/**
+ * Infers a control kind from a ts-morph TypeNode.
+ * This will be replaced by controls.ts; keep the logic self-contained here.
+ */
+export function inferControlKind(typeNode: TypeNode | undefined, typeText: string): ControlKind {
+  if (typeNode === undefined) return { kind: 'unknown', rawType: typeText };
+
+  const kind = typeNode.getKind();
+
+  if (kind === SyntaxKind.BooleanKeyword) return { kind: 'boolean' };
+  if (kind === SyntaxKind.NumberKeyword) return { kind: 'number' };
+  if (kind === SyntaxKind.StringKeyword) return { kind: 'text' };
+
+  if (kind === SyntaxKind.UnionType) {
+    const union = typeNode.asKindOrThrow(SyntaxKind.UnionType);
+    const members = union.getTypeNodes();
+    const stringLiterals: string[] = [];
+    let allStringLiterals = true;
+
+    for (const member of members) {
+      if (member.getKind() === SyntaxKind.LiteralType) {
+        const literal = member.asKindOrThrow(SyntaxKind.LiteralType).getLiteral();
+        if (literal.getKind() === SyntaxKind.StringLiteral) {
+          // getText() includes quotes; remove them
+          stringLiterals.push(literal.getText().replace(/^['"]|['"]$/g, ''));
+          continue;
+        }
+      }
+      allStringLiterals = false;
+      break;
+    }
+
+    if (allStringLiterals && stringLiterals.length > 0) {
+      return { kind: 'select', options: stringLiterals };
+    }
+    return { kind: 'unknown', rawType: typeText };
+  }
+
+  if (kind === SyntaxKind.TypeReference) {
+    const ref = typeNode.asKindOrThrow(SyntaxKind.TypeReference);
+    const name = ref.getTypeName().getText();
+
+    // Snippet or Snippet<[...]> → snippet control
+    if (name === 'Snippet') return { kind: 'snippet' };
+
+    // Try to resolve the referenced alias in the same source file
+    const sf = typeNode.getSourceFile();
+    const alias = sf.getTypeAlias(name);
+    if (alias !== undefined) {
+      const resolvedNode = alias.getTypeNode();
+      return inferControlKind(resolvedNode, resolvedNode?.getText() ?? typeText);
+    }
+
+    return { kind: 'unknown', rawType: typeText };
+  }
+
+  return { kind: 'unknown', rawType: typeText };
+}
+
+// ---------------------------------------------------------------------------
+// Svelte AST helpers — extracting props from $props() destructuring
+// ---------------------------------------------------------------------------
+
+type RawPropEntry = {
+  name: string;
+  defaultValue?: unknown;
+  bindable: boolean;
+};
+
+/**
+ * Parses the right-hand side of an AssignmentPattern (the default value expression)
+ * and returns { defaultValue, bindable }.
+ */
+function parseDefaultExpression(rhs: AstNode): { defaultValue?: unknown; bindable: boolean } {
+  if (rhs['type'] === 'Literal') {
+    return { defaultValue: rhs['value'], bindable: false };
+  }
+
+  if (rhs['type'] === 'ArrayExpression') {
+    const elements = rhs['elements'] as AstNode[];
+    if (elements.length === 0) return { defaultValue: [], bindable: false };
+    const allLiterals = elements.every((el) => el['type'] === 'Literal');
+    if (allLiterals) {
+      return { defaultValue: elements.map((el) => el['value']), bindable: false };
+    }
+    return { defaultValue: undefined, bindable: false };
+  }
+
+  if (rhs['type'] === 'CallExpression') {
+    const callee = rhs['callee'] as AstNode;
+    if (callee['type'] === 'Identifier' && callee['name'] === '$bindable') {
+      const args = rhs['arguments'] as AstNode[];
+      if (args.length === 0) return { defaultValue: undefined, bindable: true };
+      const firstArg = args[0];
+      if (firstArg === undefined) return { defaultValue: undefined, bindable: true };
+      if (firstArg['type'] === 'Literal')
+        return { defaultValue: firstArg['value'], bindable: true };
+      // ArrayExpression default with $bindable (e.g. $bindable([]))
+      if (firstArg['type'] === 'ArrayExpression') {
+        const elements = firstArg['elements'] as AstNode[];
+        return { defaultValue: elements.map((el) => el['value']), bindable: true };
+      }
+      return { defaultValue: undefined, bindable: true };
+    }
+  }
+
+  return { defaultValue: undefined, bindable: false };
+}
+
+/**
+ * Extracts prop entries from the ObjectPattern of a $props() destructuring.
+ * Returns an empty array if the component does not use destructuring (e.g.
+ * `const props: Props = $props()`).
+ */
+function extractPropsFromSvelteAst(source: string): RawPropEntry[] {
+  const ast = parse(source, { filename: '__analyze__.svelte' });
+  const instanceScript = ast['instance'] as { content: { body: AstNode[] } } | undefined;
+
+  if (instanceScript === undefined) return [];
+
+  const body = instanceScript.content.body;
+
+  for (const node of body) {
+    if (node['type'] !== 'VariableDeclaration') continue;
+
+    const declarations = node['declarations'] as AstNode[];
+    for (const declarator of declarations) {
+      const init = declarator['init'] as AstNode | undefined;
+      if (init === undefined) continue;
+
+      // Look for either `$props()` directly or `$props()` as the expression
+      const isPropsCall =
+        init['type'] === 'CallExpression' &&
+        (init['callee'] as AstNode)['type'] === 'Identifier' &&
+        (init['callee'] as AstNode)['name'] === '$props';
+
+      if (!isPropsCall) continue;
+
+      const id = declarator['id'] as AstNode;
+      if (id['type'] !== 'ObjectPattern') {
+        // `const props: Type = $props()` — no destructuring, skip
+        return [];
+      }
+
+      const properties = id['properties'] as AstNode[];
+      const entries: RawPropEntry[] = [];
+
+      for (const property of properties) {
+        // RestElement → ...rest spread — skip
+        if (property['type'] === 'RestElement') continue;
+
+        const key = property['key'] as AstNode;
+        // Computed properties (e.g. [Symbol.iterator]) — skip
+        if (property['computed'] === true) continue;
+
+        const rawName: string =
+          key['type'] === 'Identifier' ? (key['name'] as string) : (key['value'] as string);
+
+        // class, aria-* and other non-standard names — will be filtered later
+        const value = property['value'] as AstNode;
+
+        if (value['type'] === 'AssignmentPattern') {
+          const rhs = value['right'] as AstNode;
+          const { defaultValue, bindable } = parseDefaultExpression(rhs);
+          entries.push({ name: rawName, defaultValue, bindable });
+        } else {
+          // No default value
+          entries.push({ name: rawName, defaultValue: undefined, bindable: false });
+        }
+      }
+
+      return entries;
+    }
+  }
+
+  return [];
+}
+
+// ---------------------------------------------------------------------------
+// ts-morph helpers — extracting type info from the module script block
+// ---------------------------------------------------------------------------
+
+/**
+ * Extracts the content of the first `<script lang="ts" module>` block
+ * (attribute order doesn't matter — matches both orderings).
+ */
+function extractModuleScriptContent(source: string): string {
+  // Match <script module lang="ts"> or <script lang="ts" module>
+  const pattern = /<script[^>]+\bmodule\b[^>]*>([\s\S]*?)<\/script>/;
+  const match = pattern.exec(source);
+  return match?.[1] ?? '';
+}
+
+/**
+ * Collects property signatures from a TypeLiteral node into a map.
+ * Handles intersection types by recursively merging all TypeLiteral arms.
+ */
+function collectPropertiesFromTypeNode(
+  typeNode: TypeNode,
+  map: Map<string, PropertySignature>,
+): void {
+  const kind = typeNode.getKind();
+
+  if (kind === SyntaxKind.TypeLiteral) {
+    for (const member of typeNode.asKindOrThrow(SyntaxKind.TypeLiteral).getMembers()) {
+      if (member.getKind() === SyntaxKind.PropertySignature) {
+        const prop = member.asKindOrThrow(SyntaxKind.PropertySignature);
+        const name = prop.getName();
+        if (!map.has(name)) {
+          map.set(name, prop);
+        }
+      }
+    }
+    return;
+  }
+
+  if (kind === SyntaxKind.IntersectionType) {
+    for (const arm of typeNode.asKindOrThrow(SyntaxKind.IntersectionType).getTypeNodes()) {
+      collectPropertiesFromTypeNode(arm, map);
+    }
+    return;
+  }
+
+  if (kind === SyntaxKind.TypeReference) {
+    const ref = typeNode.asKindOrThrow(SyntaxKind.TypeReference);
+    const name = ref.getTypeName().getText();
+    const sf = typeNode.getSourceFile();
+    const alias = sf.getTypeAlias(name);
+    if (alias !== undefined) {
+      const resolved = alias.getTypeNode();
+      if (resolved !== undefined) collectPropertiesFromTypeNode(resolved, map);
+    }
+    return;
+  }
+
+  if (kind === SyntaxKind.ParenthesizedType) {
+    collectPropertiesFromTypeNode(
+      typeNode.asKindOrThrow(SyntaxKind.ParenthesizedType).getTypeNode(),
+      map,
+    );
+    return;
+  }
+}
+
+type TypeInfo = {
+  control: ControlKind;
+  optional: boolean;
+  description: string | undefined;
+};
+
+/**
+ * Builds a map from prop name → TypeInfo by reading the exported Props type alias
+ * from ts-morph. Handles discriminated unions at the top level by walking all arms
+ * and merging prop types (conflicting types → unknown).
+ */
+function buildTypeInfoMap(
+  moduleScriptContent: string,
+  componentName: string,
+): Map<string, TypeInfo> {
+  const project = new Project({
+    tsConfigFilePath: join(import.meta.dirname, '../../tsconfig.json'),
+    skipAddingFilesFromTsConfig: true,
+  });
+
+  const syntheticPath = `__synthetic__/${componentName}.ts`;
+  const sf = project.createSourceFile(syntheticPath, moduleScriptContent, { overwrite: true });
+
+  const propsAliasName = `${componentName}Props`;
+  const propsAlias = sf.getTypeAlias(propsAliasName);
+
+  if (propsAlias === undefined) return new Map();
+
+  const typeNode = propsAlias.getTypeNode();
+  if (typeNode === undefined) return new Map();
+
+  const result = new Map<string, TypeInfo>();
+
+  function processTypeNode(node: TypeNode): void {
+    const nodeKind = node.getKind();
+
+    // Discriminated union at the top level: walk all arms and merge
+    if (nodeKind === SyntaxKind.UnionType) {
+      const union = node.asKindOrThrow(SyntaxKind.UnionType);
+      const perArmMaps: Array<Map<string, PropertySignature>> = [];
+
+      for (const arm of union.getTypeNodes()) {
+        const armMap = new Map<string, PropertySignature>();
+        collectPropertiesFromTypeNode(arm, armMap);
+        perArmMaps.push(armMap);
+      }
+
+      // Merge: collect all unique prop names across arms
+      const allNames = new Set<string>();
+      for (const armMap of perArmMaps) {
+        for (const name of armMap.keys()) allNames.add(name);
+      }
+
+      for (const name of allNames) {
+        // Gather all type texts from arms that have this prop
+        const typeTexts: string[] = [];
+        let firstProp: PropertySignature | undefined;
+        let description: string | undefined;
+        let optional = false;
+
+        for (const armMap of perArmMaps) {
+          const prop = armMap.get(name);
+          if (prop !== undefined) {
+            const tn = prop.getTypeNode();
+            typeTexts.push(tn?.getText() ?? '?');
+            if (firstProp === undefined) {
+              firstProp = prop;
+              description =
+                prop
+                  .getJsDocs()
+                  .map((d) => d.getDescription().trim())
+                  .join('') || undefined;
+            }
+            if (prop.hasQuestionToken()) optional = true;
+          } else {
+            // Prop missing from this arm → it's optional overall
+            optional = true;
+          }
+        }
+
+        if (firstProp === undefined) continue;
+
+        // If all arms agree on type text, use that; otherwise unknown
+        const uniqueTexts = [...new Set(typeTexts)];
+        let control: ControlKind;
+        if (uniqueTexts.length === 1 && firstProp !== undefined) {
+          control = inferControlKind(firstProp.getTypeNode(), uniqueTexts[0] ?? '?');
+        } else {
+          control = { kind: 'unknown', rawType: 'discriminated-union' };
+        }
+
+        result.set(name, { control, optional, description });
+      }
+
+      return;
+    }
+
+    // TypeLiteral, IntersectionType, TypeReference — collect all properties
+    const propMap = new Map<string, PropertySignature>();
+    collectPropertiesFromTypeNode(node, propMap);
+
+    for (const [name, prop] of propMap) {
+      const typeNodeForProp = prop.getTypeNode();
+      const typeText = typeNodeForProp?.getText() ?? '?';
+      const control = inferControlKind(typeNodeForProp, typeText);
+      const optional = prop.hasQuestionToken();
+      const description =
+        prop
+          .getJsDocs()
+          .map((d) => d.getDescription().trim())
+          .join('') || undefined;
+
+      result.set(name, { control, optional, description });
+    }
+  }
+
+  processTypeNode(typeNode);
+  return result;
+}
+
+// ---------------------------------------------------------------------------
+// Derive component name from file path
+// ---------------------------------------------------------------------------
+
+function toPascalCase(kebab: string): string {
+  return kebab.replace(/(^|-)([a-z])/g, (_, _sep, char: string) => char.toUpperCase());
+}
+
+// ---------------------------------------------------------------------------
+// Main analysis function
+// ---------------------------------------------------------------------------
+
+const SKIP_PROPS = new Set(['class', 'rest']);
+
+/** Analyzes a single Svelte component file and returns its ComponentManifest. */
+export async function analyzeComponent(filePath: string): Promise<ComponentManifest> {
+  const source = readFileSync(filePath, 'utf-8');
+  const fileBaseName = basename(filePath, '.svelte');
+  const componentName = toPascalCase(fileBaseName);
+
+  const rawProps = extractPropsFromSvelteAst(source);
+  const moduleScriptContent = extractModuleScriptContent(source);
+  const typeInfoMap = buildTypeInfoMap(moduleScriptContent, componentName);
+
+  const props: PropManifest[] = [];
+
+  for (const rawProp of rawProps) {
+    const { name, defaultValue, bindable } = rawProp;
+
+    // Skip class, ...rest, and aria-* attributes
+    if (SKIP_PROPS.has(name)) continue;
+    if (name.startsWith('aria-')) continue;
+    // Skip names with colons (e.g. aria-* style quoted keys aren't possible here,
+    // but guard against potential 'class:...' patterns)
+    if (name.includes(':')) continue;
+
+    const typeInfo = typeInfoMap.get(name);
+    const control: ControlKind = typeInfo?.control ?? { kind: 'unknown', rawType: '?' };
+    const optional = typeInfo?.optional ?? false;
+    const description = typeInfo?.description;
+
+    const manifest: PropManifest = {
+      name,
+      control,
+      bindable,
+      optional,
+    };
+
+    if (defaultValue !== undefined) manifest.defaultValue = defaultValue;
+    if (description !== undefined) manifest.description = description;
+
+    props.push(manifest);
+  }
+
+  return {
+    name: componentName,
+    kebabName: fileBaseName,
+    file: filePath,
+    importPath: `cinder/${fileBaseName}`,
+    props,
+  };
+}
+
+/** Globs all top-level *.svelte files from componentsDir and analyzes each one. */
+export async function analyzeAll(componentsDir: string): Promise<ComponentManifest[]> {
+  const glob = new Bun.Glob('*.svelte');
+  const filePaths: string[] = [];
+
+  for await (const file of glob.scan({ cwd: componentsDir })) {
+    filePaths.push(join(componentsDir, file));
+  }
+
+  const manifests = await Promise.all(filePaths.map((filePath) => analyzeComponent(filePath)));
+
+  return manifests.toSorted((a, b) => a.kebabName.localeCompare(b.kebabName));
+}

--- a/scripts/playground/analyze.ts
+++ b/scripts/playground/analyze.ts
@@ -17,34 +17,9 @@ import { basename, join } from 'node:path';
 import { parse } from 'svelte/compiler';
 import { Project, type PropertySignature, SyntaxKind, type TypeNode } from 'ts-morph';
 
-// ---------------------------------------------------------------------------
-// Public types
-// ---------------------------------------------------------------------------
+import type { ComponentManifest, ControlKind, PropManifest } from './types.ts';
 
-export type ControlKind =
-  | { kind: 'text' }
-  | { kind: 'number' }
-  | { kind: 'boolean' }
-  | { kind: 'select'; options: string[] }
-  | { kind: 'snippet' }
-  | { kind: 'unknown'; rawType: string };
-
-export type PropManifest = {
-  name: string;
-  control: ControlKind;
-  defaultValue?: unknown;
-  bindable: boolean;
-  optional: boolean;
-  description?: string;
-};
-
-export type ComponentManifest = {
-  name: string;
-  kebabName: string;
-  file: string;
-  importPath: string;
-  props: PropManifest[];
-};
+export type { ComponentManifest, ControlKind, PropManifest };
 
 // ---------------------------------------------------------------------------
 // Internal types for AST nodes (svelte/compiler returns untyped objects)
@@ -58,9 +33,12 @@ type AstNode = Record<string, unknown>;
 
 /**
  * Infers a control kind from a ts-morph TypeNode.
- * This will be replaced by controls.ts; keep the logic self-contained here.
+ * Internal implementation — the public string-based API lives in controls.ts.
  */
-export function inferControlKind(typeNode: TypeNode | undefined, typeText: string): ControlKind {
+function inferControlKindFromTypeNode(
+  typeNode: TypeNode | undefined,
+  typeText: string,
+): ControlKind {
   if (typeNode === undefined) return { kind: 'unknown', rawType: typeText };
 
   const kind = typeNode.getKind();
@@ -106,7 +84,7 @@ export function inferControlKind(typeNode: TypeNode | undefined, typeText: strin
     const alias = sf.getTypeAlias(name);
     if (alias !== undefined) {
       const resolvedNode = alias.getTypeNode();
-      return inferControlKind(resolvedNode, resolvedNode?.getText() ?? typeText);
+      return inferControlKindFromTypeNode(resolvedNode, resolvedNode?.getText() ?? typeText);
     }
 
     return { kind: 'unknown', rawType: typeText };
@@ -386,7 +364,7 @@ function buildTypeInfoMap(
         const uniqueTexts = [...new Set(typeTexts)];
         let control: ControlKind;
         if (uniqueTexts.length === 1 && firstProp !== undefined) {
-          control = inferControlKind(firstProp.getTypeNode(), uniqueTexts[0] ?? '?');
+          control = inferControlKindFromTypeNode(firstProp.getTypeNode(), uniqueTexts[0] ?? '?');
         } else {
           control = { kind: 'unknown', rawType: 'discriminated-union' };
         }
@@ -404,7 +382,7 @@ function buildTypeInfoMap(
     for (const [name, prop] of propMap) {
       const typeNodeForProp = prop.getTypeNode();
       const typeText = typeNodeForProp?.getText() ?? '?';
-      const control = inferControlKind(typeNodeForProp, typeText);
+      const control = inferControlKindFromTypeNode(typeNodeForProp, typeText);
       const optional = prop.hasQuestionToken();
       const description =
         prop

--- a/scripts/playground/component-page.svelte
+++ b/scripts/playground/component-page.svelte
@@ -35,20 +35,7 @@
   // Control values keyed by prop name. Populated from manifest on load.
   const controlValues: Record<string, unknown> = $state({});
 
-  // Debounced snapshot of controlValues used as the {#key} for example mounts.
-  // Only updates after 500ms of idle time so text input doesn't remount on every keystroke.
-  let debouncedControlsKey: string = $state('{}');
-  let debounceTimer: ReturnType<typeof setTimeout> | null = null;
-
-  function scheduleControlsKeyUpdate(): void {
-    if (debounceTimer !== null) clearTimeout(debounceTimer);
-    debounceTimer = setTimeout(() => {
-      debouncedControlsKey = JSON.stringify(controlValues);
-      debounceTimer = null;
-    }, 500);
-  }
-
-  // Immediate (non-debounced) key for window.__CINDER_CONTROLS__ sync.
+  // Track changes for window.__CINDER_CONTROLS__ sync.
   const controlsKey: string = $derived(JSON.stringify(controlValues));
 
   // Fetch the manifest for this component on mount.
@@ -75,10 +62,12 @@
       });
   });
 
-  // Keep __CINDER_CONTROLS__ in sync immediately on every control change.
+  // Sync __CINDER_CONTROLS__ and notify mounted wrapper bundles on every control change.
+  // Wrappers listen to 'cinder:controls-updated' and re-read props reactively — no remount needed.
   $effect(() => {
     void controlsKey; // subscribe to changes
     (window as unknown as Record<string, unknown>)['__CINDER_CONTROLS__'] = controlValues;
+    window.dispatchEvent(new CustomEvent('cinder:controls-updated'));
   });
 
   // Controllable props — exclude snippets and unknown kinds for rendering.
@@ -112,9 +101,8 @@
   // from the component-page bundle itself). We dynamically import them so the
   // component-page doesn't need to know the module graph at compile time.
   $effect(() => {
-    // Depend on debouncedControlsKey (not controlsKey) so remounting happens
-    // only after the user stops typing, not on every keystroke.
-    void debouncedControlsKey;
+    // Mount examples once; they stay mounted and receive control updates via the
+    // 'cinder:controls-updated' event rather than being remounted on each change.
 
     // Per-run local collection so the cleanup only unmounts this run's mounts.
     // Svelte 5 disposal is unmount(component), not component.destroy().
@@ -173,9 +161,7 @@
       </header>
 
       <div class="example-layout">
-        {#key debouncedControlsKey}
-          <div class="example-preview" id="example-mount-{scenario}"></div>
-        {/key}
+        <div class="example-preview" id="example-mount-{scenario}"></div>
 
         {#if controllableProps.length > 0}
           <div class="controls-panel">
@@ -193,7 +179,6 @@
                     checked={Boolean(controlValues[prop.name])}
                     onchange={(event) => {
                       controlValues[prop.name] = (event.currentTarget as HTMLInputElement).checked;
-                      scheduleControlsKeyUpdate();
                     }}
                   />
                 {:else if prop.control.kind === 'number'}
@@ -206,7 +191,6 @@
                       controlValues[prop.name] = Number(
                         (event.currentTarget as HTMLInputElement).value,
                       );
-                      scheduleControlsKeyUpdate();
                     }}
                   />
                 {:else if prop.control.kind === 'text'}
@@ -217,7 +201,6 @@
                     value={String(controlValues[prop.name] ?? '')}
                     oninput={(event) => {
                       controlValues[prop.name] = (event.currentTarget as HTMLInputElement).value;
-                      scheduleControlsKeyUpdate();
                     }}
                   />
                 {:else if prop.control.kind === 'select'}
@@ -227,7 +210,6 @@
                     value={String(controlValues[prop.name] ?? '')}
                     onchange={(event) => {
                       controlValues[prop.name] = (event.currentTarget as HTMLSelectElement).value;
-                      scheduleControlsKeyUpdate();
                     }}
                   >
                     {#each prop.control.options as option (option)}

--- a/scripts/playground/component-page.svelte
+++ b/scripts/playground/component-page.svelte
@@ -3,31 +3,7 @@
   import { mount, unmount } from 'svelte';
 
   import { defaultForControl } from './controls.ts';
-
-  type ControlKind =
-    | { kind: 'text' }
-    | { kind: 'number' }
-    | { kind: 'boolean' }
-    | { kind: 'select'; options: string[] }
-    | { kind: 'snippet' }
-    | { kind: 'unknown'; rawType: string };
-
-  type PropManifest = {
-    name: string;
-    control: ControlKind;
-    defaultValue?: unknown;
-    bindable: boolean;
-    optional: boolean;
-    description?: string;
-  };
-
-  type ComponentManifest = {
-    name: string;
-    kebabName: string;
-    file: string;
-    importPath: string;
-    props: PropManifest[];
-  };
+  import type { ComponentManifest, PropManifest } from './types.ts';
 
   type CinderExampleDescriptor = { scenario: string; title: string; description?: string };
   type CinderWindow = Window &
@@ -59,8 +35,20 @@
   // Control values keyed by prop name. Populated from manifest on load.
   const controlValues: Record<string, unknown> = $state({});
 
-  // Derived key that stringifies control values — used with {#key} to force
-  // remount of example containers when controls change.
+  // Debounced snapshot of controlValues used as the {#key} for example mounts.
+  // Only updates after 500ms of idle time so text input doesn't remount on every keystroke.
+  let debouncedControlsKey: string = $state('{}');
+  let debounceTimer: ReturnType<typeof setTimeout> | null = null;
+
+  function scheduleControlsKeyUpdate(): void {
+    if (debounceTimer !== null) clearTimeout(debounceTimer);
+    debounceTimer = setTimeout(() => {
+      debouncedControlsKey = JSON.stringify(controlValues);
+      debounceTimer = null;
+    }, 500);
+  }
+
+  // Immediate (non-debounced) key for window.__CINDER_CONTROLS__ sync.
   const controlsKey: string = $derived(JSON.stringify(controlValues));
 
   // Fetch the manifest for this component on mount.
@@ -87,10 +75,9 @@
       });
   });
 
-  // Keep __CINDER_CONTROLS__ in sync whenever controlValues changes.
+  // Keep __CINDER_CONTROLS__ in sync immediately on every control change.
   $effect(() => {
-    // Access controlsKey to subscribe to changes.
-    void controlsKey;
+    void controlsKey; // subscribe to changes
     (window as unknown as Record<string, unknown>)['__CINDER_CONTROLS__'] = controlValues;
   });
 
@@ -125,8 +112,9 @@
   // from the component-page bundle itself). We dynamically import them so the
   // component-page doesn't need to know the module graph at compile time.
   $effect(() => {
-    // Depend on controlsKey so re-mounting happens when controls change.
-    void controlsKey;
+    // Depend on debouncedControlsKey (not controlsKey) so remounting happens
+    // only after the user stops typing, not on every keystroke.
+    void debouncedControlsKey;
 
     // Per-run local collection so the cleanup only unmounts this run's mounts.
     // Svelte 5 disposal is unmount(component), not component.destroy().
@@ -185,7 +173,7 @@
       </header>
 
       <div class="example-layout">
-        {#key controlsKey}
+        {#key debouncedControlsKey}
           <div class="example-preview" id="example-mount-{scenario}"></div>
         {/key}
 
@@ -205,6 +193,7 @@
                     checked={Boolean(controlValues[prop.name])}
                     onchange={(event) => {
                       controlValues[prop.name] = (event.currentTarget as HTMLInputElement).checked;
+                      scheduleControlsKeyUpdate();
                     }}
                   />
                 {:else if prop.control.kind === 'number'}
@@ -217,6 +206,7 @@
                       controlValues[prop.name] = Number(
                         (event.currentTarget as HTMLInputElement).value,
                       );
+                      scheduleControlsKeyUpdate();
                     }}
                   />
                 {:else if prop.control.kind === 'text'}
@@ -227,6 +217,7 @@
                     value={String(controlValues[prop.name] ?? '')}
                     oninput={(event) => {
                       controlValues[prop.name] = (event.currentTarget as HTMLInputElement).value;
+                      scheduleControlsKeyUpdate();
                     }}
                   />
                 {:else if prop.control.kind === 'select'}
@@ -236,6 +227,7 @@
                     value={String(controlValues[prop.name] ?? '')}
                     onchange={(event) => {
                       controlValues[prop.name] = (event.currentTarget as HTMLSelectElement).value;
+                      scheduleControlsKeyUpdate();
                     }}
                   >
                     {#each prop.control.options as option (option)}

--- a/scripts/playground/component-page.svelte
+++ b/scripts/playground/component-page.svelte
@@ -2,6 +2,33 @@
 <script lang="ts">
   import { mount, unmount } from 'svelte';
 
+  import { defaultForControl } from './controls.ts';
+
+  type ControlKind =
+    | { kind: 'text' }
+    | { kind: 'number' }
+    | { kind: 'boolean' }
+    | { kind: 'select'; options: string[] }
+    | { kind: 'snippet' }
+    | { kind: 'unknown'; rawType: string };
+
+  type PropManifest = {
+    name: string;
+    control: ControlKind;
+    defaultValue?: unknown;
+    bindable: boolean;
+    optional: boolean;
+    description?: string;
+  };
+
+  type ComponentManifest = {
+    name: string;
+    kebabName: string;
+    file: string;
+    importPath: string;
+    props: PropManifest[];
+  };
+
   type CinderExampleDescriptor = { scenario: string; title: string; description?: string };
   type CinderWindow = Window &
     typeof globalThis & { __CINDER_EXAMPLES__?: CinderExampleDescriptor[] };
@@ -26,6 +53,55 @@
   const fetchedSource: Record<string, string | null> = $state({});
   const loadingSource: Record<string, boolean> = $state({});
 
+  // Manifest and controls state
+  let manifest: ComponentManifest | null = $state(null);
+
+  // Control values keyed by prop name. Populated from manifest on load.
+  const controlValues: Record<string, unknown> = $state({});
+
+  // Derived key that stringifies control values — used with {#key} to force
+  // remount of example containers when controls change.
+  const controlsKey: string = $derived(JSON.stringify(controlValues));
+
+  // Fetch the manifest for this component on mount.
+  $effect(() => {
+    if (!componentName) return;
+    fetch(`/api/manifest/${componentName}`)
+      .then((response) => (response.ok ? response.json() : null))
+      .then((data: ComponentManifest | null) => {
+        if (data === null) return;
+        manifest = data;
+        // Seed control values from manifest defaults.
+        for (const prop of data.props) {
+          if (prop.control.kind === 'snippet') continue;
+          if (prop.control.kind === 'unknown') continue;
+          const defaultValue =
+            prop.defaultValue !== undefined ? prop.defaultValue : defaultForControl(prop.control);
+          controlValues[prop.name] = defaultValue;
+        }
+        // Expose to the mounted example bundles.
+        (window as unknown as Record<string, unknown>)['__CINDER_CONTROLS__'] = controlValues;
+      })
+      .catch(() => {
+        // Manifest fetch failed — controls panel will be empty. Not fatal.
+      });
+  });
+
+  // Keep __CINDER_CONTROLS__ in sync whenever controlValues changes.
+  $effect(() => {
+    // Access controlsKey to subscribe to changes.
+    void controlsKey;
+    (window as unknown as Record<string, unknown>)['__CINDER_CONTROLS__'] = controlValues;
+  });
+
+  // Controllable props — exclude snippets and unknown kinds for rendering.
+  const controllableProps: PropManifest[] = $derived.by(() => {
+    if (manifest === null) return [];
+    return manifest.props.filter(
+      (prop: PropManifest) => prop.control.kind !== 'snippet' && prop.control.kind !== 'unknown',
+    );
+  });
+
   async function handleDetailsToggle(event: Event, scenario: string): Promise<void> {
     const details = event.currentTarget as HTMLDetailsElement;
 
@@ -49,6 +125,9 @@
   // from the component-page bundle itself). We dynamically import them so the
   // component-page doesn't need to know the module graph at compile time.
   $effect(() => {
+    // Depend on controlsKey so re-mounting happens when controls change.
+    void controlsKey;
+
     // Per-run local collection so the cleanup only unmounts this run's mounts.
     // Svelte 5 disposal is unmount(component), not component.destroy().
     const localApps: ReturnType<typeof mount>[] = [];
@@ -105,7 +184,70 @@
         {/if}
       </header>
 
-      <div class="example-preview" id="example-mount-{scenario}"></div>
+      <div class="example-layout">
+        {#key controlsKey}
+          <div class="example-preview" id="example-mount-{scenario}"></div>
+        {/key}
+
+        {#if controllableProps.length > 0}
+          <div class="controls-panel">
+            {#each controllableProps as prop (prop.name)}
+              <div class="control-row">
+                <label class="control-label" for="control-{scenario}-{prop.name}">
+                  {prop.name}
+                </label>
+
+                {#if prop.control.kind === 'boolean'}
+                  <input
+                    id="control-{scenario}-{prop.name}"
+                    class="control-input"
+                    type="checkbox"
+                    checked={Boolean(controlValues[prop.name])}
+                    onchange={(event) => {
+                      controlValues[prop.name] = (event.currentTarget as HTMLInputElement).checked;
+                    }}
+                  />
+                {:else if prop.control.kind === 'number'}
+                  <input
+                    id="control-{scenario}-{prop.name}"
+                    class="control-input"
+                    type="number"
+                    value={Number(controlValues[prop.name] ?? 0)}
+                    oninput={(event) => {
+                      controlValues[prop.name] = Number(
+                        (event.currentTarget as HTMLInputElement).value,
+                      );
+                    }}
+                  />
+                {:else if prop.control.kind === 'text'}
+                  <input
+                    id="control-{scenario}-{prop.name}"
+                    class="control-input"
+                    type="text"
+                    value={String(controlValues[prop.name] ?? '')}
+                    oninput={(event) => {
+                      controlValues[prop.name] = (event.currentTarget as HTMLInputElement).value;
+                    }}
+                  />
+                {:else if prop.control.kind === 'select'}
+                  <select
+                    id="control-{scenario}-{prop.name}"
+                    class="control-input"
+                    value={String(controlValues[prop.name] ?? '')}
+                    onchange={(event) => {
+                      controlValues[prop.name] = (event.currentTarget as HTMLSelectElement).value;
+                    }}
+                  >
+                    {#each prop.control.options as option (option)}
+                      <option value={option}>{option}</option>
+                    {/each}
+                  </select>
+                {/if}
+              </div>
+            {/each}
+          </div>
+        {/if}
+      </div>
 
       <details class="example-source" ontoggle={(event) => handleDetailsToggle(event, scenario)}>
         <summary class="example-source-toggle">View source</summary>
@@ -164,6 +306,12 @@
     line-height: var(--cinder-leading-normal);
   }
 
+  .example-layout {
+    display: grid;
+    grid-template-columns: 1fr auto;
+    gap: var(--cinder-space-4);
+  }
+
   .example-preview {
     padding: var(--cinder-space-6);
     min-height: 4rem;
@@ -171,6 +319,40 @@
     align-items: flex-start;
     flex-wrap: wrap;
     gap: var(--cinder-space-4);
+  }
+
+  .controls-panel {
+    width: 220px;
+    min-width: 180px;
+    border-left: 1px solid var(--cinder-border-muted);
+    padding: var(--cinder-space-4);
+    display: flex;
+    flex-direction: column;
+    gap: var(--cinder-space-3);
+  }
+
+  .control-row {
+    display: flex;
+    flex-direction: column;
+    gap: var(--cinder-space-1);
+  }
+
+  .control-label {
+    font-size: var(--cinder-text-xs);
+    font-weight: var(--cinder-font-medium);
+    color: var(--cinder-text-subtle);
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+  }
+
+  .control-input {
+    font-size: var(--cinder-text-sm);
+    padding: var(--cinder-space-1) var(--cinder-space-2);
+    border: 1px solid var(--cinder-border);
+    border-radius: var(--cinder-radius-sm);
+    background: var(--cinder-surface);
+    color: var(--cinder-text);
+    width: 100%;
   }
 
   .example-source {

--- a/scripts/playground/component-page.svelte
+++ b/scripts/playground/component-page.svelte
@@ -1,6 +1,6 @@
 <!-- dev-only playground scaffold; window.__CINDER_EXAMPLES__ is injected server-side -->
 <script lang="ts">
-  import { mount } from 'svelte';
+  import { mount, unmount } from 'svelte';
 
   type CinderExampleDescriptor = { scenario: string; title: string; description?: string };
   type CinderWindow = Window &
@@ -16,8 +16,9 @@
 
   const examples: CinderExampleDescriptor[] = readExamples();
 
-  // Extract the component name from the current URL path: /c/<name>
-  const componentName: string = window.location.pathname.replace(/^\/c\//, '').split('/')[0] ?? '';
+  // Extract the component name from the current URL path: /page/<name>
+  const componentName: string =
+    window.location.pathname.replace(/^\/page\//, '').split('/')[0] ?? '';
 
   // Track which <details> elements have had their source fetched so we only
   // hit /example-src once per scenario regardless of how many times the user
@@ -48,8 +49,9 @@
   // from the component-page bundle itself). We dynamically import them so the
   // component-page doesn't need to know the module graph at compile time.
   $effect(() => {
-    // Per-run local collection so the cleanup only destroys this run's mounts.
-    const localApps: Array<{ destroy?: () => void }> = [];
+    // Per-run local collection so the cleanup only unmounts this run's mounts.
+    // Svelte 5 disposal is unmount(component), not component.destroy().
+    const localApps: ReturnType<typeof mount>[] = [];
     let cancelled = false;
 
     for (const { scenario } of examples) {
@@ -68,7 +70,7 @@
           const Component = module.default;
           if (typeof Component !== 'function') return;
 
-          const app = mount(Component, { target: container }) as { destroy?: () => void };
+          const app = mount(Component, { target: container });
           localApps.push(app);
         } catch (error) {
           console.error(`[cinder playground] failed to mount example "${scenario}":`, error);
@@ -80,7 +82,7 @@
       cancelled = true;
       for (const app of localApps) {
         try {
-          app.destroy?.();
+          unmount(app);
         } catch {
           // Suppress — best-effort cleanup only.
         }

--- a/scripts/playground/controls.test.ts
+++ b/scripts/playground/controls.test.ts
@@ -1,0 +1,91 @@
+/**
+ * Unit tests for `scripts/playground/controls.ts`.
+ */
+
+import { describe, expect, it } from 'bun:test';
+
+import { defaultForControl, inferControlKind } from './controls.ts';
+
+describe('inferControlKind', () => {
+  it('maps "boolean" to { kind: "boolean" }', () => {
+    expect(inferControlKind('boolean')).toEqual({ kind: 'boolean' });
+  });
+
+  it('maps "number" to { kind: "number" }', () => {
+    expect(inferControlKind('number')).toEqual({ kind: 'number' });
+  });
+
+  it('maps "string" to { kind: "text" }', () => {
+    expect(inferControlKind('string')).toEqual({ kind: 'text' });
+  });
+
+  it('maps a single-quoted string literal union to { kind: "select", options }', () => {
+    expect(inferControlKind("'primary' | 'secondary' | 'danger'")).toEqual({
+      kind: 'select',
+      options: ['primary', 'secondary', 'danger'],
+    });
+  });
+
+  it('maps a two-option single-quoted union to select', () => {
+    expect(inferControlKind("'xs' | 'lg'")).toEqual({
+      kind: 'select',
+      options: ['xs', 'lg'],
+    });
+  });
+
+  it('maps "Snippet" (bare) to { kind: "snippet" }', () => {
+    expect(inferControlKind('Snippet')).toEqual({ kind: 'snippet' });
+  });
+
+  it('maps "Snippet<[string]>" to { kind: "snippet" }', () => {
+    expect(inferControlKind('Snippet<[string]>')).toEqual({ kind: 'snippet' });
+  });
+
+  it('maps an unrecognised type to { kind: "unknown", rawType }', () => {
+    expect(inferControlKind('HTMLDivElement')).toEqual({
+      kind: 'unknown',
+      rawType: 'HTMLDivElement',
+    });
+  });
+
+  it('maps a complex union involving non-literals to unknown', () => {
+    expect(inferControlKind('string | number')).toEqual({
+      kind: 'unknown',
+      rawType: 'string | number',
+    });
+  });
+
+  it('trims surrounding whitespace before matching', () => {
+    expect(inferControlKind('  boolean  ')).toEqual({ kind: 'boolean' });
+  });
+});
+
+describe('defaultForControl', () => {
+  it('returns false for boolean controls', () => {
+    expect(defaultForControl({ kind: 'boolean' })).toBe(false);
+  });
+
+  it('returns 0 for number controls', () => {
+    expect(defaultForControl({ kind: 'number' })).toBe(0);
+  });
+
+  it('returns an empty string for text controls', () => {
+    expect(defaultForControl({ kind: 'text' })).toBe('');
+  });
+
+  it('returns the first option for select controls', () => {
+    expect(defaultForControl({ kind: 'select', options: ['a', 'b'] })).toBe('a');
+  });
+
+  it('returns an empty string for select controls with no options', () => {
+    expect(defaultForControl({ kind: 'select', options: [] })).toBe('');
+  });
+
+  it('returns undefined for snippet controls', () => {
+    expect(defaultForControl({ kind: 'snippet' })).toBeUndefined();
+  });
+
+  it('returns undefined for unknown controls', () => {
+    expect(defaultForControl({ kind: 'unknown', rawType: 'HTMLDivElement' })).toBeUndefined();
+  });
+});

--- a/scripts/playground/controls.ts
+++ b/scripts/playground/controls.ts
@@ -1,0 +1,111 @@
+/**
+ * Maps a prop's TypeScript type string to a {@link ControlKind} discriminated union.
+ *
+ * This is the single source of truth for type→control mapping. The static analyzer
+ * (`analyze.ts`) calls {@link inferControlKind} after extracting type text from ts-morph;
+ * the wrapper generator calls {@link defaultForControl} when no explicit defaultValue
+ * is available.
+ */
+
+/** Discriminated union describing the kind of UI control for a single prop. */
+export type ControlKind =
+  | { kind: 'text' }
+  | { kind: 'number' }
+  | { kind: 'boolean' }
+  | { kind: 'select'; options: string[] }
+  | { kind: 'snippet' }
+  | { kind: 'unknown'; rawType: string };
+
+/** Regex matching a single-quoted string literal arm: `'foo'`. */
+const SINGLE_QUOTED_PATTERN = /^'[^']+'$/;
+
+/** Regex matching a double-quoted string literal arm: `"foo"`. */
+const DOUBLE_QUOTED_PATTERN = /^"[^"]+"$/;
+
+/** Returns true when a single type arm is a quoted string literal. */
+function isQuotedLiteral(arm: string): boolean {
+  return SINGLE_QUOTED_PATTERN.test(arm) || DOUBLE_QUOTED_PATTERN.test(arm);
+}
+
+/**
+ * Returns true when every arm of a ` | `-separated type string is a quoted
+ * string literal — i.e., the whole type is a union of string literals.
+ */
+function isStringLiteralUnion(typeText: string): boolean {
+  const arms = typeText.split(' | ');
+  if (arms.length < 1) return false;
+  return arms.every((arm) => isQuotedLiteral(arm.trim()));
+}
+
+/**
+ * Strips a single pair of surrounding single or double quotes from a string.
+ * `"'primary'"` → `"primary"`.
+ */
+function stripQuotes(literal: string): string {
+  const trimmed = literal.trim();
+  if (
+    (trimmed.startsWith("'") && trimmed.endsWith("'")) ||
+    (trimmed.startsWith('"') && trimmed.endsWith('"'))
+  ) {
+    return trimmed.slice(1, -1);
+  }
+  return trimmed;
+}
+
+/**
+ * Infer the {@link ControlKind} from a TypeScript type string (already resolved to text).
+ *
+ * Rules (applied in order, first match wins):
+ *  1. `'boolean'`                                      → `{ kind: 'boolean' }`
+ *  2. `'number'`                                       → `{ kind: 'number' }`
+ *  3. `'string'`                                       → `{ kind: 'text' }`
+ *  4. Union of all quoted string literals              → `{ kind: 'select', options: [...] }`
+ *  5. Type starts with `'Snippet'`                    → `{ kind: 'snippet' }`
+ *  6. Anything else                                    → `{ kind: 'unknown', rawType: typeText }`
+ */
+export function inferControlKind(typeText: string): ControlKind {
+  const trimmed = typeText.trim();
+
+  if (trimmed === 'boolean') return { kind: 'boolean' };
+  if (trimmed === 'number') return { kind: 'number' };
+  if (trimmed === 'string') return { kind: 'text' };
+
+  if (isStringLiteralUnion(trimmed)) {
+    const options = trimmed.split(' | ').map((arm) => stripQuotes(arm));
+    return { kind: 'select', options };
+  }
+
+  if (trimmed.startsWith('Snippet')) return { kind: 'snippet' };
+
+  return { kind: 'unknown', rawType: trimmed };
+}
+
+/**
+ * Produce a default value appropriate for a new control instance of the given kind.
+ *
+ * Used by the wrapper generator when no explicit `defaultValue` is available on
+ * the prop manifest.
+ *
+ * - `boolean`  → `false`
+ * - `number`   → `0`
+ * - `text`     → `''`
+ * - `select`   → first option string (or `''` if the options array is empty)
+ * - `snippet`  → `undefined`
+ * - `unknown`  → `undefined`
+ */
+export function defaultForControl(control: ControlKind): unknown {
+  switch (control.kind) {
+    case 'boolean':
+      return false;
+    case 'number':
+      return 0;
+    case 'text':
+      return '';
+    case 'select':
+      return control.options[0] ?? '';
+    case 'snippet':
+      return undefined;
+    case 'unknown':
+      return undefined;
+  }
+}

--- a/scripts/playground/controls.ts
+++ b/scripts/playground/controls.ts
@@ -1,20 +1,14 @@
 /**
  * Maps a prop's TypeScript type string to a {@link ControlKind} discriminated union.
  *
- * This is the single source of truth for type→control mapping. The static analyzer
- * (`analyze.ts`) calls {@link inferControlKind} after extracting type text from ts-morph;
- * the wrapper generator calls {@link defaultForControl} when no explicit defaultValue
- * is available.
+ * The runtime-facing public API for type→control mapping. The static analyzer uses
+ * the ts-morph TypeNode path (inferControlKindFromTypeNode in analyze.ts — internal);
+ * this string-based function is used by the controls panel UI and wrapper generator.
  */
 
-/** Discriminated union describing the kind of UI control for a single prop. */
-export type ControlKind =
-  | { kind: 'text' }
-  | { kind: 'number' }
-  | { kind: 'boolean' }
-  | { kind: 'select'; options: string[] }
-  | { kind: 'snippet' }
-  | { kind: 'unknown'; rawType: string };
+import type { ControlKind } from './types.ts';
+
+export type { ControlKind };
 
 /** Regex matching a single-quoted string literal arm: `'foo'`. */
 const SINGLE_QUOTED_PATTERN = /^'[^']+'$/;

--- a/scripts/playground/render-shell.ts
+++ b/scripts/playground/render-shell.ts
@@ -32,9 +32,10 @@ export function renderShell(activeComponent: string | null, components: string[]
     })
     .join('\n');
 
-  // Component names are path-safe; escaping is only needed in title attribute and visible text.
+  // The iframe targets /page/:name (the component page content route), not /c/:name
+  // (the shell route). Pointing an iframe at its own shell URL would cause recursive loading.
   const mainContent = activeComponent
-    ? `<iframe src="/c/${activeComponent}" title="${escapeHtml(activeComponent)} preview"></iframe>`
+    ? `<iframe src="/page/${activeComponent}" title="${escapeHtml(activeComponent)} preview"></iframe>`
     : `<div class="placeholder"><p>Select a component from the sidebar to preview it.</p></div>`;
 
   return `<!DOCTYPE html>

--- a/scripts/playground/server.test.ts
+++ b/scripts/playground/server.test.ts
@@ -12,6 +12,7 @@
 import { beforeAll, describe, expect, it } from 'bun:test';
 import { join } from 'node:path';
 
+import type { ComponentManifest } from './analyze.ts';
 import { PORT, handleRequest, triggerReload } from './server.ts';
 
 const ROOT = process.cwd();
@@ -189,4 +190,88 @@ describe('isSafeSegment (via route behavior)', () => {
     const response = await handleRequest(req('/c/bad%20name'));
     expect(response.status).toBe(404);
   });
+});
+
+// ---------------------------------------------------------------------------
+// Wave 2: manifest and controls-bundle routes
+// ---------------------------------------------------------------------------
+
+describe('/api/manifest', () => {
+  it('returns 200 application/json', async () => {
+    const response = await handleRequest(req('/api/manifest'));
+    expect(response.status).toBe(200);
+    expect(response.headers.get('Content-Type')).toBe('application/json');
+  }, 30_000);
+
+  it('returns an array with at least 21 entries', async () => {
+    const response = await handleRequest(req('/api/manifest'));
+    const manifests = (await response.json()) as unknown[];
+    expect(Array.isArray(manifests)).toBe(true);
+    expect(manifests.length).toBeGreaterThanOrEqual(21);
+  }, 30_000);
+
+  it('each entry has name, kebabName, file, importPath, and props array', async () => {
+    const response = await handleRequest(req('/api/manifest'));
+    const manifests = (await response.json()) as ComponentManifest[];
+    for (const entry of manifests) {
+      expect(typeof entry.name).toBe('string');
+      expect(typeof entry.kebabName).toBe('string');
+      expect(typeof entry.file).toBe('string');
+      expect(typeof entry.importPath).toBe('string');
+      expect(Array.isArray(entry.props)).toBe(true);
+    }
+  }, 30_000);
+
+  it('includes button in the manifest', async () => {
+    const response = await handleRequest(req('/api/manifest'));
+    const manifests = (await response.json()) as ComponentManifest[];
+    const button = manifests.find((entry) => entry.kebabName === 'button');
+    expect(button).toBeDefined();
+  }, 30_000);
+});
+
+describe('/api/manifest/:name', () => {
+  it('returns 200 for a known component (button)', async () => {
+    const response = await handleRequest(req('/api/manifest/button'));
+    expect(response.status).toBe(200);
+    expect(response.headers.get('Content-Type')).toBe('application/json');
+  }, 30_000);
+
+  it('returns parsed JSON with name=Button and kebabName=button', async () => {
+    const response = await handleRequest(req('/api/manifest/button'));
+    const result = (await response.json()) as ComponentManifest;
+    expect(result.name).toBe('Button');
+    expect(result.kebabName).toBe('button');
+  }, 30_000);
+
+  it('returns 404 for an unknown component', async () => {
+    const response = await handleRequest(req('/api/manifest/does-not-exist'));
+    expect(response.status).toBe(404);
+  }, 30_000);
+
+  it('returns 404 for segments with uppercase (isSafeSegment blocked)', async () => {
+    const response = await handleRequest(req('/api/manifest/Button'));
+    expect(response.status).toBe(404);
+  }, 30_000);
+});
+
+describe('/bundle/:name/controls.js', () => {
+  // The controls route is matched before the generic /bundle/:name/:scenario.js
+  // route so that "controls" is not treated as a scenario name.
+
+  it('returns 200 application/javascript for button', async () => {
+    const response = await handleRequest(req('/bundle/button/controls.js'));
+    expect(response.status).toBe(200);
+    expect(response.headers.get('Content-Type')).toBe('application/javascript');
+  }, 60_000);
+
+  it('returns 404 for an unknown component', async () => {
+    const response = await handleRequest(req('/bundle/does-not-exist/controls.js'));
+    expect(response.status).toBe(404);
+  }, 30_000);
+
+  it('returns 404 for unsafe segment (uppercase)', async () => {
+    const response = await handleRequest(req('/bundle/Button/controls.js'));
+    expect(response.status).toBe(404);
+  }, 30_000);
 });

--- a/scripts/playground/server.ts
+++ b/scripts/playground/server.ts
@@ -15,13 +15,15 @@
  * whenever a file changes. Use `triggerReload()` directly in tests.
  */
 
+import { randomUUID } from 'node:crypto';
 import { unlinkSync, watch, type FSWatcher } from 'node:fs';
 import { join } from 'node:path';
 
 import { sveltePlugin } from '../svelte-plugin.ts';
-import { analyzeAll, type ComponentManifest } from './analyze.ts';
+import { analyzeAll } from './analyze.ts';
 import { discoverComponents, discoverExamples } from './discover.ts';
 import { renderShell } from './render-shell.ts';
+import type { ComponentManifest } from './types.ts';
 import { generateWrapper } from './wrapper-generator.ts';
 
 export const PORT = 4173;
@@ -30,8 +32,10 @@ const ROOT = process.cwd();
 /** Compiled bundle cache: "componentName/scenario" → JS source string. */
 const bundleCache = new Map<string, string>();
 
-/** Cached result of analyzeAll — cleared whenever bundleCache is cleared. */
+/** Resolved manifest array — cached after first analysis. */
 let manifestCache: ComponentManifest[] | null = null;
+/** In-flight analyzeAll() promise — prevents duplicate concurrent analyses. */
+let manifestPromise: Promise<ComponentManifest[]> | null = null;
 
 /** Set of active SSE stream controllers. */
 const sseClients = new Set<ReadableStreamDefaultController<string>>();
@@ -69,6 +73,7 @@ function startWatcher(): FSWatcher[] {
           bundleCache.clear();
           componentPageBundleCache = null;
           manifestCache = null;
+          manifestPromise = null;
           triggerReload();
         }
       }),
@@ -188,8 +193,14 @@ async function buildComponentPageBundle(): Promise<string | null> {
  */
 async function getManifests(): Promise<ComponentManifest[]> {
   if (manifestCache !== null) return manifestCache;
-  manifestCache = await analyzeAll(join(ROOT, 'src', 'components'));
-  return manifestCache;
+  // Reuse the in-flight promise so concurrent callers don't each start analyzeAll().
+  manifestPromise ??= analyzeAll(join(ROOT, 'src', 'components'));
+  try {
+    manifestCache = await manifestPromise;
+    return manifestCache;
+  } finally {
+    manifestPromise = null;
+  }
 }
 
 /**
@@ -206,14 +217,12 @@ async function buildControlsBundle(componentName: string): Promise<string | null
   const manifest = manifests.find((m) => m.kebabName === componentName);
   if (manifest === undefined) return null;
 
-  // generateWrapper expects a manifest whose `name` is kebab-case and
-  // importPath is resolvable from the temp file's location. Use the absolute
-  // source path (manifest.file) so Bun.build can resolve it without needing
-  // the cinder package installed.
+  // Use manifest.file (absolute source path) as importPath so Bun.build can
+  // resolve it from the temp wrapper file without needing the cinder package installed.
   const wrapperSource = generateWrapper({
+    ...manifest,
     name: manifest.kebabName,
     importPath: manifest.file,
-    props: manifest.props,
   });
 
   // Write the temp wrapper inside the repo so Bun's module resolver can find
@@ -222,7 +231,7 @@ async function buildControlsBundle(componentName: string): Promise<string | null
     ROOT,
     'scripts',
     'playground',
-    `.controls-${componentName}-${Date.now()}.svelte`,
+    `.controls-${componentName}-${randomUUID()}.svelte`,
   );
   await Bun.write(tempPath, wrapperSource);
 

--- a/scripts/playground/server.ts
+++ b/scripts/playground/server.ts
@@ -3,7 +3,8 @@
  *
  * Runs at http://localhost:4173. Routes:
  *   GET /              → 302 redirect to /c/<first-component>
- *   GET /c/:name       → full shell HTML for the named component
+ *   GET /c/:name       → shell HTML (sidebar + iframe pointing at /page/:name)
+ *   GET /page/:name    → component page HTML (the iframe target — lists examples)
  *   GET /bundle/:name/:scenario.js → compiled example bundle (cached)
  *   GET /styles.css    → raw contents of src/styles/index.css
  *   GET /example-src/:name/:scenario → raw .example.svelte source
@@ -18,7 +19,7 @@ import { watch, type FSWatcher } from 'node:fs';
 import { join } from 'node:path';
 
 import { sveltePlugin } from '../svelte-plugin.ts';
-import { discoverComponents } from './discover.ts';
+import { discoverComponents, discoverExamples } from './discover.ts';
 import { renderShell } from './render-shell.ts';
 
 export const PORT = 4173;
@@ -56,16 +57,12 @@ function startWatcher(): FSWatcher[] {
     created.push(
       watch(srcPath, { recursive: true }, (_event, filename) => {
         if (filename) {
-          // Invalidate example bundle cache for any changed component.
-          const match = filename.match(/^components\/([^/]+)\.svelte$/);
-          if (match) {
-            const componentName = match[1]!;
-            for (const key of bundleCache.keys()) {
-              if (key.startsWith(`${componentName}/`)) {
-                bundleCache.delete(key);
-              }
-            }
-          }
+          // Clear both caches on any src/ change. Each example imports from
+          // src/index.ts which re-exports every component, so editing any component
+          // invalidates all cached example bundles. Also clear the component-page
+          // bundle since it imports from svelte which may pull in updated code.
+          bundleCache.clear();
+          componentPageBundleCache = null;
           triggerReload();
         }
       }),
@@ -135,6 +132,99 @@ async function buildBundle(componentName: string, scenario: string): Promise<str
   return code;
 }
 
+/** Extract title/description from an example file's module script via regex. */
+async function readExampleMetadata(
+  filePath: string,
+): Promise<{ title: string; description?: string }> {
+  const source = await Bun.file(filePath).text();
+  const titleMatch = source.match(/export\s+const\s+title\s*=\s*['"]([^'"]+)['"]/);
+  const descriptionMatch = source.match(/export\s+const\s+description\s*=\s*['"]([^'"]+)['"]/);
+  const meta: { title: string; description?: string } = {
+    title: titleMatch?.[1] ?? 'Untitled',
+  };
+  if (descriptionMatch?.[1] !== undefined) {
+    meta.description = descriptionMatch[1];
+  }
+  return meta;
+}
+
+/** Cache for the component-page client bundle. */
+let componentPageBundleCache: string | null = null;
+
+/** Compile the component-page.svelte into a client bundle (cached). */
+async function buildComponentPageBundle(): Promise<string | null> {
+  if (componentPageBundleCache !== null) return componentPageBundleCache;
+
+  const entrypoint = join(ROOT, 'scripts', 'playground', 'component-page.svelte');
+  const result = await Bun.build({
+    entrypoints: [entrypoint],
+    plugins: [sveltePlugin({ generate: 'client' })],
+    target: 'browser',
+    format: 'esm',
+  });
+
+  if (!result.success) {
+    console.error('[playground] component-page bundle failed:', result.logs);
+    return null;
+  }
+
+  const output = result.outputs[0];
+  if (!output) return null;
+
+  const code = await output.text();
+  componentPageBundleCache = code;
+  return code;
+}
+
+/** Render the standalone component page HTML (the iframe content — no outer shell). */
+async function renderComponentPage(componentName: string): Promise<string> {
+  const scenarios = await discoverExamples(componentName);
+  const examples = await Promise.all(
+    scenarios.map(async (scenario) => {
+      const filePath = join(
+        ROOT,
+        'scripts',
+        'playground',
+        'examples',
+        componentName,
+        `${scenario}.example.svelte`,
+      );
+      const meta = await readExampleMetadata(filePath);
+      return { scenario, ...meta };
+    }),
+  );
+
+  const examplesJson = JSON.stringify(examples);
+
+  return `<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>${componentName} — cinder playground</title>
+    <link rel="stylesheet" href="/styles.css" />
+    <style>
+      *, *::before, *::after { box-sizing: border-box; }
+      html, body { margin: 0; padding: 0; min-height: 100%; }
+      body {
+        background-color: var(--cinder-bg);
+        color: var(--cinder-text);
+        font-family: var(--cinder-font-sans);
+        font-size: var(--cinder-text-base);
+        line-height: var(--cinder-leading-normal);
+        padding: var(--cinder-space-6);
+      }
+      #app { display: contents; }
+    </style>
+  </head>
+  <body>
+    <script>window.__CINDER_EXAMPLES__ = ${examplesJson};</script>
+    <div id="app"></div>
+    <script type="module" src="/component-page.js"></script>
+  </body>
+</html>`;
+}
+
 /** Verify a path segment is a safe identifier (no path traversal). */
 function isSafeSegment(segment: string): boolean {
   return /^[a-z0-9][a-z0-9-]*$/.test(segment);
@@ -198,6 +288,25 @@ export async function handleRequest(request: Request): Promise<Response> {
     if (code === null)
       return notFound(`Example "${componentName}/${scenario}" not found or failed to build`);
     return new Response(code, { headers: { 'Content-Type': 'application/javascript' } });
+  }
+
+  // GET /component-page.js — the component-page.svelte compiled for the browser
+  if (pathname === '/component-page.js') {
+    const code = await buildComponentPageBundle();
+    if (code === null) return notFound('component-page bundle failed to build');
+    return new Response(code, { headers: { 'Content-Type': 'application/javascript' } });
+  }
+
+  // GET /page/:name — standalone component page (iframe content, no shell)
+  const pageMatch = pathname.match(/^\/page\/([^/]+)$/);
+  if (pageMatch) {
+    const componentName = pageMatch[1]!;
+    if (!isSafeSegment(componentName)) return notFound();
+    const allComponents = await discoverComponents();
+    if (!allComponents.includes(componentName))
+      return notFound(`Component "${componentName}" not found`);
+    const html = await renderComponentPage(componentName);
+    return new Response(html, { headers: { 'Content-Type': 'text/html' } });
   }
 
   // GET /example-src/:name/:scenario

--- a/scripts/playground/server.ts
+++ b/scripts/playground/server.ts
@@ -15,18 +15,24 @@
  * whenever a file changes. Use `triggerReload()` directly in tests.
  */
 
-import { watch, type FSWatcher } from 'node:fs';
+import { unlinkSync, watch, type FSWatcher } from 'node:fs';
+import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
 import { sveltePlugin } from '../svelte-plugin.ts';
+import { analyzeAll, type ComponentManifest } from './analyze.ts';
 import { discoverComponents, discoverExamples } from './discover.ts';
 import { renderShell } from './render-shell.ts';
+import { generateWrapper } from './wrapper-generator.ts';
 
 export const PORT = 4173;
 const ROOT = process.cwd();
 
 /** Compiled bundle cache: "componentName/scenario" → JS source string. */
 const bundleCache = new Map<string, string>();
+
+/** Cached result of analyzeAll — cleared whenever bundleCache is cleared. */
+let manifestCache: ComponentManifest[] | null = null;
 
 /** Set of active SSE stream controllers. */
 const sseClients = new Set<ReadableStreamDefaultController<string>>();
@@ -63,6 +69,7 @@ function startWatcher(): FSWatcher[] {
           // bundle since it imports from svelte which may pull in updated code.
           bundleCache.clear();
           componentPageBundleCache = null;
+          manifestCache = null;
           triggerReload();
         }
       }),
@@ -174,6 +181,70 @@ async function buildComponentPageBundle(): Promise<string | null> {
   const code = await output.text();
   componentPageBundleCache = code;
   return code;
+}
+
+/**
+ * Return the full manifest array, using the module-level cache.
+ * Cleared whenever bundleCache.clear() is called (i.e., on any src/ change).
+ */
+async function getManifests(): Promise<ComponentManifest[]> {
+  if (manifestCache !== null) return manifestCache;
+  manifestCache = await analyzeAll(join(ROOT, 'src', 'components'));
+  return manifestCache;
+}
+
+/**
+ * Compile a controls wrapper bundle for the given component and cache the result
+ * under the key `${componentName}/controls`.
+ */
+async function buildControlsBundle(componentName: string): Promise<string | null> {
+  const cacheKey = `${componentName}/controls`;
+  if (bundleCache.has(cacheKey)) {
+    return bundleCache.get(cacheKey)!;
+  }
+
+  const manifests = await getManifests();
+  const manifest = manifests.find((m) => m.kebabName === componentName);
+  if (manifest === undefined) return null;
+
+  // generateWrapper expects a manifest whose `name` field is the kebab name
+  // (it derives PascalCase from it internally).
+  const wrapperSource = generateWrapper({
+    name: manifest.kebabName,
+    importPath: manifest.importPath,
+    props: manifest.props,
+  });
+
+  const tempPath = join(tmpdir(), `cinder-controls-${componentName}-${Date.now()}.svelte`);
+  await Bun.write(tempPath, wrapperSource);
+
+  try {
+    const result = await Bun.build({
+      entrypoints: [tempPath],
+      plugins: [sveltePlugin({ generate: 'client' })],
+      target: 'browser',
+      format: 'esm',
+    });
+
+    if (!result.success) {
+      console.error(`[playground] controls bundle failed for ${componentName}:`, result.logs);
+      return null;
+    }
+
+    const output = result.outputs[0];
+    if (!output) return null;
+
+    const code = await output.text();
+    bundleCache.set(cacheKey, code);
+    return code;
+  } finally {
+    // Best-effort synchronous cleanup of the temp file.
+    try {
+      unlinkSync(tempPath);
+    } catch {
+      // Ignore — file may already be gone or never written.
+    }
+  }
 }
 
 /** Render the standalone component page HTML (the iframe content — no outer shell). */
@@ -294,6 +365,38 @@ export async function handleRequest(request: Request): Promise<Response> {
   if (pathname === '/component-page.js') {
     const code = await buildComponentPageBundle();
     if (code === null) return notFound('component-page bundle failed to build');
+    return new Response(code, { headers: { 'Content-Type': 'application/javascript' } });
+  }
+
+  // GET /api/manifest — full manifest array
+  if (pathname === '/api/manifest') {
+    const manifests = await getManifests();
+    return new Response(JSON.stringify(manifests), {
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  // GET /api/manifest/:name — single component manifest
+  const apiManifestMatch = pathname.match(/^\/api\/manifest\/([^/]+)$/);
+  if (apiManifestMatch) {
+    const componentName = apiManifestMatch[1]!;
+    if (!isSafeSegment(componentName)) return notFound();
+    const manifests = await getManifests();
+    const manifest = manifests.find((m) => m.kebabName === componentName);
+    if (manifest === undefined) return notFound(`Manifest for "${componentName}" not found`);
+    return new Response(JSON.stringify(manifest), {
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  // GET /bundle/:name/controls.js — compiled wrapper bundle
+  const controlsBundleMatch = pathname.match(/^\/bundle\/([^/]+)\/controls\.js$/);
+  if (controlsBundleMatch) {
+    const componentName = controlsBundleMatch[1]!;
+    if (!isSafeSegment(componentName)) return notFound();
+    const code = await buildControlsBundle(componentName);
+    if (code === null)
+      return notFound(`Controls bundle for "${componentName}" not found or failed to build`);
     return new Response(code, { headers: { 'Content-Type': 'application/javascript' } });
   }
 

--- a/scripts/playground/server.ts
+++ b/scripts/playground/server.ts
@@ -16,7 +16,6 @@
  */
 
 import { unlinkSync, watch, type FSWatcher } from 'node:fs';
-import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
 import { sveltePlugin } from '../svelte-plugin.ts';
@@ -207,15 +206,24 @@ async function buildControlsBundle(componentName: string): Promise<string | null
   const manifest = manifests.find((m) => m.kebabName === componentName);
   if (manifest === undefined) return null;
 
-  // generateWrapper expects a manifest whose `name` field is the kebab name
-  // (it derives PascalCase from it internally).
+  // generateWrapper expects a manifest whose `name` is kebab-case and
+  // importPath is resolvable from the temp file's location. Use the absolute
+  // source path (manifest.file) so Bun.build can resolve it without needing
+  // the cinder package installed.
   const wrapperSource = generateWrapper({
     name: manifest.kebabName,
-    importPath: manifest.importPath,
+    importPath: manifest.file,
     props: manifest.props,
   });
 
-  const tempPath = join(tmpdir(), `cinder-controls-${componentName}-${Date.now()}.svelte`);
+  // Write the temp wrapper inside the repo so Bun's module resolver can find
+  // 'svelte' and other local deps (tmpdir is outside the module graph).
+  const tempPath = join(
+    ROOT,
+    'scripts',
+    'playground',
+    `.controls-${componentName}-${Date.now()}.svelte`,
+  );
   await Bun.write(tempPath, wrapperSource);
 
   try {
@@ -349,7 +357,18 @@ export async function handleRequest(request: Request): Promise<Response> {
     return new Response(css, { headers: { 'Content-Type': 'text/css' } });
   }
 
-  // GET /bundle/:name/:scenario.js
+  // GET /bundle/:name/controls.js — compiled wrapper bundle (must precede the generic route)
+  const controlsBundleMatch = pathname.match(/^\/bundle\/([^/]+)\/controls\.js$/);
+  if (controlsBundleMatch) {
+    const componentName = controlsBundleMatch[1]!;
+    if (!isSafeSegment(componentName)) return notFound();
+    const code = await buildControlsBundle(componentName);
+    if (code === null)
+      return notFound(`Controls bundle for "${componentName}" not found or failed to build`);
+    return new Response(code, { headers: { 'Content-Type': 'application/javascript' } });
+  }
+
+  // GET /bundle/:name/:scenario.js (scenario must not be "controls" — handled above)
   const bundleMatch = pathname.match(/^\/bundle\/([^/]+)\/([^/]+)\.js$/);
   if (bundleMatch) {
     const componentName = bundleMatch[1]!;
@@ -387,17 +406,6 @@ export async function handleRequest(request: Request): Promise<Response> {
     return new Response(JSON.stringify(manifest), {
       headers: { 'Content-Type': 'application/json' },
     });
-  }
-
-  // GET /bundle/:name/controls.js — compiled wrapper bundle
-  const controlsBundleMatch = pathname.match(/^\/bundle\/([^/]+)\/controls\.js$/);
-  if (controlsBundleMatch) {
-    const componentName = controlsBundleMatch[1]!;
-    if (!isSafeSegment(componentName)) return notFound();
-    const code = await buildControlsBundle(componentName);
-    if (code === null)
-      return notFound(`Controls bundle for "${componentName}" not found or failed to build`);
-    return new Response(code, { headers: { 'Content-Type': 'application/javascript' } });
   }
 
   // GET /page/:name — standalone component page (iframe content, no shell)

--- a/scripts/playground/types.ts
+++ b/scripts/playground/types.ts
@@ -1,0 +1,34 @@
+/**
+ * Shared type definitions for the cinder playground analyzer, controls, and server.
+ *
+ * Single source of truth — import from here everywhere. Do not re-declare these
+ * types in analyze.ts, controls.ts, wrapper-generator.ts, or component-page.svelte.
+ */
+
+/** Discriminated union describing the kind of UI control for a single prop. */
+export type ControlKind =
+  | { kind: 'text' }
+  | { kind: 'number' }
+  | { kind: 'boolean' }
+  | { kind: 'select'; options: string[] }
+  | { kind: 'snippet' }
+  | { kind: 'unknown'; rawType: string };
+
+/** Metadata for a single component prop extracted by the static analyzer. */
+export type PropManifest = {
+  name: string;
+  control: ControlKind;
+  defaultValue?: unknown;
+  bindable: boolean;
+  optional: boolean;
+  description?: string;
+};
+
+/** Metadata for a Svelte component extracted by the static analyzer. */
+export type ComponentManifest = {
+  name: string;
+  kebabName: string;
+  file: string;
+  importPath: string;
+  props: PropManifest[];
+};

--- a/scripts/playground/validate-playground.ts
+++ b/scripts/playground/validate-playground.ts
@@ -47,32 +47,56 @@ async function waitForPing(timeoutMs: number): Promise<void> {
 }
 
 /**
- * Validate that every /c/<name> route returns HTTP 200 and renders an HTML page
- * with the expected <nav> shell element.
+ * Validate shell + component page routes for all discovered components:
+ *   - /c/:name — shell with sidebar nav + iframe pointing at /page/:name
+ *   - /page/:name — standalone component page (the iframe content)
  */
 async function validateComponentRoutes(baseUrl: string, components: string[]): Promise<void> {
   process.stdout.write(`[validate:playground] crawling ${components.length} component routes…\n`);
 
   for (const name of components) {
-    const url = `${baseUrl}/c/${name}`;
-    let response: Response;
+    // Shell route
+    const shellUrl = `${baseUrl}/c/${name}`;
+    let shellResponse: Response;
     try {
-      response = await fetch(url, { signal: AbortSignal.timeout(5_000) });
+      shellResponse = await fetch(shellUrl, { signal: AbortSignal.timeout(5_000) });
     } catch (error) {
-      fail(`fetch ${url} threw: ${String(error)}`);
+      fail(`fetch ${shellUrl} threw: ${String(error)}`);
+    }
+    if (shellResponse.status !== 200) {
+      fail(`GET ${shellUrl} returned ${shellResponse.status}, expected 200`);
+    }
+    const shellBody = await shellResponse.text();
+    if (!shellBody.includes('<!DOCTYPE html>')) {
+      fail(`GET ${shellUrl} did not return HTML (missing DOCTYPE)`);
+    }
+    if (!shellBody.includes('<nav>')) {
+      fail(`GET ${shellUrl} HTML is missing the expected <nav> shell element`);
+    }
+    // Shell iframe must target /page/:name, not /c/:name (recursive self-reference)
+    if (shellBody.includes(`src="/c/${name}"`)) {
+      fail(
+        `GET ${shellUrl} shell iframe references /c/${name} (recursive) — should reference /page/${name}`,
+      );
+    }
+    if (!shellBody.includes(`src="/page/${name}"`)) {
+      fail(`GET ${shellUrl} shell iframe does not reference /page/${name}`);
     }
 
-    if (response.status !== 200) {
-      fail(`GET ${url} returned ${response.status}, expected 200`);
+    // Component page route (iframe content)
+    const pageUrl = `${baseUrl}/page/${name}`;
+    let pageResponse: Response;
+    try {
+      pageResponse = await fetch(pageUrl, { signal: AbortSignal.timeout(5_000) });
+    } catch (error) {
+      fail(`fetch ${pageUrl} threw: ${String(error)}`);
     }
-
-    const body = await response.text();
-    if (!body.includes('<!DOCTYPE html>')) {
-      fail(`GET ${url} did not return HTML (missing DOCTYPE)`);
+    if (pageResponse.status !== 200) {
+      fail(`GET ${pageUrl} returned ${pageResponse.status}, expected 200`);
     }
-
-    if (!body.includes('<nav>')) {
-      fail(`GET ${url} HTML is missing the expected <nav> shell element`);
+    const pageBody = await pageResponse.text();
+    if (!pageBody.includes('__CINDER_EXAMPLES__')) {
+      fail(`GET ${pageUrl} does not inject __CINDER_EXAMPLES__`);
     }
   }
 

--- a/scripts/playground/wrapper-generator.test.ts
+++ b/scripts/playground/wrapper-generator.test.ts
@@ -13,6 +13,8 @@ import { generateWrapper } from './wrapper-generator.ts';
 /** Minimal Button manifest for testing — does not reflect all real Button props. */
 const buttonManifest: ComponentManifest = {
   name: 'button',
+  kebabName: 'button',
+  file: '/fake/src/components/button.svelte',
   importPath: '../../../../src/components/button.svelte',
   props: [
     {
@@ -117,6 +119,8 @@ describe('generateWrapper', () => {
   it('handles a component with no controllable props gracefully', () => {
     const emptyManifest: ComponentManifest = {
       name: 'spinner',
+      kebabName: 'spinner',
+      file: '/fake/src/components/spinner.svelte',
       importPath: '../../../../src/components/spinner.svelte',
       props: [
         {
@@ -147,6 +151,8 @@ describe('generateWrapper', () => {
   it('converts a multi-word kebab name to PascalCase for the identifier', () => {
     const manifest: ComponentManifest = {
       name: 'data-list',
+      kebabName: 'data-list',
+      file: '/fake/src/components/data-list.svelte',
       importPath: '../../../../src/components/data-list.svelte',
       props: [],
     };

--- a/scripts/playground/wrapper-generator.test.ts
+++ b/scripts/playground/wrapper-generator.test.ts
@@ -1,0 +1,168 @@
+/**
+ * Unit tests for `scripts/playground/wrapper-generator.ts`.
+ *
+ * These tests use hand-crafted minimal manifests — they do NOT call `analyzeComponent`
+ * from the static analyzer. The goal is to validate the string-generation logic only.
+ */
+
+import { describe, expect, it } from 'bun:test';
+
+import type { ComponentManifest, PropManifest } from './wrapper-generator.ts';
+import { generateWrapper } from './wrapper-generator.ts';
+
+/** Minimal Button manifest for testing — does not reflect all real Button props. */
+const buttonManifest: ComponentManifest = {
+  name: 'button',
+  importPath: '../../../../src/components/button.svelte',
+  props: [
+    {
+      name: 'variant',
+      control: { kind: 'select', options: ['primary', 'secondary', 'danger', 'ghost'] },
+      bindable: false,
+      defaultValue: 'secondary',
+      optional: true,
+    },
+    {
+      name: 'label',
+      control: { kind: 'text' },
+      bindable: false,
+      optional: true,
+    },
+    {
+      name: 'loading',
+      control: { kind: 'boolean' },
+      bindable: false,
+      defaultValue: false,
+      optional: true,
+    },
+    {
+      name: 'children',
+      control: { kind: 'snippet' },
+      bindable: false,
+      optional: true,
+    },
+    {
+      name: 'class',
+      control: { kind: 'text' },
+      bindable: false,
+      optional: true,
+    },
+  ],
+};
+
+describe('generateWrapper', () => {
+  it('contains an import statement for the Button component', () => {
+    const output = generateWrapper(buttonManifest);
+    expect(output).toContain('import');
+    expect(output).toContain('Button');
+  });
+
+  it('references __CINDER_CONTROLS__', () => {
+    const output = generateWrapper(buttonManifest);
+    expect(output).toContain('__CINDER_CONTROLS__');
+  });
+
+  it('imports from the importPath in the manifest', () => {
+    const output = generateWrapper(buttonManifest);
+    expect(output).toContain('../../../../src/components/button.svelte');
+  });
+
+  it('excludes snippet props from the allowed keys', () => {
+    const output = generateWrapper(buttonManifest);
+    // 'children' is a snippet and must not appear in the allowedKeys set
+    const allowedKeysMatch = output.match(/allowedKeys = new Set\((\[.*?\])\)/s);
+    expect(allowedKeysMatch).not.toBeNull();
+    const allowedKeysJson = allowedKeysMatch![1]!;
+    const allowedKeys: string[] = JSON.parse(allowedKeysJson);
+    expect(allowedKeys).not.toContain('children');
+  });
+
+  it('excludes the class prop from the allowed keys', () => {
+    const output = generateWrapper(buttonManifest);
+    const allowedKeysMatch = output.match(/allowedKeys = new Set\((\[.*?\])\)/s);
+    expect(allowedKeysMatch).not.toBeNull();
+    const allowedKeysJson = allowedKeysMatch![1]!;
+    const allowedKeys: string[] = JSON.parse(allowedKeysJson);
+    expect(allowedKeys).not.toContain('class');
+  });
+
+  it('includes non-snippet, non-class props in the allowed keys', () => {
+    const output = generateWrapper(buttonManifest);
+    const allowedKeysMatch = output.match(/allowedKeys = new Set\((\[.*?\])\)/s);
+    expect(allowedKeysMatch).not.toBeNull();
+    const allowedKeysJson = allowedKeysMatch![1]!;
+    const allowedKeys: string[] = JSON.parse(allowedKeysJson);
+    expect(allowedKeys).toContain('variant');
+    expect(allowedKeys).toContain('label');
+    expect(allowedKeys).toContain('loading');
+  });
+
+  it('renders the component with spread controlProps', () => {
+    const output = generateWrapper(buttonManifest);
+    expect(output).toContain('<Button');
+    expect(output).toContain('{...controlProps}');
+  });
+
+  it('uses $state for the controlProps object', () => {
+    const output = generateWrapper(buttonManifest);
+    expect(output).toContain('$state');
+  });
+
+  it('uses Svelte 5 script syntax (lang="ts")', () => {
+    const output = generateWrapper(buttonManifest);
+    expect(output).toContain('<script lang="ts">');
+    expect(output).not.toContain('context="module"');
+  });
+
+  it('handles a component with no controllable props gracefully', () => {
+    const emptyManifest: ComponentManifest = {
+      name: 'spinner',
+      importPath: '../../../../src/components/spinner.svelte',
+      props: [
+        {
+          name: 'children',
+          control: { kind: 'snippet' },
+          bindable: false,
+          optional: true,
+        },
+        {
+          name: 'class',
+          control: { kind: 'text' },
+          bindable: false,
+          optional: true,
+        },
+      ],
+    };
+
+    const output = generateWrapper(emptyManifest);
+    expect(output).toContain('Spinner');
+    expect(output).toContain('__CINDER_CONTROLS__');
+
+    const allowedKeysMatch = output.match(/allowedKeys = new Set\((\[.*?\])\)/s);
+    expect(allowedKeysMatch).not.toBeNull();
+    const allowedKeys: string[] = JSON.parse(allowedKeysMatch![1]!);
+    expect(allowedKeys).toHaveLength(0);
+  });
+
+  it('converts a multi-word kebab name to PascalCase for the identifier', () => {
+    const manifest: ComponentManifest = {
+      name: 'data-list',
+      importPath: '../../../../src/components/data-list.svelte',
+      props: [],
+    };
+    const output = generateWrapper(manifest);
+    expect(output).toContain('import DataList from');
+    expect(output).toContain('<DataList');
+  });
+
+  it('satisfies the PropManifest type with a bindable prop', () => {
+    const prop: PropManifest = {
+      name: 'value',
+      control: { kind: 'text' },
+      bindable: true,
+      optional: false,
+    };
+    // No assertion needed — this is a compile-time type check exercised by the test runner.
+    expect(prop.bindable).toBe(true);
+  });
+});

--- a/scripts/playground/wrapper-generator.ts
+++ b/scripts/playground/wrapper-generator.ts
@@ -1,0 +1,106 @@
+/**
+ * Generates a Svelte 5 wrapper component source string for the controls panel.
+ *
+ * The wrapper reads prop values from `window.__CINDER_CONTROLS__` (a plain object
+ * injected by the server from URL query params) and renders the target component
+ * with those values spread as props.
+ *
+ * The generated wrapper is compiled by `Bun.build` and served at
+ * `/bundle/:name/controls.js`.
+ *
+ * NOTE: `ComponentManifest` and `PropManifest` are defined here until `analyze.ts`
+ * is created in the next phase. The analyzer will re-export them so callers can
+ * `import type { ComponentManifest, PropManifest } from './analyze.ts'`.
+ */
+
+import type { ControlKind } from './controls.ts';
+
+/** Metadata for a single component prop extracted by the static analyzer. */
+export type PropManifest = {
+  /** Prop name as it appears in the component's `$props()` destructure. */
+  name: string;
+  /** Inferred control kind for this prop's type. */
+  control: ControlKind;
+  /** Whether the prop was marked `$bindable()`. */
+  bindable: boolean;
+  /** Default value from the component source, if present. */
+  defaultValue?: unknown;
+  /** Whether the prop is optional (`?`). */
+  optional: boolean;
+};
+
+/** Metadata for a Svelte component extracted by the static analyzer. */
+export type ComponentManifest = {
+  /** Kebab-case component name (matches the `.svelte` filename without extension). */
+  name: string;
+  /**
+   * Path used in the generated `import` statement. Relative to
+   * `scripts/playground/` so that `Bun.build` can resolve it.
+   */
+  importPath: string;
+  /** Ordered list of props, as extracted from the component's script. */
+  props: PropManifest[];
+};
+
+/**
+ * Returns the subset of props that should appear in `controlProps` — i.e., props
+ * that are not snippets and not the `class` prop. These are the props we can
+ * meaningfully set from URL query parameters.
+ */
+function selectableProps(props: PropManifest[]): PropManifest[] {
+  return props.filter((prop) => prop.control.kind !== 'snippet' && prop.name !== 'class');
+}
+
+/**
+ * Derive the PascalCase component identifier from a kebab-case name.
+ * `"data-list"` → `"DataList"`, `"button"` → `"Button"`.
+ */
+function toPascalCase(kebab: string): string {
+  return kebab
+    .split('-')
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join('');
+}
+
+/**
+ * Generate a Svelte 5 wrapper component source string for the given manifest.
+ *
+ * The wrapper:
+ * 1. Imports the target component by `manifest.importPath`.
+ * 2. Reads prop values from `(window as any).__CINDER_CONTROLS__ ?? {}` into a
+ *    reactive `$state` object.
+ * 3. Filters to only the controllable props (no snippets, no `class`).
+ * 4. Renders `<Component {...controlProps} />`.
+ *
+ * Snippet props are intentionally omitted — they cannot be represented as URL
+ * query params or serialised JSON values.
+ */
+export function generateWrapper(manifest: ComponentManifest): string {
+  const componentIdentifier = toPascalCase(manifest.name);
+  const controlled = selectableProps(manifest.props);
+
+  // Build the object type annotation for controlProps so TypeScript is happy
+  // inside the generated Svelte script. We use `Record<string, unknown>` as the
+  // widened type since the generated code is a dev-only harness.
+  const propKeys = controlled.map((prop) => prop.name);
+  const pickedComment =
+    propKeys.length > 0
+      ? `// Controllable props: ${propKeys.join(', ')}`
+      : '// No controllable props for this component';
+
+  return `<script lang="ts">
+  import ${componentIdentifier} from '${manifest.importPath}';
+
+  ${pickedComment}
+  const rawControls: Record<string, unknown> = (window as any).__CINDER_CONTROLS__ ?? {};
+
+  // Filter to only the props this component accepts (excluding snippets and class).
+  const allowedKeys = new Set(${JSON.stringify(propKeys)});
+  let controlProps = $state<Record<string, unknown>>(
+    Object.fromEntries(Object.entries(rawControls).filter(([key]) => allowedKeys.has(key))),
+  );
+</script>
+
+<${componentIdentifier} {...controlProps} />
+`;
+}

--- a/scripts/playground/wrapper-generator.ts
+++ b/scripts/playground/wrapper-generator.ts
@@ -2,45 +2,15 @@
  * Generates a Svelte 5 wrapper component source string for the controls panel.
  *
  * The wrapper reads prop values from `window.__CINDER_CONTROLS__` (a plain object
- * injected by the server from URL query params) and renders the target component
- * with those values spread as props.
+ * injected by the server) and renders the target component with those values spread as props.
  *
  * The generated wrapper is compiled by `Bun.build` and served at
  * `/bundle/:name/controls.js`.
- *
- * NOTE: `ComponentManifest` and `PropManifest` are defined here until `analyze.ts`
- * is created in the next phase. The analyzer will re-export them so callers can
- * `import type { ComponentManifest, PropManifest } from './analyze.ts'`.
  */
 
-import type { ControlKind } from './controls.ts';
+import type { ComponentManifest, PropManifest } from './types.ts';
 
-/** Metadata for a single component prop extracted by the static analyzer. */
-export type PropManifest = {
-  /** Prop name as it appears in the component's `$props()` destructure. */
-  name: string;
-  /** Inferred control kind for this prop's type. */
-  control: ControlKind;
-  /** Whether the prop was marked `$bindable()`. */
-  bindable: boolean;
-  /** Default value from the component source, if present. */
-  defaultValue?: unknown;
-  /** Whether the prop is optional (`?`). */
-  optional: boolean;
-};
-
-/** Metadata for a Svelte component extracted by the static analyzer. */
-export type ComponentManifest = {
-  /** Kebab-case component name (matches the `.svelte` filename without extension). */
-  name: string;
-  /**
-   * Path used in the generated `import` statement. Relative to
-   * `scripts/playground/` so that `Bun.build` can resolve it.
-   */
-  importPath: string;
-  /** Ordered list of props, as extracted from the component's script. */
-  props: PropManifest[];
-};
+export type { ComponentManifest, PropManifest };
 
 /**
  * Returns the subset of props that should appear in `controlProps` — i.e., props
@@ -72,16 +42,13 @@ function toPascalCase(kebab: string): string {
  * 3. Filters to only the controllable props (no snippets, no `class`).
  * 4. Renders `<Component {...controlProps} />`.
  *
- * Snippet props are intentionally omitted — they cannot be represented as URL
- * query params or serialised JSON values.
+ * Snippet props are intentionally omitted — they cannot be represented as
+ * serialized form values.
  */
 export function generateWrapper(manifest: ComponentManifest): string {
   const componentIdentifier = toPascalCase(manifest.name);
   const controlled = selectableProps(manifest.props);
 
-  // Build the object type annotation for controlProps so TypeScript is happy
-  // inside the generated Svelte script. We use `Record<string, unknown>` as the
-  // widened type since the generated code is a dev-only harness.
   const propKeys = controlled.map((prop) => prop.name);
   const pickedComment =
     propKeys.length > 0

--- a/scripts/playground/wrapper-generator.ts
+++ b/scripts/playground/wrapper-generator.ts
@@ -59,13 +59,25 @@ export function generateWrapper(manifest: ComponentManifest): string {
   import ${componentIdentifier} from '${manifest.importPath}';
 
   ${pickedComment}
-  const rawControls: Record<string, unknown> = (window as any).__CINDER_CONTROLS__ ?? {};
-
   // Filter to only the props this component accepts (excluding snippets and class).
   const allowedKeys = new Set(${JSON.stringify(propKeys)});
-  let controlProps = $state<Record<string, unknown>>(
-    Object.fromEntries(Object.entries(rawControls).filter(([key]) => allowedKeys.has(key))),
-  );
+
+  function readControlProps(): Record<string, unknown> {
+    const raw: Record<string, unknown> = (window as any).__CINDER_CONTROLS__ ?? {};
+    return Object.fromEntries(Object.entries(raw).filter(([key]) => allowedKeys.has(key)));
+  }
+
+  let controlProps = $state<Record<string, unknown>>(readControlProps());
+
+  // Re-read props reactively whenever the host page updates __CINDER_CONTROLS__.
+  // The host dispatches 'cinder:controls-updated' on window after each change.
+  $effect(() => {
+    function handleUpdate() {
+      controlProps = readControlProps();
+    }
+    window.addEventListener('cinder:controls-updated', handleUpdate);
+    return () => window.removeEventListener('cinder:controls-updated', handleUpdate);
+  });
 </script>
 
 <${componentIdentifier} {...controlProps} />


### PR DESCRIPTION
## Summary

Adds static analysis of component Props types to auto-generate live controls in the playground. Every public component now has a controls panel that reads its \`Props\` type and produces form inputs — text fields for strings, checkboxes for booleans, dropdowns for string unions.

- **\`scripts/playground/types.ts\`** — single source of truth for \`ControlKind\`, \`PropManifest\`, \`ComponentManifest\`
- **\`scripts/playground/analyze.ts\`** — two-source merge: \`svelte/compiler.parse\` for prop names/defaults/bindability + ts-morph for types/optionality/JSDoc; handles discriminated union Props (Card, NavigationItem)
- **\`scripts/playground/controls.ts\`** — \`inferControlKind(typeText)\` string → control mapping; \`defaultForControl\` zero-value seed
- **\`scripts/playground/wrapper-generator.ts\`** — generates Svelte 5 wrapper that reads \`window.__CINDER_CONTROLS__\` and updates reactively via \`cinder:controls-updated\` custom event
- **\`scripts/playground/server.ts\`** — \`GET /api/manifest\`, \`GET /api/manifest/:name\`, \`GET /bundle/:name/controls.js\` routes; manifest cache with in-flight Promise deduplication
- **\`scripts/playground/component-page.svelte\`** — controls panel UI; dispatches \`cinder:controls-updated\` on change; examples stay mounted (no remount on control change)
- Also includes: 3 Cursor Bugbot fixes from PR #3 (recursive iframe, Svelte 5 unmount API, stale bundle cache)

## Review committee

Pre-reviewed by: typescript-expert, testing-expert, simplicity-engineer, junior-engineer, Codex

- Codex (gpt-5.4, xhigh reasoning) — 3 rounds of adversarial review
- 3 total rounds; all must-fix items addressed

Key fixes driven by committee:
- Type duplication: ControlKind/PropManifest/ComponentManifest consolidated into types.ts
- inferControlKind name collision: analyze.ts version renamed to inferControlKindFromTypeNode (internal)
- Concurrency races: manifestPromise in-flight cache; randomUUID() for temp file names
- Controls update correctness: event-driven prop update (custom event) instead of {#key} remounting — examples stay mounted and receive prop updates via window event listener
- Test coverage: NavigationItem (non-destructuring $props), Card (discriminated union Props)
- .gitignore entry for temp wrapper files

## Test plan

```bash
bun run playground          # http://localhost:4173 — controls panel visible on each component page
bun run validate:playground # crawls all routes including /page/:name
bun test scripts/playground # 104 playground-specific tests (analyze, controls, wrapper-generator, server, discover)
bun test                    # 385 total tests
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new static-analysis, code-generation, and server routes for the playground, touching build/caching and runtime HTML/JS serving; failures could break dev tooling or mis-handle prop parsing, though it’s dev-only and gated by safe path checks.
> 
> **Overview**
> **Playground now auto-generates live prop controls** by statically analyzing each component’s `$props()` destructuring and exported `${Name}Props` type to build a per-component manifest (defaults, bindability, optionality, JSDoc, and inferred control kinds like boolean/text/select). That manifest is exposed via new `/api/manifest` and `/api/manifest/:name` endpoints and drives a new controls panel UI on the component page.
> 
> The dev server is reworked to split shell vs. content routes (`/c/:name` embeds an iframe to `/page/:name`), add a cached `component-page` client bundle, and serve a new `/bundle/:name/controls.js` wrapper bundle generated on the fly (temp `.controls-*.svelte` files) that reacts to `window.__CINDER_CONTROLS__` updates via a custom event.
> 
> Includes new shared playground types, control-kind mapping utilities, wrapper generator + unit tests, expanded server/analyzer tests (including discriminated-union and non-destructured `$props()` cases), updated validation to crawl `/page/:name`, and docs/ignore updates for the new workflow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e9182f139d80f178e0be7a870dbb716c44d87bc8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->