### PR TITLE
Improve NavigationBar and NavigationItem APIs for mobile menu and item variants

### DIFF
--- a/packages/components/fixtures/sveltekit-consumer/src/routes/+page.svelte
+++ b/packages/components/fixtures/sveltekit-consumer/src/routes/+page.svelte
@@ -92,7 +92,8 @@
 
   <section aria-label="NavigationBar">
     <NavigationBar>
-      {#snippet items()}<NavigationItem href="/">Home</NavigationItem>{/snippet}
+      {#snippet items({ variant })}<NavigationItem {variant} href="/">Home</NavigationItem
+        >{/snippet}
     </NavigationBar>
   </section>
 

--- a/packages/components/src/components/command-palette.a11y.md
+++ b/packages/components/src/components/command-palette.a11y.md
@@ -11,12 +11,12 @@ Reference: [WAI-ARIA APG Combobox Pattern](https://www.w3.org/WAI/ARIA/apg/patte
 
 ## Roles and Accessible Names
 
-| Element | Role | Accessible Name Source |
-|---------|------|------------------------|
-| `<dialog>` | `dialog` (implicit) | `aria-label` from the `label` prop |
-| `<input>` | `combobox` (explicit) | Visually-hidden `<label>` element (text from `label` prop) |
-| `<ul>` | `listbox` (explicit) | No `aria-label`; the combobox owns the listbox via `aria-controls`, and virtual focus is communicated via `aria-activedescendant` |
-| `<li>` | `option` (explicit) | Text content of the `children` snippet |
+| Element    | Role                  | Accessible Name Source                                                                                                            |
+| ---------- | --------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
+| `<dialog>` | `dialog` (implicit)   | `aria-label` from the `label` prop                                                                                                |
+| `<input>`  | `combobox` (explicit) | Visually-hidden `<label>` element (text from `label` prop)                                                                        |
+| `<ul>`     | `listbox` (explicit)  | No `aria-label`; the combobox owns the listbox via `aria-controls`, and virtual focus is communicated via `aria-activedescendant` |
+| `<li>`     | `option` (explicit)   | Text content of the `children` snippet                                                                                            |
 
 ## Virtual Focus Model
 
@@ -33,16 +33,16 @@ Invariants asserted in tests:
 
 ## Keyboard Contract
 
-| Key | Behavior |
-|-----|----------|
-| `ArrowDown` | Move active item to next non-disabled; wrap to first if at end. `preventDefault`. |
-| `ArrowUp` | Move active item to previous non-disabled; wrap to last. `preventDefault`. |
-| `Home` | Move active item to first non-disabled. `preventDefault` (prevents caret jump). |
-| `End` | Move active item to last non-disabled. `preventDefault`. |
-| `Enter` | Invoke the active item's `onselect`. `preventDefault` (prevents form submission). |
-| `Escape` | Close the palette via the shared escape stack. Single-sourced through `closePalette()`. |
+| Key                 | Behavior                                                                                                         |
+| ------------------- | ---------------------------------------------------------------------------------------------------------------- |
+| `ArrowDown`         | Move active item to next non-disabled; wrap to first if at end. `preventDefault`.                                |
+| `ArrowUp`           | Move active item to previous non-disabled; wrap to last. `preventDefault`.                                       |
+| `Home`              | Move active item to first non-disabled. `preventDefault` (prevents caret jump).                                  |
+| `End`               | Move active item to last non-disabled. `preventDefault`.                                                         |
+| `Enter`             | Invoke the active item's `onselect`. `preventDefault` (prevents form submission).                                |
+| `Escape`            | Close the palette via the shared escape stack. Single-sourced through `closePalette()`.                          |
 | `Tab` / `Shift+Tab` | Native `<dialog>` focus trap (browser-level). Focus cycles through interactive elements in the panel and footer. |
-| Typing | Updates `query` (bindable). Items snippet re-renders with the new query. |
+| Typing              | Updates `query` (bindable). Items snippet re-renders with the new query.                                         |
 
 ## Mouse / Pointer Parity
 

--- a/packages/components/src/components/navigation-bar.a11y.md
+++ b/packages/components/src/components/navigation-bar.a11y.md
@@ -57,7 +57,7 @@ If a consumer wraps the toggle in a custom component without ensuring the native
 
 ## Route-Change Auto-Close
 
-The component has no router dependency. Consumers using a client-side router (SvelteKit, etc.) should subscribe to route-change events and set `bind:mobileMenuOpen` to `false` when the route changes. Example:
+The component has no router dependency. Consumers using a client-side router ([SvelteKit](https://kit.svelte.dev), etc.) should subscribe to route-change events and set `bind:mobileMenuOpen` to `false` when the route changes. Example:
 
 ```svelte
 <script>

--- a/packages/components/src/components/navigation-bar.a11y.md
+++ b/packages/components/src/components/navigation-bar.a11y.md
@@ -1,0 +1,100 @@
+# NavigationBar Accessibility
+
+## Landmark Labeling
+
+`NavigationBar` renders a `<nav>` landmark. The accessible name is set via the `navAriaLabel` prop, which defaults to `"Main navigation"`. Pages with more than one `<nav>` landmark must pass distinct values so screen reader users can distinguish them when jumping between landmarks.
+
+The `navAriaLabel` prop always wins over any `aria-label` passed via rest props. The rest `aria-label` is stripped before spreading to prevent silent collisions.
+
+## Mobile Toggle Contract
+
+When a `menuToggle` snippet is provided, the component injects a `NavigationBarToggleAttributes` object into the snippet as its parameter:
+
+```ts
+type NavigationBarToggleAttributes = {
+  'aria-expanded': 'true' | 'false';
+  'aria-controls': string; // the id of the collapsible items region
+  onclick: (event: MouseEvent) => void;
+};
+```
+
+The consumer is responsible for:
+
+1. Spreading these attributes onto a native `<button>` element.
+2. Giving the button a meaningful accessible name via `aria-label` (e.g., `"Open menu"` / `"Close menu"`) or visible text.
+
+`aria-expanded` reflects `mobileMenuOpen`. `aria-controls` points at the items region's `id` so assistive technologies can identify the controlled region. The component manages both values internally.
+
+## Keyboard Interactions
+
+| Key    | Behavior                                                                                                         |
+| ------ | ---------------------------------------------------------------------------------------------------------------- |
+| Tab    | Moves focus through items and actions in DOM order.                                                              |
+| Escape | Closes the mobile menu when open. Scoped to the `<nav>` element—Escape pressed outside the navbar has no effect. |
+
+### Scoped Escape behavior
+
+The Escape handler is attached to the `<nav>` element rather than `<svelte:window>`. This means Escape only closes the menu when focus is inside the navbar, avoiding interference with dialogs, comboboxes, or other disclosures elsewhere on the page.
+
+### Cooperative Escape semantics
+
+If a component inside the navbar (a search field, combobox, or nested disclosure) calls `event.preventDefault()` on a keydown event, the menu's Escape handler is skipped. This lets nested interactive widgets own their own Escape behavior without fighting the navbar's dismiss logic.
+
+Consumer `onkeydown` handlers passed via rest props are also respected: the consumer handler runs _first_, and if it calls `preventDefault()`, the internal close is cancelled.
+
+## Focus Return
+
+When the user presses Escape to close the menu, focus is returned to the toggle button that opened it. This focus-return guarantee requires that the consumer's `menuToggle` snippet spreads `toggleAttributes.onclick` onto a native `<button>` element so `event.currentTarget` is a real focusable DOM element.
+
+If a consumer wraps the toggle in a custom component without ensuring the native button receives `onclick` directly, Escape still closes the menu but focus does not move. This is a documented degradation, not a bug.
+
+## Disclosure, Not Modal
+
+`NavigationBar` implements the ARIA disclosure pattern. The mobile items panel is not a modal:
+
+- There is no focus trap. Tab order continues naturally from the toggle, through the items, to the actions, and off the navbar.
+- Clicking outside the navbar does not close the menu. This is intentional: top-of-page navigation bars are not menus, and outside-click close can swallow scroll-region clicks and surprise users. Consumers who need outside-click close should attach a document-level click listener themselves and set `mobileMenuOpen = false`.
+
+## Route-Change Auto-Close
+
+The component has no router dependency. Consumers using a client-side router (SvelteKit, etc.) should subscribe to route-change events and set `bind:mobileMenuOpen` to `false` when the route changes. Example:
+
+```svelte
+<script>
+  import { page } from '$app/state';
+  let mobileMenuOpen = $state(false);
+
+  $effect(() => {
+    // Close the menu on every navigation.
+    page.url;
+    mobileMenuOpen = false;
+  });
+</script>
+
+<NavigationBar bind:mobileMenuOpen>
+  {#snippet menuToggle(attrs)}
+    <button {...attrs} aria-label="Open menu">Menu</button>
+  {/snippet}
+  ...
+</NavigationBar>
+```
+
+## Visibility and Focus Tree
+
+The items panel uses `visibility: hidden` (not `display: none` or `inert`) when closed. `visibility: hidden` removes the panel and its children from the accessibility tree immediately when the menu closes, without waiting for the CSS transition to complete. This means:
+
+- Hidden items cannot receive focus.
+- Screen readers do not announce hidden items.
+- The transition affects only the opening animation; closing is visually instant (which is intentional—accessibility wins over the close animation).
+
+## Reduced Motion
+
+When `prefers-reduced-motion: reduce` is active, all panel transitions are disabled. The panel still opens and closes; it simply does not animate.
+
+## Forced Colors (High Contrast Mode)
+
+The mobile items panel retains a visible `border-bottom` using the `CanvasText` system color in Forced Colors Mode, ensuring the panel boundary remains visible without relying on `box-shadow` or `background-color` (both of which are overridden by the forced color palette).
+
+## Actions Outside the Panel
+
+The `actions` snippet renders _outside_ the collapsible panel by design. Primary action buttons (sign-in, CTAs) remain visible even when the menu is closed. Sites whose actions are numerous or large can place them inside the `items` snippet instead—the component does not enforce a single layout.

--- a/packages/components/src/components/navigation-bar.svelte
+++ b/packages/components/src/components/navigation-bar.svelte
@@ -46,42 +46,23 @@
     // Strip these from rest so they cannot collide with internal attributes.
     'aria-label': _ariaLabel,
     'data-collapsible': _dataCollapsible,
-    'data-mobile-open': _dataMobileOpen,
     onkeydown: consumerOnKeyDown,
     ...rest
   }: NavigationBarProps = $props();
 
   const regionId = useId('cinder-navigation-bar');
 
-  const isCollapsible = $derived(menuToggle !== undefined);
-
   const variant: NavigationVariant = $derived(
-    isCollapsible && mobileMenuOpen ? 'mobile' : 'horizontal',
+    menuToggle !== undefined && mobileMenuOpen ? 'mobile' : 'horizontal',
   );
-
-  const toggleAttributes = $derived({
-    'aria-expanded': (mobileMenuOpen ? 'true' : 'false') as 'true' | 'false',
-    'aria-controls': regionId,
-    onclick: handleToggle,
-  } satisfies NavigationBarToggleAttributes);
 
   // Stores the toggle element for focus return after Escape-close.
   let toggleElement: HTMLElement | null = null;
-  // Tracks whether the menu was closed by Escape so we can return focus.
-  let closedByEscape = $state(false);
 
   function handleToggle(event: MouseEvent): void {
     mobileMenuOpen = !mobileMenuOpen;
     toggleElement = event.currentTarget as HTMLElement | null;
   }
-
-  $effect(() => {
-    // Return focus to the toggle when the menu is closed via Escape.
-    if (!mobileMenuOpen && closedByEscape) {
-      toggleElement?.focus();
-      closedByEscape = false;
-    }
-  });
 
   function handleKeyDown(event: KeyboardEvent): void {
     // Consumer handler runs first; if it cancels, skip the internal close.
@@ -89,8 +70,9 @@
       (consumerOnKeyDown as (e: KeyboardEvent) => void)(event);
     }
     if (event.key === 'Escape' && mobileMenuOpen && !event.defaultPrevented) {
-      closedByEscape = true;
       mobileMenuOpen = false;
+      // Return focus synchronously — toggleElement is captured on each click.
+      toggleElement?.focus();
     }
   }
 </script>
@@ -99,8 +81,7 @@
   {...rest}
   aria-label={navAriaLabel}
   class={cn('cinder-navigation-bar', className)}
-  data-collapsible={isCollapsible ? 'true' : 'false'}
-  data-mobile-open={mobileMenuOpen ? 'true' : 'false'}
+  data-collapsible={menuToggle !== undefined ? 'true' : 'false'}
   onkeydown={handleKeyDown}
 >
   {#if brand}
@@ -111,7 +92,11 @@
 
   {#if menuToggle}
     <div class="cinder-navigation-bar__menu-toggle">
-      {@render menuToggle(toggleAttributes)}
+      {@render menuToggle({
+        'aria-expanded': (mobileMenuOpen ? 'true' : 'false') as 'true' | 'false',
+        'aria-controls': regionId,
+        onclick: handleToggle,
+      })}
     </div>
   {/if}
 

--- a/packages/components/src/components/navigation-bar.svelte
+++ b/packages/components/src/components/navigation-bar.svelte
@@ -2,29 +2,125 @@
   import type { Snippet } from 'svelte';
   import type { HTMLAttributes } from 'svelte/elements';
 
+  export type NavigationVariant = 'horizontal' | 'mobile';
+
+  /** Attributes injected into the consumer's toggle button via the menuToggle snippet parameter. */
+  export type NavigationBarToggleAttributes = {
+    'aria-expanded': 'true' | 'false';
+    'aria-controls': string;
+    onclick: (event: MouseEvent) => void;
+  };
+
+  /** Context passed to the items snippet so items can adapt their layout. */
+  export type NavigationBarItemsContext = {
+    variant: NavigationVariant;
+  };
+
   export type NavigationBarProps = HTMLAttributes<HTMLElement> & {
     class?: string;
     brand?: Snippet;
-    items: Snippet;
+    /** Receives a context object with the current variant. */
+    items: Snippet<[NavigationBarItemsContext]>;
     actions?: Snippet;
+    /** Snippet receiving toggle button attributes. Consumer renders the actual <button>. */
+    menuToggle?: Snippet<[NavigationBarToggleAttributes]>;
+    /** Two-way bindable open state of the mobile menu. */
+    mobileMenuOpen?: boolean;
+    /** Accessible name for the <nav> landmark. Wins over any aria-label passed via rest. Default 'Main navigation'. */
+    navAriaLabel?: string;
   };
 </script>
 
 <script lang="ts">
   import { cn } from '../utilities/class-names.ts';
+  import { useId } from '../utilities/use-id.ts';
 
-  let { class: className, brand, items, actions, ...rest }: NavigationBarProps = $props();
+  let {
+    class: className,
+    brand,
+    items,
+    actions,
+    menuToggle,
+    mobileMenuOpen = $bindable(false),
+    navAriaLabel = 'Main navigation',
+    // Strip these from rest so they cannot collide with internal attributes.
+    'aria-label': _ariaLabel,
+    'data-collapsible': _dataCollapsible,
+    'data-mobile-open': _dataMobileOpen,
+    onkeydown: consumerOnKeyDown,
+    ...rest
+  }: NavigationBarProps = $props();
+
+  const regionId = useId('cinder-navigation-bar');
+
+  const isCollapsible = $derived(menuToggle !== undefined);
+
+  const variant: NavigationVariant = $derived(
+    isCollapsible && mobileMenuOpen ? 'mobile' : 'horizontal',
+  );
+
+  const toggleAttributes = $derived({
+    'aria-expanded': (mobileMenuOpen ? 'true' : 'false') as 'true' | 'false',
+    'aria-controls': regionId,
+    onclick: handleToggle,
+  } satisfies NavigationBarToggleAttributes);
+
+  // Stores the toggle element for focus return after Escape-close.
+  let toggleElement: HTMLElement | null = null;
+  // Tracks whether the menu was closed by Escape so we can return focus.
+  let closedByEscape = $state(false);
+
+  function handleToggle(event: MouseEvent): void {
+    mobileMenuOpen = !mobileMenuOpen;
+    toggleElement = event.currentTarget as HTMLElement | null;
+  }
+
+  $effect(() => {
+    // Return focus to the toggle when the menu is closed via Escape.
+    if (!mobileMenuOpen && closedByEscape) {
+      toggleElement?.focus();
+      closedByEscape = false;
+    }
+  });
+
+  function handleKeyDown(event: KeyboardEvent): void {
+    // Consumer handler runs first; if it cancels, skip the internal close.
+    if (consumerOnKeyDown) {
+      (consumerOnKeyDown as (e: KeyboardEvent) => void)(event);
+    }
+    if (event.key === 'Escape' && mobileMenuOpen && !event.defaultPrevented) {
+      closedByEscape = true;
+      mobileMenuOpen = false;
+    }
+  }
 </script>
 
-<nav class={cn('cinder-navigation-bar', className)} aria-label="Main navigation" {...rest}>
+<nav
+  {...rest}
+  aria-label={navAriaLabel}
+  class={cn('cinder-navigation-bar', className)}
+  data-collapsible={isCollapsible ? 'true' : 'false'}
+  data-mobile-open={mobileMenuOpen ? 'true' : 'false'}
+  onkeydown={handleKeyDown}
+>
   {#if brand}
     <div class="cinder-navigation-bar__brand">
       {@render brand()}
     </div>
   {/if}
 
-  <div class="cinder-navigation-bar__items">
-    {@render items()}
+  {#if menuToggle}
+    <div class="cinder-navigation-bar__menu-toggle">
+      {@render menuToggle(toggleAttributes)}
+    </div>
+  {/if}
+
+  <div
+    id={regionId}
+    class="cinder-navigation-bar__items"
+    data-open={mobileMenuOpen ? 'true' : 'false'}
+  >
+    {@render items({ variant })}
   </div>
 
   {#if actions}

--- a/packages/components/src/components/navigation-bar.test.ts
+++ b/packages/components/src/components/navigation-bar.test.ts
@@ -296,16 +296,13 @@ describe('NavigationBar', () => {
     expect(capturedVariant).toBe('horizontal');
   });
 
-  test('items snippet receives variant="mobile" after opening on a collapsible bar', async () => {
-    // In Svelte's createRawSnippet, setup() runs once at mount and render() is called once
-    // to produce the initial HTML. Reactive parameter changes trigger a DOM update by
-    // unmounting/remounting the snippet element. We observe this via the items region
-    // data-open attribute (which Svelte's template binding updates reactively) combined
-    // with the initial variant capture confirming correct derivation logic.
-    //
-    // The variant derivation — $derived(menuToggle !== undefined && mobileMenuOpen ? 'mobile' : 'horizontal')
-    // — is deterministic: when mobileMenuOpen flips to true, variant must be 'mobile'.
-    // We verify the full chain: click → mobileMenuOpen=true → data-open='true' → variant='mobile'.
+  test('opening the menu sets data-open="true" on the items region (mobileMenuOpen=true drives variant="mobile")', async () => {
+    // In Svelte's createRawSnippet, setup() runs once at mount. Reactive snippet parameter
+    // changes cannot be directly observed via the setup closure. Instead we verify the
+    // full state chain: click → mobileMenuOpen=true → data-open='true' on the items region.
+    // The variant derivation ($derived(menuToggle !== undefined && mobileMenuOpen ? 'mobile' : 'horizontal'))
+    // is deterministic — when data-open='true', variant was 'mobile'. Initial variant='horizontal'
+    // is confirmed directly via the captured closure in the test above this one.
     let capturedVariant: string | undefined;
     const captureSnippet = createRawSnippet<[{ variant: string }]>((getCtx) => ({
       render: () => `<span></span>`,

--- a/packages/components/src/components/navigation-bar.test.ts
+++ b/packages/components/src/components/navigation-bar.test.ts
@@ -8,7 +8,7 @@ import { setupHappyDom } from '../test/happy-dom.ts';
 // so we register happy-dom's globals first and then dynamic-import testing-library below.
 setupHappyDom();
 
-const { render } = await import('@testing-library/svelte');
+const { render, fireEvent } = await import('@testing-library/svelte');
 const { default: NavigationBar } = await import('./navigation-bar.svelte');
 // createRawSnippet must be imported dynamically so Bun's svelte plugin (which patches
 // the svelte package to resolve to the client build) applies before this import resolves.
@@ -18,10 +18,39 @@ const { createRawSnippet } = await import('svelte');
 function textSnippet(text: string) {
   return createRawSnippet(() => ({
     render: () => `<span>${text}</span>`,
+    setup: () => {},
+  }));
+}
+
+/**
+ * Creates a toggle button snippet that wires aria-expanded, aria-controls, and onclick
+ * from the snippet parameter. The setup closure captures the click handler from the
+ * initial render. Attribute updates (aria-expanded) after interaction are observable
+ * via the nav's data-mobile-open attribute, which Svelte binds directly in the template.
+ */
+function toggleSnippet(buttonId = 'toggle-btn') {
+  return createRawSnippet<
+    [
+      {
+        'aria-expanded': string;
+        'aria-controls': string;
+        onclick: (event: MouseEvent) => void;
+      },
+    ]
+  >((getAttrs) => ({
+    render: () => `<button type="button" id="${buttonId}">Menu</button>`,
+    setup(element: Element) {
+      const attrs = getAttrs();
+      element.setAttribute('aria-expanded', attrs['aria-expanded']);
+      element.setAttribute('aria-controls', attrs['aria-controls']);
+      element.addEventListener('click', attrs.onclick as EventListener);
+    },
   }));
 }
 
 describe('NavigationBar', () => {
+  // ── Legacy tests (preserved) ────────────────────────────────────────────
+
   test('root element is <nav>', () => {
     const { container } = render(NavigationBar, {
       items: textSnippet('nav items'),
@@ -88,5 +117,248 @@ describe('NavigationBar', () => {
       id: 'main-nav',
     });
     expect(container.querySelector('nav')?.getAttribute('id')).toBe('main-nav');
+  });
+
+  // ── navAriaLabel prop ────────────────────────────────────────────────────
+
+  test('navAriaLabel defaults to "Main navigation"', () => {
+    const { container } = render(NavigationBar, {
+      items: textSnippet('items'),
+    });
+    expect(container.querySelector('nav')?.getAttribute('aria-label')).toBe('Main navigation');
+  });
+
+  test('navAriaLabel prop is applied to <nav>', () => {
+    const { container } = render(NavigationBar, {
+      items: textSnippet('items'),
+      navAriaLabel: 'Site navigation',
+    });
+    expect(container.querySelector('nav')?.getAttribute('aria-label')).toBe('Site navigation');
+  });
+
+  test('rest-prop aria-label does not override navAriaLabel', () => {
+    const { container } = render(NavigationBar, {
+      items: textSnippet('items'),
+      navAriaLabel: 'Primary nav',
+      'aria-label': 'Should be ignored',
+    } as any);
+    expect(container.querySelector('nav')?.getAttribute('aria-label')).toBe('Primary nav');
+  });
+
+  // ── Rest props forwarding ────────────────────────────────────────────────
+
+  test('rest props are forwarded: id, data-foo, and custom class all appear on <nav>', () => {
+    const { container } = render(NavigationBar, {
+      items: textSnippet('items'),
+      id: 'my-nav',
+      'data-foo': 'bar',
+      class: 'extra-class',
+    } as any);
+    const nav = container.querySelector('nav');
+    expect(nav?.getAttribute('id')).toBe('my-nav');
+    expect(nav?.getAttribute('data-foo')).toBe('bar');
+    expect(nav?.getAttribute('class')).toContain('cinder-navigation-bar');
+    expect(nav?.getAttribute('class')).toContain('extra-class');
+  });
+
+  // ── Without menuToggle ───────────────────────────────────────────────────
+
+  test('without menuToggle, no toggle wrapper is rendered and data-collapsible is false', () => {
+    const { container } = render(NavigationBar, {
+      items: textSnippet('items'),
+    });
+    expect(container.querySelector('.cinder-navigation-bar__menu-toggle')).toBeNull();
+    expect(container.querySelector('nav')?.getAttribute('data-collapsible')).toBe('false');
+  });
+
+  // ── mobileMenuOpen defaults ──────────────────────────────────────────────
+
+  test('mobileMenuOpen defaults to false; items region has data-open="false"', () => {
+    const { container } = render(NavigationBar, {
+      items: textSnippet('items'),
+      menuToggle: toggleSnippet(),
+    });
+    expect(
+      container.querySelector('.cinder-navigation-bar__items')?.getAttribute('data-open'),
+    ).toBe('false');
+  });
+
+  // ── menuToggle snippet and ARIA ──────────────────────────────────────────
+
+  test('with menuToggle, toggle button receives aria-expanded="false" initially', () => {
+    const { container } = render(NavigationBar, {
+      items: textSnippet('items'),
+      menuToggle: toggleSnippet(),
+    });
+    const toggle = container.querySelector('#toggle-btn');
+    expect(toggle?.getAttribute('aria-expanded')).toBe('false');
+  });
+
+  test('aria-controls value equals the items region id', () => {
+    const { container } = render(NavigationBar, {
+      items: textSnippet('items'),
+      menuToggle: toggleSnippet(),
+    });
+    const toggle = container.querySelector('#toggle-btn');
+    const itemsRegion = container.querySelector('.cinder-navigation-bar__items');
+    expect(toggle?.getAttribute('aria-controls')).toBe(itemsRegion?.getAttribute('id'));
+  });
+
+  test('clicking the toggle sets data-open="true" on the items region', async () => {
+    const { container } = render(NavigationBar, {
+      items: textSnippet('items'),
+      menuToggle: toggleSnippet(),
+    });
+    const toggle = container.querySelector('#toggle-btn') as HTMLElement;
+    await fireEvent.click(toggle);
+    expect(
+      container.querySelector('.cinder-navigation-bar__items')?.getAttribute('data-open'),
+    ).toBe('true');
+  });
+
+  test('clicking the toggle sets data-mobile-open="true" on <nav>', async () => {
+    const { container } = render(NavigationBar, {
+      items: textSnippet('items'),
+      menuToggle: toggleSnippet(),
+    });
+    const toggle = container.querySelector('#toggle-btn') as HTMLElement;
+    await fireEvent.click(toggle);
+    expect(container.querySelector('nav')?.getAttribute('data-mobile-open')).toBe('true');
+  });
+
+  // ── Escape key handling ──────────────────────────────────────────────────
+
+  test('pressing Escape on <nav> while open closes the menu', async () => {
+    const { container } = render(NavigationBar, {
+      items: textSnippet('items'),
+      menuToggle: toggleSnippet(),
+    });
+    const toggle = container.querySelector('#toggle-btn') as HTMLElement;
+    const nav = container.querySelector('nav') as HTMLElement;
+
+    await fireEvent.click(toggle);
+    expect(
+      container.querySelector('.cinder-navigation-bar__items')?.getAttribute('data-open'),
+    ).toBe('true');
+
+    await fireEvent.keyDown(nav, { key: 'Escape' });
+    expect(
+      container.querySelector('.cinder-navigation-bar__items')?.getAttribute('data-open'),
+    ).toBe('false');
+  });
+
+  test('pressing Escape on <nav> while closed does not error and data-open stays false', async () => {
+    const { container } = render(NavigationBar, {
+      items: textSnippet('items'),
+      menuToggle: toggleSnippet(),
+    });
+    const nav = container.querySelector('nav') as HTMLElement;
+    await fireEvent.keyDown(nav, { key: 'Escape' });
+    expect(
+      container.querySelector('.cinder-navigation-bar__items')?.getAttribute('data-open'),
+    ).toBe('false');
+  });
+
+  test('pressing Escape outside the navbar does not close the menu', async () => {
+    const { container } = render(NavigationBar, {
+      items: textSnippet('items'),
+      menuToggle: toggleSnippet(),
+    });
+    const toggle = container.querySelector('#toggle-btn') as HTMLElement;
+    await fireEvent.click(toggle);
+
+    // Dispatch Escape on document.body — outside the nav element.
+    await fireEvent.keyDown(document.body, { key: 'Escape' });
+    expect(
+      container.querySelector('.cinder-navigation-bar__items')?.getAttribute('data-open'),
+    ).toBe('true');
+  });
+
+  // ── items snippet receives variant context ───────────────────────────────
+
+  test('items snippet receives { variant } equal to "horizontal" when menu is closed', () => {
+    let capturedVariant: string | undefined;
+    const captureSnippet = createRawSnippet<[{ variant: string }]>((getCtx) => ({
+      render: () => `<span></span>`,
+      setup() {
+        capturedVariant = getCtx().variant;
+      },
+    }));
+
+    render(NavigationBar, {
+      items: captureSnippet as any,
+      menuToggle: toggleSnippet(),
+    });
+
+    expect(capturedVariant).toBe('horizontal');
+  });
+
+  test('items snippet receives variant="mobile" after opening on a collapsible bar', async () => {
+    // The nav's data-mobile-open attribute is the direct template binding that tracks
+    // mobileMenuOpen. When it is 'true', the variant passed to the items snippet is 'mobile'.
+    // (createRawSnippet's setup runs once at mount; reactive variant changes are verified
+    // via the nav-level data-mobile-open signal which Svelte keeps in sync.)
+    const { container } = render(NavigationBar, {
+      items: textSnippet('items'),
+      menuToggle: toggleSnippet(),
+    });
+
+    const toggle = container.querySelector('#toggle-btn') as HTMLElement;
+    await fireEvent.click(toggle);
+
+    expect(container.querySelector('nav')?.getAttribute('data-mobile-open')).toBe('true');
+  });
+
+  // ── data-collapsible cannot be overridden via rest ───────────────────────
+
+  test('consumer data-collapsible rest prop cannot override internal value', () => {
+    const { container } = render(NavigationBar, {
+      items: textSnippet('items'),
+      menuToggle: toggleSnippet(),
+      'data-collapsible': 'false',
+    } as any);
+    expect(container.querySelector('nav')?.getAttribute('data-collapsible')).toBe('true');
+  });
+
+  // ── Composed onkeydown ───────────────────────────────────────────────────
+
+  test('rest-prop onkeydown is composed: spy fires AND menu closes on Escape', async () => {
+    let spyFired = false;
+    const { container } = render(NavigationBar, {
+      items: textSnippet('items'),
+      menuToggle: toggleSnippet(),
+      onkeydown: () => {
+        spyFired = true;
+      },
+    } as any);
+
+    const toggle = container.querySelector('#toggle-btn') as HTMLElement;
+    const nav = container.querySelector('nav') as HTMLElement;
+    await fireEvent.click(toggle);
+    await fireEvent.keyDown(nav, { key: 'Escape' });
+
+    expect(spyFired).toBe(true);
+    expect(
+      container.querySelector('.cinder-navigation-bar__items')?.getAttribute('data-open'),
+    ).toBe('false');
+  });
+
+  test('rest-prop onkeydown that calls preventDefault cancels the Escape close', async () => {
+    const { container } = render(NavigationBar, {
+      items: textSnippet('items'),
+      menuToggle: toggleSnippet(),
+      onkeydown: (e: KeyboardEvent) => {
+        e.preventDefault();
+      },
+    } as any);
+
+    const toggle = container.querySelector('#toggle-btn') as HTMLElement;
+    const nav = container.querySelector('nav') as HTMLElement;
+    await fireEvent.click(toggle);
+    await fireEvent.keyDown(nav, { key: 'Escape' });
+
+    expect(
+      container.querySelector('.cinder-navigation-bar__items')?.getAttribute('data-open'),
+    ).toBe('true');
   });
 });

--- a/packages/components/src/components/navigation-bar.test.ts
+++ b/packages/components/src/components/navigation-bar.test.ts
@@ -26,7 +26,7 @@ function textSnippet(text: string) {
  * Creates a toggle button snippet that wires aria-expanded, aria-controls, and onclick
  * from the snippet parameter. The setup closure captures the click handler from the
  * initial render. Attribute updates (aria-expanded) after interaction are observable
- * via the nav's data-mobile-open attribute, which Svelte binds directly in the template.
+ * via the items region's data-open attribute, which Svelte binds directly in the template.
  */
 function toggleSnippet(buttonId = 'toggle-btn') {
   return createRawSnippet<
@@ -216,14 +216,17 @@ describe('NavigationBar', () => {
     ).toBe('true');
   });
 
-  test('clicking the toggle sets data-mobile-open="true" on <nav>', async () => {
+  test('clicking the toggle a second time closes the menu', async () => {
     const { container } = render(NavigationBar, {
       items: textSnippet('items'),
       menuToggle: toggleSnippet(),
     });
     const toggle = container.querySelector('#toggle-btn') as HTMLElement;
     await fireEvent.click(toggle);
-    expect(container.querySelector('nav')?.getAttribute('data-mobile-open')).toBe('true');
+    await fireEvent.click(toggle);
+    expect(
+      container.querySelector('.cinder-navigation-bar__items')?.getAttribute('data-open'),
+    ).toBe('false');
   });
 
   // ── Escape key handling ──────────────────────────────────────────────────
@@ -294,19 +297,39 @@ describe('NavigationBar', () => {
   });
 
   test('items snippet receives variant="mobile" after opening on a collapsible bar', async () => {
-    // The nav's data-mobile-open attribute is the direct template binding that tracks
-    // mobileMenuOpen. When it is 'true', the variant passed to the items snippet is 'mobile'.
-    // (createRawSnippet's setup runs once at mount; reactive variant changes are verified
-    // via the nav-level data-mobile-open signal which Svelte keeps in sync.)
+    // In Svelte's createRawSnippet, setup() runs once at mount and render() is called once
+    // to produce the initial HTML. Reactive parameter changes trigger a DOM update by
+    // unmounting/remounting the snippet element. We observe this via the items region
+    // data-open attribute (which Svelte's template binding updates reactively) combined
+    // with the initial variant capture confirming correct derivation logic.
+    //
+    // The variant derivation — $derived(menuToggle !== undefined && mobileMenuOpen ? 'mobile' : 'horizontal')
+    // — is deterministic: when mobileMenuOpen flips to true, variant must be 'mobile'.
+    // We verify the full chain: click → mobileMenuOpen=true → data-open='true' → variant='mobile'.
+    let capturedVariant: string | undefined;
+    const captureSnippet = createRawSnippet<[{ variant: string }]>((getCtx) => ({
+      render: () => `<span></span>`,
+      setup() {
+        capturedVariant = getCtx().variant;
+      },
+    }));
+
     const { container } = render(NavigationBar, {
-      items: textSnippet('items'),
+      items: captureSnippet as any,
       menuToggle: toggleSnippet(),
     });
+
+    // At mount, variant is 'horizontal' (menu closed).
+    expect(capturedVariant).toBe('horizontal');
 
     const toggle = container.querySelector('#toggle-btn') as HTMLElement;
     await fireEvent.click(toggle);
 
-    expect(container.querySelector('nav')?.getAttribute('data-mobile-open')).toBe('true');
+    // After click: mobileMenuOpen=true → data-open='true' on the items region.
+    // The variant derivation passes 'mobile' to items when open.
+    expect(
+      container.querySelector('.cinder-navigation-bar__items')?.getAttribute('data-open'),
+    ).toBe('true');
   });
 
   // ── data-collapsible cannot be overridden via rest ───────────────────────

--- a/packages/components/src/components/navigation-item.a11y.md
+++ b/packages/components/src/components/navigation-item.a11y.md
@@ -16,7 +16,7 @@ Choosing the semantically correct element is the foundation of accessible naviga
 | Arm    | Attribute      | Value    | Meaning                                                                  |
 | ------ | -------------- | -------- | ------------------------------------------------------------------------ |
 | Link   | `aria-current` | `"page"` | Indicates this link represents the current page in a navigation set.     |
-| Button | `aria-current` | `"true"` | Indicates the button is the currently selected item in a navigation set. |
+| Button | `aria-current` | `"page"` | Indicates the button is the currently selected item in a navigation set. |
 
 `aria-pressed` is intentionally not used on the button arm. `aria-pressed` implies toggle semantics—a button that independently switches between on and off states. Navigation selection is not a toggle; the correct signal is `aria-current`, which communicates "this is the active item in a set" without implying the button controls its own binary state.
 

--- a/packages/components/src/components/navigation-item.a11y.md
+++ b/packages/components/src/components/navigation-item.a11y.md
@@ -59,3 +59,22 @@ NavigationItem is designed to be used inside a `<nav>` element or another approp
 - Each item must have a meaningful text label visible to all users — do not use icon-only items without a supplemental `aria-label` on the item or a visually hidden span inside `children`.
 - Labels should be unique within a navigation region so users can distinguish items when navigating by tab or the screen reader's link/button list.
 - Avoid changing an item's label text dynamically as the active state changes — the active state is communicated via `aria-current` / `aria-pressed`, not by altering the label.
+
+## Variants
+
+`NavigationItem` accepts a `variant` prop (`'horizontal'` | `'mobile'`, default `'horizontal'`) that controls stacked layout on small viewports. The value is emitted as a `data-variant` attribute on the root element.
+
+**Visual behavior is CSS-only and viewport-gated.** The `data-variant='mobile'` styles are scoped inside a `@media (max-width: 47.99rem)` rule. Passing `variant='mobile'` on a desktop viewport has no visual effect—the item renders identically to the horizontal variant. This keeps the variant safe to pass at all viewports without conditional JS.
+
+**Usage with `NavigationBar`.** When `NavigationBar` renders with a `menuToggle` snippet (mobile collapse enabled), it passes a `{ variant }` context object to the `items` snippet. Consumers forward this to each `NavigationItem` to enable stacked layout automatically:
+
+```svelte
+{#snippet items({ variant })}
+  <NavigationItem href="/home" {variant}>Home</NavigationItem>
+  <NavigationItem href="/docs" {variant}>Docs</NavigationItem>
+{/snippet}
+```
+
+When a consumer's `items` snippet does not destructure the context parameter, `NavigationItem` falls back to its own `variant='horizontal'` default. Mobile styling is then opt-in per-item rather than automatic.
+
+**Accessibility impact.** The `variant` prop has no ARIA semantics. It controls layout only. Screen readers announce both variants identically—the accessible name, role (`link` or `button`), and state (`aria-current`, `aria-disabled`) are unchanged by `variant`.

--- a/packages/components/src/components/navigation-item.a11y.md
+++ b/packages/components/src/components/navigation-item.a11y.md
@@ -5,7 +5,7 @@
 NavigationItem renders as one of two native elements depending on the props passed:
 
 - **`<a href="...">`** — when the `href` prop is present (link arm). Use this when the item navigates to a URL.
-- **`<button type="button">`** — when the `onClick` prop is present (button arm). Use this when the item triggers an action (e.g., filtering, opening a panel) without changing the URL.
+- **`<button type="button">`** — when the `onclick` prop is present (button arm). Use this when the item triggers an action (e.g., filtering, opening a panel) without changing the URL.
 
 Choosing the semantically correct element is the foundation of accessible navigation: screen readers announce `<a>` as a "link" and `<button>` as a "button", which sets the correct expectation for keyboard and pointer users.
 

--- a/packages/components/src/components/navigation-item.svelte
+++ b/packages/components/src/components/navigation-item.svelte
@@ -56,7 +56,7 @@
   <button
     type="button"
     class={resolvedClass}
-    aria-current={active ? 'true' : undefined}
+    aria-current={active ? 'page' : undefined}
     aria-disabled={disabled ? true : undefined}
     data-active={active}
     data-variant={variant}

--- a/packages/components/src/components/navigation-item.svelte
+++ b/packages/components/src/components/navigation-item.svelte
@@ -11,9 +11,9 @@
   };
 
   type LinkArm = CommonArm & { href: string };
-  type ButtonArm = CommonArm & { onClick: (event: MouseEvent) => void };
+  type ButtonArm = CommonArm & { onclick: (event: MouseEvent) => void };
 
-  /** Props for the NavigationItem component. Pass `href` for a link, `onClick` for a button. */
+  /** Props for the NavigationItem component. Pass `href` for a link, `onclick` for a button. */
   export type NavigationItemProps = LinkArm | ButtonArm;
 </script>
 
@@ -35,7 +35,7 @@
       return;
     }
     if (!isLink) {
-      (props as { onClick: (event: MouseEvent) => void }).onClick(event);
+      (props as { onclick: (event: MouseEvent) => void }).onclick(event);
     }
   }
 </script>

--- a/packages/components/src/components/navigation-item.svelte
+++ b/packages/components/src/components/navigation-item.svelte
@@ -1,21 +1,17 @@
 <script lang="ts" module>
   import type { Snippet } from 'svelte';
 
-  type LinkArm = {
-    href: string;
+  type CommonArm = {
     active?: boolean;
     disabled?: boolean;
     class?: string;
+    /** Controls stacked layout on mobile. Emitted as data-variant. Default 'horizontal'. */
+    variant?: 'horizontal' | 'mobile';
     children: Snippet;
   };
 
-  type ButtonArm = {
-    onClick: (event: MouseEvent) => void;
-    active?: boolean;
-    disabled?: boolean;
-    class?: string;
-    children: Snippet;
-  };
+  type LinkArm = CommonArm & { href: string };
+  type ButtonArm = CommonArm & { onClick: (event: MouseEvent) => void };
 
   /** Props for the NavigationItem component. Pass `href` for a link, `onClick` for a button. */
   export type NavigationItemProps = LinkArm | ButtonArm;
@@ -31,6 +27,7 @@
   const resolvedClass = $derived(classNames('cinder-navigation-item', props.class));
   const active = $derived(props.active ?? false);
   const disabled = $derived(props.disabled ?? false);
+  const variant = $derived(props.variant ?? 'horizontal');
 
   function handleClick(event: MouseEvent): void {
     if (disabled) {
@@ -50,6 +47,7 @@
     aria-current={active ? 'page' : undefined}
     aria-disabled={disabled ? true : undefined}
     data-active={active}
+    data-variant={variant}
     onclick={handleClick}
   >
     {@render props.children()}
@@ -61,6 +59,7 @@
     aria-current={active ? 'true' : undefined}
     aria-disabled={disabled ? true : undefined}
     data-active={active}
+    data-variant={variant}
     onclick={handleClick}
   >
     {@render props.children()}

--- a/packages/components/src/components/navigation-item.test.ts
+++ b/packages/components/src/components/navigation-item.test.ts
@@ -22,9 +22,9 @@ describe('NavigationItem rendering', () => {
     expect(container.querySelector('button')).toBeNull();
   });
 
-  test('renders as <button> with onClick prop', () => {
+  test('renders as <button> with onclick prop', () => {
     const { container } = render(NavigationItem, {
-      props: { onClick: () => {}, children: (() => {}) as never },
+      props: { onclick: () => {}, children: (() => {}) as never },
     });
     const button = container.querySelector('button');
     expect(button).not.toBeNull();
@@ -50,7 +50,7 @@ describe('NavigationItem rendering', () => {
 
   test('active button has aria-current="page"', () => {
     const { container } = render(NavigationItem, {
-      props: { onClick: () => {}, active: true, children: (() => {}) as never },
+      props: { onclick: () => {}, active: true, children: (() => {}) as never },
     });
     const button = container.querySelector('button');
     expect(button?.getAttribute('aria-current')).toBe('page');
@@ -58,7 +58,7 @@ describe('NavigationItem rendering', () => {
 
   test('inactive button does not have aria-current', () => {
     const { container } = render(NavigationItem, {
-      props: { onClick: () => {}, active: false, children: (() => {}) as never },
+      props: { onclick: () => {}, active: false, children: (() => {}) as never },
     });
     const button = container.querySelector('button');
     expect(button?.hasAttribute('aria-current')).toBe(false);
@@ -76,7 +76,7 @@ describe('NavigationItem rendering', () => {
     const anchor = container.querySelector('a');
     expect(anchor?.getAttribute('aria-disabled')).toBe('true');
     // Simulate click — the handler calls preventDefault so no navigation occurs.
-    // Since there is no consumer onClick on link arm, we just verify aria-disabled is present.
+    // Since there is no consumer onclick on link arm, we just verify aria-disabled is present.
     anchor?.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));
     expect(clickCount).toBe(0);
   });
@@ -117,11 +117,11 @@ describe('NavigationItem rendering', () => {
     expect(anchor?.hasAttribute('tabindex')).toBe(false);
   });
 
-  test('disabled button has aria-disabled and blocks onClick', () => {
+  test('disabled button has aria-disabled and blocks onclick', () => {
     let clickCount = 0;
     const { container } = render(NavigationItem, {
       props: {
-        onClick: () => {
+        onclick: () => {
           clickCount += 1;
         },
         disabled: true,
@@ -162,11 +162,11 @@ describe('NavigationItem rendering', () => {
     expect(anchor?.classList.contains('my-custom-class')).toBe(true);
   });
 
-  test('non-disabled button invokes onClick on click', () => {
+  test('non-disabled button invokes onclick on click', () => {
     let clickCount = 0;
     const { container } = render(NavigationItem, {
       props: {
-        onClick: () => {
+        onclick: () => {
           clickCount += 1;
         },
         children: (() => {}) as never,
@@ -186,7 +186,7 @@ describe('NavigationItem rendering', () => {
 
   test('button arm emits data-variant="horizontal" by default', () => {
     const { container } = render(NavigationItem, {
-      props: { onClick: () => {}, children: (() => {}) as never },
+      props: { onclick: () => {}, children: (() => {}) as never },
     });
     expect(container.querySelector('button')?.getAttribute('data-variant')).toBe('horizontal');
   });
@@ -200,7 +200,7 @@ describe('NavigationItem rendering', () => {
 
   test('button arm emits data-variant="mobile" when variant="mobile" is passed', () => {
     const { container } = render(NavigationItem, {
-      props: { onClick: () => {}, variant: 'mobile', children: (() => {}) as never },
+      props: { onclick: () => {}, variant: 'mobile', children: (() => {}) as never },
     });
     expect(container.querySelector('button')?.getAttribute('data-variant')).toBe('mobile');
   });

--- a/packages/components/src/components/navigation-item.test.ts
+++ b/packages/components/src/components/navigation-item.test.ts
@@ -176,4 +176,32 @@ describe('NavigationItem rendering', () => {
     button?.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));
     expect(clickCount).toBe(1);
   });
+
+  test('link arm emits data-variant="horizontal" by default', () => {
+    const { container } = render(NavigationItem, {
+      props: { href: '/home', children: (() => {}) as never },
+    });
+    expect(container.querySelector('a')?.getAttribute('data-variant')).toBe('horizontal');
+  });
+
+  test('button arm emits data-variant="horizontal" by default', () => {
+    const { container } = render(NavigationItem, {
+      props: { onClick: () => {}, children: (() => {}) as never },
+    });
+    expect(container.querySelector('button')?.getAttribute('data-variant')).toBe('horizontal');
+  });
+
+  test('link arm emits data-variant="mobile" when variant="mobile" is passed', () => {
+    const { container } = render(NavigationItem, {
+      props: { href: '/home', variant: 'mobile', children: (() => {}) as never },
+    });
+    expect(container.querySelector('a')?.getAttribute('data-variant')).toBe('mobile');
+  });
+
+  test('button arm emits data-variant="mobile" when variant="mobile" is passed', () => {
+    const { container } = render(NavigationItem, {
+      props: { onClick: () => {}, variant: 'mobile', children: (() => {}) as never },
+    });
+    expect(container.querySelector('button')?.getAttribute('data-variant')).toBe('mobile');
+  });
 });

--- a/packages/components/src/components/navigation-item.test.ts
+++ b/packages/components/src/components/navigation-item.test.ts
@@ -48,12 +48,12 @@ describe('NavigationItem rendering', () => {
     expect(anchor?.hasAttribute('aria-current')).toBe(false);
   });
 
-  test('active button has aria-current="true"', () => {
+  test('active button has aria-current="page"', () => {
     const { container } = render(NavigationItem, {
       props: { onClick: () => {}, active: true, children: (() => {}) as never },
     });
     const button = container.querySelector('button');
-    expect(button?.getAttribute('aria-current')).toBe('true');
+    expect(button?.getAttribute('aria-current')).toBe('page');
   });
 
   test('inactive button does not have aria-current', () => {

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -148,7 +148,12 @@ export { default as Modal } from './components/modal.svelte';
 export type { ModalProps } from './components/modal.svelte';
 
 export { default as NavigationBar } from './components/navigation-bar.svelte';
-export type { NavigationBarProps } from './components/navigation-bar.svelte';
+export type {
+  NavigationBarItemsContext,
+  NavigationBarProps,
+  NavigationBarToggleAttributes,
+  NavigationVariant,
+} from './components/navigation-bar.svelte';
 
 export { default as NavigationItem } from './components/navigation-item.svelte';
 export type { NavigationItemProps } from './components/navigation-item.svelte';

--- a/packages/components/src/styles/components/navigation-bar.css
+++ b/packages/components/src/styles/components/navigation-bar.css
@@ -1,5 +1,7 @@
 /* ========================================
  * NAVIGATION BAR
+ * Breakpoint used below: 47.99rem (~767px). No shared breakpoint token
+ * exists in this package yet; extract to a token in a follow-up task.
  * ======================================== */
 
 .cinder-navigation-bar {
@@ -40,4 +42,76 @@
   align-items: center;
   gap: var(--cinder-space-2);
   flex-shrink: 0;
+}
+
+/* ----------------------------------------
+ * Toggle button — hidden by default; shown on mobile only when
+ * the consumer provides a menuToggle snippet (data-collapsible='true').
+ * ---------------------------------------- */
+
+.cinder-navigation-bar__menu-toggle {
+  display: none;
+}
+
+/* ----------------------------------------
+ * Collapsible mobile mode
+ * Scoped under [data-collapsible='true'] so non-opted-in bars are
+ * completely unaffected at every viewport.
+ * ---------------------------------------- */
+
+@media (max-width: 47.99rem) {
+  .cinder-navigation-bar[data-collapsible='true'] .cinder-navigation-bar__menu-toggle {
+    display: inline-flex;
+  }
+
+  .cinder-navigation-bar[data-collapsible='true'] .cinder-navigation-bar__items {
+    position: absolute;
+    inset-inline: 0;
+    top: 100%;
+    flex-direction: column;
+    align-items: stretch;
+    padding: var(--cinder-space-2);
+    background: var(--cinder-surface);
+    border-bottom: 1px solid var(--cinder-border-muted);
+    z-index: var(--cinder-z-overlay, 10);
+
+    /* Open → visible, slide in */
+    transition:
+      transform 200ms ease,
+      opacity 200ms ease;
+  }
+
+  /* Closed: remove from focus/AT trees immediately via visibility. */
+  .cinder-navigation-bar[data-collapsible='true'] .cinder-navigation-bar__items[data-open='false'] {
+    visibility: hidden;
+    transform: translateY(-0.5rem);
+    opacity: 0;
+    pointer-events: none;
+  }
+
+  .cinder-navigation-bar[data-collapsible='true'] .cinder-navigation-bar__items[data-open='true'] {
+    visibility: visible;
+    transform: none;
+    opacity: 1;
+  }
+}
+
+/* ----------------------------------------
+ * Reduced motion — zero out transitions
+ * ---------------------------------------- */
+
+@media (prefers-reduced-motion: reduce) {
+  .cinder-navigation-bar[data-collapsible='true'] .cinder-navigation-bar__items {
+    transition: none;
+  }
+}
+
+/* ----------------------------------------
+ * Forced colors — keep panel border visible
+ * ---------------------------------------- */
+
+@media (forced-colors: active) {
+  .cinder-navigation-bar[data-collapsible='true'] .cinder-navigation-bar__items {
+    border-bottom-color: CanvasText;
+  }
 }

--- a/packages/components/src/styles/components/navigation-item.css
+++ b/packages/components/src/styles/components/navigation-item.css
@@ -86,3 +86,25 @@ button.cinder-navigation-item {
   background: transparent;
   padding-inline: var(--cinder-space-3);
 }
+
+/* ----------------------------------------
+ * Mobile variant — stacked full-width layout
+ * Breakpoint: 47.99rem (~767px). No breakpoint token exists in this
+ * package yet; extract to a shared token in a follow-up task.
+ * ---------------------------------------- */
+
+@media (max-width: 47.99rem) {
+  .cinder-navigation-item[data-variant='mobile'] {
+    display: flex;
+    inline-size: 100%;
+    justify-content: flex-start;
+    padding-block: var(--cinder-space-3);
+  }
+}
+
+@media (forced-colors: active) and (max-width: 47.99rem) {
+  .cinder-navigation-item[data-variant='mobile']:focus-visible {
+    outline: var(--cinder-ring-width) solid ButtonText;
+    outline-offset: 3px;
+  }
+}

--- a/packages/playground/src/examples/command-palette/basic.example.svelte
+++ b/packages/playground/src/examples/command-palette/basic.example.svelte
@@ -4,11 +4,7 @@
 </script>
 
 <script lang="ts">
-  import {
-    Button,
-    CommandItem,
-    CommandPalette,
-  } from '../../../../components/src/index.ts';
+  import { Button, CommandItem, CommandPalette } from '../../../../components/src/index.ts';
 
   let open = $state(false);
   let triggerRef: HTMLElement | null = $state(null);

--- a/packages/playground/src/examples/command-palette/search-recent-actions.example.svelte
+++ b/packages/playground/src/examples/command-palette/search-recent-actions.example.svelte
@@ -36,15 +36,11 @@
 
   // ── Filtering ──────────────────────────────────────────────────────────
   const filteredPages = $derived(
-    query
-      ? allPages.filter((p) => p.label.toLowerCase().includes(query.toLowerCase()))
-      : [],
+    query ? allPages.filter((p) => p.label.toLowerCase().includes(query.toLowerCase())) : [],
   );
 
   const filteredActions = $derived(
-    query
-      ? actions.filter((a) => a.label.toLowerCase().includes(query.toLowerCase()))
-      : actions,
+    query ? actions.filter((a) => a.label.toLowerCase().includes(query.toLowerCase())) : actions,
   );
 
   function select(label: string) {

--- a/packages/playground/src/examples/navigation-bar/basic.example.svelte
+++ b/packages/playground/src/examples/navigation-bar/basic.example.svelte
@@ -7,20 +7,26 @@
   import { Button, NavigationBar, NavigationItem } from '../../../../components/src/index.ts';
 
   let active = $state('home');
+  let mobileMenuOpen = $state(false);
 </script>
 
-<NavigationBar>
+<NavigationBar bind:mobileMenuOpen>
   {#snippet brand()}
     <strong>Acme</strong>
   {/snippet}
-  {#snippet items()}
-    <NavigationItem onClick={() => (active = 'home')} active={active === 'home'}>
+  {#snippet menuToggle(attrs)}
+    <button type="button" {...attrs} aria-label={mobileMenuOpen ? 'Close menu' : 'Open menu'}>
+      ☰
+    </button>
+  {/snippet}
+  {#snippet items({ variant })}
+    <NavigationItem {variant} onClick={() => (active = 'home')} active={active === 'home'}>
       Home
     </NavigationItem>
-    <NavigationItem onClick={() => (active = 'docs')} active={active === 'docs'}>
+    <NavigationItem {variant} onClick={() => (active = 'docs')} active={active === 'docs'}>
       Docs
     </NavigationItem>
-    <NavigationItem onClick={() => (active = 'blog')} active={active === 'blog'}>
+    <NavigationItem {variant} onClick={() => (active = 'blog')} active={active === 'blog'}>
       Blog
     </NavigationItem>
   {/snippet}

--- a/packages/playground/src/examples/navigation-bar/basic.example.svelte
+++ b/packages/playground/src/examples/navigation-bar/basic.example.svelte
@@ -20,13 +20,13 @@
     </button>
   {/snippet}
   {#snippet items({ variant })}
-    <NavigationItem {variant} onClick={() => (active = 'home')} active={active === 'home'}>
+    <NavigationItem {variant} onclick={() => (active = 'home')} active={active === 'home'}>
       Home
     </NavigationItem>
-    <NavigationItem {variant} onClick={() => (active = 'docs')} active={active === 'docs'}>
+    <NavigationItem {variant} onclick={() => (active = 'docs')} active={active === 'docs'}>
       Docs
     </NavigationItem>
-    <NavigationItem {variant} onClick={() => (active = 'blog')} active={active === 'blog'}>
+    <NavigationItem {variant} onclick={() => (active = 'blog')} active={active === 'blog'}>
       Blog
     </NavigationItem>
   {/snippet}

--- a/packages/playground/src/examples/navigation-item/button.example.svelte
+++ b/packages/playground/src/examples/navigation-item/button.example.svelte
@@ -1,6 +1,6 @@
 <script lang="ts" module>
   export const title = 'Button navigation item';
-  export const description = 'Renders a button element when onClick is provided instead of href.';
+  export const description = 'Renders a button element when onclick is provided instead of href.';
 </script>
 
 <script lang="ts">
@@ -10,13 +10,13 @@
 </script>
 
 <nav style="display: flex; gap: 0.5rem;">
-  <NavigationItem onClick={() => (active = 'dashboard')} active={active === 'dashboard'}>
+  <NavigationItem onclick={() => (active = 'dashboard')} active={active === 'dashboard'}>
     Dashboard
   </NavigationItem>
-  <NavigationItem onClick={() => (active = 'settings')} active={active === 'settings'}>
+  <NavigationItem onclick={() => (active = 'settings')} active={active === 'settings'}>
     Settings
   </NavigationItem>
-  <NavigationItem onClick={() => (active = 'billing')} active={active === 'billing'}>
+  <NavigationItem onclick={() => (active = 'billing')} active={active === 'billing'}>
     Billing
   </NavigationItem>
 </nav>

--- a/packages/testing/scripts/summarize-axe.ts
+++ b/packages/testing/scripts/summarize-axe.ts
@@ -112,12 +112,12 @@ async function main(): Promise<void> {
   }
 
   const topRules: RuleStat[] = [...ruleCounts.entries()]
-    .sort((a, b) => b[1].count - a[1].count)
+    .toSorted((a, b) => b[1].count - a[1].count)
     .slice(0, 5)
     .map(([ruleId, { count, help }]) => ({ ruleId, count, help }));
 
   const topComponents: ComponentStat[] = [...componentCounts.entries()]
-    .sort((a, b) => b[1] - a[1])
+    .toSorted((a, b) => b[1] - a[1])
     .slice(0, 5)
     .map(([slug, count]) => ({ slug, count }));
 
@@ -133,12 +133,16 @@ async function main(): Promise<void> {
   await mkdir(dirname(summaryPath), { recursive: true });
   await writeFile(summaryPath, JSON.stringify(summary, null, 2) + '\n');
 
-  console.log(`Axe summary: ${totalViolations} total violations across ${jsonFiles.length} result files`);
+  console.log(
+    `Axe summary: ${totalViolations} total violations across ${jsonFiles.length} result files`,
+  );
   console.log(
     `  By impact: critical=${byImpact.critical}, serious=${byImpact.serious}, moderate=${byImpact.moderate}, minor=${byImpact.minor}`,
   );
   if (topRules.length > 0) {
-    console.log(`  Top rules: ${topRules.map((rule) => `${rule.ruleId}(${rule.count})`).join(', ')}`);
+    console.log(
+      `  Top rules: ${topRules.map((rule) => `${rule.ruleId}(${rule.count})`).join(', ')}`,
+    );
   }
 }
 

--- a/packages/testing/src/helpers/artifact-path.ts
+++ b/packages/testing/src/helpers/artifact-path.ts
@@ -14,5 +14,11 @@ export function screenshotPath(key: ArtifactKey): string {
 }
 
 export function axeJsonPath(key: ArtifactKey): string {
-  return resolve(packageRoot(), 'test-results', 'axe', key.slug, `${key.theme}-${key.viewport}.json`);
+  return resolve(
+    packageRoot(),
+    'test-results',
+    'axe',
+    key.slug,
+    `${key.theme}-${key.viewport}.json`,
+  );
 }

--- a/scripts/next.ts
+++ b/scripts/next.ts
@@ -10,9 +10,9 @@
 //   bun scripts/next.ts --concurrency 3    # run 3 tasks in parallel
 //   bun scripts/next.ts --help
 
-import { parseArgs } from 'node:util';
 import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { join, resolve } from 'node:path';
+import { parseArgs } from 'node:util';
 
 // =============================================================================
 // Colors — Bun.color makes everything sparkle
@@ -161,7 +161,10 @@ async function runOkVisible(args: string[], options: RunOptions = {}): Promise<s
   return runOk(args, { ...options, tee: true });
 }
 
-async function runStreaming(args: string[], options: RunOptions = {}): Promise<{ exitCode: number; captured: string }> {
+async function runStreaming(
+  args: string[],
+  options: RunOptions = {},
+): Promise<{ exitCode: number; captured: string }> {
   const child = Bun.spawn(args, {
     cwd: options.cwd ?? process.cwd(),
     stdin: options.stdin === undefined ? 'ignore' : 'pipe',
@@ -228,7 +231,9 @@ type Task = {
 async function fetchNextTask(): Promise<Task | null> {
   const result = await run(['tasks', 'next']);
   if (result.exitCode !== 0) {
-    throw new Error(`tasks next failed (exit ${result.exitCode}):\n${result.stderr.trim() || result.stdout.trim()}`);
+    throw new Error(
+      `tasks next failed (exit ${result.exitCode}):\n${result.stderr.trim() || result.stdout.trim()}`,
+    );
   }
   const trimmed = result.stdout.trim();
   if (!trimmed) return null;
@@ -241,7 +246,9 @@ async function fetchNextTask(): Promise<Task | null> {
   try {
     return JSON.parse(trimmed.slice(start)) as Task;
   } catch (error) {
-    throw new Error(`tasks next emitted invalid JSON: ${(error as Error).message}\nRaw output:\n${trimmed}`);
+    throw new Error(
+      `tasks next emitted invalid JSON: ${(error as Error).message}\nRaw output:\n${trimmed}`,
+    );
   }
 }
 
@@ -250,7 +257,10 @@ async function getTask(id: string): Promise<Task> {
   return JSON.parse(result.trim()) as Task;
 }
 
-async function setStatus(id: string, status: 'in-progress' | 'in-review' | 'completed' | 'ready'): Promise<void> {
+async function setStatus(
+  id: string,
+  status: 'in-progress' | 'in-review' | 'completed' | 'ready',
+): Promise<void> {
   await runOk(['tasks', 'set-status', id, status]);
 }
 
@@ -360,7 +370,10 @@ async function tryClaimTask(taskId: string): Promise<boolean> {
   // before we got the lock (we won the mkdir but they won the status flip).
   const fresh = await getTask(taskId);
   if (fresh.status !== 'ready') {
-    log('INFO', `Task ${taskId.slice(0, 8)} no longer ready (status: ${fresh.status}) — releasing lock`);
+    log(
+      'INFO',
+      `Task ${taskId.slice(0, 8)} no longer ready (status: ${fresh.status}) — releasing lock`,
+    );
     releaseLock(directory);
     return false;
   }
@@ -389,7 +402,10 @@ async function claimNextTask(maxAttempts = 5): Promise<Task | null> {
     if (!candidate) return null;
     const won = await tryClaimTask(candidate.id);
     if (won) return candidate;
-    log('INFO', `Task ${candidate.id.slice(0, 8)} locked by another worker — trying next (${attempt}/${maxAttempts})`);
+    log(
+      'INFO',
+      `Task ${candidate.id.slice(0, 8)} locked by another worker — trying next (${attempt}/${maxAttempts})`,
+    );
     // Small jitter so multiple workers don't refetch in lockstep.
     await Bun.sleep(500 + Math.floor(Math.random() * 500));
   }
@@ -475,7 +491,9 @@ async function createWorktree(taskId: string, branch: string, baseBranch: string
   mkdirSync(resolve(directory, '..'), { recursive: true });
 
   if (await worktreeExists(directory)) {
-    const removed = await run(['git', 'worktree', 'remove', '--force', directory], { cwd: repoRoot });
+    const removed = await run(['git', 'worktree', 'remove', '--force', directory], {
+      cwd: repoRoot,
+    });
     if (removed.exitCode !== 0) {
       log('WARN', `Could not remove stale worktree at ${directory}: ${removed.stderr.trim()}`);
     }
@@ -485,7 +503,9 @@ async function createWorktree(taskId: string, branch: string, baseBranch: string
   // will surface when `git worktree add` rejects the branch below.
   await run(['git', 'branch', '-D', branch], { cwd: repoRoot });
 
-  await runOkVisible(['git', 'worktree', 'add', directory, '-b', branch, `origin/${baseBranch}`], { cwd: repoRoot });
+  await runOkVisible(['git', 'worktree', 'add', directory, '-b', branch, `origin/${baseBranch}`], {
+    cwd: repoRoot,
+  });
   activeWorktrees.add(directory);
   log('OK', `Worktree at ${palette.dim(directory)} on branch ${palette.task(branch)}`);
   return directory;
@@ -498,7 +518,9 @@ async function createWorktree(taskId: string, branch: string, baseBranch: string
  */
 async function cleanupWorktree(directory: string, branch?: string): Promise<void> {
   if (existsSync(directory)) {
-    const removed = await run(['git', 'worktree', 'remove', '--force', directory], { cwd: repoRoot });
+    const removed = await run(['git', 'worktree', 'remove', '--force', directory], {
+      cwd: repoRoot,
+    });
     if (removed.exitCode !== 0) {
       log('WARN', `worktree remove failed for ${directory}: ${removed.stderr.trim()}`);
     }
@@ -513,7 +535,9 @@ async function cleanupWorktree(directory: string, branch?: string): Promise<void
 }
 
 async function countCommitsAhead(worktree: string, baseBranch: string): Promise<number> {
-  const result = await run(['git', 'rev-list', '--count', `origin/${baseBranch}..HEAD`], { cwd: worktree });
+  const result = await run(['git', 'rev-list', '--count', `origin/${baseBranch}..HEAD`], {
+    cwd: worktree,
+  });
   if (result.exitCode !== 0) return 0;
   return Number.parseInt(result.stdout.trim(), 10) || 0;
 }
@@ -536,7 +560,17 @@ type PrSummary = {
 
 async function findOpenPr(branch: string): Promise<PrSummary | null> {
   const result = await run(
-    ['gh', 'pr', 'list', '--head', branch, '--state', 'open', '--json', 'number,url,state,mergeable,mergeStateStatus'],
+    [
+      'gh',
+      'pr',
+      'list',
+      '--head',
+      branch,
+      '--state',
+      'open',
+      '--json',
+      'number,url,state,mergeable,mergeStateStatus',
+    ],
     { cwd: repoRoot },
   );
   if (result.exitCode !== 0) return null;
@@ -548,7 +582,9 @@ type ChecksSummary = { pending: number; failing: number; passing: number; total:
 
 /** Fetch the aggregate CI state for a PR. `gh pr checks` exits non-zero on failing checks, so always parse output. */
 async function getPrChecks(prNumber: number): Promise<ChecksSummary> {
-  const result = await run(['gh', 'pr', 'checks', String(prNumber), '--json', 'state'], { cwd: repoRoot });
+  const result = await run(['gh', 'pr', 'checks', String(prNumber), '--json', 'state'], {
+    cwd: repoRoot,
+  });
   const empty: ChecksSummary = { pending: 0, failing: 0, passing: 0, total: 0 };
 
   const parsed = parseChecksJson(result.stdout);
@@ -584,7 +620,13 @@ function parseChecksJson(stdout: string): ChecksSummary | null {
     summary.total++;
     const upper = state.toUpperCase();
     if (upper === 'PENDING' || upper === 'QUEUED' || upper === 'IN_PROGRESS') summary.pending++;
-    else if (upper === 'FAILURE' || upper === 'ERROR' || upper === 'CANCELLED' || upper === 'TIMED_OUT') summary.failing++;
+    else if (
+      upper === 'FAILURE' ||
+      upper === 'ERROR' ||
+      upper === 'CANCELLED' ||
+      upper === 'TIMED_OUT'
+    )
+      summary.failing++;
     else if (upper === 'SUCCESS') summary.passing++;
   }
   return summary;
@@ -610,11 +652,17 @@ async function getReviewState(prNumber: number): Promise<ReviewState> {
   }`;
   const result = await run(
     [
-      'gh', 'api', 'graphql',
-      '-f', `query=${query}`,
-      '-F', `owner=${repoInfo.owner.login}`,
-      '-F', `name=${repoInfo.name}`,
-      '-F', `number=${prNumber}`,
+      'gh',
+      'api',
+      'graphql',
+      '-f',
+      `query=${query}`,
+      '-F',
+      `owner=${repoInfo.owner.login}`,
+      '-F',
+      `name=${repoInfo.name}`,
+      '-F',
+      `number=${prNumber}`,
     ],
     { cwd: repoRoot },
   );
@@ -669,7 +717,9 @@ function isReviewStatePayload(value: unknown): value is ReviewStatePayload {
 }
 
 async function mergePr(prNumber: number): Promise<void> {
-  await runOkVisible(['gh', 'pr', 'merge', String(prNumber), '--squash', '--delete-branch'], { cwd: repoRoot });
+  await runOkVisible(['gh', 'pr', 'merge', String(prNumber), '--squash', '--delete-branch'], {
+    cwd: repoRoot,
+  });
 }
 
 // =============================================================================
@@ -728,7 +778,9 @@ Do not modify any source files. Do not commit. Do not open a PR.`;
 async function driveImplementation(task: Task, worktree: string, planPath: string): Promise<void> {
   log('PHASE', `Implementing task ${palette.task(task.id.slice(0, 8))} in worktree`);
 
-  const planContent = existsSync(planPath) ? await Bun.file(planPath).text() : '(plan file missing)';
+  const planContent = existsSync(planPath)
+    ? await Bun.file(planPath).text()
+    : '(plan file missing)';
 
   const prompt = `You are working on this task in an isolated git worktree.
 
@@ -788,7 +840,10 @@ async function ensurePr(task: Task, worktree: string, branch: string): Promise<P
   if (created.exitCode !== 0) {
     pr = await findOpenPr(branch);
     if (pr) {
-      log('OK', `PR already existed (raced with committee-review) #${pr.number}: ${palette.dim(pr.url)}`);
+      log(
+        'OK',
+        `PR already existed (raced with committee-review) #${pr.number}: ${palette.dim(pr.url)}`,
+      );
       return pr;
     }
     throw new Error(`gh pr create failed and no open PR found:\n${created.stderr.trim()}`);
@@ -848,7 +903,9 @@ function formatSnapshot(snapshot: ReadinessSnapshot): string {
     palette.err(`${checks.failing} fail`),
   ];
   const threadStr =
-    unresolvedThreads === 0 ? palette.ok('0 unresolved') : palette.warn(`${unresolvedThreads} unresolved`);
+    unresolvedThreads === 0
+      ? palette.ok('0 unresolved')
+      : palette.warn(`${unresolvedThreads} unresolved`);
   const botStr =
     expectedBotsPending.length === 0
       ? palette.ok('all bots in')
@@ -866,7 +923,10 @@ function normalizeLogin(login: string): string {
 }
 
 async function getReadiness(prNumber: number, expectedBots: string[]): Promise<ReadinessSnapshot> {
-  const [checks, reviewState] = await Promise.all([getPrChecks(prNumber), getReviewState(prNumber)]);
+  const [checks, reviewState] = await Promise.all([
+    getPrChecks(prNumber),
+    getReviewState(prNumber),
+  ]);
   const seenLogins = new Set(Array.from(reviewState.reviewerLogins).map(normalizeLogin));
   const expectedBotsPending = expectedBots.filter((bot) => !seenLogins.has(normalizeLogin(bot)));
   return {
@@ -880,7 +940,11 @@ async function getReadiness(prNumber: number, expectedBots: string[]): Promise<R
 /** Poll until pending checks resolve or the budget runs out. Returns the last snapshot regardless. */
 async function waitForChecks(prNumber: number, expectedBots: string[]): Promise<ReadinessSnapshot> {
   let snapshot = await getReadiness(prNumber, expectedBots);
-  for (let attempt = 1; attempt <= CHECK_POLL_MAX_ATTEMPTS && snapshot.checks.pending > 0; attempt++) {
+  for (
+    let attempt = 1;
+    attempt <= CHECK_POLL_MAX_ATTEMPTS && snapshot.checks.pending > 0;
+    attempt++
+  ) {
     log(
       'INFO',
       `Checks pending (${attempt}/${CHECK_POLL_MAX_ATTEMPTS}) — sleeping ${CHECK_POLL_INTERVAL_MS / 1000}s: ${formatSnapshot(snapshot)}`,
@@ -889,7 +953,10 @@ async function waitForChecks(prNumber: number, expectedBots: string[]): Promise<
     snapshot = await getReadiness(prNumber, expectedBots);
   }
   if (snapshot.checks.pending > 0) {
-    log('WARN', `Checks still pending after ${CHECK_POLL_MAX_ATTEMPTS} attempts — proceeding anyway`);
+    log(
+      'WARN',
+      `Checks still pending after ${CHECK_POLL_MAX_ATTEMPTS} attempts — proceeding anyway`,
+    );
   }
   return snapshot;
 }
@@ -914,7 +981,10 @@ async function waitForReviewBots(
     snapshot = await getReadiness(prNumber, expectedBots);
   }
   if (snapshot.expectedBotsPending.length > 0) {
-    log('WARN', `Bots never reviewed within budget: ${snapshot.expectedBotsPending.join(', ')} — proceeding anyway`);
+    log(
+      'WARN',
+      `Bots never reviewed within budget: ${snapshot.expectedBotsPending.join(', ')} — proceeding anyway`,
+    );
   }
   return snapshot;
 }
@@ -933,7 +1003,11 @@ function isReady(snapshot: ReadinessSnapshot): boolean {
  * Drive the PR to a mergeable state. Detects readiness locally; only spawns
  * /address-pr when there is concrete failing-CI or unresolved-thread work.
  */
-async function pollPrUntilReady(prNumber: number, worktree: string, expectedBots: string[]): Promise<void> {
+async function pollPrUntilReady(
+  prNumber: number,
+  worktree: string,
+  expectedBots: string[],
+): Promise<void> {
   for (let round = 1; round <= ADDRESS_PR_MAX_ROUNDS; round++) {
     log('PHASE', `PR readiness check ${round}/${ADDRESS_PR_MAX_ROUNDS} for PR #${prNumber}`);
 
@@ -1131,7 +1205,10 @@ async function spawnWorkerInline(index: number): Promise<number> {
   activeChildren.add(child);
 
   const decoder = new TextDecoder();
-  const stream = async (source: ReadableStream<Uint8Array>, sink: NodeJS.WriteStream): Promise<void> => {
+  const stream = async (
+    source: ReadableStream<Uint8Array>,
+    sink: NodeJS.WriteStream,
+  ): Promise<void> => {
     let buffer = '';
     for await (const chunk of source) {
       buffer += decoder.decode(chunk, { stream: true });
@@ -1146,7 +1223,11 @@ async function spawnWorkerInline(index: number): Promise<number> {
   };
 
   try {
-    await Promise.all([stream(child.stdout, process.stdout), stream(child.stderr, process.stderr), child.exited]);
+    await Promise.all([
+      stream(child.stdout, process.stdout),
+      stream(child.stderr, process.stderr),
+      child.exited,
+    ]);
     return await child.exited;
   } finally {
     activeChildren.delete(child);
@@ -1155,7 +1236,9 @@ async function spawnWorkerInline(index: number): Promise<number> {
 
 async function runInlineConcurrency(concurrency: number): Promise<void> {
   log('INFO', palette.heading(`Starting ${concurrency} inline workers (no tmux)`));
-  const results = await Promise.all(Array.from({ length: concurrency }, (_, index) => spawnWorkerInline(index + 1)));
+  const results = await Promise.all(
+    Array.from({ length: concurrency }, (_, index) => spawnWorkerInline(index + 1)),
+  );
   const successes = results.filter((code) => code === 0).length;
   const noWork = results.filter((code) => code === 2).length;
   const failures = results.filter((code) => code === 1).length;
@@ -1183,8 +1266,16 @@ async function runTmuxConcurrency(concurrency: number): Promise<void> {
 
   // Create the session detached with worker 1.
   await runOk([
-    'tmux', 'new-session', '-d', '-s', session, '-n', 'worker-1',
-    'bash', '-lc', `NEXT_WORKER_INDEX=1 ${workerCommand}`,
+    'tmux',
+    'new-session',
+    '-d',
+    '-s',
+    session,
+    '-n',
+    'worker-1',
+    'bash',
+    '-lc',
+    `NEXT_WORKER_INDEX=1 ${workerCommand}`,
   ]);
 
   // Keep dead panes visible so output is still readable on attach.
@@ -1192,8 +1283,15 @@ async function runTmuxConcurrency(concurrency: number): Promise<void> {
 
   for (let index = 2; index <= concurrency; index++) {
     await runOk([
-      'tmux', 'new-window', '-t', session, '-n', `worker-${index}`,
-      'bash', '-lc', `NEXT_WORKER_INDEX=${index} ${workerCommand}`,
+      'tmux',
+      'new-window',
+      '-t',
+      session,
+      '-n',
+      `worker-${index}`,
+      'bash',
+      '-lc',
+      `NEXT_WORKER_INDEX=${index} ${workerCommand}`,
     ]);
   }
 
@@ -1205,7 +1303,14 @@ async function runTmuxConcurrency(concurrency: number): Promise<void> {
   const start = Date.now();
 
   while (true) {
-    const list = await run(['tmux', 'list-windows', '-t', session, '-F', '#{window_name}:#{pane_dead}']);
+    const list = await run([
+      'tmux',
+      'list-windows',
+      '-t',
+      session,
+      '-F',
+      '#{window_name}:#{pane_dead}',
+    ]);
     if (list.exitCode !== 0) {
       log('INFO', `tmux session ${session} ended`);
       return;
@@ -1220,7 +1325,10 @@ async function runTmuxConcurrency(concurrency: number): Promise<void> {
       return;
     }
     if (Date.now() - start > TMUX_POLL_TIMEOUT_MS) {
-      log('ERROR', `tmux session ${session} exceeded 6h supervisor timeout — leaving session running for inspection`);
+      log(
+        'ERROR',
+        `tmux session ${session} exceeded 6h supervisor timeout — leaving session running for inspection`,
+      );
       return;
     }
     await Bun.sleep(15_000);
@@ -1241,7 +1349,10 @@ let cleaningUp = false;
 function cleanupAndExit(code: number): never {
   if (cleaningUp) process.exit(code);
   cleaningUp = true;
-  log('WARN', `Caught signal — tearing down ${activeChildren.size} child(ren), ${activeWorktrees.size} worktree(s), ${heldLocks.size} lock(s)`);
+  log(
+    'WARN',
+    `Caught signal — tearing down ${activeChildren.size} child(ren), ${activeWorktrees.size} worktree(s), ${heldLocks.size} lock(s)`,
+  );
 
   // 1. SIGTERM all active children.
   for (const child of activeChildren) {
@@ -1360,7 +1471,14 @@ async function preflightChecks(): Promise<void> {
   // We send the cheapest possible prompt and bound the call at 30s.
   log('INFO', 'Validating claude -p invocation (cheap smoke test)…');
   const claudeCheck = await run(
-    ['claude', '-p', '--dangerously-skip-permissions', '--model', 'sonnet', 'reply with the single word: ok'],
+    [
+      'claude',
+      '-p',
+      '--dangerously-skip-permissions',
+      '--model',
+      'sonnet',
+      'reply with the single word: ok',
+    ],
     { env: { ...process.env, CLAUDE_BUDGET_MS: '30000' }, tee: true },
   );
   if (claudeCheck.exitCode !== 0) {
@@ -1448,7 +1566,8 @@ async function main(): Promise<void> {
       log('OK', palette.bold(palette.ok(`Queue drained after ${batch - 1} batch(es)`)));
       return;
     }
-    if (serialize) log('INFO', palette.heading(`Serialize batch ${batch} (concurrency ${concurrency})`));
+    if (serialize)
+      log('INFO', palette.heading(`Serialize batch ${batch} (concurrency ${concurrency})`));
 
     if (hasTmux()) {
       await runTmuxConcurrency(concurrency);


### PR DESCRIPTION
## Summary
This PR refines navigation primitives to support a robust mobile-collapse pattern and cleaner APIs:
- Added explicit `NavigationBar` navigation toggle and open-state contract (`menuToggle`, `mobileMenuOpen`, `navAriaLabel`, `aria-controls`/`aria-expanded` injection).
- Simplified `NavigationBar` internals by removing derived indirection and moving focus return to synchronous Escape handling.
- Updated `NavigationItem` to use `aria-current="page"` consistently and add `variant` layout propagation via `data-variant`.
- Expanded accessibility docs for both components.
- Added focused tests for menu toggle behavior, keyboard close, second-click close, and variant attributes.
- Updated example and consumer usage for the new `items({ variant })` + `menuToggle` pattern.

## Review committee
Pre-reviewed by: [frontend-architect, ux-designer, testing-expert, simplicity-engineer, prose-editor, junior-engineer, codex]
- Round 1: 1
- Round 2: 2
- All must-fix items addressed

## Test plan
- `bun test packages/components/src/components/navigation-bar.test.ts`
- `bun test packages/components/src/components/navigation-item.test.ts`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Public APIs for `NavigationBar` and `NavigationItem` change (new snippet contracts and `onClick`→`onclick`), which can break consumers and alter navigation behavior on small viewports.
> 
> **Overview**
> Adds an opt-in mobile-collapsible mode to `NavigationBar` via new `menuToggle` and bindable `mobileMenuOpen`, injects toggle ARIA attributes (`aria-expanded`/`aria-controls`), scopes Escape-to-close + focus return to the `<nav>`, and passes a `{ variant }` context into the `items` snippet.
> 
> Updates `NavigationItem` to use `onclick` (instead of `onClick`), standardizes active-state signaling to `aria-current="page"` for both link and button arms, and introduces a `variant` prop emitted as `data-variant` with new mobile-stacked CSS.
> 
> Expands a11y documentation, exports the new NavigationBar types, updates fixtures/playground examples to the new snippet/variant pattern, and adds comprehensive unit tests around toggle behavior, rest-prop precedence, Escape handling, and variant propagation. Also includes minor formatting-only tweaks in a few scripts/docs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f9ca8cf7a5525a11996483e6cb83740226c9b2a6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->