### PR TITLE
feat(image): add general-purpose image with placeholder and fallback

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -209,6 +209,10 @@
       "svelte": "./src/components/grid-list.svelte",
       "types": "./dist/components/grid-list.svelte.d.ts"
     },
+    "./image": {
+      "svelte": "./src/components/image.svelte",
+      "types": "./dist/components/image.svelte.d.ts"
+    },
     "./input": {
       "svelte": "./src/components/input.svelte",
       "types": "./dist/components/input.svelte.d.ts"

--- a/packages/components/src/components/image.a11y.md
+++ b/packages/components/src/components/image.a11y.md
@@ -1,0 +1,39 @@
+# Image — accessibility notes
+
+`Image` is a thin wrapper around `<img>` that adds aspect-ratio, a blur-up
+placeholder, and a fallback snippet. The accessible surface is the `<img>`
+element itself.
+
+## Required `alt`
+
+`alt` is a required prop with no default. Consumers must decide explicitly
+whether the image is decorative or meaningful:
+
+- **Meaningful images** — pass a description that conveys the image's
+  information or purpose.
+- **Decorative images** — pass `alt=""`. Empty string is a valid accessible
+  choice; it tells assistive tech the image is presentational and can be
+  skipped. Making this an explicit decision (rather than a silent default)
+  prevents the most common alt-text bug: missing `alt` attributes.
+
+## Lazy loading defaults
+
+`loading="lazy"` and `decoding="async"` are the defaults. For above-the-fold
+hero images, override with `loading="eager"` so the browser doesn't defer
+the most important image on the page.
+
+## Placeholder and error states
+
+The blur-up placeholder is purely visual — it's painted as the wrapper's
+background and faded out via opacity once the real image loads. Assistive tech
+only sees the `<img>` and its `alt`; the placeholder is not announced.
+
+When the image fails to load and a `fallback` snippet is provided, the
+`<img>` is unmounted and the fallback renders in its place. If the fallback
+itself contains imagery (e.g. a placeholder icon), the consumer is responsible
+for the accessible name in that fallback content.
+
+## Not for people
+
+`Image` does not render initials and has no concept of identity. For
+person-shaped thumbnails with initials fallback, use `Avatar`.

--- a/packages/components/src/components/image.a11y.md
+++ b/packages/components/src/components/image.a11y.md
@@ -35,11 +35,15 @@ the low-res layer through them. Assistive tech only sees the `<img>` and its
 `alt`; the placeholder is not announced.
 
 When the image fails to load and a `fallback` snippet is provided, the
-`<img>` is unmounted and the wrapper renders the fallback in its place. The
-wrapper switches to `role="img"` with `aria-label={alt}` for that state, so
-screen readers get a stable, named image surface regardless of what the
-fallback renders. The consumer's fallback content (e.g. an icon, a skeleton)
-sits inside this labeled region and inherits its accessible name from `alt`.
+`<img>` is unmounted and the wrapper renders the fallback in its place.
+
+- **Meaningful images** (non-empty `alt`): the wrapper switches to
+  `role="img"` with `aria-label={alt}`, so screen readers get a stable,
+  named image surface regardless of what the fallback renders.
+- **Decorative images** (`alt=""`): the wrapper switches to
+  `aria-hidden="true"` instead. This preserves the "ignore this" semantics of
+  the original `<img alt="">` — assistive tech doesn't suddenly start
+  announcing an unnamed image region just because the load failed.
 
 ## Public CSS hooks
 

--- a/packages/components/src/components/image.a11y.md
+++ b/packages/components/src/components/image.a11y.md
@@ -1,8 +1,10 @@
 # Image — accessibility notes
 
-`Image` is a thin wrapper around `<img>` that adds aspect-ratio, a blur-up
-placeholder, and a fallback snippet. The accessible surface is the `<img>`
-element itself.
+`Image` is a thin wrapper around `<img>` that adds an aspect-ratio container,
+a blur-up placeholder, and a fallback snippet. The accessible surface is the
+`<img>` element itself in the happy path; when the image errors and a
+`fallback` snippet renders, the wrapper takes over as the accessible image
+surface.
 
 ## Required `alt`
 
@@ -19,19 +21,33 @@ whether the image is decorative or meaningful:
 ## Lazy loading defaults
 
 `loading="lazy"` and `decoding="async"` are the defaults. For above-the-fold
-hero images, override with `loading="eager"` so the browser doesn't defer
-the most important image on the page.
+hero images, override with `loading="eager"`. For LCP (Largest Contentful
+Paint) hero images, combine `loading="eager"` with `fetchpriority="high"` —
+which forwards through to the underlying `<img>` via rest props — so the
+browser pushes the image to the top of its resource priority queue.
 
 ## Placeholder and error states
 
 The blur-up placeholder is purely visual — it's painted as the wrapper's
-background and faded out via opacity once the real image loads. Assistive tech
-only sees the `<img>` and its `alt`; the placeholder is not announced.
+background and the real `<img>` fades in over it once `load` fires. The
+placeholder background is cleared after load so transparent images don't show
+the low-res layer through them. Assistive tech only sees the `<img>` and its
+`alt`; the placeholder is not announced.
 
 When the image fails to load and a `fallback` snippet is provided, the
-`<img>` is unmounted and the fallback renders in its place. If the fallback
-itself contains imagery (e.g. a placeholder icon), the consumer is responsible
-for the accessible name in that fallback content.
+`<img>` is unmounted and the wrapper renders the fallback in its place. The
+wrapper switches to `role="img"` with `aria-label={alt}` for that state, so
+screen readers get a stable, named image surface regardless of what the
+fallback renders. The consumer's fallback content (e.g. an icon, a skeleton)
+sits inside this labeled region and inherits its accessible name from `alt`.
+
+## Public CSS hooks
+
+The wrapper exposes data attributes consumers can target:
+
+- `[data-cinder-loaded]` — present once the real image has loaded.
+- `[data-cinder-errored]` — present once the image has errored.
+- `[data-cinder-fallback]` — present while the fallback snippet is rendering.
 
 ## Not for people
 

--- a/packages/components/src/components/image.svelte
+++ b/packages/components/src/components/image.svelte
@@ -7,15 +7,22 @@
    *
    * A general-purpose `<img>` wrapper with `loading="lazy"` and `decoding="async"`
    * defaults, an aspect-ratio container, a blur-up placeholder for progressive
-   * loading, and a fallback snippet rendered when the image errors. Distinct from
-   * `Avatar`: this component does not render initials and has no concept of a
-   * person's identity.
+   * loading, and a fallback snippet rendered when the image errors. Distinct
+   * from `Avatar`: this component does not render initials and has no concept
+   * of a person's identity.
    *
    * `alt` is required with no default — consumers must make the
    * decorative-vs-meaningful choice explicitly. Pass `alt=""` for decorative
    * images.
+   *
+   * For above-the-fold hero images, override `loading="eager"` and pass
+   * `fetchpriority="high"` (forwarded via rest props) so the browser
+   * prioritizes the Largest Contentful Paint resource.
    */
-  export type ImageProps = Omit<HTMLImgAttributes, 'alt' | 'src' | 'loading' | 'decoding'> & {
+  export type ImageProps = Omit<
+    HTMLImgAttributes,
+    'alt' | 'src' | 'width' | 'height' | 'loading' | 'decoding' | 'onload' | 'onerror'
+  > & {
     /** Image source URL. */
     src: string;
     /**
@@ -29,8 +36,7 @@
     height?: number;
     /**
      * CSS aspect-ratio applied to the wrapper (e.g. `'16 / 9'`) so layout is
-     * stable while the image loads. Renders a wrapper element only when
-     * provided (or when `placeholder` is set).
+     * stable while the image loads.
      */
     ratio?: string;
     /** Loading strategy. Default `lazy`. Override to `eager` for above-the-fold images. */
@@ -39,16 +45,18 @@
     decoding?: 'async' | 'sync' | 'auto';
     /**
      * Low-resolution image source (typically a base64 data URI) shown as a
-     * pixelated background while the main image loads. Fades out via opacity
-     * once the `<img>` fires `load`.
+     * pixelated background while the main image loads. Fades out once the
+     * `<img>` fires `load`.
      */
     placeholder?: string;
-    /** CSS `object-fit` for the `<img>`. Default `cover`. */
-    objectFit?: 'cover' | 'contain' | 'fill' | 'none' | 'scale-down';
     /** Additional class names merged with `.cinder-image`. */
     class?: string;
     /** Rendered in place of the `<img>` when it fails to load. */
     fallback?: Snippet;
+    /** Forwarded after internal state updates. */
+    onload?: (event: Event) => void;
+    /** Forwarded after internal state updates. */
+    onerror?: (event: Event) => void;
   };
 </script>
 
@@ -64,75 +72,76 @@
     loading = 'lazy',
     decoding = 'async',
     placeholder,
-    objectFit = 'cover',
     class: className,
     fallback,
+    onload,
+    onerror,
     ...rest
   }: ImageProps = $props();
 
-  let loaded = $state(false);
-  let errored = $state(false);
+  // Track which src has loaded or errored so derived booleans reset
+  // synchronously when src changes — no $effect required.
+  let loadedSource = $state<string | null>(null);
+  let erroredSource = $state<string | null>(null);
 
-  // Reset load/error state whenever the source changes so a new src gets a
-  // fresh chance to load and show its placeholder.
-  $effect(() => {
-    void src;
-    loaded = false;
-    errored = false;
-  });
-
-  const needsWrapper = $derived(ratio !== undefined || placeholder !== undefined);
+  const loaded = $derived(loadedSource === src);
+  const errored = $derived(erroredSource === src);
   const showFallback = $derived(errored && fallback !== undefined);
 
-  function handleLoad() {
-    loaded = true;
+  function handleLoad(event: Event) {
+    loadedSource = src;
+    onload?.(event);
   }
 
-  function handleError() {
-    errored = true;
+  function handleError(event: Event) {
+    erroredSource = src;
+    onerror?.(event);
+  }
+
+  // Cached/SSR-hydrated images may already be complete before the load
+  // handler is attached. Detect that case via an attachment that fires
+  // when the element mounts, and treat it as loaded.
+  function detectCached(node: HTMLImageElement) {
+    if (node.complete && node.naturalWidth > 0) {
+      loadedSource = node.currentSrc || node.src;
+    }
+  }
+
+  const cssUrl = $derived(placeholder ? buildCssUrl(placeholder) : undefined);
+
+  function buildCssUrl(value: string): string {
+    // Quote and escape the URL so values containing parens, spaces, or quotes
+    // remain valid CSS — works for both plain URLs and data: URIs.
+    const escaped = value.replaceAll('\\', '\\\\').replaceAll('"', '\\"');
+    return `url("${escaped}")`;
   }
 </script>
 
-{#if needsWrapper}
-  <div
-    class={cn('cinder-image', className)}
-    data-cinder-loaded={loaded ? '' : undefined}
-    data-cinder-errored={errored ? '' : undefined}
-    style:aspect-ratio={ratio}
-    style:background-image={placeholder ? `url(${placeholder})` : undefined}
-  >
-    {#if showFallback}
-      {@render fallback?.()}
-    {:else}
-      <img
-        class="cinder-image__img"
-        {src}
-        {alt}
-        {width}
-        {height}
-        {loading}
-        {decoding}
-        style:object-fit={objectFit}
-        onload={handleLoad}
-        onerror={handleError}
-        {...rest}
-      />
-    {/if}
-  </div>
-{:else if showFallback}
-  {@render fallback?.()}
-{:else}
-  <img
-    class={cn('cinder-image', className)}
-    {src}
-    {alt}
-    {width}
-    {height}
-    {loading}
-    {decoding}
-    style:object-fit={objectFit}
-    onload={handleLoad}
-    onerror={handleError}
-    {...rest}
-  />
-{/if}
+<div
+  class={cn('cinder-image', className)}
+  data-cinder-loaded={loaded ? '' : undefined}
+  data-cinder-errored={errored ? '' : undefined}
+  data-cinder-fallback={showFallback ? '' : undefined}
+  role={showFallback ? 'img' : undefined}
+  aria-label={showFallback ? alt : undefined}
+  style:aspect-ratio={ratio}
+  style:background-image={cssUrl}
+>
+  {#if showFallback}
+    {@render fallback?.()}
+  {:else}
+    <img
+      class="cinder-image__img"
+      {src}
+      {alt}
+      {width}
+      {height}
+      {loading}
+      {decoding}
+      onload={handleLoad}
+      onerror={handleError}
+      {@attach detectCached}
+      {...rest}
+    />
+  {/if}
+</div>

--- a/packages/components/src/components/image.svelte
+++ b/packages/components/src/components/image.svelte
@@ -108,15 +108,18 @@
   }
 
   // Stop emitting the inline background-image once the real image has loaded
-  // so the CSS rule can clear it without `!important` overriding consumers.
-  const cssUrl = $derived(placeholder && !loaded ? buildCssUrl(placeholder) : undefined);
+  // (or errored) so the placeholder doesn't leak behind a transparent image
+  // or a fallback snippet.
+  const cssUrl = $derived(
+    placeholder && !loaded && !errored ? buildCssUrl(placeholder) : undefined,
+  );
 
   // Decorative images (alt="") should stay invisible to assistive tech even
   // when the fallback renders — otherwise we'd announce an unnamed image-like
   // region. Meaningful images keep their accessible name via role + label.
   const fallbackRole = $derived(showFallback && alt !== '' ? 'img' : undefined);
   const fallbackLabel = $derived(showFallback && alt !== '' ? alt : undefined);
-  const fallbackHidden = $derived(showFallback && alt === '' ? 'true' : undefined);
+  const fallbackHidden = $derived(showFallback && alt === '' ? true : undefined);
 
   function buildCssUrl(value: string): string {
     // Quote and escape the URL so values containing parens, spaces, or quotes

--- a/packages/components/src/components/image.svelte
+++ b/packages/components/src/components/image.svelte
@@ -103,11 +103,20 @@
   // when the element mounts, and treat it as loaded.
   function detectCached(node: HTMLImageElement) {
     if (node.complete && node.naturalWidth > 0) {
-      loadedSource = node.currentSrc || node.src;
+      loadedSource = src;
     }
   }
 
-  const cssUrl = $derived(placeholder ? buildCssUrl(placeholder) : undefined);
+  // Stop emitting the inline background-image once the real image has loaded
+  // so the CSS rule can clear it without `!important` overriding consumers.
+  const cssUrl = $derived(placeholder && !loaded ? buildCssUrl(placeholder) : undefined);
+
+  // Decorative images (alt="") should stay invisible to assistive tech even
+  // when the fallback renders — otherwise we'd announce an unnamed image-like
+  // region. Meaningful images keep their accessible name via role + label.
+  const fallbackRole = $derived(showFallback && alt !== '' ? 'img' : undefined);
+  const fallbackLabel = $derived(showFallback && alt !== '' ? alt : undefined);
+  const fallbackHidden = $derived(showFallback && alt === '' ? 'true' : undefined);
 
   function buildCssUrl(value: string): string {
     // Quote and escape the URL so values containing parens, spaces, or quotes
@@ -122,8 +131,9 @@
   data-cinder-loaded={loaded ? '' : undefined}
   data-cinder-errored={errored ? '' : undefined}
   data-cinder-fallback={showFallback ? '' : undefined}
-  role={showFallback ? 'img' : undefined}
-  aria-label={showFallback ? alt : undefined}
+  role={fallbackRole}
+  aria-label={fallbackLabel}
+  aria-hidden={fallbackHidden}
   style:aspect-ratio={ratio}
   style:background-image={cssUrl}
 >

--- a/packages/components/src/components/image.svelte
+++ b/packages/components/src/components/image.svelte
@@ -1,0 +1,138 @@
+<script lang="ts" module>
+  import type { HTMLImgAttributes } from 'svelte/elements';
+  import type { Snippet } from 'svelte';
+
+  /**
+   * Props for the Image component.
+   *
+   * A general-purpose `<img>` wrapper with `loading="lazy"` and `decoding="async"`
+   * defaults, an aspect-ratio container, a blur-up placeholder for progressive
+   * loading, and a fallback snippet rendered when the image errors. Distinct from
+   * `Avatar`: this component does not render initials and has no concept of a
+   * person's identity.
+   *
+   * `alt` is required with no default — consumers must make the
+   * decorative-vs-meaningful choice explicitly. Pass `alt=""` for decorative
+   * images.
+   */
+  export type ImageProps = Omit<HTMLImgAttributes, 'alt' | 'src' | 'loading' | 'decoding'> & {
+    /** Image source URL. */
+    src: string;
+    /**
+     * Alternative text. Required with no default — pass `alt=""` explicitly for
+     * decorative images so the choice is intentional, not silent.
+     */
+    alt: string;
+    /** Native pixel width. */
+    width?: number;
+    /** Native pixel height. */
+    height?: number;
+    /**
+     * CSS aspect-ratio applied to the wrapper (e.g. `'16 / 9'`) so layout is
+     * stable while the image loads. Renders a wrapper element only when
+     * provided (or when `placeholder` is set).
+     */
+    ratio?: string;
+    /** Loading strategy. Default `lazy`. Override to `eager` for above-the-fold images. */
+    loading?: 'lazy' | 'eager';
+    /** Decoding hint. Default `async`. */
+    decoding?: 'async' | 'sync' | 'auto';
+    /**
+     * Low-resolution image source (typically a base64 data URI) shown as a
+     * pixelated background while the main image loads. Fades out via opacity
+     * once the `<img>` fires `load`.
+     */
+    placeholder?: string;
+    /** CSS `object-fit` for the `<img>`. Default `cover`. */
+    objectFit?: 'cover' | 'contain' | 'fill' | 'none' | 'scale-down';
+    /** Additional class names merged with `.cinder-image`. */
+    class?: string;
+    /** Rendered in place of the `<img>` when it fails to load. */
+    fallback?: Snippet;
+  };
+</script>
+
+<script lang="ts">
+  import { cn } from '../utilities/class-names.ts';
+
+  let {
+    src,
+    alt,
+    width,
+    height,
+    ratio,
+    loading = 'lazy',
+    decoding = 'async',
+    placeholder,
+    objectFit = 'cover',
+    class: className,
+    fallback,
+    ...rest
+  }: ImageProps = $props();
+
+  let loaded = $state(false);
+  let errored = $state(false);
+
+  // Reset load/error state whenever the source changes so a new src gets a
+  // fresh chance to load and show its placeholder.
+  $effect(() => {
+    void src;
+    loaded = false;
+    errored = false;
+  });
+
+  const needsWrapper = $derived(ratio !== undefined || placeholder !== undefined);
+  const showFallback = $derived(errored && fallback !== undefined);
+
+  function handleLoad() {
+    loaded = true;
+  }
+
+  function handleError() {
+    errored = true;
+  }
+</script>
+
+{#if needsWrapper}
+  <div
+    class={cn('cinder-image', className)}
+    data-cinder-loaded={loaded ? '' : undefined}
+    data-cinder-errored={errored ? '' : undefined}
+    style:aspect-ratio={ratio}
+    style:background-image={placeholder ? `url(${placeholder})` : undefined}
+  >
+    {#if showFallback}
+      {@render fallback?.()}
+    {:else}
+      <img
+        class="cinder-image__img"
+        {src}
+        {alt}
+        {width}
+        {height}
+        {loading}
+        {decoding}
+        style:object-fit={objectFit}
+        onload={handleLoad}
+        onerror={handleError}
+        {...rest}
+      />
+    {/if}
+  </div>
+{:else if showFallback}
+  {@render fallback?.()}
+{:else}
+  <img
+    class={cn('cinder-image', className)}
+    {src}
+    {alt}
+    {width}
+    {height}
+    {loading}
+    {decoding}
+    style:object-fit={objectFit}
+    onload={handleLoad}
+    onerror={handleError}
+    {...rest}
+  />
+{/if}

--- a/packages/components/src/components/image.test.ts
+++ b/packages/components/src/components/image.test.ts
@@ -228,9 +228,16 @@ describe('Image', () => {
       const wrapper = container.querySelector('div.cinder-image');
       expect(wrapper?.hasAttribute('data-cinder-loaded')).toBe(true);
     } finally {
-      if (completeDescriptor) Object.defineProperty(proto, 'complete', completeDescriptor);
-      if (naturalWidthDescriptor)
+      if (completeDescriptor) {
+        Object.defineProperty(proto, 'complete', completeDescriptor);
+      } else {
+        delete (proto as { complete?: boolean }).complete;
+      }
+      if (naturalWidthDescriptor) {
         Object.defineProperty(proto, 'naturalWidth', naturalWidthDescriptor);
+      } else {
+        delete (proto as { naturalWidth?: number }).naturalWidth;
+      }
     }
   });
 
@@ -258,6 +265,25 @@ describe('Image', () => {
     expect(wrapper?.style.backgroundImage).toContain(placeholder);
     await fireEvent.load(container.querySelector('img')!);
     expect(wrapper?.style.backgroundImage).toBe('');
+  });
+
+  test('clears the inline background-image after the image errors', async () => {
+    const placeholder = 'data:image/png;base64,iVBORw0KGgo=';
+    const { container } = render(Image, { src: '/broken.jpg', alt: 'Broken', placeholder });
+    const wrapper = container.querySelector<HTMLElement>('div.cinder-image');
+    expect(wrapper?.style.backgroundImage).toContain(placeholder);
+    await fireEvent.error(container.querySelector('img')!);
+    expect(wrapper?.style.backgroundImage).toBe('');
+  });
+
+  test('sets aria-hidden as a boolean attribute (not a string literal)', async () => {
+    const { container } = render(ImageWithFallback, { src: '/missing.svg', alt: '' });
+    await fireEvent.error(container.querySelector('img')!);
+    const wrapper = container.querySelector('div.cinder-image');
+    // The DOM serializes booleans as "true" — the source of truth is that the
+    // attribute exists with value "true" regardless of input form. This test
+    // pins the wire format consumers (and AT) actually see.
+    expect(wrapper?.getAttribute('aria-hidden')).toBe('true');
   });
 
   test('restores the img when src changes while the fallback is active', async () => {

--- a/packages/components/src/components/image.test.ts
+++ b/packages/components/src/components/image.test.ts
@@ -1,0 +1,141 @@
+/// <reference lib="dom" />
+import { describe, expect, test } from 'bun:test';
+
+import { setupHappyDom } from '../test/happy-dom.ts';
+
+setupHappyDom();
+
+const { render, fireEvent } = await import('@testing-library/svelte');
+const { default: Image } = await import('./image.svelte');
+const { default: ImageWithFallback } =
+  await import('../test/fixtures/image-fallback-fixture.svelte');
+
+describe('Image', () => {
+  test('renders an <img> with the given src and alt', () => {
+    const { container } = render(Image, { src: '/a.jpg', alt: 'A photo' });
+    const img = container.querySelector('img');
+    expect(img).not.toBeNull();
+    expect(img?.getAttribute('src')).toBe('/a.jpg');
+    expect(img?.getAttribute('alt')).toBe('A photo');
+  });
+
+  test('defaults to loading="lazy" and decoding="async"', () => {
+    const { container } = render(Image, { src: '/a.jpg', alt: 'A' });
+    const img = container.querySelector('img');
+    expect(img?.getAttribute('loading')).toBe('lazy');
+    expect(img?.getAttribute('decoding')).toBe('async');
+  });
+
+  test('allows overriding loading="eager" for above-the-fold images', () => {
+    const { container } = render(Image, { src: '/a.jpg', alt: 'A', loading: 'eager' });
+    expect(container.querySelector('img')?.getAttribute('loading')).toBe('eager');
+  });
+
+  test('passes through empty alt for decorative images without modification', () => {
+    const { container } = render(Image, { src: '/decoration.svg', alt: '' });
+    const img = container.querySelector('img');
+    expect(img).not.toBeNull();
+    expect(img?.getAttribute('alt')).toBe('');
+  });
+
+  test('forwards width and height attributes', () => {
+    const { container } = render(Image, { src: '/a.jpg', alt: 'A', width: 320, height: 240 });
+    const img = container.querySelector('img');
+    expect(img?.getAttribute('width')).toBe('320');
+    expect(img?.getAttribute('height')).toBe('240');
+  });
+
+  test('does not render a wrapper when neither ratio nor placeholder is provided', () => {
+    const { container } = render(Image, { src: '/a.jpg', alt: 'A' });
+    expect(container.querySelector('div.cinder-image')).toBeNull();
+    expect(container.querySelector('img.cinder-image')).not.toBeNull();
+  });
+
+  test('renders a wrapper with aspect-ratio when ratio is provided', () => {
+    const { container } = render(Image, { src: '/a.jpg', alt: 'A', ratio: '16 / 9' });
+    const wrapper = container.querySelector('div.cinder-image');
+    expect(wrapper).not.toBeNull();
+    expect((wrapper as HTMLElement).style.aspectRatio).toBe('16 / 9');
+    expect(wrapper?.querySelector('img.cinder-image__img')).not.toBeNull();
+  });
+
+  test('renders a wrapper with background-image when placeholder is provided', () => {
+    const placeholder = 'data:image/png;base64,iVBORw0KGgo=';
+    const { container } = render(Image, { src: '/a.jpg', alt: 'A', placeholder });
+    const wrapper = container.querySelector<HTMLElement>('div.cinder-image');
+    expect(wrapper).not.toBeNull();
+    expect(wrapper?.style.backgroundImage).toContain(placeholder);
+  });
+
+  test('applies object-fit to the <img>', () => {
+    const { container } = render(Image, {
+      src: '/a.jpg',
+      alt: 'A',
+      ratio: '1 / 1',
+      objectFit: 'contain',
+    });
+    const img = container.querySelector('img');
+    expect(img?.style.objectFit).toBe('contain');
+  });
+
+  test('object-fit defaults to cover', () => {
+    const { container } = render(Image, { src: '/a.jpg', alt: 'A' });
+    const img = container.querySelector('img');
+    expect(img?.style.objectFit).toBe('cover');
+  });
+
+  test('toggles data-cinder-loaded on the wrapper after the img loads', async () => {
+    const { container } = render(Image, { src: '/a.jpg', alt: 'A', ratio: '1 / 1' });
+    const wrapper = container.querySelector('div.cinder-image');
+    expect(wrapper?.hasAttribute('data-cinder-loaded')).toBe(false);
+    const img = container.querySelector('img')!;
+    await fireEvent.load(img);
+    expect(wrapper?.hasAttribute('data-cinder-loaded')).toBe(true);
+  });
+
+  test('renders fallback snippet when the image errors', async () => {
+    const { container } = render(ImageWithFallback, { src: '/missing.jpg', alt: 'Missing' });
+    // Before error, img is rendered.
+    expect(container.querySelector('img')).not.toBeNull();
+    const img = container.querySelector('img')!;
+    await fireEvent.error(img);
+    // After error, img is unmounted and fallback shows.
+    expect(container.querySelector('img')).toBeNull();
+    expect(container.querySelector('[data-testid="image-fallback"]')?.textContent).toBe(
+      'Could not load image',
+    );
+  });
+
+  test('without a fallback snippet, an error leaves the img in place', async () => {
+    const { container } = render(Image, { src: '/broken.jpg', alt: 'Broken' });
+    const img = container.querySelector('img')!;
+    await fireEvent.error(img);
+    expect(container.querySelector('img')).not.toBeNull();
+  });
+
+  test('forwards extra HTML attributes onto the <img>', () => {
+    const { container } = render(Image, {
+      src: '/a.jpg',
+      alt: 'A',
+      id: 'hero-image',
+      'data-testid': 'hero',
+    });
+    const img = container.querySelector('img');
+    expect(img?.getAttribute('id')).toBe('hero-image');
+    expect(img?.getAttribute('data-testid')).toBe('hero');
+  });
+
+  test('class prop is merged with .cinder-image on the bare img variant', () => {
+    const { container } = render(Image, { src: '/a.jpg', alt: 'A', class: 'extra' });
+    const img = container.querySelector('img');
+    expect(img?.className).toContain('cinder-image');
+    expect(img?.className).toContain('extra');
+  });
+
+  test('class prop is merged with .cinder-image on the wrapper variant', () => {
+    const { container } = render(Image, { src: '/a.jpg', alt: 'A', ratio: '1 / 1', class: 'hero' });
+    const wrapper = container.querySelector('div.cinder-image');
+    expect(wrapper?.className).toContain('cinder-image');
+    expect(wrapper?.className).toContain('hero');
+  });
+});

--- a/packages/components/src/components/image.test.ts
+++ b/packages/components/src/components/image.test.ts
@@ -179,7 +179,11 @@ describe('Image', () => {
     expect(wrapper?.hasAttribute('data-cinder-errored')).toBe(true);
   });
 
-  test('calls consumer onload after internal state updates', async () => {
+  test('calls consumer onload after the internal state mutation', async () => {
+    // Contract: handleLoad mutates loadedSource BEFORE invoking the consumer
+    // callback. The DOM reflects the new state on the next microtask, so we
+    // verify (a) the callback fired, (b) data-cinder-loaded is set once the
+    // task settles.
     let handlerCalled = false;
     const { container } = render(Image, {
       src: '/a.jpg',
@@ -195,7 +199,7 @@ describe('Image', () => {
     );
   });
 
-  test('calls consumer onerror after internal state updates', async () => {
+  test('calls consumer onerror after the internal state mutation', async () => {
     let handlerCalled = false;
     const { container } = render(Image, {
       src: '/broken.jpg',
@@ -209,6 +213,63 @@ describe('Image', () => {
     expect(container.querySelector('div.cinder-image')?.hasAttribute('data-cinder-errored')).toBe(
       true,
     );
+  });
+
+  test('treats a cached/already-complete <img> as loaded on mount', () => {
+    // Pre-stamp the image prototype so the attachment's `complete`/`naturalWidth`
+    // probes see a cached image. Restore the prototype after the assertion.
+    const proto = window.HTMLImageElement.prototype;
+    const completeDescriptor = Object.getOwnPropertyDescriptor(proto, 'complete');
+    const naturalWidthDescriptor = Object.getOwnPropertyDescriptor(proto, 'naturalWidth');
+    Object.defineProperty(proto, 'complete', { configurable: true, get: () => true });
+    Object.defineProperty(proto, 'naturalWidth', { configurable: true, get: () => 100 });
+    try {
+      const { container } = render(Image, { src: '/relative/cached.jpg', alt: 'Cached' });
+      const wrapper = container.querySelector('div.cinder-image');
+      expect(wrapper?.hasAttribute('data-cinder-loaded')).toBe(true);
+    } finally {
+      if (completeDescriptor) Object.defineProperty(proto, 'complete', completeDescriptor);
+      if (naturalWidthDescriptor)
+        Object.defineProperty(proto, 'naturalWidth', naturalWidthDescriptor);
+    }
+  });
+
+  test('sets data-cinder-fallback while the fallback renders', async () => {
+    const { container } = render(ImageWithFallback, { src: '/missing.jpg', alt: 'Missing' });
+    const wrapper = container.querySelector('div.cinder-image');
+    expect(wrapper?.hasAttribute('data-cinder-fallback')).toBe(false);
+    await fireEvent.error(container.querySelector('img')!);
+    expect(wrapper?.hasAttribute('data-cinder-fallback')).toBe(true);
+  });
+
+  test('marks the fallback as aria-hidden for decorative images (alt="")', async () => {
+    const { container } = render(ImageWithFallback, { src: '/missing.svg', alt: '' });
+    await fireEvent.error(container.querySelector('img')!);
+    const wrapper = container.querySelector('div.cinder-image');
+    expect(wrapper?.getAttribute('aria-hidden')).toBe('true');
+    expect(wrapper?.hasAttribute('role')).toBe(false);
+    expect(wrapper?.hasAttribute('aria-label')).toBe(false);
+  });
+
+  test('clears the inline background-image after the image loads', async () => {
+    const placeholder = 'data:image/png;base64,iVBORw0KGgo=';
+    const { container } = render(Image, { src: '/a.jpg', alt: 'A', placeholder });
+    const wrapper = container.querySelector<HTMLElement>('div.cinder-image');
+    expect(wrapper?.style.backgroundImage).toContain(placeholder);
+    await fireEvent.load(container.querySelector('img')!);
+    expect(wrapper?.style.backgroundImage).toBe('');
+  });
+
+  test('restores the img when src changes while the fallback is active', async () => {
+    const { container, rerender } = render(ImageWithFallback, {
+      src: '/missing.jpg',
+      alt: 'Missing',
+    });
+    await fireEvent.error(container.querySelector('img')!);
+    expect(container.querySelectorAll('[data-testid="image-fallback"]').length).toBe(1);
+    expect(container.querySelectorAll('img').length).toBe(0);
+    await rerender({ src: '/fixed.jpg', alt: 'Missing' });
+    expect(container.querySelectorAll('img').length).toBe(1);
   });
 
   test('forwards extra HTML attributes onto the <img>', () => {

--- a/packages/components/src/components/image.test.ts
+++ b/packages/components/src/components/image.test.ts
@@ -1,14 +1,18 @@
 /// <reference lib="dom" />
-import { describe, expect, test } from 'bun:test';
+import { afterEach, describe, expect, test } from 'bun:test';
 
 import { setupHappyDom } from '../test/happy-dom.ts';
 
 setupHappyDom();
 
-const { render, fireEvent } = await import('@testing-library/svelte');
+const { render, fireEvent, cleanup } = await import('@testing-library/svelte');
 const { default: Image } = await import('./image.svelte');
 const { default: ImageWithFallback } =
   await import('../test/fixtures/image-fallback-fixture.svelte');
+
+afterEach(() => {
+  cleanup();
+});
 
 describe('Image', () => {
   test('renders an <img> with the given src and alt', () => {
@@ -45,47 +49,50 @@ describe('Image', () => {
     expect(img?.getAttribute('height')).toBe('240');
   });
 
-  test('does not render a wrapper when neither ratio nor placeholder is provided', () => {
+  test('always renders a wrapper containing the img', () => {
     const { container } = render(Image, { src: '/a.jpg', alt: 'A' });
-    expect(container.querySelector('div.cinder-image')).toBeNull();
-    expect(container.querySelector('img.cinder-image')).not.toBeNull();
-  });
-
-  test('renders a wrapper with aspect-ratio when ratio is provided', () => {
-    const { container } = render(Image, { src: '/a.jpg', alt: 'A', ratio: '16 / 9' });
     const wrapper = container.querySelector('div.cinder-image');
     expect(wrapper).not.toBeNull();
-    expect((wrapper as HTMLElement).style.aspectRatio).toBe('16 / 9');
     expect(wrapper?.querySelector('img.cinder-image__img')).not.toBeNull();
   });
 
-  test('renders a wrapper with background-image when placeholder is provided', () => {
+  test('applies aspect-ratio to the wrapper when ratio is provided', () => {
+    const { container } = render(Image, { src: '/a.jpg', alt: 'A', ratio: '16 / 9' });
+    const wrapper = container.querySelector<HTMLElement>('div.cinder-image');
+    expect(wrapper).not.toBeNull();
+    expect(wrapper?.style.aspectRatio).toBe('16 / 9');
+  });
+
+  test('does not apply aspect-ratio when ratio is omitted', () => {
+    const { container } = render(Image, { src: '/a.jpg', alt: 'A' });
+    const wrapper = container.querySelector<HTMLElement>('div.cinder-image');
+    expect(wrapper?.style.aspectRatio).toBe('');
+  });
+
+  test('applies a quoted background-image when placeholder is provided', () => {
     const placeholder = 'data:image/png;base64,iVBORw0KGgo=';
     const { container } = render(Image, { src: '/a.jpg', alt: 'A', placeholder });
     const wrapper = container.querySelector<HTMLElement>('div.cinder-image');
-    expect(wrapper).not.toBeNull();
     expect(wrapper?.style.backgroundImage).toContain(placeholder);
+    expect(wrapper?.style.backgroundImage).toContain('"');
   });
 
-  test('applies object-fit to the <img>', () => {
-    const { container } = render(Image, {
-      src: '/a.jpg',
-      alt: 'A',
-      ratio: '1 / 1',
-      objectFit: 'contain',
-    });
-    const img = container.querySelector('img');
-    expect(img?.style.objectFit).toBe('contain');
+  test('quotes placeholder URLs so values with special characters remain valid', () => {
+    const placeholder = 'https://cdn.example.com/p.jpg?w=20&blur=10';
+    const { container } = render(Image, { src: '/a.jpg', alt: 'A', placeholder });
+    const wrapper = container.querySelector<HTMLElement>('div.cinder-image');
+    expect(wrapper?.style.backgroundImage).toContain(placeholder);
+    expect(wrapper?.style.backgroundImage).toContain('url("');
   });
 
-  test('object-fit defaults to cover', () => {
-    const { container } = render(Image, { src: '/a.jpg', alt: 'A' });
-    const img = container.querySelector('img');
-    expect(img?.style.objectFit).toBe('cover');
+  test('does not set background-image when placeholder is absent', () => {
+    const { container } = render(Image, { src: '/a.jpg', alt: 'A', ratio: '1 / 1' });
+    const wrapper = container.querySelector<HTMLElement>('div.cinder-image');
+    expect(wrapper?.style.backgroundImage).toBe('');
   });
 
   test('toggles data-cinder-loaded on the wrapper after the img loads', async () => {
-    const { container } = render(Image, { src: '/a.jpg', alt: 'A', ratio: '1 / 1' });
+    const { container } = render(Image, { src: '/a.jpg', alt: 'A' });
     const wrapper = container.querySelector('div.cinder-image');
     expect(wrapper?.hasAttribute('data-cinder-loaded')).toBe(false);
     const img = container.querySelector('img')!;
@@ -93,24 +100,115 @@ describe('Image', () => {
     expect(wrapper?.hasAttribute('data-cinder-loaded')).toBe(true);
   });
 
-  test('renders fallback snippet when the image errors', async () => {
+  test('toggles data-cinder-errored on the wrapper after the img errors', async () => {
+    const { container } = render(Image, { src: '/broken.jpg', alt: 'Broken' });
+    const wrapper = container.querySelector('div.cinder-image');
+    expect(wrapper?.hasAttribute('data-cinder-errored')).toBe(false);
+    const img = container.querySelector('img')!;
+    await fireEvent.error(img);
+    expect(wrapper?.hasAttribute('data-cinder-errored')).toBe(true);
+  });
+
+  test('resets loaded state when src changes', async () => {
+    const { container, rerender } = render(Image, { src: '/a.jpg', alt: 'A' });
+    const wrapper = container.querySelector('div.cinder-image');
+    await fireEvent.load(container.querySelector('img')!);
+    expect(wrapper?.hasAttribute('data-cinder-loaded')).toBe(true);
+    await rerender({ src: '/b.jpg', alt: 'A' });
+    expect(wrapper?.hasAttribute('data-cinder-loaded')).toBe(false);
+  });
+
+  test('resets errored state when src changes', async () => {
+    const { container, rerender } = render(Image, { src: '/broken.jpg', alt: 'A' });
+    const wrapper = container.querySelector('div.cinder-image');
+    await fireEvent.error(container.querySelector('img')!);
+    expect(wrapper?.hasAttribute('data-cinder-errored')).toBe(true);
+    await rerender({ src: '/fixed.jpg', alt: 'A' });
+    expect(wrapper?.hasAttribute('data-cinder-errored')).toBe(false);
+  });
+
+  test('renders fallback snippet when the image errors and a fallback is provided', async () => {
     const { container } = render(ImageWithFallback, { src: '/missing.jpg', alt: 'Missing' });
-    // Before error, img is rendered.
     expect(container.querySelector('img')).not.toBeNull();
     const img = container.querySelector('img')!;
     await fireEvent.error(img);
-    // After error, img is unmounted and fallback shows.
     expect(container.querySelector('img')).toBeNull();
     expect(container.querySelector('[data-testid="image-fallback"]')?.textContent).toBe(
       'Could not load image',
     );
   });
 
-  test('without a fallback snippet, an error leaves the img in place', async () => {
-    const { container } = render(Image, { src: '/broken.jpg', alt: 'Broken' });
+  test('renders fallback inside the wrapper when ratio is set', async () => {
+    const { container } = render(ImageWithFallback, {
+      src: '/missing.jpg',
+      alt: 'Missing',
+      ratio: '16 / 9',
+    });
+    const img = container.querySelector('img')!;
+    await fireEvent.error(img);
+    const wrapper = container.querySelector('div.cinder-image');
+    expect(wrapper).not.toBeNull();
+    expect((wrapper as HTMLElement).style.aspectRatio).toBe('16 / 9');
+    expect(wrapper?.querySelector('[data-testid="image-fallback"]')?.textContent).toBe(
+      'Could not load image',
+    );
+  });
+
+  test('sets role="img" and aria-label on the wrapper when fallback renders', async () => {
+    const { container } = render(ImageWithFallback, { src: '/missing.jpg', alt: 'A duck' });
+    await fireEvent.error(container.querySelector('img')!);
+    const wrapper = container.querySelector('div.cinder-image');
+    expect(wrapper?.getAttribute('role')).toBe('img');
+    expect(wrapper?.getAttribute('aria-label')).toBe('A duck');
+  });
+
+  test('does not set role or aria-label before the fallback activates', () => {
+    const { container } = render(ImageWithFallback, { src: '/missing.jpg', alt: 'A duck' });
+    const wrapper = container.querySelector('div.cinder-image');
+    expect(wrapper?.hasAttribute('role')).toBe(false);
+    expect(wrapper?.hasAttribute('aria-label')).toBe(false);
+  });
+
+  test('without a fallback snippet, an error keeps the img in place and marks the wrapper', async () => {
+    const placeholder = 'data:image/png;base64,iVBORw0KGgo=';
+    const { container } = render(Image, { src: '/broken.jpg', alt: 'Broken', placeholder });
     const img = container.querySelector('img')!;
     await fireEvent.error(img);
     expect(container.querySelector('img')).not.toBeNull();
+    const wrapper = container.querySelector('div.cinder-image');
+    expect(wrapper?.hasAttribute('data-cinder-errored')).toBe(true);
+  });
+
+  test('calls consumer onload after internal state updates', async () => {
+    let handlerCalled = false;
+    const { container } = render(Image, {
+      src: '/a.jpg',
+      alt: 'A',
+      onload: () => {
+        handlerCalled = true;
+      },
+    });
+    await fireEvent.load(container.querySelector('img')!);
+    expect(handlerCalled).toBe(true);
+    expect(container.querySelector('div.cinder-image')?.hasAttribute('data-cinder-loaded')).toBe(
+      true,
+    );
+  });
+
+  test('calls consumer onerror after internal state updates', async () => {
+    let handlerCalled = false;
+    const { container } = render(Image, {
+      src: '/broken.jpg',
+      alt: 'Broken',
+      onerror: () => {
+        handlerCalled = true;
+      },
+    });
+    await fireEvent.error(container.querySelector('img')!);
+    expect(handlerCalled).toBe(true);
+    expect(container.querySelector('div.cinder-image')?.hasAttribute('data-cinder-errored')).toBe(
+      true,
+    );
   });
 
   test('forwards extra HTML attributes onto the <img>', () => {
@@ -125,15 +223,8 @@ describe('Image', () => {
     expect(img?.getAttribute('data-testid')).toBe('hero');
   });
 
-  test('class prop is merged with .cinder-image on the bare img variant', () => {
-    const { container } = render(Image, { src: '/a.jpg', alt: 'A', class: 'extra' });
-    const img = container.querySelector('img');
-    expect(img?.className).toContain('cinder-image');
-    expect(img?.className).toContain('extra');
-  });
-
-  test('class prop is merged with .cinder-image on the wrapper variant', () => {
-    const { container } = render(Image, { src: '/a.jpg', alt: 'A', ratio: '1 / 1', class: 'hero' });
+  test('class prop is merged with .cinder-image on the wrapper', () => {
+    const { container } = render(Image, { src: '/a.jpg', alt: 'A', class: 'hero' });
     const wrapper = container.querySelector('div.cinder-image');
     expect(wrapper?.className).toContain('cinder-image');
     expect(wrapper?.className).toContain('hero');

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -157,6 +157,9 @@ export type { GridListProps } from './components/grid-list.svelte';
 export { default as GridListItem } from './components/grid-list-item.svelte';
 export type { GridListItemProps } from './components/grid-list-item.svelte';
 
+export { default as Image } from './components/image.svelte';
+export type { ImageProps } from './components/image.svelte';
+
 export { default as Input } from './components/input.svelte';
 export type { InputProps, InputType } from './components/input.svelte';
 

--- a/packages/components/src/styles/components.css
+++ b/packages/components/src/styles/components.css
@@ -36,6 +36,7 @@
 @import './components/form-field.css';
 @import './components/form-section.css';
 @import './components/grid-list.css';
+@import './components/image.css';
 @import './components/input.css';
 @import './components/json-highlight.css';
 @import './components/json-schema-editor.css';

--- a/packages/components/src/styles/components/image.css
+++ b/packages/components/src/styles/components/image.css
@@ -9,8 +9,10 @@
   background-repeat: no-repeat;
 }
 
-/* Pixelated placeholder only while the real image hasn't loaded. */
-.cinder-image:not([data-cinder-loaded]) {
+/* Pixelated placeholder only while the real image hasn't resolved.
+ * Exclude the errored state too — a broken-image icon should render at the
+ * browser's native fidelity, not pixel-snapped. */
+.cinder-image:not([data-cinder-loaded]):not([data-cinder-errored]) {
   image-rendering: pixelated;
 }
 

--- a/packages/components/src/styles/components/image.css
+++ b/packages/components/src/styles/components/image.css
@@ -1,21 +1,16 @@
-/* ========================================
- * IMAGE
- * General-purpose <img> wrapper with aspect-ratio and blur-up placeholder.
- * ======================================== */
-
 .cinder-image {
   display: block;
-  max-width: 100%;
-}
-
-/* Wrapper variant — applies when ratio or placeholder is set. */
-div.cinder-image {
   position: relative;
   overflow: hidden;
+  max-width: 100%;
   background-color: var(--cinder-surface-inset);
   background-position: center;
   background-size: cover;
   background-repeat: no-repeat;
+}
+
+/* Pixelated placeholder only while the real image hasn't loaded. */
+.cinder-image:not([data-cinder-loaded]) {
   image-rendering: pixelated;
 }
 
@@ -23,18 +18,18 @@ div.cinder-image {
   display: block;
   width: 100%;
   height: 100%;
-  /* Hide until loaded so the pixelated placeholder shows through cleanly. */
-  opacity: 0;
-  transition: opacity 200ms ease-out;
+  object-fit: cover;
   image-rendering: auto;
+  opacity: 0;
+  transition: opacity var(--cinder-duration) var(--cinder-ease-standard);
 }
 
 .cinder-image[data-cinder-loaded] .cinder-image__img {
   opacity: 1;
 }
 
-@media (prefers-reduced-motion: reduce) {
-  .cinder-image__img {
-    transition: none;
-  }
+/* Clear the placeholder background after load so transparent images don't
+ * show the low-res layer through them. */
+.cinder-image[data-cinder-loaded] {
+  background-image: none !important;
 }

--- a/packages/components/src/styles/components/image.css
+++ b/packages/components/src/styles/components/image.css
@@ -1,0 +1,40 @@
+/* ========================================
+ * IMAGE
+ * General-purpose <img> wrapper with aspect-ratio and blur-up placeholder.
+ * ======================================== */
+
+.cinder-image {
+  display: block;
+  max-width: 100%;
+}
+
+/* Wrapper variant — applies when ratio or placeholder is set. */
+div.cinder-image {
+  position: relative;
+  overflow: hidden;
+  background-color: var(--cinder-surface-inset);
+  background-position: center;
+  background-size: cover;
+  background-repeat: no-repeat;
+  image-rendering: pixelated;
+}
+
+.cinder-image__img {
+  display: block;
+  width: 100%;
+  height: 100%;
+  /* Hide until loaded so the pixelated placeholder shows through cleanly. */
+  opacity: 0;
+  transition: opacity 200ms ease-out;
+  image-rendering: auto;
+}
+
+.cinder-image[data-cinder-loaded] .cinder-image__img {
+  opacity: 1;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .cinder-image__img {
+    transition: none;
+  }
+}

--- a/packages/components/src/styles/components/image.css
+++ b/packages/components/src/styles/components/image.css
@@ -28,8 +28,10 @@
   opacity: 1;
 }
 
-/* Clear the placeholder background after load so transparent images don't
- * show the low-res layer through them. */
+/* Component clears the inline `style:background-image` after load (via the
+ * `cssUrl` derivation), so the placeholder layer disappears for transparent
+ * images. Keeping this rule belt-and-braces in case a consumer overrides the
+ * inline style binding. */
 .cinder-image[data-cinder-loaded] {
-  background-image: none !important;
+  background-image: none;
 }

--- a/packages/components/src/styles/components/image.css
+++ b/packages/components/src/styles/components/image.css
@@ -28,10 +28,19 @@
   opacity: 1;
 }
 
-/* Component clears the inline `style:background-image` after load (via the
- * `cssUrl` derivation), so the placeholder layer disappears for transparent
- * images. Keeping this rule belt-and-braces in case a consumer overrides the
- * inline style binding. */
-.cinder-image[data-cinder-loaded] {
+/* Errored without a fallback snippet: reveal the <img> so the browser's
+ * native broken-image / alt-text rendering shows through, rather than
+ * leaving a permanently-blank wrapper. */
+.cinder-image[data-cinder-errored]:not([data-cinder-fallback]) .cinder-image__img {
+  opacity: 1;
+}
+
+/* Component clears the inline `style:background-image` after the image
+ * resolves (via the `cssUrl` derivation), so transparent images don't show
+ * the low-res layer through them and fallback snippets aren't painted over
+ * a leftover blurry background. This rule covers the case where a consumer
+ * has set their own background via a custom class on the wrapper. */
+.cinder-image[data-cinder-loaded],
+.cinder-image[data-cinder-errored] {
   background-image: none;
 }

--- a/packages/components/src/test/fixtures/image-fallback-fixture.svelte
+++ b/packages/components/src/test/fixtures/image-fallback-fixture.svelte
@@ -1,0 +1,22 @@
+<script lang="ts" module>
+  /**
+   * Test fixture that wraps Image with a fallback snippet. Used to verify the
+   * error → fallback rendering path.
+   */
+  export type ImageFallbackFixtureProps = {
+    src: string;
+    alt: string;
+  };
+</script>
+
+<script lang="ts">
+  import Image from '../../components/image.svelte';
+
+  let { src, alt }: ImageFallbackFixtureProps = $props();
+</script>
+
+<Image {src} {alt}>
+  {#snippet fallback()}
+    <span data-testid="image-fallback">Could not load image</span>
+  {/snippet}
+</Image>

--- a/packages/components/src/test/fixtures/image-fallback-fixture.svelte
+++ b/packages/components/src/test/fixtures/image-fallback-fixture.svelte
@@ -6,16 +6,19 @@
   export type ImageFallbackFixtureProps = {
     src: string;
     alt: string;
+    ratio?: string;
   };
 </script>
 
 <script lang="ts">
   import Image from '../../components/image.svelte';
 
-  let { src, alt }: ImageFallbackFixtureProps = $props();
+  let { src, alt, ratio }: ImageFallbackFixtureProps = $props();
+
+  const ratioProps = $derived(ratio !== undefined ? { ratio } : {});
 </script>
 
-<Image {src} {alt}>
+<Image {src} {alt} {...ratioProps}>
   {#snippet fallback()}
     <span data-testid="image-fallback">Could not load image</span>
   {/snippet}


### PR DESCRIPTION
## Summary

Adds `image.svelte` to `@cinder/components` — a general-purpose `<img>` wrapper with `loading="lazy"`/`decoding="async"` defaults, optional aspect-ratio container, blur-up placeholder, and a fallback snippet that renders when the image errors. `alt` is a required prop with no default so consumers make the decorative-vs-meaningful choice explicitly. Distinct from `avatar.svelte` — no initials, no person identity.

### Key behaviors

- Always renders a `<div.cinder-image>` wrapper with a single `<img>` inside; no dual render paths.
- **Cached / SSR images:** a mount attachment checks `image.complete && image.naturalWidth > 0` and synchronously marks the image as loaded, so already-resolved images don't get stuck at `opacity: 0` waiting for a `load` event that already fired.
- **`src` change resets state synchronously** via derived booleans keyed on `src` (no `$effect` mutating state).
- **Fallback a11y split:**
  - Meaningful (`alt !== ''`): wrapper gets `role="img"` + `aria-label={alt}` while the fallback renders.
  - Decorative (`alt === ''`): wrapper gets `aria-hidden="true"` instead, preserving the "ignore this" semantics of `<img alt="">`.
- **Errored without fallback:** the `<img>` reveals at `opacity: 1` so the browser's native broken-image icon and `alt` text are visible.
- **Placeholder placement:** URL is escaped and quoted (`buildCssUrl`) so non-data-URI CDN URLs with query strings work safely. Inline `style:background-image` clears on either resolution (load or error) so the placeholder never leaks behind a transparent image or a fallback snippet.
- **Consumer `onload` / `onerror`:** destructured out of rest props so internal state updates run first, then the consumer callback fires — no race via spread.
- **Public CSS hooks:** `[data-cinder-loaded]`, `[data-cinder-errored]`, `[data-cinder-fallback]`.
- **Motion tokens:** `var(--cinder-duration)` + `var(--cinder-ease-standard)` so `prefers-reduced-motion` flows through the token system instead of a per-component media query.

### Files

- `packages/components/src/components/image.svelte` — component
- `packages/components/src/components/image.test.ts` — 31 tests
- `packages/components/src/components/image.a11y.md` — accessibility notes
- `packages/components/src/styles/components/image.css` — component styles
- `packages/components/src/test/fixtures/image-fallback-fixture.svelte` — fallback-snippet fixture
- Wiring: `package.json` subpath export, `src/index.ts` re-export, `styles/components.css` import

## Review committee

Pre-reviewed by frontend-architect, ux-designer, testing-expert, typescript-expert, simplicity-engineer, junior-engineer, and Codex (gpt-5.4, xhigh reasoning) over 5 rounds.

Round-by-round (see `tmp/committee-state.md` for full transcript):
- **R1** — caught: `$effect` state-mutation anti-pattern, cached/SSR `<img>` stuck invisible, consumer `onload`/`onerror` racing via spread, unquoted `url()`, dual render paths, hardcoded transition bypassing motion tokens, wrapper-as-nameless-container on fallback, `width`/`height` not in `Omit`, missing test coverage.
- **R2** — caught: `detectCached` comparing absolute resolved URL against the relative `src` prop, `!important` blocking consumer overrides, decorative-image fallback exposing an unnamed image region.
- **R3** — caught: placeholder leaking behind fallback on error, errored `<img>` stuck invisible without a fallback (suppressing native broken-image rendering), `aria-hidden` set as string rather than boolean, test-prototype-restore guard.
- **R4** — caught: `image-rendering: pixelated` applying to the now-visible errored state, snapping the browser's broken-image icon.
- **R5** — consensus reached.

## Test plan

- `cd packages/components && bun run test` — full suite green (1844 tests)
- `bun run typecheck` — clean
- `bun run build` — clean
- Follow-up browser smoke check (not in this PR): hero LCP image with `loading="eager"` + `fetchpriority="high"`, blur-up placeholder fade, error → fallback render, decorative `alt=""` semantics, broken-image icon rendering at native fidelity.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive UI component and styles plus comprehensive tests; main risk is minor visual/a11y regressions or unexpected CSS interactions from the new `components/image.css` import.
> 
> **Overview**
> Introduces a new `Image` Svelte component that wraps `<img>` with default `loading="lazy"`/`decoding="async"`, optional aspect-ratio sizing, a blur-up `placeholder` background, and an optional `fallback` snippet shown on load error (with a11y handling for meaningful vs decorative `alt`).
> 
> Wires the component into the public package surface (`package.json` export + `src/index.ts` re-export) and global component CSS (`components.css` import), adds dedicated styles for load/error transitions, and includes a full test suite + fixture covering state resets, cached-image detection, attribute forwarding, and fallback semantics.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4f79212a16d4807b46be0ccffda88bb9a3f42680. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->