### PR TITLE
docs(sidebar): tighten mobile aria-controls wiring guidance

### DIFF
--- a/packages/components/src/components/sidebar/sidebar.a11y.md
+++ b/packages/components/src/components/sidebar/sidebar.a11y.md
@@ -99,11 +99,15 @@ This wires the open/close affordance into the page chrome and keeps the
 trigger discoverable on mobile. On desktop the `id` lands on the `<aside>`.
 On mobile, once the drawer has hydrated, the same `id` lands on the
 persistent drawer `<dialog>` and resolves whether the drawer is open or
-closed. The drawer is gated on hydration, so the `id` is absent during SSR
-and the pre-hydration window — see [SSR behavior](#ssr-behavior) below. If
-you need the `aria-controls` relationship to exist from the very first
-paint, render the trigger conditionally on hydration; setting `collapsed`
-does not change when the drawer mounts.
+closed. Before hydration the drawer `<dialog>` is not in the DOM at all
+(drawer markup is gated on hydration), and the server renders the desktop
+branch by default — so on a mobile-width SSR response, `aria-controls`
+points at the desktop `<aside>` for one frame before the client swaps to
+the drawer `<dialog>`. The relationship resolves throughout, but the
+controlled element changes once on hydration — see
+[SSR behavior](#ssr-behavior) below. If you need `aria-controls` to point
+at the drawer from the very first paint, render the trigger conditionally
+on hydration; setting `collapsed` does not change when the drawer mounts.
 
 ## SSR behavior
 

--- a/packages/components/src/components/sidebar/sidebar.a11y.md
+++ b/packages/components/src/components/sidebar/sidebar.a11y.md
@@ -96,9 +96,14 @@ pattern is a hamburger button with `aria-controls` pointing at the sidebar and
 ```
 
 This wires the open/close affordance into the page chrome and keeps the
-trigger discoverable on mobile. On desktop, `id` lands on the `<aside>`; on
-mobile, the same `id` lands on the persistent drawer `<dialog>` so
-`aria-controls` still resolves while the drawer panel content is closed.
+trigger discoverable on mobile. On desktop the `id` lands on the `<aside>`.
+On mobile, once the drawer has hydrated, the same `id` lands on the
+persistent drawer `<dialog>` and resolves whether the drawer is open or
+closed. The drawer is gated on hydration, so the `id` is absent during SSR
+and the pre-hydration window — see [SSR behavior](#ssr-behavior) below. If
+you need the `aria-controls` relationship to exist from the very first
+paint, render the trigger conditionally on hydration; setting `collapsed`
+does not change when the drawer mounts.
 
 ## SSR behavior
 


### PR DESCRIPTION
## Summary

The Sidebar a11y notes claimed an unqualified \"`aria-controls` still resolves while the drawer panel content is closed\" because the `id` lands on the persistent drawer `<dialog>`. That's only true after hydration: `drawer.svelte:129` gates the entire `<dialog>` behind `{#if hydrated}`, and `sidebar.svelte:63` selects the mobile branch via a `MediaQuery` whose SSR fallback is `false`. During SSR and the pre-hydration window the `id` is either absent (server) or briefly resolves to the desktop `<aside>` before the swap.

Rewrites the trailing paragraph of the \"Wiring the mobile trigger\" subsection to:
- State the actual contract narrowly (desktop on `<aside>`, mobile on `<dialog>` post-hydration).
- Link to the existing \"SSR behavior\" section rather than restating it.
- Warn that setting `collapsed` does not advance when the drawer mounts and that consumers needing first-paint `aria-controls` resolution should render the trigger conditionally on hydration.

Resolves committee round 4 must-fix from the prior Sidebar review. Documentation-only — no code or test changes.

## Review committee

Pre-reviewed by:
- prose-editor — APPROVED round 1
- junior-engineer — APPROVED round 1 (verified every claim against `sidebar.svelte` and `drawer.svelte`)
- Codex (gpt-5.4, xhigh reasoning) — APPROVED round 1

1 round of review. No must-fix items raised.

## Test plan

- [x] `bun run lint` — clean
- [x] `bunx prettier --check packages/components/src/components/sidebar/sidebar.a11y.md` — passes
- [x] Read the rewritten subsection against `sidebar.svelte` (id forwarding at lines 85, 107) and `drawer.svelte:129` (`{#if hydrated}`).
- [x] Confirmed no unconditional \"still resolves while closed\" claim remains; SSR timing lives only in the \"SSR behavior\" section; the two subsections don't contradict.
- [ ] Existing test `sidebar.test.ts:365` (\"mobile id lands on the persistent drawer dialog for aria-controls\") covers the post-hydration runtime contract.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change that tightens guidance around `aria-controls` targeting during SSR and the hydration swap; no runtime logic is modified.
> 
> **Overview**
> Updates the Sidebar accessibility docs to more precisely describe how the `id`/`aria-controls` relationship behaves on mobile: the sidebar `id` targets the desktop `<aside>` on SSR/pre-hydration and then switches to the drawer `<dialog>` after hydration.
> 
> Adds an explicit warning about this one-time controlled-element change, links readers to the existing *SSR behavior* section, and recommends conditionally rendering the trigger on hydration if first-paint `aria-controls` must target the drawer.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b2edc51d560e8bdca9dcf95826433131583996df. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->