### PR TITLE
feat(components): add StackedListItem rich list row primitive

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -237,6 +237,10 @@
       "svelte": "./src/components/spinner.svelte",
       "types": "./dist/components/spinner.svelte.d.ts"
     },
+    "./stacked-list-item": {
+      "svelte": "./src/components/stacked-list-item.svelte",
+      "types": "./dist/components/stacked-list-item.svelte.d.ts"
+    },
     "./stat-group": {
       "svelte": "./src/components/stat-group.svelte",
       "types": "./dist/components/stat-group.svelte.d.ts"

--- a/packages/components/src/components/stacked-list-item.a11y.md
+++ b/packages/components/src/components/stacked-list-item.a11y.md
@@ -1,0 +1,80 @@
+# StackedListItem — Accessibility Notes
+
+## Pattern
+
+`StackedListItem` is a presentational row primitive that renders a single `<li>`. It **must** be placed inside a consumer-owned `<ul role="list">` (or `<ol>` for ordered/chronological content). The component owns the `<li>`; the consumer owns the parent list element.
+
+```svelte
+<ul role="list">
+  <StackedListItem title={myTitleSnippet} />
+  <StackedListItem title={myTitleSnippet} />
+</ul>
+```
+
+> [!NOTE] Incompatibility with DataList
+> `DataList` wraps its children in a `<div>`, making it an invalid parent for `StackedListItem` — `<li>` children inside a `<div>` is invalid HTML. Do not compose these two components together.
+
+## Roles, Names, States
+
+- **Root element (`.cinder-stacked-list-item`)**: Renders as `<li>`. List item role is provided implicitly by the element. No `role` override is applied or forwarded.
+- **Title region (`.cinder-stacked-list-item__title`)**: Plain `<div>` when `href` is absent; wraps an `<a>` when `href` is supplied. The anchor is the focusable, interactive element — not the row itself.
+- **Leading region (`.cinder-stacked-list-item__leading`)**: Purely visual by default. Consumer controls semantics of the child (e.g., `Avatar` with a `name` prop, or `aria-hidden="true"` on decorative icons).
+- **Trailing region (`.cinder-stacked-list-item__trailing`)**: Consumer-supplied interactive controls (buttons, dropdown triggers, chevron icons). Each control must have its own accessible name.
+
+## No Interactive `<li>`
+
+`StackedListItem` does not attach event handlers to the `<li>` element, and consumers must not add them either. The ARIA `listitem` role has no interactive semantics — assistive technologies do not reliably announce interactive list items, and keyboard users would encounter an extra focus stop with no associated action.
+
+All interaction lives inside child elements:
+
+- **Navigation:** via the `title` link when `href` is supplied.
+- **Actions:** via controls placed in the `trailing` snippet.
+
+If you need the entire row to be clickable, wrap the row in an explicit interactive element rather than attaching `onclick` to the `<li>`.
+
+## Disambiguated Action Labels
+
+When the `trailing` snippet contains interactive controls — "Edit", "Delete", "View", etc. — the accessible name of each control must identify the specific row. Screen readers reading row-by-row otherwise announce a stream of identical button labels, violating WCAG 2.4.6 (Headings and Labels) and WCAG 2.4.4 (Link Purpose in Context).
+
+```svelte
+{#snippet trailing()}
+  <!-- imports and props… -->
+  <Button aria-label={`Edit ${person.name}`}>Edit</Button>
+{/snippet}
+```
+
+The snippet receives no automatic row context — the consumer is responsible for capturing the row's identity in the surrounding `{#each}` block and threading it into the `trailing` snippet.
+
+## Linkified Rows
+
+When `href` is set, the title anchor is the primary focusable element representing the row's destination. Focus order within the row is: title link → any trailing controls (left-to-right in DOM order). This component intentionally does **not** implement the stretched-link pattern (where the entire row surface area is the click target) because that pattern conflicts with independently activatable trailing controls.
+
+If `trailing` contains interactive elements alongside a linked title, both are separately reachable via keyboard. Ensure both have distinct, disambiguated accessible names.
+
+## Density and Touch Target Size
+
+`StackedListItem` exposes `density="comfortable"` (default) and `density="condensed"`. Both affect row padding only — the `trailing` slot's own dimensions are untouched by the density setting.
+
+The component cannot enforce minimum touch target sizes on `trailing` content because that region is consumer-supplied markup. Two separate WCAG criteria apply:
+
+- **WCAG 2.5.8 Target Size (Minimum)** — Level AA — requires at least 24×24 CSS pixels, with documented exceptions and a spacing allowance for smaller targets. This is the **baseline**.
+- **WCAG 2.5.5 Target Size (Enhanced)** — Level AAA — recommends at least 44×44 CSS pixels for pointer-input targets. This is the **recommendation** for comfortable interaction.
+
+Condensed density reduces row padding; it does not reduce trailing control dimensions. Consumers must ensure their trailing controls independently satisfy the applicable target size criterion.
+
+## Leading Content Semantics
+
+The `leading` snippet is not automatically hidden from assistive technologies. If the leading slot contains an avatar that identifies the same person as the row title:
+
+- Either supply a `name` prop to `Avatar` (which provides a visible accessible name), _or_
+- Apply `aria-hidden="true"` to the `Avatar` when the title already communicates the identity and the leading visual is purely decorative.
+
+Duplicating identity information is acceptable and sometimes preferred — it makes the row easier to scan with a screen reader. Hiding it is only correct when the title already provides a complete, unambiguous label.
+
+## Reading Order and Container Queries
+
+The responsive layout (trailing dropping below body at narrow widths) is purely visual — implemented via CSS container queries on the `<li>`. DOM order is always `leading → title → description → meta → trailing`, regardless of how the grid re-flows at narrow container widths. Screen readers follow DOM order, so the reading sequence is stable and predictable across all breakpoints.
+
+## Animation and Motion
+
+`StackedListItem` does not apply any transition or animation by default, so there is nothing to suppress for users who prefer reduced motion. Consumers who add hover or focus animations via the `class` prop should wrap those styles in `@media (prefers-reduced-motion: no-preference)` to respect user system preferences.

--- a/packages/components/src/components/stacked-list-item.svelte
+++ b/packages/components/src/components/stacked-list-item.svelte
@@ -67,13 +67,17 @@
 
   // Filter out any on* attributes that TypeScript already blocks but which could
   // leak through at runtime (e.g. from dynamic spreads or JS consumers).
-  const safeRest = Object.fromEntries(
-    Object.entries(rest).filter(([key]) => !key.startsWith('on')),
-  ) as Omit<typeof rest, `on${string}`>;
+  // $derived so the filtered set re-evaluates when rest changes.
+  const safeRest = $derived(
+    Object.fromEntries(Object.entries(rest).filter(([key]) => !key.startsWith('on'))) as Omit<
+      typeof rest,
+      `on${string}`
+    >,
+  );
 
   // When target="_blank" and no rel is supplied, default to "noreferrer" to
-  // prevent reverse-tabnapping.
-  const resolvedRel = target === '_blank' && !rel ? 'noreferrer' : rel;
+  // prevent reverse-tabnapping. $derived so it re-evaluates when target or rel changes.
+  const resolvedRel = $derived(target === '_blank' && !rel ? 'noopener noreferrer' : rel);
 </script>
 
 <li

--- a/packages/components/src/components/stacked-list-item.svelte
+++ b/packages/components/src/components/stacked-list-item.svelte
@@ -66,10 +66,10 @@
   }: StackedListItemProps = $props();
 
   // Filter out any on* attributes that TypeScript already blocks but which could
-  // leak through at runtime (e.g. from dynamic spreads).
+  // leak through at runtime (e.g. from dynamic spreads or JS consumers).
   const safeRest = Object.fromEntries(
     Object.entries(rest).filter(([key]) => !key.startsWith('on')),
-  );
+  ) as Omit<typeof rest, `on${string}`>;
 
   // When target="_blank" and no rel is supplied, default to "noreferrer" to
   // prevent reverse-tabnapping.

--- a/packages/components/src/components/stacked-list-item.svelte
+++ b/packages/components/src/components/stacked-list-item.svelte
@@ -1,0 +1,105 @@
+<script lang="ts" module>
+  import type { Snippet } from 'svelte';
+  import type { HTMLAttributes, HTMLAnchorAttributes } from 'svelte/elements';
+
+  export type StackedListItemDensity = 'comfortable' | 'condensed';
+
+  type LiEventAttribute = Extract<keyof HTMLAttributes<HTMLLIElement>, `on${string}`>;
+
+  type ForwardedLiAttributes = Omit<
+    HTMLAttributes<HTMLLIElement>,
+    'title' | 'class' | 'role' | 'tabindex' | LiEventAttribute
+  >;
+
+  type StackedListItemBase = ForwardedLiAttributes & {
+    /** Density token surfaced as `data-cinder-density`. Default `comfortable`. */
+    density?: StackedListItemDensity;
+    /** Leading visual (avatar, icon, status dot). */
+    leading?: Snippet;
+    /** Primary label. Required. */
+    title: Snippet;
+    /** Secondary description below the title. */
+    description?: Snippet;
+    /** Tertiary metadata (timestamp, badge, system label). */
+    meta?: Snippet;
+    /** Trailing region (chevron, action button, dropdown trigger). */
+    trailing?: Snippet;
+    /** Merged with `cinder-stacked-list-item`. */
+    class?: string;
+  };
+
+  /** Non-linkified row — `title` snippet renders as plain text. */
+  type StackedListItemStatic = StackedListItemBase & {
+    href?: never;
+    target?: never;
+    rel?: never;
+    hreflang?: never;
+  };
+
+  /** Linkified row — `title` snippet renders as `<a href>`. */
+  type StackedListItemLinked = StackedListItemBase & {
+    href: string;
+    target?: HTMLAnchorAttributes['target'];
+    rel?: HTMLAnchorAttributes['rel'];
+    hreflang?: HTMLAnchorAttributes['hreflang'];
+  };
+
+  export type StackedListItemProps = StackedListItemStatic | StackedListItemLinked;
+</script>
+
+<script lang="ts">
+  import { cn } from '../utilities/class-names.ts';
+
+  let {
+    density = 'comfortable',
+    class: className,
+    leading,
+    title,
+    description,
+    meta,
+    trailing,
+    href,
+    target,
+    rel,
+    hreflang,
+    ...rest
+  }: StackedListItemProps = $props();
+</script>
+
+<li
+  class={cn('cinder-stacked-list-item', className)}
+  class:cinder-stacked-list-item--has-leading={!!leading}
+  class:cinder-stacked-list-item--has-trailing={!!trailing}
+  data-cinder-density={density}
+  {...rest}
+>
+  <div class="cinder-stacked-list-item__layout">
+    {#if leading}
+      <div class="cinder-stacked-list-item__leading">
+        {@render leading()}
+      </div>
+    {/if}
+    <div class="cinder-stacked-list-item__body">
+      <div class="cinder-stacked-list-item__title">
+        {#if href !== undefined}
+          <a class="cinder-stacked-list-item__title-link" {href} {target} {rel} {hreflang}>
+            {@render title()}
+          </a>
+        {:else}
+          {@render title()}
+        {/if}
+      </div>
+      {#if description}
+        <div class="cinder-stacked-list-item__description">{@render description()}</div>
+      {/if}
+      {#if meta}
+        <div class="cinder-stacked-list-item__meta">{@render meta()}</div>
+      {/if}
+    </div>
+    {#if trailing}
+      <div class="cinder-stacked-list-item__trailing">
+        {@render trailing()}
+      </div>
+    {/if}
+  </div>
+</li>

--- a/packages/components/src/components/stacked-list-item.svelte
+++ b/packages/components/src/components/stacked-list-item.svelte
@@ -48,7 +48,7 @@
 </script>
 
 <script lang="ts">
-  import { cn } from '../utilities/class-names.ts';
+  import { classNames } from '../utilities/class-names.ts';
 
   let {
     density = 'comfortable',
@@ -64,14 +64,27 @@
     hreflang,
     ...rest
   }: StackedListItemProps = $props();
+
+  // Filter out any on* attributes that TypeScript already blocks but which could
+  // leak through at runtime (e.g. from dynamic spreads).
+  const safeRest = Object.fromEntries(
+    Object.entries(rest).filter(([key]) => !key.startsWith('on')),
+  );
+
+  // When target="_blank" and no rel is supplied, default to "noreferrer" to
+  // prevent reverse-tabnapping.
+  const resolvedRel = target === '_blank' && !rel ? 'noreferrer' : rel;
 </script>
 
 <li
-  class={cn('cinder-stacked-list-item', className)}
-  class:cinder-stacked-list-item--has-leading={!!leading}
-  class:cinder-stacked-list-item--has-trailing={!!trailing}
+  class={classNames(
+    'cinder-stacked-list-item',
+    leading && 'cinder-stacked-list-item--has-leading',
+    trailing && 'cinder-stacked-list-item--has-trailing',
+    className,
+  )}
   data-cinder-density={density}
-  {...rest}
+  {...safeRest}
 >
   <div class="cinder-stacked-list-item__layout">
     {#if leading}
@@ -82,7 +95,13 @@
     <div class="cinder-stacked-list-item__body">
       <div class="cinder-stacked-list-item__title">
         {#if href !== undefined}
-          <a class="cinder-stacked-list-item__title-link" {href} {target} {rel} {hreflang}>
+          <a
+            class="cinder-stacked-list-item__title-link"
+            {href}
+            {target}
+            rel={resolvedRel}
+            {hreflang}
+          >
             {@render title()}
           </a>
         {:else}

--- a/packages/components/src/components/stacked-list-item.svelte
+++ b/packages/components/src/components/stacked-list-item.svelte
@@ -65,14 +65,16 @@
     ...rest
   }: StackedListItemProps = $props();
 
-  // Filter out any on* attributes that TypeScript already blocks but which could
+  // Filter out any attributes that TypeScript already blocks but which could
   // leak through at runtime (e.g. from dynamic spreads or JS consumers).
+  // Strips on* event handlers plus role and tabindex to prevent the <li> from
+  // becoming interactive — matching the accessibility contract in the a11y docs.
   // $derived so the filtered set re-evaluates when rest changes.
+  const BLOCKED_ATTRS = new Set(['role', 'tabindex']);
   const safeRest = $derived(
-    Object.fromEntries(Object.entries(rest).filter(([key]) => !key.startsWith('on'))) as Omit<
-      typeof rest,
-      `on${string}`
-    >,
+    Object.fromEntries(
+      Object.entries(rest).filter(([key]) => !key.startsWith('on') && !BLOCKED_ATTRS.has(key)),
+    ) as Omit<typeof rest, `on${string}`>,
   );
 
   // When target="_blank" and no rel is supplied, default to "noreferrer" to

--- a/packages/components/src/components/stacked-list-item.test.ts
+++ b/packages/components/src/components/stacked-list-item.test.ts
@@ -49,6 +49,9 @@ describe('StackedListItem', () => {
     expect(root?.querySelector('.cinder-stacked-list-item__trailing')?.textContent).toContain(
       'trailing-content',
     );
+    // Modifier classes are set when snippets are present
+    expect(root?.classList.contains('cinder-stacked-list-item--has-leading')).toBe(true);
+    expect(root?.classList.contains('cinder-stacked-list-item--has-trailing')).toBe(true);
   });
 
   test('title-only minimal case omits optional sub-elements', () => {
@@ -67,6 +70,9 @@ describe('StackedListItem', () => {
     expect(root?.querySelector('.cinder-stacked-list-item__title')?.textContent).toContain(
       'only-title',
     );
+    // Modifier classes are absent when snippets are omitted
+    expect(root?.classList.contains('cinder-stacked-list-item--has-leading')).toBe(false);
+    expect(root?.classList.contains('cinder-stacked-list-item--has-trailing')).toBe(false);
   });
 
   test('href renders title as <a>', () => {
@@ -80,9 +86,9 @@ describe('StackedListItem', () => {
     const root = container.querySelector('.cinder-stacked-list-item');
     expect(root?.tagName).toBe('LI');
 
-    const anchor = root?.querySelector('.cinder-stacked-list-item__title a');
+    const anchor = root?.querySelector('.cinder-stacked-list-item__title-link');
     expect(anchor).not.toBeNull();
-    expect((anchor as HTMLAnchorElement | null)?.getAttribute('href')).toBe('/some/path');
+    expect(anchor?.getAttribute('href')).toBe('/some/path');
     expect(anchor?.textContent).toContain('linked-title');
   });
 
@@ -94,7 +100,7 @@ describe('StackedListItem', () => {
     });
 
     const titleEl = container.querySelector('.cinder-stacked-list-item__title');
-    expect(titleEl?.querySelector('a')).toBeNull();
+    expect(titleEl?.querySelector('.cinder-stacked-list-item__title-link')).toBeNull();
     expect(titleEl?.textContent).toContain('static-title');
   });
 
@@ -104,14 +110,14 @@ describe('StackedListItem', () => {
         title: textSnippet('external'),
         href: 'https://example.com',
         target: '_blank',
-        rel: 'noopener',
+        rel: 'noopener noreferrer',
         hreflang: 'en',
       },
     });
 
-    const anchor = container.querySelector('.cinder-stacked-list-item__title a');
+    const anchor = container.querySelector('.cinder-stacked-list-item__title-link');
     expect(anchor?.getAttribute('target')).toBe('_blank');
-    expect(anchor?.getAttribute('rel')).toBe('noopener');
+    expect(anchor?.getAttribute('rel')).toBe('noopener noreferrer');
     expect(anchor?.getAttribute('hreflang')).toBe('en');
 
     // Anchor attributes must not leak onto the <li>
@@ -119,6 +125,19 @@ describe('StackedListItem', () => {
     expect(li?.getAttribute('target')).toBeNull();
     expect(li?.getAttribute('rel')).toBeNull();
     expect(li?.getAttribute('hreflang')).toBeNull();
+  });
+
+  test('target="_blank" without rel auto-applies rel="noreferrer"', () => {
+    const { container } = render(StackedListItem, {
+      props: {
+        title: textSnippet('external'),
+        href: 'https://example.com',
+        target: '_blank',
+      },
+    });
+
+    const anchor = container.querySelector('.cinder-stacked-list-item__title-link');
+    expect(anchor?.getAttribute('rel')).toBe('noreferrer');
   });
 
   test('defaults to comfortable density', () => {
@@ -141,15 +160,14 @@ describe('StackedListItem', () => {
     ).toBe('condensed');
   });
 
-  test('<li> has no inline activation handlers', () => {
+  test('<li> has no role or tabindex — not interactive', () => {
     const { container } = render(StackedListItem, {
       props: { title: textSnippet('no-handlers') },
     });
 
     const li = container.querySelector('.cinder-stacked-list-item');
-    expect(li instanceof HTMLElement ? li.onclick : null).toBeNull();
-    expect(li instanceof HTMLElement ? li.onkeydown : null).toBeNull();
-    expect(li instanceof HTMLElement ? li.onkeyup : null).toBeNull();
+    expect(li?.getAttribute('role')).toBeNull();
+    expect(li?.getAttribute('tabindex')).toBeNull();
   });
 
   test('data-*, id, and aria-* attrs land on the <li>, not an anchor', () => {

--- a/packages/components/src/components/stacked-list-item.test.ts
+++ b/packages/components/src/components/stacked-list-item.test.ts
@@ -127,7 +127,7 @@ describe('StackedListItem', () => {
     expect(li?.getAttribute('hreflang')).toBeNull();
   });
 
-  test('target="_blank" without rel auto-applies rel="noreferrer"', () => {
+  test('target="_blank" without rel auto-applies rel="noopener noreferrer"', () => {
     const { container } = render(StackedListItem, {
       props: {
         title: textSnippet('external'),
@@ -137,7 +137,8 @@ describe('StackedListItem', () => {
     });
 
     const anchor = container.querySelector('.cinder-stacked-list-item__title-link');
-    expect(anchor?.getAttribute('rel')).toBe('noreferrer');
+    expect(anchor?.getAttribute('rel')).toBe('noopener noreferrer');
+    expect(anchor?.getAttribute('target')).toBe('_blank');
   });
 
   test('defaults to comfortable density', () => {

--- a/packages/components/src/components/stacked-list-item.test.ts
+++ b/packages/components/src/components/stacked-list-item.test.ts
@@ -171,6 +171,16 @@ describe('StackedListItem', () => {
     expect(li?.getAttribute('tabindex')).toBeNull();
   });
 
+  test('role and tabindex are stripped at runtime even when passed dynamically', () => {
+    const { container } = render(StackedListItem, {
+      props: { title: textSnippet('dynamic-spread'), role: 'button', tabindex: '0' } as any,
+    });
+
+    const li = container.querySelector('.cinder-stacked-list-item');
+    expect(li?.getAttribute('role')).toBeNull();
+    expect(li?.getAttribute('tabindex')).toBeNull();
+  });
+
   test('data-*, id, and aria-* attrs land on the <li>, not an anchor', () => {
     const { container } = render(StackedListItem, {
       props: {

--- a/packages/components/src/components/stacked-list-item.test.ts
+++ b/packages/components/src/components/stacked-list-item.test.ts
@@ -1,0 +1,186 @@
+/// <reference lib="dom" />
+import { describe, expect, test } from 'bun:test';
+import { createRawSnippet } from 'svelte';
+
+import { setupHappyDom } from '../test/happy-dom.ts';
+
+// setupHappyDom() MUST run before any `@testing-library/svelte` import. testing-library
+// reads `globalThis.document` / `window` at module-init (top-level, not inside test bodies),
+// so we register happy-dom's globals first and then dynamic-import testing-library below.
+setupHappyDom();
+
+const { render } = await import('@testing-library/svelte');
+const { default: StackedListItem } = await import('./stacked-list-item.svelte');
+
+/** Build a minimal Svelte snippet that renders a single text node. */
+function textSnippet(text: string) {
+  return createRawSnippet(() => ({
+    render: () => `<span>${text}</span>`,
+    setup: () => {},
+  }));
+}
+
+describe('StackedListItem', () => {
+  test('renders all snippets under their respective class names', () => {
+    const { container } = render(StackedListItem, {
+      props: {
+        leading: textSnippet('leading-content'),
+        title: textSnippet('title-content'),
+        description: textSnippet('description-content'),
+        meta: textSnippet('meta-content'),
+        trailing: textSnippet('trailing-content'),
+      },
+    });
+
+    const root = container.querySelector('.cinder-stacked-list-item');
+    expect(root).not.toBeNull();
+    expect(root?.querySelector('.cinder-stacked-list-item__leading')?.textContent).toContain(
+      'leading-content',
+    );
+    expect(root?.querySelector('.cinder-stacked-list-item__title')?.textContent).toContain(
+      'title-content',
+    );
+    expect(root?.querySelector('.cinder-stacked-list-item__description')?.textContent).toContain(
+      'description-content',
+    );
+    expect(root?.querySelector('.cinder-stacked-list-item__meta')?.textContent).toContain(
+      'meta-content',
+    );
+    expect(root?.querySelector('.cinder-stacked-list-item__trailing')?.textContent).toContain(
+      'trailing-content',
+    );
+  });
+
+  test('title-only minimal case omits optional sub-elements', () => {
+    const { container } = render(StackedListItem, {
+      props: {
+        title: textSnippet('only-title'),
+      },
+    });
+
+    const root = container.querySelector('.cinder-stacked-list-item');
+    expect(root).not.toBeNull();
+    expect(root?.querySelector('.cinder-stacked-list-item__leading')).toBeNull();
+    expect(root?.querySelector('.cinder-stacked-list-item__description')).toBeNull();
+    expect(root?.querySelector('.cinder-stacked-list-item__meta')).toBeNull();
+    expect(root?.querySelector('.cinder-stacked-list-item__trailing')).toBeNull();
+    expect(root?.querySelector('.cinder-stacked-list-item__title')?.textContent).toContain(
+      'only-title',
+    );
+  });
+
+  test('href renders title as <a>', () => {
+    const { container } = render(StackedListItem, {
+      props: {
+        title: textSnippet('linked-title'),
+        href: '/some/path',
+      },
+    });
+
+    const root = container.querySelector('.cinder-stacked-list-item');
+    expect(root?.tagName).toBe('LI');
+
+    const anchor = root?.querySelector('.cinder-stacked-list-item__title a');
+    expect(anchor).not.toBeNull();
+    expect((anchor as HTMLAnchorElement | null)?.getAttribute('href')).toBe('/some/path');
+    expect(anchor?.textContent).toContain('linked-title');
+  });
+
+  test('no href renders title without anchor', () => {
+    const { container } = render(StackedListItem, {
+      props: {
+        title: textSnippet('static-title'),
+      },
+    });
+
+    const titleEl = container.querySelector('.cinder-stacked-list-item__title');
+    expect(titleEl?.querySelector('a')).toBeNull();
+    expect(titleEl?.textContent).toContain('static-title');
+  });
+
+  test('target, rel, and hreflang are forwarded onto the anchor', () => {
+    const { container } = render(StackedListItem, {
+      props: {
+        title: textSnippet('external'),
+        href: 'https://example.com',
+        target: '_blank',
+        rel: 'noopener',
+        hreflang: 'en',
+      },
+    });
+
+    const anchor = container.querySelector('.cinder-stacked-list-item__title a');
+    expect(anchor?.getAttribute('target')).toBe('_blank');
+    expect(anchor?.getAttribute('rel')).toBe('noopener');
+    expect(anchor?.getAttribute('hreflang')).toBe('en');
+
+    // Anchor attributes must not leak onto the <li>
+    const li = container.querySelector('.cinder-stacked-list-item');
+    expect(li?.getAttribute('target')).toBeNull();
+    expect(li?.getAttribute('rel')).toBeNull();
+    expect(li?.getAttribute('hreflang')).toBeNull();
+  });
+
+  test('defaults to comfortable density', () => {
+    const { container } = render(StackedListItem, {
+      props: { title: textSnippet('t') },
+    });
+
+    expect(
+      container.querySelector('.cinder-stacked-list-item')?.getAttribute('data-cinder-density'),
+    ).toBe('comfortable');
+  });
+
+  test('condensed density sets data-cinder-density="condensed"', () => {
+    const { container } = render(StackedListItem, {
+      props: { title: textSnippet('t'), density: 'condensed' },
+    });
+
+    expect(
+      container.querySelector('.cinder-stacked-list-item')?.getAttribute('data-cinder-density'),
+    ).toBe('condensed');
+  });
+
+  test('<li> has no inline activation handlers', () => {
+    const { container } = render(StackedListItem, {
+      props: { title: textSnippet('no-handlers') },
+    });
+
+    const li = container.querySelector('.cinder-stacked-list-item');
+    expect(li instanceof HTMLElement ? li.onclick : null).toBeNull();
+    expect(li instanceof HTMLElement ? li.onkeydown : null).toBeNull();
+    expect(li instanceof HTMLElement ? li.onkeyup : null).toBeNull();
+  });
+
+  test('data-*, id, and aria-* attrs land on the <li>, not an anchor', () => {
+    const { container } = render(StackedListItem, {
+      props: {
+        title: textSnippet('spread-test'),
+        'data-row-id': '42',
+        'aria-labelledby': 'x',
+        id: 'row-42',
+      } as any,
+    });
+
+    const li = container.querySelector('.cinder-stacked-list-item');
+    expect(li?.getAttribute('data-row-id')).toBe('42');
+    expect(li?.getAttribute('aria-labelledby')).toBe('x');
+    expect(li?.getAttribute('id')).toBe('row-42');
+
+    // Confirm href/target/rel/hreflang are not on the <li>
+    expect(li?.getAttribute('href')).toBeNull();
+    expect(li?.getAttribute('target')).toBeNull();
+    expect(li?.getAttribute('rel')).toBeNull();
+    expect(li?.getAttribute('hreflang')).toBeNull();
+  });
+
+  test('custom class is merged with cinder-stacked-list-item', () => {
+    const { container } = render(StackedListItem, {
+      props: { title: textSnippet('t'), class: 'my-row' },
+    });
+
+    const li = container.querySelector('.cinder-stacked-list-item');
+    expect(li?.classList.contains('cinder-stacked-list-item')).toBe(true);
+    expect(li?.classList.contains('my-row')).toBe(true);
+  });
+});

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -209,6 +209,12 @@ export type {
 export { default as Skeleton } from './components/skeleton.svelte';
 export type { SkeletonProps } from './components/skeleton.svelte';
 
+export { default as StackedListItem } from './components/stacked-list-item.svelte';
+export type {
+  StackedListItemDensity,
+  StackedListItemProps,
+} from './components/stacked-list-item.svelte';
+
 export { default as Spinner } from './components/spinner.svelte';
 export type { SpinnerProps, SpinnerSize } from './components/spinner.svelte';
 

--- a/packages/components/src/styles/components.css
+++ b/packages/components/src/styles/components.css
@@ -44,6 +44,7 @@
 @import './components/selection-popover.css';
 @import './components/skeleton.css';
 @import './components/sortable-list.css';
+@import './components/stacked-list-item.css';
 @import './components/spinner.css';
 @import './components/stat.css';
 @import './components/stat-group.css';

--- a/packages/components/src/styles/components/stacked-list-item.css
+++ b/packages/components/src/styles/components/stacked-list-item.css
@@ -73,9 +73,19 @@
 }
 
 .cinder-stacked-list-item__title-link:focus-visible {
-  outline: 2px solid var(--cinder-color-focus-ring);
-  outline-offset: 2px;
+  outline: var(--cinder-ring-width) solid transparent;
   border-radius: var(--cinder-radius-sm);
+  box-shadow:
+    0 0 0 var(--cinder-ring-offset) var(--cinder-ring-offset-color),
+    0 0 0 calc(var(--cinder-ring-offset) + var(--cinder-ring-width)) var(--cinder-ring-color);
+}
+
+/* Forced Colors Mode — box-shadow focus rings are invisible; use a real outline. */
+@media (forced-colors: active) {
+  .cinder-stacked-list-item__title-link:focus-visible {
+    outline: var(--cinder-ring-width) solid ButtonText;
+    outline-offset: 3px;
+  }
 }
 
 .cinder-stacked-list-item__description {
@@ -96,7 +106,7 @@
 }
 
 /* Narrow container query — trailing drops below body */
-@container cinder-stacked-list-item (max-width: 28rem) {
+@container cinder-stacked-list-item (max-width: 448px) {
   .cinder-stacked-list-item--has-trailing .cinder-stacked-list-item__layout {
     grid-template-columns: 1fr;
     grid-template-areas:

--- a/packages/components/src/styles/components/stacked-list-item.css
+++ b/packages/components/src/styles/components/stacked-list-item.css
@@ -1,0 +1,114 @@
+/* ========================================
+ * STACKED LIST ITEM
+ * ======================================== */
+
+.cinder-stacked-list-item {
+  display: block;
+  container-type: inline-size;
+  container-name: cinder-stacked-list-item;
+  padding: var(--cinder-space-3) var(--cinder-space-4);
+  border-bottom: 1px solid var(--cinder-color-border-subtle);
+}
+
+.cinder-stacked-list-item[data-cinder-density='condensed'] {
+  padding: var(--cinder-space-2) var(--cinder-space-3);
+}
+
+.cinder-stacked-list-item__layout {
+  display: grid;
+  align-items: center;
+  column-gap: var(--cinder-space-3);
+  row-gap: var(--cinder-space-2);
+  grid-template-columns: 1fr;
+  grid-template-areas: 'body';
+}
+
+.cinder-stacked-list-item--has-leading .cinder-stacked-list-item__layout {
+  grid-template-columns: auto 1fr;
+  grid-template-areas: 'leading body';
+}
+
+.cinder-stacked-list-item--has-trailing .cinder-stacked-list-item__layout {
+  grid-template-columns: 1fr auto;
+  grid-template-areas: 'body trailing';
+}
+
+.cinder-stacked-list-item--has-leading.cinder-stacked-list-item--has-trailing
+  .cinder-stacked-list-item__layout {
+  grid-template-columns: auto 1fr auto;
+  grid-template-areas: 'leading body trailing';
+}
+
+.cinder-stacked-list-item__leading {
+  grid-area: leading;
+}
+
+.cinder-stacked-list-item__body {
+  grid-area: body;
+  display: flex;
+  flex-direction: column;
+  gap: var(--cinder-space-1);
+}
+
+.cinder-stacked-list-item__trailing {
+  grid-area: trailing;
+  display: flex;
+  gap: var(--cinder-space-2);
+  align-items: center;
+}
+
+.cinder-stacked-list-item__title {
+  font-size: var(--cinder-font-size-sm);
+  line-height: var(--cinder-line-height-sm);
+  color: var(--cinder-color-foreground);
+}
+
+.cinder-stacked-list-item__title-link {
+  color: inherit;
+  text-decoration: none;
+}
+
+.cinder-stacked-list-item__title-link:hover {
+  text-decoration: underline;
+}
+
+.cinder-stacked-list-item__title-link:focus-visible {
+  outline: 2px solid var(--cinder-color-focus-ring);
+  outline-offset: 2px;
+  border-radius: var(--cinder-radius-sm);
+}
+
+.cinder-stacked-list-item__description {
+  font-size: var(--cinder-font-size-sm);
+  line-height: var(--cinder-line-height-sm);
+  color: var(--cinder-color-foreground-muted);
+}
+
+.cinder-stacked-list-item__meta {
+  font-size: var(--cinder-font-size-xs);
+  line-height: var(--cinder-line-height-xs);
+  color: var(--cinder-color-foreground-muted);
+}
+
+.cinder-stacked-list-item[data-cinder-density='condensed'] .cinder-stacked-list-item__description,
+.cinder-stacked-list-item[data-cinder-density='condensed'] .cinder-stacked-list-item__meta {
+  line-height: var(--cinder-line-height-xs);
+}
+
+/* Narrow container query — trailing drops below body */
+@container cinder-stacked-list-item (max-width: 28rem) {
+  .cinder-stacked-list-item--has-trailing .cinder-stacked-list-item__layout {
+    grid-template-columns: 1fr;
+    grid-template-areas:
+      'body'
+      'trailing';
+  }
+
+  .cinder-stacked-list-item--has-leading.cinder-stacked-list-item--has-trailing
+    .cinder-stacked-list-item__layout {
+    grid-template-columns: auto 1fr;
+    grid-template-areas:
+      'leading body'
+      'trailing trailing';
+  }
+}


### PR DESCRIPTION
## Summary

- Adds `StackedListItem`, a rich list row primitive with `leading`, `title`, `description`, `meta`, and `trailing` snippet slots
- Optional `href` prop renders the title as an `<a>` (title-only linkification, not stretched-link, to preserve separately-activatable trailing controls)
- `data-cinder-density` attribute with `comfortable` (default) and `condensed` values
- Responsive layout via CSS container queries — trailing collapses below body at 448px
- Row-level interactivity intentionally blocked: `role`, `tabindex`, and all `on*` event handlers are Omit-ed from the forwarded prop type and filtered at runtime
- `target="_blank"` without explicit `rel` auto-applies `rel="noopener noreferrer"` for reverse-tabnapping protection
- Dedicated `stacked-list-item.a11y.md` covering disambiguated row labels, density/touch-target WCAG guidance, leading content semantics, and DOM reading order

## Review committee

Pre-reviewed by: typescript-expert, testing-expert, ux-designer, simplicity-engineer, prose-editor, junior-engineer, codex (gpt-5.4, xhigh reasoning)
- 2 rounds of review
- All must-fix items addressed

> [!WARNING]
> Codex (the adversarial second-opinion reviewer) was unavailable for round 2 re-review (empty session resume). Round 1 Codex findings were fully addressed. See `tmp/committee-state.md` for detail.

## Test plan

- `bun test stacked-list-item` — 11 tests covering all snippets, density, modifier classes, href/no-href, anchor attribute forwarding, auto-rel, rest prop isolation, class merging, and role/tabindex absence
- `bun run typecheck` — 0 errors
- `bun run lint` — 0 errors
- Full suite: `TZ=UTC LANG=en_US.UTF-8 bun test --conditions browser` — 867 pass, 0 fail

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk: introduces a new exported component with custom prop/attribute filtering and link handling; most impact is additive but could affect consumers via new export surface and CSS import order/bundling.
> 
> **Overview**
> Adds a new `StackedListItem` component export (and package export path) that renders a rich `<li>` row with `leading`/`title`/`description`/`meta`/`trailing` snippets, optional title linkification via `href`, and a `data-cinder-density` token.
> 
> Includes new styling for the row layout (including a narrow-width container query) and a focused test suite validating snippet rendering, density, link attribute forwarding + `target="_blank"` `rel` defaulting, and runtime stripping of `role`/`tabindex`/`on*` handlers to prevent interactive `<li>` usage; also adds a dedicated `stacked-list-item.a11y.md` documenting the accessibility contract.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d2d5af91fbcd1f1eff1b7eda870c805c9e581ed3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->