### PR TITLE
refactor(components): consolidate optional-context try/catch into one helper

### DIFF
--- a/packages/components/src/_internal/form-field-context.ts
+++ b/packages/components/src/_internal/form-field-context.ts
@@ -1,5 +1,7 @@
 import { createContext } from 'svelte';
 
+import { optionalContext } from './optional-context.ts';
+
 /**
  * Context published by `<FormField>` for descendant controls. Controls read this
  * to wire identity and ARIA. All members are getter properties on the object so
@@ -38,13 +40,9 @@ export function setFormFieldContext(context: FormFieldContext): void {
  * `<FormField>` ancestor exists. Controls rely on the `undefined` contract to
  * fall back to their standalone behavior.
  *
- * Svelte 5's `createContext` getter throws when no provider exists; the wrap
- * preserves the consumer contract.
+ * Svelte 5's `createContext` getter throws when no provider exists;
+ * `optionalContext` converts that throw to `undefined` so the consumer
+ * contract is preserved.
  */
-export function getFormFieldContext(): FormFieldContext | undefined {
-  try {
-    return getFormFieldContextStrict();
-  } catch {
-    return undefined;
-  }
-}
+export const getFormFieldContext: () => FormFieldContext | undefined =
+  optionalContext(getFormFieldContextStrict);

--- a/packages/components/src/_internal/optional-context.test.ts
+++ b/packages/components/src/_internal/optional-context.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, test } from 'bun:test';
+
+import { optionalContext } from './optional-context.ts';
+
+describe('optionalContext', () => {
+  test('returns the value when the strict getter succeeds', () => {
+    const value = { tone: 'raised' };
+    const get = optionalContext(() => value);
+    expect(get()).toBe(value);
+  });
+
+  test('returns undefined when the strict getter throws (no provider)', () => {
+    const get = optionalContext<{ tone: string }>(() => {
+      throw new Error('Context not found');
+    });
+    expect(get()).toBeUndefined();
+  });
+
+  test('does not swallow legitimately falsy values', () => {
+    expect(optionalContext(() => 0)()).toBe(0);
+    expect(optionalContext(() => '')()).toBe('');
+    expect(optionalContext(() => false)()).toBe(false);
+    expect(optionalContext<null>(() => null)()).toBeNull();
+  });
+
+  test('re-reads the strict getter on every call (no caching)', () => {
+    let calls = 0;
+    const get = optionalContext(() => {
+      calls += 1;
+      return calls;
+    });
+    expect(get()).toBe(1);
+    expect(get()).toBe(2);
+    expect(get()).toBe(3);
+  });
+
+  test('catches a throw on one call and recovers on the next', () => {
+    let provided = false;
+    const get = optionalContext(() => {
+      if (!provided) throw new Error('no provider yet');
+      return 'ready';
+    });
+    expect(get()).toBeUndefined();
+    provided = true;
+    expect(get()).toBe('ready');
+  });
+});

--- a/packages/components/src/_internal/optional-context.ts
+++ b/packages/components/src/_internal/optional-context.ts
@@ -1,0 +1,36 @@
+/**
+ * Shared helper for contexts that treat a missing provider as a valid state.
+ *
+ * Svelte 5's `createContext` returns a strict `[get, set]` pair whose `get`
+ * THROWS when no ancestor has called `set`. That contract is exactly right for
+ * required contexts (a `CommandItem` outside a command list is a programmer
+ * error), but several cinder components legitimately support running with no
+ * parent provider — a standalone `<Input>` with no `<FormField>` ancestor, a
+ * `<SideNavigationItem>` in a flat sidebar with no group, and so on. Those
+ * readers want `undefined` on no provider, not a throw.
+ *
+ * Before this helper, each such reader hand-rolled the same
+ * `try { return getStrict() } catch { return undefined }` block. This factors
+ * the throw→undefined conversion into ONE place so the contract is named,
+ * documented, and not re-derived at every call site.
+ */
+
+/**
+ * Wrap a strict context getter (from `createContext`) so it returns `undefined`
+ * when no provider exists instead of throwing. Use this for contexts where a
+ * missing parent provider is a supported, first-class state.
+ *
+ * @param getStrict The strict getter returned by `createContext` (throws when
+ *   no ancestor called `set`).
+ * @returns A getter that yields the context value, or `undefined` when no
+ *   provider is mounted.
+ */
+export function optionalContext<T>(getStrict: () => T): () => T | undefined {
+  return () => {
+    try {
+      return getStrict();
+    } catch {
+      return undefined;
+    }
+  };
+}

--- a/packages/components/src/_internal/sidebar-context.ts
+++ b/packages/components/src/_internal/sidebar-context.ts
@@ -9,6 +9,8 @@
 
 import { createContext } from 'svelte';
 
+import { optionalContext } from './optional-context.ts';
+
 /**
  * Context published by `<Sidebar>` for descendant components. `collapsed` is a
  * getter so reads stay reactive — destructuring breaks reactivity, property
@@ -30,13 +32,9 @@ export function setSidebarContext(context: SidebarContextValue): void {
  * Read the nearest enclosing `<Sidebar>` context. Returns `undefined` when no
  * `<Sidebar>` ancestor exists. Readers must handle the `undefined` case.
  *
- * Svelte 5's `createContext` getter throws when no provider exists; the wrap
- * preserves the consumer contract — `undefined` on no provider.
+ * Svelte 5's `createContext` getter throws when no provider exists;
+ * `optionalContext` converts that throw to `undefined` so the consumer
+ * contract — `undefined` on no provider — is preserved.
  */
-export function getSidebarContext(): SidebarContextValue | undefined {
-  try {
-    return getSidebarContextStrict();
-  } catch {
-    return undefined;
-  }
-}
+export const getSidebarContext: () => SidebarContextValue | undefined =
+  optionalContext(getSidebarContextStrict);

--- a/packages/components/src/_internal/surface-context.ts
+++ b/packages/components/src/_internal/surface-context.ts
@@ -13,6 +13,8 @@
 
 import { createContext } from 'svelte';
 
+import { optionalContext } from './optional-context.ts';
+
 /** The visual affordance of a surface — describes what the surface looks like. */
 export type SurfaceTone = 'default' | 'raised' | 'inset' | 'transparent';
 
@@ -41,13 +43,9 @@ export function setSurfaceContext(context: SurfaceContextValue): void {
  * `<Surface>` ancestor exists. All readers MUST handle the `undefined` case;
  * cinder makes no implicit "default" assumption when there is no parent.
  *
- * Svelte 5's `createContext` getter throws when no provider exists; we wrap
- * it here so the consumer contract — `undefined` on no provider — is preserved.
+ * Svelte 5's `createContext` getter throws when no provider exists;
+ * `optionalContext` converts that throw to `undefined` so the consumer
+ * contract — `undefined` on no provider — is preserved.
  */
-export function getSurfaceContext(): SurfaceContextValue | undefined {
-  try {
-    return getSurfaceContextStrict();
-  } catch {
-    return undefined;
-  }
-}
+export const getSurfaceContext: () => SurfaceContextValue | undefined =
+  optionalContext(getSurfaceContextStrict);

--- a/packages/components/src/components/_internal/side-navigation-group-context.ts
+++ b/packages/components/src/components/_internal/side-navigation-group-context.ts
@@ -20,6 +20,8 @@
 
 import { createContext } from 'svelte';
 
+import { optionalContext } from '../../_internal/optional-context.ts';
+
 /** Registration handle returned to each child item. */
 export type SideNavigationGroupRegistration = {
   /** Report whether this item is currently active. Idempotent per state. */
@@ -42,10 +44,5 @@ export { setSideNavigationGroupContext };
  * Optional read — items outside a group are valid (flat sidebars), so a
  * missing context resolves to `undefined` instead of throwing.
  */
-export function tryGetSideNavigationGroupContext(): SideNavigationGroupContext | undefined {
-  try {
-    return getSideNavigationGroupContextStrict();
-  } catch {
-    return undefined;
-  }
-}
+export const tryGetSideNavigationGroupContext: () => SideNavigationGroupContext | undefined =
+  optionalContext(getSideNavigationGroupContextStrict);


### PR DESCRIPTION
Reviewed by the workflow's adversarial subagent committee (correctness / testing / typescript). Green through the full pre-push gate. Part of the Group A batch (test/refactor tasks, no generated-file changes).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Internal refactor with behavior-preserving optional context reads; covered by new unit tests and no public API changes.
> 
> **Overview**
> Introduces a shared **`optionalContext`** helper that wraps Svelte 5 strict `createContext` getters so a missing provider returns **`undefined`** instead of throwing, and documents when that contract applies.
> 
> **Form field**, **sidebar**, **surface**, and **side navigation group** optional readers are switched from duplicated `try/catch` blocks to **`optionalContext(get…Strict)`** (same exported names and behavior). Adds **`optional-context.test.ts`** covering success, missing provider, falsy values, no caching, and recovery after a later provider appears.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2cfea6b198660f0715e260d8bc6406428515ff91. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->