### PR TITLE
test(components): add SSR-contract tests for image/drawer/sheet/toast-region

### DIFF
--- a/packages/components/src/components/drawer/drawer.test.ts
+++ b/packages/components/src/components/drawer/drawer.test.ts
@@ -1,4 +1,6 @@
 /// <reference lib="dom" />
+import { join } from 'node:path';
+
 import { afterEach, describe, expect, test } from 'bun:test';
 import { createRawSnippet } from 'svelte';
 
@@ -10,6 +12,9 @@ import {
   OverflowFadeResizeObserver,
   setScrollMeasurements,
 } from '../../test/overflow-fade-test-helpers.ts';
+import { renderToServerHtml } from '../../test/server-render.ts';
+
+const DRAWER_SOURCE = join(import.meta.dir, 'drawer.svelte');
 
 setupHappyDom();
 
@@ -104,13 +109,12 @@ describe('Drawer', () => {
     expect(dialog?.hasAttribute('open')).toBe(true);
   });
 
-  // ---- 2. SSR-empty: dialog absent when hydrated flag is false ----
-  test('dialog is absent during SSR (hydrated=false)', () => {
-    // In happy-dom $effect runs synchronously, so mounted=true on render.
-    // We test the SSR contract by checking that the component only renders
-    // the dialog after the $effect fires (which is observable via DOM presence).
-    // The SSR model relies on $effect not running server-side — the test documents
-    // the contract; actual SSR behavior is verified by renderToString in a Node env.
+  // ---- 2. Post-hydration: dialog present (closed) once the $effect fires ----
+  test('dialog is present but closed after hydration when open=false', () => {
+    // In happy-dom $effect runs synchronously, so `hydrated` is true by the
+    // time we read the DOM and the dialog is mounted (but closed). The
+    // server-side absence of the dialog is asserted separately in the
+    // "Drawer SSR contract" describe block below.
     const { container } = render(Drawer, {
       props: { open: false, title: 'Test Drawer', children: emptySnippet },
     });
@@ -687,5 +691,33 @@ describe('Drawer', () => {
     });
     const closeButton = container.querySelector('.cinder-drawer__close');
     expect(closeButton?.getAttribute('aria-label')).toBe('Close drawer');
+  });
+});
+
+// The drawer's <dialog> is gated behind a `hydrated` $state set inside an
+// $effect, which never runs on the server. These tests render the component in
+// Svelte's server compiler and assert the gated markup is absent server-side —
+// the contract that prevents client-only dialog markup from leaking into SSR
+// and causing a hydration mismatch.
+describe('Drawer SSR contract', () => {
+  test('emits no <dialog> server-side even when open=true', async () => {
+    const html = await renderToServerHtml(DRAWER_SOURCE, {
+      open: true,
+      title: 'Test Drawer',
+      children: emptySnippet,
+    });
+    expect(html).not.toContain('<dialog');
+    expect(html).not.toContain('cinder-drawer');
+    expect(html).not.toContain('cinder-drawer__panel');
+  });
+
+  test('emits no <dialog> server-side when open=false', async () => {
+    const html = await renderToServerHtml(DRAWER_SOURCE, {
+      open: false,
+      title: 'Test Drawer',
+      children: emptySnippet,
+    });
+    expect(html).not.toContain('<dialog');
+    expect(html).not.toContain('cinder-drawer');
   });
 });

--- a/packages/components/src/components/image/image.test.ts
+++ b/packages/components/src/components/image/image.test.ts
@@ -1,9 +1,14 @@
 /// <reference lib="dom" />
+import { join } from 'node:path';
+
 import { afterEach, describe, expect, test } from 'bun:test';
 
 import { setupHappyDom } from '../../test/happy-dom.ts';
+import { renderToServerHtml } from '../../test/server-render.ts';
 
 setupHappyDom();
+
+const IMAGE_SOURCE = join(import.meta.dir, 'image.svelte');
 
 const { render, fireEvent, cleanup } = await import('@testing-library/svelte');
 const { default: Image } = await import('./image.svelte');
@@ -315,5 +320,36 @@ describe('Image', () => {
     const wrapper = container.querySelector('div.cinder-image');
     expect(wrapper?.className).toContain('cinder-image');
     expect(wrapper?.className).toContain('hero');
+  });
+});
+
+// Unlike the dialog overlays, Image renders its wrapper and <img> on the
+// server — only the load/error STATE is client-only. `loaded`/`errored` derive
+// from `loadedSource`/`erroredSource`, which start null, and the cached-image
+// probe runs inside the client-only `{@attach detectCached}`. So the server
+// HTML must contain the wrapper and image but none of the state markers
+// (`data-cinder-loaded`, `data-cinder-errored`, `data-cinder-fallback`) that
+// only the client can set — otherwise SSR would assert a load state that
+// hasn't happened yet and hydration would mismatch.
+describe('Image SSR contract', () => {
+  test('emits the wrapper and <img> server-side', async () => {
+    const html = await renderToServerHtml(IMAGE_SOURCE, { src: '/a.jpg', alt: 'A photo' });
+    expect(html).toContain('cinder-image');
+    expect(html).toContain('cinder-image__img');
+    expect(html).toContain('src="/a.jpg"');
+    expect(html).toContain('alt="A photo"');
+  });
+
+  test('omits client-only load/error state markers server-side', async () => {
+    const html = await renderToServerHtml(IMAGE_SOURCE, {
+      src: '/a.jpg',
+      alt: 'A photo',
+      placeholder: 'data:image/png;base64,iVBORw0KGgo=',
+    });
+    expect(html).not.toContain('data-cinder-loaded');
+    expect(html).not.toContain('data-cinder-errored');
+    expect(html).not.toContain('data-cinder-fallback');
+    // The placeholder background is still emitted because nothing has loaded.
+    expect(html).toContain('background-image');
   });
 });

--- a/packages/components/src/components/sheet/sheet.test.ts
+++ b/packages/components/src/components/sheet/sheet.test.ts
@@ -1,4 +1,6 @@
 /// <reference lib="dom" />
+import { join } from 'node:path';
+
 import { afterEach, describe, expect, test } from 'bun:test';
 import { createRawSnippet } from 'svelte';
 
@@ -10,6 +12,9 @@ import {
   OverflowFadeResizeObserver,
   setScrollMeasurements,
 } from '../../test/overflow-fade-test-helpers.ts';
+import { renderToServerHtml } from '../../test/server-render.ts';
+
+const SHEET_SOURCE = join(import.meta.dir, 'sheet.svelte');
 
 setupHappyDom();
 
@@ -779,5 +784,33 @@ describe('Sheet', () => {
     await fireEvent.keyDown(window, { key: 'Escape', code: 'Escape' });
     expect(siblingEscapeCount).toBe(2);
     releaseSiblingEscape();
+  });
+});
+
+// The sheet's <dialog> is gated behind a `hydrated` $state set inside an
+// $effect, which never runs on the server. These tests render the component in
+// Svelte's server compiler and assert the gated markup is absent server-side —
+// the contract that prevents client-only dialog markup from leaking into SSR
+// and causing a hydration mismatch.
+describe('Sheet SSR contract', () => {
+  test('emits no <dialog> server-side even when open=true', async () => {
+    const html = await renderToServerHtml(SHEET_SOURCE, {
+      open: true,
+      title: 'Test Sheet',
+      children: emptySnippet,
+    });
+    expect(html).not.toContain('<dialog');
+    expect(html).not.toContain('cinder-sheet');
+    expect(html).not.toContain('cinder-sheet__panel');
+  });
+
+  test('emits no <dialog> server-side when open=false', async () => {
+    const html = await renderToServerHtml(SHEET_SOURCE, {
+      open: false,
+      title: 'Test Sheet',
+      children: emptySnippet,
+    });
+    expect(html).not.toContain('<dialog');
+    expect(html).not.toContain('cinder-sheet');
   });
 });

--- a/packages/components/src/components/toast-region/toast-region.test.ts
+++ b/packages/components/src/components/toast-region/toast-region.test.ts
@@ -16,6 +16,13 @@ const { default: Wrapper } = await import('../../test/fixtures/toast-fixture.sve
 
 const TOAST_REGION_SOURCE = join(import.meta.dir, 'toast-region.svelte');
 const REPOSITORY_ROOT = join(import.meta.dir, '../../../../../');
+// Resolve Svelte's server index from this process so the SSR subprocess works
+// regardless of where `node_modules` lives — in a git worktree it is hoisted to
+// the monorepo root, so a `process.cwd()`-relative path would not find it.
+const SVELTE_SERVER_ENTRY = new URL(
+  './src/index-server.js',
+  import.meta.resolve('svelte/package.json'),
+).href;
 
 let mockedPerformanceNow = 0;
 
@@ -65,7 +72,7 @@ describe('ToastRegion structure', () => {
       const sourcePath = ${JSON.stringify(TOAST_REGION_SOURCE)};
       const source = await Bun.file(sourcePath).text();
       const compiled = compile(source, { filename: sourcePath, generate: 'server', css: 'external', dev: false });
-      const serverSvelteEntry = pathToFileURL(join(process.cwd(), 'node_modules/svelte/src/index-server.js')).href;
+      const serverSvelteEntry = ${JSON.stringify(SVELTE_SERVER_ENTRY)};
       const serverCode = compiled.js.code.replaceAll("from 'svelte';", \`from \${JSON.stringify(serverSvelteEntry)};\`);
       const file = join(dirname(sourcePath), \`.cinder-ssr-test-\${process.pid}-\${Date.now()}.mjs\`);
       await writeFile(file, serverCode, 'utf-8');

--- a/packages/components/src/test/index.ts
+++ b/packages/components/src/test/index.ts
@@ -19,3 +19,4 @@ export {
   type KeyModifiers,
 } from './keyboard.ts';
 export { expectNoLeakedTimers, trackTimers } from './lifecycle.ts';
+export { renderToServerHtml } from './server-render.ts';

--- a/packages/components/src/test/server-render.ts
+++ b/packages/components/src/test/server-render.ts
@@ -1,0 +1,87 @@
+/**
+ * Server-render test helper.
+ *
+ * Compiles a Svelte 5 component in `generate: 'server'` mode and returns the
+ * HTML the server would emit — without hydrating it on the client. Component
+ * tests use this to assert their SSR contract: that markup gated behind a
+ * client-only `hydrated` flag (drawer, sheet, toast-region) or behind a
+ * client-only load/error state (image) does NOT appear in the server output,
+ * so there is no hydration mismatch and no client-only markup leaks into SSR.
+ *
+ * Why we recompile inside the helper: the test runtime preloads the Bun Svelte
+ * plugin in `generate: 'client'` mode (see `scripts/preload.ts`). The client
+ * compilation cannot be fed to `svelte/server`'s `render()` — it expects a live
+ * effect tree. So this helper reads the `.svelte` source directly, compiles it
+ * with `generate: 'server'`, writes the JS to a temp file next to the source,
+ * dynamic-imports it, and feeds that into `render()`.
+ *
+ * Why we rewrite the bare `svelte` import: the test process runs under the
+ * `browser` export condition, which resolves `svelte` to its client build.
+ * Lifecycle helpers from the client build (`onDestroy`, etc.) throw when invoked
+ * during a server render. We rewrite the compiled module's `from 'svelte'`
+ * imports to point at Svelte's server index so those helpers resolve to their
+ * server-safe variants.
+ */
+
+/// <reference lib="dom" />
+
+import { rm, writeFile } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+
+import type { Component } from 'svelte';
+import { compile } from 'svelte/compiler';
+
+/**
+ * Render `sourcePath`'s component on the server and return the emitted HTML.
+ *
+ * @param sourcePath Absolute path to the component's `.svelte` file.
+ * @param props Props forwarded to the server render.
+ * @returns The server-emitted HTML body.
+ */
+export async function renderToServerHtml<Props extends Record<string, unknown>>(
+  sourcePath: string,
+  props: Props = {} as Props,
+): Promise<string> {
+  const source = await Bun.file(sourcePath).text();
+  const compiled = compile(source, {
+    filename: sourcePath,
+    generate: 'server',
+    css: 'external',
+    dev: false,
+  });
+
+  // Resolve Svelte's server index and repoint the compiled module's bare
+  // `svelte` imports at it. The temp module is imported in a `browser`-condition
+  // process, which would otherwise resolve `svelte` to its client build and make
+  // server-side lifecycle calls (`onDestroy`, `setContext`) throw.
+  const sveltePackageUrl = import.meta.resolve('svelte/package.json');
+  const serverIndexUrl = new URL('./src/index-server.js', sveltePackageUrl).href;
+  const code = compiled.js.code.replaceAll(
+    /from ['"]svelte['"]/g,
+    `from ${JSON.stringify(serverIndexUrl)}`,
+  );
+
+  // Write the compiled SSR module **in the same directory** as the source so its
+  // relative imports (e.g. `../../utilities/class-names.ts`) resolve identically,
+  // and `svelte/internal/server` still resolves through the package's node_modules
+  // tree. A `.mjs` extension keeps Bun's `.svelte.js` preload plugin from trying
+  // to recompile our already-compiled output.
+  const sourceDir = dirname(sourcePath);
+  const ssrFileName = `.cinder-ssr-${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2)}.mjs`;
+  const file = join(sourceDir, ssrFileName);
+  await writeFile(file, code, 'utf-8');
+
+  try {
+    // The SSR module's default export is a server-only render function whose
+    // shape doesn't match the public `Component<Props>` type. `render` accepts
+    // it at runtime; we route through `unknown` because the public types are too
+    // narrow to express the dual-target reality.
+    const ssrModule = (await import(file)) as { default: unknown };
+    const { render } = (await import('svelte/server')) as typeof import('svelte/server');
+    const { body } = render(ssrModule.default as Component<Props>, { props });
+    return body;
+  } finally {
+    // Best-effort cleanup of the temp module. A stray file never breaks a test.
+    void rm(file, { force: true }).catch(() => {});
+  }
+}

--- a/packages/components/src/test/server-render.ts
+++ b/packages/components/src/test/server-render.ts
@@ -78,8 +78,24 @@ export async function renderToServerHtml<Props extends Record<string, unknown>>(
     // narrow to express the dual-target reality.
     const ssrModule = (await import(file)) as { default: unknown };
     const { render } = (await import('svelte/server')) as typeof import('svelte/server');
-    const { body } = render(ssrModule.default as Component<Props>, { props });
-    return body;
+
+    // Clear happy-dom's `document`/`window` globals around the server render.
+    // The surrounding tests install them via `setupHappyDom()` at module scope,
+    // so without this a component that branches on `typeof document` would take
+    // the browser path during this supposedly server-only render — making the
+    // SSR contract assert markup that real SSR would never emit. Restore them in
+    // `finally` so the rest of the test sees its DOM again. Mirrors `hydrate.ts`.
+    const originalDocument = globalThis.document;
+    const originalWindow = globalThis.window;
+    globalThis.document = undefined as unknown as Document;
+    globalThis.window = undefined as unknown as Window & typeof globalThis;
+    try {
+      const { body } = render(ssrModule.default as Component<Props>, { props });
+      return body;
+    } finally {
+      globalThis.document = originalDocument;
+      globalThis.window = originalWindow;
+    }
   } finally {
     // Best-effort cleanup of the temp module. A stray file never breaks a test.
     void rm(file, { force: true }).catch(() => {});

--- a/packages/components/src/utilities/use-reduced-motion.svelte.test.ts
+++ b/packages/components/src/utilities/use-reduced-motion.svelte.test.ts
@@ -108,4 +108,18 @@ describe('useReducedMotion', () => {
 
     expect(motion.current).toBe(false);
   });
+
+  test('returns the false fallback without throwing when matchMedia is unavailable', () => {
+    // Simulates the SSR-contract path: the client `MediaQuery` build is loaded
+    // (browser export condition) but there is no DOM, so `window.matchMedia` is
+    // missing. The hook must not call the throwing client constructor.
+    const original = window.matchMedia;
+    delete (window as { matchMedia?: typeof window.matchMedia }).matchMedia;
+    try {
+      const motion = useReducedMotion();
+      expect(motion.current).toBe(false);
+    } finally {
+      window.matchMedia = original;
+    }
+  });
 });

--- a/packages/components/src/utilities/use-reduced-motion.svelte.ts
+++ b/packages/components/src/utilities/use-reduced-motion.svelte.ts
@@ -11,7 +11,9 @@ export type UseReducedMotion = {
  * preference changes.
  *
  * SSR-safe: on the server, `svelte/reactivity` resolves to a stub that returns
- * `false` because the user's preference is unavailable. Use this hook for
+ * `false` because the user's preference is unavailable. As a defensive backstop
+ * for environments where the client build is loaded without a DOM, the hook also
+ * returns `false` when `window.matchMedia` is unavailable. Use this hook for
  * client-side imperative behavior; keep SSR-visible presentation in CSS media
  * queries and duration tokens.
  *
@@ -36,6 +38,17 @@ export type UseReducedMotion = {
  * ```
  */
 export function useReducedMotion(): UseReducedMotion {
+  // On the server, `svelte/reactivity` resolves to a stub whose `MediaQuery`
+  // never touches `window`. But when the *client* build of `MediaQuery` is
+  // loaded in a context without a DOM (e.g. our SSR-contract test harness runs
+  // under the `browser` export condition yet clears `window` to exercise the
+  // true server path), its constructor would call `window.matchMedia` and throw.
+  // Guard on `matchMedia` so the documented SSR-safe `false` fallback holds
+  // regardless of which `MediaQuery` build module resolution selected.
+  if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+    return { current: false };
+  }
+
   // Pass the parenthesized form explicitly. MediaQuery's constructor regex
   // /\(.+\)/ passes parenthesized strings verbatim to window.matchMedia, so
   // "(prefers-reduced-motion: reduce)" matches the @media guards already used


### PR DESCRIPTION
Reviewed by the workflow's adversarial subagent committee (correctness / testing / typescript). Green through the full pre-push gate. Part of the Group A batch (test/refactor tasks, no generated-file changes).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly new/updated tests and a small defensive hook guard; no production API or auth/data-path changes beyond safer reduced-motion fallback.
> 
> **Overview**
> Adds a shared **`renderToServerHtml`** test helper that server-compiles `.svelte` sources (with Svelte server import rewriting and temporary clearing of `window`/`document`) and uses it to lock in **SSR contracts** for **Drawer**, **Sheet**, and **Image**—dialog overlays must not emit `<dialog>` / overlay markup on the server; **Image** must emit wrapper/`<img>` but not client-only `data-cinder-*` load/error markers.
> 
> **Drawer** client test copy is clarified to separate post-hydration behavior from server absence. **Toast-region**’s inline SSR subprocess now resolves the Svelte server entry via **`import.meta.resolve`** so SSR tests work when `node_modules` is hoisted. **`useReducedMotion`** gains a defensive guard (and test) when `matchMedia` is missing so SSR-style harnesses don’t throw.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 30b9c6c494a8bf6deaeece7954fbad86814baca2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->