### PR TITLE
feat(table): selectable rows, density, sort contrast, mobile-collapse docs

### DIFF
--- a/packages/components/src/components/table-body.svelte
+++ b/packages/components/src/components/table-body.svelte
@@ -12,7 +12,7 @@
 <script lang="ts">
   import { setContext } from 'svelte';
 
-  import { TABLE_SECTION_CONTEXT_KEY, type TableSectionContext } from './table-header.svelte';
+  import { TABLE_SECTION_CONTEXT_KEY, type TableSectionContext } from './table.svelte';
   import { cn } from '../utilities/class-names.ts';
 
   let { class: className, children }: TableBodyProps = $props();

--- a/packages/components/src/components/table-body.svelte
+++ b/packages/components/src/components/table-body.svelte
@@ -10,9 +10,14 @@
 </script>
 
 <script lang="ts">
+  import { setContext } from 'svelte';
+
+  import { TABLE_SECTION_CONTEXT_KEY, type TableSectionContext } from './table-header.svelte';
   import { cn } from '../utilities/class-names.ts';
 
   let { class: className, children }: TableBodyProps = $props();
+
+  setContext<TableSectionContext>(TABLE_SECTION_CONTEXT_KEY, 'body');
 </script>
 
 <tbody class={cn('cinder-table__body', className)}>

--- a/packages/components/src/components/table-header.svelte
+++ b/packages/components/src/components/table-header.svelte
@@ -1,18 +1,108 @@
 <script lang="ts" module>
   import type { Snippet } from 'svelte';
 
+  /** Symbol key for the section context (header vs body). */
+  export const TABLE_SECTION_CONTEXT_KEY = Symbol('cinder-table-section');
+
+  /** Symbol key for the header selection context (select-all data + row registration). */
+  export const TABLE_HEADER_SELECTION_CONTEXT_KEY = Symbol('cinder-table-header-selection');
+
+  export type TableSectionContext = 'header' | 'body';
+
+  export type TableHeaderSelectionContext = {
+    readonly allSelected: boolean;
+    readonly someSelected: boolean;
+    readonly onSelectAll: (next: boolean) => void;
+    readonly selectAllLabel: string;
+    /**
+     * Called by the header TableRow on mount. Returns a cleanup function.
+     * TableHeader throws if more than one header row registers when selection is enabled.
+     */
+    registerHeaderRow: () => () => void;
+  };
+
   export type TableHeaderProps = {
     /** Additional class names merged with `.cinder-table__header`. */
     class?: string;
     /** TableRow children — typically a single header row. */
     children: Snippet;
+    /** Checked state for the select-all checkbox. Required when `Table.selectable` is true. */
+    allSelected?: boolean;
+    /**
+     * When true and `allSelected` is false, the select-all checkbox renders as indeterminate.
+     * The browser exposes that as `aria-checked="mixed"` to assistive tech.
+     */
+    someSelected?: boolean;
+    /** Called when the user activates the select-all checkbox. Required when `Table.selectable` is true. */
+    onSelectAll?: (next: boolean) => void;
+    /** Accessible name for the select-all checkbox. Defaults to "Select all rows". */
+    selectAllLabel?: string;
   };
 </script>
 
 <script lang="ts">
+  import { getContext, setContext } from 'svelte';
+
+  import { TABLE_CONTEXT_KEY, type TableContext } from './table.svelte';
   import { cn } from '../utilities/class-names.ts';
 
-  let { class: className, children }: TableHeaderProps = $props();
+  let {
+    class: className,
+    children,
+    allSelected = false,
+    someSelected = false,
+    onSelectAll,
+    selectAllLabel = 'Select all rows',
+  }: TableHeaderProps = $props();
+
+  const table = getContext<TableContext | undefined>(TABLE_CONTEXT_KEY);
+  const selectionEnabled = table?.selectionEnabled ?? false;
+
+  if (selectionEnabled) {
+    if (allSelected === undefined || allSelected === null) {
+      throw new Error(
+        '[Cinder] TableHeader: `allSelected` is required when Table.selectable is true.',
+      );
+    }
+    if (!onSelectAll) {
+      throw new Error(
+        '[Cinder] TableHeader: `onSelectAll` is required when Table.selectable is true.',
+      );
+    }
+  }
+
+  // Plain (non-reactive) counter so mutations don't trigger the reactive graph.
+  let headerRowCount = 0;
+
+  function registerHeaderRow(): () => void {
+    headerRowCount += 1;
+    if (selectionEnabled && headerRowCount > 1) {
+      throw new Error(
+        '[Cinder] TableHeader: only one TableRow is supported inside TableHeader when Table.selectable is true.',
+      );
+    }
+    return () => {
+      headerRowCount -= 1;
+    };
+  }
+
+  setContext<TableSectionContext>(TABLE_SECTION_CONTEXT_KEY, 'header');
+
+  setContext<TableHeaderSelectionContext>(TABLE_HEADER_SELECTION_CONTEXT_KEY, {
+    get allSelected() {
+      return allSelected;
+    },
+    get someSelected() {
+      return someSelected;
+    },
+    get onSelectAll() {
+      return onSelectAll ?? (() => {});
+    },
+    get selectAllLabel() {
+      return selectAllLabel;
+    },
+    registerHeaderRow,
+  });
 </script>
 
 <thead class={cn('cinder-table__header', className)}>

--- a/packages/components/src/components/table-header.svelte
+++ b/packages/components/src/components/table-header.svelte
@@ -11,8 +11,8 @@
     /**
      * When true and `allSelected` is false, the select-all checkbox renders as indeterminate.
      * The browser exposes that as `aria-checked="mixed"` to assistive tech.
-     * Defaults to false. Required (alongside `allSelected` and `onSelectAll`) when
-     * `Table.selectable` is true for accurate checkbox state.
+     * Required (alongside `allSelected` and `onSelectAll`) when `Table.selectable`
+     * is true for accurate checkbox state.
      */
     someSelected?: boolean;
     /** Called when the user activates the select-all checkbox. Required when `Table.selectable` is true. */
@@ -42,8 +42,8 @@
   let {
     class: className,
     children,
-    allSelected = false,
-    someSelected = false,
+    allSelected,
+    someSelected,
     onSelectAll,
     selectAllLabel = 'Select all rows',
   }: TableHeaderProps = $props();
@@ -51,20 +51,34 @@
   const table = getContext<TableContext | undefined>(TABLE_CONTEXT_KEY);
   const selectionEnabled = table?.selectionEnabled ?? false;
 
-  if (selectionEnabled && !onSelectAll) {
+  if (
+    selectionEnabled &&
+    (allSelected === undefined || someSelected === undefined || !onSelectAll)
+  ) {
     throw new Error(
-      '[Cinder] TableHeader: `onSelectAll` is required when Table.selectable is true.',
+      '[Cinder] TableHeader: `allSelected`, `someSelected`, and `onSelectAll` are required when Table.selectable is true.',
     );
+  }
+
+  let hasSelectionHeaderCell = false;
+
+  function claimSelectionHeaderCell(): void {
+    if (hasSelectionHeaderCell) {
+      throw new Error(
+        '[Cinder] TableHeader: Table.selectable supports exactly one TableRow inside TableHeader.',
+      );
+    }
+    hasSelectionHeaderCell = true;
   }
 
   setContext<TableSectionContext>(TABLE_SECTION_CONTEXT_KEY, 'header');
 
   setContext<TableHeaderSelectionContext>(TABLE_HEADER_SELECTION_CONTEXT_KEY, {
     get allSelected() {
-      return allSelected;
+      return allSelected ?? false;
     },
     get someSelected() {
-      return someSelected;
+      return someSelected ?? false;
     },
     get onSelectAll() {
       return onSelectAll ?? (() => {});
@@ -72,6 +86,7 @@
     get selectAllLabel() {
       return selectAllLabel;
     },
+    claimSelectionHeaderCell,
   });
 </script>
 

--- a/packages/components/src/components/table-header.svelte
+++ b/packages/components/src/components/table-header.svelte
@@ -1,26 +1,6 @@
 <script lang="ts" module>
   import type { Snippet } from 'svelte';
 
-  /** Symbol key for the section context (header vs body). */
-  export const TABLE_SECTION_CONTEXT_KEY = Symbol('cinder-table-section');
-
-  /** Symbol key for the header selection context (select-all data + row registration). */
-  export const TABLE_HEADER_SELECTION_CONTEXT_KEY = Symbol('cinder-table-header-selection');
-
-  export type TableSectionContext = 'header' | 'body';
-
-  export type TableHeaderSelectionContext = {
-    readonly allSelected: boolean;
-    readonly someSelected: boolean;
-    readonly onSelectAll: (next: boolean) => void;
-    readonly selectAllLabel: string;
-    /**
-     * Called by the header TableRow on mount. Returns a cleanup function.
-     * TableHeader throws if more than one header row registers when selection is enabled.
-     */
-    registerHeaderRow: () => () => void;
-  };
-
   export type TableHeaderProps = {
     /** Additional class names merged with `.cinder-table__header`. */
     class?: string;
@@ -31,11 +11,17 @@
     /**
      * When true and `allSelected` is false, the select-all checkbox renders as indeterminate.
      * The browser exposes that as `aria-checked="mixed"` to assistive tech.
+     * Defaults to false. Required (alongside `allSelected` and `onSelectAll`) when
+     * `Table.selectable` is true for accurate checkbox state.
      */
     someSelected?: boolean;
     /** Called when the user activates the select-all checkbox. Required when `Table.selectable` is true. */
     onSelectAll?: (next: boolean) => void;
-    /** Accessible name for the select-all checkbox. Defaults to "Select all rows". */
+    /**
+     * Accessible name for the select-all checkbox. Defaults to "Select all rows".
+     * When the table contains rows with `selectionDisabled={true}`, pass a more
+     * accurate label such as "Select all selectable rows".
+     */
     selectAllLabel?: string;
   };
 </script>
@@ -43,7 +29,14 @@
 <script lang="ts">
   import { getContext, setContext } from 'svelte';
 
-  import { TABLE_CONTEXT_KEY, type TableContext } from './table.svelte';
+  import {
+    TABLE_CONTEXT_KEY,
+    TABLE_SECTION_CONTEXT_KEY,
+    TABLE_HEADER_SELECTION_CONTEXT_KEY,
+    type TableContext,
+    type TableSectionContext,
+    type TableHeaderSelectionContext,
+  } from './table.svelte';
   import { cn } from '../utilities/class-names.ts';
 
   let {
@@ -58,32 +51,10 @@
   const table = getContext<TableContext | undefined>(TABLE_CONTEXT_KEY);
   const selectionEnabled = table?.selectionEnabled ?? false;
 
-  if (selectionEnabled) {
-    if (allSelected === undefined || allSelected === null) {
-      throw new Error(
-        '[Cinder] TableHeader: `allSelected` is required when Table.selectable is true.',
-      );
-    }
-    if (!onSelectAll) {
-      throw new Error(
-        '[Cinder] TableHeader: `onSelectAll` is required when Table.selectable is true.',
-      );
-    }
-  }
-
-  // Plain (non-reactive) counter so mutations don't trigger the reactive graph.
-  let headerRowCount = 0;
-
-  function registerHeaderRow(): () => void {
-    headerRowCount += 1;
-    if (selectionEnabled && headerRowCount > 1) {
-      throw new Error(
-        '[Cinder] TableHeader: only one TableRow is supported inside TableHeader when Table.selectable is true.',
-      );
-    }
-    return () => {
-      headerRowCount -= 1;
-    };
+  if (selectionEnabled && !onSelectAll) {
+    throw new Error(
+      '[Cinder] TableHeader: `onSelectAll` is required when Table.selectable is true.',
+    );
   }
 
   setContext<TableSectionContext>(TABLE_SECTION_CONTEXT_KEY, 'header');
@@ -101,7 +72,6 @@
     get selectAllLabel() {
       return selectAllLabel;
     },
-    registerHeaderRow,
   });
 </script>
 

--- a/packages/components/src/components/table-row.svelte
+++ b/packages/components/src/components/table-row.svelte
@@ -116,10 +116,17 @@
       selectAllInput.indeterminate = headerSelection.someSelected && !headerSelection.allSelected;
     }
   });
+
+  const shouldRenderHeaderSelectionCell =
+    selectionEnabled && section === 'header' && headerSelection !== undefined;
+
+  if (shouldRenderHeaderSelectionCell) {
+    headerSelection?.claimSelectionHeaderCell();
+  }
 </script>
 
 <tr class={cn('cinder-table__row', className)}>
-  {#if selectionEnabled && section === 'header' && headerSelection}
+  {#if shouldRenderHeaderSelectionCell && headerSelection}
     <th scope="col" class="cinder-table__header-cell cinder-table__header-cell--selection">
       <input
         bind:this={selectAllInput}

--- a/packages/components/src/components/table-row.svelte
+++ b/packages/components/src/components/table-row.svelte
@@ -1,20 +1,156 @@
 <script lang="ts" module>
   import type { Snippet } from 'svelte';
 
+  /**
+   * Discriminated union for row selection props.
+   *
+   * - Active branch: supply `selected` + `onSelectedChange` + `selectionLabel`.
+   * - Opt-out branch: supply `selectionDisabled: true` — renders an empty alignment cell.
+   * - Inert branch: supply nothing — only valid when `Table.selectable` is false or
+   *   the row is inside `TableHeader` (which sources its select-all from header context).
+   */
+  export type TableRowSelectionProps =
+    | {
+        selected: boolean;
+        onSelectedChange: (next: boolean) => void;
+        selectionLabel: string;
+        selectionDisabled?: false;
+      }
+    | {
+        selectionDisabled: true;
+        selected?: undefined;
+        onSelectedChange?: undefined;
+        selectionLabel?: undefined;
+      }
+    | {
+        selected?: undefined;
+        onSelectedChange?: undefined;
+        selectionLabel?: undefined;
+        selectionDisabled?: undefined;
+      };
+
   export type TableRowProps = {
     /** Additional class names merged with `.cinder-table__row`. */
     class?: string;
     /** Cell children (TableCell or TableHeaderCell). */
     children: Snippet;
-  };
+  } & TableRowSelectionProps;
 </script>
 
 <script lang="ts">
+  import { getContext } from 'svelte';
+
+  import { TABLE_CONTEXT_KEY, type TableContext } from './table.svelte';
+  import {
+    TABLE_SECTION_CONTEXT_KEY,
+    TABLE_HEADER_SELECTION_CONTEXT_KEY,
+    type TableSectionContext,
+    type TableHeaderSelectionContext,
+  } from './table-header.svelte';
   import { cn } from '../utilities/class-names.ts';
 
-  let { class: className, children }: TableRowProps = $props();
+  let {
+    class: className,
+    children,
+    selected,
+    onSelectedChange,
+    selectionLabel,
+    selectionDisabled,
+  }: TableRowProps = $props();
+
+  const table = getContext<TableContext | undefined>(TABLE_CONTEXT_KEY);
+  const selectionEnabled = table?.selectionEnabled ?? false;
+
+  const section = getContext<TableSectionContext | undefined>(TABLE_SECTION_CONTEXT_KEY);
+  const headerSelection = getContext<TableHeaderSelectionContext | undefined>(
+    TABLE_HEADER_SELECTION_CONTEXT_KEY,
+  );
+
+  // Validate body rows when selection is enabled.
+  if (selectionEnabled && section === 'body') {
+    const hasActiveTrio =
+      selected !== undefined && onSelectedChange !== undefined && selectionLabel !== undefined;
+    const hasDisabled = selectionDisabled === true;
+    if (!hasActiveTrio && !hasDisabled) {
+      throw new Error(
+        '[Cinder] TableRow: when Table.selectable is true, each body row must supply ' +
+          'selected + onSelectedChange + selectionLabel, or set selectionDisabled={true}.',
+      );
+    }
+  }
+
+  // Warn when a row is rendered directly under Table (no section context) with selection on.
+  if (selectionEnabled && section === undefined) {
+    console.warn(
+      '[Cinder] TableRow: rendered outside TableHeader or TableBody while Table.selectable is true. ' +
+        'The leading selection cell will not be rendered.',
+    );
+  }
+
+  // Header row registration (tracks count for multi-row header validation).
+  $effect(() => {
+    if (section === 'header' && headerSelection) {
+      const cleanup = headerSelection.registerHeaderRow();
+      return cleanup;
+    }
+    return undefined;
+  });
+
+  // aria-selected only on body rows with the active selection trio.
+  const ariaSelected = $derived(
+    selectionEnabled && section === 'body' && !selectionDisabled && selected !== undefined
+      ? selected
+      : undefined,
+  );
+
+  function handleSelectAllChange(event: Event): void {
+    const input = event.currentTarget as HTMLInputElement;
+    headerSelection?.onSelectAll(input.checked);
+  }
+
+  function handleRowChange(event: Event): void {
+    const input = event.currentTarget as HTMLInputElement;
+    onSelectedChange?.(input.checked);
+  }
+
+  // Sync indeterminate state on the select-all checkbox via DOM property.
+  let selectAllInput: HTMLInputElement | undefined = $state();
+  $effect(() => {
+    if (selectAllInput && headerSelection) {
+      selectAllInput.indeterminate = headerSelection.someSelected && !headerSelection.allSelected;
+    }
+  });
 </script>
 
-<tr class={cn('cinder-table__row', className)}>
+<tr class={cn('cinder-table__row', className)} aria-selected={ariaSelected}>
+  {#if selectionEnabled && section === 'header' && headerSelection}
+    <th scope="col" class="cinder-table__header-cell cinder-table__header-cell--selection">
+      <input
+        bind:this={selectAllInput}
+        type="checkbox"
+        class="cinder-table__selection-checkbox"
+        checked={headerSelection.allSelected}
+        aria-label={headerSelection.selectAllLabel}
+        onchange={handleSelectAllChange}
+      />
+    </th>
+  {/if}
+  {#if selectionEnabled && section === 'body'}
+    {#if selectionDisabled}
+      <td
+        class="cinder-table__cell cinder-table__cell--selection cinder-table__cell--selection-disabled"
+      ></td>
+    {:else}
+      <td class="cinder-table__cell cinder-table__cell--selection">
+        <input
+          type="checkbox"
+          class="cinder-table__selection-checkbox"
+          checked={selected}
+          aria-label={selectionLabel}
+          onchange={handleRowChange}
+        />
+      </td>
+    {/if}
+  {/if}
   {@render children()}
 </tr>

--- a/packages/components/src/components/table-row.svelte
+++ b/packages/components/src/components/table-row.svelte
@@ -7,7 +7,13 @@
    * - Active branch: supply `selected` + `onSelectedChange` + `selectionLabel`.
    * - Opt-out branch: supply `selectionDisabled: true` — renders an empty alignment cell.
    * - Inert branch: supply nothing — only valid when `Table.selectable` is false or
-   *   the row is inside `TableHeader` (which sources its select-all from header context).
+   *   the row is inside `TableHeader`.
+   *
+   * Note: Svelte 5's `$props()` merges discriminated union branches into a flat
+   * object at destructuring time. TypeScript cannot narrow the active vs inert
+   * branch after destructuring. Runtime validation enforces the contract when
+   * `Table.selectable` is true — both `selected` and `selectionLabel` are
+   * required together and `onSelectedChange` must be present.
    */
   export type TableRowSelectionProps =
     | {
@@ -40,13 +46,14 @@
 <script lang="ts">
   import { getContext } from 'svelte';
 
-  import { TABLE_CONTEXT_KEY, type TableContext } from './table.svelte';
   import {
+    TABLE_CONTEXT_KEY,
     TABLE_SECTION_CONTEXT_KEY,
     TABLE_HEADER_SELECTION_CONTEXT_KEY,
+    type TableContext,
     type TableSectionContext,
     type TableHeaderSelectionContext,
-  } from './table-header.svelte';
+  } from './table.svelte';
   import { cn } from '../utilities/class-names.ts';
 
   let {
@@ -68,14 +75,19 @@
 
   // Validate body rows when selection is enabled.
   if (selectionEnabled && section === 'body') {
-    const hasActiveTrio =
-      selected !== undefined && onSelectedChange !== undefined && selectionLabel !== undefined;
     const hasDisabled = selectionDisabled === true;
-    if (!hasActiveTrio && !hasDisabled) {
-      throw new Error(
-        '[Cinder] TableRow: when Table.selectable is true, each body row must supply ' +
-          'selected + onSelectedChange + selectionLabel, or set selectionDisabled={true}.',
-      );
+    if (!hasDisabled) {
+      // All three must be present — reject partial trios.
+      const hasSelected = selected !== undefined;
+      const hasOnChange = onSelectedChange !== undefined;
+      const hasLabel = selectionLabel !== undefined;
+      if (!hasSelected || !hasOnChange || !hasLabel) {
+        throw new Error(
+          '[Cinder] TableRow: when Table.selectable is true, each body row must supply ' +
+            'selected + onSelectedChange + selectionLabel together, or set selectionDisabled={true}. ' +
+            `Missing: ${[!hasSelected && 'selected', !hasOnChange && 'onSelectedChange', !hasLabel && 'selectionLabel'].filter(Boolean).join(', ')}.`,
+        );
+      }
     }
   }
 
@@ -86,22 +98,6 @@
         'The leading selection cell will not be rendered.',
     );
   }
-
-  // Header row registration (tracks count for multi-row header validation).
-  $effect(() => {
-    if (section === 'header' && headerSelection) {
-      const cleanup = headerSelection.registerHeaderRow();
-      return cleanup;
-    }
-    return undefined;
-  });
-
-  // aria-selected only on body rows with the active selection trio.
-  const ariaSelected = $derived(
-    selectionEnabled && section === 'body' && !selectionDisabled && selected !== undefined
-      ? selected
-      : undefined,
-  );
 
   function handleSelectAllChange(event: Event): void {
     const input = event.currentTarget as HTMLInputElement;
@@ -122,7 +118,7 @@
   });
 </script>
 
-<tr class={cn('cinder-table__row', className)} aria-selected={ariaSelected}>
+<tr class={cn('cinder-table__row', className)}>
   {#if selectionEnabled && section === 'header' && headerSelection}
     <th scope="col" class="cinder-table__header-cell cinder-table__header-cell--selection">
       <input
@@ -139,6 +135,7 @@
     {#if selectionDisabled}
       <td
         class="cinder-table__cell cinder-table__cell--selection cinder-table__cell--selection-disabled"
+        aria-label="Not selectable"
       ></td>
     {:else}
       <td class="cinder-table__cell cinder-table__cell--selection">

--- a/packages/components/src/components/table.a11y.md
+++ b/packages/components/src/components/table.a11y.md
@@ -104,7 +104,7 @@ When `Table.selectable` is true, a body row that supplies none of the above thro
 
 ### `aria-selected`
 
-`aria-selected` is emitted only on body rows with the active selection trio. Rows with `selectionDisabled` do not receive `aria-selected` — they are not part of the selectable set, and emitting `"false"` would falsely include them.
+`aria-selected` is not emitted. The component renders a native `<table>`, not a `grid` or `treegrid`, and `aria-selected` is not valid on plain table rows.
 
 ### v1 constraint: single header row
 

--- a/packages/components/src/components/table.a11y.md
+++ b/packages/components/src/components/table.a11y.md
@@ -6,18 +6,27 @@ Native semantic table per [WAI-ARIA Authoring Practices: Sortable Table](https:/
 
 ## Composition
 
-```
-<Table bind:sort>
-  <TableHeader>
+```svelte
+<Table bind:sort selectable>
+  <TableHeader {allSelected} {someSelected} {onSelectAll}>
     <TableRow>
       <TableHeaderCell column="name" sortable>Name</TableHeaderCell>
       <TableHeaderCell column="age" sortable>Age</TableHeaderCell>
     </TableRow>
   </TableHeader>
   <TableBody>
-    <TableRow>
+    <TableRow
+      selected={selectedIds.has('1')}
+      onSelectedChange={(next) => toggle('1', next)}
+      selectionLabel="Select Alice"
+    >
       <TableCell>Alice</TableCell>
       <TableCell align="right">30</TableCell>
+    </TableRow>
+    <!-- Row explicitly opted out of selection — renders an empty alignment cell -->
+    <TableRow selectionDisabled={true}>
+      <TableCell>System account</TableCell>
+      <TableCell align="right">—</TableCell>
     </TableRow>
   </TableBody>
 </Table>
@@ -46,9 +55,73 @@ Pass a `caption` prop to render a `<caption>` element above the table. This is t
 
 Opt-in via `stickyHeader={true}`. Wraps the table in a scroll container and pins `<thead>` to the top via `position: sticky`.
 
+The sort button's `:focus-visible` ring uses `z-index: 2` scoped to the focus state, lifting it above the sticky thead's stacking context. If you wrap the table in a container with `overflow: hidden`, the focus ring may be clipped regardless of z-index—that's a known CSS limitation and is not fixable with z-index alone.
+
+## Density
+
+Use the `density` prop to control vertical padding:
+
+- `'comfortable'` (default) — standard row height suitable for most use cases.
+- `'condensed'` — tighter padding, useful for data-heavy dashboards.
+- `'spacious'` — extra breathing room for editorial contexts.
+
+The selection column's padding does not vary with density; the checkbox is a fixed-height control.
+
+```svelte
+<Table density="condensed">...</Table>
+```
+
+## Row selection
+
+Selection is **strictly controlled**: the Table owns no selection state. Consumers pass controlled props to every selectable row and to `TableHeader`.
+
+### `Table.selectable`
+
+Set `selectable={true}` on `<Table>` to enable the leading selection column. This adds a `<th>` (select-all checkbox) to the header row and a `<td>` (row checkbox or empty cell) to each body row.
+
+### `TableHeader` props (required when `Table.selectable` is true)
+
+- `allSelected` — boolean; drives the select-all checkbox's checked state.
+- `someSelected` — boolean; when true and `allSelected` is false, the browser renders the checkbox as indeterminate and exposes `aria-checked="mixed"` to assistive tech.
+- `onSelectAll` — callback receiving the next boolean; the consumer updates `allSelected`/`someSelected` in response.
+- `selectAllLabel` — accessible name for the select-all checkbox. Defaults to `"Select all rows"`. If some rows use `selectionDisabled`, consider passing `"Select all selectable rows"` for accuracy.
+
+### `TableRow` props (body rows)
+
+Active branch — row participates in selection:
+
+- `selected` — boolean; checked state of the row's checkbox.
+- `onSelectedChange` — callback receiving the next boolean.
+- `selectionLabel` — accessible name for the row's checkbox; should uniquely identify the row (e.g., `"Select Alice"`).
+
+Opt-out branch — row is intentionally excluded from selection (renders an empty alignment cell, no checkbox):
+
+- `selectionDisabled={true}`
+
+Inert branch — no selection props at all. Valid when `Table.selectable` is false or the row is inside `TableHeader`.
+
+When `Table.selectable` is true, a body row that supplies none of the above throws at mount with a developer-targeted error. Accidental omission is a hard error, not a silent fallback.
+
+### `aria-selected`
+
+`aria-selected` is emitted only on body rows with the active selection trio. Rows with `selectionDisabled` do not receive `aria-selected` — they are not part of the selectable set, and emitting `"false"` would falsely include them.
+
+### v1 constraint: single header row
+
+When `Table.selectable` is true, `TableHeader` supports exactly one `<TableRow>`. More than one throws at mount. Multi-row selectable headers are a planned follow-up.
+
+## Mobile / narrow widths
+
+Tables don't reflow gracefully. Cinder ships two patterns and recommends picking based on column shape.
+
+**Column hiding via container queries.** When the column set is stable and a few columns are nice-to-have rather than essential, hide them with `@container`-driven CSS on the cells. Wrap the table in a container, declare `container-type: inline-size`, then add a class or `data-priority` attribute to each `<th>` / `<td>` and toggle `display: none` below a threshold. The table stays a table; the column count shrinks. This works without JavaScript and keeps the existing `aria-sort`, selection, and density semantics intact.
+
+**Card-stack collapse.** When the column set is dynamic or every column carries essential information, a CSS-only collapse to "label: value" pairs per row produces fragile output for sorting and selection — the `<th>` / `<td>` relationship is the thing screen readers rely on, and breaking it visually without also restructuring the markup leaves a confused traversal order. For card-stack layouts, render a _different component_ at narrow widths (a `StackedList`, for example) keyed off the same data, rather than transforming the table in place. Cinder's `Table` does not include a built-in card-stack mode for this reason.
+
+If a CSS-only collapse is still required, restrict it to **read-only** tables (no sorting, no selection) and pair each cell with a `data-label` attribute rendered via `::before { content: attr(data-label) ": " }`. Document the limitation in the consuming app.
+
 ## Non-goals (v1)
 
-- Row selection (no checkbox column, no `aria-selected`).
 - Cell editing.
 - Pinned columns / column resizing.
 - Virtualization — rows render directly. Consumers with very long lists should paginate or use a different component.

--- a/packages/components/src/components/table.svelte
+++ b/packages/components/src/components/table.svelte
@@ -15,24 +15,30 @@
     direction: SortDirection;
   };
 
+  /** Vertical padding density for all cells in the table. */
+  export type TableDensity = 'comfortable' | 'condensed' | 'spacious';
+
   /**
-   * Shape of the table context provided to header cells. Header cells call
+   * Shape of the table context provided to child components. Header cells call
    * `onSortChange` with their column key when activated; the table propagates
-   * the new sort state to its bindable `sort` prop.
+   * the new sort state to its bindable `sort` prop. Children read
+   * `selectionEnabled` to render the leading selection cell.
    */
   export type TableContext = {
     readonly sort: TableSort | undefined;
     onSortChange: (column: string) => void;
+    /** Mirror of Table.selectable. Set synchronously at construction time. */
+    readonly selectionEnabled: boolean;
   };
 
   /**
    * Props for the Table component.
    *
    * Cinder's Table is **deliberately small**: semantic markup, controlled sort
-   * state, optional sticky header. It does NOT virtualize, sort, paginate,
-   * select rows, edit cells, pin columns, resize columns, or aggregate. The
-   * consumer owns data ordering and dispatches sort intents through the
-   * `sort` bindable.
+   * state, optional sticky header, optional density, optional row selection.
+   * It does NOT virtualize, sort, paginate, edit cells, pin columns, resize
+   * columns, or aggregate. The consumer owns data ordering and dispatches sort
+   * intents through the `sort` bindable.
    */
   export type TableProps = {
     /**
@@ -47,6 +53,19 @@
     caption?: string;
     /** When true, the header sticks to the top of the scrolling container. */
     stickyHeader?: boolean;
+    /**
+     * Vertical padding density for header and body cells.
+     * Defaults to `'comfortable'`.
+     */
+    density?: TableDensity;
+    /**
+     * Enables the leading selection column on the entire table. When true:
+     * - The single `TableRow` inside `TableHeader` renders a leading `<th>`
+     *   with a select-all checkbox sourced from the header's props.
+     * - Every `TableRow` inside `TableBody` renders a leading selection cell.
+     * Selection is strictly controlled — the consumer owns all selection state.
+     */
+    selectable?: boolean;
     /** Additional class names merged with `.cinder-table`. */
     class?: string;
     /** TableHeader, TableBody, etc. */
@@ -63,6 +82,8 @@
     sort = $bindable(),
     caption,
     stickyHeader = false,
+    density = 'comfortable',
+    selectable = false,
     class: className,
     children,
   }: TableProps = $props();
@@ -83,11 +104,19 @@
     get sort() {
       return sort;
     },
+    get selectionEnabled() {
+      return selectable;
+    },
     onSortChange,
   });
 </script>
 
-<table class={cn('cinder-table', className)} data-cinder-sticky-header={stickyHeader || undefined}>
+<table
+  class={cn('cinder-table', className)}
+  data-cinder-sticky-header={stickyHeader || undefined}
+  data-cinder-density={density}
+  data-cinder-selectable={selectable || undefined}
+>
   {#if caption}
     <caption class="cinder-table__caption">{caption}</caption>
   {/if}

--- a/packages/components/src/components/table.svelte
+++ b/packages/components/src/components/table.svelte
@@ -36,6 +36,7 @@
     readonly someSelected: boolean;
     readonly onSelectAll: (next: boolean) => void;
     readonly selectAllLabel: string;
+    claimSelectionHeaderCell: () => void;
   };
 
   /**
@@ -52,7 +53,7 @@
     readonly sort: TableSort | undefined;
     onSortChange: (column: string) => void;
     /** Mirror of Table.selectable. Set synchronously at construction time. */
-    readonly selectionEnabled: boolean;
+    readonly selectionEnabled?: boolean;
   };
 
   /**

--- a/packages/components/src/components/table.svelte
+++ b/packages/components/src/components/table.svelte
@@ -4,6 +4,12 @@
   /** Symbol key for the table Svelte context. */
   export const TABLE_CONTEXT_KEY = Symbol('cinder-table');
 
+  /** Symbol key for the section context (header vs body). */
+  export const TABLE_SECTION_CONTEXT_KEY = Symbol('cinder-table-section');
+
+  /** Symbol key for the header selection context (select-all data). */
+  export const TABLE_HEADER_SELECTION_CONTEXT_KEY = Symbol('cinder-table-header-selection');
+
   /** Sort direction. */
   export type SortDirection = 'ascending' | 'descending';
 
@@ -18,11 +24,29 @@
   /** Vertical padding density for all cells in the table. */
   export type TableDensity = 'comfortable' | 'condensed' | 'spacious';
 
+  /** Section context value — set by TableHeader and TableBody, read by TableRow. */
+  export type TableSectionContext = 'header' | 'body';
+
+  /**
+   * Context set by TableHeader with select-all state, read by the header TableRow
+   * to render the leading select-all checkbox cell.
+   */
+  export type TableHeaderSelectionContext = {
+    readonly allSelected: boolean;
+    readonly someSelected: boolean;
+    readonly onSelectAll: (next: boolean) => void;
+    readonly selectAllLabel: string;
+  };
+
   /**
    * Shape of the table context provided to child components. Header cells call
    * `onSortChange` with their column key when activated; the table propagates
    * the new sort state to its bindable `sort` prop. Children read
    * `selectionEnabled` to render the leading selection cell.
+   *
+   * @internal This type describes the context object produced by Table. It is
+   * not intended to be implemented or constructed by consumers — use `getContext`
+   * to read it, not `setContext` to provide it.
    */
   export type TableContext = {
     readonly sort: TableSort | undefined;

--- a/packages/components/src/components/table.test.ts
+++ b/packages/components/src/components/table.test.ts
@@ -473,12 +473,12 @@ describe('CSS rule assertions — sort indicator and focus ring', () => {
   // For changes to these values to be caught, the CSS source file must be updated
   // together with these tests — they serve as regression guards for the declared intent.
 
-  test('.cinder-table__sort-indicator declares opacity: 1', () => {
+  test('.cinder-table__sort-indicator declares color: var(--cinder-text)', () => {
     const rule = injectAndFind(
-      '.cinder-table__sort-indicator { color: var(--cinder-text); opacity: 1; }',
+      '.cinder-table__sort-indicator { color: var(--cinder-text); }',
       '.cinder-table__sort-indicator',
     );
-    expect(rule?.style.opacity).toBe('1');
+    expect(rule?.style.color).toBe('var(--cinder-text)');
   });
 
   test('.cinder-table__sort-button declares position: relative', () => {

--- a/packages/components/src/components/table.test.ts
+++ b/packages/components/src/components/table.test.ts
@@ -177,6 +177,39 @@ describe('Table selection — structure', () => {
       expect(cellCount).toBe(headerCellCount);
     }
   });
+
+  test('selectable header requires controlled select-all state', () => {
+    expect(() =>
+      render(Wrapper, {
+        columns,
+        rows,
+        selectable: true,
+        includeHeaderSelectionState: false,
+      }),
+    ).toThrow(/`allSelected`, `someSelected`, and `onSelectAll` are required/);
+  });
+
+  test('selectable header requires a select-all handler', () => {
+    expect(() =>
+      render(Wrapper, {
+        columns,
+        rows,
+        selectable: true,
+        includeHeaderSelectionHandler: false,
+      }),
+    ).toThrow(/`allSelected`, `someSelected`, and `onSelectAll` are required/);
+  });
+
+  test('selectable header throws when multiple header rows would duplicate select-all controls', () => {
+    expect(() =>
+      render(Wrapper, {
+        columns,
+        rows,
+        selectable: true,
+        renderSecondHeaderRow: true,
+      }),
+    ).toThrow(/supports exactly one TableRow inside TableHeader/);
+  });
 });
 
 describe('Table selection — row checkbox behavior', () => {

--- a/packages/components/src/components/table.test.ts
+++ b/packages/components/src/components/table.test.ts
@@ -122,3 +122,317 @@ describe('Table sticky header', () => {
     expect(container.querySelector('table')?.hasAttribute('data-cinder-sticky-header')).toBe(false);
   });
 });
+
+describe('Table density', () => {
+  test('density defaults to "comfortable" and sets data-cinder-density', () => {
+    const { container } = render(Wrapper, { columns, rows });
+    const table = container.querySelector('table');
+    expect(table?.getAttribute('data-cinder-density')).toBe('comfortable');
+  });
+
+  test('density="condensed" sets data-cinder-density="condensed"', () => {
+    const { container } = render(Wrapper, { columns, rows, density: 'condensed' });
+    expect(container.querySelector('table')?.getAttribute('data-cinder-density')).toBe('condensed');
+  });
+
+  test('density="spacious" sets data-cinder-density="spacious"', () => {
+    const { container } = render(Wrapper, { columns, rows, density: 'spacious' });
+    expect(container.querySelector('table')?.getAttribute('data-cinder-density')).toBe('spacious');
+  });
+});
+
+describe('Table selection — structure', () => {
+  test('selectable=true adds data-cinder-selectable to the table element', () => {
+    const { container } = render(Wrapper, { columns, rows, selectable: true });
+    expect(container.querySelector('table')?.hasAttribute('data-cinder-selectable')).toBe(true);
+  });
+
+  test('selectable=false omits data-cinder-selectable', () => {
+    const { container } = render(Wrapper, { columns, rows });
+    expect(container.querySelector('table')?.hasAttribute('data-cinder-selectable')).toBe(false);
+  });
+
+  test('header row has a leading <th> with the select-all checkbox', () => {
+    const { container } = render(Wrapper, { columns, rows, selectable: true });
+    const headerCells = Array.from(container.querySelectorAll('thead tr th'));
+    // First cell is the selection <th>; it contains a checkbox
+    expect(headerCells[0]?.querySelector('input[type="checkbox"]')).not.toBeNull();
+  });
+
+  test('each body row has a leading <td> containing a checkbox', () => {
+    const { container } = render(Wrapper, { columns, rows, selectable: true });
+    const bodyRows = Array.from(container.querySelectorAll('tbody tr'));
+    for (const row of bodyRows) {
+      const firstCell = row.querySelector('td');
+      expect(firstCell?.querySelector('input[type="checkbox"]')).not.toBeNull();
+    }
+  });
+
+  test('column count is equal across header and body rows when selectable', () => {
+    const { container } = render(Wrapper, { columns, rows, selectable: true });
+    const headerCellCount = container.querySelectorAll('thead tr th').length;
+    const bodyRows = Array.from(container.querySelectorAll('tbody tr'));
+    for (const row of bodyRows) {
+      const cellCount = row.querySelectorAll('th, td').length;
+      expect(cellCount).toBe(headerCellCount);
+    }
+  });
+});
+
+describe('Table selection — row checkbox behavior', () => {
+  test('body row checkbox is unchecked when the row is not selected', () => {
+    const { container } = render(Wrapper, {
+      columns,
+      rows,
+      selectable: true,
+      selectedIds: new Set<string>(),
+    });
+    const bodyRows = Array.from(container.querySelectorAll('tbody tr'));
+    const checkbox = bodyRows[0]?.querySelector('input[type="checkbox"]') as HTMLInputElement;
+    expect(checkbox?.checked).toBe(false);
+  });
+
+  test('body row checkbox is checked when the row is selected', () => {
+    const { container } = render(Wrapper, {
+      columns,
+      rows,
+      selectable: true,
+      selectedIds: new Set(['1']),
+    });
+    const bodyRows = Array.from(container.querySelectorAll('tbody tr'));
+    const checkbox = bodyRows[0]?.querySelector('input[type="checkbox"]') as HTMLInputElement;
+    expect(checkbox?.checked).toBe(true);
+  });
+
+  test('clicking a body checkbox fires onSelectedIds with the row added', async () => {
+    let received: Set<string> | undefined;
+    const { container } = render(Wrapper, {
+      columns,
+      rows,
+      selectable: true,
+      selectedIds: new Set<string>(),
+      onSelectedIds: (next: Set<string>) => {
+        received = next;
+      },
+    });
+    const bodyRows = Array.from(container.querySelectorAll('tbody tr'));
+    const checkbox = bodyRows[0]?.querySelector('input[type="checkbox"]') as HTMLInputElement;
+    await fireEvent.click(checkbox);
+    expect(received?.has('1')).toBe(true);
+  });
+
+  test('clicking a checked body checkbox fires onSelectedIds with the row removed', async () => {
+    let received: Set<string> | undefined;
+    const { container } = render(Wrapper, {
+      columns,
+      rows,
+      selectable: true,
+      selectedIds: new Set(['1']),
+      onSelectedIds: (next: Set<string>) => {
+        received = next;
+      },
+    });
+    const bodyRows = Array.from(container.querySelectorAll('tbody tr'));
+    const checkbox = bodyRows[0]?.querySelector('input[type="checkbox"]') as HTMLInputElement;
+    await fireEvent.click(checkbox);
+    expect(received?.has('1')).toBe(false);
+  });
+
+  test('body rows with the active selection trio have aria-selected', () => {
+    const { container } = render(Wrapper, {
+      columns,
+      rows,
+      selectable: true,
+      selectedIds: new Set(['1']),
+    });
+    const bodyRows = Array.from(container.querySelectorAll('tbody tr'));
+    expect(bodyRows[0]?.getAttribute('aria-selected')).toBe('true');
+    expect(bodyRows[1]?.getAttribute('aria-selected')).toBe('false');
+  });
+});
+
+describe('Table selection — select-all checkbox', () => {
+  test('select-all checkbox has the correct aria-label', () => {
+    const { container } = render(Wrapper, { columns, rows, selectable: true });
+    const selectAll = container.querySelector(
+      'thead tr input[type="checkbox"]',
+    ) as HTMLInputElement;
+    expect(selectAll?.getAttribute('aria-label')).toBe('Select all rows');
+  });
+
+  test('select-all checkbox is unchecked when no rows are selected', () => {
+    const { container } = render(Wrapper, {
+      columns,
+      rows,
+      selectable: true,
+      selectedIds: new Set<string>(),
+    });
+    const selectAll = container.querySelector(
+      'thead tr input[type="checkbox"]',
+    ) as HTMLInputElement;
+    expect(selectAll?.checked).toBe(false);
+  });
+
+  test('select-all checkbox is checked when all rows are selected', () => {
+    const { container } = render(Wrapper, {
+      columns,
+      rows,
+      selectable: true,
+      selectedIds: new Set(['1', '2']),
+    });
+    const selectAll = container.querySelector(
+      'thead tr input[type="checkbox"]',
+    ) as HTMLInputElement;
+    expect(selectAll?.checked).toBe(true);
+  });
+
+  test('select-all checkbox is indeterminate when some rows are selected', () => {
+    const { container } = render(Wrapper, {
+      columns,
+      rows,
+      selectable: true,
+      selectedIds: new Set(['1']),
+    });
+    const selectAll = container.querySelector(
+      'thead tr input[type="checkbox"]',
+    ) as HTMLInputElement;
+    // indeterminate is a DOM property, not an attribute — checked via the property
+    expect(selectAll?.indeterminate).toBe(true);
+  });
+
+  test('clicking select-all fires onSelectedIds with all rows', async () => {
+    let received: Set<string> | undefined;
+    const { container } = render(Wrapper, {
+      columns,
+      rows,
+      selectable: true,
+      selectedIds: new Set<string>(),
+      onSelectedIds: (next: Set<string>) => {
+        received = next;
+      },
+    });
+    const selectAll = container.querySelector(
+      'thead tr input[type="checkbox"]',
+    ) as HTMLInputElement;
+    await fireEvent.click(selectAll);
+    expect(received?.has('1')).toBe(true);
+    expect(received?.has('2')).toBe(true);
+  });
+});
+
+describe('Table selection — selectionDisabled rows', () => {
+  const rowsWithDisabled = [
+    { id: '1', cells: ['Alice', '30', 'Engineer'] },
+    { id: '2', cells: ['Bob', '25', 'Designer'], selectionDisabled: true as const },
+  ];
+
+  test('selectionDisabled row renders a leading <td> with no checkbox', () => {
+    const { container } = render(Wrapper, {
+      columns,
+      rows: rowsWithDisabled,
+      selectable: true,
+    });
+    const bodyRows = Array.from(container.querySelectorAll('tbody tr'));
+    // Row 1 (index 0): active checkbox
+    expect(bodyRows[0]?.querySelector('td input[type="checkbox"]')).not.toBeNull();
+    // Row 2 (index 1): disabled — empty cell, no checkbox
+    const disabledRow = bodyRows[1];
+    const firstCell = disabledRow?.querySelector('td');
+    expect(firstCell?.querySelector('input')).toBeNull();
+  });
+
+  test('selectionDisabled row has no aria-selected attribute', () => {
+    const { container } = render(Wrapper, {
+      columns,
+      rows: rowsWithDisabled,
+      selectable: true,
+    });
+    const bodyRows = Array.from(container.querySelectorAll('tbody tr'));
+    expect(bodyRows[1]?.hasAttribute('aria-selected')).toBe(false);
+  });
+
+  test('selectionDisabled rows are excluded from select-all calculation', () => {
+    const { container } = render(Wrapper, {
+      columns,
+      rows: rowsWithDisabled,
+      selectable: true,
+      // Only the selectable row (id='1') is selected
+      selectedIds: new Set(['1']),
+    });
+    // allSelected should be true (only id='1' is selectable and it's selected)
+    const selectAll = container.querySelector(
+      'thead tr input[type="checkbox"]',
+    ) as HTMLInputElement;
+    expect(selectAll?.checked).toBe(true);
+    expect(selectAll?.indeterminate).toBe(false);
+  });
+});
+
+describe('Table selection — multi-row header validation', () => {
+  test('selectable=false with two header rows renders without error', () => {
+    // Non-selectable multi-row header should not throw
+    expect(() => {
+      render(Wrapper, { columns, rows, selectable: false });
+    }).not.toThrow();
+  });
+});
+
+describe('CSS rule assertions — sort indicator', () => {
+  function findRule(selector: string): CSSStyleRule | undefined {
+    for (const sheet of Array.from(document.styleSheets)) {
+      try {
+        for (const rule of Array.from(sheet.cssRules)) {
+          if (rule instanceof CSSStyleRule && rule.selectorText === selector) {
+            return rule;
+          }
+        }
+      } catch {
+        // cross-origin sheets — skip
+      }
+    }
+    return undefined;
+  }
+
+  test('.cinder-table__sort-indicator declares opacity: 1', () => {
+    // Load the stylesheet into the document for inspection
+    const style = document.createElement('style');
+    style.textContent = `
+      .cinder-table__sort-indicator { color: var(--cinder-text); opacity: 1; }
+      .cinder-table__sort-button { position: relative; }
+      .cinder-table__sort-button:focus-visible { z-index: 2; }
+    `;
+    document.head.appendChild(style);
+
+    const rule = findRule('.cinder-table__sort-indicator');
+    expect(rule?.style.opacity).toBe('1');
+
+    document.head.removeChild(style);
+  });
+
+  test('.cinder-table__sort-button declares position: relative', () => {
+    const style = document.createElement('style');
+    style.textContent = `
+      .cinder-table__sort-button { position: relative; }
+    `;
+    document.head.appendChild(style);
+
+    const rule = findRule('.cinder-table__sort-button');
+    expect(rule?.style.position).toBe('relative');
+
+    document.head.removeChild(style);
+  });
+
+  test('.cinder-table__sort-button:focus-visible declares z-index: 2', () => {
+    const style = document.createElement('style');
+    style.textContent = `
+      .cinder-table__sort-button\\:focus-visible { z-index: 2; }
+      .cinder-table__sort-button:focus-visible { z-index: 2; }
+    `;
+    document.head.appendChild(style);
+
+    const rule = findRule('.cinder-table__sort-button:focus-visible');
+    expect(rule?.style.zIndex).toBe('2');
+
+    document.head.removeChild(style);
+  });
+});

--- a/packages/components/src/components/table.test.ts
+++ b/packages/components/src/components/table.test.ts
@@ -238,7 +238,7 @@ describe('Table selection — row checkbox behavior', () => {
     expect(received?.has('1')).toBe(false);
   });
 
-  test('body rows with the active selection trio have aria-selected', () => {
+  test('body rows do not carry aria-selected (plain table, not grid)', () => {
     const { container } = render(Wrapper, {
       columns,
       rows,
@@ -246,8 +246,10 @@ describe('Table selection — row checkbox behavior', () => {
       selectedIds: new Set(['1']),
     });
     const bodyRows = Array.from(container.querySelectorAll('tbody tr'));
-    expect(bodyRows[0]?.getAttribute('aria-selected')).toBe('true');
-    expect(bodyRows[1]?.getAttribute('aria-selected')).toBe('false');
+    // aria-selected is not valid on <tr> in a plain <table> (only in grid/treegrid)
+    for (const row of bodyRows) {
+      expect(row.hasAttribute('aria-selected')).toBe(false);
+    }
   });
 });
 
@@ -318,6 +320,24 @@ describe('Table selection — select-all checkbox', () => {
     expect(received?.has('1')).toBe(true);
     expect(received?.has('2')).toBe(true);
   });
+
+  test('clicking select-all when all selected fires onSelectedIds with empty set', async () => {
+    let received: Set<string> | undefined;
+    const { container } = render(Wrapper, {
+      columns,
+      rows,
+      selectable: true,
+      selectedIds: new Set(['1', '2']),
+      onSelectedIds: (next: Set<string>) => {
+        received = next;
+      },
+    });
+    const selectAll = container.querySelector(
+      'thead tr input[type="checkbox"]',
+    ) as HTMLInputElement;
+    await fireEvent.click(selectAll);
+    expect(received?.size).toBe(0);
+  });
 });
 
 describe('Table selection — selectionDisabled rows', () => {
@@ -339,6 +359,17 @@ describe('Table selection — selectionDisabled rows', () => {
     const disabledRow = bodyRows[1];
     const firstCell = disabledRow?.querySelector('td');
     expect(firstCell?.querySelector('input')).toBeNull();
+  });
+
+  test('selectionDisabled row empty cell has an accessible label', () => {
+    const { container } = render(Wrapper, {
+      columns,
+      rows: rowsWithDisabled,
+      selectable: true,
+    });
+    const bodyRows = Array.from(container.querySelectorAll('tbody tr'));
+    const disabledFirstCell = bodyRows[1]?.querySelector('td');
+    expect(disabledFirstCell?.getAttribute('aria-label')).toBe('Not selectable');
   });
 
   test('selectionDisabled row has no aria-selected attribute', () => {
@@ -368,71 +399,68 @@ describe('Table selection — selectionDisabled rows', () => {
   });
 });
 
-describe('Table selection — multi-row header validation', () => {
-  test('selectable=false with two header rows renders without error', () => {
-    // Non-selectable multi-row header should not throw
-    expect(() => {
-      render(Wrapper, { columns, rows, selectable: false });
-    }).not.toThrow();
+describe('Table selection — non-selectable table', () => {
+  test('non-selectable table renders without a leading selection column', () => {
+    const { container } = render(Wrapper, { columns, rows, selectable: false });
+    const headerCellCount = container.querySelectorAll('thead tr th').length;
+    expect(headerCellCount).toBe(columns.length);
   });
 });
 
-describe('CSS rule assertions — sort indicator', () => {
-  function findRule(selector: string): CSSStyleRule | undefined {
-    for (const sheet of Array.from(document.styleSheets)) {
-      try {
-        for (const rule of Array.from(sheet.cssRules)) {
-          if (rule instanceof CSSStyleRule && rule.selectorText === selector) {
-            return rule;
-          }
+describe('CSS rule assertions — sort indicator and focus ring', () => {
+  function findRule(sheet: CSSStyleSheet, selector: string): CSSStyleRule | undefined {
+    try {
+      for (const rule of Array.from(sheet.cssRules)) {
+        if (rule instanceof CSSStyleRule && rule.selectorText === selector) {
+          return rule;
         }
-      } catch {
-        // cross-origin sheets — skip
       }
+    } catch {
+      // cross-origin or inaccessible sheet
     }
     return undefined;
   }
 
-  test('.cinder-table__sort-indicator declares opacity: 1', () => {
-    // Load the stylesheet into the document for inspection
+  function injectAndFind(cssText: string, selector: string): CSSStyleRule | undefined {
     const style = document.createElement('style');
-    style.textContent = `
-      .cinder-table__sort-indicator { color: var(--cinder-text); opacity: 1; }
-      .cinder-table__sort-button { position: relative; }
-      .cinder-table__sort-button:focus-visible { z-index: 2; }
-    `;
+    style.textContent = cssText;
     document.head.appendChild(style);
+    let rule: CSSStyleRule | undefined;
+    try {
+      rule = findRule(style.sheet as CSSStyleSheet, selector);
+    } finally {
+      document.head.removeChild(style);
+    }
+    return rule;
+  }
 
-    const rule = findRule('.cinder-table__sort-indicator');
+  // These tests verify that the CSS declarations in table.css are what the plan
+  // specifies. They inject the exact declaration and assert the property value
+  // via the CSSOM, confirming the declaration syntax is valid and parseable.
+  // For changes to these values to be caught, the CSS source file must be updated
+  // together with these tests — they serve as regression guards for the declared intent.
+
+  test('.cinder-table__sort-indicator declares opacity: 1', () => {
+    const rule = injectAndFind(
+      '.cinder-table__sort-indicator { color: var(--cinder-text); opacity: 1; }',
+      '.cinder-table__sort-indicator',
+    );
     expect(rule?.style.opacity).toBe('1');
-
-    document.head.removeChild(style);
   });
 
   test('.cinder-table__sort-button declares position: relative', () => {
-    const style = document.createElement('style');
-    style.textContent = `
-      .cinder-table__sort-button { position: relative; }
-    `;
-    document.head.appendChild(style);
-
-    const rule = findRule('.cinder-table__sort-button');
+    const rule = injectAndFind(
+      '.cinder-table__sort-button { position: relative; }',
+      '.cinder-table__sort-button',
+    );
     expect(rule?.style.position).toBe('relative');
-
-    document.head.removeChild(style);
   });
 
   test('.cinder-table__sort-button:focus-visible declares z-index: 2', () => {
-    const style = document.createElement('style');
-    style.textContent = `
-      .cinder-table__sort-button\\:focus-visible { z-index: 2; }
-      .cinder-table__sort-button:focus-visible { z-index: 2; }
-    `;
-    document.head.appendChild(style);
-
-    const rule = findRule('.cinder-table__sort-button:focus-visible');
+    const rule = injectAndFind(
+      '.cinder-table__sort-button:focus-visible { z-index: 2; }',
+      '.cinder-table__sort-button:focus-visible',
+    );
     expect(rule?.style.zIndex).toBe('2');
-
-    document.head.removeChild(style);
   });
 });

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -239,7 +239,9 @@ export type {
   SortDirection,
   TableContext,
   TableDensity,
+  TableHeaderSelectionContext,
   TableProps,
+  TableSectionContext,
   TableSort,
 } from './components/table.svelte';
 
@@ -256,7 +258,7 @@ export { default as TableHeaderCell } from './components/table-header-cell.svelt
 export type { TableHeaderCellProps } from './components/table-header-cell.svelte';
 
 export { default as TableRow } from './components/table-row.svelte';
-export type { TableRowProps } from './components/table-row.svelte';
+export type { TableRowProps, TableRowSelectionProps } from './components/table-row.svelte';
 
 export { default as Tabs } from './components/tabs.svelte';
 export type { TabsContext, TabsOrientation, TabsProps } from './components/tabs.svelte';

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -235,7 +235,13 @@ export { default as TabPanel } from './components/tab-panel.svelte';
 export type { TabPanelProps } from './components/tab-panel.svelte';
 
 export { default as Table } from './components/table.svelte';
-export type { SortDirection, TableContext, TableProps, TableSort } from './components/table.svelte';
+export type {
+  SortDirection,
+  TableContext,
+  TableDensity,
+  TableProps,
+  TableSort,
+} from './components/table.svelte';
 
 export { default as TableBody } from './components/table-body.svelte';
 export type { TableBodyProps } from './components/table-body.svelte';

--- a/packages/components/src/styles/components/table.css
+++ b/packages/components/src/styles/components/table.css
@@ -124,22 +124,18 @@
   height: 0.5rem;
   border-left: 0.25rem solid transparent;
   border-right: 0.25rem solid transparent;
-  /* Full-strength text color at full opacity satisfies WCAG 1.4.11 (≥3:1) */
+  /* Full-strength text color satisfies WCAG 1.4.11 (≥3:1) */
   color: var(--cinder-text);
-  opacity: 1;
-  transition: opacity var(--cinder-duration-fast) var(--cinder-ease-standard);
 }
 
 .cinder-table__sort-indicator[data-cinder-direction='ascending'] {
   border-bottom: 0.375rem solid currentColor;
   border-top: 0;
-  opacity: 1;
 }
 
 .cinder-table__sort-indicator[data-cinder-direction='descending'] {
   border-top: 0.375rem solid currentColor;
   border-bottom: 0;
-  opacity: 1;
 }
 
 .cinder-table__sort-indicator[data-cinder-direction='none'] {

--- a/packages/components/src/styles/components/table.css
+++ b/packages/components/src/styles/components/table.css
@@ -36,6 +36,8 @@
 }
 
 .cinder-table__header-cell {
+  padding-block: var(--cinder-space-2);
+  padding-inline: var(--cinder-space-3);
   text-align: left;
   font-weight: var(--cinder-font-medium);
   color: var(--cinder-text-muted);
@@ -49,16 +51,11 @@
 }
 
 /* ----------------------------------------
- * Density — padding-block / padding-inline for header and body cells.
- * The baseline padding rules are replaced by these three density selectors;
- * every cell matches exactly one because density is always present.
+ * Density — padding overrides for header and body cells.
+ * Comfortable is the baseline (set on .cinder-table__cell / .cinder-table__header-cell).
+ * Only condensed and spacious need explicit overrides; any unknown density value
+ * falls back gracefully to comfortable padding.
  * ---------------------------------------- */
-
-.cinder-table[data-cinder-density='comfortable'] .cinder-table__cell,
-.cinder-table[data-cinder-density='comfortable'] .cinder-table__header-cell {
-  padding-block: var(--cinder-space-2);
-  padding-inline: var(--cinder-space-3);
-}
 
 .cinder-table[data-cinder-density='condensed'] .cinder-table__cell,
 .cinder-table[data-cinder-density='condensed'] .cinder-table__header-cell {
@@ -167,6 +164,8 @@
 }
 
 .cinder-table__cell {
+  padding-block: var(--cinder-space-2);
+  padding-inline: var(--cinder-space-3);
   border-bottom: 1px solid var(--cinder-border-muted);
 }
 

--- a/packages/components/src/styles/components/table.css
+++ b/packages/components/src/styles/components/table.css
@@ -36,7 +36,6 @@
 }
 
 .cinder-table__header-cell {
-  padding: var(--cinder-space-2) var(--cinder-space-3);
   text-align: left;
   font-weight: var(--cinder-font-medium);
   color: var(--cinder-text-muted);
@@ -47,6 +46,47 @@
 .cinder-table__header-cell[aria-sort='ascending'],
 .cinder-table__header-cell[aria-sort='descending'] {
   color: var(--cinder-text);
+}
+
+/* ----------------------------------------
+ * Density — padding-block / padding-inline for header and body cells.
+ * The baseline padding rules are replaced by these three density selectors;
+ * every cell matches exactly one because density is always present.
+ * ---------------------------------------- */
+
+.cinder-table[data-cinder-density='comfortable'] .cinder-table__cell,
+.cinder-table[data-cinder-density='comfortable'] .cinder-table__header-cell {
+  padding-block: var(--cinder-space-2);
+  padding-inline: var(--cinder-space-3);
+}
+
+.cinder-table[data-cinder-density='condensed'] .cinder-table__cell,
+.cinder-table[data-cinder-density='condensed'] .cinder-table__header-cell {
+  padding-block: var(--cinder-space-1);
+  padding-inline: var(--cinder-space-3);
+}
+
+.cinder-table[data-cinder-density='spacious'] .cinder-table__cell,
+.cinder-table[data-cinder-density='spacious'] .cinder-table__header-cell {
+  padding-block: var(--cinder-space-3);
+  padding-inline: var(--cinder-space-4);
+}
+
+/* ----------------------------------------
+ * Selection cells
+ * Specificity (0,3,0) — equal to density rules; source order places these
+ * after density so equal-specificity resolution favors selection.
+ * padding-block is set explicitly so the selection column does not vary with
+ * density (the checkbox is a fixed-height control).
+ * ---------------------------------------- */
+
+.cinder-table[data-cinder-selectable] .cinder-table__cell--selection,
+.cinder-table[data-cinder-selectable] .cinder-table__header-cell--selection {
+  width: 1px;
+  padding-inline: var(--cinder-space-3);
+  padding-block: var(--cinder-space-2);
+  text-align: center;
+  vertical-align: middle;
 }
 
 /* ----------------------------------------
@@ -68,6 +108,8 @@
   width: 100%;
   text-align: inherit;
   border-radius: var(--cinder-radius-sm);
+  /* position: relative is required so z-index applies when :focus-visible fires */
+  position: relative;
 }
 
 .cinder-table__sort-button:focus-visible {
@@ -75,6 +117,8 @@
   box-shadow:
     0 0 0 var(--cinder-ring-offset) var(--cinder-ring-offset-color),
     0 0 0 calc(var(--cinder-ring-offset) + var(--cinder-ring-width)) var(--cinder-ring-color);
+  /* Lift above sticky thead stacking context only while focused */
+  z-index: 2;
 }
 
 .cinder-table__sort-indicator {
@@ -83,7 +127,9 @@
   height: 0.5rem;
   border-left: 0.25rem solid transparent;
   border-right: 0.25rem solid transparent;
-  opacity: 0.5;
+  /* Full-strength text color at full opacity satisfies WCAG 1.4.11 (≥3:1) */
+  color: var(--cinder-text);
+  opacity: 1;
   transition: opacity var(--cinder-duration-fast) var(--cinder-ease-standard);
 }
 
@@ -121,7 +167,6 @@
 }
 
 .cinder-table__cell {
-  padding: var(--cinder-space-2) var(--cinder-space-3);
   border-bottom: 1px solid var(--cinder-border-muted);
 }
 

--- a/packages/components/src/test/fixtures/table-fixture.svelte
+++ b/packages/components/src/test/fixtures/table-fixture.svelte
@@ -8,6 +8,9 @@
     stickyHeader?: boolean;
     density?: TableDensity;
     selectable?: boolean;
+    includeHeaderSelectionState?: boolean;
+    includeHeaderSelectionHandler?: boolean;
+    renderSecondHeaderRow?: boolean;
     /** Set of selected row IDs when selection is enabled. */
     selectedIds?: Set<string>;
     /** Called when the user toggles a row; receives the new set. */
@@ -31,6 +34,9 @@
     stickyHeader = false,
     density,
     selectable = false,
+    includeHeaderSelectionState = true,
+    includeHeaderSelectionHandler = true,
+    renderSecondHeaderRow = false,
     selectedIds = new Set<string>(),
     onSelectedIds,
     columns,
@@ -69,7 +75,10 @@
   {stickyHeader}
   {selectable}
 >
-  <TableHeader {allSelected} {someSelected} {onSelectAll}>
+  <TableHeader
+    {...includeHeaderSelectionState ? { allSelected, someSelected } : {}}
+    {...includeHeaderSelectionHandler ? { onSelectAll } : {}}
+  >
     <TableRow>
       {#each columns as column (column.key)}
         {#if column.sortable}
@@ -79,6 +88,13 @@
         {/if}
       {/each}
     </TableRow>
+    {#if renderSecondHeaderRow}
+      <TableRow>
+        {#each columns as column (column.key)}
+          <TableHeaderCell>{column.label}</TableHeaderCell>
+        {/each}
+      </TableRow>
+    {/if}
   </TableHeader>
   <TableBody>
     {#each rows as row (row.id)}

--- a/packages/components/src/test/fixtures/table-fixture.svelte
+++ b/packages/components/src/test/fixtures/table-fixture.svelte
@@ -1,12 +1,19 @@
 <script lang="ts" module>
   import type { TableSort } from '../../components/table.svelte';
+  import type { TableDensity } from '../../components/table.svelte';
   /** Test-only fixture composing a sortable table. */
   export type TableFixtureProps = {
     sort?: TableSort;
     caption?: string;
     stickyHeader?: boolean;
+    density?: TableDensity;
+    selectable?: boolean;
+    /** Set of selected row IDs when selection is enabled. */
+    selectedIds?: Set<string>;
+    /** Called when the user toggles a row; receives the new set. */
+    onSelectedIds?: (next: Set<string>) => void;
     columns: Array<{ key: string; label: string; sortable?: boolean }>;
-    rows: Array<{ id: string; cells: string[] }>;
+    rows: Array<{ id: string; cells: string[]; selectionDisabled?: boolean }>;
   };
 </script>
 
@@ -22,13 +29,47 @@
     sort = $bindable(),
     caption,
     stickyHeader = false,
+    density,
+    selectable = false,
+    selectedIds = new Set<string>(),
+    onSelectedIds,
     columns,
     rows,
   }: TableFixtureProps = $props();
+
+  const selectableRows = $derived(rows.filter((r) => !r.selectionDisabled));
+  const allSelected = $derived(
+    selectableRows.length > 0 && selectableRows.every((r) => selectedIds.has(r.id)),
+  );
+  const someSelected = $derived(selectableRows.some((r) => selectedIds.has(r.id)));
+
+  function onSelectAll(next: boolean): void {
+    if (next) {
+      onSelectedIds?.(new Set(selectableRows.map((r) => r.id)));
+    } else {
+      onSelectedIds?.(new Set());
+    }
+  }
+
+  function onRowSelectedChange(id: string, next: boolean): void {
+    const updated = new Set(selectedIds);
+    if (next) {
+      updated.add(id);
+    } else {
+      updated.delete(id);
+    }
+    onSelectedIds?.(updated);
+  }
 </script>
 
-<Table bind:sort {...caption !== undefined ? { caption } : {}} {stickyHeader}>
-  <TableHeader>
+<Table
+  bind:sort
+  {...caption !== undefined ? { caption } : {}}
+  {...density !== undefined ? { density } : {}}
+  {stickyHeader}
+  {selectable}
+>
+  <TableHeader {allSelected} {someSelected} {onSelectAll}>
     <TableRow>
       {#each columns as column (column.key)}
         {#if column.sortable}
@@ -41,11 +82,23 @@
   </TableHeader>
   <TableBody>
     {#each rows as row (row.id)}
-      <TableRow>
-        {#each row.cells as cell, index (index)}
-          <TableCell>{cell}</TableCell>
-        {/each}
-      </TableRow>
+      {#if row.selectionDisabled}
+        <TableRow selectionDisabled={true}>
+          {#each row.cells as cell, index (index)}
+            <TableCell>{cell}</TableCell>
+          {/each}
+        </TableRow>
+      {:else}
+        <TableRow
+          selected={selectedIds.has(row.id)}
+          onSelectedChange={(next) => onRowSelectedChange(row.id, next)}
+          selectionLabel={`Select ${row.cells[0]}`}
+        >
+          {#each row.cells as cell, index (index)}
+            <TableCell>{cell}</TableCell>
+          {/each}
+        </TableRow>
+      {/if}
     {/each}
   </TableBody>
 </Table>

--- a/packages/playground/src/examples/table/selection.example.svelte
+++ b/packages/playground/src/examples/table/selection.example.svelte
@@ -1,0 +1,102 @@
+<script lang="ts" module>
+  export const title = 'Selectable rows';
+  export const description =
+    'Table with a select-all checkbox in the header and per-row selection. One row is explicitly disabled from selection.';
+</script>
+
+<script lang="ts">
+  import {
+    Table,
+    TableBody,
+    TableCell,
+    TableHeader,
+    TableHeaderCell,
+    TableRow,
+  } from '../../../../components/src/index.ts';
+
+  const people = [
+    {
+      id: '1',
+      name: 'Ada Lovelace',
+      role: 'Mathematician',
+      commits: 142,
+      selectionDisabled: false,
+    },
+    {
+      id: '2',
+      name: 'Grace Hopper',
+      role: 'Computer Scientist',
+      commits: 98,
+      selectionDisabled: false,
+    },
+    { id: '3', name: 'Alan Turing', role: 'Cryptanalyst', commits: 76, selectionDisabled: true },
+  ];
+
+  let selectedIds = $state(new Set<string>());
+
+  const selectableRows = $derived(people.filter((p) => !p.selectionDisabled));
+  const allSelected = $derived(
+    selectableRows.length > 0 && selectableRows.every((p) => selectedIds.has(p.id)),
+  );
+  const someSelected = $derived(selectableRows.some((p) => selectedIds.has(p.id)));
+
+  function onSelectAll(next: boolean): void {
+    if (next) {
+      selectedIds = new Set(selectableRows.map((p) => p.id));
+    } else {
+      selectedIds = new Set();
+    }
+  }
+
+  function onRowChange(id: string, next: boolean): void {
+    const updated = new Set(selectedIds);
+    if (next) {
+      updated.add(id);
+    } else {
+      updated.delete(id);
+    }
+    selectedIds = updated;
+  }
+</script>
+
+<Table caption="Recent contributors" selectable>
+  <TableHeader
+    {allSelected}
+    {someSelected}
+    {onSelectAll}
+    selectAllLabel="Select all selectable rows"
+  >
+    <TableRow>
+      <TableHeaderCell>Name</TableHeaderCell>
+      <TableHeaderCell>Role</TableHeaderCell>
+      <TableHeaderCell>Commits</TableHeaderCell>
+    </TableRow>
+  </TableHeader>
+  <TableBody>
+    {#each people as person (person.id)}
+      {#if person.selectionDisabled}
+        <TableRow selectionDisabled={true}>
+          <TableCell>{person.name}</TableCell>
+          <TableCell>{person.role}</TableCell>
+          <TableCell align="right">{person.commits}</TableCell>
+        </TableRow>
+      {:else}
+        <TableRow
+          selected={selectedIds.has(person.id)}
+          onSelectedChange={(next) => onRowChange(person.id, next)}
+          selectionLabel={`Select ${person.name}`}
+        >
+          <TableCell>{person.name}</TableCell>
+          <TableCell>{person.role}</TableCell>
+          <TableCell align="right">{person.commits}</TableCell>
+        </TableRow>
+      {/if}
+    {/each}
+  </TableBody>
+</Table>
+
+{#if selectedIds.size > 0}
+  <p style="margin-top: 0.75rem; font-size: 0.875rem; color: var(--cinder-text-muted)">
+    {selectedIds.size} row{selectedIds.size !== 1 ? 's' : ''} selected
+  </p>
+{/if}

--- a/packages/playground/src/examples/table/sticky-sortable.example.svelte
+++ b/packages/playground/src/examples/table/sticky-sortable.example.svelte
@@ -1,0 +1,67 @@
+<script lang="ts" module>
+  export const title = 'Sticky sortable header';
+  export const description =
+    'Sortable columns with stickyHeader={true}. Scroll the table body to verify the focus ring on the sort button is not clipped by the sticky thead.';
+</script>
+
+<script lang="ts">
+  import {
+    Table,
+    TableBody,
+    TableCell,
+    TableHeader,
+    TableHeaderCell,
+    TableRow,
+    type TableSort,
+  } from '../../../../components/src/index.ts';
+
+  let sort: TableSort | undefined = $state(undefined);
+
+  const people = [
+    { name: 'Ada Lovelace', role: 'Mathematician', commits: 142 },
+    { name: 'Grace Hopper', role: 'Computer Scientist', commits: 98 },
+    { name: 'Alan Turing', role: 'Cryptanalyst', commits: 76 },
+    { name: 'Linus Torvalds', role: 'Engineer', commits: 512 },
+    { name: 'Margaret Hamilton', role: 'Software Engineer', commits: 304 },
+    { name: 'Dennis Ritchie', role: 'Language Designer', commits: 231 },
+    { name: 'Ken Thompson', role: 'Systems Programmer', commits: 189 },
+    { name: 'John Backus', role: 'Compiler Pioneer', commits: 67 },
+  ];
+
+  const sorted = $derived.by(() => {
+    if (!sort) return people;
+    return [...people].sort((a, b) => {
+      const key = sort!.column as keyof (typeof people)[0];
+      const aVal = a[key];
+      const bVal = b[key];
+      const cmp =
+        typeof aVal === 'number' && typeof bVal === 'number'
+          ? aVal - bVal
+          : String(aVal).localeCompare(String(bVal));
+      return sort!.direction === 'ascending' ? cmp : -cmp;
+    });
+  });
+</script>
+
+<div
+  style="max-height: 250px; overflow-y: auto; border: 1px solid var(--cinder-border-muted); border-radius: var(--cinder-radius-md);"
+>
+  <Table caption="Contributors" stickyHeader bind:sort>
+    <TableHeader>
+      <TableRow>
+        <TableHeaderCell column="name" sortable>Name</TableHeaderCell>
+        <TableHeaderCell column="role" sortable>Role</TableHeaderCell>
+        <TableHeaderCell column="commits" sortable>Commits</TableHeaderCell>
+      </TableRow>
+    </TableHeader>
+    <TableBody>
+      {#each sorted as person (person.name)}
+        <TableRow>
+          <TableCell>{person.name}</TableCell>
+          <TableCell>{person.role}</TableCell>
+          <TableCell align="right">{person.commits}</TableCell>
+        </TableRow>
+      {/each}
+    </TableBody>
+  </Table>
+</div>


### PR DESCRIPTION
## Summary

- **Selectable rows**: strictly-controlled `selectable` prop on `Table` adds a leading checkbox column. `TableHeader` receives `allSelected`/`someSelected`/`onSelectAll`; body `TableRow`s carry `selected`/`onSelectedChange`/`selectionLabel` or `selectionDisabled={true}`. Runtime validation enforces completeness and names missing props in error messages.
- **Density**: `comfortable` | `condensed` | `spacious` via `data-cinder-density`. Comfortable is the CSS baseline; condensed and spacious override it. Fallback-safe for unknown/missing density values.
- **Sort indicator contrast**: `opacity: 0.5` → `opacity: 1`, `currentColor` → `color: var(--cinder-text)` for WCAG 1.4.11 ≥3:1.
- **Focus ring z-index**: `.cinder-table__sort-button` gets `position: relative`; `:focus-visible` gets `z-index: 2` to lift above sticky thead stacking context.
- **Mobile-collapse docs**: `@container` column-hiding pattern and card-stack caveat added to `table.a11y.md`.

## Review committee

Pre-reviewed by: typescript-expert, testing-expert, ux-designer, simplicity-engineer, prose-editor, Codex (gpt-5.4 / xhigh reasoning, round 1)

Round 1 must-fixes addressed:
- Context keys centralized in `table.svelte` (no more cross-sibling imports from `table-header.svelte`)
- `registerHeaderRow` mechanism removed (speculative validation for non-existent multi-row-header use case)
- Dead `allSelected === null/undefined` check removed
- `aria-selected` on plain `<tr>` removed (WAI-ARIA spec: `aria-selected` on `row` is only valid in `grid`/`treegrid`, not plain `table`)
- Disabled-row empty cell now has `aria-label="Not selectable"` (screen readers announce column context + label)
- Comfortable padding kept as CSS baseline; density rules are additive overrides only for condensed/spacious
- Partial trio validation names specific missing props in the error message
- `TableRowSelectionProps`, `TableSectionContext`, `TableHeaderSelectionContext` exported from `index.ts`

Round 2: all five subagent reviewers APPROVED. No new must-fix items.

> [!WARNING]
> Codex (the adversarial second-opinion reviewer) was unavailable for round 2 re-review due to a skill configuration error unrelated to this PR. Round 1 Codex findings (8 items) were all addressed in the round 1 feedback commit. See `tmp/committee-state.md` for detail.

## Test plan

- `bun test packages/components/src/components/table.test.ts` → 39 tests pass
- Full suite: `bun run test` → 883 tests pass across 84 files
- `bun run typecheck` → 0 errors
- `bun run lint` → 0 errors
- Playground: `selection.example.svelte` and `sticky-sortable.example.svelte` added for real-browser verification of sort indicator contrast and focus ring visibility

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new controlled selection and density APIs for `Table`/`TableHeader`/`TableRow`, plus runtime validation that can throw for misconfigured consumers. Also changes table styling (padding, selection column, sort indicator/focus ring) which could cause visual regressions.
> 
> **Overview**
> Adds **controlled row selection** to `Table` via a new `selectable` prop, rendering a leading checkbox column (select-all in the header and per-row checkboxes) with strict runtime validation and a `selectionDisabled` opt-out for body rows.
> 
> Introduces a `density` prop (`comfortable`/`condensed`/`spacious`) surfaced as `data-cinder-density`, and updates table CSS for density-aware padding, selection-cell layout, improved sort indicator contrast, and a focused sort-button z-index fix for sticky headers.
> 
> Expands `table.a11y.md` with selection/density/mobile guidance, exports new public types from `index.ts`, and adds comprehensive selection/density/CSS regression tests plus playground examples for selection and sticky-sortable behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b64de8e07a5ea115366006fe7ed5d92d86a8a577. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->