### PR TITLE
feat(components): add GridList and GridListItem responsive grid primitives

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -153,6 +153,14 @@
       "svelte": "./src/components/experimental/timeline.svelte",
       "types": "./dist/components/experimental/timeline.svelte.d.ts"
     },
+    "./grid-list-item": {
+      "svelte": "./src/components/grid-list-item.svelte",
+      "types": "./dist/components/grid-list-item.svelte.d.ts"
+    },
+    "./grid-list": {
+      "svelte": "./src/components/grid-list.svelte",
+      "types": "./dist/components/grid-list.svelte.d.ts"
+    },
     "./input": {
       "svelte": "./src/components/input.svelte",
       "types": "./dist/components/input.svelte.d.ts"

--- a/packages/components/src/components/grid-list-item.svelte
+++ b/packages/components/src/components/grid-list-item.svelte
@@ -1,0 +1,104 @@
+<script lang="ts" module>
+  import type { Snippet } from 'svelte';
+  import type { HTMLAttributes } from 'svelte/elements';
+
+  export type GridListItemProps = Omit<HTMLAttributes<HTMLLIElement>, 'title'> & {
+    /**
+     * Optional URL. When present AND `title` is also provided, the title
+     * becomes a stretched link covering the entire item via a pseudo-element
+     * overlay. Only the `actions` snippet (and descendants marked with
+     * `data-cinder-stretched-link-escape`) remain pointer-operable above
+     * the overlay.
+     *
+     * If `href` is provided without `title`, no anchor is rendered.
+     */
+    href?: string;
+    /**
+     * Forwarded to the stretched-link anchor when `href` is set. When
+     * `target` matches `"_blank"` (case-insensitive), the component
+     * automatically composes `rel="noopener noreferrer"` with any
+     * consumer-supplied `rel` tokens to prevent reverse-tabnapping.
+     */
+    target?: string;
+    rel?: string;
+    class?: string;
+    /** Optional image region (avatar, thumbnail). */
+    image?: Snippet;
+    /** Primary label. Required when `href` is set for accessible link text. */
+    title?: Snippet;
+    /** Secondary description. */
+    subtitle?: Snippet;
+    /** Tertiary metadata (badges, supplementary text). */
+    meta?: Snippet;
+    /**
+     * Action buttons. This wrapper is lifted above the stretched-link overlay
+     * via `position: relative; z-index: 1` so buttons remain clickable.
+     */
+    actions?: Snippet;
+  };
+</script>
+
+<script lang="ts">
+  import { classNames } from '../utilities/class-names.ts';
+
+  let {
+    href,
+    target,
+    rel,
+    class: className,
+    image,
+    title,
+    subtitle,
+    meta,
+    actions,
+    ...rest
+  }: GridListItemProps = $props();
+
+  /**
+   * Compose `rel` for the stretched-link anchor.
+   * When target matches "_blank" (case-insensitive), merge "noopener" and
+   * "noreferrer" into whatever the consumer supplied, deduplicating tokens.
+   */
+  const composedRel = $derived.by(() => {
+    const isBlank = target?.toLowerCase() === '_blank';
+    if (!isBlank) return rel;
+    const tokens = new Set((rel ?? '').split(/\s+/).filter(Boolean));
+    tokens.add('noopener');
+    tokens.add('noreferrer');
+    return [...tokens].join(' ');
+  });
+</script>
+
+<li {...rest} class={classNames('cinder-grid-list__item', className)}>
+  {#if image}
+    <div class="cinder-grid-list__image">
+      {@render image()}
+    </div>
+  {/if}
+  {#if title}
+    <div class="cinder-grid-list__title">
+      {#if href !== undefined}
+        <a class="cinder-grid-list__link" {href} {target} rel={composedRel}>
+          {@render title()}
+        </a>
+      {:else}
+        {@render title()}
+      {/if}
+    </div>
+  {/if}
+  {#if subtitle}
+    <div class="cinder-grid-list__subtitle">
+      {@render subtitle()}
+    </div>
+  {/if}
+  {#if meta}
+    <div class="cinder-grid-list__meta">
+      {@render meta()}
+    </div>
+  {/if}
+  {#if actions}
+    <div class="cinder-grid-list__actions">
+      {@render actions()}
+    </div>
+  {/if}
+</li>

--- a/packages/components/src/components/grid-list-item.svelte
+++ b/packages/components/src/components/grid-list-item.svelte
@@ -1,30 +1,12 @@
 <script lang="ts" module>
   import type { Snippet } from 'svelte';
-  import type { HTMLAttributes } from 'svelte/elements';
+  import type { HTMLAnchorAttributes, HTMLAttributes } from 'svelte/elements';
 
-  export type GridListItemProps = Omit<HTMLAttributes<HTMLLIElement>, 'title'> & {
-    /**
-     * Optional URL. When present AND `title` is also provided, the title
-     * becomes a stretched link covering the entire item via a pseudo-element
-     * overlay. Only the `actions` snippet (and descendants marked with
-     * `data-cinder-stretched-link-escape`) remain pointer-operable above
-     * the overlay.
-     *
-     * If `href` is provided without `title`, no anchor is rendered.
-     */
-    href?: string;
-    /**
-     * Forwarded to the stretched-link anchor when `href` is set. When
-     * `target` matches `"_blank"` (case-insensitive), the component
-     * automatically composes `rel="noopener noreferrer"` with any
-     * consumer-supplied `rel` tokens to prevent reverse-tabnapping.
-     */
-    target?: string;
-    rel?: string;
+  type GridListItemBase = Omit<HTMLAttributes<HTMLLIElement>, 'title'> & {
     class?: string;
     /** Optional image region (avatar, thumbnail). */
     image?: Snippet;
-    /** Primary label. Required when `href` is set for accessible link text. */
+    /** Primary label. Provides the accessible name for the stretched link when `href` is set. */
     title?: Snippet;
     /** Secondary description. */
     subtitle?: Snippet;
@@ -36,6 +18,33 @@
      */
     actions?: Snippet;
   };
+
+  /** Non-linkified item — no stretched-link overlay. */
+  type GridListItemStatic = GridListItemBase & {
+    href?: never;
+    target?: never;
+    rel?: never;
+  };
+
+  /**
+   * Linkified item — `title` becomes a stretched link covering the entire card
+   * via a pseudo-element overlay. Only `actions` (and descendants marked with
+   * `data-cinder-stretched-link-escape`) remain pointer-operable above the overlay.
+   *
+   * If `title` is absent, no anchor is rendered even when `href` is set.
+   */
+  type GridListItemLinked = GridListItemBase & {
+    href: string;
+    /**
+     * When `target` matches `"_blank"` (case-insensitive), the component
+     * automatically composes `rel="noopener noreferrer"` with any
+     * consumer-supplied `rel` tokens to prevent reverse-tabnapping.
+     */
+    target?: HTMLAnchorAttributes['target'];
+    rel?: HTMLAnchorAttributes['rel'];
+  };
+
+  export type GridListItemProps = GridListItemStatic | GridListItemLinked;
 </script>
 
 <script lang="ts">

--- a/packages/components/src/components/grid-list-item.test.ts
+++ b/packages/components/src/components/grid-list-item.test.ts
@@ -174,4 +174,29 @@ describe('GridListItem', () => {
     expect(li?.getAttribute('class')).toContain('cinder-grid-list__item');
     expect(li?.getAttribute('class')).toContain('my-custom-class');
   });
+
+  test('optional snippet wrappers are absent when snippets not provided', () => {
+    const { container } = render(GridListItem, { props: {} });
+    const li = container.querySelector('li.cinder-grid-list__item') as HTMLElement;
+    expect(li.querySelector('.cinder-grid-list__image')).toBeNull();
+    expect(li.querySelector('.cinder-grid-list__title')).toBeNull();
+    expect(li.querySelector('.cinder-grid-list__subtitle')).toBeNull();
+    expect(li.querySelector('.cinder-grid-list__meta')).toBeNull();
+    expect(li.querySelector('.cinder-grid-list__actions')).toBeNull();
+  });
+
+  test('non-_blank target does not inject security tokens', () => {
+    const { container } = render(GridListItem, {
+      props: {
+        href: '/people/jane',
+        title: textSnippet('Jane'),
+        target: '_self',
+        rel: 'external',
+      },
+    });
+    const anchor = container.querySelector('a.cinder-grid-list__link');
+    const relTokens = (anchor?.getAttribute('rel') ?? '').split(/\s+/);
+    expect(relTokens).not.toContain('noopener');
+    expect(relTokens).not.toContain('noreferrer');
+  });
 });

--- a/packages/components/src/components/grid-list-item.test.ts
+++ b/packages/components/src/components/grid-list-item.test.ts
@@ -1,0 +1,177 @@
+/// <reference lib="dom" />
+import { describe, expect, test } from 'bun:test';
+
+import { setupHappyDom } from '../test/happy-dom.ts';
+
+setupHappyDom();
+
+const { render } = await import('@testing-library/svelte');
+const { default: GridListItem } = await import('./grid-list-item.svelte');
+const { createRawSnippet } = await import('svelte');
+
+function textSnippet(text: string) {
+  return createRawSnippet(() => ({
+    render: () => `<span>${text}</span>`,
+  }));
+}
+
+function rawSnippet(html: string) {
+  return createRawSnippet(() => ({
+    render: () => html,
+  }));
+}
+
+describe('GridListItem', () => {
+  test('renders an <li> with class cinder-grid-list__item', () => {
+    const { container } = render(GridListItem, { props: {} });
+    const item = container.querySelector('li.cinder-grid-list__item');
+    expect(item).not.toBeNull();
+  });
+
+  test('all five snippets render in DOM order', () => {
+    const { container } = render(GridListItem, {
+      props: {
+        image: textSnippet('IMG'),
+        title: textSnippet('TITLE'),
+        subtitle: textSnippet('SUBTITLE'),
+        meta: textSnippet('META'),
+        actions: textSnippet('ACTIONS'),
+      },
+    });
+    const li = container.querySelector('li.cinder-grid-list__item') as HTMLElement;
+    const text = li.textContent ?? '';
+    expect(text.indexOf('IMG')).toBeLessThan(text.indexOf('TITLE'));
+    expect(text.indexOf('TITLE')).toBeLessThan(text.indexOf('SUBTITLE'));
+    expect(text.indexOf('SUBTITLE')).toBeLessThan(text.indexOf('META'));
+    expect(text.indexOf('META')).toBeLessThan(text.indexOf('ACTIONS'));
+
+    expect(li.querySelector('.cinder-grid-list__image')).not.toBeNull();
+    expect(li.querySelector('.cinder-grid-list__title')).not.toBeNull();
+    expect(li.querySelector('.cinder-grid-list__subtitle')).not.toBeNull();
+    expect(li.querySelector('.cinder-grid-list__meta')).not.toBeNull();
+    expect(li.querySelector('.cinder-grid-list__actions')).not.toBeNull();
+  });
+
+  test('href + title produces a stretched-link anchor wrapping the title', () => {
+    const { container } = render(GridListItem, {
+      props: {
+        href: '/people/jane',
+        title: textSnippet('Jane'),
+      },
+    });
+    const anchor = container.querySelector('.cinder-grid-list__title a.cinder-grid-list__link');
+    expect(anchor).not.toBeNull();
+    expect(anchor?.getAttribute('href')).toMatch(/\/people\/jane$/);
+    expect(anchor?.textContent).toContain('Jane');
+  });
+
+  test('no href → no anchor, title still renders', () => {
+    const { container } = render(GridListItem, {
+      props: { title: textSnippet('Jane') },
+    });
+    expect(container.querySelector('a.cinder-grid-list__link')).toBeNull();
+    expect(container.querySelector('.cinder-grid-list__title')?.textContent).toContain('Jane');
+  });
+
+  test('href without title renders no anchor', () => {
+    const { container } = render(GridListItem, {
+      props: { href: '/people/jane' },
+    });
+    expect(container.querySelector('a.cinder-grid-list__link')).toBeNull();
+  });
+
+  test('renders actions in the documented wrapper', () => {
+    const { container } = render(GridListItem, {
+      props: {
+        href: '/people/jane',
+        title: textSnippet('Jane'),
+        actions: rawSnippet('<button data-testid="probe">Edit</button>'),
+      },
+    });
+    const button = container.querySelector('[data-testid="probe"]');
+    expect(button).not.toBeNull();
+    expect(button?.closest('.cinder-grid-list__actions')).not.toBeNull();
+  });
+
+  test('target and rel forwarded to the anchor', () => {
+    const { container } = render(GridListItem, {
+      props: {
+        href: '/people/jane',
+        title: textSnippet('Jane'),
+        target: '_self',
+        rel: 'external',
+      },
+    });
+    const anchor = container.querySelector('a.cinder-grid-list__link');
+    expect(anchor?.getAttribute('target')).toBe('_self');
+    expect(anchor?.getAttribute('rel')).toContain('external');
+  });
+
+  test('target="_blank" auto-composes rel="noopener noreferrer"', () => {
+    const { container } = render(GridListItem, {
+      props: {
+        href: '/people/jane',
+        title: textSnippet('Jane'),
+        target: '_blank',
+      },
+    });
+    const anchor = container.querySelector('a.cinder-grid-list__link');
+    const relTokens = (anchor?.getAttribute('rel') ?? '').split(/\s+/);
+    expect(relTokens).toContain('noopener');
+    expect(relTokens).toContain('noreferrer');
+  });
+
+  test('target="_blank" preserves consumer-supplied rel tokens', () => {
+    const { container } = render(GridListItem, {
+      props: {
+        href: '/people/jane',
+        title: textSnippet('Jane'),
+        target: '_blank',
+        rel: 'external',
+      },
+    });
+    const anchor = container.querySelector('a.cinder-grid-list__link');
+    const relTokens = (anchor?.getAttribute('rel') ?? '').split(/\s+/);
+    expect(relTokens).toContain('external');
+    expect(relTokens).toContain('noopener');
+    expect(relTokens).toContain('noreferrer');
+    // no duplicates
+    expect(new Set(relTokens).size).toBe(relTokens.length);
+  });
+
+  test('target is normalized case-insensitively for _blank safety', () => {
+    const { container } = render(GridListItem, {
+      props: {
+        href: '/people/jane',
+        title: textSnippet('Jane'),
+        target: '_Blank',
+      },
+    });
+    const anchor = container.querySelector('a.cinder-grid-list__link');
+    const relTokens = (anchor?.getAttribute('rel') ?? '').split(/\s+/);
+    expect(relTokens).toContain('noopener');
+    expect(relTokens).toContain('noreferrer');
+  });
+
+  test('escape attribute renders inside a non-actions wrapper', () => {
+    const { container } = render(GridListItem, {
+      props: {
+        href: '/people/jane',
+        title: textSnippet('Jane'),
+        meta: rawSnippet('<a href="/x" data-cinder-stretched-link-escape>profile</a>'),
+      },
+    });
+    const escapee = container.querySelector('[data-cinder-stretched-link-escape]');
+    expect(escapee).not.toBeNull();
+    expect(escapee?.closest('.cinder-grid-list__meta')).not.toBeNull();
+  });
+
+  test('class prop is merged', () => {
+    const { container } = render(GridListItem, {
+      props: { class: 'my-custom-class' },
+    });
+    const li = container.querySelector('li');
+    expect(li?.getAttribute('class')).toContain('cinder-grid-list__item');
+    expect(li?.getAttribute('class')).toContain('my-custom-class');
+  });
+});

--- a/packages/components/src/components/grid-list.svelte
+++ b/packages/components/src/components/grid-list.svelte
@@ -1,0 +1,35 @@
+<script lang="ts" module>
+  import type { Snippet } from 'svelte';
+  import type { HTMLAttributes } from 'svelte/elements';
+
+  export type GridListProps = Omit<HTMLAttributes<HTMLUListElement>, 'role'> & {
+    /**
+     * Minimum width of each grid cell, expressed as a CSS `<length>` value
+     * (e.g. `"16rem"`, `"240px"`, `"min(20rem, 100%)"`). Used as the first
+     * argument to `minmax()` inside a `repeat(auto-fill, ...)` track.
+     * Default: `"16rem"`. Empty string is treated as unset.
+     */
+    columns?: string;
+    /** Extra class names merged with `cinder-grid-list`. */
+    class?: string;
+    /** Items — typically `GridListItem` instances. */
+    children: Snippet;
+  };
+</script>
+
+<script lang="ts">
+  import { classNames } from '../utilities/class-names.ts';
+
+  let { columns, class: className, children, ...rest }: GridListProps = $props();
+
+  const minWidth = $derived(columns && columns.length > 0 ? columns : undefined);
+</script>
+
+<ul
+  {...rest}
+  role="list"
+  class={classNames('cinder-grid-list', className)}
+  style:--cinder-grid-list-min-width={minWidth}
+>
+  {@render children()}
+</ul>

--- a/packages/components/src/components/grid-list.test.ts
+++ b/packages/components/src/components/grid-list.test.ts
@@ -1,0 +1,91 @@
+/// <reference lib="dom" />
+import { describe, expect, test } from 'bun:test';
+
+import { setupHappyDom } from '../test/happy-dom.ts';
+
+setupHappyDom();
+
+const { render } = await import('@testing-library/svelte');
+const { default: GridList } = await import('./grid-list.svelte');
+const { createRawSnippet } = await import('svelte');
+
+function textSnippet(text: string) {
+  return createRawSnippet(() => ({
+    render: () => `<span>${text}</span>`,
+  }));
+}
+
+function liSnippet() {
+  return createRawSnippet(() => ({
+    render: () => `<li class="probe">item</li>`,
+  }));
+}
+
+describe('GridList', () => {
+  test('renders a <ul> with role="list"', () => {
+    const { container } = render(GridList, {
+      props: { children: textSnippet('') },
+    });
+    const list = container.querySelector('ul.cinder-grid-list');
+    expect(list).not.toBeNull();
+    expect(list?.getAttribute('role')).toBe('list');
+  });
+
+  test('consumer-supplied role cannot strip list semantics', () => {
+    const { container } = render(GridList, {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      props: { children: textSnippet(''), role: 'navigation' } as any,
+    });
+    const list = container.querySelector('ul.cinder-grid-list');
+    expect(list?.getAttribute('role')).toBe('list');
+  });
+
+  test('columns prop drives the CSS custom property', () => {
+    const { container } = render(GridList, {
+      props: { columns: '20rem', children: textSnippet('') },
+    });
+    const list = container.querySelector('ul.cinder-grid-list') as HTMLElement;
+    expect(list?.style.getPropertyValue('--cinder-grid-list-min-width')).toBe('20rem');
+  });
+
+  test('no columns → no inline custom property', () => {
+    const { container } = render(GridList, {
+      props: { children: textSnippet('') },
+    });
+    const list = container.querySelector('ul.cinder-grid-list') as HTMLElement;
+    expect(list?.style.getPropertyValue('--cinder-grid-list-min-width')).toBe('');
+  });
+
+  test('empty-string columns is treated as unset', () => {
+    const { container } = render(GridList, {
+      props: { columns: '', children: textSnippet('') },
+    });
+    const list = container.querySelector('ul.cinder-grid-list') as HTMLElement;
+    expect(list?.style.getPropertyValue('--cinder-grid-list-min-width')).toBe('');
+  });
+
+  test('class prop is merged', () => {
+    const { container } = render(GridList, {
+      props: { class: 'my-custom-class', children: textSnippet('') },
+    });
+    const list = container.querySelector('ul.cinder-grid-list');
+    expect(list?.getAttribute('class')).toContain('cinder-grid-list');
+    expect(list?.getAttribute('class')).toContain('my-custom-class');
+  });
+
+  test('rest props are forwarded', () => {
+    const { container } = render(GridList, {
+      props: { 'aria-label': 'Team members', children: textSnippet('') },
+    });
+    const list = container.querySelector('ul.cinder-grid-list');
+    expect(list?.getAttribute('aria-label')).toBe('Team members');
+  });
+
+  test('children snippet renders inside the <ul>', () => {
+    const { container } = render(GridList, {
+      props: { children: liSnippet() },
+    });
+    const items = container.querySelectorAll('ul.cinder-grid-list li.probe');
+    expect(items.length).toBe(1);
+  });
+});

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -96,6 +96,12 @@ export type { DropdownTriggerProps } from './components/dropdown-trigger.svelte'
 export { default as EmptyState } from './components/empty-state.svelte';
 export type { EmptyStateProps } from './components/empty-state.svelte';
 
+export { default as GridList } from './components/grid-list.svelte';
+export type { GridListProps } from './components/grid-list.svelte';
+
+export { default as GridListItem } from './components/grid-list-item.svelte';
+export type { GridListItemProps } from './components/grid-list-item.svelte';
+
 export { default as Input } from './components/input.svelte';
 export type { InputProps, InputType } from './components/input.svelte';
 

--- a/packages/components/src/styles/components.css
+++ b/packages/components/src/styles/components.css
@@ -24,6 +24,7 @@
 @import './components/dropdown.css';
 @import './components/empty-state.css';
 @import './components/experimental.css';
+@import './components/grid-list.css';
 @import './components/input.css';
 @import './components/json-highlight.css';
 @import './components/json-schema-editor.css';

--- a/packages/components/src/styles/components/grid-list.css
+++ b/packages/components/src/styles/components/grid-list.css
@@ -1,0 +1,123 @@
+/* ========================================
+ * GRID LIST
+ * ======================================== */
+
+.cinder-grid-list {
+  /* Default min-cell-width if `columns` prop is omitted. */
+  --cinder-grid-list-min-width: 16rem;
+
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  inline-size: 100%;
+
+  display: grid;
+  grid-template-columns: repeat(
+    auto-fill,
+    minmax(min(var(--cinder-grid-list-min-width), 100%), 1fr)
+  );
+  gap: var(--cinder-space-4);
+}
+
+/* ----------------------------------------
+ * Item — visually a card, semantically an <li>.
+ * Reuses Card tokens; no new visual variables.
+ * ---------------------------------------- */
+
+.cinder-grid-list__item {
+  position: relative; /* Anchors the stretched-link pseudo overlay. */
+  display: flex;
+  flex-direction: column;
+  gap: var(--cinder-space-2);
+  padding: var(--cinder-space-4);
+  border-radius: var(--cinder-radius-lg);
+  background: var(--cinder-surface-raised);
+  border: 1px solid var(--cinder-border-muted);
+  color: var(--cinder-text);
+  box-shadow: var(--cinder-shadow-sm);
+  transition:
+    box-shadow 150ms ease,
+    border-color 150ms ease;
+}
+
+/* Lift the whole tile when any interactive descendant takes keyboard focus. */
+.cinder-grid-list__item:focus-within {
+  outline: var(--cinder-ring-width) solid var(--cinder-ring-color);
+  outline-offset: var(--cinder-ring-offset);
+}
+
+/* ----------------------------------------
+ * Snippet wrappers — provide stable selectors and predictable layout.
+ * All wrappers sit UNDER the stretched-link overlay except `.cinder-grid-list__actions`.
+ * ---------------------------------------- */
+
+.cinder-grid-list__image,
+.cinder-grid-list__title,
+.cinder-grid-list__subtitle,
+.cinder-grid-list__meta {
+  min-inline-size: 0; /* Allows long content to truncate inside flex parents. */
+}
+
+.cinder-grid-list__title {
+  font-size: var(--cinder-text-base);
+  font-weight: var(--cinder-font-medium);
+  color: var(--cinder-text);
+}
+
+.cinder-grid-list__subtitle {
+  font-size: var(--cinder-text-sm);
+  color: var(--cinder-text-muted);
+}
+
+.cinder-grid-list__meta {
+  font-size: var(--cinder-text-sm);
+  color: var(--cinder-text-subtle);
+}
+
+/* ----------------------------------------
+ * Stretched link — opt-in via `href` prop.
+ *
+ * The anchor wraps the title text but its ::after extends to cover the
+ * entire item, so any pointer click anywhere on the item activates the link.
+ * ---------------------------------------- */
+
+.cinder-grid-list__link {
+  color: inherit;
+  text-decoration: none;
+}
+
+.cinder-grid-list__link::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  /* Match the item's radius directly — `inherit` would resolve to 0 since the
+     anchor's ancestor chain doesn't carry the radius token. */
+  border-radius: var(--cinder-radius-lg);
+  z-index: 0;
+}
+
+/* Suppress the default :focus-visible outline on the anchor itself — the
+   :focus-within rule on the item already provides a focus ring. */
+.cinder-grid-list__link:focus-visible {
+  outline: none;
+}
+
+/* ----------------------------------------
+ * Actions row — lifted above the stretched-link overlay so its
+ * buttons remain clickable / focusable.
+ * ---------------------------------------- */
+
+.cinder-grid-list__actions {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--cinder-space-2);
+  margin-block-start: auto; /* Pin actions to the bottom of the card. */
+}
+
+/* Allow consumers to lift an arbitrary descendant above the overlay. */
+.cinder-grid-list__item [data-cinder-stretched-link-escape] {
+  position: relative;
+  z-index: 1;
+}

--- a/packages/components/src/styles/components/grid-list.css
+++ b/packages/components/src/styles/components/grid-list.css
@@ -40,12 +40,6 @@
     border-color 150ms ease;
 }
 
-/* Lift the whole tile when any interactive descendant takes keyboard focus. */
-.cinder-grid-list__item:focus-within {
-  outline: var(--cinder-ring-width) solid var(--cinder-ring-color);
-  outline-offset: var(--cinder-ring-offset);
-}
-
 /* ----------------------------------------
  * Snippet wrappers — provide stable selectors and predictable layout.
  * All wrappers sit UNDER the stretched-link overlay except `.cinder-grid-list__actions`.
@@ -96,10 +90,22 @@
   z-index: 0;
 }
 
-/* Suppress the default :focus-visible outline on the anchor itself — the
-   :focus-within rule on the item already provides a focus ring. */
+/* Focus ring on the stretched-link anchor. Uses box-shadow offset technique
+   to float the ring outside the card's border, matching stacked-list-item.css. */
 .cinder-grid-list__link:focus-visible {
-  outline: none;
+  outline: var(--cinder-ring-width) solid transparent;
+  border-radius: var(--cinder-radius-lg);
+  box-shadow:
+    0 0 0 var(--cinder-ring-offset) var(--cinder-ring-offset-color),
+    0 0 0 calc(var(--cinder-ring-offset) + var(--cinder-ring-width)) var(--cinder-ring-color);
+}
+
+/* Forced Colors Mode — box-shadow rings are invisible; use a real outline. */
+@media (forced-colors: active) {
+  .cinder-grid-list__link:focus-visible {
+    outline: var(--cinder-ring-width) solid ButtonText;
+    outline-offset: 3px;
+  }
 }
 
 /* ----------------------------------------


### PR DESCRIPTION
## Summary

- Adds `GridList` — a `<ul role="list">` wrapper with responsive CSS grid layout via `repeat(auto-fill, minmax(min(var(--cinder-grid-list-min-width), 100%), 1fr))`. The `columns` prop accepts a CSS length value (default `"16rem"`) and is applied as an inline custom property.
- Adds `GridListItem` — an `<li>` card with five optional snippet slots (`image`, `title`, `subtitle`, `meta`, `actions`). Supports the stretched-link pattern via `href` prop; link only renders when both `href` and `title` are present. Actions wrapper has `z-index: 1` to remain pointer-operable above the overlay. Includes `data-cinder-stretched-link-escape` attribute API.
- All styles use existing `--cinder-*` tokens; no new design tokens introduced. CSS mirrors Card token usage (`--cinder-surface-raised`, `--cinder-border-muted`, `--cinder-radius-lg`, `--cinder-shadow-sm`).

## Review committee

Pre-reviewed by: typescript-expert, testing-expert, ux-designer, simplicity-engineer, junior-engineer, Codex (gpt-5.4, xhigh reasoning)
- 2 rounds of review
- All must-fix items addressed before PR creation

Round 1 must-fix items addressed:
1. **Discriminated union on `GridListItemProps`** — `GridListItemStatic | GridListItemLinked` mirrors the `StackedListItemProps` pattern; `target`/`rel` are typed as `HTMLAnchorAttributes['target'/'rel']` and only available when `href` is set
2. **Focus ring fixed** — replaced `focus-within` on item (collided with action button rings) with `focus-visible` box-shadow ring on `.cinder-grid-list__link` matching `stacked-list-item.css` pattern
3. **Forced-colors guard added** — `@media (forced-colors: active)` block with `ButtonText` outline for Windows High Contrast Mode
4. **Slot-isolation test added** — verifies all 5 wrapper divs are absent when no snippets provided
5. **Security token negative test added** — verifies non-`_blank` targets do NOT inject `noopener`/`noreferrer`

> [!WARNING]
> Codex (the adversarial second-opinion reviewer) was unavailable for round 2 re-review. Round 1 Codex review was completed and feedback was addressed. See `tmp/committee-state.md` for detail.

## Test plan

- [ ] `bun test grid-list` — 22 tests, all pass
- [ ] `bun run typecheck` — 0 errors
- [ ] `bun run lint` — 0 errors (warnings are pre-existing)
- [ ] Verify keyboard focus: tab into a `GridListItem` with `href` and `actions` button — card gets box-shadow focus ring from link, action button gets its own ring (no collision)
- [ ] Verify Windows High Contrast Mode: focus ring uses `ButtonText` color
- [ ] Verify stretched link: click card surface activates navigation; click action button activates button only
- [ ] Verify grid wraps from N columns to 1 column as viewport narrows

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily additive UI primitives with isolated CSS and tests; main risk is minor API/styling regressions around the stretched-link overlay and link `rel` composition.
> 
> **Overview**
> Introduces `GridList` and `GridListItem` as new list primitives for responsive grid-based card layouts, including optional snippet regions and an opt-in stretched-link pattern (with `_blank` automatically composing `rel="noopener noreferrer"`).
> 
> Wires the components into the public package surface by adding package `exports`, `src/index.ts` exports, and a new `grid-list.css` partial (imported by `components.css`), and adds focused unit tests covering rendering behavior, prop forwarding, and link security token handling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3f7623e8fcc33ef85e678b27cf85c86884638263. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->