### PR TITLE
docs(theming): document color-scheme contract and Svelte toggle recipe

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ cinder's compiled server output is coupled to the Svelte minor it was built agai
 
 ### Theming and dark mode
 
-Cinder's color tokens are built on [`light-dark()`][mdn-light-dark]. Set `color-scheme` on your root element and every semantic color follows automatically — no `ThemeProvider`, no class toggling. See [docs/theming.md](docs/theming.md) for the full contract, a copy-pasteable Svelte toggle, and a Storybook toolbar recipe.
+Cinder's color tokens are built on [`light-dark()`][mdn-light-dark]. Set `data-theme="light"` or `data-theme="dark"` on `:root` (or set `color-scheme` directly) and every semantic color follows automatically — no `ThemeProvider`, no class toggling. See [docs/theming.md](docs/theming.md) for the full contract, a copy-pasteable Svelte toggle, and a Storybook toolbar recipe.
 
 [mdn-light-dark]: https://developer.mozilla.org/en-US/docs/Web/CSS/color_value/light-dark
 

--- a/README.md
+++ b/README.md
@@ -92,6 +92,12 @@ cinder's compiled server output is coupled to the Svelte minor it was built agai
 - **Variants** use `data-cinder-*` attributes: `data-cinder-variant`, `data-cinder-size`.
 - **Design tokens** use `--cinder-*` for the public surface and `--_cinder-*` for internal-only custom properties.
 
+### Theming and dark mode
+
+Cinder's color tokens are built on [`light-dark()`][mdn-light-dark]. Set `color-scheme` on your root element and every semantic color follows automatically — no `ThemeProvider`, no class toggling. See [docs/theming.md](docs/theming.md) for the full contract, a copy-pasteable Svelte toggle, and a Storybook toolbar recipe.
+
+[mdn-light-dark]: https://developer.mozilla.org/en-US/docs/Web/CSS/color_value/light-dark
+
 ## Playground
 
 `bun run playground` starts the playground dev server at http://localhost:4173. The sidebar lists all 21 components—click any one to open its page in the main frame. Each component page shows curated examples with live controls.

--- a/docs/theming.md
+++ b/docs/theming.md
@@ -1,0 +1,186 @@
+# Theming and dark mode
+
+Cinder's color tokens are written with [`light-dark()`][mdn-light-dark]. That means the library doesn't ship a theme switcher, a context provider, or a class-toggling JavaScript runtime. Instead, **the active theme is whatever value `color-scheme` resolves to on your root element**. Cinder reads that signal through `light-dark()`, and every semantic color token follows automatically.
+
+This page documents that contract, gives you a minimal Svelte recipe for a user-facing toggle, and shows how to wire the same control into a Storybook toolbar.
+
+## The contract
+
+Every semantic color token in [`tokens-base.css`](../packages/components/src/styles/tokens-base.css) is defined like this:
+
+```css
+--cinder-bg: light-dark(oklch(96.5% 0.012 245), oklch(15% 0.035 245));
+```
+
+`light-dark(light-value, dark-value)` returns the first argument when the element's [`color-scheme`][mdn-color-scheme] resolves to `light`, and the second when it resolves to `dark`. Cinder's `:root` block declares:
+
+```css
+color-scheme: light dark;
+```
+
+That tells the browser cinder supports both schemes _and_ that the active one should follow the user's OS preference by default. Concretely:
+
+- A user on macOS with **Auto** or **Dark** appearance sees dark tokens.
+- A user on macOS with **Light** appearance sees light tokens.
+- A consuming app that wants to override the OS preference sets `color-scheme: light` or `color-scheme: dark` on `:root` (or any ancestor), and `light-dark()` resolves from there.
+
+That last bullet is the whole API. There is no `ThemeProvider`, no `data-theme` attribute to set, no `.dark` class to toggle. **Set `color-scheme` on `:root`** — cinder's tokens follow.
+
+> [!NOTE]
+> `light-dark()` needs a concrete `color-scheme` declaration on the element (or an ancestor) to resolve correctly. Cinder declares it on `:root` in `tokens-base.css`, so you don't have to. If you override it lower in the tree, make sure you set `color-scheme` on the same element.
+
+## Minimal Svelte toggle
+
+Three states — `light`, `dark`, `system` — and a single mutation: write `color-scheme` on the root element. Persist the user's choice in `localStorage` so it survives reloads, and apply it before paint so dark-mode users don't flash light first.
+
+### The pre-paint script
+
+Put this in your app's `<head>`, _before_ any stylesheet. It runs synchronously, reads the persisted choice, and sets `color-scheme` on `:root` before the first paint:
+
+```html
+<script>
+  (function () {
+    var theme = 'system';
+    try {
+      var stored = localStorage.getItem('app-theme');
+      if (stored === 'light' || stored === 'dark' || stored === 'system') {
+        theme = stored;
+      }
+    } catch (error) {
+      /* localStorage may be unavailable in private mode — fall back to system */
+    }
+    if (theme === 'light' || theme === 'dark') {
+      document.documentElement.style.colorScheme = theme;
+    }
+    // Reflect the choice so CSS can branch on it (e.g. icon swap for "system" mode).
+    document.documentElement.dataset.theme = theme;
+  })();
+</script>
+```
+
+If you're on SvelteKit, drop the same body into `src/app.html` inside the `<head>`. If you're on Vite + Svelte, it goes in `index.html`.
+
+> [!TIP]
+> Reading `localStorage` synchronously in `<head>` is the standard pattern for avoiding a "flash of incorrect theme." A 2KB inline script that runs before paint is cheaper than the flash.
+
+### The toggle component
+
+```svelte
+<!-- ThemeToggle.svelte -->
+<script lang="ts">
+  type Theme = 'light' | 'dark' | 'system';
+
+  const STORAGE_KEY = 'app-theme';
+
+  let theme = $state<Theme>(readStoredTheme());
+
+  function readStoredTheme(): Theme {
+    if (typeof localStorage === 'undefined') return 'system';
+    const value = localStorage.getItem(STORAGE_KEY);
+    return value === 'light' || value === 'dark' || value === 'system' ? value : 'system';
+  }
+
+  function setTheme(next: Theme) {
+    theme = next;
+    try {
+      localStorage.setItem(STORAGE_KEY, next);
+    } catch {
+      /* ignore */
+    }
+    const root = document.documentElement;
+    root.dataset.theme = next;
+    if (next === 'system') {
+      root.style.removeProperty('color-scheme');
+    } else {
+      root.style.colorScheme = next;
+    }
+  }
+</script>
+
+<fieldset>
+  <legend>Theme</legend>
+  {#each ['light', 'system', 'dark'] as const as option}
+    <label>
+      <input
+        type="radio"
+        name="theme"
+        value={option}
+        checked={theme === option}
+        onchange={() => setTheme(option)}
+      />
+      {option}
+    </label>
+  {/each}
+</fieldset>
+```
+
+A few notes on what's happening:
+
+- **`system` clears the inline `color-scheme`**, which lets the `:root` declaration (`light dark`) fall back to the OS preference. Don't set `color-scheme: light dark` explicitly here — _removing_ the property is what restores the system-follows behavior.
+- **`data-theme` reflects the choice itself**, not the resolved scheme. Use it when you need to render a different control state for "system" — `color-scheme` alone can't tell you whether the user picked dark or whether dark was inferred.
+- **Three options, not two.** A binary light/dark toggle hides the system option, which is what most users actually want. If you must ship a two-state switch, default to `system` and let the toggle move between `light` and `dark` only.
+
+That's the whole recipe. No store, no context, no provider. `color-scheme` on `:root` is the source of truth, and cinder's tokens read from it.
+
+## Storybook toolbar integration
+
+If your consumer app uses Storybook, you can wire the same `color-scheme` mutation into a [global toolbar control][sb-toolbars]. The pattern: declare a `globalTypes` entry for the theme, then use a decorator that applies the value to `document.documentElement`.
+
+```ts
+// .storybook/preview.ts
+import type { Preview } from '@storybook/svelte';
+
+const preview: Preview = {
+  globalTypes: {
+    theme: {
+      description: 'Color scheme',
+      defaultValue: 'system',
+      toolbar: {
+        title: 'Theme',
+        icon: 'paintbrush',
+        items: [
+          { value: 'light', title: 'Light' },
+          { value: 'system', title: 'System' },
+          { value: 'dark', title: 'Dark' },
+        ],
+        dynamicTitle: true,
+      },
+    },
+  },
+  decorators: [
+    (story, context) => {
+      const theme = context.globals.theme as 'light' | 'dark' | 'system';
+      const root = document.documentElement;
+      root.dataset.theme = theme;
+      if (theme === 'system') {
+        root.style.removeProperty('color-scheme');
+      } else {
+        root.style.colorScheme = theme;
+      }
+      return story();
+    },
+  ],
+};
+
+export default preview;
+```
+
+Import cinder's stylesheet once in `.storybook/preview.ts` (or via a `preview-head.html` `<link>`), and every story renders against the active theme. The decorator runs on every story render, so flipping the toolbar control updates the canvas immediately.
+
+> [!NOTE]
+> Storybook's [`@storybook/addon-themes`][sb-addon-themes] ships a higher-level wrapper around this pattern. The hand-rolled version above is small enough that the addon is optional — pick whichever your team prefers.
+
+## When you need more than `color-scheme`
+
+A few cases the simple recipe doesn't cover:
+
+- **Reading the resolved scheme in JavaScript.** `color-scheme: light dark` doesn't tell you which one is active. Use `window.matchMedia('(prefers-color-scheme: dark)').matches` to check, and listen on the same `MediaQueryList` for live updates when the user is in `system` mode.
+- **Per-region theme overrides.** Setting `color-scheme: dark` on a nested element (a code block on a light-themed page, for example) re-resolves cinder's tokens inside that scope. `light-dark()` is fully nestable — there is no global theme to fight against.
+- **Custom semantic tokens.** If you add your own `--app-*` tokens, define them with `light-dark()` too. They'll resolve from the same `color-scheme` cinder reads, so a single toggle controls everything.
+
+A full `ThemeSwitcher` component isn't on the v1 roadmap. The recipe above is short enough to copy, and theming-as-a-component tends to bake in opinions (icon set, label copy, layout) that don't survive contact with real apps.
+
+[mdn-light-dark]: https://developer.mozilla.org/en-US/docs/Web/CSS/color_value/light-dark
+[mdn-color-scheme]: https://developer.mozilla.org/en-US/docs/Web/CSS/color-scheme
+[sb-toolbars]: https://storybook.js.org/docs/essentials/toolbars-and-globals
+[sb-addon-themes]: https://github.com/storybookjs/storybook/tree/next/code/addons/themes

--- a/docs/theming.md
+++ b/docs/theming.md
@@ -87,7 +87,7 @@ On SvelteKit, put the body inside the `%sveltekit.head%`-adjacent `<head>` block
 > The pre-paint script avoids "flash of incorrect theme" only for users who have already chosen `light` or `dark`. System-mode users rely on cinder's stylesheet (which declares `color-scheme: light dark` on `:root`) loading promptly. If your bundler defers the cinder stylesheet behind a slow code-split chunk, system-mode users may see a brief light flash before the stylesheet resolves. In practice this is invisible on production builds, but worth knowing about if you see it during development.
 
 > [!TIP]
-> The storage key (`'app-theme'`) is repeated in the pre-paint script and the toggle component below. Nothing enforces the match — a copy-paste typo silently breaks persistence. If your app has a module that runs before both, extract the key to a shared constant and import it in both places.
+> The storage key (`'app-theme'`) is repeated in the pre-paint script and the toggle component below. Nothing enforces the match — a copy-paste typo silently breaks persistence. The pre-paint script must stay an inline classic `<script>` to run before stylesheets, so you can't `import` a shared constant into it. Either keep the two literals in sync by hand, or inject the value into your HTML template from your server/build system (a SvelteKit `transformPageChunk` hook or a Vite HTML transform).
 
 ### The toggle component
 
@@ -104,9 +104,10 @@ On SvelteKit, put the body inside the `%sveltekit.head%`-adjacent `<head>` block
 
   // Initialize to 'system' on both server and client so the SSR-rendered
   // radio markup matches the first client render. After mount, read the
-  // real value from the DOM (set by the pre-paint script) and write it
-  // back into state. The `mounted` flag gates the write effect so we
-  // don't clobber the DOM attribute before that read has happened.
+  // real value from the DOM (set by the pre-paint script) and reconcile
+  // state. The `mounted` flag gates the write effect until that read has
+  // happened, so the write effect can't clobber the pre-paint attribute
+  // with the placeholder `'system'` value before `onMount` runs.
   let theme = $state<Theme>('system');
   let mounted = $state(false);
 
@@ -131,8 +132,11 @@ On SvelteKit, put the body inside the `%sveltekit.head%`-adjacent `<head>` block
   }
 
   // Sync `theme` to the DOM and localStorage on every change. The `mounted`
-  // guard skips the initial run, so the read-from-DOM above isn't immediately
-  // echoed back as a redundant write.
+  // guard prevents the first run (with the placeholder `'system'` value)
+  // from running before `onMount` reads the real value out of the DOM. Once
+  // `onMount` flips the flag, the effect runs once with the just-read value
+  // (an idempotent re-write of the attribute and a re-write of localStorage)
+  // and then reruns on every subsequent user change.
   $effect(() => {
     if (!mounted) return;
     setTheme(theme);
@@ -154,7 +158,7 @@ A few notes on what's happening:
 
 - **`data-theme` is the only mutation.** The component never touches `color-scheme` directly; cinder's stylesheet does that translation. That keeps the DOM clean — no inline styles to remove later — and makes it trivial to query the active choice from elsewhere (`getAttribute('data-theme')`).
 - **`system` removes the attribute** rather than setting `data-theme="system"`. The absence of the attribute is what lets `:root`'s default `color-scheme: light dark` fall back to the OS preference.
-- **State starts at `'system'` on both server and client.** That matches the SSR-rendered radio markup to the first client render. The `onMount` callback reads the real value from the DOM (populated by the pre-paint script) and updates state in place, and the `mounted` guard prevents the write effect from echoing that read back to the DOM. Net result: no hydration mismatch, no redundant DOM write on mount.
+- **State starts at `'system'` on both server and client.** That matches the SSR-rendered radio markup to the first client render. The `onMount` callback reads the real value from the DOM (populated by the pre-paint script) and reconciles state; the `mounted` guard keeps the write effect from running with the placeholder value before that read. After mount, the effect runs once with the just-read value — an idempotent re-write of the same `data-theme` attribute — and then on every subsequent user change. Net result: no hydration mismatch.
 - **Three options, not two.** A binary light/dark toggle hides the system option, which is what most users actually want.
 
 That's the whole recipe. No store, no context, no provider.

--- a/docs/theming.md
+++ b/docs/theming.md
@@ -5,7 +5,7 @@ Cinder's color tokens are written with [`light-dark()`][mdn-light-dark]. That me
 This page documents that contract, gives you a minimal Svelte recipe for a user-facing toggle, and shows how to wire the same control into a Storybook toolbar.
 
 > [!NOTE]
-> The toggle recipe uses Svelte 5 runes (`$state`, `bind:group`). Cinder pins `svelte >=5.55.0 <5.56.0` as a peer dependency, so any cinder consumer is already on Svelte 5.
+> The toggle recipe uses Svelte 5 — runes (`$state`, `$effect`) plus the `bind:group` directive. Cinder pins `svelte >=5.55.0 <5.56.0` as a peer dependency, so any cinder consumer is already on Svelte 5.
 
 ## The contract
 
@@ -86,6 +86,9 @@ On SvelteKit, put the body inside the `%sveltekit.head%`-adjacent `<head>` block
 > [!WARNING]
 > The pre-paint script avoids "flash of incorrect theme" only for users who have already chosen `light` or `dark`. System-mode users rely on cinder's stylesheet (which declares `color-scheme: light dark` on `:root`) loading promptly. If your bundler defers the cinder stylesheet behind a slow code-split chunk, system-mode users may see a brief light flash before the stylesheet resolves. In practice this is invisible on production builds, but worth knowing about if you see it during development.
 
+> [!TIP]
+> The storage key (`'app-theme'`) is repeated in the pre-paint script and the toggle component below. Nothing enforces the match — a copy-paste typo silently breaks persistence. If your app has a module that runs before both, extract the key to a shared constant and import it in both places.
+
 ### The toggle component
 
 ```svelte
@@ -97,19 +100,21 @@ On SvelteKit, put the body inside the `%sveltekit.head%`-adjacent `<head>` block
   const STORAGE_KEY = 'app-theme';
   const THEMES: readonly Theme[] = ['light', 'system', 'dark'];
 
-  let theme = $state<Theme>(readInitialTheme());
+  import { onMount } from 'svelte';
 
-  /**
-   * Read the active theme from the DOM, not localStorage. The pre-paint script
-   * has already reconciled storage and the DOM by the time this component
-   * mounts, so reading from the DOM avoids SSR/hydration mismatches and a
-   * second localStorage read.
-   */
-  function readInitialTheme(): Theme {
-    if (typeof document === 'undefined') return 'system';
+  // Initialize to 'system' on both server and client so the SSR-rendered
+  // radio markup matches the first client render. After mount, read the
+  // real value from the DOM (set by the pre-paint script) and write it
+  // back into state. The `mounted` flag gates the write effect so we
+  // don't clobber the DOM attribute before that read has happened.
+  let theme = $state<Theme>('system');
+  let mounted = $state(false);
+
+  onMount(() => {
     const value = document.documentElement.getAttribute('data-theme');
-    return value === 'light' || value === 'dark' ? value : 'system';
-  }
+    theme = value === 'light' || value === 'dark' ? value : 'system';
+    mounted = true;
+  });
 
   function setTheme(next: Theme) {
     try {
@@ -125,9 +130,11 @@ On SvelteKit, put the body inside the `%sveltekit.head%`-adjacent `<head>` block
     }
   }
 
-  // React to user input. $effect runs after the bound `theme` updates from
-  // the radio group, so the DOM and localStorage stay in sync.
+  // Sync `theme` to the DOM and localStorage on every change. The `mounted`
+  // guard skips the initial run, so the read-from-DOM above isn't immediately
+  // echoed back as a redundant write.
   $effect(() => {
+    if (!mounted) return;
     setTheme(theme);
   });
 </script>
@@ -147,6 +154,7 @@ A few notes on what's happening:
 
 - **`data-theme` is the only mutation.** The component never touches `color-scheme` directly; cinder's stylesheet does that translation. That keeps the DOM clean — no inline styles to remove later — and makes it trivial to query the active choice from elsewhere (`getAttribute('data-theme')`).
 - **`system` removes the attribute** rather than setting `data-theme="system"`. The absence of the attribute is what lets `:root`'s default `color-scheme: light dark` fall back to the OS preference.
+- **State starts at `'system'` on both server and client.** That matches the SSR-rendered radio markup to the first client render. The `onMount` callback reads the real value from the DOM (populated by the pre-paint script) and updates state in place, and the `mounted` guard prevents the write effect from echoing that read back to the DOM. Net result: no hydration mismatch, no redundant DOM write on mount.
 - **Three options, not two.** A binary light/dark toggle hides the system option, which is what most users actually want.
 
 That's the whole recipe. No store, no context, no provider.
@@ -217,7 +225,7 @@ Import cinder's stylesheet once in `.storybook/preview.ts` (or via a `preview-he
 > [!NOTE]
 > Storybook's [`@storybook/addon-themes`][sb-addon-themes] ships a higher-level wrapper around this pattern. The hand-rolled version above is small enough that the addon is optional — pick whichever your team prefers.
 
-If a story renders the `ThemeToggle` component itself, the toggle will read `localStorage` and write `data-theme` independently of the toolbar global. That's by design for the toggle, but it does mean the two controls compete. For visual-regression tests of the toggle, mount it in a story with no other theme controls so the toolbar doesn't fight it.
+If a story renders the `ThemeToggle` component itself, the toggle reads the current `data-theme` attribute on mount and writes back to `data-theme` (plus `localStorage`) independently of the toolbar global. That's by design for the toggle, but it does mean the two controls compete — flipping the toolbar overwrites the attribute, and flipping the toggle overwrites it again. For visual-regression tests of the toggle, mount it in a story with no other theme controls so the toolbar doesn't fight it.
 
 ## Why not a `ThemeSwitcher` component?
 

--- a/docs/theming.md
+++ b/docs/theming.md
@@ -1,8 +1,11 @@
 # Theming and dark mode
 
-Cinder's color tokens are written with [`light-dark()`][mdn-light-dark]. That means the library doesn't ship a theme switcher, a context provider, or a class-toggling JavaScript runtime. Instead, **the active theme is whatever value `color-scheme` resolves to on your root element**. Cinder reads that signal through `light-dark()`, and every semantic color token follows automatically.
+Cinder's color tokens are written with [`light-dark()`][mdn-light-dark]. That means the library doesn't ship a theme switcher, a context provider, or a class-toggling JavaScript runtime. Instead, **the active theme is whatever value `color-scheme` resolves to on the element where a token is read**. Cinder reads that signal through `light-dark()`, and every semantic color token follows automatically.
 
 This page documents that contract, gives you a minimal Svelte recipe for a user-facing toggle, and shows how to wire the same control into a Storybook toolbar.
+
+> [!NOTE]
+> The toggle recipe uses Svelte 5 runes (`$state`, `bind:group`). Cinder pins `svelte >=5.55.0 <5.56.0` as a peer dependency, so any cinder consumer is already on Svelte 5.
 
 ## The contract
 
@@ -12,30 +15,47 @@ Every semantic color token in [`tokens-base.css`](../packages/components/src/sty
 --cinder-bg: light-dark(oklch(96.5% 0.012 245), oklch(15% 0.035 245));
 ```
 
-`light-dark(light-value, dark-value)` returns the first argument when the element's [`color-scheme`][mdn-color-scheme] resolves to `light`, and the second when it resolves to `dark`. Cinder's `:root` block declares:
+`light-dark(light-value, dark-value)` returns the first argument when the resolved `color-scheme` is `light`, and the second when it's `dark`. Cinder's `:root` block declares:
 
 ```css
 color-scheme: light dark;
 ```
 
-That tells the browser cinder supports both schemes _and_ that the active one should follow the user's OS preference by default. Concretely:
+That tells the browser cinder supports both schemes _and_ that the active one should follow the user's OS preference by default. So a user on macOS with **Dark** appearance sees the dark tokens; a user on **Light** sees the light tokens. No additional configuration required.
 
-- A user on macOS with **Auto** or **Dark** appearance sees dark tokens.
-- A user on macOS with **Light** appearance sees light tokens.
-- A consuming app that wants to override the OS preference sets `color-scheme: light` or `color-scheme: dark` on `:root` (or any ancestor), and `light-dark()` resolves from there.
+To override the OS preference, cinder ships two equivalent paths. Pick one and stick with it inside a given app:
 
-That last bullet is the whole API. There is no `ThemeProvider`, no `data-theme` attribute to set, no `.dark` class to toggle. **Set `color-scheme` on `:root`** — cinder's tokens follow.
+- **`data-theme` attribute**: set `data-theme="light"` or `data-theme="dark"` on `:root` (or any ancestor of the styled element). Cinder's stylesheet maps those attributes to `color-scheme` for you:
+
+  ```css
+  :root[data-theme='dark'] {
+    color-scheme: dark;
+  }
+  :root[data-theme='light'] {
+    color-scheme: light;
+  }
+  [data-theme='dark'] {
+    color-scheme: dark;
+  }
+  [data-theme='light'] {
+    color-scheme: light;
+  }
+  ```
+
+- **Direct `color-scheme`**: set `color-scheme: light` or `color-scheme: dark` directly via CSS or inline style. Equivalent in outcome; useful when you don't want an attribute on your markup.
+
+Both routes drive `light-dark()` identically. The toggle recipe below uses `data-theme` because it's a single attribute mutation, plays nicely with CSS selectors elsewhere in your app, and doesn't leave inline styles lying around after the component unmounts.
 
 > [!NOTE]
-> `light-dark()` needs a concrete `color-scheme` declaration on the element (or an ancestor) to resolve correctly. Cinder declares it on `:root` in `tokens-base.css`, so you don't have to. If you override it lower in the tree, make sure you set `color-scheme` on the same element.
+> The non-root `[data-theme]` selectors mean you can scope a theme override to a subtree — for example, a dark-themed code preview embedded in an otherwise-light page. `light-dark()` resolves against the nearest ancestor with a concrete `color-scheme`, so nested overrides work without fighting global state.
 
 ## Minimal Svelte toggle
 
-Three states — `light`, `dark`, `system` — and a single mutation: write `color-scheme` on the root element. Persist the user's choice in `localStorage` so it survives reloads, and apply it before paint so dark-mode users don't flash light first.
+Three states — `light`, `dark`, `system` — and a single source of truth: the `data-theme` attribute on `<html>`. Persist the user's choice in `localStorage` so it survives reloads, and apply it before paint so dark-mode users don't flash light first.
 
 ### The pre-paint script
 
-Put this in your app's `<head>`, _before_ any stylesheet. It runs synchronously, reads the persisted choice, and sets `color-scheme` on `:root` before the first paint:
+This goes in your app's `<head>`, _before_ any stylesheet. It runs synchronously and sets `data-theme` on `<html>` before the first paint:
 
 ```html
 <script>
@@ -47,21 +67,24 @@ Put this in your app's `<head>`, _before_ any stylesheet. It runs synchronously,
         theme = stored;
       }
     } catch (error) {
-      /* localStorage may be unavailable in private mode — fall back to system */
+      /* localStorage may be unavailable (private mode, sandboxed iframe) — fall back to system */
     }
+    // For light/dark, set the attribute so cinder's [data-theme] selectors apply.
+    // For system, leave it unset so :root's `color-scheme: light dark` follows the OS preference.
     if (theme === 'light' || theme === 'dark') {
-      document.documentElement.style.colorScheme = theme;
+      document.documentElement.setAttribute('data-theme', theme);
     }
-    // Reflect the choice so CSS can branch on it (e.g. icon swap for "system" mode).
-    document.documentElement.dataset.theme = theme;
   })();
 </script>
 ```
 
-If you're on SvelteKit, drop the same body into `src/app.html` inside the `<head>`. If you're on Vite + Svelte, it goes in `index.html`.
+On SvelteKit, put the body inside the `%sveltekit.head%`-adjacent `<head>` block in `src/app.html`. On Vite + Svelte, it goes in `index.html`'s `<head>`. In both cases the inline script runs before external stylesheets load — SvelteKit injects its assets after the literal `<head>` contents you write — so the attribute is set before paint.
 
 > [!TIP]
-> Reading `localStorage` synchronously in `<head>` is the standard pattern for avoiding a "flash of incorrect theme." A 2KB inline script that runs before paint is cheaper than the flash.
+> The script only sets `data-theme` for explicit `light`/`dark` choices. For `system`, the absence of the attribute lets `:root`'s `color-scheme: light dark` declaration (shipped by cinder) fall through to the OS preference. Removing the attribute is what restores system-follow behavior — don't write `data-theme="system"` to the DOM.
+
+> [!WARNING]
+> The pre-paint script avoids "flash of incorrect theme" only for users who have already chosen `light` or `dark`. System-mode users rely on cinder's stylesheet (which declares `color-scheme: light dark` on `:root`) loading promptly. If your bundler defers the cinder stylesheet behind a slow code-split chunk, system-mode users may see a brief light flash before the stylesheet resolves. In practice this is invisible on production builds, but worth knowing about if you see it during development.
 
 ### The toggle component
 
@@ -70,44 +93,50 @@ If you're on SvelteKit, drop the same body into `src/app.html` inside the `<head
 <script lang="ts">
   type Theme = 'light' | 'dark' | 'system';
 
+  // Must match the key used by the pre-paint script in app.html / index.html.
   const STORAGE_KEY = 'app-theme';
+  const THEMES: readonly Theme[] = ['light', 'system', 'dark'];
 
-  let theme = $state<Theme>(readStoredTheme());
+  let theme = $state<Theme>(readInitialTheme());
 
-  function readStoredTheme(): Theme {
-    if (typeof localStorage === 'undefined') return 'system';
-    const value = localStorage.getItem(STORAGE_KEY);
-    return value === 'light' || value === 'dark' || value === 'system' ? value : 'system';
+  /**
+   * Read the active theme from the DOM, not localStorage. The pre-paint script
+   * has already reconciled storage and the DOM by the time this component
+   * mounts, so reading from the DOM avoids SSR/hydration mismatches and a
+   * second localStorage read.
+   */
+  function readInitialTheme(): Theme {
+    if (typeof document === 'undefined') return 'system';
+    const value = document.documentElement.getAttribute('data-theme');
+    return value === 'light' || value === 'dark' ? value : 'system';
   }
 
   function setTheme(next: Theme) {
-    theme = next;
     try {
       localStorage.setItem(STORAGE_KEY, next);
     } catch {
-      /* ignore */
+      /* ignore — localStorage may be unavailable */
     }
     const root = document.documentElement;
-    root.dataset.theme = next;
     if (next === 'system') {
-      root.style.removeProperty('color-scheme');
+      root.removeAttribute('data-theme');
     } else {
-      root.style.colorScheme = next;
+      root.setAttribute('data-theme', next);
     }
   }
+
+  // React to user input. $effect runs after the bound `theme` updates from
+  // the radio group, so the DOM and localStorage stay in sync.
+  $effect(() => {
+    setTheme(theme);
+  });
 </script>
 
 <fieldset>
   <legend>Theme</legend>
-  {#each ['light', 'system', 'dark'] as const as option}
+  {#each THEMES as option}
     <label>
-      <input
-        type="radio"
-        name="theme"
-        value={option}
-        checked={theme === option}
-        onchange={() => setTheme(option)}
-      />
+      <input type="radio" name="theme" value={option} bind:group={theme} />
       {option}
     </label>
   {/each}
@@ -116,28 +145,41 @@ If you're on SvelteKit, drop the same body into `src/app.html` inside the `<head
 
 A few notes on what's happening:
 
-- **`system` clears the inline `color-scheme`**, which lets the `:root` declaration (`light dark`) fall back to the OS preference. Don't set `color-scheme: light dark` explicitly here — _removing_ the property is what restores the system-follows behavior.
-- **`data-theme` reflects the choice itself**, not the resolved scheme. Use it when you need to render a different control state for "system" — `color-scheme` alone can't tell you whether the user picked dark or whether dark was inferred.
-- **Three options, not two.** A binary light/dark toggle hides the system option, which is what most users actually want. If you must ship a two-state switch, default to `system` and let the toggle move between `light` and `dark` only.
+- **`data-theme` is the only mutation.** The component never touches `color-scheme` directly; cinder's stylesheet does that translation. That keeps the DOM clean — no inline styles to remove later — and makes it trivial to query the active choice from elsewhere (`getAttribute('data-theme')`).
+- **`system` removes the attribute** rather than setting `data-theme="system"`. The absence of the attribute is what lets `:root`'s default `color-scheme: light dark` fall back to the OS preference.
+- **Three options, not two.** A binary light/dark toggle hides the system option, which is what most users actually want.
 
-That's the whole recipe. No store, no context, no provider. `color-scheme` on `:root` is the source of truth, and cinder's tokens read from it.
+That's the whole recipe. No store, no context, no provider.
+
+### Reading the resolved scheme
+
+`color-scheme: light dark` doesn't tell JavaScript which one is _active_ — only that both are supported. If you need to know the resolved value (for example, to swap a hand-authored SVG between light and dark variants), check the media query:
+
+```ts
+function getResolvedScheme(): 'light' | 'dark' {
+  const explicit = document.documentElement.getAttribute('data-theme');
+  if (explicit === 'light' || explicit === 'dark') return explicit;
+  return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+}
+```
+
+Listen on the same `MediaQueryList` (`addEventListener('change', …)`) if you need live updates when the user is in `system` mode and changes their OS appearance.
 
 ## Storybook toolbar integration
 
-If your consumer app uses Storybook, you can wire the same `color-scheme` mutation into a [global toolbar control][sb-toolbars]. The pattern: declare a `globalTypes` entry for the theme, then use a decorator that applies the value to `document.documentElement`.
+If your consumer app uses Storybook, you can wire the same `data-theme` mutation into a [global toolbar control][sb-toolbars]. Declare a `globalTypes` entry for the toolbar, set the initial value via `initialGlobals`, and use a decorator that mirrors the toolbar state onto `document.documentElement`:
 
 ```ts
 // .storybook/preview.ts
-import type { Preview } from '@storybook/svelte';
+import type { Preview } from '@storybook/svelte-vite';
 
 const preview: Preview = {
   globalTypes: {
     theme: {
       description: 'Color scheme',
-      defaultValue: 'system',
       toolbar: {
         title: 'Theme',
-        icon: 'paintbrush',
+        icon: 'circlehollow',
         items: [
           { value: 'light', title: 'Light' },
           { value: 'system', title: 'System' },
@@ -147,17 +189,19 @@ const preview: Preview = {
       },
     },
   },
+  initialGlobals: {
+    theme: 'system',
+  },
   decorators: [
     (story, context) => {
       const theme = context.globals.theme as 'light' | 'dark' | 'system';
       const root = document.documentElement;
-      root.dataset.theme = theme;
       if (theme === 'system') {
-        root.style.removeProperty('color-scheme');
+        root.removeAttribute('data-theme');
       } else {
-        root.style.colorScheme = theme;
+        root.setAttribute('data-theme', theme);
       }
-      return story();
+      return story(context);
     },
   ],
 };
@@ -168,17 +212,16 @@ export default preview;
 Import cinder's stylesheet once in `.storybook/preview.ts` (or via a `preview-head.html` `<link>`), and every story renders against the active theme. The decorator runs on every story render, so flipping the toolbar control updates the canvas immediately.
 
 > [!NOTE]
+> The import is `@storybook/svelte-vite` (the Storybook 8/9 Svelte + Vite renderer), not the legacy `@storybook/svelte`. `initialGlobals` is the current home for the initial value of a global; older docs that put `defaultValue` directly on `globalTypes` describe Storybook 7 behavior.
+
+> [!NOTE]
 > Storybook's [`@storybook/addon-themes`][sb-addon-themes] ships a higher-level wrapper around this pattern. The hand-rolled version above is small enough that the addon is optional — pick whichever your team prefers.
 
-## When you need more than `color-scheme`
+If a story renders the `ThemeToggle` component itself, the toggle will read `localStorage` and write `data-theme` independently of the toolbar global. That's by design for the toggle, but it does mean the two controls compete. For visual-regression tests of the toggle, mount it in a story with no other theme controls so the toolbar doesn't fight it.
 
-A few cases the simple recipe doesn't cover:
+## Why not a `ThemeSwitcher` component?
 
-- **Reading the resolved scheme in JavaScript.** `color-scheme: light dark` doesn't tell you which one is active. Use `window.matchMedia('(prefers-color-scheme: dark)').matches` to check, and listen on the same `MediaQueryList` for live updates when the user is in `system` mode.
-- **Per-region theme overrides.** Setting `color-scheme: dark` on a nested element (a code block on a light-themed page, for example) re-resolves cinder's tokens inside that scope. `light-dark()` is fully nestable — there is no global theme to fight against.
-- **Custom semantic tokens.** If you add your own `--app-*` tokens, define them with `light-dark()` too. They'll resolve from the same `color-scheme` cinder reads, so a single toggle controls everything.
-
-A full `ThemeSwitcher` component isn't on the v1 roadmap. The recipe above is short enough to copy, and theming-as-a-component tends to bake in opinions (icon set, label copy, layout) that don't survive contact with real apps.
+A full `ThemeSwitcher` isn't on the v1 roadmap. The recipe above is short enough to copy, and theming-as-a-component tends to bake in opinions (icon set, label copy, layout, focus styles) that don't survive contact with real apps. When two or three reference consumers ship a near-identical toggle and ask cinder to standardize it, that's the signal to promote the recipe into a component.
 
 [mdn-light-dark]: https://developer.mozilla.org/en-US/docs/Web/CSS/color_value/light-dark
 [mdn-color-scheme]: https://developer.mozilla.org/en-US/docs/Web/CSS/color-scheme


### PR DESCRIPTION
## Summary

Adds `docs/theming.md` documenting cinder's theming contract: how `light-dark()` + `color-scheme` drive every semantic token, the two equivalent override paths (`data-theme` attribute vs. direct `color-scheme`), a copy-pasteable Svelte 5 toggle (pre-paint script + toggle component, with no hydration mismatch), and a Storybook toolbar recipe. Also adds a short "Theming and dark mode" teaser in the README that links to the new doc.

No code changes — recipe + docs only, per the task description (no full ThemeSwitcher component required in v1).

## Review committee

Pre-reviewed by: prose-editor, frontend-architect, junior-engineer
- Codex (gpt-5.4, xhigh → high reasoning) — 4 rounds
- 4 rounds of review
- All must-fix items addressed (Svelte template syntax, SSR hydration strategy, pre-paint specificity, Storybook 8/9 API correctness, mounted-guard semantics, storage-key sync constraint)

## Test plan

- [ ] `docs/theming.md` renders correctly on GitHub (callouts, code fences, link refs)
- [ ] README "Theming and dark mode" section links resolve
- [ ] Verify the Svelte toggle compiles in a Svelte 5 sandbox (no template/runes errors)
- [ ] Verify the Storybook decorator runs in a Storybook 8 or 9 + `@storybook/svelte-vite` project

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only changes (README + new markdown doc) with no runtime/library code modifications.
> 
> **Overview**
> Adds a new `docs/theming.md` that documents Cinder’s `light-dark()`/`color-scheme` theming contract, including override options (`data-theme` vs direct `color-scheme`), a copy-paste Svelte 5 light/dark/system toggle (pre-paint script + component), and a Storybook toolbar decorator recipe.
> 
> Updates `README.md` with a short **Theming and dark mode** section that links to the new doc and references the `light-dark()` approach.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d0c287e154eb8411ef5907e6ae74746c35e177f4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->