### PR TITLE
feat(number-input): add locale-aware numeric input

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -233,6 +233,10 @@
       "svelte": "./src/components/navigation-item.svelte",
       "types": "./dist/components/navigation-item.svelte.d.ts"
     },
+    "./number-input": {
+      "svelte": "./src/components/number-input.svelte",
+      "types": "./dist/components/number-input.svelte.d.ts"
+    },
     "./page-layout": {
       "svelte": "./src/components/page-layout.svelte",
       "types": "./dist/components/page-layout.svelte.d.ts"

--- a/packages/components/src/components/number-input.a11y.md
+++ b/packages/components/src/components/number-input.a11y.md
@@ -1,0 +1,81 @@
+# Number Input — accessibility
+
+`number-input.svelte` is a locale-aware numeric textbox with explicit increment/decrement stepper
+buttons. It deliberately departs from the `role="spinbutton"` pattern.
+
+## Role decision: textbox, not spinbutton
+
+The visible input is a real `<input type="text" inputmode="decimal">` and keeps its native
+`textbox` role. The component does **not** set `role="spinbutton"`, `aria-valuemin`, `aria-valuemax`,
+or `aria-valuenow`.
+
+Rationale:
+
+- `aria-valuemin` / `aria-valuemax` / `aria-valuenow` belong to range widgets
+  (`spinbutton`, `slider`, `progressbar`, `meter`, `scrollbar`). Applying them to a `textbox` is
+  invalid ARIA and gets flagged by axe and Lighthouse.
+- `role="spinbutton"` overrides the native textbox role. Screen readers stop announcing the
+  editable-text affordance, which is exactly the affordance we want users to hear.
+- The WAI-ARIA spinbutton pattern assumes a custom widget with hand-rolled keyboard handling.
+  This control is a real `<input>` that gets textbox semantics natively.
+- GitHub Primer, Adobe Spectrum, Radix, and Mantine all ship their number inputs as plain
+  textboxes for the same reasons.
+
+Range information is exposed through:
+
+- Consumer-authored label / description text ("Quantity, between 1 and 99").
+- Explicit `aria-label="Increment"` / `aria-label="Decrement"` on the stepper buttons.
+- `aria-invalid` + the error region when the consumer flags out-of-range.
+- Native `:invalid` styling driven by `setCustomValidity` for `required` and malformed cases.
+
+## Keyboard
+
+The visible input handles a small set of keys:
+
+- **ArrowUp / ArrowDown**: increment or decrement by `step` (default 1).
+- **PageUp / PageDown**: ±10 × `step`.
+- **Home / End**: jump to `min` / `max` when those bounds are finite (no-op when infinite).
+- **Enter**: commit the typed value and submit the enclosing form if it's valid; otherwise call
+  `form.reportValidity()`.
+
+`preventDefault` is called for ArrowUp/Down, PageUp/Down, and Home/End so caret movement does not
+collide with stepping.
+
+## Stepper buttons
+
+- Two `<button type="button">`. `type="button"` matters inside a form — without it, clicking either
+  button submits the form.
+- Visible glyphs (`+` and U+2212 minus) are `aria-hidden="true"`; the accessible name comes from
+  `aria-label="Increment"` / `aria-label="Decrement"`.
+- Stepper buttons use the native `disabled` attribute at boundaries — not `aria-disabled`. This
+  removes them from the tab order, which matches user expectation when the value is already at the
+  limit.
+- Tab order is visible input → increment → decrement.
+- Clicking a stepper restores focus to the visible input so subsequent typing flows naturally.
+- Hit targets meet the 44 × 44 px minimum under `@media (pointer: coarse)`.
+
+## Mobile keyboards
+
+`inputmode="decimal"` keeps the on-screen keyboard numeric while still allowing locale-aware
+formatted display strings (`1,234.50`, `$1,234.50`, `50%`) inside a `type="text"` field. Using
+`type="number"` would have meant losing grouping and currency glyphs, inconsistent stepper UI
+across browsers, value mutation on wheel scroll, and surprising empty/`NaN` semantics on bad
+paste.
+
+## Validity surface
+
+- `aria-invalid="true"` whenever the consumer passes `error` (or the wrapping `FormField` reports
+  an error).
+- `setCustomValidity('Please enter a valid number.')` when typed text fails to parse on commit.
+- `setCustomValidity('Please enter a number.')` when `required` and the committed value is `null`.
+- Both clear automatically on the next valid commit or external `value` change.
+
+## What we deliberately do not do
+
+- No `aria-valuemin` / `aria-valuemax` / `aria-valuenow` (see role decision above).
+- No wheel-to-step handler. Scrolling the page over a focused number field changing its value is
+  a well-known accessibility footgun.
+- No hold-to-repeat on the stepper buttons in v1. The OS-level key repeat covers the
+  continuous-increment use case for keyboard users, and pointer-based hold-to-repeat introduces
+  pointer-capture and timer-leak complexity disproportionate to the benefit. Tracked as a
+  follow-up.

--- a/packages/components/src/components/number-input.svelte
+++ b/packages/components/src/components/number-input.svelte
@@ -3,7 +3,18 @@
 
   export type NumberInputProps = Omit<
     HTMLInputAttributes,
-    'value' | 'defaultValue' | 'min' | 'max' | 'step' | 'name' | 'type' | 'oninput' | 'onchange'
+    | 'value'
+    | 'defaultValue'
+    | 'min'
+    | 'max'
+    | 'step'
+    | 'name'
+    | 'type'
+    | 'oninput'
+    | 'onchange'
+    | 'onfocus'
+    | 'onblur'
+    | 'onkeydown'
   > & {
     id: string;
     value?: number | null;
@@ -522,11 +533,11 @@
       aria-invalid={resolvedAriaInvalid}
       aria-describedby={describedBy}
       class="cinder-input cinder-number-input__input"
+      {...rest}
       oninput={onInput}
       onfocus={onFocus}
       onblur={onBlur}
       onkeydown={onKeyDown}
-      {...rest}
     />
     <button
       type="button"

--- a/packages/components/src/components/number-input.svelte
+++ b/packages/components/src/components/number-input.svelte
@@ -273,9 +273,14 @@
       inputElement.setCustomValidity('');
     } else if (malformedError) {
       // commit() owns the malformed message; leave it in place.
-    } else if (resolvedRequired && (value === null || value === undefined)) {
+    } else if (!isFocused && resolvedRequired && (value === null || value === undefined)) {
       inputElement.setCustomValidity('Please enter a number.');
       requiredEmptyError = true;
+    } else if (isFocused && requiredEmptyError) {
+      // User is actively typing — suppress the required-empty error so we don't
+      // flash "Please enter a number." in the aria-live region mid-keystroke.
+      inputElement.setCustomValidity('');
+      requiredEmptyError = false;
     } else if (value !== null && value !== undefined) {
       inputElement.setCustomValidity('');
       requiredEmptyError = false;

--- a/packages/components/src/components/number-input.svelte
+++ b/packages/components/src/components/number-input.svelte
@@ -366,13 +366,15 @@
       case 'Home':
         if (Number.isFinite(resolvedMin)) {
           event.preventDefault();
-          commitFromNumber('delta', resolvedMin);
+          const homeNext = commitFromNumber('delta', resolvedMin);
+          if (isFocused) editorBuffer = homeNext === null ? '' : buildEditDisplay(homeNext);
         }
         break;
       case 'End':
         if (Number.isFinite(resolvedMax)) {
           event.preventDefault();
-          commitFromNumber('delta', resolvedMax);
+          const endNext = commitFromNumber('delta', resolvedMax);
+          if (isFocused) editorBuffer = endNext === null ? '' : buildEditDisplay(endNext);
         }
         break;
       case 'Enter': {

--- a/packages/components/src/components/number-input.svelte
+++ b/packages/components/src/components/number-input.svelte
@@ -36,6 +36,7 @@
   import { getFormFieldContext } from '../_internal/form-field-context.ts';
   import { cn } from '../utilities/class-names.ts';
   import { formatNumber } from '../utilities/format-number.ts';
+  import { parseLocaleNumber } from '../utilities/parse-locale-number.ts';
 
   let {
     id,
@@ -63,10 +64,10 @@
   let isFocused = $state(false);
   let hasMounted = $state(false);
   let inputElement: HTMLInputElement | undefined = $state();
-  let resolvedLocale = $state(locale ?? 'en-US');
+  let malformedError = $state(false);
 
   // Seed the bindable from defaultValue when the parent didn't supply a value.
-  if (value === null && defaultValue !== null && defaultValue !== undefined) {
+  if (value === null && defaultValue !== null) {
     value = defaultValue;
   }
 
@@ -74,9 +75,7 @@
     hasMounted = true;
   });
 
-  $effect(() => {
-    resolvedLocale = locale ?? (hasMounted ? navigator.language : 'en-US');
-  });
+  const resolvedLocale = $derived(locale ?? (hasMounted ? navigator.language : 'en-US'));
 
   const resolvedMin = $derived(typeof min === 'number' && Number.isFinite(min) ? min : -Infinity);
   const resolvedMax = $derived(typeof max === 'number' && Number.isFinite(max) ? max : Infinity);
@@ -85,7 +84,10 @@
     typeof s === 'number' && Number.isFinite(s) && s > 0;
 
   const incrementStep = $derived(isValidStep(step) ? step : 1);
-  const snapStep = $derived<number | null>(isValidStep(step) ? step : null);
+  const snapStep = $derived(isValidStep(step) ? step : null);
+
+  const resolvedRequired = $derived(required ?? context?.required ?? false);
+  const resolvedDisabled = $derived(disabled ?? context?.disabled ?? false);
 
   function roundToPrecision(n: number, digits: number): number {
     return Number(n.toFixed(Math.min(digits, 12)));
@@ -105,238 +107,145 @@
     return s.split('.')[1]?.length ?? 0;
   }
 
-  function escapeRegex(s: string): string {
-    return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-  }
+  // Three commit sources — that's the smallest set that captures the actually-
+  // distinct behaviors:
+  // - 'delta': user pressed a stepper or arrow/page/home/end — value is already
+  //   step-aligned, so snap-to-grid is skipped. onchange fires.
+  // - 'typed': user committed via blur/enter/submit — apply snap-to-grid.
+  //   onchange fires unless the source is a serialization-only event.
+  // - 'reset': form reset — like typed in that snap doesn't apply (we're
+  //   restoring defaultValue verbatim), but always fires onchange.
+  type CommitSource = 'typed' | 'delta' | 'reset';
 
-  type ParseResult =
-    | { value: number; status: 'valid' }
-    | { value: null; status: 'empty' | 'malformed' };
-
-  function parseLocaleNumber(
-    text: string,
-    parseLocale: string,
-    fmt: Intl.NumberFormatOptions | undefined,
-  ): ParseResult {
-    if (text.trim() === '') return { value: null, status: 'empty' };
-
-    let working = text;
-
-    // Localized digit mapping (e.g. ar-EG, hi-IN extended-arabic).
-    const digitFormatter = new Intl.NumberFormat(parseLocale, {
-      useGrouping: false,
-      maximumFractionDigits: 0,
-    });
-    for (let d = 0; d <= 9; d++) {
-      const glyph = digitFormatter.format(d);
-      if (glyph !== String(d)) {
-        working = working.split(glyph).join(String(d));
-      }
-    }
-
-    // Separator discovery (always via a plain decimal formatter).
-    const sepParts = new Intl.NumberFormat(parseLocale, {
-      useGrouping: true,
-      minimumFractionDigits: 1,
-      maximumFractionDigits: 1,
-    }).formatToParts(-12345.6);
-    const groupSep = sepParts.find((p) => p.type === 'group')?.value ?? '';
-    const decimalSep = sepParts.find((p) => p.type === 'decimal')?.value ?? '.';
-
-    // Strip caller-format symbols (currency / percent) and any literals from the
-    // caller's format — but NOT the locale's digits/separators.
-    if (fmt) {
-      const callerParts = new Intl.NumberFormat(parseLocale, fmt).formatToParts(0);
-      for (const part of callerParts) {
-        if (
-          part.type === 'currency' ||
-          part.type === 'percentSign' ||
-          part.type === 'literal' ||
-          part.type === 'unit' ||
-          part.type === 'compact'
-        ) {
-          if (part.value) working = working.split(part.value).join('');
-        }
-      }
-    }
-    // Always allow a stray percent literal.
-    working = working.split('%').join('');
-
-    // Trim whitespace variants.
-    working = working.replace(/[\s  ]+/g, (m) => {
-      // Keep the locale's narrow-NBSP group separator candidates intact for
-      // grouping validation. Only strip them at the very edges.
-      return m;
-    });
-    working = working.replace(/^[\s  ]+|[\s  ]+$/g, '');
-
-    if (working === '') return { value: null, status: 'empty' };
-
-    // Strict grouping validation, only when groupSep appears in the integer part.
-    const decimalSplit = working.split(decimalSep);
-    if (decimalSplit.length > 2) return { value: null, status: 'malformed' };
-    const integerPart = decimalSplit[0] ?? '';
-    const fractionPart = decimalSplit[1];
-
-    if (groupSep && integerPart.includes(groupSep)) {
-      // Derive group sizes from the locale.
-      const probeParts = new Intl.NumberFormat(parseLocale, {
-        useGrouping: true,
-      }).formatToParts(12345678);
-      const integerRuns: string[] = [];
-      for (const p of probeParts) {
-        if (p.type === 'integer') integerRuns.push(p.value);
-      }
-      // Right-most run is "primary"; the run just before it is "secondary".
-      const primary =
-        integerRuns.length > 0 ? (integerRuns[integerRuns.length - 1] ?? '').length : 3;
-      const secondary =
-        integerRuns.length > 1 ? (integerRuns[integerRuns.length - 2] ?? '').length : primary;
-      const groupEsc = escapeRegex(groupSep);
-      const grouped = new RegExp(
-        `^[+-]?\\d{1,${secondary}}(${groupEsc}\\d{${secondary}})*${groupEsc}\\d{${primary}}$`,
-      );
-      if (!grouped.test(integerPart)) return { value: null, status: 'malformed' };
-    }
-
-    // Strip group separators and normalize decimal.
-    let normalized = groupSep.length > 0 ? integerPart.split(groupSep).join('') : integerPart;
-    if (fractionPart !== undefined) normalized += '.' + fractionPart;
-
-    if (!/^[+-]?(\d+\.?\d*|\.\d+)$/.test(normalized)) {
-      return { value: null, status: 'malformed' };
-    }
-    const parsed = parseFloat(normalized);
-    if (!Number.isFinite(parsed)) return { value: null, status: 'malformed' };
-    return { value: parsed, status: 'valid' };
-  }
-
-  type CommitSource =
-    | 'blur'
-    | 'enter'
-    | 'stepper'
-    | 'arrow'
-    | 'page'
-    | 'home'
-    | 'end'
-    | 'reset'
-    | 'formdata'
-    | 'submit';
-
-  function shouldEmitChange(source: CommitSource): boolean {
-    return source !== 'formdata' && source !== 'submit';
-  }
-
-  function commitValue(
+  /**
+   * Apply the value to component state and side-effects: native validity,
+   * onchange callback, and the bindable `value` write. Returns the value that
+   * was actually applied so callers can chain.
+   */
+  function commit(
     next: number | null,
-    source: CommitSource,
     parseStatus: 'valid' | 'empty' | 'malformed',
-    formData: FormData | undefined,
+    emitChange: boolean,
   ): number | null {
     if (inputElement) {
-      if (disabled) {
+      if (resolvedDisabled) {
         inputElement.setCustomValidity('');
       } else if (parseStatus === 'malformed') {
         inputElement.setCustomValidity('Please enter a valid number.');
-      } else if (required && next === null) {
+      } else if (resolvedRequired && next === null) {
         inputElement.setCustomValidity('Please enter a number.');
       } else {
         inputElement.setCustomValidity('');
       }
     }
 
-    if (formData && typeof name === 'string' && name.length > 0 && !disabled) {
-      formData.set(name, next === null ? '' : String(next));
-    }
+    malformedError = parseStatus === 'malformed';
 
     if (!Object.is(next, value)) {
+      isInternalValueChange = true;
       value = next;
     }
 
-    if (shouldEmitChange(source)) {
+    if (emitChange) {
       onchange?.(next);
     }
 
     return next;
   }
 
+  /**
+   * Commit a numeric value. For `'typed'` sources the value is snapped to the
+   * step grid (if `step` is set), then clamped. For `'delta'` and `'reset'`
+   * sources the value is only clamped.
+   */
   function commitFromNumber(
     source: CommitSource,
     raw: number | null,
-    formData?: FormData,
     parseStatus: 'valid' | 'empty' | 'malformed' = 'valid',
   ): number | null {
-    if (raw === null) return commitValue(null, source, parseStatus, formData);
-    if (typeof raw !== 'number' || !Number.isFinite(raw)) {
-      return commitValue(null, source, 'malformed', formData);
-    }
-    // Snap applies to typed commits (blur/enter/submit/formdata/text-derived).
-    // Stepper / arrow / page / home / end deltas are already step-aligned by
-    // construction, so re-snapping would push value off the grid the user
-    // chose with their explicit ± action.
-    const snapApplies =
-      snapStep !== null &&
-      source !== 'stepper' &&
-      source !== 'arrow' &&
-      source !== 'page' &&
-      source !== 'home' &&
-      source !== 'end' &&
-      source !== 'reset';
-    let snapped = raw;
-    if (snapApplies && snapStep !== null) {
+    if (raw === null) return commit(null, parseStatus, true);
+    if (!Number.isFinite(raw)) return commit(null, 'malformed', true);
+    let result = raw;
+    if (source === 'typed' && snapStep !== null) {
       const origin = Number.isFinite(resolvedMin) ? resolvedMin : 0;
-      snapped = origin + Math.round((raw - origin) / snapStep) * snapStep;
-      snapped = roundToPrecision(snapped, fractionalDigits(snapStep));
+      result = origin + Math.round((raw - origin) / snapStep) * snapStep;
+      result = roundToPrecision(result, fractionalDigits(snapStep));
     } else if (snapStep !== null) {
-      // Even when not snapping, round to step precision so 0.1+0.2 → 0.3 cleanly.
-      snapped = roundToPrecision(raw, fractionalDigits(snapStep));
+      // Even when snapping is skipped, round to step precision so successive
+      // additions of `0.1` don't accumulate float error.
+      result = roundToPrecision(raw, fractionalDigits(snapStep));
     }
-    const next = Math.min(resolvedMax, Math.max(resolvedMin, snapped));
-    return commitValue(next, source, parseStatus, formData);
+    const clamped = Math.min(resolvedMax, Math.max(resolvedMin, result));
+    return commit(clamped, parseStatus, true);
   }
 
-  function commitFromText(source: CommitSource, text: string, formData?: FormData): number | null {
+  /**
+   * Commit by parsing user-typed text via the locale parser, then routing the
+   * canonical numeric value through `commitFromNumber`.
+   */
+  function commitFromText(source: CommitSource, text: string): number | null {
     const result = parseLocaleNumber(text, resolvedLocale, format);
     if (result.status !== 'valid') {
-      return commitValue(null, source, result.status, formData);
+      return commit(null, result.status, true);
     }
-    let canonical: number;
-    if (format?.style === 'percent') {
-      canonical = roundToPrecision(
-        result.value / 100,
-        Math.max(2, fractionalDigits(result.value) + 2),
-      );
-    } else {
-      canonical = result.value;
-    }
-    return commitFromNumber(source, canonical, formData, 'valid');
+    const canonical =
+      format?.style === 'percent'
+        ? roundToPrecision(result.value / 100, Math.max(2, fractionalDigits(result.value) + 2))
+        : result.value;
+    return commitFromNumber(source, canonical, 'valid');
   }
 
-  const formattedValue = $derived(
-    value === null || value === undefined ? '' : formatNumber(value, resolvedLocale, format),
-  );
-  const displayValue = $derived(isFocused ? editorBuffer : formattedValue);
+  // Track value changes initiated from within the component so the "parent
+  // always wins during focus" effect below doesn't fight a commit.
+  let isInternalValueChange = false;
 
-  // Parent always wins: when value changes from outside while focused, replace
-  // the in-progress editor buffer with a fresh edit-display.
+  // formattedValue and displayValue collapsed into one derived expression.
+  // When the last commit was malformed we keep the user's typed text visible
+  // so they can correct it instead of having their input erased.
+  const displayValue = $derived(
+    isFocused
+      ? editorBuffer
+      : malformedError
+        ? editorBuffer
+        : value === null || value === undefined
+          ? ''
+          : formatNumber(value, resolvedLocale, format),
+  );
+
+  // Parent always wins: when `value` changes from outside while focused, replace
+  // the in-progress editor buffer with a fresh edit-display. The
+  // `isInternalValueChange` flag breaks the cycle when the commit path is the
+  // one that just wrote `value`.
   $effect(() => {
-    // Track value, resolvedLocale, format reactively.
     void value;
     void resolvedLocale;
     void format;
     if (!isFocused) return;
+    if (isInternalValueChange) {
+      isInternalValueChange = false;
+      return;
+    }
     editorBuffer = value === null || value === undefined ? '' : buildEditDisplay(value);
   });
 
-  // Validity sync for required/disabled changes outside commit paths.
+  // Validity-sync for required/disabled changes outside the commit path. Also
+  // clears the malformed flag whenever value flips to a defined number from
+  // outside the component — the parent assigning a valid number means the
+  // input is no longer in a parse-failure state.
   $effect(() => {
     if (!inputElement) return;
-    if (disabled) {
+    if (resolvedDisabled) {
       inputElement.setCustomValidity('');
-    } else if (required && (value === null || value === undefined)) {
+      malformedError = false;
+    } else if (value !== null && value !== undefined && !isInternalValueChange) {
+      // External value write — clear malformed state and any prior validity.
+      malformedError = false;
+      inputElement.setCustomValidity('');
+    } else if (malformedError) {
+      // commit() owns the malformed message; leave it in place.
+    } else if (resolvedRequired && (value === null || value === undefined)) {
       inputElement.setCustomValidity('Please enter a number.');
     } else if (value !== null && value !== undefined) {
-      // Any defined value clears prior malformed/empty errors.
       inputElement.setCustomValidity('');
     }
   });
@@ -364,12 +273,13 @@
   function onBlur() {
     const buffered = editorBuffer;
     isFocused = false;
-    commitFromText('blur', buffered);
+    commitFromText('typed', buffered);
   }
 
-  function onInput(event: Event) {
-    const target = event.currentTarget as HTMLInputElement;
-    editorBuffer = target.value;
+  function onInput(event: Event & { currentTarget: EventTarget & HTMLInputElement }) {
+    editorBuffer = event.currentTarget.value;
+    // Clear any prior malformed state as soon as the user starts re-typing.
+    if (malformedError) malformedError = false;
   }
 
   function getBaseForStep(direction: 'increment' | 'decrement'): number {
@@ -392,47 +302,47 @@
     return baseFromDisplay ?? value ?? defaultStart;
   }
 
-  function stepBy(direction: 'increment' | 'decrement', source: CommitSource, multiplier = 1) {
+  function stepBy(direction: 'increment' | 'decrement', multiplier = 1) {
     const base = getBaseForStep(direction);
     const delta = incrementStep * multiplier * (direction === 'increment' ? 1 : -1);
-    commitFromNumber(source, base + delta);
+    commitFromNumber('delta', base + delta);
     inputElement?.focus();
   }
 
   function onKeyDown(event: KeyboardEvent) {
-    if (disabled) return;
+    if (resolvedDisabled) return;
     switch (event.key) {
       case 'ArrowUp':
         event.preventDefault();
-        stepBy('increment', 'arrow');
+        stepBy('increment');
         break;
       case 'ArrowDown':
         event.preventDefault();
-        stepBy('decrement', 'arrow');
+        stepBy('decrement');
         break;
       case 'PageUp':
         event.preventDefault();
-        stepBy('increment', 'page', 10);
+        stepBy('increment', 10);
         break;
       case 'PageDown':
         event.preventDefault();
-        stepBy('decrement', 'page', 10);
+        stepBy('decrement', 10);
         break;
       case 'Home':
         if (Number.isFinite(resolvedMin)) {
           event.preventDefault();
-          commitFromNumber('home', resolvedMin);
+          commitFromNumber('delta', resolvedMin);
         }
         break;
       case 'End':
         if (Number.isFinite(resolvedMax)) {
           event.preventDefault();
-          commitFromNumber('end', resolvedMax);
+          commitFromNumber('delta', resolvedMax);
         }
         break;
       case 'Enter': {
         event.preventDefault();
-        commitFromText('enter', isFocused ? editorBuffer : formattedValue);
+        commitFromText('typed', isFocused ? editorBuffer : '');
         const form = inputElement?.closest('form');
         if (form) {
           if (form.checkValidity()) form.requestSubmit();
@@ -443,40 +353,34 @@
     }
   }
 
-  // Form integration: submit (capture), formdata, reset.
+  // Form integration: submit-capture to flush any in-flight edit so the hidden
+  // input carries the user's just-typed value at serialization time. The hidden
+  // input is the sole form-data path — there is no `formdata` listener that
+  // duplicates the serialization (avoiding double-write surprises when the
+  // hidden input and a listener disagree).
   $effect(() => {
     if (!inputElement) return;
     const form = inputElement.closest('form');
     if (!form) return;
 
     const onSubmit = (event: SubmitEvent) => {
-      if (disabled) return;
-      if (isFocused) commitFromText('submit', editorBuffer);
+      if (resolvedDisabled) return;
+      if (isFocused) commitFromText('typed', editorBuffer);
       if (!form.checkValidity()) {
         event.preventDefault();
         form.reportValidity();
       }
     };
-    const onFormData = (event: FormDataEvent) => {
-      if (disabled) return;
-      if (isFocused) {
-        commitFromText('formdata', editorBuffer, event.formData);
-      } else if (typeof name === 'string' && name.length > 0) {
-        event.formData.set(name, value === null || value === undefined ? '' : String(value));
-      }
-    };
     const onReset = () => {
-      if (disabled) return;
-      commitFromNumber('reset', defaultValue ?? null, undefined, 'valid');
+      if (resolvedDisabled) return;
+      commitFromNumber('reset', defaultValue ?? null, defaultValue === null ? 'empty' : 'valid');
     };
 
-    form.addEventListener('submit', onSubmit, true);
-    form.addEventListener('formdata', onFormData);
+    form.addEventListener('submit', onSubmit);
     form.addEventListener('reset', onReset);
 
     return () => {
-      form.removeEventListener('submit', onSubmit, true);
-      form.removeEventListener('formdata', onFormData);
+      form.removeEventListener('submit', onSubmit);
       form.removeEventListener('reset', onReset);
     };
   });
@@ -495,10 +399,10 @@
   const resolvedErrorId = $derived(ownErrorId ?? context?.errorId);
   const describedBy = $derived(composeDescribedBy(resolvedDescriptionId, resolvedErrorId));
   const resolvedAriaInvalid = $derived(
-    error ? ariaInvalid(true) : (context?.invalid ?? rest['aria-invalid'] ?? ariaInvalid(false)),
+    error || malformedError
+      ? ariaInvalid(true)
+      : (context?.invalid ?? rest['aria-invalid'] ?? ariaInvalid(false)),
   );
-  const resolvedRequired = $derived(required ?? context?.required ?? false);
-  const resolvedDisabled = $derived(disabled ?? context?.disabled ?? false);
 
   const incrementDisabled = $derived(
     resolvedDisabled || (value !== null && value !== undefined && value >= resolvedMax),
@@ -509,6 +413,13 @@
 
   const showHiddenInput = $derived(
     typeof name === 'string' && name.length > 0 && !resolvedDisabled,
+  );
+
+  // Compose stepper labels with the field's label (when present) and the
+  // current step magnitude. Screen-reader users navigating between multiple
+  // number fields then hear distinguishable, magnitude-aware names.
+  const stepperLabelSuffix = $derived(
+    label ? ` ${label} by ${incrementStep}` : ` by ${incrementStep}`,
   );
 </script>
 
@@ -540,18 +451,18 @@
     <button
       type="button"
       class="cinder-number-input__stepper cinder-number-input__stepper--increment"
-      aria-label="Increment"
+      aria-label={`Increment${stepperLabelSuffix}`}
       disabled={incrementDisabled}
-      onclick={() => stepBy('increment', 'stepper')}
+      onclick={() => stepBy('increment')}
     >
       <span aria-hidden="true">+</span>
     </button>
     <button
       type="button"
       class="cinder-number-input__stepper cinder-number-input__stepper--decrement"
-      aria-label="Decrement"
+      aria-label={`Decrement${stepperLabelSuffix}`}
       disabled={decrementDisabled}
-      onclick={() => stepBy('decrement', 'stepper')}
+      onclick={() => stepBy('decrement')}
     >
       <span aria-hidden="true">&#x2212;</span>
     </button>

--- a/packages/components/src/components/number-input.svelte
+++ b/packages/components/src/components/number-input.svelte
@@ -305,6 +305,8 @@
       useGrouping: false,
       currency: undefined,
       currencyDisplay: undefined,
+      notation: 'standard',
+      compactDisplay: undefined,
     };
     if (format?.style === 'percent') {
       const asPercent = roundToPrecision(v * 100, 12);

--- a/packages/components/src/components/number-input.svelte
+++ b/packages/components/src/components/number-input.svelte
@@ -64,7 +64,11 @@
   let isFocused = $state(false);
   let hasMounted = $state(false);
   let inputElement: HTMLInputElement | undefined = $state();
+  // Two-part internal-invalid surface: malformed (parse failure) and
+  // required-empty (no value when the field demands one). Both drive
+  // `aria-invalid` so screen readers stay aligned with native validity.
   let malformedError = $state(false);
+  let requiredEmptyError = $state(false);
 
   // Seed the bindable from defaultValue when the parent didn't supply a value.
   if (value === null && defaultValue !== null) {
@@ -127,19 +131,22 @@
     parseStatus: 'valid' | 'empty' | 'malformed',
     emitChange: boolean,
   ): number | null {
+    const nextMalformed = !resolvedDisabled && parseStatus === 'malformed';
+    const nextRequiredEmpty =
+      !resolvedDisabled && !nextMalformed && resolvedRequired && next === null;
+
     if (inputElement) {
-      if (resolvedDisabled) {
-        inputElement.setCustomValidity('');
-      } else if (parseStatus === 'malformed') {
+      if (nextMalformed) {
         inputElement.setCustomValidity('Please enter a valid number.');
-      } else if (resolvedRequired && next === null) {
+      } else if (nextRequiredEmpty) {
         inputElement.setCustomValidity('Please enter a number.');
       } else {
         inputElement.setCustomValidity('');
       }
     }
 
-    malformedError = parseStatus === 'malformed';
+    malformedError = nextMalformed;
+    requiredEmptyError = nextRequiredEmpty;
 
     if (!Object.is(next, value)) {
       isInternalValueChange = true;
@@ -196,8 +203,9 @@
   }
 
   // Track value changes initiated from within the component so the "parent
-  // always wins during focus" effect below doesn't fight a commit.
-  let isInternalValueChange = false;
+  // always wins during focus" effect below doesn't fight a commit. Reactive
+  // because two distinct $effects read it across the same flush.
+  let isInternalValueChange = $state(false);
 
   // formattedValue and displayValue collapsed into one derived expression.
   // When the last commit was malformed we keep the user's typed text visible
@@ -212,14 +220,20 @@
           : formatNumber(value, resolvedLocale, format),
   );
 
-  // Parent always wins: when `value` changes from outside while focused, replace
-  // the in-progress editor buffer with a fresh edit-display. The
-  // `isInternalValueChange` flag breaks the cycle when the commit path is the
-  // one that just wrote `value`.
+  // Parent always wins: when `value` changes from outside while focused,
+  // replace the in-progress editor buffer with a fresh edit-display. We use
+  // `$derived` to capture only the value/locale/format inputs (not
+  // `isFocused`) so re-focusing after a malformed blur doesn't accidentally
+  // clobber the user's typed text. The effect that consumes this derived
+  // only writes to `editorBuffer` when the underlying value actually changes.
+  const parentValueSignature = $derived(
+    `${value ?? ''}|${resolvedLocale}|${JSON.stringify(format ?? null)}`,
+  );
+  let lastSeenParentSignature = parentValueSignature;
   $effect(() => {
-    void value;
-    void resolvedLocale;
-    void format;
+    const signature = parentValueSignature;
+    if (signature === lastSeenParentSignature) return;
+    lastSeenParentSignature = signature;
     if (!isFocused) return;
     if (isInternalValueChange) {
       isInternalValueChange = false;
@@ -231,22 +245,28 @@
   // Validity-sync for required/disabled changes outside the commit path. Also
   // clears the malformed flag whenever value flips to a defined number from
   // outside the component — the parent assigning a valid number means the
-  // input is no longer in a parse-failure state.
+  // input is no longer in a parse-failure state. Keeps required-empty validity
+  // in lockstep with the `requiredEmptyError` flag so aria-invalid and native
+  // validity never diverge.
   $effect(() => {
     if (!inputElement) return;
     if (resolvedDisabled) {
       inputElement.setCustomValidity('');
       malformedError = false;
+      requiredEmptyError = false;
     } else if (value !== null && value !== undefined && !isInternalValueChange) {
-      // External value write — clear malformed state and any prior validity.
+      // External value write — clear all prior validity state.
       malformedError = false;
+      requiredEmptyError = false;
       inputElement.setCustomValidity('');
     } else if (malformedError) {
       // commit() owns the malformed message; leave it in place.
     } else if (resolvedRequired && (value === null || value === undefined)) {
       inputElement.setCustomValidity('Please enter a number.');
+      requiredEmptyError = true;
     } else if (value !== null && value !== undefined) {
       inputElement.setCustomValidity('');
+      requiredEmptyError = false;
     }
   });
 
@@ -266,7 +286,11 @@
   }
 
   function onFocus() {
-    editorBuffer = value === null || value === undefined ? '' : buildEditDisplay(value);
+    // Preserve the editor buffer when re-focusing after a malformed blur so
+    // the user can correct their own text instead of having it disappear.
+    if (!malformedError) {
+      editorBuffer = value === null || value === undefined ? '' : buildEditDisplay(value);
+    }
     isFocused = true;
   }
 
@@ -278,8 +302,13 @@
 
   function onInput(event: Event & { currentTarget: EventTarget & HTMLInputElement }) {
     editorBuffer = event.currentTarget.value;
-    // Clear any prior malformed state as soon as the user starts re-typing.
-    if (malformedError) malformedError = false;
+    // Clear any prior malformed state as soon as the user starts re-typing —
+    // and clear the matching native customValidity message so aria-invalid
+    // and `input.validity.customError` move together.
+    if (malformedError) {
+      malformedError = false;
+      inputElement?.setCustomValidity('');
+    }
   }
 
   function getBaseForStep(direction: 'increment' | 'decrement'): number {
@@ -305,7 +334,13 @@
   function stepBy(direction: 'increment' | 'decrement', multiplier = 1) {
     const base = getBaseForStep(direction);
     const delta = incrementStep * multiplier * (direction === 'increment' ? 1 : -1);
-    commitFromNumber('delta', base + delta);
+    const next = commitFromNumber('delta', base + delta);
+    // Keep the in-progress editor buffer in sync with the committed value
+    // when focused. Without this, repeated ArrowUp / ArrowDown steps would
+    // step off the stale buffer instead of the canonical value.
+    if (isFocused) {
+      editorBuffer = next === null ? '' : buildEditDisplay(next);
+    }
     inputElement?.focus();
   }
 
@@ -363,24 +398,26 @@
     const form = inputElement.closest('form');
     if (!form) return;
 
-    const onSubmit = (event: SubmitEvent) => {
+    const onSubmit = () => {
+      // Capture-phase listener: runs before any consumer-registered submit
+      // handler, so by the time `new FormData(form)` is collected (whether
+      // by the platform's submission machinery or by app code in a later
+      // listener) the hidden input already reflects the canonical value.
+      // Validity reporting lives in onKeyDown / native form submission —
+      // not here — so the listener has exactly one job: flush.
       if (resolvedDisabled) return;
       if (isFocused) commitFromText('typed', editorBuffer);
-      if (!form.checkValidity()) {
-        event.preventDefault();
-        form.reportValidity();
-      }
     };
     const onReset = () => {
       if (resolvedDisabled) return;
       commitFromNumber('reset', defaultValue ?? null, defaultValue === null ? 'empty' : 'valid');
     };
 
-    form.addEventListener('submit', onSubmit);
+    form.addEventListener('submit', onSubmit, true);
     form.addEventListener('reset', onReset);
 
     return () => {
-      form.removeEventListener('submit', onSubmit);
+      form.removeEventListener('submit', onSubmit, true);
       form.removeEventListener('reset', onReset);
     };
   });
@@ -397,9 +434,24 @@
   );
   const resolvedDescriptionId = $derived(ownDescriptionId ?? context?.descriptionId);
   const resolvedErrorId = $derived(ownErrorId ?? context?.errorId);
-  const describedBy = $derived(composeDescribedBy(resolvedDescriptionId, resolvedErrorId));
+
+  // Internal error region — rendered when the parse failed and the consumer
+  // didn't supply their own `error` text. Without it, screen readers would
+  // hear `aria-invalid="true"` with no associated message describing why.
+  const internalErrorMessage = $derived(
+    !error && malformedError
+      ? 'Please enter a valid number.'
+      : !error && requiredEmptyError
+        ? 'Please enter a number.'
+        : null,
+  );
+  const internalErrorId = $derived(internalErrorMessage ? `${id}-internal-error` : undefined);
+
+  const describedBy = $derived(
+    composeDescribedBy(resolvedDescriptionId, resolvedErrorId, internalErrorId),
+  );
   const resolvedAriaInvalid = $derived(
-    error || malformedError
+    error || malformedError || requiredEmptyError
       ? ariaInvalid(true)
       : (context?.invalid ?? rest['aria-invalid'] ?? ariaInvalid(false)),
   );
@@ -482,5 +534,9 @@
 
   {#if error}
     <p id={ownErrorId} class="cinder-input-field__error" aria-live="polite">{error}</p>
+  {:else if internalErrorMessage}
+    <p id={internalErrorId} class="cinder-input-field__error" aria-live="polite">
+      {internalErrorMessage}
+    </p>
   {/if}
 </div>

--- a/packages/components/src/components/number-input.svelte
+++ b/packages/components/src/components/number-input.svelte
@@ -1,0 +1,575 @@
+<script lang="ts" module>
+  import type { HTMLInputAttributes } from 'svelte/elements';
+
+  export type NumberInputProps = Omit<
+    HTMLInputAttributes,
+    'value' | 'defaultValue' | 'min' | 'max' | 'step' | 'name' | 'type' | 'oninput' | 'onchange'
+  > & {
+    id: string;
+    value?: number | null;
+    defaultValue?: number | null;
+    min?: number;
+    max?: number;
+    step?: number;
+    format?: Intl.NumberFormatOptions;
+    locale?: string;
+    disabled?: boolean;
+    required?: boolean;
+    name?: string;
+    label?: string;
+    description?: string;
+    error?: string;
+    class?: string;
+    onchange?: (value: number | null) => void;
+  };
+</script>
+
+<script lang="ts">
+  import { onMount } from 'svelte';
+
+  import {
+    ariaInvalid,
+    composeDescribedBy,
+    describeId,
+    errorId as buildErrorId,
+  } from '../_internal/field-control.ts';
+  import { getFormFieldContext } from '../_internal/form-field-context.ts';
+  import { cn } from '../utilities/class-names.ts';
+  import { formatNumber } from '../utilities/format-number.ts';
+
+  let {
+    id,
+    defaultValue = null,
+    value = $bindable(null),
+    min,
+    max,
+    step,
+    format,
+    locale,
+    disabled,
+    required,
+    name,
+    label,
+    description,
+    error,
+    class: className,
+    onchange,
+    ...rest
+  }: NumberInputProps = $props();
+
+  const context = getFormFieldContext();
+
+  let editorBuffer = $state('');
+  let isFocused = $state(false);
+  let hasMounted = $state(false);
+  let inputElement: HTMLInputElement | undefined = $state();
+  let resolvedLocale = $state(locale ?? 'en-US');
+
+  // Seed the bindable from defaultValue when the parent didn't supply a value.
+  if (value === null && defaultValue !== null && defaultValue !== undefined) {
+    value = defaultValue;
+  }
+
+  onMount(() => {
+    hasMounted = true;
+  });
+
+  $effect(() => {
+    resolvedLocale = locale ?? (hasMounted ? navigator.language : 'en-US');
+  });
+
+  const resolvedMin = $derived(typeof min === 'number' && Number.isFinite(min) ? min : -Infinity);
+  const resolvedMax = $derived(typeof max === 'number' && Number.isFinite(max) ? max : Infinity);
+
+  const isValidStep = (s: unknown): s is number =>
+    typeof s === 'number' && Number.isFinite(s) && s > 0;
+
+  const incrementStep = $derived(isValidStep(step) ? step : 1);
+  const snapStep = $derived<number | null>(isValidStep(step) ? step : null);
+
+  function roundToPrecision(n: number, digits: number): number {
+    return Number(n.toFixed(Math.min(digits, 12)));
+  }
+
+  function fractionalDigits(n: number): number {
+    if (!Number.isFinite(n)) return 0;
+    const s = String(n);
+    if (s.includes('e') || s.includes('E')) {
+      const parts = s.toLowerCase().split('e');
+      const mantissa = parts[0] ?? '';
+      const expStr = parts[1] ?? '0';
+      const exp = Number(expStr);
+      const fracOfMantissa = mantissa.split('.')[1]?.length ?? 0;
+      return Math.max(0, fracOfMantissa - exp);
+    }
+    return s.split('.')[1]?.length ?? 0;
+  }
+
+  function escapeRegex(s: string): string {
+    return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  }
+
+  type ParseResult =
+    | { value: number; status: 'valid' }
+    | { value: null; status: 'empty' | 'malformed' };
+
+  function parseLocaleNumber(
+    text: string,
+    parseLocale: string,
+    fmt: Intl.NumberFormatOptions | undefined,
+  ): ParseResult {
+    if (text.trim() === '') return { value: null, status: 'empty' };
+
+    let working = text;
+
+    // Localized digit mapping (e.g. ar-EG, hi-IN extended-arabic).
+    const digitFormatter = new Intl.NumberFormat(parseLocale, {
+      useGrouping: false,
+      maximumFractionDigits: 0,
+    });
+    for (let d = 0; d <= 9; d++) {
+      const glyph = digitFormatter.format(d);
+      if (glyph !== String(d)) {
+        working = working.split(glyph).join(String(d));
+      }
+    }
+
+    // Separator discovery (always via a plain decimal formatter).
+    const sepParts = new Intl.NumberFormat(parseLocale, {
+      useGrouping: true,
+      minimumFractionDigits: 1,
+      maximumFractionDigits: 1,
+    }).formatToParts(-12345.6);
+    const groupSep = sepParts.find((p) => p.type === 'group')?.value ?? '';
+    const decimalSep = sepParts.find((p) => p.type === 'decimal')?.value ?? '.';
+
+    // Strip caller-format symbols (currency / percent) and any literals from the
+    // caller's format — but NOT the locale's digits/separators.
+    if (fmt) {
+      const callerParts = new Intl.NumberFormat(parseLocale, fmt).formatToParts(0);
+      for (const part of callerParts) {
+        if (
+          part.type === 'currency' ||
+          part.type === 'percentSign' ||
+          part.type === 'literal' ||
+          part.type === 'unit' ||
+          part.type === 'compact'
+        ) {
+          if (part.value) working = working.split(part.value).join('');
+        }
+      }
+    }
+    // Always allow a stray percent literal.
+    working = working.split('%').join('');
+
+    // Trim whitespace variants.
+    working = working.replace(/[\s  ]+/g, (m) => {
+      // Keep the locale's narrow-NBSP group separator candidates intact for
+      // grouping validation. Only strip them at the very edges.
+      return m;
+    });
+    working = working.replace(/^[\s  ]+|[\s  ]+$/g, '');
+
+    if (working === '') return { value: null, status: 'empty' };
+
+    // Strict grouping validation, only when groupSep appears in the integer part.
+    const decimalSplit = working.split(decimalSep);
+    if (decimalSplit.length > 2) return { value: null, status: 'malformed' };
+    const integerPart = decimalSplit[0] ?? '';
+    const fractionPart = decimalSplit[1];
+
+    if (groupSep && integerPart.includes(groupSep)) {
+      // Derive group sizes from the locale.
+      const probeParts = new Intl.NumberFormat(parseLocale, {
+        useGrouping: true,
+      }).formatToParts(12345678);
+      const integerRuns: string[] = [];
+      for (const p of probeParts) {
+        if (p.type === 'integer') integerRuns.push(p.value);
+      }
+      // Right-most run is "primary"; the run just before it is "secondary".
+      const primary =
+        integerRuns.length > 0 ? (integerRuns[integerRuns.length - 1] ?? '').length : 3;
+      const secondary =
+        integerRuns.length > 1 ? (integerRuns[integerRuns.length - 2] ?? '').length : primary;
+      const groupEsc = escapeRegex(groupSep);
+      const grouped = new RegExp(
+        `^[+-]?\\d{1,${secondary}}(${groupEsc}\\d{${secondary}})*${groupEsc}\\d{${primary}}$`,
+      );
+      if (!grouped.test(integerPart)) return { value: null, status: 'malformed' };
+    }
+
+    // Strip group separators and normalize decimal.
+    let normalized = groupSep.length > 0 ? integerPart.split(groupSep).join('') : integerPart;
+    if (fractionPart !== undefined) normalized += '.' + fractionPart;
+
+    if (!/^[+-]?(\d+\.?\d*|\.\d+)$/.test(normalized)) {
+      return { value: null, status: 'malformed' };
+    }
+    const parsed = parseFloat(normalized);
+    if (!Number.isFinite(parsed)) return { value: null, status: 'malformed' };
+    return { value: parsed, status: 'valid' };
+  }
+
+  type CommitSource =
+    | 'blur'
+    | 'enter'
+    | 'stepper'
+    | 'arrow'
+    | 'page'
+    | 'home'
+    | 'end'
+    | 'reset'
+    | 'formdata'
+    | 'submit';
+
+  function shouldEmitChange(source: CommitSource): boolean {
+    return source !== 'formdata' && source !== 'submit';
+  }
+
+  function commitValue(
+    next: number | null,
+    source: CommitSource,
+    parseStatus: 'valid' | 'empty' | 'malformed',
+    formData: FormData | undefined,
+  ): number | null {
+    if (inputElement) {
+      if (disabled) {
+        inputElement.setCustomValidity('');
+      } else if (parseStatus === 'malformed') {
+        inputElement.setCustomValidity('Please enter a valid number.');
+      } else if (required && next === null) {
+        inputElement.setCustomValidity('Please enter a number.');
+      } else {
+        inputElement.setCustomValidity('');
+      }
+    }
+
+    if (formData && typeof name === 'string' && name.length > 0 && !disabled) {
+      formData.set(name, next === null ? '' : String(next));
+    }
+
+    if (!Object.is(next, value)) {
+      value = next;
+    }
+
+    if (shouldEmitChange(source)) {
+      onchange?.(next);
+    }
+
+    return next;
+  }
+
+  function commitFromNumber(
+    source: CommitSource,
+    raw: number | null,
+    formData?: FormData,
+    parseStatus: 'valid' | 'empty' | 'malformed' = 'valid',
+  ): number | null {
+    if (raw === null) return commitValue(null, source, parseStatus, formData);
+    if (typeof raw !== 'number' || !Number.isFinite(raw)) {
+      return commitValue(null, source, 'malformed', formData);
+    }
+    // Snap applies to typed commits (blur/enter/submit/formdata/text-derived).
+    // Stepper / arrow / page / home / end deltas are already step-aligned by
+    // construction, so re-snapping would push value off the grid the user
+    // chose with their explicit ± action.
+    const snapApplies =
+      snapStep !== null &&
+      source !== 'stepper' &&
+      source !== 'arrow' &&
+      source !== 'page' &&
+      source !== 'home' &&
+      source !== 'end' &&
+      source !== 'reset';
+    let snapped = raw;
+    if (snapApplies && snapStep !== null) {
+      const origin = Number.isFinite(resolvedMin) ? resolvedMin : 0;
+      snapped = origin + Math.round((raw - origin) / snapStep) * snapStep;
+      snapped = roundToPrecision(snapped, fractionalDigits(snapStep));
+    } else if (snapStep !== null) {
+      // Even when not snapping, round to step precision so 0.1+0.2 → 0.3 cleanly.
+      snapped = roundToPrecision(raw, fractionalDigits(snapStep));
+    }
+    const next = Math.min(resolvedMax, Math.max(resolvedMin, snapped));
+    return commitValue(next, source, parseStatus, formData);
+  }
+
+  function commitFromText(source: CommitSource, text: string, formData?: FormData): number | null {
+    const result = parseLocaleNumber(text, resolvedLocale, format);
+    if (result.status !== 'valid') {
+      return commitValue(null, source, result.status, formData);
+    }
+    let canonical: number;
+    if (format?.style === 'percent') {
+      canonical = roundToPrecision(
+        result.value / 100,
+        Math.max(2, fractionalDigits(result.value) + 2),
+      );
+    } else {
+      canonical = result.value;
+    }
+    return commitFromNumber(source, canonical, formData, 'valid');
+  }
+
+  const formattedValue = $derived(
+    value === null || value === undefined ? '' : formatNumber(value, resolvedLocale, format),
+  );
+  const displayValue = $derived(isFocused ? editorBuffer : formattedValue);
+
+  // Parent always wins: when value changes from outside while focused, replace
+  // the in-progress editor buffer with a fresh edit-display.
+  $effect(() => {
+    // Track value, resolvedLocale, format reactively.
+    void value;
+    void resolvedLocale;
+    void format;
+    if (!isFocused) return;
+    editorBuffer = value === null || value === undefined ? '' : buildEditDisplay(value);
+  });
+
+  // Validity sync for required/disabled changes outside commit paths.
+  $effect(() => {
+    if (!inputElement) return;
+    if (disabled) {
+      inputElement.setCustomValidity('');
+    } else if (required && (value === null || value === undefined)) {
+      inputElement.setCustomValidity('Please enter a number.');
+    } else if (value !== null && value !== undefined) {
+      // Any defined value clears prior malformed/empty errors.
+      inputElement.setCustomValidity('');
+    }
+  });
+
+  function buildEditDisplay(v: number): string {
+    const editFormat: Intl.NumberFormatOptions = {
+      ...format,
+      style: 'decimal',
+      useGrouping: false,
+      currency: undefined,
+      currencyDisplay: undefined,
+    };
+    if (format?.style === 'percent') {
+      const asPercent = roundToPrecision(v * 100, 12);
+      return formatNumber(asPercent, resolvedLocale, editFormat);
+    }
+    return formatNumber(v, resolvedLocale, editFormat);
+  }
+
+  function onFocus() {
+    editorBuffer = value === null || value === undefined ? '' : buildEditDisplay(value);
+    isFocused = true;
+  }
+
+  function onBlur() {
+    const buffered = editorBuffer;
+    isFocused = false;
+    commitFromText('blur', buffered);
+  }
+
+  function onInput(event: Event) {
+    const target = event.currentTarget as HTMLInputElement;
+    editorBuffer = target.value;
+  }
+
+  function getBaseForStep(direction: 'increment' | 'decrement'): number {
+    const parsed = isFocused ? parseLocaleNumber(editorBuffer, resolvedLocale, format) : null;
+    let baseFromDisplay: number | null = null;
+    if (parsed && parsed.status === 'valid') {
+      baseFromDisplay =
+        format?.style === 'percent'
+          ? roundToPrecision(parsed.value / 100, Math.max(2, fractionalDigits(parsed.value) + 2))
+          : parsed.value;
+    }
+    const defaultStart =
+      direction === 'increment'
+        ? Number.isFinite(resolvedMin)
+          ? resolvedMin
+          : 0
+        : Number.isFinite(resolvedMax)
+          ? resolvedMax
+          : 0;
+    return baseFromDisplay ?? value ?? defaultStart;
+  }
+
+  function stepBy(direction: 'increment' | 'decrement', source: CommitSource, multiplier = 1) {
+    const base = getBaseForStep(direction);
+    const delta = incrementStep * multiplier * (direction === 'increment' ? 1 : -1);
+    commitFromNumber(source, base + delta);
+    inputElement?.focus();
+  }
+
+  function onKeyDown(event: KeyboardEvent) {
+    if (disabled) return;
+    switch (event.key) {
+      case 'ArrowUp':
+        event.preventDefault();
+        stepBy('increment', 'arrow');
+        break;
+      case 'ArrowDown':
+        event.preventDefault();
+        stepBy('decrement', 'arrow');
+        break;
+      case 'PageUp':
+        event.preventDefault();
+        stepBy('increment', 'page', 10);
+        break;
+      case 'PageDown':
+        event.preventDefault();
+        stepBy('decrement', 'page', 10);
+        break;
+      case 'Home':
+        if (Number.isFinite(resolvedMin)) {
+          event.preventDefault();
+          commitFromNumber('home', resolvedMin);
+        }
+        break;
+      case 'End':
+        if (Number.isFinite(resolvedMax)) {
+          event.preventDefault();
+          commitFromNumber('end', resolvedMax);
+        }
+        break;
+      case 'Enter': {
+        event.preventDefault();
+        commitFromText('enter', isFocused ? editorBuffer : formattedValue);
+        const form = inputElement?.closest('form');
+        if (form) {
+          if (form.checkValidity()) form.requestSubmit();
+          else form.reportValidity();
+        }
+        break;
+      }
+    }
+  }
+
+  // Form integration: submit (capture), formdata, reset.
+  $effect(() => {
+    if (!inputElement) return;
+    const form = inputElement.closest('form');
+    if (!form) return;
+
+    const onSubmit = (event: SubmitEvent) => {
+      if (disabled) return;
+      if (isFocused) commitFromText('submit', editorBuffer);
+      if (!form.checkValidity()) {
+        event.preventDefault();
+        form.reportValidity();
+      }
+    };
+    const onFormData = (event: FormDataEvent) => {
+      if (disabled) return;
+      if (isFocused) {
+        commitFromText('formdata', editorBuffer, event.formData);
+      } else if (typeof name === 'string' && name.length > 0) {
+        event.formData.set(name, value === null || value === undefined ? '' : String(value));
+      }
+    };
+    const onReset = () => {
+      if (disabled) return;
+      commitFromNumber('reset', defaultValue ?? null, undefined, 'valid');
+    };
+
+    form.addEventListener('submit', onSubmit, true);
+    form.addEventListener('formdata', onFormData);
+    form.addEventListener('reset', onReset);
+
+    return () => {
+      form.removeEventListener('submit', onSubmit, true);
+      form.removeEventListener('formdata', onFormData);
+      form.removeEventListener('reset', onReset);
+    };
+  });
+
+  const defaultDescriptionId = $derived(describeId(id, !!description));
+  const defaultErrorId = $derived(buildErrorId(id, !!error));
+  const ownDescriptionId = $derived(
+    description && defaultDescriptionId === context?.descriptionId
+      ? `${id}-number-input-description`
+      : defaultDescriptionId,
+  );
+  const ownErrorId = $derived(
+    error && defaultErrorId === context?.errorId ? `${id}-number-input-error` : defaultErrorId,
+  );
+  const resolvedDescriptionId = $derived(ownDescriptionId ?? context?.descriptionId);
+  const resolvedErrorId = $derived(ownErrorId ?? context?.errorId);
+  const describedBy = $derived(composeDescribedBy(resolvedDescriptionId, resolvedErrorId));
+  const resolvedAriaInvalid = $derived(
+    error ? ariaInvalid(true) : (context?.invalid ?? rest['aria-invalid'] ?? ariaInvalid(false)),
+  );
+  const resolvedRequired = $derived(required ?? context?.required ?? false);
+  const resolvedDisabled = $derived(disabled ?? context?.disabled ?? false);
+
+  const incrementDisabled = $derived(
+    resolvedDisabled || (value !== null && value !== undefined && value >= resolvedMax),
+  );
+  const decrementDisabled = $derived(
+    resolvedDisabled || (value !== null && value !== undefined && value <= resolvedMin),
+  );
+
+  const showHiddenInput = $derived(
+    typeof name === 'string' && name.length > 0 && !resolvedDisabled,
+  );
+</script>
+
+<div class={cn('cinder-input-field', className)}>
+  {#if label}
+    <label for={id} class="cinder-input-field__label" data-disabled={resolvedDisabled || undefined}>
+      {label}
+    </label>
+  {/if}
+
+  <div class="cinder-number-input" data-disabled={resolvedDisabled ? '' : undefined}>
+    <input
+      bind:this={inputElement}
+      {id}
+      type="text"
+      inputmode="decimal"
+      value={displayValue}
+      disabled={resolvedDisabled}
+      required={resolvedRequired}
+      aria-invalid={resolvedAriaInvalid}
+      aria-describedby={describedBy}
+      class="cinder-input cinder-number-input__input"
+      oninput={onInput}
+      onfocus={onFocus}
+      onblur={onBlur}
+      onkeydown={onKeyDown}
+      {...rest}
+    />
+    <button
+      type="button"
+      class="cinder-number-input__stepper cinder-number-input__stepper--increment"
+      aria-label="Increment"
+      disabled={incrementDisabled}
+      onclick={() => stepBy('increment', 'stepper')}
+    >
+      <span aria-hidden="true">+</span>
+    </button>
+    <button
+      type="button"
+      class="cinder-number-input__stepper cinder-number-input__stepper--decrement"
+      aria-label="Decrement"
+      disabled={decrementDisabled}
+      onclick={() => stepBy('decrement', 'stepper')}
+    >
+      <span aria-hidden="true">&#x2212;</span>
+    </button>
+  </div>
+
+  {#if showHiddenInput}
+    <input
+      type="hidden"
+      {name}
+      value={value === null || value === undefined ? '' : String(value)}
+    />
+  {/if}
+
+  {#if description}
+    <p id={ownDescriptionId} class="cinder-input-field__description">{description}</p>
+  {/if}
+
+  {#if error}
+    <p id={ownErrorId} class="cinder-input-field__error" aria-live="polite">{error}</p>
+  {/if}
+</div>

--- a/packages/components/src/components/number-input.svelte
+++ b/packages/components/src/components/number-input.svelte
@@ -177,9 +177,10 @@
       const origin = Number.isFinite(resolvedMin) ? resolvedMin : 0;
       result = origin + Math.round((raw - origin) / snapStep) * snapStep;
       result = roundToPrecision(result, fractionalDigits(snapStep));
-    } else if (snapStep !== null) {
-      // Even when snapping is skipped, round to step precision so successive
-      // additions of `0.1` don't accumulate float error.
+    } else if (source === 'delta' && snapStep !== null) {
+      // For delta steps, round to step precision so successive additions of
+      // `0.1` don't accumulate float error. Reset is excluded — it restores
+      // defaultValue verbatim without any rounding.
       result = roundToPrecision(raw, fractionalDigits(snapStep));
     }
     const clamped = Math.min(resolvedMax, Math.max(resolvedMin, result));
@@ -239,11 +240,11 @@
     const signature = parentValueSignature;
     if (signature === lastSeenParentSignature) return;
     lastSeenParentSignature = signature;
-    if (!isFocused) return;
     if (isInternalValueChange) {
       isInternalValueChange = false;
       return;
     }
+    if (!isFocused) return;
     editorBuffer = value === null || value === undefined ? '' : buildEditDisplay(value);
   });
 

--- a/packages/components/src/components/number-input.svelte
+++ b/packages/components/src/components/number-input.svelte
@@ -530,10 +530,10 @@
       value={displayValue}
       disabled={resolvedDisabled}
       required={resolvedRequired}
-      aria-invalid={resolvedAriaInvalid}
-      aria-describedby={describedBy}
       class="cinder-input cinder-number-input__input"
       {...rest}
+      aria-invalid={resolvedAriaInvalid}
+      aria-describedby={describedBy}
       oninput={onInput}
       onfocus={onFocus}
       onblur={onBlur}

--- a/packages/components/src/components/number-input.svelte
+++ b/packages/components/src/components/number-input.svelte
@@ -207,6 +207,11 @@
   // because two distinct $effects read it across the same flush.
   let isInternalValueChange = $state(false);
 
+  // Set to true by the Enter key handler immediately before requestSubmit() so
+  // the capture-phase submit listener knows the value was already flushed and
+  // can skip the redundant commitFromText call (preventing double onchange).
+  let enterKeyFlushed = false;
+
   // formattedValue and displayValue collapsed into one derived expression.
   // When the last commit was malformed we keep the user's typed text visible
   // so they can correct it instead of having their input erased.
@@ -382,8 +387,12 @@
         commitFromText('typed', isFocused ? editorBuffer : '');
         const form = inputElement?.closest('form');
         if (form) {
-          if (form.checkValidity()) form.requestSubmit();
-          else form.reportValidity();
+          if (form.checkValidity()) {
+            enterKeyFlushed = true;
+            form.requestSubmit();
+          } else {
+            form.reportValidity();
+          }
         }
         break;
       }
@@ -408,6 +417,11 @@
       // Validity reporting lives in onKeyDown / native form submission —
       // not here — so the listener has exactly one job: flush.
       if (resolvedDisabled) return;
+      // Skip flush when Enter already committed — avoids double onchange.
+      if (enterKeyFlushed) {
+        enterKeyFlushed = false;
+        return;
+      }
       if (isFocused) commitFromText('typed', editorBuffer);
     };
     const onReset = () => {

--- a/packages/components/src/components/number-input.svelte
+++ b/packages/components/src/components/number-input.svelte
@@ -178,10 +178,16 @@
       result = origin + Math.round((raw - origin) / snapStep) * snapStep;
       result = roundToPrecision(result, fractionalDigits(snapStep));
     } else if (source === 'delta' && snapStep !== null) {
-      // For delta steps, round to step precision so successive additions of
-      // `0.1` don't accumulate float error. Reset is excluded — it restores
-      // defaultValue verbatim without any rounding.
-      result = roundToPrecision(raw, fractionalDigits(snapStep));
+      // Eliminate float accumulation noise (0.1 + 0.2 → 0.30000…) while
+      // preserving base-value precision that exceeds the step's precision
+      // (value=0.5 + step=1 → 1.5, not 2). First clamp at 12 digits to get a
+      // clean representation, then take the max of step digits and the clean
+      // result's digits as the final rounding target.
+      const cleanRaw = roundToPrecision(raw, 12);
+      result = roundToPrecision(
+        raw,
+        Math.max(fractionalDigits(snapStep), fractionalDigits(cleanRaw)),
+      );
     }
     const clamped = Math.min(resolvedMax, Math.max(resolvedMin, result));
     return commit(clamped, parseStatus, true);

--- a/packages/components/src/components/number-input.test.ts
+++ b/packages/components/src/components/number-input.test.ts
@@ -6,6 +6,7 @@ import { setupHappyDom } from '../test/happy-dom.ts';
 setupHappyDom();
 
 const { render, fireEvent, cleanup } = await import('@testing-library/svelte');
+const { tick } = await import('svelte');
 const { default: NumberInput } = await import('./number-input.svelte');
 
 afterEach(() => {
@@ -31,10 +32,10 @@ function getHidden(container: Element): HTMLInputElement | null {
 }
 
 function getIncrement(container: Element): HTMLButtonElement {
-  return container.querySelector('[aria-label="Increment"]') as HTMLButtonElement;
+  return container.querySelector('.cinder-number-input__stepper--increment') as HTMLButtonElement;
 }
 function getDecrement(container: Element): HTMLButtonElement {
-  return container.querySelector('[aria-label="Decrement"]') as HTMLButtonElement;
+  return container.querySelector('.cinder-number-input__stepper--decrement') as HTMLButtonElement;
 }
 
 async function type(input: HTMLInputElement, text: string) {
@@ -721,5 +722,168 @@ describe('External updates and edge cases', () => {
     const input = getInput(container);
     await fireEvent.keyDown(input, { key: 'ArrowUp' });
     expect(calls).toEqual([5]);
+  });
+});
+
+describe('Stepper aria-labels include field + step magnitude', () => {
+  test('with label and explicit step', () => {
+    const { container } = render(NumberInput, {
+      props: { id: 'n', value: 1, label: 'Quantity', step: 5, locale: 'en-US' },
+    });
+    expect(getIncrement(container).getAttribute('aria-label')).toBe('Increment Quantity by 5');
+    expect(getDecrement(container).getAttribute('aria-label')).toBe('Decrement Quantity by 5');
+  });
+
+  test('without label falls back to magnitude-only label', () => {
+    const { container } = render(NumberInput, {
+      props: { id: 'n', value: 1, locale: 'en-US' },
+    });
+    expect(getIncrement(container).getAttribute('aria-label')).toBe('Increment by 1');
+    expect(getDecrement(container).getAttribute('aria-label')).toBe('Decrement by 1');
+  });
+});
+
+describe('Locale parser coverage in component', () => {
+  test('fr-FR narrow-NBSP grouping round-trip', async () => {
+    const calls: Array<number | null> = [];
+    const { container } = render(NumberInput, {
+      props: { id: 'n', locale: 'fr-FR', onchange: (v: number | null) => calls.push(v) },
+    });
+    const input = getInput(container);
+    await focus(input);
+    // Use the locale's own formatted output so we get the actual narrow NBSP.
+    const formatted = new Intl.NumberFormat('fr-FR').format(1234.5);
+    await type(input, formatted);
+    await blur(input);
+    expect(calls).toEqual([1234.5]);
+  });
+
+  test('ar-EG localized digits round-trip', async () => {
+    const calls: Array<number | null> = [];
+    const { container } = render(NumberInput, {
+      props: { id: 'n', locale: 'ar-EG', onchange: (v: number | null) => calls.push(v) },
+    });
+    const input = getInput(container);
+    await focus(input);
+    const formatted = new Intl.NumberFormat('ar-EG').format(1234);
+    await type(input, formatted);
+    await blur(input);
+    expect(calls).toEqual([1234]);
+  });
+
+  test('hi-IN secondary grouping accepted', async () => {
+    const calls: Array<number | null> = [];
+    const { container } = render(NumberInput, {
+      props: { id: 'n', locale: 'hi-IN', onchange: (v: number | null) => calls.push(v) },
+    });
+    const input = getInput(container);
+    await focus(input);
+    await type(input, '12,34,567');
+    await blur(input);
+    expect(calls).toEqual([1234567]);
+  });
+});
+
+describe('Form serialization correctness', () => {
+  test('formdata event picks up hidden input with canonical numeric string', () => {
+    const form = document.createElement('form');
+    document.body.appendChild(form);
+    const mount = document.createElement('div');
+    form.appendChild(mount);
+    render(NumberInput, {
+      target: mount,
+      props: { id: 'n', name: 'q', value: 1234.5, locale: 'en-US' },
+    });
+    // Dispatch a formdata event with a fresh FormData; the hidden input's
+    // value is what the browser collects under `name="q"`.
+    const fd = new FormData();
+    const hidden = mount.querySelector('input[type="hidden"]') as HTMLInputElement;
+    fd.set(hidden.name, hidden.value);
+    expect(fd.get('q')).toBe('1234.5');
+  });
+
+  test('mid-edit value reaches form serialization after submit-capture flush', async () => {
+    const form = document.createElement('form');
+    document.body.appendChild(form);
+    const mount = document.createElement('div');
+    form.appendChild(mount);
+    render(NumberInput, {
+      target: mount,
+      props: { id: 'n', name: 'q', defaultValue: 0, locale: 'en-US' },
+    });
+    const input = mount.querySelector('#n') as HTMLInputElement;
+    await focus(input);
+    await type(input, '999');
+    form.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }));
+    await tick();
+    const hidden = mount.querySelector('input[type="hidden"]') as HTMLInputElement;
+    expect(hidden.value).toBe('999');
+  });
+});
+
+describe('Required + reset and other validity edge cases', () => {
+  test('required + form-reset-to-null stays invalid', async () => {
+    const form = document.createElement('form');
+    document.body.appendChild(form);
+    const mount = document.createElement('div');
+    form.appendChild(mount);
+    render(NumberInput, {
+      target: mount,
+      props: { id: 'n', name: 'q', required: true, defaultValue: null, locale: 'en-US' },
+    });
+    const input = mount.querySelector('#n') as HTMLInputElement;
+    // Force into an invalid-required state on reset.
+    form.dispatchEvent(new Event('reset', { bubbles: true, cancelable: true }));
+    expect(input.validity.customError).toBe(true);
+  });
+
+  test('malformed blur keeps user text visible for correction', async () => {
+    const { container } = render(NumberInput, {
+      props: { id: 'n', locale: 'en-US' },
+    });
+    const input = getInput(container);
+    await focus(input);
+    await type(input, '12abc');
+    await blur(input);
+    // The hostile-form-UX behavior would erase to '' here. The component
+    // keeps the user's text so they can edit it.
+    expect(input.value).toBe('12abc');
+    expect(input.validity.customError).toBe(true);
+  });
+
+  test('disabled form listeners are no-ops', async () => {
+    const calls: Array<number | null> = [];
+    const form = document.createElement('form');
+    document.body.appendChild(form);
+    const mount = document.createElement('div');
+    form.appendChild(mount);
+    render(NumberInput, {
+      target: mount,
+      props: {
+        id: 'n',
+        name: 'q',
+        value: 5,
+        disabled: true,
+        locale: 'en-US',
+        onchange: (v: number | null) => calls.push(v),
+      },
+    });
+    form.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }));
+    form.dispatchEvent(new Event('reset', { bubbles: true, cancelable: true }));
+    expect(calls).toEqual([]);
+  });
+});
+
+describe('FormField context overrides', () => {
+  test('context-disabled disables steppers and omits hidden input', async () => {
+    // Render the component and patch context post-hoc: use disabled prop as
+    // the proxy since FormField is a separate test concern. (Direct context
+    // testing lives in the form-field fixture suite — we only need to verify
+    // resolvedDisabled is the source of truth.)
+    const { container } = render(NumberInput, {
+      props: { id: 'n', name: 'q', value: 5, disabled: true, locale: 'en-US' },
+    });
+    expect(getIncrement(container).disabled).toBe(true);
+    expect(getHidden(container)).toBeNull();
   });
 });

--- a/packages/components/src/components/number-input.test.ts
+++ b/packages/components/src/components/number-input.test.ts
@@ -1107,3 +1107,60 @@ describe('reset source does not snap defaultValue to step precision', () => {
     expect(input.value).toBe('0.15');
   });
 });
+
+describe('delta rounding preserves base-value precision', () => {
+  test('ArrowUp with integer step does not clip fractional base value', async () => {
+    // Regression: delta branch rounded to step precision, so value=0.5 + step=1
+    // produced 2 (rounded to 0 decimal places) instead of 1.5.
+    const calls: Array<number | null> = [];
+    const { container } = render(NumberInput, {
+      props: {
+        id: 'n',
+        value: 0.5,
+        step: 1,
+        locale: 'en-US',
+        onchange: (v: number | null) => calls.push(v),
+      },
+    });
+    const input = getInput(container);
+    await fireEvent.keyDown(input, { key: 'ArrowUp' });
+    expect(calls[0]).toBe(1.5);
+  });
+
+  test('ArrowUp with decimal step preserves extra base precision', async () => {
+    // Regression: value=0.05, step=0.1 → delta rounding to 1 decimal produced
+    // 0.1 instead of the correct 0.15.
+    const calls: Array<number | null> = [];
+    const { container } = render(NumberInput, {
+      props: {
+        id: 'n',
+        value: 0.05,
+        step: 0.1,
+        locale: 'en-US',
+        onchange: (v: number | null) => calls.push(v),
+      },
+    });
+    const input = getInput(container);
+    await fireEvent.keyDown(input, { key: 'ArrowUp' });
+    expect(calls[0]).toBe(0.15);
+  });
+
+  test('repeated ArrowUp with decimal step still eliminates float noise', async () => {
+    // Ensure the fix still prevents 0.1+0.1+...×10 = 1.0000000000000009.
+    const calls: Array<number | null> = [];
+    const { container } = render(NumberInput, {
+      props: {
+        id: 'n',
+        value: 0,
+        step: 0.1,
+        locale: 'en-US',
+        onchange: (v: number | null) => calls.push(v),
+      },
+    });
+    const input = getInput(container);
+    for (let i = 0; i < 10; i++) {
+      await fireEvent.keyDown(input, { key: 'ArrowUp' });
+    }
+    expect(calls[calls.length - 1]).toBe(1);
+  });
+});

--- a/packages/components/src/components/number-input.test.ts
+++ b/packages/components/src/components/number-input.test.ts
@@ -813,6 +813,29 @@ describe('Locale parser coverage in component', () => {
     await blur(input);
     expect(calls).toEqual([1234567]);
   });
+
+  test('compact notation format: edit buffer shows plain number, not "1.2K"', async () => {
+    // Regression: buildEditDisplay did not clear `notation`, so format={notation:'compact'}
+    // rendered "1.2K" in the edit buffer. The parser's affix probes use 0 and -1 (too small
+    // for "K"/"M" suffixes), so "1.2K" was never stripped and was rejected as malformed on blur.
+    const calls: Array<number | null> = [];
+    const { container } = render(NumberInput, {
+      props: {
+        id: 'n',
+        locale: 'en-US',
+        value: 1200,
+        format: { notation: 'compact' },
+        onchange: (v: number | null) => calls.push(v),
+      },
+    });
+    const input = getInput(container);
+    await focus(input);
+    // Edit buffer must show the plain numeric form, not the compact abbreviation.
+    expect(input.value).toBe('1200');
+    await blur(input);
+    // Blur commit of the unmodified edit buffer should not produce a malformed error.
+    expect(calls).toEqual([1200]);
+  });
 });
 
 describe('Form serialization correctness', () => {

--- a/packages/components/src/components/number-input.test.ts
+++ b/packages/components/src/components/number-input.test.ts
@@ -1058,3 +1058,52 @@ describe('FormField context overrides', () => {
     expect(getHidden(container)).toBeNull();
   });
 });
+
+describe('isInternalValueChange stale-flag regression', () => {
+  test('malformedError clears when parent writes a valid number after a malformed blur', async () => {
+    // Regression: when blur commits null (malformed input), isInternalValueChange
+    // was set but never cleared for the unfocused case, so the validity-sync
+    // effect's !isInternalValueChange guard was always false and malformedError
+    // was never cleared by a subsequent external value change.
+    const { container, rerender } = render(NumberInput, {
+      props: { id: 'n', value: 5, locale: 'en-US' },
+    });
+    const input = getInput(container);
+    await focus(input);
+    await type(input, 'notanumber');
+    await blur(input);
+    await tick();
+    expect(input.getAttribute('aria-invalid')).toBe('true');
+
+    // Parent writes a valid value — malformedError must clear.
+    await rerender({ id: 'n', value: 42, locale: 'en-US' });
+    await tick();
+    expect(input.getAttribute('aria-invalid')).toBeNull();
+  });
+});
+
+describe('reset source does not snap defaultValue to step precision', () => {
+  test('form reset restores defaultValue verbatim even when step would round it', async () => {
+    // Regression: commitFromNumber with 'reset' source fell through to the
+    // else-if(snapStep !== null) branch, silently rounding defaultValue.
+    // e.g. defaultValue=0.15, step=0.1 → reset produced 0.2 instead of 0.15.
+    const form = document.createElement('form');
+    document.body.appendChild(form);
+    const mount = document.createElement('div');
+    form.appendChild(mount);
+    render(NumberInput, {
+      target: mount,
+      props: { id: 'n', name: 'q', defaultValue: 0.15, step: 0.1, locale: 'en-US' },
+    });
+    const input = mount.querySelector('#n') as HTMLInputElement;
+    // Change value away from default.
+    await focus(input);
+    await type(input, '0.5');
+    await blur(input);
+    await tick();
+    // Reset the form — value should return to 0.15 verbatim, not 0.2.
+    form.dispatchEvent(new Event('reset', { bubbles: true, cancelable: true }));
+    await tick();
+    expect(input.value).toBe('0.15');
+  });
+});

--- a/packages/components/src/components/number-input.test.ts
+++ b/packages/components/src/components/number-input.test.ts
@@ -856,6 +856,34 @@ describe('Form serialization correctness', () => {
     const hidden = mount.querySelector('input[type="hidden"]') as HTMLInputElement;
     expect(hidden.value).toBe('999');
   });
+
+  test('Enter key fires onchange exactly once (regression: capture-phase submit double-fire)', async () => {
+    // Regression: pressing Enter called commitFromText in onKeyDown, then
+    // requestSubmit() triggered the capture-phase submit listener which called
+    // commitFromText again, causing a duplicate onchange emission.
+    const calls: Array<number | null> = [];
+    const form = document.createElement('form');
+    document.body.appendChild(form);
+    const mount = document.createElement('div');
+    form.appendChild(mount);
+    render(NumberInput, {
+      target: mount,
+      props: {
+        id: 'n',
+        name: 'q',
+        defaultValue: 0,
+        locale: 'en-US',
+        onchange: (v: number | null) => calls.push(v),
+      },
+    });
+    const input = mount.querySelector('#n') as HTMLInputElement;
+    await focus(input);
+    await type(input, '42');
+    calls.length = 0;
+    await fireEvent.keyDown(input, { key: 'Enter' });
+    await tick();
+    expect(calls).toEqual([42]);
+  });
 });
 
 describe('Required + reset and other validity edge cases', () => {

--- a/packages/components/src/components/number-input.test.ts
+++ b/packages/components/src/components/number-input.test.ts
@@ -400,6 +400,37 @@ describe('Stepper buttons and keyboard', () => {
     expect(calls).toEqual([]);
   });
 
+  test('Home/End sync editor buffer while focused — no stale-buffer revert on blur', async () => {
+    const calls: Array<number | null> = [];
+    const { container } = render(NumberInput, {
+      props: {
+        id: 'n',
+        value: 5,
+        min: 1,
+        max: 9,
+        locale: 'en-US',
+        onchange: (v: number | null) => calls.push(v),
+      },
+    });
+    const input = getInput(container);
+    await focus(input);
+    // Press Home — should commit to min AND update the editor buffer.
+    await fireEvent.keyDown(input, { key: 'Home' });
+    await tick();
+    expect(input.value).toBe('1');
+    // Blur re-parses the buffer; if buffer was stale this would revert to 5.
+    await blur(input);
+    expect(calls.at(-1)).toBe(1);
+
+    // Now test End.
+    await focus(input);
+    await fireEvent.keyDown(input, { key: 'End' });
+    await tick();
+    expect(input.value).toBe('9');
+    await blur(input);
+    expect(calls.at(-1)).toBe(9);
+  });
+
   test('Step from focused display, not stale value', async () => {
     const calls: Array<number | null> = [];
     const { container } = render(NumberInput, {

--- a/packages/components/src/components/number-input.test.ts
+++ b/packages/components/src/components/number-input.test.ts
@@ -1025,6 +1025,31 @@ describe('Internal error region announces invalid state', () => {
     await type(input, '5');
     expect(container.querySelector('#n-internal-error')).toBeNull();
   });
+
+  test('required-empty error does not flash mid-keystroke after malformed clear', async () => {
+    // Regression: when required=true and the user re-types after a malformed blur,
+    // onInput clears malformedError but value is still null. The validity-sync
+    // $effect must NOT set requiredEmptyError while the field is focused — doing so
+    // would announce "Please enter a number." in the aria-live region mid-keystroke.
+    const { container } = render(NumberInput, {
+      props: { id: 'n', required: true, locale: 'en-US' },
+    });
+    const input = getInput(container);
+
+    // Produce a malformed state by blurring with invalid text.
+    await focus(input);
+    await type(input, 'abc');
+    await blur(input);
+    expect(input.getAttribute('aria-invalid')).toBe('true');
+
+    // Re-focus and start correcting. After the first keystroke malformedError
+    // clears but value is still null. requiredEmptyError must stay false.
+    await focus(input);
+    await type(input, '5');
+
+    expect(container.querySelector('#n-internal-error')).toBeNull();
+    expect(input.getAttribute('aria-invalid')).toBeFalsy();
+  });
 });
 
 describe('Malformed buffer preserved across re-focus', () => {

--- a/packages/components/src/components/number-input.test.ts
+++ b/packages/components/src/components/number-input.test.ts
@@ -1,0 +1,725 @@
+/// <reference lib="dom" />
+import { afterEach, describe, expect, test } from 'bun:test';
+
+import { setupHappyDom } from '../test/happy-dom.ts';
+
+setupHappyDom();
+
+const { render, fireEvent, cleanup } = await import('@testing-library/svelte');
+const { default: NumberInput } = await import('./number-input.svelte');
+
+afterEach(() => {
+  // Tear down any standalone <form> elements appended to body by form tests
+  // FIRST so cleanup() doesn't try to remove children of an already-detached
+  // form. happy-dom throws if removeChild can't find the node.
+  document.querySelectorAll('body > form').forEach((form) => {
+    try {
+      form.remove();
+    } catch {
+      // ignore detached-node errors
+    }
+  });
+  cleanup();
+});
+
+function getInput(container: Element, id = 'n'): HTMLInputElement {
+  return container.querySelector(`#${id}`) as HTMLInputElement;
+}
+
+function getHidden(container: Element): HTMLInputElement | null {
+  return container.querySelector('input[type="hidden"]');
+}
+
+function getIncrement(container: Element): HTMLButtonElement {
+  return container.querySelector('[aria-label="Increment"]') as HTMLButtonElement;
+}
+function getDecrement(container: Element): HTMLButtonElement {
+  return container.querySelector('[aria-label="Decrement"]') as HTMLButtonElement;
+}
+
+async function type(input: HTMLInputElement, text: string) {
+  input.value = text;
+  await fireEvent.input(input, { target: { value: text } });
+}
+
+async function blur(input: HTMLInputElement) {
+  await fireEvent.blur(input);
+}
+
+async function focus(input: HTMLInputElement) {
+  await fireEvent.focus(input);
+}
+
+describe('NumberInput basics', () => {
+  test('renders with defaultValue formatted in en-US', () => {
+    const { container } = render(NumberInput, {
+      props: { id: 'n', defaultValue: 1234.5, locale: 'en-US' },
+    });
+    expect(getInput(container).value).toBe('1,234.5');
+  });
+
+  test('controlled value updates display', async () => {
+    const { container, rerender } = render(NumberInput, {
+      props: { id: 'n', value: 1, locale: 'en-US' },
+    });
+    expect(getInput(container).value).toBe('1');
+    await rerender({ id: 'n', value: 42, locale: 'en-US' });
+    expect(getInput(container).value).toBe('42');
+  });
+
+  test('per-keystroke does not commit `0.`', async () => {
+    const calls: Array<number | null> = [];
+    const { container } = render(NumberInput, {
+      props: {
+        id: 'n',
+        value: null,
+        locale: 'en-US',
+        onchange: (v: number | null) => calls.push(v),
+      },
+    });
+    const input = getInput(container);
+    await focus(input);
+    await type(input, '0.');
+    expect(input.value).toBe('0.');
+    expect(calls).toEqual([]);
+  });
+
+  test('bare `-` survives mid-typing without committing', async () => {
+    const calls: Array<number | null> = [];
+    const { container } = render(NumberInput, {
+      props: { id: 'n', locale: 'en-US', onchange: (v: number | null) => calls.push(v) },
+    });
+    const input = getInput(container);
+    await focus(input);
+    await type(input, '-');
+    expect(input.value).toBe('-');
+    expect(calls).toEqual([]);
+  });
+
+  test('blur commits valid number and reformats', async () => {
+    const calls: Array<number | null> = [];
+    const { container } = render(NumberInput, {
+      props: { id: 'n', locale: 'en-US', onchange: (v: number | null) => calls.push(v) },
+    });
+    const input = getInput(container);
+    await focus(input);
+    await type(input, '1234.5');
+    await blur(input);
+    expect(calls).toEqual([1234.5]);
+    expect(input.value).toBe('1,234.5');
+  });
+
+  test('blur empty fires onchange(null)', async () => {
+    const calls: Array<number | null> = [];
+    const { container } = render(NumberInput, {
+      props: { id: 'n', value: 5, locale: 'en-US', onchange: (v: number | null) => calls.push(v) },
+    });
+    const input = getInput(container);
+    await focus(input);
+    await type(input, '');
+    await blur(input);
+    expect(calls).toEqual([null]);
+  });
+
+  test('blur `0.` → 0', async () => {
+    const calls: Array<number | null> = [];
+    const { container } = render(NumberInput, {
+      props: { id: 'n', locale: 'en-US', onchange: (v: number | null) => calls.push(v) },
+    });
+    const input = getInput(container);
+    await focus(input);
+    await type(input, '0.');
+    await blur(input);
+    expect(calls).toEqual([0]);
+  });
+
+  test('blur `.5` → 0.5', async () => {
+    const calls: Array<number | null> = [];
+    const { container } = render(NumberInput, {
+      props: { id: 'n', locale: 'en-US', onchange: (v: number | null) => calls.push(v) },
+    });
+    const input = getInput(container);
+    await focus(input);
+    await type(input, '.5');
+    await blur(input);
+    expect(calls).toEqual([0.5]);
+  });
+
+  test('blur `+1` → 1', async () => {
+    const calls: Array<number | null> = [];
+    const { container } = render(NumberInput, {
+      props: { id: 'n', locale: 'en-US', onchange: (v: number | null) => calls.push(v) },
+    });
+    const input = getInput(container);
+    await focus(input);
+    await type(input, '+1');
+    await blur(input);
+    expect(calls).toEqual([1]);
+  });
+
+  test('blur bare `-` → null', async () => {
+    const calls: Array<number | null> = [];
+    const { container } = render(NumberInput, {
+      props: { id: 'n', locale: 'en-US', onchange: (v: number | null) => calls.push(v) },
+    });
+    const input = getInput(container);
+    await focus(input);
+    await type(input, '-');
+    await blur(input);
+    expect(calls).toEqual([null]);
+  });
+});
+
+describe('Clamping and snapping', () => {
+  test('blur clamps to max', async () => {
+    const calls: Array<number | null> = [];
+    const { container } = render(NumberInput, {
+      props: { id: 'n', max: 10, locale: 'en-US', onchange: (v: number | null) => calls.push(v) },
+    });
+    const input = getInput(container);
+    await focus(input);
+    await type(input, '999');
+    await blur(input);
+    expect(calls).toEqual([10]);
+  });
+
+  test('blur clamps to min', async () => {
+    const calls: Array<number | null> = [];
+    const { container } = render(NumberInput, {
+      props: { id: 'n', min: 0, locale: 'en-US', onchange: (v: number | null) => calls.push(v) },
+    });
+    const input = getInput(container);
+    await focus(input);
+    await type(input, '-999');
+    await blur(input);
+    expect(calls).toEqual([0]);
+  });
+
+  test('blur snaps to step only when step provided', async () => {
+    const calls: Array<number | null> = [];
+    const { container } = render(NumberInput, {
+      props: { id: 'n', step: 0.5, locale: 'en-US', onchange: (v: number | null) => calls.push(v) },
+    });
+    const input = getInput(container);
+    await focus(input);
+    await type(input, '1.3');
+    await blur(input);
+    expect(calls).toEqual([1.5]);
+  });
+
+  test('default-step does NOT snap', async () => {
+    const calls: Array<number | null> = [];
+    const { container } = render(NumberInput, {
+      props: { id: 'n', locale: 'en-US', onchange: (v: number | null) => calls.push(v) },
+    });
+    const input = getInput(container);
+    await focus(input);
+    await type(input, '1234.5');
+    await blur(input);
+    expect(calls).toEqual([1234.5]);
+  });
+
+  test('snap-then-clamp ordering: clamp wins', async () => {
+    const calls: Array<number | null> = [];
+    const { container } = render(NumberInput, {
+      props: {
+        id: 'n',
+        min: 0,
+        max: 1,
+        step: 0.6,
+        locale: 'en-US',
+        onchange: (v: number | null) => calls.push(v),
+      },
+    });
+    const input = getInput(container);
+    await focus(input);
+    await type(input, '0.9');
+    await blur(input);
+    expect(calls).toEqual([1]);
+  });
+
+  test('snap origin respects min', async () => {
+    const calls: Array<number | null> = [];
+    const { container } = render(NumberInput, {
+      props: {
+        id: 'n',
+        min: 0.1,
+        step: 0.2,
+        locale: 'en-US',
+        onchange: (v: number | null) => calls.push(v),
+      },
+    });
+    const input = getInput(container);
+    await focus(input);
+    await type(input, '0.4');
+    await blur(input);
+    expect(calls).toEqual([0.5]);
+  });
+
+  test('roundToPrecision removes float artifacts', async () => {
+    const calls: Array<number | null> = [];
+    const { container } = render(NumberInput, {
+      props: { id: 'n', step: 0.1, locale: 'en-US', onchange: (v: number | null) => calls.push(v) },
+    });
+    const input = getInput(container);
+    await focus(input);
+    await type(input, '0.3');
+    await blur(input);
+    expect(calls[0]).toBe(0.3);
+    expect(Object.is(calls[0], 0.3)).toBe(true);
+  });
+
+  test('invalid step (0, -5, NaN, Infinity) falls back to increment=1', async () => {
+    for (const bad of [0, -5, Number.NaN, Number.POSITIVE_INFINITY]) {
+      const calls: Array<number | null> = [];
+      const { container, unmount } = render(NumberInput, {
+        props: {
+          id: 'n',
+          value: 1,
+          step: bad,
+          locale: 'en-US',
+          onchange: (v: number | null) => calls.push(v),
+        },
+      });
+      getIncrement(container).click();
+      expect(calls).toEqual([2]);
+      unmount();
+    }
+  });
+
+  test('exponential step precision', async () => {
+    const calls: Array<number | null> = [];
+    const { container } = render(NumberInput, {
+      props: {
+        id: 'n',
+        step: 1e-7,
+        locale: 'en-US',
+        onchange: (v: number | null) => calls.push(v),
+      },
+    });
+    const input = getInput(container);
+    await focus(input);
+    await type(input, '0.0000003');
+    await blur(input);
+    expect(calls[0]).toBeCloseTo(0.0000003, 10);
+  });
+});
+
+describe('Stepper buttons and keyboard', () => {
+  test('Increment button fires onchange(value+step)', () => {
+    const calls: Array<number | null> = [];
+    const { container } = render(NumberInput, {
+      props: {
+        id: 'n',
+        value: 1,
+        step: 2,
+        locale: 'en-US',
+        onchange: (v: number | null) => calls.push(v),
+      },
+    });
+    getIncrement(container).click();
+    expect(calls).toEqual([3]);
+  });
+
+  test('Increment disabled at max', () => {
+    const { container } = render(NumberInput, {
+      props: { id: 'n', value: 10, max: 10, locale: 'en-US' },
+    });
+    expect(getIncrement(container).disabled).toBe(true);
+  });
+
+  test('Decrement fires onchange(value-step), disabled at min', () => {
+    const calls: Array<number | null> = [];
+    const { container } = render(NumberInput, {
+      props: { id: 'n', value: 5, locale: 'en-US', onchange: (v: number | null) => calls.push(v) },
+    });
+    getDecrement(container).click();
+    expect(calls).toEqual([4]);
+
+    const { container: c2 } = render(NumberInput, {
+      props: { id: 'm', value: 0, min: 0, locale: 'en-US' },
+    });
+    expect(getDecrement(c2).disabled).toBe(true);
+  });
+
+  test('ArrowUp / ArrowDown match increment / decrement', async () => {
+    const calls: Array<number | null> = [];
+    const { container } = render(NumberInput, {
+      props: { id: 'n', value: 5, locale: 'en-US', onchange: (v: number | null) => calls.push(v) },
+    });
+    const input = getInput(container);
+    await fireEvent.keyDown(input, { key: 'ArrowUp' });
+    await fireEvent.keyDown(input, { key: 'ArrowDown' });
+    expect(calls).toEqual([6, 5]);
+  });
+
+  test('PageUp / PageDown = ±10×step', async () => {
+    const calls: Array<number | null> = [];
+    const { container } = render(NumberInput, {
+      props: {
+        id: 'n',
+        value: 0,
+        step: 2,
+        locale: 'en-US',
+        onchange: (v: number | null) => calls.push(v),
+      },
+    });
+    const input = getInput(container);
+    await fireEvent.keyDown(input, { key: 'PageUp' });
+    await fireEvent.keyDown(input, { key: 'PageDown' });
+    expect(calls).toEqual([20, 0]);
+  });
+
+  test('Home → min when finite; End → max when finite', async () => {
+    const calls: Array<number | null> = [];
+    const { container } = render(NumberInput, {
+      props: {
+        id: 'n',
+        value: 5,
+        min: 1,
+        max: 9,
+        locale: 'en-US',
+        onchange: (v: number | null) => calls.push(v),
+      },
+    });
+    const input = getInput(container);
+    await fireEvent.keyDown(input, { key: 'Home' });
+    await fireEvent.keyDown(input, { key: 'End' });
+    expect(calls).toEqual([1, 9]);
+  });
+
+  test('Home / End no-op when bound is infinite', async () => {
+    const calls: Array<number | null> = [];
+    const { container } = render(NumberInput, {
+      props: { id: 'n', value: 5, locale: 'en-US', onchange: (v: number | null) => calls.push(v) },
+    });
+    const input = getInput(container);
+    await fireEvent.keyDown(input, { key: 'Home' });
+    await fireEvent.keyDown(input, { key: 'End' });
+    expect(calls).toEqual([]);
+  });
+
+  test('Step from focused display, not stale value', async () => {
+    const calls: Array<number | null> = [];
+    const { container } = render(NumberInput, {
+      props: { id: 'n', value: 0, locale: 'en-US', onchange: (v: number | null) => calls.push(v) },
+    });
+    const input = getInput(container);
+    await focus(input);
+    await type(input, '12');
+    await fireEvent.keyDown(input, { key: 'ArrowUp' });
+    expect(calls).toEqual([13]);
+  });
+
+  test('Refocus after stepper click', () => {
+    const { container } = render(NumberInput, {
+      props: { id: 'n', value: 1, locale: 'en-US' },
+    });
+    const input = getInput(container);
+    getIncrement(container).click();
+    expect(document.activeElement).toBe(input);
+  });
+});
+
+describe('Locale formatting', () => {
+  test('en-US: 1234.5 → "1,234.5"', () => {
+    const { container } = render(NumberInput, {
+      props: { id: 'n', defaultValue: 1234.5, locale: 'en-US' },
+    });
+    expect(getInput(container).value).toBe('1,234.5');
+  });
+
+  test('de-DE: 1234.5 → "1.234,5"', () => {
+    const { container } = render(NumberInput, {
+      props: { id: 'n', defaultValue: 1234.5, locale: 'de-DE' },
+    });
+    expect(getInput(container).value).toBe('1.234,5');
+  });
+
+  test('de-DE round-trip: paste "1.234,5" parses to 1234.5', async () => {
+    const calls: Array<number | null> = [];
+    const { container } = render(NumberInput, {
+      props: { id: 'n', locale: 'de-DE', onchange: (v: number | null) => calls.push(v) },
+    });
+    const input = getInput(container);
+    await focus(input);
+    await type(input, '1.234,5');
+    await blur(input);
+    expect(calls).toEqual([1234.5]);
+  });
+
+  test('Strict grouping rejection (en-US): "1,2,3.4" → null', async () => {
+    const calls: Array<number | null> = [];
+    const { container } = render(NumberInput, {
+      props: { id: 'n', locale: 'en-US', onchange: (v: number | null) => calls.push(v) },
+    });
+    const input = getInput(container);
+    await focus(input);
+    await type(input, '1,2,3.4');
+    await blur(input);
+    expect(calls).toEqual([null]);
+  });
+
+  test('Malformed inputs commit null', async () => {
+    for (const bad of ['12abc', '1.2.3', '$--5']) {
+      const calls: Array<number | null> = [];
+      const { container, unmount } = render(NumberInput, {
+        props: { id: 'n', locale: 'en-US', onchange: (v: number | null) => calls.push(v) },
+      });
+      const input = getInput(container);
+      await focus(input);
+      await type(input, bad);
+      await blur(input);
+      expect(calls).toEqual([null]);
+      unmount();
+    }
+  });
+
+  test('Grouped + accepted: "+1,234" (en-US) → 1234', async () => {
+    const calls: Array<number | null> = [];
+    const { container } = render(NumberInput, {
+      props: { id: 'n', locale: 'en-US', onchange: (v: number | null) => calls.push(v) },
+    });
+    const input = getInput(container);
+    await focus(input);
+    await type(input, '+1,234');
+    await blur(input);
+    expect(calls).toEqual([1234]);
+  });
+});
+
+describe('Currency and percent formats', () => {
+  test('currency: USD format', async () => {
+    const { container } = render(NumberInput, {
+      props: {
+        id: 'n',
+        defaultValue: 12.5,
+        locale: 'en-US',
+        format: { style: 'currency', currency: 'USD' },
+      },
+    });
+    const input = getInput(container);
+    expect(input.value).toBe('$12.50');
+    await focus(input);
+    expect(input.value).toBe('12.5');
+  });
+
+  test('percent: round-trip', async () => {
+    const calls: Array<number | null> = [];
+    const { container } = render(NumberInput, {
+      props: {
+        id: 'n',
+        defaultValue: 0.5,
+        locale: 'en-US',
+        format: { style: 'percent' },
+        onchange: (v: number | null) => calls.push(v),
+      },
+    });
+    const input = getInput(container);
+    expect(input.value).toBe('50%');
+    await focus(input);
+    expect(input.value).toBe('50');
+    await type(input, '75');
+    await blur(input);
+    expect(calls).toEqual([0.75]);
+    expect(input.value).toBe('75%');
+  });
+
+  test('percent: focus avoids precision artifacts', async () => {
+    const { container } = render(NumberInput, {
+      props: { id: 'n', defaultValue: 0.29, locale: 'en-US', format: { style: 'percent' } },
+    });
+    const input = getInput(container);
+    await focus(input);
+    expect(input.value).toBe('29');
+  });
+
+  test('percent step is canonical', async () => {
+    const calls: Array<number | null> = [];
+    const { container } = render(NumberInput, {
+      props: {
+        id: 'n',
+        defaultValue: 0.5,
+        step: 0.01,
+        locale: 'en-US',
+        format: { style: 'percent' },
+        onchange: (v: number | null) => calls.push(v),
+      },
+    });
+    const input = getInput(container);
+    await focus(input);
+    await fireEvent.keyDown(input, { key: 'ArrowUp' });
+    expect(calls[0]).toBeCloseTo(0.51, 10);
+  });
+});
+
+describe('Form integration', () => {
+  test('disabled disables input and steppers AND omits hidden', () => {
+    const { container } = render(NumberInput, {
+      props: { id: 'n', name: 'q', value: 5, disabled: true, locale: 'en-US' },
+    });
+    expect(getInput(container).disabled).toBe(true);
+    expect(getIncrement(container).disabled).toBe(true);
+    expect(getDecrement(container).disabled).toBe(true);
+    expect(getHidden(container)).toBeNull();
+  });
+
+  test('hidden input carries canonical numeric string when enabled+named', () => {
+    const { container } = render(NumberInput, {
+      props: { id: 'n', name: 'q', value: 1234.5, locale: 'en-US' },
+    });
+    expect(getHidden(container)?.value).toBe('1234.5');
+  });
+
+  test('visible input has no name attribute', () => {
+    const { container } = render(NumberInput, {
+      props: { id: 'n', name: 'q', value: 1, locale: 'en-US' },
+    });
+    expect(getInput(container).hasAttribute('name')).toBe(false);
+  });
+
+  test('hidden input value used for form submission is canonical numeric string', () => {
+    const { container } = render(NumberInput, {
+      props: { id: 'n', name: 'q', value: 1234.5, locale: 'en-US' },
+    });
+    const hidden = getHidden(container);
+    expect(hidden).not.toBeNull();
+    expect(hidden?.value).toBe('1234.5');
+    expect(hidden?.getAttribute('name')).toBe('q');
+  });
+
+  test('form reset (uncontrolled) restores defaultValue and fires onchange', async () => {
+    const calls: Array<number | null> = [];
+    const form = document.createElement('form');
+    document.body.appendChild(form);
+    const mount = document.createElement('div');
+    form.appendChild(mount);
+    render(NumberInput, {
+      target: mount,
+      props: {
+        id: 'n',
+        defaultValue: 5,
+        locale: 'en-US',
+        onchange: (v: number | null) => calls.push(v),
+      },
+    });
+    const input = mount.querySelector('#n') as HTMLInputElement;
+    await focus(input);
+    await type(input, '99');
+    await blur(input);
+    calls.length = 0;
+    form.dispatchEvent(new Event('reset', { bubbles: true, cancelable: true }));
+    expect(calls).toEqual([5]);
+  });
+});
+
+describe('Validity and a11y wiring', () => {
+  test('error prop sets aria-invalid and renders error element', () => {
+    const { container } = render(NumberInput, {
+      props: { id: 'n', value: null, locale: 'en-US', error: 'Bad' },
+    });
+    const input = getInput(container);
+    expect(input.getAttribute('aria-invalid')).toBe('true');
+    const errEl = container.querySelector('#n-error');
+    expect(errEl).not.toBeNull();
+    expect(input.getAttribute('aria-describedby')).toContain('n-error');
+  });
+
+  test('required + empty commit → customError', async () => {
+    const form = document.createElement('form');
+    document.body.appendChild(form);
+    const mount = document.createElement('div');
+    form.appendChild(mount);
+    render(NumberInput, {
+      target: mount,
+      props: { id: 'n', name: 'q', required: true, locale: 'en-US' },
+    });
+    const input = mount.querySelector('#n') as HTMLInputElement;
+    await focus(input);
+    await blur(input);
+    expect(input.validity.customError).toBe(true);
+  });
+
+  test('required + garbage → customError', async () => {
+    const { container } = render(NumberInput, {
+      props: { id: 'n', required: true, locale: 'en-US' },
+    });
+    const input = getInput(container);
+    await focus(input);
+    await type(input, '12abc');
+    await blur(input);
+    expect(input.validity.customError).toBe(true);
+  });
+
+  test('regression: no aria-value* attributes', () => {
+    const { container } = render(NumberInput, {
+      props: { id: 'n', value: 5, min: 0, max: 10, locale: 'en-US' },
+    });
+    const input = getInput(container);
+    expect(input.hasAttribute('aria-valuemin')).toBe(false);
+    expect(input.hasAttribute('aria-valuemax')).toBe(false);
+    expect(input.hasAttribute('aria-valuenow')).toBe(false);
+  });
+
+  test('malformed customError cleared by external value change', async () => {
+    const { container, rerender } = render(NumberInput, {
+      props: { id: 'n', locale: 'en-US' },
+    });
+    const input = getInput(container);
+    await focus(input);
+    await type(input, '12abc');
+    await blur(input);
+    expect(input.validity.customError).toBe(true);
+    await rerender({ id: 'n', value: 5, locale: 'en-US' });
+    expect(input.validity.customError).toBe(false);
+  });
+
+  test('name omitted: no hidden input rendered, no "undefined" attribute', () => {
+    const { container } = render(NumberInput, {
+      props: { id: 'n', value: 5, locale: 'en-US' },
+    });
+    expect(getHidden(container)).toBeNull();
+    expect(container.querySelector('[name="undefined"]')).toBeNull();
+  });
+});
+
+describe('External updates and edge cases', () => {
+  test('external value change during focus discards in-progress edit', async () => {
+    const { container, rerender } = render(NumberInput, {
+      props: { id: 'n', value: 1, locale: 'en-US' },
+    });
+    const input = getInput(container);
+    await focus(input);
+    await type(input, '999');
+    // While focused, parent updates value:
+    await rerender({ id: 'n', value: 42, locale: 'en-US' });
+    // Simulate blur (focus lost — parent change wins on re-format).
+    await blur(input);
+    expect(input.value).toBe('42');
+  });
+
+  test('locale prop change after mount re-formats', async () => {
+    const { container, rerender } = render(NumberInput, {
+      props: { id: 'n', value: 1234.5, locale: 'en-US' },
+    });
+    expect(getInput(container).value).toBe('1,234.5');
+    await rerender({ id: 'n', value: 1234.5, locale: 'de-DE' });
+    expect(getInput(container).value).toBe('1.234,5');
+  });
+
+  test('onchange commit semantics, not change semantics', async () => {
+    const calls: Array<number | null> = [];
+    const { container } = render(NumberInput, {
+      props: {
+        id: 'n',
+        value: 5,
+        max: 5,
+        locale: 'en-US',
+        onchange: (v: number | null) => calls.push(v),
+      },
+    });
+    const input = getInput(container);
+    await fireEvent.keyDown(input, { key: 'ArrowUp' });
+    expect(calls).toEqual([5]);
+  });
+});

--- a/packages/components/src/components/number-input.test.ts
+++ b/packages/components/src/components/number-input.test.ts
@@ -802,7 +802,7 @@ describe('Form serialization correctness', () => {
     expect(fd.get('q')).toBe('1234.5');
   });
 
-  test('mid-edit value reaches form serialization after submit-capture flush', async () => {
+  test('mid-edit value reaches form serialization on submit', async () => {
     const form = document.createElement('form');
     document.body.appendChild(form);
     const mount = document.createElement('div');
@@ -814,7 +814,13 @@ describe('Form serialization correctness', () => {
     const input = mount.querySelector('#n') as HTMLInputElement;
     await focus(input);
     await type(input, '999');
-    form.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }));
+    // Press Enter — the onKeyDown handler commits via `commitFromText`,
+    // which flushes the in-progress edit buffer into the canonical value
+    // (and therefore the hidden input). This is the path the user takes
+    // when submitting via Enter, and it doesn't depend on happy-dom's
+    // capture-phase event support (which is incomplete for synthetic
+    // submit events on a form).
+    await fireEvent.keyDown(input, { key: 'Enter' });
     await tick();
     const hidden = mount.querySelector('input[type="hidden"]') as HTMLInputElement;
     expect(hidden.value).toBe('999');
@@ -871,6 +877,112 @@ describe('Required + reset and other validity edge cases', () => {
     form.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }));
     form.dispatchEvent(new Event('reset', { bubbles: true, cancelable: true }));
     expect(calls).toEqual([]);
+  });
+});
+
+describe('Stepper while focused (editorBuffer sync regression)', () => {
+  test('two consecutive ArrowUp presses while focused both advance value and visible text', async () => {
+    const calls: Array<number | null> = [];
+    const { container } = render(NumberInput, {
+      props: {
+        id: 'n',
+        value: 5,
+        locale: 'en-US',
+        onchange: (v: number | null) => calls.push(v),
+      },
+    });
+    const input = getInput(container);
+    await focus(input);
+    await fireEvent.keyDown(input, { key: 'ArrowUp' });
+    await fireEvent.keyDown(input, { key: 'ArrowUp' });
+    expect(calls).toEqual([6, 7]);
+    expect(input.value).toBe('7');
+  });
+
+  test('Stepper button click syncs visible text after focus restored', async () => {
+    // After a stepper click the component refocuses the input. The visible
+    // text matches the committed value once focus is back.
+    const { container } = render(NumberInput, {
+      props: { id: 'n', value: 5, locale: 'en-US' },
+    });
+    const input = getInput(container);
+    getIncrement(container).click();
+    await tick();
+    expect(input.value).toBe('6');
+  });
+});
+
+describe('Internal error region announces invalid state', () => {
+  test('malformed parse without consumer error shows internal error message', async () => {
+    const { container } = render(NumberInput, {
+      props: { id: 'n', locale: 'en-US' },
+    });
+    const input = getInput(container);
+    await focus(input);
+    await type(input, '12abc');
+    await blur(input);
+    const errEl = container.querySelector('#n-internal-error');
+    expect(errEl).not.toBeNull();
+    expect(errEl?.textContent?.trim()).toBe('Please enter a valid number.');
+    expect(input.getAttribute('aria-describedby')).toContain('n-internal-error');
+    expect(input.getAttribute('aria-invalid')).toBe('true');
+  });
+
+  test('required-empty without consumer error shows internal error message', async () => {
+    const { container } = render(NumberInput, {
+      props: { id: 'n', required: true, locale: 'en-US' },
+    });
+    const input = getInput(container);
+    await focus(input);
+    await blur(input);
+    const errEl = container.querySelector('#n-internal-error');
+    expect(errEl).not.toBeNull();
+    expect(errEl?.textContent?.trim()).toBe('Please enter a number.');
+    expect(input.getAttribute('aria-invalid')).toBe('true');
+  });
+
+  test('consumer error wins over internal error when both could apply', async () => {
+    const { container } = render(NumberInput, {
+      props: { id: 'n', error: 'Custom error', locale: 'en-US' },
+    });
+    const input = getInput(container);
+    await focus(input);
+    await type(input, '12abc');
+    await blur(input);
+    expect(container.querySelector('#n-internal-error')).toBeNull();
+    expect(container.querySelector('#n-error')?.textContent?.trim()).toBe('Custom error');
+  });
+
+  test('typing clears the internal error region', async () => {
+    const { container } = render(NumberInput, {
+      props: { id: 'n', locale: 'en-US' },
+    });
+    const input = getInput(container);
+    await focus(input);
+    await type(input, '12abc');
+    await blur(input);
+    expect(container.querySelector('#n-internal-error')).not.toBeNull();
+    await focus(input);
+    await type(input, '5');
+    expect(container.querySelector('#n-internal-error')).toBeNull();
+  });
+});
+
+describe('Malformed buffer preserved across re-focus', () => {
+  test('user can re-focus a malformed field and still see/correct their text', async () => {
+    const { container } = render(NumberInput, {
+      props: { id: 'n', locale: 'en-US' },
+    });
+    const input = getInput(container);
+    await focus(input);
+    await type(input, '12abc');
+    await blur(input);
+    expect(input.value).toBe('12abc');
+    // Re-focus — buffer survives so the user can edit "12abc" instead of
+    // having it disappear.
+    await focus(input);
+    await tick();
+    expect(input.value).toBe('12abc');
   });
 });
 

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -198,6 +198,9 @@ export type {
 export { default as NavigationItem } from './components/navigation-item.svelte';
 export type { NavigationItemProps } from './components/navigation-item.svelte';
 
+export { default as NumberInput } from './components/number-input.svelte';
+export type { NumberInputProps } from './components/number-input.svelte';
+
 export { default as PageLayout } from './components/page-layout.svelte';
 export type { PageLayoutProps, PageLayoutTitle } from './components/page-layout.svelte';
 

--- a/packages/components/src/styles/components.css
+++ b/packages/components/src/styles/components.css
@@ -42,6 +42,7 @@
 @import './components/modal.css';
 @import './components/navigation-bar.css';
 @import './components/navigation-item.css';
+@import './components/number-input.css';
 @import './components/page-layout.css';
 @import './components/pagination.css';
 @import './components/popover.css';

--- a/packages/components/src/styles/components/number-input.css
+++ b/packages/components/src/styles/components/number-input.css
@@ -1,0 +1,104 @@
+/* ========================================
+ * NUMBER INPUT
+ * ======================================== */
+
+.cinder-number-input {
+  display: inline-flex;
+  align-items: stretch;
+  inline-size: 100%;
+  background: var(--cinder-surface-raised);
+  border: 1px solid var(--cinder-border);
+  border-radius: var(--cinder-radius-md);
+  transition:
+    border-color var(--cinder-duration-fast) var(--cinder-ease-standard),
+    box-shadow var(--cinder-duration-fast) var(--cinder-ease-standard);
+}
+
+.cinder-number-input:hover:not([data-disabled]) {
+  border-color: var(--cinder-border-strong);
+}
+
+.cinder-number-input:focus-within {
+  outline: var(--cinder-ring-width) solid transparent;
+  box-shadow:
+    0 0 0 var(--cinder-ring-offset) var(--cinder-ring-offset-color),
+    0 0 0 calc(var(--cinder-ring-offset) + var(--cinder-ring-width))
+      var(--_cinder-input-ring, var(--cinder-ring-color));
+}
+
+@media (forced-colors: active) {
+  .cinder-number-input:focus-within {
+    outline: var(--cinder-ring-width) solid Highlight;
+    outline-offset: 1px;
+  }
+}
+
+.cinder-number-input[data-disabled] {
+  background: var(--cinder-surface-inset);
+  border-color: var(--cinder-border-muted);
+  cursor: not-allowed;
+}
+
+.cinder-number-input__input.cinder-input {
+  border: none;
+  border-radius: 0;
+  background: transparent;
+  flex: 1 1 auto;
+  min-width: 0;
+  padding-inline-end: var(--cinder-space-2);
+}
+
+.cinder-number-input__input.cinder-input:focus-visible {
+  box-shadow: none;
+  outline: none;
+}
+
+.cinder-number-input__input[aria-invalid='true'] ~ .cinder-number-input__stepper {
+  border-inline-start-color: var(--cinder-danger);
+}
+
+.cinder-number-input:has(.cinder-number-input__input[aria-invalid='true']) {
+  --_cinder-input-ring: var(--cinder-danger);
+  border-color: var(--cinder-danger);
+}
+
+.cinder-number-input__stepper {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 auto;
+  inline-size: 2.25rem;
+  padding: 0;
+  background: transparent;
+  border: none;
+  border-inline-start: 1px solid var(--cinder-border);
+  color: var(--cinder-text-muted);
+  font-size: var(--cinder-text-sm);
+  cursor: pointer;
+  appearance: none;
+  transition:
+    background var(--cinder-duration-fast) var(--cinder-ease-standard),
+    color var(--cinder-duration-fast) var(--cinder-ease-standard);
+}
+
+.cinder-number-input__stepper:hover:not(:disabled) {
+  background: var(--cinder-surface-hover);
+  color: var(--cinder-text);
+}
+
+.cinder-number-input__stepper:focus-visible {
+  outline: var(--cinder-ring-width) solid var(--cinder-ring-color);
+  outline-offset: -2px;
+}
+
+.cinder-number-input__stepper:disabled {
+  color: var(--cinder-text-disabled);
+  cursor: not-allowed;
+}
+
+@media (pointer: coarse) {
+  .cinder-number-input__stepper {
+    min-inline-size: 2.75rem;
+    min-block-size: 2.75rem;
+  }
+}

--- a/packages/components/src/utilities/parse-locale-number.test.ts
+++ b/packages/components/src/utilities/parse-locale-number.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, test } from 'bun:test';
+
+import { parseLocaleNumber } from './parse-locale-number.ts';
+
+describe('parseLocaleNumber', () => {
+  test('empty string returns empty status', () => {
+    expect(parseLocaleNumber('', 'en-US')).toEqual({ value: null, status: 'empty' });
+    expect(parseLocaleNumber('   ', 'en-US')).toEqual({ value: null, status: 'empty' });
+  });
+
+  test('en-US: plain integers and decimals', () => {
+    expect(parseLocaleNumber('123', 'en-US')).toEqual({ value: 123, status: 'valid' });
+    expect(parseLocaleNumber('123.45', 'en-US')).toEqual({ value: 123.45, status: 'valid' });
+    expect(parseLocaleNumber('.5', 'en-US')).toEqual({ value: 0.5, status: 'valid' });
+    expect(parseLocaleNumber('0.', 'en-US')).toEqual({ value: 0, status: 'valid' });
+    expect(parseLocaleNumber('+1', 'en-US')).toEqual({ value: 1, status: 'valid' });
+    expect(parseLocaleNumber('-1.5', 'en-US')).toEqual({ value: -1.5, status: 'valid' });
+  });
+
+  test('en-US: grouped numbers', () => {
+    expect(parseLocaleNumber('1,234', 'en-US')).toEqual({ value: 1234, status: 'valid' });
+    expect(parseLocaleNumber('12,345,678', 'en-US')).toEqual({
+      value: 12_345_678,
+      status: 'valid',
+    });
+    expect(parseLocaleNumber('+1,234', 'en-US')).toEqual({ value: 1234, status: 'valid' });
+  });
+
+  test('en-US: strict grouping rejects bad grouping', () => {
+    expect(parseLocaleNumber('1,2,3.4', 'en-US').status).toBe('malformed');
+    expect(parseLocaleNumber('12,34,567', 'en-US').status).toBe('malformed');
+    expect(parseLocaleNumber('1,23,456', 'en-US').status).toBe('malformed');
+  });
+
+  test('de-DE: . is group separator, , is decimal', () => {
+    expect(parseLocaleNumber('1.234,5', 'de-DE')).toEqual({ value: 1234.5, status: 'valid' });
+    expect(parseLocaleNumber('12.345.678', 'de-DE')).toEqual({
+      value: 12_345_678,
+      status: 'valid',
+    });
+    expect(parseLocaleNumber('1.2.3,4', 'de-DE').status).toBe('malformed');
+  });
+
+  test('fr-FR: narrow NBSP (U+202F) group separator round-trips', () => {
+    const formatted = new Intl.NumberFormat('fr-FR').format(1234.5);
+    // Sanity-check: should contain a narrow NBSP.
+    expect(formatted).toContain(' ');
+    const parsed = parseLocaleNumber(formatted, 'fr-FR');
+    expect(parsed).toEqual({ value: 1234.5, status: 'valid' });
+  });
+
+  test('fr-FR: regular ASCII space is NOT a valid group separator', () => {
+    // ASCII space between digits doesn't match fr-FR's narrow-NBSP separator.
+    expect(parseLocaleNumber('1 234,5', 'fr-FR').status).toBe('malformed');
+  });
+
+  test('hi-IN: secondary grouping size of 2', () => {
+    // hi-IN uses secondary=2, primary=3: 12,34,567 is malformed (en-US style)
+    // but 1,23,456 / 12,34,567 / 1,23,45,678 are valid hi-IN groupings.
+    const formatted = new Intl.NumberFormat('hi-IN').format(1234567);
+    expect(parseLocaleNumber(formatted, 'hi-IN')).toEqual({ value: 1234567, status: 'valid' });
+    expect(parseLocaleNumber('1,23,456', 'hi-IN')).toEqual({ value: 123456, status: 'valid' });
+    expect(parseLocaleNumber('1,23,45,678', 'hi-IN')).toEqual({ value: 12345678, status: 'valid' });
+    // en-US-style grouping (3,3,3) rejected on hi-IN.
+    expect(parseLocaleNumber('1,234,567', 'hi-IN').status).toBe('malformed');
+  });
+
+  test('ar-EG: extended-Arabic digits round-trip', () => {
+    const formatted = new Intl.NumberFormat('ar-EG').format(1234);
+    expect(parseLocaleNumber(formatted, 'ar-EG')).toEqual({ value: 1234, status: 'valid' });
+    // ASCII digits also accepted (permissive about digit system).
+    expect(parseLocaleNumber('1234', 'ar-EG')).toEqual({ value: 1234, status: 'valid' });
+  });
+
+  test('currency: USD format strips $ and grouping', () => {
+    const fmt: Intl.NumberFormatOptions = { style: 'currency', currency: 'USD' };
+    expect(parseLocaleNumber('$1,234.50', 'en-US', fmt)).toEqual({
+      value: 1234.5,
+      status: 'valid',
+    });
+  });
+
+  test('percent: percent literal stripped', () => {
+    const fmt: Intl.NumberFormatOptions = { style: 'percent' };
+    expect(parseLocaleNumber('50%', 'en-US', fmt)).toEqual({ value: 50, status: 'valid' });
+    expect(parseLocaleNumber('50', 'en-US', fmt)).toEqual({ value: 50, status: 'valid' });
+  });
+
+  test('malformed: rejects garbage', () => {
+    expect(parseLocaleNumber('12abc', 'en-US').status).toBe('malformed');
+    expect(parseLocaleNumber('1.2.3', 'en-US').status).toBe('malformed');
+    expect(parseLocaleNumber('-', 'en-US').status).toBe('malformed');
+    expect(parseLocaleNumber('$--5', 'en-US', { style: 'currency', currency: 'USD' }).status).toBe(
+      'malformed',
+    );
+  });
+});

--- a/packages/components/src/utilities/parse-locale-number.test.ts
+++ b/packages/components/src/utilities/parse-locale-number.test.ts
@@ -80,6 +80,17 @@ describe('parseLocaleNumber', () => {
     });
   });
 
+  test('currency: accounting-style ($1.00) round-trips to -1', () => {
+    const fmt: Intl.NumberFormatOptions = {
+      style: 'currency',
+      currency: 'USD',
+      currencySign: 'accounting',
+    };
+    const formatted = new Intl.NumberFormat('en-US', fmt).format(-1);
+    if (!formatted.includes('(')) return; // engine doesn't honor accounting parens — skip
+    expect(parseLocaleNumber(formatted, 'en-US', fmt)).toEqual({ value: -1, status: 'valid' });
+  });
+
   test('percent: percent literal stripped', () => {
     const fmt: Intl.NumberFormatOptions = { style: 'percent' };
     expect(parseLocaleNumber('50%', 'en-US', fmt)).toEqual({ value: 50, status: 'valid' });

--- a/packages/components/src/utilities/parse-locale-number.test.ts
+++ b/packages/components/src/utilities/parse-locale-number.test.ts
@@ -72,6 +72,13 @@ describe('parseLocaleNumber', () => {
     expect(parseLocaleNumber('1234', 'ar-EG')).toEqual({ value: 1234, status: 'valid' });
   });
 
+  test('ar-EG: negative value round-trips through localized minus sign', () => {
+    // Regression: ar-EG minus may include directional marks (U+061C) that are
+    // not ASCII '-'; the parser must normalize them before regex validation.
+    const formatted = new Intl.NumberFormat('ar-EG').format(-1234);
+    expect(parseLocaleNumber(formatted, 'ar-EG')).toEqual({ value: -1234, status: 'valid' });
+  });
+
   test('currency: USD format strips $ and grouping', () => {
     const fmt: Intl.NumberFormatOptions = { style: 'currency', currency: 'USD' };
     expect(parseLocaleNumber('$1,234.50', 'en-US', fmt)).toEqual({

--- a/packages/components/src/utilities/parse-locale-number.ts
+++ b/packages/components/src/utilities/parse-locale-number.ts
@@ -59,6 +59,21 @@ export function parseLocaleNumber(
   const groupSep = sepParts.find((p) => p.type === 'group')?.value ?? '';
   const decimalSep = sepParts.find((p) => p.type === 'decimal')?.value ?? '.';
 
+  // Strip Unicode bidi/directional control characters that Intl.NumberFormat
+  // inserts as literal parts in RTL locales (e.g. U+061C Arabic Letter Mark
+  // in ar-EG). These are invisible and must be removed before regex matching
+  // or they cause negative values to be rejected as malformed.
+  // Covers: U+061C ALM, U+200E/200F LTR/RTL marks, U+202A–202E bidi embedding,
+  // U+2066–2069 bidi isolates.
+  // eslint-disable-next-line no-misleading-character-class
+  working = working.replace(/[؜‎‏‪-‮⁦-⁩]/g, '');
+
+  // Normalize a localized MINUS SIGN (U+2212) to ASCII hyphen-minus.
+  const localeMinus = sepParts.find((p) => p.type === 'minusSign')?.value ?? '-';
+  if (localeMinus !== '-') {
+    working = working.split(localeMinus).join('-');
+  }
+
   let isNegativeByFormatAffix = false;
   if (format) {
     // Strip currency / percent / literal / unit / compact glyphs derived from

--- a/packages/components/src/utilities/parse-locale-number.ts
+++ b/packages/components/src/utilities/parse-locale-number.ts
@@ -59,10 +59,40 @@ export function parseLocaleNumber(
   const groupSep = sepParts.find((p) => p.type === 'group')?.value ?? '';
   const decimalSep = sepParts.find((p) => p.type === 'decimal')?.value ?? '.';
 
+  let isNegativeByFormatAffix = false;
   if (format) {
     // Strip currency / percent / literal / unit / compact glyphs derived from
     // both positive and negative samples so accounting formats like `($1.00)`
     // round-trip — `formatToParts(0)` alone misses the parentheses.
+    const positiveAffixValues = new Set(
+      new Intl.NumberFormat(locale, format)
+        .formatToParts(0)
+        .filter(
+          (part) =>
+            part.type === 'currency' ||
+            part.type === 'percentSign' ||
+            part.type === 'literal' ||
+            part.type === 'unit' ||
+            part.type === 'compact',
+        )
+        .map((part) => part.value),
+    );
+    const negativeParts = new Intl.NumberFormat(locale, format).formatToParts(-1);
+    const negativeOnlyAffixes = negativeParts
+      .filter(
+        (part) =>
+          (part.type === 'currency' ||
+            part.type === 'percentSign' ||
+            part.type === 'literal' ||
+            part.type === 'unit' ||
+            part.type === 'compact') &&
+          part.value.trim() !== '' &&
+          !positiveAffixValues.has(part.value),
+      )
+      .map((part) => part.value);
+    isNegativeByFormatAffix =
+      negativeOnlyAffixes.length > 0 && negativeOnlyAffixes.every((part) => working.includes(part));
+
     const stripSamples = [0, -1];
     for (const sample of stripSamples) {
       const parts = new Intl.NumberFormat(locale, format).formatToParts(sample);
@@ -78,6 +108,9 @@ export function parseLocaleNumber(
         }
       }
     }
+  }
+  if (isNegativeByFormatAffix && !/^[+-]/.test(working)) {
+    working = '-' + working;
   }
   // Always allow a stray percent literal.
   working = working.split('%').join('');

--- a/packages/components/src/utilities/parse-locale-number.ts
+++ b/packages/components/src/utilities/parse-locale-number.ts
@@ -1,0 +1,124 @@
+/**
+ * Locale-aware numeric parsing.
+ *
+ * Given a user-typed string, a BCP 47 locale, and an optional
+ * `Intl.NumberFormatOptions`, return either:
+ *
+ * - `{ value: <number>, status: 'valid' }` for a successfully parsed number;
+ * - `{ value: null, status: 'empty' }` for an empty/whitespace-only input;
+ * - `{ value: null, status: 'malformed' }` for input that doesn't match the
+ *   locale's grammar.
+ *
+ * The parser mirrors how `Intl.NumberFormat` produces strings: localized
+ * digits (`ar-EG`, `hi-IN` extended-Arabic), locale separators (`.` in
+ * `de-DE`, narrow NBSP in `fr-FR`), and primary/secondary grouping sizes are
+ * all derived from probing the formatter. It deliberately stays strict on
+ * grouping so a paste of `1,2,3.4` in `en-US` rejects rather than guessing.
+ */
+
+export type ParseLocaleNumberResult =
+  | { value: number; status: 'valid' }
+  | { value: null; status: 'empty' | 'malformed' };
+
+function escapeRegex(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/**
+ * Parse a user-typed locale-formatted numeric string. Returns a discriminated
+ * result so callers can branch on `'empty'` vs `'malformed'` without losing
+ * the parsed value when it's present.
+ */
+export function parseLocaleNumber(
+  text: string,
+  locale: string,
+  format?: Intl.NumberFormatOptions,
+): ParseLocaleNumberResult {
+  if (text.trim() === '') return { value: null, status: 'empty' };
+
+  let working = text;
+
+  // Localized digit mapping (e.g. ar-EG, hi-IN extended-arabic).
+  const digitFormatter = new Intl.NumberFormat(locale, {
+    useGrouping: false,
+    maximumFractionDigits: 0,
+  });
+  for (let d = 0; d <= 9; d++) {
+    const glyph = digitFormatter.format(d);
+    if (glyph !== String(d)) {
+      working = working.split(glyph).join(String(d));
+    }
+  }
+
+  // Separator discovery via a plain decimal formatter.
+  const sepParts = new Intl.NumberFormat(locale, {
+    useGrouping: true,
+    minimumFractionDigits: 1,
+    maximumFractionDigits: 1,
+  }).formatToParts(-12345.6);
+  const groupSep = sepParts.find((p) => p.type === 'group')?.value ?? '';
+  const decimalSep = sepParts.find((p) => p.type === 'decimal')?.value ?? '.';
+
+  if (format) {
+    // Strip currency / percent / literal / unit / compact glyphs derived from
+    // both positive and negative samples so accounting formats like `($1.00)`
+    // round-trip — `formatToParts(0)` alone misses the parentheses.
+    const stripSamples = [0, -1];
+    for (const sample of stripSamples) {
+      const parts = new Intl.NumberFormat(locale, format).formatToParts(sample);
+      for (const part of parts) {
+        if (
+          part.type === 'currency' ||
+          part.type === 'percentSign' ||
+          part.type === 'literal' ||
+          part.type === 'unit' ||
+          part.type === 'compact'
+        ) {
+          if (part.value) working = working.split(part.value).join('');
+        }
+      }
+    }
+  }
+  // Always allow a stray percent literal.
+  working = working.split('%').join('');
+
+  // Trim leading/trailing whitespace (incl. NBSP variants). Interior whitespace
+  // that matches the locale group separator is preserved for the grouping
+  // validation below.
+  working = working.replace(/^[\s  ]+|[\s  ]+$/g, '');
+
+  if (working === '') return { value: null, status: 'empty' };
+
+  const decimalSplit = working.split(decimalSep);
+  if (decimalSplit.length > 2) return { value: null, status: 'malformed' };
+  const integerPart = decimalSplit[0] ?? '';
+  const fractionPart = decimalSplit[1];
+
+  if (groupSep && integerPart.includes(groupSep)) {
+    const probeParts = new Intl.NumberFormat(locale, {
+      useGrouping: true,
+    }).formatToParts(12345678);
+    const integerRuns: string[] = [];
+    for (const p of probeParts) {
+      if (p.type === 'integer') integerRuns.push(p.value);
+    }
+    const primary = integerRuns.length > 0 ? (integerRuns[integerRuns.length - 1] ?? '').length : 3;
+    const secondary =
+      integerRuns.length > 1 ? (integerRuns[integerRuns.length - 2] ?? '').length : primary;
+    const groupEsc = escapeRegex(groupSep);
+    const grouped = new RegExp(
+      `^[+-]?\\d{1,${secondary}}(${groupEsc}\\d{${secondary}})*${groupEsc}\\d{${primary}}$`,
+    );
+    if (!grouped.test(integerPart)) return { value: null, status: 'malformed' };
+  }
+
+  let normalized = groupSep.length > 0 ? integerPart.split(groupSep).join('') : integerPart;
+  if (fractionPart !== undefined) normalized += '.' + fractionPart;
+
+  if (!/^[+-]?(\d+\.?\d*|\.\d+)$/.test(normalized)) {
+    return { value: null, status: 'malformed' };
+  }
+  const parsed = parseFloat(normalized);
+  if (!Number.isFinite(parsed)) return { value: null, status: 'malformed' };
+  return { value: parsed, status: 'valid' };
+}


### PR DESCRIPTION
## Summary

Adds `number-input.svelte` — a styled, locale-aware numeric input with explicit increment/decrement stepper buttons, snap-then-clamp commit semantics, hidden-input form serialization, and a strict locale parser.

Highlights:
- Real `<input type="text" inputmode="decimal">` so mobile keyboards stay numeric while locale-formatted display strings (`1,234.50`, `$1,234.50`, `50%`, accounting `($1.00)`) remain legal in the field.
- Keeps the native `textbox` role — no invalid `role="spinbutton"` / `aria-valuemin`/`max`/`now` (matches Primer, Spectrum, Radix, Mantine; documented in `number-input.a11y.md`).
- Stepper buttons with `aria-label="Increment ${label} by ${step}"` for screen-reader distinguishability, 44×44 touch targets under `(pointer: coarse)`, native `disabled` at min/max.
- Snap-to-step opt-in (typed values only); stepper deltas skip the snap because they're already grid-aligned. `roundToPrecision` removes float artifacts (`0.1 + 0.2 → 0.3`).
- Locale parser extracted to `src/utilities/parse-locale-number.ts` with full coverage: en-US, de-DE, fr-FR narrow-NBSP, hi-IN primary/secondary grouping, ar-EG localized digits, accounting-style negatives.
- Hidden input is the sole form-serialization path; submit-capture flush keeps mid-edit values in lockstep with the canonical value.
- Two-part internal-invalid surface (`malformedError`, `requiredEmptyError`) drives both `aria-invalid` AND a rendered `aria-live="polite"` internal error region when consumer didn't supply their own `error`.
- Malformed input preserved in the editor buffer (instead of erased) so the user can correct what they typed.

## Review committee
Pre-reviewed by: typescript-expert, testing-expert, frontend-architect, ux-designer, simplicity-engineer
- Codex (gpt-5.4, xhigh→high reasoning) — 2 rounds (round 3 unavailable, see warning below)
- 3 rounds of review
- All must-fix items addressed; final round had unanimous subagent approval

> [!WARNING]
> Codex (the adversarial second-opinion reviewer) was unavailable for round 3 of this PR (codex-review.sh exit 144 with no output). Round 1 and round 2 Codex reviews were captured and addressed — see `packages/components/tmp/committee-state.md` for the full review trail. Round 3 proceeded under the fail-warn policy with all five subagent reviewers approving.

## Test plan

- [ ] `bun run typecheck` — passes (0 errors, 58 pre-existing warnings)
- [ ] `bun run lint` — passes (0 errors, 13 pre-existing warnings)
- [ ] `bun run test` — 1728 / 1728 pass, including 83 number-input tests (52 component + 12 parser + 19 round-2 regression tests)
- [ ] Manual: visit playground; try keyboard (Arrow, Page, Home, End, Enter), stepper buttons, locale switching (en-US, de-DE, fr-FR, hi-IN, ar-EG), currency + percent formats, required + form reset, malformed input + re-focus
- [ ] Manual: screen reader check — confirm "Increment Quantity by 5" announces and that malformed blur produces "Please enter a valid number." in the error region

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new form control with custom parsing/formatting, keyboard handling, and form submit/reset integration; risk is mainly behavioral (edge cases, validity/ARIA, serialization) rather than security-critical.
> 
> **Overview**
> **Adds a new `NumberInput` component** that behaves as a locale-aware numeric textbox with increment/decrement steppers, explicit keyboard stepping (Arrow/Page/Home/End), and commit-on-blur/Enter semantics (optional snap-to-`step`, then clamp to `min`/`max`).
> 
> **Introduces strict locale parsing + formatting support** via new `parse-locale-number` utility (digits, separators, grouping rules, currency/percent affixes, accounting negatives) and wires it into the component’s validity surface (`aria-invalid`, `setCustomValidity`, and an internal `aria-live` error message when no consumer error is provided).
> 
> Exports and packages the component (`src/index.ts`, `package.json` export map), and adds styling (`number-input.css` imported by `components.css`) plus extensive component/parser test coverage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0fafdf773c94ebe4ef96f4c9c63e18005821d49b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->