### PR TITLE
feat(components): add JsonSchemaEditor with form/json/diff views

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -46,6 +46,7 @@
         "@lasercat/homogenaize": "^1.2.41",
         "@milkdown/ctx": "^7.17.3",
         "@milkdown/kit": "^7.17.3",
+        "ajv": "^8",
         "conversationalist": "0.0.9",
         "esm-env": "^1.2.0",
         "lucide-svelte": "^0.503.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -145,6 +145,10 @@
       "svelte": "./src/components/input.svelte",
       "types": "./dist/components/input.svelte.d.ts"
     },
+    "./json-schema-editor": {
+      "svelte": "./src/components/json-schema-editor.svelte",
+      "types": "./dist/components/json-schema-editor.svelte.d.ts"
+    },
     "./kbd": {
       "svelte": "./src/components/kbd.svelte",
       "types": "./dist/components/kbd.svelte.d.ts"

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -337,6 +337,7 @@
     "@lasercat/homogenaize": "^1.2.41",
     "@milkdown/ctx": "^7.17.3",
     "@milkdown/kit": "^7.17.3",
+    "ajv": "^8",
     "conversationalist": "0.0.9",
     "esm-env": "^1.2.0",
     "lucide-svelte": "^0.503.0"

--- a/packages/components/src/components/json-schema-editor.svelte
+++ b/packages/components/src/components/json-schema-editor.svelte
@@ -1,0 +1,34 @@
+<script lang="ts" module>
+  import type { JsonSchemaEditorProps as JsonSchemaEditorImplementationProps } from './json-schema-editor/json-schema-editor.svelte';
+
+  export type JsonSchemaEditorProps = JsonSchemaEditorImplementationProps;
+
+  export type {
+    JsonSchemaEditorView,
+    JsonSchemaEditorMode,
+  } from './json-schema-editor/json-schema-editor.svelte';
+
+  export type {
+    JsonSchemaValue,
+    JsonSchemaTypeName,
+    JsonSchemaDraft,
+    JsonSchemaKnownDraft,
+    JsonSchemaValidationError,
+    JsonSchemaValidationStatus,
+    JsonSchemaValidationResult,
+    JsonSchemaEditorChangeEvent,
+    JsonSchemaEditorRevertEvent,
+  } from './json-schema-editor/json-schema-editor-types.ts';
+</script>
+
+<script lang="ts">
+  import { classNames } from '../utilities/class-names.ts';
+
+  import Implementation from './json-schema-editor/json-schema-editor.svelte';
+
+  let { view = $bindable('form'), class: className, ...rest }: JsonSchemaEditorProps = $props();
+
+  const mergedClassName = $derived(classNames(className));
+</script>
+
+<Implementation bind:view class={mergedClassName} {...rest} />

--- a/packages/components/src/components/json-schema-editor/composition-branch-keys.test.ts
+++ b/packages/components/src/components/json-schema-editor/composition-branch-keys.test.ts
@@ -27,6 +27,15 @@ describe('reconcileCompositionBranchKeys', () => {
     expect(next).toEqual(original);
   });
 
+  test('returns the same array reference when count is unchanged (no $state re-render)', () => {
+    const createKey = keyGenerator();
+    const original = reconcileCompositionBranchKeys([], 2, createKey);
+
+    const next = reconcileCompositionBranchKeys(original, 2, createKey);
+
+    expect(next).toBe(original);
+  });
+
   test('truncates stale keys after removals', () => {
     const createKey = keyGenerator();
 

--- a/packages/components/src/components/json-schema-editor/composition-branch-keys.test.ts
+++ b/packages/components/src/components/json-schema-editor/composition-branch-keys.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, test } from 'bun:test';
+
+import { reconcileCompositionBranchKeys } from './composition-branch-keys.ts';
+
+describe('reconcileCompositionBranchKeys', () => {
+  function keyGenerator() {
+    let next = 1;
+    return () => `branch-${next++}`;
+  }
+
+  test('creates one stable key per branch from an empty start', () => {
+    const createKey = keyGenerator();
+
+    expect(reconcileCompositionBranchKeys([], 3, createKey)).toEqual([
+      'branch-1',
+      'branch-2',
+      'branch-3',
+    ]);
+  });
+
+  test('preserves existing keys when branch values are immutably replaced', () => {
+    const createKey = keyGenerator();
+    const original = reconcileCompositionBranchKeys([], 2, createKey);
+
+    const next = reconcileCompositionBranchKeys(original, 2, createKey);
+
+    expect(next).toEqual(original);
+  });
+
+  test('truncates stale keys after removals', () => {
+    const createKey = keyGenerator();
+
+    expect(reconcileCompositionBranchKeys(['branch-1', 'branch-3'], 1, createKey)).toEqual([
+      'branch-1',
+    ]);
+  });
+
+  test('appends keys without replacing surviving keys', () => {
+    const createKey = keyGenerator();
+
+    const next = reconcileCompositionBranchKeys(['branch-a'], 3, createKey);
+
+    expect(next).toEqual(['branch-a', 'branch-1', 'branch-2']);
+  });
+});

--- a/packages/components/src/components/json-schema-editor/composition-branch-keys.ts
+++ b/packages/components/src/components/json-schema-editor/composition-branch-keys.ts
@@ -22,13 +22,13 @@
  * // keys is now ['a', '<uuid-1>', '<uuid-2>']
  */
 export function reconcileCompositionBranchKeys(
-  existingKeys: readonly string[],
+  existingKeys: string[],
   branchCount: number,
   createKey: () => string,
 ): string[] {
   // Return the same reference when no change is needed — callers that assign
   // the result back to $state won't trigger re-renders in that case.
-  if (existingKeys.length === branchCount) return existingKeys as string[];
+  if (existingKeys.length === branchCount) return existingKeys;
   const nextKeys = existingKeys.slice(0, branchCount);
   while (nextKeys.length < branchCount) nextKeys.push(createKey());
   return nextKeys;

--- a/packages/components/src/components/json-schema-editor/composition-branch-keys.ts
+++ b/packages/components/src/components/json-schema-editor/composition-branch-keys.ts
@@ -26,6 +26,9 @@ export function reconcileCompositionBranchKeys(
   branchCount: number,
   createKey: () => string,
 ): string[] {
+  // Return the same reference when no change is needed — callers that assign
+  // the result back to $state won't trigger re-renders in that case.
+  if (existingKeys.length === branchCount) return existingKeys as string[];
   const nextKeys = existingKeys.slice(0, branchCount);
   while (nextKeys.length < branchCount) nextKeys.push(createKey());
   return nextKeys;

--- a/packages/components/src/components/json-schema-editor/composition-branch-keys.ts
+++ b/packages/components/src/components/json-schema-editor/composition-branch-keys.ts
@@ -1,0 +1,32 @@
+/**
+ * Stable identity keys for composition branches in property-editor.
+ *
+ * Plain JSON branch values have no built-in identity. If we use the array
+ * index as the {#each} key, removing a non-last branch makes Svelte diff by
+ * index — surviving branches inherit the wrong PropertyEditor instance
+ * (and its local $state). Each PropertyEditor instance keeps its own list
+ * of branch keys parallel to the schema's branch array, and reconciles the
+ * two lengths every render.
+ */
+
+/**
+ * Reconcile a list of stable branch keys with the current branch count.
+ *
+ * - When branches are added beyond the existing key count, append fresh
+ *   keys via `createKey()`.
+ * - When branches are removed (count shrinks), truncate the keys array.
+ * - When the count is unchanged, return the existing keys verbatim.
+ *
+ * @example
+ * const keys = reconcileCompositionBranchKeys(['a'], 3, () => crypto.randomUUID());
+ * // keys is now ['a', '<uuid-1>', '<uuid-2>']
+ */
+export function reconcileCompositionBranchKeys(
+  existingKeys: readonly string[],
+  branchCount: number,
+  createKey: () => string,
+): string[] {
+  const nextKeys = existingKeys.slice(0, branchCount);
+  while (nextKeys.length < branchCount) nextKeys.push(createKey());
+  return nextKeys;
+}

--- a/packages/components/src/components/json-schema-editor/diff-view.svelte
+++ b/packages/components/src/components/json-schema-editor/diff-view.svelte
@@ -1,0 +1,45 @@
+<script lang="ts" module>
+  import type { EditorState } from './json-schema-editor-state.svelte.ts';
+
+  export type DiffViewProps = {
+    state: EditorState;
+    class?: string;
+  };
+</script>
+
+<script lang="ts">
+  import { classNames } from '../../utilities/class-names.ts';
+  import Alert from '../alert.svelte';
+  import Button from '../button.svelte';
+  import DiffViewer from '../diff-viewer.svelte';
+  import EmptyState from '../empty-state.svelte';
+
+  let { state, class: className }: DiffViewProps = $props();
+</script>
+
+<div class={classNames('cinder-jse-diff-view', className)}>
+  {#if state.jsonDraftIsDirty}
+    <Alert variant="warning">
+      <p>The diff shows the committed state; uncommitted JSON edits are not included.</p>
+      <div class="cinder-jse-dirty-actions">
+        <Button variant="primary" size="sm" onclick={() => state.applyJsonDraft()}>
+          Apply JSON
+        </Button>
+        <Button variant="secondary" size="sm" onclick={() => state.discardJsonDraft()}>
+          Discard JSON
+        </Button>
+      </div>
+    </Alert>
+  {/if}
+
+  {#if !state.hasChanges}
+    <EmptyState title="No changes yet" description="Edit the schema to see a diff here." />
+  {:else}
+    <DiffViewer
+      original={state.diffOriginal}
+      current={state.diffCurrent}
+      normalizeInputs={false}
+      readonly
+    />
+  {/if}
+</div>

--- a/packages/components/src/components/json-schema-editor/form-view.svelte
+++ b/packages/components/src/components/json-schema-editor/form-view.svelte
@@ -1,0 +1,57 @@
+<script lang="ts" module>
+  import type { EditorState } from './json-schema-editor-state.svelte.ts';
+
+  export type FormViewProps = {
+    state: EditorState;
+    idPrefix: string;
+    class?: string;
+  };
+</script>
+
+<script lang="ts">
+  import { classNames } from '../../utilities/class-names.ts';
+  import Alert from '../alert.svelte';
+  import Button from '../button.svelte';
+  import EmptyState from '../empty-state.svelte';
+  import PropertyEditor from './property-editor.svelte';
+
+  let { state, idPrefix, class: className }: FormViewProps = $props();
+
+  // Snapshot the committed schema each render so changes propagate via the
+  // value prop on PropertyEditor. We don't pass the live committed schema by
+  // reference; PropertyEditor produces a brand-new object on each commit.
+  const rootSchema = $derived(state.committedSchema);
+</script>
+
+<div class={classNames('cinder-jse-form-view', className)}>
+  {#if state.jsonDraftIsDirty}
+    <Alert variant="warning">
+      <p>The JSON view has uncommitted changes. Apply or discard them to edit in the form.</p>
+      <div class="cinder-jse-dirty-actions">
+        <Button variant="primary" size="sm" onclick={() => state.applyJsonDraft()}>
+          Apply JSON
+        </Button>
+        <Button variant="secondary" size="sm" onclick={() => state.discardJsonDraft()}>
+          Discard JSON
+        </Button>
+      </div>
+    </Alert>
+  {/if}
+
+  {#if rootSchema === null}
+    <EmptyState
+      title="Schema not loaded"
+      description={state.originalLoadError ??
+        'The current input could not be parsed. Edit the JSON view to set a valid schema.'}
+    />
+  {:else}
+    <PropertyEditor
+      {idPrefix}
+      path=""
+      depth={0}
+      readonly={state.readonly || state.jsonDraftIsDirty}
+      value={rootSchema}
+      onchange={(next, options) => state.commitFromForm(next, options)}
+    />
+  {/if}
+</div>

--- a/packages/components/src/components/json-schema-editor/json-schema-editor-state.svelte.test.ts
+++ b/packages/components/src/components/json-schema-editor/json-schema-editor-state.svelte.test.ts
@@ -1,0 +1,242 @@
+import { describe, expect, test } from 'bun:test';
+
+import { createEditorState } from './json-schema-editor-state.svelte.ts';
+
+describe('createEditorState — initial load', () => {
+  test('parses a string schema and seeds canonical text', () => {
+    const state = createEditorState({ schema: '{"type":"string"}' });
+
+    expect(state.committedSchema).toEqual({ type: 'string' });
+    expect(state.originalRawText).toBe('{"type":"string"}');
+    expect(state.committedCanonicalText).toContain('"type"');
+    expect(state.jsonDraftIsDirty).toBe(false);
+  });
+
+  test('accepts an object schema directly', () => {
+    const state = createEditorState({ schema: { type: 'string' } });
+    expect(state.committedSchema).toEqual({ type: 'string' });
+  });
+
+  test('accepts a boolean schema', () => {
+    const state = createEditorState({ schema: true });
+    expect(state.committedSchema).toBe(true);
+  });
+
+  test('invalid initial input opens with no committed schema', () => {
+    const state = createEditorState({ schema: '{not-valid' });
+    expect(state.committedSchema).toBe(null);
+    expect(state.originalSchema).toBe(null);
+    expect(state.originalLoadError).not.toBe(null);
+    expect(state.isFormEditable).toBe(false);
+  });
+
+  test('isFormEditable is true after a valid initial load', () => {
+    const state = createEditorState({ schema: { type: 'string' } });
+    expect(state.isFormEditable).toBe(true);
+  });
+
+  test('readonly disables form editing even when valid', () => {
+    const state = createEditorState({ schema: { type: 'string' }, readonly: true });
+    expect(state.isFormEditable).toBe(false);
+  });
+});
+
+describe('createEditorState — JSON draft / Apply', () => {
+  test('setJsonDraftText marks dirty without committing', () => {
+    const state = createEditorState({ schema: { type: 'string' } });
+
+    state.setJsonDraftText('{"type":"number"}');
+
+    expect(state.jsonDraftIsDirty).toBe(true);
+    expect(state.committedSchema).toEqual({ type: 'string' });
+  });
+
+  test('applyJsonDraft commits a valid draft', () => {
+    const state = createEditorState({ schema: { type: 'string' } });
+
+    state.setJsonDraftText('{"type":"number"}');
+    const applied = state.applyJsonDraft();
+
+    expect(applied).toBe(true);
+    expect(state.committedSchema).toEqual({ type: 'number' });
+    expect(state.jsonDraftIsDirty).toBe(false);
+  });
+
+  test('applyJsonDraft rejects invalid JSON', () => {
+    const state = createEditorState({ schema: { type: 'string' } });
+
+    state.setJsonDraftText('{not-valid');
+    const applied = state.applyJsonDraft();
+
+    expect(applied).toBe(false);
+    expect(state.committedSchema).toEqual({ type: 'string' });
+  });
+
+  test('applyJsonDraft rejects meta-schema-invalid drafts', () => {
+    const state = createEditorState({ schema: { type: 'string' } });
+
+    state.setJsonDraftText('{"type":"not-a-real-type"}');
+    const applied = state.applyJsonDraft();
+
+    expect(applied).toBe(false);
+    expect(state.committedSchema).toEqual({ type: 'string' });
+  });
+
+  test('discardJsonDraft restores committed canonical text', () => {
+    const state = createEditorState({ schema: { type: 'string' } });
+
+    state.setJsonDraftText('{"type":"number"}');
+    expect(state.jsonDraftIsDirty).toBe(true);
+
+    state.discardJsonDraft();
+    expect(state.jsonDraftIsDirty).toBe(false);
+  });
+});
+
+describe('createEditorState — form commits', () => {
+  test('commitFromForm pushes a new history entry', () => {
+    const state = createEditorState({ schema: { type: 'string' } });
+
+    state.commitFromForm({ type: 'number' });
+
+    expect(state.committedSchema).toEqual({ type: 'number' });
+    expect(state.canUndo).toBe(true);
+  });
+
+  test('commitFromForm is blocked while a JSON draft is dirty', () => {
+    const state = createEditorState({ schema: { type: 'string' } });
+
+    state.setJsonDraftText('{"type":"number"}');
+    state.commitFromForm({ type: 'integer' });
+
+    expect(state.committedSchema).toEqual({ type: 'string' });
+  });
+
+  test('commitFromForm is blocked while readonly', () => {
+    const state = createEditorState({ schema: { type: 'string' }, readonly: true });
+
+    state.commitFromForm({ type: 'number' });
+
+    expect(state.committedSchema).toEqual({ type: 'string' });
+  });
+});
+
+describe('createEditorState — undo / redo / revert', () => {
+  test('undo / redo move through history', () => {
+    const state = createEditorState({ schema: { type: 'string' } });
+
+    state.commitFromForm({ type: 'number' }, { label: 'change type' });
+
+    expect(state.canUndo).toBe(true);
+    state.undo();
+    expect(state.committedSchema).toEqual({ type: 'string' });
+
+    state.redo();
+    expect(state.committedSchema).toEqual({ type: 'number' });
+  });
+
+  test('revert restores original schema and clears history', () => {
+    const state = createEditorState({ schema: { type: 'string' } });
+    state.commitFromForm({ type: 'number' });
+    state.commitFromForm({ type: 'integer' });
+
+    state.revert();
+
+    expect(state.committedSchema).toEqual({ type: 'string' });
+    expect(state.canUndo).toBe(false);
+    expect(state.canRedo).toBe(false);
+  });
+
+  test('revert from invalid initial input clears the draft to original raw', () => {
+    const state = createEditorState({ schema: '{not-valid' });
+    state.setJsonDraftText('{"type":"string"}');
+    state.applyJsonDraft();
+
+    expect(state.committedSchema).toEqual({ type: 'string' });
+
+    state.revert();
+    expect(state.committedSchema).toBe(null);
+    expect(state.jsonDraftText).toBe('{not-valid');
+  });
+});
+
+describe('createEditorState — diff and copy values', () => {
+  test('copyValue is the canonical committed text, never the dirty draft', () => {
+    const state = createEditorState({ schema: { type: 'string' } });
+
+    state.setJsonDraftText('{"type":"number"}');
+
+    expect(state.copyValue).toContain('"string"');
+    expect(state.copyValue).not.toContain('"number"');
+  });
+
+  test('hasChanges uses semantic equality (key order ignored)', () => {
+    const state = createEditorState({
+      schema: { type: 'string', title: 'A' },
+    });
+    expect(state.hasChanges).toBe(false);
+
+    state.commitFromForm({ title: 'A', type: 'string' });
+    // Same content, different key order — should still be equal
+    expect(state.hasChanges).toBe(false);
+
+    state.commitFromForm({ type: 'string', title: 'B' });
+    expect(state.hasChanges).toBe(true);
+  });
+
+  test('separate `original` overrides the diff baseline', () => {
+    const state = createEditorState({
+      schema: { type: 'number' },
+      original: { type: 'string' },
+    });
+
+    expect(state.originalSchema).toEqual({ type: 'string' });
+    expect(state.committedSchema).toEqual({ type: 'number' });
+    expect(state.hasChanges).toBe(true);
+  });
+});
+
+describe('createEditorState — reload', () => {
+  test('reload swaps schema and clears history', () => {
+    const state = createEditorState({ schema: { type: 'string' } });
+    state.commitFromForm({ type: 'number' });
+
+    state.reload({ type: 'integer' });
+
+    expect(state.committedSchema).toEqual({ type: 'integer' });
+    expect(state.canUndo).toBe(false);
+    expect(state.canRedo).toBe(false);
+  });
+});
+
+describe('createEditorState — change events', () => {
+  test('onchange fires on commit, apply, undo, redo, revert-to-valid', () => {
+    const events: string[] = [];
+    const state = createEditorState({
+      schema: { type: 'string' },
+      onchange: (event) => events.push(event.jsonString),
+    });
+
+    state.commitFromForm({ type: 'number' });
+    state.setJsonDraftText('{"type":"integer"}');
+    state.applyJsonDraft();
+    state.undo();
+    state.redo();
+    state.revert();
+
+    // commit, apply, undo, redo, revert-to-valid = 5
+    expect(events.length).toBe(5);
+  });
+
+  test('onchange does NOT fire for transient JSON edits without Apply', () => {
+    let calls = 0;
+    const state = createEditorState({
+      schema: { type: 'string' },
+      onchange: () => (calls += 1),
+    });
+
+    state.setJsonDraftText('{"type":"number"}');
+
+    expect(calls).toBe(0);
+  });
+});

--- a/packages/components/src/components/json-schema-editor/json-schema-editor-state.svelte.test.ts
+++ b/packages/components/src/components/json-schema-editor/json-schema-editor-state.svelte.test.ts
@@ -240,3 +240,84 @@ describe('createEditorState — change events', () => {
     expect(calls).toBe(0);
   });
 });
+
+describe('createEditorState — onrevert callback', () => {
+  test('fires with restoredFrom: original-schema when the original parsed', () => {
+    const events: { restoredFrom: string }[] = [];
+    const state = createEditorState({
+      schema: { type: 'string' },
+      onrevert: (event) => events.push(event),
+    });
+
+    state.commitFromForm({ type: 'number' });
+    state.revert();
+
+    expect(events).toHaveLength(1);
+    expect(events[0]?.restoredFrom).toBe('original-schema');
+  });
+
+  test('fires with restoredFrom: original-text when the original was unparseable', () => {
+    const events: { restoredFrom: string }[] = [];
+    const state = createEditorState({
+      schema: '{not-valid',
+      onrevert: (event) => events.push(event),
+    });
+
+    state.setJsonDraftText('{"type":"string"}');
+    state.applyJsonDraft();
+    state.revert();
+
+    expect(events).toHaveLength(1);
+    expect(events[0]?.restoredFrom).toBe('original-text');
+  });
+});
+
+describe('createEditorState — readonly guards', () => {
+  test('revert is a no-op in readonly mode', () => {
+    const state = createEditorState({ schema: { type: 'string' }, readonly: true });
+
+    // commitFromForm is also blocked, so we can't build divergent state to
+    // observe a "restoration" — assert revert doesn't throw and committed
+    // remains the initial value.
+    state.revert();
+    expect(state.committedSchema).toEqual({ type: 'string' });
+    expect(state.canUndo).toBe(false);
+  });
+
+  test('setReadonly toggles editability live', () => {
+    const state = createEditorState({ schema: { type: 'string' }, readonly: true });
+    expect(state.isFormEditable).toBe(false);
+
+    state.setReadonly(false);
+    expect(state.isFormEditable).toBe(true);
+
+    state.setReadonly(true);
+    expect(state.isFormEditable).toBe(false);
+  });
+});
+
+describe('createEditorState — onvalidate callback', () => {
+  test('fires on initial mount with the loaded schema status', () => {
+    const events: { status: string; valid: boolean }[] = [];
+    createEditorState({
+      schema: { type: 'string' },
+      onvalidate: (result) => events.push(result),
+    });
+
+    expect(events.length).toBeGreaterThanOrEqual(1);
+    expect(events[0]?.valid).toBe(true);
+  });
+
+  test('fires after every committed schema change', () => {
+    const events: { status: string }[] = [];
+    const state = createEditorState({
+      schema: { type: 'string' },
+      onvalidate: (result) => events.push(result),
+    });
+    const baseline = events.length;
+
+    state.commitFromForm({ type: 'number' });
+
+    expect(events.length).toBeGreaterThan(baseline);
+  });
+});

--- a/packages/components/src/components/json-schema-editor/json-schema-editor-state.svelte.test.ts
+++ b/packages/components/src/components/json-schema-editor/json-schema-editor-state.svelte.test.ts
@@ -2,6 +2,20 @@ import { describe, expect, test } from 'bun:test';
 
 import { createEditorState } from './json-schema-editor-state.svelte.ts';
 
+function withImmediateTimers<T>(run: () => T): T {
+  const originalSetTimeout = globalThis.setTimeout;
+  globalThis.setTimeout = ((handler: TimerHandler, _timeout?: number, ...args: unknown[]) => {
+    if (typeof handler === 'function') handler(...args);
+    return 0 as unknown as ReturnType<typeof setTimeout>;
+  }) as unknown as typeof setTimeout;
+
+  try {
+    return run();
+  } finally {
+    globalThis.setTimeout = originalSetTimeout;
+  }
+}
+
 describe('createEditorState — initial load', () => {
   test('parses a string schema and seeds canonical text', () => {
     const state = createEditorState({ schema: '{"type":"string"}' });
@@ -294,6 +308,25 @@ describe('createEditorState — readonly guards', () => {
     state.setReadonly(true);
     expect(state.isFormEditable).toBe(false);
   });
+
+  test('setReadonly blocks undo and redo live', () => {
+    const state = createEditorState({ schema: { type: 'string' } });
+    state.commitFromForm({ type: 'number' }, { label: 'change type' });
+
+    expect(state.canUndo).toBe(true);
+    state.setReadonly(true);
+
+    expect(state.undo()).toBeUndefined();
+    expect(state.committedSchema).toEqual({ type: 'number' });
+
+    state.setReadonly(false);
+    state.undo();
+    expect(state.committedSchema).toEqual({ type: 'string' });
+
+    state.setReadonly(true);
+    expect(state.redo()).toBeUndefined();
+    expect(state.committedSchema).toEqual({ type: 'string' });
+  });
 });
 
 describe('createEditorState — onvalidate callback', () => {
@@ -319,5 +352,64 @@ describe('createEditorState — onvalidate callback', () => {
     state.commitFromForm({ type: 'number' });
 
     expect(events.length).toBeGreaterThan(baseline);
+  });
+
+  test('fires invalid status for a dirty top-level array draft', () => {
+    const events: { status: string; valid: boolean }[] = [];
+    const state = createEditorState({
+      schema: { type: 'string' },
+      onvalidate: (result) => events.push(result),
+    });
+
+    withImmediateTimers(() => {
+      state.setJsonDraftText('[1,2,3]');
+    });
+
+    expect(state.validationStatus).toBe('invalid');
+    expect(state.validationResult.valid).toBe(false);
+    expect(events.at(-1)).toMatchObject({ status: 'invalid', valid: false });
+  });
+
+  test('does not synchronously compile a large draft (size gate)', () => {
+    const state = createEditorState({ schema: { type: 'string' } });
+
+    // Build a draft larger than the compile-defer threshold (100KB) by
+    // padding the description. This exercises the size gate in
+    // scheduleValidation: the compile timer should never fire, leaving
+    // status 'pending' instead of 'valid'. The test relies on the fact
+    // that scheduleValidation's compile branch is skipped synchronously
+    // when the draft exceeds the size threshold.
+    const largeDescription = 'x'.repeat(120_000);
+    state.setJsonDraftText(`{"type":"string","description":"${largeDescription}"}`);
+
+    // After the synchronous portion of scheduleValidation, compileResult
+    // is reset to null and no timer is scheduled. Status is 'pending'.
+    expect(state.validationStatus).toBe('pending');
+    expect(state.validationResult.compilable).toBe(null);
+  });
+
+  test('activeDraft reflects a parseable dirty JSON draft', () => {
+    const state = createEditorState({
+      schema: { $schema: 'https://json-schema.org/draft/2020-12/schema', type: 'string' },
+    });
+
+    expect(state.activeDraft).toBe('2020-12');
+
+    state.setJsonDraftText('{"$schema":"http://json-schema.org/draft-07/schema#","type":"string"}');
+
+    expect(state.activeDraft).toBe('draft-07');
+  });
+
+  test('draftOverride wins for parseable dirty JSON drafts', () => {
+    const state = createEditorState({
+      schema: { type: 'string' },
+      draftOverride: 'draft-07',
+    });
+
+    state.setJsonDraftText(
+      '{"$schema":"https://json-schema.org/draft/2020-12/schema","type":"string"}',
+    );
+
+    expect(state.activeDraft).toBe('draft-07');
   });
 });

--- a/packages/components/src/components/json-schema-editor/json-schema-editor-state.svelte.ts
+++ b/packages/components/src/components/json-schema-editor/json-schema-editor-state.svelte.ts
@@ -296,6 +296,8 @@ export function createEditorState(options: CreateEditorStateOptions) {
   );
   const jsonDraftIsDirty = $derived(jsonDraftText !== committedCanonicalText);
   const hasChanges = $derived.by(() => {
+    // Both null means invalid initial schema with no edits yet — not "changed".
+    if (originalSchema === null && committedSchema === null) return false;
     if (originalSchema === null) {
       return originalRawText !== committedCanonicalText;
     }
@@ -385,6 +387,7 @@ export function createEditorState(options: CreateEditorStateOptions) {
     discardJsonDraft() {
       jsonDraftText = committedCanonicalText;
       runMetaValidation();
+      runCompile();
       recomputeStatus();
       emitValidation(buildResult());
     },

--- a/packages/components/src/components/json-schema-editor/json-schema-editor-state.svelte.ts
+++ b/packages/components/src/components/json-schema-editor/json-schema-editor-state.svelte.ts
@@ -1,0 +1,473 @@
+/**
+ * Reactive state container for JSONSchemaEditor.
+ *
+ * Holds distinct text representations so callers cannot conflate "what the
+ * user is typing" with "what we've actually committed":
+ *  - originalRawText: parent's input verbatim (diff source-of-truth)
+ *  - originalCanonicalText: pretty-printed parsed original
+ *  - committedSchema: the most recent applied schema (via useHistory)
+ *  - committedCanonicalText: pretty-printed committed schema
+ *  - jsonDraftText: textarea contents; may differ from committed
+ *
+ * Validation runs on the JSON draft (parse) immediately, on the committed
+ * schema (meta-schema) and compile (debounced).
+ */
+
+import { useHistory, type UseHistory } from '../../utilities/use-history.svelte.ts';
+
+import type {
+  JSONSchemaDraft,
+  JSONSchemaEditorChangeEvent,
+  JSONSchemaEditorRevertEvent,
+  JSONSchemaEditorView,
+  JSONSchemaKnownDraft,
+  JSONSchemaValidationError,
+  JSONSchemaValidationResult,
+  JSONSchemaValidationStatus,
+  JSONSchemaValue,
+} from './json-schema-editor-types.ts';
+import {
+  detectDraft,
+  normaliseSchemaInput,
+  tryCompile,
+  tryParseJson,
+  validateMetaSchema,
+} from './json-schema-validator.ts';
+
+const PRETTY_INDENT = 2;
+const META_DEBOUNCE_MS = 250;
+const COMPILE_DEBOUNCE_MS = 500;
+const COMPILE_DEFER_BYTES = 100_000;
+
+export interface CreateEditorStateOptions {
+  schema: JSONSchemaValue | string;
+  original?: JSONSchemaValue | string;
+  draftOverride?: JSONSchemaKnownDraft;
+  readonly?: boolean;
+  maxHistory?: number;
+  onchange?: (event: JSONSchemaEditorChangeEvent) => void;
+  onrevert?: (event: JSONSchemaEditorRevertEvent) => void;
+  onvalidate?: (result: JSONSchemaValidationResult) => void;
+}
+
+function serialise(value: JSONSchemaValue): string {
+  return JSON.stringify(value, null, PRETTY_INDENT);
+}
+
+function isPlainRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function stableKeySerialise(value: unknown): string {
+  return JSON.stringify(value, (_key, val) => {
+    if (!isPlainRecord(val)) return val;
+    const sorted: Record<string, unknown> = {};
+    for (const k of Object.keys(val).toSorted()) {
+      sorted[k] = val[k];
+    }
+    return sorted;
+  });
+}
+
+export function createEditorState(options: CreateEditorStateOptions) {
+  // ---- Original (baseline) ----
+  let originalRawText = $state('');
+  let originalCanonicalText = $state('');
+  let originalSchema = $state<JSONSchemaValue | null>(null);
+  let originalLoadError = $state<string | null>(null);
+
+  // ---- History / committed ----
+  // history is wrapped in $state so derived values that read `history?.current`
+  // re-evaluate when the history instance is replaced (revert, reload).
+  let history = $state<UseHistory<JSONSchemaValue> | null>(null);
+
+  // ---- Draft (JSON view) ----
+  let jsonDraftText = $state('');
+
+  // ---- View ----
+  let view = $state<JSONSchemaEditorView>('form');
+
+  // ---- Settings ----
+  const readonly = $state(Boolean(options.readonly));
+  let draftOverride = $state<JSONSchemaKnownDraft | undefined>(options.draftOverride);
+
+  // ---- Validation status (debounced) ----
+  let metaResult = $state<{ valid: boolean; errors: JSONSchemaValidationError[] }>({
+    valid: true,
+    errors: [],
+  });
+  let compileResult = $state<{ ok: true } | { ok: false; error: string } | null>(null);
+  let validationStatus = $state<JSONSchemaValidationStatus>('valid');
+
+  let metaDebounceHandle: ReturnType<typeof setTimeout> | null = null;
+  let compileDebounceHandle: ReturnType<typeof setTimeout> | null = null;
+
+  function clearTimers() {
+    if (metaDebounceHandle !== null) clearTimeout(metaDebounceHandle);
+    if (compileDebounceHandle !== null) clearTimeout(compileDebounceHandle);
+    metaDebounceHandle = null;
+    compileDebounceHandle = null;
+  }
+
+  function emitValidation(result: JSONSchemaValidationResult) {
+    options.onvalidate?.(result);
+  }
+
+  function buildResult(
+    overrides: Partial<JSONSchemaValidationResult> = {},
+  ): JSONSchemaValidationResult {
+    const compilable = compileResult === null ? null : compileResult.ok;
+    const result: JSONSchemaValidationResult = {
+      status: validationStatus,
+      valid: metaResult.valid,
+      errors: metaResult.errors,
+      compilable,
+    };
+    if (compileResult && !compileResult.ok) {
+      result.compileError = compileResult.error;
+    }
+    return { ...result, ...overrides };
+  }
+
+  function detectActiveDraft(schema: JSONSchemaValue | null): JSONSchemaDraft {
+    if (draftOverride) return draftOverride;
+    if (schema === null) return '2020-12';
+    return detectDraft(schema);
+  }
+
+  function shouldDeferCompile(text: string): boolean {
+    return text.length > COMPILE_DEFER_BYTES;
+  }
+
+  function runMetaValidation(schema: JSONSchemaValue | null) {
+    if (schema === null) {
+      metaResult = { valid: false, errors: [] };
+      return;
+    }
+    metaResult = validateMetaSchema(schema, detectActiveDraft(schema));
+  }
+
+  function runCompile(schema: JSONSchemaValue | null) {
+    if (schema === null) {
+      compileResult = null;
+      return;
+    }
+    compileResult = tryCompile(schema, detectActiveDraft(schema));
+  }
+
+  function recomputeStatus() {
+    const parse = tryParseJson(jsonDraftText);
+    if (!parse.ok) {
+      validationStatus = 'invalid';
+      return;
+    }
+    if (!metaResult.valid) {
+      validationStatus = 'invalid';
+      return;
+    }
+    if (compileResult === null) {
+      // Compile not yet run. If draft is large, we deferred; otherwise pending.
+      validationStatus = shouldDeferCompile(jsonDraftText) ? 'compile-deferred' : 'pending';
+      return;
+    }
+    if (!compileResult.ok) {
+      validationStatus = 'invalid';
+      return;
+    }
+    validationStatus = 'valid';
+  }
+
+  function scheduleValidation() {
+    clearTimers();
+
+    // Pending until debounce window resolves
+    validationStatus = 'pending';
+    emitValidation(buildResult({ status: 'pending' }));
+
+    metaDebounceHandle = setTimeout(() => {
+      runMetaValidation(history?.current ?? null);
+      recomputeStatus();
+      emitValidation(buildResult());
+    }, META_DEBOUNCE_MS);
+
+    if (shouldDeferCompile(jsonDraftText)) {
+      compileResult = null;
+      return;
+    }
+
+    compileDebounceHandle = setTimeout(() => {
+      runCompile(history?.current ?? null);
+      recomputeStatus();
+      emitValidation(buildResult());
+    }, COMPILE_DEBOUNCE_MS);
+  }
+
+  function emitChange() {
+    const schema = history?.current ?? null;
+    if (schema === null) return;
+    options.onchange?.({ schema, jsonString: serialise(schema) });
+  }
+
+  function loadFrom(
+    schemaInput: JSONSchemaValue | string,
+    originalInput?: JSONSchemaValue | string,
+  ) {
+    const schemaResult = normaliseSchemaInput(schemaInput);
+    const baselineInput = originalInput ?? schemaInput;
+    const baselineResult = normaliseSchemaInput(baselineInput);
+
+    if (baselineResult.ok) {
+      originalRawText = baselineResult.rawText;
+      originalCanonicalText = baselineResult.canonicalText;
+      originalSchema = baselineResult.schema;
+      originalLoadError = null;
+    } else {
+      originalRawText = baselineResult.rawText;
+      originalCanonicalText = '';
+      originalSchema = null;
+      originalLoadError = baselineResult.error;
+    }
+
+    if (schemaResult.ok) {
+      const useHistoryOptions: { initial: JSONSchemaValue; maxDepth?: number } = {
+        initial: schemaResult.schema,
+      };
+      if (options.maxHistory !== undefined) useHistoryOptions.maxDepth = options.maxHistory;
+      history = useHistory<JSONSchemaValue>(useHistoryOptions);
+      jsonDraftText = schemaResult.canonicalText;
+    } else {
+      history = null;
+      jsonDraftText = schemaResult.rawText || '';
+    }
+
+    runMetaValidation(history?.current ?? null);
+    runCompile(history?.current ?? null);
+    recomputeStatus();
+    emitValidation(buildResult());
+  }
+
+  loadFrom(options.schema, options.original);
+
+  // ===== Derived =====
+  const committedSchema = $derived(history?.current ?? null);
+  const committedCanonicalText = $derived(
+    committedSchema === null ? '' : serialise(committedSchema),
+  );
+  const jsonDraftIsDirty = $derived(jsonDraftText !== committedCanonicalText);
+  const hasChanges = $derived.by(() => {
+    if (originalSchema === null) {
+      return originalRawText !== committedCanonicalText;
+    }
+    if (committedSchema === null) return originalRawText.length > 0;
+    return stableKeySerialise(originalSchema) !== stableKeySerialise(committedSchema);
+  });
+  const isFormEditable = $derived(committedSchema !== null && !readonly && !jsonDraftIsDirty);
+
+  // ===== Public API =====
+  return {
+    // ---- Reads ----
+    get view() {
+      return view;
+    },
+    set view(next: JSONSchemaEditorView) {
+      view = next;
+    },
+    get readonly() {
+      return readonly;
+    },
+    get originalRawText() {
+      return originalRawText;
+    },
+    get originalCanonicalText() {
+      return originalCanonicalText;
+    },
+    get originalSchema() {
+      return originalSchema;
+    },
+    get originalLoadError() {
+      return originalLoadError;
+    },
+    get committedSchema() {
+      return committedSchema;
+    },
+    get committedCanonicalText() {
+      return committedCanonicalText;
+    },
+    get jsonDraftText() {
+      return jsonDraftText;
+    },
+    get jsonDraftIsDirty() {
+      return jsonDraftIsDirty;
+    },
+    get hasChanges() {
+      return hasChanges;
+    },
+    get isFormEditable() {
+      return isFormEditable;
+    },
+    get diffOriginal() {
+      return originalCanonicalText || originalRawText;
+    },
+    get diffCurrent() {
+      return committedCanonicalText;
+    },
+    get copyValue() {
+      return committedCanonicalText;
+    },
+    get canUndo() {
+      return history?.canUndo ?? false;
+    },
+    get canRedo() {
+      return history?.canRedo ?? false;
+    },
+    get validationStatus() {
+      return validationStatus;
+    },
+    get validationResult(): JSONSchemaValidationResult {
+      return buildResult();
+    },
+    get activeDraft(): JSONSchemaDraft {
+      return detectActiveDraft(committedSchema);
+    },
+
+    // ---- Writes ----
+    setView(next: JSONSchemaEditorView) {
+      view = next;
+    },
+
+    setJsonDraftText(text: string) {
+      jsonDraftText = text;
+      // Parse status updates synchronously by caller via tryParseJson.
+      scheduleValidation();
+    },
+
+    discardJsonDraft() {
+      jsonDraftText = committedCanonicalText;
+      runMetaValidation(history?.current ?? null);
+      recomputeStatus();
+      emitValidation(buildResult());
+    },
+
+    applyJsonDraft(): boolean {
+      if (readonly) return false;
+      const parsed = tryParseJson(jsonDraftText);
+      if (!parsed.ok) return false;
+
+      const value = parsed.value;
+      if (typeof value !== 'boolean' && !isPlainRecord(value)) return false;
+
+      const schema = value as JSONSchemaValue;
+      const meta = validateMetaSchema(schema, detectActiveDraft(schema));
+      if (!meta.valid) return false;
+
+      if (history) {
+        history.commit(schema, { label: 'apply JSON' });
+      } else {
+        const applyOptions: { initial: JSONSchemaValue; maxDepth?: number } = { initial: schema };
+        if (options.maxHistory !== undefined) applyOptions.maxDepth = options.maxHistory;
+        history = useHistory<JSONSchemaValue>(applyOptions);
+      }
+      jsonDraftText = serialise(history.current);
+      runMetaValidation(history.current);
+      runCompile(history.current);
+      recomputeStatus();
+      emitChange();
+      emitValidation(buildResult());
+      return true;
+    },
+
+    commitFromForm(
+      next: JSONSchemaValue,
+      commitOptions?: { coalesceKey?: string; label?: string },
+    ) {
+      if (!history || readonly || jsonDraftIsDirty) return;
+      history.commit(next, commitOptions);
+      jsonDraftText = serialise(history.current);
+      runMetaValidation(history.current);
+      runCompile(history.current);
+      recomputeStatus();
+      emitChange();
+      emitValidation(buildResult());
+    },
+
+    undo(): string | undefined {
+      if (!history) return undefined;
+      const left = history.undo();
+      if (!left) return undefined;
+      jsonDraftText = serialise(history.current);
+      runMetaValidation(history.current);
+      runCompile(history.current);
+      recomputeStatus();
+      emitChange();
+      emitValidation(buildResult());
+      return left.label;
+    },
+
+    redo(): string | undefined {
+      if (!history) return undefined;
+      const moved = history.redo();
+      if (!moved) return undefined;
+      jsonDraftText = serialise(history.current);
+      runMetaValidation(history.current);
+      runCompile(history.current);
+      recomputeStatus();
+      emitChange();
+      emitValidation(buildResult());
+      return moved.label;
+    },
+
+    revert() {
+      if (readonly) return;
+      if (originalSchema !== null) {
+        const revertOptions: { initial: JSONSchemaValue; maxDepth?: number } = {
+          initial: originalSchema,
+        };
+        if (options.maxHistory !== undefined) revertOptions.maxDepth = options.maxHistory;
+        history = useHistory<JSONSchemaValue>(revertOptions);
+        jsonDraftText = originalCanonicalText;
+        runMetaValidation(history.current);
+        runCompile(history.current);
+        recomputeStatus();
+        emitChange();
+        emitValidation(buildResult());
+        options.onrevert?.({ restoredFrom: 'original-schema' });
+      } else {
+        history = null;
+        jsonDraftText = originalRawText;
+        metaResult = { valid: false, errors: [] };
+        compileResult = null;
+        recomputeStatus();
+        emitValidation(buildResult());
+        options.onrevert?.({ restoredFrom: 'original-text' });
+      }
+    },
+
+    /** Force compile validation now — used after the user clicks the deferred-compile button. */
+    runCompileNow() {
+      runCompile(history?.current ?? null);
+      recomputeStatus();
+      emitValidation(buildResult());
+    },
+
+    /** Update the active draft override; recomputes validation. */
+    setDraftOverride(next: JSONSchemaKnownDraft | undefined) {
+      draftOverride = next;
+      runMetaValidation(history?.current ?? null);
+      runCompile(history?.current ?? null);
+      recomputeStatus();
+      emitValidation(buildResult());
+    },
+
+    /** Reload from a new schema/original pair — used by schemaKey-triggered reset. */
+    reload(schemaInput: JSONSchemaValue | string, originalInput?: JSONSchemaValue | string) {
+      clearTimers();
+      loadFrom(schemaInput, originalInput);
+    },
+
+    destroy() {
+      clearTimers();
+    },
+  };
+}
+
+export type EditorState = ReturnType<typeof createEditorState>;

--- a/packages/components/src/components/json-schema-editor/json-schema-editor-state.svelte.ts
+++ b/packages/components/src/components/json-schema-editor/json-schema-editor-state.svelte.ts
@@ -13,7 +13,11 @@
  * schema (meta-schema) and compile (debounced).
  */
 
-import { useHistory, type UseHistory } from '../../utilities/use-history.svelte.ts';
+import {
+  stableSerialise,
+  useHistory,
+  type UseHistory,
+} from '../../utilities/use-history.svelte.ts';
 
 import type {
   JsonSchemaDraft,
@@ -64,17 +68,6 @@ function serialise(value: JsonSchemaValue): string {
 
 function isPlainRecord(value: unknown): value is Record<string, unknown> {
   return value !== null && typeof value === 'object' && !Array.isArray(value);
-}
-
-function stableKeySerialise(value: unknown): string {
-  return JSON.stringify(value, (_key, val) => {
-    if (!isPlainRecord(val)) return val;
-    const sorted: Record<string, unknown> = {};
-    for (const k of Object.keys(val).toSorted()) {
-      sorted[k] = val[k];
-    }
-    return sorted;
-  });
 }
 
 export function createEditorState(options: CreateEditorStateOptions) {
@@ -302,7 +295,7 @@ export function createEditorState(options: CreateEditorStateOptions) {
       return originalRawText !== committedCanonicalText;
     }
     if (committedSchema === null) return originalRawText.length > 0;
-    return stableKeySerialise(originalSchema) !== stableKeySerialise(committedSchema);
+    return stableSerialise(originalSchema) !== stableSerialise(committedSchema);
   });
   const isFormEditable = $derived(committedSchema !== null && !readonly && !jsonDraftIsDirty);
 
@@ -385,6 +378,7 @@ export function createEditorState(options: CreateEditorStateOptions) {
     },
 
     discardJsonDraft() {
+      clearTimers();
       jsonDraftText = committedCanonicalText;
       runMetaValidation();
       runCompile();
@@ -394,6 +388,7 @@ export function createEditorState(options: CreateEditorStateOptions) {
 
     applyJsonDraft(): boolean {
       if (readonly) return false;
+      clearTimers();
       const parsed = tryParseJson(jsonDraftText);
       if (!parsed.ok) return false;
 
@@ -425,6 +420,7 @@ export function createEditorState(options: CreateEditorStateOptions) {
       commitOptions?: { coalesceKey?: string; label?: string },
     ) {
       if (!history || readonly || jsonDraftIsDirty) return;
+      clearTimers();
       history.commit(next, commitOptions);
       jsonDraftText = serialise(history.current);
       runMetaValidation();
@@ -436,6 +432,7 @@ export function createEditorState(options: CreateEditorStateOptions) {
 
     undo(): string | undefined {
       if (!history || readonly) return undefined;
+      clearTimers();
       const left = history.undo();
       if (!left) return undefined;
       jsonDraftText = serialise(history.current);
@@ -449,6 +446,7 @@ export function createEditorState(options: CreateEditorStateOptions) {
 
     redo(): string | undefined {
       if (!history || readonly) return undefined;
+      clearTimers();
       const moved = history.redo();
       if (!moved) return undefined;
       jsonDraftText = serialise(history.current);
@@ -462,6 +460,7 @@ export function createEditorState(options: CreateEditorStateOptions) {
 
     revert() {
       if (readonly) return;
+      clearTimers();
       if (originalSchema !== null) {
         const revertOptions: { initial: JsonSchemaValue; maxDepth?: number } = {
           initial: originalSchema,

--- a/packages/components/src/components/json-schema-editor/json-schema-editor-state.svelte.ts
+++ b/packages/components/src/components/json-schema-editor/json-schema-editor-state.svelte.ts
@@ -37,7 +37,6 @@ import {
 const PRETTY_INDENT = 2;
 const META_DEBOUNCE_MS = 250;
 const COMPILE_DEBOUNCE_MS = 500;
-const COMPILE_DEFER_BYTES = 100_000;
 
 export interface CreateEditorStateOptions {
   schema: JsonSchemaValue | string;
@@ -88,8 +87,14 @@ export function createEditorState(options: CreateEditorStateOptions) {
   let view = $state<JsonSchemaEditorView>('form');
 
   // ---- Settings ----
-  const readonly = $state(Boolean(options.readonly));
+  // readonly and draftOverride are reactive so the component can sync them to
+  // current prop values via $effect after mount.
+  let readonly = $state(Boolean(options.readonly));
   let draftOverride = $state<JsonSchemaKnownDraft | undefined>(options.draftOverride);
+
+  function setReadonly(next: boolean) {
+    readonly = next;
+  }
 
   // ---- Validation status (debounced) ----
   let metaResult = $state<{ valid: boolean; errors: JsonSchemaValidationError[] }>({
@@ -135,11 +140,37 @@ export function createEditorState(options: CreateEditorStateOptions) {
     return detectDraft(schema);
   }
 
-  function shouldDeferCompile(text: string): boolean {
-    return text.length > COMPILE_DEFER_BYTES;
+  function isJsonSchemaShape(value: unknown): value is JsonSchemaValue {
+    return typeof value === 'boolean' || isPlainRecord(value);
   }
 
-  function runMetaValidation(schema: JsonSchemaValue | null) {
+  /**
+   * Pick the schema we want validation to reflect.
+   *
+   * When the JSON draft is dirty and parseable, validate that — the toolbar
+   * status mirrors what the user is editing. When the draft is unparseable,
+   * fall back to the committed schema (so the existing status remains
+   * meaningful) and let `recomputeStatus` mark `'invalid'` based on the
+   * parse error.
+   *
+   * Computes the "is dirty" check inline rather than reading the
+   * `jsonDraftIsDirty` $derived because this function is called from
+   * `loadFrom`, which runs before the $derived expressions are set up.
+   */
+  function schemaToValidate(): JsonSchemaValue | null {
+    const committed = history?.current ?? null;
+    const committedText = committed === null ? '' : serialise(committed);
+    if (jsonDraftText !== committedText) {
+      const parsed = tryParseJson(jsonDraftText);
+      if (parsed.ok && isJsonSchemaShape(parsed.value)) {
+        return parsed.value;
+      }
+    }
+    return committed;
+  }
+
+  function runMetaValidation() {
+    const schema = schemaToValidate();
     if (schema === null) {
       metaResult = { valid: false, errors: [] };
       return;
@@ -147,7 +178,8 @@ export function createEditorState(options: CreateEditorStateOptions) {
     metaResult = validateMetaSchema(schema, detectActiveDraft(schema));
   }
 
-  function runCompile(schema: JsonSchemaValue | null) {
+  function runCompile() {
+    const schema = schemaToValidate();
     if (schema === null) {
       compileResult = null;
       return;
@@ -166,8 +198,7 @@ export function createEditorState(options: CreateEditorStateOptions) {
       return;
     }
     if (compileResult === null) {
-      // Compile not yet run. If draft is large, we deferred; otherwise pending.
-      validationStatus = shouldDeferCompile(jsonDraftText) ? 'compile-deferred' : 'pending';
+      validationStatus = 'pending';
       return;
     }
     if (!compileResult.ok) {
@@ -185,18 +216,13 @@ export function createEditorState(options: CreateEditorStateOptions) {
     emitValidation(buildResult({ status: 'pending' }));
 
     metaDebounceHandle = setTimeout(() => {
-      runMetaValidation(history?.current ?? null);
+      runMetaValidation();
       recomputeStatus();
       emitValidation(buildResult());
     }, META_DEBOUNCE_MS);
 
-    if (shouldDeferCompile(jsonDraftText)) {
-      compileResult = null;
-      return;
-    }
-
     compileDebounceHandle = setTimeout(() => {
-      runCompile(history?.current ?? null);
+      runCompile();
       recomputeStatus();
       emitValidation(buildResult());
     }, COMPILE_DEBOUNCE_MS);
@@ -240,8 +266,8 @@ export function createEditorState(options: CreateEditorStateOptions) {
       jsonDraftText = schemaResult.rawText || '';
     }
 
-    runMetaValidation(history?.current ?? null);
-    runCompile(history?.current ?? null);
+    runMetaValidation();
+    runCompile();
     recomputeStatus();
     emitValidation(buildResult());
   }
@@ -343,7 +369,7 @@ export function createEditorState(options: CreateEditorStateOptions) {
 
     discardJsonDraft() {
       jsonDraftText = committedCanonicalText;
-      runMetaValidation(history?.current ?? null);
+      runMetaValidation();
       recomputeStatus();
       emitValidation(buildResult());
     },
@@ -368,8 +394,8 @@ export function createEditorState(options: CreateEditorStateOptions) {
         history = useHistory<JsonSchemaValue>(applyOptions);
       }
       jsonDraftText = serialise(history.current);
-      runMetaValidation(history.current);
-      runCompile(history.current);
+      runMetaValidation();
+      runCompile();
       recomputeStatus();
       emitChange();
       emitValidation(buildResult());
@@ -383,8 +409,8 @@ export function createEditorState(options: CreateEditorStateOptions) {
       if (!history || readonly || jsonDraftIsDirty) return;
       history.commit(next, commitOptions);
       jsonDraftText = serialise(history.current);
-      runMetaValidation(history.current);
-      runCompile(history.current);
+      runMetaValidation();
+      runCompile();
       recomputeStatus();
       emitChange();
       emitValidation(buildResult());
@@ -395,8 +421,8 @@ export function createEditorState(options: CreateEditorStateOptions) {
       const left = history.undo();
       if (!left) return undefined;
       jsonDraftText = serialise(history.current);
-      runMetaValidation(history.current);
-      runCompile(history.current);
+      runMetaValidation();
+      runCompile();
       recomputeStatus();
       emitChange();
       emitValidation(buildResult());
@@ -408,8 +434,8 @@ export function createEditorState(options: CreateEditorStateOptions) {
       const moved = history.redo();
       if (!moved) return undefined;
       jsonDraftText = serialise(history.current);
-      runMetaValidation(history.current);
-      runCompile(history.current);
+      runMetaValidation();
+      runCompile();
       recomputeStatus();
       emitChange();
       emitValidation(buildResult());
@@ -425,8 +451,8 @@ export function createEditorState(options: CreateEditorStateOptions) {
         if (options.maxHistory !== undefined) revertOptions.maxDepth = options.maxHistory;
         history = useHistory<JsonSchemaValue>(revertOptions);
         jsonDraftText = originalCanonicalText;
-        runMetaValidation(history.current);
-        runCompile(history.current);
+        runMetaValidation();
+        runCompile();
         recomputeStatus();
         emitChange();
         emitValidation(buildResult());
@@ -442,21 +468,17 @@ export function createEditorState(options: CreateEditorStateOptions) {
       }
     },
 
-    /** Force compile validation now — used after the user clicks the deferred-compile button. */
-    runCompileNow() {
-      runCompile(history?.current ?? null);
+    /** Update the active draft override; recomputes validation. */
+    setDraftOverride(next: JsonSchemaKnownDraft | undefined) {
+      draftOverride = next;
+      runMetaValidation();
+      runCompile();
       recomputeStatus();
       emitValidation(buildResult());
     },
 
-    /** Update the active draft override; recomputes validation. */
-    setDraftOverride(next: JsonSchemaKnownDraft | undefined) {
-      draftOverride = next;
-      runMetaValidation(history?.current ?? null);
-      runCompile(history?.current ?? null);
-      recomputeStatus();
-      emitValidation(buildResult());
-    },
+    /** Live-update the readonly flag (used to re-sync the prop after mount). */
+    setReadonly,
 
     /** Reload from a new schema/original pair — used by schemaKey-triggered reset. */
     reload(schemaInput: JsonSchemaValue | string, originalInput?: JsonSchemaValue | string) {

--- a/packages/components/src/components/json-schema-editor/json-schema-editor-state.svelte.ts
+++ b/packages/components/src/components/json-schema-editor/json-schema-editor-state.svelte.ts
@@ -1,5 +1,5 @@
 /**
- * Reactive state container for JSONSchemaEditor.
+ * Reactive state container for JsonSchemaEditor.
  *
  * Holds distinct text representations so callers cannot conflate "what the
  * user is typing" with "what we've actually committed":
@@ -16,15 +16,15 @@
 import { useHistory, type UseHistory } from '../../utilities/use-history.svelte.ts';
 
 import type {
-  JSONSchemaDraft,
-  JSONSchemaEditorChangeEvent,
-  JSONSchemaEditorRevertEvent,
-  JSONSchemaEditorView,
-  JSONSchemaKnownDraft,
-  JSONSchemaValidationError,
-  JSONSchemaValidationResult,
-  JSONSchemaValidationStatus,
-  JSONSchemaValue,
+  JsonSchemaDraft,
+  JsonSchemaEditorChangeEvent,
+  JsonSchemaEditorRevertEvent,
+  JsonSchemaEditorView,
+  JsonSchemaKnownDraft,
+  JsonSchemaValidationError,
+  JsonSchemaValidationResult,
+  JsonSchemaValidationStatus,
+  JsonSchemaValue,
 } from './json-schema-editor-types.ts';
 import {
   detectDraft,
@@ -40,17 +40,17 @@ const COMPILE_DEBOUNCE_MS = 500;
 const COMPILE_DEFER_BYTES = 100_000;
 
 export interface CreateEditorStateOptions {
-  schema: JSONSchemaValue | string;
-  original?: JSONSchemaValue | string;
-  draftOverride?: JSONSchemaKnownDraft;
+  schema: JsonSchemaValue | string;
+  original?: JsonSchemaValue | string;
+  draftOverride?: JsonSchemaKnownDraft;
   readonly?: boolean;
   maxHistory?: number;
-  onchange?: (event: JSONSchemaEditorChangeEvent) => void;
-  onrevert?: (event: JSONSchemaEditorRevertEvent) => void;
-  onvalidate?: (result: JSONSchemaValidationResult) => void;
+  onchange?: (event: JsonSchemaEditorChangeEvent) => void;
+  onrevert?: (event: JsonSchemaEditorRevertEvent) => void;
+  onvalidate?: (result: JsonSchemaValidationResult) => void;
 }
 
-function serialise(value: JSONSchemaValue): string {
+function serialise(value: JsonSchemaValue): string {
   return JSON.stringify(value, null, PRETTY_INDENT);
 }
 
@@ -73,31 +73,31 @@ export function createEditorState(options: CreateEditorStateOptions) {
   // ---- Original (baseline) ----
   let originalRawText = $state('');
   let originalCanonicalText = $state('');
-  let originalSchema = $state<JSONSchemaValue | null>(null);
+  let originalSchema = $state<JsonSchemaValue | null>(null);
   let originalLoadError = $state<string | null>(null);
 
   // ---- History / committed ----
   // history is wrapped in $state so derived values that read `history?.current`
   // re-evaluate when the history instance is replaced (revert, reload).
-  let history = $state<UseHistory<JSONSchemaValue> | null>(null);
+  let history = $state<UseHistory<JsonSchemaValue> | null>(null);
 
   // ---- Draft (JSON view) ----
   let jsonDraftText = $state('');
 
   // ---- View ----
-  let view = $state<JSONSchemaEditorView>('form');
+  let view = $state<JsonSchemaEditorView>('form');
 
   // ---- Settings ----
   const readonly = $state(Boolean(options.readonly));
-  let draftOverride = $state<JSONSchemaKnownDraft | undefined>(options.draftOverride);
+  let draftOverride = $state<JsonSchemaKnownDraft | undefined>(options.draftOverride);
 
   // ---- Validation status (debounced) ----
-  let metaResult = $state<{ valid: boolean; errors: JSONSchemaValidationError[] }>({
+  let metaResult = $state<{ valid: boolean; errors: JsonSchemaValidationError[] }>({
     valid: true,
     errors: [],
   });
   let compileResult = $state<{ ok: true } | { ok: false; error: string } | null>(null);
-  let validationStatus = $state<JSONSchemaValidationStatus>('valid');
+  let validationStatus = $state<JsonSchemaValidationStatus>('valid');
 
   let metaDebounceHandle: ReturnType<typeof setTimeout> | null = null;
   let compileDebounceHandle: ReturnType<typeof setTimeout> | null = null;
@@ -109,15 +109,15 @@ export function createEditorState(options: CreateEditorStateOptions) {
     compileDebounceHandle = null;
   }
 
-  function emitValidation(result: JSONSchemaValidationResult) {
+  function emitValidation(result: JsonSchemaValidationResult) {
     options.onvalidate?.(result);
   }
 
   function buildResult(
-    overrides: Partial<JSONSchemaValidationResult> = {},
-  ): JSONSchemaValidationResult {
+    overrides: Partial<JsonSchemaValidationResult> = {},
+  ): JsonSchemaValidationResult {
     const compilable = compileResult === null ? null : compileResult.ok;
-    const result: JSONSchemaValidationResult = {
+    const result: JsonSchemaValidationResult = {
       status: validationStatus,
       valid: metaResult.valid,
       errors: metaResult.errors,
@@ -129,7 +129,7 @@ export function createEditorState(options: CreateEditorStateOptions) {
     return { ...result, ...overrides };
   }
 
-  function detectActiveDraft(schema: JSONSchemaValue | null): JSONSchemaDraft {
+  function detectActiveDraft(schema: JsonSchemaValue | null): JsonSchemaDraft {
     if (draftOverride) return draftOverride;
     if (schema === null) return '2020-12';
     return detectDraft(schema);
@@ -139,7 +139,7 @@ export function createEditorState(options: CreateEditorStateOptions) {
     return text.length > COMPILE_DEFER_BYTES;
   }
 
-  function runMetaValidation(schema: JSONSchemaValue | null) {
+  function runMetaValidation(schema: JsonSchemaValue | null) {
     if (schema === null) {
       metaResult = { valid: false, errors: [] };
       return;
@@ -147,7 +147,7 @@ export function createEditorState(options: CreateEditorStateOptions) {
     metaResult = validateMetaSchema(schema, detectActiveDraft(schema));
   }
 
-  function runCompile(schema: JSONSchemaValue | null) {
+  function runCompile(schema: JsonSchemaValue | null) {
     if (schema === null) {
       compileResult = null;
       return;
@@ -209,8 +209,8 @@ export function createEditorState(options: CreateEditorStateOptions) {
   }
 
   function loadFrom(
-    schemaInput: JSONSchemaValue | string,
-    originalInput?: JSONSchemaValue | string,
+    schemaInput: JsonSchemaValue | string,
+    originalInput?: JsonSchemaValue | string,
   ) {
     const schemaResult = normaliseSchemaInput(schemaInput);
     const baselineInput = originalInput ?? schemaInput;
@@ -229,11 +229,11 @@ export function createEditorState(options: CreateEditorStateOptions) {
     }
 
     if (schemaResult.ok) {
-      const useHistoryOptions: { initial: JSONSchemaValue; maxDepth?: number } = {
+      const useHistoryOptions: { initial: JsonSchemaValue; maxDepth?: number } = {
         initial: schemaResult.schema,
       };
       if (options.maxHistory !== undefined) useHistoryOptions.maxDepth = options.maxHistory;
-      history = useHistory<JSONSchemaValue>(useHistoryOptions);
+      history = useHistory<JsonSchemaValue>(useHistoryOptions);
       jsonDraftText = schemaResult.canonicalText;
     } else {
       history = null;
@@ -269,7 +269,7 @@ export function createEditorState(options: CreateEditorStateOptions) {
     get view() {
       return view;
     },
-    set view(next: JSONSchemaEditorView) {
+    set view(next: JsonSchemaEditorView) {
       view = next;
     },
     get readonly() {
@@ -323,15 +323,15 @@ export function createEditorState(options: CreateEditorStateOptions) {
     get validationStatus() {
       return validationStatus;
     },
-    get validationResult(): JSONSchemaValidationResult {
+    get validationResult(): JsonSchemaValidationResult {
       return buildResult();
     },
-    get activeDraft(): JSONSchemaDraft {
+    get activeDraft(): JsonSchemaDraft {
       return detectActiveDraft(committedSchema);
     },
 
     // ---- Writes ----
-    setView(next: JSONSchemaEditorView) {
+    setView(next: JsonSchemaEditorView) {
       view = next;
     },
 
@@ -356,16 +356,16 @@ export function createEditorState(options: CreateEditorStateOptions) {
       const value = parsed.value;
       if (typeof value !== 'boolean' && !isPlainRecord(value)) return false;
 
-      const schema = value as JSONSchemaValue;
+      const schema = value as JsonSchemaValue;
       const meta = validateMetaSchema(schema, detectActiveDraft(schema));
       if (!meta.valid) return false;
 
       if (history) {
         history.commit(schema, { label: 'apply JSON' });
       } else {
-        const applyOptions: { initial: JSONSchemaValue; maxDepth?: number } = { initial: schema };
+        const applyOptions: { initial: JsonSchemaValue; maxDepth?: number } = { initial: schema };
         if (options.maxHistory !== undefined) applyOptions.maxDepth = options.maxHistory;
-        history = useHistory<JSONSchemaValue>(applyOptions);
+        history = useHistory<JsonSchemaValue>(applyOptions);
       }
       jsonDraftText = serialise(history.current);
       runMetaValidation(history.current);
@@ -377,7 +377,7 @@ export function createEditorState(options: CreateEditorStateOptions) {
     },
 
     commitFromForm(
-      next: JSONSchemaValue,
+      next: JsonSchemaValue,
       commitOptions?: { coalesceKey?: string; label?: string },
     ) {
       if (!history || readonly || jsonDraftIsDirty) return;
@@ -419,11 +419,11 @@ export function createEditorState(options: CreateEditorStateOptions) {
     revert() {
       if (readonly) return;
       if (originalSchema !== null) {
-        const revertOptions: { initial: JSONSchemaValue; maxDepth?: number } = {
+        const revertOptions: { initial: JsonSchemaValue; maxDepth?: number } = {
           initial: originalSchema,
         };
         if (options.maxHistory !== undefined) revertOptions.maxDepth = options.maxHistory;
-        history = useHistory<JSONSchemaValue>(revertOptions);
+        history = useHistory<JsonSchemaValue>(revertOptions);
         jsonDraftText = originalCanonicalText;
         runMetaValidation(history.current);
         runCompile(history.current);
@@ -450,7 +450,7 @@ export function createEditorState(options: CreateEditorStateOptions) {
     },
 
     /** Update the active draft override; recomputes validation. */
-    setDraftOverride(next: JSONSchemaKnownDraft | undefined) {
+    setDraftOverride(next: JsonSchemaKnownDraft | undefined) {
       draftOverride = next;
       runMetaValidation(history?.current ?? null);
       runCompile(history?.current ?? null);
@@ -459,7 +459,7 @@ export function createEditorState(options: CreateEditorStateOptions) {
     },
 
     /** Reload from a new schema/original pair — used by schemaKey-triggered reset. */
-    reload(schemaInput: JSONSchemaValue | string, originalInput?: JSONSchemaValue | string) {
+    reload(schemaInput: JsonSchemaValue | string, originalInput?: JsonSchemaValue | string) {
       clearTimers();
       loadFrom(schemaInput, originalInput);
     },

--- a/packages/components/src/components/json-schema-editor/json-schema-editor-state.svelte.ts
+++ b/packages/components/src/components/json-schema-editor/json-schema-editor-state.svelte.ts
@@ -37,6 +37,15 @@ import {
 const PRETTY_INDENT = 2;
 const META_DEBOUNCE_MS = 250;
 const COMPILE_DEBOUNCE_MS = 500;
+/**
+ * Skip Ajv compile for drafts larger than this byte threshold. Compile is
+ * the expensive step (it walks every keyword and synthesises a validator
+ * function) and on the main thread a 100KB+ schema can stall typing for
+ * hundreds of milliseconds per debounce cycle. We still run parse + meta
+ * validation; only the compile pass is silently deferred. The user sees
+ * `status: 'pending'` while the gate is active.
+ */
+const COMPILE_DEFER_BYTES = 100_000;
 
 export interface CreateEditorStateOptions {
   schema: JsonSchemaValue | string;
@@ -134,14 +143,10 @@ export function createEditorState(options: CreateEditorStateOptions) {
     return { ...result, ...overrides };
   }
 
-  function detectActiveDraft(schema: JsonSchemaValue | null): JsonSchemaDraft {
+  function detectActiveDraft(schema: unknown): JsonSchemaDraft {
     if (draftOverride) return draftOverride;
     if (schema === null) return '2020-12';
     return detectDraft(schema);
-  }
-
-  function isJsonSchemaShape(value: unknown): value is JsonSchemaValue {
-    return typeof value === 'boolean' || isPlainRecord(value);
   }
 
   /**
@@ -157,12 +162,12 @@ export function createEditorState(options: CreateEditorStateOptions) {
    * `jsonDraftIsDirty` $derived because this function is called from
    * `loadFrom`, which runs before the $derived expressions are set up.
    */
-  function schemaToValidate(): JsonSchemaValue | null {
+  function schemaToValidate(): unknown {
     const committed = history?.current ?? null;
     const committedText = committed === null ? '' : serialise(committed);
     if (jsonDraftText !== committedText) {
       const parsed = tryParseJson(jsonDraftText);
-      if (parsed.ok && isJsonSchemaShape(parsed.value)) {
+      if (parsed.ok) {
         return parsed.value;
       }
     }
@@ -220,6 +225,16 @@ export function createEditorState(options: CreateEditorStateOptions) {
       recomputeStatus();
       emitValidation(buildResult());
     }, META_DEBOUNCE_MS);
+
+    // Skip compile for very large drafts — Ajv.compile is O(schema-size)
+    // synchronous main-thread work and at 100KB+ it stalls typing badly.
+    // Status stays 'pending' (compileResult never resolves) until the user
+    // applies the draft and we have committed text to validate. Reset the
+    // result so a previously-compiled smaller draft doesn't poison us.
+    if (jsonDraftText.length > COMPILE_DEFER_BYTES) {
+      compileResult = null;
+      return;
+    }
 
     compileDebounceHandle = setTimeout(() => {
       runCompile();
@@ -353,7 +368,7 @@ export function createEditorState(options: CreateEditorStateOptions) {
       return buildResult();
     },
     get activeDraft(): JsonSchemaDraft {
-      return detectActiveDraft(committedSchema);
+      return detectActiveDraft(schemaToValidate());
     },
 
     // ---- Writes ----
@@ -417,7 +432,7 @@ export function createEditorState(options: CreateEditorStateOptions) {
     },
 
     undo(): string | undefined {
-      if (!history) return undefined;
+      if (!history || readonly) return undefined;
       const left = history.undo();
       if (!left) return undefined;
       jsonDraftText = serialise(history.current);
@@ -430,7 +445,7 @@ export function createEditorState(options: CreateEditorStateOptions) {
     },
 
     redo(): string | undefined {
-      if (!history) return undefined;
+      if (!history || readonly) return undefined;
       const moved = history.redo();
       if (!moved) return undefined;
       jsonDraftText = serialise(history.current);

--- a/packages/components/src/components/json-schema-editor/json-schema-editor-types.ts
+++ b/packages/components/src/components/json-schema-editor/json-schema-editor-types.ts
@@ -1,12 +1,12 @@
 /**
- * Public types for the JSONSchemaEditor component.
+ * Public types for the JsonSchemaEditor component.
  *
- * Naming rule: every type referenced from JSONSchemaEditorProps is prefixed
- * with `JSONSchema*` or `JSONSchemaEditor*` and exported from the package
+ * Naming rule: every type referenced from JsonSchemaEditorProps is prefixed
+ * with `JsonSchema*` or `JsonSchemaEditor*` and exported from the package
  * barrel.
  */
 
-export type JSONSchemaTypeName =
+export type JsonSchemaTypeName =
   | 'string'
   | 'number'
   | 'integer'
@@ -16,95 +16,95 @@ export type JSONSchemaTypeName =
   | 'array';
 
 /** Drafts the editor can validate against. */
-export type JSONSchemaKnownDraft = '2020-12' | '2019-09' | 'draft-07';
+export type JsonSchemaKnownDraft = '2020-12' | '2019-09' | 'draft-07';
 
 /** All draft states, including the unknown-but-encountered case. */
-export type JSONSchemaDraft = JSONSchemaKnownDraft | 'unknown';
+export type JsonSchemaDraft = JsonSchemaKnownDraft | 'unknown';
 
-export type JSONSchemaEditorView = 'form' | 'json' | 'diff';
+export type JsonSchemaEditorView = 'form' | 'json' | 'diff';
 
-export type JSONSchemaEditorMode = 'edit' | 'readonly';
+export type JsonSchemaEditorMode = 'edit' | 'readonly';
 
 /**
  * A JSON Schema document. May be a boolean (allow-all / deny-all) or an
  * object with editable + preserved keywords.
  */
-export type JSONSchemaValue = boolean | JSONSchemaObject;
+export type JsonSchemaValue = boolean | JsonSchemaObject;
 
 /**
  * Structural shape of an object-form schema. We type the keywords the editor
  * edits explicitly; everything else round-trips through the index signature.
  */
-export interface JSONSchemaObject {
-  $schema?: string;
-  $id?: string;
-  $ref?: string;
-  type?: JSONSchemaTypeName | JSONSchemaTypeName[];
-  title?: string;
-  description?: string;
+export interface JsonSchemaObject {
+  $schema?: string | undefined;
+  $id?: string | undefined;
+  $ref?: string | undefined;
+  type?: JsonSchemaTypeName | JsonSchemaTypeName[] | undefined;
+  title?: string | undefined;
+  description?: string | undefined;
   default?: unknown;
-  examples?: unknown[];
-  enum?: unknown[];
+  examples?: unknown[] | undefined;
+  enum?: unknown[] | undefined;
   const?: unknown;
 
   // String constraints
-  minLength?: number;
-  maxLength?: number;
-  pattern?: string;
-  format?: string;
+  minLength?: number | undefined;
+  maxLength?: number | undefined;
+  pattern?: string | undefined;
+  format?: string | undefined;
 
   // Number constraints
-  minimum?: number;
-  maximum?: number;
-  exclusiveMinimum?: number;
-  exclusiveMaximum?: number;
-  multipleOf?: number;
+  minimum?: number | undefined;
+  maximum?: number | undefined;
+  exclusiveMinimum?: number | undefined;
+  exclusiveMaximum?: number | undefined;
+  multipleOf?: number | undefined;
 
   // Object constraints
-  properties?: Record<string, JSONSchemaValue>;
-  required?: string[];
-  additionalProperties?: JSONSchemaValue;
+  properties?: Record<string, JsonSchemaValue> | undefined;
+  required?: string[] | undefined;
+  additionalProperties?: JsonSchemaValue | undefined;
 
   // Array constraints
-  items?: JSONSchemaValue;
-  minItems?: number;
-  maxItems?: number;
-  uniqueItems?: boolean;
+  items?: JsonSchemaValue | undefined;
+  minItems?: number | undefined;
+  maxItems?: number | undefined;
+  uniqueItems?: boolean | undefined;
 
   // Composition
-  oneOf?: JSONSchemaValue[];
-  anyOf?: JSONSchemaValue[];
-  allOf?: JSONSchemaValue[];
-  not?: JSONSchemaValue;
+  oneOf?: JsonSchemaValue[] | undefined;
+  anyOf?: JsonSchemaValue[] | undefined;
+  allOf?: JsonSchemaValue[] | undefined;
+  not?: JsonSchemaValue | undefined;
 
   // Round-trip bag for unmodeled keywords. The editor reads and writes the
   // typed slots above; everything else is preserved verbatim.
   [key: string]: unknown;
 }
 
-export type JSONSchemaValidationError = {
+export type JsonSchemaValidationError = {
   path: string;
   message: string;
   keyword: string;
 };
 
-export type JSONSchemaValidationStatus = 'valid' | 'invalid' | 'pending' | 'compile-deferred';
+export type JsonSchemaValidationStatus = 'valid' | 'invalid' | 'pending' | 'compile-deferred';
 
-export type JSONSchemaValidationResult = {
-  status: JSONSchemaValidationStatus;
+export type JsonSchemaValidationResult = {
+  status: JsonSchemaValidationStatus;
   /** Meta-schema valid. Always meaningful, even when status is `pending`. */
   valid: boolean;
-  errors: JSONSchemaValidationError[];
+  errors: JsonSchemaValidationError[];
   /** `null` when compile is deferred or not yet run. */
   compilable: boolean | null;
   compileError?: string;
 };
 
-export type JSONSchemaEditorChangeEvent = {
-  schema: JSONSchemaValue;
+export type JsonSchemaEditorChangeEvent = {
+  schema: JsonSchemaValue;
   jsonString: string;
 };
 
-export type JSONSchemaEditorRevertEvent = {
+export type JsonSchemaEditorRevertEvent = {
   restoredFrom: 'original-schema' | 'original-text';
 };

--- a/packages/components/src/components/json-schema-editor/json-schema-editor-types.ts
+++ b/packages/components/src/components/json-schema-editor/json-schema-editor-types.ts
@@ -88,7 +88,7 @@ export type JsonSchemaValidationError = {
   keyword: string;
 };
 
-export type JsonSchemaValidationStatus = 'valid' | 'invalid' | 'pending' | 'compile-deferred';
+export type JsonSchemaValidationStatus = 'valid' | 'invalid' | 'pending';
 
 export type JsonSchemaValidationResult = {
   status: JsonSchemaValidationStatus;

--- a/packages/components/src/components/json-schema-editor/json-schema-editor-types.ts
+++ b/packages/components/src/components/json-schema-editor/json-schema-editor-types.ts
@@ -1,0 +1,110 @@
+/**
+ * Public types for the JSONSchemaEditor component.
+ *
+ * Naming rule: every type referenced from JSONSchemaEditorProps is prefixed
+ * with `JSONSchema*` or `JSONSchemaEditor*` and exported from the package
+ * barrel.
+ */
+
+export type JSONSchemaTypeName =
+  | 'string'
+  | 'number'
+  | 'integer'
+  | 'boolean'
+  | 'null'
+  | 'object'
+  | 'array';
+
+/** Drafts the editor can validate against. */
+export type JSONSchemaKnownDraft = '2020-12' | '2019-09' | 'draft-07';
+
+/** All draft states, including the unknown-but-encountered case. */
+export type JSONSchemaDraft = JSONSchemaKnownDraft | 'unknown';
+
+export type JSONSchemaEditorView = 'form' | 'json' | 'diff';
+
+export type JSONSchemaEditorMode = 'edit' | 'readonly';
+
+/**
+ * A JSON Schema document. May be a boolean (allow-all / deny-all) or an
+ * object with editable + preserved keywords.
+ */
+export type JSONSchemaValue = boolean | JSONSchemaObject;
+
+/**
+ * Structural shape of an object-form schema. We type the keywords the editor
+ * edits explicitly; everything else round-trips through the index signature.
+ */
+export interface JSONSchemaObject {
+  $schema?: string;
+  $id?: string;
+  $ref?: string;
+  type?: JSONSchemaTypeName | JSONSchemaTypeName[];
+  title?: string;
+  description?: string;
+  default?: unknown;
+  examples?: unknown[];
+  enum?: unknown[];
+  const?: unknown;
+
+  // String constraints
+  minLength?: number;
+  maxLength?: number;
+  pattern?: string;
+  format?: string;
+
+  // Number constraints
+  minimum?: number;
+  maximum?: number;
+  exclusiveMinimum?: number;
+  exclusiveMaximum?: number;
+  multipleOf?: number;
+
+  // Object constraints
+  properties?: Record<string, JSONSchemaValue>;
+  required?: string[];
+  additionalProperties?: JSONSchemaValue;
+
+  // Array constraints
+  items?: JSONSchemaValue;
+  minItems?: number;
+  maxItems?: number;
+  uniqueItems?: boolean;
+
+  // Composition
+  oneOf?: JSONSchemaValue[];
+  anyOf?: JSONSchemaValue[];
+  allOf?: JSONSchemaValue[];
+  not?: JSONSchemaValue;
+
+  // Round-trip bag for unmodeled keywords. The editor reads and writes the
+  // typed slots above; everything else is preserved verbatim.
+  [key: string]: unknown;
+}
+
+export type JSONSchemaValidationError = {
+  path: string;
+  message: string;
+  keyword: string;
+};
+
+export type JSONSchemaValidationStatus = 'valid' | 'invalid' | 'pending' | 'compile-deferred';
+
+export type JSONSchemaValidationResult = {
+  status: JSONSchemaValidationStatus;
+  /** Meta-schema valid. Always meaningful, even when status is `pending`. */
+  valid: boolean;
+  errors: JSONSchemaValidationError[];
+  /** `null` when compile is deferred or not yet run. */
+  compilable: boolean | null;
+  compileError?: string;
+};
+
+export type JSONSchemaEditorChangeEvent = {
+  schema: JSONSchemaValue;
+  jsonString: string;
+};
+
+export type JSONSchemaEditorRevertEvent = {
+  restoredFrom: 'original-schema' | 'original-text';
+};

--- a/packages/components/src/components/json-schema-editor/json-schema-editor.svelte
+++ b/packages/components/src/components/json-schema-editor/json-schema-editor.svelte
@@ -1,0 +1,168 @@
+<script lang="ts" module>
+  import type {
+    JsonSchemaEditorChangeEvent,
+    JsonSchemaEditorMode,
+    JsonSchemaEditorRevertEvent,
+    JsonSchemaEditorView,
+    JsonSchemaKnownDraft,
+    JsonSchemaValidationResult,
+    JsonSchemaValue,
+  } from './json-schema-editor-types.ts';
+
+  export type JsonSchemaEditorProps = {
+    /** Required for ARIA wiring. */
+    id: string;
+    /** The schema being edited. May be a string (JSON text) or pre-parsed value. */
+    schema: JsonSchemaValue | string;
+    /** Optional explicit baseline; defaults to the initial `schema`. */
+    original?: JsonSchemaValue | string;
+    /** Changing this triggers a full reset (history clears). */
+    schemaKey?: string;
+    /** Active view: form / json / diff. Bindable. */
+    view?: JsonSchemaEditorView;
+    /** Read-only mode disables all mutations. */
+    readonly?: boolean;
+    /** Maximum history entries (default 100). */
+    maxHistory?: number;
+    /** Force a draft override regardless of $schema. */
+    draftOverride?: JsonSchemaKnownDraft;
+    onchange?: (event: JsonSchemaEditorChangeEvent) => void;
+    onrevert?: (event: JsonSchemaEditorRevertEvent) => void;
+    onvalidate?: (result: JsonSchemaValidationResult) => void;
+    class?: string;
+  };
+
+  export type { JsonSchemaEditorMode, JsonSchemaEditorView };
+</script>
+
+<script lang="ts">
+  import { classNames } from '../../utilities/class-names.ts';
+  import { useAnnouncer } from '../../utilities/use-announcer.svelte.ts';
+  import Tab from '../tab.svelte';
+  import TabPanel from '../tab-panel.svelte';
+  import Tabs from '../tabs.svelte';
+
+  import DiffView from './diff-view.svelte';
+  import FormView from './form-view.svelte';
+  import { createEditorState } from './json-schema-editor-state.svelte.ts';
+  import JsonSchemaToolbar from './json-schema-toolbar.svelte';
+  import JsonView from './json-view.svelte';
+
+  let {
+    id,
+    schema,
+    original,
+    schemaKey,
+    view = $bindable<JsonSchemaEditorView>('form'),
+    readonly = false,
+    maxHistory,
+    draftOverride,
+    onchange,
+    onrevert,
+    onvalidate,
+    class: className,
+  }: JsonSchemaEditorProps = $props();
+
+  const announcer = useAnnouncer();
+
+  // Build state container once. We deliberately pass through the snapshot of
+  // initial props; further updates flow through `state.reload` when
+  // `schemaKey` changes (round-3 finding #10).
+  const stateOptions: Parameters<typeof createEditorState>[0] = {
+    schema,
+    readonly,
+  };
+  if (original !== undefined) stateOptions.original = original;
+  if (maxHistory !== undefined) stateOptions.maxHistory = maxHistory;
+  if (draftOverride !== undefined) stateOptions.draftOverride = draftOverride;
+  if (onchange) stateOptions.onchange = onchange;
+  if (onrevert) stateOptions.onrevert = onrevert;
+  if (onvalidate) stateOptions.onvalidate = onvalidate;
+
+  const state = createEditorState(stateOptions);
+
+  // schemaKey-triggered reset. Track the previous key explicitly so we don't
+  // reload on initial mount (state was already seeded above) or on re-renders
+  // that don't change the key.
+  let lastSchemaKey: string | undefined = schemaKey;
+  $effect(() => {
+    if (schemaKey !== lastSchemaKey) {
+      lastSchemaKey = schemaKey;
+      state.reload(schema, original);
+      announcer.announce('Schema reloaded');
+    }
+  });
+
+  // Forward bindable view <-> state.view.
+  $effect(() => {
+    if (state.view !== view) state.setView(view);
+  });
+
+  // Action handlers used by the toolbar.
+  function handleUndo() {
+    const label = state.undo();
+    announcer.announce(label ? `Undid: ${label}` : 'Undid last edit');
+  }
+
+  function handleRedo() {
+    const label = state.redo();
+    announcer.announce(label ? `Redid: ${label}` : 'Redid edit');
+  }
+
+  function handleRevert() {
+    state.revert();
+    announcer.announce('Reverted to original schema');
+  }
+
+  // Editor-level keyboard shortcuts: only fire when focus isn't inside an
+  // editable element so native text undo continues to work in inputs.
+  function isEditableTarget(target: EventTarget | null): boolean {
+    if (!(target instanceof HTMLElement)) return false;
+    const tag = target.tagName;
+    if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return true;
+    return target.isContentEditable;
+  }
+
+  function onKeyDown(event: KeyboardEvent) {
+    const isMac = typeof navigator !== 'undefined' && /Mac/.test(navigator.platform);
+    const meta = isMac ? event.metaKey : event.ctrlKey;
+    if (!meta) return;
+    if (isEditableTarget(event.target)) return;
+
+    const key = event.key.toLowerCase();
+    if (key === 'z' && !event.shiftKey) {
+      event.preventDefault();
+      handleUndo();
+    } else if ((key === 'z' && event.shiftKey) || key === 'y') {
+      event.preventDefault();
+      handleRedo();
+    }
+  }
+</script>
+
+<div
+  {id}
+  class={classNames('cinder-jse', className)}
+  data-cinder-jse=""
+  onkeydown={onKeyDown}
+  role="region"
+  aria-label="JSON Schema editor"
+>
+  <JsonSchemaToolbar {state} onUndo={handleUndo} onRedo={handleRedo} onRevert={handleRevert} />
+
+  <Tabs bind:value={view}>
+    <Tab value="form">Form</Tab>
+    <Tab value="json">JSON</Tab>
+    <Tab value="diff">Diff{state.hasChanges ? ' •' : ''}</Tab>
+
+    <TabPanel value="form">
+      <FormView {state} idPrefix={`${id}-form`} />
+    </TabPanel>
+    <TabPanel value="json">
+      <JsonView {state} idPrefix={`${id}-json`} />
+    </TabPanel>
+    <TabPanel value="diff">
+      <DiffView {state} />
+    </TabPanel>
+  </Tabs>
+</div>

--- a/packages/components/src/components/json-schema-editor/json-schema-editor.svelte
+++ b/packages/components/src/components/json-schema-editor/json-schema-editor.svelte
@@ -33,6 +33,26 @@
   };
 
   export type { JsonSchemaEditorMode, JsonSchemaEditorView };
+
+  /**
+   * Mac detection for keyboard-shortcut routing. `navigator.platform` is
+   * deprecated; prefer `navigator.userAgentData?.platform` and fall back to
+   * `platform` only when the modern accessor is unavailable (Firefox, Safari).
+   * Hoisted out of the keydown handler so it isn't re-evaluated per keystroke.
+   */
+  function detectMacPlatform(): boolean {
+    if (typeof navigator === 'undefined') return false;
+    const navigatorWithUserAgentData = navigator as Navigator & {
+      userAgentData?: { platform?: string };
+    };
+    const modernPlatform = navigatorWithUserAgentData.userAgentData?.platform;
+    if (typeof modernPlatform === 'string' && modernPlatform.length > 0) {
+      return /Mac/.test(modernPlatform);
+    }
+    return /Mac/.test(navigator.platform);
+  }
+
+  const isMacPlatform = detectMacPlatform();
 </script>
 
 <script lang="ts">
@@ -66,21 +86,47 @@
 
   const announcer = useAnnouncer();
 
-  // Build state container once. We deliberately pass through the snapshot of
-  // initial props; further updates flow through `state.reload` when
-  // `schemaKey` changes (round-3 finding #10).
+  // Build state container once. Schema reloads happen via `schemaKey`. Other
+  // mutable props (readonly, draftOverride, callback handlers) are kept in
+  // sync after mount via the $effects below — without that, parents passing
+  // inline lambdas would have their handlers captured stale at construction.
   const stateOptions: Parameters<typeof createEditorState>[0] = {
     schema,
     readonly,
+    onchange: (event) => onchange?.(event),
+    onrevert: (event) => onrevert?.(event),
+    onvalidate: (result) => onvalidate?.(result),
   };
   if (original !== undefined) stateOptions.original = original;
   if (maxHistory !== undefined) stateOptions.maxHistory = maxHistory;
   if (draftOverride !== undefined) stateOptions.draftOverride = draftOverride;
-  if (onchange) stateOptions.onchange = onchange;
-  if (onrevert) stateOptions.onrevert = onrevert;
-  if (onvalidate) stateOptions.onvalidate = onvalidate;
 
   const state = createEditorState(stateOptions);
+
+  // Sync mutable props into the state container when the *prop* changes.
+  // We track the last applied value locally so the effect only calls the
+  // setter on real prop transitions — without that, the effect re-runs on
+  // every reactive read inside setReadonly/setDraftOverride and loops.
+  let lastReadonly = readonly;
+  let lastDraftOverride: JsonSchemaKnownDraft | undefined = draftOverride;
+  $effect(() => {
+    if (readonly !== lastReadonly) {
+      lastReadonly = readonly;
+      state.setReadonly(readonly);
+    }
+  });
+  $effect(() => {
+    if (draftOverride !== lastDraftOverride) {
+      lastDraftOverride = draftOverride;
+      state.setDraftOverride(draftOverride);
+    }
+  });
+
+  // Tear down debounce timers on unmount so stale callbacks don't fire after
+  // the parent unmounts the editor.
+  $effect(() => {
+    return () => state.destroy();
+  });
 
   // schemaKey-triggered reset. Track the previous key explicitly so we don't
   // reload on initial mount (state was already seeded above) or on re-renders
@@ -125,8 +171,7 @@
   }
 
   function onKeyDown(event: KeyboardEvent) {
-    const isMac = typeof navigator !== 'undefined' && /Mac/.test(navigator.platform);
-    const meta = isMac ? event.metaKey : event.ctrlKey;
+    const meta = isMacPlatform ? event.metaKey : event.ctrlKey;
     if (!meta) return;
     if (isEditableTarget(event.target)) return;
 

--- a/packages/components/src/components/json-schema-editor/json-schema-editor.svelte
+++ b/packages/components/src/components/json-schema-editor/json-schema-editor.svelte
@@ -39,6 +39,7 @@
   import { classNames } from '../../utilities/class-names.ts';
   import { useAnnouncer } from '../../utilities/use-announcer.svelte.ts';
   import Tab from '../tab.svelte';
+  import TabList from '../tab-list.svelte';
   import TabPanel from '../tab-panel.svelte';
   import Tabs from '../tabs.svelte';
 
@@ -151,9 +152,11 @@
   <JsonSchemaToolbar {state} onUndo={handleUndo} onRedo={handleRedo} onRevert={handleRevert} />
 
   <Tabs bind:value={view}>
-    <Tab value="form">Form</Tab>
-    <Tab value="json">JSON</Tab>
-    <Tab value="diff">Diff{state.hasChanges ? ' •' : ''}</Tab>
+    <TabList label="Editor view">
+      <Tab value="form">Form</Tab>
+      <Tab value="json">JSON</Tab>
+      <Tab value="diff">Diff{state.hasChanges ? ' •' : ''}</Tab>
+    </TabList>
 
     <TabPanel value="form">
       <FormView {state} idPrefix={`${id}-form`} />

--- a/packages/components/src/components/json-schema-editor/json-schema-editor.test.ts
+++ b/packages/components/src/components/json-schema-editor/json-schema-editor.test.ts
@@ -1,0 +1,40 @@
+/**
+ * Smoke tests for the JsonSchemaEditor facade. The state container has full
+ * unit coverage in json-schema-editor-state.svelte.test.ts; these tests verify
+ * the facade mounts and forwards key props.
+ *
+ * Note: deeper integration scenarios (form-edit → onchange) hit a happy-dom
+ * bug with deeply-recursive Svelte 5 component trees. Those flows are
+ * verified via the playground browser exercise instead.
+ */
+
+import { describe, expect, test } from 'bun:test';
+
+import { setupHappyDom } from '../../test/happy-dom.ts';
+
+setupHappyDom();
+
+const { render } = await import('@testing-library/svelte');
+const { default: JsonSchemaEditor } = await import('../json-schema-editor.svelte');
+
+describe('JsonSchemaEditor — mount', () => {
+  test('renders empty state for invalid initial schema', () => {
+    const { container } = render(JsonSchemaEditor, {
+      id: 'invalid-editor',
+      schema: '{not-valid',
+    });
+
+    expect(container.textContent).toContain('Schema not loaded');
+  });
+
+  test('forwards a custom class name to the root', () => {
+    const { container } = render(JsonSchemaEditor, {
+      id: 'class-editor',
+      schema: '{not-valid',
+      class: 'my-custom-class',
+    });
+
+    const root = container.querySelector('#class-editor');
+    expect(root?.className).toContain('my-custom-class');
+  });
+});

--- a/packages/components/src/components/json-schema-editor/json-schema-toolbar.svelte
+++ b/packages/components/src/components/json-schema-editor/json-schema-toolbar.svelte
@@ -1,0 +1,86 @@
+<script lang="ts" module>
+  import type { EditorState } from './json-schema-editor-state.svelte.ts';
+
+  export type JsonSchemaToolbarProps = {
+    state: EditorState;
+    onUndo?: () => void;
+    onRedo?: () => void;
+    onRevert?: () => void;
+    class?: string;
+  };
+</script>
+
+<script lang="ts">
+  import { classNames } from '../../utilities/class-names.ts';
+  import Badge from '../badge.svelte';
+  import Button from '../button.svelte';
+  import CopyButton from '../copy-button.svelte';
+
+  let { state, onUndo, onRedo, onRevert, class: className }: JsonSchemaToolbarProps = $props();
+
+  const validationBadgeVariant = $derived.by(() => {
+    switch (state.validationStatus) {
+      case 'valid':
+        return 'success' as const;
+      case 'invalid':
+        return 'danger' as const;
+      case 'pending':
+        return 'neutral' as const;
+      case 'compile-deferred':
+        return 'warning' as const;
+    }
+  });
+
+  const validationBadgeText = $derived.by(() => {
+    switch (state.validationStatus) {
+      case 'valid':
+        return `Valid (${state.activeDraft})`;
+      case 'invalid':
+        return `Invalid${state.validationResult.errors.length > 0 ? ` — ${state.validationResult.errors.length} errors` : ''}`;
+      case 'pending':
+        return 'Validating…';
+      case 'compile-deferred':
+        return 'Validation deferred';
+    }
+  });
+</script>
+
+<div class={classNames('cinder-jse-toolbar', className)}>
+  <div class="cinder-jse-toolbar__left">
+    <Badge variant={validationBadgeVariant}>{validationBadgeText}</Badge>
+    {#if state.validationResult.compileError}
+      <Badge variant="warning" title={state.validationResult.compileError}>Compile warning</Badge>
+    {/if}
+  </div>
+
+  <div class="cinder-jse-toolbar__right">
+    <Button
+      variant="ghost"
+      size="sm"
+      disabled={!state.canUndo || state.readonly}
+      onclick={() => onUndo?.()}
+    >
+      Undo
+    </Button>
+    <Button
+      variant="ghost"
+      size="sm"
+      disabled={!state.canRedo || state.readonly}
+      onclick={() => onRedo?.()}
+    >
+      Redo
+    </Button>
+    <CopyButton value={state.copyValue}>
+      {#snippet children()}Copy JSON{/snippet}
+      {#snippet confirmation()}Copied{/snippet}
+    </CopyButton>
+    <Button
+      variant="secondary"
+      size="sm"
+      disabled={!state.hasChanges || state.readonly}
+      onclick={() => onRevert?.()}
+    >
+      Revert
+    </Button>
+  </div>
+</div>

--- a/packages/components/src/components/json-schema-editor/json-schema-toolbar.svelte
+++ b/packages/components/src/components/json-schema-editor/json-schema-toolbar.svelte
@@ -26,8 +26,6 @@
         return 'danger' as const;
       case 'pending':
         return 'neutral' as const;
-      case 'compile-deferred':
-        return 'warning' as const;
     }
   });
 
@@ -39,8 +37,6 @@
         return `Invalid${state.validationResult.errors.length > 0 ? ` — ${state.validationResult.errors.length} errors` : ''}`;
       case 'pending':
         return 'Validating…';
-      case 'compile-deferred':
-        return 'Validation deferred';
     }
   });
 </script>

--- a/packages/components/src/components/json-schema-editor/json-schema-validator.test.ts
+++ b/packages/components/src/components/json-schema-editor/json-schema-validator.test.ts
@@ -1,0 +1,188 @@
+import { describe, expect, test } from 'bun:test';
+
+import {
+  detectDraft,
+  normaliseSchemaInput,
+  tryCompile,
+  tryParseJson,
+  validateMetaSchema,
+} from './json-schema-validator.ts';
+
+describe('detectDraft', () => {
+  test('returns 2020-12 when $schema is absent', () => {
+    expect(detectDraft({})).toBe('2020-12');
+  });
+
+  test('reads recognised $schema URLs', () => {
+    expect(detectDraft({ $schema: 'https://json-schema.org/draft/2020-12/schema' })).toBe(
+      '2020-12',
+    );
+    expect(detectDraft({ $schema: 'https://json-schema.org/draft/2019-09/schema' })).toBe(
+      '2019-09',
+    );
+    expect(detectDraft({ $schema: 'http://json-schema.org/draft-07/schema#' })).toBe('draft-07');
+  });
+
+  test('returns unknown for unrecognised values', () => {
+    expect(detectDraft({ $schema: 'http://example.com/schema' })).toBe('unknown');
+  });
+
+  test('boolean schemas default to 2020-12', () => {
+    expect(detectDraft(true)).toBe('2020-12');
+    expect(detectDraft(false)).toBe('2020-12');
+  });
+});
+
+describe('validateMetaSchema', () => {
+  test('valid 2020-12 schema passes', () => {
+    const result = validateMetaSchema({ type: 'string' });
+    expect(result.valid).toBe(true);
+    expect(result.errors).toEqual([]);
+  });
+
+  test('boolean schemas pass', () => {
+    expect(validateMetaSchema(true).valid).toBe(true);
+    expect(validateMetaSchema(false).valid).toBe(true);
+  });
+
+  test('schema with type array passes', () => {
+    expect(validateMetaSchema({ type: ['string', 'null'] }).valid).toBe(true);
+  });
+
+  test('schema with no type passes (matches anything)', () => {
+    expect(validateMetaSchema({}).valid).toBe(true);
+  });
+
+  test('schema with bogus type is flagged', () => {
+    const result = validateMetaSchema({ type: 'not-a-type' });
+    expect(result.valid).toBe(false);
+    expect(result.errors.length).toBeGreaterThan(0);
+  });
+
+  test('oneOf with sibling type both pass', () => {
+    const result = validateMetaSchema({
+      type: 'object',
+      oneOf: [{ required: ['a'] }, { required: ['b'] }],
+    });
+    expect(result.valid).toBe(true);
+  });
+
+  test('Draft-07 schema validated against draft-07 passes', () => {
+    const result = validateMetaSchema(
+      { $schema: 'http://json-schema.org/draft-07/schema#', type: 'string' },
+      'draft-07',
+    );
+    expect(result.valid).toBe(true);
+  });
+});
+
+describe('tryCompile', () => {
+  test('valid schema compiles', () => {
+    const result = tryCompile({ type: 'string' });
+    expect(result.ok).toBe(true);
+  });
+
+  test('flags an unresolved $ref even when meta-schema validation passes', () => {
+    const schema = { $ref: '#/$defs/missing' };
+    expect(validateMetaSchema(schema).valid).toBe(true);
+    const result = tryCompile(schema);
+    expect(result.ok).toBe(false);
+  });
+
+  test('repeated compilation of a schema with $id does not collide', () => {
+    const schema = {
+      $id: 'https://example.com/person',
+      type: 'object',
+      properties: { name: { type: 'string' } },
+    };
+    expect(tryCompile(schema).ok).toBe(true);
+    expect(tryCompile(schema).ok).toBe(true);
+    expect(tryCompile(schema).ok).toBe(true);
+  });
+});
+
+describe('tryParseJson', () => {
+  test('parses a valid JSON document', () => {
+    const result = tryParseJson('{"a":1}');
+    if (result.ok) {
+      expect(result.value).toEqual({ a: 1 });
+    } else {
+      throw new Error('expected parse success');
+    }
+  });
+
+  test('returns an error with non-empty message on malformed input', () => {
+    const result = tryParseJson('{not-valid}');
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.message.length).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe('normaliseSchemaInput', () => {
+  test('accepts a string and parses it', () => {
+    const result = normaliseSchemaInput('{"type":"string"}');
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.schema).toEqual({ type: 'string' });
+      expect(result.rawText).toBe('{"type":"string"}');
+      expect(result.canonicalText).toContain('"type"');
+    }
+  });
+
+  test('accepts a plain object', () => {
+    const result = normaliseSchemaInput({ type: 'string' });
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.schema).toEqual({ type: 'string' });
+    }
+  });
+
+  test('accepts a boolean schema', () => {
+    expect(normaliseSchemaInput(true).ok).toBe(true);
+    expect(normaliseSchemaInput(false).ok).toBe(true);
+  });
+
+  test('rejects undefined inside an object', () => {
+    const input = { properties: { x: undefined } } as unknown;
+    const result = normaliseSchemaInput(input as never);
+    expect(result.ok).toBe(false);
+  });
+
+  test('rejects functions inside an object', () => {
+    const input = { foo: () => undefined } as unknown;
+    const result = normaliseSchemaInput(input as never);
+    expect(result.ok).toBe(false);
+  });
+
+  test('rejects symbols inside an object', () => {
+    const input = { foo: Symbol('x') } as unknown;
+    const result = normaliseSchemaInput(input as never);
+    expect(result.ok).toBe(false);
+  });
+
+  test('rejects BigInt', () => {
+    const input = { foo: 1n } as unknown;
+    const result = normaliseSchemaInput(input as never);
+    expect(result.ok).toBe(false);
+  });
+
+  test('rejects NaN and Infinity', () => {
+    expect(normaliseSchemaInput({ foo: Number.NaN } as never).ok).toBe(false);
+    expect(normaliseSchemaInput({ foo: Number.POSITIVE_INFINITY } as never).ok).toBe(false);
+    expect(normaliseSchemaInput({ foo: Number.NEGATIVE_INFINITY } as never).ok).toBe(false);
+  });
+
+  test('rejects cyclic graphs', () => {
+    const cyclic: Record<string, unknown> = { foo: 1 };
+    cyclic['self'] = cyclic;
+    const result = normaliseSchemaInput(cyclic as never);
+    expect(result.ok).toBe(false);
+  });
+
+  test('rejects malformed JSON string', () => {
+    const result = normaliseSchemaInput('{not-valid}');
+    expect(result.ok).toBe(false);
+  });
+});

--- a/packages/components/src/components/json-schema-editor/json-schema-validator.test.ts
+++ b/packages/components/src/components/json-schema-editor/json-schema-validator.test.ts
@@ -185,4 +185,12 @@ describe('normaliseSchemaInput', () => {
     const result = normaliseSchemaInput('{not-valid}');
     expect(result.ok).toBe(false);
   });
+
+  test('rejects a top-level array (not a valid schema shape)', () => {
+    const result = normaliseSchemaInput('[1, 2, 3]');
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain('object or boolean');
+    }
+  });
 });

--- a/packages/components/src/components/json-schema-editor/json-schema-validator.test.ts
+++ b/packages/components/src/components/json-schema-editor/json-schema-validator.test.ts
@@ -193,4 +193,12 @@ describe('normaliseSchemaInput', () => {
       expect(result.error).toContain('object or boolean');
     }
   });
+
+  test('rejects a top-level array value (not a valid schema shape)', () => {
+    const result = normaliseSchemaInput([1, 2, 3] as never);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error).toContain('object or boolean');
+    }
+  });
 });

--- a/packages/components/src/components/json-schema-editor/json-schema-validator.ts
+++ b/packages/components/src/components/json-schema-editor/json-schema-validator.ts
@@ -18,10 +18,10 @@ import Ajv2019 from 'ajv/dist/2019.js';
 import Ajv2020 from 'ajv/dist/2020.js';
 
 import type {
-  JSONSchemaDraft,
-  JSONSchemaKnownDraft,
-  JSONSchemaValidationError,
-  JSONSchemaValue,
+  JsonSchemaDraft,
+  JsonSchemaKnownDraft,
+  JsonSchemaValidationError,
+  JsonSchemaValue,
 } from './json-schema-editor-types.ts';
 
 const DRAFT_2020_IDS = new Set([
@@ -54,7 +54,7 @@ function getSchemaId(schema: unknown): string | undefined {
  * absent (newest stable). Returns 'unknown' for unrecognised values so
  * callers can fall back deliberately.
  */
-export function detectDraft(schema: unknown): JSONSchemaDraft {
+export function detectDraft(schema: unknown): JsonSchemaDraft {
   const id = getSchemaId(schema);
   if (!id) return '2020-12';
   if (DRAFT_2020_IDS.has(id)) return '2020-12';
@@ -63,7 +63,7 @@ export function detectDraft(schema: unknown): JSONSchemaDraft {
   return 'unknown';
 }
 
-function resolveDraft(draft: JSONSchemaDraft | undefined): JSONSchemaKnownDraft {
+function resolveDraft(draft: JsonSchemaDraft | undefined): JsonSchemaKnownDraft {
   if (!draft || draft === 'unknown') return '2020-12';
   return draft;
 }
@@ -74,7 +74,7 @@ let metaAjv2020: Ajv2020 | null = null;
 let metaAjv2019: Ajv2019 | null = null;
 let metaAjv07: Ajv | null = null;
 
-function getMetaValidator(draft: JSONSchemaKnownDraft): Ajv | Ajv2020 | Ajv2019 {
+function getMetaValidator(draft: JsonSchemaKnownDraft): Ajv | Ajv2020 | Ajv2019 {
   if (draft === '2020-12') {
     if (!metaAjv2020) metaAjv2020 = new Ajv2020({ strict: false, allErrors: true });
     return metaAjv2020;
@@ -89,7 +89,7 @@ function getMetaValidator(draft: JSONSchemaKnownDraft): Ajv | Ajv2020 | Ajv2019 
 
 function ajvErrorsToValidationErrors(
   errors: { instancePath?: string; message?: string; keyword?: string }[] | null | undefined,
-): JSONSchemaValidationError[] {
+): JsonSchemaValidationError[] {
   if (!errors) return [];
   return errors.map((error) => ({
     path: error.instancePath ?? '',
@@ -104,8 +104,8 @@ function ajvErrorsToValidationErrors(
  */
 export function validateMetaSchema(
   schema: unknown,
-  draft?: JSONSchemaDraft,
-): { valid: boolean; errors: JSONSchemaValidationError[] } {
+  draft?: JsonSchemaDraft,
+): { valid: boolean; errors: JsonSchemaValidationError[] } {
   if (typeof schema === 'boolean') return { valid: true, errors: [] };
   if (!isObject(schema)) {
     return {
@@ -133,7 +133,7 @@ export function validateMetaSchema(
  */
 export function tryCompile(
   schema: unknown,
-  draft?: JSONSchemaDraft,
+  draft?: JsonSchemaDraft,
 ): { ok: true } | { ok: false; error: string } {
   if (typeof schema === 'boolean') return { ok: true };
   if (!isObject(schema)) {
@@ -276,9 +276,9 @@ const PRETTY_INDENT = 2;
  * the editor needs.
  */
 export function normaliseSchemaInput(
-  input: JSONSchemaValue | string,
+  input: JsonSchemaValue | string,
 ):
-  | { ok: true; rawText: string; canonicalText: string; schema: JSONSchemaValue }
+  | { ok: true; rawText: string; canonicalText: string; schema: JsonSchemaValue }
   | { ok: false; rawText: string; error: string } {
   if (typeof input === 'string') {
     const parsed = tryParseJson(input);
@@ -292,7 +292,7 @@ export function normaliseSchemaInput(
         error: 'Top-level schema must be an object or boolean',
       };
     }
-    const schema = parsed.value as JSONSchemaValue;
+    const schema = parsed.value as JsonSchemaValue;
     return {
       ok: true,
       rawText: input,

--- a/packages/components/src/components/json-schema-editor/json-schema-validator.ts
+++ b/packages/components/src/components/json-schema-editor/json-schema-validator.ts
@@ -1,0 +1,324 @@
+/**
+ * Ajv wrappers for JSON Schema meta-schema validation, compilability checks,
+ * and input normalisation.
+ *
+ * Two distinct validation signals are exposed:
+ *  - validateMetaSchema: does the document conform to the JSON Schema
+ *    meta-schema for the chosen draft?
+ *  - tryCompile: can Ajv compile this schema into a validator? Catches
+ *    issues meta-schema validation misses (unresolved $ref, unsupported
+ *    format, etc.).
+ *
+ * tryCompile uses a fresh Ajv instance per call so iterating on a schema
+ * with a stable $id never trips the "schema already exists" cache error.
+ */
+
+import Ajv from 'ajv';
+import Ajv2019 from 'ajv/dist/2019.js';
+import Ajv2020 from 'ajv/dist/2020.js';
+
+import type {
+  JSONSchemaDraft,
+  JSONSchemaKnownDraft,
+  JSONSchemaValidationError,
+  JSONSchemaValue,
+} from './json-schema-editor-types.ts';
+
+const DRAFT_2020_IDS = new Set([
+  'https://json-schema.org/draft/2020-12/schema',
+  'http://json-schema.org/draft/2020-12/schema',
+]);
+const DRAFT_2019_IDS = new Set([
+  'https://json-schema.org/draft/2019-09/schema',
+  'http://json-schema.org/draft/2019-09/schema',
+]);
+const DRAFT_07_IDS = new Set([
+  'http://json-schema.org/draft-07/schema#',
+  'http://json-schema.org/draft-07/schema',
+  'https://json-schema.org/draft-07/schema',
+  'https://json-schema.org/draft-07/schema#',
+]);
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function getSchemaId(schema: unknown): string | undefined {
+  if (!isObject(schema)) return undefined;
+  const id = schema['$schema'];
+  return typeof id === 'string' ? id : undefined;
+}
+
+/**
+ * Detect which draft a schema declares via $schema. Returns '2020-12' when
+ * absent (newest stable). Returns 'unknown' for unrecognised values so
+ * callers can fall back deliberately.
+ */
+export function detectDraft(schema: unknown): JSONSchemaDraft {
+  const id = getSchemaId(schema);
+  if (!id) return '2020-12';
+  if (DRAFT_2020_IDS.has(id)) return '2020-12';
+  if (DRAFT_2019_IDS.has(id)) return '2019-09';
+  if (DRAFT_07_IDS.has(id)) return 'draft-07';
+  return 'unknown';
+}
+
+function resolveDraft(draft: JSONSchemaDraft | undefined): JSONSchemaKnownDraft {
+  if (!draft || draft === 'unknown') return '2020-12';
+  return draft;
+}
+
+// Long-lived meta-schema validators. Safe to share — they don't compile the
+// user's schema, only validate against the meta-schema.
+let metaAjv2020: Ajv2020 | null = null;
+let metaAjv2019: Ajv2019 | null = null;
+let metaAjv07: Ajv | null = null;
+
+function getMetaValidator(draft: JSONSchemaKnownDraft): Ajv | Ajv2020 | Ajv2019 {
+  if (draft === '2020-12') {
+    if (!metaAjv2020) metaAjv2020 = new Ajv2020({ strict: false, allErrors: true });
+    return metaAjv2020;
+  }
+  if (draft === '2019-09') {
+    if (!metaAjv2019) metaAjv2019 = new Ajv2019({ strict: false, allErrors: true });
+    return metaAjv2019;
+  }
+  if (!metaAjv07) metaAjv07 = new Ajv({ strict: false, allErrors: true });
+  return metaAjv07;
+}
+
+function ajvErrorsToValidationErrors(
+  errors: { instancePath?: string; message?: string; keyword?: string }[] | null | undefined,
+): JSONSchemaValidationError[] {
+  if (!errors) return [];
+  return errors.map((error) => ({
+    path: error.instancePath ?? '',
+    message: error.message ?? 'Validation error',
+    keyword: error.keyword ?? '',
+  }));
+}
+
+/**
+ * Validate a schema document against the meta-schema for the chosen draft.
+ * Boolean schemas (true / false) are always valid full-document schemas.
+ */
+export function validateMetaSchema(
+  schema: unknown,
+  draft?: JSONSchemaDraft,
+): { valid: boolean; errors: JSONSchemaValidationError[] } {
+  if (typeof schema === 'boolean') return { valid: true, errors: [] };
+  if (!isObject(schema)) {
+    return {
+      valid: false,
+      errors: [{ path: '', message: 'Schema must be an object or boolean', keyword: '' }],
+    };
+  }
+
+  const resolved = resolveDraft(draft ?? detectDraft(schema));
+  const ajv = getMetaValidator(resolved);
+  const valid = ajv.validateSchema(schema);
+
+  return {
+    valid: Boolean(valid),
+    errors: ajvErrorsToValidationErrors(ajv.errors),
+  };
+}
+
+/**
+ * Try to compile the schema. Surfaces unresolved $refs, unsupported formats,
+ * and other compile-time errors that meta-schema validation misses.
+ *
+ * Each call uses a fresh Ajv instance so repeated compilation of a schema
+ * with a stable $id does not collide with Ajv's internal cache.
+ */
+export function tryCompile(
+  schema: unknown,
+  draft?: JSONSchemaDraft,
+): { ok: true } | { ok: false; error: string } {
+  if (typeof schema === 'boolean') return { ok: true };
+  if (!isObject(schema)) {
+    return { ok: false, error: 'Schema must be an object or boolean' };
+  }
+
+  const resolved = resolveDraft(draft ?? detectDraft(schema));
+  let ajv: Ajv | Ajv2020 | Ajv2019;
+  if (resolved === '2020-12') {
+    ajv = new Ajv2020({ strict: false, addUsedSchema: false });
+  } else if (resolved === '2019-09') {
+    ajv = new Ajv2019({ strict: false, addUsedSchema: false });
+  } else {
+    ajv = new Ajv({ strict: false, addUsedSchema: false });
+  }
+
+  try {
+    ajv.compile(schema);
+    return { ok: true };
+  } catch (error) {
+    return {
+      ok: false,
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+
+export type ParsePosition = { line: number; column: number };
+
+function extractParsePosition(error: SyntaxError, source: string): ParsePosition | undefined {
+  // V8/Bun: SyntaxError.message often includes "at position N" or
+  // "in JSON at position N". Best-effort extraction; tests assert message
+  // presence only, not line/col.
+  const positionMatch = error.message.match(/position (\d+)/);
+  const positionString = positionMatch?.[1];
+  if (!positionString) return undefined;
+  const offset = Number.parseInt(positionString, 10);
+  if (Number.isNaN(offset) || offset < 0 || offset > source.length) return undefined;
+
+  let line = 1;
+  let column = 1;
+  for (let i = 0; i < offset; i += 1) {
+    if (source[i] === '\n') {
+      line += 1;
+      column = 1;
+    } else {
+      column += 1;
+    }
+  }
+  return { line, column };
+}
+
+export function tryParseJson(
+  text: string,
+):
+  | { ok: true; value: unknown }
+  | { ok: false; error: { message: string; line?: number; column?: number } } {
+  try {
+    return { ok: true, value: JSON.parse(text) };
+  } catch (error) {
+    if (error instanceof SyntaxError) {
+      const position = extractParsePosition(error, text);
+      const errorPayload: { message: string; line?: number; column?: number } = {
+        message: error.message,
+      };
+      if (position) {
+        errorPayload.line = position.line;
+        errorPayload.column = position.column;
+      }
+      return { ok: false, error: errorPayload };
+    }
+    return {
+      ok: false,
+      error: {
+        message: error instanceof Error ? error.message : String(error),
+      },
+    };
+  }
+}
+
+/**
+ * Strict JSON-compatibility check. Returns the offending path when the value
+ * cannot be safely round-tripped through JSON.stringify without loss.
+ *
+ * This catches what JSON.stringify would silently drop or reject:
+ * undefined, functions, symbols, BigInt, NaN, ±Infinity, and cycles.
+ */
+function findJsonIncompatibility(value: unknown, path: string, seen: Set<unknown>): string | null {
+  if (value === null) return null;
+
+  const valueType = typeof value;
+  if (valueType === 'string' || valueType === 'boolean') return null;
+  if (valueType === 'number') {
+    if (typeof value === 'number' && !Number.isFinite(value)) {
+      return `non-finite number at ${path || 'root'}`;
+    }
+    return null;
+  }
+  if (valueType === 'undefined') return `undefined at ${path || 'root'}`;
+  if (valueType === 'function') return `function at ${path || 'root'}`;
+  if (valueType === 'symbol') return `symbol at ${path || 'root'}`;
+  if (valueType === 'bigint') return `bigint at ${path || 'root'}`;
+
+  if (seen.has(value)) return `cycle at ${path || 'root'}`;
+  seen.add(value);
+
+  if (Array.isArray(value)) {
+    for (let i = 0; i < value.length; i += 1) {
+      const error = findJsonIncompatibility(value[i], `${path}[${i}]`, seen);
+      if (error) return error;
+    }
+    seen.delete(value);
+    return null;
+  }
+
+  if (isObject(value)) {
+    const proto = Object.getPrototypeOf(value);
+    if (proto !== null && proto !== Object.prototype) {
+      const constructorName: string =
+        typeof proto.constructor?.name === 'string' ? proto.constructor.name : 'unknown';
+      return `non-plain object (${constructorName}) at ${path || 'root'}`;
+    }
+    for (const key of Object.keys(value)) {
+      const child = value[key];
+      const error = findJsonIncompatibility(child, `${path}.${key}`, seen);
+      if (error) return error;
+    }
+    seen.delete(value);
+    return null;
+  }
+
+  return `unsupported value at ${path || 'root'}`;
+}
+
+const PRETTY_INDENT = 2;
+
+/**
+ * Single entry point for accepting a schema input from a parent. Handles
+ * both string and object inputs and returns the raw + canonical text views
+ * the editor needs.
+ */
+export function normaliseSchemaInput(
+  input: JSONSchemaValue | string,
+):
+  | { ok: true; rawText: string; canonicalText: string; schema: JSONSchemaValue }
+  | { ok: false; rawText: string; error: string } {
+  if (typeof input === 'string') {
+    const parsed = tryParseJson(input);
+    if (!parsed.ok) {
+      return { ok: false, rawText: input, error: parsed.error.message };
+    }
+    if (typeof parsed.value !== 'boolean' && !isObject(parsed.value)) {
+      return {
+        ok: false,
+        rawText: input,
+        error: 'Top-level schema must be an object or boolean',
+      };
+    }
+    const schema = parsed.value as JSONSchemaValue;
+    return {
+      ok: true,
+      rawText: input,
+      canonicalText: JSON.stringify(schema, null, PRETTY_INDENT),
+      schema,
+    };
+  }
+
+  if (typeof input === 'boolean') {
+    return {
+      ok: true,
+      rawText: JSON.stringify(input),
+      canonicalText: JSON.stringify(input, null, PRETTY_INDENT),
+      schema: input,
+    };
+  }
+
+  const incompatibility = findJsonIncompatibility(input, '', new Set());
+  if (incompatibility) {
+    return { ok: false, rawText: '', error: incompatibility };
+  }
+
+  return {
+    ok: true,
+    rawText: JSON.stringify(input),
+    canonicalText: JSON.stringify(input, null, PRETTY_INDENT),
+    schema: input,
+  };
+}

--- a/packages/components/src/components/json-schema-editor/json-schema-validator.ts
+++ b/packages/components/src/components/json-schema-editor/json-schema-validator.ts
@@ -310,6 +310,14 @@ export function normaliseSchemaInput(
     };
   }
 
+  if (!isObject(input)) {
+    return {
+      ok: false,
+      rawText: '',
+      error: 'Top-level schema must be an object or boolean',
+    };
+  }
+
   const incompatibility = findJsonIncompatibility(input, '', new Set());
   if (incompatibility) {
     return { ok: false, rawText: '', error: incompatibility };

--- a/packages/components/src/components/json-schema-editor/json-view.svelte
+++ b/packages/components/src/components/json-schema-editor/json-view.svelte
@@ -26,7 +26,7 @@
   const draftParse = $derived(tryParseJson(state.jsonDraftText));
   const draftMeta = $derived.by(() => {
     if (!draftParse.ok) return null;
-    return validateMetaSchema(draftParse.value);
+    return validateMetaSchema(draftParse.value, state.activeDraft);
   });
 
   const draftErrorMessage = $derived.by(() => {

--- a/packages/components/src/components/json-schema-editor/json-view.svelte
+++ b/packages/components/src/components/json-schema-editor/json-view.svelte
@@ -1,0 +1,80 @@
+<script lang="ts" module>
+  import type { EditorState } from './json-schema-editor-state.svelte.ts';
+
+  export type JsonViewProps = {
+    state: EditorState;
+    idPrefix: string;
+    class?: string;
+  };
+</script>
+
+<script lang="ts">
+  import { classNames } from '../../utilities/class-names.ts';
+  import Alert from '../alert.svelte';
+  import Badge from '../badge.svelte';
+  import Button from '../button.svelte';
+  import Textarea from '../textarea.svelte';
+
+  import { tryParseJson, validateMetaSchema } from './json-schema-validator.ts';
+
+  let { state, idPrefix, class: className }: JsonViewProps = $props();
+
+  // Live (synchronous) parse + meta-schema status for the current draft.
+  // The state container only debounces validation against the *committed*
+  // schema; the JSON view runs an immediate cheap check on the *draft* so
+  // the user gets instant feedback while typing.
+  const draftParse = $derived(tryParseJson(state.jsonDraftText));
+  const draftMeta = $derived.by(() => {
+    if (!draftParse.ok) return null;
+    return validateMetaSchema(draftParse.value);
+  });
+
+  const draftErrorMessage = $derived.by(() => {
+    if (!draftParse.ok) return draftParse.error.message;
+    if (draftMeta && !draftMeta.valid) {
+      return draftMeta.errors.map((e) => `${e.path || '(root)'}: ${e.message}`).join('\n');
+    }
+    return null;
+  });
+
+  const canApply = $derived(
+    !state.readonly && state.jsonDraftIsDirty && draftParse.ok && draftMeta?.valid === true,
+  );
+
+  const canDiscard = $derived(state.jsonDraftIsDirty && !state.readonly);
+</script>
+
+<div class={classNames('cinder-jse-json-view', className)}>
+  <div class="cinder-jse-json-view__toolbar">
+    {#if state.jsonDraftIsDirty}
+      <Badge variant="warning">Draft modified — Apply to commit</Badge>
+    {/if}
+    <Button variant="primary" size="sm" disabled={!canApply} onclick={() => state.applyJsonDraft()}>
+      Apply
+    </Button>
+    <Button
+      variant="secondary"
+      size="sm"
+      disabled={!canDiscard}
+      onclick={() => state.discardJsonDraft()}
+    >
+      Discard
+    </Button>
+  </div>
+
+  <Textarea
+    id={`${idPrefix}-textarea`}
+    label="JSON"
+    value={state.jsonDraftText}
+    disabled={state.readonly}
+    rows={20}
+    class="cinder-jse-json-view__textarea"
+    oninput={(event: Event) => state.setJsonDraftText((event.target as HTMLTextAreaElement).value)}
+  />
+
+  {#if draftErrorMessage}
+    <Alert variant="error">
+      <pre class="cinder-jse-json-view__errors">{draftErrorMessage}</pre>
+    </Alert>
+  {/if}
+</div>

--- a/packages/components/src/components/json-schema-editor/property-editor.svelte
+++ b/packages/components/src/components/json-schema-editor/property-editor.svelte
@@ -66,27 +66,20 @@
   /** Hard recursion limit — deeper nodes show a placeholder. */
   export const MAX_RENDER_DEPTH = 30;
 
-  /**
-   * Stable identity keys for composition branches and array items.
-   *
-   * Plain JSON objects have no built-in identity. If we use the array index
-   * as the {#each} key, removing a non-last branch makes Svelte diff by
-   * index — surviving branches inherit the wrong PropertyEditor instance
-   * (and its local $state, like `userExpanded`). We assign each branch
-   * object a monotonic ID the first time it's rendered and remember it via
-   * a WeakMap so re-renders of the same object reuse the same key.
-   */
-  const branchKeys = new WeakMap<object, number>();
-  let nextBranchKey = 1;
+  export const NUMBER_CONSTRAINT_FIELDS = [
+    { key: 'minimum', label: 'Minimum' },
+    { key: 'maximum', label: 'Maximum' },
+    { key: 'exclusiveMinimum', label: 'Exclusive minimum' },
+    { key: 'exclusiveMaximum', label: 'Exclusive maximum' },
+    { key: 'multipleOf', label: 'Multiple of' },
+  ] as const;
 
-  export function keyForBranch(branch: unknown, fallbackIndex: number): string {
-    if (branch === null || typeof branch !== 'object') return `value-${fallbackIndex}`;
-    const existing = branchKeys.get(branch);
-    if (existing !== undefined) return `id-${existing}`;
-    const fresh = nextBranchKey++;
-    branchKeys.set(branch, fresh);
-    return `id-${fresh}`;
-  }
+  export type NumberConstraintKeyword = (typeof NUMBER_CONSTRAINT_FIELDS)[number]['key'];
+
+  // The branch-keying helper is extracted to a `.ts` sibling because TypeScript's
+  // ambient `*.svelte` shape doesn't surface module-block named exports cleanly,
+  // and we want it directly unit-testable.
+  export { reconcileCompositionBranchKeys } from './composition-branch-keys.ts';
 </script>
 
 <script lang="ts">
@@ -98,6 +91,7 @@
   import Input from '../input.svelte';
   import Tooltip from '../tooltip.svelte';
 
+  import { reconcileCompositionBranchKeys } from './composition-branch-keys.ts';
   import type { JsonSchemaObject } from './json-schema-editor-types.ts';
   import PropertyEditor from './property-editor.svelte';
   import PropertyList from './property-list.svelte';
@@ -187,6 +181,24 @@
     onchange({}, { label: 'convert to object schema' });
   }
 
+  function parseOptionalFiniteNumber(raw: string): number | undefined {
+    if (raw === '') return undefined;
+    const parsed = Number(raw);
+    return Number.isFinite(parsed) ? parsed : undefined;
+  }
+
+  function numberConstraintValue(key: NumberConstraintKeyword): string {
+    const value = objectValue[key];
+    return typeof value === 'number' ? value.toString() : '';
+  }
+
+  function patchNumberConstraint(key: NumberConstraintKeyword, raw: string) {
+    patch({ [key]: parseOptionalFiniteNumber(raw) } as Partial<JsonSchemaObject>, {
+      coalesceKey: `${key}:${path}`,
+      label: `edit ${key}`,
+    });
+  }
+
   // ===== Visibility flags for type-specific sections =====
   const showStringConstraints = $derived(selectedTypes.includes('string'));
   const showNumberConstraints = $derived(
@@ -237,6 +249,49 @@
     patch({ [keyword]: next } as Partial<JsonSchemaObject>, {
       label: `edit ${keyword}`,
     });
+  }
+
+  let nextCompositionBranchKey = $state(1);
+  let compositionBranchKeys = $state<Record<'allOf' | 'anyOf' | 'oneOf', string[]>>({
+    allOf: [],
+    anyOf: [],
+    oneOf: [],
+  });
+
+  function createCompositionBranchKey(): string {
+    const key = `branch-${nextCompositionBranchKey}`;
+    nextCompositionBranchKey += 1;
+    return key;
+  }
+
+  function keysForComposition(
+    keyword: 'allOf' | 'anyOf' | 'oneOf',
+    branches: JsonSchemaValue[],
+  ): string[] {
+    const reconciled = reconcileCompositionBranchKeys(
+      compositionBranchKeys[keyword],
+      branches.length,
+      createCompositionBranchKey,
+    );
+    compositionBranchKeys[keyword] = reconciled;
+    return reconciled;
+  }
+
+  function removeCompositionBranch(keyword: 'allOf' | 'anyOf' | 'oneOf', branchIndex: number) {
+    const list = Array.isArray(objectValue[keyword]) ? [...objectValue[keyword]!] : [];
+    list.splice(branchIndex, 1);
+    compositionBranchKeys[keyword] = compositionBranchKeys[keyword].toSpliced(branchIndex, 1);
+    patchComposition(keyword, list.length > 0 ? list : undefined);
+  }
+
+  function addCompositionBranch(keyword: 'allOf' | 'anyOf' | 'oneOf') {
+    const list = Array.isArray(objectValue[keyword]) ? [...objectValue[keyword]!] : [];
+    list.push({});
+    compositionBranchKeys[keyword] = [
+      ...compositionBranchKeys[keyword],
+      createCompositionBranchKey(),
+    ];
+    patchComposition(keyword, list);
   }
 </script>
 
@@ -411,34 +466,16 @@
       <details class="cinder-jse-section cinder-jse-section--collapsible">
         <summary class="cinder-jse-section__title">Number constraints</summary>
         <div class="cinder-jse-section__body">
-          <Input
-            id={`${idPrefix}-minimum`}
-            label="Minimum"
-            value={objectValue.minimum?.toString() ?? ''}
-            disabled={readonly}
-            oninput={(event: Event) => {
-              const raw = (event.target as HTMLInputElement).value;
-              const parsed = raw === '' ? undefined : Number(raw);
-              patch(
-                { minimum: parsed !== undefined && Number.isFinite(parsed) ? parsed : undefined },
-                { coalesceKey: `minimum:${path}`, label: 'edit minimum' },
-              );
-            }}
-          />
-          <Input
-            id={`${idPrefix}-maximum`}
-            label="Maximum"
-            value={objectValue.maximum?.toString() ?? ''}
-            disabled={readonly}
-            oninput={(event: Event) => {
-              const raw = (event.target as HTMLInputElement).value;
-              const parsed = raw === '' ? undefined : Number(raw);
-              patch(
-                { maximum: parsed !== undefined && Number.isFinite(parsed) ? parsed : undefined },
-                { coalesceKey: `maximum:${path}`, label: 'edit maximum' },
-              );
-            }}
-          />
+          {#each NUMBER_CONSTRAINT_FIELDS as field (field.key)}
+            <Input
+              id={`${idPrefix}-${field.key}`}
+              label={field.label}
+              value={numberConstraintValue(field.key)}
+              disabled={readonly}
+              oninput={(event: Event) =>
+                patchNumberConstraint(field.key, (event.target as HTMLInputElement).value)}
+            />
+          {/each}
         </div>
       </details>
     {/if}
@@ -446,10 +483,11 @@
     <!-- Composition (only when present) -->
     {#each ['allOf', 'anyOf', 'oneOf'] as const as keyword (keyword)}
       {#if Array.isArray(objectValue[keyword])}
+        {@const branchKeys = keysForComposition(keyword, objectValue[keyword])}
         <details class="cinder-jse-section cinder-jse-section--collapsible" open>
           <summary class="cinder-jse-section__title">{keyword}</summary>
           <div class="cinder-jse-section__body">
-            {#each objectValue[keyword] as branch, branchIndex (keyForBranch(branch, branchIndex))}
+            {#each objectValue[keyword] as branch, branchIndex (branchKeys[branchIndex])}
               <PropertyEditor
                 idPrefix={`${idPrefix}-${keyword}-${branchIndex}`}
                 path={`${path}/${keyword}/${branchIndex}`}
@@ -466,11 +504,7 @@
                 variant="ghost"
                 size="xs"
                 disabled={readonly}
-                onclick={() => {
-                  const list = [...objectValue[keyword]!];
-                  list.splice(branchIndex, 1);
-                  patchComposition(keyword, list.length > 0 ? list : undefined);
-                }}
+                onclick={() => removeCompositionBranch(keyword, branchIndex)}
               >
                 Remove branch
               </Button>
@@ -479,11 +513,7 @@
               variant="secondary"
               size="sm"
               disabled={readonly}
-              onclick={() => {
-                const list = Array.isArray(objectValue[keyword]) ? [...objectValue[keyword]!] : [];
-                list.push({});
-                patchComposition(keyword, list);
-              }}
+              onclick={() => addCompositionBranch(keyword)}
             >
               Add {keyword} branch
             </Button>

--- a/packages/components/src/components/json-schema-editor/property-editor.svelte
+++ b/packages/components/src/components/json-schema-editor/property-editor.svelte
@@ -65,6 +65,28 @@
 
   /** Hard recursion limit — deeper nodes show a placeholder. */
   export const MAX_RENDER_DEPTH = 30;
+
+  /**
+   * Stable identity keys for composition branches and array items.
+   *
+   * Plain JSON objects have no built-in identity. If we use the array index
+   * as the {#each} key, removing a non-last branch makes Svelte diff by
+   * index — surviving branches inherit the wrong PropertyEditor instance
+   * (and its local $state, like `userExpanded`). We assign each branch
+   * object a monotonic ID the first time it's rendered and remember it via
+   * a WeakMap so re-renders of the same object reuse the same key.
+   */
+  const branchKeys = new WeakMap<object, number>();
+  let nextBranchKey = 1;
+
+  export function keyForBranch(branch: unknown, fallbackIndex: number): string {
+    if (branch === null || typeof branch !== 'object') return `value-${fallbackIndex}`;
+    const existing = branchKeys.get(branch);
+    if (existing !== undefined) return `id-${existing}`;
+    const fresh = nextBranchKey++;
+    branchKeys.set(branch, fresh);
+    return `id-${fresh}`;
+  }
 </script>
 
 <script lang="ts">
@@ -427,7 +449,7 @@
         <details class="cinder-jse-section cinder-jse-section--collapsible" open>
           <summary class="cinder-jse-section__title">{keyword}</summary>
           <div class="cinder-jse-section__body">
-            {#each objectValue[keyword] as branch, branchIndex (branchIndex)}
+            {#each objectValue[keyword] as branch, branchIndex (keyForBranch(branch, branchIndex))}
               <PropertyEditor
                 idPrefix={`${idPrefix}-${keyword}-${branchIndex}`}
                 path={`${path}/${keyword}/${branchIndex}`}

--- a/packages/components/src/components/json-schema-editor/property-editor.svelte
+++ b/packages/components/src/components/json-schema-editor/property-editor.svelte
@@ -1,0 +1,496 @@
+<script lang="ts" module>
+  import type { JsonSchemaTypeName, JsonSchemaValue } from './json-schema-editor-types.ts';
+
+  export type PropertyEditorProps = {
+    /** Stable identifier prefix for ARIA wiring. */
+    idPrefix: string;
+    /** The schema node being edited. */
+    value: JsonSchemaValue;
+    /** Path to this node within the root schema, for stable coalesce keys. */
+    path: string;
+    /** Recursion depth — used to collapse deeply-nested nodes by default. */
+    depth?: number;
+    /** Whether the editor is read-only. */
+    readonly?: boolean;
+    /** Called whenever the value changes. */
+    onchange: (next: JsonSchemaValue, options?: { coalesceKey?: string; label?: string }) => void;
+    class?: string;
+  };
+
+  export const PRIMITIVE_TYPES: readonly JsonSchemaTypeName[] = [
+    'string',
+    'number',
+    'integer',
+    'boolean',
+    'null',
+    'object',
+    'array',
+  ] as const;
+
+  /** Editable keywords with dedicated UI. Everything else is preserved-only. */
+  export const EDITABLE_KEYWORDS = new Set<string>([
+    'type',
+    'title',
+    'description',
+    'default',
+    'examples',
+    'const',
+    'enum',
+    'minLength',
+    'maxLength',
+    'pattern',
+    'format',
+    'minimum',
+    'maximum',
+    'exclusiveMinimum',
+    'exclusiveMaximum',
+    'multipleOf',
+    'properties',
+    'required',
+    'additionalProperties',
+    'items',
+    'minItems',
+    'maxItems',
+    'uniqueItems',
+    'oneOf',
+    'anyOf',
+    'allOf',
+    'not',
+    '$ref',
+    '$schema',
+  ]);
+
+  /** Default render-collapsed depth for child nodes. */
+  export const DEFAULT_COLLAPSE_DEPTH = 3;
+
+  /** Hard recursion limit — deeper nodes show a placeholder. */
+  export const MAX_RENDER_DEPTH = 30;
+</script>
+
+<script lang="ts">
+  import { classNames } from '../../utilities/class-names.ts';
+  import Alert from '../alert.svelte';
+  import Badge from '../badge.svelte';
+  import Button from '../button.svelte';
+  import Checkbox from '../checkbox.svelte';
+  import Input from '../input.svelte';
+  import Surface from '../surface.svelte';
+  import Tooltip from '../tooltip.svelte';
+
+  import type { JsonSchemaObject } from './json-schema-editor-types.ts';
+  import PropertyEditor from './property-editor.svelte';
+  import PropertyList from './property-list.svelte';
+
+  let {
+    idPrefix,
+    value,
+    path,
+    depth = 0,
+    readonly = false,
+    onchange,
+    class: className,
+  }: PropertyEditorProps = $props();
+
+  // ===== Boolean schema short-circuit =====
+  const isBooleanSchema = $derived(typeof value === 'boolean');
+
+  // ===== Object-shape derivations =====
+  const objectValue = $derived.by<JsonSchemaObject>(() => {
+    if (typeof value === 'boolean') return {};
+    return value;
+  });
+
+  // Preserve original `type` representation: scalar vs single-element array.
+  const originalTypeRepresentation = $derived<'scalar' | 'array' | 'absent'>(
+    objectValue.type === undefined
+      ? 'absent'
+      : Array.isArray(objectValue.type)
+        ? 'array'
+        : 'scalar',
+  );
+
+  const selectedTypes = $derived.by<JsonSchemaTypeName[]>(() => {
+    const t = objectValue.type;
+    if (t === undefined) return [];
+    return Array.isArray(t) ? [...t] : [t];
+  });
+
+  const isAnyType = $derived(selectedTypes.length === 0);
+
+  const preservedKeys = $derived.by(() => {
+    return Object.keys(objectValue).filter((key) => !EDITABLE_KEYWORDS.has(key));
+  });
+
+  // ===== Mutation helpers =====
+  function patch(
+    edits: Partial<JsonSchemaObject>,
+    opts?: { coalesceKey?: string; label?: string },
+  ) {
+    if (readonly) return;
+    const next: JsonSchemaObject = { ...objectValue, ...edits };
+    // Drop keys whose new value is undefined so we don't accumulate noise.
+    for (const key of Object.keys(edits)) {
+      if (next[key] === undefined) delete next[key];
+    }
+    onchange(next, opts);
+  }
+
+  function setTypeFromCheckboxes(types: JsonSchemaTypeName[]) {
+    if (readonly) return;
+    if (types.length === 0) {
+      patch({ type: undefined }, { label: 'change type' });
+      return;
+    }
+    if (types.length === 1) {
+      // Preserve original representation when going back to a single type.
+      const next = originalTypeRepresentation === 'array' ? types : types[0]!;
+      patch({ type: next }, { label: 'change type' });
+      return;
+    }
+    patch({ type: types }, { label: 'change type' });
+  }
+
+  function toggleType(type: JsonSchemaTypeName, checked: boolean) {
+    const current = new Set(selectedTypes);
+    if (checked) current.add(type);
+    else current.delete(type);
+    setTypeFromCheckboxes([...current]);
+  }
+
+  function setAny(any: boolean) {
+    if (any) setTypeFromCheckboxes([]);
+  }
+
+  function convertBooleanToObject() {
+    if (readonly) return;
+    onchange({}, { label: 'convert to object schema' });
+  }
+
+  // ===== Visibility flags for type-specific sections =====
+  const showStringConstraints = $derived(selectedTypes.includes('string'));
+  const showNumberConstraints = $derived(
+    selectedTypes.includes('number') || selectedTypes.includes('integer'),
+  );
+  const showObjectConstraints = $derived(selectedTypes.includes('object'));
+  const showArrayConstraints = $derived(selectedTypes.includes('array'));
+
+  // ===== Recursion guard =====
+  const tooDeep = $derived(depth >= MAX_RENDER_DEPTH);
+  // Keep the root expanded; child nodes start collapsed at depth >= DEFAULT_COLLAPSE_DEPTH.
+  let userExpanded = $state(false);
+  const collapsedByDefault = $derived(depth >= DEFAULT_COLLAPSE_DEPTH);
+  const collapsed = $derived(collapsedByDefault && !userExpanded);
+
+  function summaryLine(): string {
+    if (typeof value === 'boolean')
+      return value ? 'true (allow anything)' : 'false (allow nothing)';
+    const parts: string[] = [];
+    if (objectValue.type !== undefined) {
+      parts.push(Array.isArray(objectValue.type) ? objectValue.type.join('|') : objectValue.type);
+    } else {
+      parts.push('any');
+    }
+    if (objectValue.properties) {
+      parts.push(`${Object.keys(objectValue.properties).length} props`);
+    }
+    if (objectValue.title) parts.push(`"${objectValue.title}"`);
+    return parts.join(' · ');
+  }
+
+  // ===== Children (object/array) =====
+  function patchProperties(properties: Record<string, JsonSchemaValue>, required: string[]) {
+    const edits: Partial<JsonSchemaObject> = { properties };
+    edits.required = required.length > 0 ? required : undefined;
+    patch(edits, { label: 'edit properties' });
+  }
+
+  function setItems(items: JsonSchemaValue) {
+    patch({ items }, { label: 'edit items' });
+  }
+
+  // ===== Composition =====
+  function patchComposition(
+    keyword: 'oneOf' | 'anyOf' | 'allOf' | 'not',
+    next: JsonSchemaValue[] | JsonSchemaValue | undefined,
+  ) {
+    patch({ [keyword]: next } as Partial<JsonSchemaObject>, {
+      label: `edit ${keyword}`,
+    });
+  }
+</script>
+
+<Surface
+  tone="raised"
+  class={classNames('cinder-jse-property-editor', className)}
+  data-depth={depth}
+>
+  {#if tooDeep}
+    <Alert variant="info">
+      Schema depth exceeded ({MAX_RENDER_DEPTH}). Edit deeper sections via the JSON view.
+    </Alert>
+  {:else if isBooleanSchema}
+    <div class="cinder-jse-boolean-schema">
+      <span>Boolean schema — {value ? 'allows anything' : 'allows nothing'}.</span>
+      <Button variant="secondary" size="sm" disabled={readonly} onclick={convertBooleanToObject}>
+        Convert to object schema
+      </Button>
+    </div>
+  {:else if collapsed}
+    <button type="button" class="cinder-jse-collapsed" onclick={() => (userExpanded = true)}>
+      <span class="cinder-jse-collapsed__summary">{summaryLine()}</span>
+      <span class="cinder-jse-collapsed__hint">Expand</span>
+    </button>
+  {:else}
+    {#if depth > 0 && collapsedByDefault}
+      <div class="cinder-jse-section-header">
+        <Button variant="ghost" size="sm" onclick={() => (userExpanded = false)}>Collapse</Button>
+      </div>
+    {/if}
+
+    <!-- Type section -->
+    <fieldset class="cinder-jse-section">
+      <legend class="cinder-jse-section__title">Type</legend>
+      <div class="cinder-jse-type-row">
+        <Checkbox
+          id={`${idPrefix}-type-any`}
+          checked={isAnyType}
+          label="Any"
+          disabled={readonly}
+          onchange={(event: Event) => setAny((event.target as HTMLInputElement).checked)}
+        />
+        {#each PRIMITIVE_TYPES as primitive (primitive)}
+          <Checkbox
+            id={`${idPrefix}-type-${primitive}`}
+            checked={selectedTypes.includes(primitive)}
+            label={primitive}
+            disabled={readonly || isAnyType}
+            onchange={(event: Event) =>
+              toggleType(primitive, (event.target as HTMLInputElement).checked)}
+          />
+        {/each}
+      </div>
+    </fieldset>
+
+    <!-- Common keywords -->
+    <fieldset class="cinder-jse-section">
+      <legend class="cinder-jse-section__title">Common</legend>
+      <Input
+        id={`${idPrefix}-title`}
+        label="Title"
+        value={objectValue.title ?? ''}
+        disabled={readonly}
+        oninput={(event: Event) =>
+          patch(
+            { title: (event.target as HTMLInputElement).value || undefined },
+            { coalesceKey: `title:${path}`, label: 'edit title' },
+          )}
+      />
+      <Input
+        id={`${idPrefix}-description`}
+        label="Description"
+        value={objectValue.description ?? ''}
+        disabled={readonly}
+        oninput={(event: Event) =>
+          patch(
+            { description: (event.target as HTMLInputElement).value || undefined },
+            { coalesceKey: `description:${path}`, label: 'edit description' },
+          )}
+      />
+    </fieldset>
+
+    <!-- String constraints -->
+    {#if showStringConstraints}
+      <fieldset class="cinder-jse-section">
+        <legend class="cinder-jse-section__title">String constraints</legend>
+        <Input
+          id={`${idPrefix}-minLength`}
+          label="Min length"
+          type="text"
+          value={objectValue.minLength?.toString() ?? ''}
+          disabled={readonly}
+          oninput={(event: Event) => {
+            const raw = (event.target as HTMLInputElement).value;
+            const parsed = raw === '' ? undefined : Number.parseInt(raw, 10);
+            patch(
+              { minLength: Number.isNaN(parsed) ? undefined : parsed },
+              { coalesceKey: `minLength:${path}`, label: 'edit minLength' },
+            );
+          }}
+        />
+        <Input
+          id={`${idPrefix}-maxLength`}
+          label="Max length"
+          type="text"
+          value={objectValue.maxLength?.toString() ?? ''}
+          disabled={readonly}
+          oninput={(event: Event) => {
+            const raw = (event.target as HTMLInputElement).value;
+            const parsed = raw === '' ? undefined : Number.parseInt(raw, 10);
+            patch(
+              { maxLength: Number.isNaN(parsed) ? undefined : parsed },
+              { coalesceKey: `maxLength:${path}`, label: 'edit maxLength' },
+            );
+          }}
+        />
+        <Input
+          id={`${idPrefix}-pattern`}
+          label="Pattern (regex)"
+          value={objectValue.pattern ?? ''}
+          disabled={readonly}
+          oninput={(event: Event) =>
+            patch(
+              { pattern: (event.target as HTMLInputElement).value || undefined },
+              { coalesceKey: `pattern:${path}`, label: 'edit pattern' },
+            )}
+        />
+        <Input
+          id={`${idPrefix}-format`}
+          label="Format"
+          value={objectValue.format ?? ''}
+          disabled={readonly}
+          oninput={(event: Event) =>
+            patch(
+              { format: (event.target as HTMLInputElement).value || undefined },
+              { coalesceKey: `format:${path}`, label: 'edit format' },
+            )}
+        />
+      </fieldset>
+    {/if}
+
+    <!-- Number constraints -->
+    {#if showNumberConstraints}
+      <fieldset class="cinder-jse-section">
+        <legend class="cinder-jse-section__title">Number constraints</legend>
+        <Input
+          id={`${idPrefix}-minimum`}
+          label="Minimum"
+          value={objectValue.minimum?.toString() ?? ''}
+          disabled={readonly}
+          oninput={(event: Event) => {
+            const raw = (event.target as HTMLInputElement).value;
+            const parsed = raw === '' ? undefined : Number(raw);
+            patch(
+              { minimum: parsed !== undefined && Number.isFinite(parsed) ? parsed : undefined },
+              { coalesceKey: `minimum:${path}`, label: 'edit minimum' },
+            );
+          }}
+        />
+        <Input
+          id={`${idPrefix}-maximum`}
+          label="Maximum"
+          value={objectValue.maximum?.toString() ?? ''}
+          disabled={readonly}
+          oninput={(event: Event) => {
+            const raw = (event.target as HTMLInputElement).value;
+            const parsed = raw === '' ? undefined : Number(raw);
+            patch(
+              { maximum: parsed !== undefined && Number.isFinite(parsed) ? parsed : undefined },
+              { coalesceKey: `maximum:${path}`, label: 'edit maximum' },
+            );
+          }}
+        />
+      </fieldset>
+    {/if}
+
+    <!-- Object constraints -->
+    {#if showObjectConstraints}
+      <fieldset class="cinder-jse-section">
+        <legend class="cinder-jse-section__title">Object constraints</legend>
+        <PropertyList
+          {idPrefix}
+          {readonly}
+          {depth}
+          path={`${path}/properties`}
+          properties={objectValue.properties ?? {}}
+          required={objectValue.required ?? []}
+          onchange={patchProperties}
+        />
+      </fieldset>
+    {/if}
+
+    <!-- Array constraints -->
+    {#if showArrayConstraints}
+      <fieldset class="cinder-jse-section">
+        <legend class="cinder-jse-section__title">Array items</legend>
+        <PropertyEditor
+          idPrefix={`${idPrefix}-items`}
+          path={`${path}/items`}
+          depth={depth + 1}
+          {readonly}
+          value={objectValue.items ?? {}}
+          onchange={(next) => setItems(next)}
+        />
+      </fieldset>
+    {/if}
+
+    <!-- Composition -->
+    {#each ['allOf', 'anyOf', 'oneOf'] as const as keyword (keyword)}
+      {#if Array.isArray(objectValue[keyword])}
+        <fieldset class="cinder-jse-section">
+          <legend class="cinder-jse-section__title">{keyword}</legend>
+          {#each objectValue[keyword] as branch, branchIndex (branchIndex)}
+            <PropertyEditor
+              idPrefix={`${idPrefix}-${keyword}-${branchIndex}`}
+              path={`${path}/${keyword}/${branchIndex}`}
+              depth={depth + 1}
+              {readonly}
+              value={branch}
+              onchange={(next) => {
+                const list = [...objectValue[keyword]!];
+                list[branchIndex] = next;
+                patchComposition(keyword, list);
+              }}
+            />
+            <Button
+              variant="ghost"
+              size="sm"
+              disabled={readonly}
+              onclick={() => {
+                const list = [...objectValue[keyword]!];
+                list.splice(branchIndex, 1);
+                patchComposition(keyword, list.length > 0 ? list : undefined);
+              }}
+            >
+              Remove
+            </Button>
+          {/each}
+          <Button
+            variant="secondary"
+            size="sm"
+            disabled={readonly}
+            onclick={() => {
+              const list = Array.isArray(objectValue[keyword]) ? [...objectValue[keyword]!] : [];
+              list.push({});
+              patchComposition(keyword, list);
+            }}
+          >
+            Add {keyword} branch
+          </Button>
+        </fieldset>
+      {/if}
+    {/each}
+
+    <!-- $ref -->
+    <fieldset class="cinder-jse-section">
+      <legend class="cinder-jse-section__title">$ref</legend>
+      <Input
+        id={`${idPrefix}-ref`}
+        label="$ref URI"
+        value={objectValue.$ref ?? ''}
+        disabled={readonly}
+        oninput={(event: Event) =>
+          patch(
+            { $ref: (event.target as HTMLInputElement).value || undefined },
+            { coalesceKey: `$ref:${path}`, label: 'edit $ref' },
+          )}
+      />
+    </fieldset>
+
+    <!-- Preserved keywords -->
+    {#if preservedKeys.length > 0}
+      <Tooltip text={`Preserved keys: ${preservedKeys.join(', ')}`}>
+        <Badge variant="info">+{preservedKeys.length} preserved</Badge>
+      </Tooltip>
+    {/if}
+  {/if}
+</Surface>

--- a/packages/components/src/components/json-schema-editor/property-editor.svelte
+++ b/packages/components/src/components/json-schema-editor/property-editor.svelte
@@ -251,46 +251,62 @@
     });
   }
 
-  let nextCompositionBranchKey = $state(1);
-  let compositionBranchKeys = $state<Record<'allOf' | 'anyOf' | 'oneOf', string[]>>({
-    allOf: [],
-    anyOf: [],
-    oneOf: [],
-  });
-
+  // Stable identity keys for composition branches. Plain counter (not $state) so
+  // generating a new key never writes reactive state.
+  let nextCompositionBranchKey = 1;
   function createCompositionBranchKey(): string {
-    const key = `branch-${nextCompositionBranchKey}`;
-    nextCompositionBranchKey += 1;
-    return key;
+    return `branch-${nextCompositionBranchKey++}`;
   }
 
-  function keysForComposition(
-    keyword: 'allOf' | 'anyOf' | 'oneOf',
-    branches: JsonSchemaValue[],
-  ): string[] {
-    const reconciled = reconcileCompositionBranchKeys(
-      compositionBranchKeys[keyword],
-      branches.length,
-      createCompositionBranchKey,
-    );
-    compositionBranchKeys[keyword] = reconciled;
-    return reconciled;
+  // Per-keyword key arrays as separate $state values so the template reacts to
+  // add/remove operations. $effect.pre reconciles them before the DOM updates.
+  // Writing only when the count actually changed avoids an infinite loop.
+  let allOfKeys = $state<string[]>([]);
+  let anyOfKeys = $state<string[]>([]);
+  let oneOfKeys = $state<string[]>([]);
+
+  $effect.pre(() => {
+    const allOfCount = objectValue.allOf?.length ?? 0;
+    if (allOfKeys.length !== allOfCount) {
+      allOfKeys = reconcileCompositionBranchKeys(allOfKeys, allOfCount, createCompositionBranchKey);
+    }
+  });
+  $effect.pre(() => {
+    const anyOfCount = objectValue.anyOf?.length ?? 0;
+    if (anyOfKeys.length !== anyOfCount) {
+      anyOfKeys = reconcileCompositionBranchKeys(anyOfKeys, anyOfCount, createCompositionBranchKey);
+    }
+  });
+  $effect.pre(() => {
+    const oneOfCount = objectValue.oneOf?.length ?? 0;
+    if (oneOfKeys.length !== oneOfCount) {
+      oneOfKeys = reconcileCompositionBranchKeys(oneOfKeys, oneOfCount, createCompositionBranchKey);
+    }
+  });
+
+  const compositionBranchKeys = $derived({
+    allOf: allOfKeys,
+    anyOf: anyOfKeys,
+    oneOf: oneOfKeys,
+  });
+
+  function setKeywordKeys(keyword: 'allOf' | 'anyOf' | 'oneOf', keys: string[]) {
+    if (keyword === 'allOf') allOfKeys = keys;
+    else if (keyword === 'anyOf') anyOfKeys = keys;
+    else oneOfKeys = keys;
   }
 
   function removeCompositionBranch(keyword: 'allOf' | 'anyOf' | 'oneOf', branchIndex: number) {
     const list = Array.isArray(objectValue[keyword]) ? [...objectValue[keyword]!] : [];
     list.splice(branchIndex, 1);
-    compositionBranchKeys[keyword] = compositionBranchKeys[keyword].toSpliced(branchIndex, 1);
+    setKeywordKeys(keyword, compositionBranchKeys[keyword].toSpliced(branchIndex, 1));
     patchComposition(keyword, list.length > 0 ? list : undefined);
   }
 
   function addCompositionBranch(keyword: 'allOf' | 'anyOf' | 'oneOf') {
     const list = Array.isArray(objectValue[keyword]) ? [...objectValue[keyword]!] : [];
     list.push({});
-    compositionBranchKeys[keyword] = [
-      ...compositionBranchKeys[keyword],
-      createCompositionBranchKey(),
-    ];
+    setKeywordKeys(keyword, [...compositionBranchKeys[keyword], createCompositionBranchKey()]);
     patchComposition(keyword, list);
   }
 </script>
@@ -483,11 +499,10 @@
     <!-- Composition (only when present) -->
     {#each ['allOf', 'anyOf', 'oneOf'] as const as keyword (keyword)}
       {#if Array.isArray(objectValue[keyword])}
-        {@const branchKeys = keysForComposition(keyword, objectValue[keyword])}
         <details class="cinder-jse-section cinder-jse-section--collapsible" open>
           <summary class="cinder-jse-section__title">{keyword}</summary>
           <div class="cinder-jse-section__body">
-            {#each objectValue[keyword] as branch, branchIndex (branchKeys[branchIndex])}
+            {#each objectValue[keyword] as branch, branchIndex (compositionBranchKeys[keyword][branchIndex])}
               <PropertyEditor
                 idPrefix={`${idPrefix}-${keyword}-${branchIndex}`}
                 path={`${path}/${keyword}/${branchIndex}`}

--- a/packages/components/src/components/json-schema-editor/property-editor.svelte
+++ b/packages/components/src/components/json-schema-editor/property-editor.svelte
@@ -173,7 +173,13 @@
   }
 
   function setAny(any: boolean) {
-    if (any) setTypeFromCheckboxes([]);
+    if (any) {
+      setTypeFromCheckboxes([]);
+    } else {
+      // Unchecking "Any" with no specific type selected would leave the schema
+      // typeless again — default to 'object' so the user has something to work with.
+      if (selectedTypes.length === 0) setTypeFromCheckboxes(['object']);
+    }
   }
 
   function convertBooleanToObject() {
@@ -377,7 +383,7 @@
             id={`${idPrefix}-type-${primitive}`}
             checked={selectedTypes.includes(primitive)}
             label={primitive}
-            disabled={readonly || isAnyType}
+            disabled={readonly}
             onchange={(event: Event) =>
               toggleType(primitive, (event.target as HTMLInputElement).checked)}
           />

--- a/packages/components/src/components/json-schema-editor/property-editor.svelte
+++ b/packages/components/src/components/json-schema-editor/property-editor.svelte
@@ -74,7 +74,6 @@
   import Button from '../button.svelte';
   import Checkbox from '../checkbox.svelte';
   import Input from '../input.svelte';
-  import Surface from '../surface.svelte';
   import Tooltip from '../tooltip.svelte';
 
   import type { JsonSchemaObject } from './json-schema-editor-types.ts';
@@ -219,11 +218,7 @@
   }
 </script>
 
-<Surface
-  tone="raised"
-  class={classNames('cinder-jse-property-editor', className)}
-  data-depth={depth}
->
+<div class={classNames('cinder-jse-property-editor', className)} data-cinder-jse-depth={depth}>
   {#if tooDeep}
     <Alert variant="info">
       Schema depth exceeded ({MAX_RENDER_DEPTH}). Edit deeper sections via the JSON view.
@@ -247,33 +242,8 @@
       </div>
     {/if}
 
-    <!-- Type section -->
-    <fieldset class="cinder-jse-section">
-      <legend class="cinder-jse-section__title">Type</legend>
-      <div class="cinder-jse-type-row">
-        <Checkbox
-          id={`${idPrefix}-type-any`}
-          checked={isAnyType}
-          label="Any"
-          disabled={readonly}
-          onchange={(event: Event) => setAny((event.target as HTMLInputElement).checked)}
-        />
-        {#each PRIMITIVE_TYPES as primitive (primitive)}
-          <Checkbox
-            id={`${idPrefix}-type-${primitive}`}
-            checked={selectedTypes.includes(primitive)}
-            label={primitive}
-            disabled={readonly || isAnyType}
-            onchange={(event: Event) =>
-              toggleType(primitive, (event.target as HTMLInputElement).checked)}
-          />
-        {/each}
-      </div>
-    </fieldset>
-
-    <!-- Common keywords -->
-    <fieldset class="cinder-jse-section">
-      <legend class="cinder-jse-section__title">Common</legend>
+    <!-- Common (Title + Description) leads at the top of every node — no section header. -->
+    <div class="cinder-jse-section cinder-jse-section--lead">
       <Input
         id={`${idPrefix}-title`}
         label="Title"
@@ -296,106 +266,36 @@
             { coalesceKey: `description:${path}`, label: 'edit description' },
           )}
       />
-    </fieldset>
+    </div>
 
-    <!-- String constraints -->
-    {#if showStringConstraints}
-      <fieldset class="cinder-jse-section">
-        <legend class="cinder-jse-section__title">String constraints</legend>
-        <Input
-          id={`${idPrefix}-minLength`}
-          label="Min length"
-          type="text"
-          value={objectValue.minLength?.toString() ?? ''}
+    <!-- Type section -->
+    <div class="cinder-jse-section">
+      <h4 class="cinder-jse-section__title">Type</h4>
+      <div class="cinder-jse-type-row">
+        <Checkbox
+          id={`${idPrefix}-type-any`}
+          checked={isAnyType}
+          label="Any"
           disabled={readonly}
-          oninput={(event: Event) => {
-            const raw = (event.target as HTMLInputElement).value;
-            const parsed = raw === '' ? undefined : Number.parseInt(raw, 10);
-            patch(
-              { minLength: Number.isNaN(parsed) ? undefined : parsed },
-              { coalesceKey: `minLength:${path}`, label: 'edit minLength' },
-            );
-          }}
+          onchange={(event: Event) => setAny((event.target as HTMLInputElement).checked)}
         />
-        <Input
-          id={`${idPrefix}-maxLength`}
-          label="Max length"
-          type="text"
-          value={objectValue.maxLength?.toString() ?? ''}
-          disabled={readonly}
-          oninput={(event: Event) => {
-            const raw = (event.target as HTMLInputElement).value;
-            const parsed = raw === '' ? undefined : Number.parseInt(raw, 10);
-            patch(
-              { maxLength: Number.isNaN(parsed) ? undefined : parsed },
-              { coalesceKey: `maxLength:${path}`, label: 'edit maxLength' },
-            );
-          }}
-        />
-        <Input
-          id={`${idPrefix}-pattern`}
-          label="Pattern (regex)"
-          value={objectValue.pattern ?? ''}
-          disabled={readonly}
-          oninput={(event: Event) =>
-            patch(
-              { pattern: (event.target as HTMLInputElement).value || undefined },
-              { coalesceKey: `pattern:${path}`, label: 'edit pattern' },
-            )}
-        />
-        <Input
-          id={`${idPrefix}-format`}
-          label="Format"
-          value={objectValue.format ?? ''}
-          disabled={readonly}
-          oninput={(event: Event) =>
-            patch(
-              { format: (event.target as HTMLInputElement).value || undefined },
-              { coalesceKey: `format:${path}`, label: 'edit format' },
-            )}
-        />
-      </fieldset>
-    {/if}
+        {#each PRIMITIVE_TYPES as primitive (primitive)}
+          <Checkbox
+            id={`${idPrefix}-type-${primitive}`}
+            checked={selectedTypes.includes(primitive)}
+            label={primitive}
+            disabled={readonly || isAnyType}
+            onchange={(event: Event) =>
+              toggleType(primitive, (event.target as HTMLInputElement).checked)}
+          />
+        {/each}
+      </div>
+    </div>
 
-    <!-- Number constraints -->
-    {#if showNumberConstraints}
-      <fieldset class="cinder-jse-section">
-        <legend class="cinder-jse-section__title">Number constraints</legend>
-        <Input
-          id={`${idPrefix}-minimum`}
-          label="Minimum"
-          value={objectValue.minimum?.toString() ?? ''}
-          disabled={readonly}
-          oninput={(event: Event) => {
-            const raw = (event.target as HTMLInputElement).value;
-            const parsed = raw === '' ? undefined : Number(raw);
-            patch(
-              { minimum: parsed !== undefined && Number.isFinite(parsed) ? parsed : undefined },
-              { coalesceKey: `minimum:${path}`, label: 'edit minimum' },
-            );
-          }}
-        />
-        <Input
-          id={`${idPrefix}-maximum`}
-          label="Maximum"
-          value={objectValue.maximum?.toString() ?? ''}
-          disabled={readonly}
-          oninput={(event: Event) => {
-            const raw = (event.target as HTMLInputElement).value;
-            const parsed = raw === '' ? undefined : Number(raw);
-            patch(
-              { maximum: parsed !== undefined && Number.isFinite(parsed) ? parsed : undefined },
-              { coalesceKey: `maximum:${path}`, label: 'edit maximum' },
-            );
-          }}
-        />
-      </fieldset>
-    {/if}
-
-    <!-- Object constraints -->
+    <!-- Object constraints (properties + required) — comes early because it's the heaviest. -->
     {#if showObjectConstraints}
-      <fieldset class="cinder-jse-section">
-        <legend class="cinder-jse-section__title">Object constraints</legend>
+      <div class="cinder-jse-section">
+        <h4 class="cinder-jse-section__title">Properties</h4>
         <PropertyList
           {idPrefix}
           {readonly}
@@ -405,13 +305,13 @@
           required={objectValue.required ?? []}
           onchange={patchProperties}
         />
-      </fieldset>
+      </div>
     {/if}
 
-    <!-- Array constraints -->
+    <!-- Array items -->
     {#if showArrayConstraints}
-      <fieldset class="cinder-jse-section">
-        <legend class="cinder-jse-section__title">Array items</legend>
+      <div class="cinder-jse-section">
+        <h4 class="cinder-jse-section__title">Array items</h4>
         <PropertyEditor
           idPrefix={`${idPrefix}-items`}
           path={`${path}/items`}
@@ -420,77 +320,202 @@
           value={objectValue.items ?? {}}
           onchange={(next) => setItems(next)}
         />
-      </fieldset>
+      </div>
     {/if}
 
-    <!-- Composition -->
+    <!-- String constraints — collapsed by default. -->
+    {#if showStringConstraints}
+      <details class="cinder-jse-section cinder-jse-section--collapsible">
+        <summary class="cinder-jse-section__title">String constraints</summary>
+        <div class="cinder-jse-section__body">
+          <Input
+            id={`${idPrefix}-minLength`}
+            label="Min length"
+            type="text"
+            value={objectValue.minLength?.toString() ?? ''}
+            disabled={readonly}
+            oninput={(event: Event) => {
+              const raw = (event.target as HTMLInputElement).value;
+              const parsed = raw === '' ? undefined : Number.parseInt(raw, 10);
+              patch(
+                { minLength: Number.isNaN(parsed) ? undefined : parsed },
+                { coalesceKey: `minLength:${path}`, label: 'edit minLength' },
+              );
+            }}
+          />
+          <Input
+            id={`${idPrefix}-maxLength`}
+            label="Max length"
+            type="text"
+            value={objectValue.maxLength?.toString() ?? ''}
+            disabled={readonly}
+            oninput={(event: Event) => {
+              const raw = (event.target as HTMLInputElement).value;
+              const parsed = raw === '' ? undefined : Number.parseInt(raw, 10);
+              patch(
+                { maxLength: Number.isNaN(parsed) ? undefined : parsed },
+                { coalesceKey: `maxLength:${path}`, label: 'edit maxLength' },
+              );
+            }}
+          />
+          <Input
+            id={`${idPrefix}-pattern`}
+            label="Pattern (regex)"
+            value={objectValue.pattern ?? ''}
+            disabled={readonly}
+            oninput={(event: Event) =>
+              patch(
+                { pattern: (event.target as HTMLInputElement).value || undefined },
+                { coalesceKey: `pattern:${path}`, label: 'edit pattern' },
+              )}
+          />
+          <Input
+            id={`${idPrefix}-format`}
+            label="Format"
+            value={objectValue.format ?? ''}
+            disabled={readonly}
+            oninput={(event: Event) =>
+              patch(
+                { format: (event.target as HTMLInputElement).value || undefined },
+                { coalesceKey: `format:${path}`, label: 'edit format' },
+              )}
+          />
+        </div>
+      </details>
+    {/if}
+
+    <!-- Number constraints — collapsed by default. -->
+    {#if showNumberConstraints}
+      <details class="cinder-jse-section cinder-jse-section--collapsible">
+        <summary class="cinder-jse-section__title">Number constraints</summary>
+        <div class="cinder-jse-section__body">
+          <Input
+            id={`${idPrefix}-minimum`}
+            label="Minimum"
+            value={objectValue.minimum?.toString() ?? ''}
+            disabled={readonly}
+            oninput={(event: Event) => {
+              const raw = (event.target as HTMLInputElement).value;
+              const parsed = raw === '' ? undefined : Number(raw);
+              patch(
+                { minimum: parsed !== undefined && Number.isFinite(parsed) ? parsed : undefined },
+                { coalesceKey: `minimum:${path}`, label: 'edit minimum' },
+              );
+            }}
+          />
+          <Input
+            id={`${idPrefix}-maximum`}
+            label="Maximum"
+            value={objectValue.maximum?.toString() ?? ''}
+            disabled={readonly}
+            oninput={(event: Event) => {
+              const raw = (event.target as HTMLInputElement).value;
+              const parsed = raw === '' ? undefined : Number(raw);
+              patch(
+                { maximum: parsed !== undefined && Number.isFinite(parsed) ? parsed : undefined },
+                { coalesceKey: `maximum:${path}`, label: 'edit maximum' },
+              );
+            }}
+          />
+        </div>
+      </details>
+    {/if}
+
+    <!-- Composition (only when present) -->
     {#each ['allOf', 'anyOf', 'oneOf'] as const as keyword (keyword)}
       {#if Array.isArray(objectValue[keyword])}
-        <fieldset class="cinder-jse-section">
-          <legend class="cinder-jse-section__title">{keyword}</legend>
-          {#each objectValue[keyword] as branch, branchIndex (branchIndex)}
-            <PropertyEditor
-              idPrefix={`${idPrefix}-${keyword}-${branchIndex}`}
-              path={`${path}/${keyword}/${branchIndex}`}
-              depth={depth + 1}
-              {readonly}
-              value={branch}
-              onchange={(next) => {
-                const list = [...objectValue[keyword]!];
-                list[branchIndex] = next;
-                patchComposition(keyword, list);
-              }}
-            />
+        <details class="cinder-jse-section cinder-jse-section--collapsible" open>
+          <summary class="cinder-jse-section__title">{keyword}</summary>
+          <div class="cinder-jse-section__body">
+            {#each objectValue[keyword] as branch, branchIndex (branchIndex)}
+              <PropertyEditor
+                idPrefix={`${idPrefix}-${keyword}-${branchIndex}`}
+                path={`${path}/${keyword}/${branchIndex}`}
+                depth={depth + 1}
+                {readonly}
+                value={branch}
+                onchange={(next) => {
+                  const list = [...objectValue[keyword]!];
+                  list[branchIndex] = next;
+                  patchComposition(keyword, list);
+                }}
+              />
+              <Button
+                variant="ghost"
+                size="xs"
+                disabled={readonly}
+                onclick={() => {
+                  const list = [...objectValue[keyword]!];
+                  list.splice(branchIndex, 1);
+                  patchComposition(keyword, list.length > 0 ? list : undefined);
+                }}
+              >
+                Remove branch
+              </Button>
+            {/each}
             <Button
-              variant="ghost"
+              variant="secondary"
               size="sm"
               disabled={readonly}
               onclick={() => {
-                const list = [...objectValue[keyword]!];
-                list.splice(branchIndex, 1);
-                patchComposition(keyword, list.length > 0 ? list : undefined);
+                const list = Array.isArray(objectValue[keyword]) ? [...objectValue[keyword]!] : [];
+                list.push({});
+                patchComposition(keyword, list);
               }}
             >
-              Remove
+              Add {keyword} branch
             </Button>
-          {/each}
-          <Button
-            variant="secondary"
-            size="sm"
-            disabled={readonly}
-            onclick={() => {
-              const list = Array.isArray(objectValue[keyword]) ? [...objectValue[keyword]!] : [];
-              list.push({});
-              patchComposition(keyword, list);
-            }}
-          >
-            Add {keyword} branch
-          </Button>
-        </fieldset>
+          </div>
+        </details>
       {/if}
     {/each}
 
-    <!-- $ref -->
-    <fieldset class="cinder-jse-section">
-      <legend class="cinder-jse-section__title">$ref</legend>
-      <Input
-        id={`${idPrefix}-ref`}
-        label="$ref URI"
-        value={objectValue.$ref ?? ''}
-        disabled={readonly}
-        oninput={(event: Event) =>
-          patch(
-            { $ref: (event.target as HTMLInputElement).value || undefined },
-            { coalesceKey: `$ref:${path}`, label: 'edit $ref' },
-          )}
-      />
-    </fieldset>
+    <!-- $ref — visible only when set; otherwise an inline trigger to add one. -->
+    {#if objectValue.$ref !== undefined}
+      <div class="cinder-jse-section">
+        <h4 class="cinder-jse-section__title">$ref</h4>
+        <Input
+          id={`${idPrefix}-ref`}
+          label="$ref URI"
+          value={objectValue.$ref}
+          disabled={readonly}
+          oninput={(event: Event) =>
+            patch(
+              { $ref: (event.target as HTMLInputElement).value || undefined },
+              { coalesceKey: `$ref:${path}`, label: 'edit $ref' },
+            )}
+        />
+        <Button
+          variant="ghost"
+          size="xs"
+          disabled={readonly}
+          onclick={() => patch({ $ref: undefined }, { label: 'remove $ref' })}
+        >
+          Remove $ref
+        </Button>
+      </div>
+    {:else if !readonly}
+      <div class="cinder-jse-advanced-row">
+        <Button
+          variant="ghost"
+          size="xs"
+          onclick={() => patch({ $ref: '' }, { label: 'add $ref' })}
+        >
+          Add $ref
+        </Button>
+        {#if preservedKeys.length > 0}
+          <Tooltip text={`Preserved keys: ${preservedKeys.join(', ')}`}>
+            <Badge variant="info">+{preservedKeys.length} preserved</Badge>
+          </Tooltip>
+        {/if}
+      </div>
+    {/if}
 
-    <!-- Preserved keywords -->
-    {#if preservedKeys.length > 0}
+    <!-- Preserved-keywords badge for the readonly case (Add $ref is hidden). -->
+    {#if readonly && objectValue.$ref === undefined && preservedKeys.length > 0}
       <Tooltip text={`Preserved keys: ${preservedKeys.join(', ')}`}>
         <Badge variant="info">+{preservedKeys.length} preserved</Badge>
       </Tooltip>
     {/if}
   {/if}
-</Surface>
+</div>

--- a/packages/components/src/components/json-schema-editor/property-list.svelte
+++ b/packages/components/src/components/json-schema-editor/property-list.svelte
@@ -258,7 +258,7 @@
     Add property
   </Button>
 
-  {#if requiredOnly.length > 0 || newRequiredOnlyName.length > 0}
+  {#if !readonly || requiredOnly.length > 0}
     <details class="cinder-jse-required-only" open={requiredOnly.length > 0}>
       <summary class="cinder-jse-required-only__summary">
         Required without property schema ({requiredOnly.length})
@@ -292,6 +292,9 @@
             }
           }}
         />
+        <Button variant="secondary" size="sm" disabled={readonly} onclick={addRequiredOnly}>
+          Add required name
+        </Button>
       </div>
     </details>
   {/if}

--- a/packages/components/src/components/json-schema-editor/property-list.svelte
+++ b/packages/components/src/components/json-schema-editor/property-list.svelte
@@ -171,21 +171,26 @@
   {#each propertyNames as key (key)}
     {@const isRequired = required.includes(key)}
     {@const isOpen = expanded[key] === true}
-    <details
-      class="cinder-jse-property-row"
-      data-cinder-required={isRequired ? '' : undefined}
-      open={isOpen}
-      ontoggle={(event: Event) => {
-        expanded[key] = (event.target as HTMLDetailsElement).open;
-      }}
-    >
-      <summary class="cinder-jse-property-row__summary">
-        <span class="cinder-jse-property-row__chevron" aria-hidden="true">▸</span>
-        <span class="cinder-jse-property-row__name">{key}</span>
-        <span class="cinder-jse-property-row__type">{summariseType(properties[key] ?? {})}</span>
-        {#if isRequired}
-          <span class="cinder-jse-property-row__required-marker">required</span>
-        {/if}
+    {@const panelId = `${idPrefix}-${key}-panel`}
+    <!--
+      Custom disclosure (not <details>/<summary>) so the action buttons can
+      live as siblings of the trigger rather than nested inside it.
+      <button> inside <summary> creates an ARIA "interactive within
+      interactive" violation.
+    -->
+    <div class="cinder-jse-property-row" data-cinder-required={isRequired ? '' : undefined}>
+      <div class="cinder-jse-property-row__summary">
+        <button
+          type="button"
+          class="cinder-jse-property-row__trigger"
+          aria-expanded={isOpen}
+          aria-controls={panelId}
+          onclick={() => (expanded[key] = !isOpen)}
+        >
+          <span class="cinder-jse-property-row__chevron" aria-hidden="true">▸</span>
+          <span class="cinder-jse-property-row__name">{key}</span>
+          <span class="cinder-jse-property-row__type">{summariseType(properties[key] ?? {})}</span>
+        </button>
         <span class="cinder-jse-property-row__spacer"></span>
         <Button
           variant={isRequired ? 'primary' : 'ghost'}
@@ -193,11 +198,7 @@
           disabled={readonly}
           aria-pressed={isRequired}
           aria-label={isRequired ? 'Required (toggle off)' : 'Optional (toggle required)'}
-          onclick={(event: MouseEvent) => {
-            event.preventDefault();
-            event.stopPropagation();
-            toggleRequired(key);
-          }}
+          onclick={() => toggleRequired(key)}
         >
           {isRequired ? 'Required' : 'Optional'}
         </Button>
@@ -206,11 +207,7 @@
           size="xs"
           disabled={readonly}
           aria-label="Move up"
-          onclick={(event: MouseEvent) => {
-            event.preventDefault();
-            event.stopPropagation();
-            moveProperty(key, -1);
-          }}
+          onclick={() => moveProperty(key, -1)}
         >
           ↑
         </Button>
@@ -219,11 +216,7 @@
           size="xs"
           disabled={readonly}
           aria-label="Move down"
-          onclick={(event: MouseEvent) => {
-            event.preventDefault();
-            event.stopPropagation();
-            moveProperty(key, 1);
-          }}
+          onclick={() => moveProperty(key, 1)}
         >
           ↓
         </Button>
@@ -232,35 +225,33 @@
           size="xs"
           disabled={readonly}
           aria-label={`Delete ${key}`}
-          onclick={(event: MouseEvent) => {
-            event.preventDefault();
-            event.stopPropagation();
-            deleteProperty(key);
-          }}
+          onclick={() => deleteProperty(key)}
         >
           Delete
         </Button>
-      </summary>
-
-      <div class="cinder-jse-property-row__panel">
-        <Input
-          id={`${idPrefix}-${key}-name`}
-          label="Name"
-          value={getDraftName(key)}
-          disabled={readonly}
-          oninput={(event: Event) => (draftNames[key] = (event.target as HTMLInputElement).value)}
-          onblur={() => commitRename(key)}
-        />
-        <PropertyEditor
-          idPrefix={`${idPrefix}-${key}-schema`}
-          path={`${path}/${key}`}
-          depth={depth + 1}
-          {readonly}
-          value={properties[key] ?? {}}
-          onchange={(next) => setPropertySchema(key, next)}
-        />
       </div>
-    </details>
+
+      {#if isOpen}
+        <div id={panelId} class="cinder-jse-property-row__panel">
+          <Input
+            id={`${idPrefix}-${key}-name`}
+            label="Name"
+            value={getDraftName(key)}
+            disabled={readonly}
+            oninput={(event: Event) => (draftNames[key] = (event.target as HTMLInputElement).value)}
+            onblur={() => commitRename(key)}
+          />
+          <PropertyEditor
+            idPrefix={`${idPrefix}-${key}-schema`}
+            path={`${path}/${key}`}
+            depth={depth + 1}
+            {readonly}
+            value={properties[key] ?? {}}
+            onchange={(next) => setPropertySchema(key, next)}
+          />
+        </div>
+      {/if}
+    </div>
   {/each}
 
   <Button variant="secondary" size="sm" disabled={readonly} onclick={addProperty}>

--- a/packages/components/src/components/json-schema-editor/property-list.svelte
+++ b/packages/components/src/components/json-schema-editor/property-list.svelte
@@ -1,0 +1,228 @@
+<script lang="ts" module>
+  import type { JsonSchemaValue } from './json-schema-editor-types.ts';
+
+  export type PropertyListProps = {
+    idPrefix: string;
+    properties: Record<string, JsonSchemaValue>;
+    required: string[];
+    path: string;
+    depth?: number;
+    readonly?: boolean;
+    onchange: (properties: Record<string, JsonSchemaValue>, required: string[]) => void;
+  };
+</script>
+
+<script lang="ts">
+  import Alert from '../alert.svelte';
+  import Button from '../button.svelte';
+  import Checkbox from '../checkbox.svelte';
+  import Input from '../input.svelte';
+  import PropertyEditor from './property-editor.svelte';
+
+  let {
+    idPrefix,
+    properties,
+    required,
+    path,
+    depth = 0,
+    readonly = false,
+    onchange,
+  }: PropertyListProps = $props();
+
+  // Required-only names (in `required` but not in `properties`) round-trip via
+  // a separate advanced section. Editing this section never invents a
+  // `properties` entry.
+  const propertyNames = $derived(Object.keys(properties));
+  const requiredOnly = $derived(required.filter((name) => !propertyNames.includes(name)));
+
+  // Per-row draft names (separate from committed key) so a partial typed name
+  // doesn't reshape the parent on every keystroke.
+  let draftNames = $state<Record<string, string>>({});
+  let renameError = $state<string | null>(null);
+
+  function getDraftName(key: string): string {
+    return draftNames[key] ?? key;
+  }
+
+  function uniqueNewKey(): string {
+    let suffix = 1;
+    let candidate = 'newField';
+    while (Object.prototype.hasOwnProperty.call(properties, candidate)) {
+      suffix += 1;
+      candidate = `newField${suffix}`;
+    }
+    return candidate;
+  }
+
+  function commitRename(oldKey: string) {
+    if (readonly) return;
+    const draft = getDraftName(oldKey).trim();
+    if (!draft) {
+      renameError = 'Property name cannot be empty';
+      return;
+    }
+    if (draft === oldKey) {
+      renameError = null;
+      return;
+    }
+    if (Object.prototype.hasOwnProperty.call(properties, draft)) {
+      renameError = `Duplicate property name: ${draft}`;
+      return;
+    }
+    renameError = null;
+
+    // Atomically rebuild properties preserving order and update `required`.
+    const next: Record<string, JsonSchemaValue> = {};
+    for (const k of propertyNames) {
+      next[k === oldKey ? draft : k] = properties[k]!;
+    }
+    const nextRequired = required.map((name) => (name === oldKey ? draft : name));
+
+    delete draftNames[oldKey];
+    onchange(next, nextRequired);
+  }
+
+  function deleteProperty(key: string) {
+    if (readonly) return;
+    const next = { ...properties };
+    delete next[key];
+    const nextRequired = required.filter((name) => name !== key);
+    delete draftNames[key];
+    onchange(next, nextRequired);
+  }
+
+  function moveProperty(key: string, direction: -1 | 1) {
+    if (readonly) return;
+    const index = propertyNames.indexOf(key);
+    const target = index + direction;
+    if (target < 0 || target >= propertyNames.length) return;
+
+    const reordered = [...propertyNames];
+    [reordered[index], reordered[target]] = [reordered[target]!, reordered[index]!];
+    const next: Record<string, JsonSchemaValue> = {};
+    for (const name of reordered) next[name] = properties[name]!;
+    onchange(next, required);
+  }
+
+  function toggleRequired(key: string, isRequired: boolean) {
+    if (readonly) return;
+    const set = new Set(required);
+    if (isRequired) set.add(key);
+    else set.delete(key);
+    onchange(properties, [...set]);
+  }
+
+  function setPropertySchema(key: string, schema: JsonSchemaValue) {
+    if (readonly) return;
+    onchange({ ...properties, [key]: schema }, required);
+  }
+
+  function addProperty() {
+    if (readonly) return;
+    const key = uniqueNewKey();
+    onchange({ ...properties, [key]: { type: 'string' } }, required);
+  }
+
+  // ===== Required-only chip editing =====
+  let newRequiredOnlyName = $state('');
+
+  function addRequiredOnly() {
+    if (readonly) return;
+    const name = newRequiredOnlyName.trim();
+    if (!name) return;
+    if (required.includes(name)) {
+      newRequiredOnlyName = '';
+      return;
+    }
+    onchange(properties, [...required, name]);
+    newRequiredOnlyName = '';
+  }
+
+  function removeRequiredOnly(name: string) {
+    if (readonly) return;
+    onchange(
+      properties,
+      required.filter((entry) => entry !== name),
+    );
+  }
+</script>
+
+<div class="cinder-jse-property-list">
+  {#if renameError}
+    <Alert variant="error">{renameError}</Alert>
+  {/if}
+
+  {#each propertyNames as key (key)}
+    <div class="cinder-jse-property-row">
+      <Input
+        id={`${idPrefix}-${key}-name`}
+        label="Name"
+        value={getDraftName(key)}
+        disabled={readonly}
+        oninput={(event: Event) => (draftNames[key] = (event.target as HTMLInputElement).value)}
+        onblur={() => commitRename(key)}
+      />
+      <Checkbox
+        id={`${idPrefix}-${key}-required`}
+        label="Required"
+        checked={required.includes(key)}
+        disabled={readonly}
+        onchange={(event: Event) => toggleRequired(key, (event.target as HTMLInputElement).checked)}
+      />
+      <Button variant="ghost" size="sm" disabled={readonly} onclick={() => moveProperty(key, -1)}>
+        ↑
+      </Button>
+      <Button variant="ghost" size="sm" disabled={readonly} onclick={() => moveProperty(key, 1)}>
+        ↓
+      </Button>
+      <Button variant="danger" size="sm" disabled={readonly} onclick={() => deleteProperty(key)}>
+        Delete
+      </Button>
+
+      <PropertyEditor
+        idPrefix={`${idPrefix}-${key}-schema`}
+        path={`${path}/${key}`}
+        depth={depth + 1}
+        {readonly}
+        value={properties[key] ?? {}}
+        onchange={(next) => setPropertySchema(key, next)}
+      />
+    </div>
+  {/each}
+
+  <Button variant="secondary" size="sm" disabled={readonly} onclick={addProperty}>
+    Add property
+  </Button>
+
+  {#if requiredOnly.length > 0 || newRequiredOnlyName.length > 0}
+    <div class="cinder-jse-required-only">
+      <h4 class="cinder-jse-required-only__title">Required without property schema</h4>
+      {#each requiredOnly as name (name)}
+        <span class="cinder-jse-required-only__chip">
+          {name}
+          <Button
+            variant="ghost"
+            size="sm"
+            disabled={readonly}
+            onclick={() => removeRequiredOnly(name)}
+          >
+            ×
+          </Button>
+        </span>
+      {/each}
+      <Input
+        id={`${idPrefix}-required-only-add`}
+        label="Add required name"
+        value={newRequiredOnlyName}
+        disabled={readonly}
+        oninput={(event: Event) => (newRequiredOnlyName = (event.target as HTMLInputElement).value)}
+        onkeydown={(event: KeyboardEvent) => {
+          if (event.key === 'Enter') {
+            event.preventDefault();
+            addRequiredOnly();
+          }
+        }}
+      />
+    </div>
+  {/if}
+</div>

--- a/packages/components/src/components/json-schema-editor/property-list.svelte
+++ b/packages/components/src/components/json-schema-editor/property-list.svelte
@@ -15,7 +15,6 @@
 <script lang="ts">
   import Alert from '../alert.svelte';
   import Button from '../button.svelte';
-  import Checkbox from '../checkbox.svelte';
   import Input from '../input.svelte';
   import PropertyEditor from './property-editor.svelte';
 
@@ -29,16 +28,13 @@
     onchange,
   }: PropertyListProps = $props();
 
-  // Required-only names (in `required` but not in `properties`) round-trip via
-  // a separate advanced section. Editing this section never invents a
-  // `properties` entry.
   const propertyNames = $derived(Object.keys(properties));
   const requiredOnly = $derived(required.filter((name) => !propertyNames.includes(name)));
 
-  // Per-row draft names (separate from committed key) so a partial typed name
-  // doesn't reshape the parent on every keystroke.
+  // Per-row draft names so a partial typed name doesn't reshape the parent.
   let draftNames = $state<Record<string, string>>({});
   let renameError = $state<string | null>(null);
+  let expanded = $state<Record<string, boolean>>({});
 
   function getDraftName(key: string): string {
     return draftNames[key] ?? key;
@@ -71,7 +67,6 @@
     }
     renameError = null;
 
-    // Atomically rebuild properties preserving order and update `required`.
     const next: Record<string, JsonSchemaValue> = {};
     for (const k of propertyNames) {
       next[k === oldKey ? draft : k] = properties[k]!;
@@ -79,6 +74,10 @@
     const nextRequired = required.map((name) => (name === oldKey ? draft : name));
 
     delete draftNames[oldKey];
+    if (expanded[oldKey]) {
+      expanded[draft] = true;
+      delete expanded[oldKey];
+    }
     onchange(next, nextRequired);
   }
 
@@ -88,6 +87,7 @@
     delete next[key];
     const nextRequired = required.filter((name) => name !== key);
     delete draftNames[key];
+    delete expanded[key];
     onchange(next, nextRequired);
   }
 
@@ -104,11 +104,11 @@
     onchange(next, required);
   }
 
-  function toggleRequired(key: string, isRequired: boolean) {
+  function toggleRequired(key: string) {
     if (readonly) return;
     const set = new Set(required);
-    if (isRequired) set.add(key);
-    else set.delete(key);
+    if (set.has(key)) set.delete(key);
+    else set.add(key);
     onchange(properties, [...set]);
   }
 
@@ -121,6 +121,15 @@
     if (readonly) return;
     const key = uniqueNewKey();
     onchange({ ...properties, [key]: { type: 'string' } }, required);
+    expanded[key] = true;
+  }
+
+  function summariseType(schema: JsonSchemaValue): string {
+    if (typeof schema === 'boolean') return schema ? 'true' : 'false';
+    const t = schema.type;
+    if (t === undefined) return 'any';
+    if (Array.isArray(t)) return t.join(' | ');
+    return t;
   }
 
   // ===== Required-only chip editing =====
@@ -129,7 +138,10 @@
   function addRequiredOnly() {
     if (readonly) return;
     const name = newRequiredOnlyName.trim();
-    if (!name) return;
+    if (!name) {
+      newRequiredOnlyName = '';
+      return;
+    }
     if (required.includes(name)) {
       newRequiredOnlyName = '';
       return;
@@ -152,42 +164,103 @@
     <Alert variant="error">{renameError}</Alert>
   {/if}
 
-  {#each propertyNames as key (key)}
-    <div class="cinder-jse-property-row">
-      <Input
-        id={`${idPrefix}-${key}-name`}
-        label="Name"
-        value={getDraftName(key)}
-        disabled={readonly}
-        oninput={(event: Event) => (draftNames[key] = (event.target as HTMLInputElement).value)}
-        onblur={() => commitRename(key)}
-      />
-      <Checkbox
-        id={`${idPrefix}-${key}-required`}
-        label="Required"
-        checked={required.includes(key)}
-        disabled={readonly}
-        onchange={(event: Event) => toggleRequired(key, (event.target as HTMLInputElement).checked)}
-      />
-      <Button variant="ghost" size="sm" disabled={readonly} onclick={() => moveProperty(key, -1)}>
-        ↑
-      </Button>
-      <Button variant="ghost" size="sm" disabled={readonly} onclick={() => moveProperty(key, 1)}>
-        ↓
-      </Button>
-      <Button variant="danger" size="sm" disabled={readonly} onclick={() => deleteProperty(key)}>
-        Delete
-      </Button>
+  {#if propertyNames.length === 0}
+    <p class="cinder-jse-property-list__empty">No properties yet.</p>
+  {/if}
 
-      <PropertyEditor
-        idPrefix={`${idPrefix}-${key}-schema`}
-        path={`${path}/${key}`}
-        depth={depth + 1}
-        {readonly}
-        value={properties[key] ?? {}}
-        onchange={(next) => setPropertySchema(key, next)}
-      />
-    </div>
+  {#each propertyNames as key (key)}
+    {@const isRequired = required.includes(key)}
+    {@const isOpen = expanded[key] === true}
+    <details
+      class="cinder-jse-property-row"
+      data-cinder-required={isRequired ? '' : undefined}
+      open={isOpen}
+      ontoggle={(event: Event) => {
+        expanded[key] = (event.target as HTMLDetailsElement).open;
+      }}
+    >
+      <summary class="cinder-jse-property-row__summary">
+        <span class="cinder-jse-property-row__chevron" aria-hidden="true">▸</span>
+        <span class="cinder-jse-property-row__name">{key}</span>
+        <span class="cinder-jse-property-row__type">{summariseType(properties[key] ?? {})}</span>
+        {#if isRequired}
+          <span class="cinder-jse-property-row__required-marker">required</span>
+        {/if}
+        <span class="cinder-jse-property-row__spacer"></span>
+        <Button
+          variant={isRequired ? 'primary' : 'ghost'}
+          size="xs"
+          disabled={readonly}
+          aria-pressed={isRequired}
+          aria-label={isRequired ? 'Required (toggle off)' : 'Optional (toggle required)'}
+          onclick={(event: MouseEvent) => {
+            event.preventDefault();
+            event.stopPropagation();
+            toggleRequired(key);
+          }}
+        >
+          {isRequired ? 'Required' : 'Optional'}
+        </Button>
+        <Button
+          variant="ghost"
+          size="xs"
+          disabled={readonly}
+          aria-label="Move up"
+          onclick={(event: MouseEvent) => {
+            event.preventDefault();
+            event.stopPropagation();
+            moveProperty(key, -1);
+          }}
+        >
+          ↑
+        </Button>
+        <Button
+          variant="ghost"
+          size="xs"
+          disabled={readonly}
+          aria-label="Move down"
+          onclick={(event: MouseEvent) => {
+            event.preventDefault();
+            event.stopPropagation();
+            moveProperty(key, 1);
+          }}
+        >
+          ↓
+        </Button>
+        <Button
+          variant="ghost-danger"
+          size="xs"
+          disabled={readonly}
+          aria-label={`Delete ${key}`}
+          onclick={(event: MouseEvent) => {
+            event.preventDefault();
+            event.stopPropagation();
+            deleteProperty(key);
+          }}
+        >
+          Delete
+        </Button>
+      </summary>
+
+      <div class="cinder-jse-property-row__panel">
+        <Input
+          id={`${idPrefix}-${key}-name`}
+          label="Name"
+          value={getDraftName(key)}
+          disabled={readonly}
+          oninput={(event: Event) => (draftNames[key] = (event.target as HTMLInputElement).value)}
+          onblur={() => commitRename(key)}
+        />
+        <PropertyEditor
+          idPrefix={`${idPrefix}-${key}-schema`}
+          path={`${path}/${key}`}
+          depth={depth + 1}
+          {readonly}
+          value={properties[key] ?? {}}
+          onchange={(next) => setPropertySchema(key, next)}
+        />
+      </div>
+    </details>
   {/each}
 
   <Button variant="secondary" size="sm" disabled={readonly} onclick={addProperty}>
@@ -195,34 +268,40 @@
   </Button>
 
   {#if requiredOnly.length > 0 || newRequiredOnlyName.length > 0}
-    <div class="cinder-jse-required-only">
-      <h4 class="cinder-jse-required-only__title">Required without property schema</h4>
-      {#each requiredOnly as name (name)}
-        <span class="cinder-jse-required-only__chip">
-          {name}
-          <Button
-            variant="ghost"
-            size="sm"
-            disabled={readonly}
-            onclick={() => removeRequiredOnly(name)}
-          >
-            ×
-          </Button>
-        </span>
-      {/each}
-      <Input
-        id={`${idPrefix}-required-only-add`}
-        label="Add required name"
-        value={newRequiredOnlyName}
-        disabled={readonly}
-        oninput={(event: Event) => (newRequiredOnlyName = (event.target as HTMLInputElement).value)}
-        onkeydown={(event: KeyboardEvent) => {
-          if (event.key === 'Enter') {
-            event.preventDefault();
-            addRequiredOnly();
-          }
-        }}
-      />
-    </div>
+    <details class="cinder-jse-required-only" open={requiredOnly.length > 0}>
+      <summary class="cinder-jse-required-only__summary">
+        Required without property schema ({requiredOnly.length})
+      </summary>
+      <div class="cinder-jse-required-only__panel">
+        {#each requiredOnly as name (name)}
+          <span class="cinder-jse-required-only__chip">
+            {name}
+            <Button
+              variant="ghost"
+              size="xs"
+              disabled={readonly}
+              aria-label={`Remove ${name}`}
+              onclick={() => removeRequiredOnly(name)}
+            >
+              ×
+            </Button>
+          </span>
+        {/each}
+        <Input
+          id={`${idPrefix}-required-only-add`}
+          label="Add required name"
+          value={newRequiredOnlyName}
+          disabled={readonly}
+          oninput={(event: Event) =>
+            (newRequiredOnlyName = (event.target as HTMLInputElement).value)}
+          onkeydown={(event: KeyboardEvent) => {
+            if (event.key === 'Enter') {
+              event.preventDefault();
+              addRequiredOnly();
+            }
+          }}
+        />
+      </div>
+    </details>
   {/if}
 </div>

--- a/packages/components/src/components/json-schema-editor/property-list.test.ts
+++ b/packages/components/src/components/json-schema-editor/property-list.test.ts
@@ -1,0 +1,37 @@
+/// <reference lib="dom" />
+import { describe, expect, test } from 'bun:test';
+
+import { setupHappyDom } from '../../test/happy-dom.ts';
+
+setupHappyDom();
+
+const { fireEvent, render } = await import('@testing-library/svelte');
+const { default: PropertyList } = await import('./property-list.svelte');
+
+describe('PropertyList', () => {
+  test('can add the first required-only property name', async () => {
+    let latestRequired: string[] = [];
+    const { container } = render(PropertyList, {
+      idPrefix: 'properties',
+      path: '/properties',
+      properties: {},
+      required: [],
+      onchange: (_properties: unknown, required: string[]) => {
+        latestRequired = required;
+      },
+    });
+
+    const input = container.querySelector('#properties-required-only-add') as HTMLInputElement;
+    const addButton = Array.from(container.querySelectorAll('button')).find(
+      (button) => button.textContent?.trim() === 'Add required name',
+    );
+
+    expect(input).not.toBeNull();
+    expect(addButton).not.toBeUndefined();
+
+    await fireEvent.input(input, { target: { value: 'missingSchema' } });
+    await fireEvent.click(addButton!);
+
+    expect(latestRequired).toEqual(['missingSchema']);
+  });
+});

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -83,6 +83,22 @@ export type { EmptyStateProps } from './components/empty-state.svelte';
 export { default as Input } from './components/input.svelte';
 export type { InputProps, InputType } from './components/input.svelte';
 
+export { default as JsonSchemaEditor } from './components/json-schema-editor.svelte';
+export type {
+  JsonSchemaDraft,
+  JsonSchemaEditorChangeEvent,
+  JsonSchemaEditorMode,
+  JsonSchemaEditorProps,
+  JsonSchemaEditorRevertEvent,
+  JsonSchemaEditorView,
+  JsonSchemaKnownDraft,
+  JsonSchemaTypeName,
+  JsonSchemaValidationError,
+  JsonSchemaValidationResult,
+  JsonSchemaValidationStatus,
+  JsonSchemaValue,
+} from './components/json-schema-editor.svelte';
+
 export { default as Kbd } from './components/kbd.svelte';
 export type { KbdProps } from './components/kbd.svelte';
 
@@ -212,6 +228,15 @@ export type {
   ToastOptions,
   ToastVariant,
 } from './components/toast-region.svelte';
+
+export { useHistory } from './utilities/use-history.svelte.ts';
+export type {
+  UseHistory,
+  UseHistoryCommitOptions,
+  UseHistoryEntry,
+  UseHistoryEntryMetadata,
+  UseHistoryOptions,
+} from './utilities/use-history.svelte.ts';
 
 export { useToast } from './utilities/use-toast.ts';
 

--- a/packages/components/src/styles/components.css
+++ b/packages/components/src/styles/components.css
@@ -22,6 +22,7 @@
 @import './components/empty-state.css';
 @import './components/experimental.css';
 @import './components/input.css';
+@import './components/json-schema-editor.css';
 @import './components/kbd.css';
 @import './components/label.css';
 @import './components/modal.css';

--- a/packages/components/src/styles/components/json-schema-editor.css
+++ b/packages/components/src/styles/components/json-schema-editor.css
@@ -224,7 +224,7 @@
 }
 
 .cinder-jse-property-row__name {
-  font-family: var(--cinder-font-mono, ui-monospace, SFMono-Regular, monospace);
+  font-family: var(--cinder-font-mono);
   font-size: var(--cinder-text-sm);
   font-weight: 600;
   color: var(--cinder-text);
@@ -328,17 +328,19 @@
   flex-wrap: wrap;
 }
 
-.cinder-jse-json-view__textarea textarea {
-  font-family: var(--cinder-font-mono, ui-monospace, SFMono-Regular, monospace);
+textarea.cinder-jse-json-view__textarea {
+  font-family: var(--cinder-font-mono);
   font-size: var(--cinder-text-sm);
   line-height: 1.5;
   min-height: 16rem;
+  /* Tab characters render as 2 spaces' worth — matches the canonical text we serialise. */
+  tab-size: 2;
 }
 
 .cinder-jse-json-view__errors {
   margin: 0;
   white-space: pre-wrap;
-  font-family: var(--cinder-font-mono, ui-monospace, SFMono-Regular, monospace);
+  font-family: var(--cinder-font-mono);
   font-size: var(--cinder-text-xs);
 }
 

--- a/packages/components/src/styles/components/json-schema-editor.css
+++ b/packages/components/src/styles/components/json-schema-editor.css
@@ -180,32 +180,49 @@
   color: var(--cinder-text-subtle);
 }
 
-/* Each property is a <details>. The summary is a fixed-height single line so
-   all controls share a baseline. The panel renders below. */
+/* Each property is a custom disclosure (not <details>/<summary> — putting the
+   action buttons inside <summary> creates an ARIA "interactive within
+   interactive" violation). One top divider per row; no per-row card chrome.
+   The Required pill's primary/ghost variant conveys required state, so we
+   don't render a separate text marker. */
 .cinder-jse-property-row {
-  border: 1px solid var(--cinder-border-muted);
-  border-radius: var(--cinder-radius-sm);
-  background: var(--cinder-surface);
-  overflow: hidden;
+  border-top: 1px solid var(--cinder-border-muted);
+  background: transparent;
 }
 
-.cinder-jse-property-row[open] {
-  background: var(--cinder-surface-raised);
+.cinder-jse-property-row:first-child {
+  border-top: 0;
 }
 
 .cinder-jse-property-row__summary {
   display: flex;
   align-items: center;
   gap: var(--cinder-space-2);
-  list-style: none;
-  cursor: pointer;
   padding: var(--cinder-space-1-5) var(--cinder-space-3);
   min-height: var(--cinder-button-height-md);
-  user-select: none;
 }
 
-.cinder-jse-property-row__summary::-webkit-details-marker {
-  display: none;
+/* The chevron + name + type form a single clickable disclosure trigger.
+   Action buttons live as siblings inside __summary so they keep the
+   single-baseline layout without nesting interactive elements. */
+.cinder-jse-property-row__trigger {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--cinder-space-2);
+  background: transparent;
+  border: 0;
+  padding: 0;
+  margin: 0;
+  cursor: pointer;
+  font-family: inherit;
+  color: inherit;
+  text-align: left;
+}
+
+.cinder-jse-property-row__trigger:focus-visible {
+  outline: 2px solid var(--cinder-accent);
+  outline-offset: 2px;
+  border-radius: var(--cinder-radius-sm);
 }
 
 .cinder-jse-property-row__chevron {
@@ -217,9 +234,7 @@
   text-align: center;
 }
 
-.cinder-jse-property-row[open]
-  > .cinder-jse-property-row__summary
-  > .cinder-jse-property-row__chevron {
+.cinder-jse-property-row__trigger[aria-expanded='true'] > .cinder-jse-property-row__chevron {
   transform: rotate(90deg);
 }
 
@@ -236,14 +251,6 @@
   padding: 0 var(--cinder-space-1-5);
 }
 
-.cinder-jse-property-row__required-marker {
-  font-size: var(--cinder-text-2xs);
-  text-transform: uppercase;
-  letter-spacing: 0.04em;
-  color: var(--cinder-text-muted);
-  font-weight: 600;
-}
-
 .cinder-jse-property-row__spacer {
   flex: 1 1 auto;
 }
@@ -252,9 +259,8 @@
   display: flex;
   flex-direction: column;
   gap: var(--cinder-space-3);
-  padding: var(--cinder-space-3);
-  border-top: 1px solid var(--cinder-border-muted);
-  background: var(--cinder-surface);
+  padding: var(--cinder-space-3) var(--cinder-space-3) var(--cinder-space-4);
+  background: transparent;
 }
 
 /* The nested PropertyEditor inside an open property panel doesn't get a card. */

--- a/packages/components/src/styles/components/json-schema-editor.css
+++ b/packages/components/src/styles/components/json-schema-editor.css
@@ -1,0 +1,235 @@
+/**
+ * Layout and spacing for the JsonSchemaEditor component.
+ * Uses Cinder tokens — no hard-coded colors or spacing.
+ */
+
+.cinder-jse {
+  display: flex;
+  flex-direction: column;
+  gap: var(--cinder-space-4);
+}
+
+/* ===== Toolbar ===== */
+.cinder-jse-toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--cinder-space-3);
+  flex-wrap: wrap;
+  padding: var(--cinder-space-2) var(--cinder-space-3);
+  border: 1px solid var(--cinder-border);
+  border-radius: var(--cinder-radius-md);
+  background: var(--cinder-surface-raised);
+}
+
+.cinder-jse-toolbar__left,
+.cinder-jse-toolbar__right {
+  display: flex;
+  align-items: center;
+  gap: var(--cinder-space-2);
+  flex-wrap: wrap;
+}
+
+/* ===== Property editor (recursive node) ===== */
+.cinder-jse-property-editor {
+  padding: var(--cinder-space-4);
+  display: flex;
+  flex-direction: column;
+  gap: var(--cinder-space-3);
+}
+
+/* Tone down nested raised surfaces so deeper nodes don't keep stacking shadows. */
+.cinder-jse-property-editor .cinder-jse-property-editor {
+  box-shadow: none;
+  background: var(--cinder-surface);
+}
+
+.cinder-jse-section {
+  border: 1px solid var(--cinder-border);
+  border-radius: var(--cinder-radius-sm);
+  padding: var(--cinder-space-3);
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--cinder-space-3);
+}
+
+.cinder-jse-section__title {
+  font-size: var(--cinder-text-xs);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--cinder-text-muted);
+  padding: 0 var(--cinder-space-1);
+}
+
+/* Type checkbox row sits horizontal; Cinder's Checkbox owns its own row, so we wrap with flex-wrap. */
+.cinder-jse-type-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--cinder-space-2) var(--cinder-space-4);
+  align-items: center;
+}
+
+.cinder-jse-type-row .cinder-checkbox-field {
+  flex: 0 0 auto;
+}
+
+/* Boolean-schema short-circuit ===== */
+.cinder-jse-boolean-schema {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--cinder-space-3);
+  padding: var(--cinder-space-3);
+  border: 1px dashed var(--cinder-border);
+  border-radius: var(--cinder-radius-sm);
+  font-size: var(--cinder-text-sm);
+  color: var(--cinder-text-muted);
+}
+
+/* ===== Collapsed deep-node summary ===== */
+.cinder-jse-collapsed {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  padding: var(--cinder-space-2) var(--cinder-space-3);
+  background: transparent;
+  border: 1px dashed var(--cinder-border);
+  border-radius: var(--cinder-radius-sm);
+  cursor: pointer;
+  font-family: inherit;
+  font-size: var(--cinder-text-sm);
+  color: var(--cinder-text);
+}
+
+.cinder-jse-collapsed:hover {
+  background: var(--cinder-surface-raised);
+}
+
+.cinder-jse-collapsed__hint {
+  color: var(--cinder-text-muted);
+  font-size: var(--cinder-text-xs);
+}
+
+/* ===== Property list ===== */
+.cinder-jse-property-list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--cinder-space-4);
+}
+
+.cinder-jse-property-row {
+  display: grid;
+  grid-template-columns: minmax(120px, 1fr) auto auto auto auto;
+  grid-template-areas:
+    'name required up down delete'
+    'schema schema schema schema schema';
+  gap: var(--cinder-space-2) var(--cinder-space-3);
+  align-items: end;
+  padding: var(--cinder-space-3);
+  border: 1px solid var(--cinder-border);
+  border-radius: var(--cinder-radius-sm);
+  background: var(--cinder-surface);
+}
+
+.cinder-jse-property-row > .cinder-input-field:first-child {
+  grid-area: name;
+}
+
+.cinder-jse-property-row > .cinder-checkbox-field {
+  grid-area: required;
+  align-self: center;
+}
+
+.cinder-jse-property-row > .cinder-button:nth-of-type(1) {
+  grid-area: up;
+}
+
+.cinder-jse-property-row > .cinder-button:nth-of-type(2) {
+  grid-area: down;
+}
+
+.cinder-jse-property-row > .cinder-button:nth-of-type(3) {
+  grid-area: delete;
+}
+
+.cinder-jse-property-row > .cinder-jse-property-editor {
+  grid-area: schema;
+}
+
+/* Required-only chip area */
+.cinder-jse-required-only {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--cinder-space-2);
+  align-items: center;
+}
+
+.cinder-jse-required-only__title {
+  flex: 1 0 100%;
+  margin: 0;
+  font-size: var(--cinder-text-xs);
+  font-weight: 600;
+  color: var(--cinder-text-muted);
+}
+
+.cinder-jse-required-only__chip {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--cinder-space-1);
+  padding: var(--cinder-space-1) var(--cinder-space-2);
+  border: 1px solid var(--cinder-border);
+  border-radius: var(--cinder-radius-full);
+  font-size: var(--cinder-text-sm);
+  background: var(--cinder-surface-raised);
+}
+
+/* ===== JSON view ===== */
+.cinder-jse-json-view {
+  display: flex;
+  flex-direction: column;
+  gap: var(--cinder-space-3);
+}
+
+.cinder-jse-json-view__toolbar {
+  display: flex;
+  align-items: center;
+  gap: var(--cinder-space-2);
+  flex-wrap: wrap;
+}
+
+.cinder-jse-json-view__textarea textarea {
+  font-family: var(--cinder-font-mono, ui-monospace, SFMono-Regular, monospace);
+  font-size: var(--cinder-text-sm);
+  line-height: 1.5;
+  min-height: 16rem;
+}
+
+.cinder-jse-json-view__errors {
+  margin: 0;
+  white-space: pre-wrap;
+  font-family: var(--cinder-font-mono, ui-monospace, SFMono-Regular, monospace);
+  font-size: var(--cinder-text-xs);
+}
+
+/* ===== Diff view ===== */
+.cinder-jse-diff-view {
+  display: flex;
+  flex-direction: column;
+  gap: var(--cinder-space-3);
+}
+
+/* ===== Form view ===== */
+.cinder-jse-form-view {
+  display: flex;
+  flex-direction: column;
+  gap: var(--cinder-space-3);
+}
+
+.cinder-jse-dirty-actions {
+  display: flex;
+  gap: var(--cinder-space-2);
+  margin-top: var(--cinder-space-2);
+}

--- a/packages/components/src/styles/components/json-schema-editor.css
+++ b/packages/components/src/styles/components/json-schema-editor.css
@@ -1,6 +1,9 @@
 /**
- * Layout and spacing for the JsonSchemaEditor component.
- * Uses Cinder tokens — no hard-coded colors or spacing.
+ * Layout for the JsonSchemaEditor component.
+ *
+ * Visual hierarchy by indentation and dividers, not nested borders. Depth 0
+ * sits inside a card; deeper nodes drop the card chrome and rely on the
+ * surrounding details panel for visual depth.
  */
 
 .cinder-jse {
@@ -19,7 +22,7 @@
   padding: var(--cinder-space-2) var(--cinder-space-3);
   border: 1px solid var(--cinder-border);
   border-radius: var(--cinder-radius-md);
-  background: var(--cinder-surface-raised);
+  background: var(--cinder-surface);
 }
 
 .cinder-jse-toolbar__left,
@@ -30,40 +33,87 @@
   flex-wrap: wrap;
 }
 
-/* ===== Property editor (recursive node) ===== */
+/* ===== Property editor ===== */
 .cinder-jse-property-editor {
-  padding: var(--cinder-space-4);
   display: flex;
   flex-direction: column;
-  gap: var(--cinder-space-3);
+  gap: 0;
 }
 
-/* Tone down nested raised surfaces so deeper nodes don't keep stacking shadows. */
-.cinder-jse-property-editor .cinder-jse-property-editor {
-  box-shadow: none;
+/* Depth 0: the only level that gets a bordered card. */
+.cinder-jse-property-editor[data-cinder-jse-depth='0'] {
+  border: 1px solid var(--cinder-border);
+  border-radius: var(--cinder-radius-md);
   background: var(--cinder-surface);
 }
 
+/* Sections are divided by a top border. The first section drops it so the
+   card's own border is the only edge. */
 .cinder-jse-section {
-  border: 1px solid var(--cinder-border);
-  border-radius: var(--cinder-radius-sm);
-  padding: var(--cinder-space-3);
-  margin: 0;
   display: flex;
   flex-direction: column;
   gap: var(--cinder-space-3);
+  padding: var(--cinder-space-4);
+  border-top: 1px solid var(--cinder-border-muted);
+}
+
+.cinder-jse-property-editor > .cinder-jse-section:first-of-type {
+  border-top: 0;
 }
 
 .cinder-jse-section__title {
-  font-size: var(--cinder-text-xs);
+  margin: 0;
+  font-size: var(--cinder-text-2xs);
   font-weight: 600;
   text-transform: uppercase;
-  letter-spacing: 0.04em;
-  color: var(--cinder-text-muted);
-  padding: 0 var(--cinder-space-1);
+  letter-spacing: 0.06em;
+  color: var(--cinder-text-subtle);
 }
 
-/* Type checkbox row sits horizontal; Cinder's Checkbox owns its own row, so we wrap with flex-wrap. */
+/* Lead section (Common: title + description) — slightly more breathing room. */
+.cinder-jse-section--lead {
+  gap: var(--cinder-space-2);
+}
+
+/* Collapsible <details> sections — chevron + section title combine into the
+   summary; body padding kicks in on expand. */
+.cinder-jse-section--collapsible {
+  padding: 0;
+}
+
+.cinder-jse-section--collapsible > summary {
+  display: flex;
+  align-items: center;
+  gap: var(--cinder-space-2);
+  list-style: none;
+  cursor: pointer;
+  padding: var(--cinder-space-3) var(--cinder-space-4);
+  user-select: none;
+}
+
+.cinder-jse-section--collapsible > summary::-webkit-details-marker {
+  display: none;
+}
+
+.cinder-jse-section--collapsible > summary::before {
+  content: '▸';
+  font-size: var(--cinder-text-xs);
+  color: var(--cinder-text-subtle);
+  transition: transform 120ms ease;
+}
+
+.cinder-jse-section--collapsible[open] > summary::before {
+  transform: rotate(90deg);
+}
+
+.cinder-jse-section__body {
+  display: flex;
+  flex-direction: column;
+  gap: var(--cinder-space-3);
+  padding: 0 var(--cinder-space-4) var(--cinder-space-4);
+}
+
+/* Type checkbox row — compact, wraps on narrow widths. */
 .cinder-jse-type-row {
   display: flex;
   flex-wrap: wrap;
@@ -75,20 +125,18 @@
   flex: 0 0 auto;
 }
 
-/* Boolean-schema short-circuit ===== */
+/* ===== Boolean schema short-circuit ===== */
 .cinder-jse-boolean-schema {
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: var(--cinder-space-3);
-  padding: var(--cinder-space-3);
-  border: 1px dashed var(--cinder-border);
-  border-radius: var(--cinder-radius-sm);
+  padding: var(--cinder-space-3) var(--cinder-space-4);
   font-size: var(--cinder-text-sm);
   color: var(--cinder-text-muted);
 }
 
-/* ===== Collapsed deep-node summary ===== */
+/* ===== Collapsed deep-node placeholder ===== */
 .cinder-jse-collapsed {
   display: flex;
   align-items: center;
@@ -96,7 +144,7 @@
   width: 100%;
   padding: var(--cinder-space-2) var(--cinder-space-3);
   background: transparent;
-  border: 1px dashed var(--cinder-border);
+  border: 1px dashed var(--cinder-border-muted);
   border-radius: var(--cinder-radius-sm);
   cursor: pointer;
   font-family: inherit;
@@ -109,81 +157,161 @@
 }
 
 .cinder-jse-collapsed__hint {
-  color: var(--cinder-text-muted);
+  color: var(--cinder-text-subtle);
   font-size: var(--cinder-text-xs);
+}
+
+.cinder-jse-section-header {
+  display: flex;
+  justify-content: flex-end;
+  padding: var(--cinder-space-2) var(--cinder-space-4) 0;
 }
 
 /* ===== Property list ===== */
 .cinder-jse-property-list {
   display: flex;
   flex-direction: column;
-  gap: var(--cinder-space-4);
+  gap: var(--cinder-space-2);
 }
 
+.cinder-jse-property-list__empty {
+  margin: 0;
+  font-size: var(--cinder-text-sm);
+  color: var(--cinder-text-subtle);
+}
+
+/* Each property is a <details>. The summary is a fixed-height single line so
+   all controls share a baseline. The panel renders below. */
 .cinder-jse-property-row {
-  display: grid;
-  grid-template-columns: minmax(120px, 1fr) auto auto auto auto;
-  grid-template-areas:
-    'name required up down delete'
-    'schema schema schema schema schema';
-  gap: var(--cinder-space-2) var(--cinder-space-3);
-  align-items: end;
-  padding: var(--cinder-space-3);
-  border: 1px solid var(--cinder-border);
+  border: 1px solid var(--cinder-border-muted);
   border-radius: var(--cinder-radius-sm);
+  background: var(--cinder-surface);
+  overflow: hidden;
+}
+
+.cinder-jse-property-row[open] {
+  background: var(--cinder-surface-raised);
+}
+
+.cinder-jse-property-row__summary {
+  display: flex;
+  align-items: center;
+  gap: var(--cinder-space-2);
+  list-style: none;
+  cursor: pointer;
+  padding: var(--cinder-space-1-5) var(--cinder-space-3);
+  min-height: var(--cinder-button-height-md);
+  user-select: none;
+}
+
+.cinder-jse-property-row__summary::-webkit-details-marker {
+  display: none;
+}
+
+.cinder-jse-property-row__chevron {
+  display: inline-block;
+  font-size: var(--cinder-text-xs);
+  color: var(--cinder-text-subtle);
+  transition: transform 120ms ease;
+  width: 0.75rem;
+  text-align: center;
+}
+
+.cinder-jse-property-row[open]
+  > .cinder-jse-property-row__summary
+  > .cinder-jse-property-row__chevron {
+  transform: rotate(90deg);
+}
+
+.cinder-jse-property-row__name {
+  font-family: var(--cinder-font-mono, ui-monospace, SFMono-Regular, monospace);
+  font-size: var(--cinder-text-sm);
+  font-weight: 600;
+  color: var(--cinder-text);
+}
+
+.cinder-jse-property-row__type {
+  font-size: var(--cinder-text-xs);
+  color: var(--cinder-text-subtle);
+  padding: 0 var(--cinder-space-1-5);
+}
+
+.cinder-jse-property-row__required-marker {
+  font-size: var(--cinder-text-2xs);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--cinder-text-muted);
+  font-weight: 600;
+}
+
+.cinder-jse-property-row__spacer {
+  flex: 1 1 auto;
+}
+
+.cinder-jse-property-row__panel {
+  display: flex;
+  flex-direction: column;
+  gap: var(--cinder-space-3);
+  padding: var(--cinder-space-3);
+  border-top: 1px solid var(--cinder-border-muted);
   background: var(--cinder-surface);
 }
 
-.cinder-jse-property-row > .cinder-input-field:first-child {
-  grid-area: name;
+/* The nested PropertyEditor inside an open property panel doesn't get a card. */
+.cinder-jse-property-row__panel > .cinder-jse-property-editor[data-cinder-jse-depth] {
+  border: 0;
+  background: transparent;
+  border-radius: 0;
 }
 
-.cinder-jse-property-row > .cinder-checkbox-field {
-  grid-area: required;
-  align-self: center;
-}
-
-.cinder-jse-property-row > .cinder-button:nth-of-type(1) {
-  grid-area: up;
-}
-
-.cinder-jse-property-row > .cinder-button:nth-of-type(2) {
-  grid-area: down;
-}
-
-.cinder-jse-property-row > .cinder-button:nth-of-type(3) {
-  grid-area: delete;
-}
-
-.cinder-jse-property-row > .cinder-jse-property-editor {
-  grid-area: schema;
+.cinder-jse-property-row__panel > .cinder-jse-property-editor > .cinder-jse-section {
+  padding-left: 0;
+  padding-right: 0;
 }
 
 /* Required-only chip area */
 .cinder-jse-required-only {
+  margin-top: var(--cinder-space-2);
+}
+
+.cinder-jse-required-only__summary {
+  cursor: pointer;
+  font-size: var(--cinder-text-xs);
+  color: var(--cinder-text-subtle);
+  padding: var(--cinder-space-1) var(--cinder-space-2);
+  list-style: none;
+}
+
+.cinder-jse-required-only__summary::-webkit-details-marker {
+  display: none;
+}
+
+.cinder-jse-required-only__panel {
   display: flex;
   flex-wrap: wrap;
   gap: var(--cinder-space-2);
   align-items: center;
-}
-
-.cinder-jse-required-only__title {
-  flex: 1 0 100%;
-  margin: 0;
-  font-size: var(--cinder-text-xs);
-  font-weight: 600;
-  color: var(--cinder-text-muted);
+  padding: var(--cinder-space-2);
 }
 
 .cinder-jse-required-only__chip {
   display: inline-flex;
   align-items: center;
   gap: var(--cinder-space-1);
-  padding: var(--cinder-space-1) var(--cinder-space-2);
-  border: 1px solid var(--cinder-border);
+  padding: var(--cinder-space-0-5) var(--cinder-space-2);
+  border: 1px solid var(--cinder-border-muted);
   border-radius: var(--cinder-radius-full);
-  font-size: var(--cinder-text-sm);
-  background: var(--cinder-surface-raised);
+  font-size: var(--cinder-text-xs);
+  background: var(--cinder-surface);
+}
+
+/* ===== Advanced row ($ref / preserved badges) ===== */
+.cinder-jse-advanced-row {
+  display: flex;
+  align-items: center;
+  gap: var(--cinder-space-2);
+  padding: var(--cinder-space-2) var(--cinder-space-4);
+  border-top: 1px solid var(--cinder-border-muted);
 }
 
 /* ===== JSON view ===== */

--- a/packages/components/src/utilities/use-history.svelte.test.ts
+++ b/packages/components/src/utilities/use-history.svelte.test.ts
@@ -1,0 +1,302 @@
+import { describe, expect, test } from 'bun:test';
+
+import { useHistory } from './use-history.svelte.ts';
+
+describe('useHistory', () => {
+  test('starts with the initial value as the only history entry', () => {
+    const history = useHistory({ initial: { count: 0 } });
+
+    expect(history.current).toEqual({ count: 0 });
+    expect(history.committedEntry.value).toEqual({ count: 0 });
+    expect(history.canUndo).toBe(false);
+    expect(history.canRedo).toBe(false);
+    expect(history.size).toBe(1);
+    expect(history.index).toBe(0);
+  });
+
+  test('commit pushes a new entry and updates current', () => {
+    const history = useHistory({ initial: { count: 0 } });
+
+    history.commit({ count: 1 });
+
+    expect(history.current).toEqual({ count: 1 });
+    expect(history.committedEntry.value).toEqual({ count: 1 });
+    expect(history.size).toBe(2);
+    expect(history.index).toBe(1);
+    expect(history.canUndo).toBe(true);
+    expect(history.canRedo).toBe(false);
+  });
+
+  test('undo returns the entry we just left and moves current back', () => {
+    const history = useHistory({ initial: { count: 0 } });
+
+    history.commit({ count: 1 }, { label: 'first' });
+    history.commit({ count: 2 }, { label: 'second' });
+
+    const left = history.undo();
+
+    expect(left?.value).toEqual({ count: 2 });
+    expect(left?.label).toBe('second');
+    expect(history.current).toEqual({ count: 1 });
+    expect(history.canRedo).toBe(true);
+  });
+
+  test('redo returns the entry we moved to', () => {
+    const history = useHistory({ initial: { count: 0 } });
+
+    history.commit({ count: 1 }, { label: 'first' });
+    history.commit({ count: 2 }, { label: 'second' });
+    history.undo();
+
+    const moved = history.redo();
+
+    expect(moved?.value).toEqual({ count: 2 });
+    expect(moved?.label).toBe('second');
+    expect(history.current).toEqual({ count: 2 });
+  });
+
+  test('commit after undo truncates the redo tail', () => {
+    const history = useHistory({ initial: { count: 0 } });
+
+    history.commit({ count: 1 });
+    history.commit({ count: 2 });
+    history.undo();
+
+    history.commit({ count: 99 });
+
+    expect(history.current).toEqual({ count: 99 });
+    expect(history.canRedo).toBe(false);
+    expect(history.size).toBe(3);
+  });
+
+  test('coalesce key collapses rapid commits sharing the same key', () => {
+    const history = useHistory({ initial: { text: '' }, coalesceMs: 1_000_000 });
+
+    history.commit({ text: 'a' }, { coalesceKey: 'title' });
+    history.commit({ text: 'ab' }, { coalesceKey: 'title' });
+    history.commit({ text: 'abc' }, { coalesceKey: 'title' });
+
+    expect(history.current).toEqual({ text: 'abc' });
+    expect(history.size).toBe(2); // initial + one collapsed entry
+  });
+
+  test('structural commits (no coalesce key) never coalesce, even back-to-back', () => {
+    const history = useHistory({ initial: { count: 0 }, coalesceMs: 1_000_000 });
+
+    history.commit({ count: 1 });
+    history.commit({ count: 2 });
+    history.commit({ count: 3 });
+
+    expect(history.size).toBe(4);
+    expect(history.canUndo).toBe(true);
+    history.undo();
+    expect(history.current).toEqual({ count: 2 });
+  });
+
+  test('different coalesce keys do not coalesce together', () => {
+    const history = useHistory({ initial: { a: '', b: '' }, coalesceMs: 1_000_000 });
+
+    history.commit({ a: 'x', b: '' }, { coalesceKey: 'a' });
+    history.commit({ a: 'x', b: 'y' }, { coalesceKey: 'b' });
+
+    expect(history.size).toBe(3);
+  });
+
+  test('equality check is against committed stack top, not transient current', () => {
+    const history = useHistory({ initial: { count: 0 } });
+
+    history.set({ count: 5 });
+    expect(history.current).toEqual({ count: 5 });
+    expect(history.committedEntry.value).toEqual({ count: 0 });
+
+    // committing the original baseline should be a no-op against the stack top
+    history.commit({ count: 0 });
+    expect(history.size).toBe(1);
+    expect(history.current).toEqual({ count: 0 });
+
+    // committing { count: 5 } pushes (vs stack top { count: 0 }), even though
+    // current was already { count: 5 } via set()
+    history.commit({ count: 5 });
+    expect(history.size).toBe(2);
+    expect(history.committedEntry.value).toEqual({ count: 5 });
+  });
+
+  test('mutating-then-committing the same reference is detected as a change', () => {
+    const value = { items: [1, 2, 3] };
+    const history = useHistory({ initial: value });
+
+    value.items.push(4);
+    history.commit(value);
+
+    expect(history.size).toBe(2);
+    expect(history.committedEntry.value).toEqual({ items: [1, 2, 3, 4] });
+    // Initial entry must still be the pristine version (deep-cloned at commit)
+    history.undo();
+    expect(history.current).toEqual({ items: [1, 2, 3] });
+  });
+
+  test('maxDepth evicts oldest entries', () => {
+    const history = useHistory({ initial: { n: 0 }, maxDepth: 3 });
+
+    history.commit({ n: 1 });
+    history.commit({ n: 2 });
+    history.commit({ n: 3 });
+    history.commit({ n: 4 });
+
+    expect(history.size).toBe(3);
+    // Oldest entry (initial { n: 0 }) was evicted; we can undo back to { n: 2 }
+    while (history.canUndo) history.undo();
+    expect(history.current).toEqual({ n: 2 });
+  });
+
+  test('reset clears history and seeds a new baseline', () => {
+    const history = useHistory({ initial: { count: 0 } });
+    history.commit({ count: 1 });
+    history.commit({ count: 2 });
+
+    history.reset({ count: 100 }, 'reset baseline');
+
+    expect(history.current).toEqual({ count: 100 });
+    expect(history.committedEntry.value).toEqual({ count: 100 });
+    expect(history.committedEntry.label).toBe('reset baseline');
+    expect(history.size).toBe(1);
+    expect(history.canUndo).toBe(false);
+    expect(history.canRedo).toBe(false);
+  });
+
+  test('label round-trips through undo and redo', () => {
+    const history = useHistory({ initial: { v: 0 } });
+    history.commit({ v: 1 }, { label: 'add' });
+    history.commit({ v: 2 }, { label: 'multiply' });
+
+    expect(history.undo()?.label).toBe('multiply');
+    expect(history.undo()?.label).toBe('add');
+    expect(history.redo()?.label).toBe('add');
+    expect(history.redo()?.label).toBe('multiply');
+  });
+
+  test('custom equals lets callers decide equivalence', () => {
+    const history = useHistory<{ id: number; data: string }>({
+      initial: { id: 1, data: 'a' },
+      equals: (a, b) => a.id === b.id,
+    });
+
+    // Same id => equal => no push
+    history.commit({ id: 1, data: 'b' });
+    expect(history.size).toBe(1);
+
+    // Different id => push
+    history.commit({ id: 2, data: 'c' });
+    expect(history.size).toBe(2);
+  });
+
+  test('custom clone supports values structuredClone cannot handle', () => {
+    type Stamped = { ts: Date; tag: string };
+    const history = useHistory<Stamped>({
+      initial: { ts: new Date('2020-01-01'), tag: 'a' },
+      clone: (value) => ({ ts: new Date(value.ts.getTime()), tag: value.tag }),
+      equals: (a, b) => a.ts.getTime() === b.ts.getTime() && a.tag === b.tag,
+    });
+
+    history.commit({ ts: new Date('2020-02-02'), tag: 'b' });
+
+    expect(history.current.tag).toBe('b');
+    expect(history.committedEntry.value.ts.toISOString()).toBe('2020-02-02T00:00:00.000Z');
+  });
+
+  test('throws when default clone (structuredClone) cannot copy the committed value', () => {
+    const history = useHistory<{ tag: string; run?: () => void }>({
+      initial: { tag: 'a' },
+    });
+
+    expect(() => history.commit({ tag: 'b', run: () => 0 })).toThrow();
+  });
+
+  test('canUndo / canRedo reflect bounds', () => {
+    const history = useHistory({ initial: 'a' });
+
+    expect(history.canUndo).toBe(false);
+    expect(history.canRedo).toBe(false);
+
+    history.commit('b');
+    expect(history.canUndo).toBe(true);
+    expect(history.canRedo).toBe(false);
+
+    history.undo();
+    expect(history.canUndo).toBe(false);
+    expect(history.canRedo).toBe(true);
+  });
+
+  test('undo / redo at boundaries returns null', () => {
+    const history = useHistory({ initial: 0 });
+
+    expect(history.undo()).toBe(null);
+    expect(history.redo()).toBe(null);
+  });
+
+  test('set updates current without touching the committed stack', () => {
+    const history = useHistory({ initial: 'a' });
+
+    history.set('b');
+
+    expect(history.current).toBe('b');
+    expect(history.committedEntry.value).toBe('a');
+    expect(history.size).toBe(1);
+    expect(history.canUndo).toBe(false);
+  });
+
+  test('mutating current does not corrupt the committed baseline', () => {
+    const history = useHistory({ initial: { count: 0 } });
+
+    history.current.count = 99;
+
+    expect(history.committedEntry.value).toEqual({ count: 0 });
+  });
+
+  test('mutating committedEntry.value does not corrupt the stored history', () => {
+    const history = useHistory({ initial: { count: 0 } });
+    history.commit({ count: 1 });
+
+    const entry = history.committedEntry;
+    entry.value.count = 999;
+
+    expect(history.committedEntry.value).toEqual({ count: 1 });
+    history.undo();
+    expect(history.committedEntry.value).toEqual({ count: 0 });
+  });
+
+  test('mutating undo() return value does not corrupt history', () => {
+    const history = useHistory({ initial: { count: 0 } });
+    history.commit({ count: 1 });
+    history.commit({ count: 2 });
+
+    const left = history.undo();
+    if (left) left.value.count = 999;
+
+    history.redo();
+    expect(history.current).toEqual({ count: 2 });
+  });
+
+  test('maxDepth less than 1 is clamped to 1', () => {
+    const history = useHistory({ initial: 0, maxDepth: 0 });
+
+    history.commit(1);
+    expect(history.size).toBe(1);
+    expect(history.committedEntry.value).toBe(1);
+
+    history.commit(2);
+    expect(history.size).toBe(1);
+    expect(history.committedEntry.value).toBe(2);
+  });
+
+  test('cloneable check throws even when next is JSON-equal to committed top', () => {
+    const history = useHistory<{ tag: string; run?: () => void }>({
+      initial: { tag: 'a' },
+    });
+
+    // This value JSON-serialises to {"tag":"a"} (function dropped) but is
+    // not structuredClone-able. Spec says commit must enforce cloneability
+    // before any decision.
+    expect(() => history.commit({ tag: 'a', run: () => 0 })).toThrow();
+  });
+});

--- a/packages/components/src/utilities/use-history.svelte.ts
+++ b/packages/components/src/utilities/use-history.svelte.ts
@@ -1,0 +1,239 @@
+/**
+ * Generic undo/redo history for JSON-compatible values.
+ *
+ * The history maintains a committed stack and a `current` value that may be
+ * ahead of the stack via {@link UseHistory.set}. Equality decisions for
+ * "did anything change?" are made against the committed stack top, never
+ * against the transient `current`, so a `set()` followed by a `commit()` of
+ * the same value still pushes when the value differs from the committed top.
+ *
+ * Defaults (`structuredClone` for cloning, stable JSON serialise for equality)
+ * cover plain JSON-shaped data: objects, arrays, primitives, and nested
+ * combinations of those. Callers using `Map`, `Set`, `Date`, `BigInt`, cyclic
+ * graphs, or other non-JSON-cloneable values must supply their own `clone`
+ * and `equals` strategies.
+ */
+
+export interface UseHistoryEntryMetadata {
+  /** Human-readable description of the action that produced this entry. */
+  label?: string;
+}
+
+export interface UseHistoryCommitOptions extends UseHistoryEntryMetadata {
+  /**
+   * Caller-provided tag. Two consecutive commits sharing the same key within
+   * `coalesceMs` replace the stack top instead of pushing. Pass `undefined`
+   * (or omit) for structural actions that should always push.
+   */
+  coalesceKey?: string;
+}
+
+export interface UseHistoryEntry<T> {
+  value: T;
+  label?: string;
+}
+
+export interface UseHistoryOptions<T> {
+  initial: T;
+  /** Maximum number of entries retained in the stack. Default: 100. */
+  maxDepth?: number;
+  /** Time window for coalescing rapid commits sharing a key. Default: 300ms. */
+  coalesceMs?: number;
+  /** Deep-clone strategy. Default: structuredClone. */
+  clone?: (value: T) => T;
+  /**
+   * Equality predicate used to skip no-op commits. Default: stable JSON
+   * serialise comparison (sorted keys). Reference identity is intentionally
+   * NOT used as a sufficient signal — callers may mutate-then-commit the
+   * same object reference and we should still push a new entry.
+   */
+  equals?: (a: T, b: T) => boolean;
+}
+
+export interface UseHistory<T> {
+  /** Current reactive value; may be ahead of the committed stack via {@link UseHistory.set}. */
+  readonly current: T;
+  /** Top of the committed stack — the entry undo would leave us at. */
+  readonly committedEntry: UseHistoryEntry<T>;
+  readonly canUndo: boolean;
+  readonly canRedo: boolean;
+  readonly size: number;
+  readonly index: number;
+  /** Replace `current` without touching the committed stack. */
+  set(next: T): void;
+  /** Push a new entry (subject to coalescing and equality). */
+  commit(next: T, options?: UseHistoryCommitOptions): void;
+  /** Move back one entry. Returns the entry we left, or null at the bottom. */
+  undo(): UseHistoryEntry<T> | null;
+  /** Move forward one entry. Returns the entry we moved to, or null at the top. */
+  redo(): UseHistoryEntry<T> | null;
+  /** Clear history and seed a new baseline. */
+  reset(value: T, label?: string): void;
+}
+
+function defaultClone<T>(value: T): T {
+  // First unwrap any Svelte $state proxies via $state.snapshot, which yields
+  // a plain object graph. Then run structuredClone to enforce our cloneable
+  // contract — structuredClone throws on functions/symbols/etc. ($state.snapshot
+  // only warns and silently includes originals).
+  // The Snapshot<T> type is structurally compatible with T at runtime; the
+  // assertion is needed because Svelte deep-marks the snapshot as readonly.
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion
+  const snapshot = $state.snapshot(value) as T;
+  return structuredClone(snapshot);
+}
+
+function isPlainObjectRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function stableSerialise(value: unknown): string {
+  return JSON.stringify(value, (_key, val) => {
+    if (!isPlainObjectRecord(val)) return val;
+    const sorted: Record<string, unknown> = {};
+    for (const k of Object.keys(val).toSorted()) {
+      sorted[k] = val[k];
+    }
+    return sorted;
+  });
+}
+
+function defaultEquals<T>(a: T, b: T): boolean {
+  if (a === b) {
+    // Reference identity is a sufficient *positive* signal only for primitives
+    // — for objects, the caller may have mutated in place, so we still need to
+    // serialise and compare. (Two primitives that are === are definitely equal.)
+    if (a === null || typeof a !== 'object') return true;
+  }
+  return stableSerialise(a) === stableSerialise(b);
+}
+
+export function useHistory<T>(options: UseHistoryOptions<T>): UseHistory<T> {
+  const {
+    initial,
+    coalesceMs = 300,
+    clone = defaultClone,
+    equals = defaultEquals,
+  } = options;
+
+  // Clamp maxDepth to at least 1 so the stack always has a committed entry.
+  const maxDepth = Math.max(1, options.maxDepth ?? 100);
+
+  type Entry = UseHistoryEntry<T> & { coalesceKey?: string; committedAt: number };
+
+  // Use separate clones for the committed stack and the transient `current`
+  // so direct mutation of `current` (via Svelte's deep reactivity) cannot
+  // corrupt the committed baseline.
+  const seed: Entry = { value: clone(initial), committedAt: 0 };
+  let stack = $state<Entry[]>([seed]);
+  let pointer = $state(0);
+  let current = $state<T>(clone(initial));
+
+  function evictIfNeeded() {
+    while (stack.length > maxDepth) {
+      stack.shift();
+      pointer = Math.max(0, pointer - 1);
+    }
+  }
+
+  function snapshotEntry(entry: Entry): UseHistoryEntry<T> {
+    // Clone on read so a caller mutating the returned value cannot corrupt
+    // committed history.
+    return { value: clone(entry.value), label: entry.label };
+  }
+
+  return {
+    get current() {
+      return current;
+    },
+    get committedEntry(): UseHistoryEntry<T> {
+      return snapshotEntry(stack[pointer]);
+    },
+    get canUndo() {
+      return pointer > 0;
+    },
+    get canRedo() {
+      return pointer < stack.length - 1;
+    },
+    get size() {
+      return stack.length;
+    },
+    get index() {
+      return pointer;
+    },
+
+    set(next: T) {
+      current = next;
+    },
+
+    commit(next: T, commitOptions?: UseHistoryCommitOptions) {
+      const top = stack[pointer];
+
+      // Clone before any decision so cloneable contract is enforced even when
+      // the value happens to be equal to the committed top.
+      const cloned = clone(next);
+
+      if (equals(next, top.value)) {
+        // Sync `current` to the committed value (caller may have drifted via
+        // set()). Use a fresh clone so consumers can't mutate stack state.
+        current = clone(top.value);
+        return;
+      }
+
+      const now = Date.now();
+      const coalesceKey = commitOptions?.coalesceKey;
+      const label = commitOptions?.label;
+
+      // Coalesce: replace the stack top when the previous entry shares a key
+      // and we're inside the time window. Structural commits (no key) never
+      // coalesce.
+      const canCoalesce =
+        coalesceKey !== undefined &&
+        top.coalesceKey === coalesceKey &&
+        now - top.committedAt <= coalesceMs &&
+        pointer === stack.length - 1;
+
+      if (canCoalesce) {
+        stack[pointer] = {
+          value: cloned,
+          label: label ?? top.label,
+          coalesceKey,
+          committedAt: now,
+        };
+      } else {
+        // Truncate redo tail before pushing.
+        if (pointer < stack.length - 1) {
+          stack = stack.slice(0, pointer + 1);
+        }
+        stack.push({ value: cloned, label, coalesceKey, committedAt: now });
+        pointer = stack.length - 1;
+        evictIfNeeded();
+      }
+
+      // Give `current` its own clone, separate from the stack entry.
+      current = clone(stack[pointer].value);
+    },
+
+    undo() {
+      if (pointer === 0) return null;
+      const left = stack[pointer];
+      pointer -= 1;
+      current = clone(stack[pointer].value);
+      return snapshotEntry(left);
+    },
+
+    redo() {
+      if (pointer >= stack.length - 1) return null;
+      pointer += 1;
+      const moved = stack[pointer];
+      current = clone(moved.value);
+      return snapshotEntry(moved);
+    },
+
+    reset(value: T, label?: string) {
+      stack = [{ value: clone(value), label, committedAt: Date.now() }];
+      pointer = 0;
+      current = clone(value);
+    },
+  };
+}

--- a/packages/components/src/utilities/use-history.svelte.ts
+++ b/packages/components/src/utilities/use-history.svelte.ts
@@ -16,7 +16,7 @@
 
 export interface UseHistoryEntryMetadata {
   /** Human-readable description of the action that produced this entry. */
-  label?: string;
+  label?: string | undefined;
 }
 
 export interface UseHistoryCommitOptions extends UseHistoryEntryMetadata {
@@ -25,29 +25,29 @@ export interface UseHistoryCommitOptions extends UseHistoryEntryMetadata {
    * `coalesceMs` replace the stack top instead of pushing. Pass `undefined`
    * (or omit) for structural actions that should always push.
    */
-  coalesceKey?: string;
+  coalesceKey?: string | undefined;
 }
 
 export interface UseHistoryEntry<T> {
   value: T;
-  label?: string;
+  label?: string | undefined;
 }
 
 export interface UseHistoryOptions<T> {
   initial: T;
   /** Maximum number of entries retained in the stack. Default: 100. */
-  maxDepth?: number;
+  maxDepth?: number | undefined;
   /** Time window for coalescing rapid commits sharing a key. Default: 300ms. */
-  coalesceMs?: number;
+  coalesceMs?: number | undefined;
   /** Deep-clone strategy. Default: structuredClone. */
-  clone?: (value: T) => T;
+  clone?: ((value: T) => T) | undefined;
   /**
    * Equality predicate used to skip no-op commits. Default: stable JSON
    * serialise comparison (sorted keys). Reference identity is intentionally
    * NOT used as a sufficient signal — callers may mutate-then-commit the
    * same object reference and we should still push a new entry.
    */
-  equals?: (a: T, b: T) => boolean;
+  equals?: ((a: T, b: T) => boolean) | undefined;
 }
 
 export interface UseHistory<T> {
@@ -109,17 +109,17 @@ function defaultEquals<T>(a: T, b: T): boolean {
 }
 
 export function useHistory<T>(options: UseHistoryOptions<T>): UseHistory<T> {
-  const {
-    initial,
-    coalesceMs = 300,
-    clone = defaultClone,
-    equals = defaultEquals,
-  } = options;
+  const { initial, coalesceMs = 300, clone = defaultClone, equals = defaultEquals } = options;
 
   // Clamp maxDepth to at least 1 so the stack always has a committed entry.
   const maxDepth = Math.max(1, options.maxDepth ?? 100);
 
-  type Entry = UseHistoryEntry<T> & { coalesceKey?: string; committedAt: number };
+  type Entry = {
+    value: T;
+    label?: string | undefined;
+    coalesceKey?: string | undefined;
+    committedAt: number;
+  };
 
   // Use separate clones for the committed stack and the transient `current`
   // so direct mutation of `current` (via Svelte's deep reactivity) cannot
@@ -128,6 +128,17 @@ export function useHistory<T>(options: UseHistoryOptions<T>): UseHistory<T> {
   let stack = $state<Entry[]>([seed]);
   let pointer = $state(0);
   let current = $state<T>(clone(initial));
+
+  // Invariant: stack always contains at least one entry and pointer is always
+  // a valid index. Calls to this helper express that intent so we don't
+  // litter the implementation with `!` non-null assertions.
+  function entryAt(index: number): Entry {
+    const entry = stack[index];
+    if (!entry) {
+      throw new Error(`useHistory: stack index ${index} out of range (size ${stack.length})`);
+    }
+    return entry;
+  }
 
   function evictIfNeeded() {
     while (stack.length > maxDepth) {
@@ -147,7 +158,7 @@ export function useHistory<T>(options: UseHistoryOptions<T>): UseHistory<T> {
       return current;
     },
     get committedEntry(): UseHistoryEntry<T> {
-      return snapshotEntry(stack[pointer]);
+      return snapshotEntry(entryAt(pointer));
     },
     get canUndo() {
       return pointer > 0;
@@ -167,7 +178,7 @@ export function useHistory<T>(options: UseHistoryOptions<T>): UseHistory<T> {
     },
 
     commit(next: T, commitOptions?: UseHistoryCommitOptions) {
-      const top = stack[pointer];
+      const top = entryAt(pointer);
 
       // Clone before any decision so cloneable contract is enforced even when
       // the value happens to be equal to the committed top.
@@ -184,9 +195,6 @@ export function useHistory<T>(options: UseHistoryOptions<T>): UseHistory<T> {
       const coalesceKey = commitOptions?.coalesceKey;
       const label = commitOptions?.label;
 
-      // Coalesce: replace the stack top when the previous entry shares a key
-      // and we're inside the time window. Structural commits (no key) never
-      // coalesce.
       const canCoalesce =
         coalesceKey !== undefined &&
         top.coalesceKey === coalesceKey &&
@@ -201,7 +209,6 @@ export function useHistory<T>(options: UseHistoryOptions<T>): UseHistory<T> {
           committedAt: now,
         };
       } else {
-        // Truncate redo tail before pushing.
         if (pointer < stack.length - 1) {
           stack = stack.slice(0, pointer + 1);
         }
@@ -210,22 +217,21 @@ export function useHistory<T>(options: UseHistoryOptions<T>): UseHistory<T> {
         evictIfNeeded();
       }
 
-      // Give `current` its own clone, separate from the stack entry.
-      current = clone(stack[pointer].value);
+      current = clone(entryAt(pointer).value);
     },
 
     undo() {
       if (pointer === 0) return null;
-      const left = stack[pointer];
+      const left = entryAt(pointer);
       pointer -= 1;
-      current = clone(stack[pointer].value);
+      current = clone(entryAt(pointer).value);
       return snapshotEntry(left);
     },
 
     redo() {
       if (pointer >= stack.length - 1) return null;
       pointer += 1;
-      const moved = stack[pointer];
+      const moved = entryAt(pointer);
       current = clone(moved.value);
       return snapshotEntry(moved);
     },

--- a/packages/components/src/utilities/use-history.svelte.ts
+++ b/packages/components/src/utilities/use-history.svelte.ts
@@ -87,7 +87,8 @@ function isPlainObjectRecord(value: unknown): value is Record<string, unknown> {
   return value !== null && typeof value === 'object' && !Array.isArray(value);
 }
 
-function stableSerialise(value: unknown): string {
+/** Stable JSON serialisation with sorted object keys — used for equality checks. */
+export function stableSerialise(value: unknown): string {
   return JSON.stringify(value, (_key, val) => {
     if (!isPlainObjectRecord(val)) return val;
     const sorted: Record<string, unknown> = {};

--- a/packages/playground/src/examples/json-schema-editor/basic.example.svelte
+++ b/packages/playground/src/examples/json-schema-editor/basic.example.svelte
@@ -5,8 +5,9 @@
 
 <script lang="ts">
   import { JsonSchemaEditor } from '../../../../components/src/index.ts';
+  import type { JsonSchemaValue } from '../../../../components/src/index.ts';
 
-  const personSchema = {
+  const personSchema: JsonSchemaValue = {
     $schema: 'https://json-schema.org/draft/2020-12/schema',
     title: 'Person',
     type: 'object',

--- a/packages/playground/src/examples/json-schema-editor/basic.example.svelte
+++ b/packages/playground/src/examples/json-schema-editor/basic.example.svelte
@@ -1,0 +1,22 @@
+<script lang="ts" module>
+  export const title = 'Basic JSON Schema editor';
+  export const description = 'Edit a flat object schema with form, JSON, and diff views.';
+</script>
+
+<script lang="ts">
+  import { JsonSchemaEditor } from '../../../../components/src/index.ts';
+
+  const personSchema = {
+    $schema: 'https://json-schema.org/draft/2020-12/schema',
+    title: 'Person',
+    type: 'object',
+    properties: {
+      name: { type: 'string', title: 'Full name', minLength: 1 },
+      age: { type: 'integer', minimum: 0 },
+      email: { type: 'string', format: 'email' },
+    },
+    required: ['name'],
+  };
+</script>
+
+<JsonSchemaEditor id="basic-jse" schema={personSchema} />

--- a/packages/playground/src/examples/json-schema-editor/composition.example.svelte
+++ b/packages/playground/src/examples/json-schema-editor/composition.example.svelte
@@ -6,8 +6,9 @@
 
 <script lang="ts">
   import { JsonSchemaEditor } from '../../../../components/src/index.ts';
+  import type { JsonSchemaValue } from '../../../../components/src/index.ts';
 
-  const schema = {
+  const schema: JsonSchemaValue = {
     type: 'object',
     properties: {
       identifier: {

--- a/packages/playground/src/examples/json-schema-editor/composition.example.svelte
+++ b/packages/playground/src/examples/json-schema-editor/composition.example.svelte
@@ -1,0 +1,23 @@
+<script lang="ts" module>
+  export const title = 'Composition (oneOf)';
+  export const description =
+    'A schema using oneOf alongside type — both render as separate sections.';
+</script>
+
+<script lang="ts">
+  import { JsonSchemaEditor } from '../../../../components/src/index.ts';
+
+  const schema = {
+    type: 'object',
+    properties: {
+      identifier: {
+        oneOf: [
+          { type: 'string', pattern: '^[a-z]+$' },
+          { type: 'integer', minimum: 1 },
+        ],
+      },
+    },
+  };
+</script>
+
+<JsonSchemaEditor id="composition-jse" {schema} />

--- a/packages/playground/src/examples/json-schema-editor/invalid-source.example.svelte
+++ b/packages/playground/src/examples/json-schema-editor/invalid-source.example.svelte
@@ -1,0 +1,13 @@
+<script lang="ts" module>
+  export const title = 'Invalid initial schema';
+  export const description =
+    'When the input cannot be parsed, the form is disabled and the JSON view is the entry point.';
+</script>
+
+<script lang="ts">
+  import { JsonSchemaEditor } from '../../../../components/src/index.ts';
+
+  const malformed = '{ "type": "not-a-real-type" }';
+</script>
+
+<JsonSchemaEditor id="invalid-jse" schema={malformed} />


### PR DESCRIPTION
### Summary
- Adds a full `JsonSchemaEditor` component with form, JSON, and diff workflows.
- Introduces robust state orchestration with guarded prop synchronisation (`readonly`, `draftOverride`) and lifecycle cleanup.
- Adds composable history via `useHistory` and integrates compile/meta validation with schema-draft-aware status updates.
- Replaces problematic composition row indexing and keyboard/ARIA interactions based on prior review fixes.
- Adds dedicated validator utilities, new unit tests, and playground examples.

### Committee roster
- typescript-expert
- testing-expert
- frontend-architect
- ux-designer
- simplicity-engineer
- junior-engineer
- security-reviewer
- codex

### Round
Round 2

### Tests
- bun test
- bun test packages/components/src/components/json-schema-editor/json-schema-editor-state.svelte.test.ts
- bun test packages/components/src/components/json-schema-editor/json-schema-validator.test.ts
- bun test packages/components/src/utilities/use-history.svelte.test.ts
- bun test packages/components/src/components/json-schema-editor/json-schema-editor.test.ts

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a sizable new editor surface plus new `ajv`-based validation and undo/redo state management; risk is mainly UI/state edge cases and validation performance/behavior across drafts.
> 
> **Overview**
> Adds a new `JsonSchemaEditor` component (exported via package `exports` and `src/index.ts`) that supports **form**, **raw JSON**, and **diff** workflows, including editor-level undo/redo/revert and copy-to-clipboard.
> 
> Introduces a new reactive `createEditorState` container with guarded prop synchronization (`readonly`, `draftOverride`, `schemaKey` reload), change/revert/validate callbacks, and debounced validation with a size gate to defer expensive AJV compilation for large drafts.
> 
> Implements form editing via recursive `PropertyEditor`/`PropertyList` (including stable keys for composition branches) and adds AJV-backed draft-aware meta-schema + compile checks (`json-schema-validator.ts`). Adds component styling, unit tests, and playground examples, and introduces `useHistory` as a new exported utility for generic undo/redo state.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 384a141c7f42ed923d9f2d986bdcb4370fd24746. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->