### PR TITLE
docs(announcer): export useAnnouncer + add recipe documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,6 +280,10 @@ These are `@cinder/*` scoped packages that live in the cinder monorepo but are n
 - **Multi-select / async combobox, virtualized table**—explicit non-goals for v1.
 - **React port of cinder**—cross-framework needs are tracked at the vocabulary level; the port itself is not in scope.
 
+## Recipes
+
+- [Live-region announcer for transient messages](docs/recipes/announcer.md)
+
 ## License
 
 MIT

--- a/docs/recipes/announcer.md
+++ b/docs/recipes/announcer.md
@@ -1,0 +1,121 @@
+# Live-region announcer for transient messages
+
+`useAnnouncer` is a Svelte 5 hook that drives a screen-reader live region from imperative announcements. You call `announcer.announce('Saved')`, the hook flickers the text into a live-region `<div>` long enough for assistive tech to pick it up, and then clears the region so the same string can be announced again later. The live region itself stays in your template; the hook owns the timing.
+
+## When to reach for it
+
+Use it for transient announcements that have no persistent visual equivalent on the page:
+
+- Form submission success: `Profile saved`.
+- Async operation results: `3 items imported`.
+- Copy-to-clipboard confirmations: `Copied to clipboard`. The shipped [`CopyButton`](../../packages/components/src/components/copy-button.svelte) component owns the visual side of this one—pair them when the announcement should run alongside an icon-only button.
+- Status changes that already produce a visible diff but warrant an SR-only confirmation: `Filter applied — 12 results`.
+
+## When _not_ to reach for it
+
+A live region is the wrong shape for anything persistent, visible, or critical:
+
+- For a visible, dismissible message, use [`Banner`](../../packages/components/src/components/banner.svelte) or [`Alert`](../../packages/components/src/components/alert.svelte).
+- For a transient floating message _with_ visible UI, use [`ToastRegion`](../../packages/components/src/components/toast-region.svelte) + `useToast`. The toast machinery already announces its own messages; layering an announcer on top double-announces.
+- For a permanently-rendered status label (something like "Auto-saved at 2:14pm" sitting in a footer), render a static `aria-live` region directly. The hook earns its keep on one-shot announcements; for steady-state text, plain reactive markup is simpler.
+
+## The markup pattern
+
+The canonical pairing is one live-region `<div>` near the root of your component or app shell, fed by the hook:
+
+```svelte
+<script lang="ts">
+  import { useAnnouncer } from 'cinder';
+
+  const announcer = useAnnouncer();
+
+  function handleSubmit() {
+    // ...submit logic
+    announcer.announce('Profile saved');
+  }
+</script>
+
+<form onsubmit={handleSubmit}>
+  <!-- ...form fields -->
+</form>
+
+<div aria-live="polite" aria-atomic="true" class="cinder-sr-only">
+  {announcer.message}
+</div>
+```
+
+A few things to notice in that snippet:
+
+- **`aria-live="polite"`** waits for the current speech queue to drain before announcing. Right for non-urgent updates, which is almost everything.
+- **`aria-atomic="true"`** asks assistive tech to re-read the full live-region content when any part of it changes. Without it, some screen readers read only the diff, which produces weird partial announcements when one message replaces another.
+- **`class="cinder-sr-only"`** is the visually-hidden utility shipped by `cinder/styles` (defined in `packages/components/src/styles/utilities.css`). It uses the canonical clip-rect technique—the live region stays in the accessibility tree and out of the visual layout.
+
+> [!NOTE]
+> If you're coming from accessibility writing that uses the `.visually-hidden` / `.focusable` class names, the equivalents here are `.cinder-sr-only` and `.cinder-sr-only-focusable`. Same technique, namespaced.
+
+## Polite vs assertive
+
+The `aria-live` attribute on _your_ `<div>` is the contract—the hook does not encode politeness. `polite` is the default in the recipe above and the right choice for almost everything: success confirmations, status updates, filter results, search-result counts.
+
+Reserve **`aria-live="assertive"`** for genuinely urgent state—the destructive action that just failed, the connection that just dropped. Assertive announcements interrupt whatever the screen reader is currently saying, which is jarring if you reach for it too often.
+
+The conventional pattern is one `polite` region per page (or per layout region), and a _separate_ `aria-live="assertive"` `<div>` with its own `useAnnouncer()` call if you need urgent announcements:
+
+```svelte
+<script lang="ts">
+  import { useAnnouncer } from 'cinder';
+
+  const status = useAnnouncer();
+  const alerts = useAnnouncer();
+</script>
+
+<div aria-live="polite" aria-atomic="true" class="cinder-sr-only">
+  {status.message}
+</div>
+
+<div aria-live="assertive" aria-atomic="true" class="cinder-sr-only">
+  {alerts.message}
+</div>
+```
+
+## `clearDelay` and `debounceMs`
+
+`AnnouncerOptions` has two knobs, and the defaults are tuned for the common case:
+
+- **`clearDelay`** (default `1000` ms): how long the message stays in the live region before the hook auto-clears it. Clearing matters because announcing the same string twice in a row—`Saved`, then `Saved` again—needs the live region to go empty in between, or screen readers see "no change" and stay quiet. Bump this up to ~3000 ms for longer multi-clause messages.
+- **`debounceMs`** (default `0`): a debounce window applied to `announce()` itself. Useful when calls fire in rapid succession—typing indicators, search-result counts that re-tally on every keystroke. `useAnnouncer({ debounceMs: 300 })` collapses a burst of `announce('Searching...')` calls into a single announcement at the trailing edge.
+
+```ts
+const announcer = useAnnouncer({ clearDelay: 3000, debounceMs: 300 });
+```
+
+## Cleanup
+
+The hook installs a `$effect` cleanup that clears every pending `setTimeout` when the component unmounts. In normal usage you don't have to call anything yourself.
+
+The `destroy()` method exists for the rare case where you need to tear down before unmount—imagine a long-lived parent component imperatively re-keying the announcer instance:
+
+```ts
+const announcer = useAnnouncer();
+
+// Later, before unmount:
+announcer.destroy();
+```
+
+If you're not doing anything fancy, ignore `destroy()` and let the effect cleanup do its job.
+
+## Pitfalls
+
+A few traps worth flagging:
+
+- **Don't mount multiple `polite` live regions at the same DOM depth.** Assistive tech may collapse them or read out of order. One `polite` region per layout region is the rule of thumb. Same for `assertive`.
+- **Never render visible UI inside the live-region `<div>`.** The `.cinder-sr-only` clip-rect utility is non-negotiable—visible content inside the live region produces both visual layout breakage and inconsistent SR behavior across browsers.
+- **Don't pass `announcer.message` to a derived computation that expects stable references.** The message intentionally goes empty between announcements as part of the re-announcement trick; downstream `$derived` will see those transitions and react accordingly.
+- **Don't call `announce()` from inside `$derived` or `$effect.pre`.** Call it from event handlers or other concrete user-driven entry points. Announcements wired to derivation cycles tend to fire on every input keystroke, which is exactly what `debounceMs` is for—but only if `announce()` is reached from an event handler, not from inside a reactive computation.
+
+## Related
+
+- [`Banner`](../../packages/components/src/components/banner.svelte): visible persistent messaging.
+- [`Alert`](../../packages/components/src/components/alert.svelte): visible dismissible messaging.
+- [`ToastRegion`](../../packages/components/src/components/toast-region.svelte) + `useToast`: transient visible notifications with their own internal announcement mechanics.
+- [`VisuallyHidden`](../../packages/components/src/components/visually-hidden.svelte): the inverse of a live region—visible-to-SR content hidden from sighted users, without `aria-live` semantics.

--- a/docs/tokens.md
+++ b/docs/tokens.md
@@ -220,6 +220,17 @@ Shared backdrop, blur, padding, and radius for Modal, Sheet, and Popover. Adjust
 | `--cinder-overlay-padding`  | `var(--cinder-space-6)`                                            |
 | `--cinder-overlay-radius`   | `var(--cinder-radius-lg)`                                          |
 
+## Scrollbars
+
+Themed native scrollbars for components that opt in via `scrollbar-width` and `::-webkit-scrollbar-*` (notably `ScrollArea`). The thumb alphas are tuned so resolved thumb-on-surface contrast clears WCAG 1.4.11 (3:1) over the common light- and dark-mode surface tokens.
+
+| Token                            | Default                                                    |
+| -------------------------------- | ---------------------------------------------------------- |
+| `--cinder-scrollbar-size`        | `0.625rem`                                                 |
+| `--cinder-scrollbar-track`       | `light-dark(oklch(0% 0 0 / 0.04), oklch(100% 0 0 / 0.04))` |
+| `--cinder-scrollbar-thumb`       | `light-dark(oklch(0% 0 0 / 0.45), oklch(100% 0 0 / 0.45))` |
+| `--cinder-scrollbar-thumb-hover` | `light-dark(oklch(0% 0 0 / 0.65), oklch(100% 0 0 / 0.65))` |
+
 ## Button
 
 Component-specific tokens for [`Button`](../packages/components/src/components/button.svelte). The base trio (`bg`, `fg`, `border`) defines the secondary-variant defaults; size tokens scale padding, height, font, and radius across `xs`/`sm`/`md`/`lg`/`xl`. `md` is the AAA touch-target size (44px); `xs` and `sm` are intentionally below AAA — see [`button.a11y.md`](../packages/components/src/components/button.a11y.md) for the rationale.

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -388,6 +388,9 @@ export type {
   ToastVariant,
 } from './components/toast-region.svelte';
 
+export { useAnnouncer } from './utilities/use-announcer.svelte.ts';
+export type { Announcer, AnnouncerOptions } from './utilities/use-announcer.svelte.ts';
+
 export { useHistory } from './utilities/use-history.svelte.ts';
 export type {
   UseHistory,


### PR DESCRIPTION
## Summary

`useAnnouncer` (DEP-83) is a fully implemented screen-reader announcement hook with debounce, auto-clear, and `$effect` cleanup, but it was never re-exported from `packages/components/src/index.ts` — external consumers couldn't reach it.

This PR:

- **Adds the barrel re-export** for `useAnnouncer` plus `Announcer` and `AnnouncerOptions` types from `packages/components/src/index.ts` (placed alphabetically with other utility hooks).
- **Adds a recipe doc** at `docs/recipes/announcer.md` covering intent, when (and when not) to reach for it, the canonical `aria-live` markup pattern, polite vs assertive routing, `clearDelay`/`debounceMs`, cleanup behavior, pitfalls, and related components.
- **Adds a `## Recipes` section** to the top-level `README.md` linking the new doc.
- **Fixes a pre-existing `tokens-doc-drift` test failure** by documenting the `--cinder-scrollbar-*` tokens that shipped with `ScrollArea` (PR #85) but were missed when the tokens catalog (PR #88) landed. This was blocking pre-commit on this branch and the fix is small and self-contained.

No subpath export was added at `cinder/use-announcer` — established convention for utility hooks is root-barrel only (matches `useToast`, `useHistory`, `useReducedMotion`), and `exports-drift.test.ts` would actively flag a `.ts` subpath as an orphan.

## Review committee

Pre-reviewed by: prose-editor, simplicity-engineer, junior-engineer, codex
- Codex (gpt-5.4, xhigh reasoning) — 1 round
- 1 round of review
- All committee members APPROVED without must-fix items
- Junior-engineer spot-checked every API claim in the recipe against the hook implementation (defaults, methods, timing, cleanup) — all accurate

## Test plan

- [x] `bun run typecheck` (packages/components) — 0 errors
- [x] `bun run lint` (packages/components) — 0 errors, 15 pre-existing warnings
- [x] `bun run test` (packages/components, with --conditions browser) — 1896 pass / 0 fail
- [x] `bun run build` (packages/components) — clean
- [x] `rg useAnnouncer dist/` — `useAnnouncer` appears in `dist/index.d.ts` and the server bundle
- [ ] Visually inspect the rendered `docs/recipes/announcer.md` after deploy preview is up

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: mostly documentation updates plus a barrel export for an already-implemented hook; no behavioral changes to components or styling tokens.
> 
> **Overview**
> Exposes the previously internal `useAnnouncer` hook (and `Announcer`/`AnnouncerOptions` types) via the main `cinder` barrel export so downstream consumers can import it.
> 
> Adds new documentation: a recipe page describing the recommended `aria-live` markup and usage patterns for transient screen-reader announcements, links it from `README.md`, and updates `docs/tokens.md` to include the missing `--cinder-scrollbar-*` tokens to resolve doc/token drift.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 042c529ce7767f9fa183377f73cea597724b85cf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->