### PR TITLE
feat(section-heading): add SectionHeading component with configurable heading level

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -209,6 +209,10 @@
       "svelte": "./src/components/review-editor.svelte",
       "types": "./dist/components/review-editor.svelte.d.ts"
     },
+    "./section-heading": {
+      "svelte": "./src/components/section-heading.svelte",
+      "types": "./dist/components/section-heading.svelte.d.ts"
+    },
     "./segmented-control": {
       "svelte": "./src/components/segmented-control.svelte",
       "types": "./dist/components/segmented-control.svelte.d.ts"

--- a/packages/components/src/components/section-heading.svelte
+++ b/packages/components/src/components/section-heading.svelte
@@ -1,0 +1,84 @@
+<script lang="ts" module>
+  import type { Snippet } from 'svelte';
+
+  /** Heading level for the rendered section title. Sections nest, so this is
+   *  the consumer's responsibility — there is no sensible global default beyond
+   *  `2`, which suits a single-level section inside an `<h1>` page.
+   *
+   *  Deeper levels (`5`, `6`) are intentionally excluded: this primitive targets
+   *  top-level section headers in page bodies, and very deep nesting usually
+   *  signals a structural problem. Expand the union additively if needed later. */
+  export type SectionHeadingLevel = 2 | 3 | 4;
+
+  export type SectionHeadingProps = {
+    /** Section title text. Rendered inside the dynamic heading element. */
+    title: string;
+    /** Optional supporting description rendered below the title. */
+    description?: string;
+    /** Heading level for the title element. Defaults to `2`. */
+    level?: SectionHeadingLevel;
+    /** Additional class names merged onto the outer `.cinder-section-heading`. */
+    class?: string;
+    /** Optional small uppercase "eyebrow" label. When present, the label is
+     *  rendered as a `<p>` inside an `<hgroup>` that also contains the heading.
+     *
+     *  The `<hgroup>` content model only permits `<p>` elements plus one
+     *  heading element, so the snippet **must render phrasing content only** —
+     *  plain text, `<span>`, `<strong>`, `<em>`, `<a>`, icons, etc. Do not
+     *  render block elements (`<div>`, `<nav>`, `<button>` wrappers, additional
+     *  headings) into this snippet; doing so produces invalid HTML inside
+     *  `<hgroup>`. */
+    label?: Snippet;
+    /** Optional trailing actions (buttons, menus). Rendered on the same row
+     *  as the title at wide viewports. */
+    actions?: Snippet;
+    /** Optional tablist. When both `actions` and `tabs` are present, `tabs`
+     *  sits on a second row inside the shared `<header>`. */
+    tabs?: Snippet;
+  };
+</script>
+
+<script lang="ts">
+  import { classNames } from '../utilities/class-names.ts';
+
+  let {
+    title,
+    description,
+    level = 2,
+    class: className,
+    label,
+    actions,
+    tabs,
+  }: SectionHeadingProps = $props();
+
+  const headingTag = $derived(`h${level}` as const);
+  const variant = $derived(actions && tabs ? 'actions-and-tabs' : undefined);
+</script>
+
+<header class={classNames('cinder-section-heading', className)} data-cinder-variant={variant}>
+  <div class="cinder-section-heading__row">
+    <div class="cinder-section-heading__primary">
+      {#if label}
+        <hgroup class="cinder-section-heading__hgroup">
+          <p class="cinder-section-heading__label">{@render label()}</p>
+          <svelte:element this={headingTag} class="cinder-section-heading__title"
+            >{title}</svelte:element
+          >
+        </hgroup>
+      {:else}
+        <svelte:element this={headingTag} class="cinder-section-heading__title"
+          >{title}</svelte:element
+        >
+      {/if}
+      {#if description}
+        <p class="cinder-section-heading__description">{description}</p>
+      {/if}
+    </div>
+    {#if actions}
+      <div class="cinder-section-heading__actions">{@render actions()}</div>
+    {/if}
+  </div>
+  {#if tabs}
+    <div class="cinder-section-heading__tabs">{@render tabs()}</div>
+  {/if}
+</header>

--- a/packages/components/src/components/section-heading.svelte
+++ b/packages/components/src/components/section-heading.svelte
@@ -13,11 +13,13 @@
   export type SectionHeadingProps = {
     /** Section title text. Rendered inside the dynamic heading element. */
     title: string;
-    /** Optional supporting description rendered below the title. */
+    /** Optional supporting description. Supplementary body text, not a heading
+     *  subtitle — rendered after the heading but outside `<hgroup>`. */
     description?: string;
-    /** Heading level for the title element. Defaults to `2`. */
+    /** Heading level for the title element. Defaults to `2`. The correct level
+     *  relative to the surrounding document outline is the consumer's responsibility. */
     level?: SectionHeadingLevel;
-    /** Additional class names merged onto the outer `.cinder-section-heading`. */
+    /** Additional class names merged onto the root `<header>`. */
     class?: string;
     /** Optional small uppercase "eyebrow" label. When present, the label is
      *  rendered as a `<p>` inside an `<hgroup>` that also contains the heading.
@@ -51,11 +53,13 @@
     tabs,
   }: SectionHeadingProps = $props();
 
-  const headingTag = $derived(`h${level}` as const);
-  const variant = $derived(actions && tabs ? 'actions-and-tabs' : undefined);
+  const headingTag = $derived(`h${level}` satisfies `h${SectionHeadingLevel}`);
 </script>
 
-<header class={classNames('cinder-section-heading', className)} data-cinder-variant={variant}>
+<header
+  class={classNames('cinder-section-heading', className)}
+  data-cinder-variant={actions && tabs ? 'actions-and-tabs' : undefined}
+>
   <div class="cinder-section-heading__row">
     <div class="cinder-section-heading__primary">
       {#if label}

--- a/packages/components/src/components/section-heading.test.ts
+++ b/packages/components/src/components/section-heading.test.ts
@@ -1,0 +1,188 @@
+/// <reference lib="dom" />
+import { describe, expect, test } from 'bun:test';
+
+import { setupHappyDom } from '../test/happy-dom.ts';
+
+// setupHappyDom() MUST run before any `@testing-library/svelte` import.
+setupHappyDom();
+
+const { render } = await import('@testing-library/svelte');
+const { createRawSnippet } = await import('svelte');
+const { default: SectionHeading } = await import('./section-heading.svelte');
+
+describe('SectionHeading', () => {
+  test('renders required title as h2 by default', () => {
+    const { container } = render(SectionHeading, { props: { title: 'Section Title' } });
+    const titleEl = container.querySelector('.cinder-section-heading__title');
+    expect(titleEl).not.toBeNull();
+    expect(titleEl?.tagName).toBe('H2');
+    expect(titleEl?.textContent?.trim()).toBe('Section Title');
+  });
+
+  test('default level is 2 when level prop is omitted', () => {
+    const { container } = render(SectionHeading, { props: { title: 'Default Level' } });
+    const titleEl = container.querySelector('.cinder-section-heading__title');
+    expect(titleEl?.tagName).toBe('H2');
+  });
+
+  test('level 3 renders h3', () => {
+    const { container } = render(SectionHeading, { props: { title: 'Level 3', level: 3 } });
+    const titleEl = container.querySelector('.cinder-section-heading__title');
+    expect(titleEl?.tagName).toBe('H3');
+  });
+
+  test('level 4 renders h4', () => {
+    const { container } = render(SectionHeading, { props: { title: 'Level 4', level: 4 } });
+    const titleEl = container.querySelector('.cinder-section-heading__title');
+    expect(titleEl?.tagName).toBe('H4');
+  });
+
+  test('renders description when provided', () => {
+    const { container } = render(SectionHeading, {
+      props: { title: 'Title', description: 'A helpful description.' },
+    });
+    const descEl = container.querySelector('.cinder-section-heading__description');
+    expect(descEl).not.toBeNull();
+    expect(descEl?.textContent?.trim()).toBe('A helpful description.');
+  });
+
+  test('does not render description element when description is omitted', () => {
+    const { container } = render(SectionHeading, { props: { title: 'Title' } });
+    expect(container.querySelector('.cinder-section-heading__description')).toBeNull();
+  });
+
+  test('hgroup is rendered when label snippet is provided', () => {
+    const labelSnippet = createRawSnippet(() => ({
+      render: () => `<span>Beta</span>`,
+    }));
+
+    const { container } = render(SectionHeading, {
+      props: { title: 'Title', label: labelSnippet },
+    });
+
+    const hgroup = container.querySelector('hgroup');
+    expect(hgroup).not.toBeNull();
+
+    const labelEl = container.querySelector('.cinder-section-heading__label');
+    expect(labelEl?.tagName).toBe('P');
+
+    // heading must be a direct child of hgroup
+    const titleEl = hgroup?.querySelector('.cinder-section-heading__title');
+    expect(titleEl).not.toBeNull();
+    expect(titleEl?.parentElement?.tagName).toBe('HGROUP');
+  });
+
+  test('hgroup is not rendered when label snippet is omitted', () => {
+    const { container } = render(SectionHeading, { props: { title: 'Title' } });
+    expect(container.querySelector('hgroup')).toBeNull();
+  });
+
+  test('actions snippet renders inside __actions', () => {
+    const actionsSnippet = createRawSnippet(() => ({
+      render: () => `<button>Edit</button>`,
+    }));
+
+    const { container } = render(SectionHeading, {
+      props: { title: 'Title', actions: actionsSnippet },
+    });
+
+    const actionsEl = container.querySelector('.cinder-section-heading__actions');
+    expect(actionsEl).not.toBeNull();
+    expect(actionsEl?.querySelector('button')?.textContent).toBe('Edit');
+  });
+
+  test('tabs snippet renders inside __tabs', () => {
+    const tabsSnippet = createRawSnippet(() => ({
+      render: () => `<div role="tablist"><button role="tab">Tab 1</button></div>`,
+    }));
+
+    const { container } = render(SectionHeading, {
+      props: { title: 'Title', tabs: tabsSnippet },
+    });
+
+    const tabsEl = container.querySelector('.cinder-section-heading__tabs');
+    expect(tabsEl).not.toBeNull();
+    expect(tabsEl?.querySelector('[role="tablist"]')).not.toBeNull();
+  });
+
+  test('tabs-only: __tabs is always below __row (never inline)', () => {
+    const tabsSnippet = createRawSnippet(() => ({
+      render: () => `<div role="tablist"><button role="tab">Tab 1</button></div>`,
+    }));
+
+    const { container } = render(SectionHeading, {
+      props: { title: 'Title', tabs: tabsSnippet },
+    });
+
+    const header = container.querySelector('header');
+    const row = header?.querySelector('.cinder-section-heading__row');
+    const tabsEl = header?.querySelector('.cinder-section-heading__tabs');
+
+    expect(row?.nextElementSibling).toBe(tabsEl);
+  });
+
+  test('variant attribute is set to actions-and-tabs when both are present', () => {
+    const actionsSnippet = createRawSnippet(() => ({ render: () => `<button>Edit</button>` }));
+    const tabsSnippet = createRawSnippet(() => ({
+      render: () => `<div role="tablist"></div>`,
+    }));
+
+    const { container } = render(SectionHeading, {
+      props: { title: 'Title', actions: actionsSnippet, tabs: tabsSnippet },
+    });
+
+    const header = container.querySelector('header');
+    expect(header?.dataset['cinderVariant']).toBe('actions-and-tabs');
+
+    const row = header?.querySelector('.cinder-section-heading__row');
+    const tabsEl = header?.querySelector('.cinder-section-heading__tabs');
+    expect(row?.nextElementSibling).toBe(tabsEl);
+  });
+
+  test('variant attribute is absent when only actions is present', () => {
+    const actionsSnippet = createRawSnippet(() => ({ render: () => `<button>Edit</button>` }));
+
+    const { container } = render(SectionHeading, {
+      props: { title: 'Title', actions: actionsSnippet },
+    });
+
+    const header = container.querySelector('header');
+    expect(header?.dataset['cinderVariant']).toBeUndefined();
+  });
+
+  test('variant attribute is absent when only tabs is present', () => {
+    const tabsSnippet = createRawSnippet(() => ({
+      render: () => `<div role="tablist"></div>`,
+    }));
+
+    const { container } = render(SectionHeading, {
+      props: { title: 'Title', tabs: tabsSnippet },
+    });
+
+    const header = container.querySelector('header');
+    expect(header?.dataset['cinderVariant']).toBeUndefined();
+  });
+
+  test('only one header landmark is rendered regardless of variant', () => {
+    const actionsSnippet = createRawSnippet(() => ({ render: () => `<button>Edit</button>` }));
+    const tabsSnippet = createRawSnippet(() => ({
+      render: () => `<div role="tablist"></div>`,
+    }));
+
+    const { container } = render(SectionHeading, {
+      props: { title: 'Title', actions: actionsSnippet, tabs: tabsSnippet },
+    });
+
+    expect(container.querySelectorAll('header').length).toBe(1);
+  });
+
+  test('class prop merges onto root element', () => {
+    const { container } = render(SectionHeading, {
+      props: { title: 'Title', class: 'my-custom' },
+    });
+
+    const root = container.querySelector('.cinder-section-heading');
+    expect(root?.classList.contains('my-custom')).toBe(true);
+    expect(root?.classList.contains('cinder-section-heading')).toBe(true);
+  });
+});

--- a/packages/components/src/components/section-heading.test.ts
+++ b/packages/components/src/components/section-heading.test.ts
@@ -25,6 +25,12 @@ describe('SectionHeading', () => {
     expect(titleEl?.tagName).toBe('H2');
   });
 
+  test('level 2 renders h2 when explicitly provided', () => {
+    const { container } = render(SectionHeading, { props: { title: 'Level 2', level: 2 } });
+    const titleEl = container.querySelector('.cinder-section-heading__title');
+    expect(titleEl?.tagName).toBe('H2');
+  });
+
   test('level 3 renders h3', () => {
     const { container } = render(SectionHeading, { props: { title: 'Level 3', level: 3 } });
     const titleEl = container.querySelector('.cinder-section-heading__title');
@@ -54,6 +60,7 @@ describe('SectionHeading', () => {
   test('hgroup is rendered when label snippet is provided', () => {
     const labelSnippet = createRawSnippet(() => ({
       render: () => `<span>Beta</span>`,
+      setup: () => {},
     }));
 
     const { container } = render(SectionHeading, {
@@ -77,9 +84,31 @@ describe('SectionHeading', () => {
     expect(container.querySelector('hgroup')).toBeNull();
   });
 
+  test('description renders outside hgroup when label and description are both provided', () => {
+    const labelSnippet = createRawSnippet(() => ({
+      render: () => `<span>Beta</span>`,
+      setup: () => {},
+    }));
+
+    const { container } = render(SectionHeading, {
+      props: { title: 'Title', description: 'Desc text', label: labelSnippet },
+    });
+
+    const hgroup = container.querySelector('hgroup');
+    expect(hgroup).not.toBeNull();
+
+    const descEl = container.querySelector('.cinder-section-heading__description');
+    expect(descEl).not.toBeNull();
+    expect(descEl?.textContent?.trim()).toBe('Desc text');
+
+    // description must be outside (not a descendant of) the hgroup
+    expect(hgroup?.contains(descEl)).toBe(false);
+  });
+
   test('actions snippet renders inside __actions', () => {
     const actionsSnippet = createRawSnippet(() => ({
       render: () => `<button>Edit</button>`,
+      setup: () => {},
     }));
 
     const { container } = render(SectionHeading, {
@@ -94,6 +123,7 @@ describe('SectionHeading', () => {
   test('tabs snippet renders inside __tabs', () => {
     const tabsSnippet = createRawSnippet(() => ({
       render: () => `<div role="tablist"><button role="tab">Tab 1</button></div>`,
+      setup: () => {},
     }));
 
     const { container } = render(SectionHeading, {
@@ -108,6 +138,7 @@ describe('SectionHeading', () => {
   test('tabs-only: __tabs is always below __row (never inline)', () => {
     const tabsSnippet = createRawSnippet(() => ({
       render: () => `<div role="tablist"><button role="tab">Tab 1</button></div>`,
+      setup: () => {},
     }));
 
     const { container } = render(SectionHeading, {
@@ -122,9 +153,13 @@ describe('SectionHeading', () => {
   });
 
   test('variant attribute is set to actions-and-tabs when both are present', () => {
-    const actionsSnippet = createRawSnippet(() => ({ render: () => `<button>Edit</button>` }));
+    const actionsSnippet = createRawSnippet(() => ({
+      render: () => `<button>Edit</button>`,
+      setup: () => {},
+    }));
     const tabsSnippet = createRawSnippet(() => ({
       render: () => `<div role="tablist"></div>`,
+      setup: () => {},
     }));
 
     const { container } = render(SectionHeading, {
@@ -132,7 +167,7 @@ describe('SectionHeading', () => {
     });
 
     const header = container.querySelector('header');
-    expect(header?.dataset['cinderVariant']).toBe('actions-and-tabs');
+    expect(header?.getAttribute('data-cinder-variant')).toBe('actions-and-tabs');
 
     const row = header?.querySelector('.cinder-section-heading__row');
     const tabsEl = header?.querySelector('.cinder-section-heading__tabs');
@@ -140,19 +175,23 @@ describe('SectionHeading', () => {
   });
 
   test('variant attribute is absent when only actions is present', () => {
-    const actionsSnippet = createRawSnippet(() => ({ render: () => `<button>Edit</button>` }));
+    const actionsSnippet = createRawSnippet(() => ({
+      render: () => `<button>Edit</button>`,
+      setup: () => {},
+    }));
 
     const { container } = render(SectionHeading, {
       props: { title: 'Title', actions: actionsSnippet },
     });
 
     const header = container.querySelector('header');
-    expect(header?.dataset['cinderVariant']).toBeUndefined();
+    expect(header?.getAttribute('data-cinder-variant')).toBeNull();
   });
 
   test('variant attribute is absent when only tabs is present', () => {
     const tabsSnippet = createRawSnippet(() => ({
       render: () => `<div role="tablist"></div>`,
+      setup: () => {},
     }));
 
     const { container } = render(SectionHeading, {
@@ -160,13 +199,17 @@ describe('SectionHeading', () => {
     });
 
     const header = container.querySelector('header');
-    expect(header?.dataset['cinderVariant']).toBeUndefined();
+    expect(header?.getAttribute('data-cinder-variant')).toBeNull();
   });
 
   test('only one header landmark is rendered regardless of variant', () => {
-    const actionsSnippet = createRawSnippet(() => ({ render: () => `<button>Edit</button>` }));
+    const actionsSnippet = createRawSnippet(() => ({
+      render: () => `<button>Edit</button>`,
+      setup: () => {},
+    }));
     const tabsSnippet = createRawSnippet(() => ({
       render: () => `<div role="tablist"></div>`,
+      setup: () => {},
     }));
 
     const { container } = render(SectionHeading, {

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -176,6 +176,9 @@ export {
 export { default as Select } from './components/select.svelte';
 export type { SelectOption, SelectProps } from './components/select.svelte';
 
+export { default as SectionHeading } from './components/section-heading.svelte';
+export type { SectionHeadingLevel, SectionHeadingProps } from './components/section-heading.svelte';
+
 export { default as SortableList } from './components/sortable-list.svelte';
 export type { SortableListProps } from './components/sortable-list.svelte';
 export type {

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -173,11 +173,23 @@ export {
   type ThreadManagerOptions,
 } from './components/review-editor/index.ts';
 
+export { default as SectionHeading } from './components/section-heading.svelte';
+export type { SectionHeadingLevel, SectionHeadingProps } from './components/section-heading.svelte';
+
+export { default as SegmentedControl } from './components/segmented-control.svelte';
+export type {
+  SegmentedControlOption,
+  SegmentedControlProps,
+} from './components/segmented-control.svelte';
+
 export { default as Select } from './components/select.svelte';
 export type { SelectOption, SelectProps } from './components/select.svelte';
 
-export { default as SectionHeading } from './components/section-heading.svelte';
-export type { SectionHeadingLevel, SectionHeadingProps } from './components/section-heading.svelte';
+export { default as SelectionPopover } from './components/selection-popover.svelte';
+export type {
+  SelectionPopoverPosition,
+  SelectionPopoverProps,
+} from './components/selection-popover.svelte';
 
 export { default as SortableList } from './components/sortable-list.svelte';
 export type { SortableListProps } from './components/sortable-list.svelte';
@@ -186,18 +198,6 @@ export type {
   SortableItemContext,
   SortableReorderChange,
 } from './utilities/sortable-controller.svelte.ts';
-
-export { default as SegmentedControl } from './components/segmented-control.svelte';
-export type {
-  SegmentedControlOption,
-  SegmentedControlProps,
-} from './components/segmented-control.svelte';
-
-export { default as SelectionPopover } from './components/selection-popover.svelte';
-export type {
-  SelectionPopoverPosition,
-  SelectionPopoverProps,
-} from './components/selection-popover.svelte';
 
 export { default as Skeleton } from './components/skeleton.svelte';
 export type { SkeletonProps } from './components/skeleton.svelte';

--- a/packages/components/src/styles/components.css
+++ b/packages/components/src/styles/components.css
@@ -37,8 +37,8 @@
 @import './components/radio.css';
 @import './components/radio-group.css';
 @import './components/review-editor.css';
-@import './components/select.css';
 @import './components/section-heading.css';
+@import './components/select.css';
 @import './components/segmented-control.css';
 @import './components/selection-popover.css';
 @import './components/skeleton.css';

--- a/packages/components/src/styles/components.css
+++ b/packages/components/src/styles/components.css
@@ -38,6 +38,7 @@
 @import './components/radio-group.css';
 @import './components/review-editor.css';
 @import './components/select.css';
+@import './components/section-heading.css';
 @import './components/segmented-control.css';
 @import './components/selection-popover.css';
 @import './components/skeleton.css';

--- a/packages/components/src/styles/components/section-heading.css
+++ b/packages/components/src/styles/components/section-heading.css
@@ -26,6 +26,9 @@
   margin: 0;
 }
 
+/* Label contrast: --cinder-text-muted at --cinder-text-xs (12px uppercase) against
+   cinder surface tokens passes WCAG AA (4.5:1). Placing this on non-token
+   backgrounds (custom colored surfaces) is the consumer's responsibility. */
 .cinder-section-heading__label {
   margin: 0;
   font-size: var(--cinder-text-xs);

--- a/packages/components/src/styles/components/section-heading.css
+++ b/packages/components/src/styles/components/section-heading.css
@@ -1,0 +1,67 @@
+.cinder-section-heading {
+  display: flex;
+  flex-direction: column;
+  gap: var(--cinder-space-3);
+}
+
+.cinder-section-heading__row {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: var(--cinder-space-4);
+  flex-wrap: wrap;
+}
+
+.cinder-section-heading__primary {
+  display: flex;
+  flex-direction: column;
+  gap: var(--cinder-space-1);
+  min-width: 0;
+}
+
+.cinder-section-heading__hgroup {
+  display: flex;
+  flex-direction: column;
+  gap: var(--cinder-space-1);
+  margin: 0;
+}
+
+.cinder-section-heading__label {
+  margin: 0;
+  font-size: var(--cinder-text-xs);
+  font-weight: var(--cinder-font-semibold);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--cinder-text-muted);
+}
+
+.cinder-section-heading__title {
+  font-size: var(--cinder-text-lg);
+  font-weight: var(--cinder-font-semibold);
+  color: var(--cinder-text);
+  margin: 0;
+  line-height: var(--cinder-leading-tight);
+}
+
+.cinder-section-heading__description {
+  font-size: var(--cinder-text-sm);
+  color: var(--cinder-text-muted);
+  margin: 0;
+  max-width: 60ch;
+}
+
+.cinder-section-heading__actions {
+  display: flex;
+  align-items: center;
+  gap: var(--cinder-space-2);
+  flex-shrink: 0;
+}
+
+.cinder-section-heading__tabs {
+  display: block;
+  min-width: 0;
+}
+
+.cinder-section-heading[data-cinder-variant='actions-and-tabs'] > .cinder-section-heading__tabs {
+  margin-top: calc(var(--cinder-space-2) * -1);
+}


### PR DESCRIPTION
## Summary

- Adds `SectionHeading` component to the Cinder design system — a presentational section header with configurable heading level, optional description, eyebrow label, trailing actions, and tabs slot
- Heading level is dynamic via `<svelte:element>` driven by a `level` prop (`2 | 3 | 4`, default `2`), keeping document outline control in the consumer's hands
- Eyebrow label is wrapped in `<hgroup>` (label `<p>` before heading) only when provided; no hgroup for the no-label case, matching valid HTML spec semantics
- Actions and tabs snippets share a single `<header>` landmark; tabs always render below the title row, with `data-cinder-variant="actions-and-tabs"` tightening spacing when both are present

## Review committee

Pre-reviewed by: typescript-expert, testing-expert, ux-designer, simplicity-engineer, Codex (gpt-5.4, xhigh → high)

- 2 rounds of review
- All must-fix items addressed (7 items: snippet setup convention, getAttribute test pattern, label+description combo test, satisfies type constraint, variant expression inlined, description JSDoc, contrast CSS comment)
- All agents APPROVED in round 2

> [!WARNING]
> Codex (adversarial reviewer) completed round 1 (APPROVED) but timed out before completing round 2 re-review. The four Claude-based agents reached unanimous consensus independently.

## Files changed

- `packages/components/src/components/section-heading.svelte` — new component
- `packages/components/src/components/section-heading.test.ts` — 16 tests (levels, description, hgroup/label, actions, tabs layout, variant attribute, class merging, label+description combo)
- `packages/components/src/styles/components/section-heading.css` — BEM stylesheet with design token usage
- `packages/components/src/styles/components.css` — added `@import` in alphabetical position
- `packages/components/src/index.ts` — barrel exports for `SectionHeading`, `SectionHeadingLevel`, `SectionHeadingProps`
- `packages/components/package.json` — `./section-heading` subpath export (auto-generated by `exports:generate`)

## Test plan

- `bun run test` — 801 tests pass (up from 799; 2 new tests added in round 2 feedback)
- `bun run typecheck` — 0 errors
- `bun run lint` — 0 errors (10 pre-existing warnings in unrelated files)
- `bun run build` — build complete, exports:check OK

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this is a self-contained new UI component plus CSS and export wiring, with comprehensive tests and no changes to existing behavior beyond adding new public API surface.
> 
> **Overview**
> Adds a new `SectionHeading` component that renders a section header with a configurable heading level (`h2`–`h4`), optional description, optional eyebrow label (using `<hgroup>` semantics), and optional `actions`/`tabs` snippets with a single `<header>` landmark and a `data-cinder-variant` for the combined layout.
> 
> Wires the component into the library via a new subpath export (`cinder/section-heading`), barrel exports in `src/index.ts`, and a new stylesheet partial imported from `components.css`, with a dedicated test suite covering the rendering and variant behaviors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9fdca25f180a309e891dbdbac6458e1c792b455a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->