### PR TITLE
docs(input): sign-in form a11y callout + playground composition

### DIFF
--- a/packages/components/src/components/input.a11y.md
+++ b/packages/components/src/components/input.a11y.md
@@ -59,6 +59,16 @@ Interactive addons (clear button, password-reveal toggle, unit toggle): pass `tr
 
 ## Autocomplete guidance
 
+### Sign-in forms (required pattern)
+
+For sign-in forms, the identifier field **must** carry `autocomplete="email"` (when the field collects an email address) or `autocomplete="username"` (when it collects an opaque handle), and the password field **must** carry `autocomplete="current-password"`. These two attributes are what enable password managers and browser autofill to recognize the form as a sign-in form and offer saved credentials.
+
+Omitting them is a regression: users who rely on autofill — including users with motor disabilities for whom typing a password is a significant barrier — lose access to saved credentials, and password managers may misclassify the form as a registration form and save wrong values.
+
+See `packages/playground/src/examples/input/sign-in.example.svelte` for a composition that wires these attributes alongside the top-of-form `role="alert"` auth-error banner.
+
+### General guidance
+
 Always set the `autocomplete` attribute when the input collects a value the browser or password manager can fill. Cinder's `Input` forwards arbitrary `HTMLInputAttributes` via rest props, so `autocomplete="email"`, `autocomplete="current-password"`, `autocomplete="one-time-code"`, `autocomplete="postal-code"`, etc., flow through unchanged.
 
 The most common values are `name`, `email`, `username`, `current-password`, `new-password`, `one-time-code`, `street-address`, `postal-code`, `cc-number`, `cc-exp`, `tel`. Use `autocomplete="off"` only for fields that genuinely should not be filled (search, ephemeral tokens)—overusing `off` degrades the experience for users who rely on autofill, including users with motor disabilities.

--- a/packages/components/src/components/input.a11y.md
+++ b/packages/components/src/components/input.a11y.md
@@ -61,13 +61,13 @@ Interactive addons (clear button, password-reveal toggle, unit toggle): pass `tr
 
 ### Sign-in forms (required pattern)
 
-For sign-in forms, the identifier field **must** carry `autocomplete="email"` (when the field collects an email address) or `autocomplete="username"` (when it collects an opaque handle), and the password field **must** carry `autocomplete="current-password"`. These two attributes are what enable password managers and browser autofill to recognize the form as a sign-in form and offer saved credentials.
+Sign-in forms are a special case. The identifier field **must** carry `autocomplete="email"` (when the field collects an email address) or `autocomplete="username"` (when it collects an opaque handle), and the password field **must** carry `autocomplete="current-password"`. These attributes are the signal password managers and browser autofill look for — omit them and the browser won't recognize the form as a sign-in form, and won't offer saved credentials.
 
-Omitting them is a regression: users who rely on autofill — including users with motor disabilities for whom typing a password is a significant barrier — lose access to saved credentials, and password managers may misclassify the form as a registration form and save wrong values.
+Do **not** use `autocomplete="new-password"` for the password field in a sign-in form: that value signals a _create-account_ flow, and password managers will misclassify the form and save the wrong values rather than offering existing credentials.
 
-See `packages/playground/src/examples/input/sign-in.example.svelte` for a composition that wires these attributes alongside the top-of-form `role="alert"` auth-error banner.
+Skip these attributes and you've broken something that was working. Users who rely on autofill — including users with motor disabilities for whom typing a password is a significant barrier — lose access to saved credentials.
 
-### General guidance
+For the auth-error message, use the `Alert` component (which already carries `role="alert"`, implying `aria-live="assertive"`) at the top of the form, and mount it conditionally on the error state so each new failure produces a fresh announcement. See `packages/playground/src/examples/input/sign-in.example.svelte` for a working composition.
 
 Always set the `autocomplete` attribute when the input collects a value the browser or password manager can fill. Cinder's `Input` forwards arbitrary `HTMLInputAttributes` via rest props, so `autocomplete="email"`, `autocomplete="current-password"`, `autocomplete="one-time-code"`, `autocomplete="postal-code"`, etc., flow through unchanged.
 

--- a/packages/playground/src/examples/input/sign-in.example.svelte
+++ b/packages/playground/src/examples/input/sign-in.example.svelte
@@ -13,12 +13,14 @@
   let submitting = $state(false);
 
   function handleSignIn() {
+    if (submitting) return;
     // Clear any prior error so a re-submit re-announces by re-mounting the Alert
     // rather than mutating its text (assistive tech announces on mount of role="alert").
     authError = undefined;
     submitting = true;
 
-    // Static example: simulate an auth failure. Do not call a real auth service.
+    // Static example: simulate an auth failure. A real implementation would
+    // POST { email, password } and redirect on success.
     setTimeout(() => {
       authError = 'Email or password is incorrect.';
       submitting = false;
@@ -34,7 +36,7 @@
     handleSignIn();
   }}
 >
-  <h2 id="sign-in-heading" style="margin: 0 0 1rem;">Sign in</h2>
+  <h2 id="sign-in-heading" style="margin-block-end: 1rem;">Sign in</h2>
 
   <!--
     Top-of-form auth-error region.

--- a/packages/playground/src/examples/input/sign-in.example.svelte
+++ b/packages/playground/src/examples/input/sign-in.example.svelte
@@ -31,12 +31,13 @@
 <form
   novalidate
   aria-labelledby="sign-in-heading"
+  style="display: flex; flex-direction: column; gap: 1rem;"
   onsubmit={(event) => {
     event.preventDefault();
     handleSignIn();
   }}
 >
-  <h2 id="sign-in-heading" style="margin-block-end: 1rem;">Sign in</h2>
+  <h2 id="sign-in-heading">Sign in</h2>
 
   <!--
     Top-of-form auth-error region.

--- a/packages/playground/src/examples/input/sign-in.example.svelte
+++ b/packages/playground/src/examples/input/sign-in.example.svelte
@@ -1,0 +1,80 @@
+<script lang="ts" module>
+  export const title = 'Sign-in composition';
+  export const description =
+    'Composition of FormField + Input + Button with a top-of-form Alert auth-error region. Demonstrates the required autocomplete values and the assertive announcement pattern via role="alert".';
+</script>
+
+<script lang="ts">
+  import { Alert, Button, FormField, Input } from '../../../../components/src/index.ts';
+
+  let email = $state('');
+  let password = $state('');
+  let authError = $state<string | undefined>(undefined);
+  let submitting = $state(false);
+
+  function handleSignIn() {
+    // Clear any prior error so a re-submit re-announces by re-mounting the Alert
+    // rather than mutating its text (assistive tech announces on mount of role="alert").
+    authError = undefined;
+    submitting = true;
+
+    // Static example: simulate an auth failure. Do not call a real auth service.
+    setTimeout(() => {
+      authError = 'Email or password is incorrect.';
+      submitting = false;
+    }, 600);
+  }
+</script>
+
+<form
+  novalidate
+  aria-labelledby="sign-in-heading"
+  onsubmit={(event) => {
+    event.preventDefault();
+    handleSignIn();
+  }}
+>
+  <h2 id="sign-in-heading" style="margin: 0 0 1rem;">Sign in</h2>
+
+  <!--
+    Top-of-form auth-error region.
+    Alert's role="alert" implies aria-live="assertive" and aria-atomic="true".
+    We intentionally do NOT add an explicit aria-live attribute (see alert.test.ts:
+    "has role=alert on root element and does not set an explicit aria-live").
+    Mounting the Alert in response to submit triggers the assertive announcement.
+  -->
+  {#if authError}
+    <Alert variant="error">
+      {authError}
+    </Alert>
+  {/if}
+
+  <FormField id="sign-in-email" label="Email" required>
+    <!-- autocomplete="email" — the identifier is an email address.
+         Use "username" instead when the field collects an opaque handle. -->
+    <Input
+      id="sign-in-email"
+      type="email"
+      bind:value={email}
+      autocomplete="email"
+      required
+      placeholder="you@example.com"
+    />
+  </FormField>
+
+  <FormField id="sign-in-password" label="Password" required>
+    <!-- autocomplete="current-password" — required for password managers to
+         recognize this as a sign-in form and offer saved credentials. -->
+    <Input
+      id="sign-in-password"
+      type="password"
+      bind:value={password}
+      autocomplete="current-password"
+      required
+    />
+  </FormField>
+
+  <Button type="submit" variant="primary" loading={submitting}>
+    {submitting ? 'Signing in…' : 'Sign in'}
+  </Button>
+</form>


### PR DESCRIPTION
## Summary

- Adds a "Sign-in forms (required pattern)" callout to `input.a11y.md` pinning `autocomplete="email"` / `autocomplete="username"` plus `autocomplete="current-password"` as **required** for sign-in forms, with an explicit "do not use `new-password`" warning and a short note on the `role="alert"` mount pattern for auth errors.
- Adds `packages/playground/src/examples/input/sign-in.example.svelte`: a composition of `FormField` + `Input` + `Button` with a top-of-form `Alert` (variant=error) demonstrating the assertive announcement pattern via mount-on-error.

Closes task `b0c228da-87cf-465d-94c2-47de53322e6d` (ROADMAP §Forms › Sign-in forms).

## Review committee

Pre-reviewed by: prose-editor, frontend-architect, ux-designer, simplicity-engineer, junior-engineer
- Codex (gpt-5.4, xhigh → high reasoning) — 2 rounds
- 2 rounds of review
- All must-fix items addressed

Round 1 must-fixes addressed in commit `f72fb0f`:
- prose-editor: dropped `### General guidance` subheading; reframed callout to be action-forward and consequence-driven.
- frontend-architect: swapped inline physical `margin: 0 0 1rem` for logical `margin-block-end: 1rem` (the example is a teaching artifact and must not normalize physical CSS); added `if (submitting) return` guard against double-submit race.
- junior-engineer: explicit "do not use `autocomplete=\"new-password\"`" warning in the docs callout.
- ux-designer: extended docs callout to cover the `role="alert"` mount pattern as part of the "required pattern" title; the deeper focus-management / per-field `aria-invalid` items were explicitly deferred per the plan's Out-of-scope clause (simplicity-engineer tie-break per skill rules — see `tmp/committee-state.md` for the full decision log).

Round 2: APPROVED by all six members.

## Test plan

- [x] `bun run typecheck` — passes
- [x] `bun run lint` — passes (oxlint + stylelint)
- [x] `bun run --filter='@cinder/playground' validate` — all 92 component routes 200, new scenario bundles
- [ ] Manual playground spot-check at `/c/input` — confirm "Sign-in composition" appears; click "Sign in"; verify Alert mounts with `role="alert"` and no explicit `aria-live`; (optional) VoiceOver: confirm assertive announcement

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to documentation and a new playground example, with no production component logic modifications.
> 
> **Overview**
> Adds a new **“Sign-in forms (required pattern)”** section to `input.a11y.md` that explicitly requires `autocomplete="email"`/`"username"` and `autocomplete="current-password"`, and warns against `"new-password"` on sign-in flows.
> 
> Introduces a new playground example `sign-in.example.svelte` showing a `FormField` + `Input` + `Button` sign-in composition with a top-of-form error `Alert` mounted conditionally to trigger assertive announcements.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5824e3962a2a227817885dfd1282d129cdf4926e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->