### PR TITLE
feat(callout): add inline admonition block for documentation content

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -53,6 +53,10 @@
       "svelte": "./src/components/button.svelte",
       "types": "./dist/components/button.svelte.d.ts"
     },
+    "./callout": {
+      "svelte": "./src/components/callout.svelte",
+      "types": "./dist/components/callout.svelte.d.ts"
+    },
     "./card": {
       "svelte": "./src/components/card.svelte",
       "types": "./dist/components/card.svelte.d.ts"

--- a/packages/components/src/components/alert.svelte
+++ b/packages/components/src/components/alert.svelte
@@ -36,13 +36,7 @@
 </script>
 
 {#if visible}
-  <div
-    class={cn('cinder-alert', className)}
-    data-cinder-variant={variant}
-    role="alert"
-    aria-live="polite"
-    {...rest}
-  >
+  <div class={cn('cinder-alert', className)} data-cinder-variant={variant} role="alert" {...rest}>
     {#if icon}
       <div class="cinder-alert__icon" aria-hidden="true">
         {@render icon()}

--- a/packages/components/src/components/alert.test.ts
+++ b/packages/components/src/components/alert.test.ts
@@ -149,13 +149,17 @@ describe('Alert rendering', () => {
     expect(container.querySelector('.cinder-alert__icon')).toBeNull();
   });
 
-  test('has role="alert" and aria-live="polite" on root element', () => {
+  test('has role="alert" on root element and does not set an explicit aria-live', () => {
+    // role="alert" implies aria-live="assertive" (and aria-atomic="true").
+    // Adding aria-live="polite" alongside it would conflict with the implicit
+    // assertive value, so the component leaves aria-live unset and lets
+    // assistive tech derive it from the role.
     const { container } = render(Alert, {
       props: { children: emptySnippet },
     });
     const root = container.querySelector('.cinder-alert');
     expect(root?.getAttribute('role')).toBe('alert');
-    expect(root?.getAttribute('aria-live')).toBe('polite');
+    expect(root?.hasAttribute('aria-live')).toBe(false);
   });
 
   test('default variant is "info"', () => {

--- a/packages/components/src/components/callout.a11y.md
+++ b/packages/components/src/components/callout.a11y.md
@@ -1,0 +1,125 @@
+# Callout Accessibility
+
+`callout.svelte` is an inline admonition block — the static, prose-embedded
+analog of a Markdown note / tip / warning / danger callout. It is **not** a
+live region, **not** dismissible, and does not own a heading level. The
+goal is to convey contextual guidance inline with surrounding content
+without interrupting screen-reader users or polluting the document
+outline.
+
+## Role + semantics
+
+The root element is `<aside>` with `data-cinder-variant` driving the
+variant color treatment. The component does not set an explicit `role` —
+`<aside>` carries the appropriate semantics on its own:
+
+- Directly inside `<body>`, `<main>`, or another sectioning-content
+  parent, `<aside>` is exposed as a `complementary` landmark.
+  Screen-reader landmark navigation surfaces it alongside banners,
+  navigation, and main content.
+- Inside `<article>` or `<section>`, `<aside>`'s landmark role is
+  suppressed by the HTML spec and the element behaves as generic
+  sectioning content. This is the intended placement for inline
+  documentation admonitions, where the callout is part of the prose
+  flow rather than a navigable region.
+
+This context-sensitivity is **by design**: the same component composes
+correctly both as a top-level landmark (e.g. a documentation page
+warning above the article) and as embedded prose content.
+
+## Accessible-name precedence
+
+Because `<aside>` can become a landmark depending on placement, an
+unlabeled callout at landmark level would surface as a nameless
+`complementary` region in screen-reader navigation. The component
+derives `aria-label` in three tiers, mirroring `banner.svelte`:
+
+1. If the consumer passes `aria-labelledby`, the root emits
+   `aria-labelledby` alone — the derived `aria-label` is suppressed so
+   accessible-name computation has a single unambiguous source.
+2. Else if the consumer passes `aria-label`, that value is used.
+3. Else if the `title` prop is supplied, the title text is promoted to
+   `aria-label`.
+
+When none of the three is supplied, the landmark is unnamed. That is
+intentional: a callout nested inside `<article>` or `<section>` has no
+landmark role to name anyway, and a titleless top-level callout is
+expected to be rare. Consumers placing callouts at landmark level should
+supply `title` or `aria-label`.
+
+## Why no `role="alert"` and no `aria-live`?
+
+A callout is **static** content. It is rendered alongside the
+surrounding prose at page-load time and does not change in response to
+user actions. `role="alert"` and `aria-live` are appropriate for content
+that appears or updates dynamically and needs assistive tech to announce
+it — that is what `alert.svelte` is for. Announcing a static admonition
+on every page load would be noisy and incorrect.
+
+The type-level `Omit` removes `role`, `aria-live`, `aria-atomic`,
+`aria-relevant`, and `aria-busy` from `CalloutProps`. The runtime also
+scrubs all five from rest-props before they reach the DOM, so consumers
+who escape the type system (`as never`, spread from an `unknown`
+source) cannot accidentally turn a callout into a live region or
+override the implicit `<aside>` role. This defense-in-depth pattern
+mirrors `banner.svelte`.
+
+Note: `banner.svelte` deliberately does **not** strip `aria-busy`
+because `aria-busy` is valid on `role="region"` to signal that
+landmark content is updating. Callout strips it because the
+`<aside>` root has no explicit role and `aria-busy` has no useful
+semantics there — the static design contract makes it dead weight.
+
+## Title rendered as `<p>`, not `<h*>`
+
+The optional `title` prop renders as `<p class="cinder-callout__title">`,
+**not** a heading element. This is deliberate: callouts appear inside
+existing document structure, and promoting `title` to `<h*>` would force
+the component to guess at the surrounding outline level and inject an
+entry that may not belong. If a callout genuinely participates in the
+outline (e.g. it titles a standalone section), wrap it in a `<section>`
+with its own heading rather than promoting `title`.
+
+## Icon channel
+
+When supplied, the `icon` snippet renders inside a wrapper with
+`aria-hidden="true"`. The icon is a **second visual channel** alongside
+variant color — it helps satisfy WCAG 1.4.1 (Use of Color) by ensuring
+the variant is conveyed by more than color alone. The accessible meaning
+still lives in `title` and `children`; the icon must not be the only
+carrier of information.
+
+## Variant vocabulary
+
+`CalloutVariant` is `'info' | 'success' | 'warning' | 'danger'`, sharing
+the semantic tokens (`--cinder-info`, `--cinder-success`,
+`--cinder-warning`, `--cinder-danger`) and visual algebra with
+`banner.svelte`. `alert.svelte` uses `'error'` instead of `'danger'`;
+the divergence is tracked in `banner.a11y.md`. Callout aligns with
+banner because both are landmark-class components that draw from the
+same design-token surface; alert remains separate because its
+`error` vocabulary aligns with form-validation conventions.
+
+## Forced-colors mode
+
+In Windows High Contrast Mode, the variant `background-color` and
+`color` values are overridden by system colors, so variants become
+visually similar. The component currently pins only the border to
+`CanvasText`. If the icon is supplied, its shape remains as a
+differentiator; otherwise variants are perceptually indistinguishable in
+forced-colors mode. This matches `banner.css` and is tracked as a
+shared follow-up.
+
+## When to use callout vs. banner vs. alert
+
+| Component | Position             | Trigger                      | Live region?         | Dismissible? |
+| --------- | -------------------- | ---------------------------- | -------------------- | ------------ |
+| `Callout` | Inline, inside prose | Static (page load)           | No                   | No           |
+| `Banner`  | Page-level strip     | Static or persistent         | No (`role="region"`) | Yes          |
+| `Alert`   | Anywhere             | Dynamic (response to action) | Yes (`role="alert"`) | Optional     |
+
+Use `Callout` for documentation admonitions, contextual tips alongside
+form fields, or contextual warnings inside an article. Use `Banner` for
+page-wide announcements (maintenance windows, trial expiry, cookie
+consent). Use `Alert` when assistive tech must be notified that
+something appeared or changed.

--- a/packages/components/src/components/callout.svelte
+++ b/packages/components/src/components/callout.svelte
@@ -26,12 +26,24 @@
    *
    * Callout is intentionally **not** a live region. It is static content
    * rendered as part of the document, analogous to Markdown admonitions
-   * (note / tip / warning / danger). Do not pass `role="alert"` or
-   * `aria-live` — both are excluded from the prop type.
+   * (note / tip / warning / danger). The type omits `role`, `aria-live`,
+   * `aria-atomic`, `aria-relevant`, and `aria-busy` from the underlying
+   * `HTMLAttributes` so a consumer cannot silently turn a callout into a
+   * live region. The runtime also scrubs those attributes from rest
+   * props for defense in depth — see banner.svelte for the analogous
+   * pattern.
+   *
+   * The root is `<aside>`. When placed directly inside `<body>`,
+   * `<main>`, or another sectioning landmark, `<aside>` is exposed as a
+   * `complementary` landmark; inside `<article>` or `<section>` the
+   * landmark role is suppressed and the element behaves as generic
+   * sectioning content. When the callout lands at landmark level, supply
+   * `title` (used as the accessible name) or pass `aria-label` /
+   * `aria-labelledby` so the landmark has a meaningful name.
    */
   export type CalloutProps = Omit<
     HTMLAttributes<HTMLElement>,
-    'children' | 'class' | 'role' | 'aria-live'
+    'children' | 'class' | 'role' | 'aria-live' | 'aria-atomic' | 'aria-relevant' | 'aria-busy'
   > & {
     /** Visual + semantic variant. Default `'info'`. */
     variant?: CalloutVariant;
@@ -43,6 +55,10 @@
      * callout genuinely participates in the outline (e.g. it titles a
      * standalone section), wrap it in a `<section>` with its own heading
      * rather than promoting this prop to `<h*>`.
+     *
+     * When supplied and no `aria-label` or `aria-labelledby` is passed
+     * on rest props, the title also becomes the `aria-label` of the
+     * root `<aside>` so the landmark has an accessible name.
      */
     title?: string;
     /**
@@ -78,26 +94,39 @@
     ...rest
   }: CalloutProps = $props();
 
-  // Strip live-region attributes from rest props. Callout is static
-  // content by design; allowing a consumer to bolt on `aria-live` would
-  // silently convert it into a live region and defeat the distinction
-  // documented above. Consumers that need announcements should use
-  // `alert.svelte` instead.
-  const restWithoutLiveRegion = $derived.by(() => {
+  // Strip role + live-region attributes from rest props. The type
+  // already omits these, but a consumer can escape the type system
+  // (`as never`, spread from an `unknown` source). Scrubbing at runtime
+  // guarantees the hard invariant that a callout is never announced as
+  // a live region and never overrides the implicit `<aside>` role.
+  // Mirrors banner.svelte's defense-in-depth pattern.
+  const restWithoutForbidden = $derived.by(() => {
     const {
+      role: _role,
       'aria-live': _ariaLive,
       'aria-atomic': _ariaAtomic,
       'aria-relevant': _ariaRelevant,
+      'aria-busy': _ariaBusy,
       ...filtered
     } = rest as HTMLAttributes<HTMLElement> & Record<string, unknown>;
     return filtered;
   });
+
+  // Derive an accessible name for the root `<aside>` so a callout that
+  // lands at landmark level (direct child of body / main / etc.) is not
+  // an unnamed `complementary` landmark — WCAG 2.4.1. Priority mirrors
+  // banner.svelte: consumer `aria-labelledby` > consumer `aria-label` >
+  // `title`. When none of the three is supplied, the landmark is
+  // unnamed, which is the right behavior for a callout nested inside
+  // an <article> or <section> where it carries no landmark role anyway.
+  const ariaLabel = $derived(rest['aria-labelledby'] ? undefined : (rest['aria-label'] ?? title));
 </script>
 
 <aside
-  {...restWithoutLiveRegion}
+  {...restWithoutForbidden}
   class={classNames('cinder-callout', className)}
   data-cinder-variant={variant}
+  aria-label={ariaLabel}
 >
   {#if icon}
     <div class="cinder-callout__icon" aria-hidden="true">

--- a/packages/components/src/components/callout.svelte
+++ b/packages/components/src/components/callout.svelte
@@ -1,0 +1,114 @@
+<script lang="ts" module>
+  import type { Snippet } from 'svelte';
+  import type { HTMLAttributes } from 'svelte/elements';
+
+  /**
+   * Visual + semantic variants for {@link Callout}.
+   *
+   * Matches `banner.svelte` so both components draw from the same semantic
+   * tokens (`--cinder-info`, `--cinder-success`, `--cinder-warning`,
+   * `--cinder-danger`). `alert.svelte` uses `error` instead of `danger`;
+   * that divergence is tracked in `banner.a11y.md`.
+   */
+  export type CalloutVariant = 'info' | 'success' | 'warning' | 'danger';
+
+  /**
+   * Props for the {@link Callout} component — an inline admonition block
+   * for documentation and long-form content.
+   *
+   * Callout is the static, prose-embedded sibling of:
+   *
+   * - `banner.svelte` — page-level, dismissible, `role="region"` landmark.
+   * - `alert.svelte` — dynamic notification with `role="alert"` that
+   *   announces to assistive tech when it appears or updates. Use that
+   *   component when the message is added to the page in response to a
+   *   user action and screen-reader users need to be notified.
+   *
+   * Callout is intentionally **not** a live region. It is static content
+   * rendered as part of the document, analogous to Markdown admonitions
+   * (note / tip / warning / danger). Do not pass `role="alert"` or
+   * `aria-live` — both are excluded from the prop type.
+   */
+  export type CalloutProps = Omit<
+    HTMLAttributes<HTMLElement>,
+    'children' | 'class' | 'role' | 'aria-live'
+  > & {
+    /** Visual + semantic variant. Default `'info'`. */
+    variant?: CalloutVariant;
+    /**
+     * Optional title rendered as a `<p class="cinder-callout__title">`.
+     *
+     * Rendered as a paragraph rather than a heading element so the
+     * callout does not inject an entry into the document outline. If a
+     * callout genuinely participates in the outline (e.g. it titles a
+     * standalone section), wrap it in a `<section>` with its own heading
+     * rather than promoting this prop to `<h*>`.
+     */
+    title?: string;
+    /**
+     * Optional decorative icon rendered inside an `aria-hidden` wrapper.
+     *
+     * The icon is a second visual channel alongside variant color — it
+     * helps satisfy WCAG 1.4.1 (Use of Color) by ensuring the variant is
+     * conveyed by more than color alone. The accessible meaning still
+     * lives in `title` and/or `children`; the icon must not be the only
+     * carrier of information.
+     */
+    icon?: Snippet;
+    /** Callout body content. */
+    children: Snippet;
+    /**
+     * Extra classes appended to the root element. Pass via the explicit
+     * `class` prop — it is excluded from rest-prop spread, so writing
+     * `class="x"` inside spread attributes will not reach the root.
+     */
+    class?: string;
+  };
+</script>
+
+<script lang="ts">
+  import { classNames } from '../utilities/class-names.ts';
+
+  let {
+    variant = 'info',
+    title,
+    icon,
+    class: className,
+    children,
+    ...rest
+  }: CalloutProps = $props();
+
+  // Strip live-region attributes from rest props. Callout is static
+  // content by design; allowing a consumer to bolt on `aria-live` would
+  // silently convert it into a live region and defeat the distinction
+  // documented above. Consumers that need announcements should use
+  // `alert.svelte` instead.
+  const restWithoutLiveRegion = $derived.by(() => {
+    const {
+      'aria-live': _ariaLive,
+      'aria-atomic': _ariaAtomic,
+      'aria-relevant': _ariaRelevant,
+      ...filtered
+    } = rest as HTMLAttributes<HTMLElement> & Record<string, unknown>;
+    return filtered;
+  });
+</script>
+
+<aside
+  {...restWithoutLiveRegion}
+  class={classNames('cinder-callout', className)}
+  data-cinder-variant={variant}
+>
+  {#if icon}
+    <div class="cinder-callout__icon" aria-hidden="true">
+      {@render icon()}
+    </div>
+  {/if}
+
+  <div class="cinder-callout__content">
+    {#if title}
+      <p class="cinder-callout__title">{title}</p>
+    {/if}
+    {@render children()}
+  </div>
+</aside>

--- a/packages/components/src/components/callout.svelte
+++ b/packages/components/src/components/callout.svelte
@@ -14,7 +14,8 @@
 
   /**
    * Props for the {@link Callout} component — an inline admonition block
-   * for documentation and long-form content.
+   * for documentation and long-form content. See `callout.a11y.md` for
+   * the full accessibility model.
    *
    * Callout is the static, prose-embedded sibling of:
    *

--- a/packages/components/src/components/callout.test.ts
+++ b/packages/components/src/components/callout.test.ts
@@ -137,7 +137,7 @@ describe('Callout icon', () => {
 });
 
 describe('Callout accessibility', () => {
-  test('does not set role="alert" on the root element', () => {
+  test('does not set an explicit role attribute on the root <aside>', () => {
     const { container } = render(Callout, {
       props: { children: emptySnippet },
     });
@@ -153,6 +153,17 @@ describe('Callout accessibility', () => {
     expect(root?.hasAttribute('aria-live')).toBe(false);
   });
 
+  test('strips a consumer-supplied role from rest props', () => {
+    // role is forbidden by the type, but a consumer can still escape it
+    // via `as never`. The runtime must scrub it so consumers cannot
+    // override the implicit <aside> role with role="alert" or similar.
+    const { container } = render(Callout, {
+      props: { role: 'alert', children: emptySnippet } as never,
+    });
+    const root = container.querySelector('.cinder-callout');
+    expect(root?.hasAttribute('role')).toBe(false);
+  });
+
   test('strips aria-live from consumer-supplied rest props', () => {
     const { container } = render(Callout, {
       // aria-live is intentionally forbidden by the type, but a runtime
@@ -164,17 +175,19 @@ describe('Callout accessibility', () => {
     expect(root?.hasAttribute('aria-live')).toBe(false);
   });
 
-  test('strips aria-atomic and aria-relevant from consumer rest props', () => {
+  test('strips aria-atomic, aria-relevant, and aria-busy from consumer rest props', () => {
     const { container } = render(Callout, {
       props: {
         'aria-atomic': 'true',
         'aria-relevant': 'additions',
+        'aria-busy': 'true',
         children: emptySnippet,
       } as never,
     });
     const root = container.querySelector('.cinder-callout');
     expect(root?.hasAttribute('aria-atomic')).toBe(false);
     expect(root?.hasAttribute('aria-relevant')).toBe(false);
+    expect(root?.hasAttribute('aria-busy')).toBe(false);
   });
 
   test('forwards aria-label from consumer rest props', () => {
@@ -182,5 +195,47 @@ describe('Callout accessibility', () => {
       props: { 'aria-label': 'Heads up', children: emptySnippet },
     });
     expect(container.querySelector('.cinder-callout')?.getAttribute('aria-label')).toBe('Heads up');
+  });
+});
+
+describe('Callout landmark labeling', () => {
+  test('derives aria-label from title when no consumer label is provided', () => {
+    const { container } = render(Callout, {
+      props: { title: 'Heads up', children: emptySnippet },
+    });
+    expect(container.querySelector('.cinder-callout')?.getAttribute('aria-label')).toBe('Heads up');
+  });
+
+  test('does not set aria-label when neither title nor consumer label is supplied', () => {
+    const { container } = render(Callout, {
+      props: { children: emptySnippet },
+    });
+    expect(container.querySelector('.cinder-callout')?.hasAttribute('aria-label')).toBe(false);
+  });
+
+  test('consumer-supplied aria-label overrides the title-derived label', () => {
+    const { container } = render(Callout, {
+      props: {
+        title: 'Visual title',
+        'aria-label': 'Accessible name',
+        children: emptySnippet,
+      },
+    });
+    expect(container.querySelector('.cinder-callout')?.getAttribute('aria-label')).toBe(
+      'Accessible name',
+    );
+  });
+
+  test('aria-labelledby suppresses the title-derived aria-label so the accessible name has a single source', () => {
+    const { container } = render(Callout, {
+      props: {
+        title: 'Visual title',
+        'aria-labelledby': 'external-heading',
+        children: emptySnippet,
+      },
+    });
+    const root = container.querySelector('.cinder-callout');
+    expect(root?.hasAttribute('aria-label')).toBe(false);
+    expect(root?.getAttribute('aria-labelledby')).toBe('external-heading');
   });
 });

--- a/packages/components/src/components/callout.test.ts
+++ b/packages/components/src/components/callout.test.ts
@@ -1,0 +1,186 @@
+/// <reference lib="dom" />
+import { describe, expect, test } from 'bun:test';
+import { createRawSnippet } from 'svelte';
+
+import { setupHappyDom } from '../test/happy-dom.ts';
+
+setupHappyDom();
+
+const { render } = await import('@testing-library/svelte');
+const { default: Callout } = await import('./callout.svelte');
+
+function textSnippet(text: string) {
+  return createRawSnippet(() => ({
+    render: () => `<span>${text}</span>`,
+    setup: () => {},
+  }));
+}
+
+const emptySnippet = createRawSnippet(() => ({
+  render: () => `<span></span>`,
+  setup: () => {},
+}));
+
+describe('Callout rendering', () => {
+  test('renders without errors with required props', () => {
+    const { container } = render(Callout, {
+      props: { children: emptySnippet },
+    });
+    expect(container.querySelector('.cinder-callout')).not.toBeNull();
+  });
+
+  test('root element is an <aside>', () => {
+    const { container } = render(Callout, {
+      props: { children: emptySnippet },
+    });
+    const root = container.querySelector('.cinder-callout');
+    expect(root?.tagName).toBe('ASIDE');
+  });
+
+  test('applies custom class prop while preserving cinder-callout', () => {
+    const { container } = render(Callout, {
+      props: { class: 'my-custom-class', children: emptySnippet },
+    });
+    const root = container.querySelector('.cinder-callout');
+    expect(root?.classList.contains('my-custom-class')).toBe(true);
+    expect(root?.classList.contains('cinder-callout')).toBe(true);
+  });
+
+  test('rest props are spread onto the root element', () => {
+    const { container } = render(Callout, {
+      props: { id: 'my-callout', children: emptySnippet },
+    });
+    expect(container.querySelector('#my-callout')).not.toBeNull();
+  });
+
+  test('renders body children inside the content region', () => {
+    const { container } = render(Callout, {
+      props: { children: textSnippet('Body text') },
+    });
+    expect(container.querySelector('.cinder-callout__content')?.textContent).toContain('Body text');
+  });
+});
+
+describe('Callout variants', () => {
+  for (const variant of ['info', 'success', 'warning', 'danger'] as const) {
+    test(`applies data-cinder-variant for variant "${variant}"`, () => {
+      const { container } = render(Callout, {
+        props: { variant, children: emptySnippet },
+      });
+      expect(container.querySelector('.cinder-callout')?.getAttribute('data-cinder-variant')).toBe(
+        variant,
+      );
+    });
+  }
+
+  test('defaults data-cinder-variant to "info" when variant is omitted', () => {
+    const { container } = render(Callout, {
+      props: { children: emptySnippet },
+    });
+    expect(container.querySelector('.cinder-callout')?.getAttribute('data-cinder-variant')).toBe(
+      'info',
+    );
+  });
+});
+
+describe('Callout title', () => {
+  test('renders title as a <p>, not a heading element', () => {
+    const { container } = render(Callout, {
+      props: { title: 'Heads up', children: emptySnippet },
+    });
+    const titleElement = container.querySelector('.cinder-callout__title');
+    expect(titleElement).not.toBeNull();
+    expect(titleElement?.tagName).toBe('P');
+    expect(titleElement?.textContent).toBe('Heads up');
+  });
+
+  test('omits the title element when no title prop is supplied', () => {
+    const { container } = render(Callout, {
+      props: { children: emptySnippet },
+    });
+    expect(container.querySelector('.cinder-callout__title')).toBeNull();
+  });
+
+  test('does not inject heading elements into the document outline', () => {
+    const { container } = render(Callout, {
+      props: { title: 'Heads up', children: textSnippet('Body') },
+    });
+    expect(container.querySelectorAll('h1, h2, h3, h4, h5, h6').length).toBe(0);
+  });
+});
+
+describe('Callout icon', () => {
+  test('renders icon snippet when provided', () => {
+    const { container } = render(Callout, {
+      props: { icon: textSnippet('icon-mark'), children: emptySnippet },
+    });
+    const iconWrapper = container.querySelector('.cinder-callout__icon');
+    expect(iconWrapper).not.toBeNull();
+    expect(iconWrapper?.textContent).toContain('icon-mark');
+  });
+
+  test('icon wrapper is aria-hidden', () => {
+    const { container } = render(Callout, {
+      props: { icon: textSnippet('x'), children: emptySnippet },
+    });
+    expect(container.querySelector('.cinder-callout__icon')?.getAttribute('aria-hidden')).toBe(
+      'true',
+    );
+  });
+
+  test('does not render an icon wrapper when icon prop is omitted', () => {
+    const { container } = render(Callout, {
+      props: { children: emptySnippet },
+    });
+    expect(container.querySelector('.cinder-callout__icon')).toBeNull();
+  });
+});
+
+describe('Callout accessibility', () => {
+  test('does not set role="alert" on the root element', () => {
+    const { container } = render(Callout, {
+      props: { children: emptySnippet },
+    });
+    const root = container.querySelector('.cinder-callout');
+    expect(root?.hasAttribute('role')).toBe(false);
+  });
+
+  test('does not set aria-live on the root element', () => {
+    const { container } = render(Callout, {
+      props: { children: emptySnippet },
+    });
+    const root = container.querySelector('.cinder-callout');
+    expect(root?.hasAttribute('aria-live')).toBe(false);
+  });
+
+  test('strips aria-live from consumer-supplied rest props', () => {
+    const { container } = render(Callout, {
+      // aria-live is intentionally forbidden by the type, but a runtime
+      // consumer could still pass it through spread props. The component
+      // must scrub it so callouts never accidentally become live regions.
+      props: { 'aria-live': 'polite', children: emptySnippet } as never,
+    });
+    const root = container.querySelector('.cinder-callout');
+    expect(root?.hasAttribute('aria-live')).toBe(false);
+  });
+
+  test('strips aria-atomic and aria-relevant from consumer rest props', () => {
+    const { container } = render(Callout, {
+      props: {
+        'aria-atomic': 'true',
+        'aria-relevant': 'additions',
+        children: emptySnippet,
+      } as never,
+    });
+    const root = container.querySelector('.cinder-callout');
+    expect(root?.hasAttribute('aria-atomic')).toBe(false);
+    expect(root?.hasAttribute('aria-relevant')).toBe(false);
+  });
+
+  test('forwards aria-label from consumer rest props', () => {
+    const { container } = render(Callout, {
+      props: { 'aria-label': 'Heads up', children: emptySnippet },
+    });
+    expect(container.querySelector('.cinder-callout')?.getAttribute('aria-label')).toBe('Heads up');
+  });
+});

--- a/packages/components/src/components/callout.type-test.ts
+++ b/packages/components/src/components/callout.type-test.ts
@@ -23,11 +23,9 @@ const _ariaLiveRejected: CalloutProps = { children: noopChildren, 'aria-live': '
 // @ts-expect-error - aria-atomic is excluded from CalloutProps
 const _ariaAtomicRejected: CalloutProps = { children: noopChildren, 'aria-atomic': 'true' };
 
+// prettier-ignore
 // @ts-expect-error - aria-relevant is excluded from CalloutProps
-const _ariaRelevantRejected: CalloutProps = {
-  children: noopChildren,
-  'aria-relevant': 'additions',
-};
+const _ariaRelevantRejected: CalloutProps = { children: noopChildren, 'aria-relevant': 'additions' };
 
 // @ts-expect-error - aria-busy is excluded from CalloutProps
 const _ariaBusyRejected: CalloutProps = { children: noopChildren, 'aria-busy': 'true' };
@@ -36,11 +34,9 @@ const _ariaBusyRejected: CalloutProps = { children: noopChildren, 'aria-busy': '
 // landmark when the callout lands at a landmark position.
 const _ariaLabelAccepted: CalloutProps = { children: noopChildren, 'aria-label': 'Note' };
 
+// prettier-ignore
 // aria-labelledby is similarly allowed and takes precedence over title.
-const _ariaLabelledByAccepted: CalloutProps = {
-  children: noopChildren,
-  'aria-labelledby': 'external-heading',
-};
+const _ariaLabelledByAccepted: CalloutProps = { children: noopChildren, 'aria-labelledby': 'external-heading' };
 
 void _roleRejected;
 void _ariaLiveRejected;

--- a/packages/components/src/components/callout.type-test.ts
+++ b/packages/components/src/components/callout.type-test.ts
@@ -1,0 +1,51 @@
+/**
+ * Compile-time regression tests for CalloutProps.
+ * svelte-check processes this file; tsc does not (it excludes .svelte imports).
+ * These verify that the prop type's `Omit` list keeps semantically forbidden
+ * attributes off the public surface — callout must never be a live region or
+ * override the implicit <aside> role.
+ */
+import type { Snippet } from 'svelte';
+
+import type { CalloutProps } from './callout.svelte';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const noopChildren = null as any as Snippet;
+
+// role is owned by the component (<aside>) and must not be overridable.
+// @ts-expect-error - role is excluded from CalloutProps
+const _roleRejected: CalloutProps = { children: noopChildren, role: 'alert' };
+
+// Callout is static; live-region attributes must not reach the type surface.
+// @ts-expect-error - aria-live is excluded from CalloutProps
+const _ariaLiveRejected: CalloutProps = { children: noopChildren, 'aria-live': 'polite' };
+
+// @ts-expect-error - aria-atomic is excluded from CalloutProps
+const _ariaAtomicRejected: CalloutProps = { children: noopChildren, 'aria-atomic': 'true' };
+
+// @ts-expect-error - aria-relevant is excluded from CalloutProps
+const _ariaRelevantRejected: CalloutProps = {
+  children: noopChildren,
+  'aria-relevant': 'additions',
+};
+
+// @ts-expect-error - aria-busy is excluded from CalloutProps
+const _ariaBusyRejected: CalloutProps = { children: noopChildren, 'aria-busy': 'true' };
+
+// aria-label remains a valid prop — consumers must be able to label the
+// landmark when the callout lands at a landmark position.
+const _ariaLabelAccepted: CalloutProps = { children: noopChildren, 'aria-label': 'Note' };
+
+// aria-labelledby is similarly allowed and takes precedence over title.
+const _ariaLabelledByAccepted: CalloutProps = {
+  children: noopChildren,
+  'aria-labelledby': 'external-heading',
+};
+
+void _roleRejected;
+void _ariaLiveRejected;
+void _ariaAtomicRejected;
+void _ariaRelevantRejected;
+void _ariaBusyRejected;
+void _ariaLabelAccepted;
+void _ariaLabelledByAccepted;

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -25,6 +25,9 @@ export type { ButtonProps, ButtonSize, ButtonVariant } from './components/button
 export { default as ButtonGroup } from './components/button-group.svelte';
 export type { ButtonGroupOrientation, ButtonGroupProps } from './components/button-group.svelte';
 
+export { default as Callout } from './components/callout.svelte';
+export type { CalloutProps, CalloutVariant } from './components/callout.svelte';
+
 export { default as Card } from './components/card.svelte';
 export type { CardProps } from './components/card.svelte';
 

--- a/packages/components/src/styles/components.css
+++ b/packages/components/src/styles/components.css
@@ -13,6 +13,7 @@
 @import './components/breadcrumbs.css';
 @import './components/button.css';
 @import './components/button-group.css';
+@import './components/callout.css';
 @import './components/card.css';
 @import './components/chip.css';
 @import './components/checkbox.css';

--- a/packages/components/src/styles/components/callout.css
+++ b/packages/components/src/styles/components/callout.css
@@ -1,0 +1,159 @@
+/* ========================================
+ * CALLOUT
+ * ----------------------------------------
+ * Inline admonition block embedded in document or section content. Static
+ * content — not dismissible, not a live region. The visual treatment
+ * mirrors `banner.css` (same semantic tokens, same variant color algebra)
+ * but the layout is sized to sit inside a prose column rather than
+ * stretch full-width like a banner.
+ *
+ * Distinct from:
+ *   - banner: page-level strip, dismissible, role="region".
+ *   - alert: dynamic notification card, role="alert".
+ * ======================================== */
+
+.cinder-callout {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--cinder-space-3);
+  inline-size: 100%;
+  padding-block: var(--cinder-space-3);
+  padding-inline: var(--cinder-space-4);
+  border: 1px solid var(--cinder-border);
+  border-radius: var(--cinder-radius-md);
+  background: var(--cinder-surface);
+  color: var(--cinder-text);
+  font-size: var(--cinder-text-sm);
+  line-height: var(--cinder-leading-normal);
+}
+
+/* ----------------------------------------
+ * Icon channel
+ * Decorative; the icon is the second WCAG 1.4.1 channel alongside color.
+ * The accessible meaning still lives in the title and body, so the icon
+ * is wrapped in aria-hidden in the markup.
+ * ---------------------------------------- */
+
+.cinder-callout__icon {
+  flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.25rem;
+  height: 1.25rem;
+  margin-block-start: 0.125rem;
+  color: inherit;
+}
+
+.cinder-callout__icon > svg {
+  width: 100%;
+  height: 100%;
+}
+
+/* ----------------------------------------
+ * Content area
+ * ---------------------------------------- */
+
+.cinder-callout__content {
+  flex: 1;
+  min-width: 0;
+}
+
+/* ----------------------------------------
+ * Title
+ * Rendered as <p>, not <h*>, so callouts don't inject entries into the
+ * document outline. See callout.svelte JSDoc.
+ * ---------------------------------------- */
+
+.cinder-callout__title {
+  margin: 0 0 var(--cinder-space-1);
+  font-weight: var(--cinder-font-weight-semibold, 600);
+  line-height: var(--cinder-leading-snug, 1.3);
+  color: inherit;
+}
+
+/* ----------------------------------------
+ * Variant: info
+ * ---------------------------------------- */
+
+.cinder-callout[data-cinder-variant='info'] {
+  background-color: light-dark(
+    oklch(from var(--cinder-info) 96.5% 0.015 h),
+    oklch(from var(--cinder-info) 20% 0.03 h)
+  );
+  border-color: light-dark(
+    oklch(from var(--cinder-info) 85% 0.05 h),
+    oklch(from var(--cinder-info) 35% 0.08 h)
+  );
+  color: light-dark(
+    oklch(from var(--cinder-info) 35% 0.12 h),
+    oklch(from var(--cinder-info) 88% 0.12 h)
+  );
+}
+
+/* ----------------------------------------
+ * Variant: success
+ * ---------------------------------------- */
+
+.cinder-callout[data-cinder-variant='success'] {
+  background-color: light-dark(
+    oklch(from var(--cinder-success) 96.5% 0.015 h),
+    oklch(from var(--cinder-success) 20% 0.03 h)
+  );
+  border-color: light-dark(
+    oklch(from var(--cinder-success) 85% 0.05 h),
+    oklch(from var(--cinder-success) 35% 0.08 h)
+  );
+  color: light-dark(
+    oklch(from var(--cinder-success) 35% 0.14 h),
+    oklch(from var(--cinder-success) 88% 0.12 h)
+  );
+}
+
+/* ----------------------------------------
+ * Variant: warning
+ * ---------------------------------------- */
+
+.cinder-callout[data-cinder-variant='warning'] {
+  background-color: light-dark(
+    oklch(from var(--cinder-warning) 96.5% 0.015 h),
+    oklch(from var(--cinder-warning) 20% 0.03 h)
+  );
+  border-color: light-dark(
+    oklch(from var(--cinder-warning) 85% 0.05 h),
+    oklch(from var(--cinder-warning) 35% 0.08 h)
+  );
+  color: light-dark(
+    oklch(from var(--cinder-warning) 35% 0.16 h),
+    oklch(from var(--cinder-warning) 88% 0.14 h)
+  );
+}
+
+/* ----------------------------------------
+ * Variant: danger
+ * ---------------------------------------- */
+
+.cinder-callout[data-cinder-variant='danger'] {
+  background-color: light-dark(
+    oklch(from var(--cinder-danger) 96.5% 0.015 h),
+    oklch(from var(--cinder-danger) 20% 0.03 h)
+  );
+  border-color: light-dark(
+    oklch(from var(--cinder-danger) 85% 0.05 h),
+    oklch(from var(--cinder-danger) 35% 0.08 h)
+  );
+  color: light-dark(
+    oklch(from var(--cinder-danger) 35% 0.18 h),
+    oklch(from var(--cinder-danger) 88% 0.16 h)
+  );
+}
+
+/* ----------------------------------------
+ * Forced-colors / high-contrast
+ * ---------------------------------------- */
+
+@media (forced-colors: active) {
+  .cinder-callout {
+    border: 1px solid CanvasText;
+  }
+}


### PR DESCRIPTION
## Summary

Adds `callout.svelte`, a static prose-embedded admonition analogous to
Markdown note/tip/warning/danger callouts. Rendered as `<aside>` with
`data-cinder-variant` driving variant color via the same semantic tokens
shared with `banner.svelte` (`--cinder-info` / `--cinder-success` /
`--cinder-warning` / `--cinder-danger`).

The component intentionally avoids `role="alert"` and `aria-live`. The
type omits `role`, `aria-live`, `aria-atomic`, `aria-relevant`, and
`aria-busy`; the runtime scrubs all five from spread props as defense
in depth so a consumer cannot silently turn a callout into a live
region or override the implicit `<aside>` role.

The optional `title` renders as a `<p>` (not a heading) so callouts
never inject entries into the document outline. When supplied and no
consumer-provided `aria-label`/`aria-labelledby` exists, the title also
becomes the `aria-label` of the root `<aside>` — this keeps the
`complementary` landmark labeled when the callout lands at landmark
level (WCAG 2.4.1). Priority mirrors banner.svelte:
`aria-labelledby` > `aria-label` > `title`.

The optional `icon` snippet is wrapped in `aria-hidden="true"` — it's
a second WCAG 1.4.1 channel alongside variant color, but the title and
body carry the accessible meaning.

`callout.a11y.md` documents the full accessibility model: context-
sensitive `<aside>` semantics, accessible-name precedence, the
deliberate `aria-busy` asymmetry vs `banner.svelte` (banner keeps it
because it is valid on `role="region"`; callout strips it because the
`<aside>` root has no explicit role), title-as-`<p>` rationale, icon
channel, variant vocabulary, forced-colors handling, and a comparison
table for callout / banner / alert.

Alert reconciliation: `role="alert"` already implies
`aria-live="assertive"` (and `aria-atomic="true"`). Setting
`aria-live="polite"` alongside it conflicted with that implicit value,
so this PR also removes the redundant `aria-live="polite"` from
`alert.svelte` and updates the corresponding test.

## Review committee

Pre-reviewed by: typescript-expert, testing-expert, frontend-architect,
ux-designer, simplicity-engineer, junior-engineer.
- Codex (gpt-5.4, xhigh reasoning) — 3 rounds.
- 3 rounds of review; unanimous approval in round 3.
- All must-fix items addressed in commits `639147b` (round 1) and `1865edc` (round 2).

Deferred follow-ups (recorded in `tmp/committee-state.md`):
- Joint banner+callout warning-variant WCAG contrast audit (same OKLCH algebra; flagged as potential, not measured).
- Forced-colors variant differentiation across banner+callout (shared gap).
- Alert.svelte `cn` → `classNames` import cleanup (scope creep on this PR; both names export from utilities/class-names.ts).

Closes scrumlord task `0081c025-19c7-4662-b9df-b890f2f53a51`.

## Test plan

- [x] `bun test --conditions browser` — full suite (1671 tests) passes locally.
- [x] New `callout.test.ts` (26 tests) covers rendering, all four variants,
      title/icon optional rendering, all aria-* runtime scrubs (role, aria-live,
      aria-atomic, aria-relevant, aria-busy), and the four aria-label derivation
      branches (title-derived, no-label, consumer-label-overrides-title,
      aria-labelledby-suppresses-label).
- [x] `callout.type-test.ts` proves `Omit` rejects role, aria-live, aria-atomic,
      aria-relevant, aria-busy at compile time via `@ts-expect-error`, and proves
      aria-label / aria-labelledby remain valid props.
- [x] `alert.test.ts` updated to assert `aria-live` is no longer set explicitly
      on the root.
- [x] `bun run typecheck` clean.
- [x] `bun run lint` clean (no new warnings; pre-existing warnings unchanged).
- [x] `package.json` `./callout` subpath export added; `exports-drift` test
      passes after regenerating exports.
- [ ] CI green on PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly additive UI component work with extensive tests; the only behavioral change is removing explicit `aria-live` from `Alert`, which could affect assistive-tech announcement behavior but should align with ARIA defaults for `role="alert"`.
> 
> **Overview**
> Introduces **`Callout`**, a new static inline admonition component rendered as an `<aside>` with `info|success|warning|danger` variants, optional `title` and decorative `icon`, and **defense-in-depth a11y constraints** (type-level omission + runtime scrubbing of `role`/live-region `aria-*`).
> 
> Exports `Callout` via the package `exports` map and `src/index.ts`, wires in new `callout.css` via the components stylesheet aggregator, and adds comprehensive runtime + type regression tests plus `callout.a11y.md` documentation.
> 
> Separately updates `Alert` to **stop setting explicit `aria-live`** on the root (relying on `role="alert"` implied semantics) and adjusts the corresponding test.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1865edcd7577c6747057813d7c017ada61c4aafc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->