### PR TITLE
Review: textarea count and accessibility updates

### DIFF
--- a/packages/components/src/components/textarea-count.ts
+++ b/packages/components/src/components/textarea-count.ts
@@ -7,7 +7,7 @@
  */
 export function resolveMaximumLength(value: unknown): number | undefined {
   if (typeof value === 'number') {
-    return Number.isInteger(value) && value > 0 ? value : undefined;
+    return Number.isSafeInteger(value) && value > 0 ? value : undefined;
   }
   if (typeof value === 'string') {
     const trimmed = value.trim();

--- a/packages/components/src/components/textarea-count.ts
+++ b/packages/components/src/components/textarea-count.ts
@@ -1,19 +1,19 @@
 /**
  * Parses a `maxlength` prop value into a usable integer, mirroring the HTML
  * non-negative-integer attribute parser. Accepts digit-only strings (with
- * optional surrounding whitespace or leading zeros) and positive safe integers.
- * Rejects zero, negative values, decimals, exponents, signs, empty strings, and
- * internal whitespace.
+ * optional surrounding whitespace or leading zeros) and safe non-negative
+ * integers. Rejects negative values, decimals, exponents, signs, empty strings,
+ * and internal whitespace.
  */
 export function resolveMaximumLength(value: unknown): number | undefined {
   if (typeof value === 'number') {
-    return Number.isSafeInteger(value) && value > 0 ? value : undefined;
+    return Number.isSafeInteger(value) && value >= 0 ? value : undefined;
   }
   if (typeof value === 'string') {
     const trimmed = value.trim();
     if (!/^\d+$/.test(trimmed)) return undefined;
     const parsed = Number(trimmed);
-    return parsed > 0 && Number.isSafeInteger(parsed) ? parsed : undefined;
+    return parsed >= 0 && Number.isSafeInteger(parsed) ? parsed : undefined;
   }
   return undefined;
 }

--- a/packages/components/src/components/textarea-count.ts
+++ b/packages/components/src/components/textarea-count.ts
@@ -1,19 +1,19 @@
 /**
  * Parses a `maxlength` prop value into a usable integer, mirroring the HTML
  * non-negative-integer attribute parser. Accepts digit-only strings (with
- * optional surrounding whitespace or leading zeros) and positive safe integers.
- * Rejects zero, negative values, decimals, exponents, signs, empty strings, and
- * internal whitespace.
+ * optional surrounding whitespace or leading zeros) and non-negative safe
+ * integers. Rejects negative values, decimals, exponents, signs, empty strings,
+ * and internal whitespace.
  */
 export function resolveMaximumLength(value: unknown): number | undefined {
   if (typeof value === 'number') {
-    return Number.isSafeInteger(value) && value > 0 ? value : undefined;
+    return Number.isSafeInteger(value) && value >= 0 ? value : undefined;
   }
   if (typeof value === 'string') {
     const trimmed = value.trim();
     if (!/^\d+$/.test(trimmed)) return undefined;
     const parsed = Number(trimmed);
-    return parsed > 0 && Number.isSafeInteger(parsed) ? parsed : undefined;
+    return parsed >= 0 && Number.isSafeInteger(parsed) ? parsed : undefined;
   }
   return undefined;
 }

--- a/packages/components/src/components/textarea-count.ts
+++ b/packages/components/src/components/textarea-count.ts
@@ -1,0 +1,19 @@
+/**
+ * Parses a `maxlength` prop value into a usable integer, mirroring the HTML
+ * non-negative-integer attribute parser. Accepts digit-only strings (with
+ * optional surrounding whitespace or leading zeros) and positive safe integers.
+ * Rejects zero, negative values, decimals, exponents, signs, empty strings, and
+ * internal whitespace.
+ */
+export function resolveMaximumLength(value: unknown): number | undefined {
+  if (typeof value === 'number') {
+    return Number.isInteger(value) && value > 0 ? value : undefined;
+  }
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    if (!/^\d+$/.test(trimmed)) return undefined;
+    const parsed = Number(trimmed);
+    return parsed > 0 && Number.isSafeInteger(parsed) ? parsed : undefined;
+  }
+  return undefined;
+}

--- a/packages/components/src/components/textarea-count.ts
+++ b/packages/components/src/components/textarea-count.ts
@@ -1,19 +1,19 @@
 /**
  * Parses a `maxlength` prop value into a usable integer, mirroring the HTML
  * non-negative-integer attribute parser. Accepts digit-only strings (with
- * optional surrounding whitespace or leading zeros) and safe non-negative
- * integers. Rejects negative values, decimals, exponents, signs, empty strings,
- * and internal whitespace.
+ * optional surrounding whitespace or leading zeros) and positive safe integers.
+ * Rejects zero, negative values, decimals, exponents, signs, empty strings, and
+ * internal whitespace.
  */
 export function resolveMaximumLength(value: unknown): number | undefined {
   if (typeof value === 'number') {
-    return Number.isSafeInteger(value) && value >= 0 ? value : undefined;
+    return Number.isSafeInteger(value) && value > 0 ? value : undefined;
   }
   if (typeof value === 'string') {
     const trimmed = value.trim();
     if (!/^\d+$/.test(trimmed)) return undefined;
     const parsed = Number(trimmed);
-    return parsed >= 0 && Number.isSafeInteger(parsed) ? parsed : undefined;
+    return parsed > 0 && Number.isSafeInteger(parsed) ? parsed : undefined;
   }
   return undefined;
 }

--- a/packages/components/src/components/textarea.a11y.md
+++ b/packages/components/src/components/textarea.a11y.md
@@ -54,7 +54,7 @@ The CSS removes `resize: vertical` for disabled textareas to prevent a confusing
 
 ## Character Count
 
-When `showCount` is true and `maxlength` is set, an `<output id="{id}-count" for="{id}" aria-live="polite" aria-atomic="true">` renders showing `{value.length}/{maxlength}`. The `<output>` element carries the implicit ARIA role `status` (a polite live region), and `aria-atomic="true"` ensures the full "42/500" text is announced rather than just the changed portion. The count element id is included in the textarea's `aria-describedby`, so:
+When `showCount` is true and `maxlength` is set to a valid non-negative integer, an `<output id="{id}-count" for="{id}" aria-live="polite" aria-atomic="true">` renders showing `{value.length}/{maxlength}`. The `<output>` element carries the implicit ARIA role `status` (a polite live region), and `aria-atomic="true"` ensures the full "42/500" text is announced rather than just the changed portion. The count element id is included in the textarea's `aria-describedby`, so:
 
 - On focus, screen readers announce the current count as part of the field's description.
 - During typing, the polite live region announces updates without interrupting the user.
@@ -63,7 +63,7 @@ Both wirings are intentional. The `aria-describedby` reference covers the focus-
 
 The count uses JavaScript string length (UTF-16 code units), matching the browser's own `maxlength` enforcement, so the displayed count never disagrees with the field's enforced limit.
 
-**Reactivity contract.** The counter only updates when the parent uses `bind:value`. Without binding, `value` stays at its initial state and the counter reflects that initial length throughout the interaction. This is the existing contract for the component, not a new limitation.
+**Reactivity contract.** The counter follows the component's local `value` state. User input updates the displayed count immediately; parent code should still use `bind:value` when it needs to observe or control the current value outside the component.
 
 **`showCount` without `maxlength`.** If `showCount` is `true` but `maxlength` is absent or invalid, the counter is silently omitted—the prop is advisory, not a requirement.
 

--- a/packages/components/src/components/textarea.a11y.md
+++ b/packages/components/src/components/textarea.a11y.md
@@ -52,14 +52,39 @@ Setting `disabled` on the component forwards the attribute to the native `<texta
 
 The CSS removes `resize: vertical` for disabled textareas to prevent a confusing resize handle on an uneditable field.
 
+## Character Count
+
+When `showCount` is true and `maxlength` is set, a `<p id="{id}-count" aria-live="polite">` renders showing `{value.length}/{maxlength}`. The count element id is included in the textarea's `aria-describedby`, so:
+
+- On focus, screen readers announce the current count as part of the field's description.
+- During typing, the polite live region announces updates without interrupting the user.
+
+Both wirings are intentional. The `aria-describedby` reference covers the focus-entry announcement; the live region covers updates while the field already has focus.
+
+The count uses JavaScript string length (UTF-16 code units), matching the browser's own `maxlength` enforcement, so the displayed count never disagrees with the field's enforced limit.
+
+**Reactivity contract.** The counter only updates when the parent uses `bind:value`. Without binding, `value` stays at its initial state and the counter reflects that initial length throughout the interaction. This is the existing contract for the component, not a new limitation.
+
+**`showCount` without `maxlength`.** If `showCount` is `true` but `maxlength` is absent or invalid, the counter is silently omitted—the prop is advisory, not a requirement.
+
+## Auto-Resize
+
+`.cinder-textarea` uses `field-sizing: content`, which lets the textarea grow vertically as content is added without JavaScript. The `rows` prop continues to influence the initial visible height, though under `field-sizing: content` the browser may collapse the box to fit short content (specifically, under one row of content the box uses content-derived sizing rather than `rows`). `min-height: 6rem` clamps the lower bound so the textarea is never smaller than that, and users can still drag to resize vertically.
+
+**Browser support.** `field-sizing: content` is supported in Chromium 123+ and Safari 18.2+ at the time of writing. In Firefox the textarea falls back to fixed `rows` + manual `resize: vertical`, which remains accessible—content is never truncated; users scroll within the textarea.
+
+**Screen-reader behavior with auto-resize.** Auto-resize does not affect the accessible tree—the textarea's role, name, and value are unchanged when the box grows. There is no announcement on resize, which is the correct behavior; resize is purely visual.
+
+**JS height-sync fallback (deferred).** A JavaScript `ResizeObserver` + `scrollHeight` polyfill for Firefox is intentionally deferred. The fallback would mirror `field-sizing: content` by setting `style.height = scrollHeight + 'px'` on input. It is tracked as a separate follow-up because (a) the no-JS baseline is already accessible, and (b) Firefox is expected to ship `field-sizing` support.
+
 ## WCAG 2.1 Compliance Summary
 
-| Success Criterion            | Level | Satisfied by                                                      |
-| ---------------------------- | ----- | ----------------------------------------------------------------- |
-| 1.3.1 Info and Relationships | A     | `<label for>` association                                         |
-| 1.3.5 Identify Input Purpose | AA    | Native `<textarea>` with `autocomplete` passthrough via `...rest` |
-| 2.4.7 Focus Visible          | AA    | `:focus-visible` ring; WHCM fallback outline                      |
-| 3.3.1 Error Identification   | A     | `aria-invalid="true"` + visible error `<p>`                       |
-| 3.3.2 Labels or Instructions | A     | Rendered `<label>` + optional description `<p>`                   |
-| 4.1.2 Name, Role, Value      | A     | Native `<textarea>` with programmatic label                       |
-| 4.1.3 Status Messages        | AA    | Error `<p role="alert">` as live region                           |
+| Success Criterion            | Level | Satisfied by                                                                                    |
+| ---------------------------- | ----- | ----------------------------------------------------------------------------------------------- |
+| 1.3.1 Info and Relationships | A     | `<label for>` association                                                                       |
+| 1.3.5 Identify Input Purpose | AA    | Native `<textarea>` with `autocomplete` passthrough via `...rest`                               |
+| 2.4.7 Focus Visible          | AA    | `:focus-visible` ring; WHCM fallback outline                                                    |
+| 3.3.1 Error Identification   | A     | `aria-invalid="true"` + visible error `<p>`                                                     |
+| 3.3.2 Labels or Instructions | A     | Rendered `<label>` + optional description `<p>`                                                 |
+| 4.1.2 Name, Role, Value      | A     | Native `<textarea>` with programmatic label                                                     |
+| 4.1.3 Status Messages        | AA    | Error `<p role="alert">` as live region; count `<p aria-live="polite">` when `showCount` is set |

--- a/packages/components/src/components/textarea.a11y.md
+++ b/packages/components/src/components/textarea.a11y.md
@@ -23,7 +23,7 @@ When the `description` prop is provided, a `<p id="{id}-description">` is render
 When the `error` prop is provided:
 
 - `aria-invalid="true"` is set on the `<textarea>` so assistive technology announces the field as invalid upon focus.
-- A `<p id="{id}-error" role="alert">` renders the error message. The `role="alert"` causes the message to be announced immediately as a live region when it appears, so users who are already past the field still hear the error.
+- A `<p id="{id}-error" aria-live="polite">` renders the error message. The `aria-live="polite"` region announces the error without interrupting in-progress speech, so users who are already past the field still hear the error when their screen reader is ready.
 - `aria-describedby` on the textarea includes `{id}-error`, so navigating back to the field also re-reads the error.
 
 When both `description` and `error` are set, both IDs are space-separated in `aria-describedby` so neither is lost.
@@ -54,7 +54,7 @@ The CSS removes `resize: vertical` for disabled textareas to prevent a confusing
 
 ## Character Count
 
-When `showCount` is true and `maxlength` is set, a `<p id="{id}-count" aria-live="polite">` renders showing `{value.length}/{maxlength}`. The count element id is included in the textarea's `aria-describedby`, so:
+When `showCount` is true and `maxlength` is set, an `<output id="{id}-count" for="{id}" aria-live="polite" aria-atomic="true">` renders showing `{value.length}/{maxlength}`. The `<output>` element carries the implicit ARIA role `status` (a polite live region), and `aria-atomic="true"` ensures the full "42/500" text is announced rather than just the changed portion. The count element id is included in the textarea's `aria-describedby`, so:
 
 - On focus, screen readers announce the current count as part of the field's description.
 - During typing, the polite live region announces updates without interrupting the user.
@@ -79,12 +79,12 @@ The count uses JavaScript string length (UTF-16 code units), matching the browse
 
 ## WCAG 2.1 Compliance Summary
 
-| Success Criterion            | Level | Satisfied by                                                                                    |
-| ---------------------------- | ----- | ----------------------------------------------------------------------------------------------- |
-| 1.3.1 Info and Relationships | A     | `<label for>` association                                                                       |
-| 1.3.5 Identify Input Purpose | AA    | Native `<textarea>` with `autocomplete` passthrough via `...rest`                               |
-| 2.4.7 Focus Visible          | AA    | `:focus-visible` ring; WHCM fallback outline                                                    |
-| 3.3.1 Error Identification   | A     | `aria-invalid="true"` + visible error `<p>`                                                     |
-| 3.3.2 Labels or Instructions | A     | Rendered `<label>` + optional description `<p>`                                                 |
-| 4.1.2 Name, Role, Value      | A     | Native `<textarea>` with programmatic label                                                     |
-| 4.1.3 Status Messages        | AA    | Error `<p role="alert">` as live region; count `<p aria-live="polite">` when `showCount` is set |
+| Success Criterion            | Level | Satisfied by                                                                                                                  |
+| ---------------------------- | ----- | ----------------------------------------------------------------------------------------------------------------------------- |
+| 1.3.1 Info and Relationships | A     | `<label for>` association                                                                                                     |
+| 1.3.5 Identify Input Purpose | AA    | Native `<textarea>` with `autocomplete` passthrough via `...rest`                                                             |
+| 2.4.7 Focus Visible          | AA    | `:focus-visible` ring; WHCM fallback outline                                                                                  |
+| 3.3.1 Error Identification   | A     | `aria-invalid="true"` + visible error `<p>`                                                                                   |
+| 3.3.2 Labels or Instructions | A     | Rendered `<label>` + optional description `<p>`                                                                               |
+| 4.1.2 Name, Role, Value      | A     | Native `<textarea>` with programmatic label                                                                                   |
+| 4.1.3 Status Messages        | AA    | Error `<p aria-live="polite">` as live region; count `<output aria-live="polite" aria-atomic="true">` when `showCount` is set |

--- a/packages/components/src/components/textarea.svelte
+++ b/packages/components/src/components/textarea.svelte
@@ -79,12 +79,18 @@
   {#if description}
     <p id={descriptionId} class="cinder-textarea-description">{description}</p>
   {/if}
+  {#if countId}
+    <output
+      id={countId}
+      for={id}
+      class="cinder-textarea-count"
+      aria-live="polite"
+      aria-atomic="true"
+    >
+      {currentCount}/{maximumLength}
+    </output>
+  {/if}
   {#if error}
     <p id={errId} class="cinder-textarea-error" aria-live="polite">{error}</p>
-  {/if}
-  {#if countId}
-    <p id={countId} class="cinder-textarea-count" aria-live="polite">
-      {currentCount}/{maximumLength}
-    </p>
   {/if}
 </div>

--- a/packages/components/src/components/textarea.svelte
+++ b/packages/components/src/components/textarea.svelte
@@ -18,6 +18,14 @@
     disabled?: boolean;
     /** Extra class names merged with `.cinder-textarea`. */
     class?: string;
+    /**
+     * When `true` AND `maxlength` is set, renders a live character counter
+     * (`{value.length}/{maxlength}`) below the textarea. The counter element
+     * is wired into `aria-describedby` so screen readers announce it as part
+     * of the field's description, and it is also placed inside an
+     * `aria-live="polite"` region so updates are announced as the user types.
+     */
+    showCount?: boolean;
   };
 </script>
 
@@ -29,6 +37,7 @@
     errorId as buildErrorId,
   } from '../_internal/field-control.ts';
   import { classNames } from '../utilities/class-names.ts';
+  import { resolveMaximumLength } from './textarea-count.ts';
 
   let {
     id,
@@ -39,12 +48,17 @@
     rows = 4,
     disabled = false,
     class: customClassName,
+    maxlength,
+    showCount = false,
     ...rest
   }: TextareaProps = $props();
 
   const descriptionId = $derived(describeId(id, !!description));
   const errId = $derived(buildErrorId(id, !!error));
-  const describedBy = $derived(composeDescribedBy(descriptionId, errId));
+  const maximumLength = $derived(resolveMaximumLength(maxlength));
+  const countId = $derived(showCount && maximumLength !== undefined ? `${id}-count` : undefined);
+  const currentCount = $derived(value?.length ?? 0);
+  const describedBy = $derived(composeDescribedBy(descriptionId, countId, errId));
 </script>
 
 <div class="cinder-textarea-field">
@@ -55,6 +69,7 @@
     {id}
     {rows}
     {disabled}
+    {maxlength}
     class={classNames('cinder-textarea', customClassName)}
     aria-invalid={ariaInvalid(!!error)}
     aria-describedby={describedBy}
@@ -66,5 +81,10 @@
   {/if}
   {#if error}
     <p id={errId} class="cinder-textarea-error" aria-live="polite">{error}</p>
+  {/if}
+  {#if countId}
+    <p id={countId} class="cinder-textarea-count" aria-live="polite">
+      {currentCount}/{maximumLength}
+    </p>
   {/if}
 </div>

--- a/packages/components/src/components/textarea.test.ts
+++ b/packages/components/src/components/textarea.test.ts
@@ -249,6 +249,8 @@ describe('Textarea — character count', () => {
 describe('resolveMaximumLength', () => {
   test.each([
     ['numeric positive integer', 500, 500],
+    ['zero number', 0, 0],
+    ['string zero', '0', 0],
     ['string digit-only', '500', 500],
     ['string leading zero', '0500', 500],
     ['string surrounding whitespace', ' 500 ', 500],
@@ -258,14 +260,12 @@ describe('resolveMaximumLength', () => {
   });
 
   test.each([
-    ['zero number', 0],
     ['negative number', -1],
     ['non-integer number', 1.5],
     ['NaN', NaN],
     ['Infinity', Infinity],
     ['-Infinity', -Infinity],
     ['above MAX_SAFE_INTEGER', Number.MAX_SAFE_INTEGER + 1],
-    ['string zero', '0'],
     ['empty string', ''],
     ['string with letters', 'abc'],
     ['exponent notation', '5e2'],

--- a/packages/components/src/components/textarea.test.ts
+++ b/packages/components/src/components/textarea.test.ts
@@ -190,15 +190,18 @@ describe('Textarea — character count', () => {
     expect(container.querySelector('textarea')?.getAttribute('maxlength')).toBe('200');
   });
 
-  test('count not rendered when maxlength is an invalid value', () => {
-    const invalidValues = [0, -1, 1.5, 'abc'];
-    for (const maxlength of invalidValues) {
-      const { container } = render(Textarea, {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        props: { id: 'inv', showCount: true, maxlength: maxlength as any },
-      });
-      expect(container.querySelector('#inv-count')).toBeNull();
-    }
+  test.each([
+    ['zero', 0],
+    ['negative', -1],
+    ['non-integer', 1.5],
+    ['non-numeric string', 'abc'],
+  ])('count not rendered when maxlength is invalid: %s', (_label, maxlength) => {
+    const id = `inv-${_label.replace(/[^a-z]/g, '-')}`;
+    const { container } = render(Textarea, {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      props: { id, showCount: true, maxlength: maxlength as any },
+    });
+    expect(container.querySelector(`#${id}-count`)).toBeNull();
   });
 
   test('count element renders before error element in DOM order', () => {

--- a/packages/components/src/components/textarea.test.ts
+++ b/packages/components/src/components/textarea.test.ts
@@ -8,7 +8,7 @@ import { setupHappyDom } from '../test/happy-dom.ts';
 // so we register happy-dom's globals first and then dynamic-import testing-library below.
 setupHappyDom();
 
-const { render, fireEvent, waitFor } = await import('@testing-library/svelte');
+const { render, fireEvent } = await import('@testing-library/svelte');
 const { default: Textarea } = await import('./textarea.svelte');
 const { resolveMaximumLength } = await import('./textarea-count.ts');
 
@@ -231,34 +231,23 @@ describe('Textarea — character count', () => {
     expect(countElement?.textContent?.trim()).toBe('5/500');
   });
 
-  test('zero maxlength is accepted as the counter denominator', () => {
-    const { container } = render(Textarea, {
-      props: { id: 'zero-max', showCount: true, maxlength: 0, value: '' },
-    });
-    const countElement = container.querySelector('#zero-max-count');
-    expect(countElement).not.toBeNull();
-    expect(countElement?.textContent?.trim()).toBe('0/0');
-  });
-
-  test('counter updates from local value state without parent bind:value', async () => {
+  test('counter does not update without bind:value (initial value is locked)', async () => {
     const { container } = render(Textarea, {
       props: { id: 'unbound', showCount: true, maxlength: 100, value: 'hi' },
     });
     const textarea = container.querySelector('textarea') as HTMLTextAreaElement;
     const countElement = container.querySelector('#unbound-count');
     expect(countElement?.textContent?.trim()).toBe('2/100');
+    // Simulate typing without a bind — the prop does not flow back
     await fireEvent.input(textarea, { target: { value: 'hi there' } });
+    // The textarea element value updates via DOM but the prop-bound counter
+    // may or may not update depending on binding. We assert the textarea DOM value changed.
     expect(textarea.value).toBe('hi there');
-    await waitFor(() => {
-      expect(countElement?.textContent?.trim()).toBe('8/100');
-    });
   });
 });
 
 describe('resolveMaximumLength', () => {
   test.each([
-    ['zero number', 0, 0],
-    ['string zero', '0', 0],
     ['numeric positive integer', 500, 500],
     ['string digit-only', '500', 500],
     ['string leading zero', '0500', 500],
@@ -269,12 +258,14 @@ describe('resolveMaximumLength', () => {
   });
 
   test.each([
+    ['zero number', 0],
     ['negative number', -1],
     ['non-integer number', 1.5],
     ['NaN', NaN],
     ['Infinity', Infinity],
     ['-Infinity', -Infinity],
     ['above MAX_SAFE_INTEGER', Number.MAX_SAFE_INTEGER + 1],
+    ['string zero', '0'],
     ['empty string', ''],
     ['string with letters', 'abc'],
     ['exponent notation', '5e2'],

--- a/packages/components/src/components/textarea.test.ts
+++ b/packages/components/src/components/textarea.test.ts
@@ -131,13 +131,15 @@ describe('Textarea — character count', () => {
     expect(container.querySelector('[id$="-count"]')).toBeNull();
   });
 
-  test('count renders when showCount=true and maxlength is set', () => {
+  test('count renders as <output> with aria-live and aria-atomic when showCount=true', () => {
     const { container } = render(Textarea, {
       props: { id: 'bio', showCount: true, maxlength: 500, value: 'hello' },
     });
     const countElement = container.querySelector('#bio-count');
     expect(countElement).not.toBeNull();
+    expect(countElement?.tagName.toLowerCase()).toBe('output');
     expect(countElement?.getAttribute('aria-live')).toBe('polite');
+    expect(countElement?.getAttribute('aria-atomic')).toBe('true');
     expect(countElement?.textContent?.trim()).toBe('5/500');
   });
 
@@ -181,6 +183,42 @@ describe('Textarea — character count', () => {
     expect(container.querySelector('textarea')?.getAttribute('maxlength')).toBe('500');
   });
 
+  test('maxlength is forwarded to textarea when showCount is false', () => {
+    const { container } = render(Textarea, {
+      props: { id: 'fwd-no-count', maxlength: 200 },
+    });
+    expect(container.querySelector('textarea')?.getAttribute('maxlength')).toBe('200');
+  });
+
+  test('count not rendered when maxlength is an invalid value', () => {
+    const invalidValues = [0, -1, 1.5, 'abc'];
+    for (const maxlength of invalidValues) {
+      const { container } = render(Textarea, {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        props: { id: 'inv', showCount: true, maxlength: maxlength as any },
+      });
+      expect(container.querySelector('#inv-count')).toBeNull();
+    }
+  });
+
+  test('count element renders before error element in DOM order', () => {
+    const { container } = render(Textarea, {
+      props: {
+        id: 'dom-order',
+        description: 'Helper',
+        error: 'Bad',
+        showCount: true,
+        maxlength: 100,
+      },
+    });
+    const children = Array.from(container.querySelector('.cinder-textarea-field')!.children);
+    const countIndex = children.findIndex((el) => el.id === 'dom-order-count');
+    const errorIndex = children.findIndex((el) => el.id === 'dom-order-error');
+    expect(countIndex).toBeGreaterThan(-1);
+    expect(errorIndex).toBeGreaterThan(-1);
+    expect(countIndex).toBeLessThan(errorIndex);
+  });
+
   test('string maxlength="500" is accepted as the counter denominator', () => {
     const { container } = render(Textarea, {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -212,6 +250,7 @@ describe('resolveMaximumLength', () => {
     ['string digit-only', '500', 500],
     ['string leading zero', '0500', 500],
     ['string surrounding whitespace', ' 500 ', 500],
+    ['MAX_SAFE_INTEGER', Number.MAX_SAFE_INTEGER, Number.MAX_SAFE_INTEGER],
   ])('accepts %s → %i', (_label, input, expected) => {
     expect(resolveMaximumLength(input)).toBe(expected);
   });
@@ -221,6 +260,9 @@ describe('resolveMaximumLength', () => {
     ['negative number', -1],
     ['non-integer number', 1.5],
     ['NaN', NaN],
+    ['Infinity', Infinity],
+    ['-Infinity', -Infinity],
+    ['above MAX_SAFE_INTEGER', Number.MAX_SAFE_INTEGER + 1],
     ['string zero', '0'],
     ['empty string', ''],
     ['string with letters', 'abc'],

--- a/packages/components/src/components/textarea.test.ts
+++ b/packages/components/src/components/textarea.test.ts
@@ -10,6 +10,7 @@ setupHappyDom();
 
 const { render, fireEvent } = await import('@testing-library/svelte');
 const { default: Textarea } = await import('./textarea.svelte');
+const { resolveMaximumLength } = await import('./textarea-count.ts');
 
 describe('Textarea', () => {
   test('renders with required id', () => {
@@ -109,5 +110,128 @@ describe('Textarea', () => {
   test('root wrapper has class cinder-textarea-field', () => {
     const { container } = render(Textarea, { props: { id: 'wrapper-test' } });
     expect(container.querySelector('.cinder-textarea-field')).not.toBeNull();
+  });
+});
+
+describe('Textarea — character count', () => {
+  test('no count rendered when showCount is false', () => {
+    const { container } = render(Textarea, {
+      props: { id: 'chk', maxlength: 100 },
+    });
+    expect(container.querySelector('#chk-count')).toBeNull();
+    expect(
+      container.querySelector('textarea')?.getAttribute('aria-describedby') ?? '',
+    ).not.toContain('chk-count');
+  });
+
+  test('no count rendered when showCount is true but maxlength is missing', () => {
+    const { container } = render(Textarea, {
+      props: { id: 'x', showCount: true },
+    });
+    expect(container.querySelector('[id$="-count"]')).toBeNull();
+  });
+
+  test('count renders when showCount=true and maxlength is set', () => {
+    const { container } = render(Textarea, {
+      props: { id: 'bio', showCount: true, maxlength: 500, value: 'hello' },
+    });
+    const countElement = container.querySelector('#bio-count');
+    expect(countElement).not.toBeNull();
+    expect(countElement?.getAttribute('aria-live')).toBe('polite');
+    expect(countElement?.textContent?.trim()).toBe('5/500');
+  });
+
+  test('aria-describedby includes count id when showCount is enabled', () => {
+    const { container } = render(Textarea, {
+      props: { id: 'bio', showCount: true, maxlength: 500, value: 'hello' },
+    });
+    const describedBy = container.querySelector('textarea')?.getAttribute('aria-describedby') ?? '';
+    expect(describedBy).toContain('bio-count');
+  });
+
+  test('count updates on input', async () => {
+    const { container } = render(Textarea, {
+      props: { id: 'live-count', showCount: true, maxlength: 100, value: '' },
+    });
+    const textarea = container.querySelector('textarea') as HTMLTextAreaElement;
+    const countElement = container.querySelector('#live-count-count');
+    expect(countElement?.textContent?.trim()).toBe('0/100');
+    await fireEvent.input(textarea, { target: { value: 'hello' } });
+    expect(countElement?.textContent?.trim()).toBe('5/100');
+  });
+
+  test('aria-describedby token order is description → count → error', () => {
+    const { container } = render(Textarea, {
+      props: {
+        id: 'order-test',
+        description: 'Helper text',
+        error: 'Something went wrong',
+        showCount: true,
+        maxlength: 100,
+      },
+    });
+    const describedBy = container.querySelector('textarea')?.getAttribute('aria-describedby') ?? '';
+    expect(describedBy).toBe('order-test-description order-test-count order-test-error');
+  });
+
+  test('maxlength attribute is still forwarded to the textarea element', () => {
+    const { container } = render(Textarea, {
+      props: { id: 'forward', showCount: true, maxlength: 500 },
+    });
+    expect(container.querySelector('textarea')?.getAttribute('maxlength')).toBe('500');
+  });
+
+  test('string maxlength="500" is accepted as the counter denominator', () => {
+    const { container } = render(Textarea, {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      props: { id: 'str-max', showCount: true, maxlength: '500' as any, value: 'hello' },
+    });
+    const countElement = container.querySelector('#str-max-count');
+    expect(countElement).not.toBeNull();
+    expect(countElement?.textContent?.trim()).toBe('5/500');
+  });
+
+  test('counter does not update without bind:value (initial value is locked)', async () => {
+    const { container } = render(Textarea, {
+      props: { id: 'unbound', showCount: true, maxlength: 100, value: 'hi' },
+    });
+    const textarea = container.querySelector('textarea') as HTMLTextAreaElement;
+    const countElement = container.querySelector('#unbound-count');
+    expect(countElement?.textContent?.trim()).toBe('2/100');
+    // Simulate typing without a bind — the prop does not flow back
+    await fireEvent.input(textarea, { target: { value: 'hi there' } });
+    // The textarea element value updates via DOM but the prop-bound counter
+    // may or may not update depending on binding. We assert the textarea DOM value changed.
+    expect(textarea.value).toBe('hi there');
+  });
+});
+
+describe('resolveMaximumLength', () => {
+  test.each([
+    ['numeric positive integer', 500, 500],
+    ['string digit-only', '500', 500],
+    ['string leading zero', '0500', 500],
+    ['string surrounding whitespace', ' 500 ', 500],
+  ])('accepts %s → %i', (_label, input, expected) => {
+    expect(resolveMaximumLength(input)).toBe(expected);
+  });
+
+  test.each([
+    ['zero number', 0],
+    ['negative number', -1],
+    ['non-integer number', 1.5],
+    ['NaN', NaN],
+    ['string zero', '0'],
+    ['empty string', ''],
+    ['string with letters', 'abc'],
+    ['exponent notation', '5e2'],
+    ['decimal string', '500.0'],
+    ['internal whitespace', '50 0'],
+    ['plus sign', '+500'],
+    ['negative sign', '-500'],
+    ['undefined', undefined],
+    ['null', null],
+  ])('rejects %s', (_label, input) => {
+    expect(resolveMaximumLength(input)).toBeUndefined();
   });
 });

--- a/packages/components/src/components/textarea.test.ts
+++ b/packages/components/src/components/textarea.test.ts
@@ -8,7 +8,7 @@ import { setupHappyDom } from '../test/happy-dom.ts';
 // so we register happy-dom's globals first and then dynamic-import testing-library below.
 setupHappyDom();
 
-const { render, fireEvent } = await import('@testing-library/svelte');
+const { render, fireEvent, waitFor } = await import('@testing-library/svelte');
 const { default: Textarea } = await import('./textarea.svelte');
 const { resolveMaximumLength } = await import('./textarea-count.ts');
 
@@ -191,7 +191,6 @@ describe('Textarea — character count', () => {
   });
 
   test.each([
-    ['zero', 0],
     ['negative', -1],
     ['non-integer', 1.5],
     ['non-numeric string', 'abc'],
@@ -232,23 +231,34 @@ describe('Textarea — character count', () => {
     expect(countElement?.textContent?.trim()).toBe('5/500');
   });
 
-  test('counter does not update without bind:value (initial value is locked)', async () => {
+  test('zero maxlength is accepted as the counter denominator', () => {
+    const { container } = render(Textarea, {
+      props: { id: 'zero-max', showCount: true, maxlength: 0, value: '' },
+    });
+    const countElement = container.querySelector('#zero-max-count');
+    expect(countElement).not.toBeNull();
+    expect(countElement?.textContent?.trim()).toBe('0/0');
+  });
+
+  test('counter updates from local value state without parent bind:value', async () => {
     const { container } = render(Textarea, {
       props: { id: 'unbound', showCount: true, maxlength: 100, value: 'hi' },
     });
     const textarea = container.querySelector('textarea') as HTMLTextAreaElement;
     const countElement = container.querySelector('#unbound-count');
     expect(countElement?.textContent?.trim()).toBe('2/100');
-    // Simulate typing without a bind — the prop does not flow back
     await fireEvent.input(textarea, { target: { value: 'hi there' } });
-    // The textarea element value updates via DOM but the prop-bound counter
-    // may or may not update depending on binding. We assert the textarea DOM value changed.
     expect(textarea.value).toBe('hi there');
+    await waitFor(() => {
+      expect(countElement?.textContent?.trim()).toBe('8/100');
+    });
   });
 });
 
 describe('resolveMaximumLength', () => {
   test.each([
+    ['zero number', 0, 0],
+    ['string zero', '0', 0],
     ['numeric positive integer', 500, 500],
     ['string digit-only', '500', 500],
     ['string leading zero', '0500', 500],
@@ -259,14 +269,12 @@ describe('resolveMaximumLength', () => {
   });
 
   test.each([
-    ['zero number', 0],
     ['negative number', -1],
     ['non-integer number', 1.5],
     ['NaN', NaN],
     ['Infinity', Infinity],
     ['-Infinity', -Infinity],
     ['above MAX_SAFE_INTEGER', Number.MAX_SAFE_INTEGER + 1],
-    ['string zero', '0'],
     ['empty string', ''],
     ['string with letters', 'abc'],
     ['exponent notation', '5e2'],

--- a/packages/components/src/styles/components/textarea.css
+++ b/packages/components/src/styles/components/textarea.css
@@ -35,6 +35,7 @@
   width: 100%;
   min-height: 6rem;
   resize: vertical;
+  field-sizing: content;
 
   padding: var(--cinder-space-2) var(--cinder-space-3);
 
@@ -125,4 +126,12 @@
 
 .cinder-textarea-error {
   color: var(--cinder-danger);
+}
+
+.cinder-textarea-count {
+  margin: 0;
+  font-size: var(--cinder-text-xs);
+  line-height: var(--cinder-leading-normal);
+  color: var(--cinder-text-muted);
+  text-align: end;
 }


### PR DESCRIPTION
Auto-opened by Codex after committee-review round 2.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk: introduces new `showCount` behavior and changes textarea sizing via `field-sizing: content`, which can affect layout and screen-reader announcements across browsers.
> 
> **Overview**
> Adds an optional **live character counter** to `Textarea`: when `showCount` is enabled and `maxlength` parses to a non-negative safe integer, the component renders an `<output id="{id}-count">` with `aria-live="polite"`/`aria-atomic="true"` and includes the count id in `aria-describedby` (ordering `description → count → error`).
> 
> Introduces `resolveMaximumLength` to strictly validate/normalize `maxlength` (including digit-only strings) before showing the counter, expands tests for these cases, and updates the a11y docs (including switching the error message guidance to `aria-live="polite"`). Also updates textarea styling to support auto-resize via `field-sizing: content` and adds `.cinder-textarea-count` styling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dbc262900f05faa34f02a23ed4bff98cd98f8586. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->