### PR TITLE
fix(tabs): skip disabled tabs during keyboard navigation

### DIFF
--- a/.changeset/tabs-disabled-keyboard-skip.md
+++ b/.changeset/tabs-disabled-keyboard-skip.md
@@ -1,0 +1,5 @@
+---
+'cinder': patch
+---
+
+`<Tabs>` now skips disabled tabs during keyboard navigation, in line with the WAI-ARIA tabs pattern. Arrow keys, Home, and End walk only over enabled tabs; an all-disabled tablist is a no-op. The `TabsContext` exposes a new `setDisabled(value, disabled)` method that `<Tab>` calls via a dedicated effect, so toggling `disabled` at runtime preserves the navigation order rather than re-inserting the tab at the end of the registry.

--- a/.changeset/tabs-disabled-keyboard-skip.md
+++ b/.changeset/tabs-disabled-keyboard-skip.md
@@ -1,5 +1,5 @@
 ---
-'cinder': patch
+'cinder': minor
 ---
 
 `<Tabs>` now skips disabled tabs during keyboard navigation, in line with the WAI-ARIA tabs pattern. Arrow keys, Home, and End walk only over enabled tabs; an all-disabled tablist is a no-op. The `TabsContext` exposes a new `setDisabled(value, disabled)` method that `<Tab>` calls via a dedicated effect, so toggling `disabled` at runtime preserves the navigation order rather than re-inserting the tab at the end of the registry.

--- a/packages/components/src/components/tab/tab.svelte
+++ b/packages/components/src/components/tab/tab.svelte
@@ -41,29 +41,35 @@
 
   let buttonElement: HTMLButtonElement | undefined = $state();
 
-  // Register on mount and re-register if the button element changes; unregister
-  // on unmount so the parent's navigation order stays accurate. This effect
-  // intentionally does NOT read `disabled` — toggling the disabled flag must
-  // not cleanup+re-register, because that would move the tab to the end of the
-  // parent's Map insertion order (which is the navigation order). The
-  // separate effect below syncs disabled state through `setDisabled`.
+  // Register the tab once when its button element becomes defined and
+  // unregister on unmount. `value` is treated as stable for this tab's
+  // lifetime (it is the identity key used by the parent's Map and the
+  // recommended key for keyed `{#each}` blocks); reading it via `untrack`
+  // ensures that a sibling prop change (e.g., `disabled` toggling) on the
+  // same render pass cannot cause Svelte to re-trigger this effect, which
+  // would delete and re-insert this tab's key in the parent's Map and
+  // move it to the end of the navigation order. If a consumer needs to
+  // change a Tab's `value` at runtime they should remount the Tab via a
+  // changed key in their `{#each}` block.
   $effect(() => {
-    // Track only `buttonElement` becoming defined; read `value` without
-    // tracking so toggling sibling props that share a render pass cannot
-    // trigger a cleanup+re-register cycle (which would re-insert this
-    // tab's key at the end of the parent's Map and corrupt nav order).
     if (!buttonElement) return;
     const currentValue = untrack(() => value);
-    tabs.register(currentValue, buttonElement);
+    const currentButton = buttonElement;
+    tabs.register(currentValue, currentButton);
     return () => {
       tabs.unregister(currentValue);
     };
   });
 
   // Sync disabled state without touching the registry, so flipping `disabled`
-  // at runtime preserves navigation order.
+  // at runtime preserves navigation order. The cleanup clears the disabled
+  // flag explicitly so this effect owns the lifecycle of the disabled bit
+  // and stops relying on `unregister`'s incidental cleanup for that.
   $effect(() => {
     tabs.setDisabled(value, disabled);
+    return () => {
+      tabs.setDisabled(value, false);
+    };
   });
 
   function handleClick(): void {

--- a/packages/components/src/components/tab/tab.svelte
+++ b/packages/components/src/components/tab/tab.svelte
@@ -17,20 +17,13 @@
 
 <script lang="ts">
   import type { TabProps } from './tab.types.ts';
-  import { getContext } from 'svelte';
+  import { getContext, untrack } from 'svelte';
 
   import { rovingTabIndex } from '../../_internal/collection.ts';
   import { TABS_CONTEXT_KEY, type TabsContext } from '../tabs/tabs.svelte';
   import { classNames } from '../../utilities/class-names.ts';
 
-  let {
-    value,
-    id,
-    disabled = false,
-    class: className,
-    children,
-    trailing,
-  }: TabProps = $props();
+  let { value, id, disabled = false, class: className, children, trailing }: TabProps = $props();
 
   const rawTabs = getContext<TabsContext | undefined>(TABS_CONTEXT_KEY);
   if (!rawTabs) {
@@ -49,16 +42,28 @@
   let buttonElement: HTMLButtonElement | undefined = $state();
 
   // Register on mount and re-register if the button element changes; unregister
-  // on unmount so the parent's navigation order stays accurate. The effect's
-  // cleanup function already handles unmount unregistration — no separate
-  // onDestroy is needed.
+  // on unmount so the parent's navigation order stays accurate. This effect
+  // intentionally does NOT read `disabled` — toggling the disabled flag must
+  // not cleanup+re-register, because that would move the tab to the end of the
+  // parent's Map insertion order (which is the navigation order). The
+  // separate effect below syncs disabled state through `setDisabled`.
   $effect(() => {
-    if (buttonElement) {
-      tabs.register(value, buttonElement);
-    }
+    // Track only `buttonElement` becoming defined; read `value` without
+    // tracking so toggling sibling props that share a render pass cannot
+    // trigger a cleanup+re-register cycle (which would re-insert this
+    // tab's key at the end of the parent's Map and corrupt nav order).
+    if (!buttonElement) return;
+    const currentValue = untrack(() => value);
+    tabs.register(currentValue, buttonElement);
     return () => {
-      tabs.unregister(value);
+      tabs.unregister(currentValue);
     };
+  });
+
+  // Sync disabled state without touching the registry, so flipping `disabled`
+  // at runtime preserves navigation order.
+  $effect(() => {
+    tabs.setDisabled(value, disabled);
   });
 
   function handleClick(): void {

--- a/packages/components/src/components/tabs/tabs.svelte
+++ b/packages/components/src/components/tabs/tabs.svelte
@@ -97,21 +97,30 @@
     } else {
       const target = event.target as HTMLElement | null;
       const focusedValue = target?.dataset['cinderValue'];
-      const anchor =
-        focusedValue && order.includes(focusedValue)
-          ? focusedValue
-          : order.includes(value)
-            ? value
-            : undefined;
-      const anchorIndex = anchor === undefined ? 0 : order.indexOf(anchor);
-      const nextIdx = nextIndex(anchorIndex, order.length, intent);
-      nextValue = order[nextIdx];
+      let anchorIndex = -1;
+      if (focusedValue && order.includes(focusedValue)) {
+        anchorIndex = order.indexOf(focusedValue);
+      } else if (order.includes(value)) {
+        anchorIndex = order.indexOf(value);
+      }
+      if (anchorIndex === -1) {
+        // No usable anchor (keydown came from somewhere unregistered and the
+        // controlled value isn't enabled either). Land on a deterministic
+        // edge: first enabled for forward, last enabled for backward — same
+        // shape Home/End would produce.
+        nextValue = intent === 'next' ? order[0] : order[order.length - 1];
+      } else {
+        const nextIdx = nextIndex(anchorIndex, order.length, intent);
+        nextValue = order[nextIdx];
+      }
     }
 
     if (nextValue === undefined) return;
 
     focusValue(nextValue);
-    if (effectiveActivateOnFocus && !disabledValues.has(nextValue)) {
+    if (effectiveActivateOnFocus) {
+      // `nextValue` is drawn from `enabledValuesInOrder()` so it is always
+      // enabled — no second disabled check needed here.
       value = nextValue;
     }
   }

--- a/packages/components/src/components/tabs/tabs.svelte
+++ b/packages/components/src/components/tabs/tabs.svelte
@@ -44,11 +44,17 @@
    * mount and unmount. The order of registration determines the navigation
    * order — children are registered in mount order, which is the same as
    * source order in the template.
+   *
+   * `disabledValues` is intentionally separate from `buttons`: deleting and
+   * re-inserting a Map key moves it to the end of iteration order, which
+   * would silently corrupt navigation order whenever a Tab's `disabled`
+   * prop toggled. `setDisabled` only mutates this set.
    */
   const buttons: Map<string, HTMLButtonElement> = new Map();
+  const disabledValues: Set<string> = new Set();
 
-  function valuesInOrder(): string[] {
-    return [...buttons.keys()];
+  function enabledValuesInOrder(): string[] {
+    return [...buttons.keys()].filter((candidate) => !disabledValues.has(candidate));
   }
 
   function focusValue(target: string): void {
@@ -59,11 +65,14 @@
   function handleKeydown(event: KeyboardEvent): void {
     const intent = navigationIntent(event.key, orientation as Orientation);
     if (!intent) {
-      // Manual activation: Enter/Space activates the focused tab.
+      // Manual activation: Enter/Space activates the focused tab, but only
+      // if its value is registered and not disabled. Native `disabled`
+      // <button> elements cannot receive focus, so this guard is
+      // defense-in-depth against future internal regressions.
       if (event.key === 'Enter' || event.key === ' ') {
         const target = event.target as HTMLElement | null;
         const focusedValue = target?.dataset['cinderValue'];
-        if (focusedValue && buttons.has(focusedValue)) {
+        if (focusedValue && buttons.has(focusedValue) && !disabledValues.has(focusedValue)) {
           event.preventDefault();
           value = focusedValue;
         }
@@ -72,15 +81,37 @@
     }
 
     event.preventDefault();
-    const order = valuesInOrder();
+    const order = enabledValuesInOrder();
     if (order.length === 0) return;
-    const currentIndex = order.indexOf(value);
-    const nextIdx = nextIndex(currentIndex === -1 ? 0 : currentIndex, order.length, intent);
-    const nextValue = order[nextIdx];
+
+    // Home/End bypass adjacency and pick the first/last enabled tab
+    // directly. Arrow keys step from the user's focused tab when it is
+    // enabled, falling back to the controlled `value` when the keydown
+    // came from somewhere other than a registered enabled tab. Disabled
+    // values never seed navigation — disabled buttons are not focusable.
+    let nextValue: string | undefined;
+    if (intent === 'first') {
+      nextValue = order[0];
+    } else if (intent === 'last') {
+      nextValue = order[order.length - 1];
+    } else {
+      const target = event.target as HTMLElement | null;
+      const focusedValue = target?.dataset['cinderValue'];
+      const anchor =
+        focusedValue && order.includes(focusedValue)
+          ? focusedValue
+          : order.includes(value)
+            ? value
+            : undefined;
+      const anchorIndex = anchor === undefined ? 0 : order.indexOf(anchor);
+      const nextIdx = nextIndex(anchorIndex, order.length, intent);
+      nextValue = order[nextIdx];
+    }
+
     if (nextValue === undefined) return;
 
     focusValue(nextValue);
-    if (effectiveActivateOnFocus) {
+    if (effectiveActivateOnFocus && !disabledValues.has(nextValue)) {
       value = nextValue;
     }
   }
@@ -106,6 +137,11 @@
     },
     unregister(target) {
       buttons.delete(target);
+      disabledValues.delete(target);
+    },
+    setDisabled(target, isDisabled) {
+      if (isDisabled) disabledValues.add(target);
+      else disabledValues.delete(target);
     },
     handleKeydown,
   });

--- a/packages/components/src/components/tabs/tabs.test.ts
+++ b/packages/components/src/components/tabs/tabs.test.ts
@@ -358,12 +358,13 @@ describe('Tabs keyboard navigation skips disabled tabs', () => {
     // re-running the registration effect on a disabled change would delete
     // and re-insert b in the parent Map, moving it to the end of the order.
     //
-    // The fixture's `{#each items (item.value)}` keyed block means each Tab
-    // component instance is preserved across rerenders that change `disabled`
-    // (the key is stable). We assert button identity is preserved before vs.
-    // after toggling, which makes the test's correctness explicit: the test
-    // can only pass for the right reason if `b`'s registration was NOT torn
-    // down and re-created during the toggle.
+    // The contract being asserted is the observable navigation result, not
+    // the internal mechanism: if the registration order were corrupted by
+    // the toggle, ArrowRight from a would land on c. We do not assert DOM
+    // identity preservation across rerender because @testing-library/svelte
+    // does not reliably preserve `Node` identity through `rerender` even
+    // with a keyed `{#each (item.value)}` block; that assertion would be
+    // brittle for reasons orthogonal to the bug being guarded.
     const allEnabled = items;
     const withBDisabled = [items[0]!, { ...items[1]!, disabled: true }, items[2]!];
     const { container, rerender } = render(Wrapper, { value: 'a', items: allEnabled });

--- a/packages/components/src/components/tabs/tabs.test.ts
+++ b/packages/components/src/components/tabs/tabs.test.ts
@@ -292,22 +292,64 @@ describe('Tabs keyboard navigation skips disabled tabs', () => {
     expect(bTab.getAttribute('aria-selected')).toBe('true');
   });
 
-  test('all-disabled tablist is a no-op on arrow keys', async () => {
-    const allDisabled = [
-      { value: 'a', title: 'A tab', body: 'A body', disabled: true },
+  // An all-disabled tablist is a consumer-side accessibility violation that
+  // the component must not crash on. The empty-enabled guard in handleKeydown
+  // is defense-in-depth: native `disabled` buttons cannot receive focus, so
+  // the guard is unreachable through realistic public interaction (the only
+  // way to dispatch the keydown is on a non-button element like the tablist
+  // wrapper, which has no `onkeydown` handler attached and therefore would
+  // never invoke handleKeydown anyway). The guard stays in the source as a
+  // safety net; it is covered by code review, not a unit test.
+
+  test('vertical: ArrowDown skips a disabled tab', async () => {
+    const itemsWithDisabledMiddle = [
+      { value: 'a', title: 'A tab', body: 'A body' },
       { value: 'b', title: 'B tab', body: 'B body', disabled: true },
+      { value: 'c', title: 'C tab', body: 'C body' },
     ];
-    const { container } = render(Wrapper, { value: 'a', items: allDisabled });
-    const tablist = container.querySelector('[role="tablist"]') as HTMLElement;
-    // No enabled tab can receive focus, so dispatch the event on the tablist
-    // container; the handler walks `event.target` and the empty-enabled guard
-    // returns early without touching value or focus.
-    await fireEvent.keyDown(tablist, { key: 'ArrowRight' });
-    const selected = container.querySelector('[role="tab"][aria-selected="true"]');
-    expect(selected?.getAttribute('data-cinder-value')).toBe('a');
-    // No panel rendered (controlled value points at a disabled tab, which is
-    // an a11y violation by the consumer, but the component must not throw).
-    // We simply assert no crash and that the selection did not silently move.
+    const { container } = render(Wrapper, {
+      value: 'a',
+      orientation: 'vertical',
+      activateOnFocus: false,
+      items: itemsWithDisabledMiddle,
+    });
+    const tabs = Array.from(container.querySelectorAll<HTMLElement>('[role="tab"]'));
+    const aTab = tabs[0]!;
+    const cTab = tabs[2]!;
+    aTab.focus();
+    await fireEvent.keyDown(aTab, { key: 'ArrowDown' });
+    expect(document.activeElement).toBe(cTab);
+    // Vertical defaults to manual activation, so panel stays on `a` until Enter.
+    const panelBeforeEnter = container.querySelector('[role="tabpanel"]');
+    expect(panelBeforeEnter?.textContent).toContain('A body');
+  });
+
+  test('activateOnFocus=false: Enter on enabled tab after skipping disabled activates it', async () => {
+    // Vertical orientation defaults to activateOnFocus=false. Navigate past
+    // a disabled tab via ArrowDown, then press Enter on the now-focused
+    // enabled tab. The Enter/Space gate must let this through (the focused
+    // tab is enabled), confirming that the disabled-skip and the manual
+    // activation gate compose correctly.
+    const itemsWithDisabledMiddle = [
+      { value: 'a', title: 'A tab', body: 'A body' },
+      { value: 'b', title: 'B tab', body: 'B body', disabled: true },
+      { value: 'c', title: 'C tab', body: 'C body' },
+    ];
+    const { container } = render(Wrapper, {
+      value: 'a',
+      orientation: 'vertical',
+      activateOnFocus: false,
+      items: itemsWithDisabledMiddle,
+    });
+    const tabs = Array.from(container.querySelectorAll<HTMLElement>('[role="tab"]'));
+    const aTab = tabs[0]!;
+    const cTab = tabs[2]!;
+    aTab.focus();
+    await fireEvent.keyDown(aTab, { key: 'ArrowDown' });
+    expect(document.activeElement).toBe(cTab);
+    await fireEvent.keyDown(cTab, { key: 'Enter' });
+    const panel = container.querySelector('[role="tabpanel"]');
+    expect(panel?.textContent).toContain('C body');
   });
 
   test('runtime disable toggle preserves navigation order (regression)', async () => {
@@ -315,6 +357,13 @@ describe('Tabs keyboard navigation skips disabled tabs', () => {
     // from a must still land on b, not c. This guards against the bug where
     // re-running the registration effect on a disabled change would delete
     // and re-insert b in the parent Map, moving it to the end of the order.
+    //
+    // The fixture's `{#each items (item.value)}` keyed block means each Tab
+    // component instance is preserved across rerenders that change `disabled`
+    // (the key is stable). We assert button identity is preserved before vs.
+    // after toggling, which makes the test's correctness explicit: the test
+    // can only pass for the right reason if `b`'s registration was NOT torn
+    // down and re-created during the toggle.
     const allEnabled = items;
     const withBDisabled = [items[0]!, { ...items[1]!, disabled: true }, items[2]!];
     const { container, rerender } = render(Wrapper, { value: 'a', items: allEnabled });

--- a/packages/components/src/components/tabs/tabs.test.ts
+++ b/packages/components/src/components/tabs/tabs.test.ts
@@ -7,9 +7,8 @@ setupHappyDom();
 
 const { render, fireEvent } = await import('@testing-library/svelte');
 const { default: Wrapper } = await import('../../test/fixtures/tabs-fixture.svelte');
-const { default: TrailingWrapper } = await import(
-  '../../test/fixtures/tabs-trailing-fixture.svelte'
-);
+const { default: TrailingWrapper } =
+  await import('../../test/fixtures/tabs-trailing-fixture.svelte');
 
 const items = [
   { value: 'a', title: 'A tab', body: 'A body' },
@@ -96,7 +95,7 @@ describe('Tab trailing snippet', () => {
     expect(trailing?.textContent).toContain('3');
   });
 
-  test("accessible name excludes trailing content (aria-hidden subtree is omitted)", () => {
+  test('accessible name excludes trailing content (aria-hidden subtree is omitted)', () => {
     const { container } = render(TrailingWrapper, { value: 'inbox', trailingText: '3' });
     const tab = container.querySelector('[role="tab"][aria-selected="true"]') as HTMLElement;
     expect(tab).not.toBeNull();
@@ -184,5 +183,150 @@ describe('Tabs keyboard navigation', () => {
     await fireEvent.keyDown(bTab, { key: 'Enter' });
     panel = container.querySelector('[role="tabpanel"]');
     expect(panel?.textContent).toContain('B body');
+  });
+});
+
+describe('Tabs keyboard navigation skips disabled tabs', () => {
+  test('ArrowRight skips a disabled tab in the middle', async () => {
+    const itemsWithDisabledMiddle = [
+      { value: 'a', title: 'A tab', body: 'A body' },
+      { value: 'b', title: 'B tab', body: 'B body', disabled: true },
+      { value: 'c', title: 'C tab', body: 'C body' },
+    ];
+    const { container } = render(Wrapper, { value: 'a', items: itemsWithDisabledMiddle });
+    const tabs = Array.from(container.querySelectorAll<HTMLElement>('[role="tab"]'));
+    const aTab = tabs[0]!;
+    const cTab = tabs[2]!;
+    aTab.focus();
+    await fireEvent.keyDown(aTab, { key: 'ArrowRight' });
+    expect(document.activeElement).toBe(cTab);
+    expect(cTab.getAttribute('aria-selected')).toBe('true');
+    const panel = container.querySelector('[role="tabpanel"]');
+    expect(panel?.textContent).toContain('C body');
+  });
+
+  test('ArrowLeft skips a disabled tab and wraps', async () => {
+    const itemsWithLeadingDisabled = [
+      { value: 'a', title: 'A tab', body: 'A body', disabled: true },
+      { value: 'b', title: 'B tab', body: 'B body' },
+      { value: 'c', title: 'C tab', body: 'C body' },
+    ];
+    const { container } = render(Wrapper, { value: 'b', items: itemsWithLeadingDisabled });
+    const tabs = Array.from(container.querySelectorAll<HTMLElement>('[role="tab"]'));
+    const bTab = tabs[1]!;
+    const cTab = tabs[2]!;
+    bTab.focus();
+    await fireEvent.keyDown(bTab, { key: 'ArrowLeft' });
+    expect(document.activeElement).toBe(cTab);
+    expect(cTab.getAttribute('aria-selected')).toBe('true');
+    const panel = container.querySelector('[role="tabpanel"]');
+    expect(panel?.textContent).toContain('C body');
+  });
+
+  test('Home skips a leading disabled tab and lands on the first enabled', async () => {
+    const itemsWithLeadingDisabled = [
+      { value: 'a', title: 'A tab', body: 'A body', disabled: true },
+      { value: 'b', title: 'B tab', body: 'B body' },
+      { value: 'c', title: 'C tab', body: 'C body' },
+    ];
+    const { container } = render(Wrapper, { value: 'c', items: itemsWithLeadingDisabled });
+    const tabs = Array.from(container.querySelectorAll<HTMLElement>('[role="tab"]'));
+    const bTab = tabs[1]!;
+    const cTab = tabs[2]!;
+    cTab.focus();
+    await fireEvent.keyDown(cTab, { key: 'Home' });
+    expect(document.activeElement).toBe(bTab);
+    expect(bTab.getAttribute('aria-selected')).toBe('true');
+    const panel = container.querySelector('[role="tabpanel"]');
+    expect(panel?.textContent).toContain('B body');
+  });
+
+  test('End skips a trailing disabled tab and lands on the last enabled', async () => {
+    const itemsWithTrailingDisabled = [
+      { value: 'a', title: 'A tab', body: 'A body' },
+      { value: 'b', title: 'B tab', body: 'B body' },
+      { value: 'c', title: 'C tab', body: 'C body', disabled: true },
+    ];
+    const { container } = render(Wrapper, { value: 'a', items: itemsWithTrailingDisabled });
+    const tabs = Array.from(container.querySelectorAll<HTMLElement>('[role="tab"]'));
+    const aTab = tabs[0]!;
+    const bTab = tabs[1]!;
+    aTab.focus();
+    await fireEvent.keyDown(aTab, { key: 'End' });
+    expect(document.activeElement).toBe(bTab);
+    expect(bTab.getAttribute('aria-selected')).toBe('true');
+    const panel = container.querySelector('[role="tabpanel"]');
+    expect(panel?.textContent).toContain('B body');
+  });
+
+  test('controlled value pointing at a disabled tab — navigation anchors from focused tab', async () => {
+    // Controlled value=b is disabled. Focus is on the enabled `a`. ArrowRight
+    // must move from focused `a` to `c`, never anchoring on disabled `b`.
+    const itemsWithDisabledMiddle = [
+      { value: 'a', title: 'A tab', body: 'A body' },
+      { value: 'b', title: 'B tab', body: 'B body', disabled: true },
+      { value: 'c', title: 'C tab', body: 'C body' },
+    ];
+    const { container } = render(Wrapper, { value: 'b', items: itemsWithDisabledMiddle });
+    const tabs = Array.from(container.querySelectorAll<HTMLElement>('[role="tab"]'));
+    const aTab = tabs[0]!;
+    const cTab = tabs[2]!;
+    aTab.focus();
+    await fireEvent.keyDown(aTab, { key: 'ArrowRight' });
+    expect(document.activeElement).toBe(cTab);
+    expect(cTab.getAttribute('aria-selected')).toBe('true');
+  });
+
+  test('Home with a controlled disabled value lands on the first enabled tab', async () => {
+    const itemsWithLeadingDisabled = [
+      { value: 'a', title: 'A tab', body: 'A body', disabled: true },
+      { value: 'b', title: 'B tab', body: 'B body' },
+      { value: 'c', title: 'C tab', body: 'C body' },
+    ];
+    const { container } = render(Wrapper, { value: 'a', items: itemsWithLeadingDisabled });
+    const tabs = Array.from(container.querySelectorAll<HTMLElement>('[role="tab"]'));
+    const bTab = tabs[1]!;
+    bTab.focus();
+    await fireEvent.keyDown(bTab, { key: 'Home' });
+    expect(document.activeElement).toBe(bTab);
+    expect(bTab.getAttribute('aria-selected')).toBe('true');
+  });
+
+  test('all-disabled tablist is a no-op on arrow keys', async () => {
+    const allDisabled = [
+      { value: 'a', title: 'A tab', body: 'A body', disabled: true },
+      { value: 'b', title: 'B tab', body: 'B body', disabled: true },
+    ];
+    const { container } = render(Wrapper, { value: 'a', items: allDisabled });
+    const tablist = container.querySelector('[role="tablist"]') as HTMLElement;
+    // No enabled tab can receive focus, so dispatch the event on the tablist
+    // container; the handler walks `event.target` and the empty-enabled guard
+    // returns early without touching value or focus.
+    await fireEvent.keyDown(tablist, { key: 'ArrowRight' });
+    const selected = container.querySelector('[role="tab"][aria-selected="true"]');
+    expect(selected?.getAttribute('data-cinder-value')).toBe('a');
+    // No panel rendered (controlled value points at a disabled tab, which is
+    // an a11y violation by the consumer, but the component must not throw).
+    // We simply assert no crash and that the selection did not silently move.
+  });
+
+  test('runtime disable toggle preserves navigation order (regression)', async () => {
+    // Render [a, b, c] enabled; toggle b.disabled true → false; ArrowRight
+    // from a must still land on b, not c. This guards against the bug where
+    // re-running the registration effect on a disabled change would delete
+    // and re-insert b in the parent Map, moving it to the end of the order.
+    const allEnabled = items;
+    const withBDisabled = [items[0]!, { ...items[1]!, disabled: true }, items[2]!];
+    const { container, rerender } = render(Wrapper, { value: 'a', items: allEnabled });
+    await rerender({ value: 'a', items: withBDisabled });
+    await rerender({ value: 'a', items: allEnabled });
+
+    const tabs = Array.from(container.querySelectorAll<HTMLElement>('[role="tab"]'));
+    const aTab = tabs[0]!;
+    const bTab = tabs[1]!;
+    aTab.focus();
+    await fireEvent.keyDown(aTab, { key: 'ArrowRight' });
+    expect(document.activeElement).toBe(bTab);
+    expect(bTab.getAttribute('aria-selected')).toBe('true');
   });
 });

--- a/packages/components/src/components/tabs/tabs.types.ts
+++ b/packages/components/src/components/tabs/tabs.types.ts
@@ -7,7 +7,10 @@ export type TabsOrientation = 'horizontal' | 'vertical';
  * `register` lets each Tab announce itself to the parent during mount so
  * the parent can drive arrow-key navigation (focus management requires the
  * parent to know each tab's element). `unregister` removes the entry on
- * unmount.
+ * unmount. `setDisabled` is kept independent of registration so toggling
+ * the disabled flag at runtime does not perturb the registration order
+ * (which is the navigation order — re-inserting a Map key moves it to the
+ * end).
  */
 export type TabsContext = {
   readonly value: string;
@@ -17,6 +20,7 @@ export type TabsContext = {
   isActive: (candidate: string) => boolean;
   register: (value: string, button: HTMLButtonElement) => void;
   unregister: (value: string) => void;
+  setDisabled: (value: string, disabled: boolean) => void;
   handleKeydown: (event: KeyboardEvent) => void;
 };
 export type TabsProps = {

--- a/packages/components/src/test/fixtures/tabs-fixture.svelte
+++ b/packages/components/src/test/fixtures/tabs-fixture.svelte
@@ -25,11 +25,7 @@
 <Tabs bind:value {orientation} {...activateOnFocus !== undefined ? { activateOnFocus } : {}}>
   <TabList label="Test tabs">
     {#each items as item (item.value)}
-      {#if item.disabled !== undefined}
-        <Tab value={item.value} disabled={item.disabled}>{item.title}</Tab>
-      {:else}
-        <Tab value={item.value}>{item.title}</Tab>
-      {/if}
+      <Tab value={item.value} disabled={item.disabled ?? false}>{item.title}</Tab>
     {/each}
   </TabList>
   {#each items as item (item.value)}


### PR DESCRIPTION
## Summary

`<Tabs>` now skips disabled tabs during keyboard navigation, matching the [WAI-ARIA tabs pattern](https://www.w3.org/WAI/ARIA/apg/patterns/tabs/). Previously, arrow keys (and Home/End) walked the full registry, so under the default `activateOnFocus` for horizontal tablists, arrowing onto a disabled tab activated it — the disabled `<TabPanel>` rendered while no tab visually indicated active state. See `docs/design-debt.md` #16.

Highlights:

- Disabled tabs are filtered out of arrow/Home/End navigation. Home and End bypass adjacency and land directly on the first/last enabled tab.
- Navigation anchors on the user's focused tab (with a fallback to the controlled `value`), so a controlled value pointing at a disabled tab does not seed movement from an invisible position.
- The `TabsContext` exposes a new `setDisabled(value, disabled)` method. `<Tab>` calls it from a dedicated `$effect` that has no dependency on `disabled` in the registration effect, so toggling `disabled` at runtime never re-runs the lifecycle effect — which is what kept the parent's `Map` insertion order (i.e., the navigation order) stable.
- Includes a regression test for the runtime disable-then-re-enable toggle, plus tests for middle/leading/trailing skip, Home/End skip, controlled-disabled-value anchoring, and vertical-orientation + `activateOnFocus=false` + disabled.

## Notable engineering decisions

- **`untrack(() => value)` in the registration effect is load-bearing.** Removing it was attempted in response to a committee finding; the runtime-toggle regression test then failed empirically because Svelte 5 re-runs the effect on the `value` prop's slot when a sibling prop on the same render pass triggers a re-evaluation. The `untrack` pattern documents a value-stability constraint: a `<Tab>`'s `value` is its identity key for its lifetime; consumers who need to change it should remount via a different `{#each}` key.
- **Native `disabled` attribute is preserved (no `aria-disabled` switch).** Native disabled buttons cannot receive focus, which is why the Enter/Space disabled-value gate is defense-in-depth that cannot be exercised through realistic interaction. Adopting `aria-disabled` (so AT users can discover disabled tabs via Tab key) is a separate task.
- **Changeset bumped to `minor`** because `TabsContext` is an exported type and `setDisabled` is an additive public API.

## Review committee

Pre-reviewed by:

- typescript-expert
- testing-expert
- frontend-architect
- simplicity-engineer
- junior-engineer
- Codex (gpt-5.4, xhigh reasoning round 1 + high reasoning round 2) — 2 rounds

2 rounds of review. All must-fix items addressed; one finding (`untrack`) was overridden based on empirical Svelte 5 reactivity behavior, with the rationale recorded in `tmp/committee-state.md`.

## Test plan

- [x] `bun run --filter=cinder typecheck` — 0 errors
- [x] `bun run --filter=cinder test` — 2383 pass, 1 skip, 0 fail
- [x] `bun run lint` — clean
- [x] Pre-commit + pre-push hooks all green
- [ ] Reviewer: verify in the playground (`bun run dev`) that the Tabs `with-keyboard` example walks Design → Develop → Review → wraps to Design, never landing on or rendering "Ship"

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core keyboard navigation behavior for `Tabs` and adds a new context method (`setDisabled`), which could affect existing integrations and edge cases around controlled values and runtime prop changes.
> 
> **Overview**
> Updates `Tabs` keyboard handling to **skip disabled tabs** for Arrow/Home/End navigation (and to ignore disabled tabs for Enter/Space manual activation), aligning behavior with the WAI-ARIA tabs pattern.
> 
> Adds `TabsContext.setDisabled(value, disabled)` and tracks disabled state separately from the tab registry so toggling `disabled` at runtime does **not** perturb navigation order; `Tab` now registers once using `untrack(() => value)` and syncs disabled state via a dedicated effect.
> 
> Expands unit coverage with new tests for disabled-skip behavior (including wraparound, Home/End, controlled disabled values, vertical/manual activation) plus a regression test ensuring disable→enable preserves navigation order, and includes a `minor` changeset for the additive context API.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4f2da8b81b2592a72ec42b7512af79fe7617d8dc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->