### PR TITLE
Chat UX improvements: collapse tool calls, fix hover shake, JSON highlight, icon sizing

### DIFF
--- a/packages/components/src/components/chat/container/chat-jump-controls.svelte
+++ b/packages/components/src/components/chat/container/chat-jump-controls.svelte
@@ -85,7 +85,9 @@
     width: var(--cinder-touch-target-min);
     height: var(--cinder-touch-target-min);
     padding: 0;
-    background: var(--cinder-surface-raised);
+    /* --cinder-surface-raised does not exist in tokens; use --cinder-surface and
+     * lean on the shadow + border for elevation against the inset chat timeline. */
+    background: var(--cinder-surface);
     border: 1px solid var(--cinder-border);
     border-radius: var(--cinder-radius-full);
     box-shadow: var(--cinder-shadow-md);

--- a/packages/components/src/components/chat/container/chat.svelte
+++ b/packages/components/src/components/chat/container/chat.svelte
@@ -766,6 +766,13 @@
     gap: var(--cinder-space-3);
   }
 
+  /* Inset surface separates assistant bubbles (--cinder-surface) from the
+   * page-level background. Only applied in default surfaceMode; embedded
+   * contexts using surfaceMode="transparent" inherit their host's background. */
+  .chat-container[data-surface-mode='default'] .chat-timeline {
+    background: var(--cinder-surface-inset);
+  }
+
   .chat-timeline:focus-visible {
     outline: 2px solid var(--cinder-ring-color);
     outline-offset: -2px;

--- a/packages/components/src/components/chat/container/scroll-utilities.test.ts
+++ b/packages/components/src/components/chat/container/scroll-utilities.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, test } from 'bun:test';
+
+import {
+  DEFAULT_SCROLL_CONFIGURATION,
+  isAtBottom,
+  shouldShowJumpToLatest,
+  type ScrollState,
+} from './scroll-utilities.ts';
+
+const { bottomThreshold, jumpThreshold } = DEFAULT_SCROLL_CONFIGURATION;
+
+function state(scrollTop: number, clientHeight = 600, scrollHeight = 2000): ScrollState {
+  return { scrollTop, clientHeight, scrollHeight };
+}
+
+describe('isAtBottom', () => {
+  test('returns true when scrolled exactly to the bottom', () => {
+    // scrollHeight - scrollTop - clientHeight === 0
+    expect(isAtBottom(state(1400), bottomThreshold)).toBe(true);
+  });
+
+  test('returns true within the bottomThreshold', () => {
+    // distance from bottom = 100, threshold = 150
+    expect(isAtBottom(state(1300), bottomThreshold)).toBe(true);
+  });
+
+  test('returns false beyond the bottomThreshold', () => {
+    // distance from bottom = 151
+    expect(isAtBottom(state(1249), bottomThreshold)).toBe(false);
+  });
+
+  test('returns true when content fits the viewport (scrollHeight <= clientHeight)', () => {
+    // No scroll possible — user is always "at bottom".
+    expect(
+      isAtBottom({ scrollTop: 0, clientHeight: 600, scrollHeight: 600 }, bottomThreshold),
+    ).toBe(true);
+  });
+});
+
+describe('shouldShowJumpToLatest', () => {
+  test('returns false when content fits the viewport', () => {
+    expect(
+      shouldShowJumpToLatest({ scrollTop: 0, clientHeight: 600, scrollHeight: 500 }, jumpThreshold),
+    ).toBe(false);
+  });
+
+  test('returns false within the jumpThreshold band (hysteresis with isAtBottom)', () => {
+    // distance from bottom = 200, threshold = 200; not strictly greater than
+    expect(shouldShowJumpToLatest(state(1200), jumpThreshold)).toBe(false);
+  });
+
+  test('returns true when scrolled beyond the jumpThreshold', () => {
+    // distance from bottom = 201
+    expect(shouldShowJumpToLatest(state(1199), jumpThreshold)).toBe(true);
+  });
+
+  test('hysteresis: a position past the bottom threshold but inside the jump threshold shows no button', () => {
+    // distance from bottom = 175 — past 150 (no longer "at bottom") but
+    // not past 200 (jump button stays hidden). This is the hysteresis band.
+    expect(isAtBottom(state(1225), bottomThreshold)).toBe(false);
+    expect(shouldShowJumpToLatest(state(1225), jumpThreshold)).toBe(false);
+  });
+});
+
+describe('isAtBottom + shouldShowJumpToLatest interaction across viewport changes', () => {
+  test('expanding content while at bottom keeps isAtBottom true if scrollTop tracks', () => {
+    // Start at bottom of 2000px content.
+    let s = state(1400, 600, 2000);
+    expect(isAtBottom(s, bottomThreshold)).toBe(true);
+
+    // Content grows to 2500px. If the parent re-anchors scrollTop to keep us at bottom,
+    // scrollTop becomes 1900 (2500 - 600), distance from bottom = 0.
+    s = { scrollTop: 1900, clientHeight: 600, scrollHeight: 2500 };
+    expect(isAtBottom(s, bottomThreshold)).toBe(true);
+  });
+
+  test('expanding content while at bottom would break stickiness without re-anchoring', () => {
+    // Start at bottom of 2000px content.
+    let s = state(1400, 600, 2000);
+    expect(isAtBottom(s, bottomThreshold)).toBe(true);
+
+    // Content grows to 2500px but scrollTop did NOT advance. distance from bottom = 500.
+    s = { scrollTop: 1400, clientHeight: 600, scrollHeight: 2500 };
+    expect(isAtBottom(s, bottomThreshold)).toBe(false);
+    // The jump button must surface so the user can recover.
+    expect(shouldShowJumpToLatest(s, jumpThreshold)).toBe(true);
+  });
+});

--- a/packages/components/src/components/chat/container/use-chat-message-groups.svelte.test.ts
+++ b/packages/components/src/components/chat/container/use-chat-message-groups.svelte.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, test } from 'bun:test';
+import type { Message } from 'conversationalist';
+
+import { useChatMessageGroups, type MessageItem } from './use-chat-message-groups.svelte.ts';
+
+const baseTimestamp = new Date('2026-05-08T12:00:00Z').toISOString();
+
+function userMessage(id: string, content = 'hi'): Message {
+  const message: Message = {
+    id,
+    role: 'user',
+    content,
+    createdAt: baseTimestamp,
+    position: 0,
+    metadata: {},
+    hidden: false,
+  };
+  return message;
+}
+
+function toolUseMessage(id: string, callId: string, name = 'exports_check'): Message {
+  const message: Message = {
+    id,
+    role: 'tool-use',
+    content: '',
+    createdAt: baseTimestamp,
+    position: 0,
+    metadata: {},
+    hidden: false,
+    toolCall: {
+      id: callId,
+      name,
+      arguments: {},
+    },
+  };
+  return message;
+}
+
+function toolResultMessage(
+  id: string,
+  callId: string,
+  outcome: 'success' | 'error' = 'success',
+): Message {
+  const message: Message = {
+    id,
+    role: 'tool-result',
+    content: '',
+    createdAt: baseTimestamp,
+    position: 0,
+    metadata: {},
+    hidden: false,
+    toolResult: {
+      callId,
+      outcome,
+      content: { ok: true },
+    },
+  };
+  return message;
+}
+
+function messages(items: MessageItem[]) {
+  return items.map((item) => item.message.id);
+}
+
+describe('useChatMessageGroups paired tool-result filtering', () => {
+  test('paired tool-use + tool-result with matching callId: only tool-use renders', () => {
+    const conversation = [
+      userMessage('m1', 'check it'),
+      toolUseMessage('m2', 'call-1'),
+      toolResultMessage('m3', 'call-1'),
+    ];
+
+    const groups = useChatMessageGroups({ getMessages: () => conversation });
+
+    const messageItems = groups.messagesWithDates.filter(
+      (item): item is MessageItem => item.type === 'message',
+    );
+
+    expect(messages(messageItems)).toEqual(['m1', 'm2']);
+  });
+
+  test('orphan tool-result with no matching tool-use: still renders', () => {
+    const conversation = [userMessage('m1'), toolResultMessage('orphan', 'call-missing')];
+
+    const groups = useChatMessageGroups({ getMessages: () => conversation });
+
+    const messageItems = groups.messagesWithDates.filter(
+      (item): item is MessageItem => item.type === 'message',
+    );
+
+    expect(messages(messageItems)).toEqual(['m1', 'orphan']);
+  });
+
+  test('pending tool-use with no result yet: renders normally', () => {
+    const conversation = [userMessage('m1'), toolUseMessage('pending', 'call-pending')];
+
+    const groups = useChatMessageGroups({ getMessages: () => conversation });
+
+    const messageItems = groups.messagesWithDates.filter(
+      (item): item is MessageItem => item.type === 'message',
+    );
+
+    expect(messages(messageItems)).toEqual(['m1', 'pending']);
+  });
+
+  test('tool-result paired with an error outcome is also filtered out', () => {
+    const conversation = [
+      toolUseMessage('m1', 'call-err'),
+      toolResultMessage('m2', 'call-err', 'error'),
+    ];
+
+    const groups = useChatMessageGroups({ getMessages: () => conversation });
+
+    const messageItems = groups.messagesWithDates.filter(
+      (item): item is MessageItem => item.type === 'message',
+    );
+
+    expect(messages(messageItems)).toEqual(['m1']);
+  });
+});

--- a/packages/components/src/components/chat/container/use-chat-message-groups.svelte.ts
+++ b/packages/components/src/components/chat/container/use-chat-message-groups.svelte.ts
@@ -92,13 +92,24 @@ export function useChatMessageGroups(
     return map;
   });
 
-  // Group messages by date for date separators
+  // Group messages by date for date separators.
+  // Paired tool-result messages are filtered out: when a tool-use renders, ToolCallGroup
+  // already shows the result inline. Rendering the tool-result as its own bubble produces
+  // a duplicate "TOOL RESULT" card next to the unified ToolCallGroup card.
   const messagesWithDates = $derived.by(() => {
     const messages = getMessages();
     const result: MessageWithDateItem[] = [];
     let lastDate: string | null = null;
 
     for (const message of messages) {
+      if (message.role === 'tool-result' && message.toolResult?.callId) {
+        const pairs = toolCallPairsByCallId.get(message.toolResult.callId);
+        const isPaired = pairs?.some((pair) => pair.call && pair.result);
+        if (isPaired) {
+          continue;
+        }
+      }
+
       const timestamp = message.createdAt ?? message.metadata?.['timestamp'];
       if (timestamp != null) {
         // eslint-disable-next-line svelte/prefer-svelte-reactivity -- Date is created fresh each derivation, not mutated

--- a/packages/components/src/components/chat/message/chat-message.svelte
+++ b/packages/components/src/components/chat/message/chat-message.svelte
@@ -611,15 +611,19 @@
   }
 
   /* Footer — absolutely positioned outside the bubble's flow so revealing it on
-   * hover/focus does not change the bubble's height. Default geometry: vertically
-   * centered against the bubble, just outside its center-facing edge.
+   * hover/focus does not change the bubble's height. Default geometry: below the
+   * bubble at the leading edge, which works for any role. The user/assistant
+   * rules below override this to put the icon beside the bubble on the
+   * center-facing edge. Roles like developer / system / unpaired tool-result
+   * inherit this default and place the footer below the bubble.
    * LTR-only: the left/right physical properties below assume left-to-right layout.
    * RTL support is a follow-up that swaps to inset-inline-start/end. */
   .chat-message-footer {
     position: absolute;
-    top: 50%;
-    transform: translateY(-50%);
+    top: 100%;
+    left: 0;
     width: max-content;
+    margin-top: var(--cinder-space-1);
     opacity: 0;
     pointer-events: none;
     transition: opacity var(--cinder-duration-fast) var(--cinder-ease-standard);
@@ -629,14 +633,22 @@
    * padding (not margin) creates a hover bridge so the pointer never leaves a
    * hovered surface while crossing from bubble to icon. */
   .chat-message-wrapper[data-role='user'] .chat-message-footer {
+    top: 50%;
+    left: auto;
     right: 100%;
+    margin-top: 0;
     padding-right: var(--cinder-space-1);
+    transform: translateY(-50%);
   }
 
   /* Assistant bubbles are left-aligned; copy icon sits to their RIGHT. */
   .chat-message-wrapper[data-role='assistant'] .chat-message-footer {
+    top: 50%;
     left: 100%;
+    right: auto;
+    margin-top: 0;
     padding-left: var(--cinder-space-1);
+    transform: translateY(-50%);
   }
 
   .chat-message-wrapper:hover .chat-message-footer,
@@ -650,10 +662,12 @@
     gap: var(--cinder-space-1);
   }
 
-  /* Narrow viewports: fall back to below-bubble where horizontal space is tight. */
+  /* Narrow viewports: every role falls back to below-bubble where horizontal
+   * space is tight. Targets all wrapper data-roles via the .chat-message-footer
+   * descendant so user / assistant / developer / system / tool-result all
+   * collapse to the same compact below-bubble layout. */
   @media (max-width: 480px) {
-    .chat-message-wrapper[data-role='user'] .chat-message-footer,
-    .chat-message-wrapper[data-role='assistant'] .chat-message-footer {
+    .chat-message-wrapper .chat-message-footer {
       top: 100%;
       left: 0;
       right: auto;

--- a/packages/components/src/components/chat/message/chat-message.svelte
+++ b/packages/components/src/components/chat/message/chat-message.svelte
@@ -392,6 +392,7 @@
     border: 1px solid var(--cinder-border-muted);
     border-radius: var(--cinder-radius-lg) var(--cinder-radius-lg) var(--cinder-radius-lg)
       var(--cinder-radius-sm);
+    box-shadow: var(--cinder-shadow-sm);
   }
 
   .chat-message-wrapper[data-role='system'] {

--- a/packages/components/src/components/chat/message/chat-message.svelte
+++ b/packages/components/src/components/chat/message/chat-message.svelte
@@ -196,10 +196,17 @@
   data-hidden={message.hidden || undefined}
   data-failed={isFailed || undefined}
   data-search-match={searchMatch || undefined}
+  data-tool-pair={isToolUse && toolPair ? '' : undefined}
   {...rest}
 >
   <!-- svelte-ignore a11y_no_noninteractive_tabindex -->
-  <article id={messageId} class="chat-message" aria-labelledby={roleId} {tabindex}>
+  <article
+    id={messageId}
+    class="chat-message"
+    aria-labelledby={isToolUse && toolPair ? undefined : roleId}
+    aria-label={isToolUse && toolPair ? `Tool call: ${toolPair.call.name}` : undefined}
+    {tabindex}
+  >
     <header class="chat-message-header">
       <span id={roleId} class="chat-message-role">{roleLabel}</span>
       {#if status}
@@ -415,6 +422,27 @@
     background: var(--cinder-surface-inset);
     font-family: var(--cinder-font-mono);
     font-size: var(--cinder-text-sm);
+  }
+
+  /* When a tool-use has a paired result, ToolCallGroup is the canonical card.
+   * Strip the outer bubble shell (background, border, padding, role label, footer)
+   * so the unified card is the only visible boundary. */
+  .chat-message-wrapper[data-tool-pair] .chat-message {
+    background: none;
+    border: none;
+    padding: 0;
+    border-radius: 0;
+    gap: 0;
+    font-family: inherit;
+    font-size: inherit;
+  }
+
+  .chat-message-wrapper[data-tool-pair] .chat-message-header {
+    display: none;
+  }
+
+  .chat-message-wrapper[data-tool-pair] .chat-message-footer {
+    display: none;
   }
 
   .chat-message-wrapper[data-role='snapshot'] {

--- a/packages/components/src/components/chat/message/chat-message.svelte
+++ b/packages/components/src/components/chat/message/chat-message.svelte
@@ -427,7 +427,14 @@
 
   /* When a tool-use has a paired result, ToolCallGroup is the canonical card.
    * Strip the outer bubble shell (background, border, padding, role label, footer)
-   * so the unified card is the only visible boundary. */
+   * so the unified card is the only visible boundary. The wrapper expands
+   * within the same readability cap as regular bubbles — chat bubbles hug
+   * their content, but a tool-call card is structural data that benefits
+   * from horizontal room without stretching across the entire timeline. */
+  .chat-message-wrapper[data-tool-pair] {
+    width: min(80%, 48rem);
+  }
+
   .chat-message-wrapper[data-tool-pair] .chat-message {
     background: none;
     border: none;

--- a/packages/components/src/components/chat/message/chat-message.svelte
+++ b/packages/components/src/components/chat/message/chat-message.svelte
@@ -603,16 +603,32 @@
   }
 
   /* Footer — absolutely positioned outside the bubble's flow so revealing it on
-   * hover/focus does not change the bubble's height (which would cause the
-   * "shake" the user reported). Geometry is set by Issue 3 rules below. */
+   * hover/focus does not change the bubble's height. Default geometry: vertically
+   * centered against the bubble, just outside its center-facing edge.
+   * LTR-only: the left/right physical properties below assume left-to-right layout.
+   * RTL support is a follow-up that swaps to inset-inline-start/end. */
   .chat-message-footer {
     position: absolute;
-    top: 100%;
-    margin-top: var(--cinder-space-1);
+    top: 50%;
+    transform: translateY(-50%);
     width: max-content;
     opacity: 0;
     pointer-events: none;
     transition: opacity var(--cinder-duration-fast) var(--cinder-ease-standard);
+  }
+
+  /* User bubbles are right-aligned; copy icon sits to their LEFT (toward chat center).
+   * padding (not margin) creates a hover bridge so the pointer never leaves a
+   * hovered surface while crossing from bubble to icon. */
+  .chat-message-wrapper[data-role='user'] .chat-message-footer {
+    right: 100%;
+    padding-right: var(--cinder-space-1);
+  }
+
+  /* Assistant bubbles are left-aligned; copy icon sits to their RIGHT. */
+  .chat-message-wrapper[data-role='assistant'] .chat-message-footer {
+    left: 100%;
+    padding-left: var(--cinder-space-1);
   }
 
   .chat-message-wrapper:hover .chat-message-footer,
@@ -624,7 +640,20 @@
   .chat-message-actions {
     display: flex;
     gap: var(--cinder-space-1);
-    padding: var(--cinder-space-0-5);
+  }
+
+  /* Narrow viewports: fall back to below-bubble where horizontal space is tight. */
+  @media (max-width: 480px) {
+    .chat-message-wrapper[data-role='user'] .chat-message-footer,
+    .chat-message-wrapper[data-role='assistant'] .chat-message-footer {
+      top: 100%;
+      left: 0;
+      right: auto;
+      transform: none;
+      padding-left: 0;
+      padding-right: 0;
+      margin-top: var(--cinder-space-1);
+    }
   }
 
   /* Touch devices: always show actions */
@@ -635,12 +664,14 @@
     }
   }
 
-  /* Copy button */
+  /* Copy button — small icon-only affordance. The visible icon is `icon-xs`;
+   * min-width/height meet the WCAG 2.2 AA tap target without enlarging the icon. */
   .chat-message-copy {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    padding: var(--cinder-space-1);
+    display: grid;
+    place-items: center;
+    min-width: var(--cinder-touch-target-min);
+    min-height: var(--cinder-touch-target-min);
+    padding: 0;
     background: transparent;
     border: none;
     border-radius: var(--cinder-radius-sm);
@@ -672,10 +703,11 @@
 
   /* Edit button (icon action button, visually identical to copy button) */
   .chat-message-edit-button {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    padding: var(--cinder-space-1);
+    display: grid;
+    place-items: center;
+    min-width: var(--cinder-touch-target-min);
+    min-height: var(--cinder-touch-target-min);
+    padding: 0;
     background: transparent;
     border: none;
     border-radius: var(--cinder-radius-sm);

--- a/packages/components/src/components/chat/message/chat-message.svelte
+++ b/packages/components/src/components/chat/message/chat-message.svelte
@@ -672,8 +672,8 @@
     }
   }
 
-  /* Copy button — small icon-only affordance. The visible icon is `icon-xs`;
-   * min-width/height meet the WCAG 2.2 AA tap target without enlarging the icon. */
+  /* Copy button — small icon-only affordance. The icon size comes from the
+   * `icon-xs` class on the SVG (defined in styles/utilities.css). */
   .chat-message-copy {
     display: grid;
     place-items: center;

--- a/packages/components/src/components/chat/message/chat-message.svelte
+++ b/packages/components/src/components/chat/message/chat-message.svelte
@@ -284,47 +284,47 @@
 
   {#if actions || (showDefaultActions && textContent) || canEdit}
     <footer class="chat-message-footer" role="none">
-      <div class="chat-message-actions-clip">
-        <div class="chat-message-actions" role="group" aria-label="Message actions">
-          {#if actions}
-            {@render actions()}
-          {/if}
-          {#if showDefaultActions && textContent}
-            <button
-              type="button"
-              class="chat-message-copy"
-              class:chat-message-copy-success={copyState === 'copied'}
-              onclick={handleCopy}
-              aria-label={copyState === 'copied' ? 'Copied!' : 'Copy message'}
-            >
-              {#if copyState === 'copied'}
-                <Check class="icon-xs" />
-              {:else}
-                <Copy class="icon-xs" />
-              {/if}
-            </button>
-          {/if}
-          {#if canEdit}
-            <button
-              type="button"
-              class="chat-message-edit-button"
-              onclick={startEditing}
-              aria-label="Edit message"
-            >
-              <Pencil class="icon-xs" />
-            </button>
-          {/if}
-        </div>
+      <div class="chat-message-actions" role="group" aria-label="Message actions">
+        {#if actions}
+          {@render actions()}
+        {/if}
+        {#if showDefaultActions && textContent}
+          <button
+            type="button"
+            class="chat-message-copy"
+            class:chat-message-copy-success={copyState === 'copied'}
+            onclick={handleCopy}
+            aria-label={copyState === 'copied' ? 'Copied!' : 'Copy message'}
+          >
+            {#if copyState === 'copied'}
+              <Check class="icon-xs" />
+            {:else}
+              <Copy class="icon-xs" />
+            {/if}
+          </button>
+        {/if}
+        {#if canEdit}
+          <button
+            type="button"
+            class="chat-message-edit-button"
+            onclick={startEditing}
+            aria-label="Edit message"
+          >
+            <Pencil class="icon-xs" />
+          </button>
+        {/if}
       </div>
     </footer>
   {/if}
 </div>
 
 <style>
-  /* Wrapper — handles layout positioning, width constraints, and hover delegation */
+  /* Wrapper — handles layout positioning, width constraints, and hover delegation.
+   * position: relative anchors the absolutely-positioned action footer below. */
   .chat-message-wrapper {
     display: flex;
     flex-direction: column;
+    position: relative;
     width: fit-content;
     /* Cap at 80% of container OR 48rem (768px) for readability on wide screens */
     max-width: min(80%, 48rem);
@@ -602,53 +602,36 @@
     outline-offset: 2px;
   }
 
-  /* Footer — lives outside the bubble to avoid inflating its height.
-   * width:0 + min-width:100% prevents the footer from contributing to
-   * the wrapper's fit-content width (short message bubbles stay compact).
-   * Uses grid-template-rows for smooth height collapse/expand. */
+  /* Footer — absolutely positioned outside the bubble's flow so revealing it on
+   * hover/focus does not change the bubble's height (which would cause the
+   * "shake" the user reported). Geometry is set by Issue 3 rules below. */
   .chat-message-footer {
-    display: grid;
+    position: absolute;
+    top: 100%;
     margin-top: var(--cinder-space-1);
-    width: 0;
-    min-width: 100%;
-    grid-template-rows: 0fr;
-    transition: grid-template-rows var(--cinder-duration-fast) var(--cinder-ease-standard);
+    width: max-content;
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity var(--cinder-duration-fast) var(--cinder-ease-standard);
   }
 
   .chat-message-wrapper:hover .chat-message-footer,
   .chat-message-wrapper:focus-within .chat-message-footer {
-    grid-template-rows: 1fr;
-  }
-
-  /* Clip container for grid animation — keeps overflow: hidden away from
-   * focusable buttons so focus rings are not cut off by keyboard users. */
-  .chat-message-actions-clip {
-    overflow: hidden;
+    opacity: 1;
+    pointer-events: auto;
   }
 
   .chat-message-actions {
     display: flex;
     gap: var(--cinder-space-1);
-    /* Small padding ensures focus-ring outlines on buttons are not clipped
-     * by the parent overflow: hidden on .chat-message-actions-clip. */
     padding: var(--cinder-space-0-5);
-    opacity: 0;
-    transition: opacity var(--cinder-duration-fast) var(--cinder-ease-standard);
-  }
-
-  .chat-message-wrapper:hover .chat-message-actions,
-  .chat-message-wrapper:focus-within .chat-message-actions {
-    opacity: 1;
   }
 
   /* Touch devices: always show actions */
   @media (hover: none) or (pointer: coarse) {
     .chat-message-footer {
-      grid-template-rows: 1fr;
-    }
-
-    .chat-message-actions {
       opacity: 1;
+      pointer-events: auto;
     }
   }
 

--- a/packages/components/src/components/chat/message/chat-message.svelte
+++ b/packages/components/src/components/chat/message/chat-message.svelte
@@ -663,11 +663,17 @@
   }
 
   /* Narrow viewports: every role falls back to below-bubble where horizontal
-   * space is tight. Targets all wrapper data-roles via the .chat-message-footer
-   * descendant so user / assistant / developer / system / tool-result all
-   * collapse to the same compact below-bubble layout. */
+   * space is tight. Each selector explicitly matches the same specificity as
+   * the role-specific desktop rules above ([data-role='…'] = 0-1-1), so the
+   * media query actually wins inside its breakpoint. */
   @media (max-width: 480px) {
-    .chat-message-wrapper .chat-message-footer {
+    .chat-message-wrapper[data-role='user'] .chat-message-footer,
+    .chat-message-wrapper[data-role='assistant'] .chat-message-footer,
+    .chat-message-wrapper[data-role='system'] .chat-message-footer,
+    .chat-message-wrapper[data-role='developer'] .chat-message-footer,
+    .chat-message-wrapper[data-role='tool-use'] .chat-message-footer,
+    .chat-message-wrapper[data-role='tool-result'] .chat-message-footer,
+    .chat-message-wrapper[data-role='snapshot'] .chat-message-footer {
       top: 100%;
       left: 0;
       right: auto;

--- a/packages/components/src/components/chat/message/tool-call-group.svelte
+++ b/packages/components/src/components/chat/message/tool-call-group.svelte
@@ -16,6 +16,7 @@
 
 <script lang="ts">
   import { classNames } from '../../../utilities/class-names.ts';
+  import { highlightJson } from '../../../utilities/json-highlight.ts';
   import { stringify } from '../../../utilities/stringify.ts';
 
   let {
@@ -129,7 +130,9 @@
       <div class="tool-call-section">
         <h4 class="tool-call-section-title">Arguments</h4>
         <!-- svelte-ignore a11y_no_noninteractive_tabindex -->
-        <pre class="tool-call-code" tabindex="0"><code>{formattedArguments}</code></pre>
+        <pre class="tool-call-code cinder-code-block__pre" tabindex="0">{@html highlightJson(
+            formattedArguments,
+          )}</pre>
       </div>
 
       {#if hasResult}
@@ -141,7 +144,9 @@
             </div>
           {:else if formattedResult !== null}
             <!-- svelte-ignore a11y_no_noninteractive_tabindex -->
-            <pre class="tool-call-code" tabindex="0"><code>{formattedResult}</code></pre>
+            <pre class="tool-call-code cinder-code-block__pre" tabindex="0">{@html highlightJson(
+                formattedResult,
+              )}</pre>
           {/if}
         </div>
       {/if}

--- a/packages/components/src/components/chat/message/tool-call-group.svelte
+++ b/packages/components/src/components/chat/message/tool-call-group.svelte
@@ -130,9 +130,7 @@
       <div class="tool-call-section">
         <h4 class="tool-call-section-title">Arguments</h4>
         <!-- svelte-ignore a11y_no_noninteractive_tabindex -->
-        <pre class="tool-call-code cinder-code-block__pre" tabindex="0">{@html highlightJson(
-            formattedArguments,
-          )}</pre>
+        <pre class="tool-call-code" tabindex="0">{@html highlightJson(formattedArguments)}</pre>
       </div>
 
       {#if hasResult}
@@ -144,9 +142,7 @@
             </div>
           {:else if formattedResult !== null}
             <!-- svelte-ignore a11y_no_noninteractive_tabindex -->
-            <pre class="tool-call-code cinder-code-block__pre" tabindex="0">{@html highlightJson(
-                formattedResult,
-              )}</pre>
+            <pre class="tool-call-code" tabindex="0">{@html highlightJson(formattedResult)}</pre>
           {/if}
         </div>
       {/if}
@@ -186,13 +182,17 @@
     color: inherit;
   }
 
+  /* Hover: subtle inset tint instead of the full surface-hover gray, which
+   * looked harsh against the colored card border. */
   .tool-call-header:hover {
-    background: var(--cinder-surface-hover);
+    background: color-mix(in oklch, var(--cinder-surface), var(--cinder-text) 4%);
   }
 
+  /* Focus: ring travels via box-shadow, not outline, so it sits inside the
+   * card's colored border instead of doubling up on top of it. */
   .tool-call-header:focus-visible {
-    outline: 2px solid var(--cinder-ring-color);
-    outline-offset: -2px;
+    outline: none;
+    box-shadow: inset 0 0 0 2px var(--cinder-ring-color);
   }
 
   .tool-call-icon {
@@ -256,7 +256,13 @@
     background: var(--cinder-surface-inset);
     display: flex;
     flex-direction: column;
-    gap: var(--cinder-space-3);
+    gap: var(--cinder-space-2);
+  }
+
+  .tool-call-section {
+    display: flex;
+    flex-direction: column;
+    gap: var(--cinder-space-1);
   }
 
   .tool-call-section-title {
@@ -265,20 +271,22 @@
     text-transform: uppercase;
     letter-spacing: 0.05em;
     color: var(--cinder-text-muted);
-    margin: 0 0 var(--cinder-space-2);
+    margin: 0;
   }
 
   .tool-call-code {
     margin: 0;
-    padding: var(--cinder-space-3);
-    background: var(--cinder-surface-inset);
-    border-radius: var(--cinder-radius-md);
+    padding: var(--cinder-space-2) var(--cinder-space-3);
+    background: var(--cinder-surface);
+    border: 1px solid var(--cinder-border-muted);
+    border-radius: var(--cinder-radius-sm);
     overflow-x: auto;
     font-family: var(--cinder-font-mono);
     font-size: var(--cinder-text-sm);
-    line-height: 1.5;
+    line-height: 1.4;
     max-height: 300px;
     overflow-y: auto;
+    color: var(--cinder-text);
   }
 
   .tool-call-error {

--- a/packages/components/src/components/chat/message/tool-call-group.svelte
+++ b/packages/components/src/components/chat/message/tool-call-group.svelte
@@ -26,6 +26,9 @@
     ...rest
   }: ToolCallGroupProps = $props();
 
+  // Stable ID for the disclosed region so the toggle can reference it via aria-controls.
+  const detailsId = `tool-call-details-${pair.call.id}`;
+
   // Determine result status
   const hasResult = $derived(!!pair.result);
   const isError = $derived(pair.result?.outcome === 'error');
@@ -53,6 +56,7 @@
     type="button"
     class="tool-call-header"
     aria-expanded={expanded}
+    aria-controls={detailsId}
     aria-label={`Toggle tool call details for ${pair.call.name}`}
     onclick={handleToggle}
   >
@@ -121,7 +125,7 @@
   </button>
 
   {#if expanded}
-    <div class="tool-call-details">
+    <div id={detailsId} class="tool-call-details" role="region" aria-label="Tool details">
       <div class="tool-call-section">
         <h4 class="tool-call-section-title">Arguments</h4>
         <!-- svelte-ignore a11y_no_noninteractive_tabindex -->

--- a/packages/components/src/components/chat/message/tool-call-group.svelte
+++ b/packages/components/src/components/chat/message/tool-call-group.svelte
@@ -28,7 +28,8 @@
   }: ToolCallGroupProps = $props();
 
   // Stable ID for the disclosed region so the toggle can reference it via aria-controls.
-  const detailsId = `tool-call-details-${pair.call.id}`;
+  // Reactive so the ID tracks the current pair when the component instance is reused.
+  const detailsId = $derived(`tool-call-details-${pair.call.id}`);
 
   // Determine result status
   const hasResult = $derived(!!pair.result);

--- a/packages/components/src/components/code-block.test.ts
+++ b/packages/components/src/components/code-block.test.ts
@@ -109,6 +109,17 @@ describe('CodeBlock', () => {
     });
   });
 
+  test('header is structurally present on the code-block when copyable', () => {
+    // Padding parity (Issue 6): with a header, the __pre still renders inside the
+    // same .cinder-code-block container as the headerless variant, so they share
+    // the same padding rules from code-block.css. Assert the relationship rather
+    // than computed styles since happy-dom doesn't apply external stylesheets.
+    const { container } = render(CodeBlock, { code: 'x', copyable: true, language: 'sql' });
+    const block = container.querySelector('.cinder-code-block');
+    expect(block?.querySelector('.cinder-code-block__header')).not.toBeNull();
+    expect(block?.querySelector('.cinder-code-block__pre')).not.toBeNull();
+  });
+
   test('empty highlighter output falls back to plain code', async () => {
     let resolveHighlightedCode: ((html: string) => void) | undefined;
     const { container } = render(CodeBlock, {

--- a/packages/components/src/styles/components.css
+++ b/packages/components/src/styles/components.css
@@ -22,6 +22,7 @@
 @import './components/empty-state.css';
 @import './components/experimental.css';
 @import './components/input.css';
+@import './components/json-highlight.css';
 @import './components/json-schema-editor.css';
 @import './components/kbd.css';
 @import './components/label.css';

--- a/packages/components/src/styles/components/code-block.css
+++ b/packages/components/src/styles/components/code-block.css
@@ -48,22 +48,25 @@
 }
 
 /* Compact, borderless copy button when nested inside a code block header.
- * Scoped to this exact compound selector so the standalone CopyButton
- * keeps its bordered default everywhere else in the app. */
-.cinder-code-block__header .cinder-copy-button {
+ * Specificity bump (`.cinder-code-block .cinder-code-block__header .cinder-copy-button`)
+ * is required because copy-button.css imports AFTER code-block.css in components.css;
+ * with equal specificity the later import would win and the bordered default would
+ * leak through. Scoped so the standalone CopyButton keeps its bordered default
+ * everywhere else in the app. */
+.cinder-code-block .cinder-code-block__header .cinder-copy-button {
   border: none;
   background: transparent;
   padding: var(--cinder-space-1);
   color: var(--cinder-text-subtle);
 }
 
-.cinder-code-block__header .cinder-copy-button:hover {
+.cinder-code-block .cinder-code-block__header .cinder-copy-button:hover {
   background: var(--cinder-surface-hover);
   color: var(--cinder-text);
-  border: none;
+  border-color: transparent;
 }
 
-.cinder-code-block__header .cinder-copy-button:focus-visible {
+.cinder-code-block .cinder-code-block__header .cinder-copy-button:focus-visible {
   outline: 2px solid var(--cinder-ring-color);
   outline-offset: 2px;
 }

--- a/packages/components/src/styles/components/code-block.css
+++ b/packages/components/src/styles/components/code-block.css
@@ -34,7 +34,7 @@
 
 .cinder-code-block__pre {
   margin: 0;
-  padding: var(--cinder-space-3) var(--cinder-space-4);
+  padding: var(--cinder-space-4);
   overflow-x: auto;
   font-family: var(--cinder-font-mono);
   font-size: var(--cinder-text-sm);
@@ -45,4 +45,25 @@
 .cinder-code-block__code {
   font-family: inherit;
   font-size: inherit;
+}
+
+/* Compact, borderless copy button when nested inside a code block header.
+ * Scoped to this exact compound selector so the standalone CopyButton
+ * keeps its bordered default everywhere else in the app. */
+.cinder-code-block__header .cinder-copy-button {
+  border: none;
+  background: transparent;
+  padding: var(--cinder-space-1);
+  color: var(--cinder-text-subtle);
+}
+
+.cinder-code-block__header .cinder-copy-button:hover {
+  background: var(--cinder-surface-hover);
+  color: var(--cinder-text);
+  border: none;
+}
+
+.cinder-code-block__header .cinder-copy-button:focus-visible {
+  outline: 2px solid var(--cinder-ring-color);
+  outline-offset: 2px;
 }

--- a/packages/components/src/styles/components/code-block.css
+++ b/packages/components/src/styles/components/code-block.css
@@ -32,7 +32,12 @@
   letter-spacing: var(--cinder-tracking-wide);
 }
 
-.cinder-code-block__pre {
+.cinder-code-block__pre,
+/* Highlighter output (e.g. Shiki) replaces __pre with its own markup
+ * (typically <pre class="shiki ...">). Match it so the highlighted variant
+ * inherits the same padding / font / line-height as the plain variant —
+ * this is what Issue 6 was supposed to fix originally. */
+.cinder-code-block > pre {
   margin: 0;
   padding: var(--cinder-space-4);
   overflow-x: auto;

--- a/packages/components/src/styles/components/json-highlight.css
+++ b/packages/components/src/styles/components/json-highlight.css
@@ -5,8 +5,11 @@
  * the highlighter. Token classes are stable; the markup is `{@html}`-rendered
  * by the helper, which HTML-escapes every character of input.
  *
- * Every token color is verified to meet WCAG AA against --cinder-surface-inset
- * (the surface where this markup renders inside tool-call-group's <pre>).
+ * Token colors target WCAG AA against --cinder-surface (the actual <pre>
+ * background in tool-call-group; previously documented as --cinder-surface-inset
+ * before the surface was changed in a follow-up commit). The number token uses
+ * a darkened warning shade because raw --cinder-warning is borderline against
+ * the lighter --cinder-surface in light mode.
  * ======================================== */
 
 .cinder-json-token-key {
@@ -17,8 +20,9 @@
   color: var(--cinder-success);
 }
 
+/* Darkened warning shade to clear AA against --cinder-surface in light mode. */
 .cinder-json-token-number {
-  color: var(--cinder-warning);
+  color: color-mix(in oklch, var(--cinder-warning), oklch(0% 0 0) 15%);
 }
 
 .cinder-json-token-boolean,
@@ -27,8 +31,8 @@
   color: var(--cinder-info);
 }
 
-/* JSON punctuation is rendered text; --cinder-text-muted meets AA on the
- * inset surface (light: oklch 32% on 94%, dark: oklch 82% on 12%). */
+/* JSON punctuation is rendered text; --cinder-text-muted meets AA in both
+ * themes (light: oklch 32% on ≥94%, dark: oklch 82% on ≤20%). */
 .cinder-json-token-punctuation {
   color: var(--cinder-text-muted);
 }

--- a/packages/components/src/styles/components/json-highlight.css
+++ b/packages/components/src/styles/components/json-highlight.css
@@ -1,0 +1,34 @@
+/* ========================================
+ * JSON syntax highlight tokens
+ * Used by `highlightJson()` (utilities/json-highlight.ts) when rendering
+ * tool-call arguments and results, or any other JSON value passed through
+ * the highlighter. Token classes are stable; the markup is `{@html}`-rendered
+ * by the helper, which HTML-escapes every character of input.
+ *
+ * Every token color is verified to meet WCAG AA against --cinder-surface-inset
+ * (the surface where this markup renders inside tool-call-group's <pre>).
+ * ======================================== */
+
+.cinder-json-token-key {
+  color: var(--cinder-accent);
+}
+
+.cinder-json-token-string {
+  color: var(--cinder-success);
+}
+
+.cinder-json-token-number {
+  color: var(--cinder-warning);
+}
+
+.cinder-json-token-boolean,
+/* `null` is a semantic value (not decoration); use the same color as boolean. */
+.cinder-json-token-null {
+  color: var(--cinder-info);
+}
+
+/* JSON punctuation is rendered text; --cinder-text-muted meets AA on the
+ * inset surface (light: oklch 32% on 94%, dark: oklch 82% on 12%). */
+.cinder-json-token-punctuation {
+  color: var(--cinder-text-muted);
+}

--- a/packages/components/src/styles/utilities.css
+++ b/packages/components/src/styles/utilities.css
@@ -10,3 +10,36 @@
   white-space: nowrap;
   border: 0;
 }
+
+/* Icon size utilities. lucide-svelte and most icon libraries default to a
+ * 24px viewBox with no inline width/height. These classes force a consistent
+ * size across the chat, markdown editor, code blocks, and any other component
+ * that renders an icon glyph. Apply directly to the icon element (e.g.
+ * `<Copy class="icon-sm" />`) — the rule cascades to nested <svg>. */
+.icon-xs,
+.icon-xs > svg,
+svg.icon-xs {
+  width: 0.875rem;
+  height: 0.875rem;
+}
+
+.icon-sm,
+.icon-sm > svg,
+svg.icon-sm {
+  width: 1rem;
+  height: 1rem;
+}
+
+.icon-md,
+.icon-md > svg,
+svg.icon-md {
+  width: 1.25rem;
+  height: 1.25rem;
+}
+
+.icon-lg,
+.icon-lg > svg,
+svg.icon-lg {
+  width: 1.5rem;
+  height: 1.5rem;
+}

--- a/packages/components/src/utilities/json-highlight.test.ts
+++ b/packages/components/src/utilities/json-highlight.test.ts
@@ -70,6 +70,16 @@ describe('highlightJson — valid JSON', () => {
     expect(html).toContain('cinder-json-token-key">"a"');
     expect(html).toContain('cinder-json-token-key">"b"');
   });
+
+  test('keys after a value containing escaped quotes still classify as keys', () => {
+    // Regression: the previous backward-scan implementation skipped strings by
+    // walking back to the next `"`, treating an escaped `\"` as the boundary.
+    // For {"a": "foo\"bar", "b": 1} that produced a mis-classification of "b"
+    // as a value string. The forward-stack tokenizer is immune.
+    const html = highlightJson(JSON.stringify({ a: 'foo"bar', b: 1 }));
+    expect(html).toContain('cinder-json-token-key">"b"');
+    expect(html).not.toContain('cinder-json-token-string">"b"');
+  });
 });
 
 describe('highlightJson — fallback paths', () => {

--- a/packages/components/src/utilities/json-highlight.test.ts
+++ b/packages/components/src/utilities/json-highlight.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, test } from 'bun:test';
+
+import { highlightJson } from './json-highlight.ts';
+
+describe('highlightJson — valid JSON', () => {
+  test('object: keys, strings, separators each get a token span', () => {
+    const html = highlightJson('{"status": "ok"}');
+    expect(html).toContain('cinder-json-token-key">"status"');
+    expect(html).toContain('cinder-json-token-string">"ok"');
+    expect(html).toContain('cinder-json-token-punctuation">{');
+    expect(html).toContain('cinder-json-token-punctuation">}');
+    expect(html).toContain('cinder-json-token-punctuation">:');
+  });
+
+  test('quoted string is valid JSON and renders as a single string token', () => {
+    const html = highlightJson('"hello world"');
+    expect(html).toContain('cinder-json-token-string">"hello world"');
+    expect(html).not.toContain('cinder-json-token-key');
+  });
+
+  test('booleans and null have their own token classes', () => {
+    const html = highlightJson('{"a": true, "b": null, "c": false}');
+    expect(html).toContain('cinder-json-token-boolean">true');
+    expect(html).toContain('cinder-json-token-boolean">false');
+    expect(html).toContain('cinder-json-token-null">null');
+  });
+
+  test('numbers including exponents tokenize as a single number', () => {
+    const html = highlightJson('1.5e-10');
+    expect(html).toContain('cinder-json-token-number">1.5e-10');
+  });
+
+  test('empty object and empty array tokenize as punctuation only', () => {
+    expect(highlightJson('{}')).toBe(
+      '<code class="cinder-json"><span class="cinder-json-token cinder-json-token-punctuation">{</span><span class="cinder-json-token cinder-json-token-punctuation">}</span></code>',
+    );
+    expect(highlightJson('[]')).toBe(
+      '<code class="cinder-json"><span class="cinder-json-token cinder-json-token-punctuation">[</span><span class="cinder-json-token cinder-json-token-punctuation">]</span></code>',
+    );
+  });
+
+  test('whitespace between tokens is preserved verbatim', () => {
+    const html = highlightJson('{\n  "a": 1\n}');
+    expect(html).toContain('}</span>\n  <span'.length === 0 ? 'never' : '');
+    // Indentation is the two literal spaces between the opener and the key span.
+    expect(html).toContain('>{</span>\n  <span class="cinder-json-token cinder-json-token-key"');
+    // Newline before the closing brace is preserved.
+    expect(html).toContain(
+      '</span>\n<span class="cinder-json-token cinder-json-token-punctuation">}',
+    );
+  });
+
+  test('escaped quote inside a string stays inside the same string token', () => {
+    const html = highlightJson('"a\\"b"');
+    expect(html).toContain('cinder-json-token-string">"a\\"b"');
+  });
+
+  test('nested arrays: strings inside an array are values, not keys', () => {
+    const html = highlightJson('{"items": ["a", "b"]}');
+    expect(html).toContain('cinder-json-token-key">"items"');
+    expect(html).toContain('cinder-json-token-string">"a"');
+    expect(html).toContain('cinder-json-token-string">"b"');
+  });
+
+  test('keys after a comma in an object are still classified as keys', () => {
+    const html = highlightJson('{"a": 1, "b": 2}');
+    expect(html).toContain('cinder-json-token-key">"a"');
+    expect(html).toContain('cinder-json-token-key">"b"');
+  });
+});
+
+describe('highlightJson — fallback paths', () => {
+  test('plain text (not JSON) returns escaped <code> without token spans', () => {
+    const html = highlightJson('hello world');
+    expect(html).toBe('<code class="cinder-json">hello world</code>');
+    expect(html).not.toContain('cinder-json-token-');
+  });
+
+  test('invalid JSON returns the plain fallback', () => {
+    const html = highlightJson('{ broken: ');
+    expect(html).toContain('<code class="cinder-json">');
+    expect(html).not.toContain('cinder-json-token-');
+  });
+});
+
+describe('highlightJson — HTML escaping', () => {
+  test('special characters in valid JSON values are escaped, never injected', () => {
+    const html = highlightJson('{"k": "<script>alert(1)</script>"}');
+    expect(html).not.toContain('<script>');
+    expect(html).toContain('&lt;script&gt;');
+    expect(html).toContain('&lt;/script&gt;');
+  });
+
+  test('special characters in non-JSON input are escaped', () => {
+    const html = highlightJson('<img src=x onerror=alert(1)>');
+    expect(html).toBe('<code class="cinder-json">&lt;img src=x onerror=alert(1)&gt;</code>');
+  });
+
+  test('ampersand in keys is escaped to &amp;', () => {
+    const html = highlightJson('{"a&b": 1}');
+    expect(html).toContain('cinder-json-token-key">"a&amp;b"');
+  });
+});

--- a/packages/components/src/utilities/json-highlight.test.ts
+++ b/packages/components/src/utilities/json-highlight.test.ts
@@ -41,7 +41,10 @@ describe('highlightJson — valid JSON', () => {
 
   test('whitespace between tokens is preserved verbatim', () => {
     const html = highlightJson('{\n  "a": 1\n}');
-    expect(html).toContain('}</span>\n  <span'.length === 0 ? 'never' : '');
+    // Newline + two-space indent between the value token and the closing brace.
+    expect(html).toContain(
+      '<span class="cinder-json-token cinder-json-token-number">1</span>\n<span class="cinder-json-token cinder-json-token-punctuation">}',
+    );
     // Indentation is the two literal spaces between the opener and the key span.
     expect(html).toContain('>{</span>\n  <span class="cinder-json-token cinder-json-token-key"');
     // Newline before the closing brace is preserved.

--- a/packages/components/src/utilities/json-highlight.ts
+++ b/packages/components/src/utilities/json-highlight.ts
@@ -73,11 +73,18 @@ function readNumberLiteral(source: string, startIndex: number): string {
 /**
  * Tokenize a well-formed JSON source string into highlighted markup.
  * Caller has already verified `JSON.parse(source)` succeeds.
+ *
+ * `openerStack` tracks the currently-open container kinds left-to-right.
+ * After a comma, the top of the stack tells us whether we're inside an
+ * object (next string is a key) or an array (next string is a value).
+ * Avoids the previous O(n²) backward scan and naturally handles strings
+ * with escaped quotes — no scan that could misread `\"` as a real boundary.
  */
 function tokenize(source: string): string {
   let output = '';
   let index = 0;
   let pendingKey = false; // tracks whether the next string is an object key
+  const openerStack: Array<'{' | '['> = [];
 
   while (index < source.length) {
     const character = source[index];
@@ -92,31 +99,30 @@ function tokenize(source: string): string {
 
     if (character === '{') {
       output += span('punctuation', '{');
+      openerStack.push('{');
       pendingKey = true;
-      index += 1;
-      continue;
-    }
-
-    if (character === '}' || character === ']') {
-      output += span('punctuation', character);
       index += 1;
       continue;
     }
 
     if (character === '[') {
       output += span('punctuation', '[');
+      openerStack.push('[');
       pendingKey = false;
+      index += 1;
+      continue;
+    }
+
+    if (character === '}' || character === ']') {
+      output += span('punctuation', character);
+      openerStack.pop();
       index += 1;
       continue;
     }
 
     if (character === ',') {
       output += span('punctuation', ',');
-      // The preceding context determines whether the next string is a key.
-      // We can't know without looking back; instead, re-set pendingKey based on
-      // the most recent unmatched opener. A cheap proxy: scan backward for the
-      // nearest `{` or `[` ignoring nested structures already emitted as spans.
-      pendingKey = mostRecentOpenerIsObject(source, index);
+      pendingKey = openerStack[openerStack.length - 1] === '{';
       index += 1;
       continue;
     }
@@ -170,40 +176,6 @@ function tokenize(source: string): string {
   }
 
   return `<code class="cinder-json">${output}</code>`;
-}
-
-/**
- * Walk backward from `index` to find the nearest unmatched `{` or `[` and
- * return true when it's `{` (object context where strings are keys).
- */
-function mostRecentOpenerIsObject(source: string, index: number): boolean {
-  let depth = 0;
-  for (let cursor = index - 1; cursor >= 0; cursor -= 1) {
-    const character = source[cursor];
-    if (character === '"') {
-      // skip over the string literal we just passed
-      cursor -= 1;
-      while (cursor >= 0 && source[cursor] !== '"') {
-        cursor -= 1;
-      }
-      continue;
-    }
-    if (character === '}' || character === ']') {
-      depth += 1;
-      continue;
-    }
-    if (character === '{') {
-      if (depth === 0) return true;
-      depth -= 1;
-      continue;
-    }
-    if (character === '[') {
-      if (depth === 0) return false;
-      depth -= 1;
-      continue;
-    }
-  }
-  return false;
 }
 
 /**

--- a/packages/components/src/utilities/json-highlight.ts
+++ b/packages/components/src/utilities/json-highlight.ts
@@ -1,0 +1,221 @@
+/**
+ * Hand-rolled JSON tokenizer for inline syntax highlighting.
+ *
+ * Parses the input first with `JSON.parse` to confirm it is well-formed JSON;
+ * non-JSON input falls through to plain (escaped) text. When parsing succeeds,
+ * walks the original source string with a small state machine and wraps each
+ * token in a `<span class="cinder-json-token cinder-json-token-{kind}">`.
+ *
+ * **HTML-safety invariant.** Every byte of the input is HTML-escaped before
+ * being placed in the output. Token spans are constructed from a fixed set of
+ * class names plus escaped text. The output is therefore safe to render via
+ * Svelte's `{@html}`. Future maintainers must keep the escape step — do not
+ * route raw input into the output.
+ *
+ * Returns a `<code class="cinder-json">…</code>` snippet only. The caller wraps
+ * it in `<pre>` so headed and headerless code blocks share container styling.
+ */
+
+const KEYWORD_NULL = 'null';
+const KEYWORD_TRUE = 'true';
+const KEYWORD_FALSE = 'false';
+
+// Only escape characters that are syntactically meaningful in HTML *text*
+// content. The double-quote needs escaping only inside attribute values, and
+// every quote in our output sits inside text nodes — escaping it would change
+// what users see when copying the rendered string.
+function escapeHtml(text: string): string {
+  return text.replaceAll('&', '&amp;').replaceAll('<', '&lt;').replaceAll('>', '&gt;');
+}
+
+function span(kind: string, raw: string): string {
+  return `<span class="cinder-json-token cinder-json-token-${kind}">${escapeHtml(raw)}</span>`;
+}
+
+function plainCode(raw: string): string {
+  return `<code class="cinder-json">${escapeHtml(raw)}</code>`;
+}
+
+/**
+ * Read a JSON string token starting at `source[index]` (which is `"`).
+ * Returns the literal source slice including the surrounding quotes.
+ */
+function readStringLiteral(source: string, startIndex: number): string {
+  let index = startIndex + 1;
+  while (index < source.length) {
+    const character = source[index];
+    if (character === '\\') {
+      index += 2;
+      continue;
+    }
+    if (character === '"') {
+      return source.slice(startIndex, index + 1);
+    }
+    index += 1;
+  }
+  // JSON.parse already validated input, so this branch is unreachable for
+  // well-formed JSON. Return the rest of the source as a defensive fallback.
+  return source.slice(startIndex);
+}
+
+/**
+ * Read a JSON number token starting at `source[startIndex]`. Numbers consist of
+ * an optional minus, integer digits, an optional fractional part, and an
+ * optional exponent.
+ */
+function readNumberLiteral(source: string, startIndex: number): string {
+  const numberPattern = /-?(?:\d+)(?:\.\d+)?(?:[eE][+-]?\d+)?/y;
+  numberPattern.lastIndex = startIndex;
+  const match = numberPattern.exec(source);
+  return match?.[0] ?? source[startIndex] ?? '';
+}
+
+/**
+ * Tokenize a well-formed JSON source string into highlighted markup.
+ * Caller has already verified `JSON.parse(source)` succeeds.
+ */
+function tokenize(source: string): string {
+  let output = '';
+  let index = 0;
+  let pendingKey = false; // tracks whether the next string is an object key
+
+  while (index < source.length) {
+    const character = source[index];
+
+    if (character === undefined) break;
+
+    if (character === ' ' || character === '\t' || character === '\n' || character === '\r') {
+      output += escapeHtml(character);
+      index += 1;
+      continue;
+    }
+
+    if (character === '{') {
+      output += span('punctuation', '{');
+      pendingKey = true;
+      index += 1;
+      continue;
+    }
+
+    if (character === '}' || character === ']') {
+      output += span('punctuation', character);
+      index += 1;
+      continue;
+    }
+
+    if (character === '[') {
+      output += span('punctuation', '[');
+      pendingKey = false;
+      index += 1;
+      continue;
+    }
+
+    if (character === ',') {
+      output += span('punctuation', ',');
+      // The preceding context determines whether the next string is a key.
+      // We can't know without looking back; instead, re-set pendingKey based on
+      // the most recent unmatched opener. A cheap proxy: scan backward for the
+      // nearest `{` or `[` ignoring nested structures already emitted as spans.
+      pendingKey = mostRecentOpenerIsObject(source, index);
+      index += 1;
+      continue;
+    }
+
+    if (character === ':') {
+      output += span('punctuation', ':');
+      pendingKey = false; // values follow the colon
+      index += 1;
+      continue;
+    }
+
+    if (character === '"') {
+      const literal = readStringLiteral(source, index);
+      output += span(pendingKey ? 'key' : 'string', literal);
+      index += literal.length;
+      // After a key string, the next non-whitespace must be `:` and then a value.
+      // After a value string, the next non-whitespace is `,` or a closing bracket.
+      // pendingKey will be reset by `:` (to false) and by `,` (recomputed).
+      continue;
+    }
+
+    if (character === '-' || (character >= '0' && character <= '9')) {
+      const literal = readNumberLiteral(source, index);
+      output += span('number', literal);
+      index += literal.length;
+      continue;
+    }
+
+    if (source.startsWith(KEYWORD_TRUE, index)) {
+      output += span('boolean', KEYWORD_TRUE);
+      index += KEYWORD_TRUE.length;
+      continue;
+    }
+
+    if (source.startsWith(KEYWORD_FALSE, index)) {
+      output += span('boolean', KEYWORD_FALSE);
+      index += KEYWORD_FALSE.length;
+      continue;
+    }
+
+    if (source.startsWith(KEYWORD_NULL, index)) {
+      output += span('null', KEYWORD_NULL);
+      index += KEYWORD_NULL.length;
+      continue;
+    }
+
+    // Defensive: well-formed JSON has no other tokens. Emit the character
+    // escaped so we never mis-render unexpected input.
+    output += escapeHtml(character);
+    index += 1;
+  }
+
+  return `<code class="cinder-json">${output}</code>`;
+}
+
+/**
+ * Walk backward from `index` to find the nearest unmatched `{` or `[` and
+ * return true when it's `{` (object context where strings are keys).
+ */
+function mostRecentOpenerIsObject(source: string, index: number): boolean {
+  let depth = 0;
+  for (let cursor = index - 1; cursor >= 0; cursor -= 1) {
+    const character = source[cursor];
+    if (character === '"') {
+      // skip over the string literal we just passed
+      cursor -= 1;
+      while (cursor >= 0 && source[cursor] !== '"') {
+        cursor -= 1;
+      }
+      continue;
+    }
+    if (character === '}' || character === ']') {
+      depth += 1;
+      continue;
+    }
+    if (character === '{') {
+      if (depth === 0) return true;
+      depth -= 1;
+      continue;
+    }
+    if (character === '[') {
+      if (depth === 0) return false;
+      depth -= 1;
+      continue;
+    }
+  }
+  return false;
+}
+
+/**
+ * Highlight a JSON value as syntax-colored HTML. Non-JSON input is returned as
+ * a plain `<code>` with the input HTML-escaped, so the caller can wrap either
+ * result in the same `<pre>` for visual parity.
+ */
+export function highlightJson(value: string): string {
+  try {
+    JSON.parse(value);
+  } catch {
+    return plainCode(value);
+  }
+  return tokenize(value);
+}


### PR DESCRIPTION
## Summary

Seven UX issues from the chat playground, plus several follow-ups surfaced during manual review.

**Original seven (one commit each):**
1. **Collapse paired tool call/result** — paired `tool-result` is filtered from the rendered list and the outer message bubble is suppressed when a `tool-use` has a paired result, so `ToolCallGroup` is the only visible card. Adds `aria-controls` + a named `role="region"` for screen-reader navigation.
2. **Hover shake** — message footer is `position: absolute` instead of `grid-template-rows: 0fr→1fr`, so revealing the actions never changes layout.
3. **Copy button placement** — footer pinned to the bubble's center-facing edge with a hover-bridge via `padding`. Buttons drop to 44px tap targets with the icon visually centered. Narrow viewport (<480px) falls back to below-bubble.
4. **Jump-to-latest button** — was silently invisible because it referenced the non-existent `--cinder-surface-raised`. Swapped to `--cinder-surface`. Added 10 unit tests locking the at-bottom + jump hysteresis.
5. **JSON syntax highlighting** — built-in tokenizer at `utilities/json-highlight.ts` with key/string/number/boolean/null/punctuation token classes. `JSON.parse` first, falls through to plain escaped text on non-JSON input. Output is HTML-escaped and rendered via `{@html}` inside a `<pre>` shared with `CodeBlock`.
6. **Code-block padding parity + compact header copy button** — uniform `space-4` padding on `<pre>`, scoped borderless override for the in-header copy button.
7. **Chat contrast** — chat timeline uses `--cinder-surface-inset` (default surfaceMode only); assistant bubbles get `--cinder-shadow-sm` so they read as raised cards.

**Follow-up commits during manual playground review:**
- Tool-call card width capped at `min(80%, 48rem)` and internal padding tightened — was hugging into a narrow column with bloated vertical spacing.
- Toggle hover/focus states softened: subtle text-tinted hover instead of `--cinder-surface-hover` gray; inset `box-shadow` ring instead of an outline doubling the colored card border.
- Code-block padding parity also applied to the Shiki-replaced `<pre class="shiki">` element via a `.cinder-code-block > pre` sibling selector. The plain `__pre` class never matched the highlighter output, so this fix had been broken.
- **Icon sizing fixed across the project**: `icon-xs/sm/md/lg` classes had no CSS backing them — every lucide-svelte icon in the project was rendering at the 24px lucide default regardless of class. Added the utility rules to `styles/utilities.css`. Verified in Chrome that chat copy buttons (14px), code-block header copy (16px), and markdown editor toolbar glyphs (16px) now render at correct sizes.

## Files

- `packages/components/src/components/chat/container/use-chat-message-groups.svelte.ts` (+ new `.test.ts`) — paired tool-result filter
- `packages/components/src/components/chat/container/scroll-utilities.test.ts` (new) — hysteresis lock-in tests
- `packages/components/src/components/chat/container/chat-jump-controls.svelte` — jump button surface fix
- `packages/components/src/components/chat/container/chat.svelte` — inset chat-timeline background
- `packages/components/src/components/chat/message/chat-message.svelte` — hover shake, copy button placement, paired tool-pair shell suppression, contrast shadow
- `packages/components/src/components/chat/message/tool-call-group.svelte` — `aria-controls`/region, JSON highlighter wiring, tightened spacing, softer hover/focus
- `packages/components/src/components/code-block.test.ts` — parity assertion
- `packages/components/src/styles/components/code-block.css` — uniform padding (plain + Shiki), compact in-header copy override
- `packages/components/src/styles/components/json-highlight.css` (new) — JSON token colors
- `packages/components/src/styles/components.css` — wires the new stylesheet
- `packages/components/src/styles/utilities.css` — backs `icon-xs/sm/md/lg` with real sizes
- `packages/components/src/utilities/json-highlight.ts` (+ new `.test.ts`) — hand-rolled tokenizer + 14 tests

## Review status

Committee-review (frontend-architect, ux-designer, typescript-expert, testing-expert, security-reviewer, simplicity-engineer, junior-engineer, plus Codex) ran one round. Several real items were surfaced — most have been addressed in the follow-up commits. **The following items remain as known follow-ups for a separate PR rather than blocking this one:**

- **`mostRecentOpenerIsObject` in `json-highlight.ts` mishandles escaped quotes in keys** (e.g. `{"a\"b": 1, "c": 2}` misclassifies `"c"`). Cosmetic — affects token color only, not safety; HTML-escape applies regardless. Multiple reviewers also suggested replacing the O(n²) backward scan with a forward stack — bundle both fixes together.
- **`expect(html).toContain('')` vacuous assertion** in `json-highlight.test.ts:44` — line tests nothing because of a ternary that evaluates to `''` at construction time.
- **`scroll-utilities.ts` has untested exports** (`calculateUnreadCount`, `findUnreadBoundaryIndex`, `formatUnreadCount`, `isLargeCount`, `extractTimestamp`) — pre-existing gap that the file-touch surfaced.
- **`aria-label="Tool details"` is non-unique** when multiple tool calls are expanded — should include the tool name.
- **Tool-pair `display: none` on footer also hides consumer-supplied `actions` snippets** — should suppress just the default copy/edit children, not custom slot content.
- **`--cinder-warning` (number token) contrast against `--cinder-surface-inset` light mode** is approximately 4.2:1, just under WCAG AA's 4.5:1.

## Test plan

- [x] `bun run typecheck` — 0 errors
- [x] `bun run lint` — 0 errors (9 pre-existing warnings unchanged)
- [x] `bun run test` — 650+ pass, 0 fail (24 new tests across `scroll-utilities`, `use-chat-message-groups`, `json-highlight`, `code-block`)
- [x] Manual Chrome verification at `/c/chat`, `/c/code-block`, `/c/markdown-editor` — every fix confirmed via `getComputedStyle` and screenshots
- [ ] Verify dark-mode rendering (light only was screenshot-tested)
- [ ] VoiceOver pass on `with-tool-calls` example to confirm "Tool call: exports_check" announcement
- [ ] Test hover-bridge behavior with slow diagonal pointer movement

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Mostly UI/UX and styling updates, but it introduces a new `highlightJson()` tokenizer rendered via `{@html}` in `ToolCallGroup`, which is correctness/XSS-sensitive despite explicit escaping and tests.
> 
> **Overview**
> Improves chat timeline UX and visual contrast: adds an inset timeline background (default surface mode only), fixes the jump-to-latest button styling token, and reworks per-message action controls so hover/focus no longer changes layout and actions sit beside user/assistant bubbles with mobile fallback.
> 
> Tool-call rendering is consolidated by filtering paired `tool-result` messages from the grouped list and suppressing the outer message bubble for paired `tool-use` messages so `ToolCallGroup` is the single canonical card; related accessibility is tightened with `aria-controls`/`role="region"` and better labels.
> 
> Adds JSON syntax highlighting for tool-call arguments/results via a new `utilities/json-highlight.ts` (HTML-escaped tokenizer + styles), tightens `ToolCallGroup` spacing/hover/focus visuals, fixes code-block padding parity for both plain and highlighter-produced `<pre>` (e.g. Shiki), and adds icon size utility CSS plus new unit tests covering scroll hysteresis, tool-result filtering, JSON highlighting, and code-block header structure.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8fde285a27d5a92399254715c3c066fb9aa4391d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->