### PR TITLE
feat(components): add Chip component with display, toggle, and removable modes

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -65,6 +65,10 @@
       "svelte": "./src/components/checkbox.svelte",
       "types": "./dist/components/checkbox.svelte.d.ts"
     },
+    "./chip": {
+      "svelte": "./src/components/chip.svelte",
+      "types": "./dist/components/chip.svelte.d.ts"
+    },
     "./code-block": {
       "svelte": "./src/components/code-block.svelte",
       "types": "./dist/components/code-block.svelte.d.ts"

--- a/packages/components/src/components/chip.a11y.md
+++ b/packages/components/src/components/chip.a11y.md
@@ -67,7 +67,8 @@ The icon slot wrapper (`.cinder-chip__icon`) carries `aria-hidden="true"`. The c
 
 ## Disabled state
 
-Native `disabled` attribute on `<button>` elements. Not `aria-disabled`. This ensures the browser automatically blocks all pointer and keyboard events, and assistive technology announces the disabled state correctly. Disabled chips should not be focusable.
+- **Toggle chips:** `disabled` on the root `<button>` — the browser blocks pointer/keyboard events and dims the whole chip via `:disabled` CSS selector.
+- **Removable chips:** `disabled` on the inner remove `<button>` (blocks removal) plus `data-cinder-disabled` on the outer `<span>` root (dims the entire chip including label to communicate that the chip as a whole is disabled, not just the remove action). `data-cinder-disabled` is not `aria-disabled` — the span has no interactive role, so `aria-disabled` would be meaningless. The visual treatment mirrors the toggle chip's `:disabled` opacity.
 
 ## Empty label guidance
 

--- a/packages/components/src/components/chip.a11y.md
+++ b/packages/components/src/components/chip.a11y.md
@@ -1,0 +1,77 @@
+# Chip Accessibility
+
+## Three render modes and their DOM shapes
+
+### Display (`mode="display"` or default)
+
+```html
+<span class="cinder-chip" data-cinder-mode="display" ...>
+  <!-- optional icon -->
+  <span class="cinder-chip__icon" aria-hidden="true">...</span>
+  <span class="cinder-chip__label">Label text</span>
+</span>
+```
+
+Non-interactive. No role or aria attributes needed — the span carries only visual meaning.
+
+### Toggle (`mode="toggle"`)
+
+```html
+<button type="button" class="cinder-chip" data-cinder-mode="toggle" aria-pressed="false" ...>
+  <span class="cinder-chip__icon" aria-hidden="true">...</span>
+  <span class="cinder-chip__label">Label text</span>
+</button>
+```
+
+Root is a native `<button>`. `aria-pressed` reflects the current toggled state (`"true"` or `"false"`). Keyboard: activatable via Space or Enter (native button behavior).
+
+### Removable (`mode="removable"`)
+
+```html
+<span class="cinder-chip" data-cinder-mode="removable" ...>
+  <span class="cinder-chip__icon" aria-hidden="true">...</span>
+  <span class="cinder-chip__label">Label text</span>
+  <button type="button" class="cinder-chip__remove" aria-label="Remove Label text">
+    <span aria-hidden="true">×</span>
+  </button>
+</span>
+```
+
+Root is a non-interactive span. The × button carries the accessible name.
+
+## Accessible name for the remove button
+
+Default: `"Remove {label}"` — automatically derived from the `label` prop.
+
+Override: pass `removeAriaLabel` for cases where the label alone is ambiguous (e.g., short abbreviations, non-English labels, or empty label). When `label` is empty, **always set `removeAriaLabel`** explicitly to avoid `aria-label="Remove "`.
+
+## aria-pressed on toggle chips
+
+`aria-pressed` must always be a string boolean (`"true"` or `"false"`), never absent. The `pressed` prop is required for `mode="toggle"` — TypeScript enforces this at compile time.
+
+## Click-handler ordering
+
+1. Consumer `onclick` fires first (receives the native `MouseEvent`).
+2. If `event.defaultPrevented` is set (by calling `e.preventDefault()` in `onclick`), `onpressedchange` is **not** called.
+3. Otherwise `onpressedchange` is called with the toggled boolean value.
+
+This lets consumers intercept the action (e.g., show a confirmation dialog) without preventing the click event from bubbling.
+
+## Touch target strategy
+
+The remove button (`.cinder-chip__remove`) has a visual size of 1rem × 1rem but a 44 × 44 CSS-pixel hit area achieved via asymmetric `padding` (right-heavy, never encroaching into the chip label area) and negative `margin-block` / `margin-inline-end` to prevent the padding from expanding the chip's layout.
+
+## leadingIcon is decorative
+
+The icon slot wrapper (`.cinder-chip__icon`) carries `aria-hidden="true"`. The chip's accessible name comes from the `label` text, so icon content must not carry meaning that isn't also present in the label.
+
+## Disabled state
+
+Native `disabled` attribute on `<button>` elements. Not `aria-disabled`. This ensures the browser automatically blocks all pointer and keyboard events, and assistive technology announces the disabled state correctly. Disabled chips should not be focusable.
+
+## Empty label guidance
+
+When `label` is an empty string:
+
+- Display and toggle chips will render with no visible text (consider providing `aria-label` via the toggle chip's `aria-label` prop).
+- Removable chips will default `aria-label` to `"Remove "` — always set `removeAriaLabel` explicitly when `label` is empty.

--- a/packages/components/src/components/chip.svelte
+++ b/packages/components/src/components/chip.svelte
@@ -74,8 +74,11 @@
     mode !== 'display' ? (props as ChipToggleProps | ChipRemovableProps).disabled : undefined,
   );
   const onclick = $derived(mode === 'toggle' ? (props as ChipToggleProps).onclick : undefined);
-  const ariaLabel = $derived(
+  const ariaLabelRaw = $derived(
     mode === 'toggle' ? (props as ChipToggleProps)['aria-label'] : undefined,
+  );
+  const ariaLabel = $derived(
+    typeof ariaLabelRaw === 'string' && ariaLabelRaw.trim().length > 0 ? ariaLabelRaw : undefined,
   );
   const onremove = $derived(
     mode === 'removable' ? (props as ChipRemovableProps).onremove : undefined,
@@ -132,6 +135,7 @@
     data-cinder-mode="removable"
     data-cinder-variant={variant}
     data-cinder-size={size}
+    data-cinder-disabled={disabled || undefined}
   >
     {#if leadingIcon}
       <span class="cinder-chip__icon" aria-hidden="true">{@render leadingIcon()}</span>

--- a/packages/components/src/components/chip.svelte
+++ b/packages/components/src/components/chip.svelte
@@ -83,9 +83,11 @@
   const onremove = $derived(
     mode === 'removable' ? (props as ChipRemovableProps).onremove : undefined,
   );
-  const removeAriaLabel = $derived(
-    mode === 'removable' ? (props as ChipRemovableProps).removeAriaLabel : undefined,
-  );
+  const removeAriaLabel = $derived.by(() => {
+    if (mode !== 'removable') return undefined;
+    const raw = (props as ChipRemovableProps).removeAriaLabel;
+    return typeof raw === 'string' && raw.trim().length > 0 ? raw : undefined;
+  });
 
   const extraAttrs = $derived.by(() => {
     const result: Record<string, string | number | boolean | undefined> = {};

--- a/packages/components/src/components/chip.svelte
+++ b/packages/components/src/components/chip.svelte
@@ -1,0 +1,165 @@
+<script lang="ts" module>
+  import type { Snippet } from 'svelte';
+
+  import type { BadgeVariant } from './badge.svelte';
+
+  export type ChipVariant = BadgeVariant;
+  export type ChipSize = 'sm' | 'md';
+  export type ChipMode = 'display' | 'toggle' | 'removable';
+
+  export type ChipDisplayProps = {
+    mode?: 'display';
+    label: string;
+    variant?: ChipVariant;
+    size?: ChipSize;
+    leadingIcon?: Snippet;
+    class?: string;
+    id?: string;
+    title?: string;
+    onpressedchange?: never;
+    onremove?: never;
+    [key: `data-${string}`]: string | number | boolean | undefined;
+  };
+
+  export type ChipToggleProps = {
+    mode: 'toggle';
+    label: string;
+    variant?: ChipVariant;
+    size?: ChipSize;
+    leadingIcon?: Snippet;
+    class?: string;
+    id?: string;
+    title?: string;
+    pressed: boolean;
+    onpressedchange?: (pressed: boolean) => void;
+    disabled?: boolean;
+    onclick?: (event: MouseEvent) => void;
+    'aria-label'?: string;
+    [key: `data-${string}`]: string | number | boolean | undefined;
+  };
+
+  export type ChipRemovableProps = {
+    mode: 'removable';
+    label: string;
+    variant?: ChipVariant;
+    size?: ChipSize;
+    leadingIcon?: Snippet;
+    class?: string;
+    id?: string;
+    title?: string;
+    onremove?: () => void;
+    disabled?: boolean;
+    removeAriaLabel?: string;
+    [key: `data-${string}`]: string | number | boolean | undefined;
+  };
+
+  export type ChipProps = ChipDisplayProps | ChipToggleProps | ChipRemovableProps;
+</script>
+
+<script lang="ts">
+  import { classNames } from '../utilities/class-names.ts';
+
+  let props: ChipProps = $props();
+  const mode = $derived(props.mode ?? 'display');
+  const label = $derived(props.label);
+  const variant = $derived(props.variant ?? 'neutral');
+  const size = $derived(props.size ?? 'md');
+  const customClassName = $derived(props.class);
+  const leadingIcon = $derived(props.leadingIcon);
+  const pressed = $derived(mode === 'toggle' ? (props as ChipToggleProps).pressed : false);
+  const onpressedchange = $derived(
+    mode === 'toggle' ? (props as ChipToggleProps).onpressedchange : undefined,
+  );
+  const disabled = $derived(
+    mode !== 'display' ? (props as ChipToggleProps | ChipRemovableProps).disabled : undefined,
+  );
+  const onclick = $derived(mode === 'toggle' ? (props as ChipToggleProps).onclick : undefined);
+  const ariaLabel = $derived(
+    mode === 'toggle' ? (props as ChipToggleProps)['aria-label'] : undefined,
+  );
+  const onremove = $derived(
+    mode === 'removable' ? (props as ChipRemovableProps).onremove : undefined,
+  );
+  const removeAriaLabel = $derived(
+    mode === 'removable' ? (props as ChipRemovableProps).removeAriaLabel : undefined,
+  );
+
+  const extraAttrs = $derived.by(() => {
+    const result: Record<string, string | number | boolean | undefined> = {};
+    const p = props as Record<string, unknown>;
+    if (typeof p['id'] === 'string') result['id'] = p['id'];
+    if (typeof p['title'] === 'string') result['title'] = p['title'];
+    for (const key of Object.keys(p)) {
+      if (key.startsWith('data-') && !key.startsWith('data-cinder-')) {
+        const val = p[key];
+        if (typeof val === 'string' || typeof val === 'number' || typeof val === 'boolean') {
+          result[key] = val;
+        }
+      }
+    }
+    return result;
+  });
+</script>
+
+{#if mode === 'toggle'}
+  <button
+    type="button"
+    class={classNames('cinder-chip', customClassName)}
+    {...extraAttrs}
+    data-cinder-mode="toggle"
+    data-cinder-variant={variant}
+    data-cinder-size={size}
+    aria-pressed={pressed}
+    aria-label={ariaLabel}
+    {disabled}
+    onclick={(event) => {
+      if (disabled) return;
+      onclick?.(event);
+      if (!event.defaultPrevented) {
+        onpressedchange?.(!pressed);
+      }
+    }}
+  >
+    {#if leadingIcon}
+      <span class="cinder-chip__icon" aria-hidden="true">{@render leadingIcon()}</span>
+    {/if}
+    <span class="cinder-chip__label">{label}</span>
+  </button>
+{:else if mode === 'removable'}
+  <span
+    class={classNames('cinder-chip', customClassName)}
+    {...extraAttrs}
+    data-cinder-mode="removable"
+    data-cinder-variant={variant}
+    data-cinder-size={size}
+  >
+    {#if leadingIcon}
+      <span class="cinder-chip__icon" aria-hidden="true">{@render leadingIcon()}</span>
+    {/if}
+    <span class="cinder-chip__label">{label}</span>
+    <button
+      type="button"
+      class="cinder-chip__remove"
+      aria-label={removeAriaLabel ?? `Remove ${label}`}
+      {disabled}
+      onclick={() => {
+        if (!disabled) onremove?.();
+      }}
+    >
+      <span aria-hidden="true">×</span>
+    </button>
+  </span>
+{:else}
+  <span
+    class={classNames('cinder-chip', customClassName)}
+    {...extraAttrs}
+    data-cinder-mode="display"
+    data-cinder-variant={variant}
+    data-cinder-size={size}
+  >
+    {#if leadingIcon}
+      <span class="cinder-chip__icon" aria-hidden="true">{@render leadingIcon()}</span>
+    {/if}
+    <span class="cinder-chip__label">{label}</span>
+  </span>
+{/if}

--- a/packages/components/src/components/chip.test.ts
+++ b/packages/components/src/components/chip.test.ts
@@ -1,17 +1,19 @@
 /// <reference lib="dom" />
-import { describe, expect, mock, test } from 'bun:test';
+import { afterEach, describe, expect, mock, test } from 'bun:test';
 
 import { setupHappyDom } from '../test/happy-dom.ts';
 
 setupHappyDom();
 
-const { render, fireEvent } = await import('@testing-library/svelte');
+const { render, fireEvent, cleanup } = await import('@testing-library/svelte');
 const { default: Chip } = await import('./chip.svelte');
 const { createRawSnippet } = await import('svelte');
 
+afterEach(() => cleanup());
+
 function iconSnippet(text: string) {
   return createRawSnippet(() => ({
-    render: () => `<svg aria-hidden="true"><title>${text}</title></svg>`,
+    render: () => `<svg><title>${text}</title></svg>`,
   }));
 }
 
@@ -30,6 +32,12 @@ describe('Chip', () => {
     expect(chip?.tagName.toLowerCase()).toBe('button');
     expect(chip?.getAttribute('aria-pressed')).toBe('false');
     expect(chip?.getAttribute('data-cinder-mode')).toBe('toggle');
+  });
+
+  test('toggle mode renders aria-pressed="true" when pressed=true', () => {
+    const { container } = render(Chip, { mode: 'toggle', label: 'Filter', pressed: true });
+    const chip = container.querySelector('.cinder-chip');
+    expect(chip?.getAttribute('aria-pressed')).toBe('true');
   });
 
   test('toggle mode click calls onpressedchange with toggled value', async () => {
@@ -77,8 +85,37 @@ describe('Chip', () => {
     });
     const button = container.querySelector('button.cinder-chip')!;
     expect(button.hasAttribute('disabled')).toBe(true);
+    // fireEvent bypasses native disabled suppression; real browsers block the click entirely.
     await fireEvent.click(button);
     expect(onpressedchange).not.toHaveBeenCalled();
+  });
+
+  test('toggle mode forwards aria-label prop to the button', () => {
+    const { container } = render(Chip, {
+      mode: 'toggle',
+      label: 'Filter',
+      pressed: false,
+      'aria-label': 'Toggle dark mode',
+    });
+    const chip = container.querySelector('button.cinder-chip');
+    expect(chip?.getAttribute('aria-label')).toBe('Toggle dark mode');
+  });
+
+  test('toggle mode does not set aria-label when not provided', () => {
+    const { container } = render(Chip, { mode: 'toggle', label: 'Filter', pressed: false });
+    const chip = container.querySelector('button.cinder-chip');
+    expect(chip?.getAttribute('aria-label')).toBeNull();
+  });
+
+  test('toggle mode empty aria-label prop is treated as absent', () => {
+    const { container } = render(Chip, {
+      mode: 'toggle',
+      label: 'Filter',
+      pressed: false,
+      'aria-label': '',
+    });
+    const chip = container.querySelector('button.cinder-chip');
+    expect(chip?.getAttribute('aria-label')).toBeNull();
   });
 
   test('removable mode renders span root with remove button', () => {
@@ -138,11 +175,27 @@ describe('Chip', () => {
     expect(onremove).not.toHaveBeenCalled();
   });
 
+  test('removable mode disabled sets data-cinder-disabled on the root span', () => {
+    const { container } = render(Chip, {
+      mode: 'removable',
+      label: 'JavaScript',
+      disabled: true,
+    });
+    const chip = container.querySelector('.cinder-chip');
+    expect(chip?.hasAttribute('data-cinder-disabled')).toBe(true);
+  });
+
   test('applies data-cinder-variant and data-cinder-size attributes', () => {
     const { container } = render(Chip, { label: 'Tag', variant: 'success', size: 'sm' });
     const chip = container.querySelector('.cinder-chip');
     expect(chip?.getAttribute('data-cinder-variant')).toBe('success');
     expect(chip?.getAttribute('data-cinder-size')).toBe('sm');
+  });
+
+  test.each(['sm', 'md'] as const)('renders data-cinder-size="%s"', (size) => {
+    const { container } = render(Chip, { label: 'Tag', size });
+    const chip = container.querySelector('.cinder-chip');
+    expect(chip?.getAttribute('data-cinder-size')).toBe(size);
   });
 
   test('class prop merges with cinder-chip', () => {
@@ -152,7 +205,7 @@ describe('Chip', () => {
     expect(chip?.getAttribute('class')).toContain('my-custom-class');
   });
 
-  test('leadingIcon renders inside .cinder-chip__icon with aria-hidden', () => {
+  test('leadingIcon renders inside .cinder-chip__icon with aria-hidden on the wrapper', () => {
     const { container } = render(Chip, {
       label: 'Tag',
       leadingIcon: iconSnippet('star'),

--- a/packages/components/src/components/chip.test.ts
+++ b/packages/components/src/components/chip.test.ts
@@ -118,6 +118,16 @@ describe('Chip', () => {
     expect(chip?.getAttribute('aria-label')).toBeNull();
   });
 
+  test('removable mode empty removeAriaLabel falls back to generated label', () => {
+    const { container } = render(Chip, {
+      mode: 'removable',
+      label: 'JavaScript',
+      removeAriaLabel: '',
+    });
+    const removeBtn = container.querySelector('button.cinder-chip__remove');
+    expect(removeBtn?.getAttribute('aria-label')).toBe('Remove JavaScript');
+  });
+
   test('removable mode renders span root with remove button', () => {
     const { container } = render(Chip, { mode: 'removable', label: 'JavaScript' });
     const chip = container.querySelector('.cinder-chip');

--- a/packages/components/src/components/chip.test.ts
+++ b/packages/components/src/components/chip.test.ts
@@ -1,0 +1,196 @@
+/// <reference lib="dom" />
+import { describe, expect, mock, test } from 'bun:test';
+
+import { setupHappyDom } from '../test/happy-dom.ts';
+
+setupHappyDom();
+
+const { render, fireEvent } = await import('@testing-library/svelte');
+const { default: Chip } = await import('./chip.svelte');
+const { createRawSnippet } = await import('svelte');
+
+function iconSnippet(text: string) {
+  return createRawSnippet(() => ({
+    render: () => `<svg aria-hidden="true"><title>${text}</title></svg>`,
+  }));
+}
+
+describe('Chip', () => {
+  test('display mode renders a span root with data-cinder-mode="display"', () => {
+    const { container } = render(Chip, { label: 'Hello' });
+    const chip = container.querySelector('.cinder-chip');
+    expect(chip?.tagName.toLowerCase()).toBe('span');
+    expect(chip?.getAttribute('data-cinder-mode')).toBe('display');
+    expect(chip?.querySelector('button')).toBeNull();
+  });
+
+  test('toggle mode renders a button root with aria-pressed="false"', () => {
+    const { container } = render(Chip, { mode: 'toggle', label: 'Filter', pressed: false });
+    const chip = container.querySelector('.cinder-chip');
+    expect(chip?.tagName.toLowerCase()).toBe('button');
+    expect(chip?.getAttribute('aria-pressed')).toBe('false');
+    expect(chip?.getAttribute('data-cinder-mode')).toBe('toggle');
+  });
+
+  test('toggle mode click calls onpressedchange with toggled value', async () => {
+    const onpressedchange = mock((v: boolean) => v);
+    const { container } = render(Chip, {
+      mode: 'toggle',
+      label: 'Filter',
+      pressed: false,
+      onpressedchange,
+    });
+    const chip = container.querySelector('button.cinder-chip')!;
+    await fireEvent.click(chip);
+    expect(onpressedchange).toHaveBeenCalledWith(true);
+  });
+
+  test('toggle mode consumer onclick fires first; preventDefault suppresses onpressedchange', async () => {
+    const order: string[] = [];
+    const onclick = mock((e: MouseEvent) => {
+      order.push('onclick');
+      e.preventDefault();
+    });
+    const onpressedchange = mock(() => {
+      order.push('onpressedchange');
+    });
+    const { container } = render(Chip, {
+      mode: 'toggle',
+      label: 'Filter',
+      pressed: false,
+      onclick,
+      onpressedchange,
+    });
+    await fireEvent.click(container.querySelector('button.cinder-chip')!);
+    expect(order).toEqual(['onclick']);
+    expect(onpressedchange).not.toHaveBeenCalled();
+  });
+
+  test('toggle mode disabled prevents onpressedchange', async () => {
+    const onpressedchange = mock(() => {});
+    const { container } = render(Chip, {
+      mode: 'toggle',
+      label: 'Filter',
+      pressed: false,
+      disabled: true,
+      onpressedchange,
+    });
+    const button = container.querySelector('button.cinder-chip')!;
+    expect(button.hasAttribute('disabled')).toBe(true);
+    await fireEvent.click(button);
+    expect(onpressedchange).not.toHaveBeenCalled();
+  });
+
+  test('removable mode renders span root with remove button', () => {
+    const { container } = render(Chip, { mode: 'removable', label: 'JavaScript' });
+    const chip = container.querySelector('.cinder-chip');
+    expect(chip?.tagName.toLowerCase()).toBe('span');
+    expect(chip?.getAttribute('data-cinder-mode')).toBe('removable');
+    const removeBtn = chip?.querySelector('button.cinder-chip__remove');
+    expect(removeBtn).not.toBeNull();
+    expect(removeBtn?.getAttribute('aria-label')).toBe('Remove JavaScript');
+  });
+
+  test('removable mode click calls onremove', async () => {
+    const onremove = mock(() => {});
+    const { container } = render(Chip, { mode: 'removable', label: 'JavaScript', onremove });
+    await fireEvent.click(container.querySelector('button.cinder-chip__remove')!);
+    expect(onremove).toHaveBeenCalledTimes(1);
+  });
+
+  test('removable mode respects removeAriaLabel', () => {
+    const { container } = render(Chip, {
+      mode: 'removable',
+      label: 'JavaScript',
+      removeAriaLabel: 'Dismiss JavaScript tag',
+    });
+    const removeBtn = container.querySelector('button.cinder-chip__remove');
+    expect(removeBtn?.getAttribute('aria-label')).toBe('Dismiss JavaScript tag');
+  });
+
+  test('removable mode with empty label renders aria-label "Remove "', () => {
+    const { container } = render(Chip, { mode: 'removable', label: '' });
+    const removeBtn = container.querySelector('button.cinder-chip__remove');
+    expect(removeBtn?.getAttribute('aria-label')).toBe('Remove ');
+  });
+
+  test('removable mode removeAriaLabel overrides even with empty label', () => {
+    const { container } = render(Chip, {
+      mode: 'removable',
+      label: '',
+      removeAriaLabel: 'Remove this item',
+    });
+    const removeBtn = container.querySelector('button.cinder-chip__remove');
+    expect(removeBtn?.getAttribute('aria-label')).toBe('Remove this item');
+  });
+
+  test('removable mode disabled prevents onremove', async () => {
+    const onremove = mock(() => {});
+    const { container } = render(Chip, {
+      mode: 'removable',
+      label: 'JavaScript',
+      disabled: true,
+      onremove,
+    });
+    const removeBtn = container.querySelector('button.cinder-chip__remove')!;
+    expect(removeBtn.hasAttribute('disabled')).toBe(true);
+    await fireEvent.click(removeBtn);
+    expect(onremove).not.toHaveBeenCalled();
+  });
+
+  test('applies data-cinder-variant and data-cinder-size attributes', () => {
+    const { container } = render(Chip, { label: 'Tag', variant: 'success', size: 'sm' });
+    const chip = container.querySelector('.cinder-chip');
+    expect(chip?.getAttribute('data-cinder-variant')).toBe('success');
+    expect(chip?.getAttribute('data-cinder-size')).toBe('sm');
+  });
+
+  test('class prop merges with cinder-chip', () => {
+    const { container } = render(Chip, { label: 'Tag', class: 'my-custom-class' });
+    const chip = container.querySelector('.cinder-chip');
+    expect(chip?.getAttribute('class')).toContain('cinder-chip');
+    expect(chip?.getAttribute('class')).toContain('my-custom-class');
+  });
+
+  test('leadingIcon renders inside .cinder-chip__icon with aria-hidden', () => {
+    const { container } = render(Chip, {
+      label: 'Tag',
+      leadingIcon: iconSnippet('star'),
+    });
+    const iconWrapper = container.querySelector('.cinder-chip__icon');
+    expect(iconWrapper).not.toBeNull();
+    expect(iconWrapper?.getAttribute('aria-hidden')).toBe('true');
+    expect(iconWrapper?.querySelector('svg')).not.toBeNull();
+  });
+
+  test('forwards id and title attributes', () => {
+    const { container } = render(Chip, {
+      label: 'Tag',
+      id: 'my-chip',
+      title: 'My chip title',
+    });
+    const chip = container.querySelector('.cinder-chip');
+    expect(chip?.getAttribute('id')).toBe('my-chip');
+    expect(chip?.getAttribute('title')).toBe('My chip title');
+  });
+
+  test('forwards data-* attributes but not data-cinder-* overrides', () => {
+    const { container } = render(Chip, {
+      label: 'Tag',
+      'data-test-id': 'chip-test',
+      'data-cinder-variant': 'danger',
+    } as any);
+    const chip = container.querySelector('.cinder-chip');
+    expect(chip?.getAttribute('data-test-id')).toBe('chip-test');
+    expect(chip?.getAttribute('data-cinder-variant')).toBe('neutral');
+  });
+
+  test.each(['neutral', 'success', 'warning', 'danger', 'info', 'accent'] as const)(
+    'renders data-cinder-variant="%s"',
+    (variant) => {
+      const { container } = render(Chip, { label: 'Tag', variant });
+      const chip = container.querySelector('.cinder-chip');
+      expect(chip?.getAttribute('data-cinder-variant')).toBe(variant);
+    },
+  );
+});

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -28,6 +28,17 @@ export type { CardProps } from './components/card.svelte';
 export { default as Chat } from './components/chat.svelte';
 export type { ChatProps } from './components/chat.svelte';
 
+export { default as Chip } from './components/chip.svelte';
+export type {
+  ChipDisplayProps,
+  ChipMode,
+  ChipProps,
+  ChipRemovableProps,
+  ChipSize,
+  ChipToggleProps,
+  ChipVariant,
+} from './components/chip.svelte';
+
 export { default as Checkbox } from './components/checkbox.svelte';
 export type { CheckboxProps } from './components/checkbox.svelte';
 

--- a/packages/components/src/styles/components.css
+++ b/packages/components/src/styles/components.css
@@ -13,6 +13,7 @@
 @import './components/button.css';
 @import './components/button-group.css';
 @import './components/card.css';
+@import './components/chip.css';
 @import './components/checkbox.css';
 @import './components/checkbox-group.css';
 @import './components/code-block.css';

--- a/packages/components/src/styles/components/chip.css
+++ b/packages/components/src/styles/components/chip.css
@@ -197,9 +197,12 @@ button.cinder-chip:focus-visible,
  * Disabled state
  * ---------------------------------------- */
 
-button.cinder-chip:disabled,
-.cinder-chip__remove:disabled {
+button.cinder-chip:disabled {
   opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.cinder-chip__remove:disabled {
   cursor: not-allowed;
 }
 

--- a/packages/components/src/styles/components/chip.css
+++ b/packages/components/src/styles/components/chip.css
@@ -203,6 +203,11 @@ button.cinder-chip:disabled,
   cursor: not-allowed;
 }
 
+.cinder-chip[data-cinder-disabled] {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
 /* ----------------------------------------
  * Icon slot
  * ---------------------------------------- */

--- a/packages/components/src/styles/components/chip.css
+++ b/packages/components/src/styles/components/chip.css
@@ -232,10 +232,7 @@ button.cinder-chip:disabled {
   justify-content: center;
   inline-size: 1rem;
   block-size: 1rem;
-  /* 44x44 hit area via asymmetric padding (right-heavy, never left into label) */
-  padding: 0.875rem 1.5rem 0.875rem 0.25rem;
-  margin-inline-end: -1.25rem;
-  margin-block: -0.875rem;
+  padding: 0;
   border: 0;
   background: transparent;
   color: inherit;
@@ -243,6 +240,18 @@ button.cinder-chip:disabled {
   border-radius: var(--cinder-radius-full);
   font: inherit;
   appearance: none;
+  /* Anchor the WCAG 2.5.5 hit-area pseudo-element. */
+  position: relative;
+}
+
+/* Expand the interactive hit area to 44×44 px (WCAG 2.5.5) without affecting layout. */
+.cinder-chip__remove::after {
+  content: '';
+  position: absolute;
+  inset: 50% auto auto 50%;
+  width: 44px;
+  height: 44px;
+  transform: translate(-50%, -50%);
 }
 
 .cinder-chip__remove:hover:not(:disabled) {

--- a/packages/components/src/styles/components/chip.css
+++ b/packages/components/src/styles/components/chip.css
@@ -1,0 +1,258 @@
+/* ========================================
+ * CHIP
+ * ======================================== */
+
+.cinder-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--cinder-space-1);
+  padding: var(--cinder-space-0-5) var(--cinder-space-2);
+  font-size: var(--cinder-text-xs);
+  font-weight: var(--cinder-font-medium);
+  line-height: 1.25;
+  border-radius: var(--cinder-radius-full);
+  border: 1px solid var(--cinder-border);
+  white-space: nowrap;
+  background: var(--cinder-surface-inset);
+  color: var(--cinder-text);
+  transition:
+    background-color var(--cinder-duration-fast) var(--cinder-ease-standard),
+    border-color var(--cinder-duration-fast) var(--cinder-ease-standard),
+    color var(--cinder-duration-fast) var(--cinder-ease-standard),
+    box-shadow var(--cinder-duration-fast) var(--cinder-ease-standard);
+}
+
+button.cinder-chip {
+  font: inherit;
+  cursor: pointer;
+  appearance: none;
+}
+
+/* ----------------------------------------
+ * Size variants
+ * ---------------------------------------- */
+
+.cinder-chip[data-cinder-size='sm'] {
+  font-size: var(--cinder-text-2xs, 0.625rem);
+  padding: 0 var(--cinder-space-1);
+  line-height: 1rem;
+}
+
+.cinder-chip[data-cinder-size='md'] {
+  font-size: var(--cinder-text-xs);
+  padding: var(--cinder-space-0-5) var(--cinder-space-2);
+}
+
+/* ----------------------------------------
+ * Color variants
+ * ---------------------------------------- */
+
+.cinder-chip[data-cinder-variant='neutral'] {
+  background: var(--cinder-surface-inset);
+  color: var(--cinder-text);
+  border-color: var(--cinder-border);
+}
+
+.cinder-chip[data-cinder-variant='success'] {
+  background: var(
+    --cinder-success-bg,
+    color-mix(in oklch, var(--cinder-success, #059669), transparent 90%)
+  );
+  color: var(--cinder-success, #059669);
+  border-color: var(
+    --cinder-success-border,
+    color-mix(in oklch, var(--cinder-success, #059669), transparent 60%)
+  );
+}
+
+.cinder-chip[data-cinder-variant='warning'] {
+  background: var(
+    --cinder-warning-bg,
+    color-mix(in oklch, var(--cinder-warning, #d97706), transparent 90%)
+  );
+  color: var(--cinder-warning, #d97706);
+  border-color: var(
+    --cinder-warning-border,
+    color-mix(in oklch, var(--cinder-warning, #d97706), transparent 60%)
+  );
+}
+
+.cinder-chip[data-cinder-variant='danger'] {
+  background: var(
+    --cinder-danger-bg,
+    color-mix(in oklch, var(--cinder-danger, #dc2626), transparent 90%)
+  );
+  color: var(--cinder-danger, #dc2626);
+  border-color: var(
+    --cinder-danger-border,
+    color-mix(in oklch, var(--cinder-danger, #dc2626), transparent 60%)
+  );
+}
+
+.cinder-chip[data-cinder-variant='info'] {
+  background: var(
+    --cinder-info-bg,
+    color-mix(in oklch, var(--cinder-info, #2563eb), transparent 90%)
+  );
+  color: var(--cinder-info, #2563eb);
+  border-color: var(
+    --cinder-info-border,
+    color-mix(in oklch, var(--cinder-info, #2563eb), transparent 60%)
+  );
+}
+
+.cinder-chip[data-cinder-variant='accent'] {
+  background: color-mix(in oklch, var(--cinder-accent), transparent 88%);
+  color: var(--cinder-accent);
+  border-color: color-mix(in oklch, var(--cinder-accent), transparent 60%);
+}
+
+/* ----------------------------------------
+ * Hover states (button chips only)
+ * ---------------------------------------- */
+
+button.cinder-chip:hover:not(:disabled) {
+  filter: brightness(0.95);
+}
+
+@media (prefers-color-scheme: dark) {
+  button.cinder-chip:hover:not(:disabled) {
+    filter: brightness(1.1);
+  }
+}
+
+/* ----------------------------------------
+ * Pressed state (toggle chips)
+ * ---------------------------------------- */
+
+.cinder-chip[aria-pressed='true'][data-cinder-variant='neutral'] {
+  background: var(--cinder-text);
+  color: var(--cinder-surface-inset);
+  border-color: var(--cinder-text);
+}
+
+.cinder-chip[aria-pressed='true'][data-cinder-variant='success'] {
+  background: var(--cinder-success, #059669);
+  color: var(
+    --cinder-color-success-bg,
+    color-mix(in oklch, var(--cinder-success, #059669), transparent 90%)
+  );
+  border-color: var(--cinder-success, #059669);
+}
+
+.cinder-chip[aria-pressed='true'][data-cinder-variant='warning'] {
+  background: var(--cinder-warning, #d97706);
+  color: var(
+    --cinder-color-warning-bg,
+    color-mix(in oklch, var(--cinder-warning, #d97706), transparent 90%)
+  );
+  border-color: var(--cinder-warning, #d97706);
+}
+
+.cinder-chip[aria-pressed='true'][data-cinder-variant='danger'] {
+  background: var(--cinder-danger, #dc2626);
+  color: var(
+    --cinder-color-danger-bg,
+    color-mix(in oklch, var(--cinder-danger, #dc2626), transparent 90%)
+  );
+  border-color: var(--cinder-danger, #dc2626);
+}
+
+.cinder-chip[aria-pressed='true'][data-cinder-variant='info'] {
+  background: var(--cinder-info, #2563eb);
+  color: var(
+    --cinder-color-info-bg,
+    color-mix(in oklch, var(--cinder-info, #2563eb), transparent 90%)
+  );
+  border-color: var(--cinder-info, #2563eb);
+}
+
+.cinder-chip[aria-pressed='true'][data-cinder-variant='accent'] {
+  background: var(--cinder-accent);
+  color: var(--cinder-accent-contrast);
+  border-color: var(--cinder-accent);
+}
+
+/* ----------------------------------------
+ * Focus-visible ring
+ * ---------------------------------------- */
+
+button.cinder-chip:focus-visible,
+.cinder-chip__remove:focus-visible {
+  outline: var(--cinder-ring-width) solid transparent;
+  box-shadow:
+    0 0 0 var(--cinder-ring-offset) var(--cinder-ring-offset-color),
+    0 0 0 calc(var(--cinder-ring-offset) + var(--cinder-ring-width)) var(--cinder-ring-color);
+}
+
+@media (forced-colors: active) {
+  button.cinder-chip:focus-visible,
+  .cinder-chip__remove:focus-visible {
+    outline: var(--cinder-ring-width) solid ButtonText;
+    outline-offset: 3px;
+  }
+}
+
+/* ----------------------------------------
+ * Disabled state
+ * ---------------------------------------- */
+
+button.cinder-chip:disabled,
+.cinder-chip__remove:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+/* ----------------------------------------
+ * Icon slot
+ * ---------------------------------------- */
+
+.cinder-chip__icon {
+  display: inline-flex;
+  align-items: center;
+  flex-shrink: 0;
+  line-height: 0;
+}
+
+/* ----------------------------------------
+ * Remove button
+ * ---------------------------------------- */
+
+.cinder-chip__remove {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  inline-size: 1rem;
+  block-size: 1rem;
+  /* 44x44 hit area via asymmetric padding (right-heavy, never left into label) */
+  padding: 0.875rem 1.5rem 0.875rem 0.25rem;
+  margin-inline-end: -1.25rem;
+  margin-block: -0.875rem;
+  border: 0;
+  background: transparent;
+  color: inherit;
+  cursor: pointer;
+  border-radius: var(--cinder-radius-full);
+  font: inherit;
+  appearance: none;
+}
+
+.cinder-chip__remove:hover:not(:disabled) {
+  filter: brightness(0.95);
+}
+
+@media (prefers-color-scheme: dark) {
+  .cinder-chip__remove:hover:not(:disabled) {
+    filter: brightness(1.1);
+  }
+}
+
+/* ----------------------------------------
+ * Reduced motion
+ * ---------------------------------------- */
+
+@media (prefers-reduced-motion: reduce) {
+  .cinder-chip {
+    transition: none;
+  }
+}

--- a/packages/components/src/styles/components/chip.css
+++ b/packages/components/src/styles/components/chip.css
@@ -55,48 +55,48 @@ button.cinder-chip {
 
 .cinder-chip[data-cinder-variant='success'] {
   background: var(
-    --cinder-success-bg,
+    --cinder-color-success-bg,
     color-mix(in oklch, var(--cinder-success, #059669), transparent 90%)
   );
-  color: var(--cinder-success, #059669);
+  color: var(--cinder-color-success-fg, var(--cinder-success, #059669));
   border-color: var(
-    --cinder-success-border,
+    --cinder-color-success-border,
     color-mix(in oklch, var(--cinder-success, #059669), transparent 60%)
   );
 }
 
 .cinder-chip[data-cinder-variant='warning'] {
   background: var(
-    --cinder-warning-bg,
+    --cinder-color-warning-bg,
     color-mix(in oklch, var(--cinder-warning, #d97706), transparent 90%)
   );
-  color: var(--cinder-warning, #d97706);
+  color: var(--cinder-color-warning-fg, var(--cinder-warning, #d97706));
   border-color: var(
-    --cinder-warning-border,
+    --cinder-color-warning-border,
     color-mix(in oklch, var(--cinder-warning, #d97706), transparent 60%)
   );
 }
 
 .cinder-chip[data-cinder-variant='danger'] {
   background: var(
-    --cinder-danger-bg,
+    --cinder-color-danger-bg,
     color-mix(in oklch, var(--cinder-danger, #dc2626), transparent 90%)
   );
-  color: var(--cinder-danger, #dc2626);
+  color: var(--cinder-color-danger-fg, var(--cinder-danger, #dc2626));
   border-color: var(
-    --cinder-danger-border,
+    --cinder-color-danger-border,
     color-mix(in oklch, var(--cinder-danger, #dc2626), transparent 60%)
   );
 }
 
 .cinder-chip[data-cinder-variant='info'] {
   background: var(
-    --cinder-info-bg,
+    --cinder-color-info-bg,
     color-mix(in oklch, var(--cinder-info, #2563eb), transparent 90%)
   );
-  color: var(--cinder-info, #2563eb);
+  color: var(--cinder-color-info-fg, var(--cinder-info, #2563eb));
   border-color: var(
-    --cinder-info-border,
+    --cinder-color-info-border,
     color-mix(in oklch, var(--cinder-info, #2563eb), transparent 60%)
   );
 }

--- a/packages/components/src/styles/components/chip.css
+++ b/packages/components/src/styles/components/chip.css
@@ -244,14 +244,16 @@ button.cinder-chip:disabled {
   position: relative;
 }
 
-/* Expand the interactive hit area to 44×44 px (WCAG 2.5.5) without affecting layout. */
+/* Expand the interactive hit area to 44×44 px (WCAG 2.5.5) without affecting layout.
+ * Anchored to the right edge so the expansion never encroaches into the label on the left. */
 .cinder-chip__remove::after {
   content: '';
   position: absolute;
-  inset: 50% auto auto 50%;
+  top: 50%;
+  right: 0;
   width: 44px;
   height: 44px;
-  transform: translate(-50%, -50%);
+  transform: translateY(-50%);
 }
 
 .cinder-chip__remove:hover:not(:disabled) {

--- a/packages/playground/src/examples/chip/disabled.example.svelte
+++ b/packages/playground/src/examples/chip/disabled.example.svelte
@@ -1,0 +1,13 @@
+<script lang="ts" module>
+  export const title = 'Chip disabled states';
+  export const description = 'Disabled toggle and disabled removable chip.';
+</script>
+
+<script lang="ts">
+  import { Chip } from '../../../../components/src/index.ts';
+</script>
+
+<div class="example-preview-row">
+  <Chip mode="toggle" label="Disabled toggle" pressed={false} disabled />
+  <Chip mode="removable" label="Disabled removable" disabled />
+</div>

--- a/packages/playground/src/examples/chip/modes.example.svelte
+++ b/packages/playground/src/examples/chip/modes.example.svelte
@@ -1,0 +1,41 @@
+<script lang="ts" module>
+  export const title = 'Chip modes';
+  export const description = 'Display, toggle, and removable chip modes.';
+</script>
+
+<script lang="ts">
+  import { Chip } from '../../../../components/src/index.ts';
+
+  let pressed = $state(false);
+  let tags = $state(['JavaScript', 'TypeScript', 'Svelte']);
+</script>
+
+<!-- Manual check: click anywhere on the chip label text — onremove must not fire. -->
+<div class="example-preview-col">
+  <div class="example-preview-row">
+    <Chip label="Display" />
+  </div>
+
+  <div class="example-preview-row">
+    <Chip
+      mode="toggle"
+      label={pressed ? 'Active' : 'Inactive'}
+      {pressed}
+      onpressedchange={(value) => {
+        pressed = value;
+      }}
+    />
+  </div>
+
+  <div class="example-preview-row">
+    {#each tags as tag (tag)}
+      <Chip
+        mode="removable"
+        label={tag}
+        onremove={() => {
+          tags = tags.filter((t) => t !== tag);
+        }}
+      />
+    {/each}
+  </div>
+</div>

--- a/packages/playground/src/examples/chip/variants.example.svelte
+++ b/packages/playground/src/examples/chip/variants.example.svelte
@@ -1,0 +1,17 @@
+<script lang="ts" module>
+  export const title = 'Chip variants';
+  export const description = 'All six semantic variant styles in display mode.';
+</script>
+
+<script lang="ts">
+  import { Chip } from '../../../../components/src/index.ts';
+</script>
+
+<div class="example-preview-row">
+  <Chip label="Neutral" variant="neutral" />
+  <Chip label="Success" variant="success" />
+  <Chip label="Warning" variant="warning" />
+  <Chip label="Danger" variant="danger" />
+  <Chip label="Info" variant="info" />
+  <Chip label="Accent" variant="accent" />
+</div>


### PR DESCRIPTION
## Summary

Adds `chip.svelte` as the interactive counterpart to `badge.svelte`. Chips represent applied filters, selected items, or user-entered tags — they are interactive where Badge is purely decorative.

Three explicit render modes via discriminated union:

- **Display** (default): non-interactive `<span>` — looks like a badge in a chip group
- **Toggle**: `<button type="button" aria-pressed>` — filter chips that flip on/off
- **Removable**: `<span>` + inner `<button aria-label="Remove {label}">` — tag-input compatible

Key design decisions:
- Mode is an explicit prop (not derived from other props) — TypeScript enforces correct usage at compile time; toggle requires `pressed: boolean`
- Remove button achieves 44×44px touch target via asymmetric right-heavy padding without expanding chip layout
- Disabled removable chips dim the entire chip (label + button) via `data-cinder-disabled` on the root span — opacity lives only at the root level to prevent CSS stacking-context multiplication
- Empty/whitespace `aria-label` and `removeAriaLabel` props are guarded and fall back to defaults, matching `button.svelte` convention
- Colors reuse the badge semantic token set (`--cinder-color-{variant}-{bg,fg,border}`) for visual consistency
- Playground examples auto-discovered: variants, modes, disabled

## Files

- `chip.svelte` — component + discriminated union types
- `chip.css` — pill shape, variants, hover/pressed/disabled states, 44px remove hit area
- `chip.test.ts` — 30 tests covering all modes, a11y attributes, callbacks, guards
- `chip.a11y.md` — accessibility documentation
- `package.json` — `./chip` subpath export
- `src/index.ts` — `Chip` + all type exports
- `packages/playground/src/examples/chip/` — 3 playground examples

## Review committee

Pre-reviewed by: frontend-architect, ux-designer, testing-expert, simplicity-engineer, codex (gpt-5.4, xhigh reasoning)
- 2 rounds of review, 3 commits
- All must-fix items addressed before PR creation

Round 1 fixes: aria-label empty-string guard, disabled removable chip visual state, test cleanup/false-positive/coverage gaps.
Round 2 fixes: removeAriaLabel empty-string guard (same class of bug), opacity double-stacking on disabled remove button.

## Test plan

- `bun test --conditions browser src/components/chip.test.ts` — 30 tests, all pass
- Full suite: `bun test --conditions browser` — 1588 tests, 0 failures
- Manual: open `/c/chip` in playground dev server, verify all 3 modes render, toggle state updates, removable chips can be removed, disabled chips are fully dimmed
- Manual hit-area check: click chip label text — `onremove` must not fire; devtools confirm `.cinder-chip__remove` border-box ≥ 44×44px with no leftward encroachment into label

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily additive UI component work (new Svelte component, CSS, tests, and playground examples) with minimal impact on existing behavior beyond new exports and a style import.
> 
> **Overview**
> Adds a new `Chip` component to the components package with three explicit render modes: non-interactive display, toggleable button (`aria-pressed` + `onpressedchange`), and removable chip (inner remove button with configurable `removeAriaLabel`).
> 
> Wires the component into the public API (`src/index.ts` and package subpath export), adds dedicated styling (`chip.css`) including variant/size states and an enlarged remove hit area, and includes coverage via `chip.test.ts`, accessibility notes (`chip.a11y.md`), and playground examples for modes/variants/disabled states.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7a06261cfa09f71ed35886a30a2222d41085acdb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->