### PR TITLE
feed.svelte + feed-event.svelte: ADD activity timeline

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -125,6 +125,14 @@
       "svelte": "./src/components/empty-state.svelte",
       "types": "./dist/components/empty-state.svelte.d.ts"
     },
+    "./feed-event": {
+      "svelte": "./src/components/feed-event.svelte",
+      "types": "./dist/components/feed-event.svelte.d.ts"
+    },
+    "./feed": {
+      "svelte": "./src/components/feed.svelte",
+      "types": "./dist/components/feed.svelte.d.ts"
+    },
     "./experimental/connection-indicator": {
       "svelte": "./src/components/experimental/connection-indicator.svelte",
       "types": "./dist/components/experimental/connection-indicator.svelte.d.ts"

--- a/packages/components/src/components/feed-event.svelte
+++ b/packages/components/src/components/feed-event.svelte
@@ -1,0 +1,68 @@
+<script lang="ts" module>
+  import type { Snippet } from 'svelte';
+  import type { HTMLAttributes } from 'svelte/elements';
+
+  export type FeedEventVariant = 'icon' | 'minimal';
+
+  type FeedEventBase = Omit<HTMLAttributes<HTMLLIElement>, 'children' | 'class'> & {
+    class?: string;
+    /**
+     * ISO 8601 datetime string. Rendered as `<time datetime={datetime}>` so
+     * assistive tech and parsers receive a machine-readable timestamp. The
+     * visible label inside the `<time>` element is consumer-controlled via
+     * the required `timestamp` snippet.
+     */
+    datetime: string;
+    /** Main event content (description, links, secondary metadata). */
+    content: Snippet;
+    /**
+     * Renders inside the `<time>` element. Consumer chooses formatting —
+     * relative (`2m ago`), absolute (`May 12, 2:30 PM`), or anything else.
+     * Required so the component stays presentational and SSR-deterministic.
+     */
+    timestamp: Snippet;
+  };
+
+  type FeedEventIcon = FeedEventBase & {
+    /** Icon variant: renders a circular badge on the rail with the icon inside. */
+    variant?: 'icon';
+    /** Required for the icon variant. Type-enforced by the discriminated union. */
+    icon: Snippet;
+  };
+
+  type FeedEventMinimal = FeedEventBase & {
+    /** Minimal variant: renders a small dot on the rail, no icon. */
+    variant: 'minimal';
+    icon?: never;
+  };
+
+  export type FeedEventProps = FeedEventIcon | FeedEventMinimal;
+</script>
+
+<script lang="ts">
+  import { cn } from '../utilities/class-names.ts';
+
+  let {
+    datetime,
+    variant = 'icon',
+    class: className,
+    icon,
+    content,
+    timestamp,
+    ...rest
+  }: FeedEventProps = $props();
+</script>
+
+<li {...rest} class={cn('cinder-feed-event', className)} data-cinder-variant={variant}>
+  <span class="cinder-feed-event-rail" aria-hidden="true">
+    {#if variant === 'icon'}
+      <span class="cinder-feed-event-icon">{@render (icon as Snippet)()}</span>
+    {:else}
+      <span class="cinder-feed-event-dot"></span>
+    {/if}
+  </span>
+  <div class="cinder-feed-event-body">
+    <div class="cinder-feed-event-content">{@render content()}</div>
+    <time class="cinder-feed-event-time" {datetime}>{@render timestamp()}</time>
+  </div>
+</li>

--- a/packages/components/src/components/feed-event.test.ts
+++ b/packages/components/src/components/feed-event.test.ts
@@ -1,0 +1,138 @@
+/// <reference lib="dom" />
+import { describe, expect, test } from 'bun:test';
+import { createRawSnippet } from 'svelte';
+
+import { setupHappyDom } from '../test/happy-dom.ts';
+
+setupHappyDom();
+
+const { render } = await import('@testing-library/svelte');
+const { default: FeedEvent } = await import('./feed-event.svelte');
+
+function textSnippet(text: string) {
+  return createRawSnippet(() => ({
+    render: () => `<span>${text}</span>`,
+    setup: () => {},
+  }));
+}
+
+const iconSnippet = textSnippet('icon-content');
+const contentSnippet = textSnippet('event-content');
+const timestampSnippet = textSnippet('2m ago');
+
+const baseProps = {
+  datetime: '2026-05-12T14:30:00Z',
+  icon: iconSnippet,
+  content: contentSnippet,
+  timestamp: timestampSnippet,
+};
+
+describe('FeedEvent', () => {
+  test('renders an <li> element with cinder-feed-event class', () => {
+    const { container } = render(FeedEvent, { props: baseProps });
+    const root = container.querySelector('.cinder-feed-event');
+    expect(root).not.toBeNull();
+    expect(root?.tagName).toBe('LI');
+  });
+
+  test('default variant is icon — sets data-cinder-variant="icon"', () => {
+    const { container } = render(FeedEvent, { props: baseProps });
+    const root = container.querySelector('.cinder-feed-event');
+    expect(root?.getAttribute('data-cinder-variant')).toBe('icon');
+  });
+
+  test('variant="minimal" sets data-cinder-variant="minimal"', () => {
+    const { container } = render(FeedEvent, {
+      props: {
+        datetime: '2026-05-12T14:30:00Z',
+        variant: 'minimal',
+        content: contentSnippet,
+        timestamp: timestampSnippet,
+      },
+    });
+    const root = container.querySelector('.cinder-feed-event');
+    expect(root?.getAttribute('data-cinder-variant')).toBe('minimal');
+  });
+
+  test('renders a <time> element with the supplied datetime attribute', () => {
+    const { container } = render(FeedEvent, { props: baseProps });
+    const time = container.querySelector('time');
+    expect(time).not.toBeNull();
+    expect(time?.getAttribute('datetime')).toBe('2026-05-12T14:30:00Z');
+  });
+
+  test('timestamp snippet content renders inside the <time> element', () => {
+    const { container } = render(FeedEvent, { props: baseProps });
+    const time = container.querySelector('time.cinder-feed-event-time');
+    expect(time).not.toBeNull();
+    expect(time?.textContent).toContain('2m ago');
+  });
+
+  test('content snippet renders inside .cinder-feed-event-content', () => {
+    const { container } = render(FeedEvent, { props: baseProps });
+    const content = container.querySelector('.cinder-feed-event-content');
+    expect(content).not.toBeNull();
+    expect(content?.textContent).toContain('event-content');
+  });
+
+  test('icon snippet renders inside the rail when variant is icon', () => {
+    const { container } = render(FeedEvent, { props: baseProps });
+    const rail = container.querySelector('.cinder-feed-event-rail');
+    expect(rail).not.toBeNull();
+    const iconEl = rail?.querySelector('.cinder-feed-event-icon');
+    expect(iconEl).not.toBeNull();
+    expect(iconEl?.textContent).toContain('icon-content');
+  });
+
+  test('minimal variant renders dot and not icon snippet content', () => {
+    const { container } = render(FeedEvent, {
+      props: {
+        datetime: '2026-05-12T14:30:00Z',
+        variant: 'minimal',
+        content: contentSnippet,
+        timestamp: timestampSnippet,
+      },
+    });
+    const rail = container.querySelector('.cinder-feed-event-rail');
+    expect(rail?.querySelector('.cinder-feed-event-dot')).not.toBeNull();
+    expect(rail?.querySelector('.cinder-feed-event-icon')).toBeNull();
+    expect(rail?.textContent?.trim()).toBe('');
+  });
+
+  test('rail wrapper has aria-hidden="true"', () => {
+    const { container } = render(FeedEvent, { props: baseProps });
+    const rail = container.querySelector('.cinder-feed-event-rail');
+    expect(rail?.getAttribute('aria-hidden')).toBe('true');
+  });
+
+  test('rest attributes pass through to the <li>', () => {
+    const { container } = render(FeedEvent, {
+      props: { ...baseProps, id: 'event-1', 'data-testid': 'my-event' },
+    });
+    const root = container.querySelector('.cinder-feed-event');
+    expect(root?.getAttribute('id')).toBe('event-1');
+    expect(root?.getAttribute('data-testid')).toBe('my-event');
+  });
+
+  test('class prop merges with cinder-feed-event', () => {
+    const { container } = render(FeedEvent, {
+      props: { ...baseProps, class: 'custom-class' },
+    });
+    const root = container.querySelector('.cinder-feed-event');
+    expect(root?.classList.contains('cinder-feed-event')).toBe(true);
+    expect(root?.classList.contains('custom-class')).toBe(true);
+  });
+
+  test('owned data-cinder-variant wins over consumer-supplied value via rest props', () => {
+    const { container } = render(FeedEvent, {
+      props: {
+        ...baseProps,
+        'data-cinder-variant': 'minimal',
+      },
+    });
+    const root = container.querySelector('.cinder-feed-event');
+    // The component's own data-cinder-variant={variant} is written after {...rest},
+    // so the owned attribute wins.
+    expect(root?.getAttribute('data-cinder-variant')).toBe('icon');
+  });
+});

--- a/packages/components/src/components/feed.a11y.md
+++ b/packages/components/src/components/feed.a11y.md
@@ -1,0 +1,90 @@
+# Feed & FeedEvent — Accessibility Notes
+
+## Semantic element choice
+
+`Feed` renders an `<ol>` (ordered list). Feeds are chronologically ordered sequences — screen readers announce "list, N items" and expose list-navigation shortcuts (e.g. `Ctrl+Opt+L` on macOS VoiceOver). Do not swap for `<ul>` or `<div role="list">`: ordered lists carry the chronological meaning that matches the component's purpose.
+
+Each `FeedEvent` renders an `<li>` inside that list. The tag is the correct content model for `<ol>` and carries list item semantics automatically.
+
+## Accessible name — required but not type-enforced
+
+The `<ol>` must have an accessible name. Provide one of:
+
+```svelte
+<!-- aria-label for a self-describing feed -->
+<Feed aria-label="Pull request timeline">…</Feed>
+
+<!-- aria-labelledby when there's a visible heading -->
+<h2 id="timeline-heading">Timeline</h2>
+<Feed aria-labelledby="timeline-heading">…</Feed>
+```
+
+TypeScript cannot express "at least one of two optional attributes is required" without breaking ergonomics, so this contract is documentation-only. A `Feed` without either attribute is silent to assistive technology users — they receive no list label and cannot distinguish this list from others on the page.
+
+## ISO datetime — non-negotiable
+
+`FeedEvent` always renders `<time datetime={datetime}>`. The `datetime` prop must be a valid ISO 8601 string (e.g. `"2026-05-12T14:30:00Z"`). The machine-readable value is owned by the component; the visible label inside `<time>` is consumer-controlled via the `timestamp` snippet.
+
+Never rely on a pre-formatted human string as the only representation. A `<time>` element with a proper `datetime` attribute allows parsers, assistive tech, and future tooling to extract the precise moment — visible text like "2m ago" carries none of that precision.
+
+## Decorative rail — aria-hidden
+
+The rail wrapper (`.cinder-feed-event-rail`) carries `aria-hidden="true"`. Both the icon badge and the dot are decorative — the event's semantic content lives in the `content` and `timestamp` snippets.
+
+**Consequence:** if you pass a meaningful icon (e.g. an avatar identifying the acting user), you must also duplicate that meaning in `content`. The icon snippet is visual reinforcement only; it is the sole carrier of meaning for no user.
+
+Example — correct:
+
+```svelte
+<FeedEvent datetime="…">
+  {#snippet icon()}<Avatar src={user.avatar} />{/snippet}
+  {#snippet content()}<strong>{user.name}</strong> pushed 3 commits{/snippet}
+  {#snippet timestamp()}2m ago{/snippet}
+</FeedEvent>
+```
+
+The connector line is a CSS `::after` pseudo-element and is therefore invisible to assistive technology by default — no extra ARIA is needed.
+
+## Live region — opt-in via `live` prop
+
+`live={false}` (default): no ARIA live attributes are set. A live region on a static feed is noise — screen readers may re-announce content on focus changes or adjacent DOM mutations.
+
+`live={true}`: sets `aria-live="polite"` and `aria-atomic="false"` on the `<ol>`. Screen readers queue announcements without interrupting the user, and announce only the newly-added node rather than the entire list.
+
+Use `live` only when items stream onto the page while the user is present (notifications, log tails, activity tickers).
+
+### Prepend vs append
+
+With `aria-live="polite"` and `aria-atomic="false"`, screen readers announce mutations regardless of insertion position. However, do not scroll the viewport on insertion — that would move the view from under keyboard and screen-reader users who are reading earlier content. Scroll only on explicit user gesture.
+
+### Focus rescue
+
+If a `FeedEvent` contains focusable controls (links, buttons) and that event is removed while focus lives inside it, focus jumps to `<body>`. The component does not attempt to rescue focus. Consumers who remove live events must detect this case and move focus to a safe target before removal.
+
+## `role="feed"` — intentionally absent
+
+The WAI-ARIA `feed` pattern requires `aria-busy`, `aria-setsize`, `aria-posinset`, and keyboard-managed navigation between articles. This component is presentational and cannot satisfy that contract.
+
+If you need the full WAI-ARIA feed pattern, pass `role="feed"` via rest attributes and own the keyboard contract yourself. Reference: [WAI-ARIA Feed Pattern](https://www.w3.org/WAI/ARIA/apg/patterns/feed/).
+
+## Dense or long feeds
+
+Prefer pagination or an explicit "Load more" control over infinite scroll. Infinite scroll requires screen-reader users to navigate through an ever-growing list without a clear end — a "Load more" button gives them explicit control over when new content arrives.
+
+## Internal class hooks
+
+The following class names are internal implementation details, subject to change. They are documented here as an escape hatch for consumers who need targeted overrides via the root `class` prop:
+
+- `.cinder-feed-event-rail` — the icon/dot column
+- `.cinder-feed-event-content` — the main body text area
+- `.cinder-feed-event-time` — the `<time>` element
+
+## Connector token coupling
+
+The `::after` pseudo-element that draws the connector line uses two tokens that must stay in sync with their corresponding layout values:
+
+- `inset-block-start: var(--cinder-space-6)` — must match `.cinder-feed-event-rail`'s `block-size`
+- `inset-block-end: calc(-1 * var(--cinder-space-4))` — must match `.cinder-feed`'s `gap`
+- `inset-inline-start: calc(var(--cinder-space-6) / 2)` — must match half of `.cinder-feed-event-rail`'s `inline-size`
+
+If you change any of these layout tokens, update the others to match.

--- a/packages/components/src/components/feed.svelte
+++ b/packages/components/src/components/feed.svelte
@@ -1,0 +1,31 @@
+<script lang="ts" module>
+  import type { Snippet } from 'svelte';
+  import type { HTMLAttributes } from 'svelte/elements';
+
+  export type FeedProps = Omit<HTMLAttributes<HTMLOListElement>, 'children' | 'class'> & {
+    class?: string;
+    /**
+     * When true, the wrapper becomes an ARIA live region: `aria-live="polite"`
+     * and `aria-atomic="false"`. Use for feeds that mutate while the user is
+     * on the page (streaming notifications, log tails, chat-like activity).
+     * Defaults to false — a polite live region on a static feed is noise.
+     */
+    live?: boolean;
+    /** Feed events (typically `<FeedEvent>` children). */
+    children: Snippet;
+  };
+</script>
+
+<script lang="ts">
+  import { cn } from '../utilities/class-names.ts';
+
+  let { live = false, class: className, children, ...rest }: FeedProps = $props();
+
+  const liveRegionAttributes = $derived(
+    live ? { 'aria-live': 'polite' as const, 'aria-atomic': 'false' as const } : {},
+  );
+</script>
+
+<ol {...rest} {...liveRegionAttributes} class={cn('cinder-feed', className)}>
+  {@render children()}
+</ol>

--- a/packages/components/src/components/feed.test.ts
+++ b/packages/components/src/components/feed.test.ts
@@ -1,0 +1,154 @@
+/// <reference lib="dom" />
+import { describe, expect, test } from 'bun:test';
+import { createRawSnippet } from 'svelte';
+
+import { setupHappyDom } from '../test/happy-dom.ts';
+
+setupHappyDom();
+
+const { render } = await import('@testing-library/svelte');
+const { default: Feed } = await import('./feed.svelte');
+
+const emptySnippet = createRawSnippet(() => ({
+  render: () => `<span></span>`,
+  setup: () => {},
+}));
+
+function textSnippet(text: string) {
+  return createRawSnippet(() => ({
+    render: () => `<span>${text}</span>`,
+    setup: () => {},
+  }));
+}
+
+function itemSnippet(labels: string[]) {
+  return createRawSnippet(() => ({
+    render: () =>
+      `<span data-items="${labels.join(',')}">${labels.map((l) => `<span class="item">${l}</span>`).join('')}</span>`,
+    setup: () => {},
+  }));
+}
+
+describe('Feed', () => {
+  test('renders an <ol> element', () => {
+    const { container } = render(Feed, {
+      props: { 'aria-label': 'Activity feed', children: emptySnippet },
+    });
+    const root = container.querySelector('.cinder-feed');
+    expect(root).not.toBeNull();
+    expect(root?.tagName).toBe('OL');
+  });
+
+  test('renders with the supplied aria-label', () => {
+    const { container } = render(Feed, {
+      props: { 'aria-label': 'Pull request timeline', children: emptySnippet },
+    });
+    const root = container.querySelector('.cinder-feed');
+    expect(root?.getAttribute('aria-label')).toBe('Pull request timeline');
+  });
+
+  test('when live is omitted, has neither aria-live nor aria-atomic', () => {
+    const { container } = render(Feed, {
+      props: { 'aria-label': 'Feed', children: emptySnippet },
+    });
+    const root = container.querySelector('.cinder-feed');
+    expect(root?.hasAttribute('aria-live')).toBe(false);
+    expect(root?.hasAttribute('aria-atomic')).toBe(false);
+  });
+
+  test('when live is false, has neither aria-live nor aria-atomic', () => {
+    const { container } = render(Feed, {
+      props: { 'aria-label': 'Feed', live: false, children: emptySnippet },
+    });
+    const root = container.querySelector('.cinder-feed');
+    expect(root?.hasAttribute('aria-live')).toBe(false);
+    expect(root?.hasAttribute('aria-atomic')).toBe(false);
+  });
+
+  test('when live is true, has aria-live="polite" and aria-atomic="false"', () => {
+    const { container } = render(Feed, {
+      props: { 'aria-label': 'Feed', live: true, children: emptySnippet },
+    });
+    const root = container.querySelector('.cinder-feed');
+    expect(root?.getAttribute('aria-live')).toBe('polite');
+    expect(root?.getAttribute('aria-atomic')).toBe('false');
+  });
+
+  test('when live is true, owned aria-live="polite" wins over consumer aria-live="assertive"', () => {
+    const { container } = render(Feed, {
+      props: {
+        'aria-label': 'Feed',
+        live: true,
+        'aria-live': 'assertive',
+        children: emptySnippet,
+      },
+    });
+    const root = container.querySelector('.cinder-feed');
+    expect(root?.getAttribute('aria-live')).toBe('polite');
+  });
+
+  test('when live is false, consumer aria-live passes through to the DOM', () => {
+    const { container } = render(Feed, {
+      props: {
+        'aria-label': 'Feed',
+        live: false,
+        'aria-live': 'assertive',
+        children: emptySnippet,
+      },
+    });
+    const root = container.querySelector('.cinder-feed');
+    expect(root?.getAttribute('aria-live')).toBe('assertive');
+  });
+
+  test('children render inside the <ol> in source order', () => {
+    const { container } = render(Feed, {
+      props: { 'aria-label': 'Feed', children: itemSnippet(['alpha', 'beta', 'gamma']) },
+    });
+    const root = container.querySelector('ol.cinder-feed');
+    expect(root).not.toBeNull();
+    const items = root?.querySelectorAll('.item');
+    expect(items?.length).toBe(3);
+    expect(items?.[0]?.textContent).toBe('alpha');
+    expect(items?.[1]?.textContent).toBe('beta');
+    expect(items?.[2]?.textContent).toBe('gamma');
+  });
+
+  test('rest attributes pass through to the <ol>', () => {
+    const { container } = render(Feed, {
+      props: {
+        'aria-label': 'Feed',
+        id: 'my-feed',
+        'data-testid': 'activity-feed',
+        children: emptySnippet,
+      },
+    });
+    const root = container.querySelector('.cinder-feed');
+    expect(root?.getAttribute('id')).toBe('my-feed');
+    expect(root?.getAttribute('data-testid')).toBe('activity-feed');
+  });
+
+  test('aria-labelledby passes through to the <ol>', () => {
+    const { container } = render(Feed, {
+      props: { 'aria-labelledby': 'heading-id', children: emptySnippet },
+    });
+    const root = container.querySelector('.cinder-feed');
+    expect(root?.getAttribute('aria-labelledby')).toBe('heading-id');
+  });
+
+  test('class prop merges with cinder-feed', () => {
+    const { container } = render(Feed, {
+      props: { 'aria-label': 'Feed', class: 'my-custom-class', children: emptySnippet },
+    });
+    const root = container.querySelector('.cinder-feed');
+    expect(root?.classList.contains('cinder-feed')).toBe(true);
+    expect(root?.classList.contains('my-custom-class')).toBe(true);
+  });
+
+  test('children snippet text content renders inside the list', () => {
+    const { container } = render(Feed, {
+      props: { 'aria-label': 'Feed', children: textSnippet('hello world') },
+    });
+    const root = container.querySelector('.cinder-feed');
+    expect(root?.textContent).toContain('hello world');
+  });
+});

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -96,6 +96,12 @@ export type { DropdownTriggerProps } from './components/dropdown-trigger.svelte'
 export { default as EmptyState } from './components/empty-state.svelte';
 export type { EmptyStateProps } from './components/empty-state.svelte';
 
+export { default as FeedEvent } from './components/feed-event.svelte';
+export type { FeedEventProps, FeedEventVariant } from './components/feed-event.svelte';
+
+export { default as Feed } from './components/feed.svelte';
+export type { FeedProps } from './components/feed.svelte';
+
 export { default as GridList } from './components/grid-list.svelte';
 export type { GridListProps } from './components/grid-list.svelte';
 

--- a/packages/components/src/styles/components.css
+++ b/packages/components/src/styles/components.css
@@ -23,6 +23,7 @@
 @import './components/drawer.css';
 @import './components/dropdown.css';
 @import './components/empty-state.css';
+@import './components/feed.css';
 @import './components/experimental.css';
 @import './components/grid-list.css';
 @import './components/input.css';

--- a/packages/components/src/styles/components/feed.css
+++ b/packages/components/src/styles/components/feed.css
@@ -1,0 +1,83 @@
+/* ========================================
+ * FEED
+ * ======================================== */
+
+.cinder-feed {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--cinder-space-4);
+}
+
+.cinder-feed-event {
+  position: relative;
+  display: grid;
+  grid-template-columns: auto 1fr;
+  column-gap: var(--cinder-space-3);
+  align-items: start;
+}
+
+.cinder-feed-event-rail {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  inline-size: var(--cinder-space-6);
+  block-size: var(--cinder-space-6);
+  border-radius: 9999px;
+  background: var(--cinder-surface-muted);
+  color: var(--cinder-text-muted);
+  flex-shrink: 0;
+}
+
+/* Minimal variant keeps the SAME rail box dimensions as the icon variant so
+ * the connector's inline anchor is constant across mixed-variant feeds. Only
+ * the inner visual marker shrinks — the dot is centered inside the same rail
+ * box via the flex centering already on .cinder-feed-event-rail. */
+.cinder-feed-event[data-cinder-variant='minimal'] .cinder-feed-event-rail {
+  background: transparent;
+}
+
+.cinder-feed-event-dot {
+  inline-size: var(--cinder-space-2);
+  block-size: var(--cinder-space-2);
+  border-radius: 9999px;
+  background: var(--cinder-border-strong);
+}
+
+/* Connector line — pseudo-element on the <li> itself, anchored at the rail's
+ * horizontal center. The line spans from the bottom of the rail all the way
+ * through the row body plus the gap, landing at the next rail's top edge.
+ *
+ * inset-block-start must match .cinder-feed-event-rail's block-size so the
+ * line starts exactly at the rail bottom regardless of body height.
+ * inset-block-end extends into the row gap to reach the next rail's top. */
+.cinder-feed-event::after {
+  content: '';
+  position: absolute;
+  inset-block-start: var(--cinder-space-6);
+  inset-block-end: calc(-1 * var(--cinder-space-4));
+  inset-inline-start: calc(var(--cinder-space-6) / 2);
+  inline-size: 1px;
+  background: var(--cinder-border-muted);
+  transform: translateX(-50%);
+  pointer-events: none;
+}
+
+.cinder-feed-event:last-child::after {
+  content: none;
+}
+
+.cinder-feed-event-body {
+  display: flex;
+  flex-direction: column;
+  gap: var(--cinder-space-1);
+  min-inline-size: 0;
+}
+
+.cinder-feed-event-time {
+  font-size: var(--cinder-text-sm);
+  color: var(--cinder-text-muted);
+}


### PR DESCRIPTION
## Summary

feed: <ol aria-label> wrapper; optional live boolean adds aria-live='polite' aria-atomic='false'. feed-event: <li> with snippets icon/content/timestamp; connector line via ::before toggled off on last child. Accept ISO datetime prop and render <time {datetime}> internally. data-cinder-variant (icon|minimal). See ROADMAP.md §Lists & Tables › Feeds.

Task: `90f5e770-24a2-49eb-a98a-1a796a74abc0`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new exported UI components and global component CSS that could affect consumers via styling and public API expectations, but does not touch security- or data-critical logic.
> 
> **Overview**
> Adds new activity timeline primitives: `Feed` (an `<ol>` wrapper with optional `live` mode applying `aria-live="polite"`/`aria-atomic="false"`) and `FeedEvent` (an `<li>` with `icon` vs `minimal` variants and a required ISO `datetime` rendered via `<time>`).
> 
> Exports both components via `src/index.ts` and package `exports`, adds dedicated `feed.css` to the global components stylesheet, and includes new unit tests plus `feed.a11y.md` documentation to codify accessibility/usage contracts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 46c53e0cd9af3891f101228585a0d8709a88a164. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->