### PR TITLE
test(components): add arrow-key navigation tests to dropdown and context-menu

### DIFF
--- a/packages/components/src/components/context-menu/_context-menu-test-harness.svelte
+++ b/packages/components/src/components/context-menu/_context-menu-test-harness.svelte
@@ -24,20 +24,28 @@
       onpointerup?: (event: PointerEvent) => void;
     };
   } = $props();
+
+  let selected = $state('');
 </script>
 
 {#snippet menuContent()}
-  <DropdownItem>Open</DropdownItem>
+  <DropdownItem onclick={() => (selected = 'open')}>Open</DropdownItem>
   <DropdownItem disabled>Disabled action</DropdownItem>
+  <DropdownItem onclick={() => (selected = 'rename')}>Rename</DropdownItem>
+  <DropdownItem onclick={() => (selected = 'delete')}>Delete</DropdownItem>
 {/snippet}
 
-<ContextMenu {disabled} {longPressDelay} {open} {anchorPoint}>
-  <ContextMenuTrigger class="context-menu-region" {...triggerHandlers}>
-    <button type="button" class="context-menu-button">File one.txt</button>
-  </ContextMenuTrigger>
-  <DropdownMenu>
-    {@render menuContent()}
-  </DropdownMenu>
-</ContextMenu>
+<div>
+  <ContextMenu {disabled} {longPressDelay} {open} {anchorPoint}>
+    <ContextMenuTrigger class="context-menu-region" {...triggerHandlers}>
+      <button type="button" class="context-menu-button">File one.txt</button>
+    </ContextMenuTrigger>
+    <DropdownMenu>
+      {@render menuContent()}
+    </DropdownMenu>
+  </ContextMenu>
 
-<div class="context-menu-selection"></div>
+  <div class="context-menu-selection"></div>
+  <output class="context-menu-selected">{selected}</output>
+</div>
+

--- a/packages/components/src/components/context-menu/context-menu.test.ts
+++ b/packages/components/src/components/context-menu/context-menu.test.ts
@@ -249,6 +249,108 @@ describe('ContextMenu', () => {
     expect(document.activeElement).toBe(triggerButton);
   });
 
+  test('opening focuses the first enabled menu item', async () => {
+    const { container } = render(ContextMenuHarness);
+    const region = container.querySelector('.context-menu-region') as HTMLElement;
+
+    await fireEvent.contextMenu(region, { clientX: 24, clientY: 36 });
+
+    await waitFor(() => expect(queryMenu()).not.toBeNull());
+    await waitFor(() => {
+      expect(document.activeElement?.textContent).toContain('Open');
+    });
+  });
+
+  test('ArrowDown and ArrowUp navigate enabled items and skip disabled ones', async () => {
+    const { container } = render(ContextMenuHarness);
+    const region = container.querySelector('.context-menu-region') as HTMLElement;
+
+    await fireEvent.contextMenu(region, { clientX: 24, clientY: 36 });
+    await waitFor(() => {
+      expect(document.activeElement?.textContent).toContain('Open');
+    });
+
+    // "Disabled action" is skipped — ArrowDown lands on the next enabled item.
+    await fireEvent.keyDown(document.activeElement as HTMLElement, { key: 'ArrowDown' });
+    expect(document.activeElement?.textContent).toContain('Rename');
+
+    await fireEvent.keyDown(document.activeElement as HTMLElement, { key: 'ArrowDown' });
+    expect(document.activeElement?.textContent).toContain('Delete');
+
+    await fireEvent.keyDown(document.activeElement as HTMLElement, { key: 'ArrowUp' });
+    expect(document.activeElement?.textContent).toContain('Rename');
+  });
+
+  test('ArrowDown wraps from the last enabled item back to the first', async () => {
+    const { container } = render(ContextMenuHarness);
+    const region = container.querySelector('.context-menu-region') as HTMLElement;
+
+    await fireEvent.contextMenu(region, { clientX: 24, clientY: 36 });
+    await waitFor(() => {
+      expect(document.activeElement?.textContent).toContain('Open');
+    });
+
+    await fireEvent.keyDown(document.activeElement as HTMLElement, { key: 'End' });
+    expect(document.activeElement?.textContent).toContain('Delete');
+
+    await fireEvent.keyDown(document.activeElement as HTMLElement, { key: 'ArrowDown' });
+    expect(document.activeElement?.textContent).toContain('Open');
+  });
+
+  test('ArrowUp wraps from the first enabled item to the last', async () => {
+    const { container } = render(ContextMenuHarness);
+    const region = container.querySelector('.context-menu-region') as HTMLElement;
+
+    await fireEvent.contextMenu(region, { clientX: 24, clientY: 36 });
+    await waitFor(() => {
+      expect(document.activeElement?.textContent).toContain('Open');
+    });
+
+    await fireEvent.keyDown(document.activeElement as HTMLElement, { key: 'ArrowUp' });
+    expect(document.activeElement?.textContent).toContain('Delete');
+  });
+
+  test('Enter on the focused item selects it and closes the menu', async () => {
+    const { container } = render(ContextMenuHarness);
+    const region = container.querySelector('.context-menu-region') as HTMLElement;
+
+    await fireEvent.contextMenu(region, { clientX: 24, clientY: 36 });
+    await waitFor(() => {
+      expect(document.activeElement?.textContent).toContain('Open');
+    });
+
+    await fireEvent.keyDown(document.activeElement as HTMLElement, { key: 'ArrowDown' });
+    expect(document.activeElement?.textContent).toContain('Rename');
+
+    // DropdownItem dispatches a synthetic click on Enter, so selection and
+    // close-on-select both fire even though happy-dom does not synthesize the
+    // click from keydown on its own.
+    await fireEvent.keyDown(document.activeElement as HTMLElement, { key: 'Enter' });
+
+    await waitFor(() => expect(queryMenu()).toBeNull());
+    expect(container.querySelector('.context-menu-selected')?.textContent).toBe('rename');
+  });
+
+  test('Escape closes the menu and restores focus to the trigger region', async () => {
+    const { container } = render(ContextMenuHarness);
+    const region = container.querySelector('.context-menu-region') as HTMLElement;
+    const triggerButton = container.querySelector('.context-menu-button') as HTMLButtonElement;
+    triggerButton.focus();
+
+    await fireEvent.contextMenu(region, { clientX: 24, clientY: 36 });
+    await waitFor(() => {
+      expect(document.activeElement?.textContent).toContain('Open');
+    });
+
+    await fireEvent.keyDown(document.activeElement as HTMLElement, { key: 'Escape' });
+
+    // Escape both flips open to false (the close effect restores focus) and
+    // runs DropdownMenu's own focusTrigger() call, so focus lands back inside
+    // the trigger region rather than escaping to the body.
+    await waitFor(() => expect(queryMenu()).toBeNull());
+    expect(region.contains(document.activeElement)).toBe(true);
+  });
+
   test('keyboard context menu keys open at the focused target edge', async () => {
     const { container } = render(ContextMenuHarness);
     const button = container.querySelector('.context-menu-button') as HTMLButtonElement;

--- a/packages/components/src/components/dropdown/dropdown.test.ts
+++ b/packages/components/src/components/dropdown/dropdown.test.ts
@@ -469,6 +469,58 @@ describe('Dropdown', () => {
     expect(document.activeElement?.textContent).toContain('Copy link');
   });
 
+  test('ArrowUp from the first item wraps to the last item', async () => {
+    const { container } = render(DropdownCompoundFixture);
+    const trigger = container.querySelector('.trigger') as HTMLElement;
+
+    await fireEvent.click(trigger);
+    await waitFor(() => {
+      expect(document.activeElement?.textContent).toContain('Copy link');
+    });
+
+    await fireEvent.keyDown(document.activeElement as HTMLElement, { key: 'ArrowUp' });
+    expect(document.activeElement?.textContent).toContain('Archive');
+  });
+
+  test('ArrowDown from the last item wraps to the first item', async () => {
+    const { container } = render(DropdownCompoundFixture);
+    const trigger = container.querySelector('.trigger') as HTMLElement;
+
+    await fireEvent.click(trigger);
+    await waitFor(() => {
+      expect(document.activeElement?.textContent).toContain('Copy link');
+    });
+
+    await fireEvent.keyDown(document.activeElement as HTMLElement, { key: 'End' });
+    expect(document.activeElement?.textContent).toContain('Archive');
+
+    await fireEvent.keyDown(document.activeElement as HTMLElement, { key: 'ArrowDown' });
+    expect(document.activeElement?.textContent).toContain('Copy link');
+  });
+
+  test('Enter activates the focused menu item and closes the menu', async () => {
+    const { container } = render(DropdownCompoundFixture);
+    const trigger = container.querySelector('.trigger') as HTMLElement;
+
+    await fireEvent.click(trigger);
+    await waitFor(() => {
+      expect(document.activeElement?.textContent).toContain('Copy link');
+    });
+
+    await fireEvent.keyDown(document.activeElement as HTMLElement, { key: 'ArrowDown' });
+    expect(document.activeElement?.textContent).toContain('Invite people');
+
+    // DropdownItem dispatches a synthetic click on Enter, so activation and
+    // close-on-select both run even though happy-dom does not synthesize the
+    // click from keydown on a <button> itself.
+    await fireEvent.keyDown(document.activeElement as HTMLElement, { key: 'Enter' });
+
+    await waitFor(() => {
+      expect(container.querySelector('[role="menu"]')).toBeNull();
+    });
+    expect(container.querySelector('output')?.textContent).toBe('share');
+  });
+
   test('legacy trigger wrapper does not own aria-haspopup', () => {
     const { container } = render(Dropdown, {
       props: {


### PR DESCRIPTION
Reviewed by the workflow's adversarial subagent committee (correctness / testing / typescript). Green through the full pre-push gate. Part of the Group A batch (test/refactor tasks, no generated-file changes).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test and harness-only changes; no production component logic modified.
> 
> **Overview**
> Adds automated coverage for **keyboard-driven menu behavior** in the shared `DropdownMenu` stack, without changing component implementation.
> 
> The **context-menu test harness** now tracks item selection (`selected` state, extra enabled items, disabled row, and an `<output>`) so tests can assert activation. New **context-menu** specs cover initial focus on the first enabled item, arrow navigation that skips disabled entries, wrap-around at the ends, **Enter** to select and close, and **Escape** to close while keeping focus in the trigger region.
> 
> **Dropdown** compound tests add the same style of checks for arrow wrap (first ↔ last) and **Enter** to activate a focused item and close the menu.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 951ab2da141dab08b81ec47a12d9e0ea950dbec1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->