### PR TITLE
chore(components): add npm metadata for cinder package

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,7 +1,24 @@
 {
   "name": "cinder",
   "version": "0.0.1",
-  "description": "",
+  "description": "A Svelte 5 component library and design system focused on accessibility, theming, and per-component tree-shaking.",
+  "keywords": [
+    "svelte",
+    "svelte-5",
+    "components",
+    "design-system",
+    "ui",
+    "accessibility"
+  ],
+  "homepage": "https://github.com/stevekinney/cinder#readme",
+  "bugs": {
+    "url": "https://github.com/stevekinney/cinder/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/stevekinney/cinder.git",
+    "directory": "packages/components"
+  },
   "license": "MIT",
   "author": "Steve Kinney <hello@stevekinney.net>",
   "sideEffects": [


### PR DESCRIPTION
## Summary

Track 2a of the Svelte 5 design system packaging plan. Adds the npm metadata that's required for a credible publish: `description`, `keywords`, `homepage`, `bugs.url`, and `repository` (with `directory: packages/components`).

- `publishConfig`, provenance, and release-workflow changes are intentionally deferred to Track 2b.
- No code changes. No build changes. Single-file edit to `packages/components/package.json`.
- The `exports` map (1300+ lines, generated) is preserved exactly.

## Review committee

Pre-reviewed by:
- Codex (gpt-5.4, xhigh reasoning) — 1 round, APPROVED

> [!NOTE]
> The `Agent` tool was unavailable in this worktree session, so additional subagent reviewers (e.g. simplicity-engineer, dx-engineer) could not be dispatched. Codex — the mandatory adversarial reviewer — was dispatched and approved. The diff is metadata-only with no behavioral change, so the risk of skipping additional reviewers is minimal.

## Test plan

- [x] `bun run --filter=cinder typecheck` — clean
- [x] `bun run --filter=cinder lint` — clean
- [x] `npm publish --dry-run` in `packages/components/` — succeeds, tarball lists the new metadata
- [ ] `bun run validate:consumer` — fails on `main` as well (pre-existing: the validator's hardcoded `PUBLIC_COMPONENTS` list expects the old flat component layout; this is what Track 1 fixes). Not caused by this PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only adds npm package metadata in `packages/components/package.json` and does not change build output, runtime code, or the `exports` map.
> 
> **Overview**
> Adds publish-facing npm metadata to the `cinder` package by populating `description` and introducing `keywords`, `homepage`, `bugs.url`, and `repository` (including `directory: packages/components`) in `packages/components/package.json`.
> 
> No functional changes are introduced; the existing `exports` map and package entrypoints remain unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a7bf7a55e84665cd5400a94c1530ce862fd88c07. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->