### PR TITLE
test: verify SSR-safety of @cinder/commentary and @cinder/markdown

### DIFF
--- a/packages/commentary/src/anchor-decorations.ts
+++ b/packages/commentary/src/anchor-decorations.ts
@@ -8,6 +8,17 @@
  * - Auto-deletes threads when their anchor text is removed
  *
  * @module
+ *
+ * SSR safety: the `@milkdown/kit/prose/*` value imports below resolve to
+ * prosemirror-state and prosemirror-view. They are imported STATICALLY — and
+ * deliberately so — because prosemirror is SSR-safe at module-evaluation time:
+ * `prosemirror-view` reads `document`/`navigator` only behind
+ * `typeof X !== 'undefined'` guards, so on the server (where those globals are
+ * absent) it falls back to null/"" rather than throwing. There is therefore
+ * nothing to defer behind a runtime browser guard at this layer; the SSR
+ * boundary lives in the consuming Svelte component (MarkdownEditor mounts the
+ * live editor inside `{#if browser}`). This invariant is enforced by
+ * `src/ssr-import.test.ts`.
  */
 
 import type { EditorState, Transaction } from '@milkdown/kit/prose/state';

--- a/packages/commentary/src/ssr-import.test.ts
+++ b/packages/commentary/src/ssr-import.test.ts
@@ -1,0 +1,99 @@
+/**
+ * @cinder/commentary SSR import safety.
+ *
+ * Mirrors `packages/editor/src/ssr-import.test.ts`. The contract this guards:
+ * importing any entry point of `@cinder/commentary` in a server (no-DOM)
+ * context must NOT touch a browser-only global at module-evaluation time.
+ *
+ * Why this matters: ReviewEditor statically imports the commentary anchoring
+ * and decoration surfaces (`@cinder/commentary/anchor-decorations`,
+ * `@cinder/commentary/anchoring`, `@cinder/commentary/comments`). Those static
+ * imports execute during SSR, so any module-eval-time `document`/`window`/
+ * `getSelection` access would throw on the server before a fallback skeleton
+ * could render.
+ *
+ * BROWSER-BOUND DEPENDENCY — the deliberate, SSR-safe exception:
+ * `anchor-decorations.ts` is the ProseMirror plugin layer for comment anchors.
+ * It statically value-imports `@milkdown/kit/prose/state` and
+ * `@milkdown/kit/prose/view` (which re-export prosemirror-state and
+ * prosemirror-view). That is the SAME legitimate pattern as @cinder/editor:
+ * this module IS the browser-side editor layer, and a *static* import is
+ * correct because prosemirror itself is SSR-safe at module-evaluation time —
+ * `prosemirror-view` reads `document`/`navigator` only behind
+ * `typeof X !== 'undefined'` guards, so when those globals are absent it
+ * falls back to null/"" rather than throwing. There is therefore nothing to
+ * defer behind a runtime browser guard at this layer; the SSR boundary lives
+ * in the consuming Svelte component (MarkdownEditor mounts the live editor
+ * inside `{#if browser}`).
+ *
+ * Approach (matching @cinder/editor): the DOM-only globals are *deleted*
+ * before each dynamic import so the test models a genuine Node SSR
+ * environment where `document`/`window` do not exist and prosemirror's
+ * `typeof`-guarded reads resolve to the safe branch. `navigator` is left in
+ * place because Node and Bun both define it and prosemirror reads it
+ * defensively; deleting it would model an environment that does not occur in
+ * practice. NOTE: this package preloads happy-dom (see bunfig.toml), so these
+ * globals are present unless explicitly removed here — deletion is what makes
+ * the assertion meaningful.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+
+// Browser-only globals that are genuinely absent in a Node SSR context.
+const SSR_ABSENT_GLOBALS = ['document', 'window', 'getSelection'] as const;
+
+const savedDescriptors: { name: string; descriptor: PropertyDescriptor | undefined }[] = [];
+
+function removeBrowserGlobals(): void {
+  savedDescriptors.length = 0;
+  for (const name of SSR_ABSENT_GLOBALS) {
+    savedDescriptors.push({ name, descriptor: Object.getOwnPropertyDescriptor(globalThis, name) });
+    Reflect.deleteProperty(globalThis, name);
+  }
+}
+
+function restoreBrowserGlobals(): void {
+  for (const { name, descriptor } of savedDescriptors) {
+    if (descriptor) Object.defineProperty(globalThis, name, descriptor);
+  }
+  savedDescriptors.length = 0;
+}
+
+beforeEach(removeBrowserGlobals);
+afterEach(restoreBrowserGlobals);
+
+describe('@cinder/commentary SSR import safety', () => {
+  it('imports the package barrel without needing browser globals', async () => {
+    // The barrel re-exports `anchor-decorations`, which transitively pulls in
+    // prosemirror-view. This assertion therefore also proves that the
+    // prosemirror dependency is SSR-safe at module-evaluation time.
+    const commentaryModule = await import('./index.js');
+    expect(typeof commentaryModule.generateBlockId).toBe('function');
+    expect(typeof commentaryModule.createAnchorPlugin).toBe('function');
+  });
+
+  it('imports the anchor-decorations subpath (prosemirror layer) without needing browser globals', async () => {
+    const anchorDecorationsModule = await import('./anchor-decorations.js');
+    expect(typeof anchorDecorationsModule.createAnchorPlugin).toBe('function');
+  });
+
+  it('imports the anchoring subpath without needing browser globals', async () => {
+    const anchoringModule = await import('./anchoring.js');
+    expect(typeof anchoringModule.generateBlockId).toBe('function');
+  });
+
+  it('imports the comments subpath without needing browser globals', async () => {
+    const commentsModule = await import('./comments/index.js');
+    expect(typeof commentsModule.extractMentions).toBe('function');
+  });
+
+  it('imports the session subpath without needing browser globals', async () => {
+    const sessionModule = await import('./session/index.js');
+    expect(typeof sessionModule.createSession).toBe('function');
+  });
+
+  it('imports the export subpath without needing browser globals', async () => {
+    const exportModule = await import('./export/index.js');
+    expect(typeof exportModule.generateMarkdownSummary).toBe('function');
+  });
+});

--- a/packages/components/src/components/chat/message/markdown-preview.ssr.test.ts
+++ b/packages/components/src/components/chat/message/markdown-preview.ssr.test.ts
@@ -1,0 +1,110 @@
+/// <reference lib="dom" />
+
+/**
+ * Chat markdown-preview SSR-safety contract.
+ *
+ * The chat surface renders message bodies through `markdown-preview.svelte`,
+ * which is where `@cinder/markdown`'s rendering pipeline (shiki/rehype/katex)
+ * enters the component tree. That pipeline is SSR-safe at module-evaluation
+ * time (see `packages/markdown/src/ssr-import.test.ts`), so the only remaining
+ * SSR concern is that the *runtime* render — which calls
+ * `renderMarkdownWithMath` and touches the DOM via `{@html}` — must not run on
+ * the server.
+ *
+ * markdown-preview.svelte satisfies this by:
+ *   - importing the rendering pipeline DYNAMICALLY inside a `$effect`
+ *     (`import('cinder/markdown/rendering')`), never statically — `$effect`
+ *     bodies never run during SSR, so the import is never evaluated on the
+ *     server, and the heavy rendering graph stays out of the SSR path; and
+ *   - rendering a raw-text fallback (`<p>{content}</p>`) in the `{:else}`
+ *     branch, so the server emits the message text without throwing and the
+ *     client swaps in formatted HTML after hydration.
+ *
+ * Unlike `markdown-editor.svelte` — whose live-editor branch pulls in
+ * `cinder/editor/component-runtime` (ProseMirror) and so cannot be exercised
+ * by `renderThenHydrate` (the recompiled SSR module resolves that import
+ * against a missing "node"-conditional dist, producing `effect_orphan`) —
+ * markdown-preview has no child components and no static cinder/editor import.
+ * Its only heavy dependency is reached through a dynamic import inside an
+ * `$effect`, which never runs during SSR. We therefore verify the SSR contract
+ * by actually rendering on the server via `renderThenHydrate` and asserting on
+ * the produced markup, the same pattern `portal.test.ts` uses for its
+ * SSR-omission contract.
+ */
+
+import { describe, expect, test } from 'bun:test';
+
+import { renderThenHydrate } from '../../../test/hydrate.ts';
+
+const { default: MarkdownPreview } = await import('./markdown-preview.svelte');
+
+const sourcePath = new URL('./markdown-preview.svelte', import.meta.url).pathname;
+
+describe('Chat markdown-preview SSR contract', () => {
+  test('server-renders the raw-text fallback for the message content', async () => {
+    // The `$effect` that populates `renderedHtml` never runs on the server, so
+    // `renderedHtml` stays '' and the `{:else}` branch emits the raw content as
+    // a paragraph — without throwing and without importing the rendering graph.
+    const result = await renderThenHydrate(MarkdownPreview, sourcePath, {
+      content: 'hello world',
+    });
+
+    try {
+      expect(result.ssrHtml).toContain(
+        '<div class="cinder-markdown-content message-content-preview">',
+      );
+      expect(result.ssrHtml).toContain('<p>hello world</p>');
+    } finally {
+      result.cleanup();
+    }
+  });
+
+  test('does not emit rendered {@html} markdown output on the server', async () => {
+    // `**bold**` would become `<strong>bold</strong>` once the client pipeline
+    // runs. On the server the `{#if renderedHtml}` branch is never taken, so the
+    // markdown source is emitted verbatim inside the `<p>` fallback and the
+    // rendered `<strong>` markup is absent.
+    const result = await renderThenHydrate(MarkdownPreview, sourcePath, {
+      content: '**bold**',
+    });
+
+    try {
+      expect(result.ssrHtml).toContain('<p>**bold**</p>');
+      expect(result.ssrHtml).not.toContain('<strong>');
+    } finally {
+      result.cleanup();
+    }
+  });
+
+  test('escapes HTML-special characters in the server-rendered fallback', async () => {
+    // The fallback is a plain `{content}` text interpolation, so Svelte escapes
+    // the opening `<` to `&lt;`. This proves the server path emits *text*,
+    // never an unescaped `{@html}` injection of the raw message body — the
+    // `<img>` tag is neutralized and cannot execute its `onerror` handler.
+    const result = await renderThenHydrate(MarkdownPreview, sourcePath, {
+      content: '<img src=x onerror=alert(1)>',
+    });
+
+    try {
+      expect(result.ssrHtml).toContain('&lt;img src=x onerror=alert(1)>');
+      expect(result.ssrHtml).not.toContain('<img src=x onerror=alert(1)>');
+    } finally {
+      result.cleanup();
+    }
+  });
+
+  test('hydrates the server markup without warnings', async () => {
+    // A clean hydrate (no mismatch warnings) confirms the SSR output and the
+    // client's first render agree: both produce the raw-text fallback, and the
+    // dynamic-import effect only swaps in formatted HTML on a later frame.
+    const result = await renderThenHydrate(MarkdownPreview, sourcePath, {
+      content: 'hello world',
+    });
+
+    try {
+      expect(result.warnings).toEqual([]);
+    } finally {
+      result.cleanup();
+    }
+  });
+});

--- a/packages/components/src/components/review-editor/review-editor.ssr.test.ts
+++ b/packages/components/src/components/review-editor/review-editor.ssr.test.ts
@@ -28,17 +28,214 @@
  * client compilation, producing `effect_orphan`). We therefore verify the SSR
  * contract at the source level, the established convention for these
  * editor-heavy components.
+ *
+ * Verification is performed against the parsed AST (via `svelte/compiler`)
+ * rather than raw-source regex/`indexOf`. The AST distinguishes value imports
+ * from fully-erased type-only imports and locates the `window.getSelection()`
+ * call structurally, so the contract checks do not produce false positives
+ * from `import { type Foo }` specifiers or from `getSelection` mentions inside
+ * comments.
  */
 
 import { describe, expect, test } from 'bun:test';
+import { parse } from 'svelte/compiler';
 
-const WRAPPER_SOURCE = await Bun.file(
-  new URL('./review-editor.svelte', import.meta.url).pathname,
-).text();
+// Runtime packages whose entry points reach for browser globals. A static
+// value import of any of these at the component layer would be a new,
+// unaudited SSR-unsafe entry point. Mirrors the protected set in
+// `markdown-editor.import-boundary.test.ts`.
+const PROTECTED_PREFIXES = ['@milkdown/', 'prosemirror-'] as const;
 
-const IMPL_SOURCE = await Bun.file(
-  new URL('./review-editor-impl.svelte', import.meta.url).pathname,
-).text();
+function isProtected(specifier: string): boolean {
+  return PROTECTED_PREFIXES.some((prefix) => specifier.startsWith(prefix));
+}
+
+// ---------------------------------------------------------------------------
+// Minimal AST helpers (svelte/compiler returns acorn-compatible ESTree)
+// ---------------------------------------------------------------------------
+type AstNode = Record<string, unknown>;
+
+function isNode(value: unknown): value is AstNode {
+  return typeof value === 'object' && value !== null && 'type' in value;
+}
+
+function scriptBody(ast: AstNode, block: 'module' | 'instance'): AstNode[] {
+  const content = (ast[block] as AstNode | undefined)?.['content'] as AstNode | undefined;
+  return (content?.['body'] as AstNode[] | undefined) ?? [];
+}
+
+// ---------------------------------------------------------------------------
+// Static import analysis: a protected import is a runtime (SSR-relevant)
+// import only when it brings at least one *value* binding into scope.
+//
+//   import type { Foo } from 'prosemirror-view'   -> declaration importKind 'type', erased
+//   import { type Foo } from 'prosemirror-view'   -> per-specifier importKind 'type', erased
+//   import { type Foo, bar } from 'prosemirror-…' -> `bar` is a value binding, NOT erased
+//   import Foo / import * as Foo from 'prosemirror-…' -> default/namespace value bindings
+// ---------------------------------------------------------------------------
+function hasRuntimeValueBinding(declaration: AstNode): boolean {
+  // `import type { … }` / `import type Foo` — whole declaration is type-only.
+  if (declaration['importKind'] === 'type') return false;
+
+  const specifiers = (declaration['specifiers'] as AstNode[] | undefined) ?? [];
+
+  // A bare side-effect import (`import 'pkg'`) still evaluates the module at
+  // runtime, so treat it as a runtime import.
+  if (specifiers.length === 0) return true;
+
+  return specifiers.some((specifier) => {
+    // Default and namespace specifiers are always value bindings.
+    if (specifier['type'] !== 'ImportSpecifier') return true;
+    // Inline `import { type Foo }` specifiers are erased.
+    return specifier['importKind'] !== 'type';
+  });
+}
+
+function collectProtectedRuntimeImports(statements: AstNode[]): string[] {
+  const violations: string[] = [];
+  for (const statement of statements) {
+    if (statement['type'] !== 'ImportDeclaration') continue;
+    const source = (statement['source'] as AstNode | undefined)?.['value'];
+    if (typeof source !== 'string' || !isProtected(source)) continue;
+    if (hasRuntimeValueBinding(statement)) {
+      violations.push(source);
+    }
+  }
+  return violations;
+}
+
+// ---------------------------------------------------------------------------
+// Guarded-effect detection: locate `$effect(() => { … })` calls whose body
+// opens with `if (typeof document === 'undefined') return;`, and report which
+// of those effects contain a `window.getSelection()` call expression.
+// ---------------------------------------------------------------------------
+
+/** `if (typeof document === 'undefined') return;` as the first statement. */
+function isTypeofDocumentReturnGuard(statement: AstNode | undefined): boolean {
+  if (!statement || statement['type'] !== 'IfStatement') return false;
+
+  const testExpression = statement['test'];
+  if (
+    !isNode(testExpression) ||
+    testExpression['type'] !== 'BinaryExpression' ||
+    testExpression['operator'] !== '==='
+  ) {
+    return false;
+  }
+
+  const left = testExpression['left'];
+  const right = testExpression['right'];
+  const argument = isNode(left) ? left['argument'] : undefined;
+  const isTypeofDocument =
+    isNode(left) &&
+    left['type'] === 'UnaryExpression' &&
+    left['operator'] === 'typeof' &&
+    isNode(argument) &&
+    argument['type'] === 'Identifier' &&
+    argument['name'] === 'document';
+  const isUndefinedLiteral =
+    isNode(right) && right['type'] === 'Literal' && right['value'] === 'undefined';
+  if (!isTypeofDocument || !isUndefinedLiteral) return false;
+
+  // The guard must early-return (not fall through to an else branch).
+  const consequent = statement['consequent'] as AstNode | undefined;
+  if (statement['alternate']) return false;
+  if (consequent && consequent['type'] === 'ReturnStatement') return true;
+  if (consequent && consequent['type'] === 'BlockStatement') {
+    const inner = (consequent['body'] as AstNode[] | undefined)?.[0];
+    return !!inner && inner['type'] === 'ReturnStatement';
+  }
+  return false;
+}
+
+/** Recursively detect a `window.getSelection()` call expression. */
+function containsWindowGetSelectionCall(node: unknown): boolean {
+  if (!isNode(node)) {
+    if (Array.isArray(node)) return node.some(containsWindowGetSelectionCall);
+    return false;
+  }
+
+  if (node['type'] === 'CallExpression') {
+    const callee = node['callee'];
+    if (isNode(callee) && callee['type'] === 'MemberExpression') {
+      const object = callee['object'];
+      const property = callee['property'];
+      if (
+        isNode(object) &&
+        object['type'] === 'Identifier' &&
+        object['name'] === 'window' &&
+        isNode(property) &&
+        property['type'] === 'Identifier' &&
+        property['name'] === 'getSelection'
+      ) {
+        return true;
+      }
+    }
+  }
+
+  for (const key of Object.keys(node)) {
+    if (key === 'type' || key === 'start' || key === 'end' || key === 'loc') continue;
+    if (containsWindowGetSelectionCall(node[key])) return true;
+  }
+  return false;
+}
+
+type EffectInfo = { hasTypeofDocumentGuard: boolean; callsWindowGetSelection: boolean };
+
+/** Find every `$effect(() => { … })` arrow-callback effect in the AST. */
+function findEffects(node: unknown, out: EffectInfo[]): void {
+  if (!isNode(node)) {
+    if (Array.isArray(node)) for (const item of node) findEffects(item, out);
+    return;
+  }
+
+  if (node['type'] === 'CallExpression') {
+    const callee = node['callee'];
+    const args = (node['arguments'] as AstNode[] | undefined) ?? [];
+    const callback = args[0];
+    if (
+      isNode(callee) &&
+      callee['type'] === 'Identifier' &&
+      callee['name'] === '$effect' &&
+      callback &&
+      callback['type'] === 'ArrowFunctionExpression' &&
+      isNode(callback['body']) &&
+      callback['body']['type'] === 'BlockStatement'
+    ) {
+      const callbackBody = callback['body'];
+      const body = callbackBody['body'] as AstNode[] | undefined;
+      out.push({
+        hasTypeofDocumentGuard: isTypeofDocumentReturnGuard(body?.[0]),
+        callsWindowGetSelection: containsWindowGetSelectionCall(callbackBody),
+      });
+    }
+  }
+
+  for (const key of Object.keys(node)) {
+    if (key === 'type' || key === 'start' || key === 'end' || key === 'loc') continue;
+    findEffects(node[key], out);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Load and parse the wrapper + implementation sources
+// ---------------------------------------------------------------------------
+const WRAPPER_PATH = new URL('./review-editor.svelte', import.meta.url).pathname;
+const IMPL_PATH = new URL('./review-editor-impl.svelte', import.meta.url).pathname;
+
+const WRAPPER_SOURCE = await Bun.file(WRAPPER_PATH).text();
+const IMPL_SOURCE = await Bun.file(IMPL_PATH).text();
+
+const implAst = parse(IMPL_SOURCE, { filename: IMPL_PATH }) as unknown as AstNode;
+const implStatements = [...scriptBody(implAst, 'module'), ...scriptBody(implAst, 'instance')];
+
+const protectedRuntimeImports = collectProtectedRuntimeImports(implStatements);
+
+const effects: EffectInfo[] = [];
+findEffects(implAst['instance'], effects);
+const guardedSelectionEffects = effects.filter(
+  (effect) => effect.hasTypeofDocumentGuard && effect.callsWindowGetSelection,
+);
 
 describe('ReviewEditor SSR contract (source-level verification)', () => {
   test('renders through MarkdownEditor, inheriting its server-side skeleton fallback', () => {
@@ -49,30 +246,22 @@ describe('ReviewEditor SSR contract (source-level verification)', () => {
     expect(IMPL_SOURCE).toContain('<MarkdownEditor');
   });
 
-  test('statically imports only SSR-safe package surfaces (no @milkdown/ or prosemirror- at this layer)', () => {
+  test('statically imports only SSR-safe package surfaces (no @milkdown/ or prosemirror- value import at this layer)', () => {
     // ReviewEditor reaches ProseMirror only through cinder/commentary's
-    // anchor-decorations re-export, which is SSR-safe at module-eval time.
-    // A direct static @milkdown/ or prosemirror- value import at the component
-    // layer would be a new, unaudited browser-bound entry point.
-    const protectedStaticImport =
-      /import\s+(?!type\b)[\s\S]*?\s+from\s+['"](?:@milkdown\/|prosemirror-)/;
-    expect(IMPL_SOURCE).not.toMatch(protectedStaticImport);
+    // anchor-decorations re-export, which is SSR-safe at module-eval time. A
+    // direct static @milkdown/ or prosemirror- *value* import at the component
+    // layer would be a new, unaudited browser-bound entry point. Type-only
+    // imports (`import type` and `import { type … }`) are erased at runtime and
+    // therefore not violations.
+    expect(protectedRuntimeImports).toEqual([]);
   });
 
-  test('guards DOM access (window.getSelection / document) behind $effect', () => {
+  test('guards window.getSelection() behind a $effect with a typeof-document SSR guard', () => {
     // Every browser-global access in the implementation must sit inside an
-    // $effect so it never runs during SSR. Confirm the selection-change effect
-    // — the component's primary DOM consumer — exists and is effect-scoped.
-    expect(IMPL_SOURCE).toContain('window.getSelection()');
-    const effectStart = IMPL_SOURCE.indexOf('$effect(() => {\n    if (typeof document ===');
-    expect(effectStart).toBeGreaterThan(-1);
-  });
-
-  test('selection-change effect carries an explicit typeof-document SSR guard', () => {
-    // Belt-and-suspenders: even though effects do not run on the server, the
-    // DOM-listener effect early-returns when `document` is undefined.
-    expect(IMPL_SOURCE).toMatch(
-      /\$effect\(\(\) => \{\s*\n\s*if \(typeof document === 'undefined'\) return;/,
-    );
+    // $effect so it never runs during SSR. The selection-change effect — the
+    // component's primary DOM consumer — must both call window.getSelection()
+    // and early-return when `document` is undefined. We assert the structural
+    // co-location via the AST so the check cannot be satisfied by a comment.
+    expect(guardedSelectionEffects.length).toBeGreaterThan(0);
   });
 });

--- a/packages/components/src/components/review-editor/review-editor.ssr.test.ts
+++ b/packages/components/src/components/review-editor/review-editor.ssr.test.ts
@@ -1,0 +1,78 @@
+/**
+ * ReviewEditor SSR-safety contract (source-level verification).
+ *
+ * ReviewEditor is MarkdownEditor extended with anchored comment threads. Its
+ * SSR story has two layers:
+ *
+ *   1. The live ProseMirror editor is owned by the inner MarkdownEditor, which
+ *      mounts it inside `{#if browser}` and renders `<EditorSkeleton>` on the
+ *      server (verified in `markdown-editor.hydrate.test.ts`). ReviewEditor
+ *      forwards to that component, so it inherits the server-side skeleton
+ *      fallback for free.
+ *
+ *   2. ReviewEditor's own logic statically imports the commentary and markdown
+ *      surfaces (`cinder/commentary/anchor-decorations`, `cinder/markdown/
+ *      pipeline`, `cinder/markdown/diff/line-diff`, `cinder/editor`). Those are
+ *      all SSR-safe at module-evaluation time — proven by
+ *      `packages/commentary/src/ssr-import.test.ts` and
+ *      `packages/markdown/src/ssr-import.test.ts` — so the static imports do
+ *      not throw during SSR. The only DOM access in this layer
+ *      (`document.*`, `window.getSelection()`) lives inside `$effect` bodies,
+ *      which never run on the server; the selection-change effect additionally
+ *      carries an explicit `if (typeof document === 'undefined') return;`
+ *      guard as defense in depth.
+ *
+ * Full SSR-render + hydrate of ReviewEditor is blocked in the Bun test harness
+ * for the reason documented in `markdown-editor.hydrate.test.ts` (the
+ * recompiled server module resolves its child-component imports against the
+ * client compilation, producing `effect_orphan`). We therefore verify the SSR
+ * contract at the source level, the established convention for these
+ * editor-heavy components.
+ */
+
+import { describe, expect, test } from 'bun:test';
+
+const WRAPPER_SOURCE = await Bun.file(
+  new URL('./review-editor.svelte', import.meta.url).pathname,
+).text();
+
+const IMPL_SOURCE = await Bun.file(
+  new URL('./review-editor-impl.svelte', import.meta.url).pathname,
+).text();
+
+describe('ReviewEditor SSR contract (source-level verification)', () => {
+  test('renders through MarkdownEditor, inheriting its server-side skeleton fallback', () => {
+    // The public wrapper forwards to the implementation, and the
+    // implementation renders MarkdownEditor — the component that provides the
+    // `{#if browser}` → `<EditorSkeleton>` SSR fallback.
+    expect(WRAPPER_SOURCE).toContain('ReviewEditorImplementation');
+    expect(IMPL_SOURCE).toContain('<MarkdownEditor');
+  });
+
+  test('statically imports only SSR-safe package surfaces (no @milkdown/ or prosemirror- at this layer)', () => {
+    // ReviewEditor reaches ProseMirror only through cinder/commentary's
+    // anchor-decorations re-export, which is SSR-safe at module-eval time.
+    // A direct static @milkdown/ or prosemirror- value import at the component
+    // layer would be a new, unaudited browser-bound entry point.
+    const protectedStaticImport =
+      /import\s+(?!type\b)[\s\S]*?\s+from\s+['"](?:@milkdown\/|prosemirror-)/;
+    expect(IMPL_SOURCE).not.toMatch(protectedStaticImport);
+  });
+
+  test('guards DOM access (window.getSelection / document) behind $effect', () => {
+    // Every browser-global access in the implementation must sit inside an
+    // $effect so it never runs during SSR. Confirm the selection-change effect
+    // — the component's primary DOM consumer — exists and is effect-scoped.
+    expect(IMPL_SOURCE).toContain('window.getSelection()');
+    const effectStart = IMPL_SOURCE.indexOf('$effect(() => {\n    if (typeof document ===');
+    expect(effectStart).toBeGreaterThan(-1);
+  });
+
+  test('selection-change effect carries an explicit typeof-document SSR guard', () => {
+    // Belt-and-suspenders: even though effects do not run on the server, the
+    // DOM-listener effect early-returns when `document` is undefined.
+    expect(IMPL_SOURCE).toMatch(
+      /\$effect\(\(\) => \{\s*\n\s*if \(typeof document === 'undefined'\) return;/,
+    );
+  });
+});

--- a/packages/markdown/src/ssr-import.test.ts
+++ b/packages/markdown/src/ssr-import.test.ts
@@ -1,0 +1,79 @@
+/**
+ * @cinder/markdown SSR import safety.
+ *
+ * Mirrors `packages/editor/src/ssr-import.test.ts`. The contract this guards:
+ * importing any entry point of `@cinder/markdown` in a server (no-DOM)
+ * context must NOT touch a browser-only global at module-evaluation time.
+ *
+ * Why this matters: ReviewEditor and Chat statically import markdown
+ * utilities (`@cinder/markdown/pipeline`, `@cinder/markdown/diff`,
+ * `@cinder/markdown/rendering`). Those static imports execute during SSR, so
+ * any module-eval-time `document`/`window`/`getSelection` access would throw
+ * on the server before a fallback could render.
+ *
+ * Unlike @cinder/editor, this package depends on NONE of the browser-bound
+ * packages (@milkdown/, prosemirror-). Its parsing stack is remark/unified,
+ * which is SSR-safe, and its rendering stack (shiki/rehype/katex) defers all
+ * DOM and Web Worker work behind runtime guards (see
+ * `rendering/render-async.ts`, which only constructs a `Worker` inside
+ * `getProxy()` after a `typeof Worker === 'undefined' || typeof window ===
+ * 'undefined'` check). So the only invariant to enforce here is the
+ * module-eval one.
+ *
+ * Approach (matching @cinder/editor): the DOM-only globals are *deleted*
+ * before each dynamic import — not replaced with throwing stubs — so the test
+ * models a genuine Node SSR environment where `document`/`window` simply do
+ * not exist and `typeof` checks resolve to `'undefined'`. `navigator` is left
+ * in place because Node and Bun both define it and SSR-safe libraries read it
+ * defensively behind `typeof navigator !== 'undefined'`; deleting it would
+ * model an environment that does not occur in practice.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+
+// Browser-only globals that are genuinely absent in a Node SSR context.
+const SSR_ABSENT_GLOBALS = ['document', 'window', 'getSelection'] as const;
+
+const savedDescriptors: { name: string; descriptor: PropertyDescriptor | undefined }[] = [];
+
+function removeBrowserGlobals(): void {
+  savedDescriptors.length = 0;
+  for (const name of SSR_ABSENT_GLOBALS) {
+    savedDescriptors.push({ name, descriptor: Object.getOwnPropertyDescriptor(globalThis, name) });
+    Reflect.deleteProperty(globalThis, name);
+  }
+}
+
+function restoreBrowserGlobals(): void {
+  for (const { name, descriptor } of savedDescriptors) {
+    if (descriptor) Object.defineProperty(globalThis, name, descriptor);
+  }
+  savedDescriptors.length = 0;
+}
+
+beforeEach(removeBrowserGlobals);
+afterEach(restoreBrowserGlobals);
+
+describe('@cinder/markdown SSR import safety', () => {
+  it('imports the package barrel without needing browser globals', async () => {
+    const markdownModule = await import('./index.js');
+    expect(typeof markdownModule.diff).toBe('object');
+    expect(typeof markdownModule.pipeline).toBe('object');
+  });
+
+  it('imports the pipeline subpath without needing browser globals', async () => {
+    const pipelineModule = await import('./pipeline/index.js');
+    expect(typeof pipelineModule.normalize).toBe('function');
+    expect(typeof pipelineModule.contentEquals).toBe('function');
+  });
+
+  it('imports the diff subpath without needing browser globals', async () => {
+    const diffModule = await import('./diff/index.js');
+    expect(typeof diffModule.computeLineDiff).toBe('function');
+  });
+
+  it('imports the rendering subpath without needing browser globals', async () => {
+    const renderingModule = await import('./rendering/index.js');
+    expect(typeof renderingModule.renderMarkdown).toBe('function');
+  });
+});


### PR DESCRIPTION
Reviewed by the workflow's adversarial subagent committee (correctness / testing / typescript). Green through the full pre-push gate. Part of the Group A batch (test/refactor tasks, no generated-file changes).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test and documentation only; no production behavior changes beyond comments in anchor-decorations.
> 
> **Overview**
> Adds **SSR safety contracts** across `@cinder/commentary`, `@cinder/markdown`, and key Svelte surfaces so server rendering cannot break when those modules are statically imported.
> 
> **Package-level import tests** (mirroring `@cinder/editor`): new `ssr-import.test.ts` files delete `document` / `window` / `getSelection` before dynamic imports and assert barrel and subpath entry points load without throwing. Commentary’s test explicitly covers the ProseMirror path via `anchor-decorations`.
> 
> **Component contracts**: `markdown-preview.ssr.test.ts` uses `renderThenHydrate` to assert the server shows raw `<p>{content}</p>` (no formatted `{@html}`, escaped HTML) and hydrates cleanly. `review-editor.ssr.test.ts` parses `review-editor-impl.svelte` with the Svelte compiler AST to forbid runtime `@milkdown/` / `prosemirror-` imports at the component layer and to require `window.getSelection()` inside a `$effect` guarded by `typeof document === 'undefined'`.
> 
> **Docs**: `anchor-decorations.ts` gains a module comment explaining why static ProseMirror imports are intentional and where the real SSR boundary lives (`{#if browser}` in `MarkdownEditor`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2b5827ea73d2299a649a0e0add2b7064230416ef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->