### PR TITLE
feat(page-layout): add breadcrumbs/meta/avatar slots + title snippet

### DIFF
--- a/packages/components/src/api-contract.ts
+++ b/packages/components/src/api-contract.ts
@@ -295,10 +295,13 @@ export const CONTRACT: Record<string, ComponentContract> = {
   'page-layout': {
     kind: 'literal',
     props: {
-      title: { optional: false, type_kind: 'TSStringKeyword', default: REQUIRED },
+      title: { optional: false, type_kind: 'TSTypeReference', default: REQUIRED },
       class: { optional: true, type_kind: 'TSStringKeyword', default: L(undefined) },
     },
     snippets: {
+      breadcrumbs: s0(true),
+      avatar: s0(true),
+      meta: s0(true),
       actions: s0(true),
       children: s0(false),
     },

--- a/packages/components/src/components/page-layout.svelte
+++ b/packages/components/src/components/page-layout.svelte
@@ -1,10 +1,29 @@
 <script lang="ts" module>
   import type { Snippet } from 'svelte';
 
+  /**
+   * Title input. A plain TypeScript union narrowed via `typeof title === 'string'`.
+   *
+   * - `string`: page-layout renders `<h1 class="cinder-page-layout-title">` itself.
+   * - `Snippet`: the snippet fully owns the heading element. Consumers MUST render
+   *   an `<h1>` inside the snippet.
+   */
+  export type PageLayoutTitle = string | Snippet;
+
   export type PageLayoutProps = {
-    title: string;
+    /** Page title. String renders inside `.cinder-page-layout-title` <h1>; Snippet owns its own heading. */
+    title: PageLayoutTitle;
+    /** Additional class names merged onto the root element. */
     class?: string;
+    /** Optional breadcrumb row rendered above the title row. */
+    breadcrumbs?: Snippet;
+    /** Optional avatar rendered inline-start of the title. */
+    avatar?: Snippet;
+    /** Optional metadata rendered beneath the title. Intended for a `<dl>` of role/date/location. */
+    meta?: Snippet;
+    /** Optional action cluster rendered at the flex-end of the title row. */
     actions?: Snippet;
+    /** Main page content. */
     children: Snippet;
   };
 </script>
@@ -12,13 +31,46 @@
 <script lang="ts">
   import { classNames } from '../utilities/class-names.ts';
 
-  let { title, class: className, actions, children }: PageLayoutProps = $props();
+  let {
+    title,
+    class: className,
+    breadcrumbs,
+    avatar,
+    meta,
+    actions,
+    children,
+  }: PageLayoutProps = $props();
 </script>
 
 <div class={classNames('cinder-page-layout', className)}>
   <header class="cinder-page-layout-header">
+    {#if breadcrumbs}
+      <div class="cinder-page-layout-breadcrumbs">
+        {@render breadcrumbs()}
+      </div>
+    {/if}
+
     <div class="cinder-page-layout-header-row">
-      <h1 class="cinder-page-layout-title">{title}</h1>
+      {#if avatar}
+        <div class="cinder-page-layout-avatar">
+          {@render avatar()}
+        </div>
+      {/if}
+
+      <div class="cinder-page-layout-title-column">
+        {#if typeof title === 'string'}
+          <h1 class="cinder-page-layout-title">{title}</h1>
+        {:else}
+          {@render title()}
+        {/if}
+
+        {#if meta}
+          <div class="cinder-page-layout-meta">
+            {@render meta()}
+          </div>
+        {/if}
+      </div>
+
       {#if actions}
         <div class="cinder-page-layout-actions">
           {@render actions()}

--- a/packages/components/src/components/page-layout.svelte
+++ b/packages/components/src/components/page-layout.svelte
@@ -44,12 +44,6 @@
 
 <div class={classNames('cinder-page-layout', className)}>
   <header class="cinder-page-layout-header">
-    {#if breadcrumbs}
-      <div class="cinder-page-layout-breadcrumbs">
-        {@render breadcrumbs()}
-      </div>
-    {/if}
-
     <div class="cinder-page-layout-header-row">
       {#if avatar}
         <div class="cinder-page-layout-avatar">
@@ -78,6 +72,12 @@
       {/if}
     </div>
   </header>
+
+  {#if breadcrumbs}
+    <div class="cinder-page-layout-breadcrumbs">
+      {@render breadcrumbs()}
+    </div>
+  {/if}
 
   <div class="cinder-page-layout-content">
     {@render children()}

--- a/packages/components/src/components/page-layout.test.ts
+++ b/packages/components/src/components/page-layout.test.ts
@@ -79,6 +79,13 @@ describe('PageLayout rendering', () => {
     expect(container.querySelector('.cinder-page-layout-actions')).toBeNull();
   });
 
+  test('header landmark wraps the title row', () => {
+    const { container } = render(PageLayout, {
+      props: { title: 'Page', children },
+    });
+    expect(container.querySelector('header.cinder-page-layout-header')).not.toBeNull();
+  });
+
   test('applies class prop to root element', () => {
     const { container } = render(PageLayout, {
       props: {
@@ -95,7 +102,7 @@ describe('PageLayout rendering', () => {
 });
 
 describe('PageLayout breadcrumbs slot', () => {
-  test('breadcrumbs snippet renders above the title row', () => {
+  test('breadcrumbs snippet renders below the sticky header and above the content', () => {
     const breadcrumbs = createRawSnippet(() => ({
       render: () => '<nav aria-label="Breadcrumb">Home</nav>',
     }));
@@ -105,12 +112,18 @@ describe('PageLayout breadcrumbs slot', () => {
     });
 
     const breadcrumbsEl = container.querySelector('.cinder-page-layout-breadcrumbs');
-    const headerRow = container.querySelector('.cinder-page-layout-header-row');
+    const header = container.querySelector('.cinder-page-layout-header');
+    const content = container.querySelector('.cinder-page-layout-content');
     expect(breadcrumbsEl).not.toBeNull();
-    expect(headerRow).not.toBeNull();
-    // breadcrumbs must precede the header row in DOM order
-    const position = breadcrumbsEl!.compareDocumentPosition(headerRow!);
-    expect(position & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    expect(header).not.toBeNull();
+    expect(content).not.toBeNull();
+    // breadcrumbs must be outside (after) the sticky header and before content
+    const afterHeader =
+      header!.compareDocumentPosition(breadcrumbsEl!) & Node.DOCUMENT_POSITION_FOLLOWING;
+    const beforeContent =
+      breadcrumbsEl!.compareDocumentPosition(content!) & Node.DOCUMENT_POSITION_FOLLOWING;
+    expect(afterHeader).toBeTruthy();
+    expect(beforeContent).toBeTruthy();
   });
 
   test('breadcrumbs slot is absent when not provided', () => {
@@ -187,6 +200,9 @@ describe('PageLayout title as snippet', () => {
 
     expect(container.querySelector('[data-testid="custom-h1"]')).not.toBeNull();
     expect(container.querySelector('.cinder-page-layout-title')).toBeNull();
+    // snippet must render inside the title column
+    const column = container.querySelector('.cinder-page-layout-title-column');
+    expect(column?.querySelector('[data-testid="custom-h1"]')).not.toBeNull();
   });
 
   test('title as string still renders default h1', () => {
@@ -204,10 +220,8 @@ describe('PageLayout actions row CSS', () => {
   test('actions row min-block-size is declared in the stylesheet', async () => {
     const cssPath = new URL('../styles/components/page-layout.css', import.meta.url);
     const css = await Bun.file(cssPath).text();
-    // Match .cinder-page-layout-header-row block containing min-block-size: 2.75rem
-    const headerRowBlockMatch = css.match(/\.cinder-page-layout-header-row\s*\{([^}]+)\}/);
-    expect(headerRowBlockMatch).not.toBeNull();
-    expect(headerRowBlockMatch![1]).toMatch(/min-block-size\s*:\s*2\.75rem/);
+    // Match the selector and then min-block-size: 2.75rem anywhere after it
+    expect(css).toMatch(/\.cinder-page-layout-header-row[\s\S]*?min-block-size\s*:\s*2\.75rem/);
   });
 
   test('actions align to the inline-end of the title row', async () => {
@@ -227,17 +241,15 @@ describe('PageLayout actions row CSS', () => {
     // (a) actions must be the last child of the header row
     expect(headerRow!.lastElementChild).toBe(actionsEl);
 
-    // (b) CSS declares margin-inline-start: auto inside .cinder-page-layout-actions
+    // (b) CSS declares margin-inline-start: auto linked to .cinder-page-layout-actions
     const cssPath = new URL('../styles/components/page-layout.css', import.meta.url);
     const css = await Bun.file(cssPath).text();
-    const actionsBlockMatch = css.match(/\.cinder-page-layout-actions\s*\{([^}]+)\}/);
-    expect(actionsBlockMatch).not.toBeNull();
-    expect(actionsBlockMatch![1]).toMatch(/margin-inline-start\s*:\s*auto/);
+    expect(css).toMatch(/\.cinder-page-layout-actions[\s\S]*?margin-inline-start\s*:\s*auto/);
   });
 });
 
 describe('PageLayout DOM order', () => {
-  test('DOM order is breadcrumbs → header-row → content', () => {
+  test('DOM order is header → breadcrumbs → content', () => {
     const breadcrumbs = createRawSnippet(() => ({
       render: () => '<nav>Breadcrumbs</nav>',
     }));
@@ -246,21 +258,21 @@ describe('PageLayout DOM order', () => {
       props: { title: 'Page', children, breadcrumbs },
     });
 
+    const header = container.querySelector('.cinder-page-layout-header')!;
     const breadcrumbsEl = container.querySelector('.cinder-page-layout-breadcrumbs')!;
-    const headerRow = container.querySelector('.cinder-page-layout-header-row')!;
     const content = container.querySelector('.cinder-page-layout-content')!;
 
+    expect(header).not.toBeNull();
     expect(breadcrumbsEl).not.toBeNull();
-    expect(headerRow).not.toBeNull();
     expect(content).not.toBeNull();
 
-    // breadcrumbs precedes header-row
+    // sticky header precedes breadcrumbs (breadcrumbs outside the banner landmark)
     expect(
-      breadcrumbsEl.compareDocumentPosition(headerRow) & Node.DOCUMENT_POSITION_FOLLOWING,
+      header.compareDocumentPosition(breadcrumbsEl) & Node.DOCUMENT_POSITION_FOLLOWING,
     ).toBeTruthy();
-    // header-row precedes content
+    // breadcrumbs precedes page content
     expect(
-      headerRow.compareDocumentPosition(content) & Node.DOCUMENT_POSITION_FOLLOWING,
+      breadcrumbsEl.compareDocumentPosition(content) & Node.DOCUMENT_POSITION_FOLLOWING,
     ).toBeTruthy();
   });
 });
@@ -311,12 +323,13 @@ describe('PageLayout integration: all slots simultaneously', () => {
     // Default .cinder-page-layout-title class must not appear when title is a snippet
     expect(container.querySelector('.cinder-page-layout-title')).toBeNull();
 
-    // DOM order: breadcrumbs → avatar → title → meta → actions → content
+    // Document order: avatar → title → meta → actions (inside header) → breadcrumbs → content
+    // Breadcrumbs sits outside the sticky <header>, between it and the page content.
     const FOLLOWING = Node.DOCUMENT_POSITION_FOLLOWING;
-    expect(breadcrumbsEl.compareDocumentPosition(avatarEl) & FOLLOWING).toBeTruthy();
     expect(avatarEl.compareDocumentPosition(customTitle) & FOLLOWING).toBeTruthy();
     expect(customTitle.compareDocumentPosition(metaEl) & FOLLOWING).toBeTruthy();
     expect(metaEl.compareDocumentPosition(actionsEl) & FOLLOWING).toBeTruthy();
-    expect(actionsEl.compareDocumentPosition(contentEl) & FOLLOWING).toBeTruthy();
+    expect(actionsEl.compareDocumentPosition(breadcrumbsEl) & FOLLOWING).toBeTruthy();
+    expect(breadcrumbsEl.compareDocumentPosition(contentEl) & FOLLOWING).toBeTruthy();
   });
 });

--- a/packages/components/src/components/page-layout.test.ts
+++ b/packages/components/src/components/page-layout.test.ts
@@ -12,12 +12,14 @@ const { render } = await import('@testing-library/svelte');
 const { createRawSnippet } = await import('svelte');
 const { default: PageLayout } = await import('./page-layout.svelte');
 
+const children = createRawSnippet(() => ({ render: () => '<p>Content</p>' }));
+
 describe('PageLayout rendering', () => {
   test('renders with title', () => {
     const { container } = render(PageLayout, {
       props: {
         title: 'Dashboard',
-        children: createRawSnippet(() => ({ render: () => '<p>Content</p>' })),
+        children,
       },
     });
     expect(container.querySelector('.cinder-page-layout')).not.toBeNull();
@@ -27,7 +29,7 @@ describe('PageLayout rendering', () => {
     const { container } = render(PageLayout, {
       props: {
         title: 'My Page',
-        children: createRawSnippet(() => ({ render: () => '<p>Content</p>' })),
+        children,
       },
     });
     const heading = container.querySelector('.cinder-page-layout-title');
@@ -56,7 +58,7 @@ describe('PageLayout rendering', () => {
     const { container } = render(PageLayout, {
       props: {
         title: 'Page',
-        children: createRawSnippet(() => ({ render: () => '<p>Content</p>' })),
+        children,
         actions: actionsSnippet,
       },
     });
@@ -70,7 +72,7 @@ describe('PageLayout rendering', () => {
     const { container } = render(PageLayout, {
       props: {
         title: 'Page',
-        children: createRawSnippet(() => ({ render: () => '<p>Content</p>' })),
+        children,
       },
     });
 
@@ -82,12 +84,239 @@ describe('PageLayout rendering', () => {
       props: {
         title: 'Page',
         class: 'my-custom-class',
-        children: createRawSnippet(() => ({ render: () => '<p>Content</p>' })),
+        children,
       },
     });
 
     const root = container.querySelector('.cinder-page-layout');
     expect(root?.classList.contains('my-custom-class')).toBe(true);
     expect(root?.classList.contains('cinder-page-layout')).toBe(true);
+  });
+});
+
+describe('PageLayout breadcrumbs slot', () => {
+  test('breadcrumbs snippet renders above the title row', () => {
+    const breadcrumbs = createRawSnippet(() => ({
+      render: () => '<nav aria-label="Breadcrumb">Home</nav>',
+    }));
+
+    const { container } = render(PageLayout, {
+      props: { title: 'Page', children, breadcrumbs },
+    });
+
+    const breadcrumbsEl = container.querySelector('.cinder-page-layout-breadcrumbs');
+    const headerRow = container.querySelector('.cinder-page-layout-header-row');
+    expect(breadcrumbsEl).not.toBeNull();
+    expect(headerRow).not.toBeNull();
+    // breadcrumbs must precede the header row in DOM order
+    const position = breadcrumbsEl!.compareDocumentPosition(headerRow!);
+    expect(position & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  });
+
+  test('breadcrumbs slot is absent when not provided', () => {
+    const { container } = render(PageLayout, {
+      props: { title: 'Page', children },
+    });
+    expect(container.querySelector('.cinder-page-layout-breadcrumbs')).toBeNull();
+  });
+});
+
+describe('PageLayout meta slot', () => {
+  test('meta snippet renders beneath the title', () => {
+    const meta = createRawSnippet(() => ({
+      render: () => '<dl><dt>Role</dt><dd>Owner</dd></dl>',
+    }));
+
+    const { container } = render(PageLayout, {
+      props: { title: 'Page', children, meta },
+    });
+
+    const metaEl = container.querySelector('.cinder-page-layout-meta');
+    const titleEl = container.querySelector('.cinder-page-layout-title');
+    expect(metaEl).not.toBeNull();
+    expect(titleEl).not.toBeNull();
+    // title must precede meta in DOM order
+    const position = titleEl!.compareDocumentPosition(metaEl!);
+    expect(position & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  });
+
+  test('meta slot is absent when not provided', () => {
+    const { container } = render(PageLayout, {
+      props: { title: 'Page', children },
+    });
+    expect(container.querySelector('.cinder-page-layout-meta')).toBeNull();
+  });
+});
+
+describe('PageLayout avatar slot', () => {
+  test('avatar snippet renders inline-start of the title', () => {
+    const avatar = createRawSnippet(() => ({
+      render: () => '<img src="/avatar.png" alt="User" />',
+    }));
+
+    const { container } = render(PageLayout, {
+      props: { title: 'Page', children, avatar },
+    });
+
+    const avatarEl = container.querySelector('.cinder-page-layout-avatar');
+    const titleEl = container.querySelector('.cinder-page-layout-title');
+    expect(avatarEl).not.toBeNull();
+    expect(titleEl).not.toBeNull();
+    // avatar must precede the title in DOM order
+    const position = avatarEl!.compareDocumentPosition(titleEl!);
+    expect(position & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  });
+
+  test('avatar slot is absent when not provided', () => {
+    const { container } = render(PageLayout, {
+      props: { title: 'Page', children },
+    });
+    expect(container.querySelector('.cinder-page-layout-avatar')).toBeNull();
+  });
+});
+
+describe('PageLayout title as snippet', () => {
+  test('title accepts a snippet and renders it in place of the default h1', () => {
+    const titleSnippet = createRawSnippet(() => ({
+      render: () => '<h1 data-testid="custom-h1">Custom</h1>',
+    }));
+
+    const { container } = render(PageLayout, {
+      props: { title: titleSnippet, children },
+    });
+
+    expect(container.querySelector('[data-testid="custom-h1"]')).not.toBeNull();
+    expect(container.querySelector('.cinder-page-layout-title')).toBeNull();
+  });
+
+  test('title as string still renders default h1', () => {
+    const { container } = render(PageLayout, {
+      props: { title: 'String Title', children },
+    });
+
+    const heading = container.querySelector('.cinder-page-layout-title');
+    expect(heading?.tagName).toBe('H1');
+    expect(heading?.textContent?.trim()).toBe('String Title');
+  });
+});
+
+describe('PageLayout actions row CSS', () => {
+  test('actions row min-block-size is declared in the stylesheet', async () => {
+    const cssPath = new URL('../styles/components/page-layout.css', import.meta.url);
+    const css = await Bun.file(cssPath).text();
+    // Match .cinder-page-layout-header-row block containing min-block-size: 2.75rem
+    const headerRowBlockMatch = css.match(/\.cinder-page-layout-header-row\s*\{([^}]+)\}/);
+    expect(headerRowBlockMatch).not.toBeNull();
+    expect(headerRowBlockMatch![1]).toMatch(/min-block-size\s*:\s*2\.75rem/);
+  });
+
+  test('actions align to the inline-end of the title row', async () => {
+    const actionsSnippet = createRawSnippet(() => ({
+      render: () => '<button>Action</button>',
+    }));
+
+    const { container } = render(PageLayout, {
+      props: { title: 'Page', children, actions: actionsSnippet },
+    });
+
+    const headerRow = container.querySelector('.cinder-page-layout-header-row');
+    const actionsEl = container.querySelector('.cinder-page-layout-actions');
+    expect(headerRow).not.toBeNull();
+    expect(actionsEl).not.toBeNull();
+
+    // (a) actions must be the last child of the header row
+    expect(headerRow!.lastElementChild).toBe(actionsEl);
+
+    // (b) CSS declares margin-inline-start: auto inside .cinder-page-layout-actions
+    const cssPath = new URL('../styles/components/page-layout.css', import.meta.url);
+    const css = await Bun.file(cssPath).text();
+    const actionsBlockMatch = css.match(/\.cinder-page-layout-actions\s*\{([^}]+)\}/);
+    expect(actionsBlockMatch).not.toBeNull();
+    expect(actionsBlockMatch![1]).toMatch(/margin-inline-start\s*:\s*auto/);
+  });
+});
+
+describe('PageLayout DOM order', () => {
+  test('DOM order is breadcrumbs → header-row → content', () => {
+    const breadcrumbs = createRawSnippet(() => ({
+      render: () => '<nav>Breadcrumbs</nav>',
+    }));
+
+    const { container } = render(PageLayout, {
+      props: { title: 'Page', children, breadcrumbs },
+    });
+
+    const breadcrumbsEl = container.querySelector('.cinder-page-layout-breadcrumbs')!;
+    const headerRow = container.querySelector('.cinder-page-layout-header-row')!;
+    const content = container.querySelector('.cinder-page-layout-content')!;
+
+    expect(breadcrumbsEl).not.toBeNull();
+    expect(headerRow).not.toBeNull();
+    expect(content).not.toBeNull();
+
+    // breadcrumbs precedes header-row
+    expect(
+      breadcrumbsEl.compareDocumentPosition(headerRow) & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+    // header-row precedes content
+    expect(
+      headerRow.compareDocumentPosition(content) & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+  });
+});
+
+describe('PageLayout integration: all slots simultaneously', () => {
+  test('renders with all five optional snippets and preserves DOM order', () => {
+    const breadcrumbs = createRawSnippet(() => ({
+      render: () => '<nav data-testid="breadcrumbs">Home / Projects</nav>',
+    }));
+    const avatarSnippet = createRawSnippet(() => ({
+      render: () => '<img data-testid="avatar" src="/avatar.png" alt="User" />',
+    }));
+    const titleSnippet = createRawSnippet(() => ({
+      render: () => '<h1 data-testid="custom-title">Acme Corp</h1>',
+    }));
+    const metaSnippet = createRawSnippet(() => ({
+      render: () => '<dl data-testid="meta"><dt>Role</dt><dd>Owner</dd></dl>',
+    }));
+    const actionsSnippet = createRawSnippet(() => ({
+      render: () => '<button data-testid="action-btn">New Project</button>',
+    }));
+
+    const { container } = render(PageLayout, {
+      props: {
+        title: titleSnippet,
+        children,
+        breadcrumbs,
+        avatar: avatarSnippet,
+        meta: metaSnippet,
+        actions: actionsSnippet,
+      },
+    });
+
+    const breadcrumbsEl = container.querySelector('.cinder-page-layout-breadcrumbs')!;
+    const avatarEl = container.querySelector('.cinder-page-layout-avatar')!;
+    const customTitle = container.querySelector('[data-testid="custom-title"]')!;
+    const metaEl = container.querySelector('.cinder-page-layout-meta')!;
+    const actionsEl = container.querySelector('.cinder-page-layout-actions')!;
+    const contentEl = container.querySelector('.cinder-page-layout-content')!;
+
+    expect(breadcrumbsEl).not.toBeNull();
+    expect(avatarEl).not.toBeNull();
+    expect(customTitle).not.toBeNull();
+    expect(metaEl).not.toBeNull();
+    expect(actionsEl).not.toBeNull();
+    expect(contentEl).not.toBeNull();
+
+    // Default .cinder-page-layout-title class must not appear when title is a snippet
+    expect(container.querySelector('.cinder-page-layout-title')).toBeNull();
+
+    // DOM order: breadcrumbs → avatar → title → meta → actions → content
+    const FOLLOWING = Node.DOCUMENT_POSITION_FOLLOWING;
+    expect(breadcrumbsEl.compareDocumentPosition(avatarEl) & FOLLOWING).toBeTruthy();
+    expect(avatarEl.compareDocumentPosition(customTitle) & FOLLOWING).toBeTruthy();
+    expect(customTitle.compareDocumentPosition(metaEl) & FOLLOWING).toBeTruthy();
+    expect(metaEl.compareDocumentPosition(actionsEl) & FOLLOWING).toBeTruthy();
+    expect(actionsEl.compareDocumentPosition(contentEl) & FOLLOWING).toBeTruthy();
   });
 });

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -132,7 +132,7 @@ export { default as NavigationItem } from './components/navigation-item.svelte';
 export type { NavigationItemProps } from './components/navigation-item.svelte';
 
 export { default as PageLayout } from './components/page-layout.svelte';
-export type { PageLayoutProps } from './components/page-layout.svelte';
+export type { PageLayoutProps, PageLayoutTitle } from './components/page-layout.svelte';
 
 export { default as Pagination } from './components/pagination.svelte';
 export type { PaginationProps } from './components/pagination.svelte';

--- a/packages/components/src/styles/components/page-layout.css
+++ b/packages/components/src/styles/components/page-layout.css
@@ -29,6 +29,7 @@
  * ---------------------------------------- */
 
 .cinder-page-layout-breadcrumbs {
+  width: 100%;
   max-width: 72rem;
   margin-inline: auto;
   padding-inline: var(--cinder-space-4);

--- a/packages/components/src/styles/components/page-layout.css
+++ b/packages/components/src/styles/components/page-layout.css
@@ -24,10 +24,32 @@
   backdrop-filter: blur(24px);
 }
 
+/* ----------------------------------------
+ * Breadcrumbs row (optional, above header-row)
+ * ---------------------------------------- */
+
+.cinder-page-layout-breadcrumbs {
+  max-width: 72rem;
+  margin-inline: auto;
+  padding-inline: var(--cinder-space-4);
+  padding-block-end: var(--cinder-space-2);
+}
+
+@media (min-width: 640px) {
+  .cinder-page-layout-breadcrumbs {
+    padding-inline: var(--cinder-space-6);
+  }
+}
+
+/* ----------------------------------------
+ * Header row: avatar + title column + actions
+ * ---------------------------------------- */
+
 .cinder-page-layout-header-row {
   display: flex;
   align-items: center;
-  justify-content: space-between;
+  gap: var(--cinder-space-3);
+  min-block-size: 2.75rem;
   max-width: 72rem;
   margin-inline: auto;
   padding-inline: var(--cinder-space-4);
@@ -39,11 +61,42 @@
   }
 }
 
+/* ----------------------------------------
+ * Avatar (optional, inline-start of title column)
+ * ---------------------------------------- */
+
+.cinder-page-layout-avatar {
+  display: flex;
+  align-items: center;
+  flex: 0 0 auto;
+}
+
+/* ----------------------------------------
+ * Title column: heading + optional meta
+ * ---------------------------------------- */
+
+.cinder-page-layout-title-column {
+  display: flex;
+  flex-direction: column;
+  gap: var(--cinder-space-1);
+  min-inline-size: 0;
+  flex: 1 1 auto;
+}
+
 .cinder-page-layout-title {
   font-size: var(--cinder-text-lg);
   font-weight: var(--cinder-font-semibold);
   color: var(--cinder-text);
   margin: 0;
+}
+
+/* ----------------------------------------
+ * Meta (optional, beneath title)
+ * ---------------------------------------- */
+
+.cinder-page-layout-meta {
+  font-size: var(--cinder-text-sm);
+  color: var(--cinder-text-muted);
 }
 
 /* ----------------------------------------
@@ -54,6 +107,8 @@
   display: flex;
   align-items: center;
   gap: var(--cinder-space-2);
+  margin-inline-start: auto;
+  flex: 0 0 auto;
 }
 
 /* ----------------------------------------

--- a/packages/components/src/styles/components/page-layout.css
+++ b/packages/components/src/styles/components/page-layout.css
@@ -32,7 +32,7 @@
   max-width: 72rem;
   margin-inline: auto;
   padding-inline: var(--cinder-space-4);
-  padding-block-end: var(--cinder-space-2);
+  padding-block: var(--cinder-space-2);
 }
 
 @media (min-width: 640px) {

--- a/packages/components/src/styles/components/page-layout.css
+++ b/packages/components/src/styles/components/page-layout.css
@@ -25,7 +25,7 @@
 }
 
 /* ----------------------------------------
- * Breadcrumbs row (optional, above header-row)
+ * Breadcrumbs row (optional, below sticky header, above content)
  * ---------------------------------------- */
 
 .cinder-page-layout-breadcrumbs {
@@ -49,6 +49,7 @@
   display: flex;
   align-items: center;
   gap: var(--cinder-space-3);
+  /* 2.75rem = 44px — WCAG 2.5.5 minimum touch target row height */
   min-block-size: 2.75rem;
   max-width: 72rem;
   margin-inline: auto;
@@ -97,6 +98,11 @@
 .cinder-page-layout-meta {
   font-size: var(--cinder-text-sm);
   color: var(--cinder-text-muted);
+}
+
+.cinder-page-layout-meta > * {
+  /* Suppress browser default margins on <dl> and other block-level meta elements */
+  margin-block: 0;
 }
 
 /* ----------------------------------------


### PR DESCRIPTION
## Summary

- Add optional `breadcrumbs`, `avatar`, and `meta` snippet slots to `PageLayout`
- Accept `title` as `string | Snippet` (`PageLayoutTitle` union), with `typeof` narrowing — string renders the default `<h1>`, Snippet owns the heading element
- Ensure header row has `min-block-size: 2.75rem` (44px) and actions align to flex-end via `margin-inline-start: auto`
- Export `PageLayoutTitle` from the public index alongside `PageLayoutProps`
- Move breadcrumbs outside `<header>` banner landmark (renders between sticky header and page content, not inside it)

## Review committee

Pre-reviewed by: typescript-expert, testing-expert, frontend-architect, simplicity-engineer, junior-engineer, Codex (gpt-5.4, xhigh reasoning)
- 2 rounds of review
- All must-fix items addressed (breadcrumbs landmark semantics, PageLayoutTitle export)
- Round 2: all reviewers approved

## Test plan

- `bun test packages/components/src/components/page-layout.test.ts` — 19 tests covering all new slots, DOM order, title-as-snippet, CSS source assertions, and integration test with all five slots simultaneously
- `bun run typecheck` — clean (workspace-wide including playground)
- `bun run lint` — clean (no errors)
- All pre-commit hooks pass

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes `PageLayout`’s public API (`title` type) and DOM/CSS layout, which could affect consumers’ rendering and styling expectations.
> 
> **Overview**
> Enhances `PageLayout` to support richer headers: adds optional `breadcrumbs`, `avatar`, and `meta` snippet slots, and allows `title` to be either a `string` (default `<h1>`) or a `Snippet` (`PageLayoutTitle`) that owns its own heading.
> 
> Updates styling to accommodate the new header structure (title column, avatar, breadcrumbs row), enforces a 44px minimum header-row height, and ensures actions align to the inline-end via `margin-inline-start: auto`. Public exports and the machine-readable `api-contract` are updated accordingly, and tests are expanded to cover slot rendering, DOM order/landmark semantics, and CSS assertions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit beec64719b5558371cac23ddb902b287b4de1d1d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->