### PR TITLE
Fix seven visual defects: dropdown placement, kbd, pagination, segmented-control, navigation, toggle

### DIFF
--- a/packages/components/src/components/pagination.svelte
+++ b/packages/components/src/components/pagination.svelte
@@ -123,7 +123,7 @@
     </button>
 
     <!-- Page number buttons -->
-    <ul class="cinder-pagination__pages">
+    <ul class="cinder-pagination__pages" role="list">
       {#each pageItems as item (typeof item === 'string' ? item : `page-${item}`)}
         {#if typeof item === 'string'}
           <li class="cinder-pagination__ellipsis-item" aria-hidden="true">

--- a/packages/components/src/styles/components/dropdown.css
+++ b/packages/components/src/styles/components/dropdown.css
@@ -104,7 +104,7 @@
   display: flex;
   align-items: center;
   gap: var(--cinder-space-2);
-  width: 100%;
+  width: calc(100% - var(--cinder-space-1) * 2);
   min-height: 2.75rem;
   margin-inline: var(--cinder-space-1);
   padding-block: var(--cinder-space-2-5);
@@ -228,8 +228,8 @@
   }
 
   .cinder-dropdown[data-cinder-placement='bottom-end'] .cinder-dropdown__menu[popover] {
-    right: anchor(right);
-    left: auto;
+    inset-inline-end: anchor(right);
+    inset-inline-start: auto;
   }
 }
 

--- a/packages/components/src/styles/components/dropdown.css
+++ b/packages/components/src/styles/components/dropdown.css
@@ -104,9 +104,8 @@
   display: flex;
   align-items: center;
   gap: var(--cinder-space-2);
-  width: calc(100% - var(--cinder-space-1) * 2);
+  width: 100%;
   min-height: 2.75rem;
-  margin-inline: var(--cinder-space-1);
   padding-block: var(--cinder-space-2-5);
   padding-inline: var(--cinder-space-3);
   border: 0;
@@ -121,6 +120,15 @@
   transition:
     background-color var(--cinder-duration-fast) var(--cinder-ease-standard),
     color var(--cinder-duration-fast) var(--cinder-ease-standard);
+}
+
+/* Scoped to the BEM-style menu (.cinder-dropdown__menu), which uses padding-block-only
+ * (no horizontal inset). Items inset themselves so the rounded hover/focus background
+ * doesn't bleed into the menu's outer corners. The flat-named .cinder-dropdown-menu
+ * variant already has padding on all sides — items there sit at full width. */
+.cinder-dropdown__menu .cinder-dropdown-item {
+  width: calc(100% - var(--cinder-space-1) * 2);
+  margin-inline: var(--cinder-space-1);
 }
 
 .cinder-dropdown-item[data-disabled] {

--- a/packages/components/src/styles/components/dropdown.css
+++ b/packages/components/src/styles/components/dropdown.css
@@ -67,6 +67,7 @@
   z-index: var(--cinder-z-dropdown, 40);
   min-width: 12rem;
   padding: var(--cinder-space-1) 0;
+  overflow: hidden;
 
   border-radius: var(--cinder-radius-lg);
   border: 1px solid var(--cinder-border);
@@ -105,9 +106,11 @@
   gap: var(--cinder-space-2);
   width: 100%;
   min-height: 2.75rem;
+  margin-inline: var(--cinder-space-1);
   padding-block: var(--cinder-space-2-5);
   padding-inline: var(--cinder-space-3);
   border: 0;
+  border-radius: var(--cinder-radius-sm);
   background: transparent;
   color: var(--cinder-text);
   cursor: pointer;
@@ -225,7 +228,8 @@
   }
 
   .cinder-dropdown[data-cinder-placement='bottom-end'] .cinder-dropdown__menu[popover] {
-    inset-inline-end: calc(100vw - anchor(right));
+    right: anchor(right);
+    left: auto;
   }
 }
 

--- a/packages/components/src/styles/components/kbd.css
+++ b/packages/components/src/styles/components/kbd.css
@@ -19,8 +19,16 @@
   border: 1px solid var(--cinder-border);
   border-radius: var(--cinder-radius-sm);
   box-shadow: inset 0 -1px 0 var(--cinder-border-muted);
-  box-sizing: border-box;
   vertical-align: middle;
+}
+
+/* Forced-colors mode suppresses box-shadow, so the keycap depth disappears.
+ * Restore the visual affordance with a real bottom border (which HCM keeps). */
+@media (forced-colors: active) {
+  .cinder-kbd {
+    border-bottom-width: 2px;
+    box-shadow: none;
+  }
 }
 
 .cinder-kbd[data-cinder-size='sm'] {

--- a/packages/components/src/styles/components/kbd.css
+++ b/packages/components/src/styles/components/kbd.css
@@ -17,8 +17,10 @@
   color: var(--cinder-text);
   background: var(--cinder-surface-raised);
   border: 1px solid var(--cinder-border);
-  border-bottom-width: 2px;
   border-radius: var(--cinder-radius-sm);
+  box-shadow: inset 0 -1px 0 var(--cinder-border-muted);
+  box-sizing: border-box;
+  vertical-align: middle;
 }
 
 .cinder-kbd[data-cinder-size='sm'] {

--- a/packages/components/src/styles/components/navigation-bar.css
+++ b/packages/components/src/styles/components/navigation-bar.css
@@ -19,11 +19,13 @@
  * ---------------------------------------- */
 
 .cinder-navigation-bar__brand {
-  display: inline-flex;
+  display: flex;
   align-items: center;
   flex-shrink: 0;
   min-height: 2rem;
   padding-block: var(--cinder-space-1-5);
+  font-size: var(--cinder-text-lg);
+  font-weight: var(--cinder-font-semibold);
 }
 
 .cinder-navigation-bar__items {

--- a/packages/components/src/styles/components/navigation-bar.css
+++ b/packages/components/src/styles/components/navigation-bar.css
@@ -19,9 +19,11 @@
  * ---------------------------------------- */
 
 .cinder-navigation-bar__brand {
-  display: flex;
+  display: inline-flex;
   align-items: center;
   flex-shrink: 0;
+  min-height: 2rem;
+  padding-block: var(--cinder-space-1-5);
 }
 
 .cinder-navigation-bar__items {

--- a/packages/components/src/styles/components/segmented-control.css
+++ b/packages/components/src/styles/components/segmented-control.css
@@ -6,7 +6,6 @@
   display: inline-flex;
   flex-direction: column;
   gap: var(--cinder-space-2);
-  width: max-content;
 }
 
 .cinder-segmented-control-label {

--- a/packages/components/src/styles/components/segmented-control.css
+++ b/packages/components/src/styles/components/segmented-control.css
@@ -6,6 +6,7 @@
   display: inline-flex;
   flex-direction: column;
   gap: var(--cinder-space-2);
+  width: max-content;
 }
 
 .cinder-segmented-control-label {

--- a/packages/components/src/styles/components/toggle.css
+++ b/packages/components/src/styles/components/toggle.css
@@ -20,6 +20,7 @@
   border: none;
   border-radius: 9999px;
   cursor: pointer;
+  vertical-align: middle;
 
   /* Track background — unset (off) state. */
   background: var(--cinder-toggle-track-off, var(--cinder-border-muted, #d1d5db));
@@ -96,8 +97,11 @@
   inset-block-start: 50%;
   inset-inline-start: 0.125rem; /* 2px gap from track edge */
   display: block;
-  width: var(--cinder-toggle-thumb-size, 1rem); /* 16px — leaves 4px vertical gap in 24px track */
-  height: var(--cinder-toggle-thumb-size, 1rem);
+  width: var(
+    --cinder-toggle-thumb-size,
+    1.125rem
+  ); /* 18px — leaves 3px vertical gap in 24px track */
+  height: var(--cinder-toggle-thumb-size, 1.125rem);
   border-radius: 50%;
   background: var(--cinder-toggle-thumb-color, #ffffff);
   box-shadow: var(
@@ -115,9 +119,9 @@
 }
 
 /* Pressed: slide thumb to the end. Travel distance is track-width minus thumb-size minus
- * the 2px gap on each side: 44 - 16 - 4 = 24px = 1.5rem. */
+ * the 2px gap on each side: 44 - 18 - 4 = 22px = 1.375rem. */
 .cinder-toggle[data-cinder-checked] .cinder-toggle__thumb {
-  transform: translate(var(--cinder-toggle-thumb-travel, 1.5rem), -50%);
+  transform: translate(var(--cinder-toggle-thumb-travel, 1.375rem), -50%);
 }
 
 /* ----------------------------------------

--- a/packages/playground/src/examples/navigation-bar/basic.example.svelte
+++ b/packages/playground/src/examples/navigation-bar/basic.example.svelte
@@ -11,7 +11,7 @@
 
 <NavigationBar>
   {#snippet brand()}
-    <strong style="font-size: 1.1rem;">Acme</strong>
+    <strong>Acme</strong>
   {/snippet}
   {#snippet items()}
     <NavigationItem onClick={() => (active = 'home')} active={active === 'home'}>

--- a/packages/playground/src/examples/segmented-control/basic.example.svelte
+++ b/packages/playground/src/examples/segmented-control/basic.example.svelte
@@ -15,7 +15,7 @@
   ];
 </script>
 
-<div style="display: grid; gap: 0.75rem;">
+<div style="display: grid; gap: 0.75rem; justify-items: start;">
   <SegmentedControl id="playground-view" bind:value label="Document view" {options} />
   <p style="margin: 0; color: var(--cinder-text-muted);">Current view: {value}</p>
 </div>


### PR DESCRIPTION
## Summary

Fixes seven visual defects from the playground audit. CSS-only (plus one markup change for the pagination `role="list"`). Verified visually in a real browser via `claude-in-chrome` MCP — see "Verification" section.

## Changes

**Dropdown**
- Bottom-end placement now anchors to the trigger's right edge instead of the viewport. Uses logical properties (`inset-inline-end: anchor(right); inset-inline-start: auto`) matching the bottom-start rule's convention. RTL is explicitly out of scope for this PR.
- Item highlight respects the menu's border-radius. Menu clips children via `overflow: hidden`; items have their own `border-radius: var(--cinder-radius-sm)` and `margin-inline: var(--cinder-space-1)`. Width corrected to `calc(100% - var(--cinder-space-1) * 2)` so items fit the menu without relying on overflow clipping.

**Kbd**
- Replaced asymmetric `border-bottom-width: 2px` with `box-shadow: inset 0 -1px 0 var(--cinder-border-muted)` for the keycap effect — no dimensional shift, consistent heights across content.
- Added `vertical-align: middle` for inline contexts.
- Added `@media (forced-colors: active)` block restoring `border-bottom-width: 2px` and clearing the shadow (HCM suppresses box-shadows; the border keeps the keycap depth cue accessible).

**Pagination**
- `<ul>` gets `role="list"` so the foundation reset (`ul[role='list'] { list-style: none; padding: 0 }`) applies. Bullet glyphs gone.

**Segmented control**
- Story container uses `justify-items: start` so the control sizes to its content rather than stretching to fill the grid cell. No component-level constraint added (one source of truth: the story's grid alignment).

**Navigation bar brand**
- `display: flex; align-items: center; min-height: 2rem; padding-block: var(--cinder-space-1-5)` so the brand shares vertical metrics with `.cinder-navigation-item`.
- Explicit `font-size: var(--cinder-text-lg)` (16px) + `font-weight: var(--cinder-font-semibold)` for visual hierarchy. Story drops the inline `font-size: 1.1rem` override — the component owns brand typography now.

**Toggle**
- Thumb size `1rem` → `1.125rem` (16→18px), travel `1.5rem` → `1.375rem` (math: 44 - 18 - 4 = 22). iOS/macOS-proportioned.
- `vertical-align: middle` for inline alignment.

## Verification

Visual verification via `claude-in-chrome` MCP (1700px viewport, LTR):

| Story | Result |
|---|---|
| `/page/dropdown` placement | Bottom-end menu right edge matches trigger right edge: delta = 0px |
| `/page/dropdown` items | All 4 grouped-menu items fit cleanly inside 192px menu (174px wide, 9px gap each side) |
| `/page/kbd` | All `md` chips 20px height, all `sm` chips 16px height across content (`Esc`, `⌘`, `K`, `Shift`, `Tab`) |
| `/page/pagination` | `<ul>` has `role="list"`, computed `list-style: none`, `padding: 0` |
| `/page/segmented-control` | Container 171px in 1602px parent (sized to content) |
| `/page/navigation-bar` | Brand 16px / 600, item 13px / 500; bottom edges within 2px |
| `/page/toggle` | Track 44×24, thumb 18×18, gap-top 3px (centered), gap-left 2px (off) / 24px (on) |

Commands:
```bash
bun install
cd packages/components
bun run lint        # 0 errors, 8 pre-existing warnings
bun run typecheck   # 0 errors
bun run test        # 515 pass, 0 fail
bun run build       # succeeds
```

## Review committee

Pre-reviewed by:
- frontend-architect
- ux-designer
- simplicity-engineer
- junior-engineer
- Codex (gpt-5.4, xhigh reasoning)

2 rounds of review. Round 1 produced 5 must-fix items (dropdown item width overflow, kbd HCM regression, navigation brand visual hierarchy, segmented control duplicate constraint, dropdown bottom-end logical-properties consistency); all addressed. Round 2: all reviewers APPROVED.

## Test plan

- [x] Lint clean (0 errors)
- [x] Typecheck clean (0 errors)
- [x] Tests pass (515/515)
- [x] Build succeeds
- [x] Visual smoke-tests pass via `claude-in-chrome` (see table above)
- [ ] Eyeball each affected story manually after merge to confirm no surprises in dark mode / smaller viewports

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily CSS/markup tweaks to component styling and positioning; low risk but could cause minor visual regressions across dropdowns/toggles in edge browsers (popover/anchor positioning, forced-colors).
> 
> **Overview**
> Fixes several UI polish issues across components, mainly via CSS adjustments.
> 
> Dropdown menus now clip item hover/focus to rounded corners (`overflow: hidden` + item inset/radius) and `bottom-end` popover positioning anchors to the trigger’s right edge (logical `inset-*` updates). `kbd` switches to an inset shadow for the keycap effect with a forced-colors fallback, and both `kbd` and `toggle` add `vertical-align: middle`; the toggle thumb size/travel are updated for better proportions.
> 
> Pagination adds `role="list"` to its `<ul>` so list-reset styles apply, and playground examples are adjusted to rely on component-owned navigation brand typography and prevent segmented-control stretching (`justify-items: start`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 25cede549970e1d985edd3db938d79c96ce82394. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->