### PR TITLE
fix(checkbox-group): align disabled state and aria regression coverage

### DIFF
--- a/docs/focus-ring-policy.md
+++ b/docs/focus-ring-policy.md
@@ -62,7 +62,7 @@ Use when:
 }
 ```
 
-**Why the transparent outline is load-bearing.** In Windows High Contrast Mode `box-shadow` is suppressed by the browser. Without an outline channel reserved, the focus indicator vanishes — a WCAG 2.4.7 failure. The forced-colors block repaints that channel with a system color. Never omit `outline: var(--cinder-ring-width) solid transparent` from a Strategy B rule.
+**Why the transparent outline is load-bearing.** In Windows High Contrast Mode `box-shadow` is suppressed by the browser. Without an outline channel reserved, the focus indicator vanishes — a [WCAG 2.4.7 Focus Visible](https://www.w3.org/WAI/WCAG21/Understanding/focus-visible.html) failure. The forced-colors block repaints that channel with a system color. Never omit `outline: var(--cinder-ring-width) solid transparent` from a Strategy B rule.
 
 **Forced-colors color choice.** Use `ButtonText` when the element is `<button>`-shaped or `role="menuitem"` — anything the user clicks or activates. Use `Highlight` for text-entry surfaces (`input`, `textarea`, `select`) and for selection states.
 

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -53,6 +53,10 @@
       "svelte": "./src/components/chat.svelte",
       "types": "./dist/components/chat.svelte.d.ts"
     },
+    "./checkbox-group": {
+      "svelte": "./src/components/checkbox-group.svelte",
+      "types": "./dist/components/checkbox-group.svelte.d.ts"
+    },
     "./checkbox": {
       "svelte": "./src/components/checkbox.svelte",
       "types": "./dist/components/checkbox.svelte.d.ts"
@@ -125,14 +129,6 @@
       "svelte": "./src/components/empty-state.svelte",
       "types": "./dist/components/empty-state.svelte.d.ts"
     },
-    "./feed-event": {
-      "svelte": "./src/components/feed-event.svelte",
-      "types": "./dist/components/feed-event.svelte.d.ts"
-    },
-    "./feed": {
-      "svelte": "./src/components/feed.svelte",
-      "types": "./dist/components/feed.svelte.d.ts"
-    },
     "./experimental/connection-indicator": {
       "svelte": "./src/components/experimental/connection-indicator.svelte",
       "types": "./dist/components/experimental/connection-indicator.svelte.d.ts"
@@ -160,6 +156,14 @@
     "./experimental/timeline": {
       "svelte": "./src/components/experimental/timeline.svelte",
       "types": "./dist/components/experimental/timeline.svelte.d.ts"
+    },
+    "./feed-event": {
+      "svelte": "./src/components/feed-event.svelte",
+      "types": "./dist/components/feed-event.svelte.d.ts"
+    },
+    "./feed": {
+      "svelte": "./src/components/feed.svelte",
+      "types": "./dist/components/feed.svelte.d.ts"
     },
     "./grid-list-item": {
       "svelte": "./src/components/grid-list-item.svelte",

--- a/packages/components/src/_internal/OVERLAY-POLICY.md
+++ b/packages/components/src/_internal/OVERLAY-POLICY.md
@@ -12,7 +12,7 @@ The runtime helpers backing this policy live in `src/_internal/overlay.ts`.
 
 ## SSR rule (hard constraint)
 
-Overlays render nothing on the server, regardless of their initial `open` state. The standard idiom in a Svelte 5 component:
+Overlays render nothing on the server, regardless of their initial `open` state. The standard idiom in a [Svelte 5](https://svelte.dev/docs/svelte/overview) component:
 
 ```svelte
 <script>

--- a/packages/components/src/components/checkbox-group.a11y.md
+++ b/packages/components/src/components/checkbox-group.a11y.md
@@ -1,0 +1,84 @@
+# CheckboxGroup Accessibility Notes
+
+## Pattern
+
+`CheckboxGroup` wraps independent checkboxes in a native `<fieldset>` + `<legend>` element pair, following the [WAI-ARIA APG: Checkbox (multi-select)](https://www.w3.org/WAI/ARIA/apg/patterns/checkbox/) guidance. No ARIA `role` is added — `<fieldset>` carries the implicit grouping role already.
+
+## Why `<fieldset>` Instead of a Labelled `<div>`
+
+Screen readers announce the `<legend>` text when focus enters **any** descendant control. A bare `<div aria-labelledby="…">` only announces its label on initial focus into the group, so users navigating mid-group lose context. The `<fieldset>` approach means that as a user tabs through three checkboxes, each focus event re-announces the group name alongside the individual checkbox label.
+
+As a bonus, `<fieldset disabled>` cascades the disabled state to every descendant `<input>` natively — no Svelte context or prop forwarding required.
+
+## Names, Roles, States
+
+- **Group name**: the `<legend>` element.
+- **Group description**: a `<p>` element whose `id` is included in the fieldset's `aria-describedby`.
+- **Group error**: a `<p aria-live="polite">` element whose `id` is included in the fieldset's `aria-describedby`. The fieldset also carries `aria-invalid="true"` when `error` is set.
+- **Individual checkboxes**: each child `<input type="checkbox">` retains its own `aria-checked`, its own `aria-invalid` (only when its own `error` prop is set), and its own label association via `<label for="…">`.
+
+## Group `error` vs. Per-Checkbox `error`
+
+AT support for `aria-invalid` on `<fieldset>` is inconsistent across NVDA, JAWS, and VoiceOver. Additionally, fieldset-level `aria-describedby` is **not reliably re-announced** as focus moves between descendant checkboxes. The group-level `error` is therefore **best-effort supplemental context**: always visible to sighted users, but not a guaranteed per-focus screen reader announcement.
+
+When the error **must** be announced as the user focuses a specific control, pass the `error` prop directly to that `<Checkbox>` (which wires `aria-describedby` on the native input) in addition to or instead of the group `error`.
+
+## Disabled Propagation
+
+The `disabled` prop sets the native `disabled` attribute on `<fieldset>`. The browser then marks every descendant `<input>` as disabled — children cannot opt out of this cascade. The `CheckboxGroup` itself adds no JavaScript logic; this is the platform contract.
+
+## Required
+
+The `required` prop is a **visual and data-attribute hint only**. It sets `data-cinder-required` on the fieldset (present when `true`, absent when `false`) so consumers can target it for styling (e.g., rendering an asterisk in the legend).
+
+It does **not** set the `required` attribute on any child `<input>` and does **not** enforce constraint validation. To enforce that at least one checkbox is checked, either:
+
+- Add `required` to the specific child `<Checkbox>` that must be checked, or
+- Implement form-level validation that inspects the group's checked state.
+
+## Indeterminate Parent ("Select All") Pattern
+
+A common UI pattern is a top-level "select all" checkbox whose visual state reflects whether **some** (indeterminate) or **all** (checked) children are checked:
+
+```svelte
+<script>
+  let items = $state([
+    { id: 'a', label: 'Item A', checked: false },
+    { id: 'b', label: 'Item B', checked: true },
+  ]);
+
+  let allChecked = $derived(items.every((i) => i.checked));
+  let someChecked = $derived(items.some((i) => i.checked));
+
+  function toggleAll(event) {
+    const next = event.target.checked;
+    items = items.map((i) => ({ ...i, checked: next }));
+  }
+</script>
+
+<CheckboxGroup legend="Select items">
+  <Checkbox
+    id="select-all"
+    name="select-all"
+    label="Select all"
+    checked={allChecked}
+    indeterminate={someChecked && !allChecked}
+    onchange={toggleAll}
+  />
+  {#each items as item}
+    <Checkbox id={item.id} name={item.id} label={item.label} bind:checked={item.checked} />
+  {/each}
+</CheckboxGroup>
+```
+
+The existing `Checkbox` component already supports `indeterminate` (synced via a `$effect` as a DOM property). `CheckboxGroup` has no indeterminate-aware code — the behavior belongs entirely to `Checkbox`.
+
+## Card Variant
+
+The card layout (`variant="card"`) is purely visual: a bordered surface wraps each direct-child `.cinder-checkbox-field`. The checked-state border highlight is **additive** — the native check glyph inside each `Checkbox` remains the canonical indicator. Screen readers and users in Windows High Contrast / forced-colors mode rely on `aria-checked` on the native input, not on the card border.
+
+Card mode expects each direct child of the items container to be a single `<Checkbox>`. Non-checkbox content or wrapper elements inside `children` will not receive the card styling, by design.
+
+## Keyboard
+
+No custom keyboard handling is added. Each checkbox responds to `Space` to toggle, `Tab` to move focus, as the platform defines. DOM order determines tab sequence.

--- a/packages/components/src/components/checkbox-group.svelte
+++ b/packages/components/src/components/checkbox-group.svelte
@@ -88,7 +88,7 @@
   aria-invalid={ariaInvalid(!!error)}
   aria-describedby={describedBy}
   data-cinder-disabled={disabled || undefined}
-  data-cinder-required={required ? '' : undefined}
+  data-cinder-required={required || undefined}
   data-variant={variant}
 >
   {#if legend}

--- a/packages/components/src/components/checkbox-group.svelte
+++ b/packages/components/src/components/checkbox-group.svelte
@@ -87,6 +87,7 @@
   {disabled}
   aria-invalid={ariaInvalid(!!error)}
   aria-describedby={describedBy}
+  data-cinder-disabled={disabled || undefined}
   data-cinder-required={required ? '' : undefined}
   data-variant={variant}
 >

--- a/packages/components/src/components/checkbox-group.svelte
+++ b/packages/components/src/components/checkbox-group.svelte
@@ -1,0 +1,108 @@
+<script lang="ts" module>
+  import type { Snippet } from 'svelte';
+
+  /**
+   * Props for the CheckboxGroup component.
+   *
+   * Wraps a set of independent checkboxes in a `<fieldset>` + `<legend>`
+   * structure for semantic grouping. Unlike RadioGroup, this component does
+   * NOT own a shared `value` or `name` — each child `<Checkbox>` owns its
+   * own name and checked state. Native `<fieldset disabled>` propagation
+   * handles the disabled cascade without any Svelte context.
+   */
+  export type CheckboxGroupProps = {
+    /** Optional legend rendered as a `<legend>` inside the `<fieldset>`. */
+    legend?: string;
+    /** Helper text below the group; wired via `aria-describedby` on the fieldset. */
+    description?: string;
+    /**
+     * Group-level validation message. Rendered as a polite live region and
+     * referenced by the fieldset's `aria-describedby`. Also sets
+     * `aria-invalid="true"` on the fieldset itself as a supplementary signal.
+     *
+     * Note: fieldset-level `aria-describedby` is not reliably re-announced as
+     * focus moves between descendants. This is best-effort supplemental context
+     * — if a specific control must announce as invalid on focus, pass `error`
+     * to that `<Checkbox>` directly.
+     */
+    error?: string;
+    /**
+     * Disables every native form control inside via the fieldset's built-in
+     * cascade. Renders as the native `disabled` attribute on `<fieldset>`.
+     */
+    disabled?: boolean;
+    /**
+     * Marks the group as visually required. Sets `data-cinder-required` on the
+     * fieldset so consumers can target it (e.g. legend asterisk).
+     *
+     * This is a visual/data-attribute hint. It does NOT set `required` on any
+     * child `<input>` and does NOT enforce constraint validation. Per-control
+     * `required` must be set on the individual `<Checkbox>`.
+     */
+    required?: boolean;
+    /**
+     * Layout variant. `'default'` is a stacked column. `'card'` styles each
+     * direct child `.cinder-checkbox-field` as a bordered card row.
+     *
+     * Always emitted as `data-variant` on the fieldset. Card variant assumes
+     * each direct child of the items container is a single `<Checkbox>`.
+     */
+    variant?: 'default' | 'card';
+    /** Additional class names merged with `.cinder-checkbox-group`. */
+    class?: string;
+    /** Checkbox children. */
+    children: Snippet;
+  };
+</script>
+
+<script lang="ts">
+  import {
+    ariaInvalid,
+    composeDescribedBy,
+    describeId,
+    errorId as buildErrorId,
+  } from '../_internal/field-control.ts';
+  import { cn } from '../utilities/class-names.ts';
+  import { useId } from '../utilities/use-id.ts';
+
+  let {
+    legend,
+    description,
+    error,
+    disabled = false,
+    required = false,
+    variant = 'default',
+    class: className,
+    children,
+  }: CheckboxGroupProps = $props();
+
+  const groupId = useId('cinder-checkbox-group');
+  const descriptionId = $derived(describeId(groupId, !!description));
+  const errId = $derived(buildErrorId(groupId, !!error));
+  const describedBy = $derived(composeDescribedBy(descriptionId, errId));
+</script>
+
+<fieldset
+  class={cn('cinder-checkbox-group', className)}
+  {disabled}
+  aria-invalid={ariaInvalid(!!error)}
+  aria-describedby={describedBy}
+  data-cinder-required={required ? '' : undefined}
+  data-variant={variant}
+>
+  {#if legend}
+    <legend class="cinder-checkbox-group__legend">{legend}</legend>
+  {/if}
+
+  <div class="cinder-checkbox-group__items">
+    {@render children()}
+  </div>
+
+  {#if description}
+    <p id={descriptionId} class="cinder-checkbox-group__description">{description}</p>
+  {/if}
+
+  {#if error}
+    <p id={errId} class="cinder-checkbox-group__error" aria-live="polite">{error}</p>
+  {/if}
+</fieldset>

--- a/packages/components/src/components/checkbox-group.test.ts
+++ b/packages/components/src/components/checkbox-group.test.ts
@@ -135,6 +135,32 @@ describe('CheckboxGroup', () => {
     expect(typeof CheckboxGroup).toBe('function');
   });
 
+  // aria-describedby absent when neither description nor error present
+  test('aria-describedby is absent when neither description nor error is provided', () => {
+    const { container } = render(Wrapper, {
+      options: [{ id: 'cb-a', name: 'email', label: 'Email' }],
+    });
+    const fieldset = container.querySelector('fieldset') as HTMLFieldSetElement;
+    expect(fieldset.hasAttribute('aria-describedby')).toBe(false);
+  });
+
+  // Both description and error contribute to aria-describedby simultaneously
+  test('aria-describedby contains both description and error ids when both are provided', () => {
+    const { container } = render(Wrapper, {
+      description: 'Choose at least one',
+      error: 'Selection required',
+      options: [{ id: 'cb-a', name: 'email', label: 'Email' }],
+    });
+    const fieldset = container.querySelector('fieldset') as HTMLFieldSetElement;
+    const descriptionEl = container.querySelector('.cinder-checkbox-group__description');
+    const errorEl = container.querySelector('.cinder-checkbox-group__error');
+    expect(descriptionEl).not.toBeNull();
+    expect(errorEl).not.toBeNull();
+    const parts = (fieldset.getAttribute('aria-describedby') ?? '').split(' ');
+    expect(parts).toContain(descriptionEl?.id ?? '');
+    expect(parts).toContain(errorEl?.id ?? '');
+  });
+
   // Test 9: card variant DOM structure assertion
   test('card variant: items container has correct number of .cinder-checkbox-field children', () => {
     const { container } = render(Wrapper, {

--- a/packages/components/src/components/checkbox-group.test.ts
+++ b/packages/components/src/components/checkbox-group.test.ts
@@ -1,0 +1,176 @@
+/// <reference lib="dom" />
+import { describe, expect, test } from 'bun:test';
+
+import { setupHappyDom } from '../test/happy-dom.ts';
+
+setupHappyDom();
+
+const { render } = await import('@testing-library/svelte');
+const { default: CheckboxGroup } = await import('./checkbox-group.svelte');
+const { default: Wrapper } = await import('../test/fixtures/checkbox-group-fixture.svelte');
+
+describe('CheckboxGroup', () => {
+  // Test 1: fieldset + legend
+  test('renders a <fieldset> with the given legend', () => {
+    const { container } = render(Wrapper, {
+      legend: 'Notifications',
+      options: [
+        { id: 'cb-a', name: 'email', label: 'Email' },
+        { id: 'cb-b', name: 'sms', label: 'SMS' },
+      ],
+    });
+    expect(container.querySelector('fieldset')).not.toBeNull();
+    expect(container.querySelector('legend')?.textContent?.trim()).toBe('Notifications');
+  });
+
+  // Test 2: each checkbox keeps its own name (no shared name)
+  test('renders one checkbox per option, each keeping its own name', () => {
+    const { container } = render(Wrapper, {
+      options: [
+        { id: 'cb-a', name: 'email', label: 'Email' },
+        { id: 'cb-b', name: 'sms', label: 'SMS' },
+        { id: 'cb-c', name: 'push', label: 'Push' },
+      ],
+    });
+    const checkboxes = Array.from(container.querySelectorAll('input[type="checkbox"]'));
+    expect(checkboxes.length).toBe(3);
+    expect(checkboxes[0]?.getAttribute('name')).toBe('email');
+    expect(checkboxes[1]?.getAttribute('name')).toBe('sms');
+    expect(checkboxes[2]?.getAttribute('name')).toBe('push');
+  });
+
+  // Test 3: description renders with correct id and aria-describedby
+  test('description renders with the correct id and is referenced by aria-describedby on the fieldset', () => {
+    const { container } = render(Wrapper, {
+      description: 'Choose at least one',
+      options: [{ id: 'cb-a', name: 'email', label: 'Email' }],
+    });
+    const fieldset = container.querySelector('fieldset') as HTMLFieldSetElement;
+    const describedBy = fieldset.getAttribute('aria-describedby') ?? '';
+    // Find the description element
+    const descriptionEl = container.querySelector('.cinder-checkbox-group__description');
+    expect(descriptionEl).not.toBeNull();
+    expect(descriptionEl?.textContent?.trim()).toBe('Choose at least one');
+    // The fieldset's aria-describedby must include the description element's id
+    expect(descriptionEl?.id).toBeTruthy();
+    expect(describedBy.split(' ')).toContain(descriptionEl?.id ?? '');
+  });
+
+  // Test 4: error renders with aria-live, contributes id to fieldset, sets aria-invalid
+  test('error renders with aria-live="polite", contributes id to aria-describedby, and sets aria-invalid="true" on fieldset', () => {
+    const { container } = render(Wrapper, {
+      error: 'Select at least one option',
+      options: [{ id: 'cb-a', name: 'email', label: 'Email' }],
+    });
+    const fieldset = container.querySelector('fieldset') as HTMLFieldSetElement;
+    const errorEl = container.querySelector('.cinder-checkbox-group__error') as HTMLElement;
+    expect(errorEl).not.toBeNull();
+    expect(errorEl.getAttribute('aria-live')).toBe('polite');
+    expect(errorEl.textContent?.trim()).toBe('Select at least one option');
+    expect(fieldset.getAttribute('aria-invalid')).toBe('true');
+    const describedBy = fieldset.getAttribute('aria-describedby') ?? '';
+    expect(describedBy.split(' ')).toContain(errorEl.id);
+  });
+
+  // Test 5: disabled propagates via native fieldset cascade
+  test('disabled propagates via native fieldset cascade', () => {
+    const { container } = render(Wrapper, {
+      disabled: true,
+      options: [
+        { id: 'cb-a', name: 'email', label: 'Email' },
+        { id: 'cb-b', name: 'sms', label: 'SMS' },
+      ],
+    });
+    const fieldset = container.querySelector('fieldset') as HTMLFieldSetElement;
+    // The fieldset itself must be disabled — this is the platform contract.
+    // happy-dom does not reflect inherited disabled state onto descendant inputs
+    // (input.disabled and :disabled both return false even when the parent fieldset
+    // is disabled). The descendant cascade is tested at the browser layer.
+    expect(fieldset.disabled).toBe(true);
+  });
+
+  // Test 6: required attribute rendering — both states
+  test('required=true renders data-cinder-required; required=false omits it', () => {
+    const { container: c1 } = render(Wrapper, {
+      required: true,
+      options: [{ id: 'cb-a', name: 'email', label: 'Email' }],
+    });
+    const fieldsetRequired = c1.querySelector('fieldset') as HTMLFieldSetElement;
+    expect(fieldsetRequired.hasAttribute('data-cinder-required')).toBe(true);
+    // No child input should have required set
+    const inputs1 = Array.from(c1.querySelectorAll('input[type="checkbox"]'));
+    inputs1.forEach((input) => {
+      expect((input as HTMLInputElement).required).toBe(false);
+    });
+
+    const { container: c2 } = render(Wrapper, {
+      required: false,
+      options: [{ id: 'cb-b', name: 'email', label: 'Email' }],
+    });
+    const fieldsetNotRequired = c2.querySelector('fieldset') as HTMLFieldSetElement;
+    expect(fieldsetNotRequired.hasAttribute('data-cinder-required')).toBe(false);
+  });
+
+  // Test 7: variant data attribute always present
+  test('data-variant="default" is emitted by default', () => {
+    const { container } = render(Wrapper, {
+      options: [{ id: 'cb-a', name: 'email', label: 'Email' }],
+    });
+    const fieldset = container.querySelector('fieldset') as HTMLFieldSetElement;
+    expect(fieldset.getAttribute('data-variant')).toBe('default');
+  });
+
+  test('data-variant="card" is emitted when variant="card"', () => {
+    const { container } = render(Wrapper, {
+      variant: 'card',
+      options: [{ id: 'cb-a', name: 'email', label: 'Email' }],
+    });
+    const fieldset = container.querySelector('fieldset') as HTMLFieldSetElement;
+    expect(fieldset.getAttribute('data-variant')).toBe('card');
+  });
+
+  // Test 8: value export smoke test — import the component directly rather
+  // than the full index to avoid triggering compilation of all components.
+  test('CheckboxGroup is exported as a function', () => {
+    expect(typeof CheckboxGroup).toBe('function');
+  });
+
+  // Test 9: card variant DOM structure assertion
+  test('card variant: items container has correct number of .cinder-checkbox-field children', () => {
+    const { container } = render(Wrapper, {
+      variant: 'card',
+      options: [
+        { id: 'cb-a', name: 'email', label: 'Email' },
+        { id: 'cb-b', name: 'sms', label: 'SMS' },
+        { id: 'cb-c', name: 'push', label: 'Push' },
+      ],
+    });
+    const items = container.querySelector('.cinder-checkbox-group__items');
+    expect(items).not.toBeNull();
+    const directChildren = Array.from(items?.children ?? []);
+    expect(directChildren.length).toBe(3);
+    directChildren.forEach((child) => {
+      expect(child.classList.contains('cinder-checkbox-field')).toBe(true);
+    });
+  });
+
+  // Test 10: disabled-label selector contract
+  test('disabled fieldset contains .cinder-checkbox-field__label elements as descendants', () => {
+    const { container } = render(Wrapper, {
+      disabled: true,
+      options: [
+        { id: 'cb-a', name: 'email', label: 'Email' },
+        { id: 'cb-b', name: 'sms', label: 'SMS' },
+      ],
+    });
+    const fieldset = container.querySelector('fieldset') as HTMLFieldSetElement;
+    // Fieldset is [disabled]
+    expect(fieldset.matches('[disabled]')).toBe(true);
+    // Every label element is a descendant of the disabled fieldset
+    const labels = Array.from(container.querySelectorAll('.cinder-checkbox-field__label'));
+    expect(labels.length).toBeGreaterThan(0);
+    labels.forEach((label) => {
+      expect(fieldset.contains(label)).toBe(true);
+    });
+  });
+});

--- a/packages/components/src/components/checkbox-group.test.ts
+++ b/packages/components/src/components/checkbox-group.test.ts
@@ -156,9 +156,13 @@ describe('CheckboxGroup', () => {
     const errorEl = container.querySelector('.cinder-checkbox-group__error');
     expect(descriptionEl).not.toBeNull();
     expect(errorEl).not.toBeNull();
+    // Assert IDs are non-empty before using them in containment checks,
+    // matching the pattern in Test 3. ?. + ?? '' would silently pass if IDs are empty.
+    expect(descriptionEl?.id).toBeTruthy();
+    expect(errorEl?.id).toBeTruthy();
     const parts = (fieldset.getAttribute('aria-describedby') ?? '').split(' ');
-    expect(parts).toContain(descriptionEl?.id ?? '');
-    expect(parts).toContain(errorEl?.id ?? '');
+    expect(parts).toContain(descriptionEl!.id);
+    expect(parts).toContain(errorEl!.id);
   });
 
   // Test 9: card variant DOM structure assertion

--- a/packages/components/src/components/description-list.a11y.md
+++ b/packages/components/src/components/description-list.a11y.md
@@ -28,7 +28,7 @@ Any interactive element rendered through the `actions` snippet **must** set an `
 {/snippet}
 ```
 
-Bare "Edit" or "Delete" labels violate WCAG 2.4.4 (Link Purpose in Context) when stripped from surrounding text. The `actions` snippet receives the full `DescriptionListItem` to make disambiguation ergonomic.
+Bare "Edit" or "Delete" labels violate [WCAG 2.4.4 Link Purpose in Context](https://www.w3.org/WAI/WCAG21/Understanding/link-purpose-in-context.html) when stripped from surrounding text. The `actions` snippet receives the full `DescriptionListItem` to make disambiguation ergonomic.
 
 ## Keying and Duplicate Terms
 

--- a/packages/components/src/components/radio-group.a11y.md
+++ b/packages/components/src/components/radio-group.a11y.md
@@ -33,7 +33,7 @@ Fieldset-level descriptions (`RadioGroupProps.description`) and per-option descr
 
 **The card border is decorative reinforcement, not the sole indicator of selection.** The native checked-state dot (`.cinder-radio:checked` background SVG) remains the primary indicator. Forced-colors mode uses border weight (`1px → 2px`) and the `Highlight` system color to ensure a non-color indicator is always present.
 
-**Activation surface is the native `<input>` + `<label for=…>` pair.** The card padding is intentionally modest (`--cinder-space-3`) to minimise the gap between the visible card edge and the clickable area. Whole-card activation (click anywhere on the card to select the radio) is a known follow-up and is explicitly out of scope for this variant — it would require either a wrapping `<label>` or JavaScript pointer handling, both of which affect the WAI-ARIA keyboard model and WCAG 2.5.3 (Label in Name).
+**Activation surface is the native `<input>` + `<label for=…>` pair.** The card padding is intentionally modest (`--cinder-space-3`) to minimise the gap between the visible card edge and the clickable area. Whole-card activation (click anywhere on the card to select the radio) is a known follow-up and is explicitly out of scope for this variant — it would require either a wrapping `<label>` or JavaScript pointer handling, both of which affect the WAI-ARIA keyboard model and [WCAG 2.5.3 Label in Name](https://www.w3.org/WAI/WCAG21/Understanding/label-in-name.html).
 
 ## `aria-invalid`
 

--- a/packages/components/src/components/stacked-list-item.a11y.md
+++ b/packages/components/src/components/stacked-list-item.a11y.md
@@ -34,7 +34,7 @@ If you need the entire row to be clickable, wrap the row in an explicit interact
 
 ## Disambiguated Action Labels
 
-When the `trailing` snippet contains interactive controls — "Edit", "Delete", "View", etc. — the accessible name of each control must identify the specific row. Screen readers reading row-by-row otherwise announce a stream of identical button labels, violating WCAG 2.4.6 (Headings and Labels) and WCAG 2.4.4 (Link Purpose in Context).
+When the `trailing` snippet contains interactive controls — "Edit", "Delete", "View", etc. — the accessible name of each control must identify the specific row. Screen readers reading row-by-row otherwise announce a stream of identical button labels, violating [WCAG 2.4.6 Headings and Labels](https://www.w3.org/WAI/WCAG21/Understanding/headings-and-labels.html) and [WCAG 2.4.4 Link Purpose in Context](https://www.w3.org/WAI/WCAG21/Understanding/link-purpose-in-context.html).
 
 ```svelte
 {#snippet trailing()}
@@ -57,8 +57,8 @@ If `trailing` contains interactive elements alongside a linked title, both are s
 
 The component cannot enforce minimum touch target sizes on `trailing` content because that region is consumer-supplied markup. Two separate WCAG criteria apply:
 
-- **WCAG 2.5.8 Target Size (Minimum)** — Level AA — requires at least 24×24 CSS pixels, with documented exceptions and a spacing allowance for smaller targets. This is the **baseline**.
-- **WCAG 2.5.5 Target Size (Enhanced)** — Level AAA — recommends at least 44×44 CSS pixels for pointer-input targets. This is the **recommendation** for comfortable interaction.
+- **[WCAG 2.5.8 Target Size (Minimum)](https://www.w3.org/WAI/WCAG22/Understanding/target-size-minimum.html)** — Level AA — requires at least 24×24 CSS pixels, with documented exceptions and a spacing allowance for smaller targets. This is the **baseline**.
+- **[WCAG 2.5.5 Target Size (Enhanced)](https://www.w3.org/WAI/WCAG21/Understanding/target-size.html)** — Level AAA — recommends at least 44×44 CSS pixels for pointer-input targets. This is the **recommendation** for comfortable interaction.
 
 Condensed density reduces row padding; it does not reduce trailing control dimensions. Consumers must ensure their trailing controls independently satisfy the applicable target size criterion.
 

--- a/packages/components/src/components/textarea.a11y.md
+++ b/packages/components/src/components/textarea.a11y.md
@@ -10,7 +10,7 @@ When the `label` prop is provided, a `<label for={id}>` is rendered. The `for` a
 
 - Gives the textarea an accessible name announced by screen readers on focus.
 - Expands the click target — clicking the label text moves focus to the textarea.
-- Is required for WCAG 2.1 SC 1.3.1 (Info and Relationships) and SC 4.1.2 (Name, Role, Value).
+- Is required for [WCAG 2.1 SC 1.3.1 Info and Relationships](https://www.w3.org/WAI/WCAG21/Understanding/info-and-relationships.html) and [SC 4.1.2 Name, Role, Value](https://www.w3.org/WAI/WCAG21/Understanding/name-role-value.html).
 
 The `id` prop is required on `TextareaProps` and intentionally has no default, enforcing uniqueness at the call site.
 
@@ -40,7 +40,7 @@ No custom keyboard handling is added; the browser's native textarea behaviour is
 
 ## Focus Visibility
 
-The textarea's `:focus-visible` style renders a `box-shadow` ring (2 px offset + ring width) using `--cinder-ring-color` (defaults to the accent colour). In Forced Colors Mode (Windows High Contrast, print), `box-shadow` is suppressed by the browser, so a `@media (forced-colors: active)` block substitutes a solid `outline` on `ButtonText` to maintain a visible focus indicator per WCAG 2.1 SC 2.4.7.
+The textarea's `:focus-visible` style renders a `box-shadow` ring (2 px offset + ring width) using `--cinder-ring-color` (defaults to the accent colour). In Forced Colors Mode (Windows High Contrast, print), `box-shadow` is suppressed by the browser, so a `@media (forced-colors: active)` block substitutes a solid `outline` on `ButtonText` to maintain a visible focus indicator per [WCAG 2.1 SC 2.4.7 Focus Visible](https://www.w3.org/WAI/WCAG21/Understanding/focus-visible.html).
 
 ## Disabled State
 
@@ -79,12 +79,12 @@ The count uses JavaScript string length (UTF-16 code units), matching the browse
 
 ## WCAG 2.1 Compliance Summary
 
-| Success Criterion            | Level | Satisfied by                                                                                                                  |
-| ---------------------------- | ----- | ----------------------------------------------------------------------------------------------------------------------------- |
-| 1.3.1 Info and Relationships | A     | `<label for>` association                                                                                                     |
-| 1.3.5 Identify Input Purpose | AA    | Native `<textarea>` with `autocomplete` passthrough via `...rest`                                                             |
-| 2.4.7 Focus Visible          | AA    | `:focus-visible` ring; WHCM fallback outline                                                                                  |
-| 3.3.1 Error Identification   | A     | `aria-invalid="true"` + visible error `<p>`                                                                                   |
-| 3.3.2 Labels or Instructions | A     | Rendered `<label>` + optional description `<p>`                                                                               |
-| 4.1.2 Name, Role, Value      | A     | Native `<textarea>` with programmatic label                                                                                   |
-| 4.1.3 Status Messages        | AA    | Error `<p aria-live="polite">` as live region; count `<output aria-live="polite" aria-atomic="true">` when `showCount` is set |
+| Success Criterion                                                                                       | Level | Satisfied by                                                                                                                  |
+| ------------------------------------------------------------------------------------------------------- | ----- | ----------------------------------------------------------------------------------------------------------------------------- |
+| [1.3.1 Info and Relationships](https://www.w3.org/WAI/WCAG21/Understanding/info-and-relationships.html) | A     | `<label for>` association                                                                                                     |
+| [1.3.5 Identify Input Purpose](https://www.w3.org/WAI/WCAG21/Understanding/identify-input-purpose.html) | AA    | Native `<textarea>` with `autocomplete` passthrough via `...rest`                                                             |
+| [2.4.7 Focus Visible](https://www.w3.org/WAI/WCAG21/Understanding/focus-visible.html)                   | AA    | `:focus-visible` ring; WHCM fallback outline                                                                                  |
+| [3.3.1 Error Identification](https://www.w3.org/WAI/WCAG21/Understanding/error-identification.html)     | A     | `aria-invalid="true"` + visible error `<p>`                                                                                   |
+| [3.3.2 Labels or Instructions](https://www.w3.org/WAI/WCAG21/Understanding/labels-or-instructions.html) | A     | Rendered `<label>` + optional description `<p>`                                                                               |
+| [4.1.2 Name, Role, Value](https://www.w3.org/WAI/WCAG21/Understanding/name-role-value.html)             | A     | Native `<textarea>` with programmatic label                                                                                   |
+| [4.1.3 Status Messages](https://www.w3.org/WAI/WCAG21/Understanding/status-messages.html)               | AA    | Error `<p aria-live="polite">` as live region; count `<output aria-live="polite" aria-atomic="true">` when `showCount` is set |

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -28,6 +28,9 @@ export type { ChatProps } from './components/chat.svelte';
 export { default as Checkbox } from './components/checkbox.svelte';
 export type { CheckboxProps } from './components/checkbox.svelte';
 
+export { default as CheckboxGroup } from './components/checkbox-group.svelte';
+export type { CheckboxGroupProps } from './components/checkbox-group.svelte';
+
 export { default as CodeBlock } from './components/code-block.svelte';
 export type { CodeBlockProps } from './components/code-block.svelte';
 

--- a/packages/components/src/styles/components.css
+++ b/packages/components/src/styles/components.css
@@ -13,6 +13,7 @@
 @import './components/button.css';
 @import './components/card.css';
 @import './components/checkbox.css';
+@import './components/checkbox-group.css';
 @import './components/code-block.css';
 @import './components/combobox.css';
 @import './components/command-palette.css';

--- a/packages/components/src/styles/components/checkbox-group.css
+++ b/packages/components/src/styles/components/checkbox-group.css
@@ -1,0 +1,94 @@
+/* ========================================
+ * CHECKBOX GROUP
+ * Fieldset wrapper + child Checkbox items.
+ * ======================================== */
+
+.cinder-checkbox-group {
+  border: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--cinder-space-2);
+}
+
+.cinder-checkbox-group__legend {
+  font-size: var(--cinder-text-xs);
+  font-weight: var(--cinder-font-medium);
+  color: var(--cinder-text);
+  padding: 0;
+  margin: 0 0 var(--cinder-space-1) 0;
+}
+
+.cinder-checkbox-group[disabled] .cinder-checkbox-group__legend {
+  color: var(--cinder-text-disabled);
+}
+
+/* When the group is disabled via native fieldset cascade, dim the label.
+ * checkbox.css styles .cinder-checkbox-field__label via [data-disabled] which
+ * is set from the per-Checkbox prop — not from the inherited fieldset state.
+ * This companion rule fixes the gap without editing checkbox.css. */
+.cinder-checkbox-group[disabled] .cinder-checkbox-field__label {
+  color: var(--cinder-text-disabled);
+  cursor: not-allowed;
+}
+
+.cinder-checkbox-group__items {
+  display: flex;
+  flex-direction: column;
+  gap: var(--cinder-space-2);
+}
+
+.cinder-checkbox-group__description {
+  font-size: var(--cinder-text-xs);
+  line-height: var(--cinder-leading-normal);
+  color: var(--cinder-text-muted);
+  margin: 0;
+}
+
+.cinder-checkbox-group__error {
+  font-size: var(--cinder-text-xs);
+  line-height: var(--cinder-leading-normal);
+  color: var(--cinder-danger);
+  margin: 0;
+}
+
+/* ========================================
+ * CARD VARIANT
+ * ======================================== */
+
+.cinder-checkbox-group[data-variant='card'] .cinder-checkbox-group__items > .cinder-checkbox-field {
+  border: 1px solid var(--cinder-border);
+  border-radius: var(--cinder-radius-md);
+  padding: var(--cinder-space-3);
+  transition:
+    border-color var(--cinder-duration-fast) var(--cinder-ease-standard),
+    background var(--cinder-duration-fast) var(--cinder-ease-standard);
+}
+
+.cinder-checkbox-group[data-variant='card']
+  .cinder-checkbox-group__items
+  > .cinder-checkbox-field:hover {
+  border-color: var(--cinder-border-strong);
+}
+
+/* Checked highlight — additive only; the check glyph is the canonical indicator. */
+.cinder-checkbox-group[data-variant='card']
+  .cinder-checkbox-group__items
+  > .cinder-checkbox-field:has(input:checked) {
+  border-color: var(--cinder-accent);
+}
+
+@media (forced-colors: active) {
+  .cinder-checkbox-group[data-variant='card']
+    .cinder-checkbox-group__items
+    > .cinder-checkbox-field {
+    border: 1px solid CanvasText;
+  }
+
+  .cinder-checkbox-group[data-variant='card']
+    .cinder-checkbox-group__items
+    > .cinder-checkbox-field:has(input:checked) {
+    border: 2px solid Highlight;
+  }
+}

--- a/packages/components/src/styles/components/checkbox-group.css
+++ b/packages/components/src/styles/components/checkbox-group.css
@@ -61,6 +61,7 @@
   border: 1px solid var(--cinder-border);
   border-radius: var(--cinder-radius-md);
   padding: var(--cinder-space-3);
+  background: var(--cinder-surface-raised);
   transition:
     border-color var(--cinder-duration-fast) var(--cinder-ease-standard),
     background var(--cinder-duration-fast) var(--cinder-ease-standard);

--- a/packages/components/src/styles/components/checkbox-group.css
+++ b/packages/components/src/styles/components/checkbox-group.css
@@ -79,6 +79,22 @@
   border-color: var(--cinder-accent);
 }
 
+/* Disabled card — uses :has(input:disabled) because disabled state arrives via
+ * native fieldset cascade, not a data attribute on the card element. */
+.cinder-checkbox-group[data-variant='card']
+  .cinder-checkbox-group__items
+  > .cinder-checkbox-field:has(input:disabled) {
+  background: var(--cinder-surface-inset);
+  border-color: var(--cinder-border-muted);
+  cursor: not-allowed;
+}
+
+.cinder-checkbox-group[data-variant='card']
+  .cinder-checkbox-group__items
+  > .cinder-checkbox-field:has(input:disabled):hover {
+  border-color: var(--cinder-border-muted);
+}
+
 @media (forced-colors: active) {
   .cinder-checkbox-group[data-variant='card']
     .cinder-checkbox-group__items

--- a/packages/components/src/test/fixtures/checkbox-group-fixture.svelte
+++ b/packages/components/src/test/fixtures/checkbox-group-fixture.svelte
@@ -1,0 +1,57 @@
+<script lang="ts" module>
+  /** Test-only fixture: composes CheckboxGroup with N Checkbox children for testing. */
+  export type CheckboxGroupFixtureProps = {
+    legend?: string;
+    description?: string;
+    error?: string;
+    disabled?: boolean;
+    required?: boolean;
+    variant?: 'default' | 'card';
+    options: Array<{
+      id: string;
+      /** Each checkbox owns its own name — not shared across the group. */
+      name: string;
+      label: string;
+      value?: string;
+      checked?: boolean;
+      description?: string;
+      disabled?: boolean;
+    }>;
+  };
+</script>
+
+<script lang="ts">
+  import CheckboxGroup from '../../components/checkbox-group.svelte';
+  import Checkbox from '../../components/checkbox.svelte';
+
+  let {
+    legend,
+    description,
+    error,
+    disabled = false,
+    required = false,
+    variant,
+    options,
+  }: CheckboxGroupFixtureProps = $props();
+</script>
+
+<CheckboxGroup
+  {...legend !== undefined ? { legend } : {}}
+  {...description !== undefined ? { description } : {}}
+  {...error !== undefined ? { error } : {}}
+  {...variant !== undefined ? { variant } : {}}
+  {disabled}
+  {required}
+>
+  {#each options as option (option.id)}
+    <Checkbox
+      id={option.id}
+      name={option.name}
+      label={option.label}
+      {...option.value !== undefined ? { value: option.value } : {}}
+      {...option.checked !== undefined ? { checked: option.checked } : {}}
+      {...option.description !== undefined ? { description: option.description } : {}}
+      {...option.disabled !== undefined ? { disabled: option.disabled } : {}}
+    />
+  {/each}
+</CheckboxGroup>


### PR DESCRIPTION
## Summary
- Added `data-cinder-disabled={disabled || undefined}` to `CheckboxGroup` so system-level styling tokens receive a consistent disabled signal alongside native `fieldset` disabling.
- Added card-variant disabled visual rules in `checkbox-group.css` (`:has(input:disabled)`) for muted surfaces, border, cursor state, and hover suppression.
- Expanded `CheckboxGroup` tests to verify `aria-describedby` is omitted when no description/error exists and includes both description+error IDs when both are present.

## Review committee
Pre-reviewed by: typescript-expert, testing-expert, ux-designer, simplicity-engineer, prose-editor, junior-engineer, Codex (gpt-5.4 / xhigh)
- Codex (gpt-5.4 / xhigh) — 2 rounds
- 2 rounds of review
- All must-fix items addressed

## Test plan
- bun test packages/components/src/components/checkbox-group.test.ts
- bun test packages/components/src/utilities/use-reduced-motion.svelte.test.ts
- bun run lint

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new exported UI component plus new CSS using `:has()` selectors; regressions would primarily be visual/a11y behavior for grouped checkboxes and cross-browser styling support.
> 
> **Overview**
> Adds a new `CheckboxGroup` component (exported via package `exports` + `src/index.ts`) that wraps checkbox children in a native `<fieldset>/<legend>` and wires group-level `aria-invalid`/`aria-describedby`, `data-cinder-disabled`, `data-cinder-required`, and `data-variant`.
> 
> Includes new `checkbox-group.css` (imported into `components.css`) with a `card` variant, forced-colors support, and disabled-state visuals that follow native fieldset disable propagation (via `:has(input:disabled)`). Adds a fixture and comprehensive tests around legend rendering, per-checkbox independence, `aria-describedby` composition/omission, and variant/disabled contracts.
> 
> Also updates several a11y/policy docs to replace plain WCAG references with direct links (and links the Svelte 5 docs in `OVERLAY-POLICY.md`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d323bd3757d3fd43fdab0e62cb245946c9ae5618. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->