### PR TITLE
Scaffold @cinder/editor workspace package porting the Milkdown/ProseMirror integration

### DIFF
--- a/packages/diff/package.json
+++ b/packages/diff/package.json
@@ -6,17 +6,20 @@
   "type": "module",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
+      "types": "./src/index.ts",
+      "bun": "./src/index.ts",
       "import": "./dist/index.js",
       "default": "./dist/index.js"
     },
     "./line-diff": {
-      "types": "./dist/line-diff.d.ts",
+      "types": "./src/line-diff.ts",
+      "bun": "./src/line-diff.ts",
       "import": "./dist/line-diff.js",
       "default": "./dist/line-diff.js"
     },
     "./types": {
-      "types": "./dist/types.d.ts",
+      "types": "./src/types.ts",
+      "bun": "./src/types.ts",
       "import": "./dist/types.js",
       "default": "./dist/types.js"
     }

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -6,27 +6,32 @@
   "type": "module",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
+      "types": "./src/index.ts",
+      "bun": "./src/index.ts",
       "import": "./dist/index.js",
       "default": "./dist/index.js"
     },
     "./sanitize-html": {
-      "types": "./dist/sanitize-html.d.ts",
+      "types": "./src/sanitize-html.ts",
+      "bun": "./src/sanitize-html.ts",
       "import": "./dist/sanitize-html.js",
       "default": "./dist/sanitize-html.js"
     },
     "./template-placeholders": {
-      "types": "./dist/template-placeholders.d.ts",
+      "types": "./src/template-placeholders.ts",
+      "bun": "./src/template-placeholders.ts",
       "import": "./dist/template-placeholders.js",
       "default": "./dist/template-placeholders.js"
     },
     "./template-render": {
-      "types": "./dist/template-render.d.ts",
+      "types": "./src/template-render.ts",
+      "bun": "./src/template-render.ts",
       "import": "./dist/template-render.js",
       "default": "./dist/template-render.js"
     },
     "./test-utilities": {
-      "types": "./dist/test-utilities.d.ts",
+      "types": "./src/test-utilities.ts",
+      "bun": "./src/test-utilities.ts",
       "import": "./dist/test-utilities.js",
       "default": "./dist/test-utilities.js"
     }

--- a/packages/markdown/package.json
+++ b/packages/markdown/package.json
@@ -6,57 +6,68 @@
   "type": "module",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
+      "types": "./src/index.ts",
+      "bun": "./src/index.ts",
       "import": "./dist/index.js",
       "default": "./dist/index.js"
     },
     "./pipeline": {
-      "types": "./dist/pipeline/index.d.ts",
+      "types": "./src/pipeline/index.ts",
+      "bun": "./src/pipeline/index.ts",
       "import": "./dist/pipeline/index.js",
       "default": "./dist/pipeline/index.js"
     },
     "./diff": {
-      "types": "./dist/diff/index.d.ts",
+      "types": "./src/diff/index.ts",
+      "bun": "./src/diff/index.ts",
       "import": "./dist/diff/index.js",
       "default": "./dist/diff/index.js"
     },
     "./diff/line-diff": {
-      "types": "./dist/diff/line-diff.d.ts",
+      "types": "./src/diff/line-diff.ts",
+      "bun": "./src/diff/line-diff.ts",
       "import": "./dist/diff/line-diff.js",
       "default": "./dist/diff/line-diff.js"
     },
     "./diff/types": {
-      "types": "./dist/diff/types.d.ts",
+      "types": "./src/diff/types.ts",
+      "bun": "./src/diff/types.ts",
       "import": "./dist/diff/types.js",
       "default": "./dist/diff/types.js"
     },
     "./rendering": {
-      "types": "./dist/rendering/index.d.ts",
+      "types": "./src/rendering/index.ts",
+      "bun": "./src/rendering/index.ts",
       "import": "./dist/rendering/index.js",
       "default": "./dist/rendering/index.js"
     },
     "./rendering/types": {
-      "types": "./dist/rendering/types.d.ts",
+      "types": "./src/rendering/types.ts",
+      "bun": "./src/rendering/types.ts",
       "import": "./dist/rendering/types.js",
       "default": "./dist/rendering/types.js"
     },
     "./rendering/highlighter": {
-      "types": "./dist/rendering/highlighter.d.ts",
+      "types": "./src/rendering/highlighter.ts",
+      "bun": "./src/rendering/highlighter.ts",
       "import": "./dist/rendering/highlighter.js",
       "default": "./dist/rendering/highlighter.js"
     },
     "./rendering/mermaid-cache": {
-      "types": "./dist/rendering/mermaid-cache.d.ts",
+      "types": "./src/rendering/mermaid-cache.ts",
+      "bun": "./src/rendering/mermaid-cache.ts",
       "import": "./dist/rendering/mermaid-cache.js",
       "default": "./dist/rendering/mermaid-cache.js"
     },
     "./utilities/safe-url": {
-      "types": "./dist/utilities/safe-url.d.ts",
+      "types": "./src/utilities/safe-url.ts",
+      "bun": "./src/utilities/safe-url.ts",
       "import": "./dist/utilities/safe-url.js",
       "default": "./dist/utilities/safe-url.js"
     },
     "./utilities/sort-keys": {
-      "types": "./dist/utilities/sort-keys.d.ts",
+      "types": "./src/utilities/sort-keys.ts",
+      "bun": "./src/utilities/sort-keys.ts",
       "import": "./dist/utilities/sort-keys.js",
       "default": "./dist/utilities/sort-keys.js"
     }


### PR DESCRIPTION
## Summary

Scaffold `@cinder/editor` workspace package porting the Milkdown/ProseMirror integration

Automated by ralph-pipeline.

## Test plan

- CI checks pass
- Review bot feedback addressed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Package metadata-only changes; risk is limited to module/type resolution differences for consumers (especially TS/Bun) but no runtime logic changes.
> 
> **Overview**
> Updates `@cinder/diff`, `@cinder/editor`, and `@cinder/markdown` package `exports` so TypeScript `types` point at the source `.ts` files (instead of `dist/*.d.ts`) and adds explicit `bun` export targets for each entrypoint while keeping runtime `import`/`default` pointing at `dist/*.js`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d23348ca8af6537ca78fb2aa933ed49b5bf48331. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->