### PR TITLE
refactor(page-layout): extract --cinder-content-width token

### DIFF
--- a/packages/components/src/components/page-layout.test.ts
+++ b/packages/components/src/components/page-layout.test.ts
@@ -336,22 +336,23 @@ describe('PageLayout integration: all slots simultaneously', () => {
 
 describe('PageLayout content-width token', () => {
   test('page-layout.css uses --cinder-content-width for max-width caps', async () => {
-    const { join } = await import('node:path');
-    const cssPath = join(import.meta.dir, '../styles/components/page-layout.css');
+    const cssPath = new URL('../styles/components/page-layout.css', import.meta.url);
     const source = await Bun.file(cssPath).text();
 
-    // No hardcoded width value on max-width — must reference the shared token.
-    const hardcodedMaxWidth = /max-width:\s*\d/.exec(source);
+    // No hardcoded length on max-width — must reference the shared token.
+    // Matches dimensional units only; viewport-relative or percentage values
+    // (e.g. 100%, 100vw) are legitimate and intentionally not flagged.
+    const hardcodedMaxWidth = /max-width:\s*\d+(?:\.\d+)?(?:rem|px|em|ch)\b/.exec(source);
     expect(hardcodedMaxWidth).toBeNull();
 
-    // Three layout regions cap their inline size: breadcrumbs, header row, content.
+    // Three layout regions cap their inline size: breadcrumbs, header-row, content.
+    // If you add a fourth, update this count deliberately.
     const tokenReferences = source.match(/max-width:\s*var\(--cinder-content-width\)/g) ?? [];
     expect(tokenReferences.length).toBe(3);
   });
 
   test('--cinder-content-width is declared in tokens-base.css', async () => {
-    const { join } = await import('node:path');
-    const tokensPath = join(import.meta.dir, '../styles/tokens-base.css');
+    const tokensPath = new URL('../styles/tokens-base.css', import.meta.url);
     const source = await Bun.file(tokensPath).text();
     expect(source).toMatch(/--cinder-content-width:\s*\S+/);
   });

--- a/packages/components/src/components/page-layout.test.ts
+++ b/packages/components/src/components/page-layout.test.ts
@@ -333,3 +333,26 @@ describe('PageLayout integration: all slots simultaneously', () => {
     expect(breadcrumbsEl.compareDocumentPosition(contentEl) & FOLLOWING).toBeTruthy();
   });
 });
+
+describe('PageLayout content-width token', () => {
+  test('page-layout.css uses --cinder-content-width for max-width caps', async () => {
+    const { join } = await import('node:path');
+    const cssPath = join(import.meta.dir, '../styles/components/page-layout.css');
+    const source = await Bun.file(cssPath).text();
+
+    // No hardcoded width value on max-width — must reference the shared token.
+    const hardcodedMaxWidth = /max-width:\s*\d/.exec(source);
+    expect(hardcodedMaxWidth).toBeNull();
+
+    // Three layout regions cap their inline size: breadcrumbs, header row, content.
+    const tokenReferences = source.match(/max-width:\s*var\(--cinder-content-width\)/g) ?? [];
+    expect(tokenReferences.length).toBe(3);
+  });
+
+  test('--cinder-content-width is declared in tokens-base.css', async () => {
+    const { join } = await import('node:path');
+    const tokensPath = join(import.meta.dir, '../styles/tokens-base.css');
+    const source = await Bun.file(tokensPath).text();
+    expect(source).toMatch(/--cinder-content-width:\s*\S+/);
+  });
+});

--- a/packages/components/src/styles/components/page-layout.css
+++ b/packages/components/src/styles/components/page-layout.css
@@ -30,7 +30,7 @@
 
 .cinder-page-layout-breadcrumbs {
   width: 100%;
-  max-width: 72rem;
+  max-width: var(--cinder-content-width);
   margin-inline: auto;
   padding-inline: var(--cinder-space-4);
   padding-block: var(--cinder-space-2);
@@ -52,7 +52,7 @@
   gap: var(--cinder-space-3);
   /* 2.75rem = 44px — WCAG 2.5.5 minimum touch target row height */
   min-block-size: 2.75rem;
-  max-width: 72rem;
+  max-width: var(--cinder-content-width);
   margin-inline: auto;
   padding-inline: var(--cinder-space-4);
 }
@@ -126,7 +126,7 @@
   flex: 1 1 0;
   min-height: 0;
   width: 100%;
-  max-width: 72rem;
+  max-width: var(--cinder-content-width);
   margin-inline: auto;
   padding-inline: var(--cinder-space-4);
   padding-block: var(--cinder-space-6);

--- a/packages/components/src/styles/tokens-base.css
+++ b/packages/components/src/styles/tokens-base.css
@@ -74,8 +74,8 @@
    * ======================================== */
   /**
    * Maximum inline size for primary page content. Caps line length and keeps
-   * content readable on wide viewports. Consumed by `page-layout.svelte` and
-   * the `Center` Every-Layout primitive; consumers can override per scope.
+   * content readable on wide viewports. Used by page layout styles; consumers
+   * can override per scope.
    */
   --cinder-content-width: 72rem;
 

--- a/packages/components/src/styles/tokens-base.css
+++ b/packages/components/src/styles/tokens-base.css
@@ -70,6 +70,16 @@
   --cinder-touch-target-min: 44px;
 
   /* ========================================
+   * LAYOUT
+   * ======================================== */
+  /**
+   * Maximum inline size for primary page content. Caps line length and keeps
+   * content readable on wide viewports. Consumed by `page-layout.svelte` and
+   * the `Center` Every-Layout primitive; consumers can override per scope.
+   */
+  --cinder-content-width: 72rem;
+
+  /* ========================================
    * MOTION
    * ======================================== */
   --cinder-duration-instant: 0ms;


### PR DESCRIPTION
## Summary
Extracts the repeated `72rem` page layout max-width into a shared `--cinder-content-width` token and updates the PageLayout styles to consume it from breadcrumbs, the header row, and content.

This keeps the current layout behavior the same while making the width constraint a single design-token source of truth. The follow-up review fixes tighten the regression guard so it only flags dimensional literals, align file-path resolution with the existing `import.meta.url` pattern, and document the exact-count sentinel in the test.

## Review committee
Pre-reviewed by: simplicity-engineer, frontend-architect, testing-expert, junior-engineer
- Codex (gpt-5.4, xhigh reasoning) — 3 rounds
- 3 rounds of review
- All must-fix items addressed

## Test plan
- `bun test packages/components/src/components/page-layout.test.ts`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this is a small CSS refactor that preserves the existing `72rem` max-width behavior while centralizing it into a token, with tests added to prevent regressions.
> 
> **Overview**
> Extracts PageLayout’s repeated `max-width: 72rem` into a shared `--cinder-content-width` token declared in `tokens-base.css`, and updates `page-layout.css` to use the token for breadcrumbs, header-row, and content width caps.
> 
> Adds regression tests in `page-layout.test.ts` to assert no hardcoded dimensional `max-width` values remain and that the token is referenced exactly three times and is declared in the base tokens file.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 92ec57928fb14ca92d1387de66eeb736b35953b0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->