### PR TITLE
next/ecf96e49

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -281,6 +281,10 @@
       "svelte": "./src/components/stat.svelte",
       "types": "./dist/components/stat.svelte.d.ts"
     },
+    "./steps": {
+      "svelte": "./src/components/steps.svelte",
+      "types": "./dist/components/steps.svelte.d.ts"
+    },
     "./surface": {
       "svelte": "./src/components/surface.svelte",
       "types": "./dist/components/surface.svelte.d.ts"

--- a/packages/components/src/components/progress.test.ts
+++ b/packages/components/src/components/progress.test.ts
@@ -119,23 +119,27 @@ const progressCssPath = join(import.meta.dir, '../styles/components/progress.css
 describe('Progress CSS reduced-motion audit', () => {
   test('progress.css disables the indeterminate bar animation under prefers-reduced-motion: reduce', async () => {
     const css = await Bun.file(progressCssPath).text();
-    const allBlockText = extractReducedMotionBlocks(css).join('\n');
+    const blocks = extractReducedMotionBlocks(css);
 
-    const hasBarRule =
-      allBlockText.includes('.cinder-progress--bar .cinder-progress__fill--indeterminate') &&
-      allBlockText.includes('animation: none');
+    const barRuleBlock = blocks.find(
+      (block) =>
+        block.includes('.cinder-progress--bar .cinder-progress__fill--indeterminate') &&
+        block.includes('animation: none'),
+    );
 
-    expect(hasBarRule).toBe(true);
+    expect(barRuleBlock).not.toBeUndefined();
   });
 
   test('progress.css disables the indeterminate ring animation under prefers-reduced-motion: reduce', async () => {
     const css = await Bun.file(progressCssPath).text();
-    const allBlockText = extractReducedMotionBlocks(css).join('\n');
+    const blocks = extractReducedMotionBlocks(css);
 
-    const hasRingRule =
-      allBlockText.includes('.cinder-progress--ring .cinder-progress__fill--indeterminate') &&
-      allBlockText.includes('animation: none');
+    const ringRuleBlock = blocks.find(
+      (block) =>
+        block.includes('.cinder-progress--ring .cinder-progress__fill--indeterminate') &&
+        block.includes('animation: none'),
+    );
 
-    expect(hasRingRule).toBe(true);
+    expect(ringRuleBlock).not.toBeUndefined();
   });
 });

--- a/packages/components/src/components/progress.test.ts
+++ b/packages/components/src/components/progress.test.ts
@@ -1,5 +1,6 @@
 /// <reference lib="dom" />
 import { describe, expect, test } from 'bun:test';
+import { join } from 'node:path';
 
 import { setupHappyDom } from '../test/happy-dom.ts';
 
@@ -70,5 +71,71 @@ describe('Progress (ring)', () => {
     const { container } = render(Progress, { value: 60, variant: 'ring', size: 'lg' });
     const el = container.querySelector('[role="progressbar"]');
     expect(el?.getAttribute('data-cinder-size')).toBe('lg');
+  });
+});
+
+/**
+ * Extracts all @media (prefers-reduced-motion: reduce) block bodies from a CSS
+ * string by balancing braces. Returns an array of block bodies (the content
+ * between the outer { and }).
+ */
+function extractReducedMotionBlocks(css: string): string[] {
+  const blocks: string[] = [];
+  const token = 'prefers-reduced-motion: reduce';
+  let searchFrom = 0;
+
+  while (true) {
+    const tokenIndex = css.indexOf(token, searchFrom);
+    if (tokenIndex === -1) break;
+
+    const openBrace = css.indexOf('{', tokenIndex);
+    if (openBrace === -1) break;
+
+    let depth = 0;
+    let closeIndex = -1;
+    for (let i = openBrace; i < css.length; i++) {
+      if (css[i] === '{') depth++;
+      else if (css[i] === '}') {
+        depth--;
+        if (depth === 0) {
+          closeIndex = i;
+          break;
+        }
+      }
+    }
+
+    if (closeIndex !== -1) {
+      blocks.push(css.slice(openBrace + 1, closeIndex));
+    }
+
+    searchFrom = closeIndex === -1 ? openBrace + 1 : closeIndex + 1;
+  }
+
+  return blocks;
+}
+
+const progressCssPath = join(import.meta.dir, '../styles/components/progress.css');
+
+describe('Progress CSS reduced-motion audit', () => {
+  test('progress.css disables the indeterminate bar animation under prefers-reduced-motion: reduce', async () => {
+    const css = await Bun.file(progressCssPath).text();
+    const allBlockText = extractReducedMotionBlocks(css).join('\n');
+
+    const hasBarRule =
+      allBlockText.includes('.cinder-progress--bar .cinder-progress__fill--indeterminate') &&
+      allBlockText.includes('animation: none');
+
+    expect(hasBarRule).toBe(true);
+  });
+
+  test('progress.css disables the indeterminate ring animation under prefers-reduced-motion: reduce', async () => {
+    const css = await Bun.file(progressCssPath).text();
+    const allBlockText = extractReducedMotionBlocks(css).join('\n');
+
+    const hasRingRule =
+      allBlockText.includes('.cinder-progress--ring .cinder-progress__fill--indeterminate') &&
+      allBlockText.includes('animation: none');
+
+    expect(hasRingRule).toBe(true);
   });
 });

--- a/packages/components/src/components/steps.a11y.md
+++ b/packages/components/src/components/steps.a11y.md
@@ -23,7 +23,7 @@ The active step is marked with `aria-current="step"` on its `<li>`. This is one 
 
 The marker element (`<span class="cinder-steps__marker">`) is `aria-hidden="true"`. It is purely decorative — the checkmark icon and step number carry no semantic weight themselves.
 
-Completed steps render a visually-hidden `<span class="cinder-steps__sr-only">` **inside `.cinder-steps__body`**, before the label. This produces the announcement:
+Completed steps render a visually-hidden `<span class="cinder-steps__sr-only">` **inside `.cinder-steps__body`**, before the label. A separate visually-hidden whitespace separator follows that span so the caller-provided `completedLabel` remains verbatim while the announcement still has a word boundary. This produces the announcement:
 
 > "Completed Set up profile Tell us about yourself"
 

--- a/packages/components/src/components/steps.a11y.md
+++ b/packages/components/src/components/steps.a11y.md
@@ -1,0 +1,56 @@
+# Steps — Accessibility Notes
+
+## Why `<nav>` + `<ol>`, not `role="progressbar"`
+
+A wizard step indicator is a **navigational summary** of where the user is in a discrete sequence. `role="progressbar"` is defined in ARIA as a meter — a quantitative value between numeric bounds. Applying it to a step indicator is incorrect for two reasons:
+
+1. There is no meaningful numeric value (what is "55%" of "step 2 of 4"?).
+2. Screen readers announce `progressbar` with a computed percentage derived from `aria-valuenow / aria-valuemax`, which is nonsensical for discrete labeled steps.
+
+The correct structure is a `<nav>` landmark wrapping an `<ol>`. This gives users:
+
+- A named navigation landmark (`aria-label` on `<nav>`) they can jump to directly.
+- Ordered list semantics ("item 1 of 4", "item 2 of 4") that convey sequence.
+- No percentage fabrication.
+
+## `aria-current="step"`
+
+The active step is marked with `aria-current="step"` on its `<li>`. This is one of the spec-defined tokens for `aria-current` alongside `page`, `location`, `date`, `time`, and `true`. Screen readers announce it as "current step" or equivalent, conveying the user's position without requiring an additional visually-hidden label.
+
+`aria-current` is applied to the `<li>` (the semantic step entity), not to a child `<span>`.
+
+## Visually-hidden completion text
+
+The marker element (`<span class="cinder-steps__marker">`) is `aria-hidden="true"`. It is purely decorative — the checkmark icon and step number carry no semantic weight themselves.
+
+Completed steps render a visually-hidden `<span class="cinder-steps__sr-only">` **inside `.cinder-steps__body`**, before the label. This produces the announcement:
+
+> "Completed Set up profile Tell us about yourself"
+
+The `completedLabel` prop (default `'Completed'`) lets consuming teams localize or override this text without forking the component.
+
+**Current step:** state is conveyed solely by `aria-current="step"` on the `<li>`. No additional visually-hidden text is added to avoid duplicate announcements.
+
+**Upcoming steps:** no state text — the visible label alone is sufficient.
+
+## `completedLabel` contract
+
+The prop value is rendered verbatim with no punctuation added by the component. If the caller wants a trailing comma for pause cuing (e.g., "Completed, Set up profile"), they should pass `completedLabel="Completed,"`.
+
+## Default `label` value
+
+The wrapping `<nav>` defaults to `aria-label="Progress"`. Callers on pages with multiple navigation regions should pass a distinct `label` (e.g., `label="Checkout steps"`) to differentiate the landmark from breadcrumbs, primary navigation, and pagination.
+
+## Marker contrast and forced-colors
+
+Completed step markers use `background: var(--cinder-accent)` with `color: var(--cinder-accent-contrast)`. The `--cinder-accent-contrast` token is defined in `tokens-base.css` as a `light-dark()` value that maintains 4.5:1 contrast ratio in both light and dark themes.
+
+The current-step marker uses a `box-shadow` ring. In Windows High Contrast Mode (`forced-colors: active`), `box-shadow` is suppressed by the browser. The CSS includes a `@media (forced-colors: active)` block that restores the ring as a `ButtonText`-colored `outline`.
+
+## Touch targets
+
+The step markers (24px × 24px) are non-interactive display elements. Touch target minimums (WCAG 2.5.5 / 2.5.8) apply to interactive controls, not static indicators.
+
+## No keyboard interaction
+
+This component is read-only — steps are not clickable or focusable. If a future use case requires navigating backward through completed steps, an optional `onSelect` callback should be added to render completed steps as `<button>` elements.

--- a/packages/components/src/components/steps.svelte
+++ b/packages/components/src/components/steps.svelte
@@ -83,6 +83,7 @@
         <span class="cinder-steps__body">
           {#if isComplete}
             <span class="cinder-steps__sr-only">{completedLabel}</span>
+            <span class="cinder-steps__sr-only-separator"> </span>
           {/if}
           <span class="cinder-steps__label">{step.label}</span>
           {#if step.description}

--- a/packages/components/src/components/steps.svelte
+++ b/packages/components/src/components/steps.svelte
@@ -1,0 +1,102 @@
+<script lang="ts" module>
+  export type StepsOrientation = 'horizontal' | 'vertical';
+
+  export type StepItem = {
+    /** Stable identifier used as the keyed-each key. Must be unique. */
+    id: string;
+    /** Visible label for the step. */
+    label: string;
+    /** Optional secondary text shown beneath the label. */
+    description?: string;
+  };
+
+  export type StepsProps = {
+    /** Ordered list of step entries from first to last. */
+    steps: StepItem[];
+    /**
+     * Zero-based index of the active step. Steps with index < currentStep are
+     * "completed". Pass `steps.length` to mark every step as complete (terminal
+     * "done" state).
+     */
+    currentStep: number;
+    /** Layout direction. Defaults to 'horizontal'. */
+    orientation?: StepsOrientation;
+    /** Accessible name for the wrapping nav landmark. Defaults to 'Progress'. */
+    label?: string;
+    /**
+     * Visually-hidden text prepended to completed steps so screen readers
+     * announce state + label. Defaults to 'Completed'.
+     */
+    completedLabel?: string;
+    /** Additional class names merged with `.cinder-steps`. */
+    class?: string;
+  };
+</script>
+
+<script lang="ts">
+  import { cn } from '../utilities/class-names.ts';
+  import { Check } from './icons/index.ts';
+
+  let {
+    steps,
+    currentStep,
+    orientation = 'horizontal',
+    label = 'Progress',
+    completedLabel = 'Completed',
+    class: className,
+  }: StepsProps = $props();
+
+  const clampedCurrent = $derived(
+    steps.length === 0 ? undefined : Math.max(0, Math.min(steps.length, currentStep)),
+  );
+
+  type StepState = 'complete' | 'current' | 'upcoming';
+
+  const stepStates = $derived<StepState[]>(
+    steps.map((_, index) => {
+      if (clampedCurrent === undefined) return 'upcoming';
+      if (index < clampedCurrent) return 'complete';
+      if (index === clampedCurrent) return 'current';
+      return 'upcoming';
+    }),
+  );
+</script>
+
+<nav class={cn('cinder-steps', className)} aria-label={label} data-cinder-orientation={orientation}>
+  <ol class="cinder-steps__list">
+    {#each steps as step, index (step.id)}
+      {@const state = stepStates[index]}
+      {@const isCurrent = state === 'current'}
+      {@const isComplete = state === 'complete'}
+      <li
+        class="cinder-steps__item"
+        data-cinder-state={state}
+        {...isCurrent ? { 'aria-current': 'step' } : {}}
+      >
+        <span class="cinder-steps__marker" aria-hidden="true">
+          {#if isComplete}
+            <Check class="cinder-steps__check" />
+          {:else}
+            <span class="cinder-steps__index">{index + 1}</span>
+          {/if}
+        </span>
+        {#if isComplete}
+          <span class="cinder-steps__sr-only">{completedLabel},</span>
+        {/if}
+        <span class="cinder-steps__body">
+          <span class="cinder-steps__label">{step.label}</span>
+          {#if step.description}
+            <span class="cinder-steps__description">{step.description}</span>
+          {/if}
+        </span>
+        {#if index < steps.length - 1}
+          <span
+            class="cinder-steps__connector"
+            data-cinder-state={isComplete ? 'complete' : 'upcoming'}
+            aria-hidden="true"
+          ></span>
+        {/if}
+      </li>
+    {/each}
+  </ol>
+</nav>

--- a/packages/components/src/components/steps.svelte
+++ b/packages/components/src/components/steps.svelte
@@ -80,10 +80,10 @@
             <span class="cinder-steps__index">{index + 1}</span>
           {/if}
         </span>
-        {#if isComplete}
-          <span class="cinder-steps__sr-only">{completedLabel},</span>
-        {/if}
         <span class="cinder-steps__body">
+          {#if isComplete}
+            <span class="cinder-steps__sr-only">{completedLabel}</span>
+          {/if}
           <span class="cinder-steps__label">{step.label}</span>
           {#if step.description}
             <span class="cinder-steps__description">{step.description}</span>

--- a/packages/components/src/components/steps.test.ts
+++ b/packages/components/src/components/steps.test.ts
@@ -1,0 +1,162 @@
+/// <reference lib="dom" />
+import { describe, expect, test } from 'bun:test';
+
+import { setupHappyDom } from '../test/happy-dom.ts';
+
+setupHappyDom();
+
+const { render } = await import('@testing-library/svelte');
+const { default: Steps } = await import('./steps.svelte');
+
+const defaultSteps = [
+  { id: 'a', label: 'Set up profile', description: 'Tell us about yourself' },
+  { id: 'b', label: 'Connect account', description: 'Link your services' },
+  { id: 'c', label: 'Invite teammates' },
+  { id: 'd', label: 'Done' },
+];
+
+describe('Steps', () => {
+  test('renders the supplied step labels and descriptions', () => {
+    const { container } = render(Steps, { steps: defaultSteps, currentStep: 1 });
+    for (const step of defaultSteps) {
+      expect(container.textContent).toContain(step.label);
+    }
+    expect(container.textContent).toContain('Tell us about yourself');
+    expect(container.textContent).toContain('Link your services');
+  });
+
+  test('marks the active step with aria-current="step" on the list item', () => {
+    const { container } = render(Steps, { steps: defaultSteps, currentStep: 1 });
+    const current = Array.from(container.querySelectorAll('[aria-current="step"]'));
+    expect(current.length).toBe(1);
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    expect(current[0]!.tagName).toBe('LI');
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    expect(current[0]!.textContent).toContain('Connect account');
+  });
+
+  test('completed steps include visually-hidden completion text inside the li', () => {
+    const { container } = render(Steps, { steps: defaultSteps, currentStep: 2 });
+    const items = Array.from(container.querySelectorAll('li'));
+    expect(items.length).toBe(4);
+
+    const [first, second, third, fourth] = items;
+
+    // First two are complete
+    for (const item of [first!, second!]) {
+      const srOnly = item.querySelector('.cinder-steps__sr-only');
+      expect(srOnly).not.toBeNull();
+      expect(srOnly?.textContent).toContain('Completed');
+      expect(item.querySelector('.cinder-steps__check')).not.toBeNull();
+      expect(item.querySelector('.cinder-steps__index')).toBeNull();
+    }
+
+    // Current and upcoming should not have sr-only
+    for (const item of [third!, fourth!]) {
+      expect(item.querySelector('.cinder-steps__sr-only')).toBeNull();
+      expect(item.querySelector('.cinder-steps__index')).not.toBeNull();
+    }
+  });
+
+  test('completedLabel prop overrides the default visually-hidden text', () => {
+    const { container } = render(Steps, {
+      steps: defaultSteps,
+      currentStep: 2,
+      completedLabel: 'Done',
+    });
+    const srOnlySpans = container.querySelectorAll('.cinder-steps__sr-only');
+    expect(srOnlySpans.length).toBe(2);
+    for (const span of srOnlySpans) {
+      expect(span.textContent).toContain('Done');
+    }
+  });
+
+  test('orientation prop drives layout via data-cinder-orientation', () => {
+    const { container: hContainer } = render(Steps, {
+      steps: defaultSteps,
+      currentStep: 0,
+    });
+    expect(hContainer.querySelector('nav')?.getAttribute('data-cinder-orientation')).toBe(
+      'horizontal',
+    );
+
+    const { container: vContainer } = render(Steps, {
+      steps: defaultSteps,
+      currentStep: 0,
+      orientation: 'vertical',
+    });
+    expect(vContainer.querySelector('nav')?.getAttribute('data-cinder-orientation')).toBe(
+      'vertical',
+    );
+  });
+
+  test('does not render role="progressbar"', () => {
+    const { container } = render(Steps, { steps: defaultSteps, currentStep: 1 });
+    expect(container.querySelector('[role="progressbar"]')).toBeNull();
+  });
+
+  test('clamps out-of-range currentStep values', () => {
+    const { container: loContainer } = render(Steps, { steps: defaultSteps, currentStep: -3 });
+    const loCurrent = Array.from(loContainer.querySelectorAll('[aria-current="step"]'));
+    expect(loCurrent.length).toBe(1);
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    expect(loCurrent[0]!.textContent).toContain('Set up profile');
+
+    const { container: hiContainer } = render(Steps, { steps: defaultSteps, currentStep: 99 });
+    // All steps complete, no current
+    expect(hiContainer.querySelectorAll('[aria-current="step"]').length).toBe(0);
+    expect(hiContainer.querySelectorAll('.cinder-steps__sr-only').length).toBe(4);
+  });
+
+  test('currentStep === steps.length renders all steps as complete with no current', () => {
+    const { container } = render(Steps, { steps: defaultSteps, currentStep: 4 });
+    expect(container.querySelectorAll('[aria-current="step"]').length).toBe(0);
+    expect(container.querySelectorAll('.cinder-steps__sr-only').length).toBe(4);
+  });
+
+  test('exposes the nav landmark with the default label', () => {
+    const { container } = render(Steps, { steps: defaultSteps, currentStep: 0 });
+    const nav = container.querySelector('nav');
+    expect(nav).not.toBeNull();
+    expect(nav?.getAttribute('aria-label')).toBe('Progress');
+  });
+
+  test('label prop overrides the nav accessible name', () => {
+    const { container } = render(Steps, { steps: defaultSteps, currentStep: 0, label: 'Wizard' });
+    const nav = container.querySelector('nav');
+    expect(nav).not.toBeNull();
+    expect(nav?.getAttribute('aria-label')).toBe('Wizard');
+  });
+
+  test('empty steps array renders an empty nav without throwing', () => {
+    const { container } = render(Steps, { steps: [], currentStep: 0 });
+    const nav = container.querySelector('nav');
+    expect(nav).not.toBeNull();
+    const ol = container.querySelector('ol');
+    expect(ol).not.toBeNull();
+    expect(container.querySelectorAll('li').length).toBe(0);
+    expect(container.querySelectorAll('[aria-current="step"]').length).toBe(0);
+  });
+
+  test('reorder preserves the list-item DOM identity by id', async () => {
+    const stepsABC = [
+      { id: 'a', label: 'Alpha' },
+      { id: 'b', label: 'Beta' },
+      { id: 'c', label: 'Gamma' },
+    ];
+
+    const { container, rerender } = render(Steps, { steps: stepsABC, currentStep: 0 });
+    const items = container.querySelectorAll('li');
+    const betaNode = items[1];
+
+    await rerender({
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      steps: [stepsABC[2]!, stepsABC[1]!, stepsABC[0]!],
+      currentStep: 0,
+    });
+
+    const reorderedItems = container.querySelectorAll('li');
+    // Beta was at index 1 (id="b"), now at index 1 in [c, b, a] — same DOM node
+    expect(reorderedItems[1]).toBe(betaNode);
+  });
+});

--- a/packages/components/src/components/steps.test.ts
+++ b/packages/components/src/components/steps.test.ts
@@ -62,12 +62,12 @@ describe('Steps', () => {
     const { container } = render(Steps, {
       steps: defaultSteps,
       currentStep: 2,
-      completedLabel: 'Done',
+      completedLabel: 'Finished',
     });
     const srOnlySpans = container.querySelectorAll('.cinder-steps__sr-only');
     expect(srOnlySpans.length).toBe(2);
     for (const span of srOnlySpans) {
-      expect(span.textContent).toContain('Done');
+      expect(span.textContent).toContain('Finished');
     }
   });
 
@@ -148,6 +148,7 @@ describe('Steps', () => {
     const { container, rerender } = render(Steps, { steps: stepsABC, currentStep: 0 });
     const items = container.querySelectorAll('li');
     const betaNode = items[1];
+    expect(betaNode).not.toBeUndefined();
 
     await rerender({
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
@@ -156,7 +157,10 @@ describe('Steps', () => {
     });
 
     const reorderedItems = container.querySelectorAll('li');
-    // Beta was at index 1 (id="b"), now at index 1 in [c, b, a] — same DOM node
-    expect(reorderedItems[1]).toBe(betaNode);
+    const betaAfterReorder = reorderedItems[1];
+    expect(betaAfterReorder).not.toBeUndefined();
+    // Beta is at index 1 in [c, b, a] — verify content and stable DOM identity
+    expect(betaAfterReorder?.textContent).toContain('Beta');
+    expect(betaAfterReorder).toBe(betaNode);
   });
 });

--- a/packages/components/src/components/steps.test.ts
+++ b/packages/components/src/components/steps.test.ts
@@ -67,8 +67,19 @@ describe('Steps', () => {
     const srOnlySpans = container.querySelectorAll('.cinder-steps__sr-only');
     expect(srOnlySpans.length).toBe(2);
     for (const span of srOnlySpans) {
-      expect(span.textContent).toContain('Finished');
+      expect(span.textContent).toBe('Finished');
     }
+  });
+
+  test('completedLabel is separated from the visible step label in accessible text', () => {
+    const { container } = render(Steps, {
+      steps: defaultSteps,
+      currentStep: 1,
+      completedLabel: 'Finished',
+    });
+    const firstItem = container.querySelector('li');
+    expect(firstItem?.textContent).not.toContain('FinishedSet up profile');
+    expect(firstItem?.textContent).toMatch(/Finished\s+Set up profile/);
   });
 
   test('orientation prop drives layout via data-cinder-orientation', () => {

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -247,6 +247,9 @@ export type {
 export { default as Spinner } from './components/spinner.svelte';
 export type { SpinnerProps, SpinnerSize } from './components/spinner.svelte';
 
+export { default as Steps } from './components/steps.svelte';
+export type { StepItem, StepsOrientation, StepsProps } from './components/steps.svelte';
+
 export { default as Stat } from './components/stat.svelte';
 export type { StatChange, StatChangeDirection, StatProps } from './components/stat.svelte';
 

--- a/packages/components/src/styles/components.css
+++ b/packages/components/src/styles/components.css
@@ -53,6 +53,7 @@
 @import './components/spinner.css';
 @import './components/stat.css';
 @import './components/stat-group.css';
+@import './components/steps.css';
 @import './components/surface.css';
 @import './components/tab.css';
 @import './components/tab-list.css';

--- a/packages/components/src/styles/components/steps.css
+++ b/packages/components/src/styles/components/steps.css
@@ -153,6 +153,7 @@
  * ---------------------------------------- */
 
 .cinder-steps__body {
+  position: relative;
   display: flex;
   flex-direction: column;
   gap: var(--cinder-space-1);

--- a/packages/components/src/styles/components/steps.css
+++ b/packages/components/src/styles/components/steps.css
@@ -1,0 +1,203 @@
+/* ========================================
+ * STEPS
+ * Wizard step indicator with horizontal and vertical orientations.
+ * Uses aria-current="step" for the active step; completed steps render
+ * a checkmark icon. No role="progressbar" — steps are navigation, not metering.
+ * ======================================== */
+
+.cinder-steps {
+  display: block;
+}
+
+/* ----------------------------------------
+ * List
+ * ---------------------------------------- */
+
+.cinder-steps__list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+}
+
+.cinder-steps[data-cinder-orientation='horizontal'] .cinder-steps__list {
+  flex-direction: row;
+  align-items: flex-start;
+}
+
+.cinder-steps[data-cinder-orientation='vertical'] .cinder-steps__list {
+  flex-direction: column;
+  align-items: stretch;
+}
+
+/* ----------------------------------------
+ * Item — horizontal layout
+ * Marker (top-left) | Connector (top-right, centered vertically)
+ * Body spans full width in second row
+ * ---------------------------------------- */
+
+.cinder-steps[data-cinder-orientation='horizontal'] .cinder-steps__item {
+  flex: 1 1 0;
+  display: grid;
+  grid-template-columns: auto 1fr;
+  grid-template-rows: auto auto;
+  gap: 0 var(--cinder-space-2);
+}
+
+.cinder-steps[data-cinder-orientation='horizontal'] .cinder-steps__marker {
+  grid-column: 1;
+  grid-row: 1;
+}
+
+.cinder-steps[data-cinder-orientation='horizontal'] .cinder-steps__connector {
+  grid-column: 2;
+  grid-row: 1;
+  align-self: center;
+  height: 1px;
+  width: 100%;
+}
+
+.cinder-steps[data-cinder-orientation='horizontal'] .cinder-steps__sr-only,
+.cinder-steps[data-cinder-orientation='horizontal'] .cinder-steps__body {
+  grid-column: 1 / -1;
+  grid-row: 2;
+}
+
+/* ----------------------------------------
+ * Item — vertical layout
+ * Marker (top of column 1) | Body (column 2, spanning both rows)
+ * Connector (below marker in column 1)
+ * ---------------------------------------- */
+
+.cinder-steps[data-cinder-orientation='vertical'] .cinder-steps__item {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  grid-template-rows: auto 1fr;
+  gap: 0 var(--cinder-space-3);
+}
+
+.cinder-steps[data-cinder-orientation='vertical'] .cinder-steps__marker {
+  grid-column: 1;
+  grid-row: 1;
+}
+
+.cinder-steps[data-cinder-orientation='vertical'] .cinder-steps__connector {
+  grid-column: 1;
+  grid-row: 2;
+  justify-self: center;
+  width: 1px;
+  min-height: var(--cinder-space-6);
+  align-self: stretch;
+}
+
+.cinder-steps[data-cinder-orientation='vertical'] .cinder-steps__sr-only,
+.cinder-steps[data-cinder-orientation='vertical'] .cinder-steps__body {
+  grid-column: 2;
+  grid-row: 1 / span 2;
+  padding-bottom: var(--cinder-space-4);
+}
+
+/* ----------------------------------------
+ * Marker — the step circle
+ * ---------------------------------------- */
+
+.cinder-steps__marker {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.5rem;
+  height: 1.5rem;
+  border-radius: var(--cinder-radius-full);
+  background: var(--cinder-surface-inset);
+  flex-shrink: 0;
+}
+
+[data-cinder-state='complete'] .cinder-steps__marker {
+  background: var(--cinder-accent);
+  color: white;
+}
+
+[data-cinder-state='current'] .cinder-steps__marker {
+  background: var(--cinder-surface);
+  box-shadow: 0 0 0 2px var(--cinder-accent);
+  color: var(--cinder-accent);
+}
+
+[data-cinder-state='upcoming'] .cinder-steps__marker {
+  color: var(--cinder-text-muted);
+}
+
+/* ----------------------------------------
+ * Check icon and step index number
+ * ---------------------------------------- */
+
+.cinder-steps__check {
+  width: 0.875rem;
+  height: 0.875rem;
+}
+
+.cinder-steps__index {
+  font-size: var(--cinder-text-xs);
+  font-weight: var(--cinder-font-semibold);
+  line-height: 1;
+}
+
+/* ----------------------------------------
+ * Body — label and description
+ * ---------------------------------------- */
+
+.cinder-steps__body {
+  display: flex;
+  flex-direction: column;
+  gap: var(--cinder-space-1);
+  padding-top: var(--cinder-space-2);
+}
+
+.cinder-steps__label {
+  font-size: var(--cinder-text-sm);
+  font-weight: var(--cinder-font-normal);
+  color: var(--cinder-text);
+  line-height: var(--cinder-leading-tight);
+}
+
+[data-cinder-state='current'] .cinder-steps__label {
+  font-weight: var(--cinder-font-semibold);
+}
+
+[data-cinder-state='upcoming'] .cinder-steps__label {
+  color: var(--cinder-text-muted);
+}
+
+.cinder-steps__description {
+  font-size: var(--cinder-text-xs);
+  color: var(--cinder-text-muted);
+  line-height: var(--cinder-leading-normal);
+}
+
+/* ----------------------------------------
+ * Connector — the line between steps
+ * ---------------------------------------- */
+
+.cinder-steps__connector {
+  background: var(--cinder-border);
+}
+
+.cinder-steps__connector[data-cinder-state='complete'] {
+  background: var(--cinder-accent);
+}
+
+/* ----------------------------------------
+ * Visually-hidden text for completed steps
+ * ---------------------------------------- */
+
+.cinder-steps__sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border-width: 0;
+}

--- a/packages/components/src/styles/components/steps.css
+++ b/packages/components/src/styles/components/steps.css
@@ -197,7 +197,8 @@
  * Visually-hidden text for completed steps
  * ---------------------------------------- */
 
-.cinder-steps__sr-only {
+.cinder-steps__sr-only,
+.cinder-steps__sr-only-separator {
   position: absolute;
   width: 1px;
   height: 1px;

--- a/packages/components/src/styles/components/steps.css
+++ b/packages/components/src/styles/components/steps.css
@@ -57,7 +57,6 @@
   width: 100%;
 }
 
-.cinder-steps[data-cinder-orientation='horizontal'] .cinder-steps__sr-only,
 .cinder-steps[data-cinder-orientation='horizontal'] .cinder-steps__body {
   grid-column: 1 / -1;
   grid-row: 2;
@@ -90,7 +89,6 @@
   align-self: stretch;
 }
 
-.cinder-steps[data-cinder-orientation='vertical'] .cinder-steps__sr-only,
 .cinder-steps[data-cinder-orientation='vertical'] .cinder-steps__body {
   grid-column: 2;
   grid-row: 1 / span 2;
@@ -114,13 +112,21 @@
 
 [data-cinder-state='complete'] .cinder-steps__marker {
   background: var(--cinder-accent);
-  color: white;
+  color: var(--cinder-accent-contrast);
 }
 
 [data-cinder-state='current'] .cinder-steps__marker {
   background: var(--cinder-surface);
   box-shadow: 0 0 0 2px var(--cinder-accent);
   color: var(--cinder-accent);
+}
+
+@media (forced-colors: active) {
+  [data-cinder-state='current'] .cinder-steps__marker {
+    outline: 2px solid ButtonText;
+    outline-offset: 2px;
+    box-shadow: none;
+  }
 }
 
 [data-cinder-state='upcoming'] .cinder-steps__marker {


### PR DESCRIPTION
- **feat(components): add Steps wizard indicator and progress reduced-motion regression tests**
- **Address review committee feedback (round 1)**

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: primarily adds a new presentational component and test-only CSS audits, with minimal impact beyond new exports and bundled styles.
> 
> **Overview**
> Adds a new **`Steps`** wizard step indicator component, including its public exports (`src/index.ts`, package `exports`), shared stylesheet aggregation, and dedicated `steps.css` supporting horizontal/vertical layouts and forced-colors handling.
> 
> Introduces `Steps` unit tests covering a11y semantics (`aria-current="step"`, completed-step announcements), prop behavior (orientation/labels), edge cases (empty/clamped indices), and keyed reordering stability.
> 
> Extends `Progress` tests with a reduced-motion regression audit that parses `progress.css` to assert indeterminate bar/ring animations are disabled inside `@media (prefers-reduced-motion: reduce)`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 761439b1d057fd08b0a66390932da6918602f8ac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->