### PR TITLE
feat(scroll-area): add ScrollArea — styled native-scrollbar container

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -269,6 +269,10 @@
       "svelte": "./src/components/review-editor.svelte",
       "types": "./dist/components/review-editor.svelte.d.ts"
     },
+    "./scroll-area": {
+      "svelte": "./src/components/scroll-area.svelte",
+      "types": "./dist/components/scroll-area.svelte.d.ts"
+    },
     "./section-heading": {
       "svelte": "./src/components/section-heading.svelte",
       "types": "./dist/components/section-heading.svelte.d.ts"

--- a/packages/components/src/components/scroll-area.svelte
+++ b/packages/components/src/components/scroll-area.svelte
@@ -1,0 +1,95 @@
+<script lang="ts" module>
+  import type { Snippet } from 'svelte';
+  import type { HTMLAttributes } from 'svelte/elements';
+
+  /** Axis to allow scrolling along. */
+  export type ScrollAreaDirection = 'vertical' | 'horizontal' | 'both';
+
+  /**
+   * Non-void element tags valid for the `as` prop. Void elements are excluded
+   * because this component always renders a `children` snippet.
+   */
+  export type ScrollAreaElement = Exclude<
+    keyof HTMLElementTagNameMap,
+    | 'area'
+    | 'base'
+    | 'br'
+    | 'col'
+    | 'embed'
+    | 'hr'
+    | 'img'
+    | 'input'
+    | 'link'
+    | 'meta'
+    | 'source'
+    | 'track'
+    | 'wbr'
+  >;
+
+  /**
+   * Props for ScrollArea. A styled scrollable container with cross-browser
+   * scrollbar theming via design tokens. This is chrome only — virtualization
+   * (svelte-virtual, TanStack Virtual, etc.) remains a consumer-level concern
+   * and pairs *with* this component, not inside it.
+   */
+  export type ScrollAreaProps = Omit<HTMLAttributes<HTMLElement>, 'class' | 'children'> & {
+    /** Axis to allow scrolling on. Defaults to `'vertical'`. */
+    direction?: ScrollAreaDirection;
+    /** Maximum block size of the scroll viewport (any valid CSS length). */
+    maxHeight?: string;
+    /** Maximum inline size of the scroll viewport (any valid CSS length). */
+    maxWidth?: string;
+    /**
+     * Accessible name for the scroll region. When provided, the container also
+     * gets `role="region"` so assistive technology treats it as a landmark.
+     * Provide this when the scroll area represents a meaningful section
+     * (a chat transcript, a code panel) — omit it for purely decorative
+     * scrolling chrome.
+     */
+    ariaLabel?: string;
+    /**
+     * Override the default focusable behavior. The component sets `tabindex="0"`
+     * by default so keyboard users can scroll the viewport with arrow keys.
+     * Pass `tabindex={-1}` (or any value) to opt out or change the order.
+     */
+    tabindex?: number;
+    /** Element tag to render. Defaults to `'div'`. */
+    as?: ScrollAreaElement;
+    /** Additional classes merged onto the scroll viewport. */
+    class?: string;
+    /** Scrollable content. */
+    children: Snippet;
+  };
+</script>
+
+<script lang="ts">
+  import { classNames } from '../utilities/class-names.ts';
+
+  let {
+    direction = 'vertical',
+    maxHeight,
+    maxWidth,
+    ariaLabel,
+    tabindex = 0,
+    as = 'div',
+    class: className,
+    children,
+    ...rest
+  }: ScrollAreaProps = $props();
+
+  const role = $derived(ariaLabel ? 'region' : undefined);
+</script>
+
+<svelte:element
+  this={as}
+  class={classNames('cinder-scroll-area', className)}
+  data-cinder-direction={direction}
+  {role}
+  aria-label={ariaLabel}
+  {tabindex}
+  style:max-block-size={maxHeight}
+  style:max-inline-size={maxWidth}
+  {...rest}
+>
+  {@render children()}
+</svelte:element>

--- a/packages/components/src/components/scroll-area.svelte
+++ b/packages/components/src/components/scroll-area.svelte
@@ -5,26 +5,20 @@
   /** Axis to allow scrolling along. */
   export type ScrollAreaDirection = 'vertical' | 'horizontal' | 'both';
 
-  /**
-   * Non-void element tags valid for the `as` prop. Void elements are excluded
-   * because this component always renders a `children` snippet.
-   */
-  export type ScrollAreaElement = Exclude<
-    keyof HTMLElementTagNameMap,
-    | 'area'
-    | 'base'
-    | 'br'
-    | 'col'
-    | 'embed'
-    | 'hr'
-    | 'img'
-    | 'input'
-    | 'link'
-    | 'meta'
-    | 'source'
-    | 'track'
-    | 'wbr'
-  >;
+  /** Element tags intentionally supported by the `as` prop. */
+  export type ScrollAreaElement =
+    | 'article'
+    | 'aside'
+    | 'div'
+    | 'li'
+    | 'main'
+    | 'nav'
+    | 'ol'
+    | 'pre'
+    | 'section'
+    | 'ul';
+
+  const explicitRegionElements = new Set<ScrollAreaElement>(['div', 'pre']);
 
   /**
    * Props for ScrollArea. A styled scrollable container with cross-browser
@@ -43,9 +37,10 @@
     /** Maximum inline size of the scroll viewport (any valid CSS length). */
     maxWidth?: string;
     /**
-     * Accessible name for the scroll region. When provided, the container also
-     * gets `role="region"` so assistive technology treats it as a landmark.
-     * Provide this when the scroll area represents a meaningful section
+     * Accessible name for the scroll region. When provided on neutral
+     * containers, the container also gets `role="region"` so assistive
+     * technology treats it as a landmark. Semantic tags keep their native
+     * roles. Provide this when the scroll area represents a meaningful section
      * (a chat transcript, a code panel) — omit it for purely decorative
      * scrolling chrome. This is the single source of truth for the accessible
      * name; pass it through this prop rather than the raw `aria-label` HTML
@@ -84,7 +79,12 @@
     ...rest
   }: ScrollAreaProps = $props();
 
-  const role = $derived(ariaLabel ? 'region' : undefined);
+  const normalizedAriaLabel = $derived(
+    typeof ariaLabel === 'string' && ariaLabel.trim().length > 0 ? ariaLabel.trim() : undefined,
+  );
+  const role = $derived(
+    normalizedAriaLabel && explicitRegionElements.has(as) ? 'region' : undefined,
+  );
 </script>
 
 <svelte:element
@@ -93,7 +93,7 @@
   class={classNames('cinder-scroll-area', className)}
   data-cinder-direction={direction}
   {role}
-  aria-label={ariaLabel}
+  aria-label={normalizedAriaLabel}
   {tabindex}
   style:max-block-size={maxHeight}
   style:max-inline-size={maxWidth}

--- a/packages/components/src/components/scroll-area.svelte
+++ b/packages/components/src/components/scroll-area.svelte
@@ -32,7 +32,10 @@
    * (svelte-virtual, TanStack Virtual, etc.) remains a consumer-level concern
    * and pairs *with* this component, not inside it.
    */
-  export type ScrollAreaProps = Omit<HTMLAttributes<HTMLElement>, 'class' | 'children'> & {
+  export type ScrollAreaProps = Omit<
+    HTMLAttributes<HTMLElement>,
+    'class' | 'children' | 'tabindex' | 'role' | 'aria-label'
+  > & {
     /** Axis to allow scrolling on. Defaults to `'vertical'`. */
     direction?: ScrollAreaDirection;
     /** Maximum block size of the scroll viewport (any valid CSS length). */
@@ -44,13 +47,17 @@
      * gets `role="region"` so assistive technology treats it as a landmark.
      * Provide this when the scroll area represents a meaningful section
      * (a chat transcript, a code panel) — omit it for purely decorative
-     * scrolling chrome.
+     * scrolling chrome. This is the single source of truth for the accessible
+     * name; pass it through this prop rather than the raw `aria-label` HTML
+     * attribute so the landmark role and label stay coupled.
      */
     ariaLabel?: string;
     /**
      * Override the default focusable behavior. The component sets `tabindex="0"`
      * by default so keyboard users can scroll the viewport with arrow keys.
-     * Pass `tabindex={-1}` (or any value) to opt out or change the order.
+     * Pass `tabindex={-1}` to opt out when the scroll area wraps content that
+     * is guaranteed not to overflow, or when the container is focused
+     * programmatically rather than via tab order.
      */
     tabindex?: number;
     /** Element tag to render. Defaults to `'div'`. */
@@ -82,6 +89,7 @@
 
 <svelte:element
   this={as}
+  {...rest}
   class={classNames('cinder-scroll-area', className)}
   data-cinder-direction={direction}
   {role}
@@ -89,7 +97,6 @@
   {tabindex}
   style:max-block-size={maxHeight}
   style:max-inline-size={maxWidth}
-  {...rest}
 >
   {@render children()}
 </svelte:element>

--- a/packages/components/src/components/scroll-area.test.ts
+++ b/packages/components/src/components/scroll-area.test.ts
@@ -68,8 +68,8 @@ describe('ScrollArea', () => {
   test('omits role and aria-label when ariaLabel is not provided', () => {
     const { container } = render(ScrollArea, { children: textSnippet('body') });
     const root = container.querySelector('.cinder-scroll-area');
-    expect(root?.getAttribute('role')).toBeNull();
-    expect(root?.getAttribute('aria-label')).toBeNull();
+    expect(root?.hasAttribute('role')).toBe(false);
+    expect(root?.hasAttribute('aria-label')).toBe(false);
   });
 
   test('applies tabindex="0" by default so keyboard users can scroll', () => {
@@ -93,6 +93,16 @@ describe('ScrollArea', () => {
     expect(root?.style.getPropertyValue('max-inline-size')).toBe('40rem');
   });
 
+  test('omits max-inline-size when only maxHeight is provided', () => {
+    const { container } = render(ScrollArea, {
+      maxHeight: '20rem',
+      children: textSnippet('body'),
+    });
+    const root = container.querySelector<HTMLElement>('.cinder-scroll-area');
+    expect(root?.style.getPropertyValue('max-block-size')).toBe('20rem');
+    expect(root?.style.getPropertyValue('max-inline-size')).toBe('');
+  });
+
   test('merges a consumer-provided class with cinder-scroll-area', () => {
     const { container } = render(ScrollArea, {
       class: 'extra-class',
@@ -108,7 +118,38 @@ describe('ScrollArea', () => {
       'data-testid': 'scroll',
       children: textSnippet('body'),
     });
-    expect(container.querySelector('[data-testid="scroll"]')).not.toBeNull();
+    const root = container.querySelector('.cinder-scroll-area');
+    expect(root?.getAttribute('data-testid')).toBe('scroll');
+  });
+
+  test('renders the tag passed via as="article" (non-sectioning element)', () => {
+    const { container } = render(ScrollArea, { as: 'article', children: textSnippet('body') });
+    expect(container.querySelector('article.cinder-scroll-area')).not.toBeNull();
+  });
+});
+
+describe('ScrollArea attribute precedence', () => {
+  test('consumer-supplied role via rest props does not override the component-derived role', () => {
+    // `role` is Omitted from ScrollAreaProps, so we cast to `any` to simulate
+    // a consumer reaching past the type to pass it anyway — the runtime
+    // contract must still hold.
+    const { container } = render(ScrollArea, {
+      ariaLabel: 'Chat transcript',
+      role: 'complementary',
+      children: textSnippet('body'),
+    } as any);
+    expect(container.querySelector('.cinder-scroll-area')?.getAttribute('role')).toBe('region');
+  });
+
+  test('consumer-supplied direction via data-cinder-direction does not override the prop', () => {
+    const { container } = render(ScrollArea, {
+      direction: 'horizontal',
+      'data-cinder-direction': 'vertical',
+      children: textSnippet('body'),
+    });
+    expect(
+      container.querySelector('.cinder-scroll-area')?.getAttribute('data-cinder-direction'),
+    ).toBe('horizontal');
   });
 });
 
@@ -116,10 +157,12 @@ describe('ScrollArea scrollbar tokens', () => {
   test('scrollbar tokens are declared in tokens-base.css', async () => {
     const tokensPath = new URL('../styles/tokens-base.css', import.meta.url);
     const source = await Bun.file(tokensPath).text();
-    expect(source).toMatch(/--cinder-scrollbar-track:\s*\S+/);
-    expect(source).toMatch(/--cinder-scrollbar-thumb:\s*\S+/);
-    expect(source).toMatch(/--cinder-scrollbar-thumb-hover:\s*\S+/);
-    expect(source).toMatch(/--cinder-scrollbar-size:\s*\S+/);
+    // Use a colon anchor so `--cinder-scrollbar-thumb` does not also match
+    // `--cinder-scrollbar-thumb-hover` (prefix overlap).
+    expect(source).toMatch(/--cinder-scrollbar-size\s*:/);
+    expect(source).toMatch(/--cinder-scrollbar-track\s*:/);
+    expect(source).toMatch(/--cinder-scrollbar-thumb\s*:/);
+    expect(source).toMatch(/--cinder-scrollbar-thumb-hover\s*:/);
   });
 
   test('scroll-area.css consumes the scrollbar tokens for both engines', async () => {

--- a/packages/components/src/components/scroll-area.test.ts
+++ b/packages/components/src/components/scroll-area.test.ts
@@ -65,6 +65,47 @@ describe('ScrollArea', () => {
     expect(root?.getAttribute('aria-label')).toBe('Chat transcript');
   });
 
+  test('trims ariaLabel before deriving the accessible region label', () => {
+    const { container } = render(ScrollArea, {
+      ariaLabel: '  Chat transcript  ',
+      children: textSnippet('body'),
+    });
+    const root = container.querySelector('.cinder-scroll-area');
+    expect(root?.getAttribute('role')).toBe('region');
+    expect(root?.getAttribute('aria-label')).toBe('Chat transcript');
+  });
+
+  test('omits role and aria-label when ariaLabel is empty after trimming', () => {
+    const { container } = render(ScrollArea, {
+      ariaLabel: '   ',
+      children: textSnippet('body'),
+    });
+    const root = container.querySelector('.cinder-scroll-area');
+    expect(root?.hasAttribute('role')).toBe(false);
+    expect(root?.hasAttribute('aria-label')).toBe(false);
+  });
+
+  test('omits role and aria-label when ariaLabel is an empty string', () => {
+    const { container } = render(ScrollArea, {
+      ariaLabel: '',
+      children: textSnippet('body'),
+    });
+    const root = container.querySelector('.cinder-scroll-area');
+    expect(root?.hasAttribute('role')).toBe(false);
+    expect(root?.hasAttribute('aria-label')).toBe(false);
+  });
+
+  test('does not override semantic element roles when ariaLabel is provided', () => {
+    const { container } = render(ScrollArea, {
+      as: 'main',
+      ariaLabel: 'Primary page content',
+      children: textSnippet('body'),
+    });
+    const root = container.querySelector('main.cinder-scroll-area');
+    expect(root?.hasAttribute('role')).toBe(false);
+    expect(root?.getAttribute('aria-label')).toBe('Primary page content');
+  });
+
   test('omits role and aria-label when ariaLabel is not provided', () => {
     const { container } = render(ScrollArea, { children: textSnippet('body') });
     const root = container.querySelector('.cinder-scroll-area');
@@ -122,7 +163,12 @@ describe('ScrollArea', () => {
     expect(root?.getAttribute('data-testid')).toBe('scroll');
   });
 
-  test('renders the tag passed via as="article" (non-sectioning element)', () => {
+  test('renders the tag passed via as="main"', () => {
+    const { container } = render(ScrollArea, { as: 'main', children: textSnippet('body') });
+    expect(container.querySelector('main.cinder-scroll-area')).not.toBeNull();
+  });
+
+  test('renders the tag passed via as="article"', () => {
     const { container } = render(ScrollArea, { as: 'article', children: textSnippet('body') });
     expect(container.querySelector('article.cinder-scroll-area')).not.toBeNull();
   });
@@ -171,5 +217,14 @@ describe('ScrollArea scrollbar tokens', () => {
     expect(source).toMatch(/scrollbar-color:\s*var\(--cinder-scrollbar-thumb\)/);
     expect(source).toMatch(/::-webkit-scrollbar-thumb/);
     expect(source).toMatch(/var\(--cinder-scrollbar-track\)/);
+  });
+
+  test('forced-colors fallback uses standardized system colors', async () => {
+    const cssPath = new URL('../styles/components/scroll-area.css', import.meta.url);
+    const source = await Bun.file(cssPath).text();
+    expect(source).not.toContain('ScrollbarThumb');
+    expect(source).not.toContain('ScrollbarTrack');
+    expect(source).toMatch(/background:\s*Canvas;/);
+    expect(source).toMatch(/background:\s*CanvasText;/);
   });
 });

--- a/packages/components/src/components/scroll-area.test.ts
+++ b/packages/components/src/components/scroll-area.test.ts
@@ -1,0 +1,132 @@
+/// <reference lib="dom" />
+import { describe, expect, test } from 'bun:test';
+
+import { setupHappyDom } from '../test/happy-dom.ts';
+
+setupHappyDom();
+
+const { render } = await import('@testing-library/svelte');
+const { default: ScrollArea } = await import('./scroll-area.svelte');
+const { createRawSnippet } = await import('svelte');
+
+function textSnippet(text: string) {
+  return createRawSnippet(() => ({
+    render: () => `<span>${text}</span>`,
+  }));
+}
+
+describe('ScrollArea', () => {
+  test('renders a <div> by default with the scroll-area class', () => {
+    const { container } = render(ScrollArea, { children: textSnippet('body') });
+    const root = container.querySelector('div.cinder-scroll-area');
+    expect(root).not.toBeNull();
+    expect(root?.textContent).toContain('body');
+  });
+
+  test('honors the `as` prop for the rendered element', () => {
+    const { container } = render(ScrollArea, { as: 'section', children: textSnippet('body') });
+    expect(container.querySelector('section.cinder-scroll-area')).not.toBeNull();
+    expect(container.querySelector('div.cinder-scroll-area')).toBeNull();
+  });
+
+  test('defaults to vertical direction via data attribute', () => {
+    const { container } = render(ScrollArea, { children: textSnippet('body') });
+    const root = container.querySelector('.cinder-scroll-area');
+    expect(root?.getAttribute('data-cinder-direction')).toBe('vertical');
+  });
+
+  test('reflects horizontal direction on the data attribute', () => {
+    const { container } = render(ScrollArea, {
+      direction: 'horizontal',
+      children: textSnippet('body'),
+    });
+    expect(
+      container.querySelector('.cinder-scroll-area')?.getAttribute('data-cinder-direction'),
+    ).toBe('horizontal');
+  });
+
+  test('reflects bidirectional scrolling on the data attribute', () => {
+    const { container } = render(ScrollArea, {
+      direction: 'both',
+      children: textSnippet('body'),
+    });
+    expect(
+      container.querySelector('.cinder-scroll-area')?.getAttribute('data-cinder-direction'),
+    ).toBe('both');
+  });
+
+  test('adds role="region" and aria-label when ariaLabel is provided', () => {
+    const { container } = render(ScrollArea, {
+      ariaLabel: 'Chat transcript',
+      children: textSnippet('body'),
+    });
+    const root = container.querySelector('.cinder-scroll-area');
+    expect(root?.getAttribute('role')).toBe('region');
+    expect(root?.getAttribute('aria-label')).toBe('Chat transcript');
+  });
+
+  test('omits role and aria-label when ariaLabel is not provided', () => {
+    const { container } = render(ScrollArea, { children: textSnippet('body') });
+    const root = container.querySelector('.cinder-scroll-area');
+    expect(root?.getAttribute('role')).toBeNull();
+    expect(root?.getAttribute('aria-label')).toBeNull();
+  });
+
+  test('applies tabindex="0" by default so keyboard users can scroll', () => {
+    const { container } = render(ScrollArea, { children: textSnippet('body') });
+    expect(container.querySelector('.cinder-scroll-area')?.getAttribute('tabindex')).toBe('0');
+  });
+
+  test('allows consumers to override tabindex', () => {
+    const { container } = render(ScrollArea, { tabindex: -1, children: textSnippet('body') });
+    expect(container.querySelector('.cinder-scroll-area')?.getAttribute('tabindex')).toBe('-1');
+  });
+
+  test('applies maxHeight and maxWidth as inline logical sizing styles', () => {
+    const { container } = render(ScrollArea, {
+      maxHeight: '20rem',
+      maxWidth: '40rem',
+      children: textSnippet('body'),
+    });
+    const root = container.querySelector<HTMLElement>('.cinder-scroll-area');
+    expect(root?.style.getPropertyValue('max-block-size')).toBe('20rem');
+    expect(root?.style.getPropertyValue('max-inline-size')).toBe('40rem');
+  });
+
+  test('merges a consumer-provided class with cinder-scroll-area', () => {
+    const { container } = render(ScrollArea, {
+      class: 'extra-class',
+      children: textSnippet('body'),
+    });
+    const root = container.querySelector('.cinder-scroll-area');
+    expect(root?.classList.contains('cinder-scroll-area')).toBe(true);
+    expect(root?.classList.contains('extra-class')).toBe(true);
+  });
+
+  test('forwards rest props onto the root element', () => {
+    const { container } = render(ScrollArea, {
+      'data-testid': 'scroll',
+      children: textSnippet('body'),
+    });
+    expect(container.querySelector('[data-testid="scroll"]')).not.toBeNull();
+  });
+});
+
+describe('ScrollArea scrollbar tokens', () => {
+  test('scrollbar tokens are declared in tokens-base.css', async () => {
+    const tokensPath = new URL('../styles/tokens-base.css', import.meta.url);
+    const source = await Bun.file(tokensPath).text();
+    expect(source).toMatch(/--cinder-scrollbar-track:\s*\S+/);
+    expect(source).toMatch(/--cinder-scrollbar-thumb:\s*\S+/);
+    expect(source).toMatch(/--cinder-scrollbar-thumb-hover:\s*\S+/);
+    expect(source).toMatch(/--cinder-scrollbar-size:\s*\S+/);
+  });
+
+  test('scroll-area.css consumes the scrollbar tokens for both engines', async () => {
+    const cssPath = new URL('../styles/components/scroll-area.css', import.meta.url);
+    const source = await Bun.file(cssPath).text();
+    expect(source).toMatch(/scrollbar-color:\s*var\(--cinder-scrollbar-thumb\)/);
+    expect(source).toMatch(/::-webkit-scrollbar-thumb/);
+    expect(source).toMatch(/var\(--cinder-scrollbar-track\)/);
+  });
+});

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -249,6 +249,13 @@ export {
   type ThreadManagerOptions,
 } from './components/review-editor/index.ts';
 
+export { default as ScrollArea } from './components/scroll-area.svelte';
+export type {
+  ScrollAreaDirection,
+  ScrollAreaElement,
+  ScrollAreaProps,
+} from './components/scroll-area.svelte';
+
 export { default as SectionHeading } from './components/section-heading.svelte';
 export type { SectionHeadingLevel, SectionHeadingProps } from './components/section-heading.svelte';
 

--- a/packages/components/src/styles/components.css
+++ b/packages/components/src/styles/components.css
@@ -51,6 +51,7 @@
 @import './components/radio.css';
 @import './components/radio-group.css';
 @import './components/review-editor.css';
+@import './components/scroll-area.css';
 @import './components/section-heading.css';
 @import './components/select.css';
 @import './components/segmented-control.css';

--- a/packages/components/src/styles/components/scroll-area.css
+++ b/packages/components/src/styles/components/scroll-area.css
@@ -79,11 +79,11 @@
 
   .cinder-scroll-area::-webkit-scrollbar-track,
   .cinder-scroll-area::-webkit-scrollbar-corner {
-    background: ScrollbarTrack;
+    background: Canvas;
   }
 
   .cinder-scroll-area::-webkit-scrollbar-thumb {
-    background: ScrollbarThumb;
+    background: CanvasText;
   }
 
   .cinder-scroll-area::-webkit-scrollbar-thumb:hover {

--- a/packages/components/src/styles/components/scroll-area.css
+++ b/packages/components/src/styles/components/scroll-area.css
@@ -1,0 +1,60 @@
+/* ========================================
+ * SCROLL AREA
+ *
+ * Styled scrollable container. Uses the native scrollbar (never substitutes
+ * a fake one) and themes it via cross-browser properties so keyboard, touch,
+ * and assistive-technology interactions stay intact.
+ * ======================================== */
+
+.cinder-scroll-area {
+  display: block;
+  min-block-size: 0;
+  min-inline-size: 0;
+
+  /* Firefox scrollbar theming. */
+  scrollbar-width: thin;
+  scrollbar-color: var(--cinder-scrollbar-thumb) var(--cinder-scrollbar-track);
+}
+
+.cinder-scroll-area[data-cinder-direction='vertical'] {
+  overflow-y: auto;
+  overflow-x: hidden;
+}
+
+.cinder-scroll-area[data-cinder-direction='horizontal'] {
+  overflow-x: auto;
+  overflow-y: hidden;
+}
+
+.cinder-scroll-area[data-cinder-direction='both'] {
+  overflow: auto;
+}
+
+/* Chromium / Safari scrollbar theming. */
+.cinder-scroll-area::-webkit-scrollbar {
+  inline-size: var(--cinder-scrollbar-size);
+  block-size: var(--cinder-scrollbar-size);
+}
+
+.cinder-scroll-area::-webkit-scrollbar-track {
+  background: var(--cinder-scrollbar-track);
+}
+
+.cinder-scroll-area::-webkit-scrollbar-thumb {
+  background: var(--cinder-scrollbar-thumb);
+  border-radius: var(--cinder-radius-sm);
+}
+
+.cinder-scroll-area::-webkit-scrollbar-thumb:hover {
+  background: var(--cinder-scrollbar-thumb-hover);
+}
+
+.cinder-scroll-area::-webkit-scrollbar-corner {
+  background: var(--cinder-scrollbar-track);
+}
+
+/* Visible focus ring for keyboard scroll users. */
+.cinder-scroll-area:focus-visible {
+  outline: var(--cinder-ring-width) solid var(--cinder-ring-color);
+  outline-offset: var(--cinder-ring-offset);
+}

--- a/packages/components/src/styles/components/scroll-area.css
+++ b/packages/components/src/styles/components/scroll-area.css
@@ -10,6 +10,10 @@
   display: block;
   min-block-size: 0;
   min-inline-size: 0;
+  /* Contain scroll momentum so reaching the end of this region does not
+   * bleed into an ancestor scroller (rubber-band on iOS, page-scroll on
+   * desktop). Matches the modal / command-palette body convention. */
+  overscroll-behavior: contain;
 
   /* Firefox scrollbar theming. */
   scrollbar-width: thin;
@@ -53,8 +57,36 @@
   background: var(--cinder-scrollbar-track);
 }
 
-/* Visible focus ring for keyboard scroll users. */
+/* Visible focus ring for keyboard scroll users. Matches the button focus
+ * pattern: transparent outline as a forced-colors fallback, box-shadow rings
+ * for offset + ring colors. */
 .cinder-scroll-area:focus-visible {
-  outline: var(--cinder-ring-width) solid var(--cinder-ring-color);
-  outline-offset: var(--cinder-ring-offset);
+  outline: var(--cinder-ring-width) solid transparent;
+  box-shadow:
+    0 0 0 var(--cinder-ring-offset) var(--cinder-ring-offset-color),
+    0 0 0 calc(var(--cinder-ring-offset) + var(--cinder-ring-width)) var(--cinder-ring-color);
+}
+
+/* Windows High Contrast Mode (forced-colors) ignores box-shadow and
+ * overrides custom scrollbar paint. Map the focus ring and scrollbar parts
+ * to system colors so keyboard users keep their affordances. */
+@media (forced-colors: active) {
+  .cinder-scroll-area:focus-visible {
+    outline: var(--cinder-ring-width) solid ButtonText;
+    outline-offset: 3px;
+    box-shadow: none;
+  }
+
+  .cinder-scroll-area::-webkit-scrollbar-track,
+  .cinder-scroll-area::-webkit-scrollbar-corner {
+    background: ScrollbarTrack;
+  }
+
+  .cinder-scroll-area::-webkit-scrollbar-thumb {
+    background: ScrollbarThumb;
+  }
+
+  .cinder-scroll-area::-webkit-scrollbar-thumb:hover {
+    background: ButtonText;
+  }
 }

--- a/packages/components/src/styles/tokens-base.css
+++ b/packages/components/src/styles/tokens-base.css
@@ -159,6 +159,15 @@
   --cinder-color-danger-fg: light-dark(oklch(32% 0.16 25), oklch(90% 0.12 25));
   --cinder-color-danger-border: light-dark(oklch(82% 0.1 25), oklch(50% 0.11 25));
 
+  /* Scrollbars — used by the ScrollArea component and any consumer that
+     opts into themed native scrollbars via `scrollbar-width` and
+     `::-webkit-scrollbar-*`. Kept semi-transparent so they sit lightly over
+     either light or dark surfaces. */
+  --cinder-scrollbar-size: 0.625rem;
+  --cinder-scrollbar-track: light-dark(oklch(0% 0 0 / 0.04), oklch(100% 0 0 / 0.04));
+  --cinder-scrollbar-thumb: light-dark(oklch(0% 0 0 / 0.25), oklch(100% 0 0 / 0.25));
+  --cinder-scrollbar-thumb-hover: light-dark(oklch(0% 0 0 / 0.4), oklch(100% 0 0 / 0.4));
+
   /* Focus ring */
   --cinder-ring-width: 3px;
   --cinder-ring-offset: 1px;

--- a/packages/components/src/styles/tokens-base.css
+++ b/packages/components/src/styles/tokens-base.css
@@ -161,12 +161,13 @@
 
   /* Scrollbars — used by the ScrollArea component and any consumer that
      opts into themed native scrollbars via `scrollbar-width` and
-     `::-webkit-scrollbar-*`. Kept semi-transparent so they sit lightly over
-     either light or dark surfaces. */
+     `::-webkit-scrollbar-*`. Thumb alpha is tuned so the resolved
+     thumb-on-surface contrast clears WCAG 1.4.11 (3:1) over the common
+     light- and dark-mode surface tokens. */
   --cinder-scrollbar-size: 0.625rem;
   --cinder-scrollbar-track: light-dark(oklch(0% 0 0 / 0.04), oklch(100% 0 0 / 0.04));
-  --cinder-scrollbar-thumb: light-dark(oklch(0% 0 0 / 0.25), oklch(100% 0 0 / 0.25));
-  --cinder-scrollbar-thumb-hover: light-dark(oklch(0% 0 0 / 0.4), oklch(100% 0 0 / 0.4));
+  --cinder-scrollbar-thumb: light-dark(oklch(0% 0 0 / 0.45), oklch(100% 0 0 / 0.45));
+  --cinder-scrollbar-thumb-hover: light-dark(oklch(0% 0 0 / 0.65), oklch(100% 0 0 / 0.65));
 
   /* Focus ring */
   --cinder-ring-width: 3px;


### PR DESCRIPTION
## Summary

Adds `ScrollArea` — a chrome-only scroll viewport for the cinder design system that themes the native scrollbar across Firefox (`scrollbar-width` / `scrollbar-color`) and Chromium/Safari (`::-webkit-scrollbar-*`) without substituting a fake scrollbar. Keyboard, touch, and assistive-technology scrolling stay intact.

- Defaults to vertical scrolling and `tabindex=0` so keyboard users can scroll the viewport with arrow keys.
- Opts into `role="region"` only when an `ariaLabel` is provided **and** the rendered tag is a neutral container (`div` or `pre`). Semantic landmarks (`main`, `section`, `nav`, etc.) keep their native roles.
- `ariaLabel` is normalized — empty and whitespace-only strings collapse to `undefined`, so no blank-named landmark ever ships.
- Cross-browser scrollbar theming via four new shared design tokens (`--cinder-scrollbar-{size,track,thumb,thumb-hover}`). Thumb contrast tuned to clear WCAG 1.4.11 (3:1).
- Forced-colors (Windows High Contrast) fallback maps the focus ring to `ButtonText` and the webkit scrollbar parts to `Canvas` / `CanvasText` / `ButtonText`.
- `overscroll-behavior: contain` prevents scroll bleed into ancestor scrollers (rubber-band on iOS, page scroll on desktop).
- Virtualization (svelte-virtual, TanStack Virtual, etc.) remains a consumer-level concern and pairs *with* this component — explicitly out of scope.

Implements ROADMAP.md § *Scroll area — ADD `scroll-area.svelte`*.

## Review committee

Pre-reviewed by: frontend-architect, ux-designer, testing-expert, typescript-expert, simplicity-engineer, junior-engineer
- Codex (gpt-5.4) — xhigh reasoning round 1, high reasoning rounds 2–3
- 3 rounds of review
- All must-fix items addressed; consensus reached

## Test plan

- `bun run --filter cinder test` — 1837 component tests pass
- `bun test scroll-area.test.ts` — 24 scoped tests, 43 expect() calls (covers defaults, all three `direction` values, `as` polymorphism including non-sectioning + semantic-landmark cases, `ariaLabel` on/off/empty/whitespace/trimmed, `tabindex` override, partial sizing, class merging, rest-prop forwarding, role + `data-cinder-direction` precedence under rest spread, and token presence + consumption)
- `bun run typecheck` — 0 errors
- `bun run lint` — 0 warnings, 0 errors

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a new UI component and CSS tokens/styles; risk is mainly visual/regression risk around scrollbar theming and focus/aria behavior, with minimal impact to existing components.
> 
> **Overview**
> Adds a new `ScrollArea` component that renders a configurable scrollable viewport (`direction`, `maxHeight`/`maxWidth`, polymorphic `as`) and normalizes `ariaLabel` to optionally apply `role="region"` plus `tabindex` defaults for keyboard scrolling.
> 
> Introduces cross-browser native scrollbar theming via new design tokens (`--cinder-scrollbar-*`) and a new `scroll-area.css` partial (including forced-colors fallback), wires the styles into `components.css`, exports the component/types from `src/index.ts`, and exposes it via `package.json` exports; includes a comprehensive `scroll-area.test.ts` suite covering props, attribute precedence, and token/CSS consumption.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0cc94b32b22f7dd6a1daa2edca29a095c5eac8f4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->