### PR TITLE
Update playground default port fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Cinder's color tokens are built on [`light-dark()`][mdn-light-dark]. Set `data-t
 
 ## Playground
 
-`bun run playground` starts the playground dev server at http://localhost:4173. The sidebar lists all 21 components—click any one to open its page in the main frame. Each component page shows curated examples with live controls.
+`bun run playground` starts the playground dev server at http://localhost:5555 by default, or the next available port if 5555 is already taken. The sidebar lists all 21 components—click any one to open its page in the main frame. Each component page shows curated examples with live controls.
 
 Those controls aren't hardcoded. The playground reads your component's `Props` type and generates form inputs automatically—text fields for strings, toggles for booleans, dropdowns for string unions. Change a `.svelte` file and the playground reloads via Server-Sent Events; no manual refresh needed.
 

--- a/packages/playground/src/server.test.ts
+++ b/packages/playground/src/server.test.ts
@@ -84,10 +84,11 @@ describe('port selection', () => {
     const reservedPort = reserved.port;
     if (reservedPort === undefined) throw new Error('Reserved test server did not expose a port');
 
-    const server = createHttpServerOnAvailablePort(reservedPort, () => new Response('fallback'));
+    const { port: serverPort, server } = createHttpServerOnAvailablePort(
+      reservedPort,
+      () => new Response('fallback'),
+    );
     temporaryServers.push(server);
-    const serverPort = server.port;
-    if (serverPort === undefined) throw new Error('Fallback test server did not expose a port');
 
     expect(serverPort).toBeGreaterThan(reservedPort);
     const response = await fetch(`http://127.0.0.1:${serverPort}`);

--- a/packages/playground/src/server.test.ts
+++ b/packages/playground/src/server.test.ts
@@ -9,11 +9,11 @@
  * beforeAll guard asserts this up front so failures are diagnosable.
  */
 
-import { beforeAll, describe, expect, it } from 'bun:test';
+import { afterEach, beforeAll, describe, expect, it } from 'bun:test';
 import { join } from 'node:path';
 
 import type { ComponentManifest } from './analyze.ts';
-import { PORT, handleRequest, triggerReload } from './server.ts';
+import { PORT, createHttpServerOnAvailablePort, handleRequest, triggerReload } from './server.ts';
 
 const FIXTURE_COMPONENT = 'button';
 const FIXTURE_SCENARIO = 'primary';
@@ -34,9 +34,66 @@ beforeAll(async () => {
   }
 });
 
+const temporaryServers: ReturnType<typeof Bun.serve>[] = [];
+
+afterEach(async () => {
+  const servers = temporaryServers.splice(0);
+  await Promise.all(servers.map((server) => server.stop(true)));
+});
+
 function req(path: string, options?: RequestInit): Request {
   return new Request(`http://localhost:${PORT}${path}`, options);
 }
+
+function reservePort(start: number): ReturnType<typeof Bun.serve> {
+  for (let port = start; port < start + 100; port++) {
+    try {
+      return Bun.serve({
+        port,
+        fetch: () => new Response('reserved'),
+      });
+    } catch (error) {
+      const errorWithCode = error as Error & { code?: unknown };
+      if (errorWithCode.code !== 'EADDRINUSE') throw error;
+    }
+  }
+  throw new Error(`Could not reserve a test port starting at ${start}`);
+}
+
+function tryReservePort(port: number): ReturnType<typeof Bun.serve> | null {
+  try {
+    return Bun.serve({
+      port,
+      fetch: () => new Response('reserved'),
+    });
+  } catch (error) {
+    const errorWithCode = error as Error & { code?: unknown };
+    if (errorWithCode.code === 'EADDRINUSE') return null;
+    throw error;
+  }
+}
+
+describe('port selection', () => {
+  it('defaults to port 5555', () => {
+    expect(PORT).toBe(5555);
+  });
+
+  it('uses the next available port when the preferred port is taken', async () => {
+    const reserved = tryReservePort(PORT) ?? reservePort(56_000);
+    temporaryServers.push(reserved);
+    const reservedPort = reserved.port;
+    if (reservedPort === undefined) throw new Error('Reserved test server did not expose a port');
+
+    const server = createHttpServerOnAvailablePort(reservedPort, () => new Response('fallback'));
+    temporaryServers.push(server);
+    const serverPort = server.port;
+    if (serverPort === undefined) throw new Error('Fallback test server did not expose a port');
+
+    expect(serverPort).toBeGreaterThan(reservedPort);
+    const response = await fetch(`http://127.0.0.1:${serverPort}`);
+    expect(await response.text()).toBe('fallback');
+  });
+});
 
 describe('/ping', () => {
   it('returns 200 pong', async () => {

--- a/packages/playground/src/server.ts
+++ b/packages/playground/src/server.ts
@@ -1205,6 +1205,10 @@ export type PlaygroundServer = {
 
 type BunServer = ReturnType<typeof Bun.serve>;
 type PlaygroundFetchHandler = (request: Request) => Response | Promise<Response>;
+type PlaygroundHttpServer = {
+  server: BunServer;
+  port: number;
+};
 
 function isAddressInUseError(error: unknown): boolean {
   if (!(error instanceof Error)) return false;
@@ -1215,14 +1219,15 @@ function isAddressInUseError(error: unknown): boolean {
 export function createHttpServerOnAvailablePort(
   preferredPort: number,
   fetchHandler: PlaygroundFetchHandler,
-): BunServer {
+): PlaygroundHttpServer {
   for (let offset = 0; offset < MAX_PORT_SCAN_ATTEMPTS; offset++) {
     const port = preferredPort + offset;
     try {
-      return Bun.serve({
+      const server = Bun.serve({
         port,
         fetch: fetchHandler,
       });
+      return { server, port };
     } catch (error) {
       if (!isAddressInUseError(error)) throw error;
     }
@@ -1298,7 +1303,8 @@ export async function startServer(port: number = PORT): Promise<PlaygroundServer
 
   // Start the HTTP server first — if binding fails for reasons other than an
   // occupied port, no watchers are leaked.
-  const server = createHttpServerOnAvailablePort(port, handleRequest);
+  const playgroundHttpServer = createHttpServerOnAvailablePort(port, handleRequest);
+  const { port: actualPort, server } = playgroundHttpServer;
 
   let watchers: FSWatcher[];
   try {
@@ -1316,7 +1322,6 @@ export async function startServer(port: number = PORT): Promise<PlaygroundServer
     await server.stop(true);
   }
 
-  const actualPort = server.port ?? port;
   const portFile = Bun.env['PLAYGROUND_PORT_FILE'];
   if (portFile !== undefined) {
     await Bun.write(portFile, `${actualPort}\n`);

--- a/packages/playground/src/server.ts
+++ b/packages/playground/src/server.ts
@@ -1,7 +1,7 @@
 /**
  * Cinder component playground dev server.
  *
- * Runs at http://localhost:4173. Routes:
+ * Runs at http://localhost:5555 by default, or the next available port. Routes:
  *   GET /              → 302 redirect to /c/<first-component>
  *   GET /c/:name       → shell HTML (sidebar + iframe pointing at /page/:name)
  *   GET /page/:name    → component page HTML (the iframe target — lists examples)
@@ -33,7 +33,8 @@ import { PRE_PAINT_THEME_SCRIPT, renderShell } from './render-shell.ts';
 
 import type { ComponentManifest } from './types.ts';
 
-export const PORT = 4173;
+export const PORT = 5555;
+const MAX_PORT_SCAN_ATTEMPTS = 100;
 // import.meta.dirname is packages/playground/src/
 const PLAYGROUND_ROOT = dirname(import.meta.dirname); // packages/playground/
 const COMPONENTS_ROOT = join(PLAYGROUND_ROOT, '..', 'components'); // packages/components/
@@ -1202,6 +1203,38 @@ export type PlaygroundServer = {
   dispose: () => Promise<void>;
 };
 
+type BunServer = ReturnType<typeof Bun.serve>;
+type PlaygroundFetchHandler = (request: Request) => Response | Promise<Response>;
+
+function isAddressInUseError(error: unknown): boolean {
+  if (!(error instanceof Error)) return false;
+  const errorWithCode = error as Error & { code?: unknown };
+  return errorWithCode.code === 'EADDRINUSE';
+}
+
+export function createHttpServerOnAvailablePort(
+  preferredPort: number,
+  fetchHandler: PlaygroundFetchHandler,
+): BunServer {
+  for (let offset = 0; offset < MAX_PORT_SCAN_ATTEMPTS; offset++) {
+    const port = preferredPort + offset;
+    try {
+      return Bun.serve({
+        port,
+        fetch: fetchHandler,
+      });
+    } catch (error) {
+      if (!isAddressInUseError(error)) throw error;
+    }
+  }
+
+  throw new Error(
+    `[playground] no available port found from ${preferredPort} through ${
+      preferredPort + MAX_PORT_SCAN_ATTEMPTS - 1
+    }`,
+  );
+}
+
 /**
  * Pre-build every sidebar component's page bundle + the shell bundle.
  *
@@ -1263,12 +1296,9 @@ export async function startServer(port: number = PORT): Promise<PlaygroundServer
     `[playground] Pre-built ${prebuild.succeeded}/${total} page bundles${failedSuffix}\n`,
   );
 
-  // Start the HTTP server first — if Bun.serve throws (e.g. EADDRINUSE),
-  // no watchers are leaked.
-  const server = Bun.serve({
-    port,
-    fetch: handleRequest,
-  });
+  // Start the HTTP server first — if binding fails for reasons other than an
+  // occupied port, no watchers are leaked.
+  const server = createHttpServerOnAvailablePort(port, handleRequest);
 
   let watchers: FSWatcher[];
   try {
@@ -1287,6 +1317,10 @@ export async function startServer(port: number = PORT): Promise<PlaygroundServer
   }
 
   const actualPort = server.port ?? port;
+  const portFile = Bun.env['PLAYGROUND_PORT_FILE'];
+  if (portFile !== undefined) {
+    await Bun.write(portFile, `${actualPort}\n`);
+  }
   process.stdout.write(`[playground] Listening at http://localhost:${actualPort}\n`);
   return { port: actualPort, dispose };
 }

--- a/packages/playground/src/validate-playground.ts
+++ b/packages/playground/src/validate-playground.ts
@@ -29,21 +29,19 @@ function fail(message: string): never {
 /** Minimum number of public components expected in src/components/. */
 const MINIMUM_COMPONENT_COUNT = 21;
 
-const BASE_URL = `http://127.0.0.1:${PORT}`;
-
 /** Wait for the server to become ready by polling /ping. */
-async function waitForPing(timeoutMs: number): Promise<void> {
+async function waitForPing(baseUrl: string, timeoutMs: number): Promise<void> {
   const startTime = Date.now();
   while (Date.now() - startTime < timeoutMs) {
     try {
-      const response = await fetch(`${BASE_URL}/ping`, { signal: AbortSignal.timeout(500) });
+      const response = await fetch(`${baseUrl}/ping`, { signal: AbortSignal.timeout(500) });
       if (response.status === 200) return;
     } catch {
       // Not ready yet.
     }
     await Bun.sleep(100);
   }
-  fail(`playground server did not respond on port ${PORT} within ${timeoutMs}ms`);
+  fail(`playground server did not respond at ${baseUrl} within ${timeoutMs}ms`);
 }
 
 /**
@@ -187,9 +185,12 @@ let server: PlaygroundServer | undefined;
 
 try {
   server = await startServer(PORT);
-  process.stdout.write(`[validate:playground] waiting for playground server on port ${PORT}…\n`);
-  await waitForPing(10_000);
-  process.stdout.write(`[validate:playground] server ready at ${BASE_URL}\n`);
+  const baseUrl = `http://127.0.0.1:${server.port}`;
+  process.stdout.write(
+    `[validate:playground] waiting for playground server on port ${server.port}…\n`,
+  );
+  await waitForPing(baseUrl, 10_000);
+  process.stdout.write(`[validate:playground] server ready at ${baseUrl}\n`);
 
   const components = await discoverComponents();
   if (components.length < MINIMUM_COMPONENT_COUNT) {
@@ -198,8 +199,8 @@ try {
     );
   }
 
-  await validateComponentRoutes(BASE_URL, components);
-  await validateSseReload(BASE_URL);
+  await validateComponentRoutes(baseUrl, components);
+  await validateSseReload(baseUrl);
 
   process.stdout.write('[validate:playground] all checks passed.\n');
   await server.dispose();

--- a/packages/testing/README.md
+++ b/packages/testing/README.md
@@ -31,7 +31,7 @@ bun run test:playwright:headed
 bun run test:playwright:ui
 ```
 
-`start-server.ts` manages the playground server automatically. By default it will reuse an already-running playground on the target URL (`PLAYGROUND_URL`, default `http://localhost:4173`). Set `PLAYWRIGHT_REUSE_SERVER=0` to force a hard failure if the port is already taken.
+`start-server.ts` manages the playground server automatically. By default it will reuse an already-running playground on the target URL (`PLAYGROUND_URL`, default `http://localhost:5555`). If it starts the local playground itself and 5555 is taken, it follows the playground server to the next available port. Set `PLAYWRIGHT_REUSE_SERVER=0` to force a hard failure if the target URL is already responding.
 
 ### Reproducing a single failing test
 

--- a/packages/testing/scripts/playground-server-url.test.ts
+++ b/packages/testing/scripts/playground-server-url.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'bun:test';
+import { isLocalDefaultPlaygroundUrl } from './playground-server-url';
+
+describe('isLocalDefaultPlaygroundUrl', () => {
+  it.each(['http://localhost:5555', 'http://127.0.0.1:5555', 'http://[::1]:5555'])(
+    'accepts local default playground URL %s',
+    (playgroundUrl) => {
+      expect(isLocalDefaultPlaygroundUrl(playgroundUrl)).toBe(true);
+    },
+  );
+
+  it.each([
+    'http://localhost:5556',
+    'http://example.com:5555',
+    'https://localhost:5555',
+    'http://localhost:5555/custom',
+  ])('rejects non-default playground URL %s', (playgroundUrl) => {
+    expect(isLocalDefaultPlaygroundUrl(playgroundUrl)).toBe(false);
+  });
+});

--- a/packages/testing/scripts/playground-server-url.ts
+++ b/packages/testing/scripts/playground-server-url.ts
@@ -1,0 +1,17 @@
+export const DEFAULT_PLAYGROUND_URL = 'http://localhost:5555';
+const DEFAULT_PLAYGROUND_PORT = Number(new URL(DEFAULT_PLAYGROUND_URL).port);
+const LOOPBACK_HOSTNAMES = new Set(['localhost', '127.0.0.1', '::1', '[::1]']);
+
+export function isLocalDefaultPlaygroundUrl(playgroundUrl: string): boolean {
+  try {
+    const url = new URL(playgroundUrl);
+    return (
+      url.protocol === 'http:' &&
+      LOOPBACK_HOSTNAMES.has(url.hostname) &&
+      Number(url.port) === DEFAULT_PLAYGROUND_PORT &&
+      (url.pathname === '' || url.pathname === '/')
+    );
+  } catch {
+    return false;
+  }
+}

--- a/packages/testing/scripts/start-server.ts
+++ b/packages/testing/scripts/start-server.ts
@@ -1,21 +1,38 @@
 import { spawn } from 'node:child_process';
-import { dirname, resolve } from 'node:path';
+import { mkdirSync, rmSync } from 'node:fs';
+import { dirname, resolve as resolvePath } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { PLAYGROUND_URL } from '../src/helpers/playground-url.ts';
 
 const here = dirname(fileURLToPath(import.meta.url));
-const packageRoot = resolve(here, '..');
-const repoRoot = resolve(here, '../../..');
+const packageRoot = resolvePath(here, '..');
+const repoRoot = resolvePath(here, '../../..');
 const readinessPath = '/api/manifest';
 const reuseOptOut = process.env['PLAYWRIGHT_REUSE_SERVER'] === '0';
+let targetPlaygroundUrl = PLAYGROUND_URL;
+const PLAYGROUND_PORT_PROBE_TIMEOUT_MS = 500;
 
-async function ping(): Promise<boolean> {
+async function ping(playgroundUrl: string = targetPlaygroundUrl): Promise<boolean> {
   try {
-    const response = await fetch(PLAYGROUND_URL + readinessPath);
+    const response = await fetch(playgroundUrl + readinessPath, {
+      signal: AbortSignal.timeout(PLAYGROUND_PORT_PROBE_TIMEOUT_MS),
+    });
     return response.ok;
   } catch {
     return false;
   }
+}
+
+function localPlaygroundUrlForPort(port: number): string {
+  return `http://localhost:${port}`;
+}
+
+async function readPlaygroundPortFile(path: string): Promise<number | null> {
+  const file = Bun.file(path);
+  if (!(await file.exists())) return null;
+  const text = await file.text();
+  const port = Number(text.trim());
+  return Number.isInteger(port) && port > 0 ? port : null;
 }
 
 function waitForExit(childProcess: ReturnType<typeof spawn>): Promise<number> {
@@ -31,48 +48,77 @@ function waitForExit(childProcess: ReturnType<typeof spawn>): Promise<number> {
   });
 }
 
-const DEFAULT_PLAYGROUND_URL = 'http://localhost:4173';
-const isLocalDefault = PLAYGROUND_URL === DEFAULT_PLAYGROUND_URL;
+const DEFAULT_PLAYGROUND_URL = 'http://localhost:5555';
+const DEFAULT_PLAYGROUND_PORT = Number(new URL(DEFAULT_PLAYGROUND_URL).port);
+const LOOPBACK_HOSTNAMES = new Set(['localhost', '127.0.0.1', '[::1]']);
+
+function isLocalDefaultPlaygroundUrl(playgroundUrl: string): boolean {
+  try {
+    const url = new URL(playgroundUrl);
+    return (
+      url.protocol === 'http:' &&
+      LOOPBACK_HOSTNAMES.has(url.hostname) &&
+      Number(url.port) === DEFAULT_PLAYGROUND_PORT &&
+      (url.pathname === '' || url.pathname === '/')
+    );
+  } catch {
+    return false;
+  }
+}
+
+const isLocalDefault = isLocalDefaultPlaygroundUrl(PLAYGROUND_URL);
 
 async function main(): Promise<void> {
   const args = process.argv.slice(2);
 
   let serverProcess: ReturnType<typeof spawn> | null = null;
+  let playgroundPortFile: string | null = null;
   const alreadyUp = await ping();
 
   if (alreadyUp && reuseOptOut) {
     console.error(
-      `Playground server already responding at ${PLAYGROUND_URL}, but PLAYWRIGHT_REUSE_SERVER=0 is set. Stop the running server or unset that variable.`,
+      `Playground server already responding at ${targetPlaygroundUrl}, but PLAYWRIGHT_REUSE_SERVER=0 is set. Stop the running server or unset that variable.`,
     );
     process.exit(1);
   }
 
   if (alreadyUp) {
-    console.log(`Reusing playground server at ${PLAYGROUND_URL}.`);
+    console.log(`Reusing playground server at ${targetPlaygroundUrl}.`);
   } else if (!isLocalDefault) {
-    // The local `bun run --filter=@cinder/playground dev` server binds to
-    // port 4173 unconditionally — starting it cannot satisfy readiness for
-    // a non-default `PLAYGROUND_URL`. Fail fast with an actionable message
-    // rather than spinning for 120s.
+    // The local `bun run --filter=@cinder/playground dev` server starts from
+    // the local default port and scans upward. Starting it cannot satisfy
+    // readiness for a custom `PLAYGROUND_URL`. Fail fast with an actionable
+    // message rather than spinning for 120s.
     console.error(
-      `Playground server not responding at ${PLAYGROUND_URL}, and it differs from the local default (${DEFAULT_PLAYGROUND_URL}). Start the target server manually before running the suite, or unset PLAYGROUND_URL.`,
+      `Playground server not responding at ${targetPlaygroundUrl}, and it differs from the local default (${DEFAULT_PLAYGROUND_URL}). Start the target server manually before running the suite, or unset PLAYGROUND_URL.`,
     );
     process.exit(1);
   } else {
-    console.log(`Starting playground server (target: ${PLAYGROUND_URL})...`);
+    console.log(`Starting playground server (target: ${targetPlaygroundUrl})...`);
+    playgroundPortFile = resolvePath(repoRoot, 'tmp', `playground-port-${process.pid}.txt`);
+    mkdirSync(resolvePath(repoRoot, 'tmp'), { recursive: true });
+    rmSync(playgroundPortFile, { force: true });
     serverProcess = spawn('bun', ['run', '--filter=@cinder/playground', 'dev'], {
       cwd: repoRoot,
-      stdio: ['ignore', 'inherit', 'inherit'],
+      stdio: ['ignore', 'pipe', 'inherit'],
+      env: { ...process.env, PLAYGROUND_PORT_FILE: playgroundPortFile },
+    });
+    serverProcess.stdout?.on('data', (chunk: string | Uint8Array) => {
+      process.stdout.write(chunk);
     });
 
     const startedAt = Date.now();
     const deadline = startedAt + 120_000;
     let lastLog = startedAt;
     while (Date.now() < deadline) {
-      if (await ping()) break;
+      const selectedPort = await readPlaygroundPortFile(playgroundPortFile);
+      if (selectedPort !== null) {
+        targetPlaygroundUrl = localPlaygroundUrlForPort(selectedPort);
+        if (await ping()) break;
+      }
       if (Date.now() - lastLog >= 10_000) {
         const elapsed = Math.round((Date.now() - startedAt) / 1000);
-        console.log(`Waiting for playground at ${PLAYGROUND_URL} (${elapsed}s elapsed)...`);
+        console.log(`Waiting for playground to report its selected port (${elapsed}s elapsed)...`);
         lastLog = Date.now();
       }
       await new Promise<void>((resolve) => setTimeout(resolve, 500));
@@ -84,7 +130,10 @@ async function main(): Promise<void> {
       } catch (error) {
         console.error('Failed to kill unready server process:', error);
       }
-      console.error(`Playground server did not become ready within 120s at ${PLAYGROUND_URL}.`);
+      console.error(
+        `Playground server did not become ready within 120s at ${targetPlaygroundUrl}.`,
+      );
+      if (playgroundPortFile !== null) rmSync(playgroundPortFile, { force: true });
       process.exit(1);
     }
   }
@@ -105,6 +154,7 @@ async function main(): Promise<void> {
         console.error('Failed to kill child process:', error);
       }
     }
+    if (playgroundPortFile !== null) rmSync(playgroundPortFile, { force: true });
   };
 
   process.on('SIGINT', () => {
@@ -119,6 +169,7 @@ async function main(): Promise<void> {
   const prep = spawn('bun', ['run', 'scripts/prepare-manifest.ts'], {
     cwd: packageRoot,
     stdio: 'inherit',
+    env: { ...process.env, PLAYGROUND_URL: targetPlaygroundUrl },
   });
   children.push(prep);
   const prepCode = await waitForExit(prep);
@@ -130,7 +181,7 @@ async function main(): Promise<void> {
   const playwright = spawn('bunx', ['playwright', 'test', ...args], {
     cwd: packageRoot,
     stdio: 'inherit',
-    env: { ...process.env },
+    env: { ...process.env, PLAYGROUND_URL: targetPlaygroundUrl },
   });
   children.push(playwright);
   const playwrightCode = await waitForExit(playwright);
@@ -138,6 +189,7 @@ async function main(): Promise<void> {
   const summary = spawn('bun', ['run', 'scripts/summarize-axe.ts'], {
     cwd: packageRoot,
     stdio: 'inherit',
+    env: { ...process.env, PLAYGROUND_URL: targetPlaygroundUrl },
   });
   children.push(summary);
   const summaryCode = await waitForExit(summary);

--- a/packages/testing/scripts/start-server.ts
+++ b/packages/testing/scripts/start-server.ts
@@ -3,6 +3,7 @@ import { mkdirSync, rmSync } from 'node:fs';
 import { dirname, resolve as resolvePath } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { PLAYGROUND_URL } from '../src/helpers/playground-url.ts';
+import { DEFAULT_PLAYGROUND_URL, isLocalDefaultPlaygroundUrl } from './playground-server-url';
 
 const here = dirname(fileURLToPath(import.meta.url));
 const packageRoot = resolvePath(here, '..');
@@ -46,24 +47,6 @@ function waitForExit(childProcess: ReturnType<typeof spawn>): Promise<number> {
       resolve(1);
     });
   });
-}
-
-const DEFAULT_PLAYGROUND_URL = 'http://localhost:5555';
-const DEFAULT_PLAYGROUND_PORT = Number(new URL(DEFAULT_PLAYGROUND_URL).port);
-const LOOPBACK_HOSTNAMES = new Set(['localhost', '127.0.0.1', '[::1]']);
-
-function isLocalDefaultPlaygroundUrl(playgroundUrl: string): boolean {
-  try {
-    const url = new URL(playgroundUrl);
-    return (
-      url.protocol === 'http:' &&
-      LOOPBACK_HOSTNAMES.has(url.hostname) &&
-      Number(url.port) === DEFAULT_PLAYGROUND_PORT &&
-      (url.pathname === '' || url.pathname === '/')
-    );
-  } catch {
-    return false;
-  }
 }
 
 const isLocalDefault = isLocalDefaultPlaygroundUrl(PLAYGROUND_URL);

--- a/packages/testing/src/helpers/playground-url.ts
+++ b/packages/testing/src/helpers/playground-url.ts
@@ -5,4 +5,4 @@
  * the playground's local dev port. Single source of truth — config, fixture,
  * and scripts all consume this.
  */
-export const PLAYGROUND_URL = process.env['PLAYGROUND_URL'] ?? 'http://localhost:4173';
+export const PLAYGROUND_URL = process.env['PLAYGROUND_URL'] ?? 'http://localhost:5555';


### PR DESCRIPTION
## Summary

- Change the playground default port from 4173 to 5555.
- Retry upward from the preferred port when Bun reports `EADDRINUSE`.
- Propagate the actual selected playground port into validation and browser-test startup, using a child-written port file so the wrapper follows the server it spawned.
- Update documentation and add regression coverage for fallback binding.

## Review committee

Pre-reviewed by: typescript-expert, testing-expert, dx-engineer, simplicity-engineer, prose-editor, junior-engineer.

- Codex reviewer unavailable: local Codex CLI shim could not produce review text because its expected vendor binary was missing.
- 2 rounds of review
- All must-fix items addressed

> [!WARNING]
> Codex (the adversarial second-opinion reviewer) was unavailable for this PR. See `tmp/committee-state.md` for detail.

## Test plan

- `bun test packages/playground/src/server.test.ts`
- `bun run --filter='@cinder/playground' typecheck`
- `bun run --filter='@cinder/testing' typecheck`
- `bun run --filter='@cinder/playground' lint`
- `bunx prettier --check README.md packages/testing/README.md packages/playground/src/server.ts packages/playground/src/server.test.ts packages/playground/src/validate-playground.ts packages/testing/src/helpers/playground-url.ts packages/testing/scripts/start-server.ts`
- Occupied port 5555 and ran `bun run --filter='@cinder/playground' validate`; server selected 5556 and validation passed.
- Pre-commit hook: `lint:fix`, typecheck, `TZ=UTC LANG=en_US.UTF-8 bun test --conditions browser` (2037 passing tests), and lint-staged.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes how the playground binds network ports and how the browser-test harness discovers the running server, which can break local dev/CI if any consumer still assumes a fixed port.
> 
> **Overview**
> **Playground now defaults to port `5555`** (was `4173`) and will *scan upward for the next free port* when the preferred port is already in use.
> 
> This introduces `createHttpServerOnAvailablePort()` in `packages/playground/src/server.ts`, writes the selected port to an optional `PLAYGROUND_PORT_FILE`, and updates `validate-playground.ts` plus the Playwright `start-server.ts` wrapper to follow the actual chosen port via that file (including stricter “local default URL” detection). Documentation and new/updated unit tests add regression coverage for port fallback behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5f38907e475990dccb7635b567fff8a1e5e77ab7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->