### PR TITLE
feat(components): enrich analyzer convention errors + AGENTS.md CinderProvider warning

### DIFF
--- a/packages/components/AGENTS.md
+++ b/packages/components/AGENTS.md
@@ -48,9 +48,10 @@ component's CSS. There is no per-component CSS to import.
 ### Provider setup (highlighter context)
 
 > [!WARNING]
-> CinderProvider is planned for removal — CodeBlock will auto-load Shiki without
-> it. Only add this if you need a custom highlighter or scoped highlighting for a
-> subtree.
+> CinderProvider is planned for removal: CodeBlock is moving to auto-load Shiki on
+> its own, so don't scaffold a provider expecting it to be permanent. Today it is
+> still required for highlighting; only add it if you need a custom highlighter or
+> scoped highlighting for a subtree.
 
 `<CodeBlock>` resolves its syntax highlighter through Svelte context. Mount
 **one** `<CinderProvider>` near your app root and every descendant

--- a/packages/components/AGENTS.md
+++ b/packages/components/AGENTS.md
@@ -47,6 +47,11 @@ component's CSS. There is no per-component CSS to import.
 
 ### Provider setup (highlighter context)
 
+> [!WARNING]
+> CinderProvider is planned for removal — CodeBlock will auto-load Shiki without
+> it. Only add this if you need a custom highlighter or scoped highlighting for a
+> subtree.
+
 `<CodeBlock>` resolves its syntax highlighter through Svelte context. Mount
 **one** `<CinderProvider>` near your app root and every descendant
 `<CodeBlock>` shares the highlighter. The recommended default is the

--- a/packages/components/scripts/generate-component-metadata.test.ts
+++ b/packages/components/scripts/generate-component-metadata.test.ts
@@ -8,6 +8,7 @@
 
 import { describe, expect, it } from 'bun:test';
 
+import { categories, statusLevels } from '../src/manifest.meta.ts';
 import { extractFromSource } from './generate-component-metadata.ts';
 
 // ---------------------------------------------------------------------------
@@ -309,6 +310,26 @@ export type { ButtonProps } from './button.types.ts';
     if (result.ok) throw new Error('expected error');
     expect(result.error.reason).toContain('no @cinder metadata header found');
   });
+
+  it('appends an inline fix hint pointing at AGENTS.md for the missing @cinder block', () => {
+    const source = svelteFile(
+      moduleScript(`
+/**
+ * This component exports some types.
+ * @internal
+ */
+export type { ButtonProps } from './button.types.ts';
+`),
+    );
+
+    const result = extract(source);
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('expected error');
+    expect(result.error.reason).toContain(
+      'Add @cinder as the first tag in the <script lang=ts module> JSDoc block',
+    );
+    expect(result.error.reason).toContain('AGENTS.md §The five analyzer conventions');
+  });
 });
 
 describe('error: missing required tags', () => {
@@ -345,9 +366,36 @@ describe('error: missing required tags', () => {
     const result = extract(source);
     expect(result.ok).toBe(false);
     if (result.ok) throw new Error('expected error');
+    // The appended minimal-block fix snippet always lists all three tags, so
+    // the missing-list correctness guard must scope to the "missing required
+    // tags:" prefix (everything before the "\n  Fix:" marker) rather than the
+    // whole message. Split on the marker and assert the prefix enumerates ONLY
+    // the genuinely-missing tag and does not spuriously list present ones.
+    const prefix = result.error.reason.split('\n  Fix:')[0];
+    expect(prefix).toContain('@purpose');
+    expect(prefix).not.toContain('@category');
+    expect(prefix).not.toContain('@status');
+    expect(result.error.reason).toContain('the minimal block is');
+  });
+
+  it('appends the minimal @cinder block snippet as an inline fix', () => {
+    const source = svelteFile(
+      moduleScript(`
+/**
+ * @cinder
+ * @tag action
+ */
+`),
+    );
+
+    const result = extract(source);
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('expected error');
+    expect(result.error.reason).toContain('the minimal block is');
+    expect(result.error.reason).toContain('@cinder');
+    expect(result.error.reason).toContain('@category');
+    expect(result.error.reason).toContain('@status');
     expect(result.error.reason).toContain('@purpose');
-    expect(result.error.reason).not.toContain('@category');
-    expect(result.error.reason).not.toContain('@status');
   });
 });
 
@@ -389,6 +437,27 @@ describe('error: unknown category id', () => {
     if (result.ok) throw new Error('expected error');
     expect(result.error.reason).toContain("unknown category 'widgets'");
   });
+
+  it('lists every valid category inline', () => {
+    const source = svelteFile(
+      moduleScript(`
+/**
+ * @cinder
+ * @category widgets
+ * @status stable
+ * @purpose Some component.
+ */
+`),
+    );
+
+    const result = extract(source);
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('expected error');
+    expect(result.error.reason).toContain('Valid values:');
+    for (const category of Object.keys(categories)) {
+      expect(result.error.reason).toContain(category);
+    }
+  });
 });
 
 describe('error: unknown status id', () => {
@@ -408,6 +477,27 @@ describe('error: unknown status id', () => {
     expect(result.ok).toBe(false);
     if (result.ok) throw new Error('expected error');
     expect(result.error.reason).toContain("unknown status 'released'");
+  });
+
+  it('lists every valid status inline', () => {
+    const source = svelteFile(
+      moduleScript(`
+/**
+ * @cinder
+ * @category action
+ * @status released
+ * @purpose Some action component.
+ */
+`),
+    );
+
+    const result = extract(source);
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('expected error');
+    expect(result.error.reason).toContain('Valid values:');
+    for (const status of Object.keys(statusLevels)) {
+      expect(result.error.reason).toContain(status);
+    }
   });
 });
 

--- a/packages/components/scripts/generate-component-metadata.test.ts
+++ b/packages/components/scripts/generate-component-metadata.test.ts
@@ -326,7 +326,7 @@ export type { ButtonProps } from './button.types.ts';
     expect(result.ok).toBe(false);
     if (result.ok) throw new Error('expected error');
     expect(result.error.reason).toContain(
-      'Add @cinder as the first tag in the <script lang=ts module> JSDoc block',
+      'Add @cinder as the first tag in the <script lang="ts" module> JSDoc block',
     );
     expect(result.error.reason).toContain('AGENTS.md §The five analyzer conventions');
   });

--- a/packages/components/scripts/generate-component-metadata.ts
+++ b/packages/components/scripts/generate-component-metadata.ts
@@ -137,6 +137,20 @@ function parseTagsFromLines(lines: string[], cinderIndex: number): ParsedTag[] {
 }
 
 /**
+ * Inline fix appended to the "no @cinder metadata header found" failure.
+ * Tells the author exactly where the tag goes and where to read more.
+ */
+const NO_CINDER_HEADER_FIX =
+  '\n  Fix: Add @cinder as the first tag in the <script lang=ts module> JSDoc block. See AGENTS.md §The five analyzer conventions.';
+
+/**
+ * Inline fix appended to the "missing required tags" failure. A copy-pasteable
+ * minimal block showing the three mandatory tags in context.
+ */
+const MISSING_REQUIRED_TAGS_FIX =
+  '\n  Fix: the minimal block is:\n  /**\n   * @cinder\n   * @category <one of the values above>\n   * @status <one of the values above>\n   * @purpose <one-sentence description>\n   */';
+
+/**
  * Return a short "did you mean X?" hint when `actual` shares a leading
  * prefix with one of the `candidates`. Only fires when the match is
  * reasonably strong (≥4 shared leading characters).
@@ -196,7 +210,7 @@ export function extractFromSource(
   // Step 2 — Parse JSDoc tags after `@cinder`.
   const tags = parseCinderTags(scriptContent);
   if (tags === null) {
-    return fail(`no @cinder metadata header found in ${filePath}`);
+    return fail(`no @cinder metadata header found in ${filePath}${NO_CINDER_HEADER_FIX}`);
   }
 
   // Step 3 — Bucket tag values by name.
@@ -249,7 +263,7 @@ export function extractFromSource(
   if (statusValues.length === 0) missing.push('@status');
   if (purposeValues.length === 0) missing.push('@purpose');
   if (missing.length > 0) {
-    return fail(`missing required tags: ${missing.join(', ')}`);
+    return fail(`missing required tags: ${missing.join(', ')}${MISSING_REQUIRED_TAGS_FIX}`);
   }
 
   const categoryRaw = categoryValues[0]!;
@@ -258,13 +272,17 @@ export function extractFromSource(
 
   // Step 6 — Validate closed vocabulary ids.
   if (!isCategoryId(categoryRaw)) {
+    const categoryKeys = Object.keys(categories);
     return fail(
-      `unknown category '${categoryRaw}'${didYouMean(categoryRaw, Object.keys(categories))}`,
+      `unknown category '${categoryRaw}'${didYouMean(categoryRaw, categoryKeys)}. Valid values: ${categoryKeys.join(', ')}`,
     );
   }
 
   if (!isStatusLevel(statusRaw)) {
-    return fail(`unknown status '${statusRaw}'${didYouMean(statusRaw, Object.keys(statusLevels))}`);
+    const statusKeys = Object.keys(statusLevels);
+    return fail(
+      `unknown status '${statusRaw}'${didYouMean(statusRaw, statusKeys)}. Valid values: ${statusKeys.join(', ')}`,
+    );
   }
 
   // Step 7 — Validate @purpose constraints.

--- a/packages/components/scripts/generate-component-metadata.ts
+++ b/packages/components/scripts/generate-component-metadata.ts
@@ -141,14 +141,14 @@ function parseTagsFromLines(lines: string[], cinderIndex: number): ParsedTag[] {
  * Tells the author exactly where the tag goes and where to read more.
  */
 const NO_CINDER_HEADER_FIX =
-  '\n  Fix: Add @cinder as the first tag in the <script lang=ts module> JSDoc block. See AGENTS.md §The five analyzer conventions.';
+  '\n  Fix: Add @cinder as the first tag in the <script lang="ts" module> JSDoc block. See AGENTS.md §The five analyzer conventions.';
 
 /**
  * Inline fix appended to the "missing required tags" failure. A copy-pasteable
  * minimal block showing the three mandatory tags in context.
  */
 const MISSING_REQUIRED_TAGS_FIX =
-  '\n  Fix: the minimal block is:\n  /**\n   * @cinder\n   * @category <one of the values above>\n   * @status <one of the values above>\n   * @purpose <one-sentence description>\n   */';
+  '\n  Fix: the minimal block is:\n  /**\n   * @cinder\n   * @category <valid category id — see AGENTS.md §The five analyzer conventions>\n   * @status <valid status id — see AGENTS.md §The five analyzer conventions>\n   * @purpose <one-sentence description>\n   */';
 
 /**
  * Return a short "did you mean X?" hint when `actual` shares a leading


### PR DESCRIPTION
Reviewed by the workflow's adversarial subagent committee (correctness / testing / typescript). Green through the full pre-push gate. Part of the Group A batch (test/refactor tasks, no generated-file changes).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to contributor docs, metadata generator error strings, and unit tests; no component runtime or public API behavior changes.
> 
> **Overview**
> **Consumer docs:** Adds a warning under Provider setup that `CinderProvider` is planned for removal once `CodeBlock` auto-loads Shiki, and that apps should only add it today for custom or scoped highlighters.
> 
> **Metadata extractor DX:** `@cinder` validation failures now ship actionable fixes—missing `@cinder` points to AGENTS.md; missing required tags append a copy-paste minimal JSDoc block; unknown `@category` / `@status` errors include the full allowed id lists from `manifest.meta.ts` (still with optional “did you mean” hints).
> 
> **Tests:** Unit tests cover the new fix snippets, the partial-missing-tags case (assertions scoped before the `Fix:` block so the template snippet does not confuse the missing-tag list), and that every valid category/status appears in unknown-id errors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d0aac937ba38edc6fd3e1c5b9ff1fb3f1993406b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->