### PR TITLE
Make playground story switching instant; add top control bar

### DIFF
--- a/packages/playground/src/render-shell.test.ts
+++ b/packages/playground/src/render-shell.test.ts
@@ -1,0 +1,78 @@
+/**
+ * Tests for the small surface exposed by `render-shell.ts`:
+ *
+ * - `jsonForScriptTag` is the escaping policy that keeps the
+ *   `<script type="application/json" id="cinder-initial">` data island safe
+ *   from `</script>` injection and U+2028/U+2029 historical edge cases.
+ * - `renderShell` integrates the policy with the rest of the scaffold and
+ *   must always produce a payload that parses cleanly back to the original
+ *   shape after `JSON.parse`.
+ */
+
+import { describe, expect, it } from 'bun:test';
+
+import { jsonForScriptTag, renderShell } from './render-shell.ts';
+
+describe('jsonForScriptTag', () => {
+  it('escapes < and > so a `</script>` substring cannot close the tag', () => {
+    const escaped = jsonForScriptTag({ component: '</script><img src=x>' });
+    expect(escaped).not.toContain('</script>');
+    expect(escaped).not.toContain('<img');
+    expect(escaped).toContain('\\u003c');
+  });
+
+  it('escapes ampersand so HTML-encoded sequences in values stay literal', () => {
+    const escaped = jsonForScriptTag({ component: 'a&b' });
+    expect(escaped).not.toContain('&');
+    expect(escaped).toContain('\\u0026');
+  });
+
+  it('escapes U+2028 (LINE SEPARATOR)', () => {
+    const dangerous = `line${String.fromCharCode(0x2028)}separator`;
+    const escaped = jsonForScriptTag({ component: dangerous });
+    expect(escaped).not.toContain(String.fromCharCode(0x2028));
+    expect(escaped).toContain('\\u2028');
+  });
+
+  it('escapes U+2029 (PARAGRAPH SEPARATOR)', () => {
+    const dangerous = `para${String.fromCharCode(0x2029)}separator`;
+    const escaped = jsonForScriptTag({ component: dangerous });
+    expect(escaped).not.toContain(String.fromCharCode(0x2029));
+    expect(escaped).toContain('\\u2029');
+  });
+
+  it('produces valid JSON that round-trips through JSON.parse', () => {
+    const payload = { component: 'button', components: ['button', 'avatar', '<x>'] };
+    const escaped = jsonForScriptTag(payload);
+    const parsed = JSON.parse(escaped) as typeof payload;
+    expect(parsed).toEqual(payload);
+  });
+});
+
+describe('renderShell', () => {
+  it('embeds the active component and component list in the data island', () => {
+    const html = renderShell('button', ['button', 'avatar']);
+    const match = /<script type="application\/json" id="cinder-initial">([^<]+)<\/script>/.exec(
+      html,
+    );
+    expect(match).not.toBeNull();
+    const payload = JSON.parse(match![1]!) as { component: string; components: string[] };
+    expect(payload.component).toBe('button');
+    expect(payload.components).toEqual(['button', 'avatar']);
+  });
+
+  it('renders the shell-bundle script tag and #shell-root mount point', () => {
+    const html = renderShell('button', ['button']);
+    expect(html).toContain('id="shell-root"');
+    expect(html).toContain('/shell-bundle/shell.js');
+  });
+
+  it('does not allow component names to break the data island via injection', () => {
+    // A hypothetical bad component name is still valid input to the renderer
+    // (the kebab-case invariant is enforced separately by the server); the
+    // escaper has to handle whatever comes in.
+    const html = renderShell('button', ['button', '</script><script>alert(1)</script>']);
+    expect(html).not.toContain('</script><script>alert(1)</script>');
+    expect(html).toContain('id="cinder-initial"');
+  });
+});

--- a/packages/playground/src/render-shell.ts
+++ b/packages/playground/src/render-shell.ts
@@ -25,8 +25,10 @@ const PARAGRAPH_SEPARATOR = String.fromCharCode(0x2029);
  * have terminated script bodies in some historical parsers). Replacing these
  * with `\uXXXX` escapes keeps the payload valid JSON AND safe inside a script
  * tag.
+ *
+ * Exported so the same escaping policy can be verified by unit tests.
  */
-function jsonForScriptTag(value: unknown): string {
+export function jsonForScriptTag(value: unknown): string {
   return JSON.stringify(value)
     .replaceAll('<', '\\u003c')
     .replaceAll('>', '\\u003e')
@@ -34,6 +36,25 @@ function jsonForScriptTag(value: unknown): string {
     .replaceAll(LINE_SEPARATOR, '\\u2028')
     .replaceAll(PARAGRAPH_SEPARATOR, '\\u2029');
 }
+
+/**
+ * Inline script body that applies a persisted theme to `:root` before any
+ * stylesheet or bundle runs. Same source of truth for both the shell scaffold
+ * and the iframe page (`renderComponentPage`) so the localStorage key, the
+ * try/catch policy, and the validation rules stay in sync. If you change the
+ * theme storage key, change `THEME_STORAGE_KEY` in `preview-store.svelte.ts`
+ * to match.
+ */
+export const PRE_PAINT_THEME_SCRIPT = `
+      (function () {
+        try {
+          var theme = localStorage.getItem('cinder-playground-theme');
+          if (theme === 'light' || theme === 'dark') {
+            document.documentElement.style.colorScheme = theme;
+          }
+        } catch (e) { /* ignore — localStorage unavailable in private mode etc. */ }
+      })();
+    `;
 
 /** Escape a string for safe use in HTML text content and attribute values. */
 function escapeHtml(text: string): string {
@@ -61,20 +82,7 @@ export function renderShell(activeComponent: string | null, components: string[]
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>${title}</title>
-    <script>
-      // Pre-paint theme application. Runs synchronously before the shell
-      // bundle loads so the user never sees a flash of system-default theme
-      // when they have a persisted preference. Falls back silently to
-      // "system" if localStorage is unavailable (private browsing, etc.).
-      (function () {
-        try {
-          var theme = localStorage.getItem('cinder-playground-theme');
-          if (theme === 'light' || theme === 'dark') {
-            document.documentElement.style.colorScheme = theme;
-          }
-        } catch (e) { /* ignore */ }
-      })();
-    </script>
+    <script>${PRE_PAINT_THEME_SCRIPT}</script>
     <style>
       *, *::before, *::after {
         box-sizing: border-box;

--- a/packages/playground/src/render-shell.ts
+++ b/packages/playground/src/render-shell.ts
@@ -96,6 +96,15 @@ export function renderShell(activeComponent: string | null, components: string[]
         padding: 0;
       }
 
+      /* light-dark() needs an active color-scheme to know which value to
+         return. Without this declaration, light-dark() always returns its
+         first argument, so system-preference dark-mode users see a light
+         flash before the SPA mounts. The pre-paint script overrides this
+         to a concrete light/dark for explicit theme choices. */
+      html {
+        color-scheme: light dark;
+      }
+
       html, body, #shell-root {
         height: 100%;
       }

--- a/packages/playground/src/render-shell.ts
+++ b/packages/playground/src/render-shell.ts
@@ -1,3 +1,40 @@
+/**
+ * Renders the minimal HTML scaffold for the cinder playground shell.
+ *
+ * The scaffold is intentionally tiny: it sets up a `#shell-root` mount point,
+ * embeds initial data via a `<script type="application/json">` data island,
+ * and loads the compiled shell-app bundle. Everything else — sidebar, top
+ * control bar, iframe — is rendered by the Svelte 5 SPA that boots from
+ * `shell-app/shell-entry.ts`.
+ *
+ * The data-island pattern (instead of `window.__GLOBAL__ = JSON.stringify(...)`)
+ * eliminates `</script>` injection vectors and is the standard SSR-hydration
+ * shape. The JSON body still gets defensive escaping for `<`, `>`, `&`, and
+ * the Unicode line separators U+2028/U+2029, which are valid in JSON but
+ * terminate a script body in some parsers.
+ */
+
+const LINE_SEPARATOR = String.fromCharCode(0x2028);
+const PARAGRAPH_SEPARATOR = String.fromCharCode(0x2029);
+
+/**
+ * Escape a string value so it's safe to embed inside the body of a
+ * `<script type="application/json">` tag. JSON.stringify alone is not enough
+ * because the resulting string may contain literal `</script>` substrings (if
+ * a value embedded a tag close) or U+2028/U+2029 (which are valid in JSON but
+ * have terminated script bodies in some historical parsers). Replacing these
+ * with `\uXXXX` escapes keeps the payload valid JSON AND safe inside a script
+ * tag.
+ */
+function jsonForScriptTag(value: unknown): string {
+  return JSON.stringify(value)
+    .replaceAll('<', '\\u003c')
+    .replaceAll('>', '\\u003e')
+    .replaceAll('&', '\\u0026')
+    .replaceAll(LINE_SEPARATOR, '\\u2028')
+    .replaceAll(PARAGRAPH_SEPARATOR, '\\u2029');
+}
+
 /** Escape a string for safe use in HTML text content and attribute values. */
 function escapeHtml(text: string): string {
   return text
@@ -8,35 +45,15 @@ function escapeHtml(text: string): string {
     .replace(/'/g, '&#39;');
 }
 
-/**
- * Renders the full HTML shell for the cinder component playground.
- *
- * Returns a plain HTML string — no framework, no bundler dependency.
- * The shell consists of a fixed sidebar nav listing all components
- * alphabetically and a main area containing an iframe for the active component.
- * A small inline script establishes a Server-Sent Events connection to `/events`
- * and reloads the page on a `reload` message.
- */
 export function renderShell(activeComponent: string | null, components: string[]): string {
   const title = activeComponent
     ? `cinder playground — ${escapeHtml(activeComponent)}`
     : 'cinder playground';
 
-  const navItems = components
-    .map((name) => {
-      const isActive = name === activeComponent;
-      const ariaCurrent = isActive ? ' aria-current="page"' : '';
-      // Component names are validated by isSafeSegment (/^[a-z0-9][a-z0-9-]*$/),
-      // so they're safe in URL paths. Escape only the visible text node.
-      return `      <li><a href="/c/${name}"${ariaCurrent}>${escapeHtml(name)}</a></li>`;
-    })
-    .join('\n');
-
-  // The iframe targets /page/:name (the component page content route), not /c/:name
-  // (the shell route). Pointing an iframe at its own shell URL would cause recursive loading.
-  const mainContent = activeComponent
-    ? `<iframe src="/page/${activeComponent}" title="${escapeHtml(activeComponent)} preview"></iframe>`
-    : `<div class="placeholder"><p>Select a component from the sidebar to preview it.</p></div>`;
+  const initialData = {
+    component: activeComponent ?? '',
+    components,
+  };
 
   return `<!DOCTYPE html>
 <html lang="en">
@@ -44,6 +61,20 @@ export function renderShell(activeComponent: string | null, components: string[]
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>${title}</title>
+    <script>
+      // Pre-paint theme application. Runs synchronously before the shell
+      // bundle loads so the user never sees a flash of system-default theme
+      // when they have a persisted preference. Falls back silently to
+      // "system" if localStorage is unavailable (private browsing, etc.).
+      (function () {
+        try {
+          var theme = localStorage.getItem('cinder-playground-theme');
+          if (theme === 'light' || theme === 'dark') {
+            document.documentElement.style.colorScheme = theme;
+          }
+        } catch (e) { /* ignore */ }
+      })();
+    </script>
     <style>
       *, *::before, *::after {
         box-sizing: border-box;
@@ -51,111 +82,22 @@ export function renderShell(activeComponent: string | null, components: string[]
         padding: 0;
       }
 
-      html, body {
+      html, body, #shell-root {
         height: 100%;
       }
 
       body {
-        display: flex;
         font-family: system-ui, -apple-system, sans-serif;
         font-size: 14px;
-        background: #f5f5f5;
-        color: #111;
-      }
-
-      nav {
-        width: 220px;
-        min-width: 220px;
-        height: 100vh;
-        position: fixed;
-        top: 0;
-        left: 0;
-        background: #fff;
-        border-right: 1px solid #e5e5e5;
-        overflow-y: auto;
-        display: flex;
-        flex-direction: column;
-      }
-
-      nav .nav-header {
-        padding: 16px;
-        font-weight: 700;
-        font-size: 13px;
-        letter-spacing: 0.04em;
-        text-transform: uppercase;
-        color: #666;
-        border-bottom: 1px solid #e5e5e5;
-      }
-
-      nav ul {
-        list-style: none;
-        padding: 8px 0;
-        flex: 1;
-      }
-
-      nav ul li a {
-        display: block;
-        padding: 6px 16px;
-        text-decoration: none;
-        color: #333;
-        border-radius: 4px;
-        margin: 1px 8px;
-        transition: background 0.1s;
-      }
-
-      nav ul li a:hover {
-        background: #f0f0f0;
-      }
-
-      nav ul li a[aria-current="page"] {
-        background: #e8f0fe;
-        color: #1a56db;
-        font-weight: 600;
-      }
-
-      main {
-        margin-left: 220px;
-        flex: 1;
-        height: 100vh;
-        display: flex;
-        flex-direction: column;
-      }
-
-      main iframe {
-        flex: 1;
-        width: 100%;
-        height: 100%;
-        border: none;
-        background: #fff;
-      }
-
-      main .placeholder {
-        flex: 1;
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        color: #888;
-      }
-
-      main .placeholder p {
-        font-size: 16px;
+        background: light-dark(#f5f5f5, #1a1a1a);
+        color: light-dark(#111, #eee);
       }
     </style>
   </head>
   <body>
-    <nav>
-      <div class="nav-header">cinder</div>
-      <ul>
-${navItems}
-      </ul>
-    </nav>
-    <main>
-      ${mainContent}
-    </main>
-    <script>
-      const es = new EventSource('/events');
-      es.addEventListener('reload', () => location.reload());
-    </script>
+    <script type="application/json" id="cinder-initial">${jsonForScriptTag(initialData)}</script>
+    <div id="shell-root"></div>
+    <script type="module" src="/shell-bundle/shell.js"></script>
   </body>
 </html>`;
 }

--- a/packages/playground/src/render-shell.ts
+++ b/packages/playground/src/render-shell.ts
@@ -47,12 +47,18 @@ export function jsonForScriptTag(value: unknown): string {
  */
 export const PRE_PAINT_THEME_SCRIPT = `
       (function () {
+        var theme = 'system';
         try {
-          var theme = localStorage.getItem('cinder-playground-theme');
-          if (theme === 'light' || theme === 'dark') {
-            document.documentElement.style.colorScheme = theme;
-          }
+          var stored = localStorage.getItem('cinder-playground-theme');
+          if (stored === 'light' || stored === 'dark' || stored === 'system') theme = stored;
         } catch (e) { /* ignore — localStorage unavailable in private mode etc. */ }
+        if (theme === 'light' || theme === 'dark') {
+          document.documentElement.style.colorScheme = theme;
+        }
+        // data-cinder-theme is the authoritative theme-choice signal — read it
+        // from CSS instead of sniffing the inline color-scheme style. Reflects
+        // 'system' explicitly so CSS can branch on prefers-color-scheme.
+        document.documentElement.dataset.cinderTheme = theme;
       })();
     `;
 

--- a/packages/playground/src/server.test.ts
+++ b/packages/playground/src/server.test.ts
@@ -70,7 +70,23 @@ describe('/c/:name', () => {
     expect(response.headers.get('Content-Type')).toBe('text/html');
     const html = await response.text();
     expect(html).toContain('<!DOCTYPE html>');
-    expect(html).toContain('<nav>');
+    // Shell SPA scaffolding: mount point, data island, and bundle tag.
+    expect(html).toContain('id="shell-root"');
+    expect(html).toContain('id="cinder-initial"');
+    expect(html).toContain('/shell-bundle/shell.js');
+  });
+
+  it('embeds the active component name in the cinder-initial data island', async () => {
+    const response = await handleRequest(req('/c/button'));
+    const html = await response.text();
+    const match = html.match(
+      /<script type="application\/json" id="cinder-initial">([^<]+)<\/script>/,
+    );
+    expect(match).not.toBeNull();
+    const payload = JSON.parse(match![1]!) as { component: string; components: string[] };
+    expect(payload.component).toBe('button');
+    expect(payload.components).toContain('button');
+    expect(payload.components).toContain('avatar');
   });
 
   it('returns 404 for an unknown component', async () => {
@@ -85,6 +101,23 @@ describe('/c/:name', () => {
 
   it('returns 404 for segments starting with a hyphen', async () => {
     const response = await handleRequest(req('/c/-bad'));
+    expect(response.status).toBe(404);
+  });
+});
+
+describe('/shell-bundle/:filename.js', () => {
+  it('returns 200 application/javascript for the canonical /shell.js entry', async () => {
+    const response = await handleRequest(req('/shell-bundle/shell.js'));
+    expect(response.status).toBe(200);
+    expect(response.headers.get('Content-Type')).toBe('application/javascript');
+    const body = await response.text();
+    // Shell bundle must mount the SPA — the mount target ID is part of the
+    // public contract between the bundle and render-shell.ts.
+    expect(body).toContain('shell-root');
+  }, 30_000);
+
+  it('returns 404 for an unknown shell-bundle filename', async () => {
+    const response = await handleRequest(req('/shell-bundle/does-not-exist.js'));
     expect(response.status).toBe(404);
   });
 });

--- a/packages/playground/src/server.test.ts
+++ b/packages/playground/src/server.test.ts
@@ -337,6 +337,41 @@ describe('triggerReload', () => {
     await reader.cancel();
     expect(() => triggerReload()).not.toThrow();
   });
+
+  // The shell SPA's EventSource listener branches on the event-type line of
+  // the SSE record. If the wire format ever drifts (typo, casing, missing
+  // newlines), live-reload silently breaks. These tests pin the format.
+  it("emits the literal 'event: reload' line for the default event type", async () => {
+    const response = await handleRequest(req('/events'));
+    const reader = response.body!.getReader();
+    await reader.read(); // consume handshake comment
+
+    triggerReload();
+
+    const { value } = await reader.read();
+    const text = value instanceof Uint8Array ? new TextDecoder().decode(value) : String(value);
+    expect(text).toContain('event: reload');
+    expect(text).toContain('data: {}');
+    await reader.cancel();
+  });
+
+  it("emits 'event: shell-reload' when called with shell-reload", async () => {
+    const response = await handleRequest(req('/events'));
+    const reader = response.body!.getReader();
+    await reader.read();
+
+    triggerReload('shell-reload');
+
+    const { value } = await reader.read();
+    const text = value instanceof Uint8Array ? new TextDecoder().decode(value) : String(value);
+    expect(text).toContain('event: shell-reload');
+    expect(text).toContain('data: {}');
+    await reader.cancel();
+  });
+
+  it('does not throw when shell-reload is dispatched with no connected clients', () => {
+    expect(() => triggerReload('shell-reload')).not.toThrow();
+  });
 });
 
 describe('unknown routes', () => {

--- a/packages/playground/src/server.ts
+++ b/packages/playground/src/server.ts
@@ -274,9 +274,6 @@ async function repopulateBundleCaches(
         failedPages.push(name);
       }
     }
-    // Manifest cache also needs invalidation since the watcher saw a src change.
-    manifestCache = null;
-    manifestPromise = null;
   } catch (error) {
     console.error('[playground] rebuild fatal error:', error);
     fatalRebuildFailed = true;
@@ -287,6 +284,12 @@ async function repopulateBundleCaches(
   if (generation !== rebuildGeneration) return;
   // Fatal error: do NOT touch caches at all.
   if (fatalRebuildFailed) return;
+
+  // Manifest cache invalidation is part of the publish step — a stale
+  // rebuild that lost the generation race must NOT clear it, since a newer
+  // rebuild may already have populated a fresh manifest.
+  manifestCache = null;
+  manifestPromise = null;
 
   // Atomic per-family swap. We .clear() then re-populate the existing Map
   // instances so any reference captured by a route handler stays valid.
@@ -419,12 +422,18 @@ function startWatcher(): FSWatcher[] {
 }
 
 /**
- * Shared Bun.build options for both bundle families.
+ * Shared Bun.build options used by every family.
  *
- * All artifacts use a flat namespace under `/page-bundle/` so that
- * dynamic-import URLs emitted by either family resolve through one route.
- * Putting chunks in a `chunks/` subdir triggers a Bun publicPath quirk
- * where peer-chunk imports get the subdirectory stripped from their URL.
+ * Each compile site supplies its own `publicPath` so that dynamic-import URLs
+ * emitted by the splitter resolve through the matching route. The shell entry
+ * has no dynamic imports today, but parameterizing `publicPath` keeps the
+ * route boundary honest the moment a shell descendant ever uses `import()`,
+ * rather than relying on `findArtifactForFamily`'s cross-family fallback to
+ * paper over chunks that bake in the wrong URL.
+ *
+ * Putting chunks in a `chunks/` subdir triggers a Bun publicPath quirk where
+ * peer-chunk imports get the subdirectory stripped from their URL, so the
+ * naming template stays flat.
  */
 const SHARED_BUILD_OPTIONS = {
   plugins: [sveltePlugin({ generate: 'client', injectCss: true })],
@@ -432,13 +441,26 @@ const SHARED_BUILD_OPTIONS = {
   format: 'esm',
   conditions: ['bun'],
   splitting: true,
-  publicPath: '/page-bundle/',
   naming: {
     entry: '[name]-[hash].js',
     chunk: '[name]-[hash].js',
     asset: '[name]-[hash][ext]',
   },
-} as const satisfies Omit<Parameters<typeof Bun.build>[0], 'entrypoints'>;
+} as const satisfies Omit<Parameters<typeof Bun.build>[0], 'entrypoints' | 'publicPath'>;
+
+/**
+ * Per-family `publicPath` baked into each emitted chunk's import URL.
+ *
+ * The page and scenario families share `/page-bundle/` because scenario chunks
+ * have always resolved through that route — there is no separate scenario
+ * bundle route. Shell gets its own `/shell-bundle/` so any future dynamic
+ * import in the shell tree resolves through the shell route.
+ */
+const PUBLIC_PATH_BY_FAMILY: Record<ArtifactFamily, string> = {
+  page: '/page-bundle/',
+  shell: '/shell-bundle/',
+  scenario: '/page-bundle/',
+};
 
 /**
  * Walk `result.outputs` and return the entry path/code plus a map of EVERY
@@ -520,7 +542,11 @@ async function buildBundle(componentName: string, scenario: string): Promise<str
     // is idempotent for a missing dir).
     await Bun.write(entryTempPath, shim);
 
-    const result = await Bun.build({ entrypoints: [entryTempPath], ...SHARED_BUILD_OPTIONS });
+    const result = await Bun.build({
+      entrypoints: [entryTempPath],
+      publicPath: PUBLIC_PATH_BY_FAMILY.scenario,
+      ...SHARED_BUILD_OPTIONS,
+    });
 
     if (!result.success) {
       console.error(`[playground] Bundle failed for ${componentName}/${scenario}:`, result.logs);
@@ -674,7 +700,11 @@ mount(ComponentPage, { target });
   try {
     await Bun.write(entryTempPath, entrySource);
 
-    const result = await Bun.build({ entrypoints: [entryTempPath], ...SHARED_BUILD_OPTIONS });
+    const result = await Bun.build({
+      entrypoints: [entryTempPath],
+      publicPath: PUBLIC_PATH_BY_FAMILY.page,
+      ...SHARED_BUILD_OPTIONS,
+    });
 
     if (!result.success) {
       console.error(`[playground] page bundle failed for ${componentName}:`, result.logs);
@@ -752,7 +782,11 @@ async function compileShellBundleArtifacts(): Promise<{
   try {
     await Bun.write(entryTempPath, shim);
 
-    const result = await Bun.build({ entrypoints: [entryTempPath], ...SHARED_BUILD_OPTIONS });
+    const result = await Bun.build({
+      entrypoints: [entryTempPath],
+      publicPath: PUBLIC_PATH_BY_FAMILY.shell,
+      ...SHARED_BUILD_OPTIONS,
+    });
 
     if (!result.success) {
       console.error('[playground] shell bundle failed:', result.logs);

--- a/packages/playground/src/server.ts
+++ b/packages/playground/src/server.ts
@@ -114,13 +114,12 @@ const ENTRY_PREFIXES: Record<ArtifactFamily, string> = {
  * match.
  */
 function findArtifactForFamily(family: ArtifactFamily, path: string): string | undefined {
-  const ownMap =
-    family === 'page'
-      ? pageArtifactByPath
-      : family === 'shell'
-        ? shellArtifactByPath
-        : scenarioArtifactByPath;
-  const ownHit = ownMap.get(path);
+  const allMaps: Record<ArtifactFamily, Map<string, string>> = {
+    page: pageArtifactByPath,
+    shell: shellArtifactByPath,
+    scenario: scenarioArtifactByPath,
+  };
+  const ownHit = allMaps[family].get(path);
   if (ownHit !== undefined) return ownHit;
 
   // Cross-family fallback is restricted to chunk-style artifacts (no entry
@@ -131,11 +130,13 @@ function findArtifactForFamily(family: ArtifactFamily, path: string): string | u
   );
   if (isEntryName) return undefined;
 
-  return (
-    pageArtifactByPath.get(path) ??
-    shellArtifactByPath.get(path) ??
-    scenarioArtifactByPath.get(path)
-  );
+  // Search every map *except* the requesting family's own (already checked).
+  for (const otherFamily of Object.keys(allMaps) as ArtifactFamily[]) {
+    if (otherFamily === family) continue;
+    const hit = allMaps[otherFamily].get(path);
+    if (hit !== undefined) return hit;
+  }
+  return undefined;
 }
 
 /** Resolved manifest array — cached after first analysis. */
@@ -747,8 +748,16 @@ async function buildPageBundle(componentName: string): Promise<string | null> {
   const entry = await compilePageBundleArtifacts(componentName);
   if (entry === null) return null;
 
+  // We always publish the artifacts: the entry code we're about to return
+  // statically imports content-hashed chunk URLs, and if those chunks aren't
+  // in the cache, the browser's chunk requests will 404. Chunk filenames are
+  // content-hashed, so writing them is safe even if a newer watcher rebuild
+  // already wrote the same chunks — the bytes are identical.
+  for (const [path, code] of entry.artifacts) pageArtifactByPath.set(path, code);
+  // Only update the entry-by-name mapping when we're not racing a newer
+  // rebuild. Stale generations skip this so the watcher's atomic publish
+  // remains authoritative for the entry-name → hashed-entry mapping.
   if (generationAtStart === rebuildGeneration && currentRebuild === null) {
-    for (const [path, code] of entry.artifacts) pageArtifactByPath.set(path, code);
     pageEntryByName.set(componentName, entry.entryPath);
   }
   return entry.entryCode;
@@ -823,8 +832,11 @@ async function buildShellBundle(): Promise<string | null> {
   const entry = await compileShellBundleArtifacts();
   if (entry === null) return null;
 
+  // Always publish chunks (see buildPageBundle's comment for the rationale —
+  // the entry we're returning has static imports to content-hashed chunks
+  // that must be servable).
+  for (const [path, code] of entry.artifacts) shellArtifactByPath.set(path, code);
   if (generationAtStart === rebuildGeneration && currentRebuild === null) {
-    for (const [path, code] of entry.artifacts) shellArtifactByPath.set(path, code);
     shellEntryByName.set('shell', entry.entryPath);
   }
   return entry.entryCode;

--- a/packages/playground/src/server.ts
+++ b/packages/playground/src/server.ts
@@ -29,7 +29,7 @@ import type { BuildArtifact } from 'bun';
 import { sveltePlugin } from '../../components/scripts/svelte-plugin.ts';
 import { analyzeAll } from './analyze.ts';
 import { discoverComponents, discoverExamples, discoverSidebarComponents } from './discover.ts';
-import { renderShell } from './render-shell.ts';
+import { PRE_PAINT_THEME_SCRIPT, renderShell } from './render-shell.ts';
 
 import type { ComponentManifest } from './types.ts';
 
@@ -78,10 +78,59 @@ const shellArtifactByPath = new Map<string, string>();
 const scenarioArtifactByPath = new Map<string, string>();
 
 /**
- * Look up an artifact across every family. Used by route handlers that need
- * to serve any compiled chunk regardless of which build produced it.
+ * Family identifier used by `findArtifactForFamily` to constrain which
+ * artifacts a given route may serve. Each family corresponds to one of the
+ * three artifact maps.
  */
-function findArtifact(path: string): string | undefined {
+type ArtifactFamily = 'page' | 'shell' | 'scenario';
+
+/**
+ * Prefixes that identify a hashed entry artifact for each bundle family.
+ * Bun's `naming` template uses the entrypoint basename for `[name]`, and
+ * each family's compile step writes its entry basename with one of these
+ * prefixes (see `compilePageBundleArtifacts`, `compileShellBundleArtifacts`,
+ * and `buildBundle`). Content-hashed peer chunks (e.g. `core-abc123.js`,
+ * `commonmark-def456.js`) do NOT have any of these prefixes — they're
+ * emitted by Bun's code-splitter without a family label.
+ */
+const ENTRY_PREFIXES: Record<ArtifactFamily, string> = {
+  page: 'page-',
+  shell: 'shell-',
+  scenario: 'bundle-',
+};
+
+/**
+ * Look up an artifact for a specific bundle family route.
+ *
+ * Rules:
+ * - The requesting family's own map is searched first.
+ * - On miss, other family maps are searched ONLY for chunk-style artifacts
+ *   (names that don't begin with any family's entry prefix). This allows
+ *   shared content-hashed chunks to be served regardless of which build
+ *   produced them, while preventing `/shell-bundle/page-button-abc.js`
+ *   from being satisfied by a page-bundle entry artifact in the page map.
+ *
+ * Returns the artifact source, or `undefined` if no family has a permitted
+ * match.
+ */
+function findArtifactForFamily(family: ArtifactFamily, path: string): string | undefined {
+  const ownMap =
+    family === 'page'
+      ? pageArtifactByPath
+      : family === 'shell'
+        ? shellArtifactByPath
+        : scenarioArtifactByPath;
+  const ownHit = ownMap.get(path);
+  if (ownHit !== undefined) return ownHit;
+
+  // Cross-family fallback is restricted to chunk-style artifacts (no entry
+  // prefix). Entries belong to their family and must not be served under
+  // another family's route.
+  const isEntryName = (Object.values(ENTRY_PREFIXES) as readonly string[]).some((prefix) =>
+    path.startsWith(prefix),
+  );
+  if (isEntryName) return undefined;
+
   return (
     pageArtifactByPath.get(path) ??
     shellArtifactByPath.get(path) ??
@@ -263,8 +312,17 @@ async function repopulateBundleCaches(
   if (failedPages.length > 0) {
     console.error(`[playground] rebuild: failed components: ${failedPages.join(', ')}`);
   }
+  if (shellSourceChanged && !shellBuildSucceeded) {
+    // The user edited a shell-app source but the rebuild produced no new
+    // shell bundle. Surface a prominent warning so it's clear from the
+    // terminal why the browser didn't pick up their change.
+    console.error(
+      '[playground] shell source changed but shell rebuild failed — running shell preserved; no shell-reload emitted',
+    );
+  }
 
-  // Emit exactly one event per successful publish.
+  // Emit exactly one event per publish. `shell-reload` only fires when shell
+  // sources actually changed AND the new shell bundle is in the cache.
   if (shellSourceChanged && shellBuildSucceeded) triggerReload('shell-reload');
   else triggerReload('reload');
 }
@@ -640,6 +698,13 @@ mount(ComponentPage, { target });
  * Used by the `/page-bundle/:filename.js` route as a fallback when an
  * eagerly-pre-built bundle isn't already in the cache (e.g. a component
  * whose pre-build failed, or a brand-new component added after server start).
+ *
+ * Concurrency: captures `rebuildGeneration` before the build starts and
+ * skips publishing if the watcher rebuilt during the compile (the watcher's
+ * atomic publish is newer and shouldn't be overwritten by our older result).
+ * The compiled artifacts are still returned to the caller, so the request
+ * that triggered the lazy build is served correctly; only the shared cache
+ * is left alone in the race-loss case.
  */
 async function buildPageBundle(componentName: string): Promise<string | null> {
   const cachedEntryPath = pageEntryByName.get(componentName);
@@ -648,11 +713,14 @@ async function buildPageBundle(componentName: string): Promise<string | null> {
     if (cached !== undefined) return cached;
   }
 
+  const generationAtStart = rebuildGeneration;
   const entry = await compilePageBundleArtifacts(componentName);
   if (entry === null) return null;
 
-  for (const [path, code] of entry.artifacts) pageArtifactByPath.set(path, code);
-  pageEntryByName.set(componentName, entry.entryPath);
+  if (generationAtStart === rebuildGeneration && currentRebuild === null) {
+    for (const [path, code] of entry.artifacts) pageArtifactByPath.set(path, code);
+    pageEntryByName.set(componentName, entry.entryPath);
+  }
   return entry.entryCode;
 }
 
@@ -675,7 +743,11 @@ async function compileShellBundleArtifacts(): Promise<{
   const entryBasename = 'shell-shell';
   const entryTempDir = join(PLAYGROUND_ROOT, 'src', `.tmp-${randomUUID()}`);
   const entryTempPath = join(entryTempDir, `${entryBasename}.ts`);
-  const shim = `export {} from '../shell-app/shell-entry.ts';\n`;
+  // Side-effect import: `shell-entry.ts` calls `mount(Shell, ...)` at module
+  // top level and exports nothing. `export {} from` is a re-export of named
+  // bindings and is eligible for tree-shaking when the source exports no
+  // names; a bare side-effect import preserves the module's evaluation.
+  const shim = `import '../shell-app/shell-entry.ts';\n`;
 
   try {
     await Bun.write(entryTempPath, shim);
@@ -702,7 +774,9 @@ async function compileShellBundleArtifacts(): Promise<{
 /**
  * Lazy-build wrapper: compile the shell bundle and publish into shared
  * caches. Used by `/shell-bundle/shell.js` as a fallback when the shell
- * bundle isn't already cached.
+ * bundle isn't already cached. Same race-discipline as `buildPageBundle`
+ * (see the doc-comment there): skip the shared-cache publish if the
+ * watcher rebuilt during the compile.
  */
 async function buildShellBundle(): Promise<string | null> {
   const cachedEntryPath = shellEntryByName.get('shell');
@@ -711,11 +785,14 @@ async function buildShellBundle(): Promise<string | null> {
     if (cached !== undefined) return cached;
   }
 
+  const generationAtStart = rebuildGeneration;
   const entry = await compileShellBundleArtifacts();
   if (entry === null) return null;
 
-  for (const [path, code] of entry.artifacts) shellArtifactByPath.set(path, code);
-  shellEntryByName.set('shell', entry.entryPath);
+  if (generationAtStart === rebuildGeneration && currentRebuild === null) {
+    for (const [path, code] of entry.artifacts) shellArtifactByPath.set(path, code);
+    shellEntryByName.set('shell', entry.entryPath);
+  }
   return entry.entryCode;
 }
 
@@ -761,18 +838,7 @@ async function renderComponentPage(componentName: string): Promise<string> {
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>${componentName} — cinder playground</title>
     <link rel="stylesheet" href="/styles/index.css" />
-    <script>
-      // Pre-paint theme. Same origin as the shell, so we read the same key.
-      // Same-origin postMessage replays via the shell after the iframe loads.
-      (function () {
-        try {
-          var theme = localStorage.getItem('cinder-playground-theme');
-          if (theme === 'light' || theme === 'dark') {
-            document.documentElement.style.colorScheme = theme;
-          }
-        } catch (e) { /* ignore */ }
-      })();
-    </script>
+    <script>${PRE_PAINT_THEME_SCRIPT}</script>
     <style>
       *, *::before, *::after { box-sizing: border-box; }
       html, body { margin: 0; padding: 0; min-height: 100%; }
@@ -937,7 +1003,7 @@ export async function handleRequest(request: Request): Promise<Response> {
     // half-cleared cache. Cheap (sync null check) when warm.
     await awaitWarmCache();
     const filename = pageBundleMatch[1]!;
-    const directHit = findArtifact(`${filename}.js`);
+    const directHit = findArtifactForFamily('page', `${filename}.js`);
     if (directHit !== undefined) {
       return new Response(directHit, {
         headers: { 'Content-Type': 'application/javascript' },
@@ -960,12 +1026,15 @@ export async function handleRequest(request: Request): Promise<Response> {
   if (shellBundleMatch) {
     await awaitWarmCache();
     const filename = shellBundleMatch[1]!;
-    const directHit = findArtifact(`${filename}.js`);
+    const directHit = findArtifactForFamily('shell', `${filename}.js`);
     if (directHit !== undefined) {
       return new Response(directHit, {
         headers: { 'Content-Type': 'application/javascript' },
       });
     }
+    // Canonical entry URL is `/shell-bundle/shell.js`. Other filenames must
+    // be hashed chunks served from the cache above; we never lazily build
+    // anything other than the entry on this route.
     if (filename !== 'shell') return notFound();
     const code = await buildShellBundle();
     if (code === null) return notFound('Shell bundle failed to build');

--- a/packages/playground/src/server.ts
+++ b/packages/playground/src/server.ts
@@ -263,9 +263,15 @@ async function repopulateBundleCaches(
       console.error('[playground] shell rebuild failed:', error);
     }
 
-    // Page bundles with per-component failure isolation.
+    // Page bundles with per-component failure isolation. Sidebar components
+    // are a subset of all components, so we can pass the same set as the
+    // validation list — saves N redundant filesystem scans from
+    // compilePageBundleArtifacts re-discovering on each call.
     const components = await discoverSidebarComponents();
-    const results = await Promise.allSettled(components.map(compilePageBundleArtifacts));
+    const knownComponents = new Set(components);
+    const results = await Promise.allSettled(
+      components.map((name) => compilePageBundleArtifacts(name, knownComponents)),
+    );
     for (let i = 0; i < results.length; i++) {
       const result = results[i]!;
       const name = components[i]!;
@@ -657,12 +663,21 @@ function unescapeStringLiteral(raw: string): string {
  */
 async function compilePageBundleArtifacts(
   componentName: string,
+  knownComponents?: ReadonlySet<string>,
 ): Promise<{ entryPath: string; entryCode: string; artifacts: Map<string, string> } | null> {
   // Validate that this is an actual component before building. A bundle for a
   // bogus name still compiles (empty scenario list + the no-examples fallback)
   // and would 200, hiding typos behind a "No examples found" UI.
-  const components = await discoverComponents();
-  if (!components.includes(componentName)) return null;
+  //
+  // The watcher rebuild already knows the component list (it discovered them
+  // a moment ago), so it passes `knownComponents` to skip the redundant glob
+  // scan. The lazy-build path falls through to discoverComponents().
+  if (knownComponents !== undefined) {
+    if (!knownComponents.has(componentName)) return null;
+  } else {
+    const components = await discoverComponents();
+    if (!components.includes(componentName)) return null;
+  }
 
   const scenarios = await discoverExamples(componentName);
   // Zero scenarios is allowed: the bundle still mounts component-page.svelte,
@@ -738,7 +753,10 @@ mount(ComponentPage, { target });
  * that triggered the lazy build is served correctly; only the shared cache
  * is left alone in the race-loss case.
  */
-async function buildPageBundle(componentName: string): Promise<string | null> {
+async function buildPageBundle(
+  componentName: string,
+  knownComponents?: ReadonlySet<string>,
+): Promise<string | null> {
   const cachedEntryPath = pageEntryByName.get(componentName);
   if (cachedEntryPath) {
     const cached = pageArtifactByPath.get(cachedEntryPath);
@@ -746,7 +764,7 @@ async function buildPageBundle(componentName: string): Promise<string | null> {
   }
 
   const generationAtStart = rebuildGeneration;
-  const entry = await compilePageBundleArtifacts(componentName);
+  const entry = await compilePageBundleArtifacts(componentName, knownComponents);
   if (entry === null) return null;
 
   // We always publish the artifacts: the entry code we're about to return
@@ -1218,7 +1236,13 @@ async function eagerPrebuildAll(): Promise<{
     return null;
   });
   const components = await discoverSidebarComponents();
-  const pagePromise = Promise.allSettled(components.map(buildPageBundle));
+  // Sidebar components are a subset of all components, so each is a valid
+  // bundle target. Passing the set avoids N redundant glob scans during the
+  // eager pre-build.
+  const knownComponents = new Set(components);
+  const pagePromise = Promise.allSettled(
+    components.map((name) => buildPageBundle(name, knownComponents)),
+  );
 
   const [shellCode, pageResults] = await Promise.all([shellPromise, pagePromise]);
 

--- a/packages/playground/src/server.ts
+++ b/packages/playground/src/server.ts
@@ -886,11 +886,26 @@ async function renderComponentPage(componentName: string): Promise<string> {
         transition: background 0.1s, color 0.1s;
       }
       #app { display: contents; }
-      body[data-cinder-bg="inverse"] {
+      /* Inverse flips relative to the currently effective scheme. The
+         authoritative signal is html[data-cinder-theme], set by the pre-paint
+         script and the postMessage handler. For "system", the effective
+         scheme depends on the OS preference, so we branch on the media
+         query instead of sniffing inline style. */
+      html[data-cinder-theme="dark"] body[data-cinder-bg="inverse"] {
         color-scheme: light;
       }
-      html[style*="color-scheme: light"] body[data-cinder-bg="inverse"] {
+      html[data-cinder-theme="light"] body[data-cinder-bg="inverse"] {
         color-scheme: dark;
+      }
+      @media (prefers-color-scheme: dark) {
+        html[data-cinder-theme="system"] body[data-cinder-bg="inverse"] {
+          color-scheme: light;
+        }
+      }
+      @media (prefers-color-scheme: light) {
+        html[data-cinder-theme="system"] body[data-cinder-bg="inverse"] {
+          color-scheme: dark;
+        }
       }
       body[data-cinder-bg="checker"] {
         background-image:
@@ -915,8 +930,10 @@ async function renderComponentPage(componentName: string): Promise<string> {
         if (data.type === 'cinder:set-theme') {
           if (data.value === 'light' || data.value === 'dark') {
             document.documentElement.style.colorScheme = data.value;
+            document.documentElement.dataset.cinderTheme = data.value;
           } else if (data.value === 'system') {
             document.documentElement.style.colorScheme = '';
+            document.documentElement.dataset.cinderTheme = 'system';
           }
         } else if (data.type === 'cinder:set-background') {
           if (data.value === 'surface' || data.value === 'inverse' || data.value === 'checker') {

--- a/packages/playground/src/server.ts
+++ b/packages/playground/src/server.ts
@@ -52,17 +52,42 @@ const pageEntryByName = new Map<string, string>();
 const bundleEntryByKey = new Map<string, string>();
 
 /**
- * Shared artifact contents: artifact.path → JS source. Holds entries from
- * BOTH bundle families plus all hashed async chunks (e.g. `core-abc123.js`).
- * All artifacts share a flat namespace under `/page-bundle/` — there is no
- * `chunks/` subdirectory; the Bun `naming` config emits everything as
- * `[name]-[hash].js` at the same level as entries.
- *
- * Chunks are content-hashed, so when two builds emit the same chunk path
- * the bytes are identical — no overwrite hazard. Entries can never collide
- * because they use disjoint `page-` / `bundle-` prefixes.
+ * Shell-bundle entries: keyed by logical name → entry artifact path. There's
+ * currently exactly one shell bundle (`'shell'`), but the map shape mirrors
+ * the page-bundle map for symmetry and lets the cache-state machine in
+ * Phase 2 publish atomically per family.
  */
-const artifactByPath = new Map<string, string>();
+const shellEntryByName = new Map<string, string>();
+
+/**
+ * Per-family artifact maps: artifact.path → JS source. Each family owns its
+ * own map so the watcher rebuild can preserve one family's previously-published
+ * artifacts when another family's rebuild fails. Routes resolve a filename by
+ * checking the most-specific family first, then falling through to the others
+ * (chunks can be shared between families via dedupe-by-content hash, and the
+ * URL itself doesn't carry the family).
+ *
+ * All artifacts share a flat namespace under `/page-bundle/` and `/shell-bundle/`
+ * URLs — there is no `chunks/` subdirectory; the Bun `naming` config emits
+ * everything as `[name]-[hash].js` at the same level as entries. Entries can
+ * never collide because they use disjoint `page-` / `bundle-` / `shell-`
+ * basename prefixes.
+ */
+const pageArtifactByPath = new Map<string, string>();
+const shellArtifactByPath = new Map<string, string>();
+const scenarioArtifactByPath = new Map<string, string>();
+
+/**
+ * Look up an artifact across every family. Used by route handlers that need
+ * to serve any compiled chunk regardless of which build produced it.
+ */
+function findArtifact(path: string): string | undefined {
+  return (
+    pageArtifactByPath.get(path) ??
+    shellArtifactByPath.get(path) ??
+    scenarioArtifactByPath.get(path)
+  );
+}
 
 /** Resolved manifest array — cached after first analysis. */
 let manifestCache: ComponentManifest[] | null = null;
@@ -70,24 +95,195 @@ let manifestCache: ComponentManifest[] | null = null;
 let manifestPromise: Promise<ComponentManifest[]> | null = null;
 
 /**
- * Atomically clear every build-derived cache. The three artifact maps and
- * the manifest cache are cleared in one synchronous call so a request can
- * never observe a partially-cleared state.
+ * Watcher cache state machine.
+ *
+ * `rebuildGeneration` increments at the start of every rebuild. A rebuild's
+ * publish step only mutates module-level caches if its generation is still
+ * the current one — older rebuilds that finish after a newer one started
+ * discard their results.
+ *
+ * `currentRebuild` is `null` when the caches are warm; non-null while a
+ * rebuild is in flight. Route handlers `await currentRebuild.promise` before
+ * serving so a request that lands mid-rebuild blocks on the newest in-flight
+ * publish rather than observing a half-cleared cache.
  */
-function clearCaches(): void {
+let rebuildGeneration = 0;
+let currentRebuild: { generation: number; promise: Promise<void> } | null = null;
+
+/**
+ * Wait for any in-flight rebuild to finish publishing. Route handlers call
+ * this before reading from the cache maps to guarantee cache coherence.
+ *
+ * Cheap when warm (synchronous null check); blocks just on the current
+ * rebuild Promise when not warm.
+ */
+async function awaitWarmCache(): Promise<void> {
+  if (currentRebuild !== null) await currentRebuild.promise;
+}
+
+/** Debounce timer for the watcher. */
+let rebuildDebounceTimer: ReturnType<typeof setTimeout> | null = null;
+/** Whether any change in the current debounce window touched shell sources. */
+let pendingShellSourceChanged = false;
+
+/**
+ * Schedule a debounced rebuild. Coalesces save bursts: multiple calls within
+ * the debounce window collapse into one rebuild that fires after the window
+ * elapses with no further calls.
+ *
+ * Per-call `shellSourceChanged` is OR-ed across the window so the publish
+ * step knows whether to emit `shell-reload` after a successful shell rebuild.
+ */
+function scheduleRebuild(shellSourceChanged: boolean): void {
+  pendingShellSourceChanged ||= shellSourceChanged;
+  if (rebuildDebounceTimer !== null) clearTimeout(rebuildDebounceTimer);
+  rebuildDebounceTimer = setTimeout(() => {
+    rebuildDebounceTimer = null;
+    const shellChanged = pendingShellSourceChanged;
+    pendingShellSourceChanged = false;
+    startRebuild(shellChanged);
+  }, 100);
+}
+
+/**
+ * Begin a rebuild. Increments the generation, stores `currentRebuild`, and
+ * wires a finally hook to clear `currentRebuild` ONLY when this generation
+ * remains the active one. Older generations whose promises resolve after
+ * a newer rebuild started must not clobber state.
+ */
+function startRebuild(shellSourceChanged: boolean): void {
+  const generation = ++rebuildGeneration;
+  const promise = repopulateBundleCaches(generation, shellSourceChanged);
+  currentRebuild = { generation, promise };
+  // The rebuild promise is held in `currentRebuild` for route handlers to
+  // await; the chain below is just for unhandled-rejection safety and the
+  // finally-clear hook. Explicit `void` discards the resulting promise.
+  void promise
+    .catch((error: unknown) => {
+      // repopulateBundleCaches() already handles its own errors and logs them.
+      // The catch here exists so we don't trigger an unhandled-rejection on
+      // the promise we hand back to route handlers via currentRebuild.
+      console.error('[playground] rebuild promise rejected unexpectedly:', error);
+    })
+    .finally(() => {
+      if (currentRebuild?.generation === generation) currentRebuild = null;
+    });
+}
+
+/**
+ * Atomic rebuild: compile every bundle into local maps, then publish to the
+ * shared module-level maps if (and only if) this rebuild's generation is
+ * still the active one. See `startRebuild()` for ownership semantics and the
+ * implementation plan for the full state-machine contract.
+ *
+ * Failure modes:
+ * - Per-component page-bundle failure: logged; that component is absent from
+ *   the published `pageEntryByName` map; the route's lazy-build fallback
+ *   handles user requests for it.
+ * - Shell-bundle failure: shell entries/artifacts NOT swapped; the previously
+ *   published shell stays fully coherent; no `shell-reload` is emitted.
+ * - Fatal error: nothing is published. Old artifacts continue serving.
+ *
+ * Emits exactly one SSE event per successful publish: `shell-reload` when
+ * shell sources changed AND the shell build succeeded; `reload` otherwise.
+ */
+async function repopulateBundleCaches(
+  generation: number,
+  shellSourceChanged: boolean,
+): Promise<void> {
+  const localPageEntries = new Map<string, string>();
+  const localShellEntries = new Map<string, string>();
+  const localPageArtifacts = new Map<string, string>();
+  const localShellArtifacts = new Map<string, string>();
+  let shellBuildSucceeded = false;
+  let fatalRebuildFailed = false;
+  const failedPages: string[] = [];
+
+  try {
+    // Shell bundle.
+    try {
+      const shell = await compileShellBundleArtifacts();
+      if (shell !== null) {
+        localShellEntries.set('shell', shell.entryPath);
+        for (const [path, code] of shell.artifacts) localShellArtifacts.set(path, code);
+        shellBuildSucceeded = true;
+      }
+    } catch (error) {
+      console.error('[playground] shell rebuild failed:', error);
+    }
+
+    // Page bundles with per-component failure isolation.
+    const components = await discoverSidebarComponents();
+    const results = await Promise.allSettled(components.map(compilePageBundleArtifacts));
+    for (let i = 0; i < results.length; i++) {
+      const result = results[i]!;
+      const name = components[i]!;
+      if (result.status === 'fulfilled' && result.value !== null) {
+        localPageEntries.set(name, result.value.entryPath);
+        for (const [path, code] of result.value.artifacts) localPageArtifacts.set(path, code);
+      } else {
+        failedPages.push(name);
+      }
+    }
+    // Manifest cache also needs invalidation since the watcher saw a src change.
+    manifestCache = null;
+    manifestPromise = null;
+  } catch (error) {
+    console.error('[playground] rebuild fatal error:', error);
+    fatalRebuildFailed = true;
+  }
+
+  // Publish guard: only the newest generation may publish. Stale rebuilds
+  // discard their work silently.
+  if (generation !== rebuildGeneration) return;
+  // Fatal error: do NOT touch caches at all.
+  if (fatalRebuildFailed) return;
+
+  // Atomic per-family swap. We .clear() then re-populate the existing Map
+  // instances so any reference captured by a route handler stays valid.
   pageEntryByName.clear();
+  for (const [k, v] of localPageEntries) pageEntryByName.set(k, v);
+  pageArtifactByPath.clear();
+  for (const [k, v] of localPageArtifacts) pageArtifactByPath.set(k, v);
+  // Scenario builds are lazy (per-example), not part of the watcher rebuild.
+  // Clear them so stale per-scenario artifacts don't accumulate; they'll be
+  // rebuilt on next view-source toggle.
   bundleEntryByKey.clear();
-  artifactByPath.clear();
-  manifestCache = null;
-  manifestPromise = null;
+  scenarioArtifactByPath.clear();
+
+  if (shellBuildSucceeded) {
+    shellEntryByName.clear();
+    for (const [k, v] of localShellEntries) shellEntryByName.set(k, v);
+    shellArtifactByPath.clear();
+    for (const [k, v] of localShellArtifacts) shellArtifactByPath.set(k, v);
+  }
+  // If the shell build failed, BOTH shellEntryByName and shellArtifactByPath
+  // are untouched — the old, still-coherent shell stays intact.
+
+  if (failedPages.length > 0) {
+    console.error(`[playground] rebuild: failed components: ${failedPages.join(', ')}`);
+  }
+
+  // Emit exactly one event per successful publish.
+  if (shellSourceChanged && shellBuildSucceeded) triggerReload('shell-reload');
+  else triggerReload('reload');
 }
 
 /** Set of active SSE stream controllers. */
 const sseClients = new Set<ReadableStreamDefaultController<string>>();
 
-/** Send a `reload` event to every connected SSE client. */
-export function triggerReload(): void {
-  const message = 'event: reload\ndata: {}\n\n';
+/**
+ * Send a named SSE event to every connected client.
+ *
+ * - `reload` (default) → shell SPA reloads only the iframe, preserving any
+ *   in-shell state (sidebar scroll, future top-bar state). Used when
+ *   preview-source files change.
+ * - `shell-reload` → shell SPA performs a full `location.reload()` because
+ *   the shell bundle itself changed. Used when files under `shell-app/` or
+ *   `render-shell.ts` change.
+ */
+export function triggerReload(eventType: 'reload' | 'shell-reload' = 'reload'): void {
+  const message = `event: ${eventType}\ndata: {}\n\n`;
   const dead: ReadableStreamDefaultController<string>[] = [];
   for (const controller of sseClients) {
     try {
@@ -102,53 +298,41 @@ export function triggerReload(): void {
   }
 }
 
-/** Start watching `src/` and `src/examples/` for live reload. */
+/**
+ * Start watching the components, examples, and playground source trees and
+ * route every change through `scheduleRebuild`. The scheduler debounces
+ * bursts and the generation-token state machine guarantees publish atomicity.
+ */
 function startWatcher(): FSWatcher[] {
   const created: FSWatcher[] = [];
 
   try {
+    // Components tree: every change invalidates every page bundle (each
+    // example imports from the cinder workspace package which re-exports
+    // every component), but does NOT touch shell sources.
     const srcPath = join(COMPONENTS_ROOT, 'src');
     created.push(
       watch(srcPath, { recursive: true }, (_event, filename) => {
-        if (filename) {
-          // Clear all caches on any src/ change. Each example imports from
-          // the cinder workspace package which re-exports every component, so
-          // editing any component invalidates every cached bundle. Content-hashed
-          // chunks whose content changed will have a new hash on the next build,
-          // so old cache entries would never be requested again — but clearing
-          // them proactively keeps memory bounded and avoids serving outdated
-          // bundles if a hash collision ever occurred.
-          clearCaches();
-          triggerReload();
-        }
+        if (filename) scheduleRebuild(false);
       }),
     );
 
-    // Watch the examples directory so edits to .example.svelte files invalidate
-    // the cached bundle and trigger a browser reload. Examples are compiled
-    // into per-component page bundles AND per-scenario bundles, so we clear
-    // both family entries plus every chunk (chunks are shared across builds).
+    // Examples directory: edits to `.example.svelte` files invalidate the
+    // corresponding component's page bundle. We don't try to be precise about
+    // which bundles to rebuild — `repopulateBundleCaches` rebuilds all sidebar
+    // components in parallel, which is fast and avoids stale-entry hazards.
     const examplesPath = join(PLAYGROUND_ROOT, 'src', 'examples');
     created.push(
       watch(examplesPath, { recursive: true }, (_event, filename) => {
-        if (filename) {
-          // Clear all caches. The partial approach (deleting only the changed
-          // component's entries while wiping all artifacts) left stale entry
-          // references in the lookup maps that pointed at deleted artifacts,
-          // causing spurious rebuilds on next request. A full clearCaches()
-          // is simpler and correct — rebuilds are cheap relative to the cost
-          // of serving stale content.
-          if (filename.match(/^([^/]+)\/([^/]+)\.example\.svelte$/)) {
-            clearCaches();
-          }
-          triggerReload();
-        }
+        if (filename) scheduleRebuild(false);
       }),
     );
 
-    // Watch the playground src tree (component-page.svelte, render-shell.ts,
-    // analyze.ts, etc.) — these are baked into every page bundle, so any edit
-    // must invalidate every cached bundle.
+    // Playground src tree: component-page.svelte, render-shell.ts, the
+    // shell-app/ directory, analyze.ts, etc. Shell-source changes (paths
+    // under `shell-app/` or to `render-shell.ts`) flip the shellSourceChanged
+    // flag so the rebuild's publish step emits `shell-reload` instead of
+    // `reload`.
     const playgroundSrcPath = join(PLAYGROUND_ROOT, 'src');
     created.push(
       watch(playgroundSrcPath, { recursive: true }, (_event, filename) => {
@@ -158,8 +342,10 @@ function startWatcher(): FSWatcher[] {
           !filename.endsWith('.test.ts') &&
           !filename.startsWith('.')
         ) {
-          clearCaches();
-          triggerReload();
+          const normalizedFilename = filename.replaceAll('\\', '/');
+          const isShellChange =
+            normalizedFilename.startsWith('shell-app/') || normalizedFilename === 'render-shell.ts';
+          scheduleRebuild(isShellChange);
         }
       }),
     );
@@ -194,31 +380,37 @@ const SHARED_BUILD_OPTIONS = {
     chunk: '[name]-[hash].js',
     asset: '[name]-[hash][ext]',
   },
-};
+} as const satisfies Omit<Parameters<typeof Bun.build>[0], 'entrypoints'>;
 
 /**
- * Walk `result.outputs`, store every artifact in `artifactByPath`, and
- * return the `kind === 'entry-point'` artifact's path and source.
+ * Walk `result.outputs` and return the entry path/code plus a map of EVERY
+ * artifact produced by this build (entry plus all hashed chunks).
  *
- * Returns `null` if no entry-point artifact was found (shouldn't happen
- * with a valid Bun.build result, but handled defensively).
+ * This function is pure with respect to the module-level caches — it does NOT
+ * write to any shared map. The caller decides whether to publish into the
+ * shared cache directly (the lazy-build path) or accumulate into local maps
+ * for an atomic publish (the watcher rebuild path).
+ *
+ * Returns `null` if no entry-point artifact was found (shouldn't happen with
+ * a valid Bun.build result, but handled defensively).
  */
 async function collectBuildArtifacts(
   outputs: BuildArtifact[],
-): Promise<{ entryPath: string; entryCode: string } | null> {
+): Promise<{ entryPath: string; entryCode: string; artifacts: Map<string, string> } | null> {
+  const artifacts = new Map<string, string>();
   let entryCode: string | null = null;
   let entryPath: string | null = null;
   for (const output of outputs) {
     const path = artifactRelativePath(output.path);
     const code = await output.text();
-    artifactByPath.set(path, code);
+    artifacts.set(path, code);
     if (output.kind === 'entry-point') {
       entryCode = code;
       entryPath = path;
     }
   }
   if (entryPath === null || entryCode === null) return null;
-  return { entryPath, entryCode };
+  return { entryPath, entryCode, artifacts };
 }
 
 /**
@@ -237,7 +429,7 @@ async function buildBundle(componentName: string, scenario: string): Promise<str
   const cacheKey = `${componentName}/${scenario}`;
   const cachedEntryPath = bundleEntryByKey.get(cacheKey);
   if (cachedEntryPath) {
-    const cached = artifactByPath.get(cachedEntryPath);
+    const cached = scenarioArtifactByPath.get(cachedEntryPath);
     if (cached !== undefined) return cached;
   }
 
@@ -283,6 +475,7 @@ async function buildBundle(componentName: string, scenario: string): Promise<str
       return null;
     }
 
+    for (const [path, code] of entry.artifacts) scenarioArtifactByPath.set(path, code);
     bundleEntryByKey.set(cacheKey, entry.entryPath);
     return entry.entryCode;
   } finally {
@@ -365,37 +558,30 @@ function unescapeStringLiteral(raw: string): string {
 }
 
 /**
- * Build the all-in-one page bundle for a single component: component-page.svelte
- * plus every scenario, all in one `Bun.build` invocation so they share a
- * single Svelte runtime instance in the browser.
+ * Compile the all-in-one page bundle for a single component without
+ * mutating any module-level state. Pure with respect to the cache maps —
+ * returns the entry path/code + every artifact this build emitted, leaving
+ * publication to the caller (lazy-build wrapper or the atomic watcher
+ * rebuild).
  *
+ * The bundle includes component-page.svelte plus every scenario, all in one
+ * Bun.build invocation so they share a single Svelte runtime in the browser.
  * Scenarios register themselves on `window.__CINDER_SCENARIOS__`, and
  * `component-page.svelte` reads that global on mount.
  */
-async function buildPageBundle(componentName: string): Promise<string | null> {
-  const cachedEntryPath = pageEntryByName.get(componentName);
-  if (cachedEntryPath) {
-    const cached = artifactByPath.get(cachedEntryPath);
-    if (cached !== undefined) return cached;
-  }
-
+async function compilePageBundleArtifacts(
+  componentName: string,
+): Promise<{ entryPath: string; entryCode: string; artifacts: Map<string, string> } | null> {
   // Validate that this is an actual component before building. A bundle for a
   // bogus name still compiles (empty scenario list + the no-examples fallback)
-  // and would 200, hiding typos behind a "No examples found" UI. The
-  // componentName must correspond to a real `.svelte` under components/src/.
+  // and would 200, hiding typos behind a "No examples found" UI.
   const components = await discoverComponents();
   if (!components.includes(componentName)) return null;
 
   const scenarios = await discoverExamples(componentName);
   // Zero scenarios is allowed: the bundle still mounts component-page.svelte,
-  // which renders a "No examples found" fallback. Returning null here would
-  // 404 the bundle URL and the iframe would silently fail to load.
+  // which renders a "No examples found" fallback.
 
-  // Bun's `naming` template uses the entrypoint basename for `[name]`. We
-  // give the temp file the basename `page-<componentName>` so the emitted
-  // entry artifact is `page-<componentName>.js` — disjoint from the
-  // `bundle-*` family that buildBundle produces. The temp directory has
-  // a UUID for concurrent-build isolation.
   const entryBasename = `page-${componentName}`;
   const entryTempDir = join(PLAYGROUND_ROOT, 'src', `.tmp-${randomUUID()}`);
   const entryTempPath = join(entryTempDir, `${entryBasename}.ts`);
@@ -428,9 +614,6 @@ mount(ComponentPage, { target });
 `;
 
   try {
-    // Bun.write auto-creates parent directories. We keep the write inside
-    // the try so a write failure still hits the finally cleanup (rmSync
-    // is idempotent for a missing dir).
     await Bun.write(entryTempPath, entrySource);
 
     const result = await Bun.build({ entrypoints: [entryTempPath], ...SHARED_BUILD_OPTIONS });
@@ -446,13 +629,94 @@ mount(ComponentPage, { target });
       return null;
     }
 
-    pageEntryByName.set(componentName, entry.entryPath);
-    return entry.entryCode;
+    return entry;
   } finally {
-    // Recursive remove handles intermediate files Bun might emit and is
-    // idempotent if the dir was never created.
     rmSync(entryTempDir, { recursive: true, force: true });
   }
+}
+
+/**
+ * Lazy-build wrapper: compile a page bundle and publish into shared caches.
+ * Used by the `/page-bundle/:filename.js` route as a fallback when an
+ * eagerly-pre-built bundle isn't already in the cache (e.g. a component
+ * whose pre-build failed, or a brand-new component added after server start).
+ */
+async function buildPageBundle(componentName: string): Promise<string | null> {
+  const cachedEntryPath = pageEntryByName.get(componentName);
+  if (cachedEntryPath) {
+    const cached = pageArtifactByPath.get(cachedEntryPath);
+    if (cached !== undefined) return cached;
+  }
+
+  const entry = await compilePageBundleArtifacts(componentName);
+  if (entry === null) return null;
+
+  for (const [path, code] of entry.artifacts) pageArtifactByPath.set(path, code);
+  pageEntryByName.set(componentName, entry.entryPath);
+  return entry.entryCode;
+}
+
+/**
+ * Compile the playground shell SPA bundle without mutating cache state.
+ *
+ * Compiles `shell-app/shell-entry.ts` (which imports `shell.svelte`) into a
+ * single ESM bundle using the same `SHARED_BUILD_OPTIONS` + Svelte plugin
+ * configuration as the page-bundle family. The entry uses a `shell-` basename
+ * prefix so the entry key is disjoint from `page-*` and `bundle-*`.
+ *
+ * Returns the entry path/code and every emitted artifact, or `null` on
+ * build failure. The caller decides whether to publish into shared caches.
+ */
+async function compileShellBundleArtifacts(): Promise<{
+  entryPath: string;
+  entryCode: string;
+  artifacts: Map<string, string>;
+} | null> {
+  const entryBasename = 'shell-shell';
+  const entryTempDir = join(PLAYGROUND_ROOT, 'src', `.tmp-${randomUUID()}`);
+  const entryTempPath = join(entryTempDir, `${entryBasename}.ts`);
+  const shim = `export {} from '../shell-app/shell-entry.ts';\n`;
+
+  try {
+    await Bun.write(entryTempPath, shim);
+
+    const result = await Bun.build({ entrypoints: [entryTempPath], ...SHARED_BUILD_OPTIONS });
+
+    if (!result.success) {
+      console.error('[playground] shell bundle failed:', result.logs);
+      return null;
+    }
+
+    const entry = await collectBuildArtifacts(result.outputs);
+    if (entry === null) {
+      console.error('[playground] shell bundle produced no entry chunk');
+      return null;
+    }
+
+    return entry;
+  } finally {
+    rmSync(entryTempDir, { recursive: true, force: true });
+  }
+}
+
+/**
+ * Lazy-build wrapper: compile the shell bundle and publish into shared
+ * caches. Used by `/shell-bundle/shell.js` as a fallback when the shell
+ * bundle isn't already cached.
+ */
+async function buildShellBundle(): Promise<string | null> {
+  const cachedEntryPath = shellEntryByName.get('shell');
+  if (cachedEntryPath) {
+    const cached = shellArtifactByPath.get(cachedEntryPath);
+    if (cached !== undefined) return cached;
+  }
+
+  const entry = await compileShellBundleArtifacts();
+  if (entry === null) return null;
+
+  for (const [path, code] of entry.artifacts) shellArtifactByPath.set(path, code);
+  shellEntryByName.set('shell', entry.entryPath);
+  return entry.entryCode;
 }
 
 /**
@@ -497,6 +761,18 @@ async function renderComponentPage(componentName: string): Promise<string> {
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>${componentName} — cinder playground</title>
     <link rel="stylesheet" href="/styles/index.css" />
+    <script>
+      // Pre-paint theme. Same origin as the shell, so we read the same key.
+      // Same-origin postMessage replays via the shell after the iframe loads.
+      (function () {
+        try {
+          var theme = localStorage.getItem('cinder-playground-theme');
+          if (theme === 'light' || theme === 'dark') {
+            document.documentElement.style.colorScheme = theme;
+          }
+        } catch (e) { /* ignore */ }
+      })();
+    </script>
     <style>
       *, *::before, *::after { box-sizing: border-box; }
       html, body { margin: 0; padding: 0; min-height: 100%; }
@@ -507,9 +783,48 @@ async function renderComponentPage(componentName: string): Promise<string> {
         font-size: var(--cinder-text-base);
         line-height: var(--cinder-leading-normal);
         padding: var(--cinder-space-6);
+        transition: background 0.1s, color 0.1s;
       }
       #app { display: contents; }
+      body[data-cinder-bg="inverse"] {
+        color-scheme: light;
+      }
+      html[style*="color-scheme: light"] body[data-cinder-bg="inverse"] {
+        color-scheme: dark;
+      }
+      body[data-cinder-bg="checker"] {
+        background-image:
+          linear-gradient(45deg, #e0e0e0 25%, transparent 25%),
+          linear-gradient(-45deg, #e0e0e0 25%, transparent 25%),
+          linear-gradient(45deg, transparent 75%, #e0e0e0 75%),
+          linear-gradient(-45deg, transparent 75%, #e0e0e0 75%);
+        background-size: 16px 16px;
+        background-position: 0 0, 0 8px, 8px -8px, -8px 0;
+        background-color: #fff;
+      }
     </style>
+    <script>
+      // Validated postMessage listener for shell→iframe theme + background
+      // commands. The shell SPA is same-origin, but we still validate origin
+      // and shape so unknown messages can't push the iframe into a bad state.
+      window.addEventListener('message', function (event) {
+        if (event.origin !== window.location.origin) return;
+        var data = event.data;
+        if (!data || typeof data !== 'object') return;
+        if (typeof data.type !== 'string' || data.type.indexOf('cinder:') !== 0) return;
+        if (data.type === 'cinder:set-theme') {
+          if (data.value === 'light' || data.value === 'dark') {
+            document.documentElement.style.colorScheme = data.value;
+          } else if (data.value === 'system') {
+            document.documentElement.style.colorScheme = '';
+          }
+        } else if (data.type === 'cinder:set-background') {
+          if (data.value === 'surface' || data.value === 'inverse' || data.value === 'checker') {
+            document.body.dataset.cinderBg = data.value;
+          }
+        }
+      });
+    </script>
   </head>
   <body>
     <script>window.__CINDER_EXAMPLES__ = ${examplesJson};</script>
@@ -592,6 +907,7 @@ export async function handleRequest(request: Request): Promise<Response> {
   // GET /bundle/:name/:scenario.js
   const bundleMatch = pathname.match(/^\/bundle\/([^/]+)\/([^/]+)\.js$/);
   if (bundleMatch) {
+    await awaitWarmCache();
     const componentName = bundleMatch[1]!;
     const scenario = bundleMatch[2]!;
     if (!isSafeSegment(componentName) || !isSafeSegment(scenario)) return notFound();
@@ -601,22 +917,27 @@ export async function handleRequest(request: Request): Promise<Response> {
     return new Response(code, { headers: { 'Content-Type': 'application/javascript' } });
   }
 
-  // GET /page-bundle/<filename>.js — covers two cases that share a flat
-  // artifact namespace:
+  // GET /page-bundle/<filename>.js — covers two cases:
   //   1. The unhashed page-bundle entry URL `/page-bundle/<component>.js`
   //      (the request the iframe makes, where <component> is a safe
   //      segment like `chat`). We look that up via `pageEntryByName` and
   //      serve the actual hashed entry artifact.
   //   2. A hashed chunk URL the entry references, like
   //      `/page-bundle/page-chat-abc123.js` or `/page-bundle/core-def456.js`.
-  //      These appear directly in `artifactByPath` and don't need a build.
+  //      Chunks can live in any family map (shared content-hashed chunks may
+  //      have been emitted by the shell or scenario builds first); we use
+  //      findArtifact to walk every family.
   //
-  // Resolution order: artifactByPath first (cheap lookup, no build), then
-  // entry-name lookup with a build fallback.
+  // Resolution order: family-map lookup first (cheap, no build), then
+  // entry-name lookup with a build fallback. The state-machine guard above
+  // ensured caches are coherent before we got here.
   const pageBundleMatch = pathname.match(/^\/page-bundle\/([A-Za-z0-9_-]+)\.js$/);
   if (pageBundleMatch) {
+    // Block on any in-flight watcher rebuild so we never observe a
+    // half-cleared cache. Cheap (sync null check) when warm.
+    await awaitWarmCache();
     const filename = pageBundleMatch[1]!;
-    const directHit = artifactByPath.get(`${filename}.js`);
+    const directHit = findArtifact(`${filename}.js`);
     if (directHit !== undefined) {
       return new Response(directHit, {
         headers: { 'Content-Type': 'application/javascript' },
@@ -629,8 +950,31 @@ export async function handleRequest(request: Request): Promise<Response> {
     return new Response(code, { headers: { 'Content-Type': 'application/javascript' } });
   }
 
+  // GET /shell-bundle/<filename>.js — same shape as /page-bundle/*:
+  //   1. `/shell-bundle/shell.js` is the unhashed entry URL the scaffold
+  //      script tag requests; we resolve it to the hashed entry artifact via
+  //      `shellEntryByName`.
+  //   2. `/shell-bundle/<hash>.js` URLs are chunks the entry imports; they
+  //      live in any family map.
+  const shellBundleMatch = pathname.match(/^\/shell-bundle\/([A-Za-z0-9_-]+)\.js$/);
+  if (shellBundleMatch) {
+    await awaitWarmCache();
+    const filename = shellBundleMatch[1]!;
+    const directHit = findArtifact(`${filename}.js`);
+    if (directHit !== undefined) {
+      return new Response(directHit, {
+        headers: { 'Content-Type': 'application/javascript' },
+      });
+    }
+    if (filename !== 'shell') return notFound();
+    const code = await buildShellBundle();
+    if (code === null) return notFound('Shell bundle failed to build');
+    return new Response(code, { headers: { 'Content-Type': 'application/javascript' } });
+  }
+
   // GET /api/manifest — full manifest array
   if (pathname === '/api/manifest') {
+    await awaitWarmCache();
     const manifests = await getManifests();
     return new Response(JSON.stringify(manifests), {
       headers: { 'Content-Type': 'application/json' },
@@ -642,6 +986,7 @@ export async function handleRequest(request: Request): Promise<Response> {
   if (apiManifestMatch) {
     const componentName = apiManifestMatch[1]!;
     if (!isSafeSegment(componentName)) return notFound();
+    await awaitWarmCache();
     const manifests = await getManifests();
     const manifest = manifests.find((m) => m.kebabName === componentName);
     if (manifest === undefined) return notFound(`Manifest for "${componentName}" not found`);
@@ -718,8 +1063,61 @@ export type PlaygroundServer = {
   dispose: () => Promise<void>;
 };
 
+/**
+ * Pre-build every sidebar component's page bundle + the shell bundle.
+ *
+ * Per-component page failures are logged but do NOT abort startup — the
+ * playground's lazy-build fallback in `/page-bundle/:filename.js` handles
+ * those at request time (surfacing the build error to the user when they
+ * click that entry). Shell-bundle failure IS fatal because there's no UI
+ * without it; the caller decides whether to exit.
+ *
+ * Returns counts so the caller can log a single line and pass the shell
+ * failure signal upward.
+ */
+async function eagerPrebuildAll(): Promise<{
+  shellSucceeded: boolean;
+  succeeded: number;
+  failed: string[];
+}> {
+  const shellPromise = buildShellBundle().catch((error) => {
+    console.error('[playground] shell bundle threw during pre-build:', error);
+    return null;
+  });
+  const components = await discoverSidebarComponents();
+  const pagePromise = Promise.allSettled(components.map(buildPageBundle));
+
+  const [shellCode, pageResults] = await Promise.all([shellPromise, pagePromise]);
+
+  let succeeded = 0;
+  const failed: string[] = [];
+  for (let i = 0; i < pageResults.length; i++) {
+    const result = pageResults[i]!;
+    if (result.status === 'fulfilled' && result.value !== null) {
+      succeeded++;
+    } else {
+      failed.push(components[i]!);
+    }
+  }
+
+  return { shellSucceeded: shellCode !== null, succeeded, failed };
+}
+
 /** Start the playground server on the given port. Returns a handle with dispose() to stop everything. */
 export async function startServer(port: number = PORT): Promise<PlaygroundServer> {
+  // Eager pre-build BEFORE binding the port. Sidebar clicks should serve
+  // from cache; we don't want the first user to pay a build cost.
+  // Shell-bundle failure is fatal — there's no UI without it.
+  const prebuild = await eagerPrebuildAll();
+  if (!prebuild.shellSucceeded) {
+    throw new Error('[playground] shell bundle failed to build — see logs above');
+  }
+  const total = prebuild.succeeded + prebuild.failed.length;
+  const failedSuffix = prebuild.failed.length > 0 ? ` (failed: ${prebuild.failed.join(', ')})` : '';
+  process.stdout.write(
+    `[playground] Pre-built ${prebuild.succeeded}/${total} page bundles${failedSuffix}\n`,
+  );
+
   // Start the HTTP server first — if Bun.serve throws (e.g. EADDRINUSE),
   // no watchers are leaked.
   const server = Bun.serve({

--- a/packages/playground/src/server.ts
+++ b/packages/playground/src/server.ts
@@ -203,21 +203,22 @@ function scheduleRebuild(shellSourceChanged: boolean): void {
  */
 function startRebuild(shellSourceChanged: boolean): void {
   const generation = ++rebuildGeneration;
-  const promise = repopulateBundleCaches(generation, shellSourceChanged);
-  currentRebuild = { generation, promise };
-  // The rebuild promise is held in `currentRebuild` for route handlers to
-  // await; the chain below is just for unhandled-rejection safety and the
-  // finally-clear hook. Explicit `void` discards the resulting promise.
-  void promise
+  // The caught chain — NOT the raw rebuild promise — is what route handlers
+  // await via `awaitWarmCache`. If we stored the raw promise and it rejected,
+  // every blocked route handler would see the rejection re-thrown into its
+  // own `await`. Attaching `.catch()` to a forked branch doesn't prevent
+  // that — only the chain that owns the catch swallows the error. So we
+  // store the chained version where the catch lives.
+  const settled = repopulateBundleCaches(generation, shellSourceChanged)
     .catch((error: unknown) => {
-      // repopulateBundleCaches() already handles its own errors and logs them.
-      // The catch here exists so we don't trigger an unhandled-rejection on
-      // the promise we hand back to route handlers via currentRebuild.
+      // repopulateBundleCaches() already handles its own errors and logs them;
+      // an unexpected throw past those handlers gets logged here.
       console.error('[playground] rebuild promise rejected unexpectedly:', error);
     })
     .finally(() => {
       if (currentRebuild?.generation === generation) currentRebuild = null;
     });
+  currentRebuild = { generation, promise: settled };
 }
 
 /**

--- a/packages/playground/src/shell-app/preview-frame.svelte
+++ b/packages/playground/src/shell-app/preview-frame.svelte
@@ -2,7 +2,7 @@
   import { onMount } from 'svelte';
 
   import { getPreviewStore } from './preview-store.svelte.ts';
-  import { buildIframeSrc, createPreviewMessage } from './routing.ts';
+  import { buildIframeSrc, createPreviewMessage, type PreviewMessage } from './routing.ts';
 
   type Props = {
     componentName: string;
@@ -17,28 +17,33 @@
   let src = $derived(buildIframeSrc(componentName));
 
   /**
-   * Send a validated message to the iframe with an explicit target origin.
-   * Never uses '*' — the message goes only to the page we control.
+   * Send a typed message to the iframe with an explicit target origin.
+   * Never uses '*' — the message goes only to the page we control. The
+   * message must come from `createPreviewMessage` so its shape and value
+   * have already been validated against the protocol allowlist.
    */
-  function postToFrame(type: 'cinder:set-theme' | 'cinder:set-background', value: string): void {
+  function postToFrame(message: PreviewMessage): void {
     const win = iframeEl?.contentWindow;
     if (!win) return;
-    let message;
-    if (type === 'cinder:set-theme') {
-      message = createPreviewMessage(type, value as 'light' | 'dark' | 'system');
-    } else {
-      message = createPreviewMessage(type, value as 'surface' | 'inverse' | 'checker');
-    }
-    if (message === null) return;
     win.postMessage(message, window.location.origin);
+  }
+
+  function syncTheme(): void {
+    const message = createPreviewMessage('cinder:set-theme', store.theme);
+    if (message !== null) postToFrame(message);
+  }
+
+  function syncBackground(): void {
+    const message = createPreviewMessage('cinder:set-background', store.background);
+    if (message !== null) postToFrame(message);
   }
 
   // Reactive: theme/background changes push to the iframe immediately.
   $effect(() => {
-    postToFrame('cinder:set-theme', store.theme);
+    syncTheme();
   });
   $effect(() => {
-    postToFrame('cinder:set-background', store.background);
+    syncBackground();
   });
 
   function handleLoad(): void {
@@ -46,8 +51,8 @@
     // iframe's inline pre-paint script already reads localStorage for theme,
     // but background is session-only and lives in the shell — we need to
     // sync it after each navigation/reload.
-    postToFrame('cinder:set-theme', store.theme);
-    postToFrame('cinder:set-background', store.background);
+    syncTheme();
+    syncBackground();
   }
 
   onMount(() => {
@@ -82,23 +87,34 @@
     flex: 1;
     display: flex;
     flex-direction: column;
-    overflow: auto;
+    /* Don't let the host scroll itself — the iframe owns its own scrolling.
+       This also keeps the iframe's height stable when previewWidth narrows
+       the wrapper. */
+    overflow: hidden;
     background: #f5f5f5;
+    min-height: 0;
   }
 
   .preview-frame-wrapper {
-    flex: 1;
+    /* Definite height seed for the column-direction parent so the iframe
+       (flex: 1) inside us has a non-zero height to grow into. Without this,
+       constraining width via inline style would let the wrapper collapse
+       vertically in some browsers. */
+    flex: 1 1 0;
+    min-height: 0;
+    height: 100%;
     display: flex;
     flex-direction: column;
-    min-height: 0;
   }
 
   iframe {
     flex: 1;
     width: 100%;
+    height: 100%;
     border: none;
     background: #fff;
     display: block;
+    min-height: 0;
   }
 
   .placeholder {

--- a/packages/playground/src/shell-app/preview-frame.svelte
+++ b/packages/playground/src/shell-app/preview-frame.svelte
@@ -1,6 +1,4 @@
 <script lang="ts">
-  import { onMount } from 'svelte';
-
   import { getPreviewStore } from './preview-store.svelte.ts';
   import { buildIframeSrc, createPreviewMessage, type PreviewMessage } from './routing.ts';
 
@@ -55,10 +53,16 @@
     syncBackground();
   }
 
-  onMount(() => {
-    if (iframeEl) iframeEl.addEventListener('load', handleLoad);
+  // The iframe lives inside {#if componentName}, so its DOM element is
+  // destroyed and recreated when the user selects their first component (or
+  // any subsequent transition between placeholder and iframe). Use $effect
+  // tracking iframeEl so the load listener re-attaches on every remount.
+  $effect(() => {
+    const element = iframeEl;
+    if (element === null) return;
+    element.addEventListener('load', handleLoad);
     return () => {
-      iframeEl?.removeEventListener('load', handleLoad);
+      element.removeEventListener('load', handleLoad);
     };
   });
 

--- a/packages/playground/src/shell-app/preview-frame.svelte
+++ b/packages/playground/src/shell-app/preview-frame.svelte
@@ -1,0 +1,116 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+
+  import { getPreviewStore } from './preview-store.svelte.ts';
+  import { buildIframeSrc, createPreviewMessage } from './routing.ts';
+
+  type Props = {
+    componentName: string;
+  };
+
+  let { componentName }: Props = $props();
+
+  const store = getPreviewStore();
+
+  let iframeEl = $state<HTMLIFrameElement | null>(null);
+
+  let src = $derived(buildIframeSrc(componentName));
+
+  /**
+   * Send a validated message to the iframe with an explicit target origin.
+   * Never uses '*' — the message goes only to the page we control.
+   */
+  function postToFrame(type: 'cinder:set-theme' | 'cinder:set-background', value: string): void {
+    const win = iframeEl?.contentWindow;
+    if (!win) return;
+    let message;
+    if (type === 'cinder:set-theme') {
+      message = createPreviewMessage(type, value as 'light' | 'dark' | 'system');
+    } else {
+      message = createPreviewMessage(type, value as 'surface' | 'inverse' | 'checker');
+    }
+    if (message === null) return;
+    win.postMessage(message, window.location.origin);
+  }
+
+  // Reactive: theme/background changes push to the iframe immediately.
+  $effect(() => {
+    postToFrame('cinder:set-theme', store.theme);
+  });
+  $effect(() => {
+    postToFrame('cinder:set-background', store.background);
+  });
+
+  function handleLoad(): void {
+    // Replay the current theme + background after a fresh iframe load. The
+    // iframe's inline pre-paint script already reads localStorage for theme,
+    // but background is session-only and lives in the shell — we need to
+    // sync it after each navigation/reload.
+    postToFrame('cinder:set-theme', store.theme);
+    postToFrame('cinder:set-background', store.background);
+  }
+
+  onMount(() => {
+    if (iframeEl) iframeEl.addEventListener('load', handleLoad);
+    return () => {
+      iframeEl?.removeEventListener('load', handleLoad);
+    };
+  });
+
+  let wrapperStyle = $derived(
+    store.previewWidth === null
+      ? ''
+      : `width: ${store.previewWidth}px; max-width: 100%; margin: 0 auto;`,
+  );
+</script>
+
+<div class="preview-host">
+  {#if componentName}
+    <div class="preview-frame-wrapper" style={wrapperStyle}>
+      <iframe bind:this={iframeEl} {src} title="{componentName} preview" data-cinder-preview
+      ></iframe>
+    </div>
+  {:else}
+    <div class="placeholder">
+      <p>Select a component from the sidebar to preview it.</p>
+    </div>
+  {/if}
+</div>
+
+<style>
+  .preview-host {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    overflow: auto;
+    background: #f5f5f5;
+  }
+
+  .preview-frame-wrapper {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    min-height: 0;
+  }
+
+  iframe {
+    flex: 1;
+    width: 100%;
+    border: none;
+    background: #fff;
+    display: block;
+  }
+
+  .placeholder {
+    flex: 1;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: #888;
+  }
+
+  .placeholder p {
+    font-size: 16px;
+    margin: 0;
+  }
+</style>

--- a/packages/playground/src/shell-app/preview-store.svelte.ts
+++ b/packages/playground/src/shell-app/preview-store.svelte.ts
@@ -47,12 +47,18 @@ export function writePersistedTheme(value: ThemeChoice): void {
 }
 
 /**
- * Apply a theme choice to a document's root element by setting `color-scheme`.
- * 'system' clears the inline value so the base CSS declaration of
- * `color-scheme: light dark` takes effect (the default behavior).
+ * Apply a theme choice to a document's root element.
+ *
+ * - `color-scheme`: 'system' clears the inline value so the base CSS
+ *   declaration of `color-scheme: light dark` takes effect.
+ * - `data-cinder-theme`: always set to the explicit choice, including
+ *   'system'. This is the authoritative signal CSS reads when deciding
+ *   things like the inverse-background flip — sniffing inline style breaks
+ *   the moment a user selects 'system'.
  */
 export function applyThemeToDocument(doc: Document, theme: ThemeChoice): void {
   doc.documentElement.style.colorScheme = theme === 'system' ? '' : theme;
+  doc.documentElement.dataset['cinderTheme'] = theme;
 }
 
 export class PreviewStore {

--- a/packages/playground/src/shell-app/preview-store.svelte.ts
+++ b/packages/playground/src/shell-app/preview-store.svelte.ts
@@ -11,13 +11,14 @@
 
 import { getContext, setContext } from 'svelte';
 
+import type { BackgroundChoice, ThemeChoice } from './routing.ts';
+
+export type { BackgroundChoice, ThemeChoice };
+
 const PREVIEW_STORE_KEY = Symbol('cinder-preview-store');
 
-/** Persisted theme key — must match the inline pre-paint scripts in render-shell.ts and server.ts. */
+/** Persisted theme key — must match `PRE_PAINT_THEME_SCRIPT` in render-shell.ts. */
 export const THEME_STORAGE_KEY = 'cinder-playground-theme';
-
-export type ThemeChoice = 'light' | 'dark' | 'system';
-export type BackgroundChoice = 'surface' | 'inverse' | 'checker';
 
 const THEME_VALUES: ReadonlySet<ThemeChoice> = new Set(['light', 'dark', 'system']);
 

--- a/packages/playground/src/shell-app/preview-store.svelte.ts
+++ b/packages/playground/src/shell-app/preview-store.svelte.ts
@@ -1,0 +1,90 @@
+/**
+ * Reactive store for the playground shell SPA.
+ *
+ * Phase 1 held only `currentComponent`. Phase 3 adds the top-bar controls:
+ * theme (persisted to localStorage), viewport width, background swatch, and
+ * focus-mode toggle (all three of the latter are session-only).
+ *
+ * Single instance provided via a Svelte 5 context key so any descendant
+ * component can read/write it without prop drilling.
+ */
+
+import { getContext, setContext } from 'svelte';
+
+const PREVIEW_STORE_KEY = Symbol('cinder-preview-store');
+
+/** Persisted theme key — must match the inline pre-paint scripts in render-shell.ts and server.ts. */
+export const THEME_STORAGE_KEY = 'cinder-playground-theme';
+
+export type ThemeChoice = 'light' | 'dark' | 'system';
+export type BackgroundChoice = 'surface' | 'inverse' | 'checker';
+
+const THEME_VALUES: ReadonlySet<ThemeChoice> = new Set(['light', 'dark', 'system']);
+
+/**
+ * Safe localStorage read. localStorage can throw in private-browsing,
+ * restricted content-script contexts, or when storage quota is exhausted.
+ * Failures degrade silently to "system" so the playground keeps booting.
+ */
+export function readPersistedTheme(): ThemeChoice {
+  try {
+    const value = localStorage.getItem(THEME_STORAGE_KEY);
+    if (value === 'light' || value === 'dark' || value === 'system') return value;
+    return 'system';
+  } catch {
+    return 'system';
+  }
+}
+
+/** Safe localStorage write. Failures are ignored. */
+export function writePersistedTheme(value: ThemeChoice): void {
+  try {
+    localStorage.setItem(THEME_STORAGE_KEY, value);
+  } catch {
+    /* ignore — degraded but functional */
+  }
+}
+
+/**
+ * Apply a theme choice to a document's root element by setting `color-scheme`.
+ * 'system' clears the inline value so the base CSS declaration of
+ * `color-scheme: light dark` takes effect (the default behavior).
+ */
+export function applyThemeToDocument(doc: Document, theme: ThemeChoice): void {
+  doc.documentElement.style.colorScheme = theme === 'system' ? '' : theme;
+}
+
+export class PreviewStore {
+  currentComponent = $state<string>('');
+  /** null = full / unconstrained width. Number = pixel width applied to the iframe. */
+  previewWidth = $state<number | null>(null);
+  theme = $state<ThemeChoice>('system');
+  background = $state<BackgroundChoice>('surface');
+  isFocusMode = $state<boolean>(false);
+
+  constructor(initialComponent: string, initialTheme: ThemeChoice = 'system') {
+    this.currentComponent = initialComponent;
+    this.theme = initialTheme;
+  }
+
+  setTheme(value: ThemeChoice): void {
+    if (!THEME_VALUES.has(value)) return;
+    this.theme = value;
+    writePersistedTheme(value);
+    if (typeof document !== 'undefined') applyThemeToDocument(document, value);
+  }
+}
+
+/** Install the singleton store on the current component tree. */
+export function setPreviewStore(store: PreviewStore): void {
+  setContext(PREVIEW_STORE_KEY, store);
+}
+
+/** Read the singleton store from the current component tree. Throws if absent. */
+export function getPreviewStore(): PreviewStore {
+  const store = getContext<PreviewStore | undefined>(PREVIEW_STORE_KEY);
+  if (store === undefined) {
+    throw new Error('[cinder playground] PreviewStore is not set in this component tree');
+  }
+  return store;
+}

--- a/packages/playground/src/shell-app/preview-store.test.ts
+++ b/packages/playground/src/shell-app/preview-store.test.ts
@@ -122,7 +122,7 @@ describe('writePersistedTheme', () => {
 
 function makeFakeDocument(): Document {
   return {
-    documentElement: { style: { colorScheme: '' } },
+    documentElement: { style: { colorScheme: '' }, dataset: {} as Record<string, string> },
   } as unknown as Document;
 }
 
@@ -146,5 +146,13 @@ describe('applyThemeToDocument', () => {
     doc.documentElement.style.colorScheme = 'dark';
     applyThemeToDocument(doc, 'system');
     expect(doc.documentElement.style.colorScheme).toBe('');
+  });
+
+  it('writes data-cinder-theme for every choice including "system"', () => {
+    for (const choice of ['light', 'dark', 'system'] as const) {
+      const doc = makeFakeDocument();
+      applyThemeToDocument(doc, choice);
+      expect(doc.documentElement.dataset['cinderTheme']).toBe(choice);
+    }
   });
 });

--- a/packages/playground/src/shell-app/preview-store.test.ts
+++ b/packages/playground/src/shell-app/preview-store.test.ts
@@ -1,0 +1,150 @@
+/**
+ * Tests for the pure(-ish) helpers in `preview-store.svelte.ts`:
+ *
+ * - `readPersistedTheme` / `writePersistedTheme` wrap `localStorage` access
+ *   in try/catch so a thrown access never breaks the bundle. The tests stub
+ *   `localStorage` at the global level for the duration of each case.
+ * - `applyThemeToDocument` sets or clears `color-scheme` on a document's
+ *   `documentElement.style`. We use a minimal fake document.
+ */
+
+import { afterEach, describe, expect, it } from 'bun:test';
+
+import {
+  applyThemeToDocument,
+  readPersistedTheme,
+  THEME_STORAGE_KEY,
+  writePersistedTheme,
+  type ThemeChoice,
+} from './preview-store.svelte.ts';
+
+type LocalStorageStub = {
+  getItem: (key: string) => string | null;
+  setItem: (key: string, value: string) => void;
+};
+
+const originalLocalStorage = (globalThis as { localStorage?: Storage }).localStorage;
+
+function installLocalStorage(stub: LocalStorageStub | undefined): void {
+  if (stub === undefined) {
+    Object.defineProperty(globalThis, 'localStorage', {
+      configurable: true,
+      get() {
+        throw new Error('localStorage unavailable');
+      },
+    });
+    return;
+  }
+  Object.defineProperty(globalThis, 'localStorage', {
+    configurable: true,
+    value: stub as unknown as Storage,
+    writable: true,
+  });
+}
+
+afterEach(() => {
+  if (originalLocalStorage === undefined) {
+    delete (globalThis as { localStorage?: Storage }).localStorage;
+  } else {
+    Object.defineProperty(globalThis, 'localStorage', {
+      configurable: true,
+      value: originalLocalStorage,
+      writable: true,
+    });
+  }
+});
+
+describe('readPersistedTheme', () => {
+  it('returns the stored "light" value', () => {
+    installLocalStorage({ getItem: () => 'light', setItem: () => {} });
+    expect(readPersistedTheme()).toBe('light');
+  });
+
+  it('returns the stored "dark" value', () => {
+    installLocalStorage({ getItem: () => 'dark', setItem: () => {} });
+    expect(readPersistedTheme()).toBe('dark');
+  });
+
+  it('returns "system" when the stored value is missing', () => {
+    installLocalStorage({ getItem: () => null, setItem: () => {} });
+    expect(readPersistedTheme()).toBe('system');
+  });
+
+  it('returns "system" when the stored value is an unknown string', () => {
+    installLocalStorage({ getItem: () => 'midnight', setItem: () => {} });
+    expect(readPersistedTheme()).toBe('system');
+  });
+
+  it('returns "system" when localStorage.getItem throws', () => {
+    installLocalStorage({
+      getItem: () => {
+        throw new Error('blocked');
+      },
+      setItem: () => {},
+    });
+    expect(readPersistedTheme()).toBe('system');
+  });
+
+  it('returns "system" when localStorage is not defined at all', () => {
+    installLocalStorage(undefined);
+    expect(readPersistedTheme()).toBe('system');
+  });
+});
+
+describe('writePersistedTheme', () => {
+  it('forwards the value to localStorage under THEME_STORAGE_KEY', () => {
+    const calls: Array<{ key: string; value: string }> = [];
+    installLocalStorage({
+      getItem: () => null,
+      setItem: (key, value) => {
+        calls.push({ key, value });
+      },
+    });
+    writePersistedTheme('dark');
+    expect(calls).toEqual([{ key: THEME_STORAGE_KEY, value: 'dark' }]);
+  });
+
+  it('does not throw when localStorage.setItem throws', () => {
+    installLocalStorage({
+      getItem: () => null,
+      setItem: () => {
+        throw new Error('quota exceeded');
+      },
+    });
+    expect(() => writePersistedTheme('light')).not.toThrow();
+  });
+
+  it('does not throw when localStorage is undefined', () => {
+    installLocalStorage(undefined);
+    expect(() => writePersistedTheme('light')).not.toThrow();
+  });
+});
+
+function makeFakeDocument(): Document {
+  return {
+    documentElement: { style: { colorScheme: '' } },
+  } as unknown as Document;
+}
+
+describe('applyThemeToDocument', () => {
+  const cases: Array<[ThemeChoice, string]> = [
+    ['light', 'light'],
+    ['dark', 'dark'],
+    ['system', ''], // empty string clears the inline override
+  ];
+
+  for (const [input, expected] of cases) {
+    it(`sets colorScheme to "${expected}" for "${input}"`, () => {
+      const doc = makeFakeDocument();
+      applyThemeToDocument(doc, input);
+      expect(doc.documentElement.style.colorScheme).toBe(expected);
+    });
+  }
+
+  it('clears a previously-set inline override when called with "system"', () => {
+    const doc = makeFakeDocument();
+    doc.documentElement.style.colorScheme = 'dark';
+    applyThemeToDocument(doc, 'system');
+    expect(doc.documentElement.style.colorScheme).toBe('');
+  });
+});

--- a/packages/playground/src/shell-app/routing.test.ts
+++ b/packages/playground/src/shell-app/routing.test.ts
@@ -1,0 +1,131 @@
+/**
+ * Unit tests for the shell-app routing helpers.
+ *
+ * These helpers are pure functions extracted from the Svelte SPA shell
+ * specifically so they can be unit-tested without a DOM. They are the only
+ * pieces of the SPA shell with deterministic input/output contracts; the
+ * Svelte components themselves are integration-tested via the manual checks
+ * documented in the implementation plan.
+ */
+
+import { describe, expect, it } from 'bun:test';
+
+import {
+  buildIframeSrc,
+  buildShellHref,
+  createPreviewMessage,
+  parseComponentFromPath,
+} from './routing.ts';
+
+describe('parseComponentFromPath', () => {
+  it('returns the component name for a valid /c/:name path', () => {
+    expect(parseComponentFromPath('/c/avatar')).toBe('avatar');
+  });
+
+  it('accepts kebab-case names with hyphens', () => {
+    expect(parseComponentFromPath('/c/markdown-editor')).toBe('markdown-editor');
+  });
+
+  it('accepts names with digits', () => {
+    expect(parseComponentFromPath('/c/h1-heading')).toBe('h1-heading');
+  });
+
+  it('returns null for paths outside /c/', () => {
+    expect(parseComponentFromPath('/page/avatar')).toBeNull();
+    expect(parseComponentFromPath('/styles.css')).toBeNull();
+    expect(parseComponentFromPath('/')).toBeNull();
+  });
+
+  it('returns null for an empty segment', () => {
+    expect(parseComponentFromPath('/c/')).toBeNull();
+  });
+
+  it('returns null for an encoded path with whitespace', () => {
+    expect(parseComponentFromPath('/c/foo%20bar')).toBeNull();
+  });
+
+  it('returns null for path-traversal attempts', () => {
+    expect(parseComponentFromPath('/c/..')).toBeNull();
+    expect(parseComponentFromPath('/c/../etc/passwd')).toBeNull();
+  });
+
+  it('returns null for uppercase names (kebab invariant)', () => {
+    expect(parseComponentFromPath('/c/Avatar')).toBeNull();
+  });
+
+  it('returns null for names starting with a hyphen', () => {
+    expect(parseComponentFromPath('/c/-bad')).toBeNull();
+  });
+
+  it('ignores trailing path segments after the component', () => {
+    expect(parseComponentFromPath('/c/avatar/extra')).toBeNull();
+  });
+
+  it('handles a malformed percent-encoding by returning null', () => {
+    expect(parseComponentFromPath('/c/%E0%A4%A')).toBeNull();
+  });
+});
+
+describe('buildShellHref', () => {
+  it('returns /c/<name> for a kebab-case component', () => {
+    expect(buildShellHref('avatar')).toBe('/c/avatar');
+    expect(buildShellHref('markdown-editor')).toBe('/c/markdown-editor');
+  });
+
+  it('encodes special characters defensively', () => {
+    expect(buildShellHref('weird name')).toBe('/c/weird%20name');
+  });
+});
+
+describe('buildIframeSrc', () => {
+  it('returns /page/<name> for a kebab-case component', () => {
+    expect(buildIframeSrc('button')).toBe('/page/button');
+    expect(buildIframeSrc('markdown-editor')).toBe('/page/markdown-editor');
+  });
+
+  it('encodes special characters defensively', () => {
+    expect(buildIframeSrc('weird name')).toBe('/page/weird%20name');
+  });
+});
+
+describe('createPreviewMessage', () => {
+  it('builds a theme message for each allowed value', () => {
+    expect(createPreviewMessage('cinder:set-theme', 'light')).toEqual({
+      type: 'cinder:set-theme',
+      value: 'light',
+    });
+    expect(createPreviewMessage('cinder:set-theme', 'dark')).toEqual({
+      type: 'cinder:set-theme',
+      value: 'dark',
+    });
+    expect(createPreviewMessage('cinder:set-theme', 'system')).toEqual({
+      type: 'cinder:set-theme',
+      value: 'system',
+    });
+  });
+
+  it('builds a background message for each allowed value', () => {
+    expect(createPreviewMessage('cinder:set-background', 'surface')).toEqual({
+      type: 'cinder:set-background',
+      value: 'surface',
+    });
+    expect(createPreviewMessage('cinder:set-background', 'inverse')).toEqual({
+      type: 'cinder:set-background',
+      value: 'inverse',
+    });
+    expect(createPreviewMessage('cinder:set-background', 'checker')).toEqual({
+      type: 'cinder:set-background',
+      value: 'checker',
+    });
+  });
+
+  it('returns null for an unknown theme value', () => {
+    // @ts-expect-error — exercising runtime validation
+    expect(createPreviewMessage('cinder:set-theme', 'midnight')).toBeNull();
+  });
+
+  it('returns null for an unknown background value', () => {
+    // @ts-expect-error — exercising runtime validation
+    expect(createPreviewMessage('cinder:set-background', 'rainbow')).toBeNull();
+  });
+});

--- a/packages/playground/src/shell-app/routing.ts
+++ b/packages/playground/src/shell-app/routing.ts
@@ -54,6 +54,15 @@ export function buildIframeSrc(componentName: string): string {
 }
 
 /**
+ * Theme and background value unions are defined here (and re-exported by
+ * `preview-store.svelte.ts`) so this pure-helper module has no import from
+ * any Svelte file. That keeps it cleanly unit-testable from `bun:test`
+ * without paying the `.svelte.ts` compilation cost in test boot.
+ */
+export type ThemeChoice = 'light' | 'dark' | 'system';
+export type BackgroundChoice = 'surface' | 'inverse' | 'checker';
+
+/**
  * Message types exchanged between the shell SPA and the iframe page. The
  * `cinder:` prefix scopes the protocol so future iframe content can't
  * accidentally collide with unrelated messages on the same channel.
@@ -63,11 +72,23 @@ export function buildIframeSrc(componentName: string): string {
  * allowed set before applying any effect.
  */
 export type PreviewMessage =
-  | { type: 'cinder:set-theme'; value: 'light' | 'dark' | 'system' }
-  | { type: 'cinder:set-background'; value: 'surface' | 'inverse' | 'checker' };
+  | { type: 'cinder:set-theme'; value: ThemeChoice }
+  | { type: 'cinder:set-background'; value: BackgroundChoice };
 
-const PREVIEW_THEMES: ReadonlySet<PreviewMessage['value']> = new Set(['light', 'dark', 'system']);
-const PREVIEW_BACKGROUNDS: ReadonlySet<string> = new Set(['surface', 'inverse', 'checker']);
+const PREVIEW_THEMES: ReadonlySet<ThemeChoice> = new Set<ThemeChoice>(['light', 'dark', 'system']);
+const PREVIEW_BACKGROUNDS: ReadonlySet<BackgroundChoice> = new Set<BackgroundChoice>([
+  'surface',
+  'inverse',
+  'checker',
+]);
+
+function isThemeChoice(value: string): value is ThemeChoice {
+  return PREVIEW_THEMES.has(value as ThemeChoice);
+}
+
+function isBackgroundChoice(value: string): value is BackgroundChoice {
+  return PREVIEW_BACKGROUNDS.has(value as BackgroundChoice);
+}
 
 /**
  * Construct a typed preview message. Returns `null` if the value doesn't
@@ -76,18 +97,18 @@ const PREVIEW_BACKGROUNDS: ReadonlySet<string> = new Set(['surface', 'inverse', 
  */
 export function createPreviewMessage(
   type: 'cinder:set-theme',
-  value: 'light' | 'dark' | 'system',
+  value: ThemeChoice,
 ): PreviewMessage | null;
 export function createPreviewMessage(
   type: 'cinder:set-background',
-  value: 'surface' | 'inverse' | 'checker',
+  value: BackgroundChoice,
 ): PreviewMessage | null;
 export function createPreviewMessage(type: string, value: string): PreviewMessage | null {
-  if (type === 'cinder:set-theme' && PREVIEW_THEMES.has(value as PreviewMessage['value'])) {
-    return { type, value: value as 'light' | 'dark' | 'system' };
+  if (type === 'cinder:set-theme' && isThemeChoice(value)) {
+    return { type, value };
   }
-  if (type === 'cinder:set-background' && PREVIEW_BACKGROUNDS.has(value)) {
-    return { type, value: value as 'surface' | 'inverse' | 'checker' };
+  if (type === 'cinder:set-background' && isBackgroundChoice(value)) {
+    return { type, value };
   }
   return null;
 }

--- a/packages/playground/src/shell-app/routing.ts
+++ b/packages/playground/src/shell-app/routing.ts
@@ -1,0 +1,93 @@
+/**
+ * Pure routing helpers for the playground shell SPA.
+ *
+ * Extracted from the Svelte components so they're testable without a DOM.
+ * Every helper is side-effect-free; the SPA is responsible for choosing what
+ * to do with the return values (e.g. seeding state, building hrefs).
+ */
+
+/**
+ * Regex that matches the component-name invariant enforced server-side by
+ * `isSafeSegment` in `server.ts`. Kebab-case, ASCII only, starts with
+ * alphanumeric. Kept in sync with `/^[a-z0-9][a-z0-9-]*$/` at server.ts:523.
+ */
+const COMPONENT_NAME_PATTERN = /^[a-z0-9][a-z0-9-]*$/;
+
+/**
+ * Extract a component name from a `/c/:name` pathname. Returns `null` for any
+ * input that doesn't match the route shape or whose segment fails the
+ * kebab-case invariant. The caller decides what to do with `null` — typically
+ * leave the current component unchanged.
+ *
+ * Trailing path segments are rejected (`/c/avatar/extra` returns null) so the
+ * helper has the same shape as the server's `/c/:name` route.
+ */
+export function parseComponentFromPath(pathname: string): string | null {
+  const match = /^\/c\/([^/]+)$/.exec(pathname);
+  if (!match) return null;
+  let decoded: string;
+  try {
+    decoded = decodeURIComponent(match[1]!);
+  } catch {
+    return null;
+  }
+  if (!COMPONENT_NAME_PATTERN.test(decoded)) return null;
+  return decoded;
+}
+
+/**
+ * Build the shell URL for a component — used for both sidebar anchor `href`
+ * attributes and `history.pushState`. The component name is always encoded
+ * defensively, even though kebab slugs don't actually need encoding; this
+ * keeps URL construction safe if the invariant ever slips.
+ */
+export function buildShellHref(componentName: string): string {
+  return `/c/${encodeURIComponent(componentName)}`;
+}
+
+/**
+ * Build the iframe `src` URL for a component's preview page. Same encoding
+ * discipline as `buildShellHref`.
+ */
+export function buildIframeSrc(componentName: string): string {
+  return `/page/${encodeURIComponent(componentName)}`;
+}
+
+/**
+ * Message types exchanged between the shell SPA and the iframe page. The
+ * `cinder:` prefix scopes the protocol so future iframe content can't
+ * accidentally collide with unrelated messages on the same channel.
+ *
+ * Theme/background changes flow shell → iframe; the iframe never sends
+ * back. The receiver MUST validate the origin AND the value against the
+ * allowed set before applying any effect.
+ */
+export type PreviewMessage =
+  | { type: 'cinder:set-theme'; value: 'light' | 'dark' | 'system' }
+  | { type: 'cinder:set-background'; value: 'surface' | 'inverse' | 'checker' };
+
+const PREVIEW_THEMES: ReadonlySet<PreviewMessage['value']> = new Set(['light', 'dark', 'system']);
+const PREVIEW_BACKGROUNDS: ReadonlySet<string> = new Set(['surface', 'inverse', 'checker']);
+
+/**
+ * Construct a typed preview message. Returns `null` if the value doesn't
+ * match the type's allowlist — callers can use this to validate user input
+ * before sending the message across the postMessage boundary.
+ */
+export function createPreviewMessage(
+  type: 'cinder:set-theme',
+  value: 'light' | 'dark' | 'system',
+): PreviewMessage | null;
+export function createPreviewMessage(
+  type: 'cinder:set-background',
+  value: 'surface' | 'inverse' | 'checker',
+): PreviewMessage | null;
+export function createPreviewMessage(type: string, value: string): PreviewMessage | null {
+  if (type === 'cinder:set-theme' && PREVIEW_THEMES.has(value as PreviewMessage['value'])) {
+    return { type, value: value as 'light' | 'dark' | 'system' };
+  }
+  if (type === 'cinder:set-background' && PREVIEW_BACKGROUNDS.has(value)) {
+    return { type, value: value as 'surface' | 'inverse' | 'checker' };
+  }
+  return null;
+}

--- a/packages/playground/src/shell-app/shell-entry.ts
+++ b/packages/playground/src/shell-app/shell-entry.ts
@@ -16,19 +16,35 @@ import Shell from './shell.svelte';
 
 type InitialData = { component: string; components: string[] };
 
+/**
+ * Validate that the parsed JSON payload matches the expected `InitialData`
+ * shape and that every component name in the list satisfies the kebab-case
+ * invariant the server enforces. This is defense-in-depth: render-shell
+ * already validates server-side, but treating the data island as untrusted
+ * input keeps the boundary explicit.
+ */
+function isInitialData(value: unknown): value is InitialData {
+  if (typeof value !== 'object' || value === null) return false;
+  const record = value as Record<string, unknown>;
+  if (typeof record.component !== 'string') return false;
+  if (!Array.isArray(record.components)) return false;
+  const componentNamePattern = /^[a-z0-9][a-z0-9-]*$/;
+  for (const item of record.components) {
+    if (typeof item !== 'string' || !componentNamePattern.test(item)) return false;
+  }
+  // The initial component must either be empty (no-component placeholder) or
+  // present in the validated components list — otherwise the sidebar's
+  // current-selection state would point at an unknown entry.
+  if (record.component !== '' && !record.components.includes(record.component)) return false;
+  return true;
+}
+
 function readInitialData(): InitialData {
   const node = document.getElementById('cinder-initial');
   if (!node) return { component: '', components: [] };
   try {
-    const parsed = JSON.parse(node.textContent ?? '{}') as unknown;
-    if (
-      typeof parsed === 'object' &&
-      parsed !== null &&
-      typeof (parsed as InitialData).component === 'string' &&
-      Array.isArray((parsed as InitialData).components)
-    ) {
-      return parsed as InitialData;
-    }
+    const parsed: unknown = JSON.parse(node.textContent ?? '{}');
+    if (isInitialData(parsed)) return parsed;
   } catch (error) {
     console.error('[cinder playground] failed to parse #cinder-initial:', error);
   }

--- a/packages/playground/src/shell-app/shell-entry.ts
+++ b/packages/playground/src/shell-app/shell-entry.ts
@@ -26,16 +26,18 @@ type InitialData = { component: string; components: string[] };
 function isInitialData(value: unknown): value is InitialData {
   if (typeof value !== 'object' || value === null) return false;
   const record = value as Record<string, unknown>;
-  if (typeof record.component !== 'string') return false;
-  if (!Array.isArray(record.components)) return false;
+  const component = record['component'];
+  const components = record['components'];
+  if (typeof component !== 'string') return false;
+  if (!Array.isArray(components)) return false;
   const componentNamePattern = /^[a-z0-9][a-z0-9-]*$/;
-  for (const item of record.components) {
+  for (const item of components) {
     if (typeof item !== 'string' || !componentNamePattern.test(item)) return false;
   }
   // The initial component must either be empty (no-component placeholder) or
   // present in the validated components list — otherwise the sidebar's
   // current-selection state would point at an unknown entry.
-  if (record.component !== '' && !record.components.includes(record.component)) return false;
+  if (component !== '' && !components.includes(component)) return false;
   return true;
 }
 

--- a/packages/playground/src/shell-app/shell-entry.ts
+++ b/packages/playground/src/shell-app/shell-entry.ts
@@ -31,13 +31,16 @@ function isInitialData(value: unknown): value is InitialData {
   if (typeof component !== 'string') return false;
   if (!Array.isArray(components)) return false;
   const componentNamePattern = /^[a-z0-9][a-z0-9-]*$/;
+  // The active component can legitimately be absent from `components`: the
+  // server lists only sidebar-eligible components there (those with at least
+  // one .example.svelte), but `/c/<name>` accepts any discovered component.
+  // So we validate the component name's shape but NOT membership in the
+  // sidebar list — that would wipe the sidebar for a perfectly valid URL
+  // like /c/radio.
+  if (component !== '' && !componentNamePattern.test(component)) return false;
   for (const item of components) {
     if (typeof item !== 'string' || !componentNamePattern.test(item)) return false;
   }
-  // The initial component must either be empty (no-component placeholder) or
-  // present in the validated components list — otherwise the sidebar's
-  // current-selection state would point at an unknown entry.
-  if (component !== '' && !components.includes(component)) return false;
   return true;
 }
 

--- a/packages/playground/src/shell-app/shell-entry.ts
+++ b/packages/playground/src/shell-app/shell-entry.ts
@@ -1,0 +1,51 @@
+/**
+ * Entry point for the playground shell SPA bundle.
+ *
+ * Reads the `<script type="application/json" id="cinder-initial">` data island
+ * embedded by `render-shell.ts` to get the initial component name and the
+ * full sidebar component list, then mounts the Svelte shell into `#shell-root`.
+ *
+ * The data-island pattern is used instead of a `window.__GLOBAL__` to avoid
+ * any risk of `</script>` injection through the embedded payload, even though
+ * payload values are filesystem-derived and kebab-case-validated server-side.
+ */
+
+import { mount } from 'svelte';
+
+import Shell from './shell.svelte';
+
+type InitialData = { component: string; components: string[] };
+
+function readInitialData(): InitialData {
+  const node = document.getElementById('cinder-initial');
+  if (!node) return { component: '', components: [] };
+  try {
+    const parsed = JSON.parse(node.textContent ?? '{}') as unknown;
+    if (
+      typeof parsed === 'object' &&
+      parsed !== null &&
+      typeof (parsed as InitialData).component === 'string' &&
+      Array.isArray((parsed as InitialData).components)
+    ) {
+      return parsed as InitialData;
+    }
+  } catch (error) {
+    console.error('[cinder playground] failed to parse #cinder-initial:', error);
+  }
+  return { component: '', components: [] };
+}
+
+const initial = readInitialData();
+
+const target = document.getElementById('shell-root');
+if (target === null) {
+  throw new Error('[cinder playground] #shell-root target not found');
+}
+
+mount(Shell, {
+  target,
+  props: {
+    initialComponent: initial.component,
+    components: initial.components,
+  },
+});

--- a/packages/playground/src/shell-app/shell.svelte
+++ b/packages/playground/src/shell-app/shell.svelte
@@ -1,0 +1,126 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+
+  import PreviewFrame from './preview-frame.svelte';
+  import {
+    applyThemeToDocument,
+    PreviewStore,
+    readPersistedTheme,
+    setPreviewStore,
+  } from './preview-store.svelte.ts';
+  import { buildShellHref, parseComponentFromPath } from './routing.ts';
+  import Sidebar from './sidebar.svelte';
+  import TopBar from './top-bar.svelte';
+
+  type Props = {
+    initialComponent: string;
+    components: string[];
+  };
+
+  let { initialComponent, components }: Props = $props();
+
+  const initialTheme = typeof window === 'undefined' ? 'system' : readPersistedTheme();
+  const store = new PreviewStore(initialComponent, initialTheme);
+  setPreviewStore(store);
+
+  // Apply the persisted theme to the shell's root document on first paint.
+  // The inline pre-paint script in render-shell.ts already did this before
+  // the bundle loaded, but reapplying here keeps the state machine simple
+  // (the inline script is a perf optimization, not a correctness gate).
+  if (typeof document !== 'undefined') applyThemeToDocument(document, store.theme);
+
+  let copiedFlash = $state<boolean>(false);
+
+  function copyLink(): void {
+    void navigator.clipboard
+      .writeText(window.location.href)
+      .then(() => {
+        copiedFlash = true;
+        setTimeout(() => {
+          copiedFlash = false;
+        }, 1500);
+      })
+      .catch((error: unknown) => {
+        console.error('[cinder playground] copy failed:', error);
+      });
+  }
+
+  function selectComponent(name: string): void {
+    if (name === store.currentComponent) return;
+    store.currentComponent = name;
+    history.pushState({}, '', buildShellHref(name));
+  }
+
+  onMount(() => {
+    function handlePopState(): void {
+      const parsed = parseComponentFromPath(window.location.pathname);
+      if (parsed !== null) store.currentComponent = parsed;
+    }
+    window.addEventListener('popstate', handlePopState);
+
+    function handleEscape(event: KeyboardEvent): void {
+      if (event.key === 'Escape' && store.isFocusMode) {
+        store.isFocusMode = false;
+      }
+    }
+    window.addEventListener('keydown', handleEscape);
+
+    const events = new EventSource('/events');
+    events.addEventListener('reload', () => {
+      const iframe = document.querySelector<HTMLIFrameElement>('iframe[data-cinder-preview]');
+      iframe?.contentWindow?.location.reload();
+    });
+    events.addEventListener('shell-reload', () => {
+      window.location.reload();
+    });
+
+    return () => {
+      window.removeEventListener('popstate', handlePopState);
+      window.removeEventListener('keydown', handleEscape);
+      events.close();
+    };
+  });
+</script>
+
+<div class="shell" class:focus-mode={store.isFocusMode}>
+  <Sidebar {components} currentComponent={store.currentComponent} onSelect={selectComponent} />
+  <main>
+    <TopBar onCopyLink={copyLink} {copiedFlash} />
+    <PreviewFrame componentName={store.currentComponent} />
+  </main>
+</div>
+
+<style>
+  .shell {
+    display: flex;
+    height: 100vh;
+    font-family:
+      system-ui,
+      -apple-system,
+      sans-serif;
+    font-size: 14px;
+    background: #f5f5f5;
+    color: #111;
+  }
+
+  main {
+    margin-left: 220px;
+    flex: 1;
+    height: 100vh;
+    display: flex;
+    flex-direction: column;
+    min-width: 0;
+  }
+
+  .shell.focus-mode :global(nav[aria-label='Components']) {
+    display: none;
+  }
+
+  .shell.focus-mode :global(header.top-bar) {
+    display: none;
+  }
+
+  .shell.focus-mode main {
+    margin-left: 0;
+  }
+</style>

--- a/packages/playground/src/shell-app/sidebar.svelte
+++ b/packages/playground/src/shell-app/sidebar.svelte
@@ -1,0 +1,97 @@
+<script lang="ts">
+  import { buildShellHref } from './routing.ts';
+
+  type Props = {
+    components: string[];
+    currentComponent: string;
+    onSelect: (componentName: string) => void;
+  };
+
+  let { components, currentComponent, onSelect }: Props = $props();
+
+  function handleClick(event: MouseEvent, componentName: string): void {
+    // Only intercept plain left-clicks. Modified clicks (cmd/ctrl/shift/alt)
+    // and middle-clicks fall through to native browser navigation so
+    // open-in-new-tab, "Copy Link Address", and status-bar URL preview all
+    // continue to work like regular anchor semantics.
+    if (event.button !== 0) return;
+    if (event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) return;
+    event.preventDefault();
+    onSelect(componentName);
+  }
+</script>
+
+<nav aria-label="Components">
+  <div class="nav-header">cinder</div>
+  <ul>
+    {#each components as name (name)}
+      {@const isActive = name === currentComponent}
+      <li>
+        <a
+          href={buildShellHref(name)}
+          aria-current={isActive ? 'page' : undefined}
+          onclick={(event) => handleClick(event, name)}
+        >
+          {name}
+        </a>
+      </li>
+    {/each}
+  </ul>
+</nav>
+
+<style>
+  nav {
+    width: 220px;
+    min-width: 220px;
+    height: 100vh;
+    position: fixed;
+    top: 0;
+    left: 0;
+    background: #fff;
+    border-right: 1px solid #e5e5e5;
+    overflow-y: auto;
+    display: flex;
+    flex-direction: column;
+  }
+
+  .nav-header {
+    padding: 16px;
+    font-weight: 700;
+    font-size: 13px;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    color: #666;
+    border-bottom: 1px solid #e5e5e5;
+  }
+
+  ul {
+    list-style: none;
+    padding: 8px 0;
+    margin: 0;
+    flex: 1;
+  }
+
+  li {
+    margin: 0;
+  }
+
+  ul li a {
+    display: block;
+    padding: 6px 16px;
+    text-decoration: none;
+    color: #333;
+    border-radius: 4px;
+    margin: 1px 8px;
+    transition: background 0.1s;
+  }
+
+  ul li a:hover {
+    background: #f0f0f0;
+  }
+
+  ul li a[aria-current='page'] {
+    background: #e8f0fe;
+    color: #1a56db;
+    font-weight: 600;
+  }
+</style>

--- a/packages/playground/src/shell-app/top-bar.svelte
+++ b/packages/playground/src/shell-app/top-bar.svelte
@@ -76,22 +76,26 @@
   }
 
   let announcement = $state<string>('');
+  let announceTimeout: ReturnType<typeof setTimeout> | null = null;
 
   function announce(text: string): void {
     // Clear first, then set on the next tick. Assigning the same string twice
     // in a row to a Svelte reactive value is a no-op and the aria-live region
     // never updates the DOM, so an AT user clicking the same control twice
     // would not hear the second announcement. Empty-then-set forces a DOM
-    // change every time.
+    // change every time. clearTimeout ensures back-to-back announce() calls
+    // resolve deterministically — the latest call wins, in order.
+    if (announceTimeout !== null) clearTimeout(announceTimeout);
     announcement = '';
-    setTimeout(() => {
+    announceTimeout = setTimeout(() => {
       announcement = text;
+      announceTimeout = null;
     }, 50);
   }
 
   function selectViewport(preset: (typeof VIEWPORT_PRESETS)[number]): void {
     store.previewWidth = preset.value;
-    announce(`Viewport: ${preset.label}${preset.value ? `, ${preset.value} pixels` : ''}`);
+    announce(`Viewport: ${preset.label}${preset.value !== null ? `, ${preset.value} pixels` : ''}`);
   }
 
   function selectTheme(option: (typeof THEME_OPTIONS)[number]): void {
@@ -117,21 +121,20 @@
 </script>
 
 <header class="top-bar">
-  <nav aria-label="Preview controls">
+  <div class="controls" role="group" aria-label="Preview controls">
     <div class="breadcrumb" title={store.currentComponent}>
       {store.currentComponent || ' '}
     </div>
 
-    <div role="radiogroup" aria-label="Viewport width" class="cluster">
+    <div role="group" aria-label="Viewport width" class="cluster">
       {#each VIEWPORT_PRESETS as preset (preset.abbrev)}
         {@const active = presetIsActive(preset.value)}
         <button
           type="button"
           class="segment"
           class:active
-          role="radio"
-          aria-checked={active}
-          aria-label={`${preset.label}${preset.value ? ` (${preset.value} pixels)` : ''}`}
+          aria-pressed={active}
+          aria-label={`${preset.label}${preset.value !== null ? ` (${preset.value} pixels)` : ''}`}
           title={preset.label}
           onclick={() => selectViewport(preset)}
         >
@@ -159,15 +162,14 @@
       <span class="unit" aria-hidden="true">px</span>
     </div>
 
-    <div role="radiogroup" aria-label="Color scheme" class="cluster">
+    <div role="group" aria-label="Color scheme" class="cluster">
       {#each THEME_OPTIONS as option (option.value)}
         {@const active = store.theme === option.value}
         <button
           type="button"
           class="segment icon-segment"
           class:active
-          role="radio"
-          aria-checked={active}
+          aria-pressed={active}
           aria-label={`${option.label} theme`}
           title={`${option.label} theme`}
           onclick={() => selectTheme(option)}
@@ -177,15 +179,14 @@
       {/each}
     </div>
 
-    <div role="radiogroup" aria-label="Preview background" class="cluster">
+    <div role="group" aria-label="Preview background" class="cluster">
       {#each BACKGROUND_OPTIONS as option (option.value)}
         {@const active = store.background === option.value}
         <button
           type="button"
           class="segment icon-segment"
           class:active
-          role="radio"
-          aria-checked={active}
+          aria-pressed={active}
           aria-label={`${option.label} background`}
           title={`${option.label} background`}
           onclick={() => selectBackground(option)}
@@ -217,7 +218,7 @@
         <span aria-hidden="true">{copiedFlash ? '✓' : '⎘'}</span>
       </button>
     </div>
-  </nav>
+  </div>
   <span class="sr-only" aria-live="polite" aria-atomic="true">{announcement}</span>
 </header>
 
@@ -233,7 +234,7 @@
     flex-shrink: 0;
   }
 
-  nav {
+  .controls {
     display: flex;
     align-items: center;
     gap: 12px;

--- a/packages/playground/src/shell-app/top-bar.svelte
+++ b/packages/playground/src/shell-app/top-bar.svelte
@@ -58,13 +58,14 @@
   }
 
   function handleCustomKeydown(event: KeyboardEvent): void {
+    const input = event.currentTarget;
     if (event.key === 'Enter') {
       event.preventDefault();
       commitCustomWidth();
-      (event.currentTarget as HTMLInputElement).blur();
+      if (input instanceof HTMLInputElement) input.blur();
     } else if (event.key === 'Escape') {
       customWidthDraft = store.previewWidth === null ? '' : String(store.previewWidth);
-      (event.currentTarget as HTMLInputElement).blur();
+      if (input instanceof HTMLInputElement) input.blur();
     }
   }
 
@@ -77,11 +78,14 @@
   let announcement = $state<string>('');
 
   function announce(text: string): void {
-    announcement = text;
-    // Force a refresh of the live region for AT — same text in a row won't
-    // re-announce, so we briefly clear then set.
+    // Clear first, then set on the next tick. Assigning the same string twice
+    // in a row to a Svelte reactive value is a no-op and the aria-live region
+    // never updates the DOM, so an AT user clicking the same control twice
+    // would not hear the second announcement. Empty-then-set forces a DOM
+    // change every time.
+    announcement = '';
     setTimeout(() => {
-      if (announcement === text) announcement = text;
+      announcement = text;
     }, 50);
   }
 
@@ -102,8 +106,14 @@
 
   function toggleFocusMode(): void {
     store.isFocusMode = !store.isFocusMode;
-    announce(store.isFocusMode ? 'Focus mode on' : 'Focus mode off');
+    announce(store.isFocusMode ? 'Focus mode on. Press Escape to exit.' : 'Focus mode off');
   }
+
+  // When the copy-link parent flips copiedFlash to true, announce success
+  // for AT users — the visual glyph swap alone is not perceivable.
+  $effect(() => {
+    if (copiedFlash) announce('Link copied to clipboard');
+  });
 </script>
 
 <header class="top-bar">
@@ -112,17 +122,23 @@
       {store.currentComponent || ' '}
     </div>
 
-    <div role="group" aria-label="Viewport width" class="cluster">
+    <div role="radiogroup" aria-label="Viewport width" class="cluster">
       {#each VIEWPORT_PRESETS as preset (preset.abbrev)}
         {@const active = presetIsActive(preset.value)}
         <button
           type="button"
           class="segment"
           class:active
-          aria-pressed={active}
+          role="radio"
+          aria-checked={active}
           aria-label={`${preset.label}${preset.value ? ` (${preset.value} pixels)` : ''}`}
+          title={preset.label}
           onclick={() => selectViewport(preset)}
         >
+          <!-- Always-visible abbrev so the button has content at every
+               width. The friendly label shows in addition when the bar
+               has room (see the .segment-label media query). -->
+          <span class="segment-abbrev" aria-hidden="true">{preset.abbrev}</span>
           <span class="segment-label">{preset.label}</span>
         </button>
       {/each}
@@ -136,22 +152,22 @@
         step="1"
         inputmode="numeric"
         placeholder="Full"
-        aria-describedby="viewport-width-unit"
         bind:value={customWidthDraft}
         onkeydown={handleCustomKeydown}
         onblur={commitCustomWidth}
       />
-      <span id="viewport-width-unit" class="unit" aria-hidden="true">px</span>
+      <span class="unit" aria-hidden="true">px</span>
     </div>
 
-    <div role="group" aria-label="Color scheme" class="cluster">
+    <div role="radiogroup" aria-label="Color scheme" class="cluster">
       {#each THEME_OPTIONS as option (option.value)}
         {@const active = store.theme === option.value}
         <button
           type="button"
           class="segment icon-segment"
           class:active
-          aria-pressed={active}
+          role="radio"
+          aria-checked={active}
           aria-label={`${option.label} theme`}
           title={`${option.label} theme`}
           onclick={() => selectTheme(option)}
@@ -161,14 +177,15 @@
       {/each}
     </div>
 
-    <div role="group" aria-label="Preview background" class="cluster">
+    <div role="radiogroup" aria-label="Preview background" class="cluster">
       {#each BACKGROUND_OPTIONS as option (option.value)}
         {@const active = store.background === option.value}
         <button
           type="button"
           class="segment icon-segment"
           class:active
-          aria-pressed={active}
+          role="radio"
+          aria-checked={active}
           aria-label={`${option.label} background`}
           title={`${option.label} background`}
           onclick={() => selectBackground(option)}
@@ -184,8 +201,8 @@
         class="segment icon-segment"
         class:active={store.isFocusMode}
         aria-pressed={store.isFocusMode}
-        aria-label="Focus mode"
-        title="Focus mode (hide chrome)"
+        aria-label="Focus mode (press Escape to exit)"
+        title="Focus mode — hide sidebar and top bar"
         onclick={toggleFocusMode}
       >
         <span aria-hidden="true">⛶</span>
@@ -193,8 +210,8 @@
       <button
         type="button"
         class="segment icon-segment"
-        aria-label="Copy component link"
-        title="Copy component link"
+        aria-label={copiedFlash ? 'Link copied to clipboard' : 'Copy component link'}
+        title={copiedFlash ? 'Copied!' : 'Copy component link'}
         onclick={onCopyLink}
       >
         <span aria-hidden="true">{copiedFlash ? '✓' : '⎘'}</span>
@@ -337,9 +354,24 @@
     border: 0;
   }
 
+  /* Viewport preset buttons render an abbrev (numeric width or "Full") that
+     is ALWAYS visible, plus a friendly label that appears only when there's
+     room. The aria-label on the button carries the full accessible name. */
+  .segment-abbrev {
+    display: inline-block;
+  }
+
+  .segment-label {
+    display: inline-block;
+    margin-left: 4px;
+  }
+
   @media (max-width: 1279px) {
     .segment-label {
       display: none;
+    }
+    .segment-abbrev {
+      margin-left: 0;
     }
   }
 </style>

--- a/packages/playground/src/shell-app/top-bar.svelte
+++ b/packages/playground/src/shell-app/top-bar.svelte
@@ -149,11 +149,13 @@
       <input
         id="viewport-width-input"
         class="width-input"
-        type="number"
-        min="200"
-        max="3840"
-        step="1"
+        type="text"
         inputmode="numeric"
+        pattern="[0-9]*"
+        autocomplete="off"
+        spellcheck="false"
+        maxlength="4"
+        aria-label="Custom viewport width in pixels (200 to 3840)"
         placeholder="Full"
         bind:value={customWidthDraft}
         onkeydown={handleCustomKeydown}
@@ -311,7 +313,6 @@
   }
 
   .width-input {
-    appearance: textfield;
     width: 64px;
     height: 28px;
     margin-left: 6px;
@@ -323,12 +324,6 @@
     text-align: right;
     background: #fff;
     color: #333;
-  }
-
-  .width-input::-webkit-outer-spin-button,
-  .width-input::-webkit-inner-spin-button {
-    -webkit-appearance: none;
-    margin: 0;
   }
 
   .width-input:focus-visible {

--- a/packages/playground/src/shell-app/top-bar.svelte
+++ b/packages/playground/src/shell-app/top-bar.svelte
@@ -1,0 +1,345 @@
+<script lang="ts">
+  import type { BackgroundChoice, ThemeChoice } from './preview-store.svelte.ts';
+  import { getPreviewStore } from './preview-store.svelte.ts';
+
+  type Props = {
+    onCopyLink: () => void;
+    copiedFlash: boolean;
+  };
+
+  let { onCopyLink, copiedFlash }: Props = $props();
+
+  const store = getPreviewStore();
+
+  const VIEWPORT_PRESETS: ReadonlyArray<{ label: string; abbrev: string; value: number | null }> = [
+    { label: 'Mobile', abbrev: '375', value: 375 },
+    { label: 'Tablet', abbrev: '768', value: 768 },
+    { label: 'Desktop', abbrev: '1280', value: 1280 },
+    { label: 'Full', abbrev: 'Full', value: null },
+  ];
+
+  const THEME_OPTIONS: ReadonlyArray<{ value: ThemeChoice; label: string; glyph: string }> = [
+    { value: 'light', label: 'Light', glyph: '☀' },
+    { value: 'system', label: 'System', glyph: '◐' },
+    { value: 'dark', label: 'Dark', glyph: '☾' },
+  ];
+
+  const BACKGROUND_OPTIONS: ReadonlyArray<{
+    value: BackgroundChoice;
+    label: string;
+    glyph: string;
+  }> = [
+    { value: 'surface', label: 'Surface', glyph: '▢' },
+    { value: 'inverse', label: 'Inverse', glyph: '■' },
+    { value: 'checker', label: 'Checker', glyph: '▦' },
+  ];
+
+  // Local input state for the custom width box so a partial value (e.g. user
+  // mid-typing "12") doesn't blow away the iframe size on every keystroke.
+  let customWidthDraft = $state<string>('');
+
+  $effect(() => {
+    customWidthDraft = store.previewWidth === null ? '' : String(store.previewWidth);
+  });
+
+  function commitCustomWidth(): void {
+    const raw = customWidthDraft.trim();
+    if (raw === '') {
+      store.previewWidth = null;
+      return;
+    }
+    const parsed = Number.parseInt(raw, 10);
+    if (Number.isNaN(parsed) || parsed < 200 || parsed > 3840) {
+      // Snap back to the current value.
+      customWidthDraft = store.previewWidth === null ? '' : String(store.previewWidth);
+      return;
+    }
+    store.previewWidth = parsed;
+  }
+
+  function handleCustomKeydown(event: KeyboardEvent): void {
+    if (event.key === 'Enter') {
+      event.preventDefault();
+      commitCustomWidth();
+      (event.currentTarget as HTMLInputElement).blur();
+    } else if (event.key === 'Escape') {
+      customWidthDraft = store.previewWidth === null ? '' : String(store.previewWidth);
+      (event.currentTarget as HTMLInputElement).blur();
+    }
+  }
+
+  // The "Full" preset is active when previewWidth is null; numeric presets
+  // are active when previewWidth matches exactly.
+  function presetIsActive(presetValue: number | null): boolean {
+    return store.previewWidth === presetValue;
+  }
+
+  let announcement = $state<string>('');
+
+  function announce(text: string): void {
+    announcement = text;
+    // Force a refresh of the live region for AT — same text in a row won't
+    // re-announce, so we briefly clear then set.
+    setTimeout(() => {
+      if (announcement === text) announcement = text;
+    }, 50);
+  }
+
+  function selectViewport(preset: (typeof VIEWPORT_PRESETS)[number]): void {
+    store.previewWidth = preset.value;
+    announce(`Viewport: ${preset.label}${preset.value ? `, ${preset.value} pixels` : ''}`);
+  }
+
+  function selectTheme(option: (typeof THEME_OPTIONS)[number]): void {
+    store.setTheme(option.value);
+    announce(`Color scheme: ${option.label}`);
+  }
+
+  function selectBackground(option: (typeof BACKGROUND_OPTIONS)[number]): void {
+    store.background = option.value;
+    announce(`Preview background: ${option.label}`);
+  }
+
+  function toggleFocusMode(): void {
+    store.isFocusMode = !store.isFocusMode;
+    announce(store.isFocusMode ? 'Focus mode on' : 'Focus mode off');
+  }
+</script>
+
+<header class="top-bar">
+  <nav aria-label="Preview controls">
+    <div class="breadcrumb" title={store.currentComponent}>
+      {store.currentComponent || ' '}
+    </div>
+
+    <div role="group" aria-label="Viewport width" class="cluster">
+      {#each VIEWPORT_PRESETS as preset (preset.abbrev)}
+        {@const active = presetIsActive(preset.value)}
+        <button
+          type="button"
+          class="segment"
+          class:active
+          aria-pressed={active}
+          aria-label={`${preset.label}${preset.value ? ` (${preset.value} pixels)` : ''}`}
+          onclick={() => selectViewport(preset)}
+        >
+          <span class="segment-label">{preset.label}</span>
+        </button>
+      {/each}
+      <label for="viewport-width-input" class="sr-only">Custom viewport width in pixels</label>
+      <input
+        id="viewport-width-input"
+        class="width-input"
+        type="number"
+        min="200"
+        max="3840"
+        step="1"
+        inputmode="numeric"
+        placeholder="Full"
+        aria-describedby="viewport-width-unit"
+        bind:value={customWidthDraft}
+        onkeydown={handleCustomKeydown}
+        onblur={commitCustomWidth}
+      />
+      <span id="viewport-width-unit" class="unit" aria-hidden="true">px</span>
+    </div>
+
+    <div role="group" aria-label="Color scheme" class="cluster">
+      {#each THEME_OPTIONS as option (option.value)}
+        {@const active = store.theme === option.value}
+        <button
+          type="button"
+          class="segment icon-segment"
+          class:active
+          aria-pressed={active}
+          aria-label={`${option.label} theme`}
+          title={`${option.label} theme`}
+          onclick={() => selectTheme(option)}
+        >
+          <span aria-hidden="true">{option.glyph}</span>
+        </button>
+      {/each}
+    </div>
+
+    <div role="group" aria-label="Preview background" class="cluster">
+      {#each BACKGROUND_OPTIONS as option (option.value)}
+        {@const active = store.background === option.value}
+        <button
+          type="button"
+          class="segment icon-segment"
+          class:active
+          aria-pressed={active}
+          aria-label={`${option.label} background`}
+          title={`${option.label} background`}
+          onclick={() => selectBackground(option)}
+        >
+          <span aria-hidden="true">{option.glyph}</span>
+        </button>
+      {/each}
+    </div>
+
+    <div role="group" aria-label="Actions" class="cluster">
+      <button
+        type="button"
+        class="segment icon-segment"
+        class:active={store.isFocusMode}
+        aria-pressed={store.isFocusMode}
+        aria-label="Focus mode"
+        title="Focus mode (hide chrome)"
+        onclick={toggleFocusMode}
+      >
+        <span aria-hidden="true">⛶</span>
+      </button>
+      <button
+        type="button"
+        class="segment icon-segment"
+        aria-label="Copy component link"
+        title="Copy component link"
+        onclick={onCopyLink}
+      >
+        <span aria-hidden="true">{copiedFlash ? '✓' : '⎘'}</span>
+      </button>
+    </div>
+  </nav>
+  <span class="sr-only" aria-live="polite" aria-atomic="true">{announcement}</span>
+</header>
+
+<style>
+  .top-bar {
+    box-sizing: border-box;
+    height: 48px;
+    padding: 0 12px;
+    background: #fff;
+    border-bottom: 1px solid #e5e5e5;
+    display: flex;
+    align-items: center;
+    flex-shrink: 0;
+  }
+
+  nav {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    width: 100%;
+    overflow-x: auto;
+  }
+
+  .breadcrumb {
+    font-size: 13px;
+    font-weight: 600;
+    color: #333;
+    flex: 0 1 240px;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    padding-right: 12px;
+    border-right: 1px solid #e5e5e5;
+  }
+
+  .cluster {
+    display: flex;
+    align-items: center;
+    gap: 2px;
+    border-right: 1px solid #e5e5e5;
+    padding-right: 12px;
+  }
+
+  .cluster:last-of-type {
+    border-right: none;
+    padding-right: 0;
+  }
+
+  .segment {
+    appearance: none;
+    background: transparent;
+    border: 1px solid transparent;
+    color: #444;
+    padding: 4px 10px;
+    font: inherit;
+    font-size: 12px;
+    line-height: 1;
+    border-radius: 4px;
+    cursor: pointer;
+    transition:
+      background 0.1s,
+      border-color 0.1s;
+    min-height: 28px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  .segment:hover {
+    background: #f0f0f0;
+  }
+
+  .segment.active {
+    background: #e8f0fe;
+    color: #1a56db;
+    border-color: rgba(26, 86, 219, 0.2);
+    font-weight: 600;
+  }
+
+  .icon-segment {
+    padding: 4px 8px;
+    min-width: 30px;
+    font-size: 14px;
+  }
+
+  .segment:focus-visible {
+    outline: 2px solid #1a56db;
+    outline-offset: 1px;
+  }
+
+  .width-input {
+    appearance: textfield;
+    width: 64px;
+    height: 28px;
+    margin-left: 6px;
+    border: 1px solid #d4d4d4;
+    border-radius: 4px;
+    padding: 0 6px;
+    font: inherit;
+    font-size: 12px;
+    text-align: right;
+    background: #fff;
+    color: #333;
+  }
+
+  .width-input::-webkit-outer-spin-button,
+  .width-input::-webkit-inner-spin-button {
+    -webkit-appearance: none;
+    margin: 0;
+  }
+
+  .width-input:focus-visible {
+    outline: 2px solid #1a56db;
+    outline-offset: 1px;
+    border-color: transparent;
+  }
+
+  .unit {
+    font-size: 11px;
+    color: #888;
+    padding-left: 4px;
+  }
+
+  .sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+  }
+
+  @media (max-width: 1279px) {
+    .segment-label {
+      display: none;
+    }
+  }
+</style>


### PR DESCRIPTION
## Summary

Switching between playground stories was a full top-level page reload plus a fresh iframe doc plus an on-demand `Bun.build` per click. This PR makes the shell a persistent Svelte 5 SPA so sidebar clicks only swap `iframe.src`, pre-builds every page bundle at server start, and adds a global top control bar (viewport, theme, background, focus mode, copy-link).

- **Phase 1 — Persistent shell SPA**: shell mounts once via `mount(Shell, ...)` and never reloads. Sidebar uses real `<a href="/c/:name">` anchors and intercepts only plain left-clicks so cmd-click / middle-click / "Open Link in New Tab" still work. `history.pushState` + `popstate` keep deep-links and back/forward correct.
- **Phase 2 — Eager bundle pre-build + cache state machine**: every page bundle is built once at server start (logged as `Pre-built N/N`). A rebuild-generation token + per-family artifact maps (page / shell / scenario) guarantee atomic publish — stale rebuilds discard themselves silently, shell-only failures preserve the old coherent shell while page builds still ship, and the watcher emits exactly one SSE reload event per publish (`shell-reload` triggers full reload, `reload` reloads just the iframe).
- **Phase 3 — Top control bar**: viewport presets (Mobile / Tablet / Desktop / Full) + custom width input, three-state theme toggle persisted to localStorage with try/catch wrappers + pre-paint inline scripts on both shell and iframe pages to prevent FOUC, session-only background swatch + focus mode, and a copy-link button. The shell→iframe channel is a `cinder:`-prefixed `postMessage` protocol with origin + shape validation on the iframe side.

Component name segments are encoded with `encodeURIComponent` defensively, validated against the existing `/^[a-z0-9][a-z0-9-]*$/` invariant. The `cinder-initial` data island is escaped via `jsonForScriptTag` (covers `<`, `>`, `&`, U+2028, U+2029) and parsed via a real `isInitialData` type guard — no `as` casts.

## Review committee

Pre-reviewed by: typescript-expert, frontend-architect, testing-expert, simplicity-engineer, ux-designer, junior-engineer
- Codex (gpt-5.4, xhigh reasoning) — 3 rounds
- 3 rounds of review
- All must-fix items addressed; codex APPROVED on round 3

Round 2 tie-break: frontend-architect (revert to `aria-pressed`) vs ux-designer round 1 (keep `role="radio"`). Resolved by simplicity tie-breaker — `role="radio"` advertises arrow-key roving tabindex that isn't implemented; misleading AT users is worse than the radio role's discoverability benefit. Buttons with `aria-pressed` work correctly with screen readers out of the box.

## Test plan

- [x] `bun test packages/playground` — 140/140 pass (new: `routing.test.ts` 19 tests, `preview-store.test.ts` 13 tests, `render-shell.test.ts` jsonForScriptTag escaping, server.test.ts shell-bundle route + shell-reload SSE wire format)
- [x] `bun run typecheck` clean
- [x] `bun run lint` clean
- [x] Manual smoke in browser: persistent shell across switches, no `/c/X` re-fetch, no `Bun.build` log on click, cmd-click opens new tab, theme toggle hot-applies to both shell + iframe in same frame, custom width input, focus mode + Escape, background swatch, copy-link

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it refactors the playground server’s bundling/cache/reload pipeline (new shell bundle route, atomic rebuild state machine, and eager prebuild), which can affect dev-server stability and live-reload behavior.
> 
> **Overview**
> Converts the playground `GET /c/:name` response from a fully-rendered sidebar/iframe page into a minimal scaffold that boots a persistent Svelte shell SPA, passing initial state via a safely-escaped `application/json` data island and mounting into `#shell-root`.
> 
> Adds the shell SPA UI (sidebar + new top control bar) to make component switching update only the iframe, plus controls for viewport width, theme (persisted), background, focus mode, and copy-link; theme/background sync to the iframe via a validated `postMessage` protocol and a shared pre-paint theme script to reduce flashes.
> 
> Overhauls server bundling/caching: introduces a separate `/shell-bundle/*` build+route, eager prebuild at startup, per-family artifact caches with guarded cross-family chunk serving, and a debounced generation-based rebuild publisher that emits either `reload` (iframe-only) or `shell-reload` (full page) SSE events. Tests were added/updated to pin escaping, data-island contents, new routes, and SSE wire format.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 20c7865dcacbf9df6231b157a418bafb5267f5eb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->