### PR TITLE
feat(status-dot): add semantic status indicator with label

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -313,6 +313,10 @@
       "svelte": "./src/components/stat.svelte",
       "types": "./dist/components/stat.svelte.d.ts"
     },
+    "./status-dot": {
+      "svelte": "./src/components/status-dot.svelte",
+      "types": "./dist/components/status-dot.svelte.d.ts"
+    },
     "./steps": {
       "svelte": "./src/components/steps.svelte",
       "types": "./dist/components/steps.svelte.d.ts"

--- a/packages/components/src/components/status-dot.svelte
+++ b/packages/components/src/components/status-dot.svelte
@@ -53,18 +53,14 @@
     ...rest
   }: StatusDotProps = $props();
 
-  const hasLabelText = $derived(label !== undefined && label.length > 0);
+  const normalizedAriaLabel = $derived(ariaLabel?.trim() ? ariaLabel.trim() : undefined);
+  const normalizedLabel = $derived(label?.trim() ? label.trim() : undefined);
+  const hasLabelText = $derived(normalizedLabel !== undefined);
   const hasVisibleLabel = $derived(showLabel && hasLabelText);
 
-  // Accessible-name priority: non-empty consumer override → label text (even
-  // when hidden) → raw status token. An empty-string `aria-label` is treated
-  // as "no override" rather than blanking the accessible name. When a visible
-  // label is rendered we omit `aria-label` so the label text itself becomes
-  // the accessible name.
-  const resolvedAriaLabel = $derived(
-    (ariaLabel ? ariaLabel : undefined) ??
-      (hasVisibleLabel ? undefined : hasLabelText ? label : status),
-  );
+  // `role="img"` needs an author-provided name. Blank labels are treated as
+  // absent so status is never communicated by color alone.
+  const resolvedAriaLabel = $derived(normalizedAriaLabel ?? normalizedLabel ?? status);
 </script>
 
 <!--

--- a/packages/components/src/components/status-dot.svelte
+++ b/packages/components/src/components/status-dot.svelte
@@ -1,0 +1,74 @@
+<script lang="ts" module>
+  import type { HTMLAttributes } from 'svelte/elements';
+
+  /**
+   * Semantic status values understood by {@link StatusDot}.
+   *
+   * The string values are stamped onto the root as `data-cinder-status` and
+   * drive color exclusively via CSS — there are no hard-coded color classes
+   * on the component. The token mapping (e.g. `online` → `--cinder-success`,
+   * `error` → `--cinder-danger`) lives in `status-dot.css` so consumers can
+   * theme without forking the component.
+   *
+   * Exported so host components (e.g. `stacked-list-item.svelte`) can type
+   * their own `status` prop against this union rather than restating it.
+   */
+  export type StatusDotStatus = 'online' | 'offline' | 'warning' | 'error' | 'building' | 'neutral';
+
+  export type StatusDotSize = 'sm' | 'md';
+
+  /**
+   * Props for {@link StatusDot}.
+   *
+   * `aria-label` is excluded from the spread HTML attributes because the
+   * component manages the accessible name itself: if `showLabel` is `false`
+   * or no `label` is provided, the root receives `aria-label={status}` so
+   * the status is not communicated by color alone (WCAG 1.4.1). A consumer
+   * can still override that label by passing one explicitly.
+   */
+  export type StatusDotProps = Omit<HTMLAttributes<HTMLSpanElement>, 'class'> & {
+    /** Required semantic status. Drives color via `data-cinder-status`. */
+    status: StatusDotStatus;
+    /** Optional human label shown next to the dot. */
+    label?: string;
+    /** Whether to render the visible label. Default `true`. */
+    showLabel?: boolean;
+    /** Dot size. Default `'md'`. */
+    size?: StatusDotSize;
+    /** Extra classes appended to the root element. */
+    class?: string;
+  };
+</script>
+
+<script lang="ts">
+  import { classNames } from '../utilities/class-names.ts';
+
+  let {
+    status,
+    label,
+    showLabel = true,
+    size = 'md',
+    class: className,
+    ...rest
+  }: StatusDotProps = $props();
+
+  const hasVisibleLabel = $derived(showLabel && label !== undefined && label.length > 0);
+
+  // When no visible label is rendered the dot would communicate the state by
+  // color alone, so fall back to `aria-label={status}`. A consumer-supplied
+  // `aria-label` wins over the automatic one.
+  const resolvedAriaLabel = $derived(rest['aria-label'] ?? (hasVisibleLabel ? undefined : status));
+</script>
+
+<span
+  {...rest}
+  class={classNames('cinder-status-dot', className)}
+  data-cinder-status={status}
+  data-cinder-size={size}
+  aria-label={resolvedAriaLabel}
+>
+  <span class="cinder-status-dot__indicator" aria-hidden="true"></span>
+  {#if hasVisibleLabel}
+    <span class="cinder-status-dot__label">{label}</span>
+  {/if}
+</span>

--- a/packages/components/src/components/status-dot.svelte
+++ b/packages/components/src/components/status-dot.svelte
@@ -56,20 +56,33 @@
   const hasLabelText = $derived(label !== undefined && label.length > 0);
   const hasVisibleLabel = $derived(showLabel && hasLabelText);
 
-  // Accessible-name priority: consumer override → label text (even when hidden)
-  // → raw status token. Omitting `aria-label` when a visible label is rendered
-  // lets the label text itself serve as the accessible name.
+  // Accessible-name priority: non-empty consumer override → label text (even
+  // when hidden) → raw status token. An empty-string `aria-label` is treated
+  // as "no override" rather than blanking the accessible name. When a visible
+  // label is rendered we omit `aria-label` so the label text itself becomes
+  // the accessible name.
   const resolvedAriaLabel = $derived(
-    ariaLabel ?? (hasVisibleLabel ? undefined : hasLabelText ? label : status),
+    (ariaLabel ? ariaLabel : undefined) ??
+      (hasVisibleLabel ? undefined : hasLabelText ? label : status),
   );
 </script>
 
+<!--
+  `role="img"` (not `role="status"`) because StatusDot is a static decorative
+  indicator that can appear many times in a single view (e.g. one per row in a
+  list). `role="status"` is an ARIA polite live region: when injected into an
+  already-rendered DOM (paginated tables, virtualized lists) it can cause
+  screen readers to announce each dot as it mounts. `role="img"` declares the
+  element as a graphic with an accessible name supplied via `aria-label`,
+  which is the semantically correct choice for a non-changing visual state
+  badge.
+-->
 <span
   {...rest}
   class={classNames('cinder-status-dot', className)}
   data-cinder-status={status}
   data-cinder-size={size}
-  role="status"
+  role="img"
   aria-label={resolvedAriaLabel}
 >
   <span class="cinder-status-dot__indicator" aria-hidden="true"></span>

--- a/packages/components/src/components/status-dot.svelte
+++ b/packages/components/src/components/status-dot.svelte
@@ -20,16 +20,16 @@
   /**
    * Props for {@link StatusDot}.
    *
-   * `aria-label` is excluded from the spread HTML attributes because the
-   * component manages the accessible name itself: if `showLabel` is `false`
-   * or no `label` is provided, the root receives `aria-label={status}` so
-   * the status is not communicated by color alone (WCAG 1.4.1). A consumer
-   * can still override that label by passing one explicitly.
+   * The component manages the accessible name itself so the status is never
+   * communicated by color alone (WCAG 1.4.1): the visible label text wins,
+   * then a hidden but provided `label`, then the raw `status` token. A
+   * consumer-supplied `aria-label` always takes priority over the automatic
+   * fallback.
    */
   export type StatusDotProps = Omit<HTMLAttributes<HTMLSpanElement>, 'class'> & {
     /** Required semantic status. Drives color via `data-cinder-status`. */
     status: StatusDotStatus;
-    /** Optional human label shown next to the dot. */
+    /** Optional human label. Rendered visibly when `showLabel` is true; used as the accessible name either way. */
     label?: string;
     /** Whether to render the visible label. Default `true`. */
     showLabel?: boolean;
@@ -49,15 +49,19 @@
     showLabel = true,
     size = 'md',
     class: className,
+    'aria-label': ariaLabel,
     ...rest
   }: StatusDotProps = $props();
 
-  const hasVisibleLabel = $derived(showLabel && label !== undefined && label.length > 0);
+  const hasLabelText = $derived(label !== undefined && label.length > 0);
+  const hasVisibleLabel = $derived(showLabel && hasLabelText);
 
-  // When no visible label is rendered the dot would communicate the state by
-  // color alone, so fall back to `aria-label={status}`. A consumer-supplied
-  // `aria-label` wins over the automatic one.
-  const resolvedAriaLabel = $derived(rest['aria-label'] ?? (hasVisibleLabel ? undefined : status));
+  // Accessible-name priority: consumer override → label text (even when hidden)
+  // → raw status token. Omitting `aria-label` when a visible label is rendered
+  // lets the label text itself serve as the accessible name.
+  const resolvedAriaLabel = $derived(
+    ariaLabel ?? (hasVisibleLabel ? undefined : hasLabelText ? label : status),
+  );
 </script>
 
 <span
@@ -65,6 +69,7 @@
   class={classNames('cinder-status-dot', className)}
   data-cinder-status={status}
   data-cinder-size={size}
+  role="status"
   aria-label={resolvedAriaLabel}
 >
   <span class="cinder-status-dot__indicator" aria-hidden="true"></span>

--- a/packages/components/src/components/status-dot.svelte
+++ b/packages/components/src/components/status-dot.svelte
@@ -83,6 +83,6 @@
 >
   <span class="cinder-status-dot__indicator" aria-hidden="true"></span>
   {#if hasVisibleLabel}
-    <span class="cinder-status-dot__label">{label}</span>
+    <span class="cinder-status-dot__label">{normalizedLabel}</span>
   {/if}
 </span>

--- a/packages/components/src/components/status-dot.test.ts
+++ b/packages/components/src/components/status-dot.test.ts
@@ -1,0 +1,135 @@
+/// <reference lib="dom" />
+import { describe, expect, test } from 'bun:test';
+
+import { setupHappyDom } from '../test/happy-dom.ts';
+
+setupHappyDom();
+
+const { render } = await import('@testing-library/svelte');
+const { default: StatusDot } = await import('./status-dot.svelte');
+
+const ALL_STATUSES = ['online', 'offline', 'warning', 'error', 'building', 'neutral'] as const;
+
+describe('StatusDot rendering', () => {
+  test('renders the root with cinder-status-dot class', () => {
+    const { container } = render(StatusDot, { props: { status: 'online' } });
+    expect(container.querySelector('.cinder-status-dot')).not.toBeNull();
+  });
+
+  test('renders an aria-hidden indicator dot', () => {
+    const { container } = render(StatusDot, { props: { status: 'online' } });
+    const indicator = container.querySelector('.cinder-status-dot__indicator');
+    expect(indicator).not.toBeNull();
+    expect(indicator?.getAttribute('aria-hidden')).toBe('true');
+  });
+
+  test('applies custom class alongside cinder-status-dot', () => {
+    const { container } = render(StatusDot, {
+      props: { status: 'online', class: 'my-custom-class' },
+    });
+    const root = container.querySelector('.cinder-status-dot');
+    expect(root?.classList.contains('cinder-status-dot')).toBe(true);
+    expect(root?.classList.contains('my-custom-class')).toBe(true);
+  });
+
+  test('rest props are spread onto the root element', () => {
+    const { container } = render(StatusDot, {
+      props: { status: 'online', id: 'my-status' },
+    });
+    expect(container.querySelector('#my-status')).not.toBeNull();
+  });
+
+  test('defaults data-cinder-size to "md" when size is omitted', () => {
+    const { container } = render(StatusDot, { props: { status: 'online' } });
+    expect(container.querySelector('.cinder-status-dot')?.getAttribute('data-cinder-size')).toBe(
+      'md',
+    );
+  });
+
+  test.each(['sm', 'md'] as const)('applies data-cinder-size="%s"', (size) => {
+    const { container } = render(StatusDot, { props: { status: 'online', size } });
+    expect(container.querySelector('.cinder-status-dot')?.getAttribute('data-cinder-size')).toBe(
+      size,
+    );
+  });
+});
+
+describe('StatusDot status attribute (color via CSS)', () => {
+  test.each(ALL_STATUSES.map((status) => [status] as const))(
+    'renders data-cinder-status="%s"',
+    (status) => {
+      const { container } = render(StatusDot, { props: { status } });
+      expect(
+        container.querySelector('.cinder-status-dot')?.getAttribute('data-cinder-status'),
+      ).toBe(status);
+    },
+  );
+
+  test('does not apply inline color styles — color is driven by CSS only', () => {
+    const { container } = render(StatusDot, { props: { status: 'online' } });
+    const root = container.querySelector<HTMLElement>('.cinder-status-dot');
+    const indicator = container.querySelector<HTMLElement>('.cinder-status-dot__indicator');
+    expect(root?.getAttribute('style')).toBeNull();
+    expect(indicator?.getAttribute('style')).toBeNull();
+  });
+});
+
+describe('StatusDot label rendering', () => {
+  test('renders the visible label when label is provided and showLabel defaults to true', () => {
+    const { container } = render(StatusDot, {
+      props: { status: 'online', label: 'Online' },
+    });
+    const label = container.querySelector('.cinder-status-dot__label');
+    expect(label).not.toBeNull();
+    expect(label?.textContent).toBe('Online');
+  });
+
+  test('omits the visible label when showLabel is false', () => {
+    const { container } = render(StatusDot, {
+      props: { status: 'online', label: 'Online', showLabel: false },
+    });
+    expect(container.querySelector('.cinder-status-dot__label')).toBeNull();
+  });
+
+  test('omits the visible label when no label is provided', () => {
+    const { container } = render(StatusDot, { props: { status: 'online' } });
+    expect(container.querySelector('.cinder-status-dot__label')).toBeNull();
+  });
+
+  test('omits the visible label when label is an empty string', () => {
+    const { container } = render(StatusDot, { props: { status: 'online', label: '' } });
+    expect(container.querySelector('.cinder-status-dot__label')).toBeNull();
+  });
+});
+
+describe('StatusDot accessible name (WCAG 1.4.1)', () => {
+  test('adds aria-label={status} when no visible label is rendered', () => {
+    const { container } = render(StatusDot, { props: { status: 'error' } });
+    expect(container.querySelector('.cinder-status-dot')?.getAttribute('aria-label')).toBe('error');
+  });
+
+  test('adds aria-label={status} when showLabel is false even if label is set', () => {
+    const { container } = render(StatusDot, {
+      props: { status: 'warning', label: 'Degraded', showLabel: false },
+    });
+    expect(container.querySelector('.cinder-status-dot')?.getAttribute('aria-label')).toBe(
+      'warning',
+    );
+  });
+
+  test('omits aria-label when a visible label is rendered (label text is the accessible name)', () => {
+    const { container } = render(StatusDot, {
+      props: { status: 'online', label: 'Online' },
+    });
+    expect(container.querySelector('.cinder-status-dot')?.getAttribute('aria-label')).toBeNull();
+  });
+
+  test('consumer-supplied aria-label overrides the automatic fallback', () => {
+    const { container } = render(StatusDot, {
+      props: { status: 'building', 'aria-label': 'Deployment in progress' },
+    });
+    expect(container.querySelector('.cinder-status-dot')?.getAttribute('aria-label')).toBe(
+      'Deployment in progress',
+    );
+  });
+});

--- a/packages/components/src/components/status-dot.test.ts
+++ b/packages/components/src/components/status-dot.test.ts
@@ -55,15 +55,12 @@ describe('StatusDot rendering', () => {
 });
 
 describe('StatusDot status attribute (color via CSS)', () => {
-  test.each(ALL_STATUSES.map((status) => [status] as const))(
-    'renders data-cinder-status="%s"',
-    (status) => {
-      const { container } = render(StatusDot, { props: { status } });
-      expect(
-        container.querySelector('.cinder-status-dot')?.getAttribute('data-cinder-status'),
-      ).toBe(status);
-    },
-  );
+  test.each(ALL_STATUSES.map((status) => [status]))('renders data-cinder-status="%s"', (status) => {
+    const { container } = render(StatusDot, { props: { status } });
+    expect(container.querySelector('.cinder-status-dot')?.getAttribute('data-cinder-status')).toBe(
+      status,
+    );
+  });
 
   test('does not apply inline color styles — color is driven by CSS only', () => {
     const { container } = render(StatusDot, { props: { status: 'online' } });
@@ -103,14 +100,35 @@ describe('StatusDot label rendering', () => {
 });
 
 describe('StatusDot accessible name (WCAG 1.4.1)', () => {
-  test('adds aria-label={status} when no visible label is rendered', () => {
+  test('root has role="status" so assistive tech exposes the accessible name', () => {
+    const { container } = render(StatusDot, { props: { status: 'online' } });
+    expect(container.querySelector('.cinder-status-dot')?.getAttribute('role')).toBe('status');
+  });
+
+  test('falls back to aria-label={status} when no label is provided', () => {
     const { container } = render(StatusDot, { props: { status: 'error' } });
     expect(container.querySelector('.cinder-status-dot')?.getAttribute('aria-label')).toBe('error');
   });
 
-  test('adds aria-label={status} when showLabel is false even if label is set', () => {
+  test('falls back to aria-label={status} when label is undefined and showLabel defaults true', () => {
+    const { container } = render(StatusDot, { props: { status: 'offline' } });
+    expect(container.querySelector('.cinder-status-dot')?.getAttribute('aria-label')).toBe(
+      'offline',
+    );
+  });
+
+  test('uses label text as aria-label when showLabel is false but label is provided', () => {
     const { container } = render(StatusDot, {
-      props: { status: 'warning', label: 'Degraded', showLabel: false },
+      props: { status: 'error', label: 'Database unavailable', showLabel: false },
+    });
+    expect(container.querySelector('.cinder-status-dot')?.getAttribute('aria-label')).toBe(
+      'Database unavailable',
+    );
+  });
+
+  test('falls back to aria-label={status} when showLabel is false and label is empty', () => {
+    const { container } = render(StatusDot, {
+      props: { status: 'warning', label: '', showLabel: false },
     });
     expect(container.querySelector('.cinder-status-dot')?.getAttribute('aria-label')).toBe(
       'warning',
@@ -130,6 +148,19 @@ describe('StatusDot accessible name (WCAG 1.4.1)', () => {
     });
     expect(container.querySelector('.cinder-status-dot')?.getAttribute('aria-label')).toBe(
       'Deployment in progress',
+    );
+  });
+
+  test('consumer-supplied aria-label is preserved even when a visible label is rendered', () => {
+    const { container } = render(StatusDot, {
+      props: {
+        status: 'online',
+        label: 'Online',
+        'aria-label': 'Server is currently online and accepting connections',
+      },
+    });
+    expect(container.querySelector('.cinder-status-dot')?.getAttribute('aria-label')).toBe(
+      'Server is currently online and accepting connections',
     );
   });
 });

--- a/packages/components/src/components/status-dot.test.ts
+++ b/packages/components/src/components/status-dot.test.ts
@@ -6,6 +6,7 @@ import { setupHappyDom } from '../test/happy-dom.ts';
 setupHappyDom();
 
 const { render } = await import('@testing-library/svelte');
+const { within } = await import('@testing-library/dom');
 const { default: StatusDot } = await import('./status-dot.svelte');
 
 const ALL_STATUSES = ['online', 'offline', 'warning', 'error', 'building', 'neutral'] as const;
@@ -97,6 +98,11 @@ describe('StatusDot label rendering', () => {
     const { container } = render(StatusDot, { props: { status: 'online', label: '' } });
     expect(container.querySelector('.cinder-status-dot__label')).toBeNull();
   });
+
+  test('omits the visible label when label is whitespace-only', () => {
+    const { container } = render(StatusDot, { props: { status: 'online', label: '   ' } });
+    expect(container.querySelector('.cinder-status-dot__label')).toBeNull();
+  });
 });
 
 describe('StatusDot accessible name (WCAG 1.4.1)', () => {
@@ -128,11 +134,14 @@ describe('StatusDot accessible name (WCAG 1.4.1)', () => {
     );
   });
 
-  test('omits aria-label when a visible label is rendered (label text is the accessible name)', () => {
+  test('uses label text as aria-label when a visible label is rendered', () => {
     const { container } = render(StatusDot, {
       props: { status: 'online', label: 'Online' },
     });
-    expect(container.querySelector('.cinder-status-dot')?.getAttribute('aria-label')).toBeNull();
+    expect(container.querySelector('.cinder-status-dot')?.getAttribute('aria-label')).toBe(
+      'Online',
+    );
+    expect(within(container).getByRole('img', { name: 'Online' })).not.toBeNull();
   });
 
   test('consumer-supplied aria-label overrides the automatic fallback', () => {
@@ -163,6 +172,13 @@ describe('StatusDot accessible name (WCAG 1.4.1)', () => {
     });
     // An empty override would hide the element from AT — treat it as "no
     // override" and fall through to the automatic status fallback instead.
+    expect(container.querySelector('.cinder-status-dot')?.getAttribute('aria-label')).toBe('error');
+  });
+
+  test('whitespace-only aria-label from consumer does not blank the accessible name', () => {
+    const { container } = render(StatusDot, {
+      props: { status: 'error', 'aria-label': '   ' },
+    });
     expect(container.querySelector('.cinder-status-dot')?.getAttribute('aria-label')).toBe('error');
   });
 });

--- a/packages/components/src/components/status-dot.test.ts
+++ b/packages/components/src/components/status-dot.test.ts
@@ -100,21 +100,14 @@ describe('StatusDot label rendering', () => {
 });
 
 describe('StatusDot accessible name (WCAG 1.4.1)', () => {
-  test('root has role="status" so assistive tech exposes the accessible name', () => {
+  test('root has role="img" so the static indicator has a graphic semantic with a name', () => {
     const { container } = render(StatusDot, { props: { status: 'online' } });
-    expect(container.querySelector('.cinder-status-dot')?.getAttribute('role')).toBe('status');
+    expect(container.querySelector('.cinder-status-dot')?.getAttribute('role')).toBe('img');
   });
 
   test('falls back to aria-label={status} when no label is provided', () => {
     const { container } = render(StatusDot, { props: { status: 'error' } });
     expect(container.querySelector('.cinder-status-dot')?.getAttribute('aria-label')).toBe('error');
-  });
-
-  test('falls back to aria-label={status} when label is undefined and showLabel defaults true', () => {
-    const { container } = render(StatusDot, { props: { status: 'offline' } });
-    expect(container.querySelector('.cinder-status-dot')?.getAttribute('aria-label')).toBe(
-      'offline',
-    );
   });
 
   test('uses label text as aria-label when showLabel is false but label is provided', () => {
@@ -162,5 +155,14 @@ describe('StatusDot accessible name (WCAG 1.4.1)', () => {
     expect(container.querySelector('.cinder-status-dot')?.getAttribute('aria-label')).toBe(
       'Server is currently online and accepting connections',
     );
+  });
+
+  test('empty-string aria-label from consumer does not blank the accessible name', () => {
+    const { container } = render(StatusDot, {
+      props: { status: 'error', 'aria-label': '' },
+    });
+    // An empty override would hide the element from AT — treat it as "no
+    // override" and fall through to the automatic status fallback instead.
+    expect(container.querySelector('.cinder-status-dot')?.getAttribute('aria-label')).toBe('error');
   });
 });

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -303,6 +303,13 @@ export type {
   StatGroupVariant,
 } from './components/stat-group.svelte';
 
+export { default as StatusDot } from './components/status-dot.svelte';
+export type {
+  StatusDotProps,
+  StatusDotSize,
+  StatusDotStatus,
+} from './components/status-dot.svelte';
+
 export { default as Surface } from './components/surface.svelte';
 export type { SurfaceProps, SurfaceTone } from './components/surface.svelte';
 

--- a/packages/components/src/styles/components.css
+++ b/packages/components/src/styles/components.css
@@ -61,6 +61,7 @@
 @import './components/spinner.css';
 @import './components/stat.css';
 @import './components/stat-group.css';
+@import './components/status-dot.css';
 @import './components/steps.css';
 @import './components/surface.css';
 @import './components/tab.css';

--- a/packages/components/src/styles/components/status-dot.css
+++ b/packages/components/src/styles/components/status-dot.css
@@ -1,0 +1,77 @@
+/* ========================================
+ * STATUS DOT
+ *
+ * Small colored dot with optional visible label communicating binary or
+ * enumerated state. Color is driven exclusively from the
+ * `data-cinder-status` attribute — never hard-code hex values when
+ * consuming this component. Dot sizing is exposed as the
+ * `--cinder-status-dot-size` custom property so callers can override per
+ * instance without forking.
+ * ======================================== */
+
+.cinder-status-dot {
+  --cinder-status-dot-size: 0.625rem; /* 10px — md default */
+  --cinder-status-dot-color: var(--cinder-text-muted);
+
+  display: inline-flex;
+  align-items: center;
+  gap: var(--cinder-space-1-5);
+  font-size: var(--cinder-text-sm);
+  line-height: 1.25;
+  color: var(--cinder-text);
+  vertical-align: middle;
+}
+
+.cinder-status-dot__indicator {
+  display: inline-block;
+  flex-shrink: 0;
+  inline-size: var(--cinder-status-dot-size);
+  block-size: var(--cinder-status-dot-size);
+  border-radius: var(--cinder-radius-full);
+  background: var(--cinder-status-dot-color);
+}
+
+.cinder-status-dot__label {
+  color: inherit;
+}
+
+/* ----------------------------------------
+ * Size variants
+ * ---------------------------------------- */
+
+.cinder-status-dot[data-cinder-size='sm'] {
+  --cinder-status-dot-size: 0.5rem; /* 8px */
+  font-size: var(--cinder-text-xs);
+}
+
+.cinder-status-dot[data-cinder-size='md'] {
+  --cinder-status-dot-size: 0.625rem; /* 10px */
+}
+
+/* ----------------------------------------
+ * Status → semantic token mapping
+ * ---------------------------------------- */
+
+.cinder-status-dot[data-cinder-status='online'] {
+  --cinder-status-dot-color: var(--cinder-success, #059669);
+}
+
+.cinder-status-dot[data-cinder-status='offline'] {
+  --cinder-status-dot-color: var(--cinder-text-muted);
+}
+
+.cinder-status-dot[data-cinder-status='warning'] {
+  --cinder-status-dot-color: var(--cinder-warning, #d97706);
+}
+
+.cinder-status-dot[data-cinder-status='error'] {
+  --cinder-status-dot-color: var(--cinder-danger, #dc2626);
+}
+
+.cinder-status-dot[data-cinder-status='building'] {
+  --cinder-status-dot-color: var(--cinder-info, #2563eb);
+}
+
+.cinder-status-dot[data-cinder-status='neutral'] {
+  --cinder-status-dot-color: var(--cinder-text-muted);
+}

--- a/packages/components/src/styles/components/status-dot.css
+++ b/packages/components/src/styles/components/status-dot.css
@@ -53,7 +53,7 @@
  * ---------------------------------------- */
 
 .cinder-status-dot[data-cinder-status='online'] {
-  --cinder-status-dot-color: var(--cinder-success, #059669);
+  --cinder-status-dot-color: var(--cinder-success);
 }
 
 .cinder-status-dot[data-cinder-status='offline'] {
@@ -61,15 +61,15 @@
 }
 
 .cinder-status-dot[data-cinder-status='warning'] {
-  --cinder-status-dot-color: var(--cinder-warning, #d97706);
+  --cinder-status-dot-color: var(--cinder-warning);
 }
 
 .cinder-status-dot[data-cinder-status='error'] {
-  --cinder-status-dot-color: var(--cinder-danger, #dc2626);
+  --cinder-status-dot-color: var(--cinder-danger);
 }
 
 .cinder-status-dot[data-cinder-status='building'] {
-  --cinder-status-dot-color: var(--cinder-info, #2563eb);
+  --cinder-status-dot-color: var(--cinder-info);
 }
 
 .cinder-status-dot[data-cinder-status='neutral'] {


### PR DESCRIPTION
## Summary

Adds `StatusDot`, a small colored dot with an optional visible label for communicating binary or enumerated state (`online`, `offline`, `building`, `warning`, `error`, `neutral`) in list rows, avatars, and page headers.

- Color comes exclusively from `data-cinder-status` mapped to existing semantic tokens (`--cinder-success`, `--cinder-warning`, `--cinder-danger`, `--cinder-info`, `--cinder-text-muted`) — no hard-coded colors on the component.
- Dot size is exposed as `--cinder-status-dot-size` so callers can override per instance without forking. `sm` (8px) and `md` (10px, default) are provided.
- Exports `StatusDotStatus` from the module block so host components (e.g. `stacked-list-item.svelte`) can reuse the union.

### Accessibility

- Root carries `role=\"img\"` (not `role=\"status\"`) because the indicator is static and can be repeated in dynamic lists — a polite live region would cause AT to announce every instance as it mounts.
- An author-provided `aria-label` is always emitted, with priority: trimmed consumer `aria-label` → trimmed `label` → raw `status` token. Whitespace-only and empty-string overrides fall through to the automatic name; status is never communicated by color alone (WCAG 1.4.1).
- The visible label renders the trimmed `label` so visible and announced text cannot diverge for whitespace-padded input.

## Review committee

Pre-reviewed by: frontend-architect, ux-designer, testing-expert, typescript-expert, simplicity-engineer, junior-engineer, Codex (gpt-5.4, xhigh reasoning). Four rounds; all must-fix items addressed.

> [!WARNING]
> Codex was unavailable during round 2 (CLI shim timed out). The other reviewers covered that round; Codex returned for rounds 3 and 4 and approved in round 4. See `tmp/committee-state.md` for detail.

## Test plan

- `bun test packages/components/src/components/status-dot.test.ts` — 28 tests covering rendering, status & size attributes, label rendering (including whitespace handling), and the WCAG accessible-name contract (including consumer-aria-label override, empty/whitespace overrides, and computed-name assertion via `getByRole`).
- `bun run typecheck` and `bun run lint` clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: additive UI component and CSS with thorough rendering/a11y tests, no changes to existing business logic or data flows.
> 
> **Overview**
> Introduces a new `StatusDot` Svelte component for displaying a semantic status indicator with optional label, exposing typed props/status unions and ensuring an accessible name via computed `aria-label`.
> 
> Wires the component into the public package surface by adding the `./status-dot` export in `package.json`, exporting it from `src/index.ts`, and including its new `status-dot.css` in the component stylesheet bundle. A dedicated `status-dot.test.ts` suite validates rendering, sizing/status attributes, label trimming behavior, and `aria-label` precedence rules.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 30c95aa0f43481e69e833415b08f9362c41abe2d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->