### PR TITLE
feat(description-list): add DescriptionList component with variant support

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -81,6 +81,10 @@
       "svelte": "./src/components/data-list.svelte",
       "types": "./dist/components/data-list.svelte.d.ts"
     },
+    "./description-list": {
+      "svelte": "./src/components/description-list.svelte",
+      "types": "./dist/components/description-list.svelte.d.ts"
+    },
     "./diff-statistics": {
       "svelte": "./src/components/diff-statistics.svelte",
       "types": "./dist/components/diff-statistics.svelte.d.ts"

--- a/packages/components/src/components/description-list.a11y.md
+++ b/packages/components/src/components/description-list.a11y.md
@@ -1,0 +1,44 @@
+# DescriptionList — Accessibility Notes
+
+## Semantics
+
+`<dl>` is the correct container for term/definition pairs. The HTML Living Standard permits `<dl>` to contain either (a) bare `<dt>`/`<dd>` pairs, or (b) `<div>` elements where **each row `<div>` must contain only `<dt>`, `<dd>`, and script-supporting elements** — no other flow content.
+
+This component renders actions **inside `<dd>`** (wrapped in a `<div class="cinder-description-list__actions">`), not as a sibling of `<dd>`. This keeps the row `<div>` strictly conforming to the `<dl>` content model. `<dd>`'s content model is flow content, which permits a `<div>` wrapper — and `<div>` is the right element choice because the consumer's snippet may render block-level UI (button groups, dropdown triggers) that a `<span>` cannot legally contain.
+
+## Two-Column Variant
+
+Visual columns come from CSS grid placement; DOM order is preserved (term → definition → actions) so screen reader linearization maintains the term/definition pairing. At narrow container widths (< 28rem) the variant collapses to stacked rows via container query — keeping content readable without the consumer needing to switch variants manually.
+
+## Narrow Variant — When to Use It
+
+The `narrow` variant hides the `<dt>` visually using `.cinder-sr-only` (clip-rect technique). The term text **is not removed** from the DOM and **is not `aria-hidden`**; screen readers still announce it.
+
+**Only use `narrow`** when the surrounding context already makes labels obvious — for example, a single-row metadata strip beside a visible heading, or a values-only strip where a column header above already identifies the field.
+
+**Do not use `narrow` as a general compact mode.** For lists like Status / Owner / Updated / Priority, use `default` or `striped` so sighted users can see the labels.
+
+## Action Link Labels
+
+Any interactive element rendered through the `actions` snippet **must** set an `aria-label` that disambiguates the row:
+
+```svelte
+{#snippet actions(item)}
+  <button type="button" aria-label={`Edit ${item.term}`}>Edit</button>
+{/snippet}
+```
+
+Bare "Edit" or "Delete" labels violate WCAG 2.4.4 (Link Purpose in Context) when stripped from surrounding text. The `actions` snippet receives the full `DescriptionListItem` to make disambiguation ergonomic.
+
+## Keying and Duplicate Terms
+
+Rows key on `item.id ?? item.term`. Lists with duplicate terms **must** provide explicit `id` values per item — duplicate keys cause Svelte to throw at runtime.
+
+Example:
+
+```svelte
+const items = [
+  { id: 'email-work', term: 'Email', definition: 'work@example.com' },
+  { id: 'email-personal', term: 'Email', definition: 'personal@example.com' },
+];
+```

--- a/packages/components/src/components/description-list.svelte
+++ b/packages/components/src/components/description-list.svelte
@@ -1,0 +1,65 @@
+<script lang="ts" module>
+  import type { Snippet } from 'svelte';
+  import type { HTMLAttributes } from 'svelte/elements';
+
+  /** Layout variant for the description list. */
+  export type DescriptionListVariant = 'default' | 'striped' | 'two-column' | 'narrow';
+
+  export type DescriptionListItem = {
+    /**
+     * Stable identity for keyed rendering. Falls back to `term` when omitted.
+     * Provide an explicit `id` when the list may contain duplicate terms.
+     */
+    id?: string;
+    /** The label rendered inside `<dt>`. */
+    term: string;
+    /** The value rendered inside `<dd>`. */
+    definition: string;
+  };
+
+  export type DescriptionListProps = Omit<HTMLAttributes<HTMLDListElement>, 'class'> & {
+    items: DescriptionListItem[];
+    /**
+     * Controls the visual layout:
+     * - `default`: stacked rows with visible terms.
+     * - `striped`: alternating row backgrounds.
+     * - `two-column`: term and definition share a row; collapses to stacked at narrow widths.
+     * - `narrow`: `<dt>` is visually hidden via `.cinder-sr-only`. Only appropriate when
+     *   surrounding context already labels the value. NOT a general compact mode.
+     */
+    variant?: DescriptionListVariant;
+    class?: string;
+    /**
+     * Optional snippet rendered once per row. Receives the full `DescriptionListItem` so
+     * consumers can build disambiguated `aria-label` strings (e.g. `aria-label="Edit ${item.term}"`).
+     * Any interactive element in `actions` MUST set an unambiguous `aria-label`.
+     */
+    actions?: Snippet<[DescriptionListItem]>;
+  };
+</script>
+
+<script lang="ts">
+  import { cn } from '../utilities/class-names.ts';
+
+  let {
+    items,
+    variant = 'default',
+    class: className,
+    actions,
+    ...rest
+  }: DescriptionListProps = $props();
+</script>
+
+<dl {...rest} class={cn('cinder-description-list', className)} data-cinder-variant={variant}>
+  {#each items as item (item.id ?? item.term)}
+    <div class="cinder-description-list__row">
+      <dt class={variant === 'narrow' ? 'cinder-sr-only' : undefined}>{item.term}</dt>
+      <dd>
+        <div class="cinder-description-list__definition">{item.definition}</div>
+        {#if actions}
+          <div class="cinder-description-list__actions">{@render actions(item)}</div>
+        {/if}
+      </dd>
+    </div>
+  {/each}
+</dl>

--- a/packages/components/src/components/description-list.svelte
+++ b/packages/components/src/components/description-list.svelte
@@ -39,7 +39,7 @@
 </script>
 
 <script lang="ts">
-  import { cn } from '../utilities/class-names.ts';
+  import { classNames } from '../utilities/class-names.ts';
 
   let {
     items,
@@ -50,7 +50,11 @@
   }: DescriptionListProps = $props();
 </script>
 
-<dl {...rest} class={cn('cinder-description-list', className)} data-cinder-variant={variant}>
+<dl
+  {...rest}
+  class={classNames('cinder-description-list', className)}
+  data-cinder-variant={variant}
+>
   {#each items as item (item.id ?? item.term)}
     <div class="cinder-description-list__row">
       <dt class={variant === 'narrow' ? 'cinder-sr-only' : undefined}>{item.term}</dt>

--- a/packages/components/src/components/description-list.test.ts
+++ b/packages/components/src/components/description-list.test.ts
@@ -31,6 +31,7 @@ describe('DescriptionList', () => {
     const dl = container.querySelector('.cinder-description-list');
     expect(dl).not.toBeNull();
     expect(dl?.tagName).toBe('DL');
+    expect(dl?.getAttribute('data-cinder-variant')).toBe('default');
 
     const rows = dl?.querySelectorAll('.cinder-description-list__row');
     expect(rows?.length).toBe(2);

--- a/packages/components/src/components/description-list.test.ts
+++ b/packages/components/src/components/description-list.test.ts
@@ -1,0 +1,211 @@
+/// <reference lib="dom" />
+import { describe, expect, test } from 'bun:test';
+
+import { setupHappyDom } from '../test/happy-dom.ts';
+
+setupHappyDom();
+
+const { render } = await import('@testing-library/svelte');
+const { default: DescriptionList } = await import('./description-list.svelte');
+const { createRawSnippet } = await import('svelte');
+
+type Item = { id?: string; term: string; definition: string };
+
+function actionSnippet(transform: (item: Item) => string) {
+  // createRawSnippet receives getter functions at runtime even though
+  // the TypeScript types model them as plain values.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return createRawSnippet<[Item]>((getItem: any) => ({
+    render: () => transform(getItem()),
+  }));
+}
+
+const sampleItems: Item[] = [
+  { term: 'Status', definition: 'Active' },
+  { term: 'Owner', definition: 'Steve' },
+];
+
+describe('DescriptionList', () => {
+  test('default variant renders <dl> with rows containing <dt> and <dd>', () => {
+    const { container } = render(DescriptionList, { items: sampleItems });
+    const dl = container.querySelector('.cinder-description-list');
+    expect(dl).not.toBeNull();
+    expect(dl?.tagName).toBe('DL');
+
+    const rows = dl?.querySelectorAll('.cinder-description-list__row');
+    expect(rows?.length).toBe(2);
+
+    const firstRow = rows?.[0];
+    expect(firstRow?.querySelector('dt')?.textContent).toBe('Status');
+    expect(firstRow?.querySelector('dd')?.textContent).toContain('Active');
+
+    const secondRow = rows?.[1];
+    expect(secondRow?.querySelector('dt')?.textContent).toBe('Owner');
+    expect(secondRow?.querySelector('dd')?.textContent).toContain('Steve');
+  });
+
+  test('striped variant sets data-cinder-variant="striped"', () => {
+    const { container } = render(DescriptionList, { items: sampleItems, variant: 'striped' });
+    const dl = container.querySelector('.cinder-description-list');
+    expect(dl?.getAttribute('data-cinder-variant')).toBe('striped');
+  });
+
+  test('two-column variant sets data-cinder-variant and preserves DOM order (dt then dd)', () => {
+    const { container } = render(DescriptionList, { items: sampleItems, variant: 'two-column' });
+    const dl = container.querySelector('.cinder-description-list');
+    expect(dl?.getAttribute('data-cinder-variant')).toBe('two-column');
+
+    const rows = dl?.querySelectorAll('.cinder-description-list__row');
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const firstRow = rows![0]!;
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    expect(firstRow.children[0]!.tagName).toBe('DT');
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    expect(firstRow.children[1]!.tagName).toBe('DD');
+  });
+
+  test('narrow variant renders <dt> with cinder-sr-only class and keeps text in DOM', () => {
+    const { container } = render(DescriptionList, { items: sampleItems, variant: 'narrow' });
+    const dl = container.querySelector('.cinder-description-list');
+    expect(dl?.getAttribute('data-cinder-variant')).toBe('narrow');
+
+    const dts = dl?.querySelectorAll('dt');
+    expect(dts?.length).toBe(2);
+
+    const firstDt = dts?.[0];
+    expect(firstDt?.classList.contains('cinder-sr-only')).toBe(true);
+    expect(firstDt?.textContent).toBe('Status');
+
+    const firstDd = dl?.querySelector('dd');
+    expect(firstDd?.classList.contains('cinder-sr-only')).toBe(false);
+  });
+
+  test('actions snippet renders inside <dd> wrapped in .cinder-description-list__actions', () => {
+    const actions = actionSnippet((item) => `<a aria-label="Edit ${item.term}">Edit</a>`);
+    const { container } = render(DescriptionList, { items: sampleItems, actions });
+
+    const actionsWrappers = container.querySelectorAll('.cinder-description-list__actions');
+    expect(actionsWrappers.length).toBe(2);
+
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const firstActions = actionsWrappers[0]!;
+    expect(firstActions.parentElement?.tagName).toBe('DD');
+    expect(firstActions.querySelector('[aria-label="Edit Status"]')).not.toBeNull();
+
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const secondActions = actionsWrappers[1]!;
+    expect(secondActions.querySelector('[aria-label="Edit Owner"]')).not.toBeNull();
+  });
+
+  test('class prop is composed onto the root <dl>', () => {
+    const { container } = render(DescriptionList, {
+      items: sampleItems,
+      class: 'my-custom-class',
+    });
+    const dl = container.querySelector('.cinder-description-list');
+    expect(dl?.getAttribute('class')).toContain('cinder-description-list');
+    expect(dl?.getAttribute('class')).toContain('my-custom-class');
+  });
+
+  test('rest props spread onto the <dl> root', () => {
+    const { container } = render(DescriptionList, {
+      items: sampleItems,
+      id: 'user-info',
+      'aria-labelledby': 'user-heading',
+    } as Parameters<typeof render>[1]);
+    const dl = container.querySelector('.cinder-description-list');
+    expect(dl?.getAttribute('id')).toBe('user-info');
+    expect(dl?.getAttribute('aria-labelledby')).toBe('user-heading');
+  });
+
+  test('rest props cannot clobber managed class attribute', () => {
+    const { container } = render(DescriptionList, {
+      items: sampleItems,
+      class: 'rogue',
+    });
+    const dl = container.querySelector('.cinder-description-list');
+    expect(dl?.getAttribute('class')).toContain('cinder-description-list');
+    expect(dl?.getAttribute('class')).toContain('rogue');
+  });
+
+  test('empty items renders an empty <dl> with no rows', () => {
+    const { container } = render(DescriptionList, { items: [] });
+    const dl = container.querySelector('.cinder-description-list');
+    expect(dl).not.toBeNull();
+    const rows = dl?.querySelectorAll('.cinder-description-list__row');
+    expect(rows?.length).toBe(0);
+  });
+
+  test('keying with explicit id renders both rows when terms are duplicate', () => {
+    const items: Item[] = [
+      { id: 'email-work', term: 'Email', definition: 'work@example.com' },
+      { id: 'email-personal', term: 'Email', definition: 'personal@example.com' },
+    ];
+    const { container } = render(DescriptionList, { items });
+    const rows = container.querySelectorAll('.cinder-description-list__row');
+    expect(rows.length).toBe(2);
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    expect(rows[0]!.textContent).toContain('work@example.com');
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    expect(rows[1]!.textContent).toContain('personal@example.com');
+  });
+
+  test('keying falls back to term when id is omitted', () => {
+    const items: Item[] = [
+      { term: 'Alpha', definition: 'first' },
+      { term: 'Beta', definition: 'second' },
+    ];
+    const { container } = render(DescriptionList, { items });
+    const rows = container.querySelectorAll('.cinder-description-list__row');
+    expect(rows.length).toBe(2);
+  });
+
+  test('default <dd> margin reset is present in the stylesheet', async () => {
+    const css = await Bun.file(
+      `${import.meta.dir}/../styles/components/description-list.css`,
+    ).text();
+    expect(css).toMatch(/\.cinder-description-list[^{]*dd[^{]*\{[^}]*margin:\s*0/);
+  });
+
+  test('<dl> content model: only row divs as direct children, each with exactly dt then dd', () => {
+    const { container } = render(DescriptionList, { items: sampleItems });
+    const dl = container.querySelector('.cinder-description-list')!;
+
+    for (const child of Array.from(dl.children)) {
+      expect(child.tagName).toBe('DIV');
+      expect(child.classList.contains('cinder-description-list__row')).toBe(true);
+      expect(child.children.length).toBe(2);
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      expect(child.children[0]!.tagName).toBe('DT');
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      expect(child.children[1]!.tagName).toBe('DD');
+    }
+  });
+
+  test('<dd> content model: definition div first, at most one actions div, in order', () => {
+    const actions = actionSnippet((item) => `<button>Edit ${item.term}</button>`);
+    const { container } = render(DescriptionList, { items: sampleItems, actions });
+    const dds = container.querySelectorAll('dd');
+
+    for (const dd of Array.from(dds)) {
+      const children = Array.from(dd.children);
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      expect(children[0]!.classList.contains('cinder-description-list__definition')).toBe(true);
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      expect(children[1]!.classList.contains('cinder-description-list__actions')).toBe(true);
+      expect(children.length).toBe(2);
+    }
+  });
+
+  test('<dd> without actions contains only the definition div', () => {
+    const { container } = render(DescriptionList, { items: sampleItems });
+    const dds = container.querySelectorAll('dd');
+
+    for (const dd of Array.from(dds)) {
+      const children = Array.from(dd.children);
+      expect(children.length).toBe(1);
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      expect(children[0]!.classList.contains('cinder-description-list__definition')).toBe(true);
+    }
+  });
+});

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -48,6 +48,13 @@ export { copyToClipboard } from './utilities/clipboard.ts';
 export { default as DataList } from './components/data-list.svelte';
 export type { DataListProps } from './components/data-list.svelte';
 
+export { default as DescriptionList } from './components/description-list.svelte';
+export type {
+  DescriptionListItem,
+  DescriptionListProps,
+  DescriptionListVariant,
+} from './components/description-list.svelte';
+
 export { default as DiffStatistics } from './components/diff-statistics.svelte';
 export type {
   DiffStatisticsProps,

--- a/packages/components/src/styles/components.css
+++ b/packages/components/src/styles/components.css
@@ -18,6 +18,7 @@
 @import './components/command-palette.css';
 @import './components/copy-button.css';
 @import './components/data-list.css';
+@import './components/description-list.css';
 @import './components/diff-statistics.css';
 @import './components/drawer.css';
 @import './components/dropdown.css';

--- a/packages/components/src/styles/components/description-list.css
+++ b/packages/components/src/styles/components/description-list.css
@@ -66,7 +66,10 @@
   }
 }
 
-/* Narrow variant: <dt> is sr-only; <dd> takes full visible width. */
+/* Narrow variant: <dt> is sr-only (position: absolute, out-of-flow) so <dd>
+ * fills the visible row. flex-direction: row here matches the intended reading
+ * direction if a future variant needs the dt in-flow; for now the sr-only dt
+ * has no layout footprint and the dd is visually full-width. */
 .cinder-description-list[data-cinder-variant='narrow'] .cinder-description-list__row {
   flex-direction: row;
   align-items: baseline;

--- a/packages/components/src/styles/components/description-list.css
+++ b/packages/components/src/styles/components/description-list.css
@@ -1,0 +1,74 @@
+/* ========================================
+ * DESCRIPTION LIST
+ * ======================================== */
+
+.cinder-description-list {
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+/* Reset UA default margin-inline-start on <dd> (~40px in most browsers). */
+.cinder-description-list dt,
+.cinder-description-list dd {
+  margin: 0;
+}
+
+.cinder-description-list__row {
+  display: flex;
+  flex-direction: column;
+  gap: var(--cinder-space-1);
+  padding: var(--cinder-space-2) var(--cinder-space-3);
+}
+
+/* <dd> hosts both definition and optional actions. */
+.cinder-description-list dd {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: var(--cinder-space-2);
+}
+
+.cinder-description-list__definition {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.cinder-description-list__actions {
+  flex: 0 0 auto;
+  display: inline-flex;
+  align-items: center;
+  gap: var(--cinder-space-1);
+}
+
+/* Striped variant: odd rows get a subtle background. */
+.cinder-description-list[data-cinder-variant='striped']
+  .cinder-description-list__row:nth-child(odd) {
+  background: var(--cinder-surface-inset);
+}
+
+/* Two-column variant: term and definition share a row. */
+.cinder-description-list[data-cinder-variant='two-column'] {
+  container-type: inline-size;
+}
+
+.cinder-description-list[data-cinder-variant='two-column'] .cinder-description-list__row {
+  display: grid;
+  grid-template-columns: minmax(8rem, 1fr) 3fr;
+  align-items: baseline;
+  gap: var(--cinder-space-3);
+}
+
+/* Collapse two-column to stacked at narrow container widths. */
+@container (max-width: 28rem) {
+  .cinder-description-list[data-cinder-variant='two-column'] .cinder-description-list__row {
+    grid-template-columns: 1fr;
+  }
+}
+
+/* Narrow variant: <dt> is sr-only; <dd> takes full visible width. */
+.cinder-description-list[data-cinder-variant='narrow'] .cinder-description-list__row {
+  flex-direction: row;
+  align-items: baseline;
+  gap: var(--cinder-space-2);
+}


### PR DESCRIPTION
## Summary

- Adds a new `DescriptionList` component rendering semantic `<dl>`/`<dt>`/`<dd>` markup with four layout variants: `default`, `striped`, `two-column`, and `narrow`
- Each term/definition pair is wrapped in a `<div class="cinder-description-list__row">` to support striping and per-row action affordances while keeping the `<dl>` content model valid (HTML Living Standard conformant)
- Actions render inside `<dd>` via an optional `actions` snippet that receives the full `DescriptionListItem` so consumers can build disambiguated `aria-label` strings
- The `narrow` variant applies `.cinder-sr-only` to `<dt>` for visually-hidden-but-screen-reader-announced terms; a11y doc explains when this is and isn't appropriate

## Review committee

Pre-reviewed by: testing-expert, ux-designer, typescript-expert, simplicity-engineer, Codex (gpt-5.4/xhigh)
- 2 rounds of review
- All must-fix items addressed
- Codex re-raised two concerns (optional `id` field, narrow variant design) that were overridden by committee consensus: ux-designer and simplicity-engineer both explicitly approved both design choices in both rounds

## Key design decisions

- **`id` optional**: Rows key on `item.id ?? item.term`. Duplicate-term lists must supply explicit `id` values (documented in a11y.md and JSDoc). This was accepted over requiring `id` as simpler for the common case.
- **Narrow variant**: `<dt>` is visually hidden but stays in the DOM for screen readers. Only appropriate when surrounding context labels the values — documented prominently to prevent misuse.
- **Actions inside `<dd>`**: Required by HTML Living Standard — the row `<div>` may only contain `<dt>` and `<dd>` elements. Placing actions inside `<dd>` (which accepts flow content) keeps the markup valid.

## Test plan

- 15 unit tests covering: all four variants, actions placement inside `<dd>`, `aria-label` pass-through, class composition, rest-props spread, keying (explicit id + term fallback), empty list, CSS margin reset presence, and HTML content model conformance
- `bun test` passes: 816 pass, 0 fail across 82 files
- `bun run lint`: 0 errors
- `bun run typecheck`: exit 0
- `bun run format:check`: new files pass; 6 pre-existing format warnings in unrelated files

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new exported UI component and CSS that becomes part of the public library surface; risk is mainly API/markup/styling regressions for consumers rather than security or data-handling issues.
> 
> **Overview**
> Adds a new `DescriptionList` Svelte component that renders semantic `<dl>/<dt>/<dd>` rows from `items`, supports `default`/`striped`/`two-column`/`narrow` layout variants via `data-cinder-variant`, and optionally renders per-row `actions` content inside `<dd>`.
> 
> Exports the component and its types from `src/index.ts`, adds a new `./description-list` entry to `package.json` exports, and includes a new `description-list.css` partial in the global `components.css` aggregator.
> 
> Adds an accessibility guidance doc (`description-list.a11y.md`) and comprehensive unit tests covering variants, snippet placement, prop spreading/class composition, keying behavior (`item.id ?? item.term`), and basic markup/content-model expectations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a88f608b4d36f03ec6f32d5dae2bc95e0dd94dd3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->