### PR TITLE
feat(slider): add WAI-ARIA slider with single and range modes

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -293,6 +293,10 @@
       "svelte": "./src/components/skeleton.svelte",
       "types": "./dist/components/skeleton.svelte.d.ts"
     },
+    "./slider": {
+      "svelte": "./src/components/slider.svelte",
+      "types": "./dist/components/slider.svelte.d.ts"
+    },
     "./sortable-list": {
       "svelte": "./src/components/sortable-list.svelte",
       "types": "./dist/components/sortable-list.svelte.d.ts"

--- a/packages/components/src/components/slider.a11y.md
+++ b/packages/components/src/components/slider.a11y.md
@@ -1,0 +1,113 @@
+# Slider Accessibility
+
+`slider.svelte` implements the WAI-ARIA
+[slider pattern](https://www.w3.org/WAI/ARIA/apg/patterns/slider/) for
+single-value sliders and the
+[multi-thumb slider pattern](https://www.w3.org/WAI/ARIA/apg/patterns/slider-multithumb/)
+for two-thumb (range) sliders.
+
+## Role + Semantics
+
+Each thumb is a focusable `<div role="slider">` carrying:
+
+- `aria-valuemin`, `aria-valuemax`, `aria-valuenow` — required numeric state.
+- `aria-valuetext` — set when the consumer supplies a `valueText` formatter.
+  Screen readers prefer `aria-valuetext` over `aria-valuenow` when both are
+  present, so use it for currency, percentages, or other formatted values.
+- `aria-orientation="horizontal"` — the slider is exclusively horizontal in
+  this implementation.
+- `aria-disabled="true"` when `disabled` is set.
+
+### Accessible name
+
+| Mode     | Thumb        | Accessible name           |
+| -------- | ------------ | ------------------------- |
+| `single` | (only thumb) | `label`                   |
+| `range`  | low          | `{label} — minimum value` |
+| `range`  | high         | `{label} — maximum value` |
+
+When the slider is composed inside `<FormField>`, the field's label is
+linked via `aria-labelledby` and the per-thumb `aria-label` is suppressed
+so accessible-name computation has a single unambiguous source.
+
+## Keyboard Interactions
+
+| Key                     | Behavior                                      |
+| ----------------------- | --------------------------------------------- |
+| `ArrowRight`/`ArrowUp`  | Increase by `step` (or move to next tick)     |
+| `ArrowLeft`/`ArrowDown` | Decrease by `step` (or move to previous tick) |
+| `PageUp`                | Increase by `pageStep` (default `10 * step`)  |
+| `PageDown`              | Decrease by `pageStep`                        |
+| `Home`                  | Snap to `min`                                 |
+| `End`                   | Snap to `max`                                 |
+
+When `ticks` is supplied as an array, arrow keys move thumbs to the
+**adjacent tick** rather than the next `step` increment. This matches user
+expectation for "discrete tick" sliders.
+
+## Pointer Interactions
+
+- `pointerdown` on a thumb begins a drag. The component attaches
+  `pointermove` and `pointerup` listeners on `document`, so a drag
+  continues to follow the pointer even when it leaves the thumb element
+  or the track.
+- `pointerdown` on the track sets the value at the clicked position
+  (single mode) or moves the nearer thumb (range mode), then begins a
+  drag on that thumb.
+- Touch input is supported via the same Pointer Events API. `touch-action:
+none` is applied to the track so the browser does not steal the gesture
+  for scrolling.
+
+## Range Mode
+
+- The low thumb's `aria-valuemax` is the current `aria-valuenow` of the
+  high thumb, and vice versa. Screen-reader announcements therefore
+  reflect the live constraint, not the static `min`/`max` bounds.
+- Thumbs are constrained so the low value never exceeds the high value.
+- When thumbs overlap, the most recently moved thumb is raised via
+  `z-index` so it remains the click target.
+
+## Focus Behavior
+
+- Each thumb receives `tabindex="0"` when enabled and `tabindex="-1"`
+  when `disabled`.
+- `:focus-visible` produces an outline using `--cinder-focus-ring` (or
+  `--cinder-accent` as a fallback) with a 2px offset.
+
+## Reduced Motion
+
+Position transitions on the thumb and the filled range are disabled when
+`@media (prefers-reduced-motion: reduce)` matches.
+
+## Color Contrast
+
+The filled range uses `--cinder-accent` and the thumb border uses the
+same token. The thumb fill is `--cinder-surface-raised`. Both are part
+of the cinder semantic palette and meet WCAG 1.4.11 (non-text contrast).
+
+The tick marks are decorative (`aria-hidden="true"`); they exist as a
+visual affordance, not as the channel through which discrete state is
+communicated.
+
+## Form Integration
+
+When `name` is set:
+
+- **Single mode** renders one hidden `<input type="hidden" name="{name}">`.
+- **Range mode** renders two: `name="{name}.min"` and `name="{name}.max"`.
+
+Hidden inputs make the slider participate in native form submission.
+Form `reset` is currently handled by the consumer re-rendering with the
+original `defaultValue` — there is no internal listener on the parent
+`<form>`'s `reset` event, since the slider does not know which form it
+belongs to in advance.
+
+## Content Guidance
+
+- The `label` prop is required. A slider without an accessible name is
+  unusable for assistive technology.
+- Provide `valueText` whenever the raw number is not self-evident —
+  prices, dates, percentages of an unusual base, etc.
+- For sliders with fewer than ~10 discrete values, prefer a `select`,
+  `radio-group`, or `segmented-control`. Sliders are better for
+  continuous ranges or coarse "feel" adjustments.

--- a/packages/components/src/components/slider.a11y.md
+++ b/packages/components/src/components/slider.a11y.md
@@ -79,8 +79,9 @@ none` is applied to the track so the browser does not steal the gesture
 
 - Each thumb receives `tabindex="0"` when enabled and `tabindex="-1"`
   when `disabled`.
-- `:focus-visible` produces an outline using `--cinder-focus-ring` (or
-  `--cinder-accent` as a fallback) with a 2px offset.
+- `:focus-visible` produces an outline using the shared focus-ring
+  tokens (`--cinder-ring-width`, `--cinder-ring-color`, and
+  `--cinder-ring-offset`).
 
 ## Reduced Motion
 

--- a/packages/components/src/components/slider.a11y.md
+++ b/packages/components/src/components/slider.a11y.md
@@ -26,9 +26,17 @@ Each thumb is a focusable `<div role="slider">` carrying:
 | `range`  | low          | `{label} — minimum value` |
 | `range`  | high         | `{label} — maximum value` |
 
+The range-mode labels include the slider's `label` so a screen reader
+that announces only the thumb (rather than both the thumb and its parent
+container) still has context — "Price — minimum value" is more useful
+than the bare "Minimum value" called for in the WAI-ARIA APG example.
+
 When the slider is composed inside `<FormField>`, the field's label is
 linked via `aria-labelledby` and the per-thumb `aria-label` is suppressed
-so accessible-name computation has a single unambiguous source.
+so accessible-name computation has a single unambiguous source. In range
+mode, each thumb's `aria-labelledby` references both the field label and
+a visually hidden qualifier span (`{label-id} {qualifier-id}`) so that the
+"minimum value" / "maximum value" distinction is preserved.
 
 ## Keyboard Interactions
 
@@ -96,11 +104,15 @@ When `name` is set:
 - **Single mode** renders one hidden `<input type="hidden" name="{name}">`.
 - **Range mode** renders two: `name="{name}.min"` and `name="{name}.max"`.
 
-Hidden inputs make the slider participate in native form submission.
-Form `reset` is currently handled by the consumer re-rendering with the
-original `defaultValue` — there is no internal listener on the parent
-`<form>`'s `reset` event, since the slider does not know which form it
-belongs to in advance.
+Hidden inputs make the slider participate in native form submission. The
+hidden input's `value` tracks the slider's current value live, so the
+submitted payload is always up to date.
+
+Native form `reset` is not handled internally: a hidden input does not
+participate in the `reset` event the way `<input type="range">` does.
+Consumers that need form-reset to restore the slider should either
+re-render the component with the original `defaultValue` after reset, or
+prefer the controlled pattern and reset the state externally.
 
 ## Content Guidance
 

--- a/packages/components/src/components/slider.svelte
+++ b/packages/components/src/components/slider.svelte
@@ -358,14 +358,26 @@
     if (target?.dataset['cinderSliderThumb'] !== undefined) return;
     event.preventDefault();
     const raw = valueFromClientX(event.clientX);
+    let activated: 'single' | 'low' | 'high';
     if (isRange) {
       const which = chooseNearestThumb(raw);
       updateRange(which, raw);
       activeThumb = which;
       activeThumbRecent = which;
+      activated = which;
     } else {
       updateSingle(raw);
       activeThumb = 'single';
+      activated = 'single';
+    }
+    // Move focus to the activated thumb so the user can immediately refine
+    // the value with the keyboard. Matches the focus behavior of clicking
+    // directly on a thumb.
+    if (trackElement) {
+      const thumb = trackElement.querySelector<HTMLElement>(
+        `[data-cinder-slider-thumb="${activated}"]`,
+      );
+      if (thumb && document.activeElement !== thumb) thumb.focus();
     }
   }
 

--- a/packages/components/src/components/slider.svelte
+++ b/packages/components/src/components/slider.svelte
@@ -182,6 +182,11 @@
   /** Snap a raw value: clamp into `[min, max]`, then to the nearest tick or step. */
   function snap(raw: number): number {
     const clamped = clampToBounds(raw);
+    // `min` and `max` are always reachable, regardless of step alignment.
+    // Without this, a non-divisible step (e.g. `min=0, max=100, step=30`)
+    // would let Home/End or a clamped overshoot snap to 90 instead of 100,
+    // creating a mismatch with `aria-valuemax`.
+    if (clamped === min || clamped === max) return clamped;
     if (tickList && tickList.length > 0) {
       let nearest = tickList[0]!;
       let nearestDelta = Math.abs(clamped - nearest);

--- a/packages/components/src/components/slider.svelte
+++ b/packages/components/src/components/slider.svelte
@@ -1,0 +1,422 @@
+<script lang="ts" module>
+  /** Single-value or `[min, max]` tuple. */
+  export type SliderValue = number | [number, number];
+
+  /** Mode of the slider — `single` thumb or two-thumb `range`. */
+  export type SliderMode = 'single' | 'range';
+
+  /**
+   * Props for the Slider component.
+   *
+   * Implements the WAI-ARIA `role="slider"` pattern. Each thumb is its own
+   * focusable `<div role="slider">` carrying `aria-valuemin`, `aria-valuemax`,
+   * `aria-valuenow`, optional `aria-valuetext`, and an accessible name from
+   * either `aria-label` or `aria-labelledby`.
+   *
+   * The slider is controlled when `value` is supplied and uncontrolled when
+   * only `defaultValue` is supplied. `onchange` fires after every committed
+   * change (keyboard step, track click, end of pointer drag).
+   *
+   * Distinct from `progress.svelte` (passive read-only progress) and from
+   * the internal sliders inside `color-picker.svelte` (specialized for
+   * color manipulation).
+   */
+  export type SliderProps = {
+    /** Controlled value. Pass a number for `single`, a tuple for `range`. */
+    value?: SliderValue;
+    /** Initial value for uncontrolled usage. */
+    defaultValue?: SliderValue;
+    /** `single` (default) or `range`. */
+    mode?: SliderMode;
+    /** Minimum value. Default `0`. */
+    min?: number;
+    /** Maximum value. Default `100`. */
+    max?: number;
+    /** Step increment for arrow keys. Default `1`. */
+    step?: number;
+    /** Step increment for Page Up/Down. Default `step * 10`. */
+    pageStep?: number;
+    /** Visible label / accessible name for the slider. Required. */
+    label: string;
+    /** Formats the numeric value for `aria-valuetext`. */
+    valueText?: (value: number) => string;
+    /** Optional tick marks. `true` renders one per `step`; an array snaps to those values. */
+    ticks?: boolean | number[];
+    /** Disables interaction. */
+    disabled?: boolean;
+    /** Form field name. Renders hidden inputs for form submission. */
+    name?: string;
+    /** Extra class names merged with `.cinder-slider`. */
+    class?: string;
+    /** Called after every committed value change. */
+    onchange?: (value: SliderValue) => void;
+  };
+</script>
+
+<script lang="ts">
+  import { getFormFieldContext } from '../_internal/form-field-context.ts';
+  import { classNames } from '../utilities/class-names.ts';
+
+  let {
+    value,
+    defaultValue,
+    mode = 'single',
+    min = 0,
+    max = 100,
+    step = 1,
+    pageStep,
+    label,
+    valueText,
+    ticks,
+    disabled: disabledProp = false,
+    name,
+    class: className,
+    onchange,
+  }: SliderProps = $props();
+
+  const formField = getFormFieldContext();
+  const disabled = $derived(disabledProp || (formField?.disabled ?? false));
+
+  const effectivePageStep = $derived(pageStep ?? step * 10);
+
+  // Internal state mirrors `value` when controlled, otherwise tracks the
+  // uncontrolled value initialized from `defaultValue`.
+  const initialInternal: SliderValue =
+    value ?? defaultValue ?? (mode === 'range' ? [min, max] : min);
+  let internal = $state<SliderValue>(initialInternal);
+
+  // Treat `value` as the source of truth when provided so external updates
+  // flow through. Reads of `value` inside this effect register dependency.
+  $effect(() => {
+    if (value !== undefined) {
+      internal = Array.isArray(value) ? [value[0], value[1]] : value;
+    }
+  });
+
+  const isRange = $derived(mode === 'range');
+
+  const lowValue = $derived(Array.isArray(internal) ? internal[0] : (internal as number));
+  const highValue = $derived(Array.isArray(internal) ? internal[1] : (internal as number));
+
+  /** Snap a raw value to the nearest tick / step and clamp into `[min, max]`. */
+  function snap(raw: number): number {
+    const clamped = Math.max(min, Math.min(max, raw));
+    if (Array.isArray(ticks) && ticks.length > 0) {
+      let nearest = ticks[0]!;
+      let nearestDelta = Math.abs(clamped - nearest);
+      for (const tick of ticks) {
+        const delta = Math.abs(clamped - tick);
+        if (delta < nearestDelta) {
+          nearest = tick;
+          nearestDelta = delta;
+        }
+      }
+      return nearest;
+    }
+    const stepped = Math.round((clamped - min) / step) * step + min;
+    // Floating point hygiene — round to the precision implied by `step`.
+    const decimals = decimalsFromStep(step);
+    const rounded = Number(stepped.toFixed(decimals));
+    return Math.max(min, Math.min(max, rounded));
+  }
+
+  function decimalsFromStep(s: number): number {
+    if (!Number.isFinite(s) || s <= 0) return 0;
+    const text = String(s);
+    const dot = text.indexOf('.');
+    return dot >= 0 ? text.length - dot - 1 : 0;
+  }
+
+  function percentOf(numeric: number): number {
+    if (max === min) return 0;
+    return ((numeric - min) / (max - min)) * 100;
+  }
+
+  /** Apply a new value, respecting range constraint and controlled prop. */
+  function commit(next: SliderValue) {
+    let normalized: SliderValue = next;
+    if (isRange && Array.isArray(next)) {
+      const [a, b] = next;
+      normalized = a <= b ? [a, b] : [b, a];
+    }
+    if (value === undefined) {
+      internal = Array.isArray(normalized) ? [normalized[0], normalized[1]] : normalized;
+    }
+    onchange?.(normalized);
+  }
+
+  function updateSingle(nextValue: number) {
+    commit(snap(nextValue));
+  }
+
+  function updateRange(thumb: 'low' | 'high', nextValue: number) {
+    const snapped = snap(nextValue);
+    if (thumb === 'low') {
+      commit([Math.min(snapped, highValue), highValue]);
+    } else {
+      commit([lowValue, Math.max(snapped, lowValue)]);
+    }
+  }
+
+  function thumbAccessibleName(thumb: 'single' | 'low' | 'high'): string {
+    if (thumb === 'single') return label;
+    if (thumb === 'low') return `${label} — minimum value`;
+    return `${label} — maximum value`;
+  }
+
+  function neighborTick(current: number, direction: 1 | -1): number {
+    if (!Array.isArray(ticks) || ticks.length === 0) return current;
+    const sorted = [...ticks].filter((t) => t >= min && t <= max).sort((a, b) => a - b);
+    if (direction === 1) {
+      for (const tick of sorted) if (tick > current) return tick;
+      return sorted.at(-1) ?? current;
+    }
+    for (let index = sorted.length - 1; index >= 0; index--) {
+      const tick = sorted[index]!;
+      if (tick < current) return tick;
+    }
+    return sorted[0] ?? current;
+  }
+
+  function handleKey(event: KeyboardEvent, thumb: 'single' | 'low' | 'high') {
+    if (disabled) return;
+    const current = thumb === 'high' ? highValue : lowValue;
+    const tickArray = Array.isArray(ticks);
+    let next = current;
+    switch (event.key) {
+      case 'ArrowRight':
+      case 'ArrowUp':
+        next = tickArray ? neighborTick(current, 1) : current + step;
+        break;
+      case 'ArrowLeft':
+      case 'ArrowDown':
+        next = tickArray ? neighborTick(current, -1) : current - step;
+        break;
+      case 'PageUp':
+        next = current + effectivePageStep;
+        break;
+      case 'PageDown':
+        next = current - effectivePageStep;
+        break;
+      case 'Home':
+        next = min;
+        break;
+      case 'End':
+        next = max;
+        break;
+      default:
+        return;
+    }
+    event.preventDefault();
+    if (thumb === 'single') {
+      updateSingle(next);
+    } else {
+      updateRange(thumb, next);
+    }
+  }
+
+  // Pointer drag handling. We attach move/up listeners on `document` so that
+  // dragging continues to track the pointer even when it leaves the thumb.
+  let trackElement: HTMLDivElement | undefined = $state();
+  let activeThumb: 'single' | 'low' | 'high' | null = $state(null);
+  let activeThumbRecent: 'low' | 'high' | null = $state(null);
+
+  function valueFromClientX(clientX: number): number {
+    if (!trackElement) return min;
+    const rect = trackElement.getBoundingClientRect();
+    if (rect.width === 0) return min;
+    const ratio = Math.max(0, Math.min(1, (clientX - rect.left) / rect.width));
+    return min + ratio * (max - min);
+  }
+
+  function chooseNearestThumb(raw: number): 'low' | 'high' {
+    const distanceLow = Math.abs(raw - lowValue);
+    const distanceHigh = Math.abs(raw - highValue);
+    if (distanceLow === distanceHigh) {
+      // Tie-break: prefer moving the thumb closer to the click target's side.
+      return raw < (lowValue + highValue) / 2 ? 'low' : 'high';
+    }
+    return distanceLow < distanceHigh ? 'low' : 'high';
+  }
+
+  function onPointerMove(event: PointerEvent) {
+    if (!activeThumb) return;
+    const raw = valueFromClientX(event.clientX);
+    if (activeThumb === 'single') {
+      updateSingle(raw);
+    } else {
+      updateRange(activeThumb, raw);
+    }
+  }
+
+  function onPointerUp() {
+    activeThumb = null;
+    document.removeEventListener('pointermove', onPointerMove);
+    document.removeEventListener('pointerup', onPointerUp);
+    document.removeEventListener('pointercancel', onPointerUp);
+  }
+
+  function beginDrag(thumb: 'single' | 'low' | 'high') {
+    activeThumb = thumb;
+    if (thumb === 'low' || thumb === 'high') activeThumbRecent = thumb;
+    document.addEventListener('pointermove', onPointerMove);
+    document.addEventListener('pointerup', onPointerUp);
+    document.addEventListener('pointercancel', onPointerUp);
+  }
+
+  function handleThumbPointerDown(event: PointerEvent, thumb: 'single' | 'low' | 'high') {
+    if (disabled) return;
+    event.preventDefault();
+    (event.currentTarget as HTMLElement).focus();
+    beginDrag(thumb);
+  }
+
+  function handleTrackPointerDown(event: PointerEvent) {
+    if (disabled) return;
+    // Ignore clicks that originated on a thumb — those are handled above.
+    const target = event.target as HTMLElement | null;
+    if (target?.dataset['cinderSliderThumb'] !== undefined) return;
+    event.preventDefault();
+    const raw = valueFromClientX(event.clientX);
+    if (isRange) {
+      const which = chooseNearestThumb(raw);
+      updateRange(which, raw);
+      beginDrag(which);
+    } else {
+      updateSingle(raw);
+      beginDrag('single');
+    }
+  }
+
+  // Resolve aria-labelledby from a FormField wrapper when present, so labels
+  // remain visible and the slider does not double up `aria-label`.
+  const labelledBy = $derived(formField?.labelId);
+  const describedBy = $derived(formField?.describedBy);
+  const ariaInvalid = $derived(formField?.invalid);
+
+  function ariaAttrs(thumbKind: 'single' | 'low' | 'high', currentValue: number) {
+    const name = thumbAccessibleName(thumbKind);
+    return {
+      ariaLabel: labelledBy ? undefined : name,
+      ariaLabelledBy: labelledBy,
+      ariaDescribedBy: describedBy,
+      ariaInvalid,
+      ariaValueText: valueText ? valueText(currentValue) : undefined,
+    };
+  }
+
+  // Render tick mark positions. `true` produces one tick per step.
+  const tickMarks = $derived.by<number[]>(() => {
+    if (!ticks) return [];
+    if (Array.isArray(ticks)) return ticks.filter((t) => t >= min && t <= max);
+    const out: number[] = [];
+    for (let v = min; v <= max + step / 2; v += step) {
+      const snapped = Number(v.toFixed(decimalsFromStep(step)));
+      if (snapped <= max) out.push(snapped);
+    }
+    return out;
+  });
+
+  const singleAttrs = $derived(ariaAttrs('single', lowValue));
+  const lowAttrs = $derived(ariaAttrs('low', lowValue));
+  const highAttrs = $derived(ariaAttrs('high', highValue));
+</script>
+
+<div
+  class={classNames('cinder-slider', isRange && 'cinder-slider--range', className)}
+  data-cinder-disabled={disabled || undefined}
+>
+  <div
+    bind:this={trackElement}
+    class="cinder-slider__track"
+    onpointerdown={handleTrackPointerDown}
+    role="presentation"
+  >
+    <div
+      class="cinder-slider__range"
+      style:--_cinder-slider-low="{percentOf(lowValue)}%"
+      style:--_cinder-slider-high="{percentOf(isRange ? highValue : lowValue)}%"
+      aria-hidden="true"
+    ></div>
+
+    {#if tickMarks.length > 0}
+      <div class="cinder-slider__ticks" aria-hidden="true">
+        {#each tickMarks as tick (tick)}
+          <span class="cinder-slider__tick" style:--_cinder-slider-tick="{percentOf(tick)}%"></span>
+        {/each}
+      </div>
+    {/if}
+
+    {#if isRange}
+      <div
+        class="cinder-slider__thumb"
+        data-cinder-slider-thumb="low"
+        data-cinder-active={activeThumbRecent === 'low' || undefined}
+        role="slider"
+        tabindex={disabled ? -1 : 0}
+        aria-label={lowAttrs.ariaLabel}
+        aria-labelledby={lowAttrs.ariaLabelledBy}
+        aria-describedby={lowAttrs.ariaDescribedBy}
+        aria-invalid={lowAttrs.ariaInvalid}
+        aria-valuemin={min}
+        aria-valuemax={highValue}
+        aria-valuenow={lowValue}
+        aria-valuetext={lowAttrs.ariaValueText}
+        aria-disabled={disabled || undefined}
+        aria-orientation="horizontal"
+        style:--_cinder-slider-pos="{percentOf(lowValue)}%"
+        onkeydown={(event) => handleKey(event, 'low')}
+        onpointerdown={(event) => handleThumbPointerDown(event, 'low')}
+      ></div>
+      <div
+        class="cinder-slider__thumb"
+        data-cinder-slider-thumb="high"
+        data-cinder-active={activeThumbRecent === 'high' || undefined}
+        role="slider"
+        tabindex={disabled ? -1 : 0}
+        aria-label={highAttrs.ariaLabel}
+        aria-labelledby={highAttrs.ariaLabelledBy}
+        aria-describedby={highAttrs.ariaDescribedBy}
+        aria-invalid={highAttrs.ariaInvalid}
+        aria-valuemin={lowValue}
+        aria-valuemax={max}
+        aria-valuenow={highValue}
+        aria-valuetext={highAttrs.ariaValueText}
+        aria-disabled={disabled || undefined}
+        aria-orientation="horizontal"
+        style:--_cinder-slider-pos="{percentOf(highValue)}%"
+        onkeydown={(event) => handleKey(event, 'high')}
+        onpointerdown={(event) => handleThumbPointerDown(event, 'high')}
+      ></div>
+    {:else}
+      <div
+        class="cinder-slider__thumb"
+        data-cinder-slider-thumb="single"
+        role="slider"
+        tabindex={disabled ? -1 : 0}
+        aria-label={singleAttrs.ariaLabel}
+        aria-labelledby={singleAttrs.ariaLabelledBy}
+        aria-describedby={singleAttrs.ariaDescribedBy}
+        aria-invalid={singleAttrs.ariaInvalid}
+        aria-valuemin={min}
+        aria-valuemax={max}
+        aria-valuenow={lowValue}
+        aria-valuetext={singleAttrs.ariaValueText}
+        aria-disabled={disabled || undefined}
+        aria-orientation="horizontal"
+        style:--_cinder-slider-pos="{percentOf(lowValue)}%"
+        onkeydown={(event) => handleKey(event, 'single')}
+        onpointerdown={(event) => handleThumbPointerDown(event, 'single')}
+      ></div>
+    {/if}
+  </div>
+
+  {#if name}
+    {#if isRange}
+      <input type="hidden" name="{name}.min" value={lowValue} />
+      <input type="hidden" name="{name}.max" value={highValue} />
+    {:else}
+      <input type="hidden" {name} value={lowValue} />
+    {/if}
+  {/if}
+</div>

--- a/packages/components/src/components/slider.svelte
+++ b/packages/components/src/components/slider.svelte
@@ -155,8 +155,10 @@
   }
 
   // Uncontrolled state: initialized once from defaultValue / mode default.
+  // Normalize at construction so the stored state never carries an
+  // out-of-bounds or inverted-tuple value, even before the first commit.
   let uncontrolledInternal = $state<SliderValue>(
-    defaultValue ?? (mode === 'range' ? [min, max] : min),
+    normalizeValueForMode(defaultValue ?? (mode === 'range' ? [min, max] : min)),
   );
 
   // Controlled flag and current value. When `value` is provided we read

--- a/packages/components/src/components/slider.svelte
+++ b/packages/components/src/components/slider.svelte
@@ -107,7 +107,18 @@
     return step;
   });
 
-  const effectivePageStep = $derived(pageStep ?? safeStep * 10);
+  const safePageStep = $derived.by(() => {
+    if (pageStep === undefined) return safeStep * 10;
+    if (!Number.isFinite(pageStep) || pageStep <= 0) {
+      if (typeof console !== 'undefined') {
+        console.warn(
+          `[cinder/Slider] pageStep must be a positive finite number — received ${pageStep}. Falling back to ${safeStep * 10}.`,
+        );
+      }
+      return safeStep * 10;
+    }
+    return pageStep;
+  });
 
   // Normalize a tick array (or boolean) once. The list is filtered to
   // `[min, max]` so the renderer, snap, and keyboard neighbor lookups all
@@ -127,6 +138,22 @@
     return dot >= 0 ? text.length - dot - 1 : 0;
   }
 
+  function clampToBounds(raw: number): number {
+    if (raw === Infinity) return max;
+    if (raw === -Infinity || Number.isNaN(raw)) return min;
+    return Math.max(min, Math.min(max, raw));
+  }
+
+  function normalizeValueForMode(nextValue: SliderValue): SliderValue {
+    if (mode === 'range') {
+      const [rawLow, rawHigh] = Array.isArray(nextValue) ? nextValue : [min, max];
+      const first = clampToBounds(rawLow);
+      const second = clampToBounds(rawHigh);
+      return first <= second ? [first, second] : [second, first];
+    }
+    return clampToBounds(Array.isArray(nextValue) ? nextValue[0] : nextValue);
+  }
+
   // Uncontrolled state: initialized once from defaultValue / mode default.
   let uncontrolledInternal = $state<SliderValue>(
     defaultValue ?? (mode === 'range' ? [min, max] : min),
@@ -136,11 +163,13 @@
   // through to it; otherwise the uncontrolled state is the source of truth.
   const isControlled = $derived(value !== undefined);
   const currentValue = $derived<SliderValue>(
-    value !== undefined
-      ? Array.isArray(value)
-        ? [value[0], value[1]]
-        : value
-      : uncontrolledInternal,
+    normalizeValueForMode(
+      value !== undefined
+        ? Array.isArray(value)
+          ? [value[0], value[1]]
+          : value
+        : uncontrolledInternal,
+    ),
   );
 
   const isRange = $derived(mode === 'range');
@@ -150,7 +179,7 @@
 
   /** Snap a raw value: clamp into `[min, max]`, then to the nearest tick or step. */
   function snap(raw: number): number {
-    const clamped = Math.max(min, Math.min(max, raw));
+    const clamped = clampToBounds(raw);
     if (tickList && tickList.length > 0) {
       let nearest = tickList[0]!;
       let nearestDelta = Math.abs(clamped - nearest);
@@ -166,7 +195,7 @@
     const stepped = Math.round((clamped - min) / safeStep) * safeStep + min;
     const decimals = decimalsFromStep(safeStep);
     const rounded = Number(stepped.toFixed(decimals));
-    return Math.max(min, Math.min(max, rounded));
+    return clampToBounds(rounded);
   }
 
   function percentOf(numeric: number): number {
@@ -174,13 +203,9 @@
     return ((numeric - min) / (max - min)) * 100;
   }
 
-  /** Apply a new value, respecting range constraint and controlled prop. */
+  /** Apply a new value, respecting the controlled prop. */
   function commit(next: SliderValue) {
-    let normalized: SliderValue = next;
-    if (isRange && Array.isArray(next)) {
-      const [a, b] = next;
-      normalized = a <= b ? [a, b] : [b, a];
-    }
+    const normalized = normalizeValueForMode(next);
     if (!isControlled) {
       uncontrolledInternal = Array.isArray(normalized)
         ? [normalized[0], normalized[1]]
@@ -233,10 +258,10 @@
         next = hasTickArray ? neighborTick(current, -1) : current - safeStep;
         break;
       case 'PageUp':
-        next = current + effectivePageStep;
+        next = current + safePageStep;
         break;
       case 'PageDown':
-        next = current - effectivePageStep;
+        next = current - safePageStep;
         break;
       case 'Home':
         next = min;
@@ -251,6 +276,7 @@
     if (thumb === 'single') {
       updateSingle(next);
     } else {
+      activeThumbRecent = thumb;
       updateRange(thumb, next);
     }
   }
@@ -324,7 +350,11 @@
 
   function accessibleNameFor(thumb: 'single' | 'low' | 'high'): string {
     if (thumb === 'single') return label;
-    return thumb === 'low' ? `${label} — minimum value` : `${label} — maximum value`;
+    return `${label} — ${qualifierFor(thumb)}`;
+  }
+
+  function qualifierFor(thumb: 'low' | 'high'): string {
+    return thumb === 'low' ? 'minimum value' : 'maximum value';
   }
 
   // FormField wiring. When inside a FormField the field's label becomes the
@@ -335,9 +365,9 @@
   const describedBy = $derived(formField?.describedBy);
   const ariaInvalidFromField = $derived(formField?.invalid);
 
-  const uniqueId = $props.id();
-  const lowQualifierId = `${uniqueId}-low-label`;
-  const highQualifierId = `${uniqueId}-high-label`;
+  const sliderId = $props.id();
+  const lowQualifierId = `${sliderId}-low-label`;
+  const highQualifierId = `${sliderId}-high-label`;
 
   function labelledByFor(thumb: 'single' | 'low' | 'high'): string | undefined {
     if (!formFieldLabelId) return undefined;
@@ -376,10 +406,10 @@
 >
   {#if isRange}
     <span id={lowQualifierId} class="cinder-sr-only">
-      {accessibleNameFor('low')}
+      {qualifierFor('low')}
     </span>
     <span id={highQualifierId} class="cinder-sr-only">
-      {accessibleNameFor('high')}
+      {qualifierFor('high')}
     </span>
   {/if}
 

--- a/packages/components/src/components/slider.svelte
+++ b/packages/components/src/components/slider.svelte
@@ -5,6 +5,51 @@
   /** Mode of the slider — `single` thumb or two-thumb `range`. */
   export type SliderMode = 'single' | 'range';
 
+  type SliderBaseProps = {
+    /** Minimum value. Default `0`. */
+    min?: number;
+    /** Maximum value. Default `100`. */
+    max?: number;
+    /** Step increment for arrow keys. Default `1`. Must be a positive finite number. */
+    step?: number;
+    /** Step increment for Page Up/Down. Default `step * 10`. */
+    pageStep?: number;
+    /** Visible label / accessible name for the slider. Required. */
+    label: string;
+    /** Formats the numeric value for `aria-valuetext`. */
+    valueText?: (value: number) => string;
+    /** Optional tick marks. `true` renders one per `step`; an array snaps to those values. */
+    ticks?: boolean | number[];
+    /** Disables interaction. */
+    disabled?: boolean;
+    /** Form field name. Renders hidden inputs for form submission. */
+    name?: string;
+    /** Extra class names merged with `.cinder-slider`. */
+    class?: string;
+  };
+
+  /**
+   * Props for the single-thumb slider. `value`/`defaultValue` are scalars and
+   * `onchange` receives a scalar.
+   */
+  export type SliderSingleProps = SliderBaseProps & {
+    mode?: 'single';
+    value?: number;
+    defaultValue?: number;
+    onchange?: (value: number) => void;
+  };
+
+  /**
+   * Props for the two-thumb range slider. `value`/`defaultValue` are `[low, high]`
+   * tuples and `onchange` receives the same tuple shape.
+   */
+  export type SliderRangeProps = SliderBaseProps & {
+    mode: 'range';
+    value?: [number, number];
+    defaultValue?: [number, number];
+    onchange?: (value: [number, number]) => void;
+  };
+
   /**
    * Props for the Slider component.
    *
@@ -21,36 +66,7 @@
    * the internal sliders inside `color-picker.svelte` (specialized for
    * color manipulation).
    */
-  export type SliderProps = {
-    /** Controlled value. Pass a number for `single`, a tuple for `range`. */
-    value?: SliderValue;
-    /** Initial value for uncontrolled usage. */
-    defaultValue?: SliderValue;
-    /** `single` (default) or `range`. */
-    mode?: SliderMode;
-    /** Minimum value. Default `0`. */
-    min?: number;
-    /** Maximum value. Default `100`. */
-    max?: number;
-    /** Step increment for arrow keys. Default `1`. */
-    step?: number;
-    /** Step increment for Page Up/Down. Default `step * 10`. */
-    pageStep?: number;
-    /** Visible label / accessible name for the slider. Required. */
-    label: string;
-    /** Formats the numeric value for `aria-valuetext`. */
-    valueText?: (value: number) => string;
-    /** Optional tick marks. `true` renders one per `step`; an array snaps to those values. */
-    ticks?: boolean | number[];
-    /** Disables interaction. */
-    disabled?: boolean;
-    /** Form field name. Renders hidden inputs for form submission. */
-    name?: string;
-    /** Extra class names merged with `.cinder-slider`. */
-    class?: string;
-    /** Called after every committed value change. */
-    onchange?: (value: SliderValue) => void;
-  };
+  export type SliderProps = SliderSingleProps | SliderRangeProps;
 </script>
 
 <script lang="ts">
@@ -77,34 +93,68 @@
   const formField = getFormFieldContext();
   const disabled = $derived(disabledProp || (formField?.disabled ?? false));
 
-  const effectivePageStep = $derived(pageStep ?? step * 10);
-
-  // Internal state mirrors `value` when controlled, otherwise tracks the
-  // uncontrolled value initialized from `defaultValue`.
-  const initialInternal: SliderValue =
-    value ?? defaultValue ?? (mode === 'range' ? [min, max] : min);
-  let internal = $state<SliderValue>(initialInternal);
-
-  // Treat `value` as the source of truth when provided so external updates
-  // flow through. Reads of `value` inside this effect register dependency.
-  $effect(() => {
-    if (value !== undefined) {
-      internal = Array.isArray(value) ? [value[0], value[1]] : value;
+  // Guarantee a usable step. `0`, `NaN`, and negative values would let the
+  // tick generator loop forever, so fall back to `1` and warn during dev.
+  const safeStep = $derived.by(() => {
+    if (!Number.isFinite(step) || step <= 0) {
+      if (typeof console !== 'undefined') {
+        console.warn(
+          `[cinder/Slider] step must be a positive finite number — received ${step}. Falling back to 1.`,
+        );
+      }
+      return 1;
     }
+    return step;
   });
+
+  const effectivePageStep = $derived(pageStep ?? safeStep * 10);
+
+  // Normalize a tick array (or boolean) once. The list is filtered to
+  // `[min, max]` so the renderer, snap, and keyboard neighbor lookups all
+  // share the same set of valid stops.
+  const tickList = $derived.by<number[] | null>(() => {
+    if (!ticks) return null;
+    if (Array.isArray(ticks)) {
+      return ticks.filter((t) => Number.isFinite(t) && t >= min && t <= max).sort((a, b) => a - b);
+    }
+    return null;
+  });
+
+  function decimalsFromStep(s: number): number {
+    if (!Number.isFinite(s) || s <= 0) return 0;
+    const text = String(s);
+    const dot = text.indexOf('.');
+    return dot >= 0 ? text.length - dot - 1 : 0;
+  }
+
+  // Uncontrolled state: initialized once from defaultValue / mode default.
+  let uncontrolledInternal = $state<SliderValue>(
+    defaultValue ?? (mode === 'range' ? [min, max] : min),
+  );
+
+  // Controlled flag and current value. When `value` is provided we read
+  // through to it; otherwise the uncontrolled state is the source of truth.
+  const isControlled = $derived(value !== undefined);
+  const currentValue = $derived<SliderValue>(
+    value !== undefined
+      ? Array.isArray(value)
+        ? [value[0], value[1]]
+        : value
+      : uncontrolledInternal,
+  );
 
   const isRange = $derived(mode === 'range');
 
-  const lowValue = $derived(Array.isArray(internal) ? internal[0] : (internal as number));
-  const highValue = $derived(Array.isArray(internal) ? internal[1] : (internal as number));
+  const lowValue = $derived(Array.isArray(currentValue) ? currentValue[0] : currentValue);
+  const highValue = $derived(Array.isArray(currentValue) ? currentValue[1] : currentValue);
 
-  /** Snap a raw value to the nearest tick / step and clamp into `[min, max]`. */
+  /** Snap a raw value: clamp into `[min, max]`, then to the nearest tick or step. */
   function snap(raw: number): number {
     const clamped = Math.max(min, Math.min(max, raw));
-    if (Array.isArray(ticks) && ticks.length > 0) {
-      let nearest = ticks[0]!;
+    if (tickList && tickList.length > 0) {
+      let nearest = tickList[0]!;
       let nearestDelta = Math.abs(clamped - nearest);
-      for (const tick of ticks) {
+      for (const tick of tickList) {
         const delta = Math.abs(clamped - tick);
         if (delta < nearestDelta) {
           nearest = tick;
@@ -113,18 +163,10 @@
       }
       return nearest;
     }
-    const stepped = Math.round((clamped - min) / step) * step + min;
-    // Floating point hygiene — round to the precision implied by `step`.
-    const decimals = decimalsFromStep(step);
+    const stepped = Math.round((clamped - min) / safeStep) * safeStep + min;
+    const decimals = decimalsFromStep(safeStep);
     const rounded = Number(stepped.toFixed(decimals));
     return Math.max(min, Math.min(max, rounded));
-  }
-
-  function decimalsFromStep(s: number): number {
-    if (!Number.isFinite(s) || s <= 0) return 0;
-    const text = String(s);
-    const dot = text.indexOf('.');
-    return dot >= 0 ? text.length - dot - 1 : 0;
   }
 
   function percentOf(numeric: number): number {
@@ -139,10 +181,15 @@
       const [a, b] = next;
       normalized = a <= b ? [a, b] : [b, a];
     }
-    if (value === undefined) {
-      internal = Array.isArray(normalized) ? [normalized[0], normalized[1]] : normalized;
+    if (!isControlled) {
+      uncontrolledInternal = Array.isArray(normalized)
+        ? [normalized[0], normalized[1]]
+        : normalized;
     }
-    onchange?.(normalized);
+    // The discriminated SliderProps union ensures the parent's onchange
+    // matches the mode it declared; the cast here bridges the runtime
+    // (SliderValue) and prop (number | [number, number]) types.
+    (onchange as ((value: SliderValue) => void) | undefined)?.(normalized);
   }
 
   function updateSingle(nextValue: number) {
@@ -158,39 +205,32 @@
     }
   }
 
-  function thumbAccessibleName(thumb: 'single' | 'low' | 'high'): string {
-    if (thumb === 'single') return label;
-    if (thumb === 'low') return `${label} — minimum value`;
-    return `${label} — maximum value`;
-  }
-
   function neighborTick(current: number, direction: 1 | -1): number {
-    if (!Array.isArray(ticks) || ticks.length === 0) return current;
-    const sorted = [...ticks].filter((t) => t >= min && t <= max).sort((a, b) => a - b);
+    if (!tickList || tickList.length === 0) return current;
     if (direction === 1) {
-      for (const tick of sorted) if (tick > current) return tick;
-      return sorted.at(-1) ?? current;
+      for (const tick of tickList) if (tick > current) return tick;
+      return tickList.at(-1) ?? current;
     }
-    for (let index = sorted.length - 1; index >= 0; index--) {
-      const tick = sorted[index]!;
+    for (let index = tickList.length - 1; index >= 0; index--) {
+      const tick = tickList[index]!;
       if (tick < current) return tick;
     }
-    return sorted[0] ?? current;
+    return tickList[0] ?? current;
   }
 
   function handleKey(event: KeyboardEvent, thumb: 'single' | 'low' | 'high') {
     if (disabled) return;
     const current = thumb === 'high' ? highValue : lowValue;
-    const tickArray = Array.isArray(ticks);
+    const hasTickArray = tickList !== null && tickList.length > 0;
     let next = current;
     switch (event.key) {
       case 'ArrowRight':
       case 'ArrowUp':
-        next = tickArray ? neighborTick(current, 1) : current + step;
+        next = hasTickArray ? neighborTick(current, 1) : current + safeStep;
         break;
       case 'ArrowLeft':
       case 'ArrowDown':
-        next = tickArray ? neighborTick(current, -1) : current - step;
+        next = hasTickArray ? neighborTick(current, -1) : current - safeStep;
         break;
       case 'PageUp':
         next = current + effectivePageStep;
@@ -215,8 +255,9 @@
     }
   }
 
-  // Pointer drag handling. We attach move/up listeners on `document` so that
-  // dragging continues to track the pointer even when it leaves the thumb.
+  // Pointer drag handling. The `pointermove`/`pointerup` listeners live on
+  // `<svelte:document>` so they activate only while `activeThumb` is set,
+  // and Svelte tears them down on unmount automatically.
   let trackElement: HTMLDivElement | undefined = $state();
   let activeThumb: 'single' | 'low' | 'high' | null = $state(null);
   let activeThumbRecent: 'low' | 'high' | null = $state(null);
@@ -233,13 +274,12 @@
     const distanceLow = Math.abs(raw - lowValue);
     const distanceHigh = Math.abs(raw - highValue);
     if (distanceLow === distanceHigh) {
-      // Tie-break: prefer moving the thumb closer to the click target's side.
       return raw < (lowValue + highValue) / 2 ? 'low' : 'high';
     }
     return distanceLow < distanceHigh ? 'low' : 'high';
   }
 
-  function onPointerMove(event: PointerEvent) {
+  function handleDocumentPointerMove(event: PointerEvent) {
     if (!activeThumb) return;
     const raw = valueFromClientX(event.clientX);
     if (activeThumb === 'single') {
@@ -249,83 +289,100 @@
     }
   }
 
-  function onPointerUp() {
+  function handleDocumentPointerEnd() {
     activeThumb = null;
-    document.removeEventListener('pointermove', onPointerMove);
-    document.removeEventListener('pointerup', onPointerUp);
-    document.removeEventListener('pointercancel', onPointerUp);
-  }
-
-  function beginDrag(thumb: 'single' | 'low' | 'high') {
-    activeThumb = thumb;
-    if (thumb === 'low' || thumb === 'high') activeThumbRecent = thumb;
-    document.addEventListener('pointermove', onPointerMove);
-    document.addEventListener('pointerup', onPointerUp);
-    document.addEventListener('pointercancel', onPointerUp);
   }
 
   function handleThumbPointerDown(event: PointerEvent, thumb: 'single' | 'low' | 'high') {
     if (disabled) return;
     event.preventDefault();
-    (event.currentTarget as HTMLElement).focus();
-    beginDrag(thumb);
+    const target = event.currentTarget;
+    if (target instanceof HTMLElement && document.activeElement !== target) {
+      target.focus();
+    }
+    activeThumb = thumb;
+    if (thumb === 'low' || thumb === 'high') activeThumbRecent = thumb;
   }
 
   function handleTrackPointerDown(event: PointerEvent) {
     if (disabled) return;
     // Ignore clicks that originated on a thumb — those are handled above.
-    const target = event.target as HTMLElement | null;
+    const target = event.target instanceof HTMLElement ? event.target : null;
     if (target?.dataset['cinderSliderThumb'] !== undefined) return;
     event.preventDefault();
     const raw = valueFromClientX(event.clientX);
     if (isRange) {
       const which = chooseNearestThumb(raw);
       updateRange(which, raw);
-      beginDrag(which);
+      activeThumb = which;
+      activeThumbRecent = which;
     } else {
       updateSingle(raw);
-      beginDrag('single');
+      activeThumb = 'single';
     }
   }
 
-  // Resolve aria-labelledby from a FormField wrapper when present, so labels
-  // remain visible and the slider does not double up `aria-label`.
-  const labelledBy = $derived(formField?.labelId);
-  const describedBy = $derived(formField?.describedBy);
-  const ariaInvalid = $derived(formField?.invalid);
-
-  function ariaAttrs(thumbKind: 'single' | 'low' | 'high', currentValue: number) {
-    const name = thumbAccessibleName(thumbKind);
-    return {
-      ariaLabel: labelledBy ? undefined : name,
-      ariaLabelledBy: labelledBy,
-      ariaDescribedBy: describedBy,
-      ariaInvalid,
-      ariaValueText: valueText ? valueText(currentValue) : undefined,
-    };
+  function accessibleNameFor(thumb: 'single' | 'low' | 'high'): string {
+    if (thumb === 'single') return label;
+    return thumb === 'low' ? `${label} — minimum value` : `${label} — maximum value`;
   }
 
-  // Render tick mark positions. `true` produces one tick per step.
+  // FormField wiring. When inside a FormField the field's label becomes the
+  // primary accessible name. In range mode we still need to disambiguate
+  // the thumbs, so each thumb references both the field label and a hidden
+  // qualifier span via `aria-labelledby`.
+  const formFieldLabelId = $derived(formField?.labelId);
+  const describedBy = $derived(formField?.describedBy);
+  const ariaInvalidFromField = $derived(formField?.invalid);
+
+  const uniqueId = $props.id();
+  const lowQualifierId = `${uniqueId}-low-label`;
+  const highQualifierId = `${uniqueId}-high-label`;
+
+  function labelledByFor(thumb: 'single' | 'low' | 'high'): string | undefined {
+    if (!formFieldLabelId) return undefined;
+    if (thumb === 'low') return `${formFieldLabelId} ${lowQualifierId}`;
+    if (thumb === 'high') return `${formFieldLabelId} ${highQualifierId}`;
+    return formFieldLabelId;
+  }
+
+  function ariaLabelFor(thumb: 'single' | 'low' | 'high'): string | undefined {
+    return formFieldLabelId ? undefined : accessibleNameFor(thumb);
+  }
+
+  // Render tick mark positions.
   const tickMarks = $derived.by<number[]>(() => {
-    if (!ticks) return [];
-    if (Array.isArray(ticks)) return ticks.filter((t) => t >= min && t <= max);
+    if (tickList) return tickList;
+    if (ticks !== true) return [];
     const out: number[] = [];
-    for (let v = min; v <= max + step / 2; v += step) {
-      const snapped = Number(v.toFixed(decimalsFromStep(step)));
+    const decimals = decimalsFromStep(safeStep);
+    for (let v = min; v <= max + safeStep / 2; v += safeStep) {
+      const snapped = Number(v.toFixed(decimals));
       if (snapped <= max) out.push(snapped);
     }
     return out;
   });
-
-  const singleAttrs = $derived(ariaAttrs('single', lowValue));
-  const lowAttrs = $derived(ariaAttrs('low', lowValue));
-  const highAttrs = $derived(ariaAttrs('high', highValue));
 </script>
+
+<svelte:document
+  onpointermove={activeThumb ? handleDocumentPointerMove : null}
+  onpointerup={activeThumb ? handleDocumentPointerEnd : null}
+  onpointercancel={activeThumb ? handleDocumentPointerEnd : null}
+/>
 
 <div
   class={classNames('cinder-slider', isRange && 'cinder-slider--range', className)}
   data-cinder-disabled={disabled || undefined}
 >
+  {#if isRange}
+    <span id={lowQualifierId} class="cinder-sr-only">
+      {accessibleNameFor('low')}
+    </span>
+    <span id={highQualifierId} class="cinder-sr-only">
+      {accessibleNameFor('high')}
+    </span>
+  {/if}
+
   <div
     bind:this={trackElement}
     class="cinder-slider__track"
@@ -354,14 +411,14 @@
         data-cinder-active={activeThumbRecent === 'low' || undefined}
         role="slider"
         tabindex={disabled ? -1 : 0}
-        aria-label={lowAttrs.ariaLabel}
-        aria-labelledby={lowAttrs.ariaLabelledBy}
-        aria-describedby={lowAttrs.ariaDescribedBy}
-        aria-invalid={lowAttrs.ariaInvalid}
+        aria-label={ariaLabelFor('low')}
+        aria-labelledby={labelledByFor('low')}
+        aria-describedby={describedBy}
+        aria-invalid={ariaInvalidFromField}
         aria-valuemin={min}
         aria-valuemax={highValue}
         aria-valuenow={lowValue}
-        aria-valuetext={lowAttrs.ariaValueText}
+        aria-valuetext={valueText ? valueText(lowValue) : undefined}
         aria-disabled={disabled || undefined}
         aria-orientation="horizontal"
         style:--_cinder-slider-pos="{percentOf(lowValue)}%"
@@ -374,14 +431,14 @@
         data-cinder-active={activeThumbRecent === 'high' || undefined}
         role="slider"
         tabindex={disabled ? -1 : 0}
-        aria-label={highAttrs.ariaLabel}
-        aria-labelledby={highAttrs.ariaLabelledBy}
-        aria-describedby={highAttrs.ariaDescribedBy}
-        aria-invalid={highAttrs.ariaInvalid}
+        aria-label={ariaLabelFor('high')}
+        aria-labelledby={labelledByFor('high')}
+        aria-describedby={describedBy}
+        aria-invalid={ariaInvalidFromField}
         aria-valuemin={lowValue}
         aria-valuemax={max}
         aria-valuenow={highValue}
-        aria-valuetext={highAttrs.ariaValueText}
+        aria-valuetext={valueText ? valueText(highValue) : undefined}
         aria-disabled={disabled || undefined}
         aria-orientation="horizontal"
         style:--_cinder-slider-pos="{percentOf(highValue)}%"
@@ -394,14 +451,14 @@
         data-cinder-slider-thumb="single"
         role="slider"
         tabindex={disabled ? -1 : 0}
-        aria-label={singleAttrs.ariaLabel}
-        aria-labelledby={singleAttrs.ariaLabelledBy}
-        aria-describedby={singleAttrs.ariaDescribedBy}
-        aria-invalid={singleAttrs.ariaInvalid}
+        aria-label={ariaLabelFor('single')}
+        aria-labelledby={labelledByFor('single')}
+        aria-describedby={describedBy}
+        aria-invalid={ariaInvalidFromField}
         aria-valuemin={min}
         aria-valuemax={max}
         aria-valuenow={lowValue}
-        aria-valuetext={singleAttrs.ariaValueText}
+        aria-valuetext={valueText ? valueText(lowValue) : undefined}
         aria-disabled={disabled || undefined}
         aria-orientation="horizontal"
         style:--_cinder-slider-pos="{percentOf(lowValue)}%"

--- a/packages/components/src/components/slider.svelte
+++ b/packages/components/src/components/slider.svelte
@@ -245,6 +245,25 @@
     return tickList[0] ?? current;
   }
 
+  /**
+   * Advance from `current` toward `direction` by at least `distance` of value,
+   * landing on a tick. Guarantees at least one tick of movement so PageUp/PageDown
+   * stays functional when tick spacing exceeds `pageStep`.
+   */
+  function tickPageJump(current: number, distance: number, direction: 1 | -1): number {
+    if (!tickList || tickList.length === 0) return current;
+    const target = current + direction * distance;
+    let candidate = neighborTick(current, direction);
+    while (true) {
+      const stepped = neighborTick(candidate, direction);
+      if (stepped === candidate) break;
+      const passedTarget = direction === 1 ? stepped > target : stepped < target;
+      if (passedTarget) break;
+      candidate = stepped;
+    }
+    return candidate;
+  }
+
   function handleKey(event: KeyboardEvent, thumb: 'single' | 'low' | 'high') {
     if (disabled) return;
     const current = thumb === 'high' ? highValue : lowValue;
@@ -260,10 +279,10 @@
         next = hasTickArray ? neighborTick(current, -1) : current - safeStep;
         break;
       case 'PageUp':
-        next = current + safePageStep;
+        next = hasTickArray ? tickPageJump(current, safePageStep, 1) : current + safePageStep;
         break;
       case 'PageDown':
-        next = current - safePageStep;
+        next = hasTickArray ? tickPageJump(current, safePageStep, -1) : current - safePageStep;
         break;
       case 'Home':
         next = min;

--- a/packages/components/src/components/slider.test.ts
+++ b/packages/components/src/components/slider.test.ts
@@ -109,13 +109,13 @@ describe('Slider (single)', () => {
   });
 
   test('onchange fires with the snapped value on each keyboard adjust', async () => {
-    const calls: Array<number | [number, number]> = [];
+    const calls: number[] = [];
     const { container } = render(Slider, {
       props: {
         label: 'Volume',
         defaultValue: 10,
         step: 5,
-        onchange: (value: number | [number, number]) => calls.push(value),
+        onchange: (value: number) => calls.push(value),
       },
     });
     const thumb = getThumbs(container)[0]!;
@@ -163,7 +163,7 @@ describe('Slider (single)', () => {
     expect(hidden?.value).toBe('42');
   });
 
-  test('form reset restores the defaultValue via the hidden input', async () => {
+  test('hidden input reflects the current value after keyboard movement', async () => {
     const { container } = render(Slider, {
       props: { label: 'Volume', defaultValue: 20, name: 'volume', step: 5 },
     });
@@ -172,6 +172,30 @@ describe('Slider (single)', () => {
     expect(thumb.getAttribute('aria-valuenow')).toBe('25');
     const hidden = container.querySelector<HTMLInputElement>('input[type="hidden"]');
     expect(hidden?.value).toBe('25');
+  });
+
+  test('PageDown clamps to min when it would overshoot', async () => {
+    const { container } = render(Slider, {
+      props: { label: 'Volume', defaultValue: 5, step: 1, pageStep: 50 },
+    });
+    const thumb = getThumbs(container)[0]!;
+    await fireEvent.keyDown(thumb, { key: 'PageDown' });
+    expect(thumb.getAttribute('aria-valuenow')).toBe('0');
+  });
+
+  test('aria-valuetext updates when value changes via keyboard', async () => {
+    const { container } = render(Slider, {
+      props: {
+        label: 'Volume',
+        defaultValue: 30,
+        step: 10,
+        valueText: (v: number) => `${v} percent`,
+      },
+    });
+    const thumb = getThumbs(container)[0]!;
+    expect(thumb.getAttribute('aria-valuetext')).toBe('30 percent');
+    await fireEvent.keyDown(thumb, { key: 'ArrowRight' });
+    expect(thumb.getAttribute('aria-valuetext')).toBe('40 percent');
   });
 });
 
@@ -265,12 +289,26 @@ describe('Slider (range)', () => {
         mode: 'range',
         defaultValue: [10, 40],
         step: 5,
-        onchange: (value: number | [number, number]) => calls.push(value),
+        onchange: (value: [number, number]) => calls.push(value),
       },
     });
     const [low] = getThumbs(container);
     await fireEvent.keyDown(low!, { key: 'ArrowRight' });
     expect(calls[0]).toEqual([15, 40]);
+  });
+
+  test('aria-valuetext is applied to both thumbs in range mode', () => {
+    const { container } = render(Slider, {
+      props: {
+        label: 'Price',
+        mode: 'range',
+        defaultValue: [10, 90],
+        valueText: (v: number) => `$${v}`,
+      },
+    });
+    const [low, high] = getThumbs(container);
+    expect(low!.getAttribute('aria-valuetext')).toBe('$10');
+    expect(high!.getAttribute('aria-valuetext')).toBe('$90');
   });
 });
 
@@ -325,26 +363,105 @@ describe('Slider (ticks)', () => {
   });
 });
 
+function mockTrackRect(track: HTMLElement, width: number) {
+  track.getBoundingClientRect = () =>
+    ({
+      left: 0,
+      top: 0,
+      right: width,
+      bottom: 20,
+      width,
+      height: 20,
+      x: 0,
+      y: 0,
+      toJSON: () => ({}),
+    }) as DOMRect;
+}
+
 describe('Slider (pointer)', () => {
-  test('pointerdown on the track moves the thumb toward the click', async () => {
+  test('pointerdown on the track sets the value based on click position', async () => {
     const { container } = render(Slider, {
-      props: { label: 'Volume', defaultValue: 0 },
+      props: { label: 'Volume', defaultValue: 0, min: 0, max: 100 },
     });
     const track = container.querySelector<HTMLDivElement>('.cinder-slider__track')!;
-    // happy-dom returns zero-width rects, so the value resolves to `min`.
-    // Verify the event handler is wired up without throwing.
-    await fireEvent.pointerDown(track, { clientX: 0 });
+    mockTrackRect(track, 200);
+    await fireEvent.pointerDown(track, { clientX: 100 });
     const thumb = getThumbs(container)[0]!;
-    expect(thumb.getAttribute('aria-valuenow')).toBe('0');
+    expect(thumb.getAttribute('aria-valuenow')).toBe('50');
   });
 
-  test('pointerdown on the thumb does not throw and focuses the thumb', async () => {
+  test('pointermove on document updates the value while dragging', async () => {
     const { container } = render(Slider, {
+      props: { label: 'Volume', defaultValue: 0, min: 0, max: 100 },
+    });
+    const track = container.querySelector<HTMLDivElement>('.cinder-slider__track')!;
+    const thumb = getThumbs(container)[0]!;
+    mockTrackRect(track, 200);
+
+    await fireEvent.pointerDown(thumb, { clientX: 0 });
+    await fireEvent(document, new PointerEvent('pointermove', { clientX: 150, bubbles: true }));
+    expect(thumb.getAttribute('aria-valuenow')).toBe('75');
+    await fireEvent(document, new PointerEvent('pointerup', { bubbles: true }));
+  });
+
+  test('pointerup ends the drag — further pointermove no longer mutates value', async () => {
+    const { container } = render(Slider, {
+      props: { label: 'Volume', defaultValue: 50, min: 0, max: 100 },
+    });
+    const track = container.querySelector<HTMLDivElement>('.cinder-slider__track')!;
+    const thumb = getThumbs(container)[0]!;
+    mockTrackRect(track, 200);
+
+    await fireEvent.pointerDown(thumb, { clientX: 100 });
+    await fireEvent(document, new PointerEvent('pointerup', { bubbles: true }));
+    await fireEvent(document, new PointerEvent('pointermove', { clientX: 20, bubbles: true }));
+    // The slider value should remain wherever the last drag commit left it
+    // (here, the thumb pointerdown did not move it since it landed at the
+    // existing 50 position with clientX=100 / 200px = 50%).
+    expect(thumb.getAttribute('aria-valuenow')).toBe('50');
+  });
+
+  test('pointercancel ends the drag like pointerup', async () => {
+    const { container } = render(Slider, {
+      props: { label: 'Volume', defaultValue: 30 },
+    });
+    const thumb = getThumbs(container)[0]!;
+    await fireEvent.pointerDown(thumb, { clientX: 0 });
+    await fireEvent(document, new PointerEvent('pointercancel', { bubbles: true }));
+    // No throw and subsequent pointermove no longer updates.
+    await fireEvent(document, new PointerEvent('pointermove', { clientX: 999, bubbles: true }));
+    expect(thumb.getAttribute('aria-valuenow')).toBe('30');
+  });
+
+  test('track click in range mode moves the nearer thumb', async () => {
+    const { container } = render(Slider, {
+      props: {
+        label: 'Price',
+        mode: 'range',
+        defaultValue: [20, 80],
+        min: 0,
+        max: 100,
+      },
+    });
+    const track = container.querySelector<HTMLDivElement>('.cinder-slider__track')!;
+    mockTrackRect(track, 200);
+    // clientX=20/200 → value 10, closer to low thumb (20) than high (80).
+    await fireEvent.pointerDown(track, { clientX: 20 });
+    await fireEvent(document, new PointerEvent('pointerup', { bubbles: true }));
+    const [low, high] = getThumbs(container);
+    expect(low!.getAttribute('aria-valuenow')).toBe('10');
+    expect(high!.getAttribute('aria-valuenow')).toBe('80');
+  });
+
+  test('document listeners are cleaned up on unmount during drag', async () => {
+    const { container, unmount } = render(Slider, {
       props: { label: 'Volume', defaultValue: 50 },
     });
     const thumb = getThumbs(container)[0]!;
     await fireEvent.pointerDown(thumb, { clientX: 50 });
-    // Cleanup any document listeners by simulating pointerup.
-    await fireEvent(document, new Event('pointerup'));
+    unmount();
+    // No throw firing pointermove on document after unmount means Svelte
+    // tore down the <svelte:document> listeners correctly.
+    await fireEvent(document, new PointerEvent('pointermove', { clientX: 60, bubbles: true }));
   });
 });

--- a/packages/components/src/components/slider.test.ts
+++ b/packages/components/src/components/slider.test.ts
@@ -402,6 +402,42 @@ describe('Slider (ticks)', () => {
     expect(thumb.getAttribute('aria-valuenow')).toBe('25');
   });
 
+  test('PageUp/PageDown move across ticks when tick spacing exceeds pageStep', async () => {
+    // Regression: with ticks=[0,25,50,75,100] and default pageStep (10× step=10),
+    // PageUp at tick 0 would compute 10, then snap back to 0 — making the keys
+    // non-functional. PageUp must always advance to at least the next tick.
+    const { container } = render(Slider, {
+      props: {
+        label: 'Volume',
+        defaultValue: 0,
+        ticks: [0, 25, 50, 75, 100],
+        step: 1,
+      },
+    });
+    const thumb = getThumbs(container)[0]!;
+    await fireEvent.keyDown(thumb, { key: 'PageUp' });
+    expect(thumb.getAttribute('aria-valuenow')).toBe('25');
+    await fireEvent.keyDown(thumb, { key: 'PageDown' });
+    expect(thumb.getAttribute('aria-valuenow')).toBe('0');
+  });
+
+  test('PageUp jumps multiple ticks when pageStep spans several', async () => {
+    const { container } = render(Slider, {
+      props: {
+        label: 'Volume',
+        defaultValue: 0,
+        ticks: [0, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100],
+        step: 1,
+        pageStep: 30,
+      },
+    });
+    const thumb = getThumbs(container)[0]!;
+    await fireEvent.keyDown(thumb, { key: 'PageUp' });
+    // pageStep=30, ticks every 10 → should land at 30 (the last tick that
+    // doesn't overshoot current+30).
+    expect(thumb.getAttribute('aria-valuenow')).toBe('30');
+  });
+
   test('pointer drag snaps to the nearest tick when ticks is an array', async () => {
     const { container } = render(Slider, {
       props: {

--- a/packages/components/src/components/slider.test.ts
+++ b/packages/components/src/components/slider.test.ts
@@ -1,0 +1,350 @@
+/// <reference lib="dom" />
+import { describe, expect, test } from 'bun:test';
+
+import { setupHappyDom } from '../test/happy-dom.ts';
+
+setupHappyDom();
+
+const { fireEvent, render } = await import('@testing-library/svelte');
+const { default: Slider } = await import('./slider.svelte');
+
+function getThumbs(container: Element): HTMLElement[] {
+  return Array.from(container.querySelectorAll<HTMLElement>('[role="slider"]'));
+}
+
+describe('Slider (single)', () => {
+  test('renders one role=slider with min/max/now and accessible name', () => {
+    const { container } = render(Slider, {
+      props: { label: 'Volume', defaultValue: 30 },
+    });
+    const thumbs = getThumbs(container);
+    expect(thumbs).toHaveLength(1);
+    const thumb = thumbs[0]!;
+    expect(thumb.getAttribute('aria-valuemin')).toBe('0');
+    expect(thumb.getAttribute('aria-valuemax')).toBe('100');
+    expect(thumb.getAttribute('aria-valuenow')).toBe('30');
+    expect(thumb.getAttribute('aria-label')).toBe('Volume');
+  });
+
+  test('ArrowRight increments by step', async () => {
+    const { container } = render(Slider, {
+      props: { label: 'Brightness', defaultValue: 20, step: 5 },
+    });
+    const thumb = getThumbs(container)[0]!;
+    thumb.focus();
+    await fireEvent.keyDown(thumb, { key: 'ArrowRight' });
+    expect(thumb.getAttribute('aria-valuenow')).toBe('25');
+  });
+
+  test('ArrowLeft decrements by step', async () => {
+    const { container } = render(Slider, {
+      props: { label: 'Brightness', defaultValue: 20, step: 5 },
+    });
+    const thumb = getThumbs(container)[0]!;
+    await fireEvent.keyDown(thumb, { key: 'ArrowLeft' });
+    expect(thumb.getAttribute('aria-valuenow')).toBe('15');
+  });
+
+  test('ArrowUp / ArrowDown also adjust by step', async () => {
+    const { container } = render(Slider, {
+      props: { label: 'Volume', defaultValue: 50, step: 2 },
+    });
+    const thumb = getThumbs(container)[0]!;
+    await fireEvent.keyDown(thumb, { key: 'ArrowUp' });
+    expect(thumb.getAttribute('aria-valuenow')).toBe('52');
+    await fireEvent.keyDown(thumb, { key: 'ArrowDown' });
+    expect(thumb.getAttribute('aria-valuenow')).toBe('50');
+  });
+
+  test('Page Up / Page Down jump by pageStep (default 10× step)', async () => {
+    const { container } = render(Slider, {
+      props: { label: 'Volume', defaultValue: 50, step: 1 },
+    });
+    const thumb = getThumbs(container)[0]!;
+    await fireEvent.keyDown(thumb, { key: 'PageUp' });
+    expect(thumb.getAttribute('aria-valuenow')).toBe('60');
+    await fireEvent.keyDown(thumb, { key: 'PageDown' });
+    expect(thumb.getAttribute('aria-valuenow')).toBe('50');
+  });
+
+  test('Page Up / Page Down honors custom pageStep', async () => {
+    const { container } = render(Slider, {
+      props: { label: 'Volume', defaultValue: 50, step: 1, pageStep: 25 },
+    });
+    const thumb = getThumbs(container)[0]!;
+    await fireEvent.keyDown(thumb, { key: 'PageUp' });
+    expect(thumb.getAttribute('aria-valuenow')).toBe('75');
+  });
+
+  test('Home and End clamp to min and max', async () => {
+    const { container } = render(Slider, {
+      props: { label: 'Volume', defaultValue: 50 },
+    });
+    const thumb = getThumbs(container)[0]!;
+    await fireEvent.keyDown(thumb, { key: 'Home' });
+    expect(thumb.getAttribute('aria-valuenow')).toBe('0');
+    await fireEvent.keyDown(thumb, { key: 'End' });
+    expect(thumb.getAttribute('aria-valuenow')).toBe('100');
+  });
+
+  test('value clamps to [min, max] when arrow key would overshoot', async () => {
+    const { container } = render(Slider, {
+      props: { label: 'Volume', defaultValue: 99, step: 5 },
+    });
+    const thumb = getThumbs(container)[0]!;
+    await fireEvent.keyDown(thumb, { key: 'ArrowRight' });
+    expect(thumb.getAttribute('aria-valuenow')).toBe('100');
+  });
+
+  test('aria-valuetext uses valueText formatter when provided', () => {
+    const { container } = render(Slider, {
+      props: {
+        label: 'Volume',
+        defaultValue: 30,
+        valueText: (v: number) => `${v} percent`,
+      },
+    });
+    const thumb = getThumbs(container)[0]!;
+    expect(thumb.getAttribute('aria-valuetext')).toBe('30 percent');
+  });
+
+  test('onchange fires with the snapped value on each keyboard adjust', async () => {
+    const calls: Array<number | [number, number]> = [];
+    const { container } = render(Slider, {
+      props: {
+        label: 'Volume',
+        defaultValue: 10,
+        step: 5,
+        onchange: (value: number | [number, number]) => calls.push(value),
+      },
+    });
+    const thumb = getThumbs(container)[0]!;
+    await fireEvent.keyDown(thumb, { key: 'ArrowRight' });
+    await fireEvent.keyDown(thumb, { key: 'ArrowRight' });
+    expect(calls).toEqual([15, 20]);
+  });
+
+  test('controlled value reflects the passed prop on initial render', () => {
+    const { container } = render(Slider, {
+      props: { label: 'Volume', value: 70 },
+    });
+    expect(getThumbs(container)[0]!.getAttribute('aria-valuenow')).toBe('70');
+  });
+
+  test('controlled value: keyboard does not mutate when no onchange echoes it back', async () => {
+    const { container } = render(Slider, {
+      props: { label: 'Volume', value: 30, step: 5 },
+    });
+    const thumb = getThumbs(container)[0]!;
+    await fireEvent.keyDown(thumb, { key: 'ArrowRight' });
+    // value prop is the source of truth; without onchange echoing back, the
+    // controlled value stays at 30.
+    expect(thumb.getAttribute('aria-valuenow')).toBe('30');
+  });
+
+  test('disabled slider does not move with keyboard', async () => {
+    const { container } = render(Slider, {
+      props: { label: 'Volume', defaultValue: 30, disabled: true },
+    });
+    const thumb = getThumbs(container)[0]!;
+    await fireEvent.keyDown(thumb, { key: 'ArrowRight' });
+    expect(thumb.getAttribute('aria-valuenow')).toBe('30');
+    expect(thumb.getAttribute('aria-disabled')).toBe('true');
+    expect(thumb.getAttribute('tabindex')).toBe('-1');
+  });
+
+  test('renders a hidden input with name for form submission', () => {
+    const { container } = render(Slider, {
+      props: { label: 'Volume', defaultValue: 42, name: 'volume' },
+    });
+    const hidden = container.querySelector<HTMLInputElement>('input[type="hidden"]');
+    expect(hidden).not.toBeNull();
+    expect(hidden?.name).toBe('volume');
+    expect(hidden?.value).toBe('42');
+  });
+
+  test('form reset restores the defaultValue via the hidden input', async () => {
+    const { container } = render(Slider, {
+      props: { label: 'Volume', defaultValue: 20, name: 'volume', step: 5 },
+    });
+    const thumb = getThumbs(container)[0]!;
+    await fireEvent.keyDown(thumb, { key: 'ArrowRight' });
+    expect(thumb.getAttribute('aria-valuenow')).toBe('25');
+    const hidden = container.querySelector<HTMLInputElement>('input[type="hidden"]');
+    expect(hidden?.value).toBe('25');
+  });
+});
+
+describe('Slider (range)', () => {
+  test('renders two thumbs with labels for min and max', () => {
+    const { container } = render(Slider, {
+      props: {
+        label: 'Price',
+        mode: 'range',
+        defaultValue: [20, 80],
+      },
+    });
+    const thumbs = getThumbs(container);
+    expect(thumbs).toHaveLength(2);
+    expect(thumbs[0]!.getAttribute('aria-label')).toBe('Price — minimum value');
+    expect(thumbs[1]!.getAttribute('aria-label')).toBe('Price — maximum value');
+    expect(thumbs[0]!.getAttribute('aria-valuenow')).toBe('20');
+    expect(thumbs[1]!.getAttribute('aria-valuenow')).toBe('80');
+  });
+
+  test('low thumb cannot move past high thumb', async () => {
+    const { container } = render(Slider, {
+      props: {
+        label: 'Price',
+        mode: 'range',
+        defaultValue: [20, 30],
+        step: 5,
+      },
+    });
+    const [low, high] = getThumbs(container);
+    // 20 → 25 → 30 (high). Next press should clamp at 30, not exceed.
+    await fireEvent.keyDown(low!, { key: 'ArrowRight' });
+    await fireEvent.keyDown(low!, { key: 'ArrowRight' });
+    await fireEvent.keyDown(low!, { key: 'ArrowRight' });
+    expect(low!.getAttribute('aria-valuenow')).toBe('30');
+    expect(high!.getAttribute('aria-valuenow')).toBe('30');
+  });
+
+  test('high thumb cannot move below low thumb', async () => {
+    const { container } = render(Slider, {
+      props: {
+        label: 'Price',
+        mode: 'range',
+        defaultValue: [50, 60],
+        step: 5,
+      },
+    });
+    const [low, high] = getThumbs(container);
+    await fireEvent.keyDown(high!, { key: 'ArrowLeft' });
+    await fireEvent.keyDown(high!, { key: 'ArrowLeft' });
+    await fireEvent.keyDown(high!, { key: 'ArrowLeft' });
+    expect(high!.getAttribute('aria-valuenow')).toBe('50');
+    expect(low!.getAttribute('aria-valuenow')).toBe('50');
+  });
+
+  test('aria-valuemax on the low thumb is the high value, and vice versa', () => {
+    const { container } = render(Slider, {
+      props: {
+        label: 'Price',
+        mode: 'range',
+        defaultValue: [10, 40],
+      },
+    });
+    const [low, high] = getThumbs(container);
+    expect(low!.getAttribute('aria-valuemax')).toBe('40');
+    expect(high!.getAttribute('aria-valuemin')).toBe('10');
+  });
+
+  test('renders two hidden inputs in range mode', () => {
+    const { container } = render(Slider, {
+      props: {
+        label: 'Price',
+        mode: 'range',
+        defaultValue: [10, 40],
+        name: 'price',
+      },
+    });
+    const inputs = container.querySelectorAll<HTMLInputElement>('input[type="hidden"]');
+    expect(inputs).toHaveLength(2);
+    expect(inputs[0]!.name).toBe('price.min');
+    expect(inputs[0]!.value).toBe('10');
+    expect(inputs[1]!.name).toBe('price.max');
+    expect(inputs[1]!.value).toBe('40');
+  });
+
+  test('onchange fires with a tuple in range mode', async () => {
+    const calls: Array<number | [number, number]> = [];
+    const { container } = render(Slider, {
+      props: {
+        label: 'Price',
+        mode: 'range',
+        defaultValue: [10, 40],
+        step: 5,
+        onchange: (value: number | [number, number]) => calls.push(value),
+      },
+    });
+    const [low] = getThumbs(container);
+    await fireEvent.keyDown(low!, { key: 'ArrowRight' });
+    expect(calls[0]).toEqual([15, 40]);
+  });
+});
+
+describe('Slider (ticks)', () => {
+  test('renders tick marks when ticks=true', () => {
+    const { container } = render(Slider, {
+      props: { label: 'Volume', defaultValue: 50, step: 25, ticks: true },
+    });
+    const ticks = container.querySelectorAll('.cinder-slider__tick');
+    // min=0, max=100, step=25 → 0, 25, 50, 75, 100 = 5 ticks.
+    expect(ticks).toHaveLength(5);
+  });
+
+  test('arrow keys step between adjacent ticks when ticks is an array', async () => {
+    const { container } = render(Slider, {
+      props: {
+        label: 'Volume',
+        defaultValue: 0,
+        ticks: [0, 25, 50, 75, 100],
+        step: 1,
+      },
+    });
+    const thumb = getThumbs(container)[0]!;
+    await fireEvent.keyDown(thumb, { key: 'ArrowRight' });
+    expect(thumb.getAttribute('aria-valuenow')).toBe('25');
+    await fireEvent.keyDown(thumb, { key: 'ArrowRight' });
+    expect(thumb.getAttribute('aria-valuenow')).toBe('50');
+    await fireEvent.keyDown(thumb, { key: 'ArrowLeft' });
+    expect(thumb.getAttribute('aria-valuenow')).toBe('25');
+  });
+
+  test('pointer drag snaps to the nearest tick when ticks is an array', async () => {
+    const { container } = render(Slider, {
+      props: {
+        label: 'Volume',
+        defaultValue: 0,
+        ticks: [0, 25, 50, 75, 100],
+      },
+    });
+    const thumb = getThumbs(container)[0]!;
+    // Home/End ignores ticks (clamps to min/max), then snap brings to closest tick.
+    await fireEvent.keyDown(thumb, { key: 'End' });
+    expect(thumb.getAttribute('aria-valuenow')).toBe('100');
+  });
+
+  test('tick marks have aria-hidden ancestor and are decorative', () => {
+    const { container } = render(Slider, {
+      props: { label: 'Volume', defaultValue: 50, step: 25, ticks: true },
+    });
+    const ticksContainer = container.querySelector('.cinder-slider__ticks');
+    expect(ticksContainer?.getAttribute('aria-hidden')).toBe('true');
+  });
+});
+
+describe('Slider (pointer)', () => {
+  test('pointerdown on the track moves the thumb toward the click', async () => {
+    const { container } = render(Slider, {
+      props: { label: 'Volume', defaultValue: 0 },
+    });
+    const track = container.querySelector<HTMLDivElement>('.cinder-slider__track')!;
+    // happy-dom returns zero-width rects, so the value resolves to `min`.
+    // Verify the event handler is wired up without throwing.
+    await fireEvent.pointerDown(track, { clientX: 0 });
+    const thumb = getThumbs(container)[0]!;
+    expect(thumb.getAttribute('aria-valuenow')).toBe('0');
+  });
+
+  test('pointerdown on the thumb does not throw and focuses the thumb', async () => {
+    const { container } = render(Slider, {
+      props: { label: 'Volume', defaultValue: 50 },
+    });
+    const thumb = getThumbs(container)[0]!;
+    await fireEvent.pointerDown(thumb, { clientX: 50 });
+    // Cleanup any document listeners by simulating pointerup.
+    await fireEvent(document, new Event('pointerup'));
+  });
+});

--- a/packages/components/src/components/slider.test.ts
+++ b/packages/components/src/components/slider.test.ts
@@ -7,9 +7,19 @@ setupHappyDom();
 
 const { fireEvent, render } = await import('@testing-library/svelte');
 const { default: Slider } = await import('./slider.svelte');
+const { default: SliderFormFieldFixture } =
+  await import('../test/fixtures/slider-form-field-fixture.svelte');
 
 function getThumbs(container: Element): HTMLElement[] {
   return Array.from(container.querySelectorAll<HTMLElement>('[role="slider"]'));
+}
+
+function textForLabelledBy(container: Element, labelledBy: string): string {
+  return labelledBy
+    .split(/\s+/)
+    .map((id) => container.ownerDocument.getElementById(id)?.textContent?.trim() ?? '')
+    .filter(Boolean)
+    .join(' ');
 }
 
 describe('Slider (single)', () => {
@@ -129,6 +139,13 @@ describe('Slider (single)', () => {
       props: { label: 'Volume', value: 70 },
     });
     expect(getThumbs(container)[0]!.getAttribute('aria-valuenow')).toBe('70');
+  });
+
+  test('initial value is clamped to the configured bounds', () => {
+    const { container } = render(Slider, {
+      props: { label: 'Volume', defaultValue: 200, min: 0, max: 100 },
+    });
+    expect(getThumbs(container)[0]!.getAttribute('aria-valuenow')).toBe('100');
   });
 
   test('controlled value: keyboard does not mutate when no onchange echoes it back', async () => {
@@ -264,6 +281,21 @@ describe('Slider (range)', () => {
     expect(high!.getAttribute('aria-valuemin')).toBe('10');
   });
 
+  test('initial range value is clamped and ordered before render', () => {
+    const { container } = render(Slider, {
+      props: {
+        label: 'Price',
+        mode: 'range',
+        defaultValue: [120, -10],
+        min: 0,
+        max: 100,
+      },
+    });
+    const [low, high] = getThumbs(container);
+    expect(low!.getAttribute('aria-valuenow')).toBe('0');
+    expect(high!.getAttribute('aria-valuenow')).toBe('100');
+  });
+
   test('renders two hidden inputs in range mode', () => {
     const { container } = render(Slider, {
       props: {
@@ -309,6 +341,36 @@ describe('Slider (range)', () => {
     const [low, high] = getThumbs(container);
     expect(low!.getAttribute('aria-valuetext')).toBe('$10');
     expect(high!.getAttribute('aria-valuetext')).toBe('$90');
+  });
+
+  test('range thumbs inside FormField use the field label plus non-duplicating qualifiers', () => {
+    const { container } = render(SliderFormFieldFixture);
+    const [low, high] = getThumbs(container);
+
+    const lowLabelledBy = low!.getAttribute('aria-labelledby');
+    const highLabelledBy = high!.getAttribute('aria-labelledby');
+
+    expect(low!.getAttribute('aria-label')).toBeNull();
+    expect(high!.getAttribute('aria-label')).toBeNull();
+    expect(lowLabelledBy).not.toBeNull();
+    expect(highLabelledBy).not.toBeNull();
+    expect(textForLabelledBy(container, lowLabelledBy!)).toBe('Price minimum value');
+    expect(textForLabelledBy(container, highLabelledBy!)).toBe('Price maximum value');
+  });
+
+  test('range qualifier ids are unique across sliders without explicit ids', () => {
+    const { container } = render(SliderFormFieldFixture, {
+      props: { renderSecond: true },
+    });
+    const labelledByIds = getThumbs(container).flatMap(
+      (thumb) => thumb.getAttribute('aria-labelledby')?.split(/\s+/) ?? [],
+    );
+    const qualifierIds = labelledByIds.filter(
+      (id) => id.endsWith('-low-label') || id.endsWith('-high-label'),
+    );
+
+    expect(qualifierIds).toHaveLength(4);
+    expect(new Set(qualifierIds).size).toBe(4);
   });
 });
 

--- a/packages/components/src/components/slider.test.ts
+++ b/packages/components/src/components/slider.test.ts
@@ -531,6 +531,40 @@ describe('Slider (pointer)', () => {
     expect(thumb.getAttribute('aria-valuenow')).toBe('30');
   });
 
+  test('track click focuses the activated thumb so keyboard refinement works', async () => {
+    // Regression: clicking the track activated a thumb but did not move
+    // focus to it, so the user could not immediately press ArrowRight to
+    // refine the value.
+    const { container } = render(Slider, {
+      props: { label: 'Volume', defaultValue: 0, min: 0, max: 100 },
+    });
+    const track = container.querySelector<HTMLDivElement>('.cinder-slider__track')!;
+    mockTrackRect(track, 200);
+    const thumb = getThumbs(container)[0]!;
+    expect(document.activeElement).not.toBe(thumb);
+    await fireEvent.pointerDown(track, { clientX: 100 });
+    expect(document.activeElement).toBe(thumb);
+  });
+
+  test('range-mode track click focuses the nearer thumb', async () => {
+    const { container } = render(Slider, {
+      props: {
+        label: 'Price',
+        mode: 'range',
+        defaultValue: [20, 80],
+        min: 0,
+        max: 100,
+      },
+    });
+    const track = container.querySelector<HTMLDivElement>('.cinder-slider__track')!;
+    mockTrackRect(track, 200);
+    const [low, high] = getThumbs(container);
+    // Click near the high thumb (clientX=160 → value 80).
+    await fireEvent.pointerDown(track, { clientX: 160 });
+    expect(document.activeElement).toBe(high!);
+    expect(document.activeElement).not.toBe(low!);
+  });
+
   test('track click in range mode moves the nearer thumb', async () => {
     const { container } = render(Slider, {
       props: {

--- a/packages/components/src/components/slider.test.ts
+++ b/packages/components/src/components/slider.test.ts
@@ -402,6 +402,20 @@ describe('Slider (ticks)', () => {
     expect(thumb.getAttribute('aria-valuenow')).toBe('25');
   });
 
+  test('End reaches max even when step does not evenly divide the range', async () => {
+    // Regression: with min=0, max=100, step=30, pressing End used to snap
+    // 100 → Math.round(100/30)*30 = 90, leaving aria-valuenow at 90 while
+    // aria-valuemax still announced 100.
+    const { container } = render(Slider, {
+      props: { label: 'Volume', defaultValue: 0, min: 0, max: 100, step: 30 },
+    });
+    const thumb = getThumbs(container)[0]!;
+    await fireEvent.keyDown(thumb, { key: 'End' });
+    expect(thumb.getAttribute('aria-valuenow')).toBe('100');
+    await fireEvent.keyDown(thumb, { key: 'Home' });
+    expect(thumb.getAttribute('aria-valuenow')).toBe('0');
+  });
+
   test('PageUp/PageDown move across ticks when tick spacing exceeds pageStep', async () => {
     // Regression: with ticks=[0,25,50,75,100] and default pageStep (10× step=10),
     // PageUp at tick 0 would compute 10, then snap back to 0 — making the keys

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -281,6 +281,9 @@ export type {
 export { default as Skeleton } from './components/skeleton.svelte';
 export type { SkeletonProps } from './components/skeleton.svelte';
 
+export { default as Slider } from './components/slider.svelte';
+export type { SliderMode, SliderProps, SliderValue } from './components/slider.svelte';
+
 export { default as StackedListItem } from './components/stacked-list-item.svelte';
 export type {
   StackedListItemDensity,

--- a/packages/components/src/styles/components.css
+++ b/packages/components/src/styles/components.css
@@ -56,6 +56,7 @@
 @import './components/side-navigation.css';
 @import './components/side-navigation-group.css';
 @import './components/skeleton.css';
+@import './components/slider.css';
 @import './components/sortable-list.css';
 @import './components/stacked-list-item.css';
 @import './components/spinner.css';

--- a/packages/components/src/styles/components/slider.css
+++ b/packages/components/src/styles/components/slider.css
@@ -82,13 +82,23 @@
   transform: translate(-50%, -50%);
   cursor: grab;
   box-shadow: var(--cinder-shadow-sm, 0 1px 2px rgba(0, 0, 0, 0.1));
+  /* Touch-action is set on the track for the same reason; explicitly setting
+   * it on the thumb prevents older Chromium-on-Android from intercepting the
+   * gesture for scrolling when pointerdown lands directly on the thumb. */
+  touch-action: none;
   transition:
     left var(--cinder-duration-fast, 120ms) var(--cinder-ease-standard, ease),
     box-shadow var(--cinder-duration-fast, 120ms) var(--cinder-ease-standard, ease);
 }
 
-.cinder-slider__thumb:active,
+/* The most recently moved thumb in range mode is raised above its sibling
+ * so that when the two values coincide, the active one remains the click
+ * target. */
 .cinder-slider__thumb[data-cinder-active] {
+  z-index: 2;
+}
+
+.cinder-slider__thumb:active {
   cursor: grabbing;
   z-index: 2;
 }

--- a/packages/components/src/styles/components/slider.css
+++ b/packages/components/src/styles/components/slider.css
@@ -1,0 +1,110 @@
+/* ========================================
+ * SLIDER
+ * Single-thumb and dual-thumb (range) slider following the WAI-ARIA
+ * `role="slider"` pattern. Thumbs are absolutely positioned along the
+ * track via the `--_cinder-slider-pos` custom property (a percentage).
+ * Reduced-motion: thumb position transitions are suppressed.
+ * ======================================== */
+
+.cinder-slider {
+  --_cinder-slider-thumb-size: 1.125rem;
+  --_cinder-slider-track-thickness: 0.375rem;
+
+  position: relative;
+  display: block;
+  width: 100%;
+  padding-block: calc(var(--_cinder-slider-thumb-size) / 2);
+}
+
+.cinder-slider[data-cinder-disabled] {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
+.cinder-slider__track {
+  position: relative;
+  width: 100%;
+  height: var(--_cinder-slider-track-thickness);
+  background: var(--cinder-surface-inset);
+  border-radius: var(--cinder-radius-full);
+  touch-action: none;
+  cursor: pointer;
+}
+
+.cinder-slider[data-cinder-disabled] .cinder-slider__track {
+  cursor: not-allowed;
+}
+
+.cinder-slider__range {
+  position: absolute;
+  inset-block: 0;
+  left: var(--_cinder-slider-low);
+  right: calc(100% - var(--_cinder-slider-high));
+  background: var(--cinder-accent);
+  border-radius: var(--cinder-radius-full);
+  transition:
+    left var(--cinder-duration-fast, 120ms) var(--cinder-ease-standard, ease),
+    right var(--cinder-duration-fast, 120ms) var(--cinder-ease-standard, ease);
+}
+
+.cinder-slider:not(.cinder-slider--range) .cinder-slider__range {
+  left: 0;
+  right: calc(100% - var(--_cinder-slider-low));
+}
+
+.cinder-slider__ticks {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+}
+
+.cinder-slider__tick {
+  position: absolute;
+  top: 50%;
+  left: var(--_cinder-slider-tick);
+  width: 2px;
+  height: 0.5rem;
+  background: var(--cinder-border, currentColor);
+  transform: translate(-50%, -50%);
+  border-radius: var(--cinder-radius-full);
+  opacity: 0.6;
+}
+
+.cinder-slider__thumb {
+  position: absolute;
+  top: 50%;
+  left: var(--_cinder-slider-pos);
+  width: var(--_cinder-slider-thumb-size);
+  height: var(--_cinder-slider-thumb-size);
+  background: var(--cinder-surface-raised, white);
+  border: 2px solid var(--cinder-accent);
+  border-radius: var(--cinder-radius-full);
+  transform: translate(-50%, -50%);
+  cursor: grab;
+  box-shadow: var(--cinder-shadow-sm, 0 1px 2px rgba(0, 0, 0, 0.1));
+  transition:
+    left var(--cinder-duration-fast, 120ms) var(--cinder-ease-standard, ease),
+    box-shadow var(--cinder-duration-fast, 120ms) var(--cinder-ease-standard, ease);
+}
+
+.cinder-slider__thumb:active,
+.cinder-slider__thumb[data-cinder-active] {
+  cursor: grabbing;
+  z-index: 2;
+}
+
+.cinder-slider__thumb:focus-visible {
+  outline: 2px solid var(--cinder-focus-ring, var(--cinder-accent));
+  outline-offset: 2px;
+}
+
+.cinder-slider[data-cinder-disabled] .cinder-slider__thumb {
+  cursor: not-allowed;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .cinder-slider__range,
+  .cinder-slider__thumb {
+    transition: none;
+  }
+}

--- a/packages/components/src/styles/components/slider.css
+++ b/packages/components/src/styles/components/slider.css
@@ -104,8 +104,8 @@
 }
 
 .cinder-slider__thumb:focus-visible {
-  outline: 2px solid var(--cinder-focus-ring, var(--cinder-accent));
-  outline-offset: 2px;
+  outline: var(--cinder-ring-width) solid var(--cinder-ring-color);
+  outline-offset: var(--cinder-ring-offset);
 }
 
 .cinder-slider[data-cinder-disabled] .cinder-slider__thumb {

--- a/packages/components/src/test/fixtures/slider-form-field-fixture.svelte
+++ b/packages/components/src/test/fixtures/slider-form-field-fixture.svelte
@@ -1,0 +1,22 @@
+<script lang="ts" module>
+  export type SliderFormFieldFixtureProps = {
+    renderSecond?: boolean;
+  };
+</script>
+
+<script lang="ts">
+  import FormField from '../../components/form-field.svelte';
+  import Slider from '../../components/slider.svelte';
+
+  let { renderSecond = false }: SliderFormFieldFixtureProps = $props();
+</script>
+
+<FormField id="price" label="Price">
+  <Slider label="Price" mode="range" defaultValue={[10, 90]} />
+</FormField>
+
+{#if renderSecond}
+  <FormField id="quantity" label="Quantity">
+    <Slider label="Quantity" mode="range" defaultValue={[1, 5]} min={0} max={10} />
+  </FormField>
+{/if}

--- a/packages/playground/src/examples/slider/basic.example.svelte
+++ b/packages/playground/src/examples/slider/basic.example.svelte
@@ -1,0 +1,22 @@
+<script lang="ts" module>
+  export const title = 'Single-value slider';
+  export const description =
+    'A simple slider for one numeric value. Keyboard, mouse, and touch all work.';
+</script>
+
+<script lang="ts">
+  import { Slider } from '../../../../components/src/index.ts';
+
+  let value = $state(40);
+</script>
+
+<div style="display: flex; flex-direction: column; gap: 1rem; max-width: 24rem;">
+  <Slider
+    label="Volume"
+    {value}
+    onchange={(next) => {
+      value = next as number;
+    }}
+  />
+  <p>Value: {value}</p>
+</div>

--- a/packages/playground/src/examples/slider/basic.example.svelte
+++ b/packages/playground/src/examples/slider/basic.example.svelte
@@ -15,7 +15,7 @@
     label="Volume"
     {value}
     onchange={(next) => {
-      value = next as number;
+      value = next;
     }}
   />
   <p>Value: {value}</p>

--- a/packages/playground/src/examples/slider/disabled.example.svelte
+++ b/packages/playground/src/examples/slider/disabled.example.svelte
@@ -1,0 +1,13 @@
+<script lang="ts" module>
+  export const title = 'Disabled slider';
+  export const description =
+    'A disabled slider does not respond to keyboard or pointer input and is excluded from tab order.';
+</script>
+
+<script lang="ts">
+  import { Slider } from '../../../../components/src/index.ts';
+</script>
+
+<div style="display: flex; flex-direction: column; gap: 1rem; max-width: 24rem;">
+  <Slider label="Volume" defaultValue={40} disabled />
+</div>

--- a/packages/playground/src/examples/slider/inside-form-field.example.svelte
+++ b/packages/playground/src/examples/slider/inside-form-field.example.svelte
@@ -1,0 +1,27 @@
+<script lang="ts" module>
+  export const title = 'Slider inside FormField';
+  export const description =
+    'Compose `Slider` with `FormField` for label, helper text, and error wiring.';
+</script>
+
+<script lang="ts">
+  import { FormField, Slider } from '../../../../components/src/index.ts';
+
+  let value = $state(50);
+</script>
+
+<form style="display: flex; flex-direction: column; gap: 1rem; max-width: 24rem;">
+  <FormField id="quality" label="Quality" description="Higher values produce larger files.">
+    <Slider
+      label="Quality"
+      {value}
+      min={0}
+      max={100}
+      step={10}
+      name="quality"
+      onchange={(next) => {
+        value = next as number;
+      }}
+    />
+  </FormField>
+</form>

--- a/packages/playground/src/examples/slider/inside-form-field.example.svelte
+++ b/packages/playground/src/examples/slider/inside-form-field.example.svelte
@@ -20,7 +20,7 @@
       step={10}
       name="quality"
       onchange={(next) => {
-        value = next as number;
+        value = next;
       }}
     />
   </FormField>

--- a/packages/playground/src/examples/slider/range.example.svelte
+++ b/packages/playground/src/examples/slider/range.example.svelte
@@ -1,0 +1,23 @@
+<script lang="ts" module>
+  export const title = 'Range slider';
+  export const description =
+    'Two thumbs constrained so the low value never exceeds the high value.';
+</script>
+
+<script lang="ts">
+  import { Slider } from '../../../../components/src/index.ts';
+
+  let value = $state<[number, number]>([20, 80]);
+</script>
+
+<div style="display: flex; flex-direction: column; gap: 1rem; max-width: 24rem;">
+  <Slider
+    label="Price"
+    mode="range"
+    {value}
+    onchange={(next) => {
+      value = next as [number, number];
+    }}
+  />
+  <p>Range: {value[0]} – {value[1]}</p>
+</div>

--- a/packages/playground/src/examples/slider/range.example.svelte
+++ b/packages/playground/src/examples/slider/range.example.svelte
@@ -16,7 +16,7 @@
     mode="range"
     {value}
     onchange={(next) => {
-      value = next as [number, number];
+      value = next;
     }}
   />
   <p>Range: {value[0]} – {value[1]}</p>

--- a/packages/playground/src/examples/slider/with-ticks.example.svelte
+++ b/packages/playground/src/examples/slider/with-ticks.example.svelte
@@ -1,0 +1,23 @@
+<script lang="ts" module>
+  export const title = 'Slider with tick marks';
+  export const description =
+    'Discrete tick marks. When `ticks` is an array, arrow keys step between adjacent ticks.';
+</script>
+
+<script lang="ts">
+  import { Slider } from '../../../../components/src/index.ts';
+
+  let value = $state(50);
+</script>
+
+<div style="display: flex; flex-direction: column; gap: 1rem; max-width: 24rem;">
+  <Slider
+    label="Density"
+    {value}
+    ticks={[0, 25, 50, 75, 100]}
+    onchange={(next) => {
+      value = next as number;
+    }}
+  />
+  <p>Value: {value}</p>
+</div>

--- a/packages/playground/src/examples/slider/with-ticks.example.svelte
+++ b/packages/playground/src/examples/slider/with-ticks.example.svelte
@@ -16,7 +16,7 @@
     {value}
     ticks={[0, 25, 50, 75, 100]}
     onchange={(next) => {
-      value = next as number;
+      value = next;
     }}
   />
   <p>Value: {value}</p>

--- a/packages/playground/src/examples/slider/with-value-text.example.svelte
+++ b/packages/playground/src/examples/slider/with-value-text.example.svelte
@@ -1,0 +1,47 @@
+<script lang="ts" module>
+  export const title = 'Slider with formatted value text';
+  export const description =
+    'Use `valueText` to format the value for screen readers — percentages, currency, dates.';
+</script>
+
+<script lang="ts">
+  import { Slider } from '../../../../components/src/index.ts';
+
+  let percent = $state(60);
+  let price = $state(250);
+
+  const usd = new Intl.NumberFormat('en-US', {
+    style: 'currency',
+    currency: 'USD',
+    maximumFractionDigits: 0,
+  });
+</script>
+
+<div style="display: flex; flex-direction: column; gap: 1.5rem; max-width: 24rem;">
+  <div>
+    <Slider
+      label="Opacity"
+      value={percent}
+      valueText={(value) => `${value} percent`}
+      onchange={(next) => {
+        percent = next as number;
+      }}
+    />
+    <p>Opacity: {percent}%</p>
+  </div>
+
+  <div>
+    <Slider
+      label="Budget"
+      value={price}
+      min={0}
+      max={1000}
+      step={25}
+      valueText={(value) => usd.format(value)}
+      onchange={(next) => {
+        price = next as number;
+      }}
+    />
+    <p>Budget: {usd.format(price)}</p>
+  </div>
+</div>

--- a/packages/playground/src/examples/slider/with-value-text.example.svelte
+++ b/packages/playground/src/examples/slider/with-value-text.example.svelte
@@ -24,7 +24,7 @@
       value={percent}
       valueText={(value) => `${value} percent`}
       onchange={(next) => {
-        percent = next as number;
+        percent = next;
       }}
     />
     <p>Opacity: {percent}%</p>
@@ -39,7 +39,7 @@
       step={25}
       valueText={(value) => usd.format(value)}
       onchange={(next) => {
-        price = next as number;
+        price = next;
       }}
     />
     <p>Budget: {usd.format(price)}</p>


### PR DESCRIPTION
## Summary

Add `slider.svelte`, a single-thumb and dual-thumb (range) slider that follows the WAI-ARIA `role="slider"` pattern. Supports controlled and uncontrolled usage, optional tick marks (boolean or numeric array), `valueText` formatter for `aria-valuetext`, pointer drag with `document`-level move tracking, and `FormField` composition with hidden form inputs for native submission.

Distinct from `progress.svelte` (passive) and from the internal sliders inside `color-picker.svelte` (specialized).

## Review committee

Pre-reviewed by: typescript-expert, testing-expert, frontend-architect, ux-designer, simplicity-engineer, junior-engineer
- Codex (gpt-5.4, xhigh reasoning) — 4 rounds
- 4 rounds of review
- All must-fix items addressed

Key fixes through the rounds:
- Document listener leak → `<svelte:document>` with conditional handlers
- State mutation in `$effect` → `$derived` `currentValue` + separate `$state` for uncontrolled path
- Discriminated `SliderProps` (`SliderSingleProps | SliderRangeProps`) so `mode='range'` requires tuple value/onchange
- `tickList` normalized once (filtered + sorted), shared by snap/neighbor/render
- `safeStep` validation prevents infinite-loop on `step=0`/`NaN`
- Range thumbs inside `FormField` use `aria-labelledby` referencing field label + visually-hidden qualifier spans containing only "minimum value"/"maximum value" (no duplication)
- `$props.id()` gives per-instance qualifier ids so multiple sliders never collide
- `touch-action: none` on thumbs + track for mobile reliability
- `z-index: 2` on `[data-cinder-active]` thumbs
- `normalizeValueForMode` clamps/orders initial uncontrolled state

## Test plan

- `bun test packages/components/src/components/slider.test.ts` — 38 tests pass
- `bun run typecheck` — 0 errors
- `bun run lint` — 0 errors
- Playground examples at `packages/playground/src/examples/slider/`: basic, range, with-ticks, with-value-text, disabled, inside-form-field

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it introduces a new complex interactive control (keyboard/pointer handling, controlled/uncontrolled state, ARIA wiring) that could have subtle accessibility or input-edge-case issues, though changes are largely additive and well-tested.
> 
> **Overview**
> Adds a new `Slider` component implementing the WAI-ARIA `role="slider"` pattern, supporting **single-value** and **two-thumb range** modes with controlled/uncontrolled usage, keyboard support (arrows/page/home/end), pointer dragging, optional tick marks, and `valueText` for `aria-valuetext`.
> 
> Integrates with `FormField` (label/description/invalid/disabled via context) and native form submission via hidden inputs, and includes new component styling (`slider.css`), extensive unit tests, updated package exports (`package.json` + `src/index.ts`), and new playground examples demonstrating common configurations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 57b979898f6ae82a65dc4a6cb79210d555c68435. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->