### PR TITLE
Add CopyButton iconOnly mode and code-block syntax highlighting

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -150,6 +150,7 @@
       "version": "0.0.1",
       "dependencies": {
         "cinder": "workspace:*",
+        "shiki": "^3.0.0",
       },
       "devDependencies": {
         "@types/bun": "^1.3.11",

--- a/packages/components/src/components/code-block.svelte
+++ b/packages/components/src/components/code-block.svelte
@@ -2,11 +2,9 @@
   /**
    * Props for the CodeBlock component.
    *
-   * Renders preformatted code in a `<pre><code>` element. **No syntax
-   * highlighting** — that's a consumer concern (depict already owns Shiki).
-   * If you want highlighting, run the consumer's highlighter on the source
-   * and pass the resulting HTML through a different surface, or compose
-   * your own component on top of these primitives.
+   * Renders preformatted code in a `<pre><code>` element. No syntax
+   * highlighting is applied by default. Consumers can provide a highlighter when they
+   * own the syntax-highlighting dependency and output sanitization contract.
    */
   export type CodeBlockProps = {
     /** The code to render. */
@@ -15,6 +13,8 @@
     language?: string;
     /** When true, render a copy button in the header. */
     copyable?: boolean;
+    /** @param highlighter — function that returns syntax-highlighted HTML. Return value is rendered with `{@html}` and is the caller's responsibility to ensure it is safe (e.g. that input code is escaped). Shiki's `codeToHtml` is a safe default. */
+    highlighter?: (code: string, lang: string) => string | Promise<string>;
     /** Additional class names merged with `.cinder-code-block`. */
     class?: string;
   };
@@ -24,7 +24,33 @@
   import CopyButton from './copy-button.svelte';
   import { cn } from '../utilities/class-names.ts';
 
-  let { code, language, copyable = false, class: className }: CodeBlockProps = $props();
+  let {
+    code,
+    language,
+    copyable = false,
+    highlighter,
+    class: className,
+  }: CodeBlockProps = $props();
+
+  let highlighted = $state<string | null>(null);
+
+  $effect(() => {
+    if (!language || !highlighter) {
+      highlighted = null;
+      return;
+    }
+    let cancelled = false;
+    Promise.resolve(highlighter(code, language))
+      .then((html) => {
+        if (!cancelled) highlighted = html;
+      })
+      .catch(() => {
+        if (!cancelled) highlighted = null;
+      });
+    return () => {
+      cancelled = true;
+    };
+  });
 </script>
 
 <div class={cn('cinder-code-block', className)}>
@@ -34,9 +60,23 @@
         <span class="cinder-code-block__language">{language}</span>
       {/if}
       {#if copyable}
-        <CopyButton value={code} class="cinder-code-block__copy" label="Copy code" />
+        <CopyButton
+          value={code}
+          class="cinder-code-block__copy"
+          label="Copy code"
+          iconOnly={true}
+        />
       {/if}
     </header>
   {/if}
-  <pre class="cinder-code-block__pre"><code class="cinder-code-block__code">{code}</code></pre>
+  <svelte:boundary>
+    {#if highlighted}
+      {@html highlighted}
+    {:else}
+      <pre class="cinder-code-block__pre"><code class="cinder-code-block__code">{code}</code></pre>
+    {/if}
+    {#snippet failed()}
+      <pre class="cinder-code-block__pre"><code class="cinder-code-block__code">{code}</code></pre>
+    {/snippet}
+  </svelte:boundary>
 </div>

--- a/packages/components/src/components/code-block.svelte
+++ b/packages/components/src/components/code-block.svelte
@@ -91,6 +91,7 @@
           value={code}
           class="cinder-code-block__copy"
           label="Copy code"
+          copiedLabel="Code copied"
           iconOnly={true}
         />
       {/if}

--- a/packages/components/src/components/code-block.svelte
+++ b/packages/components/src/components/code-block.svelte
@@ -2,9 +2,11 @@
   /**
    * Props for the CodeBlock component.
    *
-   * Renders preformatted code in a `<pre><code>` element. No syntax
-   * highlighting is applied by default. Consumers can provide a highlighter when they
-   * own the syntax-highlighting dependency and output sanitization contract.
+   * Renders preformatted code in a `<pre><code>` element. Plain code is
+   * Svelte-text-interpolated so HTML entities are escaped automatically.
+   * Syntax highlighting is opt-in via the `highlighter` prop — when provided,
+   * the highlighter's HTML output replaces the entire `<pre><code>` block and
+   * is rendered via `{@html}`, so the caller owns the sanitization contract.
    */
   export type CodeBlockProps = {
     /** The code to render. */
@@ -13,7 +15,22 @@
     language?: string;
     /** When true, render a copy button in the header. */
     copyable?: boolean;
-    /** @param highlighter — function that returns syntax-highlighted HTML. Return value is rendered with `{@html}` and is the caller's responsibility to ensure it is safe (e.g. that input code is escaped). Shiki's `codeToHtml` is a safe default. */
+    /**
+     * Optional syntax highlighter. Receives the raw `code` and `lang` and must
+     * return an HTML string (sync or async). The return value is rendered with
+     * `{@html}` and replaces the default `<pre><code>` markup — including the
+     * `cinder-code-block__pre` / `__code` classes — so the caller is also
+     * responsible for matching any structural CSS the consumer relies on
+     * (Shiki's own `<pre class="shiki ...">` output covers most cases).
+     *
+     * The return value is rendered verbatim with `{@html}`. It is the caller's
+     * responsibility to ensure the output is safe — specifically, that the
+     * input `code` is escaped. Shiki's `codeToHtml` escapes input by default
+     * and is the recommended choice.
+     *
+     * Only invoked when `language` is also set. Theme/color-scheme selection
+     * is the caller's responsibility — pass it through closure.
+     */
     highlighter?: (code: string, lang: string) => string | Promise<string>;
     /** Additional class names merged with `.cinder-code-block`. */
     class?: string;
@@ -39,14 +56,24 @@
       highlighted = null;
       return;
     }
+    // Drop any stale highlighted output before starting a new request so
+    // a code/lang change can't leave the previous render visible while the
+    // new request is in flight.
+    highlighted = null;
     let cancelled = false;
-    Promise.resolve(highlighter(code, language))
-      .then((html) => {
+    // The highlighter may throw synchronously OR reject. Promise.resolve()
+    // alone wouldn't catch a sync throw — wrap it in an async IIFE so
+    // both failure modes hit the same .catch.
+    void (async () => {
+      try {
+        const html = await highlighter(code, language);
         if (!cancelled) highlighted = html;
-      })
-      .catch(() => {
+      } catch (error) {
         if (!cancelled) highlighted = null;
-      });
+        // Surface to the developer without breaking the graceful fallback.
+        console.warn('[cinder/CodeBlock] highlighter threw:', error);
+      }
+    })();
     return () => {
       cancelled = true;
     };
@@ -69,8 +96,11 @@
       {/if}
     </header>
   {/if}
+  <!-- The svelte:boundary catches errors thrown during render of {@html highlighted}
+       (e.g. a malformed HTML string that breaks Svelte's reconciliation). Sync/async
+       errors from the highlighter ITSELF are caught above; this is the secondary net. -->
   <svelte:boundary>
-    {#if highlighted}
+    {#if highlighted !== null}
       {@html highlighted}
     {:else}
       <pre class="cinder-code-block__pre"><code class="cinder-code-block__code">{code}</code></pre>

--- a/packages/components/src/components/code-block.test.ts
+++ b/packages/components/src/components/code-block.test.ts
@@ -8,8 +8,8 @@ setupHappyDom();
 const { render, waitFor } = await import('@testing-library/svelte');
 const { default: CodeBlock } = await import('./code-block.svelte');
 
-async function renderHighlightedCode() {
-  return '<pre><code class="highlighted">const x = 1;</code></pre>';
+async function renderHighlightedCode(code: string, _lang: string): Promise<string> {
+  return `<pre class="shiki"><code><span class="highlighted-token">${code}</span></code></pre>`;
 }
 
 describe('CodeBlock', () => {
@@ -42,25 +42,43 @@ describe('CodeBlock', () => {
     expect(container.querySelector('pre code')?.textContent).toBe('const x = 1;');
   });
 
-  test('highlighter prop output is rendered verbatim via html', async () => {
+  test('plain code path escapes HTML special characters', () => {
+    // Svelte text interpolation `{code}` escapes by default. This regression test
+    // catches a future refactor that accidentally moves the no-highlighter path
+    // into an `{@html}` render and exposes XSS.
+    const { container } = render(CodeBlock, { code: '<script>alert(1)</script>' });
+    const code = container.querySelector('.cinder-code-block__code');
+    expect(code?.textContent).toBe('<script>alert(1)</script>');
+    // No actual <script> element should be present in the rendered DOM.
+    expect(container.querySelector('script')).toBeNull();
+  });
+
+  test('highlighter output replaces the plain pre/code and renders verbatim', async () => {
     const { container } = render(CodeBlock, {
       code: 'const x = 1;',
       language: 'js',
       highlighter: renderHighlightedCode,
     });
     await waitFor(() => {
-      expect(container.querySelector('.highlighted')).not.toBeNull();
+      const token = container.querySelector('.highlighted-token');
+      expect(token).not.toBeNull();
+      expect(token?.textContent).toBe('const x = 1;');
+      // The Shiki-style <pre.shiki> replaces the default cinder-code-block__pre.
+      expect(container.querySelector('.cinder-code-block__pre')).toBeNull();
     });
   });
 
-  test('highlighter prop documents the trust boundary in source', async () => {
-    // The component renders highlighter output via {@html} without sanitization.
-    // The JSDoc comment on the highlighter prop is the contract that tells
-    // consumers they own the safety boundary. If this comment goes missing,
-    // a future contributor might forget the trust boundary and add a "sanitize
-    // before render" path that would silently break Shiki's spans.
-    const source = await Bun.file(new URL('./code-block.svelte', import.meta.url).pathname).text();
-    expect(source).toContain('rendered with `{@html}`');
-    expect(source).toContain("caller's responsibility");
+  test('synchronous highlighter exception falls back to plain code', async () => {
+    const { container } = render(CodeBlock, {
+      code: 'const x = 1;',
+      language: 'js',
+      highlighter: () => {
+        throw new Error('boom');
+      },
+    });
+    // The async wrapper inside the effect catches sync throws and flips back to plain.
+    await waitFor(() => {
+      expect(container.querySelector('.cinder-code-block__code')?.textContent).toBe('const x = 1;');
+    });
   });
 });

--- a/packages/components/src/components/code-block.test.ts
+++ b/packages/components/src/components/code-block.test.ts
@@ -5,8 +5,12 @@ import { setupHappyDom } from '../test/happy-dom.ts';
 
 setupHappyDom();
 
-const { render } = await import('@testing-library/svelte');
+const { render, waitFor } = await import('@testing-library/svelte');
 const { default: CodeBlock } = await import('./code-block.svelte');
+
+async function renderHighlightedCode() {
+  return '<pre><code class="highlighted">const x = 1;</code></pre>';
+}
 
 describe('CodeBlock', () => {
   test('renders code in a <pre><code> pair', () => {
@@ -31,5 +35,32 @@ describe('CodeBlock', () => {
     const { container } = render(CodeBlock, { code: 'x', copyable: true });
     expect(container.querySelector('.cinder-code-block__header')).not.toBeNull();
     expect(container.querySelector('.cinder-copy-button')).not.toBeNull();
+  });
+
+  test('no highlighter prop renders plain unhighlighted code', () => {
+    const { container } = render(CodeBlock, { code: 'const x = 1;' });
+    expect(container.querySelector('pre code')?.textContent).toBe('const x = 1;');
+  });
+
+  test('highlighter prop output is rendered verbatim via html', async () => {
+    const { container } = render(CodeBlock, {
+      code: 'const x = 1;',
+      language: 'js',
+      highlighter: renderHighlightedCode,
+    });
+    await waitFor(() => {
+      expect(container.querySelector('.highlighted')).not.toBeNull();
+    });
+  });
+
+  test('highlighter prop documents the trust boundary in source', async () => {
+    // The component renders highlighter output via {@html} without sanitization.
+    // The JSDoc comment on the highlighter prop is the contract that tells
+    // consumers they own the safety boundary. If this comment goes missing,
+    // a future contributor might forget the trust boundary and add a "sanitize
+    // before render" path that would silently break Shiki's spans.
+    const source = await Bun.file(new URL('./code-block.svelte', import.meta.url).pathname).text();
+    expect(source).toContain('rendered with `{@html}`');
+    expect(source).toContain("caller's responsibility");
   });
 });

--- a/packages/components/src/components/code-block.test.ts
+++ b/packages/components/src/components/code-block.test.ts
@@ -37,6 +37,17 @@ describe('CodeBlock', () => {
     expect(container.querySelector('.cinder-copy-button')).not.toBeNull();
   });
 
+  test('copyable=true renders the copy button in iconOnly mode (no text label)', () => {
+    // The component hardcodes iconOnly={true} on its embedded CopyButton because
+    // headers are space-constrained. This test guards against an accidental
+    // change to that contract.
+    const { container } = render(CodeBlock, { code: 'x', copyable: true });
+    const button = container.querySelector('.cinder-copy-button');
+    expect(button).not.toBeNull();
+    expect(button?.querySelector('svg')).not.toBeNull();
+    expect(button?.textContent?.trim()).toBe('');
+  });
+
   test('no highlighter prop renders plain unhighlighted code', () => {
     const { container } = render(CodeBlock, { code: 'const x = 1;' });
     expect(container.querySelector('pre code')?.textContent).toBe('const x = 1;');
@@ -79,6 +90,22 @@ describe('CodeBlock', () => {
     // The async wrapper inside the effect catches sync throws and flips back to plain.
     await waitFor(() => {
       expect(container.querySelector('.cinder-code-block__code')?.textContent).toBe('const x = 1;');
+    });
+  });
+
+  test('async highlighter rejection falls back to plain code', async () => {
+    // Companion to the sync-throw test above. Verifies the async branch of the
+    // catch handler — a highlighter that returns a rejected Promise must also
+    // produce the graceful plain-code fallback.
+    const { container } = render(CodeBlock, {
+      code: 'const y = 2;',
+      language: 'js',
+      highlighter: async () => {
+        throw new Error('async boom');
+      },
+    });
+    await waitFor(() => {
+      expect(container.querySelector('.cinder-code-block__code')?.textContent).toBe('const y = 2;');
     });
   });
 });

--- a/packages/components/src/components/copy-button.svelte
+++ b/packages/components/src/components/copy-button.svelte
@@ -15,6 +15,9 @@
     confirmDuration?: number;
     /** Accessible label for the button when no children are supplied. */
     label?: string;
+    /** Render the button with only an icon and a visually hidden label.
+     * When true, defaults to a Copy icon (idle) and a Check icon (copied). */
+    iconOnly?: boolean;
     /** Additional class names merged with `.cinder-copy-button`. */
     class?: string;
     /** Default content (idle state). */
@@ -27,6 +30,7 @@
 <script lang="ts">
   import { onDestroy } from 'svelte';
 
+  import { Check, Copy } from './icons/index.ts';
   import { copyToClipboard } from '../utilities/clipboard.ts';
   import { cn } from '../utilities/class-names.ts';
 
@@ -34,6 +38,7 @@
     value,
     confirmDuration = 1500,
     label,
+    iconOnly,
     class: className,
     children,
     confirmation,
@@ -67,10 +72,20 @@
 >
   {#if copied && confirmation}
     {@render confirmation()}
+  {:else if copied && iconOnly}
+    <span aria-hidden="true">
+      <Check class="icon-sm" />
+    </span>
+    <span class="sr-only">Copied</span>
   {:else if copied}
     Copied
   {:else if children}
     {@render children()}
+  {:else if iconOnly}
+    <span aria-hidden="true">
+      <Copy class="icon-sm" />
+    </span>
+    <span class="sr-only">{label ?? 'Copy to clipboard'}</span>
   {:else}
     Copy
   {/if}

--- a/packages/components/src/components/copy-button.svelte
+++ b/packages/components/src/components/copy-button.svelte
@@ -13,8 +13,13 @@
     value: string;
     /** Duration in ms to show the confirmation state. Default 1500. */
     confirmDuration?: number;
-    /** Accessible label for the button when no children are supplied. */
+    /** Accessible label for the idle state. Defaults to "Copy to clipboard". */
     label?: string;
+    /** Accessible label for the copied state — what `aria-live="polite"` announces
+     * when the copy succeeds. Defaults to "Copied". Override this when `label` is
+     * customized so the live-region announcement reflects what just happened
+     * (e.g. label="Copy code" + copiedLabel="Code copied"). */
+    copiedLabel?: string;
     /** Render the button with only an icon and a visually hidden label.
      * When true, defaults to a Copy icon (idle) and a Check icon (copied). */
     iconOnly?: boolean;
@@ -38,6 +43,7 @@
     value,
     confirmDuration = 1500,
     label,
+    copiedLabel,
     iconOnly = false,
     class: className,
     children,
@@ -62,11 +68,14 @@
   });
 </script>
 
+<!-- aria-label MUST flip on `copied` so the polite live region announces the
+     state change. Without that flip, screen readers receive no feedback when
+     copy succeeds in iconOnly mode (the visible icon is aria-hidden). -->
 <button
   type="button"
   class={cn('cinder-copy-button', className)}
   data-cinder-copied={copied || undefined}
-  aria-label={label ?? (copied ? 'Copied' : 'Copy to clipboard')}
+  aria-label={copied ? (copiedLabel ?? 'Copied') : (label ?? 'Copy to clipboard')}
   aria-live="polite"
   onclick={handleClick}
 >

--- a/packages/components/src/components/copy-button.svelte
+++ b/packages/components/src/components/copy-button.svelte
@@ -38,7 +38,7 @@
     value,
     confirmDuration = 1500,
     label,
-    iconOnly,
+    iconOnly = false,
     class: className,
     children,
     confirmation,
@@ -70,22 +70,20 @@
   aria-live="polite"
   onclick={handleClick}
 >
+  <!-- Accessible name for every branch comes from `aria-label` on the button.
+       In iconOnly mode the icon is decorative — `aria-hidden` keeps it out of the
+       accessibility tree. The `aria-live` region on the button announces state
+       changes (Copy → Copied) without needing a redundant sr-only label. -->
   {#if copied && confirmation}
     {@render confirmation()}
   {:else if copied && iconOnly}
-    <span aria-hidden="true">
-      <Check class="icon-sm" />
-    </span>
-    <span class="sr-only">Copied</span>
+    <Check class="icon-sm" aria-hidden="true" />
   {:else if copied}
     Copied
   {:else if children}
     {@render children()}
   {:else if iconOnly}
-    <span aria-hidden="true">
-      <Copy class="icon-sm" />
-    </span>
-    <span class="sr-only">{label ?? 'Copy to clipboard'}</span>
+    <Copy class="icon-sm" aria-hidden="true" />
   {:else}
     Copy
   {/if}

--- a/packages/components/src/components/copy-button.test.ts
+++ b/packages/components/src/components/copy-button.test.ts
@@ -1,5 +1,5 @@
 /// <reference lib="dom" />
-import { describe, expect, test } from 'bun:test';
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
 
 import { setupHappyDom } from '../test/happy-dom.ts';
 
@@ -8,7 +8,41 @@ setupHappyDom();
 const { render, fireEvent, waitFor } = await import('@testing-library/svelte');
 const { default: CopyButton } = await import('./copy-button.svelte');
 
+type ClipboardLike = { writeText: (text: string) => Promise<void> };
+
+let originalClipboard: ClipboardLike | undefined;
+
+function mockClipboard(writes: string[] = []): ClipboardLike {
+  const clipboard: ClipboardLike = {
+    writeText: async (text: string) => {
+      writes.push(text);
+    },
+  };
+  Object.defineProperty(globalThis.navigator, 'clipboard', {
+    configurable: true,
+    value: clipboard,
+  });
+  return clipboard;
+}
+
 describe('CopyButton', () => {
+  beforeEach(() => {
+    originalClipboard = globalThis.navigator.clipboard as unknown as ClipboardLike | undefined;
+  });
+
+  afterEach(() => {
+    if (originalClipboard) {
+      Object.defineProperty(globalThis.navigator, 'clipboard', {
+        configurable: true,
+        value: originalClipboard,
+      });
+    } else {
+      // Restore the absence of clipboard if it wasn't there before.
+      // happy-dom may not provide one by default; deleting keeps tests clean.
+      delete (globalThis.navigator as unknown as { clipboard?: ClipboardLike }).clipboard;
+    }
+  });
+
   test('renders a button with a default accessible label', () => {
     const { container } = render(CopyButton, { value: 'hello' });
     const button = container.querySelector('button');
@@ -28,14 +62,7 @@ describe('CopyButton', () => {
 
   test('clicking the button writes value to the clipboard and flashes confirmation', async () => {
     const writes: string[] = [];
-    Object.defineProperty(globalThis.navigator, 'clipboard', {
-      configurable: true,
-      value: {
-        writeText: async (text: string) => {
-          writes.push(text);
-        },
-      },
-    });
+    mockClipboard(writes);
 
     const { container } = render(CopyButton, { value: 'payload' });
     const button = container.querySelector('button') as HTMLButtonElement;
@@ -51,32 +78,39 @@ describe('CopyButton', () => {
   test('iconOnly mode renders Copy icon in idle state', () => {
     const { container } = render(CopyButton, { value: 'hello', iconOnly: true });
     const button = container.querySelector('button');
-    // Should contain an SVG (the Copy icon) and a screen-reader span
+    // The icon SVG is the only content; aria-label on the button carries the accessible name.
     expect(button?.querySelector('svg')).not.toBeNull();
-    expect(button?.querySelector('.sr-only')?.textContent).toBe('Copy to clipboard');
+    expect(button?.querySelector('svg')?.getAttribute('aria-hidden')).toBe('true');
+    expect(button?.getAttribute('aria-label')).toBe('Copy to clipboard');
+    // No redundant sr-only label — aria-label is the single source of truth.
+    expect(button?.querySelector('.sr-only')).toBeNull();
   });
 
-  test('iconOnly mode renders Check icon after click', async () => {
-    Object.defineProperty(globalThis.navigator, 'clipboard', {
-      configurable: true,
-      value: { writeText: async () => {} },
-    });
+  test('iconOnly mode swaps icon and aria-label after click', async () => {
+    mockClipboard();
     const { container } = render(CopyButton, { value: 'hello', iconOnly: true });
     const button = container.querySelector('button') as HTMLButtonElement;
+    const idleSvgPath = button.querySelector('svg path')?.getAttribute('d');
+
     await fireEvent.click(button);
+
     await waitFor(() => {
-      expect(button.querySelector('svg')).not.toBeNull();
-      expect(button.querySelector('.sr-only')?.textContent).toBe('Copied');
+      // aria-label flips to "Copied" (announced via aria-live="polite").
+      expect(button.getAttribute('aria-label')).toBe('Copied');
+      expect(button.hasAttribute('data-cinder-copied')).toBe(true);
+      // The rendered SVG changes from Copy to Check — verify the path data differs
+      // so the icon swap actually happened, not just the aria-label.
+      const copiedSvgPath = button.querySelector('svg path')?.getAttribute('d');
+      expect(copiedSvgPath).toBeDefined();
+      expect(copiedSvgPath).not.toBe(idleSvgPath);
     });
   });
 
-  test('custom children with no confirmation shows "Copied" text when copied', async () => {
-    Object.defineProperty(globalThis.navigator, 'clipboard', {
-      configurable: true,
-      value: { writeText: async () => {} },
-    });
-    // Render without confirmation snippet — children are provided but confirmation is not
-    // After click, should show "Copied" (regression for bug where children+no-confirmation never showed copied feedback)
+  test('default mode (no children, no confirmation) shows "Copied" text after click', async () => {
+    // Regression test for the bug Codex caught in plan-review:
+    // when neither `children` nor `confirmation` snippets are provided,
+    // the copied branch must fall through to the literal "Copied" text.
+    mockClipboard();
     const { container } = render(CopyButton, { value: 'hello' });
     const button = container.querySelector('button') as HTMLButtonElement;
     await fireEvent.click(button);

--- a/packages/components/src/components/copy-button.test.ts
+++ b/packages/components/src/components/copy-button.test.ts
@@ -55,9 +55,41 @@ describe('CopyButton', () => {
     expect(container.querySelector('button')?.textContent?.trim()).toBe('Copy');
   });
 
-  test('custom label overrides aria-label', () => {
+  test('custom label sets the idle aria-label', () => {
     const { container } = render(CopyButton, { value: 'x', label: 'Copy snippet' });
     expect(container.querySelector('button')?.getAttribute('aria-label')).toBe('Copy snippet');
+  });
+
+  test('aria-label flips to copiedLabel after click even when label is set', async () => {
+    // Regression test for the bug Cursor Bugbot caught: when a consumer passes
+    // a static `label`, the `aria-label` short-circuited and never changed to
+    // "Copied". Combined with iconOnly (icons are aria-hidden), screen readers
+    // received no feedback when copy succeeded. The fix: aria-label flips on
+    // copied state regardless of whether label is set.
+    mockClipboard();
+    const { container } = render(CopyButton, {
+      value: 'x',
+      label: 'Copy code',
+      copiedLabel: 'Code copied',
+      iconOnly: true,
+    });
+    const button = container.querySelector('button') as HTMLButtonElement;
+    expect(button.getAttribute('aria-label')).toBe('Copy code');
+    await fireEvent.click(button);
+    await waitFor(() => {
+      expect(button.getAttribute('aria-label')).toBe('Code copied');
+    });
+  });
+
+  test('aria-label flips to default "Copied" when no copiedLabel provided', async () => {
+    mockClipboard();
+    const { container } = render(CopyButton, { value: 'x', label: 'Copy code' });
+    const button = container.querySelector('button') as HTMLButtonElement;
+    expect(button.getAttribute('aria-label')).toBe('Copy code');
+    await fireEvent.click(button);
+    await waitFor(() => {
+      expect(button.getAttribute('aria-label')).toBe('Copied');
+    });
   });
 
   test('clicking the button writes value to the clipboard and flashes confirmation', async () => {

--- a/packages/components/src/components/copy-button.test.ts
+++ b/packages/components/src/components/copy-button.test.ts
@@ -47,4 +47,41 @@ describe('CopyButton', () => {
       expect(button.textContent?.trim()).toBe('Copied');
     });
   });
+
+  test('iconOnly mode renders Copy icon in idle state', () => {
+    const { container } = render(CopyButton, { value: 'hello', iconOnly: true });
+    const button = container.querySelector('button');
+    // Should contain an SVG (the Copy icon) and a screen-reader span
+    expect(button?.querySelector('svg')).not.toBeNull();
+    expect(button?.querySelector('.sr-only')?.textContent).toBe('Copy to clipboard');
+  });
+
+  test('iconOnly mode renders Check icon after click', async () => {
+    Object.defineProperty(globalThis.navigator, 'clipboard', {
+      configurable: true,
+      value: { writeText: async () => {} },
+    });
+    const { container } = render(CopyButton, { value: 'hello', iconOnly: true });
+    const button = container.querySelector('button') as HTMLButtonElement;
+    await fireEvent.click(button);
+    await waitFor(() => {
+      expect(button.querySelector('svg')).not.toBeNull();
+      expect(button.querySelector('.sr-only')?.textContent).toBe('Copied');
+    });
+  });
+
+  test('custom children with no confirmation shows "Copied" text when copied', async () => {
+    Object.defineProperty(globalThis.navigator, 'clipboard', {
+      configurable: true,
+      value: { writeText: async () => {} },
+    });
+    // Render without confirmation snippet — children are provided but confirmation is not
+    // After click, should show "Copied" (regression for bug where children+no-confirmation never showed copied feedback)
+    const { container } = render(CopyButton, { value: 'hello' });
+    const button = container.querySelector('button') as HTMLButtonElement;
+    await fireEvent.click(button);
+    await waitFor(() => {
+      expect(button.textContent?.trim()).toBe('Copied');
+    });
+  });
 });

--- a/packages/components/src/styles/components/code-block.css
+++ b/packages/components/src/styles/components/code-block.css
@@ -1,8 +1,10 @@
 /* ========================================
  * CODE BLOCK
  * Preformatted code with optional language label and copy button.
- * No syntax highlighting — consumers run their own highlighter and pass
- * highlighted HTML through a different surface if needed.
+ * Syntax highlighting is opt-in via the `highlighter` prop. Highlighter
+ * output replaces the __pre/__code markup entirely, so consumers using a
+ * non-Shiki highlighter are responsible for matching any structural CSS
+ * (overflow-x, mono font, padding) on their own <pre> element.
  * ======================================== */
 
 .cinder-code-block {

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -12,7 +12,8 @@
     "validate": "bun run src/validate-playground.ts"
   },
   "dependencies": {
-    "cinder": "workspace:*"
+    "cinder": "workspace:*",
+    "shiki": "^3.0.0"
   },
   "devDependencies": {
     "@types/bun": "^1.3.11",

--- a/packages/playground/src/examples/code-block/with-language.example.svelte
+++ b/packages/playground/src/examples/code-block/with-language.example.svelte
@@ -4,6 +4,7 @@
 </script>
 
 <script lang="ts">
+  import { codeToHtml } from 'shiki';
   import { CodeBlock } from '../../../../components/src/index.ts';
 
   const code = `SELECT id, name, created_at
@@ -11,6 +12,10 @@ FROM users
 WHERE active = true
 ORDER BY created_at DESC
 LIMIT 10;`;
+
+  async function highlighter(source: string, lang: string): Promise<string> {
+    return codeToHtml(source, { lang, theme: 'github-light' });
+  }
 </script>
 
-<CodeBlock {code} language="sql" copyable />
+<CodeBlock {code} language="sql" copyable {highlighter} />


### PR DESCRIPTION
## Summary

Adds two related fixes from the playground audit:

1. **CopyButton `iconOnly` opt-in** — non-breaking. Default behavior preserves the legacy "Copy" / "Copied" text; `iconOnly={true}` renders just the Lucide Copy/Check icons with the button's `aria-label` carrying the accessible name.

2. **`code-block` syntax highlighting** — opt-in via a new `highlighter?: (code, lang) => string | Promise<string>` prop. Component renders plain code first paint and swaps in highlighter output via `{@html}` once the promise resolves. Wrapped in `<svelte:boundary>` for fallback if `{@html}` reconciliation throws.

The component package itself ships zero highlighter dependencies. The playground story passes a Shiki-backed highlighter to demonstrate the pattern.

## Spike-driven architecture decision

The plan started with shiki bundled directly into `@cinder/components`. The pre-implementation spike measured the bundle delta:

| Metric | Baseline | In-house Shiki | Final (escape-hatch) |
|---|---|---|---|
| Filesystem | 3.2M | **24M** | 3.2M |
| Gzipped JS | 145.8KB | **1.83MB** | 145.9KB |

In-house Shiki blew through the plan's 200KB compressed-delta gate by **8x**. Took the escape-hatch: shiki lives in `packages/playground`, the component exposes a `highlighter?` callback. Final bundle delta: **+124 bytes gzipped** (≈zero).

## Trust boundary

The `highlighter` prop's return value is rendered with `{@html}` and is not sanitized by the component — that is the caller's responsibility. The JSDoc on the prop documents this contract explicitly. Shiki's `codeToHtml` is the documented safe default (escapes input by default).

The plain-code path (no highlighter, or no language) uses Svelte's text interpolation `{code}`, which auto-escapes. A regression test asserts that `<script>alert(1)</script>` renders as text, not an executable element.

## Files changed

- `packages/components/src/components/copy-button.svelte` — new `iconOnly` prop
- `packages/components/src/components/code-block.svelte` — new `highlighter?` prop, async lifecycle, sync-throw + async-rejection handling, stale-render guard, empty-string handling, `<svelte:boundary>` fallback, expanded JSDoc
- `packages/components/src/styles/components/code-block.css` — comment updated to reflect highlighter is now a real prop
- `packages/components/src/components/copy-button.test.ts` — clipboard mock has beforeEach/afterEach teardown; iconOnly tests verify icon swap by SVG path data; regression test for "no children + no confirmation"
- `packages/components/src/components/code-block.test.ts` — XSS regression test for plain path; sync-throw fallback test; async-rejection fallback test; iconOnly integration test; strengthened highlighter assertion
- `packages/playground/package.json` — adds `shiki ^3.0.0`
- `packages/playground/src/examples/code-block/with-language.example.svelte` — passes a Shiki-backed `highlighter`

## Verification

- Lint: 0 errors, 8 pre-existing warnings.
- Typecheck: 0 errors.
- Tests: **524 pass, 0 fail** (was 515 baseline → +9 new tests for D).
- Build: passes.
- Bundle: 3.2M / 145,980 bytes gzipped (+124 bytes vs baseline 145,856).
- Visual: `/page/code-block` renders Shiki-highlighted SQL (`pre.shiki github-light`) with an icon-only copy button.

## Review committee

Pre-reviewed by:
- typescript-expert
- testing-expert
- simplicity-engineer
- frontend-architect
- security-reviewer
- junior-engineer
- Codex (gpt-5.4, xhigh reasoning)

2 rounds. Round 1 produced 11 must-fix items across all 6 reviewers — all addressed. Round 2: all 7 reviewers APPROVED. Two non-blocking suggestions implemented before merge (codeblock+iconOnly integration test, async-rejection fallback test).

Notable user decisions during review:
- **Theme context bag deferred** — adding a `context: { theme }` arg now is speculative without a real consumer. JSDoc documents that theme selection is the caller's responsibility (closure pattern).
- **`<svelte:boundary>` kept** despite simplicity-engineer's call to remove. The catch handler covers highlighter errors; the boundary covers `{@html}` render-time errors. Different surfaces. Comment in source explains.
- **JSDoc-source assertion test removed** per testing-expert + simplicity-engineer; behavior is enforced by the actual highlighter test.

## Test plan

- [x] Lint, typecheck, tests, build all pass
- [x] `/page/code-block/with-language` shows Shiki-highlighted SQL
- [x] CopyButton on the code-block has `aria-label="Copy code"`, single SVG, no `.sr-only` span
- [x] CopyButton standalone (without `iconOnly`) still shows "Copy"/"Copied" text — backwards compatible
- [ ] Click through other code-block consumers (none exist in this PR's scope)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces an opt-in `{@html}` rendering path for `CodeBlock` via a caller-supplied highlighter, which can affect XSS/sanitization and rendering stability if misused. Behavior is guarded with fallback logic and expanded tests, but it still changes a security-sensitive surface area.
> 
> **Overview**
> **Adds two opt-in UI capabilities to `@cinder/components`:** `CopyButton` gains `iconOnly` (plus `copiedLabel`) to render Copy/Check icons while ensuring `aria-label` flips on copy for screen-reader feedback.
> 
> **`CodeBlock` now supports optional syntax highlighting** via a new `highlighter(code, lang)` callback that can be async and swaps in returned HTML (rendered with `{@html}`) with cancellation/error fallback and a `<svelte:boundary>` safety net; it also updates the embedded copy button to be icon-only.
> 
> Updates tests to cover accessibility label flipping, icon-only behavior, HTML escaping on the plain-code path, and highlighter success/failure fallbacks, and adds `shiki` to the playground with an example passing a Shiki-backed `highlighter`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cc383a2ee3887216ad1db09420b3a64e94afb7b8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->