### PR TITLE
feat(button): variant/size expansion, icon slots, iconOnly, and a11y improvements

### DIFF
--- a/packages/components/src/components/button.a11y.md
+++ b/packages/components/src/components/button.a11y.md
@@ -1,29 +1,31 @@
-# Button — Accessibility Notes
+# Button—Accessibility Notes
 
 ## Icon-only buttons
 
-Use `iconOnly={true}` for square buttons that show only an icon. The button **must** have an accessible name — either via `aria-label`, `aria-labelledby`, or a non-empty `label` prop (which renders as visually-hidden text).
+Use `iconOnly={true}` for square buttons that show only an icon. The button **must** have an accessible name—either via `aria-label`, `aria-labelledby`, or a non-empty `label` prop (which renders as visually-hidden text).
 
 The dev-mode guard warns when:
 
 - `iconOnly={true}` with no `aria-label`, `aria-labelledby`, or non-empty `label` (no accessible name).
-- `iconOnly={true}` with no `leadingIcon`, `trailingIcon`, or `children` (blank square — real UI failure).
+- `iconOnly={true}` with no `leadingIcon`, `trailingIcon`, or `children` (blank square—real UI failure).
 
 `children` is **not** a valid accessible-name source for icon-only buttons because children may be a non-text SVG or other non-text markup. Use `aria-label` or `label` for the name; use `leadingIcon`, `trailingIcon`, or `children` for the visual.
 
 ### Accessible-name precedence
 
-1. If `aria-label` (non-empty) or `aria-labelledby` (non-empty) is provided, that is the name. `label` text is not rendered as sr-only in this case.
-2. Otherwise, if `label` is a non-empty string, it is rendered inside a `<span class="cinder-sr-only">` — visually hidden but in the DOM as the accessible name via text content.
+1. If `aria-label` (non-empty) or `aria-labelledby` (non-empty) is provided, it becomes the accessible name per the ARIA spec ([accessible name computation](https://www.w3.org/TR/accname-1.2/)). Text content—including a sr-only span—is not considered. Rendering a redundant sr-only span alongside `aria-label` adds invisible DOM noise with no accessible benefit, so the component suppresses it.
+2. Otherwise, if `label` is a non-empty string, it is rendered inside a `<span class="cinder-sr-only">`—visually hidden but in the DOM as the accessible name via text content.
 3. If neither is present, the dev guard warns; production renders silently (we don't crash apps over a label mistake).
 
 ### Icon slots are decorative
 
 `leadingIcon` and `trailingIcon` render inside `<span aria-hidden="true">`. The meaning belongs in the button's accessible name. If an icon must convey meaning (e.g., external-link indicator), put that meaning in `label` or `aria-label` instead.
 
+When `iconOnly={true}`, `children` is also wrapped in an `aria-hidden` span and treated as the visual icon—it is never a name source in this mode.
+
 ## Touch targets
 
-- `md` (default): 44px minimum height — meets WCAG 2.5.5 AAA touch-target requirement out of the box.
+- `md` (default): 44px minimum height—meets WCAG 2.5.5 AAA touch-target requirement out of the box.
 - `lg`, `xl`: exceed 44px.
 - `sm` (32px) and `xs` (24px): **intentionally below AAA**. Use these sizes only in dense UI contexts (toolbars, compact tables, developer tools) where space is at a premium and the surrounding context makes smaller targets acceptable. Do not use `sm` or `xs` as the primary action button for a touch-first surface.
 
@@ -37,15 +39,19 @@ A Playwright check for rendered `md`/`lg`/`xl` heights is tracked as a future ta
 
 ## Loading state
 
-The spinner is a CSS `::after` pseudo-element — not a DOM node. Pseudo-elements are excluded from the accessibility tree per the ARIA specification, so no explicit `aria-hidden` is needed on a spinner element.
+The spinner is a CSS `::after` pseudo-element—not a DOM node. Pseudo-elements are excluded from the accessibility tree per the ARIA specification, so no explicit `aria-hidden` is needed on a spinner element.
 
 The button's label text (`label` prop or `children`) remains in the DOM throughout the loading state and continues to serve as the accessible name. `aria-busy="true"` communicates the loading state to assistive technology. `aria-disabled="true"` signals that the button is not interactive during loading.
 
 ## Forced-colors (Windows High Contrast)
 
-The focus ring uses `outline: var(--cinder-ring-width) solid ButtonText` under `@media (forced-colors: active)` — guaranteed to contrast against the button surface.
+The focus ring uses `outline: var(--cinder-ring-width) solid ButtonText` under `@media (forced-colors: active)`—guaranteed to contrast against the button surface.
 
 `soft` and `soft-danger` variants add `border: 1px solid ButtonBorder` under forced-colors so they remain visually distinct. Verify in Windows High Contrast emulator before shipping.
+
+## Soft variant contrast
+
+`soft` and `soft-danger` use `color-mix(in oklch, var(--cinder-accent|danger), transparent 88%)` as the background. Contrast ratios must be verified mechanically before shipping: compute the resolved hex values via browser devtools Computed panel for both light and dark themes, then run through the WebAIM contrast checker. Record the numeric ratios in the PR description. If either theme falls below 4.5:1 for normal text, introduce per-theme `--cinder-color-accent-soft-bg`/`-fg` tokens with explicit values that meet the threshold.
 
 ## Variant guidance
 

--- a/packages/components/src/components/button.a11y.md
+++ b/packages/components/src/components/button.a11y.md
@@ -1,0 +1,58 @@
+# Button — Accessibility Notes
+
+## Icon-only buttons
+
+Use `iconOnly={true}` for square buttons that show only an icon. The button **must** have an accessible name — either via `aria-label`, `aria-labelledby`, or a non-empty `label` prop (which renders as visually-hidden text).
+
+The dev-mode guard warns when:
+
+- `iconOnly={true}` with no `aria-label`, `aria-labelledby`, or non-empty `label` (no accessible name).
+- `iconOnly={true}` with no `leadingIcon`, `trailingIcon`, or `children` (blank square — real UI failure).
+
+`children` is **not** a valid accessible-name source for icon-only buttons because children may be a non-text SVG or other non-text markup. Use `aria-label` or `label` for the name; use `leadingIcon`, `trailingIcon`, or `children` for the visual.
+
+### Accessible-name precedence
+
+1. If `aria-label` (non-empty) or `aria-labelledby` (non-empty) is provided, that is the name. `label` text is not rendered as sr-only in this case.
+2. Otherwise, if `label` is a non-empty string, it is rendered inside a `<span class="cinder-sr-only">` — visually hidden but in the DOM as the accessible name via text content.
+3. If neither is present, the dev guard warns; production renders silently (we don't crash apps over a label mistake).
+
+### Icon slots are decorative
+
+`leadingIcon` and `trailingIcon` render inside `<span aria-hidden="true">`. The meaning belongs in the button's accessible name. If an icon must convey meaning (e.g., external-link indicator), put that meaning in `label` or `aria-label` instead.
+
+## Touch targets
+
+- `md` (default): 44px minimum height — meets WCAG 2.5.5 AAA touch-target requirement out of the box.
+- `lg`, `xl`: exceed 44px.
+- `sm` (32px) and `xs` (24px): **intentionally below AAA**. Use these sizes only in dense UI contexts (toolbars, compact tables, developer tools) where space is at a premium and the surrounding context makes smaller targets acceptable. Do not use `sm` or `xs` as the primary action button for a touch-first surface.
+
+### Migration note: `md` height change
+
+The `md` size bumped from 36px to 44px to meet AAA sizing out of the box. Fixed-height toolbar layouts that depended on the 36px height will grow by 8px. Switch to `size="sm"` (32px) to restore the previous density if needed.
+
+### Follow-up
+
+A Playwright check for rendered `md`/`lg`/`xl` heights is tracked as a future task once the playground has Playwright coverage.
+
+## Loading state
+
+The spinner is a CSS `::after` pseudo-element — not a DOM node. Pseudo-elements are excluded from the accessibility tree per the ARIA specification, so no explicit `aria-hidden` is needed on a spinner element.
+
+The button's label text (`label` prop or `children`) remains in the DOM throughout the loading state and continues to serve as the accessible name. `aria-busy="true"` communicates the loading state to assistive technology. `aria-disabled="true"` signals that the button is not interactive during loading.
+
+## Forced-colors (Windows High Contrast)
+
+The focus ring uses `outline: var(--cinder-ring-width) solid ButtonText` under `@media (forced-colors: active)` — guaranteed to contrast against the button surface.
+
+`soft` and `soft-danger` variants add `border: 1px solid ButtonBorder` under forced-colors so they remain visually distinct. Verify in Windows High Contrast emulator before shipping.
+
+## Variant guidance
+
+- `primary`: high-emphasis action. One per region.
+- `secondary`: medium-emphasis, outline-flavored (surface fill + border).
+- `soft`: medium-emphasis, tinted fill, no border. Good for secondary actions in colored contexts.
+- `soft-danger`: same as soft but uses danger tint. For destructive secondary actions.
+- `danger`: high-emphasis destructive action.
+- `ghost`: low-emphasis, transparent background.
+- `ghost-danger`: low-emphasis destructive action.

--- a/packages/components/src/components/button.a11y.md
+++ b/packages/components/src/components/button.a11y.md
@@ -25,7 +25,7 @@ When `iconOnly={true}`, `children` is also wrapped in an `aria-hidden` span and 
 
 ## Touch targets
 
-- `md` (default): 44px minimum height—meets WCAG 2.5.5 AAA touch-target requirement out of the box.
+- `md` (default): 44px minimum height—meets [WCAG 2.5.5 AAA touch-target](https://www.w3.org/WAI/WCAG22/Understanding/target-size-enhanced.html) requirement out of the box.
 - `lg`, `xl`: exceed 44px.
 - `sm` (32px) and `xs` (24px): **intentionally below AAA**. Use these sizes only in dense UI contexts (toolbars, compact tables, developer tools) where space is at a premium and the surrounding context makes smaller targets acceptable. Do not use `sm` or `xs` as the primary action button for a touch-first surface.
 
@@ -35,7 +35,7 @@ The `md` size bumped from 36px to 44px to meet AAA sizing out of the box. Fixed-
 
 ### Follow-up
 
-A Playwright check for rendered `md`/`lg`/`xl` heights is tracked as a future task once the playground has Playwright coverage.
+A [Playwright](https://playwright.dev/) check for rendered `md`/`lg`/`xl` heights is tracked as a future task once the playground has browser coverage.
 
 ## Loading state
 
@@ -43,7 +43,7 @@ The spinner is a CSS `::after` pseudo-element—not a DOM node. Pseudo-elements 
 
 The button's label text (`label` prop or `children`) remains in the DOM throughout the loading state and continues to serve as the accessible name. `aria-busy="true"` communicates the loading state to assistive technology. `aria-disabled="true"` signals that the button is not interactive during loading.
 
-## Forced-colors (Windows High Contrast)
+## Forced-colors ([Windows High Contrast](https://learn.microsoft.com/en-us/windows/apps/design/accessibility/high-contrast-themes))
 
 The focus ring uses `outline: var(--cinder-ring-width) solid ButtonText` under `@media (forced-colors: active)`—guaranteed to contrast against the button surface.
 
@@ -51,7 +51,7 @@ The focus ring uses `outline: var(--cinder-ring-width) solid ButtonText` under `
 
 ## Soft variant contrast
 
-`soft` and `soft-danger` use `color-mix(in oklch, var(--cinder-accent|danger), transparent 88%)` as the background. Contrast ratios must be verified mechanically before shipping: compute the resolved hex values via browser devtools Computed panel for both light and dark themes, then run through the WebAIM contrast checker. Record the numeric ratios in the PR description. If either theme falls below 4.5:1 for normal text, introduce per-theme `--cinder-color-accent-soft-bg`/`-fg` tokens with explicit values that meet the threshold.
+`soft` and `soft-danger` use `color-mix(in oklch, var(--cinder-accent|danger), transparent 88%)` as the background. Contrast ratios must be verified mechanically before shipping: compute the resolved hex values via browser devtools Computed panel for both light and dark themes, then run through the [WebAIM contrast checker](https://webaim.org/resources/contrastchecker/). Record the numeric ratios in the PR description. If either theme falls below 4.5:1 for normal text, introduce per-theme `--cinder-color-accent-soft-bg`/`-fg` tokens with explicit values that meet the threshold.
 
 ## Variant guidance
 

--- a/packages/components/src/components/button.a11y.md
+++ b/packages/components/src/components/button.a11y.md
@@ -26,7 +26,7 @@ When `iconOnly={true}`, `children` is also wrapped in an `aria-hidden` span and 
 ## Touch targets
 
 - `md` (default): 44px minimum height—meets [WCAG 2.5.5 AAA touch-target](https://www.w3.org/WAI/WCAG22/Understanding/target-size-enhanced.html) requirement out of the box.
-- `lg`, `xl`: exceed 44px.
+- `lg` (48px) and `xl` (52px): exceed 44px.
 - `sm` (32px) and `xs` (24px): **intentionally below AAA**. Use these sizes only in dense UI contexts (toolbars, compact tables, developer tools) where space is at a premium and the surrounding context makes smaller targets acceptable. Do not use `sm` or `xs` as the primary action button for a touch-first surface.
 
 ### Migration note: `md` height change

--- a/packages/components/src/components/button.svelte
+++ b/packages/components/src/components/button.svelte
@@ -57,9 +57,17 @@
   // `WithChildren` genuinely forbids `iconOnly={true}`, and `WithIconOnly` requires it.
   type WithLabel = { label: string; children?: Snippet; iconOnly?: false };
   type WithChildren = { label?: string; children: Snippet; iconOnly?: false };
-  // Icon-only buttons may have a label (rendered sr-only) or rely on aria-label/aria-labelledby
-  // passed via rest props. `children` is accepted as the visual icon (not a name source).
-  type WithIconOnly = { iconOnly: true; label?: string; children?: Snippet };
+  type IconOnlyAccessibleName =
+    | { label: string; 'aria-label'?: string; 'aria-labelledby'?: string }
+    | { label?: string; 'aria-label': string; 'aria-labelledby'?: string }
+    | { label?: string; 'aria-label'?: string; 'aria-labelledby': string };
+  type IconOnlyVisual =
+    | { children: Snippet; leadingIcon?: Snippet; trailingIcon?: Snippet }
+    | { children?: Snippet; leadingIcon: Snippet; trailingIcon?: Snippet }
+    | { children?: Snippet; leadingIcon?: Snippet; trailingIcon: Snippet };
+  // Icon-only buttons require a name source and a visual icon source at compile time.
+  // `children` is accepted as the visual icon only; it is not a name source in this mode.
+  type WithIconOnly = { iconOnly: true } & IconOnlyAccessibleName & IconOnlyVisual;
   type SharedProps = SharedBase & (WithLabel | WithChildren | WithIconOnly);
 
   type ButtonOnlyProps = SharedProps & Omit<HTMLButtonAttributes, 'class'> & { href?: undefined };
@@ -119,6 +127,20 @@
   // doesn't silently erase their intent.
   const resolvedAriaDisabled = $derived(loading ? 'true' : consumerAriaDisabled);
   const resolvedAriaBusy = $derived(loading ? 'true' : consumerAriaBusy);
+
+  // Normalize ARIA label props: an empty string `aria-label=""` suppresses text-content fallback
+  // in the accessible-name computation (ARIA spec §4.3) without providing a name. Convert empty
+  // strings to `undefined` so the DOM attribute is omitted and the fallback (sr-only label text,
+  // or button text content) remains the accessible name. Guards and sr-only suppression use the
+  // normalized values for consistency.
+  const resolvedAriaLabel = $derived(
+    typeof ariaLabel === 'string' && ariaLabel.trim().length > 0 ? ariaLabel : undefined,
+  );
+  const resolvedAriaLabelledBy = $derived(
+    typeof ariaLabelledBy === 'string' && ariaLabelledBy.trim().length > 0
+      ? ariaLabelledBy
+      : undefined,
+  );
 
   // `rest` is typed as the union of both branches' attribute sets minus the keys we
   // destructured. TypeScript can't narrow a destructured remainder per branch, so each
@@ -191,13 +213,11 @@
     if (!DEV) return;
 
     // Guard 1 — Updated baseline: warn when the button has no accessible name at all.
-    // aria-label/aria-labelledby (via rest props) are now valid name sources alongside label and
-    // children, so iconOnly + aria-label + leadingIcon no longer falsely triggers this warning.
+    // Use the normalized resolved values so an empty aria-label="" doesn't falsely satisfy the check.
     const hasLabel = typeof label === 'string' && label.trim().length > 0;
     const hasChildren = Boolean(children);
-    const hasAriaLabel = typeof ariaLabel === 'string' && ariaLabel.trim().length > 0;
-    const hasAriaLabelledBy =
-      typeof ariaLabelledBy === 'string' && ariaLabelledBy.trim().length > 0;
+    const hasAriaLabel = resolvedAriaLabel !== undefined;
+    const hasAriaLabelledBy = resolvedAriaLabelledBy !== undefined;
     if (!hasLabel && !hasChildren && !hasAriaLabel && !hasAriaLabelledBy) {
       console.warn(
         '[cinder/Button] rendered without an accessible name — pass a non-empty `label`, `children`, `aria-label`, or `aria-labelledby`.',
@@ -226,7 +246,7 @@
     <span class="cinder-button__icon" aria-hidden="true">{@render leadingIcon()}</span>
   {/if}
   {#if iconOnly}
-    {#if !ariaLabel && !ariaLabelledBy && label}
+    {#if !resolvedAriaLabel && !resolvedAriaLabelledBy && label}
       <span class="cinder-sr-only">{label}</span>
     {/if}
     {#if children}
@@ -251,8 +271,8 @@
     {...dataAttributes}
     aria-disabled={resolvedAriaDisabled}
     aria-busy={resolvedAriaBusy}
-    aria-label={ariaLabel}
-    aria-labelledby={ariaLabelledBy}
+    aria-label={resolvedAriaLabel}
+    aria-labelledby={resolvedAriaLabelledBy}
     onclick={handleClick}
   >
     {@render buttonContent()}
@@ -266,8 +286,8 @@
     disabled={buttonDisabled || loading}
     aria-disabled={resolvedAriaDisabled}
     aria-busy={resolvedAriaBusy}
-    aria-label={ariaLabel}
-    aria-labelledby={ariaLabelledBy}
+    aria-label={resolvedAriaLabel}
+    aria-labelledby={resolvedAriaLabelledBy}
     onclick={handleClick}
   >
     {@render buttonContent()}

--- a/packages/components/src/components/button.svelte
+++ b/packages/components/src/components/button.svelte
@@ -35,9 +35,6 @@
     fullWidth?: boolean;
     /** Disable the button and show a spinner. */
     loading?: boolean;
-    /** Render as a square icon-only button. Requires an explicit accessible name
-     *  via `aria-label`, `aria-labelledby`, or `label`. Enforced in dev. */
-    iconOnly?: boolean;
     /** DECORATIVE icon rendered before the label/children. Always wrapped in aria-hidden.
      *  If the icon conveys meaning, supply accessible text via `label`/`aria-label` instead. */
     leadingIcon?: Snippet;
@@ -55,7 +52,10 @@
   // analyzer reads this two-variant shape to generate correct prop-control UI for each branch.
   // Runtime limitation: `string` includes `""`, so a literal empty label still satisfies
   // `WithLabel`. The dev-mode guard in the instance script catches that case.
-  type WithLabel = { label: string; children?: Snippet; iconOnly?: boolean };
+  //
+  // `iconOnly` lives only in the union branches (not SharedBase) so the discriminant is real:
+  // `WithChildren` genuinely forbids `iconOnly={true}`, and `WithIconOnly` requires it.
+  type WithLabel = { label: string; children?: Snippet; iconOnly?: false };
   type WithChildren = { label?: string; children: Snippet; iconOnly?: false };
   // Icon-only buttons may have a label (rendered sr-only) or rely on aria-label/aria-labelledby
   // passed via rest props. `children` is accepted as the visual icon (not a name source).
@@ -221,6 +221,27 @@
   });
 </script>
 
+{#snippet buttonContent()}
+  {#if leadingIcon}
+    <span class="cinder-button__icon" aria-hidden="true">{@render leadingIcon()}</span>
+  {/if}
+  {#if iconOnly}
+    {#if !ariaLabel && !ariaLabelledBy && label}
+      <span class="cinder-sr-only">{label}</span>
+    {/if}
+    {#if children}
+      <span class="cinder-button__icon" aria-hidden="true">{@render children()}</span>
+    {/if}
+  {:else if children}
+    {@render children()}
+  {:else}
+    {label}
+  {/if}
+  {#if trailingIcon}
+    <span class="cinder-button__icon" aria-hidden="true">{@render trailingIcon()}</span>
+  {/if}
+{/snippet}
+
 {#if href !== undefined}
   <a
     {...anchorAttributes}
@@ -234,26 +255,7 @@
     aria-labelledby={ariaLabelledBy}
     onclick={handleClick}
   >
-    {#if leadingIcon}
-      <span class="cinder-button__icon" aria-hidden="true">{@render leadingIcon()}</span>
-    {/if}
-    {#if iconOnly}
-      {#if !ariaLabel && !ariaLabelledBy && label}
-        <span class="cinder-sr-only">{label}</span>
-      {/if}
-      {#if children && !leadingIcon && !trailingIcon}
-        <span class="cinder-button__icon" aria-hidden="true">{@render children()}</span>
-      {:else if children}
-        {@render children()}
-      {/if}
-    {:else if children}
-      {@render children()}
-    {:else}
-      {label}
-    {/if}
-    {#if trailingIcon}
-      <span class="cinder-button__icon" aria-hidden="true">{@render trailingIcon()}</span>
-    {/if}
+    {@render buttonContent()}
   </a>
 {:else}
   <button
@@ -268,25 +270,6 @@
     aria-labelledby={ariaLabelledBy}
     onclick={handleClick}
   >
-    {#if leadingIcon}
-      <span class="cinder-button__icon" aria-hidden="true">{@render leadingIcon()}</span>
-    {/if}
-    {#if iconOnly}
-      {#if !ariaLabel && !ariaLabelledBy && label}
-        <span class="cinder-sr-only">{label}</span>
-      {/if}
-      {#if children && !leadingIcon && !trailingIcon}
-        <span class="cinder-button__icon" aria-hidden="true">{@render children()}</span>
-      {:else if children}
-        {@render children()}
-      {/if}
-    {:else if children}
-      {@render children()}
-    {:else}
-      {label}
-    {/if}
-    {#if trailingIcon}
-      <span class="cinder-button__icon" aria-hidden="true">{@render trailingIcon()}</span>
-    {/if}
+    {@render buttonContent()}
   </button>
 {/if}

--- a/packages/components/src/components/button.svelte
+++ b/packages/components/src/components/button.svelte
@@ -2,11 +2,29 @@
   import type { Snippet } from 'svelte';
   import type { HTMLAnchorAttributes, HTMLButtonAttributes } from 'svelte/elements';
 
-  /** Visual style of the button. */
-  export type ButtonVariant = 'primary' | 'secondary' | 'danger' | 'ghost' | 'ghost-danger';
+  /**
+   * Visual style of the button.
+   *
+   * `secondary` is an outline-style button (filled surface + border). It is kept as `secondary`
+   * rather than `outline` because: (a) today's `secondary` is already outline-flavored, (b) `ghost`
+   * covers the transparent-background case, and (c) 27+ call sites depend on `secondary` today.
+   *
+   * `soft` / `soft-danger` use a tinted fill with no border — mid-emphasis between `ghost` and
+   * `primary`/`danger`. Background is `color-mix(in oklch, accent, transparent 88%)` so it
+   * resolves against the current theme's accent/danger color in both light and dark modes.
+   */
+  export type ButtonVariant =
+    | 'primary'
+    | 'secondary'
+    | 'soft'
+    | 'danger'
+    | 'soft-danger'
+    | 'ghost'
+    | 'ghost-danger';
 
-  /** Size of the button. */
-  export type ButtonSize = 'xs' | 'sm' | 'md' | 'lg';
+  /** Size of the button. `xs` and `sm` are below WCAG AAA touch-target (44px) and are intended
+   * for dense UI contexts only. `md` meets WCAG AAA (44px). See button.a11y.md for rationale. */
+  export type ButtonSize = 'xs' | 'sm' | 'md' | 'lg' | 'xl';
 
   type SharedBase = {
     /** Visual style. */
@@ -17,6 +35,15 @@
     fullWidth?: boolean;
     /** Disable the button and show a spinner. */
     loading?: boolean;
+    /** Render as a square icon-only button. Requires an explicit accessible name
+     *  via `aria-label`, `aria-labelledby`, or `label`. Enforced in dev. */
+    iconOnly?: boolean;
+    /** DECORATIVE icon rendered before the label/children. Always wrapped in aria-hidden.
+     *  If the icon conveys meaning, supply accessible text via `label`/`aria-label` instead. */
+    leadingIcon?: Snippet;
+    /** DECORATIVE icon rendered after the label/children. Always wrapped in aria-hidden.
+     *  Same accessible-name guidance as `leadingIcon`. */
+    trailingIcon?: Snippet;
     /** Custom class merged with `.cinder-button`. */
     class?: string;
   };
@@ -28,9 +55,12 @@
   // analyzer reads this two-variant shape to generate correct prop-control UI for each branch.
   // Runtime limitation: `string` includes `""`, so a literal empty label still satisfies
   // `WithLabel`. The dev-mode guard in the instance script catches that case.
-  type WithLabel = { label: string; children?: Snippet };
-  type WithChildren = { label?: string; children: Snippet };
-  type SharedProps = SharedBase & (WithLabel | WithChildren);
+  type WithLabel = { label: string; children?: Snippet; iconOnly?: boolean };
+  type WithChildren = { label?: string; children: Snippet; iconOnly?: false };
+  // Icon-only buttons may have a label (rendered sr-only) or rely on aria-label/aria-labelledby
+  // passed via rest props. `children` is accepted as the visual icon (not a name source).
+  type WithIconOnly = { iconOnly: true; label?: string; children?: Snippet };
+  type SharedProps = SharedBase & (WithLabel | WithChildren | WithIconOnly);
 
   type ButtonOnlyProps = SharedProps & Omit<HTMLButtonAttributes, 'class'> & { href?: undefined };
   type LinkButtonProps = SharedProps & Omit<HTMLAnchorAttributes, 'class'> & { href: string };
@@ -58,6 +88,9 @@
     size = 'md',
     fullWidth = false,
     loading = false,
+    iconOnly = false,
+    leadingIcon,
+    trailingIcon,
     children,
     label,
     class: customClassName,
@@ -65,6 +98,8 @@
     onclick: consumerOnClick,
     'aria-disabled': consumerAriaDisabled,
     'aria-busy': consumerAriaBusy,
+    'aria-label': ariaLabel,
+    'aria-labelledby': ariaLabelledBy,
     ...rest
   }: ButtonProps = $props();
 
@@ -76,6 +111,7 @@
     'data-cinder-size': size,
     'data-cinder-full-width': fullWidth ? '' : undefined,
     'data-cinder-loading': loading ? '' : undefined,
+    'data-cinder-icon-only': iconOnly ? '' : undefined,
   });
 
   // When loading, force aria-disabled/aria-busy to 'true' so assistive tech always hears the
@@ -92,11 +128,25 @@
   // the underlying `rest` object is itself reactive, so consumers see prop changes flow through.
   const anchorAttributes = rest as Omit<
     HTMLAnchorAttributes,
-    'class' | 'href' | 'tabindex' | 'onclick' | 'aria-disabled' | 'aria-busy'
+    | 'class'
+    | 'href'
+    | 'tabindex'
+    | 'onclick'
+    | 'aria-disabled'
+    | 'aria-busy'
+    | 'aria-label'
+    | 'aria-labelledby'
   >;
   const buttonAttributes = rest as Omit<
     HTMLButtonAttributes,
-    'class' | 'type' | 'disabled' | 'onclick' | 'aria-disabled' | 'aria-busy'
+    | 'class'
+    | 'type'
+    | 'disabled'
+    | 'onclick'
+    | 'aria-disabled'
+    | 'aria-busy'
+    | 'aria-label'
+    | 'aria-labelledby'
   >;
 
   // Branch-specific prop reads still need `$derived` because `loading` prop flips must
@@ -134,21 +184,38 @@
     }
   }
 
-  // Dev-mode guard: TypeScript's `label: string` lets `""` through. Warn when the button
-  // would render without an accessible name so the bug surfaces in local dev. `DEV` from
-  // `esm-env` is a bundler-replaced constant: `true` in dev builds, `false` in prod — so
-  // the whole `$effect` body is tree-shaken in production. Safe in Vite, SvelteKit, Bun, Node.
-  //
-  // The check runs reactively via `$effect` (not once at mount) so prop changes after mount
-  // also surface the issue — e.g., a consumer binding `label` to a reactive source that flips
-  // to `""` mid-session will warn at the point the problem shows up.
+  // Dev-mode guards. DEV from esm-env is a bundler-replaced constant: true in dev, false in
+  // prod — the whole $effect body is tree-shaken in production. Guards run reactively so prop
+  // changes after mount also surface issues.
   $effect(() => {
     if (!DEV) return;
+
+    // Guard 1 — Updated baseline: warn when the button has no accessible name at all.
+    // aria-label/aria-labelledby (via rest props) are now valid name sources alongside label and
+    // children, so iconOnly + aria-label + leadingIcon no longer falsely triggers this warning.
     const hasLabel = typeof label === 'string' && label.trim().length > 0;
     const hasChildren = Boolean(children);
-    if (!hasLabel && !hasChildren) {
+    const hasAriaLabel = typeof ariaLabel === 'string' && ariaLabel.trim().length > 0;
+    const hasAriaLabelledBy =
+      typeof ariaLabelledBy === 'string' && ariaLabelledBy.trim().length > 0;
+    if (!hasLabel && !hasChildren && !hasAriaLabel && !hasAriaLabelledBy) {
       console.warn(
-        '[cinder/Button] rendered without an accessible name — pass a non-empty `label` or `children`.',
+        '[cinder/Button] rendered without an accessible name — pass a non-empty `label`, `children`, `aria-label`, or `aria-labelledby`.',
+      );
+    }
+
+    // Guard 2 — icon-only accessible name: children alone does not count because it may be a
+    // non-text SVG. Requires aria-label, aria-labelledby, or a non-empty label string.
+    if (iconOnly && !hasAriaLabel && !hasAriaLabelledBy && !hasLabel) {
+      console.warn(
+        '[cinder/Button] iconOnly=true requires aria-label, aria-labelledby, or a non-empty label.',
+      );
+    }
+
+    // Guard 3 — icon-only visual: a blank square is a real UI failure, not just an a11y issue.
+    if (iconOnly && !leadingIcon && !trailingIcon && !children) {
+      console.warn(
+        '[cinder/Button] iconOnly=true requires a visible icon — pass leadingIcon, trailingIcon, or children.',
       );
     }
   });
@@ -163,9 +230,30 @@
     {...dataAttributes}
     aria-disabled={resolvedAriaDisabled}
     aria-busy={resolvedAriaBusy}
+    aria-label={ariaLabel}
+    aria-labelledby={ariaLabelledBy}
     onclick={handleClick}
   >
-    {#if children}{@render children()}{:else}{label}{/if}
+    {#if leadingIcon}
+      <span class="cinder-button__icon" aria-hidden="true">{@render leadingIcon()}</span>
+    {/if}
+    {#if iconOnly}
+      {#if !ariaLabel && !ariaLabelledBy && label}
+        <span class="cinder-sr-only">{label}</span>
+      {/if}
+      {#if children && !leadingIcon && !trailingIcon}
+        <span class="cinder-button__icon" aria-hidden="true">{@render children()}</span>
+      {:else if children}
+        {@render children()}
+      {/if}
+    {:else if children}
+      {@render children()}
+    {:else}
+      {label}
+    {/if}
+    {#if trailingIcon}
+      <span class="cinder-button__icon" aria-hidden="true">{@render trailingIcon()}</span>
+    {/if}
   </a>
 {:else}
   <button
@@ -176,8 +264,29 @@
     disabled={buttonDisabled || loading}
     aria-disabled={resolvedAriaDisabled}
     aria-busy={resolvedAriaBusy}
+    aria-label={ariaLabel}
+    aria-labelledby={ariaLabelledBy}
     onclick={handleClick}
   >
-    {#if children}{@render children()}{:else}{label}{/if}
+    {#if leadingIcon}
+      <span class="cinder-button__icon" aria-hidden="true">{@render leadingIcon()}</span>
+    {/if}
+    {#if iconOnly}
+      {#if !ariaLabel && !ariaLabelledBy && label}
+        <span class="cinder-sr-only">{label}</span>
+      {/if}
+      {#if children && !leadingIcon && !trailingIcon}
+        <span class="cinder-button__icon" aria-hidden="true">{@render children()}</span>
+      {:else if children}
+        {@render children()}
+      {/if}
+    {:else if children}
+      {@render children()}
+    {:else}
+      {label}
+    {/if}
+    {#if trailingIcon}
+      <span class="cinder-button__icon" aria-hidden="true">{@render trailingIcon()}</span>
+    {/if}
   </button>
 {/if}

--- a/packages/components/src/components/button.test.ts
+++ b/packages/components/src/components/button.test.ts
@@ -1,5 +1,5 @@
 /// <reference lib="dom" />
-import { describe, expect, test } from 'bun:test';
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
 
 import { setupHappyDom } from '../test/happy-dom.ts';
 
@@ -114,5 +114,163 @@ describe('Button rendering', () => {
     const classAttr = container.querySelector('button')?.getAttribute('class') ?? '';
     expect(classAttr).toContain('cinder-button');
     expect(classAttr).toContain('my-extra-class');
+  });
+});
+
+describe('Button variants — new additions', () => {
+  test('soft variant applies data-cinder-variant="soft"', () => {
+    const { container } = render(Button, { props: { label: 'Soft', variant: 'soft' } });
+    expect(container.querySelector('button')?.getAttribute('data-cinder-variant')).toBe('soft');
+  });
+
+  test('soft-danger variant applies data-cinder-variant="soft-danger"', () => {
+    const { container } = render(Button, {
+      props: { label: 'Delete', variant: 'soft-danger' },
+    });
+    expect(container.querySelector('button')?.getAttribute('data-cinder-variant')).toBe(
+      'soft-danger',
+    );
+  });
+});
+
+describe('Button sizes — xl', () => {
+  test('xl size applies data-cinder-size="xl"', () => {
+    const { container } = render(Button, { props: { label: 'Big', size: 'xl' } });
+    expect(container.querySelector('button')?.getAttribute('data-cinder-size')).toBe('xl');
+  });
+});
+
+describe('Button icon slots', () => {
+  test('leadingIcon renders inside .cinder-button__icon with aria-hidden="true" before label', () => {
+    // Snippet-based icon slots are verified via the iconOnly and dev-warning tests below.
+    // Here we confirm the baseline: a label-only button renders its label text.
+    const { container } = render(Button, { props: { label: 'Save' } });
+    expect(container.querySelector('button')?.textContent?.trim()).toBe('Save');
+  });
+
+  test('trailingIcon renders inside .cinder-button__icon with aria-hidden="true" after label', () => {
+    const { container } = render(Button, { props: { label: 'Next' } });
+    expect(container.querySelector('button')?.textContent?.trim()).toBe('Next');
+  });
+});
+
+describe('Button iconOnly', () => {
+  test('iconOnly=true applies data-cinder-icon-only=""', () => {
+    const { container } = render(Button, {
+      props: { iconOnly: true, 'aria-label': 'Close', label: 'Close' },
+    });
+    expect(container.querySelector('button')?.getAttribute('data-cinder-icon-only')).toBe('');
+  });
+
+  test('iconOnly=false does not apply data-cinder-icon-only', () => {
+    const { container } = render(Button, { props: { label: 'Save', iconOnly: false } });
+    expect(container.querySelector('button')?.hasAttribute('data-cinder-icon-only')).toBe(false);
+  });
+});
+
+describe('Button loading state', () => {
+  test('loading + label: label text remains in DOM', () => {
+    const { getByText } = render(Button, { props: { label: 'Saving', loading: true } });
+    // Label must remain in the DOM as the accessible name throughout loading.
+    expect(getByText('Saving')).not.toBeNull();
+  });
+
+  test('loading + label: no DOM spinner node (spinner is a CSS pseudo-element)', () => {
+    const { container } = render(Button, { props: { label: 'Saving', loading: true } });
+    expect(container.querySelector('[role="status"]')).toBeNull();
+    expect(container.querySelector('.cinder-spinner')).toBeNull();
+  });
+});
+
+describe('Button iconOnly sr-only label', () => {
+  test('iconOnly=true with label renders label text in a sr-only span (no aria-label override)', () => {
+    const { container, getByText } = render(Button, {
+      props: { iconOnly: true, label: 'Close' },
+    });
+    // Label text must be queryable — it's in a visually-hidden span.
+    const labelNode = getByText('Close');
+    expect(labelNode).not.toBeNull();
+    expect(labelNode.className).toContain('cinder-sr-only');
+    // The button should NOT have a synthesized aria-label attribute from label.
+    expect(container.querySelector('button')?.getAttribute('aria-label')).toBeNull();
+  });
+
+  test('iconOnly=true with aria-label does NOT render a sr-only span for label', () => {
+    const { container } = render(Button, {
+      props: { iconOnly: true, 'aria-label': 'Close dialog', label: 'Close' },
+    });
+    // When aria-label is set it is the accessible name; sr-only label span should not appear.
+    const button = container.querySelector('button');
+    expect(button?.getAttribute('aria-label')).toBe('Close dialog');
+    // label text should NOT be rendered as sr-only span when aria-label supplies the name
+    const srOnlySpan = container.querySelector('.cinder-sr-only');
+    expect(srOnlySpan).toBeNull();
+  });
+});
+
+describe('Button dev warnings', () => {
+  let warnMessages: string[] = [];
+  let originalWarn: typeof console.warn;
+
+  beforeEach(() => {
+    warnMessages = [];
+    originalWarn = console.warn;
+    console.warn = (...args: unknown[]) => {
+      warnMessages.push(args.join(' '));
+    };
+  });
+
+  afterEach(() => {
+    console.warn = originalWarn;
+  });
+
+  test('iconOnly=true with aria-label: no iconOnly name warning', () => {
+    render(Button, { props: { iconOnly: true, 'aria-label': 'Close' } });
+    const iconOnlyWarnings = warnMessages.filter((m) =>
+      m.includes('iconOnly=true requires aria-label'),
+    );
+    expect(iconOnlyWarnings).toHaveLength(0);
+  });
+
+  test('iconOnly=true with label: no iconOnly name warning', () => {
+    render(Button, { props: { iconOnly: true, label: 'Close' } });
+    const iconOnlyWarnings = warnMessages.filter((m) =>
+      m.includes('iconOnly=true requires aria-label'),
+    );
+    expect(iconOnlyWarnings).toHaveLength(0);
+  });
+
+  test('iconOnly=true with only children: iconOnly name warning IS emitted', () => {
+    // children alone does not satisfy the iconOnly name guard
+    render(Button, {
+      props: { iconOnly: true, children: undefined as any },
+    });
+    const iconOnlyWarnings = warnMessages.filter((m) =>
+      m.includes('iconOnly=true requires aria-label'),
+    );
+    // No label, no aria-label, no aria-labelledby → warning must fire
+    expect(iconOnlyWarnings.length).toBeGreaterThan(0);
+  });
+
+  test('iconOnly=true with neither label nor aria-label: iconOnly name warning IS emitted', () => {
+    render(Button, { props: { iconOnly: true } as any });
+    const iconOnlyWarnings = warnMessages.filter((m) =>
+      m.includes('iconOnly=true requires aria-label'),
+    );
+    expect(iconOnlyWarnings.length).toBeGreaterThan(0);
+  });
+
+  test('iconOnly=true + aria-label + no visual icon: visible-icon warning IS emitted', () => {
+    render(Button, { props: { iconOnly: true, 'aria-label': 'Close' } });
+    const visualWarnings = warnMessages.filter((m) => m.includes('requires a visible icon'));
+    expect(visualWarnings.length).toBeGreaterThan(0);
+  });
+
+  test('baseline guard: aria-label alone satisfies name requirement, no baseline warning', () => {
+    render(Button, { props: { 'aria-label': 'Close', iconOnly: true, label: 'Close' } });
+    const baselineWarnings = warnMessages.filter((m) =>
+      m.includes('rendered without an accessible name'),
+    );
+    expect(baselineWarnings).toHaveLength(0);
   });
 });

--- a/packages/components/src/components/button.test.ts
+++ b/packages/components/src/components/button.test.ts
@@ -140,19 +140,10 @@ describe('Button sizes — xl', () => {
   });
 });
 
-describe('Button icon slots', () => {
-  test('leadingIcon renders inside .cinder-button__icon with aria-hidden="true" before label', () => {
-    // Snippet-based icon slots are verified via the iconOnly and dev-warning tests below.
-    // Here we confirm the baseline: a label-only button renders its label text.
-    const { container } = render(Button, { props: { label: 'Save' } });
-    expect(container.querySelector('button')?.textContent?.trim()).toBe('Save');
-  });
-
-  test('trailingIcon renders inside .cinder-button__icon with aria-hidden="true" after label', () => {
-    const { container } = render(Button, { props: { label: 'Next' } });
-    expect(container.querySelector('button')?.textContent?.trim()).toBe('Next');
-  });
-});
+// NOTE: leadingIcon/trailingIcon snippet rendering (DOM order, aria-hidden wrapper) cannot be
+// tested with @testing-library/svelte in happy-dom because the test harness cannot pass Svelte
+// snippet props. Those paths are covered by manual playground inspection and tracked for a
+// future Playwright test once the playground has browser test coverage.
 
 describe('Button iconOnly', () => {
   test('iconOnly=true applies data-cinder-icon-only=""', () => {
@@ -208,6 +199,35 @@ describe('Button iconOnly sr-only label', () => {
   });
 });
 
+describe('Button accessible name precedence', () => {
+  test('aria-label takes precedence over label as the accessible name', () => {
+    const { container } = render(Button, {
+      props: { label: 'Close', 'aria-label': 'Close dialog' },
+    });
+    const button = container.querySelector('button');
+    expect(button?.getAttribute('aria-label')).toBe('Close dialog');
+  });
+
+  test('aria-labelledby is passed through to the element', () => {
+    const { container } = render(Button, {
+      props: { label: 'Close', 'aria-labelledby': 'dialog-title' },
+    });
+    const button = container.querySelector('button');
+    expect(button?.getAttribute('aria-labelledby')).toBe('dialog-title');
+  });
+});
+
+describe('Button ghost-danger disabled state', () => {
+  test('ghost-danger disabled button preserves data attributes', () => {
+    const { container } = render(Button, {
+      props: { label: 'Delete', variant: 'ghost-danger', 'aria-disabled': 'true' },
+    });
+    const button = container.querySelector('button');
+    expect(button?.getAttribute('data-cinder-variant')).toBe('ghost-danger');
+    expect(button?.getAttribute('aria-disabled')).toBe('true');
+  });
+});
+
 describe('Button dev warnings', () => {
   let warnMessages: string[] = [];
   let originalWarn: typeof console.warn;
@@ -238,18 +258,6 @@ describe('Button dev warnings', () => {
       m.includes('iconOnly=true requires aria-label'),
     );
     expect(iconOnlyWarnings).toHaveLength(0);
-  });
-
-  test('iconOnly=true with only children: iconOnly name warning IS emitted', () => {
-    // children alone does not satisfy the iconOnly name guard
-    render(Button, {
-      props: { iconOnly: true, children: undefined as any },
-    });
-    const iconOnlyWarnings = warnMessages.filter((m) =>
-      m.includes('iconOnly=true requires aria-label'),
-    );
-    // No label, no aria-label, no aria-labelledby → warning must fire
-    expect(iconOnlyWarnings.length).toBeGreaterThan(0);
   });
 
   test('iconOnly=true with neither label nor aria-label: iconOnly name warning IS emitted', () => {

--- a/packages/components/src/components/button.test.ts
+++ b/packages/components/src/components/button.test.ts
@@ -1,5 +1,6 @@
 /// <reference lib="dom" />
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
 
 import { setupHappyDom } from '../test/happy-dom.ts';
 
@@ -12,6 +13,20 @@ setupHappyDom();
 
 const { render } = await import('@testing-library/svelte');
 const { default: Button } = await import('./button.svelte');
+
+function readTokenSource(): string {
+  return readFileSync(new URL('../styles/tokens-base.css', import.meta.url), 'utf8');
+}
+
+function readButtonHeightToken(size: 'md' | 'lg' | 'xl'): number {
+  const source = readTokenSource();
+  const match = new RegExp(`--cinder-button-height-${size}: (?<value>\\d+(?:\\.\\d+)?)rem;`).exec(
+    source,
+  );
+  const value = match?.groups?.['value'];
+  if (value === undefined) throw new Error(`Missing button height token for ${size}`);
+  return Number.parseFloat(value);
+}
 
 describe('Button rendering', () => {
   test('renders a <button> when no href is provided', () => {
@@ -137,6 +152,15 @@ describe('Button sizes — xl', () => {
   test('xl size applies data-cinder-size="xl"', () => {
     const { container } = render(Button, { props: { label: 'Big', size: 'xl' } });
     expect(container.querySelector('button')?.getAttribute('data-cinder-size')).toBe('xl');
+  });
+
+  test('large sizes remain monotonic after md touch-target increase', () => {
+    expect(readButtonHeightToken('lg')).toBeGreaterThanOrEqual(readButtonHeightToken('md'));
+    expect(readButtonHeightToken('xl')).toBeGreaterThan(readButtonHeightToken('lg'));
+  });
+
+  test('xl font size references an existing typography token', () => {
+    expect(readTokenSource()).toContain('--cinder-button-font-size-xl: var(--cinder-text-base);');
   });
 });
 

--- a/packages/components/src/components/button.test.ts
+++ b/packages/components/src/components/button.test.ts
@@ -148,7 +148,7 @@ describe('Button sizes — xl', () => {
 describe('Button iconOnly', () => {
   test('iconOnly=true applies data-cinder-icon-only=""', () => {
     const { container } = render(Button, {
-      props: { iconOnly: true, 'aria-label': 'Close', label: 'Close' },
+      props: { iconOnly: true, 'aria-label': 'Close', label: 'Close' } as any,
     });
     expect(container.querySelector('button')?.getAttribute('data-cinder-icon-only')).toBe('');
   });
@@ -176,7 +176,7 @@ describe('Button loading state', () => {
 describe('Button iconOnly sr-only label', () => {
   test('iconOnly=true with label renders label text in a sr-only span (no aria-label override)', () => {
     const { container, getByText } = render(Button, {
-      props: { iconOnly: true, label: 'Close' },
+      props: { iconOnly: true, label: 'Close' } as any,
     });
     // Label text must be queryable — it's in a visually-hidden span.
     const labelNode = getByText('Close');
@@ -188,7 +188,7 @@ describe('Button iconOnly sr-only label', () => {
 
   test('iconOnly=true with aria-label does NOT render a sr-only span for label', () => {
     const { container } = render(Button, {
-      props: { iconOnly: true, 'aria-label': 'Close dialog', label: 'Close' },
+      props: { iconOnly: true, 'aria-label': 'Close dialog', label: 'Close' } as any,
     });
     // When aria-label is set it is the accessible name; sr-only label span should not appear.
     const button = container.querySelector('button');
@@ -196,6 +196,28 @@ describe('Button iconOnly sr-only label', () => {
     // label text should NOT be rendered as sr-only span when aria-label supplies the name
     const srOnlySpan = container.querySelector('.cinder-sr-only');
     expect(srOnlySpan).toBeNull();
+  });
+
+  test('iconOnly=true with whitespace aria-label falls back to sr-only label', () => {
+    const { container } = render(Button, {
+      props: { iconOnly: true, 'aria-label': '   ', label: 'Close' } as any,
+    });
+
+    const srOnlySpan = container.querySelector('.cinder-sr-only');
+    expect(srOnlySpan).not.toBeNull();
+    expect(srOnlySpan?.textContent).toBe('Close');
+    expect(container.querySelector('button')?.getAttribute('aria-label')).toBeNull();
+  });
+
+  test('iconOnly=true with whitespace aria-labelledby falls back to sr-only label', () => {
+    const { container } = render(Button, {
+      props: { iconOnly: true, 'aria-labelledby': '   ', label: 'Close' } as any,
+    });
+
+    const srOnlySpan = container.querySelector('.cinder-sr-only');
+    expect(srOnlySpan).not.toBeNull();
+    expect(srOnlySpan?.textContent).toBe('Close');
+    expect(container.querySelector('button')?.getAttribute('aria-labelledby')).toBeNull();
   });
 });
 
@@ -245,7 +267,7 @@ describe('Button dev warnings', () => {
   });
 
   test('iconOnly=true with aria-label: no iconOnly name warning', () => {
-    render(Button, { props: { iconOnly: true, 'aria-label': 'Close' } });
+    render(Button, { props: { iconOnly: true, 'aria-label': 'Close' } as any });
     const iconOnlyWarnings = warnMessages.filter((m) =>
       m.includes('iconOnly=true requires aria-label'),
     );
@@ -253,7 +275,7 @@ describe('Button dev warnings', () => {
   });
 
   test('iconOnly=true with label: no iconOnly name warning', () => {
-    render(Button, { props: { iconOnly: true, label: 'Close' } });
+    render(Button, { props: { iconOnly: true, label: 'Close' } as any });
     const iconOnlyWarnings = warnMessages.filter((m) =>
       m.includes('iconOnly=true requires aria-label'),
     );
@@ -269,13 +291,13 @@ describe('Button dev warnings', () => {
   });
 
   test('iconOnly=true + aria-label + no visual icon: visible-icon warning IS emitted', () => {
-    render(Button, { props: { iconOnly: true, 'aria-label': 'Close' } });
+    render(Button, { props: { iconOnly: true, 'aria-label': 'Close' } as any });
     const visualWarnings = warnMessages.filter((m) => m.includes('requires a visible icon'));
     expect(visualWarnings.length).toBeGreaterThan(0);
   });
 
   test('baseline guard: aria-label alone satisfies name requirement, no baseline warning', () => {
-    render(Button, { props: { 'aria-label': 'Close', iconOnly: true, label: 'Close' } });
+    render(Button, { props: { 'aria-label': 'Close' } as any });
     const baselineWarnings = warnMessages.filter((m) =>
       m.includes('rendered without an accessible name'),
     );

--- a/packages/components/src/components/button.test.ts
+++ b/packages/components/src/components/button.test.ts
@@ -155,7 +155,7 @@ describe('Button sizes — xl', () => {
   });
 
   test('large sizes remain monotonic after md touch-target increase', () => {
-    expect(readButtonHeightToken('lg')).toBeGreaterThanOrEqual(readButtonHeightToken('md'));
+    expect(readButtonHeightToken('lg')).toBeGreaterThan(readButtonHeightToken('md'));
     expect(readButtonHeightToken('xl')).toBeGreaterThan(readButtonHeightToken('lg'));
   });
 

--- a/packages/components/src/styles/components/button.css
+++ b/packages/components/src/styles/components/button.css
@@ -141,6 +141,56 @@
   border-radius: var(--cinder-button-radius-lg);
 }
 
+.cinder-button[data-cinder-size='xl'] {
+  font-size: var(--cinder-button-font-size-xl);
+  padding: var(--cinder-button-padding-y-xl) var(--cinder-button-padding-x-xl);
+  min-height: var(--cinder-button-height-xl);
+  border-radius: var(--cinder-button-radius-xl);
+}
+
+/* ----------------------------------------
+ * Icon-only modifier
+ * xs and sm are below WCAG AAA (44px) and are intended for dense UI contexts only.
+ * Use md or larger for primary touch surfaces. See button.a11y.md for full rationale.
+ * ---------------------------------------- */
+
+.cinder-button[data-cinder-icon-only] {
+  padding-inline: 0;
+  aspect-ratio: 1;
+}
+
+.cinder-button[data-cinder-icon-only][data-cinder-size='xs'] {
+  min-width: var(--cinder-button-height-xs);
+}
+
+.cinder-button[data-cinder-icon-only][data-cinder-size='sm'] {
+  min-width: var(--cinder-button-height-sm);
+}
+
+.cinder-button[data-cinder-icon-only][data-cinder-size='md'] {
+  min-width: var(--cinder-button-height-md);
+}
+
+.cinder-button[data-cinder-icon-only][data-cinder-size='lg'] {
+  min-width: var(--cinder-button-height-lg);
+}
+
+.cinder-button[data-cinder-icon-only][data-cinder-size='xl'] {
+  min-width: var(--cinder-button-height-xl);
+}
+
+/* ----------------------------------------
+ * Icon slot wrapper — used for leadingIcon and trailingIcon snippets.
+ * These slots are decorative-only; meaning lives in the button's accessible name.
+ * ---------------------------------------- */
+
+.cinder-button__icon {
+  display: inline-flex;
+  align-items: center;
+  flex-shrink: 0;
+  line-height: 0;
+}
+
 /* ----------------------------------------
  * Color variants
  * ---------------------------------------- */
@@ -249,4 +299,69 @@
   color: var(--cinder-text-disabled);
   border-color: transparent;
   opacity: 0.6;
+}
+
+/* soft — tinted accent background, accent foreground, no border.
+ * Background uses color-mix so it resolves against the theme-aware --cinder-accent token
+ * in both light and dark themes. Contrast ratios must be verified mechanically (WebAIM
+ * contrast checker) before shipping; see button.a11y.md for the verification procedure. */
+.cinder-button[data-cinder-variant='soft'] {
+  --_cinder-button-ring: var(--cinder-accent);
+  background: color-mix(in oklch, var(--cinder-accent), transparent 88%);
+  color: var(--cinder-accent);
+  border-color: transparent;
+}
+
+.cinder-button[data-cinder-variant='soft']:hover:not(:disabled):not([aria-disabled='true']) {
+  background: color-mix(in oklch, var(--cinder-accent), transparent 80%);
+}
+
+.cinder-button[data-cinder-variant='soft']:active:not(:disabled):not([aria-disabled='true']) {
+  background: color-mix(in oklch, var(--cinder-accent), transparent 74%);
+}
+
+.cinder-button[data-cinder-variant='soft']:disabled:not([data-cinder-loading]),
+.cinder-button[data-cinder-variant='soft'][aria-disabled='true']:not([data-cinder-loading]) {
+  background: var(--cinder-surface-inset);
+  color: var(--cinder-text-disabled);
+  border-color: transparent;
+  opacity: 0.6;
+}
+
+@media (forced-colors: active) {
+  .cinder-button[data-cinder-variant='soft'] {
+    border: 1px solid ButtonBorder;
+  }
+}
+
+/* soft-danger — tinted danger background, danger foreground, no border. */
+.cinder-button[data-cinder-variant='soft-danger'] {
+  --_cinder-button-ring: var(--cinder-danger);
+  background: color-mix(in oklch, var(--cinder-danger), transparent 88%);
+  color: var(--cinder-danger);
+  border-color: transparent;
+}
+
+.cinder-button[data-cinder-variant='soft-danger']:hover:not(:disabled):not([aria-disabled='true']) {
+  background: color-mix(in oklch, var(--cinder-danger), transparent 80%);
+}
+
+.cinder-button[data-cinder-variant='soft-danger']:active:not(:disabled):not(
+    [aria-disabled='true']
+  ) {
+  background: color-mix(in oklch, var(--cinder-danger), transparent 74%);
+}
+
+.cinder-button[data-cinder-variant='soft-danger']:disabled:not([data-cinder-loading]),
+.cinder-button[data-cinder-variant='soft-danger'][aria-disabled='true']:not([data-cinder-loading]) {
+  background: var(--cinder-surface-inset);
+  color: var(--cinder-text-disabled);
+  border-color: transparent;
+  opacity: 0.6;
+}
+
+@media (forced-colors: active) {
+  .cinder-button[data-cinder-variant='soft-danger'] {
+    border: 1px solid ButtonBorder;
+  }
 }

--- a/packages/components/src/styles/components/button.css
+++ b/packages/components/src/styles/components/button.css
@@ -301,6 +301,16 @@
   opacity: 0.6;
 }
 
+.cinder-button[data-cinder-variant='ghost-danger']:disabled:not([data-cinder-loading]),
+.cinder-button[data-cinder-variant='ghost-danger'][aria-disabled='true']:not(
+    [data-cinder-loading]
+  ) {
+  background: transparent;
+  color: var(--cinder-danger);
+  border-color: transparent;
+  opacity: 0.6;
+}
+
 /* soft — tinted accent background, accent foreground, no border.
  * Background uses color-mix so it resolves against the theme-aware --cinder-accent token
  * in both light and dark themes. Contrast ratios must be verified mechanically (WebAIM

--- a/packages/components/src/styles/components/button.css
+++ b/packages/components/src/styles/components/button.css
@@ -301,6 +301,12 @@
   opacity: 0.6;
 }
 
+.cinder-button[data-cinder-variant='ghost-danger'][data-cinder-loading] {
+  background: transparent;
+  color: var(--cinder-danger);
+  border-color: transparent;
+}
+
 .cinder-button[data-cinder-variant='ghost-danger']:disabled:not([data-cinder-loading]),
 .cinder-button[data-cinder-variant='ghost-danger'][aria-disabled='true']:not(
     [data-cinder-loading]

--- a/packages/components/src/styles/tokens-base.css
+++ b/packages/components/src/styles/tokens-base.css
@@ -221,14 +221,14 @@
   /* Size: lg */
   --cinder-button-padding-x-lg: var(--cinder-space-4);
   --cinder-button-padding-y-lg: var(--cinder-space-2);
-  --cinder-button-height-lg: 2.75rem;
+  --cinder-button-height-lg: 3rem;
   --cinder-button-font-size-lg: var(--cinder-text-sm);
   --cinder-button-radius-lg: var(--cinder-radius-md);
 
   /* Size: xl */
   --cinder-button-padding-x-xl: var(--cinder-space-5);
   --cinder-button-padding-y-xl: var(--cinder-space-2-5);
-  --cinder-button-height-xl: 3rem;
+  --cinder-button-height-xl: 3.25rem;
   --cinder-button-font-size-xl: var(--cinder-text-base);
   --cinder-button-radius-xl: var(--cinder-radius-md);
 }

--- a/packages/components/src/styles/tokens-base.css
+++ b/packages/components/src/styles/tokens-base.css
@@ -210,10 +210,11 @@
   --cinder-button-font-size-sm: var(--cinder-text-xs);
   --cinder-button-radius-sm: var(--cinder-radius-sm);
 
-  /* Size: md */
+  /* Size: md — 44px min-height meets WCAG AAA touch-target (2.75rem = 44px at 16px base).
+   * xs (24px) and sm (32px) are intentionally below AAA; see button.a11y.md for rationale. */
   --cinder-button-padding-x-md: var(--cinder-space-3);
-  --cinder-button-padding-y-md: var(--cinder-space-1-5);
-  --cinder-button-height-md: 2.25rem;
+  --cinder-button-padding-y-md: var(--cinder-space-2-5);
+  --cinder-button-height-md: 2.75rem;
   --cinder-button-font-size-md: var(--cinder-text-sm);
   --cinder-button-radius-md: var(--cinder-radius-md);
 
@@ -223,6 +224,13 @@
   --cinder-button-height-lg: 2.5rem;
   --cinder-button-font-size-lg: var(--cinder-text-sm);
   --cinder-button-radius-lg: var(--cinder-radius-md);
+
+  /* Size: xl */
+  --cinder-button-padding-x-xl: var(--cinder-space-5);
+  --cinder-button-padding-y-xl: var(--cinder-space-2-5);
+  --cinder-button-height-xl: 3rem;
+  --cinder-button-font-size-xl: var(--cinder-text-md);
+  --cinder-button-radius-xl: var(--cinder-radius-md);
 }
 
 :root[data-theme='dark'] {

--- a/packages/components/src/styles/tokens-base.css
+++ b/packages/components/src/styles/tokens-base.css
@@ -221,7 +221,7 @@
   /* Size: lg */
   --cinder-button-padding-x-lg: var(--cinder-space-4);
   --cinder-button-padding-y-lg: var(--cinder-space-2);
-  --cinder-button-height-lg: 2.5rem;
+  --cinder-button-height-lg: 2.75rem;
   --cinder-button-font-size-lg: var(--cinder-text-sm);
   --cinder-button-radius-lg: var(--cinder-radius-md);
 
@@ -229,7 +229,7 @@
   --cinder-button-padding-x-xl: var(--cinder-space-5);
   --cinder-button-padding-y-xl: var(--cinder-space-2-5);
   --cinder-button-height-xl: 3rem;
-  --cinder-button-font-size-xl: var(--cinder-text-md);
+  --cinder-button-font-size-xl: var(--cinder-text-base);
   --cinder-button-radius-xl: var(--cinder-radius-md);
 }
 

--- a/packages/playground/src/examples/button/soft.example.svelte
+++ b/packages/playground/src/examples/button/soft.example.svelte
@@ -1,0 +1,14 @@
+<script lang="ts" module>
+  export const title = 'Soft variants';
+  export const description =
+    'Soft and soft-danger use a tinted fill with no border — mid-emphasis between ghost and primary/danger.';
+</script>
+
+<script lang="ts">
+  import { Button } from '../../../../components/src/index.ts';
+</script>
+
+<div class="example-preview-row">
+  <Button variant="soft" label="Soft" />
+  <Button variant="soft-danger" label="Soft Danger" />
+</div>

--- a/packages/playground/src/examples/button/with-icons.example.svelte
+++ b/packages/playground/src/examples/button/with-icons.example.svelte
@@ -1,0 +1,141 @@
+<script lang="ts" module>
+  export const title = 'Icon buttons';
+  export const description =
+    'leadingIcon and trailingIcon are decorative-only — always wrapped in aria-hidden. Meaning lives in the accessible name. For icon-only buttons, pass aria-label or label.';
+</script>
+
+<script lang="ts">
+  import { Button } from '../../../../components/src/index.ts';
+</script>
+
+<div class="example-preview-col">
+  <div class="example-preview-row">
+    <Button variant="primary" label="Save">
+      {#snippet leadingIcon()}
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width="14"
+          height="14"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          aria-hidden="true"
+        >
+          <path d="M19 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11l5 5v11a2 2 0 0 1-2 2z" />
+          <polyline points="17 21 17 13 7 13 7 21" />
+          <polyline points="7 3 7 8 15 8" />
+        </svg>
+      {/snippet}
+    </Button>
+
+    <Button variant="secondary" label="Next">
+      {#snippet trailingIcon()}
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width="14"
+          height="14"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          aria-hidden="true"
+        >
+          <polyline points="9 18 15 12 9 6" />
+        </svg>
+      {/snippet}
+    </Button>
+
+    <Button variant="ghost" label="Share">
+      {#snippet leadingIcon()}
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width="14"
+          height="14"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          aria-hidden="true"
+        >
+          <circle cx="18" cy="5" r="3" />
+          <circle cx="6" cy="12" r="3" />
+          <circle cx="18" cy="19" r="3" />
+          <line x1="8.59" y1="13.51" x2="15.42" y2="17.49" />
+          <line x1="15.41" y1="6.51" x2="8.59" y2="10.49" />
+        </svg>
+      {/snippet}
+    </Button>
+  </div>
+
+  <div class="example-preview-row">
+    <Button iconOnly={true} aria-label="Close" variant="ghost">
+      {#snippet leadingIcon()}
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width="16"
+          height="16"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          aria-hidden="true"
+        >
+          <line x1="18" y1="6" x2="6" y2="18" />
+          <line x1="6" y1="6" x2="18" y2="18" />
+        </svg>
+      {/snippet}
+    </Button>
+
+    <Button iconOnly={true} aria-label="Delete" variant="ghost-danger">
+      {#snippet leadingIcon()}
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width="16"
+          height="16"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          aria-hidden="true"
+        >
+          <polyline points="3 6 5 6 21 6" />
+          <path d="M19 6l-1 14H6L5 6" />
+          <path d="M10 11v6" />
+          <path d="M14 11v6" />
+          <path d="M9 6V4h6v2" />
+        </svg>
+      {/snippet}
+    </Button>
+
+    <Button iconOnly={true} size="sm" aria-label="Search" variant="secondary">
+      {#snippet leadingIcon()}
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width="14"
+          height="14"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          aria-hidden="true"
+        >
+          <circle cx="11" cy="11" r="8" />
+          <line x1="21" y1="21" x2="16.65" y2="16.65" />
+        </svg>
+      {/snippet}
+    </Button>
+  </div>
+</div>


### PR DESCRIPTION
## Summary

- Adds `soft` and `soft-danger` variants (tinted fill via `color-mix`, no border, forced-colors border fallback)
- Adds `xl` size (48px height token)
- Bumps `md` default height 36px → 44px to meet WCAG AAA touch-target out of the box
- Adds `leadingIcon` / `trailingIcon` snippet props, always wrapped in `aria-hidden`
- Adds `iconOnly` boolean: square padding per size, dev guards enforce accessible name + visible icon presence
- TypeScript union made genuinely disjoint: `WithLabel`/`WithChildren` get `iconOnly?: false`, `WithIconOnly` requires both a name source and a visual source at compile time
- Template content extracted into `{#snippet buttonContent()}` to eliminate duplication between `<a>` and `<button>` branches
- Adds `ghost-danger` disabled + loading state CSS override (was falling through to grey base style)
- `aria-label`/`aria-labelledby` normalized: empty/whitespace strings converted to `undefined` to prevent suppressing text-content fallback in ARIA accessible-name computation
- Updated baseline dev guard accepts `aria-label`/`aria-labelledby` as valid name sources
- Loading spinner documented as CSS pseudo-element; label stays in DOM
- New playground examples: `soft.example.svelte`, `with-icons.example.svelte`
- New `button.a11y.md` covering icon-only contract, touch-target rationale, loading behavior

## Roadmap deviation: `md` height and touch targets

The ROADMAP checklist says "add hit-area expansion if not [meeting 44px]" for `xs`/`sm`. Instead, `md` (the default) was bumped to 44px so the default button meets AAA out of the box. `xs` and `sm` remain at their current heights and are documented as dense-UI-only sizes in `button.a11y.md`. Reviewer acceptance of this deviation is requested.

## Manual verification required before merging

- [ ] Verify `md` button renders at ≥44px tall in Chrome, Safari, and Firefox (devtools computed-style on the rendered `<button>`)
- [ ] Verify `soft` variant contrast ratio ≥4.5:1 in light theme (WebAIM contrast checker with resolved hex values)
- [ ] Verify `soft` variant contrast ratio ≥4.5:1 in dark theme
- [ ] Verify `soft-danger` contrast ratio ≥4.5:1 in both themes
- [ ] Verify `soft` and `soft-danger` remain visible in Windows High Contrast emulator (screenshot in PR)
- [ ] Visual check: `iconOnly + loading` at `xs` and `sm` sizes

## Review committee

Pre-reviewed by: typescript-expert, testing-expert, ux-designer, simplicity-engineer, prose-editor, Codex (gpt-5.4, xhigh reasoning)
- 2 rounds of review
- All must-fix items addressed across both rounds

## Test plan

- `bun test packages/components` — 684 tests pass (0 failures)
- `bun run typecheck` — all packages exit 0
- `bun run lint` — 0 errors
- `bun run build` — clean build
- Playground: `soft.example.svelte` and `with-icons.example.svelte` auto-discovered via glob

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it expands the `Button` public API and changes default sizing (`md` height), which can affect layouts and accessibility behavior across many call sites.
> 
> **Overview**
> Adds new `Button` capabilities: **new visual options** (`soft`, `soft-danger`, plus fixed `ghost-danger` disabled/loading styling) and an **`xl` size**, while bumping default `md` height tokens to 44px for WCAG touch-target compliance.
> 
> Introduces **icon support** via `leadingIcon`/`trailingIcon` (decorative, `aria-hidden`) and an **`iconOnly` mode** (square buttons) with compile-time prop unions, runtime dev warnings for missing accessible names/visual icons, and normalized `aria-label`/`aria-labelledby` handling (whitespace/empty values omitted).
> 
> Adds comprehensive tests, new playground examples, and `button.a11y.md` documentation to codify the accessibility contract and migration notes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 247fdb1884c49efd2df03f83de793ef08aa7dc07. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->