### PR TITLE
feat(markdown-editor): SSR-safety tests, import-boundary invariant, hydrate.ts bug fix

### DIFF
--- a/packages/components/src/components/markdown-editor/markdown-editor.hydrate.test.ts
+++ b/packages/components/src/components/markdown-editor/markdown-editor.hydrate.test.ts
@@ -74,10 +74,17 @@ describe('MarkdownEditor SSR contract (source-level verification)', () => {
   test('server output does not render the live editor (role=application) element', () => {
     // The live editor div has role="application". Svelte's SSR renderer won't
     // emit it because it's inside `{#if browser}`.
-    // Verify: the role="application" element is inside the `{#if browser}` branch.
-    const browserBranchMatch = SVELTE_SOURCE.match(/\{#if browser\}([\s\S]*?)\{:else\}/);
-    expect(browserBranchMatch).not.toBeNull();
-    const browserBranch = browserBranchMatch?.[1] ?? '';
+    // Extract the browser branch by finding the outer {#if browser} … {:else} boundary.
+    // Use index-based extraction rather than a non-greedy regex to avoid matching
+    // the inner {:else} inside {#if mode === 'wysiwyg'} that appears before the
+    // browser/server boundary.
+    const ifBrowserStart = SVELTE_SOURCE.indexOf('{#if browser}');
+    expect(ifBrowserStart).toBeGreaterThan(-1);
+    // The EditorSkeleton {:else} is: {:else}\n    <EditorSkeleton — find this sequence.
+    const elseSkeletonMarker = '{:else}\n    <EditorSkeleton';
+    const elseStart = SVELTE_SOURCE.indexOf(elseSkeletonMarker, ifBrowserStart);
+    expect(elseStart).toBeGreaterThan(ifBrowserStart);
+    const browserBranch = SVELTE_SOURCE.slice(ifBrowserStart + '{#if browser}'.length, elseStart);
     expect(browserBranch).toContain('role="application"');
   });
 

--- a/packages/components/src/components/markdown-editor/markdown-editor.hydrate.test.ts
+++ b/packages/components/src/components/markdown-editor/markdown-editor.hydrate.test.ts
@@ -1,0 +1,105 @@
+/**
+ * MarkdownEditor SSR → hydration path test
+ *
+ * Verifies that the server renders <EditorSkeleton> (the SSR branch) and
+ * the client hydrates without a hydration-mismatch warning.
+ *
+ * MarkdownEditor's SSR contract:
+ *   - Server: `{#if browser}` is false → renders <EditorSkeleton>
+ *   - Client: `BROWSER` from esm-env resolves to true → hydrates with the
+ *     live editor inside the `{#if browser}` branch
+ *
+ * LIVE-EDITOR HYDRATION STATUS — BLOCKED (tracking note):
+ * =========================================================
+ * The `renderThenHydrate` helper works by compiling the .svelte source in
+ * `generate: 'server'` mode, writing the compiled output to a temp .mjs file,
+ * and dynamically importing it. When Bun resolves that .mjs file's imports,
+ * `cinder/editor/component-runtime` matches the "node" conditional export
+ * (no "bun" condition exists), which points to `./dist/server/…` — a file
+ * that does not exist in the development tree.
+ *
+ * Root cause: `cinder/editor/component-runtime` bundles ProseMirror symbols.
+ * ProseMirror touches the DOM at module-evaluation time, so the package.json
+ * uses a server-specific "node" export to provide a stub — but the stub's
+ * dist is not built in development. The Svelte preload plugin (which maps
+ * imports to src/) only applies to the Bun native module loader, not to
+ * dynamically imported .mjs files the helper writes to disk.
+ *
+ * To unblock full live-editor hydration, one of:
+ * (a) Add a "bun" condition to `cinder/editor/component-runtime` → src file.
+ * (b) Implement a Playwright browser test that exercises real hydration.
+ * (c) Build the dist before running these tests.
+ *
+ * This test verifies the parts that CAN be tested without full hydration:
+ * reading the SSR output statically and asserting on the skeleton contract.
+ * Those assertions are correct and meaningful for the SSR side of the contract.
+ */
+
+import { describe, expect, test } from 'bun:test';
+
+// SSR contract verification via source analysis
+// The server render produces EditorSkeleton because `browser` is false.
+// We verify this contract by reading the component source rather than
+// attempting to dynamically compile+import it (which is blocked per above).
+
+const SVELTE_SOURCE = await Bun.file(
+  new URL('./markdown-editor.svelte', import.meta.url).pathname,
+).text();
+
+describe('MarkdownEditor SSR contract (source-level verification)', () => {
+  test('renders EditorSkeleton in the {:else} branch of {#if browser}', () => {
+    // The component has: {#if browser} ... {:else} <EditorSkeleton .../> {/if}
+    // This is the server-rendered path. Verify the structure exists.
+    expect(SVELTE_SOURCE).toMatch(/\{:else\}[\s\S]*?EditorSkeleton/);
+  });
+
+  test('EditorSkeleton is in the {:else} immediately before the closing {/if}', () => {
+    // The component structure is:
+    //   {#if browser}
+    //     ... live editor ...
+    //   {:else}
+    //     <EditorSkeleton .../>
+    //   {/if}
+    // Verify the else→skeleton→close-if sequence exists directly.
+    expect(SVELTE_SOURCE).toMatch(/\{:else\}\s*\n\s*<EditorSkeleton[^>]*\/>\s*\n\s*\{\/if\}/);
+  });
+
+  test('BROWSER import guard: effects use `if (!browser) return` early-return pattern', () => {
+    // The two dynamic-import effects each guard with `if (!browser) return;`
+    // This is the runtime SSR safety mechanism — effects never fire on the server.
+    const earlyReturnGuards = SVELTE_SOURCE.match(/if \(!browser\) return;/g) ?? [];
+    expect(earlyReturnGuards.length).toBeGreaterThanOrEqual(2);
+  });
+
+  test('server output does not render the live editor (role=application) element', () => {
+    // The live editor div has role="application". Svelte's SSR renderer won't
+    // emit it because it's inside `{#if browser}`.
+    // Verify: the role="application" element is inside the `{#if browser}` branch.
+    const browserBranchMatch = SVELTE_SOURCE.match(/\{#if browser\}([\s\S]*?)\{:else\}/);
+    expect(browserBranchMatch).not.toBeNull();
+    const browserBranch = browserBranchMatch?.[1] ?? '';
+    expect(browserBranch).toContain('role="application"');
+  });
+
+  test('EditorSkeleton is referenced by name in the component source', () => {
+    // Confirms the SSR-rendered skeleton component is present in the source.
+    expect(SVELTE_SOURCE).toContain('EditorSkeleton');
+  });
+});
+
+describe('MarkdownEditor hydration status', () => {
+  test('live-editor hydration is BLOCKED — document why', () => {
+    // This test explicitly records that full renderThenHydrate of MarkdownEditor
+    // is blocked by the `cinder/editor/component-runtime` "node" conditional
+    // export pointing to a missing dist file. See file header for details.
+    //
+    // Acceptance criterion from the plan: "Default-mode (wysiwyg) hydrate test
+    // passes, OR live-editor hydration is explicitly marked blocked/unmet with
+    // a tracking note."
+    //
+    // This test PASSES (asserts true) to signal the criterion is documented as
+    // blocked, not silently skipped. The note above describes what's needed to
+    // unblock it.
+    expect(true).toBe(true);
+  });
+});

--- a/packages/components/src/components/markdown-editor/markdown-editor.hydrate.test.ts
+++ b/packages/components/src/components/markdown-editor/markdown-editor.hydrate.test.ts
@@ -95,18 +95,12 @@ describe('MarkdownEditor SSR contract (source-level verification)', () => {
 });
 
 describe('MarkdownEditor hydration status', () => {
-  test('live-editor hydration is BLOCKED — document why', () => {
-    // This test explicitly records that full renderThenHydrate of MarkdownEditor
-    // is blocked by the `cinder/editor/component-runtime` "node" conditional
-    // export pointing to a missing dist file. See file header for details.
-    //
-    // Acceptance criterion from the plan: "Default-mode (wysiwyg) hydrate test
-    // passes, OR live-editor hydration is explicitly marked blocked/unmet with
-    // a tracking note."
-    //
-    // This test PASSES (asserts true) to signal the criterion is documented as
-    // blocked, not silently skipped. The note above describes what's needed to
-    // unblock it.
-    expect(true).toBe(true);
-  });
+  // Acceptance criterion from the plan: "Default-mode (wysiwyg) hydrate test passes,
+  // OR live-editor hydration is explicitly marked blocked/unmet with a tracking note."
+  //
+  // Full renderThenHydrate is blocked by `cinder/editor/component-runtime` having no
+  // "bun" conditional export — the "node" export points to a missing dist file.
+  // See file header for the three unblocking options. When unblocked, replace this
+  // todo with a real renderThenHydrate assertion.
+  test.skip('live-editor hydration BLOCKED — cinder/editor/component-runtime missing "bun" conditional export (see file header)', () => {});
 });

--- a/packages/components/src/components/markdown-editor/markdown-editor.import-boundary.test.ts
+++ b/packages/components/src/components/markdown-editor/markdown-editor.import-boundary.test.ts
@@ -1,0 +1,313 @@
+/**
+ * MarkdownEditor import-boundary invariant
+ *
+ * Ensures that runtime packages with browser-global dependencies — Milkdown
+ * and ProseMirror — are NEVER statically imported as values from
+ * markdown-editor.svelte, and any dynamic import() of those packages is
+ * guarded by a browser check that structurally dominates the call site.
+ *
+ * The protected package set is an exact prefix list: @milkdown/ and
+ * prosemirror-. Adding a new package means adding to PROTECTED_PREFIXES.
+ *
+ * Guard detection: the import sits inside an effect arrow function whose body
+ * opens with `if (!browser) return;` (early-return domination). A guard that
+ * merely precedes the effect call, or that's in a sibling branch, does NOT
+ * count.
+ *
+ * Uses svelte/compiler (already a project dependency) to parse the .svelte
+ * source into an AST instead of regexing over source text, for structural
+ * accuracy. Fails hard if the source file cannot be read.
+ */
+
+import { describe, expect, it } from 'bun:test';
+import { parse } from 'svelte/compiler';
+
+// ---------------------------------------------------------------------------
+// Protected package set (explicit prefix constants — change only here)
+// ---------------------------------------------------------------------------
+const PROTECTED_PREFIXES = ['@milkdown/', 'prosemirror-'] as const;
+
+function isProtected(specifier: string): boolean {
+  return PROTECTED_PREFIXES.some((prefix) => specifier.startsWith(prefix));
+}
+
+// ---------------------------------------------------------------------------
+// Minimal AST types (svelte/compiler returns acorn-compatible ESTree)
+// ---------------------------------------------------------------------------
+type AstNode = Record<string, unknown>;
+
+function isNode(value: unknown): value is AstNode {
+  return typeof value === 'object' && value !== null && 'type' in value;
+}
+
+// ---------------------------------------------------------------------------
+// Guard detection: `if (!browser) return;` as the first statement
+// ---------------------------------------------------------------------------
+function isEarlyBrowserReturnGuard(statement: AstNode): boolean {
+  if (statement['type'] !== 'IfStatement') return false;
+  const test = statement['test'] as AstNode | undefined;
+  if (!test || test['type'] !== 'UnaryExpression') return false;
+  if (test['operator'] !== '!') return false;
+  const argument = test['argument'] as AstNode | undefined;
+  if (!argument || argument['type'] !== 'Identifier') return false;
+  if (argument['name'] !== 'browser') return false;
+  const consequent = statement['consequent'] as AstNode | undefined;
+  if (!consequent || consequent['type'] !== 'ReturnStatement') return false;
+  // Disallow else branches — they change the domination semantics
+  if (statement['alternate']) return false;
+  return true;
+}
+
+// ---------------------------------------------------------------------------
+// Find all dynamic import() expressions inside a node, returning specifiers
+// ---------------------------------------------------------------------------
+type DynamicImportInfo = {
+  specifier: string | null; // null = non-literal specifier (also a violation)
+  guardedByEarlyReturn: boolean;
+};
+
+function findDynamicImports(node: AstNode, dominatedByGuard: boolean): DynamicImportInfo[] {
+  const results: DynamicImportInfo[] = [];
+
+  if (node['type'] === 'ImportExpression') {
+    const sourceNode = node['source'] as AstNode | undefined;
+    const specifier =
+      sourceNode && sourceNode['type'] === 'Literal' && typeof sourceNode['value'] === 'string'
+        ? sourceNode['value']
+        : null;
+    results.push({ specifier, guardedByEarlyReturn: dominatedByGuard });
+    return results;
+  }
+
+  // Arrow function body: detect domination by `if (!browser) return;`
+  if (node['type'] === 'ArrowFunctionExpression') {
+    const body = node['body'];
+    if (isNode(body) && body['type'] === 'BlockStatement') {
+      const stmts = (body['body'] as AstNode[]) ?? [];
+      // First statement dominates the rest if it's an early-return guard
+      const firstStmt = stmts[0];
+      const dominated = firstStmt !== undefined && isEarlyBrowserReturnGuard(firstStmt);
+      for (const stmt of stmts) {
+        results.push(...findDynamicImports(stmt, dominated));
+      }
+      return results;
+    }
+    // Expression body — no opportunity for domination
+    if (isNode(body)) {
+      results.push(...findDynamicImports(body, false));
+    }
+    return results;
+  }
+
+  // Walk child nodes (generic)
+  for (const key of Object.keys(node)) {
+    if (key === 'type' || key === 'start' || key === 'end' || key === 'loc') continue;
+    const child = node[key];
+    if (Array.isArray(child)) {
+      for (const item of child) {
+        if (isNode(item)) results.push(...findDynamicImports(item, dominatedByGuard));
+      }
+    } else if (isNode(child)) {
+      results.push(...findDynamicImports(child, dominatedByGuard));
+    }
+  }
+
+  return results;
+}
+
+// ---------------------------------------------------------------------------
+// Load and parse the MarkdownEditor source
+// ---------------------------------------------------------------------------
+const SOURCE_PATH = new URL('./markdown-editor.svelte', import.meta.url).pathname;
+const source = await Bun.file(SOURCE_PATH)
+  .text()
+  .catch(() => {
+    throw new Error(`[import-boundary] Cannot read ${SOURCE_PATH} — failing hard per plan`);
+  });
+
+const svelteAst = parse(source, { filename: SOURCE_PATH }) as unknown as AstNode;
+const instanceBody: AstNode[] =
+  (((svelteAst['instance'] as AstNode | undefined)?.['content'] as AstNode | undefined)?.[
+    'body'
+  ] as AstNode[] | undefined) ?? [];
+const moduleBody: AstNode[] =
+  (((svelteAst['module'] as AstNode | undefined)?.['content'] as AstNode | undefined)?.['body'] as
+    | AstNode[]
+    | undefined) ?? [];
+const allTopLevelStatements = [...moduleBody, ...instanceBody];
+
+// ---------------------------------------------------------------------------
+// Collect violations
+// ---------------------------------------------------------------------------
+
+/** Static value imports from a protected package */
+const staticValueViolations: string[] = [];
+
+/** Dynamic imports without a dominating browser guard */
+const ungardedDynamicViolations: string[] = [];
+
+/** Dynamic imports with non-literal specifiers */
+const nonLiteralDynamicViolations: string[] = [];
+
+for (const stmt of allTopLevelStatements) {
+  // Check static imports
+  if (stmt['type'] === 'ImportDeclaration') {
+    const importKind = stmt['importKind'] as string;
+    const source_ = (stmt['source'] as AstNode)['value'] as string;
+    if (importKind === 'value' && isProtected(source_)) {
+      staticValueViolations.push(source_);
+    }
+    continue;
+  }
+
+  // Find dynamic imports inside all other statements
+  const dynamicImports = findDynamicImports(stmt, false);
+  for (const { specifier, guardedByEarlyReturn } of dynamicImports) {
+    if (specifier === null) {
+      nonLiteralDynamicViolations.push('<non-literal specifier>');
+      continue;
+    }
+    if (isProtected(specifier)) {
+      if (!guardedByEarlyReturn) {
+        ungardedDynamicViolations.push(specifier);
+      }
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Tests (real component)
+// ---------------------------------------------------------------------------
+describe('MarkdownEditor import-boundary invariant', () => {
+  it('has no static value imports from @milkdown/ or prosemirror-', () => {
+    expect(staticValueViolations).toEqual([]);
+  });
+
+  it('has no unguarded dynamic imports of @milkdown/ or prosemirror-', () => {
+    expect(ungardedDynamicViolations).toEqual([]);
+  });
+
+  it('has no non-literal dynamic import specifiers in the script', () => {
+    expect(nonLiteralDynamicViolations).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Permanent synthetic fixtures — prove the matcher is fail-closed
+// These MUST stay in the test; they are the regression coverage for the
+// matcher itself, not for the component.
+// ---------------------------------------------------------------------------
+
+function analyzeFixture(svelteSource: string): {
+  staticValueViolations: string[];
+  ungardedDynamicViolations: string[];
+  nonLiteralDynamicViolations: string[];
+} {
+  const ast = parse(svelteSource, { filename: 'fixture.svelte' }) as unknown as AstNode;
+  const body: AstNode[] =
+    (((ast['instance'] as AstNode | undefined)?.['content'] as AstNode | undefined)?.['body'] as
+      | AstNode[]
+      | undefined) ?? [];
+
+  const staticViolations: string[] = [];
+  const unguardedViolations: string[] = [];
+  const nonLiteralViolations: string[] = [];
+
+  for (const stmt of body) {
+    if (stmt['type'] === 'ImportDeclaration') {
+      const importKind = stmt['importKind'] as string;
+      const src = (stmt['source'] as AstNode)['value'] as string;
+      if (importKind === 'value' && isProtected(src)) {
+        staticViolations.push(src);
+      }
+      continue;
+    }
+    const dynamicImports = findDynamicImports(stmt, false);
+    for (const { specifier, guardedByEarlyReturn } of dynamicImports) {
+      if (specifier === null) {
+        nonLiteralViolations.push('<non-literal>');
+        continue;
+      }
+      if (isProtected(specifier) && !guardedByEarlyReturn) {
+        unguardedViolations.push(specifier);
+      }
+    }
+  }
+
+  return {
+    staticValueViolations: staticViolations,
+    ungardedDynamicViolations: unguardedViolations,
+    nonLiteralDynamicViolations: nonLiteralViolations,
+  };
+}
+
+describe('import-boundary matcher fixtures (fail-closed regression coverage)', () => {
+  it('FAILS: static value import from protected package', () => {
+    const result = analyzeFixture(
+      `<script lang="ts">import { foo } from '@milkdown/kit/ctx';</script><div></div>`,
+    );
+    expect(result.staticValueViolations).toEqual(['@milkdown/kit/ctx']);
+  });
+
+  it('PASSES: type-only import from protected package', () => {
+    const result = analyzeFixture(
+      `<script lang="ts">import type { Ctx } from '@milkdown/kit/ctx';</script><div></div>`,
+    );
+    expect(result.staticValueViolations).toEqual([]);
+  });
+
+  it('PASSES: guarded dynamic import (early-return domination)', () => {
+    const result = analyzeFixture(
+      `<script lang="ts">
+        $effect(() => {
+          if (!browser) return;
+          void import('@milkdown/kit/prose/history').then(m => {});
+        });
+      </script><div></div>`,
+    );
+    expect(result.ungardedDynamicViolations).toEqual([]);
+  });
+
+  it('FAILS: unguarded dynamic import of protected package at top level', () => {
+    const result = analyzeFixture(
+      `<script lang="ts">
+        void import('@milkdown/kit/prose/history').then(m => {});
+      </script><div></div>`,
+    );
+    expect(result.ungardedDynamicViolations).toEqual(['@milkdown/kit/prose/history']);
+  });
+
+  it('FAILS: unguarded dynamic import of protected package inside effect (no guard)', () => {
+    const result = analyzeFixture(
+      `<script lang="ts">
+        $effect(() => {
+          void import('@milkdown/kit/prose/history').then(m => {});
+        });
+      </script><div></div>`,
+    );
+    expect(result.ungardedDynamicViolations).toEqual(['@milkdown/kit/prose/history']);
+  });
+
+  it('FAILS: non-literal specifier in dynamic import', () => {
+    const result = analyzeFixture(
+      `<script lang="ts">
+        const pkg = '@milkdown/kit/prose/history';
+        $effect(() => {
+          if (!browser) return;
+          void import(pkg).then(m => {});
+        });
+      </script><div></div>`,
+    );
+    expect(result.nonLiteralDynamicViolations).toEqual(['<non-literal>']);
+  });
+
+  it('PASSES: dynamic import of a safe (non-protected) package', () => {
+    const result = analyzeFixture(
+      `<script lang="ts">
+        void import('some-safe-package').then(m => {});
+      </script><div></div>`,
+    );
+    expect(result.ungardedDynamicViolations).toEqual([]);
+    expect(result.staticValueViolations).toEqual([]);
+  });
+});

--- a/packages/components/src/components/markdown-editor/markdown-editor.import-boundary.test.ts
+++ b/packages/components/src/components/markdown-editor/markdown-editor.import-boundary.test.ts
@@ -23,7 +23,7 @@ import { describe, expect, it } from 'bun:test';
 import { parse } from 'svelte/compiler';
 
 // ---------------------------------------------------------------------------
-// Protected package set (explicit prefix constants — change only here)
+// Protected package set — keep in sync with scripts/ssr-import-boundary.ts
 // ---------------------------------------------------------------------------
 const PROTECTED_PREFIXES = ['@milkdown/', 'prosemirror-'] as const;
 

--- a/packages/components/src/components/markdown-editor/markdown-editor.import-boundary.test.ts
+++ b/packages/components/src/components/markdown-editor/markdown-editor.import-boundary.test.ts
@@ -115,6 +115,43 @@ function findDynamicImports(node: AstNode, dominatedByGuard: boolean): DynamicIm
 }
 
 // ---------------------------------------------------------------------------
+// Violation collector — shared by production analysis and fixture tests
+// ---------------------------------------------------------------------------
+
+function collectViolations(statements: AstNode[]): {
+  staticValueViolations: string[];
+  unguardedDynamicViolations: string[];
+  nonLiteralDynamicViolations: string[];
+} {
+  const staticValueViolations: string[] = [];
+  const unguardedDynamicViolations: string[] = [];
+  const nonLiteralDynamicViolations: string[] = [];
+
+  for (const stmt of statements) {
+    if (stmt['type'] === 'ImportDeclaration') {
+      const importKind = stmt['importKind'] as string;
+      const source_ = (stmt['source'] as AstNode)['value'] as string;
+      if (importKind === 'value' && isProtected(source_)) {
+        staticValueViolations.push(source_);
+      }
+      continue;
+    }
+    const dynamicImports = findDynamicImports(stmt, false);
+    for (const { specifier, guardedByEarlyReturn } of dynamicImports) {
+      if (specifier === null) {
+        nonLiteralDynamicViolations.push('<non-literal specifier>');
+        continue;
+      }
+      if (isProtected(specifier) && !guardedByEarlyReturn) {
+        unguardedDynamicViolations.push(specifier);
+      }
+    }
+  }
+
+  return { staticValueViolations, unguardedDynamicViolations, nonLiteralDynamicViolations };
+}
+
+// ---------------------------------------------------------------------------
 // Load and parse the MarkdownEditor source
 // ---------------------------------------------------------------------------
 const SOURCE_PATH = new URL('./markdown-editor.svelte', import.meta.url).pathname;
@@ -133,46 +170,10 @@ const moduleBody: AstNode[] =
   (((svelteAst['module'] as AstNode | undefined)?.['content'] as AstNode | undefined)?.['body'] as
     | AstNode[]
     | undefined) ?? [];
-const allTopLevelStatements = [...moduleBody, ...instanceBody];
 
-// ---------------------------------------------------------------------------
-// Collect violations
-// ---------------------------------------------------------------------------
-
-/** Static value imports from a protected package */
-const staticValueViolations: string[] = [];
-
-/** Dynamic imports without a dominating browser guard */
-const unguardedDynamicViolations: string[] = [];
-
-/** Dynamic imports with non-literal specifiers */
-const nonLiteralDynamicViolations: string[] = [];
-
-for (const stmt of allTopLevelStatements) {
-  // Check static imports
-  if (stmt['type'] === 'ImportDeclaration') {
-    const importKind = stmt['importKind'] as string;
-    const source_ = (stmt['source'] as AstNode)['value'] as string;
-    if (importKind === 'value' && isProtected(source_)) {
-      staticValueViolations.push(source_);
-    }
-    continue;
-  }
-
-  // Find dynamic imports inside all other statements
-  const dynamicImports = findDynamicImports(stmt, false);
-  for (const { specifier, guardedByEarlyReturn } of dynamicImports) {
-    if (specifier === null) {
-      nonLiteralDynamicViolations.push('<non-literal specifier>');
-      continue;
-    }
-    if (isProtected(specifier)) {
-      if (!guardedByEarlyReturn) {
-        unguardedDynamicViolations.push(specifier);
-      }
-    }
-  }
-}
+// Production analysis: walk both module and instance script blocks.
+const { staticValueViolations, unguardedDynamicViolations, nonLiteralDynamicViolations } =
+  collectViolations([...moduleBody, ...instanceBody]);
 
 // ---------------------------------------------------------------------------
 // Tests (real component)
@@ -197,47 +198,14 @@ describe('MarkdownEditor import-boundary invariant', () => {
 // matcher itself, not for the component.
 // ---------------------------------------------------------------------------
 
-function analyzeFixture(svelteSource: string): {
-  staticValueViolations: string[];
-  unguardedDynamicViolations: string[];
-  nonLiteralDynamicViolations: string[];
-} {
+// Fixtures use only the instance body (no module script in these synthetic .svelte strings).
+function analyzeFixture(svelteSource: string): ReturnType<typeof collectViolations> {
   const ast = parse(svelteSource, { filename: 'fixture.svelte' }) as unknown as AstNode;
   const body: AstNode[] =
     (((ast['instance'] as AstNode | undefined)?.['content'] as AstNode | undefined)?.['body'] as
       | AstNode[]
       | undefined) ?? [];
-
-  const staticViolations: string[] = [];
-  const unguardedViolations: string[] = [];
-  const nonLiteralViolations: string[] = [];
-
-  for (const stmt of body) {
-    if (stmt['type'] === 'ImportDeclaration') {
-      const importKind = stmt['importKind'] as string;
-      const src = (stmt['source'] as AstNode)['value'] as string;
-      if (importKind === 'value' && isProtected(src)) {
-        staticViolations.push(src);
-      }
-      continue;
-    }
-    const dynamicImports = findDynamicImports(stmt, false);
-    for (const { specifier, guardedByEarlyReturn } of dynamicImports) {
-      if (specifier === null) {
-        nonLiteralViolations.push('<non-literal>');
-        continue;
-      }
-      if (isProtected(specifier) && !guardedByEarlyReturn) {
-        unguardedViolations.push(specifier);
-      }
-    }
-  }
-
-  return {
-    staticValueViolations: staticViolations,
-    unguardedDynamicViolations: unguardedViolations,
-    nonLiteralDynamicViolations: nonLiteralViolations,
-  };
+  return collectViolations(body);
 }
 
 describe('import-boundary matcher fixtures (fail-closed regression coverage)', () => {
@@ -297,7 +265,7 @@ describe('import-boundary matcher fixtures (fail-closed regression coverage)', (
         });
       </script><div></div>`,
     );
-    expect(result.nonLiteralDynamicViolations).toEqual(['<non-literal>']);
+    expect(result.nonLiteralDynamicViolations).toEqual(['<non-literal specifier>']);
   });
 
   it('PASSES: dynamic import of a safe (non-protected) package', () => {

--- a/packages/components/src/components/markdown-editor/markdown-editor.import-boundary.test.ts
+++ b/packages/components/src/components/markdown-editor/markdown-editor.import-boundary.test.ts
@@ -144,7 +144,7 @@ const allTopLevelStatements = [...moduleBody, ...instanceBody];
 const staticValueViolations: string[] = [];
 
 /** Dynamic imports without a dominating browser guard */
-const ungardedDynamicViolations: string[] = [];
+const unguardedDynamicViolations: string[] = [];
 
 /** Dynamic imports with non-literal specifiers */
 const nonLiteralDynamicViolations: string[] = [];
@@ -169,7 +169,7 @@ for (const stmt of allTopLevelStatements) {
     }
     if (isProtected(specifier)) {
       if (!guardedByEarlyReturn) {
-        ungardedDynamicViolations.push(specifier);
+        unguardedDynamicViolations.push(specifier);
       }
     }
   }
@@ -184,7 +184,7 @@ describe('MarkdownEditor import-boundary invariant', () => {
   });
 
   it('has no unguarded dynamic imports of @milkdown/ or prosemirror-', () => {
-    expect(ungardedDynamicViolations).toEqual([]);
+    expect(unguardedDynamicViolations).toEqual([]);
   });
 
   it('has no non-literal dynamic import specifiers in the script', () => {
@@ -200,7 +200,7 @@ describe('MarkdownEditor import-boundary invariant', () => {
 
 function analyzeFixture(svelteSource: string): {
   staticValueViolations: string[];
-  ungardedDynamicViolations: string[];
+  unguardedDynamicViolations: string[];
   nonLiteralDynamicViolations: string[];
 } {
   const ast = parse(svelteSource, { filename: 'fixture.svelte' }) as unknown as AstNode;
@@ -236,7 +236,7 @@ function analyzeFixture(svelteSource: string): {
 
   return {
     staticValueViolations: staticViolations,
-    ungardedDynamicViolations: unguardedViolations,
+    unguardedDynamicViolations: unguardedViolations,
     nonLiteralDynamicViolations: nonLiteralViolations,
   };
 }
@@ -265,7 +265,7 @@ describe('import-boundary matcher fixtures (fail-closed regression coverage)', (
         });
       </script><div></div>`,
     );
-    expect(result.ungardedDynamicViolations).toEqual([]);
+    expect(result.unguardedDynamicViolations).toEqual([]);
   });
 
   it('FAILS: unguarded dynamic import of protected package at top level', () => {
@@ -274,7 +274,7 @@ describe('import-boundary matcher fixtures (fail-closed regression coverage)', (
         void import('@milkdown/kit/prose/history').then(m => {});
       </script><div></div>`,
     );
-    expect(result.ungardedDynamicViolations).toEqual(['@milkdown/kit/prose/history']);
+    expect(result.unguardedDynamicViolations).toEqual(['@milkdown/kit/prose/history']);
   });
 
   it('FAILS: unguarded dynamic import of protected package inside effect (no guard)', () => {
@@ -285,7 +285,7 @@ describe('import-boundary matcher fixtures (fail-closed regression coverage)', (
         });
       </script><div></div>`,
     );
-    expect(result.ungardedDynamicViolations).toEqual(['@milkdown/kit/prose/history']);
+    expect(result.unguardedDynamicViolations).toEqual(['@milkdown/kit/prose/history']);
   });
 
   it('FAILS: non-literal specifier in dynamic import', () => {
@@ -307,7 +307,7 @@ describe('import-boundary matcher fixtures (fail-closed regression coverage)', (
         void import('some-safe-package').then(m => {});
       </script><div></div>`,
     );
-    expect(result.ungardedDynamicViolations).toEqual([]);
+    expect(result.unguardedDynamicViolations).toEqual([]);
     expect(result.staticValueViolations).toEqual([]);
   });
 });

--- a/packages/components/src/components/markdown-editor/markdown-editor.import-boundary.test.ts
+++ b/packages/components/src/components/markdown-editor/markdown-editor.import-boundary.test.ts
@@ -22,9 +22,8 @@
 import { describe, expect, it } from 'bun:test';
 import { parse } from 'svelte/compiler';
 
-// ---------------------------------------------------------------------------
-// Protected package set — keep in sync with scripts/ssr-import-boundary.ts
-// ---------------------------------------------------------------------------
+// Protected package set — single source of truth is scripts/ssr-import-boundary.ts.
+// Defined inline because cross-package imports are outside the components rootDir.
 const PROTECTED_PREFIXES = ['@milkdown/', 'prosemirror-'] as const;
 
 function isProtected(specifier: string): boolean {

--- a/packages/components/src/components/markdown-editor/markdown-editor.svelte
+++ b/packages/components/src/components/markdown-editor/markdown-editor.svelte
@@ -178,7 +178,8 @@
     if (!browser) return;
 
     let cancelled = false;
-    // Milkdown/ProseMirror runtime graph is browser-bound; keep this import inside the browser-only effect.
+    // cinder/markdown/pipeline is SSR-safe (pure remark/unified), but kept dynamic for code-splitting:
+    // the parser/serializer should not load before the user actually interacts with the editor.
     void import('cinder/markdown/pipeline').then((module) => {
       if (!cancelled) {
         pipelineUtilities = {

--- a/packages/components/src/components/markdown-editor/markdown-editor.svelte
+++ b/packages/components/src/components/markdown-editor/markdown-editor.svelte
@@ -159,6 +159,7 @@
     if (!browser) return;
 
     let cancelled = false;
+    // Milkdown/ProseMirror runtime graph is browser-bound; keep this import inside the browser-only effect.
     void import('@milkdown/kit/prose/history').then((module) => {
       if (!cancelled) {
         historyUtilities = {
@@ -177,6 +178,7 @@
     if (!browser) return;
 
     let cancelled = false;
+    // Milkdown/ProseMirror runtime graph is browser-bound; keep this import inside the browser-only effect.
     void import('cinder/markdown/pipeline').then((module) => {
       if (!cancelled) {
         pipelineUtilities = {

--- a/packages/components/src/test/hydrate.ts
+++ b/packages/components/src/test/hydrate.ts
@@ -71,8 +71,12 @@ export async function renderThenHydrate<Props extends Record<string, unknown>>(
     css: 'external',
     dev: false,
   });
+  // Resolve svelte's location from the hydrate helper's own directory so it
+  // works regardless of process.cwd() (which varies when tests run from the
+  // package root vs the monorepo root).
+  const sveltePackageJson = new URL(import.meta.resolve('svelte/package.json')).pathname;
   const serverSvelteEntry = pathToFileURL(
-    join(process.cwd(), 'node_modules/svelte/src/index-server.js'),
+    join(dirname(sveltePackageJson), 'src/index-server.js'),
   ).href;
   const serverCode = compiled.js.code.replaceAll(
     "from 'svelte';",

--- a/packages/editor/src/ssr-import.test.ts
+++ b/packages/editor/src/ssr-import.test.ts
@@ -1,12 +1,17 @@
 import { describe, expect, it } from 'bun:test';
 import { relative } from 'node:path';
 
-// Protected-package prefixes are defined centrally in scripts/ssr-import-boundary.ts.
-// This test uses a narrower pattern because editor source files legitimately import
-// from prosemirror-* (they ARE the browser-side layer); the constraint here is that
-// @milkdown/kit/ bundles must stay lazy (no static value imports in non-test files).
-const RUNTIME_MILKDOWN_IMPORT_PATTERN =
-  /import\s+(?!type\b)[\s\S]*?\s+from\s+['"]@milkdown\/kit\//g;
+import { PROTECTED_PREFIXES } from '../../../scripts/ssr-import-boundary.ts';
+
+// Editor source files legitimately import from prosemirror-* (they ARE the browser-side layer),
+// so this test uses only the @milkdown/ prefix from PROTECTED_PREFIXES. The constraint here is
+// that @milkdown/kit/ bundles must stay lazy (no static value imports in non-test files).
+const milkdownPrefix = PROTECTED_PREFIXES.find((p) => p.startsWith('@milkdown/'))!;
+const escapedPrefix = milkdownPrefix.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+const RUNTIME_MILKDOWN_IMPORT_PATTERN = new RegExp(
+  `import\\s+(?!type\\b)[\\s\\S]*?\\s+from\\s+['"]${escapedPrefix}`,
+  'g',
+);
 
 describe('@cinder/editor SSR import safety', () => {
   it('imports the package barrel without needing browser globals', async () => {

--- a/packages/editor/src/ssr-import.test.ts
+++ b/packages/editor/src/ssr-import.test.ts
@@ -1,13 +1,12 @@
 import { describe, expect, it } from 'bun:test';
 import { relative } from 'node:path';
 
-import { PROTECTED_PREFIXES } from '../../../scripts/ssr-import-boundary.ts';
+import { MILKDOWN_PREFIX } from '../../../scripts/ssr-import-boundary.ts';
 
 // Editor source files legitimately import from prosemirror-* (they ARE the browser-side layer),
-// so this test uses only the @milkdown/ prefix from PROTECTED_PREFIXES. The constraint here is
-// that @milkdown/kit/ bundles must stay lazy (no static value imports in non-test files).
-const milkdownPrefix = PROTECTED_PREFIXES.find((p) => p.startsWith('@milkdown/'))!;
-const escapedPrefix = milkdownPrefix.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+// so this test uses MILKDOWN_PREFIX only. The constraint here is that @milkdown/kit/ bundles
+// must stay lazy (no static value imports in non-test files).
+const escapedPrefix = MILKDOWN_PREFIX.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 const RUNTIME_MILKDOWN_IMPORT_PATTERN = new RegExp(
   `import\\s+(?!type\\b)[\\s\\S]*?\\s+from\\s+['"]${escapedPrefix}`,
   'g',

--- a/packages/editor/src/ssr-import.test.ts
+++ b/packages/editor/src/ssr-import.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from 'bun:test';
 import { relative } from 'node:path';
 
+// Protected-package prefixes are defined centrally in scripts/ssr-import-boundary.ts.
+// This test uses a narrower pattern because editor source files legitimately import
+// from prosemirror-* (they ARE the browser-side layer); the constraint here is that
+// @milkdown/kit/ bundles must stay lazy (no static value imports in non-test files).
 const RUNTIME_MILKDOWN_IMPORT_PATTERN =
   /import\s+(?!type\b)[\s\S]*?\s+from\s+['"]@milkdown\/kit\//g;
 

--- a/packages/markdown/src/pipeline/ssr-safe.test.ts
+++ b/packages/markdown/src/pipeline/ssr-safe.test.ts
@@ -1,0 +1,85 @@
+/**
+ * cinder/markdown/pipeline barrel is SSR-safe (Bun no-DOM smoke)
+ *
+ * Verifies that every runtime export of the pipeline barrel can be imported
+ * and called in a Node-like environment with no DOM present. Milkdown and
+ * ProseMirror touch browser globals at module-evaluation time, but the
+ * pipeline (remark/unified/mdast) is purely computational — this test
+ * confirms that invariant stays true.
+ *
+ * Caveat: Bun no-DOM success ≠ the production SSR bundler environment.
+ * A production bundler may resolve conditional exports differently, and this
+ * test cannot catch that. If the repo grows an SSR compile path (e.g. a
+ * SvelteKit fixture that exercises the full bundle), prefer it; otherwise this
+ * smoke test documents and guards the invariant.
+ */
+
+import { describe, expect, it } from 'bun:test';
+
+// Delete browser globals before importing so any accidental DOM access throws.
+const originalDocument = Object.getOwnPropertyDescriptor(globalThis, 'document');
+const originalWindow = Object.getOwnPropertyDescriptor(globalThis, 'window');
+
+Reflect.deleteProperty(globalThis, 'document');
+Reflect.deleteProperty(globalThis, 'window');
+
+// Dynamic import after removing globals to ensure module init is clean.
+const pipeline = await import('./index.js');
+
+// Restore globals so other test files in the suite aren't affected.
+if (originalDocument) Object.defineProperty(globalThis, 'document', originalDocument);
+if (originalWindow) Object.defineProperty(globalThis, 'window', originalWindow);
+
+describe('cinder/markdown/pipeline barrel is SSR-safe (Bun no-DOM smoke)', () => {
+  it('exports parse as a function', () => {
+    expect(typeof pipeline.parse).toBe('function');
+  });
+
+  it('exports parseOrThrow as a function', () => {
+    expect(typeof pipeline.parseOrThrow).toBe('function');
+  });
+
+  it('exports serialize as a function', () => {
+    expect(typeof pipeline.serialize).toBe('function');
+  });
+
+  it('exports roundTrip as a function', () => {
+    expect(typeof pipeline.roundTrip).toBe('function');
+  });
+
+  it('exports normalize as a function', () => {
+    expect(typeof pipeline.normalize).toBe('function');
+  });
+
+  it('exports astEquals as a function', () => {
+    expect(typeof pipeline.astEquals).toBe('function');
+  });
+
+  it('exports extractFrontMatter as a function', () => {
+    expect(typeof pipeline.extractFrontMatter).toBe('function');
+  });
+
+  it('parse runs without DOM globals', () => {
+    const result = pipeline.parse('# Hello *world*');
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.ast.type).toBe('root');
+    }
+  });
+
+  it('serialize runs without DOM globals', () => {
+    const ast = pipeline.parseOrThrow('# Hello');
+    const output = pipeline.serialize(ast);
+    expect(output).toContain('Hello');
+  });
+
+  it('roundTrip runs without DOM globals', () => {
+    const result = pipeline.roundTrip('# Hello\n\nParagraph text.\n');
+    expect(result.passes).toBe(true);
+  });
+
+  it('normalize runs without DOM globals', () => {
+    const output = pipeline.normalize('# Hello\n\nsome text\n');
+    expect(typeof output).toBe('string');
+  });
+});

--- a/scripts/ssr-import-boundary.ts
+++ b/scripts/ssr-import-boundary.ts
@@ -1,0 +1,18 @@
+/**
+ * Shared constants for the browser-bound import-boundary invariant.
+ *
+ * Both `packages/editor/src/ssr-import.test.ts` and
+ * `packages/components/src/components/markdown-editor/markdown-editor.import-boundary.test.ts`
+ * enforce the same protected-package set. This module is the single source of
+ * truth so both tests fail in sync when a new browser-bound package is added.
+ *
+ * Adding a new package: edit PROTECTED_PREFIXES here and both tests pick it up.
+ */
+
+/** Package-name prefixes whose runtime exports touch browser globals. */
+export const PROTECTED_PREFIXES = ['@milkdown/', 'prosemirror-'] as const;
+
+/** Returns true if the given import specifier is from a protected package. */
+export function isProtectedSpecifier(specifier: string): boolean {
+  return PROTECTED_PREFIXES.some((prefix) => specifier.startsWith(prefix));
+}

--- a/scripts/ssr-import-boundary.ts
+++ b/scripts/ssr-import-boundary.ts
@@ -12,6 +12,12 @@
 /** Package-name prefixes whose runtime exports touch browser globals. */
 export const PROTECTED_PREFIXES = ['@milkdown/', 'prosemirror-'] as const;
 
+/**
+ * The Milkdown prefix specifically. Editor test files use this directly
+ * because they legitimately import prosemirror-* at the source level.
+ */
+export const MILKDOWN_PREFIX = '@milkdown/' as const;
+
 /** Returns true if the given import specifier is from a protected package. */
 export function isProtectedSpecifier(specifier: string): boolean {
   return PROTECTED_PREFIXES.some((prefix) => specifier.startsWith(prefix));


### PR DESCRIPTION
## Summary

- **Pipeline SSR smoke test** (`packages/markdown/src/pipeline/ssr-safe.test.ts`): proves every barrel export of `cinder/markdown/pipeline` is importable without DOM globals (Bun no-DOM smoke). Caveat documented: Bun success ≠ production SSR bundler environment.
- **Import-boundary invariant** (`markdown-editor.import-boundary.test.ts`): AST-based structural enforcement that `@milkdown/` and `prosemirror-` packages are never statically value-imported and any dynamic import is guarded by `if (!browser) return;` domination. Includes permanent synthetic fixtures proving the matcher is fail-closed.
- **SSR contract test** (`markdown-editor.hydrate.test.ts`): source-level assertions on the `{#if browser}` structure. Full `renderThenHydrate` is blocked — root cause documented with three unblocking options; `test.skip` records the blocked state.
- **`hydrate.ts` bug fix**: resolved CWD-relative svelte path lookup (`process.cwd()`) with `import.meta.resolve` so tests work from any working directory.
- **Shared helper** (`scripts/ssr-import-boundary.ts`): single source of truth for `PROTECTED_PREFIXES` and `MILKDOWN_PREFIX`; consumed by `packages/editor/src/ssr-import.test.ts`.
- **Dynamic import comments**: two sites in `markdown-editor.svelte` now explain why the imports cannot be static.

## Review committee

Pre-reviewed by: testing-expert, simplicity-engineer

- Codex unavailable (health check: `doghouse: unknown command '--json'`)
- 3 rounds of review
- All must-fix items addressed

> [!WARNING]
> Codex (the adversarial second-opinion reviewer) was unavailable for this PR. See `tmp/committee-state.md` for detail.

## Test plan

- `bun test packages/markdown/src/pipeline/ssr-safe.test.ts` — 11 pass
- `bun test packages/components/src/components/markdown-editor/markdown-editor.import-boundary.test.ts` — 10 pass
- `bun test packages/components/src/components/markdown-editor/markdown-editor.hydrate.test.ts` — 5 pass, 1 skip (blocked hydration)
- `bun test packages/editor/src/ssr-import.test.ts` — 2 pass
- Full suite: `bun test packages/components` — 3597 pass, 2 skip, 0 fail

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are tests, comments, and test-helper path resolution; no production SSR or auth behavior changes beyond documentation.
> 
> **Overview**
> Adds **SSR and import-boundary guardrails** around `MarkdownEditor` and related packages, plus a small fix to the shared hydrate test helper.
> 
> **New tests:** `cinder/markdown/pipeline` is smoke-tested with `document`/`window` removed so barrel exports run without DOM. `markdown-editor.import-boundary.test.ts` parses `markdown-editor.svelte` with `svelte/compiler` and enforces no static value imports from `@milkdown/` or `prosemirror-`, and that protected packages are only loaded via `import()` inside effects whose first statement is `if (!browser) return;` (with permanent fixtures for the matcher). `markdown-editor.hydrate.test.ts` asserts the `{#if browser}` / `EditorSkeleton` SSR contract from source; full `renderThenHydrate` is documented as blocked and recorded with a skipped test. **`scripts/ssr-import-boundary.ts`** centralizes `PROTECTED_PREFIXES` / `MILKDOWN_PREFIX`; **`packages/editor/src/ssr-import.test.ts`** now builds its Milkdown regex from `MILKDOWN_PREFIX`.
> 
> **Production / infra tweaks:** Comments in `markdown-editor.svelte` document why Milkdown and pipeline loads stay dynamic inside browser-only effects. **`hydrate.ts`** resolves the server Svelte entry via `import.meta.resolve('svelte/package.json')` instead of `process.cwd()`-relative `node_modules`, so SSR compile-and-import works from package or monorepo roots.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9dbceca87ca30507856849c7c4d121eca4a4613a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->