### PR TITLE
Fix code block empty highlighter fallback

### DIFF
--- a/packages/components/fixtures/node-consumer/src/render.ts
+++ b/packages/components/fixtures/node-consumer/src/render.ts
@@ -25,6 +25,7 @@ import {
   Textarea,
   Toggle,
   Tooltip,
+  useHistory,
 } from 'cinder';
 
 // Minimal no-op snippet for components that require children.
@@ -89,3 +90,10 @@ for (const { name, component } of snippetComponents) {
   }
   process.stdout.write(`<!-- ${name} imported OK -->\n`);
 }
+
+if (typeof useHistory !== 'function') {
+  process.stderr.write('useHistory is not a function — import failed\n');
+  process.exit(1);
+}
+
+process.stdout.write('<!-- useHistory imported OK -->\n');

--- a/packages/components/fixtures/sveltekit-consumer/src/routes/+page.svelte
+++ b/packages/components/fixtures/sveltekit-consumer/src/routes/+page.svelte
@@ -22,6 +22,7 @@
     Textarea,
     Toggle,
     Tooltip,
+    useHistory,
   } from 'cinder';
   import '../app.css';
 
@@ -33,9 +34,10 @@
   let modalOpen = $state(false);
   let dropdownOpen = $state(false);
   let expandedIds = $state<string[]>([]);
+  const useHistoryExportIsFunction = typeof useHistory === 'function';
 </script>
 
-<main>
+<main data-use-history-import={useHistoryExportIsFunction ? 'available' : 'missing'}>
   <h1>cinder sveltekit consumer fixture — barrel imports</h1>
 
   <section aria-label="Alert">

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -311,6 +311,7 @@
     "src/utilities/stringify.ts",
     "src/utilities/truncate.ts",
     "src/utilities/use-announcer.svelte.ts",
+    "src/utilities/use-history.svelte.ts",
     "src/utilities/use-id.ts",
     "src/utilities/use-toast.ts",
     "README.md"

--- a/packages/components/scripts/validate-consumers.ts
+++ b/packages/components/scripts/validate-consumers.ts
@@ -219,6 +219,7 @@ const tarballExpectations: TarballExpectations = {
     'package/package.json',
     'package/src/index.ts',
     'package/src/utilities/class-names.ts',
+    'package/src/utilities/use-history.svelte.ts',
     'package/src/styles/index.css',
     'package/src/styles/tokens.css',
     'package/src/styles/tokens-base.css',
@@ -536,6 +537,9 @@ async function runNodeFixture(): Promise<void> {
     // Verify snippet-only components were imported (marked "OK" in render.ts output).
     if (!renderedOutput.includes('Card imported OK')) {
       fail(`node render output missing "Card imported OK" — subpath import failed`);
+    }
+    if (!renderedOutput.includes('useHistory imported OK')) {
+      fail(`node render output missing "useHistory imported OK" — barrel utility import failed`);
     }
   } finally {
     restoreManifest();

--- a/packages/components/src/components/code-block.svelte
+++ b/packages/components/src/components/code-block.svelte
@@ -67,7 +67,7 @@
     void (async () => {
       try {
         const html = await highlighter(code, language);
-        if (!cancelled) highlighted = html;
+        if (!cancelled) highlighted = html === '' ? null : html;
       } catch (error) {
         if (!cancelled) highlighted = null;
         // Surface to the developer without breaking the graceful fallback.

--- a/packages/components/src/components/code-block.test.ts
+++ b/packages/components/src/components/code-block.test.ts
@@ -108,4 +108,28 @@ describe('CodeBlock', () => {
       expect(container.querySelector('.cinder-code-block__code')?.textContent).toBe('const y = 2;');
     });
   });
+
+  test('empty highlighter output falls back to plain code', async () => {
+    let resolveHighlightedCode: ((html: string) => void) | undefined;
+    const { container } = render(CodeBlock, {
+      code: 'const visible = true;',
+      language: 'js',
+      highlighter: async () => {
+        return await new Promise<string>((resolve) => {
+          resolveHighlightedCode = resolve;
+        });
+      },
+    });
+
+    await waitFor(() => {
+      expect(resolveHighlightedCode).toBeDefined();
+    });
+    resolveHighlightedCode?.('');
+
+    await waitFor(() => {
+      expect(container.querySelector('.cinder-code-block__code')?.textContent).toBe(
+        'const visible = true;',
+      );
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- Treat empty-string CodeBlock highlighter output as the plain-code fallback instead of rendering a blank block.
- Add a regression test for async highlighters that resolve to an empty string.
- Add package and consumer validation for the exported `useHistory` source file that surfaced while validating the package tarball.

## Review committee
Pre-reviewed by: testing-expert, frontend-architect, dx-engineer
- 2 rounds of review
- Round 1: one developer-experience must-fix and one suggestion found
- Round 2: all reviewers approved

> [!WARNING]
> Codex, the adversarial second-opinion reviewer, was unavailable because the configured `codex-review.sh` shim was not present in this environment. The PR was reviewed by the available committee agents.

## Test plan
- `TZ=UTC LANG=en_US.UTF-8 bun test --conditions browser packages/components/src/components/code-block.test.ts`
- `bun run --filter=cinder validate`
- pre-commit hook: lint, typecheck, test, lint-staged

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small UI rendering tweak plus additional packaging/consumer validation around `useHistory` exports, with minimal runtime impact outside `CodeBlock`. Main risk is false negatives in consumer fixtures if environments differ, but behavior is straightforward.
> 
> **Overview**
> Updates `CodeBlock` so a `highlighter` that resolves to `''` is treated as *no highlighted output*, falling back to the plain `<pre><code>` render instead of showing a blank block; adds a regression test for this async empty-string case.
> 
> Tightens packaging/consumer validation for the `useHistory` utility by including `src/utilities/use-history.svelte.ts` in `package.json#files`, requiring it in tarball inspection, and asserting barrel imports succeed in both the node and SvelteKit consumer fixtures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit db7d372f5fa23874ad5357ad3c765bb0a657f15b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->