### PR TITLE
fix(components): promotion-gate bugs surfaced by Bugbot on #188

### DIFF
--- a/packages/components/AGENTS.md
+++ b/packages/components/AGENTS.md
@@ -498,12 +498,16 @@ but do not cause failure.
 
 ### Frozen prop-name denylist
 
-These exact strings are forbidden as prop names. They are the all-lowercased,
-wrong-cased forms of legitimate camelCase props:
+These exact strings are forbidden as prop names. Most are the all-lowercased,
+wrong-cased forms of legitimate camelCase props. `className` is special: it is
+valid camelCase but still forbidden, because cinder components expose
+`class?: string` as the public prop and destructure it internally as
+`class: className` — the public API is always `class`, never `className`.
 
 | Forbidden name | Correct form   |
 | -------------- | -------------- |
-| `classname`    | `className`    |
+| `classname`    | `class`        |
+| `className`    | `class`        |
 | `icononly`     | `iconOnly`     |
 | `leadingicon`  | `leadingIcon`  |
 | `trailingicon` | `trailingIcon` |

--- a/packages/components/scripts/check-promotion-readiness.test.ts
+++ b/packages/components/scripts/check-promotion-readiness.test.ts
@@ -370,6 +370,19 @@ describe('checkPropNames', () => {
     expect(violations).toHaveLength(0);
   });
 
+  test('fails for className even though it is valid camelCase (convention: class)', () => {
+    // cinder components expose `class?: string`, never `className`.
+    const schema = { properties: { className: {} } };
+    const { violations } = checkPropNames(schema);
+    expect(violations.length).toBeGreaterThan(0);
+  });
+
+  test('passes for the canonical class passthrough', () => {
+    const schema = { properties: { class: {} } };
+    const { violations } = checkPropNames(schema);
+    expect(violations).toHaveLength(0);
+  });
+
   test('fails for kebab-case prop names', () => {
     const schema = { properties: { 'full-width': {} } };
     const { violations } = checkPropNames(schema);
@@ -442,6 +455,34 @@ describe('hasHydrationTest', () => {
 
   test('returns false for non-existent file', () => {
     expect(hasHydrationTest('/tmp/no-such-file.test.ts')).toBe(false);
+  });
+
+  test('returns true when renderThenHydrate is inside an active test() block', () => {
+    const tempPath = join(tmpdir(), `hydration-active-${Date.now()}.test.ts`);
+    writeFileSync(
+      tempPath,
+      `import { test } from 'bun:test';\n` +
+        `test('hydrates', () => { renderThenHydrate(Foo, src, {}); });\n`,
+    );
+    try {
+      expect(hasHydrationTest(tempPath)).toBe(true);
+    } finally {
+      rmSync(tempPath, { force: true });
+    }
+  });
+
+  test('returns false when renderThenHydrate is only inside test.skip (never runs)', () => {
+    const tempPath = join(tmpdir(), `hydration-skip-${Date.now()}.test.ts`);
+    writeFileSync(
+      tempPath,
+      `import { test } from 'bun:test';\n` +
+        `test.skip('hydrates', () => { renderThenHydrate(Foo, src, {}); });\n`,
+    );
+    try {
+      expect(hasHydrationTest(tempPath)).toBe(false);
+    } finally {
+      rmSync(tempPath, { force: true });
+    }
   });
 });
 

--- a/packages/components/scripts/component-conventions.ts
+++ b/packages/components/scripts/component-conventions.ts
@@ -9,10 +9,10 @@
  */
 
 import { existsSync, readFileSync } from 'node:fs';
-import { join } from 'node:path';
+import { basename, dirname, join } from 'node:path';
 
 import { parse as parseSvelte } from 'svelte/compiler';
-import { CallExpression, Node, Project, type SourceFile } from 'ts-morph';
+import { Node, Project, type CallExpression, type SourceFile } from 'ts-morph';
 
 // ---------------------------------------------------------------------------
 // Interactive categories — components in these categories require a11y checks.
@@ -23,14 +23,18 @@ const INTERACTIVE_CATEGORIES = new Set(['action', 'form', 'navigation', 'overlay
 
 // ---------------------------------------------------------------------------
 // Prop-name denylist (frozen per plan spec).
-// These are the exact forbidden name strings — the wrong-cased or abbreviated
-// forms that cinder conventions prohibit. Comparison is case-sensitive exact
-// match against the lowercased prop name: a prop named `classname` is denied,
-// but `className` (not in the list) is separately caught by the camelCase rule.
+// These are exact forbidden prop-name strings, compared case-sensitively.
+// They fall into two groups:
+//   1. Wrong-cased / abbreviated forms cinder prohibits (`classname`, `icononly`, …).
+//   2. Valid-camelCase names that nonetheless violate a cinder API convention:
+//      `className` is forbidden because cinder components expose `class?: string`
+//      and destructure it internally as `class: className` — the public prop is
+//      `class`, never `className`. (camelCase alone would let `className` pass.)
 // ---------------------------------------------------------------------------
 
 export const PROP_NAME_DENYLIST = [
   'classname',
+  'className',
   'icononly',
   'leadingicon',
   'trailingicon',
@@ -90,13 +94,30 @@ export function isInteractive(manifestEntry: { category?: string }): boolean {
 /**
  * Returns `true` when an a11y doc exists at either canonical location:
  *   1. Adjacent: `<componentDir>/<name>.a11y.md`
- *   2. Legacy flat: `src/components/<name>.a11y.md` (one directory above componentDir)
+ *   2. Legacy flat: `src/components/<name>.a11y.md`
+ *
+ * The legacy flat path is always anchored at the `src/components` root, not at
+ * the component's immediate parent — for an experimental component at
+ * `src/components/experimental/<name>/`, the flat doc still lives at
+ * `src/components/<name>.a11y.md`, not `src/components/experimental/<name>.a11y.md`.
  */
 export function hasA11yDoc(componentDir: string, componentName: string): boolean {
   const adjacent = join(componentDir, `${componentName}.a11y.md`);
-  // Derive the flat/legacy path: one level above the component directory.
-  const parentDirectory = join(componentDir, '..');
-  const flat = join(parentDirectory, `${componentName}.a11y.md`);
+
+  // Anchor the legacy flat path at the `src/components` root. Walk up from the
+  // component directory until the parent segment is `components`.
+  let candidate = componentDir;
+  for (let depth = 0; depth < 3; depth += 1) {
+    const parent = dirname(candidate);
+    if (basename(parent) === 'components') {
+      const flat = join(parent, `${componentName}.a11y.md`);
+      return existsSync(adjacent) || existsSync(flat);
+    }
+    candidate = parent;
+  }
+
+  // Fallback: if we never found a `components` ancestor, use the immediate parent.
+  const flat = join(dirname(componentDir), `${componentName}.a11y.md`);
   return existsSync(adjacent) || existsSync(flat);
 }
 
@@ -307,25 +328,27 @@ export function hasHydrationTest(testFilePath: string): boolean {
   const project = new Project({ skipAddingFilesFromTsConfig: true });
   const sourceFile = project.addSourceFileAtPath(testFilePath);
 
-  let found = false;
-  sourceFile.forEachDescendant((node) => {
-    if (found || !Node.isCallExpression(node)) return;
-    const expression = node.getExpression();
+  const renderIsFromSvelteServer = isImportedFromSvelteServer(sourceFile, 'render');
 
-    // renderThenHydrate(...)
-    if (Node.isIdentifier(expression) && expression.getText() === 'renderThenHydrate') {
-      found = true;
-      return;
-    }
-
-    // render(...) where render is imported from svelte/server
-    if (Node.isIdentifier(expression) && expression.getText() === 'render') {
-      if (isImportedFromSvelteServer(sourceFile, 'render')) {
+  // Scope the search to ACTIVE test(...)/it(...) blocks only — a render or
+  // renderThenHydrate call inside test.skip / test.todo would never run, so it
+  // must not satisfy the hydration gate (mirrors the substantive-test check).
+  for (const testCall of collectTestCalls(sourceFile)) {
+    let found = false;
+    testCall.forEachDescendant((node) => {
+      if (found || !Node.isCallExpression(node)) return;
+      const expression = node.getExpression();
+      if (!Node.isIdentifier(expression)) return;
+      const name = expression.getText();
+      if (name === 'renderThenHydrate') {
+        found = true;
+      } else if (name === 'render' && renderIsFromSvelteServer) {
         found = true;
       }
-    }
-  });
-  return found;
+    });
+    if (found) return true;
+  }
+  return false;
 }
 
 /** Returns `true` when `name` is imported from `svelte/server` in the given file. */


### PR DESCRIPTION
## Summary

Follow-up to the stable-promotion gate merged in #187. Fixes three latent bugs that Cursor Bugbot flagged on PR #188 (closed as a duplicate of #187 — a concurrent session merged the same feature before these fixes were applied).

1. **Reject `className` as a prop name.** cinder's public prop is `class?: string` (destructured internally as `class: className`). `className` is valid camelCase, so the gate previously let it pass. Added to `PROP_NAME_DENYLIST`. Verified no committed component schema exposes `className`.
2. **Scope `hasHydrationTest` to active `test()`/`it()` blocks.** It scanned the whole file, so a `render`/`renderThenHydrate` inside `test.skip`/`test.todo` falsely satisfied the hydration gate — matching the behavior `hasSubstantiveTest` already had.
3. **Anchor `hasA11yDoc`'s legacy flat path at the `src/components` root.** For experimental components it resolved to `src/components/experimental/<name>.a11y.md` instead of the documented `src/components/<name>.a11y.md`.
4. Minor: import `CallExpression` as a type-only symbol (`verbatimModuleSyntax`).

AGENTS.md denylist table updated: `classname` and `className` both correct to `class`.

## Provenance

These exact fixes were reviewed and APPROVED by the multi-agent committee (typescript-expert, testing-expert, simplicity-engineer, dx-engineer, prose-editor — 2 rounds) on the now-closed #188, and were independently surfaced by Cursor Bugbot. This PR re-scopes them as a focused diff on top of the merged gate.

## Test plan

- `bun test packages/components/scripts/check-promotion-readiness.test.ts` — 49 pass / 0 fail (added regression tests for className denial, class passthrough, and hydration active-block scoping)
- `bun run components:promotion-check button` / `json-viewer` — both PASS
- `bun run --filter=cinder typecheck` — 0 errors
- `bun run --filter=cinder lint` — 0 errors

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes only promotion-check helpers, docs, and tests; no runtime component or public API behavior.
> 
> **Overview**
> Tightens the **stable-promotion gate** in `component-conventions.ts` so three false passes cannot slip through, with matching **AGENTS.md** denylist docs and regression tests.
> 
> **Prop names:** `className` is added to `PROP_NAME_DENYLIST` even though it is valid camelCase—the public API is `class`, not `className`. The denylist table now maps both `classname` and `className` to `class`.
> 
> **Hydration:** `hasHydrationTest` only counts `render` / `renderThenHydrate` inside active `test()` / `it()` blocks, so calls in `test.skip` no longer satisfy the gate (aligned with substantive-test behavior).
> 
> **A11y docs:** `hasA11yDoc` resolves the legacy flat doc at `src/components/<name>.a11y.md` by walking up to the `components` root, fixing wrong paths for `experimental/<name>/` components.
> 
> Tests cover `className` denial, `class` passthrough, and hydration active vs skipped blocks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5a586ce5913a85f8e196ad074288a9092a0a70bf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->