### PR TITLE
feat(stylelint): @media (hover: hover) guards + cinder/no-unguarded-hover-colors rule

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -1,5 +1,8 @@
 {
-  "plugins": ["stylelint-use-logical"],
+  "plugins": [
+    "stylelint-use-logical",
+    "./packages/components/scripts/stylelint/no-unguarded-hover-colors.cjs"
+  ],
   "overrides": [
     {
       "files": ["**/*.svelte"],
@@ -7,6 +10,7 @@
     }
   ],
   "rules": {
+    "cinder/no-unguarded-hover-colors": true,
     "csstools/use-logical": [
       "always",
       {

--- a/packages/components/scripts/discover-component-directories.ts
+++ b/packages/components/scripts/discover-component-directories.ts
@@ -1,0 +1,68 @@
+/**
+ * Walks `src/components/` and returns the canonical list of component
+ * directories the artifact, constraint, schema, variables, examples, and
+ * manifest generators all need.
+ *
+ * Extracted from `generate-component-artifacts.ts` so other generator scripts
+ * (e.g. `generate-component-constraints.ts`) can import this without forming
+ * a cycle through the artifact orchestrator.
+ */
+
+import { existsSync } from 'node:fs';
+import { readdir } from 'node:fs/promises';
+import { join } from 'node:path';
+
+export type DiscoveredComponent = {
+  /** Absolute path to the component directory. */
+  directory: string;
+  /** Kebab-case component name (the directory basename). */
+  name: string;
+  /** True for `src/components/experimental/<name>/`. */
+  isExperimental: boolean;
+};
+
+const COMPONENTS_ROOT = join(import.meta.dir, '..', 'src', 'components');
+
+/**
+ * Discover every directory-shaped component under `src/components/`.
+ *
+ * A directory qualifies when it contains both `<name>.svelte` and
+ * `<name>.types.ts`. The presence of the `.types.ts` file is the marker that
+ * the per-directory migration is complete; legacy flat or in-progress
+ * subdirectories are skipped.
+ *
+ * Directories named `experimental/` are descended one level, and
+ * `icons/` plus underscore-prefixed names (`_internal/`, etc.) are skipped.
+ *
+ * Returns the list sorted by absolute directory path.
+ */
+export async function discoverComponentDirectories(): Promise<DiscoveredComponent[]> {
+  const results: DiscoveredComponent[] = [];
+
+  for (const entry of await readdir(COMPONENTS_ROOT, { withFileTypes: true })) {
+    if (!entry.isDirectory()) continue;
+    if (entry.name.startsWith('_')) continue;
+
+    if (entry.name === 'experimental') {
+      const experimentalRoot = join(COMPONENTS_ROOT, 'experimental');
+      for (const subEntry of await readdir(experimentalRoot, { withFileTypes: true })) {
+        if (!subEntry.isDirectory()) continue;
+        if (subEntry.name.startsWith('_')) continue;
+        const directory = join(experimentalRoot, subEntry.name);
+        if (!existsSync(join(directory, `${subEntry.name}.svelte`))) continue;
+        if (!existsSync(join(directory, `${subEntry.name}.types.ts`))) continue;
+        results.push({ directory, name: subEntry.name, isExperimental: true });
+      }
+      continue;
+    }
+
+    if (entry.name === 'icons') continue;
+
+    const directory = join(COMPONENTS_ROOT, entry.name);
+    if (!existsSync(join(directory, `${entry.name}.svelte`))) continue;
+    if (!existsSync(join(directory, `${entry.name}.types.ts`))) continue;
+    results.push({ directory, name: entry.name, isExperimental: false });
+  }
+
+  return results.toSorted((a, b) => a.directory.localeCompare(b.directory));
+}

--- a/packages/components/scripts/generate-component-artifacts.ts
+++ b/packages/components/scripts/generate-component-artifacts.ts
@@ -20,11 +20,14 @@
  */
 
 import { existsSync } from 'node:fs';
-import { readdir } from 'node:fs/promises';
 import { join } from 'node:path';
 
 import prettier from 'prettier';
 
+import {
+  discoverComponentDirectories,
+  type DiscoveredComponent,
+} from './discover-component-directories.ts';
 import { checkConstraintsDrift, generateAllConstraints } from './generate-component-constraints.ts';
 import {
   checkExamplesDrift,
@@ -35,6 +38,8 @@ import { generateSchemaForComponent } from './generate-component-schema.ts';
 import { generateVariablesForComponent } from './generate-component-variables.ts';
 import { buildManifest, writeManifest } from './generate-manifest.ts';
 import { renderComponentReadme } from './render-component-readme.ts';
+
+export { discoverComponentDirectories, type DiscoveredComponent };
 
 /**
  * Run prettier over the generated content using the repo's prettier config.
@@ -50,51 +55,6 @@ async function formatGenerated(content: string, filepath: string): Promise<strin
   } catch {
     return content;
   }
-}
-
-export interface DiscoveredComponent {
-  /** Absolute path to the component directory. */
-  directory: string;
-  /** Kebab-case component name (the directory basename). */
-  name: string;
-  /** True for `src/components/experimental/<name>/`. */
-  isExperimental: boolean;
-}
-
-const COMPONENTS_ROOT = join(import.meta.dir, '..', 'src', 'components');
-
-export async function discoverComponentDirectories(): Promise<DiscoveredComponent[]> {
-  const results: DiscoveredComponent[] = [];
-
-  for (const entry of await readdir(COMPONENTS_ROOT, { withFileTypes: true })) {
-    if (!entry.isDirectory()) continue;
-    if (entry.name.startsWith('_')) continue;
-
-    if (entry.name === 'experimental') {
-      const experimentalRoot = join(COMPONENTS_ROOT, 'experimental');
-      for (const subEntry of await readdir(experimentalRoot, { withFileTypes: true })) {
-        if (!subEntry.isDirectory()) continue;
-        if (subEntry.name.startsWith('_')) continue;
-        const directory = join(experimentalRoot, subEntry.name);
-        // A migrated component has both `<name>.svelte` AND `<name>.types.ts` —
-        // the types file is the schema generator's input and the marker of
-        // completed migration. Legacy ad-hoc subdirectories (e.g. chat/) lack it.
-        if (!existsSync(join(directory, `${subEntry.name}.svelte`))) continue;
-        if (!existsSync(join(directory, `${subEntry.name}.types.ts`))) continue;
-        results.push({ directory, name: subEntry.name, isExperimental: true });
-      }
-      continue;
-    }
-
-    if (entry.name === 'icons') continue;
-
-    const directory = join(COMPONENTS_ROOT, entry.name);
-    if (!existsSync(join(directory, `${entry.name}.svelte`))) continue;
-    if (!existsSync(join(directory, `${entry.name}.types.ts`))) continue;
-    results.push({ directory, name: entry.name, isExperimental: false });
-  }
-
-  return results.toSorted((a, b) => a.directory.localeCompare(b.directory));
 }
 
 export interface ComponentArtifacts {

--- a/packages/components/scripts/generate-component-constraints.ts
+++ b/packages/components/scripts/generate-component-constraints.ts
@@ -22,7 +22,7 @@ import type {
   ConstraintsDocument,
   ConstraintSeverity,
 } from '../src/_internal/constraints.ts';
-import { discoverComponentDirectories } from './generate-component-artifacts.ts';
+import { discoverComponentDirectories } from './discover-component-directories.ts';
 
 // ---------------------------------------------------------------------------
 // Constants

--- a/packages/components/scripts/stylelint/no-unguarded-hover-colors.cjs
+++ b/packages/components/scripts/stylelint/no-unguarded-hover-colors.cjs
@@ -19,7 +19,7 @@ const ruleName = 'cinder/no-unguarded-hover-colors';
 
 const messages = stylelint.utils.ruleMessages(ruleName, {
   unguarded: (selector, property) =>
-    `Unguarded :hover rule "${selector}" declares "${property}". Wrap in @media (hover: hover) to avoid sticky hover on touch.`,
+    `Unguarded :hover rule "${String(selector)}" declares "${String(property)}". Wrap in @media (hover: hover) to avoid sticky hover on touch.`,
 });
 
 const meta = {

--- a/packages/components/scripts/stylelint/no-unguarded-hover-colors.cjs
+++ b/packages/components/scripts/stylelint/no-unguarded-hover-colors.cjs
@@ -1,0 +1,144 @@
+'use strict';
+
+/**
+ * Stylelint rule: cinder/no-unguarded-hover-colors
+ *
+ * Rejects :hover rules that change background or border color properties when
+ * no ancestor @media (hover: hover) guard is present. The guard prevents
+ * "sticky hover" on touch devices that synthesize :hover on tap.
+ *
+ * Conservative guard semantics: an ancestor @media must contain
+ * `(hover: hover)`, must not contain a top-level comma (media list), and must
+ * not contain a `not` modifier. Other conjunctive features are allowed.
+ */
+
+const stylelint = require('stylelint');
+const selectorParser = require('postcss-selector-parser');
+
+const ruleName = 'cinder/no-unguarded-hover-colors';
+
+const messages = stylelint.utils.ruleMessages(ruleName, {
+  unguarded: (selector, property) =>
+    `Unguarded :hover rule "${selector}" declares "${property}". Wrap in @media (hover: hover) to avoid sticky hover on touch.`,
+});
+
+const meta = {
+  url: 'https://github.com/stevekinney/cinder/blob/main/packages/components/scripts/stylelint/no-unguarded-hover-colors.cjs',
+};
+
+const TARGET_PROPERTIES = new Set([
+  'background',
+  'background-color',
+  'background-image',
+  'border',
+  'border-color',
+  'border-top',
+  'border-right',
+  'border-bottom',
+  'border-left',
+  'border-block',
+  'border-inline',
+  'border-block-start',
+  'border-block-end',
+  'border-inline-start',
+  'border-inline-end',
+  'border-top-color',
+  'border-right-color',
+  'border-bottom-color',
+  'border-left-color',
+  'border-block-color',
+  'border-inline-color',
+  'border-block-start-color',
+  'border-block-end-color',
+  'border-inline-start-color',
+  'border-inline-end-color',
+]);
+
+/**
+ * Walk a selector AST and return true if any selector branch contains a :hover
+ * pseudo node — including pseudos nested inside :is(), :where(), :not(), etc.
+ *
+ * Scrollbar pseudo-elements (::-webkit-scrollbar-*) are excluded because they
+ * only render with a real pointer; touch devices never paint a custom scrollbar
+ * thumb, so :hover on them cannot synthesize a sticky-tap state. Guarding them
+ * would suppress the legitimate cursor-hover tint on hybrid touch/trackpad
+ * laptops for no benefit.
+ */
+function selectorHasHover(selectorString) {
+  let found = false;
+  let isScrollbarPseudo = false;
+  try {
+    selectorParser((root) => {
+      root.walkPseudos((node) => {
+        if (node.value === ':hover') {
+          found = true;
+        }
+        if (typeof node.value === 'string' && node.value.startsWith('::-webkit-scrollbar')) {
+          isScrollbarPseudo = true;
+        }
+      });
+    }).processSync(selectorString);
+  } catch {
+    // If the selector won't parse, fall back to a coarse text check.
+    return /:hover\b/.test(selectorString) && !/::-webkit-scrollbar/.test(selectorString);
+  }
+  return found && !isScrollbarPseudo;
+}
+
+/**
+ * Conservative hover-guard predicate. Accepts only single, non-negated media
+ * queries that contain (hover: hover). Comma-separated media lists are
+ * rejected because any branch without (hover: hover) can activate on touch.
+ */
+function isHoverGuard(params) {
+  if (!params) return false;
+  if (params.includes(',')) return false;
+  if (/\bnot\b/i.test(params)) return false;
+  return /\(\s*hover\s*:\s*hover\s*\)/i.test(params);
+}
+
+function hasGuardingAncestor(rule) {
+  let parent = rule.parent;
+  while (parent) {
+    if (parent.type === 'atrule' && parent.name === 'media' && isHoverGuard(parent.params)) {
+      return true;
+    }
+    parent = parent.parent;
+  }
+  return false;
+}
+
+const ruleFunction = (primary, _secondaryOptions, context) => {
+  return (root, result) => {
+    const validOptions = stylelint.utils.validateOptions(result, ruleName, {
+      actual: primary,
+      possible: [true, false],
+    });
+    if (!validOptions || !primary) return;
+
+    root.walkRules((rule) => {
+      // Skip rules that live inside @keyframes or other non-style at-rules
+      // where :hover is meaningless.
+      if (!selectorHasHover(rule.selector)) return;
+      if (hasGuardingAncestor(rule)) return;
+
+      rule.walkDecls((decl) => {
+        const property = decl.prop.toLowerCase();
+        if (!TARGET_PROPERTIES.has(property)) return;
+
+        stylelint.utils.report({
+          message: messages.unguarded(rule.selector, property),
+          node: decl,
+          result,
+          ruleName,
+        });
+      });
+    });
+  };
+};
+
+ruleFunction.ruleName = ruleName;
+ruleFunction.messages = messages;
+ruleFunction.meta = meta;
+
+module.exports = stylelint.createPlugin(ruleName, ruleFunction);

--- a/packages/components/scripts/stylelint/no-unguarded-hover-colors.cjs
+++ b/packages/components/scripts/stylelint/no-unguarded-hover-colors.cjs
@@ -58,31 +58,43 @@ const TARGET_PROPERTIES = new Set([
  * Walk a selector AST and return true if any selector branch contains a :hover
  * pseudo node — including pseudos nested inside :is(), :where(), :not(), etc.
  *
- * Scrollbar pseudo-elements (::-webkit-scrollbar-*) are excluded because they
- * only render with a real pointer; touch devices never paint a custom scrollbar
- * thumb, so :hover on them cannot synthesize a sticky-tap state. Guarding them
- * would suppress the legitimate cursor-hover tint on hybrid touch/trackpad
- * laptops for no benefit.
+ * Each branch of a comma-separated selector list is evaluated independently:
+ * a branch whose compound contains `::-webkit-scrollbar*` is excluded because
+ * scrollbar pseudo-elements only render with a real pointer (touch devices
+ * never paint custom scrollbar thumbs, so :hover there cannot synthesize a
+ * sticky-tap state). A mixed selector list like
+ *   `.foo:hover, .bar::-webkit-scrollbar-thumb:hover`
+ * still triggers a warning for `.foo:hover` — only the scrollbar branch is
+ * skipped.
  */
 function selectorHasHover(selectorString) {
   let found = false;
-  let isScrollbarPseudo = false;
   try {
     selectorParser((root) => {
-      root.walkPseudos((node) => {
-        if (node.value === ':hover') {
+      root.each((branch) => {
+        let branchHasHover = false;
+        let branchIsScrollbar = false;
+        branch.walkPseudos((node) => {
+          if (node.value === ':hover') {
+            branchHasHover = true;
+          }
+          if (typeof node.value === 'string' && node.value.startsWith('::-webkit-scrollbar')) {
+            branchIsScrollbar = true;
+          }
+        });
+        if (branchHasHover && !branchIsScrollbar) {
           found = true;
-        }
-        if (typeof node.value === 'string' && node.value.startsWith('::-webkit-scrollbar')) {
-          isScrollbarPseudo = true;
         }
       });
     }).processSync(selectorString);
   } catch {
-    // If the selector won't parse, fall back to a coarse text check.
-    return /:hover\b/.test(selectorString) && !/::-webkit-scrollbar/.test(selectorString);
+    // If the selector won't parse, fall back to a coarse text check that
+    // applies the same per-branch exclusion.
+    return selectorString
+      .split(',')
+      .some((branch) => /:hover\b/.test(branch) && !/::-webkit-scrollbar/.test(branch));
   }
-  return found && !isScrollbarPseudo;
+  return found;
 }
 
 /**

--- a/packages/components/scripts/stylelint/no-unguarded-hover-colors.test.ts
+++ b/packages/components/scripts/stylelint/no-unguarded-hover-colors.test.ts
@@ -1,0 +1,192 @@
+import { describe, expect, it } from 'bun:test';
+import { fileURLToPath } from 'node:url';
+import stylelint from 'stylelint';
+
+const pluginPath = fileURLToPath(new URL('./no-unguarded-hover-colors.cjs', import.meta.url));
+
+type LintOptions = {
+  code: string;
+  codeFilename?: string;
+  customSyntax?: string;
+};
+
+async function lint({ code, codeFilename, customSyntax }: LintOptions) {
+  const baseOptions = {
+    code,
+    codeFilename: codeFilename ?? '/virtual/example/component.css',
+    config: {
+      plugins: [pluginPath],
+      rules: {
+        'cinder/no-unguarded-hover-colors': true,
+      },
+    },
+  };
+  return customSyntax
+    ? stylelint.lint({ ...baseOptions, customSyntax })
+    : stylelint.lint(baseOptions);
+}
+
+function warningsOf(result: Awaited<ReturnType<typeof stylelint.lint>>) {
+  const lintResult = result.results[0];
+  return lintResult ? lintResult.warnings : [];
+}
+
+describe('cinder/no-unguarded-hover-colors', () => {
+  it('rejects unguarded :hover { background: ... }', async () => {
+    const result = await lint({
+      code: `.cinder-example:hover { background: red; }`,
+    });
+    const warnings = warningsOf(result);
+    expect(warnings).toHaveLength(1);
+    const first = warnings[0]!;
+    expect(first.rule).toBe('cinder/no-unguarded-hover-colors');
+    expect(first.text).toContain('.cinder-example:hover');
+    expect(first.text).toContain('background');
+  });
+
+  it('rejects unguarded :hover { background-color: ... }', async () => {
+    const result = await lint({
+      code: `.cinder-example:hover { background-color: red; }`,
+    });
+    expect(warningsOf(result)).toHaveLength(1);
+  });
+
+  it('rejects unguarded :hover { border-color: ... }', async () => {
+    const result = await lint({
+      code: `.cinder-example:hover { border-color: red; }`,
+    });
+    expect(warningsOf(result)).toHaveLength(1);
+  });
+
+  it('rejects unguarded :hover { border: shorthand }', async () => {
+    const result = await lint({
+      code: `.cinder-example:hover { border: 1px solid red; }`,
+    });
+    expect(warningsOf(result)).toHaveLength(1);
+  });
+
+  it('rejects unguarded :hover { border-inline-start-color: ... }', async () => {
+    const result = await lint({
+      code: `.cinder-example:hover { border-inline-start-color: red; }`,
+    });
+    expect(warningsOf(result)).toHaveLength(1);
+  });
+
+  it('accepts @media (hover: hover) wrapping the :hover rule', async () => {
+    const result = await lint({
+      code: `@media (hover: hover) { .cinder-example:hover { background: red; } }`,
+    });
+    expect(warningsOf(result)).toHaveLength(0);
+  });
+
+  it('accepts conjunctive media (forced-colors: active) and (hover: hover)', async () => {
+    const result = await lint({
+      code: `@media (forced-colors: active) and (hover: hover) { .cinder-example:hover { border-color: ButtonText; } }`,
+    });
+    expect(warningsOf(result)).toHaveLength(0);
+  });
+
+  it('accepts nested media where ancestor satisfies the guard', async () => {
+    const result = await lint({
+      code: `@media (hover: hover) { @media (prefers-reduced-motion: no-preference) { .cinder-example:hover { background: red; } } }`,
+    });
+    expect(warningsOf(result)).toHaveLength(0);
+  });
+
+  it('rejects comma-separated media list even when one branch is (hover: hover)', async () => {
+    const result = await lint({
+      code: `@media (hover: hover), (min-width: 1px) { .cinder-example:hover { background: red; } }`,
+    });
+    expect(warningsOf(result)).toHaveLength(1);
+  });
+
+  it('rejects negated media @media not (hover: hover)', async () => {
+    const result = await lint({
+      code: `@media not (hover: hover) { .cinder-example:hover { background: red; } }`,
+    });
+    expect(warningsOf(result)).toHaveLength(1);
+  });
+
+  it('passes :hover that only changes non-target properties', async () => {
+    const result = await lint({
+      code: `.cinder-example:hover { color: red; text-decoration: underline; z-index: 1; }`,
+    });
+    expect(warningsOf(result)).toHaveLength(0);
+  });
+
+  it('passes :focus-visible rules that change background/border', async () => {
+    const result = await lint({
+      code: `.cinder-example:focus-visible { background: red; border-color: blue; }`,
+    });
+    expect(warningsOf(result)).toHaveLength(0);
+  });
+
+  it('rejects :where(:hover, :focus-visible) when unguarded', async () => {
+    const result = await lint({
+      code: `.cinder-example:where(:hover, :focus-visible) { background: red; }`,
+    });
+    expect(warningsOf(result)).toHaveLength(1);
+  });
+
+  it('rejects (any-hover: hover) — only (hover: hover) is accepted', async () => {
+    const result = await lint({
+      code: `@media (any-hover: hover) { .cinder-example:hover { background: red; } }`,
+    });
+    expect(warningsOf(result)).toHaveLength(1);
+  });
+
+  it('rejects Svelte <style> block with unguarded :hover background', async () => {
+    const result = await lint({
+      code: `<style>.cinder-example:hover { background: red; }</style>`,
+      codeFilename: '/virtual/example/component.svelte',
+      customSyntax: 'postcss-html',
+    });
+    expect(warningsOf(result)).toHaveLength(1);
+  });
+
+  it('skips ::-webkit-scrollbar pseudo-elements (real cursor hover, not touch-synthesized)', async () => {
+    const result = await lint({
+      code: `.area::-webkit-scrollbar-thumb:hover { background: red; }`,
+    });
+    expect(warningsOf(result)).toHaveLength(0);
+  });
+
+  it('skips scrollbar thumb hover inside @media (forced-colors: active)', async () => {
+    const result = await lint({
+      code: `@media (forced-colors: active) { .area::-webkit-scrollbar-thumb:hover { background: ButtonText; } }`,
+    });
+    expect(warningsOf(result)).toHaveLength(0);
+  });
+
+  it('rejects unguarded :hover inside @supports (no hover guard ancestor)', async () => {
+    const result = await lint({
+      code: `@supports (display: grid) { .cinder-example:hover { background: red; } }`,
+    });
+    expect(warningsOf(result)).toHaveLength(1);
+  });
+
+  it('rejects @media not print and (hover: hover) — `not` modifier disqualifies', async () => {
+    const result = await lint({
+      code: `@media not print and (hover: hover) { .cinder-example:hover { background: red; } }`,
+    });
+    expect(warningsOf(result)).toHaveLength(1);
+  });
+
+  it('does not flag custom-property declarations in :hover (intentional — outside target set)', async () => {
+    const result = await lint({
+      code: `.cinder-example:hover { --cinder-surface-hover: red; }`,
+    });
+    expect(warningsOf(result)).toHaveLength(0);
+  });
+
+  it('emits one warning per offending declaration', async () => {
+    const result = await lint({
+      code: `.cinder-example:hover { background: red; border-color: blue; }`,
+    });
+    const warnings = warningsOf(result);
+    expect(warnings).toHaveLength(2);
+    const props = warnings.map((w) => w.text);
+    expect(props.some((t) => t.includes('background'))).toBe(true);
+    expect(props.some((t) => t.includes('border-color'))).toBe(true);
+  });
+});

--- a/packages/components/scripts/stylelint/no-unguarded-hover-colors.test.ts
+++ b/packages/components/scripts/stylelint/no-unguarded-hover-colors.test.ts
@@ -144,6 +144,13 @@ describe('cinder/no-unguarded-hover-colors', () => {
     expect(warningsOf(result)).toHaveLength(1);
   });
 
+  it('flags non-scrollbar :hover in a mixed selector list (per-branch evaluation)', async () => {
+    const result = await lint({
+      code: `.foo:hover, .area::-webkit-scrollbar-thumb:hover { background: red; }`,
+    });
+    expect(warningsOf(result)).toHaveLength(1);
+  });
+
   it('skips ::-webkit-scrollbar pseudo-elements (real cursor hover, not touch-synthesized)', async () => {
     const result = await lint({
       code: `.area::-webkit-scrollbar-thumb:hover { background: red; }`,

--- a/packages/components/src/components/accordion-item/accordion-item.css
+++ b/packages/components/src/components/accordion-item/accordion-item.css
@@ -48,8 +48,11 @@
     color var(--cinder-duration-fast) var(--cinder-ease-standard);
 }
 
-.cinder-accordion-item__trigger:hover:not(:disabled) {
-  background: var(--cinder-surface-hover);
+/* Sticky-hover suppression on touch. */
+@media (hover: hover) {
+  .cinder-accordion-item__trigger:hover:not(:disabled) {
+    background: var(--cinder-surface-hover);
+  }
 }
 
 .cinder-accordion-item__trigger:active:not(:disabled) {

--- a/packages/components/src/components/banner/banner.css
+++ b/packages/components/src/components/banner/banner.css
@@ -185,9 +185,12 @@
     border-block: 1px solid CanvasText;
   }
 
-  /* `color-mix` against transparent is unreliable in forced-colors mode; pin to ButtonFace. */
-  .cinder-banner__dismiss:hover {
-    background: ButtonFace;
+  /* `color-mix` against transparent is unreliable in forced-colors mode; pin to ButtonFace.
+   * Nested under @media (hover: hover) to suppress sticky-hover on touch. */
+  @media (hover: hover) {
+    .cinder-banner__dismiss:hover {
+      background: ButtonFace;
+    }
   }
 
   .cinder-banner__dismiss:focus-visible {

--- a/packages/components/src/components/chat/artifact/artifact-panel.svelte
+++ b/packages/components/src/components/chat/artifact/artifact-panel.svelte
@@ -97,9 +97,11 @@
       color var(--cinder-duration-fast) var(--cinder-ease-standard);
   }
 
-  .artifact-panel-close:hover {
-    background: var(--cinder-surface-hover);
-    color: var(--cinder-text);
+  @media (hover: hover) {
+    .artifact-panel-close:hover {
+      background: var(--cinder-surface-hover);
+      color: var(--cinder-text);
+    }
   }
 
   .artifact-panel-close:focus-visible {

--- a/packages/components/src/components/chat/container/chat-jump-controls.svelte
+++ b/packages/components/src/components/chat/container/chat-jump-controls.svelte
@@ -113,9 +113,11 @@
     }
   }
 
-  .chat-jump-button:hover {
-    background: var(--cinder-surface-hover);
-    box-shadow: var(--cinder-shadow-lg);
+  @media (hover: hover) {
+    .chat-jump-button:hover {
+      background: var(--cinder-surface-hover);
+      box-shadow: var(--cinder-shadow-lg);
+    }
   }
 
   .chat-jump-button:focus-visible {

--- a/packages/components/src/components/chat/container/chat-search-bar.svelte
+++ b/packages/components/src/components/chat/container/chat-search-bar.svelte
@@ -227,10 +227,12 @@
       color var(--cinder-duration-fast) var(--cinder-ease-standard);
   }
 
-  .chat-search-nav-button:hover,
-  .chat-search-close:hover {
-    background: var(--cinder-surface-hover);
-    color: var(--cinder-text);
+  @media (hover: hover) {
+    .chat-search-nav-button:hover,
+    .chat-search-close:hover {
+      background: var(--cinder-surface-hover);
+      color: var(--cinder-text);
+    }
   }
 
   .chat-search-nav-button:focus-visible,
@@ -244,8 +246,10 @@
     cursor: not-allowed;
   }
 
-  .chat-search-nav-button:disabled:hover {
-    background: transparent;
-    color: var(--cinder-text-muted);
+  @media (hover: hover) {
+    .chat-search-nav-button:disabled:hover {
+      background: transparent;
+      color: var(--cinder-text-muted);
+    }
   }
 </style>

--- a/packages/components/src/components/chat/container/chat.svelte
+++ b/packages/components/src/components/chat/container/chat.svelte
@@ -817,9 +817,11 @@
       border-color var(--cinder-duration-fast) var(--cinder-ease-standard);
   }
 
-  .chat-empty-prompt:hover {
-    background: var(--cinder-surface-hover);
-    border-color: var(--cinder-accent);
+  @media (hover: hover) {
+    .chat-empty-prompt:hover {
+      background: var(--cinder-surface-hover);
+      border-color: var(--cinder-accent);
+    }
   }
 
   .chat-empty-prompt:focus-visible {

--- a/packages/components/src/components/chat/export/conversation-export-actions.svelte
+++ b/packages/components/src/components/chat/export/conversation-export-actions.svelte
@@ -179,8 +179,10 @@
     transition: background-color var(--cinder-duration-fast) var(--cinder-ease-standard);
   }
 
-  .conversation-export-actions :global(.export-trigger:hover) {
-    background: var(--cinder-surface-hover);
+  @media (hover: hover) {
+    .conversation-export-actions :global(.export-trigger:hover) {
+      background: var(--cinder-surface-hover);
+    }
   }
 
   .conversation-export-actions :global(.export-trigger:focus-visible) {

--- a/packages/components/src/components/chat/input/chat-input.svelte
+++ b/packages/components/src/components/chat/input/chat-input.svelte
@@ -685,8 +685,10 @@
     z-index: -1;
   }
 
-  .chat-input-attachment-remove:hover::before {
-    background: var(--cinder-danger);
+  @media (hover: hover) {
+    .chat-input-attachment-remove:hover::before {
+      background: var(--cinder-danger);
+    }
   }
 
   .chat-input-attachment-wrapper:hover .chat-input-attachment-remove,
@@ -810,8 +812,10 @@
       transform var(--cinder-duration-fast) var(--cinder-ease-standard);
   }
 
-  .chat-input-send:hover:not(:disabled) {
-    background: color-mix(in oklch, var(--cinder-accent), black 15%);
+  @media (hover: hover) {
+    .chat-input-send:hover:not(:disabled) {
+      background: color-mix(in oklch, var(--cinder-accent), black 15%);
+    }
   }
 
   .chat-input-send:active:not(:disabled) {
@@ -838,9 +842,11 @@
     border: 1px solid color-mix(in oklch, var(--cinder-danger), transparent 60%);
   }
 
-  .chat-input-send[data-stop]:hover {
-    background: color-mix(in oklch, var(--cinder-danger), transparent 75%);
-    border-color: var(--cinder-danger);
+  @media (hover: hover) {
+    .chat-input-send[data-stop]:hover {
+      background: color-mix(in oklch, var(--cinder-danger), transparent 75%);
+      border-color: var(--cinder-danger);
+    }
   }
 
   .chat-input-send[data-stop]:focus-visible {

--- a/packages/components/src/components/chat/message/chat-message.svelte
+++ b/packages/components/src/components/chat/message/chat-message.svelte
@@ -618,9 +618,11 @@
       border-color var(--cinder-duration-fast) var(--cinder-ease-standard);
   }
 
-  .chat-message-retry:hover {
-    background: color-mix(in oklch, var(--cinder-danger), transparent 90%);
-    border-color: var(--cinder-danger);
+  @media (hover: hover) {
+    .chat-message-retry:hover {
+      background: color-mix(in oklch, var(--cinder-danger), transparent 90%);
+      border-color: var(--cinder-danger);
+    }
   }
 
   .chat-message-retry:focus-visible {
@@ -739,9 +741,11 @@
       background var(--cinder-duration-fast) var(--cinder-ease-standard);
   }
 
-  .chat-message-copy:hover {
-    color: var(--cinder-text);
-    background: var(--cinder-surface-hover);
+  @media (hover: hover) {
+    .chat-message-copy:hover {
+      color: var(--cinder-text);
+      background: var(--cinder-surface-hover);
+    }
   }
 
   .chat-message-copy:focus-visible {
@@ -753,9 +757,11 @@
     color: var(--cinder-success);
   }
 
-  .chat-message-copy-success:hover {
-    color: var(--cinder-success);
-    background: color-mix(in oklch, var(--cinder-success), transparent 90%);
+  @media (hover: hover) {
+    .chat-message-copy-success:hover {
+      color: var(--cinder-success);
+      background: color-mix(in oklch, var(--cinder-success), transparent 90%);
+    }
   }
 
   /* Edit button (icon action button, visually identical to copy button) */
@@ -775,9 +781,11 @@
       background var(--cinder-duration-fast) var(--cinder-ease-standard);
   }
 
-  .chat-message-edit-button:hover {
-    color: var(--cinder-text);
-    background: var(--cinder-surface-hover);
+  @media (hover: hover) {
+    .chat-message-edit-button:hover {
+      color: var(--cinder-text);
+      background: var(--cinder-surface-hover);
+    }
   }
 
   .chat-message-edit-button:focus-visible {
@@ -829,8 +837,10 @@
     transition: background var(--cinder-duration-fast) var(--cinder-ease-standard);
   }
 
-  .chat-message-edit-save:hover {
-    background: color-mix(in oklch, var(--cinder-accent), black 15%);
+  @media (hover: hover) {
+    .chat-message-edit-save:hover {
+      background: color-mix(in oklch, var(--cinder-accent), black 15%);
+    }
   }
 
   .chat-message-edit-save:focus-visible {
@@ -853,9 +863,11 @@
       color var(--cinder-duration-fast) var(--cinder-ease-standard);
   }
 
-  .chat-message-edit-cancel:hover {
-    color: var(--cinder-text);
-    background: var(--cinder-surface-hover);
+  @media (hover: hover) {
+    .chat-message-edit-cancel:hover {
+      color: var(--cinder-text);
+      background: var(--cinder-surface-hover);
+    }
   }
 
   .chat-message-edit-cancel:focus-visible {

--- a/packages/components/src/components/chat/message/image-lightbox.svelte
+++ b/packages/components/src/components/chat/message/image-lightbox.svelte
@@ -190,8 +190,10 @@
     z-index: 1;
   }
 
-  .lightbox-close:hover {
-    background: rgba(255, 255, 255, 0.2);
+  @media (hover: hover) {
+    .lightbox-close:hover {
+      background: rgba(255, 255, 255, 0.2);
+    }
   }
 
   .lightbox-close:focus-visible {
@@ -218,8 +220,10 @@
     z-index: 1;
   }
 
-  .lightbox-nav:hover {
-    background: rgba(255, 255, 255, 0.2);
+  @media (hover: hover) {
+    .lightbox-nav:hover {
+      background: rgba(255, 255, 255, 0.2);
+    }
   }
 
   .lightbox-nav:focus-visible {

--- a/packages/components/src/components/chat/message/tool-call-group.svelte
+++ b/packages/components/src/components/chat/message/tool-call-group.svelte
@@ -147,8 +147,10 @@
 
   /* Hover: subtle inset tint instead of the full surface-hover gray, which
    * looked harsh against the colored card border. */
-  .tool-call-header:hover {
-    background: color-mix(in oklch, var(--cinder-surface), var(--cinder-text) 4%);
+  @media (hover: hover) {
+    .tool-call-header:hover {
+      background: color-mix(in oklch, var(--cinder-surface), var(--cinder-text) 4%);
+    }
   }
 
   /* Focus: ring travels via box-shadow, not outline, so it sits inside the

--- a/packages/components/src/components/checkbox-group/checkbox-group.css
+++ b/packages/components/src/components/checkbox-group/checkbox-group.css
@@ -67,10 +67,14 @@
     background var(--cinder-duration-fast) var(--cinder-ease-standard);
 }
 
-.cinder-checkbox-group[data-variant='card']
-  .cinder-checkbox-group__items
-  > .cinder-checkbox-field:hover {
-  border-color: var(--cinder-border-strong);
+/* Sticky-hover suppression on touch. The :not(:has(input:disabled)) exclusion
+ * replaces a separate disabled-state reset rule. */
+@media (hover: hover) {
+  .cinder-checkbox-group[data-variant='card']
+    .cinder-checkbox-group__items
+    > .cinder-checkbox-field:hover:not(:has(input:disabled)) {
+    border-color: var(--cinder-border-strong);
+  }
 }
 
 /* Checked highlight — additive only; the check glyph is the canonical indicator. */
@@ -88,12 +92,6 @@
   background: var(--cinder-surface-inset);
   border-color: var(--cinder-border-muted);
   cursor: not-allowed;
-}
-
-.cinder-checkbox-group[data-variant='card']
-  .cinder-checkbox-group__items
-  > .cinder-checkbox-field:has(input:disabled):hover {
-  border-color: var(--cinder-border-muted);
 }
 
 @media (forced-colors: active) {

--- a/packages/components/src/components/code-block/code-block.css
+++ b/packages/components/src/components/code-block/code-block.css
@@ -81,10 +81,13 @@
   color: var(--cinder-text-subtle);
 }
 
-.cinder-code-block .cinder-code-block__header .cinder-copy-button:hover {
-  background: var(--cinder-surface-hover);
-  color: var(--cinder-text);
-  border-color: transparent;
+/* Sticky-hover suppression on touch. */
+@media (hover: hover) {
+  .cinder-code-block .cinder-code-block__header .cinder-copy-button:hover {
+    background: var(--cinder-surface-hover);
+    color: var(--cinder-text);
+    border-color: transparent;
+  }
 }
 
 .cinder-code-block .cinder-code-block__header .cinder-copy-button:focus-visible {

--- a/packages/components/src/components/combobox/combobox.css
+++ b/packages/components/src/components/combobox/combobox.css
@@ -42,8 +42,11 @@
     box-shadow var(--cinder-duration-fast) var(--cinder-ease-standard);
 }
 
-.cinder-combobox__input:hover:not(:disabled) {
-  border-color: var(--cinder-border-strong);
+/* Sticky-hover suppression on touch. */
+@media (hover: hover) {
+  .cinder-combobox__input:hover:not(:disabled) {
+    border-color: var(--cinder-border-strong);
+  }
 }
 
 .cinder-combobox__input:focus-visible {

--- a/packages/components/src/components/copy-button/copy-button.css
+++ b/packages/components/src/components/copy-button/copy-button.css
@@ -23,10 +23,14 @@
     border-color var(--cinder-duration-fast) var(--cinder-ease-standard);
 }
 
-.cinder-copy-button:hover {
-  color: var(--cinder-text);
-  background: var(--cinder-surface-hover);
-  border-color: var(--cinder-border-strong);
+/* Sticky-hover suppression on touch: wrap hover-only chrome so it doesn't
+ * "stick" after tap on touch devices that emulate :hover. */
+@media (hover: hover) {
+  .cinder-copy-button:hover {
+    color: var(--cinder-text);
+    background: var(--cinder-surface-hover);
+    border-color: var(--cinder-border-strong);
+  }
 }
 
 .cinder-copy-button:focus-visible {

--- a/packages/components/src/components/diff-viewer/front-matter-header.svelte
+++ b/packages/components/src/components/diff-viewer/front-matter-header.svelte
@@ -133,8 +133,10 @@
     padding: 0;
   }
 
-  .front-matter-header:hover {
-    background: var(--cinder-surface-hover);
+  @media (hover: hover) {
+    .front-matter-header:hover {
+      background: var(--cinder-surface-hover);
+    }
   }
 
   .front-matter-header:focus-visible {

--- a/packages/components/src/components/drawer/drawer.css
+++ b/packages/components/src/components/drawer/drawer.css
@@ -99,9 +99,12 @@
     color var(--cinder-duration-fast) var(--cinder-ease-standard);
 }
 
-.cinder-drawer__close:hover {
-  background: color-mix(in oklch, currentColor, transparent 85%);
-  color: var(--cinder-text);
+/* Sticky-hover suppression on touch. */
+@media (hover: hover) {
+  .cinder-drawer__close:hover {
+    background: color-mix(in oklch, currentColor, transparent 85%);
+    color: var(--cinder-text);
+  }
 }
 
 .cinder-drawer__close:focus-visible {

--- a/packages/components/src/components/input/input.css
+++ b/packages/components/src/components/input/input.css
@@ -59,8 +59,11 @@
   color: var(--cinder-text-subtle);
 }
 
-.cinder-input:hover:not(:disabled) {
-  border-color: var(--cinder-border-strong);
+/* Sticky-hover suppression on touch. */
+@media (hover: hover) {
+  .cinder-input:hover:not(:disabled) {
+    border-color: var(--cinder-border-strong);
+  }
 }
 
 .cinder-input[data-cinder-native-date] {
@@ -121,8 +124,10 @@
   border-color: var(--cinder-danger);
 }
 
-.cinder-input[aria-invalid='true']:hover:not(:disabled) {
-  border-color: oklch(from var(--cinder-danger) calc(l - 0.06) c h);
+@media (hover: hover) {
+  .cinder-input[aria-invalid='true']:hover:not(:disabled) {
+    border-color: oklch(from var(--cinder-danger) calc(l - 0.06) c h);
+  }
 }
 
 /* ----------------------------------------
@@ -189,9 +194,11 @@
   outline: none;
 }
 
-/* Hover mirrors the standalone input. */
-.cinder-input-group:hover:not([data-disabled]) {
-  border-color: var(--cinder-border-strong);
+/* Hover mirrors the standalone input. Sticky-hover suppression on touch. */
+@media (hover: hover) {
+  .cinder-input-group:hover:not([data-disabled]) {
+    border-color: var(--cinder-border-strong);
+  }
 }
 
 /* Focus ring on the group via :focus-within — same token math as standalone. */
@@ -215,8 +222,10 @@
   --_cinder-input-ring: var(--cinder-danger);
   border-color: var(--cinder-danger);
 }
-.cinder-input-group[data-invalid]:hover:not([data-disabled]) {
-  border-color: oklch(from var(--cinder-danger) calc(l - 0.06) c h);
+@media (hover: hover) {
+  .cinder-input-group[data-invalid]:hover:not([data-disabled]) {
+    border-color: oklch(from var(--cinder-danger) calc(l - 0.06) c h);
+  }
 }
 
 /* Disabled state. */

--- a/packages/components/src/components/json-schema-editor/json-schema-editor.css
+++ b/packages/components/src/components/json-schema-editor/json-schema-editor.css
@@ -152,8 +152,10 @@
   color: var(--cinder-text);
 }
 
-.cinder-jse-collapsed:hover {
-  background: var(--cinder-surface-raised);
+@media (hover: hover) {
+  .cinder-jse-collapsed:hover {
+    background: var(--cinder-surface-raised);
+  }
 }
 
 .cinder-jse-collapsed__hint {

--- a/packages/components/src/components/markdown-editor/editor-toolbar/link-popover.svelte
+++ b/packages/components/src/components/markdown-editor/editor-toolbar/link-popover.svelte
@@ -268,9 +268,11 @@
       color var(--cinder-duration-fast) var(--cinder-ease-standard);
   }
 
-  .link-popover-close:hover {
-    color: var(--cinder-text);
-    background: var(--cinder-surface-hover);
+  @media (hover: hover) {
+    .link-popover-close:hover {
+      color: var(--cinder-text);
+      background: var(--cinder-surface-hover);
+    }
   }
 
   .link-popover-close:focus-visible {

--- a/packages/components/src/components/markdown-editor/editor-toolbar/toolbar-button.svelte
+++ b/packages/components/src/components/markdown-editor/editor-toolbar/toolbar-button.svelte
@@ -70,9 +70,11 @@
       color var(--cinder-duration-fast) var(--cinder-ease-standard);
   }
 
-  .toolbar-button:hover:not(:disabled) {
-    background: var(--cinder-surface-hover);
-    color: var(--cinder-text);
+  @media (hover: hover) {
+    .toolbar-button:hover:not(:disabled) {
+      background: var(--cinder-surface-hover);
+      color: var(--cinder-text);
+    }
   }
 
   .toolbar-button:active:not(:disabled) {
@@ -84,9 +86,11 @@
     color: var(--cinder-accent);
   }
 
-  .toolbar-button[data-active]:hover:not(:disabled) {
-    background: var(--cinder-surface-pressed);
-    color: var(--cinder-accent);
+  @media (hover: hover) {
+    .toolbar-button[data-active]:hover:not(:disabled) {
+      background: var(--cinder-surface-pressed);
+      color: var(--cinder-accent);
+    }
   }
 
   .toolbar-button:focus-visible {

--- a/packages/components/src/components/markdown-editor/editor-toolbar/toolbar-dropdown.svelte
+++ b/packages/components/src/components/markdown-editor/editor-toolbar/toolbar-dropdown.svelte
@@ -96,9 +96,11 @@
       color var(--cinder-duration-fast) var(--cinder-ease-standard);
   }
 
-  :global(.toolbar-dropdown-trigger:hover:not(:disabled)) {
-    background: var(--cinder-surface-hover);
-    color: var(--cinder-text);
+  @media (hover: hover) {
+    :global(.toolbar-dropdown-trigger:hover:not(:disabled)) {
+      background: var(--cinder-surface-hover);
+      color: var(--cinder-text);
+    }
   }
 
   :global(.toolbar-dropdown-trigger:focus-visible) {

--- a/packages/components/src/components/markdown-editor/markdown-editor.svelte
+++ b/packages/components/src/components/markdown-editor/markdown-editor.svelte
@@ -835,9 +835,14 @@
     line-height: 1.4;
   }
 
-  .markdown-editor :global(.template-completion-item:hover),
   .markdown-editor :global(.template-completion-item--active) {
     background: var(--cinder-surface-active, #f0f4ff);
+  }
+
+  @media (hover: hover) {
+    .markdown-editor :global(.template-completion-item:hover) {
+      background: var(--cinder-surface-active, #f0f4ff);
+    }
   }
 
   .markdown-editor :global(.template-completion-item-path) {

--- a/packages/components/src/components/modal/modal.css
+++ b/packages/components/src/components/modal/modal.css
@@ -95,9 +95,11 @@
     box-shadow var(--cinder-duration-fast) var(--cinder-ease-standard);
 }
 
-.cinder-modal__close:hover {
-  background: color-mix(in oklch, currentColor, transparent 85%);
-  color: var(--cinder-text);
+@media (hover: hover) {
+  .cinder-modal__close:hover {
+    background: color-mix(in oklch, currentColor, transparent 85%);
+    color: var(--cinder-text);
+  }
 }
 
 .cinder-modal__close:focus-visible {

--- a/packages/components/src/components/number-input/number-input.css
+++ b/packages/components/src/components/number-input/number-input.css
@@ -14,8 +14,10 @@
     box-shadow var(--cinder-duration-fast) var(--cinder-ease-standard);
 }
 
-.cinder-number-input:hover:not([data-disabled]) {
-  border-color: var(--cinder-border-strong);
+@media (hover: hover) {
+  .cinder-number-input:hover:not([data-disabled]) {
+    border-color: var(--cinder-border-strong);
+  }
 }
 
 .cinder-number-input:focus-within {
@@ -81,9 +83,11 @@
     color var(--cinder-duration-fast) var(--cinder-ease-standard);
 }
 
-.cinder-number-input__stepper:hover:not(:disabled) {
-  background: var(--cinder-surface-hover);
-  color: var(--cinder-text);
+@media (hover: hover) {
+  .cinder-number-input__stepper:hover:not(:disabled) {
+    background: var(--cinder-surface-hover);
+    color: var(--cinder-text);
+  }
 }
 
 .cinder-number-input__stepper:focus-visible {

--- a/packages/components/src/components/pagination/pagination.css
+++ b/packages/components/src/components/pagination/pagination.css
@@ -74,10 +74,12 @@
  * Hover — non-current, non-disabled
  * ---------------------------------------- */
 
-.cinder-pagination__step:hover:not(:disabled),
-.cinder-pagination__page:hover:not([data-cinder-current]) {
-  background: color-mix(in oklch, var(--cinder-text) 8%, transparent);
-  border-color: var(--cinder-border-muted);
+@media (hover: hover) {
+  .cinder-pagination__step:hover:not(:disabled),
+  .cinder-pagination__page:hover:not([data-cinder-current]) {
+    background: color-mix(in oklch, var(--cinder-text) 8%, transparent);
+    border-color: var(--cinder-border-muted);
+  }
 }
 
 /* ----------------------------------------

--- a/packages/components/src/components/radio-group/radio-group.css
+++ b/packages/components/src/components/radio-group/radio-group.css
@@ -73,8 +73,12 @@
     box-shadow var(--cinder-duration-fast) var(--cinder-ease-standard);
 }
 
-.cinder-radio:hover:not(:disabled) {
-  border-color: var(--cinder-border-strong);
+/* Sticky-hover suppression on touch: wrap hover-only chrome so it doesn't
+ * "stick" after tap on touch devices that emulate :hover. */
+@media (hover: hover) {
+  .cinder-radio:hover:not(:disabled) {
+    border-color: var(--cinder-border-strong);
+  }
 }
 
 .cinder-radio:focus-visible {
@@ -184,8 +188,13 @@
     background var(--cinder-duration-fast) var(--cinder-ease-standard);
 }
 
-.cinder-radio-group[data-variant='card'] .cinder-radio-row:hover {
-  border-color: var(--cinder-border-strong);
+/* Sticky-hover suppression on touch: wrap hover-only chrome so it doesn't
+ * "stick" after tap on touch devices that emulate :hover. The :not([data-disabled])
+ * exclusion replaces a separate reset rule for disabled cards. */
+@media (hover: hover) {
+  .cinder-radio-group[data-variant='card'] .cinder-radio-row:hover:not([data-disabled]) {
+    border-color: var(--cinder-border-strong);
+  }
 }
 
 /* Selection reinforcement — NOT the sole indicator. */
@@ -204,11 +213,6 @@
   background: var(--cinder-surface-inset);
   border-color: var(--cinder-border-muted);
   cursor: not-allowed;
-}
-
-/* Suppress hover on disabled cards. */
-.cinder-radio-group[data-variant='card'] .cinder-radio-row[data-disabled]:hover {
-  border-color: var(--cinder-border-muted);
 }
 
 @media (forced-colors: active) {

--- a/packages/components/src/components/review-editor/comment-list.svelte
+++ b/packages/components/src/components/review-editor/comment-list.svelte
@@ -297,15 +297,17 @@
       color var(--cinder-duration-fast) var(--cinder-ease-standard);
   }
 
-  .comment-action:hover {
-    color: var(--cinder-text);
-    background: var(--cinder-surface-hover);
-  }
+  @media (hover: hover) {
+    .comment-action:hover {
+      color: var(--cinder-text);
+      background: var(--cinder-surface-hover);
+    }
 
-  .comment-action-danger:hover {
-    color: var(--cinder-danger);
-    background: color-mix(in oklch, var(--cinder-danger), transparent 90%);
-    border-color: var(--cinder-danger);
+    .comment-action-danger:hover {
+      color: var(--cinder-danger);
+      background: color-mix(in oklch, var(--cinder-danger), transparent 90%);
+      border-color: var(--cinder-danger);
+    }
   }
 
   .comment-list-empty {

--- a/packages/components/src/components/review-editor/comment-sidebar.svelte
+++ b/packages/components/src/components/review-editor/comment-sidebar.svelte
@@ -282,9 +282,11 @@
       color var(--cinder-duration-fast) var(--cinder-ease-standard);
   }
 
-  .sidebar-header :global(.actions-trigger:hover) {
-    background: var(--cinder-surface-hover);
-    color: var(--cinder-text);
+  @media (hover: hover) {
+    .sidebar-header :global(.actions-trigger:hover) {
+      background: var(--cinder-surface-hover);
+      color: var(--cinder-text);
+    }
   }
 
   .sidebar-header :global(.actions-trigger:focus-visible) {
@@ -357,9 +359,11 @@
       border-color var(--cinder-duration-fast) var(--cinder-ease-standard);
   }
 
-  .thread-item:hover {
-    background: var(--cinder-surface-hover);
-    border-color: var(--cinder-border);
+  @media (hover: hover) {
+    .thread-item:hover {
+      background: var(--cinder-surface-hover);
+      border-color: var(--cinder-border);
+    }
   }
 
   .thread-item:focus-visible {

--- a/packages/components/src/components/review-editor/export-actions.svelte
+++ b/packages/components/src/components/review-editor/export-actions.svelte
@@ -183,8 +183,10 @@
     transition: background-color var(--cinder-duration-fast) var(--cinder-ease-standard);
   }
 
-  .export-actions :global(.export-trigger:hover) {
-    background: var(--cinder-surface-hover);
+  @media (hover: hover) {
+    .export-actions :global(.export-trigger:hover) {
+      background: var(--cinder-surface-hover);
+    }
   }
 
   .export-actions :global(.export-trigger:focus-visible) {

--- a/packages/components/src/components/review-editor/review-editor.css
+++ b/packages/components/src/components/review-editor/review-editor.css
@@ -219,6 +219,8 @@
   transition: background var(--cinder-duration-fast) var(--cinder-ease-standard);
 }
 
-.review-editor-container .comment-anchor:hover {
-  background: color-mix(in oklch, var(--cinder-accent), transparent 75%);
+@media (hover: hover) {
+  .review-editor-container .comment-anchor:hover {
+    background: color-mix(in oklch, var(--cinder-accent), transparent 75%);
+  }
 }

--- a/packages/components/src/components/review-editor/thread-popover.svelte
+++ b/packages/components/src/components/review-editor/thread-popover.svelte
@@ -270,9 +270,11 @@
       color var(--cinder-duration-fast) var(--cinder-ease-standard);
   }
 
-  .thread-popover-close:hover {
-    color: var(--cinder-text);
-    background: var(--cinder-surface-hover);
+  @media (hover: hover) {
+    .thread-popover-close:hover {
+      color: var(--cinder-text);
+      background: var(--cinder-surface-hover);
+    }
   }
 
   .thread-popover-close:focus-visible {

--- a/packages/components/src/components/search-field/search-field.css
+++ b/packages/components/src/components/search-field/search-field.css
@@ -18,8 +18,10 @@
     box-shadow var(--cinder-duration-fast) var(--cinder-ease-standard);
 }
 
-.cinder-search-field:hover:not([data-disabled]) {
-  border-color: var(--cinder-border-strong);
+@media (hover: hover) {
+  .cinder-search-field:hover:not([data-disabled]) {
+    border-color: var(--cinder-border-strong);
+  }
 }
 
 .cinder-search-field:focus-within {
@@ -141,9 +143,11 @@
   display: none;
 }
 
-.cinder-search-field__clear:hover:not(:disabled) {
-  color: var(--cinder-text);
-  background: var(--cinder-surface-inset);
+@media (hover: hover) {
+  .cinder-search-field__clear:hover:not(:disabled) {
+    color: var(--cinder-text);
+    background: var(--cinder-surface-inset);
+  }
 }
 
 .cinder-search-field__clear:focus-visible {

--- a/packages/components/src/components/segmented-control/segmented-control.css
+++ b/packages/components/src/components/segmented-control/segmented-control.css
@@ -163,11 +163,15 @@
 
 /* ── Hover ──────────────────────────────────────────────────────────────── */
 
-.cinder-segmented-control-option:hover:not(:disabled):not([data-cinder-selected]):not(
-    [data-cinder-pressed]
-  ) {
-  background: color-mix(in oklch, var(--cinder-accent), transparent 90%);
-  color: var(--cinder-text);
+/* Sticky-hover suppression on touch: wrap hover-only chrome so it doesn't
+ * "stick" after tap on touch devices that emulate :hover. */
+@media (hover: hover) {
+  .cinder-segmented-control-option:hover:not(:disabled):not([data-cinder-selected]):not(
+      [data-cinder-pressed]
+    ) {
+    background: color-mix(in oklch, var(--cinder-accent), transparent 90%);
+    color: var(--cinder-text);
+  }
 }
 
 /* ── Focus ──────────────────────────────────────────────────────────────── */

--- a/packages/components/src/components/select/select.css
+++ b/packages/components/src/components/select/select.css
@@ -55,8 +55,10 @@
     box-shadow var(--cinder-duration-fast) var(--cinder-ease-standard);
 }
 
-.cinder-select:hover:not(:disabled) {
-  border-color: var(--cinder-border-strong);
+@media (hover: hover) {
+  .cinder-select:hover:not(:disabled) {
+    border-color: var(--cinder-border-strong);
+  }
 }
 
 .cinder-select:focus-visible {
@@ -96,8 +98,10 @@
   border-color: var(--cinder-danger);
 }
 
-.cinder-select[aria-invalid='true']:hover:not(:disabled) {
-  border-color: oklch(from var(--cinder-danger) calc(l - 0.06) c h);
+@media (hover: hover) {
+  .cinder-select[aria-invalid='true']:hover:not(:disabled) {
+    border-color: oklch(from var(--cinder-danger) calc(l - 0.06) c h);
+  }
 }
 
 /* ----------------------------------------

--- a/packages/components/src/components/selection-popover/selection-popover.css
+++ b/packages/components/src/components/selection-popover/selection-popover.css
@@ -34,8 +34,10 @@
     transform var(--cinder-duration-fast) var(--cinder-ease-standard);
 }
 
-.cinder-selection-popover__button:hover {
-  background: var(--cinder-accent-hover);
+@media (hover: hover) {
+  .cinder-selection-popover__button:hover {
+    background: var(--cinder-accent-hover);
+  }
 }
 
 .cinder-selection-popover__button:focus-visible {
@@ -106,9 +108,11 @@
   color: var(--cinder-text-muted);
 }
 
-.cinder-selection-popover__cancel:hover {
-  background: var(--cinder-surface-hover);
-  color: var(--cinder-text);
+@media (hover: hover) {
+  .cinder-selection-popover__cancel:hover {
+    background: var(--cinder-surface-hover);
+    color: var(--cinder-text);
+  }
 }
 
 .cinder-selection-popover__submit {
@@ -116,8 +120,10 @@
   color: var(--cinder-accent-contrast);
 }
 
-.cinder-selection-popover__submit:hover:not(:disabled) {
-  background: var(--cinder-accent-hover);
+@media (hover: hover) {
+  .cinder-selection-popover__submit:hover:not(:disabled) {
+    background: var(--cinder-accent-hover);
+  }
 }
 
 .cinder-selection-popover__submit:disabled {

--- a/packages/components/src/components/sheet/sheet.css
+++ b/packages/components/src/components/sheet/sheet.css
@@ -101,9 +101,11 @@
     color var(--cinder-duration-fast) var(--cinder-ease-standard);
 }
 
-.cinder-sheet__close:hover {
-  background: color-mix(in oklch, currentColor, transparent 85%);
-  color: var(--cinder-text);
+@media (hover: hover) {
+  .cinder-sheet__close:hover {
+    background: color-mix(in oklch, currentColor, transparent 85%);
+    color: var(--cinder-text);
+  }
 }
 
 .cinder-sheet__close:focus-visible {

--- a/packages/components/src/components/side-navigation-group/side-navigation-group.css
+++ b/packages/components/src/components/side-navigation-group/side-navigation-group.css
@@ -38,9 +38,11 @@
     background-color var(--cinder-duration-fast) var(--cinder-ease-standard);
 }
 
-.cinder-side-navigation-group__trigger:hover:not(:disabled) {
-  color: var(--cinder-text);
-  background-color: var(--cinder-surface-hover);
+@media (hover: hover) {
+  .cinder-side-navigation-group__trigger:hover:not(:disabled) {
+    color: var(--cinder-text);
+    background-color: var(--cinder-surface-hover);
+  }
 }
 
 .cinder-side-navigation-group__trigger:focus-visible {

--- a/packages/components/src/components/table/table.css
+++ b/packages/components/src/components/table/table.css
@@ -154,8 +154,10 @@
   transition: background var(--cinder-duration-fast) var(--cinder-ease-standard);
 }
 
-.cinder-table__body .cinder-table__row:hover {
-  background: var(--cinder-surface-hover);
+@media (hover: hover) {
+  .cinder-table__body .cinder-table__row:hover {
+    background: var(--cinder-surface-hover);
+  }
 }
 
 .cinder-table__cell {

--- a/packages/components/src/components/textarea/textarea.css
+++ b/packages/components/src/components/textarea/textarea.css
@@ -57,8 +57,10 @@
   color: var(--cinder-text-placeholder, var(--cinder-text-muted));
 }
 
-.cinder-textarea:hover:not(:disabled) {
-  border-color: var(--cinder-border-strong);
+@media (hover: hover) {
+  .cinder-textarea:hover:not(:disabled) {
+    border-color: var(--cinder-border-strong);
+  }
 }
 
 .cinder-textarea:focus {

--- a/packages/components/src/components/toast-region/toast-region.css
+++ b/packages/components/src/components/toast-region/toast-region.css
@@ -159,9 +159,11 @@
   transform: translate(-50%, -50%);
 }
 
-.cinder-toast__dismiss:hover {
-  color: var(--cinder-text);
-  background: var(--cinder-surface-hover);
+@media (hover: hover) {
+  .cinder-toast__dismiss:hover {
+    color: var(--cinder-text);
+    background: var(--cinder-surface-hover);
+  }
 }
 
 .cinder-toast__dismiss:focus-visible {

--- a/packages/components/src/components/toggle/toggle.css
+++ b/packages/components/src/components/toggle/toggle.css
@@ -65,12 +65,14 @@
  * Hover
  * ---------------------------------------- */
 
-.cinder-toggle:hover:not(:disabled) {
-  background: var(--cinder-toggle-track-off-hover, var(--cinder-border, #9ca3af));
-}
+@media (hover: hover) {
+  .cinder-toggle:hover:not(:disabled) {
+    background: var(--cinder-toggle-track-off-hover, var(--cinder-border, #9ca3af));
+  }
 
-.cinder-toggle[data-cinder-checked]:hover:not(:disabled) {
-  background: var(--cinder-toggle-track-on-hover, var(--cinder-accent-hover, #4f46e5));
+  .cinder-toggle[data-cinder-checked]:hover:not(:disabled) {
+    background: var(--cinder-toggle-track-on-hover, var(--cinder-accent-hover, #4f46e5));
+  }
 }
 
 /* ----------------------------------------


### PR DESCRIPTION
## Summary

On touch-primary devices, `:hover` is synthesized by a tap and sticks until the next interaction — leaving the hover background or border color painted on the last-tapped element. This PR fixes the sticky-hover regression across the cinder component library and adds a Stylelint rule that prevents it from coming back.

- Wraps every unguarded `:hover` rule that declares a `background*` or `border*` property in `@media (hover: hover)` — ~40 component CSS and Svelte files.
- Adds local Stylelint plugin `cinder/no-unguarded-hover-colors` at `packages/components/scripts/stylelint/no-unguarded-hover-colors.cjs` with 22 tests. Uses `postcss-selector-parser` to detect `:hover` inside `:where/:is/:not`, walks ancestor `@media` at-rules for a conservative guard (requires literal `(hover: hover)`, rejects comma media lists, rejects `not` modifier, rejects `(any-hover: hover)`).
- Evaluates scrollbar pseudo-element selectors per-branch so a mixed list like `.foo:hover, .bar::-webkit-scrollbar-thumb:hover` still warns on `.foo:hover`. Scrollbar pseudo-elements never paint on touch, so their `:hover` is genuine cursor hover and is intentionally exempt.
- Collapses two-rule disabled-reset patterns in `radio-group.css` and `checkbox-group.css` into a single guarded selector with `:not([data-disabled])` / `:not(:has(input:disabled))` — the base disabled rules already set `border-color: var(--cinder-border-muted)`, so the fallthrough is identical.
- Drive-by fix to clear a pre-existing lint baseline: breaks the import cycle between `generate-component-artifacts.ts` and `generate-component-constraints.ts` by extracting `discoverComponentDirectories` into its own file. Required so `bun run lint` exits 0 and the pre-push hook passes.

## Review committee
Pre-reviewed by:
- frontend-architect (3 rounds — must-fix on scroll-area scrollbar wraps, plus a round-2 per-branch refinement)
- simplicity-engineer (round 1 — APPROVED)
- testing-expert (2 rounds — round-1 suggestions for `@supports` / `not print` / custom-property tests, all addressed)
- dx-engineer (2 rounds — round-1 must-fix on path resolution was downgraded after empirical verification; redundant re-exports removed)
- junior-engineer (round 1 — APPROVED against the plan)
- Codex (gpt-5.4, xhigh → high for re-review, 3 rounds — caught the round-2 per-branch scrollbar gap)

All must-fix items addressed; final approvals from every reviewer.

## Test plan

- [x] `bun test packages/components/scripts/stylelint/no-unguarded-hover-colors.test.ts` — 22 pass
- [x] `bunx stylelint "packages/**/src/**/*.{css,svelte}"` — zero violations
- [x] `bun run lint` — exits 0
- [x] `bun run typecheck` — 0 errors
- [x] `bun run --filter cinder test` — 2,640 pass / 0 fail
- [x] `bun run build` — exits 0
- [ ] Touch device verification (manual) — tap a button, scroll away, verify the previously-tapped chrome does not stay hovered.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Broad CSS churn across many components and a new Stylelint rule can cause unexpected hover/forced-colors behavior changes and new lint failures in downstream work, though the changes are largely constrained to pointer-hover styling.
> 
> **Overview**
> Prevents *sticky hover* on touch devices by wrapping component `:hover` rules that change `background*`/`border*` properties in `@media (hover: hover)` across the component library (including some simplification of disabled-hover selectors).
> 
> Adds and enables a local Stylelint plugin rule, `cinder/no-unguarded-hover-colors`, with a Bun test suite to block future unguarded hover color changes (including conservative media-guard detection and a scrollbar pseudo-element exemption).
> 
> Extracts `discoverComponentDirectories()` into `discover-component-directories.ts` and updates generators to import it directly, avoiding an import cycle between artifacts and constraints scripts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e1e7f3d0637809da03a73f5d8f99da589074656b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->