### PR TITLE
fix(tabs): skip disabled tabs during arrow-key navigation

### DIFF
--- a/packages/components/src/components/tab/tab.svelte
+++ b/packages/components/src/components/tab/tab.svelte
@@ -12,12 +12,16 @@
    * @avoidWhen Rendering a generic action button — use button instead.
    * @related tabs, tab-list, tab-panel
    */
+  // `Tab.value` is treated as immutable after mount. The component reads
+  // `value` via `untrack` inside both registration effects so that changing
+  // `value` at runtime does not re-key the parent registry. Mutating `value`
+  // after mount is unsupported and will leave the registry in a stale state.
   export type { TabProps } from './tab.types.ts';
 </script>
 
 <script lang="ts">
   import type { TabProps } from './tab.types.ts';
-  import { getContext } from 'svelte';
+  import { getContext, untrack } from 'svelte';
 
   import { rovingTabIndex } from '../../_internal/collection.ts';
   import { TABS_CONTEXT_KEY, type TabsContext } from '../tabs/tabs.svelte';
@@ -45,20 +49,36 @@
   const panelId = `cinder-tab-panel-${value}`;
 
   const isActive = $derived(tabs.isActive(value));
+  const isFocusable = $derived(tabs.isFocusable(value));
 
   let buttonElement: HTMLButtonElement | undefined = $state();
 
-  // Register on mount and re-register if the button element changes; unregister
-  // on unmount so the parent's navigation order stays accurate. The effect's
-  // cleanup function already handles unmount unregistration — no separate
-  // onDestroy is needed.
+  // Effect A — mount/unmount registration. Depends only on `buttonElement`.
+  // Everything else is read via `untrack`, including the registry mutation
+  // call: `tabs.register` writes to a reactive `version` counter, and reading
+  // that inside an effect would subscribe this effect to it and create a
+  // self-triggering loop.
   $effect(() => {
-    if (buttonElement) {
-      tabs.register(value, buttonElement);
-    }
+    if (!buttonElement) return;
+    const button = buttonElement;
+    untrack(() => {
+      tabs.register(value, button, disabled);
+    });
     return () => {
-      tabs.unregister(value);
+      untrack(() => {
+        tabs.unregister(value);
+      });
     };
+  });
+
+  // Effect B — sync `disabled` to the registry without re-registering.
+  // Subscribes only to `disabled`; the mutation call is wrapped in `untrack`
+  // for the same reason as Effect A.
+  $effect(() => {
+    const next = disabled;
+    untrack(() => {
+      tabs.setDisabled(value, next);
+    });
   });
 
   function handleClick(): void {
@@ -78,7 +98,7 @@
   data-cinder-disabled={disabled || undefined}
   aria-selected={isActive}
   aria-controls={panelId}
-  tabindex={rovingTabIndex(isActive)}
+  tabindex={rovingTabIndex(isFocusable)}
   {disabled}
   onclick={handleClick}
   onkeydown={tabs.handleKeydown}

--- a/packages/components/src/components/tab/tab.svelte
+++ b/packages/components/src/components/tab/tab.svelte
@@ -54,26 +54,32 @@
   let buttonElement: HTMLButtonElement | undefined = $state();
 
   // Effect A — mount/unmount registration. Depends only on `buttonElement`.
-  // Everything else is read via `untrack`, including the registry mutation
-  // call: `tabs.register` writes to a reactive `version` counter, and reading
-  // that inside an effect would subscribe this effect to it and create a
-  // self-triggering loop.
+  // The `value` read is captured once (via `untrack`) and reused in cleanup
+  // so unregister always targets the same key the registration used. The
+  // initial `disabled` is also seeded into the registry on mount so first
+  // paint computes the right tab stop without waiting for Effect B. The
+  // mutation calls themselves are wrapped in `untrack` because `register`
+  // and `unregister` write to a reactive `version` counter; reading that
+  // inside an effect would self-trigger.
   $effect(() => {
     if (!buttonElement) return;
     const button = buttonElement;
+    const registeredValue = untrack(() => value);
+    const initialDisabled = untrack(() => disabled);
     untrack(() => {
-      tabs.register(value, button, disabled);
+      tabs.register(registeredValue, button, initialDisabled);
     });
     return () => {
       untrack(() => {
-        tabs.unregister(value);
+        tabs.unregister(registeredValue);
       });
     };
   });
 
-  // Effect B — sync `disabled` to the registry without re-registering.
-  // Subscribes only to `disabled`; the mutation call is wrapped in `untrack`
-  // for the same reason as Effect A.
+  // Effect B — sync subsequent `disabled` prop changes to the registry
+  // without re-registering. Subscribes only to `disabled`; the mutation
+  // call is wrapped in `untrack` for the same reason as Effect A.
+  // `setDisabled` is a safe no-op when called before `register` has run.
   $effect(() => {
     const next = disabled;
     untrack(() => {

--- a/packages/components/src/components/tab/tab.svelte
+++ b/packages/components/src/components/tab/tab.svelte
@@ -53,10 +53,15 @@
 
   let buttonElement: HTMLButtonElement | undefined = $state();
 
+  // Capture the registry key once. `Tab.value` is treated as immutable after
+  // mount (see module-level note above); reading it via `untrack` here makes
+  // the immutability mechanical — even if a consumer mutates the prop, the
+  // registry keeps using the original key for register, setDisabled, and
+  // unregister, so the registry never drifts into an inconsistent state.
+  const registeredValue = untrack(() => value);
+
   // Effect A — mount/unmount registration. Depends only on `buttonElement`.
-  // The `value` read is captured once (via `untrack`) and reused in cleanup
-  // so unregister always targets the same key the registration used. The
-  // initial `disabled` is also seeded into the registry on mount so first
+  // The initial `disabled` is seeded into the registry on mount so first
   // paint computes the right tab stop without waiting for Effect B. The
   // mutation calls themselves are wrapped in `untrack` because `register`
   // and `unregister` write to a reactive `version` counter; reading that
@@ -64,7 +69,6 @@
   $effect(() => {
     if (!buttonElement) return;
     const button = buttonElement;
-    const registeredValue = untrack(() => value);
     const initialDisabled = untrack(() => disabled);
     untrack(() => {
       tabs.register(registeredValue, button, initialDisabled);
@@ -83,7 +87,7 @@
   $effect(() => {
     const next = disabled;
     untrack(() => {
-      tabs.setDisabled(value, next);
+      tabs.setDisabled(registeredValue, next);
     });
   });
 

--- a/packages/components/src/components/tabs/tabs.a11y.md
+++ b/packages/components/src/components/tabs/tabs.a11y.md
@@ -13,7 +13,9 @@
 
 ## Roving tabindex
 
-Per the WAI-ARIA pattern, only the currently-active tab sits in the tab order (`tabindex=0`); inactive tabs are reachable via arrow keys (`tabindex=-1`). The `rovingTabIndex` helper from `_internal/collection.ts` handles this.
+Per the WAI-ARIA pattern, only one tab sits in the tab order (`tabindex=0`); the rest are reachable via arrow keys (`tabindex=-1`). The selected tab takes that tab stop _when it is enabled_. If the selected tab is disabled — at mount, or because `disabled` toggled true after mount — the tab stop falls back to the first enabled tab in source order, so keyboard users always have a reachable entry point into the tablist. Selection (`aria-selected`) is preserved on the disabled tab; only the tab stop moves.
+
+When every tab is disabled, no tab carries `tabindex="0"`. The tablist is unreachable by keyboard in that state, which is the correct outcome: there is nothing actionable to focus.
 
 ## Keyboard
 
@@ -31,3 +33,11 @@ The horizontal default activates tabs as focus moves. Vertical orientation defau
 ## Orientation
 
 `Tabs` exposes orientation via context to `TabList` (which sets `aria-orientation`) and to its own keydown handler (which translates arrow keys to navigation intents per the orientation).
+
+## Disabled tabs
+
+Disabled tabs use the native HTML `disabled` attribute on the underlying `<button>`. That alone makes them non-focusable by Tab key and non-clickable. On top of that, the keyboard handler skips disabled tabs entirely during arrow-key, Home, and End navigation: pressing ArrowRight on a tab whose next sibling is disabled lands focus on the following enabled tab, wrapping past disabled tabs at the ends of the tablist. Enter and Space refuse to activate a focused disabled tab (a defensive guard — real browsers will not focus the button in the first place).
+
+If every tab in the tablist is disabled, the handler still calls `event.preventDefault()` on Arrow, Home, and End so the keypress does not leak into page scrolling. No focus changes occur.
+
+Consumers should avoid disabling the currently selected tab. If it happens, selection is preserved on the disabled tab (so the bound `value` does not change unexpectedly), but the tab stop moves to the first enabled tab so the tablist remains keyboard-reachable.

--- a/packages/components/src/components/tabs/tabs.svelte
+++ b/packages/components/src/components/tabs/tabs.svelte
@@ -22,7 +22,7 @@
   import type { TabsContext, TabsProps } from './tabs.types.ts';
   import { setContext } from 'svelte';
 
-  import { type Orientation, navigationIntent, nextIndex } from '../../_internal/collection.ts';
+  import { handleRovingKeydown } from '../../utilities/roving-tabindex.ts';
   import { cn } from '../../utilities/class-names.ts';
 
   let {
@@ -39,46 +39,97 @@
   // panel content too).
   const effectiveActivateOnFocus = $derived(activateOnFocus ?? orientation === 'horizontal');
 
-  /**
-   * Registry of tab buttons keyed by their `value`. Updated as Tab children
-   * mount and unmount. The order of registration determines the navigation
-   * order — children are registered in mount order, which is the same as
-   * source order in the template.
-   */
-  const buttons: Map<string, HTMLButtonElement> = new Map();
+  type RegistryEntry = { button: HTMLButtonElement; disabled: boolean };
 
-  function valuesInOrder(): string[] {
-    return [...buttons.keys()];
-  }
+  /**
+   * Registry of tab buttons keyed by their `value`. Order of registration
+   * determines navigation order — children register in mount order.
+   *
+   * In-place mutation of an entry's `disabled` field does not trigger Svelte
+   * reactivity on its own, so every mutation path also bumps `version`. Any
+   * `$derived` that reads from the registry must also read `version` to
+   * re-run when entries change.
+   */
+  const buttons: Map<string, RegistryEntry> = new Map();
+  let version = $state(0);
+
+  const focusableValue = $derived.by(() => {
+    void version;
+    for (const [registeredValue, entry] of buttons) {
+      if (!entry.disabled) return registeredValue;
+    }
+    return undefined;
+  });
 
   function focusValue(target: string): void {
-    const btn = buttons.get(target);
-    if (btn) btn.focus();
+    const entry = buttons.get(target);
+    if (entry) entry.button.focus();
   }
 
+  function resolveFocusedIndex(active: Element | null): number {
+    const entries = [...buttons.values()];
+    return entries.findIndex(({ button }) => button === active);
+  }
+
+  function resolveStartingIndex(event: KeyboardEvent): number {
+    const entries = [...buttons.values()];
+    if (entries.length === 0) return -1;
+    const target = event.currentTarget as HTMLElement | null;
+    const active = target?.ownerDocument.activeElement ?? null;
+    const focused = resolveFocusedIndex(active);
+    if (focused !== -1) return focused;
+    // Fallback: active tab if enabled, else first enabled.
+    const order = [...buttons.keys()];
+    const activeIdx = order.indexOf(value);
+    if (activeIdx !== -1 && !entries[activeIdx]!.disabled) return activeIdx;
+    return entries.findIndex((e) => !e.disabled);
+  }
+
+  const ROVING_KEYS = new Set(['ArrowLeft', 'ArrowRight', 'ArrowUp', 'ArrowDown', 'Home', 'End']);
+
   function handleKeydown(event: KeyboardEvent): void {
-    const intent = navigationIntent(event.key, orientation as Orientation);
-    if (!intent) {
-      // Manual activation: Enter/Space activates the focused tab.
-      if (event.key === 'Enter' || event.key === ' ') {
-        const target = event.target as HTMLElement | null;
-        const focusedValue = target?.dataset['cinderValue'];
-        if (focusedValue && buttons.has(focusedValue)) {
-          event.preventDefault();
-          value = focusedValue;
-        }
-      }
+    void version;
+    const entries = [...buttons.values()];
+    const order = [...buttons.keys()];
+
+    if (event.key === 'Enter' || event.key === ' ') {
+      // Manual activation: activate the focused tab if it is enabled.
+      const target = event.currentTarget as HTMLElement | null;
+      const active = target?.ownerDocument.activeElement ?? null;
+      const focused = resolveFocusedIndex(active);
+      if (focused === -1) return;
+      if (entries[focused]!.disabled) return;
+      const focusedValue = order[focused];
+      if (focusedValue === undefined) return;
+      event.preventDefault();
+      value = focusedValue;
       return;
     }
 
+    if (!ROVING_KEYS.has(event.key)) return;
+    if (entries.length === 0) return;
+
+    const currentIndex = resolveStartingIndex(event);
+    if (currentIndex === -1) {
+      // All entries disabled — prevent default so arrow/Home/End do not leak
+      // page scroll, but otherwise no-op.
+      event.preventDefault();
+      return;
+    }
+
+    const isHorizontal = orientation === 'horizontal';
+    const nextIdx = handleRovingKeydown(event, currentIndex, entries.length, {
+      isDisabled: (i) => entries[i]!.disabled,
+      horizontal: isHorizontal,
+      vertical: !isHorizontal,
+    });
+
+    if (nextIdx === null) return;
     event.preventDefault();
-    const order = valuesInOrder();
-    if (order.length === 0) return;
-    const currentIndex = order.indexOf(value);
-    const nextIdx = nextIndex(currentIndex === -1 ? 0 : currentIndex, order.length, intent);
+    if (nextIdx === currentIndex) return;
+
     const nextValue = order[nextIdx];
     if (nextValue === undefined) return;
-
     focusValue(nextValue);
     if (effectiveActivateOnFocus) {
       value = nextValue;
@@ -101,11 +152,41 @@
     isActive(candidate) {
       return value === candidate;
     },
-    register(target, button) {
-      buttons.set(target, button);
+    register(target, button, disabled = false) {
+      const existing = buttons.get(target);
+      if (existing) {
+        existing.button = button;
+        existing.disabled = disabled;
+      } else {
+        buttons.set(target, { button, disabled });
+      }
+      version += 1;
     },
     unregister(target) {
-      buttons.delete(target);
+      if (buttons.delete(target)) {
+        version += 1;
+      }
+    },
+    setDisabled(target, disabled) {
+      const existing = buttons.get(target);
+      if (!existing) return;
+      if (existing.disabled === disabled) return;
+      existing.disabled = disabled;
+      version += 1;
+    },
+    isFocusable(candidate) {
+      void version;
+      const entry = buttons.get(candidate);
+      if (!entry || entry.disabled) return false;
+      // The selected tab takes the tab stop when it is enabled.
+      if (value === candidate) return true;
+      // Otherwise, fall back to the first enabled tab — but only when the
+      // selected tab is disabled or unknown, so the tablist always has a
+      // reachable tab stop.
+      const selectedEntry = buttons.get(value);
+      const selectedFocusable = selectedEntry !== undefined && !selectedEntry.disabled;
+      if (selectedFocusable) return false;
+      return focusableValue === candidate;
     },
     handleKeydown,
   });

--- a/packages/components/src/components/tabs/tabs.svelte
+++ b/packages/components/src/components/tabs/tabs.svelte
@@ -23,7 +23,7 @@
   import { setContext } from 'svelte';
 
   import { handleRovingKeydown } from '../../utilities/roving-tabindex.ts';
-  import { cn } from '../../utilities/class-names.ts';
+  import { classNames } from '../../utilities/class-names.ts';
 
   let {
     value = $bindable(''),
@@ -71,34 +71,45 @@
     return entries.findIndex(({ button }) => button === active);
   }
 
+  function readActiveElement(event: KeyboardEvent): Element | null {
+    // Prefer the event target if it is itself a registered tab button —
+    // that is the most local, most reliable signal. Fall back to
+    // ownerDocument.activeElement when the target is not a tab (e.g., when
+    // the handler is attached at a higher level).
+    const target = event.target instanceof HTMLElement ? event.target : null;
+    if (target) {
+      for (const { button } of buttons.values()) {
+        if (button === target) return target;
+      }
+    }
+    const currentTarget = event.currentTarget instanceof HTMLElement ? event.currentTarget : null;
+    return currentTarget?.ownerDocument.activeElement ?? null;
+  }
+
   function resolveStartingIndex(event: KeyboardEvent): number {
     const entries = [...buttons.values()];
     if (entries.length === 0) return -1;
-    const target = event.currentTarget as HTMLElement | null;
-    const active = target?.ownerDocument.activeElement ?? null;
-    const focused = resolveFocusedIndex(active);
+    const focused = resolveFocusedIndex(readActiveElement(event));
     if (focused !== -1) return focused;
-    // Fallback: active tab if enabled, else first enabled.
+    // Fallback: active tab if enabled, else first enabled. Returns -1 only
+    // when every entry is disabled — the caller's guard handles that case.
     const order = [...buttons.keys()];
     const activeIdx = order.indexOf(value);
-    if (activeIdx !== -1 && !entries[activeIdx]!.disabled) return activeIdx;
-    return entries.findIndex((e) => !e.disabled);
+    if (activeIdx !== -1 && entries[activeIdx]?.disabled === false) return activeIdx;
+    return entries.findIndex((entry) => !entry.disabled);
   }
 
   const ROVING_KEYS = new Set(['ArrowLeft', 'ArrowRight', 'ArrowUp', 'ArrowDown', 'Home', 'End']);
 
   function handleKeydown(event: KeyboardEvent): void {
-    void version;
     const entries = [...buttons.values()];
     const order = [...buttons.keys()];
 
     if (event.key === 'Enter' || event.key === ' ') {
       // Manual activation: activate the focused tab if it is enabled.
-      const target = event.currentTarget as HTMLElement | null;
-      const active = target?.ownerDocument.activeElement ?? null;
-      const focused = resolveFocusedIndex(active);
+      const focused = resolveFocusedIndex(readActiveElement(event));
       if (focused === -1) return;
-      if (entries[focused]!.disabled) return;
+      if (entries[focused]?.disabled !== false) return;
       const focusedValue = order[focused];
       if (focusedValue === undefined) return;
       event.preventDefault();
@@ -119,7 +130,7 @@
 
     const isHorizontal = orientation === 'horizontal';
     const nextIdx = handleRovingKeydown(event, currentIndex, entries.length, {
-      isDisabled: (i) => entries[i]!.disabled,
+      isDisabled: (i) => entries[i]?.disabled ?? false,
       horizontal: isHorizontal,
       vertical: !isHorizontal,
     });
@@ -175,23 +186,25 @@
       version += 1;
     },
     isFocusable(candidate) {
+      // Force reads of every reactive input up front, regardless of which
+      // branch the predicate ultimately takes. The calling $derived in
+      // tab.svelte needs to subscribe to `value` AND `version` for any
+      // possible code path — early-returning before reading one of them
+      // would leave the derived under-subscribed and stale when only the
+      // unread input changes. Must be called inside a $derived/$effect.
+      void value;
       void version;
+      const selectedEntry = buttons.get(value);
+      const selectedIsEnabled = selectedEntry !== undefined && !selectedEntry.disabled;
       const entry = buttons.get(candidate);
       if (!entry || entry.disabled) return false;
-      // The selected tab takes the tab stop when it is enabled.
-      if (value === candidate) return true;
-      // Otherwise, fall back to the first enabled tab — but only when the
-      // selected tab is disabled or unknown, so the tablist always has a
-      // reachable tab stop.
-      const selectedEntry = buttons.get(value);
-      const selectedFocusable = selectedEntry !== undefined && !selectedEntry.disabled;
-      if (selectedFocusable) return false;
+      if (selectedIsEnabled) return value === candidate;
       return focusableValue === candidate;
     },
     handleKeydown,
   });
 </script>
 
-<div class={cn('cinder-tabs', className)} data-cinder-orientation={orientation}>
+<div class={classNames('cinder-tabs', className)} data-cinder-orientation={orientation}>
   {@render children()}
 </div>

--- a/packages/components/src/components/tabs/tabs.svelte
+++ b/packages/components/src/components/tabs/tabs.svelte
@@ -22,7 +22,7 @@
   import type { TabsContext, TabsProps } from './tabs.types.ts';
   import { setContext } from 'svelte';
 
-  import { handleRovingKeydown } from '../../utilities/roving-tabindex.ts';
+  import { handleRovingKeydown, isRovingKey } from '../../utilities/roving-tabindex.ts';
   import { classNames } from '../../utilities/class-names.ts';
 
   let {
@@ -95,11 +95,23 @@
     // when every entry is disabled — the caller's guard handles that case.
     const order = [...buttons.keys()];
     const activeIdx = order.indexOf(value);
-    if (activeIdx !== -1 && entries[activeIdx]?.disabled === false) return activeIdx;
+    if (activeIdx !== -1 && !entries[activeIdx]?.disabled) return activeIdx;
     return entries.findIndex((entry) => !entry.disabled);
   }
 
-  const ROVING_KEYS = new Set(['ArrowLeft', 'ArrowRight', 'ArrowUp', 'ArrowDown', 'Home', 'End']);
+  /**
+   * Whether the given key is one this orientation handles. Home/End are
+   * always relevant; Arrow keys are orientation-specific. Mirrors the
+   * `horizontal`/`vertical` filtering inside `handleRovingKeydown` so the
+   * all-disabled no-op path does not preventDefault on keys we would
+   * otherwise have let bubble (e.g., ArrowUp on a horizontal tablist).
+   */
+  function isOrientedKey(key: string, isHorizontal: boolean): boolean {
+    if (!isRovingKey(key)) return false;
+    if (key === 'Home' || key === 'End') return true;
+    if (isHorizontal) return key === 'ArrowLeft' || key === 'ArrowRight';
+    return key === 'ArrowUp' || key === 'ArrowDown';
+  }
 
   function handleKeydown(event: KeyboardEvent): void {
     const entries = [...buttons.values()];
@@ -117,7 +129,8 @@
       return;
     }
 
-    if (!ROVING_KEYS.has(event.key)) return;
+    const isHorizontal = orientation === 'horizontal';
+    if (!isOrientedKey(event.key, isHorizontal)) return;
     if (entries.length === 0) return;
 
     const currentIndex = resolveStartingIndex(event);
@@ -128,7 +141,6 @@
       return;
     }
 
-    const isHorizontal = orientation === 'horizontal';
     const nextIdx = handleRovingKeydown(event, currentIndex, entries.length, {
       isDisabled: (i) => entries[i]?.disabled ?? false,
       horizontal: isHorizontal,

--- a/packages/components/src/components/tabs/tabs.test.ts
+++ b/packages/components/src/components/tabs/tabs.test.ts
@@ -202,6 +202,10 @@ describe('Tabs keyboard navigation skips disabled tabs', () => {
     const tabs = Array.from(container.querySelectorAll('[role="tab"]'));
     expect(tabs[2]?.getAttribute('aria-selected')).toBe('true');
     expect(tabs[1]?.getAttribute('aria-selected')).toBe('false');
+    // Roving tabindex tracks the new selection.
+    expect(tabs[0]?.getAttribute('tabindex')).toBe('-1');
+    expect(tabs[1]?.getAttribute('tabindex')).toBe('-1');
+    expect(tabs[2]?.getAttribute('tabindex')).toBe('0');
     const panel = container.querySelector('[role="tabpanel"]');
     expect(panel?.textContent).toContain('C body');
   });
@@ -213,6 +217,9 @@ describe('Tabs keyboard navigation skips disabled tabs', () => {
     await fireEvent.keyDown(cTab, { key: 'ArrowLeft' });
     const tabs = Array.from(container.querySelectorAll('[role="tab"]'));
     expect(tabs[0]?.getAttribute('aria-selected')).toBe('true');
+    expect(tabs[0]?.getAttribute('tabindex')).toBe('0');
+    expect(tabs[1]?.getAttribute('tabindex')).toBe('-1');
+    expect(tabs[2]?.getAttribute('tabindex')).toBe('-1');
     const panel = container.querySelector('[role="tabpanel"]');
     expect(panel?.textContent).toContain('A body');
   });
@@ -287,6 +294,25 @@ describe('Tabs keyboard navigation skips disabled tabs', () => {
     expect(tabs[0]?.getAttribute('aria-selected')).toBe('true');
   });
 
+  test('vertical: ArrowDown wraps past a disabled boundary tab', async () => {
+    const items = [
+      { value: 'a', title: 'A tab', body: 'A body' },
+      { value: 'b', title: 'B tab', body: 'B body' },
+      { value: 'c', title: 'C tab', body: 'C body', disabled: true },
+    ];
+    const { container } = render(Wrapper, {
+      value: 'b',
+      orientation: 'vertical',
+      activateOnFocus: true,
+      items,
+    });
+    const bTab = Array.from(container.querySelectorAll('[role="tab"]'))[1] as HTMLElement;
+    bTab.focus();
+    await fireEvent.keyDown(bTab, { key: 'ArrowDown' });
+    const tabs = Array.from(container.querySelectorAll('[role="tab"]'));
+    expect(tabs[0]?.getAttribute('aria-selected')).toBe('true');
+  });
+
   test('all-disabled-except-one: arrow keys stay on the only enabled tab', async () => {
     const items = [
       { value: 'a', title: 'A tab', body: 'A body', disabled: true },
@@ -303,26 +329,34 @@ describe('Tabs keyboard navigation skips disabled tabs', () => {
     expect(tabs[1]?.getAttribute('aria-selected')).toBe('true');
   });
 
-  test('all-disabled: arrow keys are a no-op without exception', async () => {
+  test('all-disabled: arrow keys are a no-op and call preventDefault', async () => {
     const items = [
       { value: 'a', title: 'A tab', body: 'A body', disabled: true },
       { value: 'b', title: 'B tab', body: 'B body', disabled: true },
     ];
     const { container } = render(Wrapper, { value: 'a', items });
     const aTab = Array.from(container.querySelectorAll('[role="tab"]'))[0] as HTMLElement;
-    // Focus does not move to a native-disabled button, but the keydown
-    // handler still runs when synthesized.
-    await fireEvent.keyDown(aTab, { key: 'ArrowRight' });
-    await fireEvent.keyDown(aTab, { key: 'Home' });
-    await fireEvent.keyDown(aTab, { key: 'End' });
+    // Construct cancelable KeyboardEvents so we can assert `defaultPrevented`
+    // after dispatch. happy-dom respects preventDefault on these.
+    for (const key of ['ArrowRight', 'ArrowLeft', 'Home', 'End']) {
+      const event = new KeyboardEvent('keydown', { key, bubbles: true, cancelable: true });
+      aTab.dispatchEvent(event);
+      expect(event.defaultPrevented).toBe(true);
+    }
     const tabs = Array.from(container.querySelectorAll('[role="tab"]'));
-    // aria-selected remains on `a` (still the bound value).
+    // aria-selected remains on `a` (still the bound value); no tab gets tabindex=0.
     expect(tabs[0]?.getAttribute('aria-selected')).toBe('true');
     expect(tabs[1]?.getAttribute('aria-selected')).toBe('false');
+    expect(tabs[0]?.getAttribute('tabindex')).toBe('-1');
+    expect(tabs[1]?.getAttribute('tabindex')).toBe('-1');
   });
 
-  test('activateOnFocus: arrowing past a disabled tab activates the next enabled tab', async () => {
-    const { container } = render(Wrapper, { value: 'a', items: withDisabledMiddle });
+  test('activateOnFocus=true: arrowing past a disabled tab activates the next enabled tab', async () => {
+    const { container } = render(Wrapper, {
+      value: 'a',
+      activateOnFocus: true,
+      items: withDisabledMiddle,
+    });
     const aTab = Array.from(container.querySelectorAll('[role="tab"]'))[0] as HTMLElement;
     aTab.focus();
     await fireEvent.keyDown(aTab, { key: 'ArrowRight' });
@@ -331,6 +365,29 @@ describe('Tabs keyboard navigation skips disabled tabs', () => {
     expect(tabs[2]?.getAttribute('aria-selected')).toBe('true');
     const panel = container.querySelector('[role="tabpanel"]');
     expect(panel?.textContent).toContain('C body');
+  });
+
+  test('activateOnFocus=false: arrowing past a disabled tab moves focus but not selection', async () => {
+    const { container } = render(Wrapper, {
+      value: 'a',
+      orientation: 'vertical',
+      activateOnFocus: false,
+      items: withDisabledMiddle,
+    });
+    const aTab = Array.from(container.querySelectorAll('[role="tab"]'))[0] as HTMLElement;
+    aTab.focus();
+    await fireEvent.keyDown(aTab, { key: 'ArrowDown' });
+    // Focus moved past the disabled middle tab to C, but selection stays on A.
+    const tabs = Array.from(container.querySelectorAll('[role="tab"]'));
+    expect(tabs[0]?.getAttribute('aria-selected')).toBe('true');
+    expect(tabs[2]?.getAttribute('aria-selected')).toBe('false');
+    const cTab = tabs[2] as HTMLElement;
+    expect(cTab.ownerDocument.activeElement).toBe(cTab);
+    const panel = container.querySelector('[role="tabpanel"]');
+    expect(panel?.textContent).toContain('A body');
+    // Enter on the focused enabled tab activates it.
+    await fireEvent.keyDown(cTab, { key: 'Enter' });
+    expect(container.querySelector('[role="tabpanel"]')?.textContent).toContain('C body');
   });
 
   test('dynamic disable: toggling a tab to disabled makes arrows skip it', async () => {
@@ -379,16 +436,17 @@ describe('Tabs keyboard navigation skips disabled tabs', () => {
     expect(tabs[1]?.getAttribute('aria-selected')).toBe('true');
   });
 
-  test('Enter on a disabled tab does not change value (defensive unit test)', async () => {
-    // Real browsers do not focus native-disabled buttons; this is a defensive
-    // assertion that the activation guard runs if an Enter keydown is
-    // synthesized at a disabled tab.
+  test('Enter targeting a disabled tab does not change selection', async () => {
+    // Real browsers will not focus a native-disabled button, so this is an
+    // observable-output check, not a focus-handling drill. We dispatch Enter
+    // synthetically against the disabled tab's element to verify that under
+    // any synthetic path (manual dispatch, test harness, etc.), selection
+    // never lands on a disabled tab.
     const { container } = render(Wrapper, { value: 'a', items: withDisabledMiddle });
     const bTab = Array.from(container.querySelectorAll('[role="tab"]'))[1] as HTMLElement;
-    // happy-dom permits .focus() on disabled buttons; that is fine for this
-    // unit-level check.
     bTab.focus();
     await fireEvent.keyDown(bTab, { key: 'Enter' });
+    await fireEvent.keyDown(bTab, { key: ' ' });
     const tabs = Array.from(container.querySelectorAll('[role="tab"]'));
     expect(tabs[0]?.getAttribute('aria-selected')).toBe('true');
     expect(tabs[1]?.getAttribute('aria-selected')).toBe('false');

--- a/packages/components/src/components/tabs/tabs.test.ts
+++ b/packages/components/src/components/tabs/tabs.test.ts
@@ -329,6 +329,17 @@ describe('Tabs keyboard navigation skips disabled tabs', () => {
     expect(tabs[1]?.getAttribute('aria-selected')).toBe('true');
   });
 
+  test('horizontal: orientation-irrelevant ArrowUp/Down do not preventDefault', async () => {
+    const { container } = render(Wrapper, { value: 'a', items });
+    const aTab = Array.from(container.querySelectorAll('[role="tab"]'))[0] as HTMLElement;
+    aTab.focus();
+    for (const key of ['ArrowUp', 'ArrowDown']) {
+      const event = new KeyboardEvent('keydown', { key, bubbles: true, cancelable: true });
+      aTab.dispatchEvent(event);
+      expect(event.defaultPrevented).toBe(false);
+    }
+  });
+
   test('all-disabled: arrow keys are a no-op and call preventDefault', async () => {
     const items = [
       { value: 'a', title: 'A tab', body: 'A body', disabled: true },

--- a/packages/components/src/components/tabs/tabs.test.ts
+++ b/packages/components/src/components/tabs/tabs.test.ts
@@ -186,3 +186,264 @@ describe('Tabs keyboard navigation', () => {
     expect(panel?.textContent).toContain('B body');
   });
 });
+
+describe('Tabs keyboard navigation skips disabled tabs', () => {
+  const withDisabledMiddle = [
+    { value: 'a', title: 'A tab', body: 'A body' },
+    { value: 'b', title: 'B tab', body: 'B body', disabled: true },
+    { value: 'c', title: 'C tab', body: 'C body' },
+  ];
+
+  test('horizontal: ArrowRight skips a disabled middle tab', async () => {
+    const { container } = render(Wrapper, { value: 'a', items: withDisabledMiddle });
+    const aTab = Array.from(container.querySelectorAll('[role="tab"]'))[0] as HTMLElement;
+    aTab.focus();
+    await fireEvent.keyDown(aTab, { key: 'ArrowRight' });
+    const tabs = Array.from(container.querySelectorAll('[role="tab"]'));
+    expect(tabs[2]?.getAttribute('aria-selected')).toBe('true');
+    expect(tabs[1]?.getAttribute('aria-selected')).toBe('false');
+    const panel = container.querySelector('[role="tabpanel"]');
+    expect(panel?.textContent).toContain('C body');
+  });
+
+  test('horizontal: ArrowLeft skips a disabled middle tab', async () => {
+    const { container } = render(Wrapper, { value: 'c', items: withDisabledMiddle });
+    const cTab = Array.from(container.querySelectorAll('[role="tab"]'))[2] as HTMLElement;
+    cTab.focus();
+    await fireEvent.keyDown(cTab, { key: 'ArrowLeft' });
+    const tabs = Array.from(container.querySelectorAll('[role="tab"]'));
+    expect(tabs[0]?.getAttribute('aria-selected')).toBe('true');
+    const panel = container.querySelector('[role="tabpanel"]');
+    expect(panel?.textContent).toContain('A body');
+  });
+
+  test('vertical: ArrowDown skips a disabled middle tab', async () => {
+    const { container } = render(Wrapper, {
+      value: 'a',
+      orientation: 'vertical',
+      activateOnFocus: true,
+      items: withDisabledMiddle,
+    });
+    const aTab = Array.from(container.querySelectorAll('[role="tab"]'))[0] as HTMLElement;
+    aTab.focus();
+    await fireEvent.keyDown(aTab, { key: 'ArrowDown' });
+    const tabs = Array.from(container.querySelectorAll('[role="tab"]'));
+    expect(tabs[2]?.getAttribute('aria-selected')).toBe('true');
+  });
+
+  test('vertical: ArrowUp skips a disabled middle tab', async () => {
+    const { container } = render(Wrapper, {
+      value: 'c',
+      orientation: 'vertical',
+      activateOnFocus: true,
+      items: withDisabledMiddle,
+    });
+    const cTab = Array.from(container.querySelectorAll('[role="tab"]'))[2] as HTMLElement;
+    cTab.focus();
+    await fireEvent.keyDown(cTab, { key: 'ArrowUp' });
+    const tabs = Array.from(container.querySelectorAll('[role="tab"]'));
+    expect(tabs[0]?.getAttribute('aria-selected')).toBe('true');
+  });
+
+  test('Home skips a disabled leading tab to land on the first enabled', async () => {
+    const items = [
+      { value: 'a', title: 'A tab', body: 'A body', disabled: true },
+      { value: 'b', title: 'B tab', body: 'B body' },
+      { value: 'c', title: 'C tab', body: 'C body' },
+    ];
+    const { container } = render(Wrapper, { value: 'c', items });
+    const cTab = Array.from(container.querySelectorAll('[role="tab"]'))[2] as HTMLElement;
+    cTab.focus();
+    await fireEvent.keyDown(cTab, { key: 'Home' });
+    const tabs = Array.from(container.querySelectorAll('[role="tab"]'));
+    expect(tabs[1]?.getAttribute('aria-selected')).toBe('true');
+  });
+
+  test('End skips a disabled trailing tab to land on the last enabled', async () => {
+    const items = [
+      { value: 'a', title: 'A tab', body: 'A body' },
+      { value: 'b', title: 'B tab', body: 'B body' },
+      { value: 'c', title: 'C tab', body: 'C body', disabled: true },
+    ];
+    const { container } = render(Wrapper, { value: 'a', items });
+    const aTab = Array.from(container.querySelectorAll('[role="tab"]'))[0] as HTMLElement;
+    aTab.focus();
+    await fireEvent.keyDown(aTab, { key: 'End' });
+    const tabs = Array.from(container.querySelectorAll('[role="tab"]'));
+    expect(tabs[1]?.getAttribute('aria-selected')).toBe('true');
+  });
+
+  test('ArrowRight wraps past a disabled boundary tab', async () => {
+    const items = [
+      { value: 'a', title: 'A tab', body: 'A body' },
+      { value: 'b', title: 'B tab', body: 'B body' },
+      { value: 'c', title: 'C tab', body: 'C body', disabled: true },
+    ];
+    const { container } = render(Wrapper, { value: 'b', items });
+    const bTab = Array.from(container.querySelectorAll('[role="tab"]'))[1] as HTMLElement;
+    bTab.focus();
+    await fireEvent.keyDown(bTab, { key: 'ArrowRight' });
+    const tabs = Array.from(container.querySelectorAll('[role="tab"]'));
+    expect(tabs[0]?.getAttribute('aria-selected')).toBe('true');
+  });
+
+  test('all-disabled-except-one: arrow keys stay on the only enabled tab', async () => {
+    const items = [
+      { value: 'a', title: 'A tab', body: 'A body', disabled: true },
+      { value: 'b', title: 'B tab', body: 'B body' },
+      { value: 'c', title: 'C tab', body: 'C body', disabled: true },
+    ];
+    const { container } = render(Wrapper, { value: 'b', items });
+    const bTab = Array.from(container.querySelectorAll('[role="tab"]'))[1] as HTMLElement;
+    bTab.focus();
+    await fireEvent.keyDown(bTab, { key: 'ArrowRight' });
+    const tabs = Array.from(container.querySelectorAll('[role="tab"]'));
+    expect(tabs[1]?.getAttribute('aria-selected')).toBe('true');
+    await fireEvent.keyDown(bTab, { key: 'ArrowLeft' });
+    expect(tabs[1]?.getAttribute('aria-selected')).toBe('true');
+  });
+
+  test('all-disabled: arrow keys are a no-op without exception', async () => {
+    const items = [
+      { value: 'a', title: 'A tab', body: 'A body', disabled: true },
+      { value: 'b', title: 'B tab', body: 'B body', disabled: true },
+    ];
+    const { container } = render(Wrapper, { value: 'a', items });
+    const aTab = Array.from(container.querySelectorAll('[role="tab"]'))[0] as HTMLElement;
+    // Focus does not move to a native-disabled button, but the keydown
+    // handler still runs when synthesized.
+    await fireEvent.keyDown(aTab, { key: 'ArrowRight' });
+    await fireEvent.keyDown(aTab, { key: 'Home' });
+    await fireEvent.keyDown(aTab, { key: 'End' });
+    const tabs = Array.from(container.querySelectorAll('[role="tab"]'));
+    // aria-selected remains on `a` (still the bound value).
+    expect(tabs[0]?.getAttribute('aria-selected')).toBe('true');
+    expect(tabs[1]?.getAttribute('aria-selected')).toBe('false');
+  });
+
+  test('activateOnFocus: arrowing past a disabled tab activates the next enabled tab', async () => {
+    const { container } = render(Wrapper, { value: 'a', items: withDisabledMiddle });
+    const aTab = Array.from(container.querySelectorAll('[role="tab"]'))[0] as HTMLElement;
+    aTab.focus();
+    await fireEvent.keyDown(aTab, { key: 'ArrowRight' });
+    const tabs = Array.from(container.querySelectorAll('[role="tab"]'));
+    expect(tabs[1]?.getAttribute('aria-selected')).toBe('false');
+    expect(tabs[2]?.getAttribute('aria-selected')).toBe('true');
+    const panel = container.querySelector('[role="tabpanel"]');
+    expect(panel?.textContent).toContain('C body');
+  });
+
+  test('dynamic disable: toggling a tab to disabled makes arrows skip it', async () => {
+    const initialItems = [
+      { value: 'a', title: 'A tab', body: 'A body' },
+      { value: 'b', title: 'B tab', body: 'B body', disabled: false },
+      { value: 'c', title: 'C tab', body: 'C body' },
+    ];
+    const { container, rerender } = render(Wrapper, { value: 'a', items: initialItems });
+
+    // Initially, ArrowRight from A lands on B.
+    let aTab = Array.from(container.querySelectorAll('[role="tab"]'))[0] as HTMLElement;
+    aTab.focus();
+    await fireEvent.keyDown(aTab, { key: 'ArrowRight' });
+    let tabs = Array.from(container.querySelectorAll('[role="tab"]'));
+    expect(tabs[1]?.getAttribute('aria-selected')).toBe('true');
+
+    // Toggle B to disabled; ArrowRight from A should now skip B to C.
+    await rerender({
+      value: 'a',
+      items: [
+        { value: 'a', title: 'A tab', body: 'A body' },
+        { value: 'b', title: 'B tab', body: 'B body', disabled: true },
+        { value: 'c', title: 'C tab', body: 'C body' },
+      ],
+    });
+    aTab = Array.from(container.querySelectorAll('[role="tab"]'))[0] as HTMLElement;
+    aTab.focus();
+    await fireEvent.keyDown(aTab, { key: 'ArrowRight' });
+    tabs = Array.from(container.querySelectorAll('[role="tab"]'));
+    expect(tabs[2]?.getAttribute('aria-selected')).toBe('true');
+
+    // Toggle B back to enabled; ArrowRight from A lands on B again.
+    await rerender({
+      value: 'a',
+      items: [
+        { value: 'a', title: 'A tab', body: 'A body' },
+        { value: 'b', title: 'B tab', body: 'B body', disabled: false },
+        { value: 'c', title: 'C tab', body: 'C body' },
+      ],
+    });
+    aTab = Array.from(container.querySelectorAll('[role="tab"]'))[0] as HTMLElement;
+    aTab.focus();
+    await fireEvent.keyDown(aTab, { key: 'ArrowRight' });
+    tabs = Array.from(container.querySelectorAll('[role="tab"]'));
+    expect(tabs[1]?.getAttribute('aria-selected')).toBe('true');
+  });
+
+  test('Enter on a disabled tab does not change value (defensive unit test)', async () => {
+    // Real browsers do not focus native-disabled buttons; this is a defensive
+    // assertion that the activation guard runs if an Enter keydown is
+    // synthesized at a disabled tab.
+    const { container } = render(Wrapper, { value: 'a', items: withDisabledMiddle });
+    const bTab = Array.from(container.querySelectorAll('[role="tab"]'))[1] as HTMLElement;
+    // happy-dom permits .focus() on disabled buttons; that is fine for this
+    // unit-level check.
+    bTab.focus();
+    await fireEvent.keyDown(bTab, { key: 'Enter' });
+    const tabs = Array.from(container.querySelectorAll('[role="tab"]'));
+    expect(tabs[0]?.getAttribute('aria-selected')).toBe('true');
+    expect(tabs[1]?.getAttribute('aria-selected')).toBe('false');
+  });
+});
+
+describe('Tabs roving tabindex with disabled tabs', () => {
+  test('selected-disabled at mount: first enabled tab gets tabindex="0"', () => {
+    const items = [
+      { value: 'a', title: 'A tab', body: 'A body', disabled: true },
+      { value: 'b', title: 'B tab', body: 'B body' },
+      { value: 'c', title: 'C tab', body: 'C body' },
+    ];
+    const { container } = render(Wrapper, { value: 'a', items });
+    const tabs = Array.from(container.querySelectorAll('[role="tab"]'));
+    // `a` is selected but disabled, so the tab stop moves to the first enabled (`b`).
+    expect(tabs[0]?.getAttribute('aria-selected')).toBe('true');
+    expect(tabs[0]?.getAttribute('tabindex')).toBe('-1');
+    expect(tabs[1]?.getAttribute('tabindex')).toBe('0');
+    expect(tabs[2]?.getAttribute('tabindex')).toBe('-1');
+  });
+
+  test('selected tab becomes disabled: tabindex="0" moves to first enabled', async () => {
+    const initialItems = [
+      { value: 'a', title: 'A tab', body: 'A body' },
+      { value: 'b', title: 'B tab', body: 'B body' },
+      { value: 'c', title: 'C tab', body: 'C body' },
+    ];
+    const { container, rerender } = render(Wrapper, { value: 'a', items: initialItems });
+    let tabs = Array.from(container.querySelectorAll('[role="tab"]'));
+    expect(tabs[0]?.getAttribute('tabindex')).toBe('0');
+
+    await rerender({
+      value: 'a',
+      items: [
+        { value: 'a', title: 'A tab', body: 'A body', disabled: true },
+        { value: 'b', title: 'B tab', body: 'B body' },
+        { value: 'c', title: 'C tab', body: 'C body' },
+      ],
+    });
+    tabs = Array.from(container.querySelectorAll('[role="tab"]'));
+    // Selection preserved; tabindex moved.
+    expect(tabs[0]?.getAttribute('aria-selected')).toBe('true');
+    expect(tabs[0]?.getAttribute('tabindex')).toBe('-1');
+    expect(tabs[1]?.getAttribute('tabindex')).toBe('0');
+  });
+
+  test('all-disabled: no tab gets tabindex="0"', () => {
+    const items = [
+      { value: 'a', title: 'A tab', body: 'A body', disabled: true },
+      { value: 'b', title: 'B tab', body: 'B body', disabled: true },
+    ];
+    const { container } = render(Wrapper, { value: 'a', items });
+    const tabs = Array.from(container.querySelectorAll('[role="tab"]'));
+    expect(tabs[0]?.getAttribute('tabindex')).toBe('-1');
+    expect(tabs[1]?.getAttribute('tabindex')).toBe('-1');
+  });
+});

--- a/packages/components/src/components/tabs/tabs.types.ts
+++ b/packages/components/src/components/tabs/tabs.types.ts
@@ -7,7 +7,12 @@ export type TabsOrientation = 'horizontal' | 'vertical';
  * `register` lets each Tab announce itself to the parent during mount so
  * the parent can drive arrow-key navigation (focus management requires the
  * parent to know each tab's element). `unregister` removes the entry on
- * unmount.
+ * unmount. `setDisabled` lets a Tab sync its `disabled` prop to the parent
+ * registry without re-registering, preserving insertion order across
+ * disabled-state changes. `isFocusable` answers whether a given tab value
+ * should currently sit at `tabindex="0"` — selection and the tab stop are
+ * decoupled so that a selected-but-disabled tab does not strand the
+ * tablist with an unfocusable tab stop.
  */
 export type TabsContext = {
   readonly value: string;
@@ -15,8 +20,10 @@ export type TabsContext = {
   readonly activateOnFocus: boolean;
   select: (next: string) => void;
   isActive: (candidate: string) => boolean;
-  register: (value: string, button: HTMLButtonElement) => void;
+  register: (value: string, button: HTMLButtonElement, disabled?: boolean) => void;
   unregister: (value: string) => void;
+  setDisabled: (value: string, disabled: boolean) => void;
+  isFocusable: (candidate: string) => boolean;
   handleKeydown: (event: KeyboardEvent) => void;
 };
 export type TabsProps = {

--- a/packages/components/src/components/tabs/tabs.types.ts
+++ b/packages/components/src/components/tabs/tabs.types.ts
@@ -4,26 +4,48 @@ export type TabsOrientation = 'horizontal' | 'vertical';
 /**
  * Shape of the context object provided to Tab and TabPanel children.
  *
- * `register` lets each Tab announce itself to the parent during mount so
- * the parent can drive arrow-key navigation (focus management requires the
- * parent to know each tab's element). `unregister` removes the entry on
- * unmount. `setDisabled` lets a Tab sync its `disabled` prop to the parent
- * registry without re-registering, preserving insertion order across
- * disabled-state changes. `isFocusable` answers whether a given tab value
- * should currently sit at `tabindex="0"` — selection and the tab stop are
- * decoupled so that a selected-but-disabled tab does not strand the
- * tablist with an unfocusable tab stop.
+ * The contract is split between selection (the bound `value`, exposed via
+ * `select` and `isActive`) and roving-tabindex focus management (`register`,
+ * `unregister`, `setDisabled`, `isFocusable`). Decoupling lets a
+ * selected-but-disabled tab keep `aria-selected="true"` while the tab stop
+ * (`tabindex="0"`) shifts to the first enabled tab — so the tablist always
+ * has a reachable entry point.
  */
 export type TabsContext = {
+  /** The currently active tab value. */
   readonly value: string;
+  /** Layout orientation, forwarded to TabList for `aria-orientation`. */
   readonly orientation: TabsOrientation;
+  /** Whether focus movement also activates a tab (per WAI-ARIA pattern). */
   readonly activateOnFocus: boolean;
+  /** Activate a tab by value. */
   select: (next: string) => void;
+  /** True when `candidate` is the active tab. */
   isActive: (candidate: string) => boolean;
+  /**
+   * Announce a tab to the parent registry on mount. Registry order is the
+   * navigation order. Re-registering an existing value updates its button
+   * reference in place; insertion order is preserved. The `disabled` argument
+   * seeds the registry entry's initial state so first paint reflects the
+   * tab's current `disabled` prop without waiting for `setDisabled` to run.
+   */
   register: (value: string, button: HTMLButtonElement, disabled?: boolean) => void;
+  /** Remove a tab from the registry on unmount. */
   unregister: (value: string) => void;
+  /**
+   * Sync the disabled state for a registered tab. Safe no-op when called
+   * before `register` has run (e.g., during the first paint of a Tab whose
+   * disabled-sync effect fires before its registration effect).
+   */
   setDisabled: (value: string, disabled: boolean) => void;
+  /**
+   * Whether `candidate` should currently hold `tabindex="0"`. Reads
+   * reactive registry state, so callers MUST invoke this inside a
+   * `$derived` or `$effect` to stay current — a plain assignment captures
+   * a stale snapshot.
+   */
   isFocusable: (candidate: string) => boolean;
+  /** Tab buttons forward `keydown` here for shared arrow-key navigation. */
   handleKeydown: (event: KeyboardEvent) => void;
 };
 export type TabsProps = {


### PR DESCRIPTION
## Summary

Disabled tabs were reachable via Arrow/Home/End even though they couldn't be activated. Per the WAI-ARIA tabs pattern (and the behavior already shipped in `SegmentedControl`), arrow-key navigation now skips disabled tabs entirely.

- Switch `tabs.svelte` from the simple `nextIndex` helper to the existing `handleRovingKeydown` utility — skip-on-disabled and Home/End handling are built in, no new abstraction.
- Decouple roving tabindex from selection. When the selected tab is disabled (at mount or dynamically), `aria-selected` stays put but `tabindex="0"` moves to the first enabled tab so the tablist remains keyboard-reachable. New `TabsContext.isFocusable` predicate + `setDisabled` method handle this.
- Parent registry now tracks `{ button, disabled }` per tab, with a reactive `version` counter so derived focus state re-derives when entries mutate in place. `tab.svelte` effects use `untrack` around mutation calls to prevent self-triggering, and capture `registeredValue` once at component scope so register/setDisabled/unregister all target the same immutable key.
- All-disabled tablist is a no-op that `preventDefault`s only the orientation-relevant navigation keys (Arrow/Home/End for the active orientation) so unrelated keys still bubble.
- 16 new regression tests: middle/leading/trailing skips, vertical wrap, all-disabled no-op (with `defaultPrevented` assertions), orientation-irrelevant arrow non-prevention, dynamic disable/re-enable, Enter+Space disabled-tab guard, and `tabindex` shifts when the selected tab becomes disabled.

Touches: `packages/components/src/components/tab/tab.svelte`, `tabs.svelte`, `tabs.types.ts`, `tabs.test.ts`, `tabs.a11y.md`.

## Review committee

Pre-reviewed by: frontend-architect, testing-expert, typescript-expert, simplicity-engineer, ux-designer, junior-engineer
- Codex (gpt-5.4, xhigh reasoning) — 3 rounds
- 3 rounds of review
- All must-fix items addressed; final round 3 explicit APPROVED from frontend-architect and Codex

## Test plan

- [x] `bun test src/components/tabs` (packages/components) — 33 pass, 0 fail
- [x] Full `@cinder/components` test suite — 2392 pass, 1 pre-existing skip, 0 fail
- [x] `bunx svelte-check` — 0 errors
- [x] `bun run lint` (monorepo) — 0 warnings, 0 errors
- [ ] Visual spot-check in playground with leading/middle/trailing disabled tabs (manual)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates core `Tabs` keyboard/roving-tabindex behavior and context contract, which could affect focus management and accessibility edge cases across consumers.
> 
> **Overview**
> Disabled tabs are no longer reachable via Arrow/Home/End navigation; `Tabs` now uses the shared `handleRovingKeydown` logic and explicitly guards Enter/Space activation so disabled tabs can’t be selected via synthetic key events.
> 
> Roving tabindex is decoupled from selection: when the selected tab is disabled (at mount or after toggling), `aria-selected` stays on the selected value but `tabindex="0"` moves to the first enabled tab (or to none when all are disabled). This adds `TabsContext.setDisabled` and `TabsContext.isFocusable`, updates the internal registry to track `{ button, disabled }` with a reactive `version`, and updates `Tab` registration/sync effects (using `untrack`) to keep the registry consistent.
> 
> Accessibility docs are updated and extensive new tests cover skip/wrap behavior, all-disabled no-op + `preventDefault`, dynamic disable/reenable, and `tabindex` shifting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b41d7228a21fa8150e48d8a47f5ee62fa4f422b6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->