### PR TITLE
Scaffold @cinder/editor workspace package porting the Milkdown/ProseMirror integration

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -61,6 +61,10 @@
       "dependencies": {
         "@cinder/markdown": "workspace:*",
         "@milkdown/kit": "^7.17.3",
+        "prosemirror-inputrules": "^1.5.1",
+        "prosemirror-model": "^1.25.4",
+        "prosemirror-state": "^1.4.4",
+        "prosemirror-view": "^1.41.3",
       },
       "devDependencies": {
         "@milkdown/ctx": "^7.17.3",

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -47,7 +47,11 @@
   },
   "dependencies": {
     "@cinder/markdown": "workspace:*",
-    "@milkdown/kit": "^7.17.3"
+    "@milkdown/kit": "^7.17.3",
+    "prosemirror-inputrules": "^1.5.1",
+    "prosemirror-model": "^1.25.4",
+    "prosemirror-state": "^1.4.4",
+    "prosemirror-view": "^1.41.3"
   },
   "devDependencies": {
     "@milkdown/ctx": "^7.17.3",

--- a/packages/editor/src/clipboard.ts
+++ b/packages/editor/src/clipboard.ts
@@ -15,11 +15,16 @@
  */
 
 import { normalize } from '@cinder/markdown/pipeline';
-import { editorViewOptionsCtx, parserCtx, schemaCtx, serializerCtx } from '@milkdown/kit/core';
-import { getNodeFromSchema, isTextOnlySlice } from '@milkdown/kit/prose';
-import { DOMParser, DOMSerializer } from '@milkdown/kit/prose/model';
-import { Plugin, PluginKey, TextSelection } from '@milkdown/kit/prose/state';
-import { $prose } from '@milkdown/kit/utils';
+import {
+  DOMParser,
+  DOMSerializer,
+  type Node as ProseMirrorNode,
+  type Schema,
+  type Slice,
+} from 'prosemirror-model';
+import { Plugin, PluginKey, TextSelection } from 'prosemirror-state';
+
+import { createLazyProsePlugin } from './milkdown-plugin-runtime.js';
 import { sanitizeHtml } from './sanitize-html.js';
 
 function isVscodeClipboardPayload(value: unknown): value is { mode?: unknown } {
@@ -56,10 +61,35 @@ function getLanguageHintFromVscodeClipboard(dataTransfer: DataTransfer): string 
   }
 }
 
+function getNodeFromSchema(type: string, schema: Schema) {
+  const nodeType = schema.nodes[type];
+  if (!nodeType) {
+    throw new Error(`Missing ProseMirror node type: ${type}`);
+  }
+
+  return nodeType;
+}
+
+function isTextOnlySlice(slice: Slice): ProseMirrorNode | false {
+  if (slice.content.childCount !== 1) return false;
+
+  const node = slice.content.firstChild;
+  if (node?.type.name === 'text' && node.marks.length === 0) return node;
+
+  if (node?.type.name === 'paragraph' && node.childCount === 1) {
+    const firstChild = node.firstChild;
+    if (firstChild?.type.name === 'text' && firstChild.marks.length === 0) return firstChild;
+  }
+
+  return false;
+}
+
 /**
  * Milkdown plugin wrapper for the ProseMirror clipboard plugin.
  */
-export const clipboardPlugin = $prose((ctx) => {
+export const clipboardPlugin = createLazyProsePlugin(async (ctx) => {
+  const { editorViewOptionsCtx, parserCtx, schemaCtx, serializerCtx } =
+    await import('@milkdown/kit/core');
   const schema = ctx.get(schemaCtx);
 
   // Ensure editable prop exists (Milkdown issue workaround).

--- a/packages/editor/src/link-input-rule.ts
+++ b/packages/editor/src/link-input-rule.ts
@@ -2,13 +2,14 @@
  * Input rule for converting Markdown link syntax into a link mark.
  */
 
-import { schemaCtx } from '@milkdown/kit/core';
-import { InputRule } from '@milkdown/kit/prose/inputrules';
-import { $inputRule } from '@milkdown/kit/utils';
+import { InputRule } from 'prosemirror-inputrules';
+
+import { createLazyInputRule } from './milkdown-plugin-runtime.js';
 
 const linkInputRuleRegex = /(^|[^!])\[([^\]]+)\]\(([^)\s]+)\)$/;
 
-export const linkInputRulePlugin = $inputRule((ctx) => {
+export const linkInputRulePlugin = createLazyInputRule(async (ctx) => {
+  const { schemaCtx } = await import('@milkdown/kit/core');
   const schema = ctx.get(schemaCtx);
   const linkMark = schema.marks['link'];
 

--- a/packages/editor/src/milkdown-plugin-runtime.ts
+++ b/packages/editor/src/milkdown-plugin-runtime.ts
@@ -1,0 +1,76 @@
+import type { Ctx, MilkdownPlugin } from '@milkdown/ctx';
+import type { InputRule } from '@milkdown/kit/prose/inputrules';
+import type { Plugin, PluginKey } from '@milkdown/kit/prose/state';
+
+/** Milkdown plugin wrapper that exposes the registered ProseMirror plugin lazily. */
+export type LazyProsePlugin = MilkdownPlugin & {
+  plugin: () => Plugin;
+  key: () => PluginKey | undefined;
+};
+
+/** Milkdown plugin wrapper that records the registered input rule after initialization. */
+export type LazyInputRulePlugin = MilkdownPlugin & {
+  inputRule?: InputRule;
+};
+
+/**
+ * Register a ProseMirror plugin without importing Milkdown runtime modules at package import time.
+ */
+export function createLazyProsePlugin(
+  createProseMirrorPlugin: (context: Ctx) => Plugin | Promise<Plugin>,
+) {
+  let prosePlugin: Plugin | undefined;
+
+  const milkdownPlugin: MilkdownPlugin = (context) => async () => {
+    const { SchemaReady, prosePluginsCtx } = await import('@milkdown/kit/core');
+
+    await context.wait(SchemaReady);
+    const registeredPlugin = await createProseMirrorPlugin(context);
+    prosePlugin = registeredPlugin;
+    context.update(prosePluginsCtx, (plugins) => [...plugins, registeredPlugin]);
+
+    return () => {
+      context.update(prosePluginsCtx, (plugins) =>
+        plugins.filter((plugin) => plugin !== registeredPlugin),
+      );
+    };
+  };
+
+  const lazyPlugin: LazyProsePlugin = Object.assign(milkdownPlugin, {
+    plugin: (): Plugin => {
+      if (!prosePlugin) {
+        throw new Error('ProseMirror plugin has not been registered yet.');
+      }
+
+      return prosePlugin;
+    },
+    key: (): PluginKey | undefined => prosePlugin?.spec.key,
+  });
+
+  return lazyPlugin;
+}
+
+/**
+ * Register a ProseMirror input rule without importing Milkdown runtime modules at package import time.
+ */
+export function createLazyInputRule(
+  createInputRule: (context: Ctx) => InputRule | Promise<InputRule>,
+) {
+  const milkdownPlugin: MilkdownPlugin = (context) => async () => {
+    const { SchemaReady, inputRulesCtx } = await import('@milkdown/kit/core');
+
+    await context.wait(SchemaReady);
+    const inputRule = await createInputRule(context);
+    context.update(inputRulesCtx, (inputRules) => [...inputRules, inputRule]);
+    lazyPlugin.inputRule = inputRule;
+
+    return () => {
+      context.update(inputRulesCtx, (inputRules) =>
+        inputRules.filter((registeredInputRule) => registeredInputRule !== inputRule),
+      );
+    };
+  };
+
+  const lazyPlugin: LazyInputRulePlugin = milkdownPlugin;
+  return lazyPlugin;
+}

--- a/packages/editor/src/placeholder.ts
+++ b/packages/editor/src/placeholder.ts
@@ -5,9 +5,11 @@
  * is empty, enabling CSS placeholder styling via ::before pseudo-element.
  */
 
-import { Plugin, PluginKey } from '@milkdown/kit/prose/state';
-import { Decoration, DecorationSet } from '@milkdown/kit/prose/view';
-import { $prose } from '@milkdown/kit/utils';
+import type { Node as ProseMirrorNode } from 'prosemirror-model';
+import { Plugin, PluginKey } from 'prosemirror-state';
+import { Decoration, DecorationSet } from 'prosemirror-view';
+
+import { createLazyProsePlugin } from './milkdown-plugin-runtime.js';
 
 const placeholderPluginKey = new PluginKey('placeholder');
 
@@ -15,7 +17,7 @@ const placeholderPluginKey = new PluginKey('placeholder');
  * Check if the document is considered "empty" for placeholder purposes.
  * Empty means: single paragraph with no text content, or completely empty.
  */
-function isDocumentEmpty(doc: import('@milkdown/kit/prose/model').Node): boolean {
+function isDocumentEmpty(doc: ProseMirrorNode): boolean {
   // Document must have exactly one child
   if (doc.childCount !== 1) return false;
 
@@ -36,7 +38,7 @@ function isDocumentEmpty(doc: import('@milkdown/kit/prose/model').Node): boolean
  * `is-editor-empty` class to the first paragraph, allowing CSS to
  * display a placeholder via `::before` pseudo-element.
  */
-export const placeholderPlugin = $prose(() => {
+export const placeholderPlugin = createLazyProsePlugin(() => {
   return new Plugin({
     key: placeholderPluginKey,
     props: {

--- a/packages/editor/src/ssr-import.test.ts
+++ b/packages/editor/src/ssr-import.test.ts
@@ -1,4 +1,8 @@
 import { describe, expect, it } from 'bun:test';
+import { relative } from 'node:path';
+
+const RUNTIME_MILKDOWN_IMPORT_PATTERN =
+  /import\s+(?!type\b)[\s\S]*?\s+from\s+['"]@milkdown\/kit\//g;
 
 describe('@cinder/editor SSR import safety', () => {
   it('imports the package barrel without needing browser globals', async () => {
@@ -14,5 +18,26 @@ describe('@cinder/editor SSR import safety', () => {
         Object.defineProperty(globalThis, 'document', documentDescriptor);
       }
     }
+  });
+
+  it('keeps Milkdown runtime imports lazy in non-test source files', async () => {
+    const violations: string[] = [];
+    const glob = new Bun.Glob('**/*.ts');
+
+    for await (const filePath of glob.scan({
+      absolute: true,
+      cwd: import.meta.dirname,
+      onlyFiles: true,
+    })) {
+      if (filePath.endsWith('.test.ts') || filePath.endsWith('.d.ts')) continue;
+
+      const source = await Bun.file(filePath).text();
+      for (const match of source.matchAll(RUNTIME_MILKDOWN_IMPORT_PATTERN)) {
+        const lineNumber = source.slice(0, match.index).split('\n').length;
+        violations.push(`${relative(import.meta.dirname, filePath)}:${lineNumber}`);
+      }
+    }
+
+    expect(violations).toEqual([]);
   });
 });

--- a/packages/editor/src/template-completion-plugin.test.ts
+++ b/packages/editor/src/template-completion-plugin.test.ts
@@ -834,8 +834,10 @@ describe('template completion async lookup lifecycle', () => {
 
   beforeEach(() => {
     const mockBody = createMockElement();
+    const mockDocumentElement = createMockElement();
     const mockDocument = {
       body: mockBody,
+      documentElement: mockDocumentElement,
       createElement: () => createMockElement(),
     } as unknown as Document;
     Object.defineProperty(globalThis, 'document', {

--- a/packages/editor/src/template-completion-plugin.ts
+++ b/packages/editor/src/template-completion-plugin.ts
@@ -10,11 +10,11 @@
  * DEP-583: WYSIWYG placeholder completion for saved-prompt template authoring.
  */
 
-import type { EditorState, Transaction } from '@milkdown/kit/prose/state';
-import { Plugin, PluginKey, TextSelection } from '@milkdown/kit/prose/state';
-import type { EditorView } from '@milkdown/kit/prose/view';
-import { $prose } from '@milkdown/kit/utils';
+import type { EditorState, Transaction } from 'prosemirror-state';
+import { Plugin, PluginKey, TextSelection } from 'prosemirror-state';
+import type { EditorView } from 'prosemirror-view';
 
+import { createLazyProsePlugin, type LazyProsePlugin } from './milkdown-plugin-runtime.js';
 import { textOffsetToBlockDocumentPosition } from './template-position-utilities.js';
 import type { PlaceholderCandidate, PlaceholderCompletionConfiguration } from './types.js';
 
@@ -570,8 +570,8 @@ export function computeCompletionState(
  */
 export function createTemplateCompletionPlugin(
   getConfiguration: () => PlaceholderCompletionConfiguration | undefined,
-): ReturnType<typeof $prose> {
-  return $prose(() => {
+): LazyProsePlugin {
+  return createLazyProsePlugin(() => {
     return new Plugin<CompletionState>({
       key: templateCompletionPluginKey,
 

--- a/packages/editor/src/template-invalid-decoration-plugin.ts
+++ b/packages/editor/src/template-invalid-decoration-plugin.ts
@@ -9,11 +9,11 @@
  * DEP-583: WYSIWYG invalid-token decoration for saved-prompt template authoring.
  */
 
-import type { Node as ProseMirrorNode } from '@milkdown/kit/prose/model';
-import { Plugin, PluginKey } from '@milkdown/kit/prose/state';
-import { Decoration, DecorationSet } from '@milkdown/kit/prose/view';
-import { $prose } from '@milkdown/kit/utils';
+import type { Node as ProseMirrorNode } from 'prosemirror-model';
+import { Plugin, PluginKey } from 'prosemirror-state';
+import { Decoration, DecorationSet } from 'prosemirror-view';
 
+import { createLazyProsePlugin } from './milkdown-plugin-runtime.js';
 import { parsePlaceholderTokens, validatePlaceholderTokens } from './template-placeholders.js';
 import { textOffsetToBlockDocumentPosition } from './template-position-utilities.js';
 import type { PlaceholderCandidate } from './types.js';
@@ -144,7 +144,7 @@ export function createTemplateInvalidDecorationPlugin(
 ) {
   const resolveInvalidClassName = () => getInvalidClassName?.() ?? 'template-placeholder-invalid';
 
-  return $prose(() => {
+  return createLazyProsePlugin(() => {
     return new Plugin<DecorationPluginState>({
       key: templateInvalidDecorationPluginKey,
 

--- a/packages/editor/src/test-utilities.ts
+++ b/packages/editor/src/test-utilities.ts
@@ -7,10 +7,7 @@
  * @module
  */
 
-import { defaultValueCtx, Editor, editorViewCtx, rootCtx } from '@milkdown/kit/core';
-import { commonmark } from '@milkdown/kit/preset/commonmark';
-import { gfm } from '@milkdown/kit/preset/gfm';
-import type { Node as ProseMirrorNode } from '@milkdown/kit/prose/model';
+import type { Node as ProseMirrorNode } from 'prosemirror-model';
 
 /**
  * Result of creating a test document.
@@ -47,6 +44,13 @@ export async function createDocFromMarkdown(markdown: string): Promise<TestDocum
   if (typeof document === 'undefined') {
     throw new Error('createDocFromMarkdown() requires a browser document.');
   }
+
+  const [{ defaultValueCtx, Editor, editorViewCtx, rootCtx }, { commonmark }, { gfm }] =
+    await Promise.all([
+      import('@milkdown/kit/core'),
+      import('@milkdown/kit/preset/commonmark'),
+      import('@milkdown/kit/preset/gfm'),
+    ]);
 
   // Create a hidden container for the editor
   const container = document.createElement('div');


### PR DESCRIPTION
## Summary

Scaffold `@cinder/editor` workspace package porting the Milkdown/ProseMirror integration

Automated by ralph-pipeline.

## Test plan

- CI checks pass
- Review bot feedback addressed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core editor plugin initialization and clipboard/paste handling, so regressions could affect editing behavior and SSR builds; changes are mostly dependency/import refactors with added test coverage.
> 
> **Overview**
> Improves **SSR/import safety** for `@cinder/editor` by introducing `createLazyProsePlugin`/`createLazyInputRule`, which registers ProseMirror plugins and input rules via dynamic `@milkdown/kit/core` imports after `SchemaReady` instead of at module import time.
> 
> Updates editor plugins (`clipboard`, `placeholder`, `link-input-rule`, template completion/invalid-decoration) to import `prosemirror-*` modules directly, adds helper implementations where Milkdown utilities were previously used, and adjusts tests to enforce “no non-type `@milkdown/kit/*` imports” in source plus a small DOM mock fix. Adds explicit `prosemirror-*` dependencies to the editor package (and lockfile).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6293787750ba2a0f933aef8325ca1402eeeb19e1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->