### PR TITLE
refactor(components): drop redundant as-casts on compound-component constructors

### DIFF
--- a/packages/components/src/components/accordion/accordion.type-test.ts
+++ b/packages/components/src/components/accordion/accordion.type-test.ts
@@ -1,0 +1,20 @@
+/**
+ * Compile-time regression tests for the `Accordion` compound-component namespace.
+ * svelte-check processes this file; tsc does not (it excludes .svelte imports).
+ *
+ * These verify that the `Object.assign` namespace members resolve and stay
+ * correctly typed WITHOUT a hand-maintained `as typeof Root & { ... }` cast.
+ * If a member is renamed in the `Object.assign` literal, the assignment below
+ * stops compiling — surfacing the drift as a type error instead of silently
+ * keeping the old declared type.
+ */
+import type { Component } from 'svelte';
+
+import AccordionItem from '../accordion-item/accordion-item.svelte';
+import { Accordion } from './index.ts';
+
+const _item: typeof AccordionItem = Accordion.Item;
+
+Accordion satisfies Component<never>;
+
+void _item;

--- a/packages/components/src/components/accordion/index.ts
+++ b/packages/components/src/components/accordion/index.ts
@@ -8,9 +8,7 @@ import AccordionRoot from './accordion.svelte';
  */
 const Accordion = Object.assign(AccordionRoot, {
   Item: AccordionItem,
-}) as typeof AccordionRoot & {
-  Item: typeof AccordionItem;
-};
+});
 
 export default Accordion;
 export { ACCORDION_CONTEXT_KEY } from './accordion.context.ts';

--- a/packages/components/src/components/context-menu/context-menu.type-test.ts
+++ b/packages/components/src/components/context-menu/context-menu.type-test.ts
@@ -1,0 +1,35 @@
+/**
+ * Compile-time regression tests for the `ContextMenu` compound-component namespace.
+ * svelte-check processes this file; tsc does not (it excludes .svelte imports).
+ *
+ * These verify that the `Object.assign` namespace members resolve and stay
+ * correctly typed WITHOUT a hand-maintained `as typeof Root & { ... }` cast.
+ * If a member is renamed in the `Object.assign` literal, the assignments below
+ * stop compiling — surfacing the drift as a type error instead of silently
+ * keeping the old declared type.
+ */
+import type { Component } from 'svelte';
+
+import ContextMenuTrigger from '../context-menu-trigger/context-menu-trigger.svelte';
+import DropdownGroup from '../dropdown-group/dropdown-group.svelte';
+import DropdownItem from '../dropdown-item/dropdown-item.svelte';
+import DropdownLabel from '../dropdown-label/dropdown-label.svelte';
+import DropdownMenu from '../dropdown-menu/dropdown-menu.svelte';
+import DropdownSeparator from '../dropdown-separator/dropdown-separator.svelte';
+import { ContextMenu } from './index.ts';
+
+const _trigger: typeof ContextMenuTrigger = ContextMenu.Trigger;
+const _menu: typeof DropdownMenu = ContextMenu.Menu;
+const _item: typeof DropdownItem = ContextMenu.Item;
+const _label: typeof DropdownLabel = ContextMenu.Label;
+const _separator: typeof DropdownSeparator = ContextMenu.Separator;
+const _group: typeof DropdownGroup = ContextMenu.Group;
+
+ContextMenu satisfies Component<never>;
+
+void _trigger;
+void _menu;
+void _item;
+void _label;
+void _separator;
+void _group;

--- a/packages/components/src/components/context-menu/index.ts
+++ b/packages/components/src/components/context-menu/index.ts
@@ -13,14 +13,7 @@ const ContextMenu = Object.assign(ContextMenuRoot, {
   Label: DropdownLabel,
   Separator: DropdownSeparator,
   Group: DropdownGroup,
-}) as typeof ContextMenuRoot & {
-  Trigger: typeof ContextMenuTrigger;
-  Menu: typeof DropdownMenu;
-  Item: typeof DropdownItem;
-  Label: typeof DropdownLabel;
-  Separator: typeof DropdownSeparator;
-  Group: typeof DropdownGroup;
-};
+});
 
 export default ContextMenu;
 export type { ContextMenuProps } from './context-menu.types.ts';

--- a/packages/components/src/components/dropdown/dropdown.type-test.ts
+++ b/packages/components/src/components/dropdown/dropdown.type-test.ts
@@ -1,0 +1,35 @@
+/**
+ * Compile-time regression tests for the `Dropdown` compound-component namespace.
+ * svelte-check processes this file; tsc does not (it excludes .svelte imports).
+ *
+ * These verify that the `Object.assign` namespace members resolve and stay
+ * correctly typed WITHOUT a hand-maintained `as typeof Root & { ... }` cast.
+ * If a member is renamed in the `Object.assign` literal, the assignments below
+ * stop compiling — surfacing the drift as a type error instead of silently
+ * keeping the old declared type.
+ */
+import type { Component } from 'svelte';
+
+import DropdownGroup from '../dropdown-group/dropdown-group.svelte';
+import DropdownItem from '../dropdown-item/dropdown-item.svelte';
+import DropdownLabel from '../dropdown-label/dropdown-label.svelte';
+import DropdownMenu from '../dropdown-menu/dropdown-menu.svelte';
+import DropdownSeparator from '../dropdown-separator/dropdown-separator.svelte';
+import DropdownTrigger from '../dropdown-trigger/dropdown-trigger.svelte';
+import { Dropdown } from './index.ts';
+
+const _trigger: typeof DropdownTrigger = Dropdown.Trigger;
+const _menu: typeof DropdownMenu = Dropdown.Menu;
+const _item: typeof DropdownItem = Dropdown.Item;
+const _label: typeof DropdownLabel = Dropdown.Label;
+const _separator: typeof DropdownSeparator = Dropdown.Separator;
+const _group: typeof DropdownGroup = Dropdown.Group;
+
+Dropdown satisfies Component<never>;
+
+void _trigger;
+void _menu;
+void _item;
+void _label;
+void _separator;
+void _group;

--- a/packages/components/src/components/dropdown/index.ts
+++ b/packages/components/src/components/dropdown/index.ts
@@ -20,14 +20,7 @@ const Dropdown = Object.assign(DropdownRoot, {
   Label: DropdownLabel,
   Separator: DropdownSeparator,
   Group: DropdownGroup,
-}) as typeof DropdownRoot & {
-  Trigger: typeof DropdownTrigger;
-  Menu: typeof DropdownMenu;
-  Item: typeof DropdownItem;
-  Label: typeof DropdownLabel;
-  Separator: typeof DropdownSeparator;
-  Group: typeof DropdownGroup;
-};
+});
 
 export default Dropdown;
 export {

--- a/packages/components/src/components/feed/feed.type-test.ts
+++ b/packages/components/src/components/feed/feed.type-test.ts
@@ -1,0 +1,20 @@
+/**
+ * Compile-time regression tests for the `Feed` compound-component namespace.
+ * svelte-check processes this file; tsc does not (it excludes .svelte imports).
+ *
+ * These verify that the `Object.assign` namespace members resolve and stay
+ * correctly typed WITHOUT a hand-maintained `as typeof Root & { ... }` cast.
+ * If a member is renamed in the `Object.assign` literal, the assignment below
+ * stops compiling — surfacing the drift as a type error instead of silently
+ * keeping the old declared type.
+ */
+import type { Component } from 'svelte';
+
+import FeedEvent from '../feed-event/feed-event.svelte';
+import { Feed } from './index.ts';
+
+const _event: typeof FeedEvent = Feed.Event;
+
+Feed satisfies Component<never>;
+
+void _event;

--- a/packages/components/src/components/feed/index.ts
+++ b/packages/components/src/components/feed/index.ts
@@ -8,9 +8,7 @@ import FeedRoot from './feed.svelte';
  */
 const Feed = Object.assign(FeedRoot, {
   Event: FeedEvent,
-}) as typeof FeedRoot & {
-  Event: typeof FeedEvent;
-};
+});
 
 export default Feed;
 export type { FeedProps } from './feed.types.ts';

--- a/packages/components/src/components/grid-list/grid-list.type-test.ts
+++ b/packages/components/src/components/grid-list/grid-list.type-test.ts
@@ -1,0 +1,20 @@
+/**
+ * Compile-time regression tests for the `GridList` compound-component namespace.
+ * svelte-check processes this file; tsc does not (it excludes .svelte imports).
+ *
+ * These verify that the `Object.assign` namespace members resolve and stay
+ * correctly typed WITHOUT a hand-maintained `as typeof Root & { ... }` cast.
+ * If a member is renamed in the `Object.assign` literal, the assignment below
+ * stops compiling — surfacing the drift as a type error instead of silently
+ * keeping the old declared type.
+ */
+import type { Component } from 'svelte';
+
+import GridListItem from '../grid-list-item/grid-list-item.svelte';
+import { GridList } from './index.ts';
+
+const _item: typeof GridListItem = GridList.Item;
+
+GridList satisfies Component<never>;
+
+void _item;

--- a/packages/components/src/components/grid-list/index.ts
+++ b/packages/components/src/components/grid-list/index.ts
@@ -8,9 +8,7 @@ import GridListRoot from './grid-list.svelte';
  */
 const GridList = Object.assign(GridListRoot, {
   Item: GridListItem,
-}) as typeof GridListRoot & {
-  Item: typeof GridListItem;
-};
+});
 
 export default GridList;
 export type { GridListProps } from './grid-list.types.ts';

--- a/packages/components/src/components/side-navigation/index.ts
+++ b/packages/components/src/components/side-navigation/index.ts
@@ -11,10 +11,7 @@ import SideNavigationRoot from './side-navigation.svelte';
 const SideNavigation = Object.assign(SideNavigationRoot, {
   Group: SideNavigationGroup,
   Item: SideNavigationItem,
-}) as typeof SideNavigationRoot & {
-  Group: typeof SideNavigationGroup;
-  Item: typeof SideNavigationItem;
-};
+});
 
 export default SideNavigation;
 export type { SideNavigationProps } from './side-navigation.types.ts';

--- a/packages/components/src/components/side-navigation/side-navigation.type-test.ts
+++ b/packages/components/src/components/side-navigation/side-navigation.type-test.ts
@@ -1,0 +1,24 @@
+/**
+ * Compile-time regression tests for the `SideNavigation` compound-component
+ * namespace. svelte-check processes this file; tsc does not (it excludes
+ * .svelte imports).
+ *
+ * These verify that the `Object.assign` namespace members resolve and stay
+ * correctly typed WITHOUT a hand-maintained `as typeof Root & { ... }` cast.
+ * If a member is renamed in the `Object.assign` literal, the assignments below
+ * stop compiling — surfacing the drift as a type error instead of silently
+ * keeping the old declared type.
+ */
+import type { Component } from 'svelte';
+
+import SideNavigationGroup from '../side-navigation-group/side-navigation-group.svelte';
+import SideNavigationItem from '../side-navigation-item/side-navigation-item.svelte';
+import { SideNavigation } from './index.ts';
+
+const _group: typeof SideNavigationGroup = SideNavigation.Group;
+const _item: typeof SideNavigationItem = SideNavigation.Item;
+
+SideNavigation satisfies Component<never>;
+
+void _group;
+void _item;

--- a/packages/components/src/components/stat-group/index.ts
+++ b/packages/components/src/components/stat-group/index.ts
@@ -8,9 +8,7 @@ import StatGroupRoot from './stat-group.svelte';
  */
 const StatGroup = Object.assign(StatGroupRoot, {
   Stat,
-}) as typeof StatGroupRoot & {
-  Stat: typeof Stat;
-};
+});
 
 export default StatGroup;
 export type { StatGroupColumns, StatGroupProps, StatGroupVariant } from './stat-group.types.ts';

--- a/packages/components/src/components/stat-group/stat-group.type-test.ts
+++ b/packages/components/src/components/stat-group/stat-group.type-test.ts
@@ -1,0 +1,20 @@
+/**
+ * Compile-time regression tests for the `StatGroup` compound-component namespace.
+ * svelte-check processes this file; tsc does not (it excludes .svelte imports).
+ *
+ * These verify that the `Object.assign` namespace members resolve and stay
+ * correctly typed WITHOUT a hand-maintained `as typeof Root & { ... }` cast.
+ * If a member is renamed in the `Object.assign` literal, the assignment below
+ * stops compiling — surfacing the drift as a type error instead of silently
+ * keeping the old declared type.
+ */
+import type { Component } from 'svelte';
+
+import Stat from '../stat/stat.svelte';
+import { StatGroup } from './index.ts';
+
+const _stat: typeof Stat = StatGroup.Stat;
+
+StatGroup satisfies Component<never>;
+
+void _stat;

--- a/packages/components/src/components/table/index.ts
+++ b/packages/components/src/components/table/index.ts
@@ -17,13 +17,7 @@ const Table = Object.assign(TableRoot, {
   Header: TableHeader,
   HeaderCell: TableHeaderCell,
   Row: TableRow,
-}) as typeof TableRoot & {
-  Body: typeof TableBody;
-  Cell: typeof TableCell;
-  Header: typeof TableHeader;
-  HeaderCell: typeof TableHeaderCell;
-  Row: typeof TableRow;
-};
+});
 
 export default Table;
 export {

--- a/packages/components/src/components/table/table.type-test.ts
+++ b/packages/components/src/components/table/table.type-test.ts
@@ -1,0 +1,32 @@
+/**
+ * Compile-time regression tests for the `Table` compound-component namespace.
+ * svelte-check processes this file; tsc does not (it excludes .svelte imports).
+ *
+ * These verify that the `Object.assign` namespace members resolve and stay
+ * correctly typed WITHOUT a hand-maintained `as typeof Root & { ... }` cast.
+ * If a member is renamed in the `Object.assign` literal, the assignments below
+ * stop compiling — surfacing the drift as a type error instead of silently
+ * keeping the old declared type.
+ */
+import type { Component } from 'svelte';
+
+import TableBody from '../table-body/table-body.svelte';
+import TableCell from '../table-cell/table-cell.svelte';
+import TableHeaderCell from '../table-header-cell/table-header-cell.svelte';
+import TableHeader from '../table-header/table-header.svelte';
+import TableRow from '../table-row/table-row.svelte';
+import { Table } from './index.ts';
+
+const _body: typeof TableBody = Table.Body;
+const _cell: typeof TableCell = Table.Cell;
+const _header: typeof TableHeader = Table.Header;
+const _headerCell: typeof TableHeaderCell = Table.HeaderCell;
+const _row: typeof TableRow = Table.Row;
+
+Table satisfies Component<never>;
+
+void _body;
+void _cell;
+void _header;
+void _headerCell;
+void _row;

--- a/packages/components/src/components/tabs/index.ts
+++ b/packages/components/src/components/tabs/index.ts
@@ -13,11 +13,7 @@ const Tabs = Object.assign(TabsRoot, {
   List: TabList,
   Trigger: Tab,
   Panel: TabPanel,
-}) as typeof TabsRoot & {
-  List: typeof TabList;
-  Trigger: typeof Tab;
-  Panel: typeof TabPanel;
-};
+});
 
 export default Tabs;
 export type { TabsContext, TabsOrientation, TabsProps } from './tabs.types.ts';

--- a/packages/components/src/components/tabs/tabs.type-test.ts
+++ b/packages/components/src/components/tabs/tabs.type-test.ts
@@ -1,0 +1,28 @@
+/**
+ * Compile-time regression tests for the `Tabs` compound-component namespace.
+ * svelte-check processes this file; tsc does not (it excludes .svelte imports).
+ *
+ * These verify that the `Object.assign` namespace members resolve and stay
+ * correctly typed WITHOUT a hand-maintained `as typeof Root & { ... }` cast.
+ * If a member is renamed in the `Object.assign` literal (e.g. `Trigger` →
+ * `Tab`), the `satisfies` assertions below stop compiling — surfacing the
+ * drift as a type error instead of silently keeping the old declared type.
+ */
+import type { Component } from 'svelte';
+
+import TabList from '../tab-list/tab-list.svelte';
+import TabPanel from '../tab-panel/tab-panel.svelte';
+import Tab from '../tab/tab.svelte';
+import { Tabs } from './index.ts';
+
+// Each namespace member must resolve and be exactly its source component type.
+const _list: typeof TabList = Tabs.List;
+const _trigger: typeof Tab = Tabs.Trigger;
+const _panel: typeof TabPanel = Tabs.Panel;
+
+// The root remains callable as a component (the `Object.assign` target).
+Tabs satisfies Component<never>;
+
+void _list;
+void _trigger;
+void _panel;

--- a/packages/components/src/components/toolbar/index.ts
+++ b/packages/components/src/components/toolbar/index.ts
@@ -5,10 +5,7 @@ import ToolbarRoot from './toolbar.svelte';
 const Toolbar = Object.assign(ToolbarRoot, {
   Group: ToolbarGroup,
   Spacer: ToolbarSpacer,
-}) as typeof ToolbarRoot & {
-  Group: typeof ToolbarGroup;
-  Spacer: typeof ToolbarSpacer;
-};
+});
 
 export default Toolbar;
 export type {

--- a/packages/components/src/components/toolbar/toolbar.type-test.ts
+++ b/packages/components/src/components/toolbar/toolbar.type-test.ts
@@ -1,0 +1,23 @@
+/**
+ * Compile-time regression tests for the `Toolbar` compound-component namespace.
+ * svelte-check processes this file; tsc does not (it excludes .svelte imports).
+ *
+ * These verify that the `Object.assign` namespace members resolve and stay
+ * correctly typed WITHOUT a hand-maintained `as typeof Root & { ... }` cast.
+ * If a member is renamed in the `Object.assign` literal, the assignments below
+ * stop compiling — surfacing the drift as a type error instead of silently
+ * keeping the old declared type.
+ */
+import type { Component } from 'svelte';
+
+import { Toolbar } from './index.ts';
+import ToolbarGroup from './toolbar-group.svelte';
+import ToolbarSpacer from './toolbar-spacer.svelte';
+
+const _group: typeof ToolbarGroup = Toolbar.Group;
+const _spacer: typeof ToolbarSpacer = Toolbar.Spacer;
+
+Toolbar satisfies Component<never>;
+
+void _group;
+void _spacer;

--- a/packages/components/src/components/tree/index.ts
+++ b/packages/components/src/components/tree/index.ts
@@ -8,9 +8,7 @@ import TreeRoot from './tree.svelte';
  */
 const Tree = Object.assign(TreeRoot, {
   Item: TreeItem,
-}) as typeof TreeRoot & {
-  Item: typeof TreeItem;
-};
+});
 
 export default Tree;
 export type { TreeProps, TreeSelectionBehavior, TreeSelectionMode } from './tree.types.ts';

--- a/packages/components/src/components/tree/tree.type-test.ts
+++ b/packages/components/src/components/tree/tree.type-test.ts
@@ -1,0 +1,20 @@
+/**
+ * Compile-time regression tests for the `Tree` compound-component namespace.
+ * svelte-check processes this file; tsc does not (it excludes .svelte imports).
+ *
+ * These verify that the `Object.assign` namespace members resolve and stay
+ * correctly typed WITHOUT a hand-maintained `as typeof Root & { ... }` cast.
+ * If a member is renamed in the `Object.assign` literal, the assignment below
+ * stops compiling — surfacing the drift as a type error instead of silently
+ * keeping the old declared type.
+ */
+import type { Component } from 'svelte';
+
+import TreeItem from '../tree-item/tree-item.svelte';
+import { Tree } from './index.ts';
+
+const _item: typeof TreeItem = Tree.Item;
+
+Tree satisfies Component<never>;
+
+void _item;


### PR DESCRIPTION
Reviewed by the workflow's adversarial subagent committee (correctness / testing / typescript). Green through the full pre-push gate. Part of the Group A batch (test/refactor tasks, no generated-file changes).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Type-only refactor with no runtime behavior changes; public API shape is preserved and guarded by new compile-time tests.
> 
> **Overview**
> Removes hand-maintained `as typeof Root & { ... }` assertions from compound-component `index.ts` files (Accordion, ContextMenu, Dropdown, Feed, GridList, SideNavigation, StatGroup, Table, Tabs, Toolbar, Tree), relying on `Object.assign` inference instead.
> 
> Adds per-component `*.type-test.ts` files that assert each namespace member matches its leaf Svelte component type and that the root still `satisfies Component<never>`, so renames in the `Object.assign` literal fail at **svelte-check** time instead of drifting from a stale cast.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2df9c2b5468f9f498aa77b967c8aea8864d65f1d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->