### PR TITLE
Scaffold @cinder/editor workspace package porting the Milkdown/ProseMirror integration

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -55,6 +55,25 @@
         "typescript": "^5.9.0",
       },
     },
+    "packages/editor": {
+      "name": "@cinder/editor",
+      "version": "0.0.1",
+      "dependencies": {
+        "@cinder/markdown": "workspace:*",
+        "@milkdown/kit": "^7.17.3",
+      },
+      "devDependencies": {
+        "@milkdown/ctx": "^7.17.3",
+        "@types/bun": "^1.3.11",
+        "oxlint": "^1.56.0",
+        "oxlint-tsgolint": "^0.17.0",
+        "svelte": "~5.55.0",
+        "typescript": "^5.9.0",
+      },
+      "peerDependencies": {
+        "svelte": ">=5.55.0 <5.56.0",
+      },
+    },
     "packages/markdown": {
       "name": "@cinder/markdown",
       "version": "0.0.1",
@@ -111,15 +130,35 @@
 
     "@babel/code-frame": ["@babel/code-frame@7.29.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.28.5", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw=="],
 
+    "@babel/helper-string-parser": ["@babel/helper-string-parser@7.27.1", "", {}, "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA=="],
+
     "@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.28.5", "", {}, "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q=="],
+
+    "@babel/parser": ["@babel/parser@7.29.2", "", { "dependencies": { "@babel/types": "^7.29.0" }, "bin": "./bin/babel-parser.js" }, "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA=="],
 
     "@babel/runtime": ["@babel/runtime@7.29.2", "", {}, "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g=="],
 
+    "@babel/types": ["@babel/types@7.29.0", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A=="],
+
     "@cinder/diff": ["@cinder/diff@workspace:packages/diff"],
+
+    "@cinder/editor": ["@cinder/editor@workspace:packages/editor"],
 
     "@cinder/markdown": ["@cinder/markdown@workspace:packages/markdown"],
 
     "@cinder/playground": ["@cinder/playground@workspace:packages/playground"],
+
+    "@codemirror/language": ["@codemirror/language@6.12.3", "", { "dependencies": { "@codemirror/state": "^6.0.0", "@codemirror/view": "^6.23.0", "@lezer/common": "^1.5.0", "@lezer/highlight": "^1.0.0", "@lezer/lr": "^1.0.0", "style-mod": "^4.0.0" } }, "sha512-QwCZW6Tt1siP37Jet9Tb02Zs81TQt6qQrZR2H+eGMcFsL1zMrk2/b9CLC7/9ieP1fjIUMgviLWMmgiHoJrj+ZA=="],
+
+    "@codemirror/state": ["@codemirror/state@6.6.0", "", { "dependencies": { "@marijn/find-cluster-break": "^1.0.0" } }, "sha512-4nbvra5R5EtiCzr9BTHiTLc+MLXK2QGiAVYMyi8PkQd3SR+6ixar/Q/01Fa21TBIDOZXgeWV4WppsQolSreAPQ=="],
+
+    "@codemirror/view": ["@codemirror/view@6.41.1", "", { "dependencies": { "@codemirror/state": "^6.6.0", "crelt": "^1.0.6", "style-mod": "^4.1.0", "w3c-keyname": "^2.2.4" } }, "sha512-ToDnWKbBnke+ZLrP6vgTTDScGi5H37YYuZGniQaBzxMVdtCxMrslsmtnOvbPZk4RX9bvkQqnWR/WS/35tJA0qg=="],
+
+    "@floating-ui/core": ["@floating-ui/core@1.7.5", "", { "dependencies": { "@floating-ui/utils": "^0.2.11" } }, "sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ=="],
+
+    "@floating-ui/dom": ["@floating-ui/dom@1.7.6", "", { "dependencies": { "@floating-ui/core": "^1.7.5", "@floating-ui/utils": "^0.2.11" } }, "sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ=="],
+
+    "@floating-ui/utils": ["@floating-ui/utils@0.2.11", "", {}, "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg=="],
 
     "@jridgewell/gen-mapping": ["@jridgewell/gen-mapping@0.3.13", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.0", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA=="],
 
@@ -130,6 +169,56 @@
     "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
 
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
+
+    "@lezer/common": ["@lezer/common@1.5.2", "", {}, "sha512-sxQE460fPZyU3sdc8lafxiPwJHBzZRy/udNFynGQky1SePYBdhkBl1kOagA9uT3pxR8K09bOrmTUqA9wb/PjSQ=="],
+
+    "@lezer/highlight": ["@lezer/highlight@1.2.3", "", { "dependencies": { "@lezer/common": "^1.3.0" } }, "sha512-qXdH7UqTvGfdVBINrgKhDsVTJTxactNNxLk7+UMwZhU13lMHaOBlJe9Vqp907ya56Y3+ed2tlqzys7jDkTmW0g=="],
+
+    "@lezer/lr": ["@lezer/lr@1.4.10", "", { "dependencies": { "@lezer/common": "^1.0.0" } }, "sha512-rnCpTIBafOx4mRp43xOxDJbFipJm/c0cia/V5TiGlhmMa+wsSdoGmUN3w5Bqrks/09Q/D4tNAmWaT8p6NRi77A=="],
+
+    "@marijn/find-cluster-break": ["@marijn/find-cluster-break@1.0.2", "", {}, "sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g=="],
+
+    "@milkdown/components": ["@milkdown/components@7.20.0", "", { "dependencies": { "@floating-ui/dom": "^1.5.1", "@milkdown/core": "7.20.0", "@milkdown/ctx": "7.20.0", "@milkdown/exception": "7.20.0", "@milkdown/plugin-tooltip": "7.20.0", "@milkdown/preset-commonmark": "7.20.0", "@milkdown/preset-gfm": "7.20.0", "@milkdown/prose": "7.20.0", "@milkdown/transformer": "7.20.0", "@milkdown/utils": "7.20.0", "@types/lodash-es": "^4.17.12", "clsx": "^2.0.0", "dompurify": "^3.2.5", "lodash-es": "^4.17.21", "nanoid": "^5.0.9", "unist-util-visit": "^5.0.0", "vue": "^3.5.20" }, "peerDependencies": { "@codemirror/language": "^6", "@codemirror/state": "^6", "@codemirror/view": "^6" } }, "sha512-Qn91/oZugGjf17ARE51nbEsH4YklZQaomRSsfxOAtIcwGEJe5osq+zhhKGtgAYFfUb6rU3W86Pe4XDlXN6vFjg=="],
+
+    "@milkdown/core": ["@milkdown/core@7.20.0", "", { "dependencies": { "@milkdown/ctx": "7.20.0", "@milkdown/exception": "7.20.0", "@milkdown/prose": "7.20.0", "@milkdown/transformer": "7.20.0", "remark-parse": "^11.0.0", "remark-stringify": "^11.0.0", "unified": "^11.0.3" } }, "sha512-X9LaUcIR4Y2oiY2J5tslavlPVOwIB3X8/9z1bOeBjlIPtr+urbkY7YEX86EeLV9LyRQ3+t+jXaLMCIjW1wsV6w=="],
+
+    "@milkdown/ctx": ["@milkdown/ctx@7.20.0", "", { "dependencies": { "@milkdown/exception": "7.20.0" } }, "sha512-LUK4xdsUngY2xCCvPTyHPifjAknJ5rE6VBjgsP+LySIUKeFUrhqzo/zz2vaOODKzm3DBMIhpZAoW3MAqxoMGIQ=="],
+
+    "@milkdown/exception": ["@milkdown/exception@7.20.0", "", {}, "sha512-u8EL7rbqgrWrPpkDhrxUYXauw2DO52JUQmuokrUZvqezmflo7pgIDCr+Rk6AQslzB4Xw+n9eYik5rXX3RXC7Qg=="],
+
+    "@milkdown/kit": ["@milkdown/kit@7.20.0", "", { "dependencies": { "@milkdown/components": "7.20.0", "@milkdown/core": "7.20.0", "@milkdown/ctx": "7.20.0", "@milkdown/plugin-block": "7.20.0", "@milkdown/plugin-clipboard": "7.20.0", "@milkdown/plugin-cursor": "7.20.0", "@milkdown/plugin-history": "7.20.0", "@milkdown/plugin-indent": "7.20.0", "@milkdown/plugin-listener": "7.20.0", "@milkdown/plugin-slash": "7.20.0", "@milkdown/plugin-tooltip": "7.20.0", "@milkdown/plugin-trailing": "7.20.0", "@milkdown/plugin-upload": "7.20.0", "@milkdown/preset-commonmark": "7.20.0", "@milkdown/preset-gfm": "7.20.0", "@milkdown/prose": "7.20.0", "@milkdown/transformer": "7.20.0", "@milkdown/utils": "7.20.0" } }, "sha512-X74KMa0tcDAAMOE9aFtBRN+RCdD/HMXor5YN18e7d0pe4a65MGFklUGlcg1U6zEfeMMYeC3msNvMKLMwk3O5RA=="],
+
+    "@milkdown/plugin-block": ["@milkdown/plugin-block@7.20.0", "", { "dependencies": { "@floating-ui/dom": "^1.5.1", "@milkdown/core": "7.20.0", "@milkdown/ctx": "7.20.0", "@milkdown/prose": "7.20.0", "@milkdown/utils": "7.20.0", "@types/lodash-es": "^4.17.12", "lodash-es": "^4.17.21" } }, "sha512-jIXfzJ8Zje+6+9ZwQuVmNeYE8KfzqL9YJ/YdMvWQIEiKhy2x9pZMAkkufgmUlq1aouxOV+gk5fX+ovxzEzfSrA=="],
+
+    "@milkdown/plugin-clipboard": ["@milkdown/plugin-clipboard@7.20.0", "", { "dependencies": { "@milkdown/core": "7.20.0", "@milkdown/ctx": "7.20.0", "@milkdown/prose": "7.20.0", "@milkdown/utils": "7.20.0" } }, "sha512-PyokNvwgWcO6/I/0LxDRnATpnxvs5upFRlp6eO8PhjwBFZftCIU6D15Wg4JAxwW7Y0NyTWfViWjc9TwiBd6KOQ=="],
+
+    "@milkdown/plugin-cursor": ["@milkdown/plugin-cursor@7.20.0", "", { "dependencies": { "@milkdown/ctx": "7.20.0", "@milkdown/prose": "7.20.0", "@milkdown/utils": "7.20.0", "prosemirror-drop-indicator": "^0.1.0" } }, "sha512-goCPwUARBzGV6Hvnr3P57Bj5TnyFjYIfDFLvgWTIlsm/dR2Wr4Syy4HDOtaKO9YL/VtZ8gtiZVgeo0vhc4CzMA=="],
+
+    "@milkdown/plugin-history": ["@milkdown/plugin-history@7.20.0", "", { "dependencies": { "@milkdown/core": "7.20.0", "@milkdown/ctx": "7.20.0", "@milkdown/prose": "7.20.0", "@milkdown/utils": "7.20.0" } }, "sha512-lqOYQBrxKj4px/i0Cav3zRkCArwnkv8o7fGMh3NtnUXMLSE7/xojK5GFPS4EaS/UKK7/+i1oV2+HRA6+6Ezy7w=="],
+
+    "@milkdown/plugin-indent": ["@milkdown/plugin-indent@7.20.0", "", { "dependencies": { "@milkdown/ctx": "7.20.0", "@milkdown/prose": "7.20.0", "@milkdown/utils": "7.20.0" } }, "sha512-KfdIztQMuHv4Rx1JmSQe2vooN4+Zm7MhjQkNolGyiI7BPZbu855hVIC/s96x3Dk04tkbb+M/i9MJhxCazxfd6Q=="],
+
+    "@milkdown/plugin-listener": ["@milkdown/plugin-listener@7.20.0", "", { "dependencies": { "@milkdown/core": "7.20.0", "@milkdown/ctx": "7.20.0", "@milkdown/prose": "7.20.0", "@types/lodash-es": "^4.17.12", "lodash-es": "^4.17.21" } }, "sha512-Sj+B63JfM3NVVS3uGXTPkoz8xx8MQYrR28pI9AaqX5q60tvCvOJw9E1ODvSsBEjeqnN4kablDthIugLlBhOlwQ=="],
+
+    "@milkdown/plugin-slash": ["@milkdown/plugin-slash@7.20.0", "", { "dependencies": { "@floating-ui/dom": "^1.5.1", "@milkdown/ctx": "7.20.0", "@milkdown/prose": "7.20.0", "@milkdown/utils": "7.20.0", "@types/lodash-es": "^4.17.12", "lodash-es": "^4.17.21" } }, "sha512-Qm3/ZxkGYd5XN+J/X91lGGu7SBzuQBOTOLjuJdg4qDBZmdEHlGojB+5BhCSAMB3WGyCpQQGbSqKOelUrXtj68w=="],
+
+    "@milkdown/plugin-tooltip": ["@milkdown/plugin-tooltip@7.20.0", "", { "dependencies": { "@floating-ui/dom": "^1.5.1", "@milkdown/ctx": "7.20.0", "@milkdown/prose": "7.20.0", "@milkdown/utils": "7.20.0", "@types/lodash-es": "^4.17.12", "lodash-es": "^4.17.21" } }, "sha512-BVaXorpmA6ZAS3+xv0rgrtjV1h2K39G5Z9Wun4RxT1YXJTTbzIuFQ3hwBAGLjLMwTsosp7YhRLaMJJAC0jEY5Q=="],
+
+    "@milkdown/plugin-trailing": ["@milkdown/plugin-trailing@7.20.0", "", { "dependencies": { "@milkdown/ctx": "7.20.0", "@milkdown/prose": "7.20.0", "@milkdown/utils": "7.20.0" } }, "sha512-AxDeMSAZfj0Er7RYLvLRf6FKdQtLVmotxML6Se6zgqIa++bFeIXCU22/FC+9r/6d1eUtraTva9ez5K2qPy8qig=="],
+
+    "@milkdown/plugin-upload": ["@milkdown/plugin-upload@7.20.0", "", { "dependencies": { "@milkdown/core": "7.20.0", "@milkdown/ctx": "7.20.0", "@milkdown/exception": "7.20.0", "@milkdown/prose": "7.20.0", "@milkdown/utils": "7.20.0" } }, "sha512-g3UQrD2zfpm86r3BcBDfOdEAyQHhay1nf5wUQgNf4zn6IgRttfEF8tosQsL1B/WBnZB05hH5scLWo4DR2bFhUw=="],
+
+    "@milkdown/preset-commonmark": ["@milkdown/preset-commonmark@7.20.0", "", { "dependencies": { "@milkdown/core": "7.20.0", "@milkdown/ctx": "7.20.0", "@milkdown/exception": "7.20.0", "@milkdown/prose": "7.20.0", "@milkdown/transformer": "7.20.0", "@milkdown/utils": "7.20.0", "remark-inline-links": "^7.0.0", "unist-util-visit": "^5.0.0", "unist-util-visit-parents": "^6.0.1" } }, "sha512-+mPcONXfdjaXdx8JMxDIOT3PWHfy5vewK8iY8j8bUiYD8Iw7YfyWTUh9JHOf4vmOpiKGCJd7+iz7e93u95bQRw=="],
+
+    "@milkdown/preset-gfm": ["@milkdown/preset-gfm@7.20.0", "", { "dependencies": { "@milkdown/core": "7.20.0", "@milkdown/ctx": "7.20.0", "@milkdown/exception": "7.20.0", "@milkdown/preset-commonmark": "7.20.0", "@milkdown/prose": "7.20.0", "@milkdown/transformer": "7.20.0", "@milkdown/utils": "7.20.0", "prosemirror-safari-ime-span": "^1.0.1", "remark-gfm": "^4.0.1" } }, "sha512-ulErTWDqrGYYqto4kQO9dPTMRp+q44pdRTPW4MTeiSO7eJ6JIBUKSqtCm1zf7MX6nZPaPhuscmg5CU2moXOwxQ=="],
+
+    "@milkdown/prose": ["@milkdown/prose@7.20.0", "", { "dependencies": { "@milkdown/exception": "7.20.0", "prosemirror-changeset": "^2.3.1", "prosemirror-commands": "^1.7.1", "prosemirror-dropcursor": "^1.8.2", "prosemirror-gapcursor": "^1.4.0", "prosemirror-history": "^1.5.0", "prosemirror-inputrules": "^1.5.1", "prosemirror-keymap": "^1.2.3", "prosemirror-model": "^1.25.4", "prosemirror-schema-list": "^1.5.1", "prosemirror-state": "^1.4.4", "prosemirror-tables": "^1.8.1", "prosemirror-transform": "^1.10.5", "prosemirror-view": "^1.41.3" } }, "sha512-Qe6jmKcXsjOfpk8duDFdkLCEo5044L8HSyKVn7ewAe7XJJPUM6bPQaP130UAznq75/+TiKxFCzurcrBO3LzNRg=="],
+
+    "@milkdown/transformer": ["@milkdown/transformer@7.20.0", "", { "dependencies": { "@milkdown/exception": "7.20.0", "@milkdown/prose": "7.20.0", "remark": "^15.0.1", "unified": "^11.0.3" } }, "sha512-h7KGFr1o5AYwc+hEfnA3Dldo4jRrYOB/7KExaqelcjUz++KYI/9LXMOsV7CpgjtLI3Xtf2IIRTZND1+p2nsOaw=="],
+
+    "@milkdown/utils": ["@milkdown/utils@7.20.0", "", { "dependencies": { "@milkdown/core": "7.20.0", "@milkdown/ctx": "7.20.0", "@milkdown/exception": "7.20.0", "@milkdown/prose": "7.20.0", "@milkdown/transformer": "7.20.0", "nanoid": "^5.0.9" } }, "sha512-ciEhtLKhIW/Kaz/NRE5DUXVoMCdenn7S4mClrO7sZ/nXtmObnk3okJzSDnamQoDOcLOIbpOu1V3E1Btkvc5x9w=="],
+
+    "@ocavue/utils": ["@ocavue/utils@1.6.0", "", {}, "sha512-8W3q1hxx9qFdrYgPtbElllG/tqYkO/dMhlRUiqasO0SuDFTj78azSQjhIrBTFWxlBPPsSZN6zXYHmb3RwN2Jtg=="],
 
     "@oxlint-tsgolint/darwin-arm64": ["@oxlint-tsgolint/darwin-arm64@0.17.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-z3XwCDuOAKgk7bO4y5tyH8Zogwr51G56R0XGKC3tlAbrAq8DecoxAd3qhRZqWBMG2Gzl5bWU3Ghu7lrxuLPzYw=="],
 
@@ -225,6 +314,10 @@
 
     "@types/katex": ["@types/katex@0.16.8", "", {}, "sha512-trgaNyfU+Xh2Tc+ABIb44a5AYUpicB3uwirOioeOkNPPbmgRNtcWyDeeFRzjPZENO9Vq8gvVqfhaaXWLlevVwg=="],
 
+    "@types/lodash": ["@types/lodash@4.17.24", "", {}, "sha512-gIW7lQLZbue7lRSWEFql49QJJWThrTFFeIMJdp3eH4tKoxm1OvEPg02rm4wCCSHS0cL3/Fizimb35b7k8atwsQ=="],
+
+    "@types/lodash-es": ["@types/lodash-es@4.17.12", "", { "dependencies": { "@types/lodash": "*" } }, "sha512-0NgftHUcV4v34VhXm8QBSftKVXtbkBG3ViCjs6+eJ5a6y6Mi/jiFGPc1sC7QK+9BFhWrURE3EOggmWaSxL9OzQ=="],
+
     "@types/mdast": ["@types/mdast@4.0.4", "", { "dependencies": { "@types/unist": "*" } }, "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA=="],
 
     "@types/ms": ["@types/ms@2.1.0", "", {}, "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA=="],
@@ -236,6 +329,24 @@
     "@types/unist": ["@types/unist@3.0.3", "", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
 
     "@ungap/structured-clone": ["@ungap/structured-clone@1.3.0", "", {}, "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g=="],
+
+    "@vue/compiler-core": ["@vue/compiler-core@3.5.33", "", { "dependencies": { "@babel/parser": "^7.29.2", "@vue/shared": "3.5.33", "entities": "^7.0.1", "estree-walker": "^2.0.2", "source-map-js": "^1.2.1" } }, "sha512-3PZLQwFw4Za3TC8t0FvTy3wI16Kt+pmwcgNZca4Pj9iWL2E72a/gZlpBtAJvEdDMdCxdG/qq0C7PN0bsJuv0Rw=="],
+
+    "@vue/compiler-dom": ["@vue/compiler-dom@3.5.33", "", { "dependencies": { "@vue/compiler-core": "3.5.33", "@vue/shared": "3.5.33" } }, "sha512-PXq0yrfCLzzL07rbXO4awtXY1Z06LG2eu6Adg3RJFa/j3Cii217XxxLXG22N330gw7GmALCY0Z8RgXEviwgpjA=="],
+
+    "@vue/compiler-sfc": ["@vue/compiler-sfc@3.5.33", "", { "dependencies": { "@babel/parser": "^7.29.2", "@vue/compiler-core": "3.5.33", "@vue/compiler-dom": "3.5.33", "@vue/compiler-ssr": "3.5.33", "@vue/shared": "3.5.33", "estree-walker": "^2.0.2", "magic-string": "^0.30.21", "postcss": "^8.5.10", "source-map-js": "^1.2.1" } }, "sha512-UTUvRO9cY+rROrx/pvN9P5Z7FgA6QGfokUCfhQE4EnmUj3rVnK+CHI0LsEO1pg+I7//iRYMUfcNcCPe7tg0CoA=="],
+
+    "@vue/compiler-ssr": ["@vue/compiler-ssr@3.5.33", "", { "dependencies": { "@vue/compiler-dom": "3.5.33", "@vue/shared": "3.5.33" } }, "sha512-IErjYdnj1qIupG5xxiVIYiiRvDhGWV4zuh/RCrwfYpuL+HWQzeU6lCk/nF9r7olWMnjKxCAkOctT2qFWFkzb1A=="],
+
+    "@vue/reactivity": ["@vue/reactivity@3.5.33", "", { "dependencies": { "@vue/shared": "3.5.33" } }, "sha512-p8UfIqyIhb0rYGlSgSBV+lPhF2iUSBcRy7enhTmPqKWadHy9kcOFYF1AejYBP9P+avnd3OBbD49DU4pLWX/94A=="],
+
+    "@vue/runtime-core": ["@vue/runtime-core@3.5.33", "", { "dependencies": { "@vue/reactivity": "3.5.33", "@vue/shared": "3.5.33" } }, "sha512-UpFF45RI9//a7rvq7RdOQblb4tup7hHG9QsmIrxkFQLzQ7R8/iNQ5LE15NhLZ1/WcHMU2b47u6P33CPUelHyIQ=="],
+
+    "@vue/runtime-dom": ["@vue/runtime-dom@3.5.33", "", { "dependencies": { "@vue/reactivity": "3.5.33", "@vue/runtime-core": "3.5.33", "@vue/shared": "3.5.33", "csstype": "^3.2.3" } }, "sha512-IOxMsAOwquhfITgmOgaPYl7/j8gKUxUFoflRc+u4LxyD3+783xne8vNta1PONVCvCV9A0w7hkyEepINDqfO0tw=="],
+
+    "@vue/server-renderer": ["@vue/server-renderer@3.5.33", "", { "dependencies": { "@vue/compiler-ssr": "3.5.33", "@vue/shared": "3.5.33" }, "peerDependencies": { "vue": "3.5.33" } }, "sha512-0xylq/8/h44lVG0pZFknv1XIdEgymq2E9n59uTWJBG+dIgiT0TMCSsxrN7nO16Z0MU0MPjFcguBbZV8Itk52Hw=="],
+
+    "@vue/shared": ["@vue/shared@3.5.33", "", {}, "sha512-5vR2QIlmaLG77Ygd4pMP6+SGQ5yox9VhtnbDWTy9DzMzdmeLxZ1QqxrywEZ9sa1AVubfIJyaCG3ytyWU81ufcQ=="],
 
     "acorn": ["acorn@8.16.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw=="],
 
@@ -291,7 +402,11 @@
 
     "commander": ["commander@14.0.3", "", {}, "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw=="],
 
+    "crelt": ["crelt@1.0.6", "", {}, "sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g=="],
+
     "css.escape": ["css.escape@1.5.1", "", {}, "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg=="],
+
+    "csstype": ["csstype@3.2.3", "", {}, "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="],
 
     "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
@@ -313,6 +428,8 @@
 
     "dom-accessibility-api": ["dom-accessibility-api@0.6.3", "", {}, "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w=="],
 
+    "dompurify": ["dompurify@3.4.1", "", { "optionalDependencies": { "@types/trusted-types": "^2.0.7" } }, "sha512-JahakDAIg1gyOm7dlgWSDjV4n7Ip2PKR55NIT6jrMfIgLFgWo81vdr1/QGqWtFNRqXP9UV71oVePtjqS2ebnPw=="],
+
     "emoji-regex": ["emoji-regex@10.4.0", "", {}, "sha512-EC+0oUMY1Rqm4O6LLrgjtYDvcVYTy7chDnM4Q7030tP4Kwj3u/pR6gP9ygnp2CJMK5Gq+9Q2oqmrFJAz01DXjw=="],
 
     "entities": ["entities@4.5.0", "", {}, "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="],
@@ -324,6 +441,8 @@
     "esm-env": ["esm-env@1.2.2", "", {}, "sha512-Epxrv+Nr/CaL4ZcFGPJIYLWFom+YeV1DqMLHJoEd9SYRxNbaFruBwfEX/kkHUJf55j2+TUbmDcmuilbP1TmXHA=="],
 
     "esrap": ["esrap@2.2.5", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.4.15" }, "peerDependencies": { "@typescript-eslint/types": "^8.2.0" }, "optionalPeers": ["@typescript-eslint/types"] }, "sha512-/yLB1538mag+dn0wsePTe8C0rDIjUOaJpMs2McodSzmM2msWcZsBSdRtg6HOBt0A/r82BN+Md3pgwSc/uWt2Ig=="],
+
+    "estree-walker": ["estree-walker@2.0.2", "", {}, "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="],
 
     "eventemitter3": ["eventemitter3@5.0.1", "", {}, "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA=="],
 
@@ -385,6 +504,8 @@
 
     "locate-character": ["locate-character@3.0.0", "", {}, "sha512-SW13ws7BjaeJ6p7Q6CO2nchbYEc3X3J6WrmTTDto7yMPqVSZTUyY5Tjbid+Ab8gLnATtygYtiDIJGQRRn2ZOiA=="],
 
+    "lodash-es": ["lodash-es@4.18.1", "", {}, "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A=="],
+
     "log-update": ["log-update@6.1.0", "", { "dependencies": { "ansi-escapes": "^7.0.0", "cli-cursor": "^5.0.0", "slice-ansi": "^7.1.0", "strip-ansi": "^7.1.0", "wrap-ansi": "^9.0.0" } }, "sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w=="],
 
     "longest-streak": ["longest-streak@3.1.0", "", {}, "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g=="],
@@ -394,6 +515,8 @@
     "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
 
     "markdown-table": ["markdown-table@3.0.4", "", {}, "sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw=="],
+
+    "mdast-util-definitions": ["mdast-util-definitions@6.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "@types/unist": "^3.0.0", "unist-util-visit": "^5.0.0" } }, "sha512-scTllyX6pnYNZH/AIp/0ePz6s4cZtARxImwoPJ7kS42n+MnVsI4XbnG6d4ibehRIldYMWM2LD7ImQblVhUejVQ=="],
 
     "mdast-util-find-and-replace": ["mdast-util-find-and-replace@3.0.2", "", { "dependencies": { "@types/mdast": "^4.0.0", "escape-string-regexp": "^5.0.0", "unist-util-is": "^6.0.0", "unist-util-visit-parents": "^6.0.0" } }, "sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg=="],
 
@@ -489,11 +612,15 @@
 
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
+    "nanoid": ["nanoid@5.1.9", "", { "bin": { "nanoid": "bin/nanoid.js" } }, "sha512-ZUvP7KeBLe3OZ1ypw6dI/TzYJuvHP77IM4Ry73waSQTLn8/g8rpdjfyVAh7t1/+FjBtG4lCP42MEbDxOsRpBMw=="],
+
     "onetime": ["onetime@7.0.0", "", { "dependencies": { "mimic-function": "^5.0.0" } }, "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ=="],
 
     "oniguruma-parser": ["oniguruma-parser@0.12.2", "", {}, "sha512-6HVa5oIrgMC6aA6WF6XyyqbhRPJrKR02L20+2+zpDtO5QAzGHAUGw5TKQvwi5vctNnRHkJYmjAhRVQF2EKdTQw=="],
 
     "oniguruma-to-es": ["oniguruma-to-es@4.3.6", "", { "dependencies": { "oniguruma-parser": "^0.12.2", "regex": "^6.1.0", "regex-recursion": "^6.0.2" } }, "sha512-csuQ9x3Yr0cEIs/Zgx/OEt9iBw9vqIunAPQkx19R/fiMq2oGVTgcMqO/V3Ybqefr1TBvosI6jU539ksaBULJyA=="],
+
+    "orderedmap": ["orderedmap@2.1.1", "", {}, "sha512-TvAWxi0nDe1j/rtMcWcIj94+Ffe6n7zhow33h40SKxmsmozs6dz/e+EajymfoFcHd7sxNn8yHM8839uixMOV6g=="],
 
     "oxlint": ["oxlint@1.56.0", "", { "optionalDependencies": { "@oxlint/binding-android-arm-eabi": "1.56.0", "@oxlint/binding-android-arm64": "1.56.0", "@oxlint/binding-darwin-arm64": "1.56.0", "@oxlint/binding-darwin-x64": "1.56.0", "@oxlint/binding-freebsd-x64": "1.56.0", "@oxlint/binding-linux-arm-gnueabihf": "1.56.0", "@oxlint/binding-linux-arm-musleabihf": "1.56.0", "@oxlint/binding-linux-arm64-gnu": "1.56.0", "@oxlint/binding-linux-arm64-musl": "1.56.0", "@oxlint/binding-linux-ppc64-gnu": "1.56.0", "@oxlint/binding-linux-riscv64-gnu": "1.56.0", "@oxlint/binding-linux-riscv64-musl": "1.56.0", "@oxlint/binding-linux-s390x-gnu": "1.56.0", "@oxlint/binding-linux-x64-gnu": "1.56.0", "@oxlint/binding-linux-x64-musl": "1.56.0", "@oxlint/binding-openharmony-arm64": "1.56.0", "@oxlint/binding-win32-arm64-msvc": "1.56.0", "@oxlint/binding-win32-ia32-msvc": "1.56.0", "@oxlint/binding-win32-x64-msvc": "1.56.0" }, "peerDependencies": { "oxlint-tsgolint": ">=0.15.0" }, "optionalPeers": ["oxlint-tsgolint"], "bin": { "oxlint": "bin/oxlint" } }, "sha512-Q+5Mj5PVaH/R6/fhMMFzw4dT+KPB+kQW4kaL8FOIq7tfhlnEVp6+3lcWqFruuTNlUo9srZUW3qH7Id4pskeR6g=="],
 
@@ -507,6 +634,8 @@
 
     "picomatch": ["picomatch@4.0.3", "", {}, "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q=="],
 
+    "postcss": ["postcss@8.5.12", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA=="],
+
     "prettier": ["prettier@3.8.1", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg=="],
 
     "prettier-plugin-organize-imports": ["prettier-plugin-organize-imports@4.3.0", "", { "peerDependencies": { "prettier": ">=2.0", "typescript": ">=2.9", "vue-tsc": "^2.1.0 || 3" }, "optionalPeers": ["vue-tsc"] }, "sha512-FxFz0qFhyBsGdIsb697f/EkvHzi5SZOhWAjxcx2dLt+Q532bAlhswcXGYB1yzjZ69kW8UoadFBw7TyNwlq96Iw=="],
@@ -516,6 +645,36 @@
     "pretty-format": ["pretty-format@27.5.1", "", { "dependencies": { "ansi-regex": "^5.0.1", "ansi-styles": "^5.0.0", "react-is": "^17.0.1" } }, "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ=="],
 
     "property-information": ["property-information@7.1.0", "", {}, "sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ=="],
+
+    "prosemirror-changeset": ["prosemirror-changeset@2.4.1", "", { "dependencies": { "prosemirror-transform": "^1.0.0" } }, "sha512-96WBLhOaYhJ+kPhLg3uW359Tz6I/MfcrQfL4EGv4SrcqKEMC1gmoGrXHecPE8eOwTVCJ4IwgfzM8fFad25wNfw=="],
+
+    "prosemirror-commands": ["prosemirror-commands@1.7.1", "", { "dependencies": { "prosemirror-model": "^1.0.0", "prosemirror-state": "^1.0.0", "prosemirror-transform": "^1.10.2" } }, "sha512-rT7qZnQtx5c0/y/KlYaGvtG411S97UaL6gdp6RIZ23DLHanMYLyfGBV5DtSnZdthQql7W+lEVbpSfwtO8T+L2w=="],
+
+    "prosemirror-drop-indicator": ["prosemirror-drop-indicator@0.1.3", "", { "dependencies": { "@ocavue/utils": "^1.0.0", "prosemirror-model": "^1.25.4", "prosemirror-state": "^1.4.4", "prosemirror-view": "^1.41.3" } }, "sha512-fJV6G2tHIVXZLUuc60fS9ly1/GuGOlAZUm67S1El+kGFUYh27Hyv6hcGx3rrJ+Q/JZL5jnyAibIZYYWpPqE45g=="],
+
+    "prosemirror-dropcursor": ["prosemirror-dropcursor@1.8.2", "", { "dependencies": { "prosemirror-state": "^1.0.0", "prosemirror-transform": "^1.1.0", "prosemirror-view": "^1.1.0" } }, "sha512-CCk6Gyx9+Tt2sbYk5NK0nB1ukHi2ryaRgadV/LvyNuO3ena1payM2z6Cg0vO1ebK8cxbzo41ku2DE5Axj1Zuiw=="],
+
+    "prosemirror-gapcursor": ["prosemirror-gapcursor@1.4.1", "", { "dependencies": { "prosemirror-keymap": "^1.0.0", "prosemirror-model": "^1.0.0", "prosemirror-state": "^1.0.0", "prosemirror-view": "^1.0.0" } }, "sha512-pMdYaEnjNMSwl11yjEGtgTmLkR08m/Vl+Jj443167p9eB3HVQKhYCc4gmHVDsLPODfZfjr/MmirsdyZziXbQKw=="],
+
+    "prosemirror-history": ["prosemirror-history@1.5.0", "", { "dependencies": { "prosemirror-state": "^1.2.2", "prosemirror-transform": "^1.0.0", "prosemirror-view": "^1.31.0", "rope-sequence": "^1.3.0" } }, "sha512-zlzTiH01eKA55UAf1MEjtssJeHnGxO0j4K4Dpx+gnmX9n+SHNlDqI2oO1Kv1iPN5B1dm5fsljCfqKF9nFL6HRg=="],
+
+    "prosemirror-inputrules": ["prosemirror-inputrules@1.5.1", "", { "dependencies": { "prosemirror-state": "^1.0.0", "prosemirror-transform": "^1.0.0" } }, "sha512-7wj4uMjKaXWAQ1CDgxNzNtR9AlsuwzHfdFH1ygEHA2KHF2DOEaXl1CJfNPAKCg9qNEh4rum975QLaCiQPyY6Fw=="],
+
+    "prosemirror-keymap": ["prosemirror-keymap@1.2.3", "", { "dependencies": { "prosemirror-state": "^1.0.0", "w3c-keyname": "^2.2.0" } }, "sha512-4HucRlpiLd1IPQQXNqeo81BGtkY8Ai5smHhKW9jjPKRc2wQIxksg7Hl1tTI2IfT2B/LgX6bfYvXxEpJl7aKYKw=="],
+
+    "prosemirror-model": ["prosemirror-model@1.25.4", "", { "dependencies": { "orderedmap": "^2.0.0" } }, "sha512-PIM7E43PBxKce8OQeezAs9j4TP+5yDpZVbuurd1h5phUxEKIu+G2a+EUZzIC5nS1mJktDJWzbqS23n1tsAf5QA=="],
+
+    "prosemirror-safari-ime-span": ["prosemirror-safari-ime-span@1.0.2", "", { "dependencies": { "prosemirror-state": "^1.4.3", "prosemirror-view": "^1.33.8" } }, "sha512-QJqD8s1zE/CuK56kDsUhndh5hiHh/gFnAuPOA9ytva2s85/ZEt2tNWeALTJN48DtWghSKOmiBsvVn2OlnJ5H2w=="],
+
+    "prosemirror-schema-list": ["prosemirror-schema-list@1.5.1", "", { "dependencies": { "prosemirror-model": "^1.0.0", "prosemirror-state": "^1.0.0", "prosemirror-transform": "^1.7.3" } }, "sha512-927lFx/uwyQaGwJxLWCZRkjXG0p48KpMj6ueoYiu4JX05GGuGcgzAy62dfiV8eFZftgyBUvLx76RsMe20fJl+Q=="],
+
+    "prosemirror-state": ["prosemirror-state@1.4.4", "", { "dependencies": { "prosemirror-model": "^1.0.0", "prosemirror-transform": "^1.0.0", "prosemirror-view": "^1.27.0" } }, "sha512-6jiYHH2CIGbCfnxdHbXZ12gySFY/fz/ulZE333G6bPqIZ4F+TXo9ifiR86nAHpWnfoNjOb3o5ESi7J8Uz1jXHw=="],
+
+    "prosemirror-tables": ["prosemirror-tables@1.8.5", "", { "dependencies": { "prosemirror-keymap": "^1.2.3", "prosemirror-model": "^1.25.4", "prosemirror-state": "^1.4.4", "prosemirror-transform": "^1.10.5", "prosemirror-view": "^1.41.4" } }, "sha512-V/0cDCsHKHe/tfWkeCmthNUcEp1IVO3p6vwN8XtwE9PZQLAZJigbw3QoraAdfJPir4NKJtNvOB8oYGKRl+t0Dw=="],
+
+    "prosemirror-transform": ["prosemirror-transform@1.12.0", "", { "dependencies": { "prosemirror-model": "^1.21.0" } }, "sha512-GxboyN4AMIsoHNtz5uf2r2Ru551i5hWeCMD6E2Ib4Eogqoub0NflniaBPVQ4MrGE5yZ8JV9tUHg9qcZTTrcN4w=="],
+
+    "prosemirror-view": ["prosemirror-view@1.41.8", "", { "dependencies": { "prosemirror-model": "^1.20.0", "prosemirror-state": "^1.0.0", "prosemirror-transform": "^1.1.0" } }, "sha512-TnKDdohEatgyZNGCDWIdccOHXhYloJwbwU+phw/a23KBvJIR9lWQWW7WHHK3vBdOLDNuF7TaX98GObUZOWkOnA=="],
 
     "react-is": ["react-is@17.0.2", "", {}, "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="],
 
@@ -535,9 +694,13 @@
 
     "rehype-stringify": ["rehype-stringify@10.0.1", "", { "dependencies": { "@types/hast": "^3.0.0", "hast-util-to-html": "^9.0.0", "unified": "^11.0.0" } }, "sha512-k9ecfXHmIPuFVI61B9DeLPN0qFHfawM6RsuX48hoqlaKSF61RskNjSm1lI8PhBEM0MRdLxVVm4WmTqJQccH9mA=="],
 
+    "remark": ["remark@15.0.1", "", { "dependencies": { "@types/mdast": "^4.0.0", "remark-parse": "^11.0.0", "remark-stringify": "^11.0.0", "unified": "^11.0.0" } }, "sha512-Eht5w30ruCXgFmxVUSlNWQ9iiimq07URKeFS3hNc8cUWy1llX4KDWfyEDZRycMc+znsN9Ux5/tJ/BFdgdOwA3A=="],
+
     "remark-gfm": ["remark-gfm@4.0.1", "", { "dependencies": { "@types/mdast": "^4.0.0", "mdast-util-gfm": "^3.0.0", "micromark-extension-gfm": "^3.0.0", "remark-parse": "^11.0.0", "remark-stringify": "^11.0.0", "unified": "^11.0.0" } }, "sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg=="],
 
     "remark-html": ["remark-html@16.0.1", "", { "dependencies": { "@types/mdast": "^4.0.0", "hast-util-sanitize": "^5.0.0", "hast-util-to-html": "^9.0.0", "mdast-util-to-hast": "^13.0.0", "unified": "^11.0.0" } }, "sha512-B9JqA5i0qZe0Nsf49q3OXyGvyXuZFDzAP2iOFLEumymuYJITVpiH1IgsTEwTpdptDmZlMDMWeDmSawdaJIGCXQ=="],
+
+    "remark-inline-links": ["remark-inline-links@7.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "mdast-util-definitions": "^6.0.0", "unist-util-visit": "^5.0.0" } }, "sha512-4uj1pPM+F495ySZhTIB6ay2oSkTsKgmYaKk/q5HIdhX2fuyLEegpjWa0VdJRJ01sgOqAFo7MBKdDUejIYBMVMQ=="],
 
     "remark-math": ["remark-math@6.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "mdast-util-math": "^3.0.0", "micromark-extension-math": "^3.0.0", "unified": "^11.0.0" } }, "sha512-MMqgnP74Igy+S3WwnhQ7kqGlEerTETXMvJhrUzDikVZ2/uogJCb+WHUg97hK9/jcfc0dkD73s3LN8zU49cTEtA=="],
 
@@ -550,6 +713,8 @@
     "restore-cursor": ["restore-cursor@5.1.0", "", { "dependencies": { "onetime": "^7.0.0", "signal-exit": "^4.1.0" } }, "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA=="],
 
     "rfdc": ["rfdc@1.4.1", "", {}, "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA=="],
+
+    "rope-sequence": ["rope-sequence@1.3.4", "", {}, "sha512-UT5EDe2cu2E/6O4igUr5PSFs23nvvukicWHx6GnOPlHAiiYbzNuCRQCuiUdHJQcqKalLKlrYJnjY0ySGsXNQXQ=="],
 
     "sade": ["sade@1.8.1", "", { "dependencies": { "mri": "^1.1.0" } }, "sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A=="],
 
@@ -567,6 +732,8 @@
 
     "sort-package-json": ["sort-package-json@3.6.1", "", { "dependencies": { "detect-indent": "^7.0.2", "detect-newline": "^4.0.1", "git-hooks-list": "^4.1.1", "is-plain-obj": "^4.1.0", "semver": "^7.7.3", "sort-object-keys": "^2.0.1", "tinyglobby": "^0.2.15" }, "bin": { "sort-package-json": "cli.js" } }, "sha512-Chgejw1+10p2D0U2tB7au1lHtz6TkFnxmvZktyBCRyV0GgmF6nl1IxXxAsPtJVsUyg/fo+BfCMAVVFUVRkAHrQ=="],
 
+    "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
+
     "space-separated-tokens": ["space-separated-tokens@2.0.2", "", {}, "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q=="],
 
     "string-argv": ["string-argv@0.3.2", "", {}, "sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q=="],
@@ -578,6 +745,8 @@
     "strip-ansi": ["strip-ansi@7.1.0", "", { "dependencies": { "ansi-regex": "^6.0.1" } }, "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ=="],
 
     "strip-indent": ["strip-indent@3.0.0", "", { "dependencies": { "min-indent": "^1.0.0" } }, "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ=="],
+
+    "style-mod": ["style-mod@4.1.3", "", {}, "sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ=="],
 
     "svelte": ["svelte@5.55.4", "", { "dependencies": { "@jridgewell/remapping": "^2.3.4", "@jridgewell/sourcemap-codec": "^1.5.0", "@sveltejs/acorn-typescript": "^1.0.5", "@types/estree": "^1.0.5", "@types/trusted-types": "^2.0.7", "acorn": "^8.12.1", "aria-query": "5.3.1", "axobject-query": "^4.1.0", "clsx": "^2.1.1", "devalue": "^5.6.4", "esm-env": "^1.2.1", "esrap": "^2.2.4", "is-reference": "^3.0.3", "locate-character": "^3.0.0", "magic-string": "^0.30.11", "zimmerframe": "^1.1.2" } }, "sha512-q8DFohk6vUswSng95IZb9nzWJnbINZsK7OiM1snAa3qCjJBL0ZQpvMyAaVXjUukdM75J/m8UE8xwqat8Ors/zQ=="],
 
@@ -623,6 +792,10 @@
 
     "vfile-message": ["vfile-message@4.0.3", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-stringify-position": "^4.0.0" } }, "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw=="],
 
+    "vue": ["vue@3.5.33", "", { "dependencies": { "@vue/compiler-dom": "3.5.33", "@vue/compiler-sfc": "3.5.33", "@vue/runtime-dom": "3.5.33", "@vue/server-renderer": "3.5.33", "@vue/shared": "3.5.33" }, "peerDependencies": { "typescript": "*" }, "optionalPeers": ["typescript"] }, "sha512-1AgChhx5w3ALgT4oK3acm2Es/7jyZhWSVUfs3rOBlGQC0rjEDkS7G4lWlJJGGNQD+BV3reCwbQrOe1mPNwKHBQ=="],
+
+    "w3c-keyname": ["w3c-keyname@2.2.8", "", {}, "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ=="],
+
     "web-namespaces": ["web-namespaces@2.0.1", "", {}, "sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ=="],
 
     "webidl-conversions": ["webidl-conversions@7.0.0", "", {}, "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g=="],
@@ -641,9 +814,13 @@
 
     "@testing-library/dom/dom-accessibility-api": ["dom-accessibility-api@0.5.16", "", {}, "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg=="],
 
+    "@vue/compiler-core/entities": ["entities@7.0.1", "", {}, "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA=="],
+
     "katex/commander": ["commander@8.3.0", "", {}, "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww=="],
 
     "parse5/entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
+
+    "postcss/nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
 
     "pretty-format/ansi-styles": ["ansi-styles@5.2.0", "", {}, "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA=="],
 

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "workspaces": [
     "packages/components",
     "packages/diff",
+    "packages/editor",
     "packages/markdown",
     "packages/playground"
   ],
@@ -34,6 +35,10 @@
     ],
     "packages/diff/**/*.{js,ts,tsx,jsx,mjs,cjs}": [
       "oxlint --fix --type-aware --tsconfig ./packages/diff/tsconfig.json",
+      "prettier --write"
+    ],
+    "packages/editor/**/*.{js,ts,tsx,jsx,mjs,cjs}": [
+      "oxlint --fix --type-aware --tsconfig ./packages/editor/tsconfig.json",
       "prettier --write"
     ],
     "packages/markdown/**/*.{js,ts,tsx,jsx,mjs,cjs}": [

--- a/packages/components/fixtures/node-consumer/src/render.ts
+++ b/packages/components/fixtures/node-consumer/src/render.ts
@@ -46,8 +46,16 @@ const components: Array<{ name: string; component: unknown; props: Record<string
   { name: 'Pagination', component: Pagination, props: { currentPage: 1, totalPages: 5 } },
   { name: 'Toggle', component: Toggle, props: { id: 'toggle-1', pressed: false, label: 'Toggle' } },
   // Lazy-mount components render only their trigger surface at open=false
-  { name: 'Modal', component: Modal, props: { open: false, title: 'My modal', children: noopSnippet } },
-  { name: 'Dropdown', component: Dropdown, props: { open: false, trigger: noopSnippet, children: noopSnippet } },
+  {
+    name: 'Modal',
+    component: Modal,
+    props: { open: false, title: 'My modal', children: noopSnippet },
+  },
+  {
+    name: 'Dropdown',
+    component: Dropdown,
+    props: { open: false, trigger: noopSnippet, children: noopSnippet },
+  },
 ];
 
 for (const { name, component, props } of components) {

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -1,0 +1,58 @@
+{
+  "name": "@cinder/editor",
+  "version": "0.0.1",
+  "private": true,
+  "sideEffects": false,
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    },
+    "./sanitize-html": {
+      "types": "./dist/sanitize-html.d.ts",
+      "import": "./dist/sanitize-html.js",
+      "default": "./dist/sanitize-html.js"
+    },
+    "./template-placeholders": {
+      "types": "./dist/template-placeholders.d.ts",
+      "import": "./dist/template-placeholders.js",
+      "default": "./dist/template-placeholders.js"
+    },
+    "./template-render": {
+      "types": "./dist/template-render.d.ts",
+      "import": "./dist/template-render.js",
+      "default": "./dist/template-render.js"
+    },
+    "./test-utilities": {
+      "types": "./dist/test-utilities.d.ts",
+      "import": "./dist/test-utilities.js",
+      "default": "./dist/test-utilities.js"
+    }
+  },
+  "scripts": {
+    "build": "bun run scripts/build.ts",
+    "clean": "rm -rf dist coverage node_modules/.cache",
+    "lint": "oxlint --type-aware --tsconfig ./tsconfig.json",
+    "lint:fix": "oxlint --fix --type-aware --tsconfig ./tsconfig.json",
+    "test": "bun run --filter='@cinder/diff' build && bun run --filter='@cinder/markdown' build && TZ=UTC LANG=en_US.UTF-8 bun test",
+    "typecheck": "tsc --noEmit -p tsconfig.check.json",
+    "validate": "bun run lint && bun run typecheck && bun run test && bun run build"
+  },
+  "dependencies": {
+    "@cinder/markdown": "workspace:*",
+    "@milkdown/kit": "^7.17.3"
+  },
+  "devDependencies": {
+    "@milkdown/ctx": "^7.17.3",
+    "@types/bun": "^1.3.11",
+    "oxlint": "^1.56.0",
+    "oxlint-tsgolint": "^0.17.0",
+    "svelte": "~5.55.0",
+    "typescript": "^5.9.0"
+  },
+  "peerDependencies": {
+    "svelte": ">=5.55.0 <5.56.0"
+  }
+}

--- a/packages/editor/scripts/build.ts
+++ b/packages/editor/scripts/build.ts
@@ -1,0 +1,55 @@
+import { $ } from 'bun';
+
+const packageRoot = process.cwd();
+const distributionDirectory = `${packageRoot}/dist`;
+const entrypoints = [
+  `${packageRoot}/src/index.ts`,
+  `${packageRoot}/src/sanitize-html.ts`,
+  `${packageRoot}/src/template-placeholders.ts`,
+  `${packageRoot}/src/template-render.ts`,
+  `${packageRoot}/src/test-utilities.ts`,
+];
+
+await $`rm -rf dist`;
+
+const buildResult = await Bun.build({
+  entrypoints,
+  outdir: distributionDirectory,
+  root: `${packageRoot}/src`,
+  target: 'browser',
+  format: 'esm',
+  naming: '[dir]/[name].js',
+  sourcemap: 'external',
+  minify: false,
+  external: ['@cinder/*', 'svelte'],
+});
+
+if (!buildResult.success) {
+  const messages = ['Build failed:', ...buildResult.logs.map(String)].join('\n');
+  process.stderr.write(`${messages}\n`);
+  process.exit(1);
+}
+
+await $`tsc -p tsconfig.build.json`;
+
+const expectedOutputs = [
+  `${distributionDirectory}/index.js`,
+  `${distributionDirectory}/index.d.ts`,
+  `${distributionDirectory}/sanitize-html.js`,
+  `${distributionDirectory}/sanitize-html.d.ts`,
+  `${distributionDirectory}/template-placeholders.js`,
+  `${distributionDirectory}/template-placeholders.d.ts`,
+  `${distributionDirectory}/template-render.js`,
+  `${distributionDirectory}/template-render.d.ts`,
+  `${distributionDirectory}/test-utilities.js`,
+  `${distributionDirectory}/test-utilities.d.ts`,
+];
+
+for (const outputPath of expectedOutputs) {
+  if (!(await Bun.file(outputPath).exists())) {
+    process.stderr.write(`Missing build output: ${outputPath}\n`);
+    process.exit(1);
+  }
+}
+
+process.stdout.write('Build complete.\n');

--- a/packages/editor/src/attach.ts
+++ b/packages/editor/src/attach.ts
@@ -1,0 +1,109 @@
+/**
+ * Svelte 5 attachment factory for Milkdown editor.
+ *
+ * This module provides the {@attach} integration pattern for mounting
+ * Milkdown within Svelte components. The attachment handles:
+ * - Editor initialization
+ * - Lifecycle management (mount/destroy)
+ * - Reactive readonly updates
+ * - Two-way binding with effect loop prevention
+ */
+
+import { untrack } from 'svelte';
+import type { Attachment } from 'svelte/attachments';
+import { createEditor, destroyEditor } from './editor.js';
+import type { EditorAttachmentOptions, EditorConfig, EditorState } from './types.js';
+import { DEFAULT_DEBOUNCE_MS } from './types.js';
+
+/**
+ * Create an attachment function for the {@attach} directive.
+ *
+ * @example
+ * ```svelte
+ * <script>
+ *   const editorAttachment = createEditorAttachment({
+ *     getInitialValue: () => markdown,
+ *     getReadonly: () => readonly,
+ *     onReady: (state) => { editorState = state; },
+ *     onChange: (md) => { markdown = md; },
+ *   });
+ * </script>
+ *
+ * <div {@attach editorAttachment}></div>
+ * ```
+ */
+export function createEditorAttachment(options: EditorAttachmentOptions): Attachment<HTMLElement> {
+  const {
+    getInitialValue,
+    getReadonly,
+    getAriaLabel,
+    onReady,
+    onChange,
+    onSelectionChange,
+    onLinkShortcut,
+    onCommentShortcut,
+    debounceMs = DEFAULT_DEBOUNCE_MS,
+    getPlugins,
+    getPlaceholderCompletion,
+    getPlaceholderDecoration,
+  } = options;
+
+  return (element: HTMLElement) => {
+    let editorState: EditorState | null = null;
+    let destroyed = false;
+
+    // Untrack getter calls to prevent the attachment effect from re-running
+    // when reactive props (value, readonly, plugins) change. The component
+    // handles reactive updates separately via its own $effect blocks.
+    const initialContent = untrack(() => getInitialValue());
+    const readonly = untrack(() => getReadonly());
+    const ariaLabel = untrack(() => getAriaLabel());
+    const plugins = untrack(() => getPlugins?.() ?? []);
+    const placeholderCompletion = untrack(() => getPlaceholderCompletion?.());
+    const placeholderDecoration = untrack(() => getPlaceholderDecoration?.());
+
+    const editorConfiguration: EditorConfig = {
+      initialContent,
+      readonly,
+      ariaLabel,
+      changeDebounceMs: debounceMs,
+      plugins,
+    };
+
+    if (onChange) editorConfiguration.onChange = onChange;
+    if (onSelectionChange) editorConfiguration.onSelectionChange = onSelectionChange;
+    if (onLinkShortcut) editorConfiguration.onLinkShortcut = onLinkShortcut;
+    if (onCommentShortcut) editorConfiguration.onCommentShortcut = onCommentShortcut;
+    if (placeholderCompletion) editorConfiguration.placeholderCompletion = placeholderCompletion;
+    if (placeholderDecoration) editorConfiguration.placeholderDecoration = placeholderDecoration;
+
+    // Initialize editor asynchronously
+    void (async () => {
+      try {
+        const state = await createEditor(element, editorConfiguration);
+
+        // Guard against race condition if destroyed before init completes
+        if (destroyed) {
+          destroyEditor(state);
+          return;
+        }
+
+        editorState = state;
+        onReady?.(state);
+      } catch (error) {
+        // If we were unmounted mid-init, swallow the error to avoid unhandled rejections
+        // in test environments that rapidly mount/unmount.
+        if (destroyed) return;
+        console.error('[Editor] Failed to initialize Milkdown editor:', error);
+      }
+    })();
+
+    return () => {
+      destroyed = true;
+      if (editorState) {
+        destroyEditor(editorState);
+        editorState = null;
+      }
+    };
+  };
+}

--- a/packages/editor/src/bridge.test.ts
+++ b/packages/editor/src/bridge.test.ts
@@ -1,0 +1,620 @@
+import { describe, expect, it } from 'bun:test';
+import { enrichSelectionWithSource, mapPosToSource, mapSourceToPos } from './bridge.js';
+import type { EditorSelection } from './types.js';
+
+describe('mapPosToSource', () => {
+  it('maps position 0 to line 1, column 1', () => {
+    const markdown = 'Hello world';
+    const result = mapPosToSource(0, markdown);
+
+    expect(result).toEqual({
+      line: 1,
+      column: 1,
+      offset: 0,
+    });
+  });
+
+  it('tracks column position within a line', () => {
+    const markdown = 'Hello world';
+    const result = mapPosToSource(6, markdown);
+
+    expect(result).toEqual({
+      line: 1,
+      column: 7,
+      offset: 6,
+    });
+  });
+
+  it('tracks line position across newlines', () => {
+    const markdown = 'Line one\nLine two\nLine three';
+    const result = mapPosToSource(9, markdown);
+
+    expect(result).toEqual({
+      line: 2,
+      column: 1,
+      offset: 9,
+    });
+  });
+
+  it('tracks both line and column', () => {
+    const markdown = 'First\nSecond\nThird';
+    // Position 10 is 'o' in "Second" (after "First\nSec")
+    const result = mapPosToSource(10, markdown);
+
+    expect(result).toEqual({
+      line: 2,
+      column: 5,
+      offset: 10,
+    });
+  });
+
+  it('returns null for negative position', () => {
+    const markdown = 'Hello';
+    const result = mapPosToSource(-1, markdown);
+
+    expect(result).toBeNull();
+  });
+
+  it('returns null for position beyond document length', () => {
+    const markdown = 'Hello';
+    const result = mapPosToSource(100, markdown);
+
+    expect(result).toBeNull();
+  });
+
+  it('handles empty string', () => {
+    const result = mapPosToSource(0, '');
+
+    expect(result).toEqual({
+      line: 1,
+      column: 1,
+      offset: 0,
+    });
+  });
+
+  it('handles position at end of document', () => {
+    const markdown = 'Hi';
+    const result = mapPosToSource(2, markdown);
+
+    expect(result).toEqual({
+      line: 1,
+      column: 3,
+      offset: 2,
+    });
+  });
+});
+
+describe('mapSourceToPos', () => {
+  it('uses offset directly when available', () => {
+    const markdown = 'Hello world';
+    const result = mapSourceToPos({ line: 1, column: 7, offset: 6 }, markdown);
+
+    expect(result).toBe(6);
+  });
+
+  it('calculates position from line/column when no offset', () => {
+    const markdown = 'First\nSecond\nThird';
+    // Line 2, column 3 = "Second"[2] = 'c'
+    const result = mapSourceToPos({ line: 2, column: 3, offset: -1 }, markdown);
+
+    expect(result).toBe(8); // "First\nSe" = 8 characters
+  });
+
+  it('finds first line position', () => {
+    const markdown = 'Hello';
+    const result = mapSourceToPos({ line: 1, column: 1, offset: -1 }, markdown);
+
+    expect(result).toBe(0);
+  });
+
+  it('handles line beyond document', () => {
+    const markdown = 'Only one line';
+    const result = mapSourceToPos({ line: 5, column: 1, offset: -1 }, markdown);
+
+    expect(result).toBeNull();
+  });
+
+  it('clamps offset to document length', () => {
+    const markdown = 'Short';
+    const result = mapSourceToPos({ line: 1, column: 1, offset: 100 }, markdown);
+
+    expect(result).toBe(5); // Clamped to length
+  });
+
+  it('handles multi-line document correctly', () => {
+    const markdown = '# Heading\n\nParagraph text.';
+    // Line 3 = "Paragraph text.", column 1 = 'P'
+    const result = mapSourceToPos({ line: 3, column: 1, offset: -1 }, markdown);
+
+    expect(result).toBe(11); // "# Heading\n\n" = 11 characters
+  });
+});
+
+describe('enrichSelectionWithSource', () => {
+  it('adds sourcePosition to selection', () => {
+    const selection: EditorSelection = {
+      from: 5,
+      to: 10,
+      isCollapsed: false,
+    };
+    const markdown = 'Hello world, how are you?';
+
+    const enriched = enrichSelectionWithSource(selection, markdown);
+
+    expect(enriched.from).toBe(5);
+    expect(enriched.to).toBe(10);
+    expect(enriched.isCollapsed).toBe(false);
+    expect(enriched.sourcePosition).toEqual({
+      line: 1,
+      column: 6,
+      offset: 5,
+    });
+  });
+
+  it('handles collapsed selection (cursor)', () => {
+    const selection: EditorSelection = {
+      from: 0,
+      to: 0,
+      isCollapsed: true,
+    };
+    const markdown = 'Hello';
+
+    const enriched = enrichSelectionWithSource(selection, markdown);
+
+    expect(enriched.isCollapsed).toBe(true);
+    expect(enriched.sourcePosition).toEqual({
+      line: 1,
+      column: 1,
+      offset: 0,
+    });
+  });
+
+  it('maps position at start of new line', () => {
+    const selection: EditorSelection = {
+      from: 6,
+      to: 6,
+      isCollapsed: true,
+    };
+    const markdown = 'Hello\nWorld';
+
+    const enriched = enrichSelectionWithSource(selection, markdown);
+
+    expect(enriched.sourcePosition).toEqual({
+      line: 2,
+      column: 1,
+      offset: 6,
+    });
+  });
+});
+
+describe('round-trip position mapping', () => {
+  it('round-trips simple position', () => {
+    const markdown = 'Hello world';
+    const position = 6;
+
+    const source = mapPosToSource(position, markdown);
+    expect(source).not.toBeNull();
+
+    const roundTripped = mapSourceToPos(source!, markdown);
+    expect(roundTripped).toBe(position);
+  });
+
+  it('round-trips position in multi-line document', () => {
+    const markdown = '# Heading\n\nParagraph with some text.\n\nAnother paragraph.';
+    const position = 15;
+
+    const source = mapPosToSource(position, markdown);
+    expect(source).not.toBeNull();
+
+    const roundTripped = mapSourceToPos(source!, markdown);
+    expect(roundTripped).toBe(position);
+  });
+
+  it('round-trips position at document boundaries', () => {
+    const markdown = 'Content';
+
+    // Start
+    const startSource = mapPosToSource(0, markdown);
+    expect(mapSourceToPos(startSource!, markdown)).toBe(0);
+
+    // End
+    const endSource = mapPosToSource(7, markdown);
+    expect(mapSourceToPos(endSource!, markdown)).toBe(7);
+  });
+});
+
+// ============================================================================
+// Text Offset <-> ProseMirror Position Mapping Tests
+// ============================================================================
+// NOTE: Full testing of buildTextToProseMirrorPositionMap, textOffsetToProseMirrorPosition,
+// and proseMirrorPositionToTextOffset requires actual ProseMirror documents.
+// These tests verify the function contracts and behavior expectations.
+// End-to-end testing happens in browser tests with the actual editor.
+
+describe('textOffsetToProseMirrorPosition contract', () => {
+  // Import the functions dynamically to test their existence and types
+  it('exports textOffsetToProseMirrorPosition function', async () => {
+    const bridge = await import('./bridge.js');
+    expect(typeof bridge.textOffsetToProseMirrorPosition).toBe('function');
+  });
+
+  it('exports proseMirrorPositionToTextOffset function', async () => {
+    const bridge = await import('./bridge.js');
+    expect(typeof bridge.proseMirrorPositionToTextOffset).toBe('function');
+  });
+
+  it('exports buildTextToProseMirrorPositionMap function', async () => {
+    const bridge = await import('./bridge.js');
+    expect(typeof bridge.buildTextToProseMirrorPositionMap).toBe('function');
+  });
+});
+
+describe('position offset map structure', () => {
+  it('PositionOffsetMap has correct shape', () => {
+    // The map should have bidirectional mapping
+    interface PositionOffsetMap {
+      textToPm: Map<number, number>;
+      pmToText: Map<number, number>;
+    }
+
+    const map: PositionOffsetMap = {
+      textToPm: new Map(),
+      pmToText: new Map(),
+    };
+
+    // Simulate adding a mapping
+    map.textToPm.set(0, 1); // text offset 0 -> PM position 1
+    map.pmToText.set(1, 0); // PM position 1 -> text offset 0
+
+    expect(map.textToPm.get(0)).toBe(1);
+    expect(map.pmToText.get(1)).toBe(0);
+  });
+
+  it('bidirectional mapping is consistent', () => {
+    // For every textToPm[x] = y, pmToText[y] should = x
+    const textToPm = new Map<number, number>();
+    const pmToText = new Map<number, number>();
+
+    // Add consistent mappings
+    const pairs = [
+      [0, 1],
+      [1, 2],
+      [2, 3],
+      [3, 5], // PM positions can skip (structural positions)
+    ];
+
+    for (const [textOff, pmPos] of pairs) {
+      textToPm.set(textOff, pmPos);
+      pmToText.set(pmPos, textOff);
+    }
+
+    // Verify consistency
+    for (const [textOff, pmPos] of pairs) {
+      expect(textToPm.get(textOff)).toBe(pmPos);
+      expect(pmToText.get(pmPos)).toBe(textOff);
+    }
+  });
+});
+
+describe('offset mapping edge cases', () => {
+  it('handles offset 0 (start of document)', () => {
+    // In ProseMirror, position 0 is before the doc
+    // Position 1 is at the start of the first block's content
+    // This is documented behavior
+
+    // For a doc with just text, we expect:
+    // text offset 0 -> PM position 1 (inside first paragraph)
+    // This is because PM has structural positions
+
+    const expectedFirstTextPosition = 1; // After doc opening tag
+    expect(expectedFirstTextPosition).toBeGreaterThan(0);
+  });
+
+  it('block separators add to text offset', () => {
+    // When doc.textBetween is called, blocks are separated by '\n'
+    // This means text offset grows by 1 at each block boundary
+
+    // For "Para 1\nPara 2", the text between two paragraphs includes '\n'
+    const para1 = 'Para 1';
+    const separator = '\n';
+    const para2 = 'Para 2';
+
+    const textContent = para1 + separator + para2;
+    expect(textContent).toBe('Para 1\nPara 2');
+
+    // The offset of 'P' in "Para 2" is 7 (including separator)
+    expect(textContent.indexOf('Para 2')).toBe(7);
+  });
+
+  it('nested blocks add separators correctly', () => {
+    // For lists and blockquotes, separators are added between block content
+    // Example: "- Item 1\n- Item 2" has separator between list items
+
+    const listItem1 = 'Item 1';
+    const listItem2 = 'Item 2';
+    const separator = '\n';
+
+    // textBetween for a list would produce:
+    const expectedText = listItem1 + separator + listItem2;
+    expect(expectedText).toBe('Item 1\nItem 2');
+
+    // Offset of "Item 2" is after "Item 1\n"
+    expect(expectedText.indexOf('Item 2')).toBe(7);
+  });
+
+  it('leaf nodes with leafText contribute to offset', () => {
+    // Some nodes like hard_break have leafText that adds to offset
+    // Example: hard_break typically adds '\n'
+
+    const textBefore = 'Line 1';
+    const hardBreak = '\n'; // leafText for hard_break
+    const textAfter = 'Line 2';
+
+    const combined = textBefore + hardBreak + textAfter;
+    expect(combined).toBe('Line 1\nLine 2');
+  });
+});
+
+describe('nested block structure separator rules', () => {
+  /**
+   * This describes the critical distinction between isBlock and isTextblock:
+   *
+   * isBlock = true for: doc, paragraph, heading, blockquote, bullet_list,
+   *                     ordered_list, list_item, code_block, etc.
+   * isTextblock = true for: paragraph, heading, code_block
+   *                         (blocks that DIRECTLY contain inline content)
+   *
+   * doc.textBetween() adds separators ONLY between textblocks, not between
+   * wrapper blocks like list_item or blockquote.
+   */
+
+  it('only adds separator between text blocks, not wrapper blocks', () => {
+    // For a list structure:
+    // bullet_list > list_item > paragraph > "Item 1"
+    // bullet_list > list_item > paragraph > "Item 2"
+    //
+    // textBetween produces: "Item 1\nItem 2" (ONE separator)
+    //
+    // The walk function must use isTextblock (not isBlock) to match this.
+    // list_item.isBlock = true, list_item.isTextblock = false
+    // paragraph.isBlock = true, paragraph.isTextblock = true
+
+    // Expected: separator added ONLY when entering the second paragraph
+    const expectedOutput = 'Item 1\nItem 2';
+    expect(expectedOutput.match(/\n/g)?.length).toBe(1);
+  });
+
+  it('handles deeply nested blockquote with list', () => {
+    // > - Item A
+    // > - Item B
+    //
+    // Structure: blockquote > bullet_list > list_item > paragraph > text
+    // textBetween produces: "Item A\nItem B" (ONE separator)
+
+    const expectedOutput = 'Item A\nItem B';
+    expect(expectedOutput.split('\n').length).toBe(2);
+  });
+
+  it('handles multiple paragraphs in a list item', () => {
+    // - Para 1
+    //
+    //   Para 2
+    // - Para 3
+    //
+    // Structure has 3 paragraphs, so 2 separators
+    // textBetween produces: "Para 1\nPara 2\nPara 3"
+
+    const expectedOutput = 'Para 1\nPara 2\nPara 3';
+    expect(expectedOutput.split('\n').length).toBe(3);
+    expect(expectedOutput.match(/\n/g)?.length).toBe(2);
+  });
+
+  it('handles code block inside list', () => {
+    // - Item
+    //
+    //   ```
+    //   code
+    //   ```
+    //
+    // list_item contains paragraph + code_block (both isTextblock)
+    // textBetween produces: "Item\ncode" (ONE separator)
+
+    const expectedOutput = 'Item\ncode';
+    expect(expectedOutput.split('\n').length).toBe(2);
+  });
+
+  it('correctly skips separator for wrapper blocks', () => {
+    // Wrapper blocks that should NOT trigger separator:
+    const wrapperBlocks = ['bullet_list', 'ordered_list', 'list_item', 'blockquote'];
+
+    // Text blocks that SHOULD trigger separator (after first content):
+    const textBlocks = ['paragraph', 'heading', 'code_block'];
+
+    // This documents the behavior: separator only before textBlocks
+    expect(wrapperBlocks.every((b) => !textBlocks.includes(b))).toBe(true);
+    expect(textBlocks.every((b) => !wrapperBlocks.includes(b))).toBe(true);
+  });
+});
+
+describe('end position mapping for slice semantics', () => {
+  /**
+   * JavaScript string slice uses exclusive end indices: str.slice(0, 5)
+   * includes indices 0-4, not 5. When reanchorQuote returns { from: 10, to: 15 },
+   * we need textOffsetToProseMirrorPosition(15) to return a valid PM position.
+   *
+   * The fix: After processing each text node, we map the exclusive end offset
+   * (textOffset after incrementing) to the PM position after the text node.
+   */
+
+  it('maps exclusive end offset for text content', () => {
+    // For text "Hello" (length 5) at text offset 0:
+    // - Indices 0-4 map to content positions
+    // - Index 5 (exclusive end) must also be mapped for slice semantics
+    //
+    // This ensures textOffsetToProseMirrorPosition(5) returns the position
+    // after "Hello", not null.
+
+    const text = 'Hello';
+    const expectedMappings = text.length + 1; // 0..5 inclusive = 6 entries
+
+    // The map should have entries for indices 0 through text.length
+    expect(expectedMappings).toBe(6);
+  });
+
+  it('end offset equals start of next content', () => {
+    // For "Para 1\nPara 2", the end of "Para 1" (offset 6)
+    // is the same position as the separator (also offset 6).
+    // The separator is between blocks, and its end position
+    // aligns with the start of "Para 2" content.
+
+    const para1 = 'Para 1';
+    const separator = '\n';
+    const para2 = 'Para 2';
+    const combined = para1 + separator + para2;
+
+    // Offset 6 is both the end of "Para 1" and the separator position
+    expect(para1.length).toBe(6);
+    expect(combined.indexOf(separator)).toBe(6);
+
+    // Offset 7 is the start of "Para 2"
+    expect(combined.indexOf(para2)).toBe(7);
+  });
+});
+
+describe('offset map caching', () => {
+  it('cache key should be document instance', () => {
+    // The offset map is cached using WeakMap with doc as key
+    // This ensures the map is garbage collected when doc is unreferenced
+
+    // WeakMap behavior verification
+    const cache = new WeakMap<object, string>();
+    const obj1 = { id: 1 };
+    const obj2 = { id: 2 };
+
+    cache.set(obj1, 'map1');
+    cache.set(obj2, 'map2');
+
+    expect(cache.get(obj1)).toBe('map1');
+    expect(cache.get(obj2)).toBe('map2');
+  });
+
+  it('same doc returns cached map', () => {
+    // If buildTextToProseMirrorPositionMap is called with same doc
+    // it should return the cached map, not rebuild
+
+    // This is verified by the implementation using WeakMap
+    // We test the caching behavior works as expected
+    const cache = new WeakMap<object, { built: number }>();
+    let buildCount = 0;
+
+    function getOrBuild(doc: object) {
+      const cached = cache.get(doc);
+      if (cached) return cached;
+
+      buildCount++;
+      const map = { built: buildCount };
+      cache.set(doc, map);
+      return map;
+    }
+
+    const doc = {};
+    const map1 = getOrBuild(doc);
+    const map2 = getOrBuild(doc);
+
+    expect(map1).toBe(map2);
+    expect(buildCount).toBe(1); // Only built once
+  });
+});
+
+// ============================================================================
+// textOffsetToLineColumn Contract Tests
+// ============================================================================
+// NOTE: Full testing requires actual ProseMirror documents.
+// These tests verify the function export and expected behavior patterns.
+
+describe('textOffsetToLineColumn contract', () => {
+  it('exports textOffsetToLineColumn function', async () => {
+    const bridge = await import('./bridge.js');
+    expect(typeof bridge.textOffsetToLineColumn).toBe('function');
+  });
+
+  it('returns SourcePosition with offset, line, and column', async () => {
+    // Verify the return type structure
+    interface ExpectedSourcePosition {
+      offset: number;
+      line: number;
+      column: number;
+    }
+
+    const mockResult: ExpectedSourcePosition = {
+      offset: 5,
+      line: 1,
+      column: 6,
+    };
+
+    expect(mockResult).toHaveProperty('offset');
+    expect(mockResult).toHaveProperty('line');
+    expect(mockResult).toHaveProperty('column');
+    expect(typeof mockResult.offset).toBe('number');
+    expect(typeof mockResult.line).toBe('number');
+    expect(typeof mockResult.column).toBe('number');
+  });
+
+  it('line counting starts at 1 (1-based)', () => {
+    // Line numbers should be 1-based (matching editor conventions)
+    // At the start of a document, line = 1
+    const expectedFirstLine = 1;
+    expect(expectedFirstLine).toBe(1);
+  });
+
+  it('column counting starts at 1 (1-based)', () => {
+    // Column numbers should be 1-based (matching editor conventions)
+    // At the start of a line, column = 1
+    const expectedFirstColumn = 1;
+    expect(expectedFirstColumn).toBe(1);
+  });
+
+  it('newlines increment line count and reset column', () => {
+    // Expected behavior:
+    // "abc\ndef" at offset 4 (the 'd') should be line 2, column 1
+    const text = 'abc\ndef';
+    const offsetOfD = text.indexOf('d');
+    expect(offsetOfD).toBe(4);
+
+    // After the newline, we're on line 2
+    const expectedLine = 2;
+    // First character of new line is column 1
+    const expectedColumn = 1;
+
+    expect(expectedLine).toBe(2);
+    expect(expectedColumn).toBe(1);
+  });
+
+  it('handles multi-line text correctly', () => {
+    // "line1\nline2\nline3" has 3 lines
+    const text = 'line1\nline2\nline3';
+    const lines = text.split('\n');
+    expect(lines.length).toBe(3);
+
+    // Offset of 'l' in "line3" (position 12)
+    const offsetOfLine3 = text.indexOf('line3');
+    expect(offsetOfLine3).toBe(12);
+
+    // Should be line 3, column 1
+    const expectedLine = 3;
+    const expectedColumn = 1;
+    expect(expectedLine).toBe(3);
+    expect(expectedColumn).toBe(1);
+  });
+
+  it('clamps offset to valid range', () => {
+    // Negative offsets should be clamped to 0
+    // Offsets beyond content should be clamped to content length
+    const contentLength = 10;
+    const clampedNegative = Math.max(0, -5);
+    const clampedOverflow = Math.min(contentLength, 15);
+
+    expect(clampedNegative).toBe(0);
+    expect(clampedOverflow).toBe(contentLength);
+  });
+});

--- a/packages/editor/src/bridge.ts
+++ b/packages/editor/src/bridge.ts
@@ -1,0 +1,309 @@
+/**
+ * Bridge between ProseMirror positions and text offsets.
+ *
+ * This module provides position mapping utilities needed for:
+ * - DEP-39: Comment anchoring (map selection to persistable positions)
+ * - DEP-43: Suggested edits (map stored positions back to editor)
+ *
+ * The bridge maintains the invariant that positions can round-trip
+ * between ProseMirror and text offset coordinate systems.
+ *
+ * Key insight: ProseMirror positions include structural characters
+ * (node boundaries), while text offsets (from doc.textBetween()) only
+ * count text content plus block separators ('\n' between blocks).
+ */
+
+import type { SourcePosition } from '@cinder/markdown/diff/types';
+import type { Node as ProseMirrorNode } from '@milkdown/kit/prose/model';
+import type { EditorSelection } from './types.js';
+
+// ============================================================================
+// Text Offset <-> ProseMirror Position Mapping
+// ============================================================================
+
+/**
+ * Bidirectional map between text offsets and ProseMirror positions.
+ */
+interface PositionOffsetMap {
+  /** Map from text offset to ProseMirror position */
+  textToPm: Map<number, number>;
+  /** Map from ProseMirror position to text offset */
+  pmToText: Map<number, number>;
+}
+
+/**
+ * WeakMap cache for offset maps, keyed by document instance.
+ * Automatically garbage collected when document is no longer referenced.
+ */
+const offsetMapCache = new WeakMap<ProseMirrorNode, PositionOffsetMap>();
+
+/**
+ * Build bidirectional offset map matching doc.textBetween() semantics.
+ *
+ * textBetween inserts blockSeparator (default '\n') between block nodes.
+ * This function mirrors that behavior exactly by walking the document
+ * and tracking when we transition between blocks.
+ *
+ * Key insight: textBetween adds separator BETWEEN consecutive block content,
+ * not at every block boundary. We track this by noting when we exit one
+ * block's text content and enter another's.
+ *
+ * @param doc - ProseMirror document node
+ * @returns Cached bidirectional position map
+ */
+export function buildTextToProseMirrorPositionMap(doc: ProseMirrorNode): PositionOffsetMap {
+  const cached = offsetMapCache.get(doc);
+  if (cached) return cached;
+
+  const textToPm = new Map<number, number>();
+  const pmToText = new Map<number, number>();
+  let textOffset = 0;
+  let hasEmittedContent = false;
+
+  /**
+   * Walk document in order, tracking block boundaries.
+   *
+   * Key insight: doc.textBetween() adds separators between TEXT BLOCKS
+   * (paragraph, heading, code_block), not wrapper blocks (list, blockquote,
+   * list_item). Using isTextblock instead of isBlock ensures we only add
+   * separators where textBetween would.
+   */
+  function walk(node: ProseMirrorNode, pos: number) {
+    // For text blocks (not wrapper blocks), add separator
+    // before their content if we've already emitted content
+    // isTextblock = true for paragraph, heading, code_block
+    // isTextblock = false for bullet_list, list_item, blockquote
+    if (node.isTextblock && hasEmittedContent && pos > 0) {
+      // This is where textBetween would insert '\n'
+      textToPm.set(textOffset, pos);
+      pmToText.set(pos, textOffset);
+      textOffset += 1;
+    }
+
+    if (node.isText && node.text) {
+      for (let i = 0; i < node.text.length; i++) {
+        textToPm.set(textOffset + i, pos + i);
+        pmToText.set(pos + i, textOffset + i);
+      }
+      textOffset += node.text.length;
+      // Map the exclusive end position (for slice semantics)
+      // This ensures textOffsetToProseMirrorPosition works for end-of-quote offsets
+      textToPm.set(textOffset, pos + node.text.length);
+      pmToText.set(pos + node.text.length, textOffset);
+      hasEmittedContent = true;
+    } else if (node.isLeaf && !node.isText) {
+      // Atom nodes (images, hard breaks, etc.)
+      // textBetween uses leafText spec or empty string
+      const leafText =
+        (node.type.spec.leafText as ((node: ProseMirrorNode) => string) | undefined)?.(node) ?? '';
+      if (leafText.length > 0) {
+        for (let i = 0; i < leafText.length; i++) {
+          textToPm.set(textOffset + i, pos);
+          pmToText.set(pos, textOffset + i);
+        }
+        textOffset += leafText.length;
+        // Map the exclusive end position for leaf nodes too
+        textToPm.set(textOffset, pos + 1);
+        pmToText.set(pos + 1, textOffset);
+        hasEmittedContent = true;
+      }
+    }
+
+    // Recurse into children
+    // Each node's content starts 1 position after the node's start
+    // But for inline content within textblocks, children don't add extra positions
+    if (node.isTextblock) {
+      // For textblocks (paragraph, heading, code_block), content starts at pos + 1
+      const childPos = pos + 1;
+      node.forEach((child, offset) => {
+        walk(child, childPos + offset);
+      });
+    } else if (!node.isLeaf) {
+      // For container blocks (doc, list, blockquote, list_item), content starts at pos + 1
+      const childPos = pos + 1;
+      node.forEach((child, offset) => {
+        walk(child, childPos + offset);
+      });
+    }
+  }
+
+  // Start walking from doc's children
+  // Doc's content starts at position 0 (doc has no opening token in positions)
+  const docChildPos = 0;
+  doc.forEach((child, offset) => {
+    walk(child, docChildPos + offset);
+  });
+
+  const map = { textToPm, pmToText };
+  offsetMapCache.set(doc, map);
+  return map;
+}
+
+/**
+ * Convert a text offset (from doc.textBetween()) to a ProseMirror position.
+ *
+ * @param doc - ProseMirror document node
+ * @param offset - Text offset (0-based)
+ * @returns ProseMirror position or null if offset not found
+ */
+export function textOffsetToProseMirrorPosition(
+  doc: ProseMirrorNode,
+  offset: number,
+): number | null {
+  const map = buildTextToProseMirrorPositionMap(doc);
+  return map.textToPm.get(offset) ?? null;
+}
+
+/**
+ * Convert a ProseMirror position to a text offset (as from doc.textBetween()).
+ *
+ * @param doc - ProseMirror document node
+ * @param pos - ProseMirror position
+ * @returns Text offset or 0 if position not found
+ */
+export function proseMirrorPositionToTextOffset(doc: ProseMirrorNode, pos: number): number {
+  const map = buildTextToProseMirrorPositionMap(doc);
+  return map.pmToText.get(pos) ?? 0;
+}
+
+/**
+ * Compute line and column from a text offset within the document text.
+ *
+ * Unlike mapPosToSource (which maps to markdown source positions), this function
+ * computes line/column within the document's text content (doc.textBetween semantics).
+ * This is useful for originalPosition storage where we want coordinates that match
+ * the text offset coordinate system.
+ *
+ * @param doc - ProseMirror document node
+ * @param textOffset - Text offset (0-based, from doc.textBetween)
+ * @returns SourcePosition with offset, line, and column
+ */
+export function textOffsetToLineColumn(doc: ProseMirrorNode, textOffset: number): SourcePosition {
+  // Extract full document text using textBetween semantics
+  const docText = doc.textBetween(0, doc.content.size, '\n');
+
+  // Count lines and columns within the document text
+  let line = 1;
+  let column = 1;
+
+  const clampedOffset = Math.max(0, Math.min(textOffset, docText.length));
+
+  for (let i = 0; i < clampedOffset; i++) {
+    if (docText[i] === '\n') {
+      line++;
+      column = 1;
+    } else {
+      column++;
+    }
+  }
+
+  return {
+    offset: clampedOffset,
+    line,
+    column,
+  };
+}
+
+// ============================================================================
+// Markdown Source Position Mapping (Legacy)
+// ============================================================================
+
+/**
+ * Map a ProseMirror position to an mdast source position.
+ *
+ * This enables persisting selection/anchor positions in a format
+ * that survives editor remounts and document changes.
+ *
+ * @param pmPos - ProseMirror document position
+ * @param markdown - Current markdown content
+ * @returns Source position or null if mapping fails
+ *
+ * @remarks
+ * This is a stub implementation for DEP-36. Full implementation
+ * will be added in DEP-39 when comment anchoring is built.
+ */
+export function mapPosToSource(pmPos: number, markdown: string): SourcePosition | null {
+  // Stub: Direct offset mapping
+  // Full implementation will walk the ProseMirror document structure
+  // and correlate with markdown character offsets
+
+  if (pmPos < 0 || pmPos > markdown.length) {
+    return null;
+  }
+
+  // Count lines and columns from the markdown string
+  let line = 1;
+  let column = 1;
+
+  for (let i = 0; i < pmPos && i < markdown.length; i++) {
+    if (markdown[i] === '\n') {
+      line++;
+      column = 1;
+    } else {
+      column++;
+    }
+  }
+
+  return {
+    line,
+    column,
+    offset: pmPos,
+  };
+}
+
+/**
+ * Map an mdast source position to a ProseMirror position.
+ *
+ * This enables jumping to stored positions (comments, suggestions)
+ * when the editor loads.
+ *
+ * @param sourcePos - mdast source position
+ * @param markdown - Current markdown content
+ * @returns ProseMirror position or null if mapping fails
+ *
+ * @remarks
+ * This is a stub implementation for DEP-36. Full implementation
+ * will be added in DEP-39 when comment anchoring is built.
+ */
+export function mapSourceToPos(sourcePos: SourcePosition, markdown: string): number | null {
+  // Stub: Use offset directly if available
+  if (sourcePos.offset !== undefined && sourcePos.offset >= 0) {
+    return Math.min(sourcePos.offset, markdown.length);
+  }
+
+  // Fall back to line/column calculation
+  let offset = 0;
+  let currentLine = 1;
+
+  for (let i = 0; i < markdown.length; i++) {
+    if (currentLine === sourcePos.line) {
+      // Found the line, add column offset
+      return Math.min(offset + sourcePos.column - 1, markdown.length);
+    }
+
+    if (markdown[i] === '\n') {
+      currentLine++;
+    }
+    offset++;
+  }
+
+  // Line not found
+  return null;
+}
+
+/**
+ * Enrich an editor selection with source position information.
+ *
+ * @param selection - Editor selection state
+ * @param markdown - Current markdown content
+ * @returns Selection with sourcePosition field populated
+ */
+export function enrichSelectionWithSource(
+  selection: EditorSelection,
+  markdown: string,
+): EditorSelection {
+  return {
+    ...selection,
+    sourcePosition: mapPosToSource(selection.from, markdown),
+  };
+}

--- a/packages/editor/src/clipboard.ts
+++ b/packages/editor/src/clipboard.ts
@@ -1,0 +1,197 @@
+/**
+ * Custom clipboard behavior for Milkdown (DEP-45).
+ *
+ * Paste rules:
+ * - **Code (VSCode)**: Detect `vscode-editor-data` and insert a fenced code block (with language if available).
+ * - **Markdown**: If clipboard provides `text/markdown` or `text/x-markdown`, parse and insert structured content.
+ * - **HTML**: Sanitize (DEP-47) then parse and insert.
+ * - **Plain text**: Let the default ProseMirror behavior insert as-is.
+ *
+ * Copy behavior:
+ * - Serialize selection to Markdown via Milkdown serializer
+ * - Normalize via DEP-35 `normalize()` before writing to the clipboard
+ *
+ * @module
+ */
+
+import { normalize } from '@cinder/markdown/pipeline';
+import { editorViewOptionsCtx, parserCtx, schemaCtx, serializerCtx } from '@milkdown/kit/core';
+import { getNodeFromSchema, isTextOnlySlice } from '@milkdown/kit/prose';
+import { DOMParser, DOMSerializer } from '@milkdown/kit/prose/model';
+import { Plugin, PluginKey, TextSelection } from '@milkdown/kit/prose/state';
+import { $prose } from '@milkdown/kit/utils';
+import { sanitizeHtml } from './sanitize-html.js';
+
+function isVscodeClipboardPayload(value: unknown): value is { mode?: unknown } {
+  return value !== null && typeof value === 'object';
+}
+
+function normalizeMarkdownSafely(markdown: string): string {
+  try {
+    return normalize(markdown);
+  } catch (error) {
+    console.warn('Failed to normalize clipboard markdown:', error);
+    return markdown;
+  }
+}
+
+function getMarkdownFromClipboard(dataTransfer: DataTransfer): string {
+  // Prefer the markdown-specific clipboard types.
+  const markdown =
+    dataTransfer.getData('text/markdown') || dataTransfer.getData('text/x-markdown') || '';
+  return markdown;
+}
+
+function getLanguageHintFromVscodeClipboard(dataTransfer: DataTransfer): string | undefined {
+  const vscodeData = dataTransfer.getData('vscode-editor-data');
+  if (!vscodeData) return undefined;
+
+  try {
+    const parsed: unknown = JSON.parse(vscodeData);
+    return isVscodeClipboardPayload(parsed) && typeof parsed.mode === 'string'
+      ? parsed.mode
+      : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Milkdown plugin wrapper for the ProseMirror clipboard plugin.
+ */
+export const clipboardPlugin = $prose((ctx) => {
+  const schema = ctx.get(schemaCtx);
+
+  // Ensure editable prop exists (Milkdown issue workaround).
+  ctx.update(editorViewOptionsCtx, (previous) => ({
+    ...previous,
+    editable: previous.editable ?? (() => true),
+  }));
+
+  const key = new PluginKey('DEP_45_CLIPBOARD');
+
+  return new Plugin({
+    key,
+    props: {
+      handlePaste: (view, event) => {
+        const editable = view.props.editable?.(view.state);
+        const { clipboardData } = event;
+        if (!editable || !clipboardData) return false;
+
+        const currentNode = view.state.selection.$from.node();
+        if (currentNode.type.spec.code) return false;
+
+        const plainText = clipboardData.getData('text/plain');
+
+        // 1) VSCode paste → code block
+        const vscodeEditorData = clipboardData.getData('vscode-editor-data');
+        if (vscodeEditorData && plainText) {
+          const language = getLanguageHintFromVscodeClipboard(clipboardData);
+          const codeBlockType = getNodeFromSchema('code_block', schema);
+
+          const transaction = view.state.tr;
+
+          // Create a code block node, with a language hint if available.
+          transaction.replaceSelectionWith(codeBlockType.create({ language }));
+          transaction
+            .setSelection(
+              TextSelection.near(
+                transaction.doc.resolve(Math.max(0, transaction.selection.from - 2)),
+              ),
+            )
+            .insertText(plainText.replace(/\r\n?/g, '\n'));
+
+          view.dispatch(transaction);
+          return true;
+        }
+
+        // 2) Markdown clipboard type → parse and insert
+        const markdown = getMarkdownFromClipboard(clipboardData);
+        if (markdown) {
+          const parser = ctx.get(parserCtx);
+          const parsed = parser(markdown);
+          if (!parsed || typeof parsed === 'string') {
+            // If parsing fails, fall back to inserting as plain text.
+            view.dispatch(view.state.tr.insertText(markdown.replace(/\r\n?/g, '\n')));
+            return true;
+          }
+
+          const dom = DOMSerializer.fromSchema(schema).serializeFragment(parsed.content);
+          const slice = DOMParser.fromSchema(schema).parseSlice(dom);
+
+          const textOnlyNode = isTextOnlySlice(slice);
+          if (textOnlyNode) {
+            view.dispatch(view.state.tr.replaceSelectionWith(textOnlyNode, true));
+            return true;
+          }
+
+          try {
+            view.dispatch(view.state.tr.replaceSelection(slice));
+            return true;
+          } catch {
+            return false;
+          }
+        }
+
+        // 3) HTML → sanitize then parse and insert
+        const html = clipboardData.getData('text/html');
+        if (html) {
+          const sanitizedHtml = sanitizeHtml(html);
+          const template = document.createElement('template');
+          template.innerHTML = sanitizedHtml;
+          const dom = template.content.cloneNode(true);
+          template.remove();
+
+          const slice = DOMParser.fromSchema(schema).parseSlice(dom);
+          const textOnlyNode = isTextOnlySlice(slice);
+          if (textOnlyNode) {
+            view.dispatch(view.state.tr.replaceSelectionWith(textOnlyNode, true));
+            return true;
+          }
+
+          try {
+            view.dispatch(view.state.tr.replaceSelection(slice));
+            return true;
+          } catch {
+            // If HTML parsing fails, fall back to plain text (safe).
+            if (plainText) {
+              view.dispatch(view.state.tr.insertText(plainText.replace(/\r\n?/g, '\n')));
+              return true;
+            }
+            return false;
+          }
+        }
+
+        // 4) Plain text → default ProseMirror behavior (insert as-is)
+        return false;
+      },
+
+      clipboardTextSerializer: (slice) => {
+        const serializer = ctx.get(serializerCtx);
+
+        // Try to serialize as a valid doc node first.
+        let doc = schema.topNodeType.createAndFill(undefined, slice.content);
+
+        // If the slice is inline-only (common for partial selections), wrap it in a paragraph.
+        if (!doc) {
+          const paragraphType = schema.nodes['paragraph'];
+          if (paragraphType) {
+            const paragraph = paragraphType.createAndFill(undefined, slice.content);
+            if (paragraph) {
+              doc = schema.topNodeType.createAndFill(undefined, paragraph);
+            }
+          }
+        }
+
+        // Fallback to plain text if we can't build a valid document.
+        if (!doc) {
+          const plain = slice.content.textBetween(0, slice.content.size, '\n\n');
+          return normalizeMarkdownSafely(plain);
+        }
+
+        const markdown = serializer(doc);
+        return normalizeMarkdownSafely(markdown);
+      },
+    },
+  });
+});

--- a/packages/editor/src/commands.ts
+++ b/packages/editor/src/commands.ts
@@ -1,0 +1,863 @@
+/**
+ * Command registry for the Milkdown editor.
+ *
+ * This module provides functions to execute editor commands and query editor state.
+ * Used by the toolbar and keyboard shortcuts.
+ *
+ * IMPORTANT: Uses Milkdown's command system (callCommand) to ensure
+ * commands respect Milkdown contexts and work correctly.
+ */
+
+import type { CmdKey } from '@milkdown/kit/core';
+import type { Ctx } from '@milkdown/kit/ctx';
+import type { Mark, MarkType, Schema } from '@milkdown/kit/prose/model';
+import type { EditorView } from '@milkdown/kit/prose/view';
+
+type CommandRuntime = {
+  editorViewCtx: typeof import('@milkdown/kit/core').editorViewCtx;
+  schemaCtx: typeof import('@milkdown/kit/core').schemaCtx;
+  callCommand: typeof import('@milkdown/kit/utils').callCommand;
+  toggleStrongCommand: typeof import('@milkdown/kit/preset/commonmark').toggleStrongCommand;
+  toggleEmphasisCommand: typeof import('@milkdown/kit/preset/commonmark').toggleEmphasisCommand;
+  toggleInlineCodeCommand: typeof import('@milkdown/kit/preset/commonmark').toggleInlineCodeCommand;
+  wrapInHeadingCommand: typeof import('@milkdown/kit/preset/commonmark').wrapInHeadingCommand;
+  wrapInBulletListCommand: typeof import('@milkdown/kit/preset/commonmark').wrapInBulletListCommand;
+  wrapInOrderedListCommand: typeof import('@milkdown/kit/preset/commonmark').wrapInOrderedListCommand;
+  wrapInBlockquoteCommand: typeof import('@milkdown/kit/preset/commonmark').wrapInBlockquoteCommand;
+  insertHrCommand: typeof import('@milkdown/kit/preset/commonmark').insertHrCommand;
+  turnIntoTextCommand: typeof import('@milkdown/kit/preset/commonmark').turnIntoTextCommand;
+  liftListItemCommand: typeof import('@milkdown/kit/preset/commonmark').liftListItemCommand;
+  sinkListItemCommand: typeof import('@milkdown/kit/preset/commonmark').sinkListItemCommand;
+  toggleStrikethroughCommand: typeof import('@milkdown/kit/preset/gfm').toggleStrikethroughCommand;
+  undoCommand: typeof import('@milkdown/kit/plugin/history').undoCommand;
+  redoCommand: typeof import('@milkdown/kit/plugin/history').redoCommand;
+  liftListItem: typeof import('@milkdown/kit/prose/schema-list').liftListItem;
+  wrapInList: typeof import('@milkdown/kit/prose/schema-list').wrapInList;
+};
+
+let commandRuntime: CommandRuntime | null = null;
+let commandRuntimePromise: Promise<CommandRuntime> | null = null;
+
+function formatCommandKey(commandKey: unknown): string {
+  return typeof commandKey === 'string' ? commandKey : 'Milkdown command';
+}
+
+async function resolveCommandRuntime(): Promise<CommandRuntime> {
+  if (commandRuntime) return commandRuntime;
+
+  commandRuntimePromise ??= (async () => {
+    const [core, utilities, commonmark, gfm, history, schemaList] = await Promise.all([
+      import('@milkdown/kit/core'),
+      import('@milkdown/kit/utils'),
+      import('@milkdown/kit/preset/commonmark'),
+      import('@milkdown/kit/preset/gfm'),
+      import('@milkdown/kit/plugin/history'),
+      import('@milkdown/kit/prose/schema-list'),
+    ]);
+
+    return {
+      editorViewCtx: core.editorViewCtx,
+      schemaCtx: core.schemaCtx,
+      callCommand: utilities.callCommand,
+      toggleStrongCommand: commonmark.toggleStrongCommand,
+      toggleEmphasisCommand: commonmark.toggleEmphasisCommand,
+      toggleInlineCodeCommand: commonmark.toggleInlineCodeCommand,
+      wrapInHeadingCommand: commonmark.wrapInHeadingCommand,
+      wrapInBulletListCommand: commonmark.wrapInBulletListCommand,
+      wrapInOrderedListCommand: commonmark.wrapInOrderedListCommand,
+      wrapInBlockquoteCommand: commonmark.wrapInBlockquoteCommand,
+      insertHrCommand: commonmark.insertHrCommand,
+      turnIntoTextCommand: commonmark.turnIntoTextCommand,
+      liftListItemCommand: commonmark.liftListItemCommand,
+      sinkListItemCommand: commonmark.sinkListItemCommand,
+      toggleStrikethroughCommand: gfm.toggleStrikethroughCommand,
+      undoCommand: history.undoCommand,
+      redoCommand: history.redoCommand,
+      liftListItem: schemaList.liftListItem,
+      wrapInList: schemaList.wrapInList,
+    };
+  })();
+
+  commandRuntime = await commandRuntimePromise;
+  return commandRuntime;
+}
+
+/** Load Milkdown command modules before synchronous command handlers run. */
+export async function preloadCommandRuntime(): Promise<void> {
+  await resolveCommandRuntime();
+}
+
+function getCommandRuntime(): CommandRuntime | null {
+  if (commandRuntime) return commandRuntime;
+
+  commandRuntimePromise ??= resolveCommandRuntime();
+  return null;
+}
+
+function shouldLogDevelopmentWarnings(): boolean {
+  return typeof process === 'undefined' || process.env.NODE_ENV !== 'production';
+}
+
+function getEditorView(ctx: Ctx): EditorView | null {
+  const runtime = getCommandRuntime();
+  if (!runtime) return null;
+  return ctx.get(runtime.editorViewCtx);
+}
+
+function getEditorSchema(ctx: Ctx): Schema | null {
+  const runtime = getCommandRuntime();
+  if (!runtime) return null;
+  return ctx.get(runtime.schemaCtx);
+}
+
+function getEditorViewAndSchema(ctx: Ctx): {
+  view: EditorView | null;
+  schema: Schema | null;
+} {
+  const runtime = getCommandRuntime();
+  if (!runtime) return { view: null, schema: null };
+  return {
+    view: ctx.get(runtime.editorViewCtx),
+    schema: ctx.get(runtime.schemaCtx),
+  };
+}
+
+/**
+ * Active marks at the current selection.
+ */
+export interface ActiveMarks {
+  bold: boolean;
+  italic: boolean;
+  code: boolean;
+  strikethrough: boolean;
+  link: boolean;
+}
+
+/**
+ * Current block type at the selection.
+ *
+ * Uses a discriminated union to ensure type safety - you can't have
+ * a paragraph with a headingLevel or a blockquote with a listType.
+ */
+export type ActiveBlockType =
+  | { type: 'paragraph' }
+  | { type: 'heading'; headingLevel: 1 | 2 | 3 | 4 | 5 | 6 }
+  | { type: 'blockquote' }
+  | { type: 'codeBlock' }
+  | { type: 'listItem'; listType?: 'bullet' | 'ordered' | 'task' }
+  | { type: 'unknown' };
+
+const WORD_CHAR_REGEX = /[A-Za-z0-9_]/;
+
+function isHeadingLevel(value: unknown): value is 1 | 2 | 3 | 4 | 5 | 6 {
+  return value === 1 || value === 2 || value === 3 || value === 4 || value === 5 || value === 6;
+}
+
+function findWordRange(view: EditorView): { from: number; to: number } | null {
+  const { selection } = view.state;
+  if (!selection.empty) return null;
+
+  const { $from } = selection;
+  if (!$from.parent.isTextblock) return null;
+
+  const text = $from.parent.textBetween(0, $from.parent.content.size, '\0', '\ufffc');
+  if (!text) return null;
+
+  const offset = $from.parentOffset;
+  const leftChar = offset > 0 ? (text[offset - 1] ?? '') : '';
+  const rightChar = offset < text.length ? (text[offset] ?? '') : '';
+
+  if (!WORD_CHAR_REGEX.test(leftChar) && !WORD_CHAR_REGEX.test(rightChar)) {
+    return null;
+  }
+
+  let startOffset = offset;
+  let endOffset = offset;
+
+  if (WORD_CHAR_REGEX.test(leftChar)) {
+    startOffset = offset - 1;
+    while (startOffset > 0 && WORD_CHAR_REGEX.test(text[startOffset - 1] ?? '')) {
+      startOffset--;
+    }
+  }
+
+  if (WORD_CHAR_REGEX.test(rightChar)) {
+    endOffset = offset + 1;
+    while (endOffset < text.length && WORD_CHAR_REGEX.test(text[endOffset] ?? '')) {
+      endOffset++;
+    }
+  }
+
+  const base = $from.start();
+  const from = base + startOffset;
+  const to = base + endOffset;
+
+  if (from === to) return null;
+
+  return { from, to };
+}
+
+/**
+ * Run a Milkdown command and refocus the editor.
+ */
+export function runCommand<T>(ctx: Ctx, commandKey: CmdKey<T> | string, payload?: T): boolean {
+  const runtime = getCommandRuntime();
+  if (!runtime) return false;
+
+  try {
+    // callCommand returns a function that takes ctx and returns boolean
+    const result = runtime.callCommand(commandKey, payload)(ctx);
+    // Refocus editor after command
+    const view = getEditorView(ctx);
+    view?.focus();
+    return result;
+  } catch (error) {
+    if (shouldLogDevelopmentWarnings()) {
+      console.warn(`[Editor] Command failed: ${formatCommandKey(commandKey)}`, error);
+    }
+    return false;
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Mark Commands
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Toggle bold (strong) mark on the current selection.
+ */
+export function toggleBold(ctx: Ctx): boolean {
+  const runtime = getCommandRuntime();
+  if (!runtime) return false;
+
+  const { view, schema } = getEditorViewAndSchema(ctx);
+  if (!schema) return false;
+  const strongMark = schema.marks['strong'];
+
+  if (!view || !strongMark) {
+    return runCommand(ctx, runtime.toggleStrongCommand.key);
+  }
+
+  const wordRange = findWordRange(view);
+  if (!wordRange) {
+    return runCommand(ctx, runtime.toggleStrongCommand.key);
+  }
+
+  const { from, to } = wordRange;
+  const tr = view.state.tr;
+
+  if (view.state.doc.rangeHasMark(from, to, strongMark)) {
+    tr.removeMark(from, to, strongMark);
+  } else {
+    tr.addMark(from, to, strongMark.create());
+  }
+
+  view.dispatch(tr.scrollIntoView());
+  view.focus();
+  return true;
+}
+
+/**
+ * Toggle italic (emphasis) mark on the current selection.
+ */
+export function toggleItalic(ctx: Ctx): boolean {
+  const runtime = getCommandRuntime();
+  return runtime ? runCommand(ctx, runtime.toggleEmphasisCommand.key) : false;
+}
+
+/**
+ * Toggle inline code mark on the current selection.
+ */
+export function toggleCode(ctx: Ctx): boolean {
+  const runtime = getCommandRuntime();
+  return runtime ? runCommand(ctx, runtime.toggleInlineCodeCommand.key) : false;
+}
+
+/**
+ * Toggle strikethrough mark on the current selection.
+ */
+export function toggleStrikethrough(ctx: Ctx): boolean {
+  const runtime = getCommandRuntime();
+  return runtime ? runCommand(ctx, runtime.toggleStrikethroughCommand.key) : false;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Block Commands
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Set the current block to a heading at the specified level.
+ */
+export function setHeading(ctx: Ctx, level: 1 | 2 | 3 | 4 | 5 | 6): boolean {
+  const runtime = getCommandRuntime();
+  return runtime ? runCommand(ctx, runtime.wrapInHeadingCommand.key, level) : false;
+}
+
+/**
+ * Convert the current block to a paragraph (remove heading/list/etc).
+ */
+export function setParagraph(ctx: Ctx): boolean {
+  const runtime = getCommandRuntime();
+  return runtime ? runCommand(ctx, runtime.turnIntoTextCommand.key) : false;
+}
+
+/**
+ * Toggle bullet list on the current block.
+ */
+export function toggleBulletList(ctx: Ctx): boolean {
+  const runtime = getCommandRuntime();
+  if (!runtime) return false;
+
+  if (runCommand(ctx, runtime.wrapInBulletListCommand.key)) return true;
+
+  return toggleListFallback(ctx, 'bullet');
+}
+
+/**
+ * Toggle ordered list on the current block.
+ */
+export function toggleOrderedList(ctx: Ctx): boolean {
+  const runtime = getCommandRuntime();
+  if (!runtime) return false;
+
+  if (runCommand(ctx, runtime.wrapInOrderedListCommand.key)) return true;
+
+  return toggleListFallback(ctx, 'ordered');
+}
+
+function toggleListFallback(ctx: Ctx, listType: 'bullet' | 'ordered'): boolean {
+  const runtime = getCommandRuntime();
+  if (!runtime) return false;
+
+  try {
+    const { view, schema } = getEditorViewAndSchema(ctx);
+
+    if (!view || !schema) return false;
+
+    const listItemType = schema.nodes['list_item'];
+    const listNodeType =
+      listType === 'bullet' ? schema.nodes['bullet_list'] : schema.nodes['ordered_list'];
+
+    if (!listItemType || !listNodeType) return false;
+
+    const activeBlock = getActiveBlockType(ctx);
+    const isSameList = activeBlock.type === 'listItem' && activeBlock.listType === listType;
+    const isOtherList =
+      activeBlock.type === 'listItem' && activeBlock.listType && activeBlock.listType !== listType;
+
+    if (isSameList || isOtherList) {
+      const lifted = runtime.liftListItem(listItemType)(view.state, view.dispatch);
+      if (lifted && isSameList) {
+        view.focus();
+        return true;
+      }
+    }
+
+    const wrapped = runtime.wrapInList(listNodeType)(view.state, view.dispatch);
+    if (wrapped) {
+      view.focus();
+      return true;
+    }
+  } catch {
+    return false;
+  }
+
+  return false;
+}
+
+/**
+ * Toggle blockquote on the current block.
+ */
+export function toggleBlockquote(ctx: Ctx): boolean {
+  const runtime = getCommandRuntime();
+  return runtime ? runCommand(ctx, runtime.wrapInBlockquoteCommand.key) : false;
+}
+
+/**
+ * Indent a list item (sink).
+ */
+export function indentListItem(ctx: Ctx): boolean {
+  const runtime = getCommandRuntime();
+  return runtime ? runCommand(ctx, runtime.sinkListItemCommand.key) : false;
+}
+
+/**
+ * Outdent a list item (lift).
+ */
+export function outdentListItem(ctx: Ctx): boolean {
+  const runtime = getCommandRuntime();
+  return runtime ? runCommand(ctx, runtime.liftListItemCommand.key) : false;
+}
+
+/**
+ * Insert a horizontal rule.
+ */
+export function insertHorizontalRule(ctx: Ctx): boolean {
+  const runtime = getCommandRuntime();
+  return runtime ? runCommand(ctx, runtime.insertHrCommand.key) : false;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// History Commands
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Undo the last action.
+ */
+export function undo(ctx: Ctx): boolean {
+  const runtime = getCommandRuntime();
+  return runtime ? runCommand(ctx, runtime.undoCommand.key) : false;
+}
+
+/**
+ * Redo the last undone action.
+ */
+export function redo(ctx: Ctx): boolean {
+  const runtime = getCommandRuntime();
+  return runtime ? runCommand(ctx, runtime.redoCommand.key) : false;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Link Commands
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Insert a link at the current cursor position (when no selection).
+ * This inserts text and applies the link mark in a single transaction.
+ */
+export function insertLinkAtCursor(ctx: Ctx, text: string, url: string): boolean {
+  try {
+    const view = getEditorView(ctx);
+    const schema = getEditorSchema(ctx);
+
+    if (!schema) return false;
+    const linkMarkType = schema.marks['link'];
+    if (!view || !linkMarkType) return false;
+
+    const { from } = view.state.selection;
+    const linkMark = linkMarkType.create({ href: url });
+
+    const tr = view.state.tr.insertText(text, from).addMark(from, from + text.length, linkMark);
+
+    view.dispatch(tr);
+    view.focus();
+    return true;
+  } catch (error) {
+    if (shouldLogDevelopmentWarnings()) {
+      console.warn('[Editor] insertLinkAtCursor failed:', error);
+    }
+    return false;
+  }
+}
+
+/**
+ * Apply a link mark to the current selection.
+ */
+export function applyLinkToSelection(ctx: Ctx, url: string): boolean {
+  try {
+    const view = getEditorView(ctx);
+    const schema = getEditorSchema(ctx);
+
+    if (!schema) return false;
+    const linkMarkType = schema.marks['link'];
+    if (!view || !linkMarkType) return false;
+
+    const { from, to } = view.state.selection;
+    if (from === to) return false; // No selection
+
+    const linkMark = linkMarkType.create({ href: url });
+    const tr = view.state.tr.addMark(from, to, linkMark);
+
+    view.dispatch(tr);
+    view.focus();
+    return true;
+  } catch (error) {
+    if (shouldLogDevelopmentWarnings()) {
+      console.warn('[Editor] applyLinkToSelection failed:', error);
+    }
+    return false;
+  }
+}
+
+/**
+ * Update an existing link at the cursor position.
+ * Replaces the text and URL of the link the cursor is inside.
+ * Used when editing a link (cursor inside link, no selection).
+ */
+export function updateLinkAtCursor(ctx: Ctx, text: string, url: string): boolean {
+  try {
+    const view = getEditorView(ctx);
+    const schema = getEditorSchema(ctx);
+
+    if (!schema) return false;
+    const linkMarkType = schema.marks['link'];
+    if (!view || !linkMarkType) return false;
+
+    const { from } = view.state.selection;
+    const range = findMarkRange(view, linkMarkType, from);
+
+    if (!range) return false;
+
+    const [start, end] = range;
+    const linkMark = linkMarkType.create({ href: url });
+
+    // Replace the existing link text with new text and apply link mark
+    const tr = view.state.tr
+      .delete(start, end)
+      .insertText(text, start)
+      .addMark(start, start + text.length, linkMark);
+
+    view.dispatch(tr);
+    view.focus();
+    return true;
+  } catch (error) {
+    if (shouldLogDevelopmentWarnings()) {
+      console.warn('[Editor] updateLinkAtCursor failed:', error);
+    }
+    return false;
+  }
+}
+
+/**
+ * Find the range of a specific mark instance at a given position.
+ * Returns [start, end] if mark exists at position, null otherwise.
+ *
+ * IMPORTANT: This compares mark instances (same type AND same attributes),
+ * not just mark types. This ensures adjacent links with different URLs
+ * are treated as separate ranges.
+ */
+function findMarkRange(view: EditorView, markType: MarkType, pos: number): [number, number] | null {
+  const $pos = view.state.doc.resolve(pos);
+  const parent = $pos.parent;
+
+  // Get the specific mark instance at the cursor position.
+  // $pos.marks() returns marks AFTER the position, so if cursor is at end of
+  // marked text, we need to also check nodeBefore and nodeAfter.
+  let targetMark = markType.isInSet($pos.marks());
+
+  // If not found, check the node before (handles cursor at end of marked text)
+  if (!targetMark && $pos.nodeBefore) {
+    targetMark = markType.isInSet($pos.nodeBefore.marks);
+  }
+
+  // If still not found, check the node after (handles cursor at start of marked text)
+  if (!targetMark && $pos.nodeAfter) {
+    targetMark = markType.isInSet($pos.nodeAfter.marks);
+  }
+
+  if (!targetMark) {
+    return null;
+  }
+
+  // Helper to check if a node has the same mark instance (type + attributes)
+  const hasSameMark = (marks: readonly Mark[]): boolean => {
+    const mark = markType.isInSet(marks);
+    return mark !== undefined && mark.eq(targetMark);
+  };
+
+  // When cursor is at end of parent content, index equals childCount (out of bounds).
+  // Clamp to valid range for iteration.
+  const startIndex = Math.min($pos.index(), parent.childCount - 1);
+
+  // Find start by walking backward from current index
+  let start = $pos.start();
+  for (let i = startIndex; i >= 0; i--) {
+    const child = parent.child(i);
+    if (!hasSameMark(child.marks)) {
+      // Mark starts after this node - sum up sizes of nodes before current
+      for (let j = 0; j <= i; j++) {
+        start += parent.child(j).nodeSize;
+      }
+      break;
+    }
+    if (i === 0) {
+      // Mark starts at beginning of parent
+      start = $pos.start();
+    }
+  }
+
+  // Find end by walking forward from current index
+  let end = $pos.start();
+  for (let i = 0; i < parent.childCount; i++) {
+    const child = parent.child(i);
+    end += child.nodeSize;
+    if (i >= startIndex && !hasSameMark(child.marks)) {
+      // Mark ends before this node
+      end -= child.nodeSize;
+      break;
+    }
+  }
+
+  return [start, end];
+}
+
+/**
+ * Remove link mark from the current selection or a specified range.
+ *
+ * @param ctx - Milkdown editor context
+ * @param range - Optional pre-computed range [from, to] to remove link from.
+ *                If not provided, uses current selection (or finds link at cursor).
+ *                Pass this when the editor may have lost focus (e.g., popover interactions).
+ */
+export function removeLink(ctx: Ctx, range?: [number, number]): boolean {
+  try {
+    const view = getEditorView(ctx);
+    const schema = getEditorSchema(ctx);
+
+    if (!schema) return false;
+    const linkMarkType = schema.marks['link'];
+    if (!view || !linkMarkType) return false;
+
+    let from: number;
+    let to: number;
+
+    if (range) {
+      // Use pre-computed range (preferred when called from popovers/dialogs)
+      [from, to] = range;
+    } else {
+      // Fall back to current selection
+      ({ from, to } = view.state.selection);
+
+      // If selection is collapsed, find the link mark range
+      if (from === to) {
+        const foundRange = findMarkRange(view, linkMarkType, from);
+        if (!foundRange) return false;
+        [from, to] = foundRange;
+      }
+    }
+
+    const tr = view.state.tr.removeMark(from, to, linkMarkType);
+    view.dispatch(tr);
+    view.focus();
+    return true;
+  } catch (error) {
+    if (shouldLogDevelopmentWarnings()) {
+      console.warn('[Editor] removeLink failed:', error);
+    }
+    return false;
+  }
+}
+
+/**
+ * Get the link URL at the current cursor position, if any.
+ */
+export function getLinkAtCursor(ctx: Ctx): string | null {
+  try {
+    const view = getEditorView(ctx);
+    const schema = getEditorSchema(ctx);
+
+    if (!schema) return null;
+    const linkMarkType = schema.marks['link'];
+    if (!view || !linkMarkType) return null;
+
+    const { $from } = view.state.selection;
+    const linkMark = linkMarkType.isInSet($from.marks());
+
+    if (linkMark) {
+      const href = linkMark.attrs['href'];
+      return typeof href === 'string' ? href : null;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Get the link text at the current cursor position, if cursor is inside a link.
+ * Returns the full link text even when selection is collapsed.
+ */
+export function getLinkTextAtCursor(ctx: Ctx): string | null {
+  try {
+    const view = getEditorView(ctx);
+    const schema = getEditorSchema(ctx);
+
+    if (!schema) return null;
+    const linkMarkType = schema.marks['link'];
+    if (!view || !linkMarkType) return null;
+
+    const { from } = view.state.selection;
+    const range = findMarkRange(view, linkMarkType, from);
+
+    if (!range) return null;
+
+    const [start, end] = range;
+    return view.state.doc.textBetween(start, end);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Get the link range at the current cursor position.
+ * Returns [from, to] if cursor is inside a link, null otherwise.
+ *
+ * Use this to capture the link range before focus leaves the editor
+ * (e.g., when opening a popover), then pass the range to removeLink.
+ */
+export function getLinkRangeAtCursor(ctx: Ctx): [number, number] | null {
+  try {
+    const view = getEditorView(ctx);
+    const schema = getEditorSchema(ctx);
+
+    if (!schema) return null;
+    const linkMarkType = schema.marks['link'];
+    if (!view || !linkMarkType) return null;
+
+    const { from } = view.state.selection;
+    return findMarkRange(view, linkMarkType, from);
+  } catch {
+    return null;
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// State Queries
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Check if a mark type is active at the current selection.
+ */
+export function isMarkActive(view: EditorView, markType: MarkType): boolean {
+  const { from, $from, to, empty } = view.state.selection;
+
+  if (empty) {
+    return !!markType.isInSet(view.state.storedMarks || $from.marks());
+  }
+
+  return view.state.doc.rangeHasMark(from, to, markType);
+}
+
+/**
+ * Get all active marks at the current selection.
+ */
+export function getActiveMarks(ctx: Ctx): ActiveMarks {
+  const result: ActiveMarks = {
+    bold: false,
+    italic: false,
+    code: false,
+    strikethrough: false,
+    link: false,
+  };
+
+  try {
+    const view = getEditorView(ctx);
+    const schema = getEditorSchema(ctx);
+
+    if (!view || !schema) return result;
+
+    const strongMark = schema.marks['strong'];
+    const emphasisMark = schema.marks['emphasis'];
+    const codeMark = schema.marks['code'];
+    const strikethroughMark = schema.marks['strikethrough'];
+    const linkMark = schema.marks['link'];
+
+    if (strongMark) {
+      result.bold = isMarkActive(view, strongMark);
+    }
+    if (emphasisMark) {
+      result.italic = isMarkActive(view, emphasisMark);
+    }
+    if (codeMark) {
+      result.code = isMarkActive(view, codeMark);
+    }
+    if (strikethroughMark) {
+      result.strikethrough = isMarkActive(view, strikethroughMark);
+    }
+    if (linkMark) {
+      result.link = isMarkActive(view, linkMark);
+    }
+  } catch {
+    // Return default values on error
+  }
+
+  return result;
+}
+
+/**
+ * Get the active block type at the current selection.
+ */
+export function getActiveBlockType(ctx: Ctx): ActiveBlockType {
+  const result: ActiveBlockType = { type: 'paragraph' };
+
+  try {
+    const view = getEditorView(ctx);
+    const schema = getEditorSchema(ctx);
+
+    if (!view || !schema) return result;
+
+    const { $from } = view.state.selection;
+
+    // Walk up the document tree to find the block type
+    for (let depth = $from.depth; depth >= 0; depth--) {
+      const node = $from.node(depth);
+
+      if (node.type === schema.nodes['heading']) {
+        const headingLevel = node.attrs['level'];
+        if (!isHeadingLevel(headingLevel)) return { type: 'unknown' };
+
+        return {
+          type: 'heading',
+          headingLevel,
+        };
+      }
+
+      if (node.type === schema.nodes['blockquote']) {
+        return { type: 'blockquote' };
+      }
+
+      if (node.type === schema.nodes['code_block']) {
+        return { type: 'codeBlock' };
+      }
+
+      if (node.type === schema.nodes['list_item']) {
+        const parent = depth > 0 ? $from.node(depth - 1) : null;
+        if (parent?.type === schema.nodes['bullet_list']) {
+          return { type: 'listItem', listType: 'bullet' };
+        }
+        if (parent?.type === schema.nodes['ordered_list']) {
+          return { type: 'listItem', listType: 'ordered' };
+        }
+        return { type: 'listItem' };
+      }
+
+      if (node.type === schema.nodes['paragraph']) {
+        return { type: 'paragraph' };
+      }
+    }
+  } catch {
+    // Return default values on error
+  }
+
+  return result;
+}
+
+/**
+ * Check if the current selection is collapsed (cursor only, no selection).
+ */
+export function isSelectionCollapsed(ctx: Ctx): boolean {
+  try {
+    const view = getEditorView(ctx);
+    if (!view) return true;
+    return view.state.selection.empty;
+  } catch {
+    return true;
+  }
+}
+
+/**
+ * Get the selected text, if any.
+ */
+export function getSelectedText(ctx: Ctx): string {
+  try {
+    const view = getEditorView(ctx);
+    if (!view) return '';
+
+    const { from, to } = view.state.selection;
+    if (from === to) return '';
+
+    return view.state.doc.textBetween(from, to);
+  } catch {
+    return '';
+  }
+}

--- a/packages/editor/src/editor.ts
+++ b/packages/editor/src/editor.ts
@@ -1,0 +1,329 @@
+/**
+ * Core Milkdown editor initialization.
+ *
+ * This module configures Milkdown with CommonMark + GFM support,
+ * integrating with the DEP-35 pipeline for consistent serialization.
+ */
+
+import type { Ctx } from '@milkdown/kit/ctx';
+
+import type { EditorConfig, EditorSelection, EditorState } from './types.js';
+import { DEFAULT_DEBOUNCE_MS } from './types.js';
+
+function shouldLogDevelopmentWarnings(): boolean {
+  return typeof process === 'undefined' || process.env.NODE_ENV !== 'production';
+}
+
+/**
+ * Create and configure a Milkdown editor instance.
+ *
+ * @param container - DOM element to mount the editor in
+ * @param config - Editor configuration
+ * @returns Promise resolving to EditorState for imperative control
+ */
+export async function createEditor(
+  container: HTMLElement,
+  config: EditorConfig = {},
+): Promise<EditorState> {
+  if (typeof document === 'undefined') {
+    throw new Error('createEditor() requires a browser document.');
+  }
+
+  const [
+    { Editor, rootCtx, defaultValueCtx, editorViewCtx },
+    { commonmark },
+    { gfm },
+    { history },
+    { listener, listenerCtx },
+    { getMarkdown, replaceAll },
+    { preloadCommandRuntime },
+    { placeholderPlugin },
+    { createEditorKeymap },
+    { clipboardPlugin },
+    { linkInputRulePlugin },
+    { createTemplateCompletionPlugin },
+    { createTemplateInvalidDecorationPlugin },
+  ] = await Promise.all([
+    import('@milkdown/kit/core'),
+    import('@milkdown/kit/preset/commonmark'),
+    import('@milkdown/kit/preset/gfm'),
+    import('@milkdown/kit/plugin/history'),
+    import('@milkdown/kit/plugin/listener'),
+    import('@milkdown/kit/utils'),
+    import('./commands.js'),
+    import('./placeholder.js'),
+    import('./keymap-plugin.js'),
+    import('./clipboard.js'),
+    import('./link-input-rule.js'),
+    import('./template-completion-plugin.js'),
+    import('./template-invalid-decoration-plugin.js'),
+  ]);
+  await preloadCommandRuntime();
+
+  const {
+    initialContent = '',
+    readonly = false,
+    ariaLabel,
+    changeDebounceMs = DEFAULT_DEBOUNCE_MS,
+    onChange,
+    onSelectionChange,
+    onLinkShortcut,
+    onCommentShortcut,
+    plugins = [],
+    placeholderCompletion,
+    placeholderDecoration,
+  } = config;
+
+  // Track if we're updating from external source to prevent loops
+  let isExternalUpdate = false;
+  // Track if editor is destroyed to prevent accessing context after cleanup
+  let isDestroyed = false;
+  let debounceTimeout: ReturnType<typeof setTimeout> | null = null;
+
+  // Build the editor
+  let builder = Editor.make()
+    .config((ctx) => {
+      ctx.set(rootCtx, container);
+      ctx.set(defaultValueCtx, initialContent);
+    })
+    .config((ctx) => {
+      // Set up change listener
+      const listenerManager = ctx.get(listenerCtx);
+
+      listenerManager.markdownUpdated((_ctx, markdown, prevMarkdown) => {
+        // Skip if editor is destroyed (debounced callback fired after cleanup)
+        if (isDestroyed) return;
+        // Skip if this is an external update (from setMarkdown)
+        if (isExternalUpdate) return;
+        // Skip if content unchanged
+        if (markdown === prevMarkdown) return;
+
+        // Debounce onChange calls
+        if (debounceTimeout) clearTimeout(debounceTimeout);
+        debounceTimeout = setTimeout(() => {
+          if (isDestroyed) return; // Guard after debounce
+          onChange?.(markdown);
+        }, changeDebounceMs);
+      });
+
+      // Selection change tracking (for DEP-39 comment anchoring and toolbar state)
+      // We need TWO listeners:
+      // 1. selectionUpdated - fires on selection-only changes (user clicks without editing)
+      // 2. updated - fires on document changes (which also change the selection position)
+      // Together, these ensure the toolbar always reflects the current cursor position.
+      if (onSelectionChange) {
+        const notifySelectionChange = (listenerContext: Ctx) => {
+          // Skip if editor is destroyed
+          if (isDestroyed) return;
+
+          // Wrap context access in try-catch - Milkdown may have already cleared
+          // its context registry during unmount, causing ctx.get() to throw
+          let view;
+          try {
+            view = listenerContext.get(editorViewCtx);
+          } catch {
+            // Context already destroyed during cleanup, silently ignore
+            return;
+          }
+          // Guard against view not being ready or state not yet attached
+          if (!view?.state) return;
+
+          const { from, to } = view.state.selection;
+          const selection: EditorSelection = {
+            from,
+            to,
+            isCollapsed: from === to,
+          };
+
+          onSelectionChange(selection);
+        };
+
+        // Listen for selection-only changes (clicking without editing)
+        listenerManager.selectionUpdated(notifySelectionChange);
+
+        // Listen for document changes (which also affect selection position)
+        listenerManager.updated(notifySelectionChange);
+      }
+    })
+    .use(commonmark)
+    .use(gfm)
+    .use(linkInputRulePlugin)
+    .use(clipboardPlugin)
+    .use(history)
+    .use(
+      createEditorKeymap({
+        ...(onLinkShortcut ? { onLinkShortcut } : {}),
+        ...(onCommentShortcut ? { onCommentShortcut } : {}),
+      }),
+    ) // DEP-37/47: Keyboard shortcuts
+    .use(listener)
+    .use(placeholderPlugin);
+
+  // DEP-583: Conditionally register placeholder completion plugin
+  if (placeholderCompletion) {
+    const completionConfig = placeholderCompletion;
+    builder = builder.use(createTemplateCompletionPlugin(() => completionConfig));
+  }
+
+  // DEP-583: Conditionally register placeholder invalid decoration plugin
+  if (placeholderDecoration) {
+    const decorationConfig = placeholderDecoration;
+    builder = builder.use(
+      createTemplateInvalidDecorationPlugin(
+        () => decorationConfig.candidates,
+        decorationConfig.invalidClassName ? () => decorationConfig.invalidClassName! : undefined,
+      ),
+    );
+  }
+
+  // Apply additional plugins (for DEP-39 anchoring, decorations, etc.)
+  const editor = await builder.use(plugins).create();
+
+  // Get the view for direct access
+  const view = editor.ctx.get(editorViewCtx);
+
+  // Apply readonly state
+  if (readonly && view) {
+    view.setProps({ editable: () => false });
+  }
+
+  // Apply aria-label to the ProseMirror DOM element (the element with role="textbox")
+  if (ariaLabel && view?.dom) {
+    view.dom.setAttribute('aria-label', ariaLabel);
+  }
+
+  // Build the state object
+  const state: EditorState = {
+    editor,
+    view,
+
+    focus() {
+      view?.focus();
+    },
+
+    getMarkdown() {
+      return editor.action(getMarkdown());
+    },
+
+    setMarkdown(content: string) {
+      // Clear any pending debounce to prevent stale callbacks
+      if (debounceTimeout) {
+        clearTimeout(debounceTimeout);
+        debounceTimeout = null;
+      }
+
+      isExternalUpdate = true;
+      editor.action(replaceAll(content));
+      // Reset flag after microtask
+      queueMicrotask(() => {
+        isExternalUpdate = false;
+      });
+    },
+
+    clearPendingTimers() {
+      if (debounceTimeout) {
+        clearTimeout(debounceTimeout);
+        debounceTimeout = null;
+      }
+    },
+
+    markDestroyed() {
+      isDestroyed = true;
+    },
+  };
+
+  return state;
+}
+
+/**
+ * Update the readonly state of an editor.
+ */
+export function setEditorReadonly(state: EditorState, readonly: boolean): void {
+  state.view?.setProps({ editable: () => !readonly });
+}
+
+// Track stderr suppression nesting to prevent race conditions (DEP-139).
+// When multiple destroyEditor calls execute concurrently, we need reference counting
+// to ensure we only restore stderr when the outermost call completes.
+let stderrSuppressionDepth = 0;
+let originalStderrWrite: NodeJS.WriteStream['write'] | null = null;
+
+function writeWithSuppressedMilkdownErrors(
+  this: NodeJS.WriteStream,
+  buffer: string | Uint8Array,
+  callback?: (error?: Error | null) => void,
+): boolean;
+function writeWithSuppressedMilkdownErrors(
+  this: NodeJS.WriteStream,
+  str: string | Uint8Array,
+  encoding?: BufferEncoding,
+  callback?: (error?: Error | null) => void,
+): boolean;
+function writeWithSuppressedMilkdownErrors(
+  this: NodeJS.WriteStream,
+  chunk: string | Uint8Array,
+  encodingOrCallback?: BufferEncoding | ((error?: Error | null) => void),
+  callback?: (error?: Error | null) => void,
+): boolean {
+  const message = typeof chunk === 'string' ? chunk : chunk.toString();
+  if (message.includes('MilkdownError')) {
+    return true;
+  }
+
+  if (!originalStderrWrite) return true;
+
+  if (typeof encodingOrCallback === 'function') {
+    return originalStderrWrite(chunk, encodingOrCallback);
+  }
+
+  return originalStderrWrite(chunk, encodingOrCallback, callback);
+}
+
+/**
+ * Destroy an editor instance and clean up resources.
+ */
+export function destroyEditor(state: EditorState): void {
+  // Mark destroyed first to prevent debounced callbacks from accessing context
+  state.markDestroyed();
+  state.clearPendingTimers();
+
+  // Suppress MilkdownError stderr output during destruction (DEP-139).
+  // Milkdown logs "Context editorView not found" errors to stderr during teardown
+  // when it accesses its own context that's being destroyed. These are harmless.
+  // Only applicable in Node/test environments; browser builds don't have process.stderr.
+  const stderr = typeof process !== 'undefined' ? process.stderr : undefined;
+
+  if (stderr) {
+    // Increment depth and capture original on first entry
+    if (stderrSuppressionDepth === 0) {
+      originalStderrWrite = stderr.write.bind(stderr);
+      stderr.write = writeWithSuppressedMilkdownErrors;
+    }
+    stderrSuppressionDepth++;
+  }
+
+  try {
+    void state.editor.destroy();
+  } catch (error) {
+    // Milkdown can throw during teardown if its context registry has already been cleared
+    // (e.g. rapid mount/unmount in tests). Destroy should never crash the app.
+    // Suppress "Context editorView not found" errors during cleanup - they're harmless.
+    const isMilkdownContextError =
+      error instanceof Error &&
+      error.message.includes('Context') &&
+      error.message.includes('not found');
+
+    if (!isMilkdownContextError && shouldLogDevelopmentWarnings()) {
+      console.warn('[Editor] Failed to destroy Milkdown editor:', error);
+    }
+  } finally {
+    // Decrement depth and restore stderr only when reaching zero
+    if (stderr) {
+      stderrSuppressionDepth--;
+      if (stderrSuppressionDepth === 0 && originalStderrWrite) {
+        stderr.write = originalStderrWrite;
+        originalStderrWrite = null;
+      }
+    }
+  }
+}

--- a/packages/editor/src/env.d.ts
+++ b/packages/editor/src/env.d.ts
@@ -1,0 +1,8 @@
+interface ImportMetaEnv {
+  readonly DEV: boolean;
+  readonly PROD: boolean;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}

--- a/packages/editor/src/index.ts
+++ b/packages/editor/src/index.ts
@@ -1,0 +1,133 @@
+/**
+ * Milkdown editor integration for SvelteKit.
+ *
+ * This module provides the core editor functionality for the
+ * Markdown Review Editor, integrating Milkdown (ProseMirror-based)
+ * with Svelte 5 patterns.
+ *
+ * @example
+ * ```svelte
+ * <script>
+ *   import { createEditorAttachment, type EditorHandle } from '$lib/editor';
+ *
+ *   let markdown = $state('# Hello');
+ *   let handle: EditorHandle | null = null;
+ * </script>
+ * ```
+ *
+ * @packageDocumentation
+ */
+
+// Types
+export type {
+  EditorAttachmentOptions,
+  EditorConfig,
+  EditorHandle,
+  EditorSelection,
+  EditorState,
+} from './types.js';
+
+export { DEFAULT_DEBOUNCE_MS } from './types.js';
+
+// Core editor
+export { createEditor, destroyEditor, setEditorReadonly } from './editor.js';
+
+// Svelte integration
+export { createEditorAttachment } from './attach.js';
+
+// Position mapping (DEP-39)
+export {
+  buildTextToProseMirrorPositionMap,
+  enrichSelectionWithSource,
+  mapPosToSource,
+  mapSourceToPos,
+  proseMirrorPositionToTextOffset,
+  textOffsetToLineColumn,
+  textOffsetToProseMirrorPosition,
+} from './bridge.js';
+
+// Commands (DEP-37)
+export {
+  applyLinkToSelection,
+  getActiveBlockType,
+  getActiveMarks,
+  getLinkAtCursor,
+  getLinkRangeAtCursor,
+  getLinkTextAtCursor,
+  getSelectedText,
+  indentListItem,
+  insertHorizontalRule,
+  // Link commands
+  insertLinkAtCursor,
+  // State queries
+  isMarkActive,
+  isSelectionCollapsed,
+  outdentListItem,
+  redo,
+  removeLink,
+  // Block commands
+  setHeading,
+  setParagraph,
+  toggleBlockquote,
+  // Mark commands
+  toggleBold,
+  toggleBulletList,
+  toggleCode,
+  toggleItalic,
+  toggleOrderedList,
+  toggleStrikethrough,
+  // History commands
+  undo,
+  updateLinkAtCursor,
+  type ActiveBlockType,
+  // Types
+  type ActiveMarks,
+} from './commands.js';
+
+// Keymap plugin (DEP-37)
+export {
+  createEditorKeymap,
+  editorKeymap,
+  getShortcutDefinitions,
+  getShortcutDisplay,
+  type EditorKeymapOptions,
+  type ShortcutDefinition,
+} from './keymap-plugin.js';
+
+// Template placeholders (DEP-582, DEP-625)
+export {
+  buildPlaceholderCandidatesFromJsonSchema,
+  isBlockedSegment,
+  parsePlaceholderTokens,
+  resolveTemplatePlaceholders,
+  validatePlaceholderTokens,
+} from './template-placeholders.js';
+
+// Template rendering (DEP-625)
+// Not re-exported here to avoid loading heavy @cinder/markdown pipeline for lightweight placeholder operations
+// Import from '@cinder/editor/template-render' instead
+
+// Placeholder security (DEP-625)
+export { RESERVED_SEGMENTS } from './placeholder-security.js';
+
+// Template placeholder plugins (DEP-583)
+export {
+  createTemplateCompletionPlugin,
+  templateCompletionPluginKey,
+} from './template-completion-plugin.js';
+
+export {
+  createTemplateInvalidDecorationPlugin,
+  templateInvalidDecorationPluginKey,
+} from './template-invalid-decoration-plugin.js';
+
+export type {
+  PlaceholderCandidate,
+  PlaceholderCompletionConfiguration,
+  PlaceholderDecorationConfiguration,
+  PlaceholderResolutionResult,
+  PlaceholderToken,
+  PlaceholderValidationIssue,
+  PlaceholderValidationResult,
+  PlaceholderValueKind,
+} from './types.js';

--- a/packages/editor/src/keymap-plugin.ts
+++ b/packages/editor/src/keymap-plugin.ts
@@ -1,0 +1,218 @@
+/**
+ * Keyboard shortcuts plugin for the Milkdown editor.
+ *
+ * IMPORTANT: Uses $shortcut + callCommand (NOT raw ProseMirror keymap).
+ * This ensures bindings are registered after editor init and respect Milkdown contexts.
+ */
+
+import type { MilkdownPlugin } from '@milkdown/ctx';
+
+type ShortcutRuntime = {
+  $shortcut: typeof import('@milkdown/kit/utils').$shortcut;
+  callCommand: typeof import('@milkdown/kit/utils').callCommand;
+  toggleStrongCommand: typeof import('@milkdown/kit/preset/commonmark').toggleStrongCommand;
+  toggleEmphasisCommand: typeof import('@milkdown/kit/preset/commonmark').toggleEmphasisCommand;
+  toggleInlineCodeCommand: typeof import('@milkdown/kit/preset/commonmark').toggleInlineCodeCommand;
+  wrapInHeadingCommand: typeof import('@milkdown/kit/preset/commonmark').wrapInHeadingCommand;
+  wrapInBulletListCommand: typeof import('@milkdown/kit/preset/commonmark').wrapInBulletListCommand;
+  wrapInOrderedListCommand: typeof import('@milkdown/kit/preset/commonmark').wrapInOrderedListCommand;
+  wrapInBlockquoteCommand: typeof import('@milkdown/kit/preset/commonmark').wrapInBlockquoteCommand;
+  insertHrCommand: typeof import('@milkdown/kit/preset/commonmark').insertHrCommand;
+  sinkListItemCommand: typeof import('@milkdown/kit/preset/commonmark').sinkListItemCommand;
+  liftListItemCommand: typeof import('@milkdown/kit/preset/commonmark').liftListItemCommand;
+  toggleStrikethroughCommand: typeof import('@milkdown/kit/preset/gfm').toggleStrikethroughCommand;
+  undoCommand: typeof import('@milkdown/kit/plugin/history').undoCommand;
+  redoCommand: typeof import('@milkdown/kit/plugin/history').redoCommand;
+};
+
+let shortcutRuntime: ShortcutRuntime | null = null;
+let shortcutRuntimePromise: Promise<ShortcutRuntime> | null = null;
+
+async function resolveShortcutRuntime(): Promise<ShortcutRuntime> {
+  if (shortcutRuntime) return shortcutRuntime;
+
+  shortcutRuntimePromise ??= (async () => {
+    const [utilities, commonmark, gfm, history] = await Promise.all([
+      import('@milkdown/kit/utils'),
+      import('@milkdown/kit/preset/commonmark'),
+      import('@milkdown/kit/preset/gfm'),
+      import('@milkdown/kit/plugin/history'),
+    ]);
+
+    return {
+      $shortcut: utilities.$shortcut,
+      callCommand: utilities.callCommand,
+      toggleStrongCommand: commonmark.toggleStrongCommand,
+      toggleEmphasisCommand: commonmark.toggleEmphasisCommand,
+      toggleInlineCodeCommand: commonmark.toggleInlineCodeCommand,
+      wrapInHeadingCommand: commonmark.wrapInHeadingCommand,
+      wrapInBulletListCommand: commonmark.wrapInBulletListCommand,
+      wrapInOrderedListCommand: commonmark.wrapInOrderedListCommand,
+      wrapInBlockquoteCommand: commonmark.wrapInBlockquoteCommand,
+      insertHrCommand: commonmark.insertHrCommand,
+      sinkListItemCommand: commonmark.sinkListItemCommand,
+      liftListItemCommand: commonmark.liftListItemCommand,
+      toggleStrikethroughCommand: gfm.toggleStrikethroughCommand,
+      undoCommand: history.undoCommand,
+      redoCommand: history.redoCommand,
+    };
+  })();
+
+  shortcutRuntime = await shortcutRuntimePromise;
+  return shortcutRuntime;
+}
+
+/**
+ * Options for customizing keyboard shortcuts.
+ */
+export interface EditorKeymapOptions {
+  /** Called when Mod-k (link shortcut) is pressed */
+  onLinkShortcut?: () => void;
+  /** Called when Ctrl-Alt-c (comment shortcut) is pressed (DEP-47) */
+  onCommentShortcut?: () => void;
+}
+
+/**
+ * Create keyboard shortcuts plugin for the Milkdown editor.
+ *
+ * @param options - Optional callbacks for shortcuts that need external handling
+ * @returns Milkdown plugin with keyboard bindings
+ *
+ * Note: Mod = Cmd on Mac, Ctrl on Windows/Linux
+ */
+export function createEditorKeymap(options: EditorKeymapOptions = {}): MilkdownPlugin {
+  const keymapPlugin: MilkdownPlugin = (ctx) => async () => {
+    const runtime = await resolveShortcutRuntime();
+    const shortcutPlugin = runtime.$shortcut((shortcutContext) => {
+      const call = <T>(key: Parameters<typeof runtime.callCommand>[0], payload?: T) =>
+        runtime.callCommand(key, payload)(shortcutContext);
+
+      const bindings: Record<string, () => boolean> = {
+        'Mod-b': () => call(runtime.toggleStrongCommand.key),
+        'Mod-i': () => call(runtime.toggleEmphasisCommand.key),
+        'Mod-e': () => call(runtime.toggleInlineCodeCommand.key),
+        'Mod-Shift-s': () => call(runtime.toggleStrikethroughCommand.key),
+        'Mod-Alt-1': () => call(runtime.wrapInHeadingCommand.key, 1),
+        'Mod-Alt-2': () => call(runtime.wrapInHeadingCommand.key, 2),
+        'Mod-Alt-3': () => call(runtime.wrapInHeadingCommand.key, 3),
+        'Mod-Shift-8': () => call(runtime.wrapInBulletListCommand.key),
+        'Mod-Shift-7': () => call(runtime.wrapInOrderedListCommand.key),
+        Tab: () => call(runtime.sinkListItemCommand.key),
+        'Shift-Tab': () => call(runtime.liftListItemCommand.key),
+        'Mod-Shift-9': () => call(runtime.wrapInBlockquoteCommand.key),
+        'Mod-Shift--': () => call(runtime.insertHrCommand.key),
+        'Mod-z': () => call(runtime.undoCommand.key),
+        'Mod-Shift-z': () => call(runtime.redoCommand.key),
+        'Mod-y': () => call(runtime.redoCommand.key),
+      };
+
+      if (options.onLinkShortcut) {
+        bindings['Mod-k'] = () => {
+          options.onLinkShortcut?.();
+          return true;
+        };
+      }
+
+      if (options.onCommentShortcut) {
+        bindings['Ctrl-Alt-c'] = () => {
+          options.onCommentShortcut?.();
+          return true;
+        };
+      }
+
+      return bindings;
+    });
+
+    await shortcutPlugin(ctx)();
+  };
+
+  return keymapPlugin;
+}
+
+/**
+ * Default keyboard shortcuts (no external callbacks).
+ * @deprecated Use createEditorKeymap() for new code.
+ */
+export const editorKeymap = createEditorKeymap();
+
+/**
+ * Keyboard shortcut definitions for display in the UI.
+ * Uses platform-specific modifiers.
+ */
+export interface ShortcutDefinition {
+  action: string;
+  keys: string[];
+  /** macOS-specific display */
+  macKeys?: string[];
+}
+
+/**
+ * Convert a Mod-style shortcut to platform-specific display string.
+ *
+ * @param shortcut - Shortcut in Mod notation (e.g., "Mod-b", "Mod-Shift-k")
+ * @param isMac - Whether to use macOS symbols (defaults to detecting from navigator)
+ * @returns Display string (e.g., "⌘B" on Mac, "Ctrl+B" on Windows)
+ *
+ * @example
+ * getShortcutDisplay('Mod-b')         // "⌘B" on Mac, "Ctrl+B" on Windows
+ * getShortcutDisplay('Mod-Shift-s')   // "⌘⇧S" on Mac, "Ctrl+Shift+S" on Windows
+ */
+export function getShortcutDisplay(shortcut: string, isMac?: boolean): string {
+  // Detect platform if not specified (SSR-safe default to false)
+  const isMacPlatform =
+    isMac ?? (typeof navigator !== 'undefined' && /Mac|iPod|iPhone|iPad/.test(navigator.platform));
+
+  const parts = shortcut.split('-');
+
+  // Convert each part to display format
+  const displayParts = parts.map((part) => {
+    switch (part) {
+      case 'Mod':
+        return isMacPlatform ? '⌘' : 'Ctrl';
+      case 'Shift':
+        return isMacPlatform ? '⇧' : 'Shift';
+      case 'Alt':
+        return isMacPlatform ? '⌥' : 'Alt';
+      case 'Ctrl':
+        return isMacPlatform ? '⌃' : 'Ctrl';
+      default:
+        // Uppercase single letters, keep others as-is
+        return part.length === 1 ? part.toUpperCase() : part;
+    }
+  });
+
+  // Join with + for Windows, no separator for Mac (just symbols)
+  return isMacPlatform ? displayParts.join('') : displayParts.join('+');
+}
+
+/**
+ * Get keyboard shortcuts for the current platform.
+ */
+export function getShortcutDefinitions(isMac: boolean = false): ShortcutDefinition[] {
+  const mod = isMac ? '⌘' : 'Ctrl';
+  const alt = isMac ? '⌥' : 'Alt';
+  const shift = isMac ? '⇧' : 'Shift';
+
+  return [
+    { action: 'Bold', keys: [mod, 'B'] },
+    { action: 'Italic', keys: [mod, 'I'] },
+    { action: 'Inline Code', keys: [mod, 'E'] },
+    { action: 'Strikethrough', keys: [mod, shift, 'S'] },
+    { action: 'Link', keys: [mod, 'K'] },
+    { action: 'Heading 1', keys: [mod, alt, '1'] },
+    { action: 'Heading 2', keys: [mod, alt, '2'] },
+    { action: 'Heading 3', keys: [mod, alt, '3'] },
+    { action: 'Bullet List', keys: [mod, shift, '8'] },
+    { action: 'Ordered List', keys: [mod, shift, '7'] },
+    { action: 'Blockquote', keys: [mod, shift, '9'] },
+    { action: 'Indent', keys: ['Tab'] },
+    { action: 'Outdent', keys: [shift, 'Tab'] },
+    { action: 'Undo', keys: [mod, 'Z'] },
+    { action: 'Redo', keys: isMac ? [mod, shift, 'Z'] : [mod, 'Y'] },
+    // Suggestion shortcuts (DEP-43) - suggest-mode-specific
+    { action: 'Accept Suggestion (Suggest mode only)', keys: [mod, shift, 'Y'] },
+    { action: 'Reject Suggestion (Suggest mode only)', keys: [mod, shift, 'N'] },
+    // Comment shortcut (DEP-47) - review-mode-specific
+    { action: 'Add Comment (Comment mode only)', keys: ['Ctrl', alt, 'C'] },
+  ];
+}

--- a/packages/editor/src/link-input-rule.ts
+++ b/packages/editor/src/link-input-rule.ts
@@ -1,0 +1,37 @@
+/**
+ * Input rule for converting Markdown link syntax into a link mark.
+ */
+
+import { schemaCtx } from '@milkdown/kit/core';
+import { InputRule } from '@milkdown/kit/prose/inputrules';
+import { $inputRule } from '@milkdown/kit/utils';
+
+const linkInputRuleRegex = /(^|[^!])\[([^\]]+)\]\(([^)\s]+)\)$/;
+
+export const linkInputRulePlugin = $inputRule((ctx) => {
+  const schema = ctx.get(schemaCtx);
+  const linkMark = schema.marks['link'];
+
+  if (!linkMark) {
+    return new InputRule(/$^/, () => null);
+  }
+
+  return new InputRule(
+    linkInputRuleRegex,
+    (state, match, start, end) => {
+      const prefix = match[1] ?? '';
+      const text = match[2];
+      const url = match[3];
+
+      if (!text || !url) return null;
+
+      const startPos = start + prefix.length;
+      const mark = linkMark.create({ href: url });
+      const baseMarks = state.storedMarks ?? state.selection.$from.marks();
+      const marks = mark.addToSet(baseMarks);
+
+      return state.tr.replaceWith(startPos, end, state.schema.text(text, marks));
+    },
+    { inCodeMark: false },
+  );
+});

--- a/packages/editor/src/package-smoke.test.ts
+++ b/packages/editor/src/package-smoke.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'bun:test';
+
+import { contentEquals } from '@cinder/markdown/pipeline';
+
+import { createEditorAttachment, DEFAULT_DEBOUNCE_MS } from './index.js';
+
+describe('@cinder/editor package wiring', () => {
+  it('resolves @cinder/markdown through the workspace export map', () => {
+    expect(typeof contentEquals).toBe('function');
+  });
+
+  it('exports the editor attachment surface from the package barrel', () => {
+    expect(typeof createEditorAttachment).toBe('function');
+    expect(DEFAULT_DEBOUNCE_MS).toBe(300);
+  });
+});

--- a/packages/editor/src/placeholder-security.ts
+++ b/packages/editor/src/placeholder-security.ts
@@ -1,0 +1,37 @@
+/**
+ * Shared security constants for placeholder path validation and resolution.
+ *
+ * DEP-625: Prototype pollution prevention.
+ * DEP-617 learning: Security constants that enforce the same invariant across layers
+ * must live in one place and be imported where needed.
+ *
+ * @module
+ */
+
+/**
+ * Reserved segments that must never be resolved in placeholder paths.
+ *
+ * Accessing these property names can pollute prototypes, invoke built-in methods,
+ * or traverse the prototype chain in unexpected ways. All reserved segments are
+ * checked case-insensitively to prevent bypasses like `__PROTO__` or `Constructor`.
+ *
+ * This constant is shared across:
+ * - `template-placeholders.ts`: Runtime placeholder resolution
+ * - `applications/web/src/lib/validators/placeholder-path.ts`: Validation layer
+ * - `applications/web/src/lib/utilities/preview-composer.ts`: Preview rendering
+ */
+export const RESERVED_SEGMENTS = new Set([
+  '__proto__',
+  'constructor',
+  'prototype',
+  '__definegetter__',
+  '__definesetter__',
+  '__lookupgetter__',
+  '__lookupsetter__',
+  'hasownproperty',
+  'isprototypeof',
+  'propertyisenumerable',
+  'tostring',
+  'tolocalestring',
+  'valueof',
+]);

--- a/packages/editor/src/placeholder.ts
+++ b/packages/editor/src/placeholder.ts
@@ -1,0 +1,64 @@
+/**
+ * Placeholder plugin for Milkdown.
+ *
+ * Adds the `is-editor-empty` class to the first paragraph when the editor
+ * is empty, enabling CSS placeholder styling via ::before pseudo-element.
+ */
+
+import { Plugin, PluginKey } from '@milkdown/kit/prose/state';
+import { Decoration, DecorationSet } from '@milkdown/kit/prose/view';
+import { $prose } from '@milkdown/kit/utils';
+
+const placeholderPluginKey = new PluginKey('placeholder');
+
+/**
+ * Check if the document is considered "empty" for placeholder purposes.
+ * Empty means: single paragraph with no text content, or completely empty.
+ */
+function isDocumentEmpty(doc: import('@milkdown/kit/prose/model').Node): boolean {
+  // Document must have exactly one child
+  if (doc.childCount !== 1) return false;
+
+  const firstChild = doc.firstChild;
+  if (!firstChild) return true;
+
+  // First child must be a paragraph
+  if (firstChild.type.name !== 'paragraph') return false;
+
+  // Paragraph must be empty or contain only whitespace
+  return firstChild.textContent.trim().length === 0;
+}
+
+/**
+ * Create a Milkdown plugin that adds placeholder support.
+ *
+ * When the editor is empty (single empty paragraph), this adds the
+ * `is-editor-empty` class to the first paragraph, allowing CSS to
+ * display a placeholder via `::before` pseudo-element.
+ */
+export const placeholderPlugin = $prose(() => {
+  return new Plugin({
+    key: placeholderPluginKey,
+    props: {
+      decorations(state) {
+        const { doc } = state;
+
+        if (!isDocumentEmpty(doc)) {
+          return DecorationSet.empty;
+        }
+
+        const firstChild = doc.firstChild;
+        if (!firstChild) {
+          return DecorationSet.empty;
+        }
+
+        // Add the is-editor-empty class to the first paragraph
+        const decoration = Decoration.node(0, firstChild.nodeSize, {
+          class: 'is-editor-empty',
+        });
+
+        return DecorationSet.create(doc, [decoration]);
+      },
+    },
+  });
+});

--- a/packages/editor/src/sanitize-html.ts
+++ b/packages/editor/src/sanitize-html.ts
@@ -1,0 +1,152 @@
+/**
+ * HTML sanitization for clipboard paste (DEP-45, DEP-47).
+ *
+ * This is intentionally conservative:
+ * - Removes potentially dangerous tags (`script`, `iframe`, etc.)
+ * - Strips event handler attributes (`on*`)
+ * - Strips inline styles
+ * - Blocks unsafe URL protocols (`javascript:`, `data:` by default)
+ *
+ * @module
+ */
+
+export interface SanitizeHtmlOptions {
+  /**
+   * Allowed URL protocols for href/src-like attributes.
+   *
+   * Defaults to: http, https, mailto, tel
+   */
+  allowedProtocols?: ReadonlyArray<string>;
+
+  /**
+   * Allow `data:` URLs for images.
+   * Defaults to false (blocked).
+   */
+  allowDataUrlImages?: boolean;
+}
+
+const DEFAULT_ALLOWED_PROTOCOLS = ['http', 'https', 'mailto', 'tel'] as const;
+
+const DISALLOWED_TAGS = ['script', 'style', 'iframe', 'object', 'embed', 'link', 'meta'] as const;
+
+/**
+ * Return a safe URL value or null to indicate it should be removed.
+ */
+function sanitizeUrl(
+  rawUrl: string,
+  options: Required<SanitizeHtmlOptions>,
+  element: Element,
+  attributeName: string,
+): string | null {
+  const value = rawUrl.trim();
+  if (!value) return null;
+
+  // Allow hash and relative paths (including bare relative like "foo/bar").
+  if (
+    value.startsWith('#') ||
+    value.startsWith('/') ||
+    value.startsWith('./') ||
+    value.startsWith('../')
+  ) {
+    return value;
+  }
+
+  // Detect explicit protocol (scheme:)
+  const match = value.match(/^([a-zA-Z][a-zA-Z0-9+.-]*):/);
+  if (!match) {
+    // No protocol = treat as relative URL (safe).
+    return value;
+  }
+
+  const protocol = match[1]?.toLowerCase();
+  if (!protocol) return '';
+
+  // Allow specific protocols.
+  if (options.allowedProtocols.includes(protocol)) {
+    return value;
+  }
+
+  // Optionally allow data: URLs for <img src="data:..."> only.
+  if (
+    protocol === 'data' &&
+    options.allowDataUrlImages &&
+    attributeName === 'src' &&
+    element.tagName.toLowerCase() === 'img'
+  ) {
+    return value;
+  }
+
+  // Block everything else (javascript:, vbscript:, file:, data: by default, etc.).
+  return null;
+}
+
+/**
+ * Sanitize an HTML string.
+ *
+ * @param html - Raw clipboard HTML
+ * @param options - Optional sanitization configuration
+ * @returns Sanitized HTML suitable for ProseMirror DOM parsing
+ */
+export function sanitizeHtml(html: string, options: SanitizeHtmlOptions = {}): string {
+  if (!html) return '';
+
+  const resolvedOptions: Required<SanitizeHtmlOptions> = {
+    allowedProtocols: options.allowedProtocols ?? DEFAULT_ALLOWED_PROTOCOLS,
+    allowDataUrlImages: options.allowDataUrlImages ?? false,
+  };
+
+  // This is only used in the browser (clipboard paste). In non-DOM environments,
+  // fail closed and return an empty string to avoid accidental unsafe passthrough.
+  if (typeof DOMParser === 'undefined') {
+    return '';
+  }
+
+  const parser = new DOMParser();
+  const document = parser.parseFromString(html, 'text/html');
+
+  // Remove disallowed tags.
+  for (const tag of DISALLOWED_TAGS) {
+    document.querySelectorAll(tag).forEach((element) => element.remove());
+  }
+
+  // Strip unsafe attributes.
+  const elements = Array.from(document.body.querySelectorAll('*'));
+  for (const element of elements) {
+    // Copy attributes first since we'll mutate.
+    const attributes = Array.from(element.attributes);
+
+    for (const attribute of attributes) {
+      const name = attribute.name.toLowerCase();
+
+      // Remove event handlers (onclick, onload, …)
+      if (name.startsWith('on')) {
+        element.removeAttribute(attribute.name);
+        continue;
+      }
+
+      // Remove inline styles to avoid CSS-based tricks.
+      if (name === 'style') {
+        element.removeAttribute(attribute.name);
+        continue;
+      }
+
+      // Strip srcset completely (multiple URLs; easiest safe handling is removing).
+      if (name === 'srcset') {
+        element.removeAttribute(attribute.name);
+        continue;
+      }
+
+      // Sanitize common URL-bearing attributes.
+      if (name === 'href' || name === 'src' || name === 'xlink:href' || name === 'formaction') {
+        const sanitized = sanitizeUrl(attribute.value, resolvedOptions, element, name);
+        if (sanitized === null) {
+          element.removeAttribute(attribute.name);
+        } else {
+          element.setAttribute(attribute.name, sanitized);
+        }
+      }
+    }
+  }
+
+  return document.body.innerHTML;
+}

--- a/packages/editor/src/security.test.ts
+++ b/packages/editor/src/security.test.ts
@@ -1,0 +1,331 @@
+/**
+ * Security tests for Markdown editor.
+ * DEP-47: Verify XSS prevention in URL validation and understand HTML handling.
+ *
+ * IMPORTANT ARCHITECTURAL NOTE:
+ * The markdown parser (remark/unified) preserves raw HTML nodes in the AST.
+ * HTML sanitization happens at RENDER time through:
+ * 1. Svelte's auto-escaping when using {expression} (not @html)
+ * 2. ProseMirror's node schema (only allows whitelisted nodes)
+ * 3. Explicit sanitization for clipboard paste (sanitizeHtml)
+ *
+ * These tests verify:
+ * - URL validation (isSafeUrl) blocks XSS vectors
+ * - Protocol-based attacks are blocked
+ * - Entity encoding bypass attempts are blocked
+ * - Round-trip behavior is predictable
+ */
+
+import { parse, serialize } from '@cinder/markdown/pipeline';
+import { isSafeUrl, sanitizeUrl } from '@cinder/markdown/utilities/safe-url';
+import { describe, expect, it } from 'bun:test';
+
+describe('URL Safety - Protocol Attacks', () => {
+  describe('javascript: protocol', () => {
+    const javascriptVectors = [
+      'javascript:alert(1)',
+      'javascript:alert(document.cookie)',
+      'JAVASCRIPT:alert(1)',
+      'JaVaScRiPt:alert(1)',
+      'javascript\n:alert(1)',
+      'javascript\t:alert(1)',
+      'javascript\u0000:alert(1)',
+      'java\u0000script:alert(1)',
+      'java\u200bscript:alert(1)', // Zero-width space
+      'java\u200cscript:alert(1)', // Zero-width non-joiner
+      'java\u200dscript:alert(1)', // Zero-width joiner
+      'java\ufeffscript:alert(1)', // BOM
+      '&#106;&#97;&#118;&#97;&#115;&#99;&#114;&#105;&#112;&#116;:alert(1)', // Entity encoded
+      '&#x6A;&#x61;&#x76;&#x61;&#x73;&#x63;&#x72;&#x69;&#x70;&#x74;:alert(1)', // Hex entities
+    ];
+
+    it.each(javascriptVectors)('should block: %s', (vector) => {
+      expect(isSafeUrl(vector)).toBe(false);
+      expect(sanitizeUrl(vector)).toBe('');
+    });
+  });
+
+  describe('vbscript: protocol', () => {
+    const vbscriptVectors = [
+      'vbscript:msgbox(1)',
+      'VBSCRIPT:msgbox(1)',
+      'vbscript:Execute()',
+      'VbScRiPt:msgbox',
+    ];
+
+    it.each(vbscriptVectors)('should block: %s', (vector) => {
+      expect(isSafeUrl(vector)).toBe(false);
+    });
+  });
+
+  describe('data: protocol', () => {
+    const dataVectors = [
+      'data:text/html,<script>alert(1)</script>',
+      'data:text/html;base64,PHNjcmlwdD5hbGVydCgxKTwvc2NyaXB0Pg==',
+      'data:application/javascript,alert(1)',
+      'data:text/javascript,alert(1)',
+      'DATA:text/html,<script>alert(1)</script>',
+    ];
+
+    it.each(dataVectors)('should block XSS data: URLs: %s', (vector) => {
+      expect(isSafeUrl(vector)).toBe(false);
+    });
+
+    it('should allow safe image data: URLs when explicitly enabled', () => {
+      expect(isSafeUrl('data:image/png;base64,abc123', { allowDataImages: true })).toBe(true);
+      expect(isSafeUrl('data:image/jpeg;base64,abc123', { allowDataImages: true })).toBe(true);
+      expect(isSafeUrl('data:image/gif;base64,abc123', { allowDataImages: true })).toBe(true);
+      expect(isSafeUrl('data:image/webp;base64,abc123', { allowDataImages: true })).toBe(true);
+      expect(isSafeUrl('data:image/svg+xml;base64,abc123', { allowDataImages: true })).toBe(true);
+    });
+
+    it('should block image data: URLs by default', () => {
+      expect(isSafeUrl('data:image/png;base64,abc123')).toBe(false);
+    });
+  });
+
+  describe('file: protocol', () => {
+    const fileVectors = [
+      'file:///etc/passwd',
+      'file://localhost/etc/passwd',
+      'FILE:///C:/Windows/System32',
+      'file:///C:/Users/victim/Documents',
+    ];
+
+    it.each(fileVectors)('should block: %s', (vector) => {
+      expect(isSafeUrl(vector)).toBe(false);
+    });
+  });
+});
+
+describe('URL Safety - Allowed Protocols', () => {
+  describe('safe protocols', () => {
+    const safeUrls = [
+      'https://example.com',
+      'http://example.com',
+      'mailto:user@example.com',
+      'tel:+1234567890',
+      '/relative/path',
+      './current/relative',
+      '../parent/relative',
+      '#anchor',
+      '?query=value',
+    ];
+
+    it.each(safeUrls)('should allow: %s', (url) => {
+      expect(isSafeUrl(url)).toBe(true);
+    });
+  });
+
+  describe('blocked protocols', () => {
+    const blockedUrls = [
+      'javascript:void(0)',
+      'vbscript:execute',
+      'file:///path',
+      'ftp://example.com',
+      'gopher://example.com',
+      'ldap://example.com',
+      '//example.com', // Protocol-relative (ambiguous)
+      'example.com', // Bare hostname
+    ];
+
+    it.each(blockedUrls)('should block: %s', (url) => {
+      expect(isSafeUrl(url)).toBe(false);
+    });
+  });
+});
+
+describe('Null Byte and Control Character Injection', () => {
+  const nullByteVectors = ['java\x00script:alert(1)', 'javascript\x00:alert(1)'];
+
+  it.each(nullByteVectors)('should block null bytes in URLs: %s', (vector) => {
+    expect(isSafeUrl(vector)).toBe(false);
+  });
+
+  const controlCharVectors = [
+    'java\x01script:alert(1)',
+    'java\x02script:alert(1)',
+    'java\x0bscript:alert(1)',
+    'java\x0cscript:alert(1)',
+    'java\x1fscript:alert(1)',
+  ];
+
+  it.each(controlCharVectors)('should block control characters in URLs: %s', (vector) => {
+    expect(isSafeUrl(vector)).toBe(false);
+  });
+});
+
+describe('Markdown Link URL Validation', () => {
+  it('should handle javascript: links in markdown AST', () => {
+    const markdown = '[Click me](javascript:alert(1))';
+    const result = parse(markdown);
+
+    // Parser successfully parses the markdown
+    expect(result.success).toBe(true);
+
+    if (result.success) {
+      // Find the link node
+      const linkNode = result.ast.children[0];
+      expect(linkNode.type).toBe('paragraph');
+
+      // The URL in the AST should be validated before use
+      // This is done at render time, not parse time
+      const url = 'javascript:alert(1)';
+      expect(isSafeUrl(url)).toBe(false);
+      expect(sanitizeUrl(url)).toBe('');
+    }
+  });
+
+  it('should handle safe links in markdown', () => {
+    const markdown = '[Safe link](https://example.com)';
+    const result = parse(markdown);
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      const output = serialize(result.ast);
+      expect(output).toContain('https://example.com');
+      expect(isSafeUrl('https://example.com')).toBe(true);
+    }
+  });
+});
+
+describe('HTML in Markdown - Parser Behavior', () => {
+  /**
+   * NOTE: These tests document the parser's behavior, not security enforcement.
+   * The markdown parser preserves raw HTML in the AST. Security enforcement happens:
+   * 1. At render time (Svelte auto-escaping, ProseMirror schema)
+   * 2. Via clipboard paste sanitization (sanitizeHtml)
+   */
+
+  it('should parse raw HTML as HTML nodes', () => {
+    const markdown = '<script>alert(1)</script>';
+    const result = parse(markdown);
+
+    // Parser successfully parses
+    expect(result.success).toBe(true);
+
+    if (result.success) {
+      // HTML is preserved in AST (this is expected parser behavior)
+      const output = serialize(result.ast);
+      // The raw HTML is in the output - sanitization happens at render time
+      expect(output).toContain('<script>');
+    }
+  });
+
+  it('should preserve markdown structure around HTML', () => {
+    const markdown = '# Heading\n\nSafe text.\n\n<div>HTML block</div>';
+    const result = parse(markdown);
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      const output = serialize(result.ast);
+      expect(output).toContain('# Heading');
+      expect(output).toContain('Safe text.');
+    }
+  });
+
+  it('should handle inline code with suspicious content safely', () => {
+    const markdown = 'Check this: `<script>alert(1)</script>`';
+    const result = parse(markdown);
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      const output = serialize(result.ast);
+      // Content in backticks is safe (displayed as code, not executed)
+      expect(output).toContain('`<script>alert(1)</script>`');
+    }
+  });
+
+  it('should handle code blocks with suspicious content safely', () => {
+    const markdown = '```html\n<script>alert(1)</script>\n```';
+    const result = parse(markdown);
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      const output = serialize(result.ast);
+      // Content in code blocks is safe (displayed as code, not executed)
+      expect(output).toContain('<script>alert(1)</script>');
+    }
+  });
+});
+
+describe('Round-trip Behavior', () => {
+  it('should preserve safe markdown structures', () => {
+    const input = `# Heading
+
+Paragraph with **bold** and *italic*.
+
+- List item 1
+- List item 2
+
+\`\`\`javascript
+// Code is safe in code blocks
+const x = "<script>alert(1)</script>";
+\`\`\`
+
+[Link](https://example.com)
+`;
+
+    const result = parse(input);
+    expect(result.success).toBe(true);
+
+    if (result.success) {
+      const output = serialize(result.ast);
+
+      // Safe structures should be preserved
+      expect(output).toContain('# Heading');
+      expect(output).toContain('**bold**');
+      expect(output).toContain('*italic*');
+      expect(output).toContain('- List item');
+      expect(output).toContain('[Link](https://example.com)');
+    }
+  });
+
+  it('should be deterministic for the same input', () => {
+    const input = '# Test\n\nParagraph with [link](https://example.com).';
+
+    const result1 = parse(input);
+    const result2 = parse(input);
+
+    expect(result1.success).toBe(true);
+    expect(result2.success).toBe(true);
+
+    if (result1.success && result2.success) {
+      const output1 = serialize(result1.ast);
+      const output2 = serialize(result2.ast);
+      expect(output1).toBe(output2);
+    }
+  });
+});
+
+describe('URL Sanitization Integration', () => {
+  it('should provide sanitizeUrl for rendering layer', () => {
+    // This demonstrates how the rendering layer should use sanitizeUrl
+    const urls = [
+      { input: 'javascript:alert(1)', expected: '' },
+      { input: 'https://safe.com', expected: 'https://safe.com' },
+      { input: 'data:text/html,evil', expected: '' },
+      { input: '/relative/path', expected: '/relative/path' },
+    ];
+
+    for (const { input, expected } of urls) {
+      expect(sanitizeUrl(input)).toBe(expected);
+    }
+  });
+
+  it('should handle edge cases in URL validation', () => {
+    // Empty/whitespace
+    expect(isSafeUrl('')).toBe(false);
+    expect(isSafeUrl('   ')).toBe(false);
+    expect(isSafeUrl('\t\n')).toBe(false);
+
+    // Protocol variations
+    expect(isSafeUrl('HTTPS://EXAMPLE.COM')).toBe(true);
+    expect(isSafeUrl('Http://Example.Com')).toBe(true);
+
+    // Fragment and query
+    expect(isSafeUrl('#section-1')).toBe(true);
+    expect(isSafeUrl('?page=1&sort=asc')).toBe(true);
+    expect(isSafeUrl('/path?query=value#anchor')).toBe(true);
+  });
+});

--- a/packages/editor/src/ssr-import.test.ts
+++ b/packages/editor/src/ssr-import.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'bun:test';
+
+describe('@cinder/editor SSR import safety', () => {
+  it('imports the package barrel without needing browser globals', async () => {
+    const documentDescriptor = Object.getOwnPropertyDescriptor(globalThis, 'document');
+
+    try {
+      Reflect.deleteProperty(globalThis, 'document');
+      const editorModule = await import('./index.js');
+      expect(typeof editorModule.createEditor).toBe('function');
+      expect(typeof editorModule.destroyEditor).toBe('function');
+    } finally {
+      if (documentDescriptor) {
+        Object.defineProperty(globalThis, 'document', documentDescriptor);
+      }
+    }
+  });
+});

--- a/packages/editor/src/template-completion-plugin.test.ts
+++ b/packages/editor/src/template-completion-plugin.test.ts
@@ -1,0 +1,943 @@
+/* eslint-disable max-lines -- Comprehensive matrix for plugin state and async lifecycle regressions. */
+/**
+ * Tests for the template completion plugin internal logic.
+ *
+ * DEP-583: Validates filterAndSortCandidates, mergeCandidates, detectTokenQuery,
+ * and computeCompletionState using ProseMirror's model and state layers in Node.
+ * Async plugin view lifecycle coverage uses a minimal mocked document instead of
+ * a real DOM runtime.
+ */
+
+import { Schema } from '@milkdown/kit/prose/model';
+import type { Plugin } from '@milkdown/kit/prose/state';
+import { EditorState, TextSelection } from '@milkdown/kit/prose/state';
+import type { EditorView } from '@milkdown/kit/prose/view';
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+
+import {
+  computeCompletionState,
+  createTemplateCompletionPlugin,
+  detectTokenQuery,
+  filterAndSortCandidates,
+  findTokenEnd,
+  INACTIVE_STATE,
+  MAXIMUM_VISIBLE_SUGGESTIONS,
+  mergeCandidates,
+  templateCompletionPluginKey,
+} from './template-completion-plugin.js';
+import type { PlaceholderCandidate, PlaceholderCompletionConfiguration } from './types.js';
+
+// ---------------------------------------------------------------------------
+// Test schema
+// ---------------------------------------------------------------------------
+
+const schema = new Schema({
+  nodes: {
+    doc: { content: 'block+' },
+    paragraph: {
+      content: 'inline*',
+      group: 'block',
+      parseDOM: [{ tag: 'p' }],
+      toDOM() {
+        return ['p', 0];
+      },
+    },
+    text: { group: 'inline' },
+  },
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeCandidate(path: string, description?: string): PlaceholderCandidate {
+  return { path, description, valueKind: 'string' as const };
+}
+
+function makeCandidates(...paths: string[]): PlaceholderCandidate[] {
+  return paths.map((path) => makeCandidate(path));
+}
+
+/**
+ * Create an EditorState with a single paragraph containing the given text
+ * and the cursor positioned at the specified character offset within the
+ * paragraph content.
+ *
+ * When `cursorOffset` is omitted the selection defaults to the end of the
+ * document (ProseMirror's default).
+ */
+function createStateWithText(text: string, cursorOffset?: number): EditorState {
+  const doc = schema.node('doc', null, [
+    schema.node('paragraph', null, text ? [schema.text(text)] : []),
+  ]);
+  const state = EditorState.create({ doc, schema });
+
+  if (cursorOffset !== undefined) {
+    // Position = 1 (doc open) + cursorOffset (within paragraph content).
+    return state.apply(state.tr.setSelection(TextSelection.create(state.doc, 1 + cursorOffset)));
+  }
+
+  return state;
+}
+
+/**
+ * Create an EditorState with a non-collapsed (range) selection.
+ */
+function createStateWithSelection(text: string, from: number, to: number): EditorState {
+  const doc = schema.node('doc', null, [
+    schema.node('paragraph', null, text ? [schema.text(text)] : []),
+  ]);
+  const state = EditorState.create({ doc, schema });
+
+  return state.apply(state.tr.setSelection(TextSelection.create(state.doc, 1 + from, 1 + to)));
+}
+
+function createStateWithTextAndPlugins(
+  text: string,
+  cursorOffset: number,
+  plugins: readonly Plugin[],
+): EditorState {
+  const doc = schema.node('doc', null, [
+    schema.node('paragraph', null, text ? [schema.text(text)] : []),
+  ]);
+  const state = EditorState.create({ doc, schema, plugins: [...plugins] });
+
+  return state.apply(state.tr.setSelection(TextSelection.create(state.doc, 1 + cursorOffset)));
+}
+
+type MockElement = {
+  className: string;
+  style: Record<string, string>;
+  textContent: string;
+  parentElement: MockElement | null;
+  classList: { add: (...tokens: string[]) => void };
+  setAttribute: (name: string, value: string) => void;
+  appendChild: (child: MockElement) => MockElement;
+  removeChild: (child: MockElement) => MockElement;
+  addEventListener: () => void;
+  getBoundingClientRect: () => DOMRect;
+};
+
+function createMockElement(): MockElement {
+  const children: MockElement[] = [];
+  const attributes = new Map<string, string>();
+
+  const element: MockElement = {
+    className: '',
+    style: {},
+    textContent: '',
+    parentElement: null,
+    classList: {
+      add(...tokens: string[]) {
+        if (tokens.length === 0) return;
+        const existing = element.className ? element.className.split(/\s+/) : [];
+        element.className = [...new Set([...existing, ...tokens])].join(' ');
+      },
+    },
+    setAttribute(name: string, value: string) {
+      attributes.set(name, value);
+    },
+    appendChild(child: MockElement) {
+      child.parentElement = element;
+      children.push(child);
+      return child;
+    },
+    removeChild(child: MockElement) {
+      const index = children.indexOf(child);
+      if (index >= 0) {
+        children.splice(index, 1);
+        child.parentElement = null;
+      }
+      return child;
+    },
+    addEventListener() {},
+    getBoundingClientRect() {
+      return {
+        x: 0,
+        y: 0,
+        left: 0,
+        top: 0,
+        right: 0,
+        bottom: 0,
+        width: 0,
+        height: 0,
+        toJSON() {
+          return {};
+        },
+      } as DOMRect;
+    },
+  };
+
+  return element;
+}
+
+type CompletionHarness = {
+  view: EditorView;
+  pluginView: {
+    update?: (view: EditorView, previousState: EditorState) => void;
+    destroy?: () => void;
+  };
+  typeText: (text: string) => void;
+  getPluginState: () => ReturnType<typeof templateCompletionPluginKey.getState>;
+};
+
+async function createCompletionHarness(
+  configuration: PlaceholderCompletionConfiguration,
+  text = '{{',
+): Promise<CompletionHarness> {
+  const completionPlugin = createTemplateCompletionPlugin(() => configuration) as unknown as {
+    (ctx: {
+      wait: () => Promise<void>;
+      update: (slice: unknown, updater: (plugins: Plugin[]) => Plugin[]) => void;
+    }): () => Promise<unknown>;
+    plugin: () => Plugin;
+  };
+
+  const registeredPlugins: Plugin[] = [];
+  const initializePlugin = completionPlugin({
+    wait: async () => {},
+    update: (_slice, updater) => {
+      const updated = updater(registeredPlugins);
+      registeredPlugins.length = 0;
+      registeredPlugins.push(...updated);
+    },
+  });
+  await initializePlugin();
+
+  const prosePlugin = completionPlugin.plugin();
+  let state = createStateWithTextAndPlugins(text, text.length, [prosePlugin]);
+
+  let pluginView: CompletionHarness['pluginView'] = {};
+  const view = {
+    get state() {
+      return state;
+    },
+    set state(nextState: EditorState) {
+      state = nextState;
+    },
+    dom: {
+      parentElement: document.body,
+    },
+    dispatch(transaction) {
+      const previousState = state;
+      state = state.apply(transaction);
+      pluginView.update?.(view as unknown as EditorView, previousState);
+    },
+    coordsAtPos() {
+      return { left: 0, right: 0, top: 0, bottom: 0 };
+    },
+  };
+
+  pluginView = prosePlugin.spec.view?.(view as unknown as EditorView) ?? {};
+
+  return {
+    view: view as unknown as EditorView,
+    pluginView,
+    typeText(inputText: string) {
+      for (const character of inputText) {
+        const cursorPosition = state.selection.from;
+        const transaction = state.tr.insertText(character, cursorPosition, cursorPosition);
+        view.dispatch(transaction);
+      }
+    },
+    getPluginState() {
+      return templateCompletionPluginKey.getState(state);
+    },
+  };
+}
+
+async function flushMicrotasks(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+async function flushTimers(): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  await flushMicrotasks();
+}
+
+// ---------------------------------------------------------------------------
+// filterAndSortCandidates
+// ---------------------------------------------------------------------------
+
+describe('filterAndSortCandidates', () => {
+  const candidates = makeCandidates(
+    'input.name',
+    'input.age',
+    'input.address',
+    'output.result',
+    'output.error',
+    'config.timeout',
+    'config.retries',
+    'metadata.created',
+  );
+
+  it('filters by case-insensitive prefix match', () => {
+    const result = filterAndSortCandidates(candidates, 'INPUT');
+
+    expect(result.every((candidate) => candidate.path.startsWith('input.'))).toBe(true);
+    expect(result).toHaveLength(3);
+  });
+
+  it('sorts results lexicographically by path', () => {
+    const result = filterAndSortCandidates(candidates, 'input');
+    const paths = result.map((candidate) => candidate.path);
+
+    expect(paths).toEqual(['input.address', 'input.age', 'input.name']);
+  });
+
+  it('limits results to MAXIMUM_VISIBLE_SUGGESTIONS', () => {
+    // Create more candidates than the limit.
+    const manyCandidates = Array.from({ length: 20 }, (_, index) =>
+      makeCandidate(`field${String(index).padStart(2, '0')}`),
+    );
+
+    const result = filterAndSortCandidates(manyCandidates, 'field');
+
+    expect(result).toHaveLength(MAXIMUM_VISIBLE_SUGGESTIONS);
+  });
+
+  it('returns all candidates (up to max) when query is empty', () => {
+    const result = filterAndSortCandidates(candidates, '');
+
+    expect(result).toHaveLength(MAXIMUM_VISIBLE_SUGGESTIONS);
+    // Should be sorted lexicographically.
+    const paths = result.map((candidate) => candidate.path);
+    expect(paths).toEqual(paths.toSorted());
+  });
+
+  it('returns empty array when no candidates match', () => {
+    const result = filterAndSortCandidates(candidates, 'nonexistent');
+
+    expect(result).toEqual([]);
+  });
+
+  it('returns exact match when query matches a path exactly', () => {
+    const result = filterAndSortCandidates(candidates, 'input.name');
+
+    expect(result).toHaveLength(1);
+    expect(result[0].path).toBe('input.name');
+  });
+
+  it('matches partial path segments', () => {
+    const result = filterAndSortCandidates(candidates, 'config.t');
+
+    expect(result).toHaveLength(1);
+    expect(result[0].path).toBe('config.timeout');
+  });
+
+  it('returns empty array when candidates list is empty', () => {
+    const result = filterAndSortCandidates([], 'anything');
+
+    expect(result).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// mergeCandidates
+// ---------------------------------------------------------------------------
+
+describe('mergeCandidates', () => {
+  it('deduplicates by path with static candidates taking priority', () => {
+    const staticCandidates = [makeCandidate('input.name', 'Static description')];
+    const asyncCandidates = [makeCandidate('input.name', 'Async description')];
+
+    const merged = mergeCandidates(staticCandidates, asyncCandidates);
+
+    expect(merged).toHaveLength(1);
+    expect(merged[0].description).toBe('Static description');
+  });
+
+  it('appends unique async candidates after static ones', () => {
+    const staticCandidates = [makeCandidate('input.name')];
+    const asyncCandidates = [makeCandidate('input.age'), makeCandidate('input.address')];
+
+    const merged = mergeCandidates(staticCandidates, asyncCandidates);
+
+    expect(merged).toHaveLength(3);
+    expect(merged[0].path).toBe('input.name');
+    expect(merged[1].path).toBe('input.age');
+    expect(merged[2].path).toBe('input.address');
+  });
+
+  it('handles empty static and non-empty async candidates', () => {
+    const asyncCandidates = [makeCandidate('input.name'), makeCandidate('input.age')];
+
+    const merged = mergeCandidates([], asyncCandidates);
+
+    expect(merged).toHaveLength(2);
+    expect(merged).toEqual(asyncCandidates);
+  });
+
+  it('handles non-empty static and empty async candidates', () => {
+    const staticCandidates = [makeCandidate('input.name')];
+
+    const merged = mergeCandidates(staticCandidates, []);
+
+    expect(merged).toHaveLength(1);
+    expect(merged).toEqual(staticCandidates);
+  });
+
+  it('handles both empty', () => {
+    const merged = mergeCandidates([], []);
+
+    expect(merged).toEqual([]);
+  });
+
+  it('returns only static set when all async candidates are duplicates', () => {
+    const staticCandidates = [makeCandidate('a'), makeCandidate('b')];
+    const asyncCandidates = [makeCandidate('a'), makeCandidate('b')];
+
+    const merged = mergeCandidates(staticCandidates, asyncCandidates);
+
+    expect(merged).toHaveLength(2);
+    expect(merged[0].path).toBe('a');
+    expect(merged[1].path).toBe('b');
+  });
+
+  it('deduplicates within async candidates themselves', () => {
+    const asyncCandidates = [makeCandidate('a'), makeCandidate('a'), makeCandidate('b')];
+
+    const merged = mergeCandidates([], asyncCandidates);
+
+    expect(merged).toHaveLength(2);
+    expect(merged[0].path).toBe('a');
+    expect(merged[1].path).toBe('b');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// detectTokenQuery
+// ---------------------------------------------------------------------------
+
+describe('detectTokenQuery', () => {
+  it('detects cursor inside an open token', () => {
+    //           0123456
+    // Content: "{{inp"
+    // Cursor at end (offset 5) => inside open token.
+    const state = createStateWithText('{{inp', 5);
+    const result = detectTokenQuery(state);
+
+    expect(result).not.toBeNull();
+    expect(result!.query).toBe('inp');
+    // tokenFrom: doc content starts at 1, {{ at text offset 0, so tokenFrom = 1 + 0 = 1
+    expect(result!.tokenFrom).toBe(1);
+    // cursorPos: 1 + 5 = 6
+    expect(result!.cursorPos).toBe(6);
+  });
+
+  it('returns null when cursor is after a closed token', () => {
+    //           01234567890123
+    // Content: "{{input.name}}"
+    // Cursor at end (offset 14).
+    const state = createStateWithText('{{input.name}}', 14);
+    const result = detectTokenQuery(state);
+
+    expect(result).toBeNull();
+  });
+
+  it('returns null when there is no {{ before the cursor', () => {
+    const state = createStateWithText('plain text', 5);
+    const result = detectTokenQuery(state);
+
+    expect(result).toBeNull();
+  });
+
+  it('detects empty query when cursor is right after {{', () => {
+    // Content: "{{"
+    // Cursor at offset 2.
+    const state = createStateWithText('{{', 2);
+    const result = detectTokenQuery(state);
+
+    expect(result).not.toBeNull();
+    expect(result!.query).toBe('');
+  });
+
+  it('detects the second open token when a closed token precedes it', () => {
+    // Content: "{{a}} then {{b" (14 chars)
+    // Cursor at end (offset 14).
+    const state = createStateWithText('{{a}} then {{b', 14);
+    const result = detectTokenQuery(state);
+
+    expect(result).not.toBeNull();
+    expect(result!.query).toBe('b');
+    // The second {{ starts at text offset 11. tokenFrom = 1 + 11 = 12.
+    expect(result!.tokenFrom).toBe(12);
+  });
+
+  it('returns null for invalid query characters (hyphen)', () => {
+    // Content: "{{a-b"
+    // The query would be "a-b" which does not match VALID_QUERY_PATTERN.
+    const state = createStateWithText('{{a-b', 5);
+    const result = detectTokenQuery(state);
+
+    expect(result).toBeNull();
+  });
+
+  it('returns null for a non-collapsed (range) selection', () => {
+    const state = createStateWithSelection('{{input', 0, 5);
+    const result = detectTokenQuery(state);
+
+    expect(result).toBeNull();
+  });
+
+  it('returns null when cursor is positioned before the {{ in the text', () => {
+    // Content: "before {{query"
+    // Cursor at offset 3 (inside "before").
+    const state = createStateWithText('before {{query', 3);
+    const result = detectTokenQuery(state);
+
+    expect(result).toBeNull();
+  });
+
+  it('handles spaces in token by trimming the query', () => {
+    // Content: "{{ inp"
+    // The raw query is " inp", trimmed to "inp".
+    const state = createStateWithText('{{ inp', 6);
+    const result = detectTokenQuery(state);
+
+    expect(result).not.toBeNull();
+    expect(result!.query).toBe('inp');
+  });
+
+  it('handles dot-separated paths in query', () => {
+    const state = createStateWithText('{{input.na', 10);
+    const result = detectTokenQuery(state);
+
+    expect(result).not.toBeNull();
+    expect(result!.query).toBe('input.na');
+  });
+
+  it('returns null when {{ is followed by }} before cursor position', () => {
+    // Content: "{{done}} more text"
+    // Cursor at offset 13 (inside "more text").
+    const state = createStateWithText('{{done}} more text', 13);
+    const result = detectTokenQuery(state);
+
+    expect(result).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// findTokenEnd
+// ---------------------------------------------------------------------------
+
+describe('findTokenEnd', () => {
+  it('finds the end of a complete token when cursor is at the start', () => {
+    // Text: "{{input.name}}", tokenFrom = 1 (position of `{{`)
+    const state = createStateWithText('{{input.name}}', 0);
+    // tokenFrom is doc position 1 (1 = doc open + 0 for paragraph content start)
+    const result = findTokenEnd(state, 1);
+
+    // Should point past the closing `}}`
+    // `{{input.name}}` has length 14, so end = 1 + 14 = 15
+    expect(result).toBe(15);
+  });
+
+  it('finds the end of a complete token when cursor is in the middle', () => {
+    // Text: "{{input.name}}", tokenFrom = 1
+    // Simulates cursor mid-token (e.g., between `input.n` and `ame}}`).
+    const state = createStateWithText('{{input.name}}', 8);
+    const result = findTokenEnd(state, 1);
+
+    expect(result).toBe(15); // position after the final `}}`
+  });
+
+  it('returns null when there is no closing `}}`', () => {
+    // Text: "{{input.na" — no closing braces
+    const state = createStateWithText('{{input.na', 10);
+    const result = findTokenEnd(state, 1);
+
+    expect(result).toBeNull();
+  });
+
+  it('finds the first `}}` when multiple tokens exist in the block', () => {
+    // Text: "{{input.name}} and {{output.result}}"
+    // First token: positions 1..15 (`{{input.name}}`)
+    const state = createStateWithText('{{input.name}} and {{output.result}}', 0);
+    const result = findTokenEnd(state, 1);
+
+    // First `}}` is at offset 12 within the content after `{{` (offset 2),
+    // so result = 1 + 2 + 12 + 2 = 17... let's count:
+    // `{{input.name}}` = positions 1..14 in content, so doc pos 1+14=15.
+    expect(result).toBe(15);
+  });
+
+  it('finds the end of the second token in a block', () => {
+    // Text: "{{input.name}} and {{output.result}}"
+    // Second token `{{` is at text offset 19, doc position 1 + 19 = 20.
+    const state = createStateWithText('{{input.name}} and {{output.result}}', 0);
+    const result = findTokenEnd(state, 20);
+
+    // contentStart = 22, `output.result}}` has `}}` at index 13,
+    // so return = 22 + 13 + 2 = 37.
+    expect(result).toBe(37);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// computeCompletionState
+// ---------------------------------------------------------------------------
+
+describe('computeCompletionState', () => {
+  const candidates = makeCandidates('input.name', 'input.age', 'input.address', 'output.result');
+
+  const configuration: PlaceholderCompletionConfiguration = {
+    candidates,
+    minimumQueryLength: 1,
+  };
+
+  it('returns INACTIVE_STATE when configuration is undefined', () => {
+    const state = createStateWithText('{{inp', 5);
+    const transaction = state.tr;
+
+    const result = computeCompletionState(INACTIVE_STATE, transaction, state, undefined);
+
+    expect(result).toEqual(INACTIVE_STATE);
+  });
+
+  it('returns INACTIVE_STATE on meta close', () => {
+    const state = createStateWithText('{{inp', 5);
+    const transaction = state.tr.setMeta(templateCompletionPluginKey, { type: 'close' });
+
+    const result = computeCompletionState(
+      { ...INACTIVE_STATE, active: true, query: 'inp' },
+      transaction,
+      state,
+      configuration,
+    );
+
+    expect(result).toEqual(INACTIVE_STATE);
+  });
+
+  it('updates activeIndex on meta navigate', () => {
+    const previousState = {
+      active: true,
+      query: 'input',
+      suggestions: candidates.filter((c) => c.path.startsWith('input')),
+      activeIndex: 0,
+      tokenFrom: 1,
+      cursorPos: 8,
+    };
+    const state = createStateWithText('{{input', 7);
+    const transaction = state.tr.setMeta(templateCompletionPluginKey, {
+      type: 'navigate',
+      index: 2,
+    });
+
+    const result = computeCompletionState(previousState, transaction, state, configuration);
+
+    expect(result.activeIndex).toBe(2);
+    expect(result.active).toBe(true);
+  });
+
+  it('merges async results and re-filters on meta asyncResults', () => {
+    const previousState = {
+      active: true,
+      query: 'input',
+      suggestions: filterAndSortCandidates(candidates, 'input'),
+      activeIndex: 0,
+      tokenFrom: 1,
+      cursorPos: 8,
+    };
+    const asyncCandidates = [makeCandidate('input.email'), makeCandidate('input.phone')];
+    const state = createStateWithText('{{input', 7);
+    const transaction = state.tr.setMeta(templateCompletionPluginKey, {
+      type: 'asyncResults',
+      candidates: asyncCandidates,
+    });
+
+    const result = computeCompletionState(previousState, transaction, state, configuration);
+
+    expect(result.active).toBe(true);
+    // Should include original + new async candidates that match "input".
+    const paths = result.suggestions.map((s) => s.path);
+    expect(paths).toContain('input.email');
+    expect(paths).toContain('input.phone');
+    expect(paths).toContain('input.name');
+  });
+
+  it('returns INACTIVE_STATE when query is below minimumQueryLength', () => {
+    const configWithMinLength: PlaceholderCompletionConfiguration = {
+      candidates,
+      minimumQueryLength: 3,
+    };
+    // Query "in" has length 2, below the minimum of 3.
+    const state = createStateWithText('{{in', 4);
+    const transaction = state.tr;
+
+    const result = computeCompletionState(INACTIVE_STATE, transaction, state, configWithMinLength);
+
+    expect(result).toEqual(INACTIVE_STATE);
+  });
+
+  it('returns active state with filtered suggestions for a valid query', () => {
+    const state = createStateWithText('{{input', 7);
+    const transaction = state.tr;
+
+    const result = computeCompletionState(INACTIVE_STATE, transaction, state, configuration);
+
+    expect(result.active).toBe(true);
+    expect(result.query).toBe('input');
+    expect(result.suggestions.length).toBeGreaterThan(0);
+    expect(result.suggestions.every((s) => s.path.startsWith('input'))).toBe(true);
+  });
+
+  it('resets activeIndex to 0 when query changes', () => {
+    const previousState = {
+      active: true,
+      query: 'input.n',
+      suggestions: filterAndSortCandidates(candidates, 'input.n'),
+      activeIndex: 2,
+      tokenFrom: 1,
+      cursorPos: 10,
+    };
+    // Query changed from "input.n" to "input.a"
+    const state = createStateWithText('{{input.a', 9);
+    const transaction = state.tr;
+
+    const result = computeCompletionState(previousState, transaction, state, configuration);
+
+    expect(result.active).toBe(true);
+    expect(result.query).toBe('input.a');
+    expect(result.activeIndex).toBe(0);
+  });
+
+  it('preserves activeIndex when query has not changed', () => {
+    const previousState = {
+      active: true,
+      query: 'input',
+      suggestions: filterAndSortCandidates(candidates, 'input'),
+      activeIndex: 1,
+      tokenFrom: 1,
+      cursorPos: 8,
+    };
+    const state = createStateWithText('{{input', 7);
+    const transaction = state.tr;
+
+    const result = computeCompletionState(previousState, transaction, state, configuration);
+
+    expect(result.active).toBe(true);
+    expect(result.query).toBe('input');
+    expect(result.activeIndex).toBe(1);
+  });
+
+  it('returns INACTIVE_STATE when cursor is not inside a token', () => {
+    const state = createStateWithText('plain text', 5);
+    const transaction = state.tr;
+
+    const result = computeCompletionState(INACTIVE_STATE, transaction, state, configuration);
+
+    expect(result).toEqual(INACTIVE_STATE);
+  });
+
+  it('returns INACTIVE_STATE when no candidates match and no async lookup configured', () => {
+    const state = createStateWithText('{{zzzzz', 7);
+    const transaction = state.tr;
+
+    const result = computeCompletionState(INACTIVE_STATE, transaction, state, configuration);
+
+    expect(result).toEqual(INACTIVE_STATE);
+  });
+
+  it('returns active state with empty suggestions when async lookup is configured but no static matches', () => {
+    const configWithLookup: PlaceholderCompletionConfiguration = {
+      candidates,
+      minimumQueryLength: 1,
+      lookupCandidates: async () => [],
+    };
+    const state = createStateWithText('{{zzzzz', 7);
+    const transaction = state.tr;
+
+    const result = computeCompletionState(INACTIVE_STATE, transaction, state, configWithLookup);
+
+    expect(result.active).toBe(true);
+    expect(result.suggestions).toHaveLength(0);
+    expect(result.query).toBe('zzzzz');
+  });
+
+  it('clamps activeIndex when async results reduce the number of suggestions', () => {
+    const previousState = {
+      active: true,
+      query: 'input',
+      suggestions: filterAndSortCandidates(candidates, 'input'),
+      activeIndex: 2, // Points to 3rd suggestion.
+      tokenFrom: 1,
+      cursorPos: 8,
+    };
+
+    // Async results that only produce 1 total match after merge+filter.
+    const asyncCandidates: PlaceholderCandidate[] = [];
+    const configSingle: PlaceholderCompletionConfiguration = {
+      candidates: [makeCandidate('input.only')],
+      minimumQueryLength: 1,
+    };
+
+    const state = createStateWithText('{{input', 7);
+    const transaction = state.tr.setMeta(templateCompletionPluginKey, {
+      type: 'asyncResults',
+      candidates: asyncCandidates,
+    });
+
+    const result = computeCompletionState(previousState, transaction, state, configSingle);
+
+    // activeIndex should be clamped to suggestions.length - 1.
+    expect(result.activeIndex).toBeLessThanOrEqual(Math.max(0, result.suggestions.length - 1));
+  });
+
+  it('returns INACTIVE_STATE when asyncResults produces no suggestions', () => {
+    const previousState = {
+      active: true,
+      query: 'zzzzz',
+      suggestions: [],
+      activeIndex: 0,
+      tokenFrom: 1,
+      cursorPos: 8,
+    };
+
+    const configNoMatch: PlaceholderCompletionConfiguration = {
+      candidates: [],
+      minimumQueryLength: 1,
+    };
+
+    const state = createStateWithText('{{zzzzz', 7);
+    const transaction = state.tr.setMeta(templateCompletionPluginKey, {
+      type: 'asyncResults',
+      candidates: [makeCandidate('unrelated.path')],
+    });
+
+    const result = computeCompletionState(previousState, transaction, state, configNoMatch);
+
+    // "zzzzz" does not match "unrelated.path", so no suggestions after merge+filter.
+    expect(result).toEqual(INACTIVE_STATE);
+  });
+
+  it('uses default minimumQueryLength of 1 when not specified in configuration', () => {
+    const configNoMinLength: PlaceholderCompletionConfiguration = {
+      candidates,
+    };
+
+    // Single-char query "i" should be sufficient with default minimum of 1.
+    const state = createStateWithText('{{i', 3);
+    const transaction = state.tr;
+
+    const result = computeCompletionState(INACTIVE_STATE, transaction, state, configNoMinLength);
+
+    expect(result.active).toBe(true);
+    expect(result.query).toBe('i');
+    expect(result.suggestions.length).toBeGreaterThan(0);
+  });
+});
+
+describe('template completion async lookup lifecycle', () => {
+  const originalDocumentDescriptor = Object.getOwnPropertyDescriptor(globalThis, 'document');
+
+  beforeEach(() => {
+    const mockBody = createMockElement();
+    const mockDocument = {
+      body: mockBody,
+      createElement: () => createMockElement(),
+    } as unknown as Document;
+    Object.defineProperty(globalThis, 'document', {
+      value: mockDocument,
+      configurable: true,
+      writable: true,
+    });
+  });
+
+  afterEach(() => {
+    if (originalDocumentDescriptor) {
+      Object.defineProperty(globalThis, 'document', originalDocumentDescriptor);
+      return;
+    }
+    Reflect.deleteProperty(globalThis, 'document');
+  });
+
+  it('swallows aborted async lookup rejections without uncaught errors', async () => {
+    const abortedQueries: string[] = [];
+    const unhandledRejections: unknown[] = [];
+    const onUnhandledRejection = (reason: unknown) => {
+      unhandledRejections.push(reason);
+    };
+    process.on('unhandledRejection', onUnhandledRejection);
+
+    try {
+      const deferredResolutions = new Map<string, (value: PlaceholderCandidate[]) => void>();
+      const configuration: PlaceholderCompletionConfiguration = {
+        candidates: [],
+        minimumQueryLength: 1,
+        lookupDebounceMs: 0,
+        lookupCandidates: (query, signal) =>
+          new Promise<PlaceholderCandidate[]>((resolve, reject) => {
+            deferredResolutions.set(query, resolve);
+            signal.addEventListener(
+              'abort',
+              () => {
+                abortedQueries.push(query);
+                reject(new Error(`aborted:${query}`));
+              },
+              { once: true },
+            );
+          }),
+      };
+
+      const harness = await createCompletionHarness(configuration);
+
+      harness.typeText('a');
+      await flushTimers();
+
+      harness.typeText('b');
+      await flushTimers();
+
+      deferredResolutions.get('ab')?.([]);
+      await flushMicrotasks();
+
+      harness.pluginView.destroy?.();
+      await flushTimers();
+
+      expect(abortedQueries).toContain('a');
+      expect(unhandledRejections).toEqual([]);
+    } finally {
+      process.off('unhandledRejection', onUnhandledRejection);
+    }
+  });
+
+  it('keeps suggestions from the latest query when rapid typing causes overlapping lookups', async () => {
+    type DeferredLookup = {
+      resolve: (value: PlaceholderCandidate[]) => void;
+      signal: AbortSignal;
+    };
+    const deferredByQuery = new Map<string, DeferredLookup>();
+
+    const configuration: PlaceholderCompletionConfiguration = {
+      candidates: [],
+      minimumQueryLength: 1,
+      lookupDebounceMs: 0,
+      lookupCandidates: (query, signal) =>
+        new Promise<PlaceholderCandidate[]>((resolve) => {
+          deferredByQuery.set(query, { resolve, signal });
+        }),
+    };
+
+    const harness = await createCompletionHarness(configuration);
+    harness.typeText('a');
+    await flushTimers();
+
+    harness.typeText('b');
+    await flushTimers();
+
+    deferredByQuery.get('ab')?.resolve([makeCandidate('ab.latest')]);
+    await flushMicrotasks();
+
+    deferredByQuery.get('a')?.resolve([makeCandidate('a.stale')]);
+    await flushMicrotasks();
+
+    const pluginState = harness.getPluginState();
+
+    expect(deferredByQuery.get('a')?.signal.aborted).toBe(true);
+    expect(pluginState?.query).toBe('ab');
+    expect(pluginState?.suggestions.map((candidate) => candidate.path)).toEqual(['ab.latest']);
+
+    harness.pluginView.destroy?.();
+  });
+});

--- a/packages/editor/src/template-completion-plugin.ts
+++ b/packages/editor/src/template-completion-plugin.ts
@@ -1,0 +1,789 @@
+/**
+ * ProseMirror plugin for inline autocomplete of `{{…}}` template placeholder tokens.
+ *
+ * Shows a popup suggestion menu as the user types inside `{{…}}` tokens in the
+ * WYSIWYG editor. Supports both static candidates and async lookup with debouncing.
+ *
+ * The plugin integrates with Milkdown via `$prose` and communicates state changes
+ * through ProseMirror meta transactions on its plugin key.
+ *
+ * DEP-583: WYSIWYG placeholder completion for saved-prompt template authoring.
+ */
+
+import type { EditorState, Transaction } from '@milkdown/kit/prose/state';
+import { Plugin, PluginKey, TextSelection } from '@milkdown/kit/prose/state';
+import type { EditorView } from '@milkdown/kit/prose/view';
+import { $prose } from '@milkdown/kit/utils';
+
+import { textOffsetToBlockDocumentPosition } from './template-position-utilities.js';
+import type { PlaceholderCandidate, PlaceholderCompletionConfiguration } from './types.js';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Constants
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** @internal Exported for testing only. */
+export const MAXIMUM_VISIBLE_SUGGESTIONS = 8;
+
+/** Default minimum query length before showing suggestions. */
+const DEFAULT_MINIMUM_QUERY_LENGTH = 1;
+
+/** Default debounce interval for async lookup calls (ms). */
+const DEFAULT_LOOKUP_DEBOUNCE_MS = 150;
+
+/**
+ * Pattern for valid placeholder path prefixes.
+ * Allows letters, digits, underscores, and dots (partial paths like "input.na").
+ */
+const VALID_QUERY_PATTERN = /^[a-zA-Z0-9_.]*$/;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Plugin key (exported for external state inspection)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** Plugin key for the template completion plugin. */
+export const templateCompletionPluginKey = new PluginKey<CompletionState>('template-completion');
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Completion state
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Internal state tracked by the completion plugin across transactions.
+ *
+ * @internal Exported for testing only.
+ */
+export interface CompletionState {
+  /** Whether the completion menu is currently active. */
+  active: boolean;
+  /** The current query string (text between `{{` and cursor, trimmed). */
+  query: string;
+  /** Filtered and sorted suggestions for the current query. */
+  suggestions: PlaceholderCandidate[];
+  /** Index of the currently highlighted suggestion (0-based). */
+  activeIndex: number;
+  /** ProseMirror document position where the `{{` token starts. */
+  tokenFrom: number;
+  /** ProseMirror document position of the cursor (for popup positioning). */
+  cursorPos: number;
+}
+
+/** @internal Exported for testing only. */
+export const INACTIVE_STATE: CompletionState = {
+  active: false,
+  query: '',
+  suggestions: [],
+  activeIndex: 0,
+  tokenFrom: 0,
+  cursorPos: 0,
+};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Meta transaction types
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Meta payload shapes dispatched on `templateCompletionPluginKey`.
+ *
+ * @internal Exported for testing only.
+ */
+export type CompletionMeta =
+  | { type: 'close' }
+  | { type: 'navigate'; index: number }
+  | { type: 'asyncResults'; candidates: PlaceholderCandidate[] };
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function isCompletionMeta(value: unknown): value is CompletionMeta {
+  if (!isRecord(value)) return false;
+
+  if (value['type'] === 'close') return true;
+  if (value['type'] === 'navigate') return typeof value['index'] === 'number';
+  if (value['type'] === 'asyncResults') return Array.isArray(value['candidates']);
+  return false;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Query detection
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Detect whether the cursor is inside an in-progress `{{…}}` token.
+ *
+ * Uses `doc.textBetween` to derive pre-cursor text so that inline atom nodes
+ * (hard_break, images, etc.) are correctly excluded from the text coordinate
+ * space. This prevents `$from.parentOffset` — which counts atom nodeSize —
+ * from diverging from the plain-text index into `textContent`.
+ *
+ * @internal Exported for testing only.
+ *
+ * @returns An object with the query text and token start position, or `null`
+ *   if the cursor is not inside an open placeholder token.
+ */
+export function detectTokenQuery(
+  state: EditorState,
+): { query: string; tokenFrom: number; cursorPos: number } | null {
+  const { $from } = state.selection;
+  const cursorPos = state.selection.from;
+
+  // Must be a cursor (collapsed selection)
+  if (state.selection.from !== state.selection.to) return null;
+
+  // Get the parent text block
+  const parentNode = $from.parent;
+  if (!parentNode.isTextblock) return null;
+
+  const blockContentStart = $from.start();
+  const blockContentEnd = $from.end();
+
+  // Use textBetween to collect the block's text correctly. Unlike
+  // `parentNode.textContent.slice(0, $from.parentOffset)`, this approach
+  // treats inline atoms (hard_break, images) as having zero text length,
+  // keeping the text-offset coordinate system consistent with textContent.
+  const textBeforeCursor = state.doc.textBetween(blockContentStart, cursorPos);
+  const fullText = state.doc.textBetween(blockContentStart, blockContentEnd);
+
+  // Find the last occurrence of `{{` before the cursor
+  const openIndex = textBeforeCursor.lastIndexOf('{{');
+  if (openIndex === -1) return null;
+
+  // Check for a closing `}}` between `{{` and the cursor
+  const textBetween = textBeforeCursor.slice(openIndex + 2);
+  if (textBetween.includes('}}')) return null;
+
+  // Also check if the full block text has `}}` right at/after cursor position
+  // that would indicate a completed token
+  const textAfterOpen = fullText.slice(openIndex + 2);
+  const closingIndex = textAfterOpen.indexOf('}}');
+  if (closingIndex !== -1 && closingIndex < textBeforeCursor.length - openIndex - 2) {
+    // The `}}` is before the cursor in the text, so the token is complete
+    return null;
+  }
+
+  // Extract and trim the query
+  const rawQuery = textBeforeCursor.slice(openIndex + 2);
+  const query = rawQuery.trim();
+
+  // Validate query characters
+  if (!VALID_QUERY_PATTERN.test(query)) return null;
+
+  // Convert the text-coordinate `openIndex` to an absolute document position
+  // by walking the block's children, counting text characters to skip atoms.
+  const tokenFrom = textOffsetToBlockDocumentPosition(parentNode, blockContentStart, openIndex);
+
+  return { query, tokenFrom, cursorPos };
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Filtering and sorting
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Filter candidates by case-insensitive prefix match and sort lexicographically.
+ *
+ * @internal Exported for testing only.
+ *
+ * @param candidates - All available candidates.
+ * @param query - The query to match against candidate paths.
+ * @returns Filtered and sorted candidates, limited to {@link MAXIMUM_VISIBLE_SUGGESTIONS}.
+ */
+export function filterAndSortCandidates(
+  candidates: PlaceholderCandidate[],
+  query: string,
+): PlaceholderCandidate[] {
+  const lowerQuery = query.toLowerCase();
+
+  return candidates
+    .filter((candidate) => candidate.path.toLowerCase().startsWith(lowerQuery))
+    .toSorted((a, b) => a.path.localeCompare(b.path))
+    .slice(0, MAXIMUM_VISIBLE_SUGGESTIONS);
+}
+
+/**
+ * Merge static and async candidates, deduplicating by path.
+ *
+ * Static candidates take priority when paths overlap.
+ *
+ * @internal Exported for testing only.
+ *
+ * @param staticCandidates - Candidates from the static configuration.
+ * @param asyncCandidates - Candidates from the async lookup.
+ * @returns Merged candidate array with duplicates removed.
+ */
+export function mergeCandidates(
+  staticCandidates: PlaceholderCandidate[],
+  asyncCandidates: PlaceholderCandidate[],
+): PlaceholderCandidate[] {
+  const seen = new Set(staticCandidates.map((candidate) => candidate.path));
+  const merged = [...staticCandidates];
+
+  for (const candidate of asyncCandidates) {
+    if (!seen.has(candidate.path)) {
+      seen.add(candidate.path);
+      merged.push(candidate);
+    }
+  }
+
+  return merged;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Suggestion acceptance
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Find the end position of the complete `{{…}}` token starting at `tokenFrom`.
+ *
+ * Scans forward from `tokenFrom + 2` (past the opening `{{`) to find the first
+ * `}}` within the document, stopping at the end of the current text block.
+ *
+ * The closing `}}` position is computed by walking the block's inline children
+ * rather than treating the text-string index of `}}` as a document-position
+ * offset. When inline atom nodes (such as `hard_break`) exist between
+ * `tokenFrom` and `}}`, the text string is shorter than the document-position
+ * span because atoms contribute zero text characters but occupy document
+ * positions. Using the raw text index as a doc offset would return a position
+ * that is too low, causing `acceptSuggestion` to leave trailing characters
+ * behind.
+ *
+ * @param state - The current ProseMirror editor state.
+ * @param tokenFrom - The document position where `{{` starts.
+ * @returns The document position immediately after the closing `}}`, or `null`
+ *   if no closing `}}` is found within the current block.
+ *
+ * @internal Exported for testing only.
+ */
+export function findTokenEnd(state: EditorState, tokenFrom: number): number | null {
+  const $tokenFrom = state.doc.resolve(tokenFrom);
+  const blockContentStart = $tokenFrom.start();
+  const blockEnd = $tokenFrom.end();
+  const parentNode = $tokenFrom.parent;
+
+  const contentStart = tokenFrom + 2; // skip past `{{`
+  if (contentStart >= blockEnd) return null;
+
+  // textBetween treats atom nodes as empty strings, so the returned string
+  // may be shorter than the document-position span when atoms are present.
+  // We use this only to locate the `}}` in text space.
+  const textFromContentStart = state.doc.textBetween(contentStart, blockEnd);
+  const closingIndex = textFromContentStart.indexOf('}}');
+  if (closingIndex === -1) return null;
+
+  // closingIndex is a text-string index within [contentStart, blockEnd].
+  // Convert it to an absolute document position by expressing it as a
+  // text-coordinate offset from blockContentStart, then using the shared
+  // walker that correctly accounts for atom-node document sizes.
+  const textUpToContentStart = state.doc.textBetween(blockContentStart, contentStart);
+  const closingTextOffset = textUpToContentStart.length + closingIndex;
+  const closingDocPos = textOffsetToBlockDocumentPosition(
+    parentNode,
+    blockContentStart,
+    closingTextOffset,
+  );
+
+  // closingDocPos is the position of the first `}`. The closing `}}` occupies
+  // two text characters (no atoms), so the end of the token is +2.
+  return closingDocPos + 2;
+}
+
+/**
+ * Accept a suggestion by replacing the entire `{{…}}` token with the completed placeholder.
+ *
+ * Finds the full extent of the token (from `{{` to the matching `}}`, if present)
+ * and replaces it with `{{path}}`, then positions the cursor after the closing braces.
+ * When the caret is in the middle of an existing token (e.g., `{{input.n|ame}}`),
+ * the entire token including the suffix is replaced, preventing partial-suffix corruption.
+ *
+ * @param view - The ProseMirror editor view.
+ * @param suggestion - The candidate to accept.
+ * @param tokenFrom - The document position where `{{` starts.
+ */
+function acceptSuggestion(
+  view: EditorView,
+  suggestion: PlaceholderCandidate,
+  tokenFrom: number,
+): void {
+  const replacementText = `{{${suggestion.path}}}`;
+  const { state } = view;
+  const cursorPos = state.selection.from;
+
+  // Scan forward from the token start to find the full `{{…}}` extent.
+  // This handles the case where the cursor is in the middle of an existing
+  // token (e.g., `{{input.n|ame}}`), replacing the whole token rather than
+  // leaving the suffix behind.
+  const fullTokenEnd = findTokenEnd(state, tokenFrom);
+  const tokenTo = fullTokenEnd ?? cursorPos;
+
+  const transaction = state.tr
+    .replaceWith(tokenFrom, tokenTo, state.schema.text(replacementText))
+    .setMeta(templateCompletionPluginKey, { type: 'close' } satisfies CompletionMeta);
+
+  // Place cursor after the replacement text
+  const newCursorPos = tokenFrom + replacementText.length;
+  transaction.setSelection(TextSelection.create(transaction.doc, newCursorPos));
+
+  view.dispatch(transaction);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// DOM popup
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Create the popup container element for the suggestion menu.
+ *
+ * @returns A positioned, hidden `<div>` with `role="listbox"`.
+ */
+function createPopupElement(): HTMLElement {
+  const popup = document.createElement('div');
+  popup.className = 'template-completion-popup';
+  popup.setAttribute('role', 'listbox');
+  popup.style.position = 'absolute';
+  popup.style.zIndex = '50';
+  popup.style.display = 'none';
+  return popup;
+}
+
+/**
+ * Render suggestion items into the popup element.
+ *
+ * Each suggestion is a `<div role="option">` containing the path and optional
+ * description. Click handlers accept the clicked suggestion.
+ *
+ * @param popup - The popup container element.
+ * @param completionState - Current completion state with suggestions and active index.
+ * @param view - The ProseMirror editor view (for dispatching acceptance).
+ */
+function renderSuggestions(
+  popup: HTMLElement,
+  completionState: CompletionState,
+  view: EditorView,
+): void {
+  // Clear existing children
+  popup.textContent = '';
+
+  const { suggestions, activeIndex, tokenFrom } = completionState;
+
+  for (let index = 0; index < suggestions.length; index++) {
+    const candidate = suggestions[index];
+    if (!candidate) continue;
+
+    const item = document.createElement('div');
+    item.setAttribute('role', 'option');
+    item.setAttribute('aria-selected', String(index === activeIndex));
+    item.className = 'template-completion-item';
+
+    if (index === activeIndex) {
+      item.classList.add('template-completion-item--active');
+    }
+
+    // Path label
+    const pathLabel = document.createElement('span');
+    pathLabel.className = 'template-completion-item-path';
+    pathLabel.textContent = candidate.path;
+    item.appendChild(pathLabel);
+
+    // Description and value kind (secondary text)
+    if (candidate.description || candidate.valueKind !== 'unknown') {
+      const secondary = document.createElement('span');
+      secondary.className = 'template-completion-item-description';
+
+      const parts: string[] = [];
+      if (candidate.valueKind && candidate.valueKind !== 'unknown') {
+        parts.push(candidate.valueKind);
+      }
+      if (candidate.description) {
+        parts.push(candidate.description);
+      }
+      secondary.textContent = parts.join(' — ');
+      item.appendChild(secondary);
+    }
+
+    // Click handler to accept this suggestion
+    item.addEventListener('mousedown', (event) => {
+      // Prevent the editor from losing focus
+      event.preventDefault();
+      event.stopPropagation();
+      acceptSuggestion(view, candidate, tokenFrom);
+    });
+
+    popup.appendChild(item);
+  }
+}
+
+/**
+ * Position the popup element near the cursor using ProseMirror coordinates.
+ *
+ * Places the popup below the cursor line, aligned to the cursor's horizontal position.
+ *
+ * @param popup - The popup container element.
+ * @param view - The ProseMirror editor view.
+ * @param cursorPos - The document position to anchor the popup to.
+ */
+function positionPopup(popup: HTMLElement, view: EditorView, cursorPos: number): void {
+  const coordinates = view.coordsAtPos(cursorPos);
+  const parentElement = popup.parentElement;
+  if (!parentElement) return;
+
+  const parentRect = parentElement.getBoundingClientRect();
+
+  popup.style.left = `${coordinates.left - parentRect.left}px`;
+  popup.style.top = `${coordinates.bottom - parentRect.top + 4}px`;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// State computation
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Compute the next completion state from a transaction.
+ *
+ * Handles meta-driven updates (close, navigate, asyncResults) and recomputes
+ * the token query and suggestions on each document/selection change.
+ *
+ * @internal Exported for testing only.
+ *
+ * @param previousState - The completion state before this transaction.
+ * @param transaction - The ProseMirror transaction being applied.
+ * @param editorState - The new ProseMirror editor state after the transaction.
+ * @param configuration - The current placeholder completion configuration.
+ * @returns The updated completion state.
+ */
+export function computeCompletionState(
+  previousState: CompletionState,
+  transaction: Transaction,
+  editorState: EditorState,
+  configuration: PlaceholderCompletionConfiguration | undefined,
+): CompletionState {
+  // If disabled, always return inactive
+  if (!configuration) return INACTIVE_STATE;
+
+  // Check for meta-driven updates
+  const rawMeta: unknown = transaction.getMeta(templateCompletionPluginKey);
+  const meta = isCompletionMeta(rawMeta) ? rawMeta : undefined;
+
+  if (meta) {
+    if (meta.type === 'close') {
+      return INACTIVE_STATE;
+    }
+
+    if (meta.type === 'navigate') {
+      return { ...previousState, activeIndex: meta.index };
+    }
+
+    if (meta.type === 'asyncResults') {
+      // Merge async results with static candidates, re-filter, and re-sort
+      const merged = mergeCandidates(configuration.candidates, meta.candidates);
+      const suggestions = filterAndSortCandidates(merged, previousState.query);
+      const activeIndex = Math.min(previousState.activeIndex, Math.max(0, suggestions.length - 1));
+
+      if (suggestions.length === 0) {
+        return INACTIVE_STATE;
+      }
+
+      return { ...previousState, suggestions, activeIndex };
+    }
+  }
+
+  // Detect if the cursor is inside an open `{{…}}` token
+  const detected = detectTokenQuery(editorState);
+
+  if (!detected) {
+    return INACTIVE_STATE;
+  }
+
+  const { query, tokenFrom, cursorPos } = detected;
+  const minimumQueryLength = configuration.minimumQueryLength ?? DEFAULT_MINIMUM_QUERY_LENGTH;
+
+  // Query too short — close menu
+  if (query.length < minimumQueryLength) {
+    return INACTIVE_STATE;
+  }
+
+  // Filter and sort candidates
+  const suggestions = filterAndSortCandidates(configuration.candidates, query);
+
+  if (suggestions.length === 0) {
+    // Keep menu active with empty suggestions if async lookup is configured
+    // (async results may arrive later). Otherwise, close.
+    if (!configuration.lookupCandidates) {
+      return INACTIVE_STATE;
+    }
+
+    return {
+      active: true,
+      query,
+      suggestions: [],
+      activeIndex: 0,
+      tokenFrom,
+      cursorPos,
+    };
+  }
+
+  // Preserve active index when query hasn't changed, reset otherwise
+  const activeIndex =
+    previousState.active && previousState.query === query
+      ? Math.min(previousState.activeIndex, suggestions.length - 1)
+      : 0;
+
+  return {
+    active: true,
+    query,
+    suggestions,
+    activeIndex,
+    tokenFrom,
+    cursorPos,
+  };
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Plugin factory
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Create a Milkdown plugin that provides inline autocomplete for `{{…}}` template tokens.
+ *
+ * The plugin watches the cursor position, detects when it is inside an in-progress
+ * placeholder token, filters available candidates, and shows a positioned popup with
+ * suggestions. Keyboard navigation (ArrowUp/Down, Enter, Tab, Escape) and mouse
+ * clicks interact with the popup.
+ *
+ * The factory accepts a getter function so the configuration can change at runtime
+ * (e.g., when the candidate set is recomputed from a new JSON Schema) without
+ * recreating the plugin.
+ *
+ * @param getConfiguration - Returns the current completion configuration, or
+ *   `undefined` to disable the popup entirely.
+ * @returns A Milkdown-compatible plugin created via `$prose`.
+ *
+ * @example
+ * ```typescript
+ * const plugin = createTemplateCompletionPlugin(() => ({
+ *   candidates: [
+ *     { path: 'input.name', description: 'User name', valueKind: 'string' },
+ *     { path: 'input.age', description: 'User age', valueKind: 'number' },
+ *   ],
+ * }));
+ * ```
+ */
+export function createTemplateCompletionPlugin(
+  getConfiguration: () => PlaceholderCompletionConfiguration | undefined,
+): ReturnType<typeof $prose> {
+  return $prose(() => {
+    return new Plugin<CompletionState>({
+      key: templateCompletionPluginKey,
+
+      // ─────────────────────────────────────────────────────────────────────
+      // State field: compute completion state on each transaction
+      // ─────────────────────────────────────────────────────────────────────
+
+      state: {
+        init(): CompletionState {
+          return INACTIVE_STATE;
+        },
+
+        apply(transaction, previousState, _oldEditorState, newEditorState): CompletionState {
+          return computeCompletionState(
+            previousState,
+            transaction,
+            newEditorState,
+            getConfiguration(),
+          );
+        },
+      },
+
+      // ─────────────────────────────────────────────────────────────────────
+      // Props: keyboard interception when the menu is open
+      // ─────────────────────────────────────────────────────────────────────
+
+      props: {
+        handleKeyDown(view, event): boolean {
+          const pluginState = templateCompletionPluginKey.getState(view.state);
+          if (!pluginState?.active) {
+            // Menu is not open — let all keys pass through
+            return false;
+          }
+
+          const { suggestions, activeIndex, tokenFrom } = pluginState;
+
+          switch (event.key) {
+            case 'ArrowDown': {
+              if (suggestions.length === 0) return false;
+              const nextIndex = (activeIndex + 1) % suggestions.length;
+              view.dispatch(
+                view.state.tr.setMeta(templateCompletionPluginKey, {
+                  type: 'navigate',
+                  index: nextIndex,
+                } satisfies CompletionMeta),
+              );
+              event.preventDefault();
+              return true;
+            }
+
+            case 'ArrowUp': {
+              if (suggestions.length === 0) return false;
+              const previousIndex = (activeIndex - 1 + suggestions.length) % suggestions.length;
+              view.dispatch(
+                view.state.tr.setMeta(templateCompletionPluginKey, {
+                  type: 'navigate',
+                  index: previousIndex,
+                } satisfies CompletionMeta),
+              );
+              event.preventDefault();
+              return true;
+            }
+
+            case 'Enter': {
+              if (suggestions.length === 0) return false;
+              const selected = suggestions[activeIndex];
+              if (selected) {
+                acceptSuggestion(view, selected, tokenFrom);
+                event.preventDefault();
+                return true;
+              }
+              return false;
+            }
+
+            case 'Tab': {
+              // Accept active suggestion when menu is open with suggestions.
+              // When menu is NOT open, this returns false above (before the switch).
+              if (suggestions.length === 0) return false;
+              const tabSelected = suggestions[activeIndex];
+              if (tabSelected) {
+                acceptSuggestion(view, tabSelected, tokenFrom);
+                event.preventDefault();
+                return true;
+              }
+              return false;
+            }
+
+            case 'Escape': {
+              view.dispatch(
+                view.state.tr.setMeta(templateCompletionPluginKey, {
+                  type: 'close',
+                } satisfies CompletionMeta),
+              );
+              event.preventDefault();
+              return true;
+            }
+
+            default:
+              return false;
+          }
+        },
+      },
+
+      // ─────────────────────────────────────────────────────────────────────
+      // View: manage DOM popup and async lookup lifecycle
+      // ─────────────────────────────────────────────────────────────────────
+
+      view(editorView) {
+        // Create the popup element and append it to the editor's parent
+        const popup = createPopupElement();
+        const parentElement = editorView.dom.parentElement ?? document.body;
+        parentElement.appendChild(popup);
+
+        // Async lookup state
+        let currentAbortController: AbortController | null = null;
+        let debounceTimeout: ReturnType<typeof setTimeout> | null = null;
+
+        /**
+         * Update popup visibility, content, and position based on current state.
+         */
+        function updatePopup(view: EditorView): void {
+          const pluginState = templateCompletionPluginKey.getState(view.state);
+
+          if (!pluginState?.active || pluginState.suggestions.length === 0) {
+            popup.style.display = 'none';
+            return;
+          }
+
+          popup.style.display = '';
+          renderSuggestions(popup, pluginState, view);
+          positionPopup(popup, view, pluginState.cursorPos);
+        }
+
+        /**
+         * Cancel any pending async lookup.
+         */
+        function cancelAsyncLookup(): void {
+          currentAbortController?.abort();
+          currentAbortController = null;
+          if (debounceTimeout !== null) {
+            clearTimeout(debounceTimeout);
+            debounceTimeout = null;
+          }
+        }
+
+        // Initial render
+        updatePopup(editorView);
+
+        return {
+          update(view, previousEditorState) {
+            const pluginState = templateCompletionPluginKey.getState(view.state);
+            const previousPluginState = templateCompletionPluginKey.getState(previousEditorState);
+
+            // If menu closed, cancel any pending async lookup
+            if (!pluginState?.active) {
+              cancelAsyncLookup();
+              updatePopup(view);
+              return;
+            }
+
+            // If the query changed, trigger a new async lookup (if configured)
+            if (pluginState.active && pluginState.query !== previousPluginState?.query) {
+              cancelAsyncLookup();
+
+              const configuration = getConfiguration();
+              if (configuration?.lookupCandidates) {
+                const abortController = new AbortController();
+                currentAbortController = abortController;
+
+                const lookupDebounceMs =
+                  configuration.lookupDebounceMs ?? DEFAULT_LOOKUP_DEBOUNCE_MS;
+
+                debounceTimeout = setTimeout(async () => {
+                  debounceTimeout = null;
+                  try {
+                    const asyncResults = await configuration.lookupCandidates!(
+                      pluginState.query,
+                      abortController.signal,
+                    );
+
+                    // Abort controller may have been replaced since the lookup started
+                    if (abortController.signal.aborted) return;
+
+                    // Dispatch async results into the plugin state
+                    view.dispatch(
+                      view.state.tr.setMeta(templateCompletionPluginKey, {
+                        type: 'asyncResults',
+                        candidates: asyncResults,
+                      } satisfies CompletionMeta),
+                    );
+                  } catch {
+                    // Ignore errors from aborted requests or lookup failures.
+                    // The popup will continue showing static results (if any).
+                  }
+                }, lookupDebounceMs);
+              }
+            }
+
+            // Update popup rendering
+            updatePopup(view);
+          },
+
+          destroy() {
+            cancelAsyncLookup();
+
+            // Remove the popup from the DOM
+            if (popup.parentElement) {
+              popup.parentElement.removeChild(popup);
+            }
+          },
+        };
+      },
+    });
+  });
+}

--- a/packages/editor/src/template-invalid-decoration-plugin.test.ts
+++ b/packages/editor/src/template-invalid-decoration-plugin.test.ts
@@ -1,0 +1,373 @@
+/**
+ * Tests for the template invalid decoration plugin internal logic.
+ *
+ * DEP-583: Validates that buildInvalidTokenDecorations correctly identifies
+ * invalid `{{…}}` tokens in ProseMirror documents and creates decorations
+ * with the expected CSS classes and data attributes.
+ *
+ * These tests run in Node environment using ProseMirror's model layer
+ * (no DOM required).
+ */
+
+import { Schema } from '@milkdown/kit/prose/model';
+import { describe, expect, it } from 'bun:test';
+
+import {
+  buildInvalidTokenDecorations,
+  textOffsetToDocumentPosition,
+} from './template-invalid-decoration-plugin.js';
+import type { PlaceholderCandidate } from './types.js';
+
+// ---------------------------------------------------------------------------
+// Test schema — minimal ProseMirror schema sufficient for document creation.
+// ---------------------------------------------------------------------------
+
+const schema = new Schema({
+  nodes: {
+    doc: { content: 'block+' },
+    paragraph: {
+      content: 'inline*',
+      group: 'block',
+      parseDOM: [{ tag: 'p' }],
+      toDOM() {
+        return ['p', 0];
+      },
+    },
+    heading: {
+      attrs: { level: { default: 1 } },
+      content: 'inline*',
+      group: 'block',
+      parseDOM: [{ tag: 'h1', attrs: { level: 1 } }],
+      toDOM(node) {
+        return [`h${node.attrs.level}`, 0];
+      },
+    },
+    text: { group: 'inline' },
+  },
+  marks: {
+    strong: {
+      parseDOM: [{ tag: 'strong' }],
+      toDOM() {
+        return ['strong', 0];
+      },
+    },
+  },
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const DEFAULT_INVALID_CLASS = 'template-placeholder-invalid';
+
+function makeCandidates(...paths: string[]): PlaceholderCandidate[] {
+  return paths.map((path) => ({
+    path,
+    description: undefined,
+    valueKind: 'string' as const,
+  }));
+}
+
+/**
+ * Extract the inline decoration attributes from a Decoration object.
+ *
+ * ProseMirror's `Decoration.inline()` stores attributes on `decoration.type.attrs`.
+ */
+function getDecorationAttributes(decoration: unknown): Record<string, string> {
+  return (decoration as any).type.attrs;
+}
+
+// ---------------------------------------------------------------------------
+// textOffsetToDocumentPosition
+// ---------------------------------------------------------------------------
+
+describe('textOffsetToDocumentPosition', () => {
+  it('maps offset 0 to the start of the block content (blockPosition + 1)', () => {
+    const paragraph = schema.node('paragraph', null, [schema.text('hello')]);
+    // In a real doc the paragraph might be at position 0; its content starts at 1.
+    const blockPosition = 0;
+
+    expect(textOffsetToDocumentPosition(paragraph, blockPosition, 0)).toBe(1);
+  });
+
+  it('maps offset equal to text length to the end of the text', () => {
+    const paragraph = schema.node('paragraph', null, [schema.text('hello')]);
+    const blockPosition = 0;
+
+    // offset 5 is one-past-end, but the function should still produce a valid position.
+    expect(textOffsetToDocumentPosition(paragraph, blockPosition, 5)).toBe(6);
+  });
+
+  it('maps an intermediate offset correctly', () => {
+    const paragraph = schema.node('paragraph', null, [schema.text('hello')]);
+    const blockPosition = 0;
+
+    // offset 3 => position 4 (blockPos 0 + 1 + childOffset 0 + textOffset 3)
+    expect(textOffsetToDocumentPosition(paragraph, blockPosition, 3)).toBe(4);
+  });
+
+  it('accounts for non-zero block position', () => {
+    const paragraph = schema.node('paragraph', null, [schema.text('hello')]);
+    const blockPosition = 10;
+
+    // offset 2 => 10 + 1 + 0 + 2 = 13
+    expect(textOffsetToDocumentPosition(paragraph, blockPosition, 2)).toBe(13);
+  });
+
+  it('maps correctly across multiple text nodes (split by marks)', () => {
+    // "helloworld" split into two text nodes: "hello" (plain) + "world" (strong)
+    const plainText = schema.text('hello');
+    const strongText = schema.text('world', [schema.mark('strong')]);
+    const paragraph = schema.node('paragraph', null, [plainText, strongText]);
+    const blockPosition = 0;
+
+    // offset 0 => in first text node at char 0 => blockPos + 1 + childOffset(0) + 0 = 1
+    expect(textOffsetToDocumentPosition(paragraph, blockPosition, 0)).toBe(1);
+
+    // offset 4 => in first text node at char 4 => blockPos + 1 + 0 + 4 = 5
+    expect(textOffsetToDocumentPosition(paragraph, blockPosition, 4)).toBe(5);
+
+    // offset 5 => first char of second text node. childOffset for second text node
+    // in ProseMirror is 5 (the length of "hello"). localOffset = 5 - 5 = 0.
+    // result = 0 + 1 + 5 + 0 = 6
+    expect(textOffsetToDocumentPosition(paragraph, blockPosition, 5)).toBe(6);
+
+    // offset 8 => "wor|ld" => childOffset 5, localOffset 3 => 0 + 1 + 5 + 3 = 9
+    expect(textOffsetToDocumentPosition(paragraph, blockPosition, 8)).toBe(9);
+  });
+
+  it('returns start of block content for an empty block', () => {
+    const paragraph = schema.node('paragraph', null, []);
+    const blockPosition = 0;
+
+    // No children, so the default (blockPosition + 1) is returned.
+    expect(textOffsetToDocumentPosition(paragraph, blockPosition, 0)).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildInvalidTokenDecorations
+// ---------------------------------------------------------------------------
+
+describe('buildInvalidTokenDecorations', () => {
+  it('returns no decorations for a valid token that matches a known candidate', () => {
+    const doc = schema.node('doc', null, [
+      schema.node('paragraph', null, [schema.text('Hello {{input.name}} world')]),
+    ]);
+    const candidates = makeCandidates('input.name');
+
+    const decorations = buildInvalidTokenDecorations(doc, candidates, DEFAULT_INVALID_CLASS);
+
+    expect(decorations).toHaveLength(0);
+  });
+
+  it('produces a decoration for an unknown placeholder', () => {
+    const doc = schema.node('doc', null, [
+      schema.node('paragraph', null, [schema.text('Use {{input.unknown}} here')]),
+    ]);
+    const candidates = makeCandidates('input.name');
+
+    const decorations = buildInvalidTokenDecorations(doc, candidates, DEFAULT_INVALID_CLASS);
+
+    expect(decorations).toHaveLength(1);
+
+    const attributes = getDecorationAttributes(decorations[0]);
+    expect(attributes.class).toBe(DEFAULT_INVALID_CLASS);
+    expect(attributes['data-placeholder-validation-reason']).toBe('unknown_placeholder');
+  });
+
+  it('produces a decoration for a malformed (unclosed) token', () => {
+    const doc = schema.node('doc', null, [
+      schema.node('paragraph', null, [schema.text('Check {{unclosed')]),
+    ]);
+    const candidates = makeCandidates('unclosed');
+
+    const decorations = buildInvalidTokenDecorations(doc, candidates, DEFAULT_INVALID_CLASS);
+
+    expect(decorations).toHaveLength(1);
+
+    const attributes = getDecorationAttributes(decorations[0]);
+    expect(attributes.class).toBe(DEFAULT_INVALID_CLASS);
+    expect(attributes['data-placeholder-validation-reason']).toBe('malformed_token');
+  });
+
+  it('produces a decoration for a token with invalid path format', () => {
+    const doc = schema.node('doc', null, [
+      schema.node('paragraph', null, [schema.text('Bad {{123invalid}}')]),
+    ]);
+    const candidates = makeCandidates();
+
+    const decorations = buildInvalidTokenDecorations(doc, candidates, DEFAULT_INVALID_CLASS);
+
+    expect(decorations).toHaveLength(1);
+
+    const attributes = getDecorationAttributes(decorations[0]);
+    expect(attributes.class).toBe(DEFAULT_INVALID_CLASS);
+    expect(attributes['data-placeholder-validation-reason']).toBe('invalid_path_format');
+  });
+
+  it('produces decorations across multiple paragraphs', () => {
+    const doc = schema.node('doc', null, [
+      schema.node('paragraph', null, [schema.text('First {{bad1}}')]),
+      schema.node('paragraph', null, [schema.text('Second {{bad2}}')]),
+    ]);
+    const candidates = makeCandidates();
+
+    const decorations = buildInvalidTokenDecorations(doc, candidates, DEFAULT_INVALID_CLASS);
+
+    expect(decorations).toHaveLength(2);
+
+    // Both should be unknown_placeholder since the paths are valid format but
+    // not in candidates.
+    for (const decoration of decorations) {
+      const attributes = getDecorationAttributes(decoration);
+      expect(attributes['data-placeholder-validation-reason']).toBe('unknown_placeholder');
+    }
+  });
+
+  it('applies a custom CSS class when provided', () => {
+    const doc = schema.node('doc', null, [
+      schema.node('paragraph', null, [schema.text('{{unknown_field}}')]),
+    ]);
+    const candidates = makeCandidates();
+    const customClass = 'my-custom-invalid-class';
+
+    const decorations = buildInvalidTokenDecorations(doc, candidates, customClass);
+
+    expect(decorations).toHaveLength(1);
+    const attributes = getDecorationAttributes(decorations[0]);
+    expect(attributes.class).toBe(customClass);
+  });
+
+  it('only decorates invalid tokens when valid and invalid tokens are mixed', () => {
+    const doc = schema.node('doc', null, [
+      schema.node('paragraph', null, [
+        schema.text('Valid: {{name}}, Invalid: {{missing}}, Also valid: {{age}}'),
+      ]),
+    ]);
+    const candidates = makeCandidates('name', 'age');
+
+    const decorations = buildInvalidTokenDecorations(doc, candidates, DEFAULT_INVALID_CLASS);
+
+    expect(decorations).toHaveLength(1);
+    const attributes = getDecorationAttributes(decorations[0]);
+    expect(attributes['data-placeholder-validation-reason']).toBe('unknown_placeholder');
+  });
+
+  it('returns no decorations for an empty document', () => {
+    const doc = schema.node('doc', null, [schema.node('paragraph', null, [])]);
+    const candidates = makeCandidates('name');
+
+    const decorations = buildInvalidTokenDecorations(doc, candidates, DEFAULT_INVALID_CLASS);
+
+    expect(decorations).toHaveLength(0);
+  });
+
+  it('returns no decorations for a document with no placeholder tokens', () => {
+    const doc = schema.node('doc', null, [
+      schema.node('paragraph', null, [schema.text('Just regular text without any templates.')]),
+    ]);
+    const candidates = makeCandidates('name');
+
+    const decorations = buildInvalidTokenDecorations(doc, candidates, DEFAULT_INVALID_CLASS);
+
+    expect(decorations).toHaveLength(0);
+  });
+
+  it('computes correct from/to positions for a single-paragraph document', () => {
+    // Document structure:
+    //   doc (pos 0)
+    //     paragraph (pos 0, content starts at 1)
+    //       text: "ab{{bad}}cd"
+    //
+    // "{{bad}}" starts at text offset 2 and ends at text offset 9.
+    // In the document: from = 1 + 2 = 3, to = 1 + 9 = 10.
+    const doc = schema.node('doc', null, [
+      schema.node('paragraph', null, [schema.text('ab{{bad}}cd')]),
+    ]);
+    const candidates = makeCandidates();
+
+    const decorations = buildInvalidTokenDecorations(doc, candidates, DEFAULT_INVALID_CLASS);
+
+    expect(decorations).toHaveLength(1);
+    expect(decorations[0].from).toBe(3);
+    expect(decorations[0].to).toBe(10);
+  });
+
+  it('computes correct positions for tokens in a second paragraph', () => {
+    // Document structure:
+    //   doc (pos 0)
+    //     paragraph (pos 0, content: "first", size 7 = 1 open + 5 text + 1 close)
+    //     paragraph (pos 7, content starts at 8)
+    //       text: "{{bad}}"
+    //
+    // "{{bad}}" starts at text offset 0 and ends at text offset 7.
+    // In the document: from = 8 + 0 = 8, to = 8 + 7 = 15.
+    const doc = schema.node('doc', null, [
+      schema.node('paragraph', null, [schema.text('first')]),
+      schema.node('paragraph', null, [schema.text('{{bad}}')]),
+    ]);
+    const candidates = makeCandidates();
+
+    const decorations = buildInvalidTokenDecorations(doc, candidates, DEFAULT_INVALID_CLASS);
+
+    expect(decorations).toHaveLength(1);
+    expect(decorations[0].from).toBe(8);
+    expect(decorations[0].to).toBe(15);
+  });
+
+  it('handles multiple invalid tokens in the same paragraph', () => {
+    const doc = schema.node('doc', null, [
+      schema.node('paragraph', null, [schema.text('{{bad1}} and {{bad2}}')]),
+    ]);
+    const candidates = makeCandidates();
+
+    const decorations = buildInvalidTokenDecorations(doc, candidates, DEFAULT_INVALID_CLASS);
+
+    expect(decorations).toHaveLength(2);
+
+    // First token: "{{bad1}}" at text offset 0..8 => doc position 1..9
+    expect(decorations[0].from).toBe(1);
+    expect(decorations[0].to).toBe(9);
+
+    // Second token: "{{bad2}}" at text offset 13, endOffset 21 => doc position 14..22
+    expect(decorations[1].from).toBe(14);
+    expect(decorations[1].to).toBe(22);
+  });
+
+  it('works with heading nodes (not just paragraphs)', () => {
+    const doc = schema.node('doc', null, [
+      schema.node('heading', { level: 1 }, [schema.text('Title {{unknown}}')]),
+    ]);
+    const candidates = makeCandidates();
+
+    const decorations = buildInvalidTokenDecorations(doc, candidates, DEFAULT_INVALID_CLASS);
+
+    expect(decorations).toHaveLength(1);
+    const attributes = getDecorationAttributes(decorations[0]);
+    expect(attributes['data-placeholder-validation-reason']).toBe('unknown_placeholder');
+  });
+
+  it('handles empty body token {{}} as invalid_path_format', () => {
+    const doc = schema.node('doc', null, [
+      schema.node('paragraph', null, [schema.text('empty {{}} token')]),
+    ]);
+    const candidates = makeCandidates();
+
+    const decorations = buildInvalidTokenDecorations(doc, candidates, DEFAULT_INVALID_CLASS);
+
+    expect(decorations).toHaveLength(1);
+    const attributes = getDecorationAttributes(decorations[0]);
+    expect(attributes['data-placeholder-validation-reason']).toBe('invalid_path_format');
+  });
+
+  it('returns empty array with empty candidates and no tokens', () => {
+    const doc = schema.node('doc', null, [
+      schema.node('paragraph', null, [schema.text('no tokens here')]),
+    ]);
+
+    const decorations = buildInvalidTokenDecorations(doc, [], DEFAULT_INVALID_CLASS);
+
+    expect(decorations).toHaveLength(0);
+  });
+});

--- a/packages/editor/src/template-invalid-decoration-plugin.ts
+++ b/packages/editor/src/template-invalid-decoration-plugin.ts
@@ -1,0 +1,216 @@
+/**
+ * ProseMirror plugin for decorating invalid `{{…}}` template placeholder tokens.
+ *
+ * Scans the document on every change, parses `{{…}}` tokens from each text block,
+ * validates them against the current candidate set, and applies inline decorations
+ * to invalid tokens with a CSS class and a `data-placeholder-validation-reason`
+ * attribute describing the failure.
+ *
+ * DEP-583: WYSIWYG invalid-token decoration for saved-prompt template authoring.
+ */
+
+import type { Node as ProseMirrorNode } from '@milkdown/kit/prose/model';
+import { Plugin, PluginKey } from '@milkdown/kit/prose/state';
+import { Decoration, DecorationSet } from '@milkdown/kit/prose/view';
+import { $prose } from '@milkdown/kit/utils';
+
+import { parsePlaceholderTokens, validatePlaceholderTokens } from './template-placeholders.js';
+import { textOffsetToBlockDocumentPosition } from './template-position-utilities.js';
+import type { PlaceholderCandidate } from './types.js';
+
+/** Plugin key for the template invalid decoration plugin. */
+export const templateInvalidDecorationPluginKey = new PluginKey('template-invalid-decoration');
+
+/**
+ * Convert a text offset within a block node to a ProseMirror document position.
+ *
+ * Thin adapter over the shared `textOffsetToBlockDocumentPosition` utility.
+ * The parameter name `blockPosition` refers to the absolute document position
+ * of the block node itself (the value yielded by `document.descendants`).
+ * Internally it is converted to `blockContentStart = blockPosition + 1` before
+ * delegating to the shared walker.
+ *
+ * @internal Exported for testing only.
+ *
+ * @param block - The block-level ProseMirror node (paragraph, heading, etc.).
+ * @param blockPosition - The absolute document position of the block node itself.
+ * @param textOffset - A character offset into `block.textContent`.
+ * @returns The absolute ProseMirror position corresponding to `textOffset`.
+ */
+export function textOffsetToDocumentPosition(
+  block: ProseMirrorNode,
+  blockPosition: number,
+  textOffset: number,
+): number {
+  // blockPosition is the node's own position (before its opening tag).
+  // blockContentStart = blockPosition + 1 is the position of the first
+  // character inside the block.
+  return textOffsetToBlockDocumentPosition(block, blockPosition + 1, textOffset);
+}
+
+/**
+ * Build decorations for all invalid `{{…}}` tokens in the document.
+ *
+ * Walks every block-level node, extracts its text content, parses placeholder
+ * tokens, validates them against the candidate set, and creates inline
+ * decorations for each invalid token.
+ *
+ * @internal Exported for testing only.
+ *
+ * @param document - The ProseMirror document node.
+ * @param candidates - Known placeholder candidates for validation.
+ * @param invalidClassName - CSS class applied to invalid token decorations.
+ * @returns An array of ProseMirror inline decorations.
+ */
+export function buildInvalidTokenDecorations(
+  document: ProseMirrorNode,
+  candidates: PlaceholderCandidate[],
+  invalidClassName: string,
+): Decoration[] {
+  const decorations: Decoration[] = [];
+
+  document.descendants((node, position) => {
+    // Only process block-level nodes that contain inline content.
+    if (!node.isBlock || node.isAtom || !node.inlineContent) return;
+
+    const textContent = node.textContent;
+    if (!textContent) return;
+
+    const tokens = parsePlaceholderTokens(textContent);
+    if (tokens.length === 0) return;
+
+    const { issues } = validatePlaceholderTokens(tokens, candidates);
+
+    for (const issue of issues) {
+      const from = textOffsetToDocumentPosition(node, position, issue.token.startOffset);
+      const to = textOffsetToDocumentPosition(node, position, issue.token.endOffset);
+
+      decorations.push(
+        Decoration.inline(from, to, {
+          class: invalidClassName,
+          'data-placeholder-validation-reason': issue.reason,
+        }),
+      );
+    }
+
+    // Do not descend into children — we already processed the full text content
+    // of this block via textContent.
+    return false;
+  });
+
+  return decorations;
+}
+
+/**
+ * Internal state stored by `createTemplateInvalidDecorationPlugin` in its
+ * ProseMirror plugin state field.
+ */
+interface DecorationPluginState {
+  /** The current decoration set, mapped or rebuilt each transaction. */
+  decorations: DecorationSet;
+  /** JSON.stringify of the last candidate set used to build decorations. */
+  candidatesKey: string;
+  /** The CSS class used to build the current decorations. */
+  invalidClassName: string;
+}
+
+/**
+ * Create a Milkdown plugin that decorates invalid `{{…}}` template tokens.
+ *
+ * Caches the `DecorationSet` in plugin state and rebuilds it only when the
+ * document changes or when the candidate set/class name changes. For unchanged
+ * transactions the existing set is mapped through `tr.mapping` so ProseMirror
+ * can update decoration positions without a full document scan.
+ *
+ * The factory accepts accessor functions so the candidate set and class name
+ * can change at runtime without recreating the plugin.
+ *
+ * @param getCandidates - Returns the current set of placeholder candidates.
+ * @param getInvalidClassName - Returns the CSS class for invalid tokens.
+ *   Defaults to returning `'template-placeholder-invalid'`.
+ * @returns A Milkdown-compatible plugin created via `$prose`.
+ *
+ * @example
+ * ```typescript
+ * const plugin = createTemplateInvalidDecorationPlugin(
+ *   () => candidates,
+ *   () => 'my-invalid-class',
+ * );
+ * ```
+ */
+export function createTemplateInvalidDecorationPlugin(
+  getCandidates: () => PlaceholderCandidate[],
+  getInvalidClassName?: () => string,
+) {
+  const resolveInvalidClassName = () => getInvalidClassName?.() ?? 'template-placeholder-invalid';
+
+  return $prose(() => {
+    return new Plugin<DecorationPluginState>({
+      key: templateInvalidDecorationPluginKey,
+
+      state: {
+        init(_config, editorState) {
+          const candidates = getCandidates();
+          const invalidClassName = resolveInvalidClassName();
+          const candidatesKey = JSON.stringify(candidates);
+          const decorationSpecs = buildInvalidTokenDecorations(
+            editorState.doc,
+            candidates,
+            invalidClassName,
+          );
+
+          const decorations =
+            decorationSpecs.length === 0
+              ? DecorationSet.empty
+              : DecorationSet.create(editorState.doc, decorationSpecs);
+
+          return { decorations, candidatesKey, invalidClassName };
+        },
+
+        apply(transaction, pluginState, _oldEditorState, newEditorState) {
+          const nextCandidates = getCandidates();
+          const nextInvalidClassName = resolveInvalidClassName();
+          const nextCandidatesKey = JSON.stringify(nextCandidates);
+
+          const shouldRebuild =
+            transaction.docChanged ||
+            nextCandidatesKey !== pluginState.candidatesKey ||
+            nextInvalidClassName !== pluginState.invalidClassName;
+
+          if (shouldRebuild) {
+            const decorationSpecs = buildInvalidTokenDecorations(
+              newEditorState.doc,
+              nextCandidates,
+              nextInvalidClassName,
+            );
+
+            const decorations =
+              decorationSpecs.length === 0
+                ? DecorationSet.empty
+                : DecorationSet.create(newEditorState.doc, decorationSpecs);
+
+            return {
+              decorations,
+              candidatesKey: nextCandidatesKey,
+              invalidClassName: nextInvalidClassName,
+            };
+          }
+
+          // Map existing decorations through the transaction's position mapping
+          // to keep them aligned when text is inserted/deleted elsewhere.
+          return {
+            decorations: pluginState.decorations.map(transaction.mapping, newEditorState.doc),
+            candidatesKey: pluginState.candidatesKey,
+            invalidClassName: pluginState.invalidClassName,
+          };
+        },
+      },
+
+      props: {
+        decorations(state) {
+          return templateInvalidDecorationPluginKey.getState(state)?.decorations ?? null;
+        },
+      },
+    });
+  });
+}

--- a/packages/editor/src/template-placeholders.test.ts
+++ b/packages/editor/src/template-placeholders.test.ts
@@ -1,0 +1,1293 @@
+/**
+ * Exhaustive tests for template placeholder domain logic.
+ * DEP-582: Pure functions with no ProseMirror or DOM dependencies.
+ * DEP-625: Comprehensive security tests for prototype pollution and XSS prevention.
+ */
+
+/* eslint-disable max-lines */
+
+import { describe, expect, it } from 'bun:test';
+
+import {
+  buildPlaceholderCandidatesFromJsonSchema,
+  parsePlaceholderTokens,
+  resolveTemplatePlaceholders,
+  validatePlaceholderTokens,
+} from './template-placeholders.js';
+
+describe('buildPlaceholderCandidatesFromJsonSchema', () => {
+  it('emits candidates for each property of a flat object schema with correct valueKind', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        name: { type: 'string', description: 'The name' },
+        age: { type: 'number' },
+      },
+    };
+
+    const candidates = buildPlaceholderCandidatesFromJsonSchema(schema);
+
+    expect(candidates).toEqual([
+      { path: 'age', description: undefined, valueKind: 'number' },
+      { path: 'name', description: 'The name', valueKind: 'string' },
+    ]);
+  });
+
+  it('emits parent and child paths for nested object schema in lexicographic order', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        input: {
+          type: 'object',
+          properties: {
+            y: { type: 'number' },
+            x: { type: 'string' },
+          },
+        },
+      },
+    };
+
+    const candidates = buildPlaceholderCandidatesFromJsonSchema(schema);
+    const paths = candidates.map((c) => c.path);
+
+    expect(paths).toEqual(['input', 'input.x', 'input.y']);
+  });
+
+  it('emits whole-array path only for array-typed properties with valueKind "array"', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        tags: { type: 'array', items: { type: 'string' } },
+      },
+    };
+
+    const candidates = buildPlaceholderCandidatesFromJsonSchema(schema);
+
+    expect(candidates).toEqual([{ path: 'tags', description: undefined, valueKind: 'array' }]);
+  });
+
+  it('carries through description when present; undefined when missing', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        described: { type: 'string', description: 'Has a description' },
+        undescribed: { type: 'string' },
+      },
+    };
+
+    const candidates = buildPlaceholderCandidatesFromJsonSchema(schema);
+
+    expect(candidates.find((c) => c.path === 'described')?.description).toBe('Has a description');
+    expect(candidates.find((c) => c.path === 'undescribed')?.description).toBeUndefined();
+  });
+
+  it('maps JSON Schema type values to correct valueKind', () => {
+    const typeMap: [string, string][] = [
+      ['string', 'string'],
+      ['number', 'number'],
+      ['integer', 'number'],
+      ['boolean', 'boolean'],
+      ['array', 'array'],
+      ['object', 'object'],
+    ];
+
+    const properties: Record<string, { type: string }> = {};
+    for (const [schemaType] of typeMap) {
+      properties[schemaType] = { type: schemaType };
+    }
+
+    const schema = { type: 'object', properties };
+    const candidates = buildPlaceholderCandidatesFromJsonSchema(schema);
+
+    for (const [schemaType, expectedKind] of typeMap) {
+      const candidate = candidates.find((c) => c.path === schemaType);
+      expect(candidate?.valueKind, `type "${schemaType}" should map to "${expectedKind}"`).toBe(
+        expectedKind,
+      );
+    }
+  });
+
+  it('returns valueKind "unknown" when the type field is missing', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        mystery: { description: 'no type' },
+      },
+    };
+
+    const candidates = buildPlaceholderCandidatesFromJsonSchema(schema);
+
+    expect(candidates[0].valueKind).toBe('unknown');
+  });
+
+  const unsupportedKeywords = [
+    '$ref',
+    'allOf',
+    'anyOf',
+    'oneOf',
+    'if',
+    'then',
+    'else',
+    'patternProperties',
+    'additionalProperties',
+  ] as const;
+
+  it.each(unsupportedKeywords)(
+    'silently ignores unsupported keyword "%s" (no throw)',
+    (keyword) => {
+      const schema = {
+        type: 'object',
+        properties: {
+          field: { type: 'string' },
+        },
+        [keyword]: keyword === '$ref' ? '#/definitions/Foo' : { type: 'string' },
+      };
+
+      expect(() => buildPlaceholderCandidatesFromJsonSchema(schema)).not.toThrow();
+      const candidates = buildPlaceholderCandidatesFromJsonSchema(schema);
+      expect(candidates).toHaveLength(1);
+      expect(candidates[0].path).toBe('field');
+    },
+  );
+
+  it('returns empty array for a schema with no properties', () => {
+    expect(buildPlaceholderCandidatesFromJsonSchema({})).toEqual([]);
+    expect(buildPlaceholderCandidatesFromJsonSchema({ type: 'object' })).toEqual([]);
+  });
+
+  it('emits all intermediate and leaf paths for deeply nested schema (3+ levels)', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        a: {
+          type: 'object',
+          properties: {
+            b: {
+              type: 'object',
+              properties: {
+                c: {
+                  type: 'object',
+                  properties: {
+                    d: { type: 'string' },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    };
+
+    const candidates = buildPlaceholderCandidatesFromJsonSchema(schema);
+    const paths = candidates.map((c) => c.path);
+
+    expect(paths).toEqual(['a', 'a.b', 'a.b.c', 'a.b.c.d']);
+  });
+
+  it('recurses into nested properties even without explicit type "object"', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        container: {
+          // No type field at all
+          properties: {
+            inner: { type: 'string' },
+          },
+        },
+      },
+    };
+
+    const candidates = buildPlaceholderCandidatesFromJsonSchema(schema);
+    const paths = candidates.map((c) => c.path);
+
+    expect(paths).toEqual(['container', 'container.inner']);
+    expect(candidates.find((c) => c.path === 'container')?.valueKind).toBe('unknown');
+    expect(candidates.find((c) => c.path === 'container.inner')?.valueKind).toBe('string');
+  });
+
+  it('skips keys with non-identifier characters that PATH_REGEX would reject', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        'first-name': { type: 'string' },
+        'first.name': { type: 'string' },
+        '123numeric': { type: 'number' },
+        valid_field: { type: 'string' },
+      },
+    };
+
+    const candidates = buildPlaceholderCandidatesFromJsonSchema(schema);
+    const paths = candidates.map((c) => c.path);
+
+    expect(paths).toEqual(['valid_field']);
+  });
+
+  it('skips non-identifier keys in nested schemas', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        parent: {
+          type: 'object',
+          properties: {
+            'child-field': { type: 'string' },
+            child_valid: { type: 'number' },
+          },
+        },
+      },
+    };
+
+    const candidates = buildPlaceholderCandidatesFromJsonSchema(schema);
+    const paths = candidates.map((c) => c.path);
+
+    expect(paths).toContain('parent');
+    expect(paths).toContain('parent.child_valid');
+    expect(paths).not.toContain('parent.child-field');
+  });
+});
+
+describe('parsePlaceholderTokens', () => {
+  it('parses a single well-formed token with correct fields', () => {
+    const text = '{{input.x}}';
+    const tokens = parsePlaceholderTokens(text);
+
+    expect(tokens).toHaveLength(1);
+    expect(tokens[0]).toEqual({
+      raw: '{{input.x}}',
+      path: 'input.x',
+      startOffset: 0,
+      endOffset: 11,
+      closed: true,
+    });
+  });
+
+  it('trims whitespace around path', () => {
+    const text = '{{ input.x }}';
+    const tokens = parsePlaceholderTokens(text);
+
+    expect(tokens).toHaveLength(1);
+    expect(tokens[0].path).toBe('input.x');
+    expect(tokens[0].raw).toBe('{{ input.x }}');
+    expect(tokens[0].closed).toBe(true);
+  });
+
+  it('parses adjacent tokens with correct non-overlapping offsets', () => {
+    const text = '{{a}}{{b}}';
+    const tokens = parsePlaceholderTokens(text);
+
+    expect(tokens).toHaveLength(2);
+    expect(tokens[0]).toEqual({
+      raw: '{{a}}',
+      path: 'a',
+      startOffset: 0,
+      endOffset: 5,
+      closed: true,
+    });
+    expect(tokens[1]).toEqual({
+      raw: '{{b}}',
+      path: 'b',
+      startOffset: 5,
+      endOffset: 10,
+      closed: true,
+    });
+  });
+
+  it('returns two separate token objects for repeated same token', () => {
+    const text = '{{x}} and {{x}}';
+    const tokens = parsePlaceholderTokens(text);
+
+    expect(tokens).toHaveLength(2);
+    expect(tokens[0].path).toBe('x');
+    expect(tokens[1].path).toBe('x');
+    expect(tokens[0].startOffset).toBe(0);
+    expect(tokens[1].startOffset).toBe(10);
+    expect(tokens[0]).not.toBe(tokens[1]);
+  });
+
+  it('detects unclosed token at end of string', () => {
+    const text = '{{input.x';
+    const tokens = parsePlaceholderTokens(text);
+
+    expect(tokens).toHaveLength(1);
+    expect(tokens[0]).toEqual({
+      raw: '{{input.x',
+      path: 'input.x',
+      startOffset: 0,
+      endOffset: text.length,
+      closed: false,
+    });
+  });
+
+  it('returns closed token with empty string path for empty body', () => {
+    const text = '{{}}';
+    const tokens = parsePlaceholderTokens(text);
+
+    expect(tokens).toHaveLength(1);
+    expect(tokens[0]).toEqual({
+      raw: '{{}}',
+      path: '',
+      startOffset: 0,
+      endOffset: 4,
+      closed: true,
+    });
+  });
+
+  it('returns empty array for text with no tokens', () => {
+    expect(parsePlaceholderTokens('Hello world')).toEqual([]);
+    expect(parsePlaceholderTokens('')).toEqual([]);
+    expect(parsePlaceholderTokens('just { single braces }')).toEqual([]);
+  });
+
+  it('parses tokens interspersed with prose with correct offsets', () => {
+    const text = 'Hello {{name}}, your {{item}} is ready';
+    const tokens = parsePlaceholderTokens(text);
+
+    expect(tokens).toHaveLength(2);
+
+    expect(tokens[0]).toEqual({
+      raw: '{{name}}',
+      path: 'name',
+      startOffset: 6,
+      endOffset: 14,
+      closed: true,
+    });
+
+    expect(tokens[1]).toEqual({
+      raw: '{{item}}',
+      path: 'item',
+      startOffset: 21,
+      endOffset: 29,
+      closed: true,
+    });
+  });
+
+  it('parses nested braces as-is for path body', () => {
+    const text = '{{ {inner} }}';
+    const tokens = parsePlaceholderTokens(text);
+
+    expect(tokens).toHaveLength(1);
+    expect(tokens[0].path).toBe('{inner}');
+    expect(tokens[0].closed).toBe(true);
+  });
+});
+
+describe('validatePlaceholderTokens', () => {
+  const candidates = [
+    { path: 'name', description: undefined, valueKind: 'string' as const },
+    { path: 'age', description: undefined, valueKind: 'number' as const },
+    { path: 'input.x', description: undefined, valueKind: 'string' as const },
+  ];
+
+  it('reports malformed_token issue for unclosed token', () => {
+    const tokens = parsePlaceholderTokens('{{name');
+    const result = validatePlaceholderTokens(tokens, candidates);
+
+    expect(result.invalidTokens).toHaveLength(1);
+    expect(result.validTokens).toHaveLength(0);
+    expect(result.issues).toHaveLength(1);
+    expect(result.issues[0].reason).toBe('malformed_token');
+    expect(result.issues[0].token).toBe(tokens[0]);
+  });
+
+  const invalidPaths = [
+    ['numeric start', '123'],
+    ['double dot', 'a..b'],
+    ['empty string', ''],
+    ['leading dot', '.a'],
+  ] as const;
+
+  it.each(invalidPaths)(
+    'reports invalid_path_format for path with %s ("%s")',
+    (_label, pathValue) => {
+      const token = {
+        raw: `{{${pathValue}}}`,
+        path: pathValue,
+        startOffset: 0,
+        endOffset: pathValue.length + 4,
+        closed: true,
+      };
+
+      const result = validatePlaceholderTokens([token], candidates);
+
+      expect(result.invalidTokens).toHaveLength(1);
+      expect(result.issues).toHaveLength(1);
+      expect(result.issues[0].reason).toBe('invalid_path_format');
+    },
+  );
+
+  it('reports unknown_placeholder for valid-format path not in candidate set', () => {
+    const tokens = parsePlaceholderTokens('{{unknown_field}}');
+    const result = validatePlaceholderTokens(tokens, candidates);
+
+    expect(result.invalidTokens).toHaveLength(1);
+    expect(result.validTokens).toHaveLength(0);
+    expect(result.issues).toHaveLength(1);
+    expect(result.issues[0].reason).toBe('unknown_placeholder');
+  });
+
+  it('places valid token in validTokens with zero issues for that token', () => {
+    const tokens = parsePlaceholderTokens('{{name}}');
+    const result = validatePlaceholderTokens(tokens, candidates);
+
+    expect(result.validTokens).toHaveLength(1);
+    expect(result.validTokens[0].path).toBe('name');
+    expect(result.invalidTokens).toHaveLength(0);
+    expect(result.issues).toHaveLength(0);
+  });
+
+  it('correctly partitions mixed valid and invalid tokens', () => {
+    const text = '{{name}} and {{}} and {{unknown}} and {{input.x';
+    const tokens = parsePlaceholderTokens(text);
+    const result = validatePlaceholderTokens(tokens, candidates);
+
+    expect(result.validTokens).toHaveLength(1);
+    expect(result.validTokens[0].path).toBe('name');
+
+    expect(result.invalidTokens).toHaveLength(3);
+    expect(result.issues).toHaveLength(3);
+
+    const reasons = result.issues.map((issue) => issue.reason);
+    expect(reasons).toContain('invalid_path_format'); // {{}}
+    expect(reasons).toContain('unknown_placeholder'); // {{unknown}}
+    expect(reasons).toContain('malformed_token'); // {{input.x (unclosed)
+  });
+
+  it('references the original token with source offsets in each issue', () => {
+    const text = 'prefix {{bad..path}} suffix';
+    const tokens = parsePlaceholderTokens(text);
+    const result = validatePlaceholderTokens(tokens, candidates);
+
+    expect(result.issues).toHaveLength(1);
+    expect(result.issues[0].token.startOffset).toBe(7);
+    expect(result.issues[0].token.endOffset).toBe(20);
+    expect(result.issues[0].token.raw).toBe('{{bad..path}}');
+  });
+});
+
+describe('resolveTemplatePlaceholders', () => {
+  it('resolves string value', () => {
+    const result = resolveTemplatePlaceholders('{{ input.x }}', { input: { x: 'hello' } });
+
+    expect(result.text).toBe('hello');
+    expect(result.issues).toHaveLength(0);
+  });
+
+  it('resolves number value', () => {
+    const result = resolveTemplatePlaceholders('{{count}}', { count: 42 });
+
+    expect(result.text).toBe('42');
+  });
+
+  it('resolves boolean value', () => {
+    const result = resolveTemplatePlaceholders('{{flag}}', { flag: true });
+
+    expect(result.text).toBe('true');
+  });
+
+  it('resolves object value as JSON', () => {
+    const result = resolveTemplatePlaceholders('{{input}}', { input: { x: 'hello', y: 1 } });
+
+    expect(result.text).toBe('{"x":"hello","y":1}');
+  });
+
+  it('resolves array value as comma-separated items', () => {
+    const result = resolveTemplatePlaceholders('{{tags}}', { tags: ['a', 'b', 3] });
+
+    expect(result.text).toBe('a, b, 3');
+  });
+
+  it('handles array with null and object items per item-coercion rules', () => {
+    const result = resolveTemplatePlaceholders('{{items}}', {
+      items: [null, { key: 'value' }, undefined, 'text'],
+    });
+
+    expect(result.text).toBe(', {"key":"value"}, , text');
+  });
+
+  it('coerces function items in arrays to empty string (consistent with top-level behavior)', () => {
+    // String(fn) emits the function source code; that is inconsistent with the
+    // documented contract that function values resolve to ''.
+    const result = resolveTemplatePlaceholders('{{items}}', {
+      items: ['a', () => 'hello', 'b'],
+    });
+
+    expect(result.text).toBe('a, , b');
+  });
+
+  it('coerces symbol items in arrays to empty string (consistent with top-level behavior)', () => {
+    // String(sym) emits "Symbol(...)"; that is inconsistent with the documented
+    // contract that symbol values resolve to ''.
+    const result = resolveTemplatePlaceholders('{{items}}', {
+      items: ['a', Symbol('test'), 'b'],
+    });
+
+    expect(result.text).toBe('a, , b');
+  });
+
+  it('resolves null value to empty string', () => {
+    const result = resolveTemplatePlaceholders('{{field}}', { field: null });
+
+    expect(result.text).toBe('');
+  });
+
+  it('resolves undefined / missing path to empty string', () => {
+    const result = resolveTemplatePlaceholders('{{missing}}', {});
+
+    expect(result.text).toBe('');
+  });
+
+  it('resolves bigint value', () => {
+    const result = resolveTemplatePlaceholders('{{big}}', { big: BigInt(42) });
+
+    expect(result.text).toBe('42');
+  });
+
+  it('preserves unclosed tokens in output text unmodified', () => {
+    const text = 'Hello {{name}} and {{unclosed';
+    const result = resolveTemplatePlaceholders(text, { name: 'World' });
+
+    expect(result.text).toBe('Hello World and {{unclosed');
+  });
+
+  it('reports unknown_placeholder issues when candidatePaths is provided', () => {
+    const result = resolveTemplatePlaceholders('{{unknown}}', {}, ['name', 'age']);
+
+    expect(result.text).toBe('');
+    expect(result.issues).toHaveLength(1);
+    expect(result.issues[0].reason).toBe('unknown_placeholder');
+  });
+
+  it('replaces unknown paths with empty string without issues when candidatePaths is omitted', () => {
+    const result = resolveTemplatePlaceholders('{{unknown}}', {});
+
+    expect(result.text).toBe('');
+    expect(result.issues).toHaveLength(0);
+  });
+
+  it('resolves multiple tokens in same text correctly via reverse-order iteration', () => {
+    const text = '{{greeting}} {{name}}, you have {{count}} items.';
+    const result = resolveTemplatePlaceholders(text, {
+      greeting: 'Hello',
+      name: 'Alice',
+      count: 5,
+    });
+
+    expect(result.text).toBe('Hello Alice, you have 5 items.');
+  });
+
+  it('does not mutate the input values object', () => {
+    const values = { name: 'Alice', nested: { x: 1 } };
+    const valuesCopy = JSON.parse(JSON.stringify(values));
+
+    resolveTemplatePlaceholders('{{name}} {{nested}}', values);
+
+    expect(values).toEqual(valuesCopy);
+  });
+
+  it('resolves inherited prototype property names to empty string, not the inherited function', () => {
+    // Without the Object.hasOwn guard, paths like "constructor" or "toString"
+    // traverse the prototype chain and return the inherited function. JSON.stringify
+    // coerces a function to undefined, producing the literal text "undefined" rather
+    // than the expected empty string.
+    const result = resolveTemplatePlaceholders('{{constructor}}', {});
+    expect(result.text).toBe('');
+  });
+
+  it('resolves nested prototype property names to empty string', () => {
+    const result = resolveTemplatePlaceholders('{{a.toString}}', { a: {} });
+    expect(result.text).toBe('');
+  });
+
+  it('resolves function value to empty string (not the literal text "undefined")', () => {
+    // JSON.stringify returns undefined for function values, which string
+    // concatenation coerces to the literal text "undefined". The function/symbol
+    // guard in formatValueForReplacement must intercept before JSON.stringify.
+    const result = resolveTemplatePlaceholders('{{fn}}', { fn: () => 'hello' });
+    expect(result.text).toBe('');
+  });
+
+  it('resolves symbol value to empty string (not the literal text "undefined")', () => {
+    const result = resolveTemplatePlaceholders('{{sym}}', { sym: Symbol('test') });
+    expect(result.text).toBe('');
+  });
+
+  it('reports issues in forward document order when multiple unknown tokens appear', () => {
+    // resolveTemplatePlaceholders iterates tokens in reverse for correct string
+    // splicing, but issues must be returned in forward document order to match
+    // the ordering produced by validatePlaceholderTokens.
+    const result = resolveTemplatePlaceholders('{{alpha}} and {{beta}} and {{gamma}}', {}, [
+      'name',
+    ]);
+
+    expect(result.issues).toHaveLength(3);
+    expect(result.issues[0].token.path).toBe('alpha');
+    expect(result.issues[1].token.path).toBe('beta');
+    expect(result.issues[2].token.path).toBe('gamma');
+
+    // Verify by startOffset, not just path
+    const offsets = result.issues.map((issue) => issue.token.startOffset);
+    expect(offsets).toEqual(offsets.toSorted((a, b) => a - b));
+  });
+});
+
+describe('DEP-625: Prototype pollution prevention', () => {
+  describe('reserved segment blocking', () => {
+    it('blocks __proto__ access', () => {
+      const result = resolveTemplatePlaceholders('{{__proto__}}', {});
+      expect(result.text).toBe('');
+    });
+
+    it('blocks constructor access', () => {
+      const result = resolveTemplatePlaceholders('{{constructor}}', {});
+      expect(result.text).toBe('');
+    });
+
+    it('blocks prototype access', () => {
+      const result = resolveTemplatePlaceholders('{{prototype}}', {});
+      expect(result.text).toBe('');
+    });
+
+    it('blocks nested __proto__ path (user.__proto__.isAdmin)', () => {
+      const result = resolveTemplatePlaceholders('{{user.__proto__.isAdmin}}', {
+        user: { name: 'Alice' },
+      });
+      expect(result.text).toBe('');
+    });
+
+    it('blocks nested constructor.prototype path', () => {
+      const result = resolveTemplatePlaceholders('{{data.constructor.prototype}}', {
+        data: { value: 42 },
+      });
+      expect(result.text).toBe('');
+    });
+
+    it('blocks __defineGetter__ access', () => {
+      const result = resolveTemplatePlaceholders('{{__defineGetter__}}', {});
+      expect(result.text).toBe('');
+    });
+
+    it('blocks __defineSetter__ access', () => {
+      const result = resolveTemplatePlaceholders('{{__defineSetter__}}', {});
+      expect(result.text).toBe('');
+    });
+
+    it('blocks __lookupGetter__ access', () => {
+      const result = resolveTemplatePlaceholders('{{__lookupGetter__}}', {});
+      expect(result.text).toBe('');
+    });
+
+    it('blocks __lookupSetter__ access', () => {
+      const result = resolveTemplatePlaceholders('{{__lookupSetter__}}', {});
+      expect(result.text).toBe('');
+    });
+
+    it('blocks hasOwnProperty access', () => {
+      const result = resolveTemplatePlaceholders('{{hasOwnProperty}}', {});
+      expect(result.text).toBe('');
+    });
+
+    it('blocks isPrototypeOf access', () => {
+      const result = resolveTemplatePlaceholders('{{isPrototypeOf}}', {});
+      expect(result.text).toBe('');
+    });
+
+    it('blocks propertyIsEnumerable access', () => {
+      const result = resolveTemplatePlaceholders('{{propertyIsEnumerable}}', {});
+      expect(result.text).toBe('');
+    });
+
+    it('blocks toString access', () => {
+      const result = resolveTemplatePlaceholders('{{toString}}', {});
+      expect(result.text).toBe('');
+    });
+
+    it('blocks toLocaleString access', () => {
+      const result = resolveTemplatePlaceholders('{{toLocaleString}}', {});
+      expect(result.text).toBe('');
+    });
+
+    it('blocks valueOf access', () => {
+      const result = resolveTemplatePlaceholders('{{valueOf}}', {});
+      expect(result.text).toBe('');
+    });
+  });
+
+  describe('case-insensitive reserved segment blocking', () => {
+    it('blocks __PROTO__ (uppercase)', () => {
+      const result = resolveTemplatePlaceholders('{{__PROTO__}}', {});
+      expect(result.text).toBe('');
+    });
+
+    it('blocks Constructor (mixed case)', () => {
+      const result = resolveTemplatePlaceholders('{{Constructor}}', {});
+      expect(result.text).toBe('');
+    });
+
+    it('blocks PROTOTYPE (uppercase)', () => {
+      const result = resolveTemplatePlaceholders('{{PROTOTYPE}}', {});
+      expect(result.text).toBe('');
+    });
+
+    it('blocks ToStRiNg (mixed case)', () => {
+      const result = resolveTemplatePlaceholders('{{ToStRiNg}}', {});
+      expect(result.text).toBe('');
+    });
+
+    it('blocks nested case-variant path (user.__PROTO__.isAdmin)', () => {
+      const result = resolveTemplatePlaceholders('{{user.__PROTO__.isAdmin}}', {
+        user: { name: 'Alice' },
+      });
+      expect(result.text).toBe('');
+    });
+  });
+
+  describe('dunder property blocking', () => {
+    it('blocks any segment starting with __ (custom dunder)', () => {
+      const result = resolveTemplatePlaceholders('{{__custom__}}', {});
+      expect(result.text).toBe('');
+    });
+
+    it('blocks nested path with dunder segment (user.__secret__.data)', () => {
+      const result = resolveTemplatePlaceholders('{{user.__secret__.data}}', {
+        user: { name: 'Alice' },
+      });
+      expect(result.text).toBe('');
+    });
+
+    it('blocks __proto__ via dunder prefix check', () => {
+      const result = resolveTemplatePlaceholders('{{__proto__}}', {});
+      expect(result.text).toBe('');
+    });
+
+    it('blocks __defineGetter__ via dunder prefix check', () => {
+      const result = resolveTemplatePlaceholders('{{__defineGetter__}}', {});
+      expect(result.text).toBe('');
+    });
+  });
+
+  describe('empty segment blocking', () => {
+    it('blocks empty segments from double dots (user..name)', () => {
+      const result = resolveTemplatePlaceholders('{{user..name}}', {
+        user: { name: 'Alice' },
+      });
+      expect(result.text).toBe('');
+    });
+
+    it('blocks leading dot (.user.name)', () => {
+      const result = resolveTemplatePlaceholders('{{.user.name}}', {
+        user: { name: 'Alice' },
+      });
+      expect(result.text).toBe('');
+    });
+
+    it('blocks trailing dot (user.name.)', () => {
+      const result = resolveTemplatePlaceholders('{{user.name.}}', {
+        user: { name: 'Alice' },
+      });
+      expect(result.text).toBe('');
+    });
+
+    it('blocks multiple consecutive dots (user...name)', () => {
+      const result = resolveTemplatePlaceholders('{{user...name}}', {
+        user: { name: 'Alice' },
+      });
+      expect(result.text).toBe('');
+    });
+  });
+
+  describe('legitimate paths still resolve', () => {
+    it('resolves valid simple path', () => {
+      const result = resolveTemplatePlaceholders('{{name}}', { name: 'Alice' });
+      expect(result.text).toBe('Alice');
+    });
+
+    it('resolves valid nested path', () => {
+      const result = resolveTemplatePlaceholders('{{user.name}}', {
+        user: { name: 'Alice' },
+      });
+      expect(result.text).toBe('Alice');
+    });
+
+    it('resolves deeply nested path (3+ levels)', () => {
+      const result = resolveTemplatePlaceholders('{{a.b.c.d}}', {
+        a: { b: { c: { d: 'value' } } },
+      });
+      expect(result.text).toBe('value');
+    });
+
+    it('resolves path with underscores (user_data.field_name)', () => {
+      const result = resolveTemplatePlaceholders('{{user_data.field_name}}', {
+        user_data: { field_name: 'test' },
+      });
+      expect(result.text).toBe('test');
+    });
+
+    it('resolves path starting with underscore (_private.data)', () => {
+      const result = resolveTemplatePlaceholders('{{_private.data}}', {
+        _private: { data: 'secret' },
+      });
+      expect(result.text).toBe('secret');
+    });
+
+    it('resolves legitimate single underscore properties', () => {
+      const result = resolveTemplatePlaceholders('{{_value}}', { _value: 42 });
+      expect(result.text).toBe('42');
+    });
+  });
+
+  describe('edge cases', () => {
+    it('returns empty string for null context with reserved segment', () => {
+      const result = resolveTemplatePlaceholders('{{__proto__}}', {});
+      expect(result.text).toBe('');
+    });
+
+    it('blocks reserved segments even when they exist in data', () => {
+      // Even if someone manages to set these keys, they should not resolve
+      const maliciousData = Object.create(null);
+      maliciousData.constructor = 'evil';
+      const result = resolveTemplatePlaceholders('{{constructor}}', maliciousData);
+      expect(result.text).toBe('');
+    });
+
+    it('blocks reserved segments in complex nested paths', () => {
+      const result = resolveTemplatePlaceholders('{{a.b.__proto__.c.d}}', {
+        a: { b: { c: { d: 'value' } } },
+      });
+      expect(result.text).toBe('');
+    });
+
+    it('allows properties that contain reserved words but are not exact matches', () => {
+      const result = resolveTemplatePlaceholders('{{constructor_id}}', {
+        constructor_id: '12345',
+      });
+      expect(result.text).toBe('12345');
+    });
+
+    it('allows properties that end with reserved words', () => {
+      const result = resolveTemplatePlaceholders('{{my_constructor}}', {
+        my_constructor: 'Builder',
+      });
+      expect(result.text).toBe('Builder');
+    });
+  });
+
+  describe('multiple tokens with mixed valid and blocked paths', () => {
+    it('resolves valid paths and blocks reserved segments in same template', () => {
+      const result = resolveTemplatePlaceholders(
+        '{{name}} is {{age}} years old and {{__proto__}} is blocked',
+        {
+          name: 'Alice',
+          age: 30,
+        },
+      );
+      expect(result.text).toBe('Alice is 30 years old and  is blocked');
+    });
+
+    it('handles template with all blocked segments', () => {
+      const result = resolveTemplatePlaceholders('{{__proto__}} {{constructor}} {{prototype}}', {});
+      expect(result.text).toBe('  ');
+    });
+
+    it('handles template with all valid segments', () => {
+      const result = resolveTemplatePlaceholders('{{a}} {{b}} {{c}}', { a: '1', b: '2', c: '3' });
+      expect(result.text).toBe('1 2 3');
+    });
+  });
+});
+
+describe('determinism and purity', () => {
+  it('buildPlaceholderCandidatesFromJsonSchema returns identical output for identical input across two calls', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        b: { type: 'number' },
+        a: { type: 'string', description: 'first' },
+      },
+    };
+
+    const result1 = buildPlaceholderCandidatesFromJsonSchema(schema);
+    const result2 = buildPlaceholderCandidatesFromJsonSchema(schema);
+
+    expect(result1).toEqual(result2);
+  });
+
+  it('buildPlaceholderCandidatesFromJsonSchema does not mutate the input schema', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        name: { type: 'string', description: 'The name' },
+        nested: {
+          type: 'object',
+          properties: {
+            inner: { type: 'number' },
+          },
+        },
+      },
+    };
+
+    const schemaCopy = JSON.parse(JSON.stringify(schema));
+
+    buildPlaceholderCandidatesFromJsonSchema(schema);
+
+    expect(schema).toEqual(schemaCopy);
+  });
+
+  it('resolveTemplatePlaceholders returns identical output for identical input across two calls', () => {
+    const text = '{{a}} and {{b.c}}';
+    const values = { a: 'x', b: { c: 'y' } };
+
+    const result1 = resolveTemplatePlaceholders(text, values);
+    const result2 = resolveTemplatePlaceholders(text, values);
+
+    expect(result1).toEqual(result2);
+  });
+
+  it('resolveTemplatePlaceholders does not mutate the input values object', () => {
+    const values = { a: 'hello', nested: { b: [1, 2, 3] } };
+    const valuesCopy = JSON.parse(JSON.stringify(values));
+
+    resolveTemplatePlaceholders('{{a}} {{nested.b}} {{nested}}', values);
+
+    expect(values).toEqual(valuesCopy);
+  });
+});
+
+describe('DEP-625: XSS prevention via renderTemplate', () => {
+  // Tests use dynamic imports to avoid loading the heavy markdown rendering
+  // pipeline at module load time for lightweight function tests
+  describe('script tag removal', () => {
+    it('removes <script> tags from template', async () => {
+      const { renderTemplate } = await import('./template-render.js');
+      // Markdown parser treats the text "Hello" after raw HTML differently, so we wrap in markdown context
+      const html = renderTemplate('Hello <script>alert(1)</script> World', {});
+
+      expect(html).not.toContain('<script>');
+      expect(html).toContain('Hello');
+      expect(html).toContain('World');
+    });
+
+    it('removes <script> tags with attributes', async () => {
+      const { renderTemplate } = await import('./template-render.js');
+      const html = renderTemplate('Text <script type="text/javascript">alert(1)</script> more', {});
+
+      expect(html).not.toContain('<script>');
+      expect(html).not.toContain('type="text/javascript"');
+    });
+
+    it('removes multiple <script> tags', async () => {
+      const { renderTemplate } = await import('./template-render.js');
+      const html = renderTemplate(
+        'Start <script>alert(1)</script> Safe <script>alert(2)</script> End',
+        {},
+      );
+
+      expect(html).not.toContain('<script>');
+      expect(html).toContain('Safe');
+    });
+
+    it('removes <script> tags mixed with placeholders', async () => {
+      const { renderTemplate } = await import('./template-render.js');
+      const html = renderTemplate('Hello <script>alert(1)</script> {{name}}', {
+        name: 'Alice',
+      });
+
+      expect(html).not.toContain('<script>');
+      expect(html).toContain('Alice');
+    });
+  });
+
+  describe('event handler removal', () => {
+    it('removes onerror handler from img tag', async () => {
+      const { renderTemplate } = await import('./template-render.js');
+      const html = renderTemplate('<img src=x onerror=alert(1)>', {});
+
+      expect(html).not.toContain('onerror');
+      expect(html).not.toContain('alert');
+    });
+
+    it('removes onclick handler from div', async () => {
+      const { renderTemplate } = await import('./template-render.js');
+      const html = renderTemplate('<div onclick=alert(1)>Click me</div>', {});
+
+      expect(html).not.toContain('onclick');
+      expect(html).not.toContain('alert');
+    });
+
+    it('removes onload handler from body', async () => {
+      const { renderTemplate } = await import('./template-render.js');
+      const html = renderTemplate('<body onload=alert(1)>Content</body>', {});
+
+      expect(html).not.toContain('onload');
+      expect(html).not.toContain('alert');
+    });
+
+    it('removes onmouseover handler', async () => {
+      const { renderTemplate } = await import('./template-render.js');
+      const html = renderTemplate('<span onmouseover=alert(1)>Hover</span>', {});
+
+      expect(html).not.toContain('onmouseover');
+      expect(html).not.toContain('alert');
+    });
+
+    it('removes onfocus handler from input', async () => {
+      const { renderTemplate } = await import('./template-render.js');
+      const html = renderTemplate('<input onfocus=alert(1) value="test">', {});
+
+      expect(html).not.toContain('onfocus');
+      expect(html).not.toContain('alert');
+    });
+  });
+
+  describe('dangerous URL blocking', () => {
+    it('blocks javascript: URLs in links', async () => {
+      const { renderTemplate } = await import('./template-render.js');
+      const html = renderTemplate('[Click me](javascript:alert(1))', {});
+
+      expect(html).not.toContain('javascript:');
+      expect(html).not.toContain('alert');
+    });
+
+    it('blocks data: URLs in images by default', async () => {
+      const { renderTemplate } = await import('./template-render.js');
+      const html = renderTemplate('![img](data:text/html,<script>alert(1)</script>)', {});
+
+      expect(html).not.toContain('data:');
+      expect(html).not.toContain('<script>');
+      expect(html).not.toContain('alert');
+    });
+
+    it('blocks vbscript: URLs', async () => {
+      const { renderTemplate } = await import('./template-render.js');
+      const html = renderTemplate('[Click](vbscript:msgbox(1))', {});
+
+      expect(html).not.toContain('vbscript:');
+      expect(html).not.toContain('msgbox');
+    });
+
+    it('blocks file: URLs', async () => {
+      const { renderTemplate } = await import('./template-render.js');
+      const html = renderTemplate('[Local file](file:///etc/passwd)', {});
+
+      expect(html).not.toContain('file:');
+      expect(html).not.toContain('/etc/passwd');
+    });
+  });
+
+  describe('safe content preservation', () => {
+    it('preserves markdown headings', async () => {
+      const { renderTemplate } = await import('./template-render.js');
+      const html = renderTemplate('# Hello {{name}}', { name: 'World' });
+
+      expect(html).toContain('<h1');
+      expect(html).toContain('Hello World');
+      expect(html).toContain('</h1>');
+    });
+
+    it('preserves markdown emphasis', async () => {
+      const { renderTemplate } = await import('./template-render.js');
+      const html = renderTemplate('**bold** and *italic*', {});
+
+      expect(html).toContain('<strong>bold</strong>');
+      expect(html).toContain('<em>italic</em>');
+    });
+
+    it('preserves safe links (https)', async () => {
+      const { renderTemplate } = await import('./template-render.js');
+      const html = renderTemplate('[Link](https://example.com)', {});
+
+      expect(html).toContain('<a');
+      expect(html).toContain('href="https://example.com"');
+      expect(html).toContain('Link');
+      expect(html).toContain('</a>');
+    });
+
+    it('preserves safe links (http)', async () => {
+      const { renderTemplate } = await import('./template-render.js');
+      const html = renderTemplate('[Link](http://example.com)', {});
+
+      expect(html).toContain('<a');
+      expect(html).toContain('href="http://example.com"');
+    });
+
+    it('preserves mailto links', async () => {
+      const { renderTemplate } = await import('./template-render.js');
+      const html = renderTemplate('[Email](mailto:test@example.com)', {});
+
+      expect(html).toContain('<a');
+      expect(html).toContain('href="mailto:test@example.com"');
+    });
+
+    it('preserves markdown lists', async () => {
+      const { renderTemplate } = await import('./template-render.js');
+      const html = renderTemplate('- Item 1\n- Item 2', {});
+
+      expect(html).toContain('<ul');
+      expect(html).toContain('<li');
+      expect(html).toContain('Item 1');
+      expect(html).toContain('Item 2');
+    });
+
+    it('preserves code blocks', async () => {
+      const { renderTemplate } = await import('./template-render.js');
+      const html = renderTemplate('`inline code`', {});
+
+      expect(html).toContain('<code');
+      expect(html).toContain('inline code');
+    });
+
+    it('preserves blockquotes', async () => {
+      const { renderTemplate } = await import('./template-render.js');
+      const html = renderTemplate('> Quote', {});
+
+      expect(html).toContain('<blockquote');
+      expect(html).toContain('Quote');
+    });
+  });
+
+  describe('mixed malicious and safe content', () => {
+    it('sanitizes XSS while preserving safe markdown', async () => {
+      const { renderTemplate } = await import('./template-render.js');
+      const html = renderTemplate(
+        '# Title\n\n<script>alert(1)</script>\n\n**Safe text** {{name}}',
+        { name: 'Alice' },
+      );
+
+      expect(html).toContain('<h1');
+      expect(html).toContain('Title');
+      expect(html).toContain('<strong>Safe text</strong>');
+      expect(html).toContain('Alice');
+      expect(html).not.toContain('<script>');
+      expect(html).not.toContain('alert');
+    });
+
+    it('sanitizes event handlers while preserving content', async () => {
+      const { renderTemplate } = await import('./template-render.js');
+      const html = renderTemplate('**Bold** <div onclick=alert(1)>Click</div> *italic*', {});
+
+      expect(html).toContain('<strong>Bold</strong>');
+      expect(html).toContain('<em>italic</em>');
+      expect(html).not.toContain('onclick');
+      expect(html).not.toContain('alert');
+    });
+
+    it('handles placeholders that contain XSS attempts', async () => {
+      const { renderTemplate } = await import('./template-render.js');
+      const html = renderTemplate('Hello {{user}}', { user: '<script>alert(1)</script>' });
+
+      // The placeholder value is inserted as text, then markdown parsing treats
+      // the raw HTML node as unsafe and removes it. The text inside (alert(1))
+      // is preserved as safe text content.
+      expect(html).not.toContain('<script>');
+      expect(html).toContain('Hello');
+      expect(html).toContain('alert(1)'); // text content inside script is preserved
+    });
+
+    it('blocks prototype pollution in placeholders and sanitizes output', async () => {
+      const { renderTemplate } = await import('./template-render.js');
+      const html = renderTemplate('{{__proto__.isAdmin}} <script>alert(1)</script>', {});
+
+      // Both attacks blocked: prototype pollution returns empty, script removed
+      expect(html).not.toContain('<script>');
+      expect(html).not.toContain('alert');
+      expect(html).not.toContain('isAdmin');
+    });
+  });
+
+  describe('attribute-based XSS attempts', () => {
+    it('removes style attribute with expression()', async () => {
+      const { renderTemplate } = await import('./template-render.js');
+      const html = renderTemplate('<div style="width:expression(alert(1))">Test</div>', {});
+
+      expect(html).not.toContain('expression');
+      expect(html).not.toContain('alert');
+    });
+
+    it('removes javascript: in style url()', async () => {
+      const { renderTemplate } = await import('./template-render.js');
+      const html = renderTemplate(
+        '<div style="background:url(javascript:alert(1))">Test</div>',
+        {},
+      );
+
+      expect(html).not.toContain('javascript:');
+      expect(html).not.toContain('alert');
+    });
+
+    it('removes srcdoc attribute from iframe', async () => {
+      const { renderTemplate } = await import('./template-render.js');
+      const html = renderTemplate('<iframe srcdoc="<script>alert(1)</script>"></iframe>', {});
+
+      expect(html).not.toContain('srcdoc');
+      expect(html).not.toContain('<script>');
+      expect(html).not.toContain('alert');
+    });
+
+    it('removes formaction attribute', async () => {
+      const { renderTemplate } = await import('./template-render.js');
+      const html = renderTemplate('<button formaction="javascript:alert(1)">Click</button>', {});
+
+      expect(html).not.toContain('formaction');
+      expect(html).not.toContain('javascript:');
+      expect(html).not.toContain('alert');
+    });
+  });
+
+  describe('edge cases and complex attacks', () => {
+    it('handles nested HTML entities', async () => {
+      const { renderTemplate } = await import('./template-render.js');
+      const html = renderTemplate('&lt;script&gt;alert(1)&lt;/script&gt;', {});
+
+      // HTML entities in markdown are treated as plain text
+      // The markdown renderer wraps text in block elements (e.g., <p>)
+      expect(html).not.toContain('<script>');
+      // Verify the entity-encoded content is safely rendered
+      // rehype-stringify encodes < as &#x3C; but may leave > unencoded (both are valid HTML)
+      expect(html).toMatch(/(&lt;|&#x3C;)/);
+      expect(html).toContain('alert(1)');
+      // > can appear as &gt;, &#x3E;, or unencoded (all valid)
+      expect(html).toMatch(/(&gt;|&#x3E;|>)/);
+    });
+
+    it('blocks case variations of script tag', async () => {
+      const { renderTemplate } = await import('./template-render.js');
+      const html = renderTemplate('Text <ScRiPt>alert(1)</ScRiPt> more', {});
+
+      expect(html).not.toContain('<ScRiPt>');
+      expect(html).not.toContain('<script>');
+    });
+
+    it('handles SVG-based XSS attempts', async () => {
+      const { renderTemplate } = await import('./template-render.js');
+      const html = renderTemplate('Text <svg><script>alert(1)</script></svg> more', {});
+
+      expect(html).not.toContain('<script>');
+      expect(html).not.toContain('<svg>');
+      // The text inside is preserved
+      expect(html).toContain('alert(1)');
+    });
+
+    it('blocks object/embed tags', async () => {
+      const { renderTemplate } = await import('./template-render.js');
+      const html = renderTemplate('<object data="javascript:alert(1)"></object>', {});
+
+      expect(html).not.toContain('<object');
+      expect(html).not.toContain('javascript:');
+      expect(html).not.toContain('alert');
+    });
+
+    it('handles empty template gracefully', async () => {
+      const { renderTemplate } = await import('./template-render.js');
+      const html = renderTemplate('', {});
+
+      expect(html).toBe('');
+    });
+
+    it('handles template with only placeholders', async () => {
+      const { renderTemplate } = await import('./template-render.js');
+      const html = renderTemplate('{{a}} {{b}} {{c}}', { a: '1', b: '2', c: '3' });
+
+      expect(html).toContain('1');
+      expect(html).toContain('2');
+      expect(html).toContain('3');
+    });
+  });
+});

--- a/packages/editor/src/template-placeholders.ts
+++ b/packages/editor/src/template-placeholders.ts
@@ -1,0 +1,414 @@
+/**
+ * Template placeholder domain logic for saved-prompt/template authoring.
+ *
+ * Pure functions for JSON Schema candidate extraction, {{path}} token parsing,
+ * validation against known paths, and deterministic template resolution.
+ *
+ * DEP-582: No ProseMirror or DOM dependencies.
+ * DEP-625: For secure markdown rendering with sanitization, use renderTemplate from template-render.ts
+ */
+
+import { renderMarkdown } from '@cinder/markdown/rendering';
+import { RESERVED_SEGMENTS } from './placeholder-security.js';
+import type {
+  PlaceholderCandidate,
+  PlaceholderResolutionResult,
+  PlaceholderToken,
+  PlaceholderValidationIssue,
+  PlaceholderValidationResult,
+  PlaceholderValueKind,
+} from './types.js';
+
+/** Valid placeholder path pattern: dot-separated identifiers starting with letter or underscore */
+const PATH_REGEX = /^[A-Za-z_][A-Za-z0-9_]*(\.[A-Za-z_][A-Za-z0-9_]*)*$/;
+
+/** Valid single path segment: one identifier (no dots) */
+const SEGMENT_REGEX = /^[A-Za-z_][A-Za-z0-9_]*$/;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+/**
+ * Validate a single path segment against security rules.
+ *
+ * DEP-625: Central security validation to prevent prototype pollution.
+ * - Blocks empty segments (e.g., from "user..name")
+ * - Enforces identifier rules (must match SEGMENT_REGEX)
+ * - Blocks reserved segments (case-insensitive)
+ * - Blocks segments starting with '__' (dunder properties)
+ *
+ * Returns true if the segment is blocked (invalid), false if allowed.
+ *
+ * @internal - Shared by template-placeholders.ts and preview-composer.ts
+ */
+export function isBlockedSegment(segment: string): boolean {
+  // Block empty segments (e.g., from "user..name")
+  if (segment === '') {
+    return true;
+  }
+
+  // Enforce identifier rules (must match SEGMENT_REGEX)
+  if (!SEGMENT_REGEX.test(segment)) {
+    return true;
+  }
+
+  // Block reserved segments (case-insensitive)
+  if (RESERVED_SEGMENTS.has(segment.toLowerCase())) {
+    return true;
+  }
+
+  // Block segments starting with '__' (dunder properties)
+  // Note: SEGMENT_REGEX allows '__' prefixes (e.g., '__proto__', '__custom__')
+  // since '_' is a valid identifier character. This check is the only guard
+  // against arbitrary '__'-prefixed segments not in RESERVED_SEGMENTS.
+  if (segment.startsWith('__')) {
+    return true;
+  }
+
+  return false;
+}
+
+/**
+ * Map a JSON Schema `type` value to a PlaceholderValueKind.
+ * Returns 'unknown' for missing or unsupported type values.
+ */
+function mapSchemaTypeToValueKind(type: unknown): PlaceholderValueKind {
+  switch (type) {
+    case 'string':
+      return 'string';
+    case 'number':
+    case 'integer':
+      return 'number';
+    case 'boolean':
+      return 'boolean';
+    case 'array':
+      return 'array';
+    case 'object':
+      return 'object';
+    default:
+      return 'unknown';
+  }
+}
+
+/**
+ * Traverse a nested object by dot-separated path segments.
+ * Returns undefined if any segment is missing or a non-object intermediate is encountered.
+ *
+ * DEP-625: Hardened against prototype pollution attacks.
+ * - Validates all segments before resolution using isBlockedSegment()
+ * - Uses Object.hasOwn() to prevent prototype chain traversal
+ *
+ * This function enforces the same identifier rules as PATH_REGEX/SEGMENT_REGEX
+ * to ensure resolution behavior matches validation/candidate generation.
+ */
+function getNestedValue(values: Record<string, unknown>, path: string): unknown {
+  const segments = path.split('.');
+
+  // Validate all segments before resolution (DEP-625)
+  for (const segment of segments) {
+    if (isBlockedSegment(segment)) {
+      return undefined;
+    }
+  }
+
+  // Traverse the path using validated segments
+  let current: unknown = values;
+
+  for (const segment of segments) {
+    if (!isRecord(current)) {
+      return undefined;
+    }
+    // Use Object.hasOwn to avoid traversing the prototype chain. Without this
+    // guard, paths like "constructor" or "toString" resolve to inherited
+    // functions, which JSON.stringify coerces to the literal text "undefined"
+    // instead of the expected empty string.
+    if (!Object.hasOwn(current, segment)) {
+      return undefined;
+    }
+    current = current[segment];
+  }
+
+  return current;
+}
+
+/**
+ * Format a value for placeholder replacement using strict coercion rules.
+ *
+ * - undefined/null → ''
+ * - function/symbol → '' (JSON.stringify returns undefined for these types,
+ *   which string concatenation coerces to the literal text "undefined")
+ * - string → unchanged
+ * - number/boolean/bigint → String(value)
+ * - array → map items then join(', ')
+ * - object → JSON.stringify(value)
+ */
+function formatValueForReplacement(value: unknown): string {
+  if (value === undefined || value === null) {
+    return '';
+  }
+
+  // JSON.stringify returns undefined (not a string) for function and symbol
+  // values. String concatenation then coerces that to the literal text
+  // "undefined" rather than the expected empty string.
+  if (typeof value === 'function' || typeof value === 'symbol') {
+    return '';
+  }
+
+  if (typeof value === 'string') {
+    return value;
+  }
+
+  if (typeof value === 'number' || typeof value === 'boolean' || typeof value === 'bigint') {
+    return String(value);
+  }
+
+  if (Array.isArray(value)) {
+    return value
+      .map((item) => {
+        if (item === null || item === undefined) {
+          return '';
+        }
+        // Mirror the top-level function/symbol guard: JSON.stringify returns
+        // undefined for these types, and String() produces function source code
+        // or "Symbol(...)" — both inconsistent with the documented '' contract.
+        if (typeof item === 'function' || typeof item === 'symbol') {
+          return '';
+        }
+        if (typeof item === 'object') {
+          return JSON.stringify(item);
+        }
+        return String(item);
+      })
+      .join(', ');
+  }
+
+  return JSON.stringify(value);
+}
+
+/**
+ * Extract placeholder candidates from a JSON Schema by recursively walking `properties`.
+ *
+ * For each property:
+ * 1. Build the dot-separated path (e.g., "input.x").
+ * 2. Determine valueKind from the type field.
+ * 3. Extract description (string or undefined).
+ * 4. Emit a candidate for the current path.
+ * 5. If the property has nested properties, recurse (regardless of explicit type: 'object').
+ * 6. Silently ignore $ref, allOf, anyOf, oneOf, if/then/else, patternProperties, additionalProperties.
+ *
+ * Returns candidates sorted lexicographically by path.
+ */
+export function buildPlaceholderCandidatesFromJsonSchema(
+  schema: Record<string, unknown>,
+): PlaceholderCandidate[] {
+  const candidates: PlaceholderCandidate[] = [];
+
+  function walk(properties: Record<string, unknown>, prefix: string): void {
+    for (const key of Object.keys(properties)) {
+      // Skip keys that are not valid identifier segments — paths containing
+      // non-identifier characters (e.g. "first-name", "first.name") cannot
+      // be emitted as candidates because validatePlaceholderTokens would
+      // reject them as invalid_path_format and resolveTemplatePlaceholders
+      // would mis-resolve them by splitting on dots.
+      if (!SEGMENT_REGEX.test(key)) {
+        continue;
+      }
+
+      const property = properties[key];
+
+      if (!isRecord(property)) {
+        continue;
+      }
+
+      const path = prefix ? `${prefix}.${key}` : key;
+      const valueKind = mapSchemaTypeToValueKind(property['type']);
+      const description =
+        typeof property['description'] === 'string' ? property['description'] : undefined;
+
+      candidates.push({ path, description, valueKind });
+
+      // Recurse into nested properties regardless of explicit type: 'object'
+      if (isRecord(property['properties'])) {
+        walk(property['properties'], path);
+      }
+    }
+  }
+
+  if (isRecord(schema['properties'])) {
+    walk(schema['properties'], '');
+  }
+
+  return candidates.toSorted((a, b) => (a.path < b.path ? -1 : a.path > b.path ? 1 : 0));
+}
+
+/**
+ * Parse all {{...}} tokens from the given text with source offsets.
+ *
+ * Scans for {{ delimiters and extracts tokens with:
+ * - raw: full text including delimiters
+ * - path: trimmed body between delimiters
+ * - startOffset/endOffset: source positions
+ * - closed: whether the token has a closing }}
+ *
+ * Never throws for any input.
+ */
+export function parsePlaceholderTokens(text: string): PlaceholderToken[] {
+  const tokens: PlaceholderToken[] = [];
+  let position = 0;
+
+  while (position < text.length) {
+    const openIndex = text.indexOf('{{', position);
+
+    if (openIndex === -1) {
+      break;
+    }
+
+    const closeIndex = text.indexOf('}}', openIndex + 2);
+
+    if (closeIndex !== -1) {
+      const raw = text.slice(openIndex, closeIndex + 2);
+      const path = raw.slice(2, -2).trim();
+      tokens.push({
+        raw,
+        path,
+        startOffset: openIndex,
+        endOffset: closeIndex + 2,
+        closed: true,
+      });
+      position = closeIndex + 2;
+    } else {
+      const raw = text.slice(openIndex);
+      const path = raw.slice(2).trim();
+      tokens.push({
+        raw,
+        path,
+        startOffset: openIndex,
+        endOffset: text.length,
+        closed: false,
+      });
+      break;
+    }
+  }
+
+  return tokens;
+}
+
+/**
+ * Validate parsed tokens against a set of known placeholder candidates.
+ *
+ * Classifies each token as valid or invalid:
+ * - Unclosed tokens → malformed_token
+ * - Invalid path format → invalid_path_format
+ * - Path not in candidate set → unknown_placeholder
+ * - Otherwise → valid
+ */
+export function validatePlaceholderTokens(
+  tokens: PlaceholderToken[],
+  candidates: PlaceholderCandidate[],
+): PlaceholderValidationResult {
+  const candidatePaths = new Set(candidates.map((candidate) => candidate.path));
+  const validTokens: PlaceholderToken[] = [];
+  const invalidTokens: PlaceholderToken[] = [];
+  const issues: PlaceholderValidationIssue[] = [];
+
+  for (const token of tokens) {
+    if (!token.closed) {
+      invalidTokens.push(token);
+      issues.push({ token, reason: 'malformed_token' });
+    } else if (!PATH_REGEX.test(token.path)) {
+      invalidTokens.push(token);
+      issues.push({ token, reason: 'invalid_path_format' });
+    } else if (!candidatePaths.has(token.path)) {
+      invalidTokens.push(token);
+      issues.push({ token, reason: 'unknown_placeholder' });
+    } else {
+      validTokens.push(token);
+    }
+  }
+
+  return { validTokens, invalidTokens, issues };
+}
+
+/**
+ * Resolve all placeholder tokens in the given text by substituting values.
+ *
+ * Iterates tokens in reverse order to preserve earlier offsets during string splicing.
+ * Unclosed tokens are left in the text unmodified.
+ * When candidatePaths is provided, unknown paths are reported as issues.
+ */
+export function resolveTemplatePlaceholders(
+  text: string,
+  values: Record<string, unknown>,
+  candidatePaths?: string[],
+): PlaceholderResolutionResult {
+  const tokens = parsePlaceholderTokens(text);
+  const candidateSet = candidatePaths ? new Set(candidatePaths) : undefined;
+  const issues: PlaceholderValidationIssue[] = [];
+
+  // Iterate in reverse to preserve offsets during splicing. Issues are
+  // collected in reverse traversal order and sorted by startOffset before
+  // return so downstream consumers receive them in forward document order,
+  // consistent with validatePlaceholderTokens.
+  for (let i = tokens.length - 1; i >= 0; i--) {
+    const token = tokens[i];
+    if (!token) continue;
+
+    if (!token.closed) {
+      continue;
+    }
+
+    const value = getNestedValue(values, token.path);
+    const replacement = formatValueForReplacement(value);
+    text = text.slice(0, token.startOffset) + replacement + text.slice(token.endOffset);
+
+    if (candidateSet && !candidateSet.has(token.path) && PATH_REGEX.test(token.path)) {
+      issues.push({ token, reason: 'unknown_placeholder' });
+    }
+  }
+
+  // Sort issues in forward document order so callers receive a consistent
+  // ordering regardless of whether they came from this function (which
+  // traverses tokens in reverse) or validatePlaceholderTokens (which
+  // traverses forward).
+  const sortedIssues = issues.toSorted((a, b) => a.token.startOffset - b.token.startOffset);
+
+  return { text, issues: sortedIssues };
+}
+
+/**
+ * Render a template with placeholder substitution and markdown-to-HTML conversion.
+ *
+ * DEP-625: This function provides a secure rendering pipeline that:
+ * 1. Resolves placeholders using the hardened getNestedValue() (blocks prototype pollution)
+ * 2. Converts markdown to HTML using @cinder/markdown's sanitized pipeline
+ * 3. Sanitizes output via rehype-sanitize (blocks XSS attacks)
+ *
+ * Security guarantees:
+ * - Prototype pollution prevented via reserved segment blocking in getNestedValue()
+ * - XSS prevented via markdown pipeline's raw HTML removal and rehype-sanitize
+ * - Script tags, event handlers, and dangerous URLs are stripped
+ * - Only safe HTML tags and attributes are allowed
+ *
+ * @param template - Template string with {{placeholder}} tokens
+ * @param values - Data object for placeholder resolution
+ * @returns Sanitized HTML string safe for rendering
+ *
+ * @example
+ * ```typescript
+ * const html = renderTemplate('# Hello {{name}}', { name: 'World' });
+ * // Returns: '<h1>Hello World</h1>'
+ *
+ * const xss = renderTemplate('<script>alert(1)</script>{{user}}', { user: 'Alice' });
+ * // Returns: 'Alice' (script tag removed by markdown pipeline)
+ * ```
+ */
+export function renderTemplate(template: string, values: Record<string, unknown>): string {
+  // Resolve placeholders using the hardened path resolution from Phase 1
+  const { text } = resolveTemplatePlaceholders(template, values);
+
+  // Render markdown to sanitized HTML using the existing secure pipeline
+  const result = renderMarkdown(text);
+
+  return result.html;
+}

--- a/packages/editor/src/template-position-utilities.ts
+++ b/packages/editor/src/template-position-utilities.ts
@@ -1,0 +1,71 @@
+/**
+ * Shared position-conversion utilities for template placeholder plugins.
+ *
+ * Both the completion plugin and the invalid-decoration plugin need to convert
+ * a character offset within a block's `textContent` to an absolute ProseMirror
+ * document position. This module provides a single canonical implementation so
+ * the two plugins cannot diverge.
+ *
+ * DEP-583: Extracted from template-completion-plugin and
+ * template-invalid-decoration-plugin to eliminate duplicated logic that
+ * previously had divergent atom-boundary behaviour.
+ */
+
+import type { Node as ProseMirrorNode } from '@milkdown/kit/prose/model';
+
+/**
+ * Convert a text-coordinate offset within a block's `textContent` to an
+ * absolute ProseMirror document position.
+ *
+ * Walks the block's inline children, counting only text characters (atom
+ * nodes such as `hard_break` and images contribute nothing to the text
+ * coordinate space, but `childOffset` already accounts for their document
+ * size). The function does **not** short-circuit after finding the first
+ * matching text node, so later text nodes can overwrite `result` correctly
+ * when `textOffset` falls exactly on a boundary between a text node and an
+ * atom.
+ *
+ * @param block - The block-level ProseMirror node (paragraph, heading, etc.).
+ * @param blockContentStart - The absolute document position of the first
+ *   character inside the block (i.e. `$from.start()` or `blockPosition + 1`).
+ * @param textOffset - A character offset into `block.textContent`.
+ * @returns The absolute ProseMirror position corresponding to `textOffset`.
+ *
+ * @internal Exported for testing only.
+ */
+export function textOffsetToBlockDocumentPosition(
+  block: ProseMirrorNode,
+  blockContentStart: number,
+  textOffset: number,
+): number {
+  let accumulated = 0;
+  let result = blockContentStart;
+
+  block.forEach((child, childOffset) => {
+    if (accumulated > textOffset) return;
+
+    if (child.isText && child.text) {
+      const localOffset = textOffset - accumulated;
+      if (localOffset <= child.text.length) {
+        result = blockContentStart + childOffset + localOffset;
+      }
+      // Always advance accumulated so subsequent text nodes get the correct
+      // localOffset. The early-exit pattern (`accumulated = textOffset + 1`)
+      // must NOT be used here: when textOffset falls at the exact boundary
+      // between a text node and a following atom, the early exit would
+      // prevent the next iteration from overwriting `result` with the
+      // correct position.
+      accumulated += child.text.length;
+    } else if (!child.isAtom) {
+      // Non-text, non-atom inline nodes (e.g., mark-wrapped spans) contribute
+      // their text to `block.textContent`, so we count them here to keep
+      // `accumulated` aligned with the text coordinate space. Atom nodes
+      // (hard_break, images) are intentionally excluded because they
+      // contribute zero text characters; `childOffset` already incorporates
+      // their document-position size.
+      accumulated += child.textContent.length;
+    }
+  });
+
+  return result;
+}

--- a/packages/editor/src/template-render.ts
+++ b/packages/editor/src/template-render.ts
@@ -1,0 +1,49 @@
+/**
+ * Secure template rendering with placeholder substitution and markdown-to-HTML conversion.
+ *
+ * DEP-625: This module is separated from template-placeholders.ts to avoid loading the
+ * heavy @cinder/markdown rendering pipeline for consumers that only need lightweight
+ * placeholder parsing/validation functions.
+ *
+ * @module
+ */
+
+import { renderMarkdown } from '@cinder/markdown/rendering';
+import { resolveTemplatePlaceholders } from './template-placeholders.js';
+
+/**
+ * Render a template with placeholder substitution and markdown-to-HTML conversion.
+ *
+ * DEP-625: This function provides a secure rendering pipeline that:
+ * 1. Resolves placeholders using the hardened getNestedValue() (blocks prototype pollution)
+ * 2. Converts markdown to HTML using @cinder/markdown's sanitized pipeline
+ * 3. Sanitizes output via rehype-sanitize (blocks XSS attacks)
+ *
+ * Security guarantees:
+ * - Prototype pollution prevented via reserved segment blocking in getNestedValue()
+ * - XSS prevented via markdown pipeline's raw HTML removal and rehype-sanitize
+ * - Script tags, event handlers, and dangerous URLs are stripped (entirely removed, including content)
+ * - Only safe HTML tags and attributes are allowed
+ *
+ * @param template - Template string with {{placeholder}} tokens
+ * @param values - Data object for placeholder resolution
+ * @returns Sanitized HTML string safe for rendering
+ *
+ * @example
+ * ```typescript
+ * const html = renderTemplate('# Hello {{name}}', { name: 'World' });
+ * // Returns: '<h1>Hello World</h1>'
+ *
+ * const xss = renderTemplate('<script>alert(1)</script>{{user}}', { user: 'Alice' });
+ * // Returns: '<p>Alice</p>' (script tag and its contents removed; text wrapped in a paragraph by the markdown renderer)
+ * ```
+ */
+export function renderTemplate(template: string, values: Record<string, unknown>): string {
+  // Resolve placeholders using the hardened path resolution from Phase 1
+  const { text } = resolveTemplatePlaceholders(template, values);
+
+  // Render markdown to sanitized HTML using the existing secure pipeline
+  const result = renderMarkdown(text);
+
+  return result.html;
+}

--- a/packages/editor/src/test-utilities.ts
+++ b/packages/editor/src/test-utilities.ts
@@ -1,0 +1,117 @@
+/**
+ * Test utilities for creating ProseMirror documents from markdown.
+ *
+ * These utilities require a browser environment (DOM) to work.
+ * Use in `.svelte.test.ts` files which run in browser context.
+ *
+ * @module
+ */
+
+import { defaultValueCtx, Editor, editorViewCtx, rootCtx } from '@milkdown/kit/core';
+import { commonmark } from '@milkdown/kit/preset/commonmark';
+import { gfm } from '@milkdown/kit/preset/gfm';
+import type { Node as ProseMirrorNode } from '@milkdown/kit/prose/model';
+
+/**
+ * Result of creating a test document.
+ */
+export interface TestDocument {
+  /** The ProseMirror document node */
+  doc: ProseMirrorNode;
+  /** Full text content via doc.textBetween() */
+  text: string;
+  /** Cleanup function - call in afterEach */
+  destroy: () => void;
+}
+
+/**
+ * Create a ProseMirror document from markdown for testing.
+ *
+ * This creates a minimal Milkdown editor with the same schema used in production
+ * (CommonMark + GFM), extracts the document, and returns it for testing.
+ *
+ * @param markdown - Markdown content to parse
+ * @returns TestDocument with doc, text, and cleanup function
+ *
+ * @example
+ * ```typescript
+ * const { doc, text, destroy } = await createDocFromMarkdown('# Hello\n\nWorld');
+ * try {
+ *   expect(text).toBe('Hello\nWorld');
+ * } finally {
+ *   destroy();
+ * }
+ * ```
+ */
+export async function createDocFromMarkdown(markdown: string): Promise<TestDocument> {
+  if (typeof document === 'undefined') {
+    throw new Error('createDocFromMarkdown() requires a browser document.');
+  }
+
+  // Create a hidden container for the editor
+  const container = document.createElement('div');
+  container.style.position = 'absolute';
+  container.style.left = '-9999px';
+  container.style.top = '-9999px';
+  document.body.appendChild(container);
+
+  // Create minimal editor with same schema as production
+  const editor = await Editor.make()
+    .config((ctx) => {
+      ctx.set(rootCtx, container);
+      ctx.set(defaultValueCtx, markdown);
+    })
+    .use(commonmark)
+    .use(gfm)
+    .create();
+
+  // Extract the document
+  const view = editor.ctx.get(editorViewCtx);
+  const doc = view.state.doc;
+  const text = doc.textBetween(0, doc.content.size, '\n');
+
+  return {
+    doc,
+    text,
+    destroy: () => {
+      void editor.destroy();
+      container.remove();
+    },
+  };
+}
+
+/**
+ * Debug helper: Print document structure to console.
+ *
+ * Useful for understanding ProseMirror node structure during test development.
+ *
+ * @param doc - ProseMirror document to inspect
+ * @param maxDepth - Maximum depth to print (default: 5)
+ */
+export function debugDocStructure(doc: ProseMirrorNode, maxDepth = 5): void {
+  function printNode(node: ProseMirrorNode, pos: number, indent: number): void {
+    if (indent > maxDepth) {
+      console.log('  '.repeat(indent) + '...');
+      return;
+    }
+
+    const isTextblock = node.isTextblock ? ' (textblock)' : '';
+    const isBlock = node.isBlock ? ' (block)' : '';
+    const content = node.isText ? `: "${node.text}"` : '';
+
+    console.log(
+      '  '.repeat(indent) +
+        `${node.type.name} [${pos}, ${pos + node.nodeSize})${isTextblock}${isBlock}${content}`,
+    );
+
+    if (!node.isLeaf) {
+      const childPos = pos + 1;
+      node.forEach((child, offset) => {
+        printNode(child, childPos + offset, indent + 1);
+      });
+    }
+  }
+
+  console.log('Document structure:');
+  printNode(doc, 0, 0);
+}

--- a/packages/editor/src/types.ts
+++ b/packages/editor/src/types.ts
@@ -1,0 +1,259 @@
+/**
+ * Types for the Milkdown editor integration.
+ *
+ * This module defines the public API surface for the editor,
+ * including configuration, handle interface, and selection state.
+ */
+
+import type { SourcePosition } from '@cinder/markdown/diff/types';
+import type { Root } from '@cinder/markdown/pipeline';
+import type { MilkdownPlugin } from '@milkdown/ctx';
+import type { Editor } from '@milkdown/kit/core';
+import type { EditorView } from '@milkdown/kit/prose/view';
+
+/**
+ * Editor configuration options.
+ */
+export interface EditorConfig {
+  /** Initial markdown content */
+  initialContent?: string;
+  /** Read-only mode (no editing allowed) */
+  readonly?: boolean;
+  /** Accessible label for the editor (applied to ProseMirror element) */
+  ariaLabel?: string;
+  /** Debounce interval for onChange callback (ms) */
+  changeDebounceMs?: number;
+  /** Callback when content changes (debounced) */
+  onChange?: (markdown: string) => void;
+  /** Callback when selection changes (stub for DEP-39) */
+  onSelectionChange?: (selection: EditorSelection | null) => void;
+  /** Callback when link keyboard shortcut (Mod-k) is pressed */
+  onLinkShortcut?: () => void;
+  /** Callback when comment shortcut (Ctrl-Alt-c) is pressed (DEP-47) */
+  onCommentShortcut?: () => void;
+  /**
+   * Additional Milkdown plugins to load.
+   *
+   * Use this for comment anchoring, decorations, and other extensions.
+   * Plugins are applied after the core plugins (commonmark, gfm, history, listener).
+   *
+   * @example
+   * ```typescript
+   * plugins: [createAnchorPlugin(threads)]
+   * ```
+   */
+  plugins?: MilkdownPlugin[];
+
+  /**
+   * Placeholder completion configuration (DEP-583).
+   * When provided, enables inline suggestion menu for `{{…}}` tokens in WYSIWYG mode.
+   */
+  placeholderCompletion?: PlaceholderCompletionConfiguration;
+
+  /**
+   * Placeholder decoration configuration (DEP-583).
+   * When provided, decorates invalid `{{…}}` tokens with CSS class and data attributes.
+   */
+  placeholderDecoration?: PlaceholderDecorationConfiguration;
+}
+
+/**
+ * Selection state exposed to consumers.
+ * Used for comment anchoring (DEP-39) and suggested edits (DEP-43).
+ */
+export interface EditorSelection {
+  /** ProseMirror start position */
+  from: number;
+  /** ProseMirror end position */
+  to: number;
+  /** Is the selection collapsed (cursor only)? */
+  isCollapsed: boolean;
+  /** Mapped to mdast position via bridge (when available) */
+  sourcePosition?: SourcePosition | null;
+}
+
+/**
+ * Imperative handle for external control of the editor.
+ * Exposed via bind:this on the component.
+ */
+export interface EditorHandle {
+  /** Focus the editor */
+  focus(): void;
+
+  /** Get current markdown content */
+  getMarkdown(): string;
+
+  /** Set markdown content (replaces entire document) */
+  setMarkdown(content: string): void;
+
+  /** Get current mdast AST (via DEP-35 pipeline) */
+  getAst(): Root;
+
+  /** Get current selection state */
+  getSelection(): EditorSelection | null;
+
+  /**
+   * Direct access to ProseMirror EditorView.
+   * Advanced use only - for DEP-39/43 integration.
+   */
+  readonly view: EditorView | null;
+
+  /**
+   * Direct access to Milkdown Editor instance.
+   * Advanced use only.
+   */
+  readonly editor: Editor | null;
+}
+
+/**
+ * Internal state for the editor attachment.
+ */
+export interface EditorState {
+  editor: Editor;
+  view: EditorView;
+  focus(): void;
+  getMarkdown(): string;
+  setMarkdown(content: string): void;
+  /** Clear any pending debounce timers (called on destroy) */
+  clearPendingTimers(): void;
+  /** Mark the editor as destroyed to prevent callbacks from firing after cleanup */
+  markDestroyed(): void;
+}
+
+/**
+ * Options for the editor attachment factory.
+ */
+export interface EditorAttachmentOptions {
+  /** Get initial markdown value */
+  getInitialValue: () => string;
+  /** Get current readonly state */
+  getReadonly: () => boolean;
+  /** Get accessible label for the editor */
+  getAriaLabel: () => string;
+  /** Called when editor is ready */
+  onReady?: (state: EditorState) => void;
+  /** Called when document changes (debounced) */
+  onChange?: (markdown: string) => void;
+  /** Called when selection changes */
+  onSelectionChange?: (selection: EditorSelection | null) => void;
+  /** Called when link keyboard shortcut (Mod-k) is pressed */
+  onLinkShortcut?: () => void;
+  /** Called when comment shortcut (Ctrl-Alt-c) is pressed (DEP-47) */
+  onCommentShortcut?: () => void;
+  /** Debounce delay for onChange in ms */
+  debounceMs?: number;
+  /**
+   * Additional Milkdown plugins to load.
+   * Used for comment anchoring (DEP-39), decorations, and other extensions.
+   */
+  getPlugins?: () => MilkdownPlugin[];
+
+  /**
+   * Get placeholder completion configuration (DEP-583).
+   * Returns undefined to disable, or a configuration object to enable.
+   */
+  getPlaceholderCompletion?: () => PlaceholderCompletionConfiguration | undefined;
+
+  /**
+   * Get placeholder decoration configuration (DEP-583).
+   * Returns undefined to disable, or a configuration object to enable.
+   */
+  getPlaceholderDecoration?: () => PlaceholderDecorationConfiguration | undefined;
+}
+
+/** Default debounce for content changes (matches DiffViewer) */
+export const DEFAULT_DEBOUNCE_MS = 300;
+
+// Template placeholder types (DEP-582)
+
+/** Value kind inferred from JSON Schema type field */
+export type PlaceholderValueKind = 'string' | 'number' | 'boolean' | 'array' | 'object' | 'unknown';
+
+/** A single candidate path extracted from a JSON Schema */
+export interface PlaceholderCandidate {
+  /** Dot-separated property path (e.g., "input.x") */
+  path: string;
+  /** Schema description, if present */
+  description: string | undefined;
+  /** Inferred value kind from the schema type field */
+  valueKind: PlaceholderValueKind;
+}
+
+/** A parsed {{...}} token with source offsets */
+export interface PlaceholderToken {
+  /** The full raw text including delimiters (e.g., "{{ input.x }}") */
+  raw: string;
+  /** The trimmed path body (may be empty for malformed tokens) */
+  path: string;
+  /** Inclusive start offset in the source text */
+  startOffset: number;
+  /** Exclusive end offset in the source text */
+  endOffset: number;
+  /** Whether the token has a closing }} */
+  closed: boolean;
+}
+
+/** A single validation problem */
+export interface PlaceholderValidationIssue {
+  /** The token that caused the issue */
+  token: PlaceholderToken;
+  /** Exact string reason */
+  reason: 'malformed_token' | 'invalid_path_format' | 'unknown_placeholder';
+}
+
+/** Full validation output */
+export interface PlaceholderValidationResult {
+  validTokens: PlaceholderToken[];
+  invalidTokens: PlaceholderToken[];
+  issues: PlaceholderValidationIssue[];
+}
+
+/** Output from resolveTemplatePlaceholders */
+export interface PlaceholderResolutionResult {
+  /** The resolved text with placeholders replaced */
+  text: string;
+  /** Validation issues found during resolution (when candidate paths provided) */
+  issues: PlaceholderValidationIssue[];
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Placeholder completion & decoration configuration (DEP-583)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Configuration for the placeholder completion menu in WYSIWYG mode.
+ *
+ * When provided, the editor shows an inline suggestion popup as the user
+ * types inside `{{…}}` tokens.
+ */
+export interface PlaceholderCompletionConfiguration {
+  /** Static candidate paths available for completion */
+  candidates: PlaceholderCandidate[];
+
+  /**
+   * Optional async lookup for additional candidates.
+   * Called after `lookupDebounceMs` with the current query text.
+   * The signal is aborted when the query changes or the menu closes.
+   */
+  lookupCandidates?: (query: string, signal: AbortSignal) => Promise<PlaceholderCandidate[]>;
+
+  /** Minimum query length before showing suggestions (default: 1) */
+  minimumQueryLength?: number;
+
+  /** Debounce interval for async lookup calls in ms (default: 150) */
+  lookupDebounceMs?: number;
+}
+
+/**
+ * Configuration for invalid-token decoration in WYSIWYG mode.
+ *
+ * When provided, the editor decorates `{{…}}` tokens that fail validation
+ * with a CSS class and a data attribute describing the failure reason.
+ */
+export interface PlaceholderDecorationConfiguration {
+  /** Known candidates used for validation */
+  candidates: PlaceholderCandidate[];
+
+  /** CSS class applied to invalid tokens (default: 'template-placeholder-invalid') */
+  invalidClassName?: string;
+}

--- a/packages/editor/tsconfig.build.json
+++ b/packages/editor/tsconfig.build.json
@@ -1,0 +1,15 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "declaration": true,
+    "allowImportingTsExtensions": false,
+    "incremental": false,
+    "rootDir": "./src",
+    "outDir": "./dist",
+    "sourceMap": true,
+    "inlineSources": true
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "**/*.test.ts", "**/*.spec.ts"]
+}

--- a/packages/editor/tsconfig.check.json
+++ b/packages/editor/tsconfig.check.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": [
+    "node_modules",
+    "coverage",
+    "**/dist/**",
+    "**/build/**",
+    "**/*.test.ts",
+    "**/*.spec.ts"
+  ]
+}

--- a/packages/editor/tsconfig.json
+++ b/packages/editor/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "tsBuildInfoFile": "node_modules/.cache/tsconfig.tsbuildinfo",
+    "rootDir": ".",
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  },
+  "include": ["src", "scripts"],
+  "exclude": ["node_modules", "coverage", "**/dist/**", "**/build/**"]
+}

--- a/scripts/preload.ts
+++ b/scripts/preload.ts
@@ -1,5 +1,25 @@
 import { plugin } from 'bun';
+import { mock } from 'bun:test';
 
 import { sveltePlugin } from '../packages/components/scripts/svelte-plugin.ts';
+
+process.env.TZ ??= 'UTC';
+process.env.LANG ??= 'en_US.UTF-8';
+
+const svelteBrowserEntries = new Map([
+  ['svelte', '../node_modules/svelte/src/index-client.js'],
+  ['svelte/legacy', '../node_modules/svelte/src/legacy/legacy-client.js'],
+  ['svelte/reactivity', '../node_modules/svelte/src/reactivity/index-client.js'],
+  ['svelte/store', '../node_modules/svelte/src/store/index-client.js'],
+]);
+
+function localPath(relativePath: string): string {
+  return new URL(relativePath, import.meta.url).pathname;
+}
+
+for (const [specifier, browserEntry] of svelteBrowserEntries) {
+  const browserModule = await import(localPath(browserEntry));
+  mock.module(specifier, () => browserModule);
+}
 
 await plugin(sveltePlugin({ generate: 'client' }));


### PR DESCRIPTION
## Summary

Scaffold `@cinder/editor` workspace package porting the Milkdown/ProseMirror integration

Automated by ralph-pipeline.

## Test plan

- CI checks pass
- Review bot feedback addressed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large new editor package and many new dependencies; changes include clipboard/HTML sanitization and position-mapping logic that can affect content integrity and XSS posture if incorrect.
> 
> **Overview**
> Introduces a new `@cinder/editor` workspace package exporting a Milkdown/ProseMirror editor surface, including a Svelte 5 `{@attach}` integration (`createEditorAttachment`), core editor lifecycle (`createEditor`/`destroyEditor` with debounce + teardown safeguards), and a command/keymap layer for toolbar + shortcuts.
> 
> Adds editor infrastructure for richer UX and safety: custom clipboard handling that prefers markdown types, detects VSCode code pastes, sanitizes pasted HTML (`sanitizeHtml`), and normalizes copied markdown; plus position-bridging utilities for mapping text offsets/ProseMirror positions and placeholder completion/decoration plugins with shared prototype-pollution guards (`RESERVED_SEGMENTS`).
> 
> Wires the package into the monorepo (workspace + lint-staged config) and updates `bun.lock`; includes extensive unit tests for bridge mapping, SSR-safe imports, package wiring, placeholder completion behavior, and URL/XSS-related security expectations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2871cd764c28bf90bfc3478aa7d4a5bdf08c1fc5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->