### PR TITLE
Scaffold @cinder/editor workspace package porting the Milkdown/ProseMirror integration

### DIFF
--- a/packages/editor/src/bridge.ts
+++ b/packages/editor/src/bridge.ts
@@ -13,7 +13,7 @@
  * count text content plus block separators ('\n' between blocks).
  */
 
-import type { SourcePosition } from '@cinder/markdown/diff/types';
+import type { SourcePosition } from '@cinder/markdown/diff';
 import type { Node as ProseMirrorNode } from '@milkdown/kit/prose/model';
 import type { EditorSelection } from './types.js';
 

--- a/packages/editor/src/types.ts
+++ b/packages/editor/src/types.ts
@@ -5,7 +5,7 @@
  * including configuration, handle interface, and selection state.
  */
 
-import type { SourcePosition } from '@cinder/markdown/diff/types';
+import type { SourcePosition } from '@cinder/markdown/diff';
 import type { Root } from '@cinder/markdown/pipeline';
 import type { MilkdownPlugin } from '@milkdown/ctx';
 import type { Editor } from '@milkdown/kit/core';


### PR DESCRIPTION
## Summary

Scaffold `@cinder/editor` workspace package porting the Milkdown/ProseMirror integration

Automated by ralph-pipeline.

## Test plan

- CI checks pass
- Review bot feedback addressed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Type-only import path change with no runtime behavior impact; risk limited to potential build/typecheck breakage if the new export path is incorrect.
> 
> **Overview**
> Updates `@cinder/editor` to import `SourcePosition` from `@cinder/markdown/diff` instead of `@cinder/markdown/diff/types` in `bridge.ts` and `types.ts`, aligning with the package’s public export surface.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d98e0de5bf48e5cfbdeb9b43d26466db87c23fe1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->