### PR TITLE
docs(tokens): catalog --cinder-* public token surface with drift test

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ cinder's compiled server output is coupled to the Svelte minor it was built agai
 
 - **Classes** use the `.cinder-*` prefix: `.cinder-button`, `.cinder-alert`.
 - **Variants** use `data-cinder-*` attributes: `data-cinder-variant`, `data-cinder-size`.
-- **Design tokens** use `--cinder-*` for the public surface and `--_cinder-*` for internal-only custom properties.
+- **Design tokens** use `--cinder-*` for the public surface and `--_cinder-*` for internal-only custom properties. See [`docs/tokens.md`](docs/tokens.md) for the full catalog of public tokens and their defaults.
 
 ## Playground
 

--- a/docs/tokens.md
+++ b/docs/tokens.md
@@ -1,0 +1,284 @@
+# Design tokens
+
+cinder ships its design tokens as plain CSS custom properties on `:root`. Every token has a `--cinder-*` prefix; that prefix is the public surface, and you can override any of them at `:root` (globally) or on any ancestor selector (scoped) to reskin the system. Internal-only custom properties use `--_cinder-*`; those are not part of the contract and may change without notice.
+
+This file is hand-maintained. It is the source of truth for what cinder exposes; the CSS files in `packages/components/src/styles/` are the source of truth for the values. A drift test in [`tokens-doc-drift.test.ts`](../packages/components/src/styles/tokens-doc-drift.test.ts) keeps the two in sync — if you add, remove, or rename a token, update both this doc and the CSS, or CI will fail.
+
+All tokens are declared in [`tokens-base.css`](../packages/components/src/styles/tokens-base.css). The aggregator [`tokens.css`](../packages/components/src/styles/tokens.css) imports the base file and is the entry point components consume.
+
+> [!NOTE]
+> Color tokens use [`light-dark()`](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value/light-dark) keyed off `color-scheme`. The default `:root` sets `color-scheme: light dark`, which means the browser picks based on the user's OS preference. Force a scheme by setting `color-scheme: light` or `color-scheme: dark` on `:root` (or any ancestor) — or use the shorthand `[data-theme='light']` / `[data-theme='dark']` selectors cinder already wires up.
+
+## Spacing
+
+Rem-based spacing scale. Use these for padding, gap, margin — anywhere you'd otherwise hardcode a pixel value.
+
+| Token                | Default    |
+| -------------------- | ---------- |
+| `--cinder-space-0`   | `0`        |
+| `--cinder-space-0-5` | `0.125rem` |
+| `--cinder-space-1`   | `0.25rem`  |
+| `--cinder-space-1-5` | `0.375rem` |
+| `--cinder-space-2`   | `0.5rem`   |
+| `--cinder-space-2-5` | `0.625rem` |
+| `--cinder-space-3`   | `0.75rem`  |
+| `--cinder-space-4`   | `1rem`     |
+| `--cinder-space-5`   | `1.25rem`  |
+| `--cinder-space-6`   | `1.5rem`   |
+| `--cinder-space-7`   | `1.75rem`  |
+| `--cinder-space-8`   | `2rem`     |
+| `--cinder-space-10`  | `2.5rem`   |
+| `--cinder-space-12`  | `3rem`     |
+| `--cinder-space-16`  | `4rem`     |
+| `--cinder-space-20`  | `5rem`     |
+| `--cinder-space-24`  | `6rem`     |
+| `--cinder-space-32`  | `8rem`     |
+
+## Radii and shadows
+
+Corner radii and elevation shadows. `--cinder-radius-full` produces a pill or circle depending on the element's aspect ratio.
+
+| Token                  | Default                                                                      |
+| ---------------------- | ---------------------------------------------------------------------------- |
+| `--cinder-radius-sm`   | `0.375rem`                                                                   |
+| `--cinder-radius-md`   | `0.5rem`                                                                     |
+| `--cinder-radius-lg`   | `0.75rem`                                                                    |
+| `--cinder-radius-full` | `9999px`                                                                     |
+| `--cinder-shadow-sm`   | `0 1px 2px oklch(0% 0 0 / 0.08)`                                             |
+| `--cinder-shadow-md`   | `0 4px 6px -1px oklch(0% 0 0 / 0.12), 0 2px 4px -2px oklch(0% 0 0 / 0.1)`    |
+| `--cinder-shadow-lg`   | `0 10px 15px -3px oklch(0% 0 0 / 0.14), 0 4px 6px -4px oklch(0% 0 0 / 0.12)` |
+
+## Typography
+
+Font stacks, type scale, line heights, letter spacing, and weights. The base font size is `0.875rem` (`--cinder-text-base`) — slightly smaller than the browser default, tuned for dense application UI.
+
+| Token                       | Default                                                                                          |
+| --------------------------- | ------------------------------------------------------------------------------------------------ |
+| `--cinder-font-sans`        | `system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', sans-serif` |
+| `--cinder-font-mono`        | `ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, 'Liberation Mono', monospace`         |
+| `--cinder-text-2xs`         | `0.6875rem`                                                                                      |
+| `--cinder-text-xs`          | `0.75rem`                                                                                        |
+| `--cinder-text-sm`          | `0.8125rem`                                                                                      |
+| `--cinder-text-base`        | `0.875rem`                                                                                       |
+| `--cinder-text-lg`          | `1rem`                                                                                           |
+| `--cinder-text-xl`          | `1.125rem`                                                                                       |
+| `--cinder-text-2xl`         | `1.25rem`                                                                                        |
+| `--cinder-text-3xl`         | `1.5rem`                                                                                         |
+| `--cinder-text-4xl`         | `1.875rem`                                                                                       |
+| `--cinder-text-5xl`         | `2.25rem`                                                                                        |
+| `--cinder-leading-none`     | `1`                                                                                              |
+| `--cinder-leading-tight`    | `1.15`                                                                                           |
+| `--cinder-leading-snug`     | `1.3`                                                                                            |
+| `--cinder-leading-normal`   | `1.5`                                                                                            |
+| `--cinder-leading-relaxed`  | `1.625`                                                                                          |
+| `--cinder-tracking-tight`   | `-0.01em`                                                                                        |
+| `--cinder-tracking-normal`  | `0`                                                                                              |
+| `--cinder-tracking-wide`    | `0.02em`                                                                                         |
+| `--cinder-font-normal`      | `400`                                                                                            |
+| `--cinder-font-medium`      | `500`                                                                                            |
+| `--cinder-font-semibold`    | `600`                                                                                            |
+| `--cinder-font-bold`        | `700`                                                                                            |
+| `--cinder-touch-target-min` | `44px`                                                                                           |
+
+`--cinder-touch-target-min` is the WCAG AAA touch-target floor. Interactive primitives use it as a minimum height or width.
+
+## Layout
+
+| Token                    | Default |
+| ------------------------ | ------- |
+| `--cinder-content-width` | `72rem` |
+
+`--cinder-content-width` caps the inline size of primary page content. Used by [`PageLayout`](../packages/components/src/components/page-layout.svelte); consumers can override per scope.
+
+## Motion
+
+Durations and easing curves. `--cinder-duration-normal` is an alias for `--cinder-duration` — both resolve to the same value. The `prefers-reduced-motion: reduce` media query collapses all durations to `0ms` automatically; you do not need to handle that case yourself.
+
+| Token                        | Default                        |
+| ---------------------------- | ------------------------------ |
+| `--cinder-duration-instant`  | `0ms`                          |
+| `--cinder-duration-fast`     | `120ms`                        |
+| `--cinder-duration`          | `200ms`                        |
+| `--cinder-duration-normal`   | `var(--cinder-duration)`       |
+| `--cinder-duration-moderate` | `280ms`                        |
+| `--cinder-duration-slow`     | `400ms`                        |
+| `--cinder-ease-standard`     | `cubic-bezier(0.2, 0, 0, 1)`   |
+| `--cinder-ease-decelerate`   | `cubic-bezier(0, 0, 0, 1)`     |
+| `--cinder-ease-accelerate`   | `cubic-bezier(0.3, 0, 1, 1)`   |
+| `--cinder-ease-in-out`       | `cubic-bezier(0.4, 0, 0.2, 1)` |
+
+## Surfaces
+
+Background and surface tokens for the three core elevations — page background, default surface, and raised surface — plus an inset variant for sunken regions and `hover`/`pressed` derivatives that lift or darken via `color-mix`.
+
+| Token                      | Default                                                                                      |
+| -------------------------- | -------------------------------------------------------------------------------------------- |
+| `--cinder-bg`              | `light-dark(oklch(96.5% 0.012 245), oklch(15% 0.035 245))`                                   |
+| `--cinder-surface`         | `light-dark(oklch(98.5% 0.008 245), oklch(20% 0.04 245))`                                    |
+| `--cinder-surface-raised`  | `light-dark(oklch(100% 0.004 245), oklch(24% 0.045 245))`                                    |
+| `--cinder-surface-inset`   | `light-dark(oklch(94% 0.018 245), oklch(12% 0.03 245))`                                      |
+| `--cinder-surface-hover`   | `color-mix(in oklch, var(--cinder-surface), light-dark(oklch(0% 0 0), oklch(100% 0 0)) 8%)`  |
+| `--cinder-surface-pressed` | `color-mix(in oklch, var(--cinder-surface), light-dark(oklch(0% 0 0), oklch(100% 0 0)) 12%)` |
+
+## Text colors
+
+Foreground colors keyed to readability against the surface tokens. `--cinder-text-disabled` meets the relaxed contrast bar for disabled UI; the others meet WCAG AA against `--cinder-surface`.
+
+| Token                    | Default                                                 |
+| ------------------------ | ------------------------------------------------------- |
+| `--cinder-text`          | `light-dark(oklch(20% 0.03 245), oklch(92% 0.02 245))`  |
+| `--cinder-text-muted`    | `light-dark(oklch(32% 0.02 245), oklch(82% 0.02 245))`  |
+| `--cinder-text-subtle`   | `light-dark(oklch(42% 0.02 245), oklch(72% 0.02 245))`  |
+| `--cinder-text-disabled` | `light-dark(oklch(52% 0.015 245), oklch(62% 0.02 245))` |
+
+## Borders
+
+| Token                    | Default                                                 |
+| ------------------------ | ------------------------------------------------------- |
+| `--cinder-border`        | `light-dark(oklch(86% 0.025 245), oklch(35% 0.05 245))` |
+| `--cinder-border-muted`  | `light-dark(oklch(90% 0.018 245), oklch(30% 0.04 245))` |
+| `--cinder-border-strong` | `light-dark(oklch(75% 0.035 245), oklch(45% 0.06 245))` |
+
+## Accent
+
+The brand color and its derivatives. `hover` and `active` are computed from `--cinder-accent` with `oklch(from ...)`, so overriding `--cinder-accent` re-derives both. `--cinder-accent-contrast` is the foreground color for text and icons placed on top of `--cinder-accent`.
+
+| Token                      | Default                                                |
+| -------------------------- | ------------------------------------------------------ |
+| `--cinder-accent`          | `light-dark(oklch(45% 0.14 195), oklch(78% 0.15 195))` |
+| `--cinder-accent-contrast` | `light-dark(oklch(100% 0 0), oklch(15% 0.035 245))`    |
+| `--cinder-accent-hover`    | `oklch(from var(--cinder-accent) calc(l - 0.08) c h)`  |
+| `--cinder-accent-active`   | `oklch(from var(--cinder-accent) calc(l - 0.15) c h)`  |
+
+## Status — solid
+
+Single-value status tokens for solid fills like badges and dot indicators. For soft-tinted surfaces (Alert, Toast, Callout) use the semantic triples below instead.
+
+| Token                      | Default                                                |
+| -------------------------- | ------------------------------------------------------ |
+| `--cinder-info`            | `light-dark(oklch(45% 0.14 245), oklch(78% 0.13 245))` |
+| `--cinder-success`         | `light-dark(oklch(42% 0.16 145), oklch(78% 0.14 145))` |
+| `--cinder-warning`         | `light-dark(oklch(48% 0.18 75), oklch(82% 0.16 75))`   |
+| `--cinder-danger`          | `light-dark(oklch(45% 0.22 25), oklch(72% 0.18 25))`   |
+| `--cinder-danger-contrast` | `light-dark(oklch(100% 0 0), oklch(12% 0.02 25))`      |
+| `--cinder-danger-hover`    | `oklch(from var(--cinder-danger) calc(l - 0.08) c h)`  |
+| `--cinder-danger-active`   | `oklch(from var(--cinder-danger) calc(l - 0.15) c h)`  |
+
+`--cinder-danger-contrast` exists because dark-mode `--cinder-danger` sits around 72% lightness and pure white fails WCAG AA against it.
+
+## Status — semantic triples
+
+Foreground / background / border triples for soft tinted surfaces. Use these in Alert, Toast, Callout, and anywhere else you need a status surface with semantically-paired text and border.
+
+| Token                           | Default                                                 |
+| ------------------------------- | ------------------------------------------------------- |
+| `--cinder-color-info-bg`        | `light-dark(oklch(96% 0.025 245), oklch(28% 0.06 245))` |
+| `--cinder-color-info-fg`        | `light-dark(oklch(28% 0.12 245), oklch(88% 0.1 245))`   |
+| `--cinder-color-info-border`    | `light-dark(oklch(82% 0.06 245), oklch(45% 0.08 245))`  |
+| `--cinder-color-success-bg`     | `light-dark(oklch(96% 0.04 145), oklch(28% 0.07 145))`  |
+| `--cinder-color-success-fg`     | `light-dark(oklch(28% 0.13 145), oklch(88% 0.11 145))`  |
+| `--cinder-color-success-border` | `light-dark(oklch(80% 0.08 145), oklch(45% 0.09 145))`  |
+| `--cinder-color-warning-bg`     | `light-dark(oklch(96% 0.04 75), oklch(28% 0.08 75))`    |
+| `--cinder-color-warning-fg`     | `light-dark(oklch(32% 0.14 75), oklch(90% 0.12 75))`    |
+| `--cinder-color-warning-border` | `light-dark(oklch(82% 0.1 75), oklch(50% 0.1 75))`      |
+| `--cinder-color-danger-bg`      | `light-dark(oklch(96% 0.04 25), oklch(28% 0.09 25))`    |
+| `--cinder-color-danger-fg`      | `light-dark(oklch(32% 0.16 25), oklch(90% 0.12 25))`    |
+| `--cinder-color-danger-border`  | `light-dark(oklch(82% 0.1 25), oklch(50% 0.11 25))`     |
+
+## Focus ring
+
+The ring tokens drive the focus-visible outline used across interactive primitives. See [`focus-ring-policy.md`](./focus-ring-policy.md) for when components are expected to render the ring vs. when they delegate to the user agent.
+
+| Token                        | Default                                                                                                    |
+| ---------------------------- | ---------------------------------------------------------------------------------------------------------- |
+| `--cinder-ring-width`        | `3px`                                                                                                      |
+| `--cinder-ring-offset`       | `1px`                                                                                                      |
+| `--cinder-ring-offset-color` | `var(--cinder-bg)`                                                                                         |
+| `--cinder-ring-color`        | `light-dark(oklch(from var(--cinder-accent) 55% 0.12 195), oklch(from var(--cinder-accent) 70% 0.14 195))` |
+
+## Z-index layers
+
+Stacking order is fixed: tooltip < dropdown ≈ popover < modal ≈ sheet < toast. Toast sits above modal so confirmations and warnings still reach the user when a modal is open. Override these only if you are integrating cinder into an app with its own established stacking contract.
+
+| Token                 | Default |
+| --------------------- | ------- |
+| `--cinder-z-tooltip`  | `1000`  |
+| `--cinder-z-dropdown` | `1100`  |
+| `--cinder-z-popover`  | `1100`  |
+| `--cinder-z-modal`    | `1200`  |
+| `--cinder-z-sheet`    | `1200`  |
+| `--cinder-z-toast`    | `1300`  |
+
+## Overlay surfaces
+
+Shared backdrop, blur, padding, and radius for Modal, Sheet, and Popover. Adjust these once and every overlay primitive picks up the change.
+
+| Token                       | Default                                                            |
+| --------------------------- | ------------------------------------------------------------------ |
+| `--cinder-overlay-backdrop` | `light-dark(oklch(20% 0.03 245 / 0.5), oklch(8% 0.02 245 / 0.65))` |
+| `--cinder-overlay-blur`     | `4px`                                                              |
+| `--cinder-overlay-padding`  | `var(--cinder-space-6)`                                            |
+| `--cinder-overlay-radius`   | `var(--cinder-radius-lg)`                                          |
+
+## Button
+
+Component-specific tokens for [`Button`](../packages/components/src/components/button.svelte). The base trio (`bg`, `fg`, `border`) defines the secondary-variant defaults; size tokens scale padding, height, font, and radius across `xs`/`sm`/`md`/`lg`/`xl`. `md` is the AAA touch-target size (44px); `xs` and `sm` are intentionally below AAA — see [`button.a11y.md`](../packages/components/src/components/button.a11y.md) for the rationale.
+
+### Base
+
+| Token                    | Default                        |
+| ------------------------ | ------------------------------ |
+| `--cinder-button-bg`     | `var(--cinder-surface-raised)` |
+| `--cinder-button-fg`     | `var(--cinder-text)`           |
+| `--cinder-button-border` | `var(--cinder-border)`         |
+| `--cinder-button-radius` | `var(--cinder-radius-md)`      |
+
+### Size: xs
+
+| Token                          | Default                   |
+| ------------------------------ | ------------------------- |
+| `--cinder-button-padding-x-xs` | `var(--cinder-space-1-5)` |
+| `--cinder-button-padding-y-xs` | `var(--cinder-space-0-5)` |
+| `--cinder-button-height-xs`    | `1.5rem`                  |
+| `--cinder-button-font-size-xs` | `var(--cinder-text-xs)`   |
+| `--cinder-button-radius-xs`    | `var(--cinder-radius-sm)` |
+
+### Size: sm
+
+| Token                          | Default                   |
+| ------------------------------ | ------------------------- |
+| `--cinder-button-padding-x-sm` | `var(--cinder-space-2)`   |
+| `--cinder-button-padding-y-sm` | `var(--cinder-space-1)`   |
+| `--cinder-button-height-sm`    | `2rem`                    |
+| `--cinder-button-font-size-sm` | `var(--cinder-text-xs)`   |
+| `--cinder-button-radius-sm`    | `var(--cinder-radius-sm)` |
+
+### Size: md
+
+| Token                          | Default                   |
+| ------------------------------ | ------------------------- |
+| `--cinder-button-padding-x-md` | `var(--cinder-space-3)`   |
+| `--cinder-button-padding-y-md` | `var(--cinder-space-2-5)` |
+| `--cinder-button-height-md`    | `2.75rem`                 |
+| `--cinder-button-font-size-md` | `var(--cinder-text-sm)`   |
+| `--cinder-button-radius-md`    | `var(--cinder-radius-md)` |
+
+### Size: lg
+
+| Token                          | Default                   |
+| ------------------------------ | ------------------------- |
+| `--cinder-button-padding-x-lg` | `var(--cinder-space-4)`   |
+| `--cinder-button-padding-y-lg` | `var(--cinder-space-2)`   |
+| `--cinder-button-height-lg`    | `3rem`                    |
+| `--cinder-button-font-size-lg` | `var(--cinder-text-sm)`   |
+| `--cinder-button-radius-lg`    | `var(--cinder-radius-md)` |
+
+### Size: xl
+
+| Token                          | Default                   |
+| ------------------------------ | ------------------------- |
+| `--cinder-button-padding-x-xl` | `var(--cinder-space-5)`   |
+| `--cinder-button-padding-y-xl` | `var(--cinder-space-2-5)` |
+| `--cinder-button-height-xl`    | `3.25rem`                 |
+| `--cinder-button-font-size-xl` | `var(--cinder-text-base)` |
+| `--cinder-button-radius-xl`    | `var(--cinder-radius-md)` |

--- a/packages/components/src/styles/tokens-doc-drift.test.ts
+++ b/packages/components/src/styles/tokens-doc-drift.test.ts
@@ -1,0 +1,79 @@
+/**
+ * Drift test for docs/tokens.md.
+ *
+ * The doc is hand-maintained, so this test makes sure it stays in sync with
+ * the actual `--cinder-*` declarations in tokens-base.css. We extract the set
+ * of token names from each source and assert they match exactly.
+ *
+ * Test files may use `any` per project conventions.
+ */
+
+import { readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+
+import { describe, expect, test } from 'bun:test';
+
+const PACKAGE_ROOT = join(import.meta.dir, '..', '..');
+const REPO_ROOT = join(PACKAGE_ROOT, '..', '..');
+const TOKENS_CSS = join(PACKAGE_ROOT, 'src', 'styles', 'tokens-base.css');
+const TOKENS_DOC = join(REPO_ROOT, 'docs', 'tokens.md');
+
+function extractCssTokens(css: string): Set<string> {
+  // Pull just the `:root { ... }` block. The file also has scoped redeclarations
+  // (`:root[data-theme='dark']`, the prefers-reduced-motion override, etc.) that
+  // would otherwise inflate the token set with duplicates.
+  const rootMatch = css.match(/^:root\s*\{([\s\S]*?)\n\}/m);
+  const rootBody = rootMatch?.[1];
+  if (!rootBody) {
+    throw new Error('Could not find :root { ... } block in tokens-base.css');
+  }
+  const tokens = new Set<string>();
+  const declarationPattern = /--cinder-[a-z0-9-]+(?=\s*:)/g;
+  for (const match of rootBody.matchAll(declarationPattern)) {
+    tokens.add(match[0]);
+  }
+  return tokens;
+}
+
+function extractDocTokens(markdown: string): Set<string> {
+  // Doc lists tokens as inline code in table rows: `` `--cinder-space-4` ``.
+  // We deliberately only count tokens that appear inside backticks at the start
+  // of a table cell (i.e. `| \`--cinder-...\``) so that incidental mentions in
+  // prose (e.g. "override `--cinder-accent` to re-derive both") don't count.
+  const tokens = new Set<string>();
+  const rowPattern = /^\|\s*`(--cinder-[a-z0-9-]+)`/gm;
+  for (const match of markdown.matchAll(rowPattern)) {
+    if (match[1]) tokens.add(match[1]);
+  }
+  return tokens;
+}
+
+describe('docs/tokens.md drift', () => {
+  test('documents exactly the tokens declared in tokens-base.css', async () => {
+    const [css, doc] = await Promise.all([
+      readFile(TOKENS_CSS, 'utf8'),
+      readFile(TOKENS_DOC, 'utf8'),
+    ]);
+
+    const cssTokens = extractCssTokens(css);
+    const docTokens = extractDocTokens(doc);
+
+    const missingFromDoc = [...cssTokens].filter((token) => !docTokens.has(token)).toSorted();
+    const missingFromCss = [...docTokens].filter((token) => !cssTokens.has(token)).toSorted();
+
+    expect({ missingFromDoc, missingFromCss }).toEqual({
+      missingFromDoc: [],
+      missingFromCss: [],
+    });
+  });
+
+  test('finds at least one token in each source (guards against parser regressions)', async () => {
+    const [css, doc] = await Promise.all([
+      readFile(TOKENS_CSS, 'utf8'),
+      readFile(TOKENS_DOC, 'utf8'),
+    ]);
+
+    expect(extractCssTokens(css).size).toBeGreaterThan(0);
+    expect(extractDocTokens(doc).size).toBeGreaterThan(0);
+  });
+});

--- a/packages/components/src/styles/tokens-doc-drift.test.ts
+++ b/packages/components/src/styles/tokens-doc-drift.test.ts
@@ -22,14 +22,17 @@ function extractCssTokens(css: string): Set<string> {
   // Pull just the `:root { ... }` block. The file also has scoped redeclarations
   // (`:root[data-theme='dark']`, the prefers-reduced-motion override, etc.) that
   // would otherwise inflate the token set with duplicates.
-  const rootMatch = css.match(/^:root\s*\{([\s\S]*?)\n\}/m);
+  const rootMatch = css.match(/^\s*:root\s*\{([\s\S]*?)\n\}/m);
   const rootBody = rootMatch?.[1];
   if (!rootBody) {
     throw new Error('Could not find :root { ... } block in tokens-base.css');
   }
+  // Strip CSS block comments so a `/* --cinder-future: reserved */` aside in the
+  // source never gets counted as a real declaration.
+  const stripped = rootBody.replace(/\/\*[\s\S]*?\*\//g, '');
   const tokens = new Set<string>();
   const declarationPattern = /--cinder-[a-z0-9-]+(?=\s*:)/g;
-  for (const match of rootBody.matchAll(declarationPattern)) {
+  for (const match of stripped.matchAll(declarationPattern)) {
     tokens.add(match[0]);
   }
   return tokens;
@@ -58,6 +61,13 @@ describe('docs/tokens.md drift', () => {
     const cssTokens = extractCssTokens(css);
     const docTokens = extractDocTokens(doc);
 
+    // Sanity floor: a parser regression that silently returns a tiny set would
+    // otherwise show up as a confusing "missing from CSS: [137 tokens]" diff
+    // rather than a clear "the parser broke" signal. The real count sits well
+    // above 100; 50 leaves room to delete tokens without lowering this floor.
+    expect(cssTokens.size).toBeGreaterThan(50);
+    expect(docTokens.size).toBeGreaterThan(50);
+
     const missingFromDoc = [...cssTokens].filter((token) => !docTokens.has(token)).toSorted();
     const missingFromCss = [...docTokens].filter((token) => !cssTokens.has(token)).toSorted();
 
@@ -65,15 +75,5 @@ describe('docs/tokens.md drift', () => {
       missingFromDoc: [],
       missingFromCss: [],
     });
-  });
-
-  test('finds at least one token in each source (guards against parser regressions)', async () => {
-    const [css, doc] = await Promise.all([
-      readFile(TOKENS_CSS, 'utf8'),
-      readFile(TOKENS_DOC, 'utf8'),
-    ]);
-
-    expect(extractCssTokens(css).size).toBeGreaterThan(0);
-    expect(extractDocTokens(doc).size).toBeGreaterThan(0);
   });
 });


### PR DESCRIPTION
## Summary

Adds `docs/tokens.md` as the hand-maintained source of truth for every `--cinder-*` CSS custom property cinder exposes — grouped by category (spacing, radii, typography, layout, motion, surfaces, text, borders, accent, status, focus ring, z-index, overlays, button) with defaults inline. The doc explains the public-vs-internal token contract, the `light-dark()` / `color-scheme` interaction, and where derived values come from (`color-mix`, `oklch(from ...)`).

A `bun:test` drift check at `packages/components/src/styles/tokens-doc-drift.test.ts` parses the `:root` block of `tokens-base.css` and the inline-code token names in the doc's tables, asserts the two sets match, and includes a `size > 50` floor so a future parser regression fails loudly rather than producing a confusing 100-entry diff. CSS block comments are stripped before matching so a future `/* --cinder-foo: reserved */` aside cannot be miscounted.

The README's styling section links to the new doc.

## Review committee

Pre-reviewed by: prose-editor, testing-expert, simplicity-engineer, junior-engineer, typescript-expert
- Codex (gpt-5.4, xhigh reasoning) — 2 rounds
- 2 rounds of review
- All must-fix items addressed (none raised; suggestions implemented)

Round 1 suggestions addressed:
- Folded the parser-regression guard into the main test (one test, one pair of file reads).
- Raised the parser-floor assertion from `> 0` to `> 50`.
- Stripped CSS block comments from the parsed `:root` body before token-name matching.
- Loosened the `:root` regex to allow leading whitespace.

## Test plan

- `bun test src/styles/tokens-doc-drift.test.ts` — drift test passes.
- Manually add a fake `--cinder-foo: 0;` to `tokens-base.css` without updating the doc — test fails with `missingFromDoc: ['--cinder-foo']`.
- Manually rename a token in the doc without touching the CSS — test fails with the rename in `missingFromCss`.
- `bun run --filter='cinder' test` — full components suite passes (1815 tests).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds documentation plus a Bun test that enforces parity between `docs/tokens.md` and `tokens-base.css`, without changing runtime token values or component behavior.
> 
> **Overview**
> Adds `docs/tokens.md`, a hand-maintained catalog of the public `--cinder-*` CSS token surface (grouped by category with defaults and notes on theming/derivations).
> 
> Introduces `packages/components/src/styles/tokens-doc-drift.test.ts` to assert the token names documented in tables exactly match the `:root` declarations in `tokens-base.css` (with comment stripping and a minimum-size sanity check), and updates `README.md` to link to the new token doc.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cc84ed1154b940cb7ad4157f5964420acabb50b0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->