### PR TITLE
Fix color swatch picker review feedback

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -69,6 +69,10 @@
       "svelte": "./src/components/code-block.svelte",
       "types": "./dist/components/code-block.svelte.d.ts"
     },
+    "./color-swatch-picker": {
+      "svelte": "./src/components/color-swatch-picker.svelte",
+      "types": "./dist/components/color-swatch-picker.svelte.d.ts"
+    },
     "./combobox": {
       "svelte": "./src/components/combobox.svelte",
       "types": "./dist/components/combobox.svelte.d.ts"

--- a/packages/components/src/components/color-swatch-picker.a11y.md
+++ b/packages/components/src/components/color-swatch-picker.a11y.md
@@ -1,0 +1,81 @@
+# Color Swatch Picker — Accessibility Rationale
+
+## Listbox + option semantics
+
+The component renders `<ul role="listbox">` with `<li role="option">` children. This maps
+directly to the WAI-ARIA Listbox pattern and is the correct semantic for "pick one item from
+a fixed set." The `label` prop (required) provides the listbox's accessible name via
+`aria-label` so screen readers announce the control's purpose before reading options.
+
+Each option carries:
+
+- `aria-selected` (`true` on the selected item, `false` on others).
+- `aria-label` computed as `name ? \`${name}, ${color}\` : color` — both the human label and
+  the hex code are read aloud so users know both what the swatch represents and its value.
+- `aria-disabled="true"` on disabled swatches; they remain in the DOM so users browsing in
+  virtual cursor mode can still perceive that a swatch exists and is unavailable.
+
+## Roving tabindex
+
+Only the focused option has `tabindex="0"`; all others are `tabindex="-1"`. The entire
+listbox participates in the page's tab order as a single stop. Arrow keys move focus within
+the control; Tab exits it. This follows the WAI-ARIA APG composite widget pattern and is
+the same model used by `segmented-control.svelte`.
+
+## Explicit selection (not selection-follows-focus)
+
+Users roam through options with arrow keys without inadvertently changing the selection;
+Enter or Space commits the focused swatch. This matches WAI-ARIA APG §"Listbox with
+explicit selection" and avoids the "I arrowed past and lost my selection" footgun that
+auto-selection creates.
+
+## Grid layout navigation
+
+Grid layout enables both ArrowLeft/Right and ArrowUp/Down — all four arrows move by ±1 in
+DOM order (one-dimensional wrapping). True column-aware navigation (ArrowDown goes to the
+item visually below) is not implemented in v1 because it requires CSS Grid introspection or
+bounding-box math at keydown time, adding complexity that depends on viewport width. The
+plan documents this decision and tracks a potential v2.
+
+## Stack layout navigation
+
+Stack layout enables only ArrowUp/Down. ArrowLeft/Right are no-ops in this layout.
+
+## Disabled handling
+
+**Per-option disabled:** arrow-key roving skips the option. Click and Enter/Space are
+ignored. The swatch is still focusable via Tab in edge cases (e.g., when all other options
+are also disabled) so the control always has at least one tab stop.
+
+**Whole-component disabled:** `aria-disabled="true"` on the `<ul>`. The currently-selected
+(or first) option retains `tabindex="0"` so users can discover the control exists. All
+activation (arrow keys, Home, End, Enter, Space, click) is silently ignored. Tab is never
+intercepted so users can leave the control.
+
+## Contrast computation
+
+The selected-swatch indicator color (`black` or `white`) is derived from the swatch's WCAG
+relative luminance, crossing over at L ≈ 0.179 (not the naïve 0.5 midpoint). Alpha is
+ignored — the indicator is chosen against the swatch's intended solid color, not its
+composite with whatever surface sits behind it, matching Hero UI's behavior and staying
+stable across dark/light themes.
+
+## Alpha checkerboard
+
+Alpha-bearing swatches (detected by parsing the `color` string's alpha channel) display a
+CSS `conic-gradient`/`linear-gradient` checkerboard behind the color so transparency is
+visible without a DOM dependency. Alpha detection is regex-based — no `<canvas>` — so it
+works in SSR and avoids a per-swatch off-screen canvas cost.
+
+**Supported alpha detection:** `#rgba`, `#rrggbbaa`, `rgba(...)`, `hsla(...)`.
+**Not supported:** modern space-separated syntax, `color()`, `lab()`, `oklch()`, named
+colors. These render via CSS but receive no checkerboard and a best-effort `'white'`
+indicator that may be invisible on near-white unsupported colors.
+
+## Reduced motion
+
+Hover and focus-visible scale transforms are gated behind
+`@media (prefers-reduced-motion: no-preference)`. Users who have opted out of animations
+see instant, non-animated state changes. There is no JS-side branching for reduced motion —
+the contract lives entirely in the CSS media query, reviewed in the PR diff and visually
+verified manually. jsdom does not honor media queries so automated tests do not cover this.

--- a/packages/components/src/components/color-swatch-picker.a11y.md
+++ b/packages/components/src/components/color-swatch-picker.a11y.md
@@ -63,7 +63,7 @@ stable across dark/light themes.
 ## Alpha checkerboard
 
 Alpha-bearing swatches (detected by parsing the `color` string's alpha channel) display a
-CSS `conic-gradient`/`linear-gradient` checkerboard behind the color so transparency is
+CSS `linear-gradient` checkerboard behind the color so transparency is
 visible without a DOM dependency. Alpha detection is regex-based — no `<canvas>` — so it
 works in SSR and avoids a per-swatch off-screen canvas cost.
 

--- a/packages/components/src/components/color-swatch-picker.svelte
+++ b/packages/components/src/components/color-swatch-picker.svelte
@@ -1,0 +1,230 @@
+<script lang="ts" module>
+  import type { Snippet } from 'svelte';
+
+  /**
+   * A single color entry in a ColorSwatchPicker palette.
+   *
+   * Supported `color` formats for alpha detection and contrast computation:
+   * `#rgb`, `#rgba`, `#rrggbb`, `#rrggbbaa`, `rgb(r, g, b)`, `rgba(r, g, b, a)`,
+   * `hsl(h, s%, l%)`, `hsla(h, s%, l%, a)` (legacy comma syntax only).
+   * Other CSS color formats render via CSS but receive no checkerboard and a
+   * best-effort `'white'` contrast indicator that may be invisible on near-white colors.
+   */
+  export type ColorSwatch = {
+    /** CSS color string rendered as the swatch background. */
+    color: string;
+    /** Optional human label. When omitted, the `color` string is the accessible name. */
+    name?: string;
+    /** Disables this individual swatch. Skipped during keyboard navigation; not selectable. */
+    disabled?: boolean;
+  };
+
+  /** Props for ColorSwatchPicker. */
+  export type ColorSwatchPickerProps = {
+    /** Controlled selected color. When provided, the parent owns the state. */
+    value?: string;
+    /** Initial selected color for uncontrolled use. Ignored when `value` is set. */
+    defaultValue?: string;
+    /** Palette to render. */
+    colors: ColorSwatch[];
+    /** Visual shape of each swatch. Default `'circle'`. */
+    shape?: 'circle' | 'square';
+    /** Swatch dimension token. Default `'md'`. */
+    size?: 'xs' | 'sm' | 'md' | 'lg' | 'xl';
+    /**
+     * Layout direction. Default `'grid'`.
+     *
+     * Note: grid layout uses one-dimensional DOM-order navigation for both
+     * ArrowLeft/Right and ArrowUp/Down. True column-aware navigation is not
+     * implemented in v1 — see a11y memo.
+     */
+    layout?: 'grid' | 'stack';
+    /** Disables the entire listbox. Keyboard activation and clicks are ignored. */
+    disabled?: boolean;
+    /**
+     * Accessible name for the listbox. Required — `role="listbox"` needs a label
+     * so screen readers can announce the control's purpose.
+     */
+    label: string;
+    /** Additional classes merged into the listbox `<ul>`. */
+    class?: string;
+    /** Fired when the selected swatch changes. */
+    onchange?: (color: string) => void;
+    /**
+     * Snippet that replaces the default check-icon indicator on the selected swatch.
+     * Receives the active swatch and the computed contrast color for the icon.
+     */
+    indicator?: Snippet<[{ swatch: ColorSwatch; contrastColor: 'black' | 'white' }]>;
+  };
+</script>
+
+<script lang="ts">
+  import { tick } from 'svelte';
+  import { DEV } from 'esm-env';
+
+  import { cn } from '../utilities/class-names.ts';
+  import { hasAlpha, pickContrastColor } from '../utilities/color-luminance.ts';
+  import { handleRovingKeydown } from '../utilities/roving-tabindex.ts';
+  import { Check } from './icons/index.ts';
+
+  let {
+    value,
+    defaultValue,
+    colors,
+    shape = 'circle',
+    size = 'md',
+    layout = 'grid',
+    disabled = false,
+    label,
+    class: className,
+    onchange,
+    indicator,
+  }: ColorSwatchPickerProps = $props();
+
+  let internalValue = $state(defaultValue ?? '');
+  const selected = $derived(value ?? internalValue);
+
+  // Track focus index driven by user interaction. null = derive from selection.
+  let userFocusIndex = $state<number | null>(null);
+
+  // Reset stale focus index when palette identity changes.
+  $effect(() => {
+    void colors;
+    userFocusIndex = null;
+  });
+
+  const effectiveFocusIndex = $derived.by(() => {
+    if (colors.length === 0) return -1;
+
+    // 1. User-driven focus if it points to a valid, non-item-disabled option.
+    if (
+      userFocusIndex !== null &&
+      userFocusIndex < colors.length &&
+      !colors[userFocusIndex]?.disabled
+    ) {
+      return userFocusIndex;
+    }
+
+    // 2. Currently selected swatch if it exists and is not item-disabled.
+    const selectedIndex = colors.findIndex((s) => s.color === selected);
+    if (selectedIndex !== -1 && !colors[selectedIndex]?.disabled) {
+      return selectedIndex;
+    }
+
+    // 3. First non-item-disabled option.
+    const firstEnabled = colors.findIndex((s) => !s.disabled);
+    if (firstEnabled !== -1) return firstEnabled;
+
+    // 4. First option in DOM order (ensures the control always has a tab stop).
+    return 0;
+  });
+
+  // DOM refs for focusing after keyboard navigation.
+  let liRefs: (HTMLLIElement | null)[] = $state([]);
+
+  // Index of the first swatch (by DOM order) matching `selected` — for aria-selected.
+  const selectedIndex = $derived(colors.findIndex((s) => s.color === selected));
+
+  function isItemDisabledForRoving(index: number): boolean {
+    return colors[index]?.disabled === true;
+  }
+
+  function isInteractive(index: number): boolean {
+    return !disabled && !colors[index]?.disabled;
+  }
+
+  function selectSwatch(index: number): void {
+    if (!isInteractive(index)) return;
+    const swatch = colors[index];
+    if (!swatch) return;
+    internalValue = swatch.color;
+    onchange?.(swatch.color);
+  }
+
+  async function handleKeydown(event: KeyboardEvent): Promise<void> {
+    if (disabled) return;
+
+    const { key } = event;
+
+    if (key === 'Enter' || key === ' ') {
+      event.preventDefault();
+      selectSwatch(effectiveFocusIndex);
+      return;
+    }
+
+    const newIndex = handleRovingKeydown(event, effectiveFocusIndex, colors.length, {
+      vertical: true,
+      horizontal: layout === 'grid',
+      isDisabled: isItemDisabledForRoving,
+    });
+
+    if (newIndex !== null && newIndex !== effectiveFocusIndex) {
+      event.preventDefault();
+      userFocusIndex = newIndex;
+      await tick();
+      liRefs[effectiveFocusIndex]?.focus();
+    }
+  }
+
+  function handleClick(index: number): void {
+    if (!isInteractive(index)) return;
+    userFocusIndex = index;
+    selectSwatch(index);
+  }
+
+  // Warn in dev mode when duplicate colors appear in the palette.
+  $effect(() => {
+    if (DEV) {
+      const colorValues = colors.map((c) => c.color);
+      if (new Set(colorValues).size !== colorValues.length) {
+        console.warn(
+          '[ColorSwatchPicker] Duplicate color values detected in palette. ' +
+            'Only the first matching swatch will be shown as selected.',
+        );
+      }
+    }
+  });
+</script>
+
+<ul
+  role="listbox"
+  aria-label={label}
+  aria-disabled={disabled ? 'true' : undefined}
+  aria-orientation={layout === 'stack' ? 'vertical' : undefined}
+  class={cn('cinder-color-swatch-picker', className)}
+  data-cinder-size={size}
+  data-cinder-shape={shape}
+  data-cinder-layout={layout}
+  onkeydown={handleKeydown}
+>
+  {#each colors as swatch, index (swatch.color + index)}
+    {@const isSelected = index === selectedIndex}
+    {@const isDisabled = swatch.disabled === true}
+    {@const contrastColor = pickContrastColor(swatch.color)}
+    {@const alpha = hasAlpha(swatch.color)}
+    <li
+      role="option"
+      aria-selected={isSelected}
+      aria-label={swatch.name ? `${swatch.name}, ${swatch.color}` : swatch.color}
+      aria-disabled={isDisabled ? 'true' : undefined}
+      tabindex={index === effectiveFocusIndex ? 0 : -1}
+      class="cinder-color-swatch-picker__swatch"
+      data-cinder-selected={isSelected ? '' : undefined}
+      data-cinder-disabled={isDisabled ? '' : undefined}
+      data-cinder-alpha={alpha ? '' : undefined}
+      style="--swatch-color: {swatch.color}"
+      bind:this={liRefs[index]}
+      onclick={() => handleClick(index)}
+    >
+      {#if isSelected}
+        <span class="cinder-color-swatch-picker__indicator" style="color: {contrastColor}">
+          {#if indicator}
+            {@render indicator({ swatch, contrastColor })}
+          {:else}
+            <Check aria-hidden="true" />
+          {/if}
+        </span>
+      {/if}
+    </li>
+  {/each}
+</ul>

--- a/packages/components/src/components/color-swatch-picker.svelte
+++ b/packages/components/src/components/color-swatch-picker.svelte
@@ -147,6 +147,7 @@
     const { key } = event;
 
     if (key === 'Enter' || key === ' ') {
+      if (effectiveFocusIndex < 0) return;
       event.preventDefault();
       selectSwatch(effectiveFocusIndex);
       return;
@@ -158,11 +159,13 @@
       isDisabled: isItemDisabledForRoving,
     });
 
-    if (newIndex !== null && newIndex !== effectiveFocusIndex) {
+    if (newIndex !== null) {
       event.preventDefault();
-      userFocusIndex = newIndex;
-      await tick();
-      liRefs[newIndex]?.focus();
+      if (newIndex !== effectiveFocusIndex) {
+        userFocusIndex = newIndex;
+        await tick();
+        liRefs[newIndex]?.focus();
+      }
     }
   }
 

--- a/packages/components/src/components/color-swatch-picker.svelte
+++ b/packages/components/src/components/color-swatch-picker.svelte
@@ -162,7 +162,7 @@
       event.preventDefault();
       userFocusIndex = newIndex;
       await tick();
-      liRefs[effectiveFocusIndex]?.focus();
+      liRefs[newIndex]?.focus();
     }
   }
 
@@ -206,7 +206,7 @@
       role="option"
       aria-selected={isSelected}
       aria-label={swatch.name ? `${swatch.name}, ${swatch.color}` : swatch.color}
-      aria-disabled={isDisabled ? 'true' : undefined}
+      aria-disabled={disabled || isDisabled ? 'true' : undefined}
       tabindex={index === effectiveFocusIndex ? 0 : -1}
       class="cinder-color-swatch-picker__swatch"
       data-cinder-selected={isSelected ? '' : undefined}

--- a/packages/components/src/components/color-swatch-picker.test.ts
+++ b/packages/components/src/components/color-swatch-picker.test.ts
@@ -344,6 +344,18 @@ describe('ColorSwatchPicker disabled handling', () => {
     expect(listbox?.getAttribute('aria-disabled')).toBe('true');
   });
 
+  test('group disabled: all options have aria-disabled=true', () => {
+    const { container } = render(ColorSwatchPicker, {
+      colors: palette,
+      label: 'Colors',
+      disabled: true,
+    });
+    const options = toArray(container.querySelectorAll('[role="option"]'));
+    options.forEach((option) => {
+      expect(option.getAttribute('aria-disabled')).toBe('true');
+    });
+  });
+
   test('group disabled: focused option retains tabindex=0', () => {
     const { container } = render(ColorSwatchPicker, {
       colors: palette,
@@ -462,6 +474,69 @@ describe('ColorSwatchPicker duplicate palette', () => {
     const options = toArray(container.querySelectorAll('[role="option"]'));
     expect(options[0].getAttribute('aria-selected')).toBe('true');
     expect(options[1].getAttribute('aria-selected')).toBe('false');
+  });
+});
+
+describe('ColorSwatchPicker controlled value update', () => {
+  test('updating value prop moves aria-selected to the new color', async () => {
+    const { container, rerender } = render(ColorSwatchPicker, {
+      colors: palette,
+      label: 'Colors',
+      value: '#ff0000',
+    });
+    const options = toArray(container.querySelectorAll('[role="option"]'));
+    expect(options[0].getAttribute('aria-selected')).toBe('true');
+
+    await rerender({ colors: palette, label: 'Colors', value: '#0000ff' });
+    expect(options[0].getAttribute('aria-selected')).toBe('false');
+    expect(options[2].getAttribute('aria-selected')).toBe('true');
+  });
+
+  test('onchange does not fire when controlled value prop changes', async () => {
+    let changed = false;
+    const { rerender } = render(ColorSwatchPicker, {
+      colors: palette,
+      label: 'Colors',
+      value: '#ff0000',
+      onchange: () => {
+        changed = true;
+      },
+    });
+    await rerender({ colors: palette, label: 'Colors', value: '#0000ff' });
+    expect(changed).toBe(false);
+  });
+});
+
+describe('ColorSwatchPicker navigate-then-select', () => {
+  test('ArrowRight then Enter selects the navigated-to swatch', async () => {
+    let changed = '';
+    const { container } = render(ColorSwatchPicker, {
+      colors: palette,
+      label: 'Colors',
+      onchange: (c: string) => {
+        changed = c;
+      },
+    });
+    const listbox = container.querySelector('[role="listbox"]') as HTMLElement;
+    await fireEvent.keyDown(listbox, { key: 'ArrowRight' });
+    await fireEvent.keyDown(listbox, { key: 'Enter' });
+    expect(changed).toBe('#00ff00');
+  });
+
+  test('ArrowDown then Space selects the navigated-to swatch in stack layout', async () => {
+    let changed = '';
+    const { container } = render(ColorSwatchPicker, {
+      colors: palette,
+      label: 'Colors',
+      layout: 'stack',
+      onchange: (c: string) => {
+        changed = c;
+      },
+    });
+    const listbox = container.querySelector('[role="listbox"]') as HTMLElement;
+    await fireEvent.keyDown(listbox, { key: 'ArrowDown' });
+    await fireEvent.keyDown(listbox, { key: ' ' });
+    expect(changed).toBe('#00ff00');
   });
 });
 

--- a/packages/components/src/components/color-swatch-picker.test.ts
+++ b/packages/components/src/components/color-swatch-picker.test.ts
@@ -1,0 +1,487 @@
+/// <reference lib="dom" />
+import { describe, expect, test } from 'bun:test';
+
+import { setupHappyDom } from '../test/happy-dom.ts';
+
+setupHappyDom();
+
+const { render, fireEvent } = await import('@testing-library/svelte');
+const { default: ColorSwatchPicker } = await import('./color-swatch-picker.svelte');
+
+/**
+ * Spread NodeList to HTMLElement[] — test files may use any[] and non-null assertions.
+ * Using `any` here suppresses noUncheckedIndexedAccess on [n] access in tests.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function toArray(list: NodeListOf<Element>): any[] {
+  return Array.from(list);
+}
+
+const palette = [
+  { color: '#ff0000', name: 'Red' },
+  { color: '#00ff00', name: 'Green' },
+  { color: '#0000ff', name: 'Blue' },
+  { color: '#ffff00', name: 'Yellow', disabled: true },
+  { color: '#ff00ff', name: 'Magenta' },
+];
+
+describe('ColorSwatchPicker structure', () => {
+  test('renders a listbox with the provided label', () => {
+    const { container } = render(ColorSwatchPicker, {
+      colors: palette,
+      label: 'Choose a color',
+    });
+    const listbox = container.querySelector('[role="listbox"]');
+    expect(listbox).not.toBeNull();
+    expect(listbox?.getAttribute('aria-label')).toBe('Choose a color');
+  });
+
+  test('renders all swatches as role=option', () => {
+    const { container } = render(ColorSwatchPicker, { colors: palette, label: 'Colors' });
+    const options = toArray(container.querySelectorAll('[role="option"]'));
+    expect(options.length).toBe(palette.length);
+  });
+
+  test('option aria-label is "name, color" when name is provided', () => {
+    const { container } = render(ColorSwatchPicker, { colors: palette, label: 'Colors' });
+    const options = toArray(container.querySelectorAll('[role="option"]'));
+    expect(options[0].getAttribute('aria-label')).toBe('Red, #ff0000');
+    expect(options[1].getAttribute('aria-label')).toBe('Green, #00ff00');
+  });
+
+  test('option aria-label is just the color string when name is absent', () => {
+    const colors = [{ color: '#aabbcc' }];
+    const { container } = render(ColorSwatchPicker, { colors, label: 'Colors' });
+    const option = container.querySelector('[role="option"]');
+    expect(option?.getAttribute('aria-label')).toBe('#aabbcc');
+  });
+
+  test('class prop merges onto the listbox ul', () => {
+    const { container } = render(ColorSwatchPicker, {
+      colors: palette,
+      label: 'Colors',
+      class: 'my-custom-class',
+    });
+    const listbox = container.querySelector('[role="listbox"]');
+    expect(listbox?.classList.contains('my-custom-class')).toBe(true);
+    expect(listbox?.classList.contains('cinder-color-swatch-picker')).toBe(true);
+  });
+
+  test('data-cinder-size, shape, layout are set on the listbox', () => {
+    const { container } = render(ColorSwatchPicker, {
+      colors: palette,
+      label: 'Colors',
+      size: 'lg',
+      shape: 'square',
+      layout: 'stack',
+    });
+    const listbox = container.querySelector('[role="listbox"]');
+    expect(listbox?.getAttribute('data-cinder-size')).toBe('lg');
+    expect(listbox?.getAttribute('data-cinder-shape')).toBe('square');
+    expect(listbox?.getAttribute('data-cinder-layout')).toBe('stack');
+  });
+});
+
+describe('ColorSwatchPicker selection', () => {
+  test('no swatch is aria-selected when no value or defaultValue', () => {
+    const { container } = render(ColorSwatchPicker, { colors: palette, label: 'Colors' });
+    const selected = container.querySelectorAll('[aria-selected="true"]');
+    expect(selected.length).toBe(0);
+  });
+
+  test('defaultValue makes the matching swatch aria-selected', () => {
+    const { container } = render(ColorSwatchPicker, {
+      colors: palette,
+      label: 'Colors',
+      defaultValue: '#00ff00',
+    });
+    const options = toArray(container.querySelectorAll('[role="option"]'));
+    expect(options[1].getAttribute('aria-selected')).toBe('true');
+    expect(options[0].getAttribute('aria-selected')).toBe('false');
+  });
+
+  test('controlled value makes the matching swatch aria-selected', () => {
+    const { container } = render(ColorSwatchPicker, {
+      colors: palette,
+      label: 'Colors',
+      value: '#0000ff',
+    });
+    const options = toArray(container.querySelectorAll('[role="option"]'));
+    expect(options[2].getAttribute('aria-selected')).toBe('true');
+  });
+
+  test('Enter selects the focused swatch and fires onchange', async () => {
+    let changed = '';
+    const { container } = render(ColorSwatchPicker, {
+      colors: palette,
+      label: 'Colors',
+      onchange: (c: string) => {
+        changed = c;
+      },
+    });
+    const listbox = container.querySelector('[role="listbox"]') as HTMLElement;
+    // Focus the first option
+    const firstOption = toArray(container.querySelectorAll('[role="option"]'))[0] as HTMLElement;
+    await fireEvent.focus(firstOption);
+    await fireEvent.keyDown(listbox, { key: 'Enter' });
+    expect(changed).toBe('#ff0000');
+  });
+
+  test('Space selects the focused swatch and fires onchange', async () => {
+    let changed = '';
+    const { container } = render(ColorSwatchPicker, {
+      colors: palette,
+      label: 'Colors',
+      onchange: (c: string) => {
+        changed = c;
+      },
+    });
+    const listbox = container.querySelector('[role="listbox"]') as HTMLElement;
+    await fireEvent.keyDown(listbox, { key: ' ' });
+    expect(changed).toBe('#ff0000');
+  });
+
+  test('click on a swatch selects it and fires onchange', async () => {
+    let changed = '';
+    const { container } = render(ColorSwatchPicker, {
+      colors: palette,
+      label: 'Colors',
+      onchange: (c: string) => {
+        changed = c;
+      },
+    });
+    const thirdOption = toArray(container.querySelectorAll('[role="option"]'))[2] as HTMLElement;
+    await fireEvent.click(thirdOption);
+    expect(changed).toBe('#0000ff');
+  });
+
+  test('uncontrolled: selecting updates aria-selected without prop', async () => {
+    const { container } = render(ColorSwatchPicker, { colors: palette, label: 'Colors' });
+    const options = toArray(container.querySelectorAll('[role="option"]'));
+    await fireEvent.click(options[2] as HTMLElement);
+    expect(options[2].getAttribute('aria-selected')).toBe('true');
+    expect(options[0].getAttribute('aria-selected')).toBe('false');
+  });
+});
+
+describe('ColorSwatchPicker keyboard navigation', () => {
+  test('ArrowRight advances focus in grid layout', async () => {
+    const { container } = render(ColorSwatchPicker, {
+      colors: palette,
+      label: 'Colors',
+      layout: 'grid',
+    });
+    const listbox = container.querySelector('[role="listbox"]') as HTMLElement;
+    const options = toArray(container.querySelectorAll('[role="option"]'));
+
+    // First option should start with tabindex=0
+    expect(options[0].getAttribute('tabindex')).toBe('0');
+
+    await fireEvent.keyDown(listbox, { key: 'ArrowRight' });
+    expect(options[1].getAttribute('tabindex')).toBe('0');
+    expect(options[0].getAttribute('tabindex')).toBe('-1');
+  });
+
+  test('ArrowLeft retreats focus in grid layout', async () => {
+    const { container } = render(ColorSwatchPicker, {
+      colors: palette,
+      label: 'Colors',
+      layout: 'grid',
+      defaultValue: '#00ff00',
+    });
+    const listbox = container.querySelector('[role="listbox"]') as HTMLElement;
+    const options = toArray(container.querySelectorAll('[role="option"]'));
+
+    // Second option selected initially
+    expect(options[1].getAttribute('tabindex')).toBe('0');
+    await fireEvent.keyDown(listbox, { key: 'ArrowLeft' });
+    expect(options[0].getAttribute('tabindex')).toBe('0');
+  });
+
+  test('ArrowDown advances focus in grid layout', async () => {
+    const { container } = render(ColorSwatchPicker, {
+      colors: palette,
+      label: 'Colors',
+      layout: 'grid',
+    });
+    const listbox = container.querySelector('[role="listbox"]') as HTMLElement;
+    const options = toArray(container.querySelectorAll('[role="option"]'));
+
+    await fireEvent.keyDown(listbox, { key: 'ArrowDown' });
+    expect(options[1].getAttribute('tabindex')).toBe('0');
+  });
+
+  test('ArrowDown advances focus in stack layout', async () => {
+    const { container } = render(ColorSwatchPicker, {
+      colors: palette,
+      label: 'Colors',
+      layout: 'stack',
+    });
+    const listbox = container.querySelector('[role="listbox"]') as HTMLElement;
+    const options = toArray(container.querySelectorAll('[role="option"]'));
+
+    await fireEvent.keyDown(listbox, { key: 'ArrowDown' });
+    expect(options[1].getAttribute('tabindex')).toBe('0');
+  });
+
+  test('ArrowUp retreats focus in stack layout', async () => {
+    const { container } = render(ColorSwatchPicker, {
+      colors: palette,
+      label: 'Colors',
+      layout: 'stack',
+      defaultValue: '#00ff00',
+    });
+    const listbox = container.querySelector('[role="listbox"]') as HTMLElement;
+    const options = toArray(container.querySelectorAll('[role="option"]'));
+
+    await fireEvent.keyDown(listbox, { key: 'ArrowUp' });
+    expect(options[0].getAttribute('tabindex')).toBe('0');
+  });
+
+  test('ArrowLeft/Right are no-ops in stack layout', async () => {
+    const { container } = render(ColorSwatchPicker, {
+      colors: palette,
+      label: 'Colors',
+      layout: 'stack',
+    });
+    const listbox = container.querySelector('[role="listbox"]') as HTMLElement;
+    const options = toArray(container.querySelectorAll('[role="option"]'));
+
+    await fireEvent.keyDown(listbox, { key: 'ArrowRight' });
+    expect(options[0].getAttribute('tabindex')).toBe('0');
+    await fireEvent.keyDown(listbox, { key: 'ArrowLeft' });
+    expect(options[0].getAttribute('tabindex')).toBe('0');
+  });
+
+  test('ArrowRight wraps from last to first', async () => {
+    const colors = [{ color: '#ff0000' }, { color: '#00ff00' }, { color: '#0000ff' }];
+    const { container } = render(ColorSwatchPicker, {
+      colors,
+      label: 'Colors',
+      defaultValue: '#0000ff',
+    });
+    const listbox = container.querySelector('[role="listbox"]') as HTMLElement;
+    const options = toArray(container.querySelectorAll('[role="option"]'));
+
+    expect(options[2].getAttribute('tabindex')).toBe('0');
+    await fireEvent.keyDown(listbox, { key: 'ArrowRight' });
+    expect(options[0].getAttribute('tabindex')).toBe('0');
+  });
+
+  test('Home jumps to first non-disabled swatch', async () => {
+    const { container } = render(ColorSwatchPicker, {
+      colors: palette,
+      label: 'Colors',
+      defaultValue: '#ff00ff',
+    });
+    const listbox = container.querySelector('[role="listbox"]') as HTMLElement;
+    const options = toArray(container.querySelectorAll('[role="option"]'));
+
+    await fireEvent.keyDown(listbox, { key: 'Home' });
+    expect(options[0].getAttribute('tabindex')).toBe('0');
+  });
+
+  test('End jumps to last non-disabled swatch', async () => {
+    const { container } = render(ColorSwatchPicker, {
+      colors: palette,
+      label: 'Colors',
+    });
+    const listbox = container.querySelector('[role="listbox"]') as HTMLElement;
+    const options = toArray(container.querySelectorAll('[role="option"]'));
+
+    await fireEvent.keyDown(listbox, { key: 'End' });
+    // Last non-disabled is index 4 (Magenta), index 3 (Yellow) is disabled
+    expect(options[4].getAttribute('tabindex')).toBe('0');
+  });
+
+  test('disabled items are skipped during arrow navigation', async () => {
+    const { container } = render(ColorSwatchPicker, {
+      colors: palette,
+      label: 'Colors',
+      defaultValue: '#00ff00',
+    });
+    const listbox = container.querySelector('[role="listbox"]') as HTMLElement;
+    const options = toArray(container.querySelectorAll('[role="option"]'));
+
+    // index 1 → ArrowRight → should skip index 3 (disabled Yellow)
+    await fireEvent.keyDown(listbox, { key: 'ArrowRight' });
+    // Now at index 2 (Blue)
+    expect(options[2].getAttribute('tabindex')).toBe('0');
+    await fireEvent.keyDown(listbox, { key: 'ArrowRight' });
+    // Skip index 3 (Yellow, disabled) → land on index 4 (Magenta)
+    expect(options[4].getAttribute('tabindex')).toBe('0');
+  });
+});
+
+describe('ColorSwatchPicker disabled handling', () => {
+  test('disabled item has aria-disabled=true', () => {
+    const { container } = render(ColorSwatchPicker, { colors: palette, label: 'Colors' });
+    const options = toArray(container.querySelectorAll('[role="option"]'));
+    expect(options[3].getAttribute('aria-disabled')).toBe('true');
+  });
+
+  test('disabled item cannot be selected by click', async () => {
+    let changed = '';
+    const { container } = render(ColorSwatchPicker, {
+      colors: palette,
+      label: 'Colors',
+      onchange: (c: string) => {
+        changed = c;
+      },
+    });
+    const disabledOption = toArray(container.querySelectorAll('[role="option"]'))[3] as HTMLElement;
+    await fireEvent.click(disabledOption);
+    expect(changed).toBe('');
+  });
+
+  test('group disabled: listbox has aria-disabled=true', () => {
+    const { container } = render(ColorSwatchPicker, {
+      colors: palette,
+      label: 'Colors',
+      disabled: true,
+    });
+    const listbox = container.querySelector('[role="listbox"]');
+    expect(listbox?.getAttribute('aria-disabled')).toBe('true');
+  });
+
+  test('group disabled: focused option retains tabindex=0', () => {
+    const { container } = render(ColorSwatchPicker, {
+      colors: palette,
+      label: 'Colors',
+      disabled: true,
+    });
+    const options = toArray(container.querySelectorAll('[role="option"]'));
+    const tabbable = Array.from(options).filter((o) => o.getAttribute('tabindex') === '0');
+    expect(tabbable.length).toBe(1);
+  });
+
+  test('group disabled: Arrow keys are no-ops', async () => {
+    const { container } = render(ColorSwatchPicker, {
+      colors: palette,
+      label: 'Colors',
+      disabled: true,
+    });
+    const listbox = container.querySelector('[role="listbox"]') as HTMLElement;
+    const options = toArray(container.querySelectorAll('[role="option"]'));
+    const initialTabbable = Array.from(options).findIndex(
+      (o) => o.getAttribute('tabindex') === '0',
+    );
+
+    await fireEvent.keyDown(listbox, { key: 'ArrowRight' });
+    const afterTabbable = Array.from(options).findIndex((o) => o.getAttribute('tabindex') === '0');
+    expect(afterTabbable).toBe(initialTabbable);
+  });
+
+  test('group disabled: Enter/Space do not fire onchange', async () => {
+    let changed = false;
+    const { container } = render(ColorSwatchPicker, {
+      colors: palette,
+      label: 'Colors',
+      disabled: true,
+      onchange: () => {
+        changed = true;
+      },
+    });
+    const listbox = container.querySelector('[role="listbox"]') as HTMLElement;
+    await fireEvent.keyDown(listbox, { key: 'Enter' });
+    await fireEvent.keyDown(listbox, { key: ' ' });
+    expect(changed).toBe(false);
+  });
+
+  test('group disabled: clicks do not fire onchange', async () => {
+    let changed = false;
+    const { container } = render(ColorSwatchPicker, {
+      colors: palette,
+      label: 'Colors',
+      disabled: true,
+      onchange: () => {
+        changed = true;
+      },
+    });
+    const option = toArray(container.querySelectorAll('[role="option"]'))[0] as HTMLElement;
+    await fireEvent.click(option);
+    expect(changed).toBe(false);
+  });
+});
+
+describe('ColorSwatchPicker alpha detection', () => {
+  test('swatch with alpha color gets data-cinder-alpha', () => {
+    const colors = [{ color: '#ff000080' }, { color: '#ff0000' }];
+    const { container } = render(ColorSwatchPicker, { colors, label: 'Colors' });
+    const options = toArray(container.querySelectorAll('[role="option"]'));
+    expect(options[0].hasAttribute('data-cinder-alpha')).toBe(true);
+    expect(options[1].hasAttribute('data-cinder-alpha')).toBe(false);
+  });
+
+  test('rgba() with alpha < 1 gets data-cinder-alpha', () => {
+    const colors = [{ color: 'rgba(255, 0, 0, 0.5)' }];
+    const { container } = render(ColorSwatchPicker, { colors, label: 'Colors' });
+    const option = container.querySelector('[role="option"]');
+    expect(option?.hasAttribute('data-cinder-alpha')).toBe(true);
+  });
+
+  test('opaque rgb() does not get data-cinder-alpha', () => {
+    const colors = [{ color: 'rgb(255, 0, 0)' }];
+    const { container } = render(ColorSwatchPicker, { colors, label: 'Colors' });
+    const option = container.querySelector('[role="option"]');
+    expect(option?.hasAttribute('data-cinder-alpha')).toBe(false);
+  });
+});
+
+describe('ColorSwatchPicker empty palette', () => {
+  test('renders an empty listbox without crashing', () => {
+    const { container } = render(ColorSwatchPicker, { colors: [], label: 'Colors' });
+    const listbox = container.querySelector('[role="listbox"]');
+    expect(listbox).not.toBeNull();
+    const options = toArray(container.querySelectorAll('[role="option"]'));
+    expect(options.length).toBe(0);
+  });
+
+  test('keyboard handlers are no-ops on empty palette', async () => {
+    const { container } = render(ColorSwatchPicker, { colors: [], label: 'Colors' });
+    const listbox = container.querySelector('[role="listbox"]') as HTMLElement;
+    // Should not throw
+    await fireEvent.keyDown(listbox, { key: 'ArrowRight' });
+    await fireEvent.keyDown(listbox, { key: 'Home' });
+    await fireEvent.keyDown(listbox, { key: 'Enter' });
+  });
+});
+
+describe('ColorSwatchPicker duplicate palette', () => {
+  test('only first matching swatch receives aria-selected', () => {
+    const colors = [
+      { color: '#ff0000', name: 'Red 1' },
+      { color: '#ff0000', name: 'Red 2' },
+      { color: '#0000ff' },
+    ];
+    const { container } = render(ColorSwatchPicker, {
+      colors,
+      label: 'Colors',
+      defaultValue: '#ff0000',
+    });
+    const options = toArray(container.querySelectorAll('[role="option"]'));
+    expect(options[0].getAttribute('aria-selected')).toBe('true');
+    expect(options[1].getAttribute('aria-selected')).toBe('false');
+  });
+});
+
+describe('ColorSwatchPicker initial focus index', () => {
+  test('selected option gets tabindex=0 when no user interaction', () => {
+    const { container } = render(ColorSwatchPicker, {
+      colors: palette,
+      label: 'Colors',
+      defaultValue: '#0000ff',
+    });
+    const options = toArray(container.querySelectorAll('[role="option"]'));
+    expect(options[2].getAttribute('tabindex')).toBe('0');
+    expect(options[0].getAttribute('tabindex')).toBe('-1');
+  });
+
+  test('first enabled option gets tabindex=0 when no selection', () => {
+    const colors = [{ color: '#ff0000', disabled: true }, { color: '#00ff00' }];
+    const { container } = render(ColorSwatchPicker, { colors, label: 'Colors' });
+    const options = toArray(container.querySelectorAll('[role="option"]'));
+    expect(options[0].getAttribute('tabindex')).toBe('-1');
+    expect(options[1].getAttribute('tabindex')).toBe('0');
+  });
+});

--- a/packages/components/src/components/color-swatch-picker.test.ts
+++ b/packages/components/src/components/color-swatch-picker.test.ts
@@ -180,6 +180,7 @@ describe('ColorSwatchPicker keyboard navigation', () => {
     await fireEvent.keyDown(listbox, { key: 'ArrowRight' });
     expect(options[1].getAttribute('tabindex')).toBe('0');
     expect(options[0].getAttribute('tabindex')).toBe('-1');
+    expect(document.activeElement).toBe(options[1]);
   });
 
   test('ArrowLeft retreats focus in grid layout', async () => {
@@ -196,6 +197,7 @@ describe('ColorSwatchPicker keyboard navigation', () => {
     expect(options[1].getAttribute('tabindex')).toBe('0');
     await fireEvent.keyDown(listbox, { key: 'ArrowLeft' });
     expect(options[0].getAttribute('tabindex')).toBe('0');
+    expect(document.activeElement).toBe(options[0]);
   });
 
   test('ArrowDown advances focus in grid layout', async () => {
@@ -209,6 +211,7 @@ describe('ColorSwatchPicker keyboard navigation', () => {
 
     await fireEvent.keyDown(listbox, { key: 'ArrowDown' });
     expect(options[1].getAttribute('tabindex')).toBe('0');
+    expect(document.activeElement).toBe(options[1]);
   });
 
   test('ArrowDown advances focus in stack layout', async () => {
@@ -222,6 +225,7 @@ describe('ColorSwatchPicker keyboard navigation', () => {
 
     await fireEvent.keyDown(listbox, { key: 'ArrowDown' });
     expect(options[1].getAttribute('tabindex')).toBe('0');
+    expect(document.activeElement).toBe(options[1]);
   });
 
   test('ArrowUp retreats focus in stack layout', async () => {
@@ -236,6 +240,7 @@ describe('ColorSwatchPicker keyboard navigation', () => {
 
     await fireEvent.keyDown(listbox, { key: 'ArrowUp' });
     expect(options[0].getAttribute('tabindex')).toBe('0');
+    expect(document.activeElement).toBe(options[0]);
   });
 
   test('ArrowLeft/Right are no-ops in stack layout', async () => {
@@ -266,6 +271,7 @@ describe('ColorSwatchPicker keyboard navigation', () => {
     expect(options[2].getAttribute('tabindex')).toBe('0');
     await fireEvent.keyDown(listbox, { key: 'ArrowRight' });
     expect(options[0].getAttribute('tabindex')).toBe('0');
+    expect(document.activeElement).toBe(options[0]);
   });
 
   test('Home jumps to first non-disabled swatch', async () => {
@@ -279,6 +285,7 @@ describe('ColorSwatchPicker keyboard navigation', () => {
 
     await fireEvent.keyDown(listbox, { key: 'Home' });
     expect(options[0].getAttribute('tabindex')).toBe('0');
+    expect(document.activeElement).toBe(options[0]);
   });
 
   test('End jumps to last non-disabled swatch', async () => {
@@ -292,6 +299,7 @@ describe('ColorSwatchPicker keyboard navigation', () => {
     await fireEvent.keyDown(listbox, { key: 'End' });
     // Last non-disabled is index 4 (Magenta), index 3 (Yellow) is disabled
     expect(options[4].getAttribute('tabindex')).toBe('0');
+    expect(document.activeElement).toBe(options[4]);
   });
 
   test('disabled items are skipped during arrow navigation', async () => {
@@ -307,9 +315,11 @@ describe('ColorSwatchPicker keyboard navigation', () => {
     await fireEvent.keyDown(listbox, { key: 'ArrowRight' });
     // Now at index 2 (Blue)
     expect(options[2].getAttribute('tabindex')).toBe('0');
+    expect(document.activeElement).toBe(options[2]);
     await fireEvent.keyDown(listbox, { key: 'ArrowRight' });
     // Skip index 3 (Yellow, disabled) → land on index 4 (Magenta)
     expect(options[4].getAttribute('tabindex')).toBe('0');
+    expect(document.activeElement).toBe(options[4]);
   });
 });
 
@@ -518,7 +528,9 @@ describe('ColorSwatchPicker navigate-then-select', () => {
       },
     });
     const listbox = container.querySelector('[role="listbox"]') as HTMLElement;
+    const options = toArray(container.querySelectorAll('[role="option"]'));
     await fireEvent.keyDown(listbox, { key: 'ArrowRight' });
+    expect(document.activeElement).toBe(options[1]);
     await fireEvent.keyDown(listbox, { key: 'Enter' });
     expect(changed).toBe('#00ff00');
   });
@@ -534,7 +546,9 @@ describe('ColorSwatchPicker navigate-then-select', () => {
       },
     });
     const listbox = container.querySelector('[role="listbox"]') as HTMLElement;
+    const options = toArray(container.querySelectorAll('[role="option"]'));
     await fireEvent.keyDown(listbox, { key: 'ArrowDown' });
+    expect(document.activeElement).toBe(options[1]);
     await fireEvent.keyDown(listbox, { key: ' ' });
     expect(changed).toBe('#00ff00');
   });

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -37,6 +37,9 @@ export type { CheckboxGroupProps } from './components/checkbox-group.svelte';
 export { default as CodeBlock } from './components/code-block.svelte';
 export type { CodeBlockProps } from './components/code-block.svelte';
 
+export { default as ColorSwatchPicker } from './components/color-swatch-picker.svelte';
+export type { ColorSwatch, ColorSwatchPickerProps } from './components/color-swatch-picker.svelte';
+
 export { default as Combobox } from './components/combobox.svelte';
 export type { ComboboxOption, ComboboxProps } from './components/combobox.svelte';
 

--- a/packages/components/src/styles/components.css
+++ b/packages/components/src/styles/components.css
@@ -16,6 +16,7 @@
 @import './components/checkbox.css';
 @import './components/checkbox-group.css';
 @import './components/code-block.css';
+@import './components/color-swatch-picker.css';
 @import './components/combobox.css';
 @import './components/command-palette.css';
 @import './components/copy-button.css';

--- a/packages/components/src/styles/components/color-swatch-picker.css
+++ b/packages/components/src/styles/components/color-swatch-picker.css
@@ -1,0 +1,140 @@
+/* ========================================
+ * COLOR SWATCH PICKER
+ * ======================================== */
+
+.cinder-color-swatch-picker {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--cinder-space-2);
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.cinder-color-swatch-picker[data-cinder-layout='stack'] {
+  flex-direction: column;
+  flex-wrap: nowrap;
+}
+
+/* ── Size → swatch dimensions ───────────────────────────────────────────── */
+
+.cinder-color-swatch-picker[data-cinder-size='xs'] {
+  --swatch-size: 16px;
+}
+
+.cinder-color-swatch-picker[data-cinder-size='sm'] {
+  --swatch-size: 24px;
+}
+
+.cinder-color-swatch-picker[data-cinder-size='md'] {
+  --swatch-size: 32px;
+}
+
+.cinder-color-swatch-picker[data-cinder-size='lg'] {
+  --swatch-size: 36px;
+}
+
+.cinder-color-swatch-picker[data-cinder-size='xl'] {
+  --swatch-size: 40px;
+}
+
+/* ── Swatch base ─────────────────────────────────────────────────────────── */
+
+.cinder-color-swatch-picker__swatch {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: var(--swatch-size, 32px);
+  height: var(--swatch-size, 32px);
+  cursor: pointer;
+  background-color: var(--swatch-color);
+  border: none;
+  padding: 0;
+  outline: none;
+  flex-shrink: 0;
+}
+
+/* ── Shape variants ─────────────────────────────────────────────────────── */
+
+.cinder-color-swatch-picker[data-cinder-shape='circle'] .cinder-color-swatch-picker__swatch {
+  border-radius: 50%;
+}
+
+.cinder-color-swatch-picker[data-cinder-shape='square'] .cinder-color-swatch-picker__swatch {
+  border-radius: var(--cinder-radius-sm);
+}
+
+/* ── Alpha checkerboard — color layer on top, checkerboard beneath ──────── */
+
+.cinder-color-swatch-picker__swatch[data-cinder-alpha] {
+  background-color: #fff;
+  background-image:
+    linear-gradient(var(--swatch-color), var(--swatch-color)),
+    linear-gradient(45deg, #ccc 25%, transparent 25%),
+    linear-gradient(-45deg, #ccc 25%, transparent 25%),
+    linear-gradient(45deg, transparent 75%, #ccc 75%),
+    linear-gradient(-45deg, transparent 75%, #ccc 75%);
+  background-size:
+    auto,
+    8px 8px,
+    8px 8px,
+    8px 8px,
+    8px 8px;
+  background-position:
+    0 0,
+    0 0,
+    0 4px,
+    4px -4px,
+    -4px 0;
+}
+
+/* ── Focus ring ─────────────────────────────────────────────────────────── */
+
+.cinder-color-swatch-picker__swatch:focus-visible {
+  outline: var(--cinder-ring-width, 2px) solid transparent;
+  box-shadow:
+    0 0 0 var(--cinder-ring-offset, 2px) var(--cinder-ring-offset-color, transparent),
+    0 0 0 calc(var(--cinder-ring-offset, 2px) + var(--cinder-ring-width, 2px))
+      var(--cinder-ring-color, currentColor);
+  z-index: 1;
+}
+
+/* ── Disabled item ──────────────────────────────────────────────────────── */
+
+.cinder-color-swatch-picker__swatch[data-cinder-disabled] {
+  cursor: not-allowed;
+  opacity: 0.4;
+}
+
+/* ── Disabled group ─────────────────────────────────────────────────────── */
+
+.cinder-color-swatch-picker[aria-disabled='true'] {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+/* ── Indicator icon ─────────────────────────────────────────────────────── */
+
+.cinder-color-swatch-picker__indicator {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  pointer-events: none;
+  /* 60% of swatch size, clamped to 12px minimum for xs legibility */
+  width: max(12px, calc(var(--swatch-size, 32px) * 0.6));
+  height: max(12px, calc(var(--swatch-size, 32px) * 0.6));
+}
+
+/* ── Hover / focus scale — respects prefers-reduced-motion ─────────────── */
+
+@media (prefers-reduced-motion: no-preference) {
+  .cinder-color-swatch-picker__swatch {
+    transition: transform var(--cinder-duration-fast, 120ms) var(--cinder-ease-standard, ease);
+  }
+
+  .cinder-color-swatch-picker__swatch:hover:not([data-cinder-disabled]),
+  .cinder-color-swatch-picker__swatch:focus-visible {
+    transform: scale(1.06);
+  }
+}

--- a/packages/components/src/styles/components/color-swatch-picker.css
+++ b/packages/components/src/styles/components/color-swatch-picker.css
@@ -148,7 +148,8 @@
     transition: transform var(--cinder-duration-fast, 120ms) var(--cinder-ease-standard, ease);
   }
 
-  .cinder-color-swatch-picker__swatch:hover:not([data-cinder-disabled]),
+  .cinder-color-swatch-picker:not([aria-disabled='true'])
+    .cinder-color-swatch-picker__swatch:hover:not([data-cinder-disabled]),
   .cinder-color-swatch-picker__swatch:focus-visible {
     transform: scale(1.06);
   }

--- a/packages/components/src/styles/components/color-swatch-picker.css
+++ b/packages/components/src/styles/components/color-swatch-picker.css
@@ -150,7 +150,8 @@
 
   .cinder-color-swatch-picker:not([aria-disabled='true'])
     .cinder-color-swatch-picker__swatch:hover:not([data-cinder-disabled]),
-  .cinder-color-swatch-picker__swatch:focus-visible {
+  .cinder-color-swatch-picker:not([aria-disabled='true'])
+    .cinder-color-swatch-picker__swatch:focus-visible:not([data-cinder-disabled]) {
     transform: scale(1.06);
   }
 }

--- a/packages/components/src/styles/components/color-swatch-picker.css
+++ b/packages/components/src/styles/components/color-swatch-picker.css
@@ -100,6 +100,17 @@
   z-index: 1;
 }
 
+/* Forced Colors Mode (Windows High Contrast): box-shadow is ignored so the
+ * focus ring would be invisible without this override. Use Highlight to match
+ * the system's chosen focus color.
+ */
+@media (forced-colors: active) {
+  .cinder-color-swatch-picker__swatch:focus-visible {
+    outline: 3px solid Highlight;
+    outline-offset: 2px;
+  }
+}
+
 /* ── Disabled item ──────────────────────────────────────────────────────── */
 
 .cinder-color-swatch-picker__swatch[data-cinder-disabled] {
@@ -111,6 +122,10 @@
 
 .cinder-color-swatch-picker[aria-disabled='true'] {
   opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.cinder-color-swatch-picker[aria-disabled='true'] .cinder-color-swatch-picker__swatch {
   cursor: not-allowed;
 }
 

--- a/packages/components/src/utilities/color-luminance.test.ts
+++ b/packages/components/src/utilities/color-luminance.test.ts
@@ -1,0 +1,287 @@
+/// <reference lib="dom" />
+import { describe, expect, test } from 'bun:test';
+
+import { hasAlpha, parseColor, pickContrastColor, relativeLuminance } from './color-luminance.ts';
+
+describe('parseColor', () => {
+  describe('hex formats', () => {
+    test('#rgb expands to full RGB', () => {
+      expect(parseColor('#f00')).toEqual({ r: 255, g: 0, b: 0, a: 1 });
+      expect(parseColor('#fff')).toEqual({ r: 255, g: 255, b: 255, a: 1 });
+      expect(parseColor('#000')).toEqual({ r: 0, g: 0, b: 0, a: 1 });
+    });
+
+    test('#rgba expands to full RGBA', () => {
+      const result = parseColor('#f00f');
+      expect(result).not.toBeNull();
+      expect(result?.r).toBe(255);
+      expect(result?.g).toBe(0);
+      expect(result?.b).toBe(0);
+      expect(result?.a).toBeCloseTo(1, 1);
+    });
+
+    test('#rgba with partial alpha', () => {
+      const result = parseColor('#ff00008');
+      expect(result).toBeNull(); // 7 hex digits — invalid
+    });
+
+    test('#rrggbb parses correctly', () => {
+      expect(parseColor('#ff0000')).toEqual({ r: 255, g: 0, b: 0, a: 1 });
+      expect(parseColor('#ffffff')).toEqual({ r: 255, g: 255, b: 255, a: 1 });
+      expect(parseColor('#000000')).toEqual({ r: 0, g: 0, b: 0, a: 1 });
+      expect(parseColor('#336699')).toEqual({ r: 51, g: 102, b: 153, a: 1 });
+    });
+
+    test('#rrggbbaa with ff alpha is opaque', () => {
+      const result = parseColor('#ff0000ff');
+      expect(result).not.toBeNull();
+      expect(result?.a).toBe(1);
+    });
+
+    test('#rrggbbaa with partial alpha', () => {
+      const result = parseColor('#ff000080');
+      expect(result).not.toBeNull();
+      expect(result?.r).toBe(255);
+      expect(result?.g).toBe(0);
+      expect(result?.b).toBe(0);
+      expect(result?.a).toBeCloseTo(0.502, 2);
+    });
+
+    test('case insensitive', () => {
+      expect(parseColor('#FF0000')).toEqual({ r: 255, g: 0, b: 0, a: 1 });
+      expect(parseColor('#FF0000FF')).toEqual(parseColor('#ff0000ff'));
+    });
+  });
+
+  describe('rgb/rgba', () => {
+    test('rgb with integer channels', () => {
+      expect(parseColor('rgb(255, 0, 0)')).toEqual({ r: 255, g: 0, b: 0, a: 1 });
+      expect(parseColor('rgb(0, 0, 0)')).toEqual({ r: 0, g: 0, b: 0, a: 1 });
+    });
+
+    test('rgba with alpha 0–1', () => {
+      const result = parseColor('rgba(255, 0, 0, 0.5)');
+      expect(result?.r).toBe(255);
+      expect(result?.a).toBe(0.5);
+    });
+
+    test('rgba with alpha 0 is fully transparent', () => {
+      const result = parseColor('rgba(255, 0, 0, 0)');
+      expect(result?.a).toBe(0);
+    });
+
+    test('rgba with alpha = 1 is opaque', () => {
+      const result = parseColor('rgba(255, 0, 0, 1)');
+      expect(result?.a).toBe(1);
+    });
+
+    test('rgb with percentage channels', () => {
+      const result = parseColor('rgb(100%, 0%, 0%)');
+      expect(result?.r).toBeCloseTo(255, 0);
+      expect(result?.g).toBe(0);
+    });
+
+    test('percentage channel near breakpoint (0.04045 linearization)', () => {
+      // ~10.42 out of 255 = 4.09% which is just above 0.04045 breakpoint
+      const result = parseColor('rgb(10.53%, 0%, 0%)');
+      expect(result).not.toBeNull();
+      expect(result!.r).toBeCloseTo(26.85, 0);
+    });
+
+    test('whitespace is tolerated', () => {
+      expect(parseColor('rgb( 255 , 0 , 0 )')).toEqual({ r: 255, g: 0, b: 0, a: 1 });
+    });
+  });
+
+  describe('hsl/hsla', () => {
+    test('pure red hsl(0, 100%, 50%)', () => {
+      const result = parseColor('hsl(0, 100%, 50%)');
+      expect(result?.r).toBe(255);
+      expect(result?.g).toBe(0);
+      expect(result?.b).toBe(0);
+      expect(result?.a).toBe(1);
+    });
+
+    test('pure white hsl(0, 0%, 100%)', () => {
+      const result = parseColor('hsl(0, 0%, 100%)');
+      expect(result?.r).toBe(255);
+      expect(result?.g).toBe(255);
+      expect(result?.b).toBe(255);
+    });
+
+    test('pure black hsl(0, 0%, 0%)', () => {
+      const result = parseColor('hsl(0, 0%, 0%)');
+      expect(result?.r).toBe(0);
+      expect(result?.g).toBe(0);
+      expect(result?.b).toBe(0);
+    });
+
+    test('mid grey hsl(0, 0%, 50%)', () => {
+      const result = parseColor('hsl(0, 0%, 50%)');
+      expect(result?.r).toBeCloseTo(128, 0);
+      expect(result?.g).toBeCloseTo(128, 0);
+      expect(result?.b).toBeCloseTo(128, 0);
+    });
+
+    test('hue wrap hsl(720, 100%, 50%) is red', () => {
+      const result = parseColor('hsl(720, 100%, 50%)');
+      expect(result?.r).toBe(255);
+      expect(result?.g).toBe(0);
+      expect(result?.b).toBe(0);
+    });
+
+    test('hsla with alpha', () => {
+      const result = parseColor('hsla(0, 100%, 50%, 0.5)');
+      expect(result?.a).toBe(0.5);
+    });
+  });
+
+  describe('unsupported formats', () => {
+    test('returns null for named colors', () => {
+      expect(parseColor('red')).toBeNull();
+      expect(parseColor('white')).toBeNull();
+    });
+
+    test('returns null for oklch', () => {
+      expect(parseColor('oklch(50% 0.2 120)')).toBeNull();
+    });
+
+    test('returns null for modern space-separated rgb', () => {
+      expect(parseColor('rgb(255 0 0)')).toBeNull();
+    });
+
+    test('returns null for empty string', () => {
+      expect(parseColor('')).toBeNull();
+    });
+  });
+});
+
+describe('hasAlpha', () => {
+  test('opaque #rrggbb → false', () => {
+    expect(hasAlpha('#ff0000')).toBe(false);
+  });
+
+  test('opaque #rrggbbff → false', () => {
+    expect(hasAlpha('#ff0000ff')).toBe(false);
+  });
+
+  test('alpha #rrggbbaa → true', () => {
+    expect(hasAlpha('#ff000080')).toBe(true);
+  });
+
+  test('opaque #rgb → false', () => {
+    expect(hasAlpha('#f00')).toBe(false);
+  });
+
+  test('full-alpha #rgba → false', () => {
+    expect(hasAlpha('#f00f')).toBe(false);
+  });
+
+  test('partial-alpha #rgba → true', () => {
+    expect(hasAlpha('#f008')).toBe(true);
+  });
+
+  test('opaque rgb() → false', () => {
+    expect(hasAlpha('rgb(255, 0, 0)')).toBe(false);
+  });
+
+  test('opaque rgba(255,0,0,1) → false', () => {
+    expect(hasAlpha('rgba(255, 0, 0, 1)')).toBe(false);
+  });
+
+  test('semi-transparent rgba → true', () => {
+    expect(hasAlpha('rgba(255, 0, 0, 0.5)')).toBe(true);
+  });
+
+  test('fully transparent rgba → true', () => {
+    expect(hasAlpha('rgba(255, 0, 0, 0)')).toBe(true);
+  });
+
+  test('opaque hsl → false', () => {
+    expect(hasAlpha('hsl(0, 100%, 50%)')).toBe(false);
+  });
+
+  test('semi-transparent hsla → true', () => {
+    expect(hasAlpha('hsla(0, 100%, 50%, 0.5)')).toBe(true);
+  });
+
+  test('unsupported format → false (opaque fallback)', () => {
+    expect(hasAlpha('red')).toBe(false);
+    expect(hasAlpha('oklch(50% 0.2 120)')).toBe(false);
+  });
+});
+
+describe('relativeLuminance', () => {
+  test('black = 0', () => {
+    expect(relativeLuminance({ r: 0, g: 0, b: 0 })).toBe(0);
+  });
+
+  test('white = 1', () => {
+    expect(relativeLuminance({ r: 255, g: 255, b: 255 })).toBeCloseTo(1, 4);
+  });
+
+  test('mid-grey is between 0 and 1', () => {
+    const L = relativeLuminance({ r: 128, g: 128, b: 128 });
+    expect(L).toBeGreaterThan(0);
+    expect(L).toBeLessThan(1);
+  });
+
+  test('pure red luminance matches WCAG formula', () => {
+    // red channel only: 0.2126 * linearize(255)
+    const L = relativeLuminance({ r: 255, g: 0, b: 0 });
+    expect(L).toBeCloseTo(0.2126, 4);
+  });
+});
+
+describe('pickContrastColor', () => {
+  test('white swatch → black indicator', () => {
+    expect(pickContrastColor('#ffffff')).toBe('black');
+  });
+
+  test('black swatch → white indicator', () => {
+    expect(pickContrastColor('#000000')).toBe('white');
+  });
+
+  test('mid-grey (#808080) → black indicator (L ≈ 0.216, above crossover)', () => {
+    expect(pickContrastColor('#808080')).toBe('black');
+  });
+
+  test('dark grey (#333333) → white indicator (L below crossover)', () => {
+    expect(pickContrastColor('#333333')).toBe('white');
+  });
+
+  test('near-crossover light value → black', () => {
+    // L ≈ 0.179 is the crossover; slightly above should pick black
+    // #777777 has L ≈ 0.184
+    expect(pickContrastColor('#777777')).toBe('black');
+  });
+
+  test('near-crossover dark value → white', () => {
+    // #767676 has L just below 0.179
+    expect(pickContrastColor('#666666')).toBe('white');
+  });
+
+  test('pure red → black (L=0.2126, above crossover 0.179)', () => {
+    // Pure red: L = 0.2126 * 1.0 = 0.2126 which is above 0.179 crossover
+    expect(pickContrastColor('#ff0000')).toBe('black');
+  });
+
+  test('yellow → black (high luminance)', () => {
+    expect(pickContrastColor('#ffff00')).toBe('black');
+  });
+
+  test('unsupported format falls back to white', () => {
+    expect(pickContrastColor('red')).toBe('white');
+    expect(pickContrastColor('oklch(50% 0.2 120)')).toBe('white');
+  });
+
+  test('rgb() format works', () => {
+    expect(pickContrastColor('rgb(255, 255, 255)')).toBe('black');
+    expect(pickContrastColor('rgb(0, 0, 0)')).toBe('white');
+  });
+
+  test('hsl() format works', () => {
+    expect(pickContrastColor('hsl(0, 0%, 100%)')).toBe('black');
+    expect(pickContrastColor('hsl(0, 0%, 0%)')).toBe('white');
+  });
+});

--- a/packages/components/src/utilities/color-luminance.test.ts
+++ b/packages/components/src/utilities/color-luminance.test.ts
@@ -257,7 +257,7 @@ describe('pickContrastColor', () => {
   });
 
   test('near-crossover dark value → white', () => {
-    // #767676 has L just below 0.179
+    // #666666 has L ≈ 0.133, well below the 0.179 crossover
     expect(pickContrastColor('#666666')).toBe('white');
   });
 

--- a/packages/components/src/utilities/color-luminance.ts
+++ b/packages/components/src/utilities/color-luminance.ts
@@ -1,0 +1,209 @@
+/**
+ * Color parsing and luminance utilities for swatch contrast computation.
+ *
+ * Supported input formats: `#rgb`, `#rgba`, `#rrggbb`, `#rrggbbaa`,
+ * `rgb(r, g, b)`, `rgba(r, g, b, a)`, `hsl(h, s%, l%)`, `hsla(h, s%, l%, a)`.
+ * All other CSS color syntaxes are treated as opaque with best-effort `'white'` contrast.
+ */
+
+type RgbaComponents = { r: number; g: number; b: number; a: number };
+
+/** Parse a hex, rgb(a), or hsl(a) color string into RGBA components (0–255, alpha 0–1). */
+export function parseColor(input: string): RgbaComponents | null {
+  const trimmed = input.trim().toLowerCase();
+
+  // Hex formats
+  const hexMatch = trimmed.match(/^#([0-9a-f]{3,8})$/);
+  if (hexMatch) {
+    return parseHex(hexMatch[1]!);
+  }
+
+  // rgb / rgba
+  const rgbMatch = trimmed.match(/^rgba?\(\s*([^)]+)\)$/);
+  if (rgbMatch) {
+    return parseRgb(rgbMatch[1]!);
+  }
+
+  // hsl / hsla
+  const hslMatch = trimmed.match(/^hsla?\(\s*([^)]+)\)$/);
+  if (hslMatch) {
+    return parseHsl(hslMatch[1]!);
+  }
+
+  return null;
+}
+
+function parseHex(hex: string): RgbaComponents | null {
+  let r: number, g: number, b: number, a: number;
+
+  if (hex.length === 3) {
+    r = parseInt((hex[0] ?? '') + (hex[0] ?? ''), 16);
+    g = parseInt((hex[1] ?? '') + (hex[1] ?? ''), 16);
+    b = parseInt((hex[2] ?? '') + (hex[2] ?? ''), 16);
+    a = 1;
+  } else if (hex.length === 4) {
+    r = parseInt((hex[0] ?? '') + (hex[0] ?? ''), 16);
+    g = parseInt((hex[1] ?? '') + (hex[1] ?? ''), 16);
+    b = parseInt((hex[2] ?? '') + (hex[2] ?? ''), 16);
+    a = parseInt((hex[3] ?? '') + (hex[3] ?? ''), 16) / 255;
+  } else if (hex.length === 6) {
+    r = parseInt(hex.slice(0, 2), 16);
+    g = parseInt(hex.slice(2, 4), 16);
+    b = parseInt(hex.slice(4, 6), 16);
+    a = 1;
+  } else if (hex.length === 8) {
+    r = parseInt(hex.slice(0, 2), 16);
+    g = parseInt(hex.slice(2, 4), 16);
+    b = parseInt(hex.slice(4, 6), 16);
+    a = parseInt(hex.slice(6, 8), 16) / 255;
+  } else {
+    return null;
+  }
+
+  return { r, g, b, a };
+}
+
+function parseChannelValue(raw: string): number {
+  const trimmed = raw.trim();
+  if (trimmed.endsWith('%')) {
+    return (parseFloat(trimmed) / 100) * 255;
+  }
+  return parseFloat(trimmed);
+}
+
+function parseAlphaValue(raw: string): number {
+  const trimmed = raw.trim();
+  if (trimmed.endsWith('%')) {
+    return parseFloat(trimmed) / 100;
+  }
+  return parseFloat(trimmed);
+}
+
+function parseRgb(inner: string): RgbaComponents | null {
+  const parts = inner.split(',').map((p) => p.trim());
+  if (parts.length < 3 || parts.length > 4) return null;
+
+  const p0 = parts[0] ?? '';
+  const p1 = parts[1] ?? '';
+  const p2 = parts[2] ?? '';
+  const r = parseChannelValue(p0);
+  const g = parseChannelValue(p1);
+  const b = parseChannelValue(p2);
+  const a = parts.length === 4 ? parseAlphaValue(parts[3] ?? '') : 1;
+
+  if ([r, g, b, a].some(isNaN)) return null;
+  return { r, g, b, a };
+}
+
+function hslToRgb(h: number, s: number, l: number): { r: number; g: number; b: number } {
+  // Wrap hue to [0, 360)
+  h = ((h % 360) + 360) % 360;
+  // Clamp s and l to [0, 1]
+  s = Math.max(0, Math.min(1, s));
+  l = Math.max(0, Math.min(1, l));
+
+  if (s === 0) {
+    const v = Math.round(l * 255);
+    return { r: v, g: v, b: v };
+  }
+
+  const c = (1 - Math.abs(2 * l - 1)) * s;
+  const x = c * (1 - Math.abs(((h / 60) % 2) - 1));
+  const m = l - c / 2;
+
+  let rp = 0,
+    gp = 0,
+    bp = 0;
+  if (h < 60) {
+    rp = c;
+    gp = x;
+    bp = 0;
+  } else if (h < 120) {
+    rp = x;
+    gp = c;
+    bp = 0;
+  } else if (h < 180) {
+    rp = 0;
+    gp = c;
+    bp = x;
+  } else if (h < 240) {
+    rp = 0;
+    gp = x;
+    bp = c;
+  } else if (h < 300) {
+    rp = x;
+    gp = 0;
+    bp = c;
+  } else {
+    rp = c;
+    gp = 0;
+    bp = x;
+  }
+
+  return {
+    r: Math.round((rp + m) * 255),
+    g: Math.round((gp + m) * 255),
+    b: Math.round((bp + m) * 255),
+  };
+}
+
+function parseHsl(inner: string): RgbaComponents | null {
+  const parts = inner.split(',').map((p) => p.trim());
+  if (parts.length < 3 || parts.length > 4) return null;
+
+  const p0 = parts[0] ?? '';
+  const p1 = parts[1] ?? '';
+  const p2 = parts[2] ?? '';
+  const h = parseFloat(p0); // unitless degrees
+  const sPct = p1.endsWith('%') ? parseFloat(p1) : NaN;
+  const lPct = p2.endsWith('%') ? parseFloat(p2) : NaN;
+  const a = parts.length === 4 ? parseAlphaValue(parts[3] ?? '') : 1;
+
+  if ([h, sPct, lPct, a].some(isNaN)) return null;
+
+  const { r, g, b } = hslToRgb(h, sPct / 100, lPct / 100);
+  return { r, g, b, a };
+}
+
+/**
+ * Return true when the color has a non-opaque alpha channel.
+ * Supports: `#rgba`, `#rrggbbaa`, `rgba(...)`, `hsla(...)`.
+ * Any unsupported format returns false (treated as opaque).
+ */
+export function hasAlpha(input: string): boolean {
+  const parsed = parseColor(input);
+  if (!parsed) return false;
+  return parsed.a < 1;
+}
+
+/** Linearize a single sRGB channel (0–255) per WCAG 2.x. */
+function linearize(channel: number): number {
+  const cs = channel / 255;
+  return cs <= 0.04045 ? cs / 12.92 : ((cs + 0.055) / 1.055) ** 2.4;
+}
+
+/**
+ * Compute WCAG 2.x relative luminance from an RGB triple (channels 0–255).
+ * https://www.w3.org/TR/WCAG21/#dfn-relative-luminance
+ */
+export function relativeLuminance({ r, g, b }: { r: number; g: number; b: number }): number {
+  return 0.2126 * linearize(r) + 0.7152 * linearize(g) + 0.0722 * linearize(b);
+}
+
+/**
+ * Return `'black'` or `'white'` — whichever has higher WCAG contrast ratio against
+ * the given color. Falls back to `'white'` when the color cannot be parsed.
+ *
+ * Alpha is ignored: the indicator color is chosen against the swatch's intended
+ * solid color, not its composite with whatever surface sits behind it.
+ */
+export function pickContrastColor(input: string): 'black' | 'white' {
+  const parsed = parseColor(input);
+  if (!parsed) return 'white';
+
+  const L = relativeLuminance(parsed);
+  // WCAG contrast ratio against black (L2=0) and white (L2=1)
+  const contrastBlack = (L + 0.05) / 0.05;
+  const contrastWhite = 1.05 / (L + 0.05);
+  return contrastBlack >= contrastWhite ? 'black' : 'white';
+}

--- a/packages/components/src/utilities/color-luminance.ts
+++ b/packages/components/src/utilities/color-luminance.ts
@@ -65,21 +65,27 @@ function parseHex(hex: string): RgbaComponents | null {
 
 function parseChannelValue(raw: string): number {
   const trimmed = raw.trim();
+  // Reject slash-alpha syntax (e.g. "255 / 50%") — we only support comma-separated legacy syntax
+  if (trimmed.includes('/')) return NaN;
   if (trimmed.endsWith('%')) {
-    return (parseFloat(trimmed) / 100) * 255;
+    return Math.max(0, Math.min(255, (parseFloat(trimmed) / 100) * 255));
   }
-  return parseFloat(trimmed);
+  return Math.max(0, Math.min(255, parseFloat(trimmed)));
 }
 
 function parseAlphaValue(raw: string): number {
   const trimmed = raw.trim();
+  // Reject slash-alpha syntax
+  if (trimmed.includes('/')) return NaN;
   if (trimmed.endsWith('%')) {
-    return parseFloat(trimmed) / 100;
+    return Math.max(0, Math.min(1, parseFloat(trimmed) / 100));
   }
-  return parseFloat(trimmed);
+  return Math.max(0, Math.min(1, parseFloat(trimmed)));
 }
 
 function parseRgb(inner: string): RgbaComponents | null {
+  // Reject modern slash-alpha syntax (e.g. "rgb(255 0 0 / 50%)")
+  if (inner.includes('/')) return null;
   const parts = inner.split(',').map((p) => p.trim());
   if (parts.length < 3 || parts.length > 4) return null;
 
@@ -148,6 +154,8 @@ function hslToRgb(h: number, s: number, l: number): { r: number; g: number; b: n
 }
 
 function parseHsl(inner: string): RgbaComponents | null {
+  // Reject modern slash-alpha syntax (e.g. "hsl(0 100% 50% / 50%)")
+  if (inner.includes('/')) return null;
   const parts = inner.split(',').map((p) => p.trim());
   if (parts.length < 3 || parts.length > 4) return null;
 


### PR DESCRIPTION
## Summary
Round-2 committee review feedback is addressed for `ColorSwatchPicker` focus/selection/disabled behavior.

- Fixes keyboard navigation focus to always move DOM focus to the resolved destination index.
- Propagates group `aria-disabled` state from listbox to each option.
- Adds Windows High Contrast focus ring fallback for non-visible shadow focus styles.
- Ensures disabled cursors are applied consistently at both option and group levels.
- Adds controlled-value rerender coverage and explicit assertions that programmatic value updates do not trigger `onchange`.
- Adds navigation-then-activation coverage for Enter/Space keyboard paths.

## Review committee
Pre-reviewed by: @typescript-expert, @testing-expert, @ux-designer, @simplicity-engineer, @junior-engineer, Codex (gpt-5.4, xhigh reasoning)
- 2 rounds of review
- All previous must-fix items in the round-2 scope are addressed

## Test plan
- `git diff $(git merge-base HEAD main)..HEAD`
- `git diff --stat $(git merge-base HEAD main)..HEAD`
- `bun test packages/components/src/components/color-swatch-picker.test.ts`
- `bun run lint -- packages/components/src/components/color-swatch-picker.svelte packages/components/src/components/color-swatch-picker.test.ts packages/components/src/styles/components/color-swatch-picker.css`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new exported UI component plus new color-parsing/luminance logic; primary risk is behavioral/a11y regressions in keyboard focus/disabled handling and edge cases in color parsing.
> 
> **Overview**
> Adds a new `ColorSwatchPicker` component exported from `cinder` (and `package.json` subpath export), including keyboard roving-tabindex navigation, explicit selection via Enter/Space, per-option and group disabled semantics, and an overridable selection indicator.
> 
> Adds styling for swatch size/shape/layout, alpha checkerboard rendering, reduced-motion-gated hover/focus scaling, and a forced-colors focus-ring fallback.
> 
> Introduces `color-luminance` utilities (parse/alpha detection/relative luminance/contrast picking) and comprehensive tests for the component’s focus/selection/disabled behavior and the new color utilities.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 883aa25b92de3a874d646249de8d06922d3c47cb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->