### PR TITLE
feat(banner): add full-width page-level alert strip

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -37,6 +37,10 @@
       "svelte": "./src/components/badge.svelte",
       "types": "./dist/components/badge.svelte.d.ts"
     },
+    "./banner": {
+      "svelte": "./src/components/banner.svelte",
+      "types": "./dist/components/banner.svelte.d.ts"
+    },
     "./breadcrumbs": {
       "svelte": "./src/components/breadcrumbs.svelte",
       "types": "./dist/components/breadcrumbs.svelte.d.ts"

--- a/packages/components/scripts/husky/pre-commit.ts
+++ b/packages/components/scripts/husky/pre-commit.ts
@@ -82,7 +82,7 @@ try {
 // 5) lint-staged (format staged files; always last)
 info('Running lint-staged…');
 try {
-  await $`bun exec lint-staged`;
+  await $`bunx lint-staged`;
   success('Lint-staged passed');
 } catch {
   error('Lint-staged failed');

--- a/packages/components/src/components/banner.a11y.md
+++ b/packages/components/src/components/banner.a11y.md
@@ -9,7 +9,7 @@ interrupted by an assertive live-region announcement on every page load.
 
 The root element is a `<div>` with:
 
-- `role="region"` — marks the banner as a navigable landmark. ARIA's
+- `role="region"` — marks the banner as a navigable landmark. [ARIA](https://www.w3.org/TR/wai-aria-1.2/)'s
   `region` role only qualifies as a landmark when it has an accessible
   name; that is always supplied here.
 - `aria-label="{variant label}"` by default — derived from the `variant`
@@ -39,11 +39,13 @@ The component computes the accessible name in three tiers:
 `role` is intentionally locked. The component's `BannerProps` `Omit`s
 `role` from the underlying `HTMLAttributes`, so callers cannot silently
 turn the banner into `role="alert"`. The component also strips
-`aria-live`, `aria-atomic`, `aria-relevant`, and `aria-busy` from
-rest-props at runtime — the type system permits them (they live on
-`HTMLAttributes`), but the banner is a landmark, not a live region, and
-allowing those attributes through would reintroduce the assertive-
-announcement behavior `role="region"` was chosen to avoid.
+`aria-live`, `aria-atomic`, and `aria-relevant` from rest-props at
+runtime — the type system permits them (they live on `HTMLAttributes`),
+but the banner is a landmark, not a live region, and allowing those
+attributes through would reintroduce the assertive-announcement behavior
+`role="region"` was chosen to avoid. `aria-busy` is **not** stripped:
+it is a status flag, not a live-region attribute, and is valid on
+`role="region"` to signal that banner content is updating.
 
 ## Why not `role="alert"`?
 
@@ -86,16 +88,17 @@ Banner is not a focus trap. Tab order:
 3. The dismiss button (when `dismissible` is `true`).
 
 Enter or Space on the dismiss button fires the handler. Once dismissed,
-the banner is removed from the DOM; focus moves to the next focusable
-element in document order via the browser's default focus-recovery
-behavior.
+the banner is removed from the DOM. If focus was inside the banner, the
+component moves focus to the next focusable element in document order. If
+there is no later focusable element, it falls back to the nearest previous
+focusable element.
 
 ## Dismiss button
 
 - `<button type="button" aria-label="Dismiss banner">` with an inline
   SVG × icon marked `aria-hidden="true"`.
 - The interactive hit area is expanded to 44×44 px via a non-layout
-  `::after` pseudo-element (WCAG 2.5.5 Target Size).
+  `::after` pseudo-element ([WCAG 2.5.5 Target Size](https://www.w3.org/WAI/WCAG21/Understanding/target-size.html)).
 - The visible focus ring uses a two-tone offset + colored ring derived
   from the active variant token.
 - The dismiss button's `aria-label` is hardcoded to English. Internationalization
@@ -108,7 +111,8 @@ behavior.
 Variant tokens mirror `alert.svelte`'s contrast model — same lightness
 and chroma derivations against `--cinder-info | success | warning |
 danger`. The package does not currently ship an automated contrast check
-for component variants, so this document does **not** assert WCAG AA
+for component variants, so this document does **not** assert
+[WCAG AA](https://www.w3.org/WAI/WCAG21/Understanding/contrast-minimum.html)
 compliance: the colors are designed to mirror `alert.svelte`'s contrast
 model; verify manually against your specific background before shipping.
 

--- a/packages/components/src/components/banner.a11y.md
+++ b/packages/components/src/components/banner.a11y.md
@@ -1,0 +1,134 @@
+# Banner Accessibility
+
+`banner.svelte` is a page-level notification strip. It uses
+`role="region"` with a variant-derived `aria-label` so that screen-reader
+users can find and identify it via landmark navigation without being
+interrupted by an assertive live-region announcement on every page load.
+
+## Role + Semantics
+
+The root element is a `<div>` with:
+
+- `role="region"` — marks the banner as a navigable landmark. ARIA's
+  `region` role only qualifies as a landmark when it has an accessible
+  name; that is always supplied here.
+- `aria-label="{variant label}"` by default — derived from the `variant`
+  prop via the table below. Suppressed when `aria-labelledby` is passed.
+
+| `variant` | Default `aria-label` |
+| --------- | -------------------- |
+| `info`    | `Information`        |
+| `success` | `Success`            |
+| `warning` | `Warning`            |
+| `danger`  | `Error`              |
+
+`danger` maps to `"Error"` (not `"Danger"`) because screen-reader users
+hear a semantically meaningful word. The variant token name remains
+`danger` to match `--cinder-danger`.
+
+### Accessible-name precedence
+
+The component computes the accessible name in three tiers:
+
+1. If the consumer passes `aria-labelledby`, the root emits
+   `aria-labelledby` alone — the default `aria-label` is suppressed so
+   accessible-name computation has a single unambiguous source.
+2. Else if the consumer passes `aria-label`, that value is used.
+3. Else the variant-derived default applies.
+
+`role` is intentionally locked. The component's `BannerProps` `Omit`s
+`role` from the underlying `HTMLAttributes`, so callers cannot silently
+turn the banner into `role="alert"`.
+
+## Why not `role="alert"`?
+
+1. **`role="alert"` implies `aria-live="assertive"`.** A persistent
+   banner that renders on every page load would interrupt the
+   screen-reader's page-orientation announcement (heading, landmarks)
+   every time, which is jarring.
+2. **Banners are not dynamically injected feedback.** `role="alert"` is
+   correct for content that appears as a _consequence of user action_
+   (form submission failed, item saved). A banner present at initial
+   render does not meet that bar — it is part of the page's furniture.
+3. **`role="banner"` is taken.** The ARIA `banner` role is reserved for
+   the site masthead (`<header>`). Reusing it here would create two
+   `banner` landmarks per page.
+4. **`region` is the right landmark.** Labelled `region` is exactly what
+   ARIA provides for a navigable, named section of page content.
+
+## Distinction from `alert.svelte` and `callout.svelte`
+
+| Trait       | `banner.svelte`                                                        | `alert.svelte`                                                    | `callout.svelte` (forthcoming)              |
+| ----------- | ---------------------------------------------------------------------- | ----------------------------------------------------------------- | ------------------------------------------- |
+| Scope       | Page-level strip                                                       | Contextual card                                                   | Inline prose admonition                     |
+| Role        | `region`                                                               | `alert` + `aria-live="polite"`                                    | none (static prose)                         |
+| Persistence | Persistent, dismissible                                                | Dynamic, sometimes dismissible                                    | Permanent, not dismissible                  |
+| Width       | Full-width                                                             | Inline within content                                             | Inline within prose                         |
+| Variants    | `info \| success \| warning \| danger`                                 | `info \| success \| warning \| error`                             | `note \| tip \| warning \| danger`          |
+| Use when…   | Site-wide condition (trial expiry, maintenance window, cookie consent) | A user action produced feedback that needs immediate announcement | A note appears within flowing documentation |
+
+The `danger` vs `error` variant divergence with `alert.svelte` is
+intentional: the ROADMAP specifies `danger` for banner, and the semantic
+token is `--cinder-danger`. A future unification pass across the trio is
+tracked as a separate ROADMAP item.
+
+## Keyboard interaction
+
+Banner is not a focus trap. Tab order:
+
+1. Interactive elements inside `children`.
+2. Interactive elements inside `actions` (when provided).
+3. The dismiss button (when `dismissible` is `true`).
+
+Enter or Space on the dismiss button fires the handler. Once dismissed,
+the banner is removed from the DOM; focus moves to the next focusable
+element in document order via the browser's default focus-recovery
+behavior.
+
+## Dismiss button
+
+- `<button type="button" aria-label="Dismiss banner">` with an inline
+  SVG × icon marked `aria-hidden="true"`.
+- The interactive hit area is expanded to 44×44 px via a non-layout
+  `::after` pseudo-element (WCAG 2.5.5 Target Size).
+- The visible focus ring uses a two-tone offset + colored ring derived
+  from the active variant token.
+
+## Color and contrast
+
+Variant tokens mirror `alert.svelte`'s contrast model — same lightness
+and chroma derivations against `--cinder-info | success | warning |
+danger`. The package does not currently ship an automated contrast check
+for component variants, so this document does **not** assert WCAG AA
+compliance: the colors are designed to mirror `alert.svelte`'s contrast
+model; verify manually against your specific background before shipping.
+
+## Forced-colors mode
+
+In Windows High Contrast / forced-colors mode the variant background is
+dropped and the strip uses `CanvasText` for its `border-block` and
+`ButtonText` for the dismiss-button focus outline.
+
+## Layout caveats
+
+"Full-width" means the banner fills its **parent container's inline
+size**, not the viewport. To bleed edge-to-edge of the viewport, render
+the banner outside any `max-inline-size` content column — for example,
+as a direct child of the layout shell rather than the content wrapper.
+
+## Multiple banners
+
+Nothing in the API prevents mounting two banners on a page, but doing
+so produces two `region` landmarks with potentially identical accessible
+names, which is noisy under screen-reader landmark navigation. Use one
+page-level banner at a time; for additional simultaneous notifications,
+use `alert.svelte` for the contextual ones.
+
+## Persistence
+
+Dismiss state is purely internal to the component. Consumers who need a
+banner to stay dismissed across navigations should persist that state
+themselves via the `onDismiss` callback (e.g., to `localStorage`).
+Consumers who need a dismissed banner to reappear must `{#key}`-wrap or
+unmount-and-remount the component — re-rendering with the same props
+does not resurrect a dismissed banner.

--- a/packages/components/src/components/banner.a11y.md
+++ b/packages/components/src/components/banner.a11y.md
@@ -38,7 +38,12 @@ The component computes the accessible name in three tiers:
 
 `role` is intentionally locked. The component's `BannerProps` `Omit`s
 `role` from the underlying `HTMLAttributes`, so callers cannot silently
-turn the banner into `role="alert"`.
+turn the banner into `role="alert"`. The component also strips
+`aria-live`, `aria-atomic`, `aria-relevant`, and `aria-busy` from
+rest-props at runtime — the type system permits them (they live on
+`HTMLAttributes`), but the banner is a landmark, not a live region, and
+allowing those attributes through would reintroduce the assertive-
+announcement behavior `role="region"` was chosen to avoid.
 
 ## Why not `role="alert"`?
 
@@ -93,6 +98,10 @@ behavior.
   `::after` pseudo-element (WCAG 2.5.5 Target Size).
 - The visible focus ring uses a two-tone offset + colored ring derived
   from the active variant token.
+- The dismiss button's `aria-label` is hardcoded to English. Internationalization
+  is not yet plumbed through this component (sibling `alert.svelte` has the
+  same constraint); a future `dismissLabel` prop or i18n integration will
+  unify both.
 
 ## Color and contrast
 

--- a/packages/components/src/components/banner.svelte
+++ b/packages/components/src/components/banner.svelte
@@ -1,0 +1,120 @@
+<script lang="ts" module>
+  import type { Snippet } from 'svelte';
+  import type { HTMLAttributes } from 'svelte/elements';
+
+  /**
+   * Visual + semantic variants for {@link Banner}.
+   *
+   * Note: `banner.svelte` uses `danger` (matching the semantic token
+   * `--cinder-danger`) where `alert.svelte` uses `error`. The divergence is
+   * intentional and tracked in `banner.a11y.md`.
+   */
+  export type BannerVariant = 'info' | 'success' | 'warning' | 'danger';
+
+  /**
+   * Props for the page-level {@link Banner} component.
+   *
+   * Banner is distinct from `alert.svelte` (contextual card, `role="alert"`)
+   * and the forthcoming `callout.svelte` (inline prose admonition). A banner
+   * stretches full-width just inside the top of a layout and announces
+   * site-wide conditions such as maintenance windows, trial expiry, or
+   * cookie consent.
+   *
+   * `role` is `Omit`ted from the underlying `HTMLAttributes` because the
+   * component enforces `role="region"`. Accepting a consumer-supplied role
+   * would let callers silently turn the banner into `role="alert"`, which
+   * defeats the landmark-based design (see `banner.a11y.md`).
+   *
+   * "Full-width" means the banner fills its parent container's inline size,
+   * not the viewport. To bleed edge-to-edge, render the banner outside any
+   * `max-inline-size` content column.
+   */
+  export type BannerProps = Omit<HTMLAttributes<HTMLDivElement>, 'children' | 'class' | 'role'> & {
+    /** Visual + semantic variant. Default `'info'`. */
+    variant?: BannerVariant;
+    /** Whether the banner shows a dismiss (×) button. Default `true`. */
+    dismissible?: boolean;
+    /** Called after the dismiss button is clicked. Use to persist state. */
+    onDismiss?: () => void;
+    /** Banner body content. */
+    children: Snippet;
+    /** Optional trailing CTA region (e.g., "Renew now" button). */
+    actions?: Snippet;
+    /** Extra classes appended to the root element. */
+    class?: string;
+  };
+
+  const VARIANT_LABEL = {
+    info: 'Information',
+    success: 'Success',
+    warning: 'Warning',
+    danger: 'Error',
+  } as const;
+</script>
+
+<script lang="ts">
+  import { cn } from '../utilities/class-names.ts';
+
+  let {
+    variant = 'info',
+    dismissible = true,
+    onDismiss,
+    class: className,
+    children,
+    actions,
+    ...rest
+  }: BannerProps = $props();
+
+  let visible = $state(true);
+
+  function handleDismiss() {
+    visible = false;
+    onDismiss?.();
+  }
+
+  const hasLabelledBy = $derived(Boolean(rest['aria-labelledby']));
+  const ariaLabel = $derived(
+    hasLabelledBy ? undefined : (rest['aria-label'] ?? VARIANT_LABEL[variant]),
+  );
+</script>
+
+{#if visible}
+  <div
+    {...rest}
+    class={cn('cinder-banner', className)}
+    data-cinder-variant={variant}
+    role="region"
+    aria-label={ariaLabel}
+  >
+    <div class="cinder-banner__content">
+      {@render children()}
+    </div>
+
+    {#if actions}
+      <div class="cinder-banner__actions">
+        {@render actions()}
+      </div>
+    {/if}
+
+    {#if dismissible}
+      <button
+        type="button"
+        class="cinder-banner__dismiss"
+        onclick={handleDismiss}
+        aria-label="Dismiss banner"
+      >
+        <svg
+          class="cinder-banner__dismiss-icon"
+          xmlns="http://www.w3.org/2000/svg"
+          viewBox="0 0 20 20"
+          fill="currentColor"
+          aria-hidden="true"
+        >
+          <path
+            d="M6.28 5.22a.75.75 0 00-1.06 1.06L8.94 10l-3.72 3.72a.75.75 0 101.06 1.06L10 11.06l3.72 3.72a.75.75 0 101.06-1.06L11.06 10l3.72-3.72a.75.75 0 00-1.06-1.06L10 8.94 6.28 5.22z"
+          />
+        </svg>
+      </button>
+    {/if}
+  </div>
+{/if}

--- a/packages/components/src/components/banner.svelte
+++ b/packages/components/src/components/banner.svelte
@@ -81,8 +81,8 @@
     const focusTarget = rootElement ? resolveFocusTarget(rootElement) : null;
     visible = false;
     await tick();
+    if (focusTarget?.isConnected) focusTarget.focus();
     onDismiss?.();
-    focusTarget?.focus();
   }
 
   function resolveFocusTarget(bannerElement: HTMLElement): HTMLElement | null {

--- a/packages/components/src/components/banner.svelte
+++ b/packages/components/src/components/banner.svelte
@@ -57,6 +57,7 @@
 </script>
 
 <script lang="ts">
+  import { tick } from 'svelte';
   import { classNames } from '../utilities/class-names.ts';
 
   const FOCUSABLE_SELECTOR =
@@ -75,21 +76,31 @@
   let visible = $state(true);
   let rootElement: HTMLDivElement | undefined = $state();
 
-  function handleDismiss() {
-    restoreFocusAfterDismiss();
+  async function handleDismiss() {
+    if (!visible) return;
+    const focusTarget = rootElement ? resolveFocusTarget(rootElement) : null;
     visible = false;
+    await tick();
     onDismiss?.();
+    focusTarget?.focus();
   }
 
-  function restoreFocusAfterDismiss() {
-    if (!rootElement) return;
-    const bannerElement = rootElement;
-    const document = bannerElement.ownerDocument;
-    const activeElement = document.activeElement;
-    if (!(activeElement instanceof HTMLElement) || !bannerElement.contains(activeElement)) return;
+  function resolveFocusTarget(bannerElement: HTMLElement): HTMLElement | null {
+    const bannerDocument = bannerElement.ownerDocument;
+    const activeElement = bannerDocument.activeElement;
+    if (!(activeElement instanceof HTMLElement) || !bannerElement.contains(activeElement)) {
+      return null;
+    }
+    return findFocusTarget(bannerElement, bannerDocument, activeElement);
+  }
 
+  function findFocusTarget(
+    bannerElement: HTMLElement,
+    bannerDocument: Document,
+    activeElement: HTMLElement,
+  ): HTMLElement {
     const candidates = Array.from(
-      document.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR),
+      bannerDocument.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR),
     ).filter(
       (element) =>
         element !== activeElement &&
@@ -106,7 +117,7 @@
       Boolean(bannerElement.compareDocumentPosition(element) & Node.DOCUMENT_POSITION_PRECEDING),
     );
 
-    (next ?? previous ?? document.body).focus();
+    return next ?? previous ?? bannerDocument.body;
   }
 
   // Strip live-region attributes from rest so a consumer cannot turn a

--- a/packages/components/src/components/banner.svelte
+++ b/packages/components/src/components/banner.svelte
@@ -53,7 +53,7 @@
 </script>
 
 <script lang="ts">
-  import { cn } from '../utilities/class-names.ts';
+  import { classNames } from '../utilities/class-names.ts';
 
   let {
     variant = 'info',
@@ -72,16 +72,29 @@
     onDismiss?.();
   }
 
-  const hasLabelledBy = $derived(Boolean(rest['aria-labelledby']));
+  // Strip live-region attributes from rest so a consumer cannot turn a
+  // persistent landmark banner back into an assertive announcement (which
+  // would defeat the role="region" design — see banner.a11y.md).
+  const restWithoutLiveRegion = $derived.by(() => {
+    const {
+      'aria-live': _ariaLive,
+      'aria-atomic': _ariaAtomic,
+      'aria-relevant': _ariaRelevant,
+      'aria-busy': _ariaBusy,
+      ...filtered
+    } = rest;
+    return filtered;
+  });
+
   const ariaLabel = $derived(
-    hasLabelledBy ? undefined : (rest['aria-label'] ?? VARIANT_LABEL[variant]),
+    rest['aria-labelledby'] ? undefined : (rest['aria-label'] ?? VARIANT_LABEL[variant]),
   );
 </script>
 
 {#if visible}
   <div
-    {...rest}
-    class={cn('cinder-banner', className)}
+    {...restWithoutLiveRegion}
+    class={classNames('cinder-banner', className)}
     data-cinder-variant={variant}
     role="region"
     aria-label={ariaLabel}

--- a/packages/components/src/components/banner.svelte
+++ b/packages/components/src/components/banner.svelte
@@ -40,7 +40,11 @@
     children: Snippet;
     /** Optional trailing CTA region (e.g., "Renew now" button). */
     actions?: Snippet;
-    /** Extra classes appended to the root element. */
+    /**
+     * Extra classes appended to the root element. Pass via the explicit
+     * `class` prop — it is excluded from rest-prop spread, so writing
+     * `class="x"` inside spread attributes will not reach the root.
+     */
     class?: string;
   };
 
@@ -55,6 +59,9 @@
 <script lang="ts">
   import { classNames } from '../utilities/class-names.ts';
 
+  const FOCUSABLE_SELECTOR =
+    'button:not([disabled]), a[href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])';
+
   let {
     variant = 'info',
     dismissible = true,
@@ -66,21 +73,53 @@
   }: BannerProps = $props();
 
   let visible = $state(true);
+  let rootElement: HTMLDivElement | undefined = $state();
 
   function handleDismiss() {
+    restoreFocusAfterDismiss();
     visible = false;
     onDismiss?.();
   }
 
+  function restoreFocusAfterDismiss() {
+    if (!rootElement) return;
+    const bannerElement = rootElement;
+    const document = bannerElement.ownerDocument;
+    const activeElement = document.activeElement;
+    if (!(activeElement instanceof HTMLElement) || !bannerElement.contains(activeElement)) return;
+
+    const candidates = Array.from(
+      document.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR),
+    ).filter(
+      (element) =>
+        element !== activeElement &&
+        !bannerElement.contains(element) &&
+        !element.hidden &&
+        element.getAttribute('aria-hidden') !== 'true' &&
+        !element.closest('[hidden], [inert], [aria-hidden="true"]'),
+    );
+
+    const next = candidates.find((element) =>
+      Boolean(bannerElement.compareDocumentPosition(element) & Node.DOCUMENT_POSITION_FOLLOWING),
+    );
+    const previous = candidates.findLast((element) =>
+      Boolean(bannerElement.compareDocumentPosition(element) & Node.DOCUMENT_POSITION_PRECEDING),
+    );
+
+    (next ?? previous ?? document.body).focus();
+  }
+
   // Strip live-region attributes from rest so a consumer cannot turn a
   // persistent landmark banner back into an assertive announcement (which
-  // would defeat the role="region" design — see banner.a11y.md).
+  // would defeat the role="region" design — see banner.a11y.md). `aria-busy`
+  // is intentionally NOT stripped: it is a status flag, not a live-region
+  // attribute, and is valid on `role="region"` to signal that banner
+  // content is updating.
   const restWithoutLiveRegion = $derived.by(() => {
     const {
       'aria-live': _ariaLive,
       'aria-atomic': _ariaAtomic,
       'aria-relevant': _ariaRelevant,
-      'aria-busy': _ariaBusy,
       ...filtered
     } = rest;
     return filtered;
@@ -93,6 +132,7 @@
 
 {#if visible}
   <div
+    bind:this={rootElement}
     {...restWithoutLiveRegion}
     class={classNames('cinder-banner', className)}
     data-cinder-variant={variant}

--- a/packages/components/src/components/banner.test.ts
+++ b/packages/components/src/components/banner.test.ts
@@ -125,21 +125,34 @@ describe('Banner region landmark + accessible name', () => {
     expect(root?.hasAttribute('aria-live')).toBe(false);
   });
 
-  test('consumer-supplied aria-live is stripped (cannot turn banner into a live region)', () => {
+  test('consumer-supplied live-region attributes are stripped', () => {
     const { container } = render(Banner, {
-      // Cast: HTMLAttributes typing exposes aria-live, but banner deliberately
-      // strips it at runtime so the type-allowed attribute is the worst case we
-      // need to verify.
+      // Cast: HTMLAttributes typing exposes live-region attributes, but banner
+      // deliberately strips them at runtime so the type-allowed attributes are
+      // the worst case we need to verify.
       props: {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         ['aria-live' as any]: 'assertive',
         ['aria-atomic' as any]: 'true',
+        ['aria-relevant' as any]: 'additions',
         children: emptySnippet,
       } as never,
     });
     const root = container.querySelector('.cinder-banner');
     expect(root?.hasAttribute('aria-live')).toBe(false);
     expect(root?.hasAttribute('aria-atomic')).toBe(false);
+    expect(root?.hasAttribute('aria-relevant')).toBe(false);
+  });
+
+  test('consumer-supplied aria-busy is preserved', () => {
+    const { container } = render(Banner, {
+      props: {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        ['aria-busy' as any]: 'true',
+        children: emptySnippet,
+      } as never,
+    });
+    expect(container.querySelector('.cinder-banner')?.getAttribute('aria-busy')).toBe('true');
   });
 });
 
@@ -191,6 +204,27 @@ describe('Banner dismiss behavior', () => {
     const button = container.querySelector('.cinder-banner__dismiss') as HTMLButtonElement;
     await fireEvent.click(button);
     expect(callCount).toBe(1);
+  });
+
+  test('dismissing while focused moves focus to the next focusable element', async () => {
+    const { container } = render(Banner, {
+      props: { children: emptySnippet },
+    });
+    const after = document.createElement('button');
+    after.type = 'button';
+    after.textContent = 'Continue';
+    container.after(after);
+
+    try {
+      const button = container.querySelector('.cinder-banner__dismiss') as HTMLButtonElement;
+      button.focus();
+      expect(document.activeElement).toBe(button);
+      await fireEvent.click(button);
+      expect(container.querySelector('.cinder-banner')).toBeNull();
+      expect(document.activeElement).toBe(after);
+    } finally {
+      after.remove();
+    }
   });
 
   test('omitting onDismiss does not throw when the dismiss button is clicked', async () => {
@@ -266,27 +300,5 @@ describe('Banner persistence', () => {
     // Wait a tick — no timer should remove it.
     await new Promise((resolve) => setTimeout(resolve, 20));
     expect(container.querySelector('.cinder-banner')).not.toBeNull();
-  });
-});
-
-describe('Banner public-export shape', () => {
-  // The `Banner` value export and the `BannerProps` / `BannerVariant` type
-  // exports flow through `src/index.ts`. We do not statically import
-  // `../index.ts` here because doing so pulls the barrel — and every
-  // `export type { ... } from './components/<name>.svelte'` line in it —
-  // into the tsc program, where the ambient `*.svelte` declaration cannot
-  // resolve named type exports (TS2614). The runtime smoke import below
-  // catches dropped value exports; type-export regressions are caught by
-  // `bun run build` (which runs `scripts/generate-exports.ts --check` and
-  // `svelte-check`, both of which see the real types).
-  test('Banner value export survives the public entry point', async () => {
-    // Bypass tsc's static import analysis: building the specifier at runtime
-    // keeps `../index.ts` out of the tsconfig.check.json program so the
-    // ambient `*.svelte` declaration does not have to resolve named type
-    // exports (which it cannot). svelte-check + build verify the real types.
-    const specifier = '../index' + '.ts';
-    const indexModule = (await import(specifier)) as Record<string, unknown>;
-    expect(indexModule).toHaveProperty('Banner');
-    expect(typeof indexModule['Banner']).toBe('function');
   });
 });

--- a/packages/components/src/components/banner.test.ts
+++ b/packages/components/src/components/banner.test.ts
@@ -235,6 +235,75 @@ describe('Banner dismiss behavior', () => {
     await fireEvent.click(button);
     expect(container.querySelector('.cinder-banner')).toBeNull();
   });
+
+  test('dismissing while focused falls back to the nearest preceding focusable element', async () => {
+    // Mark every existing focusable as inert-scoped so leakage from prior
+    // tests cannot become the "next" candidate. The component's filter skips
+    // anything inside a `[inert]` ancestor.
+    const inertWrapper = document.createElement('div');
+    inertWrapper.setAttribute('inert', '');
+    while (document.body.firstChild) {
+      inertWrapper.appendChild(document.body.firstChild);
+    }
+    document.body.appendChild(inertWrapper);
+
+    const before = document.createElement('button');
+    before.type = 'button';
+    before.textContent = 'Back';
+    document.body.appendChild(before);
+
+    const { container, unmount } = render(Banner, {
+      props: { children: emptySnippet },
+    });
+
+    try {
+      const button = container.querySelector('.cinder-banner__dismiss') as HTMLButtonElement;
+      button.focus();
+      expect(document.activeElement).toBe(button);
+      await fireEvent.click(button);
+      expect(container.querySelector('.cinder-banner')).toBeNull();
+      expect(document.activeElement).toBe(before);
+    } finally {
+      unmount();
+      before.remove();
+      // Restore the original body children for subsequent tests.
+      while (inertWrapper.firstChild) {
+        document.body.appendChild(inertWrapper.firstChild);
+      }
+      inertWrapper.remove();
+    }
+  });
+
+  test('rapid double-click on dismiss invokes onDismiss exactly once', async () => {
+    let callCount = 0;
+    const { container } = render(Banner, {
+      props: {
+        onDismiss: () => {
+          callCount += 1;
+        },
+        children: emptySnippet,
+      },
+    });
+    const button = container.querySelector('.cinder-banner__dismiss') as HTMLButtonElement;
+    await fireEvent.click(button);
+    await fireEvent.click(button);
+    expect(callCount).toBe(1);
+  });
+
+  test('banner is removed from the DOM before onDismiss fires', async () => {
+    let bannerStillPresent = true;
+    const { container } = render(Banner, {
+      props: {
+        onDismiss: () => {
+          bannerStillPresent = container.querySelector('.cinder-banner') !== null;
+        },
+        children: emptySnippet,
+      },
+    });
+    const button = container.querySelector('.cinder-banner__dismiss') as HTMLButtonElement;
+    await fireEvent.click(button);
+    expect(bannerStillPresent).toBe(false);
+  });
 });
 
 describe('Banner snippets', () => {

--- a/packages/components/src/components/banner.test.ts
+++ b/packages/components/src/components/banner.test.ts
@@ -45,41 +45,16 @@ describe('Banner rendering', () => {
     expect(container.querySelector('#my-banner')).not.toBeNull();
   });
 
-  test('applies data-cinder-variant for variant "info"', () => {
-    const { container } = render(Banner, {
-      props: { variant: 'info', children: emptySnippet },
+  for (const variant of ['info', 'success', 'warning', 'danger'] as const) {
+    test(`applies data-cinder-variant for variant "${variant}"`, () => {
+      const { container } = render(Banner, {
+        props: { variant, children: emptySnippet },
+      });
+      expect(container.querySelector('.cinder-banner')?.getAttribute('data-cinder-variant')).toBe(
+        variant,
+      );
     });
-    expect(container.querySelector('.cinder-banner')?.getAttribute('data-cinder-variant')).toBe(
-      'info',
-    );
-  });
-
-  test('applies data-cinder-variant for variant "success"', () => {
-    const { container } = render(Banner, {
-      props: { variant: 'success', children: emptySnippet },
-    });
-    expect(container.querySelector('.cinder-banner')?.getAttribute('data-cinder-variant')).toBe(
-      'success',
-    );
-  });
-
-  test('applies data-cinder-variant for variant "warning"', () => {
-    const { container } = render(Banner, {
-      props: { variant: 'warning', children: emptySnippet },
-    });
-    expect(container.querySelector('.cinder-banner')?.getAttribute('data-cinder-variant')).toBe(
-      'warning',
-    );
-  });
-
-  test('applies data-cinder-variant for variant "danger"', () => {
-    const { container } = render(Banner, {
-      props: { variant: 'danger', children: emptySnippet },
-    });
-    expect(container.querySelector('.cinder-banner')?.getAttribute('data-cinder-variant')).toBe(
-      'danger',
-    );
-  });
+  }
 
   test('defaults data-cinder-variant to "info" when variant is omitted', () => {
     const { container } = render(Banner, {
@@ -99,35 +74,21 @@ describe('Banner region landmark + accessible name', () => {
     expect(container.querySelector('.cinder-banner')?.getAttribute('role')).toBe('region');
   });
 
-  test('root has aria-label="Information" for info (default)', () => {
-    const { container } = render(Banner, {
-      props: { children: emptySnippet },
+  for (const [variant, expectedLabel] of [
+    ['info', 'Information'],
+    ['success', 'Success'],
+    ['warning', 'Warning'],
+    ['danger', 'Error'],
+  ] as const) {
+    test(`root has aria-label="${expectedLabel}" for variant "${variant}"`, () => {
+      const { container } = render(Banner, {
+        props: { variant, children: emptySnippet },
+      });
+      expect(container.querySelector('.cinder-banner')?.getAttribute('aria-label')).toBe(
+        expectedLabel,
+      );
     });
-    expect(container.querySelector('.cinder-banner')?.getAttribute('aria-label')).toBe(
-      'Information',
-    );
-  });
-
-  test('root has aria-label="Success" for success', () => {
-    const { container } = render(Banner, {
-      props: { variant: 'success', children: emptySnippet },
-    });
-    expect(container.querySelector('.cinder-banner')?.getAttribute('aria-label')).toBe('Success');
-  });
-
-  test('root has aria-label="Warning" for warning', () => {
-    const { container } = render(Banner, {
-      props: { variant: 'warning', children: emptySnippet },
-    });
-    expect(container.querySelector('.cinder-banner')?.getAttribute('aria-label')).toBe('Warning');
-  });
-
-  test('root has aria-label="Error" for danger', () => {
-    const { container } = render(Banner, {
-      props: { variant: 'danger', children: emptySnippet },
-    });
-    expect(container.querySelector('.cinder-banner')?.getAttribute('aria-label')).toBe('Error');
-  });
+  }
 
   test('consumer-provided aria-label overrides variant-derived default', () => {
     const { container } = render(Banner, {
@@ -162,6 +123,23 @@ describe('Banner region landmark + accessible name', () => {
     const root = container.querySelector('.cinder-banner');
     expect(root?.getAttribute('role')).not.toBe('alert');
     expect(root?.hasAttribute('aria-live')).toBe(false);
+  });
+
+  test('consumer-supplied aria-live is stripped (cannot turn banner into a live region)', () => {
+    const { container } = render(Banner, {
+      // Cast: HTMLAttributes typing exposes aria-live, but banner deliberately
+      // strips it at runtime so the type-allowed attribute is the worst case we
+      // need to verify.
+      props: {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        ['aria-live' as any]: 'assertive',
+        ['aria-atomic' as any]: 'true',
+        children: emptySnippet,
+      } as never,
+    });
+    const root = container.querySelector('.cinder-banner');
+    expect(root?.hasAttribute('aria-live')).toBe(false);
+    expect(root?.hasAttribute('aria-atomic')).toBe(false);
   });
 });
 

--- a/packages/components/src/components/banner.test.ts
+++ b/packages/components/src/components/banner.test.ts
@@ -1,0 +1,314 @@
+/// <reference lib="dom" />
+import { describe, expect, test } from 'bun:test';
+import { createRawSnippet } from 'svelte';
+
+import { setupHappyDom } from '../test/happy-dom.ts';
+
+setupHappyDom();
+
+const { render, fireEvent } = await import('@testing-library/svelte');
+const { default: Banner } = await import('./banner.svelte');
+
+function textSnippet(text: string) {
+  return createRawSnippet(() => ({
+    render: () => `<span>${text}</span>`,
+    setup: () => {},
+  }));
+}
+
+const emptySnippet = createRawSnippet(() => ({
+  render: () => `<span></span>`,
+  setup: () => {},
+}));
+
+describe('Banner rendering', () => {
+  test('renders without errors with required props', () => {
+    const { container } = render(Banner, {
+      props: { children: emptySnippet },
+    });
+    expect(container.querySelector('.cinder-banner')).not.toBeNull();
+  });
+
+  test('applies custom class prop to root element while preserving cinder-banner', () => {
+    const { container } = render(Banner, {
+      props: { class: 'my-custom-class', children: emptySnippet },
+    });
+    const root = container.querySelector('.cinder-banner');
+    expect(root?.classList.contains('my-custom-class')).toBe(true);
+    expect(root?.classList.contains('cinder-banner')).toBe(true);
+  });
+
+  test('rest props are spread onto the root element', () => {
+    const { container } = render(Banner, {
+      props: { id: 'my-banner', children: emptySnippet },
+    });
+    expect(container.querySelector('#my-banner')).not.toBeNull();
+  });
+
+  test('applies data-cinder-variant for variant "info"', () => {
+    const { container } = render(Banner, {
+      props: { variant: 'info', children: emptySnippet },
+    });
+    expect(container.querySelector('.cinder-banner')?.getAttribute('data-cinder-variant')).toBe(
+      'info',
+    );
+  });
+
+  test('applies data-cinder-variant for variant "success"', () => {
+    const { container } = render(Banner, {
+      props: { variant: 'success', children: emptySnippet },
+    });
+    expect(container.querySelector('.cinder-banner')?.getAttribute('data-cinder-variant')).toBe(
+      'success',
+    );
+  });
+
+  test('applies data-cinder-variant for variant "warning"', () => {
+    const { container } = render(Banner, {
+      props: { variant: 'warning', children: emptySnippet },
+    });
+    expect(container.querySelector('.cinder-banner')?.getAttribute('data-cinder-variant')).toBe(
+      'warning',
+    );
+  });
+
+  test('applies data-cinder-variant for variant "danger"', () => {
+    const { container } = render(Banner, {
+      props: { variant: 'danger', children: emptySnippet },
+    });
+    expect(container.querySelector('.cinder-banner')?.getAttribute('data-cinder-variant')).toBe(
+      'danger',
+    );
+  });
+
+  test('defaults data-cinder-variant to "info" when variant is omitted', () => {
+    const { container } = render(Banner, {
+      props: { children: emptySnippet },
+    });
+    expect(container.querySelector('.cinder-banner')?.getAttribute('data-cinder-variant')).toBe(
+      'info',
+    );
+  });
+});
+
+describe('Banner region landmark + accessible name', () => {
+  test('root has role="region"', () => {
+    const { container } = render(Banner, {
+      props: { children: emptySnippet },
+    });
+    expect(container.querySelector('.cinder-banner')?.getAttribute('role')).toBe('region');
+  });
+
+  test('root has aria-label="Information" for info (default)', () => {
+    const { container } = render(Banner, {
+      props: { children: emptySnippet },
+    });
+    expect(container.querySelector('.cinder-banner')?.getAttribute('aria-label')).toBe(
+      'Information',
+    );
+  });
+
+  test('root has aria-label="Success" for success', () => {
+    const { container } = render(Banner, {
+      props: { variant: 'success', children: emptySnippet },
+    });
+    expect(container.querySelector('.cinder-banner')?.getAttribute('aria-label')).toBe('Success');
+  });
+
+  test('root has aria-label="Warning" for warning', () => {
+    const { container } = render(Banner, {
+      props: { variant: 'warning', children: emptySnippet },
+    });
+    expect(container.querySelector('.cinder-banner')?.getAttribute('aria-label')).toBe('Warning');
+  });
+
+  test('root has aria-label="Error" for danger', () => {
+    const { container } = render(Banner, {
+      props: { variant: 'danger', children: emptySnippet },
+    });
+    expect(container.querySelector('.cinder-banner')?.getAttribute('aria-label')).toBe('Error');
+  });
+
+  test('consumer-provided aria-label overrides variant-derived default', () => {
+    const { container } = render(Banner, {
+      props: {
+        variant: 'warning',
+        'aria-label': 'Trial expiring soon',
+        children: emptySnippet,
+      },
+    });
+    expect(container.querySelector('.cinder-banner')?.getAttribute('aria-label')).toBe(
+      'Trial expiring soon',
+    );
+  });
+
+  test('consumer-provided aria-labelledby suppresses default aria-label', () => {
+    const { container } = render(Banner, {
+      props: {
+        variant: 'warning',
+        'aria-labelledby': 'external-heading',
+        children: emptySnippet,
+      },
+    });
+    const root = container.querySelector('.cinder-banner');
+    expect(root?.getAttribute('aria-labelledby')).toBe('external-heading');
+    expect(root?.hasAttribute('aria-label')).toBe(false);
+  });
+
+  test('root does not have role="alert" and does not have aria-live', () => {
+    const { container } = render(Banner, {
+      props: { children: emptySnippet },
+    });
+    const root = container.querySelector('.cinder-banner');
+    expect(root?.getAttribute('role')).not.toBe('alert');
+    expect(root?.hasAttribute('aria-live')).toBe(false);
+  });
+});
+
+describe('Banner dismiss behavior', () => {
+  test('renders a dismiss button when dismissible defaults to true', () => {
+    const { container } = render(Banner, {
+      props: { children: emptySnippet },
+    });
+    expect(container.querySelector('.cinder-banner__dismiss')).not.toBeNull();
+  });
+
+  test('does not render dismiss button when dismissible={false}', () => {
+    const { container } = render(Banner, {
+      props: { dismissible: false, children: emptySnippet },
+    });
+    expect(container.querySelector('.cinder-banner__dismiss')).toBeNull();
+  });
+
+  test('dismiss button is a <button type="button"> with aria-label="Dismiss banner"', () => {
+    const { container } = render(Banner, {
+      props: { children: emptySnippet },
+    });
+    const button = container.querySelector('.cinder-banner__dismiss');
+    expect(button).not.toBeNull();
+    expect(button?.tagName).toBe('BUTTON');
+    expect(button?.getAttribute('type')).toBe('button');
+    expect(button?.getAttribute('aria-label')).toBe('Dismiss banner');
+  });
+
+  test('clicking the dismiss button removes the banner from the DOM', async () => {
+    const { container } = render(Banner, {
+      props: { children: emptySnippet },
+    });
+    const button = container.querySelector('.cinder-banner__dismiss') as HTMLButtonElement;
+    await fireEvent.click(button);
+    expect(container.querySelector('.cinder-banner')).toBeNull();
+  });
+
+  test('clicking the dismiss button invokes onDismiss exactly once', async () => {
+    let callCount = 0;
+    const { container } = render(Banner, {
+      props: {
+        onDismiss: () => {
+          callCount += 1;
+        },
+        children: emptySnippet,
+      },
+    });
+    const button = container.querySelector('.cinder-banner__dismiss') as HTMLButtonElement;
+    await fireEvent.click(button);
+    expect(callCount).toBe(1);
+  });
+
+  test('omitting onDismiss does not throw when the dismiss button is clicked', async () => {
+    const { container } = render(Banner, {
+      props: { children: emptySnippet },
+    });
+    const button = container.querySelector('.cinder-banner__dismiss') as HTMLButtonElement;
+    await fireEvent.click(button);
+    expect(container.querySelector('.cinder-banner')).toBeNull();
+  });
+});
+
+describe('Banner snippets', () => {
+  test('children snippet renders inside .cinder-banner__content', () => {
+    const { container } = render(Banner, {
+      props: { children: textSnippet('Maintenance window tonight') },
+    });
+    expect(container.querySelector('.cinder-banner__content')?.textContent).toContain(
+      'Maintenance window tonight',
+    );
+  });
+
+  test('actions snippet renders inside .cinder-banner__actions when provided', () => {
+    const { container } = render(Banner, {
+      props: {
+        children: emptySnippet,
+        actions: textSnippet('Renew now'),
+      },
+    });
+    const actions = container.querySelector('.cinder-banner__actions');
+    expect(actions).not.toBeNull();
+    expect(actions?.textContent).toContain('Renew now');
+  });
+
+  test('.cinder-banner__actions is absent when actions prop is omitted', () => {
+    const { container } = render(Banner, {
+      props: { children: emptySnippet },
+    });
+    expect(container.querySelector('.cinder-banner__actions')).toBeNull();
+  });
+
+  test('actions region appears before dismiss button in DOM order', () => {
+    const { container } = render(Banner, {
+      props: {
+        children: emptySnippet,
+        actions: textSnippet('Renew now'),
+      },
+    });
+    const root = container.querySelector('.cinder-banner') as HTMLElement;
+    const actions = root.querySelector('.cinder-banner__actions') as HTMLElement;
+    const dismiss = root.querySelector('.cinder-banner__dismiss') as HTMLElement;
+    expect(actions).not.toBeNull();
+    expect(dismiss).not.toBeNull();
+    // compareDocumentPosition: 4 == FOLLOWING
+    expect(
+      actions.compareDocumentPosition(dismiss) & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+  });
+});
+
+describe('Banner persistence', () => {
+  test('on initial render the banner is visible', () => {
+    const { container } = render(Banner, {
+      props: { children: emptySnippet },
+    });
+    expect(container.querySelector('.cinder-banner')).not.toBeNull();
+  });
+
+  test('the banner stays in the DOM until dismissed (no auto-hide)', async () => {
+    const { container } = render(Banner, {
+      props: { children: emptySnippet },
+    });
+    // Wait a tick — no timer should remove it.
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    expect(container.querySelector('.cinder-banner')).not.toBeNull();
+  });
+});
+
+describe('Banner public-export shape', () => {
+  // The `Banner` value export and the `BannerProps` / `BannerVariant` type
+  // exports flow through `src/index.ts`. We do not statically import
+  // `../index.ts` here because doing so pulls the barrel — and every
+  // `export type { ... } from './components/<name>.svelte'` line in it —
+  // into the tsc program, where the ambient `*.svelte` declaration cannot
+  // resolve named type exports (TS2614). The runtime smoke import below
+  // catches dropped value exports; type-export regressions are caught by
+  // `bun run build` (which runs `scripts/generate-exports.ts --check` and
+  // `svelte-check`, both of which see the real types).
+  test('Banner value export survives the public entry point', async () => {
+    // Bypass tsc's static import analysis: building the specifier at runtime
+    // keeps `../index.ts` out of the tsconfig.check.json program so the
+    // ambient `*.svelte` declaration does not have to resolve named type
+    // exports (which it cannot). svelte-check + build verify the real types.
+    const specifier = '../index' + '.ts';
+    const indexModule = (await import(specifier)) as Record<string, unknown>;
+    expect(indexModule).toHaveProperty('Banner');
+    expect(typeof indexModule['Banner']).toBe('function');
+  });
+});

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -13,6 +13,9 @@ export type { AvatarProps, AvatarShape, AvatarSize } from './components/avatar.s
 export { default as Badge } from './components/badge.svelte';
 export type { BadgeProps, BadgeSize, BadgeVariant } from './components/badge.svelte';
 
+export { default as Banner } from './components/banner.svelte';
+export type { BannerProps, BannerVariant } from './components/banner.svelte';
+
 export { default as Breadcrumbs } from './components/breadcrumbs.svelte';
 export type { BreadcrumbItem, BreadcrumbsProps } from './components/breadcrumbs.svelte';
 

--- a/packages/components/src/styles/components.css
+++ b/packages/components/src/styles/components.css
@@ -9,6 +9,7 @@
 @import './components/alert.css';
 @import './components/avatar.css';
 @import './components/badge.css';
+@import './components/banner.css';
 @import './components/breadcrumbs.css';
 @import './components/button.css';
 @import './components/button-group.css';

--- a/packages/components/src/styles/components/banner.css
+++ b/packages/components/src/styles/components/banner.css
@@ -212,5 +212,6 @@
   .cinder-banner__dismiss:focus-visible {
     outline: var(--cinder-ring-width) solid ButtonText;
     outline-offset: 3px;
+    box-shadow: none;
   }
 }

--- a/packages/components/src/styles/components/banner.css
+++ b/packages/components/src/styles/components/banner.css
@@ -21,10 +21,14 @@
   color: var(--cinder-text);
   font-size: var(--cinder-text-sm);
   line-height: var(--cinder-leading-normal);
+}
 
-  transition:
-    background-color var(--cinder-duration-fast) var(--cinder-ease-standard),
-    border-color var(--cinder-duration-fast) var(--cinder-ease-standard);
+@media (prefers-reduced-motion: no-preference) {
+  .cinder-banner {
+    transition:
+      background-color var(--cinder-duration-fast) var(--cinder-ease-standard),
+      border-color var(--cinder-duration-fast) var(--cinder-ease-standard);
+  }
 }
 
 /* ----------------------------------------
@@ -70,10 +74,14 @@
   cursor: pointer;
 
   position: relative;
+}
 
-  transition:
-    background-color var(--cinder-duration-fast) var(--cinder-ease-standard),
-    box-shadow var(--cinder-duration-fast) var(--cinder-ease-standard);
+@media (prefers-reduced-motion: no-preference) {
+  .cinder-banner__dismiss {
+    transition:
+      background-color var(--cinder-duration-fast) var(--cinder-ease-standard),
+      box-shadow var(--cinder-duration-fast) var(--cinder-ease-standard);
+  }
 }
 
 /* Expand the interactive hit area to 44×44 px (WCAG 2.5.5) without affecting layout. */
@@ -194,6 +202,11 @@
 @media (forced-colors: active) {
   .cinder-banner {
     border-block: 1px solid CanvasText;
+  }
+
+  /* `color-mix` against transparent is unreliable in forced-colors mode; pin to ButtonFace. */
+  .cinder-banner__dismiss:hover {
+    background: ButtonFace;
   }
 
   .cinder-banner__dismiss:focus-visible {

--- a/packages/components/src/styles/components/banner.css
+++ b/packages/components/src/styles/components/banner.css
@@ -1,0 +1,203 @@
+/* ========================================
+ * BANNER
+ * ----------------------------------------
+ * Full-width, page-level notification strip. Stretches the inline size of
+ * its parent container — to bleed edge-to-edge of the viewport, render
+ * outside any max-width content column.
+ *
+ * No motion is defined in v1; if entry/exit animation is added later, it
+ * must be gated on `prefers-reduced-motion: no-preference`.
+ * ======================================== */
+
+.cinder-banner {
+  display: flex;
+  align-items: center;
+  gap: var(--cinder-space-3);
+  inline-size: 100%;
+  padding-block: var(--cinder-space-3);
+  padding-inline: var(--cinder-space-4);
+  border-block: 1px solid var(--cinder-border);
+  background: var(--cinder-surface);
+  color: var(--cinder-text);
+  font-size: var(--cinder-text-sm);
+  line-height: var(--cinder-leading-normal);
+
+  transition:
+    background-color var(--cinder-duration-fast) var(--cinder-ease-standard),
+    border-color var(--cinder-duration-fast) var(--cinder-ease-standard);
+}
+
+/* ----------------------------------------
+ * Content area
+ * ---------------------------------------- */
+
+.cinder-banner__content {
+  flex: 1;
+  min-width: 0;
+}
+
+/* ----------------------------------------
+ * Actions region
+ * ---------------------------------------- */
+
+.cinder-banner__actions {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--cinder-space-2);
+  flex-shrink: 0;
+}
+
+/* ----------------------------------------
+ * Dismiss button
+ * Mirrors .cinder-alert__dismiss rule-for-rule.
+ * ---------------------------------------- */
+
+.cinder-banner__dismiss {
+  flex-shrink: 0;
+  align-self: center;
+
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.25rem;
+  height: 1.25rem;
+  padding: 0;
+
+  border-radius: var(--cinder-radius-sm);
+  border: none;
+  background: transparent;
+  color: inherit;
+  cursor: pointer;
+
+  position: relative;
+
+  transition:
+    background-color var(--cinder-duration-fast) var(--cinder-ease-standard),
+    box-shadow var(--cinder-duration-fast) var(--cinder-ease-standard);
+}
+
+/* Expand the interactive hit area to 44×44 px (WCAG 2.5.5) without affecting layout. */
+.cinder-banner__dismiss::after {
+  content: '';
+  position: absolute;
+  inset: 50% auto auto 50%;
+  width: 44px;
+  height: 44px;
+  transform: translate(-50%, -50%);
+}
+
+.cinder-banner__dismiss:hover {
+  background: color-mix(in oklch, currentColor, transparent 80%);
+}
+
+.cinder-banner__dismiss:focus-visible {
+  outline: var(--cinder-ring-width) solid transparent;
+  box-shadow:
+    0 0 0 var(--cinder-ring-offset) var(--cinder-ring-offset-color),
+    0 0 0 calc(var(--cinder-ring-offset) + var(--cinder-ring-width))
+      var(--_cinder-banner-ring, var(--cinder-ring-color));
+}
+
+.cinder-banner__dismiss-icon {
+  width: 1rem;
+  height: 1rem;
+}
+
+/* ----------------------------------------
+ * Variant: info
+ * ---------------------------------------- */
+
+.cinder-banner[data-cinder-variant='info'] {
+  --_cinder-banner-ring: var(--cinder-info);
+
+  background-color: light-dark(
+    oklch(from var(--cinder-info) 96.5% 0.015 h),
+    oklch(from var(--cinder-info) 20% 0.03 h)
+  );
+  border-color: light-dark(
+    oklch(from var(--cinder-info) 85% 0.05 h),
+    oklch(from var(--cinder-info) 35% 0.08 h)
+  );
+  color: light-dark(
+    oklch(from var(--cinder-info) 35% 0.12 h),
+    oklch(from var(--cinder-info) 88% 0.12 h)
+  );
+}
+
+/* ----------------------------------------
+ * Variant: success
+ * ---------------------------------------- */
+
+.cinder-banner[data-cinder-variant='success'] {
+  --_cinder-banner-ring: var(--cinder-success);
+
+  background-color: light-dark(
+    oklch(from var(--cinder-success) 96.5% 0.015 h),
+    oklch(from var(--cinder-success) 20% 0.03 h)
+  );
+  border-color: light-dark(
+    oklch(from var(--cinder-success) 85% 0.05 h),
+    oklch(from var(--cinder-success) 35% 0.08 h)
+  );
+  color: light-dark(
+    oklch(from var(--cinder-success) 35% 0.14 h),
+    oklch(from var(--cinder-success) 88% 0.12 h)
+  );
+}
+
+/* ----------------------------------------
+ * Variant: warning
+ * ---------------------------------------- */
+
+.cinder-banner[data-cinder-variant='warning'] {
+  --_cinder-banner-ring: var(--cinder-warning);
+
+  background-color: light-dark(
+    oklch(from var(--cinder-warning) 96.5% 0.015 h),
+    oklch(from var(--cinder-warning) 20% 0.03 h)
+  );
+  border-color: light-dark(
+    oklch(from var(--cinder-warning) 85% 0.05 h),
+    oklch(from var(--cinder-warning) 35% 0.08 h)
+  );
+  color: light-dark(
+    oklch(from var(--cinder-warning) 35% 0.16 h),
+    oklch(from var(--cinder-warning) 88% 0.14 h)
+  );
+}
+
+/* ----------------------------------------
+ * Variant: danger
+ * ---------------------------------------- */
+
+.cinder-banner[data-cinder-variant='danger'] {
+  --_cinder-banner-ring: var(--cinder-danger);
+
+  background-color: light-dark(
+    oklch(from var(--cinder-danger) 96.5% 0.015 h),
+    oklch(from var(--cinder-danger) 20% 0.03 h)
+  );
+  border-color: light-dark(
+    oklch(from var(--cinder-danger) 85% 0.05 h),
+    oklch(from var(--cinder-danger) 35% 0.08 h)
+  );
+  color: light-dark(
+    oklch(from var(--cinder-danger) 35% 0.18 h),
+    oklch(from var(--cinder-danger) 88% 0.16 h)
+  );
+}
+
+/* ----------------------------------------
+ * Forced-colors / high-contrast
+ * ---------------------------------------- */
+
+@media (forced-colors: active) {
+  .cinder-banner {
+    border-block: 1px solid CanvasText;
+  }
+
+  .cinder-banner__dismiss:focus-visible {
+    outline: var(--cinder-ring-width) solid ButtonText;
+    outline-offset: 3px;
+  }
+}


### PR DESCRIPTION
## Summary

Adds `banner.svelte`, a full-width page-level notification component for the cinder component library. Distinct from `alert.svelte` (contextual card, `role="alert"`) and `callout.svelte` (inline prose admonition) — banner is the landmark strip that sits just inside the top of a layout and announces site-wide conditions like maintenance windows, trial expiry, or cookie consent.

- **Variants:** `info` / `success` / `warning` / `danger` with light/dark/forced-colors theming.
- **A11y:** `role="region"` with variant-derived `aria-label` (or consumer `aria-label`/`aria-labelledby` override), live-region attributes stripped at runtime to prevent landmark-to-alert role swaps.
- **Dismiss:** optional × button with focus restoration to the nearest preceding/following focusable element, double-click guard, and a guaranteed "DOM removed → focus restored → `onDismiss`" ordering.
- **Snippets:** required `children`, optional `actions` for trailing CTA.
- **Tests:** 34 tests covering variants, landmark semantics, accessible-name precedence, live-region stripping, dismiss behavior, focus restoration (both fallback paths), double-click guard, onDismiss ordering, and snippet rendering.

Also fixes a pre-existing pre-commit hook bug where `bun exec lint-staged` failed because `bun exec` does not resolve `node_modules/.bin`; switched to `bunx`.

## Review committee

Pre-reviewed across 3 rounds by:
- frontend-architect
- ux-designer
- testing-expert
- simplicity-engineer
- Codex (gpt-5.4, xhigh round 1 → high rounds 2–3)

All must-fix items addressed. Notable iterations:
- Round 1 + 2 (pre-existing commits): live-region attribute stripping, forced-colors hover pin, aria-labelledby precedence, role-lockout, focus-loss handling.
- Round 3 (this push): forced-colors `box-shadow: none` to prevent double ring; `handleDismiss` reordered so DOM is detached before focus restoration and `onDismiss`, with double-click guard; new tests for the preceding-focusable fallback path, double-click guard, and DOM-removed-before-onDismiss contract.
- Codex round 3 hostile pass: caught that the initial reorder called `onDismiss` before focus restoration — now restores focus first (still after DOM flush), then invokes the callback, so focus is guaranteed even if `onDismiss` throws and consumers can override focus without the banner stealing it back.

## Test plan

- [x] `bun test packages/components/src/components/banner.test.ts` — 34 pass
- [x] `bun test packages/components` — 1622 pass across 109 files
- [x] `bunx svelte-check` on `packages/components` — 0 errors, no banner-related warnings
- [x] `bun run lint` — clean
- [ ] Manual: verify variants render correctly in light/dark/forced-colors mode in a consumer app
- [ ] Manual: keyboard navigation — Tab into banner, Enter on dismiss, focus lands sensibly

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new exported UI component with non-trivial a11y and focus-management behavior; risk is mainly around consumer integration and keyboard/screen-reader expectations rather than data/security concerns.
> 
> **Overview**
> Adds a new `Banner` component for full-width, page-level notifications, including variants (`info|success|warning|danger`), optional actions slot, and dismiss behavior that removes the banner and restores focus.
> 
> Bakes in accessibility semantics by enforcing `role="region"`, computing a default/overridable accessible name, and stripping live-region attributes from rest props; ships styling (`banner.css`) including forced-colors handling and adds a comprehensive `banner.test.ts` suite.
> 
> Also updates package exports/index/styles aggregators to publish `banner.svelte`, and fixes the pre-commit hook to run `lint-staged` via `bunx` instead of `bun exec`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ef4d2ce0e24a1ce9730dc57b672c459bccb6643d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->