### PR TITLE
Differentiate Alert vs Callout per P6-C2: lock Alert's live region, pin border contracts

### DIFF
--- a/packages/components/src/components/alert/alert.css.test.ts
+++ b/packages/components/src/components/alert/alert.css.test.ts
@@ -107,47 +107,22 @@ function findRule(selector: string): Rule {
 
 const VARIANTS = ['info', 'success', 'warning', 'error'];
 
-/**
- * Every property that can set an inline-edge width directly or via a shorthand.
- * The base rule sets width only through the `border` shorthand; if NONE of these
- * appear anywhere in the sheet, both inline edges resolve to the base shorthand
- * width and are therefore equal — which is exactly Alert's stripe-free contract.
- */
-const INLINE_WIDTH_AFFECTING = new Set([
-  'border',
-  'border-width',
-  'border-left',
-  'border-right',
-  'border-left-width',
-  'border-right-width',
-  'border-inline',
-  'border-inline-start',
-  'border-inline-end',
-  'border-inline-width',
-  'border-inline-start-width',
-  'border-inline-end-width',
-]);
-
 describe('alert chrome reduction — border-equals-base', () => {
   test('inline-start width EQUALS inline-end width (no stripe — relationship, not magic number)', () => {
     // P6-C2 acceptance: Alert must NOT have a dominant start edge — start width
-    // must equal end width. Rather than hardcoding 1px === 1px, prove it
-    // structurally: the ONLY rule that sets any inline-edge width is the base
-    // `border` shorthand (which sets both edges to the same value). No other
-    // width-affecting declaration exists anywhere in the sheet, so both inline
-    // edges resolve to that one shorthand width and are necessarily equal. A
-    // future edit that lifts one edge would add a declaration here and fail.
+    // must equal end width. Prove it structurally: walk the base rules for
+    // .cinder-alert and assert the only border-affecting declaration is the
+    // `border` shorthand (which sets every edge to the same value). Any future
+    // edit that adds a width longhand would appear here and fail. Uses the
+    // existing BORDER_AFFECTING set — no separate subset needed.
     const widthDeclarations: string[] = [];
-    root.walkRules((rule) => {
+    for (const rule of findRules('.cinder-alert')) {
       rule.walkDecls((decl) => {
-        if (INLINE_WIDTH_AFFECTING.has(decl.prop)) widthDeclarations.push(decl.prop);
+        if (BORDER_AFFECTING.has(decl.prop)) widthDeclarations.push(decl.prop);
       });
-    });
-    // Exactly one width-affecting declaration, and it's the `border` shorthand —
-    // a shorthand sets every edge to the SAME width, so inline-start === inline-end
-    // by construction. No per-edge width longhand exists to break the equality.
-    // The literal value is intentionally NOT asserted here (that's the base-rule
-    // test below); a base border of 1px or 2px both satisfy start === end.
+    }
+    // Exactly one entry, the base `border` shorthand — a shorthand sets every
+    // edge identically, so inline-start === inline-end by construction.
     expect(widthDeclarations).toEqual(['border']);
   });
 

--- a/packages/components/src/components/alert/alert.css.test.ts
+++ b/packages/components/src/components/alert/alert.css.test.ts
@@ -107,7 +107,50 @@ function findRule(selector: string): Rule {
 
 const VARIANTS = ['info', 'success', 'warning', 'error'];
 
+/**
+ * Every property that can set an inline-edge width directly or via a shorthand.
+ * The base rule sets width only through the `border` shorthand; if NONE of these
+ * appear anywhere in the sheet, both inline edges resolve to the base shorthand
+ * width and are therefore equal — which is exactly Alert's stripe-free contract.
+ */
+const INLINE_WIDTH_AFFECTING = new Set([
+  'border',
+  'border-width',
+  'border-left',
+  'border-right',
+  'border-left-width',
+  'border-right-width',
+  'border-inline',
+  'border-inline-start',
+  'border-inline-end',
+  'border-inline-width',
+  'border-inline-start-width',
+  'border-inline-end-width',
+]);
+
 describe('alert chrome reduction — border-equals-base', () => {
+  test('inline-start width EQUALS inline-end width (no stripe — relationship, not magic number)', () => {
+    // P6-C2 acceptance: Alert must NOT have a dominant start edge — start width
+    // must equal end width. Rather than hardcoding 1px === 1px, prove it
+    // structurally: the ONLY rule that sets any inline-edge width is the base
+    // `border` shorthand (which sets both edges to the same value). No other
+    // width-affecting declaration exists anywhere in the sheet, so both inline
+    // edges resolve to that one shorthand width and are necessarily equal. A
+    // future edit that lifts one edge would add a declaration here and fail.
+    const widthDeclarations: string[] = [];
+    root.walkRules((rule) => {
+      rule.walkDecls((decl) => {
+        if (INLINE_WIDTH_AFFECTING.has(decl.prop)) widthDeclarations.push(decl.prop);
+      });
+    });
+    // Exactly one width-affecting declaration, and it's the `border` shorthand —
+    // a shorthand sets every edge to the SAME width, so inline-start === inline-end
+    // by construction. No per-edge width longhand exists to break the equality.
+    // The literal value is intentionally NOT asserted here (that's the base-rule
+    // test below); a base border of 1px or 2px both satisfy start === end.
+    expect(widthDeclarations).toEqual(['border']);
+  });
+
   test('base rule declares exactly border: 1px solid var(--cinder-border)', () => {
     // The base selector appears in two rules (one declares the scoped
     // --cinder-alert-info token, the other the box). Exactly one of them must

--- a/packages/components/src/components/alert/alert.svelte
+++ b/packages/components/src/components/alert/alert.svelte
@@ -35,10 +35,31 @@
     visible = false;
     onDismiss?.();
   }
+
+  // P6-C2 locks Alert as the live-region notification: `role="alert"` is
+  // non-overridable and must never downgrade to `role="status"`. The prop type
+  // inherits `role` from HTMLAttributes, so a consumer can still pass it via
+  // spread. Scrub `role` (and `aria-live`, which would fight the role's implicit
+  // `aria-live="assertive"`) from rest, then spread the filtered rest BEFORE the
+  // locked `role="alert"` so the hardcoded value always wins the cascade.
+  // Mirrors banner.svelte / callout.svelte defense-in-depth.
+  const restWithoutForbidden = $derived.by(() => {
+    const {
+      role: _role,
+      'aria-live': _ariaLive,
+      ...filtered
+    } = rest as typeof rest & Record<string, unknown>;
+    return filtered;
+  });
 </script>
 
 {#if visible}
-  <div class={cn('cinder-alert', className)} data-cinder-variant={variant} role="alert" {...rest}>
+  <div
+    {...restWithoutForbidden}
+    class={cn('cinder-alert', className)}
+    data-cinder-variant={variant}
+    role="alert"
+  >
     {#if icon}
       <div class="cinder-alert__icon" aria-hidden="true">
         {@render icon()}

--- a/packages/components/src/components/alert/alert.svelte
+++ b/packages/components/src/components/alert/alert.svelte
@@ -16,6 +16,8 @@
 </script>
 
 <script lang="ts">
+  import type { HTMLAttributes } from 'svelte/elements';
+
   import { cn } from '../../utilities/class-names.ts';
   import type { AlertProps } from './alert.types.ts';
 
@@ -37,18 +39,20 @@
   }
 
   // P6-C2 locks Alert as the live-region notification: `role="alert"` is
-  // non-overridable and must never downgrade to `role="status"`. The prop type
-  // inherits `role` from HTMLAttributes, so a consumer can still pass it via
-  // spread. Scrub `role` (and `aria-live`, which would fight the role's implicit
-  // `aria-live="assertive"`) from rest, then spread the filtered rest BEFORE the
-  // locked `role="alert"` so the hardcoded value always wins the cascade.
-  // Mirrors banner.svelte / callout.svelte defense-in-depth.
+  // non-overridable and must never downgrade to `role="status"`. Scrub role,
+  // aria-live (would fight the implicit assertive), aria-atomic (ARIA spec
+  // implies true for role=alert; a consumer false would override the implicit),
+  // and aria-relevant (modifies announcement behavior) from rest, then spread
+  // the filtered rest BEFORE the locked `role="alert"` so the hardcoded value
+  // always wins the cascade. Mirrors banner.svelte / callout.svelte defense.
   const restWithoutForbidden = $derived.by(() => {
     const {
       role: _role,
       'aria-live': _ariaLive,
+      'aria-atomic': _ariaAtomic,
+      'aria-relevant': _ariaRelevant,
       ...filtered
-    } = rest as typeof rest & Record<string, unknown>;
+    } = rest as HTMLAttributes<HTMLDivElement> & Record<string, unknown>;
     return filtered;
   });
 </script>

--- a/packages/components/src/components/alert/alert.test.ts
+++ b/packages/components/src/components/alert/alert.test.ts
@@ -164,11 +164,12 @@ describe('Alert rendering', () => {
 
   test('role="alert" is non-overridable — a consumer role="status" does not downgrade it', () => {
     // P6-C2 locks Alert as the live-region notification: the role must stay
-    // "alert" and must never become "status" (or any other live-region role). A
-    // consumer can pass role via the inherited HTMLAttributes surface, so the
-    // component scrubs it from rest and spreads filtered rest before role="alert".
+    // "alert" and must never become "status" (or any other live-region role).
+    // `role` is omitted from AlertProps, but a consumer can still escape the type
+    // (`as never`), so the component scrubs it from rest and spreads the filtered
+    // rest before role="alert".
     const { container } = render(Alert, {
-      props: { role: 'status', children: emptySnippet },
+      props: { role: 'status', children: emptySnippet } as never,
     });
     const root = container.querySelector('.cinder-alert');
     expect(root?.getAttribute('role')).toBe('alert');
@@ -178,8 +179,10 @@ describe('Alert rendering', () => {
   test('a consumer-supplied aria-live is stripped so it cannot fight the implicit assertive role', () => {
     // role="alert" implies aria-live="assertive". A consumer aria-live="polite"
     // would silently downgrade the announcement urgency, so it is scrubbed.
+    // `aria-live` is omitted from AlertProps; `as never` simulates a consumer
+    // escaping the type system.
     const { container } = render(Alert, {
-      props: { 'aria-live': 'polite', children: emptySnippet },
+      props: { 'aria-live': 'polite', children: emptySnippet } as never,
     });
     const root = container.querySelector('.cinder-alert');
     expect(root?.getAttribute('role')).toBe('alert');

--- a/packages/components/src/components/alert/alert.test.ts
+++ b/packages/components/src/components/alert/alert.test.ts
@@ -162,6 +162,29 @@ describe('Alert rendering', () => {
     expect(root?.hasAttribute('aria-live')).toBe(false);
   });
 
+  test('role="alert" is non-overridable — a consumer role="status" does not downgrade it', () => {
+    // P6-C2 locks Alert as the live-region notification: the role must stay
+    // "alert" and must never become "status". A consumer can pass role via the
+    // inherited HTMLAttributes surface, so the component scrubs it from rest and
+    // spreads the filtered rest before the hardcoded role="alert".
+    const { container } = render(Alert, {
+      props: { role: 'status', children: emptySnippet },
+    });
+    const root = container.querySelector('.cinder-alert');
+    expect(root?.getAttribute('role')).toBe('alert');
+  });
+
+  test('a consumer-supplied aria-live is stripped so it cannot fight the implicit assertive role', () => {
+    // role="alert" implies aria-live="assertive". A consumer aria-live="polite"
+    // would silently downgrade the announcement urgency, so it is scrubbed.
+    const { container } = render(Alert, {
+      props: { 'aria-live': 'polite', children: emptySnippet },
+    });
+    const root = container.querySelector('.cinder-alert');
+    expect(root?.getAttribute('role')).toBe('alert');
+    expect(root?.hasAttribute('aria-live')).toBe(false);
+  });
+
   test('default variant is "info"', () => {
     const { container } = render(Alert, {
       props: { children: emptySnippet },

--- a/packages/components/src/components/alert/alert.test.ts
+++ b/packages/components/src/components/alert/alert.test.ts
@@ -164,14 +164,15 @@ describe('Alert rendering', () => {
 
   test('role="alert" is non-overridable — a consumer role="status" does not downgrade it', () => {
     // P6-C2 locks Alert as the live-region notification: the role must stay
-    // "alert" and must never become "status". A consumer can pass role via the
-    // inherited HTMLAttributes surface, so the component scrubs it from rest and
-    // spreads the filtered rest before the hardcoded role="alert".
+    // "alert" and must never become "status" (or any other live-region role). A
+    // consumer can pass role via the inherited HTMLAttributes surface, so the
+    // component scrubs it from rest and spreads filtered rest before role="alert".
     const { container } = render(Alert, {
       props: { role: 'status', children: emptySnippet },
     });
     const root = container.querySelector('.cinder-alert');
     expect(root?.getAttribute('role')).toBe('alert');
+    expect(root?.hasAttribute('aria-live')).toBe(false);
   });
 
   test('a consumer-supplied aria-live is stripped so it cannot fight the implicit assertive role', () => {
@@ -183,6 +184,23 @@ describe('Alert rendering', () => {
     const root = container.querySelector('.cinder-alert');
     expect(root?.getAttribute('role')).toBe('alert');
     expect(root?.hasAttribute('aria-live')).toBe(false);
+  });
+
+  test('aria-atomic and aria-relevant are stripped so consumers cannot override the implicit live-region behavior', () => {
+    // role="alert" implies aria-atomic="true". A consumer aria-atomic="false"
+    // would override the implicit value and fragment announcements. aria-relevant
+    // modifies what changes are announced. Both are scrubbed to prevent the
+    // consumer from undermining the assertive live region.
+    const { container } = render(Alert, {
+      props: {
+        'aria-atomic': 'false',
+        'aria-relevant': 'additions',
+        children: emptySnippet,
+      } as never,
+    });
+    const root = container.querySelector('.cinder-alert');
+    expect(root?.hasAttribute('aria-atomic')).toBe(false);
+    expect(root?.hasAttribute('aria-relevant')).toBe(false);
   });
 
   test('default variant is "info"', () => {

--- a/packages/components/src/components/alert/alert.type-test.ts
+++ b/packages/components/src/components/alert/alert.type-test.ts
@@ -1,0 +1,47 @@
+/**
+ * Compile-time regression tests for AlertProps.
+ * svelte-check processes this file; tsc does not (it excludes .svelte imports).
+ * These verify that the prop type's `Omit` list keeps the live-region attributes
+ * that design decision P6-C2 locks off the public surface — Alert owns a
+ * non-overridable `role="alert"` assertive live region, so a consumer must not
+ * be able to type a role, downgrade the urgency, or fragment the announcement.
+ * The runtime scrub in alert.svelte is defense-in-depth; this pins the contract
+ * at the type level so a future edit to alert.types.ts trips a compile error.
+ */
+import type { Snippet } from 'svelte';
+
+import type { AlertProps } from './alert.types.ts';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const noopChildren = null as any as Snippet;
+
+// role is owned by the component (role="alert") and must not be overridable.
+// @ts-expect-error - role is excluded from AlertProps
+const _roleRejected: AlertProps = { children: noopChildren, role: 'status' };
+
+// role="alert" implies aria-live="assertive"; a consumer must not downgrade it.
+// @ts-expect-error - aria-live is excluded from AlertProps
+const _ariaLiveRejected: AlertProps = { children: noopChildren, 'aria-live': 'polite' };
+
+// role="alert" implies aria-atomic="true"; overriding to false would fragment
+// the assertive announcement, so the attribute is off the surface.
+// @ts-expect-error - aria-atomic is excluded from AlertProps
+const _ariaAtomicRejected: AlertProps = { children: noopChildren, 'aria-atomic': 'false' };
+
+// prettier-ignore
+// @ts-expect-error - aria-relevant is excluded from AlertProps
+const _ariaRelevantRejected: AlertProps = { children: noopChildren, 'aria-relevant': 'additions' };
+
+// aria-label remains valid — consumers may name the alert.
+const _ariaLabelAccepted: AlertProps = { children: noopChildren, 'aria-label': 'Save failed' };
+
+// aria-busy remains valid — it is a status flag, not a live-region presentation
+// attribute, and is left on the surface (matching the runtime scrub set).
+const _ariaBusyAccepted: AlertProps = { children: noopChildren, 'aria-busy': true };
+
+void _roleRejected;
+void _ariaLiveRejected;
+void _ariaAtomicRejected;
+void _ariaRelevantRejected;
+void _ariaLabelAccepted;
+void _ariaBusyAccepted;

--- a/packages/components/src/components/alert/alert.types.test.ts
+++ b/packages/components/src/components/alert/alert.types.test.ts
@@ -15,14 +15,20 @@ import type { HTMLAttributes } from 'svelte/elements';
 import Alert from './alert.svelte';
 import type { AlertProps } from './alert.types.ts';
 
-// --- Snapshot of the pre-migration AlertProps shape ----------------------------------
-// Copied verbatim from the original module-script types in `src/components/alert.svelte`
-// at the start of the migration. This anchors the public surface so future
-// refactors must explicitly update both the migrated type AND this snapshot.
+// --- Snapshot of the intended AlertProps shape ---------------------------------------
+// Anchors the public surface so future refactors must explicitly update both the
+// type AND this snapshot. Per design decision P6-C2, Alert owns a non-overridable
+// `role="alert"` live region, so `role`, `aria-live`, `aria-atomic`, and
+// `aria-relevant` are intentionally omitted from the surface (and scrubbed at
+// runtime). The snapshot mirrors that omit set so the assertions verify the
+// reduced surface rather than pinning the pre-P6-C2 shape.
 
 type _SnapshotAlertVariant = 'info' | 'success' | 'warning' | 'error';
 
-type SnapshotAlertProps = HTMLAttributes<HTMLDivElement> & {
+type SnapshotAlertProps = Omit<
+  HTMLAttributes<HTMLDivElement>,
+  'children' | 'role' | 'aria-live' | 'aria-atomic' | 'aria-relevant'
+> & {
   variant?: _SnapshotAlertVariant;
   dismissible?: boolean;
   onDismiss?: () => void;

--- a/packages/components/src/components/alert/alert.types.ts
+++ b/packages/components/src/components/alert/alert.types.ts
@@ -3,7 +3,24 @@ import type { HTMLAttributes } from 'svelte/elements';
 
 export type AlertVariant = 'info' | 'success' | 'warning' | 'error';
 
-export type AlertProps = HTMLAttributes<HTMLDivElement> & {
+/**
+ * Props for the {@link Alert} component — a live-region notification card.
+ *
+ * Per design decision P6-C2, Alert is the assertive live region: it owns
+ * `role="alert"` (which implies `aria-live="assertive"` and `aria-atomic="true"`)
+ * and that role is non-overridable. `role`, `aria-live`, `aria-atomic`, and
+ * `aria-relevant` are therefore omitted from the public surface so a consumer
+ * cannot type `<Alert role="status" />`, downgrade the announcement urgency, or
+ * fragment the assertive announcement — the component also scrubs all four from
+ * spread props at runtime for defense in depth. Mirrors the `Omit`-plus-runtime-
+ * scrub pattern in {@link CalloutProps} (the omit/scrub sets match the
+ * component's behavior in each case). `aria-busy` remains on the surface: it is
+ * a status flag rather than a live-region presentation attribute.
+ */
+export type AlertProps = Omit<
+  HTMLAttributes<HTMLDivElement>,
+  'children' | 'role' | 'aria-live' | 'aria-atomic' | 'aria-relevant'
+> & {
   variant?: AlertVariant;
   dismissible?: boolean;
   onDismiss?: () => void;

--- a/packages/components/src/components/callout/callout.css.test.ts
+++ b/packages/components/src/components/callout/callout.css.test.ts
@@ -157,6 +157,33 @@ const VARIANTS: Array<{ variant: string; token: string }> = [
   { variant: 'danger', token: '--cinder-danger' },
 ];
 
+/**
+ * Parse a CSS length like `4px`, `1px`, or `0.5rem` into a number of pixels.
+ * Only `px` and unitless `0` are accepted — every border width in this sheet is
+ * authored in px, so a unit the resolver does not model (em/rem/%) returns NaN
+ * and fails the relationship comparison cleanly instead of silently matching.
+ */
+function pxWidth(value: string): number {
+  const trimmed = value.trim();
+  if (trimmed === '0') return 0;
+  const match = /^([\d.]+)px$/.exec(trimmed);
+  return match ? Number(match[1]) : Number.NaN;
+}
+
+/**
+ * Extract the width token from a `border` shorthand like
+ * `1px solid var(--cinder-border)`. The width is the first space-separated
+ * component that parses as a length; `solid` and the `var(...)` color are
+ * skipped. Returns NaN when no length component is present.
+ */
+function borderShorthandWidth(value: string): number {
+  for (const part of value.trim().split(/\s+/)) {
+    const width = pxWidth(part);
+    if (!Number.isNaN(width)) return width;
+  }
+  return Number.NaN;
+}
+
 describe('callout stripe — directional treatment', () => {
   test('base rule sets the box border and the 4px inline-start stripe width', () => {
     // Stripe width is not theme-branched (no light-dark on widths), so the 4px
@@ -164,6 +191,23 @@ describe('callout stripe — directional treatment', () => {
     const base = findRule('.cinder-callout');
     expect(declValue(base, 'border')).toBe('1px solid var(--cinder-border)');
     expect(declValue(base, 'border-inline-start-width')).toBe('4px');
+  });
+
+  test('inline-start width is strictly GREATER than inline-end width (relationship, not magic number)', () => {
+    // P6-C2 acceptance: Callout's start edge must dominate its end edge. Derive
+    // both widths from the source rather than hardcoding 4px > 1px so a token
+    // change (e.g. base border 1px → 2px, stripe 4px → 6px) keeps the test green
+    // as long as the start-dominates-end RELATIONSHIP holds. No variant rule
+    // touches a width longhand (asserted below), so the inline-end width is the
+    // base `border` shorthand width and the inline-start width is the explicit
+    // base longhand. Widths are not theme-branched, so this holds in both
+    // schemes and is asserted once.
+    const base = findRule('.cinder-callout');
+    const endWidth = borderShorthandWidth(declValue(base, 'border')!);
+    const startWidth = pxWidth(declValue(base, 'border-inline-start-width')!);
+    expect(Number.isNaN(endWidth)).toBe(false);
+    expect(Number.isNaN(startWidth)).toBe(false);
+    expect(startWidth).toBeGreaterThan(endWidth);
   });
 
   for (const { variant, token } of VARIANTS) {

--- a/packages/components/src/components/callout/callout.css.test.ts
+++ b/packages/components/src/components/callout/callout.css.test.ts
@@ -160,8 +160,9 @@ const VARIANTS: Array<{ variant: string; token: string }> = [
 /**
  * Parse a CSS length like `4px`, `1px`, or `0.5rem` into a number of pixels.
  * Only `px` and unitless `0` are accepted — every border width in this sheet is
- * authored in px, so a unit the resolver does not model (em/rem/%) returns NaN
- * and fails the relationship comparison cleanly instead of silently matching.
+ * authored in px. Keyword widths (`thin`, `medium`, `thick`) and relative units
+ * (em/rem/%) return NaN, which fails the relationship comparison cleanly instead
+ * of silently passing with a wrong value.
  */
 function pxWidth(value: string): number {
   const trimmed = value.trim();
@@ -171,10 +172,10 @@ function pxWidth(value: string): number {
 }
 
 /**
- * Extract the width token from a `border` shorthand like
- * `1px solid var(--cinder-border)`. The width is the first space-separated
- * component that parses as a length; `solid` and the `var(...)` color are
- * skipped. Returns NaN when no length component is present.
+ * Extract the width from a `border` shorthand like `1px solid var(--cinder-border)`.
+ * The width is the first space-separated component that parses as a px length;
+ * `solid`, `var(...)`, and keyword widths are skipped (keywords return NaN from
+ * pxWidth, causing the test to fail rather than silently pass with a wrong value).
  */
 function borderShorthandWidth(value: string): number {
   for (const part of value.trim().split(/\s+/)) {


### PR DESCRIPTION
## Summary

Closes the verification + hardening follow-up for design decision **P6-C2** (Alert vs Callout visual differentiation). The CSS treatment itself shipped in #175; this PR proves and locks the contract.

**What changed:**

- **Alert's `role="alert"` is now non-overridable.** Previously the component rendered `role="alert" {...rest}`, so a consumer's `role="status"` in spread props would win the cascade and a leaked `aria-live="polite"` would fight the role's implicit `aria-live="assertive"`. The component now scrubs `role`, `aria-live`, `aria-atomic`, and `aria-relevant` from rest and spreads the filtered rest **before** the hardcoded `role="alert"` (mirrors the established `banner.svelte` / `callout.svelte` scrub-then-lock pattern). `role="alert"` implies `aria-atomic="true"` per ARIA 1.2 §6.6.1, so a consumer override would fragment the assertive announcement — hence the wider scrub set. `aria-busy` stays on the surface as a legitimate status flag.
- **`AlertProps` omits the four locked attributes** at the type level (matching the runtime scrub set), so `<Alert role="status" />` is a compile error rather than a silent runtime no-op. A new `alert.type-test.ts` pins this with `@ts-expect-error` regressions, mirroring `callout.type-test.ts`.
- **Relationship-based CSS border-width assertions** (per P6-C2 acceptance, "no magic numbers"): Callout proves `border-inline-start-width > border-inline-end-width` derived from source (so a `1px → 2px` token change won't break the test); Alert proves `start === end` structurally (the only border-affecting declaration in the base rules is the `border` shorthand, which sets every edge equally).

These are CSS **cascade-resolution** tests (postcss source parsing), not browser computed-style — happy-dom does not compute styles from stylesheets and the package ships no browser-test harness for these components.

## Review committee

Pre-reviewed by: typescript-expert, testing-expert, frontend-architect, simplicity-engineer
- Codex (gpt-5.4, xhigh) — unavailable this run (see warning below)
- 2 rounds of review; all must-fix items addressed (type-level `Omit`, atrule-skip guard on the Alert width walk, runtime scrub of `aria-atomic`/`aria-relevant`)
- Round 2: unanimous APPROVED

> [!WARNING]
> Codex (the adversarial second-opinion reviewer) was unavailable for this PR — the review shim exited non-zero (`config profile 'heavy' not found`). See `tmp/committee-state.md` for detail. The four Claude-family subagents reviewed across two rounds.

## Test plan

- Targeted: `TZ=UTC LANG=en_US.UTF-8 bun test --conditions browser --conditions svelte --parallel=1 src/components/alert src/components/callout` → **79 pass, 0 fail**
- Full components suite: `bun run test` → **3582 pass, 1 skip, 0 fail**
- `bun run typecheck` (tsc + svelte-check) → **0 errors**
- `bun run lint` → **0 errors**
- TDD verified: the role/aria-live override tests fail against the pre-fix component.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes accessibility behavior for Alert spread props and public types; mistakes could break assistive-tech announcements, though the change aligns with existing banner/callout patterns and is heavily tested.
> 
> **Overview**
> This PR **hardens design decision P6-C2** (Alert vs Callout differentiation) with tests and accessibility contracts, on top of CSS that already shipped elsewhere.
> 
> **Alert** now treats **`role="alert"` as fixed**: spread props are filtered to drop `role`, `aria-live`, `aria-atomic`, and `aria-relevant`, then the filtered rest is applied **before** a hardcoded `role="alert"` so consumers cannot downgrade to `status` or weaken the assertive live region. **`AlertProps`** uses the same **`Omit`** list at compile time, with **`alert.type-test.ts`** and updated snapshot tests; runtime tests cover type escapes via `as never`.
> 
> **CSS acceptance** adds relationship-based border checks parsed from source (not computed styles): **Alert** must have only the base `border` shorthand among border-affecting rules (no dominant start stripe); **Callout** must have **inline-start width strictly greater than** inline-end width, derived from the stylesheet rather than fixed pixel literals.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 146f54256af3a9f30b8315765300436a094b50ed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->