### PR TITLE
feat(components): rewrite segmented-control to absorb multi-select (toggle-button-group)

### DIFF
--- a/packages/components/src/components/diff-viewer/diff-toolbar.svelte
+++ b/packages/components/src/components/diff-viewer/diff-toolbar.svelte
@@ -79,6 +79,7 @@
   <div class="toolbar-left">
     <SegmentedControl
       id="diff-view-mode"
+      selectionMode="single"
       label="View mode"
       hideLabel
       bind:value={viewMode}

--- a/packages/components/src/components/diff-viewer/diff-toolbar.svelte
+++ b/packages/components/src/components/diff-viewer/diff-toolbar.svelte
@@ -80,6 +80,7 @@
     <SegmentedControl
       id="diff-view-mode"
       selectionMode="single"
+      size="sm"
       label="View mode"
       hideLabel
       bind:value={viewMode}

--- a/packages/components/src/components/markdown-editor.svelte
+++ b/packages/components/src/components/markdown-editor.svelte
@@ -620,6 +620,7 @@
             <SegmentedControl
               id={`${id}-mode-toggle`}
               selectionMode="single"
+              size="sm"
               bind:value={mode}
               options={[
                 { value: 'wysiwyg', label: 'Rich' },
@@ -733,16 +734,7 @@
     flex-shrink: 0;
   }
 
-  /* Compact mode toggle styling for toolbar context */
-  .toolbar-mode-toggle :global(.cinder-segmented-control) {
-    font-size: var(--cinder-text-xs);
-  }
-
-  .toolbar-mode-toggle :global(.cinder-segmented-control-option) {
-    padding-block: var(--cinder-space-1);
-    padding-inline: var(--cinder-space-2);
-    min-block-size: auto;
-  }
+  /* SegmentedControl uses size="sm" — no height override needed */
 
   .toolbar-leading,
   .toolbar-actions {

--- a/packages/components/src/components/markdown-editor.svelte
+++ b/packages/components/src/components/markdown-editor.svelte
@@ -619,6 +619,7 @@
           <div class="toolbar-mode-toggle">
             <SegmentedControl
               id={`${id}-mode-toggle`}
+              selectionMode="single"
               bind:value={mode}
               options={[
                 { value: 'wysiwyg', label: 'Rich' },
@@ -733,13 +734,14 @@
   }
 
   /* Compact mode toggle styling for toolbar context */
-  .toolbar-mode-toggle :global(.segmented-control) {
+  .toolbar-mode-toggle :global(.cinder-segmented-control) {
     font-size: var(--cinder-text-xs);
   }
 
-  .toolbar-mode-toggle :global(.segmented-control-option) {
-    padding: var(--cinder-space-1) var(--cinder-space-2);
-    min-height: auto;
+  .toolbar-mode-toggle :global(.cinder-segmented-control-option) {
+    padding-block: var(--cinder-space-1);
+    padding-inline: var(--cinder-space-2);
+    min-block-size: auto;
   }
 
   .toolbar-leading,

--- a/packages/components/src/components/review-editor/review-editor-controls.svelte
+++ b/packages/components/src/components/review-editor/review-editor-controls.svelte
@@ -103,6 +103,7 @@
       <SegmentedControl
         id="{id}-diff-view-mode"
         selectionMode="single"
+        size="sm"
         label="Diff view mode"
         hideLabel
         bind:value={diffViewMode}
@@ -199,18 +200,7 @@
     line-height: 1;
   }
 
-  /* SegmentedControl wrapper - ensure consistent outer height */
-  .review-editor-controls :global(.cinder-segmented-control) {
-    padding: 2px;
-  }
-
-  /* SegmentedControl options - 20px inner height (24px with wrapper padding + border) */
-  .review-editor-controls :global(.cinder-segmented-control-option) {
-    block-size: 18px;
-    min-block-size: 18px;
-    padding-block: 0;
-    padding-inline: var(--cinder-space-2);
-  }
+  /* SegmentedControl uses size="sm" (1.5rem = 24px) — no height override needed */
 
   /* Buttons - 24px height to match */
   .review-editor-controls :global(.button[data-size='sm']) {

--- a/packages/components/src/components/review-editor/review-editor-controls.svelte
+++ b/packages/components/src/components/review-editor/review-editor-controls.svelte
@@ -102,6 +102,7 @@
       <div class="controls-separator" aria-hidden="true"></div>
       <SegmentedControl
         id="{id}-diff-view-mode"
+        selectionMode="single"
         label="Diff view mode"
         hideLabel
         bind:value={diffViewMode}
@@ -199,15 +200,16 @@
   }
 
   /* SegmentedControl wrapper - ensure consistent outer height */
-  .review-editor-controls :global(.segmented-control) {
+  .review-editor-controls :global(.cinder-segmented-control) {
     padding: 2px;
   }
 
   /* SegmentedControl options - 20px inner height (24px with wrapper padding + border) */
-  .review-editor-controls :global(.segmented-control-option) {
-    height: 18px;
-    min-height: 18px;
-    padding: 0 var(--cinder-space-2);
+  .review-editor-controls :global(.cinder-segmented-control-option) {
+    block-size: 18px;
+    min-block-size: 18px;
+    padding-block: 0;
+    padding-inline: var(--cinder-space-2);
   }
 
   /* Buttons - 24px height to match */

--- a/packages/components/src/components/segmented-control.a11y.md
+++ b/packages/components/src/components/segmented-control.a11y.md
@@ -1,0 +1,81 @@
+# Segmented Control — Accessibility Notes
+
+## Pattern
+
+`segmented-control` encodes **selection state**. It has two modes:
+
+- **Single** (`selectionMode="single"`, default) — follows the [WAI-ARIA Radio Group pattern](https://www.w3.org/WAI/ARIA/apg/patterns/radio/). Exactly one option is selected at a time.
+- **Multiple** (`selectionMode="multiple"`) — follows the [Toggle Button pattern](https://www.w3.org/WAI/ARIA/apg/patterns/button/) applied across a group. Options toggle independently; any number may be active.
+
+## Roles and States
+
+### Single mode
+
+| Element             | Role                                       | State attributes                                       |
+| ------------------- | ------------------------------------------ | ------------------------------------------------------ |
+| Labelled group root | `radiogroup`                               | `aria-labelledby`, `aria-disabled`, `aria-orientation` |
+| Each option         | `radio` (via `role="radio"` on `<button>`) | `aria-checked` (`true`/`false`), `disabled`            |
+
+### Multiple mode
+
+| Element             | Role             | State attributes                            |
+| ------------------- | ---------------- | ------------------------------------------- |
+| Labelled group root | `group`          | `aria-labelledby`, `aria-disabled`          |
+| Each option         | button (default) | `aria-pressed` (`true`/`false`), `disabled` |
+
+Group-level `disabled` sets `aria-disabled="true"` on the labelled group root in both modes and disables every option button.
+
+`aria-orientation` is present on the labelled group root in **single mode only** — `radiogroup` is a composite widget where orientation guides arrow-key navigation. The `group` role used in multiple mode is not a composite widget, so `aria-orientation` would be meaningless there.
+
+## Why Not `aria-pressed` on Radios?
+
+`aria-pressed` is a state for toggle buttons. Radio buttons use `aria-checked`. Mixing them confuses assistive technology — a screen reader announces "toggle button, pressed" for a radio or "radio button, checked" for a toggle button, creating a mismatch between the announced semantics and the actual interaction model.
+
+Single mode uses `role="radio"` + `aria-checked`. Multiple mode uses default button role + `aria-pressed`. The two states are never mixed.
+
+## Why No Roving Tabindex in Multiple Mode?
+
+Roving tabindex marks one item in a composite widget as the single Tab stop and uses arrow keys to move focus within the group. This is appropriate for radio groups (where options are mutually exclusive and form a single logical control) and other composite widgets like toolbars and menus.
+
+Toggle buttons are **independent controls**. Each one is its own Tab stop with its own state. Using roving tabindex would imply they form a single composite widget — which they don't. Multiple mode therefore uses natural Tab order: every enabled option receives focus in document order, and there is no arrow-key navigation between options.
+
+## Keyboard Interaction
+
+### Single mode
+
+| Key                        | Behavior                                                                                      |
+| -------------------------- | --------------------------------------------------------------------------------------------- |
+| `Tab` / `Shift+Tab`        | Move focus into / out of the group (one Tab stop — the selected or first non-disabled option) |
+| `ArrowRight` / `ArrowDown` | Move focus **and selection** to the next non-disabled option (wraps)                          |
+| `ArrowLeft` / `ArrowUp`    | Move focus **and selection** to the previous non-disabled option (wraps)                      |
+| `Home`                     | Move focus and selection to the first non-disabled option                                     |
+| `End`                      | Move focus and selection to the last non-disabled option                                      |
+| `Space` / `Enter`          | Activate the focused option (browser synthesizes a `click` on `<button>`)                     |
+
+Vertical orientation (`orientation="vertical"`) maps `ArrowUp`/`ArrowDown` for navigation and disables horizontal arrows.
+
+### Multiple mode
+
+| Key                 | Behavior                                                       |
+| ------------------- | -------------------------------------------------------------- |
+| `Tab` / `Shift+Tab` | Move focus between enabled options (each is a normal Tab stop) |
+| `Space` / `Enter`   | Toggle the focused option (browser default for `<button>`)     |
+
+Arrow keys have no special meaning in multiple mode.
+
+## Group Labeling
+
+Both modes label the group via `aria-labelledby` pointing at a sibling `<span>`. When `hideLabel` is set, the span receives `.cinder-sr-only` — visually hidden but still referenced by `aria-labelledby`, so the group name is available to assistive technology.
+
+## Boundary: `segmented-control` vs `button-group`
+
+**If you need selection state** — one option active at a time, or a set of toggle states — use `segmented-control`.
+
+**If you need independent action buttons** laid out in a strip — no selection state, no `aria-checked`, no `aria-pressed` — use `button-group`. It is layout-only: buttons are independent, there is no roving tabindex, and no value binding.
+
+The distinction matters for assistive technology:
+
+- `segmented-control` announces the group as `radiogroup` or `group` with a label. Screen readers can navigate to the group directly and understand the selection relationship.
+- `button-group` is a visual affordance only. Screen readers traverse the buttons individually as ordinary interactive controls with no implied relationship between them.
+
+If you find yourself wanting selection state on a `button-group`, you want `segmented-control`. If you find yourself wanting independent actions in a `segmented-control`, you want `button-group`.

--- a/packages/components/src/components/segmented-control.svelte
+++ b/packages/components/src/components/segmented-control.svelte
@@ -144,7 +144,7 @@
     const nextIndex = handleRovingKeydown(event, currentIndex, options.length, {
       isDisabled: isOptionDisabled,
       vertical: true,
-      horizontal: true,
+      horizontal: orientation !== 'vertical',
     });
 
     if (nextIndex === null) return;

--- a/packages/components/src/components/segmented-control.svelte
+++ b/packages/components/src/components/segmented-control.svelte
@@ -143,8 +143,8 @@
     const currentIndex = focusedIndex ?? (selectedIndex >= 0 ? selectedIndex : focusableIndex);
     const nextIndex = handleRovingKeydown(event, currentIndex, options.length, {
       isDisabled: isOptionDisabled,
-      vertical: orientation === 'vertical',
-      horizontal: orientation === 'horizontal',
+      vertical: true,
+      horizontal: true,
     });
 
     if (nextIndex === null) return;

--- a/packages/components/src/components/segmented-control.svelte
+++ b/packages/components/src/components/segmented-control.svelte
@@ -1,5 +1,6 @@
 <script lang="ts" module>
   import type { HTMLAttributes } from 'svelte/elements';
+  import type { SvelteSet } from 'svelte/reactivity';
 
   export type SegmentedControlOption<T extends string = string> = {
     value: T;
@@ -7,25 +8,63 @@
     disabled?: boolean;
   };
 
-  export type SegmentedControlProps<T extends string = string> = Omit<
+  type ComponentOwnedAttributes =
+    | 'id'
+    | 'class'
+    | 'role'
+    | 'tabindex'
+    | 'aria-label'
+    | 'aria-labelledby'
+    | 'aria-disabled'
+    | 'aria-orientation'
+    | 'onkeydown';
+
+  type CommonProps<T extends string> = Omit<
     HTMLAttributes<HTMLDivElement>,
-    'id'
+    ComponentOwnedAttributes
   > & {
     /** Unique identifier for the control. */
     id: string;
-    /** Selected option value. */
-    value?: T;
-    /** Available options. */
-    options: readonly SegmentedControlOption<T>[];
-    /** Accessible label for the radio group. */
+    /** Accessible label for the group. */
     label: string;
     /** Visually hide the label while keeping it available to assistive technology. */
     hideLabel?: boolean;
     /** Disable the whole control. */
     disabled?: boolean;
+    /** Visual size of the control. */
+    size?: 'sm' | 'md' | 'lg';
+    /** Layout orientation. */
+    orientation?: 'horizontal' | 'vertical';
+    /** Show options as detached individual buttons instead of a unified strip. */
+    detached?: boolean;
+    /** Stretch the control to fill available width. */
+    fullWidth?: boolean;
+    /** Available options. */
+    options: readonly SegmentedControlOption<T>[];
     /** Additional class names merged with `.cinder-segmented-control`. */
     class?: string;
   };
+
+  type SingleProps<T extends string> = CommonProps<T> & {
+    selectionMode?: 'single';
+    /** Selected option value. */
+    value?: T;
+    /**
+     * When true (default), clicking the already-selected option is a no-op.
+     * When false, clicking the selected option clears value to undefined.
+     */
+    disallowEmptySelection?: boolean;
+  };
+
+  type MultipleProps<T extends string> = CommonProps<T> & {
+    selectionMode: 'multiple';
+    /** Set of selected option values. Must be a SvelteSet for reactivity. */
+    value?: SvelteSet<T>;
+    /** Not applicable in multiple mode — present for Svelte destructuring compatibility. */
+    disallowEmptySelection?: undefined;
+  };
+
+  export type SegmentedControlProps<T extends string = string> = SingleProps<T> | MultipleProps<T>;
 </script>
 
 <script lang="ts" generics="T extends string = string">
@@ -34,35 +73,78 @@
 
   let {
     id,
-    value = $bindable<T>(),
+    value = $bindable<any>(),
     options,
     label,
     hideLabel = false,
     disabled = false,
+    size = 'md',
+    orientation = 'horizontal',
+    detached = false,
+    fullWidth = false,
+    selectionMode = 'single',
+    disallowEmptySelection = true,
     class: customClassName,
     ...rest
   }: SegmentedControlProps<T> = $props();
 
+  // Single-mode state
   let focusedIndex = $state<number | null>(null);
 
-  const selectedIndex = $derived(options.findIndex((option) => option.value === value));
-  const isOptionDisabled = (index: number) => disabled || options[index]?.disabled === true;
-  const focusableIndex = $derived(
-    getFocusableIndex(selectedIndex, options.length, isOptionDisabled),
+  const selectedIndex = $derived(
+    selectionMode === 'single'
+      ? options.findIndex((option) => option.value === (value as T | undefined))
+      : -1,
   );
 
-  function selectOption(index: number): void {
+  const isOptionDisabled = (index: number) => disabled || options[index]?.disabled === true;
+
+  const focusableIndex = $derived.by((): number => {
+    if (selectionMode !== 'single') return -1;
+    const candidate = getFocusableIndex(selectedIndex, options.length, isOptionDisabled);
+    // If every option is disabled, getFocusableIndex falls back to index 0.
+    // Don't give tabindex="0" to a disabled option — return -1 so no option is focusable.
+    if (candidate >= 0 && isOptionDisabled(candidate)) return -1;
+    return candidate;
+  });
+
+  function handleSingleClick(index: number): void {
     const option = options[index];
     if (!option || disabled || option.disabled) return;
-    value = option.value;
+
+    const currentValue = value as T | undefined;
+    if (option.value === currentValue) {
+      if (!disallowEmptySelection) {
+        (value as any) = undefined;
+      }
+      return;
+    }
+
+    (value as any) = option.value;
+  }
+
+  function handleMultipleClick(index: number): void {
+    const option = options[index];
+    if (!option || disabled || option.disabled) return;
+
+    const set = value as SvelteSet<T> | undefined;
+    if (!set) return;
+
+    if (set.has(option.value)) {
+      set.delete(option.value);
+    } else {
+      set.add(option.value);
+    }
   }
 
   function handleKeydown(event: KeyboardEvent): void {
-    if (disabled) return;
+    if (disabled || selectionMode !== 'single') return;
 
     const currentIndex = focusedIndex ?? (selectedIndex >= 0 ? selectedIndex : focusableIndex);
     const nextIndex = handleRovingKeydown(event, currentIndex, options.length, {
       isDisabled: isOptionDisabled,
+      vertical: orientation === 'vertical',
+      horizontal: orientation === 'horizontal',
     });
 
     if (nextIndex === null) return;
@@ -70,9 +152,15 @@
     event.preventDefault();
     if (nextIndex === currentIndex) return;
 
-    selectOption(nextIndex);
+    handleSingleClick(nextIndex);
     focusedIndex = nextIndex;
     document.getElementById(`${id}-option-${nextIndex}`)?.focus();
+  }
+
+  function isPressed(optionValue: T): boolean {
+    if (selectionMode !== 'multiple') return false;
+    const set = value as SvelteSet<T> | undefined;
+    return set?.has(optionValue) ?? false;
   }
 </script>
 
@@ -84,34 +172,53 @@
     {label}
   </span>
   <div
+    {...rest}
     {id}
-    role="radiogroup"
+    role={selectionMode === 'single' ? 'radiogroup' : 'group'}
     aria-labelledby={`${id}-label`}
     aria-disabled={disabled ? 'true' : undefined}
+    aria-orientation={selectionMode === 'single' ? orientation : undefined}
+    data-cinder-orientation={orientation}
+    data-cinder-size={size}
+    data-cinder-selection-mode={selectionMode}
+    data-cinder-detached={detached ? '' : undefined}
+    data-cinder-full-width={fullWidth ? '' : undefined}
     class={classNames('cinder-segmented-control', customClassName)}
-    data-cinder-disabled={disabled ? '' : undefined}
-    onkeydown={handleKeydown}
-    {...rest}
+    onkeydown={selectionMode === 'single' ? handleKeydown : undefined}
   >
     {#each options as option, index (option.value)}
-      {@const isSelected = option.value === value}
       {@const isDisabled = disabled || option.disabled === true}
-      <button
-        id={`${id}-option-${index}`}
-        type="button"
-        role="radio"
-        aria-checked={isSelected}
-        aria-disabled={isDisabled ? 'true' : undefined}
-        disabled={isDisabled}
-        tabindex={index === focusableIndex ? 0 : -1}
-        class="cinder-segmented-control-option"
-        data-cinder-selected={isSelected ? '' : undefined}
-        onclick={() => selectOption(index)}
-        onfocus={() => (focusedIndex = index)}
-        onblur={() => (focusedIndex = null)}
-      >
-        {option.label}
-      </button>
+      {#if selectionMode === 'single'}
+        {@const isSelected = option.value === (value as T | undefined)}
+        <button
+          id={`${id}-option-${index}`}
+          type="button"
+          role="radio"
+          aria-checked={isSelected}
+          disabled={isDisabled}
+          tabindex={index === focusableIndex ? 0 : -1}
+          class="cinder-segmented-control-option"
+          data-cinder-selected={isSelected ? '' : undefined}
+          onclick={() => handleSingleClick(index)}
+          onfocus={() => (focusedIndex = index)}
+          onblur={() => (focusedIndex = null)}
+        >
+          {option.label}
+        </button>
+      {:else}
+        {@const pressed = isPressed(option.value)}
+        <button
+          id={`${id}-option-${index}`}
+          type="button"
+          aria-pressed={pressed}
+          disabled={isDisabled}
+          class="cinder-segmented-control-option"
+          data-cinder-pressed={pressed ? '' : undefined}
+          onclick={() => handleMultipleClick(index)}
+        >
+          {option.label}
+        </button>
+      {/if}
     {/each}
   </div>
 </div>

--- a/packages/components/src/components/segmented-control.svelte
+++ b/packages/components/src/components/segmented-control.svelte
@@ -73,7 +73,7 @@
 
   let {
     id,
-    value = $bindable<any>(),
+    value = $bindable<T | SvelteSet<T> | undefined>(),
     options,
     label,
     hideLabel = false,

--- a/packages/components/src/components/segmented-control.test.ts
+++ b/packages/components/src/components/segmented-control.test.ts
@@ -171,6 +171,31 @@ describe('SegmentedControl — single mode', () => {
     expect(selected).toBeUndefined();
   });
 
+  // Test 7a
+  test('Space key on focused already-selected option clears value when disallowEmptySelection=false', async () => {
+    let selected: string | undefined = 'source';
+
+    render(SegmentedControl, {
+      props: {
+        id: 'document-view',
+        get value() {
+          return selected;
+        },
+        set value(nextValue: string | undefined) {
+          selected = nextValue;
+        },
+        label: 'Document view',
+        options,
+        disallowEmptySelection: false,
+      } as any,
+    });
+
+    // Space on a <button> synthesizes a click — the keydown handler routes roving keys only,
+    // so Space falls through to native button behavior which fires a click event.
+    await fireEvent.click(screen.getByRole('radio', { name: 'Source' }));
+    expect(selected).toBeUndefined();
+  });
+
   // Test 8
   test('with invalid value, first non-disabled option holds tabindex="0"', () => {
     render(SegmentedControl, {
@@ -355,6 +380,8 @@ describe('SegmentedControl — multiple mode', () => {
 
     await fireEvent.click(screen.getByRole('button', { name: 'Bold' }));
     expect(set.has('bold')).toBe(true);
+    // Prove DOM reactivity: aria-pressed must reflect the mutation
+    expect(screen.getByRole('button', { name: 'Bold' }).getAttribute('aria-pressed')).toBe('true');
   });
 
   // Test 15
@@ -374,6 +401,11 @@ describe('SegmentedControl — multiple mode', () => {
     await fireEvent.click(screen.getByRole('button', { name: 'Bold' }));
     expect(set.has('bold')).toBe(false);
     expect(set.has('italic')).toBe(true);
+    // Prove DOM reactivity: aria-pressed must reflect the updated state
+    expect(screen.getByRole('button', { name: 'Bold' }).getAttribute('aria-pressed')).toBe('false');
+    expect(screen.getByRole('button', { name: 'Italic' }).getAttribute('aria-pressed')).toBe(
+      'true',
+    );
   });
 
   // Test 16
@@ -412,9 +444,9 @@ describe('SegmentedControl — multiple mode', () => {
     const italicBtn = screen.getByRole('button', { name: 'Italic' });
     const underlineBtn = screen.getByRole('button', { name: 'Underline' });
 
-    // Enabled buttons should not have tabindex="-1"
-    expect(boldBtn.getAttribute('tabindex')).not.toBe('-1');
-    expect(italicBtn.getAttribute('tabindex')).not.toBe('-1');
+    // Multi-mode buttons have no explicit tabindex — they are naturally in tab order
+    expect(boldBtn.getAttribute('tabindex')).toBeNull();
+    expect(italicBtn.getAttribute('tabindex')).toBeNull();
     // Disabled button has the disabled attribute
     expect(underlineBtn.hasAttribute('disabled')).toBe(true);
   });

--- a/packages/components/src/components/segmented-control.test.ts
+++ b/packages/components/src/components/segmented-control.test.ts
@@ -171,36 +171,22 @@ describe('SegmentedControl — single mode', () => {
     expect(selected).toBeUndefined();
   });
 
-  // Test 7a — verifies handleKeydown does not preventDefault on Space, allowing browser click synthesis
-  test('Space keydown does not suppress click on already-selected option (disallowEmptySelection=false)', async () => {
-    let selected: string | undefined = 'source';
-
+  // Test 7a — verifies handleKeydown does not preventDefault on Space
+  // (jsdom doesn't auto-synthesize clicks from Space; real browsers do, so we only assert the event was not cancelled)
+  test('Space keydown on a focused option does not call preventDefault', async () => {
     render(SegmentedControl, {
       props: {
         id: 'document-view',
-        get value() {
-          return selected;
-        },
-        set value(nextValue: string | undefined) {
-          selected = nextValue;
-        },
+        value: 'source',
         label: 'Document view',
         options,
-        disallowEmptySelection: false,
-      } as any,
+      },
     });
 
     const sourceOption = screen.getByRole('radio', { name: 'Source' });
-
-    // Fire Space keydown — handleKeydown only handles Arrow/Home/End and returns null for Space,
-    // so preventDefault is not called and the browser can synthesize its native click.
-    const spaceEvent = await fireEvent.keyDown(sourceOption, { key: ' ' });
-    // Verify handleKeydown did not swallow the event (defaultPrevented would break browser click synthesis)
-    expect(spaceEvent).toBe(true); // fireEvent returns true when event was not cancelled
-
-    // Simulate the browser's native Space→click synthesis
-    await fireEvent.click(sourceOption);
-    expect(selected).toBeUndefined();
+    // dispatchEvent returns false when preventDefault() was called; true otherwise
+    const notCancelled = await fireEvent.keyDown(sourceOption, { key: ' ' });
+    expect(notCancelled).toBe(true);
   });
 
   // Test 8

--- a/packages/components/src/components/segmented-control.test.ts
+++ b/packages/components/src/components/segmented-control.test.ts
@@ -171,8 +171,8 @@ describe('SegmentedControl — single mode', () => {
     expect(selected).toBeUndefined();
   });
 
-  // Test 7a
-  test('Space key on focused already-selected option clears value when disallowEmptySelection=false', async () => {
+  // Test 7a — verifies handleKeydown does not preventDefault on Space, allowing browser click synthesis
+  test('Space keydown does not suppress click on already-selected option (disallowEmptySelection=false)', async () => {
     let selected: string | undefined = 'source';
 
     render(SegmentedControl, {
@@ -190,9 +190,16 @@ describe('SegmentedControl — single mode', () => {
       } as any,
     });
 
-    // Space on a <button> synthesizes a click — the keydown handler routes roving keys only,
-    // so Space falls through to native button behavior which fires a click event.
-    await fireEvent.click(screen.getByRole('radio', { name: 'Source' }));
+    const sourceOption = screen.getByRole('radio', { name: 'Source' });
+
+    // Fire Space keydown — handleKeydown only handles Arrow/Home/End and returns null for Space,
+    // so preventDefault is not called and the browser can synthesize its native click.
+    const spaceEvent = await fireEvent.keyDown(sourceOption, { key: ' ' });
+    // Verify handleKeydown did not swallow the event (defaultPrevented would break browser click synthesis)
+    expect(spaceEvent).toBe(true); // fireEvent returns true when event was not cancelled
+
+    // Simulate the browser's native Space→click synthesis
+    await fireEvent.click(sourceOption);
     expect(selected).toBeUndefined();
   });
 

--- a/packages/components/src/components/segmented-control.test.ts
+++ b/packages/components/src/components/segmented-control.test.ts
@@ -1,5 +1,6 @@
 /// <reference lib="dom" />
 import { afterEach, describe, expect, test } from 'bun:test';
+import { SvelteSet } from 'svelte/reactivity';
 
 import { setupHappyDom } from '../test/happy-dom.ts';
 
@@ -16,8 +17,16 @@ const options = [
   { value: 'diff', label: 'Diff', disabled: true },
 ] as const;
 
-describe('SegmentedControl', () => {
-  test('renders accessible radio options', () => {
+const allDisabledOptions = [
+  { value: 'a', label: 'A', disabled: true },
+  { value: 'b', label: 'B', disabled: true },
+] as const;
+
+// ── Single mode ─────────────────────────────────────────────────────────────
+
+describe('SegmentedControl — single mode', () => {
+  // Test 1
+  test('renders role="radiogroup" with the provided accessible name', () => {
     render(SegmentedControl, {
       props: {
         id: 'document-view',
@@ -28,10 +37,27 @@ describe('SegmentedControl', () => {
     });
 
     expect(screen.getByRole('radiogroup', { name: 'Document view' })).not.toBeNull();
-    expect(screen.getByRole('radio', { name: 'Source' }).getAttribute('aria-checked')).toBe('true');
   });
 
-  test('clicking an enabled option updates the bindable value', async () => {
+  // Test 2
+  test('renders each option as role="radio" with correct aria-checked', () => {
+    render(SegmentedControl, {
+      props: {
+        id: 'document-view',
+        value: 'source',
+        label: 'Document view',
+        options,
+      },
+    });
+
+    expect(screen.getByRole('radio', { name: 'Source' }).getAttribute('aria-checked')).toBe('true');
+    expect(screen.getByRole('radio', { name: 'Rendered' }).getAttribute('aria-checked')).toBe(
+      'false',
+    );
+  });
+
+  // Test 3
+  test('clicking an enabled non-selected option updates bindable value', async () => {
     let selected = 'source';
 
     render(SegmentedControl, {
@@ -50,12 +76,54 @@ describe('SegmentedControl', () => {
 
     await fireEvent.click(screen.getByRole('radio', { name: 'Rendered' }));
     expect(selected).toBe('rendered');
-
-    await fireEvent.click(screen.getByRole('radio', { name: 'Diff' }));
-    expect(selected).toBe('rendered');
   });
 
-  test('arrow navigation moves selection while skipping disabled options', async () => {
+  // Test 4
+  test('clicking the already-selected option is a no-op (disallowEmptySelection default true)', async () => {
+    let selected = 'source';
+
+    render(SegmentedControl, {
+      props: {
+        id: 'document-view',
+        get value() {
+          return selected;
+        },
+        set value(nextValue: string) {
+          selected = nextValue;
+        },
+        label: 'Document view',
+        options,
+      },
+    });
+
+    await fireEvent.click(screen.getByRole('radio', { name: 'Source' }));
+    expect(selected).toBe('source');
+  });
+
+  // Test 5
+  test('clicking a disabled option is a no-op', async () => {
+    let selected = 'source';
+
+    render(SegmentedControl, {
+      props: {
+        id: 'document-view',
+        get value() {
+          return selected;
+        },
+        set value(nextValue: string) {
+          selected = nextValue;
+        },
+        label: 'Document view',
+        options,
+      },
+    });
+
+    await fireEvent.click(screen.getByRole('radio', { name: 'Diff' }));
+    expect(selected).toBe('source');
+  });
+
+  // Test 6
+  test('arrow navigation moves selection, skipping disabled options', async () => {
     let selected = 'source';
 
     render(SegmentedControl, {
@@ -75,7 +143,541 @@ describe('SegmentedControl', () => {
     await fireEvent.keyDown(screen.getByRole('radiogroup'), { key: 'ArrowRight' });
     expect(selected).toBe('rendered');
 
+    // ArrowRight again wraps around skipping disabled 'diff'
     await fireEvent.keyDown(screen.getByRole('radiogroup'), { key: 'ArrowRight' });
     expect(selected).toBe('source');
+  });
+
+  // Test 7
+  test('with disallowEmptySelection={false}, clicking the already-selected option clears value', async () => {
+    let selected: string | undefined = 'source';
+
+    render(SegmentedControl, {
+      props: {
+        id: 'document-view',
+        get value() {
+          return selected;
+        },
+        set value(nextValue: string | undefined) {
+          selected = nextValue;
+        },
+        label: 'Document view',
+        options,
+        disallowEmptySelection: false,
+      } as any,
+    });
+
+    await fireEvent.click(screen.getByRole('radio', { name: 'Source' }));
+    expect(selected).toBeUndefined();
+  });
+
+  // Test 8
+  test('with invalid value, first non-disabled option holds tabindex="0"', () => {
+    render(SegmentedControl, {
+      props: {
+        id: 'document-view',
+        value: 'nonexistent' as any,
+        label: 'Document view',
+        options,
+      },
+    });
+
+    const source = screen.getByRole('radio', { name: 'Source' });
+    const rendered = screen.getByRole('radio', { name: 'Rendered' });
+
+    expect(source.getAttribute('tabindex')).toBe('0');
+    expect(rendered.getAttribute('tabindex')).toBe('-1');
+    // No option is aria-checked="true"
+    expect(source.getAttribute('aria-checked')).toBe('false');
+    expect(rendered.getAttribute('aria-checked')).toBe('false');
+  });
+
+  // Test 9
+  test('group-level disabled: no click changes value; root has aria-disabled="true"', async () => {
+    let selected = 'source';
+
+    render(SegmentedControl, {
+      props: {
+        id: 'document-view',
+        get value() {
+          return selected;
+        },
+        set value(nextValue: string) {
+          selected = nextValue;
+        },
+        label: 'Document view',
+        options,
+        disabled: true,
+      },
+    });
+
+    const group = screen.getByRole('radiogroup');
+    expect(group.getAttribute('aria-disabled')).toBe('true');
+
+    await fireEvent.click(screen.getByRole('radio', { name: 'Rendered' }));
+    expect(selected).toBe('source');
+  });
+
+  // Test 10
+  test('value set to string not in options: no option renders aria-checked="true"', () => {
+    render(SegmentedControl, {
+      props: {
+        id: 'document-view',
+        value: 'nonexistent' as any,
+        label: 'Document view',
+        options,
+      },
+    });
+
+    const radios = screen.getAllByRole('radio');
+    for (const radio of radios) {
+      expect(radio.getAttribute('aria-checked')).toBe('false');
+    }
+  });
+
+  // Test 10a
+  test('all options disabled: no tabindex="0", root does not carry aria-disabled', () => {
+    render(SegmentedControl, {
+      props: {
+        id: 'document-view',
+        label: 'Document view',
+        options: allDisabledOptions,
+      },
+    });
+
+    const group = screen.getByRole('radiogroup');
+    expect(group.getAttribute('aria-disabled')).toBeNull();
+
+    const buttons = screen.getAllByRole('radio');
+    for (const button of buttons) {
+      // All are disabled and should not have tabindex="0"
+      expect(button.getAttribute('tabindex')).toBe('-1');
+    }
+  });
+
+  // Test 10b
+  test('empty options: group renders, no buttons, root has no aria-disabled', () => {
+    render(SegmentedControl, {
+      props: {
+        id: 'document-view',
+        label: 'Document view',
+        options: [],
+      },
+    });
+
+    const group = screen.getByRole('radiogroup');
+    expect(group.getAttribute('aria-disabled')).toBeNull();
+    expect(screen.queryAllByRole('radio')).toHaveLength(0);
+  });
+});
+
+// ── Multiple mode ────────────────────────────────────────────────────────────
+
+describe('SegmentedControl — multiple mode', () => {
+  const multiOptions = [
+    { value: 'bold', label: 'Bold' },
+    { value: 'italic', label: 'Italic' },
+    { value: 'underline', label: 'Underline', disabled: true },
+  ] as const;
+
+  // Test 11
+  test('renders role="group" (not radiogroup); no element has role="radio"', () => {
+    const set = new SvelteSet<string>(['bold']);
+
+    render(SegmentedControl, {
+      props: {
+        id: 'text-format',
+        label: 'Text formatting',
+        options: multiOptions,
+        selectionMode: 'multiple',
+        value: set,
+      },
+    });
+
+    expect(screen.getByRole('group', { name: 'Text formatting' })).not.toBeNull();
+    expect(screen.queryByRole('radio')).toBeNull();
+    expect(screen.queryByRole('radiogroup')).toBeNull();
+  });
+
+  // Test 12
+  test('group has accessible name from label; hideLabel still provides it to AT', () => {
+    const set = new SvelteSet<string>();
+
+    render(SegmentedControl, {
+      props: {
+        id: 'text-format',
+        label: 'Text formatting',
+        options: multiOptions,
+        selectionMode: 'multiple',
+        value: set,
+        hideLabel: true,
+      },
+    });
+
+    // The group is still accessible via aria-labelledby even when label is visually hidden
+    expect(screen.getByRole('group', { name: 'Text formatting' })).not.toBeNull();
+  });
+
+  // Test 13
+  test('each option exposes aria-pressed reflecting membership in the SvelteSet', () => {
+    const set = new SvelteSet<string>(['bold']);
+
+    render(SegmentedControl, {
+      props: {
+        id: 'text-format',
+        label: 'Text formatting',
+        options: multiOptions,
+        selectionMode: 'multiple',
+        value: set,
+      },
+    });
+
+    const boldBtn = screen.getByRole('button', { name: 'Bold' });
+    const italicBtn = screen.getByRole('button', { name: 'Italic' });
+
+    expect(boldBtn.getAttribute('aria-pressed')).toBe('true');
+    expect(italicBtn.getAttribute('aria-pressed')).toBe('false');
+  });
+
+  // Test 14
+  test('clicking an unpressed option adds it to the SvelteSet (reactivity check)', async () => {
+    const set = new SvelteSet<string>();
+
+    render(SegmentedControl, {
+      props: {
+        id: 'text-format',
+        label: 'Text formatting',
+        options: multiOptions,
+        selectionMode: 'multiple',
+        value: set,
+      },
+    });
+
+    await fireEvent.click(screen.getByRole('button', { name: 'Bold' }));
+    expect(set.has('bold')).toBe(true);
+  });
+
+  // Test 15
+  test('clicking a pressed option removes it from the SvelteSet', async () => {
+    const set = new SvelteSet<string>(['bold', 'italic']);
+
+    render(SegmentedControl, {
+      props: {
+        id: 'text-format',
+        label: 'Text formatting',
+        options: multiOptions,
+        selectionMode: 'multiple',
+        value: set,
+      },
+    });
+
+    await fireEvent.click(screen.getByRole('button', { name: 'Bold' }));
+    expect(set.has('bold')).toBe(false);
+    expect(set.has('italic')).toBe(true);
+  });
+
+  // Test 16
+  test('clicking a disabled option is a no-op', async () => {
+    const set = new SvelteSet<string>();
+
+    render(SegmentedControl, {
+      props: {
+        id: 'text-format',
+        label: 'Text formatting',
+        options: multiOptions,
+        selectionMode: 'multiple',
+        value: set,
+      },
+    });
+
+    await fireEvent.click(screen.getByRole('button', { name: 'Underline' }));
+    expect(set.has('underline')).toBe(false);
+  });
+
+  // Test 17
+  test('Tab order: non-disabled options have no explicit tabindex=-1 and are not disabled', () => {
+    const set = new SvelteSet<string>();
+
+    render(SegmentedControl, {
+      props: {
+        id: 'text-format',
+        label: 'Text formatting',
+        options: multiOptions,
+        selectionMode: 'multiple',
+        value: set,
+      },
+    });
+
+    const boldBtn = screen.getByRole('button', { name: 'Bold' });
+    const italicBtn = screen.getByRole('button', { name: 'Italic' });
+    const underlineBtn = screen.getByRole('button', { name: 'Underline' });
+
+    // Enabled buttons should not have tabindex="-1"
+    expect(boldBtn.getAttribute('tabindex')).not.toBe('-1');
+    expect(italicBtn.getAttribute('tabindex')).not.toBe('-1');
+    // Disabled button has the disabled attribute
+    expect(underlineBtn.hasAttribute('disabled')).toBe(true);
+  });
+
+  // Test 18
+  test('ArrowRight on a multi-mode option does not change aria-pressed state', async () => {
+    const set = new SvelteSet<string>();
+
+    render(SegmentedControl, {
+      props: {
+        id: 'text-format',
+        label: 'Text formatting',
+        options: multiOptions,
+        selectionMode: 'multiple',
+        value: set,
+      },
+    });
+
+    const boldBtn = screen.getByRole('button', { name: 'Bold' });
+    await fireEvent.keyDown(boldBtn, { key: 'ArrowRight' });
+    expect(set.size).toBe(0);
+    expect(boldBtn.getAttribute('aria-pressed')).toBe('false');
+  });
+
+  // Test 19
+  test('group-level disabled: no click changes the SvelteSet; root has aria-disabled="true"', async () => {
+    const set = new SvelteSet<string>();
+
+    render(SegmentedControl, {
+      props: {
+        id: 'text-format',
+        label: 'Text formatting',
+        options: multiOptions,
+        selectionMode: 'multiple',
+        value: set,
+        disabled: true,
+      },
+    });
+
+    const group = screen.getByRole('group');
+    expect(group.getAttribute('aria-disabled')).toBe('true');
+
+    await fireEvent.click(screen.getByRole('button', { name: 'Bold' }));
+    expect(set.has('bold')).toBe(false);
+  });
+});
+
+// ── Variants (mode-agnostic) ─────────────────────────────────────────────────
+
+describe('SegmentedControl — variants', () => {
+  // Test 20
+  test('size prop sets data-cinder-size on the outer element; default is "md"', () => {
+    const { container } = render(SegmentedControl, {
+      props: {
+        id: 'v',
+        label: 'View',
+        options,
+      },
+    });
+
+    const group = container.querySelector('[role="radiogroup"]');
+    expect(group?.getAttribute('data-cinder-size')).toBe('md');
+  });
+
+  test('size="sm" sets data-cinder-size="sm"', () => {
+    const { container } = render(SegmentedControl, {
+      props: {
+        id: 'v',
+        label: 'View',
+        options,
+        size: 'sm',
+      },
+    });
+
+    const group = container.querySelector('[role="radiogroup"]');
+    expect(group?.getAttribute('data-cinder-size')).toBe('sm');
+  });
+
+  test('size="lg" sets data-cinder-size="lg"', () => {
+    const { container } = render(SegmentedControl, {
+      props: {
+        id: 'v',
+        label: 'View',
+        options,
+        size: 'lg',
+      },
+    });
+
+    const group = container.querySelector('[role="radiogroup"]');
+    expect(group?.getAttribute('data-cinder-size')).toBe('lg');
+  });
+
+  // Test 20a
+  test('detached=false (default): data-cinder-detached attribute is absent (not "false")', () => {
+    const { container } = render(SegmentedControl, {
+      props: {
+        id: 'v',
+        label: 'View',
+        options,
+      },
+    });
+
+    const group = container.querySelector('[role="radiogroup"]');
+    expect(group?.getAttribute('data-cinder-detached')).toBeNull();
+  });
+
+  // Test 21
+  test('orientation="vertical" sets data-cinder-orientation="vertical" and aria-orientation in single mode', () => {
+    const { container } = render(SegmentedControl, {
+      props: {
+        id: 'v',
+        label: 'View',
+        options,
+        orientation: 'vertical',
+      },
+    });
+
+    const group = container.querySelector('[role="radiogroup"]');
+    expect(group?.getAttribute('data-cinder-orientation')).toBe('vertical');
+    expect(group?.getAttribute('aria-orientation')).toBe('vertical');
+  });
+
+  test('orientation="vertical" does NOT set aria-orientation in multiple mode', () => {
+    const set = new SvelteSet<string>();
+
+    const { container } = render(SegmentedControl, {
+      props: {
+        id: 'v',
+        label: 'View',
+        options,
+        selectionMode: 'multiple',
+        value: set,
+        orientation: 'vertical',
+      },
+    });
+
+    const group = container.querySelector('[role="group"]');
+    expect(group?.getAttribute('data-cinder-orientation')).toBe('vertical');
+    expect(group?.getAttribute('aria-orientation')).toBeNull();
+  });
+
+  // Test 21a
+  test('fullWidth=false (default): data-cinder-full-width attribute is absent', () => {
+    const { container } = render(SegmentedControl, {
+      props: {
+        id: 'v',
+        label: 'View',
+        options,
+      },
+    });
+
+    const group = container.querySelector('[role="radiogroup"]');
+    expect(group?.getAttribute('data-cinder-full-width')).toBeNull();
+  });
+
+  test('unselected single-mode option does not have data-cinder-selected attribute', () => {
+    const { container } = render(SegmentedControl, {
+      props: {
+        id: 'v',
+        label: 'View',
+        options,
+        value: 'source',
+      },
+    });
+
+    const renderedBtn = container.querySelector('#v-option-1');
+    expect(renderedBtn?.getAttribute('data-cinder-selected')).toBeNull();
+  });
+
+  test('unpressed multi-mode option does not have data-cinder-pressed attribute', () => {
+    const set = new SvelteSet<string>();
+    const { container } = render(SegmentedControl, {
+      props: {
+        id: 'v',
+        label: 'View',
+        options,
+        selectionMode: 'multiple',
+        value: set,
+      },
+    });
+
+    const firstBtn = container.querySelector('#v-option-0');
+    expect(firstBtn?.getAttribute('data-cinder-pressed')).toBeNull();
+  });
+
+  // Test 22
+  test('detached=true sets data-cinder-detached attribute', () => {
+    const { container } = render(SegmentedControl, {
+      props: {
+        id: 'v',
+        label: 'View',
+        options,
+        detached: true,
+      },
+    });
+
+    const group = container.querySelector('[role="radiogroup"]');
+    expect(group?.hasAttribute('data-cinder-detached')).toBe(true);
+  });
+
+  // Test 23
+  test('fullWidth=true sets data-cinder-full-width attribute', () => {
+    const { container } = render(SegmentedControl, {
+      props: {
+        id: 'v',
+        label: 'View',
+        options,
+        fullWidth: true,
+      },
+    });
+
+    const group = container.querySelector('[role="radiogroup"]');
+    expect(group?.hasAttribute('data-cinder-full-width')).toBe(true);
+  });
+
+  // Test 24
+  test('rest props pass through to the labelled group root', () => {
+    const { container } = render(SegmentedControl, {
+      props: {
+        id: 'v',
+        label: 'View',
+        options,
+        'data-test-id': 'my-control',
+        'aria-describedby': 'hint-text',
+      } as any,
+    });
+
+    const group = container.querySelector('[role="radiogroup"]');
+    expect(group?.getAttribute('data-test-id')).toBe('my-control');
+    expect(group?.getAttribute('aria-describedby')).toBe('hint-text');
+  });
+
+  // Test 25
+  test('custom class merges with .cinder-segmented-control', () => {
+    const { container } = render(SegmentedControl, {
+      props: {
+        id: 'v',
+        label: 'View',
+        options,
+        class: 'my-custom-class',
+      },
+    });
+
+    const group = container.querySelector('[role="radiogroup"]');
+    expect(group?.classList.contains('cinder-segmented-control')).toBe(true);
+    expect(group?.classList.contains('my-custom-class')).toBe(true);
+  });
+
+  // Test: data-cinder-selection-mode is always present
+  test('data-cinder-selection-mode reflects the selection mode', () => {
+    const { container: singleContainer } = render(SegmentedControl, {
+      props: { id: 'v1', label: 'View', options },
+    });
+    const singleGroup = singleContainer.querySelector('[role="radiogroup"]');
+    expect(singleGroup?.getAttribute('data-cinder-selection-mode')).toBe('single');
+
+    cleanup();
+
+    const set = new SvelteSet<string>();
+    const { container: multiContainer } = render(SegmentedControl, {
+      props: { id: 'v2', label: 'View', options, selectionMode: 'multiple', value: set },
+    });
+    const multiGroup = multiContainer.querySelector('[role="group"]');
+    expect(multiGroup?.getAttribute('data-cinder-selection-mode')).toBe('multiple');
   });
 });

--- a/packages/components/src/components/segmented-control.type-test.ts
+++ b/packages/components/src/components/segmented-control.type-test.ts
@@ -101,6 +101,17 @@ const _onkeydownRejected: SegmentedControlProps = {
   onkeydown: () => {},
 };
 
+// ── Invalid: disallowEmptySelection=true is not applicable in multiple mode ──
+
+// @ts-expect-error - disallowEmptySelection: true is not assignable in multiple mode (type is undefined)
+const _disallowEmptyInMultiple: SegmentedControlProps<'a' | 'b'> = {
+  id: 'test',
+  label: 'Test',
+  options,
+  selectionMode: 'multiple',
+  disallowEmptySelection: true,
+};
+
 void _singleValid;
 void _singleDefault;
 void _multipleValid;
@@ -110,3 +121,4 @@ void _labelledByRejected;
 void _ariaDisabledRejected;
 void _tabindexRejected;
 void _onkeydownRejected;
+void _disallowEmptyInMultiple;

--- a/packages/components/src/components/segmented-control.type-test.ts
+++ b/packages/components/src/components/segmented-control.type-test.ts
@@ -1,0 +1,112 @@
+/**
+ * Compile-time regression tests for SegmentedControlProps discriminated union.
+ * svelte-check processes this file; tsc does not (it excludes .svelte imports).
+ * These verify that:
+ *   - Single and multiple modes accept the right value types.
+ *   - A plain Set is rejected for multiple mode (SvelteSet required).
+ *   - Component-owned attributes are rejected from rest props.
+ */
+import type { SvelteSet } from 'svelte/reactivity';
+
+import type { SegmentedControlProps } from './segmented-control.svelte';
+
+const options = [
+  { value: 'a', label: 'A' },
+  { value: 'b', label: 'B' },
+] as const;
+
+// ── Valid: single mode with string value ─────────────────────────────────────
+
+const _singleValid: SegmentedControlProps<'a' | 'b'> = {
+  id: 'test',
+  label: 'Test',
+  options,
+  selectionMode: 'single',
+  value: 'a',
+};
+
+// ── Valid: single mode without selectionMode (default) ───────────────────────
+
+const _singleDefault: SegmentedControlProps<'a' | 'b'> = {
+  id: 'test',
+  label: 'Test',
+  options,
+  value: 'a',
+};
+
+// ── Valid: multiple mode with SvelteSet ──────────────────────────────────────
+
+declare const validSet: SvelteSet<'a' | 'b'>;
+
+const _multipleValid: SegmentedControlProps<'a' | 'b'> = {
+  id: 'test',
+  label: 'Test',
+  options,
+  selectionMode: 'multiple',
+  value: validSet,
+};
+
+// ── Invalid: multiple mode with plain Set (must be rejected) ─────────────────
+
+declare const plainSet: Set<'a' | 'b'>;
+
+const _multiplePlainSet: SegmentedControlProps<'a' | 'b'> = {
+  id: 'test',
+  label: 'Test',
+  options,
+  selectionMode: 'multiple',
+  // @ts-expect-error - plain Set is not assignable to SvelteSet
+  value: plainSet,
+};
+
+// ── Invalid: component-owned attributes must be rejected from rest props ─────
+
+const _roleRejected: SegmentedControlProps = {
+  id: 'test',
+  label: 'Test',
+  options,
+  // @ts-expect-error - role is component-owned and must be rejected
+  role: 'presentation',
+};
+
+const _labelledByRejected: SegmentedControlProps = {
+  id: 'test',
+  label: 'Test',
+  options,
+  // @ts-expect-error - aria-labelledby is component-owned and must be rejected
+  'aria-labelledby': 'other-id',
+};
+
+const _ariaDisabledRejected: SegmentedControlProps = {
+  id: 'test',
+  label: 'Test',
+  options,
+  // @ts-expect-error - aria-disabled is component-owned and must be rejected
+  'aria-disabled': 'true',
+};
+
+const _tabindexRejected: SegmentedControlProps = {
+  id: 'test',
+  label: 'Test',
+  options,
+  // @ts-expect-error - tabindex is component-owned and must be rejected
+  tabindex: 0,
+};
+
+const _onkeydownRejected: SegmentedControlProps = {
+  id: 'test',
+  label: 'Test',
+  options,
+  // @ts-expect-error - onkeydown is component-owned and must be rejected
+  onkeydown: () => {},
+};
+
+void _singleValid;
+void _singleDefault;
+void _multipleValid;
+void _multiplePlainSet;
+void _roleRejected;
+void _labelledByRejected;
+void _ariaDisabledRejected;
+void _tabindexRejected;
+void _onkeydownRejected;

--- a/packages/components/src/styles/components/segmented-control.css
+++ b/packages/components/src/styles/components/segmented-control.css
@@ -123,23 +123,26 @@
 
 /* ── Size variants ──────────────────────────────────────────────────────── */
 
+/* sm: 1.5rem = 24px @ 16px base — WCAG 2.5.8 minimum touch target */
 .cinder-segmented-control[data-cinder-size='sm'] .cinder-segmented-control-option {
-  min-block-size: 1rem;
-  padding-block: 0;
+  min-block-size: 1.5rem;
+  padding-block: var(--cinder-space-1);
   padding-inline: var(--cinder-space-1);
   font-size: var(--cinder-text-xs);
 }
 
+/* md: 2rem = 32px — comfortable middle ground */
 .cinder-segmented-control[data-cinder-size='md'] .cinder-segmented-control-option {
-  min-block-size: 1.25rem;
-  padding-block: 0;
+  min-block-size: 2rem;
+  padding-block: var(--cinder-space-1);
   padding-inline: var(--cinder-space-2);
   font-size: var(--cinder-text-xs);
 }
 
+/* lg: 2.75rem = 44px — recommended pointer/touch target per WCAG 2.5.5 */
 .cinder-segmented-control[data-cinder-size='lg'] .cinder-segmented-control-option {
-  min-block-size: 1.75rem;
-  padding-block: 0;
+  min-block-size: 2.75rem;
+  padding-block: var(--cinder-space-2);
   padding-inline: var(--cinder-space-3, 0.75rem);
   font-size: var(--cinder-text-sm);
 }

--- a/packages/components/src/styles/components/segmented-control.css
+++ b/packages/components/src/styles/components/segmented-control.css
@@ -105,9 +105,11 @@
 .cinder-segmented-control:not([data-cinder-detached])
   .cinder-segmented-control-option[data-cinder-pressed]:not(:first-child)::before,
 .cinder-segmented-control:not([data-cinder-detached])
-  .cinder-segmented-control-option:has(+ [data-cinder-selected])::before,
+  [data-cinder-selected]
+  + .cinder-segmented-control-option::before,
 .cinder-segmented-control:not([data-cinder-detached])
-  .cinder-segmented-control-option:has(+ [data-cinder-pressed])::before {
+  [data-cinder-pressed]
+  + .cinder-segmented-control-option::before {
   opacity: 0;
 }
 

--- a/packages/components/src/styles/components/segmented-control.css
+++ b/packages/components/src/styles/components/segmented-control.css
@@ -8,40 +8,79 @@
   gap: var(--cinder-space-2);
 }
 
+.cinder-segmented-control-container:has([data-cinder-full-width]) {
+  display: flex;
+  width: 100%;
+}
+
 .cinder-segmented-control-label {
   color: var(--cinder-text);
   font-size: var(--cinder-text-sm);
   font-weight: var(--cinder-font-medium);
 }
 
+/* ── Attached (default) ─────────────────────────────────────────────────── */
+
 .cinder-segmented-control {
   display: inline-flex;
   align-items: center;
-  gap: 1px;
+  gap: 0;
   padding: 1px;
   border: 1px solid var(--cinder-border-muted);
   border-radius: var(--cinder-radius-md);
   background: var(--cinder-surface-inset);
 }
 
-.cinder-segmented-control[data-cinder-disabled] {
+/* ── Full width ─────────────────────────────────────────────────────────── */
+
+.cinder-segmented-control[data-cinder-full-width] {
+  display: flex;
+  width: 100%;
+}
+
+.cinder-segmented-control[data-cinder-full-width] .cinder-segmented-control-option {
+  flex: 1;
+}
+
+/* ── Vertical orientation ───────────────────────────────────────────────── */
+
+.cinder-segmented-control[data-cinder-orientation='vertical'] {
+  flex-direction: column;
+}
+
+/* ── Detached ────────────────────────────────────────────────────────────── */
+
+.cinder-segmented-control[data-cinder-detached] {
+  gap: var(--cinder-space-1);
+  padding: 0;
+  border: none;
+  background: transparent;
+}
+
+.cinder-segmented-control[data-cinder-detached] .cinder-segmented-control-option {
+  border: 1px solid var(--cinder-border-muted);
+  border-radius: var(--cinder-radius-md);
+}
+
+/* ── Disabled group ─────────────────────────────────────────────────────── */
+
+.cinder-segmented-control[aria-disabled='true'] {
   opacity: 0.6;
   pointer-events: none;
 }
+
+/* ── Option base ────────────────────────────────────────────────────────── */
 
 .cinder-segmented-control-option {
   position: relative;
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  min-height: 1.25rem;
-  padding: 0 var(--cinder-space-2);
   border: 0;
   border-radius: calc(var(--cinder-radius-sm) - 1px);
   background: transparent;
   color: var(--cinder-text-muted);
   cursor: pointer;
-  font-size: var(--cinder-text-xs);
   font-weight: var(--cinder-font-medium);
   line-height: 1;
   transition:
@@ -50,10 +89,71 @@
     box-shadow var(--cinder-duration-fast) var(--cinder-ease-standard);
 }
 
-.cinder-segmented-control-option:hover:not(:disabled):not([data-cinder-selected]) {
+/* Separator between attached options */
+.cinder-segmented-control:not([data-cinder-detached])
+  .cinder-segmented-control-option:not(:first-child)::before {
+  content: '';
+  position: absolute;
+  inset-inline-start: 0;
+  block-size: 60%;
+  border-inline-start: 1px solid var(--cinder-border-muted);
+  transition: opacity var(--cinder-duration-fast) var(--cinder-ease-standard);
+}
+
+.cinder-segmented-control:not([data-cinder-detached])
+  .cinder-segmented-control-option[data-cinder-selected]:not(:first-child)::before,
+.cinder-segmented-control:not([data-cinder-detached])
+  .cinder-segmented-control-option[data-cinder-pressed]:not(:first-child)::before,
+.cinder-segmented-control:not([data-cinder-detached])
+  .cinder-segmented-control-option:has(+ [data-cinder-selected])::before,
+.cinder-segmented-control:not([data-cinder-detached])
+  .cinder-segmented-control-option:has(+ [data-cinder-pressed])::before {
+  opacity: 0;
+}
+
+.cinder-segmented-control[data-cinder-orientation='vertical']
+  .cinder-segmented-control-option:not(:first-child)::before {
+  inset-inline-start: unset;
+  inset-block-start: 0;
+  inline-size: 60%;
+  block-size: auto;
+  border-inline-start: none;
+  border-block-start: 1px solid var(--cinder-border-muted);
+}
+
+/* ── Size variants ──────────────────────────────────────────────────────── */
+
+.cinder-segmented-control[data-cinder-size='sm'] .cinder-segmented-control-option {
+  min-block-size: 1rem;
+  padding-block: 0;
+  padding-inline: var(--cinder-space-1);
+  font-size: var(--cinder-text-xs);
+}
+
+.cinder-segmented-control[data-cinder-size='md'] .cinder-segmented-control-option {
+  min-block-size: 1.25rem;
+  padding-block: 0;
+  padding-inline: var(--cinder-space-2);
+  font-size: var(--cinder-text-xs);
+}
+
+.cinder-segmented-control[data-cinder-size='lg'] .cinder-segmented-control-option {
+  min-block-size: 1.75rem;
+  padding-block: 0;
+  padding-inline: var(--cinder-space-3, 0.75rem);
+  font-size: var(--cinder-text-sm);
+}
+
+/* ── Hover ──────────────────────────────────────────────────────────────── */
+
+.cinder-segmented-control-option:hover:not(:disabled):not([data-cinder-selected]):not(
+    [data-cinder-pressed]
+  ) {
   background: color-mix(in oklch, var(--cinder-accent), transparent 90%);
   color: var(--cinder-text);
 }
+
+/* ── Focus ──────────────────────────────────────────────────────────────── */
 
 .cinder-segmented-control-option:focus-visible {
   outline: 2px solid transparent;
@@ -63,12 +163,24 @@
   z-index: 1;
 }
 
+/* ── Disabled option ────────────────────────────────────────────────────── */
+
 .cinder-segmented-control-option:disabled {
   cursor: not-allowed;
   opacity: 0.5;
 }
 
+/* ── Selected (single mode) ─────────────────────────────────────────────── */
+
 .cinder-segmented-control-option[data-cinder-selected] {
+  background: var(--cinder-accent);
+  color: var(--cinder-accent-contrast);
+  box-shadow: var(--cinder-shadow-sm, 0 1px 2px rgb(0 0 0 / 0.1));
+}
+
+/* ── Pressed (multiple mode) ────────────────────────────────────────────── */
+
+.cinder-segmented-control-option[data-cinder-pressed] {
   background: var(--cinder-accent);
   color: var(--cinder-accent-contrast);
   box-shadow: var(--cinder-shadow-sm, 0 1px 2px rgb(0 0 0 / 0.1));

--- a/packages/playground/src/examples/segmented-control/basic.example.svelte
+++ b/packages/playground/src/examples/segmented-control/basic.example.svelte
@@ -16,6 +16,12 @@
 </script>
 
 <div style="display: grid; gap: 0.75rem; justify-items: start;">
-  <SegmentedControl id="playground-view" bind:value label="Document view" {options} />
+  <SegmentedControl
+    id="playground-view"
+    selectionMode="single"
+    bind:value
+    label="Document view"
+    {options}
+  />
   <p style="margin: 0; color: var(--cinder-text-muted);">Current view: {value}</p>
 </div>

--- a/packages/playground/src/examples/segmented-control/multiple.example.svelte
+++ b/packages/playground/src/examples/segmented-control/multiple.example.svelte
@@ -1,0 +1,32 @@
+<script lang="ts" module>
+  export const title = 'Multi-select segmented control';
+  export const description =
+    'Multiple options can be toggled independently. Bind a SvelteSet to track selection.';
+</script>
+
+<script lang="ts">
+  import { SvelteSet } from 'svelte/reactivity';
+  import { SegmentedControl } from '../../../../components/src/index.ts';
+
+  const formats = new SvelteSet<string>();
+
+  const options = [
+    { value: 'bold', label: 'Bold' },
+    { value: 'italic', label: 'Italic' },
+    { value: 'underline', label: 'Underline' },
+    { value: 'strikethrough', label: 'Strike' },
+  ];
+
+  const selected = $derived([...formats].join(', ') || 'none');
+</script>
+
+<div style="display: grid; gap: 0.75rem; justify-items: start;">
+  <SegmentedControl
+    id="playground-format"
+    selectionMode="multiple"
+    bind:value={formats}
+    label="Text formatting"
+    {options}
+  />
+  <p style="margin: 0; color: var(--cinder-text-muted);">Active formats: {selected}</p>
+</div>

--- a/packages/playground/src/examples/segmented-control/multiple.example.svelte
+++ b/packages/playground/src/examples/segmented-control/multiple.example.svelte
@@ -8,7 +8,7 @@
   import { SvelteSet } from 'svelte/reactivity';
   import { SegmentedControl } from '../../../../components/src/index.ts';
 
-  const formats = new SvelteSet<string>();
+  let formats = new SvelteSet<string>();
 
   const options = [
     { value: 'bold', label: 'Bold' },


### PR DESCRIPTION
## Summary

- Rewrites `segmented-control` to support both single and multiple selection modes, replacing what would otherwise be a separate `toggle-button-group` component
- Single mode: `role="radiogroup"` + `role="radio"` buttons + roving tabindex (no behavior change for existing consumers)
- Multiple mode: `role="group"` + `<button>` + `aria-pressed` + natural Tab order  
- New props: `selectionMode` ('single'|'multiple'), `size` ('sm'|'md'|'lg'), `orientation`, `detached`, `fullWidth`, `disallowEmptySelection`
- CSS rewritten with `data-cinder-*` attribute selectors and logical properties throughout; WCAG 2.5.8 minimum touch targets enforced on all size variants
- All 3 consumer call sites updated with explicit `selectionMode="single"` and `size="sm"`; dead `:global(.segmented-control)` selectors fixed to `cinder-` prefix
- 36 tests covering single mode, multiple mode, variant props, and type-level fixtures
- `segmented-control.a11y.md` written covering single/multiple ARIA distinction and boundary vs `button-group`

## Review committee

Pre-reviewed by: typescript-expert, testing-expert, ux-designer, simplicity-engineer, prose-editor, Codex (gpt-5.4, xhigh reasoning)
- 4 rounds of review
- All must-fix items addressed:
  - `$bindable<any>()` → `$bindable<T | SvelteSet<T> | undefined>()`
  - Type-test: `disallowEmptySelection: true` rejected in multiple mode
  - Tests 14/15: DOM `aria-pressed` assertions prove reactivity, not just mutation
  - Test 17: `tabindex` assertion uses `.toBeNull()` (multi-mode buttons carry no explicit tabindex)
  - Test 7a: Space keydown does not call `preventDefault` (verified via `dispatchEvent` return value)
  - CSS `sm`/`md`/`lg` size variants raised to 1.5rem/2rem/2.75rem (WCAG 2.5.8 minimum)
  - Consumer `:global` height overrides removed; `size="sm"` passed via component API instead
  - `multiple.example.svelte`: `const formats` → `let formats` (Svelte 5 `bind:` requires `let`)

## Test plan

- `bun test packages/components/src/components/segmented-control.test.ts` — 36 tests pass
- `bun run typecheck` — 0 errors (type-level fixture validates discriminated union)
- Single mode: keyboard navigation, radio group semantics, `disallowEmptySelection` toggling
- Multiple mode: toggle behavior, `SvelteSet` reactivity, `aria-pressed` DOM updates
- Consumer call sites: markdown-editor mode toggle, review-editor diff view mode, diff-toolbar view mode

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Rewrites a shared UI control’s interaction and accessibility semantics (radio-group vs toggle buttons) and updates styling/keyboard behavior, which could introduce regressions in focus/selection handling across consumers.
> 
> **Overview**
> **Reworks `SegmentedControl` into a dual-mode selection component.** It now supports `selectionMode="single"` (radio-group semantics with roving tabindex + arrow-key navigation) and `selectionMode="multiple"` (toggle-button semantics using `aria-pressed` with natural Tab order), plus new variant props like `size`, `orientation`, `detached`, `fullWidth`, and optional `disallowEmptySelection` clearing.
> 
> **Updates consumers and styling to use the new API.** Existing call sites explicitly pass `selectionMode="single"` and `size="sm"` and remove local CSS height overrides in favor of the component’s size variants; the SegmentedControl CSS is rewritten around `data-cinder-*` attributes.
> 
> **Adds documentation and coverage.** Introduces `segmented-control.a11y.md`, expands runtime tests substantially (single/multiple mode behavior, edge cases, variants), adds a type-level fixture file to enforce the discriminated union and prevent unsupported prop combinations, and adds a new playground example for multi-select usage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 697712ab95149fcd4d4b71c1aacb6b1380677a92. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->