### PR TITLE
feat(components): stable-promotion gate (components:promotion-check)

### DIFF
--- a/packages/components/AGENTS.md
+++ b/packages/components/AGENTS.md
@@ -203,12 +203,13 @@ the matching entry in `cinder/manifest`.
 
 <!-- generated:overlap-families:start -->
 
-### hover (2 components)
+### hover (3 components)
 
-| id        | purpose                                                                                                     | use when                                                                                                   |
-| --------- | ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------- |
-| `tooltip` | Hover-and-focus triggered descriptive hint anchored to a focusable child element, wired through…            | Showing a short non-interactive label or description for an icon-only button or terse control.             |
-| `popover` | Anchored floating panel positioned by Floating UI that hosts non-modal contextual content beside a trigger… | Showing rich, interactive contextual content anchored to a trigger such as a help panel, color picker, or… |
+| id           | purpose                                                                                                     | use when                                                                                                   |
+| ------------ | ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------- |
+| `tooltip`    | Hover-and-focus triggered descriptive hint anchored to a focusable child element, wired through…            | Showing a short non-interactive label or description for an icon-only button or terse control.             |
+| `popover`    | Anchored floating panel positioned by Floating UI that hosts non-modal contextual content beside a trigger… | Showing rich, interactive contextual content anchored to a trigger such as a help panel, color picker, or… |
+| `hover-card` | Hover-and-focus triggered rich preview card for non-interactive contextual content.                         | Showing a profile, issue, or metadata preview that is richer than a tooltip but still read-only.           |
 
 ### notice (3 components)
 
@@ -218,14 +219,15 @@ the matching entry in `cinder/manifest`.
 | `alert`   | Inline status message with assertive role for surfacing time-sensitive feedback about a nearby action or…     | Surfacing the result of a just-completed action such as a save failure or success.                        |
 | `callout` | Inline aside that highlights supporting commentary alongside body content without claiming live-region…       | Drawing attention to tangential information nested inside prose, documentation, or article content.       |
 
-### overlay (4 components)
+### overlay (5 components)
 
-| id        | purpose                                                                                                        | use when                                                                                                      |
-| --------- | -------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------- |
-| `modal`   | Centered modal dialog built on the native dialog element with focus capture, restoration, and dismissal…       | Interrupting the user for a focused task or decision that blocks the rest of the page.                        |
-| `drawer`  | Side-anchored modal panel built on the native dialog element for secondary navigation, settings, or long-form… | Showing supplementary navigation, filters, or settings that should slide in from a page edge.                 |
-| `sheet`   | Bottom-anchored modal panel built on the native dialog element with an optional drag handle for mobile-first…  | Presenting a focused task or set of actions that slides up from the bottom of the viewport on touch surfaces. |
-| `popover` | Anchored floating panel positioned by Floating UI that hosts non-modal contextual content beside a trigger…    | Showing rich, interactive contextual content anchored to a trigger such as a help panel, color picker, or…    |
+| id             | purpose                                                                                                        | use when                                                                                                      |
+| -------------- | -------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------- |
+| `modal`        | Centered modal dialog built on the native dialog element with focus capture, restoration, and dismissal…       | Interrupting the user for a focused task or decision that blocks the rest of the page.                        |
+| `drawer`       | Side-anchored modal panel built on the native dialog element for secondary navigation, settings, or long-form… | Showing supplementary navigation, filters, or settings that should slide in from a page edge.                 |
+| `sheet`        | Bottom-anchored modal panel built on the native dialog element with an optional drag handle for mobile-first…  | Presenting a focused task or set of actions that slides up from the bottom of the viewport on touch surfaces. |
+| `popover`      | Anchored floating panel positioned by Floating UI that hosts non-modal contextual content beside a trigger…    | Showing rich, interactive contextual content anchored to a trigger such as a help panel, color picker, or…    |
+| `alert-dialog` | Sticky alert dialog for urgent acknowledgement that cannot be dismissed by backdrop click or Escape.           | Requiring acknowledgement of a blocking warning before the user can continue.                                 |
 
 ### selection (3 components)
 
@@ -439,3 +441,91 @@ The reason must come from `allowedExampleExclusionReasons` in
 `manifest.meta.ts`. To add a new reason, edit that array and document
 why in your PR. The exclusion budget is capped at 10% of all playground
 examples; above that, `components:check` fails.
+
+## Stable-promotion gate
+
+Before flipping a component's `@status` from `alpha` or `beta` to `stable`,
+run the promotion gate:
+
+```bash
+bun run components:promotion-check <component-name>
+# or with machine-readable output:
+bun run components:promotion-check <component-name> --json
+```
+
+Exits 0 on PASS, 1 on FAIL. The `--json` flag writes a single JSON object to
+stdout and routes all human-readable diagnostics to stderr.
+
+### What the gate checks
+
+**Check 1 — Substantive test present.** The component must have a
+`<name>.test.ts` file containing at least one active `test(...)` or `it(...)`
+call (`.skip`, `.todo`, `.failing` suffixes excluded). A types-only snapshot
+file does not satisfy this.
+
+**Check 2 — Accessibility coverage (interactive components only).** A component
+is considered interactive when its `@category` metadata is one of `action`,
+`form`, `navigation`, or `overlay`. The check passes when EITHER:
+
+- An a11y doc exists at `<name>.a11y.md` adjacent to the component, OR at the
+  legacy flat path `src/components/<name>.a11y.md`, OR
+- A single `test(...)` block in `<name>.test.ts` contains BOTH a keyboard call
+  (`fireEvent.keyDown` or `user.keyboard`) AND an ARIA/role query
+  (`getByRole`/`findByRole`/`queryByRole`, or `expect(...).toHaveAttribute`
+  where the attribute name is `"role"` or starts with `"aria-"`).
+
+Setup-only mentions outside a test block do not count. Non-interactive
+components are N/A.
+
+**Check 3 — Hydration/SSR coverage (only if a browser guard exists).** The
+gate detects a browser guard structurally: a `{#if browser}` or
+`{#if hydrated}` template block (via `svelte/compiler` AST), or an import of
+`BROWSER` from `esm-env`. When a guard is found, the test file must contain a
+`render` call imported from `svelte/server` OR a `renderThenHydrate` call. A
+test merely _named_ "hydrates" does not satisfy this. No guard detected → N/A.
+
+**Check 4 — Prop-name conventions.** The committed `<name>.schema.json` must
+be up-to-date (no drift vs. what `components:generate` would produce), and all
+prop names must satisfy:
+
+- camelCase (starts with a lowercase letter, letters and digits only)
+- `class` is always allowed as a passthrough
+- `aria-*` and `data-*` attribute names are allowed
+- The prop name must NOT appear in the **frozen denylist** below
+
+`is`-prefix and `has`-prefix boolean props (e.g. `isLoading`) emit a **warning**
+but do not cause failure.
+
+### Frozen prop-name denylist
+
+These exact strings are forbidden as prop names. They are the all-lowercased,
+wrong-cased forms of legitimate camelCase props:
+
+| Forbidden name | Correct form   |
+| -------------- | -------------- |
+| `classname`    | `className`    |
+| `icononly`     | `iconOnly`     |
+| `leadingicon`  | `leadingIcon`  |
+| `trailingicon` | `trailingIcon` |
+| `ondismiss`    | `onDismiss`    |
+| `onchange`     | `onChange`     |
+
+To add to this list: update `PROP_NAME_DENYLIST` in
+`scripts/component-conventions.ts` and document the entry here in the same PR.
+
+### Schema-exempt components
+
+Components listed in `SCHEMA_EXEMPT` inside `scripts/check-promotion-readiness.ts`
+are skipped for the schema-drift and prop-name checks. Add a component to this
+set only when it has no `.types.ts` by design and document the reason.
+
+### Promotion workflow
+
+1. Run `bun run components:promotion-check <name>`.
+2. If PASS: flip `@status` to `stable` in the component's `.svelte` module
+   script, then run `bun run components:generate`.
+3. If FAIL: address each gap listed in the report. Do NOT promote with known
+   gaps — document them instead and leave the status unchanged.
+
+The gate is opt-in and is not wired into CI. It is a human/agent pre-promotion
+step, not an automated blocker.

--- a/packages/components/AGENTS.md
+++ b/packages/components/AGENTS.md
@@ -498,12 +498,16 @@ but do not cause failure.
 
 ### Frozen prop-name denylist
 
-These exact strings are forbidden as prop names. They are the all-lowercased,
-wrong-cased forms of legitimate camelCase props:
+These exact strings are forbidden as prop names. Most are the all-lowercased,
+wrong-cased forms of legitimate camelCase props. `className` is special: it is
+valid camelCase but still forbidden, because cinder components expose
+`class?: string` as the public prop and destructure it internally as
+`class: className` — the public API is always `class`, never `className`.
 
 | Forbidden name | Correct form   |
 | -------------- | -------------- |
-| `classname`    | `className`    |
+| `classname`    | `class`        |
+| `className`    | `class`        |
 | `icononly`     | `iconOnly`     |
 | `leadingicon`  | `leadingIcon`  |
 | `trailingicon` | `trailingIcon` |

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -2950,6 +2950,7 @@
     "components:check": "bun run scripts/generate-component-artifacts.ts --check",
     "components:fixture": "bun run scripts/run-consumer-fixture.ts",
     "components:generate": "bun run scripts/generate-component-artifacts.ts",
+    "components:promotion-check": "bun run scripts/check-promotion-readiness.ts",
     "exports:check": "bun run scripts/generate-exports.ts --check",
     "exports:generate": "bun run scripts/generate-exports.ts",
     "lint": "oxlint --type-aware --tsconfig ./tsconfig.json && bun run check:no-cycle-imports",

--- a/packages/components/scripts/check-promotion-readiness.test.ts
+++ b/packages/components/scripts/check-promotion-readiness.test.ts
@@ -8,7 +8,7 @@
  */
 
 import { describe, expect, test } from 'bun:test';
-import { existsSync, writeFileSync } from 'node:fs';
+import { existsSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -246,7 +246,7 @@ test('keyboard and role', async () => {
     try {
       expect(hasA11yCoverage(tempPath)).toBe(true);
     } finally {
-      Bun.file(tempPath);
+      rmSync(tempPath, { force: true });
     }
   });
 
@@ -268,7 +268,7 @@ test('role only', () => {
     try {
       expect(hasA11yCoverage(tempPath)).toBe(false);
     } finally {
-      Bun.file(tempPath);
+      rmSync(tempPath, { force: true });
     }
   });
 
@@ -287,7 +287,7 @@ test('keyboard only', async () => {
     try {
       expect(hasA11yCoverage(tempPath)).toBe(false);
     } finally {
-      Bun.file(tempPath);
+      rmSync(tempPath, { force: true });
     }
   });
 
@@ -305,7 +305,7 @@ test('role only', () => {
     try {
       expect(hasA11yCoverage(tempPath)).toBe(false);
     } finally {
-      Bun.file(tempPath);
+      rmSync(tempPath, { force: true });
     }
   });
 });
@@ -451,7 +451,12 @@ describe('hasHydrationTest', () => {
 
 describe('--json output shape on a failing component', () => {
   test('drawer exits 1 (hydration FAIL) with valid JSON report', async () => {
-    // Drawer has a browser guard but no renderThenHydrate test.
+    // FRAGILE: this relies on `drawer` currently having a browser guard
+    // ({#if hydrated}) but no renderThenHydrate / svelte-server render test. If
+    // drawer ever gains a hydration test, this assertion flips to PASS and the
+    // test must be repointed at another guarded-but-untested component (or
+    // replaced with a synthetic fixture). The `hydration === fail` assertion
+    // below is what guards against a silent flip.
     const { stdout, exitCode } = await runPromotionCheck(['drawer', '--json']);
     expect(exitCode).toBe(1);
 
@@ -469,4 +474,14 @@ describe('--json output shape on a failing component', () => {
     const { stdout } = await runPromotionCheck(['drawer', '--json']);
     expect(stdout.trimStart()).toMatch(/^\{/);
   });
+
+  // KNOWN COVERAGE GAP: the schema-drift FAIL paths in runPropNamesCheck
+  // (missing .schema.json, missing .types.ts, stale schema, generator throw)
+  // are not directly exercised — every committed component has an in-sync
+  // schema, so there is no real fixture to trigger them, and the script
+  // resolves COMPONENTS_DIRECTORY relative to itself which makes a synthetic
+  // out-of-tree component directory impractical to wire through the CLI. The
+  // drift PASS path is covered by the button and json-viewer integration
+  // tests above. The FAIL paths are simple guard clauses returning a
+  // structured { status: 'fail', detail } result.
 });

--- a/packages/components/scripts/check-promotion-readiness.test.ts
+++ b/packages/components/scripts/check-promotion-readiness.test.ts
@@ -370,6 +370,19 @@ describe('checkPropNames', () => {
     expect(violations).toHaveLength(0);
   });
 
+  test('fails for className even though it is valid camelCase (convention: class)', () => {
+    // cinder components expose `class?: string`, never `className`.
+    const schema = { properties: { className: {} } };
+    const { violations } = checkPropNames(schema);
+    expect(violations.length).toBeGreaterThan(0);
+  });
+
+  test('passes for the canonical class passthrough', () => {
+    const schema = { properties: { class: {} } };
+    const { violations } = checkPropNames(schema);
+    expect(violations).toHaveLength(0);
+  });
+
   test('fails for kebab-case prop names', () => {
     const schema = { properties: { 'full-width': {} } };
     const { violations } = checkPropNames(schema);
@@ -442,6 +455,34 @@ describe('hasHydrationTest', () => {
 
   test('returns false for non-existent file', () => {
     expect(hasHydrationTest('/tmp/no-such-file.test.ts')).toBe(false);
+  });
+
+  test('returns true when renderThenHydrate is inside an active test() block', () => {
+    const tempPath = join(tmpdir(), `hydration-active-${Date.now()}.test.ts`);
+    writeFileSync(
+      tempPath,
+      `import { test } from 'bun:test';\n` +
+        `test('hydrates', () => { renderThenHydrate(Foo, src, {}); });\n`,
+    );
+    try {
+      expect(hasHydrationTest(tempPath)).toBe(true);
+    } finally {
+      rmSync(tempPath, { force: true });
+    }
+  });
+
+  test('returns false when renderThenHydrate is only inside test.skip (never runs)', () => {
+    const tempPath = join(tmpdir(), `hydration-skip-${Date.now()}.test.ts`);
+    writeFileSync(
+      tempPath,
+      `import { test } from 'bun:test';\n` +
+        `test.skip('hydrates', () => { renderThenHydrate(Foo, src, {}); });\n`,
+    );
+    try {
+      expect(hasHydrationTest(tempPath)).toBe(false);
+    } finally {
+      rmSync(tempPath, { force: true });
+    }
   });
 });
 

--- a/packages/components/scripts/check-promotion-readiness.test.ts
+++ b/packages/components/scripts/check-promotion-readiness.test.ts
@@ -1,0 +1,338 @@
+/**
+ * Tests for the stable-promotion gate.
+ *
+ * Covers:
+ *   - Button (reference stable component) — must PASS
+ *   - Per-check FAIL scenarios via targeted assertions on helper functions
+ *   - --json output shape and exit-code contracts (via Bun.spawn)
+ */
+
+import { describe, expect, test } from 'bun:test';
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import {
+  checkPropNames,
+  hasA11yDoc,
+  hasBooleanIsPrefix,
+  hasBrowserGuard,
+  hasHydrationTest,
+  hasSubstantiveTest,
+  isInteractive,
+  PROP_NAME_DENYLIST,
+} from './component-conventions.ts';
+
+const SCRIPT_FILE = join(fileURLToPath(import.meta.url), '..', 'check-promotion-readiness.ts');
+
+const COMPONENTS_DIRECTORY = join(fileURLToPath(import.meta.url), '..', '..', 'src', 'components');
+
+function componentDirectory(name: string, experimental = false): string {
+  if (experimental) return join(COMPONENTS_DIRECTORY, 'experimental', name);
+  return join(COMPONENTS_DIRECTORY, name);
+}
+
+// ---------------------------------------------------------------------------
+// CLI helper — spawn the script and return { stdout, stderr, exitCode }
+// ---------------------------------------------------------------------------
+
+async function runPromotionCheck(
+  args: string[],
+): Promise<{ stdout: string; stderr: string; exitCode: number }> {
+  const process = Bun.spawn(['bun', SCRIPT_FILE, ...args], {
+    stdout: 'pipe',
+    stderr: 'pipe',
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(process.stdout).text(),
+    new Response(process.stderr).text(),
+    process.exited,
+  ]);
+
+  return { stdout, stderr, exitCode };
+}
+
+// ---------------------------------------------------------------------------
+// Reference component: button must PASS (exit 0)
+// ---------------------------------------------------------------------------
+
+describe('button reference component', () => {
+  test('exits 0 for button', async () => {
+    const { exitCode } = await runPromotionCheck(['button']);
+    expect(exitCode).toBe(0);
+  });
+
+  test('--json output for button is PASS with correct shape', async () => {
+    const { stdout, exitCode } = await runPromotionCheck(['button', '--json']);
+    expect(exitCode).toBe(0);
+    const report = JSON.parse(stdout) as {
+      component: string;
+      currentStatus: string;
+      checks: {
+        test: { status: string; detail?: string };
+        a11y: { status: string; detail?: string };
+        hydration: { status: string; detail?: string };
+        propNames: { status: string; detail?: string };
+      };
+      warnings: string[];
+      result: string;
+    };
+    expect(report.component).toBe('button');
+    expect(report.result).toBe('PASS');
+    expect(report.checks.test.status).toBe('pass');
+    expect(report.checks.a11y.status).toBe('pass');
+    expect(report.checks.hydration.status).toBe('na');
+    expect(report.checks.propNames.status).toBe('pass');
+    expect(Array.isArray(report.warnings)).toBe(true);
+  });
+
+  test('--json emits no text before the JSON object', async () => {
+    const { stdout } = await runPromotionCheck(['button', '--json']);
+    // stdout must start with the JSON object, no leading prose/diagnostics
+    expect(stdout.trimStart()).toMatch(/^\{/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Error handling — unknown component exits 1
+// ---------------------------------------------------------------------------
+
+test('exits 1 for unknown component', async () => {
+  const { exitCode } = await runPromotionCheck(['not-a-real-component-xyzzy']);
+  expect(exitCode).toBe(1);
+});
+
+test('exits 1 with no arguments', async () => {
+  const { exitCode } = await runPromotionCheck([]);
+  expect(exitCode).toBe(1);
+});
+
+// ---------------------------------------------------------------------------
+// Unit tests: hasSubstantiveTest
+// ---------------------------------------------------------------------------
+
+describe('hasSubstantiveTest', () => {
+  test('returns { pass: true } for button.test.ts (has active tests)', () => {
+    const testFile = join(componentDirectory('button'), 'button.test.ts');
+    expect(existsSync(testFile)).toBe(true);
+    const { pass, count } = hasSubstantiveTest(testFile);
+    expect(pass).toBe(true);
+    expect(count).toBeGreaterThanOrEqual(1);
+  });
+
+  test('returns { pass: false, count: 0 } for a non-existent file', () => {
+    const result = hasSubstantiveTest('/tmp/does-not-exist-xyzzy.test.ts');
+    expect(result.pass).toBe(false);
+    expect(result.count).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Unit tests: isInteractive
+// ---------------------------------------------------------------------------
+
+describe('isInteractive', () => {
+  test('returns true for action category', () => {
+    expect(isInteractive({ category: 'action' })).toBe(true);
+  });
+
+  test('returns true for form category', () => {
+    expect(isInteractive({ category: 'form' })).toBe(true);
+  });
+
+  test('returns true for navigation category', () => {
+    expect(isInteractive({ category: 'navigation' })).toBe(true);
+  });
+
+  test('returns true for overlay category', () => {
+    expect(isInteractive({ category: 'overlay' })).toBe(true);
+  });
+
+  test('returns false for feedback category', () => {
+    expect(isInteractive({ category: 'feedback' })).toBe(false);
+  });
+
+  test('returns false for layout category', () => {
+    expect(isInteractive({ category: 'layout' })).toBe(false);
+  });
+
+  test('returns false for data-display category', () => {
+    expect(isInteractive({ category: 'data-display' })).toBe(false);
+  });
+
+  test('returns false for undefined category', () => {
+    expect(isInteractive({})).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Unit tests: hasA11yDoc
+// ---------------------------------------------------------------------------
+
+describe('hasA11yDoc', () => {
+  test('returns true for button (has adjacent a11y doc)', () => {
+    const dir = componentDirectory('button');
+    expect(hasA11yDoc(dir, 'button')).toBe(true);
+  });
+
+  test('returns false for a component without an a11y doc', () => {
+    // container is layout (non-interactive) and lacks an a11y doc
+    const dir = componentDirectory('container');
+    expect(hasA11yDoc(dir, 'container')).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Unit tests: hasBrowserGuard
+// ---------------------------------------------------------------------------
+
+describe('hasBrowserGuard', () => {
+  test('returns true for drawer (has {#if hydrated} guard)', () => {
+    const sveltePath = join(componentDirectory('drawer'), 'drawer.svelte');
+    expect(hasBrowserGuard(sveltePath)).toBe(true);
+  });
+
+  test('returns true for markdown-editor (imports BROWSER from esm-env)', () => {
+    const sveltePath = join(componentDirectory('markdown-editor'), 'markdown-editor.svelte');
+    expect(hasBrowserGuard(sveltePath)).toBe(true);
+  });
+
+  test('returns false for button (no browser guard)', () => {
+    const sveltePath = join(componentDirectory('button'), 'button.svelte');
+    expect(hasBrowserGuard(sveltePath)).toBe(false);
+  });
+
+  test('returns false for non-existent file', () => {
+    expect(hasBrowserGuard('/tmp/no-such-file.svelte')).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Unit tests: checkPropNames
+// ---------------------------------------------------------------------------
+
+describe('checkPropNames', () => {
+  test('passes for conventional camelCase prop names', () => {
+    const schema = {
+      properties: {
+        variant: {},
+        iconOnly: {},
+        fullWidth: {},
+        class: {},
+        'aria-label': {},
+        'data-testid': {},
+      },
+    };
+    const { violations } = checkPropNames(schema);
+    expect(violations).toHaveLength(0);
+  });
+
+  test('fails for denylist entries (all-lowercase forbidden forms)', () => {
+    for (const deniedName of PROP_NAME_DENYLIST) {
+      const schema = { properties: { [deniedName]: {} } };
+      const { violations } = checkPropNames(schema);
+      expect(violations.length).toBeGreaterThan(0);
+    }
+  });
+
+  test('passes for iconOnly (the correct camelCase form, NOT in denylist)', () => {
+    // icononly is denied; iconOnly (camelCase) must be allowed
+    const schema = { properties: { iconOnly: {} } };
+    const { violations } = checkPropNames(schema);
+    expect(violations).toHaveLength(0);
+  });
+
+  test('fails for kebab-case prop names', () => {
+    const schema = { properties: { 'full-width': {} } };
+    const { violations } = checkPropNames(schema);
+    expect(violations.length).toBeGreaterThan(0);
+  });
+
+  test('fails for PascalCase prop names', () => {
+    const schema = { properties: { Variant: {} } };
+    const { violations } = checkPropNames(schema);
+    expect(violations.length).toBeGreaterThan(0);
+  });
+
+  test('returns warnings for is/has-prefix props', () => {
+    const schema = { properties: { isLoading: {} } };
+    const { violations, warnings } = checkPropNames(schema);
+    expect(violations).toHaveLength(0);
+    expect(warnings.length).toBeGreaterThan(0);
+  });
+
+  test('passes for schema with no properties', () => {
+    const { violations } = checkPropNames({});
+    expect(violations).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Unit tests: hasBooleanIsPrefix
+// ---------------------------------------------------------------------------
+
+describe('hasBooleanIsPrefix', () => {
+  test('returns true for is-prefix props', () => {
+    expect(hasBooleanIsPrefix('isLoading')).toBe(true);
+    expect(hasBooleanIsPrefix('isDisabled')).toBe(true);
+  });
+
+  test('returns true for has-prefix props', () => {
+    expect(hasBooleanIsPrefix('hasError')).toBe(true);
+  });
+
+  test('returns false for conventional props', () => {
+    expect(hasBooleanIsPrefix('loading')).toBe(false);
+    expect(hasBooleanIsPrefix('disabled')).toBe(false);
+    expect(hasBooleanIsPrefix('variant')).toBe(false);
+    expect(hasBooleanIsPrefix('class')).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Unit tests: hasHydrationTest
+// ---------------------------------------------------------------------------
+
+describe('hasHydrationTest', () => {
+  test('returns true for portal.test.ts (calls renderThenHydrate)', () => {
+    const testFile = join(componentDirectory('portal'), 'portal.test.ts');
+    expect(existsSync(testFile)).toBe(true);
+    expect(hasHydrationTest(testFile)).toBe(true);
+  });
+
+  test('returns false for button.test.ts (no renderThenHydrate)', () => {
+    const testFile = join(componentDirectory('button'), 'button.test.ts');
+    expect(hasHydrationTest(testFile)).toBe(false);
+  });
+
+  test('returns false for non-existent file', () => {
+    expect(hasHydrationTest('/tmp/no-such-file.test.ts')).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Integration: --json shape contract (exit 1 on FAIL)
+// ---------------------------------------------------------------------------
+
+describe('--json output shape on a failing component', () => {
+  test('drawer exits 1 (hydration FAIL) with valid JSON report', async () => {
+    // Drawer has a browser guard but no renderThenHydrate test.
+    const { stdout, exitCode } = await runPromotionCheck(['drawer', '--json']);
+    expect(exitCode).toBe(1);
+
+    const report = JSON.parse(stdout) as {
+      component: string;
+      result: string;
+      checks: Record<string, { status: string }>;
+    };
+    expect(report.result).toBe('FAIL');
+    expect(report.component).toBe('drawer');
+    expect(report.checks['hydration']?.status).toBe('fail');
+  });
+
+  test('--json emits no stdout text before the JSON object on FAIL', async () => {
+    const { stdout } = await runPromotionCheck(['drawer', '--json']);
+    expect(stdout.trimStart()).toMatch(/^\{/);
+  });
+});

--- a/packages/components/scripts/check-promotion-readiness.test.ts
+++ b/packages/components/scripts/check-promotion-readiness.test.ts
@@ -8,12 +8,14 @@
  */
 
 import { describe, expect, test } from 'bun:test';
-import { existsSync } from 'node:fs';
+import { existsSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import {
   checkPropNames,
+  hasA11yCoverage,
   hasA11yDoc,
   hasBooleanIsPrefix,
   hasBrowserGuard,
@@ -99,13 +101,48 @@ describe('button reference component', () => {
 // ---------------------------------------------------------------------------
 
 test('exits 1 for unknown component', async () => {
-  const { exitCode } = await runPromotionCheck(['not-a-real-component-xyzzy']);
+  const { exitCode, stderr } = await runPromotionCheck(['not-a-real-component-xyzzy']);
   expect(exitCode).toBe(1);
+  expect(stderr).toMatch(/not found/i);
 });
 
 test('exits 1 with no arguments', async () => {
   const { exitCode } = await runPromotionCheck([]);
   expect(exitCode).toBe(1);
+});
+
+test('--json exits 1 for unknown component with no stdout (error on stderr only)', async () => {
+  const { stdout, stderr, exitCode } = await runPromotionCheck([
+    'not-a-real-component-xyzzy',
+    '--json',
+  ]);
+  expect(exitCode).toBe(1);
+  expect(stdout.trim()).toBe('');
+  expect(stderr).toMatch(/not found/i);
+});
+
+// ---------------------------------------------------------------------------
+// Experimental component path
+// ---------------------------------------------------------------------------
+
+describe('experimental component (json-viewer)', () => {
+  test('exits 0 for json-viewer (experimental, alpha)', async () => {
+    const { exitCode } = await runPromotionCheck(['json-viewer']);
+    expect(exitCode).toBe(0);
+  });
+
+  test('--json for json-viewer reports propNames pass (depthToSrc=3 path)', async () => {
+    const { stdout, exitCode } = await runPromotionCheck(['json-viewer', '--json']);
+    expect(exitCode).toBe(0);
+    const report = JSON.parse(stdout) as {
+      component: string;
+      checks: Record<string, { status: string }>;
+      result: string;
+    };
+    expect(report.component).toBe('json-viewer');
+    expect(report.checks['propNames']?.status).toBe('pass');
+    expect(report.result).toBe('PASS');
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -184,6 +221,96 @@ describe('hasA11yDoc', () => {
 });
 
 // ---------------------------------------------------------------------------
+// Unit tests: hasA11yCoverage
+// ---------------------------------------------------------------------------
+
+describe('hasA11yCoverage', () => {
+  test('returns false for non-existent file', () => {
+    expect(hasA11yCoverage('/tmp/no-such-a11y.test.ts')).toBe(false);
+  });
+
+  test('returns true when a single test block has both a keyboard call and a role query', () => {
+    const tempPath = join(tmpdir(), `a11y-coverage-pass-${Date.now()}.test.ts`);
+    writeFileSync(
+      tempPath,
+      `
+import { fireEvent } from '@testing-library/svelte';
+test('keyboard and role', async () => {
+  const { getByRole } = render(Component);
+  const el = getByRole('button');
+  await fireEvent.keyDown(el, { key: 'Enter' });
+  expect(el).toBeTruthy();
+});
+`,
+    );
+    try {
+      expect(hasA11yCoverage(tempPath)).toBe(true);
+    } finally {
+      Bun.file(tempPath);
+    }
+  });
+
+  test('returns false when keyboard call and role query are in separate test blocks', () => {
+    const tempPath = join(tmpdir(), `a11y-coverage-split-${Date.now()}.test.ts`);
+    writeFileSync(
+      tempPath,
+      `
+import { fireEvent } from '@testing-library/svelte';
+test('keyboard only', async () => {
+  await fireEvent.keyDown(document.body, { key: 'Enter' });
+});
+test('role only', () => {
+  const el = getByRole('button');
+  expect(el).toBeTruthy();
+});
+`,
+    );
+    try {
+      expect(hasA11yCoverage(tempPath)).toBe(false);
+    } finally {
+      Bun.file(tempPath);
+    }
+  });
+
+  test('returns false when only keyboard call is present (no role query)', () => {
+    const tempPath = join(tmpdir(), `a11y-coverage-noRole-${Date.now()}.test.ts`);
+    writeFileSync(
+      tempPath,
+      `
+import { fireEvent } from '@testing-library/svelte';
+test('keyboard only', async () => {
+  await fireEvent.keyDown(document.body, { key: 'Enter' });
+  expect(true).toBe(true);
+});
+`,
+    );
+    try {
+      expect(hasA11yCoverage(tempPath)).toBe(false);
+    } finally {
+      Bun.file(tempPath);
+    }
+  });
+
+  test('returns false when only role query is present (no keyboard call)', () => {
+    const tempPath = join(tmpdir(), `a11y-coverage-noKeyboard-${Date.now()}.test.ts`);
+    writeFileSync(
+      tempPath,
+      `
+test('role only', () => {
+  const el = getByRole('button');
+  expect(el).toBeTruthy();
+});
+`,
+    );
+    try {
+      expect(hasA11yCoverage(tempPath)).toBe(false);
+    } finally {
+      Bun.file(tempPath);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Unit tests: hasBrowserGuard
 // ---------------------------------------------------------------------------
 
@@ -255,8 +382,15 @@ describe('checkPropNames', () => {
     expect(violations.length).toBeGreaterThan(0);
   });
 
-  test('returns warnings for is/has-prefix props', () => {
+  test('returns warnings for is-prefix props', () => {
     const schema = { properties: { isLoading: {} } };
+    const { violations, warnings } = checkPropNames(schema);
+    expect(violations).toHaveLength(0);
+    expect(warnings.length).toBeGreaterThan(0);
+  });
+
+  test('returns warnings for has-prefix props', () => {
+    const schema = { properties: { hasError: {} } };
     const { violations, warnings } = checkPropNames(schema);
     expect(violations).toHaveLength(0);
     expect(warnings.length).toBeGreaterThan(0);

--- a/packages/components/scripts/check-promotion-readiness.ts
+++ b/packages/components/scripts/check-promotion-readiness.ts
@@ -13,7 +13,6 @@
  */
 
 import { existsSync } from 'node:fs';
-import { mkdir, rm } from 'node:fs/promises';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -37,7 +36,6 @@ import { generateSchemaForComponent } from './generate-component-schema.ts';
 
 const SCRIPT_DIRECTORY = dirname(fileURLToPath(import.meta.url));
 const COMPONENTS_DIRECTORY = join(SCRIPT_DIRECTORY, '..', 'src', 'components');
-const TMP_DIRECTORY = join(SCRIPT_DIRECTORY, '..', 'tmp', 'promotion-check');
 
 // ---------------------------------------------------------------------------
 // Schema-exempt components (no .types.ts / schema generated)
@@ -87,7 +85,11 @@ function resolveComponentDirectory(componentName: string): {
   );
 }
 
-/** Emit a diagnostic line to stderr (visible even under --json). */
+/**
+ * Emit a progress line. Under --json it routes to stderr to keep the stdout
+ * JSON contract clean (stdout is exactly one JSON object); in human mode it
+ * writes to stdout alongside the report.
+ */
 function diagnostic(message: string, isJson: boolean): void {
   if (isJson) {
     process.stderr.write(message + '\n');
@@ -201,12 +203,9 @@ async function runPropNamesCheck(
     };
   }
 
-  // Drift check: regenerate into a temp path and compare.
-  const tempDirectory = join(TMP_DIRECTORY, componentName);
-  const tempSchemaPath = join(tempDirectory, `${componentName}.schema.json`);
-
-  await mkdir(tempDirectory, { recursive: true });
-
+  // Drift check: regenerate the schema in memory and compare against the
+  // committed file. The freshly generated schema is never written to disk —
+  // the comparison is purely in-memory, so this check never mutates anything.
   let freshSchemaJson: string;
   try {
     const typesFilePath = join(componentDirectory, `${componentName}.types.ts`);
@@ -226,7 +225,6 @@ async function runPropNamesCheck(
       ...prettierOptions,
       filepath: committedSchemaPath,
     });
-    await Bun.write(tempSchemaPath, freshSchemaJson);
   } catch (error: unknown) {
     return {
       result: {
@@ -320,12 +318,18 @@ if (import.meta.main) {
   const isJson = args.includes('--json');
   const componentName = args.find((a) => !a.startsWith('--'));
 
+  const unknownFlags = args.filter((a) => a.startsWith('--') && a !== '--json');
+  if (unknownFlags.length > 0) {
+    process.stderr.write(`Unknown flag(s): ${unknownFlags.join(', ')}\n`);
+    process.stderr.write('Usage: bun run components:promotion-check <component-name> [--json]\n');
+    process.exit(1);
+  }
+
   if (!componentName) {
     process.stderr.write('Usage: bun run components:promotion-check <component-name> [--json]\n');
     process.exit(1);
   }
 
-  let cleanupTemporaryFiles = false;
   try {
     // Resolve component directory.
     const { componentDirectory, isExperimental } = resolveComponentDirectory(componentName);
@@ -359,7 +363,6 @@ if (import.meta.main) {
     );
     const hydrationCheck = runHydrationCheck(componentName, componentDirectory);
 
-    cleanupTemporaryFiles = true;
     const { result: propNamesCheck, warnings } = await runPropNamesCheck(
       componentName,
       componentDirectory,
@@ -395,9 +398,5 @@ if (import.meta.main) {
   } catch (error: unknown) {
     process.stderr.write(`Error: ${error instanceof Error ? error.message : String(error)}\n`);
     process.exit(1);
-  } finally {
-    if (cleanupTemporaryFiles && existsSync(TMP_DIRECTORY)) {
-      await rm(TMP_DIRECTORY, { recursive: true, force: true });
-    }
   }
 }

--- a/packages/components/scripts/check-promotion-readiness.ts
+++ b/packages/components/scripts/check-promotion-readiness.ts
@@ -1,0 +1,403 @@
+/**
+ * Stable-promotion gate.
+ *
+ * Usage:
+ *   bun run components:promotion-check <component-name>
+ *   bun run components:promotion-check <component-name> --json
+ *
+ * Runs four readiness checks for a component, then prints a per-check report.
+ * Exits 0 on PASS, 1 on FAIL.
+ *
+ * Under --json: structured output to stdout only (one JSON object, no leading
+ * text), all human-readable diagnostics go to stderr.
+ */
+
+import { existsSync } from 'node:fs';
+import { mkdir, rm } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import prettier from 'prettier';
+
+import {
+  checkPropNames,
+  hasA11yCoverage,
+  hasA11yDoc,
+  hasBrowserGuard,
+  hasHydrationTest,
+  hasSubstantiveTest,
+  isInteractive,
+} from './component-conventions.ts';
+import { extractComponentMetadata } from './generate-component-metadata.ts';
+import { generateSchemaForComponent } from './generate-component-schema.ts';
+
+// ---------------------------------------------------------------------------
+// Paths
+// ---------------------------------------------------------------------------
+
+const SCRIPT_DIRECTORY = dirname(fileURLToPath(import.meta.url));
+const COMPONENTS_DIRECTORY = join(SCRIPT_DIRECTORY, '..', 'src', 'components');
+const TMP_DIRECTORY = join(SCRIPT_DIRECTORY, '..', 'tmp', 'promotion-check');
+
+// ---------------------------------------------------------------------------
+// Schema-exempt components (no .types.ts / schema generated)
+// ---------------------------------------------------------------------------
+const SCHEMA_EXEMPT = new Set<string>([]);
+
+// ---------------------------------------------------------------------------
+// Output types
+// ---------------------------------------------------------------------------
+
+type CheckStatus = 'pass' | 'fail' | 'na';
+
+type CheckResult = {
+  status: CheckStatus;
+  detail?: string;
+};
+
+type JsonReport = {
+  component: string;
+  currentStatus: string;
+  checks: {
+    test: CheckResult;
+    a11y: CheckResult;
+    hydration: CheckResult;
+    propNames: CheckResult;
+  };
+  warnings: string[];
+  result: 'PASS' | 'FAIL';
+};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function resolveComponentDirectory(componentName: string): {
+  componentDirectory: string;
+  isExperimental: boolean;
+} {
+  const regular = join(COMPONENTS_DIRECTORY, componentName);
+  if (existsSync(regular)) return { componentDirectory: regular, isExperimental: false };
+
+  const experimental = join(COMPONENTS_DIRECTORY, 'experimental', componentName);
+  if (existsSync(experimental)) return { componentDirectory: experimental, isExperimental: true };
+
+  throw new Error(
+    `Component "${componentName}" not found under src/components/ or src/components/experimental/`,
+  );
+}
+
+/** Emit a diagnostic line to stderr (visible even under --json). */
+function diagnostic(message: string, isJson: boolean): void {
+  if (isJson) {
+    process.stderr.write(message + '\n');
+  } else {
+    process.stdout.write(message + '\n');
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Check 1 — Substantive test
+// ---------------------------------------------------------------------------
+
+function runTestCheck(componentName: string, componentDirectory: string): CheckResult {
+  const testFilePath = join(componentDirectory, `${componentName}.test.ts`);
+  const { pass } = hasSubstantiveTest(testFilePath);
+  if (pass) return { status: 'pass' };
+  if (!existsSync(testFilePath)) {
+    return { status: 'fail', detail: `No test file found at ${componentName}.test.ts` };
+  }
+  return {
+    status: 'fail',
+    detail: `${componentName}.test.ts exists but has no active test() or it() calls`,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Check 2 — a11y coverage
+// ---------------------------------------------------------------------------
+
+function runA11yCheck(
+  componentName: string,
+  componentDirectory: string,
+  isInteractiveComponent: boolean,
+  isJson: boolean,
+): CheckResult {
+  if (!isInteractiveComponent) {
+    return { status: 'na' };
+  }
+
+  // Exempted by a11y doc?
+  if (hasA11yDoc(componentDirectory, componentName)) {
+    diagnostic(`  a11y: doc found at ${componentName}.a11y.md`, isJson);
+    return { status: 'pass' };
+  }
+
+  // Check for keyboard + ARIA tests in the primary test file.
+  const testFilePath = join(componentDirectory, `${componentName}.test.ts`);
+  if (hasA11yCoverage(testFilePath)) {
+    return { status: 'pass' };
+  }
+
+  return {
+    status: 'fail',
+    detail:
+      `Interactive component missing a11y coverage. ` +
+      `Need: an ${componentName}.a11y.md doc, OR a single test() block with both ` +
+      `a keyboard call (fireEvent.keyDown / user.keyboard) and a role/aria query ` +
+      `(getByRole / toHaveAttribute with "role" or "aria-*").`,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Check 3 — hydration/SSR coverage
+// ---------------------------------------------------------------------------
+
+function runHydrationCheck(componentName: string, componentDirectory: string): CheckResult {
+  const sveltePath = join(componentDirectory, `${componentName}.svelte`);
+  if (!hasBrowserGuard(sveltePath)) {
+    return { status: 'na' };
+  }
+
+  const testFilePath = join(componentDirectory, `${componentName}.test.ts`);
+  const hydrateTestFilePath = join(componentDirectory, `${componentName}.hydrate.test.ts`);
+
+  if (hasHydrationTest(testFilePath) || hasHydrationTest(hydrateTestFilePath)) {
+    return { status: 'pass' };
+  }
+
+  return {
+    status: 'fail',
+    detail:
+      `Component has a browser guard ({#if browser} or {#if hydrated}) but no hydration test. ` +
+      `Need a render call from svelte/server or a renderThenHydrate call in ` +
+      `${componentName}.test.ts or ${componentName}.hydrate.test.ts.`,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Check 4 — prop-name conventions (drift + names)
+// ---------------------------------------------------------------------------
+
+async function runPropNamesCheck(
+  componentName: string,
+  componentDirectory: string,
+  isExperimental: boolean,
+  isJson: boolean,
+): Promise<{ result: CheckResult; warnings: string[] }> {
+  if (SCHEMA_EXEMPT.has(componentName)) {
+    diagnostic(`  prop-names: schema-exempt (skipped)`, isJson);
+    return { result: { status: 'na' }, warnings: [] };
+  }
+
+  const committedSchemaPath = join(componentDirectory, `${componentName}.schema.json`);
+  if (!existsSync(committedSchemaPath)) {
+    return {
+      result: {
+        status: 'fail',
+        detail: `Missing ${componentName}.schema.json — run bun run components:generate`,
+      },
+      warnings: [],
+    };
+  }
+
+  // Drift check: regenerate into a temp path and compare.
+  const tempDirectory = join(TMP_DIRECTORY, componentName);
+  const tempSchemaPath = join(tempDirectory, `${componentName}.schema.json`);
+
+  await mkdir(tempDirectory, { recursive: true });
+
+  let freshSchemaJson: string;
+  try {
+    const typesFilePath = join(componentDirectory, `${componentName}.types.ts`);
+    if (!existsSync(typesFilePath)) {
+      return {
+        result: {
+          status: 'fail',
+          detail: `Missing ${componentName}.types.ts — cannot regenerate schema for drift check`,
+        },
+        warnings: [],
+      };
+    }
+    const depthToSrc = isExperimental ? 3 : 2;
+    const generateResult = generateSchemaForComponent({ typesFilePath, componentName, depthToSrc });
+    const prettierOptions = await prettier.resolveConfig(committedSchemaPath);
+    freshSchemaJson = await prettier.format(generateResult.schemaJson, {
+      ...prettierOptions,
+      filepath: committedSchemaPath,
+    });
+    await Bun.write(tempSchemaPath, freshSchemaJson);
+  } catch (error: unknown) {
+    return {
+      result: {
+        status: 'fail',
+        detail: `Schema generation failed: ${error instanceof Error ? error.message : String(error)}`,
+      },
+      warnings: [],
+    };
+  }
+
+  const committedSchemaJson = await Bun.file(committedSchemaPath).text();
+  if (freshSchemaJson.trim() !== committedSchemaJson.trim()) {
+    return {
+      result: {
+        status: 'fail',
+        detail:
+          `Schema is stale — committed ${componentName}.schema.json does not match what ` +
+          `components:generate would produce. Run: bun run components:generate`,
+      },
+      warnings: [],
+    };
+  }
+
+  // Parse schema and check prop names.
+  let schema: Record<string, unknown>;
+  try {
+    schema = JSON.parse(committedSchemaJson) as Record<string, unknown>;
+  } catch {
+    return {
+      result: { status: 'fail', detail: `Could not parse ${componentName}.schema.json` },
+      warnings: [],
+    };
+  }
+
+  const { violations, warnings } = checkPropNames(schema);
+
+  if (violations.length > 0) {
+    return {
+      result: { status: 'fail', detail: `Prop-name violations: ${violations.join('; ')}` },
+      warnings,
+    };
+  }
+
+  return { result: { status: 'pass' }, warnings };
+}
+
+// ---------------------------------------------------------------------------
+// Report rendering
+// ---------------------------------------------------------------------------
+
+function renderHumanReport(
+  componentName: string,
+  currentStatus: string,
+  checks: JsonReport['checks'],
+  warnings: string[],
+  overallResult: 'PASS' | 'FAIL',
+): void {
+  const statusEmoji = { pass: '✓', fail: '✗', na: '–' };
+
+  process.stdout.write(`\nPromotion readiness: ${componentName} (current: ${currentStatus})\n`);
+  process.stdout.write('─'.repeat(60) + '\n');
+
+  for (const [checkName, check] of Object.entries(checks)) {
+    const symbol = statusEmoji[check.status as CheckStatus];
+    const label = checkName.padEnd(12);
+    const statusLabel = check.status.toUpperCase().padEnd(4);
+    process.stdout.write(`  ${symbol} ${label} ${statusLabel}`);
+    if (check.detail) {
+      process.stdout.write(`\n    ${check.detail}`);
+    }
+    process.stdout.write('\n');
+  }
+
+  if (warnings.length > 0) {
+    process.stdout.write('\nWarnings:\n');
+    for (const warning of warnings) {
+      process.stdout.write(`  ⚠ ${warning}\n`);
+    }
+  }
+
+  process.stdout.write('─'.repeat(60) + '\n');
+  process.stdout.write(`Result: ${overallResult}\n\n`);
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+if (import.meta.main) {
+  const args = process.argv.slice(2);
+  const isJson = args.includes('--json');
+  const componentName = args.find((a) => !a.startsWith('--'));
+
+  if (!componentName) {
+    process.stderr.write('Usage: bun run components:promotion-check <component-name> [--json]\n');
+    process.exit(1);
+  }
+
+  let cleanupTemporaryFiles = false;
+  try {
+    // Resolve component directory.
+    const { componentDirectory, isExperimental } = resolveComponentDirectory(componentName);
+
+    // Extract metadata (needed for status + interactive detection).
+    const metaResult = await extractComponentMetadata(
+      componentName,
+      componentDirectory,
+      isExperimental,
+    );
+    if (!metaResult.ok) {
+      process.stderr.write(`Error reading component metadata: ${metaResult.error.reason}\n`);
+      process.exit(1);
+    }
+    const metadata = metaResult.metadata;
+    const currentStatus = metadata.status;
+    const isInteractiveComponent = isInteractive(metadata);
+
+    diagnostic(
+      `Checking ${componentName} (${currentStatus}, ${isInteractiveComponent ? 'interactive' : 'non-interactive'})...`,
+      isJson,
+    );
+
+    // Run checks.
+    const testCheck = runTestCheck(componentName, componentDirectory);
+    const a11yCheck = runA11yCheck(
+      componentName,
+      componentDirectory,
+      isInteractiveComponent,
+      isJson,
+    );
+    const hydrationCheck = runHydrationCheck(componentName, componentDirectory);
+
+    cleanupTemporaryFiles = true;
+    const { result: propNamesCheck, warnings } = await runPropNamesCheck(
+      componentName,
+      componentDirectory,
+      isExperimental,
+      isJson,
+    );
+
+    const checks: JsonReport['checks'] = {
+      test: testCheck,
+      a11y: a11yCheck,
+      hydration: hydrationCheck,
+      propNames: propNamesCheck,
+    };
+
+    const overallResult: 'PASS' | 'FAIL' = Object.values(checks).some((c) => c.status === 'fail')
+      ? 'FAIL'
+      : 'PASS';
+
+    if (isJson) {
+      const report: JsonReport = {
+        component: componentName,
+        currentStatus,
+        checks,
+        warnings,
+        result: overallResult,
+      };
+      process.stdout.write(JSON.stringify(report, null, 2) + '\n');
+    } else {
+      renderHumanReport(componentName, currentStatus, checks, warnings, overallResult);
+    }
+
+    process.exit(overallResult === 'PASS' ? 0 : 1);
+  } catch (error: unknown) {
+    process.stderr.write(`Error: ${error instanceof Error ? error.message : String(error)}\n`);
+    process.exit(1);
+  } finally {
+    if (cleanupTemporaryFiles && existsSync(TMP_DIRECTORY)) {
+      await rm(TMP_DIRECTORY, { recursive: true, force: true });
+    }
+  }
+}

--- a/packages/components/scripts/component-conventions.ts
+++ b/packages/components/scripts/component-conventions.ts
@@ -1,0 +1,396 @@
+/**
+ * Shared predicates consumed by the stable-promotion gate
+ * (`check-promotion-readiness.ts`) and any sibling convention checkers.
+ *
+ * Parser boundary:
+ *   - ts-morph parses ONLY `.test.ts` files (TypeScript AST).
+ *   - svelte/compiler parses ONLY `.svelte` files (Svelte AST).
+ *   Two parsers, explicit boundary, no substring fallback.
+ */
+
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { parse as parseSvelte } from 'svelte/compiler';
+import { CallExpression, Node, Project, type SourceFile } from 'ts-morph';
+
+// ---------------------------------------------------------------------------
+// Interactive categories — components in these categories require a11y checks.
+// Source of truth: manifest.meta.ts categoryId set.
+// ---------------------------------------------------------------------------
+
+const INTERACTIVE_CATEGORIES = new Set(['action', 'form', 'navigation', 'overlay']);
+
+// ---------------------------------------------------------------------------
+// Prop-name denylist (frozen per plan spec).
+// These are the exact forbidden name strings — the wrong-cased or abbreviated
+// forms that cinder conventions prohibit. Comparison is case-sensitive exact
+// match against the lowercased prop name: a prop named `classname` is denied,
+// but `className` (not in the list) is separately caught by the camelCase rule.
+// ---------------------------------------------------------------------------
+
+export const PROP_NAME_DENYLIST = [
+  'classname',
+  'icononly',
+  'leadingicon',
+  'trailingicon',
+  'ondismiss',
+  'onchange',
+] as const satisfies readonly string[];
+
+// ---------------------------------------------------------------------------
+// Check 1 — Substantive test present
+// ---------------------------------------------------------------------------
+
+/** Counts bare `test(...)` or `it(...)` CallExpressions, excluding .skip / .todo / .failing. */
+function countActiveTestCalls(sourceFile: SourceFile): number {
+  let count = 0;
+  sourceFile.forEachDescendant((node) => {
+    if (!Node.isCallExpression(node)) return;
+    const expression = node.getExpression();
+    // Bare `test` or `it` identifier — not a property access like `test.skip`.
+    if (Node.isIdentifier(expression)) {
+      const name = expression.getText();
+      if (name === 'test' || name === 'it') {
+        count++;
+      }
+    }
+  });
+  return count;
+}
+
+/**
+ * Returns `{ pass, count }` where `pass` is `true` when `testFilePath` exists
+ * and contains at least one active `test(...)` or `it(...)` call (not `.skip`,
+ * `.todo`, or `.failing`).
+ */
+export function hasSubstantiveTest(testFilePath: string): { pass: boolean; count: number } {
+  if (!existsSync(testFilePath)) return { pass: false, count: 0 };
+
+  const project = new Project({ skipAddingFilesFromTsConfig: true });
+  const sourceFile = project.addSourceFileAtPath(testFilePath);
+  const count = countActiveTestCalls(sourceFile);
+  return { pass: count >= 1, count };
+}
+
+// ---------------------------------------------------------------------------
+// Check 2 helpers — a11y coverage
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns `true` when the component's category indicates it is interactive
+ * and therefore requires a11y coverage.
+ *
+ * Accepts a partial manifest entry — only `category` is needed.
+ */
+export function isInteractive(manifestEntry: { category?: string }): boolean {
+  return manifestEntry.category !== undefined && INTERACTIVE_CATEGORIES.has(manifestEntry.category);
+}
+
+/**
+ * Returns `true` when an a11y doc exists at either canonical location:
+ *   1. Adjacent: `<componentDir>/<name>.a11y.md`
+ *   2. Legacy flat: `src/components/<name>.a11y.md` (one directory above componentDir)
+ */
+export function hasA11yDoc(componentDir: string, componentName: string): boolean {
+  const adjacent = join(componentDir, `${componentName}.a11y.md`);
+  // Derive the flat/legacy path: one level above the component directory.
+  const parentDirectory = join(componentDir, '..');
+  const flat = join(parentDirectory, `${componentName}.a11y.md`);
+  return existsSync(adjacent) || existsSync(flat);
+}
+
+/**
+ * Returns `true` when the given test file contains, within a SINGLE
+ * `test(...)` or `it(...)` call expression's subtree, BOTH:
+ *   - A keyboard call: `fireEvent.keyDown(...)` or `user.keyboard(...)`
+ *   - An ARIA/role query: `getByRole(...)`, `findByRole(...)`, `queryByRole(...)`,
+ *     or `expect(...).toHaveAttribute(name)` where name is `"role"` or starts
+ *     with `"aria-"`.
+ *
+ * Setup-only mentions outside a test block do not count.
+ */
+export function hasA11yCoverage(testFilePath: string): boolean {
+  if (!existsSync(testFilePath)) return false;
+
+  const project = new Project({ skipAddingFilesFromTsConfig: true });
+  const sourceFile = project.addSourceFileAtPath(testFilePath);
+
+  for (const testCall of collectTestCalls(sourceFile)) {
+    if (hasKeyboardCall(testCall) && hasAriaOrRoleCall(testCall)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/** Collect all `test(...)` / `it(...)` CallExpression nodes in the file. */
+function collectTestCalls(sourceFile: SourceFile): CallExpression[] {
+  const testCalls: CallExpression[] = [];
+  sourceFile.forEachDescendant((node) => {
+    if (!Node.isCallExpression(node)) return;
+    const expression = node.getExpression();
+    if (Node.isIdentifier(expression)) {
+      const name = expression.getText();
+      if (name === 'test' || name === 'it') {
+        testCalls.push(node);
+      }
+    }
+  });
+  return testCalls;
+}
+
+/** Returns `true` if the subtree contains `fireEvent.keyDown(...)` or `user.keyboard(...)`. */
+function hasKeyboardCall(root: CallExpression): boolean {
+  let found = false;
+  root.forEachDescendant((node) => {
+    if (found || !Node.isCallExpression(node)) return;
+    const expression = node.getExpression();
+    if (!Node.isPropertyAccessExpression(expression)) return;
+    const objectName = expression.getExpression().getText();
+    const propertyName = expression.getName();
+    if (
+      (objectName === 'fireEvent' && propertyName === 'keyDown') ||
+      (objectName === 'user' && propertyName === 'keyboard')
+    ) {
+      found = true;
+    }
+  });
+  return found;
+}
+
+/** Returns `true` if the subtree contains a role/aria query or toHaveAttribute with role/aria-*. */
+function hasAriaOrRoleCall(root: CallExpression): boolean {
+  const ROLE_QUERY_METHODS = new Set(['getByRole', 'findByRole', 'queryByRole']);
+  let found = false;
+
+  root.forEachDescendant((node) => {
+    if (found) return;
+
+    if (Node.isCallExpression(node)) {
+      const expression = node.getExpression();
+
+      // getByRole / findByRole / queryByRole as a property access (e.g. screen.getByRole)
+      if (Node.isPropertyAccessExpression(expression)) {
+        if (ROLE_QUERY_METHODS.has(expression.getName())) {
+          found = true;
+          return;
+        }
+      }
+
+      // Bare getByRole / findByRole / queryByRole call
+      if (Node.isIdentifier(expression) && ROLE_QUERY_METHODS.has(expression.getText())) {
+        found = true;
+        return;
+      }
+
+      // expect(...).toHaveAttribute(name) where name is "role" or starts with "aria-"
+      if (
+        Node.isPropertyAccessExpression(expression) &&
+        expression.getName() === 'toHaveAttribute'
+      ) {
+        const args = node.getArguments();
+        const firstArg = args[0];
+        if (firstArg && Node.isStringLiteral(firstArg)) {
+          const value = firstArg.getLiteralValue();
+          if (value === 'role' || value.startsWith('aria-')) {
+            found = true;
+          }
+        }
+      }
+    }
+  });
+
+  return found;
+}
+
+// ---------------------------------------------------------------------------
+// Check 3 — hydration/SSR coverage
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns `true` when the Svelte component at `sveltePath` contains a browser
+ * guard: either a `{#if browser}` / `{#if hydrated}` template block, or imports
+ * `BROWSER` from `esm-env`.
+ *
+ * Uses svelte/compiler for structural detection — no substring matching.
+ */
+export function hasBrowserGuard(sveltePath: string): boolean {
+  if (!existsSync(sveltePath)) return false;
+  const source = readFileSync(sveltePath, 'utf8');
+  return hasBrowserGuardInSource(source);
+}
+
+function hasBrowserGuardInSource(source: string): boolean {
+  const ast = parseSvelte(source, { modern: true });
+
+  // Check 1: instance script imports BROWSER from esm-env
+  if (hasBrowserImport(source)) return true;
+
+  // Check 2: template contains {#if browser} or {#if hydrated}
+  return templateHasBrowserIfBlock(ast.fragment);
+}
+
+/** Checks the raw source for `import { BROWSER` from 'esm-env'. */
+function hasBrowserImport(source: string): boolean {
+  return /import\s*\{[^}]*\bBROWSER\b[^}]*\}\s*from\s*['"]esm-env['"]/.test(source);
+}
+
+/**
+ * Recursively walks the Svelte template AST fragment to find an IfBlock
+ * whose test expression is the identifier `browser` or `hydrated`.
+ */
+function templateHasBrowserIfBlock(node: unknown): boolean {
+  if (!node || typeof node !== 'object') return false;
+  const record = node as Record<string, unknown>;
+
+  if (record['type'] === 'IfBlock') {
+    const test = record['test'] as Record<string, unknown> | undefined;
+    if (test && test['type'] === 'Identifier') {
+      const name = test['name'];
+      if (name === 'browser' || name === 'hydrated') return true;
+    }
+  }
+
+  // Recurse into all array/object children.
+  for (const value of Object.values(record)) {
+    if (Array.isArray(value)) {
+      for (const child of value) {
+        if (templateHasBrowserIfBlock(child)) return true;
+      }
+    } else if (value && typeof value === 'object') {
+      if (templateHasBrowserIfBlock(value)) return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Returns `true` when the test file contains a `render` call from
+ * `svelte/server` OR a `renderThenHydrate` call.
+ * A test merely named "hydrates" does not satisfy this.
+ */
+export function hasHydrationTest(testFilePath: string): boolean {
+  if (!existsSync(testFilePath)) return false;
+
+  const project = new Project({ skipAddingFilesFromTsConfig: true });
+  const sourceFile = project.addSourceFileAtPath(testFilePath);
+
+  let found = false;
+  sourceFile.forEachDescendant((node) => {
+    if (found || !Node.isCallExpression(node)) return;
+    const expression = node.getExpression();
+
+    // renderThenHydrate(...)
+    if (Node.isIdentifier(expression) && expression.getText() === 'renderThenHydrate') {
+      found = true;
+      return;
+    }
+
+    // render(...) where render is imported from svelte/server
+    if (Node.isIdentifier(expression) && expression.getText() === 'render') {
+      if (isImportedFromSvelteServer(sourceFile, 'render')) {
+        found = true;
+      }
+    }
+  });
+  return found;
+}
+
+/** Returns `true` when `name` is imported from `svelte/server` in the given file. */
+function isImportedFromSvelteServer(sourceFile: SourceFile, name: string): boolean {
+  for (const declaration of sourceFile.getImportDeclarations()) {
+    if (declaration.getModuleSpecifierValue() !== 'svelte/server') continue;
+    for (const specifier of declaration.getNamedImports()) {
+      if (specifier.getName() === name) return true;
+    }
+    const defaultImport = declaration.getDefaultImport();
+    if (defaultImport?.getText() === name) return true;
+  }
+  return false;
+}
+
+// ---------------------------------------------------------------------------
+// Check 4 — prop-name conventions
+// ---------------------------------------------------------------------------
+
+/**
+ * Validates all prop names in a JSON Schema object against cinder conventions:
+ *   - Must be camelCase (or `class`, or `aria-*` / `data-*`)
+ *   - Must not appear in PROP_NAME_DENYLIST (exact lowercase match)
+ *   - `is`-prefixed boolean props produce warnings, not violations
+ *
+ * Returns `{ violations, warnings }` — empty arrays indicate PASS.
+ */
+export function checkPropNames(schema: Record<string, unknown>): {
+  violations: string[];
+  warnings: string[];
+} {
+  const properties = schema['properties'];
+  if (!properties || typeof properties !== 'object') {
+    return { violations: [], warnings: [] };
+  }
+
+  const violations: string[] = [];
+  const warnings: string[] = [];
+
+  for (const propName of Object.keys(properties as Record<string, unknown>)) {
+    const violation = validatePropNameViolation(propName);
+    if (violation !== null) {
+      violations.push(`"${propName}": ${violation}`);
+      continue;
+    }
+    if (hasBooleanIsPrefix(propName)) {
+      warnings.push(
+        `"${propName}": is-prefix convention — consider renaming to drop the is/has prefix`,
+      );
+    }
+  }
+
+  return { violations, warnings };
+}
+
+/**
+ * Returns a violation reason string, or null if the name is acceptable.
+ * Does NOT emit warnings — those are handled in `checkPropNames`.
+ */
+function validatePropNameViolation(name: string): string | null {
+  // Allow: class passthrough
+  if (name === 'class') return null;
+
+  // Allow: aria-* and data-* passthrough
+  if (name.startsWith('aria-') || name.startsWith('data-')) return null;
+
+  // Deny: exact case-sensitive match against the denylist.
+  // The denylist enumerates the wrong-cased / abbreviated prop names that
+  // cinder explicitly forbids. These are already in the form they must not
+  // appear as — e.g. `icononly` is forbidden, but `iconOnly` (camelCase) is
+  // the correct form and is NOT denied by this check.
+  if ((PROP_NAME_DENYLIST as readonly string[]).includes(name)) {
+    return `"${name}" is in the prop-name denylist`;
+  }
+
+  // Must be camelCase: starts with lowercase letter, contains only letters and digits.
+  if (!isCamelCase(name)) {
+    return `"${name}" is not camelCase`;
+  }
+
+  return null;
+}
+
+/**
+ * Returns `true` when `name` is a valid camelCase identifier:
+ * starts with a lowercase letter, contains only letters and digits.
+ */
+function isCamelCase(name: string): boolean {
+  return /^[a-z][a-zA-Z0-9]*$/.test(name);
+}
+
+/**
+ * Returns `true` when `name` starts with `is` or `has` followed by an
+ * uppercase letter (boolean is-prefix convention).
+ * Used to emit a WARNING (not a failure) in the promotion gate.
+ */
+export function hasBooleanIsPrefix(name: string): boolean {
+  return /^is[A-Z]/.test(name) || /^has[A-Z]/.test(name);
+}

--- a/packages/components/scripts/component-conventions.ts
+++ b/packages/components/scripts/component-conventions.ts
@@ -9,10 +9,10 @@
  */
 
 import { existsSync, readFileSync } from 'node:fs';
-import { join } from 'node:path';
+import { basename, dirname, join } from 'node:path';
 
 import { parse as parseSvelte } from 'svelte/compiler';
-import { CallExpression, Node, Project, type SourceFile } from 'ts-morph';
+import { Node, Project, type CallExpression, type SourceFile } from 'ts-morph';
 
 // ---------------------------------------------------------------------------
 // Interactive categories — components in these categories require a11y checks.
@@ -23,14 +23,18 @@ const INTERACTIVE_CATEGORIES = new Set(['action', 'form', 'navigation', 'overlay
 
 // ---------------------------------------------------------------------------
 // Prop-name denylist (frozen per plan spec).
-// These are the exact forbidden name strings — the wrong-cased or abbreviated
-// forms that cinder conventions prohibit. Comparison is case-sensitive exact
-// match against the lowercased prop name: a prop named `classname` is denied,
-// but `className` (not in the list) is separately caught by the camelCase rule.
+// These are exact forbidden prop-name strings, compared case-sensitively.
+// They fall into two groups:
+//   1. Wrong-cased / abbreviated forms cinder prohibits (`classname`, `icononly`, …).
+//   2. Valid-camelCase names that nonetheless violate a cinder API convention:
+//      `className` is forbidden because cinder components expose `class?: string`
+//      and destructure it internally as `class: className` — the public prop is
+//      `class`, never `className`. (camelCase alone would let `className` pass.)
 // ---------------------------------------------------------------------------
 
 export const PROP_NAME_DENYLIST = [
   'classname',
+  'className',
   'icononly',
   'leadingicon',
   'trailingicon',
@@ -90,13 +94,30 @@ export function isInteractive(manifestEntry: { category?: string }): boolean {
 /**
  * Returns `true` when an a11y doc exists at either canonical location:
  *   1. Adjacent: `<componentDir>/<name>.a11y.md`
- *   2. Legacy flat: `src/components/<name>.a11y.md` (one directory above componentDir)
+ *   2. Legacy flat: `src/components/<name>.a11y.md`
+ *
+ * The legacy flat path is always anchored at the `src/components` root, not at
+ * the component's immediate parent — for an experimental component at
+ * `src/components/experimental/<name>/`, the flat doc still lives at
+ * `src/components/<name>.a11y.md`, not `src/components/experimental/<name>.a11y.md`.
  */
 export function hasA11yDoc(componentDir: string, componentName: string): boolean {
   const adjacent = join(componentDir, `${componentName}.a11y.md`);
-  // Derive the flat/legacy path: one level above the component directory.
-  const parentDirectory = join(componentDir, '..');
-  const flat = join(parentDirectory, `${componentName}.a11y.md`);
+
+  // Anchor the legacy flat path at the `src/components` root. Walk up from the
+  // component directory until the parent segment is `components`.
+  let candidate = componentDir;
+  for (let depth = 0; depth < 3; depth += 1) {
+    const parent = dirname(candidate);
+    if (basename(parent) === 'components') {
+      const flat = join(parent, `${componentName}.a11y.md`);
+      return existsSync(adjacent) || existsSync(flat);
+    }
+    candidate = parent;
+  }
+
+  // Fallback: if we never found a `components` ancestor, use the immediate parent.
+  const flat = join(dirname(componentDir), `${componentName}.a11y.md`);
   return existsSync(adjacent) || existsSync(flat);
 }
 
@@ -307,25 +328,27 @@ export function hasHydrationTest(testFilePath: string): boolean {
   const project = new Project({ skipAddingFilesFromTsConfig: true });
   const sourceFile = project.addSourceFileAtPath(testFilePath);
 
-  let found = false;
-  sourceFile.forEachDescendant((node) => {
-    if (found || !Node.isCallExpression(node)) return;
-    const expression = node.getExpression();
+  const renderIsFromSvelteServer = isImportedFromSvelteServer(sourceFile, 'render');
 
-    // renderThenHydrate(...)
-    if (Node.isIdentifier(expression) && expression.getText() === 'renderThenHydrate') {
-      found = true;
-      return;
-    }
-
-    // render(...) where render is imported from svelte/server
-    if (Node.isIdentifier(expression) && expression.getText() === 'render') {
-      if (isImportedFromSvelteServer(sourceFile, 'render')) {
+  // Scope the search to ACTIVE test(...)/it(...) blocks only — a render or
+  // renderThenHydrate call inside test.skip / test.todo would never run, so it
+  // must not satisfy the hydration gate (mirrors the substantive-test check).
+  for (const testCall of collectTestCalls(sourceFile)) {
+    let found = false;
+    testCall.forEachDescendant((node) => {
+      if (found || !Node.isCallExpression(node)) return;
+      const expression = node.getExpression();
+      if (!Node.isIdentifier(expression)) return;
+      const name = expression.getText();
+      if (name === 'renderThenHydrate') {
+        found = true;
+      } else if (name === 'render' && renderIsFromSvelteServer) {
         found = true;
       }
-    }
-  });
-  return found;
+    });
+    if (found) return true;
+  }
+  return false;
 }
 
 /** Returns `true` when `name` is imported from `svelte/server` in the given file. */

--- a/packages/components/scripts/component-conventions.ts
+++ b/packages/components/scripts/component-conventions.ts
@@ -222,18 +222,49 @@ export function hasBrowserGuard(sveltePath: string): boolean {
 }
 
 function hasBrowserGuardInSource(source: string): boolean {
-  const ast = parseSvelte(source, { modern: true });
+  const ast = parseSvelte(source, { modern: true }) as unknown as Record<string, unknown>;
 
-  // Check 1: instance script imports BROWSER from esm-env
-  if (hasBrowserImport(source)) return true;
+  // Check 1: a <script> block imports BROWSER from esm-env (structural — walk
+  // the module and instance script ASTs, not a substring/regex on raw source).
+  if (
+    scriptImportsBrowserFromEsmEnv(ast['module']) ||
+    scriptImportsBrowserFromEsmEnv(ast['instance'])
+  ) {
+    return true;
+  }
 
   // Check 2: template contains {#if browser} or {#if hydrated}
-  return templateHasBrowserIfBlock(ast.fragment);
+  return templateHasBrowserIfBlock(ast['fragment']);
 }
 
-/** Checks the raw source for `import { BROWSER` from 'esm-env'. */
-function hasBrowserImport(source: string): boolean {
-  return /import\s*\{[^}]*\bBROWSER\b[^}]*\}\s*from\s*['"]esm-env['"]/.test(source);
+/**
+ * Returns `true` when the given Svelte `<script>` node (module or instance)
+ * contains an `import { BROWSER } from 'esm-env'` declaration. Walks the ESTree
+ * body the Svelte compiler attaches at `script.content.body` — no substring match.
+ */
+function scriptImportsBrowserFromEsmEnv(scriptNode: unknown): boolean {
+  if (!scriptNode || typeof scriptNode !== 'object') return false;
+  const content = (scriptNode as Record<string, unknown>)['content'];
+  if (!content || typeof content !== 'object') return false;
+  const body = (content as Record<string, unknown>)['body'];
+  if (!Array.isArray(body)) return false;
+
+  for (const statement of body) {
+    if (!statement || typeof statement !== 'object') continue;
+    const node = statement as Record<string, unknown>;
+    if (node['type'] !== 'ImportDeclaration') continue;
+    const sourceNode = node['source'] as Record<string, unknown> | undefined;
+    if (sourceNode?.['value'] !== 'esm-env') continue;
+    const specifiers = node['specifiers'];
+    if (!Array.isArray(specifiers)) continue;
+    for (const specifier of specifiers) {
+      const imported = (specifier as Record<string, unknown>)?.['imported'] as
+        | Record<string, unknown>
+        | undefined;
+      if (imported?.['name'] === 'BROWSER') return true;
+    }
+  }
+  return false;
 }
 
 /**


### PR DESCRIPTION
## Summary

Implements the stable-promotion gate (`components:promotion-check`) — a CLI that gates a component's promotion from `@status alpha|beta` to `stable` behind four readiness checks plus a read-only schema-drift check.

- **`scripts/component-conventions.ts`** — AST helpers (ts-morph for `.test.ts`, svelte/compiler for `.svelte`, explicit parser boundary): `hasSubstantiveTest`, `isInteractive`, `hasA11yDoc`, `hasA11yCoverage`, `hasBrowserGuard`, `hasHydrationTest`, `checkPropNames`, `hasBooleanIsPrefix`, plus the frozen `PROP_NAME_DENYLIST` and `MILKDOWN_PREFIX`.
- **`scripts/check-promotion-readiness.ts`** — CLI: `bun run components:promotion-check <name> [--json]`. Runs the 4 checks, an in-memory schema-drift comparison (never mutates committed files), prints a per-check report, exits 0/1. `--json` emits exactly one JSON object on stdout, diagnostics on stderr.
- **`scripts/check-promotion-readiness.test.ts`** — 45 tests: button (reference, PASS), json-viewer (experimental, depthToSrc=3), unit tests for every helper, `--json` shape + stdout-purity contracts, exit-code contracts, unknown-component/unknown-flag errors.
- **`AGENTS.md`** — documents the gate, the four checks, the frozen denylist table, schema-exempt mechanism, and the promotion workflow.

The four checks:
1. **Substantive test** — `<name>.test.ts` has ≥1 active `test`/`it` (excludes `.skip`/`.todo`/`.failing`).
2. **a11y coverage** (interactive components only) — an `.a11y.md` doc OR a single test block with both a keyboard call and an ARIA/role query.
3. **Hydration** (only if a browser guard exists) — a `render` from `svelte/server` or `renderThenHydrate` call.
4. **Prop-name conventions** — camelCase (+ `class`/`aria-*`/`data-*`), no denylist entries; schema must be drift-free.

Opt-in, single-component, not CI-wired (per the plan's frozen scope).

## Review committee

Pre-reviewed by: typescript-expert, testing-expert, simplicity-engineer, dx-engineer, prose-editor

- Codex (gpt-5.4) — unavailable (health check: `doghouse: unknown command '--json'`)
- 2 rounds of review
- All must-fix items addressed (test temp-file cleanup, dead temp-write removal + process.exit race elimination, parser-boundary AST conversion)

> [!WARNING]
> Codex (the adversarial second-opinion reviewer) was unavailable for this PR. See `tmp/committee-state.md` for detail.

## Test plan

- `bun test packages/components/scripts/check-promotion-readiness.test.ts` — 45 pass / 0 fail
- `bun run components:promotion-check button` — exits 0 (PASS)
- `bun run --filter=cinder typecheck` — 0 errors
- `bun run --filter=cinder lint` — 0 errors

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds contributor tooling and documentation only; no runtime component behavior changes and the gate is not wired into CI.
> 
> **Overview**
> Adds an **opt-in stable-promotion gate** for moving components from `alpha`/`beta` to `stable`, exposed as `bun run components:promotion-check <name>` with optional `--json` (single JSON object on stdout, diagnostics on stderr).
> 
> **`component-conventions.ts`** centralizes AST-based checks: substantive tests, interactive-category a11y (doc or keyboard + role/aria in one test block), browser-guard detection via Svelte compiler, hydration coverage (`svelte/server` `render` or `renderThenHydrate` in active tests), and schema prop naming including a frozen denylist.
> 
> **`check-promotion-readiness.ts`** runs four checks plus in-memory schema drift (regenerate via existing generators, compare to committed `.schema.json` without writing), supports regular and `experimental/` paths, and exits 0/1.
> 
> **`check-promotion-readiness.test.ts`** covers CLI contracts, `button` PASS, `drawer` hydration FAIL, and unit tests for helpers.
> 
> **`AGENTS.md`** documents the gate, checks, denylist, schema-exempt hook, and promotion workflow; overlap-family tables gain `hover-card` and `alert-dialog` rows.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0ee08946a0998be49000cda52b7fe9d8a29b7e9e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->