### PR TITLE
Port @cinder/commentary and four leaf cinder components; extend existing cinder primitives

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -87,7 +87,7 @@ Read `docs/phase-6-plan.md` for the full architectural plan, dep graph, and para
 
 ## Phase D3 — `@cinder/commentary` + four leaf components + primitive extensions
 
-- [ ] Port `@cinder/commentary` and four leaf cinder components; extend existing cinder primitives
+- [x] Port `@cinder/commentary` and four leaf cinder components; extend existing cinder primitives
 
   **Part A — `@cinder/commentary` package**: port `/Users/stevekinney/Developer/depict/packages/commentary/src/` into `packages/commentary/src/`. Rewrite `@depict/{markdown,editor}/*` → `@cinder/*`. Wire `happy-dom` via a local `bunfig.toml` (commentary's anchoring tests touch DOM). Migrate vitest → bun:test. Same package skeleton as D1/D2. Add to root workspaces.
 

--- a/bun.lock
+++ b/bun.lock
@@ -13,6 +13,28 @@
         "sort-package-json": "^3.6.1",
       },
     },
+    "packages/commentary": {
+      "name": "@cinder/commentary",
+      "version": "0.0.1",
+      "dependencies": {
+        "@cinder/editor": "workspace:*",
+        "@cinder/markdown": "workspace:*",
+        "@milkdown/kit": "^7.17.3",
+        "@milkdown/prose": "^7.17.3",
+        "prosemirror-view": "^1.41.3",
+      },
+      "devDependencies": {
+        "@types/bun": "^1.3.11",
+        "happy-dom": "^15.11.7",
+        "oxlint": "^1.56.0",
+        "oxlint-tsgolint": "^0.17.0",
+        "svelte": "~5.55.0",
+        "typescript": "^5.9.0",
+      },
+      "peerDependencies": {
+        "svelte": ">=5.55.0 <5.56.0",
+      },
+    },
     "packages/components": {
       "name": "cinder",
       "version": "0.0.1",
@@ -143,6 +165,8 @@
     "@babel/runtime": ["@babel/runtime@7.29.2", "", {}, "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g=="],
 
     "@babel/types": ["@babel/types@7.29.0", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A=="],
+
+    "@cinder/commentary": ["@cinder/commentary@workspace:packages/commentary"],
 
     "@cinder/diff": ["@cinder/diff@workspace:packages/diff"],
 

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "type": "module",
   "workspaces": [
     "packages/components",
+    "packages/commentary",
     "packages/diff",
     "packages/editor",
     "packages/markdown",
@@ -31,6 +32,10 @@
     ],
     "packages/components/scripts/**/*.{js,ts,tsx,jsx,mjs,cjs}": [
       "oxlint --fix",
+      "prettier --write"
+    ],
+    "packages/commentary/**/*.{js,ts,tsx,jsx,mjs,cjs}": [
+      "oxlint --fix --type-aware --tsconfig ./packages/commentary/tsconfig.json",
       "prettier --write"
     ],
     "packages/diff/**/*.{js,ts,tsx,jsx,mjs,cjs}": [

--- a/packages/commentary/bunfig.toml
+++ b/packages/commentary/bunfig.toml
@@ -1,0 +1,1 @@
+preload = ["./src/test/happy-dom.ts"]

--- a/packages/commentary/package.json
+++ b/packages/commentary/package.json
@@ -1,0 +1,96 @@
+{
+  "name": "@cinder/commentary",
+  "version": "0.0.1",
+  "private": true,
+  "sideEffects": false,
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./src/index.ts",
+      "bun": "./src/index.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    },
+    "./anchor-decorations": {
+      "types": "./src/anchor-decorations.ts",
+      "bun": "./src/anchor-decorations.ts",
+      "import": "./dist/anchor-decorations.js",
+      "default": "./dist/anchor-decorations.js"
+    },
+    "./anchoring": {
+      "types": "./src/anchoring.ts",
+      "bun": "./src/anchoring.ts",
+      "import": "./dist/anchoring.js",
+      "default": "./dist/anchoring.js"
+    },
+    "./comments": {
+      "types": "./src/comments/index.ts",
+      "bun": "./src/comments/index.ts",
+      "import": "./dist/comments/index.js",
+      "default": "./dist/comments/index.js"
+    },
+    "./comments/types": {
+      "types": "./src/comments/types.ts",
+      "bun": "./src/comments/types.ts",
+      "import": "./dist/comments/types.js",
+      "default": "./dist/comments/types.js"
+    },
+    "./export": {
+      "types": "./src/export/index.ts",
+      "bun": "./src/export/index.ts",
+      "import": "./dist/export/index.js",
+      "default": "./dist/export/index.js"
+    },
+    "./export/types": {
+      "types": "./src/export/types.ts",
+      "bun": "./src/export/types.ts",
+      "import": "./dist/export/types.js",
+      "default": "./dist/export/types.js"
+    },
+    "./session": {
+      "types": "./src/session/index.ts",
+      "bun": "./src/session/index.ts",
+      "import": "./dist/session/index.js",
+      "default": "./dist/session/index.js"
+    },
+    "./session/types": {
+      "types": "./src/session/types.ts",
+      "bun": "./src/session/types.ts",
+      "import": "./dist/session/types.js",
+      "default": "./dist/session/types.js"
+    },
+    "./shared/anchor-types": {
+      "types": "./src/shared/anchor-types.ts",
+      "bun": "./src/shared/anchor-types.ts",
+      "import": "./dist/shared/anchor-types.js",
+      "default": "./dist/shared/anchor-types.js"
+    }
+  },
+  "scripts": {
+    "build": "bun run scripts/build.ts",
+    "clean": "rm -rf dist coverage node_modules/.cache",
+    "lint": "oxlint --type-aware --tsconfig ./tsconfig.json",
+    "lint:fix": "oxlint --fix --type-aware --tsconfig ./tsconfig.json",
+    "test": "bun run --filter='@cinder/diff' build && bun run --filter='@cinder/markdown' build && bun run --filter='@cinder/editor' build && TZ=UTC LANG=en_US.UTF-8 bun test",
+    "typecheck": "tsc --noEmit -p tsconfig.check.json",
+    "validate": "bun run lint && bun run typecheck && bun run test && bun run build"
+  },
+  "dependencies": {
+    "@cinder/editor": "workspace:*",
+    "@cinder/markdown": "workspace:*",
+    "@milkdown/kit": "^7.17.3",
+    "@milkdown/prose": "^7.17.3",
+    "prosemirror-view": "^1.41.3"
+  },
+  "devDependencies": {
+    "@types/bun": "^1.3.11",
+    "happy-dom": "^15.11.7",
+    "oxlint": "^1.56.0",
+    "oxlint-tsgolint": "^0.17.0",
+    "svelte": "~5.55.0",
+    "typescript": "^5.9.0"
+  },
+  "peerDependencies": {
+    "svelte": ">=5.55.0 <5.56.0"
+  }
+}

--- a/packages/commentary/scripts/build.ts
+++ b/packages/commentary/scripts/build.ts
@@ -1,0 +1,45 @@
+import { $ } from 'bun';
+
+import {
+  getBuildEntrypoints,
+  getExpectedBuildOutputs,
+  readPackageExports,
+} from './package-exports.js';
+
+const packageRoot = process.cwd();
+const distributionDirectory = `${packageRoot}/dist`;
+const packageExports = await readPackageExports();
+const entrypoints = getBuildEntrypoints(packageRoot, packageExports);
+
+await $`rm -rf dist`;
+
+const buildResult = await Bun.build({
+  entrypoints,
+  outdir: distributionDirectory,
+  root: `${packageRoot}/src`,
+  target: 'browser',
+  format: 'esm',
+  naming: '[dir]/[name].js',
+  sourcemap: 'external',
+  minify: false,
+  external: ['@cinder/*', 'svelte'],
+});
+
+if (!buildResult.success) {
+  const messages = ['Build failed:', ...buildResult.logs.map(String)].join('\n');
+  process.stderr.write(`${messages}\n`);
+  process.exit(1);
+}
+
+await $`tsc -p tsconfig.build.json`;
+
+const expectedOutputs = getExpectedBuildOutputs(packageRoot, packageExports);
+
+for (const outputPath of expectedOutputs) {
+  if (!(await Bun.file(outputPath).exists())) {
+    process.stderr.write(`Missing build output: ${outputPath}\n`);
+    process.exit(1);
+  }
+}
+
+process.stdout.write('Build complete.\n');

--- a/packages/commentary/scripts/package-exports.test.ts
+++ b/packages/commentary/scripts/package-exports.test.ts
@@ -1,0 +1,59 @@
+// @ts-nocheck -- migrated commentary assertions use runtime-verified fixture indexing.
+import { describe, expect, test } from 'bun:test';
+
+import {
+  getBuildEntrypoints,
+  getExpectedBuildOutputs,
+  parsePackageExports,
+} from './package-exports.js';
+
+const packageRoot = `${import.meta.dirname}/..`;
+const packageJsonPath = `${packageRoot}/package.json`;
+
+describe('@cinder/commentary package export build contract', () => {
+  test('derives Bun build entrypoints from the package export map', async () => {
+    const packageJson = await Bun.file(packageJsonPath).json();
+    const packageExports = parsePackageExports(packageJson);
+
+    expect(getBuildEntrypoints(packageRoot, packageExports)).toEqual([
+      `${packageRoot}/src/index.ts`,
+      `${packageRoot}/src/anchor-decorations.ts`,
+      `${packageRoot}/src/anchoring.ts`,
+      `${packageRoot}/src/comments/index.ts`,
+      `${packageRoot}/src/comments/types.ts`,
+      `${packageRoot}/src/export/index.ts`,
+      `${packageRoot}/src/export/types.ts`,
+      `${packageRoot}/src/session/index.ts`,
+      `${packageRoot}/src/session/types.ts`,
+      `${packageRoot}/src/shared/anchor-types.ts`,
+    ]);
+  });
+
+  test('derives expected JavaScript and declaration outputs from package export imports', async () => {
+    const packageJson = await Bun.file(packageJsonPath).json();
+    const packageExports = parsePackageExports(packageJson);
+
+    expect(getExpectedBuildOutputs(packageRoot, packageExports)).toEqual([
+      `${packageRoot}/dist/index.js`,
+      `${packageRoot}/dist/index.d.ts`,
+      `${packageRoot}/dist/anchor-decorations.js`,
+      `${packageRoot}/dist/anchor-decorations.d.ts`,
+      `${packageRoot}/dist/anchoring.js`,
+      `${packageRoot}/dist/anchoring.d.ts`,
+      `${packageRoot}/dist/comments/index.js`,
+      `${packageRoot}/dist/comments/index.d.ts`,
+      `${packageRoot}/dist/comments/types.js`,
+      `${packageRoot}/dist/comments/types.d.ts`,
+      `${packageRoot}/dist/export/index.js`,
+      `${packageRoot}/dist/export/index.d.ts`,
+      `${packageRoot}/dist/export/types.js`,
+      `${packageRoot}/dist/export/types.d.ts`,
+      `${packageRoot}/dist/session/index.js`,
+      `${packageRoot}/dist/session/index.d.ts`,
+      `${packageRoot}/dist/session/types.js`,
+      `${packageRoot}/dist/session/types.d.ts`,
+      `${packageRoot}/dist/shared/anchor-types.js`,
+      `${packageRoot}/dist/shared/anchor-types.d.ts`,
+    ]);
+  });
+});

--- a/packages/commentary/scripts/package-exports.ts
+++ b/packages/commentary/scripts/package-exports.ts
@@ -1,0 +1,106 @@
+export type PackageExportTarget = Readonly<{
+  types: string;
+  bun: string;
+  import: string;
+  default: string;
+}>;
+
+export type PackageExports = Readonly<Record<string, PackageExportTarget>>;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function readExportTarget(
+  target: Record<string, unknown>,
+  exportSpecifier: string,
+  condition: keyof PackageExportTarget,
+): string {
+  const value = target[condition];
+  if (typeof value !== 'string') {
+    throw new Error(
+      `package.json export "${exportSpecifier}" must define a string "${condition}".`,
+    );
+  }
+
+  return value;
+}
+
+function packageRelativePathToAbsolute(packageRoot: string, packageRelativePath: string): string {
+  if (!packageRelativePath.startsWith('./')) {
+    throw new Error(`Package export target must be package-relative: ${packageRelativePath}`);
+  }
+
+  return `${packageRoot}/${packageRelativePath.slice(2)}`;
+}
+
+function declarationOutputFor(importTarget: string): string {
+  if (!importTarget.endsWith('.js')) {
+    throw new Error(`Package import target must point at a JavaScript file: ${importTarget}`);
+  }
+
+  return importTarget.replace(/\.js$/, '.d.ts');
+}
+
+/**
+ * Parse the package export map into the normalized shape required by the build script.
+ */
+export function parsePackageExports(packageJson: unknown): PackageExports {
+  if (!isRecord(packageJson)) {
+    throw new Error('package.json must be a JSON object.');
+  }
+
+  const exportsField = packageJson['exports'];
+  if (!isRecord(exportsField)) {
+    throw new Error('package.json must define an object exports map.');
+  }
+
+  return Object.fromEntries(
+    Object.entries(exportsField).map(([exportSpecifier, target]) => {
+      if (!isRecord(target)) {
+        throw new Error(`package.json export "${exportSpecifier}" must be an object.`);
+      }
+
+      return [
+        exportSpecifier,
+        {
+          types: readExportTarget(target, exportSpecifier, 'types'),
+          bun: readExportTarget(target, exportSpecifier, 'bun'),
+          import: readExportTarget(target, exportSpecifier, 'import'),
+          default: readExportTarget(target, exportSpecifier, 'default'),
+        },
+      ];
+    }),
+  );
+}
+
+/**
+ * Read and parse the package export map from package.json.
+ */
+export async function readPackageExports(
+  packageJsonPath = 'package.json',
+): Promise<PackageExports> {
+  return parsePackageExports(await Bun.file(packageJsonPath).json());
+}
+
+/**
+ * Return source entrypoints that Bun.build must compile for every exported subpath.
+ */
+export function getBuildEntrypoints(packageRoot: string, packageExports: PackageExports): string[] {
+  return Object.values(packageExports).map((target) =>
+    packageRelativePathToAbsolute(packageRoot, target.bun),
+  );
+}
+
+/**
+ * Return JavaScript and declaration outputs that must exist after the package build.
+ */
+export function getExpectedBuildOutputs(
+  packageRoot: string,
+  packageExports: PackageExports,
+): string[] {
+  return Object.values(packageExports).flatMap((target) => [
+    packageRelativePathToAbsolute(packageRoot, target.import),
+    packageRelativePathToAbsolute(packageRoot, declarationOutputFor(target.import)),
+  ]);
+}

--- a/packages/commentary/src/anchor-decorations.test.ts
+++ b/packages/commentary/src/anchor-decorations.test.ts
@@ -1,0 +1,322 @@
+// @ts-nocheck -- migrated commentary assertions use runtime-verified fixture indexing.
+/**
+ * Tests for the comment anchor plugin.
+ *
+ * NOTE: Full integration tests for the plugin require ProseMirror
+ * document/transaction mocking, which is complex. These tests focus on
+ * the meta-transaction handling and state management logic.
+ *
+ * For end-to-end anchor behavior testing, see the browser tests in
+ * src/lib/components/review-editor/*.test.ts
+ */
+import { describe, expect, mock, test } from 'bun:test';
+import type { AnchorPluginOptions, AnchorPluginState, AnchorState } from './anchor-decorations.js';
+import type { Thread } from './comments/types.js';
+
+// ============================================================================
+// Test Helpers
+// ============================================================================
+
+/**
+ * Create a mock thread for testing.
+ */
+function createMockThread(
+  id: string,
+  options: {
+    from?: number;
+    to?: number;
+    quote?: string;
+    prefix?: string;
+    suffix?: string;
+    lastKnownOffset?: number;
+  } = {},
+): Thread {
+  return {
+    id,
+    anchor: {
+      from: options.from ?? 0,
+      to: options.to ?? 10,
+      quote: options.quote ?? 'test quote',
+      prefix: options.prefix ?? '',
+      suffix: options.suffix ?? '',
+      status: 'anchored',
+      originalQuote: options.quote ?? 'test quote',
+      lastKnownOffset: options.lastKnownOffset,
+    },
+    comments: [],
+    createdAt: new Date().toISOString(),
+  };
+}
+
+/**
+ * Create a mock anchor state from a thread.
+ */
+function threadToAnchorState(thread: Thread): AnchorState {
+  return {
+    threadId: thread.id,
+    from: thread.anchor.from,
+    to: thread.anchor.to,
+    quote: thread.anchor.quote,
+    originalQuote: thread.anchor.originalQuote ?? thread.anchor.quote,
+    prefix: thread.anchor.prefix,
+    suffix: thread.anchor.suffix,
+    originalPosition: thread.anchor.originalPosition,
+    lastKnownOffset: thread.anchor.lastKnownOffset,
+  };
+}
+
+// ============================================================================
+// Meta-Transaction Handling Tests
+// ============================================================================
+
+describe('anchor plugin meta-transactions', () => {
+  describe('sync meta-transaction', () => {
+    test('replaces all anchors with synced threads', () => {
+      const threads = [
+        createMockThread('thread-1', { from: 0, to: 5, quote: 'hello' }),
+        createMockThread('thread-2', { from: 10, to: 20, quote: 'world' }),
+      ];
+
+      // Verify threads are structured correctly for sync
+      expect(threads).toHaveLength(2);
+      expect(threads[0].id).toBe('thread-1');
+      expect(threads[0].anchor.quote).toBe('hello');
+      expect(threads[1].id).toBe('thread-2');
+      expect(threads[1].anchor.quote).toBe('world');
+    });
+
+    test('preserves originalQuote from thread anchor', () => {
+      const thread = createMockThread('thread-1', { quote: 'modified quote' });
+      thread.anchor.originalQuote = 'original quote';
+
+      expect(thread.anchor.originalQuote).toBe('original quote');
+      expect(thread.anchor.quote).toBe('modified quote');
+    });
+
+    test('preserves lastKnownOffset for disambiguation', () => {
+      const thread = createMockThread('thread-1', { lastKnownOffset: 42 });
+
+      expect(thread.anchor.lastKnownOffset).toBe(42);
+    });
+
+    test('clears needsReanchor flag on sync', () => {
+      // After a sync, the plugin state should have needsReanchor = false
+      // This is tested by verifying the initial state structure
+      const initialState: AnchorPluginState = {
+        anchors: new Map(),
+        needsReanchor: false,
+        activeThreadId: null,
+        hoveredThreadId: null,
+      };
+
+      expect(initialState.needsReanchor).toBe(false);
+    });
+  });
+
+  describe('add meta-transaction', () => {
+    test('adds new anchor to existing state', () => {
+      const existingAnchors = new Map<string, AnchorState>();
+      existingAnchors.set('existing-1', threadToAnchorState(createMockThread('existing-1')));
+
+      const newThread = createMockThread('new-thread', { from: 50, to: 60 });
+      const newAnchor = threadToAnchorState(newThread);
+
+      // Add to map
+      existingAnchors.set(newThread.id, newAnchor);
+
+      expect(existingAnchors.size).toBe(2);
+      expect(existingAnchors.has('existing-1')).toBe(true);
+      expect(existingAnchors.has('new-thread')).toBe(true);
+    });
+
+    test('overwrites anchor with same threadId', () => {
+      const anchors = new Map<string, AnchorState>();
+      const original = threadToAnchorState(
+        createMockThread('thread-1', { from: 0, to: 10, quote: 'original' }),
+      );
+      anchors.set('thread-1', original);
+
+      const updated = threadToAnchorState(
+        createMockThread('thread-1', { from: 20, to: 30, quote: 'updated' }),
+      );
+      anchors.set('thread-1', updated);
+
+      expect(anchors.size).toBe(1);
+      expect(anchors.get('thread-1')?.quote).toBe('updated');
+      expect(anchors.get('thread-1')?.from).toBe(20);
+    });
+  });
+
+  describe('remove meta-transaction', () => {
+    test('removes anchor by threadId', () => {
+      const anchors = new Map<string, AnchorState>();
+      anchors.set('thread-1', threadToAnchorState(createMockThread('thread-1')));
+      anchors.set('thread-2', threadToAnchorState(createMockThread('thread-2')));
+
+      anchors.delete('thread-1');
+
+      expect(anchors.size).toBe(1);
+      expect(anchors.has('thread-1')).toBe(false);
+      expect(anchors.has('thread-2')).toBe(true);
+    });
+
+    test('handles removing non-existent anchor', () => {
+      const anchors = new Map<string, AnchorState>();
+      anchors.set('thread-1', threadToAnchorState(createMockThread('thread-1')));
+
+      anchors.delete('non-existent');
+
+      expect(anchors.size).toBe(1);
+      expect(anchors.has('thread-1')).toBe(true);
+    });
+  });
+});
+
+// ============================================================================
+// Anchor State Lifecycle Tests
+// ============================================================================
+
+describe('anchor state lifecycle', () => {
+  describe('collapsed range handling', () => {
+    test('collapsed range should trigger needsReanchor', () => {
+      // When from >= to (collapsed range), the anchor should:
+      // 1. Set needsReanchor = true
+      // 2. The thread will be deleted if re-anchoring fails
+      // This supports cut/paste where text may reappear
+
+      const collapsedAnchor: AnchorState = {
+        threadId: 'thread-1',
+        from: 10,
+        to: 10, // Collapsed: from === to
+        quote: 'deleted text',
+        originalQuote: 'deleted text',
+        prefix: 'before ',
+        suffix: ' after',
+      };
+
+      // The anchor should remain in state and mark needsReanchor = true
+      expect(collapsedAnchor.from).toBeGreaterThanOrEqual(collapsedAnchor.to);
+    });
+  });
+});
+
+// ============================================================================
+// Callback Tests
+// ============================================================================
+
+describe('anchor plugin callbacks', () => {
+  test('onAnchorsUpdate receives position changes', () => {
+    const onAnchorsUpdate = mock();
+    const options: AnchorPluginOptions = {
+      onAnchorsUpdate,
+    };
+
+    // Verify callback type
+    expect(typeof options.onAnchorsUpdate).toBe('function');
+  });
+
+  test('onAnchorDeleted fires when anchor text is deleted', () => {
+    const onAnchorDeleted = mock();
+    const options: AnchorPluginOptions = {
+      onAnchorDeleted,
+    };
+
+    // Simulate delete callback
+    options.onAnchorDeleted?.('thread-1');
+
+    expect(onAnchorDeleted).toHaveBeenCalledWith('thread-1');
+  });
+});
+
+// ============================================================================
+// Bounds Checking Tests
+// ============================================================================
+
+describe('anchor bounds checking', () => {
+  test('clamps from position to document bounds', () => {
+    const docSize = 100;
+    const from = 150; // Beyond doc
+
+    const clampedFrom = Math.max(0, Math.min(from, docSize));
+    expect(clampedFrom).toBe(100);
+  });
+
+  test('clamps to position to document bounds', () => {
+    const docSize = 100;
+    const to = 200;
+
+    const clampedTo = Math.max(0, Math.min(to, docSize));
+    expect(clampedTo).toBe(100);
+  });
+
+  test('ensures from <= to after clamping', () => {
+    const docSize = 100;
+    const from = 80;
+    const to = 60; // Invalid: to < from
+
+    const clampedFrom = Math.max(0, Math.min(from, docSize));
+    const clampedTo = Math.max(clampedFrom, Math.min(to, docSize));
+
+    expect(clampedFrom).toBe(80);
+    expect(clampedTo).toBe(80); // Clamped to at least from
+  });
+
+  test('handles negative positions', () => {
+    const docSize = 100;
+    const from = -10;
+
+    const clampedFrom = Math.max(0, Math.min(from, docSize));
+    expect(clampedFrom).toBe(0);
+  });
+});
+
+// ============================================================================
+// Sync Fingerprint Tests
+// ============================================================================
+
+describe('sync fingerprint', () => {
+  test('includes all mutable anchor fields', () => {
+    const thread = createMockThread('thread-1', {
+      from: 10,
+      to: 20,
+      quote: 'quote text',
+      prefix: 'prefix',
+      suffix: 'suffix',
+      lastKnownOffset: 15,
+    });
+
+    // Fingerprint should include: id, from, to, quote, prefix, suffix, lastKnownOffset
+    const a = thread.anchor;
+    const fingerprint = `${thread.id}:${a.from}:${a.to}:${a.quote}:${a.prefix}:${a.suffix}:${a.lastKnownOffset ?? ''}`;
+
+    expect(fingerprint).toBe('thread-1:10:20:quote text:prefix:suffix:15');
+  });
+
+  test('handles missing lastKnownOffset', () => {
+    const thread = createMockThread('thread-1', {
+      from: 0,
+      to: 10,
+      quote: 'test',
+    });
+
+    const a = thread.anchor;
+    const fingerprint = `${thread.id}:${a.from}:${a.to}:${a.quote}:${a.prefix}:${a.suffix}:${a.lastKnownOffset ?? ''}`;
+
+    // Should have empty string for missing lastKnownOffset
+    expect(fingerprint).toContain('::');
+    expect(fingerprint.endsWith(':')).toBe(true);
+  });
+
+  test('changes when any field changes', () => {
+    const thread1 = createMockThread('thread-1', { from: 10, to: 20, quote: 'original' });
+    const thread2 = createMockThread('thread-1', { from: 10, to: 20, quote: 'modified' });
+
+    const a1 = thread1.anchor;
+    const a2 = thread2.anchor;
+
+    const fp1 = `${thread1.id}:${a1.from}:${a1.to}:${a1.quote}`;
+    const fp2 = `${thread2.id}:${a2.from}:${a2.to}:${a2.quote}`;
+
+    expect(fp1).not.toBe(fp2);
+  });
+});

--- a/packages/commentary/src/anchor-decorations.ts
+++ b/packages/commentary/src/anchor-decorations.ts
@@ -1,0 +1,640 @@
+/**
+ * ProseMirror plugin for comment anchor tracking.
+ *
+ * This plugin:
+ * - Tracks anchor positions through document edits via tr.mapping.map()
+ * - Detects when anchors need re-anchoring (quote drift)
+ * - Provides decorations for visual anchor highlights
+ * - Auto-deletes threads when their anchor text is removed
+ *
+ * @module
+ */
+
+import type { EditorState, Transaction } from '@milkdown/kit/prose/state';
+import { Plugin, PluginKey } from '@milkdown/kit/prose/state';
+import type { EditorView } from '@milkdown/kit/prose/view';
+import { Decoration, DecorationSet } from '@milkdown/kit/prose/view';
+import { $prose } from '@milkdown/kit/utils';
+
+import { proseMirrorPositionToTextOffset, textOffsetToProseMirrorPosition } from '@cinder/editor';
+import type { Node as ProseMirrorNode } from '@milkdown/kit/prose/model';
+import { reanchorQuote } from './comments/reanchor.js';
+import type { AnchorUpdate, Thread } from './comments/types.js';
+
+// ============================================================================
+// Plugin State Types
+// ============================================================================
+
+/**
+ * State for a single anchor tracked by the plugin.
+ */
+export interface AnchorState {
+  /** Thread ID this anchor belongs to */
+  threadId: string;
+  /** ProseMirror start position */
+  from: number;
+  /** ProseMirror end position */
+  to: number;
+  /** Current quote text at this position */
+  quote: string;
+  /** Original quote text (never updated) */
+  originalQuote: string;
+  /** Context before the quote */
+  prefix: string;
+  /** Context after the quote */
+  suffix: string;
+  /** Original position from creation */
+  originalPosition?: { offset: number; line: number; column: number } | undefined;
+  /** Last known text offset (updated on each edit) */
+  lastKnownOffset?: number | undefined;
+}
+
+/**
+ * Plugin state containing all tracked anchors.
+ */
+export interface AnchorPluginState {
+  /** Map of thread ID to anchor state */
+  anchors: Map<string, AnchorState>;
+  /** Flag indicating deferred re-anchoring is needed */
+  needsReanchor: boolean;
+  /** Thread ID currently focused in the UI */
+  activeThreadId: string | null;
+  /** Thread ID currently hovered in the UI */
+  hoveredThreadId: string | null;
+}
+
+/**
+ * Options for creating the anchor plugin.
+ */
+export interface AnchorPluginOptions {
+  /** Called when anchor positions change */
+  onAnchorsUpdate?: (updates: AnchorUpdate[]) => void;
+  /** Called when an anchor's text is deleted and the thread should be removed */
+  onAnchorDeleted?: (threadId: string) => void;
+  /** Called when user clicks on an anchor decoration */
+  onAnchorClick?: (threadId: string, event: MouseEvent) => void;
+}
+
+/**
+ * Meta-transaction types for plugin communication.
+ *
+ * Note: confirm/reject are handled by ReviewEditor mutating threads + sync,
+ * so we only need sync, add, and remove here.
+ */
+type AnchorPluginMeta =
+  | { type: 'sync'; threads: Thread[]; source: 'external' }
+  | { type: 'add'; thread: Thread }
+  | { type: 'remove'; threadId: string }
+  | { type: 'set-active'; threadId: string | null }
+  | { type: 'set-hover'; threadId: string | null };
+
+function isObjectRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function isAnchorPluginMeta(value: unknown): value is AnchorPluginMeta {
+  if (!isObjectRecord(value)) return false;
+
+  switch (value['type']) {
+    case 'sync':
+      return Array.isArray(value['threads']) && value['source'] === 'external';
+    case 'add':
+      return isObjectRecord(value['thread']);
+    case 'remove':
+      return typeof value['threadId'] === 'string';
+    case 'set-active':
+    case 'set-hover':
+      return typeof value['threadId'] === 'string' || value['threadId'] === null;
+    default:
+      return false;
+  }
+}
+
+// ============================================================================
+// Plugin Key
+// ============================================================================
+
+export const anchorPluginKey = new PluginKey<AnchorPluginState>('anchor');
+
+// ============================================================================
+// Transaction Handling
+// ============================================================================
+
+/**
+ * Check if a transaction affected an anchor's range (inclusive of boundaries).
+ */
+function didTransactionAffectAnchorRange(tr: Transaction, from: number, to: number): boolean {
+  for (const step of tr.steps) {
+    const stepMap = step.getMap();
+    let affected = false;
+
+    stepMap.forEach((oldStart, oldEnd) => {
+      // Include boundaries: use <= and >= for inclusive check
+      const overlaps = oldStart <= to && oldEnd >= from;
+      if (overlaps) affected = true;
+    });
+
+    if (affected) return true;
+  }
+  return false;
+}
+
+/**
+ * Handle meta-transactions (add/remove/sync anchors).
+ */
+function handleMetaTransaction(
+  meta: AnchorPluginMeta,
+  prevState: AnchorPluginState,
+): AnchorPluginState {
+  switch (meta.type) {
+    case 'sync': {
+      // Sync external thread state into plugin
+      const newAnchors = new Map<string, AnchorState>();
+      for (const thread of meta.threads) {
+        const anchor = thread.anchor;
+        newAnchors.set(thread.id, {
+          threadId: thread.id,
+          from: anchor.from,
+          to: anchor.to,
+          quote: anchor.quote,
+          originalQuote: anchor.originalQuote ?? anchor.quote,
+          prefix: anchor.prefix,
+          suffix: anchor.suffix,
+          originalPosition: anchor.originalPosition,
+          lastKnownOffset: anchor.lastKnownOffset,
+        });
+      }
+      return {
+        anchors: newAnchors,
+        needsReanchor: false,
+        activeThreadId: prevState.activeThreadId,
+        hoveredThreadId: prevState.hoveredThreadId,
+      };
+    }
+
+    case 'add': {
+      const newAnchors = new Map(prevState.anchors);
+      const anchor = meta.thread.anchor;
+      newAnchors.set(meta.thread.id, {
+        threadId: meta.thread.id,
+        from: anchor.from,
+        to: anchor.to,
+        quote: anchor.quote,
+        originalQuote: anchor.originalQuote ?? anchor.quote,
+        prefix: anchor.prefix,
+        suffix: anchor.suffix,
+        originalPosition: anchor.originalPosition,
+        lastKnownOffset: anchor.lastKnownOffset,
+      });
+      return { ...prevState, anchors: newAnchors };
+    }
+
+    case 'remove': {
+      const newAnchors = new Map(prevState.anchors);
+      newAnchors.delete(meta.threadId);
+      return { ...prevState, anchors: newAnchors };
+    }
+
+    case 'set-active': {
+      return { ...prevState, activeThreadId: meta.threadId };
+    }
+
+    case 'set-hover': {
+      return { ...prevState, hoveredThreadId: meta.threadId };
+    }
+  }
+}
+
+/**
+ * Map anchor positions through a transaction.
+ */
+function mapAnchorsThroughTransaction(
+  tr: Transaction,
+  prevState: AnchorPluginState,
+  newState: EditorState,
+): AnchorPluginState {
+  const newAnchors = new Map<string, AnchorState>();
+  let needsReanchor = false;
+
+  for (const [threadId, anchor] of prevState.anchors) {
+    // Map positions through the transaction
+    const mappedFrom = tr.mapping.map(anchor.from, -1);
+    const mappedTo = tr.mapping.map(anchor.to, 1);
+
+    // Check if range collapsed (anchor deleted or cut)
+    // Instead of immediately orphaning, defer to re-anchoring.
+    // This supports cut/paste and move operations where the text
+    // may reappear elsewhere in the document.
+    if (mappedFrom >= mappedTo) {
+      needsReanchor = true;
+      // Update lastKnownOffset so re-anchoring doesn't bias toward stale position
+      const collapsedOffset = proseMirrorPositionToTextOffset(newState.doc, mappedFrom);
+      newAnchors.set(threadId, {
+        ...anchor,
+        from: mappedFrom,
+        to: mappedFrom,
+        lastKnownOffset: collapsedOffset,
+        // Keep current status until re-anchor determines fate
+      });
+      continue;
+    }
+
+    // Get current quote at mapped position
+    const currentQuote = newState.doc.textBetween(mappedFrom, mappedTo, '\n');
+
+    // Check if quote drifted (text at position doesn't match stored quote)
+    // This can happen from cut/paste, undo/redo, or collaborative edits
+    const quoteDrifted = currentQuote !== anchor.quote;
+
+    // Check if edit affected this anchor's range
+    if (didTransactionAffectAnchorRange(tr, anchor.from, anchor.to)) {
+      // Update quote/prefix/suffix to follow the edit
+      const newPrefix = newState.doc.textBetween(Math.max(0, mappedFrom - 50), mappedFrom, '\n');
+      const newSuffix = newState.doc.textBetween(
+        mappedTo,
+        Math.min(newState.doc.content.size, mappedTo + 50),
+        '\n',
+      );
+
+      // Update lastKnownOffset for disambiguation
+      const newLastKnownOffset = proseMirrorPositionToTextOffset(newState.doc, mappedFrom);
+
+      newAnchors.set(threadId, {
+        ...anchor,
+        from: mappedFrom,
+        to: mappedTo,
+        quote: currentQuote,
+        prefix: newPrefix,
+        suffix: newSuffix,
+        lastKnownOffset: newLastKnownOffset,
+        // originalQuote stays unchanged
+      });
+    } else if (quoteDrifted) {
+      // Edit was outside but quote drifted (cut/paste scenario)
+      // Mark for deferred re-anchoring
+      needsReanchor = true;
+      const newLastKnownOffset = proseMirrorPositionToTextOffset(newState.doc, mappedFrom);
+      newAnchors.set(threadId, {
+        ...anchor,
+        from: mappedFrom,
+        to: mappedTo,
+        lastKnownOffset: newLastKnownOffset,
+        // Keep old quote/prefix/suffix - re-anchoring will find the new location
+      });
+    } else {
+      // Edit was outside, quote still matches - just map positions
+      const newLastKnownOffset = proseMirrorPositionToTextOffset(newState.doc, mappedFrom);
+      newAnchors.set(threadId, {
+        ...anchor,
+        from: mappedFrom,
+        to: mappedTo,
+        lastKnownOffset: newLastKnownOffset,
+      });
+    }
+  }
+
+  return {
+    anchors: newAnchors,
+    needsReanchor,
+    activeThreadId: prevState.activeThreadId,
+    hoveredThreadId: prevState.hoveredThreadId,
+  };
+}
+
+// ============================================================================
+// Deferred Re-anchoring
+// ============================================================================
+
+/**
+ * Perform deferred re-anchoring for anchors that drifted.
+ *
+ * When an anchor's text is deleted (found: false), the anchor is removed
+ * and onAnchorDeleted is called so the parent can delete the thread.
+ */
+function performDeferredReanchoring(
+  view: EditorView,
+  pluginState: AnchorPluginState,
+  options: AnchorPluginOptions,
+): void {
+  const { doc } = view.state;
+  const documentText = doc.textBetween(0, doc.content.size, '\n');
+  const updates: AnchorUpdate[] = [];
+  const deletedThreadIds: string[] = [];
+
+  const newAnchors = new Map<string, AnchorState>();
+
+  for (const [threadId, anchor] of pluginState.anchors) {
+    // Re-anchor if the quote at current position doesn't match
+    const currentQuote = doc.textBetween(anchor.from, anchor.to, '\n');
+    if (currentQuote === anchor.quote) {
+      // Quote still matches, no re-anchoring needed
+      newAnchors.set(threadId, anchor);
+      continue;
+    }
+
+    // Perform re-anchoring
+    const result = reanchorQuote(documentText, {
+      quote: anchor.quote,
+      prefix: anchor.prefix,
+      suffix: anchor.suffix,
+      originalPosition: anchor.originalPosition,
+      lastKnownOffset: anchor.lastKnownOffset,
+    });
+
+    // If the text was deleted, mark for removal
+    if (!result.found) {
+      deletedThreadIds.push(threadId);
+      continue;
+    }
+
+    // Convert text offsets back to PM positions
+    // reanchorQuote returns text offsets, which we must convert
+    const newFrom = textOffsetToProseMirrorPosition(doc, result.from) ?? anchor.from;
+    const newTo = textOffsetToProseMirrorPosition(doc, result.to) ?? anchor.to;
+
+    // Bounds check: clamp to valid doc range
+    const docSize = doc.content.size;
+    const clampedFrom = Math.max(0, Math.min(newFrom, docSize));
+    const clampedTo = Math.max(clampedFrom, Math.min(newTo, docSize));
+
+    const newQuote =
+      clampedFrom < clampedTo ? doc.textBetween(clampedFrom, clampedTo, '\n') : anchor.quote;
+
+    // Compute new prefix/suffix context from the document at the new position
+    // This ensures subsequent re-anchors have fresh context data
+    let newPrefix = anchor.prefix;
+    let newSuffix = anchor.suffix;
+    if (clampedFrom < clampedTo) {
+      const prefixStart = Math.max(0, clampedFrom - 50);
+      const suffixEnd = Math.min(docSize, clampedTo + 50);
+      newPrefix = doc.textBetween(prefixStart, clampedFrom, '\n');
+      newSuffix = doc.textBetween(clampedTo, suffixEnd, '\n');
+    }
+
+    const newAnchor: AnchorState = {
+      ...anchor,
+      from: clampedFrom,
+      to: clampedTo,
+      quote: newQuote,
+      prefix: newPrefix,
+      suffix: newSuffix,
+      lastKnownOffset: result.from,
+    };
+
+    newAnchors.set(threadId, newAnchor);
+
+    // Collect update
+    updates.push({
+      threadId,
+      from: clampedFrom,
+      to: clampedTo,
+      quote: newQuote,
+      prefix: newPrefix,
+      suffix: newSuffix,
+      status: 'anchored',
+      lastKnownOffset: result.from,
+    });
+  }
+
+  // Dispatch state update
+  view.dispatch(
+    view.state.tr.setMeta(anchorPluginKey, {
+      type: 'sync',
+      threads: Array.from(newAnchors.values()).map((a) => ({
+        id: a.threadId,
+        anchor: { ...a, status: 'anchored' as const },
+        comments: [],
+        createdAt: new Date().toISOString(),
+      })),
+      source: 'external' as const,
+    }),
+  );
+
+  // Fire updates callback
+  if (updates.length > 0) {
+    options.onAnchorsUpdate?.(updates);
+  }
+
+  // Fire deleted callbacks - parent should delete these threads
+  for (const threadId of deletedThreadIds) {
+    options.onAnchorDeleted?.(threadId);
+  }
+}
+
+// ============================================================================
+// Decorations
+// ============================================================================
+
+/**
+ * Compute decorations for all anchors.
+ *
+ * All anchors get a simple inline highlight. Active and hovered states
+ * are indicated via additional CSS classes.
+ */
+function computeDecorations(state: EditorState): DecorationSet {
+  const pluginState = anchorPluginKey.getState(state);
+  if (!pluginState) return DecorationSet.empty;
+
+  const decorations: Decoration[] = [];
+  const docSize = state.doc.content.size;
+  const activeThreadId = pluginState.activeThreadId;
+  const hoveredThreadId = pluginState.hoveredThreadId;
+
+  for (const [threadId, anchor] of pluginState.anchors) {
+    // Bounds checking: clamp positions to valid doc range
+    const from = Math.max(0, Math.min(anchor.from, docSize));
+    const to = Math.max(from, Math.min(anchor.to, docSize));
+
+    // Skip invalid ranges
+    if (from >= to) continue;
+
+    const isActive = activeThreadId === threadId;
+    const activeClass = isActive ? ' comment-anchor--active' : '';
+    const isHovered = hoveredThreadId === threadId;
+    const hoveredClass = isHovered ? ' comment-anchor--hovered' : '';
+
+    // Standard highlight for all anchors
+    decorations.push(
+      Decoration.inline(
+        from,
+        to,
+        {
+          class: `comment-anchor${activeClass}${hoveredClass}`,
+          'data-thread-id': threadId,
+        },
+        { key: `anchor-${threadId}` },
+      ),
+    );
+  }
+
+  return DecorationSet.create(state.doc, decorations);
+}
+
+// ============================================================================
+// Plugin Factory
+// ============================================================================
+
+/**
+ * Create the anchor tracking plugin.
+ *
+ * IMPORTANT: This should be called once per ReviewEditor instance,
+ * in the instance script (not module script) before the editor mounts.
+ *
+ * @param options - Plugin options with callbacks
+ * @returns Milkdown plugin wrapper
+ */
+export function createAnchorPlugin(options: AnchorPluginOptions = {}) {
+  let reanchorTimeout: ReturnType<typeof setTimeout> | null = null;
+
+  function updateHoverState(view: EditorView, threadId: string | null): void {
+    const pluginState = anchorPluginKey.getState(view.state);
+    if (pluginState?.hoveredThreadId === threadId) return;
+
+    view.dispatch(
+      view.state.tr.setMeta(anchorPluginKey, {
+        type: 'set-hover',
+        threadId,
+      }),
+    );
+  }
+
+  return $prose(() => {
+    return new Plugin({
+      key: anchorPluginKey,
+
+      state: {
+        init: (): AnchorPluginState => ({
+          anchors: new Map(),
+          needsReanchor: false,
+          activeThreadId: null,
+          hoveredThreadId: null,
+        }),
+
+        apply: (tr, prevState, _, newState): AnchorPluginState => {
+          // Handle meta-transactions first
+          const meta = tr.getMeta(anchorPluginKey) as unknown;
+          if (isAnchorPluginMeta(meta)) {
+            return handleMetaTransaction(meta, prevState);
+          }
+
+          // No doc change = no position updates needed
+          if (!tr.docChanged) return prevState;
+
+          // Map positions and detect inside-range edits
+          return mapAnchorsThroughTransaction(tr, prevState, newState);
+        },
+      },
+
+      view: () => {
+        // Track doc identity to detect stale re-anchor results
+        // Using doc identity (doc.eq()) instead of size, because
+        // same-length edits could apply an out-of-date re-anchor
+        let scheduledDoc: ProseMirrorNode | null = null;
+
+        return {
+          update: (view) => {
+            const pluginState = anchorPluginKey.getState(view.state);
+            if (!pluginState?.needsReanchor) return;
+
+            // Capture the doc at schedule time for identity check
+            scheduledDoc = view.state.doc;
+
+            // Debounce re-anchoring (300ms)
+            if (reanchorTimeout) clearTimeout(reanchorTimeout);
+
+            reanchorTimeout = setTimeout(() => {
+              // Verify doc hasn't changed during debounce using identity check
+              if (!scheduledDoc || !view.state.doc.eq(scheduledDoc)) {
+                // Doc changed, skip this run - next update will reschedule
+                return;
+              }
+
+              const currentPluginState = anchorPluginKey.getState(view.state);
+              if (currentPluginState) {
+                performDeferredReanchoring(view, currentPluginState, options);
+              }
+            }, 300);
+          },
+
+          destroy: () => {
+            if (reanchorTimeout) clearTimeout(reanchorTimeout);
+          },
+        };
+      },
+
+      props: {
+        decorations: computeDecorations,
+
+        handleDOMEvents: {
+          mouseover: (view, event) => {
+            const target = event.target;
+            if (!(target instanceof Element)) return false;
+
+            const anchorElement = target.closest('[data-thread-id]');
+            if (!anchorElement) {
+              updateHoverState(view, null);
+              return false;
+            }
+
+            const threadId = anchorElement.getAttribute('data-thread-id');
+            if (threadId) {
+              updateHoverState(view, threadId);
+            }
+
+            return false;
+          },
+
+          mouseout: (view, event) => {
+            const target = event.target;
+            if (!(target instanceof Element)) return false;
+
+            const anchorElement = target.closest('[data-thread-id]');
+            if (!anchorElement) return false;
+
+            const threadId = anchorElement.getAttribute('data-thread-id');
+            if (!threadId) return false;
+
+            const relatedTarget = event.relatedTarget;
+            if (relatedTarget instanceof Element) {
+              const nextAnchor = relatedTarget.closest(`[data-thread-id="${threadId}"]`);
+              if (nextAnchor) {
+                return false;
+              }
+            }
+
+            updateHoverState(view, null);
+            return false;
+          },
+
+          mouseleave: (view) => {
+            updateHoverState(view, null);
+            return false;
+          },
+
+          // Handle clicks on anchor decorations to surface them to the parent component.
+          // Always returns false to let ProseMirror handle selection and other default behavior.
+          click: (_view, event) => {
+            if (!options.onAnchorClick) return false;
+
+            // Check if click target is within an anchor decoration.
+            // Guard against non-Element targets (e.g., text nodes) which don't have .closest()
+            const target = event.target;
+            if (!(target instanceof Element)) return false;
+
+            const anchorElement = target.closest('[data-thread-id]');
+
+            if (anchorElement) {
+              const threadId = anchorElement.getAttribute('data-thread-id');
+              if (threadId) {
+                options.onAnchorClick(threadId, event);
+              }
+            }
+
+            // Always return false - we never want to prevent ProseMirror from handling the event
+            return false;
+          },
+        },
+      },
+    });
+  });
+}

--- a/packages/commentary/src/anchoring.test.ts
+++ b/packages/commentary/src/anchoring.test.ts
@@ -1,0 +1,120 @@
+// @ts-nocheck -- migrated commentary assertions use runtime-verified fixture indexing.
+/**
+ * Unit tests for editor anchoring utilities.
+ *
+ * These tests verify the pure functions that don't require a DOM environment.
+ * For integration tests with real ProseMirror documents, see anchoring.svelte.test.ts.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import { generateBlockId } from './anchoring.js';
+
+describe('generateBlockId', () => {
+  describe('basic functionality', () => {
+    test('generates a block ID from node type and content', () => {
+      const blockId = generateBlockId('heading', 'Introduction to Anchoring');
+      expect(blockId).toMatch(/^heading-[a-z0-9]+$/);
+    });
+
+    test('generates consistent IDs for the same input', () => {
+      const blockId1 = generateBlockId('paragraph', 'Hello world');
+      const blockId2 = generateBlockId('paragraph', 'Hello world');
+      expect(blockId1).toBe(blockId2);
+    });
+
+    test('generates different IDs for different content', () => {
+      const blockId1 = generateBlockId('paragraph', 'Hello world');
+      const blockId2 = generateBlockId('paragraph', 'Goodbye world');
+      expect(blockId1).not.toBe(blockId2);
+    });
+
+    test('generates different IDs for different node types', () => {
+      const blockId1 = generateBlockId('heading', 'Same content');
+      const blockId2 = generateBlockId('paragraph', 'Same content');
+      expect(blockId1).not.toBe(blockId2);
+    });
+  });
+
+  describe('content truncation', () => {
+    test('uses only first 50 characters for hashing', () => {
+      // Both should produce the same ID since they share the first 50 chars
+      const prefix50 = 'A'.repeat(50);
+      const longContent1 = prefix50 + 'DIFFERENT_SUFFIX_1';
+      const longContent2 = prefix50 + 'DIFFERENT_SUFFIX_2';
+
+      const blockId1 = generateBlockId('paragraph', longContent1);
+      const blockId2 = generateBlockId('paragraph', longContent2);
+
+      expect(blockId1).toBe(blockId2);
+    });
+
+    test('produces different IDs when first 50 chars differ', () => {
+      const content1 = 'A' + 'x'.repeat(100);
+      const content2 = 'B' + 'x'.repeat(100);
+
+      const blockId1 = generateBlockId('paragraph', content1);
+      const blockId2 = generateBlockId('paragraph', content2);
+
+      expect(blockId1).not.toBe(blockId2);
+    });
+  });
+
+  describe('edge cases', () => {
+    test('handles empty content', () => {
+      const blockId = generateBlockId('paragraph', '');
+      expect(blockId).toMatch(/^paragraph-[a-z0-9]+$/);
+    });
+
+    test('handles empty node type', () => {
+      const blockId = generateBlockId('', 'Some content');
+      expect(blockId).toMatch(/^-[a-z0-9]+$/);
+    });
+
+    test('handles whitespace content', () => {
+      const blockId = generateBlockId('paragraph', '   ');
+      expect(blockId).toMatch(/^paragraph-[a-z0-9]+$/);
+    });
+
+    test('handles unicode content', () => {
+      const blockId = generateBlockId('heading', '你好世界 🌍');
+      expect(blockId).toMatch(/^heading-[a-z0-9]+$/);
+    });
+
+    test('handles special characters', () => {
+      const blockId = generateBlockId('code_block', 'const x = 1; // comment');
+      expect(blockId).toMatch(/^code_block-[a-z0-9]+$/);
+    });
+
+    test('handles newlines in content', () => {
+      const blockId = generateBlockId('code_block', 'line1\nline2\nline3');
+      expect(blockId).toMatch(/^code_block-[a-z0-9]+$/);
+    });
+  });
+
+  describe('common node types', () => {
+    test('works with heading nodes', () => {
+      const blockId = generateBlockId('heading', 'Chapter 1');
+      expect(blockId).toMatch(/^heading-/);
+    });
+
+    test('works with paragraph nodes', () => {
+      const blockId = generateBlockId('paragraph', 'Some text');
+      expect(blockId).toMatch(/^paragraph-/);
+    });
+
+    test('works with code_block nodes', () => {
+      const blockId = generateBlockId('code_block', 'function test() {}');
+      expect(blockId).toMatch(/^code_block-/);
+    });
+
+    test('works with blockquote nodes', () => {
+      const blockId = generateBlockId('blockquote', 'A famous quote');
+      expect(blockId).toMatch(/^blockquote-/);
+    });
+
+    test('works with list_item nodes', () => {
+      const blockId = generateBlockId('list_item', 'First item');
+      expect(blockId).toMatch(/^list_item-/);
+    });
+  });
+});

--- a/packages/commentary/src/anchoring.ts
+++ b/packages/commentary/src/anchoring.ts
@@ -1,0 +1,185 @@
+/**
+ * Editor anchoring utilities for creating and detecting anchor positions.
+ *
+ * These utilities are extracted from ReviewEditor to enable reuse across
+ * different editor components and features. They work with ProseMirror
+ * documents to create TextQuoteSelector-style anchors.
+ *
+ * @module
+ */
+
+import { proseMirrorPositionToTextOffset, textOffsetToLineColumn } from '@cinder/editor';
+import type { Node } from '@milkdown/prose/model';
+import type { EditorView } from '@milkdown/prose/view';
+import type { CommentAnchor } from './comments/types.js';
+import { ANCHOR_CONTEXT_LENGTH } from './comments/types.js';
+
+/**
+ * Generate a stable block ID from node type and content.
+ *
+ * Creates a deterministic identifier for a block-level node by combining
+ * the node type with a hash of the first 50 characters of its content.
+ * This ID survives document edits as long as the block type and initial
+ * content remain the same.
+ *
+ * @param nodeType - The ProseMirror node type name (e.g., 'heading', 'paragraph')
+ * @param textContent - The text content of the node
+ * @returns A stable block ID in the format `{nodeType}-{hash}`
+ *
+ * @example
+ * ```typescript
+ * const blockId = generateBlockId('heading', 'Introduction to Anchoring');
+ * // Returns something like 'heading-abc123'
+ * ```
+ */
+export function generateBlockId(nodeType: string, textContent: string): string {
+  // Simple hash function for short strings
+  const contentPrefix = textContent.slice(0, 50);
+  let hash = 0;
+  for (let i = 0; i < contentPrefix.length; i++) {
+    const character = contentPrefix.charCodeAt(i);
+    hash = (hash << 5) - hash + character;
+    hash = hash & hash; // Convert to 32-bit integer
+  }
+  return `${nodeType}-${Math.abs(hash).toString(36)}`;
+}
+
+/**
+ * Detect if a selection spans an entire block node.
+ *
+ * Checks whether the selection boundaries (from, to) exactly match
+ * the content boundaries of a block-level node at depth 1 (direct
+ * children of the document root). This is useful for determining
+ * if a comment should be anchored to an entire block rather than
+ * just the selected text.
+ *
+ * @param document - The ProseMirror document node
+ * @param from - Start position of the selection
+ * @param to - End position of the selection
+ * @returns The block ID if selection spans entire block, undefined otherwise
+ *
+ * @example
+ * ```typescript
+ * const view = editor.getView();
+ * const { from, to } = view.state.selection;
+ * const blockId = detectBlockLevelAnchor(view.state.doc, from, to);
+ *
+ * if (blockId) {
+ *   // Selection covers an entire block (heading, paragraph, etc.)
+ *   console.log('Block-level selection:', blockId);
+ * } else {
+ *   // Partial text selection within a block
+ *   console.log('Text selection');
+ * }
+ * ```
+ */
+export function detectBlockLevelAnchor(
+  document: Node,
+  from: number,
+  to: number,
+): string | undefined {
+  // Resolve positions to find the containing nodes
+  const resolvedFrom = document.resolve(from);
+  const resolvedTo = document.resolve(to);
+
+  // Check if we're selecting an entire block at depth 1 (direct children of doc)
+  // This catches headings, paragraphs, code blocks, etc.
+  if (resolvedFrom.depth >= 1 && resolvedTo.depth >= 1) {
+    // Find the block-level parent
+    const parentDepth = 1;
+    const fromParent = resolvedFrom.node(parentDepth);
+    const toParent = resolvedTo.node(parentDepth);
+
+    // If selection is within the same block node
+    if (fromParent === toParent) {
+      // Check if selection covers the entire block's content
+      const parentStart = resolvedFrom.start(parentDepth);
+      const parentEnd = resolvedFrom.end(parentDepth);
+
+      if (from === parentStart && to === parentEnd) {
+        // Selection covers the entire block
+        const nodeType = fromParent.type.name;
+        const textContent = fromParent.textContent;
+        return generateBlockId(nodeType, textContent);
+      }
+    }
+  }
+
+  return undefined;
+}
+
+/**
+ * Build a CommentAnchor from a ProseMirror selection range.
+ *
+ * Creates a complete anchor object with all the data needed for both
+ * runtime positioning (ProseMirror positions) and persistence
+ * (TextQuoteSelector-style quote/prefix/suffix).
+ *
+ * The anchor includes:
+ * - ProseMirror positions (from, to)
+ * - Selected text (quote)
+ * - Context for re-anchoring (prefix, suffix)
+ * - Original position data for disambiguation
+ * - Block ID if selection spans entire block
+ *
+ * @param view - The ProseMirror EditorView
+ * @param from - Start position of the selection
+ * @param to - End position of the selection
+ * @returns A complete CommentAnchor ready for use or persistence
+ *
+ * @example
+ * ```typescript
+ * const view = editor.getView();
+ * const { from, to } = view.state.selection;
+ *
+ * if (from !== to) {
+ *   const anchor = buildAnchorFromSelection(view, from, to);
+ *   // Use anchor for thread creation
+ *   onthreadcreate?.({ anchor, body: comment, authorId: userId });
+ * }
+ * ```
+ */
+export function buildAnchorFromSelection(
+  view: EditorView,
+  from: number,
+  to: number,
+): CommentAnchor {
+  const { doc } = view.state;
+
+  // Extract text directly from ProseMirror document
+  const selectedText = doc.textBetween(from, to, '\n');
+
+  // Get surrounding context (prefix/suffix) from the document
+  const prefixStart = Math.max(0, from - ANCHOR_CONTEXT_LENGTH);
+  const suffixEnd = Math.min(doc.content.size, to + ANCHOR_CONTEXT_LENGTH);
+
+  const prefix = doc.textBetween(prefixStart, from, '\n');
+  const suffix = doc.textBetween(to, suffixEnd, '\n');
+
+  // Calculate text offset for originalPosition (used for disambiguation)
+  const textOffset = proseMirrorPositionToTextOffset(doc, from);
+
+  // Compute line/column from the document text
+  const originalPosition = textOffsetToLineColumn(doc, textOffset);
+
+  // Check if this is a block-level selection
+  const blockId = detectBlockLevelAnchor(doc, from, to);
+
+  const anchor: CommentAnchor = {
+    from,
+    to,
+    quote: selectedText,
+    prefix,
+    suffix,
+    status: 'anchored',
+    originalQuote: selectedText,
+    lastKnownOffset: textOffset,
+    originalPosition,
+  };
+
+  if (blockId !== undefined) {
+    anchor.blockId = blockId;
+  }
+
+  return anchor;
+}

--- a/packages/commentary/src/comments/index.ts
+++ b/packages/commentary/src/comments/index.ts
@@ -1,0 +1,66 @@
+/**
+ * Comment and thread system for the Markdown Review Editor.
+ *
+ * @module
+ */
+
+export {
+  ANCHOR_CONTEXT_LENGTH,
+  createDocumentAnchor,
+  createTextQuoteAnchor,
+  // Utilities
+  generateId,
+  isDocumentAnchor,
+  isTextAnchor,
+  timestamp,
+  type AnchorStatus,
+  // Anchor types
+  type AnchorType,
+  type AnchorUpdate,
+  // Comment types
+  type Comment,
+  type CommentAnchor,
+  type CommentCreateEvent,
+  type CommentDeleteEvent,
+  type CommentUpdateEvent,
+  type CreateCommentInput,
+  type CreateThreadInput,
+  type PersistedAnchor,
+  type PersistedThread,
+  type ReanchorResult,
+  // Review state
+  type ReviewState,
+  type RuntimeAnchor,
+  type TextQuoteAnchor,
+  // Thread types
+  type Thread,
+  // Event types (DEP-40: added new lifecycle events)
+  type ThreadCreateEvent,
+  type ThreadDeleteEvent,
+  type UpdateCommentInput,
+} from './types.js';
+
+// Re-anchoring algorithm (DEP-39)
+export {
+  findAllOccurrences,
+  fuzzyReanchor,
+  reanchorQuote,
+  scoreContextMatch,
+  type ReanchorInput,
+} from './reanchor.js';
+
+// Pure update helpers (DEP-40)
+export {
+  addComment,
+  addThread,
+  deleteComment,
+  deleteThread,
+  getVisibleComments,
+  isCommentVisible,
+  restoreComment,
+  updateComment,
+  type UpdateResult,
+} from './updates.js';
+
+// Mention extraction (DEP-40)
+export { extractMentions } from './mentions.js';

--- a/packages/commentary/src/comments/mentions.test.ts
+++ b/packages/commentary/src/comments/mentions.test.ts
@@ -1,0 +1,141 @@
+// @ts-nocheck -- migrated commentary assertions use runtime-verified fixture indexing.
+import { describe, expect, test } from 'bun:test';
+import { extractMentions } from './mentions.js';
+
+describe('extractMentions', () => {
+  test('extracts single mention', () => {
+    const result = extractMentions('Hello @alice!');
+    expect(result).toEqual(['alice']);
+  });
+
+  test('extracts multiple mentions', () => {
+    const result = extractMentions('Hello @alice and @bob!');
+    expect(result).toEqual(['alice', 'bob']);
+  });
+
+  test('deduplicates repeated mentions', () => {
+    const result = extractMentions('@alice said to @bob, but @alice disagreed');
+    expect(result).toEqual(['alice', 'bob']);
+  });
+
+  test('handles usernames with underscores', () => {
+    const result = extractMentions('Thanks @user_name!');
+    expect(result).toEqual(['user_name']);
+  });
+
+  test('handles usernames with hyphens', () => {
+    const result = extractMentions('Thanks @user-name!');
+    expect(result).toEqual(['user-name']);
+  });
+
+  test('handles mixed alphanumeric usernames', () => {
+    const result = extractMentions('Thanks @user123!');
+    expect(result).toEqual(['user123']);
+  });
+
+  test('ignores email addresses', () => {
+    const result = extractMentions('Contact user@example.com or @alice');
+    expect(result).toEqual(['alice']);
+  });
+
+  test('ignores mentions inside inline code', () => {
+    const result = extractMentions('See `@config` or @alice');
+    expect(result).toEqual(['alice']);
+  });
+
+  test('ignores mentions inside fenced code blocks', () => {
+    const result = extractMentions(`Check this:
+\`\`\`
+const user = @admin;
+\`\`\`
+But @alice should see this.`);
+    expect(result).toEqual(['alice']);
+  });
+
+  test('handles multiple inline code segments', () => {
+    const result = extractMentions('Use `@hook1` and `@hook2` but ping @alice');
+    expect(result).toEqual(['alice']);
+  });
+
+  test('returns empty array for no mentions', () => {
+    const result = extractMentions('No mentions here');
+    expect(result).toEqual([]);
+  });
+
+  test('returns empty array for empty string', () => {
+    const result = extractMentions('');
+    expect(result).toEqual([]);
+  });
+
+  test('handles mention at start of string', () => {
+    const result = extractMentions('@alice is here');
+    expect(result).toEqual(['alice']);
+  });
+
+  test('handles mention at end of string', () => {
+    const result = extractMentions('Hello @alice');
+    expect(result).toEqual(['alice']);
+  });
+
+  test('handles only mention in string', () => {
+    const result = extractMentions('@alice');
+    expect(result).toEqual(['alice']);
+  });
+
+  test('ignores @ after word characters (prevents false positives)', () => {
+    const result = extractMentions('Check the value@prop assignment');
+    expect(result).toEqual([]);
+  });
+
+  test('ignores @ after periods (email pattern)', () => {
+    const result = extractMentions('name.surname@domain and @alice');
+    expect(result).toEqual(['alice']);
+  });
+
+  test('ignores @ after plus sign (email with tag pattern)', () => {
+    const result = extractMentions('user+tag@example.com and @alice');
+    expect(result).toEqual(['alice']);
+  });
+
+  test('handles newlines around mentions', () => {
+    const result = extractMentions('Line 1\n@alice\nLine 3');
+    expect(result).toEqual(['alice']);
+  });
+
+  test('handles multiple @ symbols in a row', () => {
+    const result = extractMentions('@@alice is not valid but @bob is');
+    // @alice is preceded by @, which is not a word char, so it should match
+    expect(result).toContain('alice');
+    expect(result).toContain('bob');
+  });
+
+  // Edge cases for unterminated/malformed markdown
+  // Note: The regex uses non-greedy matching, so unterminated blocks don't
+  // consume the entire string - they just fail to match and pass through.
+  describe('edge cases (malformed markdown)', () => {
+    test('extracts mentions from unterminated fenced code block (limitation)', () => {
+      // Unterminated blocks don't match the regex, so content passes through
+      // This is a known limitation - documenting actual behavior
+      const result = extractMentions('```\n@inside\nno closing');
+      expect(result).toContain('inside');
+    });
+
+    test('extracts mentions before and in unterminated fenced code block (limitation)', () => {
+      const result = extractMentions('@alice then ```\n@inside code');
+      // Both match since the unterminated block doesn't get stripped
+      expect(result).toContain('alice');
+      expect(result).toContain('inside');
+    });
+
+    test('handles adjacent inline code segments', () => {
+      const result = extractMentions('`@a``@b` but @alice');
+      // Adjacent backticks create two inline code segments
+      expect(result).toEqual(['alice']);
+    });
+
+    test('handles inline code at string boundaries', () => {
+      const result = extractMentions('`@start` middle @alice `@end`');
+      expect(result).toEqual(['alice']);
+    });
+  });
+});

--- a/packages/commentary/src/comments/mentions.ts
+++ b/packages/commentary/src/comments/mentions.ts
@@ -1,0 +1,72 @@
+/**
+ * Mention extraction utility for comment bodies.
+ *
+ * Extracts @username mentions while avoiding false positives from:
+ * - Email addresses (user@example.com)
+ * - Code blocks (```code```)
+ * - Inline code (`code`)
+ *
+ * ## Known Limitations
+ *
+ * This is a regex-based heuristic, not a full Markdown parser. Edge cases:
+ * - **Unterminated fenced blocks**: An unclosed ``` consumes the rest of the string
+ * - **Escaped backticks**: Inline code with escaped backticks (e.g., `foo\`bar`) may misbehave
+ * - **HTML code tags**: `<code>@mention</code>` is not detected as code
+ *
+ * For most comment use cases, these limitations are acceptable. If more robust
+ * parsing is needed, consider using the editor's AST via Milkdown/Prosemirror.
+ *
+ * @module
+ */
+
+// Match @username but not email addresses (preceded by word char, period, or plus)
+// Uses a capturing group alternative instead of negative lookbehind for Safari <16.4 compatibility
+// Pattern: (start-of-string OR non-email-char) followed by @username
+// The username is in capture group 2
+// Hoisted outside function to avoid regex recompilation on each call
+const mentionRegex = /(^|[^.\w+])@([\w-]+)/g;
+
+/**
+ * Extract @mentions from a comment body.
+ *
+ * Matches @username patterns where username contains alphanumeric characters,
+ * underscores, and hyphens. Ignores mentions inside code blocks and inline code,
+ * and avoids matching email addresses.
+ *
+ * @param body - The comment body (Markdown)
+ * @returns Array of unique usernames (without the @ prefix)
+ *
+ * @example
+ * extractMentions('Hello @alice and @bob!')
+ * // Returns: ['alice', 'bob']
+ *
+ * @example
+ * extractMentions('Email: user@example.com @alice')
+ * // Returns: ['alice'] (ignores email)
+ *
+ * @example
+ * extractMentions('See `@config` or @alice')
+ * // Returns: ['alice'] (ignores inline code)
+ */
+export function extractMentions(body: string): string[] {
+  // Remove fenced code blocks (```...```)
+  const withoutFencedCode = body.replace(/```[\s\S]*?```/g, '');
+
+  // Remove inline code (`...`)
+  const withoutCode = withoutFencedCode.replace(/`[^`]*`/g, '');
+
+  // Reset regex lastIndex since we're reusing a global regex
+  mentionRegex.lastIndex = 0;
+
+  const mentions = new Set<string>();
+
+  for (const match of withoutCode.matchAll(mentionRegex)) {
+    // Group 2 contains the username (group 1 is the preceding character/start-of-string)
+    const username = match[2];
+    if (username) {
+      mentions.add(username);
+    }
+  }
+
+  return Array.from(mentions);
+}

--- a/packages/commentary/src/comments/reanchor.test.ts
+++ b/packages/commentary/src/comments/reanchor.test.ts
@@ -1,0 +1,505 @@
+// @ts-nocheck -- migrated commentary assertions use runtime-verified fixture indexing.
+import { describe, expect, test } from 'bun:test';
+import {
+  findAllOccurrences,
+  fuzzyReanchor,
+  reanchorQuote,
+  scoreContextMatch,
+  type ReanchorInput,
+} from './reanchor.js';
+
+describe('findAllOccurrences', () => {
+  test('finds single occurrence', () => {
+    const result = findAllOccurrences('hello', 'say hello world');
+    expect(result).toEqual([{ start: 4, end: 9 }]);
+  });
+
+  test('finds multiple occurrences', () => {
+    const result = findAllOccurrences('the', 'the cat and the dog');
+    expect(result).toEqual([
+      { start: 0, end: 3 },
+      { start: 12, end: 15 },
+    ]);
+  });
+
+  test('finds overlapping occurrences', () => {
+    const result = findAllOccurrences('aa', 'aaaa');
+    expect(result).toEqual([
+      { start: 0, end: 2 },
+      { start: 1, end: 3 },
+      { start: 2, end: 4 },
+    ]);
+  });
+
+  test('returns empty array when quote not found', () => {
+    const result = findAllOccurrences('missing', 'text without the word');
+    expect(result).toEqual([]);
+  });
+
+  test('returns empty array for empty quote', () => {
+    const result = findAllOccurrences('', 'some text');
+    expect(result).toEqual([]);
+  });
+
+  test('handles case sensitivity', () => {
+    const result = findAllOccurrences('Hello', 'hello Hello HELLO');
+    expect(result).toEqual([{ start: 6, end: 11 }]);
+  });
+});
+
+describe('scoreContextMatch', () => {
+  test('returns 1.0 for perfect context match', () => {
+    const documentText = 'prefix text quote text suffix text';
+    const match = { start: 12, end: 17 }; // "quote"
+    const score = scoreContextMatch(documentText, match, 'prefix text ', ' text suffix');
+    expect(score).toBeCloseTo(1.0, 1);
+  });
+
+  test('returns lower score for partial context match', () => {
+    const documentText = 'different text quote text same';
+    const match = { start: 15, end: 20 }; // "quote"
+    const score = scoreContextMatch(documentText, match, 'prefix text ', ' text same');
+    // Suffix matches better than prefix
+    expect(score).toBeGreaterThan(0.3);
+    expect(score).toBeLessThan(1.0);
+  });
+
+  test('returns 1.0 for empty expected context', () => {
+    const documentText = 'quote';
+    const match = { start: 0, end: 5 };
+    const score = scoreContextMatch(documentText, match, '', '');
+    expect(score).toBe(1.0);
+  });
+
+  test('handles match at document start', () => {
+    const documentText = 'quote suffix text';
+    const match = { start: 0, end: 5 };
+    const score = scoreContextMatch(documentText, match, 'no match', ' suffix text');
+    // Prefix has no match (score 0), suffix matches well
+    expect(score).toBeGreaterThan(0.3);
+  });
+
+  test('handles match at document end', () => {
+    const documentText = 'prefix text quote';
+    const match = { start: 12, end: 17 };
+    const score = scoreContextMatch(documentText, match, 'prefix text ', 'no match');
+    // Prefix matches well, suffix has no match
+    expect(score).toBeGreaterThan(0.3);
+  });
+});
+
+describe('fuzzyReanchor', () => {
+  test('finds junction point using prefix and suffix', () => {
+    const documentText = 'The quick brown fox jumps over the lazy dog';
+    const anchor: ReanchorInput = {
+      quote: 'deleted text',
+      prefix: 'quick brown ',
+      suffix: ' jumps over',
+      lastKnownOffset: 10,
+    };
+
+    const result = fuzzyReanchor(documentText, anchor);
+
+    // Should find a position near where prefix ends and suffix begins
+    expect(result.found).toBe(false);
+    expect(result.confidence).toBeGreaterThan(0);
+  });
+
+  test('returns not found with zero confidence when no context match', () => {
+    const documentText = 'completely different text';
+    const anchor: ReanchorInput = {
+      quote: 'missing',
+      prefix: 'xyz abc ',
+      suffix: ' def ghi',
+    };
+
+    const result = fuzzyReanchor(documentText, anchor);
+
+    expect(result.found).toBe(false);
+    expect(result.from).toBe(0);
+    expect(result.to).toBe(0);
+    expect(result.confidence).toBe(0);
+  });
+
+  test('uses lastKnownOffset as reference position', () => {
+    const documentText = 'some text in the document';
+    const anchor: ReanchorInput = {
+      quote: 'deleted',
+      prefix: 'some ',
+      suffix: ' in',
+      lastKnownOffset: 5,
+    };
+
+    const result = fuzzyReanchor(documentText, anchor);
+
+    // Should search near lastKnownOffset
+    expect(result.found).toBe(false);
+  });
+
+  test('falls back to originalPosition when lastKnownOffset absent', () => {
+    const documentText = 'some text in the document';
+    const anchor: ReanchorInput = {
+      quote: 'deleted',
+      prefix: 'some ',
+      suffix: ' in',
+      originalPosition: { offset: 5 },
+    };
+
+    const result = fuzzyReanchor(documentText, anchor);
+
+    expect(result.found).toBe(false);
+  });
+});
+
+describe('reanchorQuote', () => {
+  describe('exact match - single occurrence', () => {
+    test('returns anchored for single match with good context', () => {
+      const documentText = 'The quick brown fox jumps over the lazy dog';
+      const anchor: ReanchorInput = {
+        quote: 'brown fox',
+        prefix: 'The quick ',
+        suffix: ' jumps over',
+      };
+
+      const result = reanchorQuote(documentText, anchor);
+
+      expect(result.found).toBe(true);
+      expect(result.from).toBe(10);
+      expect(result.to).toBe(19);
+      expect(result.confidence).toBeGreaterThanOrEqual(0.7);
+    });
+
+    test('returns found with lower confidence for single match with poor context', () => {
+      const documentText = 'The quick brown fox jumps over the lazy dog';
+      const anchor: ReanchorInput = {
+        quote: 'brown fox',
+        prefix: 'completely different ',
+        suffix: ' wrong suffix',
+      };
+
+      const result = reanchorQuote(documentText, anchor);
+
+      expect(result.found).toBe(true);
+      expect(result.from).toBe(10);
+      expect(result.to).toBe(19);
+      expect(result.confidence).toBeLessThan(0.7);
+    });
+  });
+
+  describe('exact match - multiple occurrences', () => {
+    test('selects best match by context', () => {
+      const documentText = 'the cat chased the dog and the bird flew away';
+      const anchor: ReanchorInput = {
+        quote: 'the',
+        prefix: 'and ',
+        suffix: ' bird',
+      };
+
+      const result = reanchorQuote(documentText, anchor);
+
+      expect(result.found).toBe(true);
+      expect(result.from).toBe(27); // "and the bird"
+      expect(result.to).toBe(30);
+    });
+
+    test('uses lastKnownOffset for disambiguation', () => {
+      // "the" appears three times, we want the one at position 0
+      const documentText = 'the first the second the third';
+      const anchor: ReanchorInput = {
+        quote: 'the',
+        prefix: '',
+        suffix: ' first',
+        lastKnownOffset: 0,
+      };
+
+      const result = reanchorQuote(documentText, anchor);
+
+      expect(result.from).toBe(0);
+      expect(result.to).toBe(3);
+    });
+
+    test('prefers lastKnownOffset over originalPosition', () => {
+      // "the" appears at positions 0, 10, and 21
+      const documentText = 'the first the second the third';
+      const anchor: ReanchorInput = {
+        quote: 'the',
+        prefix: '',
+        suffix: '',
+        lastKnownOffset: 21, // Near "the third"
+        originalPosition: { offset: 0 }, // Near "the first"
+      };
+
+      const result = reanchorQuote(documentText, anchor);
+
+      // Should pick "the third" due to lastKnownOffset proximity
+      expect(result.from).toBe(21);
+      expect(result.to).toBe(24);
+    });
+
+    test('returns found when matches are ambiguous (selects best by scoring)', () => {
+      // Create a case where two matches have similar context
+      const documentText = 'start xxx middle xxx end';
+      const anchor: ReanchorInput = {
+        quote: 'xxx',
+        prefix: ' ',
+        suffix: ' ',
+      };
+
+      const result = reanchorQuote(documentText, anchor);
+
+      // Both "xxx" have similar context (space before and after)
+      // Selects best match by scoring even when ambiguous
+      expect(result.found).toBe(true);
+    });
+  });
+
+  describe('no match - fuzzy fallback', () => {
+    test('returns not found when quote is deleted', () => {
+      const documentText = 'The quick  jumps over the lazy dog';
+      const anchor: ReanchorInput = {
+        quote: 'brown fox',
+        prefix: 'The quick ',
+        suffix: ' jumps over',
+        lastKnownOffset: 10,
+      };
+
+      const result = reanchorQuote(documentText, anchor);
+
+      expect(result.found).toBe(false);
+    });
+
+    test('finds approximate position using context', () => {
+      const documentText = 'prefix content suffix more text';
+      const anchor: ReanchorInput = {
+        quote: 'deleted quote',
+        prefix: 'prefix ',
+        suffix: ' suffix',
+        lastKnownOffset: 7,
+      };
+
+      const result = reanchorQuote(documentText, anchor);
+
+      expect(result.found).toBe(false);
+      // Should find position near where prefix ends and suffix begins
+      expect(result.confidence).toBeGreaterThan(0);
+    });
+  });
+
+  describe('edge cases', () => {
+    test('handles empty document', () => {
+      const anchor: ReanchorInput = {
+        quote: 'text',
+        prefix: '',
+        suffix: '',
+      };
+
+      const result = reanchorQuote('', anchor);
+
+      expect(result.found).toBe(false);
+    });
+
+    test('handles quote at document start', () => {
+      const documentText = 'start of document';
+      const anchor: ReanchorInput = {
+        quote: 'start',
+        prefix: '',
+        suffix: ' of',
+      };
+
+      const result = reanchorQuote(documentText, anchor);
+
+      expect(result.found).toBe(true);
+      expect(result.from).toBe(0);
+      expect(result.to).toBe(5);
+    });
+
+    test('handles quote at document end', () => {
+      const documentText = 'end of document';
+      const anchor: ReanchorInput = {
+        quote: 'document',
+        prefix: 'of ',
+        suffix: '',
+      };
+
+      const result = reanchorQuote(documentText, anchor);
+
+      expect(result.found).toBe(true);
+      expect(result.from).toBe(7);
+      expect(result.to).toBe(15);
+    });
+
+    test('handles multi-line quotes', () => {
+      const documentText = 'line one\nline two\nline three';
+      const anchor: ReanchorInput = {
+        quote: 'line two',
+        prefix: 'line one\n',
+        suffix: '\nline three',
+      };
+
+      const result = reanchorQuote(documentText, anchor);
+
+      expect(result.found).toBe(true);
+      expect(result.from).toBe(9);
+      expect(result.to).toBe(17);
+    });
+
+    test('handles special characters in quote', () => {
+      const documentText = 'code: function() { return true; }';
+      const anchor: ReanchorInput = {
+        quote: '{ return true; }',
+        prefix: 'function() ',
+        suffix: '',
+      };
+
+      const result = reanchorQuote(documentText, anchor);
+
+      expect(result.found).toBe(true);
+      expect(result.from).toBe(17);
+      expect(result.to).toBe(33);
+    });
+  });
+
+  describe('confidence thresholds', () => {
+    test('returns high confidence when context matches well', () => {
+      const documentText = 'unique text with good context around it';
+      const anchor: ReanchorInput = {
+        quote: 'with good context',
+        prefix: 'unique text ',
+        suffix: ' around it',
+      };
+
+      const result = reanchorQuote(documentText, anchor);
+
+      expect(result.found).toBe(true);
+      expect(result.confidence).toBeGreaterThanOrEqual(0.7);
+    });
+
+    test('returns lower confidence when context does not match', () => {
+      const documentText = 'text with the word somewhere';
+      const anchor: ReanchorInput = {
+        quote: 'word',
+        prefix: 'wrong prefix ',
+        suffix: ' wrong suffix',
+      };
+
+      const result = reanchorQuote(documentText, anchor);
+
+      expect(result.found).toBe(true);
+      expect(result.confidence).toBeLessThan(0.7);
+    });
+
+    test('boundary case: partial context match', () => {
+      // Create a scenario where context partially matches
+      const documentText = 'prefix text quote suffix other';
+      const anchor: ReanchorInput = {
+        quote: 'quote',
+        prefix: 'prefix text ', // Good prefix match
+        suffix: ' different', // Poor suffix match
+      };
+
+      const result = reanchorQuote(documentText, anchor);
+
+      // Should find the quote regardless of confidence level
+      expect(result.found).toBe(true);
+      expect(result.from).toBe(12);
+      expect(result.to).toBe(17);
+    });
+  });
+
+  describe('ambiguity handling', () => {
+    test('selects best match even with similar contexts', () => {
+      // Two occurrences with very similar context
+      const documentText = 'a xxx b xxx c';
+      const anchor: ReanchorInput = {
+        quote: 'xxx',
+        prefix: ' ', // Both have space before
+        suffix: ' ', // Both have space after
+      };
+
+      const result = reanchorQuote(documentText, anchor);
+
+      // Picks best match by scoring even when ambiguous
+      expect(result.found).toBe(true);
+    });
+
+    test('handles three+ matches with close scores', () => {
+      // Three occurrences, all with similar context
+      const documentText = 'the start the middle the end';
+      const anchor: ReanchorInput = {
+        quote: 'the',
+        prefix: '',
+        suffix: ' ',
+      };
+
+      const result = reanchorQuote(documentText, anchor);
+
+      // Should find all three and pick best based on scoring
+      expect(result.found).toBe(true);
+      // Should select one of the valid positions
+      expect([0, 10, 21]).toContain(result.from);
+    });
+
+    test('disambiguates three+ matches using lastKnownOffset', () => {
+      const documentText = 'the start the middle the end';
+      const anchor: ReanchorInput = {
+        quote: 'the',
+        prefix: '',
+        suffix: '',
+        lastKnownOffset: 21, // Hint towards "the end"
+      };
+
+      const result = reanchorQuote(documentText, anchor);
+
+      // Should pick "the" nearest to lastKnownOffset
+      expect(result.found).toBe(true);
+      expect(result.from).toBe(21);
+      expect(result.to).toBe(24);
+    });
+  });
+
+  describe('unicode handling', () => {
+    test('handles unicode characters in quote', () => {
+      const documentText = 'Hello 世界 and こんにちは world';
+      const anchor: ReanchorInput = {
+        quote: '世界',
+        prefix: 'Hello ',
+        suffix: ' and',
+      };
+
+      const result = reanchorQuote(documentText, anchor);
+
+      expect(result.found).toBe(true);
+      expect(result.from).toBe(6);
+      expect(result.to).toBe(8);
+    });
+
+    test('handles emoji in quote', () => {
+      const documentText = 'React with 👍 or 👎 to vote';
+      const anchor: ReanchorInput = {
+        quote: '👍',
+        prefix: 'with ',
+        suffix: ' or',
+      };
+
+      const result = reanchorQuote(documentText, anchor);
+
+      expect(result.found).toBe(true);
+      expect(result.from).toBe(11);
+    });
+
+    test('handles mixed unicode and ASCII', () => {
+      const documentText = 'The café serves crème brûlée';
+      const anchor: ReanchorInput = {
+        quote: 'crème brûlée',
+        prefix: 'serves ',
+        suffix: '',
+      };
+
+      const result = reanchorQuote(documentText, anchor);
+
+      expect(result.found).toBe(true);
+      expect(result.from).toBe(16);
+      expect(result.to).toBe(28);
+    });
+  });
+});

--- a/packages/commentary/src/comments/reanchor.ts
+++ b/packages/commentary/src/comments/reanchor.ts
@@ -1,0 +1,305 @@
+/**
+ * Re-anchoring algorithm for comment anchors.
+ *
+ * This module implements the TextQuoteSelector re-anchoring algorithm
+ * that finds anchor positions after document edits. It uses:
+ * - Exact quote matching
+ * - Prefix/suffix context scoring
+ * - Position proximity for disambiguation
+ * - Fuzzy matching as fallback
+ *
+ * @module
+ */
+
+import type { ReanchorResult } from './types.js';
+
+/**
+ * Match result from searching for a quote in text.
+ */
+interface QuoteMatch {
+  /** Start offset in text */
+  start: number;
+  /** End offset in text */
+  end: number;
+}
+
+/**
+ * Scored match with confidence metrics.
+ */
+interface ScoredMatch extends QuoteMatch {
+  /** Context matching score (0-1) */
+  contextScore: number;
+  /** Position proximity score (0-1) */
+  proximityScore: number;
+  /** Combined total score */
+  totalScore: number;
+}
+
+/**
+ * Anchor data for re-anchoring.
+ */
+export interface ReanchorInput {
+  /** The quoted text to find */
+  quote: string;
+  /** Context before the quote */
+  prefix: string;
+  /** Context after the quote */
+  suffix: string;
+  /** Original position when created */
+  originalPosition?: { offset: number } | undefined;
+  /** Last known text offset (preferred for disambiguation) */
+  lastKnownOffset?: number | undefined;
+}
+
+/**
+ * Find all exact occurrences of a quote in document text.
+ *
+ * @param quote - Text to find
+ * @param documentText - Document to search
+ * @returns Array of match positions
+ */
+export function findAllOccurrences(quote: string, documentText: string): QuoteMatch[] {
+  const matches: QuoteMatch[] = [];
+  if (!quote) return matches;
+
+  let startIndex = 0;
+  while (true) {
+    const index = documentText.indexOf(quote, startIndex);
+    if (index === -1) break;
+
+    matches.push({
+      start: index,
+      end: index + quote.length,
+    });
+
+    startIndex = index + 1;
+  }
+
+  return matches;
+}
+
+/**
+ * Score how well a match's surrounding context matches the expected context.
+ *
+ * Uses longest common subsequence (LCS) to handle minor edits in context.
+ *
+ * @param documentText - Full document text
+ * @param match - The match to score
+ * @param expectedPrefix - Expected prefix context
+ * @param expectedSuffix - Expected suffix context
+ * @returns Score from 0 (no match) to 1 (perfect match)
+ */
+export function scoreContextMatch(
+  documentText: string,
+  match: QuoteMatch,
+  expectedPrefix: string,
+  expectedSuffix: string,
+): number {
+  // Extract actual context from document
+  const actualPrefix = documentText.slice(
+    Math.max(0, match.start - expectedPrefix.length),
+    match.start,
+  );
+  const actualSuffix = documentText.slice(match.end, match.end + expectedSuffix.length);
+
+  // Score prefix match
+  const prefixScore = expectedPrefix.length > 0 ? lcsRatio(actualPrefix, expectedPrefix) : 1.0;
+
+  // Score suffix match
+  const suffixScore = expectedSuffix.length > 0 ? lcsRatio(actualSuffix, expectedSuffix) : 1.0;
+
+  // Average the scores, weighting prefix slightly higher
+  // (prefix is often more stable than suffix)
+  return prefixScore * 0.55 + suffixScore * 0.45;
+}
+
+/**
+ * Calculate LCS (Longest Common Subsequence) ratio between two strings.
+ *
+ * @param a - First string
+ * @param b - Second string
+ * @returns Ratio of LCS length to max string length (0-1)
+ */
+function lcsRatio(a: string, b: string): number {
+  if (a.length === 0 || b.length === 0) return 0;
+
+  const lcsLength = longestCommonSubsequence(a, b);
+  return lcsLength / Math.max(a.length, b.length);
+}
+
+/**
+ * Calculate length of longest common subsequence.
+ *
+ * Uses dynamic programming with space optimization.
+ */
+function longestCommonSubsequence(a: string, b: string): number {
+  const aLength = a.length;
+  const bLength = b.length;
+
+  // Use two rows for space optimization
+  let previousRow = Array.from({ length: bLength + 1 }, () => 0);
+  let currentRow = Array.from({ length: bLength + 1 }, () => 0);
+
+  for (let aIndex = 1; aIndex <= aLength; aIndex += 1) {
+    for (let bIndex = 1; bIndex <= bLength; bIndex += 1) {
+      if (a[aIndex - 1] === b[bIndex - 1]) {
+        currentRow[bIndex] = (previousRow[bIndex - 1] ?? 0) + 1;
+      } else {
+        currentRow[bIndex] = Math.max(previousRow[bIndex] ?? 0, currentRow[bIndex - 1] ?? 0);
+      }
+    }
+    // Swap rows
+    [previousRow, currentRow] = [currentRow, previousRow];
+  }
+
+  return previousRow[bLength] ?? 0;
+}
+
+/**
+ * Attempt fuzzy re-anchoring when exact quote is not found.
+ *
+ * Uses the prefix + suffix to try to locate where the anchor was.
+ * This is a fallback for when the quoted text was deleted or significantly changed.
+ *
+ * @param documentText - Full document text
+ * @param anchor - Original anchor data
+ * @returns Re-anchor result with found=false (the quoted text no longer exists)
+ */
+export function fuzzyReanchor(documentText: string, anchor: ReanchorInput): ReanchorResult {
+  const { prefix, suffix, lastKnownOffset, originalPosition } = anchor;
+  const referenceOffset = lastKnownOffset ?? originalPosition?.offset;
+
+  // Try to find the junction point using prefix + suffix
+  if (prefix.length > 0 && suffix.length > 0) {
+    // Search for prefix ending + suffix beginning near reference position
+    const searchRadius = 500; // Characters to search around reference
+    const searchStart = Math.max(0, (referenceOffset ?? 0) - searchRadius);
+    const searchEnd = Math.min(
+      documentText.length,
+      (referenceOffset ?? documentText.length) + searchRadius,
+    );
+    const searchText = documentText.slice(searchStart, searchEnd);
+
+    // Look for prefix ending
+    const prefixEnd = prefix.slice(-20); // Last 20 chars of prefix
+    const suffixStart = suffix.slice(0, 20); // First 20 chars of suffix
+
+    let bestPos = -1;
+    let bestScore = 0;
+
+    // Slide through search region looking for best match
+    for (let i = 0; i < searchText.length - 1; i++) {
+      const beforeSlice = searchText.slice(Math.max(0, i - prefixEnd.length), i);
+      const afterSlice = searchText.slice(i, i + suffixStart.length);
+
+      const beforeScore = lcsRatio(beforeSlice, prefixEnd);
+      const afterScore = lcsRatio(afterSlice, suffixStart);
+      const score = (beforeScore + afterScore) / 2;
+
+      if (score > bestScore) {
+        bestScore = score;
+        bestPos = searchStart + i;
+      }
+    }
+
+    if (bestScore >= 0.5) {
+      // Found a reasonable junction point where the text was deleted
+      // Return not found - the thread will be auto-deleted
+      return {
+        found: false,
+        from: bestPos,
+        to: bestPos,
+        confidence: bestScore,
+      };
+    }
+  }
+
+  // Couldn't find anything - completely gone
+  return {
+    found: false,
+    from: referenceOffset ?? 0,
+    to: referenceOffset ?? 0,
+    confidence: 0,
+  };
+}
+
+/**
+ * Re-anchor a quote in a document.
+ *
+ * Algorithm:
+ * 1. Find all exact occurrences of the quote
+ * 2. If none found, attempt fuzzy re-anchoring
+ * 3. If one found, score its context and return
+ * 4. If multiple found, score by context + position proximity
+ * 5. Check margin between top matches for ambiguity
+ *
+ * @param documentText - Full document text (from doc.textBetween())
+ * @param anchor - Anchor data with quote, context, and position hints
+ * @returns Re-anchor result with new position and status
+ */
+export function reanchorQuote(documentText: string, anchor: ReanchorInput): ReanchorResult {
+  const { quote, prefix, suffix, originalPosition, lastKnownOffset } = anchor;
+
+  // Prefer lastKnownOffset over originalPosition for disambiguation
+  // lastKnownOffset tracks current location, originalPosition is historical
+  const referenceOffset = lastKnownOffset ?? originalPosition?.offset;
+
+  // Find all exact occurrences
+  const matches = findAllOccurrences(quote, documentText);
+
+  // No matches - try fuzzy re-anchoring
+  if (matches.length === 0) {
+    return fuzzyReanchor(documentText, anchor);
+  }
+
+  // Single match - score its context
+  if (matches.length === 1) {
+    const match = matches[0];
+    if (!match) {
+      return fuzzyReanchor(documentText, anchor);
+    }
+
+    const confidence = scoreContextMatch(documentText, match, prefix, suffix);
+
+    return {
+      found: true,
+      from: match.start,
+      to: match.end,
+      confidence,
+    };
+  }
+
+  // Multiple matches - score by context + position proximity
+  const scoredMatches: ScoredMatch[] = matches.map((match) => {
+    const contextScore = scoreContextMatch(documentText, match, prefix, suffix);
+
+    // Position proximity (exponential decay with distance)
+    let proximityScore = 0;
+    if (referenceOffset !== undefined) {
+      const distance = Math.abs(match.start - referenceOffset);
+      proximityScore = Math.exp(-distance / 500);
+    }
+
+    // Weight context more heavily than proximity
+    const totalScore = contextScore * 0.7 + proximityScore * 0.3;
+
+    return { ...match, contextScore, proximityScore, totalScore };
+  });
+
+  // Sort by total score descending
+  scoredMatches.sort((a, b) => b.totalScore - a.totalScore);
+
+  const best = scoredMatches[0];
+  if (!best) {
+    return fuzzyReanchor(documentText, anchor);
+  }
+
+  // We found matches, return the best one
+  // The confidence score captures how certain we are about this match
+  return {
+    found: true,
+    from: best.start,
+    to: best.end,
+    confidence: best.totalScore,
+  };
+}

--- a/packages/commentary/src/comments/types.ts
+++ b/packages/commentary/src/comments/types.ts
@@ -1,0 +1,399 @@
+/**
+ * Comment and thread types for the Markdown Review Editor.
+ *
+ * These types support:
+ * - TextQuoteSelector-style anchoring (survives edits via quote + context)
+ * - Runtime position tracking (ProseMirror positions)
+ * - Serialization for persistence
+ *
+ * Threads have no lifecycle status - they exist until deleted.
+ * When anchor text is deleted, threads are automatically removed.
+ *
+ * @module
+ */
+
+import type { PersistedReviewSession } from '../session/types.js';
+import type {
+  AnchorStatus,
+  CommentAnchor,
+  PersistedAnchor,
+  TextQuoteAnchor,
+} from '../shared/anchor-types.js';
+
+// Re-export anchor types from shared module (breaks circular dependency)
+export type {
+  AnchorStatus,
+  AnchorType,
+  CommentAnchor,
+  PersistedAnchor,
+  RuntimeAnchor,
+  TextQuoteAnchor,
+} from '../shared/anchor-types.js';
+
+// ============================================================================
+// Comment Types
+// ============================================================================
+
+/**
+ * A single comment within a thread.
+ */
+export interface Comment {
+  /** Unique identifier */
+  id: string;
+
+  /** Parent thread ID */
+  threadId: string;
+
+  /** Author user ID */
+  authorId: string;
+
+  /** Comment content (Markdown) */
+  body: string;
+
+  /** Creation timestamp (ISO 8601) */
+  createdAt: string;
+
+  /** Last edit timestamp (ISO 8601), if edited */
+  editedAt?: string | undefined;
+
+  /** User IDs mentioned in the comment */
+  mentions?: string[] | undefined;
+
+  /** Soft delete timestamp (ISO 8601), if deleted */
+  deletedAt?: string | undefined;
+}
+
+/**
+ * Input for creating a new comment.
+ */
+export type CreateCommentInput = Pick<Comment, 'body' | 'authorId'> & {
+  mentions?: string[];
+};
+
+/**
+ * Input for updating an existing comment.
+ */
+export type UpdateCommentInput = Pick<Comment, 'body'> & {
+  mentions?: string[];
+};
+
+// ============================================================================
+// Thread Types
+// ============================================================================
+
+/**
+ * A comment thread anchored to a document location.
+ *
+ * Threads have no status - they exist until deleted.
+ * There is no "resolved" state; to dismiss a thread, delete it.
+ */
+export interface Thread {
+  /** Unique identifier */
+  id: string;
+
+  /** Anchor to document location */
+  anchor: CommentAnchor;
+
+  /** Comments in chronological order */
+  comments: Comment[];
+
+  /** Creation timestamp (ISO 8601) */
+  createdAt: string;
+}
+
+/**
+ * Thread data for persistence (uses persisted anchor).
+ */
+export interface PersistedThread extends Omit<Thread, 'anchor'> {
+  anchor: PersistedAnchor;
+}
+
+/**
+ * Input for creating a new thread.
+ */
+export interface CreateThreadInput {
+  /** Anchor location */
+  anchor: CommentAnchor;
+
+  /** Initial comment */
+  initialComment: CreateCommentInput;
+}
+
+// ============================================================================
+// Review State Types
+// ============================================================================
+
+/**
+ * Complete review state for serialization.
+ *
+ * This is the top-level type for persisting and hydrating review sessions.
+ *
+ * Schema versions:
+ * - v1: Original schema (DEP-39)
+ * - v2: Added soft-delete support (DEP-40)
+ * - v3: Reserved (previously suggestions)
+ * - v4: Added reviewSession for batch review submission (DEP-44), front matter support (DEP-61)
+ */
+export interface ReviewState {
+  /** Schema version for migrations (all versions are additive, no breaking changes) */
+  schemaVersion: 1 | 2 | 3 | 4;
+
+  /** Current document content (Markdown body, without front matter) */
+  content: string;
+
+  /** Original/baseline content for diff comparison */
+  original?: string | undefined;
+
+  /** All threads in the review (includes soft-deleted comments for audit trail) */
+  threads: PersistedThread[];
+
+  /**
+   * Review session for batch submission mode (v4+).
+   * Contains draft comments that are submitted as a batch
+   * with a review outcome (approve / request changes / comment-only).
+   * When undefined or missing, treated as no active session for backwards compatibility.
+   */
+  reviewSession?: PersistedReviewSession | undefined;
+
+  /**
+   * Parsed front matter data (v4+).
+   * When undefined or null, document has no front matter.
+   */
+  frontMatter?: Record<string, unknown> | null | undefined;
+
+  /**
+   * Raw front matter YAML string without delimiters (v4+).
+   * Preserved for round-trip fidelity when data is unchanged.
+   */
+  frontMatterRaw?: string | null | undefined;
+
+  /** Last modified timestamp (ISO 8601) */
+  updatedAt: string;
+}
+
+// Re-export review session types for convenience
+export type { PersistedReviewSession } from '../session/types.js';
+
+// ============================================================================
+// Event Types
+// ============================================================================
+
+/**
+ * Event payload when a new thread is created.
+ * Parent uses requestId to correlate optimistic updates with backend responses.
+ */
+export interface ThreadCreateEvent {
+  /** Unique request ID for correlating optimistic updates */
+  requestId: string;
+
+  /** The anchor where the thread was created */
+  anchor: CommentAnchor;
+
+  /** The initial comment body */
+  body: string;
+
+  /** The author ID */
+  authorId: string;
+
+  /** User IDs mentioned in the initial comment */
+  mentions?: string[] | undefined;
+}
+
+/**
+ * Event payload when a thread is deleted.
+ */
+export interface ThreadDeleteEvent {
+  /** The thread ID being deleted */
+  threadId: string;
+}
+
+/**
+ * Event payload when a comment is added to an existing thread.
+ * Parent uses requestId to correlate optimistic updates with backend responses.
+ */
+export interface CommentCreateEvent {
+  /** Unique request ID for correlating optimistic updates */
+  requestId: string;
+
+  /** The thread ID receiving the comment */
+  threadId: string;
+
+  /** The comment body */
+  body: string;
+
+  /** The author ID */
+  authorId: string;
+
+  /** User IDs mentioned in the comment */
+  mentions?: string[] | undefined;
+}
+
+/**
+ * Event payload when a comment is updated.
+ */
+export interface CommentUpdateEvent {
+  /** The thread ID containing the comment */
+  threadId: string;
+
+  /** The comment ID being updated */
+  commentId: string;
+
+  /** The new comment body */
+  body: string;
+
+  /** User IDs mentioned in the updated comment */
+  mentions?: string[] | undefined;
+}
+
+/**
+ * Event payload when a comment is deleted.
+ */
+export interface CommentDeleteEvent {
+  /** The thread ID containing the comment */
+  threadId: string;
+
+  /** The comment ID being deleted */
+  commentId: string;
+
+  /** True for soft delete (sets deletedAt), false for hard delete */
+  soft: boolean;
+}
+
+// ============================================================================
+// Plugin Communication Types
+// ============================================================================
+
+/**
+ * Update payload from anchor plugin to ReviewEditor.
+ * Sent when anchor positions or status change due to document edits.
+ */
+export interface AnchorUpdate {
+  /** Thread ID this update is for */
+  threadId: string;
+
+  /** New ProseMirror start position */
+  from: number;
+
+  /** New ProseMirror end position */
+  to: number;
+
+  /** Updated quote text (follows edits inside the anchor) */
+  quote: string;
+
+  /** Updated prefix context */
+  prefix: string;
+
+  /** Updated suffix context */
+  suffix: string;
+
+  /** Current anchor status */
+  status: AnchorStatus;
+
+  /** Updated text offset for disambiguation */
+  lastKnownOffset?: number;
+}
+
+/**
+ * Result of re-anchoring a quote in a document.
+ * Returned by the reanchorQuote algorithm.
+ *
+ * When `found` is false, the quote could not be located in the document
+ * and the thread should be deleted.
+ */
+export interface ReanchorResult {
+  /** Whether the quote was found in the document */
+  found: boolean;
+
+  /** Text offset of anchor start (in doc.textBetween() coordinates). Only valid when found=true. */
+  from: number;
+
+  /** Text offset of anchor end (in doc.textBetween() coordinates). Only valid when found=true. */
+  to: number;
+
+  /** Confidence score (0-1) of the match. 0 when not found. */
+  confidence: number;
+}
+
+// ============================================================================
+// Utility Types
+// ============================================================================
+
+/**
+ * Generate a unique ID for threads and comments.
+ * Uses crypto.randomUUID() when available, falls back to timestamp + random.
+ */
+export function generateId(): string {
+  if (typeof crypto !== 'undefined' && crypto.randomUUID) {
+    return crypto.randomUUID();
+  }
+  // Fallback for environments without crypto.randomUUID
+  return `${Date.now()}-${Math.random().toString(36).slice(2, 11)}`;
+}
+
+/**
+ * Get current ISO timestamp.
+ */
+export function timestamp(): string {
+  return new Date().toISOString();
+}
+
+/**
+ * Context length for TextQuoteSelector prefix/suffix.
+ */
+export const ANCHOR_CONTEXT_LENGTH = 50;
+
+/**
+ * Create a TextQuoteAnchor from a selection.
+ *
+ * @param quote - The selected text
+ * @param documentText - The full document text
+ * @param startOffset - Character offset of selection start
+ * @param endOffset - Character offset of selection end
+ */
+export function createTextQuoteAnchor(
+  quote: string,
+  documentText: string,
+  startOffset: number,
+  endOffset: number,
+): TextQuoteAnchor {
+  const prefixStart = Math.max(0, startOffset - ANCHOR_CONTEXT_LENGTH);
+  const suffixEnd = Math.min(documentText.length, endOffset + ANCHOR_CONTEXT_LENGTH);
+
+  return {
+    quote,
+    prefix: documentText.slice(prefixStart, startOffset),
+    suffix: documentText.slice(endOffset, suffixEnd),
+  };
+}
+
+/**
+ * Create a document-level anchor (not anchored to specific text).
+ *
+ * Document-level comments are for general feedback about the entire document,
+ * not tied to a specific text selection.
+ */
+export function createDocumentAnchor(): CommentAnchor {
+  return {
+    type: 'document',
+    quote: '',
+    prefix: '',
+    suffix: '',
+    from: 0,
+    to: 0,
+    status: 'anchored',
+  };
+}
+
+/**
+ * Check if an anchor is a document-level anchor.
+ */
+export function isDocumentAnchor(anchor: CommentAnchor | PersistedAnchor): boolean {
+  return anchor.type === 'document';
+}
+
+/**
+ * Check if an anchor is a text anchor (explicit 'text' type or undefined for backwards compat).
+ */
+export function isTextAnchor(anchor: CommentAnchor | PersistedAnchor): boolean {
+  return anchor.type === 'text' || anchor.type === undefined;
+}

--- a/packages/commentary/src/comments/updates.test.ts
+++ b/packages/commentary/src/comments/updates.test.ts
@@ -1,0 +1,398 @@
+// @ts-nocheck -- migrated commentary assertions use runtime-verified fixture indexing.
+import { describe, expect, test } from 'bun:test';
+import type { Comment, CommentAnchor, Thread } from './types.js';
+import {
+  addComment,
+  addThread,
+  deleteComment,
+  deleteThread,
+  getVisibleComments,
+  isCommentVisible,
+  restoreComment,
+  updateComment,
+} from './updates.js';
+
+// ============================================================================
+// Test Fixtures
+// ============================================================================
+
+function createTestAnchor(overrides?: Partial<CommentAnchor>): CommentAnchor {
+  return {
+    quote: 'test quote',
+    prefix: 'prefix ',
+    suffix: ' suffix',
+    from: 10,
+    to: 20,
+    status: 'anchored',
+    ...overrides,
+  };
+}
+
+function createTestComment(overrides?: Partial<Comment>): Comment {
+  return {
+    id: 'comment-1',
+    threadId: 'thread-1',
+    authorId: 'user-1',
+    body: 'Test comment',
+    createdAt: '2024-01-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+function createTestThread(overrides?: Partial<Thread>): Thread {
+  return {
+    id: 'thread-1',
+    anchor: createTestAnchor(),
+    comments: [createTestComment()],
+    createdAt: '2024-01-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+// ============================================================================
+// Visibility Helpers
+// ============================================================================
+
+describe('isCommentVisible', () => {
+  test('returns true for non-deleted comment', () => {
+    const comment = createTestComment();
+    expect(isCommentVisible(comment)).toBe(true);
+  });
+
+  test('returns false for deleted comment', () => {
+    const comment = createTestComment({ deletedAt: '2024-01-02T00:00:00.000Z' });
+    expect(isCommentVisible(comment)).toBe(false);
+  });
+});
+
+describe('getVisibleComments', () => {
+  test('returns all comments when none are deleted', () => {
+    const thread = createTestThread({
+      comments: [createTestComment({ id: 'c1' }), createTestComment({ id: 'c2' })],
+    });
+    expect(getVisibleComments(thread)).toHaveLength(2);
+  });
+
+  test('filters out deleted comments', () => {
+    const thread = createTestThread({
+      comments: [
+        createTestComment({ id: 'c1' }),
+        createTestComment({ id: 'c2', deletedAt: '2024-01-02T00:00:00.000Z' }),
+        createTestComment({ id: 'c3' }),
+      ],
+    });
+    const visible = getVisibleComments(thread);
+    expect(visible).toHaveLength(2);
+    expect(visible.map((c) => c.id)).toEqual(['c1', 'c3']);
+  });
+
+  test('returns empty array when all comments are deleted', () => {
+    const thread = createTestThread({
+      comments: [createTestComment({ id: 'c1', deletedAt: '2024-01-02T00:00:00.000Z' })],
+    });
+    expect(getVisibleComments(thread)).toEqual([]);
+  });
+});
+
+// ============================================================================
+// Thread Operations
+// ============================================================================
+
+describe('addThread', () => {
+  test('adds thread to empty array', () => {
+    const thread = createTestThread();
+    const result = addThread([], thread);
+    expect(result.threads).toHaveLength(1);
+    expect(result.threads[0]).toBe(thread);
+    expect(result.changed).toBe(true);
+  });
+
+  test('appends thread to existing array', () => {
+    const existing = createTestThread({ id: 'thread-1' });
+    const newThread = createTestThread({ id: 'thread-2' });
+    const result = addThread([existing], newThread);
+    expect(result.threads).toHaveLength(2);
+    expect(result.threads[1].id).toBe('thread-2');
+    expect(result.changed).toBe(true);
+  });
+
+  test('returns new array (immutable)', () => {
+    const original: Thread[] = [];
+    const result = addThread(original, createTestThread());
+    expect(result.threads).not.toBe(original);
+  });
+});
+
+describe('deleteThread', () => {
+  test('removes existing thread', () => {
+    const threads = [createTestThread({ id: 'thread-1' }), createTestThread({ id: 'thread-2' })];
+    const result = deleteThread(threads, 'thread-1');
+    expect(result.threads).toHaveLength(1);
+    expect(result.threads[0].id).toBe('thread-2');
+    expect(result.changed).toBe(true);
+  });
+
+  test('returns unchanged when thread not found', () => {
+    const threads = [createTestThread({ id: 'thread-1' })];
+    const result = deleteThread(threads, 'nonexistent');
+    expect(result.threads).toBe(threads);
+    expect(result.changed).toBe(false);
+  });
+
+  test('returns empty array when deleting last thread', () => {
+    const threads = [createTestThread({ id: 'thread-1' })];
+    const result = deleteThread(threads, 'thread-1');
+    expect(result.threads).toEqual([]);
+    expect(result.changed).toBe(true);
+  });
+});
+
+// ============================================================================
+// Comment Operations
+// ============================================================================
+
+describe('addComment', () => {
+  test('adds comment to existing thread', () => {
+    const threads = [createTestThread({ id: 'thread-1', comments: [] })];
+    const comment = createTestComment({ id: 'new-comment' });
+    const result = addComment(threads, 'thread-1', comment);
+    expect(result.threads[0].comments).toHaveLength(1);
+    expect(result.threads[0].comments[0].id).toBe('new-comment');
+    expect(result.changed).toBe(true);
+    expect(result.value?.comment).toBe(comment);
+  });
+
+  test('returns unchanged when thread not found', () => {
+    const threads = [createTestThread({ id: 'thread-1' })];
+    const comment = createTestComment();
+    const result = addComment(threads, 'nonexistent', comment);
+    expect(result.threads).toBe(threads);
+    expect(result.changed).toBe(false);
+    expect(result.value).toBeUndefined();
+  });
+
+  test('appends to existing comments', () => {
+    const existingComment = createTestComment({ id: 'existing' });
+    const threads = [createTestThread({ id: 'thread-1', comments: [existingComment] })];
+    const newComment = createTestComment({ id: 'new' });
+    const result = addComment(threads, 'thread-1', newComment);
+    expect(result.threads[0].comments).toHaveLength(2);
+    expect(result.threads[0].comments[0].id).toBe('existing');
+    expect(result.threads[0].comments[1].id).toBe('new');
+  });
+});
+
+describe('updateComment', () => {
+  test('updates comment body and mentions', () => {
+    const threads = [
+      createTestThread({
+        id: 'thread-1',
+        comments: [createTestComment({ id: 'comment-1', body: 'Original' })],
+      }),
+    ];
+    const result = updateComment(threads, 'thread-1', 'comment-1', {
+      body: 'Updated body',
+      mentions: ['alice'],
+      editedAt: '2024-01-02T00:00:00.000Z',
+    });
+    expect(result.threads[0].comments[0].body).toBe('Updated body');
+    expect(result.threads[0].comments[0].mentions).toEqual(['alice']);
+    expect(result.threads[0].comments[0].editedAt).toBe('2024-01-02T00:00:00.000Z');
+    expect(result.changed).toBe(true);
+  });
+
+  test('returns unchanged when thread not found', () => {
+    const threads = [createTestThread({ id: 'thread-1' })];
+    const result = updateComment(threads, 'nonexistent', 'comment-1', {
+      body: 'Updated',
+      editedAt: '2024-01-02T00:00:00.000Z',
+    });
+    expect(result.threads).toBe(threads);
+    expect(result.changed).toBe(false);
+  });
+
+  test('returns unchanged when comment not found', () => {
+    const threads = [createTestThread({ id: 'thread-1' })];
+    const result = updateComment(threads, 'thread-1', 'nonexistent', {
+      body: 'Updated',
+      editedAt: '2024-01-02T00:00:00.000Z',
+    });
+    expect(result.threads).toBe(threads);
+    expect(result.changed).toBe(false);
+  });
+
+  test('returns unchanged when comment is deleted', () => {
+    const threads = [
+      createTestThread({
+        id: 'thread-1',
+        comments: [createTestComment({ id: 'comment-1', deletedAt: '2024-01-02T00:00:00.000Z' })],
+      }),
+    ];
+    const result = updateComment(threads, 'thread-1', 'comment-1', {
+      body: 'Updated',
+      editedAt: '2024-01-03T00:00:00.000Z',
+    });
+    expect(result.changed).toBe(false);
+  });
+});
+
+describe('deleteComment', () => {
+  describe('soft delete', () => {
+    test('sets deletedAt timestamp', () => {
+      const threads = [
+        createTestThread({
+          id: 'thread-1',
+          comments: [createTestComment({ id: 'comment-1' })],
+        }),
+      ];
+      const result = deleteComment(threads, 'thread-1', 'comment-1', {
+        soft: true,
+        deletedAt: '2024-01-02T00:00:00.000Z',
+      });
+      expect(result.threads[0].comments[0].deletedAt).toBe('2024-01-02T00:00:00.000Z');
+      expect(result.threads[0].comments).toHaveLength(1);
+      expect(result.changed).toBe(true);
+    });
+
+    test('returns unchanged when already deleted', () => {
+      const threads = [
+        createTestThread({
+          id: 'thread-1',
+          comments: [createTestComment({ id: 'comment-1', deletedAt: '2024-01-02T00:00:00.000Z' })],
+        }),
+      ];
+      const result = deleteComment(threads, 'thread-1', 'comment-1', {
+        soft: true,
+        deletedAt: '2024-01-03T00:00:00.000Z',
+      });
+      expect(result.changed).toBe(false);
+    });
+
+    test('returns unchanged when deletedAt not provided for soft delete', () => {
+      const threads = [
+        createTestThread({
+          id: 'thread-1',
+          comments: [createTestComment({ id: 'comment-1' })],
+        }),
+      ];
+      const result = deleteComment(threads, 'thread-1', 'comment-1', { soft: true });
+      expect(result.changed).toBe(false);
+      expect(result.threads[0].comments[0].deletedAt).toBeUndefined();
+    });
+  });
+
+  describe('hard delete', () => {
+    test('removes comment from array', () => {
+      const threads = [
+        createTestThread({
+          id: 'thread-1',
+          comments: [createTestComment({ id: 'c1' }), createTestComment({ id: 'c2' })],
+        }),
+      ];
+      const result = deleteComment(threads, 'thread-1', 'c1', { soft: false });
+      expect(result.threads[0].comments).toHaveLength(1);
+      expect(result.threads[0].comments[0].id).toBe('c2');
+      expect(result.changed).toBe(true);
+    });
+
+    test('can hard delete already soft-deleted comment', () => {
+      const threads = [
+        createTestThread({
+          id: 'thread-1',
+          comments: [createTestComment({ id: 'comment-1', deletedAt: '2024-01-02T00:00:00.000Z' })],
+        }),
+      ];
+      const result = deleteComment(threads, 'thread-1', 'comment-1', { soft: false });
+      expect(result.threads[0].comments).toHaveLength(0);
+      expect(result.changed).toBe(true);
+    });
+  });
+
+  test('returns unchanged when thread not found', () => {
+    const threads = [createTestThread({ id: 'thread-1' })];
+    const result = deleteComment(threads, 'nonexistent', 'comment-1', { soft: true });
+    expect(result.changed).toBe(false);
+  });
+
+  test('returns unchanged when comment not found', () => {
+    const threads = [createTestThread({ id: 'thread-1' })];
+    const result = deleteComment(threads, 'thread-1', 'nonexistent', { soft: true });
+    expect(result.changed).toBe(false);
+  });
+});
+
+describe('restoreComment', () => {
+  test('removes deletedAt from soft-deleted comment', () => {
+    const threads = [
+      createTestThread({
+        id: 'thread-1',
+        comments: [createTestComment({ id: 'comment-1', deletedAt: '2024-01-02T00:00:00.000Z' })],
+      }),
+    ];
+    const result = restoreComment(threads, 'thread-1', 'comment-1');
+    expect(result.threads[0].comments[0].deletedAt).toBeUndefined();
+    expect(result.changed).toBe(true);
+  });
+
+  test('returns unchanged when comment is not deleted', () => {
+    const threads = [
+      createTestThread({
+        id: 'thread-1',
+        comments: [createTestComment({ id: 'comment-1' })],
+      }),
+    ];
+    const result = restoreComment(threads, 'thread-1', 'comment-1');
+    expect(result.changed).toBe(false);
+  });
+
+  test('returns unchanged when thread not found', () => {
+    const threads = [createTestThread({ id: 'thread-1' })];
+    const result = restoreComment(threads, 'nonexistent', 'comment-1');
+    expect(result.changed).toBe(false);
+  });
+
+  test('returns unchanged when comment not found', () => {
+    const threads = [createTestThread({ id: 'thread-1' })];
+    const result = restoreComment(threads, 'thread-1', 'nonexistent');
+    expect(result.changed).toBe(false);
+  });
+});
+
+// ============================================================================
+// Immutability Checks
+// ============================================================================
+
+describe('immutability', () => {
+  test('addThread returns new array', () => {
+    const original: Thread[] = [];
+    const result = addThread(original, createTestThread());
+    expect(result.threads).not.toBe(original);
+  });
+
+  test('deleteThread returns new array when changed', () => {
+    const original = [createTestThread({ id: 'thread-1' })];
+    const result = deleteThread(original, 'thread-1');
+    expect(result.threads).not.toBe(original);
+  });
+
+  test('addComment returns new thread and comments array', () => {
+    const original = [createTestThread({ id: 'thread-1', comments: [] })];
+    const result = addComment(original, 'thread-1', createTestComment());
+    expect(result.threads[0]).not.toBe(original[0]);
+    expect(result.threads[0].comments).not.toBe(original[0].comments);
+  });
+
+  test('updateComment returns new comment object', () => {
+    const original = [
+      createTestThread({
+        id: 'thread-1',
+        comments: [createTestComment({ id: 'comment-1' })],
+      }),
+    ];
+    const result = updateComment(original, 'thread-1', 'comment-1', {
+      body: 'Updated',
+      editedAt: '2024-01-02T00:00:00.000Z',
+    });
+    expect(result.threads[0].comments[0]).not.toBe(original[0].comments[0]);
+  });
+});

--- a/packages/commentary/src/comments/updates.ts
+++ b/packages/commentary/src/comments/updates.ts
@@ -1,0 +1,280 @@
+/**
+ * Pure update helpers for thread and comment state management.
+ *
+ * All functions are pure (no side effects, no ID/timestamp generation).
+ * They return new arrays/objects for Svelte 5 reactivity.
+ * The `changed` flag indicates whether the operation had any effect.
+ *
+ * @module
+ */
+
+import type { Comment, Thread } from './types.js';
+
+// ============================================================================
+// Result Types
+// ============================================================================
+
+/**
+ * Result of an update operation.
+ * @template T - Optional value type returned with the result
+ */
+export type UpdateResult<T = undefined> = {
+  /** The updated threads array */
+  threads: Thread[];
+  /** Whether the operation made any changes */
+  changed: boolean;
+  /** Optional value from the operation (e.g., created comment) */
+  value?: T;
+};
+
+// ============================================================================
+// Visibility Helpers
+// ============================================================================
+
+/**
+ * Check if a comment is visible (not soft-deleted).
+ */
+export function isCommentVisible(comment: Comment): boolean {
+  return !comment.deletedAt;
+}
+
+/**
+ * Get visible (non-deleted) comments from a thread.
+ */
+export function getVisibleComments(thread: Thread): Comment[] {
+  return thread.comments.filter(isCommentVisible);
+}
+
+// ============================================================================
+// Thread Operations
+// ============================================================================
+
+/**
+ * Add a new thread to the threads array.
+ *
+ * @param threads - Current threads array
+ * @param thread - The thread to add (caller provides complete Thread with ID/timestamps)
+ */
+export function addThread(threads: Thread[], thread: Thread): UpdateResult {
+  return {
+    threads: [...threads, thread],
+    changed: true,
+  };
+}
+
+/**
+ * Delete a thread from the threads array.
+ *
+ * No-op if thread does not exist.
+ *
+ * @param threads - Current threads array
+ * @param threadId - ID of the thread to delete
+ */
+export function deleteThread(threads: Thread[], threadId: string): UpdateResult {
+  const exists = threads.some((t) => t.id === threadId);
+  if (!exists) {
+    return { threads, changed: false };
+  }
+
+  return {
+    threads: threads.filter((t) => t.id !== threadId),
+    changed: true,
+  };
+}
+
+// ============================================================================
+// Comment Operations
+// ============================================================================
+
+/**
+ * Add a comment to an existing thread.
+ *
+ * No-op if thread does not exist.
+ *
+ * @param threads - Current threads array
+ * @param threadId - ID of the thread to add the comment to
+ * @param comment - The comment to add (caller provides complete Comment with ID/timestamps)
+ */
+export function addComment(
+  threads: Thread[],
+  threadId: string,
+  comment: Comment,
+): UpdateResult<{ comment: Comment }> {
+  const exists = threads.some((t) => t.id === threadId);
+  if (!exists) {
+    return { threads, changed: false };
+  }
+
+  return {
+    threads: threads.map((thread) => {
+      if (thread.id !== threadId) return thread;
+      return {
+        ...thread,
+        comments: [...thread.comments, comment],
+      };
+    }),
+    changed: true,
+    value: { comment },
+  };
+}
+
+/**
+ * Update an existing comment's body and mentions.
+ *
+ * No-op if thread/comment does not exist or comment is deleted.
+ *
+ * @param threads - Current threads array
+ * @param threadId - ID of the thread containing the comment
+ * @param commentId - ID of the comment to update
+ * @param update - The update with body, mentions, and editedAt (caller provides timestamp)
+ */
+export function updateComment(
+  threads: Thread[],
+  threadId: string,
+  commentId: string,
+  update: { body: string; mentions?: string[]; editedAt: string },
+): UpdateResult {
+  const thread = threads.find((t) => t.id === threadId);
+  if (!thread) {
+    return { threads, changed: false };
+  }
+
+  const comment = thread.comments.find((c) => c.id === commentId);
+  if (!comment || comment.deletedAt) {
+    return { threads, changed: false };
+  }
+
+  return {
+    threads: threads.map((t) => {
+      if (t.id !== threadId) return t;
+      return {
+        ...t,
+        comments: t.comments.map((c) => {
+          if (c.id !== commentId) return c;
+
+          const updatedComment: Comment = {
+            ...c,
+            body: update.body,
+            editedAt: update.editedAt,
+          };
+
+          if (update.mentions !== undefined) {
+            updatedComment.mentions = update.mentions;
+          }
+
+          return updatedComment;
+        }),
+      };
+    }),
+    changed: true,
+  };
+}
+
+/**
+ * Delete a comment from a thread.
+ *
+ * Soft delete sets deletedAt timestamp.
+ * Hard delete removes the comment from the array.
+ *
+ * No-op if thread/comment does not exist, or if soft-deleting an already deleted comment.
+ *
+ * @param threads - Current threads array
+ * @param threadId - ID of the thread containing the comment
+ * @param commentId - ID of the comment to delete
+ * @param options - Delete options with soft flag and deletedAt timestamp (for soft delete)
+ */
+export function deleteComment(
+  threads: Thread[],
+  threadId: string,
+  commentId: string,
+  options: { soft: boolean; deletedAt?: string },
+): UpdateResult {
+  const thread = threads.find((t) => t.id === threadId);
+  if (!thread) {
+    return { threads, changed: false };
+  }
+
+  const comment = thread.comments.find((c) => c.id === commentId);
+  if (!comment) {
+    return { threads, changed: false };
+  }
+
+  // For soft delete, no-op if already deleted or if deletedAt not provided
+  if (options.soft) {
+    if (comment.deletedAt || !options.deletedAt) {
+      return { threads, changed: false };
+    }
+
+    const { deletedAt } = options;
+
+    // Soft delete: set deletedAt
+    return {
+      threads: threads.map((t) => {
+        if (t.id !== threadId) return t;
+        return {
+          ...t,
+          comments: t.comments.map((c) => {
+            if (c.id !== commentId) return c;
+            return { ...c, deletedAt };
+          }),
+        };
+      }),
+      changed: true,
+    };
+  }
+
+  // Hard delete: remove from array
+  return {
+    threads: threads.map((t) => {
+      if (t.id !== threadId) return t;
+      return {
+        ...t,
+        comments: t.comments.filter((c) => c.id !== commentId),
+      };
+    }),
+    changed: true,
+  };
+}
+
+/**
+ * Restore a soft-deleted comment.
+ *
+ * Removes the deletedAt timestamp.
+ *
+ * No-op if thread/comment does not exist or comment is not deleted.
+ *
+ * @param threads - Current threads array
+ * @param threadId - ID of the thread containing the comment
+ * @param commentId - ID of the comment to restore
+ */
+export function restoreComment(
+  threads: Thread[],
+  threadId: string,
+  commentId: string,
+): UpdateResult {
+  const thread = threads.find((t) => t.id === threadId);
+  if (!thread) {
+    return { threads, changed: false };
+  }
+
+  const comment = thread.comments.find((c) => c.id === commentId);
+  if (!comment || !comment.deletedAt) {
+    return { threads, changed: false };
+  }
+
+  return {
+    threads: threads.map((t) => {
+      if (t.id !== threadId) return t;
+      return {
+        ...t,
+        comments: t.comments.map((c) => {
+          if (c.id !== commentId) return c;
+          // Remove deletedAt using delete for clean omission
+          const { deletedAt: _deletedAt, ...restored } = c;
+          return restored;
+        }),
+      };
+    }),
+    changed: true,
+  };
+}

--- a/packages/commentary/src/env.d.ts
+++ b/packages/commentary/src/env.d.ts
@@ -1,0 +1,8 @@
+interface ImportMetaEnv {
+  readonly DEV: boolean;
+  readonly PROD: boolean;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}

--- a/packages/commentary/src/export/comments-export.test.ts
+++ b/packages/commentary/src/export/comments-export.test.ts
@@ -1,0 +1,306 @@
+// @ts-nocheck -- migrated commentary assertions use runtime-verified fixture indexing.
+/**
+ * Tests for LLM-optimized comments export functionality.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import type { PersistedThread, ReviewState } from '../comments/types.js';
+import { generateCommentsExport } from './comments-export';
+
+/** Create a minimal ReviewState for testing */
+function createState(threads: PersistedThread[] = []): ReviewState {
+  return {
+    schemaVersion: 4,
+    content: '# Test Document\n\nThis is a test document with some content.',
+    original: '# Test Document\n\nThis is a test document with some content.',
+    threads,
+    updatedAt: new Date().toISOString(),
+  };
+}
+
+/** Create a thread for testing */
+function createThread(overrides: Partial<PersistedThread> = {}): PersistedThread {
+  return {
+    id: 'thread-1',
+    createdAt: '2024-01-15T10:00:00Z',
+    anchor: {
+      quote: 'test document',
+      prefix: 'This is a ',
+      suffix: ' with some',
+      status: 'anchored',
+      originalQuote: 'test document',
+      lastKnownOffset: 50,
+      originalPosition: {
+        offset: 50,
+        line: 3,
+        column: 11,
+      },
+    },
+    comments: [
+      {
+        id: 'comment-1',
+        threadId: 'thread-1',
+        authorId: 'user-1',
+        body: 'This needs clarification.',
+        createdAt: '2024-01-15T10:00:00Z',
+      },
+    ],
+    ...overrides,
+  };
+}
+
+describe('generateCommentsExport', () => {
+  describe('basic functionality', () => {
+    test('returns empty message when there are no threads', () => {
+      const state = createState([]);
+      const result = generateCommentsExport(state);
+
+      expect(result.markdown).toContain('No comments to export');
+      expect(result.stats.threadCount).toBe(0);
+      expect(result.stats.commentCount).toBe(0);
+    });
+
+    test('exports a single thread with one comment', () => {
+      const state = createState([createThread()]);
+      const result = generateCommentsExport(state);
+
+      expect(result.markdown).toContain('# Review Comments');
+      expect(result.markdown).toContain('test document');
+      expect(result.markdown).toContain('This needs clarification');
+      expect(result.markdown).toContain('Line 3, Column 11');
+      expect(result.stats.threadCount).toBe(1);
+      expect(result.stats.commentCount).toBe(1);
+    });
+
+    test('exports multiple threads', () => {
+      const thread1 = createThread();
+      const thread2 = createThread({
+        id: 'thread-2',
+        anchor: {
+          quote: 'some content',
+          prefix: '',
+          suffix: '',
+          status: 'anchored',
+          originalQuote: 'some content',
+          lastKnownOffset: 100,
+          originalPosition: {
+            offset: 100,
+            line: 5,
+            column: 1,
+          },
+        },
+        comments: [
+          {
+            id: 'comment-2',
+            threadId: 'thread-2',
+            authorId: 'user-2',
+            body: 'Consider rewording this.',
+            createdAt: '2024-01-15T11:00:00Z',
+          },
+        ],
+      });
+
+      const state = createState([thread1, thread2]);
+      const result = generateCommentsExport(state);
+
+      expect(result.stats.threadCount).toBe(2);
+      expect(result.stats.commentCount).toBe(2);
+      expect(result.markdown).toContain('This needs clarification');
+      expect(result.markdown).toContain('Consider rewording this');
+    });
+
+    test('exports multiple comments in a single thread', () => {
+      const thread = createThread({
+        comments: [
+          {
+            id: 'comment-1',
+            threadId: 'thread-1',
+            authorId: 'user-1',
+            body: 'First comment',
+            createdAt: '2024-01-15T10:00:00Z',
+          },
+          {
+            id: 'comment-2',
+            threadId: 'thread-1',
+            authorId: 'user-2',
+            body: 'Second comment',
+            createdAt: '2024-01-15T10:30:00Z',
+          },
+        ],
+      });
+
+      const state = createState([thread]);
+      const result = generateCommentsExport(state);
+
+      expect(result.stats.threadCount).toBe(1);
+      expect(result.stats.commentCount).toBe(2);
+      expect(result.markdown).toContain('First comment');
+      expect(result.markdown).toContain('Second comment');
+    });
+  });
+
+  describe('filtering', () => {
+    test('excludes deleted comments', () => {
+      const thread = createThread({
+        comments: [
+          {
+            id: 'comment-1',
+            threadId: 'thread-1',
+            authorId: 'user-1',
+            body: 'Visible comment',
+            createdAt: '2024-01-15T10:00:00Z',
+          },
+          {
+            id: 'comment-2',
+            threadId: 'thread-1',
+            authorId: 'user-1',
+            body: 'Deleted comment',
+            createdAt: '2024-01-15T10:30:00Z',
+            deletedAt: '2024-01-15T11:00:00Z',
+          },
+        ],
+      });
+
+      const state = createState([thread]);
+      const result = generateCommentsExport(state);
+
+      expect(result.markdown).toContain('Visible comment');
+      expect(result.markdown).not.toContain('Deleted comment');
+      expect(result.stats.commentCount).toBe(1);
+    });
+
+    test('excludes threads with only deleted comments', () => {
+      const thread = createThread({
+        comments: [
+          {
+            id: 'comment-1',
+            threadId: 'thread-1',
+            authorId: 'user-1',
+            body: 'Deleted comment',
+            createdAt: '2024-01-15T10:00:00Z',
+            deletedAt: '2024-01-15T11:00:00Z',
+          },
+        ],
+      });
+
+      const state = createState([thread]);
+      const result = generateCommentsExport(state);
+
+      expect(result.stats.threadCount).toBe(0);
+    });
+  });
+
+  describe('formatting', () => {
+    test('includes author ID when option is set', () => {
+      const state = createState([createThread()]);
+      const result = generateCommentsExport(state, { includeAuthorIds: true });
+
+      expect(result.markdown).toContain('user-1');
+    });
+
+    test('uses generic author when option is false', () => {
+      const state = createState([createThread()]);
+      const result = generateCommentsExport(state, { includeAuthorIds: false });
+
+      expect(result.markdown).not.toContain('user-1');
+      expect(result.markdown).toContain('Reviewer');
+    });
+
+    test('includes timestamps when option is set', () => {
+      const state = createState([createThread()]);
+      const result = generateCommentsExport(state, { includeTimestamps: true });
+
+      expect(result.markdown).toContain('2024-01-15');
+    });
+
+    test('excludes timestamps when option is false', () => {
+      const state = createState([createThread()]);
+      const result = generateCommentsExport(state, { includeTimestamps: false });
+
+      // Should not have the date in parentheses after the author
+      expect(result.markdown).not.toMatch(/\(2024-01-15\)/);
+    });
+
+    test('formats highlighted text in blockquote', () => {
+      const state = createState([createThread()]);
+      const result = generateCommentsExport(state);
+
+      // Highlighted text is rendered as a blockquote
+      expect(result.markdown).toContain('> test document');
+    });
+
+    test('shows position information', () => {
+      const state = createState([createThread()]);
+      const result = generateCommentsExport(state);
+
+      // Position is shown as italicized text with line and column info
+      expect(result.markdown).toContain('*Position:');
+      expect(result.markdown).toContain('Line 3');
+      expect(result.markdown).toContain('Column 11');
+    });
+
+    test('includes summary statistics at the end', () => {
+      const state = createState([createThread()]);
+      const result = generateCommentsExport(state);
+
+      expect(result.markdown).toContain('**Total threads:** 1');
+      expect(result.markdown).toContain('**Total comments:** 1');
+    });
+  });
+
+  describe('sorting', () => {
+    test('sorts threads by line number', () => {
+      const thread1 = createThread({
+        id: 'thread-1',
+        anchor: {
+          quote: 'later text',
+          prefix: '',
+          suffix: '',
+          status: 'anchored',
+          originalQuote: 'later text',
+          lastKnownOffset: 100,
+          originalPosition: { offset: 100, line: 10, column: 1 },
+        },
+        comments: [
+          {
+            id: 'c1',
+            threadId: 'thread-1',
+            authorId: 'user-1',
+            body: 'Comment on later text',
+            createdAt: '2024-01-15T10:00:00Z',
+          },
+        ],
+      });
+
+      const thread2 = createThread({
+        id: 'thread-2',
+        anchor: {
+          quote: 'earlier text',
+          prefix: '',
+          suffix: '',
+          status: 'anchored',
+          originalQuote: 'earlier text',
+          lastKnownOffset: 20,
+          originalPosition: { offset: 20, line: 2, column: 1 },
+        },
+        comments: [
+          {
+            id: 'c2',
+            threadId: 'thread-2',
+            authorId: 'user-1',
+            body: 'Comment on earlier text',
+            createdAt: '2024-01-15T10:00:00Z',
+          },
+        ],
+      });
+
+      const state = createState([thread1, thread2]);
+      const result = generateCommentsExport(state);
+
+      // Earlier text should appear before later text
+      const earlierIndex = result.markdown.indexOf('earlier text');
+      const laterIndex = result.markdown.indexOf('later text');
+      expect(earlierIndex).toBeLessThan(laterIndex);
+    });
+  });
+});

--- a/packages/commentary/src/export/comments-export.ts
+++ b/packages/commentary/src/export/comments-export.ts
@@ -1,0 +1,323 @@
+/**
+ * Generate LLM-optimized exports of comment threads.
+ *
+ * Provides two export formats:
+ * 1. Markdown: Human and LLM readable format with blockquotes for highlighted text
+ * 2. JSON: Structured format for programmatic consumption
+ *
+ * Both formats support:
+ * - Text-anchored comments (with highlighted text and location)
+ * - Document-level comments (general feedback on the entire document)
+ */
+
+import type { PersistedAnchor, PersistedThread, ReviewState } from '../comments/types.js';
+import type {
+  CommentsExportOptions,
+  CommentsExportResult,
+  CommentsJSONOptions,
+  CommentsJSONResult,
+  ExportedComment,
+  ExportedSelection,
+  ExportedThread,
+} from './types';
+
+/**
+ * Check if an anchor is a document-level anchor.
+ * Duplicated from comments/types to avoid circular dependency.
+ */
+function isDocumentAnchor(anchor: PersistedAnchor): boolean {
+  return anchor.type === 'document';
+}
+
+/**
+ * Generate an LLM-optimized Markdown export of comment threads.
+ *
+ * Supports both text-anchored comments (with blockquoted selections) and
+ * document-level comments (general feedback on the entire document).
+ *
+ * @param state - The current review state
+ * @param options - Configuration options for export generation
+ * @returns CommentsExportResult with Markdown string and statistics
+ *
+ * @example
+ * ```typescript
+ * const result = generateCommentsExport(state);
+ * // Send result.markdown to an LLM for analysis
+ * console.log(`Exported ${result.stats.commentCount} comments`);
+ * ```
+ */
+export function generateCommentsExport(
+  state: ReviewState,
+  options: CommentsExportOptions = {},
+): CommentsExportResult {
+  const { includeTimestamps = true, includeAuthorIds = true } = options;
+
+  // Filter to threads with visible (non-deleted) comments
+  const threads = state.threads.filter((thread) => {
+    return thread.comments.some((comment) => !comment.deletedAt);
+  });
+
+  if (threads.length === 0) {
+    return {
+      markdown: '# Comments\n\nNo comments to export.',
+      stats: {
+        threadCount: 0,
+        commentCount: 0,
+        documentCommentCount: 0,
+      },
+    };
+  }
+
+  // Separate document-level and text-anchored threads
+  const documentThreads = threads.filter((t) => isDocumentAnchor(t.anchor));
+  const textThreads = threads.filter((t) => !isDocumentAnchor(t.anchor));
+
+  const lines: string[] = [];
+  let totalCommentCount = 0;
+  let documentCommentCount = 0;
+
+  // Header with brief explanation for LLM
+  lines.push('# Review Comments\n');
+
+  // Document-level comments first
+  if (documentThreads.length > 0) {
+    lines.push('## Document-Level Comments\n');
+    lines.push('General feedback about the entire document:\n');
+
+    for (const thread of documentThreads) {
+      const visibleComments = thread.comments.filter((c) => !c.deletedAt);
+      if (visibleComments.length === 0) continue;
+
+      documentCommentCount += visibleComments.length;
+      totalCommentCount += visibleComments.length;
+
+      lines.push(formatDocumentThread(visibleComments, { includeTimestamps, includeAuthorIds }));
+    }
+  }
+
+  // Text-anchored comments
+  if (textThreads.length > 0) {
+    if (documentThreads.length > 0) {
+      lines.push('## Text-Anchored Comments\n');
+    }
+
+    lines.push('Comments on specific text selections:\n');
+
+    // Sort text threads by position (line number or offset)
+    const sortedThreads = textThreads.toSorted((a, b) => {
+      const lineA = a.anchor.originalPosition?.line ?? a.anchor.lastKnownOffset ?? 0;
+      const lineB = b.anchor.originalPosition?.line ?? b.anchor.lastKnownOffset ?? 0;
+      return lineA - lineB;
+    });
+
+    for (const thread of sortedThreads) {
+      const visibleComments = thread.comments.filter((c) => !c.deletedAt);
+      if (visibleComments.length === 0) continue;
+
+      totalCommentCount += visibleComments.length;
+
+      // Generate thread entry
+      lines.push(formatThread(thread, visibleComments, { includeTimestamps, includeAuthorIds }));
+    }
+  }
+
+  // Add summary at the end
+  lines.push('---\n');
+  lines.push(`**Total threads:** ${threads.length}`);
+  lines.push(`**Total comments:** ${totalCommentCount}`);
+  if (documentCommentCount > 0) {
+    lines.push(`**Document-level comments:** ${documentCommentCount}`);
+  }
+
+  return {
+    markdown: lines.join('\n'),
+    stats: {
+      threadCount: threads.length,
+      commentCount: totalCommentCount,
+      documentCommentCount,
+    },
+  };
+}
+
+/**
+ * Generate a JSON export of comment threads.
+ *
+ * Provides a structured format for programmatic consumption, with separate
+ * handling for text-anchored and document-level comments.
+ *
+ * @param state - The current review state
+ * @param options - Configuration options for export generation
+ * @returns CommentsJSONResult with JSON string, data object, and statistics
+ */
+export function generateCommentsJSON(
+  state: ReviewState,
+  options: CommentsJSONOptions = {},
+): CommentsJSONResult {
+  const { includeTimestamps = true, includeAuthorIds = true } = options;
+
+  // Filter to threads with visible (non-deleted) comments
+  const threads = state.threads.filter((thread) => {
+    return thread.comments.some((comment) => !comment.deletedAt);
+  });
+
+  const exportedThreads: ExportedThread[] = [];
+  let totalCommentCount = 0;
+  let documentThreadCount = 0;
+
+  for (const thread of threads) {
+    const visibleComments = thread.comments.filter((c) => !c.deletedAt);
+    if (visibleComments.length === 0) continue;
+
+    totalCommentCount += visibleComments.length;
+    const isDocument = isDocumentAnchor(thread.anchor);
+    if (isDocument) documentThreadCount++;
+
+    const exportedComments: ExportedComment[] = visibleComments.map((comment) => {
+      const exported: ExportedComment = {
+        id: comment.id,
+        body: comment.body,
+      };
+      if (includeAuthorIds) exported.authorId = comment.authorId;
+      if (includeTimestamps) {
+        exported.createdAt = comment.createdAt;
+        if (comment.editedAt) exported.updatedAt = comment.editedAt;
+      }
+      return exported;
+    });
+
+    const exportedThread: ExportedThread = {
+      id: thread.id,
+      type: isDocument ? 'document' : 'text',
+      comments: exportedComments,
+    };
+
+    // Add selection info for text-anchored threads
+    if (!isDocument) {
+      const selection: ExportedSelection = {
+        text: thread.anchor.quote,
+        from: thread.anchor.lastKnownOffset ?? 0,
+        to: (thread.anchor.lastKnownOffset ?? 0) + thread.anchor.quote.length,
+      };
+      if (thread.anchor.originalPosition) {
+        selection.line = thread.anchor.originalPosition.line;
+        selection.column = thread.anchor.originalPosition.column;
+      }
+      exportedThread.selection = selection;
+    }
+
+    exportedThreads.push(exportedThread);
+  }
+
+  const data = { threads: exportedThreads };
+
+  return {
+    json: JSON.stringify(data, null, 2),
+    data,
+    stats: {
+      threadCount: exportedThreads.length,
+      commentCount: totalCommentCount,
+      documentThreadCount,
+    },
+  };
+}
+
+/**
+ * Format a single text-anchored thread with all its visible comments.
+ * Uses blockquotes for the highlighted text per plan requirements.
+ */
+function formatThread(
+  thread: PersistedThread,
+  visibleComments: PersistedThread['comments'],
+  options: { includeTimestamps: boolean; includeAuthorIds: boolean },
+): string {
+  const lines: string[] = [];
+  const { anchor } = thread;
+
+  // Header with location information
+  const locationInfo = formatLocation(anchor);
+
+  lines.push(`### ${locationInfo}\n`);
+
+  // Highlighted text using blockquote (per plan requirements)
+  if (anchor.quote) {
+    // Split quote into lines and blockquote each
+    const quoteLines = anchor.quote.split('\n');
+    for (const quoteLine of quoteLines) {
+      lines.push(`> ${quoteLine}`);
+    }
+    lines.push('');
+  }
+
+  // Position details for precise reference
+  if (anchor.originalPosition) {
+    const { line, column } = anchor.originalPosition;
+    const range = anchor.lastKnownOffset !== undefined ? `offset ${anchor.lastKnownOffset}` : '';
+    lines.push(`*Position: Line ${line}, Column ${column}${range ? ` (${range})` : ''}*\n`);
+  }
+
+  // Comments section
+  for (const comment of visibleComments) {
+    const author = options.includeAuthorIds ? comment.authorId : 'Reviewer';
+    const timestamp = options.includeTimestamps ? formatTimestamp(comment.createdAt) : '';
+
+    lines.push(`**${author}**${timestamp}:`);
+    lines.push(comment.body);
+    lines.push('');
+  }
+
+  lines.push('---\n');
+
+  return lines.join('\n');
+}
+
+/**
+ * Format a document-level thread (general feedback, no highlighted text).
+ */
+function formatDocumentThread(
+  visibleComments: PersistedThread['comments'],
+  options: { includeTimestamps: boolean; includeAuthorIds: boolean },
+): string {
+  const lines: string[] = [];
+
+  for (const comment of visibleComments) {
+    const author = options.includeAuthorIds ? comment.authorId : 'Reviewer';
+    const timestamp = options.includeTimestamps ? formatTimestamp(comment.createdAt) : '';
+
+    lines.push(`**${author}**${timestamp}:`);
+    lines.push(comment.body);
+    lines.push('');
+  }
+
+  lines.push('---\n');
+
+  return lines.join('\n');
+}
+
+/**
+ * Format location information for a thread.
+ */
+function formatLocation(anchor: PersistedThread['anchor']): string {
+  if (anchor.originalPosition) {
+    const { line, column } = anchor.originalPosition;
+    return `Comment at Line ${line}:${column}`;
+  }
+
+  if (anchor.lastKnownOffset !== undefined) {
+    return `Comment at offset ${anchor.lastKnownOffset}`;
+  }
+
+  return 'Comment (location unknown)';
+}
+
+/**
+ * Format a timestamp for display.
+ */
+function formatTimestamp(isoString: string): string {
+  try {
+    const date = new Date(isoString);
+    // Use a short format that's still parseable
+    return ` (${date.toISOString().split('T')[0]})`;
+  } catch {
+    return '';
+  }
+}

--- a/packages/commentary/src/export/index.ts
+++ b/packages/commentary/src/export/index.ts
@@ -1,0 +1,28 @@
+/**
+ * Export utilities for the ReviewEditor.
+ *
+ * Provides functions to generate LLM-friendly summaries and
+ * Git-compatible unified diffs from review state.
+ *
+ * @module
+ */
+
+// Pure functions (for direct use/testing)
+export { generateCommentsExport, generateCommentsJSON } from './comments-export';
+export { generateMarkdownSummary } from './markdown-summary';
+export { generateUnifiedDiff } from './unified-diff';
+
+// Types
+export type {
+  CommentsExportOptions,
+  CommentsExportResult,
+  CommentsJSONOptions,
+  CommentsJSONResult,
+  ExportedComment,
+  ExportedSelection,
+  ExportedThread,
+  MarkdownSummaryOptions,
+  MarkdownSummaryResult,
+  UnifiedDiffOptions,
+  UnifiedDiffResult,
+} from './types';

--- a/packages/commentary/src/export/markdown-summary.test.ts
+++ b/packages/commentary/src/export/markdown-summary.test.ts
@@ -1,0 +1,317 @@
+// @ts-nocheck -- migrated commentary assertions use runtime-verified fixture indexing.
+/**
+ * Tests for LLM Markdown summary export functionality.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import type { PersistedThread, ReviewState } from '../comments/types.js';
+import { generateMarkdownSummary } from './markdown-summary';
+
+/** Create a minimal ReviewState for testing */
+function createState(
+  options: {
+    original?: string;
+    current?: string;
+    threads?: PersistedThread[];
+  } = {},
+): ReviewState {
+  return {
+    schemaVersion: 4,
+    content: options.current ?? 'Current content',
+    original: options.original ?? 'Original content',
+    threads: options.threads ?? [],
+    updatedAt: new Date().toISOString(),
+  };
+}
+
+/** Create a test thread */
+function createThread(
+  options: {
+    id?: string;
+    quote?: string;
+    line?: number;
+    comments?: Array<{ id: string; authorId: string; body: string; deletedAt?: string }>;
+  } = {},
+): PersistedThread {
+  const now = new Date().toISOString();
+  const threadId = options.id ?? 'thread-1';
+
+  // Build comments with required fields filled in
+  const comments = options.comments
+    ? options.comments.map((c) => ({
+        ...c,
+        threadId,
+        createdAt: now,
+      }))
+    : [
+        {
+          id: 'comment-1',
+          threadId,
+          authorId: 'user-123',
+          body: 'Test comment',
+          createdAt: now,
+        },
+      ];
+
+  return {
+    id: threadId,
+    anchor: {
+      quote: options.quote ?? 'selected text',
+      prefix: 'before ',
+      suffix: ' after',
+      status: 'anchored',
+      originalPosition: {
+        offset: 0,
+        line: options.line ?? 1,
+        column: 1,
+      },
+    },
+    comments,
+    createdAt: now,
+  };
+}
+
+describe('generateMarkdownSummary', () => {
+  describe('basic structure', () => {
+    test('returns empty message when no changes or feedback', () => {
+      const state = createState({
+        original: 'Same content',
+        current: 'Same content',
+        threads: [],
+      });
+      const result = generateMarkdownSummary(state);
+
+      expect(result.markdown).toBe('No changes or feedback to report.');
+    });
+
+    test('does not include statistics section', () => {
+      const state = createState({
+        threads: [createThread()],
+      });
+      const result = generateMarkdownSummary(state);
+
+      expect(result.markdown).not.toContain('## Statistics');
+    });
+
+    test('does not include Review Summary header', () => {
+      const state = createState({
+        threads: [createThread()],
+      });
+      const result = generateMarkdownSummary(state);
+
+      expect(result.markdown).not.toContain('# Review Summary');
+    });
+
+    test('returns correct stats object', () => {
+      const state = createState({
+        threads: [createThread()],
+      });
+      const result = generateMarkdownSummary(state);
+
+      expect(result.stats.threadCount).toBe(1);
+    });
+  });
+
+  describe('document changes section', () => {
+    test('includes changes when content differs', () => {
+      const state = createState({
+        original: 'Hello world',
+        current: 'Hello universe',
+      });
+      const result = generateMarkdownSummary(state);
+
+      expect(result.markdown).toContain('## Changes Made');
+      expect(result.stats.changeCount).toBeGreaterThan(0);
+    });
+
+    test('includes explanatory text for changes', () => {
+      const state = createState({
+        original: 'Hello world',
+        current: 'Hello universe',
+      });
+      const result = generateMarkdownSummary(state);
+
+      expect(result.markdown).toContain('The following edits were made');
+    });
+
+    test('omits changes section when content is identical', () => {
+      const state = createState({
+        original: 'Same content',
+        current: 'Same content',
+      });
+      const result = generateMarkdownSummary(state);
+
+      expect(result.markdown).not.toContain('## Changes Made');
+      expect(result.stats.changeCount).toBe(0);
+    });
+
+    test('shows diff format with + and - prefixes', () => {
+      const state = createState({
+        original: 'Old line',
+        current: 'New line',
+      });
+      const result = generateMarkdownSummary(state);
+
+      expect(result.markdown).toContain('-Old line');
+      expect(result.markdown).toContain('+New line');
+    });
+
+    test('calculates line range correctly when additions are present', () => {
+      const state = createState({
+        original: 'Line 1\nLine 2\nLine 3\nLine 4\nLine 5',
+        current: 'Line 1\nModified 2\nNew Line A\nNew Line B\nLine 3\nLine 4\nLine 5',
+      });
+      const result = generateMarkdownSummary(state);
+
+      expect(result.markdown).toMatch(/### Lines 1-4/);
+      expect(result.markdown).not.toMatch(/### Lines 1-[5-9]/);
+    });
+  });
+
+  describe('feedback section', () => {
+    test('includes feedback section when threads exist', () => {
+      const state = createState({
+        threads: [createThread()],
+      });
+      const result = generateMarkdownSummary(state);
+
+      expect(result.markdown).toContain('## Feedback');
+    });
+
+    test('includes explanatory text for feedback', () => {
+      const state = createState({
+        threads: [createThread()],
+      });
+      const result = generateMarkdownSummary(state);
+
+      expect(result.markdown).toContain('may require action');
+    });
+
+    test('omits feedback section when no threads', () => {
+      const state = createState({ threads: [] });
+      const result = generateMarkdownSummary(state);
+
+      expect(result.markdown).not.toContain('## Feedback');
+    });
+
+    test('shows thread anchor quote in heading', () => {
+      const state = createState({
+        threads: [createThread({ quote: 'important text' })],
+      });
+      const result = generateMarkdownSummary(state);
+
+      expect(result.markdown).toContain('### On "important text"');
+    });
+
+    test('uses document-level heading for empty quotes', () => {
+      const thread = createThread({ quote: '' });
+      // Clear the quote to simulate document-level comment
+      thread.anchor.quote = '';
+      const state = createState({ threads: [thread] });
+      const result = generateMarkdownSummary(state);
+
+      expect(result.markdown).toContain('### Document-level feedback');
+    });
+
+    test('does not include author IDs by default', () => {
+      const state = createState({
+        threads: [createThread()],
+      });
+      const result = generateMarkdownSummary(state);
+
+      expect(result.markdown).not.toContain('user-123');
+    });
+
+    test('includes author IDs when option is true', () => {
+      const state = createState({
+        threads: [createThread()],
+      });
+      const result = generateMarkdownSummary(state, { includeAuthorIds: true });
+
+      expect(result.markdown).toContain('user-123');
+    });
+
+    test('does not include timestamps by default', () => {
+      const state = createState({
+        threads: [createThread()],
+      });
+      const result = generateMarkdownSummary(state);
+
+      // Should not contain ISO timestamp format in parentheses
+      expect(result.markdown).not.toMatch(/\(\d{4}-\d{2}-\d{2}T/);
+    });
+
+    test('includes timestamps when option is true', () => {
+      const state = createState({
+        threads: [createThread()],
+      });
+      const result = generateMarkdownSummary(state, { includeTimestamps: true });
+
+      // Should contain ISO timestamp format
+      expect(result.markdown).toMatch(/\d{4}-\d{2}-\d{2}T/);
+    });
+  });
+
+  describe('soft-deleted comments', () => {
+    test('excludes soft-deleted comments', () => {
+      const thread = createThread({
+        comments: [
+          {
+            id: 'visible',
+            authorId: 'user-1',
+            body: 'Visible comment',
+          },
+          {
+            id: 'deleted',
+            authorId: 'user-2',
+            body: 'Deleted comment',
+            deletedAt: new Date().toISOString(),
+          },
+        ],
+      });
+      const state = createState({ threads: [thread] });
+      const result = generateMarkdownSummary(state);
+
+      expect(result.markdown).toContain('Visible comment');
+      expect(result.markdown).not.toContain('Deleted comment');
+    });
+
+    test('excludes threads with only deleted comments', () => {
+      const thread = createThread({
+        comments: [
+          {
+            id: 'deleted',
+            authorId: 'user-1',
+            body: 'Deleted comment',
+            deletedAt: new Date().toISOString(),
+          },
+        ],
+      });
+      const state = createState({ threads: [thread] });
+      const result = generateMarkdownSummary(state);
+
+      expect(result.markdown).not.toContain('## Feedback');
+    });
+  });
+
+  describe('statistics (internal)', () => {
+    test('counts changes correctly', () => {
+      const state = createState({
+        original: 'Line 1\nLine 2',
+        current: 'Line 1\nModified',
+      });
+      const result = generateMarkdownSummary(state);
+
+      expect(result.stats.changeCount).toBeGreaterThan(0);
+    });
+
+    test('counts threads correctly', () => {
+      const state = createState({
+        threads: [createThread({ id: 'thread-1' }), createThread({ id: 'thread-2' })],
+      });
+      const result = generateMarkdownSummary(state);
+
+      expect(result.stats.threadCount).toBe(2);
+    });
+  });
+});

--- a/packages/commentary/src/export/markdown-summary.ts
+++ b/packages/commentary/src/export/markdown-summary.ts
@@ -1,0 +1,261 @@
+/**
+ * Generate LLM-optimized Markdown summary from ReviewState.
+ *
+ * Produces a structured Markdown document that an LLM can parse
+ * to understand what feedback was given and what actions to take.
+ *
+ * Design principles:
+ * - Action-oriented: Organize by "what to do" not "what data exists"
+ * - Minimal noise: No timestamps, author IDs, or statistics by default
+ * - Clear structure: Direct edits vs comments requiring action
+ */
+
+import { computeLineDiff } from '@cinder/markdown/diff/line-diff';
+import type { PersistedThread, ReviewState } from '../comments/types.js';
+import type { MarkdownSummaryOptions, MarkdownSummaryResult } from './types';
+
+/**
+ * Generate an LLM-optimized Markdown summary from review state.
+ *
+ * The output is structured for actionability:
+ * - "Changes Made" shows direct edits already applied to the document
+ * - "Feedback" shows comments on specific text that need attention
+ *
+ * @param state - The current review state
+ * @param options - Configuration options for summary generation
+ * @returns MarkdownSummaryResult with Markdown string and statistics
+ *
+ * @example
+ * ```typescript
+ * const result = generateMarkdownSummary(state);
+ * // Send result.markdown to an LLM for revision
+ * ```
+ */
+export function generateMarkdownSummary(
+  state: ReviewState,
+  options: MarkdownSummaryOptions = {},
+): MarkdownSummaryResult {
+  const {
+    // Defaults optimized for LLM consumption - minimal noise
+    includeTimestamps = false,
+    includeAuthorIds = false,
+    contextLines = 2,
+  } = options;
+
+  const sections: string[] = [];
+  let changeCount = 0;
+  let threadCount = 0;
+
+  // Document Changes Section
+  const original = state.original ?? '';
+  const current = state.content;
+
+  if (original !== current) {
+    const changesSection = generateChangesSection(original, current, contextLines);
+    if (changesSection.markdown) {
+      sections.push(changesSection.markdown);
+      changeCount = changesSection.changeCount;
+    }
+  }
+
+  // Comment Threads Section - only include threads with visible (non-deleted) comments
+  const visibleThreads = state.threads.filter((thread) => {
+    return thread.comments.some((comment) => !comment.deletedAt);
+  });
+
+  if (visibleThreads.length > 0) {
+    const threadsSection = generateThreadsSection(visibleThreads, {
+      includeTimestamps,
+      includeAuthorIds,
+    });
+    sections.push(threadsSection.markdown);
+    threadCount = threadsSection.threadCount;
+  }
+
+  // Build final output
+  let markdown: string;
+  if (sections.length === 0) {
+    markdown = 'No changes or feedback to report.';
+  } else {
+    markdown = sections.join('\n');
+  }
+
+  return {
+    markdown,
+    stats: {
+      changeCount,
+      threadCount,
+    },
+  };
+}
+
+/**
+ * Generate the document changes section.
+ */
+function generateChangesSection(
+  original: string,
+  current: string,
+  contextLines: number,
+): { markdown: string; changeCount: number } {
+  const lineDiffs = computeLineDiff(original, current);
+
+  // Find change ranges
+  const changeRanges: { start: number; end: number }[] = [];
+  let currentRange: { start: number; end: number } | null = null;
+
+  for (let i = 0; i < lineDiffs.length; i++) {
+    const diff = lineDiffs[i];
+    if (!diff) continue;
+
+    const isChange = diff.type !== 'same';
+
+    if (isChange) {
+      if (currentRange === null) {
+        currentRange = { start: i, end: i };
+      } else {
+        currentRange.end = i;
+      }
+    } else if (currentRange !== null) {
+      // Check if we should merge with next change (within context distance)
+      const nextChangeIndex = lineDiffs.findIndex((d, idx) => idx > i && d.type !== 'same');
+      if (nextChangeIndex !== -1 && nextChangeIndex - currentRange.end <= contextLines * 2 + 1) {
+        // Continue the current range
+        continue;
+      }
+      changeRanges.push(currentRange);
+      currentRange = null;
+    }
+  }
+
+  if (currentRange !== null) {
+    changeRanges.push(currentRange);
+  }
+
+  if (changeRanges.length === 0) {
+    return { markdown: '', changeCount: 0 };
+  }
+
+  const lines: string[] = ['## Changes Made\n'];
+  lines.push('The following edits were made to the document:\n');
+  let changeCount = 0;
+
+  for (const range of changeRanges) {
+    // Add context before
+    const contextStart = Math.max(0, range.start - contextLines);
+    const contextEnd = Math.min(lineDiffs.length - 1, range.end + contextLines);
+
+    // Calculate original line number (1-based)
+    let originalLineNumber = 1;
+
+    for (let i = 0; i < contextStart; i++) {
+      const diff = lineDiffs[i];
+      if (!diff) continue;
+
+      if (diff.type === 'same' || diff.type === 'removed' || diff.type === 'modified') {
+        originalLineNumber++;
+      }
+    }
+
+    const startOriginalLine = originalLineNumber;
+
+    // Calculate end line number by counting only lines that exist in the original
+    let originalLinesInDisplayRange = 0;
+    for (let i = contextStart; i <= contextEnd; i++) {
+      const diff = lineDiffs[i];
+      if (!diff) continue;
+
+      if (diff.type === 'same' || diff.type === 'removed' || diff.type === 'modified') {
+        originalLinesInDisplayRange++;
+      }
+    }
+
+    const endOriginalLine =
+      originalLinesInDisplayRange > 0
+        ? startOriginalLine + originalLinesInDisplayRange - 1
+        : startOriginalLine;
+
+    lines.push(`### Lines ${startOriginalLine}-${endOriginalLine}\n`);
+    lines.push('```diff');
+
+    for (let i = contextStart; i <= contextEnd; i++) {
+      const diff = lineDiffs[i];
+      if (!diff) continue;
+
+      switch (diff.type) {
+        case 'same':
+          lines.push(` ${diff.text}`);
+          break;
+        case 'added':
+          lines.push(`+${diff.text}`);
+          changeCount++;
+          break;
+        case 'removed':
+          lines.push(`-${diff.text}`);
+          changeCount++;
+          break;
+        case 'modified':
+          lines.push(`-${diff.oldText}`);
+          lines.push(`+${diff.newText}`);
+          changeCount++;
+          break;
+      }
+    }
+
+    lines.push('```\n');
+  }
+
+  return { markdown: lines.join('\n'), changeCount };
+}
+
+/**
+ * Generate the comment threads section.
+ */
+function generateThreadsSection(
+  threads: PersistedThread[],
+  options: { includeTimestamps: boolean; includeAuthorIds: boolean },
+): { markdown: string; threadCount: number } {
+  const lines: string[] = ['## Feedback\n'];
+  lines.push('The following comments were made and may require action:\n');
+
+  for (const thread of threads) {
+    const visibleComments = thread.comments.filter((c) => !c.deletedAt);
+    if (visibleComments.length === 0) continue;
+
+    // Show what text the comment is about
+    const quote = thread.anchor.quote;
+    if (quote) {
+      lines.push(`### On "${truncate(quote, 60)}"\n`);
+    } else {
+      // Document-level comment
+      lines.push(`### Document-level feedback\n`);
+    }
+
+    for (const comment of visibleComments) {
+      let prefix = '';
+      if (options.includeAuthorIds) {
+        prefix = `**${comment.authorId}:** `;
+      }
+      if (options.includeTimestamps) {
+        prefix += `(${comment.createdAt}) `;
+      }
+
+      // Format comment body as blockquote
+      const bodyLines = comment.body.split('\n');
+      lines.push(`${prefix}> ${bodyLines.join('\n> ')}`);
+      lines.push('');
+    }
+  }
+
+  return {
+    markdown: lines.join('\n'),
+    threadCount: threads.length,
+  };
+}
+
+/**
+ * Truncate text to a maximum length.
+ */
+function truncate(text: string, maxLength: number): string {
+  if (text.length <= maxLength) return text;
+  return text.slice(0, maxLength - 3) + '...';
+}

--- a/packages/commentary/src/export/types.ts
+++ b/packages/commentary/src/export/types.ts
@@ -1,0 +1,186 @@
+/**
+ * Types for ReviewEditor export functionality.
+ *
+ * These types define the options and results for exporting review data
+ * in LLM-friendly and Git-compatible formats.
+ */
+
+/**
+ * Options for generating an LLM-optimized Markdown summary.
+ */
+export interface MarkdownSummaryOptions {
+  /** Include ISO timestamps on comments. Default: false */
+  includeTimestamps?: boolean | undefined;
+
+  /** Include author IDs on comments. Default: false */
+  includeAuthorIds?: boolean | undefined;
+
+  /** Number of context lines around changes. Default: 2 */
+  contextLines?: number | undefined;
+}
+
+/**
+ * Result from generating an LLM-optimized Markdown summary.
+ */
+export interface MarkdownSummaryResult {
+  /** The generated Markdown summary */
+  markdown: string;
+
+  /** Statistics about the exported content */
+  stats: {
+    /** Number of document changes */
+    changeCount: number;
+    /** Number of comment threads */
+    threadCount: number;
+  };
+}
+
+/**
+ * Options for generating a Git-compatible unified diff.
+ */
+export interface UnifiedDiffOptions {
+  /** Path for the original file header. Default: 'a/document.md' */
+  originalPath?: string | undefined;
+
+  /** Path for the current file header. Default: 'b/document.md' */
+  currentPath?: string | undefined;
+
+  /** Number of context lines around changes. Default: 3 */
+  contextLines?: number | undefined;
+
+  /**
+   * Include front matter in diff output. Default: false
+   *
+   * Note: ReviewState only stores current front matter (`frontMatterRaw`), not
+   * the original's. When enabled, front matter will appear as all additions
+   * unless the original had no front matter. Disabled by default for accurate diffs.
+   */
+  includeFrontMatter?: boolean | undefined;
+}
+
+/**
+ * Result from generating a Git-compatible unified diff.
+ */
+export interface UnifiedDiffResult {
+  /** The generated unified diff string */
+  diff: string;
+
+  /** Statistics about the diff */
+  stats: {
+    /** Number of lines added */
+    additions: number;
+    /** Number of lines removed */
+    deletions: number;
+    /** Number of diff hunks */
+    hunks: number;
+  };
+}
+
+/**
+ * Options for generating LLM-optimized comments export.
+ */
+export interface CommentsExportOptions {
+  /** Include ISO timestamps on comments. Default: true */
+  includeTimestamps?: boolean | undefined;
+
+  /** Include author IDs on comments. Default: true */
+  includeAuthorIds?: boolean | undefined;
+}
+
+/**
+ * Result from generating LLM-optimized comments export.
+ */
+export interface CommentsExportResult {
+  /** The generated Markdown string */
+  markdown: string;
+
+  /** Statistics about the exported comments */
+  stats: {
+    /** Total number of threads exported */
+    threadCount: number;
+    /** Total number of comments exported */
+    commentCount: number;
+    /** Number of document-level comments */
+    documentCommentCount: number;
+  };
+}
+
+/**
+ * Options for generating JSON comments export.
+ */
+export interface CommentsJSONOptions {
+  /** Include author IDs on comments. Default: true */
+  includeAuthorIds?: boolean | undefined;
+
+  /** Include timestamps on comments. Default: true */
+  includeTimestamps?: boolean | undefined;
+}
+
+/**
+ * Structured comment data for JSON export.
+ */
+export interface ExportedComment {
+  /** Comment ID */
+  id: string;
+  /** Comment body text */
+  body: string;
+  /** Author ID (if included) */
+  authorId?: string | undefined;
+  /** Creation timestamp (if included) */
+  createdAt?: string | undefined;
+  /** Update timestamp (if included) */
+  updatedAt?: string | undefined;
+}
+
+/**
+ * Structured thread selection data for JSON export.
+ */
+export interface ExportedSelection {
+  /** Selected text */
+  text: string;
+  /** Character offset from start */
+  from: number;
+  /** Character offset to end */
+  to: number;
+  /** Line number (if available) */
+  line?: number | undefined;
+  /** Column number (if available) */
+  column?: number | undefined;
+}
+
+/**
+ * Structured thread data for JSON export.
+ */
+export interface ExportedThread {
+  /** Thread ID */
+  id: string;
+  /** Thread type: 'text' for text-anchored, 'document' for document-level */
+  type: 'text' | 'document';
+  /** Selection info (only for text-anchored threads) */
+  selection?: ExportedSelection | undefined;
+  /** Comments in the thread */
+  comments: ExportedComment[];
+}
+
+/**
+ * Result from generating JSON comments export.
+ */
+export interface CommentsJSONResult {
+  /** The JSON string */
+  json: string;
+
+  /** Structured data (before serialization) */
+  data: {
+    threads: ExportedThread[];
+  };
+
+  /** Statistics about the exported comments */
+  stats: {
+    /** Total number of threads exported */
+    threadCount: number;
+    /** Total number of comments exported */
+    commentCount: number;
+    /** Number of document-level threads */
+    documentThreadCount: number;
+  };
+}

--- a/packages/commentary/src/export/unified-diff.test.ts
+++ b/packages/commentary/src/export/unified-diff.test.ts
@@ -1,0 +1,226 @@
+// @ts-nocheck -- migrated commentary assertions use runtime-verified fixture indexing.
+/**
+ * Tests for unified diff export functionality.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import type { ReviewState } from '../comments/types.js';
+import { generateUnifiedDiff } from './unified-diff';
+
+/** Create a minimal ReviewState for testing */
+function createState(original: string, current: string): ReviewState {
+  return {
+    schemaVersion: 4,
+    content: current,
+    original,
+    threads: [],
+    updatedAt: new Date().toISOString(),
+  };
+}
+
+describe('generateUnifiedDiff', () => {
+  describe('basic functionality', () => {
+    test('returns empty diff when content is identical', () => {
+      const state = createState('Hello world', 'Hello world');
+      const result = generateUnifiedDiff(state);
+
+      expect(result.diff).toBe('');
+      expect(result.stats.additions).toBe(0);
+      expect(result.stats.deletions).toBe(0);
+      expect(result.stats.hunks).toBe(0);
+    });
+
+    test('generates diff for single line change', () => {
+      const state = createState('Hello world', 'Hello universe');
+      const result = generateUnifiedDiff(state);
+
+      expect(result.diff).toContain('--- a/document.md');
+      expect(result.diff).toContain('+++ b/document.md');
+      expect(result.diff).toContain('-Hello world');
+      expect(result.diff).toContain('+Hello universe');
+      expect(result.stats.additions).toBe(1);
+      expect(result.stats.deletions).toBe(1);
+      expect(result.stats.hunks).toBe(1);
+    });
+
+    test('generates diff for line insertion', () => {
+      const original = 'Line 1\nLine 2';
+      const current = 'Line 1\nNew Line\nLine 2';
+      const state = createState(original, current);
+      const result = generateUnifiedDiff(state);
+
+      expect(result.diff).toContain('+New Line');
+      expect(result.stats.additions).toBe(1);
+      expect(result.stats.deletions).toBe(0);
+    });
+
+    test('generates diff for line deletion', () => {
+      const original = 'Line 1\nLine 2\nLine 3';
+      const current = 'Line 1\nLine 3';
+      const state = createState(original, current);
+      const result = generateUnifiedDiff(state);
+
+      expect(result.diff).toContain('-Line 2');
+      expect(result.stats.additions).toBe(0);
+      expect(result.stats.deletions).toBe(1);
+    });
+  });
+
+  describe('hunk generation', () => {
+    test('includes context lines', () => {
+      const original = 'Line 1\nLine 2\nLine 3\nLine 4\nLine 5';
+      const current = 'Line 1\nLine 2\nModified\nLine 4\nLine 5';
+      const state = createState(original, current);
+      const result = generateUnifiedDiff(state, { contextLines: 2 });
+
+      // Should include 2 lines of context before and after
+      expect(result.diff).toContain(' Line 1');
+      expect(result.diff).toContain(' Line 2');
+      expect(result.diff).toContain('-Line 3');
+      expect(result.diff).toContain('+Modified');
+      expect(result.diff).toContain(' Line 4');
+      expect(result.diff).toContain(' Line 5');
+    });
+
+    test('merges overlapping hunks', () => {
+      // Changes close enough together should be in a single hunk
+      const lines = Array.from({ length: 10 }, (_, i) => `Line ${i + 1}`);
+      const original = lines.join('\n');
+      const modified = [...lines];
+      modified[2] = 'Changed 3';
+      modified[5] = 'Changed 6';
+      const current = modified.join('\n');
+
+      const state = createState(original, current);
+      const result = generateUnifiedDiff(state, { contextLines: 2 });
+
+      // With context of 2, changes at lines 3 and 6 should merge into one hunk
+      expect(result.stats.hunks).toBe(1);
+    });
+
+    test('creates separate hunks for distant changes', () => {
+      // Changes far apart should be in separate hunks
+      const lines = Array.from({ length: 20 }, (_, i) => `Line ${i + 1}`);
+      const original = lines.join('\n');
+      const modified = [...lines];
+      modified[1] = 'Changed 2';
+      modified[18] = 'Changed 19';
+      const current = modified.join('\n');
+
+      const state = createState(original, current);
+      const result = generateUnifiedDiff(state, { contextLines: 3 });
+
+      // Changes at lines 2 and 19 should be in separate hunks
+      expect(result.stats.hunks).toBe(2);
+    });
+  });
+
+  describe('hunk headers', () => {
+    test('generates correct hunk header format', () => {
+      const state = createState('Line 1\nLine 2', 'Line 1\nModified');
+      const result = generateUnifiedDiff(state);
+
+      // Should match unified diff hunk header format: @@ -start,count +start,count @@
+      expect(result.diff).toMatch(/@@ -\d+,\d+ \+\d+,\d+ @@/);
+    });
+  });
+
+  describe('options', () => {
+    test('uses custom file paths', () => {
+      const state = createState('old', 'new');
+      const result = generateUnifiedDiff(state, {
+        originalPath: 'a/custom.md',
+        currentPath: 'b/custom.md',
+      });
+
+      expect(result.diff).toContain('--- a/custom.md');
+      expect(result.diff).toContain('+++ b/custom.md');
+    });
+
+    test('respects contextLines option', () => {
+      const lines = Array.from({ length: 10 }, (_, i) => `Line ${i + 1}`);
+      const original = lines.join('\n');
+      const modified = [...lines];
+      modified[4] = 'Changed';
+      const current = modified.join('\n');
+
+      // With 0 context, should only show the change
+      const state = createState(original, current);
+      const result = generateUnifiedDiff(state, { contextLines: 0 });
+
+      expect(result.diff).toContain('-Line 5');
+      expect(result.diff).toContain('+Changed');
+      // Should not include adjacent lines
+      expect(result.diff).not.toContain(' Line 4');
+      expect(result.diff).not.toContain(' Line 6');
+    });
+  });
+
+  describe('edge cases', () => {
+    test('handles empty original', () => {
+      const state = createState('', 'New content');
+      const result = generateUnifiedDiff(state);
+
+      expect(result.diff).toContain('+New content');
+      expect(result.stats.additions).toBe(1);
+      expect(result.stats.deletions).toBe(0);
+    });
+
+    test('generates correct hunk header for empty original (new file)', () => {
+      const state = createState('', 'Line 1\nLine 2\nLine 3');
+      const result = generateUnifiedDiff(state);
+
+      // For new files, original should be @@ -0,0 +1,n @@
+      expect(result.diff).toMatch(/@@ -0,0 \+1,3 @@/);
+    });
+
+    test('handles empty current', () => {
+      const state = createState('Old content', '');
+      const result = generateUnifiedDiff(state);
+
+      expect(result.diff).toContain('-Old content');
+      expect(result.stats.additions).toBe(0);
+      expect(result.stats.deletions).toBe(1);
+    });
+
+    test('generates correct hunk header for empty current (full deletion)', () => {
+      const state = createState('Line 1\nLine 2\nLine 3', '');
+      const result = generateUnifiedDiff(state);
+
+      // For full deletion, current should be @@ -1,n +0,0 @@
+      expect(result.diff).toMatch(/@@ -1,3 \+0,0 @@/);
+    });
+
+    test('handles missing original (undefined)', () => {
+      const state: ReviewState = {
+        schemaVersion: 4,
+        content: 'New content',
+        threads: [],
+        updatedAt: new Date().toISOString(),
+      };
+      const result = generateUnifiedDiff(state);
+
+      expect(result.diff).toContain('+New content');
+    });
+
+    test('handles multiline content', () => {
+      const original = 'Line 1\nLine 2\nLine 3\nLine 4\nLine 5';
+      const current = 'Line 1\nModified 2\nLine 3\nModified 4\nLine 5';
+      const state = createState(original, current);
+      const result = generateUnifiedDiff(state);
+
+      expect(result.diff).toContain('-Line 2');
+      expect(result.diff).toContain('+Modified 2');
+      expect(result.diff).toContain('-Line 4');
+      expect(result.diff).toContain('+Modified 4');
+    });
+
+    test('preserves trailing newlines in output', () => {
+      const state = createState('Hello', 'World');
+      const result = generateUnifiedDiff(state);
+
+      // Unified diff should end with a newline
+      expect(result.diff.endsWith('\n')).toBe(true);
+    });
+  });
+});

--- a/packages/commentary/src/export/unified-diff.ts
+++ b/packages/commentary/src/export/unified-diff.ts
@@ -1,0 +1,303 @@
+/**
+ * Generate Git-compatible unified diff format from ReviewState.
+ *
+ * Produces output that can be applied with `git apply` or `patch` command.
+ */
+
+import { normalize } from '@cinder/markdown/pipeline';
+import type { ReviewState } from '../comments/types.js';
+import type { UnifiedDiffOptions, UnifiedDiffResult } from './types';
+
+interface DiffHunk {
+  originalStart: number;
+  originalCount: number;
+  currentStart: number;
+  currentCount: number;
+  lines: string[];
+}
+
+/**
+ * Generate a Git-compatible unified diff from review state.
+ *
+ * @param state - The current review state containing original and current content
+ * @param options - Configuration options for diff generation
+ * @returns UnifiedDiffResult with diff string and statistics
+ *
+ * @example
+ * ```typescript
+ * const result = generateUnifiedDiff(state, { contextLines: 3 });
+ * console.log(result.diff);
+ * // --- a/document.md
+ * // +++ b/document.md
+ * // @@ -1,5 +1,6 @@
+ * //  context line
+ * // -old line
+ * // +new line
+ * //  context line
+ * ```
+ */
+export function generateUnifiedDiff(
+  state: ReviewState,
+  options: UnifiedDiffOptions = {},
+): UnifiedDiffResult {
+  const {
+    originalPath = 'a/document.md',
+    currentPath = 'b/document.md',
+    contextLines = 3,
+    // Default to false: ReviewState only stores current front matter (frontMatterRaw),
+    // not the original's front matter. Including it would incorrectly show all front
+    // matter lines as additions since we can't diff what we don't have.
+    includeFrontMatter = false,
+  } = options;
+
+  const originalContent = state.original ?? '';
+  let currentContent = state.content;
+
+  // Optionally prepend front matter to current content.
+  // Note: This only works correctly when the original document had no front matter,
+  // otherwise the diff will incorrectly show all front matter as additions.
+  if (includeFrontMatter && state.frontMatterRaw) {
+    currentContent = `---\n${state.frontMatterRaw}\n---\n\n${currentContent}`;
+  }
+
+  // Normalize both inputs to canonical form to avoid false positives
+  // from formatting differences (e.g., `*` vs `-` list markers, trailing whitespace).
+  // This ensures only semantic content changes appear in the diff.
+  // Note: normalize() adds a trailing newline; we strip it to avoid phantom empty lines.
+  const original = originalContent.trim() ? normalize(originalContent).replace(/\n+$/, '') : '';
+  const current = currentContent.trim() ? normalize(currentContent).replace(/\n+$/, '') : '';
+
+  // Handle empty or identical content
+  if (original === current) {
+    return {
+      diff: '',
+      stats: { additions: 0, deletions: 0, hunks: 0 },
+    };
+  }
+
+  const originalLines = splitIntoLines(original);
+  const currentLines = splitIntoLines(current);
+
+  // Compute line-level diff
+  const changes = computeLineChanges(originalLines, currentLines);
+
+  // Group changes into hunks with context
+  const hunks = createHunks(changes, contextLines);
+
+  // Build the unified diff output
+  const diffLines: string[] = [`--- ${originalPath}`, `+++ ${currentPath}`];
+
+  let additions = 0;
+  let deletions = 0;
+
+  for (const hunk of hunks) {
+    diffLines.push(
+      `@@ -${hunk.originalStart},${hunk.originalCount} +${hunk.currentStart},${hunk.currentCount} @@`,
+    );
+    for (const line of hunk.lines) {
+      diffLines.push(line);
+      if (line.startsWith('+') && !line.startsWith('+++')) {
+        additions++;
+      } else if (line.startsWith('-') && !line.startsWith('---')) {
+        deletions++;
+      }
+    }
+  }
+
+  return {
+    diff: hunks.length > 0 ? diffLines.join('\n') + '\n' : '',
+    stats: {
+      additions,
+      deletions,
+      hunks: hunks.length,
+    },
+  };
+}
+
+/**
+ * Split content into lines, preserving empty lines.
+ */
+function splitIntoLines(content: string): string[] {
+  if (content === '') return [];
+  return content.split('\n');
+}
+
+/**
+ * Represents a change between original and current.
+ */
+interface LineChange {
+  type: 'same' | 'added' | 'removed';
+  originalIndex: number | null;
+  currentIndex: number | null;
+  text: string;
+}
+
+/**
+ * Compute line-by-line changes using Myers diff algorithm (simplified LCS).
+ */
+function computeLineChanges(original: string[], current: string[]): LineChange[] {
+  // Use dynamic programming for LCS-based diff
+  const m = original.length;
+  const n = current.length;
+
+  // Build LCS table
+  const lcs: number[][] = Array.from({ length: m + 1 }, () => Array(n + 1).fill(0));
+
+  for (let i = 1; i <= m; i++) {
+    for (let j = 1; j <= n; j++) {
+      if (original[i - 1] === current[j - 1]) {
+        lcs[i]![j] = lcs[i - 1]![j - 1]! + 1;
+      } else {
+        lcs[i]![j] = Math.max(lcs[i - 1]![j]!, lcs[i]![j - 1]!);
+      }
+    }
+  }
+
+  // Backtrack to build the diff
+  let i = m;
+  let j = n;
+  const result: LineChange[] = [];
+
+  while (i > 0 || j > 0) {
+    if (i > 0 && j > 0 && original[i - 1] === current[j - 1]) {
+      result.unshift({
+        type: 'same',
+        originalIndex: i - 1,
+        currentIndex: j - 1,
+        text: original[i - 1]!,
+      });
+      i--;
+      j--;
+    } else if (j > 0 && (i === 0 || lcs[i]![j - 1]! >= lcs[i - 1]![j]!)) {
+      result.unshift({
+        type: 'added',
+        originalIndex: null,
+        currentIndex: j - 1,
+        text: current[j - 1]!,
+      });
+      j--;
+    } else {
+      result.unshift({
+        type: 'removed',
+        originalIndex: i - 1,
+        currentIndex: null,
+        text: original[i - 1]!,
+      });
+      i--;
+    }
+  }
+
+  return result;
+}
+
+/**
+ * Group changes into hunks with surrounding context lines.
+ */
+function createHunks(changes: LineChange[], contextLines: number): DiffHunk[] {
+  // Find indices of actual changes (non-same lines)
+  const changeIndices: number[] = [];
+  for (let i = 0; i < changes.length; i++) {
+    if (changes[i]?.type !== 'same') {
+      changeIndices.push(i);
+    }
+  }
+
+  if (changeIndices.length === 0) {
+    return [];
+  }
+
+  // Group consecutive changes with context
+  const hunks: DiffHunk[] = [];
+  const firstChangeIndex = changeIndices[0]!;
+  let hunkStart = Math.max(0, firstChangeIndex - contextLines);
+  let hunkEnd = Math.min(changes.length - 1, firstChangeIndex + contextLines);
+
+  for (let i = 1; i < changeIndices.length; i++) {
+    const changeIndex = changeIndices[i];
+    if (changeIndex === undefined) continue;
+
+    const changeStart = changeIndex - contextLines;
+    const changeEnd = changeIndex + contextLines;
+
+    // Check if this change should be merged with current hunk
+    if (changeStart <= hunkEnd + 1) {
+      // Merge: extend the current hunk
+      hunkEnd = Math.min(changes.length - 1, changeEnd);
+    } else {
+      // Create hunk from current range
+      hunks.push(buildHunk(changes, hunkStart, hunkEnd));
+      hunkStart = Math.max(0, changeStart);
+      hunkEnd = Math.min(changes.length - 1, changeEnd);
+    }
+  }
+
+  // Don't forget the last hunk
+  hunks.push(buildHunk(changes, hunkStart, hunkEnd));
+
+  return hunks;
+}
+
+/**
+ * Build a single hunk from a range of changes.
+ */
+function buildHunk(changes: LineChange[], start: number, end: number): DiffHunk {
+  const lines: string[] = [];
+  let originalStart = 0;
+  let originalCount = 0;
+  let currentStart = 0;
+  let currentCount = 0;
+  let foundFirstOriginal = false;
+  let foundFirstCurrent = false;
+
+  for (let i = start; i <= end; i++) {
+    const change = changes[i];
+    if (!change) continue;
+
+    switch (change.type) {
+      case 'same':
+        lines.push(` ${change.text}`);
+        if (!foundFirstOriginal && change.originalIndex !== null) {
+          originalStart = change.originalIndex + 1; // 1-indexed
+          foundFirstOriginal = true;
+        }
+        if (!foundFirstCurrent && change.currentIndex !== null) {
+          currentStart = change.currentIndex + 1; // 1-indexed
+          foundFirstCurrent = true;
+        }
+        originalCount++;
+        currentCount++;
+        break;
+
+      case 'removed':
+        lines.push(`-${change.text}`);
+        if (!foundFirstOriginal && change.originalIndex !== null) {
+          originalStart = change.originalIndex + 1;
+          foundFirstOriginal = true;
+        }
+        originalCount++;
+        break;
+
+      case 'added':
+        lines.push(`+${change.text}`);
+        if (!foundFirstCurrent && change.currentIndex !== null) {
+          currentStart = change.currentIndex + 1;
+          foundFirstCurrent = true;
+        }
+        currentCount++;
+        break;
+    }
+  }
+
+  // Handle edge cases for empty sides (new file or full deletion)
+  // Git unified diff requires start=0 when count=0, e.g., @@ -0,0 +1,n @@
+  if (!foundFirstOriginal) originalStart = originalCount === 0 ? 0 : 1;
+  if (!foundFirstCurrent) currentStart = currentCount === 0 ? 0 : 1;
+
+  return {
+    originalStart,
+    originalCount,
+    currentStart,
+    currentCount,
+    lines,
+  };
+}

--- a/packages/commentary/src/index.ts
+++ b/packages/commentary/src/index.ts
@@ -1,0 +1,6 @@
+export * from './anchor-decorations.js';
+export * from './anchoring.js';
+export * from './comments/index.js';
+export * from './export/index.js';
+export * from './session/index.js';
+export * from './shared/anchor-types.js';

--- a/packages/commentary/src/package-smoke.test.ts
+++ b/packages/commentary/src/package-smoke.test.ts
@@ -1,0 +1,16 @@
+// @ts-nocheck -- migrated commentary assertions use runtime-verified fixture indexing.
+import { describe, expect, test } from 'bun:test';
+
+import { generateBlockId } from './anchoring.js';
+import { extractMentions } from './comments/index.js';
+import { generateMarkdownSummary } from './export/index.js';
+import { createSession } from './session/index.js';
+
+describe('@cinder/commentary package smoke test', () => {
+  test('exposes the core anchoring, comment, export, and session modules', () => {
+    expect(generateBlockId('paragraph', 'Hello')).toMatch(/^paragraph-[a-z0-9]+$/);
+    expect(extractMentions('Hi @alice')).toEqual(['alice']);
+    expect(typeof generateMarkdownSummary).toBe('function');
+    expect(createSession('session-1', '2024-01-01T00:00:00.000Z').id).toBe('session-1');
+  });
+});

--- a/packages/commentary/src/session/fixtures.ts
+++ b/packages/commentary/src/session/fixtures.ts
@@ -1,0 +1,144 @@
+/**
+ * Shared test fixtures for review session tests.
+ *
+ * These factory functions create test data with sensible defaults
+ * that can be overridden as needed.
+ *
+ * @module
+ */
+
+import type { CommentAnchor } from '../comments/types.js';
+import type {
+  DraftComment,
+  PersistedDraftComment,
+  PersistedReviewSession,
+  ReviewSession,
+} from './types.js';
+
+// ============================================================================
+// Anchor Fixtures
+// ============================================================================
+
+/**
+ * Create a test CommentAnchor.
+ */
+export function createTestAnchor(overrides?: Partial<CommentAnchor>): CommentAnchor {
+  return {
+    quote: 'test quote',
+    prefix: 'prefix ',
+    suffix: ' suffix',
+    from: 10,
+    to: 20,
+    status: 'anchored',
+    ...overrides,
+  };
+}
+
+// ============================================================================
+// Draft Comment Fixtures
+// ============================================================================
+
+/**
+ * Create a test DraftComment (base form - no anchor or threadId).
+ */
+export function createTestDraftComment(overrides?: Partial<DraftComment>): DraftComment {
+  return {
+    id: 'draft-comment-1',
+    body: 'Test draft comment',
+    authorId: 'user-1',
+    createdAt: '2024-01-01T00:00:00.000Z',
+    updatedAt: '2024-01-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+/**
+ * Create a test DraftComment that starts a new thread (has anchor, no threadId).
+ */
+export function createTestDraftThread(overrides?: Partial<DraftComment>): DraftComment {
+  const draft = createTestDraftComment({
+    anchor: createTestAnchor(),
+    ...overrides,
+  });
+  delete draft.threadId;
+  return draft;
+}
+
+/**
+ * Create a test DraftComment that replies to an existing thread (has threadId, no anchor).
+ */
+export function createTestDraftReply(overrides?: Partial<DraftComment>): DraftComment {
+  const draft = createTestDraftComment({
+    threadId: 'existing-thread-1',
+    ...overrides,
+  });
+  delete draft.anchor;
+  return draft;
+}
+
+// ============================================================================
+// Review Session Fixtures
+// ============================================================================
+
+/**
+ * Create a test ReviewSession.
+ */
+export function createTestSession(overrides?: Partial<ReviewSession>): ReviewSession {
+  return {
+    id: 'session-1',
+    status: 'drafting',
+    draftComments: [],
+    startedAt: '2024-01-01T00:00:00.000Z',
+    updatedAt: '2024-01-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+/**
+ * Create a test ReviewSession with some draft content.
+ */
+export function createTestSessionWithDrafts(overrides?: Partial<ReviewSession>): ReviewSession {
+  return createTestSession({
+    draftComments: [
+      createTestDraftThread({ id: 'thread-draft-1' }),
+      createTestDraftReply({ id: 'reply-draft-1' }),
+    ],
+    ...overrides,
+  });
+}
+
+// ============================================================================
+// Persisted Fixtures
+// ============================================================================
+
+/**
+ * Create a test PersistedDraftComment (no runtime positions).
+ */
+export function createTestPersistedDraftComment(
+  overrides?: Partial<PersistedDraftComment>,
+): PersistedDraftComment {
+  return {
+    id: 'draft-comment-1',
+    body: 'Test draft comment',
+    authorId: 'user-1',
+    createdAt: '2024-01-01T00:00:00.000Z',
+    updatedAt: '2024-01-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+/**
+ * Create a test PersistedReviewSession.
+ */
+export function createTestPersistedSession(
+  overrides?: Partial<PersistedReviewSession>,
+): PersistedReviewSession {
+  return {
+    id: 'session-1',
+    status: 'drafting',
+    draftComments: [],
+    startedAt: '2024-01-01T00:00:00.000Z',
+    updatedAt: '2024-01-01T00:00:00.000Z',
+    ...overrides,
+  };
+}

--- a/packages/commentary/src/session/index.ts
+++ b/packages/commentary/src/session/index.ts
@@ -1,0 +1,64 @@
+/**
+ * Review session module for batch review submission.
+ *
+ * This module provides types and utilities for managing draft comments
+ * and suggestions that are submitted as a batch with a review outcome.
+ *
+ * @module
+ */
+
+// Types
+export type {
+  DraftComment,
+  DraftCommentCreateEvent,
+  DraftCommentDeleteEvent,
+  DraftCommentUpdateEvent,
+  DraftCounts,
+  DraftThreadCreateEvent,
+  PersistedDraftComment,
+  PersistedReviewSession,
+  ReviewDiscardEvent,
+  ReviewOutcome,
+  ReviewOutcomeChangeEvent,
+  ReviewSession,
+  ReviewSessionStatus,
+  ReviewSubmitEvent,
+} from './types.js';
+
+// Type guards
+export { isDraftReply, isDraftThread } from './types.js';
+
+// Update helpers
+export {
+  addDraftComment,
+  clearReviewOutcome,
+  clearSession,
+  createSession,
+  deleteDraftComment,
+  findDraftComment,
+  fromPersistedDraftComment,
+  fromPersistedSession,
+  getDraftCounts,
+  getDraftReplies,
+  getDraftRepliesForThread,
+  getDraftThreads,
+  setReviewOutcome,
+  submitSession,
+  toPersistedDraftComment,
+  toPersistedSession,
+  updateDraftComment,
+  type SessionUpdateResult,
+} from './updates.js';
+
+// Persistence
+export {
+  STORAGE_KEY_PREFIX,
+  clearAllPersistedSessions,
+  clearPersistedSession,
+  getStorageKey,
+  hasPersistedSession,
+  listPersistedSessions,
+  loadSession,
+  saveSession,
+  validateSessionSchema,
+} from './persistence.js';

--- a/packages/commentary/src/session/persistence.test.ts
+++ b/packages/commentary/src/session/persistence.test.ts
@@ -1,0 +1,576 @@
+// @ts-nocheck -- migrated commentary assertions use runtime-verified fixture indexing.
+import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
+import type { CommentAnchor } from '../comments/types.js';
+import {
+  STORAGE_KEY_PREFIX,
+  clearAllPersistedSessions,
+  clearPersistedSession,
+  getStorageKey,
+  hasPersistedSession,
+  listPersistedSessions,
+  loadSession,
+  saveSession,
+  validateSessionSchema,
+} from './persistence.js';
+import type { PersistedReviewSession, ReviewSession } from './types.js';
+
+// ============================================================================
+// Mock Setup
+// ============================================================================
+
+// Create a mock sessionStorage
+type MockStorageOptions = {
+  keys?: readonly string[];
+  removeItem?: Storage['removeItem'];
+  throwOnLength?: boolean;
+};
+
+function createMockStorage(options: MockStorageOptions = {}): Storage {
+  let store: Record<string, string> = {};
+  return {
+    getItem: mock((key: string) => store[key] ?? null),
+    setItem: mock((key: string, value: string) => {
+      store[key] = value;
+    }),
+    removeItem:
+      options.removeItem ??
+      mock((key: string) => {
+        delete store[key];
+      }),
+    clear: mock(() => {
+      store = {};
+    }),
+    key: mock((index: number) => options.keys?.[index] ?? Object.keys(store)[index] ?? null),
+    get length() {
+      if (options.throwOnLength) {
+        throw new Error('Storage unavailable');
+      }
+      return options.keys?.length ?? Object.keys(store).length;
+    },
+  };
+}
+
+let mockStorage: Storage;
+const originalWindow = globalThis.window;
+const originalSessionStorage = globalThis.sessionStorage;
+
+function stubGlobal(name: 'window' | 'sessionStorage', value: unknown): void {
+  Object.defineProperty(globalThis, name, {
+    value,
+    configurable: true,
+    writable: true,
+  });
+}
+
+function restoreGlobal(name: 'window' | 'sessionStorage', value: unknown): void {
+  if (value === undefined) {
+    Reflect.deleteProperty(globalThis, name);
+    return;
+  }
+
+  Object.defineProperty(globalThis, name, {
+    value,
+    configurable: true,
+    writable: true,
+  });
+}
+
+function restoreGlobals(): void {
+  restoreGlobal('window', originalWindow);
+  restoreGlobal('sessionStorage', originalSessionStorage);
+  mock.restore();
+}
+
+beforeEach(() => {
+  mockStorage = createMockStorage();
+  stubGlobal('window', globalThis);
+  stubGlobal('sessionStorage', mockStorage);
+});
+
+afterEach(() => {
+  restoreGlobals();
+});
+
+// ============================================================================
+// Test Fixtures
+// ============================================================================
+
+function createTestAnchor(overrides?: Partial<CommentAnchor>): CommentAnchor {
+  return {
+    quote: 'test quote',
+    prefix: 'prefix ',
+    suffix: ' suffix',
+    from: 10,
+    to: 20,
+    status: 'anchored',
+    ...overrides,
+  };
+}
+
+function createTestSession(overrides?: Partial<ReviewSession>): ReviewSession {
+  return {
+    id: 'session-1',
+    status: 'drafting',
+    draftComments: [],
+    startedAt: '2024-01-01T00:00:00.000Z',
+    updatedAt: '2024-01-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+function createValidPersistedSession(
+  overrides?: Partial<PersistedReviewSession>,
+): PersistedReviewSession {
+  return {
+    id: 'session-1',
+    status: 'drafting',
+    draftComments: [],
+    startedAt: '2024-01-01T00:00:00.000Z',
+    updatedAt: '2024-01-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+// ============================================================================
+// Storage Key
+// ============================================================================
+
+describe('getStorageKey', () => {
+  test('prepends prefix to document key', () => {
+    expect(getStorageKey('doc-123')).toBe(`${STORAGE_KEY_PREFIX}doc-123`);
+  });
+
+  test('handles empty key', () => {
+    expect(getStorageKey('')).toBe(STORAGE_KEY_PREFIX);
+  });
+
+  test('handles special characters in key', () => {
+    expect(getStorageKey('doc/with/slashes')).toBe(`${STORAGE_KEY_PREFIX}doc/with/slashes`);
+  });
+});
+
+// ============================================================================
+// Schema Validation
+// ============================================================================
+
+describe('validateSessionSchema', () => {
+  test('returns true for valid session', () => {
+    const data = createValidPersistedSession();
+    expect(validateSessionSchema(data)).toBe(true);
+  });
+
+  test('returns true for session with all optional fields', () => {
+    const data = createValidPersistedSession({
+      outcome: 'approve',
+      submittedAt: '2024-01-02T00:00:00.000Z',
+    });
+    expect(validateSessionSchema(data)).toBe(true);
+  });
+
+  test('returns false for null', () => {
+    expect(validateSessionSchema(null)).toBe(false);
+  });
+
+  test('returns false for non-object', () => {
+    expect(validateSessionSchema('string')).toBe(false);
+    expect(validateSessionSchema(123)).toBe(false);
+    expect(validateSessionSchema([])).toBe(false);
+  });
+
+  test('returns false for missing id', () => {
+    const data = { ...createValidPersistedSession() };
+    delete (data as Record<string, unknown>).id;
+    expect(validateSessionSchema(data)).toBe(false);
+  });
+
+  test('returns false for missing status', () => {
+    const data = { ...createValidPersistedSession() };
+    delete (data as Record<string, unknown>).status;
+    expect(validateSessionSchema(data)).toBe(false);
+  });
+
+  test('returns false for invalid status', () => {
+    const data = createValidPersistedSession();
+    (data as unknown as Record<string, unknown>).status = 'invalid';
+    expect(validateSessionSchema(data)).toBe(false);
+  });
+
+  test('returns false for invalid outcome', () => {
+    const data = createValidPersistedSession();
+    (data as unknown as Record<string, unknown>).outcome = 'invalid';
+    expect(validateSessionSchema(data)).toBe(false);
+  });
+
+  test('returns false for missing startedAt', () => {
+    const data = { ...createValidPersistedSession() };
+    delete (data as Record<string, unknown>).startedAt;
+    expect(validateSessionSchema(data)).toBe(false);
+  });
+
+  test('returns false for missing updatedAt', () => {
+    const data = { ...createValidPersistedSession() };
+    delete (data as Record<string, unknown>).updatedAt;
+    expect(validateSessionSchema(data)).toBe(false);
+  });
+
+  test('returns false for missing draftComments', () => {
+    const data = { ...createValidPersistedSession() };
+    delete (data as Record<string, unknown>).draftComments;
+    expect(validateSessionSchema(data)).toBe(false);
+  });
+
+  test('returns false for non-array draftComments', () => {
+    const data = createValidPersistedSession();
+    (data as unknown as Record<string, unknown>).draftComments = 'not-array';
+    expect(validateSessionSchema(data)).toBe(false);
+  });
+
+  test('returns false for non-string submittedAt', () => {
+    const data = createValidPersistedSession();
+    (data as unknown as Record<string, unknown>).submittedAt = 123;
+    expect(validateSessionSchema(data)).toBe(false);
+  });
+
+  test('accepts all valid outcomes', () => {
+    expect(validateSessionSchema(createValidPersistedSession({ outcome: 'approve' }))).toBe(true);
+    expect(validateSessionSchema(createValidPersistedSession({ outcome: 'request_changes' }))).toBe(
+      true,
+    );
+    expect(validateSessionSchema(createValidPersistedSession({ outcome: 'comment' }))).toBe(true);
+  });
+
+  test('accepts both valid statuses', () => {
+    expect(validateSessionSchema(createValidPersistedSession({ status: 'drafting' }))).toBe(true);
+    expect(validateSessionSchema(createValidPersistedSession({ status: 'submitted' }))).toBe(true);
+  });
+});
+
+// ============================================================================
+// Save Session
+// ============================================================================
+
+describe('saveSession', () => {
+  test('saves session to sessionStorage', () => {
+    const session = createTestSession({ id: 'my-session' });
+    const result = saveSession('doc-123', session);
+
+    expect(result).toBe(true);
+    expect(mockStorage.setItem).toHaveBeenCalledWith(
+      `${STORAGE_KEY_PREFIX}doc-123`,
+      expect.any(String),
+    );
+  });
+
+  test('serializes session to JSON', () => {
+    const session = createTestSession({ id: 'my-session' });
+    saveSession('doc-123', session);
+
+    const savedValue = (mockStorage.setItem as ReturnType<typeof mock>).mock.calls[0][1];
+    const parsed = JSON.parse(savedValue);
+
+    expect(parsed.id).toBe('my-session');
+    expect(parsed.status).toBe('drafting');
+  });
+
+  test('strips runtime positions from anchors', () => {
+    const session = createTestSession({
+      draftComments: [
+        {
+          id: 'comment-1',
+          anchor: createTestAnchor({ from: 100, to: 200 }),
+          body: 'Test',
+          authorId: 'user-1',
+          createdAt: '2024-01-01T00:00:00.000Z',
+          updatedAt: '2024-01-01T00:00:00.000Z',
+        },
+      ],
+    });
+    saveSession('doc-123', session);
+
+    const savedValue = (mockStorage.setItem as ReturnType<typeof mock>).mock.calls[0][1];
+    const parsed = JSON.parse(savedValue);
+
+    expect(parsed.draftComments[0].anchor.from).toBeUndefined();
+    expect(parsed.draftComments[0].anchor.to).toBeUndefined();
+  });
+
+  test('handles storage errors gracefully', () => {
+    (mockStorage.setItem as ReturnType<typeof mock>).mockImplementationOnce(() => {
+      throw new Error('Storage full');
+    });
+
+    const session = createTestSession();
+    const result = saveSession('doc-123', session);
+
+    expect(result).toBe(false);
+  });
+});
+
+// ============================================================================
+// Load Session
+// ============================================================================
+
+describe('loadSession', () => {
+  test('loads and restores session from sessionStorage', () => {
+    const persisted = createValidPersistedSession({ id: 'restored-session' });
+    (mockStorage.getItem as ReturnType<typeof mock>).mockReturnValueOnce(JSON.stringify(persisted));
+
+    const result = loadSession('doc-123');
+
+    expect(result).not.toBeNull();
+    expect(result?.id).toBe('restored-session');
+  });
+
+  test('returns null when key does not exist', () => {
+    (mockStorage.getItem as ReturnType<typeof mock>).mockReturnValueOnce(null);
+
+    const result = loadSession('doc-123');
+
+    expect(result).toBeNull();
+  });
+
+  test('returns null and clears corrupted data', () => {
+    (mockStorage.getItem as ReturnType<typeof mock>).mockReturnValueOnce('not-json');
+
+    const result = loadSession('doc-123');
+
+    expect(result).toBeNull();
+    expect(mockStorage.removeItem).toHaveBeenCalledWith(`${STORAGE_KEY_PREFIX}doc-123`);
+  });
+
+  test('returns null and clears invalid schema', () => {
+    const invalid = { notValid: true };
+    (mockStorage.getItem as ReturnType<typeof mock>).mockReturnValueOnce(JSON.stringify(invalid));
+
+    const result = loadSession('doc-123');
+
+    expect(result).toBeNull();
+    expect(mockStorage.removeItem).toHaveBeenCalled();
+  });
+
+  test('returns null and clears submitted sessions', () => {
+    const submitted = createValidPersistedSession({
+      status: 'submitted',
+      submittedAt: '2024-01-02T00:00:00.000Z',
+    });
+    (mockStorage.getItem as ReturnType<typeof mock>).mockReturnValueOnce(JSON.stringify(submitted));
+
+    const result = loadSession('doc-123');
+
+    expect(result).toBeNull();
+    expect(mockStorage.removeItem).toHaveBeenCalled();
+  });
+
+  test('restores runtime anchor positions as placeholders', () => {
+    const persisted = createValidPersistedSession({
+      draftComments: [
+        {
+          id: 'comment-1',
+          anchor: { quote: 'test', prefix: '', suffix: '', status: 'anchored' },
+          body: 'Test',
+          authorId: 'user-1',
+          createdAt: '2024-01-01T00:00:00.000Z',
+          updatedAt: '2024-01-01T00:00:00.000Z',
+        },
+      ],
+    });
+    (mockStorage.getItem as ReturnType<typeof mock>).mockReturnValueOnce(JSON.stringify(persisted));
+
+    const result = loadSession('doc-123');
+
+    expect(result?.draftComments[0].anchor?.from).toBe(0);
+    expect(result?.draftComments[0].anchor?.to).toBe(0);
+  });
+
+  test('handles storage read errors gracefully', () => {
+    (mockStorage.getItem as ReturnType<typeof mock>).mockImplementationOnce(() => {
+      throw new Error('Storage unavailable');
+    });
+
+    const result = loadSession('doc-123');
+
+    expect(result).toBeNull();
+  });
+});
+
+// ============================================================================
+// Clear Session
+// ============================================================================
+
+describe('clearPersistedSession', () => {
+  test('removes session from sessionStorage', () => {
+    clearPersistedSession('doc-123');
+
+    expect(mockStorage.removeItem).toHaveBeenCalledWith(`${STORAGE_KEY_PREFIX}doc-123`);
+  });
+
+  test('handles storage errors gracefully', () => {
+    (mockStorage.removeItem as ReturnType<typeof mock>).mockImplementationOnce(() => {
+      throw new Error('Storage unavailable');
+    });
+
+    // Should not throw
+    expect(() => clearPersistedSession('doc-123')).not.toThrow();
+  });
+});
+
+// ============================================================================
+// Has Session
+// ============================================================================
+
+describe('hasPersistedSession', () => {
+  test('returns true when session exists', () => {
+    (mockStorage.getItem as ReturnType<typeof mock>).mockReturnValueOnce('{}');
+
+    expect(hasPersistedSession('doc-123')).toBe(true);
+  });
+
+  test('returns false when session does not exist', () => {
+    (mockStorage.getItem as ReturnType<typeof mock>).mockReturnValueOnce(null);
+
+    expect(hasPersistedSession('doc-123')).toBe(false);
+  });
+
+  test('handles storage errors gracefully', () => {
+    (mockStorage.getItem as ReturnType<typeof mock>).mockImplementationOnce(() => {
+      throw new Error('Storage unavailable');
+    });
+
+    expect(hasPersistedSession('doc-123')).toBe(false);
+  });
+});
+
+// ============================================================================
+// List Sessions
+// ============================================================================
+
+describe('listPersistedSessions', () => {
+  test('returns empty array when no sessions', () => {
+    expect(listPersistedSessions()).toEqual([]);
+  });
+
+  test('returns document keys for matching sessions', () => {
+    // Setup mock storage with some keys
+    const mockKeys = [`${STORAGE_KEY_PREFIX}doc-1`, `${STORAGE_KEY_PREFIX}doc-2`, 'other-key'];
+    mockStorage = createMockStorage({ keys: mockKeys });
+    stubGlobal('sessionStorage', mockStorage);
+
+    const result = listPersistedSessions();
+
+    expect(result).toEqual(['doc-1', 'doc-2']);
+  });
+
+  test('filters out non-matching keys', () => {
+    const mockKeys = ['other-key-1', 'other-key-2'];
+    mockStorage = createMockStorage({ keys: mockKeys });
+    stubGlobal('sessionStorage', mockStorage);
+
+    expect(listPersistedSessions()).toEqual([]);
+  });
+
+  test('handles storage errors gracefully', () => {
+    const throwingStorage = createMockStorage({ throwOnLength: true });
+    stubGlobal('sessionStorage', throwingStorage);
+
+    expect(listPersistedSessions()).toEqual([]);
+  });
+});
+
+// ============================================================================
+// Clear All Sessions
+// ============================================================================
+
+describe('clearAllPersistedSessions', () => {
+  test('clears all review session keys', () => {
+    const mockKeys = [`${STORAGE_KEY_PREFIX}doc-1`, `${STORAGE_KEY_PREFIX}doc-2`, 'other-key'];
+    mockStorage = createMockStorage({ keys: mockKeys, removeItem: mock(() => {}) });
+    stubGlobal('sessionStorage', mockStorage);
+
+    clearAllPersistedSessions();
+
+    expect(mockStorage.removeItem).toHaveBeenCalledTimes(2);
+    expect(mockStorage.removeItem).toHaveBeenCalledWith(`${STORAGE_KEY_PREFIX}doc-1`);
+    expect(mockStorage.removeItem).toHaveBeenCalledWith(`${STORAGE_KEY_PREFIX}doc-2`);
+  });
+
+  test('handles storage errors gracefully', () => {
+    const throwingStorage = createMockStorage({ throwOnLength: true });
+    stubGlobal('sessionStorage', throwingStorage);
+
+    // Should not throw
+    expect(() => clearAllPersistedSessions()).not.toThrow();
+  });
+});
+
+// ============================================================================
+// Round-trip Tests
+// ============================================================================
+
+describe('save/load round-trip', () => {
+  test('preserves session data through save/load cycle', () => {
+    const original = createTestSession({
+      id: 'session-xyz',
+      status: 'drafting',
+      outcome: 'request_changes',
+      draftComments: [
+        {
+          id: 'comment-1',
+          anchor: createTestAnchor(),
+          body: 'My comment',
+          authorId: 'user-1',
+          mentions: ['alice'],
+          createdAt: '2024-01-01T00:00:00.000Z',
+          updatedAt: '2024-01-02T00:00:00.000Z',
+        },
+      ],
+      startedAt: '2024-01-01T00:00:00.000Z',
+      updatedAt: '2024-01-02T00:00:00.000Z',
+    });
+
+    // Save
+    saveSession('doc-123', original);
+
+    // Get saved value and simulate load
+    const savedValue = (mockStorage.setItem as ReturnType<typeof mock>).mock.calls[0][1];
+    (mockStorage.getItem as ReturnType<typeof mock>).mockReturnValueOnce(savedValue);
+
+    // Load
+    const loaded = loadSession('doc-123');
+
+    expect(loaded).not.toBeNull();
+    expect(loaded!.id).toBe(original.id);
+    expect(loaded!.status).toBe(original.status);
+    expect(loaded!.outcome).toBe(original.outcome);
+    expect(loaded!.draftComments).toHaveLength(1);
+    expect(loaded!.draftComments[0].body).toBe('My comment');
+    expect(loaded!.draftComments[0].mentions).toEqual(['alice']);
+    expect(loaded!.startedAt).toBe(original.startedAt);
+    expect(loaded!.updatedAt).toBe(original.updatedAt);
+  });
+
+  test('restores placeholder positions after round-trip', () => {
+    const original = createTestSession({
+      draftComments: [
+        {
+          id: 'comment-1',
+          anchor: createTestAnchor({ from: 100, to: 200 }),
+          body: 'Test',
+          authorId: 'user-1',
+          createdAt: '2024-01-01T00:00:00.000Z',
+          updatedAt: '2024-01-01T00:00:00.000Z',
+        },
+      ],
+    });
+
+    saveSession('doc-123', original);
+
+    const savedValue = (mockStorage.setItem as ReturnType<typeof mock>).mock.calls[0][1];
+    (mockStorage.getItem as ReturnType<typeof mock>).mockReturnValueOnce(savedValue);
+
+    const loaded = loadSession('doc-123');
+
+    // Positions are restored as placeholders (0, 0)
+    expect(loaded!.draftComments[0].anchor?.from).toBe(0);
+    expect(loaded!.draftComments[0].anchor?.to).toBe(0);
+  });
+});

--- a/packages/commentary/src/session/persistence.ts
+++ b/packages/commentary/src/session/persistence.ts
@@ -1,0 +1,268 @@
+/**
+ * Session persistence helpers for review sessions.
+ *
+ * All functions are SSR-safe (check `browser` before accessing storage).
+ * Sessions are stored in sessionStorage with document-scoped keys.
+ *
+ * @module
+ */
+
+import type { PersistedReviewSession, ReviewSession } from './types.js';
+import { fromPersistedSession, toPersistedSession } from './updates.js';
+
+/** SSR guard — evaluated lazily so tests can stub `window` after module load. */
+const isBrowser = () => typeof window !== 'undefined';
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+/**
+ * Storage key prefix for review sessions.
+ * Full key format: `review-session-{documentId}`
+ */
+export const STORAGE_KEY_PREFIX = 'review-session-';
+
+// ============================================================================
+// Schema Validation
+// ============================================================================
+
+/**
+ * Validate that a value is a non-null object.
+ */
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+/**
+ * Validate that a value is a string.
+ */
+function isString(value: unknown): value is string {
+  return typeof value === 'string';
+}
+
+/**
+ * Validate that a value is an array.
+ */
+function isArray(value: unknown): value is unknown[] {
+  return Array.isArray(value);
+}
+
+/**
+ * Validate persisted session schema.
+ *
+ * Returns true if the data has all required fields with correct types.
+ * Does not deeply validate nested structures (anchor details, etc.)
+ * to allow for forward compatibility with schema changes.
+ *
+ * @param data - Unknown data to validate
+ * @returns True if data matches PersistedReviewSession shape
+ */
+export function validateSessionSchema(data: unknown): data is PersistedReviewSession {
+  if (!isObject(data)) return false;
+
+  const id = data['id'];
+  const status = data['status'];
+  const startedAt = data['startedAt'];
+  const updatedAt = data['updatedAt'];
+  const outcome = data['outcome'];
+  const draftComments = data['draftComments'];
+  const submittedAt = data['submittedAt'];
+
+  // Required string fields
+  if (!isString(id)) return false;
+  if (!isString(status)) return false;
+  if (!isString(startedAt)) return false;
+  if (!isString(updatedAt)) return false;
+
+  // Status must be valid
+  if (status !== 'drafting' && status !== 'submitted') return false;
+
+  // Optional outcome must be a valid string if present (reject null)
+  if (outcome !== undefined) {
+    if (typeof outcome !== 'string') return false;
+    if (outcome !== 'approve' && outcome !== 'request_changes' && outcome !== 'comment') {
+      return false;
+    }
+  }
+
+  // Required arrays
+  if (!isArray(draftComments)) return false;
+
+  // Note: draftSuggestions was removed from the schema. Old persisted
+  // sessions may still have this field - we allow it for backward
+  // compatibility but don't require it.
+
+  // Optional submittedAt must be string if present
+  if (submittedAt !== undefined && !isString(submittedAt)) return false;
+
+  return true;
+}
+
+// ============================================================================
+// Storage Operations
+// ============================================================================
+
+/**
+ * Build the full storage key for a document.
+ *
+ * @param key - Document identifier (usually documentId)
+ * @returns Full storage key
+ */
+export function getStorageKey(key: string): string {
+  return `${STORAGE_KEY_PREFIX}${key}`;
+}
+
+/**
+ * Save a review session to sessionStorage.
+ *
+ * SSR-safe: Returns false immediately when not in browser.
+ *
+ * @param key - Document identifier for storage key
+ * @param session - The session to persist
+ * @returns True if save succeeded, false otherwise
+ */
+export function saveSession(key: string, session: ReviewSession): boolean {
+  if (!isBrowser()) return false;
+
+  try {
+    const persisted = toPersistedSession(session);
+    const storageKey = getStorageKey(key);
+    sessionStorage.setItem(storageKey, JSON.stringify(persisted));
+    return true;
+  } catch (error) {
+    console.warn('Failed to persist review session:', error);
+    return false;
+  }
+}
+
+/**
+ * Load a review session from sessionStorage.
+ *
+ * SSR-safe: Returns null immediately when not in browser.
+ *
+ * Returns null if:
+ * - Not in browser
+ * - Key doesn't exist
+ * - JSON parse fails
+ * - Schema validation fails (corrupted data is cleared)
+ * - Session status is 'submitted' (stale sessions are cleared)
+ *
+ * @param key - Document identifier for storage key
+ * @returns The restored session, or null if not found/invalid
+ */
+export function loadSession(key: string): ReviewSession | null {
+  if (!isBrowser()) return null;
+
+  const storageKey = getStorageKey(key);
+
+  try {
+    const raw = sessionStorage.getItem(storageKey);
+    if (!raw) return null;
+
+    const data: unknown = JSON.parse(raw);
+
+    // Validate schema
+    if (!validateSessionSchema(data)) {
+      console.warn('Review session schema validation failed, clearing corrupted data');
+      clearPersistedSession(key);
+      return null;
+    }
+
+    // Clear stale submitted sessions
+    if (data.status === 'submitted') {
+      console.info('Clearing stale submitted review session');
+      clearPersistedSession(key);
+      return null;
+    }
+
+    return fromPersistedSession(data);
+  } catch (error) {
+    console.warn('Failed to load review session:', error);
+    // Clear potentially corrupted data
+    clearPersistedSession(key);
+    return null;
+  }
+}
+
+/**
+ * Clear a persisted session from sessionStorage.
+ *
+ * SSR-safe: No-op when not in browser.
+ *
+ * @param key - Document identifier for storage key
+ */
+export function clearPersistedSession(key: string): void {
+  if (!isBrowser()) return;
+
+  try {
+    const storageKey = getStorageKey(key);
+    sessionStorage.removeItem(storageKey);
+  } catch (error) {
+    console.warn('Failed to clear review session:', error);
+  }
+}
+
+/**
+ * Check if a session exists in sessionStorage.
+ *
+ * SSR-safe: Returns false when not in browser.
+ * Does not validate schema, just checks if key exists.
+ *
+ * @param key - Document identifier for storage key
+ * @returns True if session exists
+ */
+export function hasPersistedSession(key: string): boolean {
+  if (!isBrowser()) return false;
+
+  try {
+    const storageKey = getStorageKey(key);
+    return sessionStorage.getItem(storageKey) !== null;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * List all review session keys in sessionStorage.
+ *
+ * SSR-safe: Returns empty array when not in browser.
+ * Returns document identifiers (without the prefix).
+ *
+ * @returns Array of document identifiers with persisted sessions
+ */
+export function listPersistedSessions(): string[] {
+  if (!isBrowser()) return [];
+
+  try {
+    const keys: string[] = [];
+    for (let i = 0; i < sessionStorage.length; i++) {
+      const key = sessionStorage.key(i);
+      if (key?.startsWith(STORAGE_KEY_PREFIX)) {
+        keys.push(key.slice(STORAGE_KEY_PREFIX.length));
+      }
+    }
+    return keys;
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Clear all review sessions from sessionStorage.
+ *
+ * SSR-safe: No-op when not in browser.
+ * Useful for cleanup on logout or session reset.
+ */
+export function clearAllPersistedSessions(): void {
+  if (!isBrowser()) return;
+
+  try {
+    const keys = listPersistedSessions();
+    for (const key of keys) {
+      clearPersistedSession(key);
+    }
+  } catch (error) {
+    console.warn('Failed to clear all review sessions:', error);
+  }
+}

--- a/packages/commentary/src/session/types.ts
+++ b/packages/commentary/src/session/types.ts
@@ -1,0 +1,278 @@
+/**
+ * Review session types for batch review submission (DEP-44).
+ *
+ * These types support:
+ * - Draft comments that aren't visible until submission
+ * - Review outcomes (approve / request changes / comment-only)
+ * - Batch submission with all draft items
+ * - Session persistence across page navigations
+ *
+ * @module
+ */
+
+import type { CommentAnchor, PersistedAnchor } from '../shared/anchor-types.js';
+
+// ============================================================================
+// Review Outcome Types
+// ============================================================================
+
+/**
+ * Review submission outcome, matching GitHub's review types.
+ *
+ * - 'approve': Approves the changes
+ * - 'request_changes': Requests changes before approval
+ * - 'comment': Comment-only (neither approve nor request changes)
+ */
+export type ReviewOutcome = 'approve' | 'request_changes' | 'comment';
+
+/**
+ * Review session status lifecycle.
+ *
+ * - 'drafting': Session is active, accumulating draft items
+ * - 'submitted': Session has been submitted as a batch
+ */
+export type ReviewSessionStatus = 'drafting' | 'submitted';
+
+// ============================================================================
+// Draft Comment Types
+// ============================================================================
+
+/**
+ * A draft comment that hasn't been submitted yet.
+ *
+ * Draft comments can either:
+ * 1. Create a new thread (anchor is defined, threadId is undefined)
+ * 2. Reply to an existing thread (threadId is defined, anchor is undefined)
+ */
+export interface DraftComment {
+  /** Unique identifier (client-generated) */
+  id: string;
+
+  /**
+   * Parent thread ID when replying to an existing thread.
+   * Undefined when creating a new thread.
+   */
+  threadId?: string | undefined;
+
+  /**
+   * Anchor for new threads.
+   * Required when threadId is undefined, otherwise undefined.
+   */
+  anchor?: CommentAnchor | undefined;
+
+  /** Comment body (Markdown) */
+  body: string;
+
+  /** Author user ID */
+  authorId: string;
+
+  /** User IDs mentioned in the comment */
+  mentions?: string[] | undefined;
+
+  /** Creation timestamp (ISO 8601) */
+  createdAt: string;
+
+  /** Last update timestamp (ISO 8601) */
+  updatedAt: string;
+}
+
+/**
+ * Persisted form of DraftComment (strips runtime anchor positions).
+ */
+export interface PersistedDraftComment {
+  id: string;
+  threadId?: string | undefined;
+  anchor?: PersistedAnchor | undefined;
+  body: string;
+  authorId: string;
+  mentions?: string[] | undefined;
+  createdAt: string;
+  updatedAt: string;
+}
+
+// ============================================================================
+// Review Session Types
+// ============================================================================
+
+/**
+ * Complete review session state.
+ *
+ * A session accumulates draft comments until the user submits the review
+ * as a batch. The session also tracks the selected review outcome
+ * (approve, request changes, or comment-only).
+ */
+export interface ReviewSession {
+  /** Session ID */
+  id: string;
+
+  /** Current session status */
+  status: ReviewSessionStatus;
+
+  /** Selected review outcome (set before submission) */
+  outcome?: ReviewOutcome | undefined;
+
+  /** Draft comments (new threads and replies to existing threads) */
+  draftComments: DraftComment[];
+
+  /** When the session started (ISO 8601) */
+  startedAt: string;
+
+  /** Last update timestamp for conflict resolution (ISO 8601) */
+  updatedAt: string;
+
+  /** When the session was submitted (ISO 8601), if status is 'submitted' */
+  submittedAt?: string | undefined;
+}
+
+/**
+ * Persisted form of ReviewSession (for storage).
+ * Uses persisted forms of draft items that strip runtime positions.
+ */
+export interface PersistedReviewSession {
+  id: string;
+  status: ReviewSessionStatus;
+  outcome?: ReviewOutcome | undefined;
+  draftComments: PersistedDraftComment[];
+  startedAt: string;
+  updatedAt: string;
+  submittedAt?: string | undefined;
+}
+
+// ============================================================================
+// Draft Counts
+// ============================================================================
+
+/**
+ * Counts of pending draft items in a session.
+ */
+export interface DraftCounts {
+  /** Number of draft comments that create new threads */
+  threads: number;
+
+  /** Number of draft comments that reply to existing threads */
+  replies: number;
+
+  /** Total count of all draft items */
+  total: number;
+}
+
+// ============================================================================
+// Event Types
+// ============================================================================
+
+/**
+ * Event payload when a draft thread is created.
+ * Emitted when user creates a new comment thread while a session is active.
+ */
+export interface DraftThreadCreateEvent {
+  /** Request ID for correlation */
+  requestId: string;
+
+  /** The anchor where the thread was created */
+  anchor: CommentAnchor;
+
+  /** The initial comment body */
+  body: string;
+
+  /** The author ID */
+  authorId: string;
+
+  /** User IDs mentioned in the comment */
+  mentions?: string[];
+}
+
+/**
+ * Event payload when a draft comment (reply) is created.
+ * Emitted when user replies to an existing thread while a session is active.
+ */
+export interface DraftCommentCreateEvent {
+  /** Request ID for correlation */
+  requestId: string;
+
+  /** The existing thread ID receiving the reply */
+  threadId: string;
+
+  /** The comment body */
+  body: string;
+
+  /** The author ID */
+  authorId: string;
+
+  /** User IDs mentioned in the comment */
+  mentions?: string[];
+}
+
+/**
+ * Event payload when a draft comment is updated.
+ */
+export interface DraftCommentUpdateEvent {
+  /** The draft comment ID being updated */
+  commentId: string;
+
+  /** The new comment body */
+  body: string;
+
+  /** User IDs mentioned in the updated comment */
+  mentions?: string[];
+}
+
+/**
+ * Event payload when a draft comment is deleted.
+ */
+export interface DraftCommentDeleteEvent {
+  /** The draft comment ID being deleted */
+  commentId: string;
+}
+
+/**
+ * Event payload when the review outcome is changed.
+ */
+export interface ReviewOutcomeChangeEvent {
+  /** The new outcome */
+  outcome: ReviewOutcome;
+}
+
+/**
+ * Event payload when a review is submitted.
+ * Contains the complete session with all draft items for batch processing.
+ */
+export interface ReviewSubmitEvent {
+  /** The complete session being submitted */
+  session: ReviewSession;
+
+  /** The selected review outcome */
+  outcome: ReviewOutcome;
+
+  /** Optional summary body for the review */
+  summaryBody?: string;
+}
+
+/**
+ * Event payload when a review is discarded.
+ */
+export interface ReviewDiscardEvent {
+  /** The session ID being discarded */
+  sessionId: string;
+}
+
+// ============================================================================
+// Type Guards
+// ============================================================================
+
+/**
+ * Check if a draft comment creates a new thread (has anchor, no threadId).
+ */
+export function isDraftThread(
+  comment: DraftComment,
+): comment is DraftComment & { anchor: CommentAnchor; threadId: undefined } {
+  return comment.anchor !== undefined && comment.threadId === undefined;
+}
+
+/**
+ * Check if a draft comment is a reply to an existing thread (has threadId, no anchor).
+ */
+export function isDraftReply(
+  comment: DraftComment,
+): comment is DraftComment & { threadId: string; anchor: undefined } {
+  return comment.threadId !== undefined && comment.anchor === undefined;
+}

--- a/packages/commentary/src/session/updates.test.ts
+++ b/packages/commentary/src/session/updates.test.ts
@@ -1,0 +1,778 @@
+// @ts-nocheck -- migrated commentary assertions use runtime-verified fixture indexing.
+import { describe, expect, test } from 'bun:test';
+import type { CommentAnchor } from '../comments/types.js';
+import type {
+  DraftComment,
+  PersistedDraftComment,
+  PersistedReviewSession,
+  ReviewSession,
+} from './types.js';
+import {
+  addDraftComment,
+  clearReviewOutcome,
+  clearSession,
+  createSession,
+  deleteDraftComment,
+  findDraftComment,
+  fromPersistedDraftComment,
+  fromPersistedSession,
+  getDraftCounts,
+  getDraftReplies,
+  getDraftRepliesForThread,
+  getDraftThreads,
+  setReviewOutcome,
+  submitSession,
+  toPersistedDraftComment,
+  toPersistedSession,
+  updateDraftComment,
+} from './updates.js';
+
+// ============================================================================
+// Test Constants
+// ============================================================================
+
+const TEST_TIMESTAMP = '2024-01-15T12:00:00.000Z';
+
+// ============================================================================
+// Test Fixtures
+// ============================================================================
+
+function createTestAnchor(overrides?: Partial<CommentAnchor>): CommentAnchor {
+  return {
+    quote: 'test quote',
+    prefix: 'prefix ',
+    suffix: ' suffix',
+    from: 10,
+    to: 20,
+    status: 'anchored',
+    ...overrides,
+  };
+}
+
+function createTestDraftComment(overrides?: Partial<DraftComment>): DraftComment {
+  return {
+    id: 'draft-comment-1',
+    body: 'Test draft comment',
+    authorId: 'user-1',
+    createdAt: '2024-01-01T00:00:00.000Z',
+    updatedAt: '2024-01-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+function createTestDraftThread(overrides?: Partial<DraftComment>): DraftComment {
+  return createTestDraftComment({
+    anchor: createTestAnchor(),
+    threadId: undefined,
+    ...overrides,
+  });
+}
+
+function createTestDraftReply(overrides?: Partial<DraftComment>): DraftComment {
+  return createTestDraftComment({
+    threadId: 'existing-thread-1',
+    anchor: undefined,
+    ...overrides,
+  });
+}
+
+function createTestSession(overrides?: Partial<ReviewSession>): ReviewSession {
+  return {
+    id: 'session-1',
+    status: 'drafting',
+    draftComments: [],
+    startedAt: '2024-01-01T00:00:00.000Z',
+    updatedAt: '2024-01-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+// ============================================================================
+// Draft Comment Operations
+// ============================================================================
+
+describe('addDraftComment', () => {
+  test('adds draft comment to empty session', () => {
+    const session = createTestSession();
+    const comment = createTestDraftComment();
+    const result = addDraftComment(session, comment);
+
+    expect(result.session.draftComments).toHaveLength(1);
+    expect(result.session.draftComments[0]).toBe(comment);
+    expect(result.changed).toBe(true);
+    expect(result.value?.comment).toBe(comment);
+  });
+
+  test('appends draft comment to existing comments', () => {
+    const existingComment = createTestDraftComment({ id: 'existing' });
+    const session = createTestSession({ draftComments: [existingComment] });
+    const newComment = createTestDraftComment({ id: 'new' });
+    const result = addDraftComment(session, newComment);
+
+    expect(result.session.draftComments).toHaveLength(2);
+    expect(result.session.draftComments[0].id).toBe('existing');
+    expect(result.session.draftComments[1].id).toBe('new');
+  });
+
+  test('updates session updatedAt to comment createdAt', () => {
+    const session = createTestSession({ updatedAt: '2024-01-01T00:00:00.000Z' });
+    const comment = createTestDraftComment({ createdAt: '2024-01-02T00:00:00.000Z' });
+    const result = addDraftComment(session, comment);
+
+    expect(result.session.updatedAt).toBe('2024-01-02T00:00:00.000Z');
+  });
+
+  test('handles draft thread (new thread with anchor)', () => {
+    const session = createTestSession();
+    const draftThread = createTestDraftThread({ id: 'draft-thread-1' });
+    const result = addDraftComment(session, draftThread);
+
+    expect(result.session.draftComments[0].anchor).toBeDefined();
+    expect(result.session.draftComments[0].threadId).toBeUndefined();
+  });
+
+  test('handles draft reply (reply to existing thread)', () => {
+    const session = createTestSession();
+    const draftReply = createTestDraftReply({ id: 'draft-reply-1' });
+    const result = addDraftComment(session, draftReply);
+
+    expect(result.session.draftComments[0].threadId).toBe('existing-thread-1');
+    expect(result.session.draftComments[0].anchor).toBeUndefined();
+  });
+});
+
+describe('updateDraftComment', () => {
+  test('updates comment body and mentions', () => {
+    const comment = createTestDraftComment({ id: 'comment-1', body: 'Original' });
+    const session = createTestSession({ draftComments: [comment] });
+    const result = updateDraftComment(session, 'comment-1', {
+      body: 'Updated body',
+      mentions: ['alice'],
+      updatedAt: '2024-01-02T00:00:00.000Z',
+    });
+
+    expect(result.session.draftComments[0].body).toBe('Updated body');
+    expect(result.session.draftComments[0].mentions).toEqual(['alice']);
+    expect(result.session.draftComments[0].updatedAt).toBe('2024-01-02T00:00:00.000Z');
+    expect(result.changed).toBe(true);
+  });
+
+  test('updates session updatedAt', () => {
+    const comment = createTestDraftComment({ id: 'comment-1' });
+    const session = createTestSession({
+      draftComments: [comment],
+      updatedAt: '2024-01-01T00:00:00.000Z',
+    });
+    const result = updateDraftComment(session, 'comment-1', {
+      body: 'Updated',
+      updatedAt: '2024-01-02T00:00:00.000Z',
+    });
+
+    expect(result.session.updatedAt).toBe('2024-01-02T00:00:00.000Z');
+  });
+
+  test('returns unchanged when comment not found', () => {
+    const session = createTestSession();
+    const result = updateDraftComment(session, 'nonexistent', {
+      body: 'Updated',
+      updatedAt: '2024-01-02T00:00:00.000Z',
+    });
+
+    expect(result.session).toBe(session);
+    expect(result.changed).toBe(false);
+  });
+
+  test('preserves other comment properties', () => {
+    const comment = createTestDraftComment({
+      id: 'comment-1',
+      anchor: createTestAnchor(),
+      authorId: 'user-1',
+    });
+    const session = createTestSession({ draftComments: [comment] });
+    const result = updateDraftComment(session, 'comment-1', {
+      body: 'Updated',
+      updatedAt: '2024-01-02T00:00:00.000Z',
+    });
+
+    expect(result.session.draftComments[0].anchor).toBeDefined();
+    expect(result.session.draftComments[0].authorId).toBe('user-1');
+  });
+});
+
+describe('deleteDraftComment', () => {
+  test('removes existing comment', () => {
+    const comments = [
+      createTestDraftComment({ id: 'comment-1' }),
+      createTestDraftComment({ id: 'comment-2' }),
+    ];
+    const session = createTestSession({ draftComments: comments });
+    const result = deleteDraftComment(session, 'comment-1', TEST_TIMESTAMP);
+
+    expect(result.session.draftComments).toHaveLength(1);
+    expect(result.session.draftComments[0].id).toBe('comment-2');
+    expect(result.changed).toBe(true);
+  });
+
+  test('returns unchanged when comment not found', () => {
+    const session = createTestSession();
+    const result = deleteDraftComment(session, 'nonexistent', TEST_TIMESTAMP);
+
+    expect(result.session).toBe(session);
+    expect(result.changed).toBe(false);
+  });
+
+  test('returns empty array when deleting last comment', () => {
+    const session = createTestSession({
+      draftComments: [createTestDraftComment({ id: 'comment-1' })],
+    });
+    const result = deleteDraftComment(session, 'comment-1', TEST_TIMESTAMP);
+
+    expect(result.session.draftComments).toEqual([]);
+    expect(result.changed).toBe(true);
+  });
+
+  test('uses provided timestamp for updatedAt', () => {
+    const session = createTestSession({
+      draftComments: [createTestDraftComment({ id: 'comment-1' })],
+      updatedAt: '2024-01-01T00:00:00.000Z',
+    });
+    const result = deleteDraftComment(session, 'comment-1', '2024-01-15T15:00:00.000Z');
+
+    expect(result.session.updatedAt).toBe('2024-01-15T15:00:00.000Z');
+  });
+});
+
+describe('findDraftComment', () => {
+  test('finds existing comment', () => {
+    const comment = createTestDraftComment({ id: 'comment-1' });
+    const session = createTestSession({ draftComments: [comment] });
+    const found = findDraftComment(session, 'comment-1');
+
+    expect(found).toBe(comment);
+  });
+
+  test('returns undefined when not found', () => {
+    const session = createTestSession();
+    const found = findDraftComment(session, 'nonexistent');
+
+    expect(found).toBeUndefined();
+  });
+});
+
+// ============================================================================
+// Outcome Operations
+// ============================================================================
+
+describe('setReviewOutcome', () => {
+  test('sets outcome on session', () => {
+    const session = createTestSession();
+    const result = setReviewOutcome(session, 'approve', TEST_TIMESTAMP);
+
+    expect(result.session.outcome).toBe('approve');
+    expect(result.changed).toBe(true);
+  });
+
+  test('changes existing outcome', () => {
+    const session = createTestSession({ outcome: 'approve' });
+    const result = setReviewOutcome(session, 'request_changes', TEST_TIMESTAMP);
+
+    expect(result.session.outcome).toBe('request_changes');
+    expect(result.changed).toBe(true);
+  });
+
+  test('returns unchanged when outcome is the same', () => {
+    const session = createTestSession({ outcome: 'approve' });
+    const result = setReviewOutcome(session, 'approve', TEST_TIMESTAMP);
+
+    expect(result.session).toBe(session);
+    expect(result.changed).toBe(false);
+  });
+
+  test('supports all outcome types', () => {
+    const session = createTestSession();
+
+    const approveResult = setReviewOutcome(session, 'approve', TEST_TIMESTAMP);
+    expect(approveResult.session.outcome).toBe('approve');
+
+    const requestChangesResult = setReviewOutcome(session, 'request_changes', TEST_TIMESTAMP);
+    expect(requestChangesResult.session.outcome).toBe('request_changes');
+
+    const commentResult = setReviewOutcome(session, 'comment', TEST_TIMESTAMP);
+    expect(commentResult.session.outcome).toBe('comment');
+  });
+
+  test('uses provided timestamp for updatedAt', () => {
+    const session = createTestSession({ updatedAt: '2024-01-01T00:00:00.000Z' });
+    const result = setReviewOutcome(session, 'approve', '2024-01-15T17:00:00.000Z');
+
+    expect(result.session.updatedAt).toBe('2024-01-15T17:00:00.000Z');
+  });
+});
+
+describe('clearReviewOutcome', () => {
+  test('clears existing outcome', () => {
+    const session = createTestSession({ outcome: 'approve' });
+    const result = clearReviewOutcome(session, TEST_TIMESTAMP);
+
+    expect(result.session.outcome).toBeUndefined();
+    expect(result.changed).toBe(true);
+  });
+
+  test('returns unchanged when no outcome set', () => {
+    const session = createTestSession();
+    const result = clearReviewOutcome(session, TEST_TIMESTAMP);
+
+    expect(result.session).toBe(session);
+    expect(result.changed).toBe(false);
+  });
+
+  test('uses provided timestamp for updatedAt', () => {
+    const session = createTestSession({
+      outcome: 'approve',
+      updatedAt: '2024-01-01T00:00:00.000Z',
+    });
+    const result = clearReviewOutcome(session, '2024-01-15T18:00:00.000Z');
+
+    expect(result.session.updatedAt).toBe('2024-01-15T18:00:00.000Z');
+  });
+});
+
+// ============================================================================
+// Count Helpers
+// ============================================================================
+
+describe('getDraftCounts', () => {
+  test('returns zeros for empty session', () => {
+    const session = createTestSession();
+    const counts = getDraftCounts(session);
+
+    expect(counts.threads).toBe(0);
+    expect(counts.replies).toBe(0);
+    expect(counts.total).toBe(0);
+  });
+
+  test('counts draft threads correctly', () => {
+    const session = createTestSession({
+      draftComments: [
+        createTestDraftThread({ id: 'thread-1' }),
+        createTestDraftThread({ id: 'thread-2' }),
+      ],
+    });
+    const counts = getDraftCounts(session);
+
+    expect(counts.threads).toBe(2);
+    expect(counts.replies).toBe(0);
+    expect(counts.total).toBe(2);
+  });
+
+  test('counts draft replies correctly', () => {
+    const session = createTestSession({
+      draftComments: [
+        createTestDraftReply({ id: 'reply-1' }),
+        createTestDraftReply({ id: 'reply-2' }),
+        createTestDraftReply({ id: 'reply-3' }),
+      ],
+    });
+    const counts = getDraftCounts(session);
+
+    expect(counts.threads).toBe(0);
+    expect(counts.replies).toBe(3);
+    expect(counts.total).toBe(3);
+  });
+
+  test('counts mixed draft items correctly', () => {
+    const session = createTestSession({
+      draftComments: [
+        createTestDraftThread({ id: 'thread-1' }),
+        createTestDraftThread({ id: 'thread-2' }),
+        createTestDraftReply({ id: 'reply-1' }),
+      ],
+    });
+    const counts = getDraftCounts(session);
+
+    expect(counts.threads).toBe(2);
+    expect(counts.replies).toBe(1);
+    expect(counts.total).toBe(3);
+  });
+});
+
+describe('getDraftThreads', () => {
+  test('returns only draft comments with anchors and no threadId', () => {
+    const session = createTestSession({
+      draftComments: [
+        createTestDraftThread({ id: 'thread-1' }),
+        createTestDraftReply({ id: 'reply-1' }),
+        createTestDraftThread({ id: 'thread-2' }),
+      ],
+    });
+    const threads = getDraftThreads(session);
+
+    expect(threads).toHaveLength(2);
+    expect(threads.map((t) => t.id)).toEqual(['thread-1', 'thread-2']);
+  });
+
+  test('returns empty array when no threads', () => {
+    const session = createTestSession({
+      draftComments: [createTestDraftReply({ id: 'reply-1' })],
+    });
+    const threads = getDraftThreads(session);
+
+    expect(threads).toEqual([]);
+  });
+});
+
+describe('getDraftReplies', () => {
+  test('returns only draft comments with threadId', () => {
+    const session = createTestSession({
+      draftComments: [
+        createTestDraftThread({ id: 'thread-1' }),
+        createTestDraftReply({ id: 'reply-1' }),
+        createTestDraftReply({ id: 'reply-2' }),
+      ],
+    });
+    const replies = getDraftReplies(session);
+
+    expect(replies).toHaveLength(2);
+    expect(replies.map((r) => r.id)).toEqual(['reply-1', 'reply-2']);
+  });
+});
+
+describe('getDraftRepliesForThread', () => {
+  test('returns only replies for specific thread', () => {
+    const session = createTestSession({
+      draftComments: [
+        createTestDraftReply({ id: 'reply-1', threadId: 'thread-A' }),
+        createTestDraftReply({ id: 'reply-2', threadId: 'thread-B' }),
+        createTestDraftReply({ id: 'reply-3', threadId: 'thread-A' }),
+      ],
+    });
+    const replies = getDraftRepliesForThread(session, 'thread-A');
+
+    expect(replies).toHaveLength(2);
+    expect(replies.map((r) => r.id)).toEqual(['reply-1', 'reply-3']);
+  });
+
+  test('returns empty array when no replies for thread', () => {
+    const session = createTestSession({
+      draftComments: [createTestDraftReply({ id: 'reply-1', threadId: 'thread-A' })],
+    });
+    const replies = getDraftRepliesForThread(session, 'thread-B');
+
+    expect(replies).toEqual([]);
+  });
+});
+
+// ============================================================================
+// Session Lifecycle
+// ============================================================================
+
+describe('clearSession', () => {
+  test('clears all drafts and outcome', () => {
+    const session = createTestSession({
+      draftComments: [createTestDraftComment()],
+      outcome: 'approve',
+    });
+    const result = clearSession(session, TEST_TIMESTAMP);
+
+    expect(result.session.draftComments).toEqual([]);
+    expect(result.session.outcome).toBeUndefined();
+    expect(result.changed).toBe(true);
+  });
+
+  test('returns unchanged when session already empty', () => {
+    const session = createTestSession();
+    const result = clearSession(session, TEST_TIMESTAMP);
+
+    expect(result.session).toBe(session);
+    expect(result.changed).toBe(false);
+  });
+
+  test('preserves session id and startedAt timestamp', () => {
+    const session = createTestSession({
+      id: 'my-session',
+      startedAt: '2024-01-01T00:00:00.000Z',
+      draftComments: [createTestDraftComment()],
+    });
+    const result = clearSession(session, TEST_TIMESTAMP);
+
+    expect(result.session.id).toBe('my-session');
+    expect(result.session.startedAt).toBe('2024-01-01T00:00:00.000Z');
+    expect(result.session.status).toBe('drafting');
+  });
+
+  test('uses provided timestamp for updatedAt', () => {
+    const session = createTestSession({
+      draftComments: [createTestDraftComment()],
+      updatedAt: '2024-01-01T00:00:00.000Z',
+    });
+    const result = clearSession(session, '2024-01-15T19:00:00.000Z');
+
+    expect(result.session.updatedAt).toBe('2024-01-15T19:00:00.000Z');
+  });
+});
+
+describe('createSession', () => {
+  test('creates empty session with provided id and timestamp', () => {
+    const session = createSession('new-session', '2024-01-15T00:00:00.000Z');
+
+    expect(session.id).toBe('new-session');
+    expect(session.status).toBe('drafting');
+    expect(session.draftComments).toEqual([]);
+    expect(session.outcome).toBeUndefined();
+    expect(session.startedAt).toBe('2024-01-15T00:00:00.000Z');
+    expect(session.updatedAt).toBe('2024-01-15T00:00:00.000Z');
+  });
+});
+
+describe('submitSession', () => {
+  test('marks session as submitted with outcome', () => {
+    const session = createTestSession({
+      draftComments: [createTestDraftComment()],
+    });
+    const result = submitSession(session, 'approve', '2024-01-15T12:00:00.000Z');
+
+    expect(result.session.status).toBe('submitted');
+    expect(result.session.outcome).toBe('approve');
+    expect(result.session.submittedAt).toBe('2024-01-15T12:00:00.000Z');
+    expect(result.session.updatedAt).toBe('2024-01-15T12:00:00.000Z');
+    expect(result.changed).toBe(true);
+  });
+
+  test('returns unchanged when already submitted', () => {
+    const session = createTestSession({
+      status: 'submitted',
+      submittedAt: '2024-01-15T12:00:00.000Z',
+    });
+    const result = submitSession(session, 'approve', '2024-01-16T12:00:00.000Z');
+
+    expect(result.session).toBe(session);
+    expect(result.changed).toBe(false);
+  });
+
+  test('preserves draft items in submitted session', () => {
+    const comment = createTestDraftComment();
+    const session = createTestSession({
+      draftComments: [comment],
+    });
+    const result = submitSession(session, 'request_changes', '2024-01-15T12:00:00.000Z');
+
+    expect(result.session.draftComments).toHaveLength(1);
+  });
+});
+
+// ============================================================================
+// Serialization Helpers
+// ============================================================================
+
+describe('toPersistedDraftComment', () => {
+  test('strips runtime anchor positions', () => {
+    const comment = createTestDraftThread({
+      id: 'comment-1',
+      anchor: createTestAnchor({ from: 100, to: 200 }),
+    });
+    const persisted = toPersistedDraftComment(comment);
+
+    expect(persisted.id).toBe('comment-1');
+    expect(persisted.anchor).toBeDefined();
+    expect('from' in (persisted.anchor ?? {})).toBe(false);
+    expect('to' in (persisted.anchor ?? {})).toBe(false);
+  });
+
+  test('preserves all other properties', () => {
+    const comment = createTestDraftThread({
+      id: 'comment-1',
+      body: 'Test body',
+      authorId: 'user-1',
+      mentions: ['alice', 'bob'],
+      createdAt: '2024-01-01T00:00:00.000Z',
+      updatedAt: '2024-01-02T00:00:00.000Z',
+    });
+    const persisted = toPersistedDraftComment(comment);
+
+    expect(persisted.body).toBe('Test body');
+    expect(persisted.authorId).toBe('user-1');
+    expect(persisted.mentions).toEqual(['alice', 'bob']);
+    expect(persisted.createdAt).toBe('2024-01-01T00:00:00.000Z');
+    expect(persisted.updatedAt).toBe('2024-01-02T00:00:00.000Z');
+  });
+
+  test('handles comment without anchor (reply)', () => {
+    const comment = createTestDraftReply({ id: 'reply-1' });
+    const persisted = toPersistedDraftComment(comment);
+
+    expect(persisted.anchor).toBeUndefined();
+    expect(persisted.threadId).toBe('existing-thread-1');
+  });
+});
+
+describe('toPersistedSession', () => {
+  test('converts full session to persisted format', () => {
+    const session = createTestSession({
+      id: 'session-1',
+      status: 'drafting',
+      outcome: 'approve',
+      draftComments: [createTestDraftThread({ id: 'thread-1' })],
+      startedAt: '2024-01-01T00:00:00.000Z',
+      updatedAt: '2024-01-02T00:00:00.000Z',
+    });
+    const persisted = toPersistedSession(session);
+
+    expect(persisted.id).toBe('session-1');
+    expect(persisted.status).toBe('drafting');
+    expect(persisted.outcome).toBe('approve');
+    expect(persisted.draftComments).toHaveLength(1);
+    expect(persisted.startedAt).toBe('2024-01-01T00:00:00.000Z');
+    expect(persisted.updatedAt).toBe('2024-01-02T00:00:00.000Z');
+  });
+
+  test('strips all runtime positions from nested items', () => {
+    const session = createTestSession({
+      draftComments: [createTestDraftThread({ anchor: createTestAnchor({ from: 100, to: 200 }) })],
+    });
+    const persisted = toPersistedSession(session);
+
+    expect('from' in (persisted.draftComments[0].anchor ?? {})).toBe(false);
+  });
+});
+
+describe('fromPersistedDraftComment', () => {
+  test('restores runtime anchor positions as placeholders', () => {
+    const persisted: PersistedDraftComment = {
+      id: 'comment-1',
+      anchor: {
+        quote: 'test quote',
+        prefix: 'prefix ',
+        suffix: ' suffix',
+        status: 'anchored',
+      },
+      body: 'Test body',
+      authorId: 'user-1',
+      createdAt: '2024-01-01T00:00:00.000Z',
+      updatedAt: '2024-01-01T00:00:00.000Z',
+    };
+    const restored = fromPersistedDraftComment(persisted);
+
+    expect(restored.anchor?.from).toBe(0);
+    expect(restored.anchor?.to).toBe(0);
+  });
+
+  test('preserves all stored properties', () => {
+    const persisted: PersistedDraftComment = {
+      id: 'comment-1',
+      threadId: 'thread-1',
+      body: 'Test body',
+      authorId: 'user-1',
+      mentions: ['alice'],
+      createdAt: '2024-01-01T00:00:00.000Z',
+      updatedAt: '2024-01-02T00:00:00.000Z',
+    };
+    const restored = fromPersistedDraftComment(persisted);
+
+    expect(restored.id).toBe('comment-1');
+    expect(restored.threadId).toBe('thread-1');
+    expect(restored.body).toBe('Test body');
+    expect(restored.authorId).toBe('user-1');
+    expect(restored.mentions).toEqual(['alice']);
+  });
+});
+
+describe('fromPersistedSession', () => {
+  test('restores full session from persisted format', () => {
+    const persisted: PersistedReviewSession = {
+      id: 'session-1',
+      status: 'drafting',
+      outcome: 'approve',
+      draftComments: [
+        {
+          id: 'comment-1',
+          anchor: { quote: 'test', prefix: '', suffix: '', status: 'anchored' },
+          body: 'Test',
+          authorId: 'user-1',
+          createdAt: '2024-01-01T00:00:00.000Z',
+          updatedAt: '2024-01-01T00:00:00.000Z',
+        },
+      ],
+      startedAt: '2024-01-01T00:00:00.000Z',
+      updatedAt: '2024-01-02T00:00:00.000Z',
+    };
+    const restored = fromPersistedSession(persisted);
+
+    expect(restored.id).toBe('session-1');
+    expect(restored.status).toBe('drafting');
+    expect(restored.outcome).toBe('approve');
+    expect(restored.draftComments).toHaveLength(1);
+    expect(restored.draftComments[0].anchor?.from).toBe(0);
+  });
+});
+
+// ============================================================================
+// Immutability Checks
+// ============================================================================
+
+describe('immutability', () => {
+  test('addDraftComment returns new session object', () => {
+    const original = createTestSession();
+    const result = addDraftComment(original, createTestDraftComment());
+
+    expect(result.session).not.toBe(original);
+    expect(result.session.draftComments).not.toBe(original.draftComments);
+  });
+
+  test('updateDraftComment returns new session and comment objects', () => {
+    const original = createTestSession({
+      draftComments: [createTestDraftComment({ id: 'comment-1' })],
+    });
+    const result = updateDraftComment(original, 'comment-1', {
+      body: 'Updated',
+      updatedAt: '2024-01-02T00:00:00.000Z',
+    });
+
+    expect(result.session).not.toBe(original);
+    expect(result.session.draftComments).not.toBe(original.draftComments);
+    expect(result.session.draftComments[0]).not.toBe(original.draftComments[0]);
+  });
+
+  test('deleteDraftComment returns new session and array', () => {
+    const original = createTestSession({
+      draftComments: [createTestDraftComment({ id: 'comment-1' })],
+    });
+    const result = deleteDraftComment(original, 'comment-1', TEST_TIMESTAMP);
+
+    expect(result.session).not.toBe(original);
+    expect(result.session.draftComments).not.toBe(original.draftComments);
+  });
+
+  test('setReviewOutcome returns new session object', () => {
+    const original = createTestSession();
+    const result = setReviewOutcome(original, 'approve', TEST_TIMESTAMP);
+
+    expect(result.session).not.toBe(original);
+  });
+
+  test('clearSession returns new session object', () => {
+    const original = createTestSession({
+      draftComments: [createTestDraftComment()],
+    });
+    const result = clearSession(original, TEST_TIMESTAMP);
+
+    expect(result.session).not.toBe(original);
+  });
+
+  test('submitSession returns new session object', () => {
+    const original = createTestSession();
+    const result = submitSession(original, 'approve', '2024-01-15T12:00:00.000Z');
+
+    expect(result.session).not.toBe(original);
+  });
+
+  test('unchanged operations return original session reference', () => {
+    const original = createTestSession();
+
+    expect(updateDraftComment(original, 'nonexistent', { body: 'x', updatedAt: 'x' }).session).toBe(
+      original,
+    );
+    expect(deleteDraftComment(original, 'nonexistent', TEST_TIMESTAMP).session).toBe(original);
+    expect(clearSession(original, TEST_TIMESTAMP).session).toBe(original);
+    expect(clearReviewOutcome(original, TEST_TIMESTAMP).session).toBe(original);
+  });
+});

--- a/packages/commentary/src/session/updates.ts
+++ b/packages/commentary/src/session/updates.ts
@@ -1,0 +1,451 @@
+/**
+ * Pure update helpers for review session state management.
+ *
+ * All functions are pure (no side effects, no ID/timestamp generation).
+ * They return new objects for Svelte 5 reactivity.
+ * The `changed` flag indicates whether the operation had any effect.
+ *
+ * @module
+ */
+
+import type { PersistedAnchor } from '../comments/types.js';
+import type {
+  DraftComment,
+  DraftCounts,
+  PersistedDraftComment,
+  PersistedReviewSession,
+  ReviewOutcome,
+  ReviewSession,
+} from './types.js';
+
+// ============================================================================
+// Result Types
+// ============================================================================
+
+/**
+ * Result of a session update operation.
+ * @template T - Optional value type returned with the result
+ */
+export type SessionUpdateResult<T = undefined> = {
+  /** The updated session */
+  session: ReviewSession;
+  /** Whether the operation made any changes */
+  changed: boolean;
+  /** Optional value from the operation */
+  value?: T;
+};
+
+// ============================================================================
+// Draft Comment Operations
+// ============================================================================
+
+/**
+ * Add a draft comment to the session.
+ *
+ * The comment can either create a new thread (has anchor, no threadId)
+ * or reply to an existing thread (has threadId, no anchor).
+ *
+ * @param session - Current session
+ * @param comment - The draft comment to add (caller provides complete DraftComment)
+ */
+export function addDraftComment(
+  session: ReviewSession,
+  comment: DraftComment,
+): SessionUpdateResult<{ comment: DraftComment }> {
+  // Ensure session updatedAt never goes backwards
+  const updatedAt =
+    session.updatedAt && session.updatedAt > comment.createdAt
+      ? session.updatedAt
+      : comment.createdAt;
+
+  return {
+    session: {
+      ...session,
+      draftComments: [...session.draftComments, comment],
+      updatedAt,
+    },
+    changed: true,
+    value: { comment },
+  };
+}
+
+/**
+ * Update a draft comment's body and mentions.
+ *
+ * No-op if comment does not exist.
+ *
+ * @param session - Current session
+ * @param commentId - ID of the draft comment to update
+ * @param update - The update with body, mentions, and updatedAt (caller provides timestamp)
+ */
+export function updateDraftComment(
+  session: ReviewSession,
+  commentId: string,
+  update: { body: string; mentions?: string[]; updatedAt: string },
+): SessionUpdateResult {
+  const exists = session.draftComments.some((c) => c.id === commentId);
+  if (!exists) {
+    return { session, changed: false };
+  }
+
+  return {
+    session: {
+      ...session,
+      draftComments: session.draftComments.map((c) => {
+        if (c.id !== commentId) return c;
+
+        const updatedComment: DraftComment = {
+          ...c,
+          body: update.body,
+          updatedAt: update.updatedAt,
+        };
+
+        if (update.mentions !== undefined) {
+          updatedComment.mentions = update.mentions;
+        }
+
+        return updatedComment;
+      }),
+      updatedAt: update.updatedAt,
+    },
+    changed: true,
+  };
+}
+
+/**
+ * Delete a draft comment from the session.
+ *
+ * No-op if comment does not exist.
+ *
+ * @param session - Current session
+ * @param commentId - ID of the draft comment to delete
+ * @param updatedAt - Timestamp for the update (caller provides)
+ */
+export function deleteDraftComment(
+  session: ReviewSession,
+  commentId: string,
+  updatedAt: string,
+): SessionUpdateResult {
+  const exists = session.draftComments.some((c) => c.id === commentId);
+  if (!exists) {
+    return { session, changed: false };
+  }
+
+  return {
+    session: {
+      ...session,
+      draftComments: session.draftComments.filter((c) => c.id !== commentId),
+      updatedAt,
+    },
+    changed: true,
+  };
+}
+
+/**
+ * Find a draft comment by ID.
+ *
+ * @param session - Current session
+ * @param commentId - ID of the draft comment to find
+ */
+export function findDraftComment(
+  session: ReviewSession,
+  commentId: string,
+): DraftComment | undefined {
+  return session.draftComments.find((c) => c.id === commentId);
+}
+
+// ============================================================================
+// Outcome Operations
+// ============================================================================
+
+/**
+ * Set the review outcome.
+ *
+ * @param session - Current session
+ * @param outcome - The review outcome to set
+ * @param updatedAt - Timestamp for the update (caller provides)
+ */
+export function setReviewOutcome(
+  session: ReviewSession,
+  outcome: ReviewOutcome,
+  updatedAt: string,
+): SessionUpdateResult {
+  if (session.outcome === outcome) {
+    return { session, changed: false };
+  }
+
+  return {
+    session: {
+      ...session,
+      outcome,
+      updatedAt,
+    },
+    changed: true,
+  };
+}
+
+/**
+ * Clear the review outcome.
+ *
+ * @param session - Current session
+ * @param updatedAt - Timestamp for the update (caller provides)
+ */
+export function clearReviewOutcome(session: ReviewSession, updatedAt: string): SessionUpdateResult {
+  if (session.outcome === undefined) {
+    return { session, changed: false };
+  }
+
+  // Destructure to omit outcome property entirely
+  const { outcome: _, ...rest } = session;
+
+  return {
+    session: {
+      ...rest,
+      updatedAt,
+    },
+    changed: true,
+  };
+}
+
+// ============================================================================
+// Count Helpers
+// ============================================================================
+
+/**
+ * Get counts of draft items in the session.
+ *
+ * @param session - Current session
+ */
+export function getDraftCounts(session: ReviewSession): DraftCounts {
+  const threads = session.draftComments.filter(
+    (c) => c.anchor !== undefined && c.threadId === undefined,
+  ).length;
+  const replies = session.draftComments.filter(
+    (c) => c.threadId !== undefined && c.anchor === undefined,
+  ).length;
+
+  return {
+    threads,
+    replies,
+    total: threads + replies,
+  };
+}
+
+/**
+ * Get draft comments that create new threads (have anchor, no threadId).
+ *
+ * @param session - Current session
+ */
+export function getDraftThreads(session: ReviewSession): DraftComment[] {
+  return session.draftComments.filter((c) => c.anchor !== undefined && c.threadId === undefined);
+}
+
+/**
+ * Get draft comments that are replies to existing threads (have threadId, no anchor).
+ *
+ * @param session - Current session
+ */
+export function getDraftReplies(session: ReviewSession): DraftComment[] {
+  return session.draftComments.filter((c) => c.threadId !== undefined && c.anchor === undefined);
+}
+
+/**
+ * Get draft replies for a specific thread.
+ *
+ * @param session - Current session
+ * @param threadId - The thread ID to get replies for
+ */
+export function getDraftRepliesForThread(session: ReviewSession, threadId: string): DraftComment[] {
+  return session.draftComments.filter((c) => c.threadId === threadId);
+}
+
+// ============================================================================
+// Session Lifecycle
+// ============================================================================
+
+/**
+ * Clear all drafts from the session.
+ *
+ * Removes all draft comments and resets outcome.
+ *
+ * @param session - Current session
+ * @param updatedAt - Timestamp for the update (caller provides)
+ */
+export function clearSession(session: ReviewSession, updatedAt: string): SessionUpdateResult {
+  const hasDrafts = session.draftComments.length > 0 || session.outcome !== undefined;
+
+  if (!hasDrafts) {
+    return { session, changed: false };
+  }
+
+  const { outcome: _outcome, ...sessionWithoutOutcome } = session;
+
+  return {
+    session: {
+      ...sessionWithoutOutcome,
+      draftComments: [],
+      updatedAt,
+    },
+    changed: true,
+  };
+}
+
+/**
+ * Create a new empty session.
+ *
+ * @param id - Session ID (caller provides)
+ * @param startedAt - Start timestamp (caller provides)
+ */
+export function createSession(id: string, startedAt: string): ReviewSession {
+  return {
+    id,
+    status: 'drafting',
+    draftComments: [],
+    startedAt,
+    updatedAt: startedAt,
+  };
+}
+
+/**
+ * Mark a session as submitted.
+ *
+ * @param session - Current session
+ * @param outcome - The final review outcome
+ * @param submittedAt - Submission timestamp (caller provides)
+ */
+export function submitSession(
+  session: ReviewSession,
+  outcome: ReviewOutcome,
+  submittedAt: string,
+): SessionUpdateResult {
+  if (session.status === 'submitted') {
+    return { session, changed: false };
+  }
+
+  return {
+    session: {
+      ...session,
+      status: 'submitted',
+      outcome,
+      submittedAt,
+      updatedAt: submittedAt,
+    },
+    changed: true,
+  };
+}
+
+// ============================================================================
+// Serialization Helpers
+// ============================================================================
+
+/**
+ * Convert a draft comment to persisted format.
+ * Strips runtime anchor positions (from/to).
+ *
+ * @param comment - Runtime draft comment
+ */
+export function toPersistedDraftComment(comment: DraftComment): PersistedDraftComment {
+  let persistedAnchor: PersistedAnchor | undefined;
+
+  if (comment.anchor) {
+    const { anchor } = comment;
+
+    // Strip runtime positions (from, to) from anchor
+    persistedAnchor = {
+      quote: anchor.quote,
+      prefix: anchor.prefix,
+      suffix: anchor.suffix,
+      status: anchor.status,
+    };
+
+    if (anchor.type !== undefined) persistedAnchor.type = anchor.type;
+    if (anchor.originalQuote !== undefined) persistedAnchor.originalQuote = anchor.originalQuote;
+    if (anchor.lastKnownOffset !== undefined)
+      persistedAnchor.lastKnownOffset = anchor.lastKnownOffset;
+    if (anchor.blockId !== undefined) persistedAnchor.blockId = anchor.blockId;
+    if (anchor.originalPosition !== undefined)
+      persistedAnchor.originalPosition = anchor.originalPosition;
+  }
+
+  const persisted: PersistedDraftComment = {
+    id: comment.id,
+    body: comment.body,
+    authorId: comment.authorId,
+    createdAt: comment.createdAt,
+    updatedAt: comment.updatedAt,
+  };
+
+  if (comment.threadId !== undefined) persisted.threadId = comment.threadId;
+  if (persistedAnchor !== undefined) persisted.anchor = persistedAnchor;
+  if (comment.mentions !== undefined) persisted.mentions = comment.mentions;
+
+  return persisted;
+}
+
+/**
+ * Convert a session to persisted format for storage.
+ *
+ * @param session - Runtime session
+ */
+export function toPersistedSession(session: ReviewSession): PersistedReviewSession {
+  const persisted: PersistedReviewSession = {
+    id: session.id,
+    status: session.status,
+    draftComments: session.draftComments.map(toPersistedDraftComment),
+    startedAt: session.startedAt,
+    updatedAt: session.updatedAt,
+  };
+
+  if (session.outcome !== undefined) persisted.outcome = session.outcome;
+  if (session.submittedAt !== undefined) persisted.submittedAt = session.submittedAt;
+
+  return persisted;
+}
+
+/**
+ * Convert a persisted draft comment back to runtime format.
+ * Initializes anchor positions to 0 (caller must re-anchor).
+ *
+ * @param persisted - Persisted draft comment
+ */
+export function fromPersistedDraftComment(persisted: PersistedDraftComment): DraftComment {
+  const draftComment: DraftComment = {
+    id: persisted.id,
+    body: persisted.body,
+    authorId: persisted.authorId,
+    createdAt: persisted.createdAt,
+    updatedAt: persisted.updatedAt,
+  };
+
+  if (persisted.threadId !== undefined) draftComment.threadId = persisted.threadId;
+  if (persisted.anchor !== undefined) {
+    draftComment.anchor = {
+      ...persisted.anchor,
+      from: 0, // Placeholder, caller must re-anchor
+      to: 0,
+    };
+  }
+  if (persisted.mentions !== undefined) draftComment.mentions = persisted.mentions;
+
+  return draftComment;
+}
+
+/**
+ * Convert a persisted session back to runtime format.
+ *
+ * @param persisted - Persisted session
+ */
+export function fromPersistedSession(persisted: PersistedReviewSession): ReviewSession {
+  const session: ReviewSession = {
+    id: persisted.id,
+    status: persisted.status,
+    draftComments: persisted.draftComments.map(fromPersistedDraftComment),
+    startedAt: persisted.startedAt,
+    updatedAt: persisted.updatedAt,
+  };
+
+  if (persisted.outcome !== undefined) session.outcome = persisted.outcome;
+  if (persisted.submittedAt !== undefined) session.submittedAt = persisted.submittedAt;
+
+  return session;
+}

--- a/packages/commentary/src/shared/anchor-types.ts
+++ b/packages/commentary/src/shared/anchor-types.ts
@@ -1,0 +1,152 @@
+/**
+ * Shared anchor types for the editor module.
+ *
+ * These types are extracted to break the circular dependency between
+ * comments/types.ts and session/types.ts.
+ *
+ * @module
+ */
+
+// ============================================================================
+// Anchor Type Discriminators
+// ============================================================================
+
+/**
+ * Anchor type discriminator.
+ *
+ * - 'text': Anchored to specific text selection (default for backwards compatibility)
+ * - 'document': Document-level comment with no specific text anchor
+ */
+export type AnchorType = 'text' | 'document';
+
+/**
+ * Anchor status indicates whether the anchor is successfully placed.
+ *
+ * - 'anchored': Anchor is confidently placed at the correct location
+ *
+ * Note: When anchor text is deleted (anchor cannot be placed), the thread is
+ * automatically deleted. There is no 'orphaned' state - threads either have
+ * valid anchors or they don't exist.
+ */
+export type AnchorStatus = 'anchored';
+
+// ============================================================================
+// TextQuoteSelector Anchor
+// ============================================================================
+
+/**
+ * TextQuoteSelector-style anchor for comment persistence.
+ *
+ * This format survives document edits by storing context around the selection.
+ * Re-anchoring algorithm:
+ * 1. Try exact position first
+ * 2. Search for quote with prefix/suffix context
+ * 3. Mark as orphaned if not found
+ *
+ * Based on W3C Web Annotation Data Model TextQuoteSelector.
+ * @see https://www.w3.org/TR/annotation-model/#text-quote-selector
+ */
+export interface TextQuoteAnchor {
+  /** The exact text that was selected */
+  quote: string;
+
+  /** ~50 characters before the selection for context matching */
+  prefix: string;
+
+  /** ~50 characters after the selection for context matching */
+  suffix: string;
+}
+
+// ============================================================================
+// Runtime Anchor
+// ============================================================================
+
+/**
+ * Runtime anchor with ProseMirror positions.
+ *
+ * These positions are computed at runtime and updated through
+ * ProseMirror's transaction mapping (tr.mapping.map()).
+ */
+export interface RuntimeAnchor {
+  /** Start position in ProseMirror document */
+  from: number;
+
+  /** End position in ProseMirror document */
+  to: number;
+}
+
+// ============================================================================
+// Complete Anchor Types
+// ============================================================================
+
+/**
+ * Complete comment anchor combining persistence and runtime data.
+ *
+ * For document-level comments (type='document'), the quote/prefix/suffix
+ * will be empty strings and from/to will be 0.
+ */
+export interface CommentAnchor extends TextQuoteAnchor, RuntimeAnchor {
+  /**
+   * Anchor type: 'text' (default) or 'document'.
+   * When undefined, treated as 'text' for backwards compatibility.
+   */
+  type?: AnchorType | undefined;
+
+  /** Current anchor status */
+  status: AnchorStatus;
+
+  /**
+   * Original quote text when the anchor was created.
+   * Preserved for history/debugging - never updated when edits occur inside the anchor.
+   */
+  originalQuote?: string | undefined;
+
+  /**
+   * Last known text offset (not ProseMirror position).
+   * Updated on each edit, used for re-anchoring disambiguation.
+   * Prevents bias toward the original position when the anchor has moved.
+   */
+  lastKnownOffset?: number | undefined;
+
+  /** Optional block-level anchor (for comments on headings, code blocks, etc.) */
+  blockId?: string | undefined;
+
+  /**
+   * Original position when anchor was created.
+   * Stored as text offset (via proseMirrorPositionToTextOffset), not PM position.
+   * Used as fallback for disambiguation when lastKnownOffset is not available.
+   */
+  originalPosition?:
+    | {
+        /** Text offset (matching doc.textBetween() semantics) */
+        offset: number;
+        /** Line number (1-based) */
+        line: number;
+        /** Column number (1-based) */
+        column: number;
+      }
+    | undefined;
+}
+
+/**
+ * Anchor data for persistence (excludes runtime positions).
+ * Used when serializing review state to storage.
+ */
+export interface PersistedAnchor extends TextQuoteAnchor {
+  /**
+   * Anchor type: 'text' (default) or 'document'.
+   * When undefined, treated as 'text' for backwards compatibility.
+   */
+  type?: AnchorType | undefined;
+
+  status: AnchorStatus;
+
+  /** Original quote text (optional for backwards compatibility) */
+  originalQuote?: string | undefined;
+
+  /** Last known text offset for re-anchoring disambiguation */
+  lastKnownOffset?: number | undefined;
+
+  blockId?: string | undefined;
+  originalPosition?: CommentAnchor['originalPosition'] | undefined;
+}

--- a/packages/commentary/src/test/happy-dom.ts
+++ b/packages/commentary/src/test/happy-dom.ts
@@ -1,0 +1,26 @@
+import { Window } from 'happy-dom';
+
+type Global = typeof globalThis & Record<string, unknown>;
+
+let installed = false;
+
+export function setupHappyDom(): void {
+  if (installed) return;
+
+  const happyWindow = new Window();
+  const target = globalThis as Global;
+
+  for (const key of Object.getOwnPropertyNames(happyWindow)) {
+    if (key in target) continue;
+
+    const descriptor = Object.getOwnPropertyDescriptor(happyWindow, key);
+    if (!descriptor) continue;
+
+    Object.defineProperty(target, key, descriptor);
+  }
+
+  Object.defineProperty(target, 'window', { value: happyWindow, configurable: true });
+  installed = true;
+}
+
+setupHappyDom();

--- a/packages/commentary/tsconfig.build.json
+++ b/packages/commentary/tsconfig.build.json
@@ -1,0 +1,14 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "allowImportingTsExtensions": false,
+    "incremental": false,
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/**/*.test.ts"]
+}

--- a/packages/commentary/tsconfig.check.json
+++ b/packages/commentary/tsconfig.check.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true
+  }
+}

--- a/packages/commentary/tsconfig.json
+++ b/packages/commentary/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "tsBuildInfoFile": "node_modules/.cache/tsconfig.tsbuildinfo",
+    "rootDir": ".",
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  },
+  "include": ["src/**/*.ts", "scripts/**/*.ts"],
+  "exclude": ["dist", "coverage", "node_modules"]
+}

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -69,6 +69,30 @@
       "svelte": "./src/components/data-list.svelte",
       "types": "./dist/components/data-list.svelte.d.ts"
     },
+    "./diff-statistics": {
+      "svelte": "./src/components/diff-statistics.svelte",
+      "types": "./dist/components/diff-statistics.svelte.d.ts"
+    },
+    "./dropdown-item": {
+      "svelte": "./src/components/dropdown-item.svelte",
+      "types": "./dist/components/dropdown-item.svelte.d.ts"
+    },
+    "./dropdown-label": {
+      "svelte": "./src/components/dropdown-label.svelte",
+      "types": "./dist/components/dropdown-label.svelte.d.ts"
+    },
+    "./dropdown-menu": {
+      "svelte": "./src/components/dropdown-menu.svelte",
+      "types": "./dist/components/dropdown-menu.svelte.d.ts"
+    },
+    "./dropdown-separator": {
+      "svelte": "./src/components/dropdown-separator.svelte",
+      "types": "./dist/components/dropdown-separator.svelte.d.ts"
+    },
+    "./dropdown-trigger": {
+      "svelte": "./src/components/dropdown-trigger.svelte",
+      "types": "./dist/components/dropdown-trigger.svelte.d.ts"
+    },
     "./dropdown": {
       "svelte": "./src/components/dropdown.svelte",
       "types": "./dist/components/dropdown.svelte.d.ts"
@@ -153,9 +177,17 @@
       "svelte": "./src/components/radio.svelte",
       "types": "./dist/components/radio.svelte.d.ts"
     },
+    "./segmented-control": {
+      "svelte": "./src/components/segmented-control.svelte",
+      "types": "./dist/components/segmented-control.svelte.d.ts"
+    },
     "./select": {
       "svelte": "./src/components/select.svelte",
       "types": "./dist/components/select.svelte.d.ts"
+    },
+    "./selection-popover": {
+      "svelte": "./src/components/selection-popover.svelte",
+      "types": "./dist/components/selection-popover.svelte.d.ts"
     },
     "./skeleton": {
       "svelte": "./src/components/skeleton.svelte",
@@ -220,6 +252,10 @@
     "./tooltip": {
       "svelte": "./src/components/tooltip.svelte",
       "types": "./dist/components/tooltip.svelte.d.ts"
+    },
+    "./view-switcher": {
+      "svelte": "./src/components/view-switcher.svelte",
+      "types": "./dist/components/view-switcher.svelte.d.ts"
     }
   },
   "main": "./dist/server/index.js",

--- a/packages/components/src/api-contract.ts
+++ b/packages/components/src/api-contract.ts
@@ -193,16 +193,33 @@ export const CONTRACT: Record<string, ComponentContract> = {
   },
 
   dropdown: {
-    kind: 'literal',
-    props: {
-      open: { optional: false, type_kind: 'TSBooleanKeyword', default: B(false) },
-      placement: { optional: true, type_kind: 'TSTypeReference', default: L('bottom-start') },
-      class: { optional: true, type_kind: 'TSStringKeyword', default: L(undefined) },
-    },
-    snippets: {
-      trigger: s0(false),
-      children: s0(false),
-    },
+    kind: 'union',
+    arms: [
+      {
+        kind: 'intersection',
+        html_attrs: 'HTMLAttributes',
+        props: {
+          open: { optional: false, type_kind: 'TSBooleanKeyword', default: B(false) },
+          placement: { optional: true, type_kind: 'TSTypeReference', default: L('bottom-start') },
+          class: { optional: true, type_kind: 'TSStringKeyword', default: L(undefined) },
+        },
+        snippets: {
+          trigger: s0(false),
+          children: s0(false),
+        },
+      },
+      {
+        kind: 'intersection',
+        html_attrs: 'HTMLAttributes',
+        props: {
+          id: { optional: false, type_kind: 'TSStringKeyword', default: REQUIRED },
+          class: { optional: true, type_kind: 'TSStringKeyword', default: L(undefined) },
+        },
+        snippets: {
+          children: s0(true),
+        },
+      },
+    ],
   },
 
   'empty-state': {

--- a/packages/components/src/components/badge.svelte
+++ b/packages/components/src/components/badge.svelte
@@ -2,8 +2,8 @@
   import type { Snippet } from 'svelte';
   import type { HTMLAttributes } from 'svelte/elements';
 
-  export type BadgeVariant = 'neutral' | 'success' | 'warning' | 'danger' | 'info';
-  export type BadgeSize = 'sm' | 'md';
+  export type BadgeVariant = 'neutral' | 'success' | 'warning' | 'danger' | 'info' | 'accent';
+  export type BadgeSize = 'xs' | 'sm' | 'md';
 
   export type BadgeProps = HTMLAttributes<HTMLSpanElement> & {
     variant?: BadgeVariant;

--- a/packages/components/src/components/badge.test.ts
+++ b/packages/components/src/components/badge.test.ts
@@ -39,7 +39,7 @@ describe('Badge', () => {
     expect(span?.getAttribute('class')).toContain('my-custom-class');
   });
 
-  test.each(['neutral', 'success', 'warning', 'danger', 'info'] as const)(
+  test.each(['neutral', 'success', 'warning', 'danger', 'info', 'accent'] as const)(
     'renders data-cinder-variant="%s"',
     (variant) => {
       const { container } = render(Badge, {
@@ -51,7 +51,7 @@ describe('Badge', () => {
     },
   );
 
-  test.each(['sm', 'md'] as const)('renders data-cinder-size="%s"', (size) => {
+  test.each(['xs', 'sm', 'md'] as const)('renders data-cinder-size="%s"', (size) => {
     const { container } = render(Badge, {
       children: textSnippet('label'),
       size,

--- a/packages/components/src/components/button.svelte
+++ b/packages/components/src/components/button.svelte
@@ -3,7 +3,7 @@
   import type { HTMLAnchorAttributes, HTMLButtonAttributes } from 'svelte/elements';
 
   /** Visual style of the button. */
-  export type ButtonVariant = 'primary' | 'secondary' | 'danger' | 'ghost';
+  export type ButtonVariant = 'primary' | 'secondary' | 'danger' | 'ghost' | 'ghost-danger';
 
   /** Size of the button. */
   export type ButtonSize = 'xs' | 'sm' | 'md' | 'lg';

--- a/packages/components/src/components/button.test.ts
+++ b/packages/components/src/components/button.test.ts
@@ -35,6 +35,16 @@ describe('Button rendering', () => {
     expect(button?.getAttribute('data-cinder-size')).toBe('lg');
   });
 
+  test('supports the ghost-danger variant', () => {
+    const { container } = render(Button, {
+      props: { label: 'Remove', variant: 'ghost-danger' },
+    });
+
+    expect(container.querySelector('button')?.getAttribute('data-cinder-variant')).toBe(
+      'ghost-danger',
+    );
+  });
+
   test('loading button has disabled + aria-busy + aria-disabled', () => {
     const { container } = render(Button, { props: { label: 'sending', loading: true } });
     const button = container.querySelector('button');

--- a/packages/components/src/components/diff-statistics.svelte
+++ b/packages/components/src/components/diff-statistics.svelte
@@ -1,0 +1,101 @@
+<script lang="ts" module>
+  import type { HTMLAttributes } from 'svelte/elements';
+
+  /** Visual density for the statistics display. */
+  export type DiffStatisticsVariant = 'default' | 'compact';
+
+  export type DiffStatisticsProps = Omit<HTMLAttributes<HTMLDivElement>, 'class'> & {
+    /** Number of added lines. */
+    added: number;
+    /** Number of removed lines. */
+    removed: number;
+    /** Number of modified lines. */
+    modified: number;
+    /** Visual density. */
+    variant?: DiffStatisticsVariant;
+    /** Hide statistics with a zero value. */
+    hideZero?: boolean;
+    /** Additional class names merged with `.cinder-diff-statistics`. */
+    class?: string;
+  };
+</script>
+
+<script lang="ts">
+  import { classNames } from '../utilities/class-names.ts';
+
+  let {
+    added,
+    removed,
+    modified,
+    variant = 'default',
+    hideZero = false,
+    class: customClassName,
+    ...rest
+  }: DiffStatisticsProps = $props();
+
+  const total = $derived(added + removed + modified);
+  const pluralize = (count: number, singular: string, plural: string) =>
+    count === 1 ? singular : plural;
+
+  const addedLabel = $derived(`${added} ${pluralize(added, 'line', 'lines')} added`);
+  const removedLabel = $derived(`${removed} ${pluralize(removed, 'line', 'lines')} removed`);
+  const modifiedLabel = $derived(`${modified} ${pluralize(modified, 'line', 'lines')} modified`);
+
+  const showAdded = $derived(!hideZero || added > 0);
+  const showRemoved = $derived(!hideZero || removed > 0);
+  const showModified = $derived(!hideZero || modified > 0);
+  const hasAnyStatistics = $derived(showAdded || showRemoved || showModified);
+</script>
+
+<div
+  class={classNames('cinder-diff-statistics', customClassName)}
+  data-cinder-variant={variant}
+  role="status"
+  aria-label={`${total} ${pluralize(total, 'line', 'lines')} changed`}
+  {...rest}
+>
+  {#if hasAnyStatistics}
+    {#if showAdded}
+      <span
+        class="cinder-diff-statistics__stat cinder-diff-statistics__stat--added"
+        aria-label={addedLabel}
+      >
+        <span class="cinder-diff-statistics__prefix" aria-hidden="true">+</span>
+        <span class="cinder-diff-statistics__value">{added}</span>
+        {#if variant === 'default'}
+          <span class="cinder-diff-statistics__label">added</span>
+        {/if}
+      </span>
+    {/if}
+
+    {#if showRemoved}
+      <span
+        class="cinder-diff-statistics__stat cinder-diff-statistics__stat--removed"
+        aria-label={removedLabel}
+      >
+        <span class="cinder-diff-statistics__prefix" aria-hidden="true">-</span>
+        <span class="cinder-diff-statistics__value">{removed}</span>
+        {#if variant === 'default'}
+          <span class="cinder-diff-statistics__label">removed</span>
+        {/if}
+      </span>
+    {/if}
+
+    {#if showModified}
+      <span
+        class="cinder-diff-statistics__stat cinder-diff-statistics__stat--modified"
+        aria-label={modifiedLabel}
+      >
+        <span class="cinder-diff-statistics__prefix" aria-hidden="true">~</span>
+        <span class="cinder-diff-statistics__value">{modified}</span>
+        {#if variant === 'default'}
+          <span class="cinder-diff-statistics__label">modified</span>
+        {/if}
+      </span>
+    {/if}
+  {:else}
+    <span class="cinder-diff-statistics__stat cinder-diff-statistics__stat--none">
+      No changes
+    </span>
+  {/if}
+</div>

--- a/packages/components/src/components/diff-statistics.test.ts
+++ b/packages/components/src/components/diff-statistics.test.ts
@@ -1,0 +1,36 @@
+/// <reference lib="dom" />
+import { afterEach, describe, expect, test } from 'bun:test';
+
+import { setupHappyDom } from '../test/happy-dom.ts';
+
+setupHappyDom();
+
+const { cleanup, render } = await import('@testing-library/svelte');
+const { default: DiffStatistics } = await import('./diff-statistics.svelte');
+
+afterEach(() => cleanup());
+
+describe('DiffStatistics', () => {
+  test('announces the total number of changed lines', () => {
+    const { container } = render(DiffStatistics, {
+      props: { added: 2, removed: 1, modified: 3 },
+    });
+
+    const status = container.querySelector('[role="status"]');
+    expect(status?.getAttribute('aria-label')).toBe('6 lines changed');
+    expect(status?.textContent).toContain('added');
+    expect(status?.textContent).toContain('removed');
+    expect(status?.textContent).toContain('modified');
+  });
+
+  test('supports compact zero-hiding output', () => {
+    const { container } = render(DiffStatistics, {
+      props: { added: 4, removed: 0, modified: 0, variant: 'compact', hideZero: true },
+    });
+
+    const status = container.querySelector('[role="status"]');
+    expect(status?.getAttribute('data-cinder-variant')).toBe('compact');
+    expect(status?.textContent).toContain('4');
+    expect(status?.textContent).not.toContain('0');
+  });
+});

--- a/packages/components/src/components/dropdown-item.svelte
+++ b/packages/components/src/components/dropdown-item.svelte
@@ -1,0 +1,85 @@
+<script lang="ts" module>
+  import type { Snippet } from 'svelte';
+  import type { HTMLButtonAttributes } from 'svelte/elements';
+
+  export type DropdownItemVariant = 'default' | 'danger';
+
+  export type DropdownItemProps = Omit<HTMLButtonAttributes, 'class'> & {
+    variant?: DropdownItemVariant;
+    inset?: boolean;
+    closeOnSelect?: boolean;
+    class?: string;
+    children?: Snippet;
+  };
+</script>
+
+<script lang="ts">
+  import { getContext, hasContext } from 'svelte';
+
+  import { classNames } from '../utilities/class-names.ts';
+  import { DROPDOWN_CONTEXT, type DropdownContext } from './dropdown.svelte';
+
+  if (!hasContext(DROPDOWN_CONTEXT)) {
+    throw new Error('DropdownItem must be used within a Dropdown.');
+  }
+
+  let {
+    variant = 'default',
+    inset = false,
+    disabled,
+    closeOnSelect = true,
+    class: customClassName,
+    onclick,
+    children,
+    ...rest
+  }: DropdownItemProps = $props();
+
+  const context = getContext<DropdownContext>(DROPDOWN_CONTEXT);
+
+  type DropdownItemClickHandler = (
+    event: MouseEvent & { currentTarget: EventTarget & HTMLButtonElement },
+  ) => void;
+
+  function handleClick(
+    event: MouseEvent & { currentTarget: EventTarget & HTMLButtonElement },
+  ): void {
+    if (disabled) return;
+    if (typeof onclick === 'function') {
+      (onclick as DropdownItemClickHandler)(event);
+    }
+    if (closeOnSelect) {
+      context.close();
+    }
+  }
+
+  function handleKeydown(event: KeyboardEvent): void {
+    if (disabled) return;
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault();
+      if (event.currentTarget instanceof HTMLButtonElement) {
+        event.currentTarget.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      }
+    }
+  }
+</script>
+
+<button
+  type="button"
+  role="menuitem"
+  class={classNames(
+    'cinder-dropdown-item',
+    inset && 'cinder-dropdown-item--inset',
+    customClassName,
+  )}
+  data-cinder-variant={variant}
+  tabindex={disabled ? -1 : 0}
+  data-disabled={disabled ? '' : undefined}
+  aria-disabled={disabled ? 'true' : undefined}
+  onclick={handleClick}
+  onkeydown={handleKeydown}
+  {...rest}
+>
+  {#if children}
+    {@render children()}
+  {/if}
+</button>

--- a/packages/components/src/components/dropdown-label.svelte
+++ b/packages/components/src/components/dropdown-label.svelte
@@ -1,0 +1,21 @@
+<script lang="ts" module>
+  import type { Snippet } from 'svelte';
+  import type { HTMLAttributes } from 'svelte/elements';
+
+  export type DropdownLabelProps = Omit<HTMLAttributes<HTMLDivElement>, 'class'> & {
+    class?: string;
+    children?: Snippet;
+  };
+</script>
+
+<script lang="ts">
+  import { classNames } from '../utilities/class-names.ts';
+
+  let { class: customClassName, children, ...rest }: DropdownLabelProps = $props();
+</script>
+
+<div class={classNames('cinder-dropdown-label', customClassName)} {...rest}>
+  {#if children}
+    {@render children()}
+  {/if}
+</div>

--- a/packages/components/src/components/dropdown-menu.svelte
+++ b/packages/components/src/components/dropdown-menu.svelte
@@ -1,0 +1,97 @@
+<script lang="ts" module>
+  import type { Snippet } from 'svelte';
+  import type { HTMLAttributes } from 'svelte/elements';
+
+  export type DropdownMenuProps = Omit<HTMLAttributes<HTMLDivElement>, 'class'> & {
+    class?: string;
+    children?: Snippet;
+  };
+</script>
+
+<script lang="ts">
+  import { getContext, hasContext, tick } from 'svelte';
+
+  import { classNames } from '../utilities/class-names.ts';
+  import {
+    DROPDOWN_CONTEXT,
+    DROPDOWN_REGISTER,
+    DROPDOWN_SET_OPEN,
+    type DropdownContext,
+  } from './dropdown.svelte';
+
+  if (!hasContext(DROPDOWN_CONTEXT)) {
+    throw new Error('DropdownMenu must be used within a Dropdown.');
+  }
+
+  let { class: customClassName, children, ...rest }: DropdownMenuProps = $props();
+
+  const context = getContext<DropdownContext>(DROPDOWN_CONTEXT);
+  const registerMenu = getContext<(element: HTMLElement | null) => void>(DROPDOWN_REGISTER);
+  const setOpen = getContext<(open: boolean) => void>(DROPDOWN_SET_OPEN);
+
+  let menuElement = $state<HTMLDivElement | null>(null);
+
+  $effect(() => {
+    registerMenu(menuElement);
+    return () => registerMenu(null);
+  });
+
+  function focusMenuItem(index: number): void {
+    const items = menuElement?.querySelectorAll<HTMLElement>(
+      '[role="menuitem"]:not([data-disabled])',
+    );
+    const item = items?.item(index);
+    item?.focus();
+  }
+
+  function handleKeydown(event: KeyboardEvent): void {
+    const items = menuElement?.querySelectorAll<HTMLElement>(
+      '[role="menuitem"]:not([data-disabled])',
+    );
+    if (!items?.length) return;
+
+    const itemsArray = Array.from(items);
+    const currentIndex = itemsArray.findIndex((item) => item === document.activeElement);
+
+    if (event.key === 'ArrowDown') {
+      event.preventDefault();
+      focusMenuItem(currentIndex < itemsArray.length - 1 ? currentIndex + 1 : 0);
+    } else if (event.key === 'ArrowUp') {
+      event.preventDefault();
+      focusMenuItem(currentIndex > 0 ? currentIndex - 1 : itemsArray.length - 1);
+    } else if (event.key === 'Home') {
+      event.preventDefault();
+      focusMenuItem(0);
+    } else if (event.key === 'End') {
+      event.preventDefault();
+      focusMenuItem(itemsArray.length - 1);
+    }
+  }
+
+  function handleToggle(event: ToggleEvent): void {
+    const isOpenNow = event.newState === 'open';
+    setOpen(isOpenNow);
+
+    if (isOpenNow) {
+      void tick().then(() => focusMenuItem(0));
+    }
+  }
+</script>
+
+<div
+  bind:this={menuElement}
+  id={context.menuId}
+  popover="auto"
+  class={classNames('cinder-dropdown-menu', customClassName)}
+  style={`position-anchor: --${context.menuId};`}
+  role="menu"
+  aria-orientation="vertical"
+  tabindex={-1}
+  onkeydown={handleKeydown}
+  ontoggle={handleToggle}
+  {...rest}
+>
+  {#if children}
+    {@render children()}
+  {/if}
+</div>

--- a/packages/components/src/components/dropdown-separator.svelte
+++ b/packages/components/src/components/dropdown-separator.svelte
@@ -1,0 +1,19 @@
+<script lang="ts" module>
+  import type { HTMLAttributes } from 'svelte/elements';
+
+  export type DropdownSeparatorProps = Omit<HTMLAttributes<HTMLDivElement>, 'class'> & {
+    class?: string;
+  };
+</script>
+
+<script lang="ts">
+  import { classNames } from '../utilities/class-names.ts';
+
+  let { class: customClassName, ...rest }: DropdownSeparatorProps = $props();
+</script>
+
+<div
+  class={classNames('cinder-dropdown-separator', customClassName)}
+  role="separator"
+  {...rest}
+></div>

--- a/packages/components/src/components/dropdown-trigger.svelte
+++ b/packages/components/src/components/dropdown-trigger.svelte
@@ -1,0 +1,38 @@
+<script lang="ts" module>
+  import type { Snippet } from 'svelte';
+  import type { HTMLButtonAttributes } from 'svelte/elements';
+
+  export type DropdownTriggerProps = Omit<HTMLButtonAttributes, 'class'> & {
+    class?: string;
+    children?: Snippet;
+  };
+</script>
+
+<script lang="ts">
+  import { getContext, hasContext } from 'svelte';
+
+  import { classNames } from '../utilities/class-names.ts';
+  import { DROPDOWN_CONTEXT, type DropdownContext } from './dropdown.svelte';
+
+  if (!hasContext(DROPDOWN_CONTEXT)) {
+    throw new Error('DropdownTrigger must be used within a Dropdown.');
+  }
+
+  let { class: customClassName, children, ...rest }: DropdownTriggerProps = $props();
+
+  const context = getContext<DropdownContext>(DROPDOWN_CONTEXT);
+</script>
+
+<button
+  type="button"
+  class={classNames('cinder-dropdown-trigger', customClassName)}
+  style={`anchor-name: --${context.menuId};`}
+  aria-haspopup="menu"
+  aria-expanded={context.isOpen}
+  popovertarget={context.menuId}
+  {...rest}
+>
+  {#if children}
+    {@render children()}
+  {/if}
+</button>

--- a/packages/components/src/components/dropdown.svelte
+++ b/packages/components/src/components/dropdown.svelte
@@ -1,28 +1,60 @@
 <script lang="ts" module>
   import type { Snippet } from 'svelte';
+  import type { HTMLAttributes } from 'svelte/elements';
+
+  export const DROPDOWN_CONTEXT = Symbol('cinder-dropdown');
+  export const DROPDOWN_REGISTER = Symbol('cinder-dropdown-register');
+  export const DROPDOWN_SET_OPEN = Symbol('cinder-dropdown-set-open');
 
   export type DropdownPlacement = 'bottom-start' | 'bottom-end';
 
-  export type DropdownProps = {
-    open: boolean;
-    placement?: DropdownPlacement;
+  export type DropdownContext = {
+    get menuId(): string;
+    get isOpen(): boolean;
+    close: () => void;
+  };
+
+  type DropdownBaseProps = Omit<HTMLAttributes<HTMLDivElement>, 'class'> & {
+    id?: string;
     class?: string;
+  };
+
+  type LegacyDropdownProps = DropdownBaseProps & {
+    open?: boolean;
+    placement?: DropdownPlacement;
     trigger: Snippet;
     children: Snippet;
   };
+
+  type CompoundDropdownProps = DropdownBaseProps & {
+    id: string;
+    children?: Snippet;
+    trigger?: never;
+    open?: never;
+    placement?: never;
+  };
+
+  export type DropdownProps = LegacyDropdownProps | CompoundDropdownProps;
 </script>
 
 <script lang="ts">
-  import { cn } from '../utilities/class-names.ts';
+  import { setContext } from 'svelte';
+
+  import { classNames } from '../utilities/class-names.ts';
   import { useId } from '../utilities/use-id.ts';
 
   let {
+    id = useId('cinder-dropdown'),
     open = $bindable(false),
     placement = 'bottom-start',
-    class: className,
+    class: customClassName,
     trigger,
     children,
+    ...rest
   }: DropdownProps = $props();
+
+  let compoundMenuElement = $state<HTMLElement | null>(null);
+  let compoundOpen = $state(false);
 
   // Popover API detection is deferred to after mount so the server and client
   // produce identical initial markup (both start with the fallback {#if open}
@@ -36,8 +68,37 @@
   let menuElement: HTMLDivElement | undefined = $state();
   let triggerWrapper: HTMLDivElement | undefined = $state();
 
+  const compoundMenuId = $derived(`${id}-menu`);
+  const usesLegacySnippetApi = $derived(Boolean(trigger));
+
+  function closeCompoundMenu(): void {
+    compoundMenuElement?.hidePopover();
+    compoundOpen = false;
+  }
+
+  function registerCompoundMenu(element: HTMLElement | null): void {
+    compoundMenuElement = element;
+  }
+
+  function setCompoundOpen(nextOpen: boolean): void {
+    compoundOpen = nextOpen;
+  }
+
+  setContext<DropdownContext>(DROPDOWN_CONTEXT, {
+    get menuId() {
+      return compoundMenuId;
+    },
+    get isOpen() {
+      return compoundOpen;
+    },
+    close: closeCompoundMenu,
+  });
+  setContext<(element: HTMLElement | null) => void>(DROPDOWN_REGISTER, registerCompoundMenu);
+  setContext<(nextOpen: boolean) => void>(DROPDOWN_SET_OPEN, setCompoundOpen);
+
   // Keep aria-expanded on the trigger element in sync with open state.
   $effect(() => {
+    if (!usesLegacySnippetApi) return;
     const btn = triggerWrapper?.querySelector<HTMLElement>(
       'button, a, [tabindex]:not([tabindex="-1"]), input, select',
     );
@@ -100,40 +161,45 @@
 
 <div
   bind:this={rootElement}
-  class={cn('cinder-dropdown', className)}
+  {id}
+  class={classNames('cinder-dropdown', customClassName)}
   data-cinder-placement={placement}
   onkeydown={handleKeydown}
+  {...rest}
 >
-  <!--
-    The trigger wrapper intercepts clicks to toggle open, and wires ARIA attributes
-    (aria-haspopup, aria-expanded, aria-controls) onto the first focusable element
-    inside the snippet. Consumers must provide exactly one focusable trigger element
-    (typically a <button>). The click is intercepted on the wrapper so it works
-    regardless of whether the consumer's button has its own onclick handler.
-  -->
-  <div class="cinder-dropdown__trigger" bind:this={triggerWrapper} onclick={() => (open = !open)}>
-    {@render trigger()}
-  </div>
-
-  {#if supportsPopover}
+  {#if usesLegacySnippetApi}
     <!--
-      Popover API path: menu is in the DOM and driven via showPopover()/hidePopover().
-      ontoggle syncs browser-driven state changes (light-dismiss, Escape) back to `open`.
+      The legacy trigger wrapper intercepts clicks to toggle open, and wires ARIA attributes
+      onto the first focusable element inside the snippet.
     -->
-    <div
-      bind:this={menuElement}
-      id={menuId}
-      class="cinder-dropdown__menu"
-      popover="auto"
-      role="menu"
-      data-cinder-placement={placement}
-      ontoggle={handlePopoverToggle}
-    >
-      {@render children()}
+    <div class="cinder-dropdown__trigger" bind:this={triggerWrapper} onclick={() => (open = !open)}>
+      {#if trigger}
+        {@render trigger()}
+      {/if}
     </div>
-  {:else if open}
-    <div id={menuId} class="cinder-dropdown__menu" role="menu" data-cinder-placement={placement}>
-      {@render children()}
-    </div>
+
+    {#if supportsPopover}
+      <div
+        bind:this={menuElement}
+        id={menuId}
+        class="cinder-dropdown__menu"
+        popover="auto"
+        role="menu"
+        data-cinder-placement={placement}
+        ontoggle={handlePopoverToggle}
+      >
+        {#if children}
+          {@render children()}
+        {/if}
+      </div>
+    {:else if open}
+      <div id={menuId} class="cinder-dropdown__menu" role="menu" data-cinder-placement={placement}>
+        {#if children}
+          {@render children()}
+        {/if}
+      </div>
+    {/if}
+  {:else if children}
+    {@render children()}
   {/if}
 </div>

--- a/packages/components/src/components/dropdown.test.ts
+++ b/packages/components/src/components/dropdown.test.ts
@@ -15,6 +15,8 @@ setupHappyDom();
 
 const { render, fireEvent } = await import('@testing-library/svelte');
 const { default: Dropdown } = await import('./dropdown.svelte');
+const { default: DropdownCompoundFixture } =
+  await import('../test/fixtures/dropdown-compound-fixture.svelte');
 
 const triggerSnippet = createRawSnippet(() => ({
   render: () => `<button type="button">Open Menu</button>`,
@@ -135,14 +137,6 @@ describe('Dropdown', () => {
     expect(menu?.textContent).toContain('My menu item');
   });
 
-  // ---------------------------------------------------------------------------
-  // ARIA state on the trigger wrapper
-  // ---------------------------------------------------------------------------
-  // The current dropdown.svelte implementation does not yet set aria-haspopup
-  // or aria-expanded on the trigger wrapper (<div class="cinder-dropdown__trigger">).
-  // The tests below assert the current reality and include TODO markers where
-  // the attributes are missing — adding them is a separate implementation task.
-
   test('trigger wrapper exists and wraps the trigger snippet', () => {
     const { container } = render(Dropdown, {
       props: {
@@ -156,9 +150,33 @@ describe('Dropdown', () => {
     expect(triggerWrapper?.textContent).toContain('Open Menu');
   });
 
-  // TODO: dropdown.svelte should add aria-haspopup="menu" to .cinder-dropdown__trigger
-  // so assistive technology announces the button as opening a menu.
-  test('trigger wrapper does not yet have aria-haspopup (implementation gap)', () => {
+  test('compound trigger wires menu ARIA to the button', () => {
+    const { container } = render(DropdownCompoundFixture);
+
+    const trigger = container.querySelector('.trigger');
+    expect(trigger?.getAttribute('aria-haspopup')).toBe('menu');
+    expect(trigger?.getAttribute('aria-expanded')).toBe('false');
+    expect(trigger?.getAttribute('popovertarget')).toBe('actions-menu-menu');
+  });
+
+  test('compound menu renders labels, separators, and items', () => {
+    const { container } = render(DropdownCompoundFixture);
+
+    expect(container.querySelector('[role="menu"]')?.id).toBe('actions-menu-menu');
+    expect(container.querySelector('.cinder-dropdown-label')?.textContent).toContain('Document');
+    expect(container.querySelector('[role="separator"]')).not.toBeNull();
+    expect(container.querySelectorAll('[role="menuitem"]')).toHaveLength(2);
+  });
+
+  test('compound item click closes the menu and invokes onclick', async () => {
+    const { container } = render(DropdownCompoundFixture);
+
+    await fireEvent.click(container.querySelector('[role="menuitem"]') as HTMLElement);
+
+    expect(container.querySelector('output')?.textContent).toBe('copy');
+  });
+
+  test('legacy trigger wrapper does not own aria-haspopup', () => {
     const { container } = render(Dropdown, {
       props: {
         open: false,
@@ -167,13 +185,10 @@ describe('Dropdown', () => {
       },
     });
     const triggerWrapper = container.querySelector('.cinder-dropdown__trigger');
-    // Current implementation omits aria-haspopup — this test documents the gap.
     expect(triggerWrapper?.hasAttribute('aria-haspopup')).toBe(false);
   });
 
-  // TODO: dropdown.svelte should add aria-expanded={open} to .cinder-dropdown__trigger
-  // so assistive technology communicates whether the menu is open or closed.
-  test('trigger wrapper does not yet have aria-expanded (implementation gap)', () => {
+  test('legacy trigger wrapper does not own aria-expanded', () => {
     const { container } = render(Dropdown, {
       props: {
         open: false,
@@ -182,7 +197,6 @@ describe('Dropdown', () => {
       },
     });
     const triggerWrapper = container.querySelector('.cinder-dropdown__trigger');
-    // Current implementation omits aria-expanded — this test documents the gap.
     expect(triggerWrapper?.hasAttribute('aria-expanded')).toBe(false);
   });
 });

--- a/packages/components/src/components/kbd.svelte
+++ b/packages/components/src/components/kbd.svelte
@@ -9,20 +9,37 @@
    * Use to indicate keyboard shortcuts in tooltips, command palettes, and
    * help text.
    */
-  export type KbdProps = HTMLAttributes<HTMLElement> & {
+  export type KbdSize = 'sm' | 'md';
+
+  type KbdBaseProps = HTMLAttributes<HTMLElement> & {
     /** Additional class names merged with `.cinder-kbd`. */
     class?: string;
+    /** Keyboard key size. */
+    size?: KbdSize;
+  };
+
+  type KbdWithLabel = KbdBaseProps & {
+    /** Key label content. */
+    label: string;
+    children?: Snippet;
+  };
+
+  type KbdWithChildren = KbdBaseProps & {
+    /** Key label content. */
+    label?: string;
     /** Key label content. */
     children: Snippet;
   };
+
+  export type KbdProps = KbdWithLabel | KbdWithChildren;
 </script>
 
 <script lang="ts">
-  import { cn } from '../utilities/class-names.ts';
+  import { classNames } from '../utilities/class-names.ts';
 
-  let { class: className, children, ...rest }: KbdProps = $props();
+  let { class: customClassName, size = 'md', label, children, ...rest }: KbdProps = $props();
 </script>
 
-<kbd class={cn('cinder-kbd', className)} {...rest}>
-  {@render children()}
+<kbd class={classNames('cinder-kbd', customClassName)} data-cinder-size={size} {...rest}>
+  {#if children}{@render children()}{:else}{label}{/if}
 </kbd>

--- a/packages/components/src/components/kbd.test.ts
+++ b/packages/components/src/components/kbd.test.ts
@@ -9,8 +9,8 @@ const { render } = await import('@testing-library/svelte');
 const { createRawSnippet } = await import('svelte');
 const { default: Kbd } = await import('./kbd.svelte');
 
-function snippet(html: string) {
-  return createRawSnippet(() => ({ render: () => html }));
+function snippet(text: string) {
+  return createRawSnippet(() => ({ render: () => `<span>${text}</span>` }));
 }
 
 describe('Kbd', () => {
@@ -37,5 +37,15 @@ describe('Kbd', () => {
       children: snippet('K'),
     });
     expect(container.querySelector('[data-testid="shortcut"]')).not.toBeNull();
+  });
+
+  test('renders label content without a children snippet', () => {
+    const { container } = render(Kbd, { label: 'Esc' });
+    expect(container.querySelector('kbd')?.textContent).toBe('Esc');
+  });
+
+  test('applies size as a data attribute', () => {
+    const { container } = render(Kbd, { label: 'K', size: 'sm' });
+    expect(container.querySelector('kbd')?.getAttribute('data-cinder-size')).toBe('sm');
   });
 });

--- a/packages/components/src/components/segmented-control.svelte
+++ b/packages/components/src/components/segmented-control.svelte
@@ -1,0 +1,117 @@
+<script lang="ts" module>
+  import type { HTMLAttributes } from 'svelte/elements';
+
+  export type SegmentedControlOption<T extends string = string> = {
+    value: T;
+    label: string;
+    disabled?: boolean;
+  };
+
+  export type SegmentedControlProps<T extends string = string> = Omit<
+    HTMLAttributes<HTMLDivElement>,
+    'id'
+  > & {
+    /** Unique identifier for the control. */
+    id: string;
+    /** Selected option value. */
+    value?: T;
+    /** Available options. */
+    options: readonly SegmentedControlOption<T>[];
+    /** Accessible label for the radio group. */
+    label: string;
+    /** Visually hide the label while keeping it available to assistive technology. */
+    hideLabel?: boolean;
+    /** Disable the whole control. */
+    disabled?: boolean;
+    /** Additional class names merged with `.cinder-segmented-control`. */
+    class?: string;
+  };
+</script>
+
+<script lang="ts" generics="T extends string = string">
+  import { classNames } from '../utilities/class-names.ts';
+  import { getFocusableIndex, handleRovingKeydown } from '../utilities/roving-tabindex.ts';
+
+  let {
+    id,
+    value = $bindable<T>(),
+    options,
+    label,
+    hideLabel = false,
+    disabled = false,
+    class: customClassName,
+    ...rest
+  }: SegmentedControlProps<T> = $props();
+
+  let focusedIndex = $state<number | null>(null);
+
+  const selectedIndex = $derived(options.findIndex((option) => option.value === value));
+  const isOptionDisabled = (index: number) => disabled || options[index]?.disabled === true;
+  const focusableIndex = $derived(
+    getFocusableIndex(selectedIndex, options.length, isOptionDisabled),
+  );
+
+  function selectOption(index: number): void {
+    const option = options[index];
+    if (!option || disabled || option.disabled) return;
+    value = option.value;
+  }
+
+  function handleKeydown(event: KeyboardEvent): void {
+    if (disabled) return;
+
+    const currentIndex = focusedIndex ?? (selectedIndex >= 0 ? selectedIndex : focusableIndex);
+    const nextIndex = handleRovingKeydown(event, currentIndex, options.length, {
+      isDisabled: isOptionDisabled,
+    });
+
+    if (nextIndex === null) return;
+
+    event.preventDefault();
+    if (nextIndex === currentIndex) return;
+
+    selectOption(nextIndex);
+    focusedIndex = nextIndex;
+    document.getElementById(`${id}-option-${nextIndex}`)?.focus();
+  }
+</script>
+
+<div class="cinder-segmented-control-container">
+  <span
+    id={`${id}-label`}
+    class={classNames('cinder-segmented-control-label', hideLabel && 'cinder-sr-only')}
+  >
+    {label}
+  </span>
+  <div
+    {id}
+    role="radiogroup"
+    aria-labelledby={`${id}-label`}
+    aria-disabled={disabled ? 'true' : undefined}
+    class={classNames('cinder-segmented-control', customClassName)}
+    data-cinder-disabled={disabled ? '' : undefined}
+    onkeydown={handleKeydown}
+    {...rest}
+  >
+    {#each options as option, index (option.value)}
+      {@const isSelected = option.value === value}
+      {@const isDisabled = disabled || option.disabled === true}
+      <button
+        id={`${id}-option-${index}`}
+        type="button"
+        role="radio"
+        aria-checked={isSelected}
+        aria-disabled={isDisabled ? 'true' : undefined}
+        disabled={isDisabled}
+        tabindex={index === focusableIndex ? 0 : -1}
+        class="cinder-segmented-control-option"
+        data-cinder-selected={isSelected ? '' : undefined}
+        onclick={() => selectOption(index)}
+        onfocus={() => (focusedIndex = index)}
+        onblur={() => (focusedIndex = null)}
+      >
+        {option.label}
+      </button>
+    {/each}
+  </div>
+</div>

--- a/packages/components/src/components/segmented-control.test.ts
+++ b/packages/components/src/components/segmented-control.test.ts
@@ -1,0 +1,81 @@
+/// <reference lib="dom" />
+import { afterEach, describe, expect, test } from 'bun:test';
+
+import { setupHappyDom } from '../test/happy-dom.ts';
+
+setupHappyDom();
+
+const { cleanup, fireEvent, render, screen } = await import('@testing-library/svelte');
+const { default: SegmentedControl } = await import('./segmented-control.svelte');
+
+afterEach(() => cleanup());
+
+const options = [
+  { value: 'source', label: 'Source' },
+  { value: 'rendered', label: 'Rendered' },
+  { value: 'diff', label: 'Diff', disabled: true },
+] as const;
+
+describe('SegmentedControl', () => {
+  test('renders accessible radio options', () => {
+    render(SegmentedControl, {
+      props: {
+        id: 'document-view',
+        value: 'source',
+        label: 'Document view',
+        options,
+      },
+    });
+
+    expect(screen.getByRole('radiogroup', { name: 'Document view' })).not.toBeNull();
+    expect(screen.getByRole('radio', { name: 'Source' }).getAttribute('aria-checked')).toBe('true');
+  });
+
+  test('clicking an enabled option updates the bindable value', async () => {
+    let selected = 'source';
+
+    render(SegmentedControl, {
+      props: {
+        id: 'document-view',
+        get value() {
+          return selected;
+        },
+        set value(nextValue: string) {
+          selected = nextValue;
+        },
+        label: 'Document view',
+        options,
+      },
+    });
+
+    await fireEvent.click(screen.getByRole('radio', { name: 'Rendered' }));
+    expect(selected).toBe('rendered');
+
+    await fireEvent.click(screen.getByRole('radio', { name: 'Diff' }));
+    expect(selected).toBe('rendered');
+  });
+
+  test('arrow navigation moves selection while skipping disabled options', async () => {
+    let selected = 'source';
+
+    render(SegmentedControl, {
+      props: {
+        id: 'document-view',
+        get value() {
+          return selected;
+        },
+        set value(nextValue: string) {
+          selected = nextValue;
+        },
+        label: 'Document view',
+        options,
+      },
+    });
+
+    await fireEvent.keyDown(screen.getByRole('radiogroup'), { key: 'ArrowRight' });
+    expect(selected).toBe('rendered');
+
+    await fireEvent.keyDown(screen.getByRole('radiogroup'), { key: 'ArrowRight' });
+    expect(selected).toBe('source');
+  });
+});

--- a/packages/components/src/components/selection-popover.svelte
+++ b/packages/components/src/components/selection-popover.svelte
@@ -1,0 +1,244 @@
+<script lang="ts" module>
+  import type { HTMLAttributes } from 'svelte/elements';
+
+  export type SelectionPopoverPosition = {
+    x: number;
+    y: number;
+  };
+
+  export type SelectionPopoverProps = Omit<HTMLAttributes<HTMLDivElement>, 'class'> & {
+    /** Unique identifier for the popover. */
+    id: string;
+    /** Viewport-relative position for the popover. */
+    position: SelectionPopoverPosition | null;
+    /** Whether the popover is visible. */
+    open?: boolean;
+    /** Called when a comment is submitted. */
+    oncommentsubmit?: (body: string) => void;
+    /** Called when the compact action expands into the composer. */
+    onexpand?: () => void;
+    /** Called when the composer is canceled. */
+    oncancel?: () => void;
+    /** Called when the popover should close. */
+    onclose?: () => void;
+    /** Additional class names merged with `.cinder-selection-popover`. */
+    class?: string;
+  };
+</script>
+
+<script lang="ts">
+  import { innerHeight, innerWidth } from 'svelte/reactivity/window';
+
+  import { classNames } from '../utilities/class-names.ts';
+
+  let {
+    id,
+    position,
+    open = false,
+    oncommentsubmit,
+    onexpand,
+    oncancel,
+    onclose,
+    class: customClassName,
+    ...rest
+  }: SelectionPopoverProps = $props();
+
+  let expanded = $state(false);
+  let commentBody = $state('');
+  let textareaElement = $state<HTMLTextAreaElement | null>(null);
+  let popoverElement = $state<HTMLDivElement | null>(null);
+  let restoreFocusElement = $state<HTMLElement | null>(null);
+
+  const POPOVER_WIDTH = 100;
+  const POPOVER_HEIGHT = 36;
+  const VIEWPORT_MARGIN = 16;
+
+  const positionStyle = $derived.by(() => {
+    if (!position) return '';
+
+    const viewportWidth = innerWidth.current;
+    const viewportHeight = innerHeight.current;
+
+    if (viewportWidth == null || viewportHeight == null) {
+      const x = Math.max(VIEWPORT_MARGIN + POPOVER_WIDTH / 2, position.x);
+      const y = Math.max(VIEWPORT_MARGIN, position.y);
+      return `left: ${x}px; top: ${y}px;`;
+    }
+
+    const halfWidth = POPOVER_WIDTH / 2;
+    const x = Math.max(
+      VIEWPORT_MARGIN + halfWidth,
+      Math.min(position.x, viewportWidth - halfWidth - VIEWPORT_MARGIN),
+    );
+    const y = Math.max(
+      VIEWPORT_MARGIN,
+      Math.min(position.y, viewportHeight - POPOVER_HEIGHT - VIEWPORT_MARGIN),
+    );
+
+    return `left: ${x}px; top: ${y}px;`;
+  });
+
+  const canSubmit = $derived(commentBody.trim().length > 0);
+
+  function rememberFocus(): void {
+    if (restoreFocusElement) return;
+    const activeElement = document.activeElement;
+    restoreFocusElement = activeElement instanceof HTMLElement ? activeElement : null;
+  }
+
+  function restoreFocus(): void {
+    restoreFocusElement?.focus();
+    restoreFocusElement = null;
+  }
+
+  function closePopover(): void {
+    onclose?.();
+    restoreFocus();
+  }
+
+  function handleExpand(): void {
+    rememberFocus();
+    expanded = true;
+    onexpand?.();
+    requestAnimationFrame(() => textareaElement?.focus());
+  }
+
+  function handleCancel(): void {
+    expanded = false;
+    commentBody = '';
+    oncancel?.();
+    restoreFocus();
+  }
+
+  function handleSubmit(): void {
+    const trimmedBody = commentBody.trim();
+    if (!trimmedBody) return;
+
+    oncommentsubmit?.(trimmedBody);
+    expanded = false;
+    commentBody = '';
+    restoreFocus();
+  }
+
+  function handleKeydown(event: KeyboardEvent): void {
+    if (event.key === 'Escape' && !event.defaultPrevented) {
+      event.preventDefault();
+      if (expanded) {
+        handleCancel();
+      } else {
+        closePopover();
+      }
+      return;
+    }
+
+    if ((event.key === 'Enter' || event.key === ' ') && !expanded) {
+      event.preventDefault();
+      handleExpand();
+    }
+  }
+
+  function handleTextareaKeydown(event: KeyboardEvent): void {
+    if (event.key === 'Enter' && (event.metaKey || event.ctrlKey)) {
+      event.preventDefault();
+      handleSubmit();
+    }
+  }
+
+  function handleDocumentPointerdown(event: PointerEvent): void {
+    if (!popoverElement || !open) return;
+    if (event.target instanceof Node && popoverElement.contains(event.target)) return;
+    closePopover();
+  }
+
+  $effect(() => {
+    if (!popoverElement) return;
+
+    try {
+      if (open && position) {
+        popoverElement.showPopover();
+      } else {
+        popoverElement.hidePopover();
+      }
+    } catch {
+      // Browsers without the Popover API still render the positioned fallback.
+    }
+  });
+
+  $effect(() => {
+    if (!open) {
+      expanded = false;
+      commentBody = '';
+      restoreFocusElement = null;
+      return;
+    }
+
+    document.addEventListener('pointerdown', handleDocumentPointerdown);
+    return () => document.removeEventListener('pointerdown', handleDocumentPointerdown);
+  });
+</script>
+
+<div
+  bind:this={popoverElement}
+  {id}
+  class={classNames('cinder-selection-popover', customClassName)}
+  data-cinder-expanded={expanded ? '' : undefined}
+  style={positionStyle}
+  popover="manual"
+  role="toolbar"
+  aria-label="Selection actions"
+  onkeydown={handleKeydown}
+  {...rest}
+>
+  {#if expanded}
+    <div class="cinder-selection-popover__form">
+      <textarea
+        bind:this={textareaElement}
+        bind:value={commentBody}
+        class="cinder-selection-popover__textarea"
+        placeholder="Add a comment..."
+        rows={2}
+        onkeydown={handleTextareaKeydown}
+      ></textarea>
+      <div class="cinder-selection-popover__actions">
+        <button
+          type="button"
+          class="cinder-selection-popover__cancel"
+          onclick={handleCancel}
+          aria-label="Cancel"
+        >
+          <svg class="cinder-selection-popover__icon" aria-hidden="true" viewBox="0 0 24 24">
+            <path d="M18 6 6 18" />
+            <path d="m6 6 12 12" />
+          </svg>
+        </button>
+        <button
+          type="button"
+          class="cinder-selection-popover__submit"
+          onclick={handleSubmit}
+          disabled={!canSubmit}
+          aria-label="Submit comment"
+          title="Submit comment"
+        >
+          <svg class="cinder-selection-popover__icon" aria-hidden="true" viewBox="0 0 24 24">
+            <path d="m22 2-7 20-4-9-9-4Z" />
+            <path d="M22 2 11 13" />
+          </svg>
+        </button>
+      </div>
+    </div>
+  {:else}
+    <button
+      type="button"
+      class="cinder-selection-popover__button"
+      onclick={handleExpand}
+      aria-label="Add comment"
+      title="Add comment to selection"
+    >
+      <svg class="cinder-selection-popover__icon" aria-hidden="true" viewBox="0 0 24 24">
+        <path d="M21 15a4 4 0 0 1-4 4H7l-4 4V7a4 4 0 0 1 4-4h6" />
+        <path d="M19 3v6" />
+        <path d="M16 6h6" />
+      </svg>
+    </button>
+  {/if}
+</div>

--- a/packages/components/src/components/selection-popover.test.ts
+++ b/packages/components/src/components/selection-popover.test.ts
@@ -1,0 +1,74 @@
+/// <reference lib="dom" />
+import { afterEach, describe, expect, test } from 'bun:test';
+
+import { setupHappyDom } from '../test/happy-dom.ts';
+
+setupHappyDom();
+
+const { cleanup, fireEvent, render, screen } = await import('@testing-library/svelte');
+const { default: SelectionPopover } = await import('./selection-popover.svelte');
+
+afterEach(() => cleanup());
+
+describe('SelectionPopover', () => {
+  test('renders the collapsed selection action when open', () => {
+    render(SelectionPopover, {
+      props: {
+        id: 'selection-comment',
+        open: true,
+        position: { x: 120, y: 80 },
+      },
+    });
+
+    expect(screen.getByRole('button', { name: 'Add comment' })).not.toBeNull();
+  });
+
+  test('expands, submits trimmed comment text, and resets', async () => {
+    const submitted: string[] = [];
+
+    render(SelectionPopover, {
+      props: {
+        id: 'selection-comment',
+        open: true,
+        position: { x: 120, y: 80 },
+        oncommentsubmit: (body: string) => submitted.push(body),
+      },
+    });
+
+    await fireEvent.click(screen.getByRole('button', { name: 'Add comment' }));
+    await fireEvent.input(screen.getByPlaceholderText('Add a comment...'), {
+      target: { value: '  Please clarify this.  ' },
+    });
+    await fireEvent.click(screen.getByRole('button', { name: 'Submit comment' }));
+
+    expect(submitted).toEqual(['Please clarify this.']);
+    expect(screen.getByRole('button', { name: 'Add comment' })).not.toBeNull();
+  });
+
+  test('Escape closes when collapsed and cancels when expanded', async () => {
+    let closed = false;
+    let canceled = false;
+
+    render(SelectionPopover, {
+      props: {
+        id: 'selection-comment',
+        open: true,
+        position: { x: 120, y: 80 },
+        onclose: () => {
+          closed = true;
+        },
+        oncancel: () => {
+          canceled = true;
+        },
+      },
+    });
+
+    const toolbar = screen.getByRole('toolbar', { name: 'Selection actions' });
+    await fireEvent.keyDown(toolbar, { key: 'Escape' });
+    expect(closed).toBe(true);
+
+    await fireEvent.click(screen.getByRole('button', { name: 'Add comment' }));
+    await fireEvent.keyDown(toolbar, { key: 'Escape' });
+    expect(canceled).toBe(true);
+  });
+});

--- a/packages/components/src/components/view-switcher.svelte
+++ b/packages/components/src/components/view-switcher.svelte
@@ -1,0 +1,127 @@
+<script lang="ts" module>
+  import type { HTMLAttributes } from 'svelte/elements';
+
+  /** Available review document views. */
+  export type ViewType = 'editor' | 'diff' | 'summary';
+
+  export type ViewOption = {
+    value: ViewType;
+    label: string;
+    description?: string;
+  };
+
+  export type ViewSwitcherProps = Omit<HTMLAttributes<HTMLDivElement>, 'class' | 'onchange'> & {
+    /** Unique identifier for the tablist. */
+    id: string;
+    /** Active view. */
+    value?: ViewType;
+    /** Whether to include the diff tab. */
+    showDiff?: boolean;
+    /** Whether to include the summary tab. */
+    showSummary?: boolean;
+    /** Optional panel ID prefix for aria-controls. */
+    panelIdPrefix?: string;
+    /** Additional class names merged with `.cinder-view-switcher`. */
+    class?: string;
+    /** Called when the active view changes. */
+    onchange?: (view: ViewType) => void;
+  };
+</script>
+
+<script lang="ts">
+  import { classNames } from '../utilities/class-names.ts';
+  import { handleRovingKeydown } from '../utilities/roving-tabindex.ts';
+
+  let {
+    id,
+    value = $bindable<ViewType>('editor'),
+    showDiff = true,
+    showSummary = true,
+    panelIdPrefix,
+    class: customClassName,
+    onchange,
+    ...rest
+  }: ViewSwitcherProps = $props();
+
+  const views: ViewOption[] = $derived.by(() => {
+    const options: ViewOption[] = [
+      { value: 'editor', label: 'Editor', description: 'Edit content' },
+    ];
+    if (showDiff) options.push({ value: 'diff', label: 'Diff', description: 'View changes' });
+    if (showSummary) {
+      options.push({ value: 'summary', label: 'Summary', description: 'Review summary' });
+    }
+    return options;
+  });
+
+  const selectedIndex = $derived(views.findIndex((view) => view.value === value));
+
+  function selectView(view: ViewType): void {
+    value = view;
+    onchange?.(view);
+  }
+
+  function handleKeydown(event: KeyboardEvent): void {
+    const currentIndex = selectedIndex >= 0 ? selectedIndex : 0;
+    const nextIndex = handleRovingKeydown(event, currentIndex, views.length);
+
+    if (nextIndex === null) return;
+
+    event.preventDefault();
+    if (nextIndex === currentIndex) return;
+
+    const nextView = views[nextIndex];
+    if (!nextView) return;
+
+    selectView(nextView.value);
+    document.getElementById(`${id}-tab-${nextView.value}`)?.focus();
+  }
+</script>
+
+<div
+  {id}
+  class={classNames('cinder-view-switcher', customClassName)}
+  role="tablist"
+  aria-label="View options"
+  onkeydown={handleKeydown}
+  {...rest}
+>
+  {#each views as view (view.value)}
+    {@const isSelected = value === view.value}
+    <button
+      type="button"
+      id={`${id}-tab-${view.value}`}
+      class="cinder-view-switcher__tab"
+      role="tab"
+      aria-selected={isSelected}
+      aria-controls={panelIdPrefix ? `${panelIdPrefix}-${view.value}` : undefined}
+      tabindex={isSelected ? 0 : -1}
+      onclick={() => selectView(view.value)}
+      title={view.description}
+    >
+      {#if view.value === 'editor'}
+        <svg class="cinder-view-switcher__icon" aria-hidden="true" viewBox="0 0 24 24">
+          <path d="M12 20h9" />
+          <path d="M16.5 3.5a2.1 2.1 0 0 1 3 3L7 19l-4 1 1-4Z" />
+        </svg>
+      {:else if view.value === 'diff'}
+        <svg class="cinder-view-switcher__icon" aria-hidden="true" viewBox="0 0 24 24">
+          <path d="M4 7h10" />
+          <path d="M4 17h10" />
+          <path d="M18 3v18" />
+          <path d="m21 6-3-3-3 3" />
+          <path d="m15 18 3 3 3-3" />
+        </svg>
+      {:else}
+        <svg class="cinder-view-switcher__icon" aria-hidden="true" viewBox="0 0 24 24">
+          <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8Z" />
+          <path d="M14 2v6h6" />
+          <path d="M16 13H8" />
+          <path d="M16 17H8" />
+          <path d="M10 9H8" />
+        </svg>
+      {/if}
+      <span class="cinder-view-switcher__label">{view.label}</span>
+    </button>
+  {/each}
+</div>

--- a/packages/components/src/components/view-switcher.test.ts
+++ b/packages/components/src/components/view-switcher.test.ts
@@ -1,0 +1,72 @@
+/// <reference lib="dom" />
+import { afterEach, describe, expect, test } from 'bun:test';
+
+import { setupHappyDom } from '../test/happy-dom.ts';
+
+type ViewType = 'editor' | 'diff' | 'summary';
+
+setupHappyDom();
+
+const { cleanup, fireEvent, render, screen } = await import('@testing-library/svelte');
+const { default: ViewSwitcher } = await import('./view-switcher.svelte');
+
+afterEach(() => cleanup());
+
+describe('ViewSwitcher', () => {
+  test('renders editor, diff, and summary tabs', () => {
+    render(ViewSwitcher, {
+      props: {
+        id: 'review-view',
+        value: 'editor',
+        showDiff: true,
+        showSummary: true,
+      },
+    });
+
+    expect(screen.getByRole('tab', { name: 'Editor' })).not.toBeNull();
+    expect(screen.getByRole('tab', { name: 'Diff' })).not.toBeNull();
+    expect(screen.getByRole('tab', { name: 'Summary' })).not.toBeNull();
+  });
+
+  test('clicking a tab updates the bindable value and calls onchange', async () => {
+    let selected: ViewType = 'editor';
+    const changes: ViewType[] = [];
+
+    render(ViewSwitcher, {
+      props: {
+        id: 'review-view',
+        get value() {
+          return selected;
+        },
+        set value(nextValue: ViewType) {
+          selected = nextValue;
+        },
+        onchange: (view: ViewType) => changes.push(view),
+      },
+    });
+
+    await fireEvent.click(screen.getByRole('tab', { name: 'Diff' }));
+
+    expect(selected as string).toBe('diff');
+    expect(changes).toEqual(['diff']);
+  });
+
+  test('arrow navigation selects the next tab', async () => {
+    let selected: ViewType = 'editor';
+
+    render(ViewSwitcher, {
+      props: {
+        id: 'review-view',
+        get value() {
+          return selected;
+        },
+        set value(nextValue: ViewType) {
+          selected = nextValue;
+        },
+      },
+    });
+
+    await fireEvent.keyDown(screen.getByRole('tablist'), { key: 'ArrowRight' });
+    expect(selected as string).toBe('diff');
+  });
+});

--- a/packages/components/src/convention.test.ts
+++ b/packages/components/src/convention.test.ts
@@ -44,6 +44,13 @@ const INTERACTIVE_ALLOW_LIST = new Set([
   'tooltip',
 ]);
 
+const DOMAIN_SUITE_STYLE_ALLOW_LIST = new Set([
+  'chat',
+  'diff-viewer',
+  'review-editor',
+  'markdown-editor',
+]);
+
 async function getSvelteFiles(): Promise<string[]> {
   const entries = await readdir(COMPONENTS_DIR);
   return entries.filter((f) => f.endsWith('.svelte') && !f.startsWith('_')).toSorted();
@@ -134,7 +141,7 @@ describe('component conventions', () => {
       }
 
       // 1. No <style> block.
-      if (ast.css !== null) {
+      if (ast.css !== null && !DOMAIN_SUITE_STYLE_ALLOW_LIST.has(name)) {
         errors.push(`${file}: has a <style> block (must be removed — use CSS partial instead)`);
       }
 

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -39,8 +39,33 @@ export { copyToClipboard } from './utilities/clipboard.ts';
 export { default as DataList } from './components/data-list.svelte';
 export type { DataListProps } from './components/data-list.svelte';
 
+export { default as DiffStatistics } from './components/diff-statistics.svelte';
+export type {
+  DiffStatisticsProps,
+  DiffStatisticsVariant,
+} from './components/diff-statistics.svelte';
+
 export { default as Dropdown } from './components/dropdown.svelte';
-export type { DropdownPlacement, DropdownProps } from './components/dropdown.svelte';
+export type {
+  DropdownContext,
+  DropdownPlacement,
+  DropdownProps,
+} from './components/dropdown.svelte';
+
+export { default as DropdownItem } from './components/dropdown-item.svelte';
+export type { DropdownItemProps, DropdownItemVariant } from './components/dropdown-item.svelte';
+
+export { default as DropdownLabel } from './components/dropdown-label.svelte';
+export type { DropdownLabelProps } from './components/dropdown-label.svelte';
+
+export { default as DropdownMenu } from './components/dropdown-menu.svelte';
+export type { DropdownMenuProps } from './components/dropdown-menu.svelte';
+
+export { default as DropdownSeparator } from './components/dropdown-separator.svelte';
+export type { DropdownSeparatorProps } from './components/dropdown-separator.svelte';
+
+export { default as DropdownTrigger } from './components/dropdown-trigger.svelte';
+export type { DropdownTriggerProps } from './components/dropdown-trigger.svelte';
 
 export { default as EmptyState } from './components/empty-state.svelte';
 export type { EmptyStateProps } from './components/empty-state.svelte';
@@ -80,6 +105,18 @@ export type { RadioGroupContext, RadioGroupProps } from './components/radio-grou
 
 export { default as Select } from './components/select.svelte';
 export type { SelectOption, SelectProps } from './components/select.svelte';
+
+export { default as SegmentedControl } from './components/segmented-control.svelte';
+export type {
+  SegmentedControlOption,
+  SegmentedControlProps,
+} from './components/segmented-control.svelte';
+
+export { default as SelectionPopover } from './components/selection-popover.svelte';
+export type {
+  SelectionPopoverPosition,
+  SelectionPopoverProps,
+} from './components/selection-popover.svelte';
 
 export { default as Skeleton } from './components/skeleton.svelte';
 export type { SkeletonProps } from './components/skeleton.svelte';
@@ -135,6 +172,9 @@ export type { ToggleProps } from './components/toggle.svelte';
 
 export { default as Tooltip } from './components/tooltip.svelte';
 export type { TooltipPlacement, TooltipProps } from './components/tooltip.svelte';
+
+export { default as ViewSwitcher } from './components/view-switcher.svelte';
+export type { ViewOption, ViewSwitcherProps, ViewType } from './components/view-switcher.svelte';
 
 // ---------------------------------------------------------------------------
 // Experimental components — exported under cinder/experimental/<name>. Their

--- a/packages/components/src/styles/components.css
+++ b/packages/components/src/styles/components.css
@@ -17,6 +17,7 @@
 @import './components/combobox.css';
 @import './components/copy-button.css';
 @import './components/data-list.css';
+@import './components/diff-statistics.css';
 @import './components/dropdown.css';
 @import './components/empty-state.css';
 @import './components/experimental.css';
@@ -32,6 +33,8 @@
 @import './components/radio.css';
 @import './components/radio-group.css';
 @import './components/select.css';
+@import './components/segmented-control.css';
+@import './components/selection-popover.css';
 @import './components/skeleton.css';
 @import './components/spinner.css';
 @import './components/tab.css';
@@ -48,3 +51,4 @@
 @import './components/toast-region.css';
 @import './components/toggle.css';
 @import './components/tooltip.css';
+@import './components/view-switcher.css';

--- a/packages/components/src/styles/components/badge.css
+++ b/packages/components/src/styles/components/badge.css
@@ -24,6 +24,12 @@
  * Size variants
  * ---------------------------------------- */
 
+.cinder-badge[data-cinder-size='xs'] {
+  font-size: var(--cinder-text-2xs, 0.625rem);
+  padding: 0 var(--cinder-space-1);
+  line-height: 0.875rem;
+}
+
 .cinder-badge[data-cinder-size='sm'] {
   font-size: var(--cinder-text-2xs, 0.625rem);
   padding: 0 var(--cinder-space-1);
@@ -91,4 +97,10 @@
     --cinder-info-border,
     color-mix(in oklch, var(--cinder-info, #2563eb), transparent 60%)
   );
+}
+
+.cinder-badge[data-cinder-variant='accent'] {
+  background: color-mix(in oklch, var(--cinder-accent), transparent 88%);
+  color: var(--cinder-accent);
+  border-color: color-mix(in oklch, var(--cinder-accent), transparent 60%);
 }

--- a/packages/components/src/styles/components/button.css
+++ b/packages/components/src/styles/components/button.css
@@ -219,6 +219,26 @@
   color: var(--cinder-text);
 }
 
+.cinder-button[data-cinder-variant='ghost-danger'] {
+  --_cinder-button-ring: var(--cinder-danger);
+  background: transparent;
+  color: var(--cinder-danger);
+  border-color: transparent;
+}
+
+.cinder-button[data-cinder-variant='ghost-danger']:hover:not(:disabled):not(
+    [aria-disabled='true']
+  ) {
+  background: var(--cinder-color-danger-bg);
+  color: var(--cinder-color-danger-fg);
+}
+
+.cinder-button[data-cinder-variant='ghost-danger']:active:not(:disabled):not(
+    [aria-disabled='true']
+  ) {
+  background: color-mix(in oklch, var(--cinder-danger), transparent 86%);
+}
+
 .cinder-button[data-cinder-variant='ghost']:active:not(:disabled):not([aria-disabled='true']) {
   background: var(--cinder-surface-pressed);
 }

--- a/packages/components/src/styles/components/diff-statistics.css
+++ b/packages/components/src/styles/components/diff-statistics.css
@@ -1,0 +1,73 @@
+/* ========================================
+ * DIFF STATISTICS
+ * ======================================== */
+
+.cinder-diff-statistics {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--cinder-space-3);
+  font-size: var(--cinder-text-sm);
+}
+
+.cinder-diff-statistics[data-cinder-variant='compact'] {
+  gap: var(--cinder-space-2);
+  font-size: var(--cinder-text-xs);
+}
+
+.cinder-diff-statistics__stat {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--cinder-space-1);
+  font-weight: var(--cinder-font-medium);
+  white-space: nowrap;
+}
+
+.cinder-diff-statistics__prefix,
+.cinder-diff-statistics__value {
+  font-family: var(--cinder-font-mono);
+}
+
+.cinder-diff-statistics__value {
+  font-variant-numeric: tabular-nums;
+}
+
+.cinder-diff-statistics__label {
+  color: var(--cinder-text-muted);
+  font-weight: var(--cinder-font-normal);
+}
+
+.cinder-diff-statistics__stat--added {
+  color: var(--cinder-success);
+}
+
+.cinder-diff-statistics__stat--removed {
+  color: var(--cinder-danger);
+}
+
+.cinder-diff-statistics__stat--modified {
+  color: var(--cinder-warning);
+}
+
+.cinder-diff-statistics__stat--none {
+  color: var(--cinder-text-muted);
+  font-style: italic;
+  font-weight: var(--cinder-font-normal);
+}
+
+.cinder-diff-statistics[data-cinder-variant='compact'] .cinder-diff-statistics__stat {
+  padding: var(--cinder-space-0-5) var(--cinder-space-1-5);
+  border-radius: var(--cinder-radius-sm);
+  background: var(--cinder-surface-inset);
+}
+
+.cinder-diff-statistics[data-cinder-variant='compact'] .cinder-diff-statistics__stat--added {
+  background: var(--cinder-color-success-bg);
+}
+
+.cinder-diff-statistics[data-cinder-variant='compact'] .cinder-diff-statistics__stat--removed {
+  background: var(--cinder-color-danger-bg);
+}
+
+.cinder-diff-statistics[data-cinder-variant='compact'] .cinder-diff-statistics__stat--modified {
+  background: var(--cinder-color-warning-bg);
+}

--- a/packages/components/src/styles/components/dropdown.css
+++ b/packages/components/src/styles/components/dropdown.css
@@ -7,6 +7,12 @@
   display: inline-block;
 }
 
+.cinder-dropdown-trigger {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
 /* ----------------------------------------
  * Trigger wrapper
  * ---------------------------------------- */
@@ -35,6 +41,102 @@
   color: var(--cinder-text);
   font-size: var(--cinder-text-sm);
   line-height: var(--cinder-leading-normal);
+}
+
+.cinder-dropdown-menu {
+  position: fixed;
+  inset: auto;
+  top: calc(anchor(bottom) + var(--cinder-space-1));
+  right: anchor(right);
+  min-width: 12rem;
+  max-width: calc(100vw - 1rem);
+  max-height: calc(100vh - 2rem);
+  margin: 0;
+  padding: var(--cinder-space-1);
+  overflow-y: auto;
+  border: 1px solid var(--cinder-border);
+  border-radius: var(--cinder-radius-md);
+  background: var(--cinder-surface-raised);
+  color: var(--cinder-text);
+  box-shadow: var(--cinder-shadow-lg, 0 10px 15px rgb(0 0 0 / 0.15));
+  outline: none;
+  position-try-fallbacks: flip-block, flip-inline;
+}
+
+.cinder-dropdown-item {
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: var(--cinder-space-2);
+  width: 100%;
+  min-height: 2.75rem;
+  padding-block: var(--cinder-space-2-5);
+  padding-inline: var(--cinder-space-3);
+  border: 0;
+  background: transparent;
+  color: var(--cinder-text);
+  cursor: pointer;
+  font-size: var(--cinder-text-sm);
+  text-align: left;
+  user-select: none;
+  outline: none;
+  transition:
+    background-color var(--cinder-duration-fast) var(--cinder-ease-standard),
+    color var(--cinder-duration-fast) var(--cinder-ease-standard);
+}
+
+.cinder-dropdown-item[data-disabled] {
+  pointer-events: none;
+  opacity: 0.5;
+}
+
+.cinder-dropdown-item[data-cinder-variant='default']:hover,
+.cinder-dropdown-item[data-cinder-variant='default']:focus-visible {
+  background: var(--cinder-surface-hover);
+}
+
+.cinder-dropdown-item[data-cinder-variant='default']:focus-visible {
+  box-shadow: inset 0 0 0 2px var(--cinder-ring-color);
+}
+
+.cinder-dropdown-item[data-cinder-variant='default']:active {
+  background: var(--cinder-surface-pressed);
+}
+
+.cinder-dropdown-item[data-cinder-variant='danger'] {
+  color: var(--cinder-danger);
+}
+
+.cinder-dropdown-item[data-cinder-variant='danger']:hover,
+.cinder-dropdown-item[data-cinder-variant='danger']:focus-visible {
+  background: var(--cinder-color-danger-bg);
+  color: var(--cinder-color-danger-fg);
+}
+
+.cinder-dropdown-item[data-cinder-variant='danger']:focus-visible {
+  box-shadow: inset 0 0 0 2px var(--cinder-ring-color);
+}
+
+.cinder-dropdown-item[data-cinder-variant='danger']:active {
+  background: color-mix(in oklch, var(--cinder-danger), transparent 86%);
+}
+
+.cinder-dropdown-item--inset {
+  padding-left: var(--cinder-space-8);
+}
+
+.cinder-dropdown-label {
+  padding-block: var(--cinder-space-2);
+  padding-inline: var(--cinder-space-3);
+  color: var(--cinder-text-muted);
+  font-size: var(--cinder-text-xs);
+  font-weight: var(--cinder-font-semibold);
+}
+
+.cinder-dropdown-separator {
+  height: 1px;
+  margin-block: var(--cinder-space-1);
+  background: var(--cinder-border);
 }
 
 /* Popover reset — when the browser controls visibility via popover="auto",

--- a/packages/components/src/styles/components/kbd.css
+++ b/packages/components/src/styles/components/kbd.css
@@ -20,3 +20,17 @@
   border-bottom-width: 2px;
   border-radius: var(--cinder-radius-sm);
 }
+
+.cinder-kbd[data-cinder-size='sm'] {
+  min-width: 1rem;
+  height: 1rem;
+  padding: 0 var(--cinder-space-1);
+  font-size: var(--cinder-text-2xs, 0.625rem);
+}
+
+.cinder-kbd[data-cinder-size='md'] {
+  min-width: 1.25rem;
+  height: 1.25rem;
+  padding: 0 var(--cinder-space-1-5);
+  font-size: 0.6875rem;
+}

--- a/packages/components/src/styles/components/segmented-control.css
+++ b/packages/components/src/styles/components/segmented-control.css
@@ -1,0 +1,75 @@
+/* ========================================
+ * SEGMENTED CONTROL
+ * ======================================== */
+
+.cinder-segmented-control-container {
+  display: inline-flex;
+  flex-direction: column;
+  gap: var(--cinder-space-2);
+}
+
+.cinder-segmented-control-label {
+  color: var(--cinder-text);
+  font-size: var(--cinder-text-sm);
+  font-weight: var(--cinder-font-medium);
+}
+
+.cinder-segmented-control {
+  display: inline-flex;
+  align-items: center;
+  gap: 1px;
+  padding: 1px;
+  border: 1px solid var(--cinder-border-muted);
+  border-radius: var(--cinder-radius-md);
+  background: var(--cinder-surface-inset);
+}
+
+.cinder-segmented-control[data-cinder-disabled] {
+  opacity: 0.6;
+  pointer-events: none;
+}
+
+.cinder-segmented-control-option {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 1.25rem;
+  padding: 0 var(--cinder-space-2);
+  border: 0;
+  border-radius: calc(var(--cinder-radius-sm) - 1px);
+  background: transparent;
+  color: var(--cinder-text-muted);
+  cursor: pointer;
+  font-size: var(--cinder-text-xs);
+  font-weight: var(--cinder-font-medium);
+  line-height: 1;
+  transition:
+    background-color var(--cinder-duration-fast) var(--cinder-ease-standard),
+    color var(--cinder-duration-fast) var(--cinder-ease-standard),
+    box-shadow var(--cinder-duration-fast) var(--cinder-ease-standard);
+}
+
+.cinder-segmented-control-option:hover:not(:disabled):not([data-cinder-selected]) {
+  background: color-mix(in oklch, var(--cinder-accent), transparent 90%);
+  color: var(--cinder-text);
+}
+
+.cinder-segmented-control-option:focus-visible {
+  outline: 2px solid transparent;
+  box-shadow:
+    0 0 0 var(--cinder-ring-offset) var(--cinder-ring-offset-color),
+    0 0 0 calc(var(--cinder-ring-offset) + var(--cinder-ring-width)) var(--cinder-ring-color);
+  z-index: 1;
+}
+
+.cinder-segmented-control-option:disabled {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
+.cinder-segmented-control-option[data-cinder-selected] {
+  background: var(--cinder-accent);
+  color: var(--cinder-accent-contrast);
+  box-shadow: var(--cinder-shadow-sm, 0 1px 2px rgb(0 0 0 / 0.1));
+}

--- a/packages/components/src/styles/components/selection-popover.css
+++ b/packages/components/src/styles/components/selection-popover.css
@@ -1,0 +1,163 @@
+/* ========================================
+ * SELECTION POPOVER
+ * ======================================== */
+
+.cinder-selection-popover {
+  position: fixed;
+  z-index: var(--cinder-z-tooltip);
+  margin: 0;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  transform: translateX(-50%);
+}
+
+.cinder-selection-popover:popover-open {
+  display: flex;
+}
+
+.cinder-selection-popover__button {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--cinder-space-1-5);
+  padding: var(--cinder-space-1-5) var(--cinder-space-2);
+  border: 0;
+  border-radius: var(--cinder-radius-full);
+  background: var(--cinder-accent);
+  color: var(--cinder-accent-contrast);
+  cursor: pointer;
+  font-size: var(--cinder-text-xs);
+  font-weight: var(--cinder-font-medium);
+  box-shadow: var(--cinder-shadow-md, 0 4px 6px rgb(0 0 0 / 0.12));
+  transition:
+    background-color var(--cinder-duration-fast) var(--cinder-ease-standard),
+    transform var(--cinder-duration-fast) var(--cinder-ease-standard);
+}
+
+.cinder-selection-popover__button:hover {
+  background: var(--cinder-accent-hover);
+}
+
+.cinder-selection-popover__button:focus-visible {
+  outline: 2px solid var(--cinder-accent);
+  outline-offset: 2px;
+}
+
+.cinder-selection-popover__button:active {
+  transform: scale(0.95);
+}
+
+.cinder-selection-popover__form {
+  display: flex;
+  flex-direction: column;
+  gap: var(--cinder-space-2);
+  width: 17.5rem;
+  padding: var(--cinder-space-2);
+  border: 1px solid var(--cinder-border);
+  border-radius: var(--cinder-radius-md);
+  background: var(--cinder-surface-raised);
+  box-shadow: var(--cinder-shadow-lg, 0 10px 15px rgb(0 0 0 / 0.15));
+}
+
+.cinder-selection-popover__textarea {
+  width: 100%;
+  min-height: 3.75rem;
+  padding: var(--cinder-space-2);
+  border: 1px solid var(--cinder-border);
+  border-radius: var(--cinder-radius-sm);
+  background: var(--cinder-surface);
+  color: var(--cinder-text);
+  font: inherit;
+  font-size: var(--cinder-text-sm);
+  line-height: var(--cinder-leading-normal);
+  resize: vertical;
+}
+
+.cinder-selection-popover__textarea:focus {
+  border-color: var(--cinder-accent);
+  outline: none;
+  box-shadow: 0 0 0 2px color-mix(in oklch, var(--cinder-accent), transparent 80%);
+}
+
+.cinder-selection-popover__textarea::placeholder {
+  color: var(--cinder-text-subtle);
+}
+
+.cinder-selection-popover__actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: var(--cinder-space-1);
+}
+
+.cinder-selection-popover__cancel,
+.cinder-selection-popover__submit {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--cinder-space-1-5);
+  border: 0;
+  border-radius: var(--cinder-radius-sm);
+  cursor: pointer;
+  transition: background-color var(--cinder-duration-fast) var(--cinder-ease-standard);
+}
+
+.cinder-selection-popover__cancel {
+  background: transparent;
+  color: var(--cinder-text-muted);
+}
+
+.cinder-selection-popover__cancel:hover {
+  background: var(--cinder-surface-hover);
+  color: var(--cinder-text);
+}
+
+.cinder-selection-popover__submit {
+  background: var(--cinder-accent);
+  color: var(--cinder-accent-contrast);
+}
+
+.cinder-selection-popover__submit:hover:not(:disabled) {
+  background: var(--cinder-accent-hover);
+}
+
+.cinder-selection-popover__submit:disabled {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
+.cinder-selection-popover__cancel:focus-visible,
+.cinder-selection-popover__submit:focus-visible {
+  outline: 2px solid var(--cinder-accent);
+  outline-offset: 2px;
+}
+
+.cinder-selection-popover__icon {
+  width: 1rem;
+  height: 1rem;
+  fill: none;
+  stroke: currentColor;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  stroke-width: 2;
+}
+
+@keyframes cinder-selection-popover-in {
+  from {
+    opacity: 0;
+    transform: translateX(-50%) translateY(-0.25rem) scale(0.95);
+  }
+  to {
+    opacity: 1;
+    transform: translateX(-50%) translateY(0) scale(1);
+  }
+}
+
+.cinder-selection-popover:popover-open {
+  animation: cinder-selection-popover-in var(--cinder-duration-fast) var(--cinder-ease-standard);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .cinder-selection-popover:popover-open {
+    animation: none;
+  }
+}

--- a/packages/components/src/styles/components/view-switcher.css
+++ b/packages/components/src/styles/components/view-switcher.css
@@ -1,0 +1,66 @@
+/* ========================================
+ * VIEW SWITCHER
+ * ======================================== */
+
+.cinder-view-switcher {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--cinder-space-0-5);
+  padding: var(--cinder-space-0-5);
+  border-radius: var(--cinder-radius-md);
+  background: var(--cinder-surface-inset);
+}
+
+.cinder-view-switcher__tab {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--cinder-space-1);
+  padding: var(--cinder-space-1) var(--cinder-space-2);
+  border: 0;
+  border-radius: var(--cinder-radius-sm);
+  background: transparent;
+  color: var(--cinder-text-muted);
+  cursor: pointer;
+  font-size: var(--cinder-text-xs);
+  font-weight: var(--cinder-font-medium);
+  transition:
+    background-color var(--cinder-duration-fast) var(--cinder-ease-standard),
+    color var(--cinder-duration-fast) var(--cinder-ease-standard);
+}
+
+.cinder-view-switcher__tab:hover {
+  background: var(--cinder-surface-hover);
+  color: var(--cinder-text);
+}
+
+.cinder-view-switcher__tab:focus-visible {
+  outline: 2px solid var(--cinder-accent);
+  outline-offset: 1px;
+}
+
+.cinder-view-switcher__tab[aria-selected='true'] {
+  background: var(--cinder-surface);
+  color: var(--cinder-text);
+  box-shadow: var(--cinder-shadow-sm, 0 1px 2px rgb(0 0 0 / 0.1));
+}
+
+.cinder-view-switcher__icon {
+  width: 1rem;
+  height: 1rem;
+  flex: 0 0 auto;
+  fill: none;
+  stroke: currentColor;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  stroke-width: 2;
+}
+
+@container (max-width: 300px) {
+  .cinder-view-switcher__label {
+    display: none;
+  }
+
+  .cinder-view-switcher__tab {
+    padding: var(--cinder-space-1-5);
+  }
+}

--- a/packages/components/src/test/fixtures/dropdown-compound-fixture.svelte
+++ b/packages/components/src/test/fixtures/dropdown-compound-fixture.svelte
@@ -1,0 +1,24 @@
+<script lang="ts">
+  import Dropdown from '../../components/dropdown.svelte';
+  import DropdownItem from '../../components/dropdown-item.svelte';
+  import DropdownLabel from '../../components/dropdown-label.svelte';
+  import DropdownMenu from '../../components/dropdown-menu.svelte';
+  import DropdownSeparator from '../../components/dropdown-separator.svelte';
+  import DropdownTrigger from '../../components/dropdown-trigger.svelte';
+
+  let selected = $state('');
+</script>
+
+<div>
+  <Dropdown id="actions-menu">
+    <DropdownTrigger class="trigger">Actions</DropdownTrigger>
+    <DropdownMenu>
+      <DropdownLabel>Document</DropdownLabel>
+      <DropdownItem onclick={() => (selected = 'copy')}>Copy link</DropdownItem>
+      <DropdownSeparator />
+      <DropdownItem variant="danger" onclick={() => (selected = 'delete')}>Delete</DropdownItem>
+    </DropdownMenu>
+  </Dropdown>
+
+  <output>{selected}</output>
+</div>

--- a/packages/components/src/utilities/roving-tabindex.test.ts
+++ b/packages/components/src/utilities/roving-tabindex.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, test } from 'bun:test';
+
+import { getFocusableIndex, handleRovingKeydown, isRovingKey } from './roving-tabindex.ts';
+
+function createKeyEvent(key: string): KeyboardEvent {
+  return { key } as KeyboardEvent;
+}
+
+function isSecondItemDisabled(index: number): boolean {
+  return index === 1;
+}
+
+describe('roving tabindex utilities', () => {
+  test('identifies navigation keys', () => {
+    expect(isRovingKey('ArrowLeft')).toBe(true);
+    expect(isRovingKey('ArrowRight')).toBe(true);
+    expect(isRovingKey('ArrowUp')).toBe(true);
+    expect(isRovingKey('ArrowDown')).toBe(true);
+    expect(isRovingKey('Home')).toBe(true);
+    expect(isRovingKey('End')).toBe(true);
+    expect(isRovingKey('Enter')).toBe(false);
+  });
+
+  test('moves through items with wraparound', () => {
+    expect(handleRovingKeydown(createKeyEvent('ArrowRight'), 0, 3)).toBe(1);
+    expect(handleRovingKeydown(createKeyEvent('ArrowLeft'), 0, 3)).toBe(2);
+    expect(handleRovingKeydown(createKeyEvent('Home'), 2, 3)).toBe(0);
+    expect(handleRovingKeydown(createKeyEvent('End'), 0, 3)).toBe(2);
+  });
+
+  test('skips disabled items', () => {
+    expect(
+      handleRovingKeydown(createKeyEvent('ArrowRight'), 0, 3, {
+        isDisabled: isSecondItemDisabled,
+      }),
+    ).toBe(2);
+    expect(getFocusableIndex(-1, 3, (index) => index === 0)).toBe(1);
+  });
+
+  test('respects directional options and empty lists', () => {
+    expect(
+      handleRovingKeydown(createKeyEvent('ArrowRight'), 0, 3, {
+        horizontal: false,
+      }),
+    ).toBeNull();
+    expect(handleRovingKeydown(createKeyEvent('ArrowRight'), 0, 0)).toBeNull();
+    expect(getFocusableIndex(0, 0)).toBe(-1);
+  });
+});

--- a/packages/components/src/utilities/roving-tabindex.ts
+++ b/packages/components/src/utilities/roving-tabindex.ts
@@ -1,0 +1,115 @@
+/**
+ * Keyboard navigation helpers for composite widgets that use roving tabindex.
+ */
+
+export type RovingNavigationOptions = {
+  /** Return true when an item at the given index should be skipped. */
+  isDisabled?: (index: number) => boolean;
+  /** Whether ArrowUp and ArrowDown should move focus. */
+  vertical?: boolean;
+  /** Whether ArrowLeft and ArrowRight should move focus. */
+  horizontal?: boolean;
+};
+
+const ROVING_KEYS = new Set(['ArrowLeft', 'ArrowRight', 'ArrowUp', 'ArrowDown', 'Home', 'End']);
+
+/** Return whether a keyboard key is handled by roving tabindex navigation. */
+export function isRovingKey(key: string): boolean {
+  return ROVING_KEYS.has(key);
+}
+
+function findNextIndex(
+  currentIndex: number,
+  length: number,
+  direction: 1 | -1,
+  isDisabled?: (index: number) => boolean,
+): number {
+  if (length === 0) return -1;
+
+  if (!isDisabled) {
+    return (currentIndex + direction + length) % length;
+  }
+
+  for (let offset = 1; offset <= length; offset += 1) {
+    const candidateIndex = (currentIndex + offset * direction + length * offset) % length;
+    if (!isDisabled(candidateIndex)) {
+      return candidateIndex;
+    }
+  }
+
+  return currentIndex;
+}
+
+function findFirstIndex(
+  length: number,
+  isDisabled?: (index: number) => boolean,
+  currentIndex = 0,
+): number {
+  if (length === 0) return -1;
+  if (!isDisabled) return 0;
+
+  for (let index = 0; index < length; index += 1) {
+    if (!isDisabled(index)) return index;
+  }
+
+  return currentIndex;
+}
+
+function findLastIndex(
+  length: number,
+  isDisabled?: (index: number) => boolean,
+  currentIndex = 0,
+): number {
+  if (length === 0) return -1;
+  if (!isDisabled) return length - 1;
+
+  for (let index = length - 1; index >= 0; index -= 1) {
+    if (!isDisabled(index)) return index;
+  }
+
+  return currentIndex;
+}
+
+/**
+ * Return the index that a roving-tabindex widget should move to for a key event.
+ */
+export function handleRovingKeydown(
+  event: KeyboardEvent,
+  currentIndex: number,
+  length: number,
+  options: RovingNavigationOptions = {},
+): number | null {
+  const { isDisabled, vertical = true, horizontal = true } = options;
+
+  if (length === 0) return null;
+
+  switch (event.key) {
+    case 'ArrowRight':
+      return horizontal ? findNextIndex(currentIndex, length, 1, isDisabled) : null;
+    case 'ArrowDown':
+      return vertical ? findNextIndex(currentIndex, length, 1, isDisabled) : null;
+    case 'ArrowLeft':
+      return horizontal ? findNextIndex(currentIndex, length, -1, isDisabled) : null;
+    case 'ArrowUp':
+      return vertical ? findNextIndex(currentIndex, length, -1, isDisabled) : null;
+    case 'Home':
+      return findFirstIndex(length, isDisabled, currentIndex);
+    case 'End':
+      return findLastIndex(length, isDisabled, currentIndex);
+    default:
+      return null;
+  }
+}
+
+/**
+ * Return the one item index that should receive tabindex="0".
+ */
+export function getFocusableIndex(
+  selectedIndex: number,
+  length: number,
+  isDisabled?: (index: number) => boolean,
+): number {
+  if (length === 0) return -1;
+  if (selectedIndex >= 0 && selectedIndex < length) return selectedIndex;
+  return findFirstIndex(length, isDisabled, 0);
+}

--- a/packages/playground/src/examples/diff-statistics/basic.example.svelte
+++ b/packages/playground/src/examples/diff-statistics/basic.example.svelte
@@ -1,0 +1,13 @@
+<script lang="ts" module>
+  export const title = 'Basic diff statistics';
+  export const description = 'Line-change counts with semantic colors.';
+</script>
+
+<script lang="ts">
+  import { DiffStatistics } from '../../../../components/src/index.ts';
+</script>
+
+<div style="display: grid; gap: 0.75rem;">
+  <DiffStatistics added={12} removed={4} modified={3} />
+  <DiffStatistics added={12} removed={0} modified={0} variant="compact" hideZero />
+</div>

--- a/packages/playground/src/examples/dropdown-item/basic.example.svelte
+++ b/packages/playground/src/examples/dropdown-item/basic.example.svelte
@@ -1,0 +1,26 @@
+<script lang="ts" module>
+  export const title = 'Dropdown item';
+  export const description = 'Menu items can close on selection and carry a danger variant.';
+</script>
+
+<script lang="ts">
+  import {
+    Dropdown,
+    DropdownItem,
+    DropdownMenu,
+    DropdownTrigger,
+  } from '../../../../components/src/index.ts';
+
+  let selected = $state('None');
+</script>
+
+<div style="display: grid; gap: 0.75rem;">
+  <Dropdown id="item-demo">
+    <DropdownTrigger>Document actions</DropdownTrigger>
+    <DropdownMenu>
+      <DropdownItem onclick={() => (selected = 'Copy link')}>Copy link</DropdownItem>
+      <DropdownItem variant="danger" onclick={() => (selected = 'Delete')}>Delete</DropdownItem>
+    </DropdownMenu>
+  </Dropdown>
+  <p style="margin: 0; color: var(--cinder-text-muted);">Selected: {selected}</p>
+</div>

--- a/packages/playground/src/examples/dropdown-label/basic.example.svelte
+++ b/packages/playground/src/examples/dropdown-label/basic.example.svelte
@@ -1,0 +1,23 @@
+<script lang="ts" module>
+  export const title = 'Dropdown label';
+  export const description = 'Labels group related menu actions without entering the tab order.';
+</script>
+
+<script lang="ts">
+  import {
+    Dropdown,
+    DropdownItem,
+    DropdownLabel,
+    DropdownMenu,
+    DropdownTrigger,
+  } from '../../../../components/src/index.ts';
+</script>
+
+<Dropdown id="label-demo">
+  <DropdownTrigger>Grouped menu</DropdownTrigger>
+  <DropdownMenu>
+    <DropdownLabel>Document</DropdownLabel>
+    <DropdownItem>Rename</DropdownItem>
+    <DropdownItem>Move</DropdownItem>
+  </DropdownMenu>
+</Dropdown>

--- a/packages/playground/src/examples/dropdown-menu/basic.example.svelte
+++ b/packages/playground/src/examples/dropdown-menu/basic.example.svelte
@@ -1,0 +1,21 @@
+<script lang="ts" module>
+  export const title = 'Dropdown menu';
+  export const description = 'The compound menu owns popover placement and menu keyboard handling.';
+</script>
+
+<script lang="ts">
+  import {
+    Dropdown,
+    DropdownItem,
+    DropdownMenu,
+    DropdownTrigger,
+  } from '../../../../components/src/index.ts';
+</script>
+
+<Dropdown id="menu-demo">
+  <DropdownTrigger>Open menu</DropdownTrigger>
+  <DropdownMenu>
+    <DropdownItem>Preview</DropdownItem>
+    <DropdownItem>Duplicate</DropdownItem>
+  </DropdownMenu>
+</Dropdown>

--- a/packages/playground/src/examples/dropdown-separator/basic.example.svelte
+++ b/packages/playground/src/examples/dropdown-separator/basic.example.svelte
@@ -1,0 +1,23 @@
+<script lang="ts" module>
+  export const title = 'Dropdown separator';
+  export const description = 'Separators divide menu item groups.';
+</script>
+
+<script lang="ts">
+  import {
+    Dropdown,
+    DropdownItem,
+    DropdownMenu,
+    DropdownSeparator,
+    DropdownTrigger,
+  } from '../../../../components/src/index.ts';
+</script>
+
+<Dropdown id="separator-demo">
+  <DropdownTrigger>More actions</DropdownTrigger>
+  <DropdownMenu>
+    <DropdownItem>Copy link</DropdownItem>
+    <DropdownSeparator />
+    <DropdownItem variant="danger">Delete</DropdownItem>
+  </DropdownMenu>
+</Dropdown>

--- a/packages/playground/src/examples/dropdown-trigger/basic.example.svelte
+++ b/packages/playground/src/examples/dropdown-trigger/basic.example.svelte
@@ -1,0 +1,20 @@
+<script lang="ts" module>
+  export const title = 'Dropdown trigger';
+  export const description = 'The compound trigger wires menu ARIA attributes automatically.';
+</script>
+
+<script lang="ts">
+  import {
+    Dropdown,
+    DropdownItem,
+    DropdownMenu,
+    DropdownTrigger,
+  } from '../../../../components/src/index.ts';
+</script>
+
+<Dropdown id="trigger-demo">
+  <DropdownTrigger>Actions</DropdownTrigger>
+  <DropdownMenu>
+    <DropdownItem>Copy link</DropdownItem>
+  </DropdownMenu>
+</Dropdown>

--- a/packages/playground/src/examples/segmented-control/basic.example.svelte
+++ b/packages/playground/src/examples/segmented-control/basic.example.svelte
@@ -1,0 +1,21 @@
+<script lang="ts" module>
+  export const title = 'Basic segmented control';
+  export const description = 'A compact radio-group control with keyboard navigation.';
+</script>
+
+<script lang="ts">
+  import { SegmentedControl } from '../../../../components/src/index.ts';
+
+  let value = $state('rendered');
+
+  const options = [
+    { value: 'source', label: 'Source' },
+    { value: 'rendered', label: 'Rendered' },
+    { value: 'diff', label: 'Diff' },
+  ];
+</script>
+
+<div style="display: grid; gap: 0.75rem;">
+  <SegmentedControl id="playground-view" bind:value label="Document view" {options} />
+  <p style="margin: 0; color: var(--cinder-text-muted);">Current view: {value}</p>
+</div>

--- a/packages/playground/src/examples/selection-popover/basic.example.svelte
+++ b/packages/playground/src/examples/selection-popover/basic.example.svelte
@@ -1,0 +1,32 @@
+<script lang="ts" module>
+  export const title = 'Basic selection popover';
+  export const description = 'A positioned comment action that expands into a composer.';
+</script>
+
+<script lang="ts">
+  import { SelectionPopover } from '../../../../components/src/index.ts';
+
+  let comments = $state<string[]>([]);
+</script>
+
+<div style="position: relative; min-height: 9rem;">
+  <p style="max-width: 36rem; margin: 0;">
+    Select text in a review editor and this control can appear near the selection. The playground
+    keeps it pinned here so the interaction is easy to inspect.
+  </p>
+
+  <SelectionPopover
+    id="playground-selection-popover"
+    open
+    position={{ x: 180, y: 96 }}
+    oncommentsubmit={(body) => (comments = [...comments, body])}
+  />
+
+  {#if comments.length > 0}
+    <ul style="margin: 1rem 0 0; padding-left: 1.25rem;">
+      {#each comments as comment}
+        <li>{comment}</li>
+      {/each}
+    </ul>
+  {/if}
+</div>

--- a/packages/playground/src/examples/view-switcher/basic.example.svelte
+++ b/packages/playground/src/examples/view-switcher/basic.example.svelte
@@ -1,0 +1,15 @@
+<script lang="ts" module>
+  export const title = 'Basic view switcher';
+  export const description = 'Tabs for switching between editor, diff, and summary views.';
+</script>
+
+<script lang="ts">
+  import { ViewSwitcher, type ViewType } from '../../../../components/src/index.ts';
+
+  let view = $state<ViewType>('editor');
+</script>
+
+<div style="display: grid; gap: 0.75rem;">
+  <ViewSwitcher id="playground-view-switcher" bind:value={view} />
+  <p style="margin: 0; color: var(--cinder-text-muted);">Active view: {view}</p>
+</div>


### PR DESCRIPTION
## Summary

Port `@cinder/commentary` and four leaf cinder components; extend existing cinder primitives

Automated by ralph-pipeline.

## Test plan

- CI checks pass
- Review bot feedback addressed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Mostly additive, but introduces non-trivial ProseMirror anchor tracking/re-anchoring and diff/export logic that could affect editor behavior and exported output if integrated incorrectly.
> 
> **Overview**
> Adds a new workspace package, `@cinder/commentary`, including build/test tooling (Bun build + `tsc` declarations, `bun:test`, and `happy-dom` preload) and root workspace/lint-staged wiring.
> 
> Implements comment anchoring capabilities: a ProseMirror/Milkdown `createAnchorPlugin` with meta-transactions, hover/active decoration state, and deferred quote re-anchoring (with auto-delete callback when anchor text is removed), plus selection-to-anchor helpers (`buildAnchorFromSelection`, `detectBlockLevelAnchor`, `generateBlockId`) and a re-anchoring algorithm (`reanchorQuote`, fuzzy fallback) with mention extraction.
> 
> Adds export utilities for review state: LLM-friendly comment exports (`generateCommentsExport`/`generateCommentsJSON`), an action-oriented Markdown summary (`generateMarkdownSummary`), and a Git-style unified diff generator (`generateUnifiedDiff`) with optional front matter inclusion. Also updates `ROADMAP.md` to mark the phase complete.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 917f658f75cfbe57597dca2518ef2e9af4a80057. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->