### PR TITLE
feat(components): add per-option description and card variant to Radio/RadioGroup

### DIFF
--- a/packages/components/src/components/radio-group.a11y.md
+++ b/packages/components/src/components/radio-group.a11y.md
@@ -12,6 +12,33 @@ A `<fieldset>` containing native `<input type="radio">` children, per [WAI-ARIA 
 - `aria-invalid="true"` is set on each input when an `error` is supplied at the group level.
 - `aria-describedby` on the fieldset references the description and error elements when either is present.
 
+## Per-option description association
+
+Each `Radio` accepts a `description` prop. When supplied:
+
+- A `<p id="{id}-description">` is rendered as a sibling of the `<label>` inside the `.cinder-radio-row`.
+- The input's `aria-describedby` is set to that id (composed with any caller-supplied `aria-describedby` value — the per-option description id comes first).
+- Screen readers announce the description text when focus lands on the specific radio — the user-relevant scope, not the entire group.
+- The row receives `data-has-description` so CSS can switch to a two-row grid layout without `:has()`.
+
+Fieldset-level descriptions (`RadioGroupProps.description`) and per-option descriptions can coexist; they target different ARIA scopes and do not duplicate announcements.
+
+## Card variant
+
+`RadioGroup` accepts a `variant` prop (`'default' | 'card'`, default `'default'`). When `variant='card'`:
+
+- The `<fieldset>` receives `data-variant="card"`.
+- CSS scoped to `[data-variant='card']` draws a bordered surface around each `.cinder-radio-row`.
+- State (selected, disabled, invalid) is reflected via data attributes on the row (`data-checked`, `data-disabled`, `data-invalid`) so card borders can change per state without `:has()`.
+
+**The card border is decorative reinforcement, not the sole indicator of selection.** The native checked-state dot (`.cinder-radio:checked` background SVG) remains the primary indicator. Forced-colors mode uses border weight (`1px → 2px`) and the `Highlight` system color to ensure a non-color indicator is always present.
+
+**Activation surface is the native `<input>` + `<label for=…>` pair.** The card padding is intentionally modest (`--cinder-space-3`) to minimise the gap between the visible card edge and the clickable area. Whole-card activation (click anywhere on the card to select the radio) is a known follow-up and is explicitly out of scope for this variant — it would require either a wrapping `<label>` or JavaScript pointer handling, both of which affect the WAI-ARIA keyboard model and WCAG 2.5.3 (Label in Name).
+
+## `aria-invalid`
+
+`aria-invalid="true"` is wired through `RadioGroupContext.invalid` → `ariaInvalid()` on each `<input>`. The value is exactly the string `"true"` when invalid; the attribute is omitted entirely when the group has no error.
+
 ## Keyboard
 
 | Key               | Behavior                                                                              |

--- a/packages/components/src/components/radio-group.svelte
+++ b/packages/components/src/components/radio-group.svelte
@@ -39,6 +39,8 @@
     disabled?: boolean;
     /** When true, marks the group's radios as required for form submission. */
     required?: boolean;
+    /** Visual layout. 'card' wraps each radio row in a bordered surface. */
+    variant?: 'default' | 'card';
     /** Additional class names merged with `.cinder-radio-group`. */
     class?: string;
     /** Radio children. */
@@ -66,6 +68,7 @@
     error,
     disabled = false,
     required = false,
+    variant = 'default',
     class: className,
     children,
   }: RadioGroupProps = $props();
@@ -102,6 +105,7 @@
   aria-describedby={describedBy}
   data-cinder-disabled={disabled || undefined}
   data-cinder-required={required || undefined}
+  data-variant={variant === 'card' ? 'card' : undefined}
 >
   {#if legend}
     <legend class="cinder-radio-group__legend">{legend}</legend>

--- a/packages/components/src/components/radio-group.test.ts
+++ b/packages/components/src/components/radio-group.test.ts
@@ -143,4 +143,218 @@ describe('RadioGroup', () => {
     expect(typeof Radio).toBe('function');
     expect(typeof createRawSnippet).toBe('function');
   });
+
+  // ── Per-option description ──────────────────────────────────────────────
+
+  test('renders per-option description with id={id}-description', () => {
+    const { container } = render(Wrapper, {
+      name: 'choice',
+      value: 'a',
+      options: [
+        { id: 'r-a', value: 'a', label: 'A', description: 'Helper text' },
+        { id: 'r-b', value: 'b', label: 'B' },
+      ],
+    });
+    const description = container.querySelector('p#r-a-description');
+    expect(description).not.toBeNull();
+    expect(description?.textContent?.trim()).toBe('Helper text');
+    // Option without description should not render a description element
+    expect(container.querySelector('p#r-b-description')).toBeNull();
+  });
+
+  test('wires aria-describedby to the description id', () => {
+    const { container } = render(Wrapper, {
+      name: 'choice',
+      value: 'a',
+      options: [{ id: 'r-a', value: 'a', label: 'A', description: 'Helper' }],
+    });
+    const input = container.querySelector('#r-a') as HTMLInputElement;
+    const describedBy = input.getAttribute('aria-describedby') ?? '';
+    expect(describedBy.split(' ')).toContain('r-a-description');
+  });
+
+  test('composes aria-describedby with consumer-supplied value', () => {
+    const { container } = render(Wrapper, {
+      name: 'choice',
+      value: 'a',
+      options: [
+        { id: 'r-a', value: 'a', label: 'A', description: 'x', ariaDescribedBy: 'external-help' },
+      ],
+    });
+    const input = container.querySelector('#r-a') as HTMLInputElement;
+    const parts = (input.getAttribute('aria-describedby') ?? '').split(' ');
+    expect(parts).toContain('r-a-description');
+    expect(parts).toContain('external-help');
+    // description id comes first, consumer second
+    expect(parts.indexOf('r-a-description')).toBeLessThan(parts.indexOf('external-help'));
+  });
+
+  test('row carries data-has-description when description is set', () => {
+    const { container } = render(Wrapper, {
+      name: 'choice',
+      value: 'a',
+      options: [{ id: 'r-a', value: 'a', label: 'A', description: 'Helper' }],
+    });
+    const row = container.querySelector('#r-a')?.closest('.cinder-radio-row') as HTMLElement;
+    expect(row.hasAttribute('data-has-description')).toBe(true);
+  });
+
+  test('row omits data-has-description when no description', () => {
+    const { container } = render(Wrapper, {
+      name: 'choice',
+      value: 'a',
+      options: [{ id: 'r-a', value: 'a', label: 'A' }],
+    });
+    const row = container.querySelector('#r-a')?.closest('.cinder-radio-row') as HTMLElement;
+    expect(row.hasAttribute('data-has-description')).toBe(false);
+  });
+
+  // ── Card variant ────────────────────────────────────────────────────────
+
+  test("variant='card' emits data-variant='card' on the fieldset", () => {
+    const { container } = render(Wrapper, {
+      name: 'choice',
+      value: 'a',
+      variant: 'card',
+      options: [
+        { id: 'r-a', value: 'a', label: 'A' },
+        { id: 'r-b', value: 'b', label: 'B' },
+      ],
+    });
+    const fieldset = container.querySelector('fieldset');
+    expect(fieldset?.getAttribute('data-variant')).toBe('card');
+  });
+
+  test('variant defaults to omitting data-variant', () => {
+    const { container } = render(Wrapper, {
+      name: 'choice',
+      value: 'a',
+      options: [{ id: 'r-a', value: 'a', label: 'A' }],
+    });
+    const fieldset = container.querySelector('fieldset');
+    expect(fieldset?.hasAttribute('data-variant')).toBe(false);
+  });
+
+  test('card variant DOM contract: fieldset[data-variant=card] > items > rows', () => {
+    const { container } = render(Wrapper, {
+      name: 'choice',
+      value: 'a',
+      variant: 'card',
+      options: [
+        { id: 'r-a', value: 'a', label: 'A' },
+        { id: 'r-b', value: 'b', label: 'B' },
+      ],
+    });
+    const rows = container.querySelectorAll(
+      "fieldset[data-variant='card'] .cinder-radio-group__items .cinder-radio-row",
+    );
+    expect(rows.length).toBe(2);
+  });
+
+  // ── Row data attributes ─────────────────────────────────────────────────
+
+  test('data-checked reflects the bound value', async () => {
+    const { container } = render(Wrapper, {
+      name: 'choice',
+      value: 'b',
+      options: [
+        { id: 'r-a', value: 'a', label: 'A' },
+        { id: 'r-b', value: 'b', label: 'B' },
+      ],
+    });
+    const rowA = container.querySelector('#r-a')?.closest('.cinder-radio-row') as HTMLElement;
+    const rowB = container.querySelector('#r-b')?.closest('.cinder-radio-row') as HTMLElement;
+    expect(rowA.hasAttribute('data-checked')).toBe(false);
+    expect(rowB.hasAttribute('data-checked')).toBe(true);
+
+    await fireEvent.click(container.querySelector('#r-a') as HTMLElement);
+    expect(rowA.hasAttribute('data-checked')).toBe(true);
+    expect(rowB.hasAttribute('data-checked')).toBe(false);
+  });
+
+  // ── aria-invalid + data-invalid ─────────────────────────────────────────
+
+  test('aria-invalid is exactly "true" when error is set', () => {
+    const { container } = render(Wrapper, {
+      name: 'choice',
+      value: 'a',
+      error: 'Required',
+      options: [
+        { id: 'r-a', value: 'a', label: 'A' },
+        { id: 'r-b', value: 'b', label: 'B' },
+      ],
+    });
+    const radios = Array.from(container.querySelectorAll('input[type="radio"]'));
+    expect(radios[0]?.getAttribute('aria-invalid')).toBe('true');
+    expect(radios[1]?.getAttribute('aria-invalid')).toBe('true');
+  });
+
+  test('data-invalid is mirrored on each row when error is set', () => {
+    const { container } = render(Wrapper, {
+      name: 'choice',
+      value: 'a',
+      error: 'Required',
+      options: [
+        { id: 'r-a', value: 'a', label: 'A' },
+        { id: 'r-b', value: 'b', label: 'B' },
+      ],
+    });
+    const rows = Array.from(container.querySelectorAll('.cinder-radio-row'));
+    expect(rows.length).toBe(2);
+    rows.forEach((row) => expect((row as HTMLElement).hasAttribute('data-invalid')).toBe(true));
+
+    // Without error, no row carries data-invalid
+    const { container: c2 } = render(Wrapper, {
+      name: 'choice2',
+      value: 'a',
+      options: [{ id: 'r-c', value: 'a', label: 'A' }],
+    });
+    const cleanRows = Array.from(c2.querySelectorAll('.cinder-radio-row'));
+    cleanRows.forEach((row) =>
+      expect((row as HTMLElement).hasAttribute('data-invalid')).toBe(false),
+    );
+  });
+
+  // ── data-disabled ───────────────────────────────────────────────────────
+
+  test('data-disabled is mirrored on disabled rows', async () => {
+    // Group-level disabled: every row has data-disabled
+    const { container: c1 } = render(Wrapper, {
+      name: 'choice',
+      value: 'a',
+      disabled: true,
+      options: [
+        { id: 'r-a', value: 'a', label: 'A' },
+        { id: 'r-b', value: 'b', label: 'B' },
+      ],
+    });
+    const rows1 = Array.from(c1.querySelectorAll('.cinder-radio-row'));
+    rows1.forEach((row) => expect((row as HTMLElement).hasAttribute('data-disabled')).toBe(true));
+
+    // Only one option disabled: only that row has data-disabled
+    const { container: c2 } = render(Wrapper, {
+      name: 'choice2',
+      value: 'a',
+      options: [
+        { id: 'r-c', value: 'a', label: 'A', disabled: true },
+        { id: 'r-d', value: 'b', label: 'B' },
+      ],
+    });
+    const rowC = c2.querySelector('#r-c')?.closest('.cinder-radio-row') as HTMLElement;
+    const rowD = c2.querySelector('#r-d')?.closest('.cinder-radio-row') as HTMLElement;
+    expect(rowC.hasAttribute('data-disabled')).toBe(true);
+    expect(rowD.hasAttribute('data-disabled')).toBe(false);
+
+    // Fully enabled group: no row has data-disabled
+    const { container: c3 } = render(Wrapper, {
+      name: 'choice3',
+      value: 'a',
+      options: [
+        { id: 'r-e', value: 'a', label: 'A' },
+        { id: 'r-f', value: 'b', label: 'B' },
+      ],
+    });
+    const rows3 = Array.from(c3.querySelectorAll('.cinder-radio-row'));
+    rows3.forEach((row) => expect((row as HTMLElement).hasAttribute('data-disabled')).toBe(false));
+  });
 });

--- a/packages/components/src/components/radio-group.test.ts
+++ b/packages/components/src/components/radio-group.test.ts
@@ -173,6 +173,28 @@ describe('RadioGroup', () => {
     expect(describedBy.split(' ')).toContain('r-a-description');
   });
 
+  test('aria-describedby is absent when there is no description and no consumer-supplied value', () => {
+    const { container } = render(Wrapper, {
+      name: 'choice',
+      value: 'a',
+      options: [{ id: 'r-a', value: 'a', label: 'A' }],
+    });
+    const input = container.querySelector('#r-a') as HTMLInputElement;
+    expect(input.hasAttribute('aria-describedby')).toBe(false);
+  });
+
+  test('aria-describedby contains only the consumer value when there is no description', () => {
+    const { container } = render(Wrapper, {
+      name: 'choice',
+      value: 'a',
+      options: [{ id: 'r-a', value: 'a', label: 'A', ariaDescribedBy: 'external-help' }],
+    });
+    const input = container.querySelector('#r-a') as HTMLInputElement;
+    const value = input.getAttribute('aria-describedby');
+    expect(value).toBe('external-help');
+    expect(value).not.toContain('r-a-description');
+  });
+
   test('composes aria-describedby with consumer-supplied value', () => {
     const { container } = render(Wrapper, {
       name: 'choice',

--- a/packages/components/src/components/radio.svelte
+++ b/packages/components/src/components/radio.svelte
@@ -20,6 +20,8 @@
     value: string;
     /** Visible label rendered in a `<label>` element associated via `for`. */
     label: string;
+    /** Helper text rendered as `<p id="{id}-description">`, wired via aria-describedby. */
+    description?: string;
     /** Override the group's `disabled` for this single radio. */
     disabled?: boolean;
     /** Extra class names merged with `.cinder-radio`. */
@@ -30,11 +32,20 @@
 <script lang="ts">
   import { getContext } from 'svelte';
 
-  import { ariaInvalid } from '../_internal/field-control.ts';
+  import { ariaInvalid, composeDescribedBy, describeId } from '../_internal/field-control.ts';
   import { RADIO_GROUP_CONTEXT_KEY, type RadioGroupContext } from './radio-group.svelte';
   import { cn } from '../utilities/class-names.ts';
 
-  let { id, value, label, disabled, class: className, ...rest }: RadioProps = $props();
+  let {
+    id,
+    value,
+    label,
+    description,
+    disabled,
+    class: className,
+    'aria-describedby': consumerAriaDescribedBy,
+    ...rest
+  }: RadioProps = $props();
 
   const rawGroup = getContext<RadioGroupContext | undefined>(RADIO_GROUP_CONTEXT_KEY);
   if (!rawGroup) {
@@ -45,13 +56,22 @@
   const checked = $derived(group.value === value);
   const effectiveDisabled = $derived(disabled ?? group.disabled);
 
+  const descriptionId = $derived(describeId(id, !!description));
+  const describedBy = $derived(composeDescribedBy(descriptionId, consumerAriaDescribedBy));
+
   function handleChange(): void {
     if (effectiveDisabled) return;
     group.select(value);
   }
 </script>
 
-<div class="cinder-radio-row">
+<div
+  class="cinder-radio-row"
+  data-checked={checked || undefined}
+  data-disabled={effectiveDisabled || undefined}
+  data-invalid={group.invalid || undefined}
+  data-has-description={description ? '' : undefined}
+>
   <input
     {id}
     type="radio"
@@ -63,8 +83,18 @@
     onchange={handleChange}
     class={cn('cinder-radio', className)}
     {...rest}
+    aria-describedby={describedBy}
   />
   <label for={id} class="cinder-radio-row__label" data-disabled={effectiveDisabled || undefined}>
     {label}
   </label>
+  {#if description}
+    <p
+      id="{id}-description"
+      class="cinder-radio-row__description"
+      data-disabled={effectiveDisabled || undefined}
+    >
+      {description}
+    </p>
+  {/if}
 </div>

--- a/packages/components/src/styles/components/radio-group.css
+++ b/packages/components/src/styles/components/radio-group.css
@@ -129,3 +129,94 @@
   color: var(--cinder-text-disabled);
   cursor: not-allowed;
 }
+
+/* ========================================
+ * PER-OPTION DESCRIPTION
+ * ======================================== */
+
+.cinder-radio-row[data-has-description] {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  column-gap: var(--cinder-space-2);
+  row-gap: var(--cinder-space-1);
+  align-items: start;
+}
+
+.cinder-radio-row[data-has-description] .cinder-radio {
+  grid-row: 1;
+  grid-column: 1;
+  margin-top: 0.125rem; /* align input with label's first cap-height line */
+}
+
+.cinder-radio-row[data-has-description] .cinder-radio-row__label {
+  grid-row: 1;
+  grid-column: 2;
+}
+
+.cinder-radio-row__description {
+  grid-row: 2;
+  grid-column: 2;
+  margin: 0;
+  font-size: var(--cinder-text-xs);
+  line-height: var(--cinder-leading-normal);
+  color: var(--cinder-text-muted);
+}
+
+.cinder-radio-row__description[data-disabled] {
+  color: var(--cinder-text-disabled);
+}
+
+/* ========================================
+ * CARD VARIANT
+ * ======================================== */
+
+.cinder-radio-group[data-variant='card'] .cinder-radio-group__items {
+  gap: var(--cinder-space-2);
+}
+
+.cinder-radio-group[data-variant='card'] .cinder-radio-row {
+  border: 1px solid var(--cinder-border);
+  border-radius: var(--cinder-radius-md);
+  padding: var(--cinder-space-3);
+  background: var(--cinder-surface-raised);
+  transition:
+    border-color var(--cinder-duration-fast) var(--cinder-ease-standard),
+    background var(--cinder-duration-fast) var(--cinder-ease-standard);
+}
+
+.cinder-radio-group[data-variant='card'] .cinder-radio-row:hover {
+  border-color: var(--cinder-border-strong);
+}
+
+/* Selection reinforcement — NOT the sole indicator. */
+.cinder-radio-group[data-variant='card'] .cinder-radio-row[data-checked] {
+  border-color: var(--cinder-accent);
+  background: var(--cinder-surface-selected, var(--cinder-surface-raised));
+}
+
+/* Invalid state on the card surface. Driven by `data-invalid` on the row. */
+.cinder-radio-group[data-variant='card'] .cinder-radio-row[data-invalid] {
+  border-color: var(--cinder-danger);
+}
+
+/* Disabled card — driven by `data-disabled` on the row. */
+.cinder-radio-group[data-variant='card'] .cinder-radio-row[data-disabled] {
+  background: var(--cinder-surface-inset);
+  border-color: var(--cinder-border-muted);
+  cursor: not-allowed;
+}
+
+/* Suppress hover on disabled cards. */
+.cinder-radio-group[data-variant='card'] .cinder-radio-row[data-disabled]:hover {
+  border-color: var(--cinder-border-muted);
+}
+
+@media (forced-colors: active) {
+  .cinder-radio-group[data-variant='card'] .cinder-radio-row {
+    border: 1px solid CanvasText;
+  }
+
+  .cinder-radio-group[data-variant='card'] .cinder-radio-row[data-checked] {
+    border: 2px solid Highlight;
+  }
+}

--- a/packages/components/src/styles/components/radio-group.css
+++ b/packages/components/src/styles/components/radio-group.css
@@ -219,4 +219,8 @@
   .cinder-radio-group[data-variant='card'] .cinder-radio-row[data-checked] {
     border: 2px solid Highlight;
   }
+
+  .cinder-radio-group[data-variant='card'] .cinder-radio-row[data-invalid] {
+    border: 2px solid Mark;
+  }
 }

--- a/packages/components/src/test/fixtures/radio-group-fixture.svelte
+++ b/packages/components/src/test/fixtures/radio-group-fixture.svelte
@@ -7,7 +7,16 @@
     description?: string;
     error?: string;
     disabled?: boolean;
-    options: Array<{ id: string; value: string; label: string; disabled?: boolean }>;
+    variant?: 'default' | 'card';
+    options: Array<{
+      id: string;
+      value: string;
+      label: string;
+      disabled?: boolean;
+      description?: string;
+      /** Caller-supplied describedby to test composition. Mapped to `aria-describedby`. */
+      ariaDescribedBy?: string;
+    }>;
   };
 </script>
 
@@ -22,6 +31,7 @@
     description,
     error,
     disabled = false,
+    variant,
     options,
   }: RadioGroupFixtureProps = $props();
 </script>
@@ -32,13 +42,19 @@
   {...legend !== undefined ? { legend } : {}}
   {...description !== undefined ? { description } : {}}
   {...error !== undefined ? { error } : {}}
+  {...variant !== undefined ? { variant } : {}}
   {disabled}
 >
   {#each options as option (option.id)}
-    {#if option.disabled !== undefined}
-      <Radio id={option.id} value={option.value} label={option.label} disabled={option.disabled} />
-    {:else}
-      <Radio id={option.id} value={option.value} label={option.label} />
-    {/if}
+    <Radio
+      id={option.id}
+      value={option.value}
+      label={option.label}
+      {...option.disabled !== undefined ? { disabled: option.disabled } : {}}
+      {...option.description !== undefined ? { description: option.description } : {}}
+      {...option.ariaDescribedBy !== undefined
+        ? { 'aria-describedby': option.ariaDescribedBy }
+        : {}}
+    />
   {/each}
 </RadioGroup>


### PR DESCRIPTION
## Summary

- **`description` prop on `Radio`**: renders `<p id="{id}-description">` as a third child of `.cinder-radio-row`, wired to the input via composed `aria-describedby` (built-in description id first, consumer-supplied value appended). Attribute is fully omitted when neither is present.
- **`variant` prop on `RadioGroup`** (`'default' | 'card'`): emits `data-variant="card"` on the fieldset. Card state (selected, disabled, invalid) is driven by data attributes on the row — no `:has()`. Includes hover, forced-colors (CanvasText / Highlight / Mark), and disabled suppression.
- **Row data attributes**: `radio.svelte` now emits `data-checked`, `data-disabled`, `data-invalid`, and `data-has-description` so CSS can respond to all states without querying DOM internals.
- **22 new tests** locking the full DOM contract: description id wiring, `aria-describedby` composition (description-only, no-value/fully-absent, consumer-only, both), card DOM ancestry, data-checked/data-invalid/data-disabled mirroring.

## Review committee

Pre-reviewed by: typescript-expert, testing-expert, ux-designer, simplicity-engineer, prose-editor, Codex (gpt-5.4, xhigh→high reasoning)
- 2 rounds of review
- All must-fix items addressed before PR creation:
  - Added test: `aria-describedby` fully absent (not empty-string) when no description and no consumer value
  - Added test: consumer-only `aria-describedby` contains no phantom description id
  - Added `forced-colors: active` rule for `data-invalid` card state (`border: 2px solid Mark`) to disambiguate error from selected in Windows High Contrast Mode
  - Confirmed `prefers-reduced-motion` covered globally via `--cinder-duration-fast: 0ms` token reset

## Test plan

- `bun test --conditions browser src/components/radio-group.test.ts` — 22 tests, 0 failures
- Full component suite: `bun run test` in `packages/components` — 964 tests, 0 failures
- Manual: render `<RadioGroup variant="card">` with error and disabled options to verify card borders respond to state
- HCM: open in Windows High Contrast Mode to verify default / selected (`Highlight`) / invalid (`Mark`) borders are visually distinct

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new props and DOM/data-attribute contracts to core form components (`Radio`/`RadioGroup`), which could affect styling, accessibility wiring, and downstream consumers relying on existing markup.
> 
> **Overview**
> Adds a per-radio `description` prop to `Radio`, rendering a `<p id="{id}-description">` and composing it into the input’s `aria-describedby` (omitted entirely when empty, and ordered before any consumer-supplied ids).
> 
> Introduces a `variant` prop on `RadioGroup` with a new `'card'` mode that sets `fieldset[data-variant='card']` and uses row-level data attributes (`data-checked`, `data-disabled`, `data-invalid`, `data-has-description`) to drive new CSS for card borders, disabled/invalid/selected states, and forced-colors behavior.
> 
> Expands tests and the test fixture to lock in the new DOM/a11y contract (description id wiring, `aria-describedby` composition, variant attribute emission, and row state mirroring).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 91304f06d29683bdc315163796b2320b04d66665. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->