### PR TITLE
Scaffold @cinder/editor workspace package porting the Milkdown/ProseMirror integration

### DIFF
--- a/packages/editor/scripts/build.ts
+++ b/packages/editor/scripts/build.ts
@@ -1,14 +1,15 @@
 import { $ } from 'bun';
 
+import {
+  getBuildEntrypoints,
+  getExpectedBuildOutputs,
+  readPackageExports,
+} from './package-exports.js';
+
 const packageRoot = process.cwd();
 const distributionDirectory = `${packageRoot}/dist`;
-const entrypoints = [
-  `${packageRoot}/src/index.ts`,
-  `${packageRoot}/src/sanitize-html.ts`,
-  `${packageRoot}/src/template-placeholders.ts`,
-  `${packageRoot}/src/template-render.ts`,
-  `${packageRoot}/src/test-utilities.ts`,
-];
+const packageExports = await readPackageExports();
+const entrypoints = getBuildEntrypoints(packageRoot, packageExports);
 
 await $`rm -rf dist`;
 
@@ -32,18 +33,7 @@ if (!buildResult.success) {
 
 await $`tsc -p tsconfig.build.json`;
 
-const expectedOutputs = [
-  `${distributionDirectory}/index.js`,
-  `${distributionDirectory}/index.d.ts`,
-  `${distributionDirectory}/sanitize-html.js`,
-  `${distributionDirectory}/sanitize-html.d.ts`,
-  `${distributionDirectory}/template-placeholders.js`,
-  `${distributionDirectory}/template-placeholders.d.ts`,
-  `${distributionDirectory}/template-render.js`,
-  `${distributionDirectory}/template-render.d.ts`,
-  `${distributionDirectory}/test-utilities.js`,
-  `${distributionDirectory}/test-utilities.d.ts`,
-];
+const expectedOutputs = getExpectedBuildOutputs(packageRoot, packageExports);
 
 for (const outputPath of expectedOutputs) {
   if (!(await Bun.file(outputPath).exists())) {

--- a/packages/editor/scripts/package-exports.test.ts
+++ b/packages/editor/scripts/package-exports.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'bun:test';
+
+import {
+  getBuildEntrypoints,
+  getExpectedBuildOutputs,
+  parsePackageExports,
+} from './package-exports.js';
+
+const packageRoot = `${import.meta.dirname}/..`;
+const packageJsonPath = `${packageRoot}/package.json`;
+
+describe('@cinder/editor package export build contract', () => {
+  it('derives Bun build entrypoints from the package export map', async () => {
+    const packageJson = await Bun.file(packageJsonPath).json();
+    const packageExports = parsePackageExports(packageJson);
+
+    expect(getBuildEntrypoints(packageRoot, packageExports)).toEqual([
+      `${packageRoot}/src/index.ts`,
+      `${packageRoot}/src/sanitize-html.ts`,
+      `${packageRoot}/src/template-placeholders.ts`,
+      `${packageRoot}/src/template-render.ts`,
+      `${packageRoot}/src/test-utilities.ts`,
+    ]);
+  });
+
+  it('derives expected JavaScript and declaration outputs from package export imports', async () => {
+    const packageJson = await Bun.file(packageJsonPath).json();
+    const packageExports = parsePackageExports(packageJson);
+
+    expect(getExpectedBuildOutputs(packageRoot, packageExports)).toEqual([
+      `${packageRoot}/dist/index.js`,
+      `${packageRoot}/dist/index.d.ts`,
+      `${packageRoot}/dist/sanitize-html.js`,
+      `${packageRoot}/dist/sanitize-html.d.ts`,
+      `${packageRoot}/dist/template-placeholders.js`,
+      `${packageRoot}/dist/template-placeholders.d.ts`,
+      `${packageRoot}/dist/template-render.js`,
+      `${packageRoot}/dist/template-render.d.ts`,
+      `${packageRoot}/dist/test-utilities.js`,
+      `${packageRoot}/dist/test-utilities.d.ts`,
+    ]);
+  });
+});

--- a/packages/editor/scripts/package-exports.ts
+++ b/packages/editor/scripts/package-exports.ts
@@ -1,0 +1,106 @@
+export type PackageExportTarget = Readonly<{
+  types: string;
+  bun: string;
+  import: string;
+  default: string;
+}>;
+
+export type PackageExports = Readonly<Record<string, PackageExportTarget>>;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function readExportTarget(
+  target: Record<string, unknown>,
+  exportSpecifier: string,
+  condition: keyof PackageExportTarget,
+): string {
+  const value = target[condition];
+  if (typeof value !== 'string') {
+    throw new Error(
+      `package.json export "${exportSpecifier}" must define a string "${condition}".`,
+    );
+  }
+
+  return value;
+}
+
+function packageRelativePathToAbsolute(packageRoot: string, packageRelativePath: string): string {
+  if (!packageRelativePath.startsWith('./')) {
+    throw new Error(`Package export target must be package-relative: ${packageRelativePath}`);
+  }
+
+  return `${packageRoot}/${packageRelativePath.slice(2)}`;
+}
+
+function declarationOutputFor(importTarget: string): string {
+  if (!importTarget.endsWith('.js')) {
+    throw new Error(`Package import target must point at a JavaScript file: ${importTarget}`);
+  }
+
+  return importTarget.replace(/\.js$/, '.d.ts');
+}
+
+/**
+ * Parse the package export map into the normalized shape required by the build script.
+ */
+export function parsePackageExports(packageJson: unknown): PackageExports {
+  if (!isRecord(packageJson)) {
+    throw new Error('package.json must be a JSON object.');
+  }
+
+  const exportsField = packageJson['exports'];
+  if (!isRecord(exportsField)) {
+    throw new Error('package.json must define an object exports map.');
+  }
+
+  return Object.fromEntries(
+    Object.entries(exportsField).map(([exportSpecifier, target]) => {
+      if (!isRecord(target)) {
+        throw new Error(`package.json export "${exportSpecifier}" must be an object.`);
+      }
+
+      return [
+        exportSpecifier,
+        {
+          types: readExportTarget(target, exportSpecifier, 'types'),
+          bun: readExportTarget(target, exportSpecifier, 'bun'),
+          import: readExportTarget(target, exportSpecifier, 'import'),
+          default: readExportTarget(target, exportSpecifier, 'default'),
+        },
+      ];
+    }),
+  );
+}
+
+/**
+ * Read and parse the package export map from package.json.
+ */
+export async function readPackageExports(
+  packageJsonPath = 'package.json',
+): Promise<PackageExports> {
+  return parsePackageExports(await Bun.file(packageJsonPath).json());
+}
+
+/**
+ * Return source entrypoints that Bun.build must compile for every exported subpath.
+ */
+export function getBuildEntrypoints(packageRoot: string, packageExports: PackageExports): string[] {
+  return Object.values(packageExports).map((target) =>
+    packageRelativePathToAbsolute(packageRoot, target.bun),
+  );
+}
+
+/**
+ * Return JavaScript and declaration outputs that must exist after the package build.
+ */
+export function getExpectedBuildOutputs(
+  packageRoot: string,
+  packageExports: PackageExports,
+): string[] {
+  return Object.values(packageExports).flatMap((target) => [
+    packageRelativePathToAbsolute(packageRoot, target.import),
+    packageRelativePathToAbsolute(packageRoot, declarationOutputFor(target.import)),
+  ]);
+}


### PR DESCRIPTION
## Summary

Scaffold `@cinder/editor` workspace package porting the Milkdown/ProseMirror integration

Automated by ralph-pipeline.

## Test plan

- CI checks pass
- Review bot feedback addressed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Build behavior is now coupled to the `package.json` `exports` map; any misconfiguration or ordering change can break builds or output validation, though the change is localized to tooling and covered by tests.
> 
> **Overview**
> `@cinder/editor`’s build script now **derives Bun `entrypoints` and the post-build output existence checks from `package.json` `exports`** instead of maintaining hardcoded lists.
> 
> This introduces `scripts/package-exports.ts` to parse/validate the export map (ensuring required conditions like `types`/`bun`/`import`/`default` and package-relative targets) and adds a Bun test to lock the build contract between exports, source entrypoints, and expected `dist` artifacts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit affd87cc953e97c7e99cdead54722fe49c6484ac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->