### PR TITLE
test(markdown): fix two CI-only main-green test failures

### DIFF
--- a/packages/markdown/src/import-graph.test.ts
+++ b/packages/markdown/src/import-graph.test.ts
@@ -54,23 +54,67 @@ const RENDERING_MARKERS = ['scopeName', 'katex', '@shikijs', 'shiki'] as const;
 // `@cinder/markdown` self-reference resolves.
 const PACKAGE_ROOT = join(import.meta.dirname, '..');
 
+// Maximum number of Bun.build attempts per snippet. See `isTransientReadError`.
+const MAX_BUILD_ATTEMPTS = 5;
+
+/**
+ * Detect the transient filesystem read errors Bun's bundler throws on Linux
+ * when the same source file is touched concurrently by another process.
+ *
+ * Under CI the whole workspace runs `bun run --filter='*' test`, so the
+ * `@cinder/diff` package's own `bun test` process reads
+ * `packages/diff/src/line-diff.ts` at the same moment this test's
+ * `Bun.build` resolves that file through the `@cinder/diff/line-diff`
+ * re-export. On Linux that race surfaces as a transient
+ * `EISDIR reading file: ".../line-diff.ts"` or
+ * `Unexpected reading file: ".../line-diff.ts"` from the bundler — the
+ * file is a regular `.ts`, never a directory, and a fresh read succeeds.
+ * It never reproduces locally (single process) or on macOS. Retrying the
+ * build is the correct response: it preserves every leanness assertion and
+ * only papers over a known upstream bundler flake, not a real defect.
+ */
+function isTransientReadError(message: string): boolean {
+  return /(?:EISDIR|Unexpected) reading file:/.test(message);
+}
+
+async function buildOnce(entry: string): Promise<string> {
+  const result = await Bun.build({
+    entrypoints: [entry],
+    target: 'browser',
+    format: 'esm',
+    conditions: ['bun'],
+  });
+  if (!result.success) {
+    throw new Error(`Build failed:\n${result.logs.map(String).join('\n')}`);
+  }
+  const output = result.outputs[0];
+  if (!output) throw new Error('Build produced no output');
+  return await output.text();
+}
+
 async function bundleSnippet(snippet: string): Promise<string> {
   const dir = mkdtempSync(join(PACKAGE_ROOT, '.import-graph-'));
   const entry = join(dir, 'entry.ts');
   writeFileSync(entry, snippet);
   try {
-    const result = await Bun.build({
-      entrypoints: [entry],
-      target: 'browser',
-      format: 'esm',
-      conditions: ['bun'],
-    });
-    if (!result.success) {
-      throw new Error(`Build failed:\n${result.logs.map(String).join('\n')}`);
+    let lastError: unknown;
+    for (let attempt = 1; attempt <= MAX_BUILD_ATTEMPTS; attempt++) {
+      try {
+        return await buildOnce(entry);
+      } catch (error) {
+        lastError = error;
+        if (attempt < MAX_BUILD_ATTEMPTS && isTransientReadError(String(error))) {
+          // Brief backoff so the concurrent reader's file-access window can
+          // close before we retry, instead of re-hitting the race instantly.
+          await Bun.sleep(25 * attempt);
+          continue;
+        }
+        throw error;
+      }
     }
-    const output = result.outputs[0];
-    if (!output) throw new Error('Build produced no output');
-    return await output.text();
+    // Unreachable: the loop either returns or throws, but TypeScript needs a
+    // terminal statement after the bounded retry.
+    throw lastError;
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }

--- a/packages/markdown/src/rendering/security.test.ts
+++ b/packages/markdown/src/rendering/security.test.ts
@@ -265,7 +265,16 @@ const x = 1;
       expect(result.html).toContain('<h1>Safe Heading</h1>');
       expect(result.html).toContain('<strong>safe</strong>');
       expect(result.html).toContain('href="https://example.com"');
-      expect(result.html).toContain('const x = 1;');
+      // The fenced `js` block survives sanitization. Assert on the code's
+      // text content rather than the literal `const x = 1;` substring:
+      // when the Shiki highlighter singleton has been initialized by an
+      // earlier render (it persists process-wide), the block is tokenized
+      // into per-token `<span>`s and the literal joined string no longer
+      // appears in the markup even though every character is still present.
+      // Stripping tags makes the assertion deterministic regardless of
+      // whether highlighting ran.
+      const textContent = result.html.replaceAll(/<[^>]+>/g, '');
+      expect(textContent).toContain('const x = 1;');
 
       // Dangerous content removed
       expect(result.html).not.toContain('<script');


### PR DESCRIPTION
## Summary
Fixes two pre-existing `main-green` failures in `@cinder/markdown` that were red since before recent work and reproduce only in CI (the tests pass locally). Both are in a package the recent component PRs did not touch.

1. **import-graph leanness (2 tests)** — Bun's bundler intermittently throws `EISDIR reading file` / `Unexpected reading file` on `packages/diff/src/line-diff.ts`, a Linux-only bundler FS race triggered when the whole workspace runs `bun run --filter='*' test` concurrently and `@cinder/diff`'s own test reads that source at the same moment `Bun.build` resolves it through the re-export (upstream Bun #17607 / #11123). `bundleSnippet` now retries `Bun.build` up to 5 times, matching **only** those exact transient-read error strings — a real \"rendering payload leaked\" assertion is thrown *after* the build returns and is never retried, so the leanness guarantee is intact.

2. **XSS `handles markdown mixed with dangerous HTML`** — an order-dependent test bug: the test asserted the literal `const x = 1;` substring, which breaks once Shiki's process-wide highlighter singleton (initialized by an earlier test file) tokenizes the code block into per-token `<span>`s. Now strips tags and asserts the text content. **All dangerous-content assertions (`not.toContain('<script')`, `<iframe`, `hadUnsafeContent`) are unchanged** and still operate on the raw HTML.

## Review committee
Pre-reviewed by testing-expert + security-reviewer — both APPROVED, no must-fix.
- testing-expert traced the control flow: the retry catches only `buildOnce` errors; `assertNoRenderingPayload` runs after `bundleSnippet` returns, so a real leak fails immediately — the retry cannot mask it.
- security-reviewer confirmed the tag-stripping applies only to the safe-code assertion; the dangerous-content negative assertions are untouched, and rehype-sanitize (allowing only `className`/`style` on spans) is the real boundary.

> [!WARNING]
> Codex (the adversarial second-opinion reviewer) was unavailable for this PR (out of credits). The subagent committee reviewed in its place.

## Test plan
`cd packages/markdown && bun test` — 751 pass, 0 fail. Validated the retry via fault injection (recovers from up to 4 transient EISDIR, re-throws after the cap, never matches assertion failures) and the XSS fix both with the highlighter warm (CI ordering) and in isolation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes with no production code paths; security assertions for dangerous HTML remain on raw markup.
> 
> **Overview**
> Stabilizes two **CI-only** failures in `@cinder/markdown` tests; production rendering and sanitization behavior are unchanged.
> 
> **Import-graph leanness** — `bundleSnippet` now retries `Bun.build` up to five times with short backoff when the bundler throws Linux-only transient read errors (`EISDIR` / `Unexpected reading file` on shared sources under parallel `bun test`). Retries apply only to those messages during the build step; **rendering-payload leak checks still run once on the final bundle**, so a real regression cannot be masked by retries.
> 
> **XSS mixed-content test** — The safe fenced `js` block is verified by **text after stripping HTML tags** instead of the literal `const x = 1;` substring in raw HTML, so the assertion stays valid when Shiki’s process-wide highlighter wraps tokens in `<span>`s. **Script/iframe removal and `hadUnsafeContent` checks on raw HTML are unchanged.**
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c854401112f5a3f08f4dcb61b0a7923f629ced25. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->