### PR TITLE
Scaffold @cinder/editor workspace package porting the Milkdown/ProseMirror integration

### DIFF
--- a/packages/editor/src/package-subpath.test.ts
+++ b/packages/editor/src/package-subpath.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'bun:test';
+
+import { sanitizeHtml } from '@cinder/editor/sanitize-html';
+import {
+  parsePlaceholderTokens,
+  resolveTemplatePlaceholders,
+} from '@cinder/editor/template-placeholders';
+import { renderTemplate } from '@cinder/editor/template-render';
+import { createDocFromMarkdown, debugDocStructure } from '@cinder/editor/test-utilities';
+
+describe('@cinder/editor subpath exports', () => {
+  it('resolves every documented package subpath through the export map', () => {
+    expect(typeof sanitizeHtml).toBe('function');
+    expect(typeof parsePlaceholderTokens).toBe('function');
+    expect(typeof resolveTemplatePlaceholders).toBe('function');
+    expect(typeof renderTemplate).toBe('function');
+    expect(typeof createDocFromMarkdown).toBe('function');
+    expect(typeof debugDocStructure).toBe('function');
+  });
+});


### PR DESCRIPTION
## Summary

Scaffold `@cinder/editor` workspace package porting the Milkdown/ProseMirror integration

Automated by ralph-pipeline.

## Test plan

- CI checks pass
- Review bot feedback addressed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change that doesn’t affect runtime behavior; risk is limited to potential CI failures if exports are misconfigured.
> 
> **Overview**
> Adds `package-subpath.test.ts` to verify `@cinder/editor`’s documented subpath exports (e.g. `sanitize-html`, `template-placeholders`, `template-render`, `test-utilities`) can be imported and expose expected functions, catching broken `package.json` `exports` mappings early.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 86a0f012939aa29647cdd8b2bccf664c2b384366. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->