### PR TITLE
Add CommandPalette primitives with tests and examples

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -65,6 +65,14 @@
       "svelte": "./src/components/combobox.svelte",
       "types": "./dist/components/combobox.svelte.d.ts"
     },
+    "./command-item": {
+      "svelte": "./src/components/command-item.svelte",
+      "types": "./dist/components/command-item.svelte.d.ts"
+    },
+    "./command-palette": {
+      "svelte": "./src/components/command-palette.svelte",
+      "types": "./dist/components/command-palette.svelte.d.ts"
+    },
     "./copy-button": {
       "svelte": "./src/components/copy-button.svelte",
       "types": "./dist/components/copy-button.svelte.d.ts"

--- a/packages/components/src/components/_internal/command-palette-context.ts
+++ b/packages/components/src/components/_internal/command-palette-context.ts
@@ -35,7 +35,7 @@ export type CommandPaletteContext = {
   /** Id of the currently active (virtually focused) item, or null. */
   readonly activeItemId: string | null;
   /**
-   * Called by each CommandItem in a `$effect` on mount.
+   * Called by each CommandItem when it mounts.
    * Returns a stable id and an unregister function.
    */
   register: (input: CommandItemRegistrationInput) => { id: string; unregister: () => void };

--- a/packages/components/src/components/_internal/command-palette-context.ts
+++ b/packages/components/src/components/_internal/command-palette-context.ts
@@ -1,0 +1,44 @@
+/**
+ * Shared context contract between CommandPalette and CommandItem.
+ *
+ * This module is intentionally kept under `_internal/` so the symbol is
+ * accessible to both components without being part of the package's public
+ * surface. Consumers cannot reach `COMMAND_PALETTE_CONTEXT` without dotting
+ * into `_internal/`, which serves as a social signal matching the convention
+ * already established by `_internal/overlay.ts`.
+ */
+
+export const COMMAND_PALETTE_CONTEXT: unique symbol = Symbol('cinder-command-palette');
+
+/**
+ * Live registration input provided by each CommandItem on mount.
+ * Getters are used so the palette always reads the current prop values
+ * without requiring the item to re-register when props change.
+ */
+export type CommandItemRegistrationInput = {
+  /** Live getter for the item's submitted value. */
+  getValue: () => string;
+  /** Live getter for the activation callback. */
+  getOnselect: () => () => void;
+  /** Live getter for the disabled flag. */
+  getDisabled: () => boolean;
+};
+
+/**
+ * Context provided by CommandPalette and consumed by CommandItem.
+ */
+export type CommandPaletteContext = {
+  /** Stable id for the listbox; items compose their own ids from this. */
+  readonly listboxId: string;
+  /** Current input value. Read-only from items. */
+  readonly query: string;
+  /** Id of the currently active (virtually focused) item, or null. */
+  readonly activeItemId: string | null;
+  /**
+   * Called by each CommandItem in a `$effect` on mount.
+   * Returns a stable id and an unregister function.
+   */
+  register: (input: CommandItemRegistrationInput) => { id: string; unregister: () => void };
+  /** Called by items on pointerenter to sync hover with arrow-key navigation. */
+  setActiveById: (id: string) => void;
+};

--- a/packages/components/src/components/command-item.svelte
+++ b/packages/components/src/components/command-item.svelte
@@ -20,7 +20,7 @@
 </script>
 
 <script lang="ts">
-  import { getContext, hasContext, onDestroy } from 'svelte';
+  import { getContext, hasContext } from 'svelte';
 
   import { cn } from '../utilities/class-names.ts';
   import {
@@ -60,11 +60,6 @@
       unregister();
       itemId = null;
     };
-  });
-
-  onDestroy(() => {
-    // Belt-and-suspenders: ensure unregistration even if $effect cleanup
-    // doesn't fire (e.g. in some SSR teardown paths).
   });
 
   const isActive = $derived(itemId !== null && palette.activeItemId === itemId);

--- a/packages/components/src/components/command-item.svelte
+++ b/packages/components/src/components/command-item.svelte
@@ -1,0 +1,117 @@
+<script lang="ts" module>
+  import type { Snippet } from 'svelte';
+
+  export type CommandItemProps = {
+    /** Submitted value; surfaced through the registration record. */
+    value: string;
+    /** Invoked on Enter or click. */
+    onselect: () => void;
+    /** When true, the item is skipped by arrow keys and cannot be activated. */
+    disabled?: boolean;
+    /** Leading content (icon, avatar). Rendered with aria-hidden. */
+    leading?: Snippet;
+    /** Trailing content (kbd hint, badge). Rendered with aria-hidden. */
+    trailing?: Snippet;
+    /** Main label content. */
+    children: Snippet;
+    /** Class merged with `.cinder-command-item`. */
+    class?: string;
+  };
+</script>
+
+<script lang="ts">
+  import { getContext, hasContext, onDestroy } from 'svelte';
+
+  import { cn } from '../utilities/class-names.ts';
+  import {
+    COMMAND_PALETTE_CONTEXT,
+    type CommandPaletteContext,
+  } from './_internal/command-palette-context.ts';
+
+  if (!hasContext(COMMAND_PALETTE_CONTEXT)) {
+    throw new Error('CommandItem must be used within a CommandPalette.');
+  }
+
+  let {
+    value,
+    onselect,
+    disabled = false,
+    leading,
+    trailing,
+    children,
+    class: className,
+  }: CommandItemProps = $props();
+
+  const palette = getContext<CommandPaletteContext>(COMMAND_PALETTE_CONTEXT);
+
+  // Stable id assigned by the palette on registration.
+  let itemId = $state<string | null>(null);
+
+  // Register on mount using live getters so prop changes are reflected without
+  // re-registration. Matches the pattern in tab.svelte.
+  $effect(() => {
+    const { id, unregister } = palette.register({
+      getValue: () => value,
+      getOnselect: () => onselect,
+      getDisabled: () => disabled,
+    });
+    itemId = id;
+    return () => {
+      unregister();
+      itemId = null;
+    };
+  });
+
+  onDestroy(() => {
+    // Belt-and-suspenders: ensure unregistration even if $effect cleanup
+    // doesn't fire (e.g. in some SSR teardown paths).
+  });
+
+  const isActive = $derived(itemId !== null && palette.activeItemId === itemId);
+
+  function handlePointerEnter() {
+    if (!disabled && itemId !== null) {
+      palette.setActiveById(itemId);
+    }
+  }
+
+  function handlePointerDown(event: PointerEvent) {
+    // Prevent the input from losing focus when the user clicks an item.
+    event.preventDefault();
+  }
+
+  function handleClick() {
+    if (!disabled) {
+      onselect();
+    }
+  }
+</script>
+
+<li
+  id={itemId ?? undefined}
+  role="option"
+  class={cn('cinder-command-item', className)}
+  aria-selected={isActive}
+  aria-disabled={disabled || undefined}
+  data-cinder-active={isActive ? '' : undefined}
+  data-cinder-disabled={disabled || undefined}
+  onpointerenter={handlePointerEnter}
+  onpointerdown={handlePointerDown}
+  onclick={handleClick}
+>
+  {#if leading}
+    <span class="cinder-command-item__leading" aria-hidden="true">
+      {@render leading()}
+    </span>
+  {/if}
+
+  <span class="cinder-command-item__label">
+    {@render children()}
+  </span>
+
+  {#if trailing}
+    <span class="cinder-command-item__trailing" aria-hidden="true">
+      {@render trailing()}
+    </span>
+  {/if}
+</li>

--- a/packages/components/src/components/command-item.svelte
+++ b/packages/components/src/components/command-item.svelte
@@ -20,7 +20,7 @@
 </script>
 
 <script lang="ts">
-  import { getContext, hasContext } from 'svelte';
+  import { getContext, hasContext, onMount } from 'svelte';
 
   import { cn } from '../utilities/class-names.ts';
   import {
@@ -47,9 +47,9 @@
   // Stable id assigned by the palette on registration.
   let itemId = $state<string | null>(null);
 
-  // Register on mount using live getters so prop changes are reflected without
-  // re-registration. Matches the pattern in tab.svelte.
-  $effect(() => {
+  // Register once on mount using live getters so prop changes are reflected
+  // without re-registration churn.
+  onMount(() => {
     const { id, unregister } = palette.register({
       getValue: () => value,
       getOnselect: () => onselect,

--- a/packages/components/src/components/command-palette.a11y.md
+++ b/packages/components/src/components/command-palette.a11y.md
@@ -1,0 +1,82 @@
+# CommandPalette — Accessibility Notes
+
+## Pattern Reference
+
+The command palette composes two WAI-ARIA patterns:
+
+- **Dialog** (`role="dialog"`, `aria-modal="true"`) — provides a focus trap via `<dialog showModal()>` and a visible backdrop.
+- **Combobox + Listbox** — the `<input role="combobox">` owns virtual focus. `aria-activedescendant` points at the active `<li role="option">` so screen readers announce the currently highlighted item without moving DOM focus out of the input.
+
+Reference: [WAI-ARIA APG Combobox Pattern](https://www.w3.org/WAI/ARIA/apg/patterns/combobox/) and [Dialog Pattern](https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal/).
+
+## Roles and Accessible Names
+
+| Element | Role | Accessible Name Source |
+|---------|------|------------------------|
+| `<dialog>` | `dialog` (implicit) | `aria-label` from the `label` prop |
+| `<input>` | `combobox` (explicit) | Unlabelled — the dialog's `aria-label` provides context; consumers may add a visible `<label>` |
+| `<ul>` | `listbox` (explicit) | `aria-label` duplicated from the `label` prop |
+| `<li>` | `option` (explicit) | Text content of the `children` snippet |
+
+## Virtual Focus Model
+
+**Focus never moves into the list.** The combobox input is the screen reader's anchor from the moment the dialog opens until it closes. `aria-activedescendant` on the input is updated to the id of the highlighted option. Screen readers announce the newly-active option name as the user arrows through the list.
+
+This is the same model documented in the APG combobox pattern and already used by `combobox.svelte`.
+
+Invariants asserted in tests:
+
+1. `document.activeElement` is the search input from open to close.
+2. Exactly one `<li>` has `aria-selected="true"` when any item is active; zero when no items match.
+3. `aria-activedescendant` on the input matches the `id` of the `aria-selected` `<li>`, or is absent when no items match.
+4. Disabled items never become the active descendant — arrow keys skip them.
+
+## Keyboard Contract
+
+| Key | Behavior |
+|-----|----------|
+| `ArrowDown` | Move active item to next non-disabled; wrap to first if at end. `preventDefault`. |
+| `ArrowUp` | Move active item to previous non-disabled; wrap to last. `preventDefault`. |
+| `Home` | Move active item to first non-disabled. `preventDefault` (prevents caret jump). |
+| `End` | Move active item to last non-disabled. `preventDefault`. |
+| `Enter` | Invoke the active item's `onselect`. `preventDefault` (prevents form submission). |
+| `Escape` | Close the palette via the shared escape stack. Single-sourced through `closePalette()`. |
+| `Tab` / `Shift+Tab` | Native `<dialog>` focus trap (browser-level). Focus cycles through interactive elements in the panel and footer. |
+| Typing | Updates `query` (bindable). Items snippet re-renders with the new query. |
+
+## Mouse / Pointer Parity
+
+- `pointerenter` on a non-disabled item moves the active item id (parity with arrow keys).
+- `pointerdown` calls `event.preventDefault()` to keep focus on the input.
+- `click` on a non-disabled item invokes `onselect`. Disabled items: no-op.
+
+## Backdrop Click
+
+Clicking the `<dialog>` element itself (the backdrop area) closes the palette. Clicks on the panel, input, listbox, items, or footer do not close it — their `event.target` never equals the dialog element.
+
+## `aria-expanded` on the Combobox
+
+Per the APG pattern, `aria-expanded` reflects listbox visibility. In a command palette the listbox is always structurally visible while the dialog is open, so `aria-expanded="true"` is hard-coded. The value never toggles while the dialog is open.
+
+## Empty State
+
+The empty state renders inside a `role="status"` region so screen readers announce "No results" without stealing focus. It is gated behind a one-microtask delay (`registrationsReady`) to prevent a false "No results" flash during initial open or when a query change causes a full key-swap of items.
+
+## Reduced Motion
+
+Panel enter/exit transitions are gated behind `@media (prefers-reduced-motion: no-preference)`. An opacity-only fallback applies under `prefers-reduced-motion: reduce`.
+
+`backdrop-filter: blur()` is a separate capability/performance decision gated via `@supports (backdrop-filter: blur(1px))` — this is a capability check, not a motion check. A solid-fill backdrop is the fallback for browsers that lack it.
+
+## Grouped Sections (v1)
+
+v1 ships the flat-list pattern only. Consumers can render visually-styled "section header" `<li role="presentation">` elements between groups. Group affiliation is purely visual — all items remain direct children of the same `<ul role="listbox">` and are announced as options of that listbox.
+
+Nested `role="group"` semantics are explicitly out of scope for v1. They require real screen-reader verification before being declared canonical.
+
+## Non-Goals (v1)
+
+- Built-in fuzzy search — consumers filter their own data via the `items` snippet.
+- Virtualization — virtual focus requires `aria-activedescendant` to point at a rendered DOM node.
+- Pages / nested navigation.
+- Global Cmd+K listener — the consumer wires the keybinding and toggles `open`.

--- a/packages/components/src/components/command-palette.a11y.md
+++ b/packages/components/src/components/command-palette.a11y.md
@@ -14,8 +14,8 @@ Reference: [WAI-ARIA APG Combobox Pattern](https://www.w3.org/WAI/ARIA/apg/patte
 | Element | Role | Accessible Name Source |
 |---------|------|------------------------|
 | `<dialog>` | `dialog` (implicit) | `aria-label` from the `label` prop |
-| `<input>` | `combobox` (explicit) | Unlabelled — the dialog's `aria-label` provides context; consumers may add a visible `<label>` |
-| `<ul>` | `listbox` (explicit) | `aria-label` duplicated from the `label` prop |
+| `<input>` | `combobox` (explicit) | Visually-hidden `<label>` element (text from `label` prop) |
+| `<ul>` | `listbox` (explicit) | No `aria-label`; the combobox owns the listbox via `aria-controls`, and virtual focus is communicated via `aria-activedescendant` |
 | `<li>` | `option` (explicit) | Text content of the `children` snippet |
 
 ## Virtual Focus Model

--- a/packages/components/src/components/command-palette.a11y.md
+++ b/packages/components/src/components/command-palette.a11y.md
@@ -70,7 +70,7 @@ Panel enter/exit transitions are gated behind `@media (prefers-reduced-motion: n
 
 ## Grouped Sections (v1)
 
-v1 ships the flat-list pattern only. Consumers can render visually-styled "section header" `<li role="presentation">` elements between groups. Group affiliation is purely visual — all items remain direct children of the same `<ul role="listbox">` and are announced as options of that listbox.
+v1 ships the flat-list pattern only. Consumers can render visually-styled "section header" `<li role="none">` elements between groups. Group affiliation is purely visual — all items remain direct children of the same `<ul role="listbox">` and are announced as options of that listbox.
 
 Nested `role="group"` semantics are explicitly out of scope for v1. They require real screen-reader verification before being declared canonical.
 

--- a/packages/components/src/components/command-palette.svelte
+++ b/packages/components/src/components/command-palette.svelte
@@ -18,7 +18,7 @@
      * each open should reset it in their `onclose` callback.
      */
     query?: string;
-    /** Fired after the palette closes (Escape or backdrop). */
+    /** Fired after any close path routed through the palette close lifecycle. */
     onclose?: () => void;
     /** Element to restore focus to on close. Falls back to `captureFocus()`. */
     triggerRef?: HTMLElement | null;

--- a/packages/components/src/components/command-palette.svelte
+++ b/packages/components/src/components/command-palette.svelte
@@ -14,6 +14,8 @@
     /**
      * Bindable search query. Mutated by the input's oninput handler.
      * Exposed to the items snippet so consumers can filter.
+     * Note: query is NOT reset on close — consumers who want a fresh query on
+     * each open should reset it in their `onclose` callback.
      */
     query?: string;
     /** Fired after the palette closes (Escape or backdrop). */
@@ -110,19 +112,47 @@
   // open or when a query change causes a full key-swap of items. It is set
   // true after one microtask (giving children's $effect registrations time to
   // settle), and reset on every query change.
+  //
+  // A cycle counter guards against stale microtasks: if the query changes
+  // twice in quick succession, only the most recent microtask sets ready=true.
   let registrationsReady = $state(false);
+  let readyCycle = 0;
 
   $effect(() => {
     // Track query so this re-runs on every query change.
     void query;
     registrationsReady = false;
+    const cycle = ++readyCycle;
     queueMicrotask(() => {
-      registrationsReady = true;
+      if (cycle === readyCycle) registrationsReady = true;
     });
   });
 
   // ── Escape stack ──────────────────────────────────────────────────────────
   let releaseEscape: (() => void) | null = null;
+
+  // ── Focus restoration ─────────────────────────────────────────────────────
+  function returnFocus() {
+    if (triggerRef) {
+      restoreFocusTo(triggerRef);
+    } else {
+      restoreFocusTo(capturedFocus);
+    }
+    capturedFocus = null;
+  }
+
+  // ── Close ─────────────────────────────────────────────────────────────────
+  // Single authoritative close path. All close triggers (Escape stack,
+  // backdrop click, `close` event, programmatic open=false) route through here.
+  function closePalette() {
+    if (!open && !dialogElement?.open) return;
+    open = false;
+    releaseEscape?.();
+    releaseEscape = null;
+    if (dialogElement?.open) dialogElement.close();
+    returnFocus();
+    onclose?.();
+  }
 
   // ── Open/close lifecycle ──────────────────────────────────────────────────
   $effect(() => {
@@ -133,26 +163,11 @@
       inputElement?.focus();
       releaseEscape = pushEscapeHandler(closePalette);
     } else if (!open && dialogElement.open) {
-      dialogElement.close();
+      // Programmatic close: open was set to false externally.
+      // closePalette handles everything; call it to ensure focus is restored.
+      closePalette();
     }
   });
-
-  function returnFocus() {
-    if (triggerRef) {
-      restoreFocusTo(triggerRef);
-    } else {
-      restoreFocusTo(capturedFocus);
-    }
-    capturedFocus = null;
-  }
-
-  function closePalette() {
-    open = false;
-    releaseEscape?.();
-    releaseEscape = null;
-    returnFocus();
-    onclose?.();
-  }
 
   // Release escape handler on component destroy to prevent leaks.
   onDestroy(() => {
@@ -162,19 +177,15 @@
 
   // ── Dialog event handlers ─────────────────────────────────────────────────
 
-  // The native <dialog> fires `close` when it closes (including via Escape).
-  // We wire `oncancel` and call preventDefault so the native cancel path does
-  // not race with our escape-stack handler — closePalette() is the single
-  // source of truth for closing.
+  // The native <dialog> fires `cancel` before `close` when Escape is pressed.
+  // Prevent the native cancel so our escape-stack handler is the sole close path.
   function handleCancel(event: Event) {
     event.preventDefault();
   }
 
-  // The `close` event fires when the dialog actually closes. Mirror open state.
+  // The `close` event fires when the dialog actually closes (any path).
   function handleClose() {
-    if (open) {
-      closePalette();
-    }
+    closePalette();
   }
 
   function handleBackdropClick(event: MouseEvent) {
@@ -239,7 +250,10 @@
     },
     register(input: CommandItemRegistrationInput) {
       const id = `${listboxId}-item-${++itemCounter}`;
-      registrations = [...registrations, { id, ...input }];
+      registrations = [
+        ...registrations,
+        { id, getValue: input.getValue, getOnselect: input.getOnselect, getDisabled: input.getDisabled },
+      ];
       return {
         id,
         unregister: () => {
@@ -285,6 +299,7 @@
               clip-rule="evenodd"
             />
           </svg>
+          <label for={inputId} class="cinder-visually-hidden">{label}</label>
           <input
             bind:this={inputElement}
             id={inputId}
@@ -309,7 +324,6 @@
           id={listboxId}
           role="listbox"
           class="cinder-command-palette__listbox"
-          aria-label={label}
         >
           {@render items({ query })}
         </ul>

--- a/packages/components/src/components/command-palette.svelte
+++ b/packages/components/src/components/command-palette.svelte
@@ -1,0 +1,331 @@
+<script lang="ts" module>
+  import type { Snippet } from 'svelte';
+
+  export type CommandPaletteProps = {
+    /**
+     * Bindable open state. The component mutates `open = false` on Escape,
+     * backdrop click, or any explicit close path, then fires `onclose`.
+     */
+    open: boolean;
+    /** Placeholder rendered inside the search input. */
+    placeholder?: string;
+    /** Accessible name for the dialog, wired via `aria-label`. */
+    label?: string;
+    /**
+     * Bindable search query. Mutated by the input's oninput handler.
+     * Exposed to the items snippet so consumers can filter.
+     */
+    query?: string;
+    /** Fired after the palette closes (Escape or backdrop). */
+    onclose?: () => void;
+    /** Element to restore focus to on close. Falls back to `captureFocus()`. */
+    triggerRef?: HTMLElement | null;
+    /** Receives the current query so consumers can filter. */
+    items: Snippet<[{ query: string }]>;
+    /** Rendered when zero items are registered after filtering. */
+    empty?: Snippet;
+    /** Optional footer, e.g. for keybinding hints. Not part of the listbox. */
+    footer?: Snippet;
+    /** Class merged onto the palette panel. */
+    class?: string;
+  };
+</script>
+
+<script lang="ts">
+  import { setContext, onDestroy } from 'svelte';
+
+  import {
+    captureFocus,
+    pushEscapeHandler,
+    restoreFocusTo,
+  } from '../_internal/overlay.ts';
+  import { cn } from '../utilities/class-names.ts';
+  import { useId } from '../utilities/use-id.ts';
+  import {
+    COMMAND_PALETTE_CONTEXT,
+    type CommandItemRegistrationInput,
+    type CommandPaletteContext,
+  } from './_internal/command-palette-context.ts';
+
+  let {
+    open = $bindable(false),
+    placeholder = 'Search…',
+    label = 'Command palette',
+    query = $bindable(''),
+    onclose,
+    triggerRef = null,
+    items,
+    empty,
+    footer,
+    class: className,
+  }: CommandPaletteProps = $props();
+
+  // ── IDs ──────────────────────────────────────────────────────────────────
+  const listboxId = useId('cinder-command-palette-listbox');
+  const inputId = useId('cinder-command-palette-input');
+
+  // ── DOM refs ─────────────────────────────────────────────────────────────
+  let dialogElement: HTMLDialogElement | undefined = $state();
+  let inputElement: HTMLInputElement | undefined = $state();
+
+  // ── Hydration guard ───────────────────────────────────────────────────────
+  // `mounted` is false during SSR. The dialog is rendered only when mounted
+  // (client) or when already open (SSR open=true). Matching modal.svelte.
+  let mounted = $state(false);
+  $effect(() => {
+    mounted = true;
+  });
+
+  // ── Focus capture ─────────────────────────────────────────────────────────
+  let capturedFocus: HTMLElement | null = null;
+
+  // ── Item registration ─────────────────────────────────────────────────────
+  type RegistrationRecord = CommandItemRegistrationInput & { id: string };
+  let registrations = $state<RegistrationRecord[]>([]);
+
+  // Stable incrementing counter for item ids within this palette instance.
+  let itemCounter = 0;
+
+  // ── Active item (virtual focus) ───────────────────────────────────────────
+  let activeItemId = $state<string | null>(null);
+
+  // Ordered list of non-disabled item ids. Derived so arrow-key navigation
+  // always walks the current set, including after prop changes (e.g. toggling
+  // disabled on a mounted item).
+  const enabledIds = $derived.by(() => {
+    return registrations.filter((r) => !r.getDisabled()).map((r) => r.id);
+  });
+
+  // Repair activeItemId whenever the enabled set changes (registration churn,
+  // disabled toggled, query change). Preserve the current selection if it's
+  // still present and non-disabled; otherwise fall back to first enabled or null.
+  $effect(() => {
+    const ids = enabledIds;
+    if (activeItemId !== null && ids.includes(activeItemId)) return;
+    activeItemId = ids[0] ?? null;
+  });
+
+  // ── Empty-state flash prevention ─────────────────────────────────────────
+  // `registrationsReady` prevents the empty snippet from flashing on initial
+  // open or when a query change causes a full key-swap of items. It is set
+  // true after one microtask (giving children's $effect registrations time to
+  // settle), and reset on every query change.
+  let registrationsReady = $state(false);
+
+  $effect(() => {
+    // Track query so this re-runs on every query change.
+    void query;
+    registrationsReady = false;
+    queueMicrotask(() => {
+      registrationsReady = true;
+    });
+  });
+
+  // ── Escape stack ──────────────────────────────────────────────────────────
+  let releaseEscape: (() => void) | null = null;
+
+  // ── Open/close lifecycle ──────────────────────────────────────────────────
+  $effect(() => {
+    if (!dialogElement) return;
+    if (open && !dialogElement.open) {
+      capturedFocus = captureFocus();
+      dialogElement.showModal();
+      inputElement?.focus();
+      releaseEscape = pushEscapeHandler(closePalette);
+    } else if (!open && dialogElement.open) {
+      dialogElement.close();
+    }
+  });
+
+  function returnFocus() {
+    if (triggerRef) {
+      restoreFocusTo(triggerRef);
+    } else {
+      restoreFocusTo(capturedFocus);
+    }
+    capturedFocus = null;
+  }
+
+  function closePalette() {
+    open = false;
+    releaseEscape?.();
+    releaseEscape = null;
+    returnFocus();
+    onclose?.();
+  }
+
+  // Release escape handler on component destroy to prevent leaks.
+  onDestroy(() => {
+    releaseEscape?.();
+    releaseEscape = null;
+  });
+
+  // ── Dialog event handlers ─────────────────────────────────────────────────
+
+  // The native <dialog> fires `close` when it closes (including via Escape).
+  // We wire `oncancel` and call preventDefault so the native cancel path does
+  // not race with our escape-stack handler — closePalette() is the single
+  // source of truth for closing.
+  function handleCancel(event: Event) {
+    event.preventDefault();
+  }
+
+  // The `close` event fires when the dialog actually closes. Mirror open state.
+  function handleClose() {
+    if (open) {
+      closePalette();
+    }
+  }
+
+  function handleBackdropClick(event: MouseEvent) {
+    if (event.target === dialogElement) {
+      closePalette();
+    }
+  }
+
+  // ── Keyboard routing ──────────────────────────────────────────────────────
+  function handleKeydown(event: KeyboardEvent) {
+    const ids = enabledIds;
+
+    if (event.key === 'ArrowDown') {
+      event.preventDefault();
+      if (ids.length === 0) return;
+      if (activeItemId === null) {
+        activeItemId = ids[0];
+      } else {
+        const index = ids.indexOf(activeItemId);
+        activeItemId = ids[(index + 1) % ids.length];
+      }
+    } else if (event.key === 'ArrowUp') {
+      event.preventDefault();
+      if (ids.length === 0) return;
+      if (activeItemId === null) {
+        activeItemId = ids[ids.length - 1];
+      } else {
+        const index = ids.indexOf(activeItemId);
+        activeItemId = ids[index <= 0 ? ids.length - 1 : index - 1];
+      }
+    } else if (event.key === 'Home') {
+      event.preventDefault();
+      activeItemId = ids[0] ?? null;
+    } else if (event.key === 'End') {
+      event.preventDefault();
+      activeItemId = ids[ids.length - 1] ?? null;
+    } else if (event.key === 'Enter') {
+      event.preventDefault();
+      if (activeItemId === null) return;
+      const record = registrations.find((r) => r.id === activeItemId);
+      if (record && !record.getDisabled()) {
+        record.getOnselect()();
+      }
+    }
+  }
+
+  function handleInput(event: Event) {
+    const target = event.target as HTMLInputElement;
+    query = target.value;
+  }
+
+  // ── Context ───────────────────────────────────────────────────────────────
+  const context: CommandPaletteContext = {
+    get listboxId() {
+      return listboxId;
+    },
+    get query() {
+      return query;
+    },
+    get activeItemId() {
+      return activeItemId;
+    },
+    register(input: CommandItemRegistrationInput) {
+      const id = `${listboxId}-item-${++itemCounter}`;
+      registrations = [...registrations, { id, ...input }];
+      return {
+        id,
+        unregister: () => {
+          registrations = registrations.filter((r) => r.id !== id);
+        },
+      };
+    },
+    setActiveById(id: string) {
+      activeItemId = id;
+    },
+  };
+
+  setContext<CommandPaletteContext>(COMMAND_PALETTE_CONTEXT, context);
+
+  const showEmpty = $derived(
+    mounted && registrationsReady && registrations.length === 0,
+  );
+</script>
+
+{#if mounted || open}
+  <dialog
+    bind:this={dialogElement}
+    class="cinder-command-palette"
+    aria-label={label}
+    aria-modal="true"
+    oncancel={handleCancel}
+    onclose={handleClose}
+    onclick={handleBackdropClick}
+  >
+    {#if open}
+      <div class={cn('cinder-command-palette__panel', className)}>
+        <div class="cinder-command-palette__search">
+          <svg
+            class="cinder-command-palette__search-icon"
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 20 20"
+            fill="currentColor"
+            aria-hidden="true"
+          >
+            <path
+              fill-rule="evenodd"
+              d="M9 3.5a5.5 5.5 0 100 11 5.5 5.5 0 000-11zM2 9a7 7 0 1112.452 4.391l3.328 3.329a.75.75 0 11-1.06 1.06l-3.329-3.328A7 7 0 012 9z"
+              clip-rule="evenodd"
+            />
+          </svg>
+          <input
+            bind:this={inputElement}
+            id={inputId}
+            type="text"
+            class="cinder-command-palette__input"
+            role="combobox"
+            autocomplete="off"
+            autocorrect="off"
+            spellcheck="false"
+            {placeholder}
+            value={query}
+            aria-autocomplete="list"
+            aria-expanded="true"
+            aria-controls={listboxId}
+            aria-activedescendant={activeItemId ?? undefined}
+            oninput={handleInput}
+            onkeydown={handleKeydown}
+          />
+        </div>
+
+        <ul
+          id={listboxId}
+          role="listbox"
+          class="cinder-command-palette__listbox"
+          aria-label={label}
+        >
+          {@render items({ query })}
+        </ul>
+
+        {#if showEmpty && empty}
+          <div class="cinder-command-palette__empty" role="status">
+            {@render empty()}
+          </div>
+        {/if}
+
+        {#if footer}
+          <div class="cinder-command-palette__footer">
+            {@render footer()}
+          </div>
+        {/if}
+      </div>
+    {/if}
+  </dialog>
+{/if}

--- a/packages/components/src/components/command-palette.svelte
+++ b/packages/components/src/components/command-palette.svelte
@@ -202,19 +202,19 @@
       event.preventDefault();
       if (ids.length === 0) return;
       if (activeItemId === null) {
-        activeItemId = ids[0];
+        activeItemId = ids[0] ?? null;
       } else {
         const index = ids.indexOf(activeItemId);
-        activeItemId = ids[(index + 1) % ids.length];
+        activeItemId = ids[(index + 1) % ids.length] ?? null;
       }
     } else if (event.key === 'ArrowUp') {
       event.preventDefault();
       if (ids.length === 0) return;
       if (activeItemId === null) {
-        activeItemId = ids[ids.length - 1];
+        activeItemId = ids[ids.length - 1] ?? null;
       } else {
         const index = ids.indexOf(activeItemId);
-        activeItemId = ids[index <= 0 ? ids.length - 1 : index - 1];
+        activeItemId = ids[index <= 0 ? ids.length - 1 : index - 1] ?? null;
       }
     } else if (event.key === 'Home') {
       event.preventDefault();

--- a/packages/components/src/components/command-palette.svelte
+++ b/packages/components/src/components/command-palette.svelte
@@ -202,19 +202,23 @@
       event.preventDefault();
       if (ids.length === 0) return;
       if (activeItemId === null) {
-        activeItemId = ids[0]!;
+        const firstId = ids[0];
+        if (firstId !== undefined) activeItemId = firstId;
       } else {
         const index = ids.indexOf(activeItemId);
-        activeItemId = ids[(index + 1) % ids.length]!;
+        const nextId = ids[(index + 1) % ids.length];
+        if (nextId !== undefined) activeItemId = nextId;
       }
     } else if (event.key === 'ArrowUp') {
       event.preventDefault();
       if (ids.length === 0) return;
       if (activeItemId === null) {
-        activeItemId = ids[ids.length - 1]!;
+        const lastId = ids[ids.length - 1];
+        if (lastId !== undefined) activeItemId = lastId;
       } else {
         const index = ids.indexOf(activeItemId);
-        activeItemId = ids[index <= 0 ? ids.length - 1 : index - 1]!;
+        const previousId = ids[index <= 0 ? ids.length - 1 : index - 1];
+        if (previousId !== undefined) activeItemId = previousId;
       }
     } else if (event.key === 'Home') {
       event.preventDefault();

--- a/packages/components/src/components/command-palette.svelte
+++ b/packages/components/src/components/command-palette.svelte
@@ -36,11 +36,7 @@
 <script lang="ts">
   import { setContext, onDestroy } from 'svelte';
 
-  import {
-    captureFocus,
-    pushEscapeHandler,
-    restoreFocusTo,
-  } from '../_internal/overlay.ts';
+  import { captureFocus, pushEscapeHandler, restoreFocusTo } from '../_internal/overlay.ts';
   import { cn } from '../utilities/class-names.ts';
   import { useId } from '../utilities/use-id.ts';
   import {
@@ -263,7 +259,12 @@
       const id = `${listboxId}-item-${++itemCounter}`;
       registrations = [
         ...registrations,
-        { id, getValue: input.getValue, getOnselect: input.getOnselect, getDisabled: input.getDisabled },
+        {
+          id,
+          getValue: input.getValue,
+          getOnselect: input.getOnselect,
+          getDisabled: input.getDisabled,
+        },
       ];
       return {
         id,
@@ -279,9 +280,7 @@
 
   setContext<CommandPaletteContext>(COMMAND_PALETTE_CONTEXT, context);
 
-  const showEmpty = $derived(
-    mounted && registrationsReady && registrations.length === 0,
-  );
+  const showEmpty = $derived(mounted && registrationsReady && registrations.length === 0);
 </script>
 
 {#if mounted || open}
@@ -331,11 +330,7 @@
           />
         </div>
 
-        <ul
-          id={listboxId}
-          role="listbox"
-          class="cinder-command-palette__listbox"
-        >
+        <ul id={listboxId} role="listbox" class="cinder-command-palette__listbox">
           {@render items({ query })}
         </ul>
 

--- a/packages/components/src/components/command-palette.svelte
+++ b/packages/components/src/components/command-palette.svelte
@@ -202,19 +202,19 @@
       event.preventDefault();
       if (ids.length === 0) return;
       if (activeItemId === null) {
-        activeItemId = ids[0] ?? null;
+        activeItemId = ids[0]!;
       } else {
         const index = ids.indexOf(activeItemId);
-        activeItemId = ids[(index + 1) % ids.length] ?? null;
+        activeItemId = ids[(index + 1) % ids.length]!;
       }
     } else if (event.key === 'ArrowUp') {
       event.preventDefault();
       if (ids.length === 0) return;
       if (activeItemId === null) {
-        activeItemId = ids[ids.length - 1] ?? null;
+        activeItemId = ids[ids.length - 1]!;
       } else {
         const index = ids.indexOf(activeItemId);
-        activeItemId = ids[index <= 0 ? ids.length - 1 : index - 1] ?? null;
+        activeItemId = ids[index <= 0 ? ids.length - 1 : index - 1]!;
       }
     } else if (event.key === 'Home') {
       event.preventDefault();

--- a/packages/components/src/components/command-palette.svelte
+++ b/packages/components/src/components/command-palette.svelte
@@ -144,14 +144,21 @@
   // ── Close ─────────────────────────────────────────────────────────────────
   // Single authoritative close path. All close triggers (Escape stack,
   // backdrop click, `close` event, programmatic open=false) route through here.
+  // The `isClosing` flag prevents double-invocation: setting `open = false`
+  // schedules the lifecycle $effect, which calls closePalette() again from the
+  // else branch. The flag ensures that second call is a no-op.
+  let isClosing = false;
   function closePalette() {
+    if (isClosing) return;
     if (!open && !dialogElement?.open) return;
+    isClosing = true;
     open = false;
     releaseEscape?.();
     releaseEscape = null;
     if (dialogElement?.open) dialogElement.close();
     returnFocus();
     onclose?.();
+    isClosing = false;
   }
 
   // ── Open/close lifecycle ──────────────────────────────────────────────────
@@ -303,7 +310,7 @@
               clip-rule="evenodd"
             />
           </svg>
-          <label for={inputId} class="cinder-visually-hidden">{label}</label>
+          <label for={inputId} class="cinder-sr-only">{label}</label>
           <input
             bind:this={inputElement}
             id={inputId}

--- a/packages/components/src/components/command-palette.test.ts
+++ b/packages/components/src/components/command-palette.test.ts
@@ -1,0 +1,377 @@
+/// <reference lib="dom" />
+import { beforeEach, describe, expect, test } from 'bun:test';
+import { createRawSnippet, tick } from 'svelte';
+
+import { setupHappyDom } from '../test/happy-dom.ts';
+import { _resetEscapeStack, _resetScrollLock } from '../_internal/overlay.ts';
+
+setupHappyDom();
+
+// happy-dom does not implement HTMLDialogElement.showModal / close — stub them.
+if (typeof HTMLDialogElement !== 'undefined') {
+  if (!HTMLDialogElement.prototype.showModal) {
+    Object.defineProperty(HTMLDialogElement.prototype, 'showModal', {
+      value: function () {
+        this.setAttribute('open', '');
+      },
+      configurable: true,
+      writable: true,
+    });
+  }
+  if (!HTMLDialogElement.prototype.close) {
+    Object.defineProperty(HTMLDialogElement.prototype, 'close', {
+      value: function () {
+        this.removeAttribute('open');
+      },
+      configurable: true,
+      writable: true,
+    });
+  }
+}
+
+const { render, fireEvent } = await import('@testing-library/svelte');
+const { default: CommandPalette } = await import('./command-palette.svelte');
+const { default: CommandItem } = await import('./command-item.svelte');
+
+// ── Snippet helpers ────────────────────────────────────────────────────────
+
+function textSnippet(text: string) {
+  return createRawSnippet(() => ({
+    render: () => `<span>${text}</span>`,
+    setup: () => {},
+  }));
+}
+
+const emptySnippet = createRawSnippet(() => ({
+  render: () => `<span></span>`,
+  setup: () => {},
+}));
+
+// ── Shared setup ───────────────────────────────────────────────────────────
+
+beforeEach(() => {
+  _resetEscapeStack();
+  _resetScrollLock();
+});
+
+// ── Lifecycle ──────────────────────────────────────────────────────────────
+
+describe('CommandPalette — lifecycle', () => {
+  test('dialog is in the DOM (mounted) even when open=false', () => {
+    const { container } = render(CommandPalette, {
+      props: {
+        open: false,
+        items: emptySnippet,
+      },
+    });
+    const dialog = container.querySelector('dialog');
+    expect(dialog).not.toBeNull();
+    expect(dialog?.hasAttribute('open')).toBe(false);
+  });
+
+  test('dialog has open attribute when open=true', () => {
+    const { container } = render(CommandPalette, {
+      props: {
+        open: true,
+        items: emptySnippet,
+      },
+    });
+    const dialog = container.querySelector('dialog');
+    expect(dialog).not.toBeNull();
+    expect(dialog?.hasAttribute('open')).toBe(true);
+  });
+
+  test('setting open=false closes the dialog', async () => {
+    let openValue = true;
+    const { container } = render(CommandPalette, {
+      props: {
+        get open() {
+          return openValue;
+        },
+        set open(v: boolean) {
+          openValue = v;
+        },
+        items: emptySnippet,
+      },
+    });
+    const dialog = container.querySelector('dialog') as HTMLDialogElement;
+    await fireEvent(dialog, new Event('close'));
+    expect(openValue).toBe(false);
+  });
+
+  test('fires onclose after open is mutated to false', async () => {
+    let closeFired = false;
+    let openValue = true;
+    const { container } = render(CommandPalette, {
+      props: {
+        get open() {
+          return openValue;
+        },
+        set open(v: boolean) {
+          openValue = v;
+        },
+        onclose: () => {
+          closeFired = true;
+        },
+        items: emptySnippet,
+      },
+    });
+    const dialog = container.querySelector('dialog') as HTMLDialogElement;
+    await fireEvent(dialog, new Event('close'));
+    expect(closeFired).toBe(true);
+  });
+});
+
+// ── ARIA / combobox ────────────────────────────────────────────────────────
+
+describe('CommandPalette — combobox ARIA', () => {
+  test('input has role="combobox"', () => {
+    const { container } = render(CommandPalette, {
+      props: { open: true, items: emptySnippet },
+    });
+    const input = container.querySelector('input');
+    expect(input?.getAttribute('role')).toBe('combobox');
+  });
+
+  test('input has aria-expanded="true" while open', () => {
+    const { container } = render(CommandPalette, {
+      props: { open: true, items: emptySnippet },
+    });
+    const input = container.querySelector('input');
+    expect(input?.getAttribute('aria-expanded')).toBe('true');
+  });
+
+  test('input has aria-controls pointing at the listbox', () => {
+    const { container } = render(CommandPalette, {
+      props: { open: true, items: emptySnippet },
+    });
+    const input = container.querySelector('input');
+    const listbox = container.querySelector('[role="listbox"]');
+    expect(input?.getAttribute('aria-controls')).toBe(listbox?.getAttribute('id'));
+  });
+
+  test('listbox has role="listbox"', () => {
+    const { container } = render(CommandPalette, {
+      props: { open: true, items: emptySnippet },
+    });
+    expect(container.querySelector('[role="listbox"]')).not.toBeNull();
+  });
+
+  test('dialog has aria-modal="true"', () => {
+    const { container } = render(CommandPalette, {
+      props: { open: true, items: emptySnippet },
+    });
+    const dialog = container.querySelector('dialog');
+    expect(dialog?.getAttribute('aria-modal')).toBe('true');
+  });
+
+  test('dialog has aria-label from label prop', () => {
+    const { container } = render(CommandPalette, {
+      props: { open: true, label: 'My palette', items: emptySnippet },
+    });
+    const dialog = container.querySelector('dialog');
+    expect(dialog?.getAttribute('aria-label')).toBe('My palette');
+  });
+
+  test('dialog defaults to aria-label="Command palette"', () => {
+    const { container } = render(CommandPalette, {
+      props: { open: true, items: emptySnippet },
+    });
+    const dialog = container.querySelector('dialog');
+    expect(dialog?.getAttribute('aria-label')).toBe('Command palette');
+  });
+});
+
+// ── Backdrop click ─────────────────────────────────────────────────────────
+
+describe('CommandPalette — backdrop click', () => {
+  test('click on dialog element closes the palette', async () => {
+    let openValue = true;
+    const { container } = render(CommandPalette, {
+      props: {
+        get open() {
+          return openValue;
+        },
+        set open(v: boolean) {
+          openValue = v;
+        },
+        items: emptySnippet,
+      },
+    });
+    const dialog = container.querySelector('dialog') as HTMLDialogElement;
+    // Simulate a click where target === dialog (backdrop area).
+    const event = new MouseEvent('click', { bubbles: true });
+    Object.defineProperty(event, 'target', { value: dialog });
+    dialog.dispatchEvent(event);
+    await tick();
+    expect(openValue).toBe(false);
+  });
+
+  test('click on input does not close the palette', async () => {
+    let openValue = true;
+    const { container } = render(CommandPalette, {
+      props: {
+        get open() {
+          return openValue;
+        },
+        set open(v: boolean) {
+          openValue = v;
+        },
+        items: emptySnippet,
+      },
+    });
+    const input = container.querySelector('input') as HTMLInputElement;
+    await fireEvent.click(input);
+    expect(openValue).toBe(true);
+  });
+});
+
+// ── Query ──────────────────────────────────────────────────────────────────
+
+describe('CommandPalette — query', () => {
+  test('typing into the input updates the bound query', async () => {
+    let queryValue = '';
+    const { container } = render(CommandPalette, {
+      props: {
+        open: true,
+        get query() {
+          return queryValue;
+        },
+        set query(v: string) {
+          queryValue = v;
+        },
+        items: emptySnippet,
+      },
+    });
+    const input = container.querySelector('input') as HTMLInputElement;
+    await fireEvent.input(input, { target: { value: 'hello' } });
+    expect(queryValue).toBe('hello');
+  });
+});
+
+// ── Footer and empty snippet ───────────────────────────────────────────────
+
+describe('CommandPalette — slots', () => {
+  test('renders footer when provided', () => {
+    const { container } = render(CommandPalette, {
+      props: {
+        open: true,
+        items: emptySnippet,
+        footer: textSnippet('Footer hint'),
+      },
+    });
+    const footer = container.querySelector('.cinder-command-palette__footer');
+    expect(footer).not.toBeNull();
+    expect(footer?.textContent).toContain('Footer hint');
+  });
+
+  test('footer is absent when not provided', () => {
+    const { container } = render(CommandPalette, {
+      props: { open: true, items: emptySnippet },
+    });
+    expect(container.querySelector('.cinder-command-palette__footer')).toBeNull();
+  });
+});
+
+// ── Context guard ──────────────────────────────────────────────────────────
+
+describe('CommandItem — context guard', () => {
+  test('throws when rendered without a CommandPalette parent', () => {
+    expect(() => {
+      render(CommandItem, {
+        props: {
+          value: 'test',
+          onselect: () => {},
+          children: textSnippet('Item'),
+        },
+      });
+    }).toThrow('CommandItem must be used within a CommandPalette');
+  });
+});
+
+// ── Keyboard routing ───────────────────────────────────────────────────────
+
+describe('CommandPalette — keyboard routing', () => {
+  /**
+   * Build a palette with three items using a snippet that renders
+   * CommandItem components. We rely on the palette being open so children mount.
+   *
+   * Note: in this test harness we synthesize the items snippet inline using
+   * a component-level helper rather than mounting sub-components directly,
+   * because @testing-library/svelte does not support mounting child components
+   * into parent context in a single render call. Instead, we fire keyboard
+   * events directly on the input and assert on ARIA attributes.
+   */
+
+  test('ArrowDown moves aria-activedescendant forward', async () => {
+    const { container } = render(CommandPalette, {
+      props: {
+        open: true,
+        items: createRawSnippet(() => ({
+          render: () =>
+            `<li id="item-1" role="option" aria-selected="false">A</li>` +
+            `<li id="item-2" role="option" aria-selected="false">B</li>` +
+            `<li id="item-3" role="option" aria-selected="false">C</li>`,
+          setup: () => {},
+        })),
+      },
+    });
+    const input = container.querySelector('input') as HTMLInputElement;
+    // No items are registered via context (raw snippet doesn't use CommandItem),
+    // so we test that the keyboard handler fires without throwing.
+    await fireEvent.keyDown(input, { key: 'ArrowDown' });
+    // With no registered items, activeItemId stays null; no error.
+    expect(input?.getAttribute('aria-activedescendant')).toBeNull();
+  });
+
+  test('Enter does not throw when no items are registered', async () => {
+    const { container } = render(CommandPalette, {
+      props: { open: true, items: emptySnippet },
+    });
+    const input = container.querySelector('input') as HTMLInputElement;
+    await fireEvent.keyDown(input, { key: 'Enter' });
+    // No error thrown.
+    expect(true).toBe(true);
+  });
+
+  test('Escape fires oncancel with preventDefault', async () => {
+    const { container } = render(CommandPalette, {
+      props: { open: true, items: emptySnippet },
+    });
+    const dialog = container.querySelector('dialog') as HTMLDialogElement;
+    let cancelPrevented = false;
+    const cancelEvent = new Event('cancel', { cancelable: true });
+    cancelEvent.preventDefault = () => {
+      cancelPrevented = true;
+    };
+    dialog.dispatchEvent(cancelEvent);
+    await tick();
+    expect(cancelPrevented).toBe(true);
+  });
+
+  test('Home and End keys do not throw when no items registered', async () => {
+    const { container } = render(CommandPalette, {
+      props: { open: true, items: emptySnippet },
+    });
+    const input = container.querySelector('input') as HTMLInputElement;
+    await fireEvent.keyDown(input, { key: 'Home' });
+    await fireEvent.keyDown(input, { key: 'End' });
+    expect(true).toBe(true);
+  });
+});
+
+// ── Custom class ───────────────────────────────────────────────────────────
+
+describe('CommandPalette — class prop', () => {
+  test('applies custom class to the panel', () => {
+    const { container } = render(CommandPalette, {
+      props: {
+        open: true,
+        class: 'my-custom-palette',
+        items: emptySnippet,
+      },
+    });
+    const panel = container.querySelector('.cinder-command-palette__panel');
+    expect(panel?.classList.contains('my-custom-palette')).toBe(true);
+  });
+});

--- a/packages/components/src/components/command-palette.test.ts
+++ b/packages/components/src/components/command-palette.test.ts
@@ -32,6 +32,9 @@ if (typeof HTMLDialogElement !== 'undefined') {
 const { render, fireEvent } = await import('@testing-library/svelte');
 const { default: CommandPalette } = await import('./command-palette.svelte');
 const { default: CommandItem } = await import('./command-item.svelte');
+const { default: CommandPaletteFixture } = await import(
+  '../test/fixtures/command-palette-fixture.svelte'
+);
 
 // ── Snippet helpers ────────────────────────────────────────────────────────
 
@@ -46,6 +49,19 @@ const emptySnippet = createRawSnippet(() => ({
   render: () => `<span></span>`,
   setup: () => {},
 }));
+
+async function settleCommandPalette() {
+  await Promise.resolve();
+  await tick();
+}
+
+function getInput(container: HTMLElement) {
+  return container.querySelector('input[role="combobox"]') as HTMLInputElement;
+}
+
+function getSelectedOption(container: HTMLElement) {
+  return container.querySelector('[role="option"][aria-selected="true"]') as HTMLElement | null;
+}
 
 // ── Shared setup ───────────────────────────────────────────────────────────
 
@@ -81,44 +97,30 @@ describe('CommandPalette — lifecycle', () => {
     expect(dialog?.hasAttribute('open')).toBe(true);
   });
 
-  test('setting open=false closes the dialog', async () => {
-    let openValue = true;
-    const { container } = render(CommandPalette, {
-      props: {
-        get open() {
-          return openValue;
-        },
-        set open(v: boolean) {
-          openValue = v;
-        },
-        items: emptySnippet,
+  test('external open=false closes dialog, restores focus, and fires onclose once', async () => {
+    let closeCount = 0;
+    const { container, getByTestId } = render(CommandPaletteFixture, {
+      initialOpen: false,
+      onClosed: () => {
+        closeCount += 1;
       },
     });
-    const dialog = container.querySelector('dialog') as HTMLDialogElement;
-    await fireEvent(dialog, new Event('close'));
-    expect(openValue).toBe(false);
-  });
+    const trigger = getByTestId('command-palette-trigger') as HTMLButtonElement;
+    trigger.focus();
 
-  test('fires onclose after open is mutated to false', async () => {
-    let closeFired = false;
-    let openValue = true;
-    const { container } = render(CommandPalette, {
-      props: {
-        get open() {
-          return openValue;
-        },
-        set open(v: boolean) {
-          openValue = v;
-        },
-        onclose: () => {
-          closeFired = true;
-        },
-        items: emptySnippet,
-      },
-    });
+    await fireEvent.click(trigger);
+    await settleCommandPalette();
+
+    const input = getInput(container);
+    expect(document.activeElement).toBe(input);
+
+    await fireEvent.click(getByTestId('command-palette-external-close'));
+    await settleCommandPalette();
+
     const dialog = container.querySelector('dialog') as HTMLDialogElement;
-    await fireEvent(dialog, new Event('close'));
-    expect(closeFired).toBe(true);
+    expect(dialog.hasAttribute('open')).toBe(false);
+    expect(document.activeElement).toBe(trigger);
+    expect(closeCount).toBe(1);
   });
 });
 
@@ -179,6 +181,25 @@ describe('CommandPalette — combobox ARIA', () => {
     });
     const dialog = container.querySelector('dialog');
     expect(dialog?.getAttribute('aria-label')).toBe('Command palette');
+  });
+
+  test('search input has a <label> element associated via for/id', () => {
+    const { container } = render(CommandPalette, {
+      props: { open: true, items: emptySnippet },
+    });
+    const input = container.querySelector('input') as HTMLInputElement;
+    const inputId = input?.getAttribute('id');
+    expect(inputId).not.toBeNull();
+    const label = container.querySelector(`label[for="${inputId}"]`);
+    expect(label).not.toBeNull();
+  });
+
+  test('listbox has no aria-label (name provided via combobox aria-controls)', () => {
+    const { container } = render(CommandPalette, {
+      props: { open: true, items: emptySnippet },
+    });
+    const listbox = container.querySelector('[role="listbox"]');
+    expect(listbox?.getAttribute('aria-label')).toBeNull();
   });
 });
 
@@ -363,6 +384,55 @@ describe('CommandPalette — keyboard routing (no registered items)', () => {
   });
 });
 
+describe('CommandPalette — keyboard routing with registered items', () => {
+  test('arrow keys move aria-activedescendant through enabled items and skip disabled items', async () => {
+    const { container } = render(CommandPaletteFixture);
+    await settleCommandPalette();
+
+    const input = getInput(container);
+    expect(document.activeElement).toBe(input);
+
+    let selected = getSelectedOption(container);
+    expect(selected?.textContent).toContain('Alpha');
+    expect(input.getAttribute('aria-activedescendant')).toBe(selected?.id);
+
+    await fireEvent.keyDown(input, { key: 'ArrowDown' });
+    await tick();
+    selected = getSelectedOption(container);
+    expect(selected?.textContent).toContain('Gamma');
+    expect(input.getAttribute('aria-activedescendant')).toBe(selected?.id);
+    expect(container.querySelector('[aria-disabled="true"]')?.getAttribute('aria-selected')).toBe(
+      'false',
+    );
+
+    await fireEvent.keyDown(input, { key: 'ArrowDown' });
+    await tick();
+    selected = getSelectedOption(container);
+    expect(selected?.textContent).toContain('Alpha');
+
+    await fireEvent.keyDown(input, { key: 'ArrowUp' });
+    await tick();
+    selected = getSelectedOption(container);
+    expect(selected?.textContent).toContain('Gamma');
+  });
+
+  test('Enter invokes the active registered item callback', async () => {
+    let selectedValue = '';
+    const { container } = render(CommandPaletteFixture, {
+      onSelected: (value: string) => {
+        selectedValue = value;
+      },
+    });
+    await settleCommandPalette();
+
+    const input = getInput(container);
+    await fireEvent.keyDown(input, { key: 'ArrowDown' });
+    await fireEvent.keyDown(input, { key: 'Enter' });
+
+    expect(selectedValue).toBe('gamma');
+  });
+});
+
 // ── Empty state timing ────────────────────────────────────────────────────
 
 describe('CommandPalette — empty state timing', () => {
@@ -406,6 +476,71 @@ describe('CommandPalette — empty state timing', () => {
     await tick();
     const emptyEl = container.querySelector('.cinder-command-palette__empty');
     expect(emptyEl?.getAttribute('role')).toBe('status');
+  });
+
+  test('stale query microtasks do not show empty state before the newest cycle settles', async () => {
+    const queuedMicrotasks: Array<() => void> = [];
+    const originalQueueMicrotask = globalThis.queueMicrotask;
+    globalThis.queueMicrotask = (callback) => {
+      queuedMicrotasks.push(callback);
+    };
+
+    try {
+      const { container } = render(CommandPaletteFixture, { filterItems: true });
+      await tick();
+
+      while (queuedMicrotasks.length > 0) {
+        queuedMicrotasks.shift()?.();
+      }
+      await tick();
+
+      const input = getInput(container);
+      await fireEvent.input(input, { target: { value: 'z' } });
+      await tick();
+      await fireEvent.input(input, { target: { value: 'zz' } });
+      await tick();
+
+      expect(queuedMicrotasks.length).toBe(2);
+      expect(container.querySelector('.cinder-command-palette__empty')).toBeNull();
+
+      queuedMicrotasks.shift()?.();
+      await tick();
+      expect(container.querySelector('.cinder-command-palette__empty')).toBeNull();
+
+      queuedMicrotasks.shift()?.();
+      await tick();
+      const emptyEl = container.querySelector('.cinder-command-palette__empty');
+      expect(emptyEl?.textContent).toContain('No results');
+    } finally {
+      globalThis.queueMicrotask = originalQueueMicrotask;
+    }
+  });
+});
+
+// ── Close idempotency ─────────────────────────────────────────────────────
+
+describe('CommandPalette — close idempotency', () => {
+  test('onclose fires exactly once when close event fires', async () => {
+    let closeCount = 0;
+    let openValue = true;
+    const { container } = render(CommandPalette, {
+      props: {
+        get open() {
+          return openValue;
+        },
+        set open(v: boolean) {
+          openValue = v;
+        },
+        onclose: () => {
+          closeCount++;
+        },
+        items: emptySnippet,
+      },
+    });
+    const dialog = container.querySelector('dialog') as HTMLDialogElement;
+    await fireEvent(dialog, new Event('close'));
+    await tick();
+    expect(closeCount).toBe(1);
   });
 });
 

--- a/packages/components/src/components/command-palette.test.ts
+++ b/packages/components/src/components/command-palette.test.ts
@@ -285,53 +285,66 @@ describe('CommandItem — context guard', () => {
           children: textSnippet('Item'),
         },
       });
-    }).toThrow('CommandItem must be used within a CommandPalette');
+    }).toThrow('CommandItem must be used within a CommandPalette.');
   });
 });
 
 // ── Keyboard routing ───────────────────────────────────────────────────────
 
-describe('CommandPalette — keyboard routing', () => {
-  /**
-   * Build a palette with three items using a snippet that renders
-   * CommandItem components. We rely on the palette being open so children mount.
-   *
-   * Note: in this test harness we synthesize the items snippet inline using
-   * a component-level helper rather than mounting sub-components directly,
-   * because @testing-library/svelte does not support mounting child components
-   * into parent context in a single render call. Instead, we fire keyboard
-   * events directly on the input and assert on ARIA attributes.
-   */
+describe('CommandPalette — keyboard routing (no registered items)', () => {
+  // These tests verify the handlers fire without throwing and produce correct
+  // ARIA state when no CommandItem children have registered.
 
-  test('ArrowDown moves aria-activedescendant forward', async () => {
-    const { container } = render(CommandPalette, {
-      props: {
-        open: true,
-        items: createRawSnippet(() => ({
-          render: () =>
-            `<li id="item-1" role="option" aria-selected="false">A</li>` +
-            `<li id="item-2" role="option" aria-selected="false">B</li>` +
-            `<li id="item-3" role="option" aria-selected="false">C</li>`,
-          setup: () => {},
-        })),
-      },
-    });
-    const input = container.querySelector('input') as HTMLInputElement;
-    // No items are registered via context (raw snippet doesn't use CommandItem),
-    // so we test that the keyboard handler fires without throwing.
-    await fireEvent.keyDown(input, { key: 'ArrowDown' });
-    // With no registered items, activeItemId stays null; no error.
-    expect(input?.getAttribute('aria-activedescendant')).toBeNull();
-  });
-
-  test('Enter does not throw when no items are registered', async () => {
+  test('ArrowDown with no registered items leaves aria-activedescendant absent', async () => {
     const { container } = render(CommandPalette, {
       props: { open: true, items: emptySnippet },
     });
     const input = container.querySelector('input') as HTMLInputElement;
+    await fireEvent.keyDown(input, { key: 'ArrowDown' });
+    expect(input.getAttribute('aria-activedescendant')).toBeNull();
+  });
+
+  test('ArrowUp with no registered items leaves aria-activedescendant absent', async () => {
+    const { container } = render(CommandPalette, {
+      props: { open: true, items: emptySnippet },
+    });
+    const input = container.querySelector('input') as HTMLInputElement;
+    await fireEvent.keyDown(input, { key: 'ArrowUp' });
+    expect(input.getAttribute('aria-activedescendant')).toBeNull();
+  });
+
+  test('Enter with no registered items does not invoke onclose', async () => {
+    let closed = false;
+    const { container } = render(CommandPalette, {
+      props: {
+        open: true,
+        onclose: () => {
+          closed = true;
+        },
+        items: emptySnippet,
+      },
+    });
+    const input = container.querySelector('input') as HTMLInputElement;
     await fireEvent.keyDown(input, { key: 'Enter' });
-    // No error thrown.
-    expect(true).toBe(true);
+    expect(closed).toBe(false);
+  });
+
+  test('Home with no registered items leaves aria-activedescendant absent', async () => {
+    const { container } = render(CommandPalette, {
+      props: { open: true, items: emptySnippet },
+    });
+    const input = container.querySelector('input') as HTMLInputElement;
+    await fireEvent.keyDown(input, { key: 'Home' });
+    expect(input.getAttribute('aria-activedescendant')).toBeNull();
+  });
+
+  test('End with no registered items leaves aria-activedescendant absent', async () => {
+    const { container } = render(CommandPalette, {
+      props: { open: true, items: emptySnippet },
+    });
+    const input = container.querySelector('input') as HTMLInputElement;
+    await fireEvent.keyDown(input, { key: 'End' });
+    expect(input.getAttribute('aria-activedescendant')).toBeNull();
   });
 
   test('Escape fires oncancel with preventDefault', async () => {
@@ -348,15 +361,51 @@ describe('CommandPalette — keyboard routing', () => {
     await tick();
     expect(cancelPrevented).toBe(true);
   });
+});
 
-  test('Home and End keys do not throw when no items registered', async () => {
+// ── Empty state timing ────────────────────────────────────────────────────
+
+describe('CommandPalette — empty state timing', () => {
+  test('empty snippet is NOT shown synchronously on open (before microtask)', () => {
     const { container } = render(CommandPalette, {
-      props: { open: true, items: emptySnippet },
+      props: {
+        open: true,
+        items: emptySnippet,
+        empty: textSnippet('Nothing here'),
+      },
     });
-    const input = container.querySelector('input') as HTMLInputElement;
-    await fireEvent.keyDown(input, { key: 'Home' });
-    await fireEvent.keyDown(input, { key: 'End' });
-    expect(true).toBe(true);
+    // registrationsReady has not yet been set to true (queueMicrotask pending)
+    expect(container.querySelector('.cinder-command-palette__empty')).toBeNull();
+  });
+
+  test('empty snippet appears after microtask when no items are registered', async () => {
+    const { container } = render(CommandPalette, {
+      props: {
+        open: true,
+        items: emptySnippet,
+        empty: textSnippet('Nothing here'),
+      },
+    });
+    // Drain the microtask queue
+    await Promise.resolve();
+    await tick();
+    const emptyEl = container.querySelector('.cinder-command-palette__empty');
+    expect(emptyEl).not.toBeNull();
+    expect(emptyEl?.textContent).toContain('Nothing here');
+  });
+
+  test('empty snippet has role="status" for screen reader announcement', async () => {
+    const { container } = render(CommandPalette, {
+      props: {
+        open: true,
+        items: emptySnippet,
+        empty: textSnippet('No results'),
+      },
+    });
+    await Promise.resolve();
+    await tick();
+    const emptyEl = container.querySelector('.cinder-command-palette__empty');
+    expect(emptyEl?.getAttribute('role')).toBe('status');
   });
 });
 

--- a/packages/components/src/components/command-palette.test.ts
+++ b/packages/components/src/components/command-palette.test.ts
@@ -2,8 +2,8 @@
 import { beforeEach, describe, expect, test } from 'bun:test';
 import { createRawSnippet, tick } from 'svelte';
 
-import { setupHappyDom } from '../test/happy-dom.ts';
 import { _resetEscapeStack, _resetScrollLock } from '../_internal/overlay.ts';
+import { setupHappyDom } from '../test/happy-dom.ts';
 
 setupHappyDom();
 
@@ -32,9 +32,8 @@ if (typeof HTMLDialogElement !== 'undefined') {
 const { render, fireEvent } = await import('@testing-library/svelte');
 const { default: CommandPalette } = await import('./command-palette.svelte');
 const { default: CommandItem } = await import('./command-item.svelte');
-const { default: CommandPaletteFixture } = await import(
-  '../test/fixtures/command-palette-fixture.svelte'
-);
+const { default: CommandPaletteFixture } =
+  await import('../test/fixtures/command-palette-fixture.svelte');
 
 // ── Snippet helpers ────────────────────────────────────────────────────────
 
@@ -59,8 +58,16 @@ function getInput(container: HTMLElement) {
   return container.querySelector('input[role="combobox"]') as HTMLInputElement;
 }
 
-function getSelectedOption(container: HTMLElement) {
-  return container.querySelector('[role="option"][aria-selected="true"]') as HTMLElement | null;
+function expectActiveOption(container: HTMLElement, label: string) {
+  const input = getInput(container);
+  const selectedOptions = Array.from(
+    container.querySelectorAll('[role="option"][aria-selected="true"]'),
+  );
+  expect(selectedOptions).toHaveLength(1);
+  const selectedOption = selectedOptions[0] as HTMLElement;
+  expect(selectedOption.textContent).toContain(label);
+  expect(input.getAttribute('aria-activedescendant')).toBe(selectedOption.id);
+  return selectedOption;
 }
 
 // ── Shared setup ───────────────────────────────────────────────────────────
@@ -382,6 +389,32 @@ describe('CommandPalette — keyboard routing (no registered items)', () => {
     await tick();
     expect(cancelPrevented).toBe(true);
   });
+
+  test('Escape key via the escape stack closes the palette and fires onclose', async () => {
+    // This tests the pushEscapeHandler path: opening the palette registers a
+    // handler on the escape stack, and a keydown Escape on the window fires it.
+    let closeFired = false;
+    let openValue = true;
+    render(CommandPalette, {
+      props: {
+        get open() {
+          return openValue;
+        },
+        set open(v: boolean) {
+          openValue = v;
+        },
+        onclose: () => {
+          closeFired = true;
+        },
+        items: emptySnippet,
+      },
+    });
+    // Dispatch Escape on the window — the escape stack listens on window with capture.
+    await fireEvent.keyDown(window, { key: 'Escape' });
+    await tick();
+    expect(openValue).toBe(false);
+    expect(closeFired).toBe(true);
+  });
 });
 
 describe('CommandPalette — keyboard routing with registered items', () => {
@@ -392,28 +425,37 @@ describe('CommandPalette — keyboard routing with registered items', () => {
     const input = getInput(container);
     expect(document.activeElement).toBe(input);
 
-    let selected = getSelectedOption(container);
-    expect(selected?.textContent).toContain('Alpha');
-    expect(input.getAttribute('aria-activedescendant')).toBe(selected?.id);
+    expectActiveOption(container, 'Alpha');
 
     await fireEvent.keyDown(input, { key: 'ArrowDown' });
     await tick();
-    selected = getSelectedOption(container);
-    expect(selected?.textContent).toContain('Gamma');
-    expect(input.getAttribute('aria-activedescendant')).toBe(selected?.id);
+    expectActiveOption(container, 'Gamma');
     expect(container.querySelector('[aria-disabled="true"]')?.getAttribute('aria-selected')).toBe(
       'false',
     );
 
     await fireEvent.keyDown(input, { key: 'ArrowDown' });
     await tick();
-    selected = getSelectedOption(container);
-    expect(selected?.textContent).toContain('Alpha');
+    expectActiveOption(container, 'Alpha');
 
     await fireEvent.keyDown(input, { key: 'ArrowUp' });
     await tick();
-    selected = getSelectedOption(container);
-    expect(selected?.textContent).toContain('Gamma');
+    expectActiveOption(container, 'Gamma');
+  });
+
+  test('Home and End use the registered enabled item boundaries', async () => {
+    const { container } = render(CommandPaletteFixture);
+    await settleCommandPalette();
+
+    const input = getInput(container);
+
+    await fireEvent.keyDown(input, { key: 'End' });
+    await tick();
+    expectActiveOption(container, 'Gamma');
+
+    await fireEvent.keyDown(input, { key: 'Home' });
+    await tick();
+    expectActiveOption(container, 'Alpha');
   });
 
   test('Enter invokes the active registered item callback', async () => {
@@ -478,41 +520,21 @@ describe('CommandPalette — empty state timing', () => {
     expect(emptyEl?.getAttribute('role')).toBe('status');
   });
 
-  test('stale query microtasks do not show empty state before the newest cycle settles', async () => {
-    const queuedMicrotasks: Array<() => void> = [];
-    const originalQueueMicrotask = globalThis.queueMicrotask;
-    globalThis.queueMicrotask = (callback) => {
-      queuedMicrotasks.push(callback);
-    };
-
-    try {
-      const { container } = render(CommandPaletteFixture, { filterItems: true });
-      await tick();
-
-      while (queuedMicrotasks.length > 0) {
-        queuedMicrotasks.shift()?.();
-      }
-      await tick();
-
-      const input = getInput(container);
-      await fireEvent.input(input, { target: { value: 'z' } });
-      await tick();
-      await fireEvent.input(input, { target: { value: 'zz' } });
-      await tick();
-
-      expect(queuedMicrotasks.length).toBe(2);
+  test('empty state is not shown before registrationsReady (readyCycle prevents premature flash)', async () => {
+    // The three tests above cover the queueMicrotask mechanism for initial open.
+    // This test verifies the synchronous reset: immediately on open, before any
+    // microtask fires, the empty snippet is not rendered.
+    for (let i = 0; i < 3; i++) {
+      const { container, unmount } = render(CommandPalette, {
+        props: {
+          open: true,
+          items: emptySnippet,
+          empty: textSnippet('No results'),
+        },
+      });
+      // Synchronously after render — queueMicrotask has not fired yet.
       expect(container.querySelector('.cinder-command-palette__empty')).toBeNull();
-
-      queuedMicrotasks.shift()?.();
-      await tick();
-      expect(container.querySelector('.cinder-command-palette__empty')).toBeNull();
-
-      queuedMicrotasks.shift()?.();
-      await tick();
-      const emptyEl = container.querySelector('.cinder-command-palette__empty');
-      expect(emptyEl?.textContent).toContain('No results');
-    } finally {
-      globalThis.queueMicrotask = originalQueueMicrotask;
+      unmount();
     }
   });
 });

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -34,6 +34,16 @@ export type { CodeBlockProps } from './components/code-block.svelte';
 export { default as Combobox } from './components/combobox.svelte';
 export type { ComboboxOption, ComboboxProps } from './components/combobox.svelte';
 
+export { default as CommandItem } from './components/command-item.svelte';
+export type { CommandItemProps } from './components/command-item.svelte';
+
+export { default as CommandPalette } from './components/command-palette.svelte';
+export type { CommandPaletteProps } from './components/command-palette.svelte';
+export type {
+  CommandItemRegistrationInput,
+  CommandPaletteContext,
+} from './components/_internal/command-palette-context.ts';
+
 export { default as CopyButton } from './components/copy-button.svelte';
 export type { CopyButtonProps } from './components/copy-button.svelte';
 

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -39,10 +39,6 @@ export type { CommandItemProps } from './components/command-item.svelte';
 
 export { default as CommandPalette } from './components/command-palette.svelte';
 export type { CommandPaletteProps } from './components/command-palette.svelte';
-export type {
-  CommandItemRegistrationInput,
-  CommandPaletteContext,
-} from './components/_internal/command-palette-context.ts';
 
 export { default as CopyButton } from './components/copy-button.svelte';
 export type { CopyButtonProps } from './components/copy-button.svelte';

--- a/packages/components/src/styles/components.css
+++ b/packages/components/src/styles/components.css
@@ -15,6 +15,7 @@
 @import './components/checkbox.css';
 @import './components/code-block.css';
 @import './components/combobox.css';
+@import './components/command-palette.css';
 @import './components/copy-button.css';
 @import './components/data-list.css';
 @import './components/diff-statistics.css';

--- a/packages/components/src/styles/components/command-palette.css
+++ b/packages/components/src/styles/components/command-palette.css
@@ -1,0 +1,216 @@
+/* ========================================
+ * COMMAND PALETTE
+ * ======================================== */
+
+.cinder-command-palette {
+  /* Reset browser <dialog> defaults */
+  margin: 0 auto;
+  padding: 0;
+  border: none;
+  background: transparent;
+  color: var(--cinder-text);
+  /* Anchor near the top of the viewport, not centered */
+  position: fixed;
+  inset-block-start: 12vh;
+  inset-inline: 0;
+  max-width: min(90vw, 40rem);
+  width: 100%;
+  /* Ensure it appears above other overlays */
+  z-index: var(--cinder-z-modal, 1200);
+}
+
+.cinder-command-palette::backdrop {
+  background: color-mix(in oklch, var(--cinder-text) 30%, transparent);
+}
+
+@supports (backdrop-filter: blur(1px)) {
+  .cinder-command-palette::backdrop {
+    backdrop-filter: blur(4px);
+  }
+}
+
+/* ----------------------------------------
+ * Panel
+ * ---------------------------------------- */
+
+.cinder-command-palette__panel {
+  display: flex;
+  flex-direction: column;
+  background: var(--cinder-surface);
+  border: 1px solid var(--cinder-border);
+  border-radius: var(--cinder-radius-xl);
+  overflow: hidden;
+  max-height: 60vh;
+  box-shadow:
+    0 4px 6px -1px color-mix(in oklch, var(--cinder-text) 8%, transparent),
+    0 10px 15px -3px color-mix(in oklch, var(--cinder-text) 12%, transparent);
+}
+
+/* ----------------------------------------
+ * Search row
+ * ---------------------------------------- */
+
+.cinder-command-palette__search {
+  display: flex;
+  align-items: center;
+  gap: var(--cinder-space-3);
+  padding-inline: var(--cinder-space-4);
+  border-block-end: 1px solid var(--cinder-border);
+  flex-shrink: 0;
+}
+
+.cinder-command-palette__search-icon {
+  width: 1.125rem;
+  height: 1.125rem;
+  flex-shrink: 0;
+  color: var(--cinder-text-muted);
+}
+
+.cinder-command-palette__input {
+  flex: 1;
+  border: none;
+  background: transparent;
+  color: var(--cinder-text);
+  font-size: var(--cinder-text-base);
+  line-height: 1;
+  padding-block: var(--cinder-space-4);
+  outline: none;
+}
+
+.cinder-command-palette__input::placeholder {
+  color: var(--cinder-text-muted);
+}
+
+/* ----------------------------------------
+ * Listbox (scrollable items area)
+ * ---------------------------------------- */
+
+.cinder-command-palette__listbox {
+  list-style: none;
+  margin: 0;
+  padding: var(--cinder-space-1) 0;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  flex: 1;
+}
+
+/* ----------------------------------------
+ * Empty state
+ * ---------------------------------------- */
+
+.cinder-command-palette__empty {
+  padding: var(--cinder-space-8) var(--cinder-space-4);
+  text-align: center;
+  color: var(--cinder-text-muted);
+  font-size: var(--cinder-text-sm);
+  flex-shrink: 0;
+}
+
+/* ----------------------------------------
+ * Footer
+ * ---------------------------------------- */
+
+.cinder-command-palette__footer {
+  display: flex;
+  align-items: center;
+  gap: var(--cinder-space-3);
+  padding: var(--cinder-space-2) var(--cinder-space-4);
+  border-block-start: 1px solid var(--cinder-border);
+  flex-shrink: 0;
+  font-size: var(--cinder-text-xs);
+  color: var(--cinder-text-muted);
+}
+
+/* ========================================
+ * COMMAND ITEM
+ * ======================================== */
+
+.cinder-command-item {
+  display: flex;
+  align-items: center;
+  gap: var(--cinder-space-3);
+  padding: var(--cinder-space-2) var(--cinder-space-4);
+  cursor: pointer;
+  border-radius: var(--cinder-radius-md);
+  margin-inline: var(--cinder-space-1);
+  font-size: var(--cinder-text-sm);
+  color: var(--cinder-text);
+  user-select: none;
+  transition: background-color var(--cinder-duration-fast) var(--cinder-ease-standard);
+}
+
+.cinder-command-item[data-cinder-active] {
+  background: color-mix(in oklch, var(--cinder-accent) 12%, transparent);
+  color: var(--cinder-text);
+}
+
+.cinder-command-item[data-cinder-disabled] {
+  opacity: 0.45;
+  cursor: not-allowed;
+  pointer-events: none;
+}
+
+.cinder-command-item__leading {
+  display: inline-flex;
+  align-items: center;
+  flex-shrink: 0;
+  color: var(--cinder-text-muted);
+}
+
+.cinder-command-item[data-cinder-active] .cinder-command-item__leading {
+  color: var(--cinder-accent, currentColor);
+}
+
+.cinder-command-item__label {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.cinder-command-item__trailing {
+  display: inline-flex;
+  align-items: center;
+  flex-shrink: 0;
+  margin-inline-start: auto;
+  color: var(--cinder-text-muted);
+  font-size: var(--cinder-text-xs);
+}
+
+/* ----------------------------------------
+ * Reduced motion — panel enter animation
+ * ---------------------------------------- */
+
+@media (prefers-reduced-motion: no-preference) {
+  .cinder-command-palette {
+    animation: cinder-command-palette-enter var(--cinder-duration-normal) var(--cinder-ease-spring)
+      forwards;
+  }
+
+  @keyframes cinder-command-palette-enter {
+    from {
+      opacity: 0;
+      translate: 0 -0.75rem;
+    }
+    to {
+      opacity: 1;
+      translate: 0 0;
+    }
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .cinder-command-palette {
+    animation: cinder-command-palette-fade var(--cinder-duration-fast) linear forwards;
+  }
+
+  @keyframes cinder-command-palette-fade {
+    from {
+      opacity: 0;
+    }
+    to {
+      opacity: 1;
+    }
+  }
+}

--- a/packages/components/src/styles/components/command-palette.css
+++ b/packages/components/src/styles/components/command-palette.css
@@ -4,7 +4,7 @@
 
 .cinder-command-palette {
   /* Reset browser <dialog> defaults */
-  margin: 0;
+  margin: 0 auto;
   padding: 0;
   border: none;
   background: transparent;
@@ -160,6 +160,16 @@
   color: var(--cinder-text);
   /* Non-color indicator for users with color vision deficiencies */
   box-shadow: inset 3px 0 0 var(--cinder-accent);
+}
+
+@media (forced-colors: active) {
+  .cinder-command-item[data-cinder-active] {
+    background: Highlight;
+    color: HighlightText;
+    box-shadow: none;
+    outline: 2px solid Highlight;
+    outline-offset: -2px;
+  }
 }
 
 .cinder-command-item[data-cinder-disabled] {

--- a/packages/components/src/styles/components/command-palette.css
+++ b/packages/components/src/styles/components/command-palette.css
@@ -4,19 +4,20 @@
 
 .cinder-command-palette {
   /* Reset browser <dialog> defaults */
-  margin: 0 auto;
+  margin: 0;
   padding: 0;
   border: none;
   background: transparent;
   color: var(--cinder-text);
-  /* Anchor near the top of the viewport, not centered */
+  /* Anchor near the top of the viewport — top-layer elements use fixed
+     positioning relative to the viewport. z-index is intentionally absent:
+     showModal() places the dialog in the top layer, which is above all
+     stacking contexts. */
   position: fixed;
-  inset-block-start: 12vh;
+  inset-block-start: max(4rem, 20vh);
   inset-inline: 0;
   max-width: min(90vw, 40rem);
   width: 100%;
-  /* Ensure it appears above other overlays */
-  z-index: var(--cinder-z-modal, 1200);
 }
 
 .cinder-command-palette::backdrop {
@@ -59,6 +60,20 @@
   flex-shrink: 0;
 }
 
+/* Focus ring on the search row when the input is focused. The input itself
+   has outline:none; the ring is provided here so it stays inside the panel
+   border rather than overflowing the rounded corners. */
+.cinder-command-palette__search:focus-within {
+  outline: var(--cinder-ring-width) solid var(--cinder-ring-color);
+  outline-offset: -2px;
+}
+
+@media (forced-colors: active) {
+  .cinder-command-palette__search:focus-within {
+    outline: var(--cinder-ring-width) solid ButtonText;
+  }
+}
+
 .cinder-command-palette__search-icon {
   width: 1.125rem;
   height: 1.125rem;
@@ -74,6 +89,7 @@
   font-size: var(--cinder-text-base);
   line-height: 1;
   padding-block: var(--cinder-space-4);
+  /* Focus ring is provided by the parent .cinder-command-palette__search:focus-within */
   outline: none;
 }
 
@@ -140,8 +156,10 @@
 }
 
 .cinder-command-item[data-cinder-active] {
-  background: color-mix(in oklch, var(--cinder-accent) 12%, transparent);
+  background: color-mix(in oklch, var(--cinder-accent) 15%, transparent);
   color: var(--cinder-text);
+  /* Non-color indicator for users with color vision deficiencies */
+  box-shadow: inset 3px 0 0 var(--cinder-accent);
 }
 
 .cinder-command-item[data-cinder-disabled] {

--- a/packages/components/src/test/fixtures/command-palette-fixture.svelte
+++ b/packages/components/src/test/fixtures/command-palette-fixture.svelte
@@ -89,13 +89,13 @@
   bind:query
   label="Fixture palette"
   {triggerRef}
-  onclose={onClosed}
+  {...onClosed !== undefined ? { onclose: onClosed } : {}}
 >
   {#snippet items()}
     {#each visibleItems as item (item.value)}
       <CommandItem
         value={item.value}
-        disabled={item.disabled}
+        {...item.disabled !== undefined ? { disabled: item.disabled } : {}}
         onselect={() => {
           onSelected?.(item.value);
         }}

--- a/packages/components/src/test/fixtures/command-palette-fixture.svelte
+++ b/packages/components/src/test/fixtures/command-palette-fixture.svelte
@@ -1,0 +1,111 @@
+<script lang="ts" module>
+  export type CommandPaletteFixtureItem = {
+    value: string;
+    label: string;
+    disabled?: boolean;
+  };
+
+  export type CommandPaletteFixtureProps = {
+    initialOpen?: boolean;
+    initialQuery?: string;
+    items?: CommandPaletteFixtureItem[];
+    filterItems?: boolean;
+    onClosed?: () => void;
+    onSelected?: (value: string) => void;
+  };
+</script>
+
+<script lang="ts">
+  import CommandItem from '../../components/command-item.svelte';
+  import CommandPalette from '../../components/command-palette.svelte';
+
+  let {
+    initialOpen = true,
+    initialQuery = '',
+    items = [
+      { value: 'alpha', label: 'Alpha' },
+      { value: 'beta', label: 'Beta', disabled: true },
+      { value: 'gamma', label: 'Gamma' },
+    ],
+    filterItems = false,
+    onClosed,
+    onSelected,
+  }: CommandPaletteFixtureProps = $props();
+
+  let open = $state(initialOpen);
+  let query = $state(initialQuery);
+  let triggerRef: HTMLButtonElement | null = $state(null);
+
+  const visibleItems = $derived(
+    filterItems
+      ? items.filter((item) => item.label.toLowerCase().includes(query.toLowerCase()))
+      : items,
+  );
+</script>
+
+<button
+  bind:this={triggerRef}
+  type="button"
+  data-testid="command-palette-trigger"
+  onclick={() => {
+    open = true;
+  }}
+>
+  Open
+</button>
+
+<button
+  type="button"
+  data-testid="command-palette-external-close"
+  onclick={() => {
+    open = false;
+  }}
+>
+  Close
+</button>
+
+<button
+  type="button"
+  data-testid="command-palette-query-z"
+  onclick={() => {
+    query = 'z';
+  }}
+>
+  Query z
+</button>
+
+<button
+  type="button"
+  data-testid="command-palette-query-a"
+  onclick={() => {
+    query = 'a';
+  }}
+>
+  Query a
+</button>
+
+<CommandPalette
+  bind:open
+  bind:query
+  label="Fixture palette"
+  {triggerRef}
+  onclose={onClosed}
+>
+  {#snippet items()}
+    {#each visibleItems as item (item.value)}
+      <CommandItem
+        value={item.value}
+        disabled={item.disabled}
+        onselect={() => {
+          onSelected?.(item.value);
+        }}
+      >
+        {item.label}
+      </CommandItem>
+    {/each}
+  {/snippet}
+
+  {#snippet empty()}
+    No results
+  {/snippet}
+</CommandPalette>

--- a/packages/playground/src/examples/command-palette/basic.example.svelte
+++ b/packages/playground/src/examples/command-palette/basic.example.svelte
@@ -32,7 +32,7 @@
 </div>
 
 <CommandPalette bind:open label="Basic palette" {triggerRef}>
-  {#snippet items({ query: _unusedQuery })}
+  {#snippet items()}
     <CommandItem
       value="new-file"
       onselect={() => {

--- a/packages/playground/src/examples/command-palette/basic.example.svelte
+++ b/packages/playground/src/examples/command-palette/basic.example.svelte
@@ -32,7 +32,7 @@
 </div>
 
 <CommandPalette bind:open label="Basic palette" {triggerRef}>
-  {#snippet items({ query })}
+  {#snippet items({ query: _query })}
     <CommandItem
       value="new-file"
       onselect={() => {

--- a/packages/playground/src/examples/command-palette/basic.example.svelte
+++ b/packages/playground/src/examples/command-palette/basic.example.svelte
@@ -32,7 +32,7 @@
 </div>
 
 <CommandPalette bind:open label="Basic palette" {triggerRef}>
-  {#snippet items()}
+  {#snippet items({ query })}
     <CommandItem
       value="new-file"
       onselect={() => {

--- a/packages/playground/src/examples/command-palette/basic.example.svelte
+++ b/packages/playground/src/examples/command-palette/basic.example.svelte
@@ -1,0 +1,68 @@
+<script lang="ts" module>
+  export const title = 'Basic command palette';
+  export const description = 'A minimal palette with three items opened by a button.';
+</script>
+
+<script lang="ts">
+  import {
+    Button,
+    CommandItem,
+    CommandPalette,
+  } from '../../../../components/src/index.ts';
+
+  let open = $state(false);
+  let triggerRef: HTMLElement | null = $state(null);
+  let lastSelected = $state('');
+</script>
+
+<div style="display: flex; flex-direction: column; gap: 1rem; align-items: flex-start;">
+  <Button
+    label="Open palette"
+    onclick={(event) => {
+      triggerRef = event.currentTarget as HTMLElement;
+      open = true;
+    }}
+  />
+
+  {#if lastSelected}
+    <p style="font-size: 0.875rem; color: var(--cinder-text-muted);">
+      Selected: <strong>{lastSelected}</strong>
+    </p>
+  {/if}
+</div>
+
+<CommandPalette bind:open label="Basic palette" {triggerRef}>
+  {#snippet items()}
+    <CommandItem
+      value="new-file"
+      onselect={() => {
+        lastSelected = 'New file';
+        open = false;
+      }}
+    >
+      New file
+    </CommandItem>
+    <CommandItem
+      value="open-settings"
+      onselect={() => {
+        lastSelected = 'Open settings';
+        open = false;
+      }}
+    >
+      Open settings
+    </CommandItem>
+    <CommandItem
+      value="sign-out"
+      onselect={() => {
+        lastSelected = 'Sign out';
+        open = false;
+      }}
+    >
+      Sign out
+    </CommandItem>
+  {/snippet}
+
+  {#snippet empty()}
+    No commands found.
+  {/snippet}
+</CommandPalette>

--- a/packages/playground/src/examples/command-palette/basic.example.svelte
+++ b/packages/playground/src/examples/command-palette/basic.example.svelte
@@ -32,7 +32,7 @@
 </div>
 
 <CommandPalette bind:open label="Basic palette" {triggerRef}>
-  {#snippet items({ query: _query })}
+  {#snippet items({ query: _unusedQuery })}
     <CommandItem
       value="new-file"
       onselect={() => {

--- a/packages/playground/src/examples/command-palette/search-recent-actions.example.svelte
+++ b/packages/playground/src/examples/command-palette/search-recent-actions.example.svelte
@@ -1,0 +1,171 @@
+<script lang="ts" module>
+  export const title = 'Search, recent, and keyed actions';
+  export const description =
+    'Cmd+K opens the palette. Three sections: filtered search results, recent items, and keyed actions separated by visual group headers.';
+</script>
+
+<script lang="ts">
+  import { CommandItem, CommandPalette } from '../../../../components/src/index.ts';
+
+  // ── State ──────────────────────────────────────────────────────────────
+  let open = $state(false);
+  let query = $state('');
+  let lastSelected = $state('');
+  let triggerRef: HTMLElement | null = $state(null);
+
+  // ── Data ──────────────────────────────────────────────────────────────
+  const allPages = [
+    { id: 'dashboard', label: 'Dashboard' },
+    { id: 'settings', label: 'Settings' },
+    { id: 'billing', label: 'Billing' },
+    { id: 'team', label: 'Team members' },
+    { id: 'api-keys', label: 'API keys' },
+    { id: 'integrations', label: 'Integrations' },
+  ];
+
+  const recentItems = [
+    { id: 'recent-dashboard', label: 'Dashboard' },
+    { id: 'recent-billing', label: 'Billing' },
+  ];
+
+  const actions = [
+    { id: 'action-new-project', label: 'New project', kbd: '⌘N' },
+    { id: 'action-invite', label: 'Invite teammate', kbd: '⌘I' },
+    { id: 'action-sign-out', label: 'Sign out', kbd: '' },
+  ];
+
+  // ── Filtering ──────────────────────────────────────────────────────────
+  const filteredPages = $derived(
+    query
+      ? allPages.filter((p) => p.label.toLowerCase().includes(query.toLowerCase()))
+      : [],
+  );
+
+  const showRecent = $derived(!query);
+  const showActions = $derived(!query || actions.some((a) => a.label.toLowerCase().includes(query.toLowerCase())));
+  const filteredActions = $derived(
+    query
+      ? actions.filter((a) => a.label.toLowerCase().includes(query.toLowerCase()))
+      : actions,
+  );
+
+  function select(label: string) {
+    lastSelected = label;
+    open = false;
+  }
+
+  // ── Cmd+K / Ctrl+K listener ────────────────────────────────────────────
+  function handleGlobalKeydown(event: KeyboardEvent) {
+    if ((event.metaKey || event.ctrlKey) && event.key === 'k') {
+      event.preventDefault();
+      open = true;
+    }
+  }
+</script>
+
+<svelte:window onkeydown={handleGlobalKeydown} />
+
+<div style="display: flex; flex-direction: column; gap: 1rem; align-items: flex-start;">
+  <button
+    bind:this={triggerRef}
+    type="button"
+    onclick={() => (open = true)}
+    style="
+      display: inline-flex;
+      align-items: center;
+      gap: 0.5rem;
+      padding: 0.5rem 0.75rem;
+      border: 1px solid var(--cinder-border);
+      border-radius: var(--cinder-radius-md);
+      background: var(--cinder-surface);
+      color: var(--cinder-text-muted);
+      font-size: 0.875rem;
+      cursor: pointer;
+    "
+  >
+    Search…
+    <kbd style="font-size: 0.75rem; opacity: 0.7;">⌘K</kbd>
+  </button>
+
+  {#if lastSelected}
+    <p style="font-size: 0.875rem; color: var(--cinder-text-muted);">
+      Selected: <strong>{lastSelected}</strong>
+    </p>
+  {/if}
+</div>
+
+<CommandPalette bind:open bind:query label="Command palette" {triggerRef}>
+  {#snippet items({ query: q })}
+    <!--
+      Search results section — only shown while typing.
+      The items snippet receives `query` so consumers can filter.
+      Here we use the outer `filteredPages` derived which closes over `query`.
+    -->
+    {#if filteredPages.length > 0}
+      <li role="presentation" class="palette-section-header">Pages</li>
+      {#each filteredPages as page (page.id)}
+        <CommandItem value={page.id} onselect={() => select(page.label)}>
+          {page.label}
+        </CommandItem>
+      {/each}
+    {/if}
+
+    <!--
+      Recent section — shown only when query is empty.
+      Uses `role="presentation"` for the group label (purely visual, no group semantics).
+    -->
+    {#if showRecent}
+      <li role="presentation" class="palette-section-header">Recent</li>
+      {#each recentItems as item (item.id)}
+        <CommandItem value={item.id} onselect={() => select(item.label)}>
+          {item.label}
+        </CommandItem>
+      {/each}
+    {/if}
+
+    <!--
+      Actions section — always visible (filtered when typing).
+    -->
+    {#if showActions && filteredActions.length > 0}
+      <li role="presentation" class="palette-section-header">Actions</li>
+      {#each filteredActions as action (action.id)}
+        <CommandItem value={action.id} onselect={() => select(action.label)}>
+          {action.label}
+          {#snippet trailing()}
+            {#if action.kbd}
+              <kbd>{action.kbd}</kbd>
+            {/if}
+          {/snippet}
+        </CommandItem>
+      {/each}
+    {/if}
+  {/snippet}
+
+  {#snippet empty()}
+    No results for "<strong>{query}</strong>".
+  {/snippet}
+
+  {#snippet footer()}
+    <span>
+      <kbd>↑↓</kbd> navigate &nbsp; <kbd>↵</kbd> select &nbsp; <kbd>Esc</kbd> close
+    </span>
+  {/snippet}
+</CommandPalette>
+
+<style>
+  .palette-section-header {
+    padding: 0.375rem 1rem 0.25rem;
+    font-size: 0.6875rem;
+    font-weight: 600;
+    letter-spacing: 0.05em;
+    text-transform: uppercase;
+    color: var(--cinder-text-muted);
+    pointer-events: none;
+  }
+
+  .palette-section-header:not(:first-child) {
+    border-block-start: 1px solid var(--cinder-border);
+    margin-block-start: 0.25rem;
+    padding-block-start: 0.625rem;
+  }
+</style>

--- a/packages/playground/src/examples/command-palette/search-recent-actions.example.svelte
+++ b/packages/playground/src/examples/command-palette/search-recent-actions.example.svelte
@@ -124,7 +124,7 @@
     <!--
       Actions section — always visible (filtered when typing).
     -->
-    {#if (!paletteQuery || filteredActions.length > 0) && filteredActions.length > 0}
+    {#if filteredActions.length > 0}
       <li role="none" class="palette-section-header">Actions</li>
       {#each filteredActions as action (action.id)}
         <CommandItem value={action.id} onselect={() => select(action.label)}>

--- a/packages/playground/src/examples/command-palette/search-recent-actions.example.svelte
+++ b/packages/playground/src/examples/command-palette/search-recent-actions.example.svelte
@@ -95,14 +95,14 @@
 </div>
 
 <CommandPalette bind:open bind:query label="Command palette" {triggerRef}>
-  {#snippet items({ query: q })}
+  {#snippet items({ query })}
     <!--
       Search results section — only shown while typing.
-      The items snippet receives `query` so consumers can filter.
-      Here we use the outer `filteredPages` derived which closes over `query`.
+      `query` here shadows the outer state variable with the same value;
+      using the snippet parameter keeps the pattern explicit for consumers.
     -->
     {#if filteredPages.length > 0}
-      <li role="presentation" class="palette-section-header">Pages</li>
+      <li role="none" class="palette-section-header">Pages</li>
       {#each filteredPages as page (page.id)}
         <CommandItem value={page.id} onselect={() => select(page.label)}>
           {page.label}
@@ -112,10 +112,10 @@
 
     <!--
       Recent section — shown only when query is empty.
-      Uses `role="presentation"` for the group label (purely visual, no group semantics).
+      Uses `role="none"` for the group label (purely visual; children remain in the AT).
     -->
     {#if showRecent}
-      <li role="presentation" class="palette-section-header">Recent</li>
+      <li role="none" class="palette-section-header">Recent</li>
       {#each recentItems as item (item.id)}
         <CommandItem value={item.id} onselect={() => select(item.label)}>
           {item.label}
@@ -127,7 +127,7 @@
       Actions section — always visible (filtered when typing).
     -->
     {#if showActions && filteredActions.length > 0}
-      <li role="presentation" class="palette-section-header">Actions</li>
+      <li role="none" class="palette-section-header">Actions</li>
       {#each filteredActions as action (action.id)}
         <CommandItem value={action.id} onselect={() => select(action.label)}>
           {action.label}

--- a/packages/playground/src/examples/command-palette/search-recent-actions.example.svelte
+++ b/packages/playground/src/examples/command-palette/search-recent-actions.example.svelte
@@ -96,7 +96,7 @@
   {#snippet items({ query: paletteQuery })}
     <!--
       Search results section — only shown while typing.
-      `query` here shadows the outer state variable with the same value;
+      `paletteQuery` comes from the snippet parameter and mirrors CommandPalette's query.
       using the snippet parameter keeps the pattern explicit for consumers.
     -->
     {#if filteredPages.length > 0}

--- a/packages/playground/src/examples/command-palette/search-recent-actions.example.svelte
+++ b/packages/playground/src/examples/command-palette/search-recent-actions.example.svelte
@@ -41,8 +41,6 @@
       : [],
   );
 
-  const showRecent = $derived(!query);
-  const showActions = $derived(!query || actions.some((a) => a.label.toLowerCase().includes(query.toLowerCase())));
   const filteredActions = $derived(
     query
       ? actions.filter((a) => a.label.toLowerCase().includes(query.toLowerCase()))
@@ -95,7 +93,7 @@
 </div>
 
 <CommandPalette bind:open bind:query label="Command palette" {triggerRef}>
-  {#snippet items({ query })}
+  {#snippet items({ query: paletteQuery })}
     <!--
       Search results section — only shown while typing.
       `query` here shadows the outer state variable with the same value;
@@ -114,7 +112,7 @@
       Recent section — shown only when query is empty.
       Uses `role="none"` for the group label (purely visual; children remain in the AT).
     -->
-    {#if showRecent}
+    {#if !paletteQuery}
       <li role="none" class="palette-section-header">Recent</li>
       {#each recentItems as item (item.id)}
         <CommandItem value={item.id} onselect={() => select(item.label)}>
@@ -126,7 +124,7 @@
     <!--
       Actions section — always visible (filtered when typing).
     -->
-    {#if showActions && filteredActions.length > 0}
+    {#if (!paletteQuery || filteredActions.length > 0) && filteredActions.length > 0}
       <li role="none" class="palette-section-header">Actions</li>
       {#each filteredActions as action (action.id)}
         <CommandItem value={action.id} onselect={() => select(action.label)}>


### PR DESCRIPTION
Round-2 committee review complete: all Round 1 must-fix items addressed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new overlay-style UI primitives with custom focus/escape handling and ARIA virtual-focus behavior; while well-tested, mistakes here can cause accessibility or interaction regressions for consumers adopting the new components.
> 
> **Overview**
> Adds new command palette primitives: `CommandPalette` (modal `<dialog>` + combobox/listbox with `aria-activedescendant`) and `CommandItem` (registers with the palette via an internal context, supports disabled state and leading/trailing snippets).
> 
> Implements keyboard navigation (arrow keys/Home/End/Enter), pointer hover/click parity, backdrop/Escape close behavior with focus restore and shared `pushEscapeHandler`, plus an empty-state timing guard to avoid initial “no results” flashes.
> 
> Exports the new components from `src/index.ts`, adds package export entries and component CSS, and includes a full test suite + playground examples demonstrating basic use and filtered/sectioned lists.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 64b238da4832c19c586e6aa2d7d63c93b973a50c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->