### PR TITLE
feat(sidebar): add layout-level navigation container

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -289,6 +289,10 @@
       "svelte": "./src/components/side-navigation.svelte",
       "types": "./dist/components/side-navigation.svelte.d.ts"
     },
+    "./sidebar": {
+      "svelte": "./src/components/sidebar.svelte",
+      "types": "./dist/components/sidebar.svelte.d.ts"
+    },
     "./skeleton": {
       "svelte": "./src/components/skeleton.svelte",
       "types": "./dist/components/skeleton.svelte.d.ts"

--- a/packages/components/src/_internal/sidebar-context.ts
+++ b/packages/components/src/_internal/sidebar-context.ts
@@ -1,0 +1,38 @@
+/**
+ * Internal sidebar context. Published by `<Sidebar>` so descendant components
+ * (e.g. `side-navigation-group`, `navigation-item`) can adapt to the sidebar's
+ * collapsed state without prop drilling.
+ *
+ * The context value intentionally exposes only `collapsed` for v1. Additional
+ * coordination signals require a separate API review.
+ */
+
+import { getContext } from 'svelte';
+
+/**
+ * Context published by `<Sidebar>` for descendant components. `collapsed` is a
+ * getter so reads stay reactive — destructuring breaks reactivity, property
+ * reads preserve it.
+ */
+export type SidebarContextValue = {
+  /** True when the sidebar is in icon-only / hidden mode. */
+  readonly collapsed: boolean;
+};
+
+/** Symbol key for the sidebar Svelte context. Not exported from package root. */
+export const SIDEBAR_CONTEXT_KEY = Symbol('cinder.sidebar');
+
+/**
+ * Read the nearest enclosing `<Sidebar>` context. Returns `undefined` when no
+ * `<Sidebar>` ancestor exists. Readers must handle the `undefined` case.
+ *
+ * The try-catch mirrors the SSR/test-environment edge case documented in
+ * `form-field-context.ts` and `surface-context.ts`.
+ */
+export function getSidebarContext(): SidebarContextValue | undefined {
+  try {
+    return getContext<SidebarContextValue | undefined>(SIDEBAR_CONTEXT_KEY);
+  } catch {
+    return undefined;
+  }
+}

--- a/packages/components/src/components/sidebar.a11y.md
+++ b/packages/components/src/components/sidebar.a11y.md
@@ -7,21 +7,28 @@ landmark; below the `md` breakpoint (~767px) it renders inside a `<Drawer>`.
 ## Landmark structure
 
 - Outer container is `<aside>` with a required `aria-label` (defaults to "Sidebar").
-- The actual navigation list lives inside a nested `<nav>` element that carries
-  the same `aria-label`. The `<aside>` provides a complementary-content landmark;
-  the inner `<nav>` provides the navigation landmark. Both must have distinct,
-  non-empty labels if the page has more than one of each kind.
+- The inner navigation list lives inside a nested `<nav>` element whose
+  accessible name is derived by appending `" navigation"` to `ariaLabel`. So
+  with `ariaLabel="Workspace"` the `<aside>` is announced as "Workspace,
+  complementary" and the inner `<nav>` as "Workspace navigation". The two
+  landmarks are distinct in the landmarks list — the component owns this
+  separation; consumers do not pass two labels.
+- If the page contains more than one `<aside>` or more than one navigation
+  landmark, pass a unique `ariaLabel` per Sidebar instance. The default
+  "Sidebar" is fine for a single-sidebar page but collides on dashboards with
+  primary + contextual sidebars.
 - Below the `md` breakpoint the `<aside>` is replaced by `<Drawer>`. The drawer
   carries its own `<dialog role="dialog" aria-modal="true">` and an internal
   heading sourced from `ariaLabel`; the inner `<nav>` is still present inside
-  the drawer body.
+  the drawer body with the same derived `" navigation"` label.
 
 ## ARIA attributes
 
-| Prop / source                                            | Attribute on aside / drawer                 |
-| -------------------------------------------------------- | ------------------------------------------- |
-| `ariaLabel` (default `'Sidebar'`)                        | `aria-label` on `<aside>` and inner `<nav>` |
-| Passing `aria-label` or `aria-labelledby` via rest props | Stripped — the required prop always wins    |
+| Prop / source                                            | Attribute on aside / drawer                  |
+| -------------------------------------------------------- | -------------------------------------------- |
+| `ariaLabel` (default `'Sidebar'`)                        | `aria-label` on `<aside>` (or drawer `<h2>`) |
+| `ariaLabel` (derived `"${ariaLabel} navigation"`)        | `aria-label` on inner `<nav>`                |
+| Passing `aria-label` or `aria-labelledby` via rest props | Stripped — the required prop always wins     |
 
 An empty or whitespace-only `ariaLabel` throws at render time. This is a hard
 fail because a landmark with no accessible name is worse than no landmark — it
@@ -29,15 +36,23 @@ gets announced as a duplicate by screen readers without context.
 
 ## Collapsed mode
 
-Sidebar publishes a `collapsed` boolean via context. Descendant components
-(e.g. `side-navigation-group`, `navigation-item`) can read this context to switch
-to an icon-only presentation. Sidebar itself applies a `data-cinder-collapsed`
-attribute on the `<aside>` in desktop mode, which the stylesheet uses to hide
-text labels in nav children.
+Sidebar publishes a `collapsed` boolean via context. Sidebar itself applies a
+`data-cinder-collapsed` attribute on the inline `<aside>` (or on the mobile
+wrapper inside the drawer) which the stylesheet uses to hide visible text
+labels in nav children.
 
-**Consumer guideline**: Every `NavigationItem` inside a collapsible sidebar must
-carry an `aria-label` so the icon-only presentation retains an accessible name.
-Cinder does not synthesize labels from icon glyphs; the consumer owns the text.
+**Accessibility-preserving hide.** Visible text labels (`SideNavigationGroup`
+section headers and `NavigationItem` leaf text) are hidden using the
+visually-hidden technique (`position: absolute; clip: rect(0,0,0,0); ...`)
+rather than `display: none`. The visual presentation is icon-only, but each
+focusable element retains its accessible name in the accessibility tree, so
+screen-reader users still hear the label when focus lands on the trigger or
+link. Decorative chrome (group badge, chevron, disclosed panel) is hidden with
+`display: none` because it has no accessible name to preserve.
+
+**Consumer guideline.** Every icon inside a collapsible Sidebar should be
+marked `aria-hidden="true"` so it does not duplicate the accessible name. The
+text label is what names the element; the icon is decoration.
 
 ## Mobile drawer behavior
 
@@ -54,6 +69,30 @@ The brand region renders inline at the top of the drawer body (not as the
 drawer's `<h2>` title), so the drawer's visible heading reflects `ariaLabel`
 and the brand block stays a visual region rather than the accessible name.
 
+### Wiring the mobile trigger
+
+The mobile drawer has no built-in opener — by design, since the trigger
+typically lives in a top navigation bar outside the sidebar. The recommended
+pattern is a hamburger button with `aria-controls` pointing at the sidebar and
+`aria-expanded` reflecting `!collapsed`:
+
+```svelte
+<button
+  type="button"
+  aria-controls="primary-sidebar"
+  aria-expanded={!collapsed}
+  aria-label="Open primary navigation"
+  onclick={() => (collapsed = !collapsed)}
+>
+  <!-- hamburger icon -->
+</button>
+
+<Sidebar id="primary-sidebar" bind:collapsed ariaLabel="Workspace">...</Sidebar>
+```
+
+This wires the open/close affordance into the page chrome and keeps the
+trigger discoverable on mobile.
+
 ## SSR behavior
 
 In desktop / inline mode the `<aside>` renders normally on the server. In
@@ -63,4 +102,8 @@ hydrated-open on a mobile-width SSR response will paint one frame later than
 the desktop counterpart.
 
 The `MediaQuery` SSR fallback is `false`, so the server renders the desktop
-branch by default.
+branch by default. On a mobile-width viewport, the user briefly sees the
+desktop `<aside>` before the client-side `MediaQuery` flips and the component
+switches to the drawer branch — a one-frame layout shift. If first-paint
+mobile correctness matters more than desktop, set `collapsed={true}` as a safe
+default so the desktop sidebar renders in icon-only mode before the swap.

--- a/packages/components/src/components/sidebar.a11y.md
+++ b/packages/components/src/components/sidebar.a11y.md
@@ -1,0 +1,66 @@
+# Sidebar — Accessibility Notes
+
+Sidebar is a layout-level navigation container that combines branding, a vertical
+nav region, and an optional footer. On wide viewports it renders inline as a
+landmark; below the `md` breakpoint (~767px) it renders inside a `<Drawer>`.
+
+## Landmark structure
+
+- Outer container is `<aside>` with a required `aria-label` (defaults to "Sidebar").
+- The actual navigation list lives inside a nested `<nav>` element that carries
+  the same `aria-label`. The `<aside>` provides a complementary-content landmark;
+  the inner `<nav>` provides the navigation landmark. Both must have distinct,
+  non-empty labels if the page has more than one of each kind.
+- Below the `md` breakpoint the `<aside>` is replaced by `<Drawer>`. The drawer
+  carries its own `<dialog role="dialog" aria-modal="true">` and an internal
+  heading sourced from `ariaLabel`; the inner `<nav>` is still present inside
+  the drawer body.
+
+## ARIA attributes
+
+| Prop / source                                            | Attribute on aside / drawer                 |
+| -------------------------------------------------------- | ------------------------------------------- |
+| `ariaLabel` (default `'Sidebar'`)                        | `aria-label` on `<aside>` and inner `<nav>` |
+| Passing `aria-label` or `aria-labelledby` via rest props | Stripped — the required prop always wins    |
+
+An empty or whitespace-only `ariaLabel` throws at render time. This is a hard
+fail because a landmark with no accessible name is worse than no landmark — it
+gets announced as a duplicate by screen readers without context.
+
+## Collapsed mode
+
+Sidebar publishes a `collapsed` boolean via context. Descendant components
+(e.g. `side-navigation-group`, `navigation-item`) can read this context to switch
+to an icon-only presentation. Sidebar itself applies a `data-cinder-collapsed`
+attribute on the `<aside>` in desktop mode, which the stylesheet uses to hide
+text labels in nav children.
+
+**Consumer guideline**: Every `NavigationItem` inside a collapsible sidebar must
+carry an `aria-label` so the icon-only presentation retains an accessible name.
+Cinder does not synthesize labels from icon glyphs; the consumer owns the text.
+
+## Mobile drawer behavior
+
+Below `md`, Sidebar renders inside `<Drawer side="left" size="md">`. The
+`collapsed` prop maps to drawer state:
+
+- `collapsed=false` → drawer open
+- `collapsed=true` → drawer closed
+
+Mobile drawer inherits Drawer's focus trap, ESC handling, body scroll lock, and
+backdrop click — see [`drawer.a11y.md`](drawer.a11y.md).
+
+The brand region renders inline at the top of the drawer body (not as the
+drawer's `<h2>` title), so the drawer's visible heading reflects `ariaLabel`
+and the brand block stays a visual region rather than the accessible name.
+
+## SSR behavior
+
+In desktop / inline mode the `<aside>` renders normally on the server. In
+mobile mode the drawer follows the [OVERLAY-POLICY](../_internal/OVERLAY-POLICY.md):
+no overlay markup is emitted on the server. A sidebar that should appear
+hydrated-open on a mobile-width SSR response will paint one frame later than
+the desktop counterpart.
+
+The `MediaQuery` SSR fallback is `false`, so the server renders the desktop
+branch by default.

--- a/packages/components/src/components/sidebar.a11y.md
+++ b/packages/components/src/components/sidebar.a11y.md
@@ -36,19 +36,24 @@ gets announced as a duplicate by screen readers without context.
 
 ## Collapsed mode
 
-Sidebar publishes a `collapsed` boolean via context. Sidebar itself applies a
-`data-cinder-collapsed` attribute on the inline `<aside>` (or on the mobile
-wrapper inside the drawer) which the stylesheet uses to hide visible text
-labels in nav children.
+Sidebar publishes a `collapsed` boolean via context. On the inline `<aside>`
+desktop branch, Sidebar applies a `data-cinder-collapsed` attribute that the
+stylesheet uses to hide visible text labels in nav children (icon-rail mode).
+The mobile branch deliberately omits the attribute: there, `collapsed=true`
+means "drawer closed" rather than "icon-only", and `collapsed=false` means
+"drawer open". Activating the icon-rail CSS inside an open drawer would cause
+a one-frame label flash when the consumer flips `collapsed` from `true` to
+`false` to open the drawer.
 
 **Accessibility-preserving hide.** Visible text labels (`SideNavigationGroup`
-section headers and `NavigationItem` leaf text) are hidden using the
-visually-hidden technique (`position: absolute; clip: rect(0,0,0,0); ...`)
-rather than `display: none`. The visual presentation is icon-only, but each
-focusable element retains its accessible name in the accessibility tree, so
-screen-reader users still hear the label when focus lands on the trigger or
-link. Decorative chrome (group badge, chevron, disclosed panel) is hidden with
-`display: none` because it has no accessible name to preserve.
+section headers and `NavigationItem` leaf text) are visually removed without
+using `display: none`. Element children use the standard visually-hidden
+technique (`position: absolute; clip: rect(0,0,0,0); ...`); direct text nodes
+are suppressed by setting the item `font-size` to `0` while restoring icon
+descendant sizing. The visual presentation is icon-only, but the label text
+stays in the DOM for accessible-name computation. Decorative chrome (group
+badge, chevron, disclosed panel) is hidden with `display: none` because it has
+no accessible name to preserve.
 
 **Consumer guideline.** Every icon inside a collapsible Sidebar should be
 marked `aria-hidden="true"` so it does not duplicate the accessible name. The
@@ -91,7 +96,9 @@ pattern is a hamburger button with `aria-controls` pointing at the sidebar and
 ```
 
 This wires the open/close affordance into the page chrome and keeps the
-trigger discoverable on mobile.
+trigger discoverable on mobile. On desktop, `id` lands on the `<aside>`; on
+mobile, the same `id` lands on the persistent drawer `<dialog>` so
+`aria-controls` still resolves while the drawer panel content is closed.
 
 ## SSR behavior
 

--- a/packages/components/src/components/sidebar.svelte
+++ b/packages/components/src/components/sidebar.svelte
@@ -1,0 +1,133 @@
+<script lang="ts" module>
+  import type { Snippet } from 'svelte';
+  import type { HTMLAttributes } from 'svelte/elements';
+
+  /** Props for the Sidebar component. */
+  export type SidebarProps = Omit<
+    HTMLAttributes<HTMLElement>,
+    'aria-label' | 'aria-labelledby' | 'class' | 'children'
+  > & {
+    /**
+     * Whether the sidebar is collapsed. Bindable via `bind:collapsed`. Default `false`.
+     *
+     * On desktop (>= md breakpoint) `collapsed=true` switches the sidebar to
+     * icon-only mode. Below the md breakpoint the sidebar renders inside a
+     * `<Drawer>` and `collapsed=true` means the drawer is closed.
+     */
+    collapsed?: boolean;
+    /**
+     * Accessible name for the outer landmark and the mobile drawer. Required.
+     * Must be non-empty and distinct from any other landmark on the page.
+     */
+    ariaLabel?: string;
+    /** Additional CSS class merged with `.cinder-sidebar`. */
+    class?: string;
+    /** Optional branding region rendered above the navigation. */
+    brand?: Snippet;
+    /** Navigation region. Typically a `<SideNavigation>` subtree. Required. */
+    navigation: Snippet;
+    /** Optional footer region (e.g. user account, sign-out). */
+    footer?: Snippet;
+  };
+</script>
+
+<script lang="ts">
+  import { setContext } from 'svelte';
+  import { MediaQuery } from 'svelte/reactivity';
+
+  import { SIDEBAR_CONTEXT_KEY, type SidebarContextValue } from '../_internal/sidebar-context.ts';
+  import { classNames } from '../utilities/class-names.ts';
+  import Drawer from './drawer.svelte';
+
+  type SidebarRuntimeProps = SidebarProps & {
+    'aria-label'?: unknown;
+    'aria-labelledby'?: unknown;
+  };
+
+  let {
+    collapsed = $bindable(false),
+    ariaLabel = 'Sidebar',
+    class: className,
+    brand: brandSnippet,
+    navigation: navigationSnippet,
+    footer: footerSnippet,
+    'aria-label': _ariaLabelAttribute,
+    'aria-labelledby': _ariaLabelledbyAttribute,
+    ...rest
+  }: SidebarRuntimeProps = $props();
+
+  const validatedLabel = $derived.by(() => {
+    if (ariaLabel.trim() === '') {
+      throw new Error('Sidebar requires a non-empty ariaLabel.');
+    }
+    return ariaLabel;
+  });
+
+  // Breakpoint matches the existing `47.99rem` (~767px) convention used by
+  // navigation-bar.css and navigation-item.css. The `(max-width: ...)` form
+  // is true on mobile (< md) and false on desktop.
+  const mobile = new MediaQuery('max-width: 47.99rem', false);
+
+  const context: SidebarContextValue = {
+    get collapsed() {
+      return collapsed;
+    },
+  };
+  setContext(SIDEBAR_CONTEXT_KEY, context);
+</script>
+
+{#if mobile.current}
+  <Drawer
+    bind:open={
+      () => !collapsed,
+      (value: boolean) => {
+        collapsed = !value;
+      }
+    }
+    side="left"
+    size="md"
+    title={validatedLabel}
+    class={classNames('cinder-sidebar', 'cinder-sidebar--mobile', className)}
+  >
+    {#if brandSnippet}
+      <div class="cinder-sidebar__brand">
+        {@render brandSnippet()}
+      </div>
+    {/if}
+
+    <nav class="cinder-sidebar__nav" aria-label={validatedLabel}>
+      {@render navigationSnippet()}
+    </nav>
+
+    {#snippet footer()}
+      {#if footerSnippet}
+        <div class="cinder-sidebar__footer">
+          {@render footerSnippet()}
+        </div>
+      {/if}
+    {/snippet}
+  </Drawer>
+{:else}
+  <aside
+    {...rest}
+    class={classNames('cinder-sidebar', className)}
+    aria-label={validatedLabel}
+    data-cinder-collapsed={collapsed ? '' : undefined}
+  >
+    {#if brandSnippet}
+      <div class="cinder-sidebar__brand">
+        {@render brandSnippet()}
+      </div>
+    {/if}
+
+    <nav class="cinder-sidebar__nav" aria-label={validatedLabel}>
+      {@render navigationSnippet()}
+    </nav>
+
+    {#if footerSnippet}
+      <div class="cinder-sidebar__footer">
+        {@render footerSnippet()}
+      </div>
+    {/if}
+  </aside>
+{/if}

--- a/packages/components/src/components/sidebar.svelte
+++ b/packages/components/src/components/sidebar.svelte
@@ -110,15 +110,13 @@
       <nav class="cinder-sidebar__nav" aria-label={navigationLabel}>
         {@render navigationSnippet()}
       </nav>
-    </div>
 
-    {#snippet footer()}
       {#if footerSnippet}
         <div class="cinder-sidebar__footer cinder-sidebar__footer--mobile">
           {@render footerSnippet()}
         </div>
       {/if}
-    {/snippet}
+    </div>
   </Drawer>
 {:else}
   <aside

--- a/packages/components/src/components/sidebar.svelte
+++ b/packages/components/src/components/sidebar.svelte
@@ -16,8 +16,11 @@
      */
     collapsed?: boolean;
     /**
-     * Accessible name for the outer landmark and the mobile drawer. Required.
-     * Must be non-empty and distinct from any other landmark on the page.
+     * Accessible name for the outer landmark and the mobile drawer. Required —
+     * defaults to `'Sidebar'` for convenience but must be unique per page. The
+     * inner `<nav>` landmark derives its own accessible name from this value
+     * by appending `' navigation'` so screen readers can distinguish the
+     * outer complementary region from the inner navigation region.
      */
     ariaLabel?: string;
     /** Additional CSS class merged with `.cinder-sidebar`. */
@@ -63,10 +66,16 @@
     return ariaLabel;
   });
 
+  // The inner <nav> landmark gets a distinct accessible name so the outer
+  // complementary <aside> and the inner navigation are not announced as two
+  // identically-named landmarks.
+  const navigationLabel = $derived(`${validatedLabel} navigation`);
+
   // Breakpoint matches the existing `47.99rem` (~767px) convention used by
-  // navigation-bar.css and navigation-item.css. The `(max-width: ...)` form
-  // is true on mobile (< md) and false on desktop.
-  const mobile = new MediaQuery('max-width: 47.99rem', false);
+  // navigation-bar.css and navigation-item.css. The fully-parenthesized form
+  // is required — `window.matchMedia` rejects bare media feature expressions
+  // on Firefox and Safari.
+  const mobile = new MediaQuery('(max-width: 47.99rem)', false);
 
   const context: SidebarContextValue = {
     get collapsed() {
@@ -87,21 +96,26 @@
     side="left"
     size="md"
     title={validatedLabel}
-    class={classNames('cinder-sidebar', 'cinder-sidebar--mobile', className)}
   >
-    {#if brandSnippet}
-      <div class="cinder-sidebar__brand">
-        {@render brandSnippet()}
-      </div>
-    {/if}
+    <div
+      {...rest}
+      class={classNames('cinder-sidebar', 'cinder-sidebar--mobile', className)}
+      data-cinder-collapsed={collapsed ? '' : undefined}
+    >
+      {#if brandSnippet}
+        <div class="cinder-sidebar__brand">
+          {@render brandSnippet()}
+        </div>
+      {/if}
 
-    <nav class="cinder-sidebar__nav" aria-label={validatedLabel}>
-      {@render navigationSnippet()}
-    </nav>
+      <nav class="cinder-sidebar__nav" aria-label={navigationLabel}>
+        {@render navigationSnippet()}
+      </nav>
+    </div>
 
     {#snippet footer()}
       {#if footerSnippet}
-        <div class="cinder-sidebar__footer">
+        <div class="cinder-sidebar__footer cinder-sidebar__footer--mobile">
           {@render footerSnippet()}
         </div>
       {/if}
@@ -120,7 +134,7 @@
       </div>
     {/if}
 
-    <nav class="cinder-sidebar__nav" aria-label={validatedLabel}>
+    <nav class="cinder-sidebar__nav" aria-label={navigationLabel}>
       {@render navigationSnippet()}
     </nav>
 

--- a/packages/components/src/components/sidebar.svelte
+++ b/packages/components/src/components/sidebar.svelte
@@ -48,6 +48,7 @@
   };
 
   let {
+    id: sidebarId,
     collapsed = $bindable(false),
     ariaLabel = 'Sidebar',
     class: className,
@@ -87,6 +88,7 @@
 
 {#if mobile.current}
   <Drawer
+    {...rest}
     bind:open={
       () => !collapsed,
       (value: boolean) => {
@@ -96,12 +98,9 @@
     side="left"
     size="md"
     title={validatedLabel}
+    id={sidebarId}
   >
-    <div
-      {...rest}
-      class={classNames('cinder-sidebar', 'cinder-sidebar--mobile', className)}
-      data-cinder-collapsed={collapsed ? '' : undefined}
-    >
+    <div class={classNames('cinder-sidebar', 'cinder-sidebar--mobile', className)}>
       {#if brandSnippet}
         <div class="cinder-sidebar__brand">
           {@render brandSnippet()}
@@ -123,6 +122,7 @@
   </Drawer>
 {:else}
   <aside
+    id={sidebarId}
     {...rest}
     class={classNames('cinder-sidebar', className)}
     aria-label={validatedLabel}

--- a/packages/components/src/components/sidebar.test.ts
+++ b/packages/components/src/components/sidebar.test.ts
@@ -1,0 +1,201 @@
+/// <reference lib="dom" />
+import { describe, expect, test } from 'bun:test';
+import { createRawSnippet } from 'svelte';
+
+import { setupHappyDom } from '../test/happy-dom.ts';
+
+setupHappyDom();
+
+const { render } = await import('@testing-library/svelte');
+const { default: Sidebar } = await import('./sidebar.svelte');
+
+function textSnippet(text: string) {
+  return createRawSnippet(() => ({
+    render: () => `<span>${text}</span>`,
+    setup: () => {},
+  }));
+}
+
+function listSnippet(text: string) {
+  return createRawSnippet(() => ({
+    render: () => `<ul><li>${text}</li></ul>`,
+    setup: () => {},
+  }));
+}
+
+describe('Sidebar (desktop / inline aside)', () => {
+  test('renders an <aside> landmark', () => {
+    const { container } = render(Sidebar, {
+      props: { navigation: listSnippet('items') },
+    });
+    expect(container.querySelector('aside')).not.toBeNull();
+  });
+
+  test('aside has default aria-label "Sidebar"', () => {
+    const { container } = render(Sidebar, {
+      props: { navigation: listSnippet('items') },
+    });
+    expect(container.querySelector('aside')?.getAttribute('aria-label')).toBe('Sidebar');
+  });
+
+  test('aside uses the supplied ariaLabel', () => {
+    const { container } = render(Sidebar, {
+      props: { ariaLabel: 'Workspace', navigation: listSnippet('items') },
+    });
+    expect(container.querySelector('aside')?.getAttribute('aria-label')).toBe('Workspace');
+  });
+
+  test('empty ariaLabel throws on initial render', () => {
+    expect(() => {
+      render(Sidebar, {
+        props: { ariaLabel: '', navigation: listSnippet('items') },
+      });
+    }).toThrow();
+  });
+
+  test('whitespace-only ariaLabel throws on initial render', () => {
+    expect(() => {
+      render(Sidebar, {
+        props: { ariaLabel: '   ', navigation: listSnippet('items') },
+      });
+    }).toThrow();
+  });
+
+  test('aside carries cinder-sidebar class', () => {
+    const { container } = render(Sidebar, {
+      props: { navigation: listSnippet('items') },
+    });
+    expect(container.querySelector('aside.cinder-sidebar')).not.toBeNull();
+  });
+
+  test('consumer class prop merges onto the aside', () => {
+    const { container } = render(Sidebar, {
+      props: { class: 'my-sidebar', navigation: listSnippet('items') },
+    });
+    const aside = container.querySelector('aside');
+    expect(aside?.classList.contains('cinder-sidebar')).toBe(true);
+    expect(aside?.classList.contains('my-sidebar')).toBe(true);
+  });
+
+  test('renders <nav> inside the aside with matching aria-label', () => {
+    const { container } = render(Sidebar, {
+      props: { ariaLabel: 'Workspace', navigation: listSnippet('items') },
+    });
+    const nav = container.querySelector('aside nav.cinder-sidebar__nav');
+    expect(nav).not.toBeNull();
+    expect(nav?.getAttribute('aria-label')).toBe('Workspace');
+  });
+
+  test('renders navigation snippet inside the nav', () => {
+    const { container } = render(Sidebar, {
+      props: { navigation: listSnippet('payload') },
+    });
+    const nav = container.querySelector('aside nav.cinder-sidebar__nav');
+    expect(nav?.textContent ?? '').toContain('payload');
+  });
+
+  test('omits brand region when no brand snippet is provided', () => {
+    const { container } = render(Sidebar, {
+      props: { navigation: listSnippet('items') },
+    });
+    expect(container.querySelector('.cinder-sidebar__brand')).toBeNull();
+  });
+
+  test('renders brand snippet inside .cinder-sidebar__brand when provided', () => {
+    const { container } = render(Sidebar, {
+      props: { brand: textSnippet('Cinder'), navigation: listSnippet('items') },
+    });
+    const brand = container.querySelector('.cinder-sidebar__brand');
+    expect(brand).not.toBeNull();
+    expect(brand?.textContent ?? '').toContain('Cinder');
+  });
+
+  test('omits footer region when no footer snippet is provided', () => {
+    const { container } = render(Sidebar, {
+      props: { navigation: listSnippet('items') },
+    });
+    expect(container.querySelector('.cinder-sidebar__footer')).toBeNull();
+  });
+
+  test('renders footer snippet inside .cinder-sidebar__footer when provided', () => {
+    const { container } = render(Sidebar, {
+      props: { footer: textSnippet('Sign out'), navigation: listSnippet('items') },
+    });
+    const footer = container.querySelector('.cinder-sidebar__footer');
+    expect(footer).not.toBeNull();
+    expect(footer?.textContent ?? '').toContain('Sign out');
+  });
+
+  test('does not set data-cinder-collapsed when collapsed=false', () => {
+    const { container } = render(Sidebar, {
+      props: { collapsed: false, navigation: listSnippet('items') },
+    });
+    expect(container.querySelector('aside')?.hasAttribute('data-cinder-collapsed')).toBe(false);
+  });
+
+  test('sets data-cinder-collapsed when collapsed=true', () => {
+    const { container } = render(Sidebar, {
+      props: { collapsed: true, navigation: listSnippet('items') },
+    });
+    expect(container.querySelector('aside')?.hasAttribute('data-cinder-collapsed')).toBe(true);
+  });
+
+  test('aria-label in rest spread cannot override the component-owned ariaLabel', () => {
+    const { container } = render(Sidebar, {
+      props: {
+        ariaLabel: 'Sections',
+        'aria-label': 'Overridden',
+        navigation: listSnippet('items'),
+      } as unknown as Parameters<typeof render>[1]['props'],
+    });
+    expect(container.querySelector('aside')?.getAttribute('aria-label')).toBe('Sections');
+  });
+
+  test('aria-labelledby in rest spread is not forwarded', () => {
+    const { container } = render(Sidebar, {
+      props: {
+        ariaLabel: 'Sections',
+        'aria-labelledby': 'external-id',
+        navigation: listSnippet('items'),
+      } as unknown as Parameters<typeof render>[1]['props'],
+    });
+    const aside = container.querySelector('aside');
+    expect(aside?.getAttribute('aria-label')).toBe('Sections');
+    expect(aside?.hasAttribute('aria-labelledby')).toBe(false);
+  });
+
+  test('rest attributes spread onto the aside', () => {
+    const { container } = render(Sidebar, {
+      props: {
+        navigation: listSnippet('items'),
+        'data-testid': 'side',
+      } as never,
+    });
+    expect(container.querySelector('aside')?.getAttribute('data-testid')).toBe('side');
+  });
+});
+
+describe('Sidebar context', () => {
+  test('publishes collapsed state to descendants (collapsed=false)', async () => {
+    const { default: Fixture } = await import('../test/fixtures/sidebar-context-fixture.svelte');
+    const { container } = render(Fixture, { props: { collapsed: false } });
+    const probe = container.querySelector('[data-sidebar-probe]');
+    expect(probe?.getAttribute('data-context')).toBe('present');
+    expect(probe?.getAttribute('data-collapsed')).toBe('false');
+  });
+
+  test('publishes collapsed state to descendants (collapsed=true)', async () => {
+    const { default: Fixture } = await import('../test/fixtures/sidebar-context-fixture.svelte');
+    const { container } = render(Fixture, { props: { collapsed: true } });
+    const probe = container.querySelector('[data-sidebar-probe]');
+    expect(probe?.getAttribute('data-context')).toBe('present');
+    expect(probe?.getAttribute('data-collapsed')).toBe('true');
+  });
+
+  test('descendants outside a Sidebar see undefined context', async () => {
+    const { default: Probe } = await import('../test/fixtures/sidebar-context-probe.svelte');
+    const { container } = render(Probe);
+    const probe = container.querySelector('[data-sidebar-probe]');
+    expect(probe?.getAttribute('data-context')).toBe('absent');
+  });
+});

--- a/packages/components/src/components/sidebar.test.ts
+++ b/packages/components/src/components/sidebar.test.ts
@@ -185,6 +185,16 @@ describe('Sidebar (desktop / inline aside)', () => {
     });
     expect(container.querySelector('aside')?.getAttribute('data-testid')).toBe('side');
   });
+
+  test('id lands on the desktop aside', () => {
+    const { container } = render(Sidebar, {
+      props: {
+        id: 'primary-sidebar',
+        navigation: listSnippet('items'),
+      },
+    });
+    expect(container.querySelector('aside')?.getAttribute('id')).toBe('primary-sidebar');
+  });
 });
 
 describe('Sidebar context', () => {
@@ -261,6 +271,10 @@ function installMatchMediaMock(initialMatches: boolean) {
   };
 }
 
+function expectMobileQueryWasUsed(mock: ReturnType<typeof installMatchMediaMock>): void {
+  expect(mock.list.media).toBe('(max-width: 47.99rem)');
+}
+
 // happy-dom doesn't implement HTMLDialogElement.showModal / close — stub them
 // the same way drawer.test.ts does so the mobile <Drawer> can render.
 if (typeof HTMLDialogElement !== 'undefined') {
@@ -298,11 +312,7 @@ describe('Sidebar (mobile / drawer)', () => {
     const { container } = render(Sidebar, {
       props: { navigation: listSnippet('items') },
     });
-    if (!mock.list.media) {
-      // Bun's `svelte/reactivity` resolution may not route through matchMedia
-      // in this environment; skip without failing.
-      return;
-    }
+    expectMobileQueryWasUsed(mock);
     expect(container.querySelector('dialog')).not.toBeNull();
     expect(container.querySelector('aside')).toBeNull();
   });
@@ -312,9 +322,19 @@ describe('Sidebar (mobile / drawer)', () => {
     const { container } = render(Sidebar, {
       props: { navigation: listSnippet('items') },
     });
-    if (!mock.list.media) return;
+    expectMobileQueryWasUsed(mock);
     const wrapper = container.querySelector('dialog .cinder-sidebar.cinder-sidebar--mobile');
     expect(wrapper).not.toBeNull();
+  });
+
+  test('consumer class prop merges onto the mobile sidebar wrapper', () => {
+    mock = installMatchMediaMock(true);
+    const { container } = render(Sidebar, {
+      props: { class: 'my-sidebar', navigation: listSnippet('items') },
+    });
+    expectMobileQueryWasUsed(mock);
+    const wrapper = container.querySelector('dialog .cinder-sidebar.cinder-sidebar--mobile');
+    expect(wrapper?.classList.contains('my-sidebar')).toBe(true);
   });
 
   test('mobile nav landmark has the distinct navigation label', () => {
@@ -322,12 +342,12 @@ describe('Sidebar (mobile / drawer)', () => {
     const { container } = render(Sidebar, {
       props: { ariaLabel: 'Workspace', navigation: listSnippet('items') },
     });
-    if (!mock.list.media) return;
+    expectMobileQueryWasUsed(mock);
     const nav = container.querySelector('dialog nav.cinder-sidebar__nav');
     expect(nav?.getAttribute('aria-label')).toBe('Workspace navigation');
   });
 
-  test('mobile branch forwards rest attributes onto the wrapper', () => {
+  test('mobile branch forwards rest attributes onto the drawer dialog', () => {
     mock = installMatchMediaMock(true);
     const { container } = render(Sidebar, {
       props: {
@@ -335,9 +355,27 @@ describe('Sidebar (mobile / drawer)', () => {
         'data-testid': 'mobile-side',
       } as never,
     });
-    if (!mock.list.media) return;
+    expectMobileQueryWasUsed(mock);
+    const dialog = container.querySelector('dialog');
     const wrapper = container.querySelector('.cinder-sidebar.cinder-sidebar--mobile');
-    expect(wrapper?.getAttribute('data-testid')).toBe('mobile-side');
+    expect(dialog?.getAttribute('data-testid')).toBe('mobile-side');
+    expect(wrapper?.hasAttribute('data-testid')).toBe(false);
+  });
+
+  test('mobile id lands on the persistent drawer dialog for aria-controls', () => {
+    mock = installMatchMediaMock(true);
+    const { container } = render(Sidebar, {
+      props: {
+        id: 'primary-sidebar',
+        collapsed: true,
+        navigation: listSnippet('items'),
+      },
+    });
+    expectMobileQueryWasUsed(mock);
+    const dialog = container.querySelector('dialog');
+    const wrapper = container.querySelector('.cinder-sidebar.cinder-sidebar--mobile');
+    expect(dialog?.getAttribute('id')).toBe('primary-sidebar');
+    expect(wrapper).toBeNull();
   });
 
   test('mobile brand and footer render inside the drawer', () => {
@@ -349,12 +387,52 @@ describe('Sidebar (mobile / drawer)', () => {
         footer: textSnippet('Sign out'),
       },
     });
-    if (!mock.list.media) return;
+    expectMobileQueryWasUsed(mock);
     expect(container.querySelector('dialog .cinder-sidebar__brand')?.textContent ?? '').toContain(
       'Cinder',
     );
     expect(container.querySelector('dialog .cinder-sidebar__footer')?.textContent ?? '').toContain(
       'Sign out',
     );
+  });
+
+  test('mobile wrapper does not carry data-cinder-collapsed', () => {
+    // On mobile, drawer open/closed represents collapsed state. Putting
+    // data-cinder-collapsed on the wrapper would activate icon-rail CSS
+    // inside an open drawer for one frame when the consumer flips collapsed
+    // from true to false to open the drawer.
+    mock = installMatchMediaMock(true);
+    const { container } = render(Sidebar, {
+      props: { collapsed: true, navigation: listSnippet('items') },
+    });
+    expectMobileQueryWasUsed(mock);
+    const wrapper = container.querySelector('.cinder-sidebar.cinder-sidebar--mobile');
+    // collapsed=true with mobile=true → drawer closed → wrapper not rendered
+    expect(wrapper).toBeNull();
+  });
+});
+
+describe('Sidebar collapsed CSS contract', () => {
+  test('collapsed leaf rules cover side-navigation and footer navigation items', async () => {
+    const css = await Bun.file(new URL('../styles/components/sidebar.css', import.meta.url)).text();
+    expect(css).toContain('.cinder-side-navigation a.cinder-navigation-item');
+    expect(css).toContain('.cinder-side-navigation button.cinder-navigation-item');
+    expect(css).toContain('.cinder-sidebar__footer a.cinder-navigation-item');
+    expect(css).toContain('.cinder-sidebar__footer button.cinder-navigation-item');
+  });
+
+  test('collapsed leaf rules hide bare text without removing DOM text', async () => {
+    const css = await Bun.file(new URL('../styles/components/sidebar.css', import.meta.url)).text();
+    expect(css).toContain('font-size: 0;');
+    expect(css).toContain('The DOM text remains');
+  });
+
+  test('visually-hidden block pairs `clip` with `clip-path` for modern browsers', async () => {
+    const css = await Bun.file(new URL('../styles/components/sidebar.css', import.meta.url)).text();
+    // `clip` is deprecated and unimplemented in some modern browsers;
+    // `clip-path: inset(50%)` is the modern equivalent. Both must be present
+    // so the visually-hidden technique works across the supported matrix.
+    expect(css).toContain('clip: rect(0, 0, 0, 0);');
+    expect(css).toContain('clip-path: inset(50%);');
   });
 });

--- a/packages/components/src/components/sidebar.test.ts
+++ b/packages/components/src/components/sidebar.test.ts
@@ -394,6 +394,17 @@ describe('Sidebar (mobile / drawer)', () => {
     expect(container.querySelector('dialog .cinder-sidebar__footer')?.textContent ?? '').toContain(
       'Sign out',
     );
+    expect(container.querySelector('dialog .cinder-drawer__footer')).toBeNull();
+  });
+
+  test('mobile branch omits drawer footer when no footer snippet is provided', () => {
+    mock = installMatchMediaMock(true);
+    const { container } = render(Sidebar, {
+      props: { navigation: listSnippet('items') },
+    });
+    expectMobileQueryWasUsed(mock);
+    expect(container.querySelector('dialog .cinder-sidebar__footer')).toBeNull();
+    expect(container.querySelector('dialog .cinder-drawer__footer')).toBeNull();
   });
 
   test('mobile wrapper does not carry data-cinder-collapsed', () => {

--- a/packages/components/src/components/sidebar.test.ts
+++ b/packages/components/src/components/sidebar.test.ts
@@ -1,5 +1,5 @@
 /// <reference lib="dom" />
-import { describe, expect, test } from 'bun:test';
+import { afterEach, describe, expect, test } from 'bun:test';
 import { createRawSnippet } from 'svelte';
 
 import { setupHappyDom } from '../test/happy-dom.ts';
@@ -77,13 +77,25 @@ describe('Sidebar (desktop / inline aside)', () => {
     expect(aside?.classList.contains('my-sidebar')).toBe(true);
   });
 
-  test('renders <nav> inside the aside with matching aria-label', () => {
+  test('renders <nav> inside the aside with a distinct aria-label', () => {
     const { container } = render(Sidebar, {
       props: { ariaLabel: 'Workspace', navigation: listSnippet('items') },
     });
     const nav = container.querySelector('aside nav.cinder-sidebar__nav');
     expect(nav).not.toBeNull();
-    expect(nav?.getAttribute('aria-label')).toBe('Workspace');
+    // The inner <nav> landmark gets a distinct accessible name so it is not
+    // announced identically to the outer <aside> complementary landmark.
+    expect(nav?.getAttribute('aria-label')).toBe('Workspace navigation');
+  });
+
+  test('outer aside aria-label is distinct from inner nav aria-label', () => {
+    const { container } = render(Sidebar, {
+      props: { ariaLabel: 'Workspace', navigation: listSnippet('items') },
+    });
+    const aside = container.querySelector('aside');
+    const nav = container.querySelector('aside nav.cinder-sidebar__nav');
+    expect(aside?.getAttribute('aria-label')).toBe('Workspace');
+    expect(nav?.getAttribute('aria-label')).not.toBe(aside?.getAttribute('aria-label'));
   });
 
   test('renders navigation snippet inside the nav', () => {
@@ -197,5 +209,152 @@ describe('Sidebar context', () => {
     const { container } = render(Probe);
     const probe = container.querySelector('[data-sidebar-probe]');
     expect(probe?.getAttribute('data-context')).toBe('absent');
+    // No context means data-collapsed is omitted entirely — distinguishable from
+    // a Sidebar-wrapped probe with collapsed=false.
+    expect(probe?.hasAttribute('data-collapsed')).toBe(false);
+  });
+
+  test('context collapsed updates reactively when the prop changes', async () => {
+    const { default: Fixture } = await import('../test/fixtures/sidebar-context-fixture.svelte');
+    const { container, rerender } = render(Fixture, { props: { collapsed: false } });
+    const probe = container.querySelector('[data-sidebar-probe]');
+    expect(probe?.getAttribute('data-collapsed')).toBe('false');
+    await rerender({ collapsed: true });
+    expect(probe?.getAttribute('data-collapsed')).toBe('true');
+  });
+});
+
+// ----------------------------------------
+// Mobile / drawer branch — matchMedia mock forces `MediaQuery.current = true`
+// so the `{#if mobile.current}` branch is exercised.
+// ----------------------------------------
+
+type Listener = (event: { matches: boolean }) => void;
+
+function installMatchMediaMock(initialMatches: boolean) {
+  const list = {
+    matches: initialMatches,
+    media: '',
+    onchange: null as Listener | null,
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    addListener: () => {},
+    removeListener: () => {},
+    dispatchEvent: () => true,
+  };
+  const originalMatchMedia = (window as unknown as { matchMedia?: typeof window.matchMedia })
+    .matchMedia;
+  (window as unknown as { matchMedia: typeof window.matchMedia }).matchMedia = ((query: string) => {
+    list.media = query;
+    return list as unknown as MediaQueryList;
+  }) as typeof window.matchMedia;
+  return {
+    list,
+    restore() {
+      if (originalMatchMedia) {
+        (window as unknown as { matchMedia: typeof window.matchMedia }).matchMedia =
+          originalMatchMedia;
+      } else {
+        delete (window as unknown as { matchMedia?: typeof window.matchMedia }).matchMedia;
+      }
+    },
+  };
+}
+
+// happy-dom doesn't implement HTMLDialogElement.showModal / close — stub them
+// the same way drawer.test.ts does so the mobile <Drawer> can render.
+if (typeof HTMLDialogElement !== 'undefined') {
+  if (!HTMLDialogElement.prototype.showModal) {
+    Object.defineProperty(HTMLDialogElement.prototype, 'showModal', {
+      value: function () {
+        this.setAttribute('open', '');
+      },
+      configurable: true,
+      writable: true,
+    });
+  }
+  if (!HTMLDialogElement.prototype.close) {
+    Object.defineProperty(HTMLDialogElement.prototype, 'close', {
+      value: function () {
+        this.removeAttribute('open');
+        this.dispatchEvent(new Event('close'));
+      },
+      configurable: true,
+      writable: true,
+    });
+  }
+}
+
+describe('Sidebar (mobile / drawer)', () => {
+  let mock: ReturnType<typeof installMatchMediaMock> | undefined;
+
+  afterEach(() => {
+    mock?.restore();
+    mock = undefined;
+  });
+
+  test('renders a <dialog> instead of an <aside>', () => {
+    mock = installMatchMediaMock(true);
+    const { container } = render(Sidebar, {
+      props: { navigation: listSnippet('items') },
+    });
+    if (!mock.list.media) {
+      // Bun's `svelte/reactivity` resolution may not route through matchMedia
+      // in this environment; skip without failing.
+      return;
+    }
+    expect(container.querySelector('dialog')).not.toBeNull();
+    expect(container.querySelector('aside')).toBeNull();
+  });
+
+  test('mobile branch wraps content in .cinder-sidebar.cinder-sidebar--mobile', () => {
+    mock = installMatchMediaMock(true);
+    const { container } = render(Sidebar, {
+      props: { navigation: listSnippet('items') },
+    });
+    if (!mock.list.media) return;
+    const wrapper = container.querySelector('dialog .cinder-sidebar.cinder-sidebar--mobile');
+    expect(wrapper).not.toBeNull();
+  });
+
+  test('mobile nav landmark has the distinct navigation label', () => {
+    mock = installMatchMediaMock(true);
+    const { container } = render(Sidebar, {
+      props: { ariaLabel: 'Workspace', navigation: listSnippet('items') },
+    });
+    if (!mock.list.media) return;
+    const nav = container.querySelector('dialog nav.cinder-sidebar__nav');
+    expect(nav?.getAttribute('aria-label')).toBe('Workspace navigation');
+  });
+
+  test('mobile branch forwards rest attributes onto the wrapper', () => {
+    mock = installMatchMediaMock(true);
+    const { container } = render(Sidebar, {
+      props: {
+        navigation: listSnippet('items'),
+        'data-testid': 'mobile-side',
+      } as never,
+    });
+    if (!mock.list.media) return;
+    const wrapper = container.querySelector('.cinder-sidebar.cinder-sidebar--mobile');
+    expect(wrapper?.getAttribute('data-testid')).toBe('mobile-side');
+  });
+
+  test('mobile brand and footer render inside the drawer', () => {
+    mock = installMatchMediaMock(true);
+    const { container } = render(Sidebar, {
+      props: {
+        brand: textSnippet('Cinder'),
+        navigation: listSnippet('items'),
+        footer: textSnippet('Sign out'),
+      },
+    });
+    if (!mock.list.media) return;
+    expect(container.querySelector('dialog .cinder-sidebar__brand')?.textContent ?? '').toContain(
+      'Cinder',
+    );
+    expect(container.querySelector('dialog .cinder-sidebar__footer')?.textContent ?? '').toContain(
+      'Sign out',
+    );
   });
 });

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -270,6 +270,9 @@ export type { SideNavigationGroupProps } from './components/side-navigation-grou
 export { default as SideNavigationItem } from './components/side-navigation-item.svelte';
 export type { SideNavigationItemProps } from './components/side-navigation-item.svelte';
 
+export { default as Sidebar } from './components/sidebar.svelte';
+export type { SidebarProps } from './components/sidebar.svelte';
+
 export { default as SortableList } from './components/sortable-list.svelte';
 export type { SortableListProps } from './components/sortable-list.svelte';
 export type {

--- a/packages/components/src/styles/components.css
+++ b/packages/components/src/styles/components.css
@@ -55,6 +55,7 @@
 @import './components/selection-popover.css';
 @import './components/side-navigation.css';
 @import './components/side-navigation-group.css';
+@import './components/sidebar.css';
 @import './components/skeleton.css';
 @import './components/sortable-list.css';
 @import './components/stacked-list-item.css';

--- a/packages/components/src/styles/components/sidebar.css
+++ b/packages/components/src/styles/components/sidebar.css
@@ -26,10 +26,10 @@
   border-inline-end: none;
 }
 
-/* Collapsed (icon-only) mode applies only when rendered as an inline <aside>.
- * The mobile drawer surface ignores collapsed because the drawer being closed
- * already represents the collapsed state. */
-.cinder-sidebar[data-cinder-collapsed] {
+/* Collapsed (icon-only) mode applies to the inline <aside>. The mobile drawer
+ * surface ignores `data-cinder-collapsed` for sizing because drawer-closed is
+ * the collapsed state on mobile. */
+.cinder-sidebar[data-cinder-collapsed]:not(.cinder-sidebar--mobile) {
   inline-size: 4rem;
 }
 
@@ -61,23 +61,53 @@
 
 /* ----------------------------------------
  * Collapsed (icon-only) treatment for descendant items.
- * Hide non-icon text in collapsed inline <aside> mode so the nav reads as
- * an icon rail. Consumers must provide `aria-label` on each NavigationItem
- * for the icon-only mode to remain accessible; without it the item has no
- * accessible name once the text content is hidden.
+ *
+ * Decorative chrome (group badge, chevron, panel) is hidden with `display:
+ * none` because it carries no accessible name.
+ *
+ * Label-bearing text is hidden using the visually-hidden technique rather
+ * than `display: none` so the accessible name of each focusable element is
+ * preserved in the accessibility tree. The visual result is icon-only, but a
+ * screen-reader user still hears the section header or item text when focus
+ * lands on the trigger or link.
  * ---------------------------------------- */
 
-.cinder-sidebar[data-cinder-collapsed] .cinder-side-navigation-group__label,
 .cinder-sidebar[data-cinder-collapsed] .cinder-side-navigation-group__badge,
-.cinder-sidebar[data-cinder-collapsed] .cinder-side-navigation-group__chevron {
-  display: none;
-}
-
+.cinder-sidebar[data-cinder-collapsed] .cinder-side-navigation-group__chevron,
 .cinder-sidebar[data-cinder-collapsed] .cinder-side-navigation-group__panel {
   display: none;
 }
 
 .cinder-sidebar[data-cinder-collapsed] .cinder-side-navigation-group__trigger {
+  justify-content: center;
+  padding-inline: var(--cinder-space-2);
+}
+
+.cinder-sidebar[data-cinder-collapsed] .cinder-side-navigation-group__label,
+.cinder-sidebar[data-cinder-collapsed]
+  .cinder-side-navigation
+  a.cinder-navigation-item
+  > :not([aria-hidden='true']):not(svg):not(img),
+.cinder-sidebar[data-cinder-collapsed]
+  .cinder-side-navigation
+  button.cinder-navigation-item
+  > :not([aria-hidden='true']):not(svg):not(img) {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+/* Leaf items in collapsed mode collapse to icon-only width. The visually-
+ * hidden text above preserves the accessible name; this rule re-centers the
+ * remaining icon content. */
+.cinder-sidebar[data-cinder-collapsed] .cinder-side-navigation a.cinder-navigation-item,
+.cinder-sidebar[data-cinder-collapsed] .cinder-side-navigation button.cinder-navigation-item {
   justify-content: center;
   padding-inline: var(--cinder-space-2);
 }

--- a/packages/components/src/styles/components/sidebar.css
+++ b/packages/components/src/styles/components/sidebar.css
@@ -1,0 +1,83 @@
+/* ========================================
+ * SIDEBAR
+ * Layout-level vertical navigation container. Combines branding, a nav
+ * region, and an optional footer. Delegates the actual list to
+ * `side-navigation.svelte`. Below the md breakpoint (~767px) the consuming
+ * component swaps the inline <aside> for a <Drawer>; this stylesheet covers
+ * both surfaces because the inner regions render the same elements.
+ * ======================================== */
+
+.cinder-sidebar {
+  display: flex;
+  flex-direction: column;
+  inline-size: 16rem;
+  block-size: 100%;
+  background: var(--cinder-surface);
+  border-inline-end: 1px solid var(--cinder-border);
+  overflow: hidden;
+}
+
+/* The mobile surface is rendered inside <Drawer>, which already paints its
+ * own surface and borders. Don't double up. */
+.cinder-sidebar.cinder-sidebar--mobile {
+  inline-size: 100%;
+  block-size: 100%;
+  background: transparent;
+  border-inline-end: none;
+}
+
+/* Collapsed (icon-only) mode applies only when rendered as an inline <aside>.
+ * The mobile drawer surface ignores collapsed because the drawer being closed
+ * already represents the collapsed state. */
+.cinder-sidebar[data-cinder-collapsed] {
+  inline-size: 4rem;
+}
+
+.cinder-sidebar__brand {
+  display: flex;
+  align-items: center;
+  padding-block: var(--cinder-space-4);
+  padding-inline: var(--cinder-space-4);
+  border-block-end: 1px solid var(--cinder-border);
+  flex-shrink: 0;
+}
+
+.cinder-sidebar__nav {
+  flex: 1;
+  overflow-y: auto;
+  padding-block: var(--cinder-space-3);
+  padding-inline: var(--cinder-space-2);
+  display: flex;
+  flex-direction: column;
+  gap: var(--cinder-space-2);
+}
+
+.cinder-sidebar__footer {
+  padding-block: var(--cinder-space-3);
+  padding-inline: var(--cinder-space-3);
+  border-block-start: 1px solid var(--cinder-border);
+  flex-shrink: 0;
+}
+
+/* ----------------------------------------
+ * Collapsed (icon-only) treatment for descendant items.
+ * Hide non-icon text in collapsed inline <aside> mode so the nav reads as
+ * an icon rail. Consumers must provide `aria-label` on each NavigationItem
+ * for the icon-only mode to remain accessible; without it the item has no
+ * accessible name once the text content is hidden.
+ * ---------------------------------------- */
+
+.cinder-sidebar[data-cinder-collapsed] .cinder-side-navigation-group__label,
+.cinder-sidebar[data-cinder-collapsed] .cinder-side-navigation-group__badge,
+.cinder-sidebar[data-cinder-collapsed] .cinder-side-navigation-group__chevron {
+  display: none;
+}
+
+.cinder-sidebar[data-cinder-collapsed] .cinder-side-navigation-group__panel {
+  display: none;
+}
+
+.cinder-sidebar[data-cinder-collapsed] .cinder-side-navigation-group__trigger {
+  justify-content: center;
+  padding-inline: var(--cinder-space-2);
+}

--- a/packages/components/src/styles/components/sidebar.css
+++ b/packages/components/src/styles/components/sidebar.css
@@ -91,6 +91,14 @@
 .cinder-sidebar[data-cinder-collapsed]
   .cinder-side-navigation
   button.cinder-navigation-item
+  > :not([aria-hidden='true']):not(svg):not(img),
+.cinder-sidebar[data-cinder-collapsed]
+  .cinder-sidebar__footer
+  a.cinder-navigation-item
+  > :not([aria-hidden='true']):not(svg):not(img),
+.cinder-sidebar[data-cinder-collapsed]
+  .cinder-sidebar__footer
+  button.cinder-navigation-item
   > :not([aria-hidden='true']):not(svg):not(img) {
   position: absolute;
   width: 1px;
@@ -99,15 +107,49 @@
   margin: -1px;
   overflow: hidden;
   clip: rect(0, 0, 0, 0);
+  clip-path: inset(50%);
   white-space: nowrap;
   border: 0;
 }
 
-/* Leaf items in collapsed mode collapse to icon-only width. The visually-
- * hidden text above preserves the accessible name; this rule re-centers the
- * remaining icon content. */
+/* Leaf items in collapsed mode collapse to icon-only width. `font-size: 0`
+ * covers bare text children that cannot be selected directly; element
+ * children are additionally visually hidden above. The DOM text remains
+ * available for accessible-name computation. */
 .cinder-sidebar[data-cinder-collapsed] .cinder-side-navigation a.cinder-navigation-item,
-.cinder-sidebar[data-cinder-collapsed] .cinder-side-navigation button.cinder-navigation-item {
+.cinder-sidebar[data-cinder-collapsed] .cinder-side-navigation button.cinder-navigation-item,
+.cinder-sidebar[data-cinder-collapsed] .cinder-sidebar__footer a.cinder-navigation-item,
+.cinder-sidebar[data-cinder-collapsed] .cinder-sidebar__footer button.cinder-navigation-item {
   justify-content: center;
   padding-inline: var(--cinder-space-2);
+  gap: 0;
+  font-size: 0;
+}
+
+.cinder-sidebar[data-cinder-collapsed] .cinder-side-navigation a.cinder-navigation-item > svg,
+.cinder-sidebar[data-cinder-collapsed] .cinder-side-navigation button.cinder-navigation-item > svg,
+.cinder-sidebar[data-cinder-collapsed] .cinder-sidebar__footer a.cinder-navigation-item > svg,
+.cinder-sidebar[data-cinder-collapsed] .cinder-sidebar__footer button.cinder-navigation-item > svg,
+.cinder-sidebar[data-cinder-collapsed] .cinder-side-navigation a.cinder-navigation-item > img,
+.cinder-sidebar[data-cinder-collapsed] .cinder-side-navigation button.cinder-navigation-item > img,
+.cinder-sidebar[data-cinder-collapsed] .cinder-sidebar__footer a.cinder-navigation-item > img,
+.cinder-sidebar[data-cinder-collapsed] .cinder-sidebar__footer button.cinder-navigation-item > img,
+.cinder-sidebar[data-cinder-collapsed]
+  .cinder-side-navigation
+  a.cinder-navigation-item
+  > [aria-hidden='true'],
+.cinder-sidebar[data-cinder-collapsed]
+  .cinder-side-navigation
+  button.cinder-navigation-item
+  > [aria-hidden='true'],
+.cinder-sidebar[data-cinder-collapsed]
+  .cinder-sidebar__footer
+  a.cinder-navigation-item
+  > [aria-hidden='true'],
+.cinder-sidebar[data-cinder-collapsed]
+  .cinder-sidebar__footer
+  button.cinder-navigation-item
+  > [aria-hidden='true'] {
+  flex-shrink: 0;
+  font-size: var(--cinder-text-sm);
 }

--- a/packages/components/src/test/fixtures/sidebar-context-fixture.svelte
+++ b/packages/components/src/test/fixtures/sidebar-context-fixture.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+  import Sidebar from '../../components/sidebar.svelte';
+  import Probe from './sidebar-context-probe.svelte';
+
+  type Props = { collapsed?: boolean };
+  let { collapsed = false }: Props = $props();
+</script>
+
+<Sidebar {collapsed}>
+  {#snippet navigation()}
+    <ul>
+      <li>
+        <Probe />
+      </li>
+    </ul>
+  {/snippet}
+</Sidebar>

--- a/packages/components/src/test/fixtures/sidebar-context-probe.svelte
+++ b/packages/components/src/test/fixtures/sidebar-context-probe.svelte
@@ -1,0 +1,16 @@
+<script lang="ts">
+  import { getSidebarContext } from '../../_internal/sidebar-context.ts';
+
+  const context = getSidebarContext();
+</script>
+
+<!--
+  Reads the SidebarContext published by a parent <Sidebar> and surfaces the
+  current `collapsed` value plus a `data-context` marker so tests can confirm
+  the context exists even when collapsed is false.
+-->
+<div
+  data-sidebar-probe
+  data-context={context ? 'present' : 'absent'}
+  data-collapsed={context?.collapsed ? 'true' : 'false'}
+></div>

--- a/packages/components/src/test/fixtures/sidebar-context-probe.svelte
+++ b/packages/components/src/test/fixtures/sidebar-context-probe.svelte
@@ -12,5 +12,5 @@
 <div
   data-sidebar-probe
   data-context={context ? 'present' : 'absent'}
-  data-collapsed={context?.collapsed ? 'true' : 'false'}
+  data-collapsed={context ? String(context.collapsed) : undefined}
 ></div>

--- a/packages/playground/src/examples/sidebar/basic.example.svelte
+++ b/packages/playground/src/examples/sidebar/basic.example.svelte
@@ -1,0 +1,71 @@
+<script lang="ts" module>
+  export const title = 'Basic sidebar';
+  export const description =
+    'Layout-level sidebar with brand, navigation, and footer regions. Collapse toggles icon-only mode on desktop and closes the drawer on mobile.';
+</script>
+
+<script lang="ts">
+  import {
+    Button,
+    NavigationItem,
+    Sidebar,
+    SideNavigation,
+    SideNavigationGroup,
+    SideNavigationItem,
+  } from '../../../../components/src/index.ts';
+
+  let collapsed = $state(false);
+</script>
+
+<div style="display: flex; flex-direction: column; gap: 1rem;">
+  <div>
+    <Button
+      label={collapsed ? 'Expand sidebar' : 'Collapse sidebar'}
+      onclick={() => (collapsed = !collapsed)}
+    />
+  </div>
+
+  <div
+    style="display: flex; min-height: 24rem; border: 1px solid #e5e7eb; border-radius: 0.5rem; overflow: hidden;"
+  >
+    <Sidebar bind:collapsed ariaLabel="Workspace">
+      {#snippet brand()}
+        <strong style="font-size: 0.875rem;">Cinder</strong>
+      {/snippet}
+
+      {#snippet navigation()}
+        <SideNavigation ariaLabel="Workspace sections">
+          {#snippet children()}
+            <SideNavigationItem href="#dashboard">
+              {#snippet children()}Dashboard{/snippet}
+            </SideNavigationItem>
+            <SideNavigationItem href="#projects" active>
+              {#snippet children()}Projects{/snippet}
+            </SideNavigationItem>
+            <SideNavigationGroup label="Settings">
+              {#snippet children()}
+                <SideNavigationItem href="#general">
+                  {#snippet children()}General{/snippet}
+                </SideNavigationItem>
+                <SideNavigationItem href="#billing">
+                  {#snippet children()}Billing{/snippet}
+                </SideNavigationItem>
+              {/snippet}
+            </SideNavigationGroup>
+          {/snippet}
+        </SideNavigation>
+      {/snippet}
+
+      {#snippet footer()}
+        <NavigationItem href="#account">
+          {#snippet children()}Account{/snippet}
+        </NavigationItem>
+      {/snippet}
+    </Sidebar>
+
+    <main style="flex: 1; padding: 1rem;">
+      <p>Main content area.</p>
+      <p>Resize the viewport below ~767px to see the mobile drawer behavior.</p>
+    </main>
+  </div>
+</div>


### PR DESCRIPTION
## Summary

Adds `<Sidebar>` per ROADMAP §Navigation & Overlays › Sidebar navigation. The component combines branding, vertical navigation, and a footer into a single layout-level container. It publishes a `collapsed` boolean via Svelte context so descendant components can switch to icon-only mode, and below the `md` breakpoint (47.99rem / ~767px) it renders inside a `<Drawer>` instead of an inline `<aside>`.

Key design choices:

- **Distinct landmark names.** The outer `<aside>` carries `aria-label={ariaLabel}` (default `"Sidebar"`); the inner `<nav>` derives `${ariaLabel} navigation` so screen readers announce two distinguishable landmarks instead of identical duplicates.
- **Persistent dialog id.** On mobile, `id` lands on the `<Drawer>` dialog (always present) rather than the conditional wrapper, so the documented hamburger `aria-controls` pattern keeps working when the drawer is closed.
- **Accessibility-preserving collapse.** Visible labels in collapsed mode are visually-hidden (`clip` + `clip-path: inset(50%)`) rather than `display: none`, plus `font-size: 0` on items with icon descendants restored to text-sm — accessible names survive in the a11y tree. Decorative chrome (group badge, chevron, disclosed panel) uses `display: none`.
- **Mobile-aware `data-cinder-collapsed`.** Set only on the desktop `<aside>`, deliberately omitted from the mobile wrapper to avoid a one-frame icon-rail flash inside an opening drawer.

## Review committee
Pre-reviewed by: frontend-architect, ux-designer, testing-expert, typescript-expert, simplicity-engineer, junior-engineer, prose-editor.
- Codex (gpt-5.4, xhigh reasoning) — 1 round (round-1 findings driven into the implementation; rounds 2–4 fail-warn per `tmp/committee-state.md`)
- 4 rounds of review
- All must-fix items addressed

> [!WARNING]
> Codex (the adversarial second-opinion reviewer) was unavailable for rounds 2–4 of this PR (shim timeouts/exit 127). Codex's round-1 findings were addressed in the round-1 commit. See `tmp/committee-state.md` for detail.

## Test plan

- [x] `bun test packages/components/src/components/sidebar.test.ts` — 35 tests, 62 expects, all passing
- [x] `bun test packages/components/src/components/{side-navigation,drawer,side-navigation-group}.test.ts packages/components/src/exports-drift.test.ts` — 101 tests passing
- [x] `bun run typecheck` — 0 errors
- [x] `bun run lint` — 0 errors (13 pre-existing warnings, none in new files)
- [x] `bun run format:check` — clean
- [ ] Manual verification in the playground at `/sidebar` on desktop and mobile breakpoints
- [ ] Manual verification of the hamburger trigger / `aria-controls` pattern in a screen reader

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new exported layout component with responsive behavior, context propagation, and new CSS contracts; risk is mainly UI/regression around breakpoints, ARIA labeling, and collapsed-mode styling.
> 
> **Overview**
> Adds a new exported `Sidebar` component that renders an inline `<aside>` on desktop and switches to a left-side `<Drawer>` on small viewports, with `bind:collapsed` controlling icon-rail vs drawer open/closed state.
> 
> Introduces an internal sidebar Svelte context (`getSidebarContext`) to expose the reactive `collapsed` state to descendants without prop drilling, plus new `sidebar.css` rules to implement collapsed/visually-hidden labels while preserving accessible names.
> 
> Wires the component into the package surface (`exports`, `src/index.ts`, and `styles/components.css`), adds a dedicated a11y doc, comprehensive unit tests (including mobile `matchMedia` mocking), and a playground example demonstrating usage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 93e8d2b91b09957ba56402ee052219aae2ecb6b1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->