### PR TITLE
docs(components): affirm schema/variables exports are type-only metadata

### DIFF
--- a/packages/components/AGENTS.md
+++ b/packages/components/AGENTS.md
@@ -178,12 +178,14 @@ type ButtonSchema = typeof ButtonSchemaModule.default;
 ```
 
 > [!WARNING]
-> Do **not** use a default-only `import type ButtonSchemaModule from '…'`. That
-> binds `ButtonSchemaModule` to the **type of the default export** (`ComponentSchema`
-> directly), not the module namespace — so `typeof ButtonSchemaModule.default` fails
-> with `TS2339: Property 'default' does not exist on type 'ComponentSchema'`. Use
-> `import type * as` (namespace import) to bind the module namespace, where `.default`
-> correctly refers to the default-exported value.
+> Do **not** use a default-only `import type ButtonSchemaModule from '…'`. The failure
+> mode depends on your `moduleResolution`: under `bundler`, `node16`, or
+> `nodenext`-with-ESM-interop it errors with `TS2339: Property 'default' does not exist
+on type 'ComponentSchema'`; under `nodenext`'s CJS interop path it silently widens
+> `typeof ButtonSchemaModule.default` to `any`—no error, but you lose the schema type
+> entirely. Either way the default-import form is wrong. Use `import type * as` (namespace
+> import) to bind the module namespace, where `.default` correctly refers to the
+> default-exported value under every resolver.
 
 The resulting type describes a JSON Schema draft 2020-12 document: required
 props, prop types, enum values, and defaults are all there.

--- a/packages/components/AGENTS.md
+++ b/packages/components/AGENTS.md
@@ -170,19 +170,20 @@ modules**. They ship `types` + `svelte` conditions only — no `node`/`default`
 runtime condition, because the build emits no `.schema.js`/`.variables.js`. The
 default export is a **value** (`declare const _default: ComponentSchema`), so
 reach its type with `typeof`. Take it through `import(...)` as shown above, or
-off the default binding of an `import type`:
+off the namespace binding of an `import type * as`:
 
 ```ts
-import type ButtonSchemaModule from 'cinder/button/schema';
+import type * as ButtonSchemaModule from 'cinder/button/schema';
 type ButtonSchema = typeof ButtonSchemaModule.default;
 ```
 
 > [!WARNING]
-> A default-only `import type ButtonSchemaModule from '…'` binds the **module
-> namespace**, not the schema. Using that bare name in a type position fails
-> (`TS2709`/`TS2749`). Always reach the type through `typeof` — either
-> `typeof import('cinder/button/schema').default` or
-> `typeof ButtonSchemaModule.default`.
+> Do **not** use a default-only `import type ButtonSchemaModule from '…'`. That
+> binds `ButtonSchemaModule` to the **type of the default export** (`ComponentSchema`
+> directly), not the module namespace — so `typeof ButtonSchemaModule.default` fails
+> with `TS2339: Property 'default' does not exist on type 'ComponentSchema'`. Use
+> `import type * as` (namespace import) to bind the module namespace, where `.default`
+> correctly refers to the default-exported value.
 
 The resulting type describes a JSON Schema draft 2020-12 document: required
 props, prop types, enum values, and defaults are all there.

--- a/packages/components/AGENTS.md
+++ b/packages/components/AGENTS.md
@@ -162,14 +162,54 @@ subpaths you fetch next.
 **2. Fetch the prop signature.**
 
 ```ts
-import buttonSchema from 'cinder/button/schema';
+type ButtonSchema = typeof import('cinder/button/schema').default;
 ```
 
-`cinder/<name>/schema` and `cinder/<name>/variables` are **TypeScript modules**
-whose default export is the data — you can import them as regular ESM and
-TypeScript will type-narrow the result. The schema itself is a JSON Schema
-draft 2020-12 document. Required props, prop types, enum values, and defaults
-are all there.
+`cinder/<name>/schema` and `cinder/<name>/variables` are **type-only metadata
+modules**. They ship `types` + `svelte` conditions only — no `node`/`default`
+runtime condition, because the build emits no `.schema.js`/`.variables.js`. The
+default export is a **value** (`declare const _default: ComponentSchema`), so
+reach its type with `typeof`. Take it through `import(...)` as shown above, or
+off the default binding of an `import type`:
+
+```ts
+import type ButtonSchemaModule from 'cinder/button/schema';
+type ButtonSchema = typeof ButtonSchemaModule.default;
+```
+
+> [!WARNING]
+> A default-only `import type ButtonSchemaModule from '…'` binds the **module
+> namespace**, not the schema. Using that bare name in a type position fails
+> (`TS2709`/`TS2749`). Always reach the type through `typeof` — either
+> `typeof import('cinder/button/schema').default` or
+> `typeof ButtonSchemaModule.default`.
+
+The resulting type describes a JSON Schema draft 2020-12 document: required
+props, prop types, enum values, and defaults are all there.
+
+> [!WARNING]
+> Do not `import` these for their runtime value from a plain Node or Vite
+> (non-Svelte) consumer. Because there is no `default` condition, the runtime
+> resolver throws `ERR_PACKAGE_PATH_NOT_EXPORTED`. That is intentional — these
+> subpaths are metadata, not runtime entry points.
+
+If you genuinely need the schema as a runtime **value** (e.g. to feed a form
+generator or validator), read the JSON sidecar that ships alongside the module.
+Anchor the path off the package root — resolve `cinder/package.json` (which _is_
+an export) and join to the sidecar so you never hardcode a `node_modules` layout:
+
+```ts
+import { readFile } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const packageRoot = dirname(fileURLToPath(import.meta.resolve('cinder/package.json')));
+const sidecar = join(packageRoot, 'src/components/button/button.schema.json');
+const buttonSchema = JSON.parse(await readFile(sidecar, 'utf-8'));
+```
+
+The authoritative, machine-readable index for every component is `cinder/manifest`
+(step 1) — prefer it over hand-resolving sidecar paths whenever you can.
 
 **3. Fetch the cross-prop constraints — when `hasConstraints` is true.**
 

--- a/packages/components/fixtures/sveltekit-consumer/src/routes/+page.svelte
+++ b/packages/components/fixtures/sveltekit-consumer/src/routes/+page.svelte
@@ -29,7 +29,9 @@
   let currentPage = $state(1);
   let inputValue = $state('');
   let textareaValue = $state('');
-  let selectValue = $state('option-a');
+  // Select is generic over its option value union (#192); the bound value must
+  // be one of the literal option values, not a widened `string`.
+  let selectValue = $state<'option-a' | 'option-b'>('option-a');
   let togglePressed = $state(false);
   let modalOpen = $state(false);
   let dropdownOpen = $state(false);

--- a/packages/components/fixtures/sveltekit-consumer/src/routes/subpath/+page.svelte
+++ b/packages/components/fixtures/sveltekit-consumer/src/routes/subpath/+page.svelte
@@ -25,7 +25,9 @@
   let currentPage = $state(1);
   let inputValue = $state('');
   let textareaValue = $state('');
-  let selectValue = $state('option-a');
+  // Select is generic over its option value union (#192); this fixture offers a
+  // single option, so the bound value is the `'option-a'` literal.
+  let selectValue = $state<'option-a'>('option-a');
   let togglePressed = $state(false);
   let modalOpen = $state(false);
   let dropdownOpen = $state(false);

--- a/packages/components/scripts/generate-exports.test.ts
+++ b/packages/components/scripts/generate-exports.test.ts
@@ -79,6 +79,36 @@ describe('computeExports', () => {
     });
   });
 
+  // Tripwire (the inverse of the test above). The schema/variables subpaths are
+  // metadata, not runtime entry points: the build emits no `.schema.js` /
+  // `.variables.js`, so there is no target a runtime condition could point at.
+  // Adding `node`/`default`/`import` here would advertise a runtime export that
+  // resolves to a non-existent file — the exact regression task 4176c51c was
+  // filed against. The manifest-consumer fixture positively asserts these throw
+  // ERR_PACKAGE_PATH_NOT_EXPORTED at Node runtime; this unit test pins the same
+  // contract at the generator so a stray `default` is caught before it ships.
+  it('never emits a runtime condition on /schema or /variables', () => {
+    const out = computeExports([
+      { name: 'button', isExperimental: false, hasCss: false },
+      { name: 'lab', isExperimental: true, hasCss: false },
+    ]);
+    const runtimeConditions = ['node', 'default', 'import'] as const;
+    for (const key of [
+      './button/schema',
+      './button/variables',
+      './experimental/lab/schema',
+      './experimental/lab/variables',
+    ]) {
+      const entry = out[key]!;
+      expect(entry).toBeDefined();
+      for (const condition of runtimeConditions) {
+        expect(entry).not.toHaveProperty(condition);
+      }
+      // Only the type-narrowing conditions are present.
+      expect(Object.keys(entry)).toEqual(['types', 'svelte']);
+    }
+  });
+
   it('routes experimental components through the experimental dist paths', () => {
     const out = computeExports([{ name: 'lab', isExperimental: true, hasCss: false }]);
     expect(out['./experimental/lab']).toEqual({

--- a/packages/components/scripts/generate-exports.ts
+++ b/packages/components/scripts/generate-exports.ts
@@ -340,8 +340,23 @@ export function computeExports(
     });
 
     // Schema and variables modules ship as source + types only. They are
-    // metadata, not runtime entry points; no JS is emitted for them so we
-    // intentionally do not add `node`/`default` here.
+    // metadata, not runtime entry points; no JS is emitted for them (the build
+    // produces only `.schema.d.ts` / `.variables.d.ts`, never `.schema.js`), so
+    // there is no target a `node`/`default`/`import` condition could point at.
+    //
+    // This is a deliberate contract, NOT a missing-`default` bug: adding a
+    // runtime condition here would advertise an export that resolves to a
+    // non-existent file. A Node/Vite consumer that resolves the default
+    // condition therefore gets `ERR_PACKAGE_PATH_NOT_EXPORTED` — by design.
+    //   • The unit test "never emits a runtime condition on /schema or
+    //     /variables" (generate-exports.test.ts) pins this at the generator.
+    //   • The manifest-consumer fixture (fixtures/manifest-consumer/check.mjs)
+    //     positively asserts the throw against the packed tarball at runtime.
+    //   • AGENTS.md § Discovery recipe documents the type-only contract and the
+    //     runtime escape hatch (read the `<name>.schema.json` sidecar) for the
+    //     rare consumer that genuinely needs the JSON value at runtime.
+    // If schema/variables ever become runtime entry points, all three must move
+    // together.
     out[`${prefix}/schema`] = orderedExportEntry({
       types: `${distDir}/${name}.schema.d.ts`,
       svelte: `${srcDir}/${name}.schema.ts`,


### PR DESCRIPTION
## Summary
Investigation outcome, not the original mechanical "add a \`default\` condition" the task assumed. Per-component \`*/schema\` and \`*/variables\` exports emit **no runtime JS by design** (they ship \`types\` + \`svelte\` conditions only) — so there is no \`default\` target to point at, and \`cinder/<name>/schema\` correctly throws \`ERR_PACKAGE_PATH_NOT_EXPORTED\` at Node runtime. This PR affirms that contract and documents the correct way to consume the schema **type** in AGENTS.md, with a resolution-aware WARNING about the default-import footgun (errors under bundler; silently widens to \`any\` under nodenext). The \`manifest-consumer\` tripwire that asserts the throw stays green.

## Review committee
Pre-reviewed (build + recheck rounds) — APPROVED after empirical verification: every documented snippet was compiled against the real emitted \`button.schema.d.ts\` under both \`nodenext\` and \`bundler\` + \`verbatimModuleSyntax\`. A recheck caught that the WARNING's TS2339 claim wasn't universal (silent \`any\` under nodenext); now corrected.

> [!WARNING]
> Codex (the adversarial second-opinion reviewer) was unavailable (out of credits); the subagent committee reviewed in its place.

## Test plan
\`bun run typecheck\` (0 errors), \`bun run components:check\` + \`bun run exports:check\` (zero drift). generate-exports tripwire test asserts /schema + /variables never emit a runtime condition.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation, export-generator comments/tests, and fixture typing only—no runtime export map or component behavior changes in the diff.
> 
> **Overview**
> This PR **documents and locks in** the intentional contract that `cinder/<name>/schema` and `cinder/<name>/variables` are **type-only metadata** (`types` + `svelte` export conditions only—no runtime JS), not a missing `default` export bug.
> 
> **AGENTS.md** expands the discovery recipe: how to get schema **types** (`typeof import('…').default` or `import type * as`), warnings against default-only type imports and runtime imports (expect `ERR_PACKAGE_PATH_NOT_EXPORTED`), and how to load the `.schema.json` sidecar when a runtime JSON value is needed.
> 
> **`generate-exports.ts`** comments tie the generator behavior to the unit test, manifest-consumer fixture, and AGENTS.md. A new **`generate-exports.test.ts`** tripwire asserts `/schema` and `/variables` never get `node`, `default`, or `import` conditions (including experimental paths).
> 
> **SvelteKit consumer fixtures** narrow `selectValue` to literal option unions so they typecheck with **Select**’s generic value typing (#192).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4c9f4b495e13f711ae9c334f39e9e9e42de81daf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->