### PR TITLE
docs(phase-5): workspace split elected-deferred, browser export declined

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ The published tarball (`bun pm pack`) contains `dist/`, `src/index.ts`, `src/com
 
 ### Workspace split — elected but deferred
 
-The split criteria are met: the playground has 3,736 lines of TS/Svelte across 13 source files, and `ts-morph` (a playground-only dep) lives in the root `devDependencies` with no reason to appear there from a consumer's perspective.
+Two criteria trigger a workspace split per the project plan: (1) the playground exceeds a complexity threshold where it deserves independent dependency isolation, and (2) a playground-only tool pollutes the root development environment with no benefit to contributors working only on components. Both are met as of commit `472ebff` (2026-04-28): the playground source is substantial enough to justify isolation, and `ts-morph` — used exclusively by the playground analyzer — currently lives in root `devDependencies` alongside every contributor's install, even those who never touch the playground.
 
 The target structure when executed:
 
@@ -200,11 +200,11 @@ cinder/
 │   └── playground/   (private — name: "@cinder/playground", ts-morph isolated here)
 ```
 
-This is the right call. The migration itself is a 393-file move (import paths, tsconfigs, bunfig.toml, husky hooks) and was deliberately deferred rather than executed with broken tests to avoid shipping an unverified structural change. Execute it as a standalone commit when the repo is quiescent and a full `bun test` + `validate:consumer` green run can be confirmed before merging.
+The migration touches a large number of files (import paths, tsconfigs, `bunfig.toml`, husky hooks) and was deliberately deferred rather than executed with broken tests. Do not execute until there are no concurrent package-structure changes on `main`, and both `bun test --conditions browser` and `bun run validate:consumer` pass cleanly on the migration branch before merging.
 
 ### Browser export — declined
 
-No consumer demand for a compiled-client `"browser"` export has materialized. Both consumer fixtures use the `"svelte"` condition. Premature until a specific consumer signals a need for it.
+The two existing consumer fixtures (`fixtures/sveltekit-consumer/` and `fixtures/node-consumer/`) both resolve via the `"svelte"` condition; neither requires a pre-compiled client bundle. No external consumer has raised a specific need for a `"browser"` export condition. Revisit if a real consuming application fails to resolve cinder through its bundler, or if a concrete use case (e.g. usage in a non-Svelte-aware build pipeline) is documented in an issue.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -185,6 +185,27 @@ dist/
 
 The published tarball (`bun pm pack`) contains `dist/`, `src/index.ts`, `src/components/**/*.svelte`, `src/styles/**/*.css`, the four generic utilities, and `README.md`. Fixtures, tests, `.a11y.md` files, `scripts/`, and `_internal/` components are excluded. `validate:consumer` asserts both expected and forbidden paths.
 
+## Phase 5 decision log
+
+### Workspace split — elected but deferred
+
+The split criteria are met: the playground has 3,736 lines of TS/Svelte across 13 source files, and `ts-morph` (a playground-only dep) lives in the root `devDependencies` with no reason to appear there from a consumer's perspective.
+
+The target structure when executed:
+
+```
+cinder/
+├── packages/
+│   ├── components/   (published — name: "cinder", all current exports)
+│   └── playground/   (private — name: "@cinder/playground", ts-morph isolated here)
+```
+
+This is the right call. The migration itself is a 393-file move (import paths, tsconfigs, bunfig.toml, husky hooks) and was deliberately deferred rather than executed with broken tests to avoid shipping an unverified structural change. Execute it as a standalone commit when the repo is quiescent and a full `bun test` + `validate:consumer` green run can be confirmed before merging.
+
+### Browser export — declined
+
+No consumer demand for a compiled-client `"browser"` export has materialized. Both consumer fixtures use the `"svelte"` condition. Premature until a specific consumer signals a need for it.
+
 ## License
 
 MIT


### PR DESCRIPTION
## Summary

Phase 5 evaluation complete. Two decisions documented in the README.

**Workspace split — elected but deferred.** Two named criteria are both met as of commit \`472ebff\`: the playground source is substantial enough to justify isolation, and \`ts-morph\` (playground-only) pollutes the root \`devDependencies\` for every contributor. The migration (import paths, tsconfigs, \`bunfig.toml\`, husky hooks) was deferred after a first attempt produced test failures — do not execute until both \`bun test --conditions browser\` and \`bun run validate:consumer\` pass cleanly on the migration branch.

**Browser export — declined.** Neither consumer fixture requires a pre-compiled \`"browser"\` bundle. Both resolve via \`"svelte"\`. Revisit if a real consuming application fails to resolve through its bundler or a concrete use case is documented in an issue.

## Review committee

Pre-reviewed by: prose-editor, simplicity-engineer, Codex

- Codex (gpt-5.4, xhigh reasoning) — 2 rounds
- All 4 Codex must-fix items addressed (ts-morph rationale, volatile counts, undefined criteria, unverifiable precondition)
- prose-editor and simplicity-engineer approved in round 1

## Test plan

```bash
bun test --conditions browser  # 385 pass
bun run lint                   # 17 warnings, 0 errors
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only change that adds a Phase 5 decision log without modifying build, packaging, or runtime behavior.
> 
> **Overview**
> Adds a new **Phase 5 decision log** section to `README.md`.
> 
> Documents that a workspace split was *chosen but deferred* (including proposed `packages/components` + `packages/playground` layout, rationale around isolating `ts-morph`, and explicit preconditions/tests to run before attempting the migration), and that adding a `"browser"` export condition was *declined* pending a concrete consumer need.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 224bdd39e42313b5e18a3332f22eda6dd6f3c186. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->