### PR TITLE
fix(selection-popover): collapse composer after Cmd/Ctrl+Enter submit

### DIFF
--- a/packages/components/src/components/selection-popover/selection-popover.svelte
+++ b/packages/components/src/components/selection-popover/selection-popover.svelte
@@ -124,7 +124,7 @@
       return;
     }
 
-    if ((event.key === 'Enter' || event.key === ' ') && !expanded) {
+    if ((event.key === 'Enter' || event.key === ' ') && !expanded && !event.defaultPrevented) {
       event.preventDefault();
       handleExpand();
     }

--- a/packages/components/src/components/selection-popover/selection-popover.test.ts
+++ b/packages/components/src/components/selection-popover/selection-popover.test.ts
@@ -98,41 +98,6 @@ describe('SelectionPopover', () => {
     expect(screen.getByRole('button', { name: 'Add comment' })).not.toBeNull();
   });
 
-  test('restores focus to the prior trigger after keyboard-activated submit', async () => {
-    const submitted: string[] = [];
-    const outside = document.createElement('button');
-    document.body.appendChild(outside);
-    outside.focus();
-
-    try {
-      render(SelectionPopover, {
-        props: {
-          id: 'selection-comment',
-          open: true,
-          position: { x: 120, y: 80 },
-          oncommentsubmit: (body: string) => submitted.push(body),
-        },
-      });
-
-      // Keyboard-activate the toolbar so handleExpand captures the external
-      // trigger as the focus-restore target. (A pointer click in a real
-      // browser would move focus to the icon button first, which is a
-      // separate code path.)
-      const toolbar = screen.getByRole('toolbar', { name: 'Selection actions' });
-      expect(document.activeElement).toBe(outside);
-      await fireEvent.keyDown(toolbar, { key: 'Enter' });
-
-      const textarea = screen.getByPlaceholderText('Add a comment...');
-      await fireEvent.input(textarea, { target: { value: 'Looks good.' } });
-      await fireEvent.keyDown(textarea, { key: 'Enter', metaKey: true });
-
-      expect(submitted).toEqual(['Looks good.']);
-      expect(document.activeElement).toBe(outside);
-    } finally {
-      outside.remove();
-    }
-  });
-
   test('Escape from the focused textarea cancels the composer', async () => {
     let canceled = false;
 

--- a/packages/components/src/components/selection-popover/selection-popover.test.ts
+++ b/packages/components/src/components/selection-popover/selection-popover.test.ts
@@ -81,49 +81,66 @@ describe('SelectionPopover', () => {
     document.body.appendChild(outside);
     outside.focus();
 
-    render(SelectionPopover, {
-      props: {
-        id: 'selection-comment',
-        open: true,
-        position: { x: 120, y: 80 },
-        oncommentsubmit: (body: string) => submitted.push(body),
-      },
-    });
+    try {
+      render(SelectionPopover, {
+        props: {
+          id: 'selection-comment',
+          open: true,
+          position: { x: 120, y: 80 },
+          oncommentsubmit: (body: string) => submitted.push(body),
+        },
+      });
 
-    await fireEvent.click(screen.getByRole('button', { name: 'Add comment' }));
-    const textarea = screen.getByPlaceholderText('Add a comment...');
-    await fireEvent.input(textarea, { target: { value: '  Looks good.  ' } });
-    await fireEvent.keyDown(textarea, { key: 'Enter', ...modifier });
+      // Sanity check: `outside` must still own focus at the moment of the
+      // click handler running, since handleExpand reads document.activeElement
+      // to remember where to restore focus after submit.
+      expect(document.activeElement).toBe(outside);
 
-    expect(submitted).toEqual(['Looks good.']);
-    expect(screen.queryByPlaceholderText('Add a comment...')).toBeNull();
-    expect(screen.getByRole('button', { name: 'Add comment' })).not.toBeNull();
-    expect(document.activeElement).toBe(outside);
+      await fireEvent.click(screen.getByRole('button', { name: 'Add comment' }));
+      const textarea = screen.getByPlaceholderText('Add a comment...');
+      await fireEvent.input(textarea, { target: { value: '  Looks good.  ' } });
+      await fireEvent.keyDown(textarea, { key: 'Enter', ...modifier });
 
-    outside.remove();
+      expect(submitted).toEqual(['Looks good.']);
+      expect(screen.queryByPlaceholderText('Add a comment...')).toBeNull();
+      expect(screen.getByRole('button', { name: 'Add comment' })).not.toBeNull();
+      expect(document.activeElement).toBe(outside);
+    } finally {
+      outside.remove();
+    }
   });
 
-  test('Escape from the focused textarea cancels the composer', async () => {
+  test('Escape from the focused textarea cancels the composer and restores focus', async () => {
     let canceled = false;
+    const outside = document.createElement('button');
+    document.body.appendChild(outside);
+    outside.focus();
 
-    render(SelectionPopover, {
-      props: {
-        id: 'selection-comment',
-        open: true,
-        position: { x: 120, y: 80 },
-        oncancel: () => {
-          canceled = true;
+    try {
+      render(SelectionPopover, {
+        props: {
+          id: 'selection-comment',
+          open: true,
+          position: { x: 120, y: 80 },
+          oncancel: () => {
+            canceled = true;
+          },
         },
-      },
-    });
+      });
 
-    await fireEvent.click(screen.getByRole('button', { name: 'Add comment' }));
-    const textarea = screen.getByPlaceholderText('Add a comment...');
-    textarea.focus();
-    await fireEvent.keyDown(textarea, { key: 'Escape' });
+      expect(document.activeElement).toBe(outside);
 
-    expect(canceled).toBe(true);
-    expect(screen.queryByPlaceholderText('Add a comment...')).toBeNull();
-    expect(screen.getByRole('button', { name: 'Add comment' })).not.toBeNull();
+      await fireEvent.click(screen.getByRole('button', { name: 'Add comment' }));
+      const textarea = screen.getByPlaceholderText('Add a comment...');
+      textarea.focus();
+      await fireEvent.keyDown(textarea, { key: 'Escape' });
+
+      expect(canceled).toBe(true);
+      expect(screen.queryByPlaceholderText('Add a comment...')).toBeNull();
+      expect(screen.getByRole('button', { name: 'Add comment' })).not.toBeNull();
+      expect(document.activeElement).toBe(outside);
+    } finally {
+      outside.remove();
+    }
   });
 });

--- a/packages/components/src/components/selection-popover/selection-popover.test.ts
+++ b/packages/components/src/components/selection-popover/selection-popover.test.ts
@@ -75,7 +75,30 @@ describe('SelectionPopover', () => {
   test.each([
     { label: 'Cmd+Enter', modifier: { metaKey: true } },
     { label: 'Ctrl+Enter', modifier: { ctrlKey: true } },
-  ])('$label submits, collapses, and restores focus to the prior trigger', async ({ modifier }) => {
+  ])('$label submits the comment and collapses the composer', async ({ modifier }) => {
+    const submitted: string[] = [];
+
+    render(SelectionPopover, {
+      props: {
+        id: 'selection-comment',
+        open: true,
+        position: { x: 120, y: 80 },
+        oncommentsubmit: (body: string) => submitted.push(body),
+      },
+    });
+
+    await fireEvent.click(screen.getByRole('button', { name: 'Add comment' }));
+    const textarea = screen.getByPlaceholderText('Add a comment...');
+    await fireEvent.input(textarea, { target: { value: '  Looks good.  ' } });
+    await fireEvent.keyDown(textarea, { key: 'Enter', ...modifier });
+
+    expect(submitted).toEqual(['Looks good.']);
+    // The composer must be unmounted, not merely "trigger present alongside form".
+    expect(screen.queryByPlaceholderText('Add a comment...')).toBeNull();
+    expect(screen.getByRole('button', { name: 'Add comment' })).not.toBeNull();
+  });
+
+  test('restores focus to the prior trigger after keyboard-activated submit', async () => {
     const submitted: string[] = [];
     const outside = document.createElement('button');
     document.body.appendChild(outside);
@@ -91,56 +114,46 @@ describe('SelectionPopover', () => {
         },
       });
 
-      // Sanity check: `outside` must still own focus at the moment of the
-      // click handler running, since handleExpand reads document.activeElement
-      // to remember where to restore focus after submit.
+      // Keyboard-activate the toolbar so handleExpand captures the external
+      // trigger as the focus-restore target. (A pointer click in a real
+      // browser would move focus to the icon button first, which is a
+      // separate code path.)
+      const toolbar = screen.getByRole('toolbar', { name: 'Selection actions' });
       expect(document.activeElement).toBe(outside);
+      await fireEvent.keyDown(toolbar, { key: 'Enter' });
 
-      await fireEvent.click(screen.getByRole('button', { name: 'Add comment' }));
       const textarea = screen.getByPlaceholderText('Add a comment...');
-      await fireEvent.input(textarea, { target: { value: '  Looks good.  ' } });
-      await fireEvent.keyDown(textarea, { key: 'Enter', ...modifier });
+      await fireEvent.input(textarea, { target: { value: 'Looks good.' } });
+      await fireEvent.keyDown(textarea, { key: 'Enter', metaKey: true });
 
       expect(submitted).toEqual(['Looks good.']);
-      expect(screen.queryByPlaceholderText('Add a comment...')).toBeNull();
-      expect(screen.getByRole('button', { name: 'Add comment' })).not.toBeNull();
       expect(document.activeElement).toBe(outside);
     } finally {
       outside.remove();
     }
   });
 
-  test('Escape from the focused textarea cancels the composer and restores focus', async () => {
+  test('Escape from the focused textarea cancels the composer', async () => {
     let canceled = false;
-    const outside = document.createElement('button');
-    document.body.appendChild(outside);
-    outside.focus();
 
-    try {
-      render(SelectionPopover, {
-        props: {
-          id: 'selection-comment',
-          open: true,
-          position: { x: 120, y: 80 },
-          oncancel: () => {
-            canceled = true;
-          },
+    render(SelectionPopover, {
+      props: {
+        id: 'selection-comment',
+        open: true,
+        position: { x: 120, y: 80 },
+        oncancel: () => {
+          canceled = true;
         },
-      });
+      },
+    });
 
-      expect(document.activeElement).toBe(outside);
+    await fireEvent.click(screen.getByRole('button', { name: 'Add comment' }));
+    const textarea = screen.getByPlaceholderText('Add a comment...');
+    textarea.focus();
+    await fireEvent.keyDown(textarea, { key: 'Escape' });
 
-      await fireEvent.click(screen.getByRole('button', { name: 'Add comment' }));
-      const textarea = screen.getByPlaceholderText('Add a comment...');
-      textarea.focus();
-      await fireEvent.keyDown(textarea, { key: 'Escape' });
-
-      expect(canceled).toBe(true);
-      expect(screen.queryByPlaceholderText('Add a comment...')).toBeNull();
-      expect(screen.getByRole('button', { name: 'Add comment' })).not.toBeNull();
-      expect(document.activeElement).toBe(outside);
-    } finally {
-      outside.remove();
-    }
+    expect(canceled).toBe(true);
+    expect(screen.queryByPlaceholderText('Add a comment...')).toBeNull();
+    expect(screen.getByRole('button', { name: 'Add comment' })).not.toBeNull();
   });
 });

--- a/packages/components/src/components/selection-popover/selection-popover.test.ts
+++ b/packages/components/src/components/selection-popover/selection-popover.test.ts
@@ -71,4 +71,59 @@ describe('SelectionPopover', () => {
     await fireEvent.keyDown(toolbar, { key: 'Escape' });
     expect(canceled).toBe(true);
   });
+
+  test.each([
+    { label: 'Cmd+Enter', modifier: { metaKey: true } },
+    { label: 'Ctrl+Enter', modifier: { ctrlKey: true } },
+  ])('$label submits, collapses, and restores focus to the prior trigger', async ({ modifier }) => {
+    const submitted: string[] = [];
+    const outside = document.createElement('button');
+    document.body.appendChild(outside);
+    outside.focus();
+
+    render(SelectionPopover, {
+      props: {
+        id: 'selection-comment',
+        open: true,
+        position: { x: 120, y: 80 },
+        oncommentsubmit: (body: string) => submitted.push(body),
+      },
+    });
+
+    await fireEvent.click(screen.getByRole('button', { name: 'Add comment' }));
+    const textarea = screen.getByPlaceholderText('Add a comment...');
+    await fireEvent.input(textarea, { target: { value: '  Looks good.  ' } });
+    await fireEvent.keyDown(textarea, { key: 'Enter', ...modifier });
+
+    expect(submitted).toEqual(['Looks good.']);
+    expect(screen.queryByPlaceholderText('Add a comment...')).toBeNull();
+    expect(screen.getByRole('button', { name: 'Add comment' })).not.toBeNull();
+    expect(document.activeElement).toBe(outside);
+
+    outside.remove();
+  });
+
+  test('Escape from the focused textarea cancels the composer', async () => {
+    let canceled = false;
+
+    render(SelectionPopover, {
+      props: {
+        id: 'selection-comment',
+        open: true,
+        position: { x: 120, y: 80 },
+        oncancel: () => {
+          canceled = true;
+        },
+      },
+    });
+
+    await fireEvent.click(screen.getByRole('button', { name: 'Add comment' }));
+    const textarea = screen.getByPlaceholderText('Add a comment...');
+    textarea.focus();
+    await fireEvent.keyDown(textarea, { key: 'Escape' });
+
+    expect(canceled).toBe(true);
+    expect(screen.queryByPlaceholderText('Add a comment...')).toBeNull();
+    expect(screen.getByRole('button', { name: 'Add comment' })).not.toBeNull();
+  });
 });

--- a/packages/playground/src/examples/selection-popover/keyboard.example.svelte
+++ b/packages/playground/src/examples/selection-popover/keyboard.example.svelte
@@ -1,0 +1,45 @@
+<script lang="ts" module>
+  export const title = 'Keyboard submit';
+  export const description =
+    'Press Cmd+Enter (or Ctrl+Enter) inside the composer to submit. The composer should collapse back to the icon after each submission.';
+</script>
+
+<script lang="ts">
+  import { SelectionPopover } from 'cinder/selection-popover';
+
+  let lastSubmitted = $state<string | null>(null);
+
+  function recordComment(body: string): void {
+    lastSubmitted = body;
+  }
+</script>
+
+<div style="position: relative; min-height: 9rem;">
+  <p style="max-width: 36rem; margin: 0;">
+    Open the composer, type a comment, and press <kbd>Cmd</kbd>+<kbd>Enter</kbd> (or
+    <kbd>Ctrl</kbd>+<kbd>Enter</kbd>) to submit. The popover should collapse back to the icon — if
+    it stays expanded, the keyboard-submit regression has returned.
+  </p>
+
+  <SelectionPopover
+    id="keyboard-selection-popover"
+    open
+    position={{ x: 180, y: 96 }}
+    oncommentsubmit={recordComment}
+  />
+
+  {#if lastSubmitted}
+    <section style="margin: 1rem 0 0;" aria-label="Last submitted">
+      <h3
+        style="margin: 0 0 0.5rem; font-size: var(--cinder-text-xs); font-weight: var(--cinder-font-medium); color: var(--cinder-text-muted); text-transform: uppercase; letter-spacing: 0.04em;"
+      >
+        Last submitted
+      </h3>
+      <article
+        style="padding: 0.5rem 0.75rem; border: 1px solid var(--cinder-border-muted); border-radius: var(--cinder-radius-sm); background: var(--cinder-surface);"
+      >
+        {lastSubmitted}
+      </article>
+    </section>
+  {/if}
+</div>

--- a/packages/playground/src/examples/selection-popover/keyboard.example.svelte
+++ b/packages/playground/src/examples/selection-popover/keyboard.example.svelte
@@ -1,7 +1,7 @@
 <script lang="ts" module>
   export const title = 'Keyboard submit';
   export const description =
-    'Press Cmd+Enter (or Ctrl+Enter) inside the composer to submit. The composer should collapse back to the icon after each submission.';
+    'Press Cmd+Enter (or Ctrl+Enter) inside the composer to submit. The composer collapses back to the icon after submission — the popover does not re-expand.';
 </script>
 
 <script lang="ts">
@@ -17,8 +17,8 @@
 <div style="position: relative; min-height: 9rem;">
   <p style="max-width: 36rem; margin: 0;">
     Open the composer, type a comment, and press <kbd>Cmd</kbd>+<kbd>Enter</kbd> (or
-    <kbd>Ctrl</kbd>+<kbd>Enter</kbd>) to submit. The popover should collapse back to the icon — if
-    it stays expanded, the keyboard-submit regression has returned.
+    <kbd>Ctrl</kbd>+<kbd>Enter</kbd>) to submit. The popover collapses back to the icon — it does
+    not stay expanded.
   </p>
 
   <SelectionPopover

--- a/packages/playground/src/examples/selection-popover/null-position.example.svelte
+++ b/packages/playground/src/examples/selection-popover/null-position.example.svelte
@@ -1,0 +1,49 @@
+<script lang="ts" module>
+  export const title = 'Null position clears the popover';
+  export const description =
+    'Setting position to null hides the popover even while open is true — verifies the consumer can clear an active selection without re-rendering the host.';
+</script>
+
+<script lang="ts">
+  import type { SelectionPopoverPosition } from 'cinder/selection-popover';
+  import { SelectionPopover } from 'cinder/selection-popover';
+
+  const initialPosition: SelectionPopoverPosition = { x: 220, y: 140 };
+  let position = $state<SelectionPopoverPosition | null>(initialPosition);
+
+  function clearPosition(): void {
+    position = null;
+  }
+
+  function restorePosition(): void {
+    position = initialPosition;
+  }
+</script>
+
+<div style="position: relative; min-height: 10rem;">
+  <div style="display: flex; gap: 0.5rem;">
+    <button
+      type="button"
+      onclick={clearPosition}
+      style="padding: 0.375rem 0.75rem; border: 1px solid var(--cinder-border); border-radius: var(--cinder-radius-sm); background: var(--cinder-surface); cursor: pointer;"
+    >
+      Clear position (set null)
+    </button>
+    <button
+      type="button"
+      onclick={restorePosition}
+      style="padding: 0.375rem 0.75rem; border: 1px solid var(--cinder-border); border-radius: var(--cinder-radius-sm); background: var(--cinder-surface); cursor: pointer;"
+    >
+      Restore position
+    </button>
+  </div>
+
+  <p style="max-width: 36rem; margin: 0.75rem 0 0;">
+    The popover starts open at a real position. Clicking <em>Clear position</em> sets
+    <code>position={'{null}'}</code>
+    while leaving <code>open</code> true — the popover should disappear because the component calls
+    <code>hidePopover()</code>. <em>Restore position</em> brings it back at the original coordinates.
+  </p>
+
+  <SelectionPopover id="null-position-selection-popover" open {position} />
+</div>

--- a/packages/playground/src/examples/selection-popover/toggled.example.svelte
+++ b/packages/playground/src/examples/selection-popover/toggled.example.svelte
@@ -7,7 +7,9 @@
 <script lang="ts">
   import { SelectionPopover } from 'cinder/selection-popover';
 
+  const popoverId = 'toggled-selection-popover';
   let isOpen = $state(false);
+  let lastSubmitted = $state<string | null>(null);
 
   function toggle(): void {
     isOpen = !isOpen;
@@ -16,11 +18,18 @@
   function handleClose(): void {
     isOpen = false;
   }
+
+  function handleSubmit(body: string): void {
+    lastSubmitted = body;
+    isOpen = false;
+  }
 </script>
 
 <div style="position: relative; min-height: 9rem;">
   <button
     type="button"
+    aria-expanded={isOpen}
+    aria-controls={popoverId}
     onclick={toggle}
     style="padding: 0.375rem 0.75rem; border: 1px solid var(--cinder-border); border-radius: var(--cinder-radius-sm); background: var(--cinder-surface); cursor: pointer;"
   >
@@ -34,9 +43,25 @@
   </p>
 
   <SelectionPopover
-    id="toggled-selection-popover"
+    id={popoverId}
     open={isOpen}
     position={{ x: 260, y: 140 }}
     onclose={handleClose}
+    oncommentsubmit={handleSubmit}
   />
+
+  {#if lastSubmitted}
+    <section style="margin: 1rem 0 0;" aria-label="Last submitted">
+      <h3
+        style="margin: 0 0 0.5rem; font-size: var(--cinder-text-xs); font-weight: var(--cinder-font-medium); color: var(--cinder-text-muted); text-transform: uppercase; letter-spacing: 0.04em;"
+      >
+        Last submitted
+      </h3>
+      <article
+        style="padding: 0.5rem 0.75rem; border: 1px solid var(--cinder-border-muted); border-radius: var(--cinder-radius-sm); background: var(--cinder-surface);"
+      >
+        {lastSubmitted}
+      </article>
+    </section>
+  {/if}
 </div>

--- a/packages/playground/src/examples/selection-popover/toggled.example.svelte
+++ b/packages/playground/src/examples/selection-popover/toggled.example.svelte
@@ -1,0 +1,42 @@
+<script lang="ts" module>
+  export const title = 'Toggled by an external trigger';
+  export const description =
+    'A button outside the popover toggles open. Closing fires onclose; focus restores to the trigger button.';
+</script>
+
+<script lang="ts">
+  import { SelectionPopover } from 'cinder/selection-popover';
+
+  let isOpen = $state(false);
+
+  function toggle(): void {
+    isOpen = !isOpen;
+  }
+
+  function handleClose(): void {
+    isOpen = false;
+  }
+</script>
+
+<div style="position: relative; min-height: 9rem;">
+  <button
+    type="button"
+    onclick={toggle}
+    style="padding: 0.375rem 0.75rem; border: 1px solid var(--cinder-border); border-radius: var(--cinder-radius-sm); background: var(--cinder-surface); cursor: pointer;"
+  >
+    {isOpen ? 'Hide popover' : 'Show popover'}
+  </button>
+
+  <p style="max-width: 36rem; margin: 0.75rem 0 0;">
+    Click the button to open the popover at a fixed position. Click anywhere outside the popover and
+    it closes (the consumer flips <code>open</code> to <code>false</code> from
+    <code>onclose</code>). Focus returns to the toggle button.
+  </p>
+
+  <SelectionPopover
+    id="toggled-selection-popover"
+    open={isOpen}
+    position={{ x: 260, y: 140 }}
+    onclose={handleClose}
+  />
+</div>

--- a/packages/playground/src/examples/selection-popover/toggled.example.svelte
+++ b/packages/playground/src/examples/selection-popover/toggled.example.svelte
@@ -1,7 +1,7 @@
 <script lang="ts" module>
   export const title = 'Toggled by an external trigger';
   export const description =
-    'A button outside the popover toggles open. Closing fires onclose; focus restores to the trigger button.';
+    'A button outside the popover drives `open`. When the consumer clicks outside the popover, the component invokes `onclose` and the consumer flips `open` back to `false`.';
 </script>
 
 <script lang="ts">
@@ -38,8 +38,8 @@
 
   <p style="max-width: 36rem; margin: 0.75rem 0 0;">
     Click the button to open the popover at a fixed position. Click anywhere outside the popover and
-    it closes (the consumer flips <code>open</code> to <code>false</code> from
-    <code>onclose</code>). Focus returns to the toggle button.
+    it closes — the component fires <code>onclose</code> and the consumer flips <code>open</code>
+    back to <code>false</code>.
   </p>
 
   <SelectionPopover

--- a/packages/playground/src/examples/selection-popover/viewport-clamping.example.svelte
+++ b/packages/playground/src/examples/selection-popover/viewport-clamping.example.svelte
@@ -1,0 +1,21 @@
+<script lang="ts" module>
+  export const title = 'Viewport clamping';
+  export const description =
+    'Manual exploratory coverage (not a CI gate). Three popovers requested at out-of-bounds positions — all three should land inside the 16px viewport margin.';
+</script>
+
+<script lang="ts">
+  import { SelectionPopover } from 'cinder/selection-popover';
+</script>
+
+<div style="position: relative; min-height: 12rem;">
+  <p style="max-width: 36rem; margin: 0;">
+    Each popover below is requested at a position that would put it off-screen. The component clamps
+    to a 16px viewport margin. Visually confirm all three are inside the viewport edges — this is a
+    human-eyeball check, not a CI assertion.
+  </p>
+
+  <SelectionPopover id="viewport-clamp-negative-x" open position={{ x: -100, y: 220 }} />
+  <SelectionPopover id="viewport-clamp-overflow-x" open position={{ x: 99999, y: 260 }} />
+  <SelectionPopover id="viewport-clamp-negative-y" open position={{ x: 480, y: -50 }} />
+</div>


### PR DESCRIPTION
## Summary

Pressing `Cmd+Enter` (or `Ctrl+Enter`) inside the comment composer submitted the comment but did not collapse the popover back to the icon — the form stayed visible while the textarea blanked.

**Root cause** (`packages/components/src/components/selection-popover/selection-popover.svelte:127`): `handleTextareaKeydown` calls `handleSubmit()` (which sets `expanded = false`) and `event.preventDefault()`, but the keydown still bubbles to the toolbar's `handleKeydown`. The outer handler's Enter/Space branch saw `expanded === false` (just set) and ran `handleExpand()`, immediately re-expanding the composer. The Escape branch on line 117 already checked `event.defaultPrevented`; the fix is to mirror that guard on the Enter/Space branch — a one-line change.

**Coverage added:**
- `selection-popover.test.ts`: `test.each` over `{ metaKey: true }` and `{ ctrlKey: true }` asserting submit + composer collapse. Verified the test rows fail against the unfixed component, then pass with the guard. Plus a guard test pinning that Escape from the focused textarea still cancels the composer (a contract Codex flagged at risk during plan-review).
- Four new `.example.svelte` files in `packages/playground/src/examples/selection-popover/` give the previously-unverifiable contracts (keyboard submit, viewport clamping, consumer-driven toggle, null-position transitions) inspectable surfaces. The playground server auto-discovers them via filename glob — no manifest edits.

## Review committee

Pre-reviewed by:
- testing-expert
- frontend-architect
- simplicity-engineer
- Codex (gpt-5.4, xhigh → high reasoning) — 4 rounds

4 rounds of review. Notable rounds:
- Round 1: testing-expert flagged a cleanup leak across `test.each` iterations (fixed via `try/finally`). frontend-architect flagged missing `aria-expanded` / `aria-controls` on the toggled example's button (added).
- Round 2: Codex correctly pointed out that focus-restoration assertions after `fireEvent.click` were testing a happy-dom artifact that real browsers wouldn't reproduce.
- Round 3: Codex further pointed out that re-routing the focus test through `fireEvent.keyDown` on the toolbar constructed an impossible browser state (events go to the focused element). The honest fix was to delete the focus-restoration test entirely — the component has no API-level mechanism for remembering an external trigger that opens it programmatically.
- Round 4: full consensus.

All must-fix items addressed. simplicity-engineer's deletion proposals for the additional playground examples were explicitly overridden by user instruction (the user asked for additional playgrounds to gain confidence in the documented contracts).

## Test plan

- `bun test packages/components/src/components/selection-popover` — 6 pass, 14 expect() calls. The modifier `test.each` rows fail against the unfixed component (regression-tied).
- `bun run lint`, `bun run typecheck`, `bun run format:check` — all clean.
- Browser: visit `/c/selection-popover`. Sidebar lists 5 examples (basic, keyboard, null-position, toggled, viewport-clamping).
  - `keyboard`: click trigger → type → Cmd+Enter → composer collapses (the regression check).
  - `toggled`: click "Show popover" → opens; click outside → closes and focus returns to toggle. Submit a comment → "Last submitted" updates.
  - `null-position`: clear position → popover disappears; restore → reappears.
  - `viewport-clamping`: all three popovers clamped inside the 16px viewport margin (manual exploratory; description explicitly states this is not a CI gate).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk behavioral fix limited to keyboard event handling, plus added tests and playground examples; main risk is small regression in Enter/Space handling if other handlers rely on bubbled keydown events.
> 
> **Overview**
> Fixes a keyboard interaction bug in `SelectionPopover` by guarding the toolbar’s Enter/Space handler with `!event.defaultPrevented`, preventing the composer from re-expanding immediately after a Cmd/Ctrl+Enter textarea submit.
> 
> Adds regression tests covering Cmd+Enter/Ctrl+Enter submit-and-collapse behavior and Escape-from-textarea cancel, and introduces new playground examples to manually validate keyboard submit, `position=null` hiding, consumer-controlled toggling via `open`, and viewport clamping.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 249c7f2b9826a9cbda1f3d440791f4dc2f6cac4c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->