### PR TITLE
feat(components): add SortableList with keyboard-first drag-and-drop reorder

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -213,6 +213,10 @@
       "svelte": "./src/components/skeleton.svelte",
       "types": "./dist/components/skeleton.svelte.d.ts"
     },
+    "./sortable-list": {
+      "svelte": "./src/components/sortable-list.svelte",
+      "types": "./dist/components/sortable-list.svelte.d.ts"
+    },
     "./spinner": {
       "svelte": "./src/components/spinner.svelte",
       "types": "./dist/components/spinner.svelte.d.ts"

--- a/packages/components/src/components/_sortable-item.svelte
+++ b/packages/components/src/components/_sortable-item.svelte
@@ -257,6 +257,32 @@
     }
   }
 
+  // Observe controller state: if the controller transitions to idle while a pointer
+  // session is active on this item (e.g., window Escape handler cancels from outside),
+  // clean up local pointer bookkeeping without calling context.cancel() again.
+  $effect(() => {
+    if (!pointerActive) return;
+    if (context.controller.phase === 'idle') {
+      // Controller was cancelled externally. Release capture and stop rAFs.
+      if (moveRafHandle !== null) {
+        cancelAnimationFrame(moveRafHandle);
+        moveRafHandle = null;
+      }
+      if (scrollRafHandle !== null) {
+        cancelAnimationFrame(scrollRafHandle);
+        scrollRafHandle = null;
+      }
+      if (pointerId !== null && handleEl?.hasPointerCapture(pointerId)) {
+        try {
+          handleEl.releasePointerCapture(pointerId);
+        } catch {}
+      }
+      pointerActive = false;
+      pointerId = null;
+      listEl = null;
+    }
+  });
+
   // Cleanup on component destroy (e.g., parent removes item mid-lift).
   $effect(() => {
     return () => {

--- a/packages/components/src/components/_sortable-item.svelte
+++ b/packages/components/src/components/_sortable-item.svelte
@@ -183,6 +183,11 @@
         recomputeTarget();
       });
     }
+    // Restart auto-scroll loop if it has stopped (e.g. pointer entered edge zone
+    // after starting from the middle of the page).
+    if (scrollRafHandle === null) {
+      scheduleAutoScroll();
+    }
   }
 
   function handlePointerUp(_event: PointerEvent): void {

--- a/packages/components/src/components/_sortable-item.svelte
+++ b/packages/components/src/components/_sortable-item.svelte
@@ -1,0 +1,299 @@
+<script lang="ts" module>
+  import type { Snippet } from 'svelte';
+  import type { SortableItemContext } from '../utilities/sortable-controller.svelte.ts';
+
+  /** Internal props for SortableItem — not part of the public package API. */
+  export type SortableItemProps<Item> = {
+    item: Item;
+    itemKey: string | number;
+    index: number;
+    itemLabel: string;
+    formatHandleLabel: (itemLabel: string) => string;
+    children: Snippet<[SortableItemContext]>;
+    handle?: Snippet<[{ pressed: boolean; label: string }]>;
+    instructionsId: string;
+    total: number;
+    class?: string;
+  };
+</script>
+
+<script lang="ts" generics="Item">
+  import { getSortableContext } from '../utilities/sortable-controller.svelte.ts';
+  import { useId } from '../utilities/use-id.ts';
+  import { cn } from '../utilities/class-names.ts';
+
+  let {
+    item: _item,
+    itemKey,
+    index,
+    itemLabel,
+    formatHandleLabel,
+    children,
+    handle,
+    instructionsId,
+    total,
+    class: className,
+  }: SortableItemProps<Item> = $props();
+
+  const context = getSortableContext();
+
+  // Stable internal row id for pointer midpoint calculations.
+  const rowId = useId('cinder-sortable-row');
+
+  let handleEl = $state<HTMLButtonElement | null>(null);
+
+  // Pointer session state — instance-local, never module-scope.
+  let pointerActive = $state(false);
+  let pointerId = $state<number | null>(null);
+  let rafHandle = $state<number | null>(null);
+  let latestPointerY = $state(0);
+  let listEl = $state<HTMLElement | null>(null);
+
+  const isLifted = $derived(
+    context.controller.phase === 'lifted' && context.controller.liftedKey === itemKey,
+  );
+
+  const isDropTarget = $derived(
+    context.controller.phase === 'lifted' && context.controller.liftedTo === index,
+  );
+
+  const itemContext: SortableItemContext = {
+    get isLifted() {
+      return isLifted;
+    },
+    get isDropTarget() {
+      return isDropTarget;
+    },
+    get visualIndex() {
+      return index;
+    },
+    get total() {
+      return total;
+    },
+  };
+
+  const handleLabel = $derived(formatHandleLabel(itemLabel));
+
+  function endPointerSession(reason: 'drop' | 'cancel'): void {
+    if (rafHandle !== null) {
+      cancelAnimationFrame(rafHandle);
+      rafHandle = null;
+    }
+
+    if (pointerId !== null && handleEl?.hasPointerCapture(pointerId)) {
+      try {
+        handleEl.releasePointerCapture(pointerId);
+      } catch {
+        // Browser may have already revoked capture (common on pointercancel).
+      }
+    }
+
+    pointerActive = false;
+    pointerId = null;
+
+    if (reason === 'drop') {
+      context.commitDrop(itemKey, itemLabel);
+    } else {
+      context.cancel(itemLabel);
+    }
+  }
+
+  function scheduleAutoScroll(): void {
+    if (!pointerActive) return;
+
+    const SCROLL_ZONE = 32;
+    const SCROLL_SPEED = 8;
+    const viewportHeight = window.innerHeight;
+
+    rafHandle = requestAnimationFrame(() => {
+      rafHandle = null;
+      if (!pointerActive) return;
+
+      if (latestPointerY < SCROLL_ZONE) {
+        window.scrollBy(0, -SCROLL_SPEED);
+        recomputeTarget();
+        scheduleAutoScroll();
+      } else if (latestPointerY > viewportHeight - SCROLL_ZONE) {
+        window.scrollBy(0, SCROLL_SPEED);
+        recomputeTarget();
+        scheduleAutoScroll();
+      }
+    });
+  }
+
+  function recomputeTarget(): void {
+    if (!listEl || !pointerActive) return;
+
+    const rows = Array.from(listEl.querySelectorAll<HTMLElement>('[data-sortable-row]'));
+    const nonLifted = rows.filter((r) => r.dataset['rowId'] !== String(rowId));
+    const midpoints = nonLifted.map((r) => {
+      const rect = r.getBoundingClientRect();
+      return rect.top + rect.height / 2;
+    });
+    const insertionIndex = midpoints.filter((m) => m < latestPointerY).length;
+    const target = Math.max(0, Math.min(insertionIndex, total - 1));
+
+    context.move(target, itemLabel, total);
+  }
+
+  function handlePointerDown(event: PointerEvent): void {
+    // Only primary button (left click / touch).
+    if (event.button !== 0 && event.pointerType === 'mouse') return;
+    if (!handleEl) return;
+
+    // Find the list element for later DOM queries.
+    listEl = handleEl.closest('.cinder-sortable-list') as HTMLElement | null;
+
+    event.preventDefault();
+    pointerActive = true;
+    pointerId = event.pointerId;
+    latestPointerY = event.clientY;
+
+    handleEl.setPointerCapture(event.pointerId);
+    context.lift(itemKey, index, itemLabel, total);
+    scheduleAutoScroll();
+  }
+
+  function handlePointerMove(event: PointerEvent): void {
+    if (!pointerActive) return;
+    latestPointerY = event.clientY;
+    recomputeTarget();
+  }
+
+  function handlePointerUp(_event: PointerEvent): void {
+    if (!pointerActive) return;
+    endPointerSession('drop');
+  }
+
+  function handlePointerCancel(_event: PointerEvent): void {
+    if (!pointerActive) return;
+    endPointerSession('cancel');
+  }
+
+  function handleKeyDown(event: KeyboardEvent): void {
+    const { key } = event;
+
+    if (!isLifted) {
+      if (key === ' ' || key === 'Enter') {
+        event.preventDefault();
+        context.lift(itemKey, index, itemLabel, total);
+      }
+      return;
+    }
+
+    switch (key) {
+      case ' ':
+      case 'Enter':
+        event.preventDefault();
+        if (pointerActive) {
+          endPointerSession('drop');
+        } else {
+          context.commitDrop(itemKey, itemLabel);
+        }
+        break;
+
+      case 'ArrowDown':
+        event.preventDefault();
+        context.move(context.controller.liftedTo + 1, itemLabel, total);
+        break;
+
+      case 'ArrowUp':
+        event.preventDefault();
+        context.move(context.controller.liftedTo - 1, itemLabel, total);
+        break;
+
+      case 'Home':
+        event.preventDefault();
+        context.move(0, itemLabel, total);
+        break;
+
+      case 'End':
+        event.preventDefault();
+        context.move(total - 1, itemLabel, total);
+        break;
+
+      case 'Escape':
+        event.preventDefault();
+        context.cancel(itemLabel);
+        break;
+
+      case 'Tab':
+        // Cancel but allow native focus movement.
+        context.cancel(itemLabel);
+        break;
+    }
+  }
+
+  // Cleanup on component destroy (e.g., parent removes item mid-lift).
+  $effect(() => {
+    return () => {
+      if (!pointerActive) return;
+
+      if (context.controller.phase === 'lifted' && context.controller.liftedKey === itemKey) {
+        // Full cancel — stops auto-scroll, releases capture, announces cancelled.
+        endPointerSession('cancel');
+      } else {
+        // Controller already auto-cancelled; only do local cleanup.
+        if (rafHandle !== null) {
+          cancelAnimationFrame(rafHandle);
+          rafHandle = null;
+        }
+        if (pointerId !== null && handleEl?.hasPointerCapture(pointerId)) {
+          try {
+            handleEl.releasePointerCapture(pointerId);
+          } catch {
+            // Already revoked.
+          }
+        }
+        pointerActive = false;
+        pointerId = null;
+      }
+    };
+  });
+</script>
+
+<li
+  data-sortable-row
+  data-key={itemKey}
+  data-row-id={rowId}
+  aria-roledescription="sortable item"
+  class={cn(
+    'cinder-sortable-item',
+    isLifted && 'cinder-sortable-item--lifted',
+    !isLifted && context.controller.phase === 'lifted' && 'cinder-sortable-item--shifting',
+    className,
+  )}
+>
+  {@render children(itemContext)}
+
+  <button
+    bind:this={handleEl}
+    type="button"
+    class="cinder-sortable-handle"
+    aria-label={handleLabel}
+    aria-pressed={isLifted}
+    aria-describedby={instructionsId}
+    onkeydown={handleKeyDown}
+    onpointerdown={handlePointerDown}
+    onpointermove={handlePointerMove}
+    onpointerup={handlePointerUp}
+    onpointercancel={handlePointerCancel}
+  >
+    {#if handle}
+      {@render handle({ pressed: isLifted, label: handleLabel })}
+    {:else}
+      <!-- Default drag handle icon (grip lines) -->
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        width="16"
+        height="16"
+        viewBox="0 0 16 16"
+        fill="currentColor"
+        aria-hidden="true"
+        focusable="false"
+      >
+        <path d="M2 4h12v1.5H2zM2 7.25h12v1.5H2zM2 10.5h12v1.5H2z" />
+      </svg>
+    {/if}
+  </button>
+</li>

--- a/packages/components/src/components/_sortable-item.svelte
+++ b/packages/components/src/components/_sortable-item.svelte
@@ -50,7 +50,9 @@
   // drive template rendering or $derived expressions; they are bookkeeping only.
   let pointerActive = false;
   let pointerId: number | null = null;
-  let rafHandle: number | null = null;
+  // Two separate rAF handles so move-recompute and auto-scroll don't compete.
+  let moveRafHandle: number | null = null;
+  let scrollRafHandle: number | null = null;
   let latestPointerY = 0;
   let listEl: HTMLElement | null = null;
 
@@ -80,9 +82,13 @@
   const handleLabel = $derived(formatHandleLabel(itemLabel));
 
   function endPointerSession(reason: 'drop' | 'cancel'): void {
-    if (rafHandle !== null) {
-      cancelAnimationFrame(rafHandle);
-      rafHandle = null;
+    if (moveRafHandle !== null) {
+      cancelAnimationFrame(moveRafHandle);
+      moveRafHandle = null;
+    }
+    if (scrollRafHandle !== null) {
+      cancelAnimationFrame(scrollRafHandle);
+      scrollRafHandle = null;
     }
 
     if (pointerId !== null && handleEl?.hasPointerCapture(pointerId)) {
@@ -95,6 +101,7 @@
 
     pointerActive = false;
     pointerId = null;
+    listEl = null;
 
     if (reason === 'drop') {
       context.commitDrop(itemKey, itemLabel);
@@ -110,12 +117,14 @@
     const SCROLL_SPEED = 8;
     const viewportHeight = window.innerHeight;
 
-    rafHandle = requestAnimationFrame(() => {
-      rafHandle = null;
+    scrollRafHandle = requestAnimationFrame(() => {
+      scrollRafHandle = null;
       if (!pointerActive) return;
 
       if (latestPointerY < SCROLL_ZONE) {
         window.scrollBy(0, -SCROLL_SPEED);
+        // getBoundingClientRect forces a layout flush after scrollBy — intentional,
+        // so midpoints reflect the post-scroll positions.
         recomputeTarget();
         scheduleAutoScroll();
       } else if (latestPointerY > viewportHeight - SCROLL_ZONE) {
@@ -144,6 +153,8 @@
   }
 
   function handlePointerDown(event: PointerEvent): void {
+    // Ignore re-entry while already tracking a drag (e.g., second touch point).
+    if (pointerActive) return;
     // Only primary button (left click / touch).
     if (event.button !== 0 && event.pointerType === 'mouse') return;
     if (!handleEl) return;
@@ -165,9 +176,10 @@
     if (!pointerActive) return;
     latestPointerY = event.clientY;
     // Gate DOM reads to one per animation frame to avoid layout thrash on every event.
-    if (rafHandle === null) {
-      rafHandle = requestAnimationFrame(() => {
-        rafHandle = null;
+    // Uses a separate handle from scrollRafHandle so auto-scroll and move don't compete.
+    if (moveRafHandle === null) {
+      moveRafHandle = requestAnimationFrame(() => {
+        moveRafHandle = null;
         recomputeTarget();
       });
     }
@@ -227,12 +239,20 @@
 
       case 'Escape':
         event.preventDefault();
-        context.cancel(itemLabel);
+        if (pointerActive) {
+          endPointerSession('cancel');
+        } else {
+          context.cancel(itemLabel);
+        }
         break;
 
       case 'Tab':
         // Cancel but allow native focus movement.
-        context.cancel(itemLabel);
+        if (pointerActive) {
+          endPointerSession('cancel');
+        } else {
+          context.cancel(itemLabel);
+        }
         break;
     }
   }
@@ -243,13 +263,17 @@
       if (!pointerActive) return;
 
       if (context.controller.phase === 'lifted' && context.controller.liftedKey === itemKey) {
-        // Full cancel — stops auto-scroll, releases capture, announces cancelled.
+        // Full cancel — stops rAFs, releases capture, announces cancelled.
         endPointerSession('cancel');
       } else {
         // Controller already auto-cancelled; only do local cleanup.
-        if (rafHandle !== null) {
-          cancelAnimationFrame(rafHandle);
-          rafHandle = null;
+        if (moveRafHandle !== null) {
+          cancelAnimationFrame(moveRafHandle);
+          moveRafHandle = null;
+        }
+        if (scrollRafHandle !== null) {
+          cancelAnimationFrame(scrollRafHandle);
+          scrollRafHandle = null;
         }
         if (pointerId !== null && handleEl?.hasPointerCapture(pointerId)) {
           try {
@@ -260,6 +284,7 @@
         }
         pointerActive = false;
         pointerId = null;
+        listEl = null;
       }
     };
   });

--- a/packages/components/src/components/_sortable-item.svelte
+++ b/packages/components/src/components/_sortable-item.svelte
@@ -4,6 +4,10 @@
 
   /** Internal props for SortableItem — not part of the public package API. */
   export type SortableItemProps<Item> = {
+    /**
+     * The item being rendered. Accepted for generic type symmetry with the parent's
+     * snippet, but not read directly — the component uses itemKey and itemLabel instead.
+     */
     item: Item;
     itemKey: string | number;
     index: number;
@@ -42,12 +46,13 @@
 
   let handleEl = $state<HTMLButtonElement | null>(null);
 
-  // Pointer session state — instance-local, never module-scope.
-  let pointerActive = $state(false);
-  let pointerId = $state<number | null>(null);
-  let rafHandle = $state<number | null>(null);
-  let latestPointerY = $state(0);
-  let listEl = $state<HTMLElement | null>(null);
+  // Pointer session state — plain let (not $state) since these values do not
+  // drive template rendering or $derived expressions; they are bookkeeping only.
+  let pointerActive = false;
+  let pointerId: number | null = null;
+  let rafHandle: number | null = null;
+  let latestPointerY = 0;
+  let listEl: HTMLElement | null = null;
 
   const isLifted = $derived(
     context.controller.phase === 'lifted' && context.controller.liftedKey === itemKey,
@@ -124,7 +129,9 @@
   function recomputeTarget(): void {
     if (!listEl || !pointerActive) return;
 
-    const rows = Array.from(listEl.querySelectorAll<HTMLElement>('[data-sortable-row]'));
+    // :scope > limits to direct children of the list — avoids picking up nested sortable rows
+    const rows = Array.from(listEl.querySelectorAll<HTMLElement>(':scope > [data-sortable-row]'));
+    // data-row-id → dataset.rowId via DOM camelCase conversion
     const nonLifted = rows.filter((r) => r.dataset['rowId'] !== String(rowId));
     const midpoints = nonLifted.map((r) => {
       const rect = r.getBoundingClientRect();
@@ -157,7 +164,13 @@
   function handlePointerMove(event: PointerEvent): void {
     if (!pointerActive) return;
     latestPointerY = event.clientY;
-    recomputeTarget();
+    // Gate DOM reads to one per animation frame to avoid layout thrash on every event.
+    if (rafHandle === null) {
+      rafHandle = requestAnimationFrame(() => {
+        rafHandle = null;
+        recomputeTarget();
+      });
+    }
   }
 
   function handlePointerUp(_event: PointerEvent): void {

--- a/packages/components/src/components/_sortable-item.svelte
+++ b/packages/components/src/components/_sortable-item.svelte
@@ -260,27 +260,29 @@
   // Observe controller state: if the controller transitions to idle while a pointer
   // session is active on this item (e.g., window Escape handler cancels from outside),
   // clean up local pointer bookkeeping without calling context.cancel() again.
+  //
+  // Read phase first so this effect always tracks controller.phase as a reactive
+  // dependency — pointerActive is a plain `let` and does not create a dependency.
   $effect(() => {
-    if (!pointerActive) return;
-    if (context.controller.phase === 'idle') {
-      // Controller was cancelled externally. Release capture and stop rAFs.
-      if (moveRafHandle !== null) {
-        cancelAnimationFrame(moveRafHandle);
-        moveRafHandle = null;
-      }
-      if (scrollRafHandle !== null) {
-        cancelAnimationFrame(scrollRafHandle);
-        scrollRafHandle = null;
-      }
-      if (pointerId !== null && handleEl?.hasPointerCapture(pointerId)) {
-        try {
-          handleEl.releasePointerCapture(pointerId);
-        } catch {}
-      }
-      pointerActive = false;
-      pointerId = null;
-      listEl = null;
+    const phase = context.controller.phase;
+    if (!pointerActive || phase !== 'idle') return;
+    // Controller was cancelled externally. Release capture and stop rAFs.
+    if (moveRafHandle !== null) {
+      cancelAnimationFrame(moveRafHandle);
+      moveRafHandle = null;
     }
+    if (scrollRafHandle !== null) {
+      cancelAnimationFrame(scrollRafHandle);
+      scrollRafHandle = null;
+    }
+    if (pointerId !== null && handleEl?.hasPointerCapture(pointerId)) {
+      try {
+        handleEl.releasePointerCapture(pointerId);
+      } catch {}
+    }
+    pointerActive = false;
+    pointerId = null;
+    listEl = null;
   });
 
   // Cleanup on component destroy (e.g., parent removes item mid-lift).

--- a/packages/components/src/components/sortable-list.a11y.md
+++ b/packages/components/src/components/sortable-list.a11y.md
@@ -1,0 +1,84 @@
+# SortableList Accessibility Notes
+
+## Keyboard Interaction
+
+| Key           | Phase  | Action                                                            |
+| ------------- | ------ | ----------------------------------------------------------------- |
+| Space / Enter | idle   | Lift the item whose handle is focused.                            |
+| Space / Enter | lifted | Drop at the current target position.                              |
+| Arrow Down    | lifted | Move to next position (clamped to last).                          |
+| Arrow Up      | lifted | Move to previous position (clamped to first).                     |
+| Home          | lifted | Move to first position.                                           |
+| End           | lifted | Move to last position.                                            |
+| Escape        | lifted | Cancel. Restores original visual order; onreorder is not called.  |
+| Tab           | lifted | Cancel and allow native focus movement to next focusable element. |
+
+Only the drag handle button is in the tab sequence. Row `<li>` elements have no `tabindex`.
+
+## ARIA Model
+
+- **List root**: `<ul role="list" aria-label={label}>`. Explicit `role="list"` because `list-style: none` can strip implicit semantics in some browser+AT combinations.
+- **Each row**: `<li aria-roledescription="sortable item">`. The `aria-roledescription` gives screen reader users a hint without overriding the semantic role.
+- **Drag handle**: `<button type="button" aria-label="Reorder {itemLabel}" aria-pressed={isLifted} aria-describedby={instructionsId}>`.
+  - `aria-label` is per-item and consumer-supplied so multiple handles are distinguishable (e.g., "Reorder Buy milk").
+  - `aria-pressed` reflects lifted state (false = idle, true = lifted).
+  - `aria-describedby` points to a single hidden `<span>` with instructions rendered once inside the list.
+- **Hidden instructions**: "Press Space to lift, then arrow keys to move, Space to drop, Escape to cancel."
+- **Live region**: `<div aria-live="assertive" aria-atomic="true">` — assertive because the user just acted and is waiting for confirmation.
+
+`aria-grabbed` and `aria-dropeffect` are **deprecated in ARIA 1.1** and intentionally not used.
+
+## Announcement Strings
+
+All four state transitions are announced via an `aria-live="assertive"` region:
+
+| Transition | Message                                                                                                      |
+| ---------- | ------------------------------------------------------------------------------------------------------------ |
+| Lifted     | `{label}, lifted. Current position {n} of {total}. Use arrow keys to move. Space to drop, Escape to cancel.` |
+| Moved      | `{label}, moved to position {n} of {total}.`                                                                 |
+| Dropped    | `{label}, dropped at position {n} of {total}.`                                                               |
+| Cancelled  | `Reorder cancelled. {label} returned to original position.`                                                  |
+
+`{label}` is the raw `itemLabel` (e.g., "Buy milk"), not the handle label ("Reorder Buy milk"). Announcement strings are fully overridable via the `announcements` prop.
+
+`moved` fires only when the target position actually changes. `dropped` fires even when the item returns to its original position; `onreorder` does not fire in that case.
+
+## Pointer / Touch Strategy
+
+HTML5 Drag and Drop API is **not used**. iOS Safari does not fire touch events on HTML5 drag targets, making it incompatible with touch devices.
+
+Pointer Events (`pointerdown`, `pointermove`, `pointerup`, `pointercancel`) with `setPointerCapture` are used instead. This handles mouse, touch, and stylus uniformly. The drag handle has `touch-action: none` so the browser does not steal vertical pans.
+
+## Focus Retention
+
+Svelte's keyed `each` block preserves the focused DOM node across visual reorders. Focus stays on the handle of the lifted item as Arrow Up/Down moves it through the list.
+
+Cancellation on bare `focusout` is intentionally not implemented — DOM reordering of keyed blocks produces transient blur/focus events that would make keyboard reorder unreliable.
+
+## Auto-Scroll
+
+Window-only auto-scroll is implemented. When the pointer is within 32px of the viewport top or bottom during a drag, the page scrolls at 8px/frame and the insertion target is recomputed after each frame.
+
+**Nested scroll containers are not supported.** Items inside a scrollable container (other than the window) will not auto-scroll during a pointer drag.
+
+## Reduced Motion
+
+The shift-preview transition (`transform 150ms ease`) is disabled via:
+
+```css
+@media (prefers-reduced-motion: reduce) {
+  .cinder-sortable-item--shifting {
+    transition: none;
+  }
+}
+```
+
+The lift shadow (`box-shadow`) is preserved under reduced motion as it provides a non-animated positional cue.
+
+## Known Limitations
+
+- **Multi-select drag**: Out of scope. Each drag moves exactly one item.
+- **Horizontal/grid sortable**: Out of scope. The controller is index-based; only vertical list order is supported.
+- **Disabled items**: Out of scope.
+- **Nested scroll containers**: Auto-scroll applies to the window only.
+- **NVDA on Windows**: Verified with VoiceOver on macOS. NVDA compatibility tracking is deferred.

--- a/packages/components/src/components/sortable-list.svelte
+++ b/packages/components/src/components/sortable-list.svelte
@@ -13,8 +13,13 @@
     items: Item[];
     /** Returns a stable key for each item. Must not change across reorders. */
     getKey: (item: Item) => string | number;
-    /** Returns an accessible label for each item (e.g., "Buy milk"). Used in handle aria-label and announcements. */
-    getItemLabel: (item: Item, index: number) => string;
+    /**
+     * Returns an accessible label for each item (e.g., "Buy milk").
+     * The second argument is the item's original index in the `items` array
+     * (not its current visual position during a drag).
+     * Used in handle aria-label and announcements.
+     */
+    getItemLabel: (item: Item, originalIndex: number) => string;
     /** Optional formatter for the drag handle's accessible name. Default: "Reorder {itemLabel}". */
     formatHandleLabel?: (itemLabel: string) => string;
     /** Optional snippet rendered inside the drag-handle button. Receives { pressed, label }. */
@@ -62,7 +67,7 @@
     class: className,
   }: SortableListProps<Item> = $props();
 
-  const announcer = useAnnouncer();
+  const announcer = useAnnouncer({ clearDelay: 5000 });
   const controller = new SortableController<Item>({
     announce: (msg) => announcer.announce(msg),
     ...(announcements !== undefined ? { announcements } : {}),
@@ -79,8 +84,9 @@
   });
 
   // Reconcile lifted key when items changes externally during a lift.
+  // Reading each key forces deep tracking so in-place array mutations are caught.
   $effect(() => {
-    void items;
+    items.forEach((it) => getKey(it));
     controller.reconcileLiftedKey(items, getKey);
   });
 
@@ -92,7 +98,7 @@
     commitDrop(_itemKey, itemLabel) {
       const result = controller.drop(items, itemLabel);
       if (result) {
-        onreorder(result.nextItems as Item[], result.change);
+        onreorder(result.nextItems, result.change);
       }
     },
     cancel(itemLabel) {
@@ -106,10 +112,15 @@
     },
   });
 
-  // Escape while lifted — handled at window level.
+  // Window-level Escape handler: cancels the lift regardless of which element has focus.
+  // This covers the case where focus moved off the handle during a lift (pointer drag,
+  // programmatic focus change, etc.). The item-level Escape handler also calls cancel
+  // when the handle is focused, but the controller guard (phase !== 'lifted') makes
+  // double-cancel safe.
   function handleWindowKeydown(event: KeyboardEvent): void {
     if (controller.phase === 'lifted' && event.key === 'Escape') {
       event.preventDefault();
+      controller.cancel();
     }
   }
 </script>
@@ -117,8 +128,19 @@
 <svelte:window onkeydown={handleWindowKeydown} />
 
 <ul class={cn('cinder-sortable-list', className)} role="list" aria-label={label}>
+  <!--
+    Instructions live inside the <ul> as a visually hidden <li> so the element is
+    present in the DOM before any handle buttons that reference it via aria-describedby.
+    aria-hidden keeps it out of the reading order but the id is still resolved by AT
+    for aria-describedby (ARIA spec §6.6.1).
+  -->
+  <li role="presentation" id={instructionsId} class="cinder-sr-only">
+    Press Space to lift, then arrow keys to move, Space to drop, Escape to cancel.
+  </li>
+
   {#each visualItems as rowItem, visualIndex (getKey(rowItem))}
-    {@const rowItemLabel = getItemLabel(rowItem, visualIndex)}
+    {@const originalIndex = items.indexOf(rowItem)}
+    {@const rowItemLabel = getItemLabel(rowItem, originalIndex >= 0 ? originalIndex : visualIndex)}
     <SortableItem
       item={rowItem}
       itemKey={getKey(rowItem)}
@@ -136,12 +158,7 @@
   {/each}
 </ul>
 
-<!-- Live region for screen reader announcements -->
-<div aria-live="assertive" aria-atomic="true" class="cinder-sr-only" role="status">
+<!-- Live region — role="alert" (implicit assertive) avoids role/aria-live conflict -->
+<div role="alert" aria-atomic="true" class="cinder-sr-only">
   {announcer.message}
 </div>
-
-<!-- Single hidden instructions span referenced by handle aria-describedby -->
-<span id={instructionsId} class="cinder-sr-only">
-  Press Space to lift, then arrow keys to move, Space to drop, Escape to cancel.
-</span>

--- a/packages/components/src/components/sortable-list.svelte
+++ b/packages/components/src/components/sortable-list.svelte
@@ -131,8 +131,9 @@
   <!--
     Instructions live inside the <ul> as a visually hidden <li> so the element is
     present in the DOM before any handle buttons that reference it via aria-describedby.
-    aria-hidden keeps it out of the reading order but the id is still resolved by AT
-    for aria-describedby (ARIA spec §6.6.1).
+    role="presentation" removes the implicit listitem role so this element does not
+    count toward the list's item count. cinder-sr-only visually hides it with the
+    clip pattern (not display:none), so browsers resolve its id for aria-describedby.
   -->
   <li role="presentation" id={instructionsId} class="cinder-sr-only">
     Press Space to lift, then arrow keys to move, Space to drop, Escape to cancel.

--- a/packages/components/src/components/sortable-list.svelte
+++ b/packages/components/src/components/sortable-list.svelte
@@ -1,0 +1,147 @@
+<script lang="ts" module>
+  import type { Snippet } from 'svelte';
+
+  export type {
+    SortableAnnouncements,
+    SortableItemContext,
+    SortableReorderChange,
+  } from '../utilities/sortable-controller.svelte.ts';
+
+  /** Props for the SortableList component. */
+  export type SortableListProps<Item> = {
+    /** The list of items to render. */
+    items: Item[];
+    /** Returns a stable key for each item. Must not change across reorders. */
+    getKey: (item: Item) => string | number;
+    /** Returns an accessible label for each item (e.g., "Buy milk"). Used in handle aria-label and announcements. */
+    getItemLabel: (item: Item, index: number) => string;
+    /** Optional formatter for the drag handle's accessible name. Default: "Reorder {itemLabel}". */
+    formatHandleLabel?: (itemLabel: string) => string;
+    /** Optional snippet rendered inside the drag-handle button. Receives { pressed, label }. */
+    handle?: Snippet<[{ pressed: boolean; label: string }]>;
+    /** Fires with the full reordered array and change metadata on drop. */
+    onreorder: (
+      nextItems: Item[],
+      change: import('../utilities/sortable-controller.svelte.ts').SortableReorderChange,
+    ) => void;
+    /** Optional overrides for announcement strings. */
+    announcements?: Partial<
+      import('../utilities/sortable-controller.svelte.ts').SortableAnnouncements
+    >;
+    /** Row content snippet. Receives the item and a per-row context. */
+    children: Snippet<
+      [Item, import('../utilities/sortable-controller.svelte.ts').SortableItemContext]
+    >;
+    /** Accessible name for the list (applied as aria-label on the list root). */
+    label?: string;
+    class?: string;
+  };
+</script>
+
+<script lang="ts" generics="Item">
+  import { useAnnouncer } from '../utilities/use-announcer.svelte.ts';
+  import { useId } from '../utilities/use-id.ts';
+  import { cn } from '../utilities/class-names.ts';
+  import {
+    SortableController,
+    setSortableContext,
+    reorder,
+  } from '../utilities/sortable-controller.svelte.ts';
+  import SortableItem from './_sortable-item.svelte';
+
+  let {
+    items,
+    getKey,
+    getItemLabel,
+    formatHandleLabel = (label) => `Reorder ${label}`,
+    handle,
+    onreorder,
+    announcements,
+    children: renderRow,
+    label,
+    class: className,
+  }: SortableListProps<Item> = $props();
+
+  const announcer = useAnnouncer();
+  const controller = new SortableController<Item>({
+    announce: (msg) => announcer.announce(msg),
+    ...(announcements !== undefined ? { announcements } : {}),
+  });
+
+  const instructionsId = useId('cinder-sortable-instructions');
+
+  // Derived visual order — pure read of controller state, no side effects.
+  const visualItems = $derived.by(() => {
+    if (controller.phase !== 'lifted' || controller.liftedKey === null) return items;
+    const from = items.findIndex((it) => getKey(it) === controller.liftedKey);
+    if (from < 0) return items;
+    return reorder(items, from, controller.liftedTo);
+  });
+
+  // Reconcile lifted key when items changes externally during a lift.
+  $effect(() => {
+    void items;
+    controller.reconcileLiftedKey(items, getKey);
+  });
+
+  // Command bag passed to each SortableItem via context.
+  setSortableContext({
+    get controller() {
+      return controller as SortableController<unknown>;
+    },
+    commitDrop(_itemKey, itemLabel) {
+      const result = controller.drop(items, itemLabel);
+      if (result) {
+        onreorder(result.nextItems as Item[], result.change);
+      }
+    },
+    cancel(itemLabel) {
+      controller.cancel(itemLabel);
+    },
+    lift(key, fromIndex, itemLabel, total) {
+      controller.lift(key, fromIndex, itemLabel, total);
+    },
+    move(toIndex, itemLabel, total) {
+      controller.move(toIndex, itemLabel, total);
+    },
+  });
+
+  // Escape while lifted — handled at window level.
+  function handleWindowKeydown(event: KeyboardEvent): void {
+    if (controller.phase === 'lifted' && event.key === 'Escape') {
+      event.preventDefault();
+    }
+  }
+</script>
+
+<svelte:window onkeydown={handleWindowKeydown} />
+
+<ul class={cn('cinder-sortable-list', className)} role="list" aria-label={label}>
+  {#each visualItems as rowItem, visualIndex (getKey(rowItem))}
+    {@const rowItemLabel = getItemLabel(rowItem, visualIndex)}
+    <SortableItem
+      item={rowItem}
+      itemKey={getKey(rowItem)}
+      index={visualIndex}
+      itemLabel={rowItemLabel}
+      {formatHandleLabel}
+      {...handle !== undefined ? { handle } : {}}
+      {instructionsId}
+      total={visualItems.length}
+    >
+      {#snippet children(ctx)}
+        {@render renderRow(rowItem, ctx)}
+      {/snippet}
+    </SortableItem>
+  {/each}
+</ul>
+
+<!-- Live region for screen reader announcements -->
+<div aria-live="assertive" aria-atomic="true" class="cinder-sr-only" role="status">
+  {announcer.message}
+</div>
+
+<!-- Single hidden instructions span referenced by handle aria-describedby -->
+<span id={instructionsId} class="cinder-sr-only">
+  Press Space to lift, then arrow keys to move, Space to drop, Escape to cancel.
+</span>

--- a/packages/components/src/components/sortable-list.test.ts
+++ b/packages/components/src/components/sortable-list.test.ts
@@ -159,6 +159,22 @@ describe('SortableController', () => {
     expect(announce.mock.calls[0][0]).toContain('cancelled');
   });
 
+  test('lift while already lifted is a no-op (prevents concurrent drag corruption)', () => {
+    const announce = mock();
+    const controller = new SortableController({ announce });
+
+    controller.lift('a', 0, 'Alpha', 3);
+    announce.mockClear();
+
+    // Attempt to lift a second item while 'a' is still lifted.
+    controller.lift('b', 1, 'Beta', 3);
+
+    expect(announce).not.toHaveBeenCalled();
+    expect(controller.liftedKey).toBe('a');
+    expect(controller.liftedFrom).toBe(0);
+    expect(controller.phase).toBe('lifted');
+  });
+
   test('cancel in idle phase is a no-op', () => {
     const announce = mock();
     const controller = new SortableController({ announce });

--- a/packages/components/src/components/sortable-list.test.ts
+++ b/packages/components/src/components/sortable-list.test.ts
@@ -204,6 +204,31 @@ describe('SortableController', () => {
     expect(announce).toHaveBeenCalledTimes(0);
   });
 
+  test('reconcileLiftedKey clamps liftedTo when list shrinks from the end (index unchanged)', () => {
+    const announce = mock();
+    const controller = new SortableController<Item>({ announce });
+    const items: Item[] = [
+      { id: 'a', label: 'Alpha' },
+      { id: 'b', label: 'Beta' },
+      { id: 'c', label: 'Gamma' },
+    ];
+    // Lift 'a' and move it to position 2 (last).
+    controller.lift('a', 0, 'Alpha', 3);
+    controller.move(2, 'Alpha', 3);
+    expect(controller.liftedTo).toBe(2);
+
+    // Parent removes 'c' from the end; 'a' is still at index 0 so currentIndex === liftedFrom.
+    const shrunk: Item[] = [
+      { id: 'a', label: 'Alpha' },
+      { id: 'b', label: 'Beta' },
+    ];
+    controller.reconcileLiftedKey(shrunk, getKey);
+
+    expect(controller.phase).toBe('lifted');
+    // liftedTo must be clamped to the new last index (1), not left at 2.
+    expect(controller.liftedTo).toBe(1);
+  });
+
   test('custom announcements override defaults', () => {
     const announce = mock();
     const controller = new SortableController({

--- a/packages/components/src/components/sortable-list.test.ts
+++ b/packages/components/src/components/sortable-list.test.ts
@@ -209,7 +209,7 @@ describe('SortableController', () => {
     const controller = new SortableController({
       announce,
       announcements: {
-        lifted: (label: string) => `CUSTOM LIFT ${label}`,
+        lifted: (label: string, _position: number, _total: number) => `CUSTOM LIFT ${label}`,
       },
     });
 
@@ -320,9 +320,10 @@ describe('SortableList', () => {
     await fireEvent.keyDown(handle, { key: ' ' }); // Lift Alpha (was at index 0).
     await fireEvent.keyDown(handle, { key: 'ArrowDown' }); // Move to index 1.
 
-    // Alpha should now appear at visual index 1 in the DOM.
+    // Alpha should now appear at visual index 1; Beta should have shifted to index 0.
     const rows = container.querySelectorAll('[data-sortable-row]');
-    expect(rows[1].getAttribute('data-key')).toBe('a');
+    expect(rows[0].getAttribute('data-key')).toBe('b'); // Beta shifted to first.
+    expect(rows[1].getAttribute('data-key')).toBe('a'); // Alpha at second.
     expect(handle.getAttribute('aria-pressed')).toBe('true');
   });
 

--- a/packages/components/src/components/sortable-list.test.ts
+++ b/packages/components/src/components/sortable-list.test.ts
@@ -59,7 +59,7 @@ function renderList(overrides?: Record<string, unknown>) {
 // ---------------------------------------------------------------------------
 
 describe('SortableController', () => {
-  test('lift sets phase, key, from/to, and calls announce', () => {
+  test('lift sets phase, key, from/to, liftedLabel, and calls announce', () => {
     const announce = mock();
     const controller = new SortableController({ announce });
 
@@ -67,6 +67,7 @@ describe('SortableController', () => {
 
     expect(controller.phase).toBe('lifted');
     expect(controller.liftedKey).toBe('a');
+    expect(controller.liftedLabel).toBe('Alpha');
     expect(controller.liftedFrom).toBe(0);
     expect(controller.liftedTo).toBe(0);
     expect(announce).toHaveBeenCalledTimes(1);
@@ -140,21 +141,35 @@ describe('SortableController', () => {
     expect(announce.mock.calls[0][0]).toContain('dropped');
   });
 
-  test('cancel does not return items, resets state, and announces cancelled', () => {
+  test('cancel resets all state fields, announces cancelled', () => {
     const announce = mock();
     const controller = new SortableController({ announce });
     controller.lift('a', 0, 'Alpha', 3);
+    controller.move(2, 'Alpha', 3);
     announce.mockClear();
 
     controller.cancel('Alpha');
 
     expect(controller.phase).toBe('idle');
     expect(controller.liftedKey).toBeNull();
+    expect(controller.liftedLabel).toBe('');
+    expect(controller.liftedFrom).toBe(0);
+    expect(controller.liftedTo).toBe(0);
     expect(announce).toHaveBeenCalledTimes(1);
     expect(announce.mock.calls[0][0]).toContain('cancelled');
   });
 
-  test('reconcileLiftedKey when key is missing triggers auto-cancel announcement', () => {
+  test('cancel in idle phase is a no-op', () => {
+    const announce = mock();
+    const controller = new SortableController({ announce });
+
+    controller.cancel('Alpha');
+
+    expect(announce).not.toHaveBeenCalled();
+    expect(controller.phase).toBe('idle');
+  });
+
+  test('reconcileLiftedKey when key is missing auto-cancels with stored liftedLabel', () => {
     const announce = mock();
     const controller = new SortableController<Item>({ announce });
     controller.lift('a', 0, 'Alpha', 2);
@@ -165,6 +180,9 @@ describe('SortableController', () => {
 
     expect(controller.phase).toBe('idle');
     expect(announce).toHaveBeenCalledTimes(1);
+    // Announcement should use the stored label "Alpha" (not an empty string).
+    expect(announce.mock.calls[0][0]).toContain('Alpha');
+    expect(announce.mock.calls[0][0]).toContain('cancelled');
   });
 
   test('reconcileLiftedKey when key moved updates liftedFrom without announcing', () => {
@@ -184,6 +202,20 @@ describe('SortableController', () => {
     expect(controller.phase).toBe('lifted');
     expect(controller.liftedFrom).toBe(1);
     expect(announce).toHaveBeenCalledTimes(0);
+  });
+
+  test('custom announcements override defaults', () => {
+    const announce = mock();
+    const controller = new SortableController({
+      announce,
+      announcements: {
+        lifted: (label: string) => `CUSTOM LIFT ${label}`,
+      },
+    });
+
+    controller.lift('a', 0, 'Alpha', 3);
+
+    expect(announce.mock.calls[0][0]).toBe('CUSTOM LIFT Alpha');
   });
 });
 
@@ -254,22 +286,22 @@ describe('SortableList', () => {
     expect(handle?.getAttribute('aria-pressed')).toBe('false');
   });
 
-  test('handle has aria-describedby pointing to instructions span', () => {
+  test('handle has aria-describedby pointing to instructions element', () => {
     const { container } = renderList();
     const handle = container.querySelector('.cinder-sortable-handle');
     const describedBy = handle?.getAttribute('aria-describedby');
     expect(describedBy).toBeTruthy();
     const instructions = container.querySelector(`#${describedBy}`);
     expect(instructions).not.toBeNull();
-    expect(instructions?.textContent).toContain('Space to lift');
+    expect(instructions?.textContent?.trim().length).toBeGreaterThan(0);
   });
 
-  test('hidden instructions span exists exactly once', () => {
+  test('hidden instructions element exists exactly once', () => {
     const { container } = renderList();
     const firstHandle = container.querySelector('.cinder-sortable-handle');
     const instructionsId = firstHandle?.getAttribute('aria-describedby');
-    const spans = container.querySelectorAll(`[id="${instructionsId}"]`);
-    expect(spans.length).toBe(1);
+    const elements = container.querySelectorAll(`[id="${instructionsId}"]`);
+    expect(elements.length).toBe(1);
   });
 
   test('Space on handle lifts item — aria-pressed becomes true', async () => {
@@ -281,14 +313,16 @@ describe('SortableList', () => {
     expect(handle.getAttribute('aria-pressed')).toBe('true');
   });
 
-  test('Arrow Down moves visual order — lifted item moves down', async () => {
+  test('Arrow Down moves lifted item to next visual position', async () => {
     const { container } = renderList();
     const handle = container.querySelectorAll('.cinder-sortable-handle')[0] as HTMLElement;
 
-    await fireEvent.keyDown(handle, { key: ' ' });
-    await fireEvent.keyDown(handle, { key: 'ArrowDown' });
+    await fireEvent.keyDown(handle, { key: ' ' }); // Lift Alpha (was at index 0).
+    await fireEvent.keyDown(handle, { key: 'ArrowDown' }); // Move to index 1.
 
-    // aria-pressed stays true during move.
+    // Alpha should now appear at visual index 1 in the DOM.
+    const rows = container.querySelectorAll('[data-sortable-row]');
+    expect(rows[1].getAttribute('data-key')).toBe('a');
     expect(handle.getAttribute('aria-pressed')).toBe('true');
   });
 
@@ -313,34 +347,32 @@ describe('SortableList', () => {
     expect(handle.getAttribute('aria-pressed')).toBe('true');
   });
 
-  test('Home jumps to first position, End jumps to last', async () => {
+  test('End moves lifted item to last visual position', async () => {
     const { container } = renderList();
-    // Start from middle item.
     const handles = container.querySelectorAll('.cinder-sortable-handle');
-    const middleHandle = handles[1] as HTMLElement;
+    const middleHandle = handles[1] as HTMLElement; // Beta at index 1.
 
     await fireEvent.keyDown(middleHandle, { key: ' ' }); // Lift Beta.
-    await fireEvent.keyDown(middleHandle, { key: 'End' });
+    await fireEvent.keyDown(middleHandle, { key: 'End' }); // Move to last.
 
-    expect(middleHandle.getAttribute('aria-pressed')).toBe('true');
+    const rows = container.querySelectorAll('[data-sortable-row]');
+    expect(rows[2].getAttribute('data-key')).toBe('b'); // Beta moved to index 2.
+  });
 
-    await fireEvent.keyDown(middleHandle, { key: 'Home' });
-    expect(middleHandle.getAttribute('aria-pressed')).toBe('true');
+  test('Home moves lifted item to first visual position', async () => {
+    const { container } = renderList();
+    const handles = container.querySelectorAll('.cinder-sortable-handle');
+    const middleHandle = handles[1] as HTMLElement; // Beta at index 1.
+
+    await fireEvent.keyDown(middleHandle, { key: ' ' }); // Lift Beta.
+    await fireEvent.keyDown(middleHandle, { key: 'Home' }); // Move to first.
+
+    const rows = container.querySelectorAll('[data-sortable-row]');
+    expect(rows[0].getAttribute('data-key')).toBe('b'); // Beta moved to index 0.
   });
 
   test('Space drops and calls onreorder with reordered array', async () => {
-    const onreorder = mock();
-    const { container } = render(SortableList as any, {
-      props: {
-        items: ITEMS,
-        getKey,
-        getItemLabel,
-        onreorder,
-        label: 'Test list',
-        children: emptySnippet(),
-      },
-    });
-
+    const { container, onreorder } = renderList();
     const handle = container.querySelectorAll('.cinder-sortable-handle')[0] as HTMLElement;
 
     await fireEvent.keyDown(handle, { key: ' ' }); // Lift Alpha.
@@ -357,18 +389,7 @@ describe('SortableList', () => {
   });
 
   test('Escape cancels — onreorder not called, aria-pressed returns false', async () => {
-    const onreorder = mock();
-    const { container } = render(SortableList as any, {
-      props: {
-        items: ITEMS,
-        getKey,
-        getItemLabel,
-        onreorder,
-        label: 'Test list',
-        children: emptySnippet(),
-      },
-    });
-
+    const { container, onreorder } = renderList();
     const handle = container.querySelectorAll('.cinder-sortable-handle')[0] as HTMLElement;
 
     await fireEvent.keyDown(handle, { key: ' ' });
@@ -380,18 +401,7 @@ describe('SortableList', () => {
   });
 
   test('drop at same position does not call onreorder', async () => {
-    const onreorder = mock();
-    const { container } = render(SortableList as any, {
-      props: {
-        items: ITEMS,
-        getKey,
-        getItemLabel,
-        onreorder,
-        label: 'Test list',
-        children: emptySnippet(),
-      },
-    });
-
+    const { container, onreorder } = renderList();
     const handle = container.querySelectorAll('.cinder-sortable-handle')[0] as HTMLElement;
 
     await fireEvent.keyDown(handle, { key: ' ' }); // Lift.
@@ -400,33 +410,8 @@ describe('SortableList', () => {
     expect(onreorder).not.toHaveBeenCalled();
   });
 
-  test('custom announcements prop overrides defaults', () => {
-    const announce = mock();
-    const controller = new SortableController({
-      announce,
-      announcements: {
-        lifted: (label) => `CUSTOM LIFT ${label}`,
-      },
-    });
-
-    controller.lift('a', 0, 'Alpha', 3);
-
-    expect(announce.mock.calls[0][0]).toBe('CUSTOM LIFT Alpha');
-  });
-
   test('onreorder receives full reordered array and correct change metadata', async () => {
-    const onreorder = mock();
-    const { container } = render(SortableList as any, {
-      props: {
-        items: ITEMS,
-        getKey,
-        getItemLabel,
-        onreorder,
-        label: 'Test list',
-        children: emptySnippet(),
-      },
-    });
-
+    const { container, onreorder } = renderList();
     const handles = container.querySelectorAll('.cinder-sortable-handle');
     const lastHandle = handles[handles.length - 1] as HTMLElement; // Gamma (index 2).
 
@@ -448,17 +433,9 @@ describe('SortableList', () => {
       { id: 'b', label: 'Beta' },
     ];
     const frozen = Object.freeze(original.map((i) => Object.freeze({ ...i })));
-    const onreorder = mock();
-
-    const { container } = render(SortableList as any, {
-      props: {
-        items: frozen as any,
-        getKey,
-        getItemLabel,
-        onreorder,
-        label: 'Frozen list',
-        children: emptySnippet(),
-      },
+    const { container, onreorder } = renderList({
+      items: frozen as any,
+      label: 'Frozen list',
     });
 
     const handle = container.querySelectorAll('.cinder-sortable-handle')[0] as HTMLElement;
@@ -469,6 +446,27 @@ describe('SortableList', () => {
 
     // If items were mutated, the frozen object would throw. No throw = no mutation.
     expect(onreorder).toHaveBeenCalledTimes(1);
-    expect(frozen.map((i) => i.id)).toEqual(['a', 'b']); // Unchanged.
+    expect(frozen.map((i: Item) => i.id)).toEqual(['a', 'b']); // Unchanged.
+  });
+
+  test('list root has role=list and aria-label when label prop is set', () => {
+    const { container } = renderList({ label: 'My tasks' });
+    const list = container.querySelector('.cinder-sortable-list');
+    expect(list?.getAttribute('role')).toBe('list');
+    expect(list?.getAttribute('aria-label')).toBe('My tasks');
+  });
+
+  test('announcements prop flows to live region on lift', async () => {
+    const { container } = renderList({
+      announcements: { lifted: (label: string) => `CUSTOM ${label} LIFTED` },
+    });
+    const handle = container.querySelectorAll('.cinder-sortable-handle')[0] as HTMLElement;
+
+    await fireEvent.keyDown(handle, { key: ' ' });
+
+    // The live region text is set asynchronously via setTimeout(0) in useAnnouncer.
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    const liveRegion = container.querySelector('[role="alert"]');
+    expect(liveRegion?.textContent).toContain('CUSTOM Alpha LIFTED');
   });
 });

--- a/packages/components/src/components/sortable-list.test.ts
+++ b/packages/components/src/components/sortable-list.test.ts
@@ -326,24 +326,28 @@ describe('SortableList', () => {
     expect(handle.getAttribute('aria-pressed')).toBe('true');
   });
 
-  test('Arrow Down at last position does not crash or re-announce', async () => {
+  test('Arrow Down at last position clamps — item stays at last slot', async () => {
     const { container } = renderList();
     const handles = container.querySelectorAll('.cinder-sortable-handle');
-    const lastHandle = handles[handles.length - 1] as HTMLElement;
+    const lastHandle = handles[handles.length - 1] as HTMLElement; // Gamma at index 2.
 
     await fireEvent.keyDown(lastHandle, { key: ' ' });
-    await fireEvent.keyDown(lastHandle, { key: 'ArrowDown' }); // At last — clamps, no error.
+    await fireEvent.keyDown(lastHandle, { key: 'ArrowDown' }); // At last — clamps.
 
+    const rows = container.querySelectorAll('[data-sortable-row]');
+    expect(rows[2].getAttribute('data-key')).toBe('c'); // Gamma stays at index 2.
     expect(lastHandle.getAttribute('aria-pressed')).toBe('true');
   });
 
-  test('Arrow Up at first position does not crash', async () => {
+  test('Arrow Up at first position clamps — item stays at first slot', async () => {
     const { container } = renderList();
-    const handle = container.querySelectorAll('.cinder-sortable-handle')[0] as HTMLElement;
+    const handle = container.querySelectorAll('.cinder-sortable-handle')[0] as HTMLElement; // Alpha at index 0.
 
     await fireEvent.keyDown(handle, { key: ' ' });
     await fireEvent.keyDown(handle, { key: 'ArrowUp' }); // Already at 0 — clamps.
 
+    const rows = container.querySelectorAll('[data-sortable-row]');
+    expect(rows[0].getAttribute('data-key')).toBe('a'); // Alpha stays at index 0.
     expect(handle.getAttribute('aria-pressed')).toBe('true');
   });
 
@@ -458,7 +462,9 @@ describe('SortableList', () => {
 
   test('announcements prop flows to live region on lift', async () => {
     const { container } = renderList({
-      announcements: { lifted: (label: string) => `CUSTOM ${label} LIFTED` },
+      announcements: {
+        lifted: (label: string, _position: number, _total: number) => `CUSTOM ${label} LIFTED`,
+      },
     });
     const handle = container.querySelectorAll('.cinder-sortable-handle')[0] as HTMLElement;
 

--- a/packages/components/src/components/sortable-list.test.ts
+++ b/packages/components/src/components/sortable-list.test.ts
@@ -1,0 +1,474 @@
+// @ts-nocheck — test file; noUncheckedIndexedAccess and bun:test types disabled per project convention
+/// <reference lib="dom" />
+import { describe, expect, mock, test } from 'bun:test';
+import { createRawSnippet } from 'svelte';
+
+import { setupHappyDom } from '../test/happy-dom.ts';
+import { SortableController, reorder } from '../utilities/sortable-controller.svelte.ts';
+
+setupHappyDom();
+
+const { render, fireEvent } = await import('@testing-library/svelte');
+const { default: SortableList } = await import('./sortable-list.svelte');
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+type Item = { id: string; label: string };
+
+const ITEMS: Item[] = [
+  { id: 'a', label: 'Alpha' },
+  { id: 'b', label: 'Beta' },
+  { id: 'c', label: 'Gamma' },
+];
+
+function getKey(item: Item) {
+  return item.id;
+}
+
+function getItemLabel(item: Item) {
+  return item.label;
+}
+
+function emptySnippet() {
+  return createRawSnippet(() => ({
+    render: () => `<span></span>`,
+    setup: () => {},
+  }));
+}
+
+function renderList(overrides?: Record<string, unknown>) {
+  const onreorder = mock();
+  const { container, ...rest } = render(SortableList as any, {
+    props: {
+      items: ITEMS,
+      getKey,
+      getItemLabel,
+      onreorder,
+      label: 'Test list',
+      children: emptySnippet(),
+      ...overrides,
+    },
+  });
+  return { container, onreorder, ...rest };
+}
+
+// ---------------------------------------------------------------------------
+// Controller unit tests (no DOM)
+// ---------------------------------------------------------------------------
+
+describe('SortableController', () => {
+  test('lift sets phase, key, from/to, and calls announce', () => {
+    const announce = mock();
+    const controller = new SortableController({ announce });
+
+    controller.lift('a', 0, 'Alpha', 3);
+
+    expect(controller.phase).toBe('lifted');
+    expect(controller.liftedKey).toBe('a');
+    expect(controller.liftedFrom).toBe(0);
+    expect(controller.liftedTo).toBe(0);
+    expect(announce).toHaveBeenCalledTimes(1);
+    expect(announce.mock.calls[0][0]).toContain('Alpha');
+    expect(announce.mock.calls[0][0]).toContain('1 of 3');
+  });
+
+  test('move updates liftedTo and announces only on actual change', () => {
+    const announce = mock();
+    const controller = new SortableController({ announce });
+    controller.lift('a', 0, 'Alpha', 3);
+    announce.mockClear();
+
+    controller.move(1, 'Alpha', 3);
+    expect(controller.liftedTo).toBe(1);
+    expect(announce).toHaveBeenCalledTimes(1);
+
+    // Same index again — no re-announce.
+    controller.move(1, 'Alpha', 3);
+    expect(announce).toHaveBeenCalledTimes(1);
+  });
+
+  test('move clamps to [0, total-1] without announcing out-of-bounds', () => {
+    const announce = mock();
+    const controller = new SortableController({ announce });
+    controller.lift('a', 0, 'Alpha', 3);
+    announce.mockClear();
+
+    controller.move(-5, 'Alpha', 3);
+    expect(controller.liftedTo).toBe(0);
+    expect(announce).toHaveBeenCalledTimes(0); // Already at 0, clamped, no change.
+
+    controller.move(100, 'Alpha', 3);
+    expect(controller.liftedTo).toBe(2);
+    expect(announce).toHaveBeenCalledTimes(1);
+  });
+
+  test('drop with different from/to returns nextItems with correct order and calls announce', () => {
+    const announce = mock();
+    const controller = new SortableController<Item>({ announce });
+    const items: Item[] = [
+      { id: 'a', label: 'Alpha' },
+      { id: 'b', label: 'Beta' },
+      { id: 'c', label: 'Gamma' },
+    ];
+    controller.lift('a', 0, 'Alpha', 3);
+    controller.move(2, 'Alpha', 3);
+    announce.mockClear();
+
+    const result = controller.drop(items, 'Alpha');
+
+    expect(result).not.toBeNull();
+    expect(result!.nextItems.map((i) => i.id)).toEqual(['b', 'c', 'a']);
+    expect(result!.change).toEqual({ itemKey: 'a', fromIndex: 0, toIndex: 2 });
+    expect(announce).toHaveBeenCalledTimes(1);
+    expect(announce.mock.calls[0][0]).toContain('dropped');
+    expect(controller.phase).toBe('idle');
+  });
+
+  test('drop with same from/to returns null but still announces dropped', () => {
+    const announce = mock();
+    const controller = new SortableController<Item>({ announce });
+    const items: Item[] = [{ id: 'a', label: 'Alpha' }];
+    controller.lift('a', 0, 'Alpha', 1);
+    announce.mockClear();
+
+    const result = controller.drop(items, 'Alpha');
+
+    expect(result).toBeNull();
+    expect(announce).toHaveBeenCalledTimes(1);
+    expect(announce.mock.calls[0][0]).toContain('dropped');
+  });
+
+  test('cancel does not return items, resets state, and announces cancelled', () => {
+    const announce = mock();
+    const controller = new SortableController({ announce });
+    controller.lift('a', 0, 'Alpha', 3);
+    announce.mockClear();
+
+    controller.cancel('Alpha');
+
+    expect(controller.phase).toBe('idle');
+    expect(controller.liftedKey).toBeNull();
+    expect(announce).toHaveBeenCalledTimes(1);
+    expect(announce.mock.calls[0][0]).toContain('cancelled');
+  });
+
+  test('reconcileLiftedKey when key is missing triggers auto-cancel announcement', () => {
+    const announce = mock();
+    const controller = new SortableController<Item>({ announce });
+    controller.lift('a', 0, 'Alpha', 2);
+    announce.mockClear();
+
+    // Remove item 'a' from the list.
+    controller.reconcileLiftedKey([{ id: 'b', label: 'Beta' }], getKey);
+
+    expect(controller.phase).toBe('idle');
+    expect(announce).toHaveBeenCalledTimes(1);
+  });
+
+  test('reconcileLiftedKey when key moved updates liftedFrom without announcing', () => {
+    const announce = mock();
+    const controller = new SortableController<Item>({ announce });
+    const items: Item[] = [
+      { id: 'a', label: 'Alpha' },
+      { id: 'b', label: 'Beta' },
+    ];
+    controller.lift('a', 0, 'Alpha', 2);
+    announce.mockClear();
+
+    // Simulate parent inserting item at front, pushing 'a' to index 1.
+    const reordered: Item[] = [{ id: 'x', label: 'X' }, ...items];
+    controller.reconcileLiftedKey(reordered, getKey);
+
+    expect(controller.phase).toBe('lifted');
+    expect(controller.liftedFrom).toBe(1);
+    expect(announce).toHaveBeenCalledTimes(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// reorder helper
+// ---------------------------------------------------------------------------
+
+describe('reorder', () => {
+  test('moves item from fromIndex to toIndex', () => {
+    const result = reorder(['a', 'b', 'c'], 0, 2);
+    expect(result).toEqual(['b', 'c', 'a']);
+  });
+
+  test('does not mutate input array', () => {
+    const input = ['a', 'b', 'c'];
+    reorder(input, 0, 1);
+    expect(input).toEqual(['a', 'b', 'c']);
+  });
+
+  test('handles move to same index', () => {
+    expect(reorder(['a', 'b', 'c'], 1, 1)).toEqual(['a', 'b', 'c']);
+  });
+
+  test('handles move from last to first', () => {
+    expect(reorder(['a', 'b', 'c'], 2, 0)).toEqual(['c', 'a', 'b']);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Component tests
+// ---------------------------------------------------------------------------
+
+describe('SortableList', () => {
+  test('renders list root with role=list and aria-label', () => {
+    const { container } = renderList();
+    const list = container.querySelector('.cinder-sortable-list');
+    expect(list).not.toBeNull();
+    expect(list?.getAttribute('role')).toBe('list');
+    expect(list?.getAttribute('aria-label')).toBe('Test list');
+  });
+
+  test('renders one sortable item per data item', () => {
+    const { container } = renderList();
+    const items = container.querySelectorAll('[data-sortable-row]');
+    expect(items.length).toBe(3);
+  });
+
+  test('each handle has aria-label from formatHandleLabel (default: "Reorder {label}")', () => {
+    const { container } = renderList();
+    const handles = container.querySelectorAll('.cinder-sortable-handle');
+    expect(handles.length).toBe(3);
+    expect(handles[0].getAttribute('aria-label')).toBe('Reorder Alpha');
+    expect(handles[1].getAttribute('aria-label')).toBe('Reorder Beta');
+    expect(handles[2].getAttribute('aria-label')).toBe('Reorder Gamma');
+  });
+
+  test('custom formatHandleLabel is applied to handles', () => {
+    const { container } = renderList({
+      formatHandleLabel: (label: string) => `Drag ${label}`,
+    });
+    const handles = container.querySelectorAll('.cinder-sortable-handle');
+    expect(handles[0].getAttribute('aria-label')).toBe('Drag Alpha');
+  });
+
+  test('handle has aria-pressed=false initially', () => {
+    const { container } = renderList();
+    const handle = container.querySelector('.cinder-sortable-handle');
+    expect(handle?.getAttribute('aria-pressed')).toBe('false');
+  });
+
+  test('handle has aria-describedby pointing to instructions span', () => {
+    const { container } = renderList();
+    const handle = container.querySelector('.cinder-sortable-handle');
+    const describedBy = handle?.getAttribute('aria-describedby');
+    expect(describedBy).toBeTruthy();
+    const instructions = container.querySelector(`#${describedBy}`);
+    expect(instructions).not.toBeNull();
+    expect(instructions?.textContent).toContain('Space to lift');
+  });
+
+  test('hidden instructions span exists exactly once', () => {
+    const { container } = renderList();
+    const firstHandle = container.querySelector('.cinder-sortable-handle');
+    const instructionsId = firstHandle?.getAttribute('aria-describedby');
+    const spans = container.querySelectorAll(`[id="${instructionsId}"]`);
+    expect(spans.length).toBe(1);
+  });
+
+  test('Space on handle lifts item — aria-pressed becomes true', async () => {
+    const { container } = renderList();
+    const handle = container.querySelectorAll('.cinder-sortable-handle')[0] as HTMLElement;
+
+    await fireEvent.keyDown(handle, { key: ' ' });
+
+    expect(handle.getAttribute('aria-pressed')).toBe('true');
+  });
+
+  test('Arrow Down moves visual order — lifted item moves down', async () => {
+    const { container } = renderList();
+    const handle = container.querySelectorAll('.cinder-sortable-handle')[0] as HTMLElement;
+
+    await fireEvent.keyDown(handle, { key: ' ' });
+    await fireEvent.keyDown(handle, { key: 'ArrowDown' });
+
+    // aria-pressed stays true during move.
+    expect(handle.getAttribute('aria-pressed')).toBe('true');
+  });
+
+  test('Arrow Down at last position does not crash or re-announce', async () => {
+    const { container } = renderList();
+    const handles = container.querySelectorAll('.cinder-sortable-handle');
+    const lastHandle = handles[handles.length - 1] as HTMLElement;
+
+    await fireEvent.keyDown(lastHandle, { key: ' ' });
+    await fireEvent.keyDown(lastHandle, { key: 'ArrowDown' }); // At last — clamps, no error.
+
+    expect(lastHandle.getAttribute('aria-pressed')).toBe('true');
+  });
+
+  test('Arrow Up at first position does not crash', async () => {
+    const { container } = renderList();
+    const handle = container.querySelectorAll('.cinder-sortable-handle')[0] as HTMLElement;
+
+    await fireEvent.keyDown(handle, { key: ' ' });
+    await fireEvent.keyDown(handle, { key: 'ArrowUp' }); // Already at 0 — clamps.
+
+    expect(handle.getAttribute('aria-pressed')).toBe('true');
+  });
+
+  test('Home jumps to first position, End jumps to last', async () => {
+    const { container } = renderList();
+    // Start from middle item.
+    const handles = container.querySelectorAll('.cinder-sortable-handle');
+    const middleHandle = handles[1] as HTMLElement;
+
+    await fireEvent.keyDown(middleHandle, { key: ' ' }); // Lift Beta.
+    await fireEvent.keyDown(middleHandle, { key: 'End' });
+
+    expect(middleHandle.getAttribute('aria-pressed')).toBe('true');
+
+    await fireEvent.keyDown(middleHandle, { key: 'Home' });
+    expect(middleHandle.getAttribute('aria-pressed')).toBe('true');
+  });
+
+  test('Space drops and calls onreorder with reordered array', async () => {
+    const onreorder = mock();
+    const { container } = render(SortableList as any, {
+      props: {
+        items: ITEMS,
+        getKey,
+        getItemLabel,
+        onreorder,
+        label: 'Test list',
+        children: emptySnippet(),
+      },
+    });
+
+    const handle = container.querySelectorAll('.cinder-sortable-handle')[0] as HTMLElement;
+
+    await fireEvent.keyDown(handle, { key: ' ' }); // Lift Alpha.
+    await fireEvent.keyDown(handle, { key: 'ArrowDown' }); // Move to position 2.
+    await fireEvent.keyDown(handle, { key: ' ' }); // Drop.
+
+    expect(onreorder).toHaveBeenCalledTimes(1);
+    const [nextItems, change] = onreorder.mock.calls[0];
+    expect(nextItems.map((i: Item) => i.id)).toEqual(['b', 'a', 'c']);
+    expect(change.fromIndex).toBe(0);
+    expect(change.toIndex).toBe(1);
+    expect(change.itemKey).toBe('a');
+    expect(handle.getAttribute('aria-pressed')).toBe('false');
+  });
+
+  test('Escape cancels — onreorder not called, aria-pressed returns false', async () => {
+    const onreorder = mock();
+    const { container } = render(SortableList as any, {
+      props: {
+        items: ITEMS,
+        getKey,
+        getItemLabel,
+        onreorder,
+        label: 'Test list',
+        children: emptySnippet(),
+      },
+    });
+
+    const handle = container.querySelectorAll('.cinder-sortable-handle')[0] as HTMLElement;
+
+    await fireEvent.keyDown(handle, { key: ' ' });
+    await fireEvent.keyDown(handle, { key: 'ArrowDown' });
+    await fireEvent.keyDown(handle, { key: 'Escape' });
+
+    expect(onreorder).not.toHaveBeenCalled();
+    expect(handle.getAttribute('aria-pressed')).toBe('false');
+  });
+
+  test('drop at same position does not call onreorder', async () => {
+    const onreorder = mock();
+    const { container } = render(SortableList as any, {
+      props: {
+        items: ITEMS,
+        getKey,
+        getItemLabel,
+        onreorder,
+        label: 'Test list',
+        children: emptySnippet(),
+      },
+    });
+
+    const handle = container.querySelectorAll('.cinder-sortable-handle')[0] as HTMLElement;
+
+    await fireEvent.keyDown(handle, { key: ' ' }); // Lift.
+    await fireEvent.keyDown(handle, { key: ' ' }); // Drop at same index.
+
+    expect(onreorder).not.toHaveBeenCalled();
+  });
+
+  test('custom announcements prop overrides defaults', () => {
+    const announce = mock();
+    const controller = new SortableController({
+      announce,
+      announcements: {
+        lifted: (label) => `CUSTOM LIFT ${label}`,
+      },
+    });
+
+    controller.lift('a', 0, 'Alpha', 3);
+
+    expect(announce.mock.calls[0][0]).toBe('CUSTOM LIFT Alpha');
+  });
+
+  test('onreorder receives full reordered array and correct change metadata', async () => {
+    const onreorder = mock();
+    const { container } = render(SortableList as any, {
+      props: {
+        items: ITEMS,
+        getKey,
+        getItemLabel,
+        onreorder,
+        label: 'Test list',
+        children: emptySnippet(),
+      },
+    });
+
+    const handles = container.querySelectorAll('.cinder-sortable-handle');
+    const lastHandle = handles[handles.length - 1] as HTMLElement; // Gamma (index 2).
+
+    await fireEvent.keyDown(lastHandle, { key: ' ' }); // Lift Gamma.
+    await fireEvent.keyDown(lastHandle, { key: 'ArrowUp' }); // Move to index 1.
+    await fireEvent.keyDown(lastHandle, { key: ' ' }); // Drop.
+
+    expect(onreorder).toHaveBeenCalledTimes(1);
+    const [nextItems, change] = onreorder.mock.calls[0];
+    expect(nextItems.length).toBe(3);
+    expect(change.itemKey).toBe('c');
+    expect(change.fromIndex).toBe(2);
+    expect(change.toIndex).toBe(1);
+  });
+
+  test('component does not mutate the items prop', async () => {
+    const original = [
+      { id: 'a', label: 'Alpha' },
+      { id: 'b', label: 'Beta' },
+    ];
+    const frozen = Object.freeze(original.map((i) => Object.freeze({ ...i })));
+    const onreorder = mock();
+
+    const { container } = render(SortableList as any, {
+      props: {
+        items: frozen as any,
+        getKey,
+        getItemLabel,
+        onreorder,
+        label: 'Frozen list',
+        children: emptySnippet(),
+      },
+    });
+
+    const handle = container.querySelectorAll('.cinder-sortable-handle')[0] as HTMLElement;
+
+    await fireEvent.keyDown(handle, { key: ' ' });
+    await fireEvent.keyDown(handle, { key: 'ArrowDown' });
+    await fireEvent.keyDown(handle, { key: ' ' });
+
+    // If items were mutated, the frozen object would throw. No throw = no mutation.
+    expect(onreorder).toHaveBeenCalledTimes(1);
+    expect(frozen.map((i) => i.id)).toEqual(['a', 'b']); // Unchanged.
+  });
+});

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -167,6 +167,14 @@ export {
 export { default as Select } from './components/select.svelte';
 export type { SelectOption, SelectProps } from './components/select.svelte';
 
+export { default as SortableList } from './components/sortable-list.svelte';
+export type { SortableListProps } from './components/sortable-list.svelte';
+export type {
+  SortableAnnouncements,
+  SortableItemContext,
+  SortableReorderChange,
+} from './utilities/sortable-controller.svelte.ts';
+
 export { default as SegmentedControl } from './components/segmented-control.svelte';
 export type {
   SegmentedControlOption,

--- a/packages/components/src/styles/components.css
+++ b/packages/components/src/styles/components.css
@@ -39,6 +39,7 @@
 @import './components/segmented-control.css';
 @import './components/selection-popover.css';
 @import './components/skeleton.css';
+@import './components/sortable-list.css';
 @import './components/spinner.css';
 @import './components/surface.css';
 @import './components/tab.css';

--- a/packages/components/src/styles/components/sortable-list.css
+++ b/packages/components/src/styles/components/sortable-list.css
@@ -1,0 +1,61 @@
+/* ========================================
+ * SORTABLE LIST
+ * ======================================== */
+
+.cinder-sortable-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.cinder-sortable-item {
+  position: relative;
+  cursor: default;
+  user-select: none;
+}
+
+.cinder-sortable-item--lifted {
+  transform: scale(1.02);
+  box-shadow: var(--cinder-shadow-elevated, 0 4px 16px rgb(0 0 0 / 0.15));
+  z-index: 1;
+  position: relative;
+}
+
+.cinder-sortable-item--shifting {
+  transition: transform 150ms ease;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .cinder-sortable-item--shifting {
+    transition: none;
+  }
+
+  .cinder-sortable-item--lifted {
+    transform: none;
+    box-shadow: var(--cinder-shadow-elevated, 0 4px 16px rgb(0 0 0 / 0.15));
+  }
+}
+
+.cinder-sortable-handle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 44px;
+  min-height: 44px;
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: grab;
+  touch-action: none;
+  color: inherit;
+}
+
+.cinder-sortable-handle:focus-visible {
+  outline: var(--cinder-focus-ring, 2px solid currentcolor);
+  outline-offset: 2px;
+  border-radius: 2px;
+}
+
+.cinder-sortable-handle[aria-pressed='true'] {
+  cursor: grabbing;
+}

--- a/packages/components/src/utilities/sortable-controller.svelte.ts
+++ b/packages/components/src/utilities/sortable-controller.svelte.ts
@@ -56,6 +56,7 @@ const defaultAnnouncements: SortableAnnouncements = {
 export class SortableController<Item> {
   phase = $state<'idle' | 'lifted'>('idle');
   liftedKey = $state<string | number | null>(null);
+  liftedLabel = $state<string>('');
   liftedFrom = $state(0);
   liftedTo = $state(0);
 
@@ -73,6 +74,7 @@ export class SortableController<Item> {
   lift(key: string | number, fromIndex: number, itemLabel: string, total: number): void {
     this.phase = 'lifted';
     this.liftedKey = key;
+    this.liftedLabel = itemLabel;
     this.liftedFrom = fromIndex;
     this.liftedTo = fromIndex;
     this.#announce(this.#announcements.lifted(itemLabel, fromIndex + 1, total));
@@ -106,19 +108,26 @@ export class SortableController<Item> {
 
     if (fromIndex === toIndex) return null;
 
+    // Bounds check: liftedFrom should always be valid (reconcileLiftedKey keeps it current),
+    // but guard defensively so a stale index cannot corrupt the output array.
+    if (fromIndex < 0 || fromIndex >= items.length || toIndex < 0 || toIndex >= items.length) {
+      return null;
+    }
+
     const nextItems = reorder(items, fromIndex, toIndex);
     return { nextItems, change: { itemKey, fromIndex, toIndex } };
   }
 
-  cancel(itemLabel: string): void {
+  cancel(itemLabel?: string): void {
     if (this.phase !== 'lifted') return;
-    this.#announce(this.#announcements.cancelled(itemLabel));
+    this.#announce(this.#announcements.cancelled(itemLabel ?? this.liftedLabel));
     this.#reset();
   }
 
   /**
    * Called by SortableList in a $effect when items changes during a lift.
-   * If the lifted key is gone, auto-cancels. If it moved, updates liftedFrom.
+   * If the lifted key is gone, auto-cancels using the stored liftedLabel.
+   * If it moved, updates liftedFrom.
    */
   reconcileLiftedKey(items: Item[], getKey: (item: Item) => string | number): void {
     if (this.phase !== 'lifted' || this.liftedKey === null) return;
@@ -126,8 +135,8 @@ export class SortableController<Item> {
     const currentIndex = items.findIndex((it) => getKey(it) === this.liftedKey);
 
     if (currentIndex < 0) {
-      // Lifted item was removed by parent — auto cancel without announcement label
-      this.#announce(this.#announcements.cancelled(''));
+      // Lifted item was removed by parent — announce with the stored label
+      this.#announce(this.#announcements.cancelled(this.liftedLabel));
       this.#reset();
       return;
     }
@@ -141,6 +150,7 @@ export class SortableController<Item> {
   #reset(): void {
     this.phase = 'idle';
     this.liftedKey = null;
+    this.liftedLabel = '';
     this.liftedFrom = 0;
     this.liftedTo = 0;
   }

--- a/packages/components/src/utilities/sortable-controller.svelte.ts
+++ b/packages/components/src/utilities/sortable-controller.svelte.ts
@@ -1,0 +1,158 @@
+import { createContext } from 'svelte';
+
+export type SortableAnnouncements = {
+  lifted: (itemLabel: string, position: number, total: number) => string;
+  moved: (itemLabel: string, position: number, total: number) => string;
+  dropped: (itemLabel: string, position: number, total: number) => string;
+  cancelled: (itemLabel: string) => string;
+};
+
+export type SortableReorderChange = {
+  itemKey: string | number;
+  /** Index of the lifted item in `items` immediately before the drop. */
+  fromIndex: number;
+  /** Index where the item is placed after the drop. */
+  toIndex: number;
+};
+
+export type SortableItemContext = {
+  /** True when this row is currently lifted. */
+  isLifted: boolean;
+  /** True when this row would receive the drop. */
+  isDropTarget: boolean;
+  /** The visual index this row currently occupies. */
+  visualIndex: number;
+  /** Total rows in the list. */
+  total: number;
+};
+
+/** Shape of the command bag passed through context from SortableList to SortableItem. */
+export type SortableContextValue = {
+  controller: SortableController<unknown>;
+  commitDrop: (itemKey: string | number, itemLabel: string) => void;
+  cancel: (itemLabel: string) => void;
+  lift: (key: string | number, fromIndex: number, itemLabel: string, total: number) => void;
+  move: (toIndex: number, itemLabel: string, total: number) => void;
+};
+
+export const [getSortableContext, setSortableContext] = createContext<SortableContextValue>();
+
+const defaultAnnouncements: SortableAnnouncements = {
+  lifted: (itemLabel, position, total) =>
+    `${itemLabel}, lifted. Current position ${position} of ${total}. Use arrow keys to move. Space to drop, Escape to cancel.`,
+  moved: (itemLabel, position, total) => `${itemLabel}, moved to position ${position} of ${total}.`,
+  dropped: (itemLabel, position, total) =>
+    `${itemLabel}, dropped at position ${position} of ${total}.`,
+  cancelled: (itemLabel) => `Reorder cancelled. ${itemLabel} returned to original position.`,
+};
+
+/**
+ * Pure state machine for sortable list reordering.
+ *
+ * Does not own onreorder — SortableList inspects the return value of drop() and
+ * invokes the consumer callback itself. Does not import useAnnouncer — it receives
+ * an announce callback at construction time.
+ */
+export class SortableController<Item> {
+  phase = $state<'idle' | 'lifted'>('idle');
+  liftedKey = $state<string | number | null>(null);
+  liftedFrom = $state(0);
+  liftedTo = $state(0);
+
+  readonly #announce: (message: string) => void;
+  readonly #announcements: SortableAnnouncements;
+
+  constructor(options: {
+    announce: (message: string) => void;
+    announcements?: Partial<SortableAnnouncements>;
+  }) {
+    this.#announce = options.announce;
+    this.#announcements = { ...defaultAnnouncements, ...options.announcements };
+  }
+
+  lift(key: string | number, fromIndex: number, itemLabel: string, total: number): void {
+    this.phase = 'lifted';
+    this.liftedKey = key;
+    this.liftedFrom = fromIndex;
+    this.liftedTo = fromIndex;
+    this.#announce(this.#announcements.lifted(itemLabel, fromIndex + 1, total));
+  }
+
+  move(toIndex: number, itemLabel: string, total: number): void {
+    if (this.phase !== 'lifted') return;
+    const clamped = Math.max(0, Math.min(total - 1, toIndex));
+    if (clamped === this.liftedTo) return;
+    this.liftedTo = clamped;
+    this.#announce(this.#announcements.moved(itemLabel, clamped + 1, total));
+  }
+
+  /**
+   * Attempt a drop. Returns { nextItems, change } if order changed, null otherwise.
+   * Always announces dropped regardless.
+   * Caller (SortableList) is responsible for calling onreorder when non-null is returned.
+   */
+  drop(
+    items: Item[],
+    itemLabel: string,
+  ): { nextItems: Item[]; change: SortableReorderChange } | null {
+    if (this.phase !== 'lifted' || this.liftedKey === null) return null;
+
+    const fromIndex = this.liftedFrom;
+    const toIndex = this.liftedTo;
+    const itemKey = this.liftedKey;
+
+    this.#announce(this.#announcements.dropped(itemLabel, toIndex + 1, items.length));
+    this.#reset();
+
+    if (fromIndex === toIndex) return null;
+
+    const nextItems = reorder(items, fromIndex, toIndex);
+    return { nextItems, change: { itemKey, fromIndex, toIndex } };
+  }
+
+  cancel(itemLabel: string): void {
+    if (this.phase !== 'lifted') return;
+    this.#announce(this.#announcements.cancelled(itemLabel));
+    this.#reset();
+  }
+
+  /**
+   * Called by SortableList in a $effect when items changes during a lift.
+   * If the lifted key is gone, auto-cancels. If it moved, updates liftedFrom.
+   */
+  reconcileLiftedKey(items: Item[], getKey: (item: Item) => string | number): void {
+    if (this.phase !== 'lifted' || this.liftedKey === null) return;
+
+    const currentIndex = items.findIndex((it) => getKey(it) === this.liftedKey);
+
+    if (currentIndex < 0) {
+      // Lifted item was removed by parent — auto cancel without announcement label
+      this.#announce(this.#announcements.cancelled(''));
+      this.#reset();
+      return;
+    }
+
+    if (currentIndex !== this.liftedFrom) {
+      this.liftedFrom = currentIndex;
+      this.liftedTo = Math.max(0, Math.min(items.length - 1, this.liftedTo));
+    }
+  }
+
+  #reset(): void {
+    this.phase = 'idle';
+    this.liftedKey = null;
+    this.liftedFrom = 0;
+    this.liftedTo = 0;
+  }
+}
+
+/**
+ * Reorder helper: moves the item at fromIndex to toIndex.
+ * Returns a new array; does not mutate the input.
+ */
+export function reorder<T>(items: T[], fromIndex: number, toIndex: number): T[] {
+  const result = [...items];
+  const removed = result.splice(fromIndex, 1)[0] as T;
+  result.splice(toIndex, 0, removed);
+  return result;
+}

--- a/packages/components/src/utilities/sortable-controller.svelte.ts
+++ b/packages/components/src/utilities/sortable-controller.svelte.ts
@@ -141,9 +141,11 @@ export class SortableController<Item> {
       return;
     }
 
+    // Always clamp liftedTo — items may have been removed from the end of the list
+    // even when the lifted item's own index hasn't changed.
+    this.liftedTo = Math.max(0, Math.min(items.length - 1, this.liftedTo));
     if (currentIndex !== this.liftedFrom) {
       this.liftedFrom = currentIndex;
-      this.liftedTo = Math.max(0, Math.min(items.length - 1, this.liftedTo));
     }
   }
 

--- a/packages/components/src/utilities/sortable-controller.svelte.ts
+++ b/packages/components/src/utilities/sortable-controller.svelte.ts
@@ -72,6 +72,8 @@ export class SortableController<Item> {
   }
 
   lift(key: string | number, fromIndex: number, itemLabel: string, total: number): void {
+    // Reject concurrent lifts — a second item must not overwrite an in-progress drag.
+    if (this.phase === 'lifted') return;
     this.phase = 'lifted';
     this.liftedKey = key;
     this.liftedLabel = itemLabel;

--- a/packages/playground/src/analyze.ts
+++ b/packages/playground/src/analyze.ts
@@ -466,6 +466,8 @@ export async function analyzeAll(componentsDir: string): Promise<ComponentManife
   const filePaths: string[] = [];
 
   for await (const file of glob.scan({ cwd: componentsDir })) {
+    // Skip internal components (underscore-prefixed filenames are not public API)
+    if (file.startsWith('_')) continue;
     filePaths.push(join(componentsDir, file));
   }
 

--- a/packages/playground/src/discover.ts
+++ b/packages/playground/src/discover.ts
@@ -18,7 +18,8 @@ export async function discoverComponents(): Promise<string[]> {
   const names: string[] = [];
 
   for await (const file of glob.scan({ cwd: join(COMPONENTS_ROOT, 'src', 'components') })) {
-    // file is like "button.svelte"
+    // file is like "button.svelte"; skip internal components (underscore-prefixed)
+    if (file.startsWith('_')) continue;
     const name = file.replace(/\.svelte$/, '');
     names.push(name);
   }


### PR DESCRIPTION
## Summary

- Adds `SortableList` and internal `_SortableItem` to `@cinder/components` with full WAI-ARIA drag-and-drop authoring practices
- Keyboard-first: Space to lift, Arrow Up/Down/Home/End to move, Space to drop, Escape to cancel
- Live-region announcements (`role="alert"`) for all four state transitions (lifted/moved/dropped/cancelled)
- Pointer Events strategy (not HTML5 DnD) for iOS Safari compatibility; auto-scroll at viewport edges
- Reduced-motion CSS media query suppresses shift-preview transitions while preserving lift shadow
- 34 unit tests covering controller state machine, reorder helper, and component keyboard interactions
- Accessibility docs in `sortable-list.a11y.md`

**Public exports:** `SortableList`, `SortableListProps`, `SortableItemContext`, `SortableReorderChange`, `SortableAnnouncements`

## Review committee

Pre-reviewed by: ux-designer, testing-expert, typescript-expert, frontend-architect, simplicity-engineer, Codex

- Codex (gpt-5.4, xhigh reasoning) — 3 rounds
- 3 rounds of multi-agent review
- All must-fix items addressed across 5 commits

**Key improvements from committee review:**
- `role="alert"` replaces `role="status"` + `aria-live="assertive"` conflict
- `liftedLabel` stored on controller — auto-cancel always announces correct item name
- Instructions element moved inside `<ul>` before rows (aria-describedby timing fix)
- Window Escape handler calls `controller.cancel()` for focus-independent cancellation
- New `$effect` observes controller phase — cleans up pointer session on external cancellation
- `getItemLabel` receives original index (not visual drag position)
- Pointer session vars changed from `$state` to plain `let` (no reactive consumers)
- Split `moveRafHandle` / `scrollRafHandle` to prevent rAF competition
- `:scope > [data-sortable-row]` prevents nested sortable list corruption
- Defensive bounds check in `drop()` before reorder

**Known limitations (documented in sortable-list.a11y.md):**
- Window-only auto-scroll (nested scroll containers not supported)
- No pointer/browser tests (jsdom limitation; pointer behavior covered by code review)
- NVDA on Windows: verified with VoiceOver on macOS only

## Test plan

- [ ] `bun test src/components/sortable-list.test.ts` — 34 tests, all pass
- [ ] `bun test --conditions browser` — 699 tests, all pass
- [ ] Manual: keyboard drag with VoiceOver (Space lift → Arrow Down → Space drop)
- [ ] Manual: pointer drag in Chrome and Safari
- [ ] Manual: Escape during drag cancels and restores order

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new interactive drag/reorder component and state machine, including global key handling and pointer-capture logic, which can introduce subtle UX/a11y or edge-case bugs despite strong test coverage.
> 
> **Overview**
> Introduces a new `SortableList` component (and internal `_sortable-item`) that supports keyboard-first and pointer-based list reordering, including live-region announcements and per-row context for rendering lifted/target state.
> 
> Adds a `SortableController` utility/state machine plus `reorder()` helper, wires new styles (`sortable-list.css`), and exports the new component/types from the package API (`package.json` exports and `src/index.ts`).
> 
> Updates the playground’s component discovery/analyzer to skip underscore-prefixed internal `.svelte` files, and adds comprehensive unit tests for controller behavior and keyboard interactions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4579e5dc2d0e9fba556689f45ed40e6b000badd5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->