### PR TITLE
feat(components): add ButtonGroup as distinct layout-only primitive

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -316,11 +316,11 @@ Categorically distinct from `segmented-control.svelte`. `segmented-control` is a
 
 Best-practice notes: container needs `role="group"` with `aria-label`; toggle buttons inside need `aria-pressed`, not `aria-checked`; focused buttons must elevate `z-index` so focus rings aren't clipped by adjacent siblings; split-button dropdown trigger needs `aria-haspopup="true"` and `aria-expanded`.
 
-- [ ] Create `button-group.svelte` as a layout container: `role="group"`, required `label: string` for `aria-label`, `class` passthrough, `orientation: 'horizontal' | 'vertical'` (default horizontal).
-- [ ] Border-collapse via adjacent-sibling selectors or data attributes so internal shared borders render as a single 1px line, not 2px doubled.
-- [ ] Elevate focused child `z-index` so focus rings aren't clipped by the group's border context.
-- [ ] Document the split-button composition in Storybook using the existing `dropdown.svelte` as the trailing trigger — no new split-button primitive.
-- [ ] Do NOT add selection-state logic to `button-group` — keep that boundary clean against `segmented-control`.
+- [x] Create `button-group.svelte` as a layout container: `role="group"`, required `label: string` for `aria-label`, `class` passthrough, `orientation: 'horizontal' | 'vertical'` (default horizontal).
+- [x] Border-collapse via adjacent-sibling selectors or data attributes so internal shared borders render as a single 1px line, not 2px doubled.
+- [x] Elevate focused child `z-index` so focus rings aren't clipped by the group's border context.
+- [x] Document the split-button composition in Storybook using the existing `dropdown.svelte` as the trailing trigger — no new split-button primitive.
+- [x] Do NOT add selection-state logic to `button-group` — keep that boundary clean against `segmented-control`.
 
 ## Forms — Additional Components
 

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -41,6 +41,10 @@
       "svelte": "./src/components/breadcrumbs.svelte",
       "types": "./dist/components/breadcrumbs.svelte.d.ts"
     },
+    "./button-group": {
+      "svelte": "./src/components/button-group.svelte",
+      "types": "./dist/components/button-group.svelte.d.ts"
+    },
     "./button": {
       "svelte": "./src/components/button.svelte",
       "types": "./dist/components/button.svelte.d.ts"

--- a/packages/components/src/components/button-group.a11y.md
+++ b/packages/components/src/components/button-group.a11y.md
@@ -60,7 +60,7 @@ A `size="lg"` button next to a `size="sm"` button will look broken inside a coll
 
 ## Public styling contract
 
-Direct children are tagged with `data-cinder-button-group-item=""` at mount. The attribute is namespaced to avoid collisions and is part of the public API — it will not be renamed without a deprecation cycle. Consumers can target this attribute for their own overrides when it lands on a direct child. Manually adding the attribute to a deep descendant is **not** a supported escape hatch.
+Direct children are tagged with `data-cinder-button-group-item` at mount. The attribute value is an opaque internal identifier used for ownership tracking — **consumers must match on attribute presence only** (`[data-cinder-button-group-item]`), never on a specific value. The attribute name is namespaced to avoid collisions and is part of the public API — it will not be renamed without a deprecation cycle. Consumers can target this attribute for their own overrides when it lands on a direct child. Manually adding the attribute to a deep descendant is **not** a supported escape hatch.
 
 ## Forced-colors / high-contrast mode
 

--- a/packages/components/src/components/button-group.a11y.md
+++ b/packages/components/src/components/button-group.a11y.md
@@ -21,9 +21,9 @@ The TypeScript discriminated union enforces this at compile time. A dev-mode `$e
 
 A ButtonGroup can contain a mix of regular `<Button>` elements and toggle buttons (`<button aria-pressed="true|false">`). Toggle children manage their own `aria-pressed` — the group does not coordinate this state. This is the explicit separation from `segmented-control`: if your buttons share a value, you want `segmented-control`; if they are independent actions (some of which happen to be toggleable), you want `button-group`.
 
-## `aria-orientation`
+## Orientation
 
-The group emits `aria-orientation` matching the visual layout (`horizontal` or `vertical`). Most screen readers do not act on this for `role="group"`, but it is spec-allowed and aligns with the planned `segmented-control` vertical-mode behavior.
+The group uses `data-cinder-orientation` (a data attribute, not an ARIA attribute) to drive the CSS layout direction. `aria-orientation` is intentionally absent: per ARIA 1.2, `aria-orientation` is only valid for roles such as `toolbar`, `listbox`, `menu`, `radiogroup`, `scrollbar`, `separator`, `slider`, `tablist`, and `tree` — not `group`. Emitting it on `role="group"` would produce invalid ARIA and fail automated accessibility audits (axe-core, Deque, IBM Equal Access). Orientation is a visual concern only and is handled entirely through the `data-cinder-orientation` attribute on the container.
 
 ## Why this is not `segmented-control`
 

--- a/packages/components/src/components/button-group.a11y.md
+++ b/packages/components/src/components/button-group.a11y.md
@@ -39,7 +39,10 @@ Compose a primary `<Button>` with a `<Dropdown>` whose trigger is an icon button
 <ButtonGroup label="Save options">
   <Button>Save</Button>
   <Dropdown id="save-options">
-    <DropdownTrigger><Button aria-label="More save options">▾</Button></DropdownTrigger>
+    <DropdownTrigger>
+      <!-- Decorative glyph; aria-label supplies the accessible name. -->
+      <Button aria-label="More save options">▾</Button>
+    </DropdownTrigger>
     <DropdownMenu>
       <DropdownItem>Save as draft</DropdownItem>
       <DropdownItem>Save and publish</DropdownItem>
@@ -49,6 +52,8 @@ Compose a primary `<Button>` with a `<Dropdown>` whose trigger is an icon button
 ```
 
 The `<Dropdown>` already wires `aria-haspopup="menu"` and `aria-expanded` on its trigger. `ButtonGroup` adds nothing beyond visual attachment. This is composition — not a new primitive.
+
+When a child opens a portaled overlay, focus may move outside the group while the overlay is open. The group does not keep portaled content visually attached with `:focus-within`; overlay positioning and active trigger styling remain the child component's responsibility.
 
 ## Keyboard model
 

--- a/packages/components/src/components/button-group.a11y.md
+++ b/packages/components/src/components/button-group.a11y.md
@@ -1,0 +1,67 @@
+# ButtonGroup Accessibility
+
+## Why `role="group"`, not `role="radiogroup"` or `role="toolbar"`
+
+`role="radiogroup"` is for single-selection controls where children are `role="radio"`. That's `segmented-control`'s job.
+
+`role="toolbar"` is a stronger pattern that activates roving-tabindex expectations in screen readers — arrow keys navigate between items, and Tab exits the toolbar entirely. ButtonGroup deliberately does _not_ implement this model: its children are independent actions, and the native Tab order is the correct mental model for users.
+
+`role="group"` is the unopinionated grouping wrapper. It announces the group's accessible name to assistive technologies and does nothing else — no keyboard interception, no selection coordination.
+
+## Accessible name is required
+
+Every ButtonGroup must have a non-empty accessible name, provided via exactly one of:
+
+- **`label`**: an inline string, used when no visible heading already names the group. Emitted as `aria-label` on the container.
+- **`labelledBy`**: an element ID pointing at a visible heading that already names the group. Emitted as `aria-labelledby`. Prefer this over `label` when a visible heading exists — it avoids the screen reader announcing the name twice.
+
+The TypeScript discriminated union enforces this at compile time. A dev-mode `$effect` warns at runtime when either value is empty or whitespace-only.
+
+## `aria-pressed` on individual toggle buttons is supported
+
+A ButtonGroup can contain a mix of regular `<Button>` elements and toggle buttons (`<button aria-pressed="true|false">`). Toggle children manage their own `aria-pressed` — the group does not coordinate this state. This is the explicit separation from `segmented-control`: if your buttons share a value, you want `segmented-control`; if they are independent actions (some of which happen to be toggleable), you want `button-group`.
+
+## `aria-orientation`
+
+The group emits `aria-orientation` matching the visual layout (`horizontal` or `vertical`). Most screen readers do not act on this for `role="group"`, but it is spec-allowed and aligns with the planned `segmented-control` vertical-mode behavior.
+
+## Why this is not `segmented-control`
+
+**Decision rule:** if your buttons share a value (exactly one is selected at a time), use `segmented-control`. If they are independent actions that happen to be visually grouped, use `button-group`.
+
+`segmented-control` owns its child markup, uses `role="radiogroup"` with `role="radio"` children, and manages a bindable `value`. `button-group` is a visual container only — it renders whatever `children` you pass, with no awareness of state.
+
+## Split-button composition
+
+Compose a primary `<Button>` with a `<Dropdown>` whose trigger is an icon button:
+
+```svelte
+<ButtonGroup label="Save options">
+  <Button>Save</Button>
+  <Dropdown id="save-options">
+    <DropdownTrigger><Button aria-label="More save options">▾</Button></DropdownTrigger>
+    <DropdownMenu>
+      <DropdownItem>Save as draft</DropdownItem>
+      <DropdownItem>Save and publish</DropdownItem>
+    </DropdownMenu>
+  </Dropdown>
+</ButtonGroup>
+```
+
+The `<Dropdown>` already wires `aria-haspopup="menu"` and `aria-expanded` on its trigger. `ButtonGroup` adds nothing beyond visual attachment. This is composition — not a new primitive.
+
+## Keyboard model
+
+Tab enters the first child, Tab moves to the next, Shift+Tab reverses. There is no arrow-key interception. A `<Dropdown>` child's internal arrow handling (up/down through menu items) kicks in once focus is inside the open menu — orthogonal to the group.
+
+## Mixed-size children are a usage error
+
+A `size="lg"` button next to a `size="sm"` button will look broken inside a collapsed group. There is no runtime enforcement — keep child sizes consistent.
+
+## Public styling contract
+
+Direct children are tagged with `data-cinder-button-group-item=""` at mount. The attribute is namespaced to avoid collisions and is part of the public API — it will not be renamed without a deprecation cycle. Consumers can target this attribute for their own overrides when it lands on a direct child. Manually adding the attribute to a deep descendant is **not** a supported escape hatch.
+
+## Forced-colors / high-contrast mode
+
+The focus elevation rule relies on `z-index`, which is honored in forced-colors mode. The collapsed borders rely on `margin: -1px`, which works regardless of color. No additional `@media (forced-colors: active)` overrides are needed beyond what `<Button>` already ships.

--- a/packages/components/src/components/button-group.svelte
+++ b/packages/components/src/components/button-group.svelte
@@ -25,6 +25,8 @@
    */
   export type ButtonGroupProps = ButtonGroupBase &
     ({ label: string; labelledBy?: never } | { label?: never; labelledBy: string });
+
+  let groupIdCounter = 0;
 </script>
 
 <script lang="ts">
@@ -46,34 +48,56 @@
   const ariaLabelAttribute = $derived(typeof label === 'string' ? label : undefined);
   const ariaLabelledByAttribute = $derived(typeof labelledBy === 'string' ? labelledBy : undefined);
 
-  function tagDirectChildren(): Attachment {
-    return (element) => {
-      const ATTR = 'data-cinder-button-group-item';
-      const tagged = new Set<Element>();
+  // Each group instance gets a unique ID so the styling-contract attribute
+  // carries ownership. When a child moves from one group to another, the new
+  // group overwrites the value and the old group's cleanup only removes it if
+  // the value still matches this instance's ID.
+  const groupId = String(++groupIdCounter);
 
-      const sync = () => {
-        const currentChildren = new Set(Array.from(element.children));
+  const tagDirectChildren: Attachment = (element) => {
+    const ATTR = 'data-cinder-button-group-item';
+    // Track previously tagged children by element reference so cleanup is
+    // O(n) and ownership-specific: we only remove our group's tag value.
+    const tagged = new Set<Element>();
 
-        for (const child of currentChildren) {
-          if (!child.hasAttribute(ATTR)) child.setAttribute(ATTR, '');
-          tagged.add(child);
-        }
+    const sync = () => {
+      const currentChildren = new Set(Array.from(element.children));
 
-        for (const previouslyTagged of tagged) {
-          if (!currentChildren.has(previouslyTagged)) {
+      // Stamp current direct children with this group's ID. Overwriting
+      // another group's ID claims ownership — the other group's cleanup will
+      // see a mismatched value and skip removal, so no double-remove race.
+      for (const child of currentChildren) {
+        child.setAttribute(ATTR, groupId);
+        tagged.add(child);
+      }
+
+      // Remove ownership from children that are no longer direct children.
+      // Only remove if the value still matches this group's ID — prevents
+      // clobbering a new group that already claimed the child.
+      for (const previouslyTagged of Array.from(tagged)) {
+        if (!currentChildren.has(previouslyTagged)) {
+          if (previouslyTagged.getAttribute(ATTR) === groupId) {
             previouslyTagged.removeAttribute(ATTR);
-            tagged.delete(previouslyTagged);
           }
+          tagged.delete(previouslyTagged);
         }
-      };
-
-      sync();
-
-      const observer = new MutationObserver(sync);
-      observer.observe(element, { childList: true });
-      return () => observer.disconnect();
+      }
     };
-  }
+
+    sync();
+
+    const observer = new MutationObserver(sync);
+    observer.observe(element, { childList: true });
+    return () => {
+      observer.disconnect();
+      // Release ownership on unmount for any remaining tagged children.
+      for (const child of Array.from(tagged)) {
+        if (child.getAttribute(ATTR) === groupId) {
+          child.removeAttribute(ATTR);
+        }
+      }
+    };
+  };
 
   $effect(() => {
     if (!DEV) return;
@@ -107,10 +131,9 @@
   role="group"
   aria-label={ariaLabelAttribute}
   aria-labelledby={ariaLabelledByAttribute}
-  aria-orientation={orientation}
   class={mergedClassName}
   data-cinder-orientation={orientation}
-  {@attach tagDirectChildren()}
+  {@attach tagDirectChildren}
 >
   {@render children()}
 </div>

--- a/packages/components/src/components/button-group.svelte
+++ b/packages/components/src/components/button-group.svelte
@@ -1,0 +1,116 @@
+<script lang="ts" module>
+  import type { Snippet } from 'svelte';
+  import type { HTMLAttributes } from 'svelte/elements';
+
+  /** Visual/layout orientation of the group. */
+  export type ButtonGroupOrientation = 'horizontal' | 'vertical';
+
+  type ButtonGroupBase = Omit<
+    HTMLAttributes<HTMLDivElement>,
+    'class' | 'role' | 'aria-label' | 'aria-labelledby'
+  > & {
+    /** Orientation of the visual collapse. Default: 'horizontal'. */
+    orientation?: ButtonGroupOrientation;
+    /** Additional class merged with `.cinder-button-group`. */
+    class?: string;
+    /** Buttons (or split-button compositions) to render inside the group. */
+    children: Snippet;
+  };
+
+  /**
+   * Layout-only grouping container for related action buttons.
+   * Requires an accessible name via either `label` (for inline labelling)
+   * or `labelledBy` (when a visible heading already names the group).
+   * Exactly one must be provided.
+   */
+  export type ButtonGroupProps = ButtonGroupBase &
+    ({ label: string; labelledBy?: never } | { label?: never; labelledBy: string });
+</script>
+
+<script lang="ts">
+  import type { Attachment } from 'svelte/attachments';
+  import { DEV } from 'esm-env';
+
+  import { classNames } from '../utilities/class-names.ts';
+
+  let {
+    label,
+    labelledBy,
+    orientation = 'horizontal',
+    class: customClassName,
+    children,
+    ...rest
+  }: ButtonGroupProps = $props();
+
+  const mergedClassName = $derived(classNames('cinder-button-group', customClassName));
+  const ariaLabelAttribute = $derived(typeof label === 'string' ? label : undefined);
+  const ariaLabelledByAttribute = $derived(typeof labelledBy === 'string' ? labelledBy : undefined);
+
+  function tagDirectChildren(): Attachment {
+    return (element) => {
+      const ATTR = 'data-cinder-button-group-item';
+      const tagged = new Set<Element>();
+
+      const sync = () => {
+        const currentChildren = new Set(Array.from(element.children));
+
+        for (const child of currentChildren) {
+          if (!child.hasAttribute(ATTR)) child.setAttribute(ATTR, '');
+          tagged.add(child);
+        }
+
+        for (const previouslyTagged of tagged) {
+          if (!currentChildren.has(previouslyTagged)) {
+            previouslyTagged.removeAttribute(ATTR);
+            tagged.delete(previouslyTagged);
+          }
+        }
+      };
+
+      sync();
+
+      const observer = new MutationObserver(sync);
+      observer.observe(element, { childList: true });
+      return () => observer.disconnect();
+    };
+  }
+
+  $effect(() => {
+    if (!DEV) return;
+
+    const hasLabel = typeof label === 'string';
+    const hasLabelledBy = typeof labelledBy === 'string';
+
+    if (!hasLabel && !hasLabelledBy) {
+      console.warn(
+        "[cinder/ButtonGroup] rendered without a non-empty accessible name — pass a non-empty 'label' or 'labelledBy'.",
+      );
+      return;
+    }
+
+    if (hasLabel && label.trim().length === 0) {
+      console.warn(
+        "[cinder/ButtonGroup] rendered without a non-empty accessible name — pass a non-empty 'label' or 'labelledBy'.",
+      );
+    }
+
+    if (hasLabelledBy && labelledBy.trim().length === 0) {
+      console.warn(
+        "[cinder/ButtonGroup] rendered without a non-empty accessible name — pass a non-empty 'label' or 'labelledBy'.",
+      );
+    }
+  });
+</script>
+
+<div
+  {...rest}
+  role="group"
+  aria-label={ariaLabelAttribute}
+  aria-labelledby={ariaLabelledByAttribute}
+  aria-orientation={orientation}
+  class={mergedClassName}
+  data-cinder-orientation={orientation}
+  {@attach tagDirectChildren()}
+>
+  {@render children()}
+</div>

--- a/packages/components/src/components/button-group.test.ts
+++ b/packages/components/src/components/button-group.test.ts
@@ -1,0 +1,183 @@
+/// <reference lib="dom" />
+import { afterEach, describe, expect, mock, test } from 'bun:test';
+import { createRawSnippet } from 'svelte';
+
+import { setupHappyDom } from '../test/happy-dom.ts';
+
+setupHappyDom();
+
+const { cleanup, render } = await import('@testing-library/svelte');
+const { default: ButtonGroup } = await import('./button-group.svelte');
+
+afterEach(() => cleanup());
+
+// ---------------------------------------------------------------------------
+// Snippet helpers
+// ---------------------------------------------------------------------------
+
+function buttonSnippet(labels: string[]) {
+  return createRawSnippet(() => ({
+    render: () =>
+      `<div class="buttons-wrapper">${labels.map((l) => `<button type="button">${l}</button>`).join('')}</div>`,
+    setup: () => {},
+  }));
+}
+
+function singleButtonSnippet(label: string) {
+  return createRawSnippet(() => ({
+    render: () => `<button type="button">${label}</button>`,
+    setup: () => {},
+  }));
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('ButtonGroup', () => {
+  test('role and aria-label with label prop', () => {
+    const { container } = render(ButtonGroup, {
+      props: { label: 'Document actions', children: singleButtonSnippet('Save') },
+    });
+    const group = container.querySelector('[role="group"]');
+    expect(group).not.toBeNull();
+    expect(group?.getAttribute('aria-label')).toBe('Document actions');
+  });
+
+  test('role and aria-labelledby with labelledBy prop', () => {
+    const { container } = render(ButtonGroup, {
+      props: { labelledBy: 'heading-id', children: singleButtonSnippet('Save') },
+    });
+    const group = container.querySelector('[role="group"]');
+    expect(group).not.toBeNull();
+    expect(group?.getAttribute('aria-labelledby')).toBe('heading-id');
+    expect(group?.hasAttribute('aria-label')).toBe(false);
+  });
+
+  test('label prop produces no aria-labelledby', () => {
+    const { container } = render(ButtonGroup, {
+      props: { label: 'Actions', children: singleButtonSnippet('Save') },
+    });
+    const group = container.querySelector('[role="group"]');
+    expect(group?.hasAttribute('aria-labelledby')).toBe(false);
+  });
+
+  test('labelledBy prop produces no aria-label', () => {
+    const { container } = render(ButtonGroup, {
+      props: { labelledBy: 'x', children: singleButtonSnippet('Save') },
+    });
+    const group = container.querySelector('[role="group"]');
+    expect(group?.hasAttribute('aria-label')).toBe(false);
+  });
+
+  test('aria-orientation defaults to horizontal', () => {
+    const { container } = render(ButtonGroup, {
+      props: { label: 'Actions', children: singleButtonSnippet('Save') },
+    });
+    const group = container.querySelector('[role="group"]');
+    expect(group?.getAttribute('aria-orientation')).toBe('horizontal');
+    expect(group?.getAttribute('data-cinder-orientation')).toBe('horizontal');
+  });
+
+  test('aria-orientation vertical when orientation="vertical"', () => {
+    const { container } = render(ButtonGroup, {
+      props: { label: 'Actions', orientation: 'vertical', children: singleButtonSnippet('Save') },
+    });
+    const group = container.querySelector('[role="group"]');
+    expect(group?.getAttribute('aria-orientation')).toBe('vertical');
+    expect(group?.getAttribute('data-cinder-orientation')).toBe('vertical');
+  });
+
+  test('warns in dev mode when label is empty string', () => {
+    const warnSpy = mock(() => {});
+    const original = console.warn;
+    console.warn = warnSpy;
+
+    try {
+      render(ButtonGroup, {
+        props: { label: '', children: singleButtonSnippet('Save') },
+      });
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      expect((warnSpy.mock.calls[0] as string[])[0]).toStartWith('[cinder/ButtonGroup]');
+    } finally {
+      console.warn = original;
+    }
+  });
+
+  test('warns in dev mode when label is whitespace-only', () => {
+    const warnSpy = mock(() => {});
+    const original = console.warn;
+    console.warn = warnSpy;
+
+    try {
+      render(ButtonGroup, {
+        props: { label: '   ', children: singleButtonSnippet('Save') },
+      });
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      expect((warnSpy.mock.calls[0] as string[])[0]).toStartWith('[cinder/ButtonGroup]');
+    } finally {
+      console.warn = original;
+    }
+  });
+
+  test('warns in dev mode when labelledBy is empty string', () => {
+    const warnSpy = mock(() => {});
+    const original = console.warn;
+    console.warn = warnSpy;
+
+    try {
+      render(ButtonGroup, {
+        props: { labelledBy: '', children: singleButtonSnippet('Save') },
+      });
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      expect((warnSpy.mock.calls[0] as string[])[0]).toStartWith('[cinder/ButtonGroup]');
+    } finally {
+      console.warn = original;
+    }
+  });
+
+  test('class passthrough merges with cinder-button-group', () => {
+    const { container } = render(ButtonGroup, {
+      props: { label: 'Actions', class: 'extra', children: singleButtonSnippet('Save') },
+    });
+    const group = container.querySelector('[role="group"]');
+    expect(group?.classList.contains('cinder-button-group')).toBe(true);
+    expect(group?.classList.contains('extra')).toBe(true);
+  });
+
+  test('rest spread attributes reach the rendered div', () => {
+    const { container } = render(ButtonGroup, {
+      props: {
+        label: 'Actions',
+        'data-testid': 'my-group',
+        children: singleButtonSnippet('Save'),
+      } as any,
+    });
+    const group = container.querySelector('[role="group"]');
+    expect(group?.getAttribute('data-testid')).toBe('my-group');
+  });
+
+  test('no selection ARIA on the container', () => {
+    const { container } = render(ButtonGroup, {
+      props: { label: 'Actions', children: singleButtonSnippet('Save') },
+    });
+    const group = container.querySelector('[role="group"]');
+    expect(group?.hasAttribute('aria-activedescendant')).toBe(false);
+    expect(group?.hasAttribute('aria-multiselectable')).toBe(false);
+    expect(group?.hasAttribute('aria-checked')).toBe(false);
+    expect(group?.getAttribute('role')).not.toBe('radiogroup');
+  });
+
+  test('direct children carry the styling-contract attribute after mount', () => {
+    const { container } = render(ButtonGroup, {
+      props: { label: 'Actions', children: buttonSnippet(['Save', 'Cancel', 'Reset']) },
+    });
+
+    const group = container.querySelector('.cinder-button-group');
+    const directChildren = Array.from(group?.children ?? []);
+    expect(directChildren.length).toBeGreaterThan(0);
+    for (const child of directChildren) {
+      expect(child.hasAttribute('data-cinder-button-group-item')).toBe(true);
+    }
+  });
+});

--- a/packages/components/src/components/button-group.test.ts
+++ b/packages/components/src/components/button-group.test.ts
@@ -15,14 +15,6 @@ afterEach(() => cleanup());
 // Snippet helpers
 // ---------------------------------------------------------------------------
 
-function buttonSnippet(labels: string[]) {
-  return createRawSnippet(() => ({
-    render: () =>
-      `<div class="buttons-wrapper">${labels.map((l) => `<button type="button">${l}</button>`).join('')}</div>`,
-    setup: () => {},
-  }));
-}
-
 function singleButtonSnippet(label: string) {
   return createRawSnippet(() => ({
     render: () => `<button type="button">${label}</button>`,
@@ -70,21 +62,23 @@ describe('ButtonGroup', () => {
     expect(group?.hasAttribute('aria-label')).toBe(false);
   });
 
-  test('aria-orientation defaults to horizontal', () => {
+  test('data-cinder-orientation defaults to horizontal', () => {
     const { container } = render(ButtonGroup, {
       props: { label: 'Actions', children: singleButtonSnippet('Save') },
     });
     const group = container.querySelector('[role="group"]');
-    expect(group?.getAttribute('aria-orientation')).toBe('horizontal');
+    // aria-orientation is intentionally absent — it is not a valid attribute for role="group"
+    expect(group?.hasAttribute('aria-orientation')).toBe(false);
     expect(group?.getAttribute('data-cinder-orientation')).toBe('horizontal');
   });
 
-  test('aria-orientation vertical when orientation="vertical"', () => {
+  test('data-cinder-orientation is set to vertical when orientation="vertical"', () => {
     const { container } = render(ButtonGroup, {
       props: { label: 'Actions', orientation: 'vertical', children: singleButtonSnippet('Save') },
     });
     const group = container.querySelector('[role="group"]');
-    expect(group?.getAttribute('aria-orientation')).toBe('vertical');
+    // aria-orientation is intentionally absent — it is not a valid attribute for role="group"
+    expect(group?.hasAttribute('aria-orientation')).toBe(false);
     expect(group?.getAttribute('data-cinder-orientation')).toBe('vertical');
   });
 
@@ -165,19 +159,64 @@ describe('ButtonGroup', () => {
     expect(group?.hasAttribute('aria-activedescendant')).toBe(false);
     expect(group?.hasAttribute('aria-multiselectable')).toBe(false);
     expect(group?.hasAttribute('aria-checked')).toBe(false);
+    expect(group?.hasAttribute('aria-orientation')).toBe(false);
     expect(group?.getAttribute('role')).not.toBe('radiogroup');
   });
 
-  test('direct children carry the styling-contract attribute after mount', () => {
+  test('direct child carries the styling-contract attribute after mount', () => {
     const { container } = render(ButtonGroup, {
-      props: { label: 'Actions', children: buttonSnippet(['Save', 'Cancel', 'Reset']) },
+      props: { label: 'Actions', children: singleButtonSnippet('Save') },
     });
 
     const group = container.querySelector('.cinder-button-group');
-    const directChildren = Array.from(group?.children ?? []);
-    expect(directChildren.length).toBeGreaterThan(0);
-    for (const child of directChildren) {
-      expect(child.hasAttribute('data-cinder-button-group-item')).toBe(true);
-    }
+    const directChild = group?.children[0];
+    expect(directChild).not.toBeUndefined();
+    expect(directChild?.hasAttribute('data-cinder-button-group-item')).toBe(true);
+  });
+
+  test('styling-contract attribute carries a non-empty group ID for ownership', () => {
+    const { container } = render(ButtonGroup, {
+      props: { label: 'Actions', children: singleButtonSnippet('Save') },
+    });
+
+    const group = container.querySelector('.cinder-button-group');
+    const directChild = group?.children[0];
+    const value = directChild?.getAttribute('data-cinder-button-group-item');
+    expect(value).not.toBeNull();
+    expect(value?.length).toBeGreaterThan(0);
+  });
+
+  test('styling-contract attribute is removed from a child after it is removed from the group', async () => {
+    const { container } = render(ButtonGroup, {
+      props: { label: 'Actions', children: singleButtonSnippet('Save') },
+    });
+
+    const group = container.querySelector('.cinder-button-group')!;
+    const child = group.children[0] as Element;
+    expect(child.hasAttribute('data-cinder-button-group-item')).toBe(true);
+
+    group.removeChild(child);
+    // MutationObserver callbacks are batched as microtasks. In happy-dom,
+    // a setTimeout(0) reliably flushes the callback queue.
+    await new Promise<void>((resolve) => setTimeout(resolve, 0));
+
+    expect(child.hasAttribute('data-cinder-button-group-item')).toBe(false);
+  });
+
+  test('styling-contract attribute is added to a child appended after mount', async () => {
+    const { container } = render(ButtonGroup, {
+      props: { label: 'Actions', children: singleButtonSnippet('Save') },
+    });
+
+    const group = container.querySelector('.cinder-button-group')!;
+    const newButton = document.createElement('button');
+    newButton.textContent = 'Cancel';
+    group.appendChild(newButton);
+
+    // MutationObserver callbacks are batched as microtasks. In happy-dom,
+    // a setTimeout(0) reliably flushes the callback queue.
+    await new Promise<void>((resolve) => setTimeout(resolve, 0));
+
+    expect(newButton.hasAttribute('data-cinder-button-group-item')).toBe(true);
   });
 });

--- a/packages/components/src/components/button-group.type-test.ts
+++ b/packages/components/src/components/button-group.type-test.ts
@@ -1,0 +1,28 @@
+/**
+ * Compile-time regression tests for ButtonGroupProps discriminated union.
+ * svelte-check processes this file; tsc does not (it excludes .svelte imports).
+ * These verify that invalid prop combinations are rejected by the type system.
+ */
+import type { Snippet } from 'svelte';
+
+import type { ButtonGroupProps } from './button-group.svelte';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const noopChildren = null as any as Snippet;
+
+// label and labelledBy are mutually exclusive — TypeScript must reject this.
+// @ts-expect-error - labelledBy must be never when label is provided
+const _bothPresent: ButtonGroupProps = {
+  label: 'a',
+  labelledBy: 'b',
+  children: noopChildren,
+};
+
+// At least one of label or labelledBy is required — TypeScript must reject this.
+// @ts-expect-error - labelledBy or label is required
+const _neitherPresent: ButtonGroupProps = {
+  children: noopChildren,
+};
+
+void _bothPresent;
+void _neitherPresent;

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -19,6 +19,9 @@ export type { BreadcrumbItem, BreadcrumbsProps } from './components/breadcrumbs.
 export { default as Button } from './components/button.svelte';
 export type { ButtonProps, ButtonSize, ButtonVariant } from './components/button.svelte';
 
+export { default as ButtonGroup } from './components/button-group.svelte';
+export type { ButtonGroupOrientation, ButtonGroupProps } from './components/button-group.svelte';
+
 export { default as Card } from './components/card.svelte';
 export type { CardProps } from './components/card.svelte';
 

--- a/packages/components/src/styles/components.css
+++ b/packages/components/src/styles/components.css
@@ -11,6 +11,7 @@
 @import './components/badge.css';
 @import './components/breadcrumbs.css';
 @import './components/button.css';
+@import './components/button-group.css';
 @import './components/card.css';
 @import './components/checkbox.css';
 @import './components/checkbox-group.css';

--- a/packages/components/src/styles/components/button-group.css
+++ b/packages/components/src/styles/components/button-group.css
@@ -1,0 +1,111 @@
+/* =========================================================
+   ButtonGroup — layout-only barrel for related action buttons
+   ========================================================= */
+
+.cinder-button-group {
+  display: inline-flex;
+  /* New stacking context keeps focus-ring z-index elevation local to this
+     group — a focused child in one group never paints over a sibling group. */
+  isolation: isolate;
+}
+
+.cinder-button-group[data-cinder-orientation='horizontal'] {
+  flex-direction: row;
+}
+
+.cinder-button-group[data-cinder-orientation='vertical'] {
+  flex-direction: column;
+}
+
+/* Position context so the focused-child z-index elevation works. */
+.cinder-button-group > [data-cinder-button-group-item] {
+  position: relative;
+  z-index: 0;
+}
+
+/* Elevate the hovered/focused participant so its focus ring paints over
+   adjacent buttons' borders and is never clipped. */
+.cinder-button-group > [data-cinder-button-group-item]:where(:hover, :focus-within) {
+  z-index: 1;
+}
+
+/* ── Border collapse via negative margin ──────────────────────────────── */
+
+.cinder-button-group[data-cinder-orientation='horizontal']
+  > [data-cinder-button-group-item]:not(:first-child) {
+  margin-inline-start: -1px;
+}
+
+.cinder-button-group[data-cinder-orientation='vertical']
+  > [data-cinder-button-group-item]:not(:first-child) {
+  margin-block-start: -1px;
+}
+
+/* ── Border-radius flattening ─────────────────────────────────────────── */
+/*
+ * Every selector targets the visible button via :is(.cinder-button, button).
+ * The :not([role='menu'] *):not([role='menuitem']) guard prevents dropdown
+ * menu items from having their corners zeroed.
+ *
+ * When the participant *is* the button (no nesting), the second comma-arm of
+ * each rule matches it directly without the guard — a direct child of
+ * button-group can never be a menu item.
+ */
+
+/* Horizontal — middle children: zero all corners. */
+.cinder-button-group[data-cinder-orientation='horizontal']
+  > [data-cinder-button-group-item]:not(:first-child):not(:last-child)
+  :is(.cinder-button, button):not([role='menu'] *):not([role='menuitem']),
+.cinder-button-group[data-cinder-orientation='horizontal']
+  > [data-cinder-button-group-item]:is(.cinder-button, button):not(:first-child):not(:last-child) {
+  border-radius: 0;
+}
+
+/* Horizontal — first child: zero the inline-end corners. */
+.cinder-button-group[data-cinder-orientation='horizontal']
+  > [data-cinder-button-group-item]:first-child
+  :is(.cinder-button, button):not([role='menu'] *):not([role='menuitem']),
+.cinder-button-group[data-cinder-orientation='horizontal']
+  > [data-cinder-button-group-item]:is(.cinder-button, button):first-child {
+  border-start-end-radius: 0;
+  border-end-end-radius: 0;
+}
+
+/* Horizontal — last child: zero the inline-start corners. */
+.cinder-button-group[data-cinder-orientation='horizontal']
+  > [data-cinder-button-group-item]:last-child
+  :is(.cinder-button, button):not([role='menu'] *):not([role='menuitem']),
+.cinder-button-group[data-cinder-orientation='horizontal']
+  > [data-cinder-button-group-item]:is(.cinder-button, button):last-child {
+  border-start-start-radius: 0;
+  border-end-start-radius: 0;
+}
+
+/* Vertical — middle children: zero all corners. */
+.cinder-button-group[data-cinder-orientation='vertical']
+  > [data-cinder-button-group-item]:not(:first-child):not(:last-child)
+  :is(.cinder-button, button):not([role='menu'] *):not([role='menuitem']),
+.cinder-button-group[data-cinder-orientation='vertical']
+  > [data-cinder-button-group-item]:is(.cinder-button, button):not(:first-child):not(:last-child) {
+  border-radius: 0;
+}
+
+/* Vertical — first child: zero the block-end corners. */
+.cinder-button-group[data-cinder-orientation='vertical']
+  > [data-cinder-button-group-item]:first-child
+  :is(.cinder-button, button):not([role='menu'] *):not([role='menuitem']),
+.cinder-button-group[data-cinder-orientation='vertical']
+  > [data-cinder-button-group-item]:is(.cinder-button, button):first-child {
+  border-end-start-radius: 0;
+  border-end-end-radius: 0;
+}
+
+/* Vertical — last child: zero the block-start corners. */
+.cinder-button-group[data-cinder-orientation='vertical']
+  > [data-cinder-button-group-item]:last-child
+  :is(.cinder-button, button):not([role='menu'] *):not([role='menuitem']),
+.cinder-button-group[data-cinder-orientation='vertical']
+  > [data-cinder-button-group-item]:is(.cinder-button, button):last-child {
+  border-start-start-radius: 0;
+  border-start-end-radius: 0;
+}

--- a/packages/components/src/styles/components/button-group.css
+++ b/packages/components/src/styles/components/button-group.css
@@ -63,20 +63,20 @@
 
 /* Horizontal — first child: zero the inline-end corners. */
 .cinder-button-group[data-cinder-orientation='horizontal']
-  > [data-cinder-button-group-item]:first-child
+  > [data-cinder-button-group-item]:first-child:not(:only-child)
   :is(.cinder-button, button):not([role='menu'] *):not([role='menuitem']),
 .cinder-button-group[data-cinder-orientation='horizontal']
-  > [data-cinder-button-group-item]:is(.cinder-button, button):first-child {
+  > [data-cinder-button-group-item]:is(.cinder-button, button):first-child:not(:only-child) {
   border-start-end-radius: 0;
   border-end-end-radius: 0;
 }
 
 /* Horizontal — last child: zero the inline-start corners. */
 .cinder-button-group[data-cinder-orientation='horizontal']
-  > [data-cinder-button-group-item]:last-child
+  > [data-cinder-button-group-item]:last-child:not(:only-child)
   :is(.cinder-button, button):not([role='menu'] *):not([role='menuitem']),
 .cinder-button-group[data-cinder-orientation='horizontal']
-  > [data-cinder-button-group-item]:is(.cinder-button, button):last-child {
+  > [data-cinder-button-group-item]:is(.cinder-button, button):last-child:not(:only-child) {
   border-start-start-radius: 0;
   border-end-start-radius: 0;
 }
@@ -92,20 +92,20 @@
 
 /* Vertical — first child: zero the block-end corners. */
 .cinder-button-group[data-cinder-orientation='vertical']
-  > [data-cinder-button-group-item]:first-child
+  > [data-cinder-button-group-item]:first-child:not(:only-child)
   :is(.cinder-button, button):not([role='menu'] *):not([role='menuitem']),
 .cinder-button-group[data-cinder-orientation='vertical']
-  > [data-cinder-button-group-item]:is(.cinder-button, button):first-child {
+  > [data-cinder-button-group-item]:is(.cinder-button, button):first-child:not(:only-child) {
   border-end-start-radius: 0;
   border-end-end-radius: 0;
 }
 
 /* Vertical — last child: zero the block-start corners. */
 .cinder-button-group[data-cinder-orientation='vertical']
-  > [data-cinder-button-group-item]:last-child
+  > [data-cinder-button-group-item]:last-child:not(:only-child)
   :is(.cinder-button, button):not([role='menu'] *):not([role='menuitem']),
 .cinder-button-group[data-cinder-orientation='vertical']
-  > [data-cinder-button-group-item]:is(.cinder-button, button):last-child {
+  > [data-cinder-button-group-item]:is(.cinder-button, button):last-child:not(:only-child) {
   border-start-start-radius: 0;
   border-start-end-radius: 0;
 }

--- a/packages/components/tsconfig.check.json
+++ b/packages/components/tsconfig.check.json
@@ -8,6 +8,7 @@
     "**/dist/**",
     "**/build/**",
     "src/index.ts",
-    "src/components.test.ts"
+    "src/components.test.ts",
+    "src/**/*.type-test.ts"
   ]
 }

--- a/packages/playground/src/examples/button-group/basic.example.svelte
+++ b/packages/playground/src/examples/button-group/basic.example.svelte
@@ -1,0 +1,15 @@
+<script lang="ts" module>
+  export const title = 'Basic button group';
+  export const description =
+    'Horizontal layout container with border-collapsed buttons. Use consistent variants across children.';
+</script>
+
+<script lang="ts">
+  import { Button, ButtonGroup } from '../../../../components/src/index.ts';
+</script>
+
+<ButtonGroup label="Document actions">
+  <Button variant="secondary">Save</Button>
+  <Button variant="secondary">Duplicate</Button>
+  <Button variant="secondary">Archive</Button>
+</ButtonGroup>

--- a/packages/playground/src/examples/button-group/rtl.example.svelte
+++ b/packages/playground/src/examples/button-group/rtl.example.svelte
@@ -1,0 +1,29 @@
+<script lang="ts" module>
+  export const title = 'Right-to-left (RTL)';
+  export const description =
+    'Logical properties automatically flip collapsed borders and outer corner rounding when the writing direction is RTL.';
+</script>
+
+<script lang="ts">
+  import {
+    Button,
+    ButtonGroup,
+    Dropdown,
+    DropdownItem,
+    DropdownMenu,
+    DropdownTrigger,
+  } from '../../../../components/src/index.ts';
+</script>
+
+<div dir="rtl">
+  <ButtonGroup label="خيارات الحفظ">
+    <Button>حفظ</Button>
+    <Dropdown id="save-options-rtl">
+      <DropdownTrigger><Button aria-label="المزيد من خيارات الحفظ">▾</Button></DropdownTrigger>
+      <DropdownMenu>
+        <DropdownItem>حفظ كمسودة</DropdownItem>
+        <DropdownItem>حفظ ونشر</DropdownItem>
+      </DropdownMenu>
+    </Dropdown>
+  </ButtonGroup>
+</div>

--- a/packages/playground/src/examples/button-group/split-button.example.svelte
+++ b/packages/playground/src/examples/button-group/split-button.example.svelte
@@ -1,0 +1,28 @@
+<script lang="ts" module>
+  export const title = 'Split button composition';
+  export const description =
+    'A primary action button paired with a dropdown for related secondary actions. This is composition — ButtonGroup does no split-button work itself.';
+</script>
+
+<script lang="ts">
+  import {
+    Button,
+    ButtonGroup,
+    Dropdown,
+    DropdownItem,
+    DropdownMenu,
+    DropdownTrigger,
+  } from '../../../../components/src/index.ts';
+</script>
+
+<ButtonGroup label="Save options">
+  <Button>Save</Button>
+  <Dropdown id="save-options">
+    <DropdownTrigger><Button aria-label="More save options">▾</Button></DropdownTrigger>
+    <DropdownMenu>
+      <DropdownItem>Save as draft</DropdownItem>
+      <DropdownItem>Save and publish</DropdownItem>
+      <DropdownItem variant="danger">Discard changes</DropdownItem>
+    </DropdownMenu>
+  </Dropdown>
+</ButtonGroup>

--- a/packages/playground/src/examples/button-group/split-button.example.svelte
+++ b/packages/playground/src/examples/button-group/split-button.example.svelte
@@ -18,7 +18,10 @@
 <ButtonGroup label="Save options">
   <Button>Save</Button>
   <Dropdown id="save-options">
-    <DropdownTrigger><Button aria-label="More save options">▾</Button></DropdownTrigger>
+    <DropdownTrigger>
+      <!-- Decorative glyph; aria-label supplies the accessible name. -->
+      <Button aria-label="More save options">▾</Button>
+    </DropdownTrigger>
     <DropdownMenu>
       <DropdownItem>Save as draft</DropdownItem>
       <DropdownItem>Save and publish</DropdownItem>

--- a/packages/playground/src/examples/button-group/vertical.example.svelte
+++ b/packages/playground/src/examples/button-group/vertical.example.svelte
@@ -1,0 +1,14 @@
+<script lang="ts" module>
+  export const title = 'Vertical button group';
+  export const description = 'Vertically stacked buttons with collapsed borders.';
+</script>
+
+<script lang="ts">
+  import { Button, ButtonGroup } from '../../../../components/src/index.ts';
+</script>
+
+<ButtonGroup label="Document actions" orientation="vertical">
+  <Button variant="secondary">Save</Button>
+  <Button variant="secondary">Duplicate</Button>
+  <Button variant="secondary">Archive</Button>
+</ButtonGroup>


### PR DESCRIPTION
## Summary

- Adds `ButtonGroup` as a **layout-only** grouping container for related action buttons — distinct from `SegmentedControl` which owns selection state
- `role="group"` with required accessible name via `label` (string) or `labelledBy` (element ID) — TypeScript discriminated union enforces exactly one at compile time, dev-mode `$effect` warns on empty/whitespace values at runtime
- Horizontal and vertical orientations via `data-cinder-orientation` data attribute (CSS layout only — `aria-orientation` is intentionally absent: it is not a valid ARIA attribute for `role="group"` per ARIA 1.2)
- Direct children tagged with `data-cinder-button-group-item` via Svelte attachment + MutationObserver for dynamic child sets; attribute carries an opaque group-specific ID for ownership tracking when children move between groups
- Border collapse via `margin-inline-start: -1px` / `margin-block-start: -1px` using logical properties (RTL-safe)
- `isolation: isolate` + `z-index: 1` on `:hover`/`:focus-within` so focus rings are never clipped by adjacent borders
- Border-radius flattening with `:not([role='menu'] *):not([role='menuitem'])` guard to protect dropdown menu items
- Split-button composition documented with playground example (primary `<Button>` + `<Dropdown>` trigger)
- RTL, vertical, and split-button playground examples included

## Review committee

Pre-reviewed by: frontend-architect, testing-expert, ux-designer, simplicity-engineer, junior-engineer, Codex (gpt-5.4)

- 2 rounds of review
- All must-fix items addressed before PR creation:
  - `aria-orientation` removed (invalid ARIA for `role="group"`)
  - MutationObserver ownership bug fixed (group-ID-scoped attribute values)
  - MutationObserver cleanup and dynamic re-tagging paths tested
  - Direct-child attachment test fixed to assert on the button itself, not a wrapper div
  - Public styling contract documentation corrected (attribute value is opaque; consumers match by presence)

## Test plan

- `bun test packages/components/src/components/button-group.test.ts` — 16 tests covering ARIA contract, orientation data attribute, dev warnings, class passthrough, rest spread, no-selection-ARIA, direct-child tagging, group ID ownership, MutationObserver cleanup, MutationObserver dynamic addition
- `bun run typecheck` — svelte-check processes `button-group.type-test.ts` which verifies discriminated union rejects both-present and neither-present prop combinations
- `bun run lint` — 0 errors
- Playground: run `bun run playground` and navigate to `ButtonGroup` for basic, vertical, split-button, and RTL examples

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily additive (new component, styles, tests, and playground examples) with minimal impact on existing behavior; main risk is unintended styling interactions when consumers start grouping mixed/nested button-like children.
> 
> **Overview**
> Adds a new `ButtonGroup` component (`role="group"`) as a *layout-only* container for related action buttons, requiring an accessible name via mutually-exclusive `label`/`labelledBy` and supporting horizontal/vertical orientation via `data-cinder-orientation`.
> 
> Implements border-collapsing + focus-ring-friendly styling (`button-group.css`) and tags direct children with a `data-cinder-button-group-item` attribute (MutationObserver-backed) to support stable styling even when children change.
> 
> Exposes the component via package exports (`package.json`, `src/index.ts`), adds a11y documentation, unit + type-level tests, and new playground examples (basic, vertical, RTL, split-button composition).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bc56cd1c772f685f59306f1e87ce53c2c5a250e6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->