### PR TITLE
feat(components): per-component CSS subpath exports (Track 5)

### DIFF
--- a/docs/packaging.md
+++ b/docs/packaging.md
@@ -1,0 +1,100 @@
+# Packaging contract
+
+This document describes what `cinder` ships in its npm tarball, how the `exports`
+map is resolved by the tooling consumers use, and the two supported ways to pull
+in CSS.
+
+## Conditional exports — resolution table
+
+Every component subpath is published with the same conditional shape:
+
+```jsonc
+"./button": {
+  "types": "./dist/components/button/index.d.ts",
+  "svelte": "./src/components/button/index.ts",
+  "node": "./dist/server/components/button/index.js",
+  "default": "./dist/components/button/index.js"
+}
+```
+
+Which file a given consumer actually loads depends on the resolver and its
+condition set. Resolvers stop at the first condition they match. The table below
+captures what wins where.
+
+| Consumer / resolver                        | Condition matched | File loaded                                |
+| ------------------------------------------ | ----------------- | ------------------------------------------ |
+| TypeScript (`moduleResolution: nodenext`)  | `types`           | `./dist/components/button/index.d.ts`      |
+| TypeScript (`moduleResolution: bundler`)   | `types`           | `./dist/components/button/index.d.ts`      |
+| Vite / SvelteKit dev + build               | `svelte`          | `./src/components/button/index.ts`         |
+| `svelte-package` / Svelte-aware tooling    | `svelte`          | `./src/components/button/index.ts`         |
+| Node SSR without Svelte tooling            | `node`            | `./dist/server/components/button/index.js` |
+| Bun consumer                               | `default`         | `./dist/components/button/index.js`        |
+| Browser bundler (esbuild, Rollup, Webpack) | `default`         | `./dist/components/button/index.js`        |
+
+The `svelte` condition is the public contract for Svelte-aware tooling. Source
+paths it names are stable. Any other path under `src/` is implementation detail
+and may move at any time. `dist/` is the contract for all non-Svelte tooling.
+
+## Styles — two consumption modes
+
+`cinder` exposes CSS through dedicated subpaths. There are two supported ways
+to pull styles in.
+
+### Mode 1 — whole-system aggregator
+
+```ts
+// app.css or your global stylesheet entry
+import 'cinder/styles';
+```
+
+`cinder/styles` is the full cascade. It declares the `@layer` order and pulls in
+tokens, foundation (reset), components, and utilities — each wrapped in its own
+layer. Use this when you want the design system "as shipped" and do not need to
+tree-shake CSS by component.
+
+### Mode 2 — à la carte
+
+```ts
+// Required: tokens and foundation must come first.
+import 'cinder/styles/tokens';
+import 'cinder/styles/foundation';
+
+// Then import only the components you use.
+import 'cinder/button/styles';
+import 'cinder/badge/styles';
+```
+
+Per-component CSS exports (`cinder/<name>/styles`) ship **layer-unwrapped CSS**.
+They contain only component-scoped selectors and `--cinder-*` custom properties.
+They do **not** declare `@layer`, tokens, or resets — because those must be
+imported once at the top of the cascade, not duplicated per component.
+
+This mode lets the bundler tree-shake unused component CSS, but the contract is
+strict:
+
+- `cinder/styles/tokens` and `cinder/styles/foundation` are **required** when
+  using per-component CSS. Without them, components reference `--cinder-*`
+  variables that have no definitions and inherit no resets.
+- Component JS modules (`cinder/button`, `cinder/badge`, etc.) do not pull CSS
+  as a side effect. Importing the JS gives you the component; importing
+  `cinder/<name>/styles` gives you its CSS. They are independent.
+
+## The `files` whitelist contract
+
+The npm tarball ships both `dist/` and a curated subset of `src/`. The full list
+lives in `packages/components/package.json` under `files`. The contract:
+
+- **`dist/`** is the contract for all non-Svelte tooling (TypeScript types, Node
+  SSR, Bun, browser bundlers via the `default` condition). Anything published
+  here is public API.
+- **`src/`** paths named by a `svelte` condition in the `exports` map are public
+  API for Svelte-aware tooling. They are stable: a rename in `src/` that breaks
+  one of these references is a breaking change.
+- **Any other `src/` path** that happens to be included by the glob patterns in
+  `files` is implementation detail. We ship it because the Svelte source files
+  reference relative neighbors (CSS imports, internal modules, etc.) that the
+  consumer's bundler will follow. We do not guarantee its location or shape.
+
+If you find yourself reaching for a `src/` path that is not named in the
+`exports` map, file an issue — that path is not supported and may move without
+warning.

--- a/docs/packaging.md
+++ b/docs/packaging.md
@@ -6,14 +6,17 @@ in CSS.
 
 ## Conditional exports — resolution table
 
-Every component subpath is published with the same conditional shape:
+Every component subpath is published with the same conditional shape. The
+component JS lives behind two conditions; the CSS sidecar lives behind its own
+`/styles` subpath:
 
 ```jsonc
 "./button": {
-  "types": "./dist/components/button/index.d.ts",
   "svelte": "./src/components/button/index.ts",
-  "node": "./dist/server/components/button/index.js",
-  "default": "./dist/components/button/index.js"
+  "types": "./dist/components/button/index.d.ts"
+},
+"./button/styles": {
+  "default": "./dist/components/button/button.css"
 }
 ```
 
@@ -21,19 +24,24 @@ Which file a given consumer actually loads depends on the resolver and its
 condition set. Resolvers stop at the first condition they match. The table below
 captures what wins where.
 
-| Consumer / resolver                        | Condition matched | File loaded                                |
-| ------------------------------------------ | ----------------- | ------------------------------------------ |
-| TypeScript (`moduleResolution: nodenext`)  | `types`           | `./dist/components/button/index.d.ts`      |
-| TypeScript (`moduleResolution: bundler`)   | `types`           | `./dist/components/button/index.d.ts`      |
-| Vite / SvelteKit dev + build               | `svelte`          | `./src/components/button/index.ts`         |
-| `svelte-package` / Svelte-aware tooling    | `svelte`          | `./src/components/button/index.ts`         |
-| Node SSR without Svelte tooling            | `node`            | `./dist/server/components/button/index.js` |
-| Bun consumer                               | `default`         | `./dist/components/button/index.js`        |
-| Browser bundler (esbuild, Rollup, Webpack) | `default`         | `./dist/components/button/index.js`        |
+| Consumer / resolver                       | Subpath                | Condition matched | File loaded                           |
+| ----------------------------------------- | ---------------------- | ----------------- | ------------------------------------- |
+| TypeScript (`moduleResolution: nodenext`) | `cinder/button`        | `types`           | `./dist/components/button/index.d.ts` |
+| TypeScript (`moduleResolution: bundler`)  | `cinder/button`        | `types`           | `./dist/components/button/index.d.ts` |
+| Vite / SvelteKit dev + build              | `cinder/button`        | `svelte`          | `./src/components/button/index.ts`    |
+| `svelte-package` / Svelte-aware tooling   | `cinder/button`        | `svelte`          | `./src/components/button/index.ts`    |
+| Any resolver                              | `cinder/button/styles` | `default`         | `./dist/components/button/button.css` |
 
 The `svelte` condition is the public contract for Svelte-aware tooling. Source
 paths it names are stable. Any other path under `src/` is implementation detail
-and may move at any time. `dist/` is the contract for all non-Svelte tooling.
+and may move at any time. `dist/` is the contract for all non-Svelte tooling
+and for every CSS sidecar.
+
+Consumers using Bun, Node SSR, or a browser bundler without Svelte tooling
+will resolve via `types` for typechecking, but the component subpaths do not
+currently expose a runtime `node` or `default` JS condition. Track 4 ships
+the underlying per-component browser-ESM and SSR builds; wiring those into
+the exports map is a follow-up track.
 
 ## Styles — two consumption modes
 

--- a/packages/components/fixtures/sveltekit-consumer/src/routes/a-la-carte/+page.svelte
+++ b/packages/components/fixtures/sveltekit-consumer/src/routes/a-la-carte/+page.svelte
@@ -1,0 +1,16 @@
+<script lang="ts">
+  // À la carte CSS test: import button JS + button styles plus the required
+  // tokens and foundation aggregators. The built CSS bundle for this route
+  // should contain button selectors and `--cinder-button-*` custom properties
+  // but should NOT contain accordion-specific selectors or custom properties.
+  import Button from 'cinder/button';
+
+  import 'cinder/styles/tokens';
+  import 'cinder/styles/foundation';
+  import 'cinder/button/styles';
+</script>
+
+<main>
+  <h1>À la carte fixture</h1>
+  <Button label="à la carte button" />
+</main>

--- a/packages/components/fixtures/sveltekit-consumer/src/routes/no-styles/+page.svelte
+++ b/packages/components/fixtures/sveltekit-consumer/src/routes/no-styles/+page.svelte
@@ -1,0 +1,12 @@
+<script lang="ts">
+  // No-styles test: import only the button JS (no `cinder/button/styles`,
+  // no aggregators). The built CSS bundle for this route should NOT contain
+  // button selectors — proves the component JS does not pull CSS as a side
+  // effect.
+  import Button from 'cinder/button';
+</script>
+
+<main>
+  <h1>No-styles fixture</h1>
+  <Button label="no styles button" />
+</main>

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -34,6 +34,12 @@
     "./styles": {
       "default": "./src/styles/index.css"
     },
+    "./styles/tokens": {
+      "default": "./src/styles/tokens.css"
+    },
+    "./styles/foundation": {
+      "default": "./src/styles/foundation.css"
+    },
     "./manifest": {
       "import": "./components.json",
       "default": "./components.json"
@@ -49,6 +55,9 @@
     "./accordion/variables": {
       "svelte": "./src/components/accordion/accordion.variables.ts",
       "types": "./dist/components/accordion/accordion.variables.d.ts"
+    },
+    "./accordion/styles": {
+      "default": "./dist/components/accordion/accordion.css"
     },
     "./accordion/examples": {
       "import": "./src/components/accordion/accordion.examples.json",
@@ -66,6 +75,9 @@
       "svelte": "./src/components/accordion-item/accordion-item.variables.ts",
       "types": "./dist/components/accordion-item/accordion-item.variables.d.ts"
     },
+    "./accordion-item/styles": {
+      "default": "./dist/components/accordion-item/accordion-item.css"
+    },
     "./alert": {
       "svelte": "./src/components/alert/index.ts",
       "types": "./dist/components/alert/index.d.ts"
@@ -77,6 +89,9 @@
     "./alert/variables": {
       "svelte": "./src/components/alert/alert.variables.ts",
       "types": "./dist/components/alert/alert.variables.d.ts"
+    },
+    "./alert/styles": {
+      "default": "./dist/components/alert/alert.css"
     },
     "./alert/examples": {
       "import": "./src/components/alert/alert.examples.json",
@@ -94,6 +109,9 @@
       "svelte": "./src/components/avatar/avatar.variables.ts",
       "types": "./dist/components/avatar/avatar.variables.d.ts"
     },
+    "./avatar/styles": {
+      "default": "./dist/components/avatar/avatar.css"
+    },
     "./avatar/examples": {
       "import": "./src/components/avatar/avatar.examples.json",
       "default": "./src/components/avatar/avatar.examples.json"
@@ -109,6 +127,9 @@
     "./badge/variables": {
       "svelte": "./src/components/badge/badge.variables.ts",
       "types": "./dist/components/badge/badge.variables.d.ts"
+    },
+    "./badge/styles": {
+      "default": "./dist/components/badge/badge.css"
     },
     "./badge/examples": {
       "import": "./src/components/badge/badge.examples.json",
@@ -126,6 +147,9 @@
       "svelte": "./src/components/banner/banner.variables.ts",
       "types": "./dist/components/banner/banner.variables.d.ts"
     },
+    "./banner/styles": {
+      "default": "./dist/components/banner/banner.css"
+    },
     "./breadcrumbs": {
       "svelte": "./src/components/breadcrumbs/index.ts",
       "types": "./dist/components/breadcrumbs/index.d.ts"
@@ -137,6 +161,9 @@
     "./breadcrumbs/variables": {
       "svelte": "./src/components/breadcrumbs/breadcrumbs.variables.ts",
       "types": "./dist/components/breadcrumbs/breadcrumbs.variables.d.ts"
+    },
+    "./breadcrumbs/styles": {
+      "default": "./dist/components/breadcrumbs/breadcrumbs.css"
     },
     "./breadcrumbs/examples": {
       "import": "./src/components/breadcrumbs/breadcrumbs.examples.json",
@@ -153,6 +180,9 @@
     "./button/variables": {
       "svelte": "./src/components/button/button.variables.ts",
       "types": "./dist/components/button/button.variables.d.ts"
+    },
+    "./button/styles": {
+      "default": "./dist/components/button/button.css"
     },
     "./button/examples": {
       "import": "./src/components/button/button.examples.json",
@@ -174,6 +204,9 @@
       "svelte": "./src/components/button-group/button-group.variables.ts",
       "types": "./dist/components/button-group/button-group.variables.d.ts"
     },
+    "./button-group/styles": {
+      "default": "./dist/components/button-group/button-group.css"
+    },
     "./button-group/examples": {
       "import": "./src/components/button-group/button-group.examples.json",
       "default": "./src/components/button-group/button-group.examples.json"
@@ -190,6 +223,9 @@
       "svelte": "./src/components/callout/callout.variables.ts",
       "types": "./dist/components/callout/callout.variables.d.ts"
     },
+    "./callout/styles": {
+      "default": "./dist/components/callout/callout.css"
+    },
     "./card": {
       "svelte": "./src/components/card/index.ts",
       "types": "./dist/components/card/index.d.ts"
@@ -201,6 +237,9 @@
     "./card/variables": {
       "svelte": "./src/components/card/card.variables.ts",
       "types": "./dist/components/card/card.variables.d.ts"
+    },
+    "./card/styles": {
+      "default": "./dist/components/card/card.css"
     },
     "./card/examples": {
       "import": "./src/components/card/card.examples.json",
@@ -234,6 +273,9 @@
       "svelte": "./src/components/checkbox/checkbox.variables.ts",
       "types": "./dist/components/checkbox/checkbox.variables.d.ts"
     },
+    "./checkbox/styles": {
+      "default": "./dist/components/checkbox/checkbox.css"
+    },
     "./checkbox/examples": {
       "import": "./src/components/checkbox/checkbox.examples.json",
       "default": "./src/components/checkbox/checkbox.examples.json"
@@ -250,6 +292,9 @@
       "svelte": "./src/components/checkbox-group/checkbox-group.variables.ts",
       "types": "./dist/components/checkbox-group/checkbox-group.variables.d.ts"
     },
+    "./checkbox-group/styles": {
+      "default": "./dist/components/checkbox-group/checkbox-group.css"
+    },
     "./chip": {
       "svelte": "./src/components/chip/index.ts",
       "types": "./dist/components/chip/index.d.ts"
@@ -261,6 +306,9 @@
     "./chip/variables": {
       "svelte": "./src/components/chip/chip.variables.ts",
       "types": "./dist/components/chip/chip.variables.d.ts"
+    },
+    "./chip/styles": {
+      "default": "./dist/components/chip/chip.css"
     },
     "./chip/examples": {
       "import": "./src/components/chip/chip.examples.json",
@@ -278,6 +326,9 @@
       "svelte": "./src/components/code-block/code-block.variables.ts",
       "types": "./dist/components/code-block/code-block.variables.d.ts"
     },
+    "./code-block/styles": {
+      "default": "./dist/components/code-block/code-block.css"
+    },
     "./code-block/examples": {
       "import": "./src/components/code-block/code-block.examples.json",
       "default": "./src/components/code-block/code-block.examples.json"
@@ -294,6 +345,9 @@
       "svelte": "./src/components/color-picker/color-picker.variables.ts",
       "types": "./dist/components/color-picker/color-picker.variables.d.ts"
     },
+    "./color-picker/styles": {
+      "default": "./dist/components/color-picker/color-picker.css"
+    },
     "./color-swatch-picker": {
       "svelte": "./src/components/color-swatch-picker/index.ts",
       "types": "./dist/components/color-swatch-picker/index.d.ts"
@@ -306,6 +360,9 @@
       "svelte": "./src/components/color-swatch-picker/color-swatch-picker.variables.ts",
       "types": "./dist/components/color-swatch-picker/color-swatch-picker.variables.d.ts"
     },
+    "./color-swatch-picker/styles": {
+      "default": "./dist/components/color-swatch-picker/color-swatch-picker.css"
+    },
     "./combobox": {
       "svelte": "./src/components/combobox/index.ts",
       "types": "./dist/components/combobox/index.d.ts"
@@ -317,6 +374,9 @@
     "./combobox/variables": {
       "svelte": "./src/components/combobox/combobox.variables.ts",
       "types": "./dist/components/combobox/combobox.variables.d.ts"
+    },
+    "./combobox/styles": {
+      "default": "./dist/components/combobox/combobox.css"
     },
     "./combobox/examples": {
       "import": "./src/components/combobox/combobox.examples.json",
@@ -346,6 +406,9 @@
       "svelte": "./src/components/command-palette/command-palette.variables.ts",
       "types": "./dist/components/command-palette/command-palette.variables.d.ts"
     },
+    "./command-palette/styles": {
+      "default": "./dist/components/command-palette/command-palette.css"
+    },
     "./command-palette/examples": {
       "import": "./src/components/command-palette/command-palette.examples.json",
       "default": "./src/components/command-palette/command-palette.examples.json"
@@ -374,6 +437,9 @@
       "svelte": "./src/components/copy-button/copy-button.variables.ts",
       "types": "./dist/components/copy-button/copy-button.variables.d.ts"
     },
+    "./copy-button/styles": {
+      "default": "./dist/components/copy-button/copy-button.css"
+    },
     "./copy-button/examples": {
       "import": "./src/components/copy-button/copy-button.examples.json",
       "default": "./src/components/copy-button/copy-button.examples.json"
@@ -389,6 +455,9 @@
     "./data-list/variables": {
       "svelte": "./src/components/data-list/data-list.variables.ts",
       "types": "./dist/components/data-list/data-list.variables.d.ts"
+    },
+    "./data-list/styles": {
+      "default": "./dist/components/data-list/data-list.css"
     },
     "./data-list/examples": {
       "import": "./src/components/data-list/data-list.examples.json",
@@ -406,6 +475,9 @@
       "svelte": "./src/components/description-list/description-list.variables.ts",
       "types": "./dist/components/description-list/description-list.variables.d.ts"
     },
+    "./description-list/styles": {
+      "default": "./dist/components/description-list/description-list.css"
+    },
     "./diff-statistics": {
       "svelte": "./src/components/diff-statistics/index.ts",
       "types": "./dist/components/diff-statistics/index.d.ts"
@@ -417,6 +489,9 @@
     "./diff-statistics/variables": {
       "svelte": "./src/components/diff-statistics/diff-statistics.variables.ts",
       "types": "./dist/components/diff-statistics/diff-statistics.variables.d.ts"
+    },
+    "./diff-statistics/styles": {
+      "default": "./dist/components/diff-statistics/diff-statistics.css"
     },
     "./diff-statistics/examples": {
       "import": "./src/components/diff-statistics/diff-statistics.examples.json",
@@ -450,6 +525,9 @@
       "svelte": "./src/components/divider/divider.variables.ts",
       "types": "./dist/components/divider/divider.variables.d.ts"
     },
+    "./divider/styles": {
+      "default": "./dist/components/divider/divider.css"
+    },
     "./divider/examples": {
       "import": "./src/components/divider/divider.examples.json",
       "default": "./src/components/divider/divider.examples.json"
@@ -466,6 +544,9 @@
       "svelte": "./src/components/drawer/drawer.variables.ts",
       "types": "./dist/components/drawer/drawer.variables.d.ts"
     },
+    "./drawer/styles": {
+      "default": "./dist/components/drawer/drawer.css"
+    },
     "./drawer/examples": {
       "import": "./src/components/drawer/drawer.examples.json",
       "default": "./src/components/drawer/drawer.examples.json"
@@ -481,6 +562,9 @@
     "./dropdown/variables": {
       "svelte": "./src/components/dropdown/dropdown.variables.ts",
       "types": "./dist/components/dropdown/dropdown.variables.d.ts"
+    },
+    "./dropdown/styles": {
+      "default": "./dist/components/dropdown/dropdown.css"
     },
     "./dropdown/examples": {
       "import": "./src/components/dropdown/dropdown.examples.json",
@@ -558,6 +642,9 @@
       "svelte": "./src/components/empty-state/empty-state.variables.ts",
       "types": "./dist/components/empty-state/empty-state.variables.d.ts"
     },
+    "./empty-state/styles": {
+      "default": "./dist/components/empty-state/empty-state.css"
+    },
     "./empty-state/examples": {
       "import": "./src/components/empty-state/empty-state.examples.json",
       "default": "./src/components/empty-state/empty-state.examples.json"
@@ -573,6 +660,9 @@
     "./feed/variables": {
       "svelte": "./src/components/feed/feed.variables.ts",
       "types": "./dist/components/feed/feed.variables.d.ts"
+    },
+    "./feed/styles": {
+      "default": "./dist/components/feed/feed.css"
     },
     "./feed-event": {
       "svelte": "./src/components/feed-event/index.ts",
@@ -598,6 +688,9 @@
       "svelte": "./src/components/form-field/form-field.variables.ts",
       "types": "./dist/components/form-field/form-field.variables.d.ts"
     },
+    "./form-field/styles": {
+      "default": "./dist/components/form-field/form-field.css"
+    },
     "./form-field/examples": {
       "import": "./src/components/form-field/form-field.examples.json",
       "default": "./src/components/form-field/form-field.examples.json"
@@ -614,6 +707,9 @@
       "svelte": "./src/components/form-section/form-section.variables.ts",
       "types": "./dist/components/form-section/form-section.variables.d.ts"
     },
+    "./form-section/styles": {
+      "default": "./dist/components/form-section/form-section.css"
+    },
     "./form-section/examples": {
       "import": "./src/components/form-section/form-section.examples.json",
       "default": "./src/components/form-section/form-section.examples.json"
@@ -629,6 +725,9 @@
     "./grid-list/variables": {
       "svelte": "./src/components/grid-list/grid-list.variables.ts",
       "types": "./dist/components/grid-list/grid-list.variables.d.ts"
+    },
+    "./grid-list/styles": {
+      "default": "./dist/components/grid-list/grid-list.css"
     },
     "./grid-list-item": {
       "svelte": "./src/components/grid-list-item/index.ts",
@@ -654,6 +753,9 @@
       "svelte": "./src/components/image/image.variables.ts",
       "types": "./dist/components/image/image.variables.d.ts"
     },
+    "./image/styles": {
+      "default": "./dist/components/image/image.css"
+    },
     "./input": {
       "svelte": "./src/components/input/index.ts",
       "types": "./dist/components/input/index.d.ts"
@@ -665,6 +767,9 @@
     "./input/variables": {
       "svelte": "./src/components/input/input.variables.ts",
       "types": "./dist/components/input/input.variables.d.ts"
+    },
+    "./input/styles": {
+      "default": "./dist/components/input/input.css"
     },
     "./input/examples": {
       "import": "./src/components/input/input.examples.json",
@@ -686,6 +791,9 @@
       "svelte": "./src/components/json-schema-editor/json-schema-editor.variables.ts",
       "types": "./dist/components/json-schema-editor/json-schema-editor.variables.d.ts"
     },
+    "./json-schema-editor/styles": {
+      "default": "./dist/components/json-schema-editor/json-schema-editor.css"
+    },
     "./json-schema-editor/examples": {
       "import": "./src/components/json-schema-editor/json-schema-editor.examples.json",
       "default": "./src/components/json-schema-editor/json-schema-editor.examples.json"
@@ -702,6 +810,9 @@
       "svelte": "./src/components/kbd/kbd.variables.ts",
       "types": "./dist/components/kbd/kbd.variables.d.ts"
     },
+    "./kbd/styles": {
+      "default": "./dist/components/kbd/kbd.css"
+    },
     "./kbd/examples": {
       "import": "./src/components/kbd/kbd.examples.json",
       "default": "./src/components/kbd/kbd.examples.json"
@@ -717,6 +828,9 @@
     "./label/variables": {
       "svelte": "./src/components/label/label.variables.ts",
       "types": "./dist/components/label/label.variables.d.ts"
+    },
+    "./label/styles": {
+      "default": "./dist/components/label/label.css"
     },
     "./markdown-editor": {
       "svelte": "./src/components/markdown-editor/index.ts",
@@ -746,6 +860,9 @@
       "svelte": "./src/components/modal/modal.variables.ts",
       "types": "./dist/components/modal/modal.variables.d.ts"
     },
+    "./modal/styles": {
+      "default": "./dist/components/modal/modal.css"
+    },
     "./modal/examples": {
       "import": "./src/components/modal/modal.examples.json",
       "default": "./src/components/modal/modal.examples.json"
@@ -766,6 +883,9 @@
       "svelte": "./src/components/navigation-bar/navigation-bar.variables.ts",
       "types": "./dist/components/navigation-bar/navigation-bar.variables.d.ts"
     },
+    "./navigation-bar/styles": {
+      "default": "./dist/components/navigation-bar/navigation-bar.css"
+    },
     "./navigation-bar/examples": {
       "import": "./src/components/navigation-bar/navigation-bar.examples.json",
       "default": "./src/components/navigation-bar/navigation-bar.examples.json"
@@ -782,6 +902,9 @@
       "svelte": "./src/components/navigation-item/navigation-item.variables.ts",
       "types": "./dist/components/navigation-item/navigation-item.variables.d.ts"
     },
+    "./navigation-item/styles": {
+      "default": "./dist/components/navigation-item/navigation-item.css"
+    },
     "./number-input": {
       "svelte": "./src/components/number-input/index.ts",
       "types": "./dist/components/number-input/index.d.ts"
@@ -794,6 +917,9 @@
       "svelte": "./src/components/number-input/number-input.variables.ts",
       "types": "./dist/components/number-input/number-input.variables.d.ts"
     },
+    "./number-input/styles": {
+      "default": "./dist/components/number-input/number-input.css"
+    },
     "./page-layout": {
       "svelte": "./src/components/page-layout/index.ts",
       "types": "./dist/components/page-layout/index.d.ts"
@@ -805,6 +931,9 @@
     "./page-layout/variables": {
       "svelte": "./src/components/page-layout/page-layout.variables.ts",
       "types": "./dist/components/page-layout/page-layout.variables.d.ts"
+    },
+    "./page-layout/styles": {
+      "default": "./dist/components/page-layout/page-layout.css"
     },
     "./page-layout/examples": {
       "import": "./src/components/page-layout/page-layout.examples.json",
@@ -822,6 +951,9 @@
       "svelte": "./src/components/pagination/pagination.variables.ts",
       "types": "./dist/components/pagination/pagination.variables.d.ts"
     },
+    "./pagination/styles": {
+      "default": "./dist/components/pagination/pagination.css"
+    },
     "./pagination/examples": {
       "import": "./src/components/pagination/pagination.examples.json",
       "default": "./src/components/pagination/pagination.examples.json"
@@ -837,6 +969,9 @@
     "./popover/variables": {
       "svelte": "./src/components/popover/popover.variables.ts",
       "types": "./dist/components/popover/popover.variables.d.ts"
+    },
+    "./popover/styles": {
+      "default": "./dist/components/popover/popover.css"
     },
     "./popover/examples": {
       "import": "./src/components/popover/popover.examples.json",
@@ -854,6 +989,9 @@
       "svelte": "./src/components/progress/progress.variables.ts",
       "types": "./dist/components/progress/progress.variables.d.ts"
     },
+    "./progress/styles": {
+      "default": "./dist/components/progress/progress.css"
+    },
     "./progress/examples": {
       "import": "./src/components/progress/progress.examples.json",
       "default": "./src/components/progress/progress.examples.json"
@@ -870,6 +1008,9 @@
       "svelte": "./src/components/radio/radio.variables.ts",
       "types": "./dist/components/radio/radio.variables.d.ts"
     },
+    "./radio/styles": {
+      "default": "./dist/components/radio/radio.css"
+    },
     "./radio-group": {
       "svelte": "./src/components/radio-group/index.ts",
       "types": "./dist/components/radio-group/index.d.ts"
@@ -881,6 +1022,9 @@
     "./radio-group/variables": {
       "svelte": "./src/components/radio-group/radio-group.variables.ts",
       "types": "./dist/components/radio-group/radio-group.variables.d.ts"
+    },
+    "./radio-group/styles": {
+      "default": "./dist/components/radio-group/radio-group.css"
     },
     "./radio-group/examples": {
       "import": "./src/components/radio-group/radio-group.examples.json",
@@ -898,6 +1042,9 @@
       "svelte": "./src/components/review-editor/review-editor.variables.ts",
       "types": "./dist/components/review-editor/review-editor.variables.d.ts"
     },
+    "./review-editor/styles": {
+      "default": "./dist/components/review-editor/review-editor.css"
+    },
     "./review-editor/examples": {
       "import": "./src/components/review-editor/review-editor.examples.json",
       "default": "./src/components/review-editor/review-editor.examples.json"
@@ -914,6 +1061,9 @@
       "svelte": "./src/components/scroll-area/scroll-area.variables.ts",
       "types": "./dist/components/scroll-area/scroll-area.variables.d.ts"
     },
+    "./scroll-area/styles": {
+      "default": "./dist/components/scroll-area/scroll-area.css"
+    },
     "./search-field": {
       "svelte": "./src/components/search-field/index.ts",
       "types": "./dist/components/search-field/index.d.ts"
@@ -925,6 +1075,9 @@
     "./search-field/variables": {
       "svelte": "./src/components/search-field/search-field.variables.ts",
       "types": "./dist/components/search-field/search-field.variables.d.ts"
+    },
+    "./search-field/styles": {
+      "default": "./dist/components/search-field/search-field.css"
     },
     "./section-heading": {
       "svelte": "./src/components/section-heading/index.ts",
@@ -938,6 +1091,9 @@
       "svelte": "./src/components/section-heading/section-heading.variables.ts",
       "types": "./dist/components/section-heading/section-heading.variables.d.ts"
     },
+    "./section-heading/styles": {
+      "default": "./dist/components/section-heading/section-heading.css"
+    },
     "./segmented-control": {
       "svelte": "./src/components/segmented-control/index.ts",
       "types": "./dist/components/segmented-control/index.d.ts"
@@ -949,6 +1105,9 @@
     "./segmented-control/variables": {
       "svelte": "./src/components/segmented-control/segmented-control.variables.ts",
       "types": "./dist/components/segmented-control/segmented-control.variables.d.ts"
+    },
+    "./segmented-control/styles": {
+      "default": "./dist/components/segmented-control/segmented-control.css"
     },
     "./segmented-control/examples": {
       "import": "./src/components/segmented-control/segmented-control.examples.json",
@@ -966,6 +1125,9 @@
       "svelte": "./src/components/select/select.variables.ts",
       "types": "./dist/components/select/select.variables.d.ts"
     },
+    "./select/styles": {
+      "default": "./dist/components/select/select.css"
+    },
     "./select/examples": {
       "import": "./src/components/select/select.examples.json",
       "default": "./src/components/select/select.examples.json"
@@ -981,6 +1143,9 @@
     "./selection-popover/variables": {
       "svelte": "./src/components/selection-popover/selection-popover.variables.ts",
       "types": "./dist/components/selection-popover/selection-popover.variables.d.ts"
+    },
+    "./selection-popover/styles": {
+      "default": "./dist/components/selection-popover/selection-popover.css"
     },
     "./selection-popover/examples": {
       "import": "./src/components/selection-popover/selection-popover.examples.json",
@@ -998,6 +1163,9 @@
       "svelte": "./src/components/sheet/sheet.variables.ts",
       "types": "./dist/components/sheet/sheet.variables.d.ts"
     },
+    "./sheet/styles": {
+      "default": "./dist/components/sheet/sheet.css"
+    },
     "./side-navigation": {
       "svelte": "./src/components/side-navigation/index.ts",
       "types": "./dist/components/side-navigation/index.d.ts"
@@ -1010,6 +1178,9 @@
       "svelte": "./src/components/side-navigation/side-navigation.variables.ts",
       "types": "./dist/components/side-navigation/side-navigation.variables.d.ts"
     },
+    "./side-navigation/styles": {
+      "default": "./dist/components/side-navigation/side-navigation.css"
+    },
     "./side-navigation-group": {
       "svelte": "./src/components/side-navigation-group/index.ts",
       "types": "./dist/components/side-navigation-group/index.d.ts"
@@ -1021,6 +1192,9 @@
     "./side-navigation-group/variables": {
       "svelte": "./src/components/side-navigation-group/side-navigation-group.variables.ts",
       "types": "./dist/components/side-navigation-group/side-navigation-group.variables.d.ts"
+    },
+    "./side-navigation-group/styles": {
+      "default": "./dist/components/side-navigation-group/side-navigation-group.css"
     },
     "./side-navigation-item": {
       "svelte": "./src/components/side-navigation-item/index.ts",
@@ -1046,6 +1220,9 @@
       "svelte": "./src/components/sidebar/sidebar.variables.ts",
       "types": "./dist/components/sidebar/sidebar.variables.d.ts"
     },
+    "./sidebar/styles": {
+      "default": "./dist/components/sidebar/sidebar.css"
+    },
     "./sidebar/examples": {
       "import": "./src/components/sidebar/sidebar.examples.json",
       "default": "./src/components/sidebar/sidebar.examples.json"
@@ -1061,6 +1238,9 @@
     "./skeleton/variables": {
       "svelte": "./src/components/skeleton/skeleton.variables.ts",
       "types": "./dist/components/skeleton/skeleton.variables.d.ts"
+    },
+    "./skeleton/styles": {
+      "default": "./dist/components/skeleton/skeleton.css"
     },
     "./skeleton/examples": {
       "import": "./src/components/skeleton/skeleton.examples.json",
@@ -1078,6 +1258,9 @@
       "svelte": "./src/components/slider/slider.variables.ts",
       "types": "./dist/components/slider/slider.variables.d.ts"
     },
+    "./slider/styles": {
+      "default": "./dist/components/slider/slider.css"
+    },
     "./slider/examples": {
       "import": "./src/components/slider/slider.examples.json",
       "default": "./src/components/slider/slider.examples.json"
@@ -1094,6 +1277,9 @@
       "svelte": "./src/components/sortable-list/sortable-list.variables.ts",
       "types": "./dist/components/sortable-list/sortable-list.variables.d.ts"
     },
+    "./sortable-list/styles": {
+      "default": "./dist/components/sortable-list/sortable-list.css"
+    },
     "./spinner": {
       "svelte": "./src/components/spinner/index.ts",
       "types": "./dist/components/spinner/index.d.ts"
@@ -1105,6 +1291,9 @@
     "./spinner/variables": {
       "svelte": "./src/components/spinner/spinner.variables.ts",
       "types": "./dist/components/spinner/spinner.variables.d.ts"
+    },
+    "./spinner/styles": {
+      "default": "./dist/components/spinner/spinner.css"
     },
     "./spinner/examples": {
       "import": "./src/components/spinner/spinner.examples.json",
@@ -1122,6 +1311,9 @@
       "svelte": "./src/components/stacked-list-item/stacked-list-item.variables.ts",
       "types": "./dist/components/stacked-list-item/stacked-list-item.variables.d.ts"
     },
+    "./stacked-list-item/styles": {
+      "default": "./dist/components/stacked-list-item/stacked-list-item.css"
+    },
     "./stat": {
       "svelte": "./src/components/stat/index.ts",
       "types": "./dist/components/stat/index.d.ts"
@@ -1133,6 +1325,9 @@
     "./stat/variables": {
       "svelte": "./src/components/stat/stat.variables.ts",
       "types": "./dist/components/stat/stat.variables.d.ts"
+    },
+    "./stat/styles": {
+      "default": "./dist/components/stat/stat.css"
     },
     "./stat-group": {
       "svelte": "./src/components/stat-group/index.ts",
@@ -1146,6 +1341,9 @@
       "svelte": "./src/components/stat-group/stat-group.variables.ts",
       "types": "./dist/components/stat-group/stat-group.variables.d.ts"
     },
+    "./stat-group/styles": {
+      "default": "./dist/components/stat-group/stat-group.css"
+    },
     "./status-dot": {
       "svelte": "./src/components/status-dot/index.ts",
       "types": "./dist/components/status-dot/index.d.ts"
@@ -1157,6 +1355,9 @@
     "./status-dot/variables": {
       "svelte": "./src/components/status-dot/status-dot.variables.ts",
       "types": "./dist/components/status-dot/status-dot.variables.d.ts"
+    },
+    "./status-dot/styles": {
+      "default": "./dist/components/status-dot/status-dot.css"
     },
     "./steps": {
       "svelte": "./src/components/steps/index.ts",
@@ -1170,6 +1371,9 @@
       "svelte": "./src/components/steps/steps.variables.ts",
       "types": "./dist/components/steps/steps.variables.d.ts"
     },
+    "./steps/styles": {
+      "default": "./dist/components/steps/steps.css"
+    },
     "./surface": {
       "svelte": "./src/components/surface/index.ts",
       "types": "./dist/components/surface/index.d.ts"
@@ -1181,6 +1385,9 @@
     "./surface/variables": {
       "svelte": "./src/components/surface/surface.variables.ts",
       "types": "./dist/components/surface/surface.variables.d.ts"
+    },
+    "./surface/styles": {
+      "default": "./dist/components/surface/surface.css"
     },
     "./surface/examples": {
       "import": "./src/components/surface/surface.examples.json",
@@ -1198,6 +1405,9 @@
       "svelte": "./src/components/tab/tab.variables.ts",
       "types": "./dist/components/tab/tab.variables.d.ts"
     },
+    "./tab/styles": {
+      "default": "./dist/components/tab/tab.css"
+    },
     "./tab-list": {
       "svelte": "./src/components/tab-list/index.ts",
       "types": "./dist/components/tab-list/index.d.ts"
@@ -1209,6 +1419,9 @@
     "./tab-list/variables": {
       "svelte": "./src/components/tab-list/tab-list.variables.ts",
       "types": "./dist/components/tab-list/tab-list.variables.d.ts"
+    },
+    "./tab-list/styles": {
+      "default": "./dist/components/tab-list/tab-list.css"
     },
     "./tab-panel": {
       "svelte": "./src/components/tab-panel/index.ts",
@@ -1222,6 +1435,9 @@
       "svelte": "./src/components/tab-panel/tab-panel.variables.ts",
       "types": "./dist/components/tab-panel/tab-panel.variables.d.ts"
     },
+    "./tab-panel/styles": {
+      "default": "./dist/components/tab-panel/tab-panel.css"
+    },
     "./table": {
       "svelte": "./src/components/table/index.ts",
       "types": "./dist/components/table/index.d.ts"
@@ -1233,6 +1449,9 @@
     "./table/variables": {
       "svelte": "./src/components/table/table.variables.ts",
       "types": "./dist/components/table/table.variables.d.ts"
+    },
+    "./table/styles": {
+      "default": "./dist/components/table/table.css"
     },
     "./table/examples": {
       "import": "./src/components/table/table.examples.json",
@@ -1250,6 +1469,9 @@
       "svelte": "./src/components/table-body/table-body.variables.ts",
       "types": "./dist/components/table-body/table-body.variables.d.ts"
     },
+    "./table-body/styles": {
+      "default": "./dist/components/table-body/table-body.css"
+    },
     "./table-cell": {
       "svelte": "./src/components/table-cell/index.ts",
       "types": "./dist/components/table-cell/index.d.ts"
@@ -1261,6 +1483,9 @@
     "./table-cell/variables": {
       "svelte": "./src/components/table-cell/table-cell.variables.ts",
       "types": "./dist/components/table-cell/table-cell.variables.d.ts"
+    },
+    "./table-cell/styles": {
+      "default": "./dist/components/table-cell/table-cell.css"
     },
     "./table-header": {
       "svelte": "./src/components/table-header/index.ts",
@@ -1274,6 +1499,9 @@
       "svelte": "./src/components/table-header/table-header.variables.ts",
       "types": "./dist/components/table-header/table-header.variables.d.ts"
     },
+    "./table-header/styles": {
+      "default": "./dist/components/table-header/table-header.css"
+    },
     "./table-header-cell": {
       "svelte": "./src/components/table-header-cell/index.ts",
       "types": "./dist/components/table-header-cell/index.d.ts"
@@ -1285,6 +1513,9 @@
     "./table-header-cell/variables": {
       "svelte": "./src/components/table-header-cell/table-header-cell.variables.ts",
       "types": "./dist/components/table-header-cell/table-header-cell.variables.d.ts"
+    },
+    "./table-header-cell/styles": {
+      "default": "./dist/components/table-header-cell/table-header-cell.css"
     },
     "./table-row": {
       "svelte": "./src/components/table-row/index.ts",
@@ -1298,6 +1529,9 @@
       "svelte": "./src/components/table-row/table-row.variables.ts",
       "types": "./dist/components/table-row/table-row.variables.d.ts"
     },
+    "./table-row/styles": {
+      "default": "./dist/components/table-row/table-row.css"
+    },
     "./tabs": {
       "svelte": "./src/components/tabs/index.ts",
       "types": "./dist/components/tabs/index.d.ts"
@@ -1309,6 +1543,9 @@
     "./tabs/variables": {
       "svelte": "./src/components/tabs/tabs.variables.ts",
       "types": "./dist/components/tabs/tabs.variables.d.ts"
+    },
+    "./tabs/styles": {
+      "default": "./dist/components/tabs/tabs.css"
     },
     "./tabs/examples": {
       "import": "./src/components/tabs/tabs.examples.json",
@@ -1326,6 +1563,9 @@
       "svelte": "./src/components/textarea/textarea.variables.ts",
       "types": "./dist/components/textarea/textarea.variables.d.ts"
     },
+    "./textarea/styles": {
+      "default": "./dist/components/textarea/textarea.css"
+    },
     "./textarea/examples": {
       "import": "./src/components/textarea/textarea.examples.json",
       "default": "./src/components/textarea/textarea.examples.json"
@@ -1341,6 +1581,9 @@
     "./toast-region/variables": {
       "svelte": "./src/components/toast-region/toast-region.variables.ts",
       "types": "./dist/components/toast-region/toast-region.variables.d.ts"
+    },
+    "./toast-region/styles": {
+      "default": "./dist/components/toast-region/toast-region.css"
     },
     "./toast-region/examples": {
       "import": "./src/components/toast-region/toast-region.examples.json",
@@ -1358,6 +1601,9 @@
       "svelte": "./src/components/toggle/toggle.variables.ts",
       "types": "./dist/components/toggle/toggle.variables.d.ts"
     },
+    "./toggle/styles": {
+      "default": "./dist/components/toggle/toggle.css"
+    },
     "./toggle/examples": {
       "import": "./src/components/toggle/toggle.examples.json",
       "default": "./src/components/toggle/toggle.examples.json"
@@ -1374,6 +1620,9 @@
       "svelte": "./src/components/tooltip/tooltip.variables.ts",
       "types": "./dist/components/tooltip/tooltip.variables.d.ts"
     },
+    "./tooltip/styles": {
+      "default": "./dist/components/tooltip/tooltip.css"
+    },
     "./tooltip/examples": {
       "import": "./src/components/tooltip/tooltip.examples.json",
       "default": "./src/components/tooltip/tooltip.examples.json"
@@ -1389,6 +1638,9 @@
     "./tree/variables": {
       "svelte": "./src/components/tree/tree.variables.ts",
       "types": "./dist/components/tree/tree.variables.d.ts"
+    },
+    "./tree/styles": {
+      "default": "./dist/components/tree/tree.css"
     },
     "./tree-item": {
       "svelte": "./src/components/tree-item/index.ts",
@@ -1430,6 +1682,9 @@
       "svelte": "./src/components/experimental/connection-indicator/connection-indicator.variables.ts",
       "types": "./dist/components/experimental/connection-indicator/connection-indicator.variables.d.ts"
     },
+    "./experimental/connection-indicator/styles": {
+      "default": "./dist/components/experimental/connection-indicator/connection-indicator.css"
+    },
     "./experimental/json-viewer": {
       "svelte": "./src/components/experimental/json-viewer/index.ts",
       "types": "./dist/components/experimental/json-viewer/index.d.ts"
@@ -1441,6 +1696,9 @@
     "./experimental/json-viewer/variables": {
       "svelte": "./src/components/experimental/json-viewer/json-viewer.variables.ts",
       "types": "./dist/components/experimental/json-viewer/json-viewer.variables.d.ts"
+    },
+    "./experimental/json-viewer/styles": {
+      "default": "./dist/components/experimental/json-viewer/json-viewer.css"
     },
     "./experimental/message": {
       "svelte": "./src/components/experimental/message/index.ts",
@@ -1454,6 +1712,9 @@
       "svelte": "./src/components/experimental/message/message.variables.ts",
       "types": "./dist/components/experimental/message/message.variables.d.ts"
     },
+    "./experimental/message/styles": {
+      "default": "./dist/components/experimental/message/message.css"
+    },
     "./experimental/timeline": {
       "svelte": "./src/components/experimental/timeline/index.ts",
       "types": "./dist/components/experimental/timeline/index.d.ts"
@@ -1466,6 +1727,9 @@
       "svelte": "./src/components/experimental/timeline/timeline.variables.ts",
       "types": "./dist/components/experimental/timeline/timeline.variables.d.ts"
     },
+    "./experimental/timeline/styles": {
+      "default": "./dist/components/experimental/timeline/timeline.css"
+    },
     "./experimental/timeline-item": {
       "svelte": "./src/components/experimental/timeline-item/index.ts",
       "types": "./dist/components/experimental/timeline-item/index.d.ts"
@@ -1477,6 +1741,9 @@
     "./experimental/timeline-item/variables": {
       "svelte": "./src/components/experimental/timeline-item/timeline-item.variables.ts",
       "types": "./dist/components/experimental/timeline-item/timeline-item.variables.d.ts"
+    },
+    "./experimental/timeline-item/styles": {
+      "default": "./dist/components/experimental/timeline-item/timeline-item.css"
     }
   },
   "main": "./dist/server/index.js",
@@ -1489,7 +1756,6 @@
     "src/components/**/*.ts",
     "!src/components/**/*.test.ts",
     "!src/components/**/*.spec.ts",
-    "!src/components/**/*.fixtures.ts",
     "src/components/**/*.svelte",
     "src/components/**/*.json",
     "src/components/**/*.md",
@@ -1497,33 +1763,22 @@
     "src/components/**/*.css",
     "src/_internal/**/*.ts",
     "!src/_internal/**/*.test.ts",
-    "src/schemas/**",
     "src/styles/**/*.css",
     "src/components/icons/index.ts",
     "src/utilities/**/*.ts",
     "!src/utilities/**/*.test.ts",
-    "components.json",
-    "llms.txt",
     "README.md"
   ],
   "scripts": {
-    "agents:check": "bun run scripts/render-agents-md.ts --check",
-    "agents:generate": "bun run scripts/render-agents-md.ts",
     "build": "bun run scripts/build.ts",
     "clean": "rm -rf dist coverage tsconfig.tsbuildinfo cinder-*.tgz tmp fixtures/node-consumer/node_modules fixtures/node-consumer/dist fixtures/sveltekit-consumer/node_modules fixtures/sveltekit-consumer/.svelte-kit fixtures/sveltekit-consumer/build",
     "components:check": "bun run scripts/generate-component-artifacts.ts --check",
     "components:fixture": "bun run scripts/run-consumer-fixture.ts",
     "components:generate": "bun run scripts/generate-component-artifacts.ts",
-    "constraints:check": "bun run scripts/generate-component-constraints.ts --check",
-    "constraints:generate": "bun run scripts/generate-component-constraints.ts",
-    "examples:check": "bun run scripts/generate-component-examples.ts --check",
-    "examples:generate": "bun run scripts/generate-component-examples.ts",
     "exports:check": "bun run scripts/generate-exports.ts --check",
     "exports:generate": "bun run scripts/generate-exports.ts",
     "lint": "oxlint --type-aware --tsconfig ./tsconfig.json",
     "lint:fix": "oxlint --fix --type-aware --tsconfig ./tsconfig.json",
-    "manifest:check": "bun run scripts/generate-manifest.ts --check",
-    "manifest:generate": "bun run scripts/generate-manifest.ts",
     "prepack": "bun run build",
     "prepare": "cd ../.. && husky",
     "prepublishOnly": "bun run validate && bun run build",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -257,13 +257,10 @@
       "svelte": "./src/components/chat/chat.variables.ts",
       "types": "./dist/components/chat/chat.variables.d.ts"
     },
-<<<<<<< HEAD
     "./chat/examples": {
       "import": "./src/components/chat/chat.examples.json",
       "default": "./src/components/chat/chat.examples.json"
     },
-=======
->>>>>>> 139325c (Address review committee feedback (round 1))
     "./checkbox": {
       "svelte": "./src/components/checkbox/index.ts",
       "types": "./dist/components/checkbox/index.d.ts"
@@ -512,13 +509,10 @@
       "svelte": "./src/components/diff-viewer/diff-viewer.variables.ts",
       "types": "./dist/components/diff-viewer/diff-viewer.variables.d.ts"
     },
-<<<<<<< HEAD
     "./diff-viewer/examples": {
       "import": "./src/components/diff-viewer/diff-viewer.examples.json",
       "default": "./src/components/diff-viewer/diff-viewer.examples.json"
     },
-=======
->>>>>>> 139325c (Address review committee feedback (round 1))
     "./divider": {
       "svelte": "./src/components/divider/index.ts",
       "types": "./dist/components/divider/index.d.ts"
@@ -850,13 +844,10 @@
       "svelte": "./src/components/markdown-editor/markdown-editor.variables.ts",
       "types": "./dist/components/markdown-editor/markdown-editor.variables.d.ts"
     },
-<<<<<<< HEAD
     "./markdown-editor/examples": {
       "import": "./src/components/markdown-editor/markdown-editor.examples.json",
       "default": "./src/components/markdown-editor/markdown-editor.examples.json"
     },
-=======
->>>>>>> 139325c (Address review committee feedback (round 1))
     "./modal": {
       "svelte": "./src/components/modal/index.ts",
       "types": "./dist/components/modal/index.d.ts"
@@ -1675,13 +1666,10 @@
       "svelte": "./src/components/visually-hidden/visually-hidden.variables.ts",
       "types": "./dist/components/visually-hidden/visually-hidden.variables.d.ts"
     },
-<<<<<<< HEAD
     "./visually-hidden/examples": {
       "import": "./src/components/visually-hidden/visually-hidden.examples.json",
       "default": "./src/components/visually-hidden/visually-hidden.examples.json"
     },
-=======
->>>>>>> 139325c (Address review committee feedback (round 1))
     "./experimental/connection-indicator": {
       "svelte": "./src/components/experimental/connection-indicator/index.ts",
       "types": "./dist/components/experimental/connection-indicator/index.d.ts"

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -257,10 +257,13 @@
       "svelte": "./src/components/chat/chat.variables.ts",
       "types": "./dist/components/chat/chat.variables.d.ts"
     },
+<<<<<<< HEAD
     "./chat/examples": {
       "import": "./src/components/chat/chat.examples.json",
       "default": "./src/components/chat/chat.examples.json"
     },
+=======
+>>>>>>> 139325c (Address review committee feedback (round 1))
     "./checkbox": {
       "svelte": "./src/components/checkbox/index.ts",
       "types": "./dist/components/checkbox/index.d.ts"
@@ -509,10 +512,13 @@
       "svelte": "./src/components/diff-viewer/diff-viewer.variables.ts",
       "types": "./dist/components/diff-viewer/diff-viewer.variables.d.ts"
     },
+<<<<<<< HEAD
     "./diff-viewer/examples": {
       "import": "./src/components/diff-viewer/diff-viewer.examples.json",
       "default": "./src/components/diff-viewer/diff-viewer.examples.json"
     },
+=======
+>>>>>>> 139325c (Address review committee feedback (round 1))
     "./divider": {
       "svelte": "./src/components/divider/index.ts",
       "types": "./dist/components/divider/index.d.ts"
@@ -844,10 +850,13 @@
       "svelte": "./src/components/markdown-editor/markdown-editor.variables.ts",
       "types": "./dist/components/markdown-editor/markdown-editor.variables.d.ts"
     },
+<<<<<<< HEAD
     "./markdown-editor/examples": {
       "import": "./src/components/markdown-editor/markdown-editor.examples.json",
       "default": "./src/components/markdown-editor/markdown-editor.examples.json"
     },
+=======
+>>>>>>> 139325c (Address review committee feedback (round 1))
     "./modal": {
       "svelte": "./src/components/modal/index.ts",
       "types": "./dist/components/modal/index.d.ts"
@@ -1666,10 +1675,13 @@
       "svelte": "./src/components/visually-hidden/visually-hidden.variables.ts",
       "types": "./dist/components/visually-hidden/visually-hidden.variables.d.ts"
     },
+<<<<<<< HEAD
     "./visually-hidden/examples": {
       "import": "./src/components/visually-hidden/visually-hidden.examples.json",
       "default": "./src/components/visually-hidden/visually-hidden.examples.json"
     },
+=======
+>>>>>>> 139325c (Address review committee feedback (round 1))
     "./experimental/connection-indicator": {
       "svelte": "./src/components/experimental/connection-indicator/index.ts",
       "types": "./dist/components/experimental/connection-indicator/index.d.ts"

--- a/packages/components/scripts/generate-exports.ts
+++ b/packages/components/scripts/generate-exports.ts
@@ -5,7 +5,7 @@
  *   ./<name>             → component (svelte/types conditions)
  *   ./<name>/schema      → schema module (svelte/types conditions)
  *   ./<name>/variables   → variables module (svelte/types conditions)
- *   ./<name>/styles      → layer-unwrapped CSS sidecar (default condition; emitted when CSS exists)
+ *   ./<name>/styles      → layer-unwrapped CSS sidecar (default condition; emitted when the component ships a source <name>.css)
  *   ./<name>/examples    → examples JSON (import/default only; emitted when file exists)
  *   ./<name>/constraints → constraints JSON (import/default only; emitted when file exists)
  *
@@ -121,8 +121,10 @@ export function computeExports(
     // Per-component CSS sidecar — layer-unwrapped. Consumers using these
     // à la carte must also import `cinder/styles/tokens` and
     // `cinder/styles/foundation` to get tokens, resets, and layer assignments.
-    // Gated on `hasCss` to avoid publishing dead exports for components
-    // without a `<name>.css` file.
+    //
+    // Only emitted when the component ships a source CSS sidecar — emitting
+    // `/styles` for a component without CSS would publish a dead export
+    // pointing at a non-existent dist artifact.
     if (hasCss) {
       out[`${prefix}/styles`] = {
         default: `${distDir}/${name}.css`,

--- a/packages/components/scripts/generate-exports.ts
+++ b/packages/components/scripts/generate-exports.ts
@@ -1,10 +1,11 @@
 /**
  * Generates subpath exports for every directory-shaped component under
- * `src/components/`. Each component contributes up to five subpaths:
+ * `src/components/`. Each component contributes up to six subpaths:
  *
  *   ./<name>             → component (svelte/types conditions)
  *   ./<name>/schema      → schema module (svelte/types conditions)
  *   ./<name>/variables   → variables module (svelte/types conditions)
+ *   ./<name>/styles      → layer-unwrapped CSS sidecar (default condition; emitted when CSS exists)
  *   ./<name>/examples    → examples JSON (import/default only; emitted when file exists)
  *   ./<name>/constraints → constraints JSON (import/default only; emitted when file exists)
  *
@@ -17,8 +18,14 @@
  *
  * Reserved (non-component) entries are preserved verbatim:
  *
- *   .          → root entry
- *   ./styles   → public styles entry
+ *   .                    → root entry
+ *   ./styles             → full-cascade aggregator (tokens + foundation + components + utilities)
+ *   ./styles/tokens      → token-layer-only aggregator
+ *   ./styles/foundation  → foundation-layer-only aggregator
+ *
+ * The per-component `/styles` exports emit layer-unwrapped CSS. Consumers using
+ * à la carte CSS must also import `cinder/styles/tokens` and
+ * `cinder/styles/foundation` to get tokens, resets, and layer assignments.
  *
  * If a newly-emitted subpath would collide with a non-generated reserved
  * entry, the generator aborts with a named error rather than silently
@@ -60,7 +67,7 @@ type JsonExportEntry = {
   default: string;
 };
 
-const RESERVED_KEYS = new Set(['.', './styles']);
+const RESERVED_KEYS = new Set(['.', './styles', './styles/tokens', './styles/foundation']);
 
 /** Default package root used when `computeExports` is called without one. */
 const DEFAULT_PACKAGE_ROOT = join(import.meta.dir, '..');
@@ -84,7 +91,7 @@ export function computeExports(
   // Package-level manifest entry (always present).
   out['./manifest'] = manifestExport();
 
-  for (const { name, isExperimental } of components) {
+  for (const { name, isExperimental, hasCss } of components) {
     const prefix = isExperimental ? `./experimental/${name}` : `./${name}`;
     const srcDir = isExperimental
       ? `./src/components/experimental/${name}`
@@ -111,6 +118,16 @@ export function computeExports(
       svelte: `${srcDir}/${name}.variables.ts`,
       types: `${distDir}/${name}.variables.d.ts`,
     };
+    // Per-component CSS sidecar — layer-unwrapped. Consumers using these
+    // à la carte must also import `cinder/styles/tokens` and
+    // `cinder/styles/foundation` to get tokens, resets, and layer assignments.
+    // Gated on `hasCss` to avoid publishing dead exports for components
+    // without a `<name>.css` file.
+    if (hasCss) {
+      out[`${prefix}/styles`] = {
+        default: `${distDir}/${name}.css`,
+      };
+    }
 
     // JSON sidecar subpaths — emitted only when the file exists on disk.
     // Uses import+default conditions only (no svelte/types).
@@ -223,6 +240,7 @@ async function main(): Promise<void> {
     if (
       key.endsWith('/schema') ||
       key.endsWith('/variables') ||
+      key.endsWith('/styles') ||
       key.endsWith('/examples') ||
       key.endsWith('/constraints')
     )

--- a/packages/components/scripts/lib/discover-components.ts
+++ b/packages/components/scripts/lib/discover-components.ts
@@ -29,7 +29,13 @@ export type ComponentDiscovery = {
   name: string;
   /** True when the component lives under `src/components/experimental/`. */
   isExperimental: boolean;
-  /** True when a `<name>.css` sidecar file exists in the component directory. */
+  /**
+   * True when the component directory contains a source CSS sidecar
+   * (`<name>.css`). Drives whether `generate-exports.ts` emits a
+   * `./<name>/styles` subpath — components with no CSS sidecar would
+   * otherwise publish a dead export pointing at a non-existent
+   * `dist/components/<name>/<name>.css`.
+   */
   hasCss: boolean;
 };
 

--- a/packages/components/scripts/lib/discover-components.ts
+++ b/packages/components/scripts/lib/discover-components.ts
@@ -29,6 +29,8 @@ export type ComponentDiscovery = {
   name: string;
   /** True when the component lives under `src/components/experimental/`. */
   isExperimental: boolean;
+  /** True when a `<name>.css` sidecar file exists in the component directory. */
+  hasCss: boolean;
 };
 
 /**
@@ -52,7 +54,8 @@ export async function discoverComponents(): Promise<ComponentDiscovery[]> {
         const directory = join(experimentalRoot, subEntry.name);
         if (!existsSync(join(directory, `${subEntry.name}.svelte`))) continue;
         if (!existsSync(join(directory, `${subEntry.name}.types.ts`))) continue;
-        result.push({ name: subEntry.name, isExperimental: true });
+        const hasCss = existsSync(join(directory, `${subEntry.name}.css`));
+        result.push({ name: subEntry.name, isExperimental: true, hasCss });
       }
       continue;
     }
@@ -60,7 +63,8 @@ export async function discoverComponents(): Promise<ComponentDiscovery[]> {
     const directory = join(COMPONENTS_ROOT, entry.name);
     if (!existsSync(join(directory, `${entry.name}.svelte`))) continue;
     if (!existsSync(join(directory, `${entry.name}.types.ts`))) continue;
-    result.push({ name: entry.name, isExperimental: false });
+    const hasCss = existsSync(join(directory, `${entry.name}.css`));
+    result.push({ name: entry.name, isExperimental: false, hasCss });
   }
   return result.toSorted((a, b) => {
     if (a.isExperimental !== b.isExperimental) return a.isExperimental ? 1 : -1;

--- a/packages/components/scripts/validate-consumers.ts
+++ b/packages/components/scripts/validate-consumers.ts
@@ -4,6 +4,8 @@ import { createServer } from 'node:net';
 import { dirname, join, resolve as resolvePath } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
+import postcss from 'postcss';
+
 import { discoverComponents } from './lib/discover-components.ts';
 import { isObjectRecord } from './validation-utilities.ts';
 
@@ -387,6 +389,47 @@ async function runSveltekitFixture(): Promise<void> {
       fail(`no built CSS contains @layer cinder — @layer declaration lost during bundling`);
     }
 
+    // À la carte CSS contract — AST assertions (no text grep).
+    //
+    // The /a-la-carte route imports only `cinder/button` + `cinder/button/styles`
+    // + tokens + foundation. Its route-scoped CSS must contain a button selector
+    // and a `--cinder-button-*` custom property, and must NOT leak any selector
+    // or custom property unique to the accordion component.
+    const aLaCarteCss = await readRouteCssArtifacts(
+      fixtureDirectory,
+      'src/routes/a-la-carte/+page.svelte',
+    );
+    if (!hasSelectorContaining(aLaCarteCss, '.cinder-button')) {
+      fail(`/a-la-carte route CSS missing .cinder-button selector (à la carte presence)`);
+    }
+    if (!hasCustomPropertyStartingWith(aLaCarteCss, '--cinder-button-')) {
+      fail(
+        `/a-la-carte route CSS missing any --cinder-button-* custom property (à la carte presence)`,
+      );
+    }
+    if (hasSelectorContaining(aLaCarteCss, '.cinder-accordion')) {
+      fail(`/a-la-carte route CSS leaked .cinder-accordion selector (à la carte absence)`);
+    }
+    if (hasCustomPropertyStartingWith(aLaCarteCss, '--cinder-accordion-')) {
+      fail(
+        `/a-la-carte route CSS leaked --cinder-accordion-* custom property (à la carte absence)`,
+      );
+    }
+
+    // No-styles import contract: the /no-styles route imports `cinder/button`
+    // only — no `/styles` subpath, no aggregator. Its route-scoped CSS must
+    // not contain button selectors. Proves component JS does not pull CSS as
+    // a side effect.
+    const noStylesCss = await readRouteCssArtifacts(
+      fixtureDirectory,
+      'src/routes/no-styles/+page.svelte',
+    );
+    if (hasSelectorContaining(noStylesCss, '.cinder-button')) {
+      fail(
+        `/no-styles route CSS contains .cinder-button — component JS pulled CSS as a side effect`,
+      );
+    }
+
     // Always-rendered components (not lazy-mount): their root class MUST appear in SSR HTML.
     // Modal, Dropdown, Tooltip are lazy-mount — they render only the trigger surface at open=false.
     const ALWAYS_RENDERED_CLASSES = [
@@ -461,6 +504,113 @@ async function runSveltekitFixture(): Promise<void> {
   } finally {
     restoreManifest();
   }
+}
+
+type CssArtifact = {
+  /** Absolute path to the CSS file. */
+  filePath: string;
+  /** Selector strings encountered at the top level of the AST (or inside @layer). */
+  selectors: string[];
+  /** Custom-property names declared anywhere in the file (e.g. `--cinder-button-bg`). */
+  customProperties: string[];
+};
+
+/**
+ * Find the CSS artifacts that belong to a specific route's chunk. SvelteKit
+ * emits per-page CSS chunks indexed by a generated wrapper at
+ * `.svelte-kit/generated/client-optimized/nodes/<N>.js`. We find the wrapper
+ * that re-exports our `+page.svelte` source, then look that wrapper up in
+ * Vite's client manifest at `.svelte-kit/output/client/.vite/manifest.json`
+ * and walk its CSS imports.
+ */
+async function readRouteCssArtifacts(
+  fixtureDirectory: string,
+  routeSourceRelative: string,
+): Promise<CssArtifact[]> {
+  const clientOutputDirectory = join(fixtureDirectory, '.svelte-kit/output/client');
+  const generatedNodesDirectory = join(
+    fixtureDirectory,
+    '.svelte-kit/generated/client-optimized/nodes',
+  );
+  const manifestPath = join(clientOutputDirectory, '.vite/manifest.json');
+  if (!existsSync(manifestPath)) {
+    fail(`Vite client manifest not found at ${manifestPath}`);
+  }
+  const manifest = JSON.parse(await Bun.file(manifestPath).text()) as Record<
+    string,
+    { css?: string[]; imports?: string[]; dynamicImports?: string[]; file?: string }
+  >;
+
+  // Find the generated node wrapper that re-exports the target route source.
+  let routeSource: string | null = null;
+  const wrapperGlob = new Glob('*.js');
+  for await (const wrapperPath of wrapperGlob.scan({
+    cwd: generatedNodesDirectory,
+    absolute: true,
+  })) {
+    const content = await Bun.file(wrapperPath).text();
+    if (content.includes(`/${routeSourceRelative}`)) {
+      // Normalize to the manifest key form (paths relative to fixtureDirectory).
+      const wrapperFileName = wrapperPath.slice(generatedNodesDirectory.length + 1);
+      routeSource = `.svelte-kit/generated/client-optimized/nodes/${wrapperFileName}`;
+      break;
+    }
+  }
+  if (routeSource === null) {
+    fail(`could not locate SvelteKit node wrapper for route ${routeSourceRelative}`);
+  }
+
+  const entry = manifest[routeSource];
+  if (!entry) {
+    fail(
+      `route wrapper ${routeSource} not in Vite manifest. Keys sample: ${Object.keys(manifest)
+        .slice(0, 8)
+        .join(', ')}`,
+    );
+  }
+  const cssAssets = new Set<string>();
+  const visited = new Set<string>();
+  const stack = [routeSource];
+  while (stack.length > 0) {
+    const next = stack.pop();
+    if (next === undefined || visited.has(next)) continue;
+    visited.add(next);
+    const node = manifest[next];
+    if (!node) continue;
+    for (const css of node.css ?? []) cssAssets.add(css);
+    for (const imp of node.imports ?? []) stack.push(imp);
+    for (const imp of node.dynamicImports ?? []) stack.push(imp);
+  }
+  if (cssAssets.size === 0) return [];
+  const artifacts: CssArtifact[] = [];
+  for (const relativePath of cssAssets) {
+    const filePath = join(clientOutputDirectory, relativePath);
+    if (!existsSync(filePath)) continue;
+    const source = await Bun.file(filePath).text();
+    const root_ = postcss.parse(source, { from: filePath });
+    const selectors: string[] = [];
+    const customProperties: string[] = [];
+    root_.walkRules((rule) => {
+      for (const selector of rule.selectors) selectors.push(selector);
+    });
+    root_.walkDecls((decl) => {
+      if (decl.prop.startsWith('--')) customProperties.push(decl.prop);
+    });
+    artifacts.push({ filePath, selectors, customProperties });
+  }
+  return artifacts;
+}
+
+function hasSelectorContaining(artifacts: CssArtifact[], fragment: string): boolean {
+  return artifacts.some((artifact) =>
+    artifact.selectors.some((selector) => selector.includes(fragment)),
+  );
+}
+
+function hasCustomPropertyStartingWith(artifacts: CssArtifact[], prefix: string): boolean {
+  return artifacts.some((artifact) =>
+    artifact.customProperties.some((property) => property.startsWith(prefix)),
+  );
 }
 
 async function readAllBuiltStylesheets(roots: string[]): Promise<string> {

--- a/packages/components/scripts/validate-consumers.ts
+++ b/packages/components/scripts/validate-consumers.ts
@@ -286,6 +286,38 @@ async function inspectTarball(): Promise<void> {
   if (leakedEntries.length) {
     fail(`Tarball contains forbidden entries:\n  ${leakedEntries.join('\n  ')}`);
   }
+
+  // Every published `*/styles` export must resolve to a real CSS artifact
+  // inside the tarball. `generate-exports.ts` gates emission on the source
+  // sidecar existing (`hasCss`), but that only proves the input — this is the
+  // post-build assertion that catches a CSS file silently dropped from the
+  // build output (e.g. a build step that skips a component, a `files`
+  // whitelist that omits the path).
+  const packageJsonPath = join(repositoryRoot, 'package.json');
+  const packageJsonContent = JSON.parse(await Bun.file(packageJsonPath).text()) as {
+    exports?: Record<string, { default?: string }>;
+  };
+  const stylesExports = Object.entries(packageJsonContent.exports ?? {}).filter(
+    ([key, entry]) =>
+      key.endsWith('/styles') && key !== './styles' && typeof entry.default === 'string',
+  );
+  const tarballEntrySet = new Set(entries);
+  const danglingStylesExports: string[] = [];
+  for (const [key, entry] of stylesExports) {
+    // package.json `default` paths are package-relative (`./dist/...`); npm
+    // pack rewrites tarball entries as `package/dist/...`.
+    const tarballEntry = `package/${entry.default!.replace(/^\.\//, '')}`;
+    if (!tarballEntrySet.has(tarballEntry)) {
+      danglingStylesExports.push(
+        `${key} -> ${entry.default} (expected tarball entry ${tarballEntry})`,
+      );
+    }
+  }
+  if (danglingStylesExports.length > 0) {
+    fail(
+      `Tarball is missing CSS artifacts for published /styles exports:\n  ${danglingStylesExports.join('\n  ')}`,
+    );
+  }
 }
 
 /** Allocate an ephemeral port so concurrent CI runs don't collide on a shared one.
@@ -449,6 +481,16 @@ async function runSveltekitFixture(): Promise<void> {
       );
     }
 
+    // Runtime-truth check (defends against hoisted shared CSS): the route
+    // walk above reads from the Vite client manifest, which can drift from
+    // what the runtime SvelteKit loader actually serves if Vite hoists CSS
+    // into a shared chunk. Below, after the fixture server is up, we ALSO
+    // fetch the rendered /no-styles HTML and assert no CSS file referenced
+    // via <link rel="stylesheet"> contains .cinder-button. That closes the
+    // loop: if any path — manifest, shared chunk, or otherwise — caused
+    // .cinder-button CSS to load on /no-styles, the runtime HTML would
+    // reference a stylesheet that contains it, and the check below fails.
+
     // Always-rendered components (not lazy-mount): their root class MUST appear in SSR HTML.
     // Modal, Dropdown, Tooltip are lazy-mount — they render only the trigger surface at open=false.
     const ALWAYS_RENDERED_CLASSES = [
@@ -515,6 +557,40 @@ async function runSveltekitFixture(): Promise<void> {
         if (!subpathBody.includes(cls)) {
           fail(`fixture HTML (/subpath) does not contain class "${cls}"`);
         }
+      }
+
+      // Runtime-truth check for the no-styles side-effect contract.
+      // Fetch the rendered /no-styles HTML, extract every stylesheet href,
+      // resolve it under the client build, and assert none of those CSS
+      // files contain `.cinder-button`. This is the strongest possible
+      // in-fixture assertion: if any path (manifest, shared chunk, server
+      // injection) caused button CSS to load on /no-styles, the runtime
+      // would reference a stylesheet that contains it.
+      const noStylesResponse = await fetch(`http://127.0.0.1:${httpPort}/no-styles`);
+      if (noStylesResponse.status !== 200) {
+        fail(`fixture /no-styles returned ${noStylesResponse.status}, want 200`);
+      }
+      const noStylesBody = await noStylesResponse.text();
+      const stylesheetHrefPattern =
+        /<link[^>]*\brel=["']stylesheet["'][^>]*\bhref=["']([^"']+)["']/g;
+      const clientOutputDirectory = join(fixtureDirectory, '.svelte-kit/output/client');
+      const offendingStylesheets: string[] = [];
+      for (const match of noStylesBody.matchAll(stylesheetHrefPattern)) {
+        const href = match[1]!;
+        // SvelteKit serves /_app/immutable/... — strip the leading slash to
+        // resolve under the client output directory.
+        const relativePath = href.replace(/^\//, '');
+        const cssFilePath = join(clientOutputDirectory, relativePath);
+        if (!existsSync(cssFilePath)) continue;
+        const source = await Bun.file(cssFilePath).text();
+        if (source.includes('.cinder-button') || /--cinder-button-/.test(source)) {
+          offendingStylesheets.push(`${href} contains .cinder-button or --cinder-button-*`);
+        }
+      }
+      if (offendingStylesheets.length > 0) {
+        fail(
+          `/no-styles rendered HTML references stylesheets that contain button CSS — component JS pulled CSS as a side effect:\n  ${offendingStylesheets.join('\n  ')}`,
+        );
       }
     } finally {
       fixtureServer.kill();

--- a/packages/components/scripts/validate-consumers.ts
+++ b/packages/components/scripts/validate-consumers.ts
@@ -571,18 +571,38 @@ async function runSveltekitFixture(): Promise<void> {
         fail(`fixture /no-styles returned ${noStylesResponse.status}, want 200`);
       }
       const noStylesBody = await noStylesResponse.text();
-      const stylesheetHrefPattern =
-        /<link[^>]*\brel=["']stylesheet["'][^>]*\bhref=["']([^"']+)["']/g;
-      const clientOutputDirectory = join(fixtureDirectory, '.svelte-kit/output/client');
+      // Match every <link> tag, then check attributes order-insensitively.
+      // SvelteKit can emit href before rel, and `rel` is a space-separated
+      // token list (`rel="preload stylesheet"`) — we must not miss stylesheets
+      // because of attribute ordering or compound rel values.
+      const linkTagPattern = /<link\b[^>]*>/gi;
+      const noStylesUrl = `http://127.0.0.1:${httpPort}/no-styles`;
+      const stylesheetHrefs: string[] = [];
+      for (const match of noStylesBody.matchAll(linkTagPattern)) {
+        const tag = match[0];
+        const relMatch = /\brel\s*=\s*["']([^"']+)["']/i.exec(tag);
+        if (!relMatch) continue;
+        const relTokens = relMatch[1]!.toLowerCase().split(/\s+/);
+        if (!relTokens.includes('stylesheet')) continue;
+        const hrefMatch = /\bhref\s*=\s*["']([^"']+)["']/i.exec(tag);
+        if (!hrefMatch) continue;
+        stylesheetHrefs.push(hrefMatch[1]!);
+      }
+      // Fetch each stylesheet through the running fixture server. The server
+      // is the source of truth for what /no-styles actually loads, and this
+      // avoids fragile on-disk path resolution (relative hrefs like
+      // `../_app/immutable/...` would otherwise resolve outside the client
+      // output directory and silently be skipped).
       const offendingStylesheets: string[] = [];
-      for (const match of noStylesBody.matchAll(stylesheetHrefPattern)) {
-        const href = match[1]!;
-        // SvelteKit serves /_app/immutable/... — strip the leading slash to
-        // resolve under the client output directory.
-        const relativePath = href.replace(/^\//, '');
-        const cssFilePath = join(clientOutputDirectory, relativePath);
-        if (!existsSync(cssFilePath)) continue;
-        const source = await Bun.file(cssFilePath).text();
+      for (const href of stylesheetHrefs) {
+        const stylesheetUrl = new URL(href, noStylesUrl).toString();
+        const stylesheetResponse = await fetch(stylesheetUrl);
+        if (stylesheetResponse.status !== 200) {
+          fail(
+            `/no-styles references stylesheet ${href} (resolved to ${stylesheetUrl}) which returned ${stylesheetResponse.status} — cannot verify the side-effect contract`,
+          );
+        }
+        const source = await stylesheetResponse.text();
         if (source.includes('.cinder-button') || /--cinder-button-/.test(source)) {
           offendingStylesheets.push(`${href} contains .cinder-button or --cinder-button-*`);
         }

--- a/packages/components/scripts/validate-consumers.ts
+++ b/packages/components/scripts/validate-consumers.ts
@@ -420,6 +420,17 @@ async function runSveltekitFixture(): Promise<void> {
     // only — no `/styles` subpath, no aggregator. Its route-scoped CSS must
     // not contain button selectors. Proves component JS does not pull CSS as
     // a side effect.
+    //
+    // Triangulation against false-positives (route walk silently broken):
+    //   1. The /a-la-carte assertion above proved the route-scoped walk DOES
+    //      surface .cinder-button when the route opts into the CSS.
+    //   2. The build-wide combinedStylesheet check above proved .cinder-button
+    //      exists somewhere in the client CSS output.
+    //   3. The walk below resolves the SvelteKit wrapper or fails loudly
+    //      (readRouteCssArtifacts calls fail() if the wrapper isn't found).
+    // Together these mean: a passing absence assertion below cannot be
+    // explained by a silently-empty walk — it can only mean the no-styles
+    // route legitimately has no transitive .cinder-button CSS.
     const noStylesCss = await readRouteCssArtifacts(
       fixtureDirectory,
       'src/routes/no-styles/+page.svelte',
@@ -427,6 +438,14 @@ async function runSveltekitFixture(): Promise<void> {
     if (hasSelectorContaining(noStylesCss, '.cinder-button')) {
       fail(
         `/no-styles route CSS contains .cinder-button — component JS pulled CSS as a side effect`,
+      );
+    }
+    // Also assert that any --cinder-button-* custom property is absent,
+    // catching the case where CSS leaks via custom-property declarations on
+    // a shared chunk even if no selector tokens match.
+    if (hasCustomPropertyStartingWith(noStylesCss, '--cinder-button-')) {
+      fail(
+        `/no-styles route CSS contains --cinder-button-* — component JS pulled CSS as a side effect`,
       );
     }
 

--- a/packages/components/src/exports-drift.test.ts
+++ b/packages/components/src/exports-drift.test.ts
@@ -81,8 +81,9 @@ describe('exports drift', () => {
 
     // Orphan entries — a key in package.json that doesn't match either a flat
     // component or a directory-shaped component.
+    const RESERVED = new Set(['.', './styles', './styles/tokens', './styles/foundation']);
     for (const key of Object.keys(existing)) {
-      if (key === '.' || key === './styles') continue;
+      if (RESERVED.has(key)) continue;
       if (key in expected) continue;
       issues.push(
         `Orphan export "${key}" has no matching component — run bun run exports:generate`,
@@ -97,6 +98,8 @@ describe('exports drift', () => {
     const exports = packageJson.exports as Record<string, unknown>;
     expect(exports['.']).toBeDefined();
     expect(exports['./styles']).toBeDefined();
+    expect(exports['./styles/tokens']).toBeDefined();
+    expect(exports['./styles/foundation']).toBeDefined();
   });
 
   test('no _internal components appear as export keys', async () => {

--- a/packages/playground/src/server.ts
+++ b/packages/playground/src/server.ts
@@ -448,7 +448,14 @@ const SHARED_BUILD_OPTIONS = {
   plugins: [sveltePlugin({ generate: 'client', injectCss: true })],
   target: 'browser',
   format: 'esm',
-  conditions: ['bun'],
+  // `svelte` falls back to source resolution for the `cinder` workspace
+  // package: its exports map advertises `svelte` and `types` conditions
+  // pointing at `./src/components/<name>/index.ts`, with no `bun`/`default`
+  // condition. Without this, examples authored as `import { Button } from
+  // 'cinder/button'` (the public consumer-facing form) fail to resolve at
+  // bundle time. `bun` stays first so cinder workspace internals can still
+  // declare bun-specific overrides if needed.
+  conditions: ['bun', 'svelte'],
   splitting: true,
   naming: {
     entry: '[name]-[hash].js',


### PR DESCRIPTION
## Summary

Track 5 of `/Users/stevekinney/.claude/plans/deep-riding-eclipse.md`. Per-component CSS subpath exports so consumers can import only the CSS they need.

- `cinder/<name>/styles` per-component CSS subpath exports emitted by `generate-exports.ts`, gated on the component shipping a source `<name>.css` sidecar (15 components without CSS correctly omitted)
- `cinder/styles/tokens`, `cinder/styles/foundation` preserved as reserved aggregator entries
- `docs/packaging.md` documents the conditional-exports resolution table and the two styles consumption modes (whole-system aggregator vs à la carte)
- AST-based à la carte CSS contract assertions in `validate-consumers.ts`: postcss walks of route-scoped CSS prove `.cinder-button` presence in `/a-la-carte`, absence of `.cinder-accordion`, and absence of any `--cinder-button-*` custom property on `/no-styles`
- Runtime-truth check: fetches the rendered `/no-styles` HTML from the fixture server, parses every `<link rel="stylesheet">` order-insensitively, and asserts no referenced stylesheet contains button CSS — closes the hoisted-shared-chunk gap
- Tarball check: `inspectTarball` asserts every published `*/styles` export resolves to a real CSS artifact inside the tarball, so a CSS file silently dropped from the build fails before publish

## Review committee

Pre-reviewed by:
- Codex (gpt-5.4, xhigh initial + high rounds 2-4) — 4 rounds, APPROVED on round 4
- 3 must-fix rounds addressed: docs/contract mismatch, dead `/styles` exports, weak `/no-styles` absence (round 2 strengthening), runtime-check attribute-ordering bug (round 3)

The subagent fan-out (typescript-expert / simplicity-engineer / ux-designer) was not dispatched because the Agent dispatch tool was unavailable in this subagent runtime; the Codex adversarial pass plus self-review through those lenses substituted. Recording this so the human reviewer can apply additional review at their discretion.

@copilot please review.

## Test plan

- [ ] `bun run --filter=cinder typecheck` — passes
- [ ] `bun run --filter=cinder lint` — passes
- [ ] `bun run exports:check` (from `packages/components`) — passes
- [ ] `bun run test` (from `packages/components`) — 2035 tests pass
- [ ] `bun run validate:consumer` step 4 (sveltekit-consumer) — passes including the new à la carte AST assertions and runtime `/no-styles` check
- [ ] Note: step 5 (node-consumer tsc) fails on pre-existing `@cinder/editor` + `@cinder/markdown` tsc errors that exist on `origin/main` and are not part of Track 5

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the published `exports` map and consumer validation/fixtures, so mistakes could break downstream imports or ship missing CSS artifacts. Changes are mostly additive and guarded by new build/tarball assertions, lowering the likelihood of silent regressions.
> 
> **Overview**
> Adds **per-component CSS sidecar exports** so consumers can import `cinder/<component>/styles` for tree-shakeable, layer-unwrapped CSS, while also exposing `cinder/styles/tokens` and `cinder/styles/foundation` as dedicated required aggregators for à la carte usage.
> 
> Updates the export-generation pipeline to emit `/styles` only for components that actually ship a source `*.css` sidecar, and expands consumer/tarball validation to ensure every published `/styles` export points at a real built artifact and that component JS imports do **not** pull CSS implicitly (via new SvelteKit fixture routes and AST/runtime checks).
> 
> Documents the packaging/exports contract and the two supported style-consumption modes in `docs/packaging.md`, and adjusts the playground Bun build conditions to include the `svelte` export condition for resolving `cinder/<component>` imports in workspace builds.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fe9db483168bf2052d910e4bcaec63dd42dc9e5b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->