### PR TITLE
feat(surface): add transparent tone + SurfaceContext

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -392,6 +392,7 @@
     "src/_internal/collection.ts",
     "src/_internal/field-control.ts",
     "src/_internal/overlay.ts",
+    "src/_internal/surface-context.ts",
     "src/_internal/toast-context.ts",
     "src/_internal/tree-context.ts",
     "src/_internal/tree-registry.svelte.ts",

--- a/packages/components/src/_internal/surface-context.ts
+++ b/packages/components/src/_internal/surface-context.ts
@@ -1,0 +1,42 @@
+/**
+ * Internal surface context shape, factored out of `surface.svelte` so that
+ * plain `.ts` consumers can import the symbol key and types without going
+ * through the `.svelte` module path.
+ *
+ * `surface.svelte` re-exports `SurfaceTone` so the public type still surfaces
+ * through the existing `Surface` re-export in the package barrel.
+ *
+ * The context value intentionally contains only `tone` for v1. Additional
+ * fields (density, emphasis level, theme override) require a separate API
+ * review before being added.
+ */
+
+import { getContext } from 'svelte';
+
+/** The visual affordance of a surface — describes what the surface looks like. */
+export type SurfaceTone = 'default' | 'raised' | 'inset' | 'transparent';
+
+/**
+ * Context published by `<Surface>` for descendant components. All members are
+ * getter properties on the object so reads stay reactive — when a consumer
+ * reads `context.tone` inside a `$derived`, the read flows through the getter.
+ * Destructuring breaks reactivity; property reads preserve it.
+ *
+ * The v1 context value intentionally contains only `tone`.
+ */
+export type SurfaceContextValue = {
+  /** The tone of the nearest enclosing `<Surface>`. */
+  readonly tone: SurfaceTone;
+};
+
+/** Symbol key for the surface Svelte context. Not exported from package root. */
+export const SURFACE_CONTEXT_KEY: unique symbol = Symbol('cinder.surface');
+
+/**
+ * Read the nearest enclosing `<Surface>` context. Returns `undefined` when no
+ * `<Surface>` ancestor exists. All readers MUST handle the `undefined` case;
+ * cinder makes no implicit "default" assumption when there is no parent.
+ */
+export function getSurfaceContext(): SurfaceContextValue | undefined {
+  return getContext<SurfaceContextValue | undefined>(SURFACE_CONTEXT_KEY);
+}

--- a/packages/components/src/_internal/surface-context.ts
+++ b/packages/components/src/_internal/surface-context.ts
@@ -30,7 +30,7 @@ export type SurfaceContextValue = {
 };
 
 /** Symbol key for the surface Svelte context. Not exported from package root. */
-export const SURFACE_CONTEXT_KEY: unique symbol = Symbol('cinder.surface');
+export const SURFACE_CONTEXT_KEY = Symbol('cinder.surface');
 
 /**
  * Read the nearest enclosing `<Surface>` context. Returns `undefined` when no

--- a/packages/components/src/_internal/surface-context.ts
+++ b/packages/components/src/_internal/surface-context.ts
@@ -36,7 +36,16 @@ export const SURFACE_CONTEXT_KEY: unique symbol = Symbol('cinder.surface');
  * Read the nearest enclosing `<Surface>` context. Returns `undefined` when no
  * `<Surface>` ancestor exists. All readers MUST handle the `undefined` case;
  * cinder makes no implicit "default" assumption when there is no parent.
+ *
+ * The try-catch handles the same SSR/test-environment edge case documented in
+ * `form-field-context.ts`: compiling with `generate:'server'` while resolving
+ * 'svelte' to the client build causes `getContext` to throw
+ * `lifecycle_outside_component`. Returning `undefined` is the correct fallback.
  */
 export function getSurfaceContext(): SurfaceContextValue | undefined {
-  return getContext<SurfaceContextValue | undefined>(SURFACE_CONTEXT_KEY);
+  try {
+    return getContext<SurfaceContextValue | undefined>(SURFACE_CONTEXT_KEY);
+  } catch {
+    return undefined;
+  }
 }

--- a/packages/components/src/components/surface.svelte
+++ b/packages/components/src/components/surface.svelte
@@ -2,7 +2,8 @@
   import type { Snippet } from 'svelte';
   import type { HTMLAttributes } from 'svelte/elements';
 
-  export type SurfaceTone = 'default' | 'raised' | 'inset';
+  import type { SurfaceTone } from '../_internal/surface-context.ts';
+  export type { SurfaceTone };
 
   export type SurfaceProps = Omit<HTMLAttributes<HTMLDivElement>, 'class'> & {
     tone?: SurfaceTone;
@@ -13,9 +14,19 @@
 </script>
 
 <script lang="ts">
+  import { setContext } from 'svelte';
+
+  import { SURFACE_CONTEXT_KEY, type SurfaceContextValue } from '../_internal/surface-context.ts';
   import { classNames } from '../utilities/class-names.ts';
 
   let { tone = 'default', class: className, children, ...rest }: SurfaceProps = $props();
+
+  const context: SurfaceContextValue = {
+    get tone() {
+      return tone;
+    },
+  };
+  setContext(SURFACE_CONTEXT_KEY, context);
 </script>
 
 <div class={classNames('cinder-surface', className)} data-cinder-tone={tone} {...rest}>

--- a/packages/components/src/components/surface.test.ts
+++ b/packages/components/src/components/surface.test.ts
@@ -13,6 +13,9 @@ const { default: SurfaceContextProbe } =
   await import('../test/fixtures/surface-context-probe.svelte');
 const { default: SurfaceToneMutator } =
   await import('../test/fixtures/surface-tone-mutator.svelte');
+const { default: SurfaceWithProbe } = await import('../test/fixtures/surface-with-probe.svelte');
+const { default: NestedSurfacesFixture } =
+  await import('../test/fixtures/nested-surfaces-fixture.svelte');
 
 const emptySnippet = createRawSnippet(() => ({
   render: () => `<span></span>`,
@@ -64,34 +67,33 @@ describe('Surface rendering', () => {
     expect(root?.getAttribute('data-bar')).toBe('baz');
     expect(root?.getAttribute('aria-label')).toBe('region');
   });
+
+  test('children snippet renders inside the surface', () => {
+    const childSnippet = createRawSnippet(() => ({
+      render: () => `<span data-testid="child-content">hello</span>`,
+      setup: () => {},
+    }));
+    const { container } = render(Surface, {
+      props: { children: childSnippet },
+    });
+    expect(container.querySelector('.cinder-surface [data-testid="child-content"]')).not.toBeNull();
+  });
 });
 
 describe('SurfaceContext', () => {
   test.each(['default', 'raised', 'inset', 'transparent'] as SurfaceTone[])(
-    'context is readable by descendants for tone "%s"',
+    'context is readable by a real descendant component for tone "%s"',
     (tone) => {
-      const probeSnippet = createRawSnippet(() => ({
-        render: () => `<div data-testid="probe-tone" data-tone="${tone}"></div>`,
-        setup: () => {},
-      }));
-
-      const { container } = render(Surface, {
-        props: {
-          tone,
-          children: probeSnippet,
-        },
+      const { container } = render(SurfaceWithProbe, {
+        props: { tone },
       });
-
-      // Verify the surface itself has the right tone
-      expect(container.querySelector('.cinder-surface')?.getAttribute('data-cinder-tone')).toBe(
-        tone,
-      );
+      const probe = container.querySelector('[data-testid="probe-tone"]');
+      expect(probe?.getAttribute('data-tone')).toBe(tone);
     },
   );
 
-  test('context is readable by SurfaceContextProbe descendant', async () => {
+  test('no-parent reader returns none sentinel', () => {
     const { container } = render(SurfaceContextProbe, {});
-    // Outside any surface — expects 'none' sentinel
     const probe = container.querySelector('[data-testid="probe-tone"]');
     expect(probe?.getAttribute('data-tone')).toBe('none');
   });
@@ -122,37 +124,16 @@ describe('SurfaceContext', () => {
     });
   });
 
-  test('nested surfaces override context for their subtree', async () => {
-    // Render outer surface with raised tone containing inner surface with transparent tone,
-    // each with a context probe. We verify the inner surface has its own data attribute.
-    const { container } = render(Surface, {
-      props: {
-        tone: 'raised',
-        children: createRawSnippet(() => ({
-          render: () =>
-            `<div class="outer-probe" data-outer-tone="raised">` +
-            `<div class="cinder-surface" data-cinder-tone="transparent">` +
-            `<div class="inner-probe" data-inner-tone="transparent"></div>` +
-            `</div>` +
-            `</div>`,
-          setup: () => {},
-        })),
-      },
-    });
+  test('nested surfaces override context for their subtree', () => {
+    const { container } = render(NestedSurfacesFixture, {});
 
-    // Outer surface has raised tone
-    const outerSurface = container.querySelector('.cinder-surface');
-    expect(outerSurface?.getAttribute('data-cinder-tone')).toBe('raised');
+    // Outer probe (between outer and inner Surface) reads the outer tone
+    const outerProbe = container.querySelector('[data-testid="outer-probe"]');
+    expect(outerProbe?.getAttribute('data-tone')).toBe('raised');
 
-    // Inner surface (manually rendered via snippet) shows transparent
-    const innerSurface = container.querySelector('.cinder-surface .cinder-surface');
-    expect(innerSurface?.getAttribute('data-cinder-tone')).toBe('transparent');
-  });
-
-  test('no-parent reader returns none sentinel', () => {
-    const { container } = render(SurfaceContextProbe, {});
-    const probe = container.querySelector('[data-testid="probe-tone"]');
-    expect(probe?.getAttribute('data-tone')).toBe('none');
+    // Inner probe (inside inner Surface) reads the inner tone
+    const innerProbe = container.querySelector('[data-testid="inner-probe"]');
+    expect(innerProbe?.getAttribute('data-tone')).toBe('transparent');
   });
 });
 

--- a/packages/components/src/components/surface.test.ts
+++ b/packages/components/src/components/surface.test.ts
@@ -87,7 +87,7 @@ describe('SurfaceContext', () => {
       const { container } = render(SurfaceWithProbe, {
         props: { tone },
       });
-      const probe = container.querySelector('[data-testid="probe-tone"]');
+      const probe = container.querySelector('.cinder-surface [data-testid="probe-tone"]');
       expect(probe?.getAttribute('data-tone')).toBe(tone);
     },
   );

--- a/packages/components/src/components/surface.test.ts
+++ b/packages/components/src/components/surface.test.ts
@@ -146,9 +146,17 @@ describe('Surface CSS contract', () => {
   test('surface.css contains transparent tone rule with required declarations', async () => {
     const css = await Bun.file(new URL('../styles/components/surface.css', import.meta.url)).text();
 
+    // Base rule declares the border; transparent tone inherits it without re-declaring.
+    expect(css).toContain('border: 1px solid var(--cinder-border)');
     expect(css).toContain("[data-cinder-tone='transparent']");
     expect(css).toContain('background: transparent');
-    expect(css).toContain('border: 1px solid var(--cinder-border)');
     expect(css).toContain('box-shadow: none');
+  });
+
+  test('transparent tone rule does not re-declare border', async () => {
+    const css = await Bun.file(new URL('../styles/components/surface.css', import.meta.url)).text();
+
+    const transparentBlock = css.match(/\[data-cinder-tone='transparent'\]\s*\{[^}]*\}/)?.[0] ?? '';
+    expect(transparentBlock).not.toContain('border');
   });
 });

--- a/packages/components/src/components/surface.test.ts
+++ b/packages/components/src/components/surface.test.ts
@@ -113,7 +113,9 @@ describe('SurfaceContext', () => {
     await waitFor(() => expect(handle).not.toBeNull());
 
     const surface = container.querySelector('.cinder-surface');
+    const probe = container.querySelector('[data-testid="mutator-probe"]');
     expect(surface?.getAttribute('data-cinder-tone')).toBe('default');
+    expect(probe?.getAttribute('data-tone')).toBe('default');
 
     handle!.setTone('inset');
 
@@ -121,6 +123,9 @@ describe('SurfaceContext', () => {
       expect(container.querySelector('.cinder-surface')?.getAttribute('data-cinder-tone')).toBe(
         'inset',
       );
+      expect(
+        container.querySelector('[data-testid="mutator-probe"]')?.getAttribute('data-tone'),
+      ).toBe('inset');
     });
   });
 

--- a/packages/components/src/components/surface.test.ts
+++ b/packages/components/src/components/surface.test.ts
@@ -1,0 +1,168 @@
+/// <reference lib="dom" />
+import { describe, expect, test } from 'bun:test';
+import { createRawSnippet } from 'svelte';
+
+import type { SurfaceTone } from '../_internal/surface-context.ts';
+import { setupHappyDom } from '../test/happy-dom.ts';
+
+setupHappyDom();
+
+const { render, waitFor } = await import('@testing-library/svelte');
+const { default: Surface } = await import('./surface.svelte');
+const { default: SurfaceContextProbe } =
+  await import('../test/fixtures/surface-context-probe.svelte');
+const { default: SurfaceToneMutator } =
+  await import('../test/fixtures/surface-tone-mutator.svelte');
+
+const emptySnippet = createRawSnippet(() => ({
+  render: () => `<span></span>`,
+  setup: () => {},
+}));
+
+describe('Surface rendering', () => {
+  test('default tone renders correct data attribute', () => {
+    const { container } = render(Surface, {
+      props: { children: emptySnippet },
+    });
+    const root = container.querySelector('.cinder-surface');
+    expect(root).not.toBeNull();
+    expect(root?.getAttribute('data-cinder-tone')).toBe('default');
+  });
+
+  test.each(['default', 'raised', 'inset', 'transparent'] as SurfaceTone[])(
+    'tone "%s" renders correct data-cinder-tone attribute',
+    (tone) => {
+      const { container } = render(Surface, {
+        props: { tone, children: emptySnippet },
+      });
+      expect(container.querySelector('.cinder-surface')?.getAttribute('data-cinder-tone')).toBe(
+        tone,
+      );
+    },
+  );
+
+  test('custom class merges with cinder-surface', () => {
+    const { container } = render(Surface, {
+      props: { class: 'my-extra', children: emptySnippet },
+    });
+    const root = container.querySelector('.cinder-surface');
+    expect(root?.classList.contains('cinder-surface')).toBe(true);
+    expect(root?.classList.contains('my-extra')).toBe(true);
+  });
+
+  test('rest props (id, data-*, aria-label) forward to root element', () => {
+    const { container } = render(Surface, {
+      props: {
+        id: 'foo',
+        'data-bar': 'baz',
+        'aria-label': 'region',
+        children: emptySnippet,
+      },
+    });
+    const root = container.querySelector('.cinder-surface');
+    expect(root?.getAttribute('id')).toBe('foo');
+    expect(root?.getAttribute('data-bar')).toBe('baz');
+    expect(root?.getAttribute('aria-label')).toBe('region');
+  });
+});
+
+describe('SurfaceContext', () => {
+  test.each(['default', 'raised', 'inset', 'transparent'] as SurfaceTone[])(
+    'context is readable by descendants for tone "%s"',
+    (tone) => {
+      const probeSnippet = createRawSnippet(() => ({
+        render: () => `<div data-testid="probe-tone" data-tone="${tone}"></div>`,
+        setup: () => {},
+      }));
+
+      const { container } = render(Surface, {
+        props: {
+          tone,
+          children: probeSnippet,
+        },
+      });
+
+      // Verify the surface itself has the right tone
+      expect(container.querySelector('.cinder-surface')?.getAttribute('data-cinder-tone')).toBe(
+        tone,
+      );
+    },
+  );
+
+  test('context is readable by SurfaceContextProbe descendant', async () => {
+    const { container } = render(SurfaceContextProbe, {});
+    // Outside any surface — expects 'none' sentinel
+    const probe = container.querySelector('[data-testid="probe-tone"]');
+    expect(probe?.getAttribute('data-tone')).toBe('none');
+  });
+
+  test('context updates reactively when tone changes', async () => {
+    let handle: { setTone: (next: SurfaceTone) => void } | null = null;
+
+    const { container } = render(SurfaceToneMutator, {
+      props: {
+        initial: 'default',
+        onReady: (h: { setTone: (next: SurfaceTone) => void }) => {
+          handle = h;
+        },
+      },
+    });
+
+    await waitFor(() => expect(handle).not.toBeNull());
+
+    const surface = container.querySelector('.cinder-surface');
+    expect(surface?.getAttribute('data-cinder-tone')).toBe('default');
+
+    handle!.setTone('inset');
+
+    await waitFor(() => {
+      expect(container.querySelector('.cinder-surface')?.getAttribute('data-cinder-tone')).toBe(
+        'inset',
+      );
+    });
+  });
+
+  test('nested surfaces override context for their subtree', async () => {
+    // Render outer surface with raised tone containing inner surface with transparent tone,
+    // each with a context probe. We verify the inner surface has its own data attribute.
+    const { container } = render(Surface, {
+      props: {
+        tone: 'raised',
+        children: createRawSnippet(() => ({
+          render: () =>
+            `<div class="outer-probe" data-outer-tone="raised">` +
+            `<div class="cinder-surface" data-cinder-tone="transparent">` +
+            `<div class="inner-probe" data-inner-tone="transparent"></div>` +
+            `</div>` +
+            `</div>`,
+          setup: () => {},
+        })),
+      },
+    });
+
+    // Outer surface has raised tone
+    const outerSurface = container.querySelector('.cinder-surface');
+    expect(outerSurface?.getAttribute('data-cinder-tone')).toBe('raised');
+
+    // Inner surface (manually rendered via snippet) shows transparent
+    const innerSurface = container.querySelector('.cinder-surface .cinder-surface');
+    expect(innerSurface?.getAttribute('data-cinder-tone')).toBe('transparent');
+  });
+
+  test('no-parent reader returns none sentinel', () => {
+    const { container } = render(SurfaceContextProbe, {});
+    const probe = container.querySelector('[data-testid="probe-tone"]');
+    expect(probe?.getAttribute('data-tone')).toBe('none');
+  });
+});
+
+describe('Surface CSS contract', () => {
+  test('surface.css contains transparent tone rule with required declarations', async () => {
+    const css = await Bun.file(new URL('../styles/components/surface.css', import.meta.url)).text();
+
+    expect(css).toContain("[data-cinder-tone='transparent']");
+    expect(css).toContain('background: transparent');
+    expect(css).toContain('border: 1px solid var(--cinder-border)');
+    expect(css).toContain('box-shadow: none');
+  });
+});

--- a/packages/components/src/styles/components/surface.css
+++ b/packages/components/src/styles/components/surface.css
@@ -12,3 +12,9 @@
 .cinder-surface[data-cinder-tone='inset'] {
   background: var(--cinder-surface-inset);
 }
+
+.cinder-surface[data-cinder-tone='transparent'] {
+  background: transparent;
+  border: 1px solid var(--cinder-border);
+  box-shadow: none;
+}

--- a/packages/components/src/styles/components/surface.css
+++ b/packages/components/src/styles/components/surface.css
@@ -15,6 +15,5 @@
 
 .cinder-surface[data-cinder-tone='transparent'] {
   background: transparent;
-  border: 1px solid var(--cinder-border);
   box-shadow: none;
 }

--- a/packages/components/src/test/fixtures/nested-surfaces-fixture.svelte
+++ b/packages/components/src/test/fixtures/nested-surfaces-fixture.svelte
@@ -1,0 +1,18 @@
+<script lang="ts">
+  import Surface from '../../components/surface.svelte';
+  import SurfaceContextProbe from './surface-context-probe.svelte';
+</script>
+
+<!--
+  Renders outer Surface (raised) containing:
+  - an outer SurfaceContextProbe (should read 'raised')
+  - an inner Surface (transparent) containing:
+    - an inner SurfaceContextProbe (should read 'transparent')
+  Tests that nested Surface overrides the parent context for its own subtree.
+-->
+<Surface tone="raised">
+  <SurfaceContextProbe testid="outer-probe" />
+  <Surface tone="transparent">
+    <SurfaceContextProbe testid="inner-probe" />
+  </Surface>
+</Surface>

--- a/packages/components/src/test/fixtures/surface-context-probe.svelte
+++ b/packages/components/src/test/fixtures/surface-context-probe.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
   import { getSurfaceContext } from '../../_internal/surface-context.ts';
 
+  let { testid = 'probe-tone' }: { testid?: string } = $props();
+
   const context = getSurfaceContext();
 </script>
 
@@ -9,4 +11,4 @@
   current tone onto a data-* attribute so tests can query it deterministically.
   Renders 'none' when no enclosing <Surface> exists (getSurfaceContext returns undefined).
 -->
-<div data-testid="probe-tone" data-tone={context?.tone ?? 'none'}></div>
+<div data-testid={testid} data-tone={context?.tone ?? 'none'}></div>

--- a/packages/components/src/test/fixtures/surface-context-probe.svelte
+++ b/packages/components/src/test/fixtures/surface-context-probe.svelte
@@ -1,0 +1,12 @@
+<script lang="ts">
+  import { getSurfaceContext } from '../../_internal/surface-context.ts';
+
+  const context = getSurfaceContext();
+</script>
+
+<!--
+  Reads the SurfaceContext published by a parent <Surface> and writes the
+  current tone onto a data-* attribute so tests can query it deterministically.
+  Renders 'none' when no enclosing <Surface> exists (getSurfaceContext returns undefined).
+-->
+<div data-testid="probe-tone" data-tone={context?.tone ?? 'none'}></div>

--- a/packages/components/src/test/fixtures/surface-tone-mutator.svelte
+++ b/packages/components/src/test/fixtures/surface-tone-mutator.svelte
@@ -6,6 +6,7 @@
   export type SurfaceToneMutatorProps = {
     initial: SurfaceTone;
     onReady: (handle: { setTone: (next: SurfaceTone) => void }) => void;
+    testid?: string;
     children?: Snippet;
   };
 </script>
@@ -14,8 +15,9 @@
   import { onMount } from 'svelte';
 
   import Surface from '../../components/surface.svelte';
+  import SurfaceContextProbe from './surface-context-probe.svelte';
 
-  let { initial, onReady, children }: SurfaceToneMutatorProps = $props();
+  let { initial, onReady, testid = 'mutator-probe', children }: SurfaceToneMutatorProps = $props();
 
   let tone = $state<SurfaceTone>(initial);
 
@@ -29,5 +31,6 @@
 </script>
 
 <Surface {tone}>
+  <SurfaceContextProbe {testid} />
   {@render children?.()}
 </Surface>

--- a/packages/components/src/test/fixtures/surface-tone-mutator.svelte
+++ b/packages/components/src/test/fixtures/surface-tone-mutator.svelte
@@ -1,0 +1,33 @@
+<script lang="ts" module>
+  import type { Snippet } from 'svelte';
+
+  import type { SurfaceTone } from '../../_internal/surface-context.ts';
+
+  export type SurfaceToneMutatorProps = {
+    initial: SurfaceTone;
+    onReady: (handle: { setTone: (next: SurfaceTone) => void }) => void;
+    children?: Snippet;
+  };
+</script>
+
+<script lang="ts">
+  import { onMount } from 'svelte';
+
+  import Surface from '../../components/surface.svelte';
+
+  let { initial, onReady, children }: SurfaceToneMutatorProps = $props();
+
+  let tone = $state<SurfaceTone>(initial);
+
+  onMount(() => {
+    onReady({
+      setTone: (next: SurfaceTone) => {
+        tone = next;
+      },
+    });
+  });
+</script>
+
+<Surface {tone}>
+  {@render children?.()}
+</Surface>

--- a/packages/components/src/test/fixtures/surface-with-probe.svelte
+++ b/packages/components/src/test/fixtures/surface-with-probe.svelte
@@ -1,0 +1,18 @@
+<script lang="ts" module>
+  import type { SurfaceTone } from '../../_internal/surface-context.ts';
+
+  export type SurfaceWithProbeProps = {
+    tone: SurfaceTone;
+  };
+</script>
+
+<script lang="ts">
+  import Surface from '../../components/surface.svelte';
+  import SurfaceContextProbe from './surface-context-probe.svelte';
+
+  let { tone }: SurfaceWithProbeProps = $props();
+</script>
+
+<Surface {tone}>
+  <SurfaceContextProbe />
+</Surface>


### PR DESCRIPTION
## Summary

- Extends `SurfaceTone` to include `'transparent'` (transparent bg, border kept, no shadow)
- Extracts `SurfaceTone` + `SurfaceContextValue` types into `_internal/surface-context.ts`
- Adds `setContext` call in `surface.svelte` using getter pattern for live reactive context
- Adds `getSurfaceContext()` helper with SSR try-catch guard (matches `getFormFieldContext` precedent)
- Ships `surface-context.ts` in `package.json` files array alongside `toast-context` precedent
- 16 tests: all four tones, class merging, rest-prop forwarding, real context reads via `SurfaceWithProbe`, reactive tone update, real nested-surface context override via `NestedSurfacesFixture`, no-parent sentinel, children rendering, CSS contract assertions

## API

```ts
// New transparent tone
type SurfaceTone = 'default' | 'raised' | 'inset' | 'transparent';

// Context reader for descendants — returns undefined when no Surface ancestor exists
import { getSurfaceContext } from 'cinder/_internal/surface-context';
const context = getSurfaceContext(); // { tone: SurfaceTone } | undefined
```

The `SURFACE_CONTEXT_KEY` symbol and `SurfaceContextValue` type live in `_internal/` — not a public subpath in the `exports` map, consistent with `toast-context` and `tree-context` precedent.

## Card audit

`card.svelte` was audited and intentionally not touched. It duplicates surface-style chrome with deliberate differences (`--cinder-radius-lg` vs `--cinder-radius-md`, `--cinder-border-muted` vs `--cinder-border`). The divergence is noted in the PR description for a follow-up task.

## Review committee

Pre-reviewed by: typescript-expert, testing-expert, simplicity-engineer, junior-engineer, Codex (gpt-5.4, xhigh reasoning)
- 2 rounds of review
- All must-fix items addressed (SSR guard, real context fixture tests)

> [!WARNING]
> Codex (the adversarial second-opinion reviewer) was unavailable for round 2 (empty output on session resume). Codex approved the base diff in round 1. Round 2 changes were non-structural (selector tightening, SSR guard already added). See `tmp/committee-state.md` for detail.

## Test plan

- `bun test packages/components/src/components/surface.test.ts` — 16 tests pass
- `bun run typecheck` — 0 errors
- `bun run lint` — 0 errors (pre-existing warnings unchanged)
- All 1425 tests pass across workspace

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new `SurfaceTone` value and adds Svelte context propagation for `<Surface>`, which could subtly affect styling and descendant component behavior; changes are covered by new unit tests and are scoped to the Surface component.
> 
> **Overview**
> Adds a new `SurfaceTone` value, `transparent`, with matching CSS (`background: transparent`, `box-shadow: none`) and updates `<Surface>` to accept and render it via `data-cinder-tone`.
> 
> Introduces an internal `SurfaceContext` (`src/_internal/surface-context.ts`) with `SURFACE_CONTEXT_KEY` and `getSurfaceContext()` (SSR-safe), and updates `surface.svelte` to `setContext` using getter-based reactivity; includes new tests and fixtures validating rendering, context reads/updates, nested override behavior, and the CSS contract. Also ships `src/_internal/surface-context.ts` in the package `files` list.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bad3c78dfb808dd75871875c40e6eae25ebcbbdf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->