### PR TITLE
feat(playground): 18 playground improvements (bugs, perf, a11y, UX, DX, deploy config)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,6 @@
 NODE_ENV=development
 PORT=3000
+
+# Absolute origin for the playground shell's canonical and Open Graph URLs
+# (e.g. https://playground.cinder.dev). Leave empty to omit absolute-URL tags.
+PLAYGROUND_BASE_URL=

--- a/.github/workflows/deploy-playground.yaml
+++ b/.github/workflows/deploy-playground.yaml
@@ -1,0 +1,169 @@
+name: deploy-playground
+
+# Deploys the cinder playground (@cinder/playground) to Vercel.
+#
+#   - push to `main`  → production deployment (vercel deploy --prod)
+#   - pull_request    → preview deployment, with the URL surfaced in the job
+#                       summary. Previews are best-effort: a fork PR has no
+#                       access to the encrypted secrets and the job is skipped.
+#
+# The playground is a Bun.serve server that builds Svelte bundles on the fly
+# (no SvelteKit, no Vite). On Vercel it runs as a single Bun Function — see
+# packages/playground/api/index.ts and packages/playground/vercel.json.
+#
+# One-time setup (token, org id, project id, project root directory) is
+# documented in CONTRIBUTING.md § "Deploying the playground to Vercel".
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'packages/playground/**'
+      - 'packages/components/**'
+      - '.github/workflows/deploy-playground.yaml'
+      - 'package.json'
+      - 'bun.lock'
+  pull_request:
+    paths:
+      - 'packages/playground/**'
+      - 'packages/components/**'
+      - '.github/workflows/deploy-playground.yaml'
+      - 'package.json'
+      - 'bun.lock'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: deploy-playground-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  BUN_VERSION: 1.3.13
+  VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+  VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+  # Pass the token through the environment (quoted "$VERCEL_TOKEN" in the steps)
+  # rather than interpolating ${{ secrets.* }} into the run: script, so a token
+  # containing a shell metacharacter can't break the command and a later set -x
+  # can't expand it before GitHub's log redaction.
+  VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+
+jobs:
+  # Preflight gate: decide whether a real deploy can run. `secrets` is NOT
+  # available in a job-level `if:` (only github/needs/vars/inputs are), so we
+  # check the token inside a step here and expose the result as an output the
+  # deploy job gates on. This skips (neutral, not failing) the deploy when the
+  # Vercel secrets haven't been configured yet — see CONTRIBUTING.md
+  # § "Deploying the playground to Vercel" for the one-time setup.
+  preflight:
+    name: deploy-playground-preflight
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    # Fork PRs can't read encrypted secrets at all — skip even the preflight.
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
+    outputs:
+      can_deploy: ${{ steps.check.outputs.can_deploy }}
+    steps:
+      - name: Check Vercel credentials are configured
+        id: check
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+        run: |
+          if [ -n "$VERCEL_TOKEN" ]; then
+            echo "can_deploy=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "can_deploy=false" >> "$GITHUB_OUTPUT"
+            echo "VERCEL_TOKEN is not set — skipping deploy. Configure the Vercel secrets per CONTRIBUTING.md to enable." >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+  deploy:
+    name: deploy-playground
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    needs: preflight
+    if: ${{ needs.preflight.outputs.can_deploy == 'true' }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v1
+        with:
+          bun-version: ${{ env.BUN_VERSION }}
+
+      - name: Cache Bun install
+        uses: actions/cache@v4
+        with:
+          path: ~/.bun/install/cache
+          key: bun-${{ runner.os }}-${{ runner.arch }}-${{ env.BUN_VERSION }}-${{ hashFiles('bun.lock') }}
+          restore-keys: |
+            bun-${{ runner.os }}-${{ runner.arch }}-${{ env.BUN_VERSION }}-
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Install Vercel CLI
+        run: bun add --global vercel@latest
+
+      - name: Determine environment
+        id: environment
+        run: |
+          if [ "${{ github.event_name }}" = "push" ] || [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "vercel=production" >> "$GITHUB_OUTPUT"
+          else
+            echo "vercel=preview" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Pull Vercel environment information
+        run: vercel pull --yes --environment="${{ steps.environment.outputs.vercel }}" --token="$VERCEL_TOKEN"
+
+      - name: Build with Vercel
+        run: |
+          if [ "${{ steps.environment.outputs.vercel }}" = "production" ]; then
+            vercel build --prod --token="$VERCEL_TOKEN"
+          else
+            vercel build --token="$VERCEL_TOKEN"
+          fi
+
+      - name: Deploy to Vercel
+        id: deploy
+        run: |
+          if [ "${{ steps.environment.outputs.vercel }}" = "production" ]; then
+            url=$(vercel deploy --prebuilt --prod --token="$VERCEL_TOKEN")
+          else
+            url=$(vercel deploy --prebuilt --token="$VERCEL_TOKEN")
+          fi
+          echo "url=$url" >> "$GITHUB_OUTPUT"
+
+      - name: Smoke-test the deployment
+        run: |
+          url="${{ steps.deploy.outputs.url }}"
+          echo "Probing $url/ping"
+          # Vercel deployment URLs sit behind deployment protection on some
+          # plans; a 401 here means the deploy succeeded but the URL is gated,
+          # which is not a deploy failure. Treat 200 (pong) as the pass signal
+          # and surface anything else without failing the job.
+          status=$(curl -s -o /tmp/ping.txt -w '%{http_code}' "$url/ping" || echo "000")
+          body=$(cat /tmp/ping.txt 2>/dev/null || echo "")
+          echo "HTTP $status — body: $body"
+          if [ "$status" = "200" ] && [ "$body" = "pong" ]; then
+            echo "Health check passed." >> "$GITHUB_STEP_SUMMARY"
+          elif [ "$status" = "401" ] || [ "$status" = "403" ]; then
+            # The deploy itself succeeded; the URL is gated by Vercel deployment
+            # protection. Surface it, but don't fail the job.
+            echo "Deployment gated by Vercel deployment protection (HTTP $status) — deploy succeeded, verify the URL manually." >> "$GITHUB_STEP_SUMMARY"
+          else
+            # A real broken deploy (5xx, 000, 200-without-pong, etc.) must red-X
+            # the workflow rather than passing silently with only a summary note.
+            echo "::error::Health check failed: $url/ping returned HTTP $status (body: $body), expected 'pong'."
+            echo "Health check FAILED (HTTP $status, body: $body)." >> "$GITHUB_STEP_SUMMARY"
+            exit 1
+          fi
+
+      - name: Report deployment URL
+        run: |
+          echo "### Playground deployment (${{ steps.environment.outputs.vercel }})" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "${{ steps.deploy.outputs.url }}" >> "$GITHUB_STEP_SUMMARY"

--- a/.gitignore
+++ b/.gitignore
@@ -102,6 +102,12 @@ repomix-output.xml
 .env.*.local
 tmp/
 
+# Vercel CLI local state (vercel pull / vercel build write here)
+.vercel/
+
+# Playground Vercel build output (function-only deploy; no real static assets)
+packages/playground/public/
+
 # Playground server temporary wrapper files
 scripts/playground/.controls-*.svelte
 # Per-build UUID temp dirs created by buildBundle/buildPageBundle.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,6 +66,64 @@ If a local pre-push failure looks unrelated to your branch, check the latest `ma
 
 This workflow runs on pushes to `main`, on a daily schedule, and by manual dispatch. It is a default-branch monitor, not a pull-request required check: this repository currently reports `Branch not protected` for `main`, and `main-green / workspace-gates` should not be configured as a required pull-request status unless a future change adds a `pull_request` trigger. To roll this monitor back, revert `.github/workflows/main-green.yaml` and this section.
 
+## Deploying the playground to Vercel
+
+The playground (`@cinder/playground`) is a `Bun.serve` server that builds Svelte component bundles on the fly with `Bun.build` — there is no SvelteKit, no Vite, and no pre-rendered static output. On Vercel it runs as a **single Bun Function** that delegates every request to the same `handleRequest` the dev server uses.
+
+The moving parts:
+
+- `packages/playground/api/index.ts`: the Vercel Function entry. It default-exports `{ fetch }` (the Web Standard handler shape Vercel accepts directly) and forwards to `handleRequest` from `src/server.ts`. No second routing table, no Node `req`/`res` shim.
+- `packages/playground/vercel.json`: `bunVersion: "1.x"`, `framework: null`, the `vercel-build` build command, and `rewrites` that funnel every playground route (`/`, `/c/:name`, `/page/:name`, `/page-bundle/:f`, `/shell-bundle/:f`, `/bundle/:n/:s`, `/api/manifest*`, `/example-src/*`, `/styles/*`, `/components/*`, `/ping`, `/events`) to `/api/index`. The `functions["api/index.ts"].includeFiles` glob bundles `packages/components/{src,scripts}/**` into the function so the on-the-fly builds can read component sources at request time.
+- `packages/playground/scripts/vercel-build.ts` (the `vercel-build` npm script): smoke-imports the function entry so a broken import path fails the build instead of 500-ing the first live request, then materializes the `public/` output directory Vercel expects. `public/` is git-ignored — it holds no real static assets.
+- `.github/workflows/deploy-playground.yaml`: deploys on push to `main` (production) and on pull requests (preview). It uses the Vercel CLI (`vercel pull` → `vercel build` → `vercel deploy --prebuilt`) and finishes with a `/ping` smoke-test.
+
+### The tradeoff (read this)
+
+Because every bundle is compiled on demand, the **first** request to a given route on a cold function instance pays a `Bun.build` cost; subsequent requests to that same warm instance (including the hashed-chunk URLs an entry references) are served from the in-process cache. There is no eager pre-build on Vercel — that lives only in the dev server's `startServer`, and running it per cold start would blow the function's startup budget for routes nobody visits. This is the right tradeoff for an internal component playground; it would **not** be appropriate for a high-traffic public site, where you'd want a real static export or a long-lived container instead.
+
+### One-time setup (a human must do this — it is not automated)
+
+Nothing below is performed by this repository or its workflows. A maintainer with Vercel access must do it once:
+
+1. **Create the Vercel project.** In the Vercel dashboard, import this Git repository as a new project (or run `bunx vercel link` locally from the repo root and follow the prompts).
+2. **Set the Root Directory to `packages/playground`.** This is a Vercel **project setting** (Settings → General → Root Directory), not a `vercel.json` key — `rootDirectory` is intentionally absent from `vercel.json` because Vercel does not read it there. With the root set, Vercel reads `packages/playground/vercel.json` and runs the configured `installCommand` (which installs the whole Bun workspace from the repo root, because `cinder` is a `workspace:*` dependency). **Also enable "Include files outside of the root directory in the Build Step"** (the toggle directly under Root Directory) — the function's `includeFiles` glob reaches up into `../components`, and that toggle must be on for those files to be available during the build.
+3. **Capture the three deploy secrets** and add them to the repository's GitHub Actions secrets (Settings → Secrets and variables → Actions):
+
+   | Secret              | Where it comes from                                                                                 |
+   | ------------------- | --------------------------------------------------------------------------------------------------- |
+   | `VERCEL_TOKEN`      | Vercel → Account Settings → Tokens → Create Token (scope it to the team that owns the project).      |
+   | `VERCEL_ORG_ID`     | `.vercel/project.json` after `bunx vercel link`, or Team Settings → General → Team ID.               |
+   | `VERCEL_PROJECT_ID` | `.vercel/project.json` after `bunx vercel link`, or the project's Settings → General → Project ID.   |
+
+   The workflow reads `VERCEL_ORG_ID` and `VERCEL_PROJECT_ID` from `env` and passes `VERCEL_TOKEN` to each CLI invocation. Fork pull requests can't read these secrets, so the deploy job skips itself on fork PRs rather than failing.
+
+### Verifying a live deploy (the smoke-test)
+
+Once the project and secrets exist, a push to `main` triggers `deploy-playground`. To check the result by hand (or after a `bunx vercel deploy` from your machine), hit the two health endpoints on the deployment URL:
+
+```bash
+# 1. Liveness — must return the literal text "pong".
+curl https://<your-deployment>.vercel.app/ping
+# → pong
+
+# 2. A real component page renders (returns 200 with the shell HTML).
+curl -i https://<your-deployment>.vercel.app/c/button | head -n 1
+# → HTTP/2 200
+```
+
+The workflow's `Smoke-test the deployment` step runs the `/ping` check automatically and writes the result to the job summary. If your Vercel plan has Deployment Protection enabled, the raw deployment URL may return `401` until you visit it authenticated — that is a gating response, not a deploy failure; verify through the dashboard's preview link instead.
+
+### Running the build locally
+
+The build step is runtime-safe to run on any machine with Bun:
+
+```bash
+cd packages/playground
+bun run vercel-build   # smoke-imports api/index.ts and writes public/
+```
+
+It does not contact Vercel or deploy anything — it only proves the function entry loads.
+
 ## Commits and pull requests
 
 - Conventional commit prefixes (`feat`, `fix`, `refactor`, `docs`, `chore`).

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
       "prettier --write"
     ],
     "packages/playground/src/**/*.{js,ts,tsx,jsx,mjs,cjs}": [
-      "oxlint --fix",
+      "oxlint --fix --type-aware --tsconfig ./packages/playground/tsconfig.json",
       "prettier --write"
     ],
     "packages/testing/**/*.{js,ts,tsx,jsx,mjs,cjs}": [

--- a/packages/components/AGENTS.md
+++ b/packages/components/AGENTS.md
@@ -560,12 +560,51 @@ then fail until the sidecar exists.
 Examples ship as JSON, generated verbatim from
 `.example.svelte` files in the playground. Every example must:
 
-- Carry a `<script lang="ts" module>` block exporting string literal
-  `title` and `description`, plus an optional `component` (kebab-case id).
+- Carry a `<script lang="ts" module>` block exporting a **string-literal**
+  `title`, an optional string-literal `description`, plus an optional
+  `component` (kebab-case id).
+- Provide a **default export** — the example component itself (markup in the
+  instance `<script>` / template). The playground mounts this default export;
+  an example with no default export renders nothing.
 - Import **only** from `cinder`, `cinder/<subpath>`, or a package listed in
   `scripts/example-allowed-packages.ts`. Relative imports, `$lib`,
   playground-only modules, and fixtures are hard errors.
 - Contain no `<style>` block — styles come from `cinder/styles`.
+
+A minimal compliant example:
+
+```svelte
+<script lang="ts" module>
+  // Required: a static string literal. The playground reads this verbatim to
+  // label the example card. Template literals with `${...}` interpolation and
+  // computed expressions are NOT supported — the value must be a plain string.
+  export const title = 'Basic usage';
+  // Optional: a one-line description rendered under the title.
+  export const description = 'The smallest button you can render.';
+  // Optional: an explicit kebab-case component id when the file path can't
+  // be inferred (rare). Most examples omit this.
+  // export const component = 'button';
+</script>
+
+<script lang="ts">
+  import { Button } from 'cinder/button';
+</script>
+
+<Button>Click me</Button>
+```
+
+#### The `title` export is mandatory
+
+`title` is required and must be present as a string literal. When it is missing
+(or only a non-exported `const title` exists), the example metadata reader falls
+back to the sentinel `'Untitled'`, the dev server logs
+`[playground] example missing title: <filePath>`, and
+`bun run --filter='@cinder/playground' validate` fails with the count of
+offending files. A literal `export const title = 'Untitled'` is also rejected —
+pick a real, descriptive title. Single-, double-, and backtick-quoted string
+literals are all accepted; only interpolated template literals are not.
+
+#### Excluding an example
 
 To exclude an example that cannot ship (router-dependent, server-data,
 iframe-isolated, etc.), add a top-of-file marker:
@@ -575,9 +614,18 @@ iframe-isolated, etc.), add a top-of-file marker:
 ```
 
 The reason must come from `allowedExampleExclusionReasons` in
-`manifest.meta.ts`. To add a new reason, edit that array and document
-why in your PR. The exclusion budget is capped at 10% of all playground
-examples; above that, `components:check` fails.
+`manifest.meta.ts`. The currently allowed reasons are:
+
+- `playground-only-interaction` — relies on playground-only wiring that has no
+  standalone equivalent.
+- `requires-router` — needs a router the example harness does not provide.
+- `requires-server-data` — needs server-fetched data to render meaningfully.
+- `requires-iframe-isolation` — must run in an isolated iframe (e.g. global
+  side effects).
+
+To add a new reason, edit that array and document why in your PR. The exclusion
+budget is capped at 10% of all playground examples; above that,
+`components:check` fails.
 
 ## Stable-promotion gate
 

--- a/packages/playground/api/index.ts
+++ b/packages/playground/api/index.ts
@@ -1,0 +1,49 @@
+/**
+ * Vercel Function entrypoint for the cinder playground.
+ *
+ * The playground is a plain `Bun.serve` HTTP server (see `../src/server.ts`)
+ * whose request handling is fully expressed by the exported `handleRequest`
+ * function: `(Request) => Promise<Response>`. Vercel Functions accept exactly
+ * that shape via the Web Standard `fetch` export, so this file is a thin
+ * adapter — no Node `req`/`res` shim, no framework, no second copy of the
+ * routing table.
+ *
+ * Why a single function instead of a static export:
+ *   The playground builds Svelte bundles on the fly with `Bun.build`, reading
+ *   component sources from `packages/components/src` at request time. There is
+ *   no pre-rendered static artifact to ship; every `/page-bundle/*`,
+ *   `/bundle/*`, and `/shell-bundle/*` response is compiled on demand. A single
+ *   Bun Function that delegates to `handleRequest` preserves that behavior
+ *   exactly. All routes are funnelled here by the `rewrites` in `vercel.json`.
+ *
+ * Cold-start / warm-cache note:
+ *   `handleRequest` lazily builds (and module-caches) bundles on first request
+ *   and serves hashed chunk URLs from those same caches. Vercel keeps a Lambda
+ *   instance's module state alive between invocations, so the first request to
+ *   a given route on a fresh instance pays the build cost and subsequent
+ *   requests to that instance (including the hashed-chunk URLs the entry
+ *   references) are served warm. This mirrors the dev server's behavior without
+ *   the file watcher (which only exists in `startServer`, not in
+ *   `handleRequest`). No eager pre-build runs here; it would blow the function
+ *   cold-start budget for routes the visitor never hits.
+ *
+ * Filesystem note:
+ *   `handleRequest` resolves `packages/components/src` relative to the source
+ *   location of `server.ts`. The `functions[].includeFiles` glob in
+ *   `vercel.json` bundles that tree (plus the Svelte build plugin under
+ *   `packages/components/scripts`) into the deployed function so the on-the-fly
+ *   builds can read it.
+ */
+
+import { handleRequest } from '../src/server.ts';
+
+export default {
+  /**
+   * Handle every incoming HTTP request by delegating to the playground's
+   * shared request handler. Vercel routes all paths to this function via the
+   * `rewrites` rules in `vercel.json`.
+   */
+  fetch(request: Request): Promise<Response> {
+    return handleRequest(request);
+  },
+};

--- a/packages/playground/api/vercel-config.test.ts
+++ b/packages/playground/api/vercel-config.test.ts
@@ -1,0 +1,163 @@
+/**
+ * Tests for the Vercel deployment configuration.
+ *
+ * The playground deploys to Vercel as a single Bun Function (`api/index.ts`)
+ * with every route funnelled to it by `rewrites` in `vercel.json`. These tests
+ * guard the two ways that setup silently rots:
+ *
+ *   (a) The function entry stops exporting the `{ fetch }` shape Vercel calls,
+ *       or stops delegating to the real handler.
+ *   (b) Someone adds a new route to `src/server.ts` (or removes one) and the
+ *       `vercel.json` rewrites drift out of sync, so the new route 404s in
+ *       production while working locally. Each route family the server answers
+ *       must have a rewrite that reaches the function.
+ *
+ * These are pure config/contract assertions — no DOM, no rendering, no live
+ * Vercel calls.
+ */
+
+import { describe, expect, it } from 'bun:test';
+import { join } from 'node:path';
+
+const PLAYGROUND_ROOT = join(import.meta.dirname, '..');
+
+/**
+ * Read and JSON-parse `vercel.json`. A parse failure here is itself a useful
+ * signal — a malformed config would break every deploy.
+ */
+async function readVercelConfig(): Promise<Record<string, unknown>> {
+  const text = await Bun.file(join(PLAYGROUND_ROOT, 'vercel.json')).text();
+  const parsed: unknown = JSON.parse(text);
+  if (typeof parsed !== 'object' || parsed === null) {
+    throw new Error('vercel.json did not parse to an object');
+  }
+  return parsed as Record<string, unknown>;
+}
+
+/**
+ * Narrow the parsed config's `rewrites` to an array of `{ source }` rules.
+ * Throws if the shape is wrong so a malformed rewrite table fails loudly.
+ */
+function rewriteSources(config: Record<string, unknown>): string[] {
+  const { rewrites } = config;
+  if (!Array.isArray(rewrites)) throw new Error('vercel.json rewrites must be an array');
+  return rewrites.map((rule) => {
+    if (typeof rule !== 'object' || rule === null || !('source' in rule)) {
+      throw new Error('each rewrite must be an object with a source');
+    }
+    const { source } = rule as { source: unknown };
+    if (typeof source !== 'string') throw new Error('rewrite source must be a string');
+    return source;
+  });
+}
+
+describe('vercel.json', () => {
+  it('is valid JSON with the keys a Bun function deploy needs', async () => {
+    const config = await readVercelConfig();
+    expect(config['$schema']).toBe('https://openapi.vercel.sh/vercel.json');
+    // Bun runtime, not Node — the server relies on Bun.file / Bun.build.
+    expect(config['bunVersion']).toBe('1.x');
+    // No meta-framework: the playground is a hand-rolled Bun.serve server.
+    expect(config['framework']).toBeNull();
+    expect(typeof config['buildCommand']).toBe('string');
+    expect(typeof config['outputDirectory']).toBe('string');
+  });
+
+  it('registers exactly one function, the api/index.ts entry, with the components source bundled in', async () => {
+    const config = await readVercelConfig();
+    const functions = config['functions'];
+    expect(typeof functions).toBe('object');
+    expect(functions).not.toBeNull();
+    const fns = functions as Record<string, unknown>;
+    expect(Object.keys(fns)).toEqual(['api/index.ts']);
+    const entry = fns['api/index.ts'] as Record<string, unknown>;
+    // The on-the-fly builds read packages/components/{src,scripts} at request
+    // time, so those trees must be bundled into the deployed function.
+    expect(entry['includeFiles']).toBe('../components/{src,scripts}/**');
+  });
+
+  it('rewrites every playground route family to the single function', async () => {
+    const config = await readVercelConfig();
+    const sources = rewriteSources(config);
+    const allToFunction = (config['rewrites'] as { destination: string }[]).every(
+      (rule) => rule.destination === '/api/index',
+    );
+    expect(allToFunction).toBe(true);
+
+    // One representative path per route family the server's handleRequest
+    // answers. If a new family is added to server.ts, add it here AND to
+    // vercel.json — this list is the contract between the two.
+    const representativePaths = [
+      '/',
+      '/ping',
+      '/events',
+      '/styles.css',
+      '/styles/tokens.css',
+      '/components/button/button.css',
+      '/c/button',
+      '/page/button',
+      '/page-bundle/button.js',
+      '/shell-bundle/shell.js',
+      '/bundle/button/basic.js',
+      '/api/manifest',
+      '/api/manifest/button',
+      '/example-src/button/basic',
+    ];
+
+    for (const path of representativePaths) {
+      expect(matchesAnyRewrite(path, sources), `no rewrite covers ${path}`).toBe(true);
+    }
+  });
+});
+
+describe('api/index.ts (Vercel function entry)', () => {
+  it('default-exports a Web Standard { fetch } handler', async () => {
+    const entry = await import('./index.ts');
+    expect(typeof entry.default).toBe('object');
+    expect(typeof entry.default.fetch).toBe('function');
+  });
+
+  it('delegates /ping to the real handler (proves the wiring, not a stub)', async () => {
+    const entry = await import('./index.ts');
+    const response = await entry.default.fetch(new Request('http://localhost/ping'));
+    expect(response.status).toBe(200);
+    expect(await response.text()).toBe('pong');
+  });
+});
+
+/**
+ * Test-local matcher for Vercel's `:param` / `:param*` rewrite syntax. Vercel
+ * uses `path-to-regexp`; this re-implements just enough to assert coverage:
+ * `:name` matches a single non-slash segment, `:path*` matches zero-or-more
+ * segments, and a literal `.` is matched literally. A static source matches
+ * only itself. Built left-to-right so each token is translated exactly once,
+ * avoiding the escape/unescape ambiguity around `*`.
+ */
+function matchesAnyRewrite(pathname: string, sources: string[]): boolean {
+  return sources.some((source) => {
+    let pattern = '';
+    let index = 0;
+    while (index < source.length) {
+      const character = source[index]!;
+      if (character === ':') {
+        const rest = source.slice(index + 1);
+        const greedy = /^[A-Za-z0-9_]+\*/.exec(rest); // :path* → any depth
+        const single = /^[A-Za-z0-9_]+/.exec(rest); //  :name  → one segment
+        if (greedy) {
+          pattern += '.*';
+          index += 1 + greedy[0].length;
+          continue;
+        }
+        if (single) {
+          pattern += '[^/]+';
+          index += 1 + single[0].length;
+          continue;
+        }
+      }
+      // Everything else is a literal — escape regex metacharacters (notably `.`).
+      pattern += character.replace(/[.*+?^${}()|[\]\\]/, (ch) => `\\${ch}`);
+      index += 1;
+    }
+    return new RegExp(`^${pattern}$`).test(pathname);
+  });
+}

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -5,11 +5,12 @@
   "type": "module",
   "scripts": {
     "dev": "bun --watch run src/server.ts",
-    "lint": "oxlint src/",
-    "lint:fix": "oxlint --fix src/",
-    "test": "TZ=UTC LANG=en_US.UTF-8 bun test --conditions browser",
+    "lint": "oxlint src/ api/ scripts/",
+    "lint:fix": "oxlint --fix src/ api/ scripts/",
+    "test": "bun run scripts/run-tests.ts",
     "typecheck": "tsc --noEmit && bunx svelte-check --tsconfig tsconfig.json --threshold error",
-    "validate": "bun run src/validate-playground.ts"
+    "validate": "bun run src/validate-playground.ts",
+    "vercel-build": "bun run scripts/vercel-build.ts"
   },
   "dependencies": {
     "cinder": "workspace:*",

--- a/packages/playground/scripts/run-tests.ts
+++ b/packages/playground/scripts/run-tests.ts
@@ -1,0 +1,71 @@
+/**
+ * Playground test runner.
+ *
+ * Runs the playground test suite in TWO separate `bun test` processes and fails
+ * if either does. This split is deliberate and load-bearing — do not collapse it
+ * back into a single `bun test` invocation without re-measuring.
+ *
+ * The ONE constraint that forces it (reproducibly verified, May 2026):
+ *
+ *   `component-page.test.ts` imperatively `mount()`s Svelte fixtures (it exercises
+ *   the example-mount `$effect`). Once those fixtures have been compiled and
+ *   mounted in a process, the global Svelte runtime / Bun bundler module state is
+ *   left in a shape that makes a LATER `Bun.build` of a real component
+ *   (`server.test.ts`'s `/page-bundle/chat.js` route) fail to read Svelte's
+ *   internal sources — surfacing as `Unexpected reading file:
+ *   svelte/src/internal/client/index.js` and `Unexpected type` on a `.ts`
+ *   re-export. Both files pass in isolation; only the same-process combination
+ *   breaks. `--parallel=1` does not help (the corruption is shared-process, not a
+ *   parallel race), so the only robust fix is to run the mount-heavy test in its
+ *   own process, away from the build-driving server tests.
+ *
+ * Isolating exactly `component-page.test.ts` is sufficient: every other test
+ * file (including `server.test.ts` and the other DOM-mount tests) coexists
+ * cleanly in one process.
+ */
+
+const TEST_ENV = {
+  ...process.env,
+  TZ: 'UTC',
+  LANG: 'en_US.UTF-8',
+};
+
+// `--parallel=1` (serial) is required, same as the components package: Bun's
+// parallel runner uses worker processes that race to import the Svelte test
+// stack at module-init and deadlock, and the iframe-driven preview-frame tests
+// hit happy-dom `postMessage` cross-origin errors when multiple windows run
+// concurrently. Serial execution avoids both. Do not strip without re-measuring.
+const SHARED_FLAGS = ['--conditions', 'browser', '--conditions', 'svelte', '--parallel=1'];
+
+/** The mount-heavy file that must run alone (see module header). */
+const ISOLATED_TEST = 'src/component-page.test.ts';
+
+/**
+ * Run one `bun test` invocation with the shared flags plus `args` (a path glob
+ * to include, or a `--path-ignore-patterns=...` to exclude). Inherits stdio so
+ * the child's reporter streams straight through. Returns its exit code.
+ */
+async function runBunTest(args: string[]): Promise<number> {
+  const child = Bun.spawn(['bun', 'test', ...SHARED_FLAGS, ...args], {
+    env: TEST_ENV,
+    stdout: 'inherit',
+    stderr: 'inherit',
+  });
+  return child.exited;
+}
+
+/** Run both test processes in sequence; exit non-zero if either fails. */
+async function main(): Promise<void> {
+  // Process 1: everything EXCEPT the isolated mount test.
+  const mainExit = await runBunTest([`--path-ignore-patterns=${ISOLATED_TEST}`]);
+  // Process 2: only the isolated mount test.
+  const isolatedExit = await runBunTest([ISOLATED_TEST]);
+  process.exit(mainExit !== 0 || isolatedExit !== 0 ? 1 : 0);
+}
+
+// Fire-and-forget: `main()` calls `process.exit`, so the process ends inside it.
+// Surface an unexpected rejection as a non-zero exit rather than an unhandled one.
+void main().catch((error: unknown) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/packages/playground/scripts/vercel-build.ts
+++ b/packages/playground/scripts/vercel-build.ts
@@ -1,0 +1,64 @@
+/**
+ * Production build step for the cinder playground's Vercel deployment.
+ *
+ * The playground has no compiled output: every page and bundle is built on the
+ * fly by the `api/index.ts` Vercel Function at request time (see that file and
+ * `vercel.json`). So this "build" does two cheap, deploy-protecting things:
+ *
+ *   1. Smoke-imports the function entry. Importing `api/index.ts` transitively
+ *      loads `src/server.ts` and the Svelte build plugin under
+ *      `packages/components/scripts`. If any of that fails to evaluate — a
+ *      bad import path, a syntax error, a missing dependency — the build fails
+ *      loudly here instead of 500-ing on the first live request.
+ *   2. Materializes the `outputDirectory` that `vercel.json` points at
+ *      (`public/`). A function-only deployment ships no static assets, but
+ *      Vercel still expects the configured output directory to exist, so we
+ *      create it with a single explanatory file.
+ *
+ * Run by the `vercel-build` script in `package.json`, which Vercel invokes via
+ * the `buildCommand` in `vercel.json`.
+ */
+
+import { join } from 'node:path';
+
+const PLAYGROUND_ROOT = join(import.meta.dirname, '..');
+const OUTPUT_DIRECTORY = join(PLAYGROUND_ROOT, 'public');
+
+/**
+ * Import the Vercel Function entry to prove it (and everything it pulls in)
+ * evaluates cleanly. Throws — failing the build — if the module graph is
+ * broken. We import for side effects only; the default export is the live
+ * handler, exercised by the smoke test, not at build time.
+ */
+async function verifyFunctionEntryLoads(): Promise<void> {
+  const entry = await import('../api/index.ts');
+  if (typeof entry.default?.fetch !== 'function') {
+    throw new Error(
+      '[playground:vercel-build] api/index.ts must default-export an object with a fetch() method',
+    );
+  }
+}
+
+/**
+ * Ensure the configured output directory exists with a placeholder README so
+ * Vercel's static-output step has something to publish. The playground serves
+ * nothing static, so this directory stays effectively empty.
+ */
+async function ensureOutputDirectory(): Promise<void> {
+  await Bun.write(
+    join(OUTPUT_DIRECTORY, 'README.txt'),
+    [
+      'This directory is intentionally (almost) empty.',
+      '',
+      'The cinder playground is served entirely by the Vercel Function at',
+      'api/index.ts, which builds every page and bundle on the fly. There are',
+      'no pre-rendered static assets. This file exists only so the configured',
+      'outputDirectory in vercel.json is present for Vercel to publish.',
+      '',
+    ].join('\n'),
+  );
+}
+
+await verifyFunctionEntryLoads();
+await ensureOutputDirectory();
+process.stdout.write('[playground:vercel-build] function entry verified, output directory ready\n');

--- a/packages/playground/src/analyze.test.ts
+++ b/packages/playground/src/analyze.test.ts
@@ -1,8 +1,14 @@
-import { describe, expect, it } from 'bun:test';
-import { existsSync } from 'node:fs';
+import { afterAll, beforeAll, describe, expect, it } from 'bun:test';
+import { existsSync, mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
-import { analyzeAll, analyzeComponent } from './analyze.ts';
+import {
+  analyzeAll,
+  analyzeComponent,
+  getProjectCreationCount,
+  resetProject,
+} from './analyze.ts';
 
 const COMPONENTS_DIR = join(import.meta.dirname, '../../components/src/components');
 
@@ -228,6 +234,51 @@ describe('analyzeAll', () => {
 });
 
 // ---------------------------------------------------------------------------
+// Shared ts-morph Project — project sharing + resetProject()
+// ---------------------------------------------------------------------------
+
+describe('shared ts-morph project', () => {
+  it('exposes a callable resetProject()', () => {
+    expect(() => resetProject()).not.toThrow();
+  });
+
+  it('reuses a single Project across one analyzeAll run', async () => {
+    resetProject();
+    const before = getProjectCreationCount();
+    await analyzeAll(COMPONENTS_DIR);
+    const after = getProjectCreationCount();
+    // ~100 concurrent analyzeComponent calls must share a single Project, so
+    // exactly one new instance is created for the whole run.
+    expect(after - before).toBe(1);
+  });
+
+  it('creates exactly one new Project after a reset', async () => {
+    await analyzeAll(COMPONENTS_DIR);
+    resetProject();
+    const before = getProjectCreationCount();
+    await analyzeAll(COMPONENTS_DIR);
+    expect(getProjectCreationCount() - before).toBe(1);
+  });
+
+  it('produces identical manifests across two runs with a reset between them', async () => {
+    const first = await analyzeAll(COMPONENTS_DIR);
+    resetProject();
+    const second = await analyzeAll(COMPONENTS_DIR);
+    // A reset between runs must not change the output: no stale source files
+    // accumulate on the shared project, so the second run reproduces the first.
+    expect(second).toEqual(first);
+  });
+
+  it('produces identical manifests across two runs without a reset', async () => {
+    const first = await analyzeAll(COMPONENTS_DIR);
+    const second = await analyzeAll(COMPONENTS_DIR);
+    // Reusing the same project across runs (synthetic files removed each call)
+    // must also yield identical output.
+    expect(second).toEqual(first);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // NavigationItem — non-destructuring $props() returns empty props array
 // ---------------------------------------------------------------------------
 
@@ -292,5 +343,128 @@ describe('analyzeComponent — card.svelte (discriminated union Props)', () => {
     expect(footerTone?.control).toEqual({ kind: 'select', options: ['default', 'muted'] });
     expect(edgeToEdgeOnMobile?.control.kind).toBe('boolean');
     expect(edgeToEdgeOnMobile?.defaultValue).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Bare `<script module>` regression
+//
+// The module-script extractor's opening-tag pattern previously required at
+// least one attribute before `module` (`[^>]+`), so a bare `<script module>`
+// — valid Svelte 5 — silently failed to match. Type info was then lost and
+// every prop collapsed to `{ kind: 'unknown' }`. These fixtures exercise the
+// bare form via a real temp file so the extractor runs end to end.
+// ---------------------------------------------------------------------------
+
+describe('analyzeComponent — bare <script module> block', () => {
+  let fixtureDir: string;
+
+  beforeAll(() => {
+    fixtureDir = mkdtempSync(join(tmpdir(), 'cinder-analyze-'));
+  });
+
+  afterAll(() => {
+    rmSync(fixtureDir, { recursive: true, force: true });
+  });
+
+  /** Writes a `.svelte` fixture to the temp dir and returns its absolute path. */
+  async function writeFixture(kebabName: string, source: string): Promise<string> {
+    const filePath = join(fixtureDir, `${kebabName}.svelte`);
+    await Bun.write(filePath, source);
+    return filePath;
+  }
+
+  it('reads the Props type from a bare <script module> (no leading attribute)', async () => {
+    const source = `<script module>
+  export type WidgetProps = {
+    /** The visual variant. */
+    variant?: 'primary' | 'secondary';
+    disabled?: boolean;
+    count?: number;
+    label?: string;
+  };
+</script>
+
+<script lang="ts">
+  let {
+    variant = 'primary',
+    disabled = false,
+    count = 0,
+    label = 'Widget',
+  }: WidgetProps = $props();
+</script>
+
+<div>{label}</div>`;
+
+    const manifest = await analyzeComponent(await writeFixture('widget', source));
+
+    const variant = manifest.props.find((p) => p.name === 'variant');
+    const disabled = manifest.props.find((p) => p.name === 'disabled');
+    const count = manifest.props.find((p) => p.name === 'count');
+    const label = manifest.props.find((p) => p.name === 'label');
+
+    // The control kinds prove the module script was found: without the fix
+    // every control here would be `{ kind: 'unknown' }`.
+    expect(variant?.control).toEqual({ kind: 'select', options: ['primary', 'secondary'] });
+    expect(disabled?.control.kind).toBe('boolean');
+    expect(count?.control.kind).toBe('number');
+    expect(label?.control.kind).toBe('text');
+
+    // Defaults still come from the instance-script destructuring.
+    expect(variant?.defaultValue).toBe('primary');
+    expect(disabled?.defaultValue).toBe(false);
+    expect(count?.defaultValue).toBe(0);
+
+    // JSDoc descriptions still flow through.
+    expect(variant?.description).toBe('The visual variant.');
+  });
+
+  it('still reads the Props type when an attribute precedes module', async () => {
+    const source = `<script lang="ts" module>
+  export type GadgetProps = {
+    tone?: 'info' | 'danger';
+  };
+</script>
+
+<script lang="ts">
+  let { tone = 'info' }: GadgetProps = $props();
+</script>
+
+<span>{tone}</span>`;
+
+    const manifest = await analyzeComponent(await writeFixture('gadget', source));
+    const tone = manifest.props.find((p) => p.name === 'tone');
+    expect(tone?.control).toEqual({ kind: 'select', options: ['info', 'danger'] });
+  });
+
+  // Regression: `AST.Root.instance` is typed `Script | null`, but at runtime
+  // `parse(..., { modern: true })` returns `undefined` when a component has no
+  // instance `<script>` block. A strict `=== null` check missed that case and
+  // threw `TypeError: undefined is not an object` on `instanceScript.content`.
+  // A markup-only component is the simplest reproduction.
+  it('returns an empty manifest for a markup-only component (no instance script)', async () => {
+    const source = `<div class="notice">Static markup with no script block.</div>`;
+
+    const filePath = await writeFixture('notice', source);
+    const manifest = await analyzeComponent(filePath);
+
+    expect(manifest.props).toEqual([]);
+  });
+
+  // A component with only a `<script module>` block (no instance script) also
+  // leaves `ast.instance` undefined, exercising the same nullish path.
+  it('returns an empty manifest for a module-only component (no instance script)', async () => {
+    const source = `<script lang="ts" module>
+  export type PanelProps = {
+    heading?: string;
+  };
+</script>
+
+<section>Module-only component, no destructured props.</section>`;
+
+    const filePath = await writeFixture('panel', source);
+    const manifest = await analyzeComponent(filePath);
+
+    expect(manifest.props).toEqual([]);
   });
 });

--- a/packages/playground/src/analyze.ts
+++ b/packages/playground/src/analyze.ts
@@ -2,30 +2,25 @@
  * Component manifest analyzer for the cinder playground.
  *
  * Combines two sources of truth:
- *  1. svelte/compiler.parse — reads the $props() destructuring to extract prop names,
+ *  1. svelte/compiler.parse â reads the $props() destructuring to extract prop names,
  *     bindability ($bindable), and default values.
- *  2. ts-morph — reads the exported `${Name}Props` type alias to determine each
+ *  2. ts-morph â reads the exported `${Name}Props` type alias to determine each
  *     prop's type (and therefore control kind), optionality, and JSDoc description.
  *
  * The $props() destructuring is canonical: only props that appear there are included in
  * the manifest. If the Props type has a property not in the destructuring, it is skipped.
  */
 
-import { existsSync, readFileSync } from 'node:fs';
 import { basename, join } from 'node:path';
 
-import { parse } from 'svelte/compiler';
+import type { Expression, Pattern, Property, SpreadElement } from 'estree';
+import { type AST, parse } from 'svelte/compiler';
 import { Project, type PropertySignature, SyntaxKind, type TypeNode } from 'ts-morph';
 
+import { discoverComponentFilePaths } from './discover.ts';
 import type { ComponentManifest, ControlKind, PropManifest } from './types.ts';
 
 export type { ComponentManifest, ControlKind, PropManifest };
-
-// ---------------------------------------------------------------------------
-// Internal types for AST nodes (svelte/compiler returns untyped objects)
-// ---------------------------------------------------------------------------
-
-type AstNode = Record<string, unknown>;
 
 // ---------------------------------------------------------------------------
 // Control kind inference from ts-morph TypeNode
@@ -75,7 +70,7 @@ function inferControlKindFromTypeNode(
     const ref = typeNode.asKindOrThrow(SyntaxKind.TypeReference);
     const name = ref.getTypeName().getText();
 
-    // Snippet or Snippet<[...]> → snippet control
+    // Snippet or Snippet<[...]> â snippet control
     if (name === 'Snippet') return { kind: 'snippet' };
 
     // Try to resolve the referenced alias in the same source file
@@ -93,7 +88,7 @@ function inferControlKindFromTypeNode(
 }
 
 // ---------------------------------------------------------------------------
-// Svelte AST helpers — extracting props from $props() destructuring
+// Svelte AST helpers â extracting props from $props() destructuring
 // ---------------------------------------------------------------------------
 
 type RawPropEntry = {
@@ -103,37 +98,46 @@ type RawPropEntry = {
 };
 
 /**
+ * Returns the literal value of an array element, or `undefined` for holes,
+ * spreads, and any non-literal expression.
+ */
+function literalElementValue(element: Expression | SpreadElement | null): unknown {
+  if (element !== null && element.type === 'Literal') return element.value;
+  return undefined;
+}
+
+/**
  * Parses the right-hand side of an AssignmentPattern (the default value expression)
  * and returns { defaultValue, bindable }.
  */
-function parseDefaultExpression(rhs: AstNode): { defaultValue?: unknown; bindable: boolean } {
-  if (rhs['type'] === 'Literal') {
-    return { defaultValue: rhs['value'], bindable: false };
+function parseDefaultExpression(rhs: Expression): { defaultValue?: unknown; bindable: boolean } {
+  if (rhs.type === 'Literal') {
+    return { defaultValue: rhs.value, bindable: false };
   }
 
-  if (rhs['type'] === 'ArrayExpression') {
-    const elements = rhs['elements'] as AstNode[];
+  if (rhs.type === 'ArrayExpression') {
+    const elements = rhs.elements;
     if (elements.length === 0) return { defaultValue: [], bindable: false };
-    const allLiterals = elements.every((el) => el['type'] === 'Literal');
+    const allLiterals = elements.every((el) => el !== null && el.type === 'Literal');
     if (allLiterals) {
-      return { defaultValue: elements.map((el) => el['value']), bindable: false };
+      return { defaultValue: elements.map(literalElementValue), bindable: false };
     }
     return { defaultValue: undefined, bindable: false };
   }
 
-  if (rhs['type'] === 'CallExpression') {
-    const callee = rhs['callee'] as AstNode;
-    if (callee['type'] === 'Identifier' && callee['name'] === '$bindable') {
-      const args = rhs['arguments'] as AstNode[];
+  if (rhs.type === 'CallExpression') {
+    const callee = rhs.callee;
+    if (callee.type === 'Identifier' && callee.name === '$bindable') {
+      const args = rhs.arguments;
       if (args.length === 0) return { defaultValue: undefined, bindable: true };
       const firstArg = args[0];
-      if (firstArg === undefined) return { defaultValue: undefined, bindable: true };
-      if (firstArg['type'] === 'Literal')
-        return { defaultValue: firstArg['value'], bindable: true };
+      if (firstArg === undefined || firstArg.type === 'SpreadElement') {
+        return { defaultValue: undefined, bindable: true };
+      }
+      if (firstArg.type === 'Literal') return { defaultValue: firstArg.value, bindable: true };
       // ArrayExpression default with $bindable (e.g. $bindable([]))
-      if (firstArg['type'] === 'ArrayExpression') {
-        const elements = firstArg['elements'] as AstNode[];
-        return { defaultValue: elements.map((el) => el['value']), bindable: true };
+      if (firstArg.type === 'ArrayExpression') {
+        return { defaultValue: firstArg.elements.map(literalElementValue), bindable: true };
       }
       return { defaultValue: undefined, bindable: true };
     }
@@ -143,60 +147,73 @@ function parseDefaultExpression(rhs: AstNode): { defaultValue?: unknown; bindabl
 }
 
 /**
+ * Resolves the static name of an object-pattern property key. Returns
+ * `undefined` for keys that don't have a usable static name (e.g. a numeric
+ * `Literal` key on a destructured prop, which Svelte components never use).
+ */
+function staticPropertyKeyName(key: Property['key']): string | undefined {
+  if (key.type === 'Identifier') return key.name;
+  if (key.type === 'Literal' && typeof key.value === 'string') return key.value;
+  return undefined;
+}
+
+/**
  * Extracts prop entries from the ObjectPattern of a $props() destructuring.
  * Returns an empty array if the component does not use destructuring (e.g.
  * `const props: Props = $props()`).
  */
 function extractPropsFromSvelteAst(source: string): RawPropEntry[] {
-  const ast = parse(source, { filename: '__analyze__.svelte' });
-  const instanceScript = ast['instance'] as { content: { body: AstNode[] } } | undefined;
+  const ast: AST.Root = parse(source, { filename: '__analyze__.svelte', modern: true });
+  const instanceScript = ast.instance;
 
-  if (instanceScript === undefined) return [];
+  // `AST.Root.instance` is typed `Script | null`, but `parse(..., { modern: true })`
+  // returns `undefined` (not `null`) when a component has no instance `<script>`
+  // block — e.g. markup-only components, or ones with only a `<script module>`.
+  // A strict `=== null` check misses that case and falls through to
+  // `instanceScript.content`, throwing a TypeError. Use a nullish check so both
+  // `null` and `undefined` short-circuit to "no destructured props".
+  if (!instanceScript) return [];
 
   const body = instanceScript.content.body;
 
   for (const node of body) {
-    if (node['type'] !== 'VariableDeclaration') continue;
+    if (node.type !== 'VariableDeclaration') continue;
 
-    const declarations = node['declarations'] as AstNode[];
-    for (const declarator of declarations) {
-      const init = declarator['init'] as AstNode | undefined;
-      if (init === undefined) continue;
+    for (const declarator of node.declarations) {
+      const init = declarator.init;
+      if (init === undefined || init === null) continue;
 
-      // Look for either `$props()` directly or `$props()` as the expression
+      // Look for `$props()` as the initializer expression.
       const isPropsCall =
-        init['type'] === 'CallExpression' &&
-        (init['callee'] as AstNode)['type'] === 'Identifier' &&
-        (init['callee'] as AstNode)['name'] === '$props';
+        init.type === 'CallExpression' &&
+        init.callee.type === 'Identifier' &&
+        init.callee.name === '$props';
 
       if (!isPropsCall) continue;
 
-      const id = declarator['id'] as AstNode;
-      if (id['type'] !== 'ObjectPattern') {
-        // `const props: Type = $props()` — no destructuring, skip
+      const id: Pattern = declarator.id;
+      if (id.type !== 'ObjectPattern') {
+        // `const props: Type = $props()` â no destructuring, skip
         return [];
       }
 
-      const properties = id['properties'] as AstNode[];
       const entries: RawPropEntry[] = [];
 
-      for (const property of properties) {
-        // RestElement → ...rest spread — skip
-        if (property['type'] === 'RestElement') continue;
+      for (const property of id.properties) {
+        // RestElement â ...rest spread â skip
+        if (property.type === 'RestElement') continue;
 
-        const key = property['key'] as AstNode;
-        // Computed properties (e.g. [Symbol.iterator]) — skip
-        if (property['computed'] === true) continue;
+        // Computed properties (e.g. [Symbol.iterator]) â skip
+        if (property.computed) continue;
 
-        const rawName: string =
-          key['type'] === 'Identifier' ? (key['name'] as string) : (key['value'] as string);
+        const rawName = staticPropertyKeyName(property.key);
+        if (rawName === undefined) continue;
 
-        // class, aria-* and other non-standard names — will be filtered later
-        const value = property['value'] as AstNode;
+        // class, aria-* and other non-standard names â will be filtered later
+        const value = property.value;
 
-        if (value['type'] === 'AssignmentPattern') {
-          const rhs = value['right'] as AstNode;
-          const { defaultValue, bindable } = parseDefaultExpression(rhs);
+        if (value.type === 'AssignmentPattern') {
+          const { defaultValue, bindable } = parseDefaultExpression(value.right);
           entries.push({ name: rawName, defaultValue, bindable });
         } else {
           // No default value
@@ -212,16 +229,19 @@ function extractPropsFromSvelteAst(source: string): RawPropEntry[] {
 }
 
 // ---------------------------------------------------------------------------
-// ts-morph helpers — extracting type info from the module script block
+// ts-morph helpers â extracting type info from the module script block
 // ---------------------------------------------------------------------------
 
 /**
- * Extracts the content of the first `<script lang="ts" module>` block
- * (attribute order doesn't matter — matches both orderings).
+ * Extracts the content of the first `<script lang="ts" module>` block.
+ *
+ * Attribute order doesn't matter and the `module` attribute may stand alone:
+ * `<script module>`, `<script module lang="ts">`, and `<script lang="ts" module>`
+ * all match. The leading `[^>]*` (not `[^>]+`) is what permits the bare
+ * `<script module>` form valid in Svelte 5.
  */
 function extractModuleScriptContent(source: string): string {
-  // Match <script module lang="ts"> or <script lang="ts" module>
-  const pattern = /<script[^>]+\bmodule\b[^>]*>([\s\S]*?)<\/script>/;
+  const pattern = /<script[^>]*\bmodule\b[^>]*>([\s\S]*?)<\/script>/;
   const match = pattern.exec(source);
   return match?.[1] ?? '';
 }
@@ -283,23 +303,99 @@ type TypeInfo = {
   description: string | undefined;
 };
 
+// ---------------------------------------------------------------------------
+// Shared ts-morph Project
+// ---------------------------------------------------------------------------
+//
+// `analyzeAll` runs `analyzeComponent` concurrently via `Promise.all` for ~100
+// components. Creating a fresh `Project` per call spins up ~100 TypeScript
+// compiler instances, which is the dominant cost of a cold manifest build.
+//
+// Instead we keep one module-scoped `Project`, created lazily on first use, and
+// reuse it across every call. Each `buildTypeInfoMap` call adds a synthetic
+// source file under a unique path (so concurrent calls never collide), reads
+// the type info, then removes the file so the project doesn't accumulate stale
+// sources or leak memory.
+
+/** The shared ts-morph project, created lazily on first analysis. */
+let sharedProject: Project | undefined;
+/** Number of `Project` instances created — exposed for tests to assert sharing. */
+let projectCreationCount = 0;
+/** Monotonic counter guaranteeing a unique synthetic source-file path per call. */
+let syntheticFileCounter = 0;
+
 /**
- * Builds a map from prop name → TypeInfo by reading the exported Props type alias
+ * Returns the shared ts-morph `Project`, creating it on first use. Subsequent
+ * calls return the same instance so concurrent `analyzeComponent` runs share a
+ * single TypeScript compiler.
+ */
+function getSharedProject(): Project {
+  if (sharedProject === undefined) {
+    sharedProject = new Project({
+      tsConfigFilePath: join(import.meta.dirname, '../../components/tsconfig.json'),
+      skipAddingFilesFromTsConfig: true,
+    });
+    projectCreationCount += 1;
+  }
+  return sharedProject;
+}
+
+/**
+ * Disposes the shared ts-morph `Project` so the next analysis builds a fresh
+ * one. Wire this into manifest-cache invalidation (e.g. the playground
+ * watcher's rebuild path) so a long-running server never accumulates stale
+ * compiler state across rebuilds.
+ */
+export function resetProject(): void {
+  sharedProject = undefined;
+}
+
+/**
+ * Returns how many ts-morph `Project` instances have been created since module
+ * load. Tests use this to assert the project is shared across calls and that
+ * {@link resetProject} forces exactly one new instance.
+ */
+export function getProjectCreationCount(): number {
+  return projectCreationCount;
+}
+
+/**
+ * Builds a map from prop name â TypeInfo by reading the exported Props type alias
  * from ts-morph. Handles discriminated unions at the top level by walking all arms
- * and merging prop types (conflicting types → unknown).
+ * and merging prop types (conflicting types â unknown).
  */
 function buildTypeInfoMap(
   moduleScriptContent: string,
   componentName: string,
 ): Map<string, TypeInfo> {
-  const project = new Project({
-    tsConfigFilePath: join(import.meta.dirname, '../../components/tsconfig.json'),
-    skipAddingFilesFromTsConfig: true,
-  });
+  const project = getSharedProject();
 
-  const syntheticPath = `__synthetic__/${componentName}.ts`;
-  const sf = project.createSourceFile(syntheticPath, moduleScriptContent, { overwrite: true });
+  // A unique path per call keeps concurrent `analyzeComponent` runs (and repeat
+  // analyses of the same component) from clobbering each other's source file on
+  // the shared project.
+  syntheticFileCounter += 1;
+  const syntheticPath = `__synthetic__/${componentName}.${syntheticFileCounter}.ts`;
+  const sf = project.createSourceFile(syntheticPath, moduleScriptContent);
 
+  try {
+    return extractTypeInfo(sf, componentName);
+  } finally {
+    // Remove the synthetic source file so the shared project doesn't accumulate
+    // stale sources or leak memory across the ~100 components analyzed per build.
+    project.removeSourceFile(sf);
+  }
+}
+
+/**
+ * Reads the exported `${componentName}Props` type alias from an already-created
+ * ts-morph source file and returns a prop name → {@link TypeInfo} map. Split out
+ * of {@link buildTypeInfoMap} so the synthetic source file can be removed in a
+ * `finally` regardless of which early-return path is taken.
+ */
+function extractTypeInfo(
+  sf: ReturnType<Project['createSourceFile']>,
+  componentName: string,
+): Map<string, TypeInfo> {
   const propsAliasName = `${componentName}Props`;
   const propsAlias = sf.getTypeAlias(propsAliasName);
 
@@ -352,7 +448,7 @@ function buildTypeInfoMap(
             }
             if (prop.hasQuestionToken()) optional = true;
           } else {
-            // Prop missing from this arm → it's optional overall
+            // Prop missing from this arm â it's optional overall
             optional = true;
           }
         }
@@ -374,7 +470,7 @@ function buildTypeInfoMap(
       return;
     }
 
-    // TypeLiteral, IntersectionType, TypeReference — collect all properties
+    // TypeLiteral, IntersectionType, TypeReference â collect all properties
     const propMap = new Map<string, PropertySignature>();
     collectPropertiesFromTypeNode(node, propMap);
 
@@ -413,7 +509,7 @@ const SKIP_PROPS = new Set(['class', 'rest']);
 
 /** Analyzes a single Svelte component file and returns its ComponentManifest. */
 export async function analyzeComponent(filePath: string): Promise<ComponentManifest> {
-  const source = readFileSync(filePath, 'utf-8');
+  const source = await Bun.file(filePath).text();
   const fileBaseName = basename(filePath, '.svelte');
   const componentName = toPascalCase(fileBaseName);
 
@@ -424,8 +520,9 @@ export async function analyzeComponent(filePath: string): Promise<ComponentManif
   // re-export types from <name>.types.ts. Concatenate the types-file content
   // so the existing module-script type walker finds the Props alias.
   const typesFilePath = filePath.replace(/\.svelte$/, '.types.ts');
-  if (existsSync(typesFilePath)) {
-    const typesSource = readFileSync(typesFilePath, 'utf-8');
+  const typesFile = Bun.file(typesFilePath);
+  if (await typesFile.exists()) {
+    const typesSource = await typesFile.text();
     moduleScriptContent = `${moduleScriptContent}\n${typesSource}`;
   }
 
@@ -475,26 +572,14 @@ export async function analyzeComponent(filePath: string): Promise<ComponentManif
  * both legacy flat components (`<name>.svelte` at the top level) and the
  * migrated per-directory layout (`<name>/<name>.svelte`). Underscore-prefixed
  * names are excluded as internal-only.
+ *
+ * The file-path scan is shared with `discover.discoverComponents` via
+ * {@link discoverComponentFilePaths} so the two stay in lockstep.
  */
 export async function analyzeAll(componentsDir: string): Promise<ComponentManifest[]> {
-  const filePaths = new Set<string>();
+  const filePaths = await discoverComponentFilePaths(componentsDir);
 
-  // Flat (legacy) components.
-  for await (const file of new Bun.Glob('*.svelte').scan({ cwd: componentsDir })) {
-    if (file.startsWith('_')) continue;
-    filePaths.add(join(componentsDir, file));
-  }
-
-  // Directory-shaped (migrated) components: `<name>/<name>.svelte`.
-  for await (const dir of new Bun.Glob('*/').scan({ cwd: componentsDir, onlyFiles: false })) {
-    const dirName = dir.replace(/\/$/, '');
-    if (dirName.startsWith('_')) continue;
-    if (dirName === 'experimental' || dirName === 'icons') continue;
-    const candidate = join(componentsDir, dirName, `${dirName}.svelte`);
-    if (existsSync(candidate)) filePaths.add(candidate);
-  }
-
-  const manifests = await Promise.all([...filePaths].map((filePath) => analyzeComponent(filePath)));
+  const manifests = await Promise.all(filePaths.map((filePath) => analyzeComponent(filePath)));
 
   return manifests.toSorted((a, b) => a.kebabName.localeCompare(b.kebabName));
 }

--- a/packages/playground/src/component-page-mount-driver.svelte
+++ b/packages/playground/src/component-page-mount-driver.svelte
@@ -1,0 +1,33 @@
+<!--
+  Test-only driver wrapping `component-page-mount-fixture.svelte`.
+
+  Holds the reactive `revision` in a component context (where `$state` is
+  defined) and exposes an imperative `bump()` handle so a test can force the
+  mount-effect to re-run rapidly without an intervening flush — the precise
+  shape that surfaced the original queueMicrotask/cleanup race.
+-->
+<script lang="ts" module>
+  export type MountDriverProps = {
+    scenarios: string[];
+    registry: Record<string, unknown>;
+  };
+
+  export type MountDriverHandle = {
+    bump(): void;
+  };
+</script>
+
+<script lang="ts">
+  import Fixture from './component-page-mount-fixture.svelte';
+
+  let { scenarios, registry }: MountDriverProps = $props();
+
+  let revision = $state(0);
+
+  /** Force the fixture's mount-effect to re-run. */
+  export function bump(): void {
+    revision += 1;
+  }
+</script>
+
+<Fixture {scenarios} {registry} {revision} />

--- a/packages/playground/src/component-page-mount-fixture.svelte
+++ b/packages/playground/src/component-page-mount-fixture.svelte
@@ -1,0 +1,79 @@
+<!--
+  Test-only fixture isolating the example-mount `$effect` from
+  `component-page.svelte`.
+
+  It reproduces that effect's exact structure — render an
+  `example-mount-<scenario>` container per scenario via a keyed `{#each}`, then
+  synchronously mount the registered scenario component into each container and
+  unmount it on cleanup. Reading `revision` inside the effect lets the driver
+  force rapid re-runs, which is the scenario the original `queueMicrotask`
+  deferral mishandled (cleanup raced still-pending mounts into a stale
+  collection). Mounting the full `component-page.svelte` is impractical here: it
+  depends on `window.location.pathname`, the server-injected
+  `__CINDER_EXAMPLES__`/`__CINDER_SCENARIOS__` globals, and several
+  deep-imported cinder components — none of which the race depends on.
+-->
+<script lang="ts">
+  import { mount, unmount } from 'svelte';
+
+  type Props = {
+    /** Scenario ids; one mount container is rendered per id. */
+    scenarios: string[];
+    /**
+     * Registry of scenario id -> component, mirroring
+     * `window.__CINDER_SCENARIOS__`. Values are checked for callability before
+     * mount, exactly like the real effect.
+     */
+    registry: Record<string, unknown>;
+    /**
+     * Bumping this forces the mount-effect to re-run (it is read inside the
+     * effect body), simulating reactive re-runs of the real component.
+     */
+    revision?: number;
+  };
+
+  let { scenarios, registry, revision = 0 }: Props = $props();
+
+  // Mirrors component-page.svelte's example-mount effect verbatim: synchronous
+  // mount into the same `localApps` the cleanup closes over, no microtask.
+  $effect(() => {
+    // Read `revision` so the effect re-runs when the driver bumps it.
+    void revision;
+
+    const localApps: ReturnType<typeof mount>[] = [];
+
+    for (const scenario of scenarios) {
+      const container = document.getElementById(`example-mount-${scenario}`);
+      if (!container) continue;
+
+      const Component = registry[scenario];
+      if (typeof Component !== 'function') {
+        console.error(`[cinder playground] no registered component for scenario "${scenario}"`);
+        continue;
+      }
+
+      try {
+        const app = mount(Component as Parameters<typeof mount>[0], { target: container });
+        localApps.push(app);
+      } catch (error) {
+        console.error(`[cinder playground] failed to mount example "${scenario}":`, error);
+      }
+    }
+
+    return () => {
+      for (const app of localApps) {
+        try {
+          unmount(app);
+        } catch {
+          // Suppress — best-effort cleanup only.
+        }
+      }
+    };
+  });
+</script>
+
+<div class="example-list">
+  {#each scenarios as scenario (scenario)}
+    <div class="example-preview" id="example-mount-{scenario}"></div>
+  {/each}
+</div>

--- a/packages/playground/src/component-page-scenario-probe.svelte
+++ b/packages/playground/src/component-page-scenario-probe.svelte
@@ -1,0 +1,67 @@
+<!--
+  Test-only probe standing in for a real example scenario component.
+
+  It mirrors what a bundled scenario does — render some markup into the
+  per-scenario container — while recording its own mount/unmount lifecycle on a
+  shared module-level ledger. The mount-effect under test (see
+  `component-page-mount-fixture.svelte`) mounts these into independent Svelte
+  trees, so the ledger lets a test assert mount/unmount count parity and detect
+  orphaned trees across rapid effect re-runs.
+-->
+<script lang="ts" module>
+  /** A mount/unmount tally keyed by scenario id, shared across probe instances. */
+  export type ProbeLedger = {
+    mounts: number;
+    unmounts: number;
+    /** Live count = mounts - unmounts; must return to 0 after teardown. */
+    live: number;
+  };
+
+  const ledgers = new Map<string, ProbeLedger>();
+
+  /** Read (creating if absent) the ledger for a scenario id. */
+  export function ledgerFor(scenario: string): ProbeLedger {
+    let ledger = ledgers.get(scenario);
+    if (!ledger) {
+      ledger = { mounts: 0, unmounts: 0, live: 0 };
+      ledgers.set(scenario, ledger);
+    }
+    return ledger;
+  }
+
+  /** Sum of `live` counts across every scenario — non-zero means orphaned trees. */
+  export function totalLive(): number {
+    let total = 0;
+    for (const ledger of ledgers.values()) total += ledger.live;
+    return total;
+  }
+
+  /** Reset every ledger; call between tests. */
+  export function resetLedgers(): void {
+    ledgers.clear();
+  }
+</script>
+
+<script lang="ts">
+  import { onMount } from 'svelte';
+
+  // The mount-effect under test mounts registry components with `{ target }`
+  // only — no props — so the probe self-identifies from the
+  // `example-mount-<scenario>` container it is mounted into, keeping the
+  // fixture's mount call byte-for-byte faithful to component-page.svelte.
+  let host = $state<HTMLDivElement | null>(null);
+
+  onMount(() => {
+    if (host === null) return;
+    const scenario = host.parentElement?.id.replace(/^example-mount-/, '') ?? '';
+    const ledger = ledgerFor(scenario);
+    ledger.mounts += 1;
+    ledger.live += 1;
+    return () => {
+      ledger.unmounts += 1;
+      ledger.live -= 1;
+    };
+  });
+</script>
+
+<div class="scenario-probe" bind:this={host}>probe</div>

--- a/packages/playground/src/component-page.svelte
+++ b/packages/playground/src/component-page.svelte
@@ -1,11 +1,27 @@
 <!-- dev-only playground scaffold; window.__CINDER_EXAMPLES__ is injected server-side -->
 <script lang="ts">
   import { mount, unmount } from 'svelte';
-  import Accordion from '../../components/src/components/accordion/index.ts';
-  import AccordionItem from '../../components/src/components/accordion-item/index.ts';
-  import Card from '../../components/src/components/card/index.ts';
-  import CodeBlock from '../../components/src/components/code-block/index.ts';
-  import { shikiHighlighter } from '../../components/src/highlighters/shiki/index.ts';
+  import { Accordion } from 'cinder/accordion';
+  import { AccordionItem } from 'cinder/accordion-item';
+  import { Badge } from 'cinder/badge';
+  import { Button } from 'cinder/button';
+  import { Callout } from 'cinder/callout';
+  import { Card } from 'cinder/card';
+  import { CodeBlock } from 'cinder/code-block';
+  import { Skeleton } from 'cinder/skeleton';
+  import { Table } from 'cinder/table';
+  import { shikiHighlighter } from 'cinder/highlighters/shiki';
+  import {
+    formatErrorForClipboard,
+    toMountErrorDetail,
+    type MountErrorDetail,
+    type SourceErrorDetail,
+  } from './example-error.ts';
+  import {
+    fetchComponentManifest,
+    toPropReferenceRows,
+    type PropReferenceRow,
+  } from './manifest-reference.ts';
 
   type CinderExampleDescriptor = { scenario: string; title: string; description?: string };
   type CinderWindow = Window &
@@ -40,6 +56,16 @@
   const fetchedSource: Record<string, string | null> = $state({});
   const loadingSource: Record<string, boolean> = $state({});
 
+  // Per-scenario error surfaces. `mountErrors` captures failures thrown by the
+  // imperative `mount()` below — `<svelte:boundary>` can't catch those because
+  // the examples are mounted into bare <div>s via an $effect, not declaratively,
+  // so the try/catch around mount() is the only place the error is observable.
+  // `sourceErrors` captures the detail (requested URL + HTTP status / exception)
+  // behind a failed "View source" fetch so the Retry button has something to
+  // explain and re-run.
+  const mountErrors: Record<string, MountErrorDetail | undefined> = $state({});
+  const sourceErrors: Record<string, SourceErrorDetail | undefined> = $state({});
+
   // Per-scenario accordion expansion state — each entry is a reactive object
   // with a typed `ids` field so property access never returns undefined
   // (noUncheckedIndexedAccess widens plain index signatures, but a typed tuple
@@ -55,14 +81,44 @@
   }
 
   async function fetchSource(scenario: string): Promise<void> {
+    const url = `/example-src/${componentName}/${scenario}`;
     loadingSource[scenario] = true;
+    // Clear any prior failure so a Retry starts from a clean slate.
+    sourceErrors[scenario] = undefined;
     try {
-      const response = await fetch(`/example-src/${componentName}/${scenario}`);
-      fetchedSource[scenario] = response.ok ? await response.text() : null;
-    } catch {
+      const response = await fetch(url);
+      if (response.ok) {
+        fetchedSource[scenario] = await response.text();
+      } else {
+        fetchedSource[scenario] = null;
+        sourceErrors[scenario] = {
+          url,
+          detail: `${response.status} ${response.statusText}`.trim(),
+        };
+      }
+    } catch (error) {
       fetchedSource[scenario] = null;
+      sourceErrors[scenario] = {
+        url,
+        detail: error instanceof Error ? error.message : String(error),
+      };
     } finally {
       loadingSource[scenario] = false;
+    }
+  }
+
+  /**
+   * Copy an error detail to the clipboard. Guarded so the button is a no-op
+   * (rather than a thrown TypeError) in browsers / contexts where the async
+   * Clipboard API is unavailable.
+   */
+  async function copyError(detail: MountErrorDetail): Promise<void> {
+    if (typeof navigator === 'undefined' || navigator.clipboard === undefined) return;
+    try {
+      await navigator.clipboard.writeText(formatErrorForClipboard(detail));
+    } catch {
+      // Clipboard write can reject (permissions, insecure context). Swallow —
+      // copying an error message is a convenience, never load-bearing.
     }
   }
 
@@ -86,40 +142,41 @@
     // Per-run local collection so the cleanup only unmounts this run's mounts.
     // Svelte 5 disposal is unmount(component), not component.destroy().
     const localApps: ReturnType<typeof mount>[] = [];
-    let cancelled = false;
 
     const registry =
       ((window as unknown as Record<string, unknown>)['__CINDER_SCENARIOS__'] as
         | Record<string, unknown>
         | undefined) ?? {};
 
+    // Svelte 5 effects run after the DOM is patched, so every
+    // `example-mount-<scenario>` container the template renders already exists
+    // here. Mount synchronously into the same `localApps` the cleanup closes
+    // over — no microtask deferral, so a re-run's cleanup can never race a
+    // still-pending mount into a stale collection.
     for (const { scenario } of examples) {
-      const containerId = `example-mount-${scenario}`;
+      const container = document.getElementById(`example-mount-${scenario}`);
+      if (!container) continue;
 
-      // Defer to a microtask so the DOM element rendered by the template is
-      // guaranteed to exist before we try to mount into it.
-      queueMicrotask(() => {
-        if (cancelled) return;
-        const container = document.getElementById(containerId);
-        if (!container) return;
+      const Component = registry[scenario];
+      if (typeof Component !== 'function') {
+        console.error(`[cinder playground] no registered component for scenario "${scenario}"`);
+        continue;
+      }
 
-        const Component = registry[scenario];
-        if (typeof Component !== 'function') {
-          console.error(`[cinder playground] no registered component for scenario "${scenario}"`);
-          return;
-        }
-
-        try {
-          const app = mount(Component as Parameters<typeof mount>[0], { target: container });
-          localApps.push(app);
-        } catch (error) {
-          console.error(`[cinder playground] failed to mount example "${scenario}":`, error);
-        }
-      });
+      try {
+        const app = mount(Component as Parameters<typeof mount>[0], { target: container });
+        localApps.push(app);
+        // A previous failed run may have left an error surface; clear it now
+        // that this scenario mounted cleanly.
+        mountErrors[scenario] = undefined;
+      } catch (error) {
+        console.error(`[cinder playground] failed to mount example "${scenario}":`, error);
+        // Surface the failure in the UI instead of leaving a silent blank slot.
+        mountErrors[scenario] = toMountErrorDetail(error);
+      }
     }
 
     return () => {
-      cancelled = true;
       for (const app of localApps) {
         try {
           unmount(app);
@@ -127,6 +184,49 @@
           // Suppress — best-effort cleanup only.
         }
       }
+    };
+  });
+
+  // --- Props / API reference panel ---------------------------------------
+  // The component name is fixed for the lifetime of this page (it comes from
+  // the URL once), so the manifest is fetched exactly once at init rather than
+  // through a reactive effect. Three pieces of $state drive the panel: the
+  // normalized rows, a loading flag, and an error message.
+  let propRows: PropReferenceRow[] = $state([]);
+  let propsLoading = $state(true);
+  let propsError: string | null = $state(null);
+  // Collapsed by default; the panel sits below the examples and opens on demand.
+  let propsExpandedIds: string[] = $state([]);
+
+  // The skeleton placeholder rows give the table a stable shape while the
+  // request is in flight.
+  const skeletonRowCount = 5;
+
+  // Fetch the props manifest once. componentName is non-reactive, so this effect
+  // runs exactly once. A one-shot async fetch whose result lands in $state is
+  // exactly what $effect is for — the cancellation flag prevents writing to
+  // state after the component is torn down mid-flight (e.g. fast navigation in
+  // tests), which a floating async IIFE could not guard against.
+  $effect(() => {
+    if (componentName === '') {
+      propsLoading = false;
+      return;
+    }
+    let cancelled = false;
+    fetchComponentManifest(componentName)
+      .then((manifest) => {
+        if (!cancelled) propRows = toPropReferenceRows(manifest);
+      })
+      .catch((error: unknown) => {
+        if (!cancelled) {
+          propsError = error instanceof Error ? error.message : 'Failed to load props.';
+        }
+      })
+      .finally(() => {
+        if (!cancelled) propsLoading = false;
+      });
+    return () => {
+      cancelled = true;
     };
   });
 </script>
@@ -139,15 +239,60 @@
   {#each examples as { scenario, title, description } (scenario)}
     {@const accordionEntry = getAccordionEntry(scenario)}
     {@const source = fetchedSource[scenario]}
+    {@const mountError = mountErrors[scenario]}
+    {@const sourceError = sourceErrors[scenario]}
     {#if accordionEntry}
       <Card {title} {...description !== undefined ? { description } : {}}>
         <div class="example-preview" id="example-mount-{scenario}"></div>
+
+        {#if mountError !== undefined}
+          <div class="example-error">
+            <Callout variant="danger" title="This example failed to render">
+              <p class="example-error__message">{mountError.message}</p>
+              {#if mountError.stack !== undefined}
+                <pre class="example-error__stack" aria-label="Stack trace">{mountError.stack}</pre>
+              {/if}
+              <div class="example-error__actions">
+                <Button
+                  size="sm"
+                  variant="secondary"
+                  aria-label="Copy error for {title}"
+                  onclick={() => copyError(mountError)}
+                >
+                  Copy error
+                </Button>
+              </div>
+            </Callout>
+          </div>
+        {/if}
+
         <Accordion bind:expandedIds={accordionEntry.expandedIds}>
           <AccordionItem id="source" title="View source">
             {#if loadingSource[scenario]}
               <p class="source-loading">Loading…</p>
             {:else if source === null}
-              <p class="source-error">Could not load source.</p>
+              <div class="example-error">
+                <Callout variant="danger" title="Could not load source">
+                  <dl class="example-error__detail">
+                    <dt>Requested</dt>
+                    <dd>
+                      <code>{sourceError?.url ?? `/example-src/${componentName}/${scenario}`}</code>
+                    </dd>
+                    <dt>Reason</dt>
+                    <dd>{sourceError?.detail ?? 'Unknown error'}</dd>
+                  </dl>
+                  <div class="example-error__actions">
+                    <Button
+                      size="sm"
+                      variant="secondary"
+                      aria-label="Retry loading source for {title}"
+                      onclick={() => fetchSource(scenario)}
+                    >
+                      Retry
+                    </Button>
+                  </div>
+                </Callout>
+              </div>
             {:else if source !== undefined}
               <CodeBlock code={source} language="svelte" {highlighter} copyable />
             {/if}
@@ -156,6 +301,88 @@
       </Card>
     {/if}
   {/each}
+</div>
+
+<!-- Props / API reference. Mirrors the source-accordion visual language:
+       a Card wrapping an Accordion whose single item holds the props table.
+       The wrapper div is owned by this file so its margin selector stays
+       scoped (a class forwarded onto <Card> reads as unused here). -->
+<div class="props-section">
+  <Card title="Props">
+    <Accordion bind:expandedIds={propsExpandedIds}>
+      <AccordionItem id="props" title="API reference">
+        {#if propsLoading}
+          <div class="props-skeleton" aria-hidden="true">
+            {#each Array.from({ length: skeletonRowCount }, (_, index) => index) as row (row)}
+              <Skeleton height="1.5rem" radius="var(--cinder-radius-sm)" />
+            {/each}
+          </div>
+        {:else if propsError !== null}
+          <p class="props-error">Could not load props: {propsError}</p>
+        {:else if propRows.length === 0}
+          <p class="props-empty">This component has no documented props.</p>
+        {:else}
+          <div class="props-table-scroll">
+            <Table caption={`Props for ${componentName}`} density="condensed">
+              <Table.Header>
+                <Table.Row>
+                  <Table.HeaderCell scope="col">Name</Table.HeaderCell>
+                  <Table.HeaderCell scope="col">Type</Table.HeaderCell>
+                  <Table.HeaderCell scope="col">Default</Table.HeaderCell>
+                  <Table.HeaderCell scope="col" align="center">Required</Table.HeaderCell>
+                  <Table.HeaderCell scope="col" align="center">Bindable</Table.HeaderCell>
+                  <Table.HeaderCell scope="col">Description</Table.HeaderCell>
+                </Table.Row>
+              </Table.Header>
+              <Table.Body>
+                {#each propRows as prop (prop.name)}
+                  <Table.Row>
+                    <Table.Cell>
+                      <code class="props-name">{prop.name}</code>
+                      {#if prop.required}
+                        <span class="props-required-marker" aria-hidden="true">*</span>
+                      {/if}
+                    </Table.Cell>
+                    <Table.Cell>
+                      <code class="props-type">{prop.type}</code>
+                    </Table.Cell>
+                    <Table.Cell>
+                      {#if prop.defaultValue !== undefined}
+                        <code class="props-default">{prop.defaultValue}</code>
+                      {:else}
+                        <span class="props-dash" aria-hidden="true">—</span>
+                      {/if}
+                    </Table.Cell>
+                    <Table.Cell align="center">
+                      {#if prop.required}
+                        <Badge variant="danger" size="xs">Required</Badge>
+                      {:else}
+                        <span class="props-dash" aria-hidden="true">—</span>
+                      {/if}
+                    </Table.Cell>
+                    <Table.Cell align="center">
+                      {#if prop.bindable}
+                        <Badge variant="info" size="xs">bind:</Badge>
+                      {:else}
+                        <span class="props-dash" aria-hidden="true">—</span>
+                      {/if}
+                    </Table.Cell>
+                    <Table.Cell>
+                      {#if prop.description !== undefined}
+                        <span class="props-description">{prop.description}</span>
+                      {:else}
+                        <span class="props-dash" aria-hidden="true">—</span>
+                      {/if}
+                    </Table.Cell>
+                  </Table.Row>
+                {/each}
+              </Table.Body>
+            </Table>
+          </div>
+        {/if}
+      </AccordionItem>
+    </Accordion>
+  </Card>
 </div>
 
 <style>
@@ -193,5 +420,105 @@
     font-size: var(--cinder-text-sm);
     color: var(--cinder-text-subtle);
     font-style: italic;
+  }
+
+  /* --- Example error surfaces ------------------------------------------- */
+  .example-error {
+    padding: 0 var(--cinder-space-6) var(--cinder-space-6);
+  }
+
+  .example-error__message {
+    margin: 0;
+    font-weight: var(--cinder-font-medium);
+  }
+
+  .example-error__stack {
+    margin: var(--cinder-space-3) 0 0;
+    padding: var(--cinder-space-3);
+    border-radius: var(--cinder-radius-sm);
+    background: var(--cinder-surface-inset);
+    color: var(--cinder-text-subtle);
+    font-size: var(--cinder-text-xs);
+    line-height: 1.5;
+    white-space: pre-wrap;
+    overflow-x: auto;
+    max-height: 16rem;
+  }
+
+  .example-error__detail {
+    display: grid;
+    grid-template-columns: auto 1fr;
+    gap: var(--cinder-space-1) var(--cinder-space-4);
+    margin: 0;
+    font-size: var(--cinder-text-sm);
+  }
+
+  .example-error__detail dt {
+    font-weight: var(--cinder-font-medium);
+    color: var(--cinder-text-subtle);
+  }
+
+  .example-error__detail dd {
+    margin: 0;
+    word-break: break-word;
+  }
+
+  .example-error__actions {
+    display: flex;
+    gap: var(--cinder-space-2);
+    margin-top: var(--cinder-space-4);
+  }
+
+  /* --- Props / API reference panel ------------------------------------- */
+  .props-section {
+    margin-top: var(--cinder-space-8);
+  }
+
+  .props-skeleton {
+    display: flex;
+    flex-direction: column;
+    gap: var(--cinder-space-3);
+    padding: var(--cinder-space-2) 0;
+  }
+
+  /* The props table has six columns; the Type and Description columns can hold
+     long union strings. <Card> sets overflow: hidden, so give the table its own
+     horizontal scroll container to avoid clipping at narrow preview widths. */
+  .props-table-scroll {
+    overflow-x: auto;
+  }
+
+  .props-error,
+  .props-empty {
+    margin: 0;
+    font-size: var(--cinder-text-sm);
+    color: var(--cinder-text-subtle);
+    font-style: italic;
+  }
+
+  .props-name,
+  .props-type,
+  .props-default {
+    font-family: var(--cinder-font-mono);
+    font-size: var(--cinder-text-sm);
+  }
+
+  .props-name {
+    font-weight: var(--cinder-font-medium);
+  }
+
+  .props-required-marker {
+    margin-inline-start: var(--cinder-space-1);
+    color: var(--cinder-color-danger-fg);
+    font-weight: var(--cinder-font-semibold);
+  }
+
+  .props-description {
+    font-size: var(--cinder-text-sm);
+    color: var(--cinder-text-muted);
+  }
+
+  .props-dash {
+    color: var(--cinder-text-subtle);
   }
 </style>

--- a/packages/playground/src/component-page.test.ts
+++ b/packages/playground/src/component-page.test.ts
@@ -1,0 +1,177 @@
+/// <reference lib="dom" />
+/**
+ * Regression tests for the example-mount `$effect` in `component-page.svelte`.
+ *
+ * The original effect deferred each mount into a `queueMicrotask` callback that
+ * pushed into a per-run `localApps` array. When the effect re-ran, the previous
+ * run's cleanup fired before its queued microtasks, so those microtasks mounted
+ * into (and were tracked by) a collection that nothing would ever clean up —
+ * orphaning Svelte trees and accumulating duplicate mounts across re-runs. The
+ * fix mounts synchronously in the effect body (the container exists post
+ * DOM-patch in Svelte 5), so cleanup and mount share the same `localApps` ref.
+ *
+ * Mounting the full `component-page.svelte` is impractical: it reads
+ * `window.location.pathname`, the server-injected `__CINDER_EXAMPLES__` /
+ * `__CINDER_SCENARIOS__` globals, and several deep-imported cinder components,
+ * none of which the race depends on. These tests instead drive a fixture that
+ * reproduces the effect verbatim (see `component-page-mount-fixture.svelte`)
+ * and assert the load-bearing invariant: mount/unmount count parity, no
+ * orphaned trees, and no duplicate scenario containers across rapid re-runs.
+ *
+ * Harness setup mirrors `shell-app/event-source.test.ts`: happy-dom is
+ * installed onto `globalThis` before `@testing-library/svelte` loads.
+ */
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+
+import { setupHappyDom } from '../../components/src/test/happy-dom.ts';
+
+// Install happy-dom globals via the shared, idempotent helper BEFORE
+// dynamic-importing @testing-library/svelte. Using the single shared window
+// (rather than a private `new Window()`) keeps this file's globals consistent
+// with the bunfig preload and the other shell-app DOM tests; a competing window
+// install replaces globalThis.document with a second happy-dom document, which
+// in a full-suite run corrupts the Svelte runtime/module state that
+// `server.test.ts`'s `Bun.build` relies on.
+setupHappyDom();
+
+const { render } = await import('@testing-library/svelte');
+const { default: Driver } = await import('./component-page-mount-driver.svelte');
+// The probe's `<script module>` exports ledger helpers alongside the default
+// component, but the ambient `*.svelte` module type only surfaces `default`.
+// Cast to the known shape — test files may assert types they know hold.
+const probeModule = (await import('./component-page-scenario-probe.svelte')) as unknown as {
+  default: unknown;
+  ledgerFor: (scenario: string) => { mounts: number; unmounts: number; live: number };
+  totalLive: () => number;
+  resetLedgers: () => void;
+};
+const { default: Probe, ledgerFor, totalLive, resetLedgers } = probeModule;
+const { tick } = await import('svelte');
+
+/** Build a `__CINDER_SCENARIOS__`-style registry mapping each id to the probe. */
+function registryFor(scenarios: string[]): Record<string, unknown> {
+  const registry: Record<string, unknown> = {};
+  for (const scenario of scenarios) registry[scenario] = Probe;
+  return registry;
+}
+
+/** Count rendered `example-mount-*` containers in the document. */
+function containerCount(): number {
+  return document.querySelectorAll('[id^="example-mount-"]').length;
+}
+
+/** Count mounted probe markers in the document. */
+function probeMarkerCount(): number {
+  return document.querySelectorAll('.scenario-probe').length;
+}
+
+beforeEach(() => {
+  resetLedgers();
+});
+
+afterEach(() => {
+  resetLedgers();
+  document.body.innerHTML = '';
+});
+
+describe('component-page example-mount effect', () => {
+  test('mounts exactly one probe per scenario into its container', async () => {
+    const scenarios = ['alpha', 'beta', 'gamma'];
+    const { unmount } = render(Driver, { scenarios, registry: registryFor(scenarios) });
+    await tick();
+
+    expect(containerCount()).toBe(scenarios.length);
+    expect(probeMarkerCount()).toBe(scenarios.length);
+    for (const scenario of scenarios) {
+      expect(ledgerFor(scenario).mounts).toBe(1);
+      expect(ledgerFor(scenario).live).toBe(1);
+      // Each probe lands in its own scenario container.
+      const container = document.getElementById(`example-mount-${scenario}`);
+      expect(container?.querySelectorAll('.scenario-probe').length).toBe(1);
+    }
+
+    unmount();
+  });
+
+  test('unmounts every probe on teardown — no orphaned trees', async () => {
+    const scenarios = ['alpha', 'beta'];
+    const { unmount } = render(Driver, { scenarios, registry: registryFor(scenarios) });
+    await tick();
+    expect(totalLive()).toBe(scenarios.length);
+
+    unmount();
+    await tick();
+
+    expect(totalLive()).toBe(0);
+    expect(probeMarkerCount()).toBe(0);
+    for (const scenario of scenarios) {
+      const ledger = ledgerFor(scenario);
+      expect(ledger.mounts).toBe(ledger.unmounts);
+    }
+  });
+
+  test('rapid effect re-runs keep mount/unmount parity and never orphan trees', async () => {
+    const scenarios = ['alpha', 'beta', 'gamma'];
+    const { component, unmount } = render(Driver, {
+      scenarios,
+      registry: registryFor(scenarios),
+    });
+    await tick();
+    expect(totalLive()).toBe(scenarios.length);
+
+    // Hammer the effect: many re-runs, some without an intervening flush.
+    // This is exactly the timing that orphaned trees under the old
+    // queueMicrotask deferral.
+    const reRuns = 8;
+    for (let index = 0; index < reRuns; index += 1) {
+      component['bump']();
+      // Flush only on alternate iterations to interleave re-runs.
+      if (index % 2 === 0) await tick();
+    }
+    await tick();
+
+    // After every re-run, exactly one live tree per scenario remains — no
+    // accumulation, no orphans.
+    expect(totalLive()).toBe(scenarios.length);
+    expect(probeMarkerCount()).toBe(scenarios.length);
+    expect(containerCount()).toBe(scenarios.length);
+    for (const scenario of scenarios) {
+      const container = document.getElementById(`example-mount-${scenario}`);
+      // No duplicate probes stacked into a single container.
+      expect(container?.querySelectorAll('.scenario-probe').length).toBe(1);
+      const ledger = ledgerFor(scenario);
+      // Every mount across the re-runs was matched by an unmount, except the
+      // single currently-live tree.
+      expect(ledger.mounts - ledger.unmounts).toBe(1);
+    }
+
+    unmount();
+    await tick();
+
+    expect(totalLive()).toBe(0);
+    expect(probeMarkerCount()).toBe(0);
+    for (const scenario of scenarios) {
+      const ledger = ledgerFor(scenario);
+      expect(ledger.mounts).toBe(ledger.unmounts);
+    }
+  });
+
+  test('skips scenarios with no registered component without crashing', async () => {
+    const scenarios = ['alpha', 'missing'];
+    const registry = registryFor(scenarios);
+    delete registry['missing'];
+
+    const { unmount } = render(Driver, { scenarios, registry });
+    await tick();
+
+    // Both containers render; only the registered scenario mounts a probe.
+    expect(containerCount()).toBe(2);
+    expect(probeMarkerCount()).toBe(1);
+    expect(ledgerFor('alpha').live).toBe(1);
+    expect(ledgerFor('missing').mounts).toBe(0);
+
+    unmount();
+    await tick();
+    expect(totalLive()).toBe(0);
+  });
+});

--- a/packages/playground/src/discover.test.ts
+++ b/packages/playground/src/discover.test.ts
@@ -7,14 +7,21 @@
  */
 
 import { describe, expect, it } from 'bun:test';
+import { basename, dirname, join } from 'node:path';
 
+import { analyzeAll } from './analyze.ts';
 import {
   COMPOSE_ONLY_COMPONENTS,
   discoverAll,
+  discoverComponentFilePaths,
   discoverComponents,
   discoverExamples,
   discoverSidebarComponents,
+  invalidateDiscoveryCache,
 } from './discover.ts';
+
+// packages/components/src/components — the same root discoverComponents() scans.
+const COMPONENTS_DIR = join(dirname(import.meta.dirname), '..', 'components', 'src', 'components');
 
 describe('discoverComponents', () => {
   it('returns an array of component kebab names', async () => {
@@ -241,6 +248,177 @@ describe('discoverSidebarComponents', () => {
     const all = await discoverComponents();
     for (const leaf of COMPOSE_ONLY_COMPONENTS) {
       expect(all).toContain(leaf);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Shared file-path scan
+//
+// `discoverComponentFilePaths` is the single source of truth backing both
+// `discoverComponents` (kebab names) and `analyzeAll` (file reads). These
+// tests pin that the three views agree, so the two callers cannot drift apart.
+// ---------------------------------------------------------------------------
+
+describe('discoverComponentFilePaths', () => {
+  it('returns absolute .svelte file paths', async () => {
+    const filePaths = await discoverComponentFilePaths(COMPONENTS_DIR);
+    expect(filePaths.length).toBeGreaterThan(0);
+    for (const filePath of filePaths) {
+      expect(filePath.startsWith('/')).toBe(true);
+      expect(filePath).toMatch(/\.svelte$/);
+    }
+  });
+
+  it('yields the exact same name set as discoverComponents() (sorted compare)', async () => {
+    const filePaths = await discoverComponentFilePaths(COMPONENTS_DIR);
+    const namesFromPaths = [...new Set(filePaths.map((p) => basename(p, '.svelte')))].toSorted();
+    const components = await discoverComponents();
+    expect(namesFromPaths).toEqual(components);
+  });
+
+  it('excludes underscore-prefixed, experimental, and icons entries', async () => {
+    const filePaths = await discoverComponentFilePaths(COMPONENTS_DIR);
+    for (const filePath of filePaths) {
+      expect(basename(filePath).startsWith('_')).toBe(false);
+      expect(filePath).not.toContain('/experimental/');
+      expect(filePath).not.toContain('/icons/');
+    }
+  });
+
+  // analyzeAll spins up a fresh ts-morph Project per component (a known perf
+  // cost), so the cold-start scan over the whole library can exceed the default
+  // 5s per-test budget. The generous timeout keeps this invariant test honest
+  // without flaking on a slow machine.
+  it('matches the component set analyzeAll() resolves', async () => {
+    const manifests = await analyzeAll(COMPONENTS_DIR);
+    const fromAnalyze = manifests.map((m) => m.kebabName).toSorted();
+    const fromDiscover = await discoverComponents();
+    expect(fromAnalyze).toEqual(fromDiscover);
+  }, 60_000);
+});
+
+// ---------------------------------------------------------------------------
+// Discovery cache
+//
+// `discoverComponents` / `discoverAll` run on every `/`, `/c/:name`, and
+// `/page/:name` request, so their full `Bun.Glob` scans are memoized at module
+// scope and invalidated on each watcher rebuild via `invalidateDiscoveryCache`.
+// These tests pin that a warm call does NOT re-scan and that invalidation
+// forces a fresh scan — measured by spying on `Bun.Glob`'s `scan`.
+// ---------------------------------------------------------------------------
+
+describe('discovery cache', () => {
+  // Count Bun.Glob().scan() calls so we can assert when a real filesystem
+  // scan happens vs. when a cached result is returned. scanComponents()
+  // constructs two globs (flat + directory) per cold scan, and discoverAll
+  // additionally scans one example glob per component, so a warm call adds
+  // zero scans. We only assert direction (more vs. equal), never exact counts,
+  // so the test is robust to component-count growth.
+  let scanCallCount = 0;
+  const realScan = Bun.Glob.prototype.scan;
+
+  const installSpy = () => {
+    scanCallCount = 0;
+    Bun.Glob.prototype.scan = function spiedScan(this: Bun.Glob, ...args: unknown[]) {
+      scanCallCount += 1;
+      // @ts-expect-error — forwarding the original variadic scan signature.
+      return realScan.apply(this, args);
+    };
+  };
+
+  const restoreSpy = () => {
+    Bun.Glob.prototype.scan = realScan;
+  };
+
+  it('does not re-scan the filesystem on a warm discoverComponents() call', async () => {
+    // Warm the cache first (cold scan happens here, possibly counted partially).
+    invalidateDiscoveryCache();
+    await discoverComponents();
+
+    installSpy();
+    try {
+      const first = await discoverComponents();
+      const countAfterWarm = scanCallCount;
+      const second = await discoverComponents();
+      // A warm call must perform zero new scans.
+      expect(scanCallCount).toBe(countAfterWarm);
+      expect(scanCallCount).toBe(0);
+      // And the cached value is referentially identical across calls.
+      expect(second).toBe(first);
+    } finally {
+      restoreSpy();
+    }
+  });
+
+  it('re-scans after invalidateDiscoveryCache() forces a cold call', async () => {
+    // Warm the cache so the next discoverComponents() would be a cache hit.
+    invalidateDiscoveryCache();
+    await discoverComponents();
+
+    installSpy();
+    try {
+      // Warm hit: no scans.
+      await discoverComponents();
+      expect(scanCallCount).toBe(0);
+
+      // Invalidate, then the next call must perform a real scan.
+      invalidateDiscoveryCache();
+      await discoverComponents();
+      expect(scanCallCount).toBeGreaterThan(0);
+    } finally {
+      restoreSpy();
+    }
+  });
+
+  it('invalidates discoverAll() under the same generation as discoverComponents()', async () => {
+    invalidateDiscoveryCache();
+    const firstAll = await discoverAll();
+    const warmAll = await discoverAll();
+    // Warm discoverAll() returns the identical memoized array.
+    expect(warmAll).toBe(firstAll);
+
+    invalidateDiscoveryCache();
+    const freshAll = await discoverAll();
+    // After invalidation it is a brand-new array (cache was dropped) but with
+    // structurally equal contents — exact values and ordering preserved.
+    expect(freshAll).not.toBe(firstAll);
+    expect(freshAll).toEqual(firstAll);
+  });
+
+  it('preserves exact return values and sorting across the cache boundary', async () => {
+    invalidateDiscoveryCache();
+    const cold = await discoverComponents();
+    const warm = await discoverComponents();
+    expect(warm).toEqual(cold);
+    expect(warm).toEqual([...cold].toSorted());
+  });
+
+  it('re-scans when invalidation happens while a discoverComponents() scan is in flight', async () => {
+    // Reproduces the race the generation guard closes: a caller starts awaiting
+    // a scan, the watcher invalidates mid-flight, and the caller must NOT serve
+    // the now-stale in-flight result — it must re-scan under the new generation.
+    invalidateDiscoveryCache();
+
+    installSpy();
+    try {
+      // Kick off a scan but DON'T await it yet, then invalidate before it
+      // resolves — exactly the interleaving a watcher rebuild produces.
+      const pending = discoverComponents();
+      invalidateDiscoveryCache();
+      await pending;
+      const scansAfterRace = scanCallCount;
+      // The guard must have triggered a second (fresh) scan after invalidation,
+      // not returned the stale in-flight one — so more than one scan ran.
+      expect(scansAfterRace).toBeGreaterThan(0);
+
+      // And a subsequent call is once again a warm hit (cache settled on the
+      // post-invalidation generation).
+      const settled = scanCallCount;
+      await discoverComponents();
+      expect(scanCallCount).toBe(settled);
+    } finally {
+      restoreSpy();
     }
   });
 });

--- a/packages/playground/src/discover.ts
+++ b/packages/playground/src/discover.ts
@@ -6,7 +6,7 @@
  * All scanning uses `Bun.Glob` with absolute paths derived from `import.meta.dirname`.
  */
 
-import { dirname, join } from 'node:path';
+import { basename, dirname, join } from 'node:path';
 
 // import.meta.dirname is packages/playground/src/
 const PLAYGROUND_ROOT = dirname(import.meta.dirname); // packages/playground/
@@ -47,33 +47,122 @@ export const COMPOSE_ONLY_COMPONENTS: ReadonlySet<string> = new Set([
 ]);
 
 /**
- * Returns a sorted array of component kebab names. Discovers both the legacy
- * flat layout (`packages/components/src/components/<name>.svelte`) and the
- * per-directory migrated layout (`packages/components/src/components/<name>/<name>.svelte`).
- * Underscore-prefixed names are excluded as internal-only.
+ * Scans a component-source root for the absolute paths of every public
+ * component `.svelte` file. Covers both the legacy flat layout
+ * (`<root>/<name>.svelte`) and the per-directory migrated layout
+ * (`<root>/<name>/<name>.svelte`).
+ *
+ * Exclusions, applied identically to both layouts:
+ *  - underscore-prefixed names (internal-only),
+ *  - the `experimental/` and `icons/` directories,
+ *  - directories whose `<name>/<name>.svelte` file does not exist.
+ *
+ * This is the single source of truth shared by {@link discoverComponents}
+ * (which derives kebab names) and the playground analyzer's `analyzeAll`
+ * (which reads the files). Returned paths are deduplicated but unsorted.
  */
-export async function discoverComponents(): Promise<string[]> {
-  const names = new Set<string>();
-  const root = join(COMPONENTS_ROOT, 'src', 'components');
+export async function discoverComponentFilePaths(root: string): Promise<string[]> {
+  const filePaths = new Set<string>();
 
   // Flat (legacy) components.
   for await (const file of new Bun.Glob('*.svelte').scan({ cwd: root })) {
     if (file.startsWith('_')) continue;
-    names.add(file.replace(/\.svelte$/, ''));
+    filePaths.add(join(root, file));
   }
 
-  // Directory-shaped (migrated) components.
+  // Directory-shaped (migrated) components: `<name>/<name>.svelte`.
   for await (const dir of new Bun.Glob('*/').scan({ cwd: root, onlyFiles: false })) {
     const dirName = dir.replace(/\/$/, '');
     if (dirName.startsWith('_')) continue;
     if (dirName === 'experimental' || dirName === 'icons') continue;
     // Confirm the directory holds a top-level .svelte file matching its name.
-    const expectedFile = `${dirName}/${dirName}.svelte`;
-    const hit = await Bun.file(join(root, expectedFile)).exists();
-    if (hit) names.add(dirName);
+    const candidate = join(root, dirName, `${dirName}.svelte`);
+    if (await Bun.file(candidate).exists()) filePaths.add(candidate);
   }
 
-  return [...names].toSorted();
+  return [...filePaths];
+}
+
+/**
+ * Memoized result of {@link scanComponents}. `null` means "cold" — the next
+ * {@link discoverComponents} call performs the full glob scan and caches the
+ * in-flight promise here. Cleared by {@link invalidateDiscoveryCache} on every
+ * watcher rebuild so renamed/added/removed components are picked up.
+ *
+ * The cache stores the *promise*, not the resolved array, so concurrent first
+ * callers share a single scan instead of each kicking off their own.
+ */
+let componentsCache: Promise<string[]> | null = null;
+
+/**
+ * Monotonic discovery generation. {@link invalidateDiscoveryCache} bumps it on
+ * every watcher rebuild. Each memoized getter captures the generation when it
+ * starts a scan and ignores the cache (re-scanning) if the generation has moved
+ * on by the time it reads it — so a caller that started awaiting a scan *before*
+ * an invalidation never serves the now-stale result back as if it were fresh.
+ * Nulling the cache pointers alone could not fix that: a caller already holding
+ * the in-flight promise would still resolve to pre-invalidation data.
+ */
+let discoveryGeneration = 0;
+
+/**
+ * Memoized result of {@link computeDiscoverAll}. Derived from the cached
+ * component list plus a per-component example scan; invalidated alongside
+ * {@link componentsCache}.
+ */
+let discoverAllCache: Promise<Array<{ name: string; exampleCount: number }>> | null = null;
+
+/**
+ * Drop every memoized discovery result so the next call re-scans the
+ * filesystem. Called by the playground server whenever the file watcher kicks
+ * off a rebuild (i.e. when `rebuildGeneration` increments), guaranteeing the
+ * sidebar and component routes reflect on-disk renames, additions, and
+ * deletions without a server restart.
+ */
+export function invalidateDiscoveryCache(): void {
+  discoveryGeneration += 1;
+  componentsCache = null;
+  discoverAllCache = null;
+}
+
+/**
+ * Perform the actual scan for public component kebab names. Pure and uncached —
+ * {@link discoverComponents} owns the memoization. Delegates the filesystem
+ * walk to {@link discoverComponentFilePaths} (the single source of truth shared
+ * with the analyzer), then derives sorted, deduplicated kebab names. Kept
+ * separate so the cache layer and the scan logic stay independently testable.
+ */
+async function scanComponents(): Promise<string[]> {
+  const root = join(COMPONENTS_ROOT, 'src', 'components');
+  const filePaths = await discoverComponentFilePaths(root);
+  const names = filePaths.map((filePath) => basename(filePath, '.svelte'));
+  return [...new Set(names)].toSorted();
+}
+
+/**
+ * Returns a sorted array of component kebab names. Discovers both the legacy
+ * flat layout (`packages/components/src/components/<name>.svelte`) and the
+ * per-directory migrated layout (`packages/components/src/components/<name>/<name>.svelte`).
+ * Underscore-prefixed names are excluded as internal-only.
+ *
+ * The result is memoized at module scope: this function runs on every `/`,
+ * `/c/:name`, and `/page/:name` request, so the full `Bun.Glob` scan only
+ * happens once per watcher generation. Call {@link invalidateDiscoveryCache}
+ * to force a re-scan after a rebuild. The cache stores the in-flight promise,
+ * so the resolved array is identical between calls and preserves exact sorting.
+ */
+export async function discoverComponents(): Promise<string[]> {
+  // Re-scan until a scan completes without an invalidation racing it. A single
+  // post-await generation check is not enough: a second invalidation *during*
+  // the retry scan would otherwise be missed, returning stale data again. The
+  // loop converges as soon as no rebuild lands while a scan is in flight, which
+  // it always does because rebuilds are debounced and finite.
+  for (;;) {
+    const generationAtStart = discoveryGeneration;
+    componentsCache ??= scanComponents();
+    const result = await componentsCache;
+    if (generationAtStart === discoveryGeneration) return result;
+  }
 }
 
 /**
@@ -85,16 +174,21 @@ export async function discoverExamples(componentName: string): Promise<string[]>
   const scenarios: string[] = [];
 
   for await (const file of glob.scan({ cwd: join(PLAYGROUND_ROOT, 'src', 'examples') })) {
-    const basename = file.split('/').pop()!;
-    const scenario = basename.replace(/\.example\.svelte$/, '');
+    const fileName = file.split('/').pop()!;
+    const scenario = fileName.replace(/\.example\.svelte$/, '');
     scenarios.push(scenario);
   }
 
   return scenarios.toSorted();
 }
 
-/** Returns all components paired with their example count. */
-export async function discoverAll(): Promise<Array<{ name: string; exampleCount: number }>> {
+/**
+ * Pair every component with its example count. Pure and uncached —
+ * {@link discoverAll} owns the memoization. Relies on {@link discoverComponents}
+ * (itself cached) for the component list, then scans each component's example
+ * directory once.
+ */
+async function computeDiscoverAll(): Promise<Array<{ name: string; exampleCount: number }>> {
   const components = await discoverComponents();
 
   const results = await Promise.all(
@@ -105,6 +199,24 @@ export async function discoverAll(): Promise<Array<{ name: string; exampleCount:
   );
 
   return results;
+}
+
+/**
+ * Returns all components paired with their example count. Memoized under the
+ * same invalidation as {@link discoverComponents}, since `/` and `/c/:name`
+ * drive {@link discoverSidebarComponents} (which calls this) on every request.
+ * Call {@link invalidateDiscoveryCache} to force a re-scan after a rebuild.
+ */
+export async function discoverAll(): Promise<Array<{ name: string; exampleCount: number }>> {
+  // Loop until a compute completes without an invalidation racing it — the same
+  // convergence guard as discoverComponents(), so a second rebuild during the
+  // retry can't leave stale example counts cached.
+  for (;;) {
+    const generationAtStart = discoveryGeneration;
+    discoverAllCache ??= computeDiscoverAll();
+    const result = await discoverAllCache;
+    if (generationAtStart === discoveryGeneration) return result;
+  }
 }
 
 /**

--- a/packages/playground/src/example-error.test.ts
+++ b/packages/playground/src/example-error.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from 'bun:test';
+
+import {
+  formatErrorForClipboard,
+  formatErrorMessage,
+  MAX_STACK_LENGTH,
+  toMountErrorDetail,
+  truncateStack,
+} from './example-error.ts';
+
+describe('formatErrorMessage', () => {
+  it('uses the message of an Error instance', () => {
+    expect(formatErrorMessage(new Error('boom'))).toBe('boom');
+  });
+
+  it('falls back to the error name when the message is empty', () => {
+    const error = new TypeError('');
+    expect(formatErrorMessage(error)).toBe('TypeError');
+  });
+
+  it('returns a thrown string verbatim', () => {
+    expect(formatErrorMessage('plain string failure')).toBe('plain string failure');
+  });
+
+  it('stringifies a thrown non-error value', () => {
+    expect(formatErrorMessage(42)).toBe('42');
+    expect(formatErrorMessage({ toString: () => 'custom' })).toBe('custom');
+  });
+
+  it('never returns an empty string for a falsy thrown value', () => {
+    expect(formatErrorMessage(null)).toBe('null');
+    expect(formatErrorMessage(undefined)).toBe('undefined');
+  });
+});
+
+describe('truncateStack', () => {
+  it('returns undefined for undefined input', () => {
+    expect(truncateStack(undefined)).toBeUndefined();
+  });
+
+  it('returns undefined for whitespace-only input', () => {
+    expect(truncateStack('   \n  ')).toBeUndefined();
+  });
+
+  it('returns a short stack trimmed and intact', () => {
+    expect(truncateStack('  at foo (bar.ts:1)  ')).toBe('at foo (bar.ts:1)');
+  });
+
+  it('truncates a stack longer than the limit and appends a marker', () => {
+    const long = 'x'.repeat(MAX_STACK_LENGTH + 50);
+    const result = truncateStack(long);
+    expect(result).not.toBeUndefined();
+    expect(result?.startsWith('x'.repeat(MAX_STACK_LENGTH))).toBe(true);
+    expect(result).toContain('50 more characters truncated');
+  });
+
+  it('honors a custom maxLength', () => {
+    const result = truncateStack('abcdefghij', 4);
+    expect(result?.startsWith('abcd')).toBe(true);
+    expect(result).toContain('6 more characters truncated');
+  });
+});
+
+describe('toMountErrorDetail', () => {
+  it('captures both message and truncated stack from an Error', () => {
+    const error = new Error('mount failed');
+    error.stack = 'Error: mount failed\n    at mount (component.svelte:10)';
+    const detail = toMountErrorDetail(error);
+    expect(detail.message).toBe('mount failed');
+    expect(detail.stack).toContain('at mount (component.svelte:10)');
+  });
+
+  it('omits the stack when the thrown value carries none', () => {
+    expect(toMountErrorDetail('just a string')).toEqual({ message: 'just a string' });
+  });
+
+  it('omits the stack when an Error has an empty stack', () => {
+    const error = new Error('no stack');
+    error.stack = '';
+    expect(toMountErrorDetail(error)).toEqual({ message: 'no stack' });
+  });
+});
+
+describe('formatErrorForClipboard', () => {
+  it('returns only the message when there is no stack', () => {
+    expect(formatErrorForClipboard({ message: 'oops' })).toBe('oops');
+  });
+
+  it('joins message and stack with a blank line', () => {
+    expect(
+      formatErrorForClipboard({ message: 'oops', stack: 'at a\nat b' }),
+    ).toBe('oops\n\nat a\nat b');
+  });
+});

--- a/packages/playground/src/example-error.ts
+++ b/packages/playground/src/example-error.ts
@@ -1,0 +1,80 @@
+/**
+ * Pure helpers for the component-page example error surfaces.
+ *
+ * Mount errors (thrown by `mount()` inside the page's `$effect`) and source-fetch
+ * failures both render a styled error block in `component-page.svelte`. The
+ * formatting/truncation logic lives here, separated from the component, so it can
+ * be unit-tested without a DOM and reused by both surfaces.
+ */
+
+/** Maximum number of stack characters shown in the error surface before truncation. */
+export const MAX_STACK_LENGTH = 1200;
+
+/** A mount failure captured per scenario, ready to render. */
+export type MountErrorDetail = {
+  /** Human-readable error message (the thrown value coerced to a string). */
+  message: string;
+  /** Truncated stack trace, or `undefined` when the thrown value carried none. */
+  stack?: string;
+};
+
+/** A source-fetch failure captured per scenario, ready to render. */
+export type SourceErrorDetail = {
+  /** The `/example-src/<name>/<scenario>` URL that was requested. */
+  url: string;
+  /**
+   * The HTTP status line (`404 Not Found`) for a response error, or the
+   * exception message for a thrown/network error.
+   */
+  detail: string;
+};
+
+/**
+ * Coerce an unknown thrown value into a readable message. `Error` instances
+ * yield their `message`; everything else is `String()`-ified so a thrown string,
+ * number, or object still surfaces something meaningful rather than
+ * `[object Object]`-only noise.
+ */
+export function formatErrorMessage(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message || error.name || 'Unknown error';
+  }
+  if (typeof error === 'string') return error;
+  try {
+    return String(error);
+  } catch {
+    return 'Unknown error';
+  }
+}
+
+/**
+ * Truncate a stack trace to `MAX_STACK_LENGTH` characters, appending an
+ * ellipsis marker when content was dropped. Returns `undefined` for an empty or
+ * whitespace-only input so the caller can omit the stack block entirely.
+ */
+export function truncateStack(stack: string | undefined, maxLength = MAX_STACK_LENGTH): string | undefined {
+  if (stack === undefined) return undefined;
+  const trimmed = stack.trim();
+  if (trimmed === '') return undefined;
+  if (trimmed.length <= maxLength) return trimmed;
+  return `${trimmed.slice(0, maxLength)}\n… (${trimmed.length - maxLength} more characters truncated)`;
+}
+
+/**
+ * Build a renderable {@link MountErrorDetail} from an unknown thrown value,
+ * formatting the message and truncating the stack in one place.
+ */
+export function toMountErrorDetail(error: unknown): MountErrorDetail {
+  const message = formatErrorMessage(error);
+  const stack = error instanceof Error ? truncateStack(error.stack) : undefined;
+  return stack === undefined ? { message } : { message, stack };
+}
+
+/**
+ * Compose the multi-line text copied to the clipboard by the "Copy error"
+ * button: the message followed by the (already-truncated) stack when present.
+ */
+export function formatErrorForClipboard(detail: MountErrorDetail): string {
+  if (detail.stack === undefined) return detail.message;
+  return `${detail.message}\n\n${detail.stack}`;
+}

--- a/packages/playground/src/example-metadata.test.ts
+++ b/packages/playground/src/example-metadata.test.ts
@@ -1,0 +1,152 @@
+/**
+ * Unit tests for the example-metadata extractor.
+ *
+ * These assert observable behavior (parsed title/description for a given source
+ * string), never the regex internals — so downstream refactors (named capture
+ * groups, an added warn on missing title, etc.) don't break them.
+ */
+
+import { describe, expect, it } from 'bun:test';
+
+import {
+  extractExampleMetadataFromSource,
+  unescapeStringLiteral,
+} from './example-metadata.ts';
+
+describe('extractExampleMetadataFromSource — title', () => {
+  it('extracts a single-quoted title', () => {
+    const source = `export const title = 'Basic usage';`;
+    expect(extractExampleMetadataFromSource(source).title).toBe('Basic usage');
+  });
+
+  it('extracts a double-quoted title', () => {
+    const source = `export const title = "Basic usage";`;
+    expect(extractExampleMetadataFromSource(source).title).toBe('Basic usage');
+  });
+
+  it('extracts a backtick (template-literal) title', () => {
+    const source = 'export const title = `Basic usage`;';
+    expect(extractExampleMetadataFromSource(source).title).toBe('Basic usage');
+  });
+
+  it('unescapes an escaped backslash inside the title', () => {
+    // Source literal: 'Path: C:\\Users' → rendered: Path: C:\Users
+    const source = String.raw`export const title = 'Path: C:\\Users';`;
+    expect(extractExampleMetadataFromSource(source).title).toBe('Path: C:\\Users');
+  });
+
+  it('unescapes an escaped same-style quote inside the title', () => {
+    // Source literal: 'It\'s working' → rendered: It's working
+    const source = String.raw`export const title = 'It\'s working';`;
+    expect(extractExampleMetadataFromSource(source).title).toBe("It's working");
+  });
+
+  it('preserves unicode characters in the title', () => {
+    const source = `export const title = 'Café — 日本語 ✓';`;
+    expect(extractExampleMetadataFromSource(source).title).toBe('Café — 日本語 ✓');
+  });
+
+  it('unescapes a \\n escape sequence in the title', () => {
+    const source = String.raw`export const title = 'Line one\nLine two';`;
+    expect(extractExampleMetadataFromSource(source).title).toBe('Line one\nLine two');
+  });
+
+  it('does not break when the title contains a literal </script>', () => {
+    // The closing-tag sequence inside the string must not terminate parsing.
+    const source = `export const title = 'Before </script> after';`;
+    expect(extractExampleMetadataFromSource(source).title).toBe('Before </script> after');
+  });
+
+  it('tolerates flexible whitespace around the assignment', () => {
+    const source = `export   const    title   =   'Spaced';`;
+    expect(extractExampleMetadataFromSource(source).title).toBe('Spaced');
+  });
+});
+
+describe('extractExampleMetadataFromSource — missing title', () => {
+  it('falls back to "Untitled" without throwing when no title export exists', () => {
+    const source = `export const description = 'Only a description here';`;
+    let meta: ReturnType<typeof extractExampleMetadataFromSource> | undefined;
+    expect(() => {
+      meta = extractExampleMetadataFromSource(source);
+    }).not.toThrow();
+    expect(meta?.title).toBe('Untitled');
+  });
+
+  it('falls back to "Untitled" for completely empty source', () => {
+    expect(extractExampleMetadataFromSource('').title).toBe('Untitled');
+  });
+
+  it('does not match a non-exported `const title`', () => {
+    // The export keyword is required; a local const must not be picked up.
+    const source = `const title = 'Local only';`;
+    expect(extractExampleMetadataFromSource(source).title).toBe('Untitled');
+  });
+});
+
+describe('extractExampleMetadataFromSource — description', () => {
+  it('extracts a single-line description', () => {
+    const source = `export const description = 'A short blurb';`;
+    expect(extractExampleMetadataFromSource(source).description).toBe('A short blurb');
+  });
+
+  it('extracts a multi-line description from a template literal', () => {
+    const source = [
+      'export const description = `First line',
+      'Second line',
+      'Third line`;',
+    ].join('\n');
+    expect(extractExampleMetadataFromSource(source).description).toBe(
+      'First line\nSecond line\nThird line',
+    );
+  });
+
+  it('omits description entirely (not "") when no description export exists', () => {
+    const source = `export const title = 'Title only';`;
+    const meta = extractExampleMetadataFromSource(source);
+    expect(meta.description).toBeUndefined();
+    expect('description' in meta).toBe(false);
+  });
+
+  it('extracts both title and description together', () => {
+    const source = [
+      `export const title = 'My Example';`,
+      `export const description = 'What it shows';`,
+    ].join('\n');
+    const meta = extractExampleMetadataFromSource(source);
+    expect(meta.title).toBe('My Example');
+    expect(meta.description).toBe('What it shows');
+  });
+
+  it('preserves an empty-string description as "" when explicitly authored', () => {
+    // An explicitly-empty description is a real (if odd) authored value; it is
+    // present in the source, so it should be present in the result.
+    const source = `export const description = '';`;
+    const meta = extractExampleMetadataFromSource(source);
+    expect(meta.description).toBe('');
+    expect('description' in meta).toBe(true);
+  });
+});
+
+describe('unescapeStringLiteral', () => {
+  it('resolves \\n, \\t, and \\r', () => {
+    expect(unescapeStringLiteral(String.raw`a\nb\tc\rd`)).toBe('a\nb\tc\rd');
+  });
+
+  it('resolves an escaped backslash', () => {
+    expect(unescapeStringLiteral(String.raw`a\\b`)).toBe('a\\b');
+  });
+
+  it('resolves the three escaped quote styles', () => {
+    expect(unescapeStringLiteral(String.raw`\'\"\``)).toBe('\'"`');
+  });
+
+  it('passes through an unknown escape as the bare character', () => {
+    // `\x` is not a recognized escape, so it resolves to a literal `x`.
+    expect(unescapeStringLiteral(String.raw`a\xb`)).toBe('axb');
+  });
+
+  it('leaves a string with no escapes unchanged', () => {
+    expect(unescapeStringLiteral('plain text')).toBe('plain text');
+  });
+});

--- a/packages/playground/src/example-metadata.ts
+++ b/packages/playground/src/example-metadata.ts
@@ -1,0 +1,98 @@
+/**
+ * Example metadata extraction for `.example.svelte` files.
+ *
+ * Every page title and description shown in the playground is sourced from the
+ * `export const title = '…'` / `export const description = '…'` declarations in
+ * an example file's module script. This module owns the regex-based extraction
+ * so `server.ts` has a single, testable source of truth — the pure string
+ * parser is separated from the file read so it can be unit-tested without
+ * touching the filesystem.
+ */
+
+/** Parsed metadata for a single example file. */
+export type ExampleMetadata = {
+  /** Display title; falls back to `'Untitled'` when no `title` export exists. */
+  title: string;
+  /** Optional description; omitted entirely when no `description` export exists. */
+  description?: string;
+};
+
+// Named group `quote` = the surrounding quote (one of `'`, `"`, `` ` ``);
+// named group `body` = the string body. The body matches anything that's not a
+// backslash-escape, and `\\.` consumes any escaped character so the matching
+// close-quote isn't confused by an escaped quote inside the literal. The
+// backreference `\k<quote>` enforces a same-quote close.
+const STRING_PATTERN = /(?<quote>['"`])(?<body>(?:[^\\]|\\.)*?)\k<quote>/.source;
+
+const TITLE_PATTERN = new RegExp(`export\\s+const\\s+title\\s*=\\s*${STRING_PATTERN}`);
+const DESCRIPTION_PATTERN = new RegExp(
+  `export\\s+const\\s+description\\s*=\\s*${STRING_PATTERN}`,
+);
+
+/**
+ * Extract title/description from example source text via regex. Pure — no I/O.
+ *
+ * Supports single-quoted, double-quoted, and template-literal (backtick)
+ * strings. The matched body is run through {@link unescapeStringLiteral} so
+ * escape sequences like `\n`, `\'`, and `\\` render correctly. Template
+ * literals with `${...}` interpolations are intentionally not supported —
+ * example metadata is a static label, not a computed expression.
+ *
+ * A missing `title` export falls back to `'Untitled'` rather than throwing; a
+ * missing `description` export is omitted from the result entirely (never set
+ * to an empty string).
+ */
+export function extractExampleMetadataFromSource(source: string): ExampleMetadata {
+  const titleMatch = source.match(TITLE_PATTERN);
+  const descriptionMatch = source.match(DESCRIPTION_PATTERN);
+  const meta: ExampleMetadata = {
+    title: titleMatch ? unescapeStringLiteral(titleMatch.groups?.['body'] ?? '') : 'Untitled',
+  };
+  const descriptionBody = descriptionMatch?.groups?.['body'];
+  if (descriptionBody !== undefined) {
+    meta.description = unescapeStringLiteral(descriptionBody);
+  }
+  return meta;
+}
+
+/**
+ * Read an example file and extract its title/description metadata. Thin I/O
+ * wrapper around {@link extractExampleMetadataFromSource}.
+ *
+ * Warns once per read when the file is missing a `title` export and the title
+ * therefore falls back to `'Untitled'`, so authors get a nudge to add one
+ * without the dev server failing. The build-time `validate-playground.ts` check
+ * is the hard gate; this is the soft runtime signal.
+ */
+export async function readExampleMetadata(filePath: string): Promise<ExampleMetadata> {
+  const source = await Bun.file(filePath).text();
+  const meta = extractExampleMetadataFromSource(source);
+  if (meta.title === 'Untitled') {
+    console.warn(`[playground] example missing title: ${filePath}`);
+  }
+  return meta;
+}
+
+/** Resolve common JavaScript string escape sequences in a captured literal body. */
+export function unescapeStringLiteral(raw: string): string {
+  return raw.replace(/\\(.)/g, (_match, char: string) => {
+    switch (char) {
+      case 'n':
+        return '\n';
+      case 't':
+        return '\t';
+      case 'r':
+        return '\r';
+      case '\\':
+        return '\\';
+      case "'":
+        return "'";
+      case '"':
+        return '"';
+      case '`':
+        return '`';
+      default:
+        return char;
+    }
+  });
+}

--- a/packages/playground/src/manifest-reference.test.ts
+++ b/packages/playground/src/manifest-reference.test.ts
@@ -1,0 +1,261 @@
+/**
+ * Tests for the Props / API reference helpers.
+ *
+ * These are pure functions over a `ComponentManifest`, so we test them directly
+ * — no component mount required. We assert against Button's REAL manifest
+ * (analyzed live) to prove the panel shapes a real component with required
+ * props and varied control kinds, plus synthetic manifests to cover the
+ * bindable column and the fetch/validation paths deterministically.
+ */
+import { describe, expect, it } from 'bun:test';
+import { join } from 'node:path';
+
+import { analyzeComponent } from './analyze.ts';
+import {
+  describeControlType,
+  describeDefaultValue,
+  fetchComponentManifest,
+  isComponentManifest,
+  toPropReferenceRow,
+  toPropReferenceRows,
+} from './manifest-reference.ts';
+import type { ComponentManifest, PropManifest } from './types.ts';
+
+const COMPONENTS_ROOT = join(import.meta.dir, '..', '..', 'components', 'src', 'components');
+
+function buttonManifest(): Promise<ComponentManifest> {
+  return analyzeComponent(join(COMPONENTS_ROOT, 'button', 'button.svelte'));
+}
+
+// Module-scope fetch fixtures for the unhappy-path fetch tests. They capture
+// nothing from their call sites, so they live at module scope rather than being
+// re-created inside each `it` block.
+const notFoundFetch = async (): Promise<Response> =>
+  new Response('not found', { status: 404, statusText: 'Not Found' });
+
+const malformedBodyFetch = async (): Promise<Response> =>
+  new Response(JSON.stringify({ not: 'a manifest' }), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  });
+
+describe('describeControlType', () => {
+  it('renders a select control as a quoted union', () => {
+    expect(describeControlType({ kind: 'select', options: ['sm', 'md', 'lg'] })).toBe(
+      "'sm' | 'md' | 'lg'",
+    );
+  });
+
+  it('renders an unknown control as its raw type', () => {
+    expect(describeControlType({ kind: 'unknown', rawType: 'string | number' })).toBe(
+      'string | number',
+    );
+  });
+
+  it('falls back to "unknown" when the raw type is the "?" placeholder', () => {
+    expect(describeControlType({ kind: 'unknown', rawType: '?' })).toBe('unknown');
+    expect(describeControlType({ kind: 'unknown', rawType: '' })).toBe('unknown');
+  });
+
+  it('renders primitive control kinds as their bare kind', () => {
+    expect(describeControlType({ kind: 'text' })).toBe('text');
+    expect(describeControlType({ kind: 'number' })).toBe('number');
+    expect(describeControlType({ kind: 'boolean' })).toBe('boolean');
+    expect(describeControlType({ kind: 'snippet' })).toBe('snippet');
+  });
+});
+
+describe('describeDefaultValue', () => {
+  it('single-quotes string defaults', () => {
+    expect(describeDefaultValue('secondary')).toBe("'secondary'");
+  });
+
+  it('stringifies primitive defaults', () => {
+    expect(describeDefaultValue(false)).toBe('false');
+    expect(describeDefaultValue(42)).toBe('42');
+    expect(describeDefaultValue(null)).toBe('null');
+  });
+
+  it('returns undefined when there is no default', () => {
+    expect(describeDefaultValue(undefined)).toBeUndefined();
+  });
+
+  it('JSON-serializes structured defaults', () => {
+    expect(describeDefaultValue({ a: 1 })).toBe('{"a":1}');
+    expect(describeDefaultValue([1, 2])).toBe('[1,2]');
+  });
+});
+
+describe('toPropReferenceRow', () => {
+  it('marks a prop with no default and optional=false as required', () => {
+    const prop: PropManifest = {
+      name: 'label',
+      control: { kind: 'text' },
+      bindable: false,
+      optional: false,
+    };
+    expect(toPropReferenceRow(prop).required).toBe(true);
+  });
+
+  it('does not mark an optional prop as required', () => {
+    const prop: PropManifest = {
+      name: 'variant',
+      control: { kind: 'select', options: ['a', 'b'] },
+      bindable: false,
+      optional: true,
+    };
+    expect(toPropReferenceRow(prop).required).toBe(false);
+  });
+
+  it('does not mark a prop with a default as required even when optional=false', () => {
+    const prop: PropManifest = {
+      name: 'count',
+      control: { kind: 'number' },
+      bindable: false,
+      optional: false,
+      defaultValue: 0,
+    };
+    const row = toPropReferenceRow(prop);
+    expect(row.required).toBe(false);
+    expect(row.defaultValue).toBe('0');
+  });
+
+  it('carries the bindable flag through to the row', () => {
+    const prop: PropManifest = {
+      name: 'value',
+      control: { kind: 'text' },
+      bindable: true,
+      optional: true,
+    };
+    expect(toPropReferenceRow(prop).bindable).toBe(true);
+  });
+});
+
+describe('toPropReferenceRows — Button (real manifest)', () => {
+  it('produces one row per prop', async () => {
+    const manifest = await buttonManifest();
+    const rows = toPropReferenceRows(manifest);
+    expect(rows).toHaveLength(manifest.props.length);
+    expect(rows.length).toBeGreaterThan(0);
+  });
+
+  it('shapes the variant select prop with a quoted union and quoted default', async () => {
+    const rows = toPropReferenceRows(await buttonManifest());
+    const variant = rows.find((row) => row.name === 'variant');
+    expect(variant).toBeDefined();
+    expect(variant?.type).toContain("'primary'");
+    expect(variant?.type).toContain(' | ');
+    expect(variant?.defaultValue).toBe("'secondary'");
+    expect(variant?.required).toBe(false);
+  });
+
+  it('shapes the loading boolean prop with a boolean type and false default', async () => {
+    const rows = toPropReferenceRows(await buttonManifest());
+    const loading = rows.find((row) => row.name === 'loading');
+    expect(loading?.type).toBe('boolean');
+    expect(loading?.defaultValue).toBe('false');
+    expect(loading?.required).toBe(false);
+  });
+
+  it('marks props that have no default and are not optional as required', async () => {
+    const rows = toPropReferenceRows(await buttonManifest());
+    // `label` and `children` are not optional and carry no default.
+    const label = rows.find((row) => row.name === 'label');
+    expect(label?.required).toBe(true);
+    expect(rows.some((row) => row.required)).toBe(true);
+  });
+
+  it('covers varied control kinds (select, boolean, snippet, unknown)', async () => {
+    const rows = toPropReferenceRows(await buttonManifest());
+    const kinds = new Set(rows.map((row) => row.type));
+    // Snippet props (leadingIcon/trailingIcon) render as the bare 'snippet' kind.
+    expect(kinds.has('snippet')).toBe(true);
+    expect(kinds.has('boolean')).toBe(true);
+    // The variant union and at least one unknown/raw type are present.
+    expect(rows.some((row) => row.type.includes(' | '))).toBe(true);
+  });
+});
+
+describe('isComponentManifest', () => {
+  it("accepts Button's real manifest", async () => {
+    expect(isComponentManifest(await buttonManifest())).toBe(true);
+  });
+
+  it('rejects non-objects', () => {
+    expect(isComponentManifest(null)).toBe(false);
+    expect(isComponentManifest('nope')).toBe(false);
+    expect(isComponentManifest(undefined)).toBe(false);
+  });
+
+  it('rejects an object missing required fields', () => {
+    expect(isComponentManifest({ name: 'Button' })).toBe(false);
+  });
+
+  it('rejects a manifest with a malformed prop', () => {
+    expect(
+      isComponentManifest({
+        name: 'X',
+        kebabName: 'x',
+        file: 'x.svelte',
+        importPath: 'cinder/x',
+        props: [{ name: 'p', control: { kind: 'select' /* missing options */ } }],
+      }),
+    ).toBe(false);
+  });
+
+  it('accepts a minimal well-formed manifest', () => {
+    expect(
+      isComponentManifest({
+        name: 'X',
+        kebabName: 'x',
+        file: 'x.svelte',
+        importPath: 'cinder/x',
+        props: [{ name: 'open', control: { kind: 'boolean' }, bindable: true, optional: true }],
+      }),
+    ).toBe(true);
+  });
+});
+
+describe('fetchComponentManifest', () => {
+  const minimalManifest: ComponentManifest = {
+    name: 'Accordion',
+    kebabName: 'accordion',
+    file: 'accordion.svelte',
+    importPath: 'cinder/accordion',
+    props: [
+      {
+        name: 'expandedIds',
+        control: { kind: 'unknown', rawType: 'string[]' },
+        bindable: true,
+        optional: true,
+      },
+    ],
+  };
+
+  it('requests the encoded component name and returns the validated manifest', async () => {
+    let requestedUrl = '';
+    const fakeFetch = async (url: string) => {
+      requestedUrl = url;
+      return new Response(JSON.stringify(minimalManifest), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    };
+
+    const manifest = await fetchComponentManifest('accordion', fakeFetch);
+    expect(requestedUrl).toBe('/api/manifest/accordion');
+    expect(manifest.kebabName).toBe('accordion');
+    // The bindable prop survives the round-trip and normalizes correctly.
+    expect(toPropReferenceRows(manifest)[0]?.bindable).toBe(true);
+  });
+
+  it('throws on a non-OK response', async () => {
+    await expect(fetchComponentManifest('nope', notFoundFetch)).rejects.toThrow(/404/);
+  });
+
+  it('throws on a malformed body', async () => {
+    await expect(fetchComponentManifest('button', malformedBodyFetch)).rejects.toThrow(
+      /valid ComponentManifest/,
+    );
+  });
+});

--- a/packages/playground/src/manifest-reference.ts
+++ b/packages/playground/src/manifest-reference.ts
@@ -1,0 +1,240 @@
+/**
+ * Pure helpers backing the Props / API reference panel on a component page.
+ *
+ * The Svelte component (`component-page.svelte`) fetches a `ComponentManifest`
+ * from `/api/manifest/:name` and renders it as a table. Keeping the
+ * fetch + normalization logic here makes it unit-testable without mounting the
+ * whole page: feed a `ComponentManifest` in, assert the display rows out.
+ */
+import type { ComponentManifest, ControlKind, PropManifest } from './types.ts';
+
+/**
+ * A single prop rendered as one row in the reference table. Every field is a
+ * display-ready value derived from a {@link PropManifest}, so the template can
+ * render it directly without re-deriving anything.
+ */
+export type PropReferenceRow = {
+  /** Prop name, e.g. `variant`. */
+  name: string;
+  /** Human-readable type label derived from the control kind. */
+  type: string;
+  /** Default value rendered as source-ish text, or `undefined` when none. */
+  defaultValue: string | undefined;
+  /** True when the prop has no default and is not optional. */
+  required: boolean;
+  /** True when a parent may `bind:` to this prop. */
+  bindable: boolean;
+  /** Prop description, or `undefined` when the analyzer found none. */
+  description: string | undefined;
+};
+
+/**
+ * Describe a {@link ControlKind} as a short human-readable type label.
+ *
+ * - `select` → the options joined as a union, e.g. `'sm' | 'md' | 'lg'`.
+ * - `unknown` → the analyzer's raw type string (falling back to `unknown`
+ *   when the analyzer could not recover one, e.g. the `?` placeholder).
+ * - everything else → the bare kind (`text`, `number`, `boolean`, `snippet`).
+ *
+ * @param control - The control descriptor from a {@link PropManifest}.
+ * @returns A label suitable for the "Type" column.
+ */
+export function describeControlType(control: ControlKind): string {
+  switch (control.kind) {
+    case 'select':
+      return control.options.map((option) => `'${option}'`).join(' | ');
+    case 'unknown': {
+      const raw = control.rawType.trim();
+      return raw === '' || raw === '?' ? 'unknown' : raw;
+    }
+    default:
+      return control.kind;
+  }
+}
+
+/**
+ * Render a prop's default value as compact source-ish text for the table.
+ *
+ * Strings are single-quoted, primitives are stringified, and structured values
+ * are JSON-serialized. Returns `undefined` when the analyzer recorded no
+ * default (distinct from a default of `undefined`, which the analyzer omits).
+ *
+ * @param defaultValue - The `defaultValue` field of a {@link PropManifest}.
+ * @returns Display text, or `undefined` when there is no default.
+ */
+export function describeDefaultValue(defaultValue: unknown): string | undefined {
+  if (defaultValue === undefined) return undefined;
+  if (typeof defaultValue === 'string') return `'${defaultValue}'`;
+  if (
+    typeof defaultValue === 'number' ||
+    typeof defaultValue === 'boolean' ||
+    defaultValue === null ||
+    typeof defaultValue === 'bigint'
+  ) {
+    return String(defaultValue);
+  }
+  try {
+    // `JSON.stringify` returns `undefined` for values it can't represent
+    // (functions, symbols); fall back to a placeholder rather than the literal
+    // string "undefined".
+    const serialized = JSON.stringify(defaultValue);
+    return serialized ?? '(unserializable)';
+  } catch {
+    // Circular references and other serialization failures land here.
+    return '(unserializable)';
+  }
+}
+
+/**
+ * Normalize one {@link PropManifest} into a display-ready {@link PropReferenceRow}.
+ *
+ * A prop is "required" when it is neither optional nor has a default value —
+ * the analyzer's `optional` flag plus the presence of a default together decide
+ * whether a consumer must pass it.
+ *
+ * @param prop - The prop metadata from a {@link ComponentManifest}.
+ * @returns The display row for this prop.
+ */
+export function toPropReferenceRow(prop: PropManifest): PropReferenceRow {
+  const defaultValue = describeDefaultValue(prop.defaultValue);
+  return {
+    name: prop.name,
+    type: describeControlType(prop.control),
+    defaultValue,
+    required: !prop.optional && defaultValue === undefined,
+    bindable: prop.bindable,
+    description: prop.description,
+  };
+}
+
+/**
+ * Normalize a whole {@link ComponentManifest} into table rows.
+ *
+ * @param manifest - The component manifest fetched from `/api/manifest/:name`.
+ * @returns One {@link PropReferenceRow} per prop, in manifest order.
+ */
+export function toPropReferenceRows(manifest: ComponentManifest): PropReferenceRow[] {
+  return manifest.props.map(toPropReferenceRow);
+}
+
+/**
+ * Read a property off an object-typed `unknown` without a type assertion.
+ *
+ * `Reflect.get` returns `unknown` for an arbitrary key, which keeps the
+ * validation guards cast-free while still letting them inspect untrusted
+ * JSON one property at a time.
+ *
+ * @param value - An object (callers narrow with `typeof === 'object'` first).
+ * @param key - The property name to read.
+ * @returns The property value, typed as `unknown`.
+ */
+function readProperty(value: object, key: string): unknown {
+  return Reflect.get(value, key);
+}
+
+/**
+ * Type guard: is `value` shaped like a {@link ControlKind}?
+ *
+ * Validates the discriminant plus the kind-specific payload so a malformed
+ * manifest can't smuggle a half-built control into the table.
+ */
+function isControlKind(value: unknown): value is ControlKind {
+  if (typeof value !== 'object' || value === null) return false;
+  const kind = readProperty(value, 'kind');
+  switch (kind) {
+    case 'text':
+    case 'number':
+    case 'boolean':
+    case 'snippet':
+      return true;
+    case 'select': {
+      const options = readProperty(value, 'options');
+      return Array.isArray(options) && options.every((option) => typeof option === 'string');
+    }
+    case 'unknown':
+      return typeof readProperty(value, 'rawType') === 'string';
+    default:
+      return false;
+  }
+}
+
+/**
+ * Type guard: is `value` shaped like a {@link PropManifest}?
+ */
+function isPropManifest(value: unknown): value is PropManifest {
+  if (typeof value !== 'object' || value === null) return false;
+  const description = readProperty(value, 'description');
+  return (
+    typeof readProperty(value, 'name') === 'string' &&
+    isControlKind(readProperty(value, 'control')) &&
+    typeof readProperty(value, 'bindable') === 'boolean' &&
+    typeof readProperty(value, 'optional') === 'boolean' &&
+    (description === undefined || typeof description === 'string')
+  );
+}
+
+/**
+ * Type guard: is `value` shaped like a {@link ComponentManifest}?
+ *
+ * The `/api/manifest/:name` route returns JSON, so the fetched body is
+ * `unknown` until validated. This guard lets the component fail into its error
+ * state instead of rendering garbage when the payload is malformed.
+ *
+ * @param value - A parsed JSON body.
+ * @returns True when `value` matches the {@link ComponentManifest} shape.
+ */
+export function isComponentManifest(value: unknown): value is ComponentManifest {
+  if (typeof value !== 'object' || value === null) return false;
+  const props = readProperty(value, 'props');
+  return (
+    typeof readProperty(value, 'name') === 'string' &&
+    typeof readProperty(value, 'kebabName') === 'string' &&
+    typeof readProperty(value, 'file') === 'string' &&
+    typeof readProperty(value, 'importPath') === 'string' &&
+    Array.isArray(props) &&
+    props.every(isPropManifest)
+  );
+}
+
+/**
+ * The narrow slice of the response we read inside {@link fetchComponentManifest}.
+ */
+type ManifestResponse = {
+  ok: boolean;
+  status: number;
+  statusText: string;
+  json: () => Promise<unknown>;
+};
+
+/**
+ * The narrow slice of `fetch` we depend on. Declaring exactly what we use lets
+ * tests inject a minimal fake without satisfying the entire `fetch` surface
+ * (`preconnect`, overloads, etc.) — the global `fetch` is assignable to it.
+ */
+export type ManifestFetch = (url: string) => Promise<ManifestResponse>;
+
+/**
+ * Fetch and validate a component's manifest from `/api/manifest/:name`.
+ *
+ * Throws on a non-OK response or a malformed body so the caller can surface a
+ * single error state. The component name is the kebab-case segment from the
+ * page URL (e.g. `button`), which the route matches against `kebabName`.
+ *
+ * @param componentName - kebab-case component name from the page URL.
+ * @param fetchImpl - Injectable fetch (defaults to the global) for testing.
+ * @returns The validated manifest.
+ */
+export async function fetchComponentManifest(
+  componentName: string,
+  fetchImpl: ManifestFetch = fetch,
+): Promise<ComponentManifest> {
+  const response = await fetchImpl(`/api/manifest/${encodeURIComponent(componentName)}`);
+  if (!response.ok) {
+    throw new Error(`Manifest request failed: ${response.status} ${response.statusText}`);
+  }
+  const body: unknown = await response.json();
+  if (!isComponentManifest(body)) {
+    throw new Error('Manifest response was not a valid ComponentManifest');
+  }
+  return body;
+}

--- a/packages/playground/src/render-shell.test.ts
+++ b/packages/playground/src/render-shell.test.ts
@@ -103,4 +103,119 @@ describe('renderShell', () => {
       );
     expect(layerBlockMatch).not.toBeNull();
   });
+
+  it('declares --cinder-top-bar-height once on :root', () => {
+    // The token is the single source of truth for the fixed top bar's height.
+    // It must live on :root so the top bar, sidebar, and main column all
+    // inherit it without each re-declaring (and drifting out of sync).
+    const html = renderShell('button', ['button']);
+    const rootDeclaration = /:root\s*\{[^}]*--cinder-top-bar-height:\s*52px/.exec(html);
+    expect(rootDeclaration).not.toBeNull();
+  });
+});
+
+describe('renderShell metadata and Open Graph', () => {
+  const ROOT_DESCRIPTION =
+    'Interactive component playground for cinder — a Svelte 5 accessible component library.';
+
+  describe('root page', () => {
+    it('emits the root description and base Open Graph / Twitter tags', () => {
+      const html = renderShell(null, ['button']);
+      expect(html).toContain(`<meta name="description" content="${ROOT_DESCRIPTION}" />`);
+      expect(html).toContain(`<meta property="og:title" content="cinder playground" />`);
+      expect(html).toContain(`<meta property="og:description" content="${ROOT_DESCRIPTION}" />`);
+      expect(html).toContain(`<meta property="og:type" content="website" />`);
+      expect(html).toContain(`<meta property="og:site_name" content="cinder playground" />`);
+      expect(html).toContain(`<meta name="twitter:card" content="summary_large_image" />`);
+      expect(html).toContain(`<meta name="twitter:title" content="cinder playground" />`);
+      expect(html).toContain(`<meta name="twitter:description" content="${ROOT_DESCRIPTION}" />`);
+      // Favicon is an inlined data-URI SVG (no /favicon.svg route exists, so a
+      // file reference would 404 on every page). Assert the data URI, not a path.
+      expect(html).toContain(`<link rel="icon" href="data:image/svg+xml,`);
+      expect(html).not.toContain('href="/favicon.svg"');
+    });
+
+    it('omits absolute-URL tags when no base URL is provided', () => {
+      const html = renderShell(null, ['button'], { baseUrl: '' });
+      expect(html).not.toContain('property="og:url"');
+      expect(html).not.toContain('property="og:image"');
+      expect(html).not.toContain('name="twitter:image"');
+      expect(html).not.toContain('rel="canonical"');
+    });
+
+    it('emits absolute URL tags rooted at "/" when a base URL is provided', () => {
+      const html = renderShell(null, ['button'], { baseUrl: 'https://playground.cinder.dev' });
+      expect(html).toContain('<meta property="og:url" content="https://playground.cinder.dev/" />');
+      expect(html).toContain(
+        '<meta property="og:image" content="https://playground.cinder.dev/social.png" />',
+      );
+      expect(html).toContain(
+        '<meta name="twitter:image" content="https://playground.cinder.dev/social.png" />',
+      );
+      expect(html).toContain('<link rel="canonical" href="https://playground.cinder.dev/" />');
+    });
+  });
+
+  describe('per-component page', () => {
+    const PER_COMPONENT_DESCRIPTION =
+      'Explore the button component in the cinder playground — live examples, props, and CSS variables.';
+
+    it('emits a per-component description and matching og/twitter title', () => {
+      const html = renderShell('button', ['button']);
+      expect(html).toContain(`<meta name="description" content="${PER_COMPONENT_DESCRIPTION}" />`);
+      expect(html).toContain(
+        `<meta property="og:description" content="${PER_COMPONENT_DESCRIPTION}" />`,
+      );
+      expect(html).toContain(`<meta property="og:title" content="cinder playground — button" />`);
+      expect(html).toContain(`<meta name="twitter:title" content="cinder playground — button" />`);
+      expect(html).toContain(
+        `<meta name="twitter:description" content="${PER_COMPONENT_DESCRIPTION}" />`,
+      );
+    });
+
+    it('omits absolute-URL tags when no base URL is provided', () => {
+      const html = renderShell('button', ['button'], { baseUrl: '' });
+      expect(html).not.toContain('property="og:url"');
+      expect(html).not.toContain('property="og:image"');
+      expect(html).not.toContain('name="twitter:image"');
+      expect(html).not.toContain('rel="canonical"');
+    });
+
+    it('builds the absolute canonical/og:url from the component path when a base URL is set', () => {
+      const html = renderShell('button', ['button'], {
+        baseUrl: 'https://playground.cinder.dev',
+      });
+      expect(html).toContain(
+        '<meta property="og:url" content="https://playground.cinder.dev/c/button" />',
+      );
+      expect(html).toContain(
+        '<link rel="canonical" href="https://playground.cinder.dev/c/button" />',
+      );
+      expect(html).toContain(
+        '<meta property="og:image" content="https://playground.cinder.dev/social.png" />',
+      );
+      expect(html).toContain(
+        '<meta name="twitter:image" content="https://playground.cinder.dev/social.png" />',
+      );
+    });
+
+    it('strips a trailing slash from the base URL before composing absolute URLs', () => {
+      const html = renderShell('button', ['button'], {
+        baseUrl: 'https://playground.cinder.dev/',
+      });
+      expect(html).toContain(
+        '<meta property="og:url" content="https://playground.cinder.dev/c/button" />',
+      );
+      expect(html).not.toContain('cinder.dev//c/button');
+    });
+  });
+
+  it('HTML-escapes the component name inside metadata values', () => {
+    // The kebab-case invariant is enforced by the server, but the renderer must
+    // still escape whatever it is handed so a crafted name cannot break out of
+    // an attribute value.
+    const html = renderShell('"><script>', ['button']);
+    expect(html).not.toContain('"><script>');
+    expect(html).toContain('&quot;&gt;&lt;script&gt;');
+  });
 });

--- a/packages/playground/src/render-shell.ts
+++ b/packages/playground/src/render-shell.ts
@@ -18,6 +18,22 @@ const LINE_SEPARATOR = String.fromCharCode(0x2028);
 const PARAGRAPH_SEPARATOR = String.fromCharCode(0x2029);
 
 /**
+ * Self-contained favicon as a data URI: a rounded square in the cinder ember
+ * orange with a lowercase "c". Inlined so every page has an icon without a
+ * /favicon.svg route (which neither handleRequest nor vercel.json serves) and
+ * therefore without a guaranteed 404 in devtools and server logs.
+ */
+const FAVICON_DATA_URI =
+  'data:image/svg+xml,' +
+  encodeURIComponent(
+    '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">' +
+      '<rect width="32" height="32" rx="7" fill="#e8590c"/>' +
+      '<text x="16" y="23" font-family="system-ui,sans-serif" font-size="22" ' +
+      'font-weight="700" fill="#fff" text-anchor="middle">c</text>' +
+      '</svg>',
+  );
+
+/**
  * Escape a string value so it's safe to embed inside the body of a
  * `<script type="application/json">` tag. JSON.stringify alone is not enough
  * because the resulting string may contain literal `</script>` substrings (if
@@ -79,10 +95,76 @@ function escapeHtml(text: string): string {
     .replace(/'/g, '&#39;');
 }
 
-export function renderShell(activeComponent: string | null, components: string[]): string {
+/**
+ * Options for {@link renderShell}.
+ */
+export type RenderShellOptions = {
+  /**
+   * Absolute origin (e.g. `https://playground.cinder.dev`) used to build the
+   * canonical and Open Graph URLs. When empty (the default), the URL-bearing
+   * tags that require an absolute address — `og:url`, `og:image`,
+   * `twitter:image`, and `<link rel="canonical">` — are omitted entirely
+   * rather than emitted with a misleading relative path. Defaults to
+   * `PLAYGROUND_BASE_URL` from the environment, falling back to an empty
+   * string. Any trailing slashes are stripped before composing URLs.
+   */
+  baseUrl?: string;
+};
+
+/**
+ * Render the playground shell HTML for either the root page (`activeComponent`
+ * is `null`) or a specific component page. Emits a complete `<head>` with SEO,
+ * Open Graph, and Twitter card metadata in addition to the mount point and the
+ * data island.
+ *
+ * @param activeComponent - The component being shown, or `null` for the root.
+ * @param components - The list of components to embed for the sidebar.
+ * @param options - Optional rendering options; see {@link RenderShellOptions}.
+ * @returns A complete HTML document string.
+ */
+export function renderShell(
+  activeComponent: string | null,
+  components: string[],
+  options: RenderShellOptions = {},
+): string {
+  const baseUrl = (options.baseUrl ?? Bun.env['PLAYGROUND_BASE_URL'] ?? '').replace(/\/+$/, '');
+
   const title = activeComponent
     ? `cinder playground — ${escapeHtml(activeComponent)}`
     : 'cinder playground';
+
+  const description = activeComponent
+    ? `Explore the ${escapeHtml(activeComponent)} component in the cinder playground — live examples, props, and CSS variables.`
+    : 'Interactive component playground for cinder — a Svelte 5 accessible component library.';
+
+  // Shell routes: `/c/<component>` for a specific component, `/` for the root.
+  const path = activeComponent ? `/c/${encodeURIComponent(activeComponent)}` : '/';
+  const canonicalUrl = baseUrl ? escapeHtml(`${baseUrl}${path}`) : '';
+  // TODO(bf3680cd): /social.png is a placeholder — shipping the actual social
+  // card image is a separate task.
+  const imageUrl = baseUrl ? escapeHtml(`${baseUrl}/social.png`) : '';
+
+  const meta = [
+    `<meta name="description" content="${description}" />`,
+    `<meta property="og:title" content="${title}" />`,
+    `<meta property="og:description" content="${description}" />`,
+    `<meta property="og:type" content="website" />`,
+    canonicalUrl ? `<meta property="og:url" content="${canonicalUrl}" />` : '',
+    imageUrl ? `<meta property="og:image" content="${imageUrl}" />` : '',
+    `<meta property="og:site_name" content="cinder playground" />`,
+    `<meta name="twitter:card" content="summary_large_image" />`,
+    `<meta name="twitter:title" content="${title}" />`,
+    `<meta name="twitter:description" content="${description}" />`,
+    imageUrl ? `<meta name="twitter:image" content="${imageUrl}" />` : '',
+    canonicalUrl ? `<link rel="canonical" href="${canonicalUrl}" />` : '',
+    // Inline data-URI favicon: a self-contained SVG ember mark. Embedding it
+    // avoids a guaranteed 404 on every page (there is no /favicon.svg route in
+    // handleRequest or rewrite in vercel.json) without adding a static asset
+    // pipeline. Swap for a shipped /favicon.svg if a richer icon is ever wanted.
+    `<link rel="icon" href="${FAVICON_DATA_URI}" />`,
+  ]
+    .filter(Boolean)
+    .join('\n    ');
 
   const initialData = {
     component: activeComponent ?? '',
@@ -95,6 +177,7 @@ export function renderShell(activeComponent: string | null, components: string[]
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>${title}</title>
+    ${meta}
     <script>${PRE_PAINT_THEME_SCRIPT}</script>
     <style>
       /* Register cinder.reset as the FIRST layer (least priority) so the universal
@@ -122,6 +205,15 @@ export function renderShell(activeComponent: string | null, components: string[]
          to a concrete light/dark for explicit theme choices. */
       html {
         color-scheme: light dark;
+      }
+
+      /* Single source of truth for the fixed top bar's height. Declared on
+         :root so it resolves for the top bar, the sidebar, and the main
+         column alike — .top-bar only reaches its own descendants, so siblings
+         (sidebar.svelte, shell.svelte) previously had to duplicate this token.
+         Hoisting it here lets those components reference it without fallbacks. */
+      :root {
+        --cinder-top-bar-height: 52px;
       }
 
       html, body, #shell-root {

--- a/packages/playground/src/server.test.ts
+++ b/packages/playground/src/server.test.ts
@@ -13,6 +13,7 @@ import { afterEach, beforeAll, describe, expect, it } from 'bun:test';
 import { join } from 'node:path';
 
 import type { ComponentManifest } from './analyze.ts';
+import { jsonForScriptTag } from './render-shell.ts';
 import { PORT, createHttpServerOnAvailablePort, handleRequest, triggerReload } from './server.ts';
 
 const FIXTURE_COMPONENT = 'button';
@@ -221,8 +222,13 @@ describe('chunks under /page-bundle/<filename>.js', () => {
     // Hashed chunks contain a hash segment after the last `-`; the
     // unhashed entry URL is just `<component>.js`. Match the hashed
     // shape with at least one dash and an alphanumeric tail.
+    // A content-hashed chunk ends in `-<hash>.js` where the hash is a long
+    // lowercase-alphanumeric content digest (Bun's `[name]-[hash]` naming).
+    // Requiring that hash tail — rather than "any hyphenated segment" — avoids
+    // matching a bare multi-word entry like `page-accordion-item.js`, which has
+    // dashes but no hash and is served `no-store`, not `immutable`.
     const chunkUrls = Array.from(
-      body.matchAll(/\/page-bundle\/[A-Za-z0-9_]+(?:-[A-Za-z0-9_]+)+\.js/g),
+      body.matchAll(/\/page-bundle\/[A-Za-z0-9_-]+-[a-z0-9]{8,}\.js/g),
       (match) => match[0],
     );
     expect(chunkUrls.length).toBeGreaterThan(0);
@@ -232,6 +238,61 @@ describe('chunks under /page-bundle/<filename>.js', () => {
       expect(chunkResponse.status).toBe(200);
       expect(chunkResponse.headers.get('Content-Type')).toBe('application/javascript');
     }
+  }, 60_000);
+});
+
+// HTTP caching contract for the bundle routes. Content-hashed chunk URLs are
+// immutable (the hash changes when the bytes change), so they get a one-year
+// immutable Cache-Control. The bare, unhashed entry URLs the browser requests
+// directly (`/page-bundle/<component>.js`, `/shell-bundle/shell.js`,
+// `/bundle/<name>/<scenario>.js`) point at whatever the latest build produced
+// and must never be cached.
+describe('Cache-Control headers on bundle routes', () => {
+  const IMMUTABLE = 'public, max-age=31536000, immutable';
+  const NO_STORE = 'no-store';
+
+  it('serves the bare page-bundle entry URL with no-store', async () => {
+    const response = await handleRequest(req(`/page-bundle/${FIXTURE_COMPONENT}.js`));
+    expect(response.status).toBe(200);
+    expect(response.headers.get('Cache-Control')).toBe(NO_STORE);
+  }, 30_000);
+
+  it('serves the shell-bundle entry URL with no-store', async () => {
+    const response = await handleRequest(req('/shell-bundle/shell.js'));
+    expect(response.status).toBe(200);
+    expect(response.headers.get('Cache-Control')).toBe(NO_STORE);
+  }, 30_000);
+
+  it('serves the bare scenario bundle entry URL with no-store', async () => {
+    const response = await handleRequest(
+      req(`/bundle/${FIXTURE_COMPONENT}/${FIXTURE_SCENARIO}.js`),
+    );
+    expect(response.status).toBe(200);
+    expect(response.headers.get('Cache-Control')).toBe(NO_STORE);
+  }, 30_000);
+
+  it('serves content-hashed page-bundle chunks with an immutable Cache-Control', async () => {
+    // `chat` lazy-loads markdown rendering, so its entry references at least
+    // one hashed chunk. Warm the entry, extract a hashed chunk URL, then
+    // assert the chunk response carries the immutable header. Hashed URLs
+    // have a `-<hash>` segment; the bare entry URL (`chat.js`) does not.
+    const entryResponse = await handleRequest(req('/page-bundle/chat.js'));
+    expect(entryResponse.status).toBe(200);
+    const body = await entryResponse.text();
+    // A content-hashed chunk ends in `-<hash>.js` where the hash is a long
+    // lowercase-alphanumeric content digest (Bun's `[name]-[hash]` naming).
+    // Requiring that hash tail — rather than "any hyphenated segment" — avoids
+    // matching a bare multi-word entry like `page-accordion-item.js`, which has
+    // dashes but no hash and is served `no-store`, not `immutable`.
+    const chunkUrls = Array.from(
+      body.matchAll(/\/page-bundle\/[A-Za-z0-9_-]+-[a-z0-9]{8,}\.js/g),
+      (match) => match[0],
+    );
+    expect(chunkUrls.length).toBeGreaterThan(0);
+
+    const chunkResponse = await handleRequest(req(chunkUrls[0]!));
+    expect(chunkResponse.status).toBe(200);
+    expect(chunkResponse.headers.get('Cache-Control')).toBe(IMMUTABLE);
   }, 60_000);
 });
 
@@ -532,6 +593,95 @@ describe('/page/:name', () => {
     const html = await response.text();
     expect(html).toContain('href="/styles/all.css"');
     expect(html).not.toContain('href="/styles/index.css"');
+  });
+
+  it('checker background uses theme-adaptive custom properties, not hardcoded colors', async () => {
+    // Regression: the checker squares were hardcoded #e0e0e0 on a #fff base,
+    // which is blinding in dark mode. The pattern must adapt via light-dark()
+    // and the --cinder-surface token so it reads as a transparency checker in
+    // both schemes without any JS.
+    const response = await handleRequest(req(`/page/${FIXTURE_COMPONENT}`));
+    const html = await response.text();
+    const checkerBlockMatch = /body\[data-cinder-bg="checker"\]\s*\{[^}]*\}/.exec(html);
+    expect(checkerBlockMatch).not.toBeNull();
+    const checkerBlock = checkerBlockMatch![0];
+    expect(checkerBlock).not.toContain('#fff');
+    expect(checkerBlock).not.toContain('#e0e0e0');
+    expect(checkerBlock).toContain('light-dark(');
+    expect(checkerBlock).toContain('var(--cinder-surface)');
+    // Geometry must stay a 16px grid checker.
+    expect(checkerBlock).toContain('background-size: 16px 16px');
+  });
+
+  it('wraps the body background/color transition in a reduced-motion guard', async () => {
+    // The crossfade must only run when the user has not requested reduced
+    // motion, so the unguarded `transition: background ...` is gone.
+    const response = await handleRequest(req(`/page/${FIXTURE_COMPONENT}`));
+    const html = await response.text();
+    const guardMatch =
+      /@media\s*\(prefers-reduced-motion:\s*no-preference\)\s*\{[^}]*body\s*\{[^}]*transition:\s*background[^}]*\}/.exec(
+        html,
+      );
+    expect(guardMatch).not.toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// /page/:name — __CINDER_EXAMPLES__ inline-script escaping (regression for the
+// ecb46fa0 bug: renderComponentPage embedded the examples payload with a raw
+// JSON.stringify, so a `</script>` inside an example title/description closed
+// the inline <script> early and could inject markup. The fix routes the
+// payload through jsonForScriptTag, the same escaper used for the shell data
+// island. Verified at two levels: the escaping policy itself, and the live page.
+// ---------------------------------------------------------------------------
+
+describe('/page/:name — __CINDER_EXAMPLES__ script-tag escaping', () => {
+  it('jsonForScriptTag neutralizes </script> inside an examples-shaped payload', () => {
+    const examples = [
+      {
+        scenario: 'malicious',
+        title: 'Closes early</script><script>alert(1)</script>',
+        description: 'Also nasty: </script> & <img src=x onerror=alert(1)>',
+      },
+    ];
+
+    const encoded = jsonForScriptTag(examples);
+
+    // No raw markup characters survive — `<`, `>`, and `&` are all \uXXXX-escaped,
+    // so the payload cannot terminate the inline script or open a new element.
+    expect(encoded).not.toContain('<');
+    expect(encoded).not.toContain('>');
+    expect(encoded).not.toContain('&');
+    expect(encoded.toLowerCase()).not.toContain('</script');
+    expect(encoded).toContain('\\u003c'); // < was escaped
+    expect(encoded).toContain('\\u003e'); // > was escaped
+
+    // Still valid JSON that round-trips back to the original data.
+    expect(JSON.parse(encoded)).toEqual(examples);
+  });
+
+  it('embeds the live examples payload with no raw markup chars in the inline script', async () => {
+    const response = await handleRequest(req(`/page/${FIXTURE_COMPONENT}`));
+    const html = await response.text();
+
+    // Isolate the __CINDER_EXAMPLES__ assignment (from `window.` to the
+    // terminating `;</script>` that legitimately closes that inline script).
+    const start = html.indexOf('window.__CINDER_EXAMPLES__');
+    expect(start).toBeGreaterThanOrEqual(0);
+    const closer = html.indexOf('</script>', start);
+    expect(closer).toBeGreaterThan(start);
+    const assignment = html.slice(start, closer);
+
+    // The payload (everything after `= `) must carry no raw `<`, `>`, or `&` —
+    // those would mean a future example string could break out of the script.
+    const payload = assignment.slice(assignment.indexOf('= ') + 2);
+    expect(payload).not.toContain('<');
+    expect(payload).not.toContain('>');
+    expect(payload).not.toContain('&');
+
+    // The assignment still parses as JSON once the trailing `;` is dropped.
+    const json = payload.trimEnd().replace(/;$/, '');
+    expect(() => JSON.parse(json)).not.toThrow();
   });
 });
 

--- a/packages/playground/src/server.ts
+++ b/packages/playground/src/server.ts
@@ -28,9 +28,15 @@ import { dirname, isAbsolute, join, relative as relativePath } from 'node:path';
 
 import type { BuildArtifact } from 'bun';
 import { sveltePlugin } from '../../components/scripts/svelte-plugin.ts';
-import { analyzeAll } from './analyze.ts';
-import { discoverComponents, discoverExamples, discoverSidebarComponents } from './discover.ts';
-import { PRE_PAINT_THEME_SCRIPT, renderShell } from './render-shell.ts';
+import { analyzeAll, resetProject } from './analyze.ts';
+import {
+  discoverComponents,
+  discoverExamples,
+  discoverSidebarComponents,
+  invalidateDiscoveryCache,
+} from './discover.ts';
+import { readExampleMetadata } from './example-metadata.ts';
+import { PRE_PAINT_THEME_SCRIPT, jsonForScriptTag, renderShell } from './render-shell.ts';
 
 import {
   isSnapshotMode,
@@ -146,6 +152,23 @@ function findArtifactForFamily(family: ArtifactFamily, path: string): string | u
   return undefined;
 }
 
+/**
+ * `Cache-Control` value for content-hashed bundle artifacts (hashed entry
+ * chunks `<name>-<hash>.js` and shared chunks `chunk-<hash>.js`). The hash is
+ * part of the filename, so any source change produces a new URL — the old one
+ * can be cached forever. `immutable` tells the browser never to revalidate.
+ */
+const IMMUTABLE_CACHE_CONTROL = 'public, max-age=31536000, immutable';
+
+/**
+ * `Cache-Control` value for the bare, unhashed bundle entry URLs the browser
+ * requests directly (`/page-bundle/<component>.js`, `/shell-bundle/shell.js`,
+ * and `/bundle/<name>/<scenario>.js`). These point at whatever the latest build
+ * produced, so they must never be cached: a watcher rebuild swaps the bytes
+ * behind the same URL, and the hot-reload flow depends on the browser refetching.
+ */
+const NO_STORE_CACHE_CONTROL = 'no-store';
+
 /** Resolved manifest array — cached after first analysis. */
 let manifestCache: ComponentManifest[] | null = null;
 /** In-flight analyzeAll() promise — prevents duplicate concurrent analyses. */
@@ -210,6 +233,11 @@ function scheduleRebuild(shellSourceChanged: boolean): void {
  */
 function startRebuild(shellSourceChanged: boolean): void {
   const generation = ++rebuildGeneration;
+  // A rebuild means component files may have been added, renamed, or removed,
+  // so the cached discovery scans (component list + example counts) are now
+  // potentially stale. Drop them in lockstep with the generation bump so the
+  // next `/`, `/c/:name`, or `/page/:name` request re-scans the filesystem.
+  invalidateDiscoveryCache();
   // The caught chain — NOT the raw rebuild promise — is what route handlers
   // await via `awaitWarmCache`. If we stored the raw promise and it rejected,
   // every blocked route handler would see the rejection re-thrown into its
@@ -256,6 +284,9 @@ async function repopulateBundleCaches(
   let shellBuildSucceeded = false;
   let fatalRebuildFailed = false;
   const failedPages: string[] = [];
+
+  const rebuildStartedAt = Date.now();
+  console.log('[playground] rebuilding…');
 
   try {
     // Shell bundle.
@@ -305,6 +336,9 @@ async function repopulateBundleCaches(
   // rebuild may already have populated a fresh manifest.
   manifestCache = null;
   manifestPromise = null;
+  // Dispose the shared ts-morph project so the next analyzeAll() rebuilds from
+  // fresh compiler state rather than reusing sources from before this rebuild.
+  resetProject();
 
   // Atomic per-family swap. We .clear() then re-populate the existing Map
   // instances so any reference captured by a route handler stays valid.
@@ -338,6 +372,14 @@ async function repopulateBundleCaches(
       '[playground] shell source changed but shell rebuild failed — running shell preserved; no shell-reload emitted',
     );
   }
+
+  // Completion log — only the publishing generation reaches this point (stale
+  // and fatal rebuilds returned early above), so this never reports timing for
+  // a superseded run. N counts the page bundles that landed in the cache, plus
+  // the shell bundle when its build succeeded this run.
+  const bundleCount = localPageEntries.size + (shellBuildSucceeded ? localShellEntries.size : 0);
+  const elapsedSeconds = ((Date.now() - rebuildStartedAt) / 1000).toFixed(2);
+  console.log(`[playground] rebuilt ${bundleCount} bundles in ${elapsedSeconds}s`);
 
   // Emit exactly one event per publish. `shell-reload` only fires when shell
   // sources actually changed AND the new shell bundle is in the cache.
@@ -619,60 +661,6 @@ function artifactRelativePath(path: string): string {
 }
 
 /**
- * Extract title/description from an example file's module script via regex.
- *
- * Supports single-quoted, double-quoted, and template-literal (backtick) strings.
- * The matched body is run through `unescapeStringLiteral` so escape sequences
- * like `\n`, `\'`, and `\\` render correctly. Template literals with
- * `${...}` interpolations are intentionally not supported — example metadata
- * is a static label, not a computed expression.
- */
-async function readExampleMetadata(
-  filePath: string,
-): Promise<{ title: string; description?: string }> {
-  const source = await Bun.file(filePath).text();
-  // Capture group 1 = the surrounding quote (one of `'`, `"`, ``\``);
-  // group 2 = the body. The body matches anything that's not the matching
-  // quote or a backslash-escape — backreferenced \1 enforces same-quote close.
-  const stringPattern = /(['"`])((?:[^\\]|\\.)*?)\1/.source;
-  const titleMatch = source.match(new RegExp(`export\\s+const\\s+title\\s*=\\s*${stringPattern}`));
-  const descriptionMatch = source.match(
-    new RegExp(`export\\s+const\\s+description\\s*=\\s*${stringPattern}`),
-  );
-  const meta: { title: string; description?: string } = {
-    title: titleMatch ? unescapeStringLiteral(titleMatch[2] ?? '') : 'Untitled',
-  };
-  if (descriptionMatch?.[2] !== undefined) {
-    meta.description = unescapeStringLiteral(descriptionMatch[2]);
-  }
-  return meta;
-}
-
-/** Resolve common JavaScript string escape sequences in a captured literal body. */
-function unescapeStringLiteral(raw: string): string {
-  return raw.replace(/\\(.)/g, (_match, char: string) => {
-    switch (char) {
-      case 'n':
-        return '\n';
-      case 't':
-        return '\t';
-      case 'r':
-        return '\r';
-      case '\\':
-        return '\\';
-      case "'":
-        return "'";
-      case '"':
-        return '"';
-      case '`':
-        return '`';
-      default:
-        return char;
-    }
-  });
-}
-
-/**
  * Compile the all-in-one page bundle for a single component without
  * mutating any module-level state. Pure with respect to the cache maps —
  * returns the entry path/code + every artifact this build emitted, leaving
@@ -924,7 +912,10 @@ async function renderComponentPage(componentName: string, snapshotMode: boolean)
     }),
   );
 
-  const examplesJson = JSON.stringify(examples);
+  // jsonForScriptTag (not raw JSON.stringify) escapes <, >, &, and the Unicode
+  // line/paragraph separators so a `</script>` in an example title/description
+  // cannot terminate this inline script early or inject markup.
+  const examplesJson = jsonForScriptTag(examples);
   const htmlAttribute = snapshotModeHtmlAttribute(snapshotMode);
   const styleTag = snapshotModeStyleTag(snapshotMode);
 
@@ -950,18 +941,32 @@ async function renderComponentPage(componentName: string, snapshotMode: boolean)
         font-size: var(--cinder-text-base);
         line-height: var(--cinder-leading-normal);
         padding: var(--cinder-space-6);
-        transition: background 0.1s, color 0.1s;
+      }
+      /* Guard the background/color crossfade behind a reduced-motion opt-out so
+         users who prefer no motion get an instant theme swap, not a transition. */
+      @media (prefers-reduced-motion: no-preference) {
+        body {
+          transition: background 0.1s, color 0.1s;
+        }
       }
       #app { display: contents; }
       body[data-cinder-bg="checker"] {
+        /* The checker squares adapt with the active color-scheme via
+           light-dark(): the light value is the original subtle gray check
+           (expressed in oklch); the dark value is a faint light-gray square
+           that still reads as a transparency checker against the dark surface.
+           The base color rides on --cinder-surface, which is itself a
+           light-dark() token, so the whole pattern follows the iframe's
+           color-scheme without any JS. */
+        --cinder-checker-square: light-dark(oklch(89% 0 0), oklch(30% 0.01 245));
         background-image:
-          linear-gradient(45deg, #e0e0e0 25%, transparent 25%),
-          linear-gradient(-45deg, #e0e0e0 25%, transparent 25%),
-          linear-gradient(45deg, transparent 75%, #e0e0e0 75%),
-          linear-gradient(-45deg, transparent 75%, #e0e0e0 75%);
+          linear-gradient(45deg, var(--cinder-checker-square) 25%, transparent 25%),
+          linear-gradient(-45deg, var(--cinder-checker-square) 25%, transparent 25%),
+          linear-gradient(45deg, transparent 75%, var(--cinder-checker-square) 75%),
+          linear-gradient(-45deg, transparent 75%, var(--cinder-checker-square) 75%);
         background-size: 16px 16px;
         background-position: 0 0, 0 8px, 8px -8px, -8px 0;
-        background-color: #fff;
+        background-color: var(--cinder-surface);
       }
     </style>${styleTag ? `\n    ${styleTag}` : ''}
     <script>
@@ -1097,7 +1102,13 @@ export async function handleRequest(request: Request): Promise<Response> {
     const code = await buildBundle(componentName, scenario);
     if (code === null)
       return notFound(`Example "${componentName}/${scenario}" not found or failed to build`);
-    return new Response(code, { headers: { 'Content-Type': 'application/javascript' } });
+    // Bare, unhashed scenario entry URL — never cache (see NO_STORE_CACHE_CONTROL).
+    return new Response(code, {
+      headers: {
+        'Content-Type': 'application/javascript',
+        'Cache-Control': NO_STORE_CACHE_CONTROL,
+      },
+    });
   }
 
   // GET /page-bundle/<filename>.js — covers two cases:
@@ -1122,15 +1133,26 @@ export async function handleRequest(request: Request): Promise<Response> {
     const filename = pageBundleMatch[1]!;
     const directHit = findArtifactForFamily('page', `${filename}.js`);
     if (directHit !== undefined) {
+      // A direct cache hit is always a content-hashed artifact (a hashed entry
+      // `page-<name>-<hash>.js` or a shared `chunk-<hash>.js`) — cache forever.
       return new Response(directHit, {
-        headers: { 'Content-Type': 'application/javascript' },
+        headers: {
+          'Content-Type': 'application/javascript',
+          'Cache-Control': IMMUTABLE_CACHE_CONTROL,
+        },
       });
     }
     if (!isSafeSegment(filename)) return notFound();
     const code = await buildPageBundle(filename);
     if (code === null)
       return notFound(`Page bundle for "${filename}" not found or failed to build`);
-    return new Response(code, { headers: { 'Content-Type': 'application/javascript' } });
+    // Bare, unhashed page entry URL (`/page-bundle/<component>.js`) — never cache.
+    return new Response(code, {
+      headers: {
+        'Content-Type': 'application/javascript',
+        'Cache-Control': NO_STORE_CACHE_CONTROL,
+      },
+    });
   }
 
   // GET /shell-bundle/<filename>.js — same shape as /page-bundle/*:
@@ -1145,8 +1167,13 @@ export async function handleRequest(request: Request): Promise<Response> {
     const filename = shellBundleMatch[1]!;
     const directHit = findArtifactForFamily('shell', `${filename}.js`);
     if (directHit !== undefined) {
+      // Direct hit = content-hashed artifact (hashed entry `shell-<hash>.js` or
+      // a shared `chunk-<hash>.js`) — cache forever.
       return new Response(directHit, {
-        headers: { 'Content-Type': 'application/javascript' },
+        headers: {
+          'Content-Type': 'application/javascript',
+          'Cache-Control': IMMUTABLE_CACHE_CONTROL,
+        },
       });
     }
     // Canonical entry URL is `/shell-bundle/shell.js`. Other filenames must
@@ -1155,7 +1182,13 @@ export async function handleRequest(request: Request): Promise<Response> {
     if (filename !== 'shell') return notFound();
     const code = await buildShellBundle();
     if (code === null) return notFound('Shell bundle failed to build');
-    return new Response(code, { headers: { 'Content-Type': 'application/javascript' } });
+    // Bare, unhashed shell entry URL (`/shell-bundle/shell.js`) — never cache.
+    return new Response(code, {
+      headers: {
+        'Content-Type': 'application/javascript',
+        'Cache-Control': NO_STORE_CACHE_CONTROL,
+      },
+    });
   }
 
   // GET /api/manifest — full manifest array

--- a/packages/playground/src/shell-app/announcer-fixture.svelte
+++ b/packages/playground/src/shell-app/announcer-fixture.svelte
@@ -1,0 +1,19 @@
+<script lang="ts">
+  import Announcer from './announcer.svelte';
+  import { Announcer as AnnouncerStore, setAnnouncer } from './announcer.svelte.ts';
+
+  type Props = {
+    /**
+     * The announcer instance under test. The test holds the same reference so
+     * it can call `announce()` / `cancel()` and read `message` directly while
+     * the rendered live region reflects it.
+     */
+    announcer: AnnouncerStore;
+  };
+
+  let { announcer }: Props = $props();
+
+  setAnnouncer(announcer);
+</script>
+
+<Announcer />

--- a/packages/playground/src/shell-app/announcer-nav-fixture.svelte
+++ b/packages/playground/src/shell-app/announcer-nav-fixture.svelte
@@ -1,0 +1,39 @@
+<script lang="ts" module>
+  import type { Announcer } from './announcer.svelte.ts';
+
+  export type AnnouncerNavHandle = {
+    /** Run the real navigation side effects against this fixture's <main>. */
+    navigate(componentName: string): Promise<void>;
+    /** The fixture's main element, for focus assertions. */
+    getMain(): HTMLElement | null;
+  };
+</script>
+
+<script lang="ts">
+  import AnnouncerRegion from './announcer.svelte';
+  import { announceNavigation, setAnnouncer } from './announcer.svelte.ts';
+
+  type Props = {
+    /** Shared instance the test reads `message` from. */
+    announcer: Announcer;
+  };
+
+  let { announcer }: Props = $props();
+
+  setAnnouncer(announcer);
+
+  let mainEl = $state<HTMLElement | null>(null);
+
+  /** Drive the real `announceNavigation` from the test, targeting this <main>. */
+  export function navigate(componentName: string): Promise<void> {
+    return announceNavigation(announcer, componentName, () => mainEl);
+  }
+
+  /** Imperative handle to the focus target. */
+  export function getMain(): HTMLElement | null {
+    return mainEl;
+  }
+</script>
+
+<main bind:this={mainEl} tabindex="-1">content</main>
+<AnnouncerRegion />

--- a/packages/playground/src/shell-app/announcer-popstate-fixture.svelte
+++ b/packages/playground/src/shell-app/announcer-popstate-fixture.svelte
@@ -1,0 +1,61 @@
+<script lang="ts" module>
+  import type { Announcer } from './announcer.svelte.ts';
+
+  /** Minimal store surface the popstate handler touches. */
+  export type PopStateStoreStub = {
+    currentComponent: string;
+    syncFromUrl(): void;
+  };
+
+  export type AnnouncerPopStateHandle = {
+    /**
+     * Re-run the shell's exact `handlePopState` control flow against the
+     * current `window.location`: parse the path, update the store, re-sync the
+     * toolbar, then announce. Mirrors shell.svelte so the wiring (announce on
+     * back/forward, only when a component resolves) is regression-covered
+     * without mounting the full shell + cinder barrel.
+     */
+    popState(): Promise<void>;
+    /** The fixture's main element, for focus assertions. */
+    getMain(): HTMLElement | null;
+  };
+</script>
+
+<script lang="ts">
+  import AnnouncerRegion from './announcer.svelte';
+  import { announceNavigation, setAnnouncer } from './announcer.svelte.ts';
+  import { parseComponentFromPath } from './routing.ts';
+
+  type Props = {
+    /** Shared instance the test reads `message` from. */
+    announcer: Announcer;
+    /** Minimal store the handler mutates; the test asserts on it. */
+    store: PopStateStoreStub;
+  };
+
+  let { announcer, store }: Props = $props();
+
+  setAnnouncer(announcer);
+
+  let mainEl = $state<HTMLElement | null>(null);
+
+  /**
+   * Replicates `shell.svelte`'s `handlePopState` exactly: guard on a resolved
+   * component, sync the toolbar from the URL first, then apply the navigation
+   * side effects (title + announcement + focus).
+   */
+  export async function popState(): Promise<void> {
+    const parsed = parseComponentFromPath(window.location.pathname);
+    if (parsed !== null) store.currentComponent = parsed;
+    store.syncFromUrl();
+    if (parsed !== null) await announceNavigation(announcer, parsed, () => mainEl);
+  }
+
+  /** Imperative handle to the focus target. */
+  export function getMain(): HTMLElement | null {
+    return mainEl;
+  }
+</script>
+
+<main bind:this={mainEl} tabindex="-1">content</main>
+<AnnouncerRegion />

--- a/packages/playground/src/shell-app/announcer.svelte
+++ b/packages/playground/src/shell-app/announcer.svelte
@@ -1,0 +1,24 @@
+<script lang="ts">
+  import { getAnnouncer } from './announcer.svelte.ts';
+
+  // The shell's single polite live region. Both the top bar and the shell's
+  // client-side navigation push messages through this one Announcer instance,
+  // so there is exactly one region in the document (two would double-read).
+  const announcer = getAnnouncer();
+</script>
+
+<span class="sr-only" aria-live="polite" aria-atomic="true">{announcer.message}</span>
+
+<style>
+  .sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+  }
+</style>

--- a/packages/playground/src/shell-app/announcer.svelte.ts
+++ b/packages/playground/src/shell-app/announcer.svelte.ts
@@ -1,0 +1,106 @@
+/**
+ * Shared screen-reader announcer for the playground shell.
+ *
+ * A single polite `aria-live` region lives in the shell (rendered by
+ * `announcer.svelte`). Both the top bar (toolbar control feedback) and the
+ * shell (client-side navigation, WCAG 4.1.3) push messages through one
+ * `Announcer` instance provided via context, so there is exactly one live
+ * region in the document. Two regions would mean assistive technology reads
+ * every message twice.
+ *
+ * The empty-then-set trick: assigning the same string twice in a row is a
+ * no-op for the Svelte runtime, so the DOM never mutates and the screen
+ * reader stays silent on the second announcement. Clearing the message first,
+ * then setting it after a short gap, forces a DOM mutation every time — even
+ * for an identical repeat — so the announcement is always read.
+ */
+
+import { getContext, setContext, tick } from 'svelte';
+
+const ANNOUNCER_KEY = Symbol('cinder-announcer');
+
+/** Delay (ms) between clearing the live region and writing the new message. */
+const ANNOUNCE_COALESCE_MS = 50;
+
+/**
+ * Reactive holder for the shell's single polite live region.
+ *
+ * Read `message` in the live region's template; call `announce(text)` to
+ * queue a message. A pending announcement is cancelled if a newer one
+ * arrives before the coalescing gap elapses, so rapid-fire updates collapse
+ * to the latest message rather than stuttering.
+ */
+export class Announcer {
+  /** Current live-region text. The empty string renders nothing. */
+  message = $state<string>('');
+
+  #timeout: ReturnType<typeof setTimeout> | null = null;
+
+  /**
+   * Announce `text` in the polite live region. Clears the region first, then
+   * writes the message after `ANNOUNCE_COALESCE_MS` so the DOM always mutates
+   * — guaranteeing assistive technology reads even an identical repeat.
+   */
+  announce(text: string): void {
+    if (this.#timeout !== null) clearTimeout(this.#timeout);
+    this.message = '';
+    this.#timeout = setTimeout(() => {
+      this.message = text;
+      this.#timeout = null;
+    }, ANNOUNCE_COALESCE_MS);
+  }
+
+  /**
+   * Cancel any pending announcement. Used on teardown so a queued message
+   * never lands after the component tree is gone.
+   */
+  cancel(): void {
+    if (this.#timeout !== null) {
+      clearTimeout(this.#timeout);
+      this.#timeout = null;
+    }
+  }
+}
+
+/**
+ * Apply the three accessibility side effects of a client-side navigation in
+ * the playground shell, in one place so the shell and its tests share the
+ * exact code path:
+ *
+ *   1. Update `document.title` so each SPA "page" is distinguishable in the
+ *      title bar and history list (WCAG 2.4.2 "Page Titled").
+ *   2. Announce the navigation in the shared polite live region so assistive
+ *      technology knows the content changed (WCAG 4.1.3 "Status Messages").
+ *   3. Move keyboard focus to the freshly-rendered main region (passed in as
+ *      a getter, resolved after `tick()` so the new content is in the DOM)
+ *      (WCAG 2.4.3 "Focus Order").
+ *
+ * `getMain` is a getter rather than a bare element so the focus target is
+ * resolved *after* the awaited `tick()`, reflecting the live `bind:this`.
+ */
+export async function announceNavigation(
+  announcer: Announcer,
+  componentName: string,
+  getMain: () => HTMLElement | null,
+): Promise<void> {
+  if (typeof document !== 'undefined') {
+    document.title = `cinder playground — ${componentName}`;
+  }
+  announcer.announce(`Viewing ${componentName}`);
+  await tick();
+  getMain()?.focus();
+}
+
+/** Install the singleton announcer on the current component tree. */
+export function setAnnouncer(announcer: Announcer): void {
+  setContext(ANNOUNCER_KEY, announcer);
+}
+
+/** Read the singleton announcer from the current component tree. Throws if absent. */
+export function getAnnouncer(): Announcer {
+  const announcer = getContext<Announcer | undefined>(ANNOUNCER_KEY);
+  if (announcer === undefined) {
+    throw new Error('[cinder playground] Announcer is not set in this component tree');
+  }
+  return announcer;
+}

--- a/packages/playground/src/shell-app/announcer.test.ts
+++ b/packages/playground/src/shell-app/announcer.test.ts
@@ -1,0 +1,232 @@
+/// <reference lib="dom" />
+/**
+ * Tests for the shared `Announcer` reactive class.
+ *
+ * The class uses `$state`, so it must be exercised inside a Svelte component
+ * context — we follow the same happy-dom-before-testing-library setup as
+ * `event-source.test.ts`. A tiny fixture exposes the singleton's `announce`
+ * and `message` to the test.
+ *
+ * The behavior under test is the empty-then-set coalescing trick: `announce`
+ * clears `message` synchronously, then writes the new text after a 50 ms gap.
+ * We drive time with `setSystemTime` + Bun's fake-timer-free `setTimeout` by
+ * awaiting real delays kept short enough to stay fast.
+ */
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+
+// Use the shared, idempotent happy-dom setup (same as every other DOM test in
+// this package, via bunfig's preload) BEFORE dynamic-importing testing-library.
+// A hand-rolled `new Window()` here would clobber the globals an earlier file in
+// the same process already installed and skip the Web Animations / removeChild
+// shims, which Svelte 5 transitions depend on.
+import { setupHappyDom } from '../../../components/src/test/happy-dom.ts';
+
+setupHappyDom();
+
+/** The happy-dom window installed on globalThis, narrowed to expose `setURL`. */
+const happyWindow = window as unknown as { happyDOM: { setURL(url: string): void } };
+
+const { render, cleanup } = await import('@testing-library/svelte');
+const { default: Fixture } = await import('./announcer-fixture.svelte');
+const { default: NavFixture } = await import('./announcer-nav-fixture.svelte');
+const { default: PopStateFixture } = await import('./announcer-popstate-fixture.svelte');
+const { tick } = await import('svelte');
+const { Announcer } = await import('./announcer.svelte.ts');
+
+/** A minimal store stub that records calls the popstate handler makes. */
+function makePopStateStore(): {
+  currentComponent: string;
+  syncFromUrl(): void;
+  syncFromUrlCalls: number;
+} {
+  return {
+    currentComponent: '',
+    syncFromUrlCalls: 0,
+    syncFromUrl(): void {
+      this.syncFromUrlCalls += 1;
+    },
+  };
+}
+
+/** Wait `ms` real milliseconds, then flush Svelte's pending DOM updates. */
+async function advance(ms: number): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, ms));
+  await tick();
+}
+
+beforeEach(() => {
+  document.title = '';
+  cleanup();
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('Announcer', () => {
+  test('message starts empty', () => {
+    const announcer = new Announcer();
+    expect(announcer.message).toBe('');
+  });
+
+  test('clears the message synchronously, then sets it after the 50 ms gap', async () => {
+    const announcer = new Announcer();
+    render(Fixture, { announcer });
+    await tick();
+
+    announcer.announce('Viewing button');
+    // Synchronous empty: the DOM mutates to '' first so an identical repeat
+    // still produces a mutation later.
+    expect(announcer.message).toBe('');
+
+    // Before the gap elapses, the message is still empty.
+    await advance(20);
+    expect(announcer.message).toBe('');
+
+    // After the gap, the message lands.
+    await advance(40);
+    expect(announcer.message).toBe('Viewing button');
+  });
+
+  test('an identical repeat still empties then re-sets (forces a DOM mutation)', async () => {
+    const announcer = new Announcer();
+    render(Fixture, { announcer });
+    await tick();
+
+    announcer.announce('Viewing card');
+    await advance(60);
+    expect(announcer.message).toBe('Viewing card');
+
+    // Announcing the same string again must clear to '' first...
+    announcer.announce('Viewing card');
+    expect(announcer.message).toBe('');
+
+    // ...then restore it, guaranteeing assistive tech reads the repeat.
+    await advance(60);
+    expect(announcer.message).toBe('Viewing card');
+  });
+
+  test('a newer announcement cancels a pending one (coalesces to the latest)', async () => {
+    const announcer = new Announcer();
+    render(Fixture, { announcer });
+    await tick();
+
+    announcer.announce('first');
+    await advance(20); // still pending
+    announcer.announce('second');
+
+    await advance(60);
+    expect(announcer.message).toBe('second');
+  });
+
+  test('cancel() drops a pending announcement', async () => {
+    const announcer = new Announcer();
+    render(Fixture, { announcer });
+    await tick();
+
+    announcer.announce('should not land');
+    announcer.cancel();
+
+    await advance(60);
+    expect(announcer.message).toBe('');
+  });
+
+  test('the live region reflects the message text', async () => {
+    const announcer = new Announcer();
+    const { container } = render(Fixture, { announcer });
+    await tick();
+
+    const region = container.querySelector('[aria-live="polite"]');
+    expect(region).not.toBeNull();
+    expect(region?.getAttribute('aria-atomic')).toBe('true');
+
+    announcer.announce('Viewing accordion');
+    await advance(60);
+    expect(region?.textContent).toBe('Viewing accordion');
+  });
+});
+
+describe('announceNavigation', () => {
+  test('sets document.title to "cinder playground — <component>"', async () => {
+    const announcer = new Announcer();
+    const { component } = render(NavFixture, { announcer });
+    await tick();
+
+    await component['navigate']('button');
+    expect(document.title).toBe('cinder playground — button');
+  });
+
+  test('queues a "Viewing <component>" announcement in the live region', async () => {
+    const announcer = new Announcer();
+    const { container, component } = render(NavFixture, { announcer });
+    await tick();
+
+    await component['navigate']('card');
+    // announceNavigation awaits a tick but not the 50 ms coalescing gap.
+    await advance(70);
+
+    const region = container.querySelector('[aria-live="polite"]');
+    expect(region?.textContent).toBe('Viewing card');
+  });
+
+  test('moves focus to the main region', async () => {
+    const announcer = new Announcer();
+    const { component } = render(NavFixture, { announcer });
+    await tick();
+
+    await component['navigate']('avatar');
+    expect(document.activeElement).toBe(component['getMain']());
+  });
+});
+
+describe('popstate navigation (browser back/forward)', () => {
+  test('applies title + announcement + focus for a resolvable component', async () => {
+    happyWindow.happyDOM.setURL('http://localhost/c/button');
+    const announcer = new Announcer();
+    const store = makePopStateStore();
+    const { container, component } = render(PopStateFixture, { announcer, store });
+    await tick();
+
+    await component['popState']();
+
+    expect(store.currentComponent).toBe('button');
+    expect(document.title).toBe('cinder playground — button');
+    expect(document.activeElement).toBe(component['getMain']());
+
+    await advance(70);
+    const region = container.querySelector('[aria-live="polite"]');
+    expect(region?.textContent).toBe('Viewing button');
+  });
+
+  test('syncs the toolbar from the URL before announcing', async () => {
+    happyWindow.happyDOM.setURL('http://localhost/c/card');
+    const announcer = new Announcer();
+    const store = makePopStateStore();
+    const { component } = render(PopStateFixture, { announcer, store });
+    await tick();
+
+    await component['popState']();
+    // The handler re-syncs the toolbar exactly once before focus lands.
+    expect(store.syncFromUrlCalls).toBe(1);
+  });
+
+  test('does not announce or change title when the path is not a component route', async () => {
+    happyWindow.happyDOM.setURL('http://localhost/not-a-component-route');
+    const announcer = new Announcer();
+    const store = makePopStateStore();
+    store.currentComponent = 'button';
+    const { container, component } = render(PopStateFixture, { announcer, store });
+    await tick();
+
+    await component['popState']();
+
+    // Unresolved path: store untouched, but the toolbar still re-syncs.
+    expect(store.currentComponent).toBe('button');
+    expect(store.syncFromUrlCalls).toBe(1);
+    expect(document.title).toBe('');
+
+    await advance(70);
+    const region = container.querySelector('[aria-live="polite"]');
+    expect(region?.textContent).toBe('');
+  });
+});

--- a/packages/playground/src/shell-app/humanize.test.ts
+++ b/packages/playground/src/shell-app/humanize.test.ts
@@ -1,0 +1,99 @@
+/**
+ * Exhaustive unit tests for `humanizeComponentName`.
+ *
+ * Pure function, no DOM — covers acronym substitution, multi-word title
+ * casing, single words, mixed acronym/word names, and degenerate inputs
+ * (empty string, leading/trailing/doubled hyphens, whitespace, casing).
+ */
+
+import { describe, expect, it } from 'bun:test';
+
+import { humanizeComponentName } from './humanize.ts';
+
+describe('humanizeComponentName', () => {
+  it('title-cases a single word', () => {
+    expect(humanizeComponentName('button')).toBe('Button');
+  });
+
+  it('title-cases a multi-word kebab name', () => {
+    expect(humanizeComponentName('tag-input')).toBe('Tag Input');
+  });
+
+  it('title-cases three-plus words', () => {
+    expect(humanizeComponentName('side-navigation-item')).toBe('Side Navigation Item');
+  });
+
+  it('substitutes a leading acronym', () => {
+    expect(humanizeComponentName('json-schema-editor')).toBe('JSON Schema Editor');
+  });
+
+  it('substitutes a trailing acronym', () => {
+    expect(humanizeComponentName('copy-url')).toBe('Copy URL');
+  });
+
+  it('substitutes a standalone acronym', () => {
+    expect(humanizeComponentName('css')).toBe('CSS');
+  });
+
+  describe('each acronym in the map', () => {
+    const cases: ReadonlyArray<readonly [string, string]> = [
+      ['json', 'JSON'],
+      ['api', 'API'],
+      ['css', 'CSS'],
+      ['url', 'URL'],
+      ['html', 'HTML'],
+      ['ssr', 'SSR'],
+      ['dom', 'DOM'],
+    ];
+    for (const [input, expected] of cases) {
+      it(`renders "${input}" as "${expected}"`, () => {
+        expect(humanizeComponentName(input)).toBe(expected);
+      });
+    }
+  });
+
+  it('substitutes multiple acronyms in one name', () => {
+    expect(humanizeComponentName('html-to-json')).toBe('HTML To JSON');
+  });
+
+  it('handles acronyms embedded among words', () => {
+    expect(humanizeComponentName('api-url-builder')).toBe('API URL Builder');
+  });
+
+  it('lowercases then title-cases already-uppercased input', () => {
+    expect(humanizeComponentName('BUTTON')).toBe('Button');
+  });
+
+  it('normalizes mixed-case acronym tokens', () => {
+    expect(humanizeComponentName('Json-Editor')).toBe('JSON Editor');
+  });
+
+  it('only matches acronyms as whole tokens, not substrings', () => {
+    // "jsonish" is not the token "json", so it is plain title-cased.
+    expect(humanizeComponentName('jsonish-widget')).toBe('Jsonish Widget');
+  });
+
+  it('returns an empty string for empty input', () => {
+    expect(humanizeComponentName('')).toBe('');
+  });
+
+  it('drops empty segments from a leading hyphen', () => {
+    expect(humanizeComponentName('-button')).toBe('Button');
+  });
+
+  it('drops empty segments from a trailing hyphen', () => {
+    expect(humanizeComponentName('button-')).toBe('Button');
+  });
+
+  it('collapses doubled hyphens', () => {
+    expect(humanizeComponentName('tag--input')).toBe('Tag Input');
+  });
+
+  it('trims surrounding whitespace', () => {
+    expect(humanizeComponentName('  button  ')).toBe('Button');
+  });
+
+  it('returns an empty string for a name that is only hyphens', () => {
+    expect(humanizeComponentName('---')).toBe('');
+  });
+});

--- a/packages/playground/src/shell-app/humanize.ts
+++ b/packages/playground/src/shell-app/humanize.ts
@@ -1,0 +1,60 @@
+/**
+ * Turn a kebab-case component name into a human-readable display label.
+ *
+ * Extracted into its own module (no Svelte, no DOM) so the title-casing and
+ * acronym rules are exhaustively unit-testable from `bun:test` without paying
+ * the `.svelte` compilation cost. The sidebar renders the humanized label for
+ * readability while keeping the raw kebab name for routing, hrefs, and
+ * selection callbacks.
+ */
+
+/**
+ * Words that should render in a fixed casing rather than naive title-case.
+ * Keys are the lowercase token as it appears in a kebab name; values are the
+ * canonical display form. Acronyms render fully uppercase; the rest preserve a
+ * conventional brand/casing spelling.
+ */
+const ACRONYM_MAP: Readonly<Record<string, string>> = {
+  json: 'JSON',
+  api: 'API',
+  css: 'CSS',
+  url: 'URL',
+  html: 'HTML',
+  ssr: 'SSR',
+  dom: 'DOM',
+};
+
+/**
+ * Title-case a single token, applying the acronym map first. Empty tokens
+ * (which can appear from leading/trailing/doubled hyphens) pass through
+ * unchanged so the caller can filter them out.
+ */
+function humanizeToken(token: string): string {
+  if (token === '') return token;
+  const lower = token.toLowerCase();
+  const acronym = ACRONYM_MAP[lower];
+  if (acronym !== undefined) return acronym;
+  return lower.charAt(0).toUpperCase() + lower.slice(1);
+}
+
+/**
+ * Convert a kebab-case component name into a title-cased display label.
+ *
+ * Splits on hyphens, title-cases each word, and substitutes known acronyms
+ * (JSON, API, CSS, URL, HTML, SSR, DOM) with their canonical uppercase form.
+ * Empty segments from leading, trailing, or doubled hyphens are dropped, and
+ * surrounding whitespace is trimmed.
+ *
+ * @example
+ * humanizeComponentName('json-schema-editor'); // 'JSON Schema Editor'
+ * humanizeComponentName('tag-input');          // 'Tag Input'
+ * humanizeComponentName('button');             // 'Button'
+ */
+export function humanizeComponentName(name: string): string {
+  return name
+    .trim()
+    .split('-')
+    .map(humanizeToken)
+    .filter((token) => token !== '')
+    .join(' ');
+}

--- a/packages/playground/src/shell-app/preview-frame-driver.svelte
+++ b/packages/playground/src/shell-app/preview-frame-driver.svelte
@@ -1,0 +1,38 @@
+<script lang="ts" module>
+  export type PreviewFrameDriverProps = {
+    /** Component name the preview frame starts on. */
+    initial: string;
+  };
+
+  export type PreviewFrameDriverHandle = {
+    setComponentName(next: string): void;
+    /** Reload the framed document (exercises the live-reload overlay path). */
+    reload(): void;
+  };
+</script>
+
+<script lang="ts">
+  import PreviewFrame, { type PreviewFrameHandle } from './preview-frame.svelte';
+  import { PreviewStore, setPreviewStore } from './preview-store.svelte.ts';
+
+  let { initial }: PreviewFrameDriverProps = $props();
+
+  // Install a store in this tree so `getPreviewStore()` inside PreviewFrame
+  // resolves. The driver is the component-tree owner of the context.
+  setPreviewStore(new PreviewStore(initial));
+
+  let componentName = $state<string>(initial);
+  let frame = $state<PreviewFrameHandle | null>(null);
+
+  /** Imperative handle the test holds onto to drive sidebar navigation. */
+  export function setComponentName(next: string): void {
+    componentName = next;
+  }
+
+  /** Forward a live-reload to the framed preview, re-arming its overlay. */
+  export function reload(): void {
+    frame?.reload();
+  }
+</script>
+
+<PreviewFrame bind:this={frame} {componentName} />

--- a/packages/playground/src/shell-app/preview-frame-fixture.svelte
+++ b/packages/playground/src/shell-app/preview-frame-fixture.svelte
@@ -1,0 +1,23 @@
+<script lang="ts" module>
+  import type { PreviewStore } from './preview-store.svelte.ts';
+
+  export type PreviewFrameFixtureProps = {
+    /** The store instance to install on the context before mounting the frame. */
+    store: PreviewStore;
+    /** Component name forwarded to `preview-frame.svelte`. */
+    componentName: string;
+  };
+</script>
+
+<script lang="ts">
+  import { setPreviewStore } from './preview-store.svelte.ts';
+  import PreviewFrame from './preview-frame.svelte';
+
+  let { store, componentName }: PreviewFrameFixtureProps = $props();
+
+  // preview-frame.svelte reads the store via `getPreviewStore()`, which throws
+  // if no store is installed on the context. Install the test's store first.
+  setPreviewStore(store);
+</script>
+
+<PreviewFrame {componentName} />

--- a/packages/playground/src/shell-app/preview-frame.svelte
+++ b/packages/playground/src/shell-app/preview-frame.svelte
@@ -1,5 +1,23 @@
+<script lang="ts" module>
+  /**
+   * Imperative handle a parent obtains via `bind:this`, so a live-reload event
+   * reloads the iframe *through* this component (which re-arms the loading
+   * overlay) rather than poking `iframe.contentWindow.location.reload()`
+   * directly — a direct reload keeps the same `src`, so the overlay would never
+   * show during hot reload.
+   */
+  export type PreviewFrameHandle = { reload(): void };
+</script>
+
 <script lang="ts">
-  import { EmptyState } from '../../../components/src/index.ts';
+  // Import the two components from their per-component modules rather than the
+  // monolithic `components/src/index.ts` barrel: the barrel re-exports every
+  // component (including review-editor, which pulls in the commentary
+  // subpaths), and dragging that whole graph into this leaf both bloats the
+  // bundle and makes the component impossible to mount in a `--conditions
+  // browser` test. These narrow paths bring in only what we render.
+  import { EmptyState } from '../../../components/src/components/empty-state/index.ts';
+  import { Spinner } from '../../../components/src/components/spinner/index.ts';
   import { getPreviewStore } from './preview-store.svelte.ts';
   import { buildIframeSrc, createPreviewMessage, type PreviewMessage } from './routing.ts';
 
@@ -14,6 +32,15 @@
   let iframeEl = $state<HTMLIFrameElement | null>(null);
 
   let src = $derived(buildIframeSrc(componentName));
+
+  // The src whose document has finished painting, set in `handleLoad`. Loading
+  // is then a pure derivation: we're loading whenever the current `src` hasn't
+  // been confirmed loaded yet. This is declarative — no `$effect` copying one
+  // piece of state into another. On navigation `src` changes, `loadedSrc` lags
+  // behind until the new document fires `load`, so the overlay covers the
+  // blank white frame for the 1–5s gap with no manual re-arming.
+  let loadedSrc = $state<string | null>(null);
+  const loading = $derived(src !== loadedSrc);
 
   /**
    * Send a typed message to the iframe with an explicit target origin.
@@ -46,12 +73,28 @@
   });
 
   function handleLoad(): void {
+    // The new document has painted — mark this src loaded so `loading` derives
+    // to false and the overlay lifts.
+    loadedSrc = src;
     // Replay the current theme + background after a fresh iframe load. The
     // iframe's inline pre-paint script already reads localStorage for theme,
     // but background is session-only and lives in the shell — we need to
     // sync it after each navigation/reload.
     syncTheme();
     syncBackground();
+  }
+
+  /**
+   * Reload the iframe's current document (used by SSE live reload). Clearing
+   * `loadedSrc` re-arms the loading overlay even though `src` is unchanged, so
+   * a hot reload shows the same feedback as a navigation; `handleLoad` clears it
+   * again once the reloaded document paints.
+   */
+  export function reload(): void {
+    const win = iframeEl?.contentWindow;
+    if (!win) return;
+    loadedSrc = null;
+    win.location.reload();
   }
 
   // The iframe lives inside {#if componentName}, so its DOM element is
@@ -72,14 +115,55 @@
       ? ''
       : `width: ${store.previewWidth}px; max-width: 100%; margin: 0 auto;`,
   );
+
+  // Text for the persistent live region. It announces "Loading preview" while
+  // the frame paints and "Preview ready" once it settles. The region itself
+  // stays mounted at all times — a sibling of the iframe wrapper, never inside
+  // the {#if loading} overlay — so the transition to "ready" is actually
+  // announced. A live region that is removed from the DOM when loading clears
+  // can never fire that update.
+  let statusMessage = $derived(loading ? 'Loading preview' : 'Preview ready');
 </script>
 
 <div class="preview-host">
   {#if componentName}
-    <div class="preview-frame-wrapper" style={wrapperStyle}>
-      <iframe bind:this={iframeEl} {src} title="{componentName} preview" data-cinder-preview
+    <!-- aria-busy mirrors `loading`: WCAG 4.1.3 signal that this region is
+         temporarily unavailable. Keyboard/screen-reader users who land on the
+         iframe area learn it is busy rather than silently unresponsive. -->
+    <div class="preview-frame-wrapper" style={wrapperStyle} aria-busy={loading}>
+      <iframe
+        bind:this={iframeEl}
+        {src}
+        title="{componentName} preview"
+        class={['preview-iframe', { 'is-loading': loading }]}
+        data-cinder-preview
       ></iframe>
+      {#if loading}
+        <!-- Visual-only overlay. The Spinner renders its own role="status", so
+             we hide it from assistive tech (aria-hidden) to avoid a second,
+             competing announcement — the persistent live region (a sibling of
+             this wrapper, below) owns the spoken status. -->
+        <div
+          class="preview-loading-overlay"
+          data-testid="preview-loading-overlay"
+          aria-hidden="true"
+        >
+          <Spinner label="Loading preview" />
+        </div>
+      {/if}
     </div>
+    <!-- Persistent live region: always mounted, text swaps with `loading`.
+         Because it never leaves the DOM, the "Preview ready" update actually
+         announces when the frame settles.
+
+         It lives OUTSIDE `.preview-frame-wrapper` (a sibling here at the
+         `.preview-host` level) on purpose: the wrapper carries
+         `aria-busy={loading}`, and per the ARIA spec some screen readers
+         (notably NVDA + Firefox) suppress or defer announcing live-region
+         updates nested inside an `aria-busy="true"` container. Hoisting the
+         region out of that container guarantees the "Preview ready" update is
+         spoken rather than silently dropped. -->
+    <span class="sr-only" role="status" aria-live="polite" aria-atomic="true">{statusMessage}</span>
   {:else}
     <EmptyState
       title="No component selected"
@@ -111,6 +195,8 @@
     height: 100%;
     display: flex;
     flex-direction: column;
+    /* Positioning context for the absolutely-placed loading overlay. */
+    position: relative;
   }
 
   iframe {
@@ -121,5 +207,45 @@
     background: var(--cinder-surface);
     display: block;
     min-height: 0;
+  }
+
+  .preview-loading-overlay {
+    /* Cover the iframe exactly — no layout shift, the iframe keeps its box. */
+    position: absolute;
+    inset: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: var(--cinder-surface);
+    /* Sit above the iframe while it paints. */
+    z-index: 1;
+  }
+
+  /* Visually-hidden but readable by assistive tech — same recipe as the live
+     region in `top-bar.svelte`. Keeps the status announcement off-screen
+     without removing it from the accessibility tree. */
+  .sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+  }
+
+  /* The iframe fades from the overlay-covered loading state to the painted
+     document. Only animate when the user hasn't asked to reduce motion;
+     otherwise the swap is instantaneous. */
+  @media (prefers-reduced-motion: no-preference) {
+    .preview-iframe {
+      transition: opacity 0.2s ease;
+    }
+
+    .preview-iframe.is-loading {
+      opacity: 0;
+    }
   }
 </style>

--- a/packages/playground/src/shell-app/preview-frame.test.ts
+++ b/packages/playground/src/shell-app/preview-frame.test.ts
@@ -1,0 +1,322 @@
+/// <reference lib="dom" />
+/**
+ * DOM-mount tests for `preview-frame.svelte`.
+ *
+ * Setup mirrors `event-source.test.ts`: happy-dom is installed onto
+ * `globalThis` before `@testing-library/svelte` loads so component mount has a
+ * working DOM. `preview-frame.svelte` reads the shared store via
+ * `getPreviewStore()`, so the tests mount it through one of two fixtures:
+ *   - `preview-frame-driver.svelte` installs a `PreviewStore` and exposes
+ *     `setComponentName` so a test can simulate sidebar navigation (which flips
+ *     `src` on the iframe) — used by the loading-state suite.
+ *   - `preview-frame-fixture.svelte` installs the test's `PreviewStore` directly
+ *     — used by the src-construction and handleLoad suites.
+ *
+ * The iframe never actually fetches a document under happy-dom, so we drive the
+ * `handleLoad` path by dispatching a synthetic `load` event on the iframe
+ * element — exactly the event the real browser fires when the new preview
+ * document paints.
+ *
+ * Assertions target STABLE contracts (the loading overlay/live-region behaviour,
+ * the `buildIframeSrc` URL contract, the empty-state placeholder, and the
+ * theme/background `postMessage` replay) and avoid incidental structure so
+ * sibling refactors don't break them.
+ */
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+
+import { setupHappyDom } from '../../../components/src/test/happy-dom.ts';
+
+// Install happy-dom globals via the shared, idempotent helper BEFORE
+// dynamic-importing @testing-library/svelte. Using the single shared window
+// (rather than a private `new Window()`) keeps this file's globals consistent
+// with the other shell-app DOM tests when the whole suite runs in one process —
+// competing window installs leak `document`/`activeElement` across files.
+setupHappyDom();
+
+const { render } = await import('@testing-library/svelte');
+const { default: Driver } = await import('./preview-frame-driver.svelte');
+const { default: PreviewFrameFixture } = await import('./preview-frame-fixture.svelte');
+const { PreviewStore } = await import('./preview-store.svelte.ts');
+const { buildIframeSrc } = await import('./routing.ts');
+const { tick } = await import('svelte');
+
+type PreviewMessage = import('./routing.ts').PreviewMessage;
+
+const OVERLAY = '[data-testid="preview-loading-overlay"]';
+
+/** Fire the `load` event the browser would dispatch once the iframe paints. */
+function dispatchIframeLoad(container: HTMLElement): void {
+  const iframe = container.querySelector('iframe');
+  expect(iframe).not.toBeNull();
+  iframe?.dispatchEvent(new Event('load'));
+}
+
+beforeEach(() => {
+  // Each render owns its own component tree; nothing global to reset, but keep
+  // a stable URL so PreviewStore's URL writes don't accumulate across tests.
+  window.history.replaceState(null, '', '/');
+});
+
+afterEach(() => {
+  window.history.replaceState(null, '', '/');
+});
+
+const WRAPPER = '.preview-frame-wrapper';
+// The persistent, visually-hidden live region — distinct from the Spinner's own
+// role="status", which lives inside the aria-hidden overlay. It is hoisted OUT
+// of `.preview-frame-wrapper` (which carries `aria-busy`) so its announcements
+// are not suppressed, so we scope the selector to `.preview-host` directly.
+const LIVE_REGION = '.preview-host > .sr-only[role="status"]';
+
+describe('preview-frame loading state', () => {
+  test('starts loading with the overlay visible on first mount', async () => {
+    const { container, unmount } = render(Driver, { initial: 'button' });
+    await tick();
+
+    expect(container.querySelector(OVERLAY)).not.toBeNull();
+    // The iframe carries the loading class so its opacity transition can run.
+    expect(container.querySelector('iframe')?.classList.contains('is-loading')).toBe(true);
+
+    unmount();
+  });
+
+  test('handleLoad clears loading and removes the overlay', async () => {
+    const { container, unmount } = render(Driver, { initial: 'button' });
+    await tick();
+    expect(container.querySelector(OVERLAY)).not.toBeNull();
+
+    dispatchIframeLoad(container);
+    await tick();
+
+    expect(container.querySelector(OVERLAY)).toBeNull();
+    expect(container.querySelector('iframe')?.classList.contains('is-loading')).toBe(false);
+
+    unmount();
+  });
+
+  test('re-arms loading when the selected component (src) changes', async () => {
+    const { container, component, unmount } = render(Driver, { initial: 'button' });
+    await tick();
+
+    // Settle the initial load so we observe the transition, not the seed state.
+    dispatchIframeLoad(container);
+    await tick();
+    expect(container.querySelector(OVERLAY)).toBeNull();
+
+    // Navigate to another component — src changes, overlay returns.
+    component['setComponentName']('card');
+    await tick();
+    expect(container.querySelector(OVERLAY)).not.toBeNull();
+    expect(container.querySelector('iframe')?.classList.contains('is-loading')).toBe(true);
+
+    // The new document paints — overlay clears again.
+    dispatchIframeLoad(container);
+    await tick();
+    expect(container.querySelector(OVERLAY)).toBeNull();
+
+    unmount();
+  });
+
+  test('reload() re-arms the overlay even though src is unchanged (hot reload)', async () => {
+    const { container, component, unmount } = render(Driver, { initial: 'button' });
+    await tick();
+
+    // Settle the initial load so the overlay is gone before we reload.
+    dispatchIframeLoad(container);
+    await tick();
+    expect(container.querySelector(OVERLAY)).toBeNull();
+
+    // Live reload keeps the same component (src), so the old src-only loading
+    // derivation would never re-show the overlay. reload() must re-arm it.
+    component['reload']();
+    await tick();
+    expect(container.querySelector(OVERLAY)).not.toBeNull();
+    expect(container.querySelector('iframe')?.classList.contains('is-loading')).toBe(true);
+
+    // The reloaded document paints — overlay clears again.
+    dispatchIframeLoad(container);
+    await tick();
+    expect(container.querySelector(OVERLAY)).toBeNull();
+
+    unmount();
+  });
+
+  test('overlay spinner is hidden from assistive tech to avoid a duplicate announcement', async () => {
+    const { container, unmount } = render(Driver, { initial: 'button' });
+    await tick();
+
+    const overlay = container.querySelector(OVERLAY);
+    expect(overlay).not.toBeNull();
+    // The visual overlay (and its Spinner's own role="status") must be hidden
+    // so the persistent live region is the single spoken status.
+    expect(overlay?.getAttribute('aria-hidden')).toBe('true');
+
+    unmount();
+  });
+
+  test('wrapper sets aria-busy while loading and clears it when ready', async () => {
+    const { container, unmount } = render(Driver, { initial: 'button' });
+    await tick();
+
+    const wrapper = container.querySelector(WRAPPER);
+    expect(wrapper).not.toBeNull();
+    expect(wrapper?.getAttribute('aria-busy')).toBe('true');
+
+    dispatchIframeLoad(container);
+    await tick();
+    expect(wrapper?.getAttribute('aria-busy')).toBe('false');
+
+    unmount();
+  });
+
+  test('persistent live region stays mounted and swaps its text on load', async () => {
+    const { container, unmount } = render(Driver, { initial: 'button' });
+    await tick();
+
+    // The live region exists immediately and announces the loading state.
+    const live = container.querySelector(LIVE_REGION);
+    expect(live).not.toBeNull();
+    expect(live?.getAttribute('aria-live')).toBe('polite');
+    expect(live?.textContent).toBe('Loading preview');
+
+    dispatchIframeLoad(container);
+    await tick();
+
+    // It is STILL in the DOM — only its text changed — so the completion is
+    // actually announced rather than silently dropped.
+    expect(container.querySelector(LIVE_REGION)).not.toBeNull();
+    expect(container.querySelector(LIVE_REGION)?.textContent).toBe('Preview ready');
+
+    unmount();
+  });
+
+  test('live region is NOT nested inside the aria-busy wrapper', async () => {
+    // Regression for the review finding: a polite live region nested inside an
+    // `aria-busy="true"` container can have its updates suppressed/deferred by
+    // some screen readers (NVDA + Firefox). The region must be a sibling of the
+    // wrapper at the `.preview-host` level so the "Preview ready" announcement
+    // always fires.
+    const { container, unmount } = render(Driver, { initial: 'button' });
+    await tick();
+
+    const wrapper = container.querySelector(WRAPPER);
+    const live = container.querySelector(LIVE_REGION);
+    expect(wrapper).not.toBeNull();
+    expect(live).not.toBeNull();
+
+    // The wrapper is the element carrying aria-busy.
+    expect(wrapper?.getAttribute('aria-busy')).toBe('true');
+    // The live region must not be inside that aria-busy subtree.
+    expect(wrapper?.contains(live ?? null)).toBe(false);
+    // And it must be a direct child of the preview host.
+    const host = container.querySelector<HTMLElement>('.preview-host');
+    expect(host).not.toBeNull();
+    expect(live?.parentElement).toBe(host);
+
+    unmount();
+  });
+});
+
+/** The single preview iframe rendered by the frame, or null when absent. */
+function iframeIn(container: HTMLElement): HTMLIFrameElement | null {
+  return container.querySelector<HTMLIFrameElement>('iframe[data-cinder-preview]');
+}
+
+/**
+ * Replace the iframe's contentWindow.postMessage with a recorder so we can
+ * assert exactly what handleLoad replays. Returns the captured-message array.
+ */
+function captureFrameMessages(iframe: HTMLIFrameElement): PreviewMessage[] {
+  const messages: PreviewMessage[] = [];
+  const win = iframe.contentWindow;
+  if (win === null) throw new Error('iframe has no contentWindow');
+  (win as unknown as { postMessage: (message: PreviewMessage) => void }).postMessage = (
+    message: PreviewMessage,
+  ) => {
+    messages.push(message);
+  };
+  return messages;
+}
+
+describe('preview-frame src construction', () => {
+  test('builds iframe src from componentName via buildIframeSrc', async () => {
+    const store = new PreviewStore('button');
+    const { container } = render(PreviewFrameFixture, { store, componentName: 'button' });
+    await tick();
+
+    const iframe = iframeIn(container);
+    expect(iframe).not.toBeNull();
+    expect(iframe?.getAttribute('src')).toBe(buildIframeSrc('button'));
+    expect(iframe?.getAttribute('src')).toBe('/page/button');
+  });
+
+  test('encodes component names defensively in the src', async () => {
+    const store = new PreviewStore('a b');
+    const { container } = render(PreviewFrameFixture, { store, componentName: 'a b' });
+    await tick();
+
+    const iframe = iframeIn(container);
+    // encodeURIComponent turns the space into %20 — matches buildIframeSrc.
+    expect(iframe?.getAttribute('src')).toBe(buildIframeSrc('a b'));
+    expect(iframe?.getAttribute('src')).toBe('/page/a%20b');
+  });
+
+  test('sets a descriptive iframe title from componentName', async () => {
+    const store = new PreviewStore('card');
+    const { container } = render(PreviewFrameFixture, { store, componentName: 'card' });
+    await tick();
+
+    const iframe = iframeIn(container);
+    expect(iframe?.getAttribute('title')).toBe('card preview');
+  });
+
+  test('renders the empty-state placeholder (no iframe) when componentName is empty', async () => {
+    const store = new PreviewStore('');
+    const { container } = render(PreviewFrameFixture, { store, componentName: '' });
+    await tick();
+
+    expect(iframeIn(container)).toBeNull();
+    expect(container.textContent).toContain('No component selected');
+  });
+});
+
+describe('preview-frame handleLoad', () => {
+  test('replays the current theme and background to the iframe on load', async () => {
+    const store = new PreviewStore('button', { theme: 'dark', background: 'checker' });
+    const { container } = render(PreviewFrameFixture, { store, componentName: 'button' });
+    await tick();
+
+    const iframe = iframeIn(container);
+    if (iframe === null) throw new Error('expected an iframe');
+
+    // Install the recorder AFTER mount so the mount-time $effect posts don't
+    // pollute the assertion — we only want what the load event replays.
+    const messages = captureFrameMessages(iframe);
+
+    iframe.dispatchEvent(new Event('load'));
+    await tick();
+
+    const themeMessage = messages.find((message) => message.type === 'cinder:set-theme');
+    const backgroundMessage = messages.find((message) => message.type === 'cinder:set-background');
+    expect(themeMessage?.value).toBe('dark');
+    expect(backgroundMessage?.value).toBe('checker');
+  });
+
+  test('replays the default surface background and system theme on load', async () => {
+    const store = new PreviewStore('button');
+    const { container } = render(PreviewFrameFixture, { store, componentName: 'button' });
+    await tick();
+
+    const iframe = iframeIn(container);
+    if (iframe === null) throw new Error('expected an iframe');
+
+    const messages = captureFrameMessages(iframe);
+    iframe.dispatchEvent(new Event('load'));
+    await tick();
+
+    const themeMessage = messages.find((message) => message.type === 'cinder:set-theme');
+    const backgroundMessage = messages.find((message) => message.type === 'cinder:set-background');
+    expect(themeMessage?.value).toBe('system');
+    expect(backgroundMessage?.value).toBe('surface');
+  });
+});

--- a/packages/playground/src/shell-app/shell.svelte
+++ b/packages/playground/src/shell-app/shell.svelte
@@ -1,6 +1,14 @@
 <script lang="ts">
+  import { onDestroy } from 'svelte';
+
+  import Announcer from './announcer.svelte';
+  import {
+    announceNavigation,
+    Announcer as AnnouncerStore,
+    setAnnouncer,
+  } from './announcer.svelte.ts';
   import { createEventSource } from './event-source.svelte.ts';
-  import PreviewFrame from './preview-frame.svelte';
+  import PreviewFrame, { type PreviewFrameHandle } from './preview-frame.svelte';
   import {
     applyThemeToDocument,
     PreviewStore,
@@ -8,7 +16,7 @@
     setPreviewStore,
   } from './preview-store.svelte.ts';
   import { buildShellHref, parseComponentFromPath, readToolbarStateFromSearch } from './routing.ts';
-  import Sidebar from './sidebar.svelte';
+  import Sidebar, { type SidebarHandle } from './sidebar.svelte';
   import TopBar from './top-bar.svelte';
 
   type Props = {
@@ -17,6 +25,13 @@
   };
 
   let { initialComponent, components }: Props = $props();
+
+  // Bound to the Sidebar instance so the `/` shortcut can focus its filter.
+  let sidebar = $state<SidebarHandle | null>(null);
+
+  // Bound to the PreviewFrame so live-reload events reload through it (re-arming
+  // the loading overlay) instead of poking the raw iframe.
+  let previewFrame = $state<PreviewFrameHandle | null>(null);
 
   // Seed the toolbar from the URL (shareable, survives reload). When the URL
   // is silent about theme, fall back to the localStorage preference so the
@@ -33,30 +48,88 @@
   });
   setPreviewStore(store);
 
+  // Single shared polite live region for the shell. The top bar pushes
+  // toolbar feedback through it; client-side navigation (below) announces the
+  // newly-viewed component. One instance keeps exactly one live region in the
+  // document (two would double-read every message).
+  const announcer = new AnnouncerStore();
+  setAnnouncer(announcer);
+
+  // Clear any pending live-region announcement if the shell is ever torn down,
+  // so a queued setTimeout never fires into a detached component tree. The
+  // shell lives for the page lifetime in practice, but cancelling on teardown
+  // keeps the announcer leak-free and prevents flaky timer carryover in tests.
+  // onDestroy (not a teardown-only $effect) states the intent directly: this is
+  // pure lifecycle cleanup that never tracks reactive state.
+  onDestroy(() => announcer.cancel());
+
+  // `<main>` is programmatically focusable (tabindex="-1") so keyboard focus
+  // can move to the freshly-rendered content after client-side navigation.
+  let mainEl = $state<HTMLElement | null>(null);
+
   // Apply the persisted theme to the shell's root document on first paint.
   // The inline pre-paint script in render-shell.ts already did this before
   // the bundle loaded, but reapplying here keeps the state machine simple
   // (the inline script is a perf optimization, not a correctness gate).
   if (typeof document !== 'undefined') applyThemeToDocument(document, store.theme);
 
-  function selectComponent(name: string): void {
+  async function selectComponent(name: string): Promise<void> {
     if (name === store.currentComponent) return;
     store.currentComponent = name;
     // Preserve the current query string (e.g. ?focus=1) and hash when
     // navigating between components.
     const { search, hash } = window.location;
     history.pushState({}, '', `${buildShellHref(name)}${search}${hash}`);
+
+    // Title (2.4.2) + live-region announcement (4.1.3) + focus move to the
+    // freshly-rendered <main> (2.4.3). Centralized in announceNavigation so the
+    // shell and its tests exercise the same code path.
+    await announceNavigation(announcer, name, () => mainEl);
   }
 
-  function handlePopState(): void {
+  async function handlePopState(): Promise<void> {
     const parsed = parseComponentFromPath(window.location.pathname);
     if (parsed !== null) store.currentComponent = parsed;
+    // Re-sync the toolbar (theme/viewport/focus mode) from the URL *before*
+    // announcing so the toolbar reflects the restored state by the time focus
+    // lands on <main>.
     store.syncFromUrl();
+    // Browser back/forward is client-side navigation too: apply the same
+    // title + live-region + focus side effects as selectComponent (WCAG
+    // 2.4.2 / 4.1.3 / 2.4.3). Guard on a resolved component, mirroring the
+    // null check above.
+    if (parsed !== null) await announceNavigation(announcer, parsed, () => mainEl);
+  }
+
+  /**
+   * True when the keystroke originated from somewhere the user is actively
+   * typing — a text field, textarea, or contenteditable region. Used to keep
+   * the `/` shortcut from hijacking a literal slash the user is typing.
+   */
+  function isTypingTarget(target: EventTarget | null): boolean {
+    if (!(target instanceof HTMLElement)) return false;
+    if (target.isContentEditable) return true;
+    const tag = target.tagName;
+    return tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT';
   }
 
   function handleKeydown(event: KeyboardEvent): void {
     if (event.key === 'Escape' && store.isFocusMode) {
       store.isFocusMode = false;
+      return;
+    }
+    // `/` focuses the sidebar filter, but only when the user isn't already
+    // typing somewhere (so a literal slash in a field is untouched) and isn't
+    // holding a modifier (so browser shortcuts like ⌘/ are untouched).
+    if (
+      event.key === '/' &&
+      !event.metaKey &&
+      !event.ctrlKey &&
+      !event.altKey &&
+      !isTypingTarget(event.target)
+    ) {
+      event.preventDefault();
+      sidebar?.focusFilter();
     }
   }
 
@@ -66,8 +139,10 @@
   const streamUrl = typeof window === 'undefined' ? null : '/events';
 
   function handleReloadEvent(): void {
-    const iframe = document.querySelector<HTMLIFrameElement>('iframe[data-cinder-preview]');
-    iframe?.contentWindow?.location.reload();
+    // Reload through the PreviewFrame handle (not the raw iframe) so the loading
+    // overlay re-arms during hot reload — a direct contentWindow.reload() keeps
+    // the same src, so the overlay would otherwise never show.
+    previewFrame?.reload();
   }
 
   function handleShellReloadEvent(): void {
@@ -80,10 +155,10 @@
 <!--
   Layout overview
   ───────────────
-  The top bar is fixed and spans the full viewport width. It owns the
-  --cinder-top-bar-height custom property (52px). Both the sidebar and
-  the main content area push their top edge down by that amount so nothing
-  slides behind the bar.
+  The top bar is fixed and spans the full viewport width. Its height lives
+  in the --cinder-top-bar-height custom property (52px), declared once on
+  :root by render-shell.ts. Both the sidebar and the main content area push
+  their top edge down by that amount so nothing slides behind the bar.
 
   Focus mode hides both the top bar and the sidebar so the preview fills
   the entire viewport (Escape restores the layout).
@@ -96,23 +171,31 @@
   })}
 >
   <TopBar />
-  <Sidebar {components} currentComponent={store.currentComponent} onSelect={selectComponent} />
-  <main>
-    <PreviewFrame componentName={store.currentComponent} />
+  <Sidebar
+    bind:this={sidebar}
+    {components}
+    currentComponent={store.currentComponent}
+    onSelect={selectComponent}
+  />
+  <!--
+    tabindex="-1" makes <main> programmatically focusable so client-side
+    navigation can move keyboard focus to the new content without adding it to
+    the Tab order. bind:this gives selectComponent a handle to call .focus().
+  -->
+  <main bind:this={mainEl} tabindex="-1">
+    <PreviewFrame bind:this={previewFrame} componentName={store.currentComponent} />
   </main>
+  <Announcer />
 </div>
 
 <style>
   /*
-   * --cinder-top-bar-height is declared on the .top-bar element inside
-   * TopBar. Inherit it here for layout math. If the value ever changes we
-   * only need to update the token in one place (top-bar.svelte).
+   * --cinder-top-bar-height is declared once on :root by render-shell.ts
+   * (the shell scaffold's <head> \3c style>). We just read it here for layout
+   * math — no local declaration or fallback needed since :root always wins
+   * the cascade for an inherited custom property.
    */
   .shell {
-    /* Provide a fallback so the shell still lays out correctly if the
-       TopBar custom property hasn't resolved yet. */
-    --cinder-top-bar-height: 52px;
-
     display: flex;
     height: 100vh;
     font-family: var(--cinder-font-sans);
@@ -136,6 +219,13 @@
     display: flex;
     flex-direction: column;
     min-width: 0;
+    /*
+     * <main> is focused programmatically after client-side navigation (it has
+     * tabindex="-1" but is never in the Tab order), so a visible focus ring on
+     * the whole region would be noise. Suppress it — sighted keyboard users
+     * still see focus rings on the interactive controls inside.
+     */
+    outline: none;
   }
 
   /* Focus mode: collapse both the fixed top bar and the sidebar */
@@ -143,7 +233,14 @@
     display: none;
   }
 
-  .shell.focus-mode :global(nav[aria-label='Components']) {
+  /*
+   * Hide the entire fixed sidebar column — not just its <nav> — so the
+   * sticky filter input and the column's right border also disappear. The
+   * filter lives in .sidebar-chrome above the nav, so hiding only the nav
+   * would leave an orphaned 220px search box overlaying the fullscreen
+   * preview.
+   */
+  .shell.focus-mode :global(.sidebar-chrome) {
     display: none;
   }
 

--- a/packages/playground/src/shell-app/sidebar-scroll.test.ts
+++ b/packages/playground/src/shell-app/sidebar-scroll.test.ts
@@ -1,0 +1,256 @@
+/**
+ * Tests for the sidebar scroll-position persistence helper.
+ *
+ * - `readSidebarScroll` / `writeSidebarScroll` wrap `sessionStorage` access in
+ *   try/catch so a thrown access (private mode, disabled storage, quota) never
+ *   breaks scrolling. We stub `sessionStorage` at the global level per case,
+ *   mirroring how `preview-store.test.ts` stubs `localStorage`.
+ * - `persistScrollPosition` is the attachment: on attach it restores the saved
+ *   offset; on scroll it persists (debounced); on teardown it clears the timer
+ *   and removes the listener. We drive it with a fake element so we can assert
+ *   the scroll/save/restore lifecycle without a real DOM.
+ */
+
+import { afterEach, describe, expect, it } from 'bun:test';
+
+import {
+  persistScrollPosition,
+  readSidebarScroll,
+  SIDEBAR_SCROLL_STORAGE_KEY,
+  writeSidebarScroll,
+} from './sidebar-scroll.ts';
+
+type SessionStorageStub = {
+  getItem: (key: string) => string | null;
+  setItem: (key: string, value: string) => void;
+};
+
+const originalSessionStorage = (globalThis as { sessionStorage?: Storage }).sessionStorage;
+
+function installSessionStorage(stub: SessionStorageStub | undefined): void {
+  if (stub === undefined) {
+    Object.defineProperty(globalThis, 'sessionStorage', {
+      configurable: true,
+      get() {
+        throw new Error('sessionStorage unavailable');
+      },
+    });
+    return;
+  }
+  Object.defineProperty(globalThis, 'sessionStorage', {
+    configurable: true,
+    value: stub as unknown as Storage,
+    writable: true,
+  });
+}
+
+/** An in-memory sessionStorage stub backed by a Map. */
+function makeMemoryStorage(): SessionStorageStub & { store: Map<string, string> } {
+  const store = new Map<string, string>();
+  return {
+    store,
+    getItem: (key) => (store.has(key) ? (store.get(key) ?? null) : null),
+    setItem: (key, value) => {
+      store.set(key, value);
+    },
+  };
+}
+
+afterEach(() => {
+  if (originalSessionStorage === undefined) {
+    delete (globalThis as { sessionStorage?: Storage }).sessionStorage;
+  } else {
+    Object.defineProperty(globalThis, 'sessionStorage', {
+      configurable: true,
+      value: originalSessionStorage,
+      writable: true,
+    });
+  }
+});
+
+describe('readSidebarScroll', () => {
+  it('returns the stored integer offset', () => {
+    installSessionStorage({ getItem: () => '420', setItem: () => {} });
+    expect(readSidebarScroll()).toBe(420);
+  });
+
+  it('returns null when nothing is stored', () => {
+    installSessionStorage({ getItem: () => null, setItem: () => {} });
+    expect(readSidebarScroll()).toBeNull();
+  });
+
+  it('returns null when the stored value is not a number', () => {
+    installSessionStorage({ getItem: () => 'not-a-number', setItem: () => {} });
+    expect(readSidebarScroll()).toBeNull();
+  });
+
+  it('returns null for a negative stored value', () => {
+    installSessionStorage({ getItem: () => '-10', setItem: () => {} });
+    expect(readSidebarScroll()).toBeNull();
+  });
+
+  it('returns null when sessionStorage.getItem throws', () => {
+    installSessionStorage({
+      getItem: () => {
+        throw new Error('blocked');
+      },
+      setItem: () => {},
+    });
+    expect(readSidebarScroll()).toBeNull();
+  });
+
+  it('returns null when sessionStorage is not defined at all', () => {
+    installSessionStorage(undefined);
+    expect(readSidebarScroll()).toBeNull();
+  });
+});
+
+describe('writeSidebarScroll', () => {
+  it('forwards a rounded offset to sessionStorage under the scroll key', () => {
+    const calls: Array<{ key: string; value: string }> = [];
+    installSessionStorage({
+      getItem: () => null,
+      setItem: (key, value) => {
+        calls.push({ key, value });
+      },
+    });
+    writeSidebarScroll(123.7);
+    expect(calls).toEqual([{ key: SIDEBAR_SCROLL_STORAGE_KEY, value: '124' }]);
+  });
+
+  it('does not throw when sessionStorage.setItem throws', () => {
+    installSessionStorage({
+      getItem: () => null,
+      setItem: () => {
+        throw new Error('quota exceeded');
+      },
+    });
+    expect(() => writeSidebarScroll(50)).not.toThrow();
+  });
+
+  it('does not throw when sessionStorage is undefined', () => {
+    installSessionStorage(undefined);
+    expect(() => writeSidebarScroll(50)).not.toThrow();
+  });
+});
+
+/**
+ * A minimal stand-in for the scrollable sidebar element. It records added /
+ * removed listeners and lets a test fire a synthetic scroll event.
+ */
+function makeFakeScrollElement(initialScrollTop = 0): {
+  element: HTMLElement;
+  fireScroll: () => void;
+  listenerCount: () => number;
+} {
+  let scrollTop = initialScrollTop;
+  const listeners = new Set<() => void>();
+  const element = {
+    get scrollTop() {
+      return scrollTop;
+    },
+    set scrollTop(value: number) {
+      scrollTop = value;
+    },
+    addEventListener: (_type: string, handler: () => void) => {
+      listeners.add(handler);
+    },
+    removeEventListener: (_type: string, handler: () => void) => {
+      listeners.delete(handler);
+    },
+  } as unknown as HTMLElement;
+
+  return {
+    element,
+    fireScroll: () => {
+      for (const handler of listeners) handler();
+    },
+    listenerCount: () => listeners.size,
+  };
+}
+
+describe('persistScrollPosition attachment', () => {
+  it('restores the saved scroll offset on attach', () => {
+    const storage = makeMemoryStorage();
+    storage.store.set(SIDEBAR_SCROLL_STORAGE_KEY, '300');
+    installSessionStorage(storage);
+
+    const { element } = makeFakeScrollElement(0);
+    const cleanup = persistScrollPosition(element);
+
+    expect(element.scrollTop).toBe(300);
+    cleanup?.();
+  });
+
+  it('leaves scrollTop untouched when nothing is stored', () => {
+    installSessionStorage(makeMemoryStorage());
+
+    const { element } = makeFakeScrollElement(42);
+    const cleanup = persistScrollPosition(element);
+
+    expect(element.scrollTop).toBe(42);
+    cleanup?.();
+  });
+
+  it('persists the scroll offset after the debounce window elapses', async () => {
+    const storage = makeMemoryStorage();
+    installSessionStorage(storage);
+
+    const { element, fireScroll } = makeFakeScrollElement(0);
+    const cleanup = persistScrollPosition(element);
+
+    element.scrollTop = 250;
+    fireScroll();
+    // Not written synchronously — the write is debounced.
+    expect(storage.store.get(SIDEBAR_SCROLL_STORAGE_KEY)).toBeUndefined();
+
+    await Bun.sleep(200);
+    expect(storage.store.get(SIDEBAR_SCROLL_STORAGE_KEY)).toBe('250');
+    cleanup?.();
+  });
+
+  it('debounces a burst of scroll events into a single persisted write', async () => {
+    const storage = makeMemoryStorage();
+    const setCalls: string[] = [];
+    storage.setItem = (key, value) => {
+      if (key === SIDEBAR_SCROLL_STORAGE_KEY) setCalls.push(value);
+      storage.store.set(key, value);
+    };
+    installSessionStorage(storage);
+
+    const { element, fireScroll } = makeFakeScrollElement(0);
+    const cleanup = persistScrollPosition(element);
+
+    element.scrollTop = 10;
+    fireScroll();
+    element.scrollTop = 20;
+    fireScroll();
+    element.scrollTop = 30;
+    fireScroll();
+
+    await Bun.sleep(200);
+    // Only the final position is written, not one write per scroll event.
+    expect(setCalls).toEqual(['30']);
+    cleanup?.();
+  });
+
+  it('clears the pending timer and removes the listener on teardown', async () => {
+    const storage = makeMemoryStorage();
+    installSessionStorage(storage);
+
+    const { element, fireScroll, listenerCount } = makeFakeScrollElement(0);
+    const cleanup = persistScrollPosition(element);
+    expect(listenerCount()).toBe(1);
+
+    element.scrollTop = 99;
+    fireScroll();
+    cleanup?.();
+
+    // Listener gone…
+    expect(listenerCount()).toBe(0);
+
+    // …and the pending debounced write never lands after teardown.
+    await Bun.sleep(200);
+    expect(storage.store.get(SIDEBAR_SCROLL_STORAGE_KEY)).toBeUndefined();
+  });
+});

--- a/packages/playground/src/shell-app/sidebar-scroll.ts
+++ b/packages/playground/src/shell-app/sidebar-scroll.ts
@@ -1,0 +1,90 @@
+/**
+ * Sidebar scroll-position persistence.
+ *
+ * The playground shell is a single-page app: navigating between components
+ * re-renders the nav list and back/forward restores the route without
+ * remounting the scroll container, so the browser silently resets it to the
+ * top. This module saves the container's `scrollTop` to `sessionStorage` and
+ * restores it on mount so the user keeps their place in a long component list.
+ *
+ * `sessionStorage` access is wrapped in try/catch — it throws in private
+ * browsing, restricted content-script contexts, and when storage is disabled —
+ * exactly mirroring the resilience pattern in `preview-store.svelte.ts`.
+ */
+
+import type { Attachment } from 'svelte/attachments';
+
+/** Storage key under which the sidebar's `scrollTop` is persisted. */
+export const SIDEBAR_SCROLL_STORAGE_KEY = 'cinder-playground-sidebar-scroll';
+
+/**
+ * Delay before a scroll position is written to storage. Scroll fires many
+ * events per gesture; debouncing collapses the burst into a single write once
+ * the user pauses, so we never thrash `sessionStorage` mid-scroll.
+ */
+const SCROLL_PERSIST_DEBOUNCE_MS = 150;
+
+/**
+ * Read the persisted sidebar scroll offset.
+ *
+ * Returns `null` when nothing is stored, when the stored value is not a finite
+ * non-negative number, or when `sessionStorage` access throws. Callers treat
+ * `null` as "leave the scroll position untouched".
+ */
+export function readSidebarScroll(): number | null {
+  try {
+    const raw = sessionStorage.getItem(SIDEBAR_SCROLL_STORAGE_KEY);
+    if (raw === null) return null;
+    const value = Number.parseInt(raw, 10);
+    if (!Number.isFinite(value) || value < 0) return null;
+    return value;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Persist the sidebar scroll offset. Failures (private mode, disabled storage,
+ * quota) are swallowed so a blocked write never breaks scrolling.
+ */
+export function writeSidebarScroll(scrollTop: number): void {
+  try {
+    sessionStorage.setItem(SIDEBAR_SCROLL_STORAGE_KEY, String(Math.round(scrollTop)));
+  } catch {
+    /* ignore — degraded but functional */
+  }
+}
+
+/**
+ * Svelte attachment that restores the saved scroll offset on mount and writes
+ * the current offset back (debounced) whenever the element scrolls.
+ *
+ * Cleanup clears the pending debounce timer and removes the scroll listener,
+ * so teardown leaves no dangling timer or listener behind.
+ *
+ * @param element - The scrollable sidebar container.
+ * @returns A teardown function invoked when the element is removed.
+ */
+export const persistScrollPosition: Attachment<HTMLElement> = (element) => {
+  const restored = readSidebarScroll();
+  if (restored !== null) {
+    element.scrollTop = restored;
+  }
+
+  let timer: ReturnType<typeof setTimeout> | null = null;
+
+  const handleScroll = (): void => {
+    if (timer !== null) clearTimeout(timer);
+    timer = setTimeout(() => {
+      timer = null;
+      writeSidebarScroll(element.scrollTop);
+    }, SCROLL_PERSIST_DEBOUNCE_MS);
+  };
+
+  element.addEventListener('scroll', handleScroll, { passive: true });
+
+  return () => {
+    if (timer !== null) clearTimeout(timer);
+    element.removeEventListener('scroll', handleScroll);
+  };
+};

--- a/packages/playground/src/shell-app/sidebar.svelte
+++ b/packages/playground/src/shell-app/sidebar.svelte
@@ -1,6 +1,23 @@
+<script lang="ts" module>
+  /**
+   * Imperative handle a parent obtains via `bind:this`. Naming the exported API
+   * surface explicitly (rather than relying on `ReturnType<typeof Sidebar>`,
+   * which resolves to Svelte's opaque internal component type) keeps the
+   * binding's type tied to what the component actually exports.
+   */
+  export type SidebarHandle = { focusFilter(): void };
+</script>
+
 <script lang="ts">
-  import { SideNavigation, SideNavigationItem } from '../../../components/src/index.ts';
+  import {
+    Input,
+    SideNavigation,
+    SideNavigationItem,
+    VisuallyHidden,
+  } from '../../../components/src/index.ts';
+  import { humanizeComponentName } from './humanize.ts';
   import { buildShellHref } from './routing.ts';
+  import { persistScrollPosition } from './sidebar-scroll.ts';
 
   type Props = {
     components: string[];
@@ -9,6 +26,38 @@
   };
 
   let { components, currentComponent, onSelect }: Props = $props();
+
+  let filter = $state('');
+
+  // The cinder Input owns its native <input> and does not forward a ref, so
+  // the focus handle resolves the element by its stable id. The id is unique
+  // to this single sidebar instance.
+  const FILTER_INPUT_ID = 'sidebar-filter';
+
+  /** Focus and select the filter text. Exposed for the `/` keyboard shortcut. */
+  export function focusFilter(): void {
+    const element = document.getElementById(FILTER_INPUT_ID);
+    if (element instanceof HTMLInputElement) {
+      element.focus();
+      element.select();
+    }
+  }
+
+  // Case-insensitive substring match against both the humanized label and the
+  // raw kebab name, so "side nav" and "side-nav" both find side-navigation.
+  const visibleComponents = $derived.by(() => {
+    const needle = filter.trim().toLowerCase();
+    if (needle === '') return components;
+    return components.filter((name) => {
+      if (name.toLowerCase().includes(needle)) return true;
+      return humanizeComponentName(name).toLowerCase().includes(needle);
+    });
+  });
+
+  // Announced to assistive technology whenever the filtered count changes.
+  const resultSummary = $derived(
+    `${visibleComponents.length} component${visibleComponents.length === 1 ? '' : 's'} shown`,
+  );
 
   function handleClick(event: MouseEvent, componentName: string): void {
     // Only intercept plain left-clicks. Modified clicks (cmd/ctrl/shift/alt)
@@ -20,32 +69,67 @@
     event.preventDefault();
     onSelect(componentName);
   }
+
+  function handleFilterKeydown(event: KeyboardEvent): void {
+    // Escape clears the filter (and keeps focus so typing can resume).
+    if (event.key === 'Escape' && filter !== '') {
+      event.preventDefault();
+      // Stop the shell's window-level Escape handler from also acting on this
+      // keystroke (e.g. exiting focus mode) when the user only meant to clear
+      // the filter.
+      event.stopPropagation();
+      filter = '';
+    }
+  }
 </script>
 
 <!--
   The top bar is fixed and 52px tall. The sidebar is also fixed but its
   top edge starts below the top bar so it never overlaps the wordmark or
-  toolbar controls. The height and top values reference the same
-  --cinder-top-bar-height token that the top bar declares.
+  toolbar controls. The height and top values reference the shared
+  --cinder-top-bar-height token, declared once on :root by render-shell.ts.
 -->
-<div class="sidebar-chrome">
+<div class="sidebar-chrome" {@attach persistScrollPosition}>
+  <div class="sidebar-filter">
+    <Input
+      id={FILTER_INPUT_ID}
+      type="search"
+      bind:value={filter}
+      placeholder="Filter components…"
+      aria-label="Filter components"
+      autocomplete="off"
+      autocapitalize="off"
+      spellcheck={false}
+      onkeydown={handleFilterKeydown}
+    />
+  </div>
   <SideNavigation ariaLabel="Components">
-    {#each components as name (name)}
+    {#each visibleComponents as name (name)}
       <SideNavigationItem
         href={buildShellHref(name)}
         active={name === currentComponent}
         onclick={(event) => handleClick(event, name)}
       >
-        {name}
+        {humanizeComponentName(name)}
       </SideNavigationItem>
     {/each}
   </SideNavigation>
+  {#if visibleComponents.length === 0}
+    <!-- Visible text only — NOT a live region. The persistent aria-live region
+         below ("N components shown") is the single announcement source; marking
+         this paragraph role="status" too would double-announce on zero results. -->
+    <p class="sidebar-empty">No components match “{filter}”.</p>
+  {/if}
+  <!--
+    Always-present polite live region. Kept outside the {#if} above so it
+    stays in the DOM across filter changes — that is what lets screen
+    readers announce the updated count on every keystroke (WCAG 4.1.3).
+  -->
+  <VisuallyHidden as="p" aria-live="polite" aria-atomic="true">{resultSummary}</VisuallyHidden>
 </div>
 
 <style>
   .sidebar-chrome {
-    --cinder-top-bar-height: 52px;
-
     /* stylelint-disable-next-line csstools/use-logical */
     width: 220px;
     min-width: 220px;
@@ -60,5 +144,21 @@
     /* stylelint-disable-next-line csstools/use-logical */
     border-right: 1px solid var(--cinder-border);
     overflow-y: auto;
+  }
+
+  .sidebar-filter {
+    position: sticky;
+    top: 0;
+    z-index: 1;
+    padding: var(--cinder-space-2, 0.5rem);
+    background: var(--cinder-surface);
+    border-bottom: 1px solid var(--cinder-border);
+  }
+
+  .sidebar-empty {
+    margin: 0;
+    padding: var(--cinder-space-3, 0.75rem) var(--cinder-space-2, 0.5rem);
+    color: var(--cinder-text-muted, var(--cinder-text));
+    font-size: var(--cinder-text-sm, 0.875rem);
   }
 </style>

--- a/packages/playground/src/shell-app/sidebar.test.ts
+++ b/packages/playground/src/shell-app/sidebar.test.ts
@@ -1,0 +1,315 @@
+/// <reference lib="dom" />
+/**
+ * Render tests for the playground sidebar.
+ *
+ * Two contracts are covered:
+ *  - the search/filter behavior end-to-end through the real cinder `Input` and
+ *    `SideNavigation` components: the list renders humanized labels, typing
+ *    narrows the visible items (matching humanized and raw names), an empty
+ *    result shows a message, and Escape clears the filter. The accessibility
+ *    wiring is asserted too — a single persistent polite live region announces
+ *    the filtered count (the visible empty message is plain text, not a second
+ *    live region, so zero-result navigations announce exactly once).
+ *  - the STABLE onSelect contract: a plain left-click selects, while
+ *    modified/middle clicks fall through to native navigation. These target the
+ *    onSelect callback rather than incidental DOM structure so they survive
+ *    sibling refactors of `sidebar.svelte`.
+ *
+ * happy-dom is installed via `setupHappyDom()` (also done by the bunfig
+ * preload) before `@testing-library/svelte` loads, mirroring the
+ * components-package test convention.
+ */
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+
+import { setupHappyDom } from '../../../components/src/test/happy-dom.ts';
+
+setupHappyDom();
+
+const { render, fireEvent, cleanup } = await import('@testing-library/svelte');
+const { default: Sidebar } = await import('./sidebar.svelte');
+const { tick } = await import('svelte');
+
+// Unmount every rendered tree between tests. These tests do not unmount each
+// render individually, so without cleanup each render leaves its `#sidebar-filter`
+// in the shared happy-dom document body. The `focusFilter()` test resolves the
+// input via `document.getElementById(FILTER_INPUT_ID)`, which would otherwise
+// return a STALE input from a prior render and break the focus assertion once
+// the whole suite runs in one process.
+afterEach(() => {
+  cleanup();
+});
+
+const COMPONENTS = ['button', 'tag-input', 'json-schema-editor', 'card'];
+
+function navItemLabels(container: HTMLElement): string[] {
+  return [...container.querySelectorAll('nav[aria-label="Components"] a')].map((node) =>
+    (node.textContent ?? '').trim(),
+  );
+}
+
+function getFilterInput(container: HTMLElement): HTMLInputElement {
+  const input = container.querySelector<HTMLInputElement>('#sidebar-filter');
+  if (input === null) throw new Error('filter input not found');
+  return input;
+}
+
+function getLiveRegion(container: HTMLElement): HTMLElement {
+  const region = container.querySelector<HTMLElement>('[aria-live="polite"]');
+  if (region === null) throw new Error('live region not found');
+  return region;
+}
+
+/**
+ * Find the sidebar nav link for a component name. The sidebar renders each
+ * entry as an anchor whose href is `/c/<name>` (built by `buildShellHref`), so
+ * we select on that stable contract rather than on text or class names.
+ */
+function linkFor(container: HTMLElement, name: string): HTMLAnchorElement {
+  const anchor = container.querySelector<HTMLAnchorElement>(`a[href="/c/${name}"]`);
+  if (anchor === null) throw new Error(`No sidebar link found for "${name}"`);
+  return anchor;
+}
+
+/**
+ * Dispatch a click with the given modifiers. We build the event manually so we
+ * can set `button` and modifier keys, then dispatch it on the anchor. A default
+ * cancelable click lets us also assert `preventDefault` was called.
+ */
+function dispatchClick(
+  element: Element,
+  init: {
+    button?: number;
+    metaKey?: boolean;
+    ctrlKey?: boolean;
+    shiftKey?: boolean;
+    altKey?: boolean;
+  } = {},
+): MouseEvent {
+  const event = new MouseEvent('click', {
+    bubbles: true,
+    cancelable: true,
+    button: init.button ?? 0,
+    metaKey: init.metaKey ?? false,
+    ctrlKey: init.ctrlKey ?? false,
+    shiftKey: init.shiftKey ?? false,
+    altKey: init.altKey ?? false,
+  });
+  element.dispatchEvent(event);
+  return event;
+}
+
+describe('Sidebar', () => {
+  test('renders every component as a humanized label', () => {
+    const { container } = render(Sidebar, {
+      props: { components: COMPONENTS, currentComponent: 'button', onSelect: () => {} },
+    });
+    expect(navItemLabels(container)).toEqual(['Button', 'Tag Input', 'JSON Schema Editor', 'Card']);
+  });
+
+  test('keeps the raw kebab name in the item href', () => {
+    const { container } = render(Sidebar, {
+      props: { components: COMPONENTS, currentComponent: 'button', onSelect: () => {} },
+    });
+    const hrefs = [...container.querySelectorAll('nav[aria-label="Components"] a')].map((node) =>
+      node.getAttribute('href'),
+    );
+    expect(hrefs).toContain('/c/json-schema-editor');
+    expect(hrefs).toContain('/c/tag-input');
+  });
+
+  test('filter narrows the list by humanized name (case-insensitive)', async () => {
+    const { container } = render(Sidebar, {
+      props: { components: COMPONENTS, currentComponent: 'button', onSelect: () => {} },
+    });
+    await fireEvent.input(getFilterInput(container), { target: { value: 'schema' } });
+    await tick();
+    expect(navItemLabels(container)).toEqual(['JSON Schema Editor']);
+  });
+
+  test('filter matches the acronym in the humanized name', async () => {
+    const { container } = render(Sidebar, {
+      props: { components: COMPONENTS, currentComponent: 'button', onSelect: () => {} },
+    });
+    await fireEvent.input(getFilterInput(container), { target: { value: 'json' } });
+    await tick();
+    expect(navItemLabels(container)).toEqual(['JSON Schema Editor']);
+  });
+
+  test('filter matches the raw kebab name', async () => {
+    const { container } = render(Sidebar, {
+      props: { components: COMPONENTS, currentComponent: 'button', onSelect: () => {} },
+    });
+    await fireEvent.input(getFilterInput(container), { target: { value: 'tag-input' } });
+    await tick();
+    expect(navItemLabels(container)).toEqual(['Tag Input']);
+  });
+
+  test('shows an empty-state message when nothing matches', async () => {
+    const { container } = render(Sidebar, {
+      props: { components: COMPONENTS, currentComponent: 'button', onSelect: () => {} },
+    });
+    await fireEvent.input(getFilterInput(container), { target: { value: 'zzz-no-match' } });
+    await tick();
+    expect(navItemLabels(container)).toEqual([]);
+    // The visible empty-state paragraph is plain text — NOT a live region.
+    // Announcing zero results is the job of the persistent aria-live region
+    // below it (asserted separately); marking this paragraph role="status" too
+    // would double-announce.
+    const message = container.querySelector('.sidebar-empty');
+    expect(message?.getAttribute('role')).toBeNull();
+    expect(message?.textContent).toContain('No components match');
+    // The single live region carries the count for assistive tech.
+    const liveRegion = container.querySelector('[aria-live="polite"]');
+    expect(liveRegion?.textContent).toContain('0 components shown');
+  });
+
+  test('Escape clears the filter and restores the full list', async () => {
+    const { container } = render(Sidebar, {
+      props: { components: COMPONENTS, currentComponent: 'button', onSelect: () => {} },
+    });
+    const input = getFilterInput(container);
+    await fireEvent.input(input, { target: { value: 'schema' } });
+    await tick();
+    expect(navItemLabels(container)).toEqual(['JSON Schema Editor']);
+
+    await fireEvent.keyDown(input, { key: 'Escape' });
+    await tick();
+    expect(input.value).toBe('');
+    expect(navItemLabels(container)).toEqual(['Button', 'Tag Input', 'JSON Schema Editor', 'Card']);
+  });
+
+  test('focusFilter() focuses and selects the filter input', async () => {
+    const { container, component } = render(Sidebar, {
+      props: { components: COMPONENTS, currentComponent: 'button', onSelect: () => {} },
+    });
+    const input = getFilterInput(container);
+    component['focusFilter']();
+    await tick();
+    expect(container.ownerDocument.activeElement).toBe(input);
+  });
+
+  test('a persistent polite live region announces the filtered count', async () => {
+    const { container } = render(Sidebar, {
+      props: { components: COMPONENTS, currentComponent: 'button', onSelect: () => {} },
+    });
+    const region = getLiveRegion(container);
+    expect(region.getAttribute('aria-atomic')).toBe('true');
+    expect((region.textContent ?? '').trim()).toBe('4 components shown');
+
+    // The region stays in the DOM and updates to a narrowed plural count.
+    await fireEvent.input(getFilterInput(container), { target: { value: 'a' } });
+    await tick();
+    const narrowed = navItemLabels(container).length;
+    expect((getLiveRegion(container).textContent ?? '').trim()).toBe(
+      `${narrowed} components shown`,
+    );
+
+    // Singular grammar when exactly one component matches.
+    await fireEvent.input(getFilterInput(container), { target: { value: 'schema' } });
+    await tick();
+    expect((getLiveRegion(container).textContent ?? '').trim()).toBe('1 component shown');
+
+    // The region survives an empty result instead of unmounting.
+    await fireEvent.input(getFilterInput(container), { target: { value: 'zzz-no-match' } });
+    await tick();
+    expect((getLiveRegion(container).textContent ?? '').trim()).toBe('0 components shown');
+  });
+});
+
+const ONSELECT_COMPONENTS = ['avatar', 'button', 'card'];
+
+describe('sidebar onSelect contract', () => {
+  let selected: string[];
+  let onSelect: (name: string) => void;
+
+  beforeEach(() => {
+    selected = [];
+    onSelect = (name: string) => {
+      selected.push(name);
+    };
+  });
+
+  test('plain left-click calls onSelect with the clicked component name', async () => {
+    const { container } = render(Sidebar, {
+      components: ONSELECT_COMPONENTS,
+      currentComponent: 'avatar',
+      onSelect,
+    });
+    await tick();
+
+    const event = dispatchClick(linkFor(container, 'button'));
+
+    expect(selected).toEqual(['button']);
+    expect(event.defaultPrevented).toBe(true);
+  });
+
+  test('clicking different entries reports the right name each time', async () => {
+    const { container } = render(Sidebar, {
+      components: ONSELECT_COMPONENTS,
+      currentComponent: 'avatar',
+      onSelect,
+    });
+    await tick();
+
+    dispatchClick(linkFor(container, 'card'));
+    dispatchClick(linkFor(container, 'avatar'));
+
+    expect(selected).toEqual(['card', 'avatar']);
+  });
+
+  test('metaKey (cmd) click does NOT call onSelect', async () => {
+    const { container } = render(Sidebar, {
+      components: ONSELECT_COMPONENTS,
+      currentComponent: 'avatar',
+      onSelect,
+    });
+    await tick();
+
+    const event = dispatchClick(linkFor(container, 'button'), { metaKey: true });
+
+    expect(selected).toEqual([]);
+    expect(event.defaultPrevented).toBe(false);
+  });
+
+  test('ctrlKey click does NOT call onSelect', async () => {
+    const { container } = render(Sidebar, {
+      components: ONSELECT_COMPONENTS,
+      currentComponent: 'avatar',
+      onSelect,
+    });
+    await tick();
+
+    const event = dispatchClick(linkFor(container, 'button'), { ctrlKey: true });
+
+    expect(selected).toEqual([]);
+    expect(event.defaultPrevented).toBe(false);
+  });
+
+  test('shiftKey and altKey clicks do NOT call onSelect', async () => {
+    const { container } = render(Sidebar, {
+      components: ONSELECT_COMPONENTS,
+      currentComponent: 'avatar',
+      onSelect,
+    });
+    await tick();
+
+    dispatchClick(linkFor(container, 'button'), { shiftKey: true });
+    dispatchClick(linkFor(container, 'button'), { altKey: true });
+
+    expect(selected).toEqual([]);
+  });
+
+  test('middle-click (button 1) does NOT call onSelect', async () => {
+    const { container } = render(Sidebar, {
+      components: ONSELECT_COMPONENTS,
+      currentComponent: 'avatar',
+      onSelect,
+    });
+    await tick();
+
+    const event = dispatchClick(linkFor(container, 'button'), { button: 1 });
+
+    expect(selected).toEqual([]);
+    expect(event.defaultPrevented).toBe(false);
+  });
+});

--- a/packages/playground/src/shell-app/top-bar-fixture.svelte
+++ b/packages/playground/src/shell-app/top-bar-fixture.svelte
@@ -1,0 +1,41 @@
+<script lang="ts" module>
+  import type { PreviewStore } from './preview-store.svelte.ts';
+
+  export type TopBarFixtureProps = {
+    /**
+     * The store instance to install on the context before mounting the bar.
+     * When omitted, the fixture constructs one seeded with `currentComponent`.
+     */
+    store?: PreviewStore;
+    /**
+     * Seed value for the store's `currentComponent` when no `store` is passed.
+     * Lets tests that only care about the selected component name render the
+     * bar without constructing a store themselves.
+     */
+    currentComponent?: string;
+  };
+</script>
+
+<script lang="ts">
+  import Announcer from './announcer.svelte';
+  import { Announcer as AnnouncerStore, setAnnouncer } from './announcer.svelte.ts';
+  import { PreviewStore as PreviewStoreClass, setPreviewStore } from './preview-store.svelte.ts';
+  import TopBar from './top-bar.svelte';
+
+  let { store, currentComponent = '' }: TopBarFixtureProps = $props();
+
+  // top-bar.svelte reads the store via `getPreviewStore()` and the announcer via
+  // `getAnnouncer()`, both of which throw if nothing is installed on the
+  // context. Install a store (the caller's, or one seeded from currentComponent)
+  // and a real Announcer before mounting — mirroring how `shell.svelte` wires
+  // the real shell — and render the Announcer's single live region so tests can
+  // observe announcements.
+  const resolvedStore = store ?? new PreviewStoreClass(currentComponent);
+  setPreviewStore(resolvedStore);
+
+  const announcer = new AnnouncerStore();
+  setAnnouncer(announcer);
+</script>
+
+<TopBar />
+<Announcer />

--- a/packages/playground/src/shell-app/top-bar.svelte
+++ b/packages/playground/src/shell-app/top-bar.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
+  import { getAnnouncer } from './announcer.svelte.ts';
   import type { BackgroundChoice, ThemeChoice } from './preview-store.svelte.ts';
   import { getPreviewStore } from './preview-store.svelte.ts';
+  import { buildIframeSrc } from './routing.ts';
   import {
     Button,
     NumberInput,
@@ -10,6 +12,14 @@
   } from '../../../components/src/index.ts';
 
   const store = getPreviewStore();
+  const announcer = getAnnouncer();
+
+  // Forward toolbar feedback to the shell's single shared live region. The
+  // empty-then-set coalescing trick (so identical repeats still read) lives
+  // in the Announcer; see announcer.svelte.ts.
+  function announce(text: string): void {
+    announcer.announce(text);
+  }
 
   // ── Viewport presets ──────────────────────────────────────────────────────
   // SegmentedControl requires string values. Numeric preset widths are keyed
@@ -93,22 +103,19 @@
     announce(store.isFocusMode ? 'Focus mode on. Press Escape to exit.' : 'Focus mode off');
   }
 
-  // ── Announcements ─────────────────────────────────────────────────────────
-  // Empty-then-set with a 50 ms gap forces the aria-live region to emit a DOM
-  // mutation even when the same string is announced twice in a row. Without
-  // the gap the Svelte runtime coalesces identical consecutive assignments into
-  // a no-op and assistive technology never reads the second announcement.
+  // ── Open in new tab ───────────────────────────────────────────────────────
+  // Opens the isolated /page/:name route in a fresh tab. The button is hidden
+  // when no component is selected so we never open a /page/ URL with an empty
+  // name. `noopener` severs the new tab's `window.opener` reference for safety.
 
-  let announcement = $state<string>('');
-  let announceTimeout: ReturnType<typeof setTimeout> | null = null;
-
-  function announce(text: string): void {
-    if (announceTimeout !== null) clearTimeout(announceTimeout);
-    announcement = '';
-    announceTimeout = setTimeout(() => {
-      announcement = text;
-      announceTimeout = null;
-    }, 50);
+  function openInNewTab(): void {
+    if (store.currentComponent === '') return;
+    // Reuse buildIframeSrc so the component name is encodeURIComponent-escaped
+    // exactly like every other /page/:name URL the shell builds (and like the
+    // preview-frame tests assert), then make it absolute for window.open.
+    const url = `${window.location.origin}${buildIframeSrc(store.currentComponent)}`;
+    window.open(url, '_blank', 'noopener');
+    announce(`Opened ${store.currentComponent} preview in a new tab`);
   }
 </script>
 
@@ -181,6 +188,17 @@
     <Toolbar.Spacer />
 
     <Toolbar.Group>
+      {#if store.currentComponent !== ''}
+        <Button
+          variant="ghost"
+          size="sm"
+          aria-label="Open preview in new tab"
+          onclick={openInNewTab}
+        >
+          <span aria-hidden="true">↗</span>
+        </Button>
+      {/if}
+
       <Button
         variant="ghost"
         size="sm"
@@ -192,8 +210,6 @@
       </Button>
     </Toolbar.Group>
   </Toolbar>
-
-  <span class="sr-only" aria-live="polite" aria-atomic="true">{announcement}</span>
 </header>
 
 <style>
@@ -208,12 +224,10 @@
 
   .top-bar {
     /*
-     * Canonical height token used by shell.svelte for the sidebar's top
-     * offset. Keep them in sync — shell.svelte reads this custom property
-     * via var(--cinder-top-bar-height) on the <main> element.
+     * Height reads from the shared --cinder-top-bar-height token, declared
+     * once on :root by render-shell.ts. The sidebar and main column reference
+     * the same token for their top offset, so all three stay in sync.
      */
-    --cinder-top-bar-height: 52px;
-
     box-sizing: border-box;
     height: var(--cinder-top-bar-height);
     background: var(--cinder-surface);
@@ -301,18 +315,5 @@
     color: var(--cinder-text-subtle);
     padding-inline-start: 3px;
     flex-shrink: 0;
-  }
-
-  /* ── Accessibility ── */
-  .sr-only {
-    position: absolute;
-    width: 1px;
-    height: 1px;
-    padding: 0;
-    margin: -1px;
-    overflow: hidden;
-    clip: rect(0, 0, 0, 0);
-    white-space: nowrap;
-    border: 0;
   }
 </style>

--- a/packages/playground/src/shell-app/top-bar.test.ts
+++ b/packages/playground/src/shell-app/top-bar.test.ts
@@ -1,0 +1,212 @@
+/// <reference lib="dom" />
+/**
+ * DOM-mount tests for `top-bar.svelte`.
+ *
+ * Setup mirrors `event-source.test.ts`: happy-dom globals are installed onto
+ * `globalThis` before `@testing-library/svelte` loads so component mount has a
+ * working DOM. `top-bar.svelte` reads the shared store via `getPreviewStore()`
+ * and the announcer via `getAnnouncer()`, so we mount it through
+ * `top-bar-fixture.svelte`, which installs a real `PreviewStore` and `Announcer`
+ * on the context first.
+ *
+ * Two contracts are covered:
+ *  - the "Open in new tab" button calls `window.open` with the isolated
+ *    `/page/` URL and is absent when no component is selected;
+ *  - the theme SegmentedControl routes through `store.setTheme` (never a direct
+ *    `store.theme` assignment) and `announce()` populates the shared `aria-live`
+ *    region after the deliberate 50 ms empty-then-set gap.
+ * They avoid incidental structure (class names, element ordering) so sibling
+ * refactors of `top-bar.svelte` don't break them.
+ */
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+
+import { setupHappyDom } from '../../../components/src/test/happy-dom.ts';
+
+// Install happy-dom globals via the shared, idempotent helper BEFORE
+// dynamic-importing @testing-library/svelte. Using the single shared window
+// (rather than a private `new Window()`) keeps this file's globals consistent
+// with the other shell-app DOM tests when the whole suite runs in one process —
+// competing window installs leak `document`/`activeElement` across files and
+// make focus assertions flaky.
+setupHappyDom();
+
+const happyWindow = window as unknown as typeof globalThis & Window;
+// The open-in-new-tab button reads `window.location.origin`; resolve the shared
+// window's origin so the URL assertion is correct regardless of its default URL.
+const ORIGIN = happyWindow.location.origin;
+
+const { render } = await import('@testing-library/svelte');
+const { default: TopBarFixture } = await import('./top-bar-fixture.svelte');
+const { PreviewStore } = await import('./preview-store.svelte.ts');
+const { tick } = await import('svelte');
+
+type ThemeChoice = import('./preview-store.svelte.ts').ThemeChoice;
+
+type OpenCall = { url: string | URL; targetName: string | undefined; features: string | undefined };
+
+let openCalls: OpenCall[] = [];
+
+beforeEach(() => {
+  openCalls = [];
+  Object.defineProperty(happyWindow, 'open', {
+    configurable: true,
+    writable: true,
+    value: (url: string | URL, targetName?: string, features?: string) => {
+      openCalls.push({ url, targetName, features });
+      return null;
+    },
+  });
+});
+
+afterEach(() => {
+  delete (happyWindow as unknown as Record<string, unknown>)['open'];
+});
+
+/** Resolve after `ms` real milliseconds — `announce()` uses a 50 ms timer. */
+function wait(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Find a `<button>` by its trimmed visible text. The theme segments render as
+ * buttons whose text is the option label ("Light theme", etc.) and the toolbar
+ * action buttons carry a stable `aria-label` — both are accessible, stable
+ * selectors rather than incidental markup.
+ */
+function buttonByText(container: HTMLElement, text: string): HTMLButtonElement {
+  const buttons = [...container.querySelectorAll<HTMLButtonElement>('button')];
+  const match = buttons.find((button) => button.textContent?.trim() === text);
+  if (!match) throw new Error(`No button with text "${text}"`);
+  return match;
+}
+
+function buttonByLabel(container: HTMLElement, label: string): HTMLButtonElement {
+  const button = container.querySelector<HTMLButtonElement>(`button[aria-label="${label}"]`);
+  if (button === null) throw new Error(`No button with aria-label "${label}"`);
+  return button;
+}
+
+/** The single polite aria-live announcement region rendered by the shell. */
+function liveRegion(container: HTMLElement): HTMLElement {
+  const region = container.querySelector<HTMLElement>('[aria-live="polite"]');
+  if (region === null) throw new Error('No aria-live region found');
+  return region;
+}
+
+describe('top-bar open-in-new-tab button', () => {
+  test('renders the button when a component is selected', async () => {
+    const { container, unmount } = render(TopBarFixture, { currentComponent: 'button' });
+    await tick();
+    const button = container.querySelector('button[aria-label="Open preview in new tab"]');
+    expect(button).not.toBeNull();
+    unmount();
+  });
+
+  test('does not render the button when no component is selected', async () => {
+    const { container, unmount } = render(TopBarFixture, { currentComponent: '' });
+    await tick();
+    const button = container.querySelector('button[aria-label="Open preview in new tab"]');
+    expect(button).toBeNull();
+    unmount();
+  });
+
+  test('clicking the button calls window.open with the isolated /page/ URL', async () => {
+    const { container, unmount } = render(TopBarFixture, { currentComponent: 'accordion' });
+    await tick();
+
+    const button = container.querySelector<HTMLButtonElement>(
+      'button[aria-label="Open preview in new tab"]',
+    );
+    expect(button).not.toBeNull();
+
+    button?.click();
+    await tick();
+
+    expect(openCalls.length).toBe(1);
+    expect(openCalls[0]?.url).toBe(`${ORIGIN}/page/accordion`);
+    expect(openCalls[0]?.targetName).toBe('_blank');
+    expect(openCalls[0]?.features).toBe('noopener');
+    unmount();
+  });
+});
+
+describe('top-bar theme selection', () => {
+  test('selecting a theme segment routes through store.setTheme', async () => {
+    const store = new PreviewStore('button');
+    const themeCalls: ThemeChoice[] = [];
+    // Spy on the public write path. The top bar must call setTheme (which also
+    // persists + applies color-scheme), never assign store.theme directly.
+    store.setTheme = (value: ThemeChoice) => {
+      themeCalls.push(value);
+    };
+
+    const { container } = render(TopBarFixture, { store });
+    await tick();
+
+    buttonByText(container as HTMLElement, 'Dark theme').click();
+    await tick();
+
+    expect(themeCalls).toEqual(['dark']);
+  });
+
+  test('selecting the light theme segment passes "light" to setTheme', async () => {
+    const store = new PreviewStore('button');
+    const themeCalls: ThemeChoice[] = [];
+    store.setTheme = (value: ThemeChoice) => {
+      themeCalls.push(value);
+    };
+
+    const { container } = render(TopBarFixture, { store });
+    await tick();
+
+    buttonByText(container as HTMLElement, 'Light theme').click();
+    await tick();
+
+    expect(themeCalls).toEqual(['light']);
+  });
+});
+
+describe('top-bar announcements', () => {
+  test('aria-live region is empty until the 50 ms gap elapses, then carries the message', async () => {
+    const store = new PreviewStore('button');
+    const { container } = render(TopBarFixture, { store });
+    await tick();
+
+    const region = liveRegion(container as HTMLElement);
+    expect(region.textContent?.trim()).toBe('');
+
+    // Toggling the checkerboard button triggers announce(). The 50 ms
+    // empty-then-set gap means the message is NOT yet present right after.
+    buttonByLabel(container as HTMLElement, 'Show transparency grid').click();
+    await tick();
+    expect(region.textContent?.trim()).toBe('');
+
+    // After the gap, the announcement text appears.
+    await wait(80);
+    await tick();
+    expect(region.textContent?.trim()).toBe('Checkerboard background on');
+  });
+
+  test('a second announcement replaces the first after its own 50 ms gap', async () => {
+    const store = new PreviewStore('button');
+    const { container } = render(TopBarFixture, { store });
+    await tick();
+
+    const region = liveRegion(container as HTMLElement);
+
+    buttonByLabel(container as HTMLElement, 'Show transparency grid').click();
+    await wait(80);
+    await tick();
+    expect(region.textContent?.trim()).toBe('Checkerboard background on');
+
+    // Toggle again — off this time. The region clears immediately, then fills
+    // with the new message after the gap.
+    buttonByLabel(container as HTMLElement, 'Show transparency grid').click();
+    await tick();
+    expect(region.textContent?.trim()).toBe('');
+
+    await wait(80);
+    await tick();
+    expect(region.textContent?.trim()).toBe('Checkerboard background off');
+  });
+});

--- a/packages/playground/src/validate-playground.test.ts
+++ b/packages/playground/src/validate-playground.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'bun:test';
+
+import { classifyExampleTitle, readExampleTitle } from './validate-playground.ts';
+
+const moduleScript = (body: string): string =>
+  `<script lang="ts" module>\n${body}\n</script>\n\n<script lang="ts"></script>\n`;
+
+describe('readExampleTitle', () => {
+  it('reads a single-quoted title', () => {
+    expect(readExampleTitle(moduleScript(`export const title = 'Basic usage';`))).toBe(
+      'Basic usage',
+    );
+  });
+
+  it('reads a double-quoted title', () => {
+    expect(readExampleTitle(moduleScript(`export const title = "Basic usage";`))).toBe(
+      'Basic usage',
+    );
+  });
+
+  it('reads a backtick (template literal) title', () => {
+    expect(readExampleTitle(moduleScript('export const title = `Basic usage`;'))).toBe(
+      'Basic usage',
+    );
+  });
+
+  it('returns null when no exported title exists', () => {
+    expect(readExampleTitle(moduleScript(`export const description = 'no title here';`))).toBeNull();
+  });
+
+  it('does not match a non-exported const title', () => {
+    expect(readExampleTitle(moduleScript(`const title = 'local only';`))).toBeNull();
+  });
+});
+
+describe('classifyExampleTitle', () => {
+  it('classifies a present title as ok', () => {
+    expect(classifyExampleTitle(moduleScript(`export const title = 'Real Title';`))).toBe('ok');
+  });
+
+  it('classifies a missing title export as missing', () => {
+    expect(classifyExampleTitle(moduleScript(`export const description = 'x';`))).toBe('missing');
+    expect(classifyExampleTitle('')).toBe('missing');
+  });
+
+  it('classifies the Untitled placeholder as untitled', () => {
+    expect(classifyExampleTitle(moduleScript(`export const title = 'Untitled';`))).toBe('untitled');
+    expect(classifyExampleTitle(moduleScript(`export const title = "Untitled";`))).toBe('untitled');
+  });
+
+  it('does not treat a non-exported Untitled const as the placeholder', () => {
+    // No exported title at all → missing, not untitled.
+    expect(classifyExampleTitle(moduleScript(`const title = 'Untitled';`))).toBe('missing');
+  });
+});

--- a/packages/playground/src/validate-playground.ts
+++ b/packages/playground/src/validate-playground.ts
@@ -12,6 +12,8 @@
  * Exit 0 on success, non-zero with a descriptive error on failure.
  */
 
+import { join } from 'node:path';
+
 import { discoverComponents } from './discover.ts';
 import { type PlaygroundServer, PORT, startServer, triggerReload } from './server.ts';
 
@@ -27,7 +29,75 @@ function fail(message: string): never {
 }
 
 /** Minimum number of public components expected in src/components/. */
-const MINIMUM_COMPONENT_COUNT = 21;
+const MINIMUM_COMPONENT_COUNT = 80;
+
+// Title-presence check for `.example.svelte` files. SELF-CONTAINED on purpose:
+// this duplicates a tiny title regex rather than importing from
+// `example-metadata.ts`/`server.ts` so the build-time gate has no coupling to
+// the runtime server module (importing server.ts would also auto-wire its
+// import.meta.main guard expectations into this validator's dependency graph).
+
+/** The sentinel a missing title falls back to; an explicit one is rejected too. */
+const UNTITLED_SENTINEL = 'Untitled';
+
+// Matches `export const title = '…' | "…" | `…``. Mirrors the runtime extractor:
+// a same-quote backreference close and `\\.` to skip escaped quotes inside the
+// literal. Interpolated template literals are intentionally not parsed — titles
+// must be plain string literals.
+const TITLE_PATTERN = /export\s+const\s+title\s*=\s*(['"`])((?:[^\\]|\\.)*?)\1/;
+
+/**
+ * Read the `export const title` string literal from example source, or `null`
+ * when the file declares no exported title. Pure — no I/O. Exported for tests.
+ */
+export function readExampleTitle(source: string): string | null {
+  const match = source.match(TITLE_PATTERN);
+  return match ? (match[2] ?? '') : null;
+}
+
+/**
+ * Classify an example's title: `'ok'` when a real title is present, `'missing'`
+ * when no exported title exists, `'untitled'` when it is the `'Untitled'`
+ * sentinel. Pure — no I/O. Exported for tests.
+ */
+export function classifyExampleTitle(source: string): 'ok' | 'missing' | 'untitled' {
+  const title = readExampleTitle(source);
+  if (title === null) return 'missing';
+  if (title === UNTITLED_SENTINEL) return 'untitled';
+  return 'ok';
+}
+
+/**
+ * Scan every `.example.svelte` file and fail when any is missing a `title`
+ * export or uses the `'Untitled'` sentinel. Reports the count of checked files.
+ */
+async function validateExampleTitles(examplesRoot: string): Promise<void> {
+  process.stdout.write('[validate:playground] checking example titles…\n');
+
+  const offenders: string[] = [];
+  let checked = 0;
+  const glob = new Bun.Glob('**/*.example.svelte');
+  for await (const relativePath of glob.scan({ cwd: examplesRoot })) {
+    checked += 1;
+    const filePath = join(examplesRoot, relativePath);
+    const source = await Bun.file(filePath).text();
+    const verdict = classifyExampleTitle(source);
+    if (verdict === 'missing') {
+      offenders.push(`${relativePath} — missing \`export const title\``);
+    } else if (verdict === 'untitled') {
+      offenders.push(`${relativePath} — title is the \`'Untitled'\` placeholder`);
+    }
+  }
+
+  if (offenders.length > 0) {
+    fail(
+      `${offenders.length} of ${checked} example(s) lack a usable title:\n` +
+        offenders.map((line) => `  - ${line}`).join('\n'),
+    );
+  }
+
+  process.stdout.write(`[validate:playground] all ${checked} example titles present.\n`);
+}
 
 /** Wait for the server to become ready by polling /ping. */
 async function waitForPing(baseUrl: string, timeoutMs: number): Promise<void> {
@@ -51,6 +121,15 @@ async function waitForPing(baseUrl: string, timeoutMs: number): Promise<void> {
  */
 async function validateComponentRoutes(baseUrl: string, components: string[]): Promise<void> {
   process.stdout.write(`[validate:playground] crawling ${components.length} component routes…\n`);
+
+  // The snapshot route (`/page/:name?snapshot=1`) re-renders the same page with
+  // snapshot mode enabled, so validating it for every component is redundant.
+  // Sample a bounded, deterministic subset (every Nth component) to keep the
+  // crawl fast while still exercising the snapshot code path across the set.
+  const snapshotSampleStride = Math.max(1, Math.ceil(components.length / 10));
+  const snapshotSample = new Set(
+    components.filter((_, index) => index % snapshotSampleStride === 0),
+  );
 
   for (const name of components) {
     // Shell route
@@ -95,6 +174,25 @@ async function validateComponentRoutes(baseUrl: string, components: string[]): P
     const pageBody = await pageResponse.text();
     if (!pageBody.includes('__CINDER_EXAMPLES__')) {
       fail(`GET ${pageUrl} does not inject __CINDER_EXAMPLES__`);
+    }
+
+    // Snapshot route (sampled): /page/:name?snapshot=1 must return 200 and emit
+    // the data-snapshot-mode attribute on <html> (snapshotModeHtmlAttribute).
+    if (snapshotSample.has(name)) {
+      const snapshotUrl = `${pageUrl}?snapshot=1`;
+      let snapshotResponse: Response;
+      try {
+        snapshotResponse = await fetch(snapshotUrl, { signal: AbortSignal.timeout(5_000) });
+      } catch (error) {
+        fail(`fetch ${snapshotUrl} threw: ${String(error)}`);
+      }
+      if (snapshotResponse.status !== 200) {
+        fail(`GET ${snapshotUrl} returned ${snapshotResponse.status}, expected 200`);
+      }
+      const snapshotBody = await snapshotResponse.text();
+      if (!snapshotBody.includes('data-snapshot-mode')) {
+        fail(`GET ${snapshotUrl} did not emit the data-snapshot-mode attribute`);
+      }
     }
   }
 
@@ -181,35 +279,41 @@ async function validateSseReload(baseUrl: string): Promise<void> {
   process.stdout.write('[validate:playground] SSE reload event received.\n');
 }
 
-let server: PlaygroundServer | undefined;
+// Guarded by import.meta.main so importing this module (e.g. to unit-test the
+// pure title helpers) does not auto-start the server or call process.exit().
+if (import.meta.main) {
+  let server: PlaygroundServer | undefined;
 
-try {
-  server = await startServer(PORT);
-  const baseUrl = `http://127.0.0.1:${server.port}`;
-  process.stdout.write(
-    `[validate:playground] waiting for playground server on port ${server.port}…\n`,
-  );
-  await waitForPing(baseUrl, 10_000);
-  process.stdout.write(`[validate:playground] server ready at ${baseUrl}\n`);
-
-  const components = await discoverComponents();
-  if (components.length < MINIMUM_COMPONENT_COUNT) {
-    fail(
-      `expected at least ${MINIMUM_COMPONENT_COUNT} components but discoverComponents returned ${components.length}`,
+  try {
+    server = await startServer(PORT);
+    const baseUrl = `http://127.0.0.1:${server.port}`;
+    process.stdout.write(
+      `[validate:playground] waiting for playground server on port ${server.port}…\n`,
     );
-  }
+    await waitForPing(baseUrl, 10_000);
+    process.stdout.write(`[validate:playground] server ready at ${baseUrl}\n`);
 
-  await validateComponentRoutes(baseUrl, components);
-  await validateSseReload(baseUrl);
+    const components = await discoverComponents();
+    if (components.length < MINIMUM_COMPONENT_COUNT) {
+      fail(
+        `expected at least ${MINIMUM_COMPONENT_COUNT} components but discoverComponents returned ${components.length}`,
+      );
+    }
 
-  process.stdout.write('[validate:playground] all checks passed.\n');
-  await server.dispose();
-  process.exit(0);
-} catch (error) {
-  await server?.dispose();
-  if (error instanceof PlaygroundValidationError) {
-    process.stderr.write(`[validate:playground] FAILED: ${error.message}\n`);
-    process.exit(1);
+    // import.meta.dirname is packages/playground/src/; examples live under examples/.
+    await validateExampleTitles(join(import.meta.dirname, 'examples'));
+    await validateComponentRoutes(baseUrl, components);
+    await validateSseReload(baseUrl);
+
+    process.stdout.write('[validate:playground] all checks passed.\n');
+    await server.dispose();
+    process.exit(0);
+  } catch (error) {
+    await server?.dispose();
+    if (error instanceof PlaygroundValidationError) {
+      process.stderr.write(`[validate:playground] FAILED: ${error.message}\n`);
+      process.exit(1);
+    }
+    throw error;
   }
-  throw error;
 }

--- a/packages/playground/tsconfig.json
+++ b/packages/playground/tsconfig.json
@@ -7,5 +7,5 @@
     // succeed on a fresh checkout without a prior cinder build.
     "customConditions": ["svelte"]
   },
-  "include": ["src/**/*"]
+  "include": ["src/**/*", "api/**/*", "scripts/**/*"]
 }

--- a/packages/playground/vercel.json
+++ b/packages/playground/vercel.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "bunVersion": "1.x",
+  "framework": null,
+  "buildCommand": "bun run vercel-build",
+  "installCommand": "cd ../.. && bun install --frozen-lockfile",
+  "outputDirectory": "public",
+  "functions": {
+    "api/index.ts": {
+      "includeFiles": "../components/{src,scripts}/**",
+      "maxDuration": 60
+    }
+  },
+  "rewrites": [
+    { "source": "/", "destination": "/api/index" },
+    { "source": "/ping", "destination": "/api/index" },
+    { "source": "/events", "destination": "/api/index" },
+    { "source": "/styles.css", "destination": "/api/index" },
+    { "source": "/styles/:path*", "destination": "/api/index" },
+    { "source": "/components/:path*", "destination": "/api/index" },
+    { "source": "/c/:name", "destination": "/api/index" },
+    { "source": "/page/:name", "destination": "/api/index" },
+    { "source": "/page-bundle/:file", "destination": "/api/index" },
+    { "source": "/shell-bundle/:file", "destination": "/api/index" },
+    { "source": "/bundle/:name/:scenario", "destination": "/api/index" },
+    { "source": "/api/manifest", "destination": "/api/index" },
+    { "source": "/api/manifest/:name", "destination": "/api/index" },
+    { "source": "/example-src/:name/:scenario", "destination": "/api/index" }
+  ]
+}


### PR DESCRIPTION
## Summary

Lands 18 reviewed playground tasks for the cinder component library. Each was implemented in an isolated worktree, adversarially reviewed by svelte-expert / ux-designer / testing-expert agents, and validated before integration.

**Bugs / correctness**
- Escape the example JSON via `jsonForScriptTag` in the component-page inline script — closes a `</script>` injection vector (`ecb46fa0`)
- Mount examples synchronously in `$effect`, fixing the queueMicrotask cleanup race that orphaned mounted trees (`99211979`)
- Import cinder via package subpaths instead of deep source-tree paths (`c492fc07`); rebased to drop `CinderProvider` (deleted by #209 — CodeBlock now auto-loads Shiki)

**Performance**
- Cache discovery results; immutable `Cache-Control` on content-hashed bundles, `no-store` on entry URLs (`51061d2f`)
- Share one ts-morph `Project` across `analyzeAll` + async file reads (`7c2b2bc6`)

**TypeScript / quality**
- Svelte AST types, bare `<script module>` regex fix, named capture groups, shared discovery scan (`4c3e2902`)

**Accessibility / UX**
- SPA-nav focus management, `document.title`, single shared live-region announcer (`5da2bfa6`)
- Visible error boundary for failed example mounts + source-fetch retry (`4347c026`)
- Iframe loading state to remove the blank-flash on navigation (`cf4a5d9f`)
- Sidebar search filter + component-name humanization (`a9558006`)
- Props / API reference panel per component page (`48199181`)
- Dark-mode checker background, reduced-motion guard, top-bar token hoist (`eefa7c34`)
- Open-in-new-tab button + sidebar scroll persistence (`67542215`)

**SEO / deploy**
- Complete metadata + Open Graph tags (`bf3680cd`)
- Vercel deploy config + GitHub Actions workflow — **config only; live deploy is a manual follow-up** (`eb40c93d`)

**DX / tests**
- Watcher rebuild logging, snapshot-route validation, lint-staged `--type-aware` (`6b4f7dcd`)
- Unit tests for `example-metadata` + shell-app components; extracted `example-metadata.ts` (`49bf7aca`)
- Documented `.example.svelte` authoring + missing-title validation (`6e36b872`)

A new `scripts/run-tests.ts` splits the suite into two processes: the mount-heavy `component-page.test.ts` runs isolated to avoid a Bun bundler module-state collision with `server.test.ts`'s `Bun.build` (both pass alone; only the same-process combination failed).

## Review committee

Pre-reviewed by: svelte-expert, ux-designer, testing-expert
- 2 rounds of review; 9 must-fix items addressed in round 1, all three reviewers APPROVED in round 2
- Must-fixes covered: a `$effect`-copies-state anti-pattern, an async-IIFE `$state` write, `bind:this` on a non-reactive `let`, a wrong `bind:this` type, missing per-example button labels, a double-announcing `role="status"`, a hand-rolled happy-dom install, and an over-broad hashed-chunk test regex

> [!WARNING]
> Codex (the adversarial second-opinion reviewer) was unavailable for this PR — the account is out of credits. See `tmp/committee-state.md` for detail. The three subagent reviewers ran in full.

## Test plan

- `cd packages/playground && bun run test` → 422 pass, 0 fail (baseline was 223)
- `bun run typecheck` (tsc + svelte-check) → clean; `bun run lint` (oxlint + stylelint) → 0 errors
- Pre-push full-workspace gate passed

## Manual follow-up (Vercel go-live)

Config is in place but no live deploy was performed. To deploy: create the Vercel project (Root Directory → `packages/playground`), add secrets `VERCEL_TOKEN` / `VERCEL_ORG_ID` / `VERCEL_PROJECT_ID`, then run the first deploy + smoke-test (`/ping` → `pong`, `/c/button` renders). Documented in `CONTRIBUTING.md` § "Deploying the playground to Vercel".

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large surface area (routing, caching, inline-script escaping, deploy workflow) with strong test coverage; live Vercel deploy still depends on manual secrets and cold-start on-demand builds.
> 
> **Overview**
> This PR is a broad playground refresh: **deploy wiring**, **server/shell behavior**, **analyzer performance**, and **much larger test/docs coverage**.
> 
> **Deploy & ops:** Adds a Vercel Bun function entry (`api/index.ts` → shared `handleRequest`), `vercel.json` rewrites, `vercel-build` smoke-import, GitHub Actions `deploy-playground` (preflight when secrets missing, `/ping` smoke-test), `PLAYGROUND_BASE_URL` for optional canonical/OG URLs, and CONTRIBUTING one-time Vercel setup. Tests lock the function export and rewrite coverage.
> 
> **Correctness & security:** Component-page example JSON now uses `jsonForScriptTag` (closes `</script>` injection). Example mounts run **synchronously** in `$effect` (fixes microtask cleanup orphans). Shell uses one shared **Announcer** + `announceNavigation` for title, live region, and main focus on SPA nav/back.
> 
> **Performance:** Memoized discovery with generation-aware invalidation on rebuild; shared ts-morph `Project` + `resetProject`; `Cache-Control` `immutable` on hashed bundle chunks and `no-store` on bare entry URLs.
> 
> **UX on component pages:** Visible mount/source errors (retry, copy), collapsible **Props/API** table from `/api/manifest`, shell SEO/OG metadata and inlined favicon, theme-aware checker background and reduced-motion guard, hoisted `--cinder-top-bar-height`.
> 
> **Analyzer/DX:** Typed Svelte AST parsing, bare `<script module>` support, shared `discoverComponentFilePaths`, extracted `example-metadata` + validation docs, type-aware lint for playground, `run-tests.ts` isolates `component-page.test.ts` from `server.test.ts` due to Bun/Svelte process state.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 307d3e4f3c498b4f44643772def173b2dc8a5ae5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->