### PR TITLE
Fix MarkdownEditor toolbar padding

### DIFF
--- a/packages/components/src/components/markdown-editor/markdown-editor.svelte
+++ b/packages/components/src/components/markdown-editor/markdown-editor.svelte
@@ -664,10 +664,8 @@
     display: flex;
     align-items: center;
     gap: var(--cinder-space-2);
-    /* Padding is owned by .editor-toolbar (single source of truth).
-       Wrapper provides only layout (flex + gap) for extension points so
-       padding doesn't compound between wrapper and toolbar. */
-    padding: 0;
+    /* The wrapper owns nested toolbar padding; EditorToolbar keeps standalone chrome. */
+    padding: var(--cinder-space-2) var(--cinder-space-3);
     border-bottom: 1px solid var(--cinder-border);
     /* Background inherited from .markdown-editor-wrapper per surface nesting rule. */
     flex-wrap: wrap;
@@ -675,7 +673,7 @@
 
   .editor-toolbar-wrapper :global(.editor-toolbar) {
     flex: 1 1 auto;
-    min-width: 16rem;
+    min-width: min(16rem, 100%);
     padding: 0;
     border: 0;
     border-radius: 0;

--- a/packages/components/src/components/markdown-editor/markdown-editor.toolbar-layout.test.ts
+++ b/packages/components/src/components/markdown-editor/markdown-editor.toolbar-layout.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'bun:test';
+
+const markdownEditorPath = new URL('./markdown-editor.svelte', import.meta.url);
+const editorToolbarPath = new URL('./editor-toolbar/editor-toolbar.svelte', import.meta.url);
+
+function stripCssComments(source: string): string {
+  return source.replace(/\/\*[\s\S]*?\*\//g, '');
+}
+
+function cssBlock(source: string, selector: string): string {
+  const selectorIndex = source.indexOf(selector);
+  expect(selectorIndex, `Missing CSS selector: ${selector}`).toBeGreaterThanOrEqual(0);
+
+  const openingBraceIndex = source.indexOf('{', selectorIndex);
+  expect(openingBraceIndex, `Missing CSS block for selector: ${selector}`).toBeGreaterThanOrEqual(
+    0,
+  );
+
+  let depth = 0;
+  for (let index = openingBraceIndex; index < source.length; index++) {
+    const character = source[index];
+    if (character === '{') depth++;
+    if (character === '}') depth--;
+    if (depth === 0) {
+      return source.slice(openingBraceIndex + 1, index);
+    }
+  }
+
+  throw new Error(`Unclosed CSS block for selector: ${selector}`);
+}
+
+function expectDeclaration(block: string, property: string, value: string): void {
+  const escapedValue = value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const declaration = new RegExp(`${property}\\s*:\\s*${escapedValue}\\s*;`);
+  expect(block).toMatch(declaration);
+}
+
+describe('MarkdownEditor toolbar layout CSS ownership', () => {
+  it('keeps nested toolbar padding on the wrapper and standalone padding on EditorToolbar', async () => {
+    const markdownEditorSource = stripCssComments(await Bun.file(markdownEditorPath).text());
+    const editorToolbarSource = stripCssComments(await Bun.file(editorToolbarPath).text());
+
+    const wrapperBlock = cssBlock(markdownEditorSource, '.editor-toolbar-wrapper');
+    expectDeclaration(wrapperBlock, 'padding', 'var(--cinder-space-2) var(--cinder-space-3)');
+
+    const nestedToolbarBlock = cssBlock(
+      markdownEditorSource,
+      '.editor-toolbar-wrapper :global(.editor-toolbar)',
+    );
+    expectDeclaration(nestedToolbarBlock, 'min-width', 'min(16rem, 100%)');
+    expectDeclaration(nestedToolbarBlock, 'padding', '0');
+    expectDeclaration(nestedToolbarBlock, 'border', '0');
+    expectDeclaration(nestedToolbarBlock, 'border-radius', '0');
+    expectDeclaration(nestedToolbarBlock, 'background', 'transparent');
+
+    const standaloneToolbarBlock = cssBlock(editorToolbarSource, '.editor-toolbar');
+    expectDeclaration(
+      standaloneToolbarBlock,
+      'padding',
+      'var(--cinder-space-1) var(--cinder-space-2)',
+    );
+  });
+});

--- a/packages/testing/tests/markdown-editor-toolbar.playwright.ts
+++ b/packages/testing/tests/markdown-editor-toolbar.playwright.ts
@@ -1,0 +1,107 @@
+import { expect, test } from '../src/fixtures/component-page.ts';
+import { THEMES, VIEWPORTS } from '../src/helpers/manifest.ts';
+
+const markdownEditorEntry = {
+  name: 'MarkdownEditor',
+  slug: 'markdown-editor',
+  route: '/page/markdown-editor',
+} as const;
+
+const testedViewports = VIEWPORTS.filter(
+  (viewport) => viewport.name === 'desktop' || viewport.name === 'mobile',
+);
+
+type Box = {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+};
+
+function expectInsideContentBox(childBox: Box, contentBox: { left: number; right: number }) {
+  expect(childBox.x).toBeGreaterThanOrEqual(contentBox.left - 1);
+  expect(childBox.x + childBox.width).toBeLessThanOrEqual(contentBox.right + 1);
+}
+
+for (const theme of THEMES) {
+  for (const viewport of testedViewports) {
+    test(`MarkdownEditor toolbar padding keeps controls inset in ${theme} ${viewport.name}`, async ({
+      componentPage,
+    }) => {
+      const page = await componentPage.open({
+        entry: markdownEditorEntry,
+        theme,
+        viewport,
+      });
+
+      const editor = page.locator('#playground-markdown-editor');
+      await expect(editor).toBeVisible();
+
+      const toolbarWrapper = page.locator(
+        '.markdown-editor-wrapper:has(#playground-markdown-editor) .editor-toolbar-wrapper',
+      );
+      await expect(toolbarWrapper).toBeVisible();
+
+      const toolbar = toolbarWrapper.locator('.editor-toolbar');
+      await expect(toolbar).toBeVisible();
+
+      const modeToggle = toolbarWrapper.getByRole('radiogroup', { name: 'Editor mode' });
+      await expect(modeToggle).toBeVisible();
+
+      const wrapperMetrics = await toolbarWrapper.evaluate((element) => {
+        const computed = getComputedStyle(element);
+        const probe = document.createElement('div');
+        probe.style.padding = 'var(--cinder-space-2) var(--cinder-space-3)';
+        element.append(probe);
+        const probeComputed = getComputedStyle(probe);
+        const rect = element.getBoundingClientRect();
+        const metrics = {
+          paddingBlockStart: computed.paddingBlockStart,
+          paddingBlockEnd: computed.paddingBlockEnd,
+          paddingInlineStart: computed.paddingInlineStart,
+          paddingInlineEnd: computed.paddingInlineEnd,
+          expectedPaddingBlockStart: probeComputed.paddingBlockStart,
+          expectedPaddingBlockEnd: probeComputed.paddingBlockEnd,
+          expectedPaddingInlineStart: probeComputed.paddingInlineStart,
+          expectedPaddingInlineEnd: probeComputed.paddingInlineEnd,
+          left: rect.left,
+          right: rect.right,
+          scrollWidth: element.scrollWidth,
+          clientWidth: element.clientWidth,
+        };
+        probe.remove();
+        return metrics;
+      });
+
+      expect(wrapperMetrics.paddingBlockStart).toBe(wrapperMetrics.expectedPaddingBlockStart);
+      expect(wrapperMetrics.paddingBlockEnd).toBe(wrapperMetrics.expectedPaddingBlockEnd);
+      expect(wrapperMetrics.paddingInlineStart).toBe(wrapperMetrics.expectedPaddingInlineStart);
+      expect(wrapperMetrics.paddingInlineEnd).toBe(wrapperMetrics.expectedPaddingInlineEnd);
+
+      await expect(toolbar).toHaveCSS('padding-top', '0px');
+      await expect(toolbar).toHaveCSS('padding-right', '0px');
+      await expect(toolbar).toHaveCSS('padding-bottom', '0px');
+      await expect(toolbar).toHaveCSS('padding-left', '0px');
+
+      const toolbarBox = await toolbar.boundingBox();
+      const modeToggleBox = await modeToggle.boundingBox();
+      expect(toolbarBox).not.toBeNull();
+      expect(modeToggleBox).not.toBeNull();
+
+      const contentBox = {
+        left: wrapperMetrics.left + parseFloat(wrapperMetrics.paddingInlineStart),
+        right: wrapperMetrics.right - parseFloat(wrapperMetrics.paddingInlineEnd),
+      };
+
+      expectInsideContentBox(toolbarBox as Box, contentBox);
+      expectInsideContentBox(modeToggleBox as Box, contentBox);
+      expect(wrapperMetrics.scrollWidth).toBeLessThanOrEqual(wrapperMetrics.clientWidth + 1);
+
+      if (viewport.name === 'desktop') {
+        const toolbarCenter = (toolbarBox as Box).y + (toolbarBox as Box).height / 2;
+        const modeToggleCenter = (modeToggleBox as Box).y + (modeToggleBox as Box).height / 2;
+        expect(Math.abs(toolbarCenter - modeToggleCenter)).toBeLessThanOrEqual(8);
+      }
+    });
+  }
+}


### PR DESCRIPTION
## Summary
- Move MarkdownEditor default toolbar inset ownership to `.editor-toolbar-wrapper` so the icon row and Rich/Raw toggle have breathing room.
- Keep standalone `EditorToolbar` chrome intact while resetting nested toolbar padding, border, radius, and background.
- Make the nested toolbar minimum width responsive so mobile layouts stay inside the padded content box.

## Review committee
Pre-reviewed by: frontend-architect, testing-expert, simplicity-engineer, ux-designer, Codex.
- Committee feedback addressed: source contract now pins responsive min-width; Playwright mode-toggle lookup is scoped to the tested toolbar wrapper.
- @copilot requested for post-creation review.

## Test plan
- `bun test packages/components/src/components/markdown-editor/markdown-editor.toolbar-layout.test.ts`
- `bun run --filter="@cinder/testing" test:playwright -- --grep "MarkdownEditor toolbar"`
- `CINDER_TEST_COMPONENTS=markdown-editor bun run test:browser`
- `bun run --filter=cinder test`
- `bun run --filter=cinder typecheck`
- `bun run lint`
- Pre-commit package checks passed.
- Pre-push lint/typecheck/test validation passed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CSS-only layout adjustment plus new CSS/Playwright assertions; main risk is minor visual regression in MarkdownEditor toolbar spacing, especially at small widths.
> 
> **Overview**
> Adjusts `MarkdownEditor` toolbar layout so the `.editor-toolbar-wrapper` owns the inset padding, while the nested `.editor-toolbar` is rendered chrome-less (`padding: 0`, no border/radius/background) and uses a responsive `min-width: min(16rem, 100%)` to avoid overflow on mobile.
> 
> Adds a Bun unit test that locks in the CSS ownership contract between `markdown-editor.svelte` and `EditorToolbar`, and a Playwright regression test that verifies toolbar + mode toggle stay inside the wrapper’s padded content box across themes and desktop/mobile viewports.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2a049d3d026117ccd0f3bce67c41d2012bbdcb2a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->