### PR TITLE
test(testing): make broad axe sweep fail on critical/serious violations

### DIFF
--- a/packages/playground/src/examples/drawer/basic.example.svelte
+++ b/packages/playground/src/examples/drawer/basic.example.svelte
@@ -22,7 +22,7 @@
       <select
         value={side}
         onchange={(e) => (side = (e.currentTarget as HTMLSelectElement).value as DrawerSide)}
-        style="padding: 0.25rem 0.5rem; border-radius: 0.375rem; border: 1px solid #d1d5db;"
+        style="padding: 0.25rem 0.5rem; border-radius: 0.375rem; border: 1px solid var(--cinder-border); background-color: var(--cinder-surface-inset); color: var(--cinder-text);"
       >
         <option value="right">right</option>
         <option value="left">left</option>
@@ -34,7 +34,7 @@
       <select
         value={size}
         onchange={(e) => (size = (e.currentTarget as HTMLSelectElement).value as DrawerSize)}
-        style="padding: 0.25rem 0.5rem; border-radius: 0.375rem; border: 1px solid #d1d5db;"
+        style="padding: 0.25rem 0.5rem; border-radius: 0.375rem; border: 1px solid var(--cinder-border); background-color: var(--cinder-surface-inset); color: var(--cinder-text);"
       >
         <option value="sm">sm</option>
         <option value="md">md</option>

--- a/packages/testing/src/helpers/axe-gate.test.ts
+++ b/packages/testing/src/helpers/axe-gate.test.ts
@@ -81,6 +81,25 @@ describe('AXE_ALLOW_LIST', () => {
     }
   });
 
+  it('gives every entry a non-empty list of the specific rule ids it downgrades', () => {
+    for (const entry of AXE_ALLOW_LIST) {
+      expect(entry.ruleIds.length).toBeGreaterThan(0);
+      for (const ruleId of entry.ruleIds) {
+        expect(ruleId.trim().length).toBeGreaterThan(0);
+      }
+    }
+  });
+
+  it('names every allow-listed rule id in the entry reason so the two stay in sync', () => {
+    // The free-text reason is the human audit trail; `ruleIds` is what the gate
+    // actually enforces. If they drift, the reason becomes misleading.
+    for (const entry of AXE_ALLOW_LIST) {
+      for (const ruleId of entry.ruleIds) {
+        expect(entry.reason).toContain(ruleId);
+      }
+    }
+  });
+
   it('has no duplicate slug+theme+viewport+fixture scopes', () => {
     const scopes = AXE_ALLOW_LIST.map(
       (entry) =>
@@ -113,6 +132,29 @@ describe('AXE_ALLOW_LIST', () => {
     const darkKey: ArtifactKey = { ...lightKey, theme: 'dark' };
     expect(evaluateAxeGate(lightKey, buckets, AXE_ALLOW_LIST).status).toBe('allowed');
     expect(evaluateAxeGate(darkKey, buckets, AXE_ALLOW_LIST).status).toBe('fail');
+  });
+
+  it('still fails an allow-listed slug when a NEW rule id (outside ruleIds) regresses', () => {
+    // `table` is allow-listed only for `color-contrast`. A brand-new serious
+    // violation with a different rule id must still fail the gate rather than
+    // being silently masked by the contrast exception.
+    const buckets = makeBuckets({
+      serious: [makeViolation('color-contrast', 'serious'), makeViolation('label', 'serious')],
+    });
+    const lightKey: ArtifactKey = {
+      slug: 'table',
+      theme: 'light',
+      viewport: 'desktop',
+      fixture: 'default',
+    };
+    const decision = evaluateAxeGate(lightKey, buckets, AXE_ALLOW_LIST);
+    expect(decision.status).toBe('fail');
+    if (decision.status === 'fail') {
+      // Only the un-allowed violation is surfaced, not the tolerated one.
+      expect(decision.violations.map((violation) => violation.id)).toEqual(['label']);
+      expect(decision.message).toContain('label');
+      expect(decision.message).not.toContain('color-contrast');
+    }
   });
 });
 
@@ -149,7 +191,9 @@ describe('blockingViolations', () => {
 
 describe('findAllowEntry', () => {
   it('matches a slug-only entry across every theme/viewport/fixture', () => {
-    const allowList: AxeAllowEntry[] = [{ slug: 'button', reason: 'tracked in #123' }];
+    const allowList: AxeAllowEntry[] = [
+      { slug: 'button', ruleIds: ['label'], reason: 'tracked in #123' },
+    ];
     expect(findAllowEntry(KEY, allowList)?.reason).toBe('tracked in #123');
     expect(findAllowEntry({ ...KEY, theme: 'dark', viewport: 'mobile' }, allowList)?.reason).toBe(
       'tracked in #123',
@@ -158,7 +202,14 @@ describe('findAllowEntry', () => {
 
   it('respects theme/viewport/fixture narrowers', () => {
     const allowList: AxeAllowEntry[] = [
-      { slug: 'button', theme: 'dark', viewport: 'mobile', fixture: 'pressed', reason: 'narrow' },
+      {
+        slug: 'button',
+        theme: 'dark',
+        viewport: 'mobile',
+        fixture: 'pressed',
+        ruleIds: ['label'],
+        reason: 'narrow',
+      },
     ];
     expect(
       findAllowEntry(
@@ -171,7 +222,7 @@ describe('findAllowEntry', () => {
   });
 
   it('returns undefined when no entry matches the slug', () => {
-    const allowList: AxeAllowEntry[] = [{ slug: 'modal', reason: 'tracked' }];
+    const allowList: AxeAllowEntry[] = [{ slug: 'modal', ruleIds: ['label'], reason: 'tracked' }];
     expect(findAllowEntry(KEY, allowList)).toBeUndefined();
   });
 });
@@ -216,14 +267,30 @@ describe('evaluateAxeGate', () => {
     expect(evaluateAxeGate(KEY, buckets, []).status).toBe('fail');
   });
 
-  it('downgrades to allowed when the key is allow-listed, surfacing the reason', () => {
+  it('downgrades to allowed when the key is allow-listed for that rule id, surfacing the reason', () => {
     const buckets = makeBuckets({ critical: [makeViolation('color-contrast', 'critical')] });
-    const allowList: AxeAllowEntry[] = [{ slug: 'button', reason: 'pre-existing, tracked in #42' }];
+    const allowList: AxeAllowEntry[] = [
+      { slug: 'button', ruleIds: ['color-contrast'], reason: 'pre-existing, tracked in #42' },
+    ];
     const decision = evaluateAxeGate(KEY, buckets, allowList);
     expect(decision.status).toBe('allowed');
     if (decision.status === 'allowed') {
       expect(decision.reason).toBe('pre-existing, tracked in #42');
       expect(decision.violations).toHaveLength(1);
+    }
+  });
+
+  it('fails when the slug is allow-listed but the violation rule id is not in ruleIds', () => {
+    // The entry only tolerates `color-contrast`; a `label` regression on the
+    // same key must still fail rather than ride along on the exception.
+    const buckets = makeBuckets({ serious: [makeViolation('label', 'serious')] });
+    const allowList: AxeAllowEntry[] = [
+      { slug: 'button', ruleIds: ['color-contrast'], reason: 'contrast only, tracked in #42' },
+    ];
+    const decision = evaluateAxeGate(KEY, buckets, allowList);
+    expect(decision.status).toBe('fail');
+    if (decision.status === 'fail') {
+      expect(decision.violations.map((violation) => violation.id)).toEqual(['label']);
     }
   });
 

--- a/packages/testing/src/helpers/axe-gate.test.ts
+++ b/packages/testing/src/helpers/axe-gate.test.ts
@@ -1,0 +1,237 @@
+import { describe, expect, it } from 'bun:test';
+
+import type { ArtifactKey } from './artifact-path.ts';
+import {
+  AXE_ALLOW_LIST,
+  BLOCKING_IMPACTS,
+  blockingViolations,
+  evaluateAxeGate,
+  findAllowEntry,
+  formatBlockingViolations,
+  type AxeAllowEntry,
+} from './axe-gate.ts';
+import type { AxeBuckets, AxeImpact, AxeViolation } from './axe.ts';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeViolation(id: string, impact: AxeImpact): AxeViolation {
+  return {
+    id,
+    impact,
+    help: `${id} help`,
+    helpUrl: `https://example.test/${id}`,
+    description: `${id} description`,
+    tags: ['wcag2a'],
+    nodes: [{ target: ['.cinder-thing'], html: '<div class="cinder-thing"></div>' }],
+  };
+}
+
+function makeBuckets(partial: Partial<Record<AxeImpact, AxeViolation[]>>): AxeBuckets {
+  return {
+    critical: partial.critical ?? [],
+    serious: partial.serious ?? [],
+    moderate: partial.moderate ?? [],
+    minor: partial.minor ?? [],
+  };
+}
+
+const KEY: ArtifactKey = {
+  slug: 'button',
+  theme: 'light',
+  viewport: 'desktop',
+  fixture: 'default',
+};
+
+// ---------------------------------------------------------------------------
+// Policy constants
+// ---------------------------------------------------------------------------
+
+describe('BLOCKING_IMPACTS', () => {
+  it('blocks critical and serious, but not moderate or minor', () => {
+    expect([...BLOCKING_IMPACTS]).toEqual(['critical', 'serious']);
+  });
+});
+
+describe('AXE_ALLOW_LIST', () => {
+  it('documents every current pre-existing blocking violation captured by the sweep', () => {
+    // The baseline captured on 2026-05-29 by running the full broad sweep
+    // (134 components × 2 themes × 3 viewports) against the playground. If a
+    // violation is fixed, its entry is removed here; if a new one appears, the
+    // gate fails until it is fixed or added with a reason — that is the point.
+    const slugs = AXE_ALLOW_LIST.map((entry) => entry.slug).toSorted();
+    expect(slugs).toEqual([
+      'area-chart',
+      'avatar-group',
+      'bar-chart',
+      'chip',
+      'code-block',
+      'copy-button',
+      'line-chart',
+      'progress',
+      'table',
+      'tag-input',
+    ]);
+  });
+
+  it('gives every entry a non-empty, auditable reason', () => {
+    for (const entry of AXE_ALLOW_LIST) {
+      expect(entry.reason.trim().length).toBeGreaterThan(0);
+    }
+  });
+
+  it('has no duplicate slug+theme+viewport+fixture scopes', () => {
+    const scopes = AXE_ALLOW_LIST.map(
+      (entry) =>
+        `${entry.slug}|${entry.theme ?? '*'}|${entry.viewport ?? '*'}|${entry.fixture ?? '*'}`,
+    );
+    expect(new Set(scopes).size).toBe(scopes.length);
+  });
+
+  it('scopes the theme-dependent color-contrast exceptions to their failing theme', () => {
+    // color-contrast depends on the active palette, so these are narrowed to a
+    // single theme rather than blanket-allowing the component.
+    const table = AXE_ALLOW_LIST.find((entry) => entry.slug === 'table');
+    const chip = AXE_ALLOW_LIST.find((entry) => entry.slug === 'chip');
+    const copyButton = AXE_ALLOW_LIST.find((entry) => entry.slug === 'copy-button');
+    expect(table?.theme).toBe('light');
+    expect(chip?.theme).toBe('light');
+    expect(copyButton?.theme).toBe('dark');
+  });
+
+  it('downgrades a real allow-listed violation but still fails the same slug in an unscoped theme', () => {
+    // `table` is allow-listed only in the light theme; a serious violation in
+    // the dark theme must still fail (this is what keeps the narrowing honest).
+    const buckets = makeBuckets({ serious: [makeViolation('color-contrast', 'serious')] });
+    const lightKey: ArtifactKey = {
+      slug: 'table',
+      theme: 'light',
+      viewport: 'desktop',
+      fixture: 'default',
+    };
+    const darkKey: ArtifactKey = { ...lightKey, theme: 'dark' };
+    expect(evaluateAxeGate(lightKey, buckets, AXE_ALLOW_LIST).status).toBe('allowed');
+    expect(evaluateAxeGate(darkKey, buckets, AXE_ALLOW_LIST).status).toBe('fail');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// blockingViolations
+// ---------------------------------------------------------------------------
+
+describe('blockingViolations', () => {
+  it('returns critical and serious violations only', () => {
+    const buckets = makeBuckets({
+      critical: [makeViolation('color-contrast', 'critical')],
+      serious: [makeViolation('label', 'serious')],
+      moderate: [makeViolation('region', 'moderate')],
+      minor: [makeViolation('landmark', 'minor')],
+    });
+
+    const result = blockingViolations(buckets);
+    expect(result.map((v) => v.id)).toEqual(['color-contrast', 'label']);
+  });
+
+  it('returns an empty list when only moderate/minor violations exist', () => {
+    const buckets = makeBuckets({
+      moderate: [makeViolation('region', 'moderate')],
+      minor: [makeViolation('landmark', 'minor')],
+    });
+
+    expect(blockingViolations(buckets)).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// findAllowEntry
+// ---------------------------------------------------------------------------
+
+describe('findAllowEntry', () => {
+  it('matches a slug-only entry across every theme/viewport/fixture', () => {
+    const allowList: AxeAllowEntry[] = [{ slug: 'button', reason: 'tracked in #123' }];
+    expect(findAllowEntry(KEY, allowList)?.reason).toBe('tracked in #123');
+    expect(findAllowEntry({ ...KEY, theme: 'dark', viewport: 'mobile' }, allowList)?.reason).toBe(
+      'tracked in #123',
+    );
+  });
+
+  it('respects theme/viewport/fixture narrowers', () => {
+    const allowList: AxeAllowEntry[] = [
+      { slug: 'button', theme: 'dark', viewport: 'mobile', fixture: 'pressed', reason: 'narrow' },
+    ];
+    expect(
+      findAllowEntry(
+        { slug: 'button', theme: 'dark', viewport: 'mobile', fixture: 'pressed' },
+        allowList,
+      ),
+    ).toBeDefined();
+    // Light theme does not match the dark-only entry.
+    expect(findAllowEntry({ ...KEY, fixture: 'pressed' }, allowList)).toBeUndefined();
+  });
+
+  it('returns undefined when no entry matches the slug', () => {
+    const allowList: AxeAllowEntry[] = [{ slug: 'modal', reason: 'tracked' }];
+    expect(findAllowEntry(KEY, allowList)).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// formatBlockingViolations
+// ---------------------------------------------------------------------------
+
+describe('formatBlockingViolations', () => {
+  it('includes the key, count, rule id, impact, help, and url', () => {
+    const violations = [makeViolation('color-contrast', 'critical')];
+    const message = formatBlockingViolations(KEY, violations);
+    expect(message).toContain('button (light/desktop/default)');
+    expect(message).toContain('1 blocking axe violation');
+    expect(message).toContain('[critical] color-contrast');
+    expect(message).toContain('https://example.test/color-contrast');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// evaluateAxeGate
+// ---------------------------------------------------------------------------
+
+describe('evaluateAxeGate', () => {
+  it('passes when there are no blocking violations', () => {
+    const buckets = makeBuckets({ moderate: [makeViolation('region', 'moderate')] });
+    expect(evaluateAxeGate(KEY, buckets, []).status).toBe('pass');
+  });
+
+  it('fails when a critical violation is present and not allow-listed', () => {
+    const buckets = makeBuckets({ critical: [makeViolation('color-contrast', 'critical')] });
+    const decision = evaluateAxeGate(KEY, buckets, []);
+    expect(decision.status).toBe('fail');
+    if (decision.status === 'fail') {
+      expect(decision.violations).toHaveLength(1);
+      expect(decision.message).toContain('color-contrast');
+    }
+  });
+
+  it('fails when a serious violation is present and not allow-listed', () => {
+    const buckets = makeBuckets({ serious: [makeViolation('label', 'serious')] });
+    expect(evaluateAxeGate(KEY, buckets, []).status).toBe('fail');
+  });
+
+  it('downgrades to allowed when the key is allow-listed, surfacing the reason', () => {
+    const buckets = makeBuckets({ critical: [makeViolation('color-contrast', 'critical')] });
+    const allowList: AxeAllowEntry[] = [{ slug: 'button', reason: 'pre-existing, tracked in #42' }];
+    const decision = evaluateAxeGate(KEY, buckets, allowList);
+    expect(decision.status).toBe('allowed');
+    if (decision.status === 'allowed') {
+      expect(decision.reason).toBe('pre-existing, tracked in #42');
+      expect(decision.violations).toHaveLength(1);
+    }
+  });
+
+  it('does not treat moderate/minor violations as blocking', () => {
+    const buckets = makeBuckets({
+      moderate: [makeViolation('region', 'moderate')],
+      minor: [makeViolation('landmark', 'minor')],
+    });
+    expect(evaluateAxeGate(KEY, buckets, []).status).toBe('pass');
+  });
+});

--- a/packages/testing/src/helpers/axe-gate.ts
+++ b/packages/testing/src/helpers/axe-gate.ts
@@ -14,8 +14,10 @@
  * - `moderate` and `minor` violations are recorded as annotations only, to
  *   avoid noise from low-severity findings.
  * - A component/fixture combination may be allow-listed in {@link AXE_ALLOW_LIST}
- *   with a tracking reason; allow-listed blocking violations are downgraded to
- *   annotations instead of failing the test.
+ *   for specific axe rule ids with a tracking reason; only those rules are
+ *   downgraded to annotations. A blocking violation whose rule id is not
+ *   allow-listed still fails, so new regressions are caught even on allow-listed
+ *   components.
  *
  * The four targeted assertions in `tests/a11y-regressions.playwright.ts` are
  * intentionally stricter (they assert *zero* violations of any impact) and do
@@ -35,9 +37,10 @@ export const BLOCKING_IMPACTS: readonly AxeImpact[] = ['critical', 'serious'] as
  * A single documented exception to the accessibility gate.
  *
  * Matching is by component `slug`, optionally narrowed to a specific `theme`,
- * `viewport`, and/or `fixture`. An entry with only a `slug` allow-lists every
- * theme/viewport/fixture combination for that component. Each entry MUST carry
- * a `reason` so the exception is auditable and removable.
+ * `viewport`, and/or `fixture`. An entry with only a `slug` (plus narrowers)
+ * scopes the exception to that component, but `ruleIds` further restricts it to
+ * the specific axe rules it was created for. Each entry MUST carry a `reason`
+ * and a non-empty `ruleIds` list so the exception is auditable and removable.
  */
 export type AxeAllowEntry = {
   /** Component slug from the manifest (kebab-case). */
@@ -48,6 +51,14 @@ export type AxeAllowEntry = {
   viewport?: ArtifactKey['viewport'];
   /** Restrict the exception to a single fixture. Omit to match every fixture. */
   fixture?: string;
+  /**
+   * The exact axe rule ids this entry downgrades (e.g. `['color-contrast']`).
+   * Only blocking violations whose `id` is in this list are treated as allowed;
+   * any other blocking violation in the same scope still fails the gate, so a
+   * brand-new regression on an allow-listed component is never silently masked.
+   * Required and non-empty.
+   */
+  ruleIds: readonly string[];
   /**
    * Why this combination is allow-listed: the pre-existing violation(s) and a
    * tracking note (issue link, follow-up task, etc.). Required and non-empty.
@@ -68,17 +79,18 @@ export type AxeAllowEntry = {
  * The baseline below was captured by running the full broad sweep
  * (`bun run scripts/start-server.ts` → 134 components × 2 themes × 3 viewports)
  * against the playground on 2026-05-29. Every entry records the exact axe rule
- * id(s) it covers so the exception is auditable and can be removed the moment
- * the underlying violation is fixed. Color-contrast findings are theme-scoped
- * because contrast depends on the active palette; structural findings
- * (nested-interactive, svg-img-alt, etc.) reproduce across every
- * theme/viewport, so those entries match by slug alone.
+ * ids it covers in `ruleIds`; only those rules are downgraded, so a *new*
+ * critical/serious regression on an allow-listed component still fails the gate.
+ * Color-contrast findings are theme-scoped because contrast depends on the
+ * active palette; structural findings (nested-interactive, svg-img-alt, etc.)
+ * reproduce across every theme/viewport, so those entries match by slug alone.
  *
  * An empty list would mean the gate is fully enforced for every component.
  */
 export const AXE_ALLOW_LIST: readonly AxeAllowEntry[] = [
   {
     slug: 'area-chart',
+    ruleIds: ['nested-interactive', 'svg-img-alt'],
     reason:
       'Pre-existing serious violations: nested-interactive and svg-img-alt on the SVG chart. ' +
       'Charts render interactive data points inside the <svg> without a non-nested control and ' +
@@ -86,36 +98,42 @@ export const AXE_ALLOW_LIST: readonly AxeAllowEntry[] = [
   },
   {
     slug: 'bar-chart',
+    ruleIds: ['nested-interactive', 'svg-img-alt'],
     reason:
       'Pre-existing serious violations: nested-interactive and svg-img-alt on the SVG chart. ' +
       'Same root cause as area-chart (shared chart primitives). Tracking: chart-a11y follow-up.',
   },
   {
     slug: 'line-chart',
+    ruleIds: ['nested-interactive', 'svg-img-alt'],
     reason:
       'Pre-existing serious violations: nested-interactive and svg-img-alt on the SVG chart. ' +
       'Same root cause as area-chart (shared chart primitives). Tracking: chart-a11y follow-up.',
   },
   {
     slug: 'avatar-group',
+    ruleIds: ['aria-prohibited-attr'],
     reason:
       'Pre-existing serious violation: aria-prohibited-attr — an aria-* attribute is set on an ' +
       'element whose role does not permit it. Tracking: avatar-group-a11y follow-up.',
   },
   {
     slug: 'progress',
+    ruleIds: ['aria-progressbar-name'],
     reason:
       'Pre-existing serious violation: aria-progressbar-name — the progressbar node lacks an ' +
       'accessible name. Tracking: progress-a11y follow-up.',
   },
   {
     slug: 'tag-input',
+    ruleIds: ['nested-interactive'],
     reason:
       'Pre-existing serious violation: nested-interactive — the removable-tag control is nested ' +
       'inside another interactive element. Tracking: tag-input-a11y follow-up.',
   },
   {
     slug: 'code-block',
+    ruleIds: ['color-contrast', 'scrollable-region-focusable'],
     reason:
       'Pre-existing serious violations: color-contrast (all viewports) and ' +
       'scrollable-region-focusable (the scrollable code region lacks keyboard access, surfaces in ' +
@@ -124,6 +142,7 @@ export const AXE_ALLOW_LIST: readonly AxeAllowEntry[] = [
   {
     slug: 'table',
     theme: 'light',
+    ruleIds: ['color-contrast'],
     reason:
       'Pre-existing serious violation: color-contrast in the light theme (all viewports). ' +
       'Tracking: table-light-contrast follow-up.',
@@ -131,6 +150,7 @@ export const AXE_ALLOW_LIST: readonly AxeAllowEntry[] = [
   {
     slug: 'chip',
     theme: 'light',
+    ruleIds: ['color-contrast'],
     reason:
       'Pre-existing serious violation: color-contrast in the light theme (all viewports). ' +
       'Tracking: chip-light-contrast follow-up.',
@@ -138,6 +158,7 @@ export const AXE_ALLOW_LIST: readonly AxeAllowEntry[] = [
   {
     slug: 'copy-button',
     theme: 'dark',
+    ruleIds: ['color-contrast'],
     reason:
       'Pre-existing serious violation: color-contrast in the dark theme (all viewports). ' +
       'Tracking: copy-button-dark-contrast follow-up.',
@@ -197,10 +218,14 @@ export type AxeGateDecision =
  * Evaluates the accessibility gate for one artifact key.
  *
  * - `pass`: no blocking violations.
- * - `allowed`: blocking violations exist but the key is covered by an
- *   {@link AXE_ALLOW_LIST} entry; the caller should annotate, not fail.
- * - `fail`: blocking violations exist and the key is not allow-listed; the
- *   caller should fail the test with `message`.
+ * - `allowed`: every blocking violation is covered by a matching
+ *   {@link AXE_ALLOW_LIST} entry's `ruleIds`; the caller should annotate, not
+ *   fail.
+ * - `fail`: at least one blocking violation is not covered — either the key is
+ *   not allow-listed at all, or it is allow-listed but a blocking violation's
+ *   rule id is outside the entry's `ruleIds` (a new regression). The caller
+ *   should fail the test with `message`, which lists only the un-allowed
+ *   violations.
  */
 export function evaluateAxeGate(
   key: ArtifactKey,
@@ -213,9 +238,19 @@ export function evaluateAxeGate(
   }
 
   const allowEntry = findAllowEntry(key, allowList);
-  if (allowEntry !== undefined) {
-    return { status: 'allowed', violations, reason: allowEntry.reason };
+  if (allowEntry === undefined) {
+    return { status: 'fail', violations, message: formatBlockingViolations(key, violations) };
   }
 
-  return { status: 'fail', violations, message: formatBlockingViolations(key, violations) };
+  const allowedRuleIds = new Set(allowEntry.ruleIds);
+  const unallowed = violations.filter((violation) => !allowedRuleIds.has(violation.id));
+  if (unallowed.length > 0) {
+    return {
+      status: 'fail',
+      violations: unallowed,
+      message: formatBlockingViolations(key, unallowed),
+    };
+  }
+
+  return { status: 'allowed', violations, reason: allowEntry.reason };
 }

--- a/packages/testing/src/helpers/axe-gate.ts
+++ b/packages/testing/src/helpers/axe-gate.ts
@@ -1,0 +1,221 @@
+/**
+ * The accessibility gate for the broad component sweep
+ * (`tests/components.playwright.ts`).
+ *
+ * The sweep runs `runAxe()` across every component in two themes × three
+ * viewports and buckets violations by impact. This module decides which of
+ * those buckets are *blocking* (fail CI) and provides an explicit, documented
+ * allow-list so a known pre-existing violation can be recorded as an exception
+ * — with a required reason — rather than silently tolerated or forcing a
+ * zero-violation baseline on day one.
+ *
+ * Policy:
+ * - `critical` and `serious` violations are blocking by default.
+ * - `moderate` and `minor` violations are recorded as annotations only, to
+ *   avoid noise from low-severity findings.
+ * - A component/fixture combination may be allow-listed in {@link AXE_ALLOW_LIST}
+ *   with a tracking reason; allow-listed blocking violations are downgraded to
+ *   annotations instead of failing the test.
+ *
+ * The four targeted assertions in `tests/a11y-regressions.playwright.ts` are
+ * intentionally stricter (they assert *zero* violations of any impact) and do
+ * not use this gate.
+ */
+
+import type { ArtifactKey } from './artifact-path.ts';
+import type { AxeBuckets, AxeImpact, AxeViolation } from './axe.ts';
+
+/**
+ * Impacts that fail the broad sweep. `moderate` and `minor` are deliberately
+ * excluded so low-severity findings stay informational.
+ */
+export const BLOCKING_IMPACTS: readonly AxeImpact[] = ['critical', 'serious'] as const;
+
+/**
+ * A single documented exception to the accessibility gate.
+ *
+ * Matching is by component `slug`, optionally narrowed to a specific `theme`,
+ * `viewport`, and/or `fixture`. An entry with only a `slug` allow-lists every
+ * theme/viewport/fixture combination for that component. Each entry MUST carry
+ * a `reason` so the exception is auditable and removable.
+ */
+export type AxeAllowEntry = {
+  /** Component slug from the manifest (kebab-case). */
+  slug: string;
+  /** Restrict the exception to a single theme. Omit to match every theme. */
+  theme?: ArtifactKey['theme'];
+  /** Restrict the exception to a single viewport. Omit to match every viewport. */
+  viewport?: ArtifactKey['viewport'];
+  /** Restrict the exception to a single fixture. Omit to match every fixture. */
+  fixture?: string;
+  /**
+   * Why this combination is allow-listed: the pre-existing violation(s) and a
+   * tracking note (issue link, follow-up task, etc.). Required and non-empty.
+   */
+  reason: string;
+};
+
+/**
+ * Explicit allow-list of known, pre-existing accessibility violations.
+ *
+ * This list is the documented escape hatch the gate is built around: the gate
+ * does NOT require a zero-violation baseline on day one. When the sweep
+ * surfaces a `critical`/`serious` violation that cannot be fixed immediately,
+ * add an entry here with a `reason` (and a tracking link) rather than weakening
+ * the gate globally. Each entry should be removed as the underlying violation
+ * is fixed.
+ *
+ * The baseline below was captured by running the full broad sweep
+ * (`bun run scripts/start-server.ts` → 134 components × 2 themes × 3 viewports)
+ * against the playground on 2026-05-29. Every entry records the exact axe rule
+ * id(s) it covers so the exception is auditable and can be removed the moment
+ * the underlying violation is fixed. Color-contrast findings are theme-scoped
+ * because contrast depends on the active palette; structural findings
+ * (nested-interactive, svg-img-alt, etc.) reproduce across every
+ * theme/viewport, so those entries match by slug alone.
+ *
+ * An empty list would mean the gate is fully enforced for every component.
+ */
+export const AXE_ALLOW_LIST: readonly AxeAllowEntry[] = [
+  {
+    slug: 'area-chart',
+    reason:
+      'Pre-existing serious violations: nested-interactive and svg-img-alt on the SVG chart. ' +
+      'Charts render interactive data points inside the <svg> without a non-nested control and ' +
+      'without alt text for the img-role SVG. Tracking: chart-a11y follow-up.',
+  },
+  {
+    slug: 'bar-chart',
+    reason:
+      'Pre-existing serious violations: nested-interactive and svg-img-alt on the SVG chart. ' +
+      'Same root cause as area-chart (shared chart primitives). Tracking: chart-a11y follow-up.',
+  },
+  {
+    slug: 'line-chart',
+    reason:
+      'Pre-existing serious violations: nested-interactive and svg-img-alt on the SVG chart. ' +
+      'Same root cause as area-chart (shared chart primitives). Tracking: chart-a11y follow-up.',
+  },
+  {
+    slug: 'avatar-group',
+    reason:
+      'Pre-existing serious violation: aria-prohibited-attr — an aria-* attribute is set on an ' +
+      'element whose role does not permit it. Tracking: avatar-group-a11y follow-up.',
+  },
+  {
+    slug: 'progress',
+    reason:
+      'Pre-existing serious violation: aria-progressbar-name — the progressbar node lacks an ' +
+      'accessible name. Tracking: progress-a11y follow-up.',
+  },
+  {
+    slug: 'tag-input',
+    reason:
+      'Pre-existing serious violation: nested-interactive — the removable-tag control is nested ' +
+      'inside another interactive element. Tracking: tag-input-a11y follow-up.',
+  },
+  {
+    slug: 'code-block',
+    reason:
+      'Pre-existing serious violations: color-contrast (all viewports) and ' +
+      'scrollable-region-focusable (the scrollable code region lacks keyboard access, surfaces in ' +
+      'the mobile viewport). Tracking: code-block-a11y follow-up.',
+  },
+  {
+    slug: 'table',
+    theme: 'light',
+    reason:
+      'Pre-existing serious violation: color-contrast in the light theme (all viewports). ' +
+      'Tracking: table-light-contrast follow-up.',
+  },
+  {
+    slug: 'chip',
+    theme: 'light',
+    reason:
+      'Pre-existing serious violation: color-contrast in the light theme (all viewports). ' +
+      'Tracking: chip-light-contrast follow-up.',
+  },
+  {
+    slug: 'copy-button',
+    theme: 'dark',
+    reason:
+      'Pre-existing serious violation: color-contrast in the dark theme (all viewports). ' +
+      'Tracking: copy-button-dark-contrast follow-up.',
+  },
+];
+
+/**
+ * Returns the blocking (`critical` + `serious`) violations from a bucketed axe
+ * result, in a stable, severity-ordered list.
+ */
+export function blockingViolations(buckets: AxeBuckets): AxeViolation[] {
+  return BLOCKING_IMPACTS.flatMap((impact) => buckets[impact]);
+}
+
+/**
+ * Finds the allow-list entry that covers a given artifact key, or `undefined`
+ * when none applies. An entry matches when its `slug` equals the key's slug and
+ * each of its optional `theme`/`viewport`/`fixture` narrowers (when present)
+ * equals the corresponding key field.
+ */
+export function findAllowEntry(
+  key: ArtifactKey,
+  allowList: readonly AxeAllowEntry[] = AXE_ALLOW_LIST,
+): AxeAllowEntry | undefined {
+  return allowList.find(
+    (entry) =>
+      entry.slug === key.slug &&
+      (entry.theme === undefined || entry.theme === key.theme) &&
+      (entry.viewport === undefined || entry.viewport === key.viewport) &&
+      (entry.fixture === undefined || entry.fixture === key.fixture),
+  );
+}
+
+/**
+ * Formats a list of blocking violations into a single human-readable message
+ * for an assertion failure: the rule id, impact, help text, help URL, and the
+ * first failing node's selector for each violation.
+ */
+export function formatBlockingViolations(key: ArtifactKey, violations: AxeViolation[]): string {
+  const header = `${key.slug} (${key.theme}/${key.viewport}/${key.fixture}) has ${violations.length} blocking axe violation(s):`;
+  const lines = violations.map((violation) => {
+    const firstTarget = violation.nodes[0]?.target;
+    const selector =
+      firstTarget === undefined ? '(no node)' : JSON.stringify(firstTarget.flat().join(' '));
+    return `  - [${violation.impact}] ${violation.id}: ${violation.help} (${violation.helpUrl}) at ${selector}`;
+  });
+  return [header, ...lines].join('\n');
+}
+
+/** The decision the gate reaches for a single artifact key. */
+export type AxeGateDecision =
+  | { status: 'pass' }
+  | { status: 'fail'; violations: AxeViolation[]; message: string }
+  | { status: 'allowed'; violations: AxeViolation[]; reason: string };
+
+/**
+ * Evaluates the accessibility gate for one artifact key.
+ *
+ * - `pass`: no blocking violations.
+ * - `allowed`: blocking violations exist but the key is covered by an
+ *   {@link AXE_ALLOW_LIST} entry; the caller should annotate, not fail.
+ * - `fail`: blocking violations exist and the key is not allow-listed; the
+ *   caller should fail the test with `message`.
+ */
+export function evaluateAxeGate(
+  key: ArtifactKey,
+  buckets: AxeBuckets,
+  allowList: readonly AxeAllowEntry[] = AXE_ALLOW_LIST,
+): AxeGateDecision {
+  const violations = blockingViolations(buckets);
+  if (violations.length === 0) {
+    return { status: 'pass' };
+  }
+
+  const allowEntry = findAllowEntry(key, allowList);
+  if (allowEntry !== undefined) {
+    return { status: 'allowed', violations, reason: allowEntry.reason };
+  }
+
+  return { status: 'fail', violations, message: formatBlockingViolations(key, violations) };
+}

--- a/packages/testing/tests/components.playwright.ts
+++ b/packages/testing/tests/components.playwright.ts
@@ -111,9 +111,11 @@ for (const entry of entries) {
             // Accessibility gate: `critical` and `serious` violations fail the
             // sweep; `moderate`/`minor` stay annotation-only (recorded above).
             // An entry in `AXE_ALLOW_LIST` (matched by slug, optionally narrowed
-            // to theme/viewport/fixture) downgrades blocking violations to an
-            // annotation so a known pre-existing violation can be explicitly
-            // tracked rather than forcing a zero-violation baseline.
+            // to theme/viewport/fixture) downgrades the specific rule ids it
+            // names to an annotation so a known pre-existing violation can be
+            // explicitly tracked rather than forcing a zero-violation baseline.
+            // A blocking violation whose rule id is *not* allow-listed still
+            // fails, so new regressions on allow-listed components are caught.
             const decision = evaluateAxeGate(key, buckets);
             if (decision.status === 'allowed') {
               test.info().annotations.push({

--- a/packages/testing/tests/components.playwright.ts
+++ b/packages/testing/tests/components.playwright.ts
@@ -1,6 +1,7 @@
 import { createHash } from 'node:crypto';
 
 import { expect, test } from '../src/fixtures/component-page.ts';
+import { evaluateAxeGate } from '../src/helpers/axe-gate.ts';
 import { runAxe } from '../src/helpers/axe.ts';
 import { applyComponentFilter, parseComponentFilter } from '../src/helpers/component-filter.ts';
 import { applyInteractions } from '../src/helpers/interact.ts';
@@ -107,7 +108,21 @@ for (const entry of entries) {
               'mask' in fixture && Array.isArray(fixture.mask) ? fixture.mask : undefined;
             await captureScreenshot(page, key, masks !== undefined ? { masks } : undefined);
 
-            // v1: no assertions on axe buckets — record only.
+            // Accessibility gate: `critical` and `serious` violations fail the
+            // sweep; `moderate`/`minor` stay annotation-only (recorded above).
+            // An entry in `AXE_ALLOW_LIST` (matched by slug, optionally narrowed
+            // to theme/viewport/fixture) downgrades blocking violations to an
+            // annotation so a known pre-existing violation can be explicitly
+            // tracked rather than forcing a zero-violation baseline.
+            const decision = evaluateAxeGate(key, buckets);
+            if (decision.status === 'allowed') {
+              test.info().annotations.push({
+                type: 'axe-allowed',
+                description: `Allow-listed blocking violation(s): ${decision.reason}`,
+              });
+            } else if (decision.status === 'fail') {
+              expect(decision.violations, decision.message).toHaveLength(0);
+            }
           });
         }
       }


### PR DESCRIPTION
Reviewed by the workflow's adversarial subagent committee (correctness / testing / typescript). Green through the full pre-push gate. Part of the Group A batch (test/refactor tasks, no generated-file changes).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CI behavior for the full component matrix—new failures unless allow-listed—but policy is explicit and unit-tested; allow-list drift is guarded by tests on baseline slugs and rule-id scoping.
> 
> **Overview**
> The broad component Playwright sweep now **enforces** axe results: **critical** and **serious** violations fail the test unless they match a scoped entry in a new **`AXE_ALLOW_LIST`** (slug, optional theme/viewport/fixture, explicit **rule ids**, and a required **reason**). Allow-listed blocking issues are recorded as **`axe-allowed`** annotations instead of failing; any other serious/critical finding on those components still fails, including new rule ids on allow-listed slugs. **Moderate/minor** impacts stay annotation-only.
> 
> Adds **`axe-gate.ts`** with **`evaluateAxeGate`** and related helpers, plus **`axe-gate.test.ts`** covering policy, baseline slugs, theme narrowing, and regression masking behavior. The targeted **`a11y-regressions`** suite is unchanged (still zero-violation).
> 
> Unrelated: the drawer basic example’s **Side/Size** selects use Cinder theme CSS variables instead of a hardcoded border color.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 45dba8eeda39e1102fd2fdbcc62bbb7a8a6707fc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->