### PR TITLE
docs(recipes): add skip-link recipe + a11y docs index

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,15 @@
+# Documentation
+
+This directory holds the long-form documentation that does not live inside a component's own folder: cross-cutting policies, accessibility recipes, and internal planning notes.
+
+## Recipes
+
+- [Recipes index](./recipes/README.md): short, copy-paste-ready patterns that compose existing Cinder primitives. Currently includes the [skip-link recipe](./recipes/skip-link.md).
+
+## Policies
+
+- [Focus ring policy](./focus-ring-policy.md): the two approved `:focus-visible` strategies for Cinder component CSS, plus the four tokens both strategies consume.
+
+## Internal planning
+
+- [Phase 6 plan](./phase-6-plan.md): historical planning document. Not a consumer-facing reference — kept here for context on past phases of work.

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,7 +4,7 @@ This directory holds the long-form documentation that does not live inside a com
 
 ## Recipes
 
-- [Recipes index](./recipes/README.md): short, copy-paste-ready patterns that compose existing Cinder primitives. Currently includes the [skip-link recipe](./recipes/skip-link.md).
+- [Recipes](./recipes/README.md) — currently: the [skip-link recipe](./recipes/skip-link.md).
 
 ## Policies
 

--- a/docs/recipes/README.md
+++ b/docs/recipes/README.md
@@ -1,0 +1,7 @@
+# Recipes
+
+Short, copy-paste-ready patterns that compose existing Cinder primitives but do not warrant a dedicated component. Each recipe documents an accessibility or integration pattern, the underlying primitives it uses, and the pitfalls that catch teams off-guard the first time.
+
+The list will grow as the component set matures. Today:
+
+- [Skip link](./skip-link.md): the "Skip to main content" pattern built on `<VisuallyHidden focusable>` and the `.cinder-sr-only-focusable` utility class.

--- a/docs/recipes/README.md
+++ b/docs/recipes/README.md
@@ -2,6 +2,4 @@
 
 Short, copy-paste-ready patterns that compose existing Cinder primitives but do not warrant a dedicated component. Each recipe documents an accessibility or integration pattern, the underlying primitives it uses, and the pitfalls that catch teams off-guard the first time.
 
-The list will grow as the component set matures. Today:
-
 - [Skip link](./skip-link.md): the "Skip to main content" pattern built on `<VisuallyHidden focusable>` and the `.cinder-sr-only-focusable` utility class.

--- a/docs/recipes/skip-link.md
+++ b/docs/recipes/skip-link.md
@@ -102,7 +102,7 @@ A couple of things to keep in mind when you do this:
 ## Common pitfalls
 
 - **A focusable element before the skip link.** A logo `<a>`, a language switcher, a "Sign in" button — any of them put a stop ahead of the skip link and the user has to Tab past your chrome to find the thing that was supposed to let them skip your chrome. I've seen this most often with a logo link in the header, because the header is the first thing a designer reaches for.
-- **No `tabindex="-1"` on the target.** Activation only scrolls; focus stays on the anchor; screen readers do not jump. Easy to miss because sighted manual testing _looks_ correct.
+- **No `tabindex="-1"` on the target.** Activation only scrolls; keyboard focus stays on the anchor, leaving assistive technology without a reliable focused destination. Easy to miss because sighted manual testing _looks_ correct.
 - **`tabindex="0"` on the target instead of `-1`.** Creates an extra keyboard stop on every page. Use `-1` — programmatically focusable, not in the tab order.
 - **`display: none` instead of the visually-hidden technique.** `display: none` removes the link from the accessibility tree entirely, so keyboard users cannot tab to it. The whole point of `.cinder-sr-only` is to stay in the tree.
 - **Generic label text.** "Skip" is not specific enough; "Skip to main content" is. When multiple skip links exist, each label must describe its specific destination.

--- a/docs/recipes/skip-link.md
+++ b/docs/recipes/skip-link.md
@@ -1,0 +1,115 @@
+# Skip link
+
+A **skip link** is the small "Skip to main content" anchor that appears the first time a keyboard user presses Tab on a page. It lets them bypass repeated navigation chrome and land directly inside the page's main landmark. The pattern satisfies [WCAG 2.4.1 Bypass Blocks](https://www.w3.org/WAI/WCAG21/Understanding/bypass-blocks.html) and costs almost nothing to implement.
+
+Cinder ships skip links as a **recipe rather than a component**: the existing `<VisuallyHidden focusable>` primitive plus the underlying `.cinder-sr-only-focusable` utility already do the work. A dedicated `<SkipLink>` component would only wrap an anchor — until that wrapper earns its keep, the recipe is the right deliverable.
+
+## A note on naming
+
+Most accessibility literature calls these utility classes `.visually-hidden` and `.focusable`. Cinder uses the project-wide `cinder-` namespace, so the equivalents are:
+
+- `.cinder-sr-only`: the always-hidden screen-reader utility.
+- `.cinder-sr-only-focusable`: the focusable modifier that reveals the element on `:focus-visible` / `:focus-within` and pins it to the top-left of the viewport.
+
+If you are translating a snippet from a guide that uses the literature names, mentally replace them with the Cinder names.
+
+## Plain-HTML pattern
+
+```html
+<body>
+  <a class="cinder-sr-only cinder-sr-only-focusable" href="#main-content"> Skip to main content </a>
+  <header>...</header>
+  <nav>...</nav>
+  <main id="main-content" tabindex="-1">
+    <!-- page content -->
+  </main>
+</body>
+```
+
+A few details carry weight in that snippet:
+
+- **Both classes on the anchor.** `.cinder-sr-only` provides the always-hidden resting state; `.cinder-sr-only-focusable` overrides it once the element gains focus. The Svelte component applies both for you when you pass `focusable`; raw markup needs both class names explicitly.
+- **`tabindex="-1"` on the target.** Without it, activating the link only scrolls the viewport — focus stays on the link, and screen readers keep reading from wherever they were. With `tabindex="-1"`, the browser moves focus into `<main>` on activation, and screen readers begin reading from the landmark.
+- **No `tabindex="0"` on the target.** A `tabindex="0"` value adds a redundant tab stop on every page. `-1` makes the element programmatically focusable without inserting it into the tab order.
+- **One `<main>` per page.** Per the [WAI-ARIA spec](https://www.w3.org/TR/wai-aria-1.2/#main), a document has at most one `main` landmark. The skip link's fragment points at its `id`.
+
+## Svelte: component variant
+
+The canonical Cinder way uses the `<VisuallyHidden>` primitive with `as="a"` and `focusable`. Types come through `HTMLAnchorAttributes`, so `href` is checked normally.
+
+```svelte
+<script lang="ts">
+  import { VisuallyHidden } from 'cinder';
+  let { children } = $props();
+</script>
+
+<VisuallyHidden as="a" href="#main-content" focusable>Skip to main content</VisuallyHidden>
+
+<header>
+  <!-- site navigation -->
+</header>
+
+<main id="main-content" tabindex="-1">
+  {@render children()}
+</main>
+```
+
+Use this variant when the skip link lives inside a Svelte component — typically the topmost `+layout.svelte` in a SvelteKit project, or the root component of a Svelte SPA.
+
+## Svelte: `app.html` variant
+
+In SvelteKit, the skip link can also live in `src/app.html`, immediately inside `<body>`. That puts it ahead of any Svelte-rendered chrome and avoids a per-route component mount. There is no Svelte scope inside `app.html`, so use the raw class-based pattern:
+
+```html
+<body>
+  <a class="cinder-sr-only cinder-sr-only-focusable" href="#main-content"> Skip to main content </a>
+  %sveltekit.body%
+</body>
+```
+
+The target `<main id="main-content" tabindex="-1">` still lives inside your layout or page, wrapping the route content.
+
+## Placement: first focusable element wins
+
+The skip link must be the **first focusable element on the page**. A single Tab from a fresh page load needs to surface it; otherwise it cannot do its job.
+
+In practice that means:
+
+- In SvelteKit, place it immediately inside `<body>` in `app.html`, or as the very first markup line of the topmost `+layout.svelte` — before any header, logo, locale switcher, theme toggle, or navigation.
+- In a Svelte SPA, place it as the first child of the root component's markup.
+- Anything focusable rendered _before_ the skip link defeats the purpose. A `<a href="/">Home</a>` logo link in the header counts. A focusable theme toggle counts. Even a wrapping `<button>` around the brand counts.
+
+## Multiple skip links
+
+Most pages need exactly one skip link. The exception is pages with substantial secondary structure — a large in-page navigation alongside the main content, or a complex toolbar where a user might reasonably want to skip to either of two regions.
+
+```svelte
+<div class="skip-links">
+  <VisuallyHidden as="a" href="#main-content" focusable>Skip to main content</VisuallyHidden>
+  <VisuallyHidden as="a" href="#section-nav" focusable>Skip to section navigation</VisuallyHidden>
+</div>
+
+<header>...</header>
+<nav id="section-nav" tabindex="-1">...</nav>
+<main id="main-content" tabindex="-1">...</main>
+```
+
+A couple of things to keep in mind when you do this:
+
+- **Each label names its destination.** "Skip to main content" and "Skip to section navigation" — not "Skip" or "Skip 1" / "Skip 2". Generic labels are useless out of context.
+- **Default focused styling stacks at top-left.** `.cinder-sr-only-focusable` pins each focused link to the top-left of the viewport. Only one link is focused at a time, so consecutive links visually replace each other as the user tabs through them. That is intentional. If you want a different visual arrangement (a row of pills across the top, say), override the focus selectors on a wrapping class — the technique is documented in [`visually-hidden.a11y.md`](../../packages/components/src/components/visually-hidden.a11y.md#styling-the-focused-state).
+
+## Common pitfalls
+
+- **A focusable element before the skip link.** A logo `<a>`, a language switcher, a "Sign in" button — any of them put a stop ahead of the skip link and the user has to Tab past your chrome to find the thing that was supposed to let them skip your chrome.
+- **No `tabindex="-1"` on the target.** Activation only scrolls; focus stays on the anchor; screen readers do not jump. Easy to miss because sighted manual testing _looks_ correct.
+- **`tabindex="0"` on the target instead of `-1`.** Creates an extra keyboard stop on every page. Use `-1` — programmatically focusable, not in the tab order.
+- **`display: none` instead of the visually-hidden technique.** `display: none` removes the link from the accessibility tree entirely, so keyboard users cannot tab to it. The whole point of `.cinder-sr-only` is to stay in the tree.
+- **Generic label text.** "Skip" is not specific enough; "Skip to main content" is. When multiple skip links exist, each label must describe its specific destination.
+- **Hard-coded focus visuals on the skip link.** The revealed link inherits Cinder's focus ring policy from the surrounding tokens. Overriding `outline` or `box-shadow` in a one-off rule bypasses the policy — see [`focus-ring-policy.md`](../focus-ring-policy.md).
+
+## See also
+
+- [`visually-hidden.a11y.md`](../../packages/components/src/components/visually-hidden.a11y.md) — accessibility notes for the `<VisuallyHidden>` primitive, including the styling-the-focused-state technique referenced above.
+- [`focus-ring-policy.md`](../focus-ring-policy.md) — the focus ring tokens and strategies the revealed skip link inherits.
+- [`packages/components/src/styles/utilities.css`](../../packages/components/src/styles/utilities.css) — source of the `.cinder-sr-only` and `.cinder-sr-only-focusable` rules.

--- a/docs/recipes/skip-link.md
+++ b/docs/recipes/skip-link.md
@@ -1,6 +1,6 @@
 # Skip link
 
-A **skip link** is the small "Skip to main content" anchor that appears the first time a keyboard user presses Tab on a page. It lets them bypass repeated navigation chrome and land directly inside the page's main landmark. The pattern satisfies [WCAG 2.4.1 Bypass Blocks](https://www.w3.org/WAI/WCAG21/Understanding/bypass-blocks.html) and costs almost nothing to implement.
+A **skip link** is the small "Skip to main content" anchor that appears the first time a keyboard user presses Tab on a page. It lets them bypass repeated navigation chrome and land directly inside the page's main landmark. The pattern satisfies [WCAG 2.4.1 Bypass Blocks](https://www.w3.org/WAI/WCAG21/Understanding/bypass-blocks.html) and costs almost nothing to implement — and yet I've watched team after team ship apps without one, because the link is invisible until you tab to it and nobody on the team tabs through their own site.
 
 Cinder ships skip links as a **recipe rather than a component**: the existing `<VisuallyHidden focusable>` primitive plus the underlying `.cinder-sr-only-focusable` utility already do the work. A dedicated `<SkipLink>` component would only wrap an anchor — until that wrapper earns its keep, the recipe is the right deliverable.
 
@@ -29,7 +29,7 @@ If you are translating a snippet from a guide that uses the literature names, me
 A few details carry weight in that snippet:
 
 - **Both classes on the anchor.** `.cinder-sr-only` provides the always-hidden resting state; `.cinder-sr-only-focusable` overrides it once the element gains focus. The Svelte component applies both for you when you pass `focusable`; raw markup needs both class names explicitly.
-- **`tabindex="-1"` on the target.** Without it, activating the link only scrolls the viewport — focus stays on the link, and screen readers keep reading from wherever they were. With `tabindex="-1"`, the browser moves focus into `<main>` on activation, and screen readers begin reading from the landmark.
+- **`tabindex="-1"` on the target.** Without it, activating the link only scrolls the viewport — focus stays on the link. With `tabindex="-1"`, `<main>` becomes a programmatic focus target so fragment activation moves keyboard focus to the destination, keeps focus and scroll position aligned, and gives assistive technology a reliable landmark to announce. (Whether the screen reader then starts reading the landmark's contents varies by browser/AT combination — I've stopped trying to promise that part; the focus move is what's load-bearing.)
 - **No `tabindex="0"` on the target.** A `tabindex="0"` value adds a redundant tab stop on every page. `-1` makes the element programmatically focusable without inserting it into the tab order.
 - **One `<main>` per page.** Per the [WAI-ARIA spec](https://www.w3.org/TR/wai-aria-1.2/#main), a document has at most one `main` landmark. The skip link's fragment points at its `id`.
 
@@ -101,7 +101,7 @@ A couple of things to keep in mind when you do this:
 
 ## Common pitfalls
 
-- **A focusable element before the skip link.** A logo `<a>`, a language switcher, a "Sign in" button — any of them put a stop ahead of the skip link and the user has to Tab past your chrome to find the thing that was supposed to let them skip your chrome.
+- **A focusable element before the skip link.** A logo `<a>`, a language switcher, a "Sign in" button — any of them put a stop ahead of the skip link and the user has to Tab past your chrome to find the thing that was supposed to let them skip your chrome. I've seen this most often with a logo link in the header, because the header is the first thing a designer reaches for.
 - **No `tabindex="-1"` on the target.** Activation only scrolls; focus stays on the anchor; screen readers do not jump. Easy to miss because sighted manual testing _looks_ correct.
 - **`tabindex="0"` on the target instead of `-1`.** Creates an extra keyboard stop on every page. Use `-1` — programmatically focusable, not in the tab order.
 - **`display: none` instead of the visually-hidden technique.** `display: none` removes the link from the accessibility tree entirely, so keyboard users cannot tab to it. The whole point of `.cinder-sr-only` is to stay in the tree.

--- a/packages/components/src/components/visually-hidden.a11y.md
+++ b/packages/components/src/components/visually-hidden.a11y.md
@@ -59,6 +59,8 @@ Key points:
 - This primitive does **not** move focus programmatically. Activation of the anchor relies on the browser's default in-page navigation behavior.
 - Using `tabindex={0}` on a non-interactive element (e.g., `as="div"`) creates a keyboard stop with no action. If you must do it, add a valid interactive `role` and keyboard handlers — that is outside this primitive's scope.
 
+See also: [`docs/recipes/skip-link.md`](../../../../docs/recipes/skip-link.md) for the full skip-link recipe — placement guidance, multiple-skip-link patterns, and common pitfalls.
+
 ## Styling the focused state
 
 The default `.cinder-sr-only-focusable` rule pins the element to the top-left of the viewport with a positioned chip when focused. This is the canonical skip-link placement.


### PR DESCRIPTION
## Summary

Adds the canonical skip-link recipe and a small docs index, completing ROADMAP item 6 (skip-link recipe). Documentation-only — no component or CSS changes.

- `docs/recipes/skip-link.md` (new): the canonical "Skip to main content" recipe. Covers plain-HTML, Svelte component, and SvelteKit `app.html` patterns, placement rules, multiple-skip-link composition, and six common pitfalls. Explicitly notes the naming gap between `.cinder-sr-only` / `.cinder-sr-only-focusable` and the `.visually-hidden` / `.focusable` names in most accessibility literature.
- `docs/recipes/README.md` (new): one-paragraph recipes index.
- `docs/README.md` (new): top-of-directory docs index linking recipes, the focus ring policy, and the historical phase-6 plan.
- `packages/components/src/components/visually-hidden.a11y.md` (+2 lines): "See also" back-link to the new canonical recipe, so the component-level a11y notes and the recipe reinforce each other instead of duplicating.

Per ROADMAP item 6, no `<SkipLink>` component — the existing `<VisuallyHidden focusable>` primitive plus the documented snippet is the right deliverable until demand for a wrapper emerges.

## Review committee

Pre-reviewed by: prose-editor, simplicity-engineer, junior-engineer, codex
- Codex (gpt-5.4, xhigh / high reasoning) — 3 rounds
- 3 rounds of review
- All must-fix items addressed

Notable corrections caught in review:
- Codex (round 1): the `tabindex="-1"` rationale originally claimed "screen readers begin reading from the landmark" — that behavior varies by browser/AT and isn't promiseable. Reworded to focus on the reliable parts: keyboard focus moves, focus and scroll position stay aligned, and the landmark becomes an announceable destination.
- Codex (round 2): same overclaim survived in shorter form ("screen readers do not jump") in the pitfalls list. Reworded to talk about keyboard focus and the missing focused destination, not about whether the screen reader jumps.
- prose-editor (round 1): added two short first-person beats so the recipe sounds like teaching, not a manual.
- simplicity-engineer (round 1): dropped the "this list will grow" preamble from `docs/recipes/README.md` and collapsed the duplicate Recipes description in `docs/README.md`.

## Test plan

- [ ] Render `docs/README.md`, `docs/recipes/README.md`, and `docs/recipes/skip-link.md` in a markdown previewer; headings, code blocks, and inline code render cleanly.
- [ ] Click every relative link in the new docs and the back-link added to `visually-hidden.a11y.md`; all resolve.
- [ ] `rg "cinder-sr-only" docs/recipes/skip-link.md` confirms the class names in snippets match the actual utilities in `packages/components/src/styles/utilities.css`.
- [ ] `bun run lint` passes (no new warnings introduced by docs changes).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only additions plus a cross-link in existing a11y notes; no runtime code, CSS, or API behavior changes.
> 
> **Overview**
> Adds a `docs/` index (`docs/README.md`) and a new recipes section (`docs/recipes/README.md`) to organize long-form documentation.
> 
> Introduces a new skip-link recipe (`docs/recipes/skip-link.md`) with copy/paste snippets (plain HTML, Svelte, and SvelteKit `app.html`), plus guidance on placement, multiple skip links, and common pitfalls.
> 
> Updates `visually-hidden.a11y.md` to link readers to the new canonical skip-link recipe to avoid duplicating guidance.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2fa70732cbd7f5013eef482053aab14003318338. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->