### PR TITLE
Document Alert and Callout decision

### DIFF
--- a/docs/design-debt.md
+++ b/docs/design-debt.md
@@ -1,0 +1,26 @@
+# Design Debt
+
+This document records design decisions that unblock implementation tasks without
+requiring future executors to reopen the same product question.
+
+## Component Consolidation
+
+### C2. Alert and Callout are visually indistinguishable
+
+**Decision ID:** P6-C2
+**Source task:** `f1834ce9-87fe-4e21-9043-02b89b429abd`
+**Status:** Resolved
+**Decision date:** 2026-05-23
+
+**Decision:** Keep `Alert` and `Callout` as separate components and differentiate their visual treatments.
+
+**Accessibility boundary:** `Alert` remains the live-region notification (`role="alert"`); `Callout` remains the static prose aside (`<aside>`, no live region).
+
+**Implementation direction:** Give `Callout` a dominant `border-inline-start` stripe that uses the existing semantic status token pattern already used in `callout.css`: `var(--cinder-info)`, `var(--cinder-success)`, `var(--cinder-warning)`, and `var(--cinder-danger)`, with the same `oklch(from var(--cinder-{status}) ... h)` color algebra used by the current variant rules. Reduce `Alert`'s persistent card chrome by choosing one exact container change: replace the variant tinted full-card `background-color` with `var(--cinder-surface)`, or replace the variant-colored one-pixel `border-color` with `var(--cinder-border)`.
+
+Implementation acceptance:
+
+- `Callout` variants (`info`, `success`, `warning`, `danger`) must set `border-inline-start-width` to a larger value than `border-inline-end-width` and derive that stripe color from `--cinder-info`, `--cinder-success`, `--cinder-warning`, or `--cinder-danger` for the matching variant.
+- `Alert` variants (`info`, `success`, `warning`, `error`) must stay stripe-free and must satisfy one of these two exact outcomes: each variant's computed `background-color` equals the base `Alert` surface color, or each variant's computed `border-color` equals the base `Alert` border color.
+- Computed-style tests must prove `Callout` has a larger `border-inline-start-width` than `border-inline-end-width`, and `Alert` does not, across both light and dark color schemes.
+- `Alert` must keep `role="alert"` and must not become `role="status"`; `Callout` must not add live-region roles or `aria-live` attributes.


### PR DESCRIPTION
## Summary
- Document the P6-C2 decision to keep Alert and Callout separate
- Record the accessibility boundary for live Alert feedback versus static Callout prose
- Tighten the follow-up implementation task with exact visual and computed-style acceptance criteria

## Verification
- bunx prettier --check docs/design-debt.md
- task acceptance grep checks for decision, accessibility boundary, exact token pattern, and Alert outcomes
- committee review: prose editor approved; junior engineer approved; Codex review approved
- pre-push validation: lint, typecheck, and full workspace tests passed

## Follow-up
- Implementation task ebb0b50f-a07a-4d58-b1fe-12bca98baa8e is updated and remains blocked on this decision task.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change that records UI/accessibility decisions and acceptance criteria; no runtime behavior is modified.
> 
> **Overview**
> Adds `docs/design-debt.md` to capture the P6-C2 decision to keep `Alert` and `Callout` as separate components, explicitly defining their accessibility boundary (`role="alert"` vs static `<aside>`).
> 
> The doc also specifies implementation direction and concrete computed-style acceptance criteria for visually differentiating the two components (Callout start-stripe derived from semantic tokens; Alert remains stripe-free with neutralized background or border across light/dark schemes).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b0e8fc3cf58c8ef2c3710e1faff94f10677b372e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->