### PR TITLE
docs(toast): add usage guide, playground examples, and ToastRegionProps export

### DIFF
--- a/packages/components/src/components/toast-region.a11y.md
+++ b/packages/components/src/components/toast-region.a11y.md
@@ -1,5 +1,7 @@
 # ToastRegion · accessibility
 
+> See also: [toast-region.md](./toast-region.md) for call-site usage, prop tables, and playground examples.
+
 ## Pattern
 
 Two stacked aria-live regions per [WAI-ARIA Authoring Practices: Alert and Status](https://www.w3.org/WAI/ARIA/apg/patterns/alert/) plus the WCAG 2.x guidance on dynamic notifications. Cinder splits announcements by priority so high-urgency toasts interrupt while informational ones queue politely.

--- a/packages/components/src/components/toast-region.md
+++ b/packages/components/src/components/toast-region.md
@@ -1,0 +1,141 @@
+# ToastRegion
+
+`<ToastRegion>` is a dual live-region container that manages toast notifications. It owns an independent queue—there is no process-global singleton—so multiple regions can coexist with separate stacks (one app-root, one modal-scoped, etc.). Dispatch toasts programmatically from any descendant via `useToast()`.
+
+See also: [toast-region.a11y.md](./toast-region.a11y.md) for the full ARIA and live-region rationale.
+
+## Placement
+
+Mount one `<ToastRegion>` near the root of your app so every component can reach it via `useToast()`. In SvelteKit, that's typically `+layout.svelte`.
+
+```svelte
+<!-- +layout.svelte -->
+<ToastRegion>
+  {#snippet children()}
+    {@render children()}
+  {/snippet}
+</ToastRegion>
+```
+
+Toasts dispatched before the region mounts are no-ops—`useToast()` would throw because no context exists yet. Multiple regions are legal and produce independent queues; each handles its own `maxStack` and `defaultDuration`.
+
+## ToastRegion props
+
+| Prop              | Type      | Default | Description                                                                                                                   |
+| ----------------- | --------- | ------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| `maxStack`        | `number`  | `5`     | Maximum simultaneous toasts per stack (polite and assertive each cap independently). Overflow drops the oldest.               |
+| `defaultDuration` | `number`  | `5000`  | Auto-dismiss delay in milliseconds. `0` makes all toasts sticky by default. Overridable per-call via `ToastOptions.duration`. |
+| `class`           | `string`  | —       | Additional class names merged onto `.cinder-toast-region`.                                                                    |
+| `children`        | `Snippet` | —       | When supplied, descendants of this snippet can call `useToast()` to access the region's API.                                  |
+
+## useToast()
+
+```ts
+import { useToast } from 'cinder';
+```
+
+Call `useToast()` during component initialization—Svelte's `getContext` runs at mount time, not inside event handlers. Inside a snippet body, use `{@const toast = useToast()}` at the top of the snippet.
+
+If no `<ToastRegion>` is mounted above the caller, `useToast()` throws:
+
+```
+useToast() must be called inside a <ToastRegion />. Mount one in your root layout.
+```
+
+This is intentional, not a bug. The error surfaces misconfigured component trees at development time rather than silently dropping toasts.
+
+There is no `cinder/use-toast` subpath export. Import from the root `cinder` barrel only.
+
+## ToastOptions
+
+| Field         | Type                                                          | Default                    | Description                                                                                                                      |
+| ------------- | ------------------------------------------------------------- | -------------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| `variant`     | `'info' \| 'success' \| 'warning' \| 'danger'`                | `'info'`                   | Visual treatment and live-region routing (see [Variant routing](#variant-routing-polite-vs-assertive) below).                    |
+| `duration`    | `number`                                                      | region's `defaultDuration` | Auto-dismiss after N ms. `0` keeps the toast until dismissed manually.                                                           |
+| `dismissible` | `boolean`                                                     | `true`                     | When `true`, renders the dismiss (×) button.                                                                                     |
+| `id`          | `string`                                                      | `cinder-toast-N` (auto)    | Stable id for deduplication—calling `show` again with the same active id replaces the existing toast instead of stacking a copy. |
+| `action`      | `{ label: string; onAction: () => void; keepOpen?: boolean }` | —                          | Renders an inline button after the message. Clicking invokes `onAction` then dismisses the toast unless `keepOpen` is `true`.    |
+
+## Variant routing (polite vs assertive)
+
+The `variant` field does two things: it sets the visual style _and_ determines which live region receives the toast.
+
+| Variants            | Live region | ARIA role | `aria-live` |
+| ------------------- | ----------- | --------- | ----------- |
+| `info`, `success`   | polite      | `status`  | `polite`    |
+| `warning`, `danger` | assertive   | `alert`   | `assertive` |
+
+The polite stack queues announcements behind the user's current screen-reader focus—informational, non-interrupting. The assertive stack interrupts immediately. `maxStack` caps each stack independently: a region can hold up to `maxStack` polite toasts _and_ `maxStack` assertive toasts simultaneously.
+
+See [toast-region.a11y.md](./toast-region.a11y.md) for the full ARIA rationale and WCAG citation.
+
+## show() return value
+
+`show()` returns a `string`—the assigned toast id. Capture it to enable targeted dismiss:
+
+```ts
+const id = toast.show('Saving…', { duration: 0 });
+// …later, when the save completes
+toast.dismiss(id);
+```
+
+Auto-generated ids (`cinder-toast-N`) are not stable across reloads—only use them transiently within the current session.
+
+## Action buttons
+
+The `action` option renders a focusable button after the toast message:
+
+```ts
+toast.show('File ready.', {
+  variant: 'success',
+  duration: 0,
+  action: {
+    label: 'Download',
+    onAction: () => startDownload(),
+  },
+});
+```
+
+By default, clicking the action button invokes `onAction` and dismisses the toast. Pass `keepOpen: true` to keep the toast visible after the action fires—useful for progress toasts where the action opens a side panel and the toast should remain until the operation completes.
+
+The button is a real focusable element inside the live region; keyboard users can Tab to it after the toast is announced. See [toast-region.a11y.md § Action button](./toast-region.a11y.md) for screen-reader behavior.
+
+## Modal-scoped regions via children
+
+`<ToastRegion>` can wrap content via the `children` snippet. Nesting a region inside a modal scopes its toasts to that modal's lifecycle—when the modal unmounts, all pending timers are cleared and the queue is torn down.
+
+```svelte
+<Modal bind:open title="Upload">
+  {#snippet children()}
+    <ToastRegion>
+      {#snippet children()}
+        {@const toast = useToast()}
+        <!-- form content — useToast() here gets the modal-scoped API -->
+        <UploadForm {toast} />
+      {/snippet}
+    </ToastRegion>
+  {/snippet}
+</Modal>
+```
+
+`useToast()` inside the snippet returns the nearest enclosing region's API—the modal-scoped one, not any outer app-root region. The two queues are completely independent.
+
+## Dismiss patterns
+
+Three ways a toast can be dismissed:
+
+- **User-driven**: via the × button when `dismissible: true` (the default).
+- **Auto-dismiss**: after `duration` ms when `duration > 0`.
+- **Programmatic**: `toast.dismiss(id)` removes a specific toast by id; `toast.dismissAll()` clears both the polite and assertive stacks together. `dismiss(id)` is a no-op if the id is not currently active.
+
+## Accessibility
+
+See [toast-region.a11y.md](./toast-region.a11y.md) for the complete ARIA / live-region / reduced-motion documentation.
+
+## v1 limitations
+
+- Toasts dispatched before `<ToastRegion>` mounts are no-ops—`useToast()` would throw because no context exists yet.
+- No process-global singleton—region-scoped only. Every `useToast()` call must have an enclosing region.
+- No position/placement prop yet; the region renders at its CSS-defined default position.
+- `maxStack` applies per stack (polite and assertive each cap independently), not as a combined total.
+- `id` deduplication is exact-match string equality—no fuzzy matching.

--- a/packages/components/src/components/toast-region.md
+++ b/packages/components/src/components/toast-region.md
@@ -6,27 +6,30 @@ See also: [toast-region.a11y.md](./toast-region.a11y.md) for the full ARIA and l
 
 ## Placement
 
-Mount one `<ToastRegion>` near the root of your app so every component can reach it via `useToast()`. In SvelteKit, that's typically `+layout.svelte`.
+Mount one `<ToastRegion />` near the root of your app so every component can reach it via `useToast()`. In SvelteKit, that's typically `+layout.svelte`. The region is self-closing—`useToast()` works in any descendant, not just those inside a `children` snippet.
 
 ```svelte
 <!-- +layout.svelte -->
-<ToastRegion>
-  {#snippet children()}
-    {@render children()}
-  {/snippet}
-</ToastRegion>
+<script>
+  let { children } = $props();
+</script>
+
+<ToastRegion />
+{@render children()}
 ```
 
-Toasts dispatched before the region mounts are no-ops—`useToast()` would throw because no context exists yet. Multiple regions are legal and produce independent queues; each handles its own `maxStack` and `defaultDuration`.
+Toasts dispatched before the region mounts are no-ops—`useToast()` throws because no context exists yet. Multiple regions are legal and produce independent queues; each handles its own `maxStack` and `defaultDuration`.
 
 ## ToastRegion props
 
-| Prop              | Type      | Default | Description                                                                                                                   |
-| ----------------- | --------- | ------- | ----------------------------------------------------------------------------------------------------------------------------- |
-| `maxStack`        | `number`  | `5`     | Maximum simultaneous toasts per stack (polite and assertive each cap independently). Overflow drops the oldest.               |
-| `defaultDuration` | `number`  | `5000`  | Auto-dismiss delay in milliseconds. `0` makes all toasts sticky by default. Overridable per-call via `ToastOptions.duration`. |
-| `class`           | `string`  | —       | Additional class names merged onto `.cinder-toast-region`.                                                                    |
-| `children`        | `Snippet` | —       | When supplied, descendants of this snippet can call `useToast()` to access the region's API.                                  |
+Import `ToastRegionProps` from `cinder` for typing wrapper components.
+
+| Prop              | Type      | Default | Description                                                                                                                                                                        |
+| ----------------- | --------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `maxStack`        | `number`  | `5`     | Maximum simultaneous toasts per stack (polite and assertive each cap independently). Overflow drops the oldest.                                                                    |
+| `defaultDuration` | `number`  | `5000`  | Auto-dismiss delay in milliseconds. `0` makes all toasts sticky by default. Overridable per-call via `ToastOptions.duration`.                                                      |
+| `class`           | `string`  | —       | Additional class names merged onto `.cinder-toast-region`.                                                                                                                         |
+| `children`        | `Snippet` | —       | Optional. When supplied, descendants of this snippet can call `useToast()` to access the region's API. Most root-level placements omit this and use the self-closing form instead. |
 
 ## useToast()
 
@@ -34,7 +37,16 @@ Toasts dispatched before the region mounts are no-ops—`useToast()` would throw
 import { useToast } from 'cinder';
 ```
 
-Call `useToast()` during component initialization—Svelte's `getContext` runs at mount time, not inside event handlers. Inside a snippet body, use `{@const toast = useToast()}` at the top of the snippet.
+Call `useToast()` at the top level of a component (not inside event handlers or callbacks)—Svelte's `getContext` must run during component initialization. Snippets are an exception: `useToast()` works inside `{#snippet children()}` because snippets evaluate in the context of their defining component.
+
+```svelte
+<ToastRegion>
+  {#snippet children()}
+    {@const toast = useToast()}
+    <button onclick={() => toast.show('Hello!')}>Show toast</button>
+  {/snippet}
+</ToastRegion>
+```
 
 If no `<ToastRegion>` is mounted above the caller, `useToast()` throws:
 
@@ -46,15 +58,25 @@ This is intentional, not a bug. The error surfaces misconfigured component trees
 
 There is no `cinder/use-toast` subpath export. Import from the root `cinder` barrel only.
 
+## ToastApi
+
+`useToast()` returns a `ToastApi` object:
+
+| Method       | Signature                                             | Description                                                           |
+| ------------ | ----------------------------------------------------- | --------------------------------------------------------------------- |
+| `show`       | `(message: string, options?: ToastOptions) => string` | Shows a toast. Returns the assigned id.                               |
+| `dismiss`    | `(id: string) => void`                                | Dismisses a specific toast by id. No-op if the id is not active.      |
+| `dismissAll` | `() => void`                                          | Dismisses every active toast in both the polite and assertive stacks. |
+
 ## ToastOptions
 
-| Field         | Type                                                          | Default                    | Description                                                                                                                      |
-| ------------- | ------------------------------------------------------------- | -------------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
-| `variant`     | `'info' \| 'success' \| 'warning' \| 'danger'`                | `'info'`                   | Visual treatment and live-region routing (see [Variant routing](#variant-routing-polite-vs-assertive) below).                    |
-| `duration`    | `number`                                                      | region's `defaultDuration` | Auto-dismiss after N ms. `0` keeps the toast until dismissed manually.                                                           |
-| `dismissible` | `boolean`                                                     | `true`                     | When `true`, renders the dismiss (×) button.                                                                                     |
-| `id`          | `string`                                                      | `cinder-toast-N` (auto)    | Stable id for deduplication—calling `show` again with the same active id replaces the existing toast instead of stacking a copy. |
-| `action`      | `{ label: string; onAction: () => void; keepOpen?: boolean }` | —                          | Renders an inline button after the message. Clicking invokes `onAction` then dismisses the toast unless `keepOpen` is `true`.    |
+| Field         | Type                                                          | Default                    | Description                                                                                                                                                                     |
+| ------------- | ------------------------------------------------------------- | -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `variant`     | `'info' \| 'success' \| 'warning' \| 'danger'`                | `'info'`                   | Visual treatment and live-region routing (see [Variant routing](#variant-routing-polite-vs-assertive) below).                                                                   |
+| `duration`    | `number`                                                      | region's `defaultDuration` | Auto-dismiss after N ms. `0` keeps the toast until dismissed manually.                                                                                                          |
+| `dismissible` | `boolean`                                                     | `true`                     | When `true`, renders the dismiss (×) button.                                                                                                                                    |
+| `id`          | `string`                                                      | `cinder-toast-N` (auto)    | Stable id for deduplication—calling `show` again with the same active id replaces the existing toast instead of stacking a copy. The replacement resets the auto-dismiss timer. |
+| `action`      | `{ label: string; onAction: () => void; keepOpen?: boolean }` | —                          | Renders an inline button after the message. Clicking invokes `onAction` then dismisses the toast unless `keepOpen` is `true`.                                                   |
 
 ## Variant routing (polite vs assertive)
 
@@ -128,14 +150,16 @@ Three ways a toast can be dismissed:
 - **Auto-dismiss**: after `duration` ms when `duration > 0`.
 - **Programmatic**: `toast.dismiss(id)` removes a specific toast by id; `toast.dismissAll()` clears both the polite and assertive stacks together. `dismiss(id)` is a no-op if the id is not currently active.
 
+> [!WARNING] Combining `duration: 0` with `dismissible: false` and no `action` creates a toast that cannot be dismissed. Use at least one dismiss mechanism.
+
 ## Accessibility
 
 See [toast-region.a11y.md](./toast-region.a11y.md) for the complete ARIA / live-region / reduced-motion documentation.
 
 ## v1 limitations
 
-- Toasts dispatched before `<ToastRegion>` mounts are no-ops—`useToast()` would throw because no context exists yet.
-- No process-global singleton—region-scoped only. Every `useToast()` call must have an enclosing region.
+- No process-global singleton—region-scoped only. Every `useToast()` call must have an enclosing region mounted above it.
 - No position/placement prop yet; the region renders at its CSS-defined default position.
 - `maxStack` applies per stack (polite and assertive each cap independently), not as a combined total.
 - `id` deduplication is exact-match string equality—no fuzzy matching.
+- `id` collision between auto-generated `cinder-toast-N` ids and manually passed ids is possible if you pass `id: 'cinder-toast-3'`—prefer descriptive stable ids (`'save-progress'`) to avoid this.

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -371,6 +371,7 @@ export type {
   ToastApi,
   ToastItem,
   ToastOptions,
+  ToastRegionProps,
   ToastVariant,
 } from './components/toast-region.svelte';
 

--- a/packages/playground/src/examples/toast-region/action-button.example.svelte
+++ b/packages/playground/src/examples/toast-region/action-button.example.svelte
@@ -1,0 +1,43 @@
+<script lang="ts" module>
+  export const title = 'Action button';
+  export const description =
+    'Clicking the action dismisses the toast by default. Set keepOpen: true to keep it visible after the action fires.';
+</script>
+
+<script lang="ts">
+  import { Button, ToastRegion, useToast } from '../../../../components/src/index.ts';
+</script>
+
+<ToastRegion>
+  {#snippet children()}
+    {@const toast = useToast()}
+    <div class="example-preview-row">
+      <Button
+        label="Dismiss on action"
+        onclick={() =>
+          toast.show('File ready to download.', {
+            variant: 'success',
+            duration: 0,
+            action: {
+              label: 'Download',
+              onAction: () => toast.show('Download started.', { variant: 'info' }),
+            },
+          })}
+      />
+      <Button
+        label="Keep open after action"
+        variant="secondary"
+        onclick={() =>
+          toast.show('Deployment in progress.', {
+            variant: 'info',
+            duration: 0,
+            action: {
+              label: 'View logs',
+              onAction: () => toast.show('Logs opened.', { variant: 'success' }),
+              keepOpen: true,
+            },
+          })}
+      />
+    </div>
+  {/snippet}
+</ToastRegion>

--- a/packages/playground/src/examples/toast-region/modal-scoped.example.svelte
+++ b/packages/playground/src/examples/toast-region/modal-scoped.example.svelte
@@ -1,0 +1,36 @@
+<script lang="ts" module>
+  export const title = 'Modal-scoped region';
+  export const description =
+    'A ToastRegion nested inside a modal creates an independent queue. Toasts dispatched from within the modal stay local to it and are cleared when the modal unmounts.';
+</script>
+
+<script lang="ts">
+  import { Button, Modal, ToastRegion, useToast } from '../../../../components/src/index.ts';
+
+  let open = $state(false);
+</script>
+
+<Button label="Open modal" onclick={() => (open = true)} />
+
+<Modal bind:open title="Modal with scoped toasts">
+  {#snippet children()}
+    <ToastRegion>
+      {#snippet children()}
+        {@const toast = useToast()}
+        <p style="margin-bottom: 1rem;">
+          Toasts dispatched here are scoped to this modal. They disappear when the modal closes.
+        </p>
+        <div class="example-preview-row">
+          <Button
+            label="Show info"
+            onclick={() => toast.show('This toast lives inside the modal.', { variant: 'info' })}
+          />
+          <Button
+            label="Show success"
+            onclick={() => toast.show('Action completed successfully.', { variant: 'success' })}
+          />
+        </div>
+      {/snippet}
+    </ToastRegion>
+  {/snippet}
+</Modal>

--- a/packages/playground/src/examples/toast-region/modal-scoped.example.svelte
+++ b/packages/playground/src/examples/toast-region/modal-scoped.example.svelte
@@ -17,9 +17,6 @@
     <ToastRegion>
       {#snippet children()}
         {@const toast = useToast()}
-        <p style="margin-bottom: 1rem;">
-          Toasts dispatched here are scoped to this modal. They disappear when the modal closes.
-        </p>
         <div class="example-preview-row">
           <Button
             label="Show info"

--- a/packages/playground/src/examples/toast-region/programmatic-dismiss.example.svelte
+++ b/packages/playground/src/examples/toast-region/programmatic-dismiss.example.svelte
@@ -6,27 +6,28 @@
 
 <script lang="ts">
   import { Button, ToastRegion, useToast } from '../../../../components/src/index.ts';
+
+  let lastId = $state<string | null>(null);
 </script>
 
 <ToastRegion>
   {#snippet children()}
     {@const toast = useToast()}
-    {@const lastId = { value: null as string | null }}
     <div class="example-preview-row">
       <Button
         label="Show sticky"
         onclick={() => {
-          lastId.value = toast.show('Sticky toast — will not auto-dismiss.', { duration: 0 });
+          lastId = toast.show('Sticky toast — will not auto-dismiss.', { duration: 0 });
         }}
       />
       <Button
         label="Dismiss last"
         variant="secondary"
         onclick={() => {
-          if (lastId.value) toast.dismiss(lastId.value);
+          if (lastId) toast.dismiss(lastId);
         }}
       />
-      <Button label="Dismiss all" variant="danger" onclick={() => toast.dismissAll()} />
+      <Button label="Dismiss all" variant="secondary" onclick={() => toast.dismissAll()} />
     </div>
   {/snippet}
 </ToastRegion>

--- a/packages/playground/src/examples/toast-region/programmatic-dismiss.example.svelte
+++ b/packages/playground/src/examples/toast-region/programmatic-dismiss.example.svelte
@@ -1,0 +1,32 @@
+<script lang="ts" module>
+  export const title = 'Programmatic dismiss';
+  export const description =
+    'show() returns the toast id. Capture it to dismiss a specific toast later, or call dismissAll() to clear both stacks at once.';
+</script>
+
+<script lang="ts">
+  import { Button, ToastRegion, useToast } from '../../../../components/src/index.ts';
+</script>
+
+<ToastRegion>
+  {#snippet children()}
+    {@const toast = useToast()}
+    {@const lastId = { value: null as string | null }}
+    <div class="example-preview-row">
+      <Button
+        label="Show sticky"
+        onclick={() => {
+          lastId.value = toast.show('Sticky toast — will not auto-dismiss.', { duration: 0 });
+        }}
+      />
+      <Button
+        label="Dismiss last"
+        variant="secondary"
+        onclick={() => {
+          if (lastId.value) toast.dismiss(lastId.value);
+        }}
+      />
+      <Button label="Dismiss all" variant="danger" onclick={() => toast.dismissAll()} />
+    </div>
+  {/snippet}
+</ToastRegion>

--- a/packages/playground/src/examples/toast-region/variants.example.svelte
+++ b/packages/playground/src/examples/toast-region/variants.example.svelte
@@ -1,0 +1,35 @@
+<script lang="ts" module>
+  export const title = 'All four variants';
+  export const description =
+    'info and success route to the polite (status) region; warning and danger route to the assertive (alert) region.';
+</script>
+
+<script lang="ts">
+  import { Button, ToastRegion, useToast } from '../../../../components/src/index.ts';
+</script>
+
+<ToastRegion>
+  {#snippet children()}
+    {@const toast = useToast()}
+    <div class="example-preview-row">
+      <Button
+        label="Info"
+        onclick={() => toast.show('A new version is available.', { variant: 'info' })}
+      />
+      <Button
+        label="Success"
+        onclick={() => toast.show('Saved your changes.', { variant: 'success' })}
+      />
+      <Button
+        label="Warning"
+        variant="secondary"
+        onclick={() => toast.show('Your session expires in 5 minutes.', { variant: 'warning' })}
+      />
+      <Button
+        label="Danger"
+        variant="danger"
+        onclick={() => toast.show('Failed to save your changes.', { variant: 'danger' })}
+      />
+    </div>
+  {/snippet}
+</ToastRegion>

--- a/packages/playground/src/examples/toast-region/variants.example.svelte
+++ b/packages/playground/src/examples/toast-region/variants.example.svelte
@@ -22,12 +22,10 @@
       />
       <Button
         label="Warning"
-        variant="secondary"
         onclick={() => toast.show('Your session expires in 5 minutes.', { variant: 'warning' })}
       />
       <Button
         label="Danger"
-        variant="danger"
         onclick={() => toast.show('Failed to save your changes.', { variant: 'danger' })}
       />
     </div>


### PR DESCRIPTION
## Summary

- Adds `toast-region.md`: full call-site usage guide covering `<ToastRegion>` placement, the `ToastRegion` props table, `useToast()` lifecycle rules (including snippet context behavior), the `ToastApi` method table, all `ToastOptions` fields, variant routing (polite vs assertive), action buttons, modal-scoped regions via `children`, dismiss patterns, and v1 limitations
- Exports `ToastRegionProps` from the `cinder` barrel index (previously the only Props type from the toast surface not re-exported)
- Adds a "See also" link in `toast-region.a11y.md` → `toast-region.md`
- Adds four playground examples: `variants` (all four variants side by side with polite/assertive routing noted), `action-button` (dismiss-on-action vs keepOpen:true), `programmatic-dismiss` (captures `show()` id, targeted dismiss, dismissAll), `modal-scoped` (independent queue inside a Modal)

## Review committee

Pre-reviewed by: prose-editor, ux-designer, junior-engineer, Codex (gpt-5.4, xhigh reasoning)
- 2 rounds of review
- All must-fix items addressed before PR creation

Round 1 fixes: broken Placement example (children shadowing), `{@const}` mutable object anti-pattern in programmatic-dismiss replaced with `$state`, `variant="danger"` on non-destructive dismiss button corrected, inline style on `<p>` removed, consistent button variants in variants example, added `ToastApi` table, `ToastRegionProps` mention, footgun warning, id collision caveat.

Round 2: all agents approved.

## Test plan

- [ ] `bun run typecheck` — passes (0 errors, 67 warnings pre-existing)
- [ ] `bun test` — 1813 tests pass, 0 failures
- [ ] `bunx svelte-check` on playground — 0 errors
- [ ] Manual playground smoke: navigate to `/c/toast-region`, verify 6 examples appear (basic, dismissible, variants, action-button, programmatic-dismiss, modal-scoped)
- [ ] Variants example: all four buttons produce a toast; info/success → polite region (`role="status"`); warning/danger → assertive region (`role="alert"`)
- [ ] Action-button example: first button dismisses toast on action click; second button keeps toast visible
- [ ] Programmatic-dismiss: Show sticky → stays; Dismiss last → removes it; Dismiss all → clears active toasts
- [ ] Modal-scoped: toasts dispatched inside modal stay in modal region; closing modal clears them

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are documentation/playground additions plus a type-only barrel export (`ToastRegionProps`) with no runtime behavior changes.
> 
> **Overview**
> Adds a new `toast-region.md` guide documenting `ToastRegion` placement/props, `useToast()` usage constraints, `ToastApi`/`ToastOptions`, variant routing, action buttons, modal-scoped regions, and dismissal patterns.
> 
> Updates `toast-region.a11y.md` to link to the new usage guide, exports `ToastRegionProps` from the main `cinder` barrel, and adds four new playground examples demonstrating variants, action buttons, programmatic dismiss, and modal-scoped regions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 844ba393469d608a128d917cd415317d5d92375e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->