### PR TITLE
Fix tooltip clipping and selection-popover story rendering

### DIFF
--- a/packages/playground/src/component-page.svelte
+++ b/packages/playground/src/component-page.svelte
@@ -146,7 +146,6 @@
     background-color: var(--cinder-surface);
     border: 1px solid var(--cinder-border);
     border-radius: var(--cinder-radius-lg);
-    overflow: hidden;
   }
 
   .example-card-header {
@@ -173,6 +172,7 @@
     padding: var(--cinder-space-6);
     min-height: 4rem;
     display: block;
+    overflow: visible;
   }
 
   /* Scoped to .example-preview descendants so the helper can't leak into

--- a/packages/playground/src/examples/selection-popover/basic.example.svelte
+++ b/packages/playground/src/examples/selection-popover/basic.example.svelte
@@ -6,7 +6,13 @@
 <script lang="ts">
   import { SelectionPopover } from '../../../../components/src/index.ts';
 
-  let comments = $state<string[]>([]);
+  type Comment = { id: string; body: string };
+
+  let comments = $state<Comment[]>([]);
+
+  function addComment(body: string): void {
+    comments = [...comments, { id: crypto.randomUUID(), body }];
+  }
 </script>
 
 <div style="position: relative; min-height: 9rem;">
@@ -19,15 +25,15 @@
     id="playground-selection-popover"
     open
     position={{ x: 180, y: 96 }}
-    oncommentsubmit={(body) => (comments = [...comments, body])}
+    oncommentsubmit={addComment}
   />
 
   {#if comments.length > 0}
     <section class="comments-section" aria-label="Submitted comments">
       <h3 class="comments-title">Submitted comments</h3>
-      {#each comments as comment (comment)}
+      {#each comments as comment (comment.id)}
         <article class="comment-card">
-          {comment}
+          {comment.body}
         </article>
       {/each}
     </section>

--- a/packages/playground/src/examples/selection-popover/basic.example.svelte
+++ b/packages/playground/src/examples/selection-popover/basic.example.svelte
@@ -23,10 +23,19 @@
   />
 
   {#if comments.length > 0}
-    <ul style="margin: 1rem 0 0; padding-left: 1.25rem;">
-      {#each comments as comment}
-        <li>{comment}</li>
+    <section style="margin: 1rem 0 0;" aria-label="Submitted comments">
+      <h4
+        style="margin: 0 0 0.5rem; font-size: var(--cinder-text-xs); color: var(--cinder-text-muted); text-transform: uppercase; letter-spacing: 0.04em;"
+      >
+        Submitted comments
+      </h4>
+      {#each comments as comment, i (i)}
+        <article
+          style="padding: 0.5rem 0.75rem; border: 1px solid var(--cinder-border-muted); border-radius: 0.375rem; margin-bottom: 0.375rem; background: var(--cinder-surface);"
+        >
+          {comment}
+        </article>
       {/each}
-    </ul>
+    </section>
   {/if}
 </div>

--- a/packages/playground/src/examples/selection-popover/basic.example.svelte
+++ b/packages/playground/src/examples/selection-popover/basic.example.svelte
@@ -23,19 +23,36 @@
   />
 
   {#if comments.length > 0}
-    <section style="margin: 1rem 0 0;" aria-label="Submitted comments">
-      <h4
-        style="margin: 0 0 0.5rem; font-size: var(--cinder-text-xs); color: var(--cinder-text-muted); text-transform: uppercase; letter-spacing: 0.04em;"
-      >
-        Submitted comments
-      </h4>
-      {#each comments as comment, i (i)}
-        <article
-          style="padding: 0.5rem 0.75rem; border: 1px solid var(--cinder-border-muted); border-radius: 0.375rem; margin-bottom: 0.375rem; background: var(--cinder-surface);"
-        >
+    <section class="comments-section" aria-label="Submitted comments">
+      <h3 class="comments-title">Submitted comments</h3>
+      {#each comments as comment (comment)}
+        <article class="comment-card">
           {comment}
         </article>
       {/each}
     </section>
   {/if}
 </div>
+
+<style>
+  .comments-section {
+    margin: 1rem 0 0;
+  }
+
+  .comments-title {
+    margin: 0 0 0.5rem;
+    font-size: var(--cinder-text-xs);
+    font-weight: var(--cinder-font-medium);
+    color: var(--cinder-text-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+  }
+
+  .comment-card {
+    padding: 0.5rem 0.75rem;
+    margin-bottom: 0.375rem;
+    border: 1px solid var(--cinder-border-muted);
+    border-radius: var(--cinder-radius-sm);
+    background: var(--cinder-surface);
+  }
+</style>


### PR DESCRIPTION
## Summary

Two playground-only fixes from the audit. No component code touched — both changes are scoped to `packages/playground`.

**Tooltip clipping** — the basic tooltip story rendered with the leading "Th" of its text clipped against the playground story-card edge. Diagnosis via `claude-in-chrome` traced the clip to `.example-card` having `overflow: hidden`. Removed that and added explicit `overflow: visible` on `.example-preview`. Verified all four tooltip placements (top/right/bottom/left) still render fully within the card boundary thanks to the preview's 24px padding.

**Selection-popover story** — submitted comments rendered as `<ul>/<li>`, conceptually suggesting the popover inserted a list item into the document body. Restructured to render comments as `<article>` cards inside a labeled `<section aria-label="Submitted comments">`. Styling moved to a scoped `<style>` block (no inline-style attributes), uses design tokens (`--cinder-radius-sm`, `--cinder-text-xs`, etc.), proper heading hierarchy (`<h3>`), and stable each-block keying (`(comment)` not the array index).

## Verification

Visual verification via `claude-in-chrome` (1700px viewport):

| Story | Result |
|---|---|
| `/page/tooltip` (basic) | tooltip text "This is a helpful explanation." renders fully (left=1px) — no clipping |
| `/page/tooltip` (placements) | all four placements (top/right/bottom/left) stay within the card boundary |
| `/page/page-layout` | sticky header sits 25px inside the card, well past the 12px border-radius — no bleed |
| `/page/selection-popover` | submit a comment → renders as `<article class="comment-card">` inside `<section aria-label="Submitted comments">` with `<h3>Submitted comments</h3>` |

Computed styles verified:
- `.example-card { overflow: visible; border-radius: 12px; }`
- `.example-preview { overflow: visible; padding: 24px; }`
- `.comment-card { border-radius: 6px; background: oklch(...); }` (= `var(--cinder-radius-sm)` and `var(--cinder-surface)`)

Local checks:
```bash
bun run lint        # 0 errors
bun run typecheck   # 0 errors
bun run test        # 515 pass, 0 fail
```

## Review committee

Pre-reviewed by:
- ux-designer
- simplicity-engineer
- junior-engineer
- Codex (gpt-5.4, xhigh reasoning)

(Skipped frontend-architect, testing-expert, typescript-expert — pure playground story changes, no public API or test surface affected.)

2 rounds of review. Round 1 produced 3 must-fix items (heading level h4→h3, index keying, tooltip placement regression risk) and several suggestions. All addressed in round 1; the tooltip placement risk was accepted as out-of-scope after empirical browser verification disproved the regression. Round 2: all reviewers APPROVED.

## Notes

- **Codex's clip-path alternative was rejected** with rationale: empirically the proposed `clip-path: inset(0 round 12px)` would re-clip the basic tooltip (which extends 23px past the card edge — exactly the bug being fixed). The sticky-header bleed concern doesn't manifest because `.example-preview` has 24px padding that keeps children away from the card's 12px rounded corners.

## Test plan

- [x] Lint, typecheck, tests, build all pass
- [x] `/page/tooltip` (all stories) render tooltips fully
- [x] `/page/selection-popover` renders submitted comments as cards
- [x] `/page/page-layout` no visual regression around sticky header
- [ ] Eyeball other stories on merge to confirm no other surprises (most stories have padding that keeps children inside card corners; if any story breaks, that story's fix is its own follow-up)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to playground styling/markup and example state handling, with no component or API logic touched. Potential impact is confined to visual layout/overflow behavior within example cards.
> 
> **Overview**
> Fixes playground example-card clipping by removing `overflow: hidden` from `.example-card` and explicitly allowing overflow in `.example-preview`, so tooltips/popovers can render outside the preview area.
> 
> Updates the selection-popover playground example to store comments as `{id, body}`, submit via a dedicated handler, and render submitted comments as keyed `<article>` cards inside a labeled `<section>` with token-based styling (replacing the prior `<ul>/<li>` output).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 52883580fced61a94789ce978e2ca7e382ab80d6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->