### PR TITLE
feat(tokens): wrap shadow tokens in light-dark() for dark-mode elevation

### DIFF
--- a/docs/tokens.md
+++ b/docs/tokens.md
@@ -47,7 +47,7 @@ Shadow tokens wrap each color argument in `light-dark()` so dark mode paints a l
 | `--cinder-radius-md`   | `0.5rem`                                                                                                                                             |
 | `--cinder-radius-lg`   | `0.75rem`                                                                                                                                            |
 | `--cinder-radius-full` | `9999px`                                                                                                                                             |
-| `--cinder-shadow-sm`   | `0 1px 2px light-dark(oklch(0% 0 0 / 0.08), oklch(100% 0 0 / 0.04))`                                                                                 |
+| `--cinder-shadow-sm`   | `0 1px 2px light-dark(oklch(0% 0 0 / 0.08), oklch(100% 0 0 / 0.06))`                                                                                 |
 | `--cinder-shadow-md`   | `0 4px 6px -1px light-dark(oklch(0% 0 0 / 0.12), oklch(100% 0 0 / 0.06)), 0 2px 4px -2px light-dark(oklch(0% 0 0 / 0.1), oklch(100% 0 0 / 0.05))`    |
 | `--cinder-shadow-lg`   | `0 10px 15px -3px light-dark(oklch(0% 0 0 / 0.14), oklch(100% 0 0 / 0.08)), 0 4px 6px -4px light-dark(oklch(0% 0 0 / 0.12), oklch(100% 0 0 / 0.06))` |
 

--- a/docs/tokens.md
+++ b/docs/tokens.md
@@ -39,15 +39,17 @@ Rem-based spacing scale. Use these for padding, gap, margin — anywhere you'd o
 
 Corner radii and elevation shadows. `--cinder-radius-full` produces a pill or circle depending on the element's aspect ratio.
 
-| Token                  | Default                                                                      |
-| ---------------------- | ---------------------------------------------------------------------------- |
-| `--cinder-radius-sm`   | `0.375rem`                                                                   |
-| `--cinder-radius-md`   | `0.5rem`                                                                     |
-| `--cinder-radius-lg`   | `0.75rem`                                                                    |
-| `--cinder-radius-full` | `9999px`                                                                     |
-| `--cinder-shadow-sm`   | `0 1px 2px oklch(0% 0 0 / 0.08)`                                             |
-| `--cinder-shadow-md`   | `0 4px 6px -1px oklch(0% 0 0 / 0.12), 0 2px 4px -2px oklch(0% 0 0 / 0.1)`    |
-| `--cinder-shadow-lg`   | `0 10px 15px -3px oklch(0% 0 0 / 0.14), 0 4px 6px -4px oklch(0% 0 0 / 0.12)` |
+Shadow tokens wrap each color argument in `light-dark()` so dark mode paints a light-neutral elevation instead of invisible black-on-dark. The offsets, blur radii, spread radii, and layer counts are identical across themes; only the color values branch.
+
+| Token                  | Default                                                                                                                                              |
+| ---------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--cinder-radius-sm`   | `0.375rem`                                                                                                                                           |
+| `--cinder-radius-md`   | `0.5rem`                                                                                                                                             |
+| `--cinder-radius-lg`   | `0.75rem`                                                                                                                                            |
+| `--cinder-radius-full` | `9999px`                                                                                                                                             |
+| `--cinder-shadow-sm`   | `0 1px 2px light-dark(oklch(0% 0 0 / 0.08), oklch(100% 0 0 / 0.04))`                                                                                 |
+| `--cinder-shadow-md`   | `0 4px 6px -1px light-dark(oklch(0% 0 0 / 0.12), oklch(100% 0 0 / 0.06)), 0 2px 4px -2px light-dark(oklch(0% 0 0 / 0.1), oklch(100% 0 0 / 0.05))`    |
+| `--cinder-shadow-lg`   | `0 10px 15px -3px light-dark(oklch(0% 0 0 / 0.14), oklch(100% 0 0 / 0.08)), 0 4px 6px -4px light-dark(oklch(0% 0 0 / 0.12), oklch(100% 0 0 / 0.06))` |
 
 ## Control heights
 
@@ -105,19 +107,19 @@ Font stacks, type scale, line heights, letter spacing, and weights. The base fon
 
 Durations and easing curves. `--cinder-duration-normal` is an alias for `--cinder-duration` — both resolve to the same value. The `prefers-reduced-motion: reduce` media query collapses all durations to `0ms` automatically; you do not need to handle that case yourself.
 
-| Token                        | Default                        |
-| ---------------------------- | ------------------------------ |
-| `--cinder-duration-instant`  | `0ms`                          |
-| `--cinder-duration-fast`     | `120ms`                        |
-| `--cinder-duration`          | `200ms`                        |
-| `--cinder-duration-normal`   | `var(--cinder-duration)`       |
-| `--cinder-duration-moderate` | `280ms`                        |
-| `--cinder-duration-slow`     | `400ms`                        |
-| `--cinder-ease-standard`     | `cubic-bezier(0.2, 0, 0, 1)`   |
-| `--cinder-ease-decelerate`   | `cubic-bezier(0, 0, 0, 1)`     |
-| `--cinder-ease-accelerate`   | `cubic-bezier(0.3, 0, 1, 1)`   |
+| Token                        | Default                             |
+| ---------------------------- | ----------------------------------- |
+| `--cinder-duration-instant`  | `0ms`                               |
+| `--cinder-duration-fast`     | `120ms`                             |
+| `--cinder-duration`          | `200ms`                             |
+| `--cinder-duration-normal`   | `var(--cinder-duration)`            |
+| `--cinder-duration-moderate` | `280ms`                             |
+| `--cinder-duration-slow`     | `400ms`                             |
+| `--cinder-ease-standard`     | `cubic-bezier(0.2, 0, 0, 1)`        |
+| `--cinder-ease-decelerate`   | `cubic-bezier(0, 0, 0, 1)`          |
+| `--cinder-ease-accelerate`   | `cubic-bezier(0.3, 0, 1, 1)`        |
 | `--cinder-ease-spring`       | `cubic-bezier(0.34, 1.56, 0.64, 1)` |
-| `--cinder-ease-in-out`       | `cubic-bezier(0.4, 0, 0.2, 1)` |
+| `--cinder-ease-in-out`       | `cubic-bezier(0.4, 0, 0.2, 1)`      |
 
 ## Surfaces
 

--- a/packages/components/src/styles/tokens-base.css
+++ b/packages/components/src/styles/tokens-base.css
@@ -49,9 +49,20 @@
   --cinder-radius-lg: 0.75rem;
   --cinder-radius-full: 9999px;
 
-  --cinder-shadow-sm: 0 1px 2px oklch(0% 0 0 / 0.08);
-  --cinder-shadow-md: 0 4px 6px -1px oklch(0% 0 0 / 0.12), 0 2px 4px -2px oklch(0% 0 0 / 0.1);
-  --cinder-shadow-lg: 0 10px 15px -3px oklch(0% 0 0 / 0.14), 0 4px 6px -4px oklch(0% 0 0 / 0.12);
+  /* Shadows wrap each color argument in `light-dark()` so dark mode paints
+   * a light-neutral elevation instead of invisible black-on-dark. The light
+   * arguments preserve the original `oklch(0% 0 0 / α)` values exactly;
+   * the dark arguments use `oklch(100% 0 0 / α)` with subtle alphas tuned
+   * to lift the surface without producing a glow halo. Each shadow color
+   * is wrapped individually — the offsets, blur radii, spread radii, and
+   * layer counts are unchanged. */
+  --cinder-shadow-sm: 0 1px 2px light-dark(oklch(0% 0 0 / 0.08), oklch(100% 0 0 / 0.04));
+  --cinder-shadow-md:
+    0 4px 6px -1px light-dark(oklch(0% 0 0 / 0.12), oklch(100% 0 0 / 0.06)),
+    0 2px 4px -2px light-dark(oklch(0% 0 0 / 0.1), oklch(100% 0 0 / 0.05));
+  --cinder-shadow-lg:
+    0 10px 15px -3px light-dark(oklch(0% 0 0 / 0.14), oklch(100% 0 0 / 0.08)),
+    0 4px 6px -4px light-dark(oklch(0% 0 0 / 0.12), oklch(100% 0 0 / 0.06));
 
   /* ========================================
    * CONTROL HEIGHTS

--- a/packages/components/src/styles/tokens-base.css
+++ b/packages/components/src/styles/tokens-base.css
@@ -56,7 +56,7 @@
    * to lift the surface without producing a glow halo. Each shadow color
    * is wrapped individually — the offsets, blur radii, spread radii, and
    * layer counts are unchanged. */
-  --cinder-shadow-sm: 0 1px 2px light-dark(oklch(0% 0 0 / 0.08), oklch(100% 0 0 / 0.04));
+  --cinder-shadow-sm: 0 1px 2px light-dark(oklch(0% 0 0 / 0.08), oklch(100% 0 0 / 0.06));
   --cinder-shadow-md:
     0 4px 6px -1px light-dark(oklch(0% 0 0 / 0.12), oklch(100% 0 0 / 0.06)),
     0 2px 4px -2px light-dark(oklch(0% 0 0 / 0.1), oklch(100% 0 0 / 0.05));

--- a/packages/testing/tests/shadow-token-theme.playwright.ts
+++ b/packages/testing/tests/shadow-token-theme.playwright.ts
@@ -10,22 +10,25 @@
  * so the dark-mode variant uses a light-neutral OKLCH alpha that is
  * actually visible against the dark surface tokens.
  *
- * This test opens the basic card example in the playground and asserts
- * that `.cinder-card`:
- *   1. Has a non-`none` resolved `box-shadow` in light mode.
- *   2. Has a non-`none` resolved `box-shadow` in dark mode.
- *   3. Resolves to different `box-shadow` strings between light and dark.
- *   4. The dark-mode resolved color does not match the legacy black-only
- *      pattern (`rgba(0, 0, 0, *)` / `rgb(0, 0, 0)`).
+ * The test opens the basic card example, confirms the document advertises
+ * the correct `color-scheme` (the prerequisite for `light-dark()` to
+ * branch at all), and asserts that `.cinder-card`:
+ *   1. Has a non-`none` resolved `box-shadow` in both themes.
+ *   2. Resolves to different `box-shadow` strings between light and dark.
+ *
+ * The "different strings" assertion is the load-bearing one: if
+ * `light-dark()` did not branch (because `color-scheme` is misconfigured
+ * or the wrapping is wrong) the two computed values would match and the
+ * regression is back.
  */
 
 import { expect, test } from '@playwright/test';
 
-async function readCardBoxShadow(themedPage: import('@playwright/test').Page) {
+async function loadCard(themedPage: import('@playwright/test').Page) {
   await themedPage.goto('/page/card', { waitUntil: 'load' });
   const card = themedPage.locator('.cinder-card').first();
   await expect(card).toBeVisible();
-  return card.evaluate((element) => getComputedStyle(element).boxShadow);
+  return card;
 }
 
 test.describe('--cinder-shadow-* tokens', () => {
@@ -43,25 +46,37 @@ test.describe('--cinder-shadow-* tokens', () => {
       const lightPage = await lightContext.newPage();
       const darkPage = await darkContext.newPage();
 
-      const lightShadow = await readCardBoxShadow(lightPage);
-      const darkShadow = await readCardBoxShadow(darkPage);
+      const [lightCard, darkCard] = await Promise.all([loadCard(lightPage), loadCard(darkPage)]);
+
+      // `light-dark()` only branches when the document advertises a usable
+      // `color-scheme`. If this prerequisite is missing the rest of the
+      // test would pass vacuously, so check it explicitly.
+      const lightScheme = await lightPage.evaluate(
+        () => getComputedStyle(document.documentElement).colorScheme,
+      );
+      const darkScheme = await darkPage.evaluate(
+        () => getComputedStyle(document.documentElement).colorScheme,
+      );
+      expect(lightScheme).toMatch(/light/);
+      expect(darkScheme).toMatch(/dark/);
+
+      const [lightShadow, darkShadow] = await Promise.all([
+        lightCard.evaluate((element) => getComputedStyle(element).boxShadow),
+        darkCard.evaluate((element) => getComputedStyle(element).boxShadow),
+      ]);
 
       // Both themes must paint a real shadow.
       expect(lightShadow).not.toBe('none');
       expect(darkShadow).not.toBe('none');
 
       // Light and dark must resolve to different values; otherwise the
-      // `light-dark()` wrapping did not take effect.
+      // `light-dark()` wrapping did not take effect and the regression is
+      // back. This is the definitive assertion — string-matching on the
+      // resolved color is unreliable across browser versions (Chromium
+      // 111+ may serialize `oklch()` natively rather than normalizing to
+      // `rgb()`), so we trust the inequality and the explicit
+      // `color-scheme` check above.
       expect(lightShadow).not.toBe(darkShadow);
-
-      // Browsers normalize OKLCH to either `rgb()` or `rgba()`. The legacy
-      // bug was a black-only alpha — `rgba(0, 0, 0, α)` (or `rgb(0, 0, 0)`).
-      // Dark mode must not match that pattern.
-      const blackOnlyPattern = /rgba?\(\s*0\s*,\s*0\s*,\s*0\s*[,)]/i;
-      expect(darkShadow).not.toMatch(blackOnlyPattern);
-
-      // Light mode should preserve the original black-family color values.
-      expect(lightShadow).toMatch(blackOnlyPattern);
     } finally {
       await lightContext.close();
       await darkContext.close();

--- a/packages/testing/tests/shadow-token-theme.playwright.ts
+++ b/packages/testing/tests/shadow-token-theme.playwright.ts
@@ -1,0 +1,70 @@
+/// <reference lib="dom" />
+/**
+ * Regression test for the `--cinder-shadow-*` token family.
+ *
+ * The shadow tokens used to be defined with black-only OKLCH alphas
+ * (`oklch(0% 0 0 / α)`). In dark mode, painting black-on-dark hides the
+ * elevation entirely — cards on dark surfaces lose their lift.
+ *
+ * The fix wraps each shadow color in `light-dark(light-color, dark-color)`
+ * so the dark-mode variant uses a light-neutral OKLCH alpha that is
+ * actually visible against the dark surface tokens.
+ *
+ * This test opens the basic card example in the playground and asserts
+ * that `.cinder-card`:
+ *   1. Has a non-`none` resolved `box-shadow` in light mode.
+ *   2. Has a non-`none` resolved `box-shadow` in dark mode.
+ *   3. Resolves to different `box-shadow` strings between light and dark.
+ *   4. The dark-mode resolved color does not match the legacy black-only
+ *      pattern (`rgba(0, 0, 0, *)` / `rgb(0, 0, 0)`).
+ */
+
+import { expect, test } from '@playwright/test';
+
+async function readCardBoxShadow(themedPage: import('@playwright/test').Page) {
+  await themedPage.goto('/page/card', { waitUntil: 'load' });
+  const card = themedPage.locator('.cinder-card').first();
+  await expect(card).toBeVisible();
+  return card.evaluate((element) => getComputedStyle(element).boxShadow);
+}
+
+test.describe('--cinder-shadow-* tokens', () => {
+  test('resolve to visible, distinct shadows in light vs dark mode', async ({ browser }) => {
+    const lightContext = await browser.newContext({
+      colorScheme: 'light',
+      reducedMotion: 'reduce',
+    });
+    const darkContext = await browser.newContext({
+      colorScheme: 'dark',
+      reducedMotion: 'reduce',
+    });
+
+    try {
+      const lightPage = await lightContext.newPage();
+      const darkPage = await darkContext.newPage();
+
+      const lightShadow = await readCardBoxShadow(lightPage);
+      const darkShadow = await readCardBoxShadow(darkPage);
+
+      // Both themes must paint a real shadow.
+      expect(lightShadow).not.toBe('none');
+      expect(darkShadow).not.toBe('none');
+
+      // Light and dark must resolve to different values; otherwise the
+      // `light-dark()` wrapping did not take effect.
+      expect(lightShadow).not.toBe(darkShadow);
+
+      // Browsers normalize OKLCH to either `rgb()` or `rgba()`. The legacy
+      // bug was a black-only alpha — `rgba(0, 0, 0, α)` (or `rgb(0, 0, 0)`).
+      // Dark mode must not match that pattern.
+      const blackOnlyPattern = /rgba?\(\s*0\s*,\s*0\s*,\s*0\s*[,)]/i;
+      expect(darkShadow).not.toMatch(blackOnlyPattern);
+
+      // Light mode should preserve the original black-family color values.
+      expect(lightShadow).toMatch(blackOnlyPattern);
+    } finally {
+      await lightContext.close();
+      await darkContext.close();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

The `--cinder-shadow-sm/md/lg` tokens used black-only OKLCH alphas, which made elevated surfaces (cards) invisible in dark mode. Each shadow color argument is now wrapped in `light-dark(light, dark)`:

- **Light arguments** preserve the original `oklch(0% 0 0 / α)` values exactly.
- **Dark arguments** use `oklch(100% 0 0 / α)` with subtle alphas (0.06 / 0.06 + 0.05 / 0.08 + 0.06) tuned to lift the surface without producing a glow halo.
- Offsets, blur radii, spread radii, and layer counts are unchanged.
- Elevation ordering (sm < md < lg) is preserved in both themes.

Resolves task `92b80079-33f4-4c75-8ee9-2d27c0560a1f`.

### Scope

This PR is intentionally **token-only**, per the task plan's acceptance criterion #10. Today only `.cinder-card` consumes `--cinder-shadow-sm`. Modal, drawer, and sheet panels do not currently consume shadow tokens — their CSS is left untouched.

### Touched files

- `packages/components/src/styles/tokens-base.css` — wrap each shadow color argument in `light-dark()`.
- `docs/tokens.md` — update the shadow rows to match.
- `packages/testing/tests/shadow-token-theme.playwright.ts` — new Playwright regression test asserting that `.cinder-card` resolves to distinct, non-`none` box-shadow values in light vs dark contexts, with an explicit `getComputedStyle(document.documentElement).colorScheme` precondition so the inequality assertion can't pass vacuously.

### Follow-ups surfaced during review

- `packages/components/src/styles/components/experimental/popover.css` paints an inline `oklch(0% 0 0 / α)` shadow and inherits the same dark-mode invisibility bug. Not addressed here per the token-only scope authorization; file a follow-up to wrap it (or alias to `--cinder-shadow-md`).
- `packages/components/src/components/sortable-list/sortable-list.css` references `var(--cinder-shadow-elevated, …)` — `--cinder-shadow-elevated` is not defined anywhere, so the CSS silently falls back to a hardcoded black-only shadow in both themes. Follow-up: either add the token or rename the call site to `--cinder-shadow-md`.
- `docs/tokens.md` has a duplicate Scrollbar section (pre-existing).
- Dark-mode elevation occlusion: the current white-only shadow models a rim highlight, not occlusion. ux-designer recommends, when overlay panels adopt the tokens, exploring a two-layer shadow (white rim highlight + dark occlusion). Starting point for `sm`: secondary `0 1px 3px` layer at alpha 0.03.

## Review committee

Pre-reviewed by:
- `frontend-architect` (round 1 must-fix, round 2 APPROVED)
- `ux-designer` (round 1 must-fix, round 2 APPROVED)
- `testing-expert` (round 1 must-fix; must-fix addressed)
- `simplicity-engineer` (round 1 APPROVED)
- `prose-editor` (round 1 APPROVED)
- `Codex` (gpt-5.4, xhigh / high reasoning) — 2 rounds. Round 1 APPROVED. Round 2 raised a must-fix that misread the test source (claimed it used `document.documentElement.colorScheme` and suggested `getComputedStyle(...).colorScheme` as the fix — but the test already uses exactly that). Dismissed as not actionable.

2 rounds of review; all real must-fix items addressed or deferred to follow-up tasks per the plan's token-only scope.

## Test plan

- `bun run --filter=cinder lint` — exits 0.
- `bun run --filter=cinder typecheck` — exits 0.
- `bun run --filter=cinder test` — 2374 pass, 1 skip, 0 fail.
- The Playwright regression test (`shadow-token-theme.playwright.ts`) verifies that under emulated `colorScheme: 'light'` and `colorScheme: 'dark'` contexts the `.cinder-card` resolves to distinct, non-`none` box-shadow values, with an explicit precondition that the document advertises the expected `color-scheme`.
- Visual dark-mode screenshots for `card` should now show visible elevation — expect baseline updates via the `update-baselines` CI workflow.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core shadow design tokens, which can subtly alter visual elevation across all consumers and themes. Adds a Playwright regression test to reduce the chance of dark-mode shadow regressions due to misconfigured `color-scheme`/`light-dark()` branching.
> 
> **Overview**
> Updates the `--cinder-shadow-sm/md/lg` tokens to wrap each shadow color in `light-dark()` so dark mode uses a visible light-neutral shadow while keeping the same offsets/blur/layers as before.
> 
> Adds a Playwright regression test (`shadow-token-theme.playwright.ts`) that loads the card example under light/dark `colorScheme`, asserts `color-scheme` is set, and verifies `.cinder-card` resolves to non-`none` and **different** `box-shadow` values between themes. Documentation in `docs/tokens.md` is updated to match the new token definitions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f895c69aa77f4b0971ecc34a7470b292ef110062. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->