### PR TITLE
Make @layer cinder.components intrinsic to every component CSS file

### DIFF
--- a/packages/components/AGENTS.md
+++ b/packages/components/AGENTS.md
@@ -349,6 +349,16 @@ Convention shown for Button:
    manifest entry, and per-component READMEs. Re-run `bun run
 components:check` to confirm the drift checker is happy.
 
+If the component ships a `<id>.css` sidecar, its rules must self-declare their
+cascade layer: wrap the whole file in `@layer cinder.components { … }`. The
+layer membership has to be intrinsic to the file so it survives a direct
+subpath import (`cinder/<id>/styles`) rather than relying on the aggregator's
+`@import … layer(cinder.components)`. Applications that layer their own
+overrides should declare their layer order (e.g. `@layer cinder.components,
+app;`) before importing cinder styles — the sidecar carries layer _membership_,
+not ordering, so ordering stays the consumer's responsibility.
+`scripts/check-component-css.ts` enforces the wrapper at build time.
+
 ### Compound components
 
 A compound component is a parent that owns context and a small fixed set of

--- a/packages/components/AGENTS.md
+++ b/packages/components/AGENTS.md
@@ -359,6 +359,15 @@ app;`) before importing cinder styles — the sidecar carries layer _membership_
 not ordering, so ordering stays the consumer's responsibility.
 `scripts/check-component-css.ts` enforces the wrapper at build time.
 
+> [!WARNING] This reversed the earlier bare-rules contract
+> Component sidecars used to hold bare rules with NO `@layer` wrapper — the
+> aggregator applied `layer(cinder.components)` on import, and the build gate
+> _rejected_ any `@layer` inside a sidecar. That is now inverted. A branch that
+> adds or edits a `.css` sidecar without the wrapper will fail the build with a
+> "must live inside a single top-level `@layer cinder.components { … }` wrapper"
+> error. To migrate, wrap the file's entire content in
+> `@layer cinder.components { … }`.
+
 ### Compound components
 
 A compound component is a parent that owns context and a small fixed set of

--- a/packages/components/scripts/build.ts
+++ b/packages/components/scripts/build.ts
@@ -299,30 +299,19 @@ if (!perComponentServerBuildResult.success) {
 // -----------------------------------------------------------------------------
 
 const copiedSidecars: string[] = [];
-const unlayeredSidecars: string[] = [];
 for (const component of components) {
   const source = componentCssSource(component);
   if (!existsSync(source)) continue;
   const destination = componentCssDestination(component);
   await mkdir(dirname(destination), { recursive: true });
+  // The sidecar is copied verbatim. Its `@layer cinder.components { … }` wrapper
+  // — required so a direct `cinder/<name>/styles` import keeps its rules inside
+  // the cascade layer rather than outside every layer — was already enforced on
+  // the source by the AST gate above (`cssLintViolations`), so the copy carries
+  // it intact. No dist-side re-check is needed.
   const text = await Bun.file(source).text();
   await Bun.write(destination, text);
   copiedSidecars.push(destination);
-  // The shipped sidecar must self-declare its cascade layer so a direct
-  // subpath import (`cinder/<name>/styles`) lands its rules INSIDE
-  // `cinder.components` rather than outside every layer (where they would be
-  // un-overridable). `check-component-css.ts` enforces this on the source
-  // above; this is the dist-side backstop against a copy-path regression.
-  if (!text.includes('@layer cinder.components')) {
-    unlayeredSidecars.push(destination);
-  }
-}
-if (unlayeredSidecars.length > 0) {
-  process.stderr.write(
-    'Build aborted: component CSS sidecars copied to dist/ without a `@layer cinder.components` wrapper:\n',
-  );
-  for (const path of unlayeredSidecars) process.stderr.write(`  - ${path}\n`);
-  process.exit(1);
 }
 
 // -----------------------------------------------------------------------------

--- a/packages/components/scripts/build.ts
+++ b/packages/components/scripts/build.ts
@@ -299,6 +299,7 @@ if (!perComponentServerBuildResult.success) {
 // -----------------------------------------------------------------------------
 
 const copiedSidecars: string[] = [];
+const unlayeredSidecars: string[] = [];
 for (const component of components) {
   const source = componentCssSource(component);
   if (!existsSync(source)) continue;
@@ -307,6 +308,21 @@ for (const component of components) {
   const text = await Bun.file(source).text();
   await Bun.write(destination, text);
   copiedSidecars.push(destination);
+  // The shipped sidecar must self-declare its cascade layer so a direct
+  // subpath import (`cinder/<name>/styles`) lands its rules INSIDE
+  // `cinder.components` rather than outside every layer (where they would be
+  // un-overridable). `check-component-css.ts` enforces this on the source
+  // above; this is the dist-side backstop against a copy-path regression.
+  if (!text.includes('@layer cinder.components')) {
+    unlayeredSidecars.push(destination);
+  }
+}
+if (unlayeredSidecars.length > 0) {
+  process.stderr.write(
+    'Build aborted: component CSS sidecars copied to dist/ without a `@layer cinder.components` wrapper:\n',
+  );
+  for (const path of unlayeredSidecars) process.stderr.write(`  - ${path}\n`);
+  process.exit(1);
 }
 
 // -----------------------------------------------------------------------------

--- a/packages/components/scripts/check-component-css.test.ts
+++ b/packages/components/scripts/check-component-css.test.ts
@@ -4,9 +4,18 @@ import { checkComponentCssSource } from './check-component-css.ts';
 
 const fakePath = '/virtual/test/component.css';
 
+/**
+ * Wrap a fragment of component CSS in the required
+ * `@layer cinder.components { … }` sidecar wrapper. The layer assignment is now
+ * intrinsic to the file, so every valid sidecar must carry it.
+ */
+function layered(inner: string): string {
+  return `@layer cinder.components {\n${inner}\n}`;
+}
+
 describe('checkComponentCssSource', () => {
   it('passes a well-scoped component sidecar', () => {
-    const source = `
+    const source = layered(`
       .cinder-button {
         background: var(--cinder-button-bg);
         color: var(--cinder-button-fg);
@@ -17,141 +26,159 @@ describe('checkComponentCssSource', () => {
       .cinder-button[data-variant='primary'] {
         --cinder-button-bg: blue;
       }
-    `;
+    `);
+    expect(checkComponentCssSource(source, fakePath)).toEqual([]);
+  });
+
+  it('allows leading comments before the layer wrapper', () => {
+    const source = `/* license header */\n${layered(`.cinder-button { color: red; }`)}`;
     expect(checkComponentCssSource(source, fakePath)).toEqual([]);
   });
 
   it('allows scoped descendants of forbidden tags', () => {
-    const source = `
+    const source = layered(`
       .cinder-button > * { margin-inline-end: 0; }
       .cinder-banner :where(html) { color: inherit; }
-    `;
+    `);
     expect(checkComponentCssSource(source, fakePath)).toEqual([]);
   });
 
   it('allows class lists nested inside functional pseudos', () => {
-    const source = `
+    const source = layered(`
       :is(.cinder-button, .cinder-button-group) { color: red; }
       :where(.cinder-card) { padding: 1rem; }
       :not(.cinder-button-icon).cinder-button { font-weight: 600; }
-    `;
+    `);
     expect(checkComponentCssSource(source, fakePath)).toEqual([]);
   });
 
-  it('rejects :root at the top level', () => {
-    const source = `:root { --cinder-color-fg: black; }`;
+  it('rejects :root at the top level (inside the layer)', () => {
+    const source = layered(`:root { --cinder-color-fg: black; }`);
     const violations = checkComponentCssSource(source, fakePath);
     expect(violations).toHaveLength(1);
     expect(violations[0]?.selector).toBe(':root');
   });
 
   it('rejects :where(:root) — globals hidden inside a functional pseudo', () => {
-    const source = `:where(:root) { --cinder-color-fg: black; }`;
+    const source = layered(`:where(:root) { --cinder-color-fg: black; }`);
     const violations = checkComponentCssSource(source, fakePath);
     expect(violations).toHaveLength(1);
     expect(violations[0]?.selector).toBe(':where(:root)');
   });
 
   it('rejects :is(html, body)', () => {
-    const source = `:is(html, body) { font-family: sans-serif; }`;
+    const source = layered(`:is(html, body) { font-family: sans-serif; }`);
     const violations = checkComponentCssSource(source, fakePath);
     expect(violations).toHaveLength(1);
     expect(violations[0]?.selector).toBe(':is(html, body)');
   });
 
   it('rejects html and body selectors', () => {
-    const source = `html { font-size: 16px; } body { margin: 0; }`;
+    const source = layered(`html { font-size: 16px; } body { margin: 0; }`);
     const violations = checkComponentCssSource(source, fakePath);
     expect(violations).toHaveLength(2);
     expect(violations.map((v) => v.selector)).toEqual(['html', 'body']);
   });
 
   it('rejects raw tag selectors with no class anchor', () => {
-    const source = `button { all: unset; }`;
+    const source = layered(`button { all: unset; }`);
     const violations = checkComponentCssSource(source, fakePath);
     expect(violations).toHaveLength(1);
     expect(violations[0]?.selector).toBe('button');
   });
 
   it('rejects bare universal selectors', () => {
-    const source = `* { box-sizing: border-box; }`;
+    const source = layered(`* { box-sizing: border-box; }`);
     const violations = checkComponentCssSource(source, fakePath);
     expect(violations).toHaveLength(1);
     expect(violations[0]?.selector).toBe('*');
   });
 
   it('rejects universal + pseudo at the top level', () => {
-    const source = `*:focus { outline: 2px solid blue; }`;
+    const source = layered(`*:focus { outline: 2px solid blue; }`);
     const violations = checkComponentCssSource(source, fakePath);
     expect(violations).toHaveLength(1);
     expect(violations[0]?.selector).toBe('*:focus');
   });
 
   it('rejects bare attribute selectors at the top level', () => {
-    const source = `[data-theme='dark'] { background: black; }`;
+    const source = layered(`[data-theme='dark'] { background: black; }`);
     const violations = checkComponentCssSource(source, fakePath);
     expect(violations).toHaveLength(1);
     expect(violations[0]?.selector).toContain('data-theme');
   });
 
-  it('rejects @layer at-rules', () => {
+  it('requires the @layer cinder.components wrapper — bare rules fail', () => {
+    const source = `.cinder-button { color: red; }`;
+    const violations = checkComponentCssSource(source, fakePath);
+    expect(violations).toHaveLength(1);
+    expect(violations[0]?.message).toContain('@layer cinder.components');
+  });
+
+  it('rejects a wrapper with the wrong layer name', () => {
     const source = `@layer components { .cinder-button { color: red; } }`;
     const violations = checkComponentCssSource(source, fakePath);
     expect(violations.length).toBeGreaterThanOrEqual(1);
-    expect(violations[0]?.message).toContain('@layer');
+    expect(violations[0]?.message).toContain('@layer cinder.components');
+  });
+
+  it('rejects rules sitting outside the layer wrapper', () => {
+    const source = `${layered(`.cinder-button { color: red; }`)}\n.cinder-leaked { color: blue; }`;
+    const violations = checkComponentCssSource(source, fakePath);
+    expect(violations.length).toBeGreaterThanOrEqual(1);
+    expect(violations[0]?.message).toContain('@layer cinder.components');
   });
 
   it('rejects @import at-rules', () => {
-    const source = `@import './tokens.css'; .cinder-button { color: red; }`;
+    const source = layered(`@import './tokens.css'; .cinder-button { color: red; }`);
     const violations = checkComponentCssSource(source, fakePath);
-    expect(violations).toHaveLength(1);
-    expect(violations[0]?.message).toContain('@import');
+    expect(violations.some((v) => v.message.includes('@import'))).toBe(true);
   });
 
   it('handles selector lists', () => {
-    const source = `.cinder-button, :root { color: red; }`;
+    const source = layered(`.cinder-button, :root { color: red; }`);
     const violations = checkComponentCssSource(source, fakePath);
     expect(violations).toHaveLength(1);
     expect(violations[0]?.selector).toBe(':root');
   });
 
   it('allows data-cinder-* attribute anchors (state-driven scoping)', () => {
-    const source = `
+    const source = layered(`
       [data-cinder-state='current'] .cinder-steps__marker {
         background: var(--cinder-steps-current-bg);
       }
       [data-cinder-variant='primary'] {
         color: var(--cinder-fg);
       }
-    `;
+    `);
     expect(checkComponentCssSource(source, fakePath)).toEqual([]);
   });
 
   it('does NOT allow non-cinder data-* attribute anchors', () => {
-    const source = `[data-state='current'] { color: red; }`;
+    const source = layered(`[data-state='current'] { color: red; }`);
     const violations = checkComponentCssSource(source, fakePath);
     expect(violations).toHaveLength(1);
     expect(violations[0]?.selector).toContain('data-state');
   });
 
   it('allows @keyframes stops like from/to/0%/100%', () => {
-    const source = `
+    const source = layered(`
       @keyframes cinder-spin {
         from { transform: rotate(0); }
         50% { transform: rotate(180deg); }
         to { transform: rotate(360deg); }
       }
       .cinder-spinner { animation: cinder-spin 1s linear infinite; }
-    `;
+    `);
     expect(checkComponentCssSource(source, fakePath)).toEqual([]);
   });
 
   it('flags root selectors inside @media just like at the top level', () => {
-    const source = `
+    const source = layered(`
       @media (min-width: 640px) {
         :root { --cinder-foo: 1; }
       }
-    `;
+    `);
     const violations = checkComponentCssSource(source, fakePath);
     expect(violations).toHaveLength(1);
     expect(violations[0]?.selector).toBe(':root');

--- a/packages/components/scripts/check-component-css.test.ts
+++ b/packages/components/scripts/check-component-css.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from 'bun:test';
+import { parse } from 'postcss';
 
-import { checkComponentCssSource } from './check-component-css.ts';
+import {
+  checkComponentCssSource,
+  COMPONENT_LAYER_NAME,
+  formatViolation,
+  isSingleComponentLayer,
+} from './check-component-css.ts';
 
 const fakePath = '/virtual/test/component.css';
 
@@ -182,5 +188,51 @@ describe('checkComponentCssSource', () => {
     const violations = checkComponentCssSource(source, fakePath);
     expect(violations).toHaveLength(1);
     expect(violations[0]?.selector).toBe(':root');
+  });
+});
+
+describe('isSingleComponentLayer', () => {
+  it('accepts a single cinder.components block wrapper', () => {
+    expect(isSingleComponentLayer(parse(layered(`.cinder-x { color: red; }`)))).toBe(true);
+  });
+
+  it('accepts leading comments before the wrapper', () => {
+    expect(
+      isSingleComponentLayer(parse(`/* header */\n${layered(`.cinder-x { color: red; }`)}`)),
+    ).toBe(true);
+  });
+
+  it('rejects a bare rule with no wrapper', () => {
+    expect(isSingleComponentLayer(parse(`.cinder-x { color: red; }`))).toBe(false);
+  });
+
+  it('rejects a rule sitting outside the wrapper', () => {
+    expect(isSingleComponentLayer(parse(`${layered(`.cinder-x {}`)}\n.cinder-y {}`))).toBe(false);
+  });
+
+  it('rejects the statement form `@layer cinder.components;` (no block body)', () => {
+    expect(isSingleComponentLayer(parse(`@layer ${COMPONENT_LAYER_NAME};`))).toBe(false);
+  });
+
+  it('rejects a wrapper with a different layer name', () => {
+    expect(isSingleComponentLayer(parse(`@layer other { .cinder-x {} }`))).toBe(false);
+  });
+});
+
+describe('formatViolation', () => {
+  it('renders location + message for a selector-bearing violation', () => {
+    const [violation] = checkComponentCssSource(layered(`:root { color: red; }`), fakePath);
+    expect(violation).toBeDefined();
+    const formatted = formatViolation(violation!);
+    expect(formatted).toStartWith(`${fakePath}:`);
+    expect(formatted).toContain(violation!.message);
+  });
+
+  it('renders location + message for a wrapper violation (no selector)', () => {
+    const [violation] = checkComponentCssSource(`.cinder-x { color: red; }`, fakePath);
+    expect(violation).toBeDefined();
+    expect(violation!.selector).toBeUndefined();
+    const formatted = formatViolation(violation!);
+    expect(formatted).toContain(`@layer ${COMPONENT_LAYER_NAME}`);
   });
 });

--- a/packages/components/scripts/check-component-css.ts
+++ b/packages/components/scripts/check-component-css.ts
@@ -35,6 +35,44 @@ export type CssViolation = {
   message: string;
 };
 
+/**
+ * The single cascade layer every component CSS sidecar must self-declare.
+ * Exported as the one source of truth so the build gate, the dist-side
+ * verification, and the invariant test all agree on the name.
+ */
+export const COMPONENT_LAYER_NAME = 'cinder.components';
+
+/**
+ * Whether a top-level AST node is the `@layer cinder.components { … }` wrapper —
+ * a `@layer` at-rule whose params name exactly the component layer AND that has
+ * a block body (rejecting the statement form `@layer cinder.components;`).
+ */
+function isComponentLayerNode(node: { type: string }): boolean {
+  if (node.type !== 'atrule') return false;
+  const atRule = node as AtRule;
+  return (
+    atRule.name === 'layer' &&
+    atRule.params.trim() === COMPONENT_LAYER_NAME &&
+    atRule.nodes !== undefined
+  );
+}
+
+/**
+ * Whether a parsed stylesheet satisfies the wrapper invariant: after ignoring
+ * comments, its only top-level node is a single `@layer cinder.components { … }`
+ * block. Shared by the build gate ({@link checkComponentCssSource}), the
+ * dist-side verification in `build.ts`, and the structural invariant test so all
+ * three agree on one definition.
+ */
+export function isSingleComponentLayer(root: Root): boolean {
+  const topLevelNodes = root.nodes.filter((node) => node.type !== 'comment');
+  return (
+    topLevelNodes.length === 1 &&
+    topLevelNodes[0] !== undefined &&
+    isComponentLayerNode(topLevelNodes[0])
+  );
+}
+
 const FUNCTIONAL_PSEUDOS = new Set([':is', ':where', ':not', ':has', ':matches']);
 
 /**
@@ -150,26 +188,15 @@ export function checkComponentCssSource(source: string, file: string): CssViolat
   // contract: every top-level node (ignoring comments) must live inside a
   // single `@layer cinder.components { … }` wrapper. A bare top-level style
   // rule or at-rule sitting outside that wrapper is the violation.
-  const isCinderComponentsLayer = (node: (typeof root.nodes)[number]): boolean =>
-    node.type === 'atrule' &&
-    (node as AtRule).name === 'layer' &&
-    (node as AtRule).params.trim() === 'cinder.components';
-
-  const topLevelNodes = root.nodes.filter((node) => node.type !== 'comment');
-  const isWrapped =
-    topLevelNodes.length === 1 &&
-    topLevelNodes[0] !== undefined &&
-    isCinderComponentsLayer(topLevelNodes[0]);
-
-  if (!isWrapped) {
-    const offender = topLevelNodes.find((node) => !isCinderComponentsLayer(node));
+  if (!isSingleComponentLayer(root)) {
+    const topLevelNodes = root.nodes.filter((node) => node.type !== 'comment');
+    const offender = topLevelNodes.find((node) => !isComponentLayerNode(node));
     const target = offender ?? root;
     violations.push({
       file,
       line: target.source?.start?.line ?? 1,
       column: target.source?.start?.column ?? 1,
-      message:
-        'Component CSS sidecar rules must live inside a single top-level `@layer cinder.components { … }` wrapper so the layer assignment survives a direct subpath import. Wrap the file contents in `@layer cinder.components { … }`.',
+      message: `Component CSS sidecar rules must live inside a single top-level \`@layer ${COMPONENT_LAYER_NAME} { … }\` wrapper so the layer assignment survives a direct subpath import. Wrap the file contents in \`@layer ${COMPONENT_LAYER_NAME} { … }\`.`,
     });
   }
 
@@ -214,7 +241,7 @@ export function checkComponentCssSource(source: string, file: string): CssViolat
 
 export function formatViolation(violation: CssViolation): string {
   const location = `${violation.file}:${violation.line}:${violation.column}`;
-  return violation.selector
-    ? `${location}  ${violation.message}`
-    : `${location}  ${violation.message}`;
+  // The selector, when present, is already embedded in `message`, so the
+  // formatted line is the same shape either way.
+  return `${location}  ${violation.message}`;
 }

--- a/packages/components/scripts/check-component-css.ts
+++ b/packages/components/scripts/check-component-css.ts
@@ -9,9 +9,11 @@
  *      properties of the `--cinder-*` family.
  *   2. No `:root`, `html`, `body`, or bare universal `*` selectors at the
  *      effective top level — those belong in token / foundation layers.
- *   3. No `@layer` declarations inside the sidecar — layer assignment happens
- *      at the import side, via the `cinder/styles` aggregator wrapping its
- *      imports with `@import '...' layer(cinder.components)`.
+ *   3. All rules must live inside a single top-level
+ *      `@layer cinder.components { … }` wrapper so the layer assignment is
+ *      intrinsic to the file and survives a direct subpath import
+ *      (`cinder/<name>/styles`). A bare top-level rule outside the wrapper is
+ *      a violation.
  *
  * Scoped descendants are allowed (e.g. `.button *`, `.alert :where(html)`).
  * The check distinguishes these from forbidden globals by walking the parsed
@@ -22,7 +24,7 @@
  * build before sidecars are copied into `dist/`.
  */
 
-import postcss from 'postcss';
+import { parse, type AtRule, type Container, type Document, type Root } from 'postcss';
 import selectorParser from 'postcss-selector-parser';
 
 export type CssViolation = {
@@ -116,9 +118,9 @@ export async function checkComponentCss(file: string): Promise<CssViolation[]> {
 export function checkComponentCssSource(source: string, file: string): CssViolation[] {
   const violations: CssViolation[] = [];
 
-  let root: postcss.Root;
+  let root: Root;
   try {
-    root = postcss.parse(source, { from: file });
+    root = parse(source, { from: file });
   } catch (error) {
     violations.push({
       file,
@@ -142,15 +144,34 @@ export function checkComponentCssSource(source: string, file: string): CssViolat
     });
   });
 
-  root.walkAtRules('layer', (atRule) => {
+  // Layer assignment must be intrinsic to the sidecar so it survives a direct
+  // subpath import (`cinder/<name>/styles`) rather than relying on the
+  // aggregator wrapping the `@import` with `layer(cinder.components)`. The
+  // contract: every top-level node (ignoring comments) must live inside a
+  // single `@layer cinder.components { … }` wrapper. A bare top-level style
+  // rule or at-rule sitting outside that wrapper is the violation.
+  const isCinderComponentsLayer = (node: (typeof root.nodes)[number]): boolean =>
+    node.type === 'atrule' &&
+    (node as AtRule).name === 'layer' &&
+    (node as AtRule).params.trim() === 'cinder.components';
+
+  const topLevelNodes = root.nodes.filter((node) => node.type !== 'comment');
+  const isWrapped =
+    topLevelNodes.length === 1 &&
+    topLevelNodes[0] !== undefined &&
+    isCinderComponentsLayer(topLevelNodes[0]);
+
+  if (!isWrapped) {
+    const offender = topLevelNodes.find((node) => !isCinderComponentsLayer(node));
+    const target = offender ?? root;
     violations.push({
       file,
-      line: atRule.source?.start?.line ?? 1,
-      column: atRule.source?.start?.column ?? 1,
+      line: target.source?.start?.line ?? 1,
+      column: target.source?.start?.column ?? 1,
       message:
-        '`@layer` is not allowed inside a component CSS sidecar. Layer assignment happens at the import side via `cinder/styles`.',
+        'Component CSS sidecar rules must live inside a single top-level `@layer cinder.components { … }` wrapper so the layer assignment survives a direct subpath import. Wrap the file contents in `@layer cinder.components { … }`.',
     });
-  });
+  }
 
   root.walkRules((rule) => {
     // Rules nested under another rule (CSS nesting) are inherently scoped to a
@@ -161,12 +182,12 @@ export function checkComponentCssSource(source: string, file: string): CssViolat
     // descendant selectors that target the document tree. The keyframes rule
     // itself is scoped via its `animation-name` consumer.
     for (
-      let ancestor: postcss.Container | postcss.Document | undefined = rule.parent;
+      let ancestor: Container | Document | undefined = rule.parent;
       ancestor && ancestor.type !== 'root';
       ancestor = ancestor.parent
     ) {
       if (ancestor.type === 'atrule') {
-        const atRule = ancestor as postcss.AtRule;
+        const atRule = ancestor as AtRule;
         if (/^(-\w+-)?keyframes$/i.test(atRule.name)) return;
       }
     }

--- a/packages/components/src/components/accordion-item/accordion-item.css
+++ b/packages/components/src/components/accordion-item/accordion-item.css
@@ -1,66 +1,67 @@
-/* ========================================
+@layer cinder.components {
+  /* ========================================
  * ACCORDION ITEM
  * ======================================== */
 
-.cinder-accordion-item {
-  border-block-end: 1px solid var(--cinder-border);
-}
+  .cinder-accordion-item {
+    border-block-end: 1px solid var(--cinder-border);
+  }
 
-/* Remove the trailing divider from the last item so it doesn't
+  /* Remove the trailing divider from the last item so it doesn't
  * double-up with the parent accordion's border-radius edge. */
-.cinder-accordion-item:last-child {
-  border-block-end: none;
-}
+  .cinder-accordion-item:last-child {
+    border-block-end: none;
+  }
 
-/* ----------------------------------------
+  /* ----------------------------------------
  * Heading — reset browser h3 margins/styles
  * ---------------------------------------- */
 
-.cinder-accordion-item__heading {
-  margin: 0;
-  padding: 0;
-}
+  .cinder-accordion-item__heading {
+    margin: 0;
+    padding: 0;
+  }
 
-/* ----------------------------------------
+  /* ----------------------------------------
  * Trigger button
  * ---------------------------------------- */
 
-.cinder-accordion-item__trigger {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: var(--cinder-space-4);
-  width: 100%;
-  padding: var(--cinder-space-4) var(--cinder-space-5);
+  .cinder-accordion-item__trigger {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--cinder-space-4);
+    width: 100%;
+    padding: var(--cinder-space-4) var(--cinder-space-5);
 
-  font-size: var(--cinder-text-base);
-  font-weight: var(--cinder-font-medium);
-  line-height: var(--cinder-leading-snug);
-  color: var(--cinder-text);
-  text-align: start;
+    font-size: var(--cinder-text-base);
+    font-weight: var(--cinder-font-medium);
+    line-height: var(--cinder-leading-snug);
+    color: var(--cinder-text);
+    text-align: start;
 
-  background: transparent;
-  border: none;
-  cursor: pointer;
+    background: transparent;
+    border: none;
+    cursor: pointer;
 
-  transition:
-    background-color var(--cinder-duration-fast) var(--cinder-ease-standard),
-    color var(--cinder-duration-fast) var(--cinder-ease-standard);
-}
-
-/* Sticky-hover suppression on touch. */
-@media (hover: hover) {
-  .cinder-accordion-item__trigger:hover:not(:disabled) {
-    background: var(--cinder-surface-hover);
+    transition:
+      background-color var(--cinder-duration-fast) var(--cinder-ease-standard),
+      color var(--cinder-duration-fast) var(--cinder-ease-standard);
   }
-}
 
-.cinder-accordion-item__trigger:active:not(:disabled) {
-  background: var(--cinder-surface-pressed);
-}
+  /* Sticky-hover suppression on touch. */
+  @media (hover: hover) {
+    .cinder-accordion-item__trigger:hover:not(:disabled) {
+      background: var(--cinder-surface-hover);
+    }
+  }
 
-.cinder-accordion-item__trigger:focus-visible {
-  /* The accordion's parent has `overflow: clip` so an outset ring is trimmed,
+  .cinder-accordion-item__trigger:active:not(:disabled) {
+    background: var(--cinder-surface-pressed);
+  }
+
+  .cinder-accordion-item__trigger:focus-visible {
+    /* The accordion's parent has `overflow: clip` so an outset ring is trimmed,
      and an inset box-shadow leaves a visible bottom stripe that blends with
      an expanded item's panel border below.
 
@@ -68,96 +69,97 @@
      drawn INSIDE the trigger's border box, doesn't contribute to layout,
      and stays fully clear of the trigger/panel boundary regardless of
      expansion state. */
-  outline: var(--cinder-ring-width) solid var(--cinder-ring-color);
-  outline-offset: calc(-1 * var(--cinder-ring-width));
-  /* Reset in case any earlier rule left a box-shadow lingering. */
-  box-shadow: none;
-}
+    outline: var(--cinder-ring-width) solid var(--cinder-ring-color);
+    outline-offset: calc(-1 * var(--cinder-ring-width));
+    /* Reset in case any earlier rule left a box-shadow lingering. */
+    box-shadow: none;
+  }
 
-/* Round the trigger to match the accordion's outer corners on first/last
+  /* Round the trigger to match the accordion's outer corners on first/last
  * items so the focus outline follows the parent's border-radius rather than
  * appearing to poke past it.
  *
  * Only the corners that touch the accordion's edge are rounded. The
  * trigger is otherwise full-width with sharp corners on the inner edges. */
-.cinder-accordion-item:first-child .cinder-accordion-item__trigger {
-  border-start-start-radius: var(--cinder-radius-lg);
-  border-start-end-radius: var(--cinder-radius-lg);
-}
+  .cinder-accordion-item:first-child .cinder-accordion-item__trigger {
+    border-start-start-radius: var(--cinder-radius-lg);
+    border-start-end-radius: var(--cinder-radius-lg);
+  }
 
-/* Last-item trigger only rounds bottom corners when its panel is collapsed —
+  /* Last-item trigger only rounds bottom corners when its panel is collapsed —
  * an expanded panel renders below, so the trigger's bottom must remain square
  * to abut the panel cleanly. */
-.cinder-accordion-item:last-child:not([data-cinder-expanded]) .cinder-accordion-item__trigger {
-  border-end-start-radius: var(--cinder-radius-lg);
-  border-end-end-radius: var(--cinder-radius-lg);
-}
-
-@media (forced-colors: active) {
-  .cinder-accordion-item__trigger:focus-visible {
-    outline: var(--cinder-ring-width) solid ButtonText;
+  .cinder-accordion-item:last-child:not([data-cinder-expanded]) .cinder-accordion-item__trigger {
+    border-end-start-radius: var(--cinder-radius-lg);
+    border-end-end-radius: var(--cinder-radius-lg);
   }
-}
 
-/* Disabled state */
-.cinder-accordion-item__trigger:disabled {
-  cursor: not-allowed;
-  color: var(--cinder-text-disabled);
-  opacity: 0.6;
-}
+  @media (forced-colors: active) {
+    .cinder-accordion-item__trigger:focus-visible {
+      outline: var(--cinder-ring-width) solid ButtonText;
+    }
+  }
 
-/* ----------------------------------------
+  /* Disabled state */
+  .cinder-accordion-item__trigger:disabled {
+    cursor: not-allowed;
+    color: var(--cinder-text-disabled);
+    opacity: 0.6;
+  }
+
+  /* ----------------------------------------
  * Title text
  * ---------------------------------------- */
 
-.cinder-accordion-item__title {
-  flex: 1;
-}
+  .cinder-accordion-item__title {
+    flex: 1;
+  }
 
-/* ----------------------------------------
+  /* ----------------------------------------
  * Chevron icon
  * ---------------------------------------- */
 
-.cinder-accordion-item__chevron {
-  flex-shrink: 0;
-  width: 1.25rem;
-  height: 1.25rem;
-  color: var(--cinder-text-muted);
+  .cinder-accordion-item__chevron {
+    flex-shrink: 0;
+    width: 1.25rem;
+    height: 1.25rem;
+    color: var(--cinder-text-muted);
 
-  transition: transform var(--cinder-duration-fast) var(--cinder-ease-standard);
-}
+    transition: transform var(--cinder-duration-fast) var(--cinder-ease-standard);
+  }
 
-/* Rotate chevron when item is expanded */
-.cinder-accordion-item[data-cinder-expanded] .cinder-accordion-item__chevron {
-  transform: rotate(180deg);
-}
+  /* Rotate chevron when item is expanded */
+  .cinder-accordion-item[data-cinder-expanded] .cinder-accordion-item__chevron {
+    transform: rotate(180deg);
+  }
 
-/* Dim chevron for disabled items */
-.cinder-accordion-item[data-cinder-disabled] .cinder-accordion-item__chevron {
-  opacity: 0.4;
-}
+  /* Dim chevron for disabled items */
+  .cinder-accordion-item[data-cinder-disabled] .cinder-accordion-item__chevron {
+    opacity: 0.4;
+  }
 
-/* ----------------------------------------
+  /* ----------------------------------------
  * Panel
  * ---------------------------------------- */
 
-.cinder-accordion-item__panel {
-  border-block-start: 1px solid var(--cinder-border-muted);
-}
+  .cinder-accordion-item__panel {
+    border-block-start: 1px solid var(--cinder-border-muted);
+  }
 
-.cinder-accordion-item__panel-inner {
-  padding: var(--cinder-space-4) var(--cinder-space-5) var(--cinder-space-5);
-  font-size: var(--cinder-text-base);
-  line-height: var(--cinder-leading-normal);
-  color: var(--cinder-text-muted);
-}
+  .cinder-accordion-item__panel-inner {
+    padding: var(--cinder-space-4) var(--cinder-space-5) var(--cinder-space-5);
+    font-size: var(--cinder-text-base);
+    line-height: var(--cinder-leading-normal);
+    color: var(--cinder-text-muted);
+  }
 
-/* ----------------------------------------
+  /* ----------------------------------------
  * Reduced motion — skip chevron rotation animation
  * ---------------------------------------- */
 
-@media (prefers-reduced-motion: reduce) {
-  .cinder-accordion-item__chevron {
-    transition: none;
+  @media (prefers-reduced-motion: reduce) {
+    .cinder-accordion-item__chevron {
+      transition: none;
+    }
   }
 }

--- a/packages/components/src/components/accordion/accordion.css
+++ b/packages/components/src/components/accordion/accordion.css
@@ -1,15 +1,17 @@
-/* ========================================
+@layer cinder.components {
+  /* ========================================
  * ACCORDION
  * ======================================== */
 
-.cinder-accordion {
-  display: flex;
-  flex-direction: column;
-  inline-size: 100%;
-  border: 1px solid var(--cinder-border);
-  border-radius: var(--cinder-radius-lg);
-  background: var(--cinder-surface);
+  .cinder-accordion {
+    display: flex;
+    flex-direction: column;
+    inline-size: 100%;
+    border: 1px solid var(--cinder-border);
+    border-radius: var(--cinder-radius-lg);
+    background: var(--cinder-surface);
 
-  /* Clip children so item borders respect the container's border-radius */
-  overflow: clip;
+    /* Clip children so item borders respect the container's border-radius */
+    overflow: clip;
+  }
 }

--- a/packages/components/src/components/alert-dialog/alert-dialog.css
+++ b/packages/components/src/components/alert-dialog/alert-dialog.css
@@ -1,9 +1,11 @@
-.cinder-alert-dialog .cinder-modal__panel {
-  max-width: min(28rem, calc(100vw - 2rem));
-}
+@layer cinder.components {
+  .cinder-alert-dialog .cinder-modal__panel {
+    max-width: min(28rem, calc(100vw - 2rem));
+  }
 
-.cinder-alert-dialog__description {
-  margin: 0;
-  color: var(--cinder-text-muted);
-  line-height: var(--cinder-leading-relaxed);
+  .cinder-alert-dialog__description {
+    margin: 0;
+    color: var(--cinder-text-muted);
+    line-height: var(--cinder-leading-relaxed);
+  }
 }

--- a/packages/components/src/components/alert/alert.css
+++ b/packages/components/src/components/alert/alert.css
@@ -1,66 +1,67 @@
-/* ========================================
+@layer cinder.components {
+  /* ========================================
  * ALERT
  * ======================================== */
 
-/*
+  /*
  * --cinder-info is not defined in tokens-base.css (the project only ships
  * success / warning / danger status tokens). Define it here, scoped to
  * .cinder-alert, so it doesn't bleed into other components.
  */
-.cinder-alert {
-  --cinder-alert-info: light-dark(oklch(45% 0.14 245), oklch(78% 0.15 245));
-}
+  .cinder-alert {
+    --cinder-alert-info: light-dark(oklch(45% 0.14 245), oklch(78% 0.15 245));
+  }
 
-.cinder-alert {
-  position: relative;
-  display: flex;
-  align-items: flex-start;
-  gap: var(--cinder-space-3);
-  inline-size: 100%;
-  padding: var(--cinder-space-4);
-  border-radius: var(--cinder-radius-lg);
-  border: 1px solid var(--cinder-border);
-  background: var(--cinder-surface);
-  color: var(--cinder-text);
-  font-size: var(--cinder-text-sm);
-  line-height: var(--cinder-leading-normal);
+  .cinder-alert {
+    position: relative;
+    display: flex;
+    align-items: flex-start;
+    gap: var(--cinder-space-3);
+    inline-size: 100%;
+    padding: var(--cinder-space-4);
+    border-radius: var(--cinder-radius-lg);
+    border: 1px solid var(--cinder-border);
+    background: var(--cinder-surface);
+    color: var(--cinder-text);
+    font-size: var(--cinder-text-sm);
+    line-height: var(--cinder-leading-normal);
 
-  transition:
-    background-color var(--cinder-duration-fast) var(--cinder-ease-standard),
-    border-color var(--cinder-duration-fast) var(--cinder-ease-standard);
-}
+    transition:
+      background-color var(--cinder-duration-fast) var(--cinder-ease-standard),
+      border-color var(--cinder-duration-fast) var(--cinder-ease-standard);
+  }
 
-/* ----------------------------------------
+  /* ----------------------------------------
  * Icon slot
  * ---------------------------------------- */
 
-.cinder-alert__icon {
-  flex-shrink: 0;
-  width: 1.25rem;
-  height: 1.25rem;
-  /* Nudge down 1px to optically align with the first line of body text */
-  margin-block-start: 1px;
-}
+  .cinder-alert__icon {
+    flex-shrink: 0;
+    width: 1.25rem;
+    height: 1.25rem;
+    /* Nudge down 1px to optically align with the first line of body text */
+    margin-block-start: 1px;
+  }
 
-.cinder-alert__icon svg {
-  width: 100%;
-  height: 100%;
-}
+  .cinder-alert__icon svg {
+    width: 100%;
+    height: 100%;
+  }
 
-/* ----------------------------------------
+  /* ----------------------------------------
  * Content area
  * ---------------------------------------- */
 
-.cinder-alert__content {
-  flex: 1;
-  min-width: 0;
-}
+  .cinder-alert__content {
+    flex: 1;
+    min-width: 0;
+  }
 
-/* ----------------------------------------
+  /* ----------------------------------------
  * Dismiss button
  * ---------------------------------------- */
 
-/* Box-model reset, hit-area, and idle :hover live on .cinder-_dismiss-button
+  /* Box-model reset, hit-area, and idle :hover live on .cinder-_dismiss-button
  * (see src/styles/components.css). Only Alert-specific layout positioning
  * and status-driven focus chrome live here.
  *
@@ -69,35 +70,35 @@
  * dismissible alert is the same height as a non-dismissible one — the
  * WCAG 2.5.5 hit-area expansion happens via the shared ::after pseudo-
  * element, which is absolutely positioned and doesn't influence layout. */
-.cinder-alert__dismiss {
-  align-self: flex-start;
+  .cinder-alert__dismiss {
+    align-self: flex-start;
 
-  transition:
-    background-color var(--cinder-duration-fast) var(--cinder-ease-standard),
-    box-shadow var(--cinder-duration-fast) var(--cinder-ease-standard);
-}
-
-.cinder-alert__dismiss:focus-visible {
-  outline: var(--cinder-ring-width) solid transparent;
-  box-shadow:
-    0 0 0 var(--cinder-ring-offset) var(--cinder-ring-offset-color),
-    0 0 0 calc(var(--cinder-ring-offset) + var(--cinder-ring-width))
-      var(--_cinder-alert-ring, var(--cinder-ring-color));
-}
-
-@media (forced-colors: active) {
-  .cinder-alert__dismiss:focus-visible {
-    outline: var(--cinder-ring-width) solid ButtonText;
-    outline-offset: 3px;
+    transition:
+      background-color var(--cinder-duration-fast) var(--cinder-ease-standard),
+      box-shadow var(--cinder-duration-fast) var(--cinder-ease-standard);
   }
-}
 
-.cinder-alert__dismiss-icon {
-  width: 1rem;
-  height: 1rem;
-}
+  .cinder-alert__dismiss:focus-visible {
+    outline: var(--cinder-ring-width) solid transparent;
+    box-shadow:
+      0 0 0 var(--cinder-ring-offset) var(--cinder-ring-offset-color),
+      0 0 0 calc(var(--cinder-ring-offset) + var(--cinder-ring-width))
+        var(--_cinder-alert-ring, var(--cinder-ring-color));
+  }
 
-/* ----------------------------------------
+  @media (forced-colors: active) {
+    .cinder-alert__dismiss:focus-visible {
+      outline: var(--cinder-ring-width) solid ButtonText;
+      outline-offset: 3px;
+    }
+  }
+
+  .cinder-alert__dismiss-icon {
+    width: 1rem;
+    height: 1rem;
+  }
+
+  /* ----------------------------------------
  * Variant: info
  *
  * NOTE (CSS audit, Batch D): The four status variants below intentionally
@@ -125,73 +126,74 @@
  * message text (and an icon where practical) rather than relying on tint.
  * ---------------------------------------- */
 
-.cinder-alert[data-cinder-variant='info'] {
-  --_cinder-alert-ring: var(--cinder-alert-info);
+  .cinder-alert[data-cinder-variant='info'] {
+    --_cinder-alert-ring: var(--cinder-alert-info);
 
-  background-color: light-dark(
-    oklch(from var(--cinder-alert-info) 96.5% 0.015 h),
-    oklch(from var(--cinder-alert-info) 20% 0.03 h)
-  );
-  /* border-color intentionally omitted: every Alert variant falls through to
+    background-color: light-dark(
+      oklch(from var(--cinder-alert-info) 96.5% 0.015 h),
+      oklch(from var(--cinder-alert-info) 20% 0.03 h)
+    );
+    /* border-color intentionally omitted: every Alert variant falls through to
    * the base `border: 1px solid var(--cinder-border)`. P7 sheds the persistent
    * status-colored frame so Alert reads as a flat tinted notification, leaving
    * the directional color cue (the stripe) exclusively to Callout. */
-  color: light-dark(
-    oklch(from var(--cinder-alert-info) 35% 0.12 h),
-    oklch(from var(--cinder-alert-info) 88% 0.12 h)
-  );
-}
+    color: light-dark(
+      oklch(from var(--cinder-alert-info) 35% 0.12 h),
+      oklch(from var(--cinder-alert-info) 88% 0.12 h)
+    );
+  }
 
-/* ----------------------------------------
+  /* ----------------------------------------
  * Variant: success
  * ---------------------------------------- */
 
-.cinder-alert[data-cinder-variant='success'] {
-  --_cinder-alert-ring: var(--cinder-success);
+  .cinder-alert[data-cinder-variant='success'] {
+    --_cinder-alert-ring: var(--cinder-success);
 
-  background-color: light-dark(
-    oklch(from var(--cinder-success) 96.5% 0.015 h),
-    oklch(from var(--cinder-success) 20% 0.03 h)
-  );
-  /* border-color intentionally omitted — inherits var(--cinder-border). */
-  color: light-dark(
-    oklch(from var(--cinder-success) 35% 0.14 h),
-    oklch(from var(--cinder-success) 88% 0.12 h)
-  );
-}
+    background-color: light-dark(
+      oklch(from var(--cinder-success) 96.5% 0.015 h),
+      oklch(from var(--cinder-success) 20% 0.03 h)
+    );
+    /* border-color intentionally omitted — inherits var(--cinder-border). */
+    color: light-dark(
+      oklch(from var(--cinder-success) 35% 0.14 h),
+      oklch(from var(--cinder-success) 88% 0.12 h)
+    );
+  }
 
-/* ----------------------------------------
+  /* ----------------------------------------
  * Variant: warning
  * ---------------------------------------- */
 
-.cinder-alert[data-cinder-variant='warning'] {
-  --_cinder-alert-ring: var(--cinder-warning);
+  .cinder-alert[data-cinder-variant='warning'] {
+    --_cinder-alert-ring: var(--cinder-warning);
 
-  background-color: light-dark(
-    oklch(from var(--cinder-warning) 96.5% 0.015 h),
-    oklch(from var(--cinder-warning) 20% 0.03 h)
-  );
-  /* border-color intentionally omitted — inherits var(--cinder-border). */
-  color: light-dark(
-    oklch(from var(--cinder-warning) 35% 0.16 h),
-    oklch(from var(--cinder-warning) 88% 0.14 h)
-  );
-}
+    background-color: light-dark(
+      oklch(from var(--cinder-warning) 96.5% 0.015 h),
+      oklch(from var(--cinder-warning) 20% 0.03 h)
+    );
+    /* border-color intentionally omitted — inherits var(--cinder-border). */
+    color: light-dark(
+      oklch(from var(--cinder-warning) 35% 0.16 h),
+      oklch(from var(--cinder-warning) 88% 0.14 h)
+    );
+  }
 
-/* ----------------------------------------
+  /* ----------------------------------------
  * Variant: error
  * ---------------------------------------- */
 
-.cinder-alert[data-cinder-variant='error'] {
-  --_cinder-alert-ring: var(--cinder-danger);
+  .cinder-alert[data-cinder-variant='error'] {
+    --_cinder-alert-ring: var(--cinder-danger);
 
-  background-color: light-dark(
-    oklch(from var(--cinder-danger) 96.5% 0.015 h),
-    oklch(from var(--cinder-danger) 20% 0.03 h)
-  );
-  /* border-color intentionally omitted — inherits var(--cinder-border). */
-  color: light-dark(
-    oklch(from var(--cinder-danger) 35% 0.18 h),
-    oklch(from var(--cinder-danger) 88% 0.16 h)
-  );
+    background-color: light-dark(
+      oklch(from var(--cinder-danger) 96.5% 0.015 h),
+      oklch(from var(--cinder-danger) 20% 0.03 h)
+    );
+    /* border-color intentionally omitted — inherits var(--cinder-border). */
+    color: light-dark(
+      oklch(from var(--cinder-danger) 35% 0.18 h),
+      oklch(from var(--cinder-danger) 88% 0.16 h)
+    );
+  }
 }

--- a/packages/components/src/components/alert/alert.css.test.ts
+++ b/packages/components/src/components/alert/alert.css.test.ts
@@ -25,7 +25,7 @@ import { fileURLToPath } from 'node:url';
 
 import { describe, expect, test } from 'bun:test';
 
-import { parse, type Declaration, type Rule } from 'postcss';
+import { parse, type AtRule, type Declaration, type Rule } from 'postcss';
 
 function loadCss(relativePath: string): string {
   const fullPath = fileURLToPath(new URL(relativePath, import.meta.url));
@@ -88,10 +88,26 @@ const BORDER_AFFECTING = new Set([
   'border-image-repeat',
 ]);
 
+/**
+ * A rule is "effectively top-level" when the only at-rules between it and the
+ * stylesheet root are `@layer` wrappers. Component CSS now self-declares
+ * `@layer cinder.components { … }`, so the base rules sit one `@layer` deep;
+ * that wrapper is transparent. Rules under `@media` / `@supports` /
+ * `@container` (e.g. the forced-colors block) are NOT top-level and are skipped.
+ */
+function isEffectivelyTopLevel(rule: Rule): boolean {
+  let ancestor = rule.parent;
+  while (ancestor && ancestor.type !== 'root') {
+    if (ancestor.type === 'atrule' && (ancestor as AtRule).name !== 'layer') return false;
+    ancestor = ancestor.parent;
+  }
+  return true;
+}
+
 function findRules(selector: string): Rule[] {
   const matches: Rule[] = [];
   root.walkRules((rule) => {
-    if (rule.parent?.type === 'atrule') return undefined;
+    if (!isEffectivelyTopLevel(rule)) return undefined;
     if (rule.selectors.includes(selector)) matches.push(rule);
     return undefined;
   });

--- a/packages/components/src/components/area-chart/area-chart.css
+++ b/packages/components/src/components/area-chart/area-chart.css
@@ -1,119 +1,121 @@
-.cinder-area-chart {
-  display: grid;
-  gap: var(--cinder-space-3);
-  color: var(--cinder-text);
-}
+@layer cinder.components {
+  .cinder-area-chart {
+    display: grid;
+    gap: var(--cinder-space-3);
+    color: var(--cinder-text);
+  }
 
-.cinder-area-chart__description {
-  margin: 0;
-  color: var(--cinder-text-muted);
-  font-size: var(--cinder-text-sm);
-}
+  .cinder-area-chart__description {
+    margin: 0;
+    color: var(--cinder-text-muted);
+    font-size: var(--cinder-text-sm);
+  }
 
-.cinder-area-chart__legend {
-  display: flex;
-  flex-wrap: wrap;
-  gap: var(--cinder-space-2);
-}
+  .cinder-area-chart__legend {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--cinder-space-2);
+  }
 
-.cinder-area-chart__legend button {
-  display: inline-flex;
-  align-items: center;
-  gap: var(--cinder-space-1);
-  border: 1px solid var(--cinder-border-muted);
-  border-radius: var(--cinder-radius-sm);
-  background: var(--cinder-surface);
-  color: var(--cinder-text);
-  cursor: pointer;
-  font: inherit;
-  font-size: var(--cinder-text-sm);
-  padding: var(--cinder-space-1) var(--cinder-space-2);
-}
+  .cinder-area-chart__legend button {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--cinder-space-1);
+    border: 1px solid var(--cinder-border-muted);
+    border-radius: var(--cinder-radius-sm);
+    background: var(--cinder-surface);
+    color: var(--cinder-text);
+    cursor: pointer;
+    font: inherit;
+    font-size: var(--cinder-text-sm);
+    padding: var(--cinder-space-1) var(--cinder-space-2);
+  }
 
-.cinder-area-chart__legend button[aria-pressed='false'] {
-  opacity: 0.55;
-}
+  .cinder-area-chart__legend button[aria-pressed='false'] {
+    opacity: 0.55;
+  }
 
-.cinder-area-chart__legend span {
-  inline-size: 0.75rem;
-  block-size: 0.75rem;
-  border-radius: var(--cinder-radius-full);
-}
+  .cinder-area-chart__legend span {
+    inline-size: 0.75rem;
+    block-size: 0.75rem;
+    border-radius: var(--cinder-radius-full);
+  }
 
-.cinder-area-chart__viewport {
-  position: relative;
-}
+  .cinder-area-chart__viewport {
+    position: relative;
+  }
 
-.cinder-area-chart svg {
-  display: block;
-  inline-size: 100%;
-  block-size: 100%;
-}
+  .cinder-area-chart svg {
+    display: block;
+    inline-size: 100%;
+    block-size: 100%;
+  }
 
-.cinder-area-chart__area {
-  opacity: 0.22;
-}
+  .cinder-area-chart__area {
+    opacity: 0.22;
+  }
 
-.cinder-area-chart__line {
-  fill: none;
-  stroke-width: 2;
-}
+  .cinder-area-chart__line {
+    fill: none;
+    stroke-width: 2;
+  }
 
-.cinder-area-chart__gridline {
-  stroke: var(--cinder-border-muted);
-  stroke-width: 1;
-}
+  .cinder-area-chart__gridline {
+    stroke: var(--cinder-border-muted);
+    stroke-width: 1;
+  }
 
-.cinder-area-chart__crosshair {
-  stroke: var(--cinder-text-muted);
-  stroke-dasharray: 4 4;
-}
+  .cinder-area-chart__crosshair {
+    stroke: var(--cinder-text-muted);
+    stroke-dasharray: 4 4;
+  }
 
-.cinder-area-chart__hit-surface {
-  fill: transparent;
-}
+  .cinder-area-chart__hit-surface {
+    fill: transparent;
+  }
 
-.cinder-area-chart__focus-target {
-  fill: transparent;
-  outline: none;
-  pointer-events: none;
-}
+  .cinder-area-chart__focus-target {
+    fill: transparent;
+    outline: none;
+    pointer-events: none;
+  }
 
-/*
+  /*
  * SVG focus indicator: drop-shadow renders a visible ring around the focused
  * element on any background. Matches line-chart and bar-chart.
  */
-.cinder-area-chart__focus-target:focus-visible {
-  stroke: var(--cinder-accent);
-  stroke-width: var(--cinder-ring-width);
-  filter: drop-shadow(0 0 var(--cinder-ring-width) var(--cinder-ring-color));
-}
+  .cinder-area-chart__focus-target:focus-visible {
+    stroke: var(--cinder-accent);
+    stroke-width: var(--cinder-ring-width);
+    filter: drop-shadow(0 0 var(--cinder-ring-width) var(--cinder-ring-color));
+  }
 
-.cinder-area-chart__tick-label {
-  fill: var(--cinder-text-muted);
-  font-size: var(--cinder-text-xs);
-}
+  .cinder-area-chart__tick-label {
+    fill: var(--cinder-text-muted);
+    font-size: var(--cinder-text-xs);
+  }
 
-.cinder-area-chart__state {
-  position: absolute;
-  inset: 0;
-  display: grid;
-  place-items: center;
-  color: var(--cinder-text-muted);
-  background: color-mix(in oklch, var(--cinder-surface) 88%, transparent);
-  z-index: 1;
-}
+  .cinder-area-chart__state {
+    position: absolute;
+    inset: 0;
+    display: grid;
+    place-items: center;
+    color: var(--cinder-text-muted);
+    background: color-mix(in oklch, var(--cinder-surface) 88%, transparent);
+    z-index: 1;
+  }
 
-.cinder-area-chart__tooltip {
-  position: absolute;
-  transform: translate(0.5rem, -50%);
-  display: grid;
-  gap: 0.125rem;
-  border: 1px solid var(--cinder-border-muted);
-  border-radius: var(--cinder-radius-sm);
-  background: var(--cinder-surface-raised);
-  box-shadow: var(--cinder-shadow-md);
-  font-size: var(--cinder-text-sm);
-  padding: var(--cinder-space-2);
-  pointer-events: none;
+  .cinder-area-chart__tooltip {
+    position: absolute;
+    transform: translate(0.5rem, -50%);
+    display: grid;
+    gap: 0.125rem;
+    border: 1px solid var(--cinder-border-muted);
+    border-radius: var(--cinder-radius-sm);
+    background: var(--cinder-surface-raised);
+    box-shadow: var(--cinder-shadow-md);
+    font-size: var(--cinder-text-sm);
+    padding: var(--cinder-space-2);
+    pointer-events: none;
+  }
 }

--- a/packages/components/src/components/aspect-ratio/aspect-ratio.css
+++ b/packages/components/src/components/aspect-ratio/aspect-ratio.css
@@ -1,14 +1,16 @@
-.cinder-aspect-ratio {
-  display: block;
-  position: relative;
-  inline-size: 100%;
-  aspect-ratio: 16/9;
-}
+@layer cinder.components {
+  .cinder-aspect-ratio {
+    display: block;
+    position: relative;
+    inline-size: 100%;
+    aspect-ratio: 16/9;
+  }
 
-.cinder-aspect-ratio[data-cinder-overflow='hidden'] {
-  overflow: hidden;
-}
+  .cinder-aspect-ratio[data-cinder-overflow='hidden'] {
+    overflow: hidden;
+  }
 
-.cinder-aspect-ratio[data-cinder-overflow='visible'] {
-  overflow: visible;
+  .cinder-aspect-ratio[data-cinder-overflow='visible'] {
+    overflow: visible;
+  }
 }

--- a/packages/components/src/components/autocomplete/autocomplete.css
+++ b/packages/components/src/components/autocomplete/autocomplete.css
@@ -1,88 +1,90 @@
-.cinder-autocomplete {
-  display: grid;
-  gap: var(--cinder-space-2);
-}
+@layer cinder.components {
+  .cinder-autocomplete {
+    display: grid;
+    gap: var(--cinder-space-2);
+  }
 
-.cinder-autocomplete__label {
-  color: var(--cinder-text);
-  font-size: var(--cinder-text-sm);
-  font-weight: var(--cinder-font-weight-medium);
-}
+  .cinder-autocomplete__label {
+    color: var(--cinder-text);
+    font-size: var(--cinder-text-sm);
+    font-weight: var(--cinder-font-weight-medium);
+  }
 
-.cinder-autocomplete__input {
-  width: 100%;
-  min-height: 2.5rem;
-  padding: 0.625rem 0.75rem;
-  border: 1px solid var(--cinder-border);
-  border-radius: var(--cinder-radius-md);
-  background: var(--cinder-surface);
-  color: var(--cinder-text);
-  font: inherit;
-}
+  .cinder-autocomplete__input {
+    width: 100%;
+    min-height: 2.5rem;
+    padding: 0.625rem 0.75rem;
+    border: 1px solid var(--cinder-border);
+    border-radius: var(--cinder-radius-md);
+    background: var(--cinder-surface);
+    color: var(--cinder-text);
+    font: inherit;
+  }
 
-.cinder-autocomplete__input:focus-visible {
-  outline: var(--cinder-ring-width) solid transparent;
-  box-shadow: var(--_cinder-focus-ring-shadow);
-}
+  .cinder-autocomplete__input:focus-visible {
+    outline: var(--cinder-ring-width) solid transparent;
+    box-shadow: var(--_cinder-focus-ring-shadow);
+  }
 
-.cinder-autocomplete__description,
-.cinder-autocomplete__error {
-  margin: 0;
-  font-size: var(--cinder-text-sm);
-  line-height: var(--cinder-leading-normal);
-}
+  .cinder-autocomplete__description,
+  .cinder-autocomplete__error {
+    margin: 0;
+    font-size: var(--cinder-text-sm);
+    line-height: var(--cinder-leading-normal);
+  }
 
-.cinder-autocomplete__description {
-  color: var(--cinder-text-muted);
-}
+  .cinder-autocomplete__description {
+    color: var(--cinder-text-muted);
+  }
 
-.cinder-autocomplete__error {
-  color: var(--cinder-danger);
-}
+  .cinder-autocomplete__error {
+    color: var(--cinder-danger);
+  }
 
-.cinder-autocomplete__panel {
-  min-width: min(24rem, calc(100vw - 2rem));
-  padding: var(--cinder-space-1);
-}
+  .cinder-autocomplete__panel {
+    min-width: min(24rem, calc(100vw - 2rem));
+    padding: var(--cinder-space-1);
+  }
 
-.cinder-autocomplete__option {
-  display: grid;
-  gap: 0.125rem;
-  padding: var(--cinder-space-2) var(--cinder-space-3);
-  border-radius: var(--cinder-radius-sm);
-  color: var(--cinder-text);
-}
+  .cinder-autocomplete__option {
+    display: grid;
+    gap: 0.125rem;
+    padding: var(--cinder-space-2) var(--cinder-space-3);
+    border-radius: var(--cinder-radius-sm);
+    color: var(--cinder-text);
+  }
 
-.cinder-autocomplete__option[data-cinder-disabled] {
-  color: var(--cinder-text-muted);
-}
+  .cinder-autocomplete__option[data-cinder-disabled] {
+    color: var(--cinder-text-muted);
+  }
 
-.cinder-autocomplete__option[data-cinder-active] {
-  background: var(--cinder-surface-raised);
-}
+  .cinder-autocomplete__option[data-cinder-active] {
+    background: var(--cinder-surface-raised);
+  }
 
-.cinder-autocomplete__option-text {
-  display: grid;
-  gap: 0.125rem;
-}
+  .cinder-autocomplete__option-text {
+    display: grid;
+    gap: 0.125rem;
+  }
 
-.cinder-autocomplete__option-label {
-  font-weight: var(--cinder-font-weight-medium);
-}
+  .cinder-autocomplete__option-label {
+    font-weight: var(--cinder-font-weight-medium);
+  }
 
-.cinder-autocomplete__option-description {
-  color: var(--cinder-text-muted);
-  font-size: var(--cinder-text-sm);
-}
+  .cinder-autocomplete__option-description {
+    color: var(--cinder-text-muted);
+    font-size: var(--cinder-text-sm);
+  }
 
-.cinder-autocomplete__match {
-  padding: 0;
-  background: oklch(from var(--cinder-warning) 96.5% 0.015 h);
-  color: inherit;
-}
+  .cinder-autocomplete__match {
+    padding: 0;
+    background: oklch(from var(--cinder-warning) 96.5% 0.015 h);
+    color: inherit;
+  }
 
-.cinder-autocomplete__status {
-  padding: var(--cinder-space-2) var(--cinder-space-3);
-  color: var(--cinder-text-muted);
-  font-size: var(--cinder-text-sm);
+  .cinder-autocomplete__status {
+    padding: var(--cinder-space-2) var(--cinder-space-3);
+    color: var(--cinder-text-muted);
+    font-size: var(--cinder-text-sm);
+  }
 }

--- a/packages/components/src/components/avatar-group/avatar-group.css
+++ b/packages/components/src/components/avatar-group/avatar-group.css
@@ -1,102 +1,105 @@
-/* ========================================
+@layer cinder.components {
+  /* ========================================
  * AVATAR GROUP
  * Overlapping collaborator stack built from Avatar.
  * ======================================== */
 
-.cinder-avatar-group {
-  --cinder-avatar-group-overlap: 0.75rem;
+  .cinder-avatar-group {
+    --cinder-avatar-group-overlap: 0.75rem;
 
-  display: inline-flex;
-  align-items: center;
-  isolation: isolate;
-}
+    display: inline-flex;
+    align-items: center;
+    isolation: isolate;
+  }
 
-.cinder-avatar-group__item {
-  position: relative;
-  z-index: var(--cinder-avatar-group-index, 0);
+  .cinder-avatar-group__item {
+    position: relative;
+    z-index: var(--cinder-avatar-group-index, 0);
 
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  flex: 0 0 auto;
-}
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    flex: 0 0 auto;
+  }
 
-.cinder-avatar-group__item:focus-within {
-  z-index: calc(var(--cinder-avatar-group-index, 0) + 100);
-}
+  .cinder-avatar-group__item:focus-within {
+    z-index: calc(var(--cinder-avatar-group-index, 0) + 100);
+  }
 
-.cinder-avatar-group__item + .cinder-avatar-group__item {
-  margin-inline-start: calc(var(--cinder-avatar-group-overlap) * -1);
-}
+  .cinder-avatar-group__item + .cinder-avatar-group__item {
+    margin-inline-start: calc(var(--cinder-avatar-group-overlap) * -1);
+  }
 
-.cinder-avatar-group__trigger {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  border-radius: var(--cinder-radius-full);
-}
+  .cinder-avatar-group__trigger {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: var(--cinder-radius-full);
+  }
 
-.cinder-avatar-group[data-cinder-shape='square'] .cinder-avatar-group__trigger {
-  border-radius: var(--cinder-radius-md);
-}
+  .cinder-avatar-group[data-cinder-shape='square'] .cinder-avatar-group__trigger {
+    border-radius: var(--cinder-radius-md);
+  }
 
-.cinder-avatar-group__trigger:focus-visible {
-  outline: none;
-  box-shadow:
-    0 0 0 var(--cinder-ring-offset-width) var(--cinder-ring-offset-color),
-    0 0 0 calc(var(--cinder-ring-offset-width) + var(--cinder-ring-width)) var(--cinder-ring-color);
-}
-
-.cinder-avatar-group__overflow {
-  width: 2.5rem;
-  height: 2.5rem;
-  border: 1px solid var(--cinder-border-muted);
-  border-radius: var(--cinder-radius-full);
-  background: var(--cinder-surface-raised);
-  color: var(--cinder-text-muted);
-  font-size: var(--cinder-text-sm);
-  font-weight: var(--cinder-font-medium);
-  box-shadow: var(--cinder-shadow-sm);
-}
-
-.cinder-avatar-group[data-cinder-shape='square'] .cinder-avatar-group__overflow {
-  border-radius: var(--cinder-radius-md);
-}
-
-.cinder-avatar-group[data-cinder-size='xs'] .cinder-avatar-group__overflow {
-  width: 1.5rem;
-  height: 1.5rem;
-  font-size: var(--cinder-text-xs);
-}
-
-.cinder-avatar-group[data-cinder-size='sm'] .cinder-avatar-group__overflow {
-  width: 2rem;
-  height: 2rem;
-  font-size: var(--cinder-text-xs);
-}
-
-.cinder-avatar-group[data-cinder-size='md'] .cinder-avatar-group__overflow {
-  width: 2.5rem;
-  height: 2.5rem;
-  font-size: var(--cinder-text-sm);
-}
-
-.cinder-avatar-group[data-cinder-size='lg'] .cinder-avatar-group__overflow {
-  width: 3rem;
-  height: 3rem;
-  font-size: var(--cinder-text-base);
-}
-
-.cinder-avatar-group[data-cinder-size='xl'] .cinder-avatar-group__overflow {
-  width: 4rem;
-  height: 4rem;
-  font-size: var(--cinder-text-lg);
-}
-
-@media (forced-colors: active) {
   .cinder-avatar-group__trigger:focus-visible {
-    outline: 2px solid CanvasText;
-    outline-offset: 2px;
-    box-shadow: none;
+    outline: none;
+    box-shadow:
+      0 0 0 var(--cinder-ring-offset-width) var(--cinder-ring-offset-color),
+      0 0 0 calc(var(--cinder-ring-offset-width) + var(--cinder-ring-width))
+        var(--cinder-ring-color);
+  }
+
+  .cinder-avatar-group__overflow {
+    width: 2.5rem;
+    height: 2.5rem;
+    border: 1px solid var(--cinder-border-muted);
+    border-radius: var(--cinder-radius-full);
+    background: var(--cinder-surface-raised);
+    color: var(--cinder-text-muted);
+    font-size: var(--cinder-text-sm);
+    font-weight: var(--cinder-font-medium);
+    box-shadow: var(--cinder-shadow-sm);
+  }
+
+  .cinder-avatar-group[data-cinder-shape='square'] .cinder-avatar-group__overflow {
+    border-radius: var(--cinder-radius-md);
+  }
+
+  .cinder-avatar-group[data-cinder-size='xs'] .cinder-avatar-group__overflow {
+    width: 1.5rem;
+    height: 1.5rem;
+    font-size: var(--cinder-text-xs);
+  }
+
+  .cinder-avatar-group[data-cinder-size='sm'] .cinder-avatar-group__overflow {
+    width: 2rem;
+    height: 2rem;
+    font-size: var(--cinder-text-xs);
+  }
+
+  .cinder-avatar-group[data-cinder-size='md'] .cinder-avatar-group__overflow {
+    width: 2.5rem;
+    height: 2.5rem;
+    font-size: var(--cinder-text-sm);
+  }
+
+  .cinder-avatar-group[data-cinder-size='lg'] .cinder-avatar-group__overflow {
+    width: 3rem;
+    height: 3rem;
+    font-size: var(--cinder-text-base);
+  }
+
+  .cinder-avatar-group[data-cinder-size='xl'] .cinder-avatar-group__overflow {
+    width: 4rem;
+    height: 4rem;
+    font-size: var(--cinder-text-lg);
+  }
+
+  @media (forced-colors: active) {
+    .cinder-avatar-group__trigger:focus-visible {
+      outline: 2px solid CanvasText;
+      outline-offset: 2px;
+      box-shadow: none;
+    }
   }
 }

--- a/packages/components/src/components/avatar/avatar.css
+++ b/packages/components/src/components/avatar/avatar.css
@@ -1,73 +1,75 @@
-/* ========================================
+@layer cinder.components {
+  /* ========================================
  * AVATAR
  * Image with initials fallback. Sizes: xs|sm|md|lg|xl. Shapes: circle|square.
  * ======================================== */
 
-.cinder-avatar {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  overflow: hidden;
-  background: var(--cinder-surface-inset);
-  color: var(--cinder-text-muted);
-  font-weight: var(--cinder-font-medium);
-  user-select: none;
-  flex-shrink: 0;
-}
+  .cinder-avatar {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    overflow: hidden;
+    background: var(--cinder-surface-inset);
+    color: var(--cinder-text-muted);
+    font-weight: var(--cinder-font-medium);
+    user-select: none;
+    flex-shrink: 0;
+  }
 
-.cinder-avatar[data-cinder-shape='circle'] {
-  border-radius: var(--cinder-radius-full);
-}
+  .cinder-avatar[data-cinder-shape='circle'] {
+    border-radius: var(--cinder-radius-full);
+  }
 
-.cinder-avatar[data-cinder-shape='square'] {
-  border-radius: var(--cinder-radius-md);
-}
+  .cinder-avatar[data-cinder-shape='square'] {
+    border-radius: var(--cinder-radius-md);
+  }
 
-.cinder-avatar[data-cinder-size='xs'] {
-  width: 1.5rem;
-  height: 1.5rem;
-  font-size: var(--cinder-text-xs);
-}
+  .cinder-avatar[data-cinder-size='xs'] {
+    width: 1.5rem;
+    height: 1.5rem;
+    font-size: var(--cinder-text-xs);
+  }
 
-.cinder-avatar[data-cinder-size='sm'] {
-  width: 2rem;
-  height: 2rem;
-  font-size: var(--cinder-text-xs);
-}
+  .cinder-avatar[data-cinder-size='sm'] {
+    width: 2rem;
+    height: 2rem;
+    font-size: var(--cinder-text-xs);
+  }
 
-.cinder-avatar[data-cinder-size='md'] {
-  width: 2.5rem;
-  height: 2.5rem;
-  font-size: var(--cinder-text-sm);
-}
+  .cinder-avatar[data-cinder-size='md'] {
+    width: 2.5rem;
+    height: 2.5rem;
+    font-size: var(--cinder-text-sm);
+  }
 
-.cinder-avatar[data-cinder-size='lg'] {
-  width: 3rem;
-  height: 3rem;
-  font-size: var(--cinder-text-base);
-}
+  .cinder-avatar[data-cinder-size='lg'] {
+    width: 3rem;
+    height: 3rem;
+    font-size: var(--cinder-text-base);
+  }
 
-.cinder-avatar[data-cinder-size='xl'] {
-  width: 4rem;
-  height: 4rem;
-  font-size: var(--cinder-text-lg);
-}
+  .cinder-avatar[data-cinder-size='xl'] {
+    width: 4rem;
+    height: 4rem;
+    font-size: var(--cinder-text-lg);
+  }
 
-.cinder-avatar__image {
-  width: 100%;
-  height: 100%;
-  object-fit: cover;
-  display: block;
-}
+  .cinder-avatar__image {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    display: block;
+  }
 
-.cinder-avatar__initials {
-  text-transform: uppercase;
-  letter-spacing: var(--cinder-tracking-wide);
-}
+  .cinder-avatar__initials {
+    text-transform: uppercase;
+    letter-spacing: var(--cinder-tracking-wide);
+  }
 
-.cinder-avatar__placeholder {
-  width: 100%;
-  height: 100%;
-  background: var(--cinder-surface-inset);
-  border: 1px solid var(--cinder-border-muted);
+  .cinder-avatar__placeholder {
+    width: 100%;
+    height: 100%;
+    background: var(--cinder-surface-inset);
+    border: 1px solid var(--cinder-border-muted);
+  }
 }

--- a/packages/components/src/components/badge/badge.css
+++ b/packages/components/src/components/badge/badge.css
@@ -1,82 +1,84 @@
-/* ========================================
+@layer cinder.components {
+  /* ========================================
  * BADGE
  * ======================================== */
 
-.cinder-badge {
-  display: inline-flex;
-  align-items: center;
-  gap: var(--cinder-space-1);
-  padding: var(--cinder-space-0-5) var(--cinder-space-2);
-  font-size: var(--cinder-text-xs);
-  font-weight: var(--cinder-font-medium);
-  line-height: 1.25;
-  border-radius: var(--cinder-radius-sm);
-  border: 1px solid var(--cinder-border);
-  white-space: nowrap;
+  .cinder-badge {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--cinder-space-1);
+    padding: var(--cinder-space-0-5) var(--cinder-space-2);
+    font-size: var(--cinder-text-xs);
+    font-weight: var(--cinder-font-medium);
+    line-height: 1.25;
+    border-radius: var(--cinder-radius-sm);
+    border: 1px solid var(--cinder-border);
+    white-space: nowrap;
 
-  background: var(--cinder-surface-inset);
-  color: var(--cinder-text);
+    background: var(--cinder-surface-inset);
+    color: var(--cinder-text);
 
-  transition: background-color var(--cinder-duration-fast) var(--cinder-ease-standard);
-}
+    transition: background-color var(--cinder-duration-fast) var(--cinder-ease-standard);
+  }
 
-/* ----------------------------------------
+  /* ----------------------------------------
  * Size variants
  * ---------------------------------------- */
 
-.cinder-badge[data-cinder-size='xs'] {
-  font-size: 0.625rem; /* 10px — smaller than 2xs (11px) for icon-button count badges */
-  padding: 0 var(--cinder-space-1);
-  line-height: 0.875rem;
-}
+  .cinder-badge[data-cinder-size='xs'] {
+    font-size: 0.625rem; /* 10px — smaller than 2xs (11px) for icon-button count badges */
+    padding: 0 var(--cinder-space-1);
+    line-height: 0.875rem;
+  }
 
-.cinder-badge[data-cinder-size='sm'] {
-  font-size: var(--cinder-text-2xs, 0.625rem);
-  padding: 0 var(--cinder-space-1);
-  line-height: 1rem;
-}
+  .cinder-badge[data-cinder-size='sm'] {
+    font-size: var(--cinder-text-2xs, 0.625rem);
+    padding: 0 var(--cinder-space-1);
+    line-height: 1rem;
+  }
 
-.cinder-badge[data-cinder-size='md'] {
-  font-size: var(--cinder-text-xs);
-  padding: var(--cinder-space-0-5) var(--cinder-space-2);
-}
+  .cinder-badge[data-cinder-size='md'] {
+    font-size: var(--cinder-text-xs);
+    padding: var(--cinder-space-0-5) var(--cinder-space-2);
+  }
 
-/* ----------------------------------------
+  /* ----------------------------------------
  * Color variants
  * ---------------------------------------- */
 
-.cinder-badge[data-cinder-variant='neutral'] {
-  background: var(--cinder-surface-inset);
-  color: var(--cinder-text);
-  border-color: var(--cinder-border);
-}
+  .cinder-badge[data-cinder-variant='neutral'] {
+    background: var(--cinder-surface-inset);
+    color: var(--cinder-text);
+    border-color: var(--cinder-border);
+  }
 
-.cinder-badge[data-cinder-variant='success'] {
-  background: var(--cinder-color-success-bg);
-  color: var(--cinder-color-success-fg);
-  border-color: var(--cinder-color-success-border);
-}
+  .cinder-badge[data-cinder-variant='success'] {
+    background: var(--cinder-color-success-bg);
+    color: var(--cinder-color-success-fg);
+    border-color: var(--cinder-color-success-border);
+  }
 
-.cinder-badge[data-cinder-variant='warning'] {
-  background: var(--cinder-color-warning-bg);
-  color: var(--cinder-color-warning-fg);
-  border-color: var(--cinder-color-warning-border);
-}
+  .cinder-badge[data-cinder-variant='warning'] {
+    background: var(--cinder-color-warning-bg);
+    color: var(--cinder-color-warning-fg);
+    border-color: var(--cinder-color-warning-border);
+  }
 
-.cinder-badge[data-cinder-variant='danger'] {
-  background: var(--cinder-color-danger-bg);
-  color: var(--cinder-color-danger-fg);
-  border-color: var(--cinder-color-danger-border);
-}
+  .cinder-badge[data-cinder-variant='danger'] {
+    background: var(--cinder-color-danger-bg);
+    color: var(--cinder-color-danger-fg);
+    border-color: var(--cinder-color-danger-border);
+  }
 
-.cinder-badge[data-cinder-variant='info'] {
-  background: var(--cinder-color-info-bg);
-  color: var(--cinder-color-info-fg);
-  border-color: var(--cinder-color-info-border);
-}
+  .cinder-badge[data-cinder-variant='info'] {
+    background: var(--cinder-color-info-bg);
+    color: var(--cinder-color-info-fg);
+    border-color: var(--cinder-color-info-border);
+  }
 
-.cinder-badge[data-cinder-variant='accent'] {
-  background: color-mix(in oklch, var(--cinder-accent), transparent 88%);
-  color: var(--cinder-accent);
-  border-color: color-mix(in oklch, var(--cinder-accent), transparent 60%);
+  .cinder-badge[data-cinder-variant='accent'] {
+    background: color-mix(in oklch, var(--cinder-accent), transparent 88%);
+    color: var(--cinder-accent);
+    border-color: color-mix(in oklch, var(--cinder-accent), transparent 60%);
+  }
 }

--- a/packages/components/src/components/banner/banner.css
+++ b/packages/components/src/components/banner/banner.css
@@ -1,4 +1,5 @@
-/* ========================================
+@layer cinder.components {
+  /* ========================================
  * BANNER
  * ----------------------------------------
  * Full-width, page-level notification strip. Stretches the inline size of
@@ -9,82 +10,82 @@
  * must be gated on `prefers-reduced-motion: no-preference`.
  * ======================================== */
 
-.cinder-banner {
-  display: flex;
-  align-items: center;
-  gap: var(--cinder-space-3);
-  inline-size: 100%;
-  padding-block: var(--cinder-space-3);
-  padding-inline: var(--cinder-space-4);
-  border-block: 1px solid var(--cinder-border);
-  background: var(--cinder-surface);
-  color: var(--cinder-text);
-  font-size: var(--cinder-text-sm);
-  line-height: var(--cinder-leading-normal);
-}
-
-@media (prefers-reduced-motion: no-preference) {
   .cinder-banner {
-    transition:
-      background-color var(--cinder-duration-fast) var(--cinder-ease-standard),
-      border-color var(--cinder-duration-fast) var(--cinder-ease-standard);
+    display: flex;
+    align-items: center;
+    gap: var(--cinder-space-3);
+    inline-size: 100%;
+    padding-block: var(--cinder-space-3);
+    padding-inline: var(--cinder-space-4);
+    border-block: 1px solid var(--cinder-border);
+    background: var(--cinder-surface);
+    color: var(--cinder-text);
+    font-size: var(--cinder-text-sm);
+    line-height: var(--cinder-leading-normal);
   }
-}
 
-/* ----------------------------------------
+  @media (prefers-reduced-motion: no-preference) {
+    .cinder-banner {
+      transition:
+        background-color var(--cinder-duration-fast) var(--cinder-ease-standard),
+        border-color var(--cinder-duration-fast) var(--cinder-ease-standard);
+    }
+  }
+
+  /* ----------------------------------------
  * Content area
  * ---------------------------------------- */
 
-.cinder-banner__content {
-  flex: 1;
-  min-width: 0;
-}
+  .cinder-banner__content {
+    flex: 1;
+    min-width: 0;
+  }
 
-/* ----------------------------------------
+  /* ----------------------------------------
  * Actions region
  * ---------------------------------------- */
 
-.cinder-banner__actions {
-  display: inline-flex;
-  align-items: center;
-  gap: var(--cinder-space-2);
-  flex-shrink: 0;
-}
+  .cinder-banner__actions {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--cinder-space-2);
+    flex-shrink: 0;
+  }
 
-/* ----------------------------------------
+  /* ----------------------------------------
  * Dismiss button
  * Mirrors .cinder-alert__dismiss rule-for-rule.
  * ---------------------------------------- */
 
-/* Box-model reset, hit-area, and idle :hover live on .cinder-_dismiss-button
+  /* Box-model reset, hit-area, and idle :hover live on .cinder-_dismiss-button
  * (see src/styles/components.css). Only Banner-specific layout positioning,
  * the motion-gated transition, and status-driven focus chrome live here. */
-.cinder-banner__dismiss {
-  align-self: center;
-}
-
-@media (prefers-reduced-motion: no-preference) {
   .cinder-banner__dismiss {
-    transition:
-      background-color var(--cinder-duration-fast) var(--cinder-ease-standard),
-      box-shadow var(--cinder-duration-fast) var(--cinder-ease-standard);
+    align-self: center;
   }
-}
 
-.cinder-banner__dismiss:focus-visible {
-  outline: var(--cinder-ring-width) solid transparent;
-  box-shadow:
-    0 0 0 var(--cinder-ring-offset) var(--cinder-ring-offset-color),
-    0 0 0 calc(var(--cinder-ring-offset) + var(--cinder-ring-width))
-      var(--_cinder-banner-ring, var(--cinder-ring-color));
-}
+  @media (prefers-reduced-motion: no-preference) {
+    .cinder-banner__dismiss {
+      transition:
+        background-color var(--cinder-duration-fast) var(--cinder-ease-standard),
+        box-shadow var(--cinder-duration-fast) var(--cinder-ease-standard);
+    }
+  }
 
-.cinder-banner__dismiss-icon {
-  width: 1rem;
-  height: 1rem;
-}
+  .cinder-banner__dismiss:focus-visible {
+    outline: var(--cinder-ring-width) solid transparent;
+    box-shadow:
+      0 0 0 var(--cinder-ring-offset) var(--cinder-ring-offset-color),
+      0 0 0 calc(var(--cinder-ring-offset) + var(--cinder-ring-width))
+        var(--_cinder-banner-ring, var(--cinder-ring-color));
+  }
 
-/* ----------------------------------------
+  .cinder-banner__dismiss-icon {
+    width: 1rem;
+    height: 1rem;
+  }
+
+  /* ----------------------------------------
  * Variant: info
  *
  * NOTE (CSS audit, Batch D): The four status variants below intentionally
@@ -96,106 +97,107 @@
  * docs/css-audit/status-triple-equivalence.md for the full pre-flight table.
  * ---------------------------------------- */
 
-.cinder-banner[data-cinder-variant='info'] {
-  --_cinder-banner-ring: var(--cinder-info);
+  .cinder-banner[data-cinder-variant='info'] {
+    --_cinder-banner-ring: var(--cinder-info);
 
-  background-color: light-dark(
-    oklch(from var(--cinder-info) 96.5% 0.015 h),
-    oklch(from var(--cinder-info) 20% 0.03 h)
-  );
-  border-color: light-dark(
-    oklch(from var(--cinder-info) 85% 0.05 h),
-    oklch(from var(--cinder-info) 35% 0.08 h)
-  );
-  color: light-dark(
-    oklch(from var(--cinder-info) 35% 0.12 h),
-    oklch(from var(--cinder-info) 88% 0.12 h)
-  );
-}
+    background-color: light-dark(
+      oklch(from var(--cinder-info) 96.5% 0.015 h),
+      oklch(from var(--cinder-info) 20% 0.03 h)
+    );
+    border-color: light-dark(
+      oklch(from var(--cinder-info) 85% 0.05 h),
+      oklch(from var(--cinder-info) 35% 0.08 h)
+    );
+    color: light-dark(
+      oklch(from var(--cinder-info) 35% 0.12 h),
+      oklch(from var(--cinder-info) 88% 0.12 h)
+    );
+  }
 
-/* ----------------------------------------
+  /* ----------------------------------------
  * Variant: success
  * ---------------------------------------- */
 
-.cinder-banner[data-cinder-variant='success'] {
-  --_cinder-banner-ring: var(--cinder-success);
+  .cinder-banner[data-cinder-variant='success'] {
+    --_cinder-banner-ring: var(--cinder-success);
 
-  background-color: light-dark(
-    oklch(from var(--cinder-success) 96.5% 0.015 h),
-    oklch(from var(--cinder-success) 20% 0.03 h)
-  );
-  border-color: light-dark(
-    oklch(from var(--cinder-success) 85% 0.05 h),
-    oklch(from var(--cinder-success) 35% 0.08 h)
-  );
-  color: light-dark(
-    oklch(from var(--cinder-success) 35% 0.14 h),
-    oklch(from var(--cinder-success) 88% 0.12 h)
-  );
-}
+    background-color: light-dark(
+      oklch(from var(--cinder-success) 96.5% 0.015 h),
+      oklch(from var(--cinder-success) 20% 0.03 h)
+    );
+    border-color: light-dark(
+      oklch(from var(--cinder-success) 85% 0.05 h),
+      oklch(from var(--cinder-success) 35% 0.08 h)
+    );
+    color: light-dark(
+      oklch(from var(--cinder-success) 35% 0.14 h),
+      oklch(from var(--cinder-success) 88% 0.12 h)
+    );
+  }
 
-/* ----------------------------------------
+  /* ----------------------------------------
  * Variant: warning
  * ---------------------------------------- */
 
-.cinder-banner[data-cinder-variant='warning'] {
-  --_cinder-banner-ring: var(--cinder-warning);
+  .cinder-banner[data-cinder-variant='warning'] {
+    --_cinder-banner-ring: var(--cinder-warning);
 
-  background-color: light-dark(
-    oklch(from var(--cinder-warning) 96.5% 0.015 h),
-    oklch(from var(--cinder-warning) 20% 0.03 h)
-  );
-  border-color: light-dark(
-    oklch(from var(--cinder-warning) 85% 0.05 h),
-    oklch(from var(--cinder-warning) 35% 0.08 h)
-  );
-  color: light-dark(
-    oklch(from var(--cinder-warning) 35% 0.16 h),
-    oklch(from var(--cinder-warning) 88% 0.14 h)
-  );
-}
+    background-color: light-dark(
+      oklch(from var(--cinder-warning) 96.5% 0.015 h),
+      oklch(from var(--cinder-warning) 20% 0.03 h)
+    );
+    border-color: light-dark(
+      oklch(from var(--cinder-warning) 85% 0.05 h),
+      oklch(from var(--cinder-warning) 35% 0.08 h)
+    );
+    color: light-dark(
+      oklch(from var(--cinder-warning) 35% 0.16 h),
+      oklch(from var(--cinder-warning) 88% 0.14 h)
+    );
+  }
 
-/* ----------------------------------------
+  /* ----------------------------------------
  * Variant: danger
  * ---------------------------------------- */
 
-.cinder-banner[data-cinder-variant='danger'] {
-  --_cinder-banner-ring: var(--cinder-danger);
+  .cinder-banner[data-cinder-variant='danger'] {
+    --_cinder-banner-ring: var(--cinder-danger);
 
-  background-color: light-dark(
-    oklch(from var(--cinder-danger) 96.5% 0.015 h),
-    oklch(from var(--cinder-danger) 20% 0.03 h)
-  );
-  border-color: light-dark(
-    oklch(from var(--cinder-danger) 85% 0.05 h),
-    oklch(from var(--cinder-danger) 35% 0.08 h)
-  );
-  color: light-dark(
-    oklch(from var(--cinder-danger) 35% 0.18 h),
-    oklch(from var(--cinder-danger) 88% 0.16 h)
-  );
-}
+    background-color: light-dark(
+      oklch(from var(--cinder-danger) 96.5% 0.015 h),
+      oklch(from var(--cinder-danger) 20% 0.03 h)
+    );
+    border-color: light-dark(
+      oklch(from var(--cinder-danger) 85% 0.05 h),
+      oklch(from var(--cinder-danger) 35% 0.08 h)
+    );
+    color: light-dark(
+      oklch(from var(--cinder-danger) 35% 0.18 h),
+      oklch(from var(--cinder-danger) 88% 0.16 h)
+    );
+  }
 
-/* ----------------------------------------
+  /* ----------------------------------------
  * Forced-colors / high-contrast
  * ---------------------------------------- */
 
-@media (forced-colors: active) {
-  .cinder-banner {
-    border-block: 1px solid CanvasText;
-  }
-
-  /* `color-mix` against transparent is unreliable in forced-colors mode; pin to ButtonFace.
-   * Nested under @media (hover: hover) to suppress sticky-hover on touch. */
-  @media (hover: hover) {
-    .cinder-banner__dismiss:hover {
-      background: ButtonFace;
+  @media (forced-colors: active) {
+    .cinder-banner {
+      border-block: 1px solid CanvasText;
     }
-  }
 
-  .cinder-banner__dismiss:focus-visible {
-    outline: var(--cinder-ring-width) solid ButtonText;
-    outline-offset: 3px;
-    box-shadow: none;
+    /* `color-mix` against transparent is unreliable in forced-colors mode; pin to ButtonFace.
+   * Nested under @media (hover: hover) to suppress sticky-hover on touch. */
+    @media (hover: hover) {
+      .cinder-banner__dismiss:hover {
+        background: ButtonFace;
+      }
+    }
+
+    .cinder-banner__dismiss:focus-visible {
+      outline: var(--cinder-ring-width) solid ButtonText;
+      outline-offset: 3px;
+      box-shadow: none;
+    }
   }
 }

--- a/packages/components/src/components/bar-chart/bar-chart.css
+++ b/packages/components/src/components/bar-chart/bar-chart.css
@@ -1,109 +1,111 @@
-.cinder-bar-chart {
-  display: grid;
-  gap: var(--cinder-space-3);
-  color: var(--cinder-text);
-}
+@layer cinder.components {
+  .cinder-bar-chart {
+    display: grid;
+    gap: var(--cinder-space-3);
+    color: var(--cinder-text);
+  }
 
-.cinder-bar-chart__description {
-  margin: 0;
-  color: var(--cinder-text-muted);
-  font-size: var(--cinder-text-sm);
-}
+  .cinder-bar-chart__description {
+    margin: 0;
+    color: var(--cinder-text-muted);
+    font-size: var(--cinder-text-sm);
+  }
 
-.cinder-bar-chart__legend {
-  display: flex;
-  flex-wrap: wrap;
-  gap: var(--cinder-space-2);
-}
+  .cinder-bar-chart__legend {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--cinder-space-2);
+  }
 
-.cinder-bar-chart__legend button {
-  display: inline-flex;
-  align-items: center;
-  gap: var(--cinder-space-1);
-  border: 1px solid var(--cinder-border-muted);
-  border-radius: var(--cinder-radius-sm);
-  background: var(--cinder-surface);
-  color: var(--cinder-text);
-  cursor: pointer;
-  font: inherit;
-  font-size: var(--cinder-text-sm);
-  padding: var(--cinder-space-1) var(--cinder-space-2);
-}
+  .cinder-bar-chart__legend button {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--cinder-space-1);
+    border: 1px solid var(--cinder-border-muted);
+    border-radius: var(--cinder-radius-sm);
+    background: var(--cinder-surface);
+    color: var(--cinder-text);
+    cursor: pointer;
+    font: inherit;
+    font-size: var(--cinder-text-sm);
+    padding: var(--cinder-space-1) var(--cinder-space-2);
+  }
 
-.cinder-bar-chart__legend button[aria-pressed='false'] {
-  opacity: 0.55;
-}
+  .cinder-bar-chart__legend button[aria-pressed='false'] {
+    opacity: 0.55;
+  }
 
-.cinder-bar-chart__legend span {
-  inline-size: 0.75rem;
-  block-size: 0.75rem;
-  border-radius: var(--cinder-radius-full);
-}
+  .cinder-bar-chart__legend span {
+    inline-size: 0.75rem;
+    block-size: 0.75rem;
+    border-radius: var(--cinder-radius-full);
+  }
 
-.cinder-bar-chart__viewport {
-  position: relative;
-}
+  .cinder-bar-chart__viewport {
+    position: relative;
+  }
 
-.cinder-bar-chart svg {
-  display: block;
-  inline-size: 100%;
-  block-size: 100%;
-}
+  .cinder-bar-chart svg {
+    display: block;
+    inline-size: 100%;
+    block-size: 100%;
+  }
 
-.cinder-bar-chart__bar {
-  rx: 3;
-}
+  .cinder-bar-chart__bar {
+    rx: 3;
+  }
 
-.cinder-bar-chart__crosshair {
-  stroke: var(--cinder-text-muted);
-  stroke-dasharray: 4 4;
-}
+  .cinder-bar-chart__crosshair {
+    stroke: var(--cinder-text-muted);
+    stroke-dasharray: 4 4;
+  }
 
-.cinder-bar-chart__hit-surface {
-  fill: transparent;
-}
+  .cinder-bar-chart__hit-surface {
+    fill: transparent;
+  }
 
-.cinder-bar-chart__focus-target {
-  fill: transparent;
-  outline: none;
-  pointer-events: none;
-}
+  .cinder-bar-chart__focus-target {
+    fill: transparent;
+    outline: none;
+    pointer-events: none;
+  }
 
-/*
+  /*
  * SVG focus indicator: drop-shadow renders a visible ring around the focused
  * element on any background. Matches line-chart and area-chart.
  */
-.cinder-bar-chart__focus-target:focus-visible {
-  stroke: var(--cinder-accent);
-  stroke-width: var(--cinder-ring-width);
-  filter: drop-shadow(0 0 var(--cinder-ring-width) var(--cinder-ring-color));
-}
+  .cinder-bar-chart__focus-target:focus-visible {
+    stroke: var(--cinder-accent);
+    stroke-width: var(--cinder-ring-width);
+    filter: drop-shadow(0 0 var(--cinder-ring-width) var(--cinder-ring-color));
+  }
 
-.cinder-bar-chart__tick-label {
-  fill: var(--cinder-text-muted);
-  font-size: var(--cinder-text-xs);
-}
+  .cinder-bar-chart__tick-label {
+    fill: var(--cinder-text-muted);
+    font-size: var(--cinder-text-xs);
+  }
 
-.cinder-bar-chart__state {
-  position: absolute;
-  inset: 0;
-  display: grid;
-  place-items: center;
-  color: var(--cinder-text-muted);
-  background: color-mix(in oklch, var(--cinder-surface) 88%, transparent);
-  z-index: 1;
-}
+  .cinder-bar-chart__state {
+    position: absolute;
+    inset: 0;
+    display: grid;
+    place-items: center;
+    color: var(--cinder-text-muted);
+    background: color-mix(in oklch, var(--cinder-surface) 88%, transparent);
+    z-index: 1;
+  }
 
-.cinder-bar-chart__tooltip {
-  position: absolute;
-  transform: translate(0.5rem, -50%);
-  display: grid;
-  gap: 0.125rem;
-  border: 1px solid var(--cinder-border-muted);
-  border-radius: var(--cinder-radius-sm);
-  background: var(--cinder-surface-raised);
-  box-shadow: var(--cinder-shadow-md);
-  font-size: var(--cinder-text-sm);
-  padding: var(--cinder-space-2);
-  pointer-events: none;
+  .cinder-bar-chart__tooltip {
+    position: absolute;
+    transform: translate(0.5rem, -50%);
+    display: grid;
+    gap: 0.125rem;
+    border: 1px solid var(--cinder-border-muted);
+    border-radius: var(--cinder-radius-sm);
+    background: var(--cinder-surface-raised);
+    box-shadow: var(--cinder-shadow-md);
+    font-size: var(--cinder-text-sm);
+    padding: var(--cinder-space-2);
+    pointer-events: none;
+  }
 }

--- a/packages/components/src/components/breadcrumbs/breadcrumbs.css
+++ b/packages/components/src/components/breadcrumbs/breadcrumbs.css
@@ -1,91 +1,93 @@
-/* ========================================
+@layer cinder.components {
+  /* ========================================
  * BREADCRUMBS
  * Navigation landmark with an ordered list of links.
  * ======================================== */
 
-.cinder-breadcrumbs__list {
-  list-style: none;
-  padding: 0;
-  margin: 0;
-  display: flex;
-  align-items: center;
-  gap: var(--cinder-space-2);
-  font-size: var(--cinder-text-sm);
-  color: var(--cinder-text-muted);
-  /* Single-line stopgap: clip a long trail with an ellipsis instead of
+  .cinder-breadcrumbs__list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: flex;
+    align-items: center;
+    gap: var(--cinder-space-2);
+    font-size: var(--cinder-text-sm);
+    color: var(--cinder-text-muted);
+    /* Single-line stopgap: clip a long trail with an ellipsis instead of
      wrapping to a second row. True earliest-first priority needs the deferred
      `maxVisible` prop. */
-  overflow: hidden;
-  white-space: nowrap;
-}
+    overflow: hidden;
+    white-space: nowrap;
+  }
 
-.cinder-breadcrumbs__item {
-  display: inline-flex;
-  align-items: center;
-  gap: var(--cinder-space-2);
-  /* Ancestor crumbs shrink hard (high factor) so they absorb the overflow and
+  .cinder-breadcrumbs__item {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--cinder-space-2);
+    /* Ancestor crumbs shrink hard (high factor) so they absorb the overflow and
      ellipsize first. */
-  min-width: 0;
-  flex-shrink: 100;
-}
+    min-width: 0;
+    flex-shrink: 100;
+  }
 
-/* The last item holds the current crumb. It still shrinks — so a lone long
+  /* The last item holds the current crumb. It still shrinks — so a lone long
    current crumb ellipsizes against the container instead of hard-clipping —
    but with a far lower factor than the ancestors, so they always yield first.
    Plain flex cannot express strict source-order priority; the lopsided shrink
    factors approximate "current crumb is the priority" while guaranteeing it can
    never overflow the container without its own ellipsis engaging. */
-.cinder-breadcrumbs__item:last-child {
-  flex-shrink: 1;
-}
-
-.cinder-breadcrumbs__link {
-  min-width: 0;
-  flex: 1 1 auto;
-  color: var(--cinder-text-muted);
-  text-decoration: none;
-  border-radius: var(--cinder-radius-sm);
-  transition: color var(--cinder-duration-fast) var(--cinder-ease-standard);
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.cinder-breadcrumbs__link:hover {
-  color: var(--cinder-text);
-  text-decoration: underline;
-}
-
-.cinder-breadcrumbs__link:focus-visible {
-  outline: var(--cinder-ring-width) solid transparent;
-  box-shadow: var(--_cinder-focus-ring-shadow);
-}
-
-@media (forced-colors: active) {
-  .cinder-breadcrumbs__link:focus-visible {
-    outline: var(--cinder-ring-width) solid ButtonText;
-    outline-offset: 3px;
+  .cinder-breadcrumbs__item:last-child {
+    flex-shrink: 1;
   }
-}
 
-.cinder-breadcrumbs__current {
-  color: var(--cinder-text);
-  font-weight: var(--cinder-font-medium);
-  /* The current crumb is the priority: its low-shrink item (see `:last-child`)
+  .cinder-breadcrumbs__link {
+    min-width: 0;
+    flex: 1 1 auto;
+    color: var(--cinder-text-muted);
+    text-decoration: none;
+    border-radius: var(--cinder-radius-sm);
+    transition: color var(--cinder-duration-fast) var(--cinder-ease-standard);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .cinder-breadcrumbs__link:hover {
+    color: var(--cinder-text);
+    text-decoration: underline;
+  }
+
+  .cinder-breadcrumbs__link:focus-visible {
+    outline: var(--cinder-ring-width) solid transparent;
+    box-shadow: var(--_cinder-focus-ring-shadow);
+  }
+
+  @media (forced-colors: active) {
+    .cinder-breadcrumbs__link:focus-visible {
+      outline: var(--cinder-ring-width) solid ButtonText;
+      outline-offset: 3px;
+    }
+  }
+
+  .cinder-breadcrumbs__current {
+    color: var(--cinder-text);
+    font-weight: var(--cinder-font-medium);
+    /* The current crumb is the priority: its low-shrink item (see `:last-child`)
      makes ancestors yield first. But it must never hard-clip against the
      container edge — `max-width: 100%` plus `min-width: 0` bound it to the
      available width so its own ellipsis engages as a last resort when it alone
      exceeds the container. */
-  min-width: 0;
-  max-width: 100%;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
+    min-width: 0;
+    max-width: 100%;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
 
-.cinder-breadcrumbs__separator {
-  color: var(--cinder-text-muted);
-  user-select: none;
-  /* Separators never collapse. */
-  flex-shrink: 0;
+  .cinder-breadcrumbs__separator {
+    color: var(--cinder-text-muted);
+    user-select: none;
+    /* Separators never collapse. */
+    flex-shrink: 0;
+  }
 }

--- a/packages/components/src/components/button-group/button-group.css
+++ b/packages/components/src/components/button-group/button-group.css
@@ -1,77 +1,80 @@
-/* =========================================================
+@layer cinder.components {
+  /* =========================================================
    ButtonGroup — layout-only barrel for related action buttons
    ========================================================= */
 
-.cinder-button-group {
-  display: inline-flex;
-  align-items: stretch;
-  /* New stacking context keeps focus-ring z-index elevation local to this
+  .cinder-button-group {
+    display: inline-flex;
+    align-items: stretch;
+    /* New stacking context keeps focus-ring z-index elevation local to this
      group — a focused child in one group never paints over a sibling group. */
-  isolation: isolate;
-}
+    isolation: isolate;
+  }
 
-.cinder-button-group[data-cinder-orientation='horizontal'] {
-  flex-direction: row;
-}
+  .cinder-button-group[data-cinder-orientation='horizontal'] {
+    flex-direction: row;
+  }
 
-.cinder-button-group[data-cinder-orientation='vertical'] {
-  flex-direction: column;
-}
+  .cinder-button-group[data-cinder-orientation='vertical'] {
+    flex-direction: column;
+  }
 
-/* Position context so the focused-child z-index elevation works. */
-.cinder-button-group > [data-cinder-button-group-item] {
-  position: relative;
-  z-index: 0;
-}
+  /* Position context so the focused-child z-index elevation works. */
+  .cinder-button-group > [data-cinder-button-group-item] {
+    position: relative;
+    z-index: 0;
+  }
 
-/* Split buttons use Dropdown as the direct group participant, with the actual
+  /* Split buttons use Dropdown as the direct group participant, with the actual
    trigger button nested inside it. Make the wrapper behave like a button-shaped
    flex item so the trigger fills the grouped control instead of floating inside
    a stretched inline-block. */
-.cinder-button-group > .cinder-dropdown[data-cinder-button-group-item] {
-  display: inline-flex;
-}
+  .cinder-button-group > .cinder-dropdown[data-cinder-button-group-item] {
+    display: inline-flex;
+  }
 
-.cinder-button-group > .cinder-dropdown[data-cinder-button-group-item] > .cinder-dropdown-trigger {
-  min-block-size: 100%;
-}
+  .cinder-button-group
+    > .cinder-dropdown[data-cinder-button-group-item]
+    > .cinder-dropdown-trigger {
+    min-block-size: 100%;
+  }
 
-/* Elevate the hovered/focused participant so its focus ring paints over
+  /* Elevate the hovered/focused participant so its focus ring paints over
    adjacent buttons' borders and is never clipped. */
-.cinder-button-group > [data-cinder-button-group-item]:where(:hover, :focus-within) {
-  z-index: 1;
-}
+  .cinder-button-group > [data-cinder-button-group-item]:where(:hover, :focus-within) {
+    z-index: 1;
+  }
 
-/* ── Border collapse via seam on the group-item pseudo-element ────────── */
-/* Negative-margin overlap let a transparent-bordered variant (primary/danger)
+  /* ── Border collapse via seam on the group-item pseudo-element ────────── */
+  /* Negative-margin overlap let a transparent-bordered variant (primary/danger)
  * notch the shared hairline against a bordered one (secondary). Instead each
  * non-first item paints one deterministic 1px seam on its inner edge via a
  * ::before pseudo-element owned by the group. Drawn on the item wrapper, not
  * the button, so it never competes with the button's focus-ring box-shadow and
  * never doubles with the button's own border. */
-.cinder-button-group > [data-cinder-button-group-item]:not(:first-child)::before {
-  content: '';
-  position: absolute;
-  z-index: 1;
-  background: var(--cinder-border);
-  pointer-events: none;
-}
+  .cinder-button-group > [data-cinder-button-group-item]:not(:first-child)::before {
+    content: '';
+    position: absolute;
+    z-index: 1;
+    background: var(--cinder-border);
+    pointer-events: none;
+  }
 
-.cinder-button-group[data-cinder-orientation='horizontal']
-  > [data-cinder-button-group-item]:not(:first-child)::before {
-  inset-block: 0;
-  inset-inline-start: 0;
-  inline-size: 1px;
-}
+  .cinder-button-group[data-cinder-orientation='horizontal']
+    > [data-cinder-button-group-item]:not(:first-child)::before {
+    inset-block: 0;
+    inset-inline-start: 0;
+    inline-size: 1px;
+  }
 
-.cinder-button-group[data-cinder-orientation='vertical']
-  > [data-cinder-button-group-item]:not(:first-child)::before {
-  inset-inline: 0;
-  inset-block-start: 0;
-  block-size: 1px;
-}
+  .cinder-button-group[data-cinder-orientation='vertical']
+    > [data-cinder-button-group-item]:not(:first-child)::before {
+    inset-inline: 0;
+    inset-block-start: 0;
+    block-size: 1px;
+  }
 
-/* On the FOCUSED participant only, drop its own seam so the focus ring is never
+  /* On the FOCUSED participant only, drop its own seam so the focus ring is never
  * overpainted by a 1px line. Scoped to :focus-within — NOT :hover — because only
  * focus paints a ring that needs protecting; hovering must keep the seam visible
  * (hover has no ring, so suppressing it there would simply erase the junction
@@ -79,11 +82,11 @@
  * :where(:hover,:focus-within) rule above, so its ring additionally paints over
  * the neighbor item's seam. Net: a focused button shows a clean, unclipped ring;
  * every resting AND hovered junction keeps its seam. */
-.cinder-button-group > [data-cinder-button-group-item]:focus-within:not(:first-child)::before {
-  opacity: 0;
-}
+  .cinder-button-group > [data-cinder-button-group-item]:focus-within:not(:first-child)::before {
+    opacity: 0;
+  }
 
-/* Zero BOTH borders that meet at each junction so the pseudo-element line is the
+  /* Zero BOTH borders that meet at each junction so the pseudo-element line is the
  * only thing between two buttons. Uses -color: transparent (not border-width: 0)
  * to preserve box geometry so the radius-flattening rules and heights are
  * unaffected.
@@ -103,49 +106,49 @@
  * non-button item type is supported, update both rule sets together. The
  * `:not([role='menu'] *):not([role='menuitem'])` guard keeps a split-button's
  * dropdown menu items from being touched. */
-.cinder-button-group[data-cinder-orientation='horizontal']
-  > [data-cinder-button-group-item]:not(:first-child)
-  :is(.cinder-button, button):not([role='menu'] *):not([role='menuitem']),
-.cinder-button-group[data-cinder-orientation='horizontal']
-  > [data-cinder-button-group-item]:is(.cinder-button, button):not(:first-child) {
-  border-inline-start-color: transparent;
-}
+  .cinder-button-group[data-cinder-orientation='horizontal']
+    > [data-cinder-button-group-item]:not(:first-child)
+    :is(.cinder-button, button):not([role='menu'] *):not([role='menuitem']),
+  .cinder-button-group[data-cinder-orientation='horizontal']
+    > [data-cinder-button-group-item]:is(.cinder-button, button):not(:first-child) {
+    border-inline-start-color: transparent;
+  }
 
-.cinder-button-group[data-cinder-orientation='horizontal']
-  > [data-cinder-button-group-item]:not(:last-child)
-  :is(.cinder-button, button):not([role='menu'] *):not([role='menuitem']),
-.cinder-button-group[data-cinder-orientation='horizontal']
-  > [data-cinder-button-group-item]:is(.cinder-button, button):not(:last-child) {
-  border-inline-end-color: transparent;
-}
+  .cinder-button-group[data-cinder-orientation='horizontal']
+    > [data-cinder-button-group-item]:not(:last-child)
+    :is(.cinder-button, button):not([role='menu'] *):not([role='menuitem']),
+  .cinder-button-group[data-cinder-orientation='horizontal']
+    > [data-cinder-button-group-item]:is(.cinder-button, button):not(:last-child) {
+    border-inline-end-color: transparent;
+  }
 
-.cinder-button-group[data-cinder-orientation='vertical']
-  > [data-cinder-button-group-item]:not(:first-child)
-  :is(.cinder-button, button):not([role='menu'] *):not([role='menuitem']),
-.cinder-button-group[data-cinder-orientation='vertical']
-  > [data-cinder-button-group-item]:is(.cinder-button, button):not(:first-child) {
-  border-block-start-color: transparent;
-}
+  .cinder-button-group[data-cinder-orientation='vertical']
+    > [data-cinder-button-group-item]:not(:first-child)
+    :is(.cinder-button, button):not([role='menu'] *):not([role='menuitem']),
+  .cinder-button-group[data-cinder-orientation='vertical']
+    > [data-cinder-button-group-item]:is(.cinder-button, button):not(:first-child) {
+    border-block-start-color: transparent;
+  }
 
-.cinder-button-group[data-cinder-orientation='vertical']
-  > [data-cinder-button-group-item]:not(:last-child)
-  :is(.cinder-button, button):not([role='menu'] *):not([role='menuitem']),
-.cinder-button-group[data-cinder-orientation='vertical']
-  > [data-cinder-button-group-item]:is(.cinder-button, button):not(:last-child) {
-  border-block-end-color: transparent;
-}
+  .cinder-button-group[data-cinder-orientation='vertical']
+    > [data-cinder-button-group-item]:not(:last-child)
+    :is(.cinder-button, button):not([role='menu'] *):not([role='menuitem']),
+  .cinder-button-group[data-cinder-orientation='vertical']
+    > [data-cinder-button-group-item]:is(.cinder-button, button):not(:last-child) {
+    border-block-end-color: transparent;
+  }
 
-/* Forced colors: the pseudo-element background may not map to a system color,
+  /* Forced colors: the pseudo-element background may not map to a system color,
  * so remap to CanvasText. The seam-facing border stays transparent (not
  * restored) so exactly one separator renders — the pseudo-element line. */
-@media (forced-colors: active) {
-  .cinder-button-group > [data-cinder-button-group-item]:not(:first-child)::before {
-    background: CanvasText;
+  @media (forced-colors: active) {
+    .cinder-button-group > [data-cinder-button-group-item]:not(:first-child)::before {
+      background: CanvasText;
+    }
   }
-}
 
-/* ── Border-radius flattening ─────────────────────────────────────────── */
-/*
+  /* ── Border-radius flattening ─────────────────────────────────────────── */
+  /*
  * Every selector targets the visible button via :is(.cinder-button, button).
  * The :not([role='menu'] *):not([role='menuitem']) guard prevents dropdown
  * menu items from having their corners zeroed.
@@ -155,60 +158,65 @@
  * button-group can never be a menu item.
  */
 
-/* Horizontal — middle children: zero all corners. */
-.cinder-button-group[data-cinder-orientation='horizontal']
-  > [data-cinder-button-group-item]:not(:first-child):not(:last-child)
-  :is(.cinder-button, button):not([role='menu'] *):not([role='menuitem']),
-.cinder-button-group[data-cinder-orientation='horizontal']
-  > [data-cinder-button-group-item]:is(.cinder-button, button):not(:first-child):not(:last-child) {
-  border-radius: 0;
-}
+  /* Horizontal — middle children: zero all corners. */
+  .cinder-button-group[data-cinder-orientation='horizontal']
+    > [data-cinder-button-group-item]:not(:first-child):not(:last-child)
+    :is(.cinder-button, button):not([role='menu'] *):not([role='menuitem']),
+  .cinder-button-group[data-cinder-orientation='horizontal']
+    > [data-cinder-button-group-item]:is(.cinder-button, button):not(:first-child):not(
+      :last-child
+    ) {
+    border-radius: 0;
+  }
 
-/* Horizontal — first child: zero the inline-end corners. */
-.cinder-button-group[data-cinder-orientation='horizontal']
-  > [data-cinder-button-group-item]:first-child:not(:only-child)
-  :is(.cinder-button, button):not([role='menu'] *):not([role='menuitem']),
-.cinder-button-group[data-cinder-orientation='horizontal']
-  > [data-cinder-button-group-item]:is(.cinder-button, button):first-child:not(:only-child) {
-  border-start-end-radius: 0;
-  border-end-end-radius: 0;
-}
+  /* Horizontal — first child: zero the inline-end corners. */
+  .cinder-button-group[data-cinder-orientation='horizontal']
+    > [data-cinder-button-group-item]:first-child:not(:only-child)
+    :is(.cinder-button, button):not([role='menu'] *):not([role='menuitem']),
+  .cinder-button-group[data-cinder-orientation='horizontal']
+    > [data-cinder-button-group-item]:is(.cinder-button, button):first-child:not(:only-child) {
+    border-start-end-radius: 0;
+    border-end-end-radius: 0;
+  }
 
-/* Horizontal — last child: zero the inline-start corners. */
-.cinder-button-group[data-cinder-orientation='horizontal']
-  > [data-cinder-button-group-item]:last-child:not(:only-child)
-  :is(.cinder-button, button):not([role='menu'] *):not([role='menuitem']),
-.cinder-button-group[data-cinder-orientation='horizontal']
-  > [data-cinder-button-group-item]:is(.cinder-button, button):last-child:not(:only-child) {
-  border-start-start-radius: 0;
-  border-end-start-radius: 0;
-}
+  /* Horizontal — last child: zero the inline-start corners. */
+  .cinder-button-group[data-cinder-orientation='horizontal']
+    > [data-cinder-button-group-item]:last-child:not(:only-child)
+    :is(.cinder-button, button):not([role='menu'] *):not([role='menuitem']),
+  .cinder-button-group[data-cinder-orientation='horizontal']
+    > [data-cinder-button-group-item]:is(.cinder-button, button):last-child:not(:only-child) {
+    border-start-start-radius: 0;
+    border-end-start-radius: 0;
+  }
 
-/* Vertical — middle children: zero all corners. */
-.cinder-button-group[data-cinder-orientation='vertical']
-  > [data-cinder-button-group-item]:not(:first-child):not(:last-child)
-  :is(.cinder-button, button):not([role='menu'] *):not([role='menuitem']),
-.cinder-button-group[data-cinder-orientation='vertical']
-  > [data-cinder-button-group-item]:is(.cinder-button, button):not(:first-child):not(:last-child) {
-  border-radius: 0;
-}
+  /* Vertical — middle children: zero all corners. */
+  .cinder-button-group[data-cinder-orientation='vertical']
+    > [data-cinder-button-group-item]:not(:first-child):not(:last-child)
+    :is(.cinder-button, button):not([role='menu'] *):not([role='menuitem']),
+  .cinder-button-group[data-cinder-orientation='vertical']
+    > [data-cinder-button-group-item]:is(.cinder-button, button):not(:first-child):not(
+      :last-child
+    ) {
+    border-radius: 0;
+  }
 
-/* Vertical — first child: zero the block-end corners. */
-.cinder-button-group[data-cinder-orientation='vertical']
-  > [data-cinder-button-group-item]:first-child:not(:only-child)
-  :is(.cinder-button, button):not([role='menu'] *):not([role='menuitem']),
-.cinder-button-group[data-cinder-orientation='vertical']
-  > [data-cinder-button-group-item]:is(.cinder-button, button):first-child:not(:only-child) {
-  border-end-start-radius: 0;
-  border-end-end-radius: 0;
-}
+  /* Vertical — first child: zero the block-end corners. */
+  .cinder-button-group[data-cinder-orientation='vertical']
+    > [data-cinder-button-group-item]:first-child:not(:only-child)
+    :is(.cinder-button, button):not([role='menu'] *):not([role='menuitem']),
+  .cinder-button-group[data-cinder-orientation='vertical']
+    > [data-cinder-button-group-item]:is(.cinder-button, button):first-child:not(:only-child) {
+    border-end-start-radius: 0;
+    border-end-end-radius: 0;
+  }
 
-/* Vertical — last child: zero the block-start corners. */
-.cinder-button-group[data-cinder-orientation='vertical']
-  > [data-cinder-button-group-item]:last-child:not(:only-child)
-  :is(.cinder-button, button):not([role='menu'] *):not([role='menuitem']),
-.cinder-button-group[data-cinder-orientation='vertical']
-  > [data-cinder-button-group-item]:is(.cinder-button, button):last-child:not(:only-child) {
-  border-start-start-radius: 0;
-  border-start-end-radius: 0;
+  /* Vertical — last child: zero the block-start corners. */
+  .cinder-button-group[data-cinder-orientation='vertical']
+    > [data-cinder-button-group-item]:last-child:not(:only-child)
+    :is(.cinder-button, button):not([role='menu'] *):not([role='menuitem']),
+  .cinder-button-group[data-cinder-orientation='vertical']
+    > [data-cinder-button-group-item]:is(.cinder-button, button):last-child:not(:only-child) {
+    border-start-start-radius: 0;
+    border-start-end-radius: 0;
+  }
 }

--- a/packages/components/src/components/button/button.css
+++ b/packages/components/src/components/button/button.css
@@ -1,460 +1,468 @@
-/* ========================================
+@layer cinder.components {
+  /* ========================================
  * BUTTON
  * ======================================== */
 
-.cinder-button {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  gap: var(--cinder-space-1-5);
-  white-space: nowrap;
-  text-decoration: none;
+  .cinder-button {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: var(--cinder-space-1-5);
+    white-space: nowrap;
+    text-decoration: none;
 
-  font-weight: var(--cinder-font-medium);
-  font-size: var(--cinder-text-sm);
-  line-height: 1;
+    font-weight: var(--cinder-font-medium);
+    font-size: var(--cinder-text-sm);
+    line-height: 1;
 
-  background: var(--cinder-button-bg);
-  color: var(--cinder-button-fg);
-  border: 1px solid var(--cinder-button-border);
-  border-radius: var(--cinder-button-radius);
+    background: var(--cinder-button-bg);
+    color: var(--cinder-button-fg);
+    border: 1px solid var(--cinder-button-border);
+    border-radius: var(--cinder-button-radius);
 
-  cursor: pointer;
+    cursor: pointer;
 
-  transition:
-    background-color var(--cinder-duration-fast) var(--cinder-ease-standard),
-    border-color var(--cinder-duration-fast) var(--cinder-ease-standard),
-    color var(--cinder-duration-fast) var(--cinder-ease-standard),
-    box-shadow var(--cinder-duration-fast) var(--cinder-ease-standard);
-}
+    transition:
+      background-color var(--cinder-duration-fast) var(--cinder-ease-standard),
+      border-color var(--cinder-duration-fast) var(--cinder-ease-standard),
+      color var(--cinder-duration-fast) var(--cinder-ease-standard),
+      box-shadow var(--cinder-duration-fast) var(--cinder-ease-standard);
+  }
 
-.cinder-button:focus-visible {
-  outline: var(--cinder-ring-width) solid transparent;
-  box-shadow:
-    0 0 0 var(--cinder-ring-offset) var(--cinder-ring-offset-color),
-    0 0 0 calc(var(--cinder-ring-offset) + var(--cinder-ring-width))
-      var(--_cinder-button-ring, var(--cinder-ring-color));
-}
+  .cinder-button:focus-visible {
+    outline: var(--cinder-ring-width) solid transparent;
+    box-shadow:
+      0 0 0 var(--cinder-ring-offset) var(--cinder-ring-offset-color),
+      0 0 0 calc(var(--cinder-ring-offset) + var(--cinder-ring-width))
+        var(--_cinder-button-ring, var(--cinder-ring-color));
+  }
 
-/* Forced Colors Mode (Windows High Contrast, print, etc.) ignores `box-shadow`. Without this
+  /* Forced Colors Mode (Windows High Contrast, print, etc.) ignores `box-shadow`. Without this
  * override the entire focus ring is invisible to users who rely on WHCM. ButtonText is the
  * system color for text on buttons; it's guaranteed to contrast the button surface.
  */
-@media (forced-colors: active) {
-  /* Larger offset in WHCM separates the focus outline from ButtonBorder, which often shares
+  @media (forced-colors: active) {
+    /* Larger offset in WHCM separates the focus outline from ButtonBorder, which often shares
    * the ButtonText color family; 1px offset would let the two colors visually merge.
    */
-  .cinder-button:focus-visible {
-    outline: var(--cinder-ring-width) solid ButtonText;
-    outline-offset: 3px;
+    .cinder-button:focus-visible {
+      outline: var(--cinder-ring-width) solid ButtonText;
+      outline-offset: 3px;
+    }
   }
-}
 
-/* Disabled — matches both native :disabled and aria-disabled for link variant.
+  /* Disabled — matches both native :disabled and aria-disabled for link variant.
  * Scoped with :not([data-cinder-loading]) so the loading state can own its own colors below
  * without the variant-specific disabled rules (higher specificity) silently winning.
  */
-.cinder-button:disabled:not([data-cinder-loading]),
-.cinder-button[aria-disabled='true']:not([data-cinder-loading]) {
-  cursor: not-allowed;
-  background: var(--cinder-surface-inset);
-  color: var(--cinder-text-disabled);
-  border-color: var(--cinder-border-muted);
-  /* opacity centralized in foundation.css disabled-visual rule */
-}
+  .cinder-button:disabled:not([data-cinder-loading]),
+  .cinder-button[aria-disabled='true']:not([data-cinder-loading]) {
+    cursor: not-allowed;
+    background: var(--cinder-surface-inset);
+    color: var(--cinder-text-disabled);
+    border-color: var(--cinder-border-muted);
+    /* opacity centralized in foundation.css disabled-visual rule */
+  }
 
-/* Loading state — cursor + visible feedback. Per-variant loading overrides below restore
+  /* Loading state — cursor + visible feedback. Per-variant loading overrides below restore
  * each variant's own colors so loading buttons don't read as permanently-disabled.
  */
-.cinder-button[data-cinder-loading] {
-  cursor: wait;
-  opacity: 1;
-}
+  .cinder-button[data-cinder-loading] {
+    cursor: wait;
+    opacity: 1;
+  }
 
-/* Spinner — visible feedback for sighted users while `aria-busy` informs assistive tech.
+  /* Spinner — visible feedback for sighted users while `aria-busy` informs assistive tech.
  * No `margin-inline-start` here: the parent `.cinder-button` has `gap: var(--cinder-space-1-5)`
  * which already separates the pseudo-element from the preceding label/children. Adding margin
  * too would double-count the gap.
  */
-.cinder-button[data-cinder-loading]::after {
-  content: '';
-  display: inline-block;
-  width: 0.75em;
-  height: 0.75em;
-  border: 2px solid currentColor;
-  border-inline-end-color: transparent;
-  border-radius: 50%;
-  animation: cinder-button-spin 0.6s linear infinite;
-}
+  .cinder-button[data-cinder-loading]::after {
+    content: '';
+    display: inline-block;
+    width: 0.75em;
+    height: 0.75em;
+    border: 2px solid currentColor;
+    border-inline-end-color: transparent;
+    border-radius: 50%;
+    animation: cinder-button-spin 0.6s linear infinite;
+  }
 
-/* At `xs` size the button is ~24px tall and the spinner ends up ~9px square; a 2px border
+  /* At `xs` size the button is ~24px tall and the spinner ends up ~9px square; a 2px border
  * is disproportionately thick and reads as a chunky ring. Drop to 1px for xs only.
  */
-.cinder-button[data-cinder-size='xs'][data-cinder-loading]::after {
-  border-width: 1px;
-}
-
-@keyframes cinder-button-spin {
-  to {
-    transform: rotate(360deg);
+  .cinder-button[data-cinder-size='xs'][data-cinder-loading]::after {
+    border-width: 1px;
   }
-}
 
-/* Full-width modifier */
-.cinder-button[data-cinder-full-width] {
-  width: 100%;
-}
+  @keyframes cinder-button-spin {
+    to {
+      transform: rotate(360deg);
+    }
+  }
 
-/* ----------------------------------------
+  /* Full-width modifier */
+  .cinder-button[data-cinder-full-width] {
+    width: 100%;
+  }
+
+  /* ----------------------------------------
  * Size variants
  * ---------------------------------------- */
 
-.cinder-button[data-cinder-size='xs'] {
-  font-size: var(--cinder-button-font-size-xs);
-  padding: var(--cinder-button-padding-y-xs) var(--cinder-button-padding-x-xs);
-  min-height: var(--cinder-button-height-xs);
-  border-radius: var(--cinder-button-radius-xs);
-}
+  .cinder-button[data-cinder-size='xs'] {
+    font-size: var(--cinder-button-font-size-xs);
+    padding: var(--cinder-button-padding-y-xs) var(--cinder-button-padding-x-xs);
+    min-height: var(--cinder-button-height-xs);
+    border-radius: var(--cinder-button-radius-xs);
+  }
 
-.cinder-button[data-cinder-size='sm'] {
-  font-size: var(--cinder-button-font-size-sm);
-  padding: var(--cinder-button-padding-y-sm) var(--cinder-button-padding-x-sm);
-  min-height: var(--cinder-button-height-sm);
-  border-radius: var(--cinder-button-radius-sm);
-}
+  .cinder-button[data-cinder-size='sm'] {
+    font-size: var(--cinder-button-font-size-sm);
+    padding: var(--cinder-button-padding-y-sm) var(--cinder-button-padding-x-sm);
+    min-height: var(--cinder-button-height-sm);
+    border-radius: var(--cinder-button-radius-sm);
+  }
 
-.cinder-button[data-cinder-size='md'] {
-  font-size: var(--cinder-button-font-size-md);
-  padding: var(--cinder-button-padding-y-md) var(--cinder-button-padding-x-md);
-  min-height: var(--cinder-button-height-md);
-  border-radius: var(--cinder-button-radius-md);
-}
+  .cinder-button[data-cinder-size='md'] {
+    font-size: var(--cinder-button-font-size-md);
+    padding: var(--cinder-button-padding-y-md) var(--cinder-button-padding-x-md);
+    min-height: var(--cinder-button-height-md);
+    border-radius: var(--cinder-button-radius-md);
+  }
 
-.cinder-button[data-cinder-size='lg'] {
-  font-size: var(--cinder-button-font-size-lg);
-  padding: var(--cinder-button-padding-y-lg) var(--cinder-button-padding-x-lg);
-  min-height: var(--cinder-button-height-lg);
-  border-radius: var(--cinder-button-radius-lg);
-}
+  .cinder-button[data-cinder-size='lg'] {
+    font-size: var(--cinder-button-font-size-lg);
+    padding: var(--cinder-button-padding-y-lg) var(--cinder-button-padding-x-lg);
+    min-height: var(--cinder-button-height-lg);
+    border-radius: var(--cinder-button-radius-lg);
+  }
 
-.cinder-button[data-cinder-size='xl'] {
-  font-size: var(--cinder-button-font-size-xl);
-  padding: var(--cinder-button-padding-y-xl) var(--cinder-button-padding-x-xl);
-  min-height: var(--cinder-button-height-xl);
-  border-radius: var(--cinder-button-radius-xl);
-}
+  .cinder-button[data-cinder-size='xl'] {
+    font-size: var(--cinder-button-font-size-xl);
+    padding: var(--cinder-button-padding-y-xl) var(--cinder-button-padding-x-xl);
+    min-height: var(--cinder-button-height-xl);
+    border-radius: var(--cinder-button-radius-xl);
+  }
 
-/* ----------------------------------------
+  /* ----------------------------------------
  * Icon-only modifier
  * Button sizes are compact visual sizes, not guaranteed touch targets.
  * See button.a11y.md for touch-target guidance.
  * ---------------------------------------- */
 
-.cinder-button[data-cinder-icon-only] {
-  padding-inline: 0;
-  aspect-ratio: 1;
-}
+  .cinder-button[data-cinder-icon-only] {
+    padding-inline: 0;
+    aspect-ratio: 1;
+  }
 
-.cinder-button[data-cinder-icon-only][data-cinder-size='xs'] {
-  min-width: var(--cinder-button-height-xs);
-}
+  .cinder-button[data-cinder-icon-only][data-cinder-size='xs'] {
+    min-width: var(--cinder-button-height-xs);
+  }
 
-.cinder-button[data-cinder-icon-only][data-cinder-size='sm'] {
-  min-width: var(--cinder-button-height-sm);
-}
+  .cinder-button[data-cinder-icon-only][data-cinder-size='sm'] {
+    min-width: var(--cinder-button-height-sm);
+  }
 
-.cinder-button[data-cinder-icon-only][data-cinder-size='md'] {
-  min-width: var(--cinder-button-height-md);
-}
+  .cinder-button[data-cinder-icon-only][data-cinder-size='md'] {
+    min-width: var(--cinder-button-height-md);
+  }
 
-.cinder-button[data-cinder-icon-only][data-cinder-size='lg'] {
-  min-width: var(--cinder-button-height-lg);
-}
+  .cinder-button[data-cinder-icon-only][data-cinder-size='lg'] {
+    min-width: var(--cinder-button-height-lg);
+  }
 
-.cinder-button[data-cinder-icon-only][data-cinder-size='xl'] {
-  min-width: var(--cinder-button-height-xl);
-}
+  .cinder-button[data-cinder-icon-only][data-cinder-size='xl'] {
+    min-width: var(--cinder-button-height-xl);
+  }
 
-/* ----------------------------------------
+  /* ----------------------------------------
  * Icon slot wrapper — used for leadingIcon and trailingIcon snippets.
  * These slots are decorative-only; meaning lives in the button's accessible name.
  * ---------------------------------------- */
 
-.cinder-button__icon {
-  display: inline-flex;
-  align-items: center;
-  flex-shrink: 0;
-  line-height: 0;
-}
+  .cinder-button__icon {
+    display: inline-flex;
+    align-items: center;
+    flex-shrink: 0;
+    line-height: 0;
+  }
 
-/* ----------------------------------------
+  /* ----------------------------------------
  * Color variants
  * ---------------------------------------- */
 
-.cinder-button[data-cinder-variant='primary'] {
-  --_cinder-button-ring: var(--cinder-accent);
-  background: var(--cinder-accent);
-  color: var(--cinder-accent-contrast);
-  border-color: transparent;
-}
+  .cinder-button[data-cinder-variant='primary'] {
+    --_cinder-button-ring: var(--cinder-accent);
+    background: var(--cinder-accent);
+    color: var(--cinder-accent-contrast);
+    border-color: transparent;
+  }
 
-/* Variant-specific disabled overrides are now :not([data-cinder-loading]) so loading buttons
+  /* Variant-specific disabled overrides are now :not([data-cinder-loading]) so loading buttons
  * keep their variant colors instead of falling through to the grey disabled palette.
  */
-.cinder-button[data-cinder-variant='primary']:disabled:not([data-cinder-loading]),
-.cinder-button[data-cinder-variant='primary'][aria-disabled='true']:not([data-cinder-loading]) {
-  background: var(--cinder-surface-inset);
-  color: var(--cinder-text-disabled);
-  border-color: var(--cinder-border-muted);
-}
+  .cinder-button[data-cinder-variant='primary']:disabled:not([data-cinder-loading]),
+  .cinder-button[data-cinder-variant='primary'][aria-disabled='true']:not([data-cinder-loading]) {
+    background: var(--cinder-surface-inset);
+    color: var(--cinder-text-disabled);
+    border-color: var(--cinder-border-muted);
+  }
 
-.cinder-button[data-cinder-variant='secondary'] {
-  background: var(--cinder-surface-raised);
-  color: var(--cinder-text);
-  border-color: var(--cinder-border);
-}
+  .cinder-button[data-cinder-variant='secondary'] {
+    background: var(--cinder-surface-raised);
+    color: var(--cinder-text);
+    border-color: var(--cinder-border);
+  }
 
-.cinder-button[data-cinder-variant='danger'] {
-  --_cinder-button-ring: var(--cinder-danger);
-  background: var(--cinder-danger);
-  color: var(--cinder-danger-contrast);
-  border-color: transparent;
-}
+  .cinder-button[data-cinder-variant='danger'] {
+    --_cinder-button-ring: var(--cinder-danger);
+    background: var(--cinder-danger);
+    color: var(--cinder-danger-contrast);
+    border-color: transparent;
+  }
 
-.cinder-button[data-cinder-variant='danger']:disabled:not([data-cinder-loading]),
-.cinder-button[data-cinder-variant='danger'][aria-disabled='true']:not([data-cinder-loading]) {
-  background: var(--cinder-surface-inset);
-  color: var(--cinder-text-disabled);
-  border-color: var(--cinder-border-muted);
-}
+  .cinder-button[data-cinder-variant='danger']:disabled:not([data-cinder-loading]),
+  .cinder-button[data-cinder-variant='danger'][aria-disabled='true']:not([data-cinder-loading]) {
+    background: var(--cinder-surface-inset);
+    color: var(--cinder-text-disabled);
+    border-color: var(--cinder-border-muted);
+  }
 
-.cinder-button[data-cinder-variant='ghost'] {
-  background: transparent;
-  color: var(--cinder-text-muted);
-  border-color: transparent;
-}
+  .cinder-button[data-cinder-variant='ghost'] {
+    background: transparent;
+    color: var(--cinder-text-muted);
+    border-color: transparent;
+  }
 
-.cinder-button[data-cinder-variant='ghost-danger'] {
-  --_cinder-button-ring: var(--cinder-danger);
-  background: transparent;
-  color: var(--cinder-danger);
-  border-color: transparent;
-}
+  .cinder-button[data-cinder-variant='ghost-danger'] {
+    --_cinder-button-ring: var(--cinder-danger);
+    background: transparent;
+    color: var(--cinder-danger);
+    border-color: transparent;
+  }
 
-.cinder-button[data-cinder-icon-only][data-cinder-variant='ghost'] {
-  background: var(--cinder-surface);
-  background: color-mix(in oklch, var(--cinder-surface), var(--cinder-text) 4%);
-  border-color: var(--cinder-border-muted);
-}
+  .cinder-button[data-cinder-icon-only][data-cinder-variant='ghost'] {
+    background: var(--cinder-surface);
+    background: color-mix(in oklch, var(--cinder-surface), var(--cinder-text) 4%);
+    border-color: var(--cinder-border-muted);
+  }
 
-.cinder-button[data-cinder-icon-only][data-cinder-variant='ghost-danger'] {
-  background: var(--cinder-color-danger-bg);
-  background: color-mix(in oklch, var(--cinder-color-danger-bg), transparent 35%);
-  border-color: var(--cinder-color-danger-border);
-}
+  .cinder-button[data-cinder-icon-only][data-cinder-variant='ghost-danger'] {
+    background: var(--cinder-color-danger-bg);
+    background: color-mix(in oklch, var(--cinder-color-danger-bg), transparent 35%);
+    border-color: var(--cinder-color-danger-border);
+  }
 
-.cinder-button[data-cinder-variant='ghost']:disabled:not([data-cinder-loading]),
-.cinder-button[data-cinder-variant='ghost'][aria-disabled='true']:not([data-cinder-loading]) {
-  background: transparent;
-  color: var(--cinder-text-disabled);
-  border-color: transparent;
-  opacity: 0.6;
-}
+  .cinder-button[data-cinder-variant='ghost']:disabled:not([data-cinder-loading]),
+  .cinder-button[data-cinder-variant='ghost'][aria-disabled='true']:not([data-cinder-loading]) {
+    background: transparent;
+    color: var(--cinder-text-disabled);
+    border-color: transparent;
+    opacity: 0.6;
+  }
 
-.cinder-button[data-cinder-variant='ghost-danger'][data-cinder-loading] {
-  background: transparent;
-  color: var(--cinder-danger);
-  border-color: transparent;
-}
+  .cinder-button[data-cinder-variant='ghost-danger'][data-cinder-loading] {
+    background: transparent;
+    color: var(--cinder-danger);
+    border-color: transparent;
+  }
 
-.cinder-button[data-cinder-icon-only][data-cinder-variant='ghost-danger'][data-cinder-loading] {
-  background: var(--cinder-color-danger-bg);
-  background: color-mix(in oklch, var(--cinder-color-danger-bg), transparent 35%);
-  border-color: var(--cinder-color-danger-border);
-}
+  .cinder-button[data-cinder-icon-only][data-cinder-variant='ghost-danger'][data-cinder-loading] {
+    background: var(--cinder-color-danger-bg);
+    background: color-mix(in oklch, var(--cinder-color-danger-bg), transparent 35%);
+    border-color: var(--cinder-color-danger-border);
+  }
 
-.cinder-button[data-cinder-variant='ghost-danger']:disabled:not([data-cinder-loading]),
-.cinder-button[data-cinder-variant='ghost-danger'][aria-disabled='true']:not(
-    [data-cinder-loading]
-  ) {
-  background: transparent;
-  color: var(--cinder-danger);
-  border-color: transparent;
-  opacity: 0.6;
-}
+  .cinder-button[data-cinder-variant='ghost-danger']:disabled:not([data-cinder-loading]),
+  .cinder-button[data-cinder-variant='ghost-danger'][aria-disabled='true']:not(
+      [data-cinder-loading]
+    ) {
+    background: transparent;
+    color: var(--cinder-danger);
+    border-color: transparent;
+    opacity: 0.6;
+  }
 
-.cinder-button[data-cinder-icon-only][data-cinder-variant='ghost']:disabled:not(
-    [data-cinder-loading]
-  ),
-.cinder-button[data-cinder-icon-only][data-cinder-variant='ghost'][aria-disabled='true']:not(
-    [data-cinder-loading]
-  ),
-.cinder-button[data-cinder-icon-only][data-cinder-variant='ghost-danger']:disabled:not(
-    [data-cinder-loading]
-  ),
-.cinder-button[data-cinder-icon-only][data-cinder-variant='ghost-danger'][aria-disabled='true']:not(
-    [data-cinder-loading]
-  ) {
-  background: var(--cinder-surface-inset);
-  color: var(--cinder-text-disabled);
-  border-color: var(--cinder-border-muted);
-  opacity: 0.6;
-}
+  .cinder-button[data-cinder-icon-only][data-cinder-variant='ghost']:disabled:not(
+      [data-cinder-loading]
+    ),
+  .cinder-button[data-cinder-icon-only][data-cinder-variant='ghost'][aria-disabled='true']:not(
+      [data-cinder-loading]
+    ),
+  .cinder-button[data-cinder-icon-only][data-cinder-variant='ghost-danger']:disabled:not(
+      [data-cinder-loading]
+    ),
+  .cinder-button[data-cinder-icon-only][data-cinder-variant='ghost-danger'][aria-disabled='true']:not(
+      [data-cinder-loading]
+    ) {
+    background: var(--cinder-surface-inset);
+    color: var(--cinder-text-disabled);
+    border-color: var(--cinder-border-muted);
+    opacity: 0.6;
+  }
 
-/* soft — tinted accent background, accent foreground, no border.
+  /* soft — tinted accent background, accent foreground, no border.
  * Background uses color-mix so it resolves against the theme-aware --cinder-accent token
  * in both light and dark themes. Contrast ratios must be verified mechanically (WebAIM
  * contrast checker) before shipping; see button.a11y.md for the verification procedure. */
-.cinder-button[data-cinder-variant='soft'] {
-  --_cinder-button-ring: var(--cinder-accent);
-  background: color-mix(in oklch, var(--cinder-accent), transparent 88%);
-  color: var(--cinder-accent);
-  border-color: transparent;
-}
-
-.cinder-button[data-cinder-variant='soft']:disabled:not([data-cinder-loading]),
-.cinder-button[data-cinder-variant='soft'][aria-disabled='true']:not([data-cinder-loading]) {
-  background: var(--cinder-surface-inset);
-  color: var(--cinder-text-disabled);
-  border-color: transparent;
-  opacity: 0.6;
-}
-
-@media (forced-colors: active) {
   .cinder-button[data-cinder-variant='soft'] {
-    border: 1px solid ButtonBorder;
+    --_cinder-button-ring: var(--cinder-accent);
+    background: color-mix(in oklch, var(--cinder-accent), transparent 88%);
+    color: var(--cinder-accent);
+    border-color: transparent;
   }
-}
 
-/* soft-danger — tinted danger background, danger foreground, no border. */
-.cinder-button[data-cinder-variant='soft-danger'] {
-  --_cinder-button-ring: var(--cinder-danger);
-  background: var(--cinder-color-danger-bg);
-  color: var(--cinder-color-danger-fg);
-  border-color: transparent;
-}
+  .cinder-button[data-cinder-variant='soft']:disabled:not([data-cinder-loading]),
+  .cinder-button[data-cinder-variant='soft'][aria-disabled='true']:not([data-cinder-loading]) {
+    background: var(--cinder-surface-inset);
+    color: var(--cinder-text-disabled);
+    border-color: transparent;
+    opacity: 0.6;
+  }
 
-.cinder-button[data-cinder-variant='soft-danger']:disabled:not([data-cinder-loading]),
-.cinder-button[data-cinder-variant='soft-danger'][aria-disabled='true']:not([data-cinder-loading]) {
-  background: var(--cinder-surface-inset);
-  color: var(--cinder-text-disabled);
-  border-color: transparent;
-  opacity: 0.6;
-}
+  @media (forced-colors: active) {
+    .cinder-button[data-cinder-variant='soft'] {
+      border: 1px solid ButtonBorder;
+    }
+  }
 
-@media (forced-colors: active) {
+  /* soft-danger — tinted danger background, danger foreground, no border. */
   .cinder-button[data-cinder-variant='soft-danger'] {
-    border: 1px solid ButtonBorder;
+    --_cinder-button-ring: var(--cinder-danger);
+    background: var(--cinder-color-danger-bg);
+    color: var(--cinder-color-danger-fg);
+    border-color: transparent;
   }
-}
 
-/* Sticky-hover suppression on touch: wrap hover-only chrome so it doesn't
+  .cinder-button[data-cinder-variant='soft-danger']:disabled:not([data-cinder-loading]),
+  .cinder-button[data-cinder-variant='soft-danger'][aria-disabled='true']:not(
+      [data-cinder-loading]
+    ) {
+    background: var(--cinder-surface-inset);
+    color: var(--cinder-text-disabled);
+    border-color: transparent;
+    opacity: 0.6;
+  }
+
+  @media (forced-colors: active) {
+    .cinder-button[data-cinder-variant='soft-danger'] {
+      border: 1px solid ButtonBorder;
+    }
+  }
+
+  /* Sticky-hover suppression on touch: wrap hover-only chrome so it doesn't
  * "stick" after tap on touch devices that emulate :hover. */
-@media (hover: hover) {
-  .cinder-button:hover {
-    text-decoration: none;
+  @media (hover: hover) {
+    .cinder-button:hover {
+      text-decoration: none;
+    }
+
+    .cinder-button[data-cinder-variant='primary']:hover:not(:disabled):not([aria-disabled='true']) {
+      background: var(--cinder-accent-hover);
+      border-color: transparent;
+    }
+
+    .cinder-button[data-cinder-variant='secondary']:hover:not(:disabled):not(
+        [aria-disabled='true']
+      ) {
+      background: var(--cinder-surface-hover);
+    }
+
+    .cinder-button[data-cinder-variant='danger']:hover:not(:disabled):not([aria-disabled='true']) {
+      background: var(--cinder-danger-hover);
+      border-color: transparent;
+    }
+
+    .cinder-button[data-cinder-variant='ghost']:hover:not(:disabled):not([aria-disabled='true']) {
+      background: var(--cinder-surface-hover);
+    }
+
+    .cinder-button[data-cinder-icon-only][data-cinder-variant='ghost']:hover:not(:disabled):not(
+        [aria-disabled='true']
+      ) {
+      background: var(--cinder-surface-hover);
+      border-color: var(--cinder-border);
+      color: var(--cinder-text);
+    }
+
+    .cinder-button[data-cinder-variant='ghost-danger']:hover:not(:disabled):not(
+        [aria-disabled='true']
+      ) {
+      background: var(--cinder-color-danger-bg);
+      color: var(--cinder-color-danger-fg);
+    }
+
+    .cinder-button[data-cinder-icon-only][data-cinder-variant='ghost-danger']:hover:not(
+        :disabled
+      ):not([aria-disabled='true']) {
+      background: var(--cinder-color-danger-bg);
+      border-color: var(--cinder-color-danger-border);
+      color: var(--cinder-color-danger-fg);
+    }
+
+    .cinder-button[data-cinder-variant='soft']:hover:not(:disabled):not([aria-disabled='true']) {
+      background: color-mix(in oklch, var(--cinder-accent), transparent 80%);
+    }
+
+    .cinder-button[data-cinder-variant='soft-danger']:hover:not(:disabled):not(
+        [aria-disabled='true']
+      ) {
+      background: var(--cinder-color-danger-border);
+      color: var(--cinder-color-danger-fg);
+    }
   }
 
-  .cinder-button[data-cinder-variant='primary']:hover:not(:disabled):not([aria-disabled='true']) {
-    background: var(--cinder-accent-hover);
-    border-color: transparent;
+  /* :active rules placed AFTER @media (hover: hover) so press feedback overrides
+ * hover paint when both states are active on hover-capable devices. Unwrapped
+ * so they fire on tap. */
+  .cinder-button[data-cinder-variant='primary']:active:not(:disabled):not([aria-disabled='true']) {
+    background: var(--cinder-accent-active);
   }
 
-  .cinder-button[data-cinder-variant='secondary']:hover:not(:disabled):not([aria-disabled='true']) {
-    background: var(--cinder-surface-hover);
-  }
-
-  .cinder-button[data-cinder-variant='danger']:hover:not(:disabled):not([aria-disabled='true']) {
-    background: var(--cinder-danger-hover);
-    border-color: transparent;
-  }
-
-  .cinder-button[data-cinder-variant='ghost']:hover:not(:disabled):not([aria-disabled='true']) {
-    background: var(--cinder-surface-hover);
-  }
-
-  .cinder-button[data-cinder-icon-only][data-cinder-variant='ghost']:hover:not(:disabled):not(
+  .cinder-button[data-cinder-variant='secondary']:active:not(:disabled):not(
       [aria-disabled='true']
     ) {
-    background: var(--cinder-surface-hover);
-    border-color: var(--cinder-border);
-    color: var(--cinder-text);
+    background: var(--cinder-surface-pressed);
   }
 
-  .cinder-button[data-cinder-variant='ghost-danger']:hover:not(:disabled):not(
-      [aria-disabled='true']
-    ) {
-    background: var(--cinder-color-danger-bg);
-    color: var(--cinder-color-danger-fg);
+  .cinder-button[data-cinder-variant='danger']:active:not(:disabled):not([aria-disabled='true']) {
+    background: var(--cinder-danger-active);
   }
 
-  .cinder-button[data-cinder-icon-only][data-cinder-variant='ghost-danger']:hover:not(
-      :disabled
-    ):not([aria-disabled='true']) {
-    background: var(--cinder-color-danger-bg);
-    border-color: var(--cinder-color-danger-border);
-    color: var(--cinder-color-danger-fg);
+  .cinder-button[data-cinder-variant='ghost']:active:not(:disabled):not([aria-disabled='true']) {
+    background: var(--cinder-surface-pressed);
   }
 
-  .cinder-button[data-cinder-variant='soft']:hover:not(:disabled):not([aria-disabled='true']) {
-    background: color-mix(in oklch, var(--cinder-accent), transparent 80%);
-  }
-
-  .cinder-button[data-cinder-variant='soft-danger']:hover:not(:disabled):not(
+  .cinder-button[data-cinder-variant='ghost-danger']:active:not(:disabled):not(
       [aria-disabled='true']
     ) {
     background: var(--cinder-color-danger-border);
     color: var(--cinder-color-danger-fg);
   }
-}
 
-/* :active rules placed AFTER @media (hover: hover) so press feedback overrides
- * hover paint when both states are active on hover-capable devices. Unwrapped
- * so they fire on tap. */
-.cinder-button[data-cinder-variant='primary']:active:not(:disabled):not([aria-disabled='true']) {
-  background: var(--cinder-accent-active);
-}
-
-.cinder-button[data-cinder-variant='secondary']:active:not(:disabled):not([aria-disabled='true']) {
-  background: var(--cinder-surface-pressed);
-}
-
-.cinder-button[data-cinder-variant='danger']:active:not(:disabled):not([aria-disabled='true']) {
-  background: var(--cinder-danger-active);
-}
-
-.cinder-button[data-cinder-variant='ghost']:active:not(:disabled):not([aria-disabled='true']) {
-  background: var(--cinder-surface-pressed);
-}
-
-.cinder-button[data-cinder-variant='ghost-danger']:active:not(:disabled):not(
-    [aria-disabled='true']
-  ) {
-  background: var(--cinder-color-danger-border);
-  color: var(--cinder-color-danger-fg);
-}
-
-.cinder-button[data-cinder-variant='soft']:active:not(:disabled):not([aria-disabled='true']) {
-  background: color-mix(in oklch, var(--cinder-accent), transparent 74%);
-}
-
-.cinder-button[data-cinder-variant='soft-danger']:active:not(:disabled):not(
-    [aria-disabled='true']
-  ) {
-  background: var(--cinder-danger);
-  color: var(--cinder-danger-contrast);
-}
-
-@media (forced-colors: active) {
-  .cinder-button[data-cinder-icon-only][data-cinder-variant='ghost'] {
-    background: ButtonFace;
-    border-color: ButtonBorder;
-    color: ButtonText;
+  .cinder-button[data-cinder-variant='soft']:active:not(:disabled):not([aria-disabled='true']) {
+    background: color-mix(in oklch, var(--cinder-accent), transparent 74%);
   }
 
-  .cinder-button[data-cinder-icon-only][data-cinder-variant='ghost-danger'] {
-    background: ButtonFace;
-    border-color: ButtonBorder;
-    color: ButtonText;
+  .cinder-button[data-cinder-variant='soft-danger']:active:not(:disabled):not(
+      [aria-disabled='true']
+    ) {
+    background: var(--cinder-danger);
+    color: var(--cinder-danger-contrast);
+  }
+
+  @media (forced-colors: active) {
+    .cinder-button[data-cinder-icon-only][data-cinder-variant='ghost'] {
+      background: ButtonFace;
+      border-color: ButtonBorder;
+      color: ButtonText;
+    }
+
+    .cinder-button[data-cinder-icon-only][data-cinder-variant='ghost-danger'] {
+      background: ButtonFace;
+      border-color: ButtonBorder;
+      color: ButtonText;
+    }
   }
 }

--- a/packages/components/src/components/callout/callout.css
+++ b/packages/components/src/components/callout/callout.css
@@ -1,4 +1,5 @@
-/* ========================================
+@layer cinder.components {
+  /* ========================================
  * CALLOUT
  * ----------------------------------------
  * Inline admonition block embedded in document or section content. Static
@@ -12,72 +13,72 @@
  *   - alert: dynamic notification card, role="alert".
  * ======================================== */
 
-.cinder-callout {
-  display: flex;
-  align-items: flex-start;
-  gap: var(--cinder-space-3);
-  inline-size: 100%;
-  padding-block: var(--cinder-space-3);
-  padding-inline: var(--cinder-space-4);
-  border: 1px solid var(--cinder-border);
-  /* Dominant directional stripe; the saturated color is set per variant via
+  .cinder-callout {
+    display: flex;
+    align-items: flex-start;
+    gap: var(--cinder-space-3);
+    inline-size: 100%;
+    padding-block: var(--cinder-space-3);
+    padding-inline: var(--cinder-space-4);
+    border: 1px solid var(--cinder-border);
+    /* Dominant directional stripe; the saturated color is set per variant via
    * border-inline-start-color. Width is theme-independent, so the stripe is
    * 4px in both light and dark. This is the cue that distinguishes Callout
    * (static prose aside) from Alert (live-region notification, stripe-free). */
-  border-inline-start-width: 4px;
-  border-radius: var(--cinder-radius-md);
-  background: var(--cinder-surface);
-  color: var(--cinder-text);
-  font-size: var(--cinder-text-sm);
-  line-height: var(--cinder-leading-normal);
-}
+    border-inline-start-width: 4px;
+    border-radius: var(--cinder-radius-md);
+    background: var(--cinder-surface);
+    color: var(--cinder-text);
+    font-size: var(--cinder-text-sm);
+    line-height: var(--cinder-leading-normal);
+  }
 
-/* ----------------------------------------
+  /* ----------------------------------------
  * Icon channel
  * Decorative; the icon is the second WCAG 1.4.1 channel alongside color.
  * The accessible meaning still lives in the title and body, so the icon
  * is wrapped in aria-hidden in the markup.
  * ---------------------------------------- */
 
-.cinder-callout__icon {
-  flex-shrink: 0;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 1.25rem;
-  height: 1.25rem;
-  margin-block-start: var(--cinder-space-0-5);
-  color: inherit;
-}
+  .cinder-callout__icon {
+    flex-shrink: 0;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 1.25rem;
+    height: 1.25rem;
+    margin-block-start: var(--cinder-space-0-5);
+    color: inherit;
+  }
 
-.cinder-callout__icon > svg {
-  width: 100%;
-  height: 100%;
-}
+  .cinder-callout__icon > svg {
+    width: 100%;
+    height: 100%;
+  }
 
-/* ----------------------------------------
+  /* ----------------------------------------
  * Content area
  * ---------------------------------------- */
 
-.cinder-callout__content {
-  flex: 1;
-  min-width: 0;
-}
+  .cinder-callout__content {
+    flex: 1;
+    min-width: 0;
+  }
 
-/* ----------------------------------------
+  /* ----------------------------------------
  * Title
  * Rendered as <p>, not <h*>, so callouts don't inject entries into the
  * document outline. See callout.svelte JSDoc.
  * ---------------------------------------- */
 
-.cinder-callout__title {
-  margin: 0 0 var(--cinder-space-1);
-  font-weight: var(--cinder-font-weight-semibold, 600);
-  line-height: var(--cinder-leading-snug, 1.3);
-  color: inherit;
-}
+  .cinder-callout__title {
+    margin: 0 0 var(--cinder-space-1);
+    font-weight: var(--cinder-font-weight-semibold, 600);
+    line-height: var(--cinder-leading-snug, 1.3);
+    color: inherit;
+  }
 
-/* ----------------------------------------
+  /* ----------------------------------------
  * Variant: info
  *
  * NOTE (CSS audit, Batch D): The four status variants below intentionally
@@ -89,107 +90,108 @@
  * docs/css-audit/status-triple-equivalence.md for the full pre-flight table.
  * ---------------------------------------- */
 
-.cinder-callout[data-cinder-variant='info'] {
-  background-color: light-dark(
-    oklch(from var(--cinder-info) 96.5% 0.015 h),
-    oklch(from var(--cinder-info) 20% 0.03 h)
-  );
-  border-color: light-dark(
-    oklch(from var(--cinder-info) 85% 0.05 h),
-    oklch(from var(--cinder-info) 35% 0.08 h)
-  );
-  color: light-dark(
-    oklch(from var(--cinder-info) 35% 0.12 h),
-    oklch(from var(--cinder-info) 88% 0.12 h)
-  );
-  /* Saturated stripe — declared after border-color so the inline-start edge
+  .cinder-callout[data-cinder-variant='info'] {
+    background-color: light-dark(
+      oklch(from var(--cinder-info) 96.5% 0.015 h),
+      oklch(from var(--cinder-info) 20% 0.03 h)
+    );
+    border-color: light-dark(
+      oklch(from var(--cinder-info) 85% 0.05 h),
+      oklch(from var(--cinder-info) 35% 0.08 h)
+    );
+    color: light-dark(
+      oklch(from var(--cinder-info) 35% 0.12 h),
+      oklch(from var(--cinder-info) 88% 0.12 h)
+    );
+    /* Saturated stripe — declared after border-color so the inline-start edge
    * resolves to this high-chroma rule rather than the soft border above. */
-  border-inline-start-color: light-dark(
-    oklch(from var(--cinder-info) 55% 0.13 h),
-    oklch(from var(--cinder-info) 70% 0.13 h)
-  );
-}
+    border-inline-start-color: light-dark(
+      oklch(from var(--cinder-info) 55% 0.13 h),
+      oklch(from var(--cinder-info) 70% 0.13 h)
+    );
+  }
 
-/* ----------------------------------------
+  /* ----------------------------------------
  * Variant: success
  * ---------------------------------------- */
 
-.cinder-callout[data-cinder-variant='success'] {
-  background-color: light-dark(
-    oklch(from var(--cinder-success) 96.5% 0.015 h),
-    oklch(from var(--cinder-success) 20% 0.03 h)
-  );
-  border-color: light-dark(
-    oklch(from var(--cinder-success) 85% 0.05 h),
-    oklch(from var(--cinder-success) 35% 0.08 h)
-  );
-  color: light-dark(
-    oklch(from var(--cinder-success) 35% 0.14 h),
-    oklch(from var(--cinder-success) 88% 0.12 h)
-  );
-  border-inline-start-color: light-dark(
-    oklch(from var(--cinder-success) 55% 0.14 h),
-    oklch(from var(--cinder-success) 70% 0.14 h)
-  );
-}
+  .cinder-callout[data-cinder-variant='success'] {
+    background-color: light-dark(
+      oklch(from var(--cinder-success) 96.5% 0.015 h),
+      oklch(from var(--cinder-success) 20% 0.03 h)
+    );
+    border-color: light-dark(
+      oklch(from var(--cinder-success) 85% 0.05 h),
+      oklch(from var(--cinder-success) 35% 0.08 h)
+    );
+    color: light-dark(
+      oklch(from var(--cinder-success) 35% 0.14 h),
+      oklch(from var(--cinder-success) 88% 0.12 h)
+    );
+    border-inline-start-color: light-dark(
+      oklch(from var(--cinder-success) 55% 0.14 h),
+      oklch(from var(--cinder-success) 70% 0.14 h)
+    );
+  }
 
-/* ----------------------------------------
+  /* ----------------------------------------
  * Variant: warning
  * ---------------------------------------- */
 
-.cinder-callout[data-cinder-variant='warning'] {
-  background-color: light-dark(
-    oklch(from var(--cinder-warning) 96.5% 0.015 h),
-    oklch(from var(--cinder-warning) 20% 0.03 h)
-  );
-  border-color: light-dark(
-    oklch(from var(--cinder-warning) 85% 0.05 h),
-    oklch(from var(--cinder-warning) 35% 0.08 h)
-  );
-  color: light-dark(
-    oklch(from var(--cinder-warning) 35% 0.16 h),
-    oklch(from var(--cinder-warning) 88% 0.14 h)
-  );
-  border-inline-start-color: light-dark(
-    oklch(from var(--cinder-warning) 55% 0.16 h),
-    oklch(from var(--cinder-warning) 70% 0.16 h)
-  );
-}
+  .cinder-callout[data-cinder-variant='warning'] {
+    background-color: light-dark(
+      oklch(from var(--cinder-warning) 96.5% 0.015 h),
+      oklch(from var(--cinder-warning) 20% 0.03 h)
+    );
+    border-color: light-dark(
+      oklch(from var(--cinder-warning) 85% 0.05 h),
+      oklch(from var(--cinder-warning) 35% 0.08 h)
+    );
+    color: light-dark(
+      oklch(from var(--cinder-warning) 35% 0.16 h),
+      oklch(from var(--cinder-warning) 88% 0.14 h)
+    );
+    border-inline-start-color: light-dark(
+      oklch(from var(--cinder-warning) 55% 0.16 h),
+      oklch(from var(--cinder-warning) 70% 0.16 h)
+    );
+  }
 
-/* ----------------------------------------
+  /* ----------------------------------------
  * Variant: danger
  * ---------------------------------------- */
 
-.cinder-callout[data-cinder-variant='danger'] {
-  background-color: light-dark(
-    oklch(from var(--cinder-danger) 96.5% 0.015 h),
-    oklch(from var(--cinder-danger) 20% 0.03 h)
-  );
-  border-color: light-dark(
-    oklch(from var(--cinder-danger) 85% 0.05 h),
-    oklch(from var(--cinder-danger) 35% 0.08 h)
-  );
-  color: light-dark(
-    oklch(from var(--cinder-danger) 35% 0.18 h),
-    oklch(from var(--cinder-danger) 88% 0.16 h)
-  );
-  border-inline-start-color: light-dark(
-    oklch(from var(--cinder-danger) 55% 0.18 h),
-    oklch(from var(--cinder-danger) 70% 0.18 h)
-  );
-}
+  .cinder-callout[data-cinder-variant='danger'] {
+    background-color: light-dark(
+      oklch(from var(--cinder-danger) 96.5% 0.015 h),
+      oklch(from var(--cinder-danger) 20% 0.03 h)
+    );
+    border-color: light-dark(
+      oklch(from var(--cinder-danger) 85% 0.05 h),
+      oklch(from var(--cinder-danger) 35% 0.08 h)
+    );
+    color: light-dark(
+      oklch(from var(--cinder-danger) 35% 0.18 h),
+      oklch(from var(--cinder-danger) 88% 0.16 h)
+    );
+    border-inline-start-color: light-dark(
+      oklch(from var(--cinder-danger) 55% 0.18 h),
+      oklch(from var(--cinder-danger) 70% 0.18 h)
+    );
+  }
 
-/* ----------------------------------------
+  /* ----------------------------------------
  * Forced-colors / high-contrast
  * ---------------------------------------- */
 
-@media (forced-colors: active) {
-  .cinder-callout {
-    border: 1px solid CanvasText;
-    /* Preserve the directional stripe when oklch color is unavailable: the
+  @media (forced-colors: active) {
+    .cinder-callout {
+      border: 1px solid CanvasText;
+      /* Preserve the directional stripe when oklch color is unavailable: the
      * 4px inline-start edge survives as the differentiating cue even though
      * its color collapses to CanvasText along with the rest of the box. */
-    border-inline-start-width: 4px;
-    border-inline-start-color: CanvasText;
+      border-inline-start-width: 4px;
+      border-inline-start-color: CanvasText;
+    }
   }
 }

--- a/packages/components/src/components/callout/callout.css.test.ts
+++ b/packages/components/src/components/callout/callout.css.test.ts
@@ -20,7 +20,7 @@ import { fileURLToPath } from 'node:url';
 
 import { describe, expect, test } from 'bun:test';
 
-import { parse, type Declaration, type Rule } from 'postcss';
+import { parse, type AtRule, type Declaration, type Rule } from 'postcss';
 
 function loadCss(relativePath: string): string {
   const fullPath = fileURLToPath(new URL(relativePath, import.meta.url));
@@ -93,10 +93,27 @@ const ALLOWED_VARIANT_BORDER = ['border-color', 'border-inline-start-color'];
  * reuses `.cinder-callout`, so skipping `atrule` parents keeps us on the base
  * rule whose cascade the acceptance criteria reference.
  */
+/**
+ * A rule is "effectively top-level" when the only at-rules between it and the
+ * stylesheet root are `@layer` wrappers. Component CSS now self-declares
+ * `@layer cinder.components { … }`, so the base rules sit one `@layer` deep;
+ * that wrapper is transparent for cascade purposes. Rules nested under
+ * `@media` / `@supports` / `@container` (e.g. the forced-colors block) are NOT
+ * top-level and must still be skipped.
+ */
+function isEffectivelyTopLevel(rule: Rule): boolean {
+  let ancestor = rule.parent;
+  while (ancestor && ancestor.type !== 'root') {
+    if (ancestor.type === 'atrule' && (ancestor as AtRule).name !== 'layer') return false;
+    ancestor = ancestor.parent;
+  }
+  return true;
+}
+
 function findRule(selector: string): Rule {
   let match: Rule | undefined;
   root.walkRules((rule) => {
-    if (rule.parent?.type === 'atrule') return undefined;
+    if (!isEffectivelyTopLevel(rule)) return undefined;
     if (rule.selectors.includes(selector)) {
       match = rule;
       return false;

--- a/packages/components/src/components/card/card.css
+++ b/packages/components/src/components/card/card.css
@@ -1,91 +1,93 @@
-/* ========================================
+@layer cinder.components {
+  /* ========================================
  * CARD
  * ======================================== */
 
-.cinder-card {
-  inline-size: 100%;
-  border-radius: var(--cinder-radius-lg);
-  background: var(--cinder-surface-raised);
-  border: 1px solid var(--cinder-border-muted);
-  color: var(--cinder-text);
-  box-shadow: var(--cinder-shadow-sm);
-  overflow: hidden;
-}
+  .cinder-card {
+    inline-size: 100%;
+    border-radius: var(--cinder-radius-lg);
+    background: var(--cinder-surface-raised);
+    border: 1px solid var(--cinder-border-muted);
+    color: var(--cinder-text);
+    box-shadow: var(--cinder-shadow-sm);
+    overflow: hidden;
+  }
 
-.cinder-card[data-cinder-variant='well'] {
-  background: var(--cinder-surface);
-  box-shadow: none;
-}
+  .cinder-card[data-cinder-variant='well'] {
+    background: var(--cinder-surface);
+    box-shadow: none;
+  }
 
-/* ----------------------------------------
+  /* ----------------------------------------
  * Header
  * ---------------------------------------- */
 
-.cinder-card__header {
-  display: flex;
-  flex-direction: column;
-  gap: var(--cinder-space-1);
-  padding: var(--cinder-space-3) var(--cinder-space-4);
-  border-bottom: 1px solid var(--cinder-border-muted);
-}
+  .cinder-card__header {
+    display: flex;
+    flex-direction: column;
+    gap: var(--cinder-space-1);
+    padding: var(--cinder-space-3) var(--cinder-space-4);
+    border-bottom: 1px solid var(--cinder-border-muted);
+  }
 
-/* ----------------------------------------
+  /* ----------------------------------------
  * Title & description (title arm)
  * ---------------------------------------- */
 
-.cinder-card__title {
-  font-size: var(--cinder-text-sm);
-  font-weight: var(--cinder-font-medium);
-  color: var(--cinder-text);
-  margin: 0;
-}
+  .cinder-card__title {
+    font-size: var(--cinder-text-sm);
+    font-weight: var(--cinder-font-medium);
+    color: var(--cinder-text);
+    margin: 0;
+  }
 
-.cinder-card__description {
-  font-size: var(--cinder-text-sm);
-  color: var(--cinder-text-subtle);
-  margin: 0;
-}
+  .cinder-card__description {
+    font-size: var(--cinder-text-sm);
+    color: var(--cinder-text-subtle);
+    margin: 0;
+  }
 
-/* ----------------------------------------
+  /* ----------------------------------------
  * Body
  * ---------------------------------------- */
 
-.cinder-card__body {
-  padding: var(--cinder-space-4);
-}
+  .cinder-card__body {
+    padding: var(--cinder-space-4);
+  }
 
-.cinder-card__body[data-cinder-tone='muted'] {
-  background: var(--cinder-surface-inset);
-}
+  .cinder-card__body[data-cinder-tone='muted'] {
+    background: var(--cinder-surface-inset);
+  }
 
-.cinder-card[data-cinder-variant='well'] .cinder-card__body {
-  background: var(--cinder-surface-inset);
-}
+  .cinder-card[data-cinder-variant='well'] .cinder-card__body {
+    background: var(--cinder-surface-inset);
+  }
 
-/* ----------------------------------------
+  /* ----------------------------------------
  * Footer
  * ---------------------------------------- */
 
-.cinder-card__footer {
-  display: flex;
-  align-items: center;
-  justify-content: flex-end;
-  gap: var(--cinder-space-2);
-  padding: var(--cinder-space-3) var(--cinder-space-4);
-  border-top: 1px solid var(--cinder-border-muted);
-}
+  .cinder-card__footer {
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+    gap: var(--cinder-space-2);
+    padding: var(--cinder-space-3) var(--cinder-space-4);
+    border-top: 1px solid var(--cinder-border-muted);
+  }
 
-.cinder-card__footer[data-cinder-tone='muted'] {
-  background: var(--cinder-surface-inset);
-}
+  .cinder-card__footer[data-cinder-tone='muted'] {
+    background: var(--cinder-surface-inset);
+  }
 
-@media (width < 640px) {
-  .cinder-card[data-cinder-edge-to-edge-mobile] {
-    --cinder-card-mobile-bleed: var(--cinder-space-4);
+  @media (width < 640px) {
+    .cinder-card[data-cinder-edge-to-edge-mobile] {
+      --cinder-card-mobile-bleed: var(--cinder-space-4);
 
-    inline-size: calc(100% + (var(--cinder-card-mobile-bleed) * 2));
-    margin-inline: calc(var(--cinder-card-mobile-bleed) * -1);
-    border-inline: 0;
-    border-radius: 0;
+      inline-size: calc(100% + (var(--cinder-card-mobile-bleed) * 2));
+      margin-inline: calc(var(--cinder-card-mobile-bleed) * -1);
+      border-inline: 0;
+      border-radius: 0;
+    }
   }
 }

--- a/packages/components/src/components/center/center.css
+++ b/packages/components/src/components/center/center.css
@@ -1,17 +1,19 @@
-/* ========================================
+@layer cinder.components {
+  /* ========================================
  * CENTER
  * ======================================== */
 
-.cinder-center {
-  margin-inline: auto;
-  max-inline-size: var(--center-max-width, var(--cinder-content-width));
-  min-block-size: var(--center-min-height);
-}
+  .cinder-center {
+    margin-inline: auto;
+    max-inline-size: var(--center-max-width, var(--cinder-content-width));
+    min-block-size: var(--center-min-height);
+  }
 
-.cinder-center[data-cinder-intrinsic='true'] {
-  inline-size: fit-content;
+  .cinder-center[data-cinder-intrinsic='true'] {
+    inline-size: fit-content;
 
-  display: flex;
-  flex-direction: column;
-  align-items: center;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+  }
 }

--- a/packages/components/src/components/checkbox-group/checkbox-group.css
+++ b/packages/components/src/components/checkbox-group/checkbox-group.css
@@ -1,109 +1,113 @@
-/* ========================================
+@layer cinder.components {
+  /* ========================================
  * CHECKBOX GROUP
  * Fieldset wrapper + child Checkbox items.
  * ======================================== */
 
-.cinder-checkbox-group {
-  border: none;
-  margin: 0;
-  padding: 0;
-  display: flex;
-  flex-direction: column;
-  gap: var(--cinder-space-2);
-}
+  .cinder-checkbox-group {
+    border: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: var(--cinder-space-2);
+  }
 
-.cinder-checkbox-group__legend {
-  font-size: var(--cinder-text-xs);
-  font-weight: var(--cinder-font-medium);
-  color: var(--cinder-text);
-  padding: 0;
-  margin: 0 0 var(--cinder-space-1) 0;
-}
+  .cinder-checkbox-group__legend {
+    font-size: var(--cinder-text-xs);
+    font-weight: var(--cinder-font-medium);
+    color: var(--cinder-text);
+    padding: 0;
+    margin: 0 0 var(--cinder-space-1) 0;
+  }
 
-.cinder-checkbox-group[disabled] .cinder-checkbox-group__legend {
-  color: var(--cinder-text-disabled);
-}
+  .cinder-checkbox-group[disabled] .cinder-checkbox-group__legend {
+    color: var(--cinder-text-disabled);
+  }
 
-/* When the group is disabled via native fieldset cascade, dim the label.
+  /* When the group is disabled via native fieldset cascade, dim the label.
  * checkbox.css styles .cinder-checkbox-field__label via [data-disabled] which
  * is set from the per-Checkbox prop — not from the inherited fieldset state.
  * This companion rule fixes the gap without editing checkbox.css. */
-.cinder-checkbox-group[disabled] .cinder-checkbox-field__label {
-  color: var(--cinder-text-disabled);
-  cursor: not-allowed;
-}
+  .cinder-checkbox-group[disabled] .cinder-checkbox-field__label {
+    color: var(--cinder-text-disabled);
+    cursor: not-allowed;
+  }
 
-.cinder-checkbox-group__items {
-  display: flex;
-  flex-direction: column;
-  gap: var(--cinder-space-2);
-}
+  .cinder-checkbox-group__items {
+    display: flex;
+    flex-direction: column;
+    gap: var(--cinder-space-2);
+  }
 
-.cinder-checkbox-group__description {
-  font-size: var(--cinder-text-xs);
-  line-height: var(--cinder-leading-normal);
-  color: var(--cinder-text-muted);
-  margin: 0;
-}
+  .cinder-checkbox-group__description {
+    font-size: var(--cinder-text-xs);
+    line-height: var(--cinder-leading-normal);
+    color: var(--cinder-text-muted);
+    margin: 0;
+  }
 
-.cinder-checkbox-group__error {
-  font-size: var(--cinder-text-xs);
-  line-height: var(--cinder-leading-normal);
-  color: var(--cinder-danger);
-  margin: 0;
-}
+  .cinder-checkbox-group__error {
+    font-size: var(--cinder-text-xs);
+    line-height: var(--cinder-leading-normal);
+    color: var(--cinder-danger);
+    margin: 0;
+  }
 
-/* ========================================
+  /* ========================================
  * CARD VARIANT
  * ======================================== */
 
-.cinder-checkbox-group[data-variant='card'] .cinder-checkbox-group__items > .cinder-checkbox-field {
-  border: 1px solid var(--cinder-border);
-  border-radius: var(--cinder-radius-md);
-  padding: var(--cinder-space-3);
-  background: var(--cinder-surface-raised);
-  transition:
-    border-color var(--cinder-duration-fast) var(--cinder-ease-standard),
-    background var(--cinder-duration-fast) var(--cinder-ease-standard);
-}
-
-/* Sticky-hover suppression on touch. The :not(:has(input:disabled)) exclusion
- * replaces a separate disabled-state reset rule. */
-@media (hover: hover) {
-  .cinder-checkbox-group[data-variant='card']
-    .cinder-checkbox-group__items
-    > .cinder-checkbox-field:hover:not(:has(input:disabled)) {
-    border-color: var(--cinder-border-strong);
-  }
-}
-
-/* Checked highlight — additive only; the check glyph is the canonical indicator. */
-.cinder-checkbox-group[data-variant='card']
-  .cinder-checkbox-group__items
-  > .cinder-checkbox-field:has(input:checked) {
-  border-color: var(--cinder-accent);
-}
-
-/* Disabled card — uses :has(input:disabled) because disabled state arrives via
- * native fieldset cascade, not a data attribute on the card element. */
-.cinder-checkbox-group[data-variant='card']
-  .cinder-checkbox-group__items
-  > .cinder-checkbox-field:has(input:disabled) {
-  background: var(--cinder-surface-inset);
-  border-color: var(--cinder-border-muted);
-  cursor: not-allowed;
-}
-
-@media (forced-colors: active) {
   .cinder-checkbox-group[data-variant='card']
     .cinder-checkbox-group__items
     > .cinder-checkbox-field {
-    border: 1px solid CanvasText;
+    border: 1px solid var(--cinder-border);
+    border-radius: var(--cinder-radius-md);
+    padding: var(--cinder-space-3);
+    background: var(--cinder-surface-raised);
+    transition:
+      border-color var(--cinder-duration-fast) var(--cinder-ease-standard),
+      background var(--cinder-duration-fast) var(--cinder-ease-standard);
   }
 
+  /* Sticky-hover suppression on touch. The :not(:has(input:disabled)) exclusion
+ * replaces a separate disabled-state reset rule. */
+  @media (hover: hover) {
+    .cinder-checkbox-group[data-variant='card']
+      .cinder-checkbox-group__items
+      > .cinder-checkbox-field:hover:not(:has(input:disabled)) {
+      border-color: var(--cinder-border-strong);
+    }
+  }
+
+  /* Checked highlight — additive only; the check glyph is the canonical indicator. */
   .cinder-checkbox-group[data-variant='card']
     .cinder-checkbox-group__items
     > .cinder-checkbox-field:has(input:checked) {
-    border: 2px solid Highlight;
+    border-color: var(--cinder-accent);
+  }
+
+  /* Disabled card — uses :has(input:disabled) because disabled state arrives via
+ * native fieldset cascade, not a data attribute on the card element. */
+  .cinder-checkbox-group[data-variant='card']
+    .cinder-checkbox-group__items
+    > .cinder-checkbox-field:has(input:disabled) {
+    background: var(--cinder-surface-inset);
+    border-color: var(--cinder-border-muted);
+    cursor: not-allowed;
+  }
+
+  @media (forced-colors: active) {
+    .cinder-checkbox-group[data-variant='card']
+      .cinder-checkbox-group__items
+      > .cinder-checkbox-field {
+      border: 1px solid CanvasText;
+    }
+
+    .cinder-checkbox-group[data-variant='card']
+      .cinder-checkbox-group__items
+      > .cinder-checkbox-field:has(input:checked) {
+      border: 2px solid Highlight;
+    }
   }
 }

--- a/packages/components/src/components/checkbox/checkbox.css
+++ b/packages/components/src/components/checkbox/checkbox.css
@@ -1,182 +1,184 @@
-/* ========================================
+@layer cinder.components {
+  /* ========================================
  * CHECKBOX
  * Styled native <input type="checkbox"> with description and error.
  * ======================================== */
 
-.cinder-checkbox-field {
-  display: flex;
-  flex-direction: column;
-  gap: var(--cinder-space-1-5);
-}
+  .cinder-checkbox-field {
+    display: flex;
+    flex-direction: column;
+    gap: var(--cinder-space-1-5);
+  }
 
-.cinder-checkbox-row {
-  display: inline-flex;
-  align-items: center;
-  gap: var(--cinder-space-2);
-}
+  .cinder-checkbox-row {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--cinder-space-2);
+  }
 
-.cinder-checkbox {
-  /* Custom-painted but native: keep the input in the layout so screen readers
+  .cinder-checkbox {
+    /* Custom-painted but native: keep the input in the layout so screen readers
    * and form submission see it; restyle via appearance:none. */
-  appearance: none;
-  width: 1.125rem;
-  height: 1.125rem;
-  margin: 0;
-  border: 1px solid var(--cinder-border);
-  border-radius: var(--cinder-radius-sm);
-  background: var(--cinder-surface-raised);
-  cursor: pointer;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  flex-shrink: 0;
-  transition:
-    border-color var(--cinder-duration-fast) var(--cinder-ease-standard),
-    background var(--cinder-duration-fast) var(--cinder-ease-standard),
-    box-shadow var(--cinder-duration-fast) var(--cinder-ease-standard);
-}
+    appearance: none;
+    width: 1.125rem;
+    height: 1.125rem;
+    margin: 0;
+    border: 1px solid var(--cinder-border);
+    border-radius: var(--cinder-radius-sm);
+    background: var(--cinder-surface-raised);
+    cursor: pointer;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+    transition:
+      border-color var(--cinder-duration-fast) var(--cinder-ease-standard),
+      background var(--cinder-duration-fast) var(--cinder-ease-standard),
+      box-shadow var(--cinder-duration-fast) var(--cinder-ease-standard);
+  }
 
-/* Sticky-hover suppression on touch: wrap hover-only chrome so it doesn't
+  /* Sticky-hover suppression on touch: wrap hover-only chrome so it doesn't
  * "stick" after tap on touch devices that emulate :hover. */
-@media (hover: hover) {
-  .cinder-checkbox:hover:not(:disabled) {
-    border-color: var(--cinder-border-strong);
+  @media (hover: hover) {
+    .cinder-checkbox:hover:not(:disabled) {
+      border-color: var(--cinder-border-strong);
+    }
   }
-}
 
-.cinder-checkbox:focus-visible {
-  outline: var(--cinder-ring-width) solid transparent;
-  box-shadow:
-    0 0 0 var(--cinder-ring-offset) var(--cinder-ring-offset-color),
-    0 0 0 calc(var(--cinder-ring-offset) + var(--cinder-ring-width))
-      var(--_cinder-checkbox-ring, var(--cinder-ring-color));
-}
-
-@media (forced-colors: active) {
   .cinder-checkbox:focus-visible {
-    outline: var(--cinder-ring-width) solid Highlight;
-    outline-offset: 1px;
+    outline: var(--cinder-ring-width) solid transparent;
+    box-shadow:
+      0 0 0 var(--cinder-ring-offset) var(--cinder-ring-offset-color),
+      0 0 0 calc(var(--cinder-ring-offset) + var(--cinder-ring-width))
+        var(--_cinder-checkbox-ring, var(--cinder-ring-color));
   }
-}
 
-/* Checked state — paint the box with the accent color. The visible glyph is
+  @media (forced-colors: active) {
+    .cinder-checkbox:focus-visible {
+      outline: var(--cinder-ring-width) solid Highlight;
+      outline-offset: 1px;
+    }
+  }
+
+  /* Checked state — paint the box with the accent color. The visible glyph is
  * drawn by the aria-hidden sibling indicator with `mask-image` so the icon
  * color tracks `--cinder-accent-contrast` through theme switches. */
-.cinder-checkbox:checked {
-  background: var(--cinder-accent);
-  border-color: var(--cinder-accent);
-}
+  .cinder-checkbox:checked {
+    background: var(--cinder-accent);
+    border-color: var(--cinder-accent);
+  }
 
-.cinder-checkbox:indeterminate {
-  background: var(--cinder-accent);
-  border-color: var(--cinder-accent);
-}
+  .cinder-checkbox:indeterminate {
+    background: var(--cinder-accent);
+    border-color: var(--cinder-accent);
+  }
 
-/* Sibling indicator: a square overlay centered on the input that is masked
+  /* Sibling indicator: a square overlay centered on the input that is masked
  * to the check or indeterminate glyph. The input still owns the border,
  * focus ring, and interaction; the indicator is non-interactive. */
 
-.cinder-checkbox-field__control {
-  position: relative;
-  display: inline-flex;
-  inline-size: 1.125rem;
-  block-size: 1.125rem;
-  flex-shrink: 0;
-}
+  .cinder-checkbox-field__control {
+    position: relative;
+    display: inline-flex;
+    inline-size: 1.125rem;
+    block-size: 1.125rem;
+    flex-shrink: 0;
+  }
 
-.cinder-checkbox-field__indicator {
-  --_cinder-checkbox-check-mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Cpath d='M12.7 4.3L6.5 10.6 3.3 7.4 2 8.7l4.5 4.5 7.6-7.6z'/%3E%3C/svg%3E");
-  --_cinder-checkbox-indeterminate-mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Crect x='3' y='7' width='10' height='2' rx='1'/%3E%3C/svg%3E");
+  .cinder-checkbox-field__indicator {
+    --_cinder-checkbox-check-mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Cpath d='M12.7 4.3L6.5 10.6 3.3 7.4 2 8.7l4.5 4.5 7.6-7.6z'/%3E%3C/svg%3E");
+    --_cinder-checkbox-indeterminate-mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Crect x='3' y='7' width='10' height='2' rx='1'/%3E%3C/svg%3E");
 
-  position: absolute;
-  inset-block-start: 50%;
-  inset-inline-start: 50%;
-  inline-size: 0.875rem;
-  block-size: 0.875rem;
-  transform: translate(-50%, -50%);
-  pointer-events: none;
-  z-index: 1;
-  opacity: 0;
+    position: absolute;
+    inset-block-start: 50%;
+    inset-inline-start: 50%;
+    inline-size: 0.875rem;
+    block-size: 0.875rem;
+    transform: translate(-50%, -50%);
+    pointer-events: none;
+    z-index: 1;
+    opacity: 0;
 
-  color: var(--cinder-accent-contrast);
-  background-color: currentColor;
+    color: var(--cinder-accent-contrast);
+    background-color: currentColor;
 
-  -webkit-mask-repeat: no-repeat;
-  mask-repeat: no-repeat;
-  -webkit-mask-position: center;
-  mask-position: center;
-  -webkit-mask-size: 0.875rem 0.875rem;
-  mask-size: 0.875rem 0.875rem;
-}
+    -webkit-mask-repeat: no-repeat;
+    mask-repeat: no-repeat;
+    -webkit-mask-position: center;
+    mask-position: center;
+    -webkit-mask-size: 0.875rem 0.875rem;
+    mask-size: 0.875rem 0.875rem;
+  }
 
-.cinder-checkbox:checked + .cinder-checkbox-field__indicator {
-  opacity: 1;
-  -webkit-mask-image: var(--_cinder-checkbox-check-mask);
-  mask-image: var(--_cinder-checkbox-check-mask);
-}
+  .cinder-checkbox:checked + .cinder-checkbox-field__indicator {
+    opacity: 1;
+    -webkit-mask-image: var(--_cinder-checkbox-check-mask);
+    mask-image: var(--_cinder-checkbox-check-mask);
+  }
 
-.cinder-checkbox:indeterminate + .cinder-checkbox-field__indicator {
-  opacity: 1;
-  -webkit-mask-image: var(--_cinder-checkbox-indeterminate-mask);
-  mask-image: var(--_cinder-checkbox-indeterminate-mask);
-}
+  .cinder-checkbox:indeterminate + .cinder-checkbox-field__indicator {
+    opacity: 1;
+    -webkit-mask-image: var(--_cinder-checkbox-indeterminate-mask);
+    mask-image: var(--_cinder-checkbox-indeterminate-mask);
+  }
 
-/* Forced Colors Mode: UA suppresses `background-color: currentColor`, so the
+  /* Forced Colors Mode: UA suppresses `background-color: currentColor`, so the
  * masked indicator becomes invisible. Opt out of forced-color adjustment for
  * the glyph and paint with a system color that survives the override. */
-@media (forced-colors: active) {
-  .cinder-checkbox:checked + .cinder-checkbox-field__indicator,
-  .cinder-checkbox:indeterminate + .cinder-checkbox-field__indicator {
-    forced-color-adjust: none;
-    background-color: ButtonText;
+  @media (forced-colors: active) {
+    .cinder-checkbox:checked + .cinder-checkbox-field__indicator,
+    .cinder-checkbox:indeterminate + .cinder-checkbox-field__indicator {
+      forced-color-adjust: none;
+      background-color: ButtonText;
+    }
   }
-}
 
-/* Disabled state */
-.cinder-checkbox:disabled {
-  cursor: not-allowed;
-  background: var(--cinder-surface-inset);
-  border-color: var(--cinder-border-muted);
-}
+  /* Disabled state */
+  .cinder-checkbox:disabled {
+    cursor: not-allowed;
+    background: var(--cinder-surface-inset);
+    border-color: var(--cinder-border-muted);
+  }
 
-.cinder-checkbox:disabled:checked,
-.cinder-checkbox:disabled:indeterminate {
-  background-color: var(--cinder-text-disabled);
-  border-color: var(--cinder-text-disabled);
-}
+  .cinder-checkbox:disabled:checked,
+  .cinder-checkbox:disabled:indeterminate {
+    background-color: var(--cinder-text-disabled);
+    border-color: var(--cinder-text-disabled);
+  }
 
-/* Error / invalid state */
-.cinder-checkbox[aria-invalid='true'] {
-  --_cinder-checkbox-ring: var(--cinder-danger);
-  border-color: var(--cinder-danger);
-}
+  /* Error / invalid state */
+  .cinder-checkbox[aria-invalid='true'] {
+    --_cinder-checkbox-ring: var(--cinder-danger);
+    border-color: var(--cinder-danger);
+  }
 
-/* Label */
-.cinder-checkbox-field__label {
-  font-size: var(--cinder-text-sm);
-  line-height: var(--cinder-leading-normal);
-  color: var(--cinder-text);
-  cursor: pointer;
-}
+  /* Label */
+  .cinder-checkbox-field__label {
+    font-size: var(--cinder-text-sm);
+    line-height: var(--cinder-leading-normal);
+    color: var(--cinder-text);
+    cursor: pointer;
+  }
 
-.cinder-checkbox-field__label[data-disabled] {
-  color: var(--cinder-text-disabled);
-  cursor: not-allowed;
-}
+  .cinder-checkbox-field__label[data-disabled] {
+    color: var(--cinder-text-disabled);
+    cursor: not-allowed;
+  }
 
-/* Supporting text */
-.cinder-checkbox-field__description {
-  font-size: var(--cinder-text-xs);
-  line-height: var(--cinder-leading-normal);
-  color: var(--cinder-text-muted);
-  margin: 0;
-  padding-inline-start: calc(1.125rem + var(--cinder-space-2));
-}
+  /* Supporting text */
+  .cinder-checkbox-field__description {
+    font-size: var(--cinder-text-xs);
+    line-height: var(--cinder-leading-normal);
+    color: var(--cinder-text-muted);
+    margin: 0;
+    padding-inline-start: calc(1.125rem + var(--cinder-space-2));
+  }
 
-.cinder-checkbox-field__error {
-  font-size: var(--cinder-text-xs);
-  line-height: var(--cinder-leading-normal);
-  color: var(--cinder-danger);
-  margin: 0;
-  padding-inline-start: calc(1.125rem + var(--cinder-space-2));
+  .cinder-checkbox-field__error {
+    font-size: var(--cinder-text-xs);
+    line-height: var(--cinder-leading-normal);
+    color: var(--cinder-danger);
+    margin: 0;
+    padding-inline-start: calc(1.125rem + var(--cinder-space-2));
+  }
 }

--- a/packages/components/src/components/chip/chip.css
+++ b/packages/components/src/components/chip/chip.css
@@ -1,261 +1,263 @@
-/* ========================================
+@layer cinder.components {
+  /* ========================================
  * CHIP
  * ======================================== */
 
-.cinder-chip {
-  display: inline-flex;
-  align-items: center;
-  gap: var(--cinder-space-1);
-  padding: var(--cinder-space-0-5) var(--cinder-space-2);
-  font-size: var(--cinder-text-xs);
-  font-weight: var(--cinder-font-medium);
-  line-height: 1.25;
-  border-radius: var(--cinder-radius-full);
-  border: 1px solid var(--cinder-border);
-  white-space: nowrap;
-  background: var(--cinder-surface-inset);
-  color: var(--cinder-text);
-  transition:
-    background-color var(--cinder-duration-fast) var(--cinder-ease-standard),
-    border-color var(--cinder-duration-fast) var(--cinder-ease-standard),
-    color var(--cinder-duration-fast) var(--cinder-ease-standard),
-    box-shadow var(--cinder-duration-fast) var(--cinder-ease-standard);
-}
+  .cinder-chip {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--cinder-space-1);
+    padding: var(--cinder-space-0-5) var(--cinder-space-2);
+    font-size: var(--cinder-text-xs);
+    font-weight: var(--cinder-font-medium);
+    line-height: 1.25;
+    border-radius: var(--cinder-radius-full);
+    border: 1px solid var(--cinder-border);
+    white-space: nowrap;
+    background: var(--cinder-surface-inset);
+    color: var(--cinder-text);
+    transition:
+      background-color var(--cinder-duration-fast) var(--cinder-ease-standard),
+      border-color var(--cinder-duration-fast) var(--cinder-ease-standard),
+      color var(--cinder-duration-fast) var(--cinder-ease-standard),
+      box-shadow var(--cinder-duration-fast) var(--cinder-ease-standard);
+  }
 
-/* Mode is expressed through internal affordances, never through a separate
+  /* Mode is expressed through internal affordances, never through a separate
  * chip-root surface. Display, resting toggle, and removable roots share this
  * same surface contract. */
 
-button.cinder-chip {
-  font: inherit;
-  cursor: pointer;
-  appearance: none;
-}
+  button.cinder-chip {
+    font: inherit;
+    cursor: pointer;
+    appearance: none;
+  }
 
-/* ----------------------------------------
+  /* ----------------------------------------
  * Size variants
  * ---------------------------------------- */
 
-.cinder-chip[data-cinder-size='sm'] {
-  font-size: var(--cinder-text-2xs, 0.625rem);
-  padding: 0 var(--cinder-space-1);
-  line-height: 1rem;
-}
+  .cinder-chip[data-cinder-size='sm'] {
+    font-size: var(--cinder-text-2xs, 0.625rem);
+    padding: 0 var(--cinder-space-1);
+    line-height: 1rem;
+  }
 
-.cinder-chip[data-cinder-size='md'] {
-  font-size: var(--cinder-text-xs);
-  padding: var(--cinder-space-0-5) var(--cinder-space-2);
-}
+  .cinder-chip[data-cinder-size='md'] {
+    font-size: var(--cinder-text-xs);
+    padding: var(--cinder-space-0-5) var(--cinder-space-2);
+  }
 
-/* density="toolbar": opt the chip into the shared --cinder-control-height-sm
+  /* density="toolbar": opt the chip into the shared --cinder-control-height-sm
  * tier so it lines up with sibling Button (size="sm") and SegmentedControl
  * (density="toolbar"). The base `display: inline-flex; align-items: center`
  * already centers the chip text vertically — we just need to set the box
  * height. box-sizing: border-box is explicit so border width does not push
  * the rendered height above 32px. */
-.cinder-chip[data-cinder-density='toolbar'] {
-  box-sizing: border-box;
-  min-block-size: var(--cinder-control-height-sm);
-}
+  .cinder-chip[data-cinder-density='toolbar'] {
+    box-sizing: border-box;
+    min-block-size: var(--cinder-control-height-sm);
+  }
 
-/* ----------------------------------------
+  /* ----------------------------------------
  * Color variants
  * ---------------------------------------- */
 
-.cinder-chip[data-cinder-variant='neutral'] {
-  background: var(--cinder-surface-inset);
-  color: var(--cinder-text);
-  border-color: var(--cinder-border);
-}
+  .cinder-chip[data-cinder-variant='neutral'] {
+    background: var(--cinder-surface-inset);
+    color: var(--cinder-text);
+    border-color: var(--cinder-border);
+  }
 
-.cinder-chip[data-cinder-variant='success'] {
-  background: var(--cinder-color-success-bg);
-  color: var(--cinder-color-success-fg);
-  border-color: var(--cinder-color-success-border);
-}
+  .cinder-chip[data-cinder-variant='success'] {
+    background: var(--cinder-color-success-bg);
+    color: var(--cinder-color-success-fg);
+    border-color: var(--cinder-color-success-border);
+  }
 
-.cinder-chip[data-cinder-variant='warning'] {
-  background: var(--cinder-color-warning-bg);
-  color: var(--cinder-color-warning-fg);
-  border-color: var(--cinder-color-warning-border);
-}
+  .cinder-chip[data-cinder-variant='warning'] {
+    background: var(--cinder-color-warning-bg);
+    color: var(--cinder-color-warning-fg);
+    border-color: var(--cinder-color-warning-border);
+  }
 
-.cinder-chip[data-cinder-variant='danger'] {
-  background: var(--cinder-color-danger-bg);
-  color: var(--cinder-color-danger-fg);
-  border-color: var(--cinder-color-danger-border);
-}
+  .cinder-chip[data-cinder-variant='danger'] {
+    background: var(--cinder-color-danger-bg);
+    color: var(--cinder-color-danger-fg);
+    border-color: var(--cinder-color-danger-border);
+  }
 
-.cinder-chip[data-cinder-variant='info'] {
-  background: var(--cinder-color-info-bg);
-  color: var(--cinder-color-info-fg);
-  border-color: var(--cinder-color-info-border);
-}
+  .cinder-chip[data-cinder-variant='info'] {
+    background: var(--cinder-color-info-bg);
+    color: var(--cinder-color-info-fg);
+    border-color: var(--cinder-color-info-border);
+  }
 
-.cinder-chip[data-cinder-variant='accent'] {
-  background: color-mix(in oklch, var(--cinder-accent), transparent 88%);
-  color: var(--cinder-accent);
-  border-color: color-mix(in oklch, var(--cinder-accent), transparent 60%);
-}
+  .cinder-chip[data-cinder-variant='accent'] {
+    background: color-mix(in oklch, var(--cinder-accent), transparent 88%);
+    color: var(--cinder-accent);
+    border-color: color-mix(in oklch, var(--cinder-accent), transparent 60%);
+  }
 
-/* ----------------------------------------
+  /* ----------------------------------------
  * Hover states (button chips only)
  * ---------------------------------------- */
 
-/* Hover tint: a flat overlay drawn over the chip's existing background.
+  /* Hover tint: a flat overlay drawn over the chip's existing background.
  * Uses `light-dark()` so the overlay darkens in light mode and lightens
  * in dark mode, following `color-scheme` (driven by `prefers-color-scheme`
  * and any `[data-theme]` override on an ancestor). This replaces a
  * `filter: brightness()` toggle that previously needed a
  * prefers-color-scheme media query. */
-/* Sticky-hover suppression on touch: hover-only chrome wrapped so it doesn't
+  /* Sticky-hover suppression on touch: hover-only chrome wrapped so it doesn't
  * "stick" after tap on touch devices that emulate :hover. */
-@media (hover: hover) {
-  button.cinder-chip:hover:not(:disabled) {
-    background-image: linear-gradient(
-      light-dark(oklch(0% 0 0 / 0.08), oklch(100% 0 0 / 0.1)),
-      light-dark(oklch(0% 0 0 / 0.08), oklch(100% 0 0 / 0.1))
-    );
+  @media (hover: hover) {
+    button.cinder-chip:hover:not(:disabled) {
+      background-image: linear-gradient(
+        light-dark(oklch(0% 0 0 / 0.08), oklch(100% 0 0 / 0.1)),
+        light-dark(oklch(0% 0 0 / 0.08), oklch(100% 0 0 / 0.1))
+      );
+    }
   }
-}
 
-/* ----------------------------------------
+  /* ----------------------------------------
  * Pressed state (toggle chips)
  * ---------------------------------------- */
 
-.cinder-chip[aria-pressed='true'][data-cinder-variant='neutral'] {
-  background: var(--cinder-surface-pressed);
-  color: var(--cinder-text);
-  border-color: var(--cinder-border-strong);
-}
+  .cinder-chip[aria-pressed='true'][data-cinder-variant='neutral'] {
+    background: var(--cinder-surface-pressed);
+    color: var(--cinder-text);
+    border-color: var(--cinder-border-strong);
+  }
 
-/* Neutral pressed state is a restrained selection shift on the shared chip
+  /* Neutral pressed state is a restrained selection shift on the shared chip
  * surface, not a full inversion. Status pressed recipes remain intentionally
  * separate until their readable-foreground cleanup lands. */
-.cinder-chip[aria-pressed='true'][data-cinder-variant='success'] {
-  background: var(--cinder-success);
-  color: var(--cinder-success-contrast);
-  border-color: var(--cinder-success);
-}
+  .cinder-chip[aria-pressed='true'][data-cinder-variant='success'] {
+    background: var(--cinder-success);
+    color: var(--cinder-success-contrast);
+    border-color: var(--cinder-success);
+  }
 
-.cinder-chip[aria-pressed='true'][data-cinder-variant='warning'] {
-  background: var(--cinder-warning);
-  color: var(--cinder-warning-contrast);
-  border-color: var(--cinder-warning);
-}
+  .cinder-chip[aria-pressed='true'][data-cinder-variant='warning'] {
+    background: var(--cinder-warning);
+    color: var(--cinder-warning-contrast);
+    border-color: var(--cinder-warning);
+  }
 
-.cinder-chip[aria-pressed='true'][data-cinder-variant='danger'] {
-  background: var(--cinder-danger);
-  color: var(--cinder-danger-contrast);
-  border-color: var(--cinder-danger);
-}
+  .cinder-chip[aria-pressed='true'][data-cinder-variant='danger'] {
+    background: var(--cinder-danger);
+    color: var(--cinder-danger-contrast);
+    border-color: var(--cinder-danger);
+  }
 
-.cinder-chip[aria-pressed='true'][data-cinder-variant='info'] {
-  background: var(--cinder-info);
-  color: var(--cinder-info-contrast);
-  border-color: var(--cinder-info);
-}
+  .cinder-chip[aria-pressed='true'][data-cinder-variant='info'] {
+    background: var(--cinder-info);
+    color: var(--cinder-info-contrast);
+    border-color: var(--cinder-info);
+  }
 
-.cinder-chip[aria-pressed='true'][data-cinder-variant='accent'] {
-  background: var(--cinder-accent);
-  color: var(--cinder-accent-contrast);
-  border-color: var(--cinder-accent);
-}
+  .cinder-chip[aria-pressed='true'][data-cinder-variant='accent'] {
+    background: var(--cinder-accent);
+    color: var(--cinder-accent-contrast);
+    border-color: var(--cinder-accent);
+  }
 
-/* ----------------------------------------
+  /* ----------------------------------------
  * Focus-visible ring
  * ---------------------------------------- */
 
-button.cinder-chip:focus-visible,
-.cinder-chip__remove:focus-visible {
-  outline: var(--cinder-ring-width) solid transparent;
-  box-shadow: var(--_cinder-focus-ring-shadow);
-}
-
-@media (forced-colors: active) {
   button.cinder-chip:focus-visible,
   .cinder-chip__remove:focus-visible {
-    outline: var(--cinder-ring-width) solid ButtonText;
-    outline-offset: 3px;
+    outline: var(--cinder-ring-width) solid transparent;
+    box-shadow: var(--_cinder-focus-ring-shadow);
   }
-}
 
-/* ----------------------------------------
+  @media (forced-colors: active) {
+    button.cinder-chip:focus-visible,
+    .cinder-chip__remove:focus-visible {
+      outline: var(--cinder-ring-width) solid ButtonText;
+      outline-offset: 3px;
+    }
+  }
+
+  /* ----------------------------------------
  * Disabled state
  * ---------------------------------------- */
 
-button.cinder-chip:disabled {
-  opacity: 0.5;
-  cursor: not-allowed;
-}
+  button.cinder-chip:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
 
-.cinder-chip__remove:disabled {
-  cursor: not-allowed;
-}
+  .cinder-chip__remove:disabled {
+    cursor: not-allowed;
+  }
 
-.cinder-chip[data-cinder-disabled] {
-  opacity: 0.5;
-  cursor: not-allowed;
-}
+  .cinder-chip[data-cinder-disabled] {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
 
-/* ----------------------------------------
+  /* ----------------------------------------
  * Icon slot
  * ---------------------------------------- */
 
-.cinder-chip__icon {
-  display: inline-flex;
-  align-items: center;
-  flex-shrink: 0;
-  line-height: 0;
-}
+  .cinder-chip__icon {
+    display: inline-flex;
+    align-items: center;
+    flex-shrink: 0;
+    line-height: 0;
+  }
 
-/* ----------------------------------------
+  /* ----------------------------------------
  * Remove button
  * ---------------------------------------- */
 
-.cinder-chip__remove {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  inline-size: 1rem;
-  block-size: 1rem;
-  padding: 0;
-  border: 0;
-  background: transparent;
-  color: inherit;
-  cursor: pointer;
-  border-radius: var(--cinder-radius-full);
-  font: inherit;
-  margin-inline-start: var(--cinder-space-0-5);
-  appearance: none;
-  /* Anchor the WCAG 2.5.5 hit-area pseudo-element. */
-  position: relative;
-}
-
-/* Expand the interactive hit area to 44×44 px (WCAG 2.5.5) without affecting layout.
- * Anchored to the right edge so the expansion never encroaches into the label on the left. */
-.cinder-chip__remove::after {
-  content: '';
-  position: absolute;
-  top: 50%;
-  right: 0;
-  width: 44px;
-  height: 44px;
-  transform: translateY(-50%);
-}
-
-@media (hover: hover) {
-  .cinder-chip__remove:hover:not(:disabled) {
-    background-color: var(--cinder-surface-hover);
+  .cinder-chip__remove {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    inline-size: 1rem;
+    block-size: 1rem;
+    padding: 0;
+    border: 0;
+    background: transparent;
+    color: inherit;
+    cursor: pointer;
+    border-radius: var(--cinder-radius-full);
+    font: inherit;
+    margin-inline-start: var(--cinder-space-0-5);
+    appearance: none;
+    /* Anchor the WCAG 2.5.5 hit-area pseudo-element. */
+    position: relative;
   }
-}
 
-/* ----------------------------------------
+  /* Expand the interactive hit area to 44×44 px (WCAG 2.5.5) without affecting layout.
+ * Anchored to the right edge so the expansion never encroaches into the label on the left. */
+  .cinder-chip__remove::after {
+    content: '';
+    position: absolute;
+    top: 50%;
+    right: 0;
+    width: 44px;
+    height: 44px;
+    transform: translateY(-50%);
+  }
+
+  @media (hover: hover) {
+    .cinder-chip__remove:hover:not(:disabled) {
+      background-color: var(--cinder-surface-hover);
+    }
+  }
+
+  /* ----------------------------------------
  * Reduced motion
  * ---------------------------------------- */
 
-@media (prefers-reduced-motion: reduce) {
-  .cinder-chip {
-    transition: none;
+  @media (prefers-reduced-motion: reduce) {
+    .cinder-chip {
+      transition: none;
+    }
   }
 }

--- a/packages/components/src/components/cluster/cluster.css
+++ b/packages/components/src/components/cluster/cluster.css
@@ -1,11 +1,13 @@
-/* ========================================
+@layer cinder.components {
+  /* ========================================
  * CLUSTER
  * ======================================== */
 
-.cinder-cluster {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: var(--cluster-align, center);
-  justify-content: var(--cluster-justify, flex-start);
-  gap: var(--cluster-gap, var(--cinder-space-2));
+  .cinder-cluster {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: var(--cluster-align, center);
+    justify-content: var(--cluster-justify, flex-start);
+    gap: var(--cluster-gap, var(--cinder-space-2));
+  }
 }

--- a/packages/components/src/components/code-block/code-block.css
+++ b/packages/components/src/components/code-block/code-block.css
@@ -1,4 +1,5 @@
-/* ========================================
+@layer cinder.components {
+  /* ========================================
  * CODE BLOCK
  * Preformatted code with optional language label and copy button.
  * Syntax highlighting is opt-in via the `highlighter` prop. Highlighter
@@ -6,107 +7,108 @@
  * normalized here so highlighted and plain blocks share the same chrome.
  * ======================================== */
 
-.cinder-code-block {
-  background: var(--cinder-surface-inset);
-  border: 1px solid var(--cinder-border);
-  border-radius: var(--cinder-radius-md);
-  overflow: hidden;
-}
+  .cinder-code-block {
+    background: var(--cinder-surface-inset);
+    border: 1px solid var(--cinder-border);
+    border-radius: var(--cinder-radius-md);
+    overflow: hidden;
+  }
 
-.cinder-code-block__header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: var(--cinder-space-2);
-  min-height: 2rem;
-  padding: var(--cinder-space-1-5) var(--cinder-space-3);
-  border-bottom: 1px solid var(--cinder-border-muted);
-  background: var(--cinder-surface-inset);
-}
+  .cinder-code-block__header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--cinder-space-2);
+    min-height: 2rem;
+    padding: var(--cinder-space-1-5) var(--cinder-space-3);
+    border-bottom: 1px solid var(--cinder-border-muted);
+    background: var(--cinder-surface-inset);
+  }
 
-.cinder-code-block__language {
-  font-size: var(--cinder-text-xs);
-  font-family: var(--cinder-font-mono);
-  color: var(--cinder-text-muted);
-  text-transform: uppercase;
-  letter-spacing: var(--cinder-tracking-wide);
-}
+  .cinder-code-block__language {
+    font-size: var(--cinder-text-xs);
+    font-family: var(--cinder-font-mono);
+    color: var(--cinder-text-muted);
+    text-transform: uppercase;
+    letter-spacing: var(--cinder-tracking-wide);
+  }
 
-.cinder-code-block__pre,
+  .cinder-code-block__pre,
 /* Highlighter output (e.g. Shiki) replaces __pre with its own markup
  * (typically <pre class="shiki ...">). Match it so the highlighted variant
  * inherits the same padding / font / line-height as the plain variant —
  * this is what Issue 6 was supposed to fix originally. */
 .cinder-code-block > pre {
-  margin: 0;
-  padding: var(--cinder-space-4);
-  overflow-x: auto;
-  font-family: var(--cinder-font-mono);
-  font-size: var(--cinder-text-sm);
-  line-height: var(--cinder-leading-relaxed);
-  color: var(--cinder-text);
-  background: var(--cinder-surface-inset);
-}
+    margin: 0;
+    padding: var(--cinder-space-4);
+    overflow-x: auto;
+    font-family: var(--cinder-font-mono);
+    font-size: var(--cinder-text-sm);
+    line-height: var(--cinder-leading-relaxed);
+    color: var(--cinder-text);
+    background: var(--cinder-surface-inset);
+  }
 
-.cinder-code-block__code {
-  font-family: inherit;
-  font-size: inherit;
-}
+  .cinder-code-block__code {
+    font-family: inherit;
+    font-size: inherit;
+  }
 
-.cinder-code-block :where(pre.shiki) {
-  margin: 0 !important;
-  padding: var(--cinder-space-3) var(--cinder-space-4) !important;
-  overflow-x: auto;
-  font-family: var(--cinder-font-mono);
-  font-size: var(--cinder-text-sm);
-  line-height: var(--cinder-leading-relaxed);
-  background: var(--cinder-surface-inset) !important;
-}
+  .cinder-code-block :where(pre.shiki) {
+    margin: 0 !important;
+    padding: var(--cinder-space-3) var(--cinder-space-4) !important;
+    overflow-x: auto;
+    font-family: var(--cinder-font-mono);
+    font-size: var(--cinder-text-sm);
+    line-height: var(--cinder-leading-relaxed);
+    background: var(--cinder-surface-inset) !important;
+  }
 
-.cinder-code-block :where(pre.shiki code) {
-  font-family: inherit;
-  font-size: inherit;
-}
+  .cinder-code-block :where(pre.shiki code) {
+    font-family: inherit;
+    font-size: inherit;
+  }
 
-/* Compact, borderless copy button when nested inside a code block header.
+  /* Compact, borderless copy button when nested inside a code block header.
  * Specificity bump (`.cinder-code-block .cinder-code-block__header .cinder-copy-button`)
  * is required because copy-button.css imports AFTER code-block.css in components.css;
  * with equal specificity the later import would win and the bordered default would
  * leak through. Scoped so the standalone CopyButton keeps its bordered default
  * everywhere else in the app. */
-.cinder-code-block .cinder-code-block__header .cinder-copy-button {
-  border: none;
-  background: transparent;
-  padding: var(--cinder-space-1);
-  color: var(--cinder-text-subtle);
-}
+  .cinder-code-block .cinder-code-block__header .cinder-copy-button {
+    border: none;
+    background: transparent;
+    padding: var(--cinder-space-1);
+    color: var(--cinder-text-subtle);
+  }
 
-.cinder-code-block .cinder-code-block__header .cinder-copy-button:focus-visible {
-  outline: var(--cinder-ring-width) solid transparent;
-  box-shadow: inset 0 0 0 var(--cinder-ring-width) var(--cinder-ring-color);
-}
-
-@media (forced-colors: active) {
   .cinder-code-block .cinder-code-block__header .cinder-copy-button:focus-visible {
-    outline-color: CanvasText;
-    box-shadow: none;
+    outline: var(--cinder-ring-width) solid transparent;
+    box-shadow: inset 0 0 0 var(--cinder-ring-width) var(--cinder-ring-color);
   }
-}
 
-/* Sticky-hover suppression on touch. */
-@media (hover: hover) {
-  .cinder-code-block .cinder-code-block__header .cinder-copy-button:hover {
-    background: var(--cinder-surface-hover);
-    color: var(--cinder-text);
-    border-color: transparent;
+  @media (forced-colors: active) {
+    .cinder-code-block .cinder-code-block__header .cinder-copy-button:focus-visible {
+      outline-color: CanvasText;
+      box-shadow: none;
+    }
   }
-}
 
-/* Stable wrapper that anchors {@html highlighted} for Svelte 5 reconciliation —
+  /* Sticky-hover suppression on touch. */
+  @media (hover: hover) {
+    .cinder-code-block .cinder-code-block__header .cinder-copy-button:hover {
+      background: var(--cinder-surface-hover);
+      color: var(--cinder-text);
+      border-color: transparent;
+    }
+  }
+
+  /* Stable wrapper that anchors {@html highlighted} for Svelte 5 reconciliation —
    Svelte appends new nodes alongside the old when an `{@html}` value changes
    between two non-null strings unless it sits inside a stable parent element.
    Purely structural: `display: contents` so it never affects layout. Target
    the inner `<pre>` (Shiki-emitted) for styling, not this wrapper. */
-.cinder-code-block__highlighted {
-  display: contents;
+  .cinder-code-block__highlighted {
+    display: contents;
+  }
 }

--- a/packages/components/src/components/collapsible/collapsible.css
+++ b/packages/components/src/components/collapsible/collapsible.css
@@ -1,114 +1,116 @@
-/* ========================================
+@layer cinder.components {
+  /* ========================================
  * COLLAPSIBLE
  * ======================================== */
 
-.cinder-collapsible {
-  display: block;
-}
+  .cinder-collapsible {
+    display: block;
+  }
 
-/* ----------------------------------------
+  /* ----------------------------------------
  * Trigger button
  * ---------------------------------------- */
 
-.cinder-collapsible__trigger {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: var(--cinder-space-4);
-  inline-size: 100%;
-  padding: var(--cinder-space-4) var(--cinder-space-5);
+  .cinder-collapsible__trigger {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--cinder-space-4);
+    inline-size: 100%;
+    padding: var(--cinder-space-4) var(--cinder-space-5);
 
-  font-size: var(--cinder-text-base);
-  font-weight: var(--cinder-font-medium);
-  line-height: var(--cinder-leading-snug);
-  color: var(--cinder-text);
-  text-align: start;
+    font-size: var(--cinder-text-base);
+    font-weight: var(--cinder-font-medium);
+    line-height: var(--cinder-leading-snug);
+    color: var(--cinder-text);
+    text-align: start;
 
-  background: transparent;
-  border: none;
-  border-radius: var(--cinder-radius-md);
-  cursor: pointer;
+    background: transparent;
+    border: none;
+    border-radius: var(--cinder-radius-md);
+    cursor: pointer;
 
-  transition:
-    background-color var(--cinder-duration-fast) var(--cinder-ease-standard),
-    color var(--cinder-duration-fast) var(--cinder-ease-standard);
-}
-
-/* Sticky-hover suppression on touch. */
-@media (hover: hover) {
-  .cinder-collapsible__trigger:hover:not(:disabled) {
-    background: var(--cinder-surface-hover);
+    transition:
+      background-color var(--cinder-duration-fast) var(--cinder-ease-standard),
+      color var(--cinder-duration-fast) var(--cinder-ease-standard);
   }
-}
 
-.cinder-collapsible__trigger:active:not(:disabled) {
-  background: var(--cinder-surface-pressed);
-}
+  /* Sticky-hover suppression on touch. */
+  @media (hover: hover) {
+    .cinder-collapsible__trigger:hover:not(:disabled) {
+      background: var(--cinder-surface-hover);
+    }
+  }
 
-.cinder-collapsible__trigger:focus-visible {
-  outline: var(--cinder-ring-width) solid var(--cinder-ring-color);
-  outline-offset: var(--cinder-ring-offset);
-}
+  .cinder-collapsible__trigger:active:not(:disabled) {
+    background: var(--cinder-surface-pressed);
+  }
 
-@media (forced-colors: active) {
   .cinder-collapsible__trigger:focus-visible {
-    outline: var(--cinder-ring-width) solid ButtonText;
+    outline: var(--cinder-ring-width) solid var(--cinder-ring-color);
+    outline-offset: var(--cinder-ring-offset);
   }
-}
 
-.cinder-collapsible__trigger:disabled {
-  cursor: not-allowed;
-  color: var(--cinder-text-disabled);
-  opacity: 0.6;
-}
+  @media (forced-colors: active) {
+    .cinder-collapsible__trigger:focus-visible {
+      outline: var(--cinder-ring-width) solid ButtonText;
+    }
+  }
 
-/* ----------------------------------------
+  .cinder-collapsible__trigger:disabled {
+    cursor: not-allowed;
+    color: var(--cinder-text-disabled);
+    opacity: 0.6;
+  }
+
+  /* ----------------------------------------
  * Label text
  * ---------------------------------------- */
 
-.cinder-collapsible__label {
-  flex: 1;
-}
+  .cinder-collapsible__label {
+    flex: 1;
+  }
 
-/* ----------------------------------------
+  /* ----------------------------------------
  * Chevron icon
  * ---------------------------------------- */
 
-.cinder-collapsible__chevron {
-  flex-shrink: 0;
-  width: 1.25rem;
-  height: 1.25rem;
-  color: var(--cinder-text-muted);
+  .cinder-collapsible__chevron {
+    flex-shrink: 0;
+    width: 1.25rem;
+    height: 1.25rem;
+    color: var(--cinder-text-muted);
 
-  transition: transform var(--cinder-duration-fast) var(--cinder-ease-standard);
-}
+    transition: transform var(--cinder-duration-fast) var(--cinder-ease-standard);
+  }
 
-.cinder-collapsible[data-cinder-expanded] .cinder-collapsible__chevron {
-  transform: rotate(180deg);
-}
+  .cinder-collapsible[data-cinder-expanded] .cinder-collapsible__chevron {
+    transform: rotate(180deg);
+  }
 
-.cinder-collapsible[data-cinder-disabled] .cinder-collapsible__chevron {
-  opacity: 0.4;
-}
+  .cinder-collapsible[data-cinder-disabled] .cinder-collapsible__chevron {
+    opacity: 0.4;
+  }
 
-/* ----------------------------------------
+  /* ----------------------------------------
  * Panel
  * ---------------------------------------- */
 
-.cinder-collapsible__panel-inner {
-  padding: var(--cinder-space-4) var(--cinder-space-5) var(--cinder-space-5);
-  font-size: var(--cinder-text-base);
-  line-height: var(--cinder-leading-normal);
-  color: var(--cinder-text-muted);
-}
+  .cinder-collapsible__panel-inner {
+    padding: var(--cinder-space-4) var(--cinder-space-5) var(--cinder-space-5);
+    font-size: var(--cinder-text-base);
+    line-height: var(--cinder-leading-normal);
+    color: var(--cinder-text-muted);
+  }
 
-/* ----------------------------------------
+  /* ----------------------------------------
  * Reduced motion — skip chevron rotation animation
  * (the slide transition duration is collapsed in the component)
  * ---------------------------------------- */
 
-@media (prefers-reduced-motion: reduce) {
-  .cinder-collapsible__chevron {
-    transition: none;
+  @media (prefers-reduced-motion: reduce) {
+    .cinder-collapsible__chevron {
+      transition: none;
+    }
   }
 }

--- a/packages/components/src/components/color-field/color-field.css
+++ b/packages/components/src/components/color-field/color-field.css
@@ -1,83 +1,85 @@
-/* ========================================
+@layer cinder.components {
+  /* ========================================
  * COLOR FIELD
  * ======================================== */
 
-.cinder-color-field {
-  display: contents;
-}
+  .cinder-color-field {
+    display: contents;
+  }
 
-.cinder-color-field__swatch {
-  display: inline-block;
-  width: 18px;
-  height: 18px;
-  border-radius: var(--cinder-radius-sm, 4px);
-  background-color: var(--cinder-color-field-swatch, transparent);
-  border: 1px solid var(--cinder-border, rgba(0, 0, 0, 0.12));
-  vertical-align: middle;
-}
+  .cinder-color-field__swatch {
+    display: inline-block;
+    width: 18px;
+    height: 18px;
+    border-radius: var(--cinder-radius-sm, 4px);
+    background-color: var(--cinder-color-field-swatch, transparent);
+    border: 1px solid var(--cinder-border, rgba(0, 0, 0, 0.12));
+    vertical-align: middle;
+  }
 
-.cinder-color-field__swatch[data-cinder-empty] {
-  /* "No color" affordance: a diagonal hatch reads as "nothing selected"
+  .cinder-color-field__swatch[data-cinder-empty] {
+    /* "No color" affordance: a diagonal hatch reads as "nothing selected"
      without being mistaken for an intentionally transparent color. */
-  background-color: transparent;
-  background-image: linear-gradient(
-    135deg,
-    transparent 0%,
-    transparent 45%,
-    var(--cinder-border, rgba(0, 0, 0, 0.35)) 45%,
-    var(--cinder-border, rgba(0, 0, 0, 0.35)) 55%,
-    transparent 55%,
-    transparent 100%
-  );
-  background-size: 6px 6px;
-}
+    background-color: transparent;
+    background-image: linear-gradient(
+      135deg,
+      transparent 0%,
+      transparent 45%,
+      var(--cinder-border, rgba(0, 0, 0, 0.35)) 45%,
+      var(--cinder-border, rgba(0, 0, 0, 0.35)) 55%,
+      transparent 55%,
+      transparent 100%
+    );
+    background-size: 6px 6px;
+  }
 
-.cinder-color-field__swatch[data-cinder-alpha]:not([data-cinder-empty]) {
-  /* Checker pattern so partially-transparent swatches remain visible. */
-  background-color: #fff;
-  background-image:
-    linear-gradient(
-      var(--cinder-color-field-swatch, transparent),
-      var(--cinder-color-field-swatch, transparent)
-    ),
-    linear-gradient(45deg, #ccc 25%, transparent 25%),
-    linear-gradient(-45deg, #ccc 25%, transparent 25%),
-    linear-gradient(45deg, transparent 75%, #ccc 75%),
-    linear-gradient(-45deg, transparent 75%, #ccc 75%);
-  background-size:
-    auto,
-    6px 6px,
-    6px 6px,
-    6px 6px,
-    6px 6px;
-  background-position:
-    0 0,
-    0 0,
-    0 3px,
-    3px -3px,
-    -3px 0;
-}
+  .cinder-color-field__swatch[data-cinder-alpha]:not([data-cinder-empty]) {
+    /* Checker pattern so partially-transparent swatches remain visible. */
+    background-color: #fff;
+    background-image:
+      linear-gradient(
+        var(--cinder-color-field-swatch, transparent),
+        var(--cinder-color-field-swatch, transparent)
+      ),
+      linear-gradient(45deg, #ccc 25%, transparent 25%),
+      linear-gradient(-45deg, #ccc 25%, transparent 25%),
+      linear-gradient(45deg, transparent 75%, #ccc 75%),
+      linear-gradient(-45deg, transparent 75%, #ccc 75%);
+    background-size:
+      auto,
+      6px 6px,
+      6px 6px,
+      6px 6px,
+      6px 6px;
+    background-position:
+      0 0,
+      0 0,
+      0 3px,
+      3px -3px,
+      -3px 0;
+  }
 
-/*
+  /*
  * Forced-colors mode strips background gradients to system tokens, which
  * flattens the swatch's checker pattern and makes empty / partial-alpha
  * states indistinguishable from opaque ones. Fall back to border styles so
  * the state remains visible.
  */
-@media (forced-colors: active) {
-  .cinder-color-field__swatch {
-    forced-color-adjust: none;
-    border-color: CanvasText;
-    background-color: ButtonFace;
-  }
+  @media (forced-colors: active) {
+    .cinder-color-field__swatch {
+      forced-color-adjust: none;
+      border-color: CanvasText;
+      background-color: ButtonFace;
+    }
 
-  .cinder-color-field__swatch[data-cinder-empty] {
-    background-image: none;
-    border-style: dashed;
-  }
+    .cinder-color-field__swatch[data-cinder-empty] {
+      background-image: none;
+      border-style: dashed;
+    }
 
-  .cinder-color-field__swatch[data-cinder-alpha]:not([data-cinder-empty]) {
-    background-image: none;
-    border-style: dotted;
+    .cinder-color-field__swatch[data-cinder-alpha]:not([data-cinder-empty]) {
+      background-image: none;
+      border-style: dotted;
+    }
   }
 }

--- a/packages/components/src/components/color-picker/color-picker.css
+++ b/packages/components/src/components/color-picker/color-picker.css
@@ -1,228 +1,230 @@
-/* ========================================
+@layer cinder.components {
+  /* ========================================
  * COLOR PICKER
  * ======================================== */
 
-.cinder-color-picker {
-  display: grid;
-  grid-template-columns: 1fr auto;
-  grid-template-areas:
-    'gradient gradient'
-    'hue preview'
-    'alpha preview'
-    'swatches swatches';
-  gap: var(--cinder-space-2);
-  width: 100%;
-  max-width: 280px;
-}
+  .cinder-color-picker {
+    display: grid;
+    grid-template-columns: 1fr auto;
+    grid-template-areas:
+      'gradient gradient'
+      'hue preview'
+      'alpha preview'
+      'swatches swatches';
+    gap: var(--cinder-space-2);
+    width: 100%;
+    max-width: 280px;
+  }
 
-.cinder-color-picker:not([data-cinder-alpha]) {
-  grid-template-areas:
-    'gradient gradient'
-    'hue preview'
-    'swatches swatches';
-}
+  .cinder-color-picker:not([data-cinder-alpha]) {
+    grid-template-areas:
+      'gradient gradient'
+      'hue preview'
+      'swatches swatches';
+  }
 
-.cinder-color-picker[data-cinder-disabled] {
-  opacity: 0.6;
-  cursor: not-allowed;
-}
+  .cinder-color-picker[data-cinder-disabled] {
+    opacity: 0.6;
+    cursor: not-allowed;
+  }
 
-/* ── 2D gradient ──────────────────────────────────────────────────────── */
+  /* ── 2D gradient ──────────────────────────────────────────────────────── */
 
-.cinder-color-picker__gradient {
-  grid-area: gradient;
-  position: relative;
-  width: 100%;
-  aspect-ratio: 4 / 3;
-  border-radius: var(--cinder-radius-sm, 4px);
-  background-color: var(--cinder-color-picker-hue, hsl(0, 100%, 50%));
-  background-image:
-    linear-gradient(to top, #000, transparent), linear-gradient(to right, #fff, transparent);
-  touch-action: none;
-  cursor: crosshair;
-  outline: none;
-}
+  .cinder-color-picker__gradient {
+    grid-area: gradient;
+    position: relative;
+    width: 100%;
+    aspect-ratio: 4 / 3;
+    border-radius: var(--cinder-radius-sm, 4px);
+    background-color: var(--cinder-color-picker-hue, hsl(0, 100%, 50%));
+    background-image:
+      linear-gradient(to top, #000, transparent), linear-gradient(to right, #fff, transparent);
+    touch-action: none;
+    cursor: crosshair;
+    outline: none;
+  }
 
-.cinder-color-picker__gradient:focus-visible {
-  outline: var(--cinder-ring-width, 2px) solid var(--cinder-ring-color, currentColor);
-  outline-offset: 2px;
-}
-
-.cinder-color-picker__gradient-handle {
-  position: absolute;
-  width: 14px;
-  height: 14px;
-  border: 2px solid #fff;
-  border-radius: 50%;
-  transform: translate(-50%, -50%);
-  box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.5);
-  pointer-events: none;
-}
-
-/* ── Sliders ──────────────────────────────────────────────────────────── */
-
-.cinder-color-picker__hue,
-.cinder-color-picker__alpha {
-  position: relative;
-  height: 12px;
-  border-radius: var(--cinder-radius-full);
-  outline: none;
-  touch-action: none;
-}
-
-.cinder-color-picker__hue {
-  grid-area: hue;
-  background: linear-gradient(
-    to right,
-    hsl(0, 100%, 50%),
-    hsl(60, 100%, 50%),
-    hsl(120, 100%, 50%),
-    hsl(180, 100%, 50%),
-    hsl(240, 100%, 50%),
-    hsl(300, 100%, 50%),
-    hsl(360, 100%, 50%)
-  );
-}
-
-.cinder-color-picker__alpha {
-  grid-area: alpha;
-  /* Intentional: literal white backing for the transparency checkerboard, not a theme surface. */
-  background-color: #fff;
-  background-image:
-    linear-gradient(to right, transparent, var(--cinder-color-picker-base, currentColor)),
-    linear-gradient(45deg, #ccc 25%, transparent 25%),
-    linear-gradient(-45deg, #ccc 25%, transparent 25%),
-    linear-gradient(45deg, transparent 75%, #ccc 75%),
-    linear-gradient(-45deg, transparent 75%, #ccc 75%);
-  background-size:
-    auto,
-    8px 8px,
-    8px 8px,
-    8px 8px,
-    8px 8px;
-  background-position:
-    0 0,
-    0 0,
-    0 4px,
-    4px -4px,
-    -4px 0;
-}
-
-.cinder-color-picker__hue:focus-visible,
-.cinder-color-picker__alpha:focus-visible {
-  outline: var(--cinder-ring-width, 2px) solid var(--cinder-ring-color, currentColor);
-  outline-offset: 2px;
-}
-
-.cinder-color-picker__hue-thumb,
-.cinder-color-picker__alpha-thumb {
-  position: absolute;
-  top: 50%;
-  width: 14px;
-  height: 14px;
-  border: 2px solid #fff;
-  border-radius: 50%;
-  background: transparent;
-  transform: translate(-50%, -50%);
-  box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.5);
-  pointer-events: none;
-}
-
-/* ── Preview ──────────────────────────────────────────────────────────── */
-
-.cinder-color-picker__preview {
-  grid-area: preview;
-  width: 36px;
-  height: 36px;
-  border-radius: 50%;
-  background-color: var(--cinder-color-picker-preview, transparent);
-  align-self: center;
-  justify-self: center;
-}
-
-.cinder-color-picker__preview[data-cinder-alpha] {
-  /* Intentional: literal white backing for the transparency checkerboard, not a theme surface. */
-  background-color: #fff;
-  background-image:
-    linear-gradient(
-      var(--cinder-color-picker-preview, transparent),
-      var(--cinder-color-picker-preview, transparent)
-    ),
-    linear-gradient(45deg, #ccc 25%, transparent 25%),
-    linear-gradient(-45deg, #ccc 25%, transparent 25%),
-    linear-gradient(45deg, transparent 75%, #ccc 75%),
-    linear-gradient(-45deg, transparent 75%, #ccc 75%);
-  background-size:
-    auto,
-    8px 8px,
-    8px 8px,
-    8px 8px,
-    8px 8px;
-  background-position:
-    0 0,
-    0 0,
-    0 4px,
-    4px -4px,
-    -4px 0;
-}
-
-/* ── Swatches ─────────────────────────────────────────────────────────── */
-
-.cinder-color-picker__swatches {
-  grid-area: swatches;
-  display: flex;
-  flex-wrap: wrap;
-  gap: var(--cinder-space-2, 8px);
-  list-style: none;
-  margin: 0;
-  padding: 0;
-}
-
-.cinder-color-picker__swatch {
-  align-items: center;
-  display: inline-flex;
-  justify-content: center;
-  width: 20px;
-  height: 20px;
-  border-radius: 50%;
-  cursor: pointer;
-  background-color: var(--cinder-color-picker-swatch);
-  border: 1px solid var(--cinder-border, rgba(0, 0, 0, 0.1));
-  outline: none;
-}
-
-.cinder-color-picker__swatch[data-cinder-selected] {
-  border-color: color-mix(in srgb, var(--cinder-border, rgba(0, 0, 0, 0.1)) 20%, currentColor);
-  box-shadow: 0 0 0 1px color-mix(in srgb, currentColor 18%, transparent);
-}
-
-.cinder-color-picker__swatch:focus-visible {
-  outline: var(--cinder-ring-width, 2px) solid var(--cinder-ring-color, currentColor);
-  outline-offset: 2px;
-}
-
-.cinder-color-picker__swatch-indicator {
-  display: inline-flex;
-  inline-size: 0.75rem;
-  block-size: 0.75rem;
-  pointer-events: none;
-}
-
-.cinder-color-picker__swatch-indicator :global(svg) {
-  inline-size: 100%;
-  block-size: 100%;
-}
-
-@media (forced-colors: active) {
-  .cinder-color-picker__gradient:focus,
-  .cinder-color-picker__gradient:focus-visible,
-  .cinder-color-picker__hue:focus,
-  .cinder-color-picker__hue:focus-visible,
-  .cinder-color-picker__alpha:focus,
-  .cinder-color-picker__alpha:focus-visible,
-  .cinder-color-picker__swatch:focus,
-  .cinder-color-picker__swatch:focus-visible {
-    outline: 3px solid Highlight;
+  .cinder-color-picker__gradient:focus-visible {
+    outline: var(--cinder-ring-width, 2px) solid var(--cinder-ring-color, currentColor);
     outline-offset: 2px;
+  }
+
+  .cinder-color-picker__gradient-handle {
+    position: absolute;
+    width: 14px;
+    height: 14px;
+    border: 2px solid #fff;
+    border-radius: 50%;
+    transform: translate(-50%, -50%);
+    box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.5);
+    pointer-events: none;
+  }
+
+  /* ── Sliders ──────────────────────────────────────────────────────────── */
+
+  .cinder-color-picker__hue,
+  .cinder-color-picker__alpha {
+    position: relative;
+    height: 12px;
+    border-radius: var(--cinder-radius-full);
+    outline: none;
+    touch-action: none;
+  }
+
+  .cinder-color-picker__hue {
+    grid-area: hue;
+    background: linear-gradient(
+      to right,
+      hsl(0, 100%, 50%),
+      hsl(60, 100%, 50%),
+      hsl(120, 100%, 50%),
+      hsl(180, 100%, 50%),
+      hsl(240, 100%, 50%),
+      hsl(300, 100%, 50%),
+      hsl(360, 100%, 50%)
+    );
+  }
+
+  .cinder-color-picker__alpha {
+    grid-area: alpha;
+    /* Intentional: literal white backing for the transparency checkerboard, not a theme surface. */
+    background-color: #fff;
+    background-image:
+      linear-gradient(to right, transparent, var(--cinder-color-picker-base, currentColor)),
+      linear-gradient(45deg, #ccc 25%, transparent 25%),
+      linear-gradient(-45deg, #ccc 25%, transparent 25%),
+      linear-gradient(45deg, transparent 75%, #ccc 75%),
+      linear-gradient(-45deg, transparent 75%, #ccc 75%);
+    background-size:
+      auto,
+      8px 8px,
+      8px 8px,
+      8px 8px,
+      8px 8px;
+    background-position:
+      0 0,
+      0 0,
+      0 4px,
+      4px -4px,
+      -4px 0;
+  }
+
+  .cinder-color-picker__hue:focus-visible,
+  .cinder-color-picker__alpha:focus-visible {
+    outline: var(--cinder-ring-width, 2px) solid var(--cinder-ring-color, currentColor);
+    outline-offset: 2px;
+  }
+
+  .cinder-color-picker__hue-thumb,
+  .cinder-color-picker__alpha-thumb {
+    position: absolute;
+    top: 50%;
+    width: 14px;
+    height: 14px;
+    border: 2px solid #fff;
+    border-radius: 50%;
+    background: transparent;
+    transform: translate(-50%, -50%);
+    box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.5);
+    pointer-events: none;
+  }
+
+  /* ── Preview ──────────────────────────────────────────────────────────── */
+
+  .cinder-color-picker__preview {
+    grid-area: preview;
+    width: 36px;
+    height: 36px;
+    border-radius: 50%;
+    background-color: var(--cinder-color-picker-preview, transparent);
+    align-self: center;
+    justify-self: center;
+  }
+
+  .cinder-color-picker__preview[data-cinder-alpha] {
+    /* Intentional: literal white backing for the transparency checkerboard, not a theme surface. */
+    background-color: #fff;
+    background-image:
+      linear-gradient(
+        var(--cinder-color-picker-preview, transparent),
+        var(--cinder-color-picker-preview, transparent)
+      ),
+      linear-gradient(45deg, #ccc 25%, transparent 25%),
+      linear-gradient(-45deg, #ccc 25%, transparent 25%),
+      linear-gradient(45deg, transparent 75%, #ccc 75%),
+      linear-gradient(-45deg, transparent 75%, #ccc 75%);
+    background-size:
+      auto,
+      8px 8px,
+      8px 8px,
+      8px 8px,
+      8px 8px;
+    background-position:
+      0 0,
+      0 0,
+      0 4px,
+      4px -4px,
+      -4px 0;
+  }
+
+  /* ── Swatches ─────────────────────────────────────────────────────────── */
+
+  .cinder-color-picker__swatches {
+    grid-area: swatches;
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--cinder-space-2, 8px);
+    list-style: none;
+    margin: 0;
+    padding: 0;
+  }
+
+  .cinder-color-picker__swatch {
+    align-items: center;
+    display: inline-flex;
+    justify-content: center;
+    width: 20px;
+    height: 20px;
+    border-radius: 50%;
+    cursor: pointer;
+    background-color: var(--cinder-color-picker-swatch);
+    border: 1px solid var(--cinder-border, rgba(0, 0, 0, 0.1));
+    outline: none;
+  }
+
+  .cinder-color-picker__swatch[data-cinder-selected] {
+    border-color: color-mix(in srgb, var(--cinder-border, rgba(0, 0, 0, 0.1)) 20%, currentColor);
+    box-shadow: 0 0 0 1px color-mix(in srgb, currentColor 18%, transparent);
+  }
+
+  .cinder-color-picker__swatch:focus-visible {
+    outline: var(--cinder-ring-width, 2px) solid var(--cinder-ring-color, currentColor);
+    outline-offset: 2px;
+  }
+
+  .cinder-color-picker__swatch-indicator {
+    display: inline-flex;
+    inline-size: 0.75rem;
+    block-size: 0.75rem;
+    pointer-events: none;
+  }
+
+  .cinder-color-picker__swatch-indicator :global(svg) {
+    inline-size: 100%;
+    block-size: 100%;
+  }
+
+  @media (forced-colors: active) {
+    .cinder-color-picker__gradient:focus,
+    .cinder-color-picker__gradient:focus-visible,
+    .cinder-color-picker__hue:focus,
+    .cinder-color-picker__hue:focus-visible,
+    .cinder-color-picker__alpha:focus,
+    .cinder-color-picker__alpha:focus-visible,
+    .cinder-color-picker__swatch:focus,
+    .cinder-color-picker__swatch:focus-visible {
+      outline: 3px solid Highlight;
+      outline-offset: 2px;
+    }
   }
 }

--- a/packages/components/src/components/color-swatch-picker/color-swatch-picker.css
+++ b/packages/components/src/components/color-swatch-picker/color-swatch-picker.css
@@ -1,158 +1,160 @@
-/* ========================================
+@layer cinder.components {
+  /* ========================================
  * COLOR SWATCH PICKER
  * ======================================== */
 
-.cinder-color-swatch-picker {
-  display: flex;
-  flex-wrap: wrap;
-  gap: var(--cinder-space-2);
-  list-style: none;
-  margin: 0;
-  padding: 0;
-}
+  .cinder-color-swatch-picker {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--cinder-space-2);
+    list-style: none;
+    margin: 0;
+    padding: 0;
+  }
 
-.cinder-color-swatch-picker[data-cinder-layout='stack'] {
-  flex-direction: column;
-  flex-wrap: nowrap;
-}
+  .cinder-color-swatch-picker[data-cinder-layout='stack'] {
+    flex-direction: column;
+    flex-wrap: nowrap;
+  }
 
-/* ── Size → swatch dimensions ───────────────────────────────────────────── */
+  /* ── Size → swatch dimensions ───────────────────────────────────────────── */
 
-.cinder-color-swatch-picker[data-cinder-size='xs'] {
-  --swatch-size: 16px;
-}
+  .cinder-color-swatch-picker[data-cinder-size='xs'] {
+    --swatch-size: 16px;
+  }
 
-.cinder-color-swatch-picker[data-cinder-size='sm'] {
-  --swatch-size: 24px;
-}
+  .cinder-color-swatch-picker[data-cinder-size='sm'] {
+    --swatch-size: 24px;
+  }
 
-.cinder-color-swatch-picker[data-cinder-size='md'] {
-  --swatch-size: 32px;
-}
+  .cinder-color-swatch-picker[data-cinder-size='md'] {
+    --swatch-size: 32px;
+  }
 
-.cinder-color-swatch-picker[data-cinder-size='lg'] {
-  --swatch-size: 36px;
-}
+  .cinder-color-swatch-picker[data-cinder-size='lg'] {
+    --swatch-size: 36px;
+  }
 
-.cinder-color-swatch-picker[data-cinder-size='xl'] {
-  --swatch-size: 40px;
-}
+  .cinder-color-swatch-picker[data-cinder-size='xl'] {
+    --swatch-size: 40px;
+  }
 
-/* ── Swatch base ─────────────────────────────────────────────────────────── */
+  /* ── Swatch base ─────────────────────────────────────────────────────────── */
 
-.cinder-color-swatch-picker__swatch {
-  position: relative;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: var(--swatch-size, 32px);
-  height: var(--swatch-size, 32px);
-  cursor: pointer;
-  background-color: var(--swatch-color);
-  border: none;
-  padding: 0;
-  outline: none;
-  flex-shrink: 0;
-}
+  .cinder-color-swatch-picker__swatch {
+    position: relative;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: var(--swatch-size, 32px);
+    height: var(--swatch-size, 32px);
+    cursor: pointer;
+    background-color: var(--swatch-color);
+    border: none;
+    padding: 0;
+    outline: none;
+    flex-shrink: 0;
+  }
 
-/* ── Shape variants ─────────────────────────────────────────────────────── */
+  /* ── Shape variants ─────────────────────────────────────────────────────── */
 
-.cinder-color-swatch-picker[data-cinder-shape='circle'] .cinder-color-swatch-picker__swatch {
-  border-radius: 50%;
-}
+  .cinder-color-swatch-picker[data-cinder-shape='circle'] .cinder-color-swatch-picker__swatch {
+    border-radius: 50%;
+  }
 
-.cinder-color-swatch-picker[data-cinder-shape='square'] .cinder-color-swatch-picker__swatch {
-  border-radius: var(--cinder-radius-sm);
-}
+  .cinder-color-swatch-picker[data-cinder-shape='square'] .cinder-color-swatch-picker__swatch {
+    border-radius: var(--cinder-radius-sm);
+  }
 
-/* ── Alpha checkerboard — color layer on top, checkerboard beneath ──────── */
+  /* ── Alpha checkerboard — color layer on top, checkerboard beneath ──────── */
 
-.cinder-color-swatch-picker__swatch[data-cinder-alpha] {
-  /* Intentional: literal white backing for the transparency checkerboard, not a theme surface. */
-  background-color: #fff;
-  background-image:
-    linear-gradient(var(--swatch-color), var(--swatch-color)),
-    linear-gradient(45deg, #ccc 25%, transparent 25%),
-    linear-gradient(-45deg, #ccc 25%, transparent 25%),
-    linear-gradient(45deg, transparent 75%, #ccc 75%),
-    linear-gradient(-45deg, transparent 75%, #ccc 75%);
-  background-size:
-    auto,
-    8px 8px,
-    8px 8px,
-    8px 8px,
-    8px 8px;
-  background-position:
-    0 0,
-    0 0,
-    0 4px,
-    4px -4px,
-    -4px 0;
-}
+  .cinder-color-swatch-picker__swatch[data-cinder-alpha] {
+    /* Intentional: literal white backing for the transparency checkerboard, not a theme surface. */
+    background-color: #fff;
+    background-image:
+      linear-gradient(var(--swatch-color), var(--swatch-color)),
+      linear-gradient(45deg, #ccc 25%, transparent 25%),
+      linear-gradient(-45deg, #ccc 25%, transparent 25%),
+      linear-gradient(45deg, transparent 75%, #ccc 75%),
+      linear-gradient(-45deg, transparent 75%, #ccc 75%);
+    background-size:
+      auto,
+      8px 8px,
+      8px 8px,
+      8px 8px,
+      8px 8px;
+    background-position:
+      0 0,
+      0 0,
+      0 4px,
+      4px -4px,
+      -4px 0;
+  }
 
-/* ── Focus ring ─────────────────────────────────────────────────────────── */
+  /* ── Focus ring ─────────────────────────────────────────────────────────── */
 
-.cinder-color-swatch-picker__swatch:focus-visible {
-  outline: var(--cinder-ring-width, 2px) solid transparent;
-  box-shadow:
-    0 0 0 var(--cinder-ring-offset, 2px) var(--cinder-ring-offset-color, transparent),
-    0 0 0 calc(var(--cinder-ring-offset, 2px) + var(--cinder-ring-width, 2px))
-      var(--cinder-ring-color, currentColor);
-  z-index: 1;
-}
+  .cinder-color-swatch-picker__swatch:focus-visible {
+    outline: var(--cinder-ring-width, 2px) solid transparent;
+    box-shadow:
+      0 0 0 var(--cinder-ring-offset, 2px) var(--cinder-ring-offset-color, transparent),
+      0 0 0 calc(var(--cinder-ring-offset, 2px) + var(--cinder-ring-width, 2px))
+        var(--cinder-ring-color, currentColor);
+    z-index: 1;
+  }
 
-/* Forced Colors Mode (Windows High Contrast): box-shadow is ignored so the
+  /* Forced Colors Mode (Windows High Contrast): box-shadow is ignored so the
  * focus ring would be invisible without this override. Use Highlight to match
  * the system's chosen focus color.
  */
-@media (forced-colors: active) {
-  .cinder-color-swatch-picker__swatch:focus-visible {
-    outline: 3px solid Highlight;
-    outline-offset: 2px;
-  }
-}
-
-/* ── Disabled item ──────────────────────────────────────────────────────── */
-
-.cinder-color-swatch-picker__swatch[data-cinder-disabled] {
-  cursor: not-allowed;
-  opacity: 0.4;
-}
-
-/* ── Disabled group ─────────────────────────────────────────────────────── */
-
-.cinder-color-swatch-picker[aria-disabled='true'] {
-  opacity: 0.6;
-  cursor: not-allowed;
-}
-
-.cinder-color-swatch-picker[aria-disabled='true'] .cinder-color-swatch-picker__swatch {
-  cursor: not-allowed;
-}
-
-/* ── Indicator icon ─────────────────────────────────────────────────────── */
-
-.cinder-color-swatch-picker__indicator {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  pointer-events: none;
-  /* 60% of swatch size, clamped to 12px minimum for xs legibility */
-  width: max(12px, calc(var(--swatch-size, 32px) * 0.6));
-  height: max(12px, calc(var(--swatch-size, 32px) * 0.6));
-}
-
-/* ── Hover / focus scale — respects prefers-reduced-motion ─────────────── */
-
-@media (prefers-reduced-motion: no-preference) {
-  .cinder-color-swatch-picker__swatch {
-    transition: transform var(--cinder-duration-fast, 120ms) var(--cinder-ease-standard, ease);
+  @media (forced-colors: active) {
+    .cinder-color-swatch-picker__swatch:focus-visible {
+      outline: 3px solid Highlight;
+      outline-offset: 2px;
+    }
   }
 
-  .cinder-color-swatch-picker:not([aria-disabled='true'])
-    .cinder-color-swatch-picker__swatch:hover:not([data-cinder-disabled]),
-  .cinder-color-swatch-picker:not([aria-disabled='true'])
-    .cinder-color-swatch-picker__swatch:focus-visible:not([data-cinder-disabled]) {
-    transform: scale(1.06);
+  /* ── Disabled item ──────────────────────────────────────────────────────── */
+
+  .cinder-color-swatch-picker__swatch[data-cinder-disabled] {
+    cursor: not-allowed;
+    opacity: 0.4;
+  }
+
+  /* ── Disabled group ─────────────────────────────────────────────────────── */
+
+  .cinder-color-swatch-picker[aria-disabled='true'] {
+    opacity: 0.6;
+    cursor: not-allowed;
+  }
+
+  .cinder-color-swatch-picker[aria-disabled='true'] .cinder-color-swatch-picker__swatch {
+    cursor: not-allowed;
+  }
+
+  /* ── Indicator icon ─────────────────────────────────────────────────────── */
+
+  .cinder-color-swatch-picker__indicator {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    pointer-events: none;
+    /* 60% of swatch size, clamped to 12px minimum for xs legibility */
+    width: max(12px, calc(var(--swatch-size, 32px) * 0.6));
+    height: max(12px, calc(var(--swatch-size, 32px) * 0.6));
+  }
+
+  /* ── Hover / focus scale — respects prefers-reduced-motion ─────────────── */
+
+  @media (prefers-reduced-motion: no-preference) {
+    .cinder-color-swatch-picker__swatch {
+      transition: transform var(--cinder-duration-fast, 120ms) var(--cinder-ease-standard, ease);
+    }
+
+    .cinder-color-swatch-picker:not([aria-disabled='true'])
+      .cinder-color-swatch-picker__swatch:hover:not([data-cinder-disabled]),
+    .cinder-color-swatch-picker:not([aria-disabled='true'])
+      .cinder-color-swatch-picker__swatch:focus-visible:not([data-cinder-disabled]) {
+      transform: scale(1.06);
+    }
   }
 }

--- a/packages/components/src/components/combobox/combobox.css
+++ b/packages/components/src/components/combobox/combobox.css
@@ -1,189 +1,191 @@
-/* ========================================
+@layer cinder.components {
+  /* ========================================
  * COMBOBOX
  * Single-select with synchronous local filtering.
  * ======================================== */
 
-.cinder-combobox {
-  position: relative;
-  display: flex;
-  flex-direction: column;
-  gap: var(--cinder-space-1-5);
-}
-
-.cinder-combobox__label {
-  font-size: var(--cinder-text-xs);
-  font-weight: var(--cinder-font-medium);
-  color: var(--cinder-text);
-}
-
-.cinder-combobox__label[data-disabled] {
-  color: var(--cinder-text-disabled);
-}
-
-.cinder-combobox__control {
-  position: relative;
-}
-
-.cinder-combobox__input {
-  display: block;
-  width: 100%;
-  min-height: 2.25rem;
-  padding: var(--cinder-space-1-5) var(--cinder-space-3);
-  font-size: var(--cinder-text-sm);
-  font-family: inherit;
-  line-height: var(--cinder-leading-normal);
-  color: var(--cinder-text);
-  background: var(--cinder-surface-raised);
-  border: 1px solid var(--cinder-border);
-  border-radius: var(--cinder-radius-md);
-  appearance: none;
-  transition:
-    border-color var(--cinder-duration-fast) var(--cinder-ease-standard),
-    box-shadow var(--cinder-duration-fast) var(--cinder-ease-standard);
-}
-
-/* Sticky-hover suppression on touch. */
-@media (hover: hover) {
-  .cinder-combobox__input:hover:not(:disabled) {
-    border-color: var(--cinder-border-strong);
+  .cinder-combobox {
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    gap: var(--cinder-space-1-5);
   }
-}
 
-.cinder-combobox__input:focus-visible {
-  outline: var(--cinder-ring-width) solid transparent;
-  box-shadow: var(--_cinder-focus-ring-shadow);
-}
+  .cinder-combobox__label {
+    font-size: var(--cinder-text-xs);
+    font-weight: var(--cinder-font-medium);
+    color: var(--cinder-text);
+  }
 
-.cinder-combobox__input[aria-invalid='true'] {
-  border-color: var(--cinder-danger);
-}
+  .cinder-combobox__label[data-disabled] {
+    color: var(--cinder-text-disabled);
+  }
 
-.cinder-combobox__input:disabled {
-  background: var(--cinder-surface-inset);
-  color: var(--cinder-text-disabled);
-  border-color: var(--cinder-border-muted);
-  cursor: not-allowed;
-}
+  .cinder-combobox__control {
+    position: relative;
+  }
 
-.cinder-combobox__listbox {
-  position: absolute;
-  top: 100%;
-  left: 0;
-  right: 0;
-  margin: var(--cinder-space-1) 0 0 0;
-  padding: var(--cinder-space-1);
-  list-style: none;
-  background: var(--cinder-surface-raised);
-  border: 1px solid var(--cinder-border);
-  border-radius: var(--cinder-radius-md);
-  box-shadow: var(--cinder-shadow-md);
-  max-height: 16rem;
-  overflow-y: auto;
-  z-index: var(--cinder-z-popover);
-}
+  .cinder-combobox__input {
+    display: block;
+    width: 100%;
+    min-height: 2.25rem;
+    padding: var(--cinder-space-1-5) var(--cinder-space-3);
+    font-size: var(--cinder-text-sm);
+    font-family: inherit;
+    line-height: var(--cinder-leading-normal);
+    color: var(--cinder-text);
+    background: var(--cinder-surface-raised);
+    border: 1px solid var(--cinder-border);
+    border-radius: var(--cinder-radius-md);
+    appearance: none;
+    transition:
+      border-color var(--cinder-duration-fast) var(--cinder-ease-standard),
+      box-shadow var(--cinder-duration-fast) var(--cinder-ease-standard);
+  }
 
-.cinder-combobox__option {
-  display: flex;
-  align-items: center;
-  gap: var(--cinder-space-2);
-  padding: var(--cinder-space-1-5) var(--cinder-space-3);
-  border-radius: var(--cinder-radius-sm);
-  cursor: pointer;
-  font-size: var(--cinder-text-sm);
-  color: var(--cinder-text);
-}
+  /* Sticky-hover suppression on touch. */
+  @media (hover: hover) {
+    .cinder-combobox__input:hover:not(:disabled) {
+      border-color: var(--cinder-border-strong);
+    }
+  }
 
-.cinder-combobox__option-avatar {
-  flex: 0 0 auto;
-  width: 1.5rem;
-  height: 1.5rem;
-  border-radius: var(--cinder-radius-full);
-  object-fit: cover;
-}
-
-.cinder-combobox__option-text {
-  display: flex;
-  flex-direction: column;
-  min-width: 0;
-}
-
-.cinder-combobox__option-label {
-  line-height: inherit;
-}
-
-.cinder-combobox__option-description {
-  font-size: var(--cinder-text-xs);
-  color: var(--cinder-text-muted);
-  line-height: var(--cinder-leading-snug);
-}
-
-.cinder-combobox__option[data-cinder-active] {
-  background: var(--cinder-surface-hover);
-}
-
-.cinder-combobox__option[aria-selected='true'] {
-  font-weight: var(--cinder-font-medium);
-  color: var(--cinder-accent);
-}
-
-.cinder-combobox__option[aria-disabled='true'] {
-  color: var(--cinder-text-disabled);
-  cursor: not-allowed;
-}
-
-.cinder-combobox__empty {
-  position: absolute;
-  top: 100%;
-  left: 0;
-  right: 0;
-  margin: var(--cinder-space-1) 0 0 0;
-  padding: var(--cinder-space-3);
-  background: var(--cinder-surface-raised);
-  border: 1px solid var(--cinder-border);
-  border-radius: var(--cinder-radius-md);
-  font-size: var(--cinder-text-sm);
-  color: var(--cinder-text-muted);
-  text-align: center;
-  z-index: var(--cinder-z-popover);
-}
-
-/* Hide when not active — visibility keeps the live region in the a11y tree. */
-.cinder-combobox__empty:not([data-cinder-active]) {
-  visibility: hidden;
-  height: 0;
-  overflow: hidden;
-  padding: 0;
-  border: none;
-  margin: 0;
-}
-
-.cinder-combobox__description {
-  font-size: var(--cinder-text-xs);
-  line-height: var(--cinder-leading-normal);
-  color: var(--cinder-text-muted);
-  margin: 0;
-}
-
-.cinder-combobox__error {
-  font-size: var(--cinder-text-xs);
-  line-height: var(--cinder-leading-normal);
-  color: var(--cinder-danger);
-  margin: 0;
-}
-
-/* Hide the always-present error live region when no error is active. */
-.cinder-combobox__error:not([data-cinder-error]) {
-  position: absolute;
-  visibility: hidden;
-  height: 0;
-  overflow: hidden;
-}
-
-/* Forced Colors Mode: restore outline-based focus ring for the combobox input
- * because box-shadow is ignored in Windows High Contrast Mode. */
-@media (forced-colors: active) {
   .cinder-combobox__input:focus-visible {
-    outline: var(--cinder-ring-width) solid ButtonText;
-    outline-offset: 3px;
+    outline: var(--cinder-ring-width) solid transparent;
+    box-shadow: var(--_cinder-focus-ring-shadow);
+  }
+
+  .cinder-combobox__input[aria-invalid='true'] {
+    border-color: var(--cinder-danger);
+  }
+
+  .cinder-combobox__input:disabled {
+    background: var(--cinder-surface-inset);
+    color: var(--cinder-text-disabled);
+    border-color: var(--cinder-border-muted);
+    cursor: not-allowed;
+  }
+
+  .cinder-combobox__listbox {
+    position: absolute;
+    top: 100%;
+    left: 0;
+    right: 0;
+    margin: var(--cinder-space-1) 0 0 0;
+    padding: var(--cinder-space-1);
+    list-style: none;
+    background: var(--cinder-surface-raised);
+    border: 1px solid var(--cinder-border);
+    border-radius: var(--cinder-radius-md);
+    box-shadow: var(--cinder-shadow-md);
+    max-height: 16rem;
+    overflow-y: auto;
+    z-index: var(--cinder-z-popover);
+  }
+
+  .cinder-combobox__option {
+    display: flex;
+    align-items: center;
+    gap: var(--cinder-space-2);
+    padding: var(--cinder-space-1-5) var(--cinder-space-3);
+    border-radius: var(--cinder-radius-sm);
+    cursor: pointer;
+    font-size: var(--cinder-text-sm);
+    color: var(--cinder-text);
+  }
+
+  .cinder-combobox__option-avatar {
+    flex: 0 0 auto;
+    width: 1.5rem;
+    height: 1.5rem;
+    border-radius: var(--cinder-radius-full);
+    object-fit: cover;
+  }
+
+  .cinder-combobox__option-text {
+    display: flex;
+    flex-direction: column;
+    min-width: 0;
+  }
+
+  .cinder-combobox__option-label {
+    line-height: inherit;
+  }
+
+  .cinder-combobox__option-description {
+    font-size: var(--cinder-text-xs);
+    color: var(--cinder-text-muted);
+    line-height: var(--cinder-leading-snug);
+  }
+
+  .cinder-combobox__option[data-cinder-active] {
+    background: var(--cinder-surface-hover);
+  }
+
+  .cinder-combobox__option[aria-selected='true'] {
+    font-weight: var(--cinder-font-medium);
+    color: var(--cinder-accent);
+  }
+
+  .cinder-combobox__option[aria-disabled='true'] {
+    color: var(--cinder-text-disabled);
+    cursor: not-allowed;
+  }
+
+  .cinder-combobox__empty {
+    position: absolute;
+    top: 100%;
+    left: 0;
+    right: 0;
+    margin: var(--cinder-space-1) 0 0 0;
+    padding: var(--cinder-space-3);
+    background: var(--cinder-surface-raised);
+    border: 1px solid var(--cinder-border);
+    border-radius: var(--cinder-radius-md);
+    font-size: var(--cinder-text-sm);
+    color: var(--cinder-text-muted);
+    text-align: center;
+    z-index: var(--cinder-z-popover);
+  }
+
+  /* Hide when not active — visibility keeps the live region in the a11y tree. */
+  .cinder-combobox__empty:not([data-cinder-active]) {
+    visibility: hidden;
+    height: 0;
+    overflow: hidden;
+    padding: 0;
+    border: none;
+    margin: 0;
+  }
+
+  .cinder-combobox__description {
+    font-size: var(--cinder-text-xs);
+    line-height: var(--cinder-leading-normal);
+    color: var(--cinder-text-muted);
+    margin: 0;
+  }
+
+  .cinder-combobox__error {
+    font-size: var(--cinder-text-xs);
+    line-height: var(--cinder-leading-normal);
+    color: var(--cinder-danger);
+    margin: 0;
+  }
+
+  /* Hide the always-present error live region when no error is active. */
+  .cinder-combobox__error:not([data-cinder-error]) {
+    position: absolute;
+    visibility: hidden;
+    height: 0;
+    overflow: hidden;
+  }
+
+  /* Forced Colors Mode: restore outline-based focus ring for the combobox input
+ * because box-shadow is ignored in Windows High Contrast Mode. */
+  @media (forced-colors: active) {
+    .cinder-combobox__input:focus-visible {
+      outline: var(--cinder-ring-width) solid ButtonText;
+      outline-offset: 3px;
+    }
   }
 }

--- a/packages/components/src/components/combobox/combobox.test.ts
+++ b/packages/components/src/components/combobox/combobox.test.ts
@@ -3,6 +3,7 @@ import * as matchers from '@testing-library/jest-dom/matchers';
 import { describe, expect, test } from 'bun:test';
 import { readFileSync } from 'node:fs';
 
+import { stripCinderComponentsLayer } from '../../test/css.ts';
 import { setupHappyDom } from '../../test/happy-dom.ts';
 
 expect.extend(matchers as Parameters<typeof expect.extend>[0]);
@@ -19,7 +20,11 @@ const fruits = [
 ];
 
 function readComboboxStyles(): string {
-  return readFileSync(new URL('./combobox.css', import.meta.url), 'utf8');
+  // Strip the @layer wrapper: happy-dom does not apply layer-nested rules to
+  // getComputedStyle. Inner declarations are unchanged.
+  return stripCinderComponentsLayer(
+    readFileSync(new URL('./combobox.css', import.meta.url), 'utf8'),
+  );
 }
 
 describe('Combobox', () => {

--- a/packages/components/src/components/command-menu/command-menu.css
+++ b/packages/components/src/components/command-menu/command-menu.css
@@ -1,39 +1,41 @@
-/* ========================================
+@layer cinder.components {
+  /* ========================================
  * COMMAND MENU
  * ======================================== */
 
-.cinder-command-menu {
-  position: fixed;
-  z-index: var(--cinder-z-popover);
-  box-sizing: border-box;
-  min-inline-size: min(20rem, calc(100vw - var(--cinder-space-4)));
-  max-inline-size: min(28rem, calc(100vw - var(--cinder-space-4)));
-  max-block-size: min(20rem, calc(100vh - var(--cinder-space-4)));
-  margin: 0;
-  padding: var(--cinder-space-2) 0;
-  overflow-y: auto;
-  overscroll-behavior: contain;
-  list-style: none;
-  border: 1px solid var(--cinder-border);
-  border-radius: var(--cinder-radius-md);
-  background: var(--cinder-surface-raised);
-  color: var(--cinder-text);
-  box-shadow: var(--cinder-shadow-lg, 0 10px 15px rgb(0 0 0 / 0.15));
-}
+  .cinder-command-menu {
+    position: fixed;
+    z-index: var(--cinder-z-popover);
+    box-sizing: border-box;
+    min-inline-size: min(20rem, calc(100vw - var(--cinder-space-4)));
+    max-inline-size: min(28rem, calc(100vw - var(--cinder-space-4)));
+    max-block-size: min(20rem, calc(100vh - var(--cinder-space-4)));
+    margin: 0;
+    padding: var(--cinder-space-2) 0;
+    overflow-y: auto;
+    overscroll-behavior: contain;
+    list-style: none;
+    border: 1px solid var(--cinder-border);
+    border-radius: var(--cinder-radius-md);
+    background: var(--cinder-surface-raised);
+    color: var(--cinder-text);
+    box-shadow: var(--cinder-shadow-lg, 0 10px 15px rgb(0 0 0 / 0.15));
+  }
 
-.cinder-command-menu__listbox {
-  margin: 0;
-  padding: 0;
-  list-style: none;
-}
+  .cinder-command-menu__listbox {
+    margin: 0;
+    padding: 0;
+    list-style: none;
+  }
 
-.cinder-command-menu[data-cinder-position-ready='false'] {
-  visibility: hidden;
-}
+  .cinder-command-menu[data-cinder-position-ready='false'] {
+    visibility: hidden;
+  }
 
-.cinder-command-menu__empty {
-  padding: var(--cinder-space-6) var(--cinder-space-4);
-  color: var(--cinder-text-muted);
-  font-size: var(--cinder-text-sm);
-  text-align: center;
+  .cinder-command-menu__empty {
+    padding: var(--cinder-space-6) var(--cinder-space-4);
+    color: var(--cinder-text-muted);
+    font-size: var(--cinder-text-sm);
+    text-align: center;
+  }
 }

--- a/packages/components/src/components/command-palette/command-palette.css
+++ b/packages/components/src/components/command-palette/command-palette.css
@@ -1,304 +1,306 @@
-/* ========================================
+@layer cinder.components {
+  /* ========================================
  * COMMAND PALETTE
  * ======================================== */
 
-.cinder-command-palette {
-  /* Reset browser <dialog> defaults */
-  margin: 0 auto;
-  padding: 0;
-  border: none;
-  background: transparent;
-  color: var(--cinder-text);
-  /* The dialog's default overflow: auto produces a scroll container whose
+  .cinder-command-palette {
+    /* Reset browser <dialog> defaults */
+    margin: 0 auto;
+    padding: 0;
+    border: none;
+    background: transparent;
+    color: var(--cinder-text);
+    /* The dialog's default overflow: auto produces a scroll container whose
      box ignores the inner panel's border-radius, so child backgrounds bleed
      past the rounded corners. Clip at the dialog level too. */
-  overflow: hidden;
-  border-radius: var(--cinder-radius-lg);
-  /* Anchor near the top of the viewport — top-layer elements use fixed
+    overflow: hidden;
+    border-radius: var(--cinder-radius-lg);
+    /* Anchor near the top of the viewport — top-layer elements use fixed
      positioning relative to the viewport. z-index is intentionally absent:
      showModal() places the dialog in the top layer, which is above all
      stacking contexts. */
-  position: fixed;
-  inset-block-start: max(4rem, 20vh);
-  inset-inline: 0;
-  max-width: min(90vw, 40rem);
-  width: 100%;
-}
-
-.cinder-command-palette::backdrop {
-  background: var(--cinder-overlay-backdrop);
-}
-
-@supports (backdrop-filter: blur(1px)) {
-  .cinder-command-palette::backdrop {
-    backdrop-filter: blur(var(--cinder-overlay-blur));
+    position: fixed;
+    inset-block-start: max(4rem, 20vh);
+    inset-inline: 0;
+    max-width: min(90vw, 40rem);
+    width: 100%;
   }
-}
 
-/* ----------------------------------------
+  .cinder-command-palette::backdrop {
+    background: var(--cinder-overlay-backdrop);
+  }
+
+  @supports (backdrop-filter: blur(1px)) {
+    .cinder-command-palette::backdrop {
+      backdrop-filter: blur(var(--cinder-overlay-blur));
+    }
+  }
+
+  /* ----------------------------------------
  * Panel
  * ---------------------------------------- */
 
-.cinder-command-palette__panel {
-  display: flex;
-  flex-direction: column;
-  background: var(--cinder-surface-raised);
-  border: 1px solid var(--cinder-border);
-  border-radius: var(--cinder-radius-lg);
-  overflow: hidden;
-  max-height: 60vh;
-  box-shadow:
-    0 4px 6px -1px color-mix(in oklch, var(--cinder-text) 8%, transparent),
-    0 10px 15px -3px color-mix(in oklch, var(--cinder-text) 12%, transparent);
-}
+  .cinder-command-palette__panel {
+    display: flex;
+    flex-direction: column;
+    background: var(--cinder-surface-raised);
+    border: 1px solid var(--cinder-border);
+    border-radius: var(--cinder-radius-lg);
+    overflow: hidden;
+    max-height: 60vh;
+    box-shadow:
+      0 4px 6px -1px color-mix(in oklch, var(--cinder-text) 8%, transparent),
+      0 10px 15px -3px color-mix(in oklch, var(--cinder-text) 12%, transparent);
+  }
 
-/* ----------------------------------------
+  /* ----------------------------------------
  * Search row
  * ---------------------------------------- */
 
-.cinder-command-palette__search {
-  display: flex;
-  align-items: center;
-  gap: var(--cinder-space-3);
-  min-block-size: 4.5rem;
-  padding-inline: var(--cinder-space-5);
-  border-block-end: 1px solid var(--cinder-border);
-  flex-shrink: 0;
-}
+  .cinder-command-palette__search {
+    display: flex;
+    align-items: center;
+    gap: var(--cinder-space-3);
+    min-block-size: 4.5rem;
+    padding-inline: var(--cinder-space-5);
+    border-block-end: 1px solid var(--cinder-border);
+    flex-shrink: 0;
+  }
 
-.cinder-command-palette__search-icon {
-  width: 1.25rem;
-  height: 1.25rem;
-  flex-shrink: 0;
-  color: var(--cinder-text-muted);
-}
+  .cinder-command-palette__search-icon {
+    width: 1.25rem;
+    height: 1.25rem;
+    flex-shrink: 0;
+    color: var(--cinder-text-muted);
+  }
 
-.cinder-command-palette__input {
-  flex: 1;
-  border: none;
-  background: transparent;
-  color: var(--cinder-text);
-  font-size: var(--cinder-text-base);
-  line-height: var(--cinder-leading-normal);
-  padding-block: var(--cinder-space-4);
-  outline: none;
-}
+  .cinder-command-palette__input {
+    flex: 1;
+    border: none;
+    background: transparent;
+    color: var(--cinder-text);
+    font-size: var(--cinder-text-base);
+    line-height: var(--cinder-leading-normal);
+    padding-block: var(--cinder-space-4);
+    outline: none;
+  }
 
-.cinder-command-palette__input:focus-visible {
-  outline: var(--cinder-ring-width) solid transparent;
-  box-shadow: var(--_cinder-focus-ring-shadow);
-}
-
-.cinder-command-palette__input:focus {
-  outline: var(--cinder-ring-width) solid transparent;
-  box-shadow: var(--_cinder-focus-ring-shadow);
-}
-
-@media (forced-colors: active) {
   .cinder-command-palette__input:focus-visible {
-    outline: var(--cinder-ring-width) solid ButtonText;
+    outline: var(--cinder-ring-width) solid transparent;
+    box-shadow: var(--_cinder-focus-ring-shadow);
   }
 
   .cinder-command-palette__input:focus {
-    outline: var(--cinder-ring-width) solid ButtonText;
+    outline: var(--cinder-ring-width) solid transparent;
+    box-shadow: var(--_cinder-focus-ring-shadow);
   }
-}
 
-.cinder-command-palette__input::placeholder {
-  color: var(--cinder-text-muted);
-}
+  @media (forced-colors: active) {
+    .cinder-command-palette__input:focus-visible {
+      outline: var(--cinder-ring-width) solid ButtonText;
+    }
 
-/* ----------------------------------------
+    .cinder-command-palette__input:focus {
+      outline: var(--cinder-ring-width) solid ButtonText;
+    }
+  }
+
+  .cinder-command-palette__input::placeholder {
+    color: var(--cinder-text-muted);
+  }
+
+  /* ----------------------------------------
  * Listbox (scrollable items area)
  * ---------------------------------------- */
 
-.cinder-command-palette__listbox {
-  list-style: none;
-  margin: 0;
-  padding: var(--cinder-space-2) 0;
-  overflow-y: auto;
-  overscroll-behavior: contain;
-  scrollbar-gutter: stable;
-  flex: 1;
-}
+  .cinder-command-palette__listbox {
+    list-style: none;
+    margin: 0;
+    padding: var(--cinder-space-2) 0;
+    overflow-y: auto;
+    overscroll-behavior: contain;
+    scrollbar-gutter: stable;
+    flex: 1;
+  }
 
-/* ----------------------------------------
+  /* ----------------------------------------
  * Empty state
  * ---------------------------------------- */
 
-.cinder-command-palette__empty {
-  padding: var(--cinder-space-8) var(--cinder-space-4);
-  text-align: center;
-  color: var(--cinder-text-muted);
-  font-size: var(--cinder-text-sm);
-  flex-shrink: 0;
-}
+  .cinder-command-palette__empty {
+    padding: var(--cinder-space-8) var(--cinder-space-4);
+    text-align: center;
+    color: var(--cinder-text-muted);
+    font-size: var(--cinder-text-sm);
+    flex-shrink: 0;
+  }
 
-/* ----------------------------------------
+  /* ----------------------------------------
  * Consumer-rendered groups
  * ---------------------------------------- */
 
-.cinder-command-group {
-  margin: 0;
-  padding-block: var(--cinder-space-1);
-  list-style: none;
-}
+  .cinder-command-group {
+    margin: 0;
+    padding-block: var(--cinder-space-1);
+    list-style: none;
+  }
 
-.cinder-command-group ul {
-  margin: 0;
-  padding: 0;
-  list-style: none;
-}
+  .cinder-command-group ul {
+    margin: 0;
+    padding: 0;
+    list-style: none;
+  }
 
-.cinder-command-group__label {
-  display: block;
-  padding: var(--cinder-space-1-5) var(--cinder-space-5);
-  color: var(--cinder-text-muted);
-  font-size: var(--cinder-text-xs);
-  font-weight: var(--cinder-font-medium);
-  letter-spacing: 0.04em;
-  text-transform: uppercase;
-}
+  .cinder-command-group__label {
+    display: block;
+    padding: var(--cinder-space-1-5) var(--cinder-space-5);
+    color: var(--cinder-text-muted);
+    font-size: var(--cinder-text-xs);
+    font-weight: var(--cinder-font-medium);
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+  }
 
-/* ----------------------------------------
+  /* ----------------------------------------
  * Footer
  * ---------------------------------------- */
 
-.cinder-command-palette__footer {
-  display: flex;
-  align-items: center;
-  gap: var(--cinder-space-3);
-  padding: var(--cinder-space-2) var(--cinder-space-4);
-  border-block-start: 1px solid var(--cinder-border);
-  flex-shrink: 0;
-  font-size: var(--cinder-text-xs);
-  color: var(--cinder-text-muted);
-}
+  .cinder-command-palette__footer {
+    display: flex;
+    align-items: center;
+    gap: var(--cinder-space-3);
+    padding: var(--cinder-space-2) var(--cinder-space-4);
+    border-block-start: 1px solid var(--cinder-border);
+    flex-shrink: 0;
+    font-size: var(--cinder-text-xs);
+    color: var(--cinder-text-muted);
+  }
 
-/* ========================================
+  /* ========================================
  * COMMAND ITEM
  * ======================================== */
 
-.cinder-command-item {
-  position: relative;
-  display: flex;
-  align-items: center;
-  gap: var(--cinder-space-3);
-  overflow: hidden;
-  min-block-size: 2.75rem;
-  padding: var(--cinder-space-2-5) var(--cinder-space-5);
-  cursor: pointer;
-  border-radius: 0;
-  margin: 0;
-  font-size: var(--cinder-text-base);
-  color: var(--cinder-text);
-  user-select: none;
-  transition:
-    background-color var(--cinder-duration-fast) var(--cinder-ease-standard),
-    color var(--cinder-duration-fast) var(--cinder-ease-standard);
-}
-
-.cinder-command-item[data-cinder-active] {
-  background: var(--cinder-accent);
-  color: var(--cinder-accent-contrast);
-}
-
-@media (forced-colors: active) {
-  .cinder-command-item[data-cinder-active] {
-    background: Highlight;
-    color: HighlightText;
-    box-shadow: none;
-    outline: 2px solid Highlight;
-    outline-offset: -2px;
+  .cinder-command-item {
+    position: relative;
+    display: flex;
+    align-items: center;
+    gap: var(--cinder-space-3);
+    overflow: hidden;
+    min-block-size: 2.75rem;
+    padding: var(--cinder-space-2-5) var(--cinder-space-5);
+    cursor: pointer;
+    border-radius: 0;
+    margin: 0;
+    font-size: var(--cinder-text-base);
+    color: var(--cinder-text);
+    user-select: none;
+    transition:
+      background-color var(--cinder-duration-fast) var(--cinder-ease-standard),
+      color var(--cinder-duration-fast) var(--cinder-ease-standard);
   }
-}
 
-.cinder-command-item[data-cinder-disabled] {
-  opacity: 0.45;
-  cursor: not-allowed;
-  pointer-events: none;
-}
+  .cinder-command-item[data-cinder-active] {
+    background: var(--cinder-accent);
+    color: var(--cinder-accent-contrast);
+  }
 
-.cinder-command-item__leading {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  flex-shrink: 0;
-  inline-size: 2rem;
-  block-size: 2rem;
-  border-radius: var(--cinder-radius-md);
-  background: color-mix(in oklch, currentColor 10%, transparent);
-  color: var(--cinder-text-muted);
-}
+  @media (forced-colors: active) {
+    .cinder-command-item[data-cinder-active] {
+      background: Highlight;
+      color: HighlightText;
+      box-shadow: none;
+      outline: 2px solid Highlight;
+      outline-offset: -2px;
+    }
+  }
 
-.cinder-command-item[data-cinder-active] .cinder-command-item__leading {
-  color: currentColor;
-}
+  .cinder-command-item[data-cinder-disabled] {
+    opacity: 0.45;
+    cursor: not-allowed;
+    pointer-events: none;
+  }
 
-.cinder-command-item__content {
-  flex: 1;
-  min-width: 0;
-  display: flex;
-  flex-direction: column;
-  gap: var(--cinder-space-0-5);
-}
+  .cinder-command-item__leading {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+    inline-size: 2rem;
+    block-size: 2rem;
+    border-radius: var(--cinder-radius-md);
+    background: color-mix(in oklch, currentColor 10%, transparent);
+    color: var(--cinder-text-muted);
+  }
 
-.cinder-command-item__description {
-  color: var(--cinder-text-muted);
-  font-size: var(--cinder-text-xs);
-  line-height: var(--cinder-leading-normal);
-}
+  .cinder-command-item[data-cinder-active] .cinder-command-item__leading {
+    color: currentColor;
+  }
 
-.cinder-command-item[data-cinder-active] .cinder-command-item__description {
-  color: currentColor;
-}
+  .cinder-command-item__content {
+    flex: 1;
+    min-width: 0;
+    display: flex;
+    flex-direction: column;
+    gap: var(--cinder-space-0-5);
+  }
 
-.cinder-command-item__trailing {
-  display: inline-flex;
-  align-items: center;
-  flex-shrink: 0;
-  margin-inline-start: auto;
-  color: var(--cinder-text-muted);
-  font-size: var(--cinder-text-xs);
-}
+  .cinder-command-item__description {
+    color: var(--cinder-text-muted);
+    font-size: var(--cinder-text-xs);
+    line-height: var(--cinder-leading-normal);
+  }
 
-.cinder-command-item[data-cinder-active] .cinder-command-item__trailing {
-  color: currentColor;
-}
+  .cinder-command-item[data-cinder-active] .cinder-command-item__description {
+    color: currentColor;
+  }
 
-/* ----------------------------------------
+  .cinder-command-item__trailing {
+    display: inline-flex;
+    align-items: center;
+    flex-shrink: 0;
+    margin-inline-start: auto;
+    color: var(--cinder-text-muted);
+    font-size: var(--cinder-text-xs);
+  }
+
+  .cinder-command-item[data-cinder-active] .cinder-command-item__trailing {
+    color: currentColor;
+  }
+
+  /* ----------------------------------------
  * Reduced motion — panel enter animation
  * ---------------------------------------- */
 
-@media (prefers-reduced-motion: no-preference) {
-  .cinder-command-palette {
-    animation: cinder-command-palette-enter var(--cinder-duration-normal) var(--cinder-ease-spring)
-      forwards;
+  @media (prefers-reduced-motion: no-preference) {
+    .cinder-command-palette {
+      animation: cinder-command-palette-enter var(--cinder-duration-normal)
+        var(--cinder-ease-spring) forwards;
+    }
+
+    @keyframes cinder-command-palette-enter {
+      from {
+        opacity: 0;
+        translate: 0 -0.75rem;
+      }
+      to {
+        opacity: 1;
+        translate: 0 0;
+      }
+    }
   }
 
-  @keyframes cinder-command-palette-enter {
-    from {
-      opacity: 0;
-      translate: 0 -0.75rem;
+  @media (prefers-reduced-motion: reduce) {
+    .cinder-command-palette {
+      animation: cinder-command-palette-fade var(--cinder-duration-fast) linear forwards;
     }
-    to {
-      opacity: 1;
-      translate: 0 0;
-    }
-  }
-}
 
-@media (prefers-reduced-motion: reduce) {
-  .cinder-command-palette {
-    animation: cinder-command-palette-fade var(--cinder-duration-fast) linear forwards;
-  }
-
-  @keyframes cinder-command-palette-fade {
-    from {
-      opacity: 0;
-    }
-    to {
-      opacity: 1;
+    @keyframes cinder-command-palette-fade {
+      from {
+        opacity: 0;
+      }
+      to {
+        opacity: 1;
+      }
     }
   }
 }

--- a/packages/components/src/components/confirm-dialog/confirm-dialog.css
+++ b/packages/components/src/components/confirm-dialog/confirm-dialog.css
@@ -1,5 +1,7 @@
-.cinder-confirm-dialog__description {
-  margin: 0;
-  color: var(--cinder-text-muted);
-  font-size: var(--cinder-text-sm);
+@layer cinder.components {
+  .cinder-confirm-dialog__description {
+    margin: 0;
+    color: var(--cinder-text-muted);
+    font-size: var(--cinder-text-sm);
+  }
 }

--- a/packages/components/src/components/container/container.css
+++ b/packages/components/src/components/container/container.css
@@ -1,38 +1,40 @@
-/* ========================================
+@layer cinder.components {
+  /* ========================================
  * CONTAINER
  * ======================================== */
 
-.cinder-container {
-  box-sizing: border-box;
-  display: block;
-  inline-size: 100%;
-  /* Prevent overflow when composed inside a flex row or grid cell, whose
+  .cinder-container {
+    box-sizing: border-box;
+    display: block;
+    inline-size: 100%;
+    /* Prevent overflow when composed inside a flex row or grid cell, whose
    * default min-width:auto would otherwise let the container blow past its
    * track. */
-  min-inline-size: 0;
-  max-inline-size: var(--cinder-content-width);
-}
+    min-inline-size: 0;
+    max-inline-size: var(--cinder-content-width);
+  }
 
-.cinder-container[data-cinder-centered] {
-  margin-inline: auto;
-}
+  .cinder-container[data-cinder-centered] {
+    margin-inline: auto;
+  }
 
-.cinder-container[data-cinder-padded] {
-  padding-inline: var(--cinder-space-5);
-}
+  .cinder-container[data-cinder-padded] {
+    padding-inline: var(--cinder-space-5);
+  }
 
-.cinder-container[data-cinder-max-width='prose'] {
-  max-inline-size: var(--cinder-content-width-prose);
-}
+  .cinder-container[data-cinder-max-width='prose'] {
+    max-inline-size: var(--cinder-content-width-prose);
+  }
 
-.cinder-container[data-cinder-max-width='narrow'] {
-  max-inline-size: var(--cinder-content-width-narrow);
-}
+  .cinder-container[data-cinder-max-width='narrow'] {
+    max-inline-size: var(--cinder-content-width-narrow);
+  }
 
-.cinder-container[data-cinder-max-width='wide'] {
-  max-inline-size: var(--cinder-content-width-wide);
-}
+  .cinder-container[data-cinder-max-width='wide'] {
+    max-inline-size: var(--cinder-content-width-wide);
+  }
 
-.cinder-container[data-cinder-max-width='full'] {
-  max-inline-size: none;
+  .cinder-container[data-cinder-max-width='full'] {
+    max-inline-size: none;
+  }
 }

--- a/packages/components/src/components/context-menu/context-menu.css
+++ b/packages/components/src/components/context-menu/context-menu.css
@@ -1,7 +1,9 @@
-.cinder-context-menu {
-  display: contents;
-}
+@layer cinder.components {
+  .cinder-context-menu {
+    display: contents;
+  }
 
-.cinder-context-menu-trigger {
-  display: contents;
+  .cinder-context-menu-trigger {
+    display: contents;
+  }
 }

--- a/packages/components/src/components/copy-button/copy-button.css
+++ b/packages/components/src/components/copy-button/copy-button.css
@@ -1,51 +1,53 @@
-/* ========================================
+@layer cinder.components {
+  /* ========================================
  * COPY BUTTON
  * Compact button preset that flashes a "copied" state on success.
  * ======================================== */
 
-.cinder-copy-button {
-  appearance: none;
-  display: inline-flex;
-  align-items: center;
-  gap: var(--cinder-space-1);
-  padding: var(--cinder-space-1) var(--cinder-space-2);
-  font-size: var(--cinder-text-xs);
-  font-family: inherit;
-  font-weight: var(--cinder-font-medium);
-  color: var(--cinder-text-muted);
-  background: transparent;
-  border: 1px solid var(--cinder-border);
-  border-radius: var(--cinder-radius-sm);
-  cursor: pointer;
-  transition:
-    color var(--cinder-duration-fast) var(--cinder-ease-standard),
-    background var(--cinder-duration-fast) var(--cinder-ease-standard),
-    border-color var(--cinder-duration-fast) var(--cinder-ease-standard);
-}
+  .cinder-copy-button {
+    appearance: none;
+    display: inline-flex;
+    align-items: center;
+    gap: var(--cinder-space-1);
+    padding: var(--cinder-space-1) var(--cinder-space-2);
+    font-size: var(--cinder-text-xs);
+    font-family: inherit;
+    font-weight: var(--cinder-font-medium);
+    color: var(--cinder-text-muted);
+    background: transparent;
+    border: 1px solid var(--cinder-border);
+    border-radius: var(--cinder-radius-sm);
+    cursor: pointer;
+    transition:
+      color var(--cinder-duration-fast) var(--cinder-ease-standard),
+      background var(--cinder-duration-fast) var(--cinder-ease-standard),
+      border-color var(--cinder-duration-fast) var(--cinder-ease-standard);
+  }
 
-/* Sticky-hover suppression on touch: wrap hover-only chrome so it doesn't
+  /* Sticky-hover suppression on touch: wrap hover-only chrome so it doesn't
  * "stick" after tap on touch devices that emulate :hover. */
-@media (hover: hover) {
-  .cinder-copy-button:hover {
-    color: var(--cinder-text);
-    background: var(--cinder-surface-hover);
-    border-color: var(--cinder-border-strong);
+  @media (hover: hover) {
+    .cinder-copy-button:hover {
+      color: var(--cinder-text);
+      background: var(--cinder-surface-hover);
+      border-color: var(--cinder-border-strong);
+    }
   }
-}
 
-.cinder-copy-button:focus-visible {
-  outline: var(--cinder-ring-width) solid transparent;
-  box-shadow: var(--_cinder-focus-ring-shadow);
-}
-
-@media (forced-colors: active) {
   .cinder-copy-button:focus-visible {
-    outline: var(--cinder-ring-width) solid ButtonText;
-    outline-offset: 2px;
+    outline: var(--cinder-ring-width) solid transparent;
+    box-shadow: var(--_cinder-focus-ring-shadow);
   }
-}
 
-.cinder-copy-button[data-cinder-copied] {
-  color: var(--cinder-success);
-  border-color: var(--cinder-success);
+  @media (forced-colors: active) {
+    .cinder-copy-button:focus-visible {
+      outline: var(--cinder-ring-width) solid ButtonText;
+      outline-offset: 2px;
+    }
+  }
+
+  .cinder-copy-button[data-cinder-copied] {
+    color: var(--cinder-success);
+    border-color: var(--cinder-success);
+  }
 }

--- a/packages/components/src/components/data-list/data-list.css
+++ b/packages/components/src/components/data-list/data-list.css
@@ -1,13 +1,15 @@
-/* ========================================
+@layer cinder.components {
+  /* ========================================
  * DATA LIST
  * ======================================== */
 
-.cinder-data-list {
-  display: flex;
-  flex-direction: column;
-  inline-size: 100%;
-}
+  .cinder-data-list {
+    display: flex;
+    flex-direction: column;
+    inline-size: 100%;
+  }
 
-.cinder-data-list > :not(:first-child) {
-  border-block-start: 1px solid var(--cinder-border-muted);
+  .cinder-data-list > :not(:first-child) {
+    border-block-start: 1px solid var(--cinder-border-muted);
+  }
 }

--- a/packages/components/src/components/description-list/description-list.css
+++ b/packages/components/src/components/description-list/description-list.css
@@ -1,82 +1,84 @@
-/* ========================================
+@layer cinder.components {
+  /* ========================================
  * DESCRIPTION LIST
  * ======================================== */
 
-.cinder-description-list {
-  margin: 0;
-  display: flex;
-  flex-direction: column;
-}
-
-/* Reset UA default margin-inline-start on <dd> (~40px in most browsers). */
-.cinder-description-list dt,
-.cinder-description-list dd {
-  margin: 0;
-}
-
-.cinder-description-list__row {
-  display: flex;
-  flex-direction: column;
-  gap: var(--cinder-space-1);
-  padding: var(--cinder-space-2) var(--cinder-space-3);
-}
-
-.cinder-description-list[data-cinder-variant='default']
-  .cinder-description-list__row:not(:first-child) {
-  border-block-start: 1px solid var(--cinder-border-muted);
-}
-
-/* <dd> hosts both definition and optional actions. */
-.cinder-description-list dd {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: baseline;
-  gap: var(--cinder-space-2);
-}
-
-.cinder-description-list__definition {
-  flex: 1 1 auto;
-  min-width: 0;
-}
-
-.cinder-description-list__actions {
-  flex: 0 0 auto;
-  display: inline-flex;
-  align-items: center;
-  gap: var(--cinder-space-1);
-}
-
-/* Striped variant: odd rows get a subtle background. */
-.cinder-description-list[data-cinder-variant='striped']
-  .cinder-description-list__row:nth-child(odd) {
-  background: var(--cinder-surface-inset);
-}
-
-/* Two-column variant: term and definition share a row. */
-.cinder-description-list[data-cinder-variant='two-column'] {
-  container-type: inline-size;
-}
-
-.cinder-description-list[data-cinder-variant='two-column'] .cinder-description-list__row {
-  display: grid;
-  grid-template-columns: minmax(8rem, 1fr) 3fr;
-  align-items: baseline;
-  gap: var(--cinder-space-3);
-}
-
-/* Collapse two-column to stacked at narrow container widths. */
-@container (max-width: 28rem) {
-  .cinder-description-list[data-cinder-variant='two-column'] .cinder-description-list__row {
-    grid-template-columns: 1fr;
+  .cinder-description-list {
+    margin: 0;
+    display: flex;
+    flex-direction: column;
   }
-}
 
-/* Narrow variant: <dt> is sr-only (position: absolute, out-of-flow) so <dd>
+  /* Reset UA default margin-inline-start on <dd> (~40px in most browsers). */
+  .cinder-description-list dt,
+  .cinder-description-list dd {
+    margin: 0;
+  }
+
+  .cinder-description-list__row {
+    display: flex;
+    flex-direction: column;
+    gap: var(--cinder-space-1);
+    padding: var(--cinder-space-2) var(--cinder-space-3);
+  }
+
+  .cinder-description-list[data-cinder-variant='default']
+    .cinder-description-list__row:not(:first-child) {
+    border-block-start: 1px solid var(--cinder-border-muted);
+  }
+
+  /* <dd> hosts both definition and optional actions. */
+  .cinder-description-list dd {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: baseline;
+    gap: var(--cinder-space-2);
+  }
+
+  .cinder-description-list__definition {
+    flex: 1 1 auto;
+    min-width: 0;
+  }
+
+  .cinder-description-list__actions {
+    flex: 0 0 auto;
+    display: inline-flex;
+    align-items: center;
+    gap: var(--cinder-space-1);
+  }
+
+  /* Striped variant: odd rows get a subtle background. */
+  .cinder-description-list[data-cinder-variant='striped']
+    .cinder-description-list__row:nth-child(odd) {
+    background: var(--cinder-surface-inset);
+  }
+
+  /* Two-column variant: term and definition share a row. */
+  .cinder-description-list[data-cinder-variant='two-column'] {
+    container-type: inline-size;
+  }
+
+  .cinder-description-list[data-cinder-variant='two-column'] .cinder-description-list__row {
+    display: grid;
+    grid-template-columns: minmax(8rem, 1fr) 3fr;
+    align-items: baseline;
+    gap: var(--cinder-space-3);
+  }
+
+  /* Collapse two-column to stacked at narrow container widths. */
+  @container (max-width: 28rem) {
+    .cinder-description-list[data-cinder-variant='two-column'] .cinder-description-list__row {
+      grid-template-columns: 1fr;
+    }
+  }
+
+  /* Narrow variant: <dt> is sr-only (position: absolute, out-of-flow) so <dd>
  * fills the visible row. flex-direction: row here matches the intended reading
  * direction if a future variant needs the dt in-flow; for now the sr-only dt
  * has no layout footprint and the dd is visually full-width. */
-.cinder-description-list[data-cinder-variant='narrow'] .cinder-description-list__row {
-  flex-direction: row;
-  align-items: baseline;
-  gap: var(--cinder-space-2);
+  .cinder-description-list[data-cinder-variant='narrow'] .cinder-description-list__row {
+    flex-direction: row;
+    align-items: baseline;
+    gap: var(--cinder-space-2);
+  }
 }

--- a/packages/components/src/components/diff-statistics/diff-statistics.css
+++ b/packages/components/src/components/diff-statistics/diff-statistics.css
@@ -1,88 +1,90 @@
-/* ========================================
+@layer cinder.components {
+  /* ========================================
  * DIFF STATISTICS
  * ======================================== */
 
-.cinder-diff-statistics {
-  display: inline-flex;
-  align-items: center;
-  gap: var(--cinder-space-3);
-  font-size: var(--cinder-text-sm);
-}
+  .cinder-diff-statistics {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--cinder-space-3);
+    font-size: var(--cinder-text-sm);
+  }
 
-.cinder-diff-statistics[data-cinder-variant='compact'] {
-  gap: var(--cinder-space-2);
-  font-size: var(--cinder-text-xs);
-}
+  .cinder-diff-statistics[data-cinder-variant='compact'] {
+    gap: var(--cinder-space-2);
+    font-size: var(--cinder-text-xs);
+  }
 
-.cinder-diff-statistics__stat {
-  display: inline-flex;
-  align-items: center;
-  gap: var(--cinder-space-1);
-  font-weight: var(--cinder-font-medium);
-  white-space: nowrap;
-}
+  .cinder-diff-statistics__stat {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--cinder-space-1);
+    font-weight: var(--cinder-font-medium);
+    white-space: nowrap;
+  }
 
-.cinder-diff-statistics__prefix,
-.cinder-diff-statistics__value {
-  font-family: var(--cinder-font-mono);
-}
+  .cinder-diff-statistics__prefix,
+  .cinder-diff-statistics__value {
+    font-family: var(--cinder-font-mono);
+  }
 
-.cinder-diff-statistics__value {
-  font-variant-numeric: tabular-nums;
-}
+  .cinder-diff-statistics__value {
+    font-variant-numeric: tabular-nums;
+  }
 
-.cinder-diff-statistics__label {
-  color: var(--cinder-text-muted);
-  font-weight: var(--cinder-font-normal);
-}
+  .cinder-diff-statistics__label {
+    color: var(--cinder-text-muted);
+    font-weight: var(--cinder-font-normal);
+  }
 
-.cinder-diff-statistics__stat--added {
-  color: var(--cinder-success);
-}
+  .cinder-diff-statistics__stat--added {
+    color: var(--cinder-success);
+  }
 
-.cinder-diff-statistics__stat--removed {
-  color: var(--cinder-danger);
-}
+  .cinder-diff-statistics__stat--removed {
+    color: var(--cinder-danger);
+  }
 
-.cinder-diff-statistics__stat--modified {
-  color: var(--cinder-warning);
-}
+  .cinder-diff-statistics__stat--modified {
+    color: var(--cinder-warning);
+  }
 
-.cinder-diff-statistics__stat--none {
-  color: var(--cinder-text-muted);
-  font-style: italic;
-  font-weight: var(--cinder-font-normal);
-}
+  .cinder-diff-statistics__stat--none {
+    color: var(--cinder-text-muted);
+    font-style: italic;
+    font-weight: var(--cinder-font-normal);
+  }
 
-.cinder-diff-statistics[data-cinder-variant='compact'] .cinder-diff-statistics__stat {
-  padding: var(--cinder-space-0-5) var(--cinder-space-1-5);
-  border-radius: var(--cinder-radius-sm);
-  background: var(--cinder-surface-inset);
-}
+  .cinder-diff-statistics[data-cinder-variant='compact'] .cinder-diff-statistics__stat {
+    padding: var(--cinder-space-0-5) var(--cinder-space-1-5);
+    border-radius: var(--cinder-radius-sm);
+    background: var(--cinder-surface-inset);
+  }
 
-.cinder-diff-statistics[data-cinder-variant='compact'] .cinder-diff-statistics__stat--added {
-  background: var(--cinder-color-success-bg);
-  color: var(--cinder-color-success-fg);
-}
+  .cinder-diff-statistics[data-cinder-variant='compact'] .cinder-diff-statistics__stat--added {
+    background: var(--cinder-color-success-bg);
+    color: var(--cinder-color-success-fg);
+  }
 
-.cinder-diff-statistics[data-cinder-variant='compact'] .cinder-diff-statistics__stat--removed {
-  background: var(--cinder-color-danger-bg);
-  color: var(--cinder-color-danger-fg);
-}
+  .cinder-diff-statistics[data-cinder-variant='compact'] .cinder-diff-statistics__stat--removed {
+    background: var(--cinder-color-danger-bg);
+    color: var(--cinder-color-danger-fg);
+  }
 
-.cinder-diff-statistics[data-cinder-variant='compact'] .cinder-diff-statistics__stat--modified {
-  background: var(--cinder-color-warning-bg);
-  color: var(--cinder-color-warning-fg);
-}
+  .cinder-diff-statistics[data-cinder-variant='compact'] .cinder-diff-statistics__stat--modified {
+    background: var(--cinder-color-warning-bg);
+    color: var(--cinder-color-warning-fg);
+  }
 
-/* compact + density="toolbar": opt the compact stat pills into the shared
+  /* compact + density="toolbar": opt the compact stat pills into the shared
  * --cinder-control-height-sm tier so they align with sibling Button (size="sm")
  * and SegmentedControl (density="toolbar") in editor toolbars. The base
  * `display: inline-flex; align-items: center` already centers the text
  * vertically; we just need to set the box height. Default compact rendering
  * (without density) is unchanged. */
-.cinder-diff-statistics[data-cinder-variant='compact'][data-cinder-density='toolbar']
-  .cinder-diff-statistics__stat {
-  box-sizing: border-box;
-  min-block-size: var(--cinder-control-height-sm);
+  .cinder-diff-statistics[data-cinder-variant='compact'][data-cinder-density='toolbar']
+    .cinder-diff-statistics__stat {
+    box-sizing: border-box;
+    min-block-size: var(--cinder-control-height-sm);
+  }
 }

--- a/packages/components/src/components/divider/divider.css
+++ b/packages/components/src/components/divider/divider.css
@@ -1,56 +1,58 @@
-/* ========================================
+@layer cinder.components {
+  /* ========================================
  * DIVIDER
  * 1px visual separator between content regions.
  * Token-driven; no magic colors.
  * ======================================== */
 
-.cinder-divider {
-  display: block;
-  flex-shrink: 0;
-  border: none;
-  background-color: var(--cinder-border-muted);
-}
+  .cinder-divider {
+    display: block;
+    flex-shrink: 0;
+    border: none;
+    background-color: var(--cinder-border-muted);
+  }
 
-/* ---- Horizontal (default) ---- */
+  /* ---- Horizontal (default) ---- */
 
-.cinder-divider[data-cinder-orientation='horizontal'] {
-  width: 100%;
-  height: 1px;
-  margin-block: 0;
-}
+  .cinder-divider[data-cinder-orientation='horizontal'] {
+    width: 100%;
+    height: 1px;
+    margin-block: 0;
+  }
 
-.cinder-divider[data-cinder-orientation='horizontal'][data-cinder-inset] {
-  margin-inline: var(--cinder-space-2);
-  width: calc(100% - 2 * var(--cinder-space-2));
-}
+  .cinder-divider[data-cinder-orientation='horizontal'][data-cinder-inset] {
+    margin-inline: var(--cinder-space-2);
+    width: calc(100% - 2 * var(--cinder-space-2));
+  }
 
-/* ---- Vertical ---- */
+  /* ---- Vertical ---- */
 
-.cinder-divider[data-cinder-orientation='vertical'] {
-  display: inline-block;
-  width: 1px;
-  height: auto;
-  align-self: stretch;
-  min-height: 1em;
-}
+  .cinder-divider[data-cinder-orientation='vertical'] {
+    display: inline-block;
+    width: 1px;
+    height: auto;
+    align-self: stretch;
+    min-height: 1em;
+  }
 
-.cinder-divider[data-cinder-orientation='vertical'][data-cinder-inset] {
-  margin-block: var(--cinder-space-2);
-}
+  .cinder-divider[data-cinder-orientation='vertical'][data-cinder-inset] {
+    margin-block: var(--cinder-space-2);
+  }
 
-/* ---- Tone ---- */
+  /* ---- Tone ---- */
 
-.cinder-divider[data-cinder-tone='strong'] {
-  background-color: var(--cinder-border-strong);
-}
+  .cinder-divider[data-cinder-tone='strong'] {
+    background-color: var(--cinder-border-strong);
+  }
 
-/* The default (subtle) tone uses the muted border token already set on the base rule. */
+  /* The default (subtle) tone uses the muted border token already set on the base rule. */
 
-/* ---- Reset <hr> browser defaults ---- */
+  /* ---- Reset <hr> browser defaults ---- */
 
-hr.cinder-divider {
-  margin: 0;
-  padding: 0;
-  border: none;
-  color: inherit;
+  hr.cinder-divider {
+    margin: 0;
+    padding: 0;
+    border: none;
+    color: inherit;
+  }
 }

--- a/packages/components/src/components/drawer/drawer.css
+++ b/packages/components/src/components/drawer/drawer.css
@@ -1,204 +1,206 @@
-/* ========================================
+@layer cinder.components {
+  /* ========================================
  * DRAWER
  * Edge-anchored (left/right) slide-in panel.
  * The <dialog> fills the viewport so backdrop-click on dialog is reliable;
  * the visible panel is a child absolutely positioned at the chosen edge.
  * ======================================== */
 
-.cinder-drawer {
-  border: none;
-  background: transparent;
-  padding: 0;
-  margin: 0;
-  position: fixed;
-  inset: 0;
-  width: 100vw;
-  height: 100dvh;
-  max-width: none;
-  max-height: none;
-  z-index: var(--cinder-z-modal);
-}
+  .cinder-drawer {
+    border: none;
+    background: transparent;
+    padding: 0;
+    margin: 0;
+    position: fixed;
+    inset: 0;
+    width: 100vw;
+    height: 100dvh;
+    max-width: none;
+    max-height: none;
+    z-index: var(--cinder-z-modal);
+  }
 
-.cinder-drawer::backdrop {
-  background-color: var(--cinder-overlay-backdrop);
-  backdrop-filter: blur(var(--cinder-overlay-blur));
-  transition: background-color var(--cinder-duration-normal) var(--cinder-ease-standard);
-}
+  .cinder-drawer::backdrop {
+    background-color: var(--cinder-overlay-backdrop);
+    backdrop-filter: blur(var(--cinder-overlay-blur));
+    transition: background-color var(--cinder-duration-normal) var(--cinder-ease-standard);
+  }
 
-.cinder-drawer[data-cinder-closing]::backdrop {
-  background-color: transparent;
-}
+  .cinder-drawer[data-cinder-closing]::backdrop {
+    background-color: transparent;
+  }
 
-.cinder-drawer__panel {
-  position: absolute;
-  top: 0;
-  bottom: 0;
-  height: 100%;
-  max-width: 100vw;
-  background: var(--cinder-surface-raised);
-  box-shadow: var(--cinder-shadow-lg);
-  display: flex;
-  flex-direction: column;
-  overflow: hidden;
-  opacity: 1;
-  transition:
-    translate var(--cinder-duration-normal) var(--cinder-ease-spring),
-    opacity var(--cinder-duration-normal) var(--cinder-ease-standard);
-}
+  .cinder-drawer__panel {
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    height: 100%;
+    max-width: 100vw;
+    background: var(--cinder-surface-raised);
+    box-shadow: var(--cinder-shadow-lg);
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+    opacity: 1;
+    transition:
+      translate var(--cinder-duration-normal) var(--cinder-ease-spring),
+      opacity var(--cinder-duration-normal) var(--cinder-ease-standard);
+  }
 
-.cinder-drawer__panel[data-cinder-side='right'] {
-  right: 0;
-  left: auto;
-  border-inline-start: 1px solid var(--cinder-border);
-}
+  .cinder-drawer__panel[data-cinder-side='right'] {
+    right: 0;
+    left: auto;
+    border-inline-start: 1px solid var(--cinder-border);
+  }
 
-.cinder-drawer__panel[data-cinder-side='left'] {
-  left: 0;
-  right: auto;
-  border-inline-end: 1px solid var(--cinder-border);
-}
+  .cinder-drawer__panel[data-cinder-side='left'] {
+    left: 0;
+    right: auto;
+    border-inline-end: 1px solid var(--cinder-border);
+  }
 
-.cinder-drawer__panel[data-cinder-size='sm'] {
-  width: min(20rem, 100vw);
-}
-.cinder-drawer__panel[data-cinder-size='md'] {
-  width: min(28rem, 100vw);
-}
-.cinder-drawer__panel[data-cinder-size='lg'] {
-  width: min(36rem, 100vw);
-}
-.cinder-drawer__panel[data-cinder-size='xl'] {
-  width: min(48rem, 100vw);
-}
+  .cinder-drawer__panel[data-cinder-size='sm'] {
+    width: min(20rem, 100vw);
+  }
+  .cinder-drawer__panel[data-cinder-size='md'] {
+    width: min(28rem, 100vw);
+  }
+  .cinder-drawer__panel[data-cinder-size='lg'] {
+    width: min(36rem, 100vw);
+  }
+  .cinder-drawer__panel[data-cinder-size='xl'] {
+    width: min(48rem, 100vw);
+  }
 
-.cinder-drawer__header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: var(--cinder-space-4);
-  padding: var(--cinder-space-5) var(--cinder-space-6);
-  border-block-end: 1px solid var(--cinder-border);
-  flex-shrink: 0;
-}
+  .cinder-drawer__header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--cinder-space-4);
+    padding: var(--cinder-space-5) var(--cinder-space-6);
+    border-block-end: 1px solid var(--cinder-border);
+    flex-shrink: 0;
+  }
 
-.cinder-drawer__title {
-  margin: 0;
-  font-size: var(--cinder-text-lg);
-  font-weight: var(--cinder-font-semibold);
-  line-height: var(--cinder-leading-snug);
-  color: var(--cinder-text);
-  flex: 1;
-  min-width: 0;
-}
-
-.cinder-drawer__close {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  flex-shrink: 0;
-  width: 2.75rem;
-  height: 2.75rem;
-  padding: var(--cinder-space-1);
-  border-radius: var(--cinder-radius-md);
-  border: none;
-  background: transparent;
-  color: var(--cinder-text-muted);
-  cursor: pointer;
-  transition:
-    background-color var(--cinder-duration-fast) var(--cinder-ease-standard),
-    color var(--cinder-duration-fast) var(--cinder-ease-standard);
-}
-
-/* Sticky-hover suppression on touch. */
-@media (hover: hover) {
-  .cinder-drawer__close:hover {
-    background: color-mix(in oklch, currentColor, transparent 85%);
+  .cinder-drawer__title {
+    margin: 0;
+    font-size: var(--cinder-text-lg);
+    font-weight: var(--cinder-font-semibold);
+    line-height: var(--cinder-leading-snug);
     color: var(--cinder-text);
+    flex: 1;
+    min-width: 0;
   }
-}
 
-.cinder-drawer__close:focus-visible {
-  outline: var(--cinder-ring-width) solid var(--cinder-ring-color);
-  outline-offset: var(--cinder-ring-offset);
-}
+  .cinder-drawer__close {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+    width: 2.75rem;
+    height: 2.75rem;
+    padding: var(--cinder-space-1);
+    border-radius: var(--cinder-radius-md);
+    border: none;
+    background: transparent;
+    color: var(--cinder-text-muted);
+    cursor: pointer;
+    transition:
+      background-color var(--cinder-duration-fast) var(--cinder-ease-standard),
+      color var(--cinder-duration-fast) var(--cinder-ease-standard);
+  }
 
-@media (forced-colors: active) {
+  /* Sticky-hover suppression on touch. */
+  @media (hover: hover) {
+    .cinder-drawer__close:hover {
+      background: color-mix(in oklch, currentColor, transparent 85%);
+      color: var(--cinder-text);
+    }
+  }
+
   .cinder-drawer__close:focus-visible {
-    outline: var(--cinder-ring-width) solid ButtonText;
-    outline-offset: 3px;
+    outline: var(--cinder-ring-width) solid var(--cinder-ring-color);
+    outline-offset: var(--cinder-ring-offset);
   }
-}
 
-.cinder-drawer__close-icon {
-  width: 1.25rem;
-  height: 1.25rem;
-}
+  @media (forced-colors: active) {
+    .cinder-drawer__close:focus-visible {
+      outline: var(--cinder-ring-width) solid ButtonText;
+      outline-offset: 3px;
+    }
+  }
 
-.cinder-drawer__body {
-  flex: 1;
-  overflow-y: auto;
-  padding: var(--cinder-space-6);
-  overscroll-behavior: contain;
-  scrollbar-gutter: stable;
-  outline: none;
-}
+  .cinder-drawer__close-icon {
+    width: 1.25rem;
+    height: 1.25rem;
+  }
 
-.cinder-drawer__body[data-cinder-overflows] {
-  mask-image: linear-gradient(to bottom, black calc(100% - 1.5rem), transparent);
-  mask-size: 100% 100%;
-  mask-repeat: no-repeat;
-  -webkit-mask-image: linear-gradient(to bottom, black calc(100% - 1.5rem), transparent);
-  -webkit-mask-size: 100% 100%;
-  -webkit-mask-repeat: no-repeat;
-}
+  .cinder-drawer__body {
+    flex: 1;
+    overflow-y: auto;
+    padding: var(--cinder-space-6);
+    overscroll-behavior: contain;
+    scrollbar-gutter: stable;
+    outline: none;
+  }
 
-.cinder-drawer__footer {
-  display: flex;
-  align-items: center;
-  justify-content: flex-end;
-  gap: var(--cinder-space-3);
-  padding: var(--cinder-space-4) var(--cinder-space-6);
-  border-block-start: 1px solid var(--cinder-border);
-  flex-shrink: 0;
-}
+  .cinder-drawer__body[data-cinder-overflows] {
+    mask-image: linear-gradient(to bottom, black calc(100% - 1.5rem), transparent);
+    mask-size: 100% 100%;
+    mask-repeat: no-repeat;
+    -webkit-mask-image: linear-gradient(to bottom, black calc(100% - 1.5rem), transparent);
+    -webkit-mask-size: 100% 100%;
+    -webkit-mask-repeat: no-repeat;
+  }
 
-/* ----------------------------------------
+  .cinder-drawer__footer {
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+    gap: var(--cinder-space-3);
+    padding: var(--cinder-space-4) var(--cinder-space-6);
+    border-block-start: 1px solid var(--cinder-border);
+    flex-shrink: 0;
+  }
+
+  /* ----------------------------------------
  * Motion — slide from the anchored edge.
  * Animation targets the panel, not the dialog (which is transparent).
  * ---------------------------------------- */
 
-.cinder-drawer__panel[data-cinder-side='right'][data-cinder-closing] {
-  translate: 100% 0;
-  opacity: 0.85;
-}
-
-.cinder-drawer__panel[data-cinder-side='left'][data-cinder-closing] {
-  translate: -100% 0;
-  opacity: 0.85;
-}
-
-.cinder-drawer__panel[data-cinder-closing] {
-  pointer-events: none;
-}
-
-@starting-style {
-  .cinder-drawer__panel[data-cinder-side='right'] {
+  .cinder-drawer__panel[data-cinder-side='right'][data-cinder-closing] {
     translate: 100% 0;
     opacity: 0.85;
   }
 
-  .cinder-drawer__panel[data-cinder-side='left'] {
+  .cinder-drawer__panel[data-cinder-side='left'][data-cinder-closing] {
     translate: -100% 0;
     opacity: 0.85;
   }
-}
 
-@media (prefers-reduced-motion: reduce) {
-  .cinder-drawer__panel {
-    transition: none;
+  .cinder-drawer__panel[data-cinder-closing] {
+    pointer-events: none;
   }
 
-  .cinder-drawer::backdrop {
-    transition: none;
+  @starting-style {
+    .cinder-drawer__panel[data-cinder-side='right'] {
+      translate: 100% 0;
+      opacity: 0.85;
+    }
+
+    .cinder-drawer__panel[data-cinder-side='left'] {
+      translate: -100% 0;
+      opacity: 0.85;
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .cinder-drawer__panel {
+      transition: none;
+    }
+
+    .cinder-drawer::backdrop {
+      transition: none;
+    }
   }
 }

--- a/packages/components/src/components/dropdown/dropdown.css
+++ b/packages/components/src/components/dropdown/dropdown.css
@@ -1,235 +1,236 @@
-/* ========================================
+@layer cinder.components {
+  /* ========================================
  * DROPDOWN
  * ======================================== */
 
-.cinder-dropdown {
-  position: relative;
-  display: inline-block;
-}
+  .cinder-dropdown {
+    position: relative;
+    display: inline-block;
+  }
 
-.cinder-dropdown-trigger {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  gap: var(--cinder-space-2);
-  min-block-size: var(--cinder-button-height-md);
-  padding-block: var(--cinder-button-padding-y-md);
-  padding-inline: var(--cinder-button-padding-x-md);
-  border: 1px solid var(--cinder-border);
-  border-radius: var(--cinder-button-radius-md);
-  background: var(--cinder-surface);
-  color: var(--cinder-text);
-  font: inherit;
-  font-size: var(--cinder-button-font-size-md);
-  line-height: 1;
-  cursor: pointer;
-  transition:
-    background-color var(--cinder-duration-fast) var(--cinder-ease-standard),
-    border-color var(--cinder-duration-fast) var(--cinder-ease-standard),
-    box-shadow var(--cinder-duration-fast) var(--cinder-ease-standard);
-}
+  .cinder-dropdown-trigger {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: var(--cinder-space-2);
+    min-block-size: var(--cinder-button-height-md);
+    padding-block: var(--cinder-button-padding-y-md);
+    padding-inline: var(--cinder-button-padding-x-md);
+    border: 1px solid var(--cinder-border);
+    border-radius: var(--cinder-button-radius-md);
+    background: var(--cinder-surface);
+    color: var(--cinder-text);
+    font: inherit;
+    font-size: var(--cinder-button-font-size-md);
+    line-height: 1;
+    cursor: pointer;
+    transition:
+      background-color var(--cinder-duration-fast) var(--cinder-ease-standard),
+      border-color var(--cinder-duration-fast) var(--cinder-ease-standard),
+      box-shadow var(--cinder-duration-fast) var(--cinder-ease-standard);
+  }
 
-.cinder-dropdown-trigger:focus-visible {
-  outline: var(--cinder-ring-width) solid transparent;
-  box-shadow:
-    0 0 0 var(--cinder-ring-offset) var(--cinder-ring-offset-color),
-    0 0 0 calc(var(--cinder-ring-offset) + var(--cinder-ring-width))
-      var(--_cinder-dropdown-trigger-ring, var(--cinder-ring-color));
-}
-
-.cinder-button-group
-  > .cinder-dropdown[data-cinder-button-group-item]
-  > .cinder-dropdown-trigger:focus-visible {
-  outline: var(--cinder-ring-width) solid transparent;
-  box-shadow: inset 0 0 0 var(--cinder-ring-width)
-    var(--_cinder-dropdown-trigger-ring, var(--cinder-ring-color));
-}
-
-@media (forced-colors: active) {
-  /* box-shadow is suppressed in Windows High Contrast Mode, so paint a
-   * solid outline that respects ButtonText for visible focus. */
   .cinder-dropdown-trigger:focus-visible {
-    outline: var(--cinder-ring-width) solid ButtonText;
-    outline-offset: 3px;
+    outline: var(--cinder-ring-width) solid transparent;
+    box-shadow:
+      0 0 0 var(--cinder-ring-offset) var(--cinder-ring-offset-color),
+      0 0 0 calc(var(--cinder-ring-offset) + var(--cinder-ring-width))
+        var(--_cinder-dropdown-trigger-ring, var(--cinder-ring-color));
   }
 
   .cinder-button-group
     > .cinder-dropdown[data-cinder-button-group-item]
     > .cinder-dropdown-trigger:focus-visible {
-    outline: var(--cinder-ring-width) solid ButtonText;
-    outline-offset: calc(var(--cinder-ring-width) * -1);
+    outline: var(--cinder-ring-width) solid transparent;
+    box-shadow: inset 0 0 0 var(--cinder-ring-width)
+      var(--_cinder-dropdown-trigger-ring, var(--cinder-ring-color));
   }
-}
 
-.cinder-dropdown-trigger[aria-expanded='true'] {
-  background: var(--cinder-surface-pressed);
-}
+  @media (forced-colors: active) {
+    /* box-shadow is suppressed in Windows High Contrast Mode, so paint a
+   * solid outline that respects ButtonText for visible focus. */
+    .cinder-dropdown-trigger:focus-visible {
+      outline: var(--cinder-ring-width) solid ButtonText;
+      outline-offset: 3px;
+    }
 
-.cinder-dropdown-trigger__caret {
-  display: block;
-  flex: none;
-  inline-size: 0.75em;
-  block-size: 0.75em;
-  opacity: 0.65;
-}
+    .cinder-button-group
+      > .cinder-dropdown[data-cinder-button-group-item]
+      > .cinder-dropdown-trigger:focus-visible {
+      outline: var(--cinder-ring-width) solid ButtonText;
+      outline-offset: calc(var(--cinder-ring-width) * -1);
+    }
+  }
 
-/* ----------------------------------------
+  .cinder-dropdown-trigger[aria-expanded='true'] {
+    background: var(--cinder-surface-pressed);
+  }
+
+  .cinder-dropdown-trigger__caret {
+    display: block;
+    flex: none;
+    inline-size: 0.75em;
+    block-size: 0.75em;
+    opacity: 0.65;
+  }
+
+  /* ----------------------------------------
  * Trigger wrapper
  * ---------------------------------------- */
 
-.cinder-dropdown__trigger {
-  display: inline-block;
-}
+  .cinder-dropdown__trigger {
+    display: inline-block;
+  }
 
-/* ----------------------------------------
+  /* ----------------------------------------
  * Menu panel
  * ---------------------------------------- */
 
-.cinder-dropdown__menu,
-.cinder-dropdown-menu {
-  border: 1px solid var(--cinder-border);
-  border-radius: var(--cinder-radius-md);
-  background: var(--cinder-surface-raised);
-  color: var(--cinder-text);
-  box-shadow: var(--cinder-shadow-lg, 0 10px 15px rgb(0 0 0 / 0.15));
-}
+  .cinder-dropdown__menu,
+  .cinder-dropdown-menu {
+    border: 1px solid var(--cinder-border);
+    border-radius: var(--cinder-radius-md);
+    background: var(--cinder-surface-raised);
+    color: var(--cinder-text);
+    box-shadow: var(--cinder-shadow-lg, 0 10px 15px rgb(0 0 0 / 0.15));
+  }
 
-.cinder-dropdown__menu {
-  position: absolute;
-  z-index: var(--cinder-z-dropdown, 40);
-  min-width: 12rem;
-  padding: var(--cinder-space-1) 0;
-  overflow: hidden;
+  .cinder-dropdown__menu {
+    position: absolute;
+    z-index: var(--cinder-z-dropdown, 40);
+    min-width: 12rem;
+    padding: var(--cinder-space-1) 0;
+    overflow: hidden;
 
-  font-size: var(--cinder-text-sm);
-  line-height: var(--cinder-leading-normal);
-}
+    font-size: var(--cinder-text-sm);
+    line-height: var(--cinder-leading-normal);
+  }
 
-.cinder-dropdown-menu {
-  position: absolute;
-  inset-block-start: calc(100% + var(--cinder-space-1));
-  inset-inline-end: 0;
-  min-width: 12rem;
-  max-width: calc(100vw - 1rem);
-  max-height: calc(100vh - 2rem);
-  margin: 0;
-  padding: var(--cinder-space-1);
-  overflow-y: auto;
-  outline: none;
-}
+  .cinder-dropdown-menu {
+    position: absolute;
+    inset-block-start: calc(100% + var(--cinder-space-1));
+    inset-inline-end: 0;
+    min-width: 12rem;
+    max-width: calc(100vw - 1rem);
+    max-height: calc(100vh - 2rem);
+    margin: 0;
+    padding: var(--cinder-space-1);
+    overflow-y: auto;
+    outline: none;
+  }
 
-.cinder-dropdown-item {
-  position: relative;
-  display: flex;
-  align-items: center;
-  gap: var(--cinder-space-2);
-  width: 100%;
-  min-height: var(--cinder-control-height-lg);
-  padding-block: var(--cinder-space-2-5);
-  padding-inline: var(--cinder-space-3);
-  border: 0;
-  border-radius: var(--cinder-radius-sm);
-  background: transparent;
-  color: var(--cinder-text);
-  cursor: pointer;
-  font-size: var(--cinder-text-sm);
-  text-align: left;
-  user-select: none;
-  outline: none;
-  transition:
-    background-color var(--cinder-duration-fast) var(--cinder-ease-standard),
-    color var(--cinder-duration-fast) var(--cinder-ease-standard);
-}
+  .cinder-dropdown-item {
+    position: relative;
+    display: flex;
+    align-items: center;
+    gap: var(--cinder-space-2);
+    width: 100%;
+    min-height: var(--cinder-control-height-lg);
+    padding-block: var(--cinder-space-2-5);
+    padding-inline: var(--cinder-space-3);
+    border: 0;
+    border-radius: var(--cinder-radius-sm);
+    background: transparent;
+    color: var(--cinder-text);
+    cursor: pointer;
+    font-size: var(--cinder-text-sm);
+    text-align: left;
+    user-select: none;
+    outline: none;
+    transition:
+      background-color var(--cinder-duration-fast) var(--cinder-ease-standard),
+      color var(--cinder-duration-fast) var(--cinder-ease-standard);
+  }
 
-/* Scoped to the BEM-style menu (.cinder-dropdown__menu), which uses padding-block-only
+  /* Scoped to the BEM-style menu (.cinder-dropdown__menu), which uses padding-block-only
  * (no horizontal inset). Items inset themselves so the rounded hover/focus background
  * doesn't bleed into the menu's outer corners. The flat-named .cinder-dropdown-menu
  * variant already has padding on all sides — items there sit at full width. */
-.cinder-dropdown__menu .cinder-dropdown-item {
-  width: calc(100% - var(--cinder-space-1) * 2);
-  margin-inline: var(--cinder-space-1);
-}
-
-.cinder-dropdown-item[data-disabled] {
-  pointer-events: none;
-  /* opacity centralized in foundation.css disabled-visual rule (0.6) */
-}
-
-.cinder-dropdown-item[data-cinder-variant='default']:focus-visible {
-  background: var(--cinder-surface-hover);
-  outline: var(--cinder-ring-width) solid transparent;
-  box-shadow: inset 0 0 0 var(--cinder-ring-width)
-    var(--_cinder-dropdown-item-ring, var(--cinder-ring-color));
-}
-
-.cinder-dropdown-item[data-cinder-variant='danger'] {
-  --_cinder-dropdown-item-ring: var(--cinder-danger);
-  color: var(--cinder-danger);
-}
-
-.cinder-dropdown-item[data-cinder-variant='danger']:focus-visible {
-  background: var(--cinder-color-danger-bg);
-  color: var(--cinder-color-danger-fg);
-  outline: var(--cinder-ring-width) solid transparent;
-  box-shadow: inset 0 0 0 var(--cinder-ring-width)
-    var(--_cinder-dropdown-item-ring, var(--cinder-ring-color));
-}
-
-/* Sticky-hover suppression on touch: wrap hover-only chrome so it doesn't
- * "stick" after tap. Placed before :active rules so press feedback wins on tap. */
-@media (hover: hover) {
-  .cinder-dropdown-trigger:hover:not([aria-expanded='true']) {
-    background: var(--cinder-surface-hover);
+  .cinder-dropdown__menu .cinder-dropdown-item {
+    width: calc(100% - var(--cinder-space-1) * 2);
+    margin-inline: var(--cinder-space-1);
   }
 
-  .cinder-dropdown-item[data-cinder-variant='default']:hover {
-    background: var(--cinder-surface-hover);
+  .cinder-dropdown-item[data-disabled] {
+    pointer-events: none;
+    /* opacity centralized in foundation.css disabled-visual rule (0.6) */
   }
 
-  .cinder-dropdown-item[data-cinder-variant='danger']:hover {
+  .cinder-dropdown-item[data-cinder-variant='default']:focus-visible {
+    background: var(--cinder-surface-hover);
+    outline: var(--cinder-ring-width) solid transparent;
+    box-shadow: inset 0 0 0 var(--cinder-ring-width)
+      var(--_cinder-dropdown-item-ring, var(--cinder-ring-color));
+  }
+
+  .cinder-dropdown-item[data-cinder-variant='danger'] {
+    --_cinder-dropdown-item-ring: var(--cinder-danger);
+    color: var(--cinder-danger);
+  }
+
+  .cinder-dropdown-item[data-cinder-variant='danger']:focus-visible {
     background: var(--cinder-color-danger-bg);
     color: var(--cinder-color-danger-fg);
+    outline: var(--cinder-ring-width) solid transparent;
+    box-shadow: inset 0 0 0 var(--cinder-ring-width)
+      var(--_cinder-dropdown-item-ring, var(--cinder-ring-color));
   }
-}
 
-/* :active stays unwrapped — fires on tap. */
-.cinder-dropdown-item[data-cinder-variant='default']:active {
-  background: var(--cinder-surface-pressed);
-}
+  /* Sticky-hover suppression on touch: wrap hover-only chrome so it doesn't
+ * "stick" after tap. Placed before :active rules so press feedback wins on tap. */
+  @media (hover: hover) {
+    .cinder-dropdown-trigger:hover:not([aria-expanded='true']) {
+      background: var(--cinder-surface-hover);
+    }
 
-.cinder-dropdown-item[data-cinder-variant='danger']:active {
-  background: var(--cinder-color-danger-border);
-  color: var(--cinder-color-danger-fg);
-}
+    .cinder-dropdown-item[data-cinder-variant='default']:hover {
+      background: var(--cinder-surface-hover);
+    }
 
-@media (forced-colors: active) {
-  /* Inset box-shadow rings vanish in HCM — paint a solid outline instead. */
-  .cinder-dropdown-item[data-cinder-variant='default']:focus-visible,
-  .cinder-dropdown-item[data-cinder-variant='danger']:focus-visible {
-    outline: var(--cinder-ring-width) solid ButtonText;
-    outline-offset: calc(var(--cinder-ring-width) * -1);
+    .cinder-dropdown-item[data-cinder-variant='danger']:hover {
+      background: var(--cinder-color-danger-bg);
+      color: var(--cinder-color-danger-fg);
+    }
   }
-}
 
-.cinder-dropdown-item--inset {
-  padding-inline-start: var(--cinder-space-8);
-}
+  /* :active stays unwrapped — fires on tap. */
+  .cinder-dropdown-item[data-cinder-variant='default']:active {
+    background: var(--cinder-surface-pressed);
+  }
 
-.cinder-dropdown-label {
-  padding-block: var(--cinder-space-2);
-  padding-inline: var(--cinder-space-3);
-  color: var(--cinder-text-muted);
-  font-size: var(--cinder-text-xs);
-  font-weight: var(--cinder-font-semibold);
-}
+  .cinder-dropdown-item[data-cinder-variant='danger']:active {
+    background: var(--cinder-color-danger-border);
+    color: var(--cinder-color-danger-fg);
+  }
 
-.cinder-dropdown-separator {
-  height: 1px;
-  margin-block: var(--cinder-space-1);
-  background: var(--cinder-border);
-}
+  @media (forced-colors: active) {
+    /* Inset box-shadow rings vanish in HCM — paint a solid outline instead. */
+    .cinder-dropdown-item[data-cinder-variant='default']:focus-visible,
+    .cinder-dropdown-item[data-cinder-variant='danger']:focus-visible {
+      outline: var(--cinder-ring-width) solid ButtonText;
+      outline-offset: calc(var(--cinder-ring-width) * -1);
+    }
+  }
 
-/* ----------------------------------------
+  .cinder-dropdown-item--inset {
+    padding-inline-start: var(--cinder-space-8);
+  }
+
+  .cinder-dropdown-label {
+    padding-block: var(--cinder-space-2);
+    padding-inline: var(--cinder-space-3);
+    color: var(--cinder-text-muted);
+    font-size: var(--cinder-text-xs);
+    font-weight: var(--cinder-font-semibold);
+  }
+
+  .cinder-dropdown-separator {
+    height: 1px;
+    margin-block: var(--cinder-space-1);
+    background: var(--cinder-border);
+  }
+
+  /* ----------------------------------------
  * Popover-API positioning (CSS Anchor Positioning)
  * ----------------------------------------
  *
@@ -250,53 +251,53 @@
  * browsers would render the menu at viewport-relative `inset: auto`.
  */
 
-@supports (anchor-name: --x) and (position-anchor: --x) and (top: anchor(bottom)) {
-  .cinder-dropdown-menu[popover] {
-    position: fixed;
-    inset: auto;
-    top: calc(anchor(bottom) + var(--cinder-space-1));
-    right: anchor(right);
-    position-try-fallbacks: flip-block, flip-inline;
+  @supports (anchor-name: --x) and (position-anchor: --x) and (top: anchor(bottom)) {
+    .cinder-dropdown-menu[popover] {
+      position: fixed;
+      inset: auto;
+      top: calc(anchor(bottom) + var(--cinder-space-1));
+      right: anchor(right);
+      position-try-fallbacks: flip-block, flip-inline;
+    }
+
+    .cinder-dropdown__menu[popover] {
+      position: fixed;
+      margin: 0;
+      inset: auto;
+      inset-block-start: calc(anchor(bottom) + var(--cinder-space-1));
+      position-try-fallbacks: flip-block, flip-inline;
+    }
+
+    .cinder-dropdown[data-cinder-placement='bottom-start'] .cinder-dropdown__menu[popover] {
+      inset-inline-start: anchor(left);
+    }
+
+    .cinder-dropdown[data-cinder-placement='bottom-end'] .cinder-dropdown__menu[popover] {
+      inset-inline-end: anchor(right);
+      inset-inline-start: auto;
+    }
   }
 
-  .cinder-dropdown__menu[popover] {
-    position: fixed;
-    margin: 0;
-    inset: auto;
-    inset-block-start: calc(anchor(bottom) + var(--cinder-space-1));
-    position-try-fallbacks: flip-block, flip-inline;
-  }
-
-  .cinder-dropdown[data-cinder-placement='bottom-start'] .cinder-dropdown__menu[popover] {
-    inset-inline-start: anchor(left);
-  }
-
-  .cinder-dropdown[data-cinder-placement='bottom-end'] .cinder-dropdown__menu[popover] {
-    inset-inline-end: anchor(right);
-    inset-inline-start: auto;
-  }
-}
-
-/* ----------------------------------------
+  /* ----------------------------------------
  * Non-popover fallback path
  *
  * Browsers without the popover API render the menu inside the dropdown's
  * relatively-positioned root, so percent-based offsets work normally.
  * ---------------------------------------- */
 
-.cinder-dropdown[data-cinder-placement='bottom-start'] .cinder-dropdown__menu:not([popover]) {
-  position: absolute;
-  inset-block-start: calc(100% + var(--cinder-space-1));
-  inset-inline-start: 0;
-}
+  .cinder-dropdown[data-cinder-placement='bottom-start'] .cinder-dropdown__menu:not([popover]) {
+    position: absolute;
+    inset-block-start: calc(100% + var(--cinder-space-1));
+    inset-inline-start: 0;
+  }
 
-.cinder-dropdown[data-cinder-placement='bottom-end'] .cinder-dropdown__menu:not([popover]) {
-  position: absolute;
-  inset-block-start: calc(100% + var(--cinder-space-1));
-  inset-inline-end: 0;
-}
+  .cinder-dropdown[data-cinder-placement='bottom-end'] .cinder-dropdown__menu:not([popover]) {
+    position: absolute;
+    inset-block-start: calc(100% + var(--cinder-space-1));
+    inset-inline-end: 0;
+  }
 
-/* ----------------------------------------
+  /* ----------------------------------------
  * Reduced motion
  * ----------------------------------------
  *
@@ -305,24 +306,25 @@
  * the menu must still be visible, so we set opacity: 1 unconditionally below.
  */
 
-.cinder-dropdown__menu {
-  opacity: 1;
-}
-
-@media (prefers-reduced-motion: no-preference) {
   .cinder-dropdown__menu {
-    animation: cinder-dropdown-enter var(--cinder-duration-fast) var(--cinder-ease-standard)
-      forwards;
+    opacity: 1;
   }
 
-  @keyframes cinder-dropdown-enter {
-    from {
-      opacity: 0;
-      translate: 0 -0.25rem;
+  @media (prefers-reduced-motion: no-preference) {
+    .cinder-dropdown__menu {
+      animation: cinder-dropdown-enter var(--cinder-duration-fast) var(--cinder-ease-standard)
+        forwards;
     }
-    to {
-      opacity: 1;
-      translate: 0 0;
+
+    @keyframes cinder-dropdown-enter {
+      from {
+        opacity: 0;
+        translate: 0 -0.25rem;
+      }
+      to {
+        opacity: 1;
+        translate: 0 0;
+      }
     }
   }
 }

--- a/packages/components/src/components/dropdown/dropdown.test.ts
+++ b/packages/components/src/components/dropdown/dropdown.test.ts
@@ -2,6 +2,7 @@
 import { describe, expect, test } from 'bun:test';
 import { createRawSnippet } from 'svelte';
 
+import { stripCinderComponentsLayer } from '../../test/css.ts';
 import { setupHappyDom } from '../../test/happy-dom.ts';
 
 setupHappyDom();
@@ -94,7 +95,12 @@ function expectNoDeclaration(block: string, propertyName: string): void {
 }
 
 async function readDropdownCss(): Promise<string> {
-  return await Bun.file(new URL('./dropdown.css', import.meta.url)).text();
+  // Strip the @layer wrapper: happy-dom does not apply layer-nested rules to
+  // getComputedStyle. The inner declaration blocks are unchanged, so the
+  // string-extraction assertions that also use this read are unaffected.
+  return stripCinderComponentsLayer(
+    await Bun.file(new URL('./dropdown.css', import.meta.url)).text(),
+  );
 }
 
 async function injectDropdownCss(): Promise<() => void> {

--- a/packages/components/src/components/empty-state/empty-state.css
+++ b/packages/components/src/components/empty-state/empty-state.css
@@ -1,42 +1,44 @@
-/* ========================================
+@layer cinder.components {
+  /* ========================================
  * EMPTY STATE
  * ======================================== */
 
-.cinder-empty-state {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  inline-size: 100%;
-  text-align: center;
-  padding-block: var(--cinder-space-12);
-  padding-inline: var(--cinder-space-8);
-  gap: var(--cinder-space-2);
-}
+  .cinder-empty-state {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    inline-size: 100%;
+    text-align: center;
+    padding-block: var(--cinder-space-12);
+    padding-inline: var(--cinder-space-8);
+    gap: var(--cinder-space-2);
+  }
 
-.cinder-empty-state-icon {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  color: var(--cinder-text-subtle);
-  margin-bottom: var(--cinder-space-2);
-}
+  .cinder-empty-state-icon {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: var(--cinder-text-subtle);
+    margin-bottom: var(--cinder-space-2);
+  }
 
-.cinder-empty-state-title {
-  font-size: var(--cinder-text-base);
-  font-weight: var(--cinder-font-medium);
-  line-height: var(--cinder-leading-snug);
-  color: var(--cinder-text-muted);
-  margin: 0;
-}
+  .cinder-empty-state-title {
+    font-size: var(--cinder-text-base);
+    font-weight: var(--cinder-font-medium);
+    line-height: var(--cinder-leading-snug);
+    color: var(--cinder-text-muted);
+    margin: 0;
+  }
 
-.cinder-empty-state-description {
-  font-size: var(--cinder-text-sm);
-  line-height: var(--cinder-leading-normal);
-  color: var(--cinder-text-subtle);
-  margin: 0;
-}
+  .cinder-empty-state-description {
+    font-size: var(--cinder-text-sm);
+    line-height: var(--cinder-leading-normal);
+    color: var(--cinder-text-subtle);
+    margin: 0;
+  }
 
-.cinder-empty-state-action {
-  margin-top: var(--cinder-space-4);
+  .cinder-empty-state-action {
+    margin-top: var(--cinder-space-4);
+  }
 }

--- a/packages/components/src/components/experimental/connection-indicator/connection-indicator.css
+++ b/packages/components/src/components/experimental/connection-indicator/connection-indicator.css
@@ -1,60 +1,62 @@
-/* ========================================
+@layer cinder.components {
+  /* ========================================
  * CONNECTION INDICATOR (experimental)
  * Live-status pill with semantic dot + label.
  * ======================================== */
 
-.cinder-connection-indicator {
-  display: inline-flex;
-  align-items: center;
-  gap: var(--cinder-space-1-5);
-  padding: var(--cinder-space-0-5) var(--cinder-space-2);
-  font-size: var(--cinder-text-xs);
-  font-weight: var(--cinder-font-medium);
-  border-radius: var(--cinder-radius-full);
-  background: var(--cinder-surface-inset);
-  color: var(--cinder-text);
-}
-
-.cinder-connection-indicator__dot {
-  display: inline-block;
-  width: 0.5rem;
-  height: 0.5rem;
-  border-radius: var(--cinder-radius-full);
-  background: currentColor;
-}
-
-.cinder-connection-indicator[data-cinder-state='connected'] {
-  color: var(--cinder-success);
-}
-
-.cinder-connection-indicator[data-cinder-state='connecting'] {
-  color: var(--cinder-warning);
-}
-
-.cinder-connection-indicator[data-cinder-state='connecting'] .cinder-connection-indicator__dot {
-  animation: cinder-connection-pulse 1.4s ease-in-out infinite;
-}
-
-@keyframes cinder-connection-pulse {
-  0%,
-  100% {
-    opacity: 1;
+  .cinder-connection-indicator {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--cinder-space-1-5);
+    padding: var(--cinder-space-0-5) var(--cinder-space-2);
+    font-size: var(--cinder-text-xs);
+    font-weight: var(--cinder-font-medium);
+    border-radius: var(--cinder-radius-full);
+    background: var(--cinder-surface-inset);
+    color: var(--cinder-text);
   }
-  50% {
-    opacity: 0.3;
-  }
-}
 
-@media (prefers-reduced-motion: reduce) {
+  .cinder-connection-indicator__dot {
+    display: inline-block;
+    width: 0.5rem;
+    height: 0.5rem;
+    border-radius: var(--cinder-radius-full);
+    background: currentColor;
+  }
+
+  .cinder-connection-indicator[data-cinder-state='connected'] {
+    color: var(--cinder-success);
+  }
+
+  .cinder-connection-indicator[data-cinder-state='connecting'] {
+    color: var(--cinder-warning);
+  }
+
   .cinder-connection-indicator[data-cinder-state='connecting'] .cinder-connection-indicator__dot {
-    animation: none;
+    animation: cinder-connection-pulse 1.4s ease-in-out infinite;
   }
-}
 
-.cinder-connection-indicator[data-cinder-state='disconnected'] {
-  color: var(--cinder-text-muted);
-}
+  @keyframes cinder-connection-pulse {
+    0%,
+    100% {
+      opacity: 1;
+    }
+    50% {
+      opacity: 0.3;
+    }
+  }
 
-.cinder-connection-indicator[data-cinder-state='error'] {
-  color: var(--cinder-danger);
+  @media (prefers-reduced-motion: reduce) {
+    .cinder-connection-indicator[data-cinder-state='connecting'] .cinder-connection-indicator__dot {
+      animation: none;
+    }
+  }
+
+  .cinder-connection-indicator[data-cinder-state='disconnected'] {
+    color: var(--cinder-text-muted);
+  }
+
+  .cinder-connection-indicator[data-cinder-state='error'] {
+    color: var(--cinder-danger);
+  }
 }

--- a/packages/components/src/components/experimental/json-viewer/json-viewer.css
+++ b/packages/components/src/components/experimental/json-viewer/json-viewer.css
@@ -1,105 +1,107 @@
-/* ========================================
+@layer cinder.components {
+  /* ========================================
  * JSON VIEWER (experimental)
  * Collapsible tree visualization. Hard caps live in the component itself.
  * ======================================== */
 
-.cinder-json-viewer {
-  font-family: var(--cinder-font-mono);
-  font-size: var(--cinder-text-sm);
-  color: var(--cinder-text);
-  background: var(--cinder-surface-inset);
-  border: 1px solid var(--cinder-border);
-  border-radius: var(--cinder-radius-md);
-  padding: var(--cinder-space-3);
-  overflow: auto;
-}
+  .cinder-json-viewer {
+    font-family: var(--cinder-font-mono);
+    font-size: var(--cinder-text-sm);
+    color: var(--cinder-text);
+    background: var(--cinder-surface-inset);
+    border: 1px solid var(--cinder-border);
+    border-radius: var(--cinder-radius-md);
+    padding: var(--cinder-space-3);
+    overflow: auto;
+  }
 
-.cinder-json-viewer__fallback {
-  color: var(--cinder-text-muted);
-  font-family: var(--cinder-font-sans);
-  text-align: center;
-  padding: var(--cinder-space-4);
-}
+  .cinder-json-viewer__fallback {
+    color: var(--cinder-text-muted);
+    font-family: var(--cinder-font-sans);
+    text-align: center;
+    padding: var(--cinder-space-4);
+  }
 
-.cinder-json-viewer__fallback p {
-  margin: 0 0 var(--cinder-space-1) 0;
-}
+  .cinder-json-viewer__fallback p {
+    margin: 0 0 var(--cinder-space-1) 0;
+  }
 
-.cinder-json-viewer__node {
-  display: inline;
-}
+  .cinder-json-viewer__node {
+    display: inline;
+  }
 
-.cinder-json-viewer__key {
-  color: var(--cinder-accent);
-  margin-inline-end: var(--cinder-space-1);
-}
+  .cinder-json-viewer__key {
+    color: var(--cinder-accent);
+    margin-inline-end: var(--cinder-space-1);
+  }
 
-.cinder-json-viewer__toggle {
-  appearance: none;
-  background: none;
-  border: none;
-  padding: 0;
-  font: inherit;
-  color: inherit;
-  cursor: pointer;
-  display: inline-flex;
-  align-items: center;
-  gap: var(--cinder-space-1);
-  border-radius: var(--cinder-radius-sm);
-}
+  .cinder-json-viewer__toggle {
+    appearance: none;
+    background: none;
+    border: none;
+    padding: 0;
+    font: inherit;
+    color: inherit;
+    cursor: pointer;
+    display: inline-flex;
+    align-items: center;
+    gap: var(--cinder-space-1);
+    border-radius: var(--cinder-radius-sm);
+  }
 
-.cinder-json-viewer__toggle:focus-visible {
-  outline: var(--cinder-ring-width) solid var(--cinder-ring-color);
-  outline-offset: 2px;
-}
+  .cinder-json-viewer__toggle:focus-visible {
+    outline: var(--cinder-ring-width) solid var(--cinder-ring-color);
+    outline-offset: 2px;
+  }
 
-.cinder-json-viewer__caret {
-  display: inline-block;
-  width: 0;
-  height: 0;
-  border-inline-start: 0.25rem solid transparent;
-  border-inline-end: 0.25rem solid transparent;
-  border-top: 0.375rem solid currentColor;
-  transition: transform var(--cinder-duration-fast) var(--cinder-ease-standard);
-}
+  .cinder-json-viewer__caret {
+    display: inline-block;
+    width: 0;
+    height: 0;
+    border-inline-start: 0.25rem solid transparent;
+    border-inline-end: 0.25rem solid transparent;
+    border-top: 0.375rem solid currentColor;
+    transition: transform var(--cinder-duration-fast) var(--cinder-ease-standard);
+  }
 
-.cinder-json-viewer__caret[data-cinder-collapsed] {
-  transform: rotate(-90deg);
-}
+  .cinder-json-viewer__caret[data-cinder-collapsed] {
+    transform: rotate(-90deg);
+  }
 
-.cinder-json-viewer__brace {
-  color: var(--cinder-text-muted);
-}
+  .cinder-json-viewer__brace {
+    color: var(--cinder-text-muted);
+  }
 
-.cinder-json-viewer__summary {
-  color: var(--cinder-text-muted);
-  font-style: italic;
-}
+  .cinder-json-viewer__summary {
+    color: var(--cinder-text-muted);
+    font-style: italic;
+  }
 
-.cinder-json-viewer__children {
-  list-style: none;
-  margin: 0;
-  padding-inline-start: var(--cinder-space-4);
-  border-inline-start: 1px dashed var(--cinder-border-muted);
-}
+  .cinder-json-viewer__children {
+    list-style: none;
+    margin: 0;
+    padding-inline-start: var(--cinder-space-4);
+    border-inline-start: 1px dashed var(--cinder-border-muted);
+  }
 
-.cinder-json-viewer__too-deep {
-  color: var(--cinder-text-muted);
-}
+  .cinder-json-viewer__too-deep {
+    color: var(--cinder-text-muted);
+  }
 
-.cinder-json-viewer__value[data-cinder-type='string'] {
-  color: var(--cinder-success);
-}
+  .cinder-json-viewer__value[data-cinder-type='string'] {
+    color: var(--cinder-success);
+  }
 
-.cinder-json-viewer__value[data-cinder-type='number'] {
-  color: var(--cinder-warning);
-}
+  .cinder-json-viewer__value[data-cinder-type='number'] {
+    color: var(--cinder-warning);
+  }
 
-.cinder-json-viewer__value[data-cinder-type='boolean'] {
-  color: var(--cinder-danger);
-}
+  .cinder-json-viewer__value[data-cinder-type='boolean'] {
+    color: var(--cinder-danger);
+  }
 
-.cinder-json-viewer__value[data-cinder-type='null'] {
-  color: var(--cinder-text-muted);
-  font-style: italic;
+  .cinder-json-viewer__value[data-cinder-type='null'] {
+    color: var(--cinder-text-muted);
+    font-style: italic;
+  }
 }

--- a/packages/components/src/components/experimental/message/message.css
+++ b/packages/components/src/components/experimental/message/message.css
@@ -1,54 +1,56 @@
-/* ========================================
+@layer cinder.components {
+  /* ========================================
  * MESSAGE (experimental)
  * Chat-style bubble with role and optional timestamp.
  * ======================================== */
 
-.cinder-message {
-  display: flex;
-  flex-direction: column;
-  gap: var(--cinder-space-1);
-  padding: var(--cinder-space-3) var(--cinder-space-4);
-  border-radius: var(--cinder-radius-md);
-  background: var(--cinder-surface);
-  border: 1px solid var(--cinder-border-muted);
-  max-width: 48rem;
-}
+  .cinder-message {
+    display: flex;
+    flex-direction: column;
+    gap: var(--cinder-space-1);
+    padding: var(--cinder-space-3) var(--cinder-space-4);
+    border-radius: var(--cinder-radius-md);
+    background: var(--cinder-surface);
+    border: 1px solid var(--cinder-border-muted);
+    max-width: 48rem;
+  }
 
-.cinder-message[data-cinder-role='user'] {
-  background: var(--cinder-color-info-bg);
-  border-color: var(--cinder-color-info-border);
-  align-self: flex-end;
-}
+  .cinder-message[data-cinder-role='user'] {
+    background: var(--cinder-color-info-bg);
+    border-color: var(--cinder-color-info-border);
+    align-self: flex-end;
+  }
 
-.cinder-message[data-cinder-role='assistant'] {
-  background: var(--cinder-surface-raised);
-  border-color: var(--cinder-border);
-}
+  .cinder-message[data-cinder-role='assistant'] {
+    background: var(--cinder-surface-raised);
+    border-color: var(--cinder-border);
+  }
 
-.cinder-message[data-cinder-role='system'] {
-  background: var(--cinder-surface-inset);
-  border-style: dashed;
-  font-size: var(--cinder-text-sm);
-}
+  .cinder-message[data-cinder-role='system'] {
+    background: var(--cinder-surface-inset);
+    border-style: dashed;
+    font-size: var(--cinder-text-sm);
+  }
 
-.cinder-message__header {
-  display: flex;
-  align-items: baseline;
-  gap: var(--cinder-space-2);
-  font-size: var(--cinder-text-xs);
-  color: var(--cinder-text-muted);
-}
+  .cinder-message__header {
+    display: flex;
+    align-items: baseline;
+    gap: var(--cinder-space-2);
+    font-size: var(--cinder-text-xs);
+    color: var(--cinder-text-muted);
+  }
 
-.cinder-message__name {
-  font-weight: var(--cinder-font-medium);
-}
+  .cinder-message__name {
+    font-weight: var(--cinder-font-medium);
+  }
 
-.cinder-message__time {
-  font-variant-numeric: tabular-nums;
-}
+  .cinder-message__time {
+    font-variant-numeric: tabular-nums;
+  }
 
-.cinder-message__body {
-  font-size: var(--cinder-text-sm);
-  line-height: var(--cinder-leading-relaxed);
-  color: var(--cinder-text);
+  .cinder-message__body {
+    font-size: var(--cinder-text-sm);
+    line-height: var(--cinder-leading-relaxed);
+    color: var(--cinder-text);
+  }
 }

--- a/packages/components/src/components/experimental/timeline-item/timeline-item.css
+++ b/packages/components/src/components/experimental/timeline-item/timeline-item.css
@@ -1,4 +1,6 @@
-/* ========================================
+@layer cinder.components {
+  /* ========================================
  * TIMELINE ITEM (experimental)
  * Visual treatment lives in timeline.css. Empty registry entry.
  * ======================================== */
+}

--- a/packages/components/src/components/experimental/timeline/timeline.css
+++ b/packages/components/src/components/experimental/timeline/timeline.css
@@ -1,143 +1,146 @@
-/* ========================================
+@layer cinder.components {
+  /* ========================================
  * TIMELINE (experimental)
  * Timestamp-first event rail with optional grouping.
  * ======================================== */
 
-.cinder-timeline {
-  --_cinder-timeline-rail-size: 1.5rem;
-  --_cinder-timeline-marker-size: 0.875rem;
-  --_cinder-timeline-rail-center: 0.6875rem;
+  .cinder-timeline {
+    --_cinder-timeline-rail-size: 1.5rem;
+    --_cinder-timeline-marker-size: 0.875rem;
+    --_cinder-timeline-rail-center: 0.6875rem;
 
-  list-style: none;
-  margin: 0;
-  padding: 0;
-  position: relative;
-}
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    position: relative;
+  }
 
-.cinder-timeline[data-cinder-orientation='horizontal'] {
-  display: grid;
-  grid-auto-flow: column;
-  grid-auto-columns: minmax(12rem, 1fr);
-  gap: var(--cinder-space-4);
-  overflow-x: auto;
-  padding-block-end: var(--cinder-space-2);
-}
+  .cinder-timeline[data-cinder-orientation='horizontal'] {
+    display: grid;
+    grid-auto-flow: column;
+    grid-auto-columns: minmax(12rem, 1fr);
+    gap: var(--cinder-space-4);
+    overflow-x: auto;
+    padding-block-end: var(--cinder-space-2);
+  }
 
-.cinder-timeline-item {
-  position: relative;
-  padding-bottom: var(--cinder-space-4);
-}
+  .cinder-timeline-item {
+    position: relative;
+    padding-bottom: var(--cinder-space-4);
+  }
 
-.cinder-timeline-item:last-child {
-  padding-bottom: 0;
-}
+  .cinder-timeline-item:last-child {
+    padding-bottom: 0;
+  }
 
-.cinder-timeline-item__event {
-  display: grid;
-  grid-template-columns: var(--_cinder-timeline-rail-size) 1fr;
-  gap: var(--cinder-space-3);
-}
+  .cinder-timeline-item__event {
+    display: grid;
+    grid-template-columns: var(--_cinder-timeline-rail-size) 1fr;
+    gap: var(--cinder-space-3);
+  }
 
-.cinder-timeline__group-header {
-  margin: 0 0 var(--cinder-space-2) calc(var(--_cinder-timeline-rail-size) + var(--cinder-space-3));
-  color: var(--cinder-text-muted);
-  font-size: var(--cinder-text-xs);
-  font-weight: var(--cinder-font-semibold);
-  letter-spacing: 0;
-  text-transform: uppercase;
-}
+  .cinder-timeline__group-header {
+    margin: 0 0 var(--cinder-space-2)
+      calc(var(--_cinder-timeline-rail-size) + var(--cinder-space-3));
+    color: var(--cinder-text-muted);
+    font-size: var(--cinder-text-xs);
+    font-weight: var(--cinder-font-semibold);
+    letter-spacing: 0;
+    text-transform: uppercase;
+  }
 
-/* Connecting line between items */
-.cinder-timeline-item::before {
-  content: '';
-  position: absolute;
-  left: var(--_cinder-timeline-rail-center);
-  top: 1rem;
-  bottom: 0;
-  width: 1px;
-  background: var(--cinder-border-muted);
-}
+  /* Connecting line between items */
+  .cinder-timeline-item::before {
+    content: '';
+    position: absolute;
+    left: var(--_cinder-timeline-rail-center);
+    top: 1rem;
+    bottom: 0;
+    width: 1px;
+    background: var(--cinder-border-muted);
+  }
 
-.cinder-timeline-item[data-cinder-connector-after='hidden']::before {
-  display: none;
-}
+  .cinder-timeline-item[data-cinder-connector-after='hidden']::before {
+    display: none;
+  }
 
-.cinder-timeline-item__marker {
-  position: relative;
-  z-index: 1;
-  width: var(--_cinder-timeline-marker-size);
-  height: var(--_cinder-timeline-marker-size);
-  margin-top: var(--cinder-space-1);
-  border-radius: var(--cinder-radius-full);
-  background: var(--cinder-surface-raised);
-  border: 2px solid currentColor;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-}
+  .cinder-timeline-item__marker {
+    position: relative;
+    z-index: 1;
+    width: var(--_cinder-timeline-marker-size);
+    height: var(--_cinder-timeline-marker-size);
+    margin-top: var(--cinder-space-1);
+    border-radius: var(--cinder-radius-full);
+    background: var(--cinder-surface-raised);
+    border: 2px solid currentColor;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+  }
 
-.cinder-timeline-item[data-cinder-tone='info'] .cinder-timeline-item__marker {
-  color: var(--cinder-info);
-}
+  .cinder-timeline-item[data-cinder-tone='info'] .cinder-timeline-item__marker {
+    color: var(--cinder-info);
+  }
 
-.cinder-timeline-item[data-cinder-tone='success'] .cinder-timeline-item__marker {
-  color: var(--cinder-success);
-}
+  .cinder-timeline-item[data-cinder-tone='success'] .cinder-timeline-item__marker {
+    color: var(--cinder-success);
+  }
 
-.cinder-timeline-item[data-cinder-tone='warning'] .cinder-timeline-item__marker {
-  color: var(--cinder-warning);
-}
+  .cinder-timeline-item[data-cinder-tone='warning'] .cinder-timeline-item__marker {
+    color: var(--cinder-warning);
+  }
 
-.cinder-timeline-item[data-cinder-tone='error'] .cinder-timeline-item__marker {
-  color: var(--cinder-danger);
-}
+  .cinder-timeline-item[data-cinder-tone='error'] .cinder-timeline-item__marker {
+    color: var(--cinder-danger);
+  }
 
-.cinder-timeline-item__header {
-  display: flex;
-  align-items: baseline;
-  gap: var(--cinder-space-2);
-  flex-wrap: wrap;
-}
+  .cinder-timeline-item__header {
+    display: flex;
+    align-items: baseline;
+    gap: var(--cinder-space-2);
+    flex-wrap: wrap;
+  }
 
-.cinder-timeline-item__title {
-  font-size: var(--cinder-text-sm);
-  font-weight: var(--cinder-font-medium);
-  color: var(--cinder-text);
-}
+  .cinder-timeline-item__title {
+    font-size: var(--cinder-text-sm);
+    font-weight: var(--cinder-font-medium);
+    color: var(--cinder-text);
+  }
 
-.cinder-timeline-item__time {
-  font-size: var(--cinder-text-xs);
-  color: var(--cinder-text-muted);
-  font-variant-numeric: tabular-nums;
-}
+  .cinder-timeline-item__time {
+    font-size: var(--cinder-text-xs);
+    color: var(--cinder-text-muted);
+    font-variant-numeric: tabular-nums;
+  }
 
-.cinder-timeline-item__body {
-  margin-top: var(--cinder-space-1);
-  font-size: var(--cinder-text-sm);
-  color: var(--cinder-text-muted);
-}
+  .cinder-timeline-item__body {
+    margin-top: var(--cinder-space-1);
+    font-size: var(--cinder-text-sm);
+    color: var(--cinder-text-muted);
+  }
 
-.cinder-timeline[data-cinder-orientation='horizontal'] .cinder-timeline-item {
-  min-inline-size: 12rem;
-  padding-block-end: 0;
-  padding-inline-end: var(--cinder-space-4);
-}
+  .cinder-timeline[data-cinder-orientation='horizontal'] .cinder-timeline-item {
+    min-inline-size: 12rem;
+    padding-block-end: 0;
+    padding-inline-end: var(--cinder-space-4);
+  }
 
-.cinder-timeline[data-cinder-orientation='horizontal'] .cinder-timeline-item__event {
-  grid-template-columns: 1fr;
-  grid-template-rows: var(--_cinder-timeline-rail-size) auto;
-  gap: var(--cinder-space-2);
-}
+  .cinder-timeline[data-cinder-orientation='horizontal'] .cinder-timeline-item__event {
+    grid-template-columns: 1fr;
+    grid-template-rows: var(--_cinder-timeline-rail-size) auto;
+    gap: var(--cinder-space-2);
+  }
 
-.cinder-timeline[data-cinder-orientation='horizontal'] .cinder-timeline__group-header {
-  margin: 0 0 var(--cinder-space-2);
-}
+  .cinder-timeline[data-cinder-orientation='horizontal'] .cinder-timeline__group-header {
+    margin: 0 0 var(--cinder-space-2);
+  }
 
-.cinder-timeline[data-cinder-orientation='horizontal'] .cinder-timeline-item::before {
-  left: calc(var(--_cinder-timeline-marker-size) / 2);
-  right: calc(-1 * var(--cinder-space-4));
-  top: calc(var(--_cinder-timeline-marker-size) / 2 + var(--cinder-space-1));
-  bottom: auto;
-  width: auto;
-  height: 1px;
+  .cinder-timeline[data-cinder-orientation='horizontal'] .cinder-timeline-item::before {
+    left: calc(var(--_cinder-timeline-marker-size) / 2);
+    right: calc(-1 * var(--cinder-space-4));
+    top: calc(var(--_cinder-timeline-marker-size) / 2 + var(--cinder-space-1));
+    bottom: auto;
+    width: auto;
+    height: 1px;
+  }
 }

--- a/packages/components/src/components/feed/feed.css
+++ b/packages/components/src/components/feed/feed.css
@@ -1,85 +1,87 @@
-/* ========================================
+@layer cinder.components {
+  /* ========================================
  * FEED
  * ======================================== */
 
-.cinder-feed {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-  display: flex;
-  flex-direction: column;
-  gap: var(--cinder-space-4);
-}
+  .cinder-feed {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: var(--cinder-space-4);
+  }
 
-.cinder-feed-event {
-  --cinder-feed-rail-size: var(--cinder-space-6);
+  .cinder-feed-event {
+    --cinder-feed-rail-size: var(--cinder-space-6);
 
-  position: relative;
-  display: grid;
-  grid-template-columns: auto 1fr;
-  column-gap: var(--cinder-space-3);
-  align-items: start;
-}
+    position: relative;
+    display: grid;
+    grid-template-columns: auto 1fr;
+    column-gap: var(--cinder-space-3);
+    align-items: start;
+  }
 
-.cinder-feed-event-rail {
-  position: relative;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  inline-size: var(--cinder-feed-rail-size);
-  block-size: var(--cinder-feed-rail-size);
-  border-radius: var(--cinder-radius-full);
-  background: var(--cinder-surface-muted);
-  color: var(--cinder-text-muted);
-  flex-shrink: 0;
-}
+  .cinder-feed-event-rail {
+    position: relative;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    inline-size: var(--cinder-feed-rail-size);
+    block-size: var(--cinder-feed-rail-size);
+    border-radius: var(--cinder-radius-full);
+    background: var(--cinder-surface-muted);
+    color: var(--cinder-text-muted);
+    flex-shrink: 0;
+  }
 
-/* Minimal variant keeps the SAME rail box dimensions as the icon variant so
+  /* Minimal variant keeps the SAME rail box dimensions as the icon variant so
  * the connector's inline anchor is constant across mixed-variant feeds. Only
  * the inner visual marker shrinks — the dot is centered inside the same rail
  * box via the flex centering already on .cinder-feed-event-rail. */
-.cinder-feed-event[data-cinder-variant='minimal'] .cinder-feed-event-rail {
-  background: transparent;
-}
+  .cinder-feed-event[data-cinder-variant='minimal'] .cinder-feed-event-rail {
+    background: transparent;
+  }
 
-.cinder-feed-event-dot {
-  inline-size: var(--cinder-space-2);
-  block-size: var(--cinder-space-2);
-  border-radius: var(--cinder-radius-full);
-  background: var(--cinder-border-strong);
-}
+  .cinder-feed-event-dot {
+    inline-size: var(--cinder-space-2);
+    block-size: var(--cinder-space-2);
+    border-radius: var(--cinder-radius-full);
+    background: var(--cinder-border-strong);
+  }
 
-/* Connector line — pseudo-element on the <li> itself, anchored at the rail's
+  /* Connector line — pseudo-element on the <li> itself, anchored at the rail's
  * horizontal center. The line spans from the bottom of the rail all the way
  * through the row body plus the gap, landing at the next rail's top edge.
  *
  * inset-block-start must match .cinder-feed-event-rail's block-size so the
  * line starts exactly at the rail bottom regardless of body height.
  * inset-block-end extends into the row gap to reach the next rail's top. */
-.cinder-feed-event::after {
-  content: '';
-  position: absolute;
-  inset-block-start: var(--cinder-feed-rail-size);
-  inset-block-end: calc(-1 * var(--cinder-space-4));
-  inset-inline-start: calc(var(--cinder-feed-rail-size) / 2);
-  inline-size: 1px;
-  background: var(--cinder-border-muted);
-  transform: translateX(-50%);
-  pointer-events: none;
-}
+  .cinder-feed-event::after {
+    content: '';
+    position: absolute;
+    inset-block-start: var(--cinder-feed-rail-size);
+    inset-block-end: calc(-1 * var(--cinder-space-4));
+    inset-inline-start: calc(var(--cinder-feed-rail-size) / 2);
+    inline-size: 1px;
+    background: var(--cinder-border-muted);
+    transform: translateX(-50%);
+    pointer-events: none;
+  }
 
-.cinder-feed-event:last-child::after {
-  content: none;
-}
+  .cinder-feed-event:last-child::after {
+    content: none;
+  }
 
-.cinder-feed-event-body {
-  display: flex;
-  flex-direction: column;
-  gap: var(--cinder-space-1);
-  min-inline-size: 0;
-}
+  .cinder-feed-event-body {
+    display: flex;
+    flex-direction: column;
+    gap: var(--cinder-space-1);
+    min-inline-size: 0;
+  }
 
-.cinder-feed-event-time {
-  font-size: var(--cinder-text-sm);
-  color: var(--cinder-text-muted);
+  .cinder-feed-event-time {
+    font-size: var(--cinder-text-sm);
+    color: var(--cinder-text-muted);
+  }
 }

--- a/packages/components/src/components/file-upload/file-upload.css
+++ b/packages/components/src/components/file-upload/file-upload.css
@@ -1,181 +1,183 @@
-.cinder-file-upload {
-  --cinder-file-upload-border-color: var(--cinder-border);
-  --cinder-file-upload-background: var(--cinder-surface);
-  --cinder-file-upload-progress-background: var(--cinder-surface-inset);
-  --cinder-file-upload-progress-fill: var(--cinder-accent);
+@layer cinder.components {
+  .cinder-file-upload {
+    --cinder-file-upload-border-color: var(--cinder-border);
+    --cinder-file-upload-background: var(--cinder-surface);
+    --cinder-file-upload-progress-background: var(--cinder-surface-inset);
+    --cinder-file-upload-progress-fill: var(--cinder-accent);
 
-  display: grid;
-  gap: var(--cinder-space-3);
-}
+    display: grid;
+    gap: var(--cinder-space-3);
+  }
 
-.cinder-file-upload__dropzone {
-  display: grid;
-  gap: var(--cinder-space-3);
-  border: 2px dashed var(--cinder-file-upload-border-color);
-  border-radius: var(--cinder-radius-lg);
-  background: var(--cinder-file-upload-background);
-  padding: var(--cinder-space-4);
-  transition:
-    border-color 150ms ease,
-    background-color 150ms ease,
-    box-shadow 150ms ease;
-}
+  .cinder-file-upload__dropzone {
+    display: grid;
+    gap: var(--cinder-space-3);
+    border: 2px dashed var(--cinder-file-upload-border-color);
+    border-radius: var(--cinder-radius-lg);
+    background: var(--cinder-file-upload-background);
+    padding: var(--cinder-space-4);
+    transition:
+      border-color 150ms ease,
+      background-color 150ms ease,
+      box-shadow 150ms ease;
+  }
 
-.cinder-file-upload__dropzone[data-drag-active] {
-  border-style: solid;
-  border-color: var(--cinder-accent);
-  background: color-mix(in srgb, var(--cinder-accent) 8%, var(--cinder-file-upload-background));
-}
+  .cinder-file-upload__dropzone[data-drag-active] {
+    border-style: solid;
+    border-color: var(--cinder-accent);
+    background: color-mix(in srgb, var(--cinder-accent) 8%, var(--cinder-file-upload-background));
+  }
 
-.cinder-file-upload__dropzone[data-disabled] {
-  cursor: not-allowed;
-  opacity: 0.7;
-}
+  .cinder-file-upload__dropzone[data-disabled] {
+    cursor: not-allowed;
+    opacity: 0.7;
+  }
 
-.cinder-file-upload__dropzone:focus-within {
-  outline: 2px solid transparent;
-  box-shadow: var(--_cinder-focus-ring-shadow);
-}
+  .cinder-file-upload__dropzone:focus-within {
+    outline: 2px solid transparent;
+    box-shadow: var(--_cinder-focus-ring-shadow);
+  }
 
-.cinder-file-upload__input {
-  position: absolute;
-  inline-size: 1px;
-  block-size: 1px;
-  margin: -1px;
-  border: 0;
-  padding: 0;
-  overflow: hidden;
-  clip: rect(0 0 0 0);
-  clip-path: inset(50%);
-  white-space: nowrap;
-}
+  .cinder-file-upload__input {
+    position: absolute;
+    inline-size: 1px;
+    block-size: 1px;
+    margin: -1px;
+    border: 0;
+    padding: 0;
+    overflow: hidden;
+    clip: rect(0 0 0 0);
+    clip-path: inset(50%);
+    white-space: nowrap;
+  }
 
-.cinder-file-upload__body {
-  display: grid;
-  gap: var(--cinder-space-2);
-  justify-items: start;
-}
+  .cinder-file-upload__body {
+    display: grid;
+    gap: var(--cinder-space-2);
+    justify-items: start;
+  }
 
-.cinder-file-upload__eyebrow {
-  display: inline-flex;
-  align-items: center;
-  gap: var(--cinder-space-2);
-  color: var(--cinder-text);
-  font-size: var(--cinder-text-sm);
-  font-weight: var(--cinder-font-weight-medium);
-}
+  .cinder-file-upload__eyebrow {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--cinder-space-2);
+    color: var(--cinder-text);
+    font-size: var(--cinder-text-sm);
+    font-weight: var(--cinder-font-weight-medium);
+  }
 
-.cinder-file-upload__eyebrow-icon {
-  inline-size: 1rem;
-  block-size: 1rem;
-  color: var(--cinder-accent);
-}
+  .cinder-file-upload__eyebrow-icon {
+    inline-size: 1rem;
+    block-size: 1rem;
+    color: var(--cinder-accent);
+  }
 
-.cinder-file-upload__button {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  border-radius: var(--cinder-radius-md);
-  background: var(--cinder-accent);
-  color: var(--cinder-accent-contrast);
-  min-block-size: 2.75rem;
-  padding-inline: var(--cinder-space-4);
-  padding-block: var(--cinder-space-2);
-  font-weight: var(--cinder-font-weight-semibold);
-}
+  .cinder-file-upload__button {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: var(--cinder-radius-md);
+    background: var(--cinder-accent);
+    color: var(--cinder-accent-contrast);
+    min-block-size: 2.75rem;
+    padding-inline: var(--cinder-space-4);
+    padding-block: var(--cinder-space-2);
+    font-weight: var(--cinder-font-weight-semibold);
+  }
 
-.cinder-file-upload__hint {
-  color: var(--cinder-text-muted);
-  font-size: var(--cinder-text-sm);
-  line-height: var(--cinder-leading-relaxed);
-}
+  .cinder-file-upload__hint {
+    color: var(--cinder-text-muted);
+    font-size: var(--cinder-text-sm);
+    line-height: var(--cinder-leading-relaxed);
+  }
 
-.cinder-file-upload__list {
-  display: grid;
-  gap: var(--cinder-space-2);
-  list-style: none;
-  margin: 0;
-  padding: 0;
-}
+  .cinder-file-upload__list {
+    display: grid;
+    gap: var(--cinder-space-2);
+    list-style: none;
+    margin: 0;
+    padding: 0;
+  }
 
-.cinder-file-upload__row {
-  display: grid;
-  gap: var(--cinder-space-2);
-  border: 1px solid var(--cinder-border);
-  border-radius: var(--cinder-radius-md);
-  background: var(--cinder-surface);
-  padding: var(--cinder-space-3);
-}
+  .cinder-file-upload__row {
+    display: grid;
+    gap: var(--cinder-space-2);
+    border: 1px solid var(--cinder-border);
+    border-radius: var(--cinder-radius-md);
+    background: var(--cinder-surface);
+    padding: var(--cinder-space-3);
+  }
 
-.cinder-file-upload__row-main {
-  display: flex;
-  align-items: start;
-  justify-content: space-between;
-  gap: var(--cinder-space-3);
-}
+  .cinder-file-upload__row-main {
+    display: flex;
+    align-items: start;
+    justify-content: space-between;
+    gap: var(--cinder-space-3);
+  }
 
-.cinder-file-upload__file-meta {
-  display: grid;
-  gap: var(--cinder-space-1);
-  min-inline-size: 0;
-}
+  .cinder-file-upload__file-meta {
+    display: grid;
+    gap: var(--cinder-space-1);
+    min-inline-size: 0;
+  }
 
-.cinder-file-upload__file-name {
-  color: var(--cinder-text);
-  font-size: var(--cinder-text-sm);
-  font-weight: var(--cinder-font-weight-medium);
-}
+  .cinder-file-upload__file-name {
+    color: var(--cinder-text);
+    font-size: var(--cinder-text-sm);
+    font-weight: var(--cinder-font-weight-medium);
+  }
 
-.cinder-file-upload__file-size {
-  color: var(--cinder-text-muted);
-  font-size: var(--cinder-text-xs);
-}
+  .cinder-file-upload__file-size {
+    color: var(--cinder-text-muted);
+    font-size: var(--cinder-text-xs);
+  }
 
-.cinder-file-upload__status {
-  display: inline-flex;
-  align-items: center;
-  gap: var(--cinder-space-1);
-  color: var(--cinder-text-muted);
-  font-size: var(--cinder-text-xs);
-  white-space: nowrap;
-}
+  .cinder-file-upload__status {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--cinder-space-1);
+    color: var(--cinder-text-muted);
+    font-size: var(--cinder-text-xs);
+    white-space: nowrap;
+  }
 
-.cinder-file-upload__status[data-status='success'] {
-  color: var(--cinder-color-success-fg);
-}
+  .cinder-file-upload__status[data-status='success'] {
+    color: var(--cinder-color-success-fg);
+  }
 
-.cinder-file-upload__status[data-status='error'] {
-  color: var(--cinder-color-danger-fg);
-}
+  .cinder-file-upload__status[data-status='error'] {
+    color: var(--cinder-color-danger-fg);
+  }
 
-.cinder-file-upload__status-icon {
-  inline-size: 0.875rem;
-  block-size: 0.875rem;
-  flex: none;
-}
+  .cinder-file-upload__status-icon {
+    inline-size: 0.875rem;
+    block-size: 0.875rem;
+    flex: none;
+  }
 
-.cinder-file-upload__progress {
-  overflow: hidden;
-  border-radius: 999px;
-  background: var(--cinder-file-upload-progress-background);
-  block-size: 0.5rem;
-}
+  .cinder-file-upload__progress {
+    overflow: hidden;
+    border-radius: 999px;
+    background: var(--cinder-file-upload-progress-background);
+    block-size: 0.5rem;
+  }
 
-.cinder-file-upload__progress-fill {
-  block-size: 100%;
-  background: var(--cinder-file-upload-progress-fill);
-  inline-size: calc(clamp(0, var(--cinder-file-upload-progress, 0), 100) * 1%);
-  transition: inline-size 150ms ease;
-}
-
-.cinder-file-upload__error {
-  color: var(--cinder-color-danger-fg);
-  font-size: var(--cinder-text-xs);
-}
-
-@media (prefers-reduced-motion: reduce) {
-  .cinder-file-upload__dropzone,
   .cinder-file-upload__progress-fill {
-    transition: none;
+    block-size: 100%;
+    background: var(--cinder-file-upload-progress-fill);
+    inline-size: calc(clamp(0, var(--cinder-file-upload-progress, 0), 100) * 1%);
+    transition: inline-size 150ms ease;
+  }
+
+  .cinder-file-upload__error {
+    color: var(--cinder-color-danger-fg);
+    font-size: var(--cinder-text-xs);
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .cinder-file-upload__dropzone,
+    .cinder-file-upload__progress-fill {
+      transition: none;
+    }
   }
 }

--- a/packages/components/src/components/form-field/form-field.css
+++ b/packages/components/src/components/form-field/form-field.css
@@ -1,61 +1,63 @@
-/* ========================================
+@layer cinder.components {
+  /* ========================================
  * FORM FIELD
  * ======================================== */
 
-.cinder-form-field {
-  display: flex;
-  flex-direction: column;
-  gap: var(--cinder-space-1-5);
-  inline-size: 100%;
-}
+  .cinder-form-field {
+    display: flex;
+    flex-direction: column;
+    gap: var(--cinder-space-1-5);
+    inline-size: 100%;
+  }
 
-/* ----------------------------------------
+  /* ----------------------------------------
  * Label
  * ---------------------------------------- */
 
-.cinder-form-field__label {
-  display: inline-flex;
-  align-items: center;
-  gap: var(--cinder-space-1);
-  font-size: var(--cinder-text-xs);
-  font-weight: var(--cinder-font-medium);
-  line-height: 1;
-  color: var(--cinder-text);
-}
+  .cinder-form-field__label {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--cinder-space-1);
+    font-size: var(--cinder-text-xs);
+    font-weight: var(--cinder-font-medium);
+    line-height: 1;
+    color: var(--cinder-text);
+  }
 
-.cinder-form-field__label[data-disabled] {
-  color: var(--cinder-text-disabled);
-  cursor: not-allowed;
-}
+  .cinder-form-field__label[data-disabled] {
+    color: var(--cinder-text-disabled);
+    cursor: not-allowed;
+  }
 
-/* ----------------------------------------
+  /* ----------------------------------------
  * Required marker
  * ---------------------------------------- */
 
-.cinder-form-field__required {
-  display: inline-block;
-  width: 6px;
-  height: 6px;
-  border-radius: 50%;
-  background-color: var(--cinder-danger);
-  flex-shrink: 0;
-  align-self: center;
-}
+  .cinder-form-field__required {
+    display: inline-block;
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    background-color: var(--cinder-danger);
+    flex-shrink: 0;
+    align-self: center;
+  }
 
-/* ----------------------------------------
+  /* ----------------------------------------
  * Supporting text
  * ---------------------------------------- */
 
-.cinder-form-field__description {
-  font-size: var(--cinder-text-xs);
-  line-height: var(--cinder-leading-normal);
-  color: var(--cinder-text-muted);
-  margin: 0;
-}
+  .cinder-form-field__description {
+    font-size: var(--cinder-text-xs);
+    line-height: var(--cinder-leading-normal);
+    color: var(--cinder-text-muted);
+    margin: 0;
+  }
 
-.cinder-form-field__error {
-  font-size: var(--cinder-text-xs);
-  line-height: var(--cinder-leading-normal);
-  color: var(--cinder-danger);
-  margin: 0;
+  .cinder-form-field__error {
+    font-size: var(--cinder-text-xs);
+    line-height: var(--cinder-leading-normal);
+    color: var(--cinder-danger);
+    margin: 0;
+  }
 }

--- a/packages/components/src/components/form-section/form-section.css
+++ b/packages/components/src/components/form-section/form-section.css
@@ -1,75 +1,77 @@
-/* ========================================
+@layer cinder.components {
+  /* ========================================
  * FORM SECTION
  * ======================================== */
 
-.cinder-form-section {
-  container-type: inline-size;
-  container-name: cinder-form-section;
-  display: block;
-  border: none;
-  padding: 0;
-  margin: 0;
-}
+  .cinder-form-section {
+    container-type: inline-size;
+    container-name: cinder-form-section;
+    display: block;
+    border: none;
+    padding: 0;
+    margin: 0;
+  }
 
-/* ----------------------------------------
+  /* ----------------------------------------
  * Heading / Legend
  * ---------------------------------------- */
 
-.cinder-form-section__heading,
-.cinder-form-section__legend {
-  display: block;
-  font-size: var(--cinder-text-sm);
-  font-weight: var(--cinder-font-semibold);
-  line-height: var(--cinder-leading-snug);
-  color: var(--cinder-text);
-  margin: 0 0 var(--cinder-space-1-5);
-  padding: 0;
-}
+  .cinder-form-section__heading,
+  .cinder-form-section__legend {
+    display: block;
+    font-size: var(--cinder-text-sm);
+    font-weight: var(--cinder-font-semibold);
+    line-height: var(--cinder-leading-snug);
+    color: var(--cinder-text);
+    margin: 0 0 var(--cinder-space-1-5);
+    padding: 0;
+  }
 
-/* ----------------------------------------
+  /* ----------------------------------------
  * Description
  * ---------------------------------------- */
 
-.cinder-form-section__description {
-  font-size: var(--cinder-text-xs);
-  line-height: var(--cinder-leading-normal);
-  color: var(--cinder-text-muted);
-  margin: 0 0 var(--cinder-space-3);
-}
+  .cinder-form-section__description {
+    font-size: var(--cinder-text-xs);
+    line-height: var(--cinder-leading-normal);
+    color: var(--cinder-text-muted);
+    margin: 0 0 var(--cinder-space-3);
+  }
 
-/* ----------------------------------------
+  /* ----------------------------------------
  * Responsive grid — driven by container queries
  * ---------------------------------------- */
 
-.cinder-form-section__grid {
-  display: grid;
-  gap: var(--cinder-form-section-gap, 1rem);
-  grid-template-columns: 1fr; /* default: single column */
-}
-
-@container cinder-form-section (min-width: 40rem) {
-  .cinder-form-section[data-columns='2'] .cinder-form-section__grid,
-  .cinder-form-section[data-columns='3'] .cinder-form-section__grid,
-  .cinder-form-section[data-columns='4'] .cinder-form-section__grid {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
+  .cinder-form-section__grid {
+    display: grid;
+    gap: var(--cinder-form-section-gap, 1rem);
+    grid-template-columns: 1fr; /* default: single column */
   }
 
-  .cinder-form-section[data-columns='2'] .cinder-form-section__span-2,
-  .cinder-form-section[data-columns='3'] .cinder-form-section__span-2,
-  .cinder-form-section[data-columns='4'] .cinder-form-section__span-2 {
-    grid-column: span 2;
-  }
-}
+  @container cinder-form-section (min-width: 40rem) {
+    .cinder-form-section[data-columns='2'] .cinder-form-section__grid,
+    .cinder-form-section[data-columns='3'] .cinder-form-section__grid,
+    .cinder-form-section[data-columns='4'] .cinder-form-section__grid {
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
 
-@container cinder-form-section (min-width: 60rem) {
-  .cinder-form-section[data-columns='3'] .cinder-form-section__grid,
-  .cinder-form-section[data-columns='4'] .cinder-form-section__grid {
-    grid-template-columns: repeat(3, minmax(0, 1fr));
+    .cinder-form-section[data-columns='2'] .cinder-form-section__span-2,
+    .cinder-form-section[data-columns='3'] .cinder-form-section__span-2,
+    .cinder-form-section[data-columns='4'] .cinder-form-section__span-2 {
+      grid-column: span 2;
+    }
   }
-}
 
-@container cinder-form-section (min-width: 80rem) {
-  .cinder-form-section[data-columns='4'] .cinder-form-section__grid {
-    grid-template-columns: repeat(4, minmax(0, 1fr));
+  @container cinder-form-section (min-width: 60rem) {
+    .cinder-form-section[data-columns='3'] .cinder-form-section__grid,
+    .cinder-form-section[data-columns='4'] .cinder-form-section__grid {
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+    }
+  }
+
+  @container cinder-form-section (min-width: 80rem) {
+    .cinder-form-section[data-columns='4'] .cinder-form-section__grid {
+      grid-template-columns: repeat(4, minmax(0, 1fr));
+    }
   }
 }

--- a/packages/components/src/components/grid-list/grid-list.css
+++ b/packages/components/src/components/grid-list/grid-list.css
@@ -1,134 +1,136 @@
-/* ========================================
+@layer cinder.components {
+  /* ========================================
  * GRID LIST
  * ======================================== */
 
-.cinder-grid-list {
-  /* Default min-cell-width if `columns` prop is omitted. */
-  --cinder-grid-list-min-width: 16rem;
+  .cinder-grid-list {
+    /* Default min-cell-width if `columns` prop is omitted. */
+    --cinder-grid-list-min-width: 16rem;
 
-  list-style: none;
-  margin: 0;
-  padding: 0;
-  inline-size: 100%;
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    inline-size: 100%;
 
-  display: grid;
-  grid-template-columns: repeat(
-    auto-fill,
-    minmax(min(var(--cinder-grid-list-min-width), 100%), 1fr)
-  );
-  gap: var(--cinder-space-4);
-}
+    display: grid;
+    grid-template-columns: repeat(
+      auto-fill,
+      minmax(min(var(--cinder-grid-list-min-width), 100%), 1fr)
+    );
+    gap: var(--cinder-space-4);
+  }
 
-/* ----------------------------------------
+  /* ----------------------------------------
  * Item — visually a card, semantically an <li>.
  * Reuses Card tokens; no new visual variables.
  * ---------------------------------------- */
 
-.cinder-grid-list__item {
-  position: relative; /* Anchors the stretched-link pseudo overlay. */
-  display: flex;
-  flex-direction: column;
-  gap: var(--cinder-space-2);
-  padding: var(--cinder-space-4);
-  border-radius: var(--cinder-radius-lg);
-  background: var(--cinder-surface-raised);
-  border: 1px solid var(--cinder-border-muted);
-  color: var(--cinder-text);
-  box-shadow: var(--cinder-shadow-sm);
-  transition:
-    box-shadow 150ms ease,
-    border-color 150ms ease;
-}
-
-@media (hover: hover) {
-  .cinder-grid-list__item:has(.cinder-grid-list__link:hover) {
-    box-shadow: var(--cinder-shadow-md);
-    border-color: var(--cinder-border);
+  .cinder-grid-list__item {
+    position: relative; /* Anchors the stretched-link pseudo overlay. */
+    display: flex;
+    flex-direction: column;
+    gap: var(--cinder-space-2);
+    padding: var(--cinder-space-4);
+    border-radius: var(--cinder-radius-lg);
+    background: var(--cinder-surface-raised);
+    border: 1px solid var(--cinder-border-muted);
+    color: var(--cinder-text);
+    box-shadow: var(--cinder-shadow-sm);
+    transition:
+      box-shadow 150ms ease,
+      border-color 150ms ease;
   }
-}
 
-/* ----------------------------------------
+  @media (hover: hover) {
+    .cinder-grid-list__item:has(.cinder-grid-list__link:hover) {
+      box-shadow: var(--cinder-shadow-md);
+      border-color: var(--cinder-border);
+    }
+  }
+
+  /* ----------------------------------------
  * Snippet wrappers — provide stable selectors and predictable layout.
  * All wrappers sit UNDER the stretched-link overlay except `.cinder-grid-list__actions`.
  * ---------------------------------------- */
 
-.cinder-grid-list__image,
-.cinder-grid-list__title,
-.cinder-grid-list__subtitle,
-.cinder-grid-list__meta {
-  min-inline-size: 0; /* Allows long content to truncate inside flex parents. */
-}
+  .cinder-grid-list__image,
+  .cinder-grid-list__title,
+  .cinder-grid-list__subtitle,
+  .cinder-grid-list__meta {
+    min-inline-size: 0; /* Allows long content to truncate inside flex parents. */
+  }
 
-.cinder-grid-list__title {
-  font-size: var(--cinder-text-base);
-  font-weight: var(--cinder-font-medium);
-  color: var(--cinder-text);
-}
+  .cinder-grid-list__title {
+    font-size: var(--cinder-text-base);
+    font-weight: var(--cinder-font-medium);
+    color: var(--cinder-text);
+  }
 
-.cinder-grid-list__subtitle {
-  font-size: var(--cinder-text-sm);
-  color: var(--cinder-text-muted);
-}
+  .cinder-grid-list__subtitle {
+    font-size: var(--cinder-text-sm);
+    color: var(--cinder-text-muted);
+  }
 
-.cinder-grid-list__meta {
-  font-size: var(--cinder-text-sm);
-  color: var(--cinder-text-subtle);
-}
+  .cinder-grid-list__meta {
+    font-size: var(--cinder-text-sm);
+    color: var(--cinder-text-subtle);
+  }
 
-/* ----------------------------------------
+  /* ----------------------------------------
  * Stretched link — opt-in via `href` prop.
  *
  * The anchor wraps the title text but its ::after extends to cover the
  * entire item, so any pointer click anywhere on the item activates the link.
  * ---------------------------------------- */
 
-.cinder-grid-list__link {
-  color: inherit;
-  text-decoration: none;
-}
-
-.cinder-grid-list__link::after {
-  content: '';
-  position: absolute;
-  inset: 0;
-  /* Match the item's radius directly — `inherit` would resolve to 0 since the
-     anchor's ancestor chain doesn't carry the radius token. */
-  border-radius: var(--cinder-radius-lg);
-  z-index: 0;
-}
-
-/* Focus ring on the stretched-link anchor. Uses box-shadow offset technique
-   to float the ring outside the card's border, matching stacked-list-item.css. */
-.cinder-grid-list__link:focus-visible {
-  outline: var(--cinder-ring-width) solid transparent;
-  border-radius: var(--cinder-radius-lg);
-  box-shadow: var(--_cinder-focus-ring-shadow);
-}
-
-/* Forced Colors Mode — box-shadow rings are invisible; use a real outline. */
-@media (forced-colors: active) {
-  .cinder-grid-list__link:focus-visible {
-    outline: var(--cinder-ring-width) solid ButtonText;
-    outline-offset: 3px;
+  .cinder-grid-list__link {
+    color: inherit;
+    text-decoration: none;
   }
-}
 
-/* ----------------------------------------
+  .cinder-grid-list__link::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    /* Match the item's radius directly — `inherit` would resolve to 0 since the
+     anchor's ancestor chain doesn't carry the radius token. */
+    border-radius: var(--cinder-radius-lg);
+    z-index: 0;
+  }
+
+  /* Focus ring on the stretched-link anchor. Uses box-shadow offset technique
+   to float the ring outside the card's border, matching stacked-list-item.css. */
+  .cinder-grid-list__link:focus-visible {
+    outline: var(--cinder-ring-width) solid transparent;
+    border-radius: var(--cinder-radius-lg);
+    box-shadow: var(--_cinder-focus-ring-shadow);
+  }
+
+  /* Forced Colors Mode — box-shadow rings are invisible; use a real outline. */
+  @media (forced-colors: active) {
+    .cinder-grid-list__link:focus-visible {
+      outline: var(--cinder-ring-width) solid ButtonText;
+      outline-offset: 3px;
+    }
+  }
+
+  /* ----------------------------------------
  * Actions row — lifted above the stretched-link overlay so its
  * buttons remain clickable / focusable.
  * ---------------------------------------- */
 
-.cinder-grid-list__actions {
-  position: relative;
-  z-index: 1;
-  display: flex;
-  flex-wrap: wrap;
-  gap: var(--cinder-space-2);
-  margin-block-start: auto; /* Pin actions to the bottom of the card. */
-}
+  .cinder-grid-list__actions {
+    position: relative;
+    z-index: 1;
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--cinder-space-2);
+    margin-block-start: auto; /* Pin actions to the bottom of the card. */
+  }
 
-/* Allow consumers to lift an arbitrary descendant above the overlay. */
-.cinder-grid-list__item [data-cinder-stretched-link-escape] {
-  position: relative;
-  z-index: 1;
+  /* Allow consumers to lift an arbitrary descendant above the overlay. */
+  .cinder-grid-list__item [data-cinder-stretched-link-escape] {
+    position: relative;
+    z-index: 1;
+  }
 }

--- a/packages/components/src/components/hover-card/hover-card.css
+++ b/packages/components/src/components/hover-card/hover-card.css
@@ -1,42 +1,44 @@
-.cinder-hover-card__trigger {
-  display: inline-flex;
-}
+@layer cinder.components {
+  .cinder-hover-card__trigger {
+    display: inline-flex;
+  }
 
-.cinder-hover-card {
-  position: fixed;
-  z-index: var(--cinder-z-popover, 1000);
-  max-width: min(20rem, calc(100vw - 2rem));
-  padding: var(--cinder-space-md);
-  border: 1px solid var(--cinder-border-muted);
-  border-radius: var(--cinder-radius-md);
-  background: var(--cinder-surface-raised);
-  color: var(--cinder-text);
-  box-shadow: var(--cinder-shadow-lg);
-  opacity: 0;
-  transform: translateY(2px) scale(0.98);
-  transition:
-    opacity var(--cinder-duration-fast) var(--cinder-ease-out),
-    transform var(--cinder-duration-fast) var(--cinder-ease-out);
-}
-
-.cinder-hover-card[data-cinder-position-ready='true'] {
-  opacity: 1;
-  transform: translateY(0) scale(1);
-}
-
-.cinder-hover-card__arrow {
-  position: absolute;
-  width: 0.625rem;
-  height: 0.625rem;
-  rotate: 45deg;
-  background: inherit;
-  border-inline-start: 1px solid var(--cinder-border-muted);
-  border-block-start: 1px solid var(--cinder-border-muted);
-}
-
-@media (prefers-reduced-motion: reduce) {
   .cinder-hover-card {
-    transition: none;
-    transform: none;
+    position: fixed;
+    z-index: var(--cinder-z-popover, 1000);
+    max-width: min(20rem, calc(100vw - 2rem));
+    padding: var(--cinder-space-md);
+    border: 1px solid var(--cinder-border-muted);
+    border-radius: var(--cinder-radius-md);
+    background: var(--cinder-surface-raised);
+    color: var(--cinder-text);
+    box-shadow: var(--cinder-shadow-lg);
+    opacity: 0;
+    transform: translateY(2px) scale(0.98);
+    transition:
+      opacity var(--cinder-duration-fast) var(--cinder-ease-out),
+      transform var(--cinder-duration-fast) var(--cinder-ease-out);
+  }
+
+  .cinder-hover-card[data-cinder-position-ready='true'] {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+
+  .cinder-hover-card__arrow {
+    position: absolute;
+    width: 0.625rem;
+    height: 0.625rem;
+    rotate: 45deg;
+    background: inherit;
+    border-inline-start: 1px solid var(--cinder-border-muted);
+    border-block-start: 1px solid var(--cinder-border-muted);
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .cinder-hover-card {
+      transition: none;
+      transform: none;
+    }
   }
 }

--- a/packages/components/src/components/image/image.css
+++ b/packages/components/src/components/image/image.css
@@ -1,48 +1,50 @@
-.cinder-image {
-  display: block;
-  position: relative;
-  overflow: hidden;
-  max-width: 100%;
-  background-color: var(--cinder-surface-inset);
-  background-position: center;
-  background-size: cover;
-  background-repeat: no-repeat;
-}
+@layer cinder.components {
+  .cinder-image {
+    display: block;
+    position: relative;
+    overflow: hidden;
+    max-width: 100%;
+    background-color: var(--cinder-surface-inset);
+    background-position: center;
+    background-size: cover;
+    background-repeat: no-repeat;
+  }
 
-/* Pixelated placeholder only while the real image hasn't resolved.
+  /* Pixelated placeholder only while the real image hasn't resolved.
  * Exclude the errored state too — a broken-image icon should render at the
  * browser's native fidelity, not pixel-snapped. */
-.cinder-image:not([data-cinder-loaded]):not([data-cinder-errored]) {
-  image-rendering: pixelated;
-}
+  .cinder-image:not([data-cinder-loaded]):not([data-cinder-errored]) {
+    image-rendering: pixelated;
+  }
 
-.cinder-image__img {
-  display: block;
-  width: 100%;
-  height: 100%;
-  object-fit: cover;
-  image-rendering: auto;
-  opacity: 0;
-  transition: opacity var(--cinder-duration) var(--cinder-ease-standard);
-}
+  .cinder-image__img {
+    display: block;
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    image-rendering: auto;
+    opacity: 0;
+    transition: opacity var(--cinder-duration) var(--cinder-ease-standard);
+  }
 
-.cinder-image[data-cinder-loaded] .cinder-image__img {
-  opacity: 1;
-}
+  .cinder-image[data-cinder-loaded] .cinder-image__img {
+    opacity: 1;
+  }
 
-/* Errored without a fallback snippet: reveal the <img> so the browser's
+  /* Errored without a fallback snippet: reveal the <img> so the browser's
  * native broken-image / alt-text rendering shows through, rather than
  * leaving a permanently-blank wrapper. */
-.cinder-image[data-cinder-errored]:not([data-cinder-fallback]) .cinder-image__img {
-  opacity: 1;
-}
+  .cinder-image[data-cinder-errored]:not([data-cinder-fallback]) .cinder-image__img {
+    opacity: 1;
+  }
 
-/* Component clears the inline `style:background-image` after the image
+  /* Component clears the inline `style:background-image` after the image
  * resolves (via the `cssUrl` derivation), so transparent images don't show
  * the low-res layer through them and fallback snippets aren't painted over
  * a leftover blurry background. This rule covers the case where a consumer
  * has set their own background via a custom class on the wrapper. */
-.cinder-image[data-cinder-loaded],
-.cinder-image[data-cinder-errored] {
-  background-image: none;
+  .cinder-image[data-cinder-loaded],
+  .cinder-image[data-cinder-errored] {
+    background-image: none;
+  }
 }

--- a/packages/components/src/components/inline/inline.css
+++ b/packages/components/src/components/inline/inline.css
@@ -1,11 +1,13 @@
-/* ========================================
+@layer cinder.components {
+  /* ========================================
  * INLINE
  * ======================================== */
 
-.cinder-inline {
-  display: flex;
-  flex-direction: row;
-  flex-wrap: var(--inline-wrap, wrap);
-  align-items: var(--inline-align, center);
-  gap: var(--inline-gap, var(--cinder-space-4));
+  .cinder-inline {
+    display: flex;
+    flex-direction: row;
+    flex-wrap: var(--inline-wrap, wrap);
+    align-items: var(--inline-align, center);
+    gap: var(--inline-gap, var(--cinder-space-4));
+  }
 }

--- a/packages/components/src/components/input/input.css
+++ b/packages/components/src/components/input/input.css
@@ -1,273 +1,275 @@
-/* ========================================
+@layer cinder.components {
+  /* ========================================
  * INPUT
  * ======================================== */
 
-/* ----------------------------------------
+  /* ----------------------------------------
  * Field wrapper
  * ---------------------------------------- */
 
-.cinder-input-field {
-  display: flex;
-  flex-direction: column;
-  gap: var(--cinder-space-1-5);
-  inline-size: 100%;
-}
+  .cinder-input-field {
+    display: flex;
+    flex-direction: column;
+    gap: var(--cinder-space-1-5);
+    inline-size: 100%;
+  }
 
-/* ----------------------------------------
+  /* ----------------------------------------
  * Label
  * ---------------------------------------- */
 
-.cinder-input-field__label {
-  display: inline-flex;
-  align-items: center;
-  gap: var(--cinder-space-1);
-  font-size: var(--cinder-text-xs);
-  font-weight: var(--cinder-font-medium);
-  line-height: 1;
-  color: var(--cinder-text);
-}
+  .cinder-input-field__label {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--cinder-space-1);
+    font-size: var(--cinder-text-xs);
+    font-weight: var(--cinder-font-medium);
+    line-height: 1;
+    color: var(--cinder-text);
+  }
 
-.cinder-input-field__label[data-disabled] {
-  color: var(--cinder-text-disabled);
-  cursor: not-allowed;
-}
+  .cinder-input-field__label[data-disabled] {
+    color: var(--cinder-text-disabled);
+    cursor: not-allowed;
+  }
 
-/* ----------------------------------------
+  /* ----------------------------------------
  * Input element
  * ---------------------------------------- */
 
-.cinder-input {
-  display: block;
-  width: 100%;
-  min-height: 2.25rem;
-  padding: var(--cinder-space-1-5) var(--cinder-space-3);
-  font-size: var(--cinder-text-sm);
-  font-family: inherit;
-  line-height: var(--cinder-leading-normal);
-  color: var(--cinder-text);
-  background: var(--cinder-surface-raised);
-  border: 1px solid var(--cinder-border);
-  border-radius: var(--cinder-radius-md);
-  appearance: none;
+  .cinder-input {
+    display: block;
+    width: 100%;
+    min-height: 2.25rem;
+    padding: var(--cinder-space-1-5) var(--cinder-space-3);
+    font-size: var(--cinder-text-sm);
+    font-family: inherit;
+    line-height: var(--cinder-leading-normal);
+    color: var(--cinder-text);
+    background: var(--cinder-surface-raised);
+    border: 1px solid var(--cinder-border);
+    border-radius: var(--cinder-radius-md);
+    appearance: none;
 
-  transition:
-    border-color var(--cinder-duration-fast) var(--cinder-ease-standard),
-    box-shadow var(--cinder-duration-fast) var(--cinder-ease-standard);
-}
-
-.cinder-input::placeholder {
-  color: var(--cinder-text-subtle);
-}
-
-/* Sticky-hover suppression on touch. */
-@media (hover: hover) {
-  .cinder-input:hover:not(:disabled) {
-    border-color: var(--cinder-border-strong);
+    transition:
+      border-color var(--cinder-duration-fast) var(--cinder-ease-standard),
+      box-shadow var(--cinder-duration-fast) var(--cinder-ease-standard);
   }
-}
 
-.cinder-input[data-cinder-native-date] {
-  cursor: pointer;
-}
+  .cinder-input::placeholder {
+    color: var(--cinder-text-subtle);
+  }
 
-/* The browser still owns the native calendar. We hide the inconsistent WebKit
+  /* Sticky-hover suppression on touch. */
+  @media (hover: hover) {
+    .cinder-input:hover:not(:disabled) {
+      border-color: var(--cinder-border-strong);
+    }
+  }
+
+  .cinder-input[data-cinder-native-date] {
+    cursor: pointer;
+  }
+
+  /* The browser still owns the native calendar. We hide the inconsistent WebKit
    indicator while keeping its hit area inside the input, aligned under the
    design-system calendar glyph. */
-.cinder-input[data-cinder-native-date]::-webkit-calendar-picker-indicator {
-  opacity: 0;
-}
+  .cinder-input[data-cinder-native-date]::-webkit-calendar-picker-indicator {
+    opacity: 0;
+  }
 
-/* Focus ring — same pattern as Button so the system is visually consistent. */
-.cinder-input:focus-visible {
-  outline: var(--cinder-ring-width) solid transparent;
-  box-shadow:
-    0 0 0 var(--cinder-ring-offset) var(--cinder-ring-offset-color),
-    0 0 0 calc(var(--cinder-ring-offset) + var(--cinder-ring-width))
-      var(--_cinder-input-ring, var(--cinder-ring-color));
-}
+  /* Focus ring — same pattern as Button so the system is visually consistent. */
+  .cinder-input:focus-visible {
+    outline: var(--cinder-ring-width) solid transparent;
+    box-shadow:
+      0 0 0 var(--cinder-ring-offset) var(--cinder-ring-offset-color),
+      0 0 0 calc(var(--cinder-ring-offset) + var(--cinder-ring-width))
+        var(--_cinder-input-ring, var(--cinder-ring-color));
+  }
 
-/* Windows High Contrast Mode: box-shadow is suppressed by the browser. Restore
+  /* Windows High Contrast Mode: box-shadow is suppressed by the browser. Restore
  * focus visibility using the system Highlight color which is guaranteed to
  * contrast the field surface in WHCM.
  */
-@media (forced-colors: active) {
-  .cinder-input:focus-visible {
-    outline: var(--cinder-ring-width) solid Highlight;
-    outline-offset: 1px;
+  @media (forced-colors: active) {
+    .cinder-input:focus-visible {
+      outline: var(--cinder-ring-width) solid Highlight;
+      outline-offset: 1px;
+    }
   }
-}
 
-/* ----------------------------------------
+  /* ----------------------------------------
  * Disabled state
  * ---------------------------------------- */
 
-.cinder-input:disabled {
-  background: var(--cinder-surface-inset);
-  border-color: var(--cinder-border-muted);
-  color: var(--cinder-text-disabled);
-  cursor: not-allowed;
-}
+  .cinder-input:disabled {
+    background: var(--cinder-surface-inset);
+    border-color: var(--cinder-border-muted);
+    color: var(--cinder-text-disabled);
+    cursor: not-allowed;
+  }
 
-.cinder-input:disabled::placeholder {
-  color: var(--cinder-text-disabled);
-}
+  .cinder-input:disabled::placeholder {
+    color: var(--cinder-text-disabled);
+  }
 
-/* ----------------------------------------
+  /* ----------------------------------------
  * Error / invalid state
  * ---------------------------------------- */
 
-/* Use the danger token so the error border matches the error text and alert
+  /* Use the danger token so the error border matches the error text and alert
  * components — one semantic color, used consistently.
  */
-.cinder-input[aria-invalid='true'] {
-  --_cinder-input-ring: var(--cinder-danger);
-  border-color: var(--cinder-danger);
-}
-
-@media (hover: hover) {
-  .cinder-input[aria-invalid='true']:hover:not(:disabled) {
-    border-color: oklch(from var(--cinder-danger) calc(l - 0.06) c h);
+  .cinder-input[aria-invalid='true'] {
+    --_cinder-input-ring: var(--cinder-danger);
+    border-color: var(--cinder-danger);
   }
-}
 
-/* ----------------------------------------
+  @media (hover: hover) {
+    .cinder-input[aria-invalid='true']:hover:not(:disabled) {
+      border-color: oklch(from var(--cinder-danger) calc(l - 0.06) c h);
+    }
+  }
+
+  /* ----------------------------------------
  * Supporting text
  * ---------------------------------------- */
 
-.cinder-input-field__description {
-  font-size: var(--cinder-text-xs);
-  line-height: var(--cinder-leading-normal);
-  color: var(--cinder-text-muted);
-  margin: 0;
-}
+  .cinder-input-field__description {
+    font-size: var(--cinder-text-xs);
+    line-height: var(--cinder-leading-normal);
+    color: var(--cinder-text-muted);
+    margin: 0;
+  }
 
-.cinder-input-field__error {
-  font-size: var(--cinder-text-xs);
-  line-height: var(--cinder-leading-normal);
-  color: var(--cinder-danger);
-  margin: 0;
-}
+  .cinder-input-field__error {
+    font-size: var(--cinder-text-xs);
+    line-height: var(--cinder-leading-normal);
+    color: var(--cinder-danger);
+    margin: 0;
+  }
 
-/* ----------------------------------------
+  /* ----------------------------------------
  * Input group (leading / trailing addons)
  * ---------------------------------------- */
 
-.cinder-input-group {
-  display: flex;
-  align-items: stretch;
-  position: relative;
-  inline-size: 100%;
-  background: var(--cinder-surface-raised);
-  border: 1px solid var(--cinder-border);
-  border-radius: var(--cinder-radius-md);
-  transition:
-    border-color var(--cinder-duration-fast) var(--cinder-ease-standard),
-    box-shadow var(--cinder-duration-fast) var(--cinder-ease-standard);
-}
+  .cinder-input-group {
+    display: flex;
+    align-items: stretch;
+    position: relative;
+    inline-size: 100%;
+    background: var(--cinder-surface-raised);
+    border: 1px solid var(--cinder-border);
+    border-radius: var(--cinder-radius-md);
+    transition:
+      border-color var(--cinder-duration-fast) var(--cinder-ease-standard),
+      box-shadow var(--cinder-duration-fast) var(--cinder-ease-standard);
+  }
 
-/* Inner input: strip its own chrome, inherit the group's */
-.cinder-input-group > .cinder-input {
-  border: none;
-  border-radius: 0;
-  background: transparent;
-  flex: 1 1 auto;
-  min-width: 0;
-  padding-inline: var(--cinder-space-3);
-}
+  /* Inner input: strip its own chrome, inherit the group's */
+  .cinder-input-group > .cinder-input {
+    border: none;
+    border-radius: 0;
+    background: transparent;
+    flex: 1 1 auto;
+    min-width: 0;
+    padding-inline: var(--cinder-space-3);
+  }
 
-/* When an addon is present on a given side, the input trims its padding on
+  /* When an addon is present on a given side, the input trims its padding on
    that side; the addon container owns the visual inset. */
-.cinder-input-group[data-leading] > .cinder-input {
-  padding-inline-start: var(--cinder-space-2);
-}
-.cinder-input-group[data-trailing] > .cinder-input {
-  padding-inline-end: var(--cinder-space-2);
-}
-
-.cinder-input-group[data-native-date] > .cinder-input {
-  padding-inline-end: var(--cinder-space-10);
-}
-
-/* Suppress the inner input's focus ring when grouped — the group owns the ring. */
-.cinder-input-group > .cinder-input:focus-visible {
-  box-shadow: none;
-  outline: none;
-}
-
-/* Hover mirrors the standalone input. Sticky-hover suppression on touch. */
-@media (hover: hover) {
-  .cinder-input-group:hover:not([data-disabled]) {
-    border-color: var(--cinder-border-strong);
+  .cinder-input-group[data-leading] > .cinder-input {
+    padding-inline-start: var(--cinder-space-2);
   }
-}
+  .cinder-input-group[data-trailing] > .cinder-input {
+    padding-inline-end: var(--cinder-space-2);
+  }
 
-/* Focus ring on the group via :focus-within — same token math as standalone. */
-.cinder-input-group:focus-within {
-  outline: var(--cinder-ring-width) solid transparent;
-  box-shadow:
-    0 0 0 var(--cinder-ring-offset) var(--cinder-ring-offset-color),
-    0 0 0 calc(var(--cinder-ring-offset) + var(--cinder-ring-width))
-      var(--_cinder-input-ring, var(--cinder-ring-color));
-}
+  .cinder-input-group[data-native-date] > .cinder-input {
+    padding-inline-end: var(--cinder-space-10);
+  }
 
-@media (forced-colors: active) {
+  /* Suppress the inner input's focus ring when grouped — the group owns the ring. */
+  .cinder-input-group > .cinder-input:focus-visible {
+    box-shadow: none;
+    outline: none;
+  }
+
+  /* Hover mirrors the standalone input. Sticky-hover suppression on touch. */
+  @media (hover: hover) {
+    .cinder-input-group:hover:not([data-disabled]) {
+      border-color: var(--cinder-border-strong);
+    }
+  }
+
+  /* Focus ring on the group via :focus-within — same token math as standalone. */
   .cinder-input-group:focus-within {
-    outline: var(--cinder-ring-width) solid Highlight;
-    outline-offset: 1px;
+    outline: var(--cinder-ring-width) solid transparent;
+    box-shadow:
+      0 0 0 var(--cinder-ring-offset) var(--cinder-ring-offset-color),
+      0 0 0 calc(var(--cinder-ring-offset) + var(--cinder-ring-width))
+        var(--_cinder-input-ring, var(--cinder-ring-color));
   }
-}
 
-/* Invalid state. */
-.cinder-input-group[data-invalid] {
-  --_cinder-input-ring: var(--cinder-danger);
-  border-color: var(--cinder-danger);
-}
-@media (hover: hover) {
-  .cinder-input-group[data-invalid]:hover:not([data-disabled]) {
-    border-color: oklch(from var(--cinder-danger) calc(l - 0.06) c h);
+  @media (forced-colors: active) {
+    .cinder-input-group:focus-within {
+      outline: var(--cinder-ring-width) solid Highlight;
+      outline-offset: 1px;
+    }
   }
-}
 
-/* Disabled state. */
-.cinder-input-group[data-disabled] {
-  background: var(--cinder-surface-inset);
-  border-color: var(--cinder-border-muted);
-  cursor: not-allowed;
-}
-.cinder-input-group[data-disabled] > .cinder-input {
-  background: transparent;
-  color: var(--cinder-text-disabled);
-}
+  /* Invalid state. */
+  .cinder-input-group[data-invalid] {
+    --_cinder-input-ring: var(--cinder-danger);
+    border-color: var(--cinder-danger);
+  }
+  @media (hover: hover) {
+    .cinder-input-group[data-invalid]:hover:not([data-disabled]) {
+      border-color: oklch(from var(--cinder-danger) calc(l - 0.06) c h);
+    }
+  }
 
-/* Addon containers — decorative default sizing. */
-.cinder-input-group__leading,
-.cinder-input-group__trailing {
-  display: inline-flex;
-  align-items: center;
-  box-sizing: border-box;
-  flex: 0 0 auto;
-  max-inline-size: 40%;
-  gap: var(--cinder-space-1);
-  padding-inline: var(--cinder-space-3);
-  color: var(--cinder-text-muted);
-  font-size: var(--cinder-text-sm);
-  line-height: var(--cinder-leading-normal);
-}
+  /* Disabled state. */
+  .cinder-input-group[data-disabled] {
+    background: var(--cinder-surface-inset);
+    border-color: var(--cinder-border-muted);
+    cursor: not-allowed;
+  }
+  .cinder-input-group[data-disabled] > .cinder-input {
+    background: transparent;
+    color: var(--cinder-text-disabled);
+  }
 
-/* Interactive addons get a tighter wrapper so the consumer's control owns the inset.
+  /* Addon containers — decorative default sizing. */
+  .cinder-input-group__leading,
+  .cinder-input-group__trailing {
+    display: inline-flex;
+    align-items: center;
+    box-sizing: border-box;
+    flex: 0 0 auto;
+    max-inline-size: 40%;
+    gap: var(--cinder-space-1);
+    padding-inline: var(--cinder-space-3);
+    color: var(--cinder-text-muted);
+    font-size: var(--cinder-text-sm);
+    line-height: var(--cinder-leading-normal);
+  }
+
+  /* Interactive addons get a tighter wrapper so the consumer's control owns the inset.
    overflow: visible allows the inner control's focus ring to paint outside the container. */
-.cinder-input-group__leading:not([aria-hidden]),
-.cinder-input-group__trailing:not([aria-hidden]) {
-  padding-inline: var(--cinder-space-1);
-  overflow: visible;
-}
+  .cinder-input-group__leading:not([aria-hidden]),
+  .cinder-input-group__trailing:not([aria-hidden]) {
+    padding-inline: var(--cinder-space-1);
+    overflow: visible;
+  }
 
-.cinder-input-group__date-icon {
-  position: absolute;
-  inset-block: 0;
-  inset-inline-end: var(--cinder-space-3);
-  display: inline-flex;
-  align-items: center;
-  padding-inline: 0;
-  pointer-events: none;
+  .cinder-input-group__date-icon {
+    position: absolute;
+    inset-block: 0;
+    inset-inline-end: var(--cinder-space-3);
+    display: inline-flex;
+    align-items: center;
+    padding-inline: 0;
+    pointer-events: none;
+  }
 }

--- a/packages/components/src/components/json-schema-editor/json-schema-editor.css
+++ b/packages/components/src/components/json-schema-editor/json-schema-editor.css
@@ -1,4 +1,5 @@
-/**
+@layer cinder.components {
+  /**
  * Layout for the JsonSchemaEditor component.
  *
  * Visual hierarchy by indentation and dividers, not nested borders. Depth 0
@@ -6,367 +7,368 @@
  * surrounding details panel for visual depth.
  */
 
-.cinder-jse {
-  display: flex;
-  flex-direction: column;
-  gap: var(--cinder-space-4);
-}
-
-/* ===== Toolbar ===== */
-.cinder-jse-toolbar {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: var(--cinder-space-3);
-  flex-wrap: wrap;
-  padding: var(--cinder-space-2) var(--cinder-space-3);
-  border: 1px solid var(--cinder-border);
-  border-radius: var(--cinder-radius-md);
-  background: var(--cinder-surface);
-}
-
-.cinder-jse-toolbar__left,
-.cinder-jse-toolbar__right {
-  display: flex;
-  align-items: center;
-  gap: var(--cinder-space-2);
-  flex-wrap: wrap;
-}
-
-/* ===== Property editor ===== */
-.cinder-jse-property-editor {
-  display: flex;
-  flex-direction: column;
-  gap: 0;
-}
-
-/* Depth 0: the only level that gets a bordered card. */
-.cinder-jse-property-editor[data-cinder-jse-depth='0'] {
-  border: 1px solid var(--cinder-border);
-  border-radius: var(--cinder-radius-md);
-  background: var(--cinder-surface);
-}
-
-/* Sections are divided by a top border. The first section drops it so the
-   card's own border is the only edge. */
-.cinder-jse-section {
-  display: flex;
-  flex-direction: column;
-  gap: var(--cinder-space-3);
-  padding: var(--cinder-space-4);
-  border-top: 1px solid var(--cinder-border-muted);
-}
-
-.cinder-jse-property-editor > .cinder-jse-section:first-of-type {
-  border-top: 0;
-}
-
-.cinder-jse-section__title {
-  margin: 0;
-  font-size: var(--cinder-text-2xs);
-  font-weight: var(--cinder-font-semibold);
-  text-transform: uppercase;
-  letter-spacing: 0.06em;
-  color: var(--cinder-text-subtle);
-}
-
-/* Lead section (Common: title + description) — slightly more breathing room. */
-.cinder-jse-section--lead {
-  gap: var(--cinder-space-2);
-}
-
-/* Collapsible <details> sections — chevron + section title combine into the
-   summary; body padding kicks in on expand. */
-.cinder-jse-section--collapsible {
-  padding: 0;
-}
-
-.cinder-jse-section--collapsible > summary {
-  display: flex;
-  align-items: center;
-  gap: var(--cinder-space-2);
-  list-style: none;
-  cursor: pointer;
-  padding: var(--cinder-space-3) var(--cinder-space-4);
-  user-select: none;
-}
-
-.cinder-jse-section--collapsible > summary::-webkit-details-marker {
-  display: none;
-}
-
-.cinder-jse-section--collapsible > summary::before {
-  content: '▸';
-  font-size: var(--cinder-text-xs);
-  color: var(--cinder-text-subtle);
-  transition: transform var(--cinder-duration-fast) ease;
-}
-
-.cinder-jse-section--collapsible[open] > summary::before {
-  transform: rotate(90deg);
-}
-
-.cinder-jse-section__body {
-  display: flex;
-  flex-direction: column;
-  gap: var(--cinder-space-3);
-  padding: 0 var(--cinder-space-4) var(--cinder-space-4);
-}
-
-/* Type checkbox row — compact, wraps on narrow widths. */
-.cinder-jse-type-row {
-  display: flex;
-  flex-wrap: wrap;
-  gap: var(--cinder-space-2) var(--cinder-space-4);
-  align-items: center;
-}
-
-.cinder-jse-type-row .cinder-checkbox-field {
-  flex: 0 0 auto;
-}
-
-/* ===== Boolean schema short-circuit ===== */
-.cinder-jse-boolean-schema {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: var(--cinder-space-3);
-  padding: var(--cinder-space-3) var(--cinder-space-4);
-  font-size: var(--cinder-text-sm);
-  color: var(--cinder-text-muted);
-}
-
-/* ===== Collapsed deep-node placeholder ===== */
-.cinder-jse-collapsed {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  width: 100%;
-  padding: var(--cinder-space-2) var(--cinder-space-3);
-  background: transparent;
-  border: 1px dashed var(--cinder-border-muted);
-  border-radius: var(--cinder-radius-sm);
-  cursor: pointer;
-  font-family: inherit;
-  font-size: var(--cinder-text-sm);
-  color: var(--cinder-text);
-}
-
-@media (hover: hover) {
-  .cinder-jse-collapsed:hover {
-    background: var(--cinder-surface-raised);
+  .cinder-jse {
+    display: flex;
+    flex-direction: column;
+    gap: var(--cinder-space-4);
   }
-}
 
-.cinder-jse-collapsed__hint {
-  color: var(--cinder-text-subtle);
-  font-size: var(--cinder-text-xs);
-}
+  /* ===== Toolbar ===== */
+  .cinder-jse-toolbar {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--cinder-space-3);
+    flex-wrap: wrap;
+    padding: var(--cinder-space-2) var(--cinder-space-3);
+    border: 1px solid var(--cinder-border);
+    border-radius: var(--cinder-radius-md);
+    background: var(--cinder-surface);
+  }
 
-.cinder-jse-section-header {
-  display: flex;
-  justify-content: flex-end;
-  padding: var(--cinder-space-2) var(--cinder-space-4) 0;
-}
+  .cinder-jse-toolbar__left,
+  .cinder-jse-toolbar__right {
+    display: flex;
+    align-items: center;
+    gap: var(--cinder-space-2);
+    flex-wrap: wrap;
+  }
 
-/* ===== Property list ===== */
-.cinder-jse-property-list {
-  display: flex;
-  flex-direction: column;
-  gap: var(--cinder-space-2);
-}
+  /* ===== Property editor ===== */
+  .cinder-jse-property-editor {
+    display: flex;
+    flex-direction: column;
+    gap: 0;
+  }
 
-.cinder-jse-property-list__empty {
-  margin: 0;
-  font-size: var(--cinder-text-sm);
-  color: var(--cinder-text-subtle);
-}
+  /* Depth 0: the only level that gets a bordered card. */
+  .cinder-jse-property-editor[data-cinder-jse-depth='0'] {
+    border: 1px solid var(--cinder-border);
+    border-radius: var(--cinder-radius-md);
+    background: var(--cinder-surface);
+  }
 
-/* Each property is a custom disclosure (not <details>/<summary> — putting the
+  /* Sections are divided by a top border. The first section drops it so the
+   card's own border is the only edge. */
+  .cinder-jse-section {
+    display: flex;
+    flex-direction: column;
+    gap: var(--cinder-space-3);
+    padding: var(--cinder-space-4);
+    border-top: 1px solid var(--cinder-border-muted);
+  }
+
+  .cinder-jse-property-editor > .cinder-jse-section:first-of-type {
+    border-top: 0;
+  }
+
+  .cinder-jse-section__title {
+    margin: 0;
+    font-size: var(--cinder-text-2xs);
+    font-weight: var(--cinder-font-semibold);
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--cinder-text-subtle);
+  }
+
+  /* Lead section (Common: title + description) — slightly more breathing room. */
+  .cinder-jse-section--lead {
+    gap: var(--cinder-space-2);
+  }
+
+  /* Collapsible <details> sections — chevron + section title combine into the
+   summary; body padding kicks in on expand. */
+  .cinder-jse-section--collapsible {
+    padding: 0;
+  }
+
+  .cinder-jse-section--collapsible > summary {
+    display: flex;
+    align-items: center;
+    gap: var(--cinder-space-2);
+    list-style: none;
+    cursor: pointer;
+    padding: var(--cinder-space-3) var(--cinder-space-4);
+    user-select: none;
+  }
+
+  .cinder-jse-section--collapsible > summary::-webkit-details-marker {
+    display: none;
+  }
+
+  .cinder-jse-section--collapsible > summary::before {
+    content: '▸';
+    font-size: var(--cinder-text-xs);
+    color: var(--cinder-text-subtle);
+    transition: transform var(--cinder-duration-fast) ease;
+  }
+
+  .cinder-jse-section--collapsible[open] > summary::before {
+    transform: rotate(90deg);
+  }
+
+  .cinder-jse-section__body {
+    display: flex;
+    flex-direction: column;
+    gap: var(--cinder-space-3);
+    padding: 0 var(--cinder-space-4) var(--cinder-space-4);
+  }
+
+  /* Type checkbox row — compact, wraps on narrow widths. */
+  .cinder-jse-type-row {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--cinder-space-2) var(--cinder-space-4);
+    align-items: center;
+  }
+
+  .cinder-jse-type-row .cinder-checkbox-field {
+    flex: 0 0 auto;
+  }
+
+  /* ===== Boolean schema short-circuit ===== */
+  .cinder-jse-boolean-schema {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--cinder-space-3);
+    padding: var(--cinder-space-3) var(--cinder-space-4);
+    font-size: var(--cinder-text-sm);
+    color: var(--cinder-text-muted);
+  }
+
+  /* ===== Collapsed deep-node placeholder ===== */
+  .cinder-jse-collapsed {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    width: 100%;
+    padding: var(--cinder-space-2) var(--cinder-space-3);
+    background: transparent;
+    border: 1px dashed var(--cinder-border-muted);
+    border-radius: var(--cinder-radius-sm);
+    cursor: pointer;
+    font-family: inherit;
+    font-size: var(--cinder-text-sm);
+    color: var(--cinder-text);
+  }
+
+  @media (hover: hover) {
+    .cinder-jse-collapsed:hover {
+      background: var(--cinder-surface-raised);
+    }
+  }
+
+  .cinder-jse-collapsed__hint {
+    color: var(--cinder-text-subtle);
+    font-size: var(--cinder-text-xs);
+  }
+
+  .cinder-jse-section-header {
+    display: flex;
+    justify-content: flex-end;
+    padding: var(--cinder-space-2) var(--cinder-space-4) 0;
+  }
+
+  /* ===== Property list ===== */
+  .cinder-jse-property-list {
+    display: flex;
+    flex-direction: column;
+    gap: var(--cinder-space-2);
+  }
+
+  .cinder-jse-property-list__empty {
+    margin: 0;
+    font-size: var(--cinder-text-sm);
+    color: var(--cinder-text-subtle);
+  }
+
+  /* Each property is a custom disclosure (not <details>/<summary> — putting the
    action buttons inside <summary> creates an ARIA "interactive within
    interactive" violation). One top divider per row; no per-row card chrome.
    The Required pill's primary/ghost variant conveys required state, so we
    don't render a separate text marker. */
-.cinder-jse-property-row {
-  border-top: 1px solid var(--cinder-border-muted);
-  background: transparent;
-}
+  .cinder-jse-property-row {
+    border-top: 1px solid var(--cinder-border-muted);
+    background: transparent;
+  }
 
-.cinder-jse-property-row:first-child {
-  border-top: 0;
-}
+  .cinder-jse-property-row:first-child {
+    border-top: 0;
+  }
 
-.cinder-jse-property-row__summary {
-  display: flex;
-  align-items: center;
-  gap: var(--cinder-space-2);
-  padding: var(--cinder-space-1-5) var(--cinder-space-3);
-  min-height: var(--cinder-button-height-md);
-}
+  .cinder-jse-property-row__summary {
+    display: flex;
+    align-items: center;
+    gap: var(--cinder-space-2);
+    padding: var(--cinder-space-1-5) var(--cinder-space-3);
+    min-height: var(--cinder-button-height-md);
+  }
 
-/* The chevron + name + type form a single clickable disclosure trigger.
+  /* The chevron + name + type form a single clickable disclosure trigger.
    Action buttons live as siblings inside __summary so they keep the
    single-baseline layout without nesting interactive elements. */
-.cinder-jse-property-row__trigger {
-  display: inline-flex;
-  align-items: center;
-  gap: var(--cinder-space-2);
-  background: transparent;
-  border: 0;
-  padding: 0;
-  margin: 0;
-  cursor: pointer;
-  font-family: inherit;
-  color: inherit;
-  text-align: left;
-}
+  .cinder-jse-property-row__trigger {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--cinder-space-2);
+    background: transparent;
+    border: 0;
+    padding: 0;
+    margin: 0;
+    cursor: pointer;
+    font-family: inherit;
+    color: inherit;
+    text-align: left;
+  }
 
-.cinder-jse-property-row__trigger:focus-visible {
-  outline: 2px solid var(--cinder-accent);
-  outline-offset: 2px;
-  border-radius: var(--cinder-radius-sm);
-}
+  .cinder-jse-property-row__trigger:focus-visible {
+    outline: 2px solid var(--cinder-accent);
+    outline-offset: 2px;
+    border-radius: var(--cinder-radius-sm);
+  }
 
-.cinder-jse-property-row__chevron {
-  display: inline-block;
-  font-size: var(--cinder-text-xs);
-  color: var(--cinder-text-subtle);
-  transition: transform var(--cinder-duration-fast) ease;
-  width: 0.75rem;
-  text-align: center;
-}
+  .cinder-jse-property-row__chevron {
+    display: inline-block;
+    font-size: var(--cinder-text-xs);
+    color: var(--cinder-text-subtle);
+    transition: transform var(--cinder-duration-fast) ease;
+    width: 0.75rem;
+    text-align: center;
+  }
 
-.cinder-jse-property-row__trigger[aria-expanded='true'] > .cinder-jse-property-row__chevron {
-  transform: rotate(90deg);
-}
+  .cinder-jse-property-row__trigger[aria-expanded='true'] > .cinder-jse-property-row__chevron {
+    transform: rotate(90deg);
+  }
 
-.cinder-jse-property-row__name {
-  font-family: var(--cinder-font-mono);
-  font-size: var(--cinder-text-sm);
-  font-weight: var(--cinder-font-semibold);
-  color: var(--cinder-text);
-}
+  .cinder-jse-property-row__name {
+    font-family: var(--cinder-font-mono);
+    font-size: var(--cinder-text-sm);
+    font-weight: var(--cinder-font-semibold);
+    color: var(--cinder-text);
+  }
 
-.cinder-jse-property-row__type {
-  font-size: var(--cinder-text-xs);
-  color: var(--cinder-text-subtle);
-  padding: 0 var(--cinder-space-1-5);
-}
+  .cinder-jse-property-row__type {
+    font-size: var(--cinder-text-xs);
+    color: var(--cinder-text-subtle);
+    padding: 0 var(--cinder-space-1-5);
+  }
 
-.cinder-jse-property-row__spacer {
-  flex: 1 1 auto;
-}
+  .cinder-jse-property-row__spacer {
+    flex: 1 1 auto;
+  }
 
-.cinder-jse-property-row__panel {
-  display: flex;
-  flex-direction: column;
-  gap: var(--cinder-space-3);
-  padding: var(--cinder-space-3) var(--cinder-space-3) var(--cinder-space-4);
-  background: transparent;
-}
+  .cinder-jse-property-row__panel {
+    display: flex;
+    flex-direction: column;
+    gap: var(--cinder-space-3);
+    padding: var(--cinder-space-3) var(--cinder-space-3) var(--cinder-space-4);
+    background: transparent;
+  }
 
-/* The nested PropertyEditor inside an open property panel doesn't get a card. */
-.cinder-jse-property-row__panel > .cinder-jse-property-editor[data-cinder-jse-depth] {
-  border: 0;
-  background: transparent;
-  border-radius: 0;
-}
+  /* The nested PropertyEditor inside an open property panel doesn't get a card. */
+  .cinder-jse-property-row__panel > .cinder-jse-property-editor[data-cinder-jse-depth] {
+    border: 0;
+    background: transparent;
+    border-radius: 0;
+  }
 
-.cinder-jse-property-row__panel > .cinder-jse-property-editor > .cinder-jse-section {
-  padding-inline: 0;
-}
+  .cinder-jse-property-row__panel > .cinder-jse-property-editor > .cinder-jse-section {
+    padding-inline: 0;
+  }
 
-/* Required-only chip area */
-.cinder-jse-required-only {
-  margin-top: var(--cinder-space-2);
-}
+  /* Required-only chip area */
+  .cinder-jse-required-only {
+    margin-top: var(--cinder-space-2);
+  }
 
-.cinder-jse-required-only__summary {
-  cursor: pointer;
-  font-size: var(--cinder-text-xs);
-  color: var(--cinder-text-subtle);
-  padding: var(--cinder-space-1) var(--cinder-space-2);
-  list-style: none;
-}
+  .cinder-jse-required-only__summary {
+    cursor: pointer;
+    font-size: var(--cinder-text-xs);
+    color: var(--cinder-text-subtle);
+    padding: var(--cinder-space-1) var(--cinder-space-2);
+    list-style: none;
+  }
 
-.cinder-jse-required-only__summary::-webkit-details-marker {
-  display: none;
-}
+  .cinder-jse-required-only__summary::-webkit-details-marker {
+    display: none;
+  }
 
-.cinder-jse-required-only__panel {
-  display: flex;
-  flex-wrap: wrap;
-  gap: var(--cinder-space-2);
-  align-items: center;
-  padding: var(--cinder-space-2);
-}
+  .cinder-jse-required-only__panel {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--cinder-space-2);
+    align-items: center;
+    padding: var(--cinder-space-2);
+  }
 
-.cinder-jse-required-only__chip {
-  display: inline-flex;
-  align-items: center;
-  gap: var(--cinder-space-1);
-  padding: var(--cinder-space-0-5) var(--cinder-space-2);
-  border: 1px solid var(--cinder-border-muted);
-  border-radius: var(--cinder-radius-full);
-  font-size: var(--cinder-text-xs);
-  background: var(--cinder-surface);
-}
+  .cinder-jse-required-only__chip {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--cinder-space-1);
+    padding: var(--cinder-space-0-5) var(--cinder-space-2);
+    border: 1px solid var(--cinder-border-muted);
+    border-radius: var(--cinder-radius-full);
+    font-size: var(--cinder-text-xs);
+    background: var(--cinder-surface);
+  }
 
-/* ===== Advanced row ($ref / preserved badges) ===== */
-.cinder-jse-advanced-row {
-  display: flex;
-  align-items: center;
-  gap: var(--cinder-space-2);
-  padding: var(--cinder-space-2) var(--cinder-space-4);
-  border-top: 1px solid var(--cinder-border-muted);
-}
+  /* ===== Advanced row ($ref / preserved badges) ===== */
+  .cinder-jse-advanced-row {
+    display: flex;
+    align-items: center;
+    gap: var(--cinder-space-2);
+    padding: var(--cinder-space-2) var(--cinder-space-4);
+    border-top: 1px solid var(--cinder-border-muted);
+  }
 
-/* ===== JSON view ===== */
-.cinder-jse-json-view {
-  display: flex;
-  flex-direction: column;
-  gap: var(--cinder-space-3);
-}
+  /* ===== JSON view ===== */
+  .cinder-jse-json-view {
+    display: flex;
+    flex-direction: column;
+    gap: var(--cinder-space-3);
+  }
 
-.cinder-jse-json-view__toolbar {
-  display: flex;
-  align-items: center;
-  gap: var(--cinder-space-2);
-  flex-wrap: wrap;
-}
+  .cinder-jse-json-view__toolbar {
+    display: flex;
+    align-items: center;
+    gap: var(--cinder-space-2);
+    flex-wrap: wrap;
+  }
 
-textarea.cinder-jse-json-view__textarea {
-  font-family: var(--cinder-font-mono);
-  font-size: var(--cinder-text-sm);
-  line-height: var(--cinder-leading-normal);
-  min-height: 16rem;
-  /* Tab characters render as 2 spaces' worth — matches the canonical text we serialise. */
-  tab-size: 2;
-}
+  textarea.cinder-jse-json-view__textarea {
+    font-family: var(--cinder-font-mono);
+    font-size: var(--cinder-text-sm);
+    line-height: var(--cinder-leading-normal);
+    min-height: 16rem;
+    /* Tab characters render as 2 spaces' worth — matches the canonical text we serialise. */
+    tab-size: 2;
+  }
 
-.cinder-jse-json-view__errors {
-  margin: 0;
-  white-space: pre-wrap;
-  font-family: var(--cinder-font-mono);
-  font-size: var(--cinder-text-xs);
-}
+  .cinder-jse-json-view__errors {
+    margin: 0;
+    white-space: pre-wrap;
+    font-family: var(--cinder-font-mono);
+    font-size: var(--cinder-text-xs);
+  }
 
-/* ===== Diff view ===== */
-.cinder-jse-diff-view {
-  display: flex;
-  flex-direction: column;
-  gap: var(--cinder-space-3);
-}
+  /* ===== Diff view ===== */
+  .cinder-jse-diff-view {
+    display: flex;
+    flex-direction: column;
+    gap: var(--cinder-space-3);
+  }
 
-/* ===== Form view ===== */
-.cinder-jse-form-view {
-  display: flex;
-  flex-direction: column;
-  gap: var(--cinder-space-3);
-}
+  /* ===== Form view ===== */
+  .cinder-jse-form-view {
+    display: flex;
+    flex-direction: column;
+    gap: var(--cinder-space-3);
+  }
 
-.cinder-jse-dirty-actions {
-  display: flex;
-  gap: var(--cinder-space-2);
-  margin-top: var(--cinder-space-2);
+  .cinder-jse-dirty-actions {
+    display: flex;
+    gap: var(--cinder-space-2);
+    margin-top: var(--cinder-space-2);
+  }
 }

--- a/packages/components/src/components/kanban-board/kanban-board.css
+++ b/packages/components/src/components/kanban-board/kanban-board.css
@@ -1,143 +1,145 @@
-.cinder-kanban-board {
-  --cinder-kanban-column-width: 18rem;
-  --cinder-kanban-column-gap: var(--cinder-space-4);
-  --cinder-kanban-column-background: var(--cinder-surface-raised);
-  --cinder-kanban-card-background: var(--cinder-surface);
+@layer cinder.components {
+  .cinder-kanban-board {
+    --cinder-kanban-column-width: 18rem;
+    --cinder-kanban-column-gap: var(--cinder-space-4);
+    --cinder-kanban-column-background: var(--cinder-surface-raised);
+    --cinder-kanban-card-background: var(--cinder-surface);
 
-  display: block;
-  overflow-x: auto;
-  padding-block-end: var(--cinder-space-2);
-}
+    display: block;
+    overflow-x: auto;
+    padding-block-end: var(--cinder-space-2);
+  }
 
-.cinder-kanban-board__columns {
-  display: grid;
-  grid-auto-columns: minmax(var(--cinder-kanban-column-width), 1fr);
-  grid-auto-flow: column;
-  gap: var(--cinder-kanban-column-gap);
-  align-items: start;
-  min-inline-size: max-content;
-}
+  .cinder-kanban-board__columns {
+    display: grid;
+    grid-auto-columns: minmax(var(--cinder-kanban-column-width), 1fr);
+    grid-auto-flow: column;
+    gap: var(--cinder-kanban-column-gap);
+    align-items: start;
+    min-inline-size: max-content;
+  }
 
-.cinder-kanban-board__column {
-  display: grid;
-  grid-template-rows: auto minmax(4rem, 1fr);
-  gap: var(--cinder-space-3);
-  min-block-size: 8rem;
-  padding: var(--cinder-space-3);
-  border: 1px solid var(--cinder-border-muted);
-  border-radius: var(--cinder-radius-md);
-  background: var(--cinder-kanban-column-background);
-  box-shadow: var(--cinder-shadow-sm);
-}
+  .cinder-kanban-board__column {
+    display: grid;
+    grid-template-rows: auto minmax(4rem, 1fr);
+    gap: var(--cinder-space-3);
+    min-block-size: 8rem;
+    padding: var(--cinder-space-3);
+    border: 1px solid var(--cinder-border-muted);
+    border-radius: var(--cinder-radius-md);
+    background: var(--cinder-kanban-column-background);
+    box-shadow: var(--cinder-shadow-sm);
+  }
 
-.cinder-kanban-board__column[data-cinder-collapsed] {
-  grid-template-rows: auto;
-  min-block-size: auto;
-}
+  .cinder-kanban-board__column[data-cinder-collapsed] {
+    grid-template-rows: auto;
+    min-block-size: auto;
+  }
 
-.cinder-kanban-board__column-header {
-  display: grid;
-  grid-template-columns: auto minmax(0, 1fr) auto auto;
-  gap: var(--cinder-space-2);
-  align-items: center;
-}
+  .cinder-kanban-board__column-header {
+    display: grid;
+    grid-template-columns: auto minmax(0, 1fr) auto auto;
+    gap: var(--cinder-space-2);
+    align-items: center;
+  }
 
-.cinder-kanban-board__column-title {
-  min-inline-size: 0;
-  overflow-wrap: anywhere;
-  font-size: var(--cinder-text-sm);
-  font-weight: 600;
-  color: var(--cinder-text);
-}
-
-.cinder-kanban-board__column-actions {
-  display: inline-flex;
-  gap: var(--cinder-space-1);
-  align-items: center;
-}
-
-.cinder-kanban-board__column-handle,
-.cinder-kanban-board__collapse {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  inline-size: 1.75rem;
-  block-size: 1.75rem;
-  padding: 0;
-  border: 1px solid var(--cinder-border-muted);
-  border-radius: var(--cinder-radius-sm);
-  background: var(--cinder-surface);
-  color: var(--cinder-text-muted);
-  cursor: pointer;
-}
-
-.cinder-kanban-board__column-handle:focus-visible,
-.cinder-kanban-board__collapse:focus-visible {
-  outline: var(--cinder-ring-width) solid transparent;
-  box-shadow:
-    0 0 0 var(--cinder-ring-offset) var(--cinder-ring-offset-color),
-    0 0 0 calc(var(--cinder-ring-offset) + var(--cinder-ring-width)) var(--cinder-ring-color);
-}
-
-@media (hover: hover) {
-  .cinder-kanban-board__column-handle:hover,
-  .cinder-kanban-board__collapse:hover {
-    background: var(--cinder-surface-hover);
+  .cinder-kanban-board__column-title {
+    min-inline-size: 0;
+    overflow-wrap: anywhere;
+    font-size: var(--cinder-text-sm);
+    font-weight: 600;
     color: var(--cinder-text);
   }
-}
 
-.cinder-kanban-board__cards {
-  display: grid;
-  gap: var(--cinder-space-2);
-  min-block-size: 3rem;
-  padding: 0;
-  margin: 0;
-  list-style: none;
-}
+  .cinder-kanban-board__column-actions {
+    display: inline-flex;
+    gap: var(--cinder-space-1);
+    align-items: center;
+  }
 
-.cinder-kanban-board__card {
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) auto;
-  gap: var(--cinder-space-2);
-  align-items: start;
-  padding: var(--cinder-space-3);
-  border: 1px solid var(--cinder-border-muted);
-  border-radius: var(--cinder-radius-md);
-  background: var(--cinder-kanban-card-background);
-  box-shadow: var(--cinder-shadow-xs);
-}
+  .cinder-kanban-board__column-handle,
+  .cinder-kanban-board__collapse {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    inline-size: 1.75rem;
+    block-size: 1.75rem;
+    padding: 0;
+    border: 1px solid var(--cinder-border-muted);
+    border-radius: var(--cinder-radius-sm);
+    background: var(--cinder-surface);
+    color: var(--cinder-text-muted);
+    cursor: pointer;
+  }
 
-.cinder-kanban-board__card.cinder-sortable-item--lifted {
-  border-color: var(--cinder-ring-color);
-  box-shadow: var(--cinder-shadow-md);
-}
+  .cinder-kanban-board__column-handle:focus-visible,
+  .cinder-kanban-board__collapse:focus-visible {
+    outline: var(--cinder-ring-width) solid transparent;
+    box-shadow:
+      0 0 0 var(--cinder-ring-offset) var(--cinder-ring-offset-color),
+      0 0 0 calc(var(--cinder-ring-offset) + var(--cinder-ring-width)) var(--cinder-ring-color);
+  }
 
-.cinder-kanban-board__card-content {
-  min-inline-size: 0;
-}
+  @media (hover: hover) {
+    .cinder-kanban-board__column-handle:hover,
+    .cinder-kanban-board__collapse:hover {
+      background: var(--cinder-surface-hover);
+      color: var(--cinder-text);
+    }
+  }
 
-.cinder-kanban-board .cinder-sortable-handle {
-  align-self: start;
-}
+  .cinder-kanban-board__cards {
+    display: grid;
+    gap: var(--cinder-space-2);
+    min-block-size: 3rem;
+    padding: 0;
+    margin: 0;
+    list-style: none;
+  }
 
-.cinder-kanban-board__empty {
-  display: grid;
-  place-items: center;
-  min-block-size: 3rem;
-  padding: var(--cinder-space-3);
-  border: 1px dashed var(--cinder-border-muted);
-  border-radius: var(--cinder-radius-md);
-  color: var(--cinder-text-muted);
-  font-size: var(--cinder-text-sm);
-}
+  .cinder-kanban-board__card {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    gap: var(--cinder-space-2);
+    align-items: start;
+    padding: var(--cinder-space-3);
+    border: 1px solid var(--cinder-border-muted);
+    border-radius: var(--cinder-radius-md);
+    background: var(--cinder-kanban-card-background);
+    box-shadow: var(--cinder-shadow-xs);
+  }
 
-@media (prefers-reduced-motion: no-preference) {
-  .cinder-kanban-board__card,
-  .cinder-kanban-board__column {
-    transition:
-      border-color var(--cinder-duration-fast) var(--cinder-ease-standard),
-      box-shadow var(--cinder-duration-fast) var(--cinder-ease-standard),
-      background-color var(--cinder-duration-fast) var(--cinder-ease-standard);
+  .cinder-kanban-board__card.cinder-sortable-item--lifted {
+    border-color: var(--cinder-ring-color);
+    box-shadow: var(--cinder-shadow-md);
+  }
+
+  .cinder-kanban-board__card-content {
+    min-inline-size: 0;
+  }
+
+  .cinder-kanban-board .cinder-sortable-handle {
+    align-self: start;
+  }
+
+  .cinder-kanban-board__empty {
+    display: grid;
+    place-items: center;
+    min-block-size: 3rem;
+    padding: var(--cinder-space-3);
+    border: 1px dashed var(--cinder-border-muted);
+    border-radius: var(--cinder-radius-md);
+    color: var(--cinder-text-muted);
+    font-size: var(--cinder-text-sm);
+  }
+
+  @media (prefers-reduced-motion: no-preference) {
+    .cinder-kanban-board__card,
+    .cinder-kanban-board__column {
+      transition:
+        border-color var(--cinder-duration-fast) var(--cinder-ease-standard),
+        box-shadow var(--cinder-duration-fast) var(--cinder-ease-standard),
+        background-color var(--cinder-duration-fast) var(--cinder-ease-standard);
+    }
   }
 }

--- a/packages/components/src/components/kbd/kbd.css
+++ b/packages/components/src/components/kbd/kbd.css
@@ -1,46 +1,48 @@
-/* ========================================
+@layer cinder.components {
+  /* ========================================
  * KBD
  * Keyboard-key chip. Use to display shortcuts in tooltips and help text.
  * ======================================== */
 
-.cinder-kbd {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  min-width: 1.25rem;
-  height: 1.25rem;
-  padding: 0 var(--cinder-space-1-5);
-  font-family: var(--cinder-font-sans);
-  font-size: var(--cinder-text-2xs);
-  font-weight: var(--cinder-font-medium);
-  line-height: 1;
-  color: var(--cinder-text);
-  background: var(--cinder-surface-raised);
-  border: 1px solid var(--cinder-border);
-  border-radius: var(--cinder-radius-sm);
-  box-shadow: inset 0 -1px 0 var(--cinder-border-muted);
-  vertical-align: middle;
-}
-
-/* Forced-colors mode suppresses box-shadow, so the keycap depth disappears.
- * Restore the visual affordance with a real bottom border (which HCM keeps). */
-@media (forced-colors: active) {
   .cinder-kbd {
-    border-bottom-width: 2px;
-    box-shadow: none;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 1.25rem;
+    height: 1.25rem;
+    padding: 0 var(--cinder-space-1-5);
+    font-family: var(--cinder-font-sans);
+    font-size: var(--cinder-text-2xs);
+    font-weight: var(--cinder-font-medium);
+    line-height: 1;
+    color: var(--cinder-text);
+    background: var(--cinder-surface-raised);
+    border: 1px solid var(--cinder-border);
+    border-radius: var(--cinder-radius-sm);
+    box-shadow: inset 0 -1px 0 var(--cinder-border-muted);
+    vertical-align: middle;
   }
-}
 
-.cinder-kbd[data-cinder-size='sm'] {
-  min-width: 1rem;
-  height: 1rem;
-  padding: 0 var(--cinder-space-1);
-  font-size: var(--cinder-text-2xs, 0.625rem);
-}
+  /* Forced-colors mode suppresses box-shadow, so the keycap depth disappears.
+ * Restore the visual affordance with a real bottom border (which HCM keeps). */
+  @media (forced-colors: active) {
+    .cinder-kbd {
+      border-bottom-width: 2px;
+      box-shadow: none;
+    }
+  }
 
-.cinder-kbd[data-cinder-size='md'] {
-  min-width: 1.25rem;
-  height: 1.25rem;
-  padding: 0 var(--cinder-space-1-5);
-  font-size: var(--cinder-text-2xs);
+  .cinder-kbd[data-cinder-size='sm'] {
+    min-width: 1rem;
+    height: 1rem;
+    padding: 0 var(--cinder-space-1);
+    font-size: var(--cinder-text-2xs, 0.625rem);
+  }
+
+  .cinder-kbd[data-cinder-size='md'] {
+    min-width: 1.25rem;
+    height: 1.25rem;
+    padding: 0 var(--cinder-space-1-5);
+    font-size: var(--cinder-text-2xs);
+  }
 }

--- a/packages/components/src/components/label/label.css
+++ b/packages/components/src/components/label/label.css
@@ -1,30 +1,32 @@
-/* ========================================
+@layer cinder.components {
+  /* ========================================
  * LABEL
  * Standalone label — matches the inline labels rendered by Input, Textarea,
  * Select, Checkbox, and Radio so hand-rolled forms read consistently.
  * ======================================== */
 
-.cinder-label {
-  display: inline-flex;
-  align-items: center;
-  gap: var(--cinder-space-1);
-  font-size: var(--cinder-text-xs);
-  font-weight: var(--cinder-font-medium);
-  line-height: 1;
-  color: var(--cinder-text);
-}
+  .cinder-label {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--cinder-space-1);
+    font-size: var(--cinder-text-xs);
+    font-weight: var(--cinder-font-medium);
+    line-height: 1;
+    color: var(--cinder-text);
+  }
 
-.cinder-label[data-disabled] {
-  color: var(--cinder-text-disabled);
-  cursor: not-allowed;
-}
+  .cinder-label[data-disabled] {
+    color: var(--cinder-text-disabled);
+    cursor: not-allowed;
+  }
 
-.cinder-label__required {
-  display: inline-block;
-  width: 6px;
-  height: 6px;
-  border-radius: 50%;
-  background-color: var(--cinder-danger);
-  flex-shrink: 0;
-  align-self: center;
+  .cinder-label__required {
+    display: inline-block;
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    background-color: var(--cinder-danger);
+    flex-shrink: 0;
+    align-self: center;
+  }
 }

--- a/packages/components/src/components/line-chart/line-chart.css
+++ b/packages/components/src/components/line-chart/line-chart.css
@@ -1,122 +1,124 @@
-.cinder-line-chart {
-  display: grid;
-  gap: var(--cinder-space-3);
-  color: var(--cinder-text);
-}
+@layer cinder.components {
+  .cinder-line-chart {
+    display: grid;
+    gap: var(--cinder-space-3);
+    color: var(--cinder-text);
+  }
 
-.cinder-line-chart__description {
-  margin: 0;
-  color: var(--cinder-text-muted);
-  font-size: var(--cinder-text-sm);
-}
+  .cinder-line-chart__description {
+    margin: 0;
+    color: var(--cinder-text-muted);
+    font-size: var(--cinder-text-sm);
+  }
 
-.cinder-line-chart__legend {
-  display: flex;
-  flex-wrap: wrap;
-  gap: var(--cinder-space-2);
-}
+  .cinder-line-chart__legend {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--cinder-space-2);
+  }
 
-.cinder-line-chart__legend button {
-  display: inline-flex;
-  align-items: center;
-  gap: var(--cinder-space-1);
-  border: 1px solid var(--cinder-border-muted);
-  border-radius: var(--cinder-radius-sm);
-  background: var(--cinder-surface);
-  color: var(--cinder-text);
-  cursor: pointer;
-  font: inherit;
-  font-size: var(--cinder-text-sm);
-  padding: var(--cinder-space-1) var(--cinder-space-2);
-}
+  .cinder-line-chart__legend button {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--cinder-space-1);
+    border: 1px solid var(--cinder-border-muted);
+    border-radius: var(--cinder-radius-sm);
+    background: var(--cinder-surface);
+    color: var(--cinder-text);
+    cursor: pointer;
+    font: inherit;
+    font-size: var(--cinder-text-sm);
+    padding: var(--cinder-space-1) var(--cinder-space-2);
+  }
 
-.cinder-line-chart__legend button[aria-pressed='false'] {
-  opacity: 0.55;
-}
+  .cinder-line-chart__legend button[aria-pressed='false'] {
+    opacity: 0.55;
+  }
 
-.cinder-line-chart__legend span {
-  inline-size: 0.75rem;
-  block-size: 0.75rem;
-  border-radius: var(--cinder-radius-full);
-  /* background is set inline from the resolved series color via `style:background` */
-}
+  .cinder-line-chart__legend span {
+    inline-size: 0.75rem;
+    block-size: 0.75rem;
+    border-radius: var(--cinder-radius-full);
+    /* background is set inline from the resolved series color via `style:background` */
+  }
 
-.cinder-line-chart__viewport {
-  position: relative;
-  min-inline-size: 0;
-}
+  .cinder-line-chart__viewport {
+    position: relative;
+    min-inline-size: 0;
+  }
 
-.cinder-line-chart svg {
-  display: block;
-  inline-size: 100%;
-  block-size: 100%;
-}
+  .cinder-line-chart svg {
+    display: block;
+    inline-size: 100%;
+    block-size: 100%;
+  }
 
-.cinder-line-chart__gridline {
-  stroke: var(--cinder-border-muted);
-  stroke-width: 1;
-}
+  .cinder-line-chart__gridline {
+    stroke: var(--cinder-border-muted);
+    stroke-width: 1;
+  }
 
-.cinder-line-chart__line {
-  fill: none;
-  stroke-width: 2.25;
-  stroke-linecap: round;
-  stroke-linejoin: round;
-}
+  .cinder-line-chart__line {
+    fill: none;
+    stroke-width: 2.25;
+    stroke-linecap: round;
+    stroke-linejoin: round;
+  }
 
-.cinder-line-chart__crosshair {
-  stroke: var(--cinder-text-muted);
-  stroke-dasharray: 4 4;
-}
+  .cinder-line-chart__crosshair {
+    stroke: var(--cinder-text-muted);
+    stroke-dasharray: 4 4;
+  }
 
-.cinder-line-chart__hit-surface {
-  fill: transparent;
-}
+  .cinder-line-chart__hit-surface {
+    fill: transparent;
+  }
 
-.cinder-line-chart__focus-target {
-  fill: transparent;
-  outline: none;
-  pointer-events: none;
-}
+  .cinder-line-chart__focus-target {
+    fill: transparent;
+    outline: none;
+    pointer-events: none;
+  }
 
-/*
+  /*
  * SVG focus indicator: drop-shadow filter renders an outline-equivalent ring
  * around the focused circle that stays visible on any background. Stroke alone
  * was invisible against transparent fills.
  */
-.cinder-line-chart__focus-target:focus-visible {
-  stroke: var(--cinder-accent);
-  stroke-width: var(--cinder-ring-width);
-  filter: drop-shadow(0 0 var(--cinder-ring-width) var(--cinder-ring-color));
-}
+  .cinder-line-chart__focus-target:focus-visible {
+    stroke: var(--cinder-accent);
+    stroke-width: var(--cinder-ring-width);
+    filter: drop-shadow(0 0 var(--cinder-ring-width) var(--cinder-ring-color));
+  }
 
-.cinder-line-chart__tick-label {
-  fill: var(--cinder-text-muted);
-  font-size: var(--cinder-text-xs);
-}
+  .cinder-line-chart__tick-label {
+    fill: var(--cinder-text-muted);
+    font-size: var(--cinder-text-xs);
+  }
 
-.cinder-line-chart__state {
-  position: absolute;
-  inset: 0;
-  display: grid;
-  place-items: center;
-  color: var(--cinder-text-muted);
-  background: color-mix(in oklch, var(--cinder-surface) 88%, transparent);
-  z-index: 1;
-}
+  .cinder-line-chart__state {
+    position: absolute;
+    inset: 0;
+    display: grid;
+    place-items: center;
+    color: var(--cinder-text-muted);
+    background: color-mix(in oklch, var(--cinder-surface) 88%, transparent);
+    z-index: 1;
+  }
 
-.cinder-line-chart__tooltip {
-  position: absolute;
-  transform: translate(0.5rem, -50%);
-  display: grid;
-  gap: 0.125rem;
-  max-inline-size: 16rem;
-  border: 1px solid var(--cinder-border-muted);
-  border-radius: var(--cinder-radius-sm);
-  background: var(--cinder-surface-raised);
-  box-shadow: var(--cinder-shadow-md);
-  color: var(--cinder-text);
-  font-size: var(--cinder-text-sm);
-  padding: var(--cinder-space-2);
-  pointer-events: none;
+  .cinder-line-chart__tooltip {
+    position: absolute;
+    transform: translate(0.5rem, -50%);
+    display: grid;
+    gap: 0.125rem;
+    max-inline-size: 16rem;
+    border: 1px solid var(--cinder-border-muted);
+    border-radius: var(--cinder-radius-sm);
+    background: var(--cinder-surface-raised);
+    box-shadow: var(--cinder-shadow-md);
+    color: var(--cinder-text);
+    font-size: var(--cinder-text-sm);
+    padding: var(--cinder-space-2);
+    pointer-events: none;
+  }
 }

--- a/packages/components/src/components/load-more/load-more.css
+++ b/packages/components/src/components/load-more/load-more.css
@@ -1,74 +1,76 @@
-.cinder-load-more {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: var(--cinder-space-3);
-  padding-block: var(--cinder-space-3);
-}
-
-.cinder-load-more__sentinel {
-  inline-size: 100%;
-  block-size: 1px;
-}
-
-.cinder-load-more__button {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  gap: var(--cinder-space-2);
-  min-block-size: 2.5rem;
-  padding: 0.625rem 1rem;
-  border: 1px solid var(--cinder-border);
-  border-radius: var(--cinder-radius-md);
-  background: var(--cinder-surface-raised);
-  color: var(--cinder-text);
-  font: inherit;
-  font-size: var(--cinder-text-sm);
-  font-weight: var(--cinder-font-medium);
-  line-height: var(--cinder-leading-snug);
-  cursor: pointer;
-  transition:
-    background-color var(--cinder-duration-fast) var(--cinder-ease-standard),
-    border-color var(--cinder-duration-fast) var(--cinder-ease-standard),
-    box-shadow var(--cinder-duration-fast) var(--cinder-ease-standard);
-}
-
-@media (hover: hover) {
-  .cinder-load-more__button:hover:not(:disabled) {
-    background: var(--cinder-surface);
-    border-color: var(--cinder-border-strong);
+@layer cinder.components {
+  .cinder-load-more {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: var(--cinder-space-3);
+    padding-block: var(--cinder-space-3);
   }
-}
 
-.cinder-load-more__button:focus-visible {
-  outline: 2px solid transparent;
-  outline-offset: 2px;
-  box-shadow:
-    0 0 0 2px var(--cinder-ring-offset-color),
-    0 0 0 4px var(--cinder-ring-color);
-}
+  .cinder-load-more__sentinel {
+    inline-size: 100%;
+    block-size: 1px;
+  }
 
-.cinder-load-more__button:disabled {
-  cursor: progress;
-  opacity: 0.72;
-}
+  .cinder-load-more__button {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: var(--cinder-space-2);
+    min-block-size: 2.5rem;
+    padding: 0.625rem 1rem;
+    border: 1px solid var(--cinder-border);
+    border-radius: var(--cinder-radius-md);
+    background: var(--cinder-surface-raised);
+    color: var(--cinder-text);
+    font: inherit;
+    font-size: var(--cinder-text-sm);
+    font-weight: var(--cinder-font-medium);
+    line-height: var(--cinder-leading-snug);
+    cursor: pointer;
+    transition:
+      background-color var(--cinder-duration-fast) var(--cinder-ease-standard),
+      border-color var(--cinder-duration-fast) var(--cinder-ease-standard),
+      box-shadow var(--cinder-duration-fast) var(--cinder-ease-standard);
+  }
 
-.cinder-load-more__spinner {
-  inline-size: 0.875rem;
-  block-size: 0.875rem;
-  border: 2px solid color-mix(in oklch, var(--cinder-text-muted), transparent 65%);
-  border-top-color: var(--cinder-text);
-  border-radius: 9999px;
-}
+  @media (hover: hover) {
+    .cinder-load-more__button:hover:not(:disabled) {
+      background: var(--cinder-surface);
+      border-color: var(--cinder-border-strong);
+    }
+  }
 
-@media (prefers-reduced-motion: no-preference) {
+  .cinder-load-more__button:focus-visible {
+    outline: 2px solid transparent;
+    outline-offset: 2px;
+    box-shadow:
+      0 0 0 2px var(--cinder-ring-offset-color),
+      0 0 0 4px var(--cinder-ring-color);
+  }
+
+  .cinder-load-more__button:disabled {
+    cursor: progress;
+    opacity: 0.72;
+  }
+
   .cinder-load-more__spinner {
-    animation: cinder-load-more-spin 0.8s linear infinite;
+    inline-size: 0.875rem;
+    block-size: 0.875rem;
+    border: 2px solid color-mix(in oklch, var(--cinder-text-muted), transparent 65%);
+    border-top-color: var(--cinder-text);
+    border-radius: 9999px;
   }
-}
 
-@keyframes cinder-load-more-spin {
-  to {
-    transform: rotate(360deg);
+  @media (prefers-reduced-motion: no-preference) {
+    .cinder-load-more__spinner {
+      animation: cinder-load-more-spin 0.8s linear infinite;
+    }
+  }
+
+  @keyframes cinder-load-more-spin {
+    to {
+      transform: rotate(360deg);
+    }
   }
 }

--- a/packages/components/src/components/markdown-editor/prosemirror.css
+++ b/packages/components/src/components/markdown-editor/prosemirror.css
@@ -6,7 +6,7 @@
  * upstream CSS import is removed elsewhere.
  */
 
-@layer components {
+@layer cinder.components {
   .ProseMirror {
     position: relative;
   }

--- a/packages/components/src/components/menu-bar/menu-bar.css
+++ b/packages/components/src/components/menu-bar/menu-bar.css
@@ -1,99 +1,101 @@
-.cinder-menu-bar {
-  display: flex;
-  align-items: center;
-  gap: var(--cinder-space-1);
-  position: relative;
-  inline-size: fit-content;
-}
-
-.cinder-menu-bar__menu {
-  position: relative;
-}
-
-.cinder-menu-bar__trigger {
-  appearance: none;
-  border: 1px solid transparent;
-  border-radius: var(--cinder-radius-sm);
-  background: transparent;
-  color: var(--cinder-text);
-  cursor: pointer;
-  font: inherit;
-  line-height: var(--cinder-leading-tight);
-  padding: var(--cinder-space-1) var(--cinder-space-2);
-}
-
-.cinder-menu-bar__trigger[data-cinder-state='open'] {
-  border-color: var(--cinder-border);
-  background: var(--cinder-surface-raised);
-}
-
-@media (hover: hover) {
-  .cinder-menu-bar__trigger:not(:disabled):hover {
-    background: var(--cinder-surface-hover);
+@layer cinder.components {
+  .cinder-menu-bar {
+    display: flex;
+    align-items: center;
+    gap: var(--cinder-space-1);
+    position: relative;
+    inline-size: fit-content;
   }
-}
 
-.cinder-menu-bar__trigger:disabled {
-  color: var(--cinder-text-disabled);
-  cursor: not-allowed;
-}
+  .cinder-menu-bar__menu {
+    position: relative;
+  }
 
-.cinder-menu-bar__trigger:focus-visible {
-  outline: var(--cinder-ring-width, 2px) solid transparent;
-  box-shadow: var(--_cinder-focus-ring-shadow);
-}
+  .cinder-menu-bar__trigger {
+    appearance: none;
+    border: 1px solid transparent;
+    border-radius: var(--cinder-radius-sm);
+    background: transparent;
+    color: var(--cinder-text);
+    cursor: pointer;
+    font: inherit;
+    line-height: var(--cinder-leading-tight);
+    padding: var(--cinder-space-1) var(--cinder-space-2);
+  }
 
-.cinder-menu-bar__access-key {
-  text-decoration: underline;
-  text-underline-offset: 0.125em;
-}
+  .cinder-menu-bar__trigger[data-cinder-state='open'] {
+    border-color: var(--cinder-border);
+    background: var(--cinder-surface-raised);
+  }
 
-.cinder-menu-bar__dropdown-menu {
-  position: absolute;
-  display: grid;
-  inset-block-start: calc(100% + var(--cinder-space-1));
-  right: auto;
-  left: 0;
-  min-inline-size: 12rem;
-  max-inline-size: min(24rem, calc(100vw - var(--cinder-space-6)));
-  overflow: visible;
-  z-index: var(--cinder-z-dropdown, 1100);
-}
+  @media (hover: hover) {
+    .cinder-menu-bar__trigger:not(:disabled):hover {
+      background: var(--cinder-surface-hover);
+    }
+  }
 
-.cinder-menu-bar__dropdown-scroll {
-  min-inline-size: 100%;
-  max-block-size: min(28rem, calc(100vh - var(--cinder-space-6)));
-  overflow: auto;
-}
+  .cinder-menu-bar__trigger:disabled {
+    color: var(--cinder-text-disabled);
+    cursor: not-allowed;
+  }
 
-.cinder-menu-bar__submenu {
-  position: relative;
-  inline-size: 100%;
-}
+  .cinder-menu-bar__trigger:focus-visible {
+    outline: var(--cinder-ring-width, 2px) solid transparent;
+    box-shadow: var(--_cinder-focus-ring-shadow);
+  }
 
-.cinder-menu-bar__submenu-menu {
-  position: absolute;
-  inset-block-start: 0;
-  right: auto;
-  left: calc(100% + var(--cinder-space-1));
-  min-inline-size: 12rem;
-  max-inline-size: min(24rem, calc(100vw - var(--cinder-space-6)));
-  max-block-size: min(28rem, calc(100vh - var(--cinder-space-6)));
-  overflow: auto;
-  z-index: var(--cinder-z-dropdown, 1100);
-}
+  .cinder-menu-bar__access-key {
+    text-decoration: underline;
+    text-underline-offset: 0.125em;
+  }
 
-.cinder-menu-bar__item-label {
-  flex: 1 1 auto;
-}
+  .cinder-menu-bar__dropdown-menu {
+    position: absolute;
+    display: grid;
+    inset-block-start: calc(100% + var(--cinder-space-1));
+    right: auto;
+    left: 0;
+    min-inline-size: 12rem;
+    max-inline-size: min(24rem, calc(100vw - var(--cinder-space-6)));
+    overflow: visible;
+    z-index: var(--cinder-z-dropdown, 1100);
+  }
 
-.cinder-menu-bar__shortcut {
-  color: var(--cinder-text-muted);
-  font-size: var(--cinder-text-xs);
-  margin-inline-start: var(--cinder-space-4);
-}
+  .cinder-menu-bar__dropdown-scroll {
+    min-inline-size: 100%;
+    max-block-size: min(28rem, calc(100vh - var(--cinder-space-6)));
+    overflow: auto;
+  }
 
-.cinder-menu-bar__submenu-indicator {
-  color: var(--cinder-text-muted);
-  margin-inline-start: var(--cinder-space-4);
+  .cinder-menu-bar__submenu {
+    position: relative;
+    inline-size: 100%;
+  }
+
+  .cinder-menu-bar__submenu-menu {
+    position: absolute;
+    inset-block-start: 0;
+    right: auto;
+    left: calc(100% + var(--cinder-space-1));
+    min-inline-size: 12rem;
+    max-inline-size: min(24rem, calc(100vw - var(--cinder-space-6)));
+    max-block-size: min(28rem, calc(100vh - var(--cinder-space-6)));
+    overflow: auto;
+    z-index: var(--cinder-z-dropdown, 1100);
+  }
+
+  .cinder-menu-bar__item-label {
+    flex: 1 1 auto;
+  }
+
+  .cinder-menu-bar__shortcut {
+    color: var(--cinder-text-muted);
+    font-size: var(--cinder-text-xs);
+    margin-inline-start: var(--cinder-space-4);
+  }
+
+  .cinder-menu-bar__submenu-indicator {
+    color: var(--cinder-text-muted);
+    margin-inline-start: var(--cinder-space-4);
+  }
 }

--- a/packages/components/src/components/modal/modal.css
+++ b/packages/components/src/components/modal/modal.css
@@ -1,185 +1,187 @@
-/* ========================================
+@layer cinder.components {
+  /* ========================================
  * MODAL
  * ======================================== */
 
-.cinder-modal {
-  /* Reset browser's default <dialog> styles */
-  margin: auto;
-  padding: 0;
-  border: none;
-  border-radius: var(--cinder-radius-xl);
-  background: transparent;
-  color: var(--cinder-text);
-  max-width: min(90vw, 32rem);
-  width: 100%;
+  .cinder-modal {
+    /* Reset browser's default <dialog> styles */
+    margin: auto;
+    padding: 0;
+    border: none;
+    border-radius: var(--cinder-radius-xl);
+    background: transparent;
+    color: var(--cinder-text);
+    max-width: min(90vw, 32rem);
+    width: 100%;
 
-  /* Prevent the panel from touching viewport edges on small screens */
-  max-height: calc(100dvh - var(--cinder-space-8));
-  overflow: hidden;
-}
+    /* Prevent the panel from touching viewport edges on small screens */
+    max-height: calc(100dvh - var(--cinder-space-8));
+    overflow: hidden;
+  }
 
-/* Backdrop — native <dialog>::backdrop is controlled by the UA */
-.cinder-modal::backdrop {
-  background: var(--cinder-overlay-backdrop);
-  backdrop-filter: blur(var(--cinder-overlay-blur));
-}
+  /* Backdrop — native <dialog>::backdrop is controlled by the UA */
+  .cinder-modal::backdrop {
+    background: var(--cinder-overlay-backdrop);
+    backdrop-filter: blur(var(--cinder-overlay-blur));
+  }
 
-/* ----------------------------------------
+  /* ----------------------------------------
  * Panel (the visible card inside the dialog)
  * ---------------------------------------- */
 
-.cinder-modal__panel {
-  position: relative;
-  display: flex;
-  flex-direction: column;
-  background: var(--cinder-surface-raised);
-  border: 1px solid var(--cinder-border);
-  border-radius: var(--cinder-radius-xl);
-  box-shadow: var(--cinder-shadow-lg);
-  max-height: inherit;
-  overflow: hidden;
-}
+  .cinder-modal__panel {
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    background: var(--cinder-surface-raised);
+    border: 1px solid var(--cinder-border);
+    border-radius: var(--cinder-radius-xl);
+    box-shadow: var(--cinder-shadow-lg);
+    max-height: inherit;
+    overflow: hidden;
+  }
 
-/* ----------------------------------------
+  /* ----------------------------------------
  * Header
  * ---------------------------------------- */
 
-.cinder-modal__header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: var(--cinder-space-4);
-  /* Reserve trailing inline space so the title doesn't run under the
+  .cinder-modal__header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--cinder-space-4);
+    /* Reserve trailing inline space so the title doesn't run under the
      absolute-positioned close button. */
-  padding-block: var(--cinder-space-5);
-  padding-inline-start: var(--cinder-space-6);
-  padding-inline-end: calc(var(--cinder-space-6) + 2rem);
-  border-block-end: 1px solid var(--cinder-border);
-  flex-shrink: 0;
-}
+    padding-block: var(--cinder-space-5);
+    padding-inline-start: var(--cinder-space-6);
+    padding-inline-end: calc(var(--cinder-space-6) + 2rem);
+    border-block-end: 1px solid var(--cinder-border);
+    flex-shrink: 0;
+  }
 
-.cinder-modal__title {
-  margin: 0;
-  font-size: var(--cinder-text-lg);
-  font-weight: var(--cinder-font-semibold);
-  line-height: var(--cinder-leading-snug);
-  color: var(--cinder-text);
-}
+  .cinder-modal__title {
+    margin: 0;
+    font-size: var(--cinder-text-lg);
+    font-weight: var(--cinder-font-semibold);
+    line-height: var(--cinder-leading-snug);
+    color: var(--cinder-text);
+  }
 
-/* ----------------------------------------
+  /* ----------------------------------------
  * Close button
  * ---------------------------------------- */
 
-.cinder-modal__close {
-  /* Rendered last in DOM order so the close button isn't the first focusable
+  .cinder-modal__close {
+    /* Rendered last in DOM order so the close button isn't the first focusable
      element on dialog open — but visually positioned in the header corner. */
-  position: absolute;
-  inset-block-start: var(--cinder-space-3);
-  inset-inline-end: var(--cinder-space-3);
+    position: absolute;
+    inset-block-start: var(--cinder-space-3);
+    inset-inline-end: var(--cinder-space-3);
 
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  flex-shrink: 0;
-  width: 2rem;
-  height: 2rem;
-  padding: var(--cinder-space-1);
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+    width: 2rem;
+    height: 2rem;
+    padding: var(--cinder-space-1);
 
-  border-radius: var(--cinder-radius-md);
-  border: none;
-  background: transparent;
-  color: var(--cinder-text-muted);
-  cursor: pointer;
+    border-radius: var(--cinder-radius-md);
+    border: none;
+    background: transparent;
+    color: var(--cinder-text-muted);
+    cursor: pointer;
 
-  transition:
-    background-color var(--cinder-duration-fast) var(--cinder-ease-standard),
-    color var(--cinder-duration-fast) var(--cinder-ease-standard),
-    box-shadow var(--cinder-duration-fast) var(--cinder-ease-standard);
-}
-
-@media (hover: hover) {
-  .cinder-modal__close:hover {
-    background: color-mix(in oklch, currentColor, transparent 85%);
-    color: var(--cinder-text);
+    transition:
+      background-color var(--cinder-duration-fast) var(--cinder-ease-standard),
+      color var(--cinder-duration-fast) var(--cinder-ease-standard),
+      box-shadow var(--cinder-duration-fast) var(--cinder-ease-standard);
   }
-}
 
-.cinder-modal__close:focus-visible {
-  /* Use `outline` rather than `box-shadow` so the focus ring is not clipped
+  @media (hover: hover) {
+    .cinder-modal__close:hover {
+      background: color-mix(in oklch, currentColor, transparent 85%);
+      color: var(--cinder-text);
+    }
+  }
+
+  .cinder-modal__close:focus-visible {
+    /* Use `outline` rather than `box-shadow` so the focus ring is not clipped
      by the panel's `overflow: hidden`. Outline renders outside the box model
      and is unaffected by ancestor clipping (WCAG 2.4.11 / 2.4.12). */
-  outline: var(--cinder-ring-width) solid var(--cinder-ring-color);
-  outline-offset: var(--cinder-ring-offset);
-}
-
-@media (forced-colors: active) {
-  .cinder-modal__close:focus-visible {
-    outline: var(--cinder-ring-width) solid ButtonText;
-    outline-offset: 3px;
+    outline: var(--cinder-ring-width) solid var(--cinder-ring-color);
+    outline-offset: var(--cinder-ring-offset);
   }
-}
 
-.cinder-modal__close-icon {
-  width: 1.25rem;
-  height: 1.25rem;
-}
+  @media (forced-colors: active) {
+    .cinder-modal__close:focus-visible {
+      outline: var(--cinder-ring-width) solid ButtonText;
+      outline-offset: 3px;
+    }
+  }
 
-/* ----------------------------------------
+  .cinder-modal__close-icon {
+    width: 1.25rem;
+    height: 1.25rem;
+  }
+
+  /* ----------------------------------------
  * Body
  * ---------------------------------------- */
 
-.cinder-modal__body {
-  flex: 1;
-  overflow-y: auto;
-  padding: var(--cinder-space-6);
-  overscroll-behavior: contain;
-  scrollbar-gutter: stable;
-  /* The body container is focused on open (tabindex=-1) when the dialog has
+  .cinder-modal__body {
+    flex: 1;
+    overflow-y: auto;
+    padding: var(--cinder-space-6);
+    overscroll-behavior: contain;
+    scrollbar-gutter: stable;
+    /* The body container is focused on open (tabindex=-1) when the dialog has
      no autofocus target. The ring is hidden because focus arrived
      programmatically — pressing Tab forward will move into real content. */
-  outline: none;
-}
+    outline: none;
+  }
 
-.cinder-modal__body[data-cinder-overflows] {
-  mask-image: linear-gradient(to bottom, black calc(100% - 1.5rem), transparent);
-  mask-size: 100% 100%;
-  mask-repeat: no-repeat;
-  -webkit-mask-image: linear-gradient(to bottom, black calc(100% - 1.5rem), transparent);
-  -webkit-mask-size: 100% 100%;
-  -webkit-mask-repeat: no-repeat;
-}
+  .cinder-modal__body[data-cinder-overflows] {
+    mask-image: linear-gradient(to bottom, black calc(100% - 1.5rem), transparent);
+    mask-size: 100% 100%;
+    mask-repeat: no-repeat;
+    -webkit-mask-image: linear-gradient(to bottom, black calc(100% - 1.5rem), transparent);
+    -webkit-mask-size: 100% 100%;
+    -webkit-mask-repeat: no-repeat;
+  }
 
-/* ----------------------------------------
+  /* ----------------------------------------
  * Footer
  * ---------------------------------------- */
 
-.cinder-modal__footer {
-  display: flex;
-  align-items: center;
-  justify-content: flex-end;
-  gap: var(--cinder-space-3);
-  padding: var(--cinder-space-4) var(--cinder-space-6);
-  border-block-start: 1px solid var(--cinder-border);
-  flex-shrink: 0;
-}
+  .cinder-modal__footer {
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+    gap: var(--cinder-space-3);
+    padding: var(--cinder-space-4) var(--cinder-space-6);
+    border-block-start: 1px solid var(--cinder-border);
+    flex-shrink: 0;
+  }
 
-/* ----------------------------------------
+  /* ----------------------------------------
  * Reduced motion
  * ---------------------------------------- */
 
-@media (prefers-reduced-motion: no-preference) {
-  .cinder-modal {
-    animation: cinder-modal-enter var(--cinder-duration-normal) var(--cinder-ease-spring) forwards;
-  }
-
-  @keyframes cinder-modal-enter {
-    from {
-      opacity: 0;
-      translate: 0 -0.5rem;
+  @media (prefers-reduced-motion: no-preference) {
+    .cinder-modal {
+      animation: cinder-modal-enter var(--cinder-duration-normal) var(--cinder-ease-spring) forwards;
     }
-    to {
-      opacity: 1;
-      translate: 0 0;
+
+    @keyframes cinder-modal-enter {
+      from {
+        opacity: 0;
+        translate: 0 -0.5rem;
+      }
+      to {
+        opacity: 1;
+        translate: 0 0;
+      }
     }
   }
 }

--- a/packages/components/src/components/navigation-bar/navigation-bar.css
+++ b/packages/components/src/components/navigation-bar/navigation-bar.css
@@ -1,120 +1,124 @@
-/* ========================================
+@layer cinder.components {
+  /* ========================================
  * NAVIGATION BAR
  * Breakpoint used below: 47.99rem (~767px). No shared breakpoint token
  * exists in this package yet; extract to a token in a follow-up task.
  * ======================================== */
 
-.cinder-navigation-bar {
-  position: relative;
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: var(--cinder-space-6);
-  inline-size: 100%;
-  height: 3.5rem;
-  padding-inline: var(--cinder-space-4);
-  background: var(--cinder-surface);
-  border-bottom: 1px solid var(--cinder-border-muted);
-}
+  .cinder-navigation-bar {
+    position: relative;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--cinder-space-6);
+    inline-size: 100%;
+    height: 3.5rem;
+    padding-inline: var(--cinder-space-4);
+    background: var(--cinder-surface);
+    border-bottom: 1px solid var(--cinder-border-muted);
+  }
 
-/* ----------------------------------------
+  /* ----------------------------------------
  * Sections
  * ---------------------------------------- */
 
-.cinder-navigation-bar__brand {
-  display: flex;
-  align-items: center;
-  flex-shrink: 0;
-  margin-inline-end: var(--cinder-space-2);
-  min-height: 2rem;
-  padding-block: var(--cinder-space-1-5);
-  font-size: var(--cinder-text-lg);
-  font-weight: var(--cinder-font-semibold);
-}
+  .cinder-navigation-bar__brand {
+    display: flex;
+    align-items: center;
+    flex-shrink: 0;
+    margin-inline-end: var(--cinder-space-2);
+    min-height: 2rem;
+    padding-block: var(--cinder-space-1-5);
+    font-size: var(--cinder-text-lg);
+    font-weight: var(--cinder-font-semibold);
+  }
 
-.cinder-navigation-bar__items {
-  display: flex;
-  align-items: center;
-  gap: var(--cinder-space-1);
-  flex: 1 1 auto;
-  min-width: 0;
-}
+  .cinder-navigation-bar__items {
+    display: flex;
+    align-items: center;
+    gap: var(--cinder-space-1);
+    flex: 1 1 auto;
+    min-width: 0;
+  }
 
-.cinder-navigation-bar__actions {
-  display: flex;
-  align-items: center;
-  gap: var(--cinder-space-2);
-  flex-shrink: 0;
-}
+  .cinder-navigation-bar__actions {
+    display: flex;
+    align-items: center;
+    gap: var(--cinder-space-2);
+    flex-shrink: 0;
+  }
 
-/* ----------------------------------------
+  /* ----------------------------------------
  * Toggle button — hidden by default; shown on mobile only when
  * the consumer provides a menuToggle snippet (data-collapsible='true').
  * ---------------------------------------- */
 
-.cinder-navigation-bar__menu-toggle {
-  display: none;
-}
+  .cinder-navigation-bar__menu-toggle {
+    display: none;
+  }
 
-/* ----------------------------------------
+  /* ----------------------------------------
  * Collapsible mobile mode
  * Scoped under [data-collapsible='true'] so non-opted-in bars are
  * completely unaffected at every viewport.
  * ---------------------------------------- */
 
-@media (max-width: 47.99rem) {
-  .cinder-navigation-bar[data-collapsible='true'] .cinder-navigation-bar__menu-toggle {
-    display: inline-flex;
+  @media (max-width: 47.99rem) {
+    .cinder-navigation-bar[data-collapsible='true'] .cinder-navigation-bar__menu-toggle {
+      display: inline-flex;
+    }
+
+    .cinder-navigation-bar[data-collapsible='true'] .cinder-navigation-bar__items {
+      position: absolute;
+      inset-inline: 0;
+      top: 100%;
+      flex-direction: column;
+      align-items: stretch;
+      padding: var(--cinder-space-2);
+      background: var(--cinder-surface);
+      border-bottom: 1px solid var(--cinder-border-muted);
+      z-index: var(--cinder-z-overlay, 10);
+
+      /* Open → visible, slide in */
+      transition:
+        transform 200ms ease,
+        opacity 200ms ease;
+    }
+
+    /* Closed: remove from focus/AT trees immediately via visibility. */
+    .cinder-navigation-bar[data-collapsible='true']
+      .cinder-navigation-bar__items[data-open='false'] {
+      visibility: hidden;
+      transform: translateY(-0.5rem);
+      opacity: 0;
+      pointer-events: none;
+    }
+
+    .cinder-navigation-bar[data-collapsible='true']
+      .cinder-navigation-bar__items[data-open='true'] {
+      visibility: visible;
+      transform: none;
+      opacity: 1;
+    }
   }
 
-  .cinder-navigation-bar[data-collapsible='true'] .cinder-navigation-bar__items {
-    position: absolute;
-    inset-inline: 0;
-    top: 100%;
-    flex-direction: column;
-    align-items: stretch;
-    padding: var(--cinder-space-2);
-    background: var(--cinder-surface);
-    border-bottom: 1px solid var(--cinder-border-muted);
-    z-index: var(--cinder-z-overlay, 10);
-
-    /* Open → visible, slide in */
-    transition:
-      transform 200ms ease,
-      opacity 200ms ease;
-  }
-
-  /* Closed: remove from focus/AT trees immediately via visibility. */
-  .cinder-navigation-bar[data-collapsible='true'] .cinder-navigation-bar__items[data-open='false'] {
-    visibility: hidden;
-    transform: translateY(-0.5rem);
-    opacity: 0;
-    pointer-events: none;
-  }
-
-  .cinder-navigation-bar[data-collapsible='true'] .cinder-navigation-bar__items[data-open='true'] {
-    visibility: visible;
-    transform: none;
-    opacity: 1;
-  }
-}
-
-/* ----------------------------------------
+  /* ----------------------------------------
  * Reduced motion — zero out transitions
  * ---------------------------------------- */
 
-@media (prefers-reduced-motion: reduce) {
-  .cinder-navigation-bar[data-collapsible='true'] .cinder-navigation-bar__items {
-    transition: none;
+  @media (prefers-reduced-motion: reduce) {
+    .cinder-navigation-bar[data-collapsible='true'] .cinder-navigation-bar__items {
+      transition: none;
+    }
   }
-}
 
-/* ----------------------------------------
+  /* ----------------------------------------
  * Forced colors — keep panel border visible
  * ---------------------------------------- */
 
-@media (forced-colors: active) {
-  .cinder-navigation-bar[data-collapsible='true'] .cinder-navigation-bar__items {
-    border-bottom-color: CanvasText;
+  @media (forced-colors: active) {
+    .cinder-navigation-bar[data-collapsible='true'] .cinder-navigation-bar__items {
+      border-bottom-color: CanvasText;
+    }
   }
 }

--- a/packages/components/src/components/navigation-item/navigation-item.css
+++ b/packages/components/src/components/navigation-item/navigation-item.css
@@ -1,95 +1,96 @@
-/* ========================================
+@layer cinder.components {
+  /* ========================================
  * NAVIGATION ITEM
  * ======================================== */
 
-.cinder-navigation-item {
-  display: inline-flex;
-  align-items: center;
-  gap: var(--cinder-space-2);
-  min-height: 2rem;
-  padding-inline: var(--cinder-space-3);
-  padding-block: var(--cinder-space-1-5);
+  .cinder-navigation-item {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--cinder-space-2);
+    min-height: 2rem;
+    padding-inline: var(--cinder-space-3);
+    padding-block: var(--cinder-space-1-5);
 
-  font-size: var(--cinder-text-sm);
-  font-weight: var(--cinder-font-medium);
-  line-height: var(--cinder-leading-none);
-  text-decoration: none;
+    font-size: var(--cinder-text-sm);
+    font-weight: var(--cinder-font-medium);
+    line-height: var(--cinder-leading-none);
+    text-decoration: none;
 
-  color: var(--cinder-text-muted);
-  background: transparent;
-  border: none;
-  border-bottom: 2px solid transparent;
-  border-radius: var(--cinder-radius-sm) var(--cinder-radius-sm) 0 0;
+    color: var(--cinder-text-muted);
+    background: transparent;
+    border: none;
+    border-bottom: 2px solid transparent;
+    border-radius: var(--cinder-radius-sm) var(--cinder-radius-sm) 0 0;
 
-  cursor: pointer;
-  user-select: none;
+    cursor: pointer;
+    user-select: none;
 
-  transition:
-    color var(--cinder-duration-fast) var(--cinder-ease-standard),
-    border-color var(--cinder-duration-fast) var(--cinder-ease-standard),
-    background-color var(--cinder-duration-fast) var(--cinder-ease-standard);
-}
+    transition:
+      color var(--cinder-duration-fast) var(--cinder-ease-standard),
+      border-color var(--cinder-duration-fast) var(--cinder-ease-standard),
+      background-color var(--cinder-duration-fast) var(--cinder-ease-standard);
+  }
 
-/* ----------------------------------------
+  /* ----------------------------------------
  * Hover — only when interactive (not disabled)
  * ---------------------------------------- */
 
-/* Sticky-hover suppression on touch: wrap hover-only chrome so it doesn't
+  /* Sticky-hover suppression on touch: wrap hover-only chrome so it doesn't
  * "stick" after tap on touch devices that emulate :hover. */
-@media (hover: hover) {
-  .cinder-navigation-item:hover:not([aria-disabled='true']) {
-    color: var(--cinder-text);
-    background-color: var(--cinder-surface-hover);
+  @media (hover: hover) {
+    .cinder-navigation-item:hover:not([aria-disabled='true']) {
+      color: var(--cinder-text);
+      background-color: var(--cinder-surface-hover);
+    }
   }
-}
 
-/* ----------------------------------------
+  /* ----------------------------------------
  * Focus visible
  * ---------------------------------------- */
 
-.cinder-navigation-item:focus-visible {
-  outline: var(--cinder-ring-width) solid transparent;
-  box-shadow: var(--_cinder-focus-ring-shadow);
-}
-
-/* Forced Colors Mode — box-shadow focus rings are invisible; use a real outline. */
-@media (forced-colors: active) {
   .cinder-navigation-item:focus-visible {
-    outline: var(--cinder-ring-width) solid ButtonText;
-    outline-offset: 3px;
+    outline: var(--cinder-ring-width) solid transparent;
+    box-shadow: var(--_cinder-focus-ring-shadow);
   }
-}
 
-/* ----------------------------------------
+  /* Forced Colors Mode — box-shadow focus rings are invisible; use a real outline. */
+  @media (forced-colors: active) {
+    .cinder-navigation-item:focus-visible {
+      outline: var(--cinder-ring-width) solid ButtonText;
+      outline-offset: 3px;
+    }
+  }
+
+  /* ----------------------------------------
  * Active state
  * ---------------------------------------- */
 
-.cinder-navigation-item[data-active='true'] {
-  color: var(--cinder-text);
-  border-bottom-color: var(--cinder-accent);
-}
+  .cinder-navigation-item[data-active='true'] {
+    color: var(--cinder-text);
+    border-bottom-color: var(--cinder-accent);
+  }
 
-/* ----------------------------------------
+  /* ----------------------------------------
  * Disabled state
  * ---------------------------------------- */
 
-.cinder-navigation-item[aria-disabled='true'] {
-  color: var(--cinder-text-disabled);
-  cursor: not-allowed;
-  opacity: 0.6;
-}
+  .cinder-navigation-item[aria-disabled='true'] {
+    color: var(--cinder-text-disabled);
+    cursor: not-allowed;
+    opacity: 0.6;
+  }
 
-/* ----------------------------------------
+  /* ----------------------------------------
  * Button-specific reset (when rendered as <button>)
  * ---------------------------------------- */
 
-button.cinder-navigation-item {
-  appearance: none;
-  background: transparent;
-  padding-inline: var(--cinder-space-3);
-}
+  button.cinder-navigation-item {
+    appearance: none;
+    background: transparent;
+    padding-inline: var(--cinder-space-3);
+  }
 
-/* ----------------------------------------
+  /* ----------------------------------------
  * Vertical variant — sidebar / vertical-tab contexts
  *
  * Square row geometry for flush sidebar edges. The inline-start border is the
@@ -97,39 +98,40 @@ button.cinder-navigation-item {
  * shifts the label.
  * ---------------------------------------- */
 
-.cinder-navigation-item[data-variant='vertical'] {
-  display: flex;
-  inline-size: 100%;
-  justify-content: flex-start;
-  border-bottom: none;
-  border-radius: 0;
-  border-inline-start: 2px solid transparent;
-}
+  .cinder-navigation-item[data-variant='vertical'] {
+    display: flex;
+    inline-size: 100%;
+    justify-content: flex-start;
+    border-bottom: none;
+    border-radius: 0;
+    border-inline-start: 2px solid transparent;
+  }
 
-.cinder-navigation-item[data-variant='vertical'][data-active='true'] {
-  border-bottom-color: transparent;
-  border-inline-start-color: var(--cinder-accent);
-  background-color: var(--cinder-surface-inset);
-}
+  .cinder-navigation-item[data-variant='vertical'][data-active='true'] {
+    border-bottom-color: transparent;
+    border-inline-start-color: var(--cinder-accent);
+    background-color: var(--cinder-surface-inset);
+  }
 
-/* ----------------------------------------
+  /* ----------------------------------------
  * Mobile variant — stacked full-width layout
  * Breakpoint: 47.99rem (~767px). No breakpoint token exists in this
  * package yet; extract to a shared token in a follow-up task.
  * ---------------------------------------- */
 
-@media (max-width: 47.99rem) {
-  .cinder-navigation-item[data-variant='mobile'] {
-    display: flex;
-    inline-size: 100%;
-    justify-content: flex-start;
-    padding-block: var(--cinder-space-3);
+  @media (max-width: 47.99rem) {
+    .cinder-navigation-item[data-variant='mobile'] {
+      display: flex;
+      inline-size: 100%;
+      justify-content: flex-start;
+      padding-block: var(--cinder-space-3);
+    }
   }
-}
 
-@media (forced-colors: active) and (max-width: 47.99rem) {
-  .cinder-navigation-item[data-variant='mobile']:focus-visible {
-    outline: var(--cinder-ring-width) solid ButtonText;
-    outline-offset: 3px;
+  @media (forced-colors: active) and (max-width: 47.99rem) {
+    .cinder-navigation-item[data-variant='mobile']:focus-visible {
+      outline: var(--cinder-ring-width) solid ButtonText;
+      outline-offset: 3px;
+    }
   }
 }

--- a/packages/components/src/components/number-input/number-input.css
+++ b/packages/components/src/components/number-input/number-input.css
@@ -1,123 +1,125 @@
-/* ========================================
+@layer cinder.components {
+  /* ========================================
  * NUMBER INPUT
  * ======================================== */
 
-.cinder-number-input {
-  display: inline-flex;
-  align-items: stretch;
-  inline-size: 100%;
-  background: var(--cinder-surface-raised);
-  border: 1px solid var(--cinder-border);
-  border-radius: var(--cinder-radius-md);
-  transition:
-    border-color var(--cinder-duration-fast) var(--cinder-ease-standard),
-    box-shadow var(--cinder-duration-fast) var(--cinder-ease-standard);
-}
-
-@media (hover: hover) {
-  .cinder-number-input:hover:not([data-disabled]) {
-    border-color: var(--cinder-border-strong);
+  .cinder-number-input {
+    display: inline-flex;
+    align-items: stretch;
+    inline-size: 100%;
+    background: var(--cinder-surface-raised);
+    border: 1px solid var(--cinder-border);
+    border-radius: var(--cinder-radius-md);
+    transition:
+      border-color var(--cinder-duration-fast) var(--cinder-ease-standard),
+      box-shadow var(--cinder-duration-fast) var(--cinder-ease-standard);
   }
-}
 
-.cinder-number-input:focus-within {
-  outline: var(--cinder-ring-width) solid transparent;
-  box-shadow:
-    0 0 0 var(--cinder-ring-offset) var(--cinder-ring-offset-color),
-    0 0 0 calc(var(--cinder-ring-offset) + var(--cinder-ring-width))
-      var(--_cinder-input-ring, var(--cinder-ring-color));
-}
+  @media (hover: hover) {
+    .cinder-number-input:hover:not([data-disabled]) {
+      border-color: var(--cinder-border-strong);
+    }
+  }
 
-@media (forced-colors: active) {
   .cinder-number-input:focus-within {
-    outline: var(--cinder-ring-width) solid Highlight;
-    outline-offset: 1px;
+    outline: var(--cinder-ring-width) solid transparent;
+    box-shadow:
+      0 0 0 var(--cinder-ring-offset) var(--cinder-ring-offset-color),
+      0 0 0 calc(var(--cinder-ring-offset) + var(--cinder-ring-width))
+        var(--_cinder-input-ring, var(--cinder-ring-color));
   }
-}
 
-.cinder-number-input[data-disabled] {
-  background: var(--cinder-surface-inset);
-  border-color: var(--cinder-border-muted);
-  cursor: not-allowed;
-}
-
-.cinder-number-input__input.cinder-input {
-  border: none;
-  border-radius: 0;
-  background: transparent;
-  flex: 1 1 auto;
-  min-width: 0;
-  padding-inline-end: var(--cinder-space-2);
-}
-
-.cinder-number-input__input.cinder-input:focus-visible {
-  box-shadow: none;
-  outline: none;
-}
-
-.cinder-number-input__input[aria-invalid='true'] ~ .cinder-number-input__stepper {
-  border-inline-start-color: var(--cinder-danger);
-}
-
-.cinder-number-input:has(.cinder-number-input__input[aria-invalid='true']) {
-  --_cinder-input-ring: var(--cinder-danger);
-  border-color: var(--cinder-danger);
-}
-
-.cinder-number-input__stepper {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  flex: 0 0 auto;
-  inline-size: 2.25rem;
-  padding: 0;
-  background: transparent;
-  border: none;
-  border-inline-start: 1px solid var(--cinder-border);
-  color: var(--cinder-text-muted);
-  font-size: var(--cinder-text-sm);
-  cursor: pointer;
-  appearance: none;
-  transition:
-    background var(--cinder-duration-fast) var(--cinder-ease-standard),
-    color var(--cinder-duration-fast) var(--cinder-ease-standard);
-}
-
-@media (hover: hover) {
-  .cinder-number-input__stepper:hover:not(:disabled) {
-    background: var(--cinder-surface-hover);
-    color: var(--cinder-text);
+  @media (forced-colors: active) {
+    .cinder-number-input:focus-within {
+      outline: var(--cinder-ring-width) solid Highlight;
+      outline-offset: 1px;
+    }
   }
-}
 
-.cinder-number-input__stepper:focus-visible {
-  /* Transparent placeholder keeps the forced-colors outline channel; the visible
+  .cinder-number-input[data-disabled] {
+    background: var(--cinder-surface-inset);
+    border-color: var(--cinder-border-muted);
+    cursor: not-allowed;
+  }
+
+  .cinder-number-input__input.cinder-input {
+    border: none;
+    border-radius: 0;
+    background: transparent;
+    flex: 1 1 auto;
+    min-width: 0;
+    padding-inline-end: var(--cinder-space-2);
+  }
+
+  .cinder-number-input__input.cinder-input:focus-visible {
+    box-shadow: none;
+    outline: none;
+  }
+
+  .cinder-number-input__input[aria-invalid='true'] ~ .cinder-number-input__stepper {
+    border-inline-start-color: var(--cinder-danger);
+  }
+
+  .cinder-number-input:has(.cinder-number-input__input[aria-invalid='true']) {
+    --_cinder-input-ring: var(--cinder-danger);
+    border-color: var(--cinder-danger);
+  }
+
+  .cinder-number-input__stepper {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    flex: 0 0 auto;
+    inline-size: 2.25rem;
+    padding: 0;
+    background: transparent;
+    border: none;
+    border-inline-start: 1px solid var(--cinder-border);
+    color: var(--cinder-text-muted);
+    font-size: var(--cinder-text-sm);
+    cursor: pointer;
+    appearance: none;
+    transition:
+      background var(--cinder-duration-fast) var(--cinder-ease-standard),
+      color var(--cinder-duration-fast) var(--cinder-ease-standard);
+  }
+
+  @media (hover: hover) {
+    .cinder-number-input__stepper:hover:not(:disabled) {
+      background: var(--cinder-surface-hover);
+      color: var(--cinder-text);
+    }
+  }
+
+  .cinder-number-input__stepper:focus-visible {
+    /* Transparent placeholder keeps the forced-colors outline channel; the visible
    * ring is an INSET box-shadow so the focused stepper is individually
    * identifiable. (The outer .cinder-number-input:focus-within ring only signals
    * that *some* child has focus, not which one — and an outset ring here would
    * collide with it.) This is a self-owned ring, distinct from the shared
    * --_cinder-focus-ring-shadow outer-ring recipe used by most controls. */
-  outline: var(--cinder-ring-width) solid transparent;
-  box-shadow: inset 0 0 0 var(--cinder-ring-width) var(--cinder-ring-color);
-  background: var(--cinder-surface-hover);
-  color: var(--cinder-text);
-}
-
-@media (forced-colors: active) {
-  .cinder-number-input__stepper:focus-visible {
-    outline: var(--cinder-ring-width) solid ButtonText;
-    outline-offset: -2px;
+    outline: var(--cinder-ring-width) solid transparent;
+    box-shadow: inset 0 0 0 var(--cinder-ring-width) var(--cinder-ring-color);
+    background: var(--cinder-surface-hover);
+    color: var(--cinder-text);
   }
-}
 
-.cinder-number-input__stepper:disabled {
-  color: var(--cinder-text-disabled);
-  cursor: not-allowed;
-}
+  @media (forced-colors: active) {
+    .cinder-number-input__stepper:focus-visible {
+      outline: var(--cinder-ring-width) solid ButtonText;
+      outline-offset: -2px;
+    }
+  }
 
-@media (pointer: coarse) {
-  .cinder-number-input__stepper {
-    min-inline-size: 2.75rem;
-    min-block-size: 2.75rem;
+  .cinder-number-input__stepper:disabled {
+    color: var(--cinder-text-disabled);
+    cursor: not-allowed;
+  }
+
+  @media (pointer: coarse) {
+    .cinder-number-input__stepper {
+      min-inline-size: 2.75rem;
+      min-block-size: 2.75rem;
+    }
   }
 }

--- a/packages/components/src/components/page-layout/page-layout.css
+++ b/packages/components/src/components/page-layout/page-layout.css
@@ -1,142 +1,144 @@
-/* ========================================
+@layer cinder.components {
+  /* ========================================
  * PAGE LAYOUT
  * ======================================== */
 
-.cinder-page-layout {
-  display: flex;
-  flex-direction: column;
-  min-height: 0;
-  flex: 1 1 0;
-  width: 100%;
-}
+  .cinder-page-layout {
+    display: flex;
+    flex-direction: column;
+    min-height: 0;
+    flex: 1 1 0;
+    width: 100%;
+  }
 
-/* ----------------------------------------
+  /* ----------------------------------------
  * Header
  * ---------------------------------------- */
 
-.cinder-page-layout-header {
-  position: sticky;
-  top: 0;
-  z-index: 10;
-  border-bottom: 1px solid var(--cinder-border-muted);
-  padding-block: var(--cinder-space-3);
-  background: color-mix(in oklch, var(--cinder-surface) 80%, transparent);
-  backdrop-filter: blur(24px);
-}
+  .cinder-page-layout-header {
+    position: sticky;
+    top: 0;
+    z-index: 10;
+    border-bottom: 1px solid var(--cinder-border-muted);
+    padding-block: var(--cinder-space-3);
+    background: color-mix(in oklch, var(--cinder-surface) 80%, transparent);
+    backdrop-filter: blur(24px);
+  }
 
-/* ----------------------------------------
+  /* ----------------------------------------
  * Breadcrumbs row (optional, first row inside sticky header)
  * ---------------------------------------- */
 
-.cinder-page-layout-breadcrumbs {
-  width: 100%;
-  max-width: var(--cinder-content-width);
-  margin-inline: auto;
-  padding-inline: var(--cinder-space-4);
-  padding-block: 0 var(--cinder-space-2);
-}
-
-@media (min-width: 640px) {
   .cinder-page-layout-breadcrumbs {
-    padding-inline: var(--cinder-space-6);
+    width: 100%;
+    max-width: var(--cinder-content-width);
+    margin-inline: auto;
+    padding-inline: var(--cinder-space-4);
+    padding-block: 0 var(--cinder-space-2);
   }
-}
 
-/* ----------------------------------------
+  @media (min-width: 640px) {
+    .cinder-page-layout-breadcrumbs {
+      padding-inline: var(--cinder-space-6);
+    }
+  }
+
+  /* ----------------------------------------
  * Header row: avatar + title column + actions
  * ---------------------------------------- */
 
-.cinder-page-layout-header-row {
-  display: flex;
-  align-items: center;
-  gap: var(--cinder-space-3);
-  /* 2.75rem = 44px — WCAG 2.5.5 minimum touch target row height */
-  min-block-size: 2.75rem;
-  max-width: var(--cinder-content-width);
-  margin-inline: auto;
-  padding-inline: var(--cinder-space-4);
-}
-
-@media (min-width: 640px) {
   .cinder-page-layout-header-row {
-    padding-inline: var(--cinder-space-6);
+    display: flex;
+    align-items: center;
+    gap: var(--cinder-space-3);
+    /* 2.75rem = 44px — WCAG 2.5.5 minimum touch target row height */
+    min-block-size: 2.75rem;
+    max-width: var(--cinder-content-width);
+    margin-inline: auto;
+    padding-inline: var(--cinder-space-4);
   }
-}
 
-/* ----------------------------------------
+  @media (min-width: 640px) {
+    .cinder-page-layout-header-row {
+      padding-inline: var(--cinder-space-6);
+    }
+  }
+
+  /* ----------------------------------------
  * Avatar (optional, inline-start of title column)
  * ---------------------------------------- */
 
-.cinder-page-layout-avatar {
-  display: flex;
-  align-items: center;
-  flex: 0 0 auto;
-}
+  .cinder-page-layout-avatar {
+    display: flex;
+    align-items: center;
+    flex: 0 0 auto;
+  }
 
-/* ----------------------------------------
+  /* ----------------------------------------
  * Title column: heading + optional meta
  * ---------------------------------------- */
 
-.cinder-page-layout-title-column {
-  display: flex;
-  flex-direction: column;
-  gap: var(--cinder-space-1);
-  min-inline-size: 0;
-  flex: 1 1 auto;
-}
+  .cinder-page-layout-title-column {
+    display: flex;
+    flex-direction: column;
+    gap: var(--cinder-space-1);
+    min-inline-size: 0;
+    flex: 1 1 auto;
+  }
 
-.cinder-page-layout-title {
-  font-size: var(--cinder-text-lg);
-  font-weight: var(--cinder-font-semibold);
-  color: var(--cinder-text);
-  margin: 0;
-}
+  .cinder-page-layout-title {
+    font-size: var(--cinder-text-lg);
+    font-weight: var(--cinder-font-semibold);
+    color: var(--cinder-text);
+    margin: 0;
+  }
 
-/* ----------------------------------------
+  /* ----------------------------------------
  * Meta (optional, beneath title)
  * ---------------------------------------- */
 
-.cinder-page-layout-meta {
-  font-size: var(--cinder-text-sm);
-  color: var(--cinder-text-muted);
-}
+  .cinder-page-layout-meta {
+    font-size: var(--cinder-text-sm);
+    color: var(--cinder-text-muted);
+  }
 
-.cinder-page-layout-meta > * {
-  /* Suppress browser default margins on <dl> and other block-level meta elements */
-  margin-block: 0;
-}
+  .cinder-page-layout-meta > * {
+    /* Suppress browser default margins on <dl> and other block-level meta elements */
+    margin-block: 0;
+  }
 
-/* ----------------------------------------
+  /* ----------------------------------------
  * Actions
  * ---------------------------------------- */
 
-.cinder-page-layout-actions {
-  display: flex;
-  align-items: center;
-  gap: var(--cinder-space-2);
-  margin-inline-start: auto;
-  flex: 0 0 auto;
-}
+  .cinder-page-layout-actions {
+    display: flex;
+    align-items: center;
+    gap: var(--cinder-space-2);
+    margin-inline-start: auto;
+    flex: 0 0 auto;
+  }
 
-/* ----------------------------------------
+  /* ----------------------------------------
  * Content
  * ---------------------------------------- */
 
-.cinder-page-layout-content {
-  flex: 1 1 0;
-  min-height: 0;
-  width: 100%;
-  max-width: var(--cinder-content-width);
-  margin-inline: auto;
-  padding-inline: var(--cinder-space-4);
-  padding-block: var(--cinder-space-6);
-  display: flex;
-  flex-direction: column;
-  gap: var(--cinder-space-6);
-}
-
-@media (min-width: 640px) {
   .cinder-page-layout-content {
-    padding-inline: var(--cinder-space-6);
+    flex: 1 1 0;
+    min-height: 0;
+    width: 100%;
+    max-width: var(--cinder-content-width);
+    margin-inline: auto;
+    padding-inline: var(--cinder-space-4);
+    padding-block: var(--cinder-space-6);
+    display: flex;
+    flex-direction: column;
+    gap: var(--cinder-space-6);
+  }
+
+  @media (min-width: 640px) {
+    .cinder-page-layout-content {
+      padding-inline: var(--cinder-space-6);
+    }
   }
 }

--- a/packages/components/src/components/pagination/pagination.css
+++ b/packages/components/src/components/pagination/pagination.css
@@ -1,172 +1,174 @@
-/* ========================================
+@layer cinder.components {
+  /* ========================================
  * PAGINATION
  * ======================================== */
 
-.cinder-pagination {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: var(--cinder-space-4);
-  flex-wrap: wrap;
-}
+  .cinder-pagination {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--cinder-space-4);
+    flex-wrap: wrap;
+  }
 
-/* ----------------------------------------
+  /* ----------------------------------------
  * Result count
  * ---------------------------------------- */
 
-.cinder-pagination__count {
-  margin: 0;
-  font-size: var(--cinder-text-sm);
-  color: var(--cinder-text-muted);
-  white-space: nowrap;
-}
+  .cinder-pagination__count {
+    margin: 0;
+    font-size: var(--cinder-text-sm);
+    color: var(--cinder-text-muted);
+    white-space: nowrap;
+  }
 
-/* ----------------------------------------
+  /* ----------------------------------------
  * Controls row (prev + pages + next)
  * ---------------------------------------- */
 
-.cinder-pagination__controls {
-  display: flex;
-  align-items: center;
-  gap: var(--cinder-space-1);
-}
+  .cinder-pagination__controls {
+    display: flex;
+    align-items: center;
+    gap: var(--cinder-space-1);
+  }
 
-/* ----------------------------------------
+  /* ----------------------------------------
  * Pages list
  * ---------------------------------------- */
 
-.cinder-pagination__pages {
-  display: flex;
-  align-items: center;
-  gap: var(--cinder-space-1);
-}
+  .cinder-pagination__pages {
+    display: flex;
+    align-items: center;
+    gap: var(--cinder-space-1);
+  }
 
-/* ----------------------------------------
+  /* ----------------------------------------
  * Shared button styles (step + page)
  * ---------------------------------------- */
 
-.cinder-pagination__step,
-.cinder-pagination__page {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  min-width: 2.25rem;
-  min-height: 2.25rem;
-  padding: var(--cinder-space-1) var(--cinder-space-2);
+  .cinder-pagination__step,
+  .cinder-pagination__page {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 2.25rem;
+    min-height: 2.25rem;
+    padding: var(--cinder-space-1) var(--cinder-space-2);
 
-  border: 1px solid transparent;
-  border-radius: var(--cinder-radius-md);
-  background: transparent;
-  color: var(--cinder-text);
-  font-size: var(--cinder-text-sm);
-  font-weight: var(--cinder-font-medium);
-  line-height: 1;
-  cursor: pointer;
+    border: 1px solid transparent;
+    border-radius: var(--cinder-radius-md);
+    background: transparent;
+    color: var(--cinder-text);
+    font-size: var(--cinder-text-sm);
+    font-weight: var(--cinder-font-medium);
+    line-height: 1;
+    cursor: pointer;
 
-  transition:
-    background-color var(--cinder-duration-fast) var(--cinder-ease-standard),
-    border-color var(--cinder-duration-fast) var(--cinder-ease-standard),
-    color var(--cinder-duration-fast) var(--cinder-ease-standard),
-    box-shadow var(--cinder-duration-fast) var(--cinder-ease-standard);
-}
+    transition:
+      background-color var(--cinder-duration-fast) var(--cinder-ease-standard),
+      border-color var(--cinder-duration-fast) var(--cinder-ease-standard),
+      color var(--cinder-duration-fast) var(--cinder-ease-standard),
+      box-shadow var(--cinder-duration-fast) var(--cinder-ease-standard);
+  }
 
-/* ----------------------------------------
+  /* ----------------------------------------
  * Hover — non-current, non-disabled
  * ---------------------------------------- */
 
-@media (hover: hover) {
-  .cinder-pagination__step:hover:not(:disabled),
-  .cinder-pagination__page:hover:not([data-cinder-current]) {
-    background: color-mix(in oklch, var(--cinder-text) 8%, transparent);
-    border-color: var(--cinder-border-muted);
+  @media (hover: hover) {
+    .cinder-pagination__step:hover:not(:disabled),
+    .cinder-pagination__page:hover:not([data-cinder-current]) {
+      background: color-mix(in oklch, var(--cinder-text) 8%, transparent);
+      border-color: var(--cinder-border-muted);
+    }
   }
-}
 
-/* ----------------------------------------
+  /* ----------------------------------------
  * Focus ring
  * ---------------------------------------- */
 
-.cinder-pagination__step:focus-visible,
-.cinder-pagination__page:focus-visible {
-  outline: var(--cinder-ring-width) solid transparent;
-  box-shadow: var(--_cinder-focus-ring-shadow);
-}
-
-@media (forced-colors: active) {
   .cinder-pagination__step:focus-visible,
   .cinder-pagination__page:focus-visible {
-    outline: var(--cinder-ring-width) solid ButtonText;
-    outline-offset: 3px;
+    outline: var(--cinder-ring-width) solid transparent;
+    box-shadow: var(--_cinder-focus-ring-shadow);
   }
-}
 
-/* ----------------------------------------
+  @media (forced-colors: active) {
+    .cinder-pagination__step:focus-visible,
+    .cinder-pagination__page:focus-visible {
+      outline: var(--cinder-ring-width) solid ButtonText;
+      outline-offset: 3px;
+    }
+  }
+
+  /* ----------------------------------------
  * Current page
  * ---------------------------------------- */
 
-.cinder-pagination__page[data-cinder-current] {
-  background: var(--cinder-accent);
-  border-color: var(--cinder-accent);
-  color: var(--cinder-accent-contrast, #fff);
-  cursor: default;
-}
+  .cinder-pagination__page[data-cinder-current] {
+    background: var(--cinder-accent);
+    border-color: var(--cinder-accent);
+    color: var(--cinder-accent-contrast, #fff);
+    cursor: default;
+  }
 
-/* ----------------------------------------
+  /* ----------------------------------------
  * Disabled step buttons (prev / next at boundary)
  * ---------------------------------------- */
 
-.cinder-pagination__step:disabled {
-  color: var(--cinder-text-disabled, var(--cinder-text-muted));
-  cursor: not-allowed;
-  pointer-events: none;
-  opacity: 0.4;
-}
-
-/* opacity is ignored under forced colors, so signal the disabled boundary with
-   the GrayText system color instead. */
-@media (forced-colors: active) {
   .cinder-pagination__step:disabled {
-    color: GrayText;
-    opacity: 1;
+    color: var(--cinder-text-disabled, var(--cinder-text-muted));
+    cursor: not-allowed;
+    pointer-events: none;
+    opacity: 0.4;
   }
-}
 
-/* ----------------------------------------
+  /* opacity is ignored under forced colors, so signal the disabled boundary with
+   the GrayText system color instead. */
+  @media (forced-colors: active) {
+    .cinder-pagination__step:disabled {
+      color: GrayText;
+      opacity: 1;
+    }
+  }
+
+  /* ----------------------------------------
  * Ellipsis
  * ---------------------------------------- */
 
-.cinder-pagination__ellipsis {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  padding: 0 var(--cinder-space-1);
-  color: var(--cinder-text-muted);
-  font-size: var(--cinder-text-sm);
-  user-select: none;
-}
+  .cinder-pagination__ellipsis {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0 var(--cinder-space-1);
+    color: var(--cinder-text-muted);
+    font-size: var(--cinder-text-sm);
+    user-select: none;
+  }
 
-/* ----------------------------------------
+  /* ----------------------------------------
  * Responsive: hide page list on very small screens
  * to avoid overflow; prev/next remain accessible
  * ---------------------------------------- */
 
-@media (max-width: 480px) {
-  .cinder-pagination__pages {
-    display: none;
+  @media (max-width: 480px) {
+    .cinder-pagination__pages {
+      display: none;
+    }
+
+    .cinder-pagination {
+      justify-content: center;
+    }
   }
 
-  .cinder-pagination {
-    justify-content: center;
-  }
-}
-
-/* ----------------------------------------
+  /* ----------------------------------------
  * Reduced motion
  * ---------------------------------------- */
 
-@media (prefers-reduced-motion: reduce) {
-  .cinder-pagination__step,
-  .cinder-pagination__page {
-    transition: none;
+  @media (prefers-reduced-motion: reduce) {
+    .cinder-pagination__step,
+    .cinder-pagination__page {
+      transition: none;
+    }
   }
 }

--- a/packages/components/src/components/phone-input/phone-input.css
+++ b/packages/components/src/components/phone-input/phone-input.css
@@ -1,116 +1,118 @@
-/* ========================================
+@layer cinder.components {
+  /* ========================================
  * PHONE INPUT
  * ======================================== */
 
-.cinder-phone-input-field {
-  display: flex;
-  flex-direction: column;
-  gap: var(--cinder-space-1-5);
-  inline-size: 100%;
-}
-
-.cinder-phone-input-field__label {
-  display: inline-flex;
-  align-items: center;
-  gap: var(--cinder-space-1);
-  font-size: var(--cinder-text-xs);
-  font-weight: var(--cinder-font-medium);
-  line-height: 1;
-  color: var(--cinder-text);
-}
-
-.cinder-phone-input-field__label[data-disabled] {
-  color: var(--cinder-text-disabled);
-  cursor: not-allowed;
-}
-
-.cinder-phone-input {
-  display: grid;
-  grid-template-columns: minmax(7rem, max-content) 1fr;
-  gap: var(--cinder-space-2);
-  align-items: stretch;
-}
-
-.cinder-phone-input__country,
-.cinder-phone-input__national {
-  min-height: 2.25rem;
-  padding: var(--cinder-space-1-5) var(--cinder-space-3);
-  font-family: inherit;
-  font-size: var(--cinder-text-sm);
-  line-height: var(--cinder-leading-normal);
-  color: var(--cinder-text);
-  background: var(--cinder-surface-raised);
-  border: 1px solid var(--cinder-border);
-  border-radius: var(--cinder-radius-md);
-  appearance: none;
-
-  transition:
-    border-color var(--cinder-duration-fast) var(--cinder-ease-standard),
-    box-shadow var(--cinder-duration-fast) var(--cinder-ease-standard);
-}
-
-.cinder-phone-input__country {
-  cursor: pointer;
-  padding-inline-end: var(--cinder-space-6);
-  background-image:
-    linear-gradient(45deg, transparent 50%, currentColor 50%),
-    linear-gradient(135deg, currentColor 50%, transparent 50%);
-  background-position:
-    calc(100% - 18px) 50%,
-    calc(100% - 12px) 50%;
-  background-size:
-    6px 6px,
-    6px 6px;
-  background-repeat: no-repeat;
-}
-
-.cinder-phone-input__country::-ms-expand {
-  display: none;
-}
-
-@media (hover: hover) {
-  .cinder-phone-input__country:hover:not(:disabled),
-  .cinder-phone-input__national:hover:not(:disabled) {
-    border-color: var(--cinder-border-strong);
+  .cinder-phone-input-field {
+    display: flex;
+    flex-direction: column;
+    gap: var(--cinder-space-1-5);
+    inline-size: 100%;
   }
-}
 
-.cinder-phone-input__country:focus-visible,
-.cinder-phone-input__national:focus-visible {
-  outline: var(--cinder-ring-width) solid transparent;
-  box-shadow: var(--_cinder-focus-ring-shadow);
-  border-color: var(--cinder-border-strong);
-}
+  .cinder-phone-input-field__label {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--cinder-space-1);
+    font-size: var(--cinder-text-xs);
+    font-weight: var(--cinder-font-medium);
+    line-height: 1;
+    color: var(--cinder-text);
+  }
 
-.cinder-phone-input__country[aria-invalid='true'],
-.cinder-phone-input__national[aria-invalid='true'],
-.cinder-phone-input[aria-invalid='true'] .cinder-phone-input__country,
-.cinder-phone-input[aria-invalid='true'] .cinder-phone-input__national {
-  border-color: var(--cinder-danger);
-}
+  .cinder-phone-input-field__label[data-disabled] {
+    color: var(--cinder-text-disabled);
+    cursor: not-allowed;
+  }
 
-.cinder-phone-input__country:disabled,
-.cinder-phone-input__national:disabled {
-  cursor: not-allowed;
-  color: var(--cinder-text-disabled);
-  background-color: var(--cinder-surface-muted);
-}
+  .cinder-phone-input {
+    display: grid;
+    grid-template-columns: minmax(7rem, max-content) 1fr;
+    gap: var(--cinder-space-2);
+    align-items: stretch;
+  }
 
-@media (forced-colors: active) {
+  .cinder-phone-input__country,
+  .cinder-phone-input__national {
+    min-height: 2.25rem;
+    padding: var(--cinder-space-1-5) var(--cinder-space-3);
+    font-family: inherit;
+    font-size: var(--cinder-text-sm);
+    line-height: var(--cinder-leading-normal);
+    color: var(--cinder-text);
+    background: var(--cinder-surface-raised);
+    border: 1px solid var(--cinder-border);
+    border-radius: var(--cinder-radius-md);
+    appearance: none;
+
+    transition:
+      border-color var(--cinder-duration-fast) var(--cinder-ease-standard),
+      box-shadow var(--cinder-duration-fast) var(--cinder-ease-standard);
+  }
+
+  .cinder-phone-input__country {
+    cursor: pointer;
+    padding-inline-end: var(--cinder-space-6);
+    background-image:
+      linear-gradient(45deg, transparent 50%, currentColor 50%),
+      linear-gradient(135deg, currentColor 50%, transparent 50%);
+    background-position:
+      calc(100% - 18px) 50%,
+      calc(100% - 12px) 50%;
+    background-size:
+      6px 6px,
+      6px 6px;
+    background-repeat: no-repeat;
+  }
+
+  .cinder-phone-input__country::-ms-expand {
+    display: none;
+  }
+
+  @media (hover: hover) {
+    .cinder-phone-input__country:hover:not(:disabled),
+    .cinder-phone-input__national:hover:not(:disabled) {
+      border-color: var(--cinder-border-strong);
+    }
+  }
+
   .cinder-phone-input__country:focus-visible,
   .cinder-phone-input__national:focus-visible {
-    outline: var(--cinder-ring-width) solid Highlight;
+    outline: var(--cinder-ring-width) solid transparent;
+    box-shadow: var(--_cinder-focus-ring-shadow);
+    border-color: var(--cinder-border-strong);
   }
-}
 
-.cinder-phone-input-field__description {
-  margin: 0;
-  font-size: var(--cinder-text-xs);
-  color: var(--cinder-text-muted);
-}
+  .cinder-phone-input__country[aria-invalid='true'],
+  .cinder-phone-input__national[aria-invalid='true'],
+  .cinder-phone-input[aria-invalid='true'] .cinder-phone-input__country,
+  .cinder-phone-input[aria-invalid='true'] .cinder-phone-input__national {
+    border-color: var(--cinder-danger);
+  }
 
-.cinder-phone-input-field__error {
-  margin: 0;
-  font-size: var(--cinder-text-xs);
-  color: var(--cinder-danger);
+  .cinder-phone-input__country:disabled,
+  .cinder-phone-input__national:disabled {
+    cursor: not-allowed;
+    color: var(--cinder-text-disabled);
+    background-color: var(--cinder-surface-muted);
+  }
+
+  @media (forced-colors: active) {
+    .cinder-phone-input__country:focus-visible,
+    .cinder-phone-input__national:focus-visible {
+      outline: var(--cinder-ring-width) solid Highlight;
+    }
+  }
+
+  .cinder-phone-input-field__description {
+    margin: 0;
+    font-size: var(--cinder-text-xs);
+    color: var(--cinder-text-muted);
+  }
+
+  .cinder-phone-input-field__error {
+    margin: 0;
+    font-size: var(--cinder-text-xs);
+    color: var(--cinder-danger);
+  }
 }

--- a/packages/components/src/components/pin-input/pin-input.css
+++ b/packages/components/src/components/pin-input/pin-input.css
@@ -1,91 +1,93 @@
-/* ========================================
+@layer cinder.components {
+  /* ========================================
  * PIN INPUT
  * ======================================== */
 
-.cinder-pin-input-field {
-  display: flex;
-  flex-direction: column;
-  gap: var(--cinder-space-1-5);
-  inline-size: max-content;
-}
+  .cinder-pin-input-field {
+    display: flex;
+    flex-direction: column;
+    gap: var(--cinder-space-1-5);
+    inline-size: max-content;
+  }
 
-.cinder-pin-input-field__label {
-  display: inline-flex;
-  align-items: center;
-  gap: var(--cinder-space-1);
-  font-size: var(--cinder-text-xs);
-  font-weight: var(--cinder-font-medium);
-  line-height: 1;
-  color: var(--cinder-text);
-}
+  .cinder-pin-input-field__label {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--cinder-space-1);
+    font-size: var(--cinder-text-xs);
+    font-weight: var(--cinder-font-medium);
+    line-height: 1;
+    color: var(--cinder-text);
+  }
 
-.cinder-pin-input-field__label[data-disabled] {
-  color: var(--cinder-text-disabled);
-  cursor: not-allowed;
-}
+  .cinder-pin-input-field__label[data-disabled] {
+    color: var(--cinder-text-disabled);
+    cursor: not-allowed;
+  }
 
-.cinder-pin-input {
-  display: inline-flex;
-  align-items: center;
-  gap: var(--cinder-space-2);
-}
+  .cinder-pin-input {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--cinder-space-2);
+  }
 
-.cinder-pin-input__segment {
-  inline-size: 2.5rem;
-  block-size: 3rem;
-  padding: 0;
-  font-family: var(--cinder-font-mono, ui-monospace, monospace);
-  font-size: var(--cinder-text-lg);
-  font-weight: var(--cinder-font-medium);
-  line-height: 1;
-  text-align: center;
-  color: var(--cinder-text);
-  background: var(--cinder-surface-raised);
-  border: 1px solid var(--cinder-border);
-  border-radius: var(--cinder-radius-md);
-  appearance: none;
+  .cinder-pin-input__segment {
+    inline-size: 2.5rem;
+    block-size: 3rem;
+    padding: 0;
+    font-family: var(--cinder-font-mono, ui-monospace, monospace);
+    font-size: var(--cinder-text-lg);
+    font-weight: var(--cinder-font-medium);
+    line-height: 1;
+    text-align: center;
+    color: var(--cinder-text);
+    background: var(--cinder-surface-raised);
+    border: 1px solid var(--cinder-border);
+    border-radius: var(--cinder-radius-md);
+    appearance: none;
 
-  transition:
-    border-color var(--cinder-duration-fast) var(--cinder-ease-standard),
-    box-shadow var(--cinder-duration-fast) var(--cinder-ease-standard);
-}
+    transition:
+      border-color var(--cinder-duration-fast) var(--cinder-ease-standard),
+      box-shadow var(--cinder-duration-fast) var(--cinder-ease-standard);
+  }
 
-@media (hover: hover) {
-  .cinder-pin-input__segment:hover:not(:disabled) {
+  @media (hover: hover) {
+    .cinder-pin-input__segment:hover:not(:disabled) {
+      border-color: var(--cinder-border-strong);
+    }
+  }
+
+  .cinder-pin-input__segment:focus-visible {
+    outline: var(--cinder-ring-width) solid transparent;
+    box-shadow: var(--_cinder-focus-ring-shadow);
     border-color: var(--cinder-border-strong);
   }
-}
 
-.cinder-pin-input__segment:focus-visible {
-  outline: var(--cinder-ring-width) solid transparent;
-  box-shadow: var(--_cinder-focus-ring-shadow);
-  border-color: var(--cinder-border-strong);
-}
-
-.cinder-pin-input__segment[aria-invalid='true'] {
-  border-color: var(--cinder-danger);
-}
-
-.cinder-pin-input__segment:disabled {
-  cursor: not-allowed;
-  color: var(--cinder-text-disabled);
-  background: var(--cinder-surface-muted);
-}
-
-@media (forced-colors: active) {
-  .cinder-pin-input__segment:focus-visible {
-    outline: var(--cinder-ring-width) solid Highlight;
+  .cinder-pin-input__segment[aria-invalid='true'] {
+    border-color: var(--cinder-danger);
   }
-}
 
-.cinder-pin-input-field__description {
-  margin: 0;
-  font-size: var(--cinder-text-xs);
-  color: var(--cinder-text-muted);
-}
+  .cinder-pin-input__segment:disabled {
+    cursor: not-allowed;
+    color: var(--cinder-text-disabled);
+    background: var(--cinder-surface-muted);
+  }
 
-.cinder-pin-input-field__error {
-  margin: 0;
-  font-size: var(--cinder-text-xs);
-  color: var(--cinder-danger);
+  @media (forced-colors: active) {
+    .cinder-pin-input__segment:focus-visible {
+      outline: var(--cinder-ring-width) solid Highlight;
+    }
+  }
+
+  .cinder-pin-input-field__description {
+    margin: 0;
+    font-size: var(--cinder-text-xs);
+    color: var(--cinder-text-muted);
+  }
+
+  .cinder-pin-input-field__error {
+    margin: 0;
+    font-size: var(--cinder-text-xs);
+    color: var(--cinder-danger);
+  }
 }

--- a/packages/components/src/components/popover/popover.css
+++ b/packages/components/src/components/popover/popover.css
@@ -1,139 +1,141 @@
-.cinder-popover {
-  position: fixed;
-  left: 0;
-  top: 0;
-  z-index: var(--cinder-z-popover);
-  min-width: 10rem;
-  max-width: min(90vw, 28rem);
-  padding: var(--cinder-space-3);
-  border: 1px solid var(--cinder-border);
-  border-radius: var(--cinder-radius-md);
-  background: var(--cinder-surface);
-  color: var(--cinder-text);
-  box-shadow: var(--cinder-shadow-lg);
-  opacity: 1;
-  transition: opacity var(--cinder-duration-fast, 120ms) var(--cinder-ease-standard, ease-out);
-}
+@layer cinder.components {
+  .cinder-popover {
+    position: fixed;
+    left: 0;
+    top: 0;
+    z-index: var(--cinder-z-popover);
+    min-width: 10rem;
+    max-width: min(90vw, 28rem);
+    padding: var(--cinder-space-3);
+    border: 1px solid var(--cinder-border);
+    border-radius: var(--cinder-radius-md);
+    background: var(--cinder-surface);
+    color: var(--cinder-text);
+    box-shadow: var(--cinder-shadow-lg);
+    opacity: 1;
+    transition: opacity var(--cinder-duration-fast, 120ms) var(--cinder-ease-standard, ease-out);
+  }
 
-.cinder-popover:focus-visible {
-  outline: var(--cinder-ring-width, 2px) solid var(--cinder-ring-color, currentColor);
-  outline-offset: 2px;
-}
+  .cinder-popover:focus-visible {
+    outline: var(--cinder-ring-width, 2px) solid var(--cinder-ring-color, currentColor);
+    outline-offset: 2px;
+  }
 
-.cinder-popover[data-cinder-position-ready='false'] {
-  visibility: hidden;
-  pointer-events: none;
-  opacity: 0;
-}
+  .cinder-popover[data-cinder-position-ready='false'] {
+    visibility: hidden;
+    pointer-events: none;
+    opacity: 0;
+  }
 
-.cinder-popover__trigger {
-  display: contents;
-}
+  .cinder-popover__trigger {
+    display: contents;
+  }
 
-.cinder-popover__arrow {
-  position: absolute;
-  pointer-events: none;
-  width: 0;
-  height: 0;
-}
+  .cinder-popover__arrow {
+    position: absolute;
+    pointer-events: none;
+    width: 0;
+    height: 0;
+  }
 
-/* Panel is BELOW trigger - arrow tip points UP.
+  /* Panel is BELOW trigger - arrow tip points UP.
    Floating UI's arrow middleware writes `left` directly to center the
    border-box (offsetWidth=16 because of the 8px L+R borders) on the
    reference. Do not add a negative margin — that would double-shift it. */
-.cinder-popover[data-cinder-placement^='bottom'] .cinder-popover__arrow {
-  top: -8px;
-  /* stylelint-disable csstools/use-logical */
-  border-left: 8px solid transparent;
-  border-right: 8px solid transparent;
-  border-bottom: 8px solid var(--cinder-border);
-  /* stylelint-enable csstools/use-logical */
-}
+  .cinder-popover[data-cinder-placement^='bottom'] .cinder-popover__arrow {
+    top: -8px;
+    /* stylelint-disable csstools/use-logical */
+    border-left: 8px solid transparent;
+    border-right: 8px solid transparent;
+    border-bottom: 8px solid var(--cinder-border);
+    /* stylelint-enable csstools/use-logical */
+  }
 
-.cinder-popover[data-cinder-placement^='bottom'] .cinder-popover__arrow::after {
-  content: '';
-  position: absolute;
-  /* stylelint-disable csstools/use-logical */
-  left: -7px;
-  top: 2px;
-  border-left: 7px solid transparent;
-  border-right: 7px solid transparent;
-  border-bottom: 7px solid var(--cinder-surface);
-  /* stylelint-enable csstools/use-logical */
-}
+  .cinder-popover[data-cinder-placement^='bottom'] .cinder-popover__arrow::after {
+    content: '';
+    position: absolute;
+    /* stylelint-disable csstools/use-logical */
+    left: -7px;
+    top: 2px;
+    border-left: 7px solid transparent;
+    border-right: 7px solid transparent;
+    border-bottom: 7px solid var(--cinder-surface);
+    /* stylelint-enable csstools/use-logical */
+  }
 
-/* Panel is ABOVE trigger - arrow tip points DOWN. See bottom-placement
+  /* Panel is ABOVE trigger - arrow tip points DOWN. See bottom-placement
    note above re: Floating UI offsetWidth centering. */
-.cinder-popover[data-cinder-placement^='top'] .cinder-popover__arrow {
-  bottom: -8px;
-  /* stylelint-disable csstools/use-logical */
-  border-left: 8px solid transparent;
-  border-right: 8px solid transparent;
-  border-top: 8px solid var(--cinder-border);
-  /* stylelint-enable csstools/use-logical */
-}
+  .cinder-popover[data-cinder-placement^='top'] .cinder-popover__arrow {
+    bottom: -8px;
+    /* stylelint-disable csstools/use-logical */
+    border-left: 8px solid transparent;
+    border-right: 8px solid transparent;
+    border-top: 8px solid var(--cinder-border);
+    /* stylelint-enable csstools/use-logical */
+  }
 
-.cinder-popover[data-cinder-placement^='top'] .cinder-popover__arrow::after {
-  content: '';
-  position: absolute;
-  /* stylelint-disable csstools/use-logical */
-  left: -7px;
-  bottom: 2px;
-  border-left: 7px solid transparent;
-  border-right: 7px solid transparent;
-  border-top: 7px solid var(--cinder-surface);
-  /* stylelint-enable csstools/use-logical */
-}
+  .cinder-popover[data-cinder-placement^='top'] .cinder-popover__arrow::after {
+    content: '';
+    position: absolute;
+    /* stylelint-disable csstools/use-logical */
+    left: -7px;
+    bottom: 2px;
+    border-left: 7px solid transparent;
+    border-right: 7px solid transparent;
+    border-top: 7px solid var(--cinder-surface);
+    /* stylelint-enable csstools/use-logical */
+  }
 
-/* Panel is to the RIGHT of trigger - arrow tip points LEFT.
+  /* Panel is to the RIGHT of trigger - arrow tip points LEFT.
    Floating UI writes `top` directly to center the border-box on the
    reference vertically (offsetHeight=16); no negative margin needed. */
-.cinder-popover[data-cinder-placement^='right'] .cinder-popover__arrow {
-  left: -8px;
-  /* stylelint-disable csstools/use-logical */
-  border-top: 8px solid transparent;
-  border-bottom: 8px solid transparent;
-  border-right: 8px solid var(--cinder-border);
-  /* stylelint-enable csstools/use-logical */
-}
+  .cinder-popover[data-cinder-placement^='right'] .cinder-popover__arrow {
+    left: -8px;
+    /* stylelint-disable csstools/use-logical */
+    border-top: 8px solid transparent;
+    border-bottom: 8px solid transparent;
+    border-right: 8px solid var(--cinder-border);
+    /* stylelint-enable csstools/use-logical */
+  }
 
-.cinder-popover[data-cinder-placement^='right'] .cinder-popover__arrow::after {
-  content: '';
-  position: absolute;
-  /* stylelint-disable csstools/use-logical */
-  left: 2px;
-  top: -7px;
-  border-top: 7px solid transparent;
-  border-bottom: 7px solid transparent;
-  border-right: 7px solid var(--cinder-surface);
-  /* stylelint-enable csstools/use-logical */
-}
+  .cinder-popover[data-cinder-placement^='right'] .cinder-popover__arrow::after {
+    content: '';
+    position: absolute;
+    /* stylelint-disable csstools/use-logical */
+    left: 2px;
+    top: -7px;
+    border-top: 7px solid transparent;
+    border-bottom: 7px solid transparent;
+    border-right: 7px solid var(--cinder-surface);
+    /* stylelint-enable csstools/use-logical */
+  }
 
-/* Panel is to the LEFT of trigger - arrow tip points RIGHT. See
+  /* Panel is to the LEFT of trigger - arrow tip points RIGHT. See
    right-placement note above re: Floating UI offsetHeight centering. */
-.cinder-popover[data-cinder-placement^='left'] .cinder-popover__arrow {
-  right: -8px;
-  /* stylelint-disable csstools/use-logical */
-  border-top: 8px solid transparent;
-  border-bottom: 8px solid transparent;
-  border-left: 8px solid var(--cinder-border);
-  /* stylelint-enable csstools/use-logical */
-}
+  .cinder-popover[data-cinder-placement^='left'] .cinder-popover__arrow {
+    right: -8px;
+    /* stylelint-disable csstools/use-logical */
+    border-top: 8px solid transparent;
+    border-bottom: 8px solid transparent;
+    border-left: 8px solid var(--cinder-border);
+    /* stylelint-enable csstools/use-logical */
+  }
 
-.cinder-popover[data-cinder-placement^='left'] .cinder-popover__arrow::after {
-  content: '';
-  position: absolute;
-  /* stylelint-disable csstools/use-logical */
-  right: 2px;
-  top: -7px;
-  border-top: 7px solid transparent;
-  border-bottom: 7px solid transparent;
-  border-left: 7px solid var(--cinder-surface);
-  /* stylelint-enable csstools/use-logical */
-}
+  .cinder-popover[data-cinder-placement^='left'] .cinder-popover__arrow::after {
+    content: '';
+    position: absolute;
+    /* stylelint-disable csstools/use-logical */
+    right: 2px;
+    top: -7px;
+    border-top: 7px solid transparent;
+    border-bottom: 7px solid transparent;
+    border-left: 7px solid var(--cinder-surface);
+    /* stylelint-enable csstools/use-logical */
+  }
 
-@media (prefers-reduced-motion: reduce) {
-  .cinder-popover {
-    transition: none;
+  @media (prefers-reduced-motion: reduce) {
+    .cinder-popover {
+      transition: none;
+    }
   }
 }

--- a/packages/components/src/components/progress/progress.css
+++ b/packages/components/src/components/progress/progress.css
@@ -1,147 +1,149 @@
-/* ========================================
+@layer cinder.components {
+  /* ========================================
  * PROGRESS
  * Bar and ring variants with determinate / indeterminate states.
  * Reduced-motion: indeterminate animation is fully suppressed (no looping
  * motion); determinate value transitions become instant.
  * ======================================== */
 
-.cinder-progress {
-  display: inline-flex;
-  align-items: center;
-}
+  .cinder-progress {
+    display: inline-flex;
+    align-items: center;
+  }
 
-/* ----------------------------------------
+  /* ----------------------------------------
  * Bar variant
  * ---------------------------------------- */
 
-.cinder-progress--bar {
-  width: 100%;
-}
-
-.cinder-progress--bar .cinder-progress__track {
-  width: 100%;
-  background: var(--cinder-surface-inset);
-  border-radius: var(--cinder-radius-full);
-  overflow: hidden;
-}
-
-.cinder-progress--bar[data-cinder-size='sm'] .cinder-progress__track {
-  height: 0.25rem;
-}
-
-.cinder-progress--bar[data-cinder-size='md'] .cinder-progress__track {
-  height: 0.5rem;
-}
-
-.cinder-progress--bar[data-cinder-size='lg'] .cinder-progress__track {
-  height: 0.75rem;
-}
-
-.cinder-progress--bar .cinder-progress__fill {
-  height: 100%;
-  background: var(--cinder-accent);
-  border-radius: inherit;
-  transition: width var(--cinder-duration-moderate) var(--cinder-ease-in-out);
-}
-
-@media (prefers-reduced-motion: reduce) {
-  .cinder-progress--bar .cinder-progress__fill {
-    transition: none;
-  }
-}
-
-.cinder-progress--bar .cinder-progress__fill--indeterminate {
-  width: 30%;
-  animation: cinder-progress-bar-slide var(--cinder-duration-progress-bar-indeterminate) linear
-    infinite;
-}
-
-@keyframes cinder-progress-bar-slide {
-  from {
-    transform: translateX(-100%);
-  }
-  to {
-    transform: translateX(400%);
-  }
-}
-
-@media (prefers-reduced-motion: reduce) {
-  .cinder-progress--bar .cinder-progress__fill--indeterminate {
-    animation: none;
+  .cinder-progress--bar {
     width: 100%;
-    opacity: 0.5;
   }
-}
 
-/* ----------------------------------------
+  .cinder-progress--bar .cinder-progress__track {
+    width: 100%;
+    background: var(--cinder-surface-inset);
+    border-radius: var(--cinder-radius-full);
+    overflow: hidden;
+  }
+
+  .cinder-progress--bar[data-cinder-size='sm'] .cinder-progress__track {
+    height: 0.25rem;
+  }
+
+  .cinder-progress--bar[data-cinder-size='md'] .cinder-progress__track {
+    height: 0.5rem;
+  }
+
+  .cinder-progress--bar[data-cinder-size='lg'] .cinder-progress__track {
+    height: 0.75rem;
+  }
+
+  .cinder-progress--bar .cinder-progress__fill {
+    height: 100%;
+    background: var(--cinder-accent);
+    border-radius: inherit;
+    transition: width var(--cinder-duration-moderate) var(--cinder-ease-in-out);
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .cinder-progress--bar .cinder-progress__fill {
+      transition: none;
+    }
+  }
+
+  .cinder-progress--bar .cinder-progress__fill--indeterminate {
+    width: 30%;
+    animation: cinder-progress-bar-slide var(--cinder-duration-progress-bar-indeterminate) linear
+      infinite;
+  }
+
+  @keyframes cinder-progress-bar-slide {
+    from {
+      transform: translateX(-100%);
+    }
+    to {
+      transform: translateX(400%);
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .cinder-progress--bar .cinder-progress__fill--indeterminate {
+      animation: none;
+      width: 100%;
+      opacity: 0.5;
+    }
+  }
+
+  /* ----------------------------------------
  * Ring variant
  * ---------------------------------------- */
 
-.cinder-progress--ring[data-cinder-size='sm'] .cinder-progress__svg {
-  width: 1.25rem;
-  height: 1.25rem;
-}
+  .cinder-progress--ring[data-cinder-size='sm'] .cinder-progress__svg {
+    width: 1.25rem;
+    height: 1.25rem;
+  }
 
-.cinder-progress--ring[data-cinder-size='md'] .cinder-progress__svg {
-  width: 2rem;
-  height: 2rem;
-}
+  .cinder-progress--ring[data-cinder-size='md'] .cinder-progress__svg {
+    width: 2rem;
+    height: 2rem;
+  }
 
-.cinder-progress--ring[data-cinder-size='lg'] .cinder-progress__svg {
-  width: 2.75rem;
-  height: 2.75rem;
-}
+  .cinder-progress--ring[data-cinder-size='lg'] .cinder-progress__svg {
+    width: 2.75rem;
+    height: 2.75rem;
+  }
 
-.cinder-progress--ring .cinder-progress__svg {
-  transform: rotate(-90deg);
-}
+  .cinder-progress--ring .cinder-progress__svg {
+    transform: rotate(-90deg);
+  }
 
-.cinder-progress--ring .cinder-progress__track,
-.cinder-progress--ring .cinder-progress__fill {
-  fill: none;
-  stroke-width: 3;
-}
-
-.cinder-progress--ring .cinder-progress__track {
-  stroke: var(--cinder-surface-inset);
-}
-
-.cinder-progress--ring .cinder-progress__fill {
-  stroke: var(--cinder-accent);
-  stroke-linecap: round;
-  /* circumference = 2 * pi * 16 ≈ 100.53 */
-  stroke-dasharray: 100.53;
-  stroke-dashoffset: calc(100.53 - (var(--_cinder-progress-percent, 0) * 1.0053));
-  transition: stroke-dashoffset var(--cinder-duration-moderate) var(--cinder-ease-in-out);
-}
-
-@media (prefers-reduced-motion: reduce) {
+  .cinder-progress--ring .cinder-progress__track,
   .cinder-progress--ring .cinder-progress__fill {
-    transition: none;
+    fill: none;
+    stroke-width: 3;
   }
-}
 
-.cinder-progress--ring .cinder-progress__fill--indeterminate {
-  stroke-dasharray: 25 75;
-  stroke-dashoffset: 0;
-  animation: cinder-progress-ring-spin var(--cinder-duration-progress-ring-spin) linear infinite;
-  transform-origin: 18px 18px;
-}
-
-@keyframes cinder-progress-ring-spin {
-  from {
-    transform: rotate(0deg);
+  .cinder-progress--ring .cinder-progress__track {
+    stroke: var(--cinder-surface-inset);
   }
-  to {
-    transform: rotate(360deg);
-  }
-}
 
-@media (prefers-reduced-motion: reduce) {
-  .cinder-progress--ring .cinder-progress__fill--indeterminate {
-    animation: none;
+  .cinder-progress--ring .cinder-progress__fill {
+    stroke: var(--cinder-accent);
+    stroke-linecap: round;
+    /* circumference = 2 * pi * 16 ≈ 100.53 */
     stroke-dasharray: 100.53;
+    stroke-dashoffset: calc(100.53 - (var(--_cinder-progress-percent, 0) * 1.0053));
+    transition: stroke-dashoffset var(--cinder-duration-moderate) var(--cinder-ease-in-out);
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .cinder-progress--ring .cinder-progress__fill {
+      transition: none;
+    }
+  }
+
+  .cinder-progress--ring .cinder-progress__fill--indeterminate {
+    stroke-dasharray: 25 75;
     stroke-dashoffset: 0;
-    opacity: 0.5;
+    animation: cinder-progress-ring-spin var(--cinder-duration-progress-ring-spin) linear infinite;
+    transform-origin: 18px 18px;
+  }
+
+  @keyframes cinder-progress-ring-spin {
+    from {
+      transform: rotate(0deg);
+    }
+    to {
+      transform: rotate(360deg);
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .cinder-progress--ring .cinder-progress__fill--indeterminate {
+      animation: none;
+      stroke-dasharray: 100.53;
+      stroke-dashoffset: 0;
+      opacity: 0.5;
+    }
   }
 }

--- a/packages/components/src/components/radio-group/radio-group.css
+++ b/packages/components/src/components/radio-group/radio-group.css
@@ -1,275 +1,277 @@
-/* ========================================
+@layer cinder.components {
+  /* ========================================
  * RADIO GROUP
  * Fieldset wrapper + child Radio rows.
  * ======================================== */
 
-.cinder-radio-group {
-  border: none;
-  margin: 0;
-  padding: 0;
-  display: flex;
-  flex-direction: column;
-  gap: var(--cinder-space-2);
-}
+  .cinder-radio-group {
+    border: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: var(--cinder-space-2);
+  }
 
-.cinder-radio-group__legend {
-  font-size: var(--cinder-text-xs);
-  font-weight: var(--cinder-font-medium);
-  color: var(--cinder-text);
-  padding: 0;
-  margin: 0 0 var(--cinder-space-1) 0;
-}
+  .cinder-radio-group__legend {
+    font-size: var(--cinder-text-xs);
+    font-weight: var(--cinder-font-medium);
+    color: var(--cinder-text);
+    padding: 0;
+    margin: 0 0 var(--cinder-space-1) 0;
+  }
 
-.cinder-radio-group[data-cinder-disabled] .cinder-radio-group__legend {
-  color: var(--cinder-text-disabled);
-}
+  .cinder-radio-group[data-cinder-disabled] .cinder-radio-group__legend {
+    color: var(--cinder-text-disabled);
+  }
 
-.cinder-radio-group__items {
-  display: flex;
-  flex-direction: column;
-  gap: var(--cinder-space-2);
-}
+  .cinder-radio-group__items {
+    display: flex;
+    flex-direction: column;
+    gap: var(--cinder-space-2);
+  }
 
-.cinder-radio-group__description {
-  font-size: var(--cinder-text-xs);
-  line-height: var(--cinder-leading-normal);
-  color: var(--cinder-text-muted);
-  margin: 0;
-}
+  .cinder-radio-group__description {
+    font-size: var(--cinder-text-xs);
+    line-height: var(--cinder-leading-normal);
+    color: var(--cinder-text-muted);
+    margin: 0;
+  }
 
-.cinder-radio-group__error {
-  font-size: var(--cinder-text-xs);
-  line-height: var(--cinder-leading-normal);
-  color: var(--cinder-danger);
-  margin: 0;
-}
+  .cinder-radio-group__error {
+    font-size: var(--cinder-text-xs);
+    line-height: var(--cinder-leading-normal);
+    color: var(--cinder-danger);
+    margin: 0;
+  }
 
-/* ========================================
+  /* ========================================
  * RADIO ROW + INPUT
  * ======================================== */
 
-.cinder-radio-row {
-  display: inline-flex;
-  align-items: center;
-  gap: var(--cinder-space-2);
-}
+  .cinder-radio-row {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--cinder-space-2);
+  }
 
-.cinder-radio {
-  appearance: none;
-  width: 1.125rem;
-  height: 1.125rem;
-  margin: 0;
-  border: 1px solid var(--cinder-border);
-  border-radius: var(--cinder-radius-full);
-  background: var(--cinder-surface-raised);
-  cursor: pointer;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  flex-shrink: 0;
-  transition:
-    border-color var(--cinder-duration-fast) var(--cinder-ease-standard),
-    background var(--cinder-duration-fast) var(--cinder-ease-standard),
-    box-shadow var(--cinder-duration-fast) var(--cinder-ease-standard);
-}
+  .cinder-radio {
+    appearance: none;
+    width: 1.125rem;
+    height: 1.125rem;
+    margin: 0;
+    border: 1px solid var(--cinder-border);
+    border-radius: var(--cinder-radius-full);
+    background: var(--cinder-surface-raised);
+    cursor: pointer;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+    transition:
+      border-color var(--cinder-duration-fast) var(--cinder-ease-standard),
+      background var(--cinder-duration-fast) var(--cinder-ease-standard),
+      box-shadow var(--cinder-duration-fast) var(--cinder-ease-standard);
+  }
 
-/* Sticky-hover suppression on touch: wrap hover-only chrome so it doesn't
+  /* Sticky-hover suppression on touch: wrap hover-only chrome so it doesn't
  * "stick" after tap on touch devices that emulate :hover. */
-@media (hover: hover) {
-  .cinder-radio:hover:not(:disabled) {
-    border-color: var(--cinder-border-strong);
+  @media (hover: hover) {
+    .cinder-radio:hover:not(:disabled) {
+      border-color: var(--cinder-border-strong);
+    }
   }
-}
 
-.cinder-radio:focus-visible {
-  outline: var(--cinder-ring-width) solid transparent;
-  box-shadow:
-    0 0 0 var(--cinder-ring-offset) var(--cinder-ring-offset-color),
-    0 0 0 calc(var(--cinder-ring-offset) + var(--cinder-ring-width))
-      var(--_cinder-radio-ring, var(--cinder-ring-color));
-}
-
-@media (forced-colors: active) {
   .cinder-radio:focus-visible {
-    outline: var(--cinder-ring-width) solid Highlight;
-    outline-offset: 1px;
+    outline: var(--cinder-ring-width) solid transparent;
+    box-shadow:
+      0 0 0 var(--cinder-ring-offset) var(--cinder-ring-offset-color),
+      0 0 0 calc(var(--cinder-ring-offset) + var(--cinder-ring-width))
+        var(--_cinder-radio-ring, var(--cinder-ring-color));
   }
-}
 
-.cinder-radio:checked {
-  background: var(--cinder-accent);
-  border-color: var(--cinder-accent);
-}
+  @media (forced-colors: active) {
+    .cinder-radio:focus-visible {
+      outline: var(--cinder-ring-width) solid Highlight;
+      outline-offset: 1px;
+    }
+  }
 
-/* Sibling indicator: a circular dot drawn with `mask-image` so the inner
+  .cinder-radio:checked {
+    background: var(--cinder-accent);
+    border-color: var(--cinder-accent);
+  }
+
+  /* Sibling indicator: a circular dot drawn with `mask-image` so the inner
  * glyph color tracks `--cinder-accent-contrast`. Input keeps the border,
  * focus ring, and interaction; indicator is non-interactive. */
 
-.cinder-radio-row__control {
-  position: relative;
-  display: inline-flex;
-  inline-size: 1.125rem;
-  block-size: 1.125rem;
-  flex-shrink: 0;
-}
-
-.cinder-radio-row__indicator {
-  --_cinder-radio-dot-mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Ccircle cx='8' cy='8' r='3.5'/%3E%3C/svg%3E");
-
-  position: absolute;
-  inset-block-start: 50%;
-  inset-inline-start: 50%;
-  inline-size: 0.875rem;
-  block-size: 0.875rem;
-  transform: translate(-50%, -50%);
-  pointer-events: none;
-  z-index: 1;
-  opacity: 0;
-
-  color: var(--cinder-accent-contrast);
-  background-color: currentColor;
-
-  -webkit-mask-repeat: no-repeat;
-  mask-repeat: no-repeat;
-  -webkit-mask-position: center;
-  mask-position: center;
-  -webkit-mask-size: 0.875rem 0.875rem;
-  mask-size: 0.875rem 0.875rem;
-}
-
-.cinder-radio:checked + .cinder-radio-row__indicator {
-  opacity: 1;
-  -webkit-mask-image: var(--_cinder-radio-dot-mask);
-  mask-image: var(--_cinder-radio-dot-mask);
-}
-
-/* Forced Colors Mode override — see checkbox.css for rationale. */
-@media (forced-colors: active) {
-  .cinder-radio:checked + .cinder-radio-row__indicator {
-    forced-color-adjust: none;
-    background-color: ButtonText;
+  .cinder-radio-row__control {
+    position: relative;
+    display: inline-flex;
+    inline-size: 1.125rem;
+    block-size: 1.125rem;
+    flex-shrink: 0;
   }
-}
 
-.cinder-radio:disabled {
-  cursor: not-allowed;
-  background: var(--cinder-surface-inset);
-  border-color: var(--cinder-border-muted);
-}
+  .cinder-radio-row__indicator {
+    --_cinder-radio-dot-mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Ccircle cx='8' cy='8' r='3.5'/%3E%3C/svg%3E");
 
-.cinder-radio:disabled:checked {
-  background-color: var(--cinder-text-disabled);
-  border-color: var(--cinder-text-disabled);
-}
+    position: absolute;
+    inset-block-start: 50%;
+    inset-inline-start: 50%;
+    inline-size: 0.875rem;
+    block-size: 0.875rem;
+    transform: translate(-50%, -50%);
+    pointer-events: none;
+    z-index: 1;
+    opacity: 0;
 
-.cinder-radio[aria-invalid='true'] {
-  --_cinder-radio-ring: var(--cinder-danger);
-  border-color: var(--cinder-danger);
-}
+    color: var(--cinder-accent-contrast);
+    background-color: currentColor;
 
-.cinder-radio-row__label {
-  font-size: var(--cinder-text-sm);
-  line-height: var(--cinder-leading-normal);
-  color: var(--cinder-text);
-  cursor: pointer;
-}
+    -webkit-mask-repeat: no-repeat;
+    mask-repeat: no-repeat;
+    -webkit-mask-position: center;
+    mask-position: center;
+    -webkit-mask-size: 0.875rem 0.875rem;
+    mask-size: 0.875rem 0.875rem;
+  }
 
-.cinder-radio-row__label[data-disabled] {
-  color: var(--cinder-text-disabled);
-  cursor: not-allowed;
-}
+  .cinder-radio:checked + .cinder-radio-row__indicator {
+    opacity: 1;
+    -webkit-mask-image: var(--_cinder-radio-dot-mask);
+    mask-image: var(--_cinder-radio-dot-mask);
+  }
 
-/* ========================================
+  /* Forced Colors Mode override — see checkbox.css for rationale. */
+  @media (forced-colors: active) {
+    .cinder-radio:checked + .cinder-radio-row__indicator {
+      forced-color-adjust: none;
+      background-color: ButtonText;
+    }
+  }
+
+  .cinder-radio:disabled {
+    cursor: not-allowed;
+    background: var(--cinder-surface-inset);
+    border-color: var(--cinder-border-muted);
+  }
+
+  .cinder-radio:disabled:checked {
+    background-color: var(--cinder-text-disabled);
+    border-color: var(--cinder-text-disabled);
+  }
+
+  .cinder-radio[aria-invalid='true'] {
+    --_cinder-radio-ring: var(--cinder-danger);
+    border-color: var(--cinder-danger);
+  }
+
+  .cinder-radio-row__label {
+    font-size: var(--cinder-text-sm);
+    line-height: var(--cinder-leading-normal);
+    color: var(--cinder-text);
+    cursor: pointer;
+  }
+
+  .cinder-radio-row__label[data-disabled] {
+    color: var(--cinder-text-disabled);
+    cursor: not-allowed;
+  }
+
+  /* ========================================
  * PER-OPTION DESCRIPTION
  * ======================================== */
 
-.cinder-radio-row[data-has-description] {
-  display: grid;
-  grid-template-columns: auto 1fr;
-  column-gap: var(--cinder-space-2);
-  row-gap: var(--cinder-space-1);
-  align-items: start;
-}
+  .cinder-radio-row[data-has-description] {
+    display: grid;
+    grid-template-columns: auto 1fr;
+    column-gap: var(--cinder-space-2);
+    row-gap: var(--cinder-space-1);
+    align-items: start;
+  }
 
-.cinder-radio-row[data-has-description] .cinder-radio-row__control {
-  grid-row: 1;
-  grid-column: 1;
-  margin-top: var(--cinder-space-0-5); /* align input with label's first cap-height line */
-}
+  .cinder-radio-row[data-has-description] .cinder-radio-row__control {
+    grid-row: 1;
+    grid-column: 1;
+    margin-top: var(--cinder-space-0-5); /* align input with label's first cap-height line */
+  }
 
-.cinder-radio-row[data-has-description] .cinder-radio-row__label {
-  grid-row: 1;
-  grid-column: 2;
-}
+  .cinder-radio-row[data-has-description] .cinder-radio-row__label {
+    grid-row: 1;
+    grid-column: 2;
+  }
 
-.cinder-radio-row__description {
-  grid-row: 2;
-  grid-column: 2;
-  margin: 0;
-  font-size: var(--cinder-text-xs);
-  line-height: var(--cinder-leading-normal);
-  color: var(--cinder-text-muted);
-}
+  .cinder-radio-row__description {
+    grid-row: 2;
+    grid-column: 2;
+    margin: 0;
+    font-size: var(--cinder-text-xs);
+    line-height: var(--cinder-leading-normal);
+    color: var(--cinder-text-muted);
+  }
 
-.cinder-radio-row__description[data-disabled] {
-  color: var(--cinder-text-disabled);
-}
+  .cinder-radio-row__description[data-disabled] {
+    color: var(--cinder-text-disabled);
+  }
 
-/* ========================================
+  /* ========================================
  * CARD VARIANT
  * ======================================== */
 
-.cinder-radio-group[data-variant='card'] .cinder-radio-group__items {
-  gap: var(--cinder-space-2);
-}
+  .cinder-radio-group[data-variant='card'] .cinder-radio-group__items {
+    gap: var(--cinder-space-2);
+  }
 
-.cinder-radio-group[data-variant='card'] .cinder-radio-row {
-  border: 1px solid var(--cinder-border);
-  border-radius: var(--cinder-radius-md);
-  padding: var(--cinder-space-3);
-  background: var(--cinder-surface-raised);
-  transition:
-    border-color var(--cinder-duration-fast) var(--cinder-ease-standard),
-    background var(--cinder-duration-fast) var(--cinder-ease-standard);
-}
+  .cinder-radio-group[data-variant='card'] .cinder-radio-row {
+    border: 1px solid var(--cinder-border);
+    border-radius: var(--cinder-radius-md);
+    padding: var(--cinder-space-3);
+    background: var(--cinder-surface-raised);
+    transition:
+      border-color var(--cinder-duration-fast) var(--cinder-ease-standard),
+      background var(--cinder-duration-fast) var(--cinder-ease-standard);
+  }
 
-/* Sticky-hover suppression on touch: wrap hover-only chrome so it doesn't
+  /* Sticky-hover suppression on touch: wrap hover-only chrome so it doesn't
  * "stick" after tap on touch devices that emulate :hover. The :not([data-disabled])
  * exclusion replaces a separate reset rule for disabled cards. */
-@media (hover: hover) {
-  .cinder-radio-group[data-variant='card'] .cinder-radio-row:hover:not([data-disabled]) {
-    border-color: var(--cinder-border-strong);
-  }
-}
-
-/* Selection reinforcement — NOT the sole indicator. */
-.cinder-radio-group[data-variant='card'] .cinder-radio-row[data-checked] {
-  border-color: var(--cinder-accent);
-  background: var(--cinder-surface-selected, var(--cinder-surface-raised));
-}
-
-/* Invalid state on the card surface. Driven by `data-invalid` on the row. */
-.cinder-radio-group[data-variant='card'] .cinder-radio-row[data-invalid] {
-  border-color: var(--cinder-danger);
-}
-
-/* Disabled card — driven by `data-disabled` on the row. */
-.cinder-radio-group[data-variant='card'] .cinder-radio-row[data-disabled] {
-  background: var(--cinder-surface-inset);
-  border-color: var(--cinder-border-muted);
-  cursor: not-allowed;
-}
-
-@media (forced-colors: active) {
-  .cinder-radio-group[data-variant='card'] .cinder-radio-row {
-    border: 1px solid CanvasText;
+  @media (hover: hover) {
+    .cinder-radio-group[data-variant='card'] .cinder-radio-row:hover:not([data-disabled]) {
+      border-color: var(--cinder-border-strong);
+    }
   }
 
+  /* Selection reinforcement — NOT the sole indicator. */
   .cinder-radio-group[data-variant='card'] .cinder-radio-row[data-checked] {
-    border: 2px solid Highlight;
+    border-color: var(--cinder-accent);
+    background: var(--cinder-surface-selected, var(--cinder-surface-raised));
   }
 
+  /* Invalid state on the card surface. Driven by `data-invalid` on the row. */
   .cinder-radio-group[data-variant='card'] .cinder-radio-row[data-invalid] {
-    border: 2px solid Mark;
+    border-color: var(--cinder-danger);
+  }
+
+  /* Disabled card — driven by `data-disabled` on the row. */
+  .cinder-radio-group[data-variant='card'] .cinder-radio-row[data-disabled] {
+    background: var(--cinder-surface-inset);
+    border-color: var(--cinder-border-muted);
+    cursor: not-allowed;
+  }
+
+  @media (forced-colors: active) {
+    .cinder-radio-group[data-variant='card'] .cinder-radio-row {
+      border: 1px solid CanvasText;
+    }
+
+    .cinder-radio-group[data-variant='card'] .cinder-radio-row[data-checked] {
+      border: 2px solid Highlight;
+    }
+
+    .cinder-radio-group[data-variant='card'] .cinder-radio-row[data-invalid] {
+      border: 2px solid Mark;
+    }
   }
 }

--- a/packages/components/src/components/radio/radio.css
+++ b/packages/components/src/components/radio/radio.css
@@ -1,4 +1,5 @@
-/* ========================================
+@layer cinder.components {
+  /* ========================================
  * RADIO
  * Radio inherits its visual treatment from radio-group.css since the row
  * (input + label pair) is shared between the standalone Radio and the
@@ -9,3 +10,4 @@
  * Override any .cinder-radio specifics here in the future without touching
  * the group-level styles.
  * ======================================== */
+}

--- a/packages/components/src/components/rating/rating.css
+++ b/packages/components/src/components/rating/rating.css
@@ -1,109 +1,111 @@
-/* ========================================
+@layer cinder.components {
+  /* ========================================
  * RATING
  * ======================================== */
 
-.cinder-rating-field {
-  display: flex;
-  flex-direction: column;
-  gap: var(--cinder-space-1-5);
-  inline-size: max-content;
-}
-
-.cinder-rating-field__label {
-  display: inline-flex;
-  align-items: center;
-  gap: var(--cinder-space-1);
-  font-size: var(--cinder-text-xs);
-  font-weight: var(--cinder-font-medium);
-  line-height: 1;
-  color: var(--cinder-text);
-}
-
-.cinder-rating-field__label[data-disabled] {
-  color: var(--cinder-text-disabled);
-  cursor: not-allowed;
-}
-
-.cinder-rating {
-  position: relative;
-  display: inline-flex;
-  align-items: center;
-  gap: var(--cinder-space-1);
-  --_cinder-rating-color: var(--cinder-warning, oklch(80% 0.18 80));
-  --_cinder-rating-empty: var(--cinder-border-strong);
-  --_cinder-rating-size: 1.5rem;
-}
-
-.cinder-rating__star {
-  position: relative;
-  inline-size: var(--_cinder-rating-size);
-  block-size: var(--_cinder-rating-size);
-  background: var(--_cinder-rating-empty);
-  -webkit-mask: var(--_cinder-rating-mask) center / contain no-repeat;
-  mask: var(--_cinder-rating-mask) center / contain no-repeat;
-  --_cinder-rating-mask: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'><path d='M12 2l2.99 6.06 6.69.97-4.84 4.72 1.14 6.66L12 17.27l-5.98 3.14 1.14-6.66L2.32 9.03l6.69-.97L12 2z'/></svg>");
-}
-
-.cinder-rating__star-fill {
-  display: block;
-  block-size: 100%;
-  inline-size: var(--_cinder-rating-fill, 0%);
-  background: var(--_cinder-rating-color);
-}
-
-.cinder-rating__hit-area {
-  position: absolute;
-  inset: 0;
-  display: flex;
-  align-items: stretch;
-}
-
-.cinder-rating__option {
-  flex: 1 1 0;
-  min-inline-size: 0;
-  appearance: none;
-  background: transparent;
-  border: none;
-  padding: 0;
-  margin: 0;
-  cursor: pointer;
-  color: inherit;
-  font: inherit;
-}
-
-.cinder-rating__option:focus-visible {
-  outline: var(--cinder-ring-width) solid var(--cinder-ring-color);
-  outline-offset: var(--cinder-ring-offset);
-  border-radius: var(--cinder-radius-sm);
-}
-
-.cinder-rating--readonly {
-  pointer-events: none;
-}
-
-.cinder-rating[aria-disabled='true'] {
-  opacity: 0.55;
-  pointer-events: none;
-}
-
-.cinder-rating[aria-disabled='true'] .cinder-rating__option {
-  cursor: not-allowed;
-}
-
-@media (forced-colors: active) {
-  .cinder-rating__star-fill {
-    background: Highlight;
+  .cinder-rating-field {
+    display: flex;
+    flex-direction: column;
+    gap: var(--cinder-space-1-5);
+    inline-size: max-content;
   }
-}
 
-.cinder-rating-field__description {
-  margin: 0;
-  font-size: var(--cinder-text-xs);
-  color: var(--cinder-text-muted);
-}
+  .cinder-rating-field__label {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--cinder-space-1);
+    font-size: var(--cinder-text-xs);
+    font-weight: var(--cinder-font-medium);
+    line-height: 1;
+    color: var(--cinder-text);
+  }
 
-.cinder-rating-field__error {
-  margin: 0;
-  font-size: var(--cinder-text-xs);
-  color: var(--cinder-danger);
+  .cinder-rating-field__label[data-disabled] {
+    color: var(--cinder-text-disabled);
+    cursor: not-allowed;
+  }
+
+  .cinder-rating {
+    position: relative;
+    display: inline-flex;
+    align-items: center;
+    gap: var(--cinder-space-1);
+    --_cinder-rating-color: var(--cinder-warning, oklch(80% 0.18 80));
+    --_cinder-rating-empty: var(--cinder-border-strong);
+    --_cinder-rating-size: 1.5rem;
+  }
+
+  .cinder-rating__star {
+    position: relative;
+    inline-size: var(--_cinder-rating-size);
+    block-size: var(--_cinder-rating-size);
+    background: var(--_cinder-rating-empty);
+    -webkit-mask: var(--_cinder-rating-mask) center / contain no-repeat;
+    mask: var(--_cinder-rating-mask) center / contain no-repeat;
+    --_cinder-rating-mask: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'><path d='M12 2l2.99 6.06 6.69.97-4.84 4.72 1.14 6.66L12 17.27l-5.98 3.14 1.14-6.66L2.32 9.03l6.69-.97L12 2z'/></svg>");
+  }
+
+  .cinder-rating__star-fill {
+    display: block;
+    block-size: 100%;
+    inline-size: var(--_cinder-rating-fill, 0%);
+    background: var(--_cinder-rating-color);
+  }
+
+  .cinder-rating__hit-area {
+    position: absolute;
+    inset: 0;
+    display: flex;
+    align-items: stretch;
+  }
+
+  .cinder-rating__option {
+    flex: 1 1 0;
+    min-inline-size: 0;
+    appearance: none;
+    background: transparent;
+    border: none;
+    padding: 0;
+    margin: 0;
+    cursor: pointer;
+    color: inherit;
+    font: inherit;
+  }
+
+  .cinder-rating__option:focus-visible {
+    outline: var(--cinder-ring-width) solid var(--cinder-ring-color);
+    outline-offset: var(--cinder-ring-offset);
+    border-radius: var(--cinder-radius-sm);
+  }
+
+  .cinder-rating--readonly {
+    pointer-events: none;
+  }
+
+  .cinder-rating[aria-disabled='true'] {
+    opacity: 0.55;
+    pointer-events: none;
+  }
+
+  .cinder-rating[aria-disabled='true'] .cinder-rating__option {
+    cursor: not-allowed;
+  }
+
+  @media (forced-colors: active) {
+    .cinder-rating__star-fill {
+      background: Highlight;
+    }
+  }
+
+  .cinder-rating-field__description {
+    margin: 0;
+    font-size: var(--cinder-text-xs);
+    color: var(--cinder-text-muted);
+  }
+
+  .cinder-rating-field__error {
+    margin: 0;
+    font-size: var(--cinder-text-xs);
+    color: var(--cinder-danger);
+  }
 }

--- a/packages/components/src/components/resizable-panels/resizable-panels.css
+++ b/packages/components/src/components/resizable-panels/resizable-panels.css
@@ -1,98 +1,100 @@
-.cinder-resizable-panels {
-  display: flex;
-  min-inline-size: 0;
-  min-block-size: 0;
-}
-
-.cinder-resizable-panels[data-cinder-orientation='horizontal'] {
-  flex-direction: row;
-}
-
-.cinder-resizable-panels[data-cinder-orientation='vertical'] {
-  flex-direction: column;
-}
-
-.cinder-resizable-panels__pane {
-  flex: 1 1 0;
-  min-inline-size: 0;
-  min-block-size: 0;
-}
-
-.cinder-resizable-panels__pane[style] {
-  flex: 0 0 var(--_cinder-resizable-panel-size);
-}
-
-.cinder-resizable-panels__pane[data-cinder-collapsed] {
-  overflow: hidden;
-}
-
-.cinder-resizable-panels__handle {
-  flex: 0 0 auto;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  padding: 0;
-  border: none;
-  background: transparent;
-  color: var(--cinder-border-strong);
-  position: relative;
-}
-
-.cinder-resizable-panels__handle[data-cinder-orientation='horizontal'] {
-  inline-size: 0.75rem;
-  cursor: col-resize;
-  touch-action: none;
-}
-
-.cinder-resizable-panels__handle[data-cinder-orientation='vertical'] {
-  block-size: 0.75rem;
-  cursor: row-resize;
-  touch-action: none;
-}
-
-.cinder-resizable-panels__handle-line {
-  display: block;
-  border-radius: var(--cinder-radius-full);
-  background: currentColor;
-  opacity: 0.5;
-}
-
-.cinder-resizable-panels__handle[data-cinder-orientation='horizontal']
-  .cinder-resizable-panels__handle-line {
-  inline-size: 2px;
-  block-size: 2.5rem;
-}
-
-.cinder-resizable-panels__handle[data-cinder-orientation='vertical']
-  .cinder-resizable-panels__handle-line {
-  inline-size: 2.5rem;
-  block-size: 2px;
-}
-
-.cinder-resizable-panels__handle::after {
-  content: '';
-  position: absolute;
-  inset: 50% auto auto 50%;
-  inline-size: 44px;
-  block-size: 44px;
-  transform: translate(-50%, -50%);
-}
-
-@media (hover: hover) {
-  .cinder-resizable-panels__handle:hover .cinder-resizable-panels__handle-line {
-    opacity: 0.9;
+@layer cinder.components {
+  .cinder-resizable-panels {
+    display: flex;
+    min-inline-size: 0;
+    min-block-size: 0;
   }
-}
 
-.cinder-resizable-panels__handle:focus-visible {
-  outline: var(--cinder-ring-width) solid transparent;
-  box-shadow: var(--_cinder-focus-ring-shadow);
-}
+  .cinder-resizable-panels[data-cinder-orientation='horizontal'] {
+    flex-direction: row;
+  }
 
-@media (forced-colors: active) {
+  .cinder-resizable-panels[data-cinder-orientation='vertical'] {
+    flex-direction: column;
+  }
+
+  .cinder-resizable-panels__pane {
+    flex: 1 1 0;
+    min-inline-size: 0;
+    min-block-size: 0;
+  }
+
+  .cinder-resizable-panels__pane[style] {
+    flex: 0 0 var(--_cinder-resizable-panel-size);
+  }
+
+  .cinder-resizable-panels__pane[data-cinder-collapsed] {
+    overflow: hidden;
+  }
+
+  .cinder-resizable-panels__handle {
+    flex: 0 0 auto;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0;
+    border: none;
+    background: transparent;
+    color: var(--cinder-border-strong);
+    position: relative;
+  }
+
+  .cinder-resizable-panels__handle[data-cinder-orientation='horizontal'] {
+    inline-size: 0.75rem;
+    cursor: col-resize;
+    touch-action: none;
+  }
+
+  .cinder-resizable-panels__handle[data-cinder-orientation='vertical'] {
+    block-size: 0.75rem;
+    cursor: row-resize;
+    touch-action: none;
+  }
+
+  .cinder-resizable-panels__handle-line {
+    display: block;
+    border-radius: var(--cinder-radius-full);
+    background: currentColor;
+    opacity: 0.5;
+  }
+
+  .cinder-resizable-panels__handle[data-cinder-orientation='horizontal']
+    .cinder-resizable-panels__handle-line {
+    inline-size: 2px;
+    block-size: 2.5rem;
+  }
+
+  .cinder-resizable-panels__handle[data-cinder-orientation='vertical']
+    .cinder-resizable-panels__handle-line {
+    inline-size: 2.5rem;
+    block-size: 2px;
+  }
+
+  .cinder-resizable-panels__handle::after {
+    content: '';
+    position: absolute;
+    inset: 50% auto auto 50%;
+    inline-size: 44px;
+    block-size: 44px;
+    transform: translate(-50%, -50%);
+  }
+
+  @media (hover: hover) {
+    .cinder-resizable-panels__handle:hover .cinder-resizable-panels__handle-line {
+      opacity: 0.9;
+    }
+  }
+
   .cinder-resizable-panels__handle:focus-visible {
-    outline: var(--cinder-ring-width) solid ButtonText;
-    outline-offset: 3px;
-    box-shadow: none;
+    outline: var(--cinder-ring-width) solid transparent;
+    box-shadow: var(--_cinder-focus-ring-shadow);
+  }
+
+  @media (forced-colors: active) {
+    .cinder-resizable-panels__handle:focus-visible {
+      outline: var(--cinder-ring-width) solid ButtonText;
+      outline-offset: 3px;
+      box-shadow: none;
+    }
   }
 }

--- a/packages/components/src/components/review-editor/review-editor.css
+++ b/packages/components/src/components/review-editor/review-editor.css
@@ -1,4 +1,5 @@
-/**
+@layer cinder.components {
+  /**
  * ReviewEditor global styles.
  *
  * These styles are global (not Svelte-scoped) and are included in the main
@@ -6,221 +7,222 @@
  * prefix consistently to prevent style leakage.
  */
 
-/* =========================================================================
+  /* =========================================================================
  * Layout Container
  * ========================================================================= */
 
-.review-editor-container {
-  display: flex;
-  flex-direction: column;
-  min-height: 200px;
-  position: relative;
-  /* Card root carries the SINGLE background. Per the surface nesting rule
+  .review-editor-container {
+    display: flex;
+    flex-direction: column;
+    min-height: 200px;
+    position: relative;
+    /* Card root carries the SINGLE background. Per the surface nesting rule
      (see tokens-base.css), every region inside (controls, main, front-matter,
      editor wrapper) inherits — they must not redeclare `background:`,
      otherwise visible color bands appear between siblings. */
-  background: var(--cinder-surface-raised);
-}
+    background: var(--cinder-surface-raised);
+  }
 
-/* When sidebar is open, main layout becomes row */
-.review-editor-container:has(.comment-sidebar) {
-  display: grid;
-  grid-template-columns: 1fr auto;
-  grid-template-rows: auto 1fr;
-}
+  /* When sidebar is open, main layout becomes row */
+  .review-editor-container:has(.comment-sidebar) {
+    display: grid;
+    grid-template-columns: 1fr auto;
+    grid-template-rows: auto 1fr;
+  }
 
-/* =========================================================================
+  /* =========================================================================
  * Controls Bar Connection
  * Connect the controls bar visually to the content below
  * ========================================================================= */
 
-.review-editor-container > .review-editor-controls {
-  /* Controls bar spans the full width when sidebar is open */
-  grid-column: 1 / -1;
-}
+  .review-editor-container > .review-editor-controls {
+    /* Controls bar spans the full width when sidebar is open */
+    grid-column: 1 / -1;
+  }
 
-/* Connect controls bar to MarkdownEditor's toolbar when in editor view */
-.review-editor-container[data-view='editor'] > .review-editor-controls {
-  border-bottom: none;
-  border-radius: var(--cinder-radius-md) var(--cinder-radius-md) 0 0;
-}
+  /* Connect controls bar to MarkdownEditor's toolbar when in editor view */
+  .review-editor-container[data-view='editor'] > .review-editor-controls {
+    border-bottom: none;
+    border-radius: var(--cinder-radius-md) var(--cinder-radius-md) 0 0;
+  }
 
-/* For diff/summary views, controls bar has bottom border but no radius on bottom */
-.review-editor-container:not([data-view='editor']) > .review-editor-controls {
-  border-bottom: 1px solid var(--cinder-border);
-  border-radius: var(--cinder-radius-md) var(--cinder-radius-md) 0 0;
-}
+  /* For diff/summary views, controls bar has bottom border but no radius on bottom */
+  .review-editor-container:not([data-view='editor']) > .review-editor-controls {
+    border-bottom: 1px solid var(--cinder-border);
+    border-radius: var(--cinder-radius-md) var(--cinder-radius-md) 0 0;
+  }
 
-/*
+  /*
  * Connect EditorToolbar to controls bar when present.
  * MarkdownEditor removes the toolbar's bottom border via its [data-has-toolbar] styles
  * to visually connect toolbar and editor. Here we restore it because the controls bar
  * above already provides visual connection. This rule only applies when the toolbar
  * exists (i.e., when MarkdownEditor is in non-readonly mode with showToolbar=true).
  */
-.review-editor-container[data-view='editor']
-  .markdown-editor-wrapper[data-has-toolbar]
-  .editor-toolbar {
-  border-radius: 0;
-  border-top: none;
-  border-inline-start: none;
-  border-inline-end: none;
-  border-bottom: 1px solid var(--cinder-border);
-}
+  .review-editor-container[data-view='editor']
+    .markdown-editor-wrapper[data-has-toolbar]
+    .editor-toolbar {
+    border-radius: 0;
+    border-top: none;
+    border-inline-start: none;
+    border-inline-end: none;
+    border-bottom: 1px solid var(--cinder-border);
+  }
 
-/* =========================================================================
+  /* =========================================================================
  * Main Content Area
  * ========================================================================= */
 
-.review-editor-main {
-  flex: 1;
-  min-width: 0; /* Prevent flex item overflow */
-  min-height: 300px; /* Consistent height across views to prevent layout shift */
-  display: flex;
-  flex-direction: column;
-  position: relative;
-  overflow: hidden;
-  /* Unified border for main content area - connects to controls above */
-  border: 1px solid var(--cinder-border);
-  border-top: none;
-  border-radius: 0 0 var(--cinder-radius-md) var(--cinder-radius-md);
-  /* Background inherited from .review-editor-container per surface nesting rule. */
-}
+  .review-editor-main {
+    flex: 1;
+    min-width: 0; /* Prevent flex item overflow */
+    min-height: 300px; /* Consistent height across views to prevent layout shift */
+    display: flex;
+    flex-direction: column;
+    position: relative;
+    overflow: hidden;
+    /* Unified border for main content area - connects to controls above */
+    border: 1px solid var(--cinder-border);
+    border-top: none;
+    border-radius: 0 0 var(--cinder-radius-md) var(--cinder-radius-md);
+    /* Background inherited from .review-editor-container per surface nesting rule. */
+  }
 
-/*
+  /*
  * Make the markdown-editor-wrapper fill the main content area.
  * Border/radius/overflow are reset in review-editor.svelte via a :global() rule
  * at (0,3,0) specificity, which wins over the Svelte-scoped rule on the wrapper.
  */
-.review-editor-main .markdown-editor-wrapper {
-  flex: 1;
-  display: flex;
-  flex-direction: column;
-}
+  .review-editor-main .markdown-editor-wrapper {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+  }
 
-.review-editor-main .markdown-editor-wrapper .markdown-editor.surface {
-  border: none;
-  border-radius: 0;
-  flex: 1;
-}
+  .review-editor-main .markdown-editor-wrapper .markdown-editor.surface {
+    border: none;
+    border-radius: 0;
+    flex: 1;
+  }
 
-.review-editor-front-matter {
-  border-bottom: 1px solid var(--cinder-border-muted);
-  /* Background inherited from .review-editor-container per surface nesting rule. */
-}
+  .review-editor-front-matter {
+    border-bottom: 1px solid var(--cinder-border-muted);
+    /* Background inherited from .review-editor-container per surface nesting rule. */
+  }
 
-.review-editor-front-matter__header {
-  padding: var(--cinder-space-3) var(--cinder-space-4) 0;
-}
+  .review-editor-front-matter__header {
+    padding: var(--cinder-space-3) var(--cinder-space-4) 0;
+  }
 
-.review-editor-front-matter__title {
-  margin: 0;
-  color: var(--cinder-text-subtle);
-  font-size: var(--cinder-text-2xs);
-  font-weight: var(--cinder-font-semibold);
-  letter-spacing: 0.06em;
-  text-transform: uppercase;
-}
+  .review-editor-front-matter__title {
+    margin: 0;
+    color: var(--cinder-text-subtle);
+    font-size: var(--cinder-text-2xs);
+    font-weight: var(--cinder-font-semibold);
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+  }
 
-.review-editor-front-matter__body {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(min(18rem, 100%), 1fr));
-  gap: var(--cinder-space-3);
-  padding: var(--cinder-space-3) var(--cinder-space-4) var(--cinder-space-4);
-}
+  .review-editor-front-matter__body {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(min(18rem, 100%), 1fr));
+    gap: var(--cinder-space-3);
+    padding: var(--cinder-space-3) var(--cinder-space-4) var(--cinder-space-4);
+  }
 
-.review-editor-front-matter__field {
-  min-width: 0;
-}
+  .review-editor-front-matter__field {
+    min-width: 0;
+  }
 
-.review-editor-front-matter__field .cinder-textarea {
-  font-family: var(--cinder-font-mono);
-  font-size: var(--cinder-text-sm);
-}
+  .review-editor-front-matter__field .cinder-textarea {
+    font-family: var(--cinder-font-mono);
+    font-size: var(--cinder-text-sm);
+  }
 
-.review-editor-front-matter__empty {
-  margin: 0;
-  color: var(--cinder-text-subtle);
-  font-size: var(--cinder-text-sm);
-}
+  .review-editor-front-matter__empty {
+    margin: 0;
+    color: var(--cinder-text-subtle);
+    font-size: var(--cinder-text-sm);
+  }
 
-.review-editor-main > .diff-viewer {
-  border: none;
-  border-radius: 0;
-}
+  .review-editor-main > .diff-viewer {
+    border: none;
+    border-radius: 0;
+  }
 
-/* Summary view inherits the main container's background */
-.review-editor-main > .summary-view {
-  border: none;
-  border-radius: 0;
-}
+  /* Summary view inherits the main container's background */
+  .review-editor-main > .summary-view {
+    border: none;
+    border-radius: 0;
+  }
 
-/* When sidebar is open, main loses its inline-end border-radius */
-.review-editor-container:has(.comment-sidebar) .review-editor-main {
-  border-inline-end: none;
-  border-start-start-radius: 0;
-  border-start-end-radius: 0;
-  border-end-start-radius: var(--cinder-radius-md);
-  border-end-end-radius: 0;
-}
+  /* When sidebar is open, main loses its inline-end border-radius */
+  .review-editor-container:has(.comment-sidebar) .review-editor-main {
+    border-inline-end: none;
+    border-start-start-radius: 0;
+    border-start-end-radius: 0;
+    border-end-start-radius: var(--cinder-radius-md);
+    border-end-end-radius: 0;
+  }
 
-/* Sidebar adjusts height and connects visually to main content */
-.review-editor-container > .comment-sidebar {
-  height: auto;
-  max-height: 100%;
-  border-top: 1px solid var(--cinder-border);
-  border-bottom: 1px solid var(--cinder-border);
-  border-inline-end: 1px solid var(--cinder-border);
-  border-start-start-radius: 0;
-  border-start-end-radius: 0;
-  border-end-start-radius: 0;
-  border-end-end-radius: var(--cinder-radius-md);
-}
+  /* Sidebar adjusts height and connects visually to main content */
+  .review-editor-container > .comment-sidebar {
+    height: auto;
+    max-height: 100%;
+    border-top: 1px solid var(--cinder-border);
+    border-bottom: 1px solid var(--cinder-border);
+    border-inline-end: 1px solid var(--cinder-border);
+    border-start-start-radius: 0;
+    border-start-end-radius: 0;
+    border-end-start-radius: 0;
+    border-end-end-radius: var(--cinder-radius-md);
+  }
 
-/* In diff/summary views, sidebar top connects to controls bar bottom border */
-.review-editor-container:not([data-view='editor']) > .comment-sidebar {
-  border-top: none;
-}
+  /* In diff/summary views, sidebar top connects to controls bar bottom border */
+  .review-editor-container:not([data-view='editor']) > .comment-sidebar {
+    border-top: none;
+  }
 
-/* =========================================================================
+  /* =========================================================================
  * Summary View (DEP-47)
  * ========================================================================= */
 
-/* Summary view empty state container */
-.review-editor-container .summary-view {
-  flex: 1;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  padding: var(--cinder-space-4);
-}
+  /* Summary view empty state container */
+  .review-editor-container .summary-view {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    padding: var(--cinder-space-4);
+  }
 
-.review-editor-container .summary-empty {
-  text-align: center;
-  padding: var(--cinder-space-8);
-  color: var(--cinder-text-muted);
-}
+  .review-editor-container .summary-empty {
+    text-align: center;
+    padding: var(--cinder-space-8);
+    color: var(--cinder-text-muted);
+  }
 
-.review-editor-container .summary-hint {
-  font-size: var(--cinder-text-xs);
-  margin-top: var(--cinder-space-2);
-}
+  .review-editor-container .summary-hint {
+    font-size: var(--cinder-text-xs);
+    margin-top: var(--cinder-space-2);
+  }
 
-/* =========================================================================
+  /* =========================================================================
  * Comment Anchor Decorations (DEP-39)
  * ========================================================================= */
 
-/* Standard anchored comment highlight */
-.review-editor-container .comment-anchor {
-  background: color-mix(in oklch, var(--cinder-accent), transparent 85%);
-  border-bottom: 2px solid var(--cinder-accent);
-  cursor: pointer;
-  transition: background var(--cinder-duration-fast) var(--cinder-ease-standard);
-}
+  /* Standard anchored comment highlight */
+  .review-editor-container .comment-anchor {
+    background: color-mix(in oklch, var(--cinder-accent), transparent 85%);
+    border-bottom: 2px solid var(--cinder-accent);
+    cursor: pointer;
+    transition: background var(--cinder-duration-fast) var(--cinder-ease-standard);
+  }
 
-@media (hover: hover) {
-  .review-editor-container .comment-anchor:hover {
-    background: color-mix(in oklch, var(--cinder-accent), transparent 75%);
+  @media (hover: hover) {
+    .review-editor-container .comment-anchor:hover {
+      background: color-mix(in oklch, var(--cinder-accent), transparent 75%);
+    }
   }
 }

--- a/packages/components/src/components/scroll-area/scroll-area.css
+++ b/packages/components/src/components/scroll-area/scroll-area.css
@@ -1,4 +1,5 @@
-/* ========================================
+@layer cinder.components {
+  /* ========================================
  * SCROLL AREA
  *
  * Styled scrollable container. Uses the native scrollbar (never substitutes
@@ -6,85 +7,86 @@
  * and assistive-technology interactions stay intact.
  * ======================================== */
 
-.cinder-scroll-area {
-  display: block;
-  min-block-size: 0;
-  min-inline-size: 0;
-  /* Contain scroll momentum so reaching the end of this region does not
+  .cinder-scroll-area {
+    display: block;
+    min-block-size: 0;
+    min-inline-size: 0;
+    /* Contain scroll momentum so reaching the end of this region does not
    * bleed into an ancestor scroller (rubber-band on iOS, page-scroll on
    * desktop). Matches the modal / command-palette body convention. */
-  overscroll-behavior: contain;
+    overscroll-behavior: contain;
 
-  /* Firefox scrollbar theming. */
-  scrollbar-width: thin;
-  scrollbar-color: var(--cinder-scrollbar-thumb) var(--cinder-scrollbar-track);
-}
-
-.cinder-scroll-area[data-cinder-direction='vertical'] {
-  overflow-y: auto;
-  overflow-x: hidden;
-}
-
-.cinder-scroll-area[data-cinder-direction='horizontal'] {
-  overflow-x: auto;
-  overflow-y: hidden;
-}
-
-.cinder-scroll-area[data-cinder-direction='both'] {
-  overflow: auto;
-}
-
-/* Chromium / Safari scrollbar theming. */
-.cinder-scroll-area::-webkit-scrollbar {
-  inline-size: var(--cinder-scrollbar-size);
-  block-size: var(--cinder-scrollbar-size);
-}
-
-.cinder-scroll-area::-webkit-scrollbar-track {
-  background: var(--cinder-scrollbar-track);
-}
-
-.cinder-scroll-area::-webkit-scrollbar-thumb {
-  background: var(--cinder-scrollbar-thumb);
-  border-radius: var(--cinder-radius-sm);
-}
-
-.cinder-scroll-area::-webkit-scrollbar-thumb:hover {
-  background: var(--cinder-scrollbar-thumb-hover);
-}
-
-.cinder-scroll-area::-webkit-scrollbar-corner {
-  background: var(--cinder-scrollbar-track);
-}
-
-/* Visible focus ring for keyboard scroll users. Matches the button focus
- * pattern: transparent outline as a forced-colors fallback, box-shadow rings
- * for offset + ring colors. */
-.cinder-scroll-area:focus-visible {
-  outline: var(--cinder-ring-width) solid transparent;
-  box-shadow: var(--_cinder-focus-ring-shadow);
-}
-
-/* Windows High Contrast Mode (forced-colors) ignores box-shadow and
- * overrides custom scrollbar paint. Map the focus ring and scrollbar parts
- * to system colors so keyboard users keep their affordances. */
-@media (forced-colors: active) {
-  .cinder-scroll-area:focus-visible {
-    outline: var(--cinder-ring-width) solid ButtonText;
-    outline-offset: 3px;
-    box-shadow: none;
+    /* Firefox scrollbar theming. */
+    scrollbar-width: thin;
+    scrollbar-color: var(--cinder-scrollbar-thumb) var(--cinder-scrollbar-track);
   }
 
-  .cinder-scroll-area::-webkit-scrollbar-track,
-  .cinder-scroll-area::-webkit-scrollbar-corner {
-    background: Canvas;
+  .cinder-scroll-area[data-cinder-direction='vertical'] {
+    overflow-y: auto;
+    overflow-x: hidden;
+  }
+
+  .cinder-scroll-area[data-cinder-direction='horizontal'] {
+    overflow-x: auto;
+    overflow-y: hidden;
+  }
+
+  .cinder-scroll-area[data-cinder-direction='both'] {
+    overflow: auto;
+  }
+
+  /* Chromium / Safari scrollbar theming. */
+  .cinder-scroll-area::-webkit-scrollbar {
+    inline-size: var(--cinder-scrollbar-size);
+    block-size: var(--cinder-scrollbar-size);
+  }
+
+  .cinder-scroll-area::-webkit-scrollbar-track {
+    background: var(--cinder-scrollbar-track);
   }
 
   .cinder-scroll-area::-webkit-scrollbar-thumb {
-    background: CanvasText;
+    background: var(--cinder-scrollbar-thumb);
+    border-radius: var(--cinder-radius-sm);
   }
 
   .cinder-scroll-area::-webkit-scrollbar-thumb:hover {
-    background: ButtonText;
+    background: var(--cinder-scrollbar-thumb-hover);
+  }
+
+  .cinder-scroll-area::-webkit-scrollbar-corner {
+    background: var(--cinder-scrollbar-track);
+  }
+
+  /* Visible focus ring for keyboard scroll users. Matches the button focus
+ * pattern: transparent outline as a forced-colors fallback, box-shadow rings
+ * for offset + ring colors. */
+  .cinder-scroll-area:focus-visible {
+    outline: var(--cinder-ring-width) solid transparent;
+    box-shadow: var(--_cinder-focus-ring-shadow);
+  }
+
+  /* Windows High Contrast Mode (forced-colors) ignores box-shadow and
+ * overrides custom scrollbar paint. Map the focus ring and scrollbar parts
+ * to system colors so keyboard users keep their affordances. */
+  @media (forced-colors: active) {
+    .cinder-scroll-area:focus-visible {
+      outline: var(--cinder-ring-width) solid ButtonText;
+      outline-offset: 3px;
+      box-shadow: none;
+    }
+
+    .cinder-scroll-area::-webkit-scrollbar-track,
+    .cinder-scroll-area::-webkit-scrollbar-corner {
+      background: Canvas;
+    }
+
+    .cinder-scroll-area::-webkit-scrollbar-thumb {
+      background: CanvasText;
+    }
+
+    .cinder-scroll-area::-webkit-scrollbar-thumb:hover {
+      background: ButtonText;
+    }
   }
 }

--- a/packages/components/src/components/search-field/search-field.css
+++ b/packages/components/src/components/search-field/search-field.css
@@ -1,186 +1,188 @@
-/* ========================================
+@layer cinder.components {
+  /* ========================================
  * SEARCH FIELD
  * ======================================== */
 
-.cinder-search-field {
-  display: inline-flex;
-  align-items: center;
-  inline-size: 100%;
-  min-height: 2.25rem;
-  padding-inline: var(--cinder-space-2);
-  gap: var(--cinder-space-1-5);
-  background: var(--cinder-surface-raised);
-  border: 1px solid var(--cinder-border);
-  border-radius: var(--cinder-radius-md);
-  color: var(--cinder-text);
-  transition:
-    border-color var(--cinder-duration-fast) var(--cinder-ease-standard),
-    box-shadow var(--cinder-duration-fast) var(--cinder-ease-standard);
-}
-
-@media (hover: hover) {
-  .cinder-search-field:hover:not([data-disabled]) {
-    border-color: var(--cinder-border-strong);
+  .cinder-search-field {
+    display: inline-flex;
+    align-items: center;
+    inline-size: 100%;
+    min-height: 2.25rem;
+    padding-inline: var(--cinder-space-2);
+    gap: var(--cinder-space-1-5);
+    background: var(--cinder-surface-raised);
+    border: 1px solid var(--cinder-border);
+    border-radius: var(--cinder-radius-md);
+    color: var(--cinder-text);
+    transition:
+      border-color var(--cinder-duration-fast) var(--cinder-ease-standard),
+      box-shadow var(--cinder-duration-fast) var(--cinder-ease-standard);
   }
-}
 
-.cinder-search-field:focus-within {
-  outline: var(--cinder-ring-width) solid transparent;
-  box-shadow:
-    0 0 0 var(--cinder-ring-offset) var(--cinder-ring-offset-color),
-    0 0 0 calc(var(--cinder-ring-offset) + var(--cinder-ring-width))
-      var(--_cinder-search-field-ring, var(--cinder-ring-color));
-}
+  @media (hover: hover) {
+    .cinder-search-field:hover:not([data-disabled]) {
+      border-color: var(--cinder-border-strong);
+    }
+  }
 
-@media (forced-colors: active) {
   .cinder-search-field:focus-within {
-    outline: var(--cinder-ring-width) solid Highlight;
-    outline-offset: 1px;
+    outline: var(--cinder-ring-width) solid transparent;
+    box-shadow:
+      0 0 0 var(--cinder-ring-offset) var(--cinder-ring-offset-color),
+      0 0 0 calc(var(--cinder-ring-offset) + var(--cinder-ring-width))
+        var(--_cinder-search-field-ring, var(--cinder-ring-color));
   }
-}
 
-.cinder-search-field[data-invalid] {
-  --_cinder-search-field-ring: var(--cinder-danger);
-  border-color: var(--cinder-danger);
-}
+  @media (forced-colors: active) {
+    .cinder-search-field:focus-within {
+      outline: var(--cinder-ring-width) solid Highlight;
+      outline-offset: 1px;
+    }
+  }
 
-.cinder-search-field[data-disabled] {
-  background: var(--cinder-surface-inset);
-  border-color: var(--cinder-border-muted);
-  color: var(--cinder-text-disabled);
-  cursor: not-allowed;
-}
+  .cinder-search-field[data-invalid] {
+    --_cinder-search-field-ring: var(--cinder-danger);
+    border-color: var(--cinder-danger);
+  }
 
-/* ----------------------------------------
+  .cinder-search-field[data-disabled] {
+    background: var(--cinder-surface-inset);
+    border-color: var(--cinder-border-muted);
+    color: var(--cinder-text-disabled);
+    cursor: not-allowed;
+  }
+
+  /* ----------------------------------------
  * Leading icon
  * ---------------------------------------- */
 
-.cinder-search-field__leading {
-  display: inline-flex;
-  align-items: center;
-  flex: 0 0 auto;
-  color: var(--cinder-text-muted);
-}
+  .cinder-search-field__leading {
+    display: inline-flex;
+    align-items: center;
+    flex: 0 0 auto;
+    color: var(--cinder-text-muted);
+  }
 
-.cinder-search-field__icon {
-  inline-size: 1rem;
-  block-size: 1rem;
-}
+  .cinder-search-field__icon {
+    inline-size: 1rem;
+    block-size: 1rem;
+  }
 
-/* ----------------------------------------
+  /* ----------------------------------------
  * Input element
  * ---------------------------------------- */
 
-.cinder-search-field__input {
-  flex: 1 1 auto;
-  min-inline-size: 0;
-  appearance: none;
-  border: none;
-  background: transparent;
-  padding-block: var(--cinder-space-1-5);
-  padding-inline: 0;
-  font-size: var(--cinder-text-sm);
-  font-family: inherit;
-  line-height: var(--cinder-leading-normal);
-  color: inherit;
-}
+  .cinder-search-field__input {
+    flex: 1 1 auto;
+    min-inline-size: 0;
+    appearance: none;
+    border: none;
+    background: transparent;
+    padding-block: var(--cinder-space-1-5);
+    padding-inline: 0;
+    font-size: var(--cinder-text-sm);
+    font-family: inherit;
+    line-height: var(--cinder-leading-normal);
+    color: inherit;
+  }
 
-.cinder-search-field__input:focus-visible {
-  outline: none;
-  box-shadow: none;
-}
+  .cinder-search-field__input:focus-visible {
+    outline: none;
+    box-shadow: none;
+  }
 
-.cinder-search-field__input::placeholder {
-  color: var(--cinder-text-subtle);
-}
+  .cinder-search-field__input::placeholder {
+    color: var(--cinder-text-subtle);
+  }
 
-.cinder-search-field__input:disabled {
-  cursor: not-allowed;
-}
+  .cinder-search-field__input:disabled {
+    cursor: not-allowed;
+  }
 
-.cinder-search-field__input:disabled::placeholder {
-  color: var(--cinder-text-disabled);
-}
+  .cinder-search-field__input:disabled::placeholder {
+    color: var(--cinder-text-disabled);
+  }
 
-/* Suppress the WebKit native clear button — we render our own. */
-.cinder-search-field__input::-webkit-search-cancel-button,
-.cinder-search-field__input::-webkit-search-decoration {
-  display: none;
-}
+  /* Suppress the WebKit native clear button — we render our own. */
+  .cinder-search-field__input::-webkit-search-cancel-button,
+  .cinder-search-field__input::-webkit-search-decoration {
+    display: none;
+  }
 
-/* ----------------------------------------
+  /* ----------------------------------------
  * Clear button
  * ---------------------------------------- */
 
-.cinder-search-field__clear {
-  position: relative;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  flex: 0 0 auto;
-  inline-size: 1.25rem;
-  block-size: 1.25rem;
-  padding: 0;
-  background: transparent;
-  border: none;
-  border-radius: var(--cinder-radius-sm);
-  color: var(--cinder-text-muted);
-  cursor: pointer;
-}
+  .cinder-search-field__clear {
+    position: relative;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    flex: 0 0 auto;
+    inline-size: 1.25rem;
+    block-size: 1.25rem;
+    padding: 0;
+    background: transparent;
+    border: none;
+    border-radius: var(--cinder-radius-sm);
+    color: var(--cinder-text-muted);
+    cursor: pointer;
+  }
 
-/* Expand the interactive hit area to 44×44 px (WCAG 2.5.5) without affecting layout.
+  /* Expand the interactive hit area to 44×44 px (WCAG 2.5.5) without affecting layout.
  * Mirrors the pattern used by .cinder-alert__dismiss and .cinder-chip__remove. */
-.cinder-search-field__clear::after {
-  content: '';
-  position: absolute;
-  inset: 50% auto auto 50%;
-  inline-size: 44px;
-  block-size: 44px;
-  transform: translate(-50%, -50%);
-}
-
-.cinder-search-field__clear[hidden] {
-  display: none;
-}
-
-@media (hover: hover) {
-  .cinder-search-field__clear:hover:not(:disabled) {
-    color: var(--cinder-text);
-    background: var(--cinder-surface-inset);
+  .cinder-search-field__clear::after {
+    content: '';
+    position: absolute;
+    inset: 50% auto auto 50%;
+    inline-size: 44px;
+    block-size: 44px;
+    transform: translate(-50%, -50%);
   }
-}
 
-.cinder-search-field__clear:focus-visible {
-  outline: var(--cinder-ring-width) solid var(--cinder-ring-color);
-  outline-offset: 1px;
-}
+  .cinder-search-field__clear[hidden] {
+    display: none;
+  }
 
-@media (forced-colors: active) {
+  @media (hover: hover) {
+    .cinder-search-field__clear:hover:not(:disabled) {
+      color: var(--cinder-text);
+      background: var(--cinder-surface-inset);
+    }
+  }
+
   .cinder-search-field__clear:focus-visible {
-    outline: var(--cinder-ring-width) solid ButtonText;
-    outline-offset: 2px;
+    outline: var(--cinder-ring-width) solid var(--cinder-ring-color);
+    outline-offset: 1px;
   }
-}
 
-.cinder-search-field__clear:disabled {
-  cursor: not-allowed;
-}
+  @media (forced-colors: active) {
+    .cinder-search-field__clear:focus-visible {
+      outline: var(--cinder-ring-width) solid ButtonText;
+      outline-offset: 2px;
+    }
+  }
 
-/* ----------------------------------------
+  .cinder-search-field__clear:disabled {
+    cursor: not-allowed;
+  }
+
+  /* ----------------------------------------
  * Shortcut hint
  * ---------------------------------------- */
 
-.cinder-search-field__shortcut {
-  display: inline-flex;
-  align-items: center;
-  flex: 0 0 auto;
-  padding-inline: var(--cinder-space-1-5);
-  padding-block: var(--cinder-space-0-5);
-  font-family: inherit;
-  font-size: var(--cinder-text-xs);
-  line-height: 1;
-  color: var(--cinder-text-muted);
-  background: var(--cinder-surface-inset);
-  border: 1px solid var(--cinder-border-muted);
-  border-radius: var(--cinder-radius-sm);
+  .cinder-search-field__shortcut {
+    display: inline-flex;
+    align-items: center;
+    flex: 0 0 auto;
+    padding-inline: var(--cinder-space-1-5);
+    padding-block: var(--cinder-space-0-5);
+    font-family: inherit;
+    font-size: var(--cinder-text-xs);
+    line-height: 1;
+    color: var(--cinder-text-muted);
+    background: var(--cinder-surface-inset);
+    border: 1px solid var(--cinder-border-muted);
+    border-radius: var(--cinder-radius-sm);
+  }
 }

--- a/packages/components/src/components/section-heading/section-heading.css
+++ b/packages/components/src/components/section-heading/section-heading.css
@@ -1,70 +1,72 @@
-.cinder-section-heading {
-  display: flex;
-  flex-direction: column;
-  gap: var(--cinder-space-3);
-}
+@layer cinder.components {
+  .cinder-section-heading {
+    display: flex;
+    flex-direction: column;
+    gap: var(--cinder-space-3);
+  }
 
-.cinder-section-heading__row {
-  display: flex;
-  align-items: flex-start;
-  justify-content: space-between;
-  gap: var(--cinder-space-4);
-  flex-wrap: wrap;
-}
+  .cinder-section-heading__row {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: var(--cinder-space-4);
+    flex-wrap: wrap;
+  }
 
-.cinder-section-heading__primary {
-  display: flex;
-  flex-direction: column;
-  gap: var(--cinder-space-1);
-  min-width: 0;
-}
+  .cinder-section-heading__primary {
+    display: flex;
+    flex-direction: column;
+    gap: var(--cinder-space-1);
+    min-width: 0;
+  }
 
-.cinder-section-heading__hgroup {
-  display: flex;
-  flex-direction: column;
-  gap: var(--cinder-space-1);
-  margin: 0;
-}
+  .cinder-section-heading__hgroup {
+    display: flex;
+    flex-direction: column;
+    gap: var(--cinder-space-1);
+    margin: 0;
+  }
 
-/* Label contrast: --cinder-text-muted at --cinder-text-xs (12px uppercase) against
+  /* Label contrast: --cinder-text-muted at --cinder-text-xs (12px uppercase) against
    cinder surface tokens passes WCAG AA (4.5:1). Placing this on non-token
    backgrounds (custom colored surfaces) is the consumer's responsibility. */
-.cinder-section-heading__label {
-  margin: 0;
-  font-size: var(--cinder-text-xs);
-  font-weight: var(--cinder-font-semibold);
-  text-transform: uppercase;
-  letter-spacing: 0.04em;
-  color: var(--cinder-text-muted);
-}
+  .cinder-section-heading__label {
+    margin: 0;
+    font-size: var(--cinder-text-xs);
+    font-weight: var(--cinder-font-semibold);
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    color: var(--cinder-text-muted);
+  }
 
-.cinder-section-heading__title {
-  font-size: var(--cinder-text-lg);
-  font-weight: var(--cinder-font-semibold);
-  color: var(--cinder-text);
-  margin: 0;
-  line-height: var(--cinder-leading-tight);
-}
+  .cinder-section-heading__title {
+    font-size: var(--cinder-text-lg);
+    font-weight: var(--cinder-font-semibold);
+    color: var(--cinder-text);
+    margin: 0;
+    line-height: var(--cinder-leading-tight);
+  }
 
-.cinder-section-heading__description {
-  font-size: var(--cinder-text-sm);
-  color: var(--cinder-text-muted);
-  margin: 0;
-  max-width: 60ch;
-}
+  .cinder-section-heading__description {
+    font-size: var(--cinder-text-sm);
+    color: var(--cinder-text-muted);
+    margin: 0;
+    max-width: 60ch;
+  }
 
-.cinder-section-heading__actions {
-  display: flex;
-  align-items: center;
-  gap: var(--cinder-space-2);
-  flex-shrink: 0;
-}
+  .cinder-section-heading__actions {
+    display: flex;
+    align-items: center;
+    gap: var(--cinder-space-2);
+    flex-shrink: 0;
+  }
 
-.cinder-section-heading__tabs {
-  display: block;
-  min-width: 0;
-}
+  .cinder-section-heading__tabs {
+    display: block;
+    min-width: 0;
+  }
 
-.cinder-section-heading[data-cinder-variant='actions-and-tabs'] > .cinder-section-heading__tabs {
-  margin-top: calc(var(--cinder-space-2) * -1);
+  .cinder-section-heading[data-cinder-variant='actions-and-tabs'] > .cinder-section-heading__tabs {
+    margin-top: calc(var(--cinder-space-2) * -1);
+  }
 }

--- a/packages/components/src/components/segmented-control/segmented-control.css
+++ b/packages/components/src/components/segmented-control/segmented-control.css
@@ -1,159 +1,160 @@
-/* ========================================
+@layer cinder.components {
+  /* ========================================
  * SEGMENTED CONTROL
  * ======================================== */
 
-.cinder-segmented-control-container {
-  display: inline-flex;
-  flex-direction: column;
-  gap: var(--cinder-space-2);
-}
+  .cinder-segmented-control-container {
+    display: inline-flex;
+    flex-direction: column;
+    gap: var(--cinder-space-2);
+  }
 
-.cinder-segmented-control-container:has([data-cinder-full-width]) {
-  display: flex;
-  width: 100%;
-}
+  .cinder-segmented-control-container:has([data-cinder-full-width]) {
+    display: flex;
+    width: 100%;
+  }
 
-.cinder-segmented-control-label {
-  color: var(--cinder-text);
-  font-size: var(--cinder-text-sm);
-  font-weight: var(--cinder-font-medium);
-}
+  .cinder-segmented-control-label {
+    color: var(--cinder-text);
+    font-size: var(--cinder-text-sm);
+    font-weight: var(--cinder-font-medium);
+  }
 
-/* ── Attached (default) ─────────────────────────────────────────────────── */
+  /* ── Attached (default) ─────────────────────────────────────────────────── */
 
-.cinder-segmented-control {
-  display: inline-flex;
-  align-items: center;
-  gap: 0;
-  padding: 1px;
-  border: 1px solid var(--cinder-border-muted);
-  border-radius: var(--cinder-radius-md);
-  background: var(--cinder-surface-inset);
-}
+  .cinder-segmented-control {
+    display: inline-flex;
+    align-items: center;
+    gap: 0;
+    padding: 1px;
+    border: 1px solid var(--cinder-border-muted);
+    border-radius: var(--cinder-radius-md);
+    background: var(--cinder-surface-inset);
+  }
 
-/* ── Full width ─────────────────────────────────────────────────────────── */
+  /* ── Full width ─────────────────────────────────────────────────────────── */
 
-.cinder-segmented-control[data-cinder-full-width] {
-  display: flex;
-  width: 100%;
-}
+  .cinder-segmented-control[data-cinder-full-width] {
+    display: flex;
+    width: 100%;
+  }
 
-.cinder-segmented-control[data-cinder-full-width] .cinder-segmented-control-option {
-  flex: 1;
-}
+  .cinder-segmented-control[data-cinder-full-width] .cinder-segmented-control-option {
+    flex: 1;
+  }
 
-/* ── Vertical orientation ───────────────────────────────────────────────── */
+  /* ── Vertical orientation ───────────────────────────────────────────────── */
 
-.cinder-segmented-control[data-cinder-orientation='vertical'] {
-  flex-direction: column;
-}
+  .cinder-segmented-control[data-cinder-orientation='vertical'] {
+    flex-direction: column;
+  }
 
-/* ── Detached ────────────────────────────────────────────────────────────── */
+  /* ── Detached ────────────────────────────────────────────────────────────── */
 
-.cinder-segmented-control[data-cinder-detached] {
-  gap: var(--cinder-space-1);
-  padding: 0;
-  border: none;
-  background: transparent;
-}
+  .cinder-segmented-control[data-cinder-detached] {
+    gap: var(--cinder-space-1);
+    padding: 0;
+    border: none;
+    background: transparent;
+  }
 
-.cinder-segmented-control[data-cinder-detached] .cinder-segmented-control-option {
-  border: 1px solid var(--cinder-border-muted);
-  border-radius: var(--cinder-radius-md);
-}
+  .cinder-segmented-control[data-cinder-detached] .cinder-segmented-control-option {
+    border: 1px solid var(--cinder-border-muted);
+    border-radius: var(--cinder-radius-md);
+  }
 
-/* ── Disabled group ─────────────────────────────────────────────────────── */
+  /* ── Disabled group ─────────────────────────────────────────────────────── */
 
-.cinder-segmented-control[aria-disabled='true'] {
-  /* opacity centralized in foundation.css disabled-visual rule (0.6) */
-  pointer-events: none;
-}
+  .cinder-segmented-control[aria-disabled='true'] {
+    /* opacity centralized in foundation.css disabled-visual rule (0.6) */
+    pointer-events: none;
+  }
 
-/* ── Option base ────────────────────────────────────────────────────────── */
+  /* ── Option base ────────────────────────────────────────────────────────── */
 
-.cinder-segmented-control-option {
-  position: relative;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  gap: var(--cinder-space-1);
-  border: 0;
-  border-radius: calc(var(--cinder-radius-sm) - 1px);
-  background: transparent;
-  color: var(--cinder-text-muted);
-  cursor: pointer;
-  font-weight: var(--cinder-font-medium);
-  line-height: 1;
-  transition:
-    background-color var(--cinder-duration-fast) var(--cinder-ease-standard),
-    color var(--cinder-duration-fast) var(--cinder-ease-standard),
-    box-shadow var(--cinder-duration-fast) var(--cinder-ease-standard);
-}
+  .cinder-segmented-control-option {
+    position: relative;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: var(--cinder-space-1);
+    border: 0;
+    border-radius: calc(var(--cinder-radius-sm) - 1px);
+    background: transparent;
+    color: var(--cinder-text-muted);
+    cursor: pointer;
+    font-weight: var(--cinder-font-medium);
+    line-height: 1;
+    transition:
+      background-color var(--cinder-duration-fast) var(--cinder-ease-standard),
+      color var(--cinder-duration-fast) var(--cinder-ease-standard),
+      box-shadow var(--cinder-duration-fast) var(--cinder-ease-standard);
+  }
 
-/* Separator between attached options */
-.cinder-segmented-control:not([data-cinder-detached])
-  .cinder-segmented-control-option:not(:first-child)::before {
-  content: '';
-  position: absolute;
-  inset-inline-start: 0;
-  block-size: 60%;
-  border-inline-start: 1px solid var(--cinder-border-muted);
-  transition: opacity var(--cinder-duration-fast) var(--cinder-ease-standard);
-}
+  /* Separator between attached options */
+  .cinder-segmented-control:not([data-cinder-detached])
+    .cinder-segmented-control-option:not(:first-child)::before {
+    content: '';
+    position: absolute;
+    inset-inline-start: 0;
+    block-size: 60%;
+    border-inline-start: 1px solid var(--cinder-border-muted);
+    transition: opacity var(--cinder-duration-fast) var(--cinder-ease-standard);
+  }
 
-.cinder-segmented-control:not([data-cinder-detached])
-  .cinder-segmented-control-option[data-cinder-selected]:not(:first-child)::before,
-.cinder-segmented-control:not([data-cinder-detached])
-  .cinder-segmented-control-option[data-cinder-pressed]:not(:first-child)::before,
-.cinder-segmented-control:not([data-cinder-detached])
-  [data-cinder-selected]
-  + .cinder-segmented-control-option::before,
-.cinder-segmented-control:not([data-cinder-detached])
-  [data-cinder-pressed]
-  + .cinder-segmented-control-option::before {
-  opacity: 0;
-}
+  .cinder-segmented-control:not([data-cinder-detached])
+    .cinder-segmented-control-option[data-cinder-selected]:not(:first-child)::before,
+  .cinder-segmented-control:not([data-cinder-detached])
+    .cinder-segmented-control-option[data-cinder-pressed]:not(:first-child)::before,
+  .cinder-segmented-control:not([data-cinder-detached])
+    [data-cinder-selected]
+    + .cinder-segmented-control-option::before,
+  .cinder-segmented-control:not([data-cinder-detached])
+    [data-cinder-pressed]
+    + .cinder-segmented-control-option::before {
+    opacity: 0;
+  }
 
-.cinder-segmented-control[data-cinder-orientation='vertical']
-  .cinder-segmented-control-option:not(:first-child)::before {
-  inset-inline-start: unset;
-  inset-block-start: 0;
-  inline-size: 60%;
-  block-size: auto;
-  border-inline-start: none;
-  border-block-start: 1px solid var(--cinder-border-muted);
-}
+  .cinder-segmented-control[data-cinder-orientation='vertical']
+    .cinder-segmented-control-option:not(:first-child)::before {
+    inset-inline-start: unset;
+    inset-block-start: 0;
+    inline-size: 60%;
+    block-size: auto;
+    border-inline-start: none;
+    border-block-start: 1px solid var(--cinder-border-muted);
+  }
 
-/* ── Size variants ──────────────────────────────────────────────────────── */
+  /* ── Size variants ──────────────────────────────────────────────────────── */
 
-/* sm: 1.5rem = 24px @ 16px base — WCAG 2.5.8 minimum touch target.
+  /* sm: 1.5rem = 24px @ 16px base — WCAG 2.5.8 minimum touch target.
  * Note: 2.5.8 also requires >=24px of offset space between adjacent targets
  * smaller than 24px in either dimension. Attached options sit flush against
  * each other so the bounding box must stay >= 24px; do not reduce this. */
-.cinder-segmented-control[data-cinder-size='sm'] .cinder-segmented-control-option {
-  min-block-size: 1.5rem;
-  padding-block: var(--cinder-space-1);
-  padding-inline: var(--cinder-space-2);
-  font-size: var(--cinder-text-xs);
-}
+  .cinder-segmented-control[data-cinder-size='sm'] .cinder-segmented-control-option {
+    min-block-size: 1.5rem;
+    padding-block: var(--cinder-space-1);
+    padding-inline: var(--cinder-space-2);
+    font-size: var(--cinder-text-xs);
+  }
 
-/* md: 2rem = 32px — comfortable middle ground */
-.cinder-segmented-control[data-cinder-size='md'] .cinder-segmented-control-option {
-  min-block-size: 2rem;
-  padding-block: var(--cinder-space-1);
-  padding-inline: var(--cinder-space-2);
-  font-size: var(--cinder-text-sm);
-}
+  /* md: 2rem = 32px — comfortable middle ground */
+  .cinder-segmented-control[data-cinder-size='md'] .cinder-segmented-control-option {
+    min-block-size: 2rem;
+    padding-block: var(--cinder-space-1);
+    padding-inline: var(--cinder-space-2);
+    font-size: var(--cinder-text-sm);
+  }
 
-/* lg: 2.75rem = 44px — recommended pointer/touch target per WCAG 2.5.5 */
-.cinder-segmented-control[data-cinder-size='lg'] .cinder-segmented-control-option {
-  min-block-size: 2.75rem;
-  padding-block: var(--cinder-space-2);
-  padding-inline: var(--cinder-space-3, 0.75rem);
-  font-size: var(--cinder-text-sm);
-}
+  /* lg: 2.75rem = 44px — recommended pointer/touch target per WCAG 2.5.5 */
+  .cinder-segmented-control[data-cinder-size='lg'] .cinder-segmented-control-option {
+    min-block-size: 2.75rem;
+    padding-block: var(--cinder-space-2);
+    padding-inline: var(--cinder-space-3, 0.75rem);
+    font-size: var(--cinder-text-sm);
+  }
 
-/* density="toolbar" resolves through the component to data-cinder-size="sm",
+  /* density="toolbar" resolves through the component to data-cinder-size="sm",
  * so font and (for detached or vertical toolbars) inline padding flow from
  * the `sm` rule above; attached horizontal toolbars pick up the 12px inline
  * padding from the override block below because they match the
@@ -167,11 +168,11 @@
  * unscoped by orientation — vertical toolbar density is not a supported
  * combination, since stacking 32px options vertically would defeat the
  * row-alignment contract; treat vertical + toolbar as undefined. */
-.cinder-segmented-control[data-cinder-density='toolbar'] .cinder-segmented-control-option {
-  min-block-size: var(--cinder-control-height-sm);
-}
+  .cinder-segmented-control[data-cinder-density='toolbar'] .cinder-segmented-control-option {
+    min-block-size: var(--cinder-control-height-sm);
+  }
 
-/* Attached horizontal options need at least 12px between the inter-segment
+  /* Attached horizontal options need at least 12px between the inter-segment
  * separator (rendered as a ::before pseudo-element at inset-inline-start: 0)
  * and the option label. The base `sm` and `md` size rules use --cinder-space-2
  * (0.5rem = 8px), which causes labels to pinch against the separator. Bump
@@ -181,30 +182,30 @@
  * controls resolve to data-cinder-size="sm" via the Svelte component, so
  * attached horizontal toolbars match the `sm` arm of this selector and
  * correctly receive the 12px inline padding too. */
-.cinder-segmented-control:not(
-    [data-cinder-detached]
-  )[data-cinder-orientation='horizontal'][data-cinder-size='sm']
-  .cinder-segmented-control-option,
-.cinder-segmented-control:not(
-    [data-cinder-detached]
-  )[data-cinder-orientation='horizontal'][data-cinder-size='md']
-  .cinder-segmented-control-option {
-  padding-inline: var(--cinder-space-3, 0.75rem);
-}
-
-/* ── Hover ──────────────────────────────────────────────────────────────── */
-
-/* Sticky-hover suppression on touch: wrap hover-only chrome so it doesn't
- * "stick" after tap on touch devices that emulate :hover. */
-@media (hover: hover) {
-  .cinder-segmented-control-option:hover:not(:disabled):not([data-cinder-selected]):not(
-      [data-cinder-pressed]
-    ) {
-    background: color-mix(in oklch, var(--cinder-accent), transparent 90%);
-    color: var(--cinder-text);
+  .cinder-segmented-control:not(
+      [data-cinder-detached]
+    )[data-cinder-orientation='horizontal'][data-cinder-size='sm']
+    .cinder-segmented-control-option,
+  .cinder-segmented-control:not(
+      [data-cinder-detached]
+    )[data-cinder-orientation='horizontal'][data-cinder-size='md']
+    .cinder-segmented-control-option {
+    padding-inline: var(--cinder-space-3, 0.75rem);
   }
 
-  /* Selected/pressed segments get hover feedback too, so they don't read as
+  /* ── Hover ──────────────────────────────────────────────────────────────── */
+
+  /* Sticky-hover suppression on touch: wrap hover-only chrome so it doesn't
+ * "stick" after tap on touch devices that emulate :hover. */
+  @media (hover: hover) {
+    .cinder-segmented-control-option:hover:not(:disabled):not([data-cinder-selected]):not(
+        [data-cinder-pressed]
+      ) {
+      background: color-mix(in oklch, var(--cinder-accent), transparent 90%);
+      color: var(--cinder-text);
+    }
+
+    /* Selected/pressed segments get hover feedback too, so they don't read as
    * disabled. Darken the accent fill via the theme-aware accent-hover token
    * while keeping the selected contrast color (inherited from the resting
    * selected/pressed rules). A selected-but-disabled segment stays focusable
@@ -212,54 +213,54 @@
    * attribute (see segmented-control.a11y.md / the C6 selected-but-disabled
    * contract), so guard on BOTH :not(:disabled) and :not([aria-disabled='true'])
    * to keep hover chrome off disabled segments. */
-  .cinder-segmented-control-option[data-cinder-selected]:hover:not(:disabled):not(
-      [aria-disabled='true']
-    ),
-  .cinder-segmented-control-option[data-cinder-pressed]:hover:not(:disabled):not(
-      [aria-disabled='true']
-    ) {
-    background: var(--cinder-accent-hover);
+    .cinder-segmented-control-option[data-cinder-selected]:hover:not(:disabled):not(
+        [aria-disabled='true']
+      ),
+    .cinder-segmented-control-option[data-cinder-pressed]:hover:not(:disabled):not(
+        [aria-disabled='true']
+      ) {
+      background: var(--cinder-accent-hover);
+    }
   }
-}
 
-/* ── Focus ──────────────────────────────────────────────────────────────── */
+  /* ── Focus ──────────────────────────────────────────────────────────────── */
 
-.cinder-segmented-control-option:focus-visible {
-  outline: 2px solid transparent;
-  box-shadow:
-    0 0 0 var(--cinder-ring-offset) var(--cinder-ring-offset-color),
-    0 0 0 calc(var(--cinder-ring-offset) + var(--cinder-ring-width)) var(--cinder-ring-color);
-  z-index: 1;
-}
+  .cinder-segmented-control-option:focus-visible {
+    outline: 2px solid transparent;
+    box-shadow:
+      0 0 0 var(--cinder-ring-offset) var(--cinder-ring-offset-color),
+      0 0 0 calc(var(--cinder-ring-offset) + var(--cinder-ring-width)) var(--cinder-ring-color);
+    z-index: 1;
+  }
 
-/* ── Disabled option ────────────────────────────────────────────────────── */
+  /* ── Disabled option ────────────────────────────────────────────────────── */
 
-.cinder-segmented-control-option:disabled {
-  cursor: not-allowed;
-  /* opacity centralized in foundation.css disabled-visual rule (0.6) */
-}
+  .cinder-segmented-control-option:disabled {
+    cursor: not-allowed;
+    /* opacity centralized in foundation.css disabled-visual rule (0.6) */
+  }
 
-/* ── Selected (single mode) ─────────────────────────────────────────────── */
+  /* ── Selected (single mode) ─────────────────────────────────────────────── */
 
-.cinder-segmented-control-option[data-cinder-selected] {
-  background: var(--cinder-accent);
-  color: var(--cinder-accent-contrast);
-  box-shadow: var(--cinder-shadow-sm, 0 1px 2px rgb(0 0 0 / 0.1));
-}
+  .cinder-segmented-control-option[data-cinder-selected] {
+    background: var(--cinder-accent);
+    color: var(--cinder-accent-contrast);
+    box-shadow: var(--cinder-shadow-sm, 0 1px 2px rgb(0 0 0 / 0.1));
+  }
 
-.cinder-segmented-control-option-icon {
-  opacity: 0.9;
-}
+  .cinder-segmented-control-option-icon {
+    opacity: 0.9;
+  }
 
-/* ── Pressed (multiple mode) ────────────────────────────────────────────── */
+  /* ── Pressed (multiple mode) ────────────────────────────────────────────── */
 
-.cinder-segmented-control-option[data-cinder-pressed] {
-  background: var(--cinder-accent);
-  color: var(--cinder-accent-contrast);
-  box-shadow: var(--cinder-shadow-sm, 0 1px 2px rgb(0 0 0 / 0.1));
-}
+  .cinder-segmented-control-option[data-cinder-pressed] {
+    background: var(--cinder-accent);
+    color: var(--cinder-accent-contrast);
+    box-shadow: var(--cinder-shadow-sm, 0 1px 2px rgb(0 0 0 / 0.1));
+  }
 
-/* ── Tablist variant (single mode only) ─────────────────────────────────────
+  /* ── Tablist variant (single mode only) ─────────────────────────────────────
  * See docs/decisions/segmented-control-tablist-variant.md. The tablist variant
  * carries tab semantics for externally owned panels, so it must read as a
  * tab strip rather than the default filled-pill radiogroup. All rules here are
@@ -273,98 +274,99 @@
  * to non-tablist roots.
  * ──────────────────────────────────────────────────────────────────────────── */
 
-/* Strip the surface-inset container chrome: no background, no enclosing border,
+  /* Strip the surface-inset container chrome: no background, no enclosing border,
  * no inset padding. Layout, sizing, density, and full-width behavior are
  * unaffected because they key off other selectors. */
-.cinder-segmented-control[data-cinder-selection-mode='single'][data-cinder-variant='tablist'] {
-  padding: 0;
-  border: none;
-  background: transparent;
-}
+  .cinder-segmented-control[data-cinder-selection-mode='single'][data-cinder-variant='tablist'] {
+    padding: 0;
+    border: none;
+    background: transparent;
+  }
 
-/* Suppress the connected-bar separators between attached tablist options. The
+  /* Suppress the connected-bar separators between attached tablist options. The
  * base separator and its vertical variant both render via the option
  * ::before; neutralize them here for tablists only. */
-.cinder-segmented-control[data-cinder-selection-mode='single'][data-cinder-variant='tablist']:not(
-    [data-cinder-detached]
-  )
-  .cinder-segmented-control-option:not(:first-child)::before {
-  content: none;
-}
+  .cinder-segmented-control[data-cinder-selection-mode='single'][data-cinder-variant='tablist']:not(
+      [data-cinder-detached]
+    )
+    .cinder-segmented-control-option:not(:first-child)::before {
+    content: none;
+  }
 
-/* Selected tab: accent text, no filled background, no selected shadow. The
+  /* Selected tab: accent text, no filled background, no selected shadow. The
  * underline-style indicator (below) carries the selected affordance instead. */
-.cinder-segmented-control[data-cinder-selection-mode='single'][data-cinder-variant='tablist']
-  .cinder-segmented-control-option[data-cinder-selected] {
-  background: transparent;
-  color: var(--cinder-accent);
-}
+  .cinder-segmented-control[data-cinder-selection-mode='single'][data-cinder-variant='tablist']
+    .cinder-segmented-control-option[data-cinder-selected] {
+    background: transparent;
+    color: var(--cinder-accent);
+  }
 
-/* The base `[data-cinder-selected]` rule paints the filled-pill drop shadow via
+  /* The base `[data-cinder-selected]` rule paints the filled-pill drop shadow via
  * box-shadow; strip it for tablists. Scope to `:not(:focus-visible)` so this
  * does not run on the focused selected tab — the focus ring (also box-shadow)
  * must survive there. */
-.cinder-segmented-control[data-cinder-selection-mode='single'][data-cinder-variant='tablist']
-  .cinder-segmented-control-option[data-cinder-selected]:not(:focus-visible) {
-  box-shadow: none;
-}
+  .cinder-segmented-control[data-cinder-selection-mode='single'][data-cinder-variant='tablist']
+    .cinder-segmented-control-option[data-cinder-selected]:not(:focus-visible) {
+    box-shadow: none;
+  }
 
-/* Re-assert the focus ring on the selected + focused tab. Stripping the pill
+  /* Re-assert the focus ring on the selected + focused tab. Stripping the pill
  * shadow above is not enough: the base `[data-cinder-selected]` rule
  * (box-shadow: shadow-sm, specificity 0,2,0) is declared after the base
  * `:focus-visible` ring rule (equal specificity), so on a focused selected tab
  * the base selected shadow would otherwise win and the ring would vanish. This
  * higher-specificity tablist rule, declared last, restores the exact base ring
  * shadow so keyboard focus stays visible on the active tab. */
-.cinder-segmented-control[data-cinder-selection-mode='single'][data-cinder-variant='tablist']
-  .cinder-segmented-control-option[data-cinder-selected]:focus-visible {
-  box-shadow:
-    0 0 0 var(--cinder-ring-offset) var(--cinder-ring-offset-color),
-    0 0 0 calc(var(--cinder-ring-offset) + var(--cinder-ring-width)) var(--cinder-ring-color);
-}
+  .cinder-segmented-control[data-cinder-selection-mode='single'][data-cinder-variant='tablist']
+    .cinder-segmented-control-option[data-cinder-selected]:focus-visible {
+    box-shadow:
+      0 0 0 var(--cinder-ring-offset) var(--cinder-ring-offset-color),
+      0 0 0 calc(var(--cinder-ring-offset) + var(--cinder-ring-width)) var(--cinder-ring-color);
+  }
 
-/* Forced-colors / Windows High Contrast: box-shadow rings are suppressed by the
+  /* Forced-colors / Windows High Contrast: box-shadow rings are suppressed by the
  * UA, so the base option focus ring (outline: transparent + box-shadow) becomes
  * invisible. Substitute a system-color outline, matching the Tabs component. */
-@media (forced-colors: active) {
-  .cinder-segmented-control-option:focus-visible {
-    outline: var(--cinder-ring-width) solid Highlight;
-    outline-offset: 1px;
+  @media (forced-colors: active) {
+    .cinder-segmented-control-option:focus-visible {
+      outline: var(--cinder-ring-width) solid Highlight;
+      outline-offset: 1px;
+    }
   }
-}
 
-/* Selected hover must not restore the filled pill — keep the selected tab's
+  /* Selected hover must not restore the filled pill — keep the selected tab's
  * transparent background and accent text. Unselected hover keeps the base
  * accent-tint treatment from the base hover rule. */
-@media (hover: hover) {
-  .cinder-segmented-control[data-cinder-selection-mode='single'][data-cinder-variant='tablist']
-    .cinder-segmented-control-option[data-cinder-selected]:hover {
-    background: transparent;
-    color: var(--cinder-accent);
+  @media (hover: hover) {
+    .cinder-segmented-control[data-cinder-selection-mode='single'][data-cinder-variant='tablist']
+      .cinder-segmented-control-option[data-cinder-selected]:hover {
+      background: transparent;
+      color: var(--cinder-accent);
+    }
   }
-}
 
-/* Accent indicator on the selected tab edge. The option is already
+  /* Accent indicator on the selected tab edge. The option is already
  * position: relative (base rule), so the absolutely positioned ::after anchors
  * to it without changing layout. Horizontal tablists place the indicator on the
  * block-end edge spanning the inline axis; the vertical override below moves it
  * to the inline-start edge spanning the block axis. */
-.cinder-segmented-control[data-cinder-selection-mode='single'][data-cinder-variant='tablist']
-  .cinder-segmented-control-option[data-cinder-selected]::after {
-  content: '';
-  position: absolute;
-  inset-inline: 0;
-  inset-block-end: 0;
-  block-size: 2px;
-  background: var(--cinder-accent);
-  border-radius: var(--cinder-radius-full, 999px);
-}
+  .cinder-segmented-control[data-cinder-selection-mode='single'][data-cinder-variant='tablist']
+    .cinder-segmented-control-option[data-cinder-selected]::after {
+    content: '';
+    position: absolute;
+    inset-inline: 0;
+    inset-block-end: 0;
+    block-size: 2px;
+    background: var(--cinder-accent);
+    border-radius: var(--cinder-radius-full, 999px);
+  }
 
-/* Vertical tablist indicator: inline-start edge, spanning the block axis. */
-.cinder-segmented-control[data-cinder-selection-mode='single'][data-cinder-variant='tablist'][data-cinder-orientation='vertical']
-  .cinder-segmented-control-option[data-cinder-selected]::after {
-  inset-inline: 0 auto;
-  inset-block: 0;
-  inline-size: 2px;
-  block-size: auto;
+  /* Vertical tablist indicator: inline-start edge, spanning the block axis. */
+  .cinder-segmented-control[data-cinder-selection-mode='single'][data-cinder-variant='tablist'][data-cinder-orientation='vertical']
+    .cinder-segmented-control-option[data-cinder-selected]::after {
+    inset-inline: 0 auto;
+    inset-block: 0;
+    inline-size: 2px;
+    block-size: auto;
+  }
 }

--- a/packages/components/src/components/select/select.css
+++ b/packages/components/src/components/select/select.css
@@ -1,186 +1,188 @@
-/* ========================================
+@layer cinder.components {
+  /* ========================================
  * SELECT
  * ======================================== */
 
-.cinder-select-field {
-  display: flex;
-  flex-direction: column;
-  gap: var(--cinder-space-1-5);
-}
+  .cinder-select-field {
+    display: flex;
+    flex-direction: column;
+    gap: var(--cinder-space-1-5);
+  }
 
-/* ----------------------------------------
+  /* ----------------------------------------
  * Label
  * ---------------------------------------- */
 
-.cinder-select-field > label {
-  display: inline-block;
-  font-size: var(--cinder-text-xs);
-  font-weight: var(--cinder-font-medium);
-  line-height: 1;
-  color: var(--cinder-text);
-}
+  .cinder-select-field > label {
+    display: inline-block;
+    font-size: var(--cinder-text-xs);
+    font-weight: var(--cinder-font-medium);
+    line-height: 1;
+    color: var(--cinder-text);
+  }
 
-/* ----------------------------------------
+  /* ----------------------------------------
  * Select control
  * ---------------------------------------- */
 
-.cinder-select-field__control {
-  display: block;
-  position: relative;
-  inline-size: 100%;
-}
-
-.cinder-select {
-  display: block;
-  width: 100%;
-  min-height: var(--cinder-control-height, 2.25rem);
-  padding: var(--cinder-space-1-5) var(--cinder-space-8) var(--cinder-space-1-5)
-    var(--cinder-space-3);
-
-  font-size: var(--cinder-text-sm);
-  line-height: var(--cinder-leading-normal);
-  color: var(--cinder-text);
-
-  background-color: var(--cinder-surface-raised);
-
-  border: 1px solid var(--cinder-border);
-  border-radius: var(--cinder-radius-md);
-
-  appearance: none;
-  cursor: pointer;
-
-  transition:
-    border-color var(--cinder-duration-fast) var(--cinder-ease-standard),
-    box-shadow var(--cinder-duration-fast) var(--cinder-ease-standard);
-}
-
-@media (hover: hover) {
-  .cinder-select:hover:not(:disabled) {
-    border-color: var(--cinder-border-strong);
+  .cinder-select-field__control {
+    display: block;
+    position: relative;
+    inline-size: 100%;
   }
-}
 
-.cinder-select:focus-visible {
-  outline: var(--cinder-ring-width) solid transparent;
-  box-shadow: var(--_cinder-focus-ring-shadow);
-}
+  .cinder-select {
+    display: block;
+    width: 100%;
+    min-height: var(--cinder-control-height, 2.25rem);
+    padding: var(--cinder-space-1-5) var(--cinder-space-8) var(--cinder-space-1-5)
+      var(--cinder-space-3);
 
-/* Forced Colors Mode: box-shadow is ignored; restore an outline-based ring so
- * keyboard focus remains visible in Windows High Contrast and print modes. */
-@media (forced-colors: active) {
+    font-size: var(--cinder-text-sm);
+    line-height: var(--cinder-leading-normal);
+    color: var(--cinder-text);
+
+    background-color: var(--cinder-surface-raised);
+
+    border: 1px solid var(--cinder-border);
+    border-radius: var(--cinder-radius-md);
+
+    appearance: none;
+    cursor: pointer;
+
+    transition:
+      border-color var(--cinder-duration-fast) var(--cinder-ease-standard),
+      box-shadow var(--cinder-duration-fast) var(--cinder-ease-standard);
+  }
+
+  @media (hover: hover) {
+    .cinder-select:hover:not(:disabled) {
+      border-color: var(--cinder-border-strong);
+    }
+  }
+
   .cinder-select:focus-visible {
-    outline: var(--cinder-ring-width) solid ButtonText;
-    outline-offset: 3px;
+    outline: var(--cinder-ring-width) solid transparent;
+    box-shadow: var(--_cinder-focus-ring-shadow);
   }
-}
 
-.cinder-select:disabled {
-  background-color: var(--cinder-surface-inset);
-  border-color: var(--cinder-border-muted);
-  color: var(--cinder-text-disabled);
-  cursor: not-allowed;
-}
+  /* Forced Colors Mode: box-shadow is ignored; restore an outline-based ring so
+ * keyboard focus remains visible in Windows High Contrast and print modes. */
+  @media (forced-colors: active) {
+    .cinder-select:focus-visible {
+      outline: var(--cinder-ring-width) solid ButtonText;
+      outline-offset: 3px;
+    }
+  }
 
-/* Empty guard — visual indicator when no options are available */
-.cinder-select[data-cinder-empty='true'] {
-  border-style: dashed;
-  opacity: 0.5;
-  cursor: not-allowed;
-}
+  .cinder-select:disabled {
+    background-color: var(--cinder-surface-inset);
+    border-color: var(--cinder-border-muted);
+    color: var(--cinder-text-disabled);
+    cursor: not-allowed;
+  }
 
-/* ----------------------------------------
+  /* Empty guard — visual indicator when no options are available */
+  .cinder-select[data-cinder-empty='true'] {
+    border-style: dashed;
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+
+  /* ----------------------------------------
  * Decorative chevron
  * Painted with `mask-image` + `background-color: currentColor` so the icon
  * color tracks the `--cinder-text-muted` token through theme switches.
  * ---------------------------------------- */
 
-.cinder-select-field__chevron {
-  position: absolute;
-  inset-block-start: 50%;
-  inset-inline-end: var(--cinder-space-2);
-  inline-size: 1rem;
-  block-size: 1rem;
-  transform: translateY(-50%);
-  pointer-events: none;
-  z-index: 1;
+  .cinder-select-field__chevron {
+    position: absolute;
+    inset-block-start: 50%;
+    inset-inline-end: var(--cinder-space-2);
+    inline-size: 1rem;
+    block-size: 1rem;
+    transform: translateY(-50%);
+    pointer-events: none;
+    z-index: 1;
 
-  color: var(--cinder-text-muted);
-  background-color: currentColor;
+    color: var(--cinder-text-muted);
+    background-color: currentColor;
 
-  --_cinder-select-chevron-mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20'%3E%3Cpath fill-rule='evenodd' d='M5.23 7.21a.75.75 0 011.06.02L10 11.168l3.71-3.938a.75.75 0 111.08 1.04l-4.25 4.5a.75.75 0 01-1.08 0l-4.25-4.5a.75.75 0 01.02-1.06z' clip-rule='evenodd'/%3E%3C/svg%3E");
+    --_cinder-select-chevron-mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20'%3E%3Cpath fill-rule='evenodd' d='M5.23 7.21a.75.75 0 011.06.02L10 11.168l3.71-3.938a.75.75 0 111.08 1.04l-4.25 4.5a.75.75 0 01-1.08 0l-4.25-4.5a.75.75 0 01.02-1.06z' clip-rule='evenodd'/%3E%3C/svg%3E");
 
-  -webkit-mask-image: var(--_cinder-select-chevron-mask);
-  mask-image: var(--_cinder-select-chevron-mask);
-  -webkit-mask-repeat: no-repeat;
-  mask-repeat: no-repeat;
-  -webkit-mask-position: center;
-  mask-position: center;
-  -webkit-mask-size: 1rem 1rem;
-  mask-size: 1rem 1rem;
-}
+    -webkit-mask-image: var(--_cinder-select-chevron-mask);
+    mask-image: var(--_cinder-select-chevron-mask);
+    -webkit-mask-repeat: no-repeat;
+    mask-repeat: no-repeat;
+    -webkit-mask-position: center;
+    mask-position: center;
+    -webkit-mask-size: 1rem 1rem;
+    mask-size: 1rem 1rem;
+  }
 
-.cinder-select:disabled + .cinder-select-field__chevron {
-  color: var(--cinder-text-disabled);
-}
+  .cinder-select:disabled + .cinder-select-field__chevron {
+    color: var(--cinder-text-disabled);
+  }
 
-.cinder-select[data-cinder-empty='true'] + .cinder-select-field__chevron {
-  opacity: 0.5;
-}
+  .cinder-select[data-cinder-empty='true'] + .cinder-select-field__chevron {
+    opacity: 0.5;
+  }
 
-/* Forced Colors Mode override — UA suppresses `background-color: currentColor`,
+  /* Forced Colors Mode override — UA suppresses `background-color: currentColor`,
  * so the masked chevron becomes invisible. Opt out of forced-color adjustment
  * for the glyph and paint with a system color that survives the override.
  * Disabled selects use the conventional `GrayText` system color to match how
  * the rest of the disabled control reads in High Contrast. */
-@media (forced-colors: active) {
-  .cinder-select-field__chevron {
-    forced-color-adjust: none;
-    background-color: ButtonText;
+  @media (forced-colors: active) {
+    .cinder-select-field__chevron {
+      forced-color-adjust: none;
+      background-color: ButtonText;
+    }
+
+    .cinder-select:disabled + .cinder-select-field__chevron {
+      background-color: GrayText;
+    }
   }
 
-  .cinder-select:disabled + .cinder-select-field__chevron {
-    background-color: GrayText;
-  }
-}
-
-/* ----------------------------------------
+  /* ----------------------------------------
  * Error / invalid state
  * ---------------------------------------- */
 
-.cinder-select[aria-invalid='true'] {
-  border-color: var(--cinder-danger);
-}
-
-@media (hover: hover) {
-  .cinder-select[aria-invalid='true']:hover:not(:disabled) {
-    border-color: oklch(from var(--cinder-danger) calc(l - 0.06) c h);
+  .cinder-select[aria-invalid='true'] {
+    border-color: var(--cinder-danger);
   }
-}
 
-/* ----------------------------------------
+  @media (hover: hover) {
+    .cinder-select[aria-invalid='true']:hover:not(:disabled) {
+      border-color: oklch(from var(--cinder-danger) calc(l - 0.06) c h);
+    }
+  }
+
+  /* ----------------------------------------
  * Supporting text
  * ---------------------------------------- */
 
-.cinder-select-field__description {
-  font-size: var(--cinder-text-xs);
-  line-height: var(--cinder-leading-normal);
-  color: var(--cinder-text-muted);
-  margin: 0;
-}
+  .cinder-select-field__description {
+    font-size: var(--cinder-text-xs);
+    line-height: var(--cinder-leading-normal);
+    color: var(--cinder-text-muted);
+    margin: 0;
+  }
 
-.cinder-select-field__error {
-  font-size: var(--cinder-text-xs);
-  line-height: var(--cinder-leading-normal);
-  color: var(--cinder-danger);
-  margin: 0;
-}
+  .cinder-select-field__error {
+    font-size: var(--cinder-text-xs);
+    line-height: var(--cinder-leading-normal);
+    color: var(--cinder-danger);
+    margin: 0;
+  }
 
-/* Hide the always-present live region when no error is active. Uses visibility
+  /* Hide the always-present live region when no error is active. Uses visibility
  * rather than display:none so the aria-live region stays in the accessibility
  * tree and is ready to announce changes. */
-.cinder-select-field__error:not([data-cinder-error]) {
-  position: absolute;
-  visibility: hidden;
-  height: 0;
-  overflow: hidden;
+  .cinder-select-field__error:not([data-cinder-error]) {
+    position: absolute;
+    visibility: hidden;
+    height: 0;
+    overflow: hidden;
+  }
 }

--- a/packages/components/src/components/select/select.test.ts
+++ b/packages/components/src/components/select/select.test.ts
@@ -3,6 +3,7 @@ import * as matchers from '@testing-library/jest-dom/matchers';
 import { describe, expect, spyOn, test } from 'bun:test';
 import { readFileSync } from 'node:fs';
 
+import { stripCinderComponentsLayer } from '../../test/css.ts';
 import { setupHappyDom } from '../../test/happy-dom.ts';
 
 // Extend Bun's expect with @testing-library/jest-dom matchers (e.g. toBeDisabled, toBeVisible).
@@ -25,7 +26,9 @@ const defaultOptions = [
 ];
 
 function readSelectStyles(): string {
-  return readFileSync(new URL('./select.css', import.meta.url), 'utf8');
+  // Strip the @layer wrapper: happy-dom does not apply layer-nested rules to
+  // getComputedStyle. Inner declarations are unchanged.
+  return stripCinderComponentsLayer(readFileSync(new URL('./select.css', import.meta.url), 'utf8'));
 }
 
 describe('Select', () => {

--- a/packages/components/src/components/selection-popover/selection-popover.css
+++ b/packages/components/src/components/selection-popover/selection-popover.css
@@ -1,211 +1,213 @@
-/* ========================================
+@layer cinder.components {
+  /* ========================================
  * SELECTION POPOVER
  * ======================================== */
 
-.cinder-selection-popover {
-  position: fixed;
-  z-index: var(--cinder-z-tooltip);
-  margin: 0;
-  padding: 0;
-  border: 0;
-  background: transparent;
-  translate: -50% 0;
-}
-
-.cinder-selection-popover:popover-open {
-  display: flex;
-}
-
-.cinder-selection-popover__button {
-  display: inline-flex;
-  align-items: center;
-  gap: var(--cinder-space-1-5);
-  padding: var(--cinder-space-1-5) var(--cinder-space-2);
-  border: 0;
-  border-radius: var(--cinder-radius-full);
-  background: var(--cinder-accent);
-  color: var(--cinder-accent-contrast);
-  cursor: pointer;
-  font-size: var(--cinder-text-xs);
-  font-weight: var(--cinder-font-medium);
-  box-shadow: var(--cinder-shadow-md, 0 4px 6px rgb(0 0 0 / 0.12));
-  transition:
-    background-color var(--cinder-duration-fast) var(--cinder-ease-standard),
-    transform var(--cinder-duration-fast) var(--cinder-ease-standard);
-}
-
-@media (hover: hover) {
-  .cinder-selection-popover__button:hover {
-    background: var(--cinder-accent-hover);
+  .cinder-selection-popover {
+    position: fixed;
+    z-index: var(--cinder-z-tooltip);
+    margin: 0;
+    padding: 0;
+    border: 0;
+    background: transparent;
+    translate: -50% 0;
   }
-}
 
-.cinder-selection-popover__button:focus-visible {
-  outline: var(--cinder-ring-width) solid transparent;
-  outline-offset: var(--cinder-ring-offset);
-  box-shadow:
-    var(--_cinder-focus-ring-shadow), var(--cinder-shadow-md, 0 4px 6px rgb(0 0 0 / 0.12));
-}
+  .cinder-selection-popover:popover-open {
+    display: flex;
+  }
 
-@media (forced-colors: active) {
+  .cinder-selection-popover__button {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--cinder-space-1-5);
+    padding: var(--cinder-space-1-5) var(--cinder-space-2);
+    border: 0;
+    border-radius: var(--cinder-radius-full);
+    background: var(--cinder-accent);
+    color: var(--cinder-accent-contrast);
+    cursor: pointer;
+    font-size: var(--cinder-text-xs);
+    font-weight: var(--cinder-font-medium);
+    box-shadow: var(--cinder-shadow-md, 0 4px 6px rgb(0 0 0 / 0.12));
+    transition:
+      background-color var(--cinder-duration-fast) var(--cinder-ease-standard),
+      transform var(--cinder-duration-fast) var(--cinder-ease-standard);
+  }
+
+  @media (hover: hover) {
+    .cinder-selection-popover__button:hover {
+      background: var(--cinder-accent-hover);
+    }
+  }
+
   .cinder-selection-popover__button:focus-visible {
-    outline: var(--cinder-ring-width) solid ButtonText;
-    outline-offset: 2px;
+    outline: var(--cinder-ring-width) solid transparent;
+    outline-offset: var(--cinder-ring-offset);
+    box-shadow:
+      var(--_cinder-focus-ring-shadow), var(--cinder-shadow-md, 0 4px 6px rgb(0 0 0 / 0.12));
   }
-}
 
-.cinder-selection-popover__button:active {
-  transform: scale(0.95);
-}
+  @media (forced-colors: active) {
+    .cinder-selection-popover__button:focus-visible {
+      outline: var(--cinder-ring-width) solid ButtonText;
+      outline-offset: 2px;
+    }
+  }
 
-.cinder-selection-popover__form {
-  display: flex;
-  flex-direction: column;
-  gap: var(--cinder-space-2);
-  width: 17.5rem;
-  padding: var(--cinder-space-2);
-  border: 1px solid var(--cinder-border);
-  border-radius: var(--cinder-radius-md);
-  background: var(--cinder-surface-raised);
-  box-shadow: var(--cinder-shadow-lg, 0 10px 15px rgb(0 0 0 / 0.15));
-}
+  .cinder-selection-popover__button:active {
+    transform: scale(0.95);
+  }
 
-.cinder-selection-popover__textarea {
-  width: 100%;
-  min-height: 3.75rem;
-  padding: var(--cinder-space-2);
-  border: 1px solid var(--cinder-border);
-  border-radius: var(--cinder-radius-sm);
-  background: var(--cinder-surface);
-  color: var(--cinder-text);
-  font: inherit;
-  font-size: var(--cinder-text-sm);
-  line-height: var(--cinder-leading-normal);
-  resize: vertical;
-}
+  .cinder-selection-popover__form {
+    display: flex;
+    flex-direction: column;
+    gap: var(--cinder-space-2);
+    width: 17.5rem;
+    padding: var(--cinder-space-2);
+    border: 1px solid var(--cinder-border);
+    border-radius: var(--cinder-radius-md);
+    background: var(--cinder-surface-raised);
+    box-shadow: var(--cinder-shadow-lg, 0 10px 15px rgb(0 0 0 / 0.15));
+  }
 
-.cinder-selection-popover__textarea:focus {
-  border-color: var(--cinder-accent);
-}
+  .cinder-selection-popover__textarea {
+    width: 100%;
+    min-height: 3.75rem;
+    padding: var(--cinder-space-2);
+    border: 1px solid var(--cinder-border);
+    border-radius: var(--cinder-radius-sm);
+    background: var(--cinder-surface);
+    color: var(--cinder-text);
+    font: inherit;
+    font-size: var(--cinder-text-sm);
+    line-height: var(--cinder-leading-normal);
+    resize: vertical;
+  }
 
-.cinder-selection-popover__textarea:focus,
-.cinder-selection-popover__textarea:focus-visible {
-  outline: var(--cinder-ring-width) solid transparent;
-  outline-offset: var(--cinder-ring-offset);
-  box-shadow: var(--_cinder-focus-ring-shadow);
-}
+  .cinder-selection-popover__textarea:focus {
+    border-color: var(--cinder-accent);
+  }
 
-@media (forced-colors: active) {
   .cinder-selection-popover__textarea:focus,
   .cinder-selection-popover__textarea:focus-visible {
-    outline: var(--cinder-ring-width) solid Highlight;
-    outline-offset: 1px;
+    outline: var(--cinder-ring-width) solid transparent;
+    outline-offset: var(--cinder-ring-offset);
+    box-shadow: var(--_cinder-focus-ring-shadow);
   }
-}
 
-.cinder-selection-popover__textarea::placeholder {
-  color: var(--cinder-text-subtle);
-}
-
-.cinder-selection-popover__actions {
-  display: flex;
-  justify-content: flex-end;
-  gap: var(--cinder-space-1);
-}
-
-.cinder-selection-popover__cancel,
-.cinder-selection-popover__submit {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  padding: var(--cinder-space-1-5);
-  border: 0;
-  border-radius: var(--cinder-radius-sm);
-  cursor: pointer;
-  transition: background-color var(--cinder-duration-fast) var(--cinder-ease-standard);
-}
-
-.cinder-selection-popover__cancel {
-  background: transparent;
-  color: var(--cinder-text-muted);
-}
-
-@media (hover: hover) {
-  .cinder-selection-popover__cancel:hover {
-    background: var(--cinder-surface-hover);
-    color: var(--cinder-text);
+  @media (forced-colors: active) {
+    .cinder-selection-popover__textarea:focus,
+    .cinder-selection-popover__textarea:focus-visible {
+      outline: var(--cinder-ring-width) solid Highlight;
+      outline-offset: 1px;
+    }
   }
-}
 
-.cinder-selection-popover__submit {
-  background: var(--cinder-accent);
-  color: var(--cinder-accent-contrast);
-}
-
-@media (hover: hover) {
-  .cinder-selection-popover__submit:hover:not(:disabled) {
-    background: var(--cinder-accent-hover);
+  .cinder-selection-popover__textarea::placeholder {
+    color: var(--cinder-text-subtle);
   }
-}
 
-.cinder-selection-popover__submit:disabled {
-  cursor: not-allowed;
-  opacity: 0.5;
-}
+  .cinder-selection-popover__actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: var(--cinder-space-1);
+  }
 
-.cinder-selection-popover__cancel:focus-visible,
-.cinder-selection-popover__submit:focus-visible {
-  outline: var(--cinder-ring-width) solid transparent;
-  outline-offset: var(--cinder-ring-offset);
-  box-shadow: var(--_cinder-focus-ring-shadow);
-}
+  .cinder-selection-popover__cancel,
+  .cinder-selection-popover__submit {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: var(--cinder-space-1-5);
+    border: 0;
+    border-radius: var(--cinder-radius-sm);
+    cursor: pointer;
+    transition: background-color var(--cinder-duration-fast) var(--cinder-ease-standard);
+  }
 
-@media (forced-colors: active) {
+  .cinder-selection-popover__cancel {
+    background: transparent;
+    color: var(--cinder-text-muted);
+  }
+
+  @media (hover: hover) {
+    .cinder-selection-popover__cancel:hover {
+      background: var(--cinder-surface-hover);
+      color: var(--cinder-text);
+    }
+  }
+
+  .cinder-selection-popover__submit {
+    background: var(--cinder-accent);
+    color: var(--cinder-accent-contrast);
+  }
+
+  @media (hover: hover) {
+    .cinder-selection-popover__submit:hover:not(:disabled) {
+      background: var(--cinder-accent-hover);
+    }
+  }
+
+  .cinder-selection-popover__submit:disabled {
+    cursor: not-allowed;
+    opacity: 0.5;
+  }
+
   .cinder-selection-popover__cancel:focus-visible,
   .cinder-selection-popover__submit:focus-visible {
-    outline: var(--cinder-ring-width) solid ButtonText;
-    outline-offset: 2px;
-  }
-}
-
-.cinder-selection-popover__icon {
-  width: 1rem;
-  height: 1rem;
-  fill: none;
-  stroke: currentColor;
-  stroke-linecap: round;
-  stroke-linejoin: round;
-  stroke-width: 2;
-}
-
-@keyframes cinder-selection-popover-in {
-  from {
-    opacity: 0;
-    translate: -50% -0.25rem;
-    scale: 0.95;
-  }
-  to {
-    opacity: 1;
-    translate: -50% 0;
-    scale: 1;
-  }
-}
-
-.cinder-selection-popover:popover-open {
-  animation: cinder-selection-popover-in var(--cinder-duration-fast) var(--cinder-ease-standard);
-}
-
-@media (prefers-reduced-motion: reduce) {
-  .cinder-selection-popover:popover-open {
-    animation: cinder-selection-popover-fade var(--cinder-duration-fast) linear;
+    outline: var(--cinder-ring-width) solid transparent;
+    outline-offset: var(--cinder-ring-offset);
+    box-shadow: var(--_cinder-focus-ring-shadow);
   }
 
-  @keyframes cinder-selection-popover-fade {
+  @media (forced-colors: active) {
+    .cinder-selection-popover__cancel:focus-visible,
+    .cinder-selection-popover__submit:focus-visible {
+      outline: var(--cinder-ring-width) solid ButtonText;
+      outline-offset: 2px;
+    }
+  }
+
+  .cinder-selection-popover__icon {
+    width: 1rem;
+    height: 1rem;
+    fill: none;
+    stroke: currentColor;
+    stroke-linecap: round;
+    stroke-linejoin: round;
+    stroke-width: 2;
+  }
+
+  @keyframes cinder-selection-popover-in {
     from {
       opacity: 0;
+      translate: -50% -0.25rem;
+      scale: 0.95;
     }
     to {
       opacity: 1;
+      translate: -50% 0;
+      scale: 1;
+    }
+  }
+
+  .cinder-selection-popover:popover-open {
+    animation: cinder-selection-popover-in var(--cinder-duration-fast) var(--cinder-ease-standard);
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .cinder-selection-popover:popover-open {
+      animation: cinder-selection-popover-fade var(--cinder-duration-fast) linear;
+    }
+
+    @keyframes cinder-selection-popover-fade {
+      from {
+        opacity: 0;
+      }
+      to {
+        opacity: 1;
+      }
     }
   }
 }

--- a/packages/components/src/components/sheet/sheet.css
+++ b/packages/components/src/components/sheet/sheet.css
@@ -1,4 +1,5 @@
-/* ========================================
+@layer cinder.components {
+  /* ========================================
  * SHEET
  * Bottom-anchored slide-up panel (mobile-native modal analog).
  * The <dialog> fills the viewport so backdrop-click on dialog is reliable;
@@ -6,193 +7,194 @@
  * capped by max-height so the backdrop still covers the full viewport.
  * ======================================== */
 
-.cinder-sheet {
-  border: none;
-  background: transparent;
-  padding: 0;
-  margin: 0;
-  position: fixed;
-  inset: 0;
-  width: 100vw;
-  height: 100dvh;
-  max-width: none;
-  max-height: none;
-  z-index: var(--cinder-z-modal);
-}
+  .cinder-sheet {
+    border: none;
+    background: transparent;
+    padding: 0;
+    margin: 0;
+    position: fixed;
+    inset: 0;
+    width: 100vw;
+    height: 100dvh;
+    max-width: none;
+    max-height: none;
+    z-index: var(--cinder-z-modal);
+  }
 
-.cinder-sheet::backdrop {
-  background-color: var(--cinder-overlay-backdrop);
-  backdrop-filter: blur(var(--cinder-overlay-blur));
-  transition: background-color var(--cinder-duration-normal) var(--cinder-ease-standard);
-}
+  .cinder-sheet::backdrop {
+    background-color: var(--cinder-overlay-backdrop);
+    backdrop-filter: blur(var(--cinder-overlay-blur));
+    transition: background-color var(--cinder-duration-normal) var(--cinder-ease-standard);
+  }
 
-.cinder-sheet[data-cinder-closing]::backdrop {
-  background-color: transparent;
-}
+  .cinder-sheet[data-cinder-closing]::backdrop {
+    background-color: transparent;
+  }
 
-.cinder-sheet__panel {
-  position: absolute;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  width: 100%;
-  max-height: 90dvh;
-  background: var(--cinder-surface-raised);
-  border-block-start: 1px solid var(--cinder-border);
-  border-start-start-radius: var(--cinder-radius-lg);
-  border-start-end-radius: var(--cinder-radius-lg);
-  box-shadow: var(--cinder-shadow-lg);
-  display: flex;
-  flex-direction: column;
-  overflow: hidden;
-  opacity: 1;
-  transition:
-    translate var(--cinder-duration-normal) var(--cinder-ease-spring),
-    opacity var(--cinder-duration-normal) var(--cinder-ease-standard);
-}
+  .cinder-sheet__panel {
+    position: absolute;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    width: 100%;
+    max-height: 90dvh;
+    background: var(--cinder-surface-raised);
+    border-block-start: 1px solid var(--cinder-border);
+    border-start-start-radius: var(--cinder-radius-lg);
+    border-start-end-radius: var(--cinder-radius-lg);
+    box-shadow: var(--cinder-shadow-lg);
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+    opacity: 1;
+    transition:
+      translate var(--cinder-duration-normal) var(--cinder-ease-spring),
+      opacity var(--cinder-duration-normal) var(--cinder-ease-standard);
+  }
 
-.cinder-sheet__drag-handle {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 100%;
-  /* 44px minimum touch target. */
-  min-height: var(--cinder-touch-target-min);
-  flex-shrink: 0;
-  /* The handle is decorative until swipe-to-close ships — no grab cursor. */
-  cursor: default;
-  user-select: none;
-}
+  .cinder-sheet__drag-handle {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 100%;
+    /* 44px minimum touch target. */
+    min-height: var(--cinder-touch-target-min);
+    flex-shrink: 0;
+    /* The handle is decorative until swipe-to-close ships — no grab cursor. */
+    cursor: default;
+    user-select: none;
+  }
 
-.cinder-sheet__drag-handle-pill {
-  display: block;
-  width: 2.5rem;
-  height: 0.25rem;
-  border-radius: var(--cinder-radius-full);
-  background: var(--cinder-border);
-}
+  .cinder-sheet__drag-handle-pill {
+    display: block;
+    width: 2.5rem;
+    height: 0.25rem;
+    border-radius: var(--cinder-radius-full);
+    background: var(--cinder-border);
+  }
 
-.cinder-sheet__header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: var(--cinder-space-4);
-  padding: var(--cinder-space-5) var(--cinder-space-6);
-  border-block-end: 1px solid var(--cinder-border);
-  flex-shrink: 0;
-}
+  .cinder-sheet__header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--cinder-space-4);
+    padding: var(--cinder-space-5) var(--cinder-space-6);
+    border-block-end: 1px solid var(--cinder-border);
+    flex-shrink: 0;
+  }
 
-.cinder-sheet__title {
-  margin: 0;
-  font-size: var(--cinder-text-lg);
-  font-weight: var(--cinder-font-semibold);
-  line-height: var(--cinder-leading-snug);
-  color: var(--cinder-text);
-  flex: 1;
-  min-width: 0;
-}
-
-.cinder-sheet__close {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  flex-shrink: 0;
-  /* 44px minimum touch target. */
-  width: 2.75rem;
-  height: 2.75rem;
-  padding: var(--cinder-space-1);
-  border-radius: var(--cinder-radius-md);
-  border: none;
-  background: transparent;
-  color: var(--cinder-text-muted);
-  cursor: pointer;
-  transition:
-    background-color var(--cinder-duration-fast) var(--cinder-ease-standard),
-    color var(--cinder-duration-fast) var(--cinder-ease-standard);
-}
-
-@media (hover: hover) {
-  .cinder-sheet__close:hover {
-    background: color-mix(in oklch, currentColor, transparent 85%);
+  .cinder-sheet__title {
+    margin: 0;
+    font-size: var(--cinder-text-lg);
+    font-weight: var(--cinder-font-semibold);
+    line-height: var(--cinder-leading-snug);
     color: var(--cinder-text);
+    flex: 1;
+    min-width: 0;
   }
-}
 
-.cinder-sheet__close:focus-visible {
-  outline: var(--cinder-ring-width) solid var(--cinder-ring-color);
-  outline-offset: var(--cinder-ring-offset);
-}
+  .cinder-sheet__close {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+    /* 44px minimum touch target. */
+    width: 2.75rem;
+    height: 2.75rem;
+    padding: var(--cinder-space-1);
+    border-radius: var(--cinder-radius-md);
+    border: none;
+    background: transparent;
+    color: var(--cinder-text-muted);
+    cursor: pointer;
+    transition:
+      background-color var(--cinder-duration-fast) var(--cinder-ease-standard),
+      color var(--cinder-duration-fast) var(--cinder-ease-standard);
+  }
 
-@media (forced-colors: active) {
+  @media (hover: hover) {
+    .cinder-sheet__close:hover {
+      background: color-mix(in oklch, currentColor, transparent 85%);
+      color: var(--cinder-text);
+    }
+  }
+
   .cinder-sheet__close:focus-visible {
-    outline: var(--cinder-ring-width) solid ButtonText;
-    outline-offset: 3px;
+    outline: var(--cinder-ring-width) solid var(--cinder-ring-color);
+    outline-offset: var(--cinder-ring-offset);
   }
-}
 
-.cinder-sheet__close-icon {
-  width: 1.25rem;
-  height: 1.25rem;
-}
+  @media (forced-colors: active) {
+    .cinder-sheet__close:focus-visible {
+      outline: var(--cinder-ring-width) solid ButtonText;
+      outline-offset: 3px;
+    }
+  }
 
-.cinder-sheet__body {
-  flex: 1;
-  overflow-y: auto;
-  padding: var(--cinder-space-6);
-  overscroll-behavior: contain;
-  scrollbar-gutter: stable;
-}
+  .cinder-sheet__close-icon {
+    width: 1.25rem;
+    height: 1.25rem;
+  }
 
-.cinder-sheet__body[data-cinder-overflows] {
-  mask-image: linear-gradient(to bottom, black calc(100% - 1.5rem), transparent);
-  mask-size: 100% 100%;
-  mask-repeat: no-repeat;
-  -webkit-mask-image: linear-gradient(to bottom, black calc(100% - 1.5rem), transparent);
-  -webkit-mask-size: 100% 100%;
-  -webkit-mask-repeat: no-repeat;
-}
+  .cinder-sheet__body {
+    flex: 1;
+    overflow-y: auto;
+    padding: var(--cinder-space-6);
+    overscroll-behavior: contain;
+    scrollbar-gutter: stable;
+  }
 
-/* Suppress the focus ring only for programmatic (mouse / open-effect) focus —
+  .cinder-sheet__body[data-cinder-overflows] {
+    mask-image: linear-gradient(to bottom, black calc(100% - 1.5rem), transparent);
+    mask-size: 100% 100%;
+    mask-repeat: no-repeat;
+    -webkit-mask-image: linear-gradient(to bottom, black calc(100% - 1.5rem), transparent);
+    -webkit-mask-size: 100% 100%;
+    -webkit-mask-repeat: no-repeat;
+  }
+
+  /* Suppress the focus ring only for programmatic (mouse / open-effect) focus —
  * if the body container ever becomes keyboard-reachable, indication is preserved. */
-.cinder-sheet__body:focus:not(:focus-visible) {
-  /* cinder-focus-ring-owner: parent */
-  outline: none;
-}
+  .cinder-sheet__body:focus:not(:focus-visible) {
+    /* cinder-focus-ring-owner: parent */
+    outline: none;
+  }
 
-.cinder-sheet__footer {
-  display: flex;
-  align-items: center;
-  justify-content: flex-end;
-  gap: var(--cinder-space-3);
-  padding: var(--cinder-space-4) var(--cinder-space-6);
-  border-block-start: 1px solid var(--cinder-border);
-  flex-shrink: 0;
-}
+  .cinder-sheet__footer {
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+    gap: var(--cinder-space-3);
+    padding: var(--cinder-space-4) var(--cinder-space-6);
+    border-block-start: 1px solid var(--cinder-border);
+    flex-shrink: 0;
+  }
 
-/* ----------------------------------------
+  /* ----------------------------------------
  * Motion — slide up from the bottom edge.
  * Animation targets the panel, not the dialog (which is transparent).
  * ---------------------------------------- */
 
-.cinder-sheet__panel[data-cinder-closing] {
-  translate: 0 100%;
-  opacity: 0.85;
-  pointer-events: none;
-}
-
-@starting-style {
-  .cinder-sheet__panel {
+  .cinder-sheet__panel[data-cinder-closing] {
     translate: 0 100%;
     opacity: 0.85;
-  }
-}
-
-@media (prefers-reduced-motion: reduce) {
-  .cinder-sheet__panel {
-    transition: none;
+    pointer-events: none;
   }
 
-  .cinder-sheet::backdrop {
-    transition: none;
+  @starting-style {
+    .cinder-sheet__panel {
+      translate: 0 100%;
+      opacity: 0.85;
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .cinder-sheet__panel {
+      transition: none;
+    }
+
+    .cinder-sheet::backdrop {
+      transition: none;
+    }
   }
 }

--- a/packages/components/src/components/side-navigation-group/side-navigation-group.css
+++ b/packages/components/src/components/side-navigation-group/side-navigation-group.css
@@ -1,144 +1,147 @@
-/* ========================================
+@layer cinder.components {
+  /* ========================================
  * SIDE NAVIGATION GROUP
  * ======================================== */
 
-.cinder-side-navigation-group {
-  list-style: none;
-}
+  .cinder-side-navigation-group {
+    list-style: none;
+  }
 
-/* ----------------------------------------
+  /* ----------------------------------------
  * Disclosure trigger
  * ---------------------------------------- */
 
-.cinder-side-navigation-group__trigger {
-  appearance: none;
-  display: flex;
-  inline-size: 100%;
-  align-items: center;
-  gap: var(--cinder-space-2);
-  min-height: 2rem;
-  padding-inline: var(--cinder-space-3);
-  padding-block: var(--cinder-space-1-5);
+  .cinder-side-navigation-group__trigger {
+    appearance: none;
+    display: flex;
+    inline-size: 100%;
+    align-items: center;
+    gap: var(--cinder-space-2);
+    min-height: 2rem;
+    padding-inline: var(--cinder-space-3);
+    padding-block: var(--cinder-space-1-5);
 
-  font-size: var(--cinder-text-sm);
-  font-weight: var(--cinder-font-semibold);
-  line-height: var(--cinder-leading-none);
-  text-align: start;
+    font-size: var(--cinder-text-sm);
+    font-weight: var(--cinder-font-semibold);
+    line-height: var(--cinder-leading-none);
+    text-align: start;
 
-  color: var(--cinder-text-muted);
-  background: transparent;
-  border: none;
-  border-radius: var(--cinder-radius-sm);
+    color: var(--cinder-text-muted);
+    background: transparent;
+    border: none;
+    border-radius: var(--cinder-radius-sm);
 
-  cursor: pointer;
-  user-select: none;
+    cursor: pointer;
+    user-select: none;
 
-  transition:
-    color var(--cinder-duration-fast) var(--cinder-ease-standard),
-    background-color var(--cinder-duration-fast) var(--cinder-ease-standard);
-}
-
-@media (hover: hover) {
-  .cinder-side-navigation-group__trigger:hover:not(:disabled) {
-    color: var(--cinder-text);
-    background-color: var(--cinder-surface-hover);
+    transition:
+      color var(--cinder-duration-fast) var(--cinder-ease-standard),
+      background-color var(--cinder-duration-fast) var(--cinder-ease-standard);
   }
-}
 
-.cinder-side-navigation-group__trigger:focus-visible {
-  outline: var(--cinder-ring-width) solid transparent;
-  box-shadow: var(--_cinder-focus-ring-shadow);
-}
+  @media (hover: hover) {
+    .cinder-side-navigation-group__trigger:hover:not(:disabled) {
+      color: var(--cinder-text);
+      background-color: var(--cinder-surface-hover);
+    }
+  }
 
-@media (forced-colors: active) {
   .cinder-side-navigation-group__trigger:focus-visible {
-    outline: var(--cinder-ring-width) solid ButtonText;
-    outline-offset: 3px;
+    outline: var(--cinder-ring-width) solid transparent;
+    box-shadow: var(--_cinder-focus-ring-shadow);
   }
-}
 
-.cinder-side-navigation-group__trigger:disabled {
-  color: var(--cinder-text-disabled);
-  cursor: not-allowed;
-  opacity: 0.6;
-}
+  @media (forced-colors: active) {
+    .cinder-side-navigation-group__trigger:focus-visible {
+      outline: var(--cinder-ring-width) solid ButtonText;
+      outline-offset: 3px;
+    }
+  }
 
-/* ----------------------------------------
+  .cinder-side-navigation-group__trigger:disabled {
+    color: var(--cinder-text-disabled);
+    cursor: not-allowed;
+    opacity: 0.6;
+  }
+
+  /* ----------------------------------------
  * Contains-active — a descendant item is the current page. Hints "you are
  * here" even when collapsed, but stays subordinate to the active item's
  * accent: a color step-up plus a heavier weight, not full accent.
  * ---------------------------------------- */
 
-.cinder-side-navigation-group[data-cinder-contains-active] .cinder-side-navigation-group__trigger {
-  color: var(--cinder-text);
-}
+  .cinder-side-navigation-group[data-cinder-contains-active]
+    .cinder-side-navigation-group__trigger {
+    color: var(--cinder-text);
+  }
 
-.cinder-side-navigation-group[data-cinder-contains-active] .cinder-side-navigation-group__label {
-  font-weight: var(--cinder-font-bold);
-}
+  .cinder-side-navigation-group[data-cinder-contains-active] .cinder-side-navigation-group__label {
+    font-weight: var(--cinder-font-bold);
+  }
 
-/* ----------------------------------------
+  /* ----------------------------------------
  * Icon
  * ---------------------------------------- */
 
-.cinder-side-navigation-group__icon {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  inline-size: 1rem;
-  block-size: 1rem;
-  flex-shrink: 0;
-}
+  .cinder-side-navigation-group__icon {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    inline-size: 1rem;
+    block-size: 1rem;
+    flex-shrink: 0;
+  }
 
-/* ----------------------------------------
+  /* ----------------------------------------
  * Label — takes remaining space
  * ---------------------------------------- */
 
-.cinder-side-navigation-group__label {
-  flex: 1;
-  text-align: start;
-}
+  .cinder-side-navigation-group__label {
+    flex: 1;
+    text-align: start;
+  }
 
-/* ----------------------------------------
+  /* ----------------------------------------
  * Badge — pushed end-ward, before chevron
  * ---------------------------------------- */
 
-.cinder-side-navigation-group__badge {
-  margin-inline-start: auto;
-}
+  .cinder-side-navigation-group__badge {
+    margin-inline-start: auto;
+  }
 
-/* ----------------------------------------
+  /* ----------------------------------------
  * Chevron — rotates when expanded
  * ---------------------------------------- */
 
-.cinder-side-navigation-group__chevron {
-  inline-size: 1rem;
-  block-size: 1rem;
-  flex-shrink: 0;
-  transition: transform var(--cinder-duration-fast) var(--cinder-ease-standard);
-}
-
-.cinder-side-navigation-group[data-cinder-expanded] .cinder-side-navigation-group__chevron {
-  transform: rotate(180deg);
-}
-
-@media (prefers-reduced-motion: reduce) {
   .cinder-side-navigation-group__chevron {
-    transition: none;
+    inline-size: 1rem;
+    block-size: 1rem;
+    flex-shrink: 0;
+    transition: transform var(--cinder-duration-fast) var(--cinder-ease-standard);
   }
-}
 
-/* ----------------------------------------
+  .cinder-side-navigation-group[data-cinder-expanded] .cinder-side-navigation-group__chevron {
+    transform: rotate(180deg);
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .cinder-side-navigation-group__chevron {
+      transition: none;
+    }
+  }
+
+  /* ----------------------------------------
  * Disclosed panel
  * ---------------------------------------- */
 
-.cinder-side-navigation-group__panel {
-  list-style: none;
-  margin: 0;
-  padding-block: 0;
-  padding-inline-start: var(--cinder-space-3);
-  padding-inline-end: 0;
-  display: flex;
-  flex-direction: column;
-  gap: var(--cinder-space-1);
+  .cinder-side-navigation-group__panel {
+    list-style: none;
+    margin: 0;
+    padding-block: 0;
+    padding-inline-start: var(--cinder-space-3);
+    padding-inline-end: 0;
+    display: flex;
+    flex-direction: column;
+    gap: var(--cinder-space-1);
+  }
 }

--- a/packages/components/src/components/side-navigation/side-navigation.css
+++ b/packages/components/src/components/side-navigation/side-navigation.css
@@ -1,21 +1,22 @@
-/* ========================================
+@layer cinder.components {
+  /* ========================================
  * SIDE NAVIGATION
  * ======================================== */
 
-.cinder-side-navigation {
-  display: block;
-}
+  .cinder-side-navigation {
+    display: block;
+  }
 
-.cinder-side-navigation__list {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-  display: flex;
-  flex-direction: column;
-  gap: var(--cinder-space-1);
-}
+  .cinder-side-navigation__list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: var(--cinder-space-1);
+  }
 
-/* ----------------------------------------
+  /* ----------------------------------------
  * Item wrapper <li> — reset list styles
  *
  * Vertical geometry (square rows, inline-start active border) now lives
@@ -24,6 +25,7 @@
  * ancestor-specificity overrides are needed here.
  * ---------------------------------------- */
 
-.cinder-side-navigation__item {
-  list-style: none;
+  .cinder-side-navigation__item {
+    list-style: none;
+  }
 }

--- a/packages/components/src/components/sidebar/sidebar.css
+++ b/packages/components/src/components/sidebar/sidebar.css
@@ -1,4 +1,5 @@
-/* ========================================
+@layer cinder.components {
+  /* ========================================
  * SIDEBAR
  * Layout-level vertical navigation container. Combines branding, a nav
  * region, and an optional footer. Delegates the actual list to
@@ -7,62 +8,62 @@
  * both surfaces because the inner regions render the same elements.
  * ======================================== */
 
-.cinder-sidebar {
-  display: flex;
-  flex-direction: column;
-  inline-size: 16rem;
-  /* Fill the parent's cross-axis. `align-self: stretch` makes a flex item
+  .cinder-sidebar {
+    display: flex;
+    flex-direction: column;
+    inline-size: 16rem;
+    /* Fill the parent's cross-axis. `align-self: stretch` makes a flex item
      fill its parent's cross-axis size. An explicit `block-size` here would
      opt out of stretch behavior, so we deliberately leave it off. */
-  align-self: stretch;
-  background: var(--cinder-surface);
-  border-inline-end: 1px solid var(--cinder-border);
-  overflow: hidden;
-}
+    align-self: stretch;
+    background: var(--cinder-surface);
+    border-inline-end: 1px solid var(--cinder-border);
+    overflow: hidden;
+  }
 
-/* The mobile surface is rendered inside <Drawer>, which already paints its
+  /* The mobile surface is rendered inside <Drawer>, which already paints its
  * own surface and borders. Don't double up. */
-.cinder-sidebar.cinder-sidebar--mobile {
-  inline-size: 100%;
-  block-size: 100%;
-  background: transparent;
-  border-inline-end: none;
-}
+  .cinder-sidebar.cinder-sidebar--mobile {
+    inline-size: 100%;
+    block-size: 100%;
+    background: transparent;
+    border-inline-end: none;
+  }
 
-/* Collapsed (icon-only) mode applies to the inline <aside>. The mobile drawer
+  /* Collapsed (icon-only) mode applies to the inline <aside>. The mobile drawer
  * surface ignores `data-cinder-collapsed` for sizing because drawer-closed is
  * the collapsed state on mobile. */
-.cinder-sidebar[data-cinder-collapsed]:not(.cinder-sidebar--mobile) {
-  inline-size: 4rem;
-}
+  .cinder-sidebar[data-cinder-collapsed]:not(.cinder-sidebar--mobile) {
+    inline-size: 4rem;
+  }
 
-.cinder-sidebar__brand {
-  display: flex;
-  align-items: center;
-  padding-block: var(--cinder-space-4);
-  padding-inline: var(--cinder-space-4);
-  border-block-end: 1px solid var(--cinder-border);
-  flex-shrink: 0;
-}
+  .cinder-sidebar__brand {
+    display: flex;
+    align-items: center;
+    padding-block: var(--cinder-space-4);
+    padding-inline: var(--cinder-space-4);
+    border-block-end: 1px solid var(--cinder-border);
+    flex-shrink: 0;
+  }
 
-.cinder-sidebar__nav {
-  flex: 1;
-  overflow-y: auto;
-  padding-block: var(--cinder-space-3);
-  padding-inline: var(--cinder-space-2);
-  display: flex;
-  flex-direction: column;
-  gap: var(--cinder-space-2);
-}
+  .cinder-sidebar__nav {
+    flex: 1;
+    overflow-y: auto;
+    padding-block: var(--cinder-space-3);
+    padding-inline: var(--cinder-space-2);
+    display: flex;
+    flex-direction: column;
+    gap: var(--cinder-space-2);
+  }
 
-.cinder-sidebar__footer {
-  padding-block: var(--cinder-space-3);
-  padding-inline: var(--cinder-space-3);
-  border-block-start: 1px solid var(--cinder-border);
-  flex-shrink: 0;
-}
+  .cinder-sidebar__footer {
+    padding-block: var(--cinder-space-3);
+    padding-inline: var(--cinder-space-3);
+    border-block-start: 1px solid var(--cinder-border);
+    flex-shrink: 0;
+  }
 
-/* ----------------------------------------
+  /* ----------------------------------------
  * Collapsed (icon-only) treatment for descendant items.
  *
  * Decorative chrome (group badge, chevron, panel) is hidden with `display:
@@ -75,84 +76,97 @@
  * lands on the trigger or link.
  * ---------------------------------------- */
 
-.cinder-sidebar[data-cinder-collapsed] .cinder-side-navigation-group__badge,
-.cinder-sidebar[data-cinder-collapsed] .cinder-side-navigation-group__chevron,
-.cinder-sidebar[data-cinder-collapsed] .cinder-side-navigation-group__panel {
-  display: none;
-}
+  .cinder-sidebar[data-cinder-collapsed] .cinder-side-navigation-group__badge,
+  .cinder-sidebar[data-cinder-collapsed] .cinder-side-navigation-group__chevron,
+  .cinder-sidebar[data-cinder-collapsed] .cinder-side-navigation-group__panel {
+    display: none;
+  }
 
-.cinder-sidebar[data-cinder-collapsed] .cinder-side-navigation-group__trigger {
-  justify-content: center;
-  padding-inline: var(--cinder-space-2);
-}
+  .cinder-sidebar[data-cinder-collapsed] .cinder-side-navigation-group__trigger {
+    justify-content: center;
+    padding-inline: var(--cinder-space-2);
+  }
 
-.cinder-sidebar[data-cinder-collapsed] .cinder-side-navigation-group__label,
-.cinder-sidebar[data-cinder-collapsed]
-  .cinder-side-navigation
-  a.cinder-navigation-item
-  > :not([aria-hidden='true']):not(svg):not(img),
-.cinder-sidebar[data-cinder-collapsed]
-  .cinder-side-navigation
-  button.cinder-navigation-item
-  > :not([aria-hidden='true']):not(svg):not(img),
-.cinder-sidebar[data-cinder-collapsed]
-  .cinder-sidebar__footer
-  a.cinder-navigation-item
-  > :not([aria-hidden='true']):not(svg):not(img),
-.cinder-sidebar[data-cinder-collapsed]
-  .cinder-sidebar__footer
-  button.cinder-navigation-item
-  > :not([aria-hidden='true']):not(svg):not(img) {
-  position: absolute;
-  width: 1px;
-  height: 1px;
-  padding: 0;
-  margin: -1px;
-  overflow: hidden;
-  clip: rect(0, 0, 0, 0);
-  clip-path: inset(50%);
-  white-space: nowrap;
-  border: 0;
-}
+  .cinder-sidebar[data-cinder-collapsed] .cinder-side-navigation-group__label,
+  .cinder-sidebar[data-cinder-collapsed]
+    .cinder-side-navigation
+    a.cinder-navigation-item
+    > :not([aria-hidden='true']):not(svg):not(img),
+  .cinder-sidebar[data-cinder-collapsed]
+    .cinder-side-navigation
+    button.cinder-navigation-item
+    > :not([aria-hidden='true']):not(svg):not(img),
+  .cinder-sidebar[data-cinder-collapsed]
+    .cinder-sidebar__footer
+    a.cinder-navigation-item
+    > :not([aria-hidden='true']):not(svg):not(img),
+  .cinder-sidebar[data-cinder-collapsed]
+    .cinder-sidebar__footer
+    button.cinder-navigation-item
+    > :not([aria-hidden='true']):not(svg):not(img) {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    clip-path: inset(50%);
+    white-space: nowrap;
+    border: 0;
+  }
 
-/* Leaf items in collapsed mode collapse to icon-only width. `font-size: 0`
+  /* Leaf items in collapsed mode collapse to icon-only width. `font-size: 0`
  * covers bare text children that cannot be selected directly; element
  * children are additionally visually hidden above. The DOM text remains
  * available for accessible-name computation. */
-.cinder-sidebar[data-cinder-collapsed] .cinder-side-navigation a.cinder-navigation-item,
-.cinder-sidebar[data-cinder-collapsed] .cinder-side-navigation button.cinder-navigation-item,
-.cinder-sidebar[data-cinder-collapsed] .cinder-sidebar__footer a.cinder-navigation-item,
-.cinder-sidebar[data-cinder-collapsed] .cinder-sidebar__footer button.cinder-navigation-item {
-  justify-content: center;
-  padding-inline: var(--cinder-space-2);
-  gap: 0;
-  font-size: 0;
-}
+  .cinder-sidebar[data-cinder-collapsed] .cinder-side-navigation a.cinder-navigation-item,
+  .cinder-sidebar[data-cinder-collapsed] .cinder-side-navigation button.cinder-navigation-item,
+  .cinder-sidebar[data-cinder-collapsed] .cinder-sidebar__footer a.cinder-navigation-item,
+  .cinder-sidebar[data-cinder-collapsed] .cinder-sidebar__footer button.cinder-navigation-item {
+    justify-content: center;
+    padding-inline: var(--cinder-space-2);
+    gap: 0;
+    font-size: 0;
+  }
 
-.cinder-sidebar[data-cinder-collapsed] .cinder-side-navigation a.cinder-navigation-item > svg,
-.cinder-sidebar[data-cinder-collapsed] .cinder-side-navigation button.cinder-navigation-item > svg,
-.cinder-sidebar[data-cinder-collapsed] .cinder-sidebar__footer a.cinder-navigation-item > svg,
-.cinder-sidebar[data-cinder-collapsed] .cinder-sidebar__footer button.cinder-navigation-item > svg,
-.cinder-sidebar[data-cinder-collapsed] .cinder-side-navigation a.cinder-navigation-item > img,
-.cinder-sidebar[data-cinder-collapsed] .cinder-side-navigation button.cinder-navigation-item > img,
-.cinder-sidebar[data-cinder-collapsed] .cinder-sidebar__footer a.cinder-navigation-item > img,
-.cinder-sidebar[data-cinder-collapsed] .cinder-sidebar__footer button.cinder-navigation-item > img,
-.cinder-sidebar[data-cinder-collapsed]
-  .cinder-side-navigation
-  a.cinder-navigation-item
-  > [aria-hidden='true'],
-.cinder-sidebar[data-cinder-collapsed]
-  .cinder-side-navigation
-  button.cinder-navigation-item
-  > [aria-hidden='true'],
-.cinder-sidebar[data-cinder-collapsed]
-  .cinder-sidebar__footer
-  a.cinder-navigation-item
-  > [aria-hidden='true'],
-.cinder-sidebar[data-cinder-collapsed]
-  .cinder-sidebar__footer
-  button.cinder-navigation-item
-  > [aria-hidden='true'] {
-  flex-shrink: 0;
-  font-size: var(--cinder-text-sm);
+  .cinder-sidebar[data-cinder-collapsed] .cinder-side-navigation a.cinder-navigation-item > svg,
+  .cinder-sidebar[data-cinder-collapsed]
+    .cinder-side-navigation
+    button.cinder-navigation-item
+    > svg,
+  .cinder-sidebar[data-cinder-collapsed] .cinder-sidebar__footer a.cinder-navigation-item > svg,
+  .cinder-sidebar[data-cinder-collapsed]
+    .cinder-sidebar__footer
+    button.cinder-navigation-item
+    > svg,
+  .cinder-sidebar[data-cinder-collapsed] .cinder-side-navigation a.cinder-navigation-item > img,
+  .cinder-sidebar[data-cinder-collapsed]
+    .cinder-side-navigation
+    button.cinder-navigation-item
+    > img,
+  .cinder-sidebar[data-cinder-collapsed] .cinder-sidebar__footer a.cinder-navigation-item > img,
+  .cinder-sidebar[data-cinder-collapsed]
+    .cinder-sidebar__footer
+    button.cinder-navigation-item
+    > img,
+  .cinder-sidebar[data-cinder-collapsed]
+    .cinder-side-navigation
+    a.cinder-navigation-item
+    > [aria-hidden='true'],
+  .cinder-sidebar[data-cinder-collapsed]
+    .cinder-side-navigation
+    button.cinder-navigation-item
+    > [aria-hidden='true'],
+  .cinder-sidebar[data-cinder-collapsed]
+    .cinder-sidebar__footer
+    a.cinder-navigation-item
+    > [aria-hidden='true'],
+  .cinder-sidebar[data-cinder-collapsed]
+    .cinder-sidebar__footer
+    button.cinder-navigation-item
+    > [aria-hidden='true'] {
+    flex-shrink: 0;
+    font-size: var(--cinder-text-sm);
+  }
 }

--- a/packages/components/src/components/skeleton/skeleton.css
+++ b/packages/components/src/components/skeleton/skeleton.css
@@ -1,34 +1,36 @@
-/* ========================================
+@layer cinder.components {
+  /* ========================================
  * SKELETON
  * ======================================== */
 
-.cinder-skeleton {
-  display: block;
-  width: 100%;
-  height: 1em;
-  border-radius: var(--cinder-radius-sm);
-  background: linear-gradient(
-    90deg,
-    var(--cinder-surface-inset) 0%,
-    oklch(from var(--cinder-surface-inset) calc(l + 0.06) c h) 50%,
-    var(--cinder-surface-inset) 100%
-  );
-  background-size: 200% 100%;
-  animation: cinder-skeleton-shimmer 1.5s ease-in-out infinite;
-}
-
-@keyframes cinder-skeleton-shimmer {
-  0% {
-    background-position: 200% 0;
-  }
-  100% {
-    background-position: -200% 0;
-  }
-}
-
-@media (prefers-reduced-motion: reduce) {
   .cinder-skeleton {
-    animation: none;
-    background: var(--cinder-surface-inset);
+    display: block;
+    width: 100%;
+    height: 1em;
+    border-radius: var(--cinder-radius-sm);
+    background: linear-gradient(
+      90deg,
+      var(--cinder-surface-inset) 0%,
+      oklch(from var(--cinder-surface-inset) calc(l + 0.06) c h) 50%,
+      var(--cinder-surface-inset) 100%
+    );
+    background-size: 200% 100%;
+    animation: cinder-skeleton-shimmer 1.5s ease-in-out infinite;
+  }
+
+  @keyframes cinder-skeleton-shimmer {
+    0% {
+      background-position: 200% 0;
+    }
+    100% {
+      background-position: -200% 0;
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .cinder-skeleton {
+      animation: none;
+      background: var(--cinder-surface-inset);
+    }
   }
 }

--- a/packages/components/src/components/slider/slider.css
+++ b/packages/components/src/components/slider/slider.css
@@ -1,4 +1,5 @@
-/* ========================================
+@layer cinder.components {
+  /* ========================================
  * SLIDER
  * Single-thumb and dual-thumb (range) slider following the WAI-ARIA
  * `role="slider"` pattern. Thumbs are absolutely positioned along the
@@ -6,122 +7,123 @@
  * Reduced-motion: thumb position transitions are suppressed.
  * ======================================== */
 
-.cinder-slider {
-  --_cinder-slider-thumb-size: 1.125rem;
-  --_cinder-slider-track-thickness: 0.375rem;
+  .cinder-slider {
+    --_cinder-slider-thumb-size: 1.125rem;
+    --_cinder-slider-track-thickness: 0.375rem;
 
-  position: relative;
-  display: block;
-  width: 100%;
-  padding-block: calc(var(--_cinder-slider-thumb-size) / 2);
-}
+    position: relative;
+    display: block;
+    width: 100%;
+    padding-block: calc(var(--_cinder-slider-thumb-size) / 2);
+  }
 
-.cinder-slider[data-cinder-disabled] {
-  opacity: 0.55;
-  cursor: not-allowed;
-}
+  .cinder-slider[data-cinder-disabled] {
+    opacity: 0.55;
+    cursor: not-allowed;
+  }
 
-.cinder-slider__track {
-  position: relative;
-  width: 100%;
-  height: var(--_cinder-slider-track-thickness);
-  background: var(--cinder-surface-inset);
-  border-radius: var(--cinder-radius-full);
-  touch-action: none;
-  cursor: pointer;
-}
+  .cinder-slider__track {
+    position: relative;
+    width: 100%;
+    height: var(--_cinder-slider-track-thickness);
+    background: var(--cinder-surface-inset);
+    border-radius: var(--cinder-radius-full);
+    touch-action: none;
+    cursor: pointer;
+  }
 
-.cinder-slider[data-cinder-disabled] .cinder-slider__track {
-  cursor: not-allowed;
-}
+  .cinder-slider[data-cinder-disabled] .cinder-slider__track {
+    cursor: not-allowed;
+  }
 
-.cinder-slider__range {
-  position: absolute;
-  inset-block: 0;
-  left: var(--_cinder-slider-low);
-  right: calc(100% - var(--_cinder-slider-high));
-  background: var(--cinder-accent);
-  border-radius: var(--cinder-radius-full);
-  transition:
-    left var(--cinder-duration-fast, 120ms) var(--cinder-ease-standard, ease),
-    right var(--cinder-duration-fast, 120ms) var(--cinder-ease-standard, ease);
-}
+  .cinder-slider__range {
+    position: absolute;
+    inset-block: 0;
+    left: var(--_cinder-slider-low);
+    right: calc(100% - var(--_cinder-slider-high));
+    background: var(--cinder-accent);
+    border-radius: var(--cinder-radius-full);
+    transition:
+      left var(--cinder-duration-fast, 120ms) var(--cinder-ease-standard, ease),
+      right var(--cinder-duration-fast, 120ms) var(--cinder-ease-standard, ease);
+  }
 
-.cinder-slider:not(.cinder-slider--range) .cinder-slider__range {
-  left: 0;
-  right: calc(100% - var(--_cinder-slider-low));
-}
+  .cinder-slider:not(.cinder-slider--range) .cinder-slider__range {
+    left: 0;
+    right: calc(100% - var(--_cinder-slider-low));
+  }
 
-.cinder-slider__ticks {
-  position: absolute;
-  inset: 0;
-  pointer-events: none;
-}
+  .cinder-slider__ticks {
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+  }
 
-.cinder-slider__tick {
-  position: absolute;
-  top: 50%;
-  left: var(--_cinder-slider-tick);
-  width: 2px;
-  height: 0.5rem;
-  background: var(--cinder-border, currentColor);
-  transform: translate(-50%, -50%);
-  border-radius: var(--cinder-radius-full);
-  opacity: 0.6;
-}
+  .cinder-slider__tick {
+    position: absolute;
+    top: 50%;
+    left: var(--_cinder-slider-tick);
+    width: 2px;
+    height: 0.5rem;
+    background: var(--cinder-border, currentColor);
+    transform: translate(-50%, -50%);
+    border-radius: var(--cinder-radius-full);
+    opacity: 0.6;
+  }
 
-.cinder-slider__thumb {
-  position: absolute;
-  top: 50%;
-  left: var(--_cinder-slider-pos);
-  width: var(--_cinder-slider-thumb-size);
-  height: var(--_cinder-slider-thumb-size);
-  background: var(--cinder-surface-raised, white);
-  border: 2px solid var(--cinder-accent);
-  border-radius: var(--cinder-radius-full);
-  transform: translate(-50%, -50%);
-  cursor: grab;
-  box-shadow: var(--cinder-shadow-sm, 0 1px 2px rgba(0, 0, 0, 0.1));
-  /* Touch-action is set on the track for the same reason; explicitly setting
+  .cinder-slider__thumb {
+    position: absolute;
+    top: 50%;
+    left: var(--_cinder-slider-pos);
+    width: var(--_cinder-slider-thumb-size);
+    height: var(--_cinder-slider-thumb-size);
+    background: var(--cinder-surface-raised, white);
+    border: 2px solid var(--cinder-accent);
+    border-radius: var(--cinder-radius-full);
+    transform: translate(-50%, -50%);
+    cursor: grab;
+    box-shadow: var(--cinder-shadow-sm, 0 1px 2px rgba(0, 0, 0, 0.1));
+    /* Touch-action is set on the track for the same reason; explicitly setting
    * it on the thumb prevents older Chromium-on-Android from intercepting the
    * gesture for scrolling when pointerdown lands directly on the thumb. */
-  touch-action: none;
-  transition:
-    left var(--cinder-duration-fast, 120ms) var(--cinder-ease-standard, ease),
-    box-shadow var(--cinder-duration-fast, 120ms) var(--cinder-ease-standard, ease);
-}
+    touch-action: none;
+    transition:
+      left var(--cinder-duration-fast, 120ms) var(--cinder-ease-standard, ease),
+      box-shadow var(--cinder-duration-fast, 120ms) var(--cinder-ease-standard, ease);
+  }
 
-/* The most recently moved thumb in range mode is raised above its sibling
+  /* The most recently moved thumb in range mode is raised above its sibling
  * so that when the two values coincide, the active one remains the click
  * target. */
-.cinder-slider__thumb[data-cinder-active] {
-  z-index: 2;
-}
-
-.cinder-slider__thumb:active {
-  cursor: grabbing;
-  z-index: 2;
-}
-
-.cinder-slider__thumb:focus-visible {
-  outline: var(--cinder-ring-width) solid transparent;
-  box-shadow: var(--_cinder-focus-ring-shadow);
-}
-
-@media (forced-colors: active) {
-  .cinder-slider__thumb:focus-visible {
-    outline: var(--cinder-ring-width) solid Highlight;
-    outline-offset: 1px;
+  .cinder-slider__thumb[data-cinder-active] {
+    z-index: 2;
   }
-}
 
-.cinder-slider[data-cinder-disabled] .cinder-slider__thumb {
-  cursor: not-allowed;
-}
+  .cinder-slider__thumb:active {
+    cursor: grabbing;
+    z-index: 2;
+  }
 
-@media (prefers-reduced-motion: reduce) {
-  .cinder-slider__range,
-  .cinder-slider__thumb {
-    transition: none;
+  .cinder-slider__thumb:focus-visible {
+    outline: var(--cinder-ring-width) solid transparent;
+    box-shadow: var(--_cinder-focus-ring-shadow);
+  }
+
+  @media (forced-colors: active) {
+    .cinder-slider__thumb:focus-visible {
+      outline: var(--cinder-ring-width) solid Highlight;
+      outline-offset: 1px;
+    }
+  }
+
+  .cinder-slider[data-cinder-disabled] .cinder-slider__thumb {
+    cursor: not-allowed;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .cinder-slider__range,
+    .cinder-slider__thumb {
+      transition: none;
+    }
   }
 }

--- a/packages/components/src/components/sortable-list/sortable-list.css
+++ b/packages/components/src/components/sortable-list/sortable-list.css
@@ -1,61 +1,63 @@
-/* ========================================
+@layer cinder.components {
+  /* ========================================
  * SORTABLE LIST
  * ======================================== */
 
-.cinder-sortable-list {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-}
+  .cinder-sortable-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+  }
 
-.cinder-sortable-item {
-  position: relative;
-  cursor: default;
-  user-select: none;
-}
-
-.cinder-sortable-item--lifted {
-  transform: scale(1.02);
-  box-shadow: var(--cinder-shadow-elevated, 0 4px 16px rgb(0 0 0 / 0.15));
-  z-index: 1;
-  position: relative;
-}
-
-.cinder-sortable-item--shifting {
-  transition: transform 150ms ease;
-}
-
-@media (prefers-reduced-motion: reduce) {
-  .cinder-sortable-item--shifting {
-    transition: none;
+  .cinder-sortable-item {
+    position: relative;
+    cursor: default;
+    user-select: none;
   }
 
   .cinder-sortable-item--lifted {
-    transform: none;
+    transform: scale(1.02);
     box-shadow: var(--cinder-shadow-elevated, 0 4px 16px rgb(0 0 0 / 0.15));
+    z-index: 1;
+    position: relative;
   }
-}
 
-.cinder-sortable-handle {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  min-width: var(--cinder-touch-target-min);
-  min-height: var(--cinder-touch-target-min);
-  background: none;
-  border: none;
-  padding: 0;
-  cursor: grab;
-  touch-action: none;
-  color: inherit;
-}
+  .cinder-sortable-item--shifting {
+    transition: transform 150ms ease;
+  }
 
-.cinder-sortable-handle:focus-visible {
-  outline: var(--cinder-ring-width) solid var(--cinder-ring-color);
-  outline-offset: 2px;
-  border-radius: 2px;
-}
+  @media (prefers-reduced-motion: reduce) {
+    .cinder-sortable-item--shifting {
+      transition: none;
+    }
 
-.cinder-sortable-handle[aria-pressed='true'] {
-  cursor: grabbing;
+    .cinder-sortable-item--lifted {
+      transform: none;
+      box-shadow: var(--cinder-shadow-elevated, 0 4px 16px rgb(0 0 0 / 0.15));
+    }
+  }
+
+  .cinder-sortable-handle {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: var(--cinder-touch-target-min);
+    min-height: var(--cinder-touch-target-min);
+    background: none;
+    border: none;
+    padding: 0;
+    cursor: grab;
+    touch-action: none;
+    color: inherit;
+  }
+
+  .cinder-sortable-handle:focus-visible {
+    outline: var(--cinder-ring-width) solid var(--cinder-ring-color);
+    outline-offset: 2px;
+    border-radius: 2px;
+  }
+
+  .cinder-sortable-handle[aria-pressed='true'] {
+    cursor: grabbing;
+  }
 }

--- a/packages/components/src/components/spacer/spacer.css
+++ b/packages/components/src/components/spacer/spacer.css
@@ -1,8 +1,10 @@
-/* ========================================
+@layer cinder.components {
+  /* ========================================
  * SPACER
  * ======================================== */
 
-.cinder-spacer {
-  flex: 1 1 auto;
-  align-self: stretch;
+  .cinder-spacer {
+    flex: 1 1 auto;
+    align-self: stretch;
+  }
 }

--- a/packages/components/src/components/spinner/spinner.css
+++ b/packages/components/src/components/spinner/spinner.css
@@ -1,62 +1,64 @@
-/* ========================================
+@layer cinder.components {
+  /* ========================================
  * SPINNER
  * ======================================== */
 
-.cinder-spinner {
-  display: inline-block;
-  width: var(--cinder-spinner-size, 1.5rem);
-  height: var(--cinder-spinner-size, 1.5rem);
-  border: 2px solid var(--cinder-spinner-track, color-mix(in srgb, currentColor 25%, transparent));
-  border-top-color: var(--cinder-spinner-indicator, currentColor);
-  border-radius: 50%;
-  vertical-align: -0.125em;
-  animation: cinder-spinner-spin var(--cinder-duration-spin) linear infinite;
-  flex-shrink: 0;
-}
-
-/* Screen-reader-only label — visually hidden but announced by assistive tech */
-.cinder-spinner__sr-only {
-  position: absolute;
-  width: 1px;
-  height: 1px;
-  padding: 0;
-  margin: -1px;
-  overflow: hidden;
-  clip: rect(0, 0, 0, 0);
-  white-space: nowrap;
-  border-width: 0;
-}
-
-@keyframes cinder-spinner-spin {
-  to {
-    transform: rotate(360deg);
-  }
-}
-
-/* Respect the user's reduced-motion preference */
-@media (prefers-reduced-motion: reduce) {
   .cinder-spinner {
-    animation: none;
-    border-top-color: var(--cinder-border-muted, #ccc);
-    opacity: 0.5;
+    display: inline-block;
+    width: var(--cinder-spinner-size, 1.5rem);
+    height: var(--cinder-spinner-size, 1.5rem);
+    border: 2px solid var(--cinder-spinner-track, color-mix(in srgb, currentColor 25%, transparent));
+    border-top-color: var(--cinder-spinner-indicator, currentColor);
+    border-radius: 50%;
+    vertical-align: -0.125em;
+    animation: cinder-spinner-spin var(--cinder-duration-spin) linear infinite;
+    flex-shrink: 0;
   }
-}
 
-/* ----------------------------------------
+  /* Screen-reader-only label — visually hidden but announced by assistive tech */
+  .cinder-spinner__sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border-width: 0;
+  }
+
+  @keyframes cinder-spinner-spin {
+    to {
+      transform: rotate(360deg);
+    }
+  }
+
+  /* Respect the user's reduced-motion preference */
+  @media (prefers-reduced-motion: reduce) {
+    .cinder-spinner {
+      animation: none;
+      border-top-color: var(--cinder-border-muted, #ccc);
+      opacity: 0.5;
+    }
+  }
+
+  /* ----------------------------------------
  * Size variants
  * ---------------------------------------- */
 
-.cinder-spinner[data-cinder-size='sm'] {
-  --cinder-spinner-size: var(--cinder-spinner-size-sm, 1rem);
-  border-width: 1.5px;
-}
+  .cinder-spinner[data-cinder-size='sm'] {
+    --cinder-spinner-size: var(--cinder-spinner-size-sm, 1rem);
+    border-width: 1.5px;
+  }
 
-.cinder-spinner[data-cinder-size='md'] {
-  --cinder-spinner-size: var(--cinder-spinner-size-md, 1.5rem);
-  border-width: 2px;
-}
+  .cinder-spinner[data-cinder-size='md'] {
+    --cinder-spinner-size: var(--cinder-spinner-size-md, 1.5rem);
+    border-width: 2px;
+  }
 
-.cinder-spinner[data-cinder-size='lg'] {
-  --cinder-spinner-size: var(--cinder-spinner-size-lg, 2rem);
-  border-width: 2.5px;
+  .cinder-spinner[data-cinder-size='lg'] {
+    --cinder-spinner-size: var(--cinder-spinner-size-lg, 2rem);
+    border-width: 2.5px;
+  }
 }

--- a/packages/components/src/components/stack/stack.css
+++ b/packages/components/src/components/stack/stack.css
@@ -1,9 +1,11 @@
-/* ========================================
+@layer cinder.components {
+  /* ========================================
  * STACK
  * ======================================== */
 
-.cinder-stack {
-  display: flex;
-  flex-direction: var(--stack-direction, column);
-  gap: var(--stack-gap, var(--cinder-space-4));
+  .cinder-stack {
+    display: flex;
+    flex-direction: var(--stack-direction, column);
+    gap: var(--stack-gap, var(--cinder-space-4));
+  }
 }

--- a/packages/components/src/components/stacked-list-item/stacked-list-item.css
+++ b/packages/components/src/components/stacked-list-item/stacked-list-item.css
@@ -1,122 +1,124 @@
-/* ========================================
+@layer cinder.components {
+  /* ========================================
  * STACKED LIST ITEM
  * ======================================== */
 
-.cinder-stacked-list-item {
-  display: block;
-  container-type: inline-size;
-  container-name: cinder-stacked-list-item;
-  padding: var(--cinder-space-3) var(--cinder-space-4);
-  border-bottom: 1px solid var(--cinder-border-muted);
-}
-
-.cinder-stacked-list-item[data-cinder-density='condensed'] {
-  padding: var(--cinder-space-2) var(--cinder-space-3);
-}
-
-.cinder-stacked-list-item__layout {
-  display: grid;
-  align-items: center;
-  column-gap: var(--cinder-space-3);
-  row-gap: var(--cinder-space-2);
-  grid-template-columns: 1fr;
-  grid-template-areas: 'body';
-}
-
-.cinder-stacked-list-item--has-leading .cinder-stacked-list-item__layout {
-  grid-template-columns: auto 1fr;
-  grid-template-areas: 'leading body';
-}
-
-.cinder-stacked-list-item--has-trailing .cinder-stacked-list-item__layout {
-  grid-template-columns: 1fr auto;
-  grid-template-areas: 'body trailing';
-}
-
-.cinder-stacked-list-item--has-leading.cinder-stacked-list-item--has-trailing
-  .cinder-stacked-list-item__layout {
-  grid-template-columns: auto 1fr auto;
-  grid-template-areas: 'leading body trailing';
-}
-
-.cinder-stacked-list-item__leading {
-  grid-area: leading;
-}
-
-.cinder-stacked-list-item__body {
-  grid-area: body;
-  display: flex;
-  flex-direction: column;
-  gap: var(--cinder-space-1);
-}
-
-.cinder-stacked-list-item__trailing {
-  grid-area: trailing;
-  display: flex;
-  gap: var(--cinder-space-2);
-  align-items: center;
-}
-
-.cinder-stacked-list-item__title {
-  font-size: var(--cinder-text-sm);
-  line-height: var(--cinder-leading-snug);
-  color: var(--cinder-text);
-}
-
-.cinder-stacked-list-item__title-link {
-  color: inherit;
-  text-decoration: none;
-}
-
-.cinder-stacked-list-item__title-link:hover {
-  text-decoration: underline;
-}
-
-.cinder-stacked-list-item__title-link:focus-visible {
-  outline: var(--cinder-ring-width) solid transparent;
-  border-radius: var(--cinder-radius-sm);
-  box-shadow: var(--_cinder-focus-ring-shadow);
-}
-
-/* Forced Colors Mode — box-shadow focus rings are invisible; use a real outline. */
-@media (forced-colors: active) {
-  .cinder-stacked-list-item__title-link:focus-visible {
-    outline: var(--cinder-ring-width) solid ButtonText;
-    outline-offset: 3px;
+  .cinder-stacked-list-item {
+    display: block;
+    container-type: inline-size;
+    container-name: cinder-stacked-list-item;
+    padding: var(--cinder-space-3) var(--cinder-space-4);
+    border-bottom: 1px solid var(--cinder-border-muted);
   }
-}
 
-.cinder-stacked-list-item__description {
-  font-size: var(--cinder-text-sm);
-  line-height: var(--cinder-leading-snug);
-  color: var(--cinder-text-muted);
-}
+  .cinder-stacked-list-item[data-cinder-density='condensed'] {
+    padding: var(--cinder-space-2) var(--cinder-space-3);
+  }
 
-.cinder-stacked-list-item__meta {
-  font-size: var(--cinder-text-xs);
-  line-height: var(--cinder-leading-snug);
-  color: var(--cinder-text-muted);
-}
-
-.cinder-stacked-list-item[data-cinder-density='condensed'] .cinder-stacked-list-item__description,
-.cinder-stacked-list-item[data-cinder-density='condensed'] .cinder-stacked-list-item__meta {
-  line-height: var(--cinder-leading-snug);
-}
-
-/* Narrow container query — trailing drops below body */
-@container cinder-stacked-list-item (max-width: 448px) {
-  .cinder-stacked-list-item--has-trailing .cinder-stacked-list-item__layout {
+  .cinder-stacked-list-item__layout {
+    display: grid;
+    align-items: center;
+    column-gap: var(--cinder-space-3);
+    row-gap: var(--cinder-space-2);
     grid-template-columns: 1fr;
-    grid-template-areas:
-      'body'
-      'trailing';
+    grid-template-areas: 'body';
+  }
+
+  .cinder-stacked-list-item--has-leading .cinder-stacked-list-item__layout {
+    grid-template-columns: auto 1fr;
+    grid-template-areas: 'leading body';
+  }
+
+  .cinder-stacked-list-item--has-trailing .cinder-stacked-list-item__layout {
+    grid-template-columns: 1fr auto;
+    grid-template-areas: 'body trailing';
   }
 
   .cinder-stacked-list-item--has-leading.cinder-stacked-list-item--has-trailing
     .cinder-stacked-list-item__layout {
-    grid-template-columns: auto 1fr;
-    grid-template-areas:
-      'leading body'
-      'trailing trailing';
+    grid-template-columns: auto 1fr auto;
+    grid-template-areas: 'leading body trailing';
+  }
+
+  .cinder-stacked-list-item__leading {
+    grid-area: leading;
+  }
+
+  .cinder-stacked-list-item__body {
+    grid-area: body;
+    display: flex;
+    flex-direction: column;
+    gap: var(--cinder-space-1);
+  }
+
+  .cinder-stacked-list-item__trailing {
+    grid-area: trailing;
+    display: flex;
+    gap: var(--cinder-space-2);
+    align-items: center;
+  }
+
+  .cinder-stacked-list-item__title {
+    font-size: var(--cinder-text-sm);
+    line-height: var(--cinder-leading-snug);
+    color: var(--cinder-text);
+  }
+
+  .cinder-stacked-list-item__title-link {
+    color: inherit;
+    text-decoration: none;
+  }
+
+  .cinder-stacked-list-item__title-link:hover {
+    text-decoration: underline;
+  }
+
+  .cinder-stacked-list-item__title-link:focus-visible {
+    outline: var(--cinder-ring-width) solid transparent;
+    border-radius: var(--cinder-radius-sm);
+    box-shadow: var(--_cinder-focus-ring-shadow);
+  }
+
+  /* Forced Colors Mode — box-shadow focus rings are invisible; use a real outline. */
+  @media (forced-colors: active) {
+    .cinder-stacked-list-item__title-link:focus-visible {
+      outline: var(--cinder-ring-width) solid ButtonText;
+      outline-offset: 3px;
+    }
+  }
+
+  .cinder-stacked-list-item__description {
+    font-size: var(--cinder-text-sm);
+    line-height: var(--cinder-leading-snug);
+    color: var(--cinder-text-muted);
+  }
+
+  .cinder-stacked-list-item__meta {
+    font-size: var(--cinder-text-xs);
+    line-height: var(--cinder-leading-snug);
+    color: var(--cinder-text-muted);
+  }
+
+  .cinder-stacked-list-item[data-cinder-density='condensed'] .cinder-stacked-list-item__description,
+  .cinder-stacked-list-item[data-cinder-density='condensed'] .cinder-stacked-list-item__meta {
+    line-height: var(--cinder-leading-snug);
+  }
+
+  /* Narrow container query — trailing drops below body */
+  @container cinder-stacked-list-item (max-width: 448px) {
+    .cinder-stacked-list-item--has-trailing .cinder-stacked-list-item__layout {
+      grid-template-columns: 1fr;
+      grid-template-areas:
+        'body'
+        'trailing';
+    }
+
+    .cinder-stacked-list-item--has-leading.cinder-stacked-list-item--has-trailing
+      .cinder-stacked-list-item__layout {
+      grid-template-columns: auto 1fr;
+      grid-template-areas:
+        'leading body'
+        'trailing trailing';
+    }
   }
 }

--- a/packages/components/src/components/stat-group/stat-group.css
+++ b/packages/components/src/components/stat-group/stat-group.css
@@ -1,51 +1,53 @@
-.cinder-stat-group {
-  display: grid;
-  gap: var(--cinder-space-4, 1rem);
-}
+@layer cinder.components {
+  .cinder-stat-group {
+    display: grid;
+    gap: var(--cinder-space-4, 1rem);
+  }
 
-.cinder-stat-group[data-cinder-columns='auto'] {
-  grid-template-columns: repeat(auto-fit, minmax(min(14rem, 100%), 1fr));
-}
+  .cinder-stat-group[data-cinder-columns='auto'] {
+    grid-template-columns: repeat(auto-fit, minmax(min(14rem, 100%), 1fr));
+  }
 
-.cinder-stat-group[data-cinder-columns='1'] {
-  grid-template-columns: 1fr;
-}
+  .cinder-stat-group[data-cinder-columns='1'] {
+    grid-template-columns: 1fr;
+  }
 
-.cinder-stat-group[data-cinder-columns='2'] {
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-}
+  .cinder-stat-group[data-cinder-columns='2'] {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
 
-.cinder-stat-group[data-cinder-columns='3'] {
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-}
+  .cinder-stat-group[data-cinder-columns='3'] {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
 
-.cinder-stat-group[data-cinder-columns='4'] {
-  grid-template-columns: repeat(4, minmax(0, 1fr));
-}
+  .cinder-stat-group[data-cinder-columns='4'] {
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+  }
 
-/* variant: cards — each stat gets a card-style border, background, and shadow */
-.cinder-stat-group[data-cinder-variant='cards'] > .cinder-stat {
-  padding: var(--cinder-space-4, 1rem);
-  background: var(--cinder-surface-raised);
-  border: 1px solid var(--cinder-border);
-  border-radius: var(--cinder-radius-md, 0.5rem);
-  box-shadow: var(--cinder-shadow-sm, 0 1px 2px rgba(0, 0, 0, 0.05));
-}
+  /* variant: cards — each stat gets a card-style border, background, and shadow */
+  .cinder-stat-group[data-cinder-variant='cards'] > .cinder-stat {
+    padding: var(--cinder-space-4, 1rem);
+    background: var(--cinder-surface-raised);
+    border: 1px solid var(--cinder-border);
+    border-radius: var(--cinder-radius-md, 0.5rem);
+    box-shadow: var(--cinder-shadow-sm, 0 1px 2px rgba(0, 0, 0, 0.05));
+  }
 
-/*
+  /*
  * variant: shared-borders — outer border on the container; 1px gap filled by the
  * container background acts as the divider between cells. Children paint over the
  * gap with the surface color, avoiding nth-child math for any column count.
  */
-.cinder-stat-group[data-cinder-variant='shared-borders'] {
-  border: 1px solid var(--cinder-border);
-  border-radius: var(--cinder-radius-md, 0.5rem);
-  overflow: hidden;
-  background: var(--cinder-border);
-  gap: 1px;
-}
+  .cinder-stat-group[data-cinder-variant='shared-borders'] {
+    border: 1px solid var(--cinder-border);
+    border-radius: var(--cinder-radius-md, 0.5rem);
+    overflow: hidden;
+    background: var(--cinder-border);
+    gap: 1px;
+  }
 
-.cinder-stat-group[data-cinder-variant='shared-borders'] > .cinder-stat {
-  padding: var(--cinder-space-4, 1rem);
-  background: var(--cinder-surface-raised);
+  .cinder-stat-group[data-cinder-variant='shared-borders'] > .cinder-stat {
+    padding: var(--cinder-space-4, 1rem);
+    background: var(--cinder-surface-raised);
+  }
 }

--- a/packages/components/src/components/stat/stat.css
+++ b/packages/components/src/components/stat/stat.css
@@ -1,70 +1,72 @@
-.cinder-stat {
-  display: grid;
-  grid-template-columns: 1fr;
-  grid-template-rows: auto auto auto;
-  row-gap: var(--cinder-space-1, 0.25rem);
-  align-items: start;
-  color: var(--cinder-text);
-}
+@layer cinder.components {
+  .cinder-stat {
+    display: grid;
+    grid-template-columns: 1fr;
+    grid-template-rows: auto auto auto;
+    row-gap: var(--cinder-space-1, 0.25rem);
+    align-items: start;
+    color: var(--cinder-text);
+  }
 
-.cinder-stat[data-cinder-has-icon] {
-  grid-template-columns: auto 1fr;
-  column-gap: var(--cinder-space-3, 0.75rem);
-}
+  .cinder-stat[data-cinder-has-icon] {
+    grid-template-columns: auto 1fr;
+    column-gap: var(--cinder-space-3, 0.75rem);
+  }
 
-.cinder-stat__icon {
-  /* Span the label and value rows so the icon visually anchors the metric, not the change text. */
-  grid-row: 1 / 3;
-  grid-column: 1;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  color: var(--cinder-text-muted);
-}
+  .cinder-stat__icon {
+    /* Span the label and value rows so the icon visually anchors the metric, not the change text. */
+    grid-row: 1 / 3;
+    grid-column: 1;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    color: var(--cinder-text-muted);
+  }
 
-.cinder-stat__label {
-  font-size: var(--cinder-text-sm);
-  color: var(--cinder-text-muted);
-}
+  .cinder-stat__label {
+    font-size: var(--cinder-text-sm);
+    color: var(--cinder-text-muted);
+  }
 
-.cinder-stat[data-cinder-has-icon] .cinder-stat__label {
-  grid-column: 2;
-}
+  .cinder-stat[data-cinder-has-icon] .cinder-stat__label {
+    grid-column: 2;
+  }
 
-.cinder-stat__value {
-  font-size: var(--cinder-text-4xl);
-  font-weight: var(--cinder-font-semibold);
-  font-variant-numeric: tabular-nums;
-  line-height: 1.1;
-}
+  .cinder-stat__value {
+    font-size: var(--cinder-text-4xl);
+    font-weight: var(--cinder-font-semibold);
+    font-variant-numeric: tabular-nums;
+    line-height: 1.1;
+  }
 
-.cinder-stat[data-cinder-has-icon] .cinder-stat__value {
-  grid-column: 2;
-}
+  .cinder-stat[data-cinder-has-icon] .cinder-stat__value {
+    grid-column: 2;
+  }
 
-.cinder-stat__change {
-  display: inline-flex;
-  align-items: center;
-  gap: var(--cinder-space-1, 0.25rem);
-  font-size: var(--cinder-text-sm);
-}
+  .cinder-stat__change {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--cinder-space-1, 0.25rem);
+    font-size: var(--cinder-text-sm);
+  }
 
-.cinder-stat[data-cinder-has-icon] .cinder-stat__change {
-  grid-column: 2;
-}
+  .cinder-stat[data-cinder-has-icon] .cinder-stat__change {
+    grid-column: 2;
+  }
 
-.cinder-stat__change[data-cinder-direction='up'] {
-  color: var(--cinder-success);
-}
+  .cinder-stat__change[data-cinder-direction='up'] {
+    color: var(--cinder-success);
+  }
 
-.cinder-stat__change[data-cinder-direction='down'] {
-  color: var(--cinder-danger);
-}
+  .cinder-stat__change[data-cinder-direction='down'] {
+    color: var(--cinder-danger);
+  }
 
-.cinder-stat__change[data-cinder-direction='neutral'] {
-  color: var(--cinder-text-muted);
-}
+  .cinder-stat__change[data-cinder-direction='neutral'] {
+    color: var(--cinder-text-muted);
+  }
 
-.cinder-stat__change-description {
-  color: var(--cinder-text-muted);
+  .cinder-stat__change-description {
+    color: var(--cinder-text-muted);
+  }
 }

--- a/packages/components/src/components/status-dot/status-dot.css
+++ b/packages/components/src/components/status-dot/status-dot.css
@@ -1,4 +1,5 @@
-/* ========================================
+@layer cinder.components {
+  /* ========================================
  * STATUS DOT
  *
  * Small colored dot with optional visible label communicating binary or
@@ -9,69 +10,70 @@
  * instance without forking.
  * ======================================== */
 
-.cinder-status-dot {
-  --cinder-status-dot-size: 0.625rem; /* 10px — md default */
-  --cinder-status-dot-color: var(--cinder-text-muted);
+  .cinder-status-dot {
+    --cinder-status-dot-size: 0.625rem; /* 10px — md default */
+    --cinder-status-dot-color: var(--cinder-text-muted);
 
-  display: inline-flex;
-  align-items: center;
-  gap: var(--cinder-space-1-5);
-  font-size: var(--cinder-text-sm);
-  line-height: 1.25;
-  color: var(--cinder-text);
-  vertical-align: middle;
-}
+    display: inline-flex;
+    align-items: center;
+    gap: var(--cinder-space-1-5);
+    font-size: var(--cinder-text-sm);
+    line-height: 1.25;
+    color: var(--cinder-text);
+    vertical-align: middle;
+  }
 
-.cinder-status-dot__indicator {
-  display: inline-block;
-  flex-shrink: 0;
-  inline-size: var(--cinder-status-dot-size);
-  block-size: var(--cinder-status-dot-size);
-  border-radius: var(--cinder-radius-full);
-  background: var(--cinder-status-dot-color);
-}
+  .cinder-status-dot__indicator {
+    display: inline-block;
+    flex-shrink: 0;
+    inline-size: var(--cinder-status-dot-size);
+    block-size: var(--cinder-status-dot-size);
+    border-radius: var(--cinder-radius-full);
+    background: var(--cinder-status-dot-color);
+  }
 
-.cinder-status-dot__label {
-  color: inherit;
-}
+  .cinder-status-dot__label {
+    color: inherit;
+  }
 
-/* ----------------------------------------
+  /* ----------------------------------------
  * Size variants
  * ---------------------------------------- */
 
-.cinder-status-dot[data-cinder-size='sm'] {
-  --cinder-status-dot-size: 0.5rem; /* 8px */
-  font-size: var(--cinder-text-xs);
-}
+  .cinder-status-dot[data-cinder-size='sm'] {
+    --cinder-status-dot-size: 0.5rem; /* 8px */
+    font-size: var(--cinder-text-xs);
+  }
 
-.cinder-status-dot[data-cinder-size='md'] {
-  --cinder-status-dot-size: 0.625rem; /* 10px */
-}
+  .cinder-status-dot[data-cinder-size='md'] {
+    --cinder-status-dot-size: 0.625rem; /* 10px */
+  }
 
-/* ----------------------------------------
+  /* ----------------------------------------
  * Status → semantic token mapping
  * ---------------------------------------- */
 
-.cinder-status-dot[data-cinder-status='online'] {
-  --cinder-status-dot-color: var(--cinder-success);
-}
+  .cinder-status-dot[data-cinder-status='online'] {
+    --cinder-status-dot-color: var(--cinder-success);
+  }
 
-.cinder-status-dot[data-cinder-status='offline'] {
-  --cinder-status-dot-color: var(--cinder-text-muted);
-}
+  .cinder-status-dot[data-cinder-status='offline'] {
+    --cinder-status-dot-color: var(--cinder-text-muted);
+  }
 
-.cinder-status-dot[data-cinder-status='warning'] {
-  --cinder-status-dot-color: var(--cinder-warning);
-}
+  .cinder-status-dot[data-cinder-status='warning'] {
+    --cinder-status-dot-color: var(--cinder-warning);
+  }
 
-.cinder-status-dot[data-cinder-status='error'] {
-  --cinder-status-dot-color: var(--cinder-danger);
-}
+  .cinder-status-dot[data-cinder-status='error'] {
+    --cinder-status-dot-color: var(--cinder-danger);
+  }
 
-.cinder-status-dot[data-cinder-status='pending'] {
-  --cinder-status-dot-color: var(--cinder-info);
-}
+  .cinder-status-dot[data-cinder-status='pending'] {
+    --cinder-status-dot-color: var(--cinder-info);
+  }
 
-.cinder-status-dot[data-cinder-status='neutral'] {
-  --cinder-status-dot-color: var(--cinder-text-muted);
+  .cinder-status-dot[data-cinder-status='neutral'] {
+    --cinder-status-dot-color: var(--cinder-text-muted);
+  }
 }

--- a/packages/components/src/components/steps/steps.css
+++ b/packages/components/src/components/steps/steps.css
@@ -1,261 +1,263 @@
-/* ========================================
+@layer cinder.components {
+  /* ========================================
  * STEPS
  * Wizard step indicator with horizontal and vertical orientations.
  * Uses aria-current="step" for the active step; completed steps render
  * a checkmark icon. No role="progressbar" — steps are navigation, not metering.
  * ======================================== */
 
-.cinder-steps {
-  display: block;
-}
+  .cinder-steps {
+    display: block;
+  }
 
-/* ----------------------------------------
+  /* ----------------------------------------
  * List
  * ---------------------------------------- */
 
-.cinder-steps__list {
-  list-style: none;
-  padding: 0;
-  margin: 0;
-  display: flex;
-}
+  .cinder-steps__list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: flex;
+  }
 
-.cinder-steps[data-cinder-orientation='horizontal'] .cinder-steps__list {
-  flex-direction: row;
-  align-items: flex-start;
-}
+  .cinder-steps[data-cinder-orientation='horizontal'] .cinder-steps__list {
+    flex-direction: row;
+    align-items: flex-start;
+  }
 
-.cinder-steps[data-cinder-orientation='vertical'] .cinder-steps__list {
-  flex-direction: column;
-  align-items: stretch;
-}
+  .cinder-steps[data-cinder-orientation='vertical'] .cinder-steps__list {
+    flex-direction: column;
+    align-items: stretch;
+  }
 
-/* ----------------------------------------
+  /* ----------------------------------------
  * Item — horizontal layout
  * Marker (top-left) | Connector (top-right, centered vertically)
  * Body spans full width in second row
  * ---------------------------------------- */
 
-.cinder-steps[data-cinder-orientation='horizontal'] .cinder-steps__item {
-  flex: 1 1 0;
-  display: grid;
-  grid-template-columns: auto 1fr;
-  grid-template-rows: auto auto;
-  gap: 0 var(--cinder-space-2);
-}
+  .cinder-steps[data-cinder-orientation='horizontal'] .cinder-steps__item {
+    flex: 1 1 0;
+    display: grid;
+    grid-template-columns: auto 1fr;
+    grid-template-rows: auto auto;
+    gap: 0 var(--cinder-space-2);
+  }
 
-.cinder-steps[data-cinder-orientation='horizontal'] .cinder-steps__marker {
-  grid-column: 1;
-  grid-row: 1;
-}
+  .cinder-steps[data-cinder-orientation='horizontal'] .cinder-steps__marker {
+    grid-column: 1;
+    grid-row: 1;
+  }
 
-.cinder-steps[data-cinder-orientation='horizontal'] .cinder-steps__connector {
-  grid-column: 2;
-  grid-row: 1;
-  align-self: center;
-  height: 1px;
-  /* Shorten the painted line by the leading gap and push it clear of the
+  .cinder-steps[data-cinder-orientation='horizontal'] .cinder-steps__connector {
+    grid-column: 2;
+    grid-row: 1;
+    align-self: center;
+    height: 1px;
+    /* Shorten the painted line by the leading gap and push it clear of the
      marker, so the total inline footprint of the cell is unchanged (no
      overshoot into the next marker). */
-  width: calc(100% - var(--cinder-space-2));
-  margin-inline-start: var(--cinder-space-2);
-}
+    width: calc(100% - var(--cinder-space-2));
+    margin-inline-start: var(--cinder-space-2);
+  }
 
-.cinder-steps[data-cinder-orientation='horizontal'] .cinder-steps__body {
-  grid-column: 1 / -1;
-  grid-row: 2;
-}
+  .cinder-steps[data-cinder-orientation='horizontal'] .cinder-steps__body {
+    grid-column: 1 / -1;
+    grid-row: 2;
+  }
 
-/* ----------------------------------------
+  /* ----------------------------------------
  * Item — vertical layout
  * Marker (top of column 1) | Body (column 2, spanning both rows)
  * Connector (below marker in column 1)
  * ---------------------------------------- */
 
-.cinder-steps[data-cinder-orientation='vertical'] .cinder-steps__item {
-  display: grid;
-  grid-template-columns: auto 1fr;
-  grid-template-rows: auto 1fr;
-  gap: 0 var(--cinder-space-3);
-}
+  .cinder-steps[data-cinder-orientation='vertical'] .cinder-steps__item {
+    display: grid;
+    grid-template-columns: auto 1fr;
+    grid-template-rows: auto 1fr;
+    gap: 0 var(--cinder-space-3);
+  }
 
-.cinder-steps[data-cinder-orientation='vertical'] .cinder-steps__marker {
-  grid-column: 1;
-  grid-row: 1;
-}
+  .cinder-steps[data-cinder-orientation='vertical'] .cinder-steps__marker {
+    grid-column: 1;
+    grid-row: 1;
+  }
 
-.cinder-steps[data-cinder-orientation='vertical'] .cinder-steps__connector {
-  grid-column: 1;
-  grid-row: 2;
-  justify-self: center;
-  width: 1px;
-  min-height: var(--cinder-space-6);
-  align-self: stretch;
-}
+  .cinder-steps[data-cinder-orientation='vertical'] .cinder-steps__connector {
+    grid-column: 1;
+    grid-row: 2;
+    justify-self: center;
+    width: 1px;
+    min-height: var(--cinder-space-6);
+    align-self: stretch;
+  }
 
-.cinder-steps[data-cinder-orientation='vertical'] .cinder-steps__body {
-  grid-column: 2;
-  grid-row: 1 / span 2;
-  padding-bottom: var(--cinder-space-4);
-}
+  .cinder-steps[data-cinder-orientation='vertical'] .cinder-steps__body {
+    grid-column: 2;
+    grid-row: 1 / span 2;
+    padding-bottom: var(--cinder-space-4);
+  }
 
-/* ----------------------------------------
+  /* ----------------------------------------
  * Marker — the step circle
  * ---------------------------------------- */
 
-.cinder-steps__marker {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 1.5rem;
-  height: 1.5rem;
-  border-radius: var(--cinder-radius-full);
-  background: var(--cinder-surface-inset);
-  flex-shrink: 0;
-}
-
-[data-cinder-state='complete'] .cinder-steps__marker {
-  background: var(--cinder-accent);
-  color: var(--cinder-accent-contrast);
-}
-
-[data-cinder-state='current'] .cinder-steps__marker {
-  background: var(--cinder-surface);
-  box-shadow: 0 0 0 2px var(--cinder-accent);
-  color: var(--cinder-accent);
-}
-
-@media (forced-colors: active) {
-  [data-cinder-state='current'] .cinder-steps__marker {
-    outline: 2px solid ButtonText;
-    outline-offset: 2px;
-    box-shadow: none;
+  .cinder-steps__marker {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 1.5rem;
+    height: 1.5rem;
+    border-radius: var(--cinder-radius-full);
+    background: var(--cinder-surface-inset);
+    flex-shrink: 0;
   }
-}
 
-[data-cinder-state='upcoming'] .cinder-steps__marker {
-  color: var(--cinder-text-muted);
-}
+  [data-cinder-state='complete'] .cinder-steps__marker {
+    background: var(--cinder-accent);
+    color: var(--cinder-accent-contrast);
+  }
 
-/* ----------------------------------------
+  [data-cinder-state='current'] .cinder-steps__marker {
+    background: var(--cinder-surface);
+    box-shadow: 0 0 0 2px var(--cinder-accent);
+    color: var(--cinder-accent);
+  }
+
+  @media (forced-colors: active) {
+    [data-cinder-state='current'] .cinder-steps__marker {
+      outline: 2px solid ButtonText;
+      outline-offset: 2px;
+      box-shadow: none;
+    }
+  }
+
+  [data-cinder-state='upcoming'] .cinder-steps__marker {
+    color: var(--cinder-text-muted);
+  }
+
+  /* ----------------------------------------
  * Check icon and step index number
  * ---------------------------------------- */
 
-.cinder-steps__check {
-  width: 0.875rem;
-  height: 0.875rem;
-}
+  .cinder-steps__check {
+    width: 0.875rem;
+    height: 0.875rem;
+  }
 
-.cinder-steps__index {
-  font-size: var(--cinder-text-xs);
-  font-weight: var(--cinder-font-semibold);
-  line-height: 1;
-}
+  .cinder-steps__index {
+    font-size: var(--cinder-text-xs);
+    font-weight: var(--cinder-font-semibold);
+    line-height: 1;
+  }
 
-/* ----------------------------------------
+  /* ----------------------------------------
  * Body — label and description
  * ---------------------------------------- */
 
-.cinder-steps__body {
-  position: relative;
-  display: flex;
-  flex-direction: column;
-  gap: var(--cinder-space-1);
-  padding-top: var(--cinder-space-2);
-}
+  .cinder-steps__body {
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    gap: var(--cinder-space-1);
+    padding-top: var(--cinder-space-2);
+  }
 
-/* ----------------------------------------
+  /* ----------------------------------------
  * Interactive body — an <a>/<button> occupying the body cell. Resets native
  * chrome so both elements render identically to the static body, then layers
  * a focus ring. The element keeps .cinder-steps__body, so the body's flex
  * layout (position/display/gap) is reused with zero duplication.
  * ---------------------------------------- */
 
-.cinder-steps__interactive {
-  appearance: none;
-  border: 0;
-  background: transparent;
-  margin: 0;
-  padding: 0;
-  font: inherit;
-  text-align: inherit;
-  inline-size: 100%;
-  color: inherit;
-  text-decoration: none;
-  cursor: pointer;
-  border-radius: var(--cinder-radius-sm);
-}
-
-/* Restore body padding cleared by the reset above. Interactive steps must match
-   static step spacing in both orientations. */
-.cinder-steps__interactive.cinder-steps__body {
-  padding-top: var(--cinder-space-2);
-}
-
-.cinder-steps[data-cinder-orientation='vertical'] .cinder-steps__interactive.cinder-steps__body {
-  padding-bottom: var(--cinder-space-4);
-}
-
-.cinder-steps__interactive:focus-visible {
-  outline: var(--cinder-ring-width) solid transparent;
-  box-shadow: var(--_cinder-focus-ring-shadow);
-}
-
-@media (forced-colors: active) {
-  .cinder-steps__interactive:focus-visible {
-    outline: var(--cinder-ring-width) solid ButtonText;
-    outline-offset: 3px;
+  .cinder-steps__interactive {
+    appearance: none;
+    border: 0;
+    background: transparent;
+    margin: 0;
+    padding: 0;
+    font: inherit;
+    text-align: inherit;
+    inline-size: 100%;
+    color: inherit;
+    text-decoration: none;
+    cursor: pointer;
+    border-radius: var(--cinder-radius-sm);
   }
-}
 
-.cinder-steps__label {
-  font-size: var(--cinder-text-sm);
-  font-weight: var(--cinder-font-normal);
-  color: var(--cinder-text);
-  line-height: var(--cinder-leading-tight);
-}
+  /* Restore body padding cleared by the reset above. Interactive steps must match
+   static step spacing in both orientations. */
+  .cinder-steps__interactive.cinder-steps__body {
+    padding-top: var(--cinder-space-2);
+  }
 
-[data-cinder-state='current'] .cinder-steps__label {
-  font-weight: var(--cinder-font-semibold);
-}
+  .cinder-steps[data-cinder-orientation='vertical'] .cinder-steps__interactive.cinder-steps__body {
+    padding-bottom: var(--cinder-space-4);
+  }
 
-[data-cinder-state='upcoming'] .cinder-steps__label {
-  color: var(--cinder-text-muted);
-}
+  .cinder-steps__interactive:focus-visible {
+    outline: var(--cinder-ring-width) solid transparent;
+    box-shadow: var(--_cinder-focus-ring-shadow);
+  }
 
-.cinder-steps__description {
-  font-size: var(--cinder-text-xs);
-  color: var(--cinder-text-muted);
-  line-height: var(--cinder-leading-normal);
-}
+  @media (forced-colors: active) {
+    .cinder-steps__interactive:focus-visible {
+      outline: var(--cinder-ring-width) solid ButtonText;
+      outline-offset: 3px;
+    }
+  }
 
-/* ----------------------------------------
+  .cinder-steps__label {
+    font-size: var(--cinder-text-sm);
+    font-weight: var(--cinder-font-normal);
+    color: var(--cinder-text);
+    line-height: var(--cinder-leading-tight);
+  }
+
+  [data-cinder-state='current'] .cinder-steps__label {
+    font-weight: var(--cinder-font-semibold);
+  }
+
+  [data-cinder-state='upcoming'] .cinder-steps__label {
+    color: var(--cinder-text-muted);
+  }
+
+  .cinder-steps__description {
+    font-size: var(--cinder-text-xs);
+    color: var(--cinder-text-muted);
+    line-height: var(--cinder-leading-normal);
+  }
+
+  /* ----------------------------------------
  * Connector — the line between steps
  * ---------------------------------------- */
 
-.cinder-steps__connector {
-  /* border-muted reads clearly in dark mode where plain --cinder-border is
+  .cinder-steps__connector {
+    /* border-muted reads clearly in dark mode where plain --cinder-border is
      near-invisible against --cinder-surface. */
-  background: var(--cinder-border-muted);
-}
+    background: var(--cinder-border-muted);
+  }
 
-.cinder-steps__connector[data-cinder-state='complete'] {
-  background: var(--cinder-accent);
-}
+  .cinder-steps__connector[data-cinder-state='complete'] {
+    background: var(--cinder-accent);
+  }
 
-/* ----------------------------------------
+  /* ----------------------------------------
  * Visually-hidden text for completed steps
  * ---------------------------------------- */
 
-.cinder-steps__sr-only,
-.cinder-steps__sr-only-separator {
-  position: absolute;
-  width: 1px;
-  height: 1px;
-  padding: 0;
-  margin: -1px;
-  overflow: hidden;
-  clip: rect(0, 0, 0, 0);
-  white-space: nowrap;
-  border-width: 0;
+  .cinder-steps__sr-only,
+  .cinder-steps__sr-only-separator {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border-width: 0;
+  }
 }

--- a/packages/components/src/components/surface/surface.css
+++ b/packages/components/src/components/surface/surface.css
@@ -1,20 +1,22 @@
-.cinder-surface {
-  background: var(--cinder-surface);
-  border: 1px solid var(--cinder-border);
-  border-radius: var(--cinder-radius-md);
-}
+@layer cinder.components {
+  .cinder-surface {
+    background: var(--cinder-surface);
+    border: 1px solid var(--cinder-border);
+    border-radius: var(--cinder-radius-md);
+  }
 
-.cinder-surface[data-cinder-tone='raised'] {
-  background: var(--cinder-surface-raised);
-  box-shadow: var(--cinder-shadow-sm);
-}
+  .cinder-surface[data-cinder-tone='raised'] {
+    background: var(--cinder-surface-raised);
+    box-shadow: var(--cinder-shadow-sm);
+  }
 
-.cinder-surface[data-cinder-tone='inset'] {
-  background: var(--cinder-surface-inset);
-}
+  .cinder-surface[data-cinder-tone='inset'] {
+    background: var(--cinder-surface-inset);
+  }
 
-.cinder-surface[data-cinder-tone='transparent'] {
-  background: transparent;
-  border-color: transparent;
-  box-shadow: none;
+  .cinder-surface[data-cinder-tone='transparent'] {
+    background: transparent;
+    border-color: transparent;
+    box-shadow: none;
+  }
 }

--- a/packages/components/src/components/tab-list/tab-list.css
+++ b/packages/components/src/components/tab-list/tab-list.css
@@ -1,4 +1,6 @@
-/* ========================================
+@layer cinder.components {
+  /* ========================================
  * TAB LIST
  * Wrapper styled in tabs.css. Empty registry entry.
  * ======================================== */
+}

--- a/packages/components/src/components/tab-panel/tab-panel.css
+++ b/packages/components/src/components/tab-panel/tab-panel.css
@@ -1,4 +1,6 @@
-/* ========================================
+@layer cinder.components {
+  /* ========================================
  * TAB PANEL
  * Visual treatment lives in tabs.css. Empty registry entry.
  * ======================================== */
+}

--- a/packages/components/src/components/tab/tab.css
+++ b/packages/components/src/components/tab/tab.css
@@ -1,6 +1,8 @@
-/* ========================================
+@layer cinder.components {
+  /* ========================================
  * TAB
  * Visual treatment for the tab button lives in tabs.css alongside the
  * sibling tablist and panel styles. This file is kept as an empty registry
  * entry — one CSS partial per .svelte file keeps the convention honest.
  * ======================================== */
+}

--- a/packages/components/src/components/table-body/table-body.css
+++ b/packages/components/src/components/table-body/table-body.css
@@ -1,4 +1,6 @@
-/* ========================================
+@layer cinder.components {
+  /* ========================================
  * TABLE BODY
  * Visual treatment lives in table.css. Empty registry entry.
  * ======================================== */
+}

--- a/packages/components/src/components/table-cell/table-cell.css
+++ b/packages/components/src/components/table-cell/table-cell.css
@@ -1,4 +1,6 @@
-/* ========================================
+@layer cinder.components {
+  /* ========================================
  * TABLE CELL
  * Visual treatment lives in table.css. Empty registry entry.
  * ======================================== */
+}

--- a/packages/components/src/components/table-header-cell/table-header-cell.css
+++ b/packages/components/src/components/table-header-cell/table-header-cell.css
@@ -1,4 +1,6 @@
-/* ========================================
+@layer cinder.components {
+  /* ========================================
  * TABLE HEADER CELL
  * Visual treatment lives in table.css. Empty registry entry.
  * ======================================== */
+}

--- a/packages/components/src/components/table-header/table-header.css
+++ b/packages/components/src/components/table-header/table-header.css
@@ -1,4 +1,6 @@
-/* ========================================
+@layer cinder.components {
+  /* ========================================
  * TABLE HEADER
  * Visual treatment lives in table.css. Empty registry entry.
  * ======================================== */
+}

--- a/packages/components/src/components/table-row/table-row.css
+++ b/packages/components/src/components/table-row/table-row.css
@@ -1,4 +1,6 @@
-/* ========================================
+@layer cinder.components {
+  /* ========================================
  * TABLE ROW
  * Visual treatment lives in table.css. Empty registry entry.
  * ======================================== */
+}

--- a/packages/components/src/components/table/table.css
+++ b/packages/components/src/components/table/table.css
@@ -1,76 +1,77 @@
-/* ========================================
+@layer cinder.components {
+  /* ========================================
  * TABLE
  * Semantic <table> styled to match the rest of the design system.
  * Composition: Table > TableHeader > TableRow > TableHeaderCell
  *              Table > TableBody   > TableRow > TableCell
  * ======================================== */
 
-.cinder-table {
-  width: 100%;
-  border-collapse: collapse;
-  font-size: var(--cinder-text-sm);
-  color: var(--cinder-text);
-  background: var(--cinder-surface);
-}
+  .cinder-table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: var(--cinder-text-sm);
+    color: var(--cinder-text);
+    background: var(--cinder-surface);
+  }
 
-.cinder-table__caption {
-  caption-side: top;
-  text-align: left;
-  padding-block: var(--cinder-space-3) var(--cinder-space-2);
-  padding-inline: var(--cinder-space-3);
-  font-weight: var(--cinder-font-medium);
-  color: var(--cinder-text);
-}
+  .cinder-table__caption {
+    caption-side: top;
+    text-align: left;
+    padding-block: var(--cinder-space-3) var(--cinder-space-2);
+    padding-inline: var(--cinder-space-3);
+    font-weight: var(--cinder-font-medium);
+    color: var(--cinder-text);
+  }
 
-/* ----------------------------------------
+  /* ----------------------------------------
  * Header
  * ---------------------------------------- */
 
-.cinder-table__header {
-  background: var(--cinder-surface-inset);
-}
+  .cinder-table__header {
+    background: var(--cinder-surface-inset);
+  }
 
-.cinder-table[data-cinder-sticky-header] .cinder-table__header {
-  position: sticky;
-  top: 0;
-  z-index: 1;
-}
+  .cinder-table[data-cinder-sticky-header] .cinder-table__header {
+    position: sticky;
+    top: 0;
+    z-index: 1;
+  }
 
-.cinder-table__header-cell {
-  padding-block: var(--cinder-space-2);
-  padding-inline: var(--cinder-space-3);
-  text-align: left;
-  font-weight: var(--cinder-font-medium);
-  color: var(--cinder-text-muted);
-  border-bottom: 1px solid var(--cinder-border-muted);
-  white-space: nowrap;
-}
+  .cinder-table__header-cell {
+    padding-block: var(--cinder-space-2);
+    padding-inline: var(--cinder-space-3);
+    text-align: left;
+    font-weight: var(--cinder-font-medium);
+    color: var(--cinder-text-muted);
+    border-bottom: 1px solid var(--cinder-border-muted);
+    white-space: nowrap;
+  }
 
-.cinder-table__header-cell[aria-sort='ascending'],
-.cinder-table__header-cell[aria-sort='descending'] {
-  color: var(--cinder-text);
-}
+  .cinder-table__header-cell[aria-sort='ascending'],
+  .cinder-table__header-cell[aria-sort='descending'] {
+    color: var(--cinder-text);
+  }
 
-/* ----------------------------------------
+  /* ----------------------------------------
  * Density — padding overrides for header and body cells.
  * Comfortable is the baseline (set on .cinder-table__cell / .cinder-table__header-cell).
  * Only condensed and spacious need explicit overrides; any unknown density value
  * falls back gracefully to comfortable padding.
  * ---------------------------------------- */
 
-.cinder-table[data-cinder-density='condensed'] .cinder-table__cell,
-.cinder-table[data-cinder-density='condensed'] .cinder-table__header-cell {
-  padding-block: var(--cinder-space-1);
-  padding-inline: var(--cinder-space-3);
-}
+  .cinder-table[data-cinder-density='condensed'] .cinder-table__cell,
+  .cinder-table[data-cinder-density='condensed'] .cinder-table__header-cell {
+    padding-block: var(--cinder-space-1);
+    padding-inline: var(--cinder-space-3);
+  }
 
-.cinder-table[data-cinder-density='spacious'] .cinder-table__cell,
-.cinder-table[data-cinder-density='spacious'] .cinder-table__header-cell {
-  padding-block: var(--cinder-space-3);
-  padding-inline: var(--cinder-space-4);
-}
+  .cinder-table[data-cinder-density='spacious'] .cinder-table__cell,
+  .cinder-table[data-cinder-density='spacious'] .cinder-table__header-cell {
+    padding-block: var(--cinder-space-3);
+    padding-inline: var(--cinder-space-4);
+  }
 
-/* ----------------------------------------
+  /* ----------------------------------------
  * Selection cells
  * Specificity (0,3,0) — equal to density rules; source order places these
  * after density so equal-specificity resolution favors selection.
@@ -78,101 +79,102 @@
  * density (the checkbox is a fixed-height control).
  * ---------------------------------------- */
 
-.cinder-table[data-cinder-selectable] .cinder-table__cell--selection,
-.cinder-table[data-cinder-selectable] .cinder-table__header-cell--selection {
-  width: 1px;
-  padding-inline: var(--cinder-space-3);
-  padding-block: var(--cinder-space-2);
-  text-align: center;
-  vertical-align: middle;
-}
+  .cinder-table[data-cinder-selectable] .cinder-table__cell--selection,
+  .cinder-table[data-cinder-selectable] .cinder-table__header-cell--selection {
+    width: 1px;
+    padding-inline: var(--cinder-space-3);
+    padding-block: var(--cinder-space-2);
+    text-align: center;
+    vertical-align: middle;
+  }
 
-/* ----------------------------------------
+  /* ----------------------------------------
  * Sort button (rendered inside sortable header cells)
  * ---------------------------------------- */
 
-.cinder-table__sort-button {
-  appearance: none;
-  background: none;
-  border: none;
-  padding: 0;
-  margin: 0;
-  font: inherit;
-  color: inherit;
-  cursor: pointer;
-  display: inline-flex;
-  align-items: center;
-  gap: var(--cinder-space-1);
-  width: 100%;
-  text-align: inherit;
-  border-radius: var(--cinder-radius-sm);
-  /* position: relative is required so z-index applies when :focus-visible fires */
-  position: relative;
-}
+  .cinder-table__sort-button {
+    appearance: none;
+    background: none;
+    border: none;
+    padding: 0;
+    margin: 0;
+    font: inherit;
+    color: inherit;
+    cursor: pointer;
+    display: inline-flex;
+    align-items: center;
+    gap: var(--cinder-space-1);
+    width: 100%;
+    text-align: inherit;
+    border-radius: var(--cinder-radius-sm);
+    /* position: relative is required so z-index applies when :focus-visible fires */
+    position: relative;
+  }
 
-.cinder-table__header-cell[data-cinder-align='center'] .cinder-table__sort-button {
-  justify-content: center;
-}
+  .cinder-table__header-cell[data-cinder-align='center'] .cinder-table__sort-button {
+    justify-content: center;
+  }
 
-.cinder-table__header-cell[data-cinder-align='right'] .cinder-table__sort-button {
-  justify-content: flex-end;
-}
+  .cinder-table__header-cell[data-cinder-align='right'] .cinder-table__sort-button {
+    justify-content: flex-end;
+  }
 
-.cinder-table__sort-button:focus-visible {
-  outline: var(--cinder-ring-width) solid transparent;
-  box-shadow: var(--_cinder-focus-ring-shadow);
-  /* Lift above sticky thead stacking context only while focused */
-  z-index: 2;
-}
+  .cinder-table__sort-button:focus-visible {
+    outline: var(--cinder-ring-width) solid transparent;
+    box-shadow: var(--_cinder-focus-ring-shadow);
+    /* Lift above sticky thead stacking context only while focused */
+    z-index: 2;
+  }
 
-.cinder-table__sort-indicator {
-  display: inline-flex;
-  color: var(--cinder-text-subtle);
-}
+  .cinder-table__sort-indicator {
+    display: inline-flex;
+    color: var(--cinder-text-subtle);
+  }
 
-.cinder-table__sort-indicator[data-cinder-direction='ascending'],
-.cinder-table__sort-indicator[data-cinder-direction='descending'] {
-  color: var(--cinder-text);
-}
+  .cinder-table__sort-indicator[data-cinder-direction='ascending'],
+  .cinder-table__sort-indicator[data-cinder-direction='descending'] {
+    color: var(--cinder-text);
+  }
 
-.cinder-table__sort-indicator[data-cinder-direction='ascending'] .cinder-table__sort-chevron-down,
-.cinder-table__sort-indicator[data-cinder-direction='descending'] .cinder-table__sort-chevron-up {
-  opacity: 0.3;
-}
+  .cinder-table__sort-indicator[data-cinder-direction='ascending'] .cinder-table__sort-chevron-down,
+  .cinder-table__sort-indicator[data-cinder-direction='descending'] .cinder-table__sort-chevron-up {
+    opacity: 0.3;
+  }
 
-/* ----------------------------------------
+  /* ----------------------------------------
  * Body / rows / cells
  * ---------------------------------------- */
 
-.cinder-table__row {
-  transition: background var(--cinder-duration-fast) var(--cinder-ease-standard);
-}
-
-@media (hover: hover) {
-  .cinder-table__body .cinder-table__row:hover {
-    background: var(--cinder-surface-hover);
+  .cinder-table__row {
+    transition: background var(--cinder-duration-fast) var(--cinder-ease-standard);
   }
-}
 
-.cinder-table__cell {
-  padding-block: var(--cinder-space-2);
-  padding-inline: var(--cinder-space-3);
-  border-bottom: 1px solid var(--cinder-border-muted);
-}
+  @media (hover: hover) {
+    .cinder-table__body .cinder-table__row:hover {
+      background: var(--cinder-surface-hover);
+    }
+  }
 
-.cinder-table__cell[data-cinder-align='center'] {
-  text-align: center;
-}
+  .cinder-table__cell {
+    padding-block: var(--cinder-space-2);
+    padding-inline: var(--cinder-space-3);
+    border-bottom: 1px solid var(--cinder-border-muted);
+  }
 
-.cinder-table__cell[data-cinder-align='right'] {
-  text-align: right;
-  font-variant-numeric: tabular-nums;
-}
+  .cinder-table__cell[data-cinder-align='center'] {
+    text-align: center;
+  }
 
-.cinder-table__header-cell[data-cinder-align='center'] {
-  text-align: center;
-}
+  .cinder-table__cell[data-cinder-align='right'] {
+    text-align: right;
+    font-variant-numeric: tabular-nums;
+  }
 
-.cinder-table__header-cell[data-cinder-align='right'] {
-  text-align: right;
+  .cinder-table__header-cell[data-cinder-align='center'] {
+    text-align: center;
+  }
+
+  .cinder-table__header-cell[data-cinder-align='right'] {
+    text-align: right;
+  }
 }

--- a/packages/components/src/components/table/table.test.ts
+++ b/packages/components/src/components/table/table.test.ts
@@ -1,6 +1,7 @@
 /// <reference lib="dom" />
 import { describe, expect, mock, test } from 'bun:test';
 
+import { stripCinderComponentsLayer } from '../../test/css.ts';
 import { setupHappyDom } from '../../test/happy-dom.ts';
 
 setupHappyDom();
@@ -8,7 +9,11 @@ setupHappyDom();
 const { render, fireEvent } = await import('@testing-library/svelte');
 const { default: Wrapper } = await import('../../test/fixtures/table-fixture.svelte');
 
-const tableCss = await Bun.file(new URL('./table.css', import.meta.url)).text();
+// Strip the @layer wrapper: happy-dom does not apply layer-nested rules to
+// getComputedStyle or expose them as top-level CSSStyleRules.
+const tableCss = stripCinderComponentsLayer(
+  await Bun.file(new URL('./table.css', import.meta.url)).text(),
+);
 
 const columns = [
   { key: 'name', label: 'Name', sortable: true },

--- a/packages/components/src/components/tabs/tabs.css
+++ b/packages/components/src/components/tabs/tabs.css
@@ -1,149 +1,151 @@
-/* ========================================
+@layer cinder.components {
+  /* ========================================
  * TABS
  * Outer wrapper provides flex layout for horizontal vs vertical orientation.
  * Contains a TabList (with role="tablist") and one or more TabPanels.
  * ======================================== */
 
-.cinder-tabs {
-  display: flex;
-  flex-direction: column;
-  gap: var(--cinder-space-4);
-}
+  .cinder-tabs {
+    display: flex;
+    flex-direction: column;
+    gap: var(--cinder-space-4);
+  }
 
-.cinder-tabs[data-cinder-orientation='vertical'] {
-  flex-direction: row;
-}
+  .cinder-tabs[data-cinder-orientation='vertical'] {
+    flex-direction: row;
+  }
 
-/* ----------------------------------------
+  /* ----------------------------------------
  * Tab list
  * ---------------------------------------- */
 
-.cinder-tab-list {
-  display: flex;
-  gap: var(--cinder-space-1);
-  border-bottom: 1px solid var(--cinder-border-muted);
-}
+  .cinder-tab-list {
+    display: flex;
+    gap: var(--cinder-space-1);
+    border-bottom: 1px solid var(--cinder-border-muted);
+  }
 
-.cinder-tab-list[data-cinder-orientation='vertical'] {
-  flex-direction: column;
-  border-bottom: none;
-  border-inline-end: 1px solid var(--cinder-border-muted);
-  align-self: stretch;
-}
+  .cinder-tab-list[data-cinder-orientation='vertical'] {
+    flex-direction: column;
+    border-bottom: none;
+    border-inline-end: 1px solid var(--cinder-border-muted);
+    align-self: stretch;
+  }
 
-/* ----------------------------------------
+  /* ----------------------------------------
  * Tab button
  * ---------------------------------------- */
 
-.cinder-tab {
-  appearance: none;
-  background: none;
-  border: none;
-  padding: var(--cinder-space-2) var(--cinder-space-3);
-  font: inherit;
-  font-size: var(--cinder-text-sm);
-  color: var(--cinder-text-muted);
-  cursor: pointer;
-  position: relative;
-  display: inline-flex;
-  align-items: center;
-  gap: var(--cinder-space-2);
-  border-radius: var(--cinder-radius-sm) var(--cinder-radius-sm) 0 0;
-  transition:
-    color var(--cinder-duration-fast) var(--cinder-ease-standard),
-    background var(--cinder-duration-fast) var(--cinder-ease-standard);
-}
-
-/* Decorative trailing slot (badges, kbd hints, counters). Wrapped in
- * `aria-hidden="true"` in the markup so it never enters the accessible name. */
-.cinder-tab__trailing {
-  display: inline-flex;
-  align-items: center;
-  color: var(--cinder-text-muted);
-  font-size: var(--cinder-text-xs);
-}
-
-/* Sticky-hover suppression on touch: wrap hover-only chrome so it doesn't
- * "stick" after tap on touch devices that emulate :hover. */
-@media (hover: hover) {
-  .cinder-tab:hover:not([data-cinder-disabled]) {
-    color: var(--cinder-text);
-    background: var(--cinder-surface-hover);
+  .cinder-tab {
+    appearance: none;
+    background: none;
+    border: none;
+    padding: var(--cinder-space-2) var(--cinder-space-3);
+    font: inherit;
+    font-size: var(--cinder-text-sm);
+    color: var(--cinder-text-muted);
+    cursor: pointer;
+    position: relative;
+    display: inline-flex;
+    align-items: center;
+    gap: var(--cinder-space-2);
+    border-radius: var(--cinder-radius-sm) var(--cinder-radius-sm) 0 0;
+    transition:
+      color var(--cinder-duration-fast) var(--cinder-ease-standard),
+      background var(--cinder-duration-fast) var(--cinder-ease-standard);
   }
-}
 
-/* Vertical tab radius — override the horizontal top-rounded/bottom-square
+  /* Decorative trailing slot (badges, kbd hints, counters). Wrapped in
+ * `aria-hidden="true"` in the markup so it never enters the accessible name. */
+  .cinder-tab__trailing {
+    display: inline-flex;
+    align-items: center;
+    color: var(--cinder-text-muted);
+    font-size: var(--cinder-text-xs);
+  }
+
+  /* Sticky-hover suppression on touch: wrap hover-only chrome so it doesn't
+ * "stick" after tap on touch devices that emulate :hover. */
+  @media (hover: hover) {
+    .cinder-tab:hover:not([data-cinder-disabled]) {
+      color: var(--cinder-text);
+      background: var(--cinder-surface-hover);
+    }
+  }
+
+  /* Vertical tab radius — override the horizontal top-rounded/bottom-square
  * shape so the focus-ring box-shadow does not paint a tombstone in vertical
  * tablists. Emitted from `tabs.orientation` context as `data-variant`. */
-.cinder-tab[data-variant='vertical'] {
-  border-radius: var(--cinder-radius-sm);
-}
-
-.cinder-tab[data-cinder-active] {
-  color: var(--cinder-accent);
-  font-weight: var(--cinder-font-medium);
-}
-
-/* Active indicator — bottom (horizontal) / right (vertical) accent stripe. */
-.cinder-tab[data-cinder-active]::after {
-  content: '';
-  position: absolute;
-  background: var(--cinder-accent);
-  pointer-events: none;
-}
-
-.cinder-tabs[data-cinder-orientation='horizontal'] .cinder-tab[data-cinder-active]::after,
-.cinder-tab-list[data-cinder-orientation='horizontal'] .cinder-tab[data-cinder-active]::after {
-  left: 0;
-  right: 0;
-  bottom: -1px;
-  height: 2px;
-}
-
-.cinder-tabs[data-cinder-orientation='vertical'] .cinder-tab[data-cinder-active]::after,
-.cinder-tab-list[data-cinder-orientation='vertical'] .cinder-tab[data-cinder-active]::after {
-  top: 0;
-  bottom: 0;
-  right: -1px;
-  width: 2px;
-  height: auto;
-}
-
-.cinder-tab:focus-visible {
-  outline: var(--cinder-ring-width) solid transparent;
-  box-shadow: var(--_cinder-focus-ring-shadow);
-}
-
-@media (forced-colors: active) {
-  .cinder-tab:focus-visible {
-    outline: var(--cinder-ring-width) solid Highlight;
-    outline-offset: 1px;
+  .cinder-tab[data-variant='vertical'] {
+    border-radius: var(--cinder-radius-sm);
   }
-}
 
-.cinder-tab[data-cinder-disabled] {
-  color: var(--cinder-text-disabled);
-  cursor: not-allowed;
-}
+  .cinder-tab[data-cinder-active] {
+    color: var(--cinder-accent);
+    font-weight: var(--cinder-font-medium);
+  }
 
-/* ----------------------------------------
+  /* Active indicator — bottom (horizontal) / right (vertical) accent stripe. */
+  .cinder-tab[data-cinder-active]::after {
+    content: '';
+    position: absolute;
+    background: var(--cinder-accent);
+    pointer-events: none;
+  }
+
+  .cinder-tabs[data-cinder-orientation='horizontal'] .cinder-tab[data-cinder-active]::after,
+  .cinder-tab-list[data-cinder-orientation='horizontal'] .cinder-tab[data-cinder-active]::after {
+    left: 0;
+    right: 0;
+    bottom: -1px;
+    height: 2px;
+  }
+
+  .cinder-tabs[data-cinder-orientation='vertical'] .cinder-tab[data-cinder-active]::after,
+  .cinder-tab-list[data-cinder-orientation='vertical'] .cinder-tab[data-cinder-active]::after {
+    top: 0;
+    bottom: 0;
+    right: -1px;
+    width: 2px;
+    height: auto;
+  }
+
+  .cinder-tab:focus-visible {
+    outline: var(--cinder-ring-width) solid transparent;
+    box-shadow: var(--_cinder-focus-ring-shadow);
+  }
+
+  @media (forced-colors: active) {
+    .cinder-tab:focus-visible {
+      outline: var(--cinder-ring-width) solid Highlight;
+      outline-offset: 1px;
+    }
+  }
+
+  .cinder-tab[data-cinder-disabled] {
+    color: var(--cinder-text-disabled);
+    cursor: not-allowed;
+  }
+
+  /* ----------------------------------------
  * Tab panel
  * ---------------------------------------- */
 
-.cinder-tab-panel {
-  flex: 1 1 auto;
-  padding: var(--cinder-space-2) 0;
-  outline: none;
-}
+  .cinder-tab-panel {
+    flex: 1 1 auto;
+    padding: var(--cinder-space-2) 0;
+    outline: none;
+  }
 
-.cinder-tab-panel:focus-visible {
-  outline: var(--cinder-ring-width) solid transparent;
-  box-shadow: var(--_cinder-focus-ring-shadow);
-}
-
-@media (forced-colors: active) {
   .cinder-tab-panel:focus-visible {
-    outline: var(--cinder-ring-width) solid Highlight;
-    outline-offset: 2px;
+    outline: var(--cinder-ring-width) solid transparent;
+    box-shadow: var(--_cinder-focus-ring-shadow);
+  }
+
+  @media (forced-colors: active) {
+    .cinder-tab-panel:focus-visible {
+      outline: var(--cinder-ring-width) solid Highlight;
+      outline-offset: 2px;
+    }
   }
 }

--- a/packages/components/src/components/tag-input/tag-input.css
+++ b/packages/components/src/components/tag-input/tag-input.css
@@ -1,180 +1,182 @@
-/* ========================================
+@layer cinder.components {
+  /* ========================================
  * TAG INPUT
  * ======================================== */
 
-.cinder-tag-input {
-  display: grid;
-  gap: var(--cinder-space-2);
-}
-
-.cinder-tag-input__control {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  gap: var(--cinder-space-2);
-  inline-size: 100%;
-  min-block-size: 2.5rem;
-  padding: var(--cinder-space-2);
-  background: var(--cinder-surface-raised);
-  border: 1px solid var(--cinder-border);
-  border-radius: var(--cinder-radius-md);
-  color: var(--cinder-text);
-  transition:
-    border-color var(--cinder-duration-fast) var(--cinder-ease-standard),
-    box-shadow var(--cinder-duration-fast) var(--cinder-ease-standard);
-}
-
-@media (hover: hover) {
-  .cinder-tag-input__control:hover:not([data-disabled]) {
-    border-color: var(--cinder-border-strong);
+  .cinder-tag-input {
+    display: grid;
+    gap: var(--cinder-space-2);
   }
-}
 
-.cinder-tag-input__control:focus-within {
-  outline: var(--cinder-ring-width) solid transparent;
-  box-shadow:
-    0 0 0 var(--cinder-ring-offset) var(--cinder-ring-offset-color),
-    0 0 0 calc(var(--cinder-ring-offset) + var(--cinder-ring-width))
-      var(--_cinder-tag-input-ring, var(--cinder-ring-color));
-}
-
-@media (forced-colors: active) {
-  .cinder-tag-input__control:focus-within {
-    outline: var(--cinder-ring-width) solid Highlight;
-    outline-offset: 1px;
-  }
-}
-
-.cinder-tag-input[data-invalid] .cinder-tag-input__control {
-  --_cinder-tag-input-ring: var(--cinder-danger);
-  border-color: var(--cinder-danger);
-}
-
-.cinder-tag-input[data-disabled] .cinder-tag-input__control {
-  background: var(--cinder-surface-inset);
-  border-color: var(--cinder-border-muted);
-  color: var(--cinder-text-disabled);
-  cursor: not-allowed;
-}
-
-.cinder-tag-input__listbox {
-  display: inline-flex;
-  flex-wrap: wrap;
-  align-items: center;
-  gap: var(--cinder-space-2);
-  margin: 0;
-  padding: 0;
-  list-style: none;
-}
-
-.cinder-tag-input__chip {
-  display: inline-flex;
-  align-items: center;
-  gap: var(--cinder-space-1-5);
-  min-block-size: 1.75rem;
-  max-inline-size: 100%;
-  padding-inline: var(--cinder-space-2);
-  padding-block: var(--cinder-space-1);
-  border: 1px solid var(--cinder-border-muted);
-  border-radius: var(--cinder-radius-full);
-  background: var(--cinder-surface-inset);
-  color: var(--cinder-text);
-  cursor: default;
-}
-
-.cinder-tag-input__chip:focus-visible {
-  outline: var(--cinder-ring-width) solid transparent;
-  box-shadow:
-    0 0 0 var(--cinder-ring-offset) var(--cinder-ring-offset-color),
-    0 0 0 calc(var(--cinder-ring-offset) + var(--cinder-ring-width)) var(--cinder-ring-color);
-}
-
-@media (forced-colors: active) {
-  .cinder-tag-input__chip:focus-visible {
-    outline: var(--cinder-ring-width) solid Highlight;
-    outline-offset: 1px;
-  }
-}
-
-.cinder-tag-input__chip-label {
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  font-size: var(--cinder-text-sm);
-  line-height: var(--cinder-leading-snug);
-}
-
-.cinder-tag-input__remove {
-  position: relative;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  inline-size: 1rem;
-  block-size: 1rem;
-  padding: 0;
-  border: none;
-  border-radius: var(--cinder-radius-full);
-  background: transparent;
-  color: var(--cinder-text-muted);
-  cursor: pointer;
-}
-
-.cinder-tag-input__remove::after {
-  content: '';
-  position: absolute;
-  inset: 50% auto auto 50%;
-  inline-size: 44px;
-  block-size: 44px;
-  transform: translate(-50%, -50%);
-}
-
-@media (hover: hover) {
-  .cinder-tag-input__remove:hover:not(:disabled) {
+  .cinder-tag-input__control {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: var(--cinder-space-2);
+    inline-size: 100%;
+    min-block-size: 2.5rem;
+    padding: var(--cinder-space-2);
+    background: var(--cinder-surface-raised);
+    border: 1px solid var(--cinder-border);
+    border-radius: var(--cinder-radius-md);
     color: var(--cinder-text);
-    background: color-mix(in oklch, var(--cinder-text), transparent 92%);
+    transition:
+      border-color var(--cinder-duration-fast) var(--cinder-ease-standard),
+      box-shadow var(--cinder-duration-fast) var(--cinder-ease-standard);
   }
-}
 
-.cinder-tag-input__remove:focus-visible {
-  outline: none;
-}
+  @media (hover: hover) {
+    .cinder-tag-input__control:hover:not([data-disabled]) {
+      border-color: var(--cinder-border-strong);
+    }
+  }
 
-.cinder-tag-input__remove:disabled {
-  cursor: not-allowed;
-  color: var(--cinder-text-disabled);
-}
+  .cinder-tag-input__control:focus-within {
+    outline: var(--cinder-ring-width) solid transparent;
+    box-shadow:
+      0 0 0 var(--cinder-ring-offset) var(--cinder-ring-offset-color),
+      0 0 0 calc(var(--cinder-ring-offset) + var(--cinder-ring-width))
+        var(--_cinder-tag-input-ring, var(--cinder-ring-color));
+  }
 
-.cinder-tag-input__input {
-  flex: 1 1 10rem;
-  min-inline-size: 8rem;
-  border: none;
-  background: transparent;
-  padding: 0;
-  font: inherit;
-  line-height: var(--cinder-leading-normal);
-  color: inherit;
-}
+  @media (forced-colors: active) {
+    .cinder-tag-input__control:focus-within {
+      outline: var(--cinder-ring-width) solid Highlight;
+      outline-offset: 1px;
+    }
+  }
 
-.cinder-tag-input__input::placeholder {
-  color: var(--cinder-text-subtle);
-}
+  .cinder-tag-input[data-invalid] .cinder-tag-input__control {
+    --_cinder-tag-input-ring: var(--cinder-danger);
+    border-color: var(--cinder-danger);
+  }
 
-.cinder-tag-input__input:focus-visible {
-  outline: none;
-  box-shadow: none;
-}
+  .cinder-tag-input[data-disabled] .cinder-tag-input__control {
+    background: var(--cinder-surface-inset);
+    border-color: var(--cinder-border-muted);
+    color: var(--cinder-text-disabled);
+    cursor: not-allowed;
+  }
 
-.cinder-tag-input__input:disabled {
-  cursor: not-allowed;
-}
+  .cinder-tag-input__listbox {
+    display: inline-flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: var(--cinder-space-2);
+    margin: 0;
+    padding: 0;
+    list-style: none;
+  }
 
-.cinder-tag-input__input:disabled::placeholder {
-  color: var(--cinder-text-disabled);
-}
+  .cinder-tag-input__chip {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--cinder-space-1-5);
+    min-block-size: 1.75rem;
+    max-inline-size: 100%;
+    padding-inline: var(--cinder-space-2);
+    padding-block: var(--cinder-space-1);
+    border: 1px solid var(--cinder-border-muted);
+    border-radius: var(--cinder-radius-full);
+    background: var(--cinder-surface-inset);
+    color: var(--cinder-text);
+    cursor: default;
+  }
 
-.cinder-tag-input__error {
-  margin: 0;
-  color: var(--cinder-danger);
-  font-size: var(--cinder-text-sm);
-  line-height: var(--cinder-leading-snug);
+  .cinder-tag-input__chip:focus-visible {
+    outline: var(--cinder-ring-width) solid transparent;
+    box-shadow:
+      0 0 0 var(--cinder-ring-offset) var(--cinder-ring-offset-color),
+      0 0 0 calc(var(--cinder-ring-offset) + var(--cinder-ring-width)) var(--cinder-ring-color);
+  }
+
+  @media (forced-colors: active) {
+    .cinder-tag-input__chip:focus-visible {
+      outline: var(--cinder-ring-width) solid Highlight;
+      outline-offset: 1px;
+    }
+  }
+
+  .cinder-tag-input__chip-label {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    font-size: var(--cinder-text-sm);
+    line-height: var(--cinder-leading-snug);
+  }
+
+  .cinder-tag-input__remove {
+    position: relative;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    inline-size: 1rem;
+    block-size: 1rem;
+    padding: 0;
+    border: none;
+    border-radius: var(--cinder-radius-full);
+    background: transparent;
+    color: var(--cinder-text-muted);
+    cursor: pointer;
+  }
+
+  .cinder-tag-input__remove::after {
+    content: '';
+    position: absolute;
+    inset: 50% auto auto 50%;
+    inline-size: 44px;
+    block-size: 44px;
+    transform: translate(-50%, -50%);
+  }
+
+  @media (hover: hover) {
+    .cinder-tag-input__remove:hover:not(:disabled) {
+      color: var(--cinder-text);
+      background: color-mix(in oklch, var(--cinder-text), transparent 92%);
+    }
+  }
+
+  .cinder-tag-input__remove:focus-visible {
+    outline: none;
+  }
+
+  .cinder-tag-input__remove:disabled {
+    cursor: not-allowed;
+    color: var(--cinder-text-disabled);
+  }
+
+  .cinder-tag-input__input {
+    flex: 1 1 10rem;
+    min-inline-size: 8rem;
+    border: none;
+    background: transparent;
+    padding: 0;
+    font: inherit;
+    line-height: var(--cinder-leading-normal);
+    color: inherit;
+  }
+
+  .cinder-tag-input__input::placeholder {
+    color: var(--cinder-text-subtle);
+  }
+
+  .cinder-tag-input__input:focus-visible {
+    outline: none;
+    box-shadow: none;
+  }
+
+  .cinder-tag-input__input:disabled {
+    cursor: not-allowed;
+  }
+
+  .cinder-tag-input__input:disabled::placeholder {
+    color: var(--cinder-text-disabled);
+  }
+
+  .cinder-tag-input__error {
+    margin: 0;
+    color: var(--cinder-danger);
+    font-size: var(--cinder-text-sm);
+    line-height: var(--cinder-leading-snug);
+  }
 }

--- a/packages/components/src/components/textarea/textarea.css
+++ b/packages/components/src/components/textarea/textarea.css
@@ -1,4 +1,5 @@
-/* ========================================
+@layer cinder.components {
+  /* ========================================
  * TEXTAREA FIELD
  * ========================================
  *
@@ -7,125 +8,126 @@
  * custom properties defined in the base token sheet.
  * ======================================== */
 
-.cinder-textarea-field {
-  display: flex;
-  flex-direction: column;
-  gap: var(--cinder-space-1-5);
-  inline-size: 100%;
-}
+  .cinder-textarea-field {
+    display: flex;
+    flex-direction: column;
+    gap: var(--cinder-space-1-5);
+    inline-size: 100%;
+  }
 
-/* ----------------------------------------
+  /* ----------------------------------------
  * Label
  * ---------------------------------------- */
 
-.cinder-textarea-label {
-  display: block;
-  font-size: var(--cinder-text-xs);
-  font-weight: var(--cinder-font-medium);
-  line-height: 1;
-  color: var(--cinder-text);
-}
+  .cinder-textarea-label {
+    display: block;
+    font-size: var(--cinder-text-xs);
+    font-weight: var(--cinder-font-medium);
+    line-height: 1;
+    color: var(--cinder-text);
+  }
 
-/* ----------------------------------------
+  /* ----------------------------------------
  * Textarea control
  * ---------------------------------------- */
 
-.cinder-textarea {
-  display: block;
-  width: 100%;
-  min-height: 6rem;
-  resize: vertical;
-  field-sizing: content;
+  .cinder-textarea {
+    display: block;
+    width: 100%;
+    min-height: 6rem;
+    resize: vertical;
+    field-sizing: content;
 
-  padding: var(--cinder-space-2) var(--cinder-space-3);
+    padding: var(--cinder-space-2) var(--cinder-space-3);
 
-  font-family: inherit;
-  font-size: var(--cinder-text-sm);
-  line-height: var(--cinder-leading-normal);
-  color: var(--cinder-text);
+    font-family: inherit;
+    font-size: var(--cinder-text-sm);
+    line-height: var(--cinder-leading-normal);
+    color: var(--cinder-text);
 
-  background: var(--cinder-surface-raised);
-  border: 1px solid var(--cinder-border);
-  border-radius: var(--cinder-radius-md);
+    background: var(--cinder-surface-raised);
+    border: 1px solid var(--cinder-border);
+    border-radius: var(--cinder-radius-md);
 
-  transition:
-    border-color var(--cinder-duration-fast) var(--cinder-ease-standard),
-    box-shadow var(--cinder-duration-fast) var(--cinder-ease-standard);
-}
-
-.cinder-textarea::placeholder {
-  color: var(--cinder-text-placeholder, var(--cinder-text-muted));
-}
-
-@media (hover: hover) {
-  .cinder-textarea:hover:not(:disabled) {
-    border-color: var(--cinder-border-strong);
+    transition:
+      border-color var(--cinder-duration-fast) var(--cinder-ease-standard),
+      box-shadow var(--cinder-duration-fast) var(--cinder-ease-standard);
   }
-}
 
-.cinder-textarea:focus-visible {
-  outline: var(--cinder-ring-width) solid transparent;
-  box-shadow: var(--_cinder-focus-ring-shadow);
-}
+  .cinder-textarea::placeholder {
+    color: var(--cinder-text-placeholder, var(--cinder-text-muted));
+  }
 
-/* Forced Colors Mode — box-shadow is invisible in WHCM; use a real outline instead. */
-@media (forced-colors: active) {
+  @media (hover: hover) {
+    .cinder-textarea:hover:not(:disabled) {
+      border-color: var(--cinder-border-strong);
+    }
+  }
+
   .cinder-textarea:focus-visible {
-    outline: var(--cinder-ring-width) solid ButtonText;
-    outline-offset: 2px;
-    box-shadow: none;
+    outline: var(--cinder-ring-width) solid transparent;
+    box-shadow: var(--_cinder-focus-ring-shadow);
   }
-}
 
-/* ----------------------------------------
+  /* Forced Colors Mode — box-shadow is invisible in WHCM; use a real outline instead. */
+  @media (forced-colors: active) {
+    .cinder-textarea:focus-visible {
+      outline: var(--cinder-ring-width) solid ButtonText;
+      outline-offset: 2px;
+      box-shadow: none;
+    }
+  }
+
+  /* ----------------------------------------
  * Invalid / error state
  * ---------------------------------------- */
 
-.cinder-textarea[aria-invalid='true'] {
-  border-color: var(--cinder-danger);
-}
+  .cinder-textarea[aria-invalid='true'] {
+    border-color: var(--cinder-danger);
+  }
 
-.cinder-textarea[aria-invalid='true']:focus-visible {
-  box-shadow:
-    0 0 0 var(--cinder-ring-offset) var(--cinder-ring-offset-color),
-    0 0 0 calc(var(--cinder-ring-offset) + var(--cinder-ring-width)) var(--cinder-danger);
-}
+  .cinder-textarea[aria-invalid='true']:focus-visible {
+    box-shadow:
+      0 0 0 var(--cinder-ring-offset) var(--cinder-ring-offset-color),
+      0 0 0 calc(var(--cinder-ring-offset) + var(--cinder-ring-width)) var(--cinder-danger);
+  }
 
-/* ----------------------------------------
+  /* ----------------------------------------
  * Disabled state
  * ---------------------------------------- */
 
-.cinder-textarea:disabled {
-  cursor: not-allowed;
-  resize: none;
-  background: var(--cinder-surface-inset);
-  color: var(--cinder-text-disabled);
-  border-color: var(--cinder-border-muted);
-}
+  .cinder-textarea:disabled {
+    cursor: not-allowed;
+    resize: none;
+    background: var(--cinder-surface-inset);
+    color: var(--cinder-text-disabled);
+    border-color: var(--cinder-border-muted);
+  }
 
-/* ----------------------------------------
+  /* ----------------------------------------
  * Description and error messages
  * ---------------------------------------- */
 
-.cinder-textarea-description,
-.cinder-textarea-error {
-  margin: 0;
-  font-size: var(--cinder-text-xs);
-  line-height: var(--cinder-leading-normal);
-}
+  .cinder-textarea-description,
+  .cinder-textarea-error {
+    margin: 0;
+    font-size: var(--cinder-text-xs);
+    line-height: var(--cinder-leading-normal);
+  }
 
-.cinder-textarea-description {
-  color: var(--cinder-text-muted);
-}
+  .cinder-textarea-description {
+    color: var(--cinder-text-muted);
+  }
 
-.cinder-textarea-error {
-  color: var(--cinder-danger);
-}
+  .cinder-textarea-error {
+    color: var(--cinder-danger);
+  }
 
-.cinder-textarea-count {
-  margin: 0;
-  font-size: var(--cinder-text-xs);
-  line-height: var(--cinder-leading-normal);
-  color: var(--cinder-text-muted);
-  text-align: end;
+  .cinder-textarea-count {
+    margin: 0;
+    font-size: var(--cinder-text-xs);
+    line-height: var(--cinder-leading-normal);
+    color: var(--cinder-text-muted);
+    text-align: end;
+  }
 }

--- a/packages/components/src/components/time-picker/time-picker.css
+++ b/packages/components/src/components/time-picker/time-picker.css
@@ -1,148 +1,150 @@
-.cinder-time-picker-field {
-  display: flex;
-  flex-direction: column;
-  gap: var(--cinder-space-2);
-}
-
-.cinder-time-picker-field__label {
-  color: var(--cinder-text);
-  font-size: var(--cinder-text-sm);
-  font-weight: var(--cinder-font-weight-medium);
-}
-
-.cinder-time-picker {
-  position: relative;
-  display: flex;
-  align-items: stretch;
-}
-
-.cinder-time-picker__input {
-  padding-inline-end: calc(var(--cinder-space-10) + var(--cinder-space-2));
-}
-
-.cinder-time-picker__toggle {
-  position: absolute;
-  inset-block: var(--cinder-space-1);
-  inset-inline-end: var(--cinder-space-1);
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 2rem;
-  border: none;
-  border-radius: var(--cinder-radius-sm);
-  background: transparent;
-  color: var(--cinder-text-subtle);
-  cursor: pointer;
-}
-
-@media (hover: hover) {
-  .cinder-time-picker__toggle:hover {
-    background: var(--cinder-surface-raised);
-    color: var(--cinder-text);
+@layer cinder.components {
+  .cinder-time-picker-field {
+    display: flex;
+    flex-direction: column;
+    gap: var(--cinder-space-2);
   }
-}
 
-.cinder-time-picker[data-invalid] .cinder-time-picker__input {
-  border-color: var(--cinder-color-danger-border);
-}
+  .cinder-time-picker-field__label {
+    color: var(--cinder-text);
+    font-size: var(--cinder-text-sm);
+    font-weight: var(--cinder-font-weight-medium);
+  }
 
-.cinder-time-picker__toggle:focus-visible,
-.cinder-time-picker__option:focus-visible,
-.cinder-time-picker__period:focus-visible {
-  outline: var(--cinder-ring-width) solid transparent;
-  box-shadow: var(--_cinder-focus-ring-shadow);
-}
+  .cinder-time-picker {
+    position: relative;
+    display: flex;
+    align-items: stretch;
+  }
 
-.cinder-time-picker-field__description {
-  color: var(--cinder-text-muted);
-  font-size: var(--cinder-text-sm);
-}
-
-.cinder-time-picker-field__error {
-  color: var(--cinder-color-danger-fg);
-  font-size: var(--cinder-text-sm);
-}
-
-.cinder-time-picker__popover {
-  padding: var(--cinder-space-3);
-  min-width: 18rem;
-}
-
-.cinder-time-picker__columns {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(4rem, 1fr));
-  gap: var(--cinder-space-3);
-}
-
-.cinder-time-picker__column {
-  display: flex;
-  flex-direction: column;
-  gap: var(--cinder-space-2);
-}
-
-.cinder-time-picker__heading {
-  color: var(--cinder-text-muted);
-  font-size: var(--cinder-text-xs);
-  font-weight: var(--cinder-font-weight-medium);
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
-}
-
-.cinder-time-picker__listbox {
-  display: flex;
-  flex-direction: column;
-  gap: var(--cinder-space-1);
-  max-height: 12rem;
-  margin: 0;
-  padding: 0;
-  overflow: auto;
-  list-style: none;
-}
-
-.cinder-time-picker__option,
-.cinder-time-picker__period {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  min-height: 2.25rem;
-  padding: 0 var(--cinder-space-2);
-  border: 1px solid var(--cinder-border);
-  border-radius: var(--cinder-radius-md);
-  background: var(--cinder-surface);
-  color: var(--cinder-text);
-  cursor: pointer;
-}
-
-.cinder-time-picker__option[aria-selected='true'],
-.cinder-time-picker__period[aria-checked='true'] {
-  border-color: var(--cinder-accent);
-  background: color-mix(in oklch, var(--cinder-accent), transparent 88%);
-  color: var(--cinder-accent);
-}
-
-.cinder-time-picker__periods {
-  display: flex;
-  flex-direction: column;
-  gap: var(--cinder-space-1);
-}
-
-@media (forced-colors: active) {
-  .cinder-time-picker__toggle,
-  .cinder-time-picker__option,
-  .cinder-time-picker__period {
-    forced-color-adjust: none;
-    border-color: ButtonText;
-    background: Canvas;
-    color: ButtonText;
+  .cinder-time-picker__input {
+    padding-inline-end: calc(var(--cinder-space-10) + var(--cinder-space-2));
   }
 
   .cinder-time-picker__toggle {
-    border: 1px solid ButtonText;
+    position: absolute;
+    inset-block: var(--cinder-space-1);
+    inset-inline-end: var(--cinder-space-1);
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 2rem;
+    border: none;
+    border-radius: var(--cinder-radius-sm);
+    background: transparent;
+    color: var(--cinder-text-subtle);
+    cursor: pointer;
+  }
+
+  @media (hover: hover) {
+    .cinder-time-picker__toggle:hover {
+      background: var(--cinder-surface-raised);
+      color: var(--cinder-text);
+    }
+  }
+
+  .cinder-time-picker[data-invalid] .cinder-time-picker__input {
+    border-color: var(--cinder-color-danger-border);
+  }
+
+  .cinder-time-picker__toggle:focus-visible,
+  .cinder-time-picker__option:focus-visible,
+  .cinder-time-picker__period:focus-visible {
+    outline: var(--cinder-ring-width) solid transparent;
+    box-shadow: var(--_cinder-focus-ring-shadow);
+  }
+
+  .cinder-time-picker-field__description {
+    color: var(--cinder-text-muted);
+    font-size: var(--cinder-text-sm);
+  }
+
+  .cinder-time-picker-field__error {
+    color: var(--cinder-color-danger-fg);
+    font-size: var(--cinder-text-sm);
+  }
+
+  .cinder-time-picker__popover {
+    padding: var(--cinder-space-3);
+    min-width: 18rem;
+  }
+
+  .cinder-time-picker__columns {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(4rem, 1fr));
+    gap: var(--cinder-space-3);
+  }
+
+  .cinder-time-picker__column {
+    display: flex;
+    flex-direction: column;
+    gap: var(--cinder-space-2);
+  }
+
+  .cinder-time-picker__heading {
+    color: var(--cinder-text-muted);
+    font-size: var(--cinder-text-xs);
+    font-weight: var(--cinder-font-weight-medium);
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+  }
+
+  .cinder-time-picker__listbox {
+    display: flex;
+    flex-direction: column;
+    gap: var(--cinder-space-1);
+    max-height: 12rem;
+    margin: 0;
+    padding: 0;
+    overflow: auto;
+    list-style: none;
+  }
+
+  .cinder-time-picker__option,
+  .cinder-time-picker__period {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 2.25rem;
+    padding: 0 var(--cinder-space-2);
+    border: 1px solid var(--cinder-border);
+    border-radius: var(--cinder-radius-md);
+    background: var(--cinder-surface);
+    color: var(--cinder-text);
+    cursor: pointer;
   }
 
   .cinder-time-picker__option[aria-selected='true'],
   .cinder-time-picker__period[aria-checked='true'] {
-    background: Highlight;
-    color: HighlightText;
+    border-color: var(--cinder-accent);
+    background: color-mix(in oklch, var(--cinder-accent), transparent 88%);
+    color: var(--cinder-accent);
+  }
+
+  .cinder-time-picker__periods {
+    display: flex;
+    flex-direction: column;
+    gap: var(--cinder-space-1);
+  }
+
+  @media (forced-colors: active) {
+    .cinder-time-picker__toggle,
+    .cinder-time-picker__option,
+    .cinder-time-picker__period {
+      forced-color-adjust: none;
+      border-color: ButtonText;
+      background: Canvas;
+      color: ButtonText;
+    }
+
+    .cinder-time-picker__toggle {
+      border: 1px solid ButtonText;
+    }
+
+    .cinder-time-picker__option[aria-selected='true'],
+    .cinder-time-picker__period[aria-checked='true'] {
+      background: Highlight;
+      color: HighlightText;
+    }
   }
 }

--- a/packages/components/src/components/toast-region/toast-region.css
+++ b/packages/components/src/components/toast-region/toast-region.css
@@ -1,260 +1,262 @@
-/* ========================================
+@layer cinder.components {
+  /* ========================================
  * TOAST REGION
  * Two stacked aria-live regions (polite + assertive) anchored to the
  * bottom-right of the viewport. Toast.svelte owns the visual treatment of
  * individual toasts via the .cinder-toast class.
  * ======================================== */
 
-.cinder-toast-region {
-  position: fixed;
-  display: flex;
-  flex-direction: column;
-  gap: var(--cinder-space-2);
-  z-index: var(--cinder-z-toast);
-  pointer-events: none;
-  /* Stack the two aria-live channels in the same visual column. Each channel
+  .cinder-toast-region {
+    position: fixed;
+    display: flex;
+    flex-direction: column;
+    gap: var(--cinder-space-2);
+    z-index: var(--cinder-z-toast);
+    pointer-events: none;
+    /* Stack the two aria-live channels in the same visual column. Each channel
    * is independent — a polite info and an assertive warning may sit
    * side-by-side visually but route to different SR-announcement queues. */
-}
+  }
 
-.cinder-toast-region[data-cinder-position^='top'] {
-  top: var(--cinder-space-4);
-}
+  .cinder-toast-region[data-cinder-position^='top'] {
+    top: var(--cinder-space-4);
+  }
 
-.cinder-toast-region[data-cinder-position^='bottom'] {
-  bottom: var(--cinder-space-4);
-}
+  .cinder-toast-region[data-cinder-position^='bottom'] {
+    bottom: var(--cinder-space-4);
+  }
 
-.cinder-toast-region[data-cinder-position$='left'] {
-  left: var(--cinder-space-4);
-  align-items: flex-start;
-}
+  .cinder-toast-region[data-cinder-position$='left'] {
+    left: var(--cinder-space-4);
+    align-items: flex-start;
+  }
 
-.cinder-toast-region[data-cinder-position$='center'] {
-  left: 50%;
-  align-items: center;
-  transform: translateX(-50%);
-}
+  .cinder-toast-region[data-cinder-position$='center'] {
+    left: 50%;
+    align-items: center;
+    transform: translateX(-50%);
+  }
 
-.cinder-toast-region[data-cinder-position$='right'] {
-  right: var(--cinder-space-4);
-  align-items: flex-end;
-}
+  .cinder-toast-region[data-cinder-position$='right'] {
+    right: var(--cinder-space-4);
+    align-items: flex-end;
+  }
 
-.cinder-toast-region__channel {
-  display: flex;
-  flex-direction: column;
-  gap: var(--cinder-space-2);
-}
+  .cinder-toast-region__channel {
+    display: flex;
+    flex-direction: column;
+    gap: var(--cinder-space-2);
+  }
 
-.cinder-toast-region[data-cinder-position^='top'] .cinder-toast-region__channel {
-  flex-direction: column-reverse;
-}
+  .cinder-toast-region[data-cinder-position^='top'] .cinder-toast-region__channel {
+    flex-direction: column-reverse;
+  }
 
-.cinder-toast-shell {
-  display: block;
-  max-height: var(--cinder-toast-height, none);
-  opacity: 1;
-  transition:
-    max-height var(--cinder-duration-fast) var(--cinder-ease-standard),
-    opacity var(--cinder-duration-fast) var(--cinder-ease-standard),
-    margin-block var(--cinder-duration-fast) var(--cinder-ease-standard);
-}
+  .cinder-toast-shell {
+    display: block;
+    max-height: var(--cinder-toast-height, none);
+    opacity: 1;
+    transition:
+      max-height var(--cinder-duration-fast) var(--cinder-ease-standard),
+      opacity var(--cinder-duration-fast) var(--cinder-ease-standard),
+      margin-block var(--cinder-duration-fast) var(--cinder-ease-standard);
+  }
 
-.cinder-toast-shell[data-cinder-presence='exiting'] {
-  max-height: 0;
-  opacity: 0;
-  margin-block: 0;
-  overflow: hidden;
-}
+  .cinder-toast-shell[data-cinder-presence='exiting'] {
+    max-height: 0;
+    opacity: 0;
+    margin-block: 0;
+    overflow: hidden;
+  }
 
-/* ----------------------------------------
+  /* ----------------------------------------
  * Individual toast
  * ---------------------------------------- */
 
-.cinder-toast {
-  pointer-events: auto;
-  position: relative;
-  display: flex;
-  align-items: flex-start;
-  gap: var(--cinder-space-3);
-  min-width: 18rem;
-  max-width: 28rem;
-  padding: var(--cinder-space-3) var(--cinder-space-4);
-  background: var(--cinder-surface-raised);
-  border: 1px solid var(--cinder-border);
-  border-radius: var(--cinder-radius-md);
-  box-shadow:
-    inset 0 1px 0 light-dark(transparent, oklch(100% 0 0 / 0.06)),
-    0 1px 2px oklch(0% 0 0 / 0.04),
-    0 4px 12px oklch(0% 0 0 / 0.08);
-  font-size: var(--cinder-text-sm);
-  color: var(--cinder-text);
-  touch-action: pan-y;
-  transform: translateX(var(--cinder-toast-swipe-x, 0))
-    translateY(calc(var(--cinder-toast-stack-index, 0) * -2px));
-  transition:
-    transform var(--cinder-duration-fast) var(--cinder-ease-standard),
-    opacity var(--cinder-duration-fast) var(--cinder-ease-standard);
-  /* Smooth in/out at default speed; reduced-motion zeroes the duration via
+  .cinder-toast {
+    pointer-events: auto;
+    position: relative;
+    display: flex;
+    align-items: flex-start;
+    gap: var(--cinder-space-3);
+    min-width: 18rem;
+    max-width: 28rem;
+    padding: var(--cinder-space-3) var(--cinder-space-4);
+    background: var(--cinder-surface-raised);
+    border: 1px solid var(--cinder-border);
+    border-radius: var(--cinder-radius-md);
+    box-shadow:
+      inset 0 1px 0 light-dark(transparent, oklch(100% 0 0 / 0.06)),
+      0 1px 2px oklch(0% 0 0 / 0.04),
+      0 4px 12px oklch(0% 0 0 / 0.08);
+    font-size: var(--cinder-text-sm);
+    color: var(--cinder-text);
+    touch-action: pan-y;
+    transform: translateX(var(--cinder-toast-swipe-x, 0))
+      translateY(calc(var(--cinder-toast-stack-index, 0) * -2px));
+    transition:
+      transform var(--cinder-duration-fast) var(--cinder-ease-standard),
+      opacity var(--cinder-duration-fast) var(--cinder-ease-standard);
+    /* Smooth in/out at default speed; reduced-motion zeroes the duration via
    * the global motion tokens. */
-  animation: cinder-toast-in var(--cinder-duration-fast) var(--cinder-ease-decelerate);
-}
-
-.cinder-toast[data-cinder-swiping='true'] {
-  user-select: none;
-}
-
-@keyframes cinder-toast-in {
-  from {
-    opacity: 0;
+    animation: cinder-toast-in var(--cinder-duration-fast) var(--cinder-ease-decelerate);
   }
-  to {
-    opacity: 1;
-  }
-}
 
-@keyframes cinder-toast-spinner-spin {
-  to {
-    transform: rotate(360deg);
+  .cinder-toast[data-cinder-swiping='true'] {
+    user-select: none;
   }
-}
 
-@media (prefers-reduced-motion: reduce) {
-  .cinder-toast-shell,
-  .cinder-toast,
-  .cinder-toast__spinner {
-    animation: none;
-    transition-duration: 0ms;
+  @keyframes cinder-toast-in {
+    from {
+      opacity: 0;
+    }
+    to {
+      opacity: 1;
+    }
   }
-}
 
-/* Variant accent stripe — drawn as a ::before pseudo so it sits inside the
+  @keyframes cinder-toast-spinner-spin {
+    to {
+      transform: rotate(360deg);
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .cinder-toast-shell,
+    .cinder-toast,
+    .cinder-toast__spinner {
+      animation: none;
+      transition-duration: 0ms;
+    }
+  }
+
+  /* Variant accent stripe — drawn as a ::before pseudo so it sits inside the
  * toast's border-radius without fighting border-left's miter corners. The
  * stripe rounds its own start-side corners (matching the toast's outer
  * radius minus the 1px border) so the parent toast does not need
  * `overflow: hidden`, which would clip the dismiss button's 44×44 ::after
  * hit-area pseudo-element. */
-.cinder-toast[data-cinder-variant]::before {
-  content: '';
-  position: absolute;
-  /* Sit just inside the toast's 1px border so the stripe doesn't cover it. */
-  inset-block: 0;
-  inset-inline-start: 0;
-  width: 3px;
-  background: var(--_cinder-toast-accent, transparent);
-  border-start-start-radius: calc(var(--cinder-radius-md) - 1px);
-  border-end-start-radius: calc(var(--cinder-radius-md) - 1px);
-}
+  .cinder-toast[data-cinder-variant]::before {
+    content: '';
+    position: absolute;
+    /* Sit just inside the toast's 1px border so the stripe doesn't cover it. */
+    inset-block: 0;
+    inset-inline-start: 0;
+    width: 3px;
+    background: var(--_cinder-toast-accent, transparent);
+    border-start-start-radius: calc(var(--cinder-radius-md) - 1px);
+    border-end-start-radius: calc(var(--cinder-radius-md) - 1px);
+  }
 
-.cinder-toast[data-cinder-variant='info'] {
-  --_cinder-toast-accent: var(--cinder-info);
-}
+  .cinder-toast[data-cinder-variant='info'] {
+    --_cinder-toast-accent: var(--cinder-info);
+  }
 
-.cinder-toast[data-cinder-variant='success'] {
-  --_cinder-toast-accent: var(--cinder-success);
-}
+  .cinder-toast[data-cinder-variant='success'] {
+    --_cinder-toast-accent: var(--cinder-success);
+  }
 
-.cinder-toast[data-cinder-variant='warning'] {
-  --_cinder-toast-accent: var(--cinder-warning);
-}
+  .cinder-toast[data-cinder-variant='warning'] {
+    --_cinder-toast-accent: var(--cinder-warning);
+  }
 
-.cinder-toast[data-cinder-variant='danger'] {
-  --_cinder-toast-accent: var(--cinder-danger);
-}
+  .cinder-toast[data-cinder-variant='danger'] {
+    --_cinder-toast-accent: var(--cinder-danger);
+  }
 
-.cinder-toast__icon {
-  display: inline-flex;
-  align-items: center;
-  flex-shrink: 0;
-  line-height: 0;
-  color: var(--_cinder-toast-accent, var(--cinder-text-muted));
-}
+  .cinder-toast__icon {
+    display: inline-flex;
+    align-items: center;
+    flex-shrink: 0;
+    line-height: 0;
+    color: var(--_cinder-toast-accent, var(--cinder-text-muted));
+  }
 
-.cinder-toast__spinner {
-  display: inline-block;
-  flex-shrink: 0;
-  width: var(--cinder-spinner-size-sm, 1rem);
-  height: var(--cinder-spinner-size-sm, 1rem);
-  border: 1.5px solid color-mix(in srgb, currentColor 25%, transparent);
-  border-top-color: currentColor;
-  border-radius: 50%;
-  color: var(--_cinder-toast-accent, var(--cinder-text-muted));
-  animation: cinder-toast-spinner-spin var(--cinder-duration-spin) linear infinite;
-}
+  .cinder-toast__spinner {
+    display: inline-block;
+    flex-shrink: 0;
+    width: var(--cinder-spinner-size-sm, 1rem);
+    height: var(--cinder-spinner-size-sm, 1rem);
+    border: 1.5px solid color-mix(in srgb, currentColor 25%, transparent);
+    border-top-color: currentColor;
+    border-radius: 50%;
+    color: var(--_cinder-toast-accent, var(--cinder-text-muted));
+    animation: cinder-toast-spinner-spin var(--cinder-duration-spin) linear infinite;
+  }
 
-.cinder-toast__message {
-  flex: 1 1 auto;
-  line-height: var(--cinder-leading-normal);
-}
+  .cinder-toast__message {
+    flex: 1 1 auto;
+    line-height: var(--cinder-leading-normal);
+  }
 
-.cinder-toast__action {
-  appearance: none;
-  background: none;
-  border: none;
-  padding: 0;
-  font: inherit;
-  font-weight: var(--cinder-font-medium);
-  color: var(--cinder-accent);
-  cursor: pointer;
-  border-radius: var(--cinder-radius-sm);
-}
+  .cinder-toast__action {
+    appearance: none;
+    background: none;
+    border: none;
+    padding: 0;
+    font: inherit;
+    font-weight: var(--cinder-font-medium);
+    color: var(--cinder-accent);
+    cursor: pointer;
+    border-radius: var(--cinder-radius-sm);
+  }
 
-.cinder-toast__action:focus-visible {
-  outline: var(--cinder-ring-width) solid var(--cinder-ring-color);
-  outline-offset: 2px;
-}
+  .cinder-toast__action:focus-visible {
+    outline: var(--cinder-ring-width) solid var(--cinder-ring-color);
+    outline-offset: 2px;
+  }
 
-.cinder-toast__dismiss {
-  appearance: none;
-  background: none;
-  border: none;
-  padding: var(--cinder-space-0-5);
-  margin: 0;
-  color: var(--cinder-text-muted);
-  cursor: pointer;
-  border-radius: var(--cinder-radius-sm);
-  flex-shrink: 0;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  /* Anchor the WCAG 2.5.5 hit-area pseudo-element below. */
-  position: relative;
-}
+  .cinder-toast__dismiss {
+    appearance: none;
+    background: none;
+    border: none;
+    padding: var(--cinder-space-0-5);
+    margin: 0;
+    color: var(--cinder-text-muted);
+    cursor: pointer;
+    border-radius: var(--cinder-radius-sm);
+    flex-shrink: 0;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    /* Anchor the WCAG 2.5.5 hit-area pseudo-element below. */
+    position: relative;
+  }
 
-.cinder-toast__dismiss svg {
-  width: 1rem;
-  height: 1rem;
-}
+  .cinder-toast__dismiss svg {
+    width: 1rem;
+    height: 1rem;
+  }
 
-/*
+  /*
  * Expand the interactive hit area to 44×44 px (WCAG 2.5.5) without affecting
  * layout. Mirrors the alert dismiss treatment.
  */
-.cinder-toast__dismiss::after {
-  content: '';
-  position: absolute;
-  inset: 50% auto auto 50%;
-  width: 44px;
-  height: 44px;
-  transform: translate(-50%, -50%);
-}
-
-@media (hover: hover) {
-  .cinder-toast__dismiss:hover {
-    color: var(--cinder-text);
-    background: var(--cinder-surface-hover);
+  .cinder-toast__dismiss::after {
+    content: '';
+    position: absolute;
+    inset: 50% auto auto 50%;
+    width: 44px;
+    height: 44px;
+    transform: translate(-50%, -50%);
   }
-}
 
-.cinder-toast__dismiss:focus-visible {
-  outline: var(--cinder-ring-width) solid var(--cinder-ring-color);
-  outline-offset: 2px;
-}
+  @media (hover: hover) {
+    .cinder-toast__dismiss:hover {
+      color: var(--cinder-text);
+      background: var(--cinder-surface-hover);
+    }
+  }
 
-@media (forced-colors: active) {
-  .cinder-toast__action:focus-visible,
   .cinder-toast__dismiss:focus-visible {
-    outline-color: ButtonText;
+    outline: var(--cinder-ring-width) solid var(--cinder-ring-color);
+    outline-offset: 2px;
+  }
+
+  @media (forced-colors: active) {
+    .cinder-toast__action:focus-visible,
+    .cinder-toast__dismiss:focus-visible {
+      outline-color: ButtonText;
+    }
   }
 }

--- a/packages/components/src/components/toggle/toggle.css
+++ b/packages/components/src/components/toggle/toggle.css
@@ -1,177 +1,179 @@
-/* ========================================
+@layer cinder.components {
+  /* ========================================
  * TOGGLE (toggle-button pattern)
  * ======================================== */
 
-/* ----------------------------------------
+  /* ----------------------------------------
  * Field wrapper + label
  * ---------------------------------------- */
 
-.cinder-toggle-field {
-  position: relative; /* scope the position:absolute hidden label to the wrapper */
-  display: inline-flex;
-  align-items: center;
-  gap: var(--cinder-space-2);
-}
+  .cinder-toggle-field {
+    position: relative; /* scope the position:absolute hidden label to the wrapper */
+    display: inline-flex;
+    align-items: center;
+    gap: var(--cinder-space-2);
+  }
 
-.cinder-toggle-field__label {
-  font-size: var(--cinder-text-xs);
-  font-weight: var(--cinder-font-medium);
-  line-height: 1;
-  color: var(--cinder-text);
-  cursor: pointer;
-}
+  .cinder-toggle-field__label {
+    font-size: var(--cinder-text-xs);
+    font-weight: var(--cinder-font-medium);
+    line-height: 1;
+    color: var(--cinder-text);
+    cursor: pointer;
+  }
 
-.cinder-toggle-field__label[data-disabled] {
-  color: var(--cinder-text-disabled);
-  cursor: not-allowed;
-}
+  .cinder-toggle-field__label[data-disabled] {
+    color: var(--cinder-text-disabled);
+    cursor: not-allowed;
+  }
 
-/* hideLabel: keep the label as the accessible name, remove it from layout.
+  /* hideLabel: keep the label as the accessible name, remove it from layout.
  * Same recipe as the global .cinder-sr-only utility, inlined here so the
  * per-component sidecar (dist/components/toggle/toggle.css) is self-sufficient. */
-.cinder-toggle-field__label[data-hidden] {
-  position: absolute;
-  width: 1px;
-  height: 1px;
-  padding: 0;
-  margin: -1px;
-  overflow: hidden;
-  clip: rect(0, 0, 0, 0);
-  white-space: nowrap;
-  border: 0;
-}
+  .cinder-toggle-field__label[data-hidden] {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+  }
 
-.cinder-toggle {
-  /* Layout: pill track containing the sliding thumb. */
-  position: relative;
-  display: inline-flex;
-  flex-shrink: 0;
-  align-items: center;
-  box-sizing: border-box;
+  .cinder-toggle {
+    /* Layout: pill track containing the sliding thumb. */
+    position: relative;
+    display: inline-flex;
+    flex-shrink: 0;
+    align-items: center;
+    box-sizing: border-box;
 
-  /* Dimensions — 44 × 24 px satisfies WCAG 2.5.5 minimum touch target at 44 px height
+    /* Dimensions — 44 × 24 px satisfies WCAG 2.5.5 minimum touch target at 44 px height
    * when the surrounding interactive area is considered. Adjust via tokens if needed.
    */
-  width: var(--cinder-toggle-width, 2.75rem); /* 44px */
-  height: var(--cinder-toggle-height, 1.5rem); /* 24px */
+    width: var(--cinder-toggle-width, 2.75rem); /* 44px */
+    height: var(--cinder-toggle-height, 1.5rem); /* 24px */
 
-  padding: 0;
-  border: none;
-  border-radius: var(--cinder-radius-full);
-  cursor: pointer;
-  vertical-align: middle;
+    padding: 0;
+    border: none;
+    border-radius: var(--cinder-radius-full);
+    cursor: pointer;
+    vertical-align: middle;
 
-  /* Track background — unset (off) state. */
-  background: var(--cinder-toggle-track-off, var(--cinder-border-muted, #d1d5db));
+    /* Track background — unset (off) state. */
+    background: var(--cinder-toggle-track-off, var(--cinder-border-muted, #d1d5db));
 
-  transition:
-    background-color var(--cinder-duration-fast, 150ms) var(--cinder-ease-standard, ease),
-    box-shadow var(--cinder-duration-fast, 150ms) var(--cinder-ease-standard, ease);
-}
+    transition:
+      background-color var(--cinder-duration-fast, 150ms) var(--cinder-ease-standard, ease),
+      box-shadow var(--cinder-duration-fast, 150ms) var(--cinder-ease-standard, ease);
+  }
 
-/* ----------------------------------------
+  /* ----------------------------------------
  * Pressed (on) state
  * ---------------------------------------- */
 
-.cinder-toggle[data-cinder-checked] {
-  background: var(--cinder-toggle-track-on, var(--cinder-accent, #6366f1));
-}
+  .cinder-toggle[data-cinder-checked] {
+    background: var(--cinder-toggle-track-on, var(--cinder-accent, #6366f1));
+  }
 
-/* ----------------------------------------
+  /* ----------------------------------------
  * Focus
  * ---------------------------------------- */
 
-.cinder-toggle:focus-visible {
-  outline: var(--cinder-ring-width, 2px) solid transparent;
-  box-shadow:
-    0 0 0 var(--cinder-ring-offset, 2px)
-      var(--cinder-ring-offset-color, var(--cinder-surface, #fff)),
-    0 0 0 calc(var(--cinder-ring-offset, 2px) + var(--cinder-ring-width, 2px))
-      var(--cinder-toggle-ring, var(--cinder-ring-color, #6366f1));
-}
+  .cinder-toggle:focus-visible {
+    outline: var(--cinder-ring-width, 2px) solid transparent;
+    box-shadow:
+      0 0 0 var(--cinder-ring-offset, 2px)
+        var(--cinder-ring-offset-color, var(--cinder-surface, #fff)),
+      0 0 0 calc(var(--cinder-ring-offset, 2px) + var(--cinder-ring-width, 2px))
+        var(--cinder-toggle-ring, var(--cinder-ring-color, #6366f1));
+  }
 
-/* Forced Colors Mode: box-shadow is suppressed by Windows High Contrast Mode, so
+  /* Forced Colors Mode: box-shadow is suppressed by Windows High Contrast Mode, so
  * we switch to a solid outline. ButtonText is guaranteed to contrast the button surface.
  */
-@media (forced-colors: active) {
-  .cinder-toggle:focus-visible {
-    outline: var(--cinder-ring-width, 2px) solid ButtonText;
-    outline-offset: 3px;
+  @media (forced-colors: active) {
+    .cinder-toggle:focus-visible {
+      outline: var(--cinder-ring-width, 2px) solid ButtonText;
+      outline-offset: 3px;
+    }
   }
-}
 
-/* ----------------------------------------
+  /* ----------------------------------------
  * Hover
  * ---------------------------------------- */
 
-@media (hover: hover) {
-  .cinder-toggle:hover:not(:disabled) {
-    background: var(--cinder-toggle-track-off-hover, var(--cinder-border, #9ca3af));
+  @media (hover: hover) {
+    .cinder-toggle:hover:not(:disabled) {
+      background: var(--cinder-toggle-track-off-hover, var(--cinder-border, #9ca3af));
+    }
+
+    .cinder-toggle[data-cinder-checked]:hover:not(:disabled) {
+      background: var(--cinder-toggle-track-on-hover, var(--cinder-accent-hover, #4f46e5));
+    }
   }
 
-  .cinder-toggle[data-cinder-checked]:hover:not(:disabled) {
-    background: var(--cinder-toggle-track-on-hover, var(--cinder-accent-hover, #4f46e5));
-  }
-}
-
-/* ----------------------------------------
+  /* ----------------------------------------
  * Disabled
  * ---------------------------------------- */
 
-.cinder-toggle:disabled {
-  cursor: not-allowed;
-  /* opacity centralized in foundation.css disabled-visual rule (0.6) */
-  /* Preserve the current track color via grayscale so on/off is still readable. */
-  filter: grayscale(0.4);
-}
+  .cinder-toggle:disabled {
+    cursor: not-allowed;
+    /* opacity centralized in foundation.css disabled-visual rule (0.6) */
+    /* Preserve the current track color via grayscale so on/off is still readable. */
+    filter: grayscale(0.4);
+  }
 
-/* ----------------------------------------
+  /* ----------------------------------------
  * Thumb
  * ---------------------------------------- */
 
-.cinder-toggle__thumb {
-  /* Remove from pointer events — the button handles all interaction. */
-  pointer-events: none;
+  .cinder-toggle__thumb {
+    /* Remove from pointer events — the button handles all interaction. */
+    pointer-events: none;
 
-  /* Circle sitting inside the track, vertically centered with a gap on every side. */
-  position: absolute;
-  inset-block-start: 50%;
-  inset-inline-start: 0.125rem; /* 2px gap from track edge */
-  display: block;
-  width: var(
-    --cinder-toggle-thumb-size,
-    1.125rem
-  ); /* 18px — leaves 3px vertical gap in 24px track */
-  height: var(--cinder-toggle-thumb-size, 1.125rem);
-  border-radius: 50%;
-  background: var(--cinder-toggle-thumb-color, #ffffff);
-  box-shadow: var(
-    --cinder-shadow-sm,
-    0 1px 3px 0 rgb(0 0 0 / 0.1),
-    0 1px 2px -1px rgb(0 0 0 / 0.1)
-  );
+    /* Circle sitting inside the track, vertically centered with a gap on every side. */
+    position: absolute;
+    inset-block-start: 50%;
+    inset-inline-start: 0.125rem; /* 2px gap from track edge */
+    display: block;
+    width: var(
+      --cinder-toggle-thumb-size,
+      1.125rem
+    ); /* 18px — leaves 3px vertical gap in 24px track */
+    height: var(--cinder-toggle-thumb-size, 1.125rem);
+    border-radius: 50%;
+    background: var(--cinder-toggle-thumb-color, #ffffff);
+    box-shadow: var(
+      --cinder-shadow-sm,
+      0 1px 3px 0 rgb(0 0 0 / 0.1),
+      0 1px 2px -1px rgb(0 0 0 / 0.1)
+    );
 
-  /* Slide transition — mirrors the track transition duration. */
-  transition: transform var(--cinder-duration-fast, 150ms) var(--cinder-ease-standard, ease);
+    /* Slide transition — mirrors the track transition duration. */
+    transition: transform var(--cinder-duration-fast, 150ms) var(--cinder-ease-standard, ease);
 
-  /* Unpressed: thumb sits at the start of the track, vertically centered.
+    /* Unpressed: thumb sits at the start of the track, vertically centered.
    * translateY(-50%) compensates for inset-block-start: 50%. */
-  transform: translate(0, -50%);
-}
+    transform: translate(0, -50%);
+  }
 
-/* Pressed: slide thumb to the end. Travel distance is track-width minus thumb-size minus
+  /* Pressed: slide thumb to the end. Travel distance is track-width minus thumb-size minus
  * the 2px gap on each side: 44 - 18 - 4 = 22px = 1.375rem. */
-.cinder-toggle[data-cinder-checked] .cinder-toggle__thumb {
-  transform: translate(var(--cinder-toggle-thumb-travel, 1.375rem), -50%);
-}
+  .cinder-toggle[data-cinder-checked] .cinder-toggle__thumb {
+    transform: translate(var(--cinder-toggle-thumb-travel, 1.375rem), -50%);
+  }
 
-/* ----------------------------------------
+  /* ----------------------------------------
  * Reduced motion
  * ---------------------------------------- */
 
-@media (prefers-reduced-motion: reduce) {
-  .cinder-toggle,
-  .cinder-toggle__thumb {
-    transition: none;
+  @media (prefers-reduced-motion: reduce) {
+    .cinder-toggle,
+    .cinder-toggle__thumb {
+      transition: none;
+    }
   }
 }

--- a/packages/components/src/components/toolbar/toolbar.css
+++ b/packages/components/src/components/toolbar/toolbar.css
@@ -1,49 +1,51 @@
-.cinder-toolbar {
-  display: flex;
-  align-items: center;
-  gap: var(--cinder-space-2);
-  min-inline-size: 0;
-}
+@layer cinder.components {
+  .cinder-toolbar {
+    display: flex;
+    align-items: center;
+    gap: var(--cinder-space-2);
+    min-inline-size: 0;
+  }
 
-.cinder-toolbar[data-cinder-orientation='vertical'] {
-  flex-direction: column;
-  align-items: stretch;
-}
+  .cinder-toolbar[data-cinder-orientation='vertical'] {
+    flex-direction: column;
+    align-items: stretch;
+  }
 
-.cinder-toolbar__group {
-  display: flex;
-  align-items: center;
-  gap: var(--cinder-space-2);
-  min-inline-size: 0;
-  flex-wrap: nowrap;
-}
+  .cinder-toolbar__group {
+    display: flex;
+    align-items: center;
+    gap: var(--cinder-space-2);
+    min-inline-size: 0;
+    flex-wrap: nowrap;
+  }
 
-.cinder-toolbar[data-cinder-orientation='vertical'] .cinder-toolbar__group,
-.cinder-toolbar__group[data-cinder-orientation='vertical'] {
-  flex-direction: column;
-  align-items: stretch;
-}
+  .cinder-toolbar[data-cinder-orientation='vertical'] .cinder-toolbar__group,
+  .cinder-toolbar__group[data-cinder-orientation='vertical'] {
+    flex-direction: column;
+    align-items: stretch;
+  }
 
-.cinder-toolbar[data-cinder-orientation='horizontal']
-  > .cinder-toolbar__group
-  + .cinder-toolbar__group::before {
-  content: '';
-  inline-size: 1px;
-  block-size: 1.5rem;
-  background: var(--cinder-border);
-  flex-shrink: 0;
-}
+  .cinder-toolbar[data-cinder-orientation='horizontal']
+    > .cinder-toolbar__group
+    + .cinder-toolbar__group::before {
+    content: '';
+    inline-size: 1px;
+    block-size: 1.5rem;
+    background: var(--cinder-border);
+    flex-shrink: 0;
+  }
 
-.cinder-toolbar[data-cinder-orientation='vertical']
-  > .cinder-toolbar__group
-  + .cinder-toolbar__group::before {
-  content: '';
-  inline-size: 100%;
-  block-size: 1px;
-  background: var(--cinder-border);
-}
+  .cinder-toolbar[data-cinder-orientation='vertical']
+    > .cinder-toolbar__group
+    + .cinder-toolbar__group::before {
+    content: '';
+    inline-size: 100%;
+    block-size: 1px;
+    background: var(--cinder-border);
+  }
 
-.cinder-toolbar__spacer {
-  flex: 1 1 auto;
-  min-inline-size: var(--cinder-space-2);
+  .cinder-toolbar__spacer {
+    flex: 1 1 auto;
+    min-inline-size: var(--cinder-space-2);
+  }
 }

--- a/packages/components/src/components/tooltip/tooltip.css
+++ b/packages/components/src/components/tooltip/tooltip.css
@@ -1,62 +1,64 @@
-/* ========================================
+@layer cinder.components {
+  /* ========================================
  * TOOLTIP
  * ======================================== */
 
-.cinder-tooltip-wrapper {
-  display: inline-flex;
-  align-items: center;
-}
+  .cinder-tooltip-wrapper {
+    display: inline-flex;
+    align-items: center;
+  }
 
-/* ----------------------------------------
+  /* ----------------------------------------
  * Tooltip element
  * ---------------------------------------- */
 
-.cinder-tooltip {
-  position: fixed;
-  left: 0;
-  top: 0;
-  z-index: var(--cinder-z-tooltip, 50);
+  .cinder-tooltip {
+    position: fixed;
+    left: 0;
+    top: 0;
+    z-index: var(--cinder-z-tooltip, 50);
 
-  max-width: 16rem;
-  padding: var(--cinder-space-1-5) var(--cinder-space-2-5);
+    max-width: 16rem;
+    padding: var(--cinder-space-1-5) var(--cinder-space-2-5);
 
-  border-radius: var(--cinder-radius-md);
-  background: var(--cinder-text);
-  color: var(--cinder-surface);
-  font-size: var(--cinder-text-xs);
-  line-height: var(--cinder-leading-snug);
-  white-space: nowrap;
+    border-radius: var(--cinder-radius-md);
+    background: var(--cinder-text);
+    color: var(--cinder-surface);
+    font-size: var(--cinder-text-xs);
+    line-height: var(--cinder-leading-snug);
+    white-space: nowrap;
 
-  pointer-events: none;
-  user-select: none;
+    pointer-events: none;
+    user-select: none;
 
-  transition: opacity var(--cinder-duration-fast) var(--cinder-ease-standard);
-}
+    transition: opacity var(--cinder-duration-fast) var(--cinder-ease-standard);
+  }
 
-.cinder-tooltip[data-cinder-position-ready='false'] {
-  visibility: hidden;
-  opacity: 0;
-}
+  .cinder-tooltip[data-cinder-position-ready='false'] {
+    visibility: hidden;
+    opacity: 0;
+  }
 
-/* Visible state */
-.cinder-tooltip[aria-hidden='false'] {
-  visibility: visible;
-  opacity: 1;
-}
+  /* Visible state */
+  .cinder-tooltip[aria-hidden='false'] {
+    visibility: visible;
+    opacity: 1;
+  }
 
-/* Hidden state */
-.cinder-tooltip[aria-hidden='true'] {
-  visibility: hidden;
-  opacity: 0;
-  pointer-events: none;
-}
+  /* Hidden state */
+  .cinder-tooltip[aria-hidden='true'] {
+    visibility: hidden;
+    opacity: 0;
+    pointer-events: none;
+  }
 
-/* ----------------------------------------
+  /* ----------------------------------------
  * Reduced motion
  * ---------------------------------------- */
 
-@media (prefers-reduced-motion: reduce) {
-  .cinder-tooltip {
-    transition: none;
+  @media (prefers-reduced-motion: reduce) {
+    .cinder-tooltip {
+      transition: none;
+    }
   }
 }

--- a/packages/components/src/components/tree-select-all/tree-select-all.css
+++ b/packages/components/src/components/tree-select-all/tree-select-all.css
@@ -1,36 +1,38 @@
-.cinder-tree-select-all {
-  display: inline-flex;
-  align-items: center;
-  gap: var(--cinder-space-2, 0.5rem);
-}
+@layer cinder.components {
+  .cinder-tree-select-all {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--cinder-space-2, 0.5rem);
+  }
 
-.cinder-tree-select-all__label {
-  color: var(--cinder-text-muted, inherit);
-  font-size: var(--cinder-text-sm, 0.875rem);
-}
+  .cinder-tree-select-all__label {
+    color: var(--cinder-text-muted, inherit);
+    font-size: var(--cinder-text-sm, 0.875rem);
+  }
 
-.cinder-tree-select-all__button {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  min-block-size: 2rem;
-  padding-block: var(--cinder-space-1, 0.25rem);
-  padding-inline: var(--cinder-space-2, 0.5rem);
-  border: 1px solid var(--cinder-border, currentColor);
-  border-radius: var(--cinder-radius-sm);
-  background: var(--cinder-surface, transparent);
-  color: var(--cinder-text, currentColor);
-  font: inherit;
-  cursor: pointer;
-}
+  .cinder-tree-select-all__button {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-block-size: 2rem;
+    padding-block: var(--cinder-space-1, 0.25rem);
+    padding-inline: var(--cinder-space-2, 0.5rem);
+    border: 1px solid var(--cinder-border, currentColor);
+    border-radius: var(--cinder-radius-sm);
+    background: var(--cinder-surface, transparent);
+    color: var(--cinder-text, currentColor);
+    font: inherit;
+    cursor: pointer;
+  }
 
-.cinder-tree-select-all__button:disabled {
-  cursor: not-allowed;
-  opacity: 0.5;
-}
+  .cinder-tree-select-all__button:disabled {
+    cursor: not-allowed;
+    opacity: 0.5;
+  }
 
-@media (hover: hover) {
-  .cinder-tree-select-all__button:not(:disabled):hover {
-    background: var(--cinder-surface-raised, transparent);
+  @media (hover: hover) {
+    .cinder-tree-select-all__button:not(:disabled):hover {
+      background: var(--cinder-surface-raised, transparent);
+    }
   }
 }

--- a/packages/components/src/components/tree/tree.css
+++ b/packages/components/src/components/tree/tree.css
@@ -1,84 +1,86 @@
-/* ========================================
+@layer cinder.components {
+  /* ========================================
  * TREE
  * ======================================== */
 
-.cinder-tree-root,
-.cinder-tree {
-  display: flex;
-  flex-direction: column;
-  inline-size: 100%;
-}
+  .cinder-tree-root,
+  .cinder-tree {
+    display: flex;
+    flex-direction: column;
+    inline-size: 100%;
+  }
 
-.cinder-tree {
-  outline: none;
-}
+  .cinder-tree {
+    outline: none;
+  }
 
-.cinder-tree__selection-controls {
-  display: flex;
-  flex-wrap: wrap;
-  gap: var(--cinder-space-2, 0.5rem);
-  margin-block-end: var(--cinder-space-2, 0.5rem);
-}
+  .cinder-tree__selection-controls {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--cinder-space-2, 0.5rem);
+    margin-block-end: var(--cinder-space-2, 0.5rem);
+  }
 
-.cinder-tree-item {
-  display: flex;
-  flex-direction: column;
-  outline: none;
-  cursor: default;
-  border-radius: var(--cinder-radius-sm);
-}
+  .cinder-tree-item {
+    display: flex;
+    flex-direction: column;
+    outline: none;
+    cursor: default;
+    border-radius: var(--cinder-radius-sm);
+  }
 
-.cinder-tree-item:focus-visible {
-  outline: var(--cinder-ring-width) solid var(--cinder-ring-color);
-  outline-offset: calc(-1 * var(--cinder-ring-width));
-}
-
-@media (forced-colors: active) {
   .cinder-tree-item:focus-visible {
-    outline: var(--cinder-ring-width) solid ButtonText;
+    outline: var(--cinder-ring-width) solid var(--cinder-ring-color);
+    outline-offset: calc(-1 * var(--cinder-ring-width));
   }
-}
 
-.cinder-tree-item__row {
-  display: flex;
-  align-items: center;
-  gap: var(--cinder-space-2, 0.5rem);
-  padding-block: var(--cinder-space-1, 0.25rem);
-  padding-inline: var(--cinder-space-2, 0.5rem);
-  border-radius: var(--cinder-radius-sm);
-  user-select: none;
-}
+  @media (forced-colors: active) {
+    .cinder-tree-item:focus-visible {
+      outline: var(--cinder-ring-width) solid ButtonText;
+    }
+  }
 
-.cinder-tree-item__checkbox {
-  flex: 0 0 auto;
-  width: 1rem;
-  height: 1rem;
-  accent-color: var(--cinder-accent, currentColor);
-  pointer-events: auto;
-}
+  .cinder-tree-item__row {
+    display: flex;
+    align-items: center;
+    gap: var(--cinder-space-2, 0.5rem);
+    padding-block: var(--cinder-space-1, 0.25rem);
+    padding-inline: var(--cinder-space-2, 0.5rem);
+    border-radius: var(--cinder-radius-sm);
+    user-select: none;
+  }
 
-.cinder-tree-item[data-cinder-selected] > .cinder-tree-item__row {
-  background-color: color-mix(in srgb, var(--cinder-accent) 15%, transparent);
-  color: var(--cinder-accent);
-}
+  .cinder-tree-item__checkbox {
+    flex: 0 0 auto;
+    width: 1rem;
+    height: 1rem;
+    accent-color: var(--cinder-accent, currentColor);
+    pointer-events: auto;
+  }
 
-@media (forced-colors: active) {
   .cinder-tree-item[data-cinder-selected] > .cinder-tree-item__row {
-    background-color: Highlight;
-    color: HighlightText;
-    forced-color-adjust: none;
+    background-color: color-mix(in srgb, var(--cinder-accent) 15%, transparent);
+    color: var(--cinder-accent);
   }
-}
 
-.cinder-tree-item[data-cinder-disabled] {
-  opacity: 0.5;
-  /* Use default cursor: disabled items can still be expanded/collapsed;
+  @media (forced-colors: active) {
+    .cinder-tree-item[data-cinder-selected] > .cinder-tree-item__row {
+      background-color: Highlight;
+      color: HighlightText;
+      forced-color-adjust: none;
+    }
+  }
+
+  .cinder-tree-item[data-cinder-disabled] {
+    opacity: 0.5;
+    /* Use default cursor: disabled items can still be expanded/collapsed;
      only selection is blocked. not-allowed would mislead mouse users. */
-  cursor: default;
-}
+    cursor: default;
+  }
 
-.cinder-tree-item__children {
-  display: flex;
-  flex-direction: column;
-  padding-inline-start: var(--cinder-space-4, 1rem);
+  .cinder-tree-item__children {
+    display: flex;
+    flex-direction: column;
+    padding-inline-start: var(--cinder-space-4, 1rem);
+  }
 }

--- a/packages/components/src/styles/cascade-identity.test.ts
+++ b/packages/components/src/styles/cascade-identity.test.ts
@@ -1,0 +1,123 @@
+import { dirname, join } from 'node:path';
+
+import { describe, expect, test } from 'bun:test';
+import { parse, type ChildNode } from 'postcss';
+
+import { COMPONENT_LAYER_NAME } from '../../scripts/check-component-css.ts';
+
+/**
+ * Cascade-identity guard for the aggregated `cinder/styles` entry point.
+ *
+ * Wrapping every component CSS file in `@layer cinder.components { … }` and
+ * dropping the `layer(cinder.components)` qualifier from `index.css`'s
+ * `components.css` import is meant to be cascade-NEUTRAL for the aggregated
+ * path: the layer membership moves from the `@import` to the file itself, but
+ * each rule must still resolve into the same layer, in the same source order.
+ *
+ * "Renders unchanged" reduces to that structural contract. This test makes it
+ * reproducible and a permanent regression guard by resolving the full `@import`
+ * tree into a flat, ordered (layer, selector) stream and asserting:
+ *
+ *   1. The four cascade layers, as seen through `index.css`, resolve in the
+ *      declared order (`cinder.tokens` → `cinder.foundation` →
+ *      `cinder.components` → `cinder.utilities`).
+ *   2. EVERY rule reachable through the `components.css` aggregator resolves
+ *      into `cinder.components` — never `null` (outside any layer: the
+ *      un-overridable landmine this change removes) and never a nested or
+ *      mis-named layer.
+ *
+ * It deliberately does NOT pin exact selector text (that is the component
+ * authors' churn surface); it pins the cascade SHAPE, which is what a layering
+ * refactor must preserve. Note that `.cinder-*` selectors also legitimately
+ * appear in `cinder.foundation` and `cinder.utilities` (e.g. `.cinder-sr-only`),
+ * so the component-surface set is defined by REACHABILITY through
+ * `components.css`, not by selector prefix.
+ */
+
+const stylesRoot = import.meta.dir;
+const indexCss = join(stylesRoot, 'index.css');
+const componentsCss = join(stylesRoot, 'components.css');
+
+type FlatRule = { layer: string | null; selector: string };
+
+/** Resolve an `@import` specifier (and any `layer()` qualifier) relative to the importing file. */
+function resolveImport(
+  fromFile: string,
+  params: string,
+): { target: string; layer: string | undefined } | null {
+  const match = params.match(/['"]([^'"]+)['"]\s*(?:layer\(([^)]*)\))?/);
+  if (!match) return null;
+  return { target: join(dirname(fromFile), match[1]!), layer: match[2]?.trim() };
+}
+
+/**
+ * Recursively inline the `@import` tree rooted at `file`, tracking the active
+ * cascade-layer path, and return every style rule as `{ layer, selector }` in
+ * source order. `@keyframes` stops are skipped; `@media`/`@supports`/`@container`
+ * inherit the enclosing layer.
+ */
+async function flattenCascade(
+  file: string,
+  parentLayer: string | null = null,
+): Promise<FlatRule[]> {
+  const out: FlatRule[] = [];
+  const root = parse(await Bun.file(file).text(), { from: file });
+
+  const walk = async (nodes: ChildNode[], layer: string | null): Promise<void> => {
+    for (const node of nodes) {
+      if (node.type === 'rule') {
+        out.push({ layer, selector: node.selector.replace(/\s+/g, ' ').trim() });
+      } else if (node.type === 'atrule') {
+        const at = node;
+        if (at.name === 'import') {
+          const resolved = resolveImport(file, at.params);
+          if (!resolved) continue;
+          const nextLayer = resolved.layer
+            ? layer
+              ? `${layer}.${resolved.layer}`
+              : resolved.layer
+            : layer;
+          out.push(...(await flattenCascade(resolved.target, nextLayer)));
+        } else if (at.name === 'layer' && at.nodes) {
+          const name = at.params.trim();
+          await walk(at.nodes, layer ? `${layer}.${name}` : name);
+        } else if (/^(-\w+-)?keyframes$/i.test(at.name)) {
+          // animation stops, not document-targeting rules — skip
+        } else if (at.nodes) {
+          await walk(at.nodes, layer);
+        }
+      }
+    }
+  };
+
+  await walk(root.nodes, parentLayer);
+  return out;
+}
+
+describe('cascade identity (aggregated cinder/styles)', () => {
+  test('the four cascade layers resolve in declared order through index.css', async () => {
+    const stream = await flattenCascade(indexCss);
+    const order: string[] = [];
+    for (const { layer } of stream) {
+      if (layer && layer !== order[order.length - 1]) order.push(layer);
+    }
+    expect(order).toEqual([
+      'cinder.tokens',
+      'cinder.foundation',
+      COMPONENT_LAYER_NAME,
+      'cinder.utilities',
+    ]);
+  });
+
+  test('every rule reachable through components.css resolves into cinder.components', async () => {
+    // Flatten `components.css` on its own (no enclosing layer, exactly as
+    // `index.css` now imports it). Each rule must carry the intrinsic
+    // `@layer cinder.components` membership — none may land at `null` (outside
+    // any layer) or in a nested/mis-named layer.
+    const stream = await flattenCascade(componentsCss);
+    expect(stream.length).toBeGreaterThan(100);
+
+    const offenders = stream.filter(({ layer }) => layer !== COMPONENT_LAYER_NAME);
+    expect(offenders).toEqual([]);
+  });
+});

--- a/packages/components/src/styles/component-css-layer-invariant.test.ts
+++ b/packages/components/src/styles/component-css-layer-invariant.test.ts
@@ -1,7 +1,9 @@
 import { join } from 'node:path';
 
 import { describe, expect, test } from 'bun:test';
-import { parse } from 'postcss';
+import { parse, type ChildNode } from 'postcss';
+
+import { COMPONENT_LAYER_NAME, isSingleComponentLayer } from '../../scripts/check-component-css.ts';
 
 /**
  * Every component CSS file that reaches the cascade must carry its own
@@ -18,7 +20,8 @@ import { parse } from 'postcss';
  * This asserts the structural invariant directly against the parsed CSS AST:
  * after ignoring comments, the only top-level node in each file is a single
  * `@layer cinder.components` block. No style-producing rule or at-rule may live
- * outside it.
+ * outside it. The shape check is shared with the build gate
+ * (`isSingleComponentLayer` in `check-component-css.ts`) so both agree.
  */
 
 const repoRoot = join(import.meta.dir, '..', '..');
@@ -40,37 +43,53 @@ const UNWRAPPED_ALLOWLIST = new Set([
   'src/styles/components/experimental/_json-viewer-node.css',
 ]);
 
-async function cssFilesUnder(directory: string): Promise<string[]> {
-  const glob = new Bun.Glob(`${directory}/**/*.css`);
+async function scanGlob(pattern: string): Promise<string[]> {
+  const glob = new Bun.Glob(pattern);
   const files: string[] = [];
   for await (const file of glob.scan(repoRoot)) {
     if (file.includes('.test.')) continue;
     files.push(file);
   }
-  return files.toSorted();
+  return files;
+}
+
+/**
+ * CSS files imported DIRECTLY by component source (`import './foo.css'` in a
+ * `.svelte` or `.ts`) rather than through the `cinder/styles` aggregator. These
+ * still reach a consumer's cascade, so they are subject to the same invariant.
+ * `markdown-editor.svelte` imports `prosemirror.css` this way — it lives under
+ * `src/components/` so the glob already covers it, but enumerating the import
+ * graph keeps the guard honest if such a file ever lands outside that root.
+ */
+async function directlyImportedComponentCss(): Promise<string[]> {
+  const sources = await scanGlob('src/components/**/*.{svelte,ts}');
+  const importPattern = /import\s+['"](\.[^'"]+\.css)['"]/g;
+  const found = new Set<string>();
+  for (const source of sources) {
+    const absolute = join(repoRoot, source);
+    const text = await Bun.file(absolute).text();
+    for (const match of text.matchAll(importPattern)) {
+      // Resolve the relative specifier against the importing file's directory,
+      // then re-express it relative to the package root for comparison.
+      const resolved = join(source, '..', match[1]!);
+      found.add(resolved);
+    }
+  }
+  return [...found];
 }
 
 /**
  * The full set of component CSS files subject to the wrapper invariant:
- * per-component sidecars under `src/components/` plus the shared partials under
- * `src/styles/components/`, minus the named allowlist of files that
- * legitimately stay unwrapped.
+ * per-component sidecars under `src/components/`, the shared partials under
+ * `src/styles/components/`, and any CSS imported directly by component source —
+ * minus the named allowlist of files that legitimately stay unwrapped.
  */
 async function wrappedCssFiles(): Promise<string[]> {
-  const sidecars = await cssFilesUnder('src/components');
-  const partials = await cssFilesUnder('src/styles/components');
-  return [...sidecars, ...partials].filter((file) => !UNWRAPPED_ALLOWLIST.has(file)).toSorted();
-}
-
-function isSingleCinderComponentsLayer(source: string, file: string): boolean {
-  const root = parse(source, { from: file });
-  const topLevel = root.nodes.filter((node) => node.type !== 'comment');
-  return (
-    topLevel.length === 1 &&
-    topLevel[0]?.type === 'atrule' &&
-    topLevel[0].name === 'layer' &&
-    topLevel[0].params.trim() === 'cinder.components'
-  );
+  const sidecars = await scanGlob('src/components/**/*.css');
+  const partials = await scanGlob('src/styles/components/**/*.css');
+  const directImports = await directlyImportedComponentCss();
+  const union = new Set([...sidecars, ...partials, ...directImports]);
+  return [...union].filter((file) => !UNWRAPPED_ALLOWLIST.has(file)).toSorted();
 }
 
 function describeShape(source: string, file: string): string {
@@ -87,6 +106,11 @@ function describeShape(source: string, file: string): string {
     .join(' | ');
 }
 
+async function isWrapped(file: string): Promise<boolean> {
+  const source = await Bun.file(join(repoRoot, file)).text();
+  return isSingleComponentLayer(parse(source, { from: file }));
+}
+
 describe('component CSS @layer invariant', () => {
   test('discovers a substantial set of component CSS files', async () => {
     const files = await wrappedCssFiles();
@@ -98,13 +122,22 @@ describe('component CSS @layer invariant', () => {
     const offenders: string[] = [];
 
     for (const file of files) {
-      const source = await Bun.file(join(repoRoot, file)).text();
-      if (!isSingleCinderComponentsLayer(source, file)) {
+      if (!(await isWrapped(file))) {
+        const source = await Bun.file(join(repoRoot, file)).text();
         offenders.push(`${file} → ${describeShape(source, file)}`);
       }
     }
 
     expect(offenders).toEqual([]);
+  });
+
+  test('directly-imported component CSS (e.g. prosemirror.css) is enumerated and wrapped', async () => {
+    // Codex flagged that CSS imported by a component's source — not via the
+    // aggregator — could be a coverage hole. Assert the discovery actually finds
+    // such a file so this guard cannot silently degrade to "found nothing".
+    const directImports = await directlyImportedComponentCss();
+    expect(directImports).toContain('src/components/markdown-editor/prosemirror.css');
+    expect(await isWrapped('src/components/markdown-editor/prosemirror.css')).toBe(true);
   });
 
   test('the unwrapped allowlist stays minimal and accurate', async () => {
@@ -115,34 +148,29 @@ describe('component CSS @layer invariant', () => {
     for (const file of UNWRAPPED_ALLOWLIST) {
       const handle = Bun.file(join(repoRoot, file));
       expect(await handle.exists()).toBe(true);
-      const source = await handle.text();
-      expect(isSingleCinderComponentsLayer(source, file)).toBe(false);
+      expect(await isWrapped(file)).toBe(false);
     }
   });
 });
 
 /**
- * The named-layer override regression test — the precise reason this wrapper
- * matters for direct subpath imports.
+ * Layer-membership regression for direct subpath imports.
  *
- * A consumer that imports a component's CSS file DIRECTLY (e.g.
- * `cinder/badge/styles`, NOT `cinder/styles`) and then declares its own
- * `@layer app` override expects the documented cascade to hold:
+ * This is the structural precondition for the documented override behavior: a
+ * consumer that imports a component's CSS file DIRECTLY (e.g. `cinder/badge/styles`,
+ * NOT `cinder/styles`) and declares its own `@layer app` override after
+ * `@layer cinder.components, app;` expects `@layer app` to win. That only holds
+ * if the directly-imported file's rules are INSIDE `@layer cinder.components`.
+ * Before this fix, `badge.css` held bare rules: a direct import dropped them
+ * outside any layer, where they outrank every layered rule and the override
+ * silently loses.
  *
- *   @layer cinder.components, app;   ← app is declared AFTER cinder.components
- *   <direct import of badge.css>     ← rules join @layer cinder.components
- *   @layer app { .cinder-badge { … } } ← app wins by layer order
- *
- * This only works if the directly-imported file's rules are INSIDE
- * `@layer cinder.components`. Before this fix, `badge.css` held bare rules: a
- * direct import dropped them outside any layer, where they outrank every
- * layered rule and the `@layer app` override silently loses. We assert the
- * structural precondition for the override — every cascade-relevant component
- * rule lives in `cinder.components` — directly against the parsed AST, since a
- * real cascade resolution needs a browser and the layer membership is the only
- * thing this change controls.
+ * This asserts MEMBERSHIP (every cascade-relevant rule lives in
+ * `cinder.components`) against the parsed AST — NOT real cascade resolution,
+ * which needs a browser. Layer membership is the only thing this change
+ * controls; the named-layer ordering remains the consumer's responsibility.
  */
-describe('direct-subpath layer override regression', () => {
+describe('direct-subpath layer membership regression', () => {
   /**
    * Walk a parsed file and collect every style rule's enclosing top-level
    * layer name (or `null` when a rule sits outside any layer). `@keyframes`
@@ -152,19 +180,18 @@ describe('direct-subpath layer override regression', () => {
     const root = parse(source, { from: file });
     const layers: (string | null)[] = [];
 
-    const visit = (nodes: ReturnType<typeof parse>['nodes'], layer: string | null): void => {
+    const visit = (nodes: ChildNode[], layer: string | null): void => {
       for (const node of nodes) {
         if (node.type === 'rule') {
           layers.push(layer);
         } else if (node.type === 'atrule') {
-          const at = node;
-          if (at.name === 'layer' && at.nodes) {
-            visit(at.nodes, at.params.trim());
-          } else if (/^(-\w+-)?keyframes$/i.test(at.name)) {
+          if (node.name === 'layer' && node.nodes) {
+            visit(node.nodes, node.params.trim());
+          } else if (/^(-\w+-)?keyframes$/i.test(node.name)) {
             // animation stops, not document-targeting rules
-          } else if (at.nodes) {
+          } else if (node.nodes) {
             // @media / @supports / @container inherit the enclosing layer
-            visit(at.nodes, layer);
+            visit(node.nodes, layer);
           }
         }
       }
@@ -174,23 +201,20 @@ describe('direct-subpath layer override regression', () => {
     return layers;
   }
 
-  test('badge.css rules all live in @layer cinder.components (override precondition)', async () => {
-    const source = await Bun.file(join(repoRoot, 'src/components/badge/badge.css')).text();
-    const layers = topLevelLayerOfEveryRule(source, 'badge.css');
-
+  async function assertEveryRuleInComponentLayer(file: string): Promise<void> {
+    const source = await Bun.file(join(repoRoot, file)).text();
+    const layers = topLevelLayerOfEveryRule(source, file);
     expect(layers.length).toBeGreaterThan(0);
     // Not a single rule may sit outside the layer — that is the un-overridable
     // landmine this task removes.
-    expect(layers.every((layer) => layer === 'cinder.components')).toBe(true);
+    expect(layers.every((layer) => layer === COMPONENT_LAYER_NAME)).toBe(true);
+  }
+
+  test('badge.css rules all live in @layer cinder.components (override precondition)', async () => {
+    await assertEveryRuleInComponentLayer('src/components/badge/badge.css');
   });
 
   test('a directly-imported partial (json-highlight.css) is fully layered', async () => {
-    const source = await Bun.file(
-      join(repoRoot, 'src/styles/components/json-highlight.css'),
-    ).text();
-    const layers = topLevelLayerOfEveryRule(source, 'json-highlight.css');
-
-    expect(layers.length).toBeGreaterThan(0);
-    expect(layers.every((layer) => layer === 'cinder.components')).toBe(true);
+    await assertEveryRuleInComponentLayer('src/styles/components/json-highlight.css');
   });
 });

--- a/packages/components/src/styles/component-css-layer-invariant.test.ts
+++ b/packages/components/src/styles/component-css-layer-invariant.test.ts
@@ -1,0 +1,196 @@
+import { join } from 'node:path';
+
+import { describe, expect, test } from 'bun:test';
+import { parse } from 'postcss';
+
+/**
+ * Every component CSS file that reaches the cascade must carry its own
+ * `@layer cinder.components { … }` wrapper so the layer assignment is intrinsic
+ * to the file and survives a direct subpath import (`cinder/<name>/styles`),
+ * rather than depending on the aggregator's `@import … layer(cinder.components)`.
+ *
+ * Without an intrinsic wrapper, a consumer importing a component's CSS directly
+ * (or the `index.css` aggregator after it drops the `layer()` qualifier on
+ * `components.css`) lands those rules OUTSIDE any cascade layer — the highest
+ * priority — making them un-overridable by utilities or consumer styles. That
+ * silently breaks the cascade contract.
+ *
+ * This asserts the structural invariant directly against the parsed CSS AST:
+ * after ignoring comments, the only top-level node in each file is a single
+ * `@layer cinder.components` block. No style-producing rule or at-rule may live
+ * outside it.
+ */
+
+const repoRoot = join(import.meta.dir, '..', '..');
+
+/**
+ * CSS files that legitimately do NOT carry the wrapper, by exact path under the
+ * package root. Anything else that lacks the wrapper is a leak and fails the
+ * drift guard below.
+ *
+ * - `src/styles/components/experimental.css` is a pure `@import` aggregator;
+ *   `@import` cannot live inside a block `@layer`, and its imported leaves each
+ *   carry their own wrapper. It is never copied to `dist/`.
+ * - `src/styles/components/experimental/_json-viewer-node.css` is an orphan: no
+ *   `.css`/`.ts`/`.svelte` source imports it, so it never reaches the cascade.
+ *   (The matching `_json-viewer-node.svelte` styles ship via `json-viewer.css`.)
+ */
+const UNWRAPPED_ALLOWLIST = new Set([
+  'src/styles/components/experimental.css',
+  'src/styles/components/experimental/_json-viewer-node.css',
+]);
+
+async function cssFilesUnder(directory: string): Promise<string[]> {
+  const glob = new Bun.Glob(`${directory}/**/*.css`);
+  const files: string[] = [];
+  for await (const file of glob.scan(repoRoot)) {
+    if (file.includes('.test.')) continue;
+    files.push(file);
+  }
+  return files.toSorted();
+}
+
+/**
+ * The full set of component CSS files subject to the wrapper invariant:
+ * per-component sidecars under `src/components/` plus the shared partials under
+ * `src/styles/components/`, minus the named allowlist of files that
+ * legitimately stay unwrapped.
+ */
+async function wrappedCssFiles(): Promise<string[]> {
+  const sidecars = await cssFilesUnder('src/components');
+  const partials = await cssFilesUnder('src/styles/components');
+  return [...sidecars, ...partials].filter((file) => !UNWRAPPED_ALLOWLIST.has(file)).toSorted();
+}
+
+function isSingleCinderComponentsLayer(source: string, file: string): boolean {
+  const root = parse(source, { from: file });
+  const topLevel = root.nodes.filter((node) => node.type !== 'comment');
+  return (
+    topLevel.length === 1 &&
+    topLevel[0]?.type === 'atrule' &&
+    topLevel[0].name === 'layer' &&
+    topLevel[0].params.trim() === 'cinder.components'
+  );
+}
+
+function describeShape(source: string, file: string): string {
+  const root = parse(source, { from: file });
+  return root.nodes
+    .filter((node) => node.type !== 'comment')
+    .map((node) =>
+      node.type === 'atrule'
+        ? `@${node.name} ${node.params}`.trim()
+        : node.type === 'rule'
+          ? node.selector
+          : node.type,
+    )
+    .join(' | ');
+}
+
+describe('component CSS @layer invariant', () => {
+  test('discovers a substantial set of component CSS files', async () => {
+    const files = await wrappedCssFiles();
+    expect(files.length).toBeGreaterThan(100);
+  });
+
+  test('every component CSS file wraps its rules in a single @layer cinder.components block', async () => {
+    const files = await wrappedCssFiles();
+    const offenders: string[] = [];
+
+    for (const file of files) {
+      const source = await Bun.file(join(repoRoot, file)).text();
+      if (!isSingleCinderComponentsLayer(source, file)) {
+        offenders.push(`${file} → ${describeShape(source, file)}`);
+      }
+    }
+
+    expect(offenders).toEqual([]);
+  });
+
+  test('the unwrapped allowlist stays minimal and accurate', async () => {
+    // Guard against drift: the allowlist must name only files that exist and
+    // are genuinely unwrapped. A stale entry (file deleted or later wrapped)
+    // would silently hide a future leak, so we assert each entry is real and
+    // still unwrapped.
+    for (const file of UNWRAPPED_ALLOWLIST) {
+      const handle = Bun.file(join(repoRoot, file));
+      expect(await handle.exists()).toBe(true);
+      const source = await handle.text();
+      expect(isSingleCinderComponentsLayer(source, file)).toBe(false);
+    }
+  });
+});
+
+/**
+ * The named-layer override regression test — the precise reason this wrapper
+ * matters for direct subpath imports.
+ *
+ * A consumer that imports a component's CSS file DIRECTLY (e.g.
+ * `cinder/badge/styles`, NOT `cinder/styles`) and then declares its own
+ * `@layer app` override expects the documented cascade to hold:
+ *
+ *   @layer cinder.components, app;   ← app is declared AFTER cinder.components
+ *   <direct import of badge.css>     ← rules join @layer cinder.components
+ *   @layer app { .cinder-badge { … } } ← app wins by layer order
+ *
+ * This only works if the directly-imported file's rules are INSIDE
+ * `@layer cinder.components`. Before this fix, `badge.css` held bare rules: a
+ * direct import dropped them outside any layer, where they outrank every
+ * layered rule and the `@layer app` override silently loses. We assert the
+ * structural precondition for the override — every cascade-relevant component
+ * rule lives in `cinder.components` — directly against the parsed AST, since a
+ * real cascade resolution needs a browser and the layer membership is the only
+ * thing this change controls.
+ */
+describe('direct-subpath layer override regression', () => {
+  /**
+   * Walk a parsed file and collect every style rule's enclosing top-level
+   * layer name (or `null` when a rule sits outside any layer). `@keyframes`
+   * stops are not document-targeting style rules, so they are skipped.
+   */
+  function topLevelLayerOfEveryRule(source: string, file: string): (string | null)[] {
+    const root = parse(source, { from: file });
+    const layers: (string | null)[] = [];
+
+    const visit = (nodes: ReturnType<typeof parse>['nodes'], layer: string | null): void => {
+      for (const node of nodes) {
+        if (node.type === 'rule') {
+          layers.push(layer);
+        } else if (node.type === 'atrule') {
+          const at = node;
+          if (at.name === 'layer' && at.nodes) {
+            visit(at.nodes, at.params.trim());
+          } else if (/^(-\w+-)?keyframes$/i.test(at.name)) {
+            // animation stops, not document-targeting rules
+          } else if (at.nodes) {
+            // @media / @supports / @container inherit the enclosing layer
+            visit(at.nodes, layer);
+          }
+        }
+      }
+    };
+
+    visit(root.nodes, null);
+    return layers;
+  }
+
+  test('badge.css rules all live in @layer cinder.components (override precondition)', async () => {
+    const source = await Bun.file(join(repoRoot, 'src/components/badge/badge.css')).text();
+    const layers = topLevelLayerOfEveryRule(source, 'badge.css');
+
+    expect(layers.length).toBeGreaterThan(0);
+    // Not a single rule may sit outside the layer — that is the un-overridable
+    // landmine this task removes.
+    expect(layers.every((layer) => layer === 'cinder.components')).toBe(true);
+  });
+
+  test('a directly-imported partial (json-highlight.css) is fully layered', async () => {
+    const source = await Bun.file(
+      join(repoRoot, 'src/styles/components/json-highlight.css'),
+    ).text();
+    const layers = topLevelLayerOfEveryRule(source, 'json-highlight.css');
+
+    expect(layers.length).toBeGreaterThan(0);
+    expect(layers.every((layer) => layer === 'cinder.components')).toBe(true);
+  });
+});

--- a/packages/components/src/styles/components.css
+++ b/packages/components/src/styles/components.css
@@ -119,57 +119,7 @@
 @import '../components/tree/tree.css';
 @import '../components/tree-select-all/tree-select-all.css';
 
-/* INTERNAL — used by Alert and Banner dismiss buttons.
- * Provides hit-area + icon sizing + baseline interaction chrome.
- * Layout positioning and status-driven coloring stay component-local.
- *
- * Split breakdown:
- *   Truly-shared (here): box-model reset (display/size/padding/border/radius/
- *   background/color/cursor), flex-shrink, position relative, the WCAG 2.5.5
- *   44x44 ::after hit-area pseudo-element, and the idle :hover background
- *   color-mix. These are byte-for-byte identical between Alert and Banner.
- *
- *   Component-local (stays in alert.css / banner.css): align-self (flex-start
- *   vs center), the transition declaration (Alert applies unconditionally,
- *   Banner gates on prefers-reduced-motion), :focus-visible box-shadow (each
- *   reads a host-specific status-driven custom property), and the
- *   forced-colors overrides (Banner has additional hover/box-shadow rules).
- */
-.cinder-_dismiss-button {
-  flex-shrink: 0;
-
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 1.25rem;
-  height: 1.25rem;
-  padding: 0;
-
-  border-radius: var(--cinder-radius-sm);
-  border: none;
-  background: transparent;
-  color: inherit;
-  cursor: pointer;
-
-  /* Anchor the WCAG 2.5.5 hit-area pseudo-element below. */
-  position: relative;
-}
-
-/* Expand the interactive hit area to 44x44 px (WCAG 2.5.5) without
- * affecting layout. Absolutely positioned so it doesn't shift siblings. */
-.cinder-_dismiss-button::after {
-  content: '';
-  position: absolute;
-  inset: 50% auto auto 50%;
-  width: 44px;
-  height: 44px;
-  transform: translate(-50%, -50%);
-}
-
-/* Sticky-hover suppression on touch: hover-only background wrapped so it
- * doesn't "stick" after tap. */
-@media (hover: hover) {
-  .cinder-_dismiss-button:hover {
-    background: color-mix(in oklch, currentColor, transparent 80%);
-  }
-}
+/* Shared internal partial — base chrome for Alert/Banner dismiss buttons.
+ * Imported last to preserve the original source order of the inline rule it
+ * replaced (it previously sat after every component import). */
+@import './components/_dismiss-button.css';

--- a/packages/components/src/styles/components/_dismiss-button.css
+++ b/packages/components/src/styles/components/_dismiss-button.css
@@ -1,0 +1,56 @@
+/* INTERNAL — used by Alert and Banner dismiss buttons.
+ * Provides hit-area + icon sizing + baseline interaction chrome.
+ * Layout positioning and status-driven coloring stay component-local.
+ *
+ * Split breakdown:
+ *   Truly-shared (here): box-model reset (display/size/padding/border/radius/
+ *   background/color/cursor), flex-shrink, position relative, the WCAG 2.5.5
+ *   44x44 ::after hit-area pseudo-element, and the idle :hover background
+ *   color-mix. These are byte-for-byte identical between Alert and Banner.
+ *
+ *   Component-local (stays in alert.css / banner.css): align-self (flex-start
+ *   vs center), the transition declaration (Alert applies unconditionally,
+ *   Banner gates on prefers-reduced-motion), :focus-visible box-shadow (each
+ *   reads a host-specific status-driven custom property), and the
+ *   forced-colors overrides (Banner has additional hover/box-shadow rules).
+ */
+@layer cinder.components {
+  .cinder-_dismiss-button {
+    flex-shrink: 0;
+
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 1.25rem;
+    height: 1.25rem;
+    padding: 0;
+
+    border-radius: var(--cinder-radius-sm);
+    border: none;
+    background: transparent;
+    color: inherit;
+    cursor: pointer;
+
+    /* Anchor the WCAG 2.5.5 hit-area pseudo-element below. */
+    position: relative;
+  }
+
+  /* Expand the interactive hit area to 44x44 px (WCAG 2.5.5) without
+   * affecting layout. Absolutely positioned so it doesn't shift siblings. */
+  .cinder-_dismiss-button::after {
+    content: '';
+    position: absolute;
+    inset: 50% auto auto 50%;
+    width: 44px;
+    height: 44px;
+    transform: translate(-50%, -50%);
+  }
+
+  /* Sticky-hover suppression on touch: hover-only background wrapped so it
+   * doesn't "stick" after tap. */
+  @media (hover: hover) {
+    .cinder-_dismiss-button:hover {
+      background: color-mix(in oklch, currentColor, transparent 80%);
+    }
+  }
+}

--- a/packages/components/src/styles/components/experimental/popover.css
+++ b/packages/components/src/styles/components/experimental/popover.css
@@ -1,54 +1,56 @@
-/* ========================================
+@layer cinder.components {
+  /* ========================================
  * POPOVER (experimental)
  * Anchored interactive surface. Uses platform Popover API where available;
  * falls back to fixed positioning for older browsers.
  * ======================================== */
 
-.cinder-popover-wrapper {
-  display: inline-block;
-  position: relative;
-}
+  .cinder-popover-wrapper {
+    display: inline-block;
+    position: relative;
+  }
 
-.cinder-popover {
-  background: var(--cinder-surface-raised);
-  border: 1px solid var(--cinder-border);
-  border-radius: var(--cinder-radius-md);
-  box-shadow:
-    0 1px 2px oklch(0% 0 0 / 0.04),
-    0 8px 24px oklch(0% 0 0 / 0.12);
-  padding: var(--cinder-space-3);
-  z-index: var(--cinder-z-popover);
-  /* Initial state: auto-positioned by the platform Popover API; the
+  .cinder-popover {
+    background: var(--cinder-surface-raised);
+    border: 1px solid var(--cinder-border);
+    border-radius: var(--cinder-radius-md);
+    box-shadow:
+      0 1px 2px oklch(0% 0 0 / 0.04),
+      0 8px 24px oklch(0% 0 0 / 0.12);
+    padding: var(--cinder-space-3);
+    z-index: var(--cinder-z-popover);
+    /* Initial state: auto-positioned by the platform Popover API; the
    * fallback path uses CSS positioning. */
-  margin: 0;
-}
+    margin: 0;
+  }
 
-.cinder-popover[popover] {
-  inset: unset;
-}
+  .cinder-popover[popover] {
+    inset: unset;
+  }
 
-/* Fallback positioning for browsers without the popover API. The platform
+  /* Fallback positioning for browsers without the popover API. The platform
  * popover API takes care of positioning when supported. */
-.cinder-popover[data-cinder-placement='bottom-start'] {
-  position: absolute;
-  top: calc(100% + var(--cinder-space-1));
-  left: 0;
-}
+  .cinder-popover[data-cinder-placement='bottom-start'] {
+    position: absolute;
+    top: calc(100% + var(--cinder-space-1));
+    left: 0;
+  }
 
-.cinder-popover[data-cinder-placement='bottom-end'] {
-  position: absolute;
-  top: calc(100% + var(--cinder-space-1));
-  right: 0;
-}
+  .cinder-popover[data-cinder-placement='bottom-end'] {
+    position: absolute;
+    top: calc(100% + var(--cinder-space-1));
+    right: 0;
+  }
 
-.cinder-popover[data-cinder-placement='top-start'] {
-  position: absolute;
-  bottom: calc(100% + var(--cinder-space-1));
-  left: 0;
-}
+  .cinder-popover[data-cinder-placement='top-start'] {
+    position: absolute;
+    bottom: calc(100% + var(--cinder-space-1));
+    left: 0;
+  }
 
-.cinder-popover[data-cinder-placement='top-end'] {
-  position: absolute;
-  bottom: calc(100% + var(--cinder-space-1));
-  right: 0;
+  .cinder-popover[data-cinder-placement='top-end'] {
+    position: absolute;
+    bottom: calc(100% + var(--cinder-space-1));
+    right: 0;
+  }
 }

--- a/packages/components/src/styles/components/json-highlight.css
+++ b/packages/components/src/styles/components/json-highlight.css
@@ -1,4 +1,5 @@
-/* ========================================
+@layer cinder.components {
+  /* ========================================
  * JSON syntax highlight tokens
  * Used by `highlightJson()` (utilities/json-highlight.ts) when rendering
  * tool-call arguments and results, or any other JSON value passed through
@@ -12,27 +13,28 @@
  * the lighter --cinder-surface in light mode.
  * ======================================== */
 
-.cinder-json-token-key {
-  color: var(--cinder-accent);
-}
+  .cinder-json-token-key {
+    color: var(--cinder-accent);
+  }
 
-.cinder-json-token-string {
-  color: var(--cinder-success);
-}
+  .cinder-json-token-string {
+    color: var(--cinder-success);
+  }
 
-/* Semantic warning foreground is calibrated to remain readable on soft surfaces. */
-.cinder-json-token-number {
-  color: var(--cinder-color-warning-fg);
-}
+  /* Semantic warning foreground is calibrated to remain readable on soft surfaces. */
+  .cinder-json-token-number {
+    color: var(--cinder-color-warning-fg);
+  }
 
-.cinder-json-token-boolean,
+  .cinder-json-token-boolean,
 /* `null` is a semantic value (not decoration); use the same color as boolean. */
 .cinder-json-token-null {
-  color: var(--cinder-info);
-}
+    color: var(--cinder-info);
+  }
 
-/* JSON punctuation is rendered text; --cinder-text-muted meets AA in both
+  /* JSON punctuation is rendered text; --cinder-text-muted meets AA in both
  * themes (light: oklch 32% on ≥94%, dark: oklch 82% on ≤20%). */
-.cinder-json-token-punctuation {
-  color: var(--cinder-text-muted);
+  .cinder-json-token-punctuation {
+    color: var(--cinder-text-muted);
+  }
 }

--- a/packages/components/src/styles/index.css
+++ b/packages/components/src/styles/index.css
@@ -2,5 +2,5 @@
 
 @import './tokens.css' layer(cinder.tokens);
 @import './foundation.css' layer(cinder.foundation);
-@import './components.css' layer(cinder.components);
+@import './components.css';
 @import './utilities.css' layer(cinder.utilities);

--- a/packages/components/src/test/css.test.ts
+++ b/packages/components/src/test/css.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, test } from 'bun:test';
+import { parse } from 'postcss';
+
+import { stripCinderComponentsLayer } from './css.ts';
+
+/**
+ * Parse `css` and return its top-level selectors / at-rule headers, in order.
+ * Comments are ignored — they carry no cascade meaning and may legitimately
+ * survive a strip.
+ */
+function topLevelShape(css: string): string[] {
+  return parse(css)
+    .nodes.filter((node) => node.type !== 'comment')
+    .map((node) =>
+      node.type === 'rule'
+        ? node.selector
+        : node.type === 'atrule'
+          ? `@${node.name} ${node.params}`.trim()
+          : node.type,
+    );
+}
+
+describe('stripCinderComponentsLayer', () => {
+  test('returns source unchanged when there is no wrapper', () => {
+    const css = '.cinder-x { color: red; }';
+    expect(stripCinderComponentsLayer(css).trim()).toBe(css);
+  });
+
+  test('hoists the inner rules out of the wrapper', () => {
+    const css = '@layer cinder.components { .cinder-x { color: red; } .cinder-y { color: blue; } }';
+    expect(topLevelShape(stripCinderComponentsLayer(css))).toEqual(['.cinder-x', '.cinder-y']);
+  });
+
+  test('an empty wrapper strips to no rules', () => {
+    expect(topLevelShape(stripCinderComponentsLayer('@layer cinder.components {}'))).toEqual([]);
+  });
+
+  test('leaves a wrapper with a different layer name untouched', () => {
+    const css = '@layer other { .cinder-x { color: red; } }';
+    expect(topLevelShape(stripCinderComponentsLayer(css))).toEqual(['@layer other']);
+  });
+
+  test('preserves nested at-rules (@media) when hoisting', () => {
+    const css =
+      '@layer cinder.components { .cinder-x { color: red; } @media (hover: hover) { .cinder-x:hover { color: blue; } } }';
+    expect(topLevelShape(stripCinderComponentsLayer(css))).toEqual([
+      '.cinder-x',
+      '@media (hover: hover)',
+    ]);
+  });
+
+  test('braces inside content/url/strings do not corrupt the result', () => {
+    const css =
+      "@layer cinder.components { .cinder-x::before { content: '}{'; } .cinder-y { background: url('data:image/svg+xml,{}'); } }";
+    expect(topLevelShape(stripCinderComponentsLayer(css))).toEqual([
+      '.cinder-x::before',
+      '.cinder-y',
+    ]);
+    // The pathological content value survives intact.
+    expect(stripCinderComponentsLayer(css)).toContain("content: '}{'");
+  });
+
+  test('a closing brace inside a comment does not truncate the strip', () => {
+    const css =
+      '@layer cinder.components { /* a } brace in a comment */ .cinder-x { color: red; } }';
+    expect(topLevelShape(stripCinderComponentsLayer(css))).toEqual(['.cinder-x']);
+  });
+});

--- a/packages/components/src/test/css.ts
+++ b/packages/components/src/test/css.ts
@@ -24,12 +24,26 @@ import { COMPONENT_LAYER_NAME } from '../../scripts/check-component-css.ts';
  * (hoisting its children to the top level); content outside the wrapper and
  * wrappers with any other name are left untouched. Source with no such wrapper
  * is returned unchanged.
+ *
+ * The hoisted rules are dedented by one indentation level so the result is
+ * byte-for-byte the flat CSS the file would have been WITHOUT the wrapper —
+ * i.e. top-level declarations sit at two-space indent, not the four-space
+ * indent they carry while nested inside the layer block. Tests assert on that
+ * flat shape (`getComputedStyle` plus exact-substring matches), so the dedent
+ * keeps the helper faithful to "the CSS this file declares".
  */
 export function stripCinderComponentsLayer(css: string): string {
   const root = parse(css);
+  let stripped = false;
   root.walkAtRules('layer', (atRule: AtRule) => {
     if (atRule.params.trim() !== COMPONENT_LAYER_NAME || atRule.nodes === undefined) return;
     atRule.replaceWith(atRule.nodes);
+    stripped = true;
   });
-  return root.toString();
+  const output = root.toString();
+  if (!stripped) return output;
+  // Remove exactly one level (two spaces) of leading indentation from every
+  // line that has it — the wrapper added exactly one level uniformly, so this
+  // restores the original flat indentation without disturbing relative nesting.
+  return output.replace(/^ {2}/gm, '');
 }

--- a/packages/components/src/test/css.ts
+++ b/packages/components/src/test/css.ts
@@ -1,0 +1,42 @@
+/**
+ * CSS test helpers. Internal — not part of the public package surface.
+ */
+
+/**
+ * Strip a single outer `@layer cinder.components { … }` wrapper from a component
+ * CSS sidecar, returning the inner rule text.
+ *
+ * Component CSS files self-declare `@layer cinder.components { … }` so the layer
+ * assignment survives a direct subpath import. happy-dom's CSS engine does NOT
+ * apply rules nested inside a cascade-layer block to `getComputedStyle` or
+ * expose them as top-level `CSSStyleRule`s in `sheet.cssRules`. Tests that
+ * inject a sidecar into a `<style>` to assert on computed values or rule
+ * structure therefore strip the wrapper first — they assert on the CSS the file
+ * declares, not on layer cascade behavior (which happy-dom cannot model).
+ *
+ * If the source has no `@layer cinder.components` wrapper, it is returned
+ * unchanged.
+ */
+export function stripCinderComponentsLayer(css: string): string {
+  const open = /@layer\s+cinder\.components\s*\{/.exec(css);
+  if (!open) return css;
+
+  const bodyStart = open.index + open[0].length;
+
+  // Find the matching closing brace for the wrapper by tracking brace depth.
+  let depth = 1;
+  let index = bodyStart;
+  for (; index < css.length; index += 1) {
+    const char = css[index];
+    if (char === '{') depth += 1;
+    else if (char === '}') {
+      depth -= 1;
+      if (depth === 0) break;
+    }
+  }
+
+  const before = css.slice(0, open.index);
+  const inner = css.slice(bodyStart, index);
+  const after = css.slice(index + 1);
+  return `${before}${inner}${after}`;
+}

--- a/packages/components/src/test/css.ts
+++ b/packages/components/src/test/css.ts
@@ -2,9 +2,13 @@
  * CSS test helpers. Internal — not part of the public package surface.
  */
 
+import { parse, type AtRule } from 'postcss';
+
+import { COMPONENT_LAYER_NAME } from '../../scripts/check-component-css.ts';
+
 /**
- * Strip a single outer `@layer cinder.components { … }` wrapper from a component
- * CSS sidecar, returning the inner rule text.
+ * Strip the outer `@layer cinder.components { … }` wrapper from a component CSS
+ * sidecar, returning the inner rules as flat CSS.
  *
  * Component CSS files self-declare `@layer cinder.components { … }` so the layer
  * assignment survives a direct subpath import. happy-dom's CSS engine does NOT
@@ -14,29 +18,18 @@
  * structure therefore strip the wrapper first — they assert on the CSS the file
  * declares, not on layer cascade behavior (which happy-dom cannot model).
  *
- * If the source has no `@layer cinder.components` wrapper, it is returned
- * unchanged.
+ * Parsing is done with PostCSS (a real CSS tokenizer) rather than a hand-rolled
+ * brace scan, so braces inside `content`, quoted strings, `url()`, or comments
+ * cannot corrupt the result. Every `@layer cinder.components` block is unwrapped
+ * (hoisting its children to the top level); content outside the wrapper and
+ * wrappers with any other name are left untouched. Source with no such wrapper
+ * is returned unchanged.
  */
 export function stripCinderComponentsLayer(css: string): string {
-  const open = /@layer\s+cinder\.components\s*\{/.exec(css);
-  if (!open) return css;
-
-  const bodyStart = open.index + open[0].length;
-
-  // Find the matching closing brace for the wrapper by tracking brace depth.
-  let depth = 1;
-  let index = bodyStart;
-  for (; index < css.length; index += 1) {
-    const char = css[index];
-    if (char === '{') depth += 1;
-    else if (char === '}') {
-      depth -= 1;
-      if (depth === 0) break;
-    }
-  }
-
-  const before = css.slice(0, open.index);
-  const inner = css.slice(bodyStart, index);
-  const after = css.slice(index + 1);
-  return `${before}${inner}${after}`;
+  const root = parse(css);
+  root.walkAtRules('layer', (atRule: AtRule) => {
+    if (atRule.params.trim() !== COMPONENT_LAYER_NAME || atRule.nodes === undefined) return;
+    atRule.replaceWith(atRule.nodes);
+  });
+  return root.toString();
 }

--- a/packages/components/src/test/index.ts
+++ b/packages/components/src/test/index.ts
@@ -7,6 +7,7 @@
  */
 
 export { expectAttribute, expectAttributes, getRelated } from './aria.ts';
+export { stripCinderComponentsLayer } from './css.ts';
 export { setupHappyDom } from './happy-dom.ts';
 export { renderThenHydrate, type HydrateResult } from './hydrate.ts';
 export {


### PR DESCRIPTION
## Summary

Prerequisite for per-component CSS subpath exports (`cinder/<name>/styles`). Today the ~119 component CSS files (e.g. `badge.css`) hold bare `.cinder-badge { … }` rules and are assigned to layer `cinder.components` **only** because the aggregator chain imports them under a layer (`index.css` → `@import './components.css' layer(cinder.components)`). The moment a consumer imports a component's CSS directly via a subpath, those bare rules land **outside any cascade layer** — the highest priority — making them un-overridable by utilities or consumer styles. That silently breaks the cascade contract.

This makes the layer membership **intrinsic to each file**:

- Wrap every component CSS file — and the shared partials `json-highlight.css`, `experimental/popover.css`, and the extracted `_dismiss-button.css` — in `@layer cinder.components { … }`.
- Drop `layer(cinder.components)` from `index.css`'s `components.css` import (tokens/foundation/utilities keep theirs). The aggregated `cinder/styles` path is unchanged because each leaf now self-declares the layer.
- Extract the inline `.cinder-_dismiss-button` block from `components.css` into a wrapped partial, imported last to preserve the original source order.
- **Invert the build gate** `scripts/check-component-css.ts`: it used to *reject* `@layer` in a sidecar; it now *requires* exactly one top-level `@layer cinder.components { … }` block (a bare rule outside it is a violation). `@import` rejection and the class-anchor scoping rules are unchanged.
- `experimental.css` stays a pure `@import` aggregator (you can't `@import` inside a block `@layer`); its leaves are each wrapped.
- `stripCinderComponentsLayer` (new test helper) strips the wrapper via PostCSS for CSS-assertion tests, since happy-dom doesn't apply layer-nested rules to `getComputedStyle`. CSS-assertion tests (alert/callout/combobox/dropdown/select/table) are adapted to be `@layer`-aware.
- Documented the self-layering contract + the reversed-from-bare-rules migration note in `AGENTS.md`.

## Cascade identity

The change is cascade-neutral for the aggregated path: a probe that flattens the full `@import` tree of `index.css` into an ordered, CSS-normalized rule stream is byte-identical before and after (every rule in the same layer, same order, same declarations). This is now a permanent, reproducible regression guard — `src/styles/cascade-identity.test.ts` — which asserts the four layers resolve in declared order and every rule reachable through `components.css` lands in `cinder.components`. Verified in a real browser: the playground renders button and badge fully styled (all variants/sizes/states), confirming the layer applies.

## Review committee

Pre-reviewed by: typescript-expert, testing-expert, simplicity-engineer, frontend-architect, junior-engineer, dx-engineer
- Codex (gpt-5.4, xhigh reasoning) — 2 rounds
- 2 rounds of review; all must-fix items addressed (removed a weak dist-side substring check, rewrote the strip helper with PostCSS, added the cascade-identity regression test, extended invariant enumeration to directly-imported CSS, added a migration-cliff doc note)

## Test plan

- `bun test packages/components/src/styles packages/components/scripts/check-component-css.test.ts packages/components/src/test/css.test.ts` — invariant, cascade-identity, linter, and strip-helper suites pass.
- `bun run build` — the inverted gate accepts the wrapped sidecars; all 118 dist sidecars are self-layered.
- `bun run typecheck` / `bun run lint` — clean (0 errors).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Wide mechanical change across all component stylesheets affects cascade and override behavior; mitigated by inverted build gate, invariant/cascade-identity tests, and intended neutrality on the aggregated `cinder/styles` path.
> 
> **Overview**
> Component CSS sidecars now **self-declare** cascade membership by wrapping all rules in a single top-level `@layer cinder.components { … }` block, instead of relying on the `cinder/styles` aggregator to assign the layer on `@import`. That makes direct subpath imports (`cinder/<name>/styles`) safe: bare rules no longer escape layers and override consumer utilities.
> 
> The sidecar linter in `check-component-css.ts` is **inverted**—it now **requires** that wrapper (and still forbids `@import` and unscoped globals). `index.css` drops `layer(cinder.components)` on the `components.css` import because leaves carry the layer themselves. Docs in `AGENTS.md` describe the new contract and the migration from bare sidecars.
> 
> Tests add cascade-identity and layer-invariant guards, extend the CSS gate suite (`isSingleComponentLayer`, etc.), and teach PostCSS/CSS-assertion tests to treat `@layer` as transparent (including `stripCinderComponentsLayer` for happy-dom).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3b04d3ef494454dffd00aae8980a84d398f140ac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->