### PR TITLE
feat(components): add ConfirmDialog as opinionated Modal preset for destructive-action confirmations

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -77,10 +77,6 @@
       "svelte": "./src/components/combobox.svelte",
       "types": "./dist/components/combobox.svelte.d.ts"
     },
-    "./confirm-dialog": {
-      "svelte": "./src/components/confirm-dialog.svelte",
-      "types": "./dist/components/confirm-dialog.svelte.d.ts"
-    },
     "./command-item": {
       "svelte": "./src/components/command-item.svelte",
       "types": "./dist/components/command-item.svelte.d.ts"
@@ -88,6 +84,10 @@
     "./command-palette": {
       "svelte": "./src/components/command-palette.svelte",
       "types": "./dist/components/command-palette.svelte.d.ts"
+    },
+    "./confirm-dialog": {
+      "svelte": "./src/components/confirm-dialog.svelte",
+      "types": "./dist/components/confirm-dialog.svelte.d.ts"
     },
     "./copy-button": {
       "svelte": "./src/components/copy-button.svelte",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -77,6 +77,10 @@
       "svelte": "./src/components/combobox.svelte",
       "types": "./dist/components/combobox.svelte.d.ts"
     },
+    "./confirm-dialog": {
+      "svelte": "./src/components/confirm-dialog.svelte",
+      "types": "./dist/components/confirm-dialog.svelte.d.ts"
+    },
     "./command-item": {
       "svelte": "./src/components/command-item.svelte",
       "types": "./dist/components/command-item.svelte.d.ts"

--- a/packages/components/src/components/confirm-dialog.a11y.md
+++ b/packages/components/src/components/confirm-dialog.a11y.md
@@ -19,11 +19,11 @@ This is the industry-standard guard against accidental destructive confirms:
 
 - macOS NSAlert defaults focus to the non-destructive button.
 - GNOME HIG and APG's confirmation pattern example both default to cancel.
-- WCAG 3.2.1 is satisfied — focus is moved by the dialog opening, not by user input.
+- [WCAG 3.2.1](https://www.w3.org/WAI/WCAG22/Understanding/focus-order.html) is satisfied—focus is moved by the dialog opening, not by user input.
 
 The confirm button never carries `autofocus`. `ConfirmDialog` exposes no prop to change the default focus target — consumers who need a different focus default should compose `<Modal>` + `<Button>` directly.
 
-**Color is never the sole destructive signal.** `destructive={true}` changes the confirm button to `variant="danger"`. The cancel button still receives default focus. The `confirmLabel` prop is required so consumers must name the action being confirmed ("Delete account", "Discard changes") — generic labels like "OK" or "Confirm" are explicitly disallowed.
+**Color is never the sole destructive signal.** `destructive={true}` changes the confirm button to `variant="danger"`. The cancel button still receives default focus. The `confirmLabel` prop is required so consumers must name the action being confirmed ("Delete account", "Discard changes")—generic labels like "OK" or "Confirm" are explicitly disallowed.
 
 ## Keyboard Interactions
 

--- a/packages/components/src/components/confirm-dialog.a11y.md
+++ b/packages/components/src/components/confirm-dialog.a11y.md
@@ -1,0 +1,68 @@
+# ConfirmDialog Accessibility
+
+## Role Inheritance
+
+`ConfirmDialog` has no own `role`. It inherits `role="dialog"` and `aria-modal="true"` from the underlying `<Modal>`. The `dialog` role is used intentionally — not `alertdialog`. `alertdialog` is reserved for assertive, time-sensitive interruptions (system errors, process failures); user-initiated confirmation prompts are non-urgent. Consumers who need `alertdialog` for a confirm triggered by an out-of-band system event should compose `<Modal>` directly.
+
+## ARIA Attributes
+
+- **`aria-labelledby`**: Inherited from `<Modal>`; points at the `<h2>` title element. The title is the confirm dialog's accessible name, announced when the dialog opens.
+- **`aria-describedby`**: When `description` is provided, `<dialog>` gets `aria-describedby` referencing the `<p>` in the modal body. Screen readers announce the description immediately after the title on open. When `description` is omitted, no `aria-describedby` is set — the attribute is never emitted as an empty string.
+
+**Description constraint**: `aria-describedby` works best with short, plain text. Screen readers announce the entire referenced text as one continuous run — a paragraph plus a list would be announced as an unbroken blob. For rich body content (markup, lists, multiple paragraphs), compose `<Modal>` + `<Button>` directly instead.
+
+## Default Focus
+
+The cancel button carries the `autofocus` attribute. When the dialog opens, `<Modal>` detects the `[autofocus]` child and defers its body-container fallback, letting the browser move focus to the cancel button.
+
+This is the industry-standard guard against accidental destructive confirms:
+
+- macOS NSAlert defaults focus to the non-destructive button.
+- GNOME HIG and APG's confirmation pattern example both default to cancel.
+- WCAG 3.2.1 is satisfied — focus is moved by the dialog opening, not by user input.
+
+The confirm button never carries `autofocus`. `ConfirmDialog` exposes no prop to change the default focus target — consumers who need a different focus default should compose `<Modal>` + `<Button>` directly.
+
+**Color is never the sole destructive signal.** `destructive={true}` changes the confirm button to `variant="danger"`. The cancel button still receives default focus. The `confirmLabel` prop is required so consumers must name the action being confirmed ("Delete account", "Discard changes") — generic labels like "OK" or "Confirm" are explicitly disallowed.
+
+## Keyboard Interactions
+
+| Key                     | Behaviour                                                                                                                            |
+| ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
+| Tab / Shift+Tab         | Cycles focus through focusable elements inside the dialog. Focus trap is inherited from `<Modal>` via native `<dialog>.showModal()`. |
+| Escape                  | Closes the dialog and fires `oncancel` via Modal's native `cancel` event handler.                                                    |
+| Enter on cancel button  | Dismisses without confirming.                                                                                                        |
+| Enter on confirm button | Confirms the action and closes the dialog.                                                                                           |
+
+## Cancellation Paths
+
+`oncancel` fires on all four user-initiated dismissal paths:
+
+1. **Cancel button click** (button owned by `ConfirmDialog`).
+2. **Escape key** — via the native `cancel` event on `<dialog>`, routed through Modal's `ondismiss`.
+3. **Backdrop click** — routed through Modal's `ondismiss`.
+4. **Close-X button** — routed through Modal's `ondismiss`.
+
+Parent-driven `open = false` does **not** fire `oncancel`.
+
+## Focus Return
+
+Inherited from `<Modal>`. When the dialog closes, focus is restored to `triggerRef` if provided, otherwise to the element that held focus when the dialog opened.
+
+## Screen Reader Announcements
+
+On open, supporting screen readers announce:
+
+1. The dialog role (`dialog`).
+2. The accessible name (from `aria-labelledby`, the title).
+3. When `description` is provided: the description text (from `aria-describedby`).
+
+## Label Guidelines
+
+`confirmLabel` is required. The component is scoped to action confirmation; making the label required forces consumers to name the specific action rather than ship a generic affirmative:
+
+- **Destructive**: "Delete", "Delete account", "Discard changes", "Remove from organization".
+- **Non-destructive**: "Save", "Save changes", "Continue", "Publish".
+- **Never in production**: "OK", "Confirm", "Yes" — these don't communicate what will happen.
+
+If a truly generic affirmative is required, compose `<Modal>` + `<Button>` directly.

--- a/packages/components/src/components/confirm-dialog.a11y.md
+++ b/packages/components/src/components/confirm-dialog.a11y.md
@@ -19,7 +19,7 @@ This is the industry-standard guard against accidental destructive confirms:
 
 - macOS NSAlert defaults focus to the non-destructive button.
 - GNOME HIG and APG's confirmation pattern example both default to cancel.
-- [WCAG 3.2.1](https://www.w3.org/WAI/WCAG22/Understanding/focus-order.html) is satisfied—focus is moved by the dialog opening, not by user input.
+- [WCAG 3.2.1](https://www.w3.org/WAI/WCAG22/Understanding/on-focus.html) is satisfied—focus is moved by the dialog opening, not by user input.
 
 The confirm button never carries `autofocus`. `ConfirmDialog` exposes no prop to change the default focus target — consumers who need a different focus default should compose `<Modal>` + `<Button>` directly.
 

--- a/packages/components/src/components/confirm-dialog.svelte
+++ b/packages/components/src/components/confirm-dialog.svelte
@@ -1,0 +1,110 @@
+<script lang="ts" module>
+  /**
+   * A thin opinionated preset over `<Modal>` for destructive-action confirmations.
+   *
+   * Composes `<Modal>` + two `<Button>`s. Does not open its own `<dialog>` or manage
+   * its own focus trap — all of that is owned by `<Modal>`.
+   *
+   * Default focus lands on the **cancel** button (`autofocus`) — the industry-standard
+   * guard against accidental destructive confirms.
+   *
+   * For richer body content (markup, lists, multi-paragraph text), compose `<Modal>` +
+   * `<Button>` directly. `aria-describedby` works best with short, plain-text descriptions.
+   */
+  export type ConfirmDialogProps = {
+    /** Controls visibility. Bindable. */
+    open: boolean;
+    /** Modal title; passed through to <Modal>. */
+    title: string;
+    /**
+     * Optional body description — short, plain text only. Rendered as a single <p> and wired
+     * to aria-describedby. For rich content (markup, lists, multiple paragraphs), compose
+     * <Modal> + <Button> directly — screen readers announce aria-describedby targets as one
+     * continuous run.
+     */
+    description?: string;
+    /** Cancel button label. Defaults to "Cancel". */
+    cancelLabel?: string;
+    /**
+     * Confirm button label. Required — no default. Name the action being confirmed:
+     * - Destructive: "Delete", "Discard changes", "Remove from organization".
+     * - Non-destructive: "Save", "Continue", "Publish".
+     * Never use "OK" or "Confirm" in production — they don't describe the action.
+     */
+    confirmLabel: string;
+    /**
+     * When true, the confirm button uses variant="danger". The cancel button still
+     * receives default focus regardless — color is never the sole destructive signal.
+     */
+    destructive?: boolean;
+    /** Fired when the user activates the confirm button. Required. Component closes itself after. */
+    onconfirm: () => void;
+    /**
+     * Fired when the user cancels via ANY dismissal affordance — cancel button, Escape,
+     * backdrop click, or the close-X button. Optional.
+     * Parent-driven `open = false` does NOT fire this callback.
+     * Callbacks are not awaited; thrown callbacks do not block close.
+     */
+    oncancel?: () => void;
+    /** Forwarded to <Modal>; focus is restored here on close. */
+    triggerRef?: HTMLElement | null;
+    /** Optional extra class on the underlying <Modal>. Destructured as `class: className` per repo convention. */
+    class?: string;
+  };
+</script>
+
+<script lang="ts">
+  import Button from './button.svelte';
+  import Modal from './modal.svelte';
+  import { cn } from '../utilities/class-names.ts';
+  import { useId } from '../utilities/use-id.ts';
+
+  let {
+    open = $bindable(false),
+    title,
+    description,
+    cancelLabel = 'Cancel',
+    confirmLabel,
+    destructive = false,
+    onconfirm,
+    oncancel,
+    triggerRef = null,
+    class: className,
+  }: ConfirmDialogProps = $props();
+
+  const descriptionId = useId('cinder-confirm-dialog-description');
+  const describedById = $derived(description ? descriptionId : undefined);
+
+  function handleCancel() {
+    // Mirror Modal's dismiss() ordering: state first, then callback. No try/catch —
+    // consumer errors must propagate so tests, error boundaries, and observability see them.
+    open = false;
+    oncancel?.();
+  }
+
+  function handleConfirm() {
+    // Same ordering and error policy: close first, fire callback, let errors propagate.
+    open = false;
+    onconfirm();
+  }
+</script>
+
+<Modal
+  bind:open
+  {title}
+  {triggerRef}
+  class={cn('cinder-confirm-dialog', className)}
+  {...describedById ? { describedById } : {}}
+  {...oncancel ? { ondismiss: oncancel } : {}}
+>
+  {#if description}
+    <p id={descriptionId} class="cinder-confirm-dialog__description">{description}</p>
+  {/if}
+
+  {#snippet footer()}
+    <Button variant="secondary" autofocus onclick={handleCancel}>{cancelLabel}</Button>
+    <Button variant={destructive ? 'danger' : 'primary'} onclick={handleConfirm}
+      >{confirmLabel}</Button
+    >
+  {/snippet}
+</Modal>

--- a/packages/components/src/components/confirm-dialog.test.ts
+++ b/packages/components/src/components/confirm-dialog.test.ts
@@ -1,0 +1,465 @@
+/// <reference lib="dom" />
+import { describe, expect, test } from 'bun:test';
+
+import { setupHappyDom } from '../test/happy-dom.ts';
+
+setupHappyDom();
+
+// happy-dom does not implement HTMLDialogElement.showModal / close — stub them
+// so the $effect inside modal.svelte doesn't throw when open=true.
+if (typeof HTMLDialogElement !== 'undefined') {
+  if (!HTMLDialogElement.prototype.showModal) {
+    Object.defineProperty(HTMLDialogElement.prototype, 'showModal', {
+      value: function () {
+        this.setAttribute('open', '');
+      },
+      configurable: true,
+      writable: true,
+    });
+  }
+  if (!HTMLDialogElement.prototype.close) {
+    Object.defineProperty(HTMLDialogElement.prototype, 'close', {
+      value: function () {
+        this.removeAttribute('open');
+      },
+      configurable: true,
+      writable: true,
+    });
+  }
+}
+
+const { render, fireEvent } = await import('@testing-library/svelte');
+const { tick } = await import('svelte');
+const { default: ConfirmDialog } = await import('./confirm-dialog.svelte');
+
+// Helpers to locate buttons inside the footer without repeated null-checks.
+// Test files may use non-null assertions per CLAUDE.md — test code accepts `any` and `!`.
+function footerButtons(container: HTMLElement): [HTMLButtonElement, HTMLButtonElement] {
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+  const footer = container.querySelector('.cinder-modal__footer')!;
+  const btns = footer.querySelectorAll('button');
+  return [btns[0] as HTMLButtonElement, btns[1] as HTMLButtonElement];
+}
+
+describe('ConfirmDialog', () => {
+  test('renders closed by default — no panel content when open=false', () => {
+    const { container } = render(ConfirmDialog, {
+      props: {
+        open: false,
+        title: 'Delete account?',
+        confirmLabel: 'Delete',
+        onconfirm: () => {},
+      },
+    });
+    // Dialog element is present (mounted) but panel content is absent when closed
+    expect(container.querySelector('.cinder-modal__panel')).toBeNull();
+  });
+
+  test('renders open with title and inherits aria-labelledby', () => {
+    const { container } = render(ConfirmDialog, {
+      props: {
+        open: true,
+        title: 'Delete account?',
+        confirmLabel: 'Delete',
+        onconfirm: () => {},
+      },
+    });
+    const dialog = container.querySelector('dialog');
+    expect(dialog).not.toBeNull();
+    expect(dialog?.getAttribute('aria-labelledby')).not.toBeNull();
+    expect(container.querySelector('.cinder-modal__title')?.textContent).toContain(
+      'Delete account?',
+    );
+  });
+
+  test('description wires aria-describedby to the <p> element', () => {
+    const { container } = render(ConfirmDialog, {
+      props: {
+        open: true,
+        title: 'Delete account?',
+        description: 'This cannot be undone.',
+        confirmLabel: 'Delete',
+        onconfirm: () => {},
+      },
+    });
+    const dialog = container.querySelector('dialog') as HTMLDialogElement;
+    const descriptionParagraph = container.querySelector(
+      '.cinder-confirm-dialog__description',
+    ) as HTMLElement;
+    expect(descriptionParagraph).not.toBeNull();
+    expect(descriptionParagraph.textContent).toContain('This cannot be undone.');
+    const describedById = dialog.getAttribute('aria-describedby');
+    expect(describedById).not.toBeNull();
+    // Both reference the same ID — description paragraph's id matches aria-describedby.
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    expect(descriptionParagraph.id).toBe(describedById!);
+  });
+
+  test('aria-describedby is absent when description is omitted', () => {
+    const { container } = render(ConfirmDialog, {
+      props: {
+        open: true,
+        title: 'Delete account?',
+        confirmLabel: 'Delete',
+        onconfirm: () => {},
+      },
+    });
+    const dialog = container.querySelector('dialog');
+    expect(dialog?.hasAttribute('aria-describedby')).toBe(false);
+  });
+
+  test('cancel button carries autofocus; confirm button does not', () => {
+    const { container } = render(ConfirmDialog, {
+      props: {
+        open: true,
+        title: 'Delete account?',
+        cancelLabel: 'Cancel',
+        confirmLabel: 'Delete',
+        onconfirm: () => {},
+      },
+    });
+    const [cancelBtn, confirmBtn] = footerButtons(container);
+    // Cancel is first, confirm is second (per plan's footer snippet ordering).
+    // Svelte 5 processes autofocus as a DOM property (not an HTML attribute) via $.autofocus(),
+    // so we check the .autofocus property rather than hasAttribute().
+    expect(cancelBtn.autofocus).toBe(true);
+    expect(confirmBtn.autofocus).toBeFalsy();
+  });
+
+  test('destructive=true applies danger variant to the confirm button', () => {
+    const { container } = render(ConfirmDialog, {
+      props: {
+        open: true,
+        title: 'Delete account?',
+        confirmLabel: 'Delete',
+        destructive: true,
+        onconfirm: () => {},
+      },
+    });
+    const [, confirmBtn] = footerButtons(container);
+    expect(confirmBtn.getAttribute('data-cinder-variant')).toBe('danger');
+  });
+
+  test('destructive=false uses primary variant for the confirm button', () => {
+    const { container } = render(ConfirmDialog, {
+      props: {
+        open: true,
+        title: 'Save changes?',
+        confirmLabel: 'Save',
+        destructive: false,
+        onconfirm: () => {},
+      },
+    });
+    const [, confirmBtn] = footerButtons(container);
+    expect(confirmBtn.getAttribute('data-cinder-variant')).toBe('primary');
+  });
+
+  test('onconfirm fires and dialog closes when confirm is clicked', async () => {
+    let confirmCount = 0;
+    let cancelCount = 0;
+    let openValue = true;
+    const { container } = render(ConfirmDialog, {
+      props: {
+        get open() {
+          return openValue;
+        },
+        set open(value: boolean) {
+          openValue = value;
+        },
+        title: 'Delete account?',
+        confirmLabel: 'Delete',
+        onconfirm: () => {
+          confirmCount++;
+        },
+        oncancel: () => {
+          cancelCount++;
+        },
+      },
+    });
+    const [, confirmBtn] = footerButtons(container);
+    await fireEvent.click(confirmBtn);
+    expect(confirmCount).toBe(1);
+    expect(cancelCount).toBe(0);
+    expect(openValue).toBe(false);
+  });
+
+  test('oncancel fires and dialog closes when cancel button is clicked', async () => {
+    let confirmCount = 0;
+    let cancelCount = 0;
+    let openValue = true;
+    const { container } = render(ConfirmDialog, {
+      props: {
+        get open() {
+          return openValue;
+        },
+        set open(value: boolean) {
+          openValue = value;
+        },
+        title: 'Delete account?',
+        confirmLabel: 'Delete',
+        onconfirm: () => {
+          confirmCount++;
+        },
+        oncancel: () => {
+          cancelCount++;
+        },
+      },
+    });
+    const [cancelBtn] = footerButtons(container);
+    await fireEvent.click(cancelBtn);
+    expect(cancelCount).toBe(1);
+    expect(confirmCount).toBe(0);
+    expect(openValue).toBe(false);
+  });
+
+  test('oncancel fires on Escape (native cancel event on dialog)', async () => {
+    let cancelCount = 0;
+    let openValue = true;
+    const { container } = render(ConfirmDialog, {
+      props: {
+        get open() {
+          return openValue;
+        },
+        set open(value: boolean) {
+          openValue = value;
+        },
+        title: 'Delete account?',
+        confirmLabel: 'Delete',
+        onconfirm: () => {},
+        oncancel: () => {
+          cancelCount++;
+        },
+      },
+    });
+    const dialog = container.querySelector('dialog') as HTMLDialogElement;
+    const cancelEvent = new Event('cancel', { cancelable: true });
+    await fireEvent(dialog, cancelEvent);
+    await tick();
+    expect(cancelCount).toBe(1);
+    expect(openValue).toBe(false);
+  });
+
+  test('oncancel fires on backdrop click', async () => {
+    let cancelCount = 0;
+    let openValue = true;
+    const { container } = render(ConfirmDialog, {
+      props: {
+        get open() {
+          return openValue;
+        },
+        set open(value: boolean) {
+          openValue = value;
+        },
+        title: 'Delete account?',
+        confirmLabel: 'Delete',
+        onconfirm: () => {},
+        oncancel: () => {
+          cancelCount++;
+        },
+      },
+    });
+    const dialog = container.querySelector('dialog') as HTMLDialogElement;
+    await fireEvent.click(dialog);
+    await tick();
+    expect(cancelCount).toBe(1);
+    expect(openValue).toBe(false);
+  });
+
+  test('oncancel fires when the close-X button is clicked', async () => {
+    let cancelCount = 0;
+    let openValue = true;
+    const { container } = render(ConfirmDialog, {
+      props: {
+        get open() {
+          return openValue;
+        },
+        set open(value: boolean) {
+          openValue = value;
+        },
+        title: 'Delete account?',
+        confirmLabel: 'Delete',
+        onconfirm: () => {},
+        oncancel: () => {
+          cancelCount++;
+        },
+      },
+    });
+    const closeButton = container.querySelector('.cinder-modal__close') as HTMLButtonElement;
+    await fireEvent.click(closeButton);
+    await tick();
+    expect(cancelCount).toBe(1);
+    expect(openValue).toBe(false);
+  });
+
+  test('parent-driven close does NOT fire oncancel', async () => {
+    let cancelCount = 0;
+    const { rerender } = render(ConfirmDialog, {
+      props: {
+        open: true,
+        title: 'Delete account?',
+        confirmLabel: 'Delete',
+        onconfirm: () => {},
+        oncancel: () => {
+          cancelCount++;
+        },
+      },
+    });
+    await rerender({
+      open: false,
+      title: 'Delete account?',
+      confirmLabel: 'Delete',
+      onconfirm: () => {},
+    });
+    expect(cancelCount).toBe(0);
+  });
+
+  test('custom labels render in the DOM', () => {
+    const { container } = render(ConfirmDialog, {
+      props: {
+        open: true,
+        title: 'Discard?',
+        cancelLabel: 'Nope',
+        confirmLabel: 'Burn it',
+        onconfirm: () => {},
+      },
+    });
+    const [cancelBtn, confirmBtn] = footerButtons(container);
+    expect(cancelBtn.textContent?.trim()).toBe('Nope');
+    expect(confirmBtn.textContent?.trim()).toBe('Burn it');
+  });
+
+  test('triggerRef focus restoration — cancel button closes dialog and triggerRef is accepted', async () => {
+    // Focus restoration is owned by Modal's handleClose (fired on the native 'close' event).
+    // happy-dom's dialog polyfill does not fire 'close' natively, so we verify the observable
+    // contract we own: that clicking cancel sets open=false. Full focus-restore coverage is
+    // Modal's responsibility and is covered by existing modal.test.ts tests.
+    const trigger = document.createElement('button');
+    trigger.textContent = 'Open dialog';
+    document.body.appendChild(trigger);
+
+    let openValue = true;
+    const { container } = render(ConfirmDialog, {
+      props: {
+        get open() {
+          return openValue;
+        },
+        set open(value: boolean) {
+          openValue = value;
+        },
+        title: 'Delete account?',
+        confirmLabel: 'Delete',
+        onconfirm: () => {},
+        triggerRef: trigger,
+      },
+    });
+
+    const [cancelBtn] = footerButtons(container);
+    await fireEvent.click(cancelBtn);
+    await tick();
+    expect(openValue).toBe(false);
+
+    document.body.removeChild(trigger);
+  });
+
+  test('reopen after cancel/confirm cycle — cancel button still has autofocus', async () => {
+    let openValue = true;
+    const { container, rerender } = render(ConfirmDialog, {
+      props: {
+        get open() {
+          return openValue;
+        },
+        set open(value: boolean) {
+          openValue = value;
+        },
+        title: 'Delete account?',
+        confirmLabel: 'Delete',
+        onconfirm: () => {},
+      },
+    });
+
+    const [cancelBtn] = footerButtons(container);
+    await fireEvent.click(cancelBtn); // cancel → closes
+
+    openValue = true;
+    await rerender({
+      open: true,
+      title: 'Delete account?',
+      confirmLabel: 'Delete',
+      onconfirm: () => {},
+    });
+
+    const [reopenedCancelBtn] = footerButtons(container);
+    expect(reopenedCancelBtn.autofocus).toBe(true);
+  });
+
+  test('omitting optional oncancel does not throw when cancel is clicked', async () => {
+    let openValue = true;
+    const { container } = render(ConfirmDialog, {
+      props: {
+        get open() {
+          return openValue;
+        },
+        set open(value: boolean) {
+          openValue = value;
+        },
+        title: 'Delete account?',
+        confirmLabel: 'Delete',
+        onconfirm: () => {},
+        // oncancel intentionally omitted
+      },
+    });
+    const [cancelBtn] = footerButtons(container);
+    expect(async () => await fireEvent.click(cancelBtn)).not.toThrow();
+    expect(openValue).toBe(false);
+  });
+
+  test('thrown onconfirm does not block close — open is false after throw', async () => {
+    // Behavioral assertion: open flips to false BEFORE the callback fires, so a thrown
+    // callback cannot leave the dialog stuck open. fireEvent swallows handler errors
+    // internally, so we assert the state side-effect rather than the throw itself.
+    let openValue = true;
+    const { container } = render(ConfirmDialog, {
+      props: {
+        get open() {
+          return openValue;
+        },
+        set open(value: boolean) {
+          openValue = value;
+        },
+        title: 'Delete account?',
+        confirmLabel: 'Delete',
+        onconfirm: () => {
+          throw new Error('confirm error');
+        },
+      },
+    });
+    const [, confirmBtn] = footerButtons(container);
+    await fireEvent.click(confirmBtn);
+    // open flipped to false before the callback ran, so the throw doesn't leave dialog stuck
+    expect(openValue).toBe(false);
+  });
+
+  test('thrown oncancel does not block close — open is false after throw', async () => {
+    // Same behavioral contract as the onconfirm throw test above.
+    let openValue = true;
+    const { container } = render(ConfirmDialog, {
+      props: {
+        get open() {
+          return openValue;
+        },
+        set open(value: boolean) {
+          openValue = value;
+        },
+        title: 'Delete account?',
+        confirmLabel: 'Delete',
+        onconfirm: () => {},
+        oncancel: () => {
+          throw new Error('cancel error');
+        },
+      },
+    });
+    const [cancelBtn] = footerButtons(container);
+    await fireEvent.click(cancelBtn);
+    expect(openValue).toBe(false);
+  });
+});

--- a/packages/components/src/components/confirm-dialog.test.ts
+++ b/packages/components/src/components/confirm-dialog.test.ts
@@ -409,7 +409,9 @@ describe('ConfirmDialog', () => {
       },
     });
     const [cancelBtn] = footerButtons(container);
-    expect(async () => await fireEvent.click(cancelBtn)).not.toThrow();
+    // Directly await the click — if it threw synchronously the test would fail.
+    // Then assert the state side-effect: dialog closed without error.
+    await fireEvent.click(cancelBtn);
     expect(openValue).toBe(false);
   });
 

--- a/packages/components/src/components/confirm-dialog.test.ts
+++ b/packages/components/src/components/confirm-dialog.test.ts
@@ -32,13 +32,24 @@ const { render, fireEvent } = await import('@testing-library/svelte');
 const { tick } = await import('svelte');
 const { default: ConfirmDialog } = await import('./confirm-dialog.svelte');
 
-// Helpers to locate buttons inside the footer without repeated null-checks.
-// Test files may use non-null assertions per CLAUDE.md — test code accepts `any` and `!`.
 function footerButtons(container: HTMLElement): [HTMLButtonElement, HTMLButtonElement] {
-  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-  const footer = container.querySelector('.cinder-modal__footer')!;
-  const btns = footer.querySelectorAll('button');
-  return [btns[0] as HTMLButtonElement, btns[1] as HTMLButtonElement];
+  const footer = container.querySelector('.cinder-modal__footer');
+  if (!(footer instanceof HTMLElement)) {
+    throw new Error('Expected ConfirmDialog to render a modal footer.');
+  }
+
+  const buttons = Array.from(footer.querySelectorAll('button'));
+  if (buttons.length !== 2) {
+    throw new Error(`Expected ConfirmDialog footer to render 2 buttons, found ${buttons.length}.`);
+  }
+
+  const cancelButton = buttons.at(0);
+  const confirmButton = buttons.at(1);
+  if (!cancelButton || !confirmButton) {
+    throw new Error('Expected ConfirmDialog footer buttons to be present.');
+  }
+
+  return [cancelButton, confirmButton];
 }
 
 describe('ConfirmDialog', () => {

--- a/packages/components/src/components/modal.a11y.md
+++ b/packages/components/src/components/modal.a11y.md
@@ -41,6 +41,6 @@ State flips to `open = false` **before** the callback is invoked. A thrown callb
 
 ## Screen Reader Announcements
 
-- Opening a `<dialog>` with `showModal()` causes supporting screen readers (NVDA+Firefox, JAWS+Chrome, VoiceOver+Safari) to announce the dialog role and its accessible name (from `aria-labelledby`) immediately.
+- Opening a `<dialog>` with `showModal()` causes supporting screen readers ([NVDA](https://www.nvaccess.org/)+Firefox, [JAWS](https://www.freedomscientific.com/products/software/jaws/)+Chrome, [VoiceOver](https://www.apple.com/accessibility/vision/)+Safari) to announce the dialog role and its accessible name (from `aria-labelledby`) immediately.
 - When `describedById` is set, the referenced description text is announced immediately after the accessible name.
 - The close button carries `aria-label="Close dialog"` so it reads as "Close dialog, button" rather than the SVG icon content. Clicking the close-X fires `ondismiss`.

--- a/packages/components/src/components/modal.a11y.md
+++ b/packages/components/src/components/modal.a11y.md
@@ -5,25 +5,42 @@
 - The native `<dialog>` element carries an implicit `role="dialog"`.
 - `aria-modal="true"` is set explicitly so screen readers that do not natively understand `<dialog>` know to restrict their virtual browse to the modal's content.
 - `aria-labelledby` points to the `<h2>` title element, giving the dialog an accessible name announced when the dialog opens.
+- **`describedById` prop**: When provided, the value is applied as `aria-describedby` on the underlying `<dialog>`. Pass the `id` of a short, plain-text description element (typically a `<p>` in the modal body). This causes supporting screen readers to announce the description immediately after the dialog role and title. When omitted, no `aria-describedby` attribute is emitted — never pass an empty string. For long or richly structured body content, do not use `describedById`; screen readers announce the entire referenced text as one continuous run.
 
 ## Keyboard Interactions
 
-| Key         | Behaviour                                                                                                                                                                            |
-| ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| Tab         | Cycles focus forward through all focusable elements inside the open dialog. Focus does not leave the dialog while it is open — the native `showModal()` provides this trap for free. |
-| Shift + Tab | Cycles focus backward.                                                                                                                                                               |
-| Escape      | Closes the dialog. The native `<dialog>` fires a `close` event on Escape; the component listens to `onclose` and sets `open = false`.                                                |
+| Key         | Behaviour                                                                                                                                                                                        |
+| ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Tab         | Cycles focus forward through all focusable elements inside the open dialog. Focus does not leave the dialog while it is open — the native `showModal()` provides this trap for free.             |
+| Shift + Tab | Cycles focus backward.                                                                                                                                                                           |
+| Escape      | Fires the native `cancel` event on the `<dialog>`. The component prevents the default and calls the internal `dismiss()` helper, which flips `open = false` and fires `ondismiss` (if provided). |
 
 ## Focus Management
 
-- When the dialog opens, the browser moves focus to the first focusable element inside the dialog (or the dialog itself if none are focusable).
-- When the dialog closes, the implementation does not currently restore focus to the trigger element. The consuming page is responsible for calling `triggerElement.focus()` in the `onclose` callback. A future iteration should accept an optional `triggerRef` prop and restore focus automatically.
+- When the dialog opens, the browser moves focus to the first focusable element with `autofocus`, or to the modal body container (`tabindex="-1"`) if no child carries `autofocus`.
+- When the dialog closes, focus is restored to `triggerRef` if provided, otherwise to the element that held focus when the dialog opened (`capturedFocus`).
+
+## Dismissal Callbacks (`ondismiss`)
+
+The `ondismiss` callback fires on **user-initiated dismissal** only. The three included paths are:
+
+1. **Escape key** — via the native `cancel` event on `<dialog>` (default prevented; routed through `dismiss()`).
+2. **Backdrop click** — a click whose `event.target` is the `<dialog>` element itself.
+3. **Close-X button** — the `×` button in the panel corner.
+
+The following paths do **not** fire `ondismiss`:
+
+- Parent-driven `open = false` (a route change, a completion event, or any external state update setting the prop directly).
+- The confirm-button path in `ConfirmDialog` (that fires `onconfirm`, not `ondismiss`).
+
+State flips to `open = false` **before** the callback is invoked. A thrown callback does not leave the dialog stuck open. Callbacks are not awaited — async/rejected-promise errors are the consumer's responsibility.
 
 ## Backdrop
 
-- Clicking the backdrop (`event.target === dialogElement`) closes the dialog. This relies on the CSS background applied to `<dialog>` rather than `::backdrop`, so the click target is always the `<dialog>` element itself, not a separate pseudo-element.
+- Clicking the backdrop (`event.target === dialogElement`) calls `dismiss()`, which closes the dialog and fires `ondismiss`. This relies on the CSS background applied to `<dialog>` rather than `::backdrop`, so the click target is always the `<dialog>` element itself, not a separate pseudo-element.
 
 ## Screen Reader Announcements
 
 - Opening a `<dialog>` with `showModal()` causes supporting screen readers (NVDA+Firefox, JAWS+Chrome, VoiceOver+Safari) to announce the dialog role and its accessible name (from `aria-labelledby`) immediately.
-- The close button carries `aria-label="Close dialog"` so it reads as "Close dialog, button" rather than the SVG icon content.
+- When `describedById` is set, the referenced description text is announced immediately after the accessible name.
+- The close button carries `aria-label="Close dialog"` so it reads as "Close dialog, button" rather than the SVG icon content. Clicking the close-X fires `ondismiss`.

--- a/packages/components/src/components/modal.svelte
+++ b/packages/components/src/components/modal.svelte
@@ -72,7 +72,7 @@
           dialogElement.querySelectorAll<HTMLElement>(
             'button, input, select, textarea, [tabindex]',
           ),
-        ).some((el) => (el as HTMLElement & { autofocus?: boolean }).autofocus === true);
+        ).some((el) => el.autofocus === true);
       if (!hasExplicitAutofocus && bodyElement) {
         bodyElement.focus();
       }

--- a/packages/components/src/components/modal.svelte
+++ b/packages/components/src/components/modal.svelte
@@ -63,7 +63,16 @@
       //   2. Otherwise, focus the body container (tabindex=-1) so initial focus
       //      lands on meaningful content rather than the close-X button — which
       //      would otherwise be the first sequentially-focusable element.
-      const hasExplicitAutofocus = dialogElement.querySelector('[autofocus]') !== null;
+      // Check both the HTML attribute (set by static markup) and the DOM property
+      // (set by Svelte 5's $.autofocus() helper, which sets element.autofocus = true
+      // rather than the attribute). The attribute selector alone misses the Svelte case.
+      const hasExplicitAutofocus =
+        dialogElement.querySelector('[autofocus]') !== null ||
+        Array.from(
+          dialogElement.querySelectorAll<HTMLElement>(
+            'button, input, select, textarea, [tabindex]',
+          ),
+        ).some((el) => (el as HTMLElement & { autofocus?: boolean }).autofocus === true);
       if (!hasExplicitAutofocus && bodyElement) {
         bodyElement.focus();
       }

--- a/packages/components/src/components/modal.svelte
+++ b/packages/components/src/components/modal.svelte
@@ -8,6 +8,14 @@
     children: Snippet;
     footer?: Snippet;
     triggerRef?: HTMLElement | null;
+    /** When set, applied as aria-describedby on the underlying <dialog>. Pass a short, plain description ID only. */
+    describedById?: string;
+    /**
+     * Fired on user-initiated dismissal. Includes: Escape key (native dialog 'cancel' event),
+     * backdrop click, and the close-X button. EXCLUDES: parent-driven open = false.
+     * Callbacks are not awaited and thrown callbacks do not block close.
+     */
+    ondismiss?: () => void;
   };
 </script>
 
@@ -23,6 +31,8 @@
     children,
     footer,
     triggerRef = null,
+    describedById,
+    ondismiss,
   }: ModalProps = $props();
 
   let dialogElement: HTMLDialogElement | undefined = $state();
@@ -75,16 +85,35 @@
     capturedFocus = null;
   }
 
+  // Single source of truth for all user-initiated dismissal paths: Escape, backdrop click,
+  // and the close-X button. State flips FIRST so a thrown callback does not leave the
+  // dialog open. Callbacks are not awaited; sync throws propagate to the caller.
+  function dismiss() {
+    open = false;
+    ondismiss?.();
+  }
+
   function handleClose() {
+    // Fired on the native 'close' event — may be triggered by dismiss() (via dialogElement.close())
+    // or by parent-driven open = false. Only restores focus; does NOT call ondismiss here
+    // so parent-driven closes do not fire the callback.
     open = false;
     returnFocus();
   }
 
   function handleBackdropClick(event: MouseEvent) {
     if (event.target === dialogElement) {
-      open = false;
-      returnFocus();
+      dismiss();
     }
+  }
+
+  function handleNativeCancel(event: Event) {
+    // Escape key fires the native 'cancel' event on <dialog>. We prevent the default
+    // so the browser doesn't close the dialog through its own mechanism — we route
+    // exclusively through dismiss() → open = false → $effect → dialogElement.close()
+    // → 'close' event → handleClose. This ensures exactly one close path for Escape.
+    event.preventDefault();
+    dismiss();
   }
 </script>
 
@@ -94,8 +123,10 @@
     class={cn('cinder-modal', className)}
     aria-modal="true"
     aria-labelledby={titleId}
+    {...describedById ? { 'aria-describedby': describedById } : {}}
     onclose={handleClose}
     onclick={handleBackdropClick}
+    oncancel={handleNativeCancel}
   >
     {#if open}
       <div class="cinder-modal__panel">
@@ -121,7 +152,7 @@
           type="button"
           class="cinder-modal__close"
           aria-label="Close dialog"
-          onclick={handleClose}
+          onclick={dismiss}
         >
           <svg
             class="cinder-modal__close-icon"

--- a/packages/components/src/components/modal.svelte
+++ b/packages/components/src/components/modal.svelte
@@ -68,11 +68,9 @@
       // rather than the attribute). The attribute selector alone misses the Svelte case.
       const hasExplicitAutofocus =
         dialogElement.querySelector('[autofocus]') !== null ||
-        Array.from(
-          dialogElement.querySelectorAll<HTMLElement>(
-            'button, input, select, textarea, [tabindex]',
-          ),
-        ).some((el) => el.autofocus === true);
+        Array.from(dialogElement.querySelectorAll<HTMLElement>('*')).some(
+          (el) => el.autofocus === true,
+        );
       if (!hasExplicitAutofocus && bodyElement) {
         bodyElement.focus();
       }

--- a/packages/components/src/components/modal.test.ts
+++ b/packages/components/src/components/modal.test.ts
@@ -245,6 +245,37 @@ describe('Modal', () => {
     expect(body?.getAttribute('tabindex')).toBe('-1');
   });
 
+  test('autofocus DOM property on arbitrary child prevents body fallback focus', () => {
+    const originalFocus = HTMLElement.prototype.focus;
+    const focusTargets: HTMLElement[] = [];
+    HTMLElement.prototype.focus = function focus() {
+      focusTargets.push(this);
+      return originalFocus.call(this);
+    };
+
+    try {
+      const children = createRawSnippet(() => ({
+        render: () => `<a href="/target">Autofocus link</a>`,
+        setup: (node: Element) => {
+          (node as HTMLElement).autofocus = true;
+        },
+      }));
+
+      const { container } = render(Modal, {
+        props: {
+          open: true,
+          title: 'Test Modal',
+          children,
+        },
+      });
+
+      const body = container.querySelector('.cinder-modal__body') as HTMLElement;
+      expect(focusTargets).not.toContain(body);
+    } finally {
+      HTMLElement.prototype.focus = originalFocus;
+    }
+  });
+
   test('close button is the last focusable element inside the panel', () => {
     // The close button was deliberately moved to the end of the DOM so the
     // native <dialog>.showModal() autofocus fallback (first focusable) does

--- a/packages/components/src/components/modal.test.ts
+++ b/packages/components/src/components/modal.test.ts
@@ -264,4 +264,163 @@ describe('Modal', () => {
     const last = focusables?.[focusables.length - 1];
     expect(last?.classList.contains('cinder-modal__close')).toBe(true);
   });
+
+  test('describedById sets aria-describedby on the dialog element', () => {
+    const { container } = render(Modal, {
+      props: {
+        open: true,
+        title: 'Test Modal',
+        children: emptySnippet,
+        describedById: 'x-123',
+      },
+    });
+    const dialog = container.querySelector('dialog');
+    expect(dialog?.getAttribute('aria-describedby')).toBe('x-123');
+  });
+
+  test('aria-describedby is absent when describedById is omitted', () => {
+    const { container } = render(Modal, {
+      props: {
+        open: true,
+        title: 'Test Modal',
+        children: emptySnippet,
+      },
+    });
+    const dialog = container.querySelector('dialog');
+    expect(dialog?.hasAttribute('aria-describedby')).toBe(false);
+  });
+
+  test('ondismiss fires when native cancel event is dispatched (Escape)', async () => {
+    let dismissCount = 0;
+    let openValue = true;
+    const { container } = render(Modal, {
+      props: {
+        get open() {
+          return openValue;
+        },
+        set open(value: boolean) {
+          openValue = value;
+        },
+        title: 'Test Modal',
+        children: emptySnippet,
+        ondismiss: () => {
+          dismissCount++;
+        },
+      },
+    });
+    const dialog = container.querySelector('dialog') as HTMLDialogElement;
+    const cancelEvent = new Event('cancel', { cancelable: true });
+    await fireEvent(dialog, cancelEvent);
+    expect(dismissCount).toBe(1);
+    expect(openValue).toBe(false);
+  });
+
+  test('native cancel event is prevented (Escape routes through dismiss())', async () => {
+    const { container } = render(Modal, {
+      props: {
+        open: true,
+        title: 'Test Modal',
+        children: emptySnippet,
+      },
+    });
+    const dialog = container.querySelector('dialog') as HTMLDialogElement;
+    const cancelEvent = new Event('cancel', { cancelable: true });
+    await fireEvent(dialog, cancelEvent);
+    expect(cancelEvent.defaultPrevented).toBe(true);
+  });
+
+  test('ondismiss fires when backdrop is clicked', async () => {
+    let dismissCount = 0;
+    let openValue = true;
+    const { container } = render(Modal, {
+      props: {
+        get open() {
+          return openValue;
+        },
+        set open(value: boolean) {
+          openValue = value;
+        },
+        title: 'Test Modal',
+        children: emptySnippet,
+        ondismiss: () => {
+          dismissCount++;
+        },
+      },
+    });
+    const dialog = container.querySelector('dialog') as HTMLDialogElement;
+    await fireEvent.click(dialog);
+    expect(dismissCount).toBe(1);
+    expect(openValue).toBe(false);
+  });
+
+  test('ondismiss fires when the close-X button is clicked', async () => {
+    let dismissCount = 0;
+    let openValue = true;
+    const { container } = render(Modal, {
+      props: {
+        get open() {
+          return openValue;
+        },
+        set open(value: boolean) {
+          openValue = value;
+        },
+        title: 'Test Modal',
+        children: emptySnippet,
+        ondismiss: () => {
+          dismissCount++;
+        },
+      },
+    });
+    const closeButton = container.querySelector('.cinder-modal__close') as HTMLButtonElement;
+    await fireEvent.click(closeButton);
+    expect(dismissCount).toBe(1);
+    expect(openValue).toBe(false);
+  });
+
+  test('ondismiss does NOT fire when open is set to false by the parent', async () => {
+    let dismissCount = 0;
+    let openValue = true;
+    const { rerender } = render(Modal, {
+      props: {
+        get open() {
+          return openValue;
+        },
+        set open(value: boolean) {
+          openValue = value;
+        },
+        title: 'Test Modal',
+        children: emptySnippet,
+        ondismiss: () => {
+          dismissCount++;
+        },
+      },
+    });
+    // Parent-driven close: update the prop directly
+    await rerender({ open: false, title: 'Test Modal', children: emptySnippet });
+    expect(dismissCount).toBe(0);
+  });
+
+  test('a throwing ondismiss callback propagates the error but open is still false', async () => {
+    let openValue = true;
+    const { container } = render(Modal, {
+      props: {
+        get open() {
+          return openValue;
+        },
+        set open(value: boolean) {
+          openValue = value;
+        },
+        title: 'Test Modal',
+        children: emptySnippet,
+        ondismiss: () => {
+          throw new Error('ondismiss error');
+        },
+      },
+    });
+    const closeButton = container.querySelector('.cinder-modal__close') as HTMLButtonElement;
+    // fireEvent swallows handler errors internally; we assert the state side-effect instead.
+    await fireEvent.click(closeButton);
+    // open flipped to false before the callback ran, so the throw doesn't leave dialog stuck
+    expect(openValue).toBe(false);
+  });
 });

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -40,6 +40,9 @@ export type { CodeBlockProps } from './components/code-block.svelte';
 export { default as ColorSwatchPicker } from './components/color-swatch-picker.svelte';
 export type { ColorSwatch, ColorSwatchPickerProps } from './components/color-swatch-picker.svelte';
 
+export { default as ConfirmDialog } from './components/confirm-dialog.svelte';
+export type { ConfirmDialogProps } from './components/confirm-dialog.svelte';
+
 export { default as Combobox } from './components/combobox.svelte';
 export type { ComboboxOption, ComboboxProps } from './components/combobox.svelte';
 
@@ -166,9 +169,6 @@ export type {
   MarkdownEditorProps,
   ToolbarContext,
 } from './components/markdown-editor.svelte';
-
-export { default as ConfirmDialog } from './components/confirm-dialog.svelte';
-export type { ConfirmDialogProps } from './components/confirm-dialog.svelte';
 
 export { default as Modal } from './components/modal.svelte';
 export type { ModalProps } from './components/modal.svelte';

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -167,6 +167,9 @@ export type {
   ToolbarContext,
 } from './components/markdown-editor.svelte';
 
+export { default as ConfirmDialog } from './components/confirm-dialog.svelte';
+export type { ConfirmDialogProps } from './components/confirm-dialog.svelte';
+
 export { default as Modal } from './components/modal.svelte';
 export type { ModalProps } from './components/modal.svelte';
 

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -40,9 +40,6 @@ export type { CodeBlockProps } from './components/code-block.svelte';
 export { default as ColorSwatchPicker } from './components/color-swatch-picker.svelte';
 export type { ColorSwatch, ColorSwatchPickerProps } from './components/color-swatch-picker.svelte';
 
-export { default as ConfirmDialog } from './components/confirm-dialog.svelte';
-export type { ConfirmDialogProps } from './components/confirm-dialog.svelte';
-
 export { default as Combobox } from './components/combobox.svelte';
 export type { ComboboxOption, ComboboxProps } from './components/combobox.svelte';
 
@@ -51,6 +48,9 @@ export type { CommandItemProps } from './components/command-item.svelte';
 
 export { default as CommandPalette } from './components/command-palette.svelte';
 export type { CommandPaletteProps } from './components/command-palette.svelte';
+
+export { default as ConfirmDialog } from './components/confirm-dialog.svelte';
+export type { ConfirmDialogProps } from './components/confirm-dialog.svelte';
 
 export { default as CopyButton } from './components/copy-button.svelte';
 export type { CopyButtonProps } from './components/copy-button.svelte';


### PR DESCRIPTION
## Summary

- Adds `ConfirmDialog` as a thin opinionated preset over `<Modal>` for destructive-action confirmation flows — composes `<Modal>` + two `<Button>`s without duplicating `<dialog>` mechanics or focus-trap logic
- Default focus lands on the **cancel** button (`autofocus`) — the industry-standard guard against accidental destructive confirms (matches macOS NSAlert, GNOME HIG, APG)
- Extends `modal.svelte` with `describedById` prop (wires `aria-describedby` on the `<dialog>`) and `ondismiss` callback (fired on all 3 user-dismissal paths: Escape via native `cancel` event, backdrop click, close-X — **not** on parent-driven `open = false`)
- `confirmLabel` is required with no default, forcing consumers to name the action ("Delete account", "Discard changes") rather than shipping a generic "OK"
- `destructive={true}` maps to `variant="danger"` on the confirm button; color is never the sole destructive signal
- 19 new tests in `confirm-dialog.test.ts`, 8 regression tests added to `modal.test.ts`
- A11y documentation for both `ConfirmDialog` (`confirm-dialog.a11y.md`) and the new Modal props (`modal.a11y.md` updated)

## Review committee

Pre-reviewed by: ux-designer, testing-expert, typescript-expert, simplicity-engineer, prose-editor, Codex (gpt-5.4, xhigh reasoning — round 1; unavailable round 2)

- 2 rounds of review, 3 commits
- Must-fix items addressed across rounds: autofocus detection (Svelte 5 DOM property vs HTML attribute), vacuous `not.toThrow()` test assertion, a11y doc em-dash formatting, AT tool links (NVDA/JAWS/VoiceOver), WCAG link, `index.ts` alphabetical export ordering (Combobox < CommandItem < CommandPalette < ConfirmDialog), unnecessary `HTMLElement` intersection cast removed

> [!WARNING]
> Codex (the adversarial second-opinion reviewer) was unavailable for round 2 (empty response on session resume). Round 1 Codex findings were false positives about `bind:open` two-way binding semantics and the `close` event focus-restore chain — both rejected with test evidence. This PR was fully reviewed by the Claude-based committee across 2 rounds.

## Test plan

- `bun test --conditions browser src/components/confirm-dialog.test.ts` — 19 tests: renders, aria-describedby wiring, autofocus on cancel, destructive variant, onconfirm/oncancel callbacks, all 4 dismissal paths, parent-driven close does NOT fire oncancel, custom labels, triggerRef, reopen cycle, thrown callbacks
- `bun test --conditions browser src/components/modal.test.ts` — 8 new regression tests: describedById, ondismiss fires on cancel event/backdrop/close-X, NOT on parent-driven close, native cancel event is prevented
- `bun test --conditions browser` — 1557 pass, 0 fail
- `bun run typecheck` — 0 errors
- `bun run build` — exports check passes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new public component and changes `Modal` dismissal/focus behavior (Escape/backdrop/close-X) by introducing `ondismiss`, which could affect all modal consumers’ close semantics and callbacks. Risk is mitigated by extensive new tests covering dismissal paths, aria wiring, and autofocus handling.
> 
> **Overview**
> Adds a new `ConfirmDialog` component as an opinionated wrapper around `Modal` for confirmation flows, with required `confirmLabel`, optional `description` (wired to `aria-describedby`), and default focus on the cancel button; it closes itself before invoking `onconfirm`/`oncancel`.
> 
> Extends `Modal` with `describedById` (conditionally sets `aria-describedby`) and a new `ondismiss` callback that fires only for user-initiated dismissals (Escape via native `cancel`, backdrop click, close-X), plus improved autofocus detection that handles Svelte 5’s DOM-property `autofocus`.
> 
> Exports `ConfirmDialog` from `src/index.ts`, adds a package export entry, and includes substantial new unit tests and updated a11y docs for both `Modal` and `ConfirmDialog`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cc73723dcd22f7262157e5821e24dba3a9fcab4d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->