### PR TITLE
feat(components): per-component browser ESM + SSR build (Track 4)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -65,6 +65,7 @@
         "oxlint": "^1.56.0",
         "oxlint-tsgolint": "^0.17.0",
         "postcss": "^8.5.15",
+        "postcss-selector-parser": "^7.1.1",
         "prettier": "^3.8.1",
         "prettier-plugin-organize-imports": "^4.3.0",
         "prettier-plugin-svelte": "^3.3.2",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1315,6 +1315,7 @@
     "oxlint": "^1.56.0",
     "oxlint-tsgolint": "^0.17.0",
     "postcss": "^8.5.15",
+    "postcss-selector-parser": "^7.1.1",
     "prettier": "^3.8.1",
     "prettier-plugin-organize-imports": "^4.3.0",
     "prettier-plugin-svelte": "^3.3.2",

--- a/packages/components/scripts/build.ts
+++ b/packages/components/scripts/build.ts
@@ -1,21 +1,67 @@
 import { $ } from 'bun';
+import { existsSync } from 'node:fs';
+import { mkdir } from 'node:fs/promises';
+import { dirname } from 'node:path';
 import { emitDts } from 'svelte2tsx';
 
+import { checkComponentCss, formatViolation } from './check-component-css.ts';
+import { discoverComponents, type ComponentDiscovery } from './lib/discover-components.ts';
 import { createServerEntrySource } from './server-entry.ts';
 import { sveltePlugin } from './svelte-plugin.ts';
 
 const repositoryRoot = process.cwd();
+const sourceRoot = `${repositoryRoot}/src`;
 const distributionDirectory = `${repositoryRoot}/dist`;
 const svelteShimsPath = Bun.resolveSync('svelte2tsx/svelte-shims-v4.d.ts', repositoryRoot);
 
 async function createServerEntry(): Promise<string> {
-  const sourcePath = `${repositoryRoot}/src/index.ts`;
+  const sourcePath = `${sourceRoot}/index.ts`;
   const serverEntryPath = `${repositoryRoot}/node_modules/.cache/server-entry.ts`;
   const source = await Bun.file(sourcePath).text();
 
   await Bun.write(serverEntryPath, createServerEntrySource(source));
 
   return serverEntryPath;
+}
+
+/**
+ * Build the absolute path to `src/components/[experimental/]<name>/index.ts`
+ * for a discovered component, matching the on-disk layout that
+ * `discoverComponents()` walks.
+ */
+function componentEntrypoint(component: ComponentDiscovery): string {
+  return component.isExperimental
+    ? `${sourceRoot}/components/experimental/${component.name}/index.ts`
+    : `${sourceRoot}/components/${component.name}/index.ts`;
+}
+
+/**
+ * Per-component CSS sidecar location under `src/`. Not every component has a
+ * sidecar — domain-suite components (`chat`, `markdown-editor`, etc.) inject
+ * styles directly, and several smaller composition components have no styles
+ * of their own. Callers should check `existsSync` before relying on this.
+ */
+function componentCssSource(component: ComponentDiscovery): string {
+  return component.isExperimental
+    ? `${sourceRoot}/components/experimental/${component.name}/${component.name}.css`
+    : `${sourceRoot}/components/${component.name}/${component.name}.css`;
+}
+
+/**
+ * Per-component CSS sidecar destination under `dist/`. Mirrors the source
+ * layout so consumers can resolve `cinder/<name>/styles` and the eventual
+ * Track 5 subpath export points at exactly one file.
+ */
+function componentCssDestination(component: ComponentDiscovery): string {
+  return component.isExperimental
+    ? `${distributionDirectory}/components/experimental/${component.name}/${component.name}.css`
+    : `${distributionDirectory}/components/${component.name}/${component.name}.css`;
+}
+
+function componentDistributionDirectory(component: ComponentDiscovery): string {
+  return component.isExperimental
+    ? `${distributionDirectory}/components/experimental/${component.name}`
+    : `${distributionDirectory}/components/${component.name}`;
 }
 
 // Fail fast if generated component artifacts have drifted from source.
@@ -39,6 +85,32 @@ if (checkResult.exitCode !== 0) {
 await $`rm -rf dist`;
 
 process.env['NODE_ENV'] = 'production';
+
+const components = await discoverComponents();
+
+// Pre-emit sidecar lint: every component CSS that exists must conform to the
+// "scoped + custom properties only" contract before any output lands in
+// `dist/`. Layer assignment and global rules belong on the import side via
+// `cinder/styles`, not in the per-component sidecar.
+const cssLintViolations = [];
+for (const component of components) {
+  const cssPath = componentCssSource(component);
+  if (!existsSync(cssPath)) continue;
+  cssLintViolations.push(...(await checkComponentCss(cssPath)));
+}
+if (cssLintViolations.length > 0) {
+  process.stderr.write('Build aborted: component CSS sidecar violations:\n');
+  for (const violation of cssLintViolations) {
+    process.stderr.write(`  ${formatViolation(violation)}\n`);
+  }
+  process.exit(1);
+}
+
+// -----------------------------------------------------------------------------
+// 1. Existing single-file server bundle. PRESERVED untouched in this PR —
+//    removal is a follow-up after Track 3 + Track 5 prove the per-component
+//    SSR path works in consumer fixtures.
+// -----------------------------------------------------------------------------
 
 const serverEntryPath = await createServerEntry();
 
@@ -64,23 +136,154 @@ if (!serverBuildResult.success) {
   process.exit(1);
 }
 
+// -----------------------------------------------------------------------------
+// 2. Per-component browser ESM build (additive). Entrypoints: every component
+//    `index.ts` plus the root barrel `src/index.ts`. Output shape is fixed by
+//    `[dir]/[name].[ext]` naming relative to `root: src/`, which gives us:
+//      dist/index.js
+//      dist/components/<name>/index.js
+//      dist/components/experimental/<name>/index.js
+// -----------------------------------------------------------------------------
+
+const perComponentEntrypoints = components.map((component) => componentEntrypoint(component));
+const browserEntrypoints = [`${sourceRoot}/index.ts`, ...perComponentEntrypoints];
+
+const browserBuildResult = await Bun.build({
+  entrypoints: browserEntrypoints,
+  outdir: distributionDirectory,
+  root: sourceRoot,
+  target: 'browser',
+  format: 'esm',
+  splitting: false,
+  external: ['svelte', 'svelte/*', '@cinder/*'],
+  naming: {
+    entry: '[dir]/[name].[ext]',
+    chunk: '[name]-[hash].[ext]',
+    asset: '[name]-[hash].[ext]',
+  },
+  sourcemap: 'external',
+  minify: false,
+  plugins: [sveltePlugin({ generate: 'client' })],
+});
+
+if (!browserBuildResult.success) {
+  const messages = [
+    'Per-component browser build failed:',
+    ...browserBuildResult.logs.map(String),
+  ].join('\n');
+  process.stderr.write(`${messages}\n`);
+  process.exit(1);
+}
+
+// -----------------------------------------------------------------------------
+// 3. Per-component SSR ESM build (additive, lives alongside the existing
+//    single-file server bundle). Outputs to dist/server/components/<name>/.
+// -----------------------------------------------------------------------------
+
+const perComponentServerBuildResult = await Bun.build({
+  entrypoints: perComponentEntrypoints,
+  outdir: `${distributionDirectory}/server`,
+  root: sourceRoot,
+  target: 'node',
+  format: 'esm',
+  splitting: false,
+  external: ['svelte', 'svelte/*', '@cinder/*'],
+  naming: {
+    entry: '[dir]/[name].[ext]',
+    chunk: '[name]-[hash].[ext]',
+    asset: '[name]-[hash].[ext]',
+  },
+  sourcemap: 'external',
+  minify: false,
+  plugins: [sveltePlugin({ generate: 'server' })],
+});
+
+if (!perComponentServerBuildResult.success) {
+  const messages = [
+    'Per-component SSR build failed:',
+    ...perComponentServerBuildResult.logs.map(String),
+  ].join('\n');
+  process.stderr.write(`${messages}\n`);
+  process.exit(1);
+}
+
+// -----------------------------------------------------------------------------
+// 4. Copy per-component CSS sidecars verbatim. We do NOT have the JS import
+//    `./<name>.css`, so the only way these reach `dist/` is an explicit copy
+//    driven by `discoverComponents()`.
+// -----------------------------------------------------------------------------
+
+const copiedSidecars: string[] = [];
+for (const component of components) {
+  const source = componentCssSource(component);
+  if (!existsSync(source)) continue;
+  const destination = componentCssDestination(component);
+  await mkdir(dirname(destination), { recursive: true });
+  const text = await Bun.file(source).text();
+  await Bun.write(destination, text);
+  copiedSidecars.push(destination);
+}
+
+// -----------------------------------------------------------------------------
+// 5. Type declarations (unchanged from prior behavior).
+// -----------------------------------------------------------------------------
+
 await emitDts({
   declarationDir: distributionDirectory,
   svelteShimsPath,
-  libRoot: `${repositoryRoot}/src`,
+  libRoot: sourceRoot,
   tsconfig: `${repositoryRoot}/tsconfig.build.json`,
 });
 
-// Smoke-check declaration output for a migrated component (button is in the
-// per-directory layout) and the root barrel.
-const expectedComponentDeclarations = `${distributionDirectory}/components/button/button.svelte.d.ts`;
-const expectedBarrelDeclarations = `${distributionDirectory}/index.d.ts`;
+// -----------------------------------------------------------------------------
+// 6. Hard acceptance checks. Verify the output shape matches the contract
+//    rather than trust the build's success flag. Fails loudly so a future
+//    `Bun.build()` change that quietly drops outputs surfaces immediately.
+// -----------------------------------------------------------------------------
 
-for (const declarationPath of [expectedComponentDeclarations, expectedBarrelDeclarations]) {
-  if (!(await Bun.file(declarationPath).exists())) {
-    process.stderr.write(`Missing declaration output: ${declarationPath}\n`);
+const expectedPaths: string[] = [
+  `${distributionDirectory}/index.js`,
+  `${distributionDirectory}/index.d.ts`,
+  `${distributionDirectory}/server/index.js`,
+  `${distributionDirectory}/components/button/button.svelte.d.ts`,
+];
+
+for (const component of components) {
+  const directory = componentDistributionDirectory(component);
+  expectedPaths.push(`${directory}/index.js`);
+  expectedPaths.push(
+    component.isExperimental
+      ? `${distributionDirectory}/server/components/experimental/${component.name}/index.js`
+      : `${distributionDirectory}/server/components/${component.name}/index.js`,
+  );
+  if (existsSync(componentCssSource(component))) {
+    expectedPaths.push(componentCssDestination(component));
+  }
+}
+
+const missingPaths = expectedPaths.filter((path) => !existsSync(path));
+if (missingPaths.length > 0) {
+  process.stderr.write('Build aborted: expected output paths missing:\n');
+  for (const path of missingPaths) process.stderr.write(`  - ${path}\n`);
+  process.exit(1);
+}
+
+// Component JS must NOT import the CSS sidecar. Contract: à la carte CSS is
+// opt-in by the consumer via `cinder/<name>/styles`. Spot-check a few well-
+// known components rather than scanning every output for performance.
+const noCssImportSpotChecks = ['button', 'alert', 'card'];
+for (const name of noCssImportSpotChecks) {
+  const distributionFile = `${distributionDirectory}/components/${name}/index.js`;
+  if (!existsSync(distributionFile)) continue;
+  const text = await Bun.file(distributionFile).text();
+  if (/\bimport\s+['"][^'"]*\.css['"]/i.test(text)) {
+    process.stderr.write(
+      `Build aborted: ${distributionFile} contains a CSS import. Component JS must not pull its sidecar.\n`,
+    );
     process.exit(1);
   }
 }
 
-process.stdout.write('Build complete.\n');
+process.stdout.write(
+  `Build complete. ${components.length} components, ${copiedSidecars.length} CSS sidecars copied.\n`,
+);

--- a/packages/components/scripts/build.ts
+++ b/packages/components/scripts/build.ts
@@ -148,6 +148,15 @@ if (!serverBuildResult.success) {
 const perComponentEntrypoints = components.map((component) => componentEntrypoint(component));
 const browserEntrypoints = [`${sourceRoot}/index.ts`, ...perComponentEntrypoints];
 
+// `splitting: false` is a deliberate trade-off mandated by the Track 4 plan:
+// it gives each entrypoint a predictable, single-file output so the eventual
+// `default` condition in `package.json#exports` points at exactly one JS file
+// per subpath. The cost is that shared internal modules (utilities, runes,
+// helpers) get duplicated across component bundles. Module-identity-sensitive
+// patterns (cross-component Svelte context keys, shared stores, exported
+// singletons) MUST live in the root barrel and be imported from there by
+// consumers — never re-imported from two different `cinder/<name>` subpaths.
+// Track 5's à la carte fixture will assert this contract once it lands.
 const browserBuildResult = await Bun.build({
   entrypoints: browserEntrypoints,
   outdir: distributionDirectory,
@@ -251,6 +260,11 @@ const expectedPaths: string[] = [
 for (const component of components) {
   const directory = componentDistributionDirectory(component);
   expectedPaths.push(`${directory}/index.js`);
+  // The per-component declaration entrypoint is what `package.json#exports`
+  // resolves for the `types` condition once Track 3 lands. Check it lands
+  // alongside the JS so consumers cannot end up with untyped per-component
+  // subpaths.
+  expectedPaths.push(`${directory}/index.d.ts`);
   expectedPaths.push(
     component.isExperimental
       ? `${distributionDirectory}/server/components/experimental/${component.name}/index.js`
@@ -269,16 +283,20 @@ if (missingPaths.length > 0) {
 }
 
 // Component JS must NOT import the CSS sidecar. Contract: à la carte CSS is
-// opt-in by the consumer via `cinder/<name>/styles`. Spot-check a few well-
-// known components rather than scanning every output for performance.
-const noCssImportSpotChecks = ['button', 'alert', 'card'];
-for (const name of noCssImportSpotChecks) {
-  const distributionFile = `${distributionDirectory}/components/${name}/index.js`;
+// opt-in by the consumer via `cinder/<name>/styles`. Scan EVERY per-component
+// bundle (including experimental) for CSS imports in all the forms a bundler
+// could emit — bare side-effect imports, named imports, namespace imports,
+// and dynamic `import('./foo.css')`. Spot-checking a handful of components
+// leaves a backdoor where any unsweep'd bundle could ship a CSS import.
+const cssImportPattern =
+  /(?:\bimport\s*(?:[\w*${},\s]+\s+from\s*)?['"][^'"]*\.css['"]|\bimport\s*\(\s*['"][^'"]*\.css['"])/i;
+for (const component of components) {
+  const distributionFile = `${componentDistributionDirectory(component)}/index.js`;
   if (!existsSync(distributionFile)) continue;
   const text = await Bun.file(distributionFile).text();
-  if (/\bimport\s+['"][^'"]*\.css['"]/i.test(text)) {
+  if (cssImportPattern.test(text)) {
     process.stderr.write(
-      `Build aborted: ${distributionFile} contains a CSS import. Component JS must not pull its sidecar.\n`,
+      `Build aborted: ${distributionFile} contains a CSS import. Component JS must not pull its sidecar — à la carte CSS is opt-in via \`cinder/<name>/styles\`.\n`,
     );
     process.exit(1);
   }

--- a/packages/components/scripts/check-component-css.test.ts
+++ b/packages/components/scripts/check-component-css.test.ts
@@ -25,7 +25,15 @@ describe('checkComponentCssSource', () => {
     const source = `
       .cinder-button > * { margin-inline-end: 0; }
       .cinder-banner :where(html) { color: inherit; }
-      .cinder-card body { /* still scoped under .cinder-card */ }
+    `;
+    expect(checkComponentCssSource(source, fakePath)).toEqual([]);
+  });
+
+  it('allows class lists nested inside functional pseudos', () => {
+    const source = `
+      :is(.cinder-button, .cinder-button-group) { color: red; }
+      :where(.cinder-card) { padding: 1rem; }
+      :not(.cinder-button-icon).cinder-button { font-weight: 600; }
     `;
     expect(checkComponentCssSource(source, fakePath)).toEqual([]);
   });
@@ -35,7 +43,20 @@ describe('checkComponentCssSource', () => {
     const violations = checkComponentCssSource(source, fakePath);
     expect(violations).toHaveLength(1);
     expect(violations[0]?.selector).toBe(':root');
-    expect(violations[0]?.message).toContain(':root');
+  });
+
+  it('rejects :where(:root) — globals hidden inside a functional pseudo', () => {
+    const source = `:where(:root) { --cinder-color-fg: black; }`;
+    const violations = checkComponentCssSource(source, fakePath);
+    expect(violations).toHaveLength(1);
+    expect(violations[0]?.selector).toBe(':where(:root)');
+  });
+
+  it('rejects :is(html, body)', () => {
+    const source = `:is(html, body) { font-family: sans-serif; }`;
+    const violations = checkComponentCssSource(source, fakePath);
+    expect(violations).toHaveLength(1);
+    expect(violations[0]?.selector).toBe(':is(html, body)');
   });
 
   it('rejects html and body selectors', () => {
@@ -45,11 +66,32 @@ describe('checkComponentCssSource', () => {
     expect(violations.map((v) => v.selector)).toEqual(['html', 'body']);
   });
 
+  it('rejects raw tag selectors with no class anchor', () => {
+    const source = `button { all: unset; }`;
+    const violations = checkComponentCssSource(source, fakePath);
+    expect(violations).toHaveLength(1);
+    expect(violations[0]?.selector).toBe('button');
+  });
+
   it('rejects bare universal selectors', () => {
     const source = `* { box-sizing: border-box; }`;
     const violations = checkComponentCssSource(source, fakePath);
     expect(violations).toHaveLength(1);
     expect(violations[0]?.selector).toBe('*');
+  });
+
+  it('rejects universal + pseudo at the top level', () => {
+    const source = `*:focus { outline: 2px solid blue; }`;
+    const violations = checkComponentCssSource(source, fakePath);
+    expect(violations).toHaveLength(1);
+    expect(violations[0]?.selector).toBe('*:focus');
+  });
+
+  it('rejects bare attribute selectors at the top level', () => {
+    const source = `[data-theme='dark'] { background: black; }`;
+    const violations = checkComponentCssSource(source, fakePath);
+    expect(violations).toHaveLength(1);
+    expect(violations[0]?.selector).toContain('data-theme');
   });
 
   it('rejects @layer at-rules', () => {
@@ -59,11 +101,49 @@ describe('checkComponentCssSource', () => {
     expect(violations[0]?.message).toContain('@layer');
   });
 
+  it('rejects @import at-rules', () => {
+    const source = `@import './tokens.css'; .cinder-button { color: red; }`;
+    const violations = checkComponentCssSource(source, fakePath);
+    expect(violations).toHaveLength(1);
+    expect(violations[0]?.message).toContain('@import');
+  });
+
   it('handles selector lists', () => {
     const source = `.cinder-button, :root { color: red; }`;
     const violations = checkComponentCssSource(source, fakePath);
     expect(violations).toHaveLength(1);
     expect(violations[0]?.selector).toBe(':root');
+  });
+
+  it('allows data-cinder-* attribute anchors (state-driven scoping)', () => {
+    const source = `
+      [data-cinder-state='current'] .cinder-steps__marker {
+        background: var(--cinder-steps-current-bg);
+      }
+      [data-cinder-variant='primary'] {
+        color: var(--cinder-fg);
+      }
+    `;
+    expect(checkComponentCssSource(source, fakePath)).toEqual([]);
+  });
+
+  it('does NOT allow non-cinder data-* attribute anchors', () => {
+    const source = `[data-state='current'] { color: red; }`;
+    const violations = checkComponentCssSource(source, fakePath);
+    expect(violations).toHaveLength(1);
+    expect(violations[0]?.selector).toContain('data-state');
+  });
+
+  it('allows @keyframes stops like from/to/0%/100%', () => {
+    const source = `
+      @keyframes cinder-spin {
+        from { transform: rotate(0); }
+        50% { transform: rotate(180deg); }
+        to { transform: rotate(360deg); }
+      }
+      .cinder-spinner { animation: cinder-spin 1s linear infinite; }
+    `;
+    expect(checkComponentCssSource(source, fakePath)).toEqual([]);
   });
 
   it('flags root selectors inside @media just like at the top level', () => {

--- a/packages/components/scripts/check-component-css.test.ts
+++ b/packages/components/scripts/check-component-css.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'bun:test';
+
+import { checkComponentCssSource } from './check-component-css.ts';
+
+const fakePath = '/virtual/test/component.css';
+
+describe('checkComponentCssSource', () => {
+  it('passes a well-scoped component sidecar', () => {
+    const source = `
+      .cinder-button {
+        background: var(--cinder-button-bg);
+        color: var(--cinder-button-fg);
+      }
+      .cinder-button:hover {
+        background: var(--cinder-button-hover-bg);
+      }
+      .cinder-button[data-variant='primary'] {
+        --cinder-button-bg: blue;
+      }
+    `;
+    expect(checkComponentCssSource(source, fakePath)).toEqual([]);
+  });
+
+  it('allows scoped descendants of forbidden tags', () => {
+    const source = `
+      .cinder-button > * { margin-inline-end: 0; }
+      .cinder-banner :where(html) { color: inherit; }
+      .cinder-card body { /* still scoped under .cinder-card */ }
+    `;
+    expect(checkComponentCssSource(source, fakePath)).toEqual([]);
+  });
+
+  it('rejects :root at the top level', () => {
+    const source = `:root { --cinder-color-fg: black; }`;
+    const violations = checkComponentCssSource(source, fakePath);
+    expect(violations).toHaveLength(1);
+    expect(violations[0]?.selector).toBe(':root');
+    expect(violations[0]?.message).toContain(':root');
+  });
+
+  it('rejects html and body selectors', () => {
+    const source = `html { font-size: 16px; } body { margin: 0; }`;
+    const violations = checkComponentCssSource(source, fakePath);
+    expect(violations).toHaveLength(2);
+    expect(violations.map((v) => v.selector)).toEqual(['html', 'body']);
+  });
+
+  it('rejects bare universal selectors', () => {
+    const source = `* { box-sizing: border-box; }`;
+    const violations = checkComponentCssSource(source, fakePath);
+    expect(violations).toHaveLength(1);
+    expect(violations[0]?.selector).toBe('*');
+  });
+
+  it('rejects @layer at-rules', () => {
+    const source = `@layer components { .cinder-button { color: red; } }`;
+    const violations = checkComponentCssSource(source, fakePath);
+    expect(violations.length).toBeGreaterThanOrEqual(1);
+    expect(violations[0]?.message).toContain('@layer');
+  });
+
+  it('handles selector lists', () => {
+    const source = `.cinder-button, :root { color: red; }`;
+    const violations = checkComponentCssSource(source, fakePath);
+    expect(violations).toHaveLength(1);
+    expect(violations[0]?.selector).toBe(':root');
+  });
+
+  it('flags root selectors inside @media just like at the top level', () => {
+    const source = `
+      @media (min-width: 640px) {
+        :root { --cinder-foo: 1; }
+      }
+    `;
+    const violations = checkComponentCssSource(source, fakePath);
+    expect(violations).toHaveLength(1);
+    expect(violations[0]?.selector).toBe(':root');
+  });
+});

--- a/packages/components/scripts/check-component-css.ts
+++ b/packages/components/scripts/check-component-css.ts
@@ -25,9 +25,6 @@
 import postcss from 'postcss';
 import selectorParser from 'postcss-selector-parser';
 
-const FORBIDDEN_TAGS = new Set(['html', 'body']);
-const FORBIDDEN_PSEUDOS = new Set([':root']);
-
 export type CssViolation = {
   file: string;
   line: number;
@@ -36,39 +33,79 @@ export type CssViolation = {
   message: string;
 };
 
+const FUNCTIONAL_PSEUDOS = new Set([':is', ':where', ':not', ':has', ':matches']);
+
 /**
- * Inspect a single CSS selector and decide whether its FIRST compound targets
- * a forbidden global. Compounds inside `:is()`, `:where()`, `:not()`, etc. on
- * a non-global anchor are tolerated — only a top-level selector whose initial
- * compound is itself global is rejected.
+ * Decide whether a compound selector contains a class anchor — directly, or
+ * recursively inside a functional pseudo like `:is(.button)` / `:where(.button)`.
+ * Component CSS sidecars must always start with a class anchor so the rules
+ * stay scoped to the component. Everything else (`:root`, `html`, `body`,
+ * universal `*`, bare attribute selectors, raw tags) is global at the top
+ * level and belongs in the foundation / tokens layer.
+ */
+function compoundHasClassAnchor(nodes: readonly selectorParser.Node[]): boolean {
+  for (const node of nodes) {
+    if (node.type === 'combinator') break;
+    if (node.type === 'class') return true;
+    // Attribute selectors anchored to the `data-cinder-*` namespace are the
+    // documented convention for state-driven scoping in cinder (see
+    // `steps.css`: `[data-cinder-state='current'] .cinder-steps__marker`).
+    // The `data-cinder-` prefix is component-scoped by namespace, equivalent
+    // in intent to a `.cinder-*` class anchor.
+    if (node.type === 'attribute' && node.attribute.toLowerCase().startsWith('data-cinder-')) {
+      return true;
+    }
+    // `:is(.button)` and `:where(.button-icon, .button-label)` are valid
+    // scoped anchors — recurse into the functional pseudo's argument selectors.
+    if (node.type === 'pseudo' && FUNCTIONAL_PSEUDOS.has(node.value.toLowerCase())) {
+      for (const inner of node.nodes ?? []) {
+        if (compoundHasClassAnchor(inner.nodes)) return true;
+      }
+    }
+  }
+  return false;
+}
+
+/**
+ * Render the first compound of a parsed selector back to a string for use in
+ * a violation message. We stop at the first combinator so the message points
+ * at the offending anchor rather than the whole selector chain.
+ */
+function describeFirstCompound(nodes: readonly selectorParser.Node[]): string {
+  const compoundParts: string[] = [];
+  for (const node of nodes) {
+    if (node.type === 'combinator') break;
+    compoundParts.push(String(node));
+  }
+  const joined = compoundParts.join('').trim();
+  return joined === '' ? '(empty)' : joined;
+}
+
+/**
+ * Inspect a single CSS selector and decide whether its FIRST compound is
+ * suitably component-scoped. Returns the offending compound as a string when
+ * the selector targets a global; returns `null` when the compound is anchored
+ * to a class (or to a class nested inside `:is()` / `:where()` / `:not()` /
+ * `:has()`).
+ *
+ * The "first compound must have a class anchor" rule is strict by design:
+ * - Rejects `:root`, `html`, `body`, raw `button`, `[data-theme]`, `*:focus`,
+ *   `:where(:root)`, `:is(html, body)`, etc.
+ * - Accepts `.cinder-button`, `.cinder-button:hover`, `.button[data-state]`,
+ *   `:where(.button, .button-icon)`, etc.
+ * - Scoped descendants like `.button *`, `.button > [data-slot]` start with
+ *   `.button` so they pass.
  */
 function firstCompoundIsGlobal(selectorString: string): string | null {
-  let offendingMatch: string | null = null;
+  let offendingCompound: string | null = null;
   selectorParser((root) => {
     root.each((selector) => {
-      // Walk the first compound: nodes until the first combinator.
-      for (const node of selector.nodes) {
-        if (node.type === 'combinator') break;
-        if (node.type === 'tag' && FORBIDDEN_TAGS.has(node.value.toLowerCase())) {
-          offendingMatch = node.value;
-          return;
-        }
-        if (node.type === 'pseudo' && FORBIDDEN_PSEUDOS.has(node.value.toLowerCase())) {
-          offendingMatch = node.value;
-          return;
-        }
-        if (node.type === 'universal') {
-          // Only flag bare `*` as the entire first compound — `.button *` is a
-          // descendant universal, not a top-level target.
-          if (selector.nodes.length === 1 || selector.nodes[1]?.type === 'combinator') {
-            offendingMatch = '*';
-            return;
-          }
-        }
+      if (!compoundHasClassAnchor(selector.nodes)) {
+        offendingCompound = describeFirstCompound(selector.nodes);
       }
     });
   }).processSync(selectorString);
-  return offendingMatch;
+  return offendingCompound;
 }
 
 export async function checkComponentCss(file: string): Promise<CssViolation[]> {
@@ -92,6 +129,19 @@ export function checkComponentCssSource(source: string, file: string): CssViolat
     return violations;
   }
 
+  // Sidecars are copied verbatim into `dist/components/<name>/`. An `@import`
+  // would try to resolve from that directory, where its target was never
+  // copied. Reject upfront rather than ship a broken sidecar.
+  root.walkAtRules('import', (atRule) => {
+    violations.push({
+      file,
+      line: atRule.source?.start?.line ?? 1,
+      column: atRule.source?.start?.column ?? 1,
+      message:
+        '`@import` is not allowed inside a component CSS sidecar. The sidecar is copied verbatim into `dist/components/<name>/` and `@import` paths would not resolve. Inline the rules instead.',
+    });
+  });
+
   root.walkAtRules('layer', (atRule) => {
     violations.push({
       file,
@@ -107,6 +157,20 @@ export function checkComponentCssSource(source: string, file: string): CssViolat
     // parent compound — they cannot define globals at the effective top level.
     if (rule.parent?.type === 'rule') return;
 
+    // `@keyframes` selectors are stop markers (`from`, `to`, `50%`), not
+    // descendant selectors that target the document tree. The keyframes rule
+    // itself is scoped via its `animation-name` consumer.
+    for (
+      let ancestor: postcss.Container | postcss.Document | undefined = rule.parent;
+      ancestor && ancestor.type !== 'root';
+      ancestor = ancestor.parent
+    ) {
+      if (ancestor.type === 'atrule') {
+        const atRule = ancestor as postcss.AtRule;
+        if (/^(-\w+-)?keyframes$/i.test(atRule.name)) return;
+      }
+    }
+
     // Rules nested under at-rules other than `@layer` (e.g. `@media`,
     // `@supports`, `@container`) are still subject to their own top-level
     // selector rules.
@@ -118,7 +182,7 @@ export function checkComponentCssSource(source: string, file: string): CssViolat
           line: rule.source?.start?.line ?? 1,
           column: rule.source?.start?.column ?? 1,
           selector: rawSelector,
-          message: `Selector \`${rawSelector}\` targets the global \`${offending}\` at the top level. Component CSS sidecars must scope rules to component classes; tokens, resets, and globals belong in the foundation layer.`,
+          message: `Selector \`${rawSelector}\` is not anchored to a class — its first compound is \`${offending}\`. Component CSS sidecars must scope rules to component classes (or class lists nested in \`:is()\` / \`:where()\`); tokens, resets, and globals belong in the foundation layer.`,
         });
       }
     }

--- a/packages/components/scripts/check-component-css.ts
+++ b/packages/components/scripts/check-component-css.ts
@@ -1,0 +1,135 @@
+/**
+ * Sidecar CSS linter for per-component bundles.
+ *
+ * Component CSS files (`src/components/<name>/<name>.css`) are shipped verbatim
+ * to `dist/components/<name>/<name>.css` as an opt-in sidecar that consumers
+ * can pull in via `cinder/<name>/styles`. The contract is:
+ *
+ *   1. Component CSS may only declare component-scoped rules and custom
+ *      properties of the `--cinder-*` family.
+ *   2. No `:root`, `html`, `body`, or bare universal `*` selectors at the
+ *      effective top level — those belong in token / foundation layers.
+ *   3. No `@layer` declarations inside the sidecar — layer assignment happens
+ *      at the import side, via the `cinder/styles` aggregator wrapping its
+ *      imports with `@import '...' layer(cinder.components)`.
+ *
+ * Scoped descendants are allowed (e.g. `.button *`, `.alert :where(html)`).
+ * The check distinguishes these from forbidden globals by walking the parsed
+ * selector AST and inspecting the FIRST compound — the rule's "effective top
+ * level" — rather than text-matching the raw selector string.
+ *
+ * Used as a pre-emit gate in `scripts/build.ts`: any violation aborts the
+ * build before sidecars are copied into `dist/`.
+ */
+
+import postcss from 'postcss';
+import selectorParser from 'postcss-selector-parser';
+
+const FORBIDDEN_TAGS = new Set(['html', 'body']);
+const FORBIDDEN_PSEUDOS = new Set([':root']);
+
+export type CssViolation = {
+  file: string;
+  line: number;
+  column: number;
+  selector?: string;
+  message: string;
+};
+
+/**
+ * Inspect a single CSS selector and decide whether its FIRST compound targets
+ * a forbidden global. Compounds inside `:is()`, `:where()`, `:not()`, etc. on
+ * a non-global anchor are tolerated — only a top-level selector whose initial
+ * compound is itself global is rejected.
+ */
+function firstCompoundIsGlobal(selectorString: string): string | null {
+  let offendingMatch: string | null = null;
+  selectorParser((root) => {
+    root.each((selector) => {
+      // Walk the first compound: nodes until the first combinator.
+      for (const node of selector.nodes) {
+        if (node.type === 'combinator') break;
+        if (node.type === 'tag' && FORBIDDEN_TAGS.has(node.value.toLowerCase())) {
+          offendingMatch = node.value;
+          return;
+        }
+        if (node.type === 'pseudo' && FORBIDDEN_PSEUDOS.has(node.value.toLowerCase())) {
+          offendingMatch = node.value;
+          return;
+        }
+        if (node.type === 'universal') {
+          // Only flag bare `*` as the entire first compound — `.button *` is a
+          // descendant universal, not a top-level target.
+          if (selector.nodes.length === 1 || selector.nodes[1]?.type === 'combinator') {
+            offendingMatch = '*';
+            return;
+          }
+        }
+      }
+    });
+  }).processSync(selectorString);
+  return offendingMatch;
+}
+
+export async function checkComponentCss(file: string): Promise<CssViolation[]> {
+  const source = await Bun.file(file).text();
+  return checkComponentCssSource(source, file);
+}
+
+export function checkComponentCssSource(source: string, file: string): CssViolation[] {
+  const violations: CssViolation[] = [];
+
+  let root: postcss.Root;
+  try {
+    root = postcss.parse(source, { from: file });
+  } catch (error) {
+    violations.push({
+      file,
+      line: 1,
+      column: 1,
+      message: `Could not parse CSS: ${(error as Error).message}`,
+    });
+    return violations;
+  }
+
+  root.walkAtRules('layer', (atRule) => {
+    violations.push({
+      file,
+      line: atRule.source?.start?.line ?? 1,
+      column: atRule.source?.start?.column ?? 1,
+      message:
+        '`@layer` is not allowed inside a component CSS sidecar. Layer assignment happens at the import side via `cinder/styles`.',
+    });
+  });
+
+  root.walkRules((rule) => {
+    // Rules nested under another rule (CSS nesting) are inherently scoped to a
+    // parent compound — they cannot define globals at the effective top level.
+    if (rule.parent?.type === 'rule') return;
+
+    // Rules nested under at-rules other than `@layer` (e.g. `@media`,
+    // `@supports`, `@container`) are still subject to their own top-level
+    // selector rules.
+    for (const rawSelector of rule.selectors) {
+      const offending = firstCompoundIsGlobal(rawSelector);
+      if (offending !== null) {
+        violations.push({
+          file,
+          line: rule.source?.start?.line ?? 1,
+          column: rule.source?.start?.column ?? 1,
+          selector: rawSelector,
+          message: `Selector \`${rawSelector}\` targets the global \`${offending}\` at the top level. Component CSS sidecars must scope rules to component classes; tokens, resets, and globals belong in the foundation layer.`,
+        });
+      }
+    }
+  });
+
+  return violations;
+}
+
+export function formatViolation(violation: CssViolation): string {
+  const location = `${violation.file}:${violation.line}:${violation.column}`;
+  return violation.selector
+    ? `${location}  ${violation.message}`
+    : `${location}  ${violation.message}`;
+}


### PR DESCRIPTION
## Summary

Track 4 of the cinder packaging plan. Additive: emits per-component browser ESM JavaScript, per-component SSR ESM JavaScript, and per-component CSS sidecars under `dist/`. The existing single-file `dist/server/index.js` server bundle stays untouched — its removal is a follow-up after Track 3 + Track 5 consumer fixtures prove the new shape works.

New output shape (driven by `discoverComponents()` from Track 1 + Bun's `[dir]/[name]` naming relative to `root: src/`):

```
dist/index.js                                  (browser barrel)
dist/components/<name>/index.js                (browser per-component)
dist/components/<name>/<name>.css              (verbatim CSS sidecar)
dist/components/experimental/<name>/index.js   (experimental browser)
dist/server/index.js                           (preserved server bundle)
dist/server/components/<name>/index.js         (per-component SSR)
```

## What changed

- Two additive `Bun.build()` passes in `scripts/build.ts`:
  - Browser: `target=browser`, `format=esm`, `splitting=false`, `external=['svelte','svelte/*','@cinder/*']`, plugin `generate=client`. Entrypoints = root barrel + every component `index.ts`.
  - SSR: same entrypoints minus the barrel (so the existing single-file server bundle stays intact), `target=node`, plugin `generate=server`, outputs into `dist/server/components/<name>/`.
- Explicit verbatim copy of `src/components/<name>/<name>.css` to `dist/components/<name>/<name>.css`. The JS does not import the CSS — à la carte styles are opt-in by the consumer (Track 5 wires the subpath export).
- New `scripts/check-component-css.ts`: postcss + postcss-selector-parser AST walker. Enforces the contract:
  - First compound of every top-level rule must be anchored to a class (or `data-cinder-*` attribute, the documented state-driven convention).
  - `:where(:root)`, `:is(html, body)`, raw tag selectors, `*:focus`, bare attribute selectors all rejected.
  - `@layer` and `@import` at-rules rejected.
  - `@keyframes` stops (`from`, `to`, `0%`, `100%`) explicitly tolerated.
- Hard acceptance checks before reporting success: every expected `dist/components/<name>/index.js`, `index.d.ts`, server SSR file, and CSS sidecar (when source exists) is verified with `existsSync`. The CSS-import contract is enforced across every per-component bundle (including experimental), not just a spot check.

## Verification

- `bun run --filter=cinder build` — passes; reports `101 components, 86 CSS sidecars copied`.
- `dist/components/button/index.js` exists, externalizes `svelte` (`import * as $ from "svelte/internal/client"`), contains no CSS import.
- `dist/components/button/button.css` exists.
- `dist/server/index.js` still exists (untouched).
- `dist/server/components/button/index.js` exists.
- `bun run --filter=cinder typecheck` — 0 errors.
- `bun run --filter=cinder lint` — 0 warnings, 0 errors.
- `bun test scripts/` (cinder) — 27 pass (includes 18 new linter tests).
- `bun test` (cinder) — 2013 pass.
- `du -sh dist/` — 24M total (7M JS, 14M external sourcemaps, ~3M dts + css). JS-only footprint stays in the ~10MB target for ~100 components; sourcemap inflation is expected for `sourcemap: 'external'`.

### Pre-existing consumer-validation parity with main

`bun run validate:consumer` fails on `node_modules/@cinder/editor` and `node_modules/@cinder/markdown` `tsc` errors (missing DOM lib, `toSorted`, named exports from `@milkdown/ctx` / `@milkdown/kit`). These reproduce on `main` and are unrelated to Track 4 — the task brief explicitly calls this out as parity-with-main; fixing those modules is out of scope here.

## Review committee

Pre-reviewed by:
- Codex (gpt-5.4, xhigh r1 / high r2) — 2 rounds
  - 4 must-fix items and 1 suggestion addressed
  - APPROVED in round 2

> [!NOTE]
> The multi-subagent committee was unavailable in this subagent context, so Codex acted as the sole adversarial reviewer. See `tmp/committee-state.md` on the branch for full feedback history.

## Test plan

- [ ] CI build passes on the PR branch.
- [ ] Spot-check `dist/components/<name>/index.js` for several components — confirm no CSS import, `svelte` externalized.
- [ ] Confirm `dist/server/index.js` is byte-for-byte equivalent to `main` (no regression in the preserved server bundle).
- [ ] Confirm new `dist/server/components/<name>/index.js` outputs render server-side without throwing (Track 3 will wire the `node` condition; smoke until then).
- [ ] Confirm `bun run --filter=cinder validate:consumer` failure modes match `main` (`@cinder/editor`/`@cinder/markdown` tsc errors only).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes the `cinder` package build pipeline and output layout, adding new per-component JS/SSR artifacts and hard-failing checks that can break releases if outputs or CSS sidecars don’t meet the new contract.
> 
> **Overview**
> Adds **Track 4 packaging outputs** for `cinder`: the build now emits per-component browser ESM bundles under `dist/components/<name>/index.js` and per-component SSR ESM bundles under `dist/server/components/<name>/index.js`, while explicitly preserving the existing single-file `dist/server/index.js` bundle.
> 
> Introduces an opt-in **per-component CSS sidecar** flow by copying `src/components/<name>/<name>.css` verbatim into `dist/` (without JS importing it), plus a new PostCSS-based linter (`check-component-css.ts` + tests) that enforces sidecar scoping rules and blocks `@import`/`@layer` and top-level global selectors.
> 
> Strengthens build correctness with acceptance checks that verify expected `dist/` outputs exist and that per-component bundles contain **no `.css` imports**, and adds `postcss-selector-parser` as a dev dependency to support the new CSS linter.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8779305452dc0e83d20b3d0dd6fac8a4b13a0e63. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->