### PR TITLE
feat(color-picker): add visual color picker primitive

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -77,6 +77,10 @@
       "svelte": "./src/components/code-block.svelte",
       "types": "./dist/components/code-block.svelte.d.ts"
     },
+    "./color-picker": {
+      "svelte": "./src/components/color-picker.svelte",
+      "types": "./dist/components/color-picker.svelte.d.ts"
+    },
     "./color-swatch-picker": {
       "svelte": "./src/components/color-swatch-picker.svelte",
       "types": "./dist/components/color-swatch-picker.svelte.d.ts"

--- a/packages/components/src/components/color-picker.a11y.md
+++ b/packages/components/src/components/color-picker.a11y.md
@@ -1,0 +1,45 @@
+# Color Picker — Accessibility Rationale
+
+## What this component is — and what it isn't
+
+`color-picker.svelte` is a **visual** color selector. It exposes a 2D saturation/lightness gradient, a hue slider, an optional alpha slider, and an optional palette of preset swatches. It is intentionally _not_ a substitute for a text-entry color field. When precise color values matter (brand hex codes, accessibility-critical contrast targets), pair this component with a future `color-field.svelte` — a labeled text input that parses and normalizes hex/`rgb()`/`hsl()` strings. Users who need exact entry should reach for the field; users who want to graze around a color space should reach for the picker.
+
+## The gradient is `role="application"` on purpose
+
+The 2D saturation/lightness region is the one part of this component that **cannot** be made fully accessible. Two-dimensional pointer-driven manipulation has no clean ARIA equivalent. Wrapping it in `role="slider"` would lie to assistive technology — sliders are one-dimensional, and screen readers expect `aria-valuemin`/`max`/`now` to describe a single magnitude.
+
+Instead, we use `role="application"` with an `aria-label` that explicitly says the region is pointer-driven and that arrow keys offer coarse adjustment. `role="application"` tells screen readers to stop intercepting keys, which is what lets our arrow-key handler get the events. The component still exposes a hue slider, an alpha slider, and a swatch list as **fully accessible alternatives**, so keyboard-only and screen-reader users are not locked out of changing the color — they are just routed through controls that match the semantics they expect.
+
+The arrow-key handling on the gradient itself is a courtesy, not a substitute. Each press moves saturation or lightness by one unit (ten with Shift). It is enough to nudge a color, not enough to reliably land on a specific value. Users who need a specific value should use the swatches or, eventually, the paired color field.
+
+## Hue and alpha as `role="slider"`
+
+The hue control is a one-dimensional 0–359 degree wheel: a textbook slider. We expose `aria-valuemin="0"`, `aria-valuemax="359"`, and `aria-valuenow` rounded to an integer. Arrow keys step by 1 degree (10 with Shift), Page Up/Down jump by 36 (one twelfth of the wheel), and Home/End snap to the wheel's start and end. The control wraps — pressing ArrowLeft at hue 0 lands on 359 — because hue is a wheel, not a line, and respecting that matches user intuition.
+
+The alpha control follows the same pattern with a 0–100 range (representing percent opacity) and a smaller default step. Each press changes alpha by 1% (10% with Shift). We expose `aria-valuetext` as `"NN%"` so screen readers announce a meaningful unit rather than a bare integer.
+
+## Swatches as `role="listbox"` + `role="option"`
+
+The optional preset palette uses the WAI-ARIA Listbox pattern: a `<ul role="listbox">` with an accessible name ("Color swatches") and `<li role="option">` children. Each option carries `aria-selected` reflecting whether its color matches the picker's current value, and an `aria-label` that announces the hex string. Arrow keys move focus among swatches with wrapping; Home and End jump to the first and last. Enter and Space commit the focused swatch.
+
+We do not use selection-follows-focus here. Arrowing past a swatch should let users preview the option without committing — committing comes from an explicit Enter or Space (or click). This avoids the "I arrowed across and lost my selection" footgun common to selection-follows-focus listboxes.
+
+## Form participation and form reset
+
+The component renders a hidden `<input>` so it shows up in `FormData` and participates in `<form>` submission when `name` is set. When the surrounding form fires a `reset` event, the picker reverts to `defaultValue` (or to an empty value when no default was provided). We listen for `reset` on the input's actual form element — not on a passed-in callback — so the contract matches native form controls and consumers don't have to wire anything up.
+
+## Touch precision and fine selection
+
+Both the gradient and the sliders are pointer-driven. On touch devices, the gradient handle is small relative to a fingertip — landing on an exact hex is impractical. This is the same limitation every visual color picker has. Consumers building touch-first interfaces should pair the picker with a text field for exact entry, or expose preset swatches that cover the values they actually care about.
+
+## Reduced motion
+
+The component has no animated transitions in v1, so `prefers-reduced-motion` is a no-op for now. If we add motion later (e.g., handle slide animations on swatch commit), the animation must be gated on `@media (prefers-reduced-motion: no-preference)` — never run unconditionally.
+
+## Forced colors mode
+
+In Windows High Contrast / forced-colors mode the gradient itself cannot be meaningfully rendered (the OS strips background colors). The component still works, but the gradient region will look flat. Sliders and swatches fall back to `Highlight` system color for focus rings via a `@media (forced-colors: active)` block. Users in forced colors mode are exactly the user population most likely to rely on the swatch list or a paired color field — both of which remain fully functional.
+
+## Pairing recommendation
+
+For any production form where users need to choose a color, pair this picker with a text input that accepts and validates `#rgb`, `#rrggbb`, `#rrggbbaa`, `rgb()`, `rgba()`, `hsl()`, and `hsla()` strings. The picker is the discovery surface; the field is the precision surface. Neither replaces the other.

--- a/packages/components/src/components/color-picker.svelte
+++ b/packages/components/src/components/color-picker.svelte
@@ -261,9 +261,12 @@
 
   // ── Slider pointer handling ─────────────────────────────────────────────
 
-  let hueElement: HTMLDivElement | null = $state(null);
-  let alphaElement: HTMLDivElement | null = $state(null);
-  let draggingSlider: 'hue' | 'alpha' | null = $state(null);
+  // bind:this refs and the drag-discriminator are coordination state read only
+  // inside event handlers, never inside the template or effects — plain `let`
+  // is sufficient and avoids unnecessary reactive tracking.
+  let hueElement: HTMLDivElement | null = null;
+  let alphaElement: HTMLDivElement | null = null;
+  let draggingSlider: 'hue' | 'alpha' | null = null;
 
   function pointerToFraction(event: PointerEvent, element: HTMLElement): number {
     const rect = element.getBoundingClientRect();
@@ -429,7 +432,7 @@
   // ── Swatch list ─────────────────────────────────────────────────────────
 
   const swatchList = $derived(swatches ?? []);
-  let swatchFocusIndex = $state<number | null>(null);
+  let swatchFocusIndex: number | null = $state(null);
   let swatchRefs: (HTMLLIElement | null)[] = $state([]);
 
   const currentHex = $derived(formatHex(hue, saturation, lightnessValue, alphaValue, alpha));

--- a/packages/components/src/components/color-picker.svelte
+++ b/packages/components/src/components/color-picker.svelte
@@ -64,8 +64,9 @@
   let alphaValue = $state(1); // 0–1
 
   let internalValue = $state('');
-  let lastEmittedHex = $state('');
-  let suppressNextSync = $state(false);
+  // Plain (non-reactive) coordination var: holds the most recent value the component
+  // wrote out to `value`. The controlled-sync effect uses this to skip its own echo.
+  let lastEmittedHex = '';
   let isDragging = $state(false);
 
   function clamp(n: number, min: number, max: number): number {
@@ -133,6 +134,17 @@
     return { h, s, l, a: parsed.a };
   }
 
+  /**
+   * Canonicalize a swatch string to the same hex format the picker emits, so
+   * aria-selected matches regardless of input syntax (#0f0 vs #00ff00 vs rgb()).
+   * Returns null when the swatch is unparseable.
+   */
+  function normalizeSwatch(swatch: string): string | null {
+    const parsed = parseToHsla(swatch);
+    if (!parsed) return null;
+    return formatHex(parsed.h, parsed.s, parsed.l, parsed.a, alpha).toLowerCase();
+  }
+
   function applyHsla(next: Hsla): void {
     hue = next.h;
     saturation = next.s;
@@ -155,14 +167,12 @@
     }
   }
 
-  // Sync incoming `value` (controlled) to internal HSLA, but only when it
-  // doesn't match what we last emitted (avoids fighting bound updates).
+  // Sync incoming `value` (controlled) to internal HSLA, but skip the echo of our
+  // own writes. We compare against `lastEmittedHex` rather than using a one-shot
+  // suppression flag so a parent that normalizes or rejects the emitted value
+  // (and writes a different one back) is not ignored.
   $effect(() => {
     if (value === undefined) return;
-    if (suppressNextSync) {
-      suppressNextSync = false;
-      return;
-    }
     if (value === lastEmittedHex) return;
     if (value === '') {
       internalValue = '';
@@ -177,16 +187,26 @@
     internalValue = formatHex(parsed.h, parsed.s, parsed.l, parsed.a, alpha);
   });
 
+  // Re-normalize internal value when the `alpha` mode toggles after mount so
+  // hidden input / bound value reflect the new emit format immediately.
+  $effect(() => {
+    void alpha;
+    if (internalValue === '') return;
+    const hex = formatHex(hue, saturation, lightnessValue, alphaValue, alpha);
+    if (hex === internalValue) return;
+    internalValue = hex;
+    lastEmittedHex = hex;
+    if (value !== undefined && value !== hex) value = hex;
+  });
+
   function emit(reason: 'input' | 'change'): void {
     const hex = formatHex(hue, saturation, lightnessValue, alphaValue, alpha);
     internalValue = hex;
     lastEmittedHex = hex;
-    if (value !== undefined) {
-      suppressNextSync = true;
-      value = hex;
-    }
-    if (reason === 'input') oninput?.(hex);
-    else onchange?.(hex);
+    if (value !== undefined) value = hex;
+    // Every value mutation fires `oninput`; `onchange` additionally fires on commit.
+    oninput?.(hex);
+    if (reason === 'change') onchange?.(hex);
   }
 
   function commitFromHsla(next: Hsla, reason: 'input' | 'change'): void {
@@ -236,6 +256,62 @@
     if (!isDragging) return;
     isDragging = false;
     gradientElement?.releasePointerCapture(event.pointerId);
+    emit('change');
+  }
+
+  // ── Slider pointer handling ─────────────────────────────────────────────
+
+  let hueElement: HTMLDivElement | null = $state(null);
+  let alphaElement: HTMLDivElement | null = $state(null);
+  let draggingSlider: 'hue' | 'alpha' | null = $state(null);
+
+  function pointerToFraction(event: PointerEvent, element: HTMLElement): number {
+    const rect = element.getBoundingClientRect();
+    const x = clamp(event.clientX - rect.left, 0, rect.width);
+    return rect.width === 0 ? 0 : x / rect.width;
+  }
+
+  function handleHuePointerDown(event: PointerEvent): void {
+    if (disabled || !hueElement) return;
+    event.preventDefault();
+    hueElement.setPointerCapture(event.pointerId);
+    draggingSlider = 'hue';
+    const fraction = pointerToFraction(event, hueElement);
+    commitFromHsla({ h: fraction * 359, s: saturation, l: lightnessValue, a: alphaValue }, 'input');
+  }
+
+  function handleHuePointerMove(event: PointerEvent): void {
+    if (draggingSlider !== 'hue' || disabled || !hueElement) return;
+    const fraction = pointerToFraction(event, hueElement);
+    commitFromHsla({ h: fraction * 359, s: saturation, l: lightnessValue, a: alphaValue }, 'input');
+  }
+
+  function handleHuePointerUp(event: PointerEvent): void {
+    if (draggingSlider !== 'hue') return;
+    draggingSlider = null;
+    hueElement?.releasePointerCapture(event.pointerId);
+    emit('change');
+  }
+
+  function handleAlphaPointerDown(event: PointerEvent): void {
+    if (disabled || !alphaElement) return;
+    event.preventDefault();
+    alphaElement.setPointerCapture(event.pointerId);
+    draggingSlider = 'alpha';
+    const fraction = pointerToFraction(event, alphaElement);
+    commitFromHsla({ h: hue, s: saturation, l: lightnessValue, a: fraction }, 'input');
+  }
+
+  function handleAlphaPointerMove(event: PointerEvent): void {
+    if (draggingSlider !== 'alpha' || disabled || !alphaElement) return;
+    const fraction = pointerToFraction(event, alphaElement);
+    commitFromHsla({ h: hue, s: saturation, l: lightnessValue, a: fraction }, 'input');
+  }
+
+  function handleAlphaPointerUp(event: PointerEvent): void {
+    if (draggingSlider !== 'alpha') return;
+    draggingSlider = null;
+    alphaElement?.releasePointerCapture(event.pointerId);
     emit('change');
   }
 
@@ -322,26 +398,25 @@
   // 2D selection is inherently pointer-friendly. Documented in a11y memo.
   function handleGradientKeydown(event: KeyboardEvent): void {
     if (disabled) return;
-    const stepX = event.shiftKey ? 10 : 1;
-    const stepY = event.shiftKey ? 10 : 1;
+    const step = event.shiftKey ? 10 : 1;
     let nextS = saturation;
     let nextL = lightnessValue;
     let handled = false;
     switch (event.key) {
       case 'ArrowLeft':
-        nextS = clamp(saturation - stepX, 0, 100);
+        nextS = clamp(saturation - step, 0, 100);
         handled = true;
         break;
       case 'ArrowRight':
-        nextS = clamp(saturation + stepX, 0, 100);
+        nextS = clamp(saturation + step, 0, 100);
         handled = true;
         break;
       case 'ArrowUp':
-        nextL = clamp(lightnessValue + stepY, 0, 100);
+        nextL = clamp(lightnessValue + step, 0, 100);
         handled = true;
         break;
       case 'ArrowDown':
-        nextL = clamp(lightnessValue - stepY, 0, 100);
+        nextL = clamp(lightnessValue - step, 0, 100);
         handled = true;
         break;
     }
@@ -423,10 +498,7 @@
         alphaValue = 1;
         internalValue = '';
         lastEmittedHex = '';
-        if (value !== undefined) {
-          suppressNextSync = true;
-          value = '';
-        }
+        if (value !== undefined) value = '';
         onchange?.('');
         return;
       }
@@ -469,13 +541,8 @@
     return { x: svFromHsl * 100, y: (1 - v) * 100 };
   });
 
-  const handleX = $derived(handlePosition.x);
-  const handleY = $derived(handlePosition.y);
-
   const hueAriaValue = $derived(Math.round(hue));
   const alphaAriaValue = $derived(Math.round(alphaValue * 100));
-
-  const hiddenValue = $derived(internalValue);
 </script>
 
 <div
@@ -503,12 +570,13 @@
   >
     <div
       class="cinder-color-picker__gradient-handle"
-      style="left: {handleX}%; top: {handleY}%;"
+      style="left: {handlePosition.x}%; top: {handlePosition.y}%;"
       aria-hidden="true"
     ></div>
   </div>
 
   <div
+    bind:this={hueElement}
     id={hueId}
     role="slider"
     aria-label="Hue"
@@ -519,6 +587,10 @@
     tabindex={disabled ? -1 : 0}
     class="cinder-color-picker__hue"
     onkeydown={handleHueKeydown}
+    onpointerdown={handleHuePointerDown}
+    onpointermove={handleHuePointerMove}
+    onpointerup={handleHuePointerUp}
+    onpointercancel={handleHuePointerUp}
   >
     <div
       class="cinder-color-picker__hue-thumb"
@@ -529,6 +601,7 @@
 
   {#if alpha}
     <div
+      bind:this={alphaElement}
       id={alphaId}
       role="slider"
       aria-label="Alpha"
@@ -541,6 +614,10 @@
       class="cinder-color-picker__alpha"
       style="--cinder-color-picker-base: hsl({hue}, {saturation}%, {lightnessValue}%);"
       onkeydown={handleAlphaKeydown}
+      onpointerdown={handleAlphaPointerDown}
+      onpointermove={handleAlphaPointerMove}
+      onpointerup={handleAlphaPointerUp}
+      onpointercancel={handleAlphaPointerUp}
     >
       <div
         class="cinder-color-picker__alpha-thumb"
@@ -552,9 +629,10 @@
 
   <div
     id={previewId}
+    role="img"
     class="cinder-color-picker__preview"
     data-cinder-alpha={alpha ? '' : undefined}
-    aria-label="Selected color preview"
+    aria-label={internalValue ? `Selected color: ${internalValue}` : 'Selected color: none'}
     style="--cinder-color-picker-preview: {previewColor};"
   ></div>
 
@@ -567,12 +645,13 @@
       class="cinder-color-picker__swatches"
     >
       {#each swatchList as swatch, index (swatch + index)}
-        {@const isSelected = swatch.toLowerCase() === currentHex.toLowerCase()}
+        {@const normalized = normalizeSwatch(swatch)}
+        {@const isSelected = normalized !== null && normalized === currentHex.toLowerCase()}
         <li
           bind:this={swatchRefs[index]}
           role="option"
           aria-selected={isSelected}
-          aria-label={swatch}
+          aria-label={`Color ${swatch}`}
           tabindex={(swatchFocusIndex ?? 0) === index && !disabled ? 0 : -1}
           class="cinder-color-picker__swatch"
           data-cinder-selected={isSelected ? '' : undefined}
@@ -585,8 +664,8 @@
   {/if}
 
   {#if name}
-    <input bind:this={hiddenInput} type="hidden" {name} value={hiddenValue} />
+    <input bind:this={hiddenInput} type="hidden" {name} value={internalValue} />
   {:else}
-    <input bind:this={hiddenInput} type="hidden" value={hiddenValue} hidden />
+    <input bind:this={hiddenInput} type="hidden" value={internalValue} hidden />
   {/if}
 </div>

--- a/packages/components/src/components/color-picker.svelte
+++ b/packages/components/src/components/color-picker.svelte
@@ -1,0 +1,592 @@
+<script lang="ts" module>
+  /** Props for ColorPicker. */
+  export type ColorPickerProps = {
+    /**
+     * Bindable value. Reading the value yields a hex string (`#rrggbb`, or
+     * `#rrggbbaa` when `alpha` is true). Setting the value accepts hex, `rgb()`,
+     * `rgba()`, `hsl()`, or `hsla()` input; invalid input is normalized to `''`.
+     */
+    value?: string;
+    /** Initial color when `value` is not bound. Same input formats as `value`. */
+    defaultValue?: string;
+    /** Enable the alpha slider and emit `#rrggbbaa`. Default `false`. */
+    alpha?: boolean;
+    /** Form field name. When set, a hidden input mirrors the current value for form submission. */
+    name?: string;
+    /** Optional palette of preset colors rendered below the picker. */
+    swatches?: string[];
+    /** Disable interaction across the picker. */
+    disabled?: boolean;
+    /** Additional classes merged onto the root element. */
+    class?: string;
+    /** Accessible label for the picker. Default `'Color picker'`. */
+    label?: string;
+    /** Fired on commit (pointer up, swatch click, slider key). */
+    onchange?: (color: string) => void;
+    /** Fired on every intermediate update (drag, slider key, swatch click). */
+    oninput?: (color: string) => void;
+  };
+</script>
+
+<script lang="ts">
+  import { tick } from 'svelte';
+
+  import { classNames } from '../utilities/class-names.ts';
+  import { parseColor } from '../utilities/color-luminance.ts';
+  import { useId } from '../utilities/use-id.ts';
+
+  let {
+    value = $bindable(),
+    defaultValue,
+    alpha = false,
+    name,
+    swatches,
+    disabled = false,
+    class: className,
+    label = 'Color picker',
+    onchange,
+    oninput,
+  }: ColorPickerProps = $props();
+
+  const pickerId = useId('cinder-color-picker');
+  const gradientId = `${pickerId}-gradient`;
+  const hueId = `${pickerId}-hue`;
+  const alphaId = `${pickerId}-alpha`;
+  const swatchesId = `${pickerId}-swatches`;
+  const previewId = `${pickerId}-preview`;
+
+  type Hsla = { h: number; s: number; l: number; a: number };
+
+  // Internal canonical state is HSLA. We only round-trip to RGB/hex at the edges.
+  let hue = $state(0); // 0–360
+  let saturation = $state(100); // 0–100 (HSL saturation at the gradient corner)
+  let lightnessValue = $state(50); // 0–100
+  let alphaValue = $state(1); // 0–1
+
+  let internalValue = $state('');
+  let lastEmittedHex = $state('');
+  let suppressNextSync = $state(false);
+  let isDragging = $state(false);
+
+  function clamp(n: number, min: number, max: number): number {
+    return Math.max(min, Math.min(max, n));
+  }
+
+  function toHex2(n: number): string {
+    return clamp(Math.round(n), 0, 255).toString(16).padStart(2, '0');
+  }
+
+  function rgbToHsl(r: number, g: number, b: number): { h: number; s: number; l: number } {
+    const rn = r / 255;
+    const gn = g / 255;
+    const bn = b / 255;
+    const max = Math.max(rn, gn, bn);
+    const min = Math.min(rn, gn, bn);
+    const l = (max + min) / 2;
+    if (max === min) return { h: 0, s: 0, l: l * 100 };
+    const d = max - min;
+    const s = l > 0.5 ? d / (2 - max - min) : d / (max + min);
+    let h = 0;
+    if (max === rn) h = ((gn - bn) / d + (gn < bn ? 6 : 0)) * 60;
+    else if (max === gn) h = ((bn - rn) / d + 2) * 60;
+    else h = ((rn - gn) / d + 4) * 60;
+    return { h, s: s * 100, l: l * 100 };
+  }
+
+  function hslToRgb(h: number, s: number, l: number): { r: number; g: number; b: number } {
+    const sn = clamp(s, 0, 100) / 100;
+    const ln = clamp(l, 0, 100) / 100;
+    const hn = (((h % 360) + 360) % 360) / 360;
+    if (sn === 0) {
+      const v = Math.round(ln * 255);
+      return { r: v, g: v, b: v };
+    }
+    const q = ln < 0.5 ? ln * (1 + sn) : ln + sn - ln * sn;
+    const p = 2 * ln - q;
+    const hueToRgb = (t: number): number => {
+      let tn = t;
+      if (tn < 0) tn += 1;
+      if (tn > 1) tn -= 1;
+      if (tn < 1 / 6) return p + (q - p) * 6 * tn;
+      if (tn < 1 / 2) return q;
+      if (tn < 2 / 3) return p + (q - p) * (2 / 3 - tn) * 6;
+      return p;
+    };
+    return {
+      r: Math.round(hueToRgb(hn + 1 / 3) * 255),
+      g: Math.round(hueToRgb(hn) * 255),
+      b: Math.round(hueToRgb(hn - 1 / 3) * 255),
+    };
+  }
+
+  function formatHex(h: number, s: number, l: number, a: number, withAlpha: boolean): string {
+    const { r, g, b } = hslToRgb(h, s, l);
+    const base = `#${toHex2(r)}${toHex2(g)}${toHex2(b)}`;
+    if (!withAlpha) return base;
+    return base + toHex2(a * 255);
+  }
+
+  function parseToHsla(input: string): Hsla | null {
+    const parsed = parseColor(input);
+    if (!parsed) return null;
+    const { h, s, l } = rgbToHsl(parsed.r, parsed.g, parsed.b);
+    return { h, s, l, a: parsed.a };
+  }
+
+  function applyHsla(next: Hsla): void {
+    hue = next.h;
+    saturation = next.s;
+    lightnessValue = next.l;
+    alphaValue = alpha ? next.a : 1;
+  }
+
+  // Initialize from defaultValue (only when uncontrolled).
+  if (value === undefined && defaultValue) {
+    const parsed = parseToHsla(defaultValue);
+    if (parsed) {
+      applyHsla(parsed);
+      internalValue = formatHex(parsed.h, parsed.s, parsed.l, parsed.a, alpha);
+    }
+  } else if (value !== undefined) {
+    const parsed = parseToHsla(value);
+    if (parsed) {
+      applyHsla(parsed);
+      internalValue = formatHex(parsed.h, parsed.s, parsed.l, parsed.a, alpha);
+    }
+  }
+
+  // Sync incoming `value` (controlled) to internal HSLA, but only when it
+  // doesn't match what we last emitted (avoids fighting bound updates).
+  $effect(() => {
+    if (value === undefined) return;
+    if (suppressNextSync) {
+      suppressNextSync = false;
+      return;
+    }
+    if (value === lastEmittedHex) return;
+    if (value === '') {
+      internalValue = '';
+      return;
+    }
+    const parsed = parseToHsla(value);
+    if (!parsed) {
+      internalValue = '';
+      return;
+    }
+    applyHsla(parsed);
+    internalValue = formatHex(parsed.h, parsed.s, parsed.l, parsed.a, alpha);
+  });
+
+  function emit(reason: 'input' | 'change'): void {
+    const hex = formatHex(hue, saturation, lightnessValue, alphaValue, alpha);
+    internalValue = hex;
+    lastEmittedHex = hex;
+    if (value !== undefined) {
+      suppressNextSync = true;
+      value = hex;
+    }
+    if (reason === 'input') oninput?.(hex);
+    else onchange?.(hex);
+  }
+
+  function commitFromHsla(next: Hsla, reason: 'input' | 'change'): void {
+    applyHsla(next);
+    emit(reason);
+  }
+
+  // ── Gradient handling ──────────────────────────────────────────────────
+
+  let gradientElement: HTMLDivElement | null = $state(null);
+
+  /**
+   * Map a pointer event to (saturation, lightness) using the HSV-style square
+   * common to color pickers: x = saturation 0→100, y = value 100→0. We convert
+   * HSV to HSL on the way out so internal state stays HSL.
+   */
+  function pointerToHsl(event: PointerEvent): { s: number; l: number } {
+    const target = gradientElement;
+    if (!target) return { s: saturation, l: lightnessValue };
+    const rect = target.getBoundingClientRect();
+    const x = clamp(event.clientX - rect.left, 0, rect.width);
+    const y = clamp(event.clientY - rect.top, 0, rect.height);
+    const sv = rect.width === 0 ? 0 : x / rect.width; // 0–1 HSV saturation
+    const vv = rect.height === 0 ? 1 : 1 - y / rect.height; // 0–1 HSV value
+    // HSV → HSL
+    const l = vv * (1 - sv / 2);
+    const s = l === 0 || l === 1 ? 0 : (vv - l) / Math.min(l, 1 - l);
+    return { s: s * 100, l: l * 100 };
+  }
+
+  function handleGradientPointerDown(event: PointerEvent): void {
+    if (disabled) return;
+    event.preventDefault();
+    gradientElement?.setPointerCapture(event.pointerId);
+    isDragging = true;
+    const { s, l } = pointerToHsl(event);
+    commitFromHsla({ h: hue, s, l, a: alphaValue }, 'input');
+  }
+
+  function handleGradientPointerMove(event: PointerEvent): void {
+    if (!isDragging || disabled) return;
+    const { s, l } = pointerToHsl(event);
+    commitFromHsla({ h: hue, s, l, a: alphaValue }, 'input');
+  }
+
+  function handleGradientPointerUp(event: PointerEvent): void {
+    if (!isDragging) return;
+    isDragging = false;
+    gradientElement?.releasePointerCapture(event.pointerId);
+    emit('change');
+  }
+
+  // ── Slider keyboard handling ────────────────────────────────────────────
+
+  function adjustHue(delta: number): void {
+    const next = (((hue + delta) % 360) + 360) % 360;
+    commitFromHsla({ h: next, s: saturation, l: lightnessValue, a: alphaValue }, 'change');
+  }
+
+  function adjustAlpha(delta: number): void {
+    const next = clamp(alphaValue + delta, 0, 1);
+    commitFromHsla({ h: hue, s: saturation, l: lightnessValue, a: next }, 'change');
+  }
+
+  function handleHueKeydown(event: KeyboardEvent): void {
+    if (disabled) return;
+    const step = event.shiftKey ? 10 : 1;
+    switch (event.key) {
+      case 'ArrowLeft':
+      case 'ArrowDown':
+        event.preventDefault();
+        adjustHue(-step);
+        break;
+      case 'ArrowRight':
+      case 'ArrowUp':
+        event.preventDefault();
+        adjustHue(step);
+        break;
+      case 'Home':
+        event.preventDefault();
+        commitFromHsla({ h: 0, s: saturation, l: lightnessValue, a: alphaValue }, 'change');
+        break;
+      case 'End':
+        event.preventDefault();
+        commitFromHsla({ h: 359, s: saturation, l: lightnessValue, a: alphaValue }, 'change');
+        break;
+      case 'PageUp':
+        event.preventDefault();
+        adjustHue(36);
+        break;
+      case 'PageDown':
+        event.preventDefault();
+        adjustHue(-36);
+        break;
+    }
+  }
+
+  function handleAlphaKeydown(event: KeyboardEvent): void {
+    if (disabled) return;
+    const step = event.shiftKey ? 0.1 : 0.01;
+    switch (event.key) {
+      case 'ArrowLeft':
+      case 'ArrowDown':
+        event.preventDefault();
+        adjustAlpha(-step);
+        break;
+      case 'ArrowRight':
+      case 'ArrowUp':
+        event.preventDefault();
+        adjustAlpha(step);
+        break;
+      case 'Home':
+        event.preventDefault();
+        commitFromHsla({ h: hue, s: saturation, l: lightnessValue, a: 0 }, 'change');
+        break;
+      case 'End':
+        event.preventDefault();
+        commitFromHsla({ h: hue, s: saturation, l: lightnessValue, a: 1 }, 'change');
+        break;
+      case 'PageUp':
+        event.preventDefault();
+        adjustAlpha(0.1);
+        break;
+      case 'PageDown':
+        event.preventDefault();
+        adjustAlpha(-0.1);
+        break;
+    }
+  }
+
+  // Gradient region keyboard arrow keys also nudge saturation/lightness so the
+  // region is at least partially keyboard-operable, even though the underlying
+  // 2D selection is inherently pointer-friendly. Documented in a11y memo.
+  function handleGradientKeydown(event: KeyboardEvent): void {
+    if (disabled) return;
+    const stepX = event.shiftKey ? 10 : 1;
+    const stepY = event.shiftKey ? 10 : 1;
+    let nextS = saturation;
+    let nextL = lightnessValue;
+    let handled = false;
+    switch (event.key) {
+      case 'ArrowLeft':
+        nextS = clamp(saturation - stepX, 0, 100);
+        handled = true;
+        break;
+      case 'ArrowRight':
+        nextS = clamp(saturation + stepX, 0, 100);
+        handled = true;
+        break;
+      case 'ArrowUp':
+        nextL = clamp(lightnessValue + stepY, 0, 100);
+        handled = true;
+        break;
+      case 'ArrowDown':
+        nextL = clamp(lightnessValue - stepY, 0, 100);
+        handled = true;
+        break;
+    }
+    if (handled) {
+      event.preventDefault();
+      commitFromHsla({ h: hue, s: nextS, l: nextL, a: alphaValue }, 'change');
+    }
+  }
+
+  // ── Swatch list ─────────────────────────────────────────────────────────
+
+  const swatchList = $derived(swatches ?? []);
+  let swatchFocusIndex = $state<number | null>(null);
+  let swatchRefs: (HTMLLIElement | null)[] = $state([]);
+
+  const currentHex = $derived(formatHex(hue, saturation, lightnessValue, alphaValue, alpha));
+
+  function selectSwatch(index: number, reason: 'input' | 'change'): void {
+    if (disabled) return;
+    const next = swatchList[index];
+    if (!next) return;
+    const parsed = parseToHsla(next);
+    if (!parsed) return;
+    commitFromHsla(parsed, reason);
+  }
+
+  async function focusSwatch(index: number): Promise<void> {
+    swatchFocusIndex = index;
+    await tick();
+    swatchRefs[index]?.focus();
+  }
+
+  function handleSwatchKeydown(event: KeyboardEvent, index: number): void {
+    if (disabled) return;
+    const lastIndex = swatchList.length - 1;
+    switch (event.key) {
+      case 'ArrowRight':
+      case 'ArrowDown':
+        event.preventDefault();
+        void focusSwatch(index === lastIndex ? 0 : index + 1);
+        break;
+      case 'ArrowLeft':
+      case 'ArrowUp':
+        event.preventDefault();
+        void focusSwatch(index === 0 ? lastIndex : index - 1);
+        break;
+      case 'Home':
+        event.preventDefault();
+        void focusSwatch(0);
+        break;
+      case 'End':
+        event.preventDefault();
+        void focusSwatch(lastIndex);
+        break;
+      case 'Enter':
+      case ' ':
+        event.preventDefault();
+        selectSwatch(index, 'change');
+        break;
+    }
+  }
+
+  // ── Form reset ──────────────────────────────────────────────────────────
+
+  let hiddenInput: HTMLInputElement | null = $state(null);
+
+  $effect(() => {
+    const input: HTMLInputElement | null = hiddenInput;
+    if (input === null) return;
+    const resolvedInput: HTMLInputElement = input;
+    let currentForm: HTMLFormElement | null = null;
+
+    function resetToDefault(): void {
+      const fallback = defaultValue ?? '';
+      if (fallback === '') {
+        hue = 0;
+        saturation = 0;
+        lightnessValue = 0;
+        alphaValue = 1;
+        internalValue = '';
+        lastEmittedHex = '';
+        if (value !== undefined) {
+          suppressNextSync = true;
+          value = '';
+        }
+        onchange?.('');
+        return;
+      }
+      const parsed = parseToHsla(fallback);
+      if (!parsed) return;
+      commitFromHsla(parsed, 'change');
+    }
+
+    function attach(): void {
+      const next = resolvedInput.form;
+      if (next === currentForm) return;
+      currentForm?.removeEventListener('reset', resetToDefault);
+      currentForm = next;
+      currentForm?.addEventListener('reset', resetToDefault);
+    }
+
+    attach();
+    void tick().then(attach);
+
+    return () => {
+      currentForm?.removeEventListener('reset', resetToDefault);
+    };
+  });
+
+  // ── Visual derived data ─────────────────────────────────────────────────
+
+  const hueColor = $derived(`hsl(${hue}, 100%, 50%)`);
+  const previewColor = $derived(
+    alpha
+      ? `hsla(${hue}, ${saturation}%, ${lightnessValue}%, ${alphaValue})`
+      : `hsl(${hue}, ${saturation}%, ${lightnessValue}%)`,
+  );
+
+  // HSV position of the gradient handle (x = HSV saturation, y = HSV value).
+  const handlePosition = $derived.by(() => {
+    const ln = lightnessValue / 100;
+    const sn = saturation / 100;
+    const v = ln + sn * Math.min(ln, 1 - ln);
+    const svFromHsl = v === 0 ? 0 : 2 * (1 - ln / v);
+    return { x: svFromHsl * 100, y: (1 - v) * 100 };
+  });
+
+  const handleX = $derived(handlePosition.x);
+  const handleY = $derived(handlePosition.y);
+
+  const hueAriaValue = $derived(Math.round(hue));
+  const alphaAriaValue = $derived(Math.round(alphaValue * 100));
+
+  const hiddenValue = $derived(internalValue);
+</script>
+
+<div
+  class={classNames('cinder-color-picker', className)}
+  data-cinder-disabled={disabled ? '' : undefined}
+  data-cinder-alpha={alpha ? '' : undefined}
+  aria-label={label}
+  role="group"
+  id={pickerId}
+>
+  <div
+    bind:this={gradientElement}
+    id={gradientId}
+    role="application"
+    aria-label="Color saturation and lightness. Use a pointer to select; arrow keys provide coarse keyboard adjustment."
+    aria-disabled={disabled ? 'true' : undefined}
+    class="cinder-color-picker__gradient"
+    style="--cinder-color-picker-hue: {hueColor};"
+    tabindex={disabled ? -1 : 0}
+    onpointerdown={handleGradientPointerDown}
+    onpointermove={handleGradientPointerMove}
+    onpointerup={handleGradientPointerUp}
+    onpointercancel={handleGradientPointerUp}
+    onkeydown={handleGradientKeydown}
+  >
+    <div
+      class="cinder-color-picker__gradient-handle"
+      style="left: {handleX}%; top: {handleY}%;"
+      aria-hidden="true"
+    ></div>
+  </div>
+
+  <div
+    id={hueId}
+    role="slider"
+    aria-label="Hue"
+    aria-valuemin={0}
+    aria-valuemax={359}
+    aria-valuenow={hueAriaValue}
+    aria-disabled={disabled ? 'true' : undefined}
+    tabindex={disabled ? -1 : 0}
+    class="cinder-color-picker__hue"
+    onkeydown={handleHueKeydown}
+  >
+    <div
+      class="cinder-color-picker__hue-thumb"
+      style="left: {(hue / 359) * 100}%;"
+      aria-hidden="true"
+    ></div>
+  </div>
+
+  {#if alpha}
+    <div
+      id={alphaId}
+      role="slider"
+      aria-label="Alpha"
+      aria-valuemin={0}
+      aria-valuemax={100}
+      aria-valuenow={alphaAriaValue}
+      aria-valuetext="{alphaAriaValue}%"
+      aria-disabled={disabled ? 'true' : undefined}
+      tabindex={disabled ? -1 : 0}
+      class="cinder-color-picker__alpha"
+      style="--cinder-color-picker-base: hsl({hue}, {saturation}%, {lightnessValue}%);"
+      onkeydown={handleAlphaKeydown}
+    >
+      <div
+        class="cinder-color-picker__alpha-thumb"
+        style="left: {alphaValue * 100}%;"
+        aria-hidden="true"
+      ></div>
+    </div>
+  {/if}
+
+  <div
+    id={previewId}
+    class="cinder-color-picker__preview"
+    data-cinder-alpha={alpha ? '' : undefined}
+    aria-label="Selected color preview"
+    style="--cinder-color-picker-preview: {previewColor};"
+  ></div>
+
+  {#if swatchList.length > 0}
+    <ul
+      id={swatchesId}
+      role="listbox"
+      aria-label="Color swatches"
+      aria-disabled={disabled ? 'true' : undefined}
+      class="cinder-color-picker__swatches"
+    >
+      {#each swatchList as swatch, index (swatch + index)}
+        {@const isSelected = swatch.toLowerCase() === currentHex.toLowerCase()}
+        <li
+          bind:this={swatchRefs[index]}
+          role="option"
+          aria-selected={isSelected}
+          aria-label={swatch}
+          tabindex={(swatchFocusIndex ?? 0) === index && !disabled ? 0 : -1}
+          class="cinder-color-picker__swatch"
+          data-cinder-selected={isSelected ? '' : undefined}
+          style="--cinder-color-picker-swatch: {swatch};"
+          onclick={() => selectSwatch(index, 'change')}
+          onkeydown={(event) => handleSwatchKeydown(event, index)}
+        ></li>
+      {/each}
+    </ul>
+  {/if}
+
+  {#if name}
+    <input bind:this={hiddenInput} type="hidden" {name} value={hiddenValue} />
+  {:else}
+    <input bind:this={hiddenInput} type="hidden" value={hiddenValue} hidden />
+  {/if}
+</div>

--- a/packages/components/src/components/color-picker.svelte
+++ b/packages/components/src/components/color-picker.svelte
@@ -77,6 +77,10 @@
     return clamp(Math.round(n), 0, 255).toString(16).padStart(2, '0');
   }
 
+  function normalizeHue(h: number): number {
+    return Math.min(((h % 360) + 360) % 360, 359);
+  }
+
   function rgbToHsl(r: number, g: number, b: number): { h: number; s: number; l: number } {
     const rn = r / 255;
     const gn = g / 255;
@@ -131,7 +135,7 @@
     const parsed = parseColor(input);
     if (!parsed) return null;
     const { h, s, l } = rgbToHsl(parsed.r, parsed.g, parsed.b);
-    return { h, s, l, a: parsed.a };
+    return { h: normalizeHue(h), s, l, a: parsed.a };
   }
 
   /**

--- a/packages/components/src/components/color-picker.svelte
+++ b/packages/components/src/components/color-picker.svelte
@@ -233,6 +233,14 @@
     emit(reason);
   }
 
+  function commitCurrentValueChange(): void {
+    const hex = formatHex(hue, saturation, lightnessValue, alphaValue, alpha);
+    internalValue = hex;
+    lastEmittedHex = hex;
+    if (value !== undefined) value = hex;
+    onchange?.(hex);
+  }
+
   // ── Gradient handling ──────────────────────────────────────────────────
 
   let gradientElement: HTMLDivElement | null = $state(null);
@@ -275,11 +283,7 @@
     if (!isDragging) return;
     isDragging = false;
     gradientElement?.releasePointerCapture(event.pointerId);
-    const hex = formatHex(hue, saturation, lightnessValue, alphaValue, alpha);
-    internalValue = hex;
-    lastEmittedHex = hex;
-    if (value !== undefined) value = hex;
-    onchange?.(hex);
+    commitCurrentValueChange();
   }
 
   function handleGradientPointerCancel(event: PointerEvent): void {
@@ -322,11 +326,7 @@
     if (draggingSlider !== 'hue') return;
     draggingSlider = null;
     hueElement?.releasePointerCapture(event.pointerId);
-    const hex = formatHex(hue, saturation, lightnessValue, alphaValue, alpha);
-    internalValue = hex;
-    lastEmittedHex = hex;
-    if (value !== undefined) value = hex;
-    onchange?.(hex);
+    commitCurrentValueChange();
   }
 
   function handleHuePointerCancel(event: PointerEvent): void {
@@ -354,11 +354,7 @@
     if (draggingSlider !== 'alpha') return;
     draggingSlider = null;
     alphaElement?.releasePointerCapture(event.pointerId);
-    const hex = formatHex(hue, saturation, lightnessValue, alphaValue, alpha);
-    internalValue = hex;
-    lastEmittedHex = hex;
-    if (value !== undefined) value = hex;
-    onchange?.(hex);
+    commitCurrentValueChange();
   }
 
   function handleAlphaPointerCancel(event: PointerEvent): void {

--- a/packages/components/src/components/color-picker.svelte
+++ b/packages/components/src/components/color-picker.svelte
@@ -152,18 +152,39 @@
     alphaValue = alpha ? next.a : 1;
   }
 
+  function resetToEmptyValue(): void {
+    hue = 0;
+    saturation = 0;
+    lightnessValue = 0;
+    alphaValue = 1;
+    internalValue = '';
+    lastEmittedHex = '';
+  }
+
+  function applyHslaSilently(next: Hsla): void {
+    applyHsla(next);
+    const hex = formatHex(next.h, next.s, next.l, next.a, alpha);
+    internalValue = hex;
+    lastEmittedHex = hex;
+    if (value !== undefined) value = hex;
+  }
+
   // Initialize from defaultValue (only when uncontrolled).
   if (value === undefined && defaultValue) {
     const parsed = parseToHsla(defaultValue);
     if (parsed) {
       applyHsla(parsed);
       internalValue = formatHex(parsed.h, parsed.s, parsed.l, parsed.a, alpha);
+    } else {
+      resetToEmptyValue();
     }
   } else if (value !== undefined) {
     const parsed = parseToHsla(value);
     if (parsed) {
       applyHsla(parsed);
       internalValue = formatHex(parsed.h, parsed.s, parsed.l, parsed.a, alpha);
+    } else {
+      resetToEmptyValue();
     }
   }
 
@@ -173,14 +194,14 @@
   // (and writes a different one back) is not ignored.
   $effect(() => {
     if (value === undefined) return;
-    if (value === lastEmittedHex) return;
+    if (value !== '' && value === lastEmittedHex) return;
     if (value === '') {
-      internalValue = '';
+      resetToEmptyValue();
       return;
     }
     const parsed = parseToHsla(value);
     if (!parsed) {
-      internalValue = '';
+      resetToEmptyValue();
       return;
     }
     applyHsla(parsed);
@@ -207,6 +228,14 @@
     // Every value mutation fires `oninput`; `onchange` additionally fires on commit.
     oninput?.(hex);
     if (reason === 'change') onchange?.(hex);
+  }
+
+  function commitCurrentValue(): void {
+    const hex = formatHex(hue, saturation, lightnessValue, alphaValue, alpha);
+    internalValue = hex;
+    lastEmittedHex = hex;
+    if (value !== undefined) value = hex;
+    onchange?.(hex);
   }
 
   function commitFromHsla(next: Hsla, reason: 'input' | 'change'): void {
@@ -256,7 +285,13 @@
     if (!isDragging) return;
     isDragging = false;
     gradientElement?.releasePointerCapture(event.pointerId);
-    emit('change');
+    commitCurrentValue();
+  }
+
+  function handleGradientPointerCancel(event: PointerEvent): void {
+    if (!isDragging) return;
+    isDragging = false;
+    gradientElement?.releasePointerCapture(event.pointerId);
   }
 
   // ── Slider pointer handling ─────────────────────────────────────────────
@@ -293,7 +328,13 @@
     if (draggingSlider !== 'hue') return;
     draggingSlider = null;
     hueElement?.releasePointerCapture(event.pointerId);
-    emit('change');
+    commitCurrentValue();
+  }
+
+  function handleHuePointerCancel(event: PointerEvent): void {
+    if (draggingSlider !== 'hue') return;
+    draggingSlider = null;
+    hueElement?.releasePointerCapture(event.pointerId);
   }
 
   function handleAlphaPointerDown(event: PointerEvent): void {
@@ -315,7 +356,13 @@
     if (draggingSlider !== 'alpha') return;
     draggingSlider = null;
     alphaElement?.releasePointerCapture(event.pointerId);
-    emit('change');
+    commitCurrentValue();
+  }
+
+  function handleAlphaPointerCancel(event: PointerEvent): void {
+    if (draggingSlider !== 'alpha') return;
+    draggingSlider = null;
+    alphaElement?.releasePointerCapture(event.pointerId);
   }
 
   // ── Slider keyboard handling ────────────────────────────────────────────
@@ -495,19 +542,17 @@
     function resetToDefault(): void {
       const fallback = defaultValue ?? '';
       if (fallback === '') {
-        hue = 0;
-        saturation = 0;
-        lightnessValue = 0;
-        alphaValue = 1;
-        internalValue = '';
-        lastEmittedHex = '';
+        resetToEmptyValue();
         if (value !== undefined) value = '';
-        onchange?.('');
         return;
       }
       const parsed = parseToHsla(fallback);
-      if (!parsed) return;
-      commitFromHsla(parsed, 'change');
+      if (!parsed) {
+        resetToEmptyValue();
+        if (value !== undefined) value = '';
+        return;
+      }
+      applyHslaSilently(parsed);
     }
 
     function attach(): void {
@@ -530,9 +575,11 @@
 
   const hueColor = $derived(`hsl(${hue}, 100%, 50%)`);
   const previewColor = $derived(
-    alpha
-      ? `hsla(${hue}, ${saturation}%, ${lightnessValue}%, ${alphaValue})`
-      : `hsl(${hue}, ${saturation}%, ${lightnessValue}%)`,
+    internalValue === ''
+      ? 'transparent'
+      : alpha
+        ? `hsla(${hue}, ${saturation}%, ${lightnessValue}%, ${alphaValue})`
+        : `hsl(${hue}, ${saturation}%, ${lightnessValue}%)`,
   );
 
   // HSV position of the gradient handle (x = HSV saturation, y = HSV value).
@@ -568,7 +615,7 @@
     onpointerdown={handleGradientPointerDown}
     onpointermove={handleGradientPointerMove}
     onpointerup={handleGradientPointerUp}
-    onpointercancel={handleGradientPointerUp}
+    onpointercancel={handleGradientPointerCancel}
     onkeydown={handleGradientKeydown}
   >
     <div
@@ -593,7 +640,7 @@
     onpointerdown={handleHuePointerDown}
     onpointermove={handleHuePointerMove}
     onpointerup={handleHuePointerUp}
-    onpointercancel={handleHuePointerUp}
+    onpointercancel={handleHuePointerCancel}
   >
     <div
       class="cinder-color-picker__hue-thumb"
@@ -620,7 +667,7 @@
       onpointerdown={handleAlphaPointerDown}
       onpointermove={handleAlphaPointerMove}
       onpointerup={handleAlphaPointerUp}
-      onpointercancel={handleAlphaPointerUp}
+      onpointercancel={handleAlphaPointerCancel}
     >
       <div
         class="cinder-color-picker__alpha-thumb"
@@ -649,7 +696,8 @@
     >
       {#each swatchList as swatch, index (swatch + index)}
         {@const normalized = normalizeSwatch(swatch)}
-        {@const isSelected = normalized !== null && normalized === currentHex.toLowerCase()}
+        {@const isSelected =
+          internalValue !== '' && normalized !== null && normalized === currentHex.toLowerCase()}
         <li
           bind:this={swatchRefs[index]}
           role="option"

--- a/packages/components/src/components/color-picker.svelte
+++ b/packages/components/src/components/color-picker.svelte
@@ -152,23 +152,6 @@
     alphaValue = alpha ? next.a : 1;
   }
 
-  function resetToEmptyValue(): void {
-    hue = 0;
-    saturation = 0;
-    lightnessValue = 0;
-    alphaValue = 1;
-    internalValue = '';
-    lastEmittedHex = '';
-  }
-
-  function applyHslaSilently(next: Hsla): void {
-    applyHsla(next);
-    const hex = formatHex(next.h, next.s, next.l, next.a, alpha);
-    internalValue = hex;
-    lastEmittedHex = hex;
-    if (value !== undefined) value = hex;
-  }
-
   // Initialize from defaultValue (only when uncontrolled).
   if (value === undefined && defaultValue) {
     const parsed = parseToHsla(defaultValue);
@@ -176,7 +159,12 @@
       applyHsla(parsed);
       internalValue = formatHex(parsed.h, parsed.s, parsed.l, parsed.a, alpha);
     } else {
-      resetToEmptyValue();
+      hue = 0;
+      saturation = 0;
+      lightnessValue = 0;
+      alphaValue = 1;
+      internalValue = '';
+      lastEmittedHex = '';
     }
   } else if (value !== undefined) {
     const parsed = parseToHsla(value);
@@ -184,7 +172,12 @@
       applyHsla(parsed);
       internalValue = formatHex(parsed.h, parsed.s, parsed.l, parsed.a, alpha);
     } else {
-      resetToEmptyValue();
+      hue = 0;
+      saturation = 0;
+      lightnessValue = 0;
+      alphaValue = 1;
+      internalValue = '';
+      lastEmittedHex = '';
     }
   }
 
@@ -195,13 +188,14 @@
   $effect(() => {
     if (value === undefined) return;
     if (value !== '' && value === lastEmittedHex) return;
-    if (value === '') {
-      resetToEmptyValue();
-      return;
-    }
-    const parsed = parseToHsla(value);
-    if (!parsed) {
-      resetToEmptyValue();
+    const parsed = value === '' ? null : parseToHsla(value);
+    if (parsed === null) {
+      hue = 0;
+      saturation = 0;
+      lightnessValue = 0;
+      alphaValue = 1;
+      internalValue = '';
+      lastEmittedHex = '';
       return;
     }
     applyHsla(parsed);
@@ -228,14 +222,6 @@
     // Every value mutation fires `oninput`; `onchange` additionally fires on commit.
     oninput?.(hex);
     if (reason === 'change') onchange?.(hex);
-  }
-
-  function commitCurrentValue(): void {
-    const hex = formatHex(hue, saturation, lightnessValue, alphaValue, alpha);
-    internalValue = hex;
-    lastEmittedHex = hex;
-    if (value !== undefined) value = hex;
-    onchange?.(hex);
   }
 
   function commitFromHsla(next: Hsla, reason: 'input' | 'change'): void {
@@ -285,7 +271,11 @@
     if (!isDragging) return;
     isDragging = false;
     gradientElement?.releasePointerCapture(event.pointerId);
-    commitCurrentValue();
+    const hex = formatHex(hue, saturation, lightnessValue, alphaValue, alpha);
+    internalValue = hex;
+    lastEmittedHex = hex;
+    if (value !== undefined) value = hex;
+    onchange?.(hex);
   }
 
   function handleGradientPointerCancel(event: PointerEvent): void {
@@ -328,7 +318,11 @@
     if (draggingSlider !== 'hue') return;
     draggingSlider = null;
     hueElement?.releasePointerCapture(event.pointerId);
-    commitCurrentValue();
+    const hex = formatHex(hue, saturation, lightnessValue, alphaValue, alpha);
+    internalValue = hex;
+    lastEmittedHex = hex;
+    if (value !== undefined) value = hex;
+    onchange?.(hex);
   }
 
   function handleHuePointerCancel(event: PointerEvent): void {
@@ -356,7 +350,11 @@
     if (draggingSlider !== 'alpha') return;
     draggingSlider = null;
     alphaElement?.releasePointerCapture(event.pointerId);
-    commitCurrentValue();
+    const hex = formatHex(hue, saturation, lightnessValue, alphaValue, alpha);
+    internalValue = hex;
+    lastEmittedHex = hex;
+    if (value !== undefined) value = hex;
+    onchange?.(hex);
   }
 
   function handleAlphaPointerCancel(event: PointerEvent): void {
@@ -541,18 +539,22 @@
 
     function resetToDefault(): void {
       const fallback = defaultValue ?? '';
-      if (fallback === '') {
-        resetToEmptyValue();
+      const parsed = fallback === '' ? null : parseToHsla(fallback);
+      if (parsed === null) {
+        hue = 0;
+        saturation = 0;
+        lightnessValue = 0;
+        alphaValue = 1;
+        internalValue = '';
+        lastEmittedHex = '';
         if (value !== undefined) value = '';
         return;
       }
-      const parsed = parseToHsla(fallback);
-      if (!parsed) {
-        resetToEmptyValue();
-        if (value !== undefined) value = '';
-        return;
-      }
-      applyHslaSilently(parsed);
+      applyHsla(parsed);
+      const hex = formatHex(parsed.h, parsed.s, parsed.l, parsed.a, alpha);
+      internalValue = hex;
+      lastEmittedHex = hex;
+      if (value !== undefined) value = hex;
     }
 
     function attach(): void {

--- a/packages/components/src/components/color-picker.test.ts
+++ b/packages/components/src/components/color-picker.test.ts
@@ -1,0 +1,281 @@
+/// <reference lib="dom" />
+import { describe, expect, test } from 'bun:test';
+
+import { setupHappyDom } from '../test/happy-dom.ts';
+
+setupHappyDom();
+
+const { render, fireEvent } = await import('@testing-library/svelte');
+const { default: ColorPicker } = await import('./color-picker.svelte');
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function q<T extends Element = HTMLElement>(root: ParentNode, selector: string): T {
+  const element = root.querySelector(selector);
+  if (!element) throw new Error(`Selector not found: ${selector}`);
+  return element as T;
+}
+
+describe('ColorPicker structure', () => {
+  test('renders a labelled group with gradient, hue slider, and preview', () => {
+    const { container } = render(ColorPicker, { defaultValue: '#ff0000' });
+    expect(q(container, '[role="group"]').getAttribute('aria-label')).toBe('Color picker');
+    expect(q(container, '[role="application"]')).toBeTruthy();
+    const sliders = container.querySelectorAll('[role="slider"]');
+    expect(sliders.length).toBe(1); // hue only when alpha=false
+    expect(q(container, '.cinder-color-picker__preview')).toBeTruthy();
+  });
+
+  test('renders alpha slider when alpha=true', () => {
+    const { container } = render(ColorPicker, { defaultValue: '#ff0000', alpha: true });
+    const sliders = container.querySelectorAll('[role="slider"]');
+    expect(sliders.length).toBe(2);
+    const alphaSlider = container.querySelector('[aria-label="Alpha"]');
+    expect(alphaSlider).toBeTruthy();
+  });
+
+  test('renders swatch listbox when swatches are provided', () => {
+    const { container } = render(ColorPicker, {
+      defaultValue: '#ff0000',
+      swatches: ['#ff0000', '#00ff00', '#0000ff'],
+    });
+    const listbox = q(container, '[role="listbox"]');
+    expect(listbox.getAttribute('aria-label')).toBe('Color swatches');
+    const options = container.querySelectorAll('[role="option"]');
+    expect(options.length).toBe(3);
+  });
+
+  test('renders hidden input mirroring the value when name is provided', () => {
+    const { container } = render(ColorPicker, { defaultValue: '#ff0000', name: 'pick' });
+    const hidden = q<HTMLInputElement>(container, 'input[name="pick"]');
+    expect(hidden.type).toBe('hidden');
+    expect(hidden.value).toBe('#ff0000');
+  });
+});
+
+describe('ColorPicker parser round-trips', () => {
+  test('hex round-trips', () => {
+    const { container } = render(ColorPicker, { defaultValue: '#abcdef', name: 'p' });
+    const hidden = q<HTMLInputElement>(container, 'input[name="p"]');
+    expect(hidden.value).toBe('#abcdef');
+  });
+
+  test('rgb input emits hex', () => {
+    const { container } = render(ColorPicker, { defaultValue: 'rgb(255, 0, 0)', name: 'p' });
+    const hidden = q<HTMLInputElement>(container, 'input[name="p"]');
+    expect(hidden.value).toBe('#ff0000');
+  });
+
+  test('hsl input emits hex', () => {
+    const { container } = render(ColorPicker, {
+      defaultValue: 'hsl(120, 100%, 50%)',
+      name: 'p',
+    });
+    const hidden = q<HTMLInputElement>(container, 'input[name="p"]');
+    expect(hidden.value).toBe('#00ff00');
+  });
+
+  test('short hex expands to long hex', () => {
+    const { container } = render(ColorPicker, { defaultValue: '#f00', name: 'p' });
+    const hidden = q<HTMLInputElement>(container, 'input[name="p"]');
+    expect(hidden.value).toBe('#ff0000');
+  });
+});
+
+describe('ColorPicker alpha behavior', () => {
+  test('alpha=true emits 8-char hex', () => {
+    const { container } = render(ColorPicker, {
+      defaultValue: 'rgba(255, 0, 0, 0.5)',
+      alpha: true,
+      name: 'p',
+    });
+    const hidden = q<HTMLInputElement>(container, 'input[name="p"]');
+    expect(hidden.value).toMatch(/^#ff0000[0-9a-f]{2}$/);
+  });
+
+  test('alpha=false drops alpha on emit even when input has alpha', () => {
+    const { container } = render(ColorPicker, {
+      defaultValue: '#ff0000ff',
+      alpha: false,
+      name: 'p',
+    });
+    const hidden = q<HTMLInputElement>(container, 'input[name="p"]');
+    expect(hidden.value).toBe('#ff0000');
+  });
+});
+
+describe('ColorPicker invalid input', () => {
+  test('invalid string yields empty hidden value', () => {
+    const { container } = render(ColorPicker, {
+      defaultValue: 'not-a-color',
+      name: 'p',
+    });
+    const hidden = q<HTMLInputElement>(container, 'input[name="p"]');
+    expect(hidden.value).toBe('');
+  });
+});
+
+describe('ColorPicker hue slider keyboard', () => {
+  test('ArrowRight increments hue', async () => {
+    let captured = '';
+    const { container } = render(ColorPicker, {
+      defaultValue: '#ff0000',
+      onchange: (color: string) => {
+        captured = color;
+      },
+    });
+    const hue = q(container, '[aria-label="Hue"]');
+    expect(hue.getAttribute('aria-valuenow')).toBe('0');
+    await fireEvent.keyDown(hue, { key: 'ArrowRight' });
+    expect(hue.getAttribute('aria-valuenow')).toBe('1');
+    expect(captured).not.toBe('#ff0000');
+  });
+
+  test('ArrowLeft decrements hue (wraps)', async () => {
+    const { container } = render(ColorPicker, { defaultValue: '#ff0000' });
+    const hue = q(container, '[aria-label="Hue"]');
+    await fireEvent.keyDown(hue, { key: 'ArrowLeft' });
+    expect(hue.getAttribute('aria-valuenow')).toBe('359');
+  });
+
+  test('Home/End move hue to 0/359', async () => {
+    const { container } = render(ColorPicker, { defaultValue: 'hsl(180, 100%, 50%)' });
+    const hue = q(container, '[aria-label="Hue"]');
+    await fireEvent.keyDown(hue, { key: 'Home' });
+    expect(hue.getAttribute('aria-valuenow')).toBe('0');
+    await fireEvent.keyDown(hue, { key: 'End' });
+    expect(hue.getAttribute('aria-valuenow')).toBe('359');
+  });
+
+  test('Shift+Arrow takes 10-degree steps', async () => {
+    const { container } = render(ColorPicker, { defaultValue: '#ff0000' });
+    const hue = q(container, '[aria-label="Hue"]');
+    await fireEvent.keyDown(hue, { key: 'ArrowRight', shiftKey: true });
+    expect(hue.getAttribute('aria-valuenow')).toBe('10');
+  });
+});
+
+describe('ColorPicker alpha slider keyboard', () => {
+  test('ArrowRight increases alpha', async () => {
+    const { container } = render(ColorPicker, {
+      defaultValue: '#ff000080',
+      alpha: true,
+    });
+    const alphaSlider = q(container, '[aria-label="Alpha"]');
+    const initial = Number(alphaSlider.getAttribute('aria-valuenow'));
+    await fireEvent.keyDown(alphaSlider, { key: 'ArrowRight' });
+    const next = Number(alphaSlider.getAttribute('aria-valuenow'));
+    expect(next).toBeGreaterThan(initial);
+  });
+
+  test('Home/End set alpha to 0/100', async () => {
+    const { container } = render(ColorPicker, {
+      defaultValue: '#ff000080',
+      alpha: true,
+    });
+    const alphaSlider = q(container, '[aria-label="Alpha"]');
+    await fireEvent.keyDown(alphaSlider, { key: 'Home' });
+    expect(alphaSlider.getAttribute('aria-valuenow')).toBe('0');
+    await fireEvent.keyDown(alphaSlider, { key: 'End' });
+    expect(alphaSlider.getAttribute('aria-valuenow')).toBe('100');
+  });
+});
+
+describe('ColorPicker swatch keyboard nav', () => {
+  test('clicking a swatch updates the value', async () => {
+    let captured = '';
+    const { container } = render(ColorPicker, {
+      defaultValue: '#ffffff',
+      swatches: ['#ff0000', '#00ff00', '#0000ff'],
+      name: 'p',
+      onchange: (color: string) => {
+        captured = color;
+      },
+    });
+    const options = container.querySelectorAll<HTMLElement>('[role="option"]');
+    await fireEvent.click(options[1]!);
+    expect(captured).toBe('#00ff00');
+    const hidden = q<HTMLInputElement>(container, 'input[name="p"]');
+    expect(hidden.value).toBe('#00ff00');
+  });
+
+  test('Enter on a focused swatch selects it', async () => {
+    let captured = '';
+    const { container } = render(ColorPicker, {
+      defaultValue: '#ffffff',
+      swatches: ['#ff0000', '#00ff00', '#0000ff'],
+      onchange: (color: string) => {
+        captured = color;
+      },
+    });
+    const options = container.querySelectorAll<HTMLElement>('[role="option"]');
+    await fireEvent.keyDown(options[2]!, { key: 'Enter' });
+    expect(captured).toBe('#0000ff');
+  });
+
+  test('selected swatch is reflected with aria-selected', async () => {
+    const { container } = render(ColorPicker, {
+      defaultValue: '#00ff00',
+      swatches: ['#ff0000', '#00ff00', '#0000ff'],
+    });
+    const options = container.querySelectorAll<HTMLElement>('[role="option"]');
+    expect(options[1]!.getAttribute('aria-selected')).toBe('true');
+    expect(options[0]!.getAttribute('aria-selected')).toBe('false');
+  });
+});
+
+describe('ColorPicker form reset', () => {
+  test('form reset reverts to defaultValue', async () => {
+    const form = document.createElement('form');
+    document.body.appendChild(form);
+
+    const { container } = render(ColorPicker, {
+      defaultValue: '#ff0000',
+      name: 'p',
+    });
+    form.appendChild(container);
+    // Allow the $effect that attaches the form reset listener to run after
+    // the hidden input is reparented under the form.
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    const hidden = q<HTMLInputElement>(form, 'input[name="p"]');
+    expect(hidden.value).toBe('#ff0000');
+
+    // Mutate via hue slider
+    const hue = q(form, '[aria-label="Hue"]');
+    await fireEvent.keyDown(hue, { key: 'ArrowRight', shiftKey: true });
+    expect(hidden.value).not.toBe('#ff0000');
+
+    // Dispatch the reset event directly — Svelte's onreset wiring expects
+    // a bubbling event from the form element itself.
+    form.dispatchEvent(new Event('reset', { bubbles: true, cancelable: true }));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(hidden.value).toBe('#ff0000');
+
+    document.body.removeChild(form);
+  });
+});
+
+describe('ColorPicker disabled', () => {
+  test('disabled=true sets data-cinder-disabled and aria-disabled on subcontrols', () => {
+    const { container } = render(ColorPicker, {
+      defaultValue: '#ff0000',
+      disabled: true,
+    });
+    const root = q(container, '.cinder-color-picker');
+    expect(root.hasAttribute('data-cinder-disabled')).toBe(true);
+    const hue = q(container, '[aria-label="Hue"]');
+    expect(hue.getAttribute('aria-disabled')).toBe('true');
+    expect(hue.getAttribute('tabindex')).toBe('-1');
+  });
+
+  test('disabled blocks hue keyboard updates', async () => {
+    const { container } = render(ColorPicker, {
+      defaultValue: '#ff0000',
+      disabled: true,
+    });
+    const hue = q(container, '[aria-label="Hue"]');
+    const before = hue.getAttribute('aria-valuenow');
+    await fireEvent.keyDown(hue, { key: 'ArrowRight' });
+    expect(hue.getAttribute('aria-valuenow')).toBe(before);
+  });
+});

--- a/packages/components/src/components/color-picker.test.ts
+++ b/packages/components/src/components/color-picker.test.ts
@@ -6,6 +6,7 @@ import { setupHappyDom } from '../test/happy-dom.ts';
 setupHappyDom();
 
 const { render, fireEvent } = await import('@testing-library/svelte');
+const { tick } = await import('svelte');
 const { default: ColorPicker } = await import('./color-picker.svelte');
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -228,30 +229,130 @@ describe('ColorPicker form reset', () => {
     const form = document.createElement('form');
     document.body.appendChild(form);
 
+    // Render directly into the form so the hidden input mounts inside it
+    // from the start and the $effect attaches its reset listener at mount.
     const { container } = render(ColorPicker, {
-      defaultValue: '#ff0000',
-      name: 'p',
+      target: form,
+      props: {
+        defaultValue: '#ff0000',
+        name: 'p',
+      },
     });
-    form.appendChild(container);
-    // Allow the $effect that attaches the form reset listener to run after
-    // the hidden input is reparented under the form.
-    await new Promise((resolve) => setTimeout(resolve, 0));
+    await tick();
 
-    const hidden = q<HTMLInputElement>(form, 'input[name="p"]');
+    const hidden = q<HTMLInputElement>(container, 'input[name="p"]');
     expect(hidden.value).toBe('#ff0000');
 
     // Mutate via hue slider
-    const hue = q(form, '[aria-label="Hue"]');
+    const hue = q(container, '[aria-label="Hue"]');
     await fireEvent.keyDown(hue, { key: 'ArrowRight', shiftKey: true });
     expect(hidden.value).not.toBe('#ff0000');
 
-    // Dispatch the reset event directly — Svelte's onreset wiring expects
-    // a bubbling event from the form element itself.
     form.dispatchEvent(new Event('reset', { bubbles: true, cancelable: true }));
-    await new Promise((resolve) => setTimeout(resolve, 0));
+    await tick();
     expect(hidden.value).toBe('#ff0000');
 
     document.body.removeChild(form);
+  });
+});
+
+describe('ColorPicker callback contract', () => {
+  test('slider keypress fires both oninput and onchange', async () => {
+    const inputs: string[] = [];
+    const changes: string[] = [];
+    const { container } = render(ColorPicker, {
+      defaultValue: '#ff0000',
+      oninput: (color: string) => inputs.push(color),
+      onchange: (color: string) => changes.push(color),
+    });
+    const hue = q(container, '[aria-label="Hue"]');
+    await fireEvent.keyDown(hue, { key: 'ArrowRight' });
+    expect(inputs.length).toBe(1);
+    expect(changes.length).toBe(1);
+    expect(inputs[0]).toBe(changes[0]);
+  });
+
+  test('swatch selection fires both oninput and onchange', async () => {
+    const inputs: string[] = [];
+    const changes: string[] = [];
+    const { container } = render(ColorPicker, {
+      defaultValue: '#ffffff',
+      swatches: ['#ff0000', '#00ff00'],
+      oninput: (color: string) => inputs.push(color),
+      onchange: (color: string) => changes.push(color),
+    });
+    const option = container.querySelector<HTMLElement>('[role="option"]');
+    await fireEvent.click(option!);
+    expect(inputs).toEqual(['#ff0000']);
+    expect(changes).toEqual(['#ff0000']);
+  });
+});
+
+describe('ColorPicker pointer interaction', () => {
+  test('pointer drag on hue slider updates hue and fires oninput then onchange', async () => {
+    const inputs: string[] = [];
+    const changes: string[] = [];
+    const { container } = render(ColorPicker, {
+      defaultValue: '#ff0000',
+      oninput: (color: string) => inputs.push(color),
+      onchange: (color: string) => changes.push(color),
+    });
+    const hue = q(container, '[aria-label="Hue"]');
+    // happy-dom doesn't implement these; stub so the production setPointerCapture
+    // and releasePointerCapture calls don't throw and so getBoundingClientRect
+    // returns non-zero width for the mapping math.
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    (hue as unknown as { setPointerCapture: (id: number) => void }).setPointerCapture = () => {};
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    (hue as unknown as { releasePointerCapture: (id: number) => void }).releasePointerCapture =
+      () => {};
+    hue.getBoundingClientRect = () =>
+      ({
+        left: 0,
+        top: 0,
+        width: 100,
+        height: 12,
+        right: 100,
+        bottom: 12,
+        x: 0,
+        y: 0,
+        toJSON: () => ({}),
+      }) as DOMRect;
+    await fireEvent.pointerDown(hue, { clientX: 50, clientY: 6, pointerId: 1 });
+    expect(inputs.length).toBeGreaterThan(0);
+    expect(changes.length).toBe(0);
+    await fireEvent.pointerUp(hue, { clientX: 50, clientY: 6, pointerId: 1 });
+    expect(changes.length).toBe(1);
+    // Halfway across the 0-359 hue track ≈ 180 (cyan).
+    expect(hue.getAttribute('aria-valuenow')).toBe('180');
+  });
+});
+
+describe('ColorPicker alpha mode toggle', () => {
+  test('toggling alpha=false → alpha=true re-emits 8-char hex', async () => {
+    const { container, rerender } = render(ColorPicker, {
+      defaultValue: '#ff0000',
+      alpha: false,
+      name: 'p',
+    });
+    const hidden = q<HTMLInputElement>(container, 'input[name="p"]');
+    expect(hidden.value).toBe('#ff0000');
+
+    await rerender({ defaultValue: '#ff0000', alpha: true, name: 'p' });
+    await tick();
+    expect(hidden.value).toMatch(/^#ff0000[0-9a-f]{2}$/);
+  });
+});
+
+describe('ColorPicker swatch normalization', () => {
+  test('aria-selected matches regardless of swatch input format', () => {
+    const { container } = render(ColorPicker, {
+      defaultValue: '#00ff00',
+      swatches: ['#f00', '#0f0', '#00f'],
+    });
+    const options = container.querySelectorAll<HTMLElement>('[role="option"]');
+    expect(options[1]!.getAttribute('aria-selected')).toBe('true');
+    expect(options[0]!.getAttribute('aria-selected')).toBe('false');
   });
 });
 

--- a/packages/components/src/components/color-picker.test.ts
+++ b/packages/components/src/components/color-picker.test.ts
@@ -80,6 +80,14 @@ describe('ColorPicker parser round-trips', () => {
     const hidden = q<HTMLInputElement>(container, 'input[name="p"]');
     expect(hidden.value).toBe('#ff0000');
   });
+
+  test('near-360 parsed hue stays within slider bounds', () => {
+    const { container } = render(ColorPicker, { defaultValue: '#ff0001' });
+    const hue = q(container, '[aria-label="Hue"]');
+    const thumb = q(container, '.cinder-color-picker__hue-thumb');
+    expect(hue.getAttribute('aria-valuenow')).toBe('359');
+    expect(thumb.getAttribute('style')).toContain('left: 100%;');
+  });
 });
 
 describe('ColorPicker alpha behavior', () => {

--- a/packages/components/src/components/color-picker.test.ts
+++ b/packages/components/src/components/color-picker.test.ts
@@ -113,6 +113,48 @@ describe('ColorPicker invalid input', () => {
     const hidden = q<HTMLInputElement>(container, 'input[name="p"]');
     expect(hidden.value).toBe('');
   });
+
+  test('controlled empty value clears visual selection state', async () => {
+    const { container, rerender } = render(ColorPicker, {
+      value: '#00ff00',
+      name: 'p',
+      swatches: ['#00ff00'],
+    });
+    let hidden = q<HTMLInputElement>(container, 'input[name="p"]');
+    let preview = q(container, '.cinder-color-picker__preview');
+    let option = q(container, '[role="option"]');
+
+    expect(hidden.value).toBe('#00ff00');
+    expect(preview.getAttribute('aria-label')).toBe('Selected color: #00ff00');
+    expect(option.getAttribute('aria-selected')).toBe('true');
+
+    await rerender({ value: '', name: 'p', swatches: ['#00ff00'] });
+    await tick();
+
+    hidden = q<HTMLInputElement>(container, 'input[name="p"]');
+    preview = q(container, '.cinder-color-picker__preview');
+    option = q(container, '[role="option"]');
+    expect(hidden.value).toBe('');
+    expect(preview.getAttribute('aria-label')).toBe('Selected color: none');
+    expect(option.getAttribute('aria-selected')).toBe('false');
+  });
+
+  test('controlled invalid value clears visual selection state', async () => {
+    const { container, rerender } = render(ColorPicker, {
+      value: '#00ff00',
+      name: 'p',
+      swatches: ['#00ff00'],
+    });
+    await rerender({ value: 'not-a-color', name: 'p', swatches: ['#00ff00'] });
+    await tick();
+
+    const hidden = q<HTMLInputElement>(container, 'input[name="p"]');
+    const preview = q(container, '.cinder-color-picker__preview');
+    const option = q(container, '[role="option"]');
+    expect(hidden.value).toBe('');
+    expect(preview.getAttribute('aria-label')).toBe('Selected color: none');
+    expect(option.getAttribute('aria-selected')).toBe('false');
+  });
 });
 
 describe('ColorPicker hue slider keyboard', () => {
@@ -254,6 +296,42 @@ describe('ColorPicker form reset', () => {
 
     document.body.removeChild(form);
   });
+
+  test('form reset with invalid defaultValue resets to empty without callbacks', async () => {
+    const form = document.createElement('form');
+    document.body.appendChild(form);
+    const inputs: string[] = [];
+    const changes: string[] = [];
+
+    const { container } = render(ColorPicker, {
+      target: form,
+      props: {
+        defaultValue: 'not-a-color',
+        name: 'p',
+        oninput: (color: string) => inputs.push(color),
+        onchange: (color: string) => changes.push(color),
+      },
+    });
+    await tick();
+
+    const hidden = q<HTMLInputElement>(container, 'input[name="p"]');
+    const hue = q(container, '[aria-label="Hue"]');
+    expect(hidden.value).toBe('');
+
+    await fireEvent.keyDown(hue, { key: 'ArrowRight' });
+    expect(hidden.value).not.toBe('');
+    inputs.length = 0;
+    changes.length = 0;
+
+    form.dispatchEvent(new Event('reset', { bubbles: true, cancelable: true }));
+    await tick();
+
+    expect(hidden.value).toBe('');
+    expect(inputs).toEqual([]);
+    expect(changes).toEqual([]);
+
+    document.body.removeChild(form);
+  });
 });
 
 describe('ColorPicker callback contract', () => {
@@ -319,12 +397,47 @@ describe('ColorPicker pointer interaction', () => {
         toJSON: () => ({}),
       }) as DOMRect;
     await fireEvent.pointerDown(hue, { clientX: 50, clientY: 6, pointerId: 1 });
-    expect(inputs.length).toBeGreaterThan(0);
+    expect(inputs.length).toBe(1);
     expect(changes.length).toBe(0);
     await fireEvent.pointerUp(hue, { clientX: 50, clientY: 6, pointerId: 1 });
+    expect(inputs.length).toBe(1);
     expect(changes.length).toBe(1);
     // Halfway across the 0-359 hue track ≈ 180 (cyan).
     expect(hue.getAttribute('aria-valuenow')).toBe('180');
+  });
+
+  test('pointer cancel does not fire onchange', async () => {
+    const inputs: string[] = [];
+    const changes: string[] = [];
+    const { container } = render(ColorPicker, {
+      defaultValue: '#ff0000',
+      oninput: (color: string) => inputs.push(color),
+      onchange: (color: string) => changes.push(color),
+    });
+    const hue = q(container, '[aria-label="Hue"]');
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    (hue as unknown as { setPointerCapture: (id: number) => void }).setPointerCapture = () => {};
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    (hue as unknown as { releasePointerCapture: (id: number) => void }).releasePointerCapture =
+      () => {};
+    hue.getBoundingClientRect = () =>
+      ({
+        left: 0,
+        top: 0,
+        width: 100,
+        height: 12,
+        right: 100,
+        bottom: 12,
+        x: 0,
+        y: 0,
+        toJSON: () => ({}),
+      }) as DOMRect;
+
+    await fireEvent.pointerDown(hue, { clientX: 50, clientY: 6, pointerId: 1 });
+    await fireEvent.pointerCancel(hue, { clientX: 50, clientY: 6, pointerId: 1 });
+
+    expect(inputs.length).toBe(1);
+    expect(changes).toEqual([]);
   });
 });
 

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -51,6 +51,9 @@ export type { CheckboxGroupProps } from './components/checkbox-group.svelte';
 export { default as CodeBlock } from './components/code-block.svelte';
 export type { CodeBlockProps } from './components/code-block.svelte';
 
+export { default as ColorPicker } from './components/color-picker.svelte';
+export type { ColorPickerProps } from './components/color-picker.svelte';
+
 export { default as ColorSwatchPicker } from './components/color-swatch-picker.svelte';
 export type { ColorSwatch, ColorSwatchPickerProps } from './components/color-swatch-picker.svelte';
 

--- a/packages/components/src/styles/components.css
+++ b/packages/components/src/styles/components.css
@@ -18,6 +18,7 @@
 @import './components/checkbox.css';
 @import './components/checkbox-group.css';
 @import './components/code-block.css';
+@import './components/color-picker.css';
 @import './components/color-swatch-picker.css';
 @import './components/combobox.css';
 @import './components/command-palette.css';

--- a/packages/components/src/styles/components/color-picker.css
+++ b/packages/components/src/styles/components/color-picker.css
@@ -1,0 +1,203 @@
+/* ========================================
+ * COLOR PICKER
+ * ======================================== */
+
+.cinder-color-picker {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  grid-template-areas:
+    'gradient gradient'
+    'hue preview'
+    'alpha preview'
+    'swatches swatches';
+  gap: var(--cinder-space-2);
+  width: 100%;
+  max-width: 280px;
+}
+
+.cinder-color-picker:not([data-cinder-alpha]) {
+  grid-template-areas:
+    'gradient gradient'
+    'hue preview'
+    'swatches swatches';
+}
+
+.cinder-color-picker[data-cinder-disabled] {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+/* ── 2D gradient ──────────────────────────────────────────────────────── */
+
+.cinder-color-picker__gradient {
+  grid-area: gradient;
+  position: relative;
+  width: 100%;
+  aspect-ratio: 4 / 3;
+  border-radius: var(--cinder-radius-sm, 4px);
+  background-color: var(--cinder-color-picker-hue, hsl(0, 100%, 50%));
+  background-image:
+    linear-gradient(to top, #000, transparent), linear-gradient(to right, #fff, transparent);
+  touch-action: none;
+  cursor: crosshair;
+  outline: none;
+}
+
+.cinder-color-picker__gradient:focus-visible {
+  outline: var(--cinder-ring-width, 2px) solid var(--cinder-ring-color, currentColor);
+  outline-offset: 2px;
+}
+
+.cinder-color-picker__gradient-handle {
+  position: absolute;
+  width: 14px;
+  height: 14px;
+  border: 2px solid #fff;
+  border-radius: 50%;
+  transform: translate(-50%, -50%);
+  box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.5);
+  pointer-events: none;
+}
+
+/* ── Sliders ──────────────────────────────────────────────────────────── */
+
+.cinder-color-picker__hue,
+.cinder-color-picker__alpha {
+  position: relative;
+  height: 12px;
+  border-radius: 999px;
+  outline: none;
+  touch-action: none;
+}
+
+.cinder-color-picker__hue {
+  grid-area: hue;
+  background: linear-gradient(
+    to right,
+    hsl(0, 100%, 50%),
+    hsl(60, 100%, 50%),
+    hsl(120, 100%, 50%),
+    hsl(180, 100%, 50%),
+    hsl(240, 100%, 50%),
+    hsl(300, 100%, 50%),
+    hsl(360, 100%, 50%)
+  );
+}
+
+.cinder-color-picker__alpha {
+  grid-area: alpha;
+  background-color: #fff;
+  background-image:
+    linear-gradient(to right, transparent, var(--cinder-color-picker-base, currentColor)),
+    linear-gradient(45deg, #ccc 25%, transparent 25%),
+    linear-gradient(-45deg, #ccc 25%, transparent 25%),
+    linear-gradient(45deg, transparent 75%, #ccc 75%),
+    linear-gradient(-45deg, transparent 75%, #ccc 75%);
+  background-size:
+    auto,
+    8px 8px,
+    8px 8px,
+    8px 8px,
+    8px 8px;
+  background-position:
+    0 0,
+    0 0,
+    0 4px,
+    4px -4px,
+    -4px 0;
+}
+
+.cinder-color-picker__hue:focus-visible,
+.cinder-color-picker__alpha:focus-visible {
+  outline: var(--cinder-ring-width, 2px) solid var(--cinder-ring-color, currentColor);
+  outline-offset: 2px;
+}
+
+.cinder-color-picker__hue-thumb,
+.cinder-color-picker__alpha-thumb {
+  position: absolute;
+  top: 50%;
+  width: 14px;
+  height: 14px;
+  border: 2px solid #fff;
+  border-radius: 50%;
+  background: transparent;
+  transform: translate(-50%, -50%);
+  box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.5);
+  pointer-events: none;
+}
+
+/* ── Preview ──────────────────────────────────────────────────────────── */
+
+.cinder-color-picker__preview {
+  grid-area: preview;
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  background-color: var(--cinder-color-picker-preview, transparent);
+  align-self: center;
+  justify-self: center;
+}
+
+.cinder-color-picker__preview[data-cinder-alpha] {
+  background-color: #fff;
+  background-image:
+    linear-gradient(
+      var(--cinder-color-picker-preview, transparent),
+      var(--cinder-color-picker-preview, transparent)
+    ),
+    linear-gradient(45deg, #ccc 25%, transparent 25%),
+    linear-gradient(-45deg, #ccc 25%, transparent 25%),
+    linear-gradient(45deg, transparent 75%, #ccc 75%),
+    linear-gradient(-45deg, transparent 75%, #ccc 75%);
+  background-size:
+    auto,
+    8px 8px,
+    8px 8px,
+    8px 8px,
+    8px 8px;
+  background-position:
+    0 0,
+    0 0,
+    0 4px,
+    4px -4px,
+    -4px 0;
+}
+
+/* ── Swatches ─────────────────────────────────────────────────────────── */
+
+.cinder-color-picker__swatches {
+  grid-area: swatches;
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--cinder-space-2, 8px);
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.cinder-color-picker__swatch {
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  cursor: pointer;
+  background-color: var(--cinder-color-picker-swatch);
+  border: 1px solid var(--cinder-border, rgba(0, 0, 0, 0.1));
+  outline: none;
+}
+
+.cinder-color-picker__swatch:focus-visible,
+.cinder-color-picker__swatch[data-cinder-selected] {
+  outline: var(--cinder-ring-width, 2px) solid var(--cinder-ring-color, currentColor);
+  outline-offset: 2px;
+}
+
+@media (forced-colors: active) {
+  .cinder-color-picker__gradient:focus-visible,
+  .cinder-color-picker__hue:focus-visible,
+  .cinder-color-picker__alpha:focus-visible,
+  .cinder-color-picker__swatch:focus-visible {
+    outline: 3px solid Highlight;
+    outline-offset: 2px;
+  }
+}

--- a/packages/components/src/styles/components/color-picker.css
+++ b/packages/components/src/styles/components/color-picker.css
@@ -193,9 +193,13 @@
 }
 
 @media (forced-colors: active) {
+  .cinder-color-picker__gradient:focus,
   .cinder-color-picker__gradient:focus-visible,
+  .cinder-color-picker__hue:focus,
   .cinder-color-picker__hue:focus-visible,
+  .cinder-color-picker__alpha:focus,
   .cinder-color-picker__alpha:focus-visible,
+  .cinder-color-picker__swatch:focus,
   .cinder-color-picker__swatch:focus-visible {
     outline: 3px solid Highlight;
     outline-offset: 2px;


### PR DESCRIPTION
## Summary

Adds `color-picker.svelte` — a visual color picker with a 2D HSL gradient (`role="application"`), hue slider (`role="slider"`), optional alpha slider, and optional swatch listbox. Internal canonical state is HSLA; accepts hex / `rgb()` / `rgba()` / `hsl()` / `hsla()` input; emits 6- or 8-char hex on `oninput` (every value mutation) and `onchange` (commits). Invalid input normalizes to empty string. Form participation via hidden input that listens for native form reset to revert to `defaultValue`. Tracks ROADMAP §"Forms — Additional Components › Color picker".

- Pointer drag on gradient and both sliders (with pointer capture and pointercancel handling).
- Keyboard navigation: arrow keys, Home/End, PageUp/PageDown, Shift modifier for coarse steps.
- Swatch listbox uses canonicalized hex comparison so `#0f0` matches `#00ff00` for `aria-selected`.
- Preview swatch exposes `role="img"` with dynamic `aria-label` including the current hex.
- Forced-colors mode handled in CSS (`:focus` + `:focus-visible` for system Highlight ring).
- `color-picker.a11y.md` documents the 2D-gradient limitation, slider ARIA semantics, and pairing recommendation with a future `color-field`.

## Review committee
Pre-reviewed by:
- typescript-expert — 4 rounds, APPROVED
- testing-expert — 4 rounds, APPROVED
- frontend-architect — 4 rounds, APPROVED
- ux-designer — 4 rounds, APPROVED
- simplicity-engineer — 5 rounds, APPROVED (drove a final round of helper-inlining)
- junior-engineer — 4 rounds, APPROVED
- Codex (gpt-5.4, xhigh reasoning) — 1 round, see warning below

> [!WARNING]
> Codex (the adversarial second-opinion reviewer) was unavailable for rounds 2–5 of this PR ("agent thread limit reached"). See `tmp/committee-state.md` for detail. Round 1 Codex feedback drove substantive must-fix items (slider pointer handlers, `oninput` callback contract, alpha-mode re-normalization, swatch hex canonicalization) — all addressed.

## Test plan

- `bun test packages/components/src/components/color-picker.test.ts` — 32 tests covering parser round-trips, alpha on/off emit, slider keyboard + pointer, swatch keyboard nav + normalization, form reset, controlled clears, invalid input, callback contract (oninput on every mutation; onchange on commit), and pointer cancellation.
- `bun run typecheck` clean.
- `bun run lint` clean.
- Component file: `packages/components/src/components/color-picker.svelte`
- Styles: `packages/components/src/styles/components/color-picker.css`
- A11y memo: `packages/components/src/components/color-picker.a11y.md`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new interactive form control with custom pointer/keyboard handling and controlled/uncontrolled value syncing, which can introduce subtle state and accessibility regressions if edge cases were missed.
> 
> **Overview**
> Adds a new `ColorPicker` component that accepts multiple CSS color syntaxes, normalizes/emits hex (6- or 8-char when `alpha` is enabled), and supports both controlled (`value`) and uncontrolled (`defaultValue`) usage with `oninput` vs `onchange` semantics.
> 
> The picker includes pointer + keyboard interaction for the gradient and sliders, an optional swatch `listbox` with canonicalized selection matching, and native form participation via a hidden input that listens for form `reset`. This wires the component into the package surface (`exports` + `src/index.ts`) and global component styles (new `color-picker.css` import), and adds a dedicated a11y rationale doc and comprehensive test coverage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e978222e5a645705f8040b16350ce0ee1b44da11. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->