### PR TITLE
fix(components): svelte-check warnings, test hardening, coverage thresholds (PR1)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,6 +52,12 @@ When `left`/`right` carries semantic placement (e.g. `data-placement="left"` sel
 - Component browser tests live in `packages/testing` and run under Playwright (`bun run test:browser`).
 - Every fix should land with a regression test.
 
+### Coverage ratchet
+
+`packages/components` enforces a coverage floor through `coverageThreshold` in `packages/components/bunfig.toml`. The package `validate` script runs `test:coverage`, so the floor is checked in CI and in the pre-commit hook — a change that drops coverage below the floor fails the gate.
+
+The floor is a **ratchet: it only ever moves up.** When you add tests that lift the real numbers, raise `lines` / `functions` in `bunfig.toml` to the new measured floor in the same change. Never lower them to make a red gate pass — fix the missing coverage instead. To read the current numbers, run `bun run test:coverage` from `packages/components` and look at the `All files` row.
+
 ## Main Branch Health
 
 After `.github/workflows/main-green.yaml` lands on `main`, `main-green / workspace-gates` is the central default-branch signal for the same workspace gates developers run locally:

--- a/packages/components/bunfig.toml
+++ b/packages/components/bunfig.toml
@@ -7,6 +7,14 @@ bun = true
 [test]
 preload = ["./scripts/preload.ts"]
 
+# Coverage ratchet. These are floors, not targets — they only ever move UP.
+# Measured baseline (May 2026, `bun run test:coverage`): 63.67% functions /
+# 65.87% lines. The floors are set just below that so the gate cannot fail on a
+# clean checkout while still catching any drop. When you add tests that lift the
+# real numbers, raise these to the new floor in the same change — never lower
+# them. See ../../CONTRIBUTING.md § Coverage ratchet.
+coverageThreshold = { lines = 0.65, functions = 0.63 }
+
 # The `test` / `test:coverage` scripts in package.json run with `--parallel=1`
 # (serial). This is deliberate; do not strip the flag without re-measuring.
 #

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -3050,7 +3050,7 @@
     "test": "TZ=UTC LANG=en_US.UTF-8 bun test --conditions browser --conditions svelte --parallel=1",
     "test:coverage": "TZ=UTC LANG=en_US.UTF-8 bun test --conditions browser --conditions svelte --parallel=1 --coverage",
     "typecheck": "tsc --noEmit -p tsconfig.check.json && bunx svelte-check --workspace src --tsconfig ../tsconfig.json --threshold error",
-    "validate": "bun run lint && bun run typecheck && bun run test && bun run validate:workflow && bun run validate:consumer",
+    "validate": "bun run lint && bun run typecheck && bun run test:coverage && bun run validate:workflow && bun run validate:consumer",
     "validate:consumer": "bun run scripts/validate-consumers.ts",
     "validate:workflow": "bun run scripts/validate-commit-workflow.ts",
     "verify:release-version": "bun run scripts/verify-release-version.ts"

--- a/packages/components/src/components/_tree-test-harness.svelte
+++ b/packages/components/src/components/_tree-test-harness.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import type { Snippet } from 'svelte';
+  import { untrack } from 'svelte';
 
   import Tree from './tree/tree.svelte';
   import type { TreeSelectionMode } from './tree/tree.types.ts';
@@ -18,8 +19,8 @@
     children: Snippet;
   } = $props();
 
-  let expandedIds = $state<string[]>(initialExpandedIds);
-  let selectedIds = $state<string[]>(initialSelectedIds);
+  let expandedIds = $state<string[]>(untrack(() => initialExpandedIds));
+  let selectedIds = $state<string[]>(untrack(() => initialSelectedIds));
 </script>
 
 <Tree

--- a/packages/components/src/components/area-chart/area-chart.svelte
+++ b/packages/components/src/components/area-chart/area-chart.svelte
@@ -282,6 +282,7 @@
         {#if model.targets.length > 0}
           <rect
             class="cinder-area-chart__hit-surface"
+            role="presentation"
             width={model.geometry.plotWidth}
             height={model.geometry.plotHeight}
             onpointermove={activateByPointer}

--- a/packages/components/src/components/bar-chart/bar-chart.svelte
+++ b/packages/components/src/components/bar-chart/bar-chart.svelte
@@ -294,6 +294,7 @@
         {#if model.targets.length > 0}
           <rect
             class="cinder-bar-chart__hit-surface"
+            role="presentation"
             width={model.geometry.plotWidth}
             height={model.geometry.plotHeight}
             onpointermove={activateByPointer}

--- a/packages/components/src/components/button/button.svelte
+++ b/packages/components/src/components/button/button.svelte
@@ -86,30 +86,34 @@
   // destructured. TypeScript can't narrow a destructured remainder per branch, so each
   // template arm casts `rest` to the attribute shape its element actually accepts. The cast
   // is safe because the `#if href !== undefined` discriminant has already chosen the branch.
-  // These stay as plain `const` casts (not `$derived`) because they're type-level renames —
-  // the underlying `rest` object is itself reactive, so consumers see prop changes flow through.
-  const anchorAttributes = rest as Omit<
-    HTMLAnchorAttributes,
-    | 'class'
-    | 'href'
-    | 'tabindex'
-    | 'onclick'
-    | 'aria-disabled'
-    | 'aria-busy'
-    | 'aria-label'
-    | 'aria-labelledby'
-  >;
-  const buttonAttributes = rest as Omit<
-    HTMLButtonAttributes,
-    | 'class'
-    | 'type'
-    | 'disabled'
-    | 'onclick'
-    | 'aria-disabled'
-    | 'aria-busy'
-    | 'aria-label'
-    | 'aria-labelledby'
-  >;
+  // These are `$derived` so the read of `rest` stays reactive and consumer prop changes
+  // flow through to the rendered attributes.
+  const anchorAttributes = $derived(
+    rest as Omit<
+      HTMLAnchorAttributes,
+      | 'class'
+      | 'href'
+      | 'tabindex'
+      | 'onclick'
+      | 'aria-disabled'
+      | 'aria-busy'
+      | 'aria-label'
+      | 'aria-labelledby'
+    >,
+  );
+  const buttonAttributes = $derived(
+    rest as Omit<
+      HTMLButtonAttributes,
+      | 'class'
+      | 'type'
+      | 'disabled'
+      | 'onclick'
+      | 'aria-disabled'
+      | 'aria-busy'
+      | 'aria-label'
+      | 'aria-labelledby'
+    >,
+  );
 
   // Branch-specific prop reads still need `$derived` because `loading` prop flips must
   // propagate to `disabled` / `tabindex` attributes.

--- a/packages/components/src/components/checkbox-group/checkbox-group.svelte
+++ b/packages/components/src/components/checkbox-group/checkbox-group.svelte
@@ -45,10 +45,13 @@
 <!--
   `aria-invalid` on the <fieldset> (implicit role=group) is a deliberate,
   best-effort supplemental signal — see checkbox-group.a11y.md. ARIA does not
-  formally list aria-invalid for role=group, but the error is the primary
-  signal via the visible aria-live region referenced by aria-describedby, and
-  per-control invalidity is set on each <Checkbox> directly. The lint rule is a
-  false positive for this documented, tested tradeoff.
+  formally list aria-invalid for role=group and most screen readers do not
+  announce it there, so the PRIMARY error signal is the visible aria-live region
+  referenced by aria-describedby. This group wraps independent checkboxes and
+  does not propagate its error to them; per-control aria-invalid is set by each
+  <Checkbox> from its own `error` prop, which the consumer supplies when a
+  specific control is invalid. The lint rule is suppressed for this documented,
+  tested tradeoff.
 -->
 <!-- svelte-ignore a11y_role_supports_aria_props_implicit -->
 <fieldset

--- a/packages/components/src/components/checkbox-group/checkbox-group.svelte
+++ b/packages/components/src/components/checkbox-group/checkbox-group.svelte
@@ -42,6 +42,15 @@
   const describedBy = $derived(composeDescribedBy(descriptionId, errId));
 </script>
 
+<!--
+  `aria-invalid` on the <fieldset> (implicit role=group) is a deliberate,
+  best-effort supplemental signal — see checkbox-group.a11y.md. ARIA does not
+  formally list aria-invalid for role=group, but the error is the primary
+  signal via the visible aria-live region referenced by aria-describedby, and
+  per-control invalidity is set on each <Checkbox> directly. The lint rule is a
+  false positive for this documented, tested tradeoff.
+-->
+<!-- svelte-ignore a11y_role_supports_aria_props_implicit -->
 <fieldset
   class={cn('cinder-checkbox-group', className)}
   {disabled}

--- a/packages/components/src/components/checkbox/checkbox.hydration.test.ts
+++ b/packages/components/src/components/checkbox/checkbox.hydration.test.ts
@@ -1,0 +1,60 @@
+/// <reference lib="dom" />
+/**
+ * Hydration contract for Checkbox.
+ *
+ * `indeterminate` is a DOM *property*, not an attribute — it cannot appear in
+ * the server HTML and is set on the live input only after hydration runs the
+ * sync effect. These tests prove the SSR markup and the hydrated client agree
+ * and that the property lands post-hydration without warnings.
+ */
+import { describe, expect, test } from 'bun:test';
+
+import { setupHappyDom } from '../../test/happy-dom.ts';
+import { renderThenHydrate } from '../../test/hydrate.ts';
+
+setupHappyDom();
+
+const { default: Checkbox } = await import('./checkbox.svelte');
+const sourcePath = new URL('./checkbox.svelte', import.meta.url).pathname;
+
+describe('Checkbox hydration', () => {
+  test('hydrates without warnings and keeps the checkbox role/id stable', async () => {
+    const result = await renderThenHydrate(Checkbox, sourcePath, {
+      id: 'agree',
+      label: 'I agree',
+    });
+
+    try {
+      const input = result.container.querySelector<HTMLInputElement>('#agree');
+      expect(input).not.toBeNull();
+      expect(input?.getAttribute('type')).toBe('checkbox');
+
+      const hydrationWarnings = result.warnings.filter((w) =>
+        w.toLowerCase().includes('hydration'),
+      );
+      expect(hydrationWarnings).toEqual([]);
+    } finally {
+      result.cleanup();
+    }
+  });
+
+  test('indeterminate is absent from SSR HTML but set as a DOM property after hydration', async () => {
+    const result = await renderThenHydrate(Checkbox, sourcePath, {
+      id: 'parent',
+      label: 'Select all',
+      indeterminate: true,
+    });
+
+    try {
+      // The attribute never appears in server markup — it is a property.
+      expect(result.ssrHtml).not.toContain('indeterminate');
+
+      const input = result.container.querySelector<HTMLInputElement>('#parent');
+      expect(input).not.toBeNull();
+      // After hydration the sync effect sets the live DOM property.
+      expect(input?.indeterminate).toBe(true);
+    } finally {
+      result.cleanup();
+    }
+  });
+});

--- a/packages/components/src/components/code-block/code-block.test.ts
+++ b/packages/components/src/components/code-block/code-block.test.ts
@@ -1,24 +1,10 @@
 /// <reference lib="dom" />
-import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
+import { afterEach, beforeEach, describe, expect, mock, spyOn, test } from 'bun:test';
 
 import { setupHappyDom } from '../../test/happy-dom.ts';
 import type { Highlighter } from '../../utilities/highlighter.ts';
 
 setupHappyDom();
-
-const originalConsoleWarn = console.warn;
-const warnings: unknown[][] = [];
-
-beforeEach(() => {
-  warnings.length = 0;
-  console.warn = (...args: unknown[]) => {
-    warnings.push(args);
-  };
-});
-
-afterEach(() => {
-  console.warn = originalConsoleWarn;
-});
 
 // The default-highlighter seam is the single module CodeBlock imports to reach
 // Shiki. Mocking THIS exact specifier (never the public `cinder/highlighters/shiki`
@@ -40,9 +26,25 @@ mock.module('./code-block-default-highlighter.ts', () => ({
 const { render, waitFor } = await import('@testing-library/svelte');
 const { default: CodeBlock } = await import('./code-block.svelte');
 
+// CodeBlock emits a dev warning when a highlighter throws / fails to load (it
+// then falls back to escaped plain code). Several tests exercise that path on
+// purpose, so we spy (rather than blanket-silence) and assert in afterEach that
+// every warning is that known fallback message — any UNEXPECTED warning fails.
+const KNOWN_CODE_BLOCK_WARNING = '[cinder/CodeBlock] highlight failed';
+let warnSpy: ReturnType<typeof spyOn<typeof console, 'warn'>>;
+
 beforeEach(() => {
   loadDefaultHighlighter.mockClear();
   defaultHighlighterImpl = (code) => `<pre class="shiki shiki-default"><code>${code}</code></pre>`;
+  warnSpy = spyOn(console, 'warn').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  const unexpected = warnSpy.mock.calls
+    .map((args) => args.map(String).join(' '))
+    .filter((message) => !message.includes(KNOWN_CODE_BLOCK_WARNING));
+  warnSpy.mockRestore();
+  expect(unexpected).toEqual([]);
 });
 
 /** A custom highlighter that tags its output so we can assert it ran. */
@@ -127,9 +129,9 @@ describe('CodeBlock — automatic highlighting (bundled default)', () => {
       );
     });
     // Dev warning fired, mentions the language, but NEVER the code content
-    // (code blocks may contain secrets).
-    expect(warnings.length).toBeGreaterThan(0);
-    const flattened = warnings.flat().map(String).join(' ');
+    // (code blocks may contain secrets). Read from the module-level spy.
+    expect(warnSpy).toHaveBeenCalled();
+    const flattened = warnSpy.mock.calls.flat().map(String).join(' ');
     expect(flattened).toContain('language "js"');
     expect(flattened).not.toContain('p@ss');
     expect(flattened).not.toContain('secret');

--- a/packages/components/src/components/code-block/code-block.test.ts
+++ b/packages/components/src/components/code-block/code-block.test.ts
@@ -43,8 +43,13 @@ afterEach(() => {
   const unexpected = warnSpy.mock.calls
     .map((args) => args.map(String).join(' '))
     .filter((message) => !message.includes(KNOWN_CODE_BLOCK_WARNING));
-  warnSpy.mockRestore();
-  expect(unexpected).toEqual([]);
+  // Restore in `finally` so an unexpected-warning failure can't leave
+  // `console.warn` patched for every subsequent test in the suite.
+  try {
+    expect(unexpected).toEqual([]);
+  } finally {
+    warnSpy.mockRestore();
+  }
 });
 
 /** A custom highlighter that tags its output so we can assert it ran. */

--- a/packages/components/src/components/color-field/color-field.svelte
+++ b/packages/components/src/components/color-field/color-field.svelte
@@ -17,6 +17,7 @@
 
 <script lang="ts">
   import { DEV } from 'esm-env';
+  import { untrack } from 'svelte';
 
   import { classNames } from '../../utilities/class-names.ts';
   import { parseColor } from '../../utilities/color-luminance.ts';
@@ -43,7 +44,8 @@
   }: ColorFieldProps = $props();
 
   // Mode is captured once at mount. Runtime mode switches are unsupported.
-  const isControlled = value !== undefined;
+  // Read untracked: the mode discriminant must not become a reactive dependency.
+  const isControlled = untrack(() => value) !== undefined;
 
   type RgbaParts = { r: number; g: number; b: number; a: number };
 
@@ -115,16 +117,21 @@
 
   // ── Initialization ──────────────────────────────────────────────────────
 
+  // Snapshot the seed props once. Initialization reads only the mount-time
+  // value; the controlled-sync effect (below) handles later prop changes.
+  const initialValue = untrack(() => value);
+  const initialDefaultValue = untrack(() => defaultValue);
+
   if (isControlled) {
-    if (value !== undefined && value !== '') {
-      const trimmedInitial = value.trim();
+    if (initialValue !== undefined && initialValue !== '') {
+      const trimmedInitial = initialValue.trim();
       if (trimmedInitial !== '' && passesFormatGate(trimmedInitial)) {
         const parsed = parseColor(trimmedInitial);
         if (parsed !== null) {
           seedFromParts(parsed);
-          lastReconciledValue = value;
+          lastReconciledValue = initialValue;
         } else {
-          visibleText = value;
+          visibleText = initialValue;
           committedHex = '';
           committedRgba = null;
           parseError = defaultErrorMessage();
@@ -133,14 +140,14 @@
         // Externally-supplied value violates the `formats` gate — preserve the
         // visible text verbatim and surface a parse error, matching the
         // documented contract.
-        visibleText = value;
+        visibleText = initialValue;
         committedHex = '';
         committedRgba = null;
         parseError = defaultErrorMessage();
       }
     }
-  } else if (defaultValue !== undefined && defaultValue !== '') {
-    const trimmedDefault = defaultValue.trim();
+  } else if (initialDefaultValue !== undefined && initialDefaultValue !== '') {
+    const trimmedDefault = initialDefaultValue.trim();
     if (trimmedDefault !== '' && passesFormatGate(trimmedDefault)) {
       const parsed = parseColor(trimmedDefault);
       if (parsed !== null) {

--- a/packages/components/src/components/color-picker/color-picker.svelte
+++ b/packages/components/src/components/color-picker/color-picker.svelte
@@ -16,7 +16,7 @@
 
 <script lang="ts">
   import type { ColorPickerProps } from './color-picker.types.ts';
-  import { tick } from 'svelte';
+  import { tick, untrack } from 'svelte';
 
   import { classNames } from '../../utilities/class-names.ts';
   import { parseColor, pickContrastColor } from '../../utilities/color-luminance.ts';
@@ -144,12 +144,18 @@
     alphaValue = alpha ? next.a : 1;
   }
 
+  // Snapshot the seed props once. Initialization reads only the mount-time
+  // values; the controlled-sync effect (below) handles later `value` changes.
+  const initialValue = untrack(() => value);
+  const initialDefaultValue = untrack(() => defaultValue);
+  const initialAlpha = untrack(() => alpha);
+
   // Initialize from defaultValue (only when uncontrolled).
-  if (value === undefined && defaultValue) {
-    const parsed = parseToHsla(defaultValue);
+  if (initialValue === undefined && initialDefaultValue) {
+    const parsed = parseToHsla(initialDefaultValue);
     if (parsed) {
       applyHsla(parsed);
-      internalValue = formatHex(parsed.h, parsed.s, parsed.l, parsed.a, alpha);
+      internalValue = formatHex(parsed.h, parsed.s, parsed.l, parsed.a, initialAlpha);
     } else {
       hue = 0;
       saturation = 0;
@@ -158,11 +164,11 @@
       internalValue = '';
       lastEmittedHex = '';
     }
-  } else if (value !== undefined) {
-    const parsed = parseToHsla(value);
+  } else if (initialValue !== undefined) {
+    const parsed = parseToHsla(initialValue);
     if (parsed) {
       applyHsla(parsed);
-      internalValue = formatHex(parsed.h, parsed.s, parsed.l, parsed.a, alpha);
+      internalValue = formatHex(parsed.h, parsed.s, parsed.l, parsed.a, initialAlpha);
     } else {
       hue = 0;
       saturation = 0;
@@ -592,7 +598,8 @@
   role="group"
   id={pickerId}
 >
-  <!-- svelte-ignore a11y_no_noninteractive_tabindex a11y_no_noninteractive_element_interactions -->
+  <!-- svelte-ignore a11y_no_noninteractive_tabindex -->
+  <!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
   <div
     bind:this={gradientElement}
     id={gradientId}

--- a/packages/components/src/components/color-swatch-picker/color-swatch-picker.svelte
+++ b/packages/components/src/components/color-swatch-picker/color-swatch-picker.svelte
@@ -16,7 +16,7 @@
 
 <script lang="ts">
   import type { ColorSwatchPickerProps } from './color-swatch-picker.types.ts';
-  import { tick } from 'svelte';
+  import { tick, untrack } from 'svelte';
   import { DEV } from 'esm-env';
 
   import { cn } from '../../utilities/class-names.ts';
@@ -38,7 +38,9 @@
     indicator,
   }: ColorSwatchPickerProps = $props();
 
-  let internalValue = $state(defaultValue ?? '');
+  // Seeded once from `defaultValue` for the uncontrolled case; later selection
+  // changes flow through user interaction, not the prop.
+  let internalValue = $state(untrack(() => defaultValue) ?? '');
   const selected = $derived(value ?? internalValue);
 
   // Track focus index driven by user interaction. null = derive from selection.
@@ -162,6 +164,13 @@
     {@const isDisabled = swatch.disabled === true}
     {@const contrastColor = pickContrastColor(swatch.color)}
     {@const alpha = hasAlpha(swatch.color)}
+    <!--
+      Listbox pattern: keyboard activation (Enter/Space) and roving navigation
+      are handled once on the role="listbox" container above, where the focused
+      role="option" delegates its keydown by bubbling. Per-option click is a
+      pointer convenience, so the colocated-keydown lint rule is a false positive.
+    -->
+    <!-- svelte-ignore a11y_click_events_have_key_events -->
     <li
       role="option"
       aria-selected={isSelected}

--- a/packages/components/src/components/color-swatch-picker/color-swatch-picker.test.ts
+++ b/packages/components/src/components/color-swatch-picker/color-swatch-picker.test.ts
@@ -1,19 +1,9 @@
 /// <reference lib="dom" />
-import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { describe, expect, spyOn, test } from 'bun:test';
 
 import { setupHappyDom } from '../../test/happy-dom.ts';
 
 setupHappyDom();
-
-const originalConsoleWarn = console.warn;
-
-beforeEach(() => {
-  console.warn = () => {};
-});
-
-afterEach(() => {
-  console.warn = originalConsoleWarn;
-});
 
 const { render, fireEvent } = await import('@testing-library/svelte');
 const { default: ColorSwatchPicker } = await import('./color-swatch-picker.svelte');
@@ -480,20 +470,28 @@ describe('ColorSwatchPicker empty palette', () => {
 });
 
 describe('ColorSwatchPicker duplicate palette', () => {
-  test('only first matching swatch receives aria-selected', () => {
-    const colors = [
-      { color: '#ff0000', name: 'Red 1' },
-      { color: '#ff0000', name: 'Red 2' },
-      { color: '#0000ff' },
-    ];
-    const { container } = render(ColorSwatchPicker, {
-      colors,
-      label: 'Colors',
-      defaultValue: '#ff0000',
-    });
-    const options = toArray(container.querySelectorAll('[role="option"]'));
-    expect(options[0].getAttribute('aria-selected')).toBe('true');
-    expect(options[1].getAttribute('aria-selected')).toBe('false');
+  test('only first matching swatch receives aria-selected (and warns in dev)', () => {
+    // A duplicate palette intentionally trips the dev warning. Scope the spy to
+    // this test so incidental warnings elsewhere still fail their tests.
+    const warnSpy = spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      const colors = [
+        { color: '#ff0000', name: 'Red 1' },
+        { color: '#ff0000', name: 'Red 2' },
+        { color: '#0000ff' },
+      ];
+      const { container } = render(ColorSwatchPicker, {
+        colors,
+        label: 'Colors',
+        defaultValue: '#ff0000',
+      });
+      const options = toArray(container.querySelectorAll('[role="option"]'));
+      expect(options[0].getAttribute('aria-selected')).toBe('true');
+      expect(options[1].getAttribute('aria-selected')).toBe('false');
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('Duplicate color values'));
+    } finally {
+      warnSpy.mockRestore();
+    }
   });
 });
 

--- a/packages/components/src/components/combobox/combobox.hydration.test.ts
+++ b/packages/components/src/components/combobox/combobox.hydration.test.ts
@@ -1,0 +1,64 @@
+/// <reference lib="dom" />
+/**
+ * Hydration contract for Combobox.
+ *
+ * The combobox input carries `aria-controls` pointing at the listbox id
+ * (`{id}-listbox`) and `aria-activedescendant`. Those references must survive
+ * hydration so assistive tech keeps the input wired to its popup.
+ */
+import { describe, expect, test } from 'bun:test';
+
+import { setupHappyDom } from '../../test/happy-dom.ts';
+import { renderThenHydrate } from '../../test/hydrate.ts';
+
+setupHappyDom();
+
+const { default: Combobox } = await import('./combobox.svelte');
+const sourcePath = new URL('./combobox.svelte', import.meta.url).pathname;
+
+const fruits = [
+  { value: 'apple', label: 'Apple' },
+  { value: 'apricot', label: 'Apricot' },
+  { value: 'banana', label: 'Banana' },
+];
+
+describe('Combobox hydration', () => {
+  test('hydrates without warnings and keeps role="combobox"', async () => {
+    const result = await renderThenHydrate(Combobox, sourcePath, {
+      id: 'fruit',
+      label: 'Fruit',
+      options: fruits,
+    });
+
+    try {
+      const input = result.container.querySelector('[role="combobox"]');
+      expect(input).not.toBeNull();
+      expect(input?.id).toBe('fruit');
+
+      const hydrationWarnings = result.warnings.filter((w) =>
+        w.toLowerCase().includes('hydration'),
+      );
+      expect(hydrationWarnings).toEqual([]);
+    } finally {
+      result.cleanup();
+    }
+  });
+
+  test('aria-controls points at the same listbox id before and after hydration', async () => {
+    const result = await renderThenHydrate(Combobox, sourcePath, {
+      id: 'fruit',
+      label: 'Fruit',
+      options: fruits,
+    });
+
+    try {
+      // The id pattern is deterministic, so the SSR HTML and the hydrated DOM
+      // must agree on the listbox id reference.
+      expect(result.ssrHtml).toContain('aria-controls="fruit-listbox"');
+      const input = result.container.querySelector('[role="combobox"]');
+      expect(input?.getAttribute('aria-controls')).toBe('fruit-listbox');
+    } finally {
+      result.cleanup();
+    }
+  });
+});

--- a/packages/components/src/components/combobox/combobox.svelte
+++ b/packages/components/src/components/combobox/combobox.svelte
@@ -43,7 +43,7 @@
     'aria-describedby': consumerDescribedBy,
   }: ComboboxProps<T> = $props();
 
-  const listboxId = `${id}-listbox`;
+  const listboxId = $derived(`${id}-listbox`);
   const descriptionId = $derived(describeId(id, !!description));
   // errId only included in aria-describedby when error is active.
   const errId = $derived(buildErrorId(id, !!error));

--- a/packages/components/src/components/command-item/command-item.svelte
+++ b/packages/components/src/components/command-item/command-item.svelte
@@ -44,8 +44,9 @@
 
   const commandList = getCommandListContext();
   // Type-level mode marker: CommandPalette items own activation, while
-  // CommandMenu items can opt into parent-owned activation.
-  void selectionMode;
+  // CommandMenu items can opt into parent-owned activation. Read untracked
+  // because this is a one-time discard, not a reactive dependency.
+  void untrack(() => selectionMode);
 
   // Stable id assigned by the palette on registration.
   let itemId = $state<string | null>(null);

--- a/packages/components/src/components/context-menu-trigger/context-menu-trigger.test.ts
+++ b/packages/components/src/components/context-menu-trigger/context-menu-trigger.test.ts
@@ -1,0 +1,60 @@
+/// <reference lib="dom" />
+import { afterEach, describe, expect, mock, test } from 'bun:test';
+import { createRawSnippet } from 'svelte';
+
+import { setupHappyDom } from '../../test/happy-dom.ts';
+
+setupHappyDom();
+
+// ContextMenu positions its menu through floating-ui; stub it so opening the
+// menu does not depend on real layout (matches context-menu.test.ts).
+const computePositionSpy = mock(async () => ({ x: 32, y: 48, placement: 'right-start' }));
+const autoUpdateTeardown = mock(() => {});
+const autoUpdateSpy = mock((_reference: unknown, _menu: HTMLElement, update: () => void) => {
+  update();
+  return autoUpdateTeardown;
+});
+
+mock.module('@floating-ui/dom', () => ({
+  autoUpdate: autoUpdateSpy,
+  computePosition: computePositionSpy,
+  flip: () => ({ name: 'flip', fn: () => ({}) }),
+  shift: (options: unknown) => ({ name: 'shift', options, fn: () => ({}) }),
+}));
+
+const { cleanup, fireEvent, render, waitFor } = await import('@testing-library/svelte');
+const { default: Harness } = await import('../context-menu/_context-menu-test-harness.svelte');
+const { default: ContextMenuTrigger } = await import('./context-menu-trigger.svelte');
+
+afterEach(() => cleanup());
+
+describe('ContextMenuTrigger', () => {
+  test('throws when rendered outside a ContextMenu', () => {
+    expect(() =>
+      render(ContextMenuTrigger, {
+        props: {
+          children: createRawSnippet(() => ({ render: () => '<span>x</span>', setup: () => {} })),
+        },
+      }),
+    ).toThrow(/must be used within a ContextMenu/);
+  });
+
+  test('renders a trigger region wrapping its child content', () => {
+    const { container } = render(Harness);
+    const region = container.querySelector('.cinder-context-menu-trigger');
+    expect(region).not.toBeNull();
+    expect(region?.querySelector('.context-menu-button')?.textContent).toContain('File one.txt');
+  });
+
+  test('a contextmenu event on the trigger opens the menu', async () => {
+    const { container } = render(Harness);
+    const region = container.querySelector('.cinder-context-menu-trigger') as HTMLElement;
+    expect(document.body.querySelector('[role="menu"]')).toBeNull();
+
+    await fireEvent.contextMenu(region, { clientX: 12, clientY: 18 });
+
+    await waitFor(() => {
+      expect(document.body.querySelector('[role="menu"]')).not.toBeNull();
+    });
+  });
+});

--- a/packages/components/src/components/dropdown-group/dropdown-group.test.ts
+++ b/packages/components/src/components/dropdown-group/dropdown-group.test.ts
@@ -1,0 +1,36 @@
+/// <reference lib="dom" />
+import { describe, expect, test } from 'bun:test';
+
+import { setupHappyDom } from '../../test/happy-dom.ts';
+
+setupHappyDom();
+
+const { render, fireEvent, waitFor } = await import('@testing-library/svelte');
+const { default: Fixture } = await import('../../test/fixtures/dropdown-compound-fixture.svelte');
+
+async function openMenu() {
+  const result = render(Fixture);
+  await fireEvent.click(result.container.querySelector('.trigger') as HTMLElement);
+  await waitFor(() => expect(result.container.querySelector('[role="menu"]')).not.toBeNull());
+  return result;
+}
+
+describe('DropdownGroup', () => {
+  test('renders each group with role="group"', async () => {
+    const { container } = await openMenu();
+    expect(container.querySelectorAll('[role="group"]')).toHaveLength(2);
+  });
+
+  test('aria-labelledby points at the group label id', async () => {
+    const { container } = await openMenu();
+    const groups = Array.from(container.querySelectorAll<HTMLElement>('[role="group"]'));
+    expect(groups[0]?.getAttribute('aria-labelledby')).toBe('actions-menu-document-label');
+    expect(groups[1]?.getAttribute('aria-labelledby')).toBe('actions-menu-sharing-label');
+  });
+
+  test('the referenced label element exists for each group', async () => {
+    const { container } = await openMenu();
+    expect(container.querySelector('#actions-menu-document-label')).not.toBeNull();
+    expect(container.querySelector('#actions-menu-sharing-label')).not.toBeNull();
+  });
+});

--- a/packages/components/src/components/dropdown-item/dropdown-item.test.ts
+++ b/packages/components/src/components/dropdown-item/dropdown-item.test.ts
@@ -1,0 +1,52 @@
+/// <reference lib="dom" />
+import { describe, expect, test } from 'bun:test';
+import { createRawSnippet } from 'svelte';
+
+import { setupHappyDom } from '../../test/happy-dom.ts';
+
+setupHappyDom();
+
+const { render, fireEvent, waitFor } = await import('@testing-library/svelte');
+const { default: Fixture } = await import('../../test/fixtures/dropdown-compound-fixture.svelte');
+const { default: DropdownItem } = await import('./dropdown-item.svelte');
+
+async function openMenu() {
+  const result = render(Fixture);
+  await fireEvent.click(result.container.querySelector('.trigger') as HTMLElement);
+  await waitFor(() => expect(result.container.querySelector('[role="menu"]')).not.toBeNull());
+  return result;
+}
+
+describe('DropdownItem', () => {
+  test('throws when rendered outside a Dropdown', () => {
+    expect(() =>
+      render(DropdownItem, {
+        props: {
+          children: createRawSnippet(() => ({ render: () => '<span>x</span>', setup: () => {} })),
+        },
+      }),
+    ).toThrow(/must be used within a Dropdown/);
+  });
+
+  test('renders as a button with role="menuitem"', async () => {
+    const { container } = await openMenu();
+    const item = container.querySelector('[role="menuitem"]');
+    expect(item).not.toBeNull();
+    expect(item?.tagName.toLowerCase()).toBe('button');
+  });
+
+  test('clicking an item invokes its onclick and closes the menu', async () => {
+    const { container } = await openMenu();
+    await fireEvent.click(container.querySelector('[role="menuitem"]') as HTMLElement);
+    expect(container.querySelector('output')?.textContent).toBe('copy');
+    await waitFor(() => expect(container.querySelector('[role="menu"]')).toBeNull());
+  });
+
+  test('Enter activates the item via the keydown-to-click bridge', async () => {
+    const { container } = await openMenu();
+    const item = container.querySelector('[role="menuitem"]') as HTMLElement;
+    item.focus();
+    await fireEvent.keyDown(item, { key: 'Enter' });
+    expect(container.querySelector('output')?.textContent).toBe('copy');
+  });
+});

--- a/packages/components/src/components/dropdown-item/dropdown-item.test.ts
+++ b/packages/components/src/components/dropdown-item/dropdown-item.test.ts
@@ -47,6 +47,6 @@ describe('DropdownItem', () => {
     const item = container.querySelector('[role="menuitem"]') as HTMLElement;
     item.focus();
     await fireEvent.keyDown(item, { key: 'Enter' });
-    expect(container.querySelector('output')?.textContent).toBe('copy');
+    await waitFor(() => expect(container.querySelector('output')?.textContent).toBe('copy'));
   });
 });

--- a/packages/components/src/components/dropdown-label/dropdown-label.test.ts
+++ b/packages/components/src/components/dropdown-label/dropdown-label.test.ts
@@ -1,0 +1,41 @@
+/// <reference lib="dom" />
+import { describe, expect, test } from 'bun:test';
+
+import { setupHappyDom } from '../../test/happy-dom.ts';
+
+setupHappyDom();
+
+const { render, fireEvent, waitFor } = await import('@testing-library/svelte');
+const { default: Fixture } = await import('../../test/fixtures/dropdown-compound-fixture.svelte');
+
+async function openMenu() {
+  const result = render(Fixture);
+  await fireEvent.click(result.container.querySelector('.trigger') as HTMLElement);
+  await waitFor(() => expect(result.container.querySelector('[role="menu"]')).not.toBeNull());
+  return result;
+}
+
+describe('DropdownLabel', () => {
+  test('renders the label text inside the menu', async () => {
+    const { container } = await openMenu();
+    const label = container.querySelector('.cinder-dropdown-label');
+    expect(label).not.toBeNull();
+    expect(label?.textContent).toContain('Document');
+  });
+
+  test('carries the id its group references via aria-labelledby', async () => {
+    const { container } = await openMenu();
+    const label = container.querySelector('#actions-menu-document-label');
+    expect(label).not.toBeNull();
+    const group = container.querySelector(
+      '[role="group"][aria-labelledby="actions-menu-document-label"]',
+    );
+    expect(group).not.toBeNull();
+  });
+
+  test('is not itself an interactive menuitem', async () => {
+    const { container } = await openMenu();
+    const label = container.querySelector('#actions-menu-document-label');
+    expect(label?.getAttribute('role')).not.toBe('menuitem');
+  });
+});

--- a/packages/components/src/components/dropdown-menu/dropdown-menu.test.ts
+++ b/packages/components/src/components/dropdown-menu/dropdown-menu.test.ts
@@ -1,0 +1,41 @@
+/// <reference lib="dom" />
+import { describe, expect, test } from 'bun:test';
+import { createRawSnippet } from 'svelte';
+
+import { setupHappyDom } from '../../test/happy-dom.ts';
+
+setupHappyDom();
+
+const { render, fireEvent, waitFor } = await import('@testing-library/svelte');
+const { default: Fixture } = await import('../../test/fixtures/dropdown-compound-fixture.svelte');
+const { default: DropdownMenu } = await import('./dropdown-menu.svelte');
+
+describe('DropdownMenu', () => {
+  test('throws when rendered outside a Dropdown', () => {
+    expect(() =>
+      render(DropdownMenu, {
+        props: {
+          children: createRawSnippet(() => ({ render: () => '<span></span>', setup: () => {} })),
+        },
+      }),
+    ).toThrow(/must be used within a Dropdown/);
+  });
+
+  test('is absent until the trigger opens it, then renders with role="menu"', async () => {
+    const { container } = render(Fixture);
+    expect(container.querySelector('[role="menu"]')).toBeNull();
+
+    await fireEvent.click(container.querySelector('.trigger') as HTMLElement);
+    await waitFor(() => expect(container.querySelector('[role="menu"]')).not.toBeNull());
+    expect(container.querySelector('[role="menu"]')?.id).toBe('actions-menu-menu');
+  });
+
+  test('ArrowDown moves focus to the next menu item once open', async () => {
+    const { container } = render(Fixture);
+    await fireEvent.click(container.querySelector('.trigger') as HTMLElement);
+    await waitFor(() => expect(document.activeElement?.textContent).toContain('Copy link'));
+
+    await fireEvent.keyDown(document.activeElement as HTMLElement, { key: 'ArrowDown' });
+    expect(document.activeElement?.textContent).toContain('Invite people');
+  });
+});

--- a/packages/components/src/components/dropdown-separator/dropdown-separator.test.ts
+++ b/packages/components/src/components/dropdown-separator/dropdown-separator.test.ts
@@ -1,0 +1,25 @@
+/// <reference lib="dom" />
+import { describe, expect, test } from 'bun:test';
+
+import { setupHappyDom } from '../../test/happy-dom.ts';
+
+setupHappyDom();
+
+const { render, fireEvent, waitFor } = await import('@testing-library/svelte');
+const { default: Fixture } = await import('../../test/fixtures/dropdown-compound-fixture.svelte');
+const { default: DropdownSeparator } = await import('./dropdown-separator.svelte');
+
+describe('DropdownSeparator', () => {
+  test('renders standalone with role="separator"', () => {
+    const { container } = render(DropdownSeparator);
+    const separator = container.querySelector('[role="separator"]');
+    expect(separator).not.toBeNull();
+  });
+
+  test('appears between groups inside an open menu', async () => {
+    const { container } = render(Fixture);
+    await fireEvent.click(container.querySelector('.trigger') as HTMLElement);
+    await waitFor(() => expect(container.querySelector('[role="menu"]')).not.toBeNull());
+    expect(container.querySelector('[role="menu"] [role="separator"]')).not.toBeNull();
+  });
+});

--- a/packages/components/src/components/dropdown-trigger/dropdown-trigger.test.ts
+++ b/packages/components/src/components/dropdown-trigger/dropdown-trigger.test.ts
@@ -1,0 +1,43 @@
+/// <reference lib="dom" />
+import { describe, expect, test } from 'bun:test';
+import { createRawSnippet } from 'svelte';
+
+import { setupHappyDom } from '../../test/happy-dom.ts';
+
+setupHappyDom();
+
+const { render, fireEvent, waitFor } = await import('@testing-library/svelte');
+const { default: Fixture } = await import('../../test/fixtures/dropdown-compound-fixture.svelte');
+const { default: DropdownTrigger } = await import('./dropdown-trigger.svelte');
+
+describe('DropdownTrigger', () => {
+  test('throws when rendered outside a Dropdown', () => {
+    expect(() =>
+      render(DropdownTrigger, {
+        props: {
+          children: createRawSnippet(() => ({ render: () => '<span>x</span>', setup: () => {} })),
+        },
+      }),
+    ).toThrow(/must be used within a Dropdown/);
+  });
+
+  test('renders a button with aria-haspopup="menu"', () => {
+    const { container } = render(Fixture);
+    const trigger = container.querySelector('.cinder-dropdown-trigger');
+    expect(trigger?.tagName.toLowerCase()).toBe('button');
+    expect(trigger?.getAttribute('aria-haspopup')).toBe('menu');
+  });
+
+  test('aria-expanded reflects the open state and flips on click', async () => {
+    const { container } = render(Fixture);
+    const trigger = container.querySelector('.cinder-dropdown-trigger') as HTMLElement;
+    expect(trigger.getAttribute('aria-expanded')).toBe('false');
+
+    await fireEvent.click(trigger);
+    await waitFor(() => {
+      expect(
+        container.querySelector('.cinder-dropdown-trigger')?.getAttribute('aria-expanded'),
+      ).toBe('true');
+    });
+  });
+});

--- a/packages/components/src/components/dropdown/dropdown.svelte
+++ b/packages/components/src/components/dropdown/dropdown.svelte
@@ -214,8 +214,16 @@
       so the menu lands beside the trigger even after the popover API promotes the menu
       into the top layer (where percent-based offsets would otherwise resolve against the viewport).
     -->
+    <!--
+      Presentational delegation wrapper: the consumer's focusable trigger child
+      is the real interactive element (it receives aria-haspopup / aria-expanded
+      / aria-controls via the effect above). Keyboard activation works through
+      that child — Enter/Space fire a native click that bubbles here — so this
+      wrapper only needs role="presentation" to stay out of the a11y tree.
+    -->
     <div
       class="cinder-dropdown__trigger"
+      role="presentation"
       bind:this={triggerWrapper}
       style={`anchor-name: --${menuId};`}
       onclick={() => (open = !open)}

--- a/packages/components/src/components/json-schema-editor/json-schema-editor-impl.svelte
+++ b/packages/components/src/components/json-schema-editor/json-schema-editor-impl.svelte
@@ -56,6 +56,7 @@
 </script>
 
 <script lang="ts">
+  import { untrack } from 'svelte';
   import { classNames } from '../../utilities/class-names.ts';
   import { useAnnouncer } from '../../utilities/use-announcer.svelte.ts';
   import Badge from '../badge/badge.svelte';
@@ -91,16 +92,22 @@
   // mutable props (readonly, draftOverride, callback handlers) are kept in
   // sync after mount via the $effects below — without that, parents passing
   // inline lambdas would have their handlers captured stale at construction.
-  const stateOptions: Parameters<typeof createEditorState>[0] = {
-    schema,
-    readonly,
-    onchange: (event) => onchange?.(event),
-    onrevert: (event) => onrevert?.(event),
-    onvalidate: (result) => onvalidate?.(result),
-  };
-  if (original !== undefined) stateOptions.original = original;
-  if (maxHistory !== undefined) stateOptions.maxHistory = maxHistory;
-  if (draftOverride !== undefined) stateOptions.draftOverride = draftOverride;
+  // The container is built exactly once; read the seed props untracked so this
+  // construction never becomes a reactive dependency. Later prop changes are
+  // applied through the $effects below (readonly/draftOverride) and schemaKey.
+  const stateOptions: Parameters<typeof createEditorState>[0] = untrack(() => {
+    const options: Parameters<typeof createEditorState>[0] = {
+      schema,
+      readonly,
+      onchange: (event) => onchange?.(event),
+      onrevert: (event) => onrevert?.(event),
+      onvalidate: (result) => onvalidate?.(result),
+    };
+    if (original !== undefined) options.original = original;
+    if (maxHistory !== undefined) options.maxHistory = maxHistory;
+    if (draftOverride !== undefined) options.draftOverride = draftOverride;
+    return options;
+  });
 
   const state = createEditorState(stateOptions);
 
@@ -108,8 +115,8 @@
   // We track the last applied value locally so the effect only calls the
   // setter on real prop transitions — without that, the effect re-runs on
   // every reactive read inside setReadonly/setDraftOverride and loops.
-  let lastReadonly = readonly;
-  let lastDraftOverride: JsonSchemaKnownDraft | undefined = draftOverride;
+  let lastReadonly = untrack(() => readonly);
+  let lastDraftOverride: JsonSchemaKnownDraft | undefined = untrack(() => draftOverride);
   $effect(() => {
     if (readonly !== lastReadonly) {
       lastReadonly = readonly;
@@ -132,7 +139,7 @@
   // schemaKey-triggered reset. Track the previous key explicitly so we don't
   // reload on initial mount (state was already seeded above) or on re-renders
   // that don't change the key.
-  let lastSchemaKey: string | undefined = schemaKey;
+  let lastSchemaKey: string | undefined = untrack(() => schemaKey);
   $effect(() => {
     if (schemaKey !== lastSchemaKey) {
       lastSchemaKey = schemaKey;
@@ -187,6 +194,14 @@
   }
 </script>
 
+<!--
+  The keydown handler implements editor-wide undo/redo shortcuts (Cmd/Ctrl+Z,
+  Shift+Z, Y). It listens on the region landmark and acts on keystrokes that
+  bubble up from the focusable editor surfaces (form fields, JSON textarea,
+  diff view) inside it, so the noninteractive-element-interactions rule is a
+  false positive — `role="region"` is the correct landmark for the editor.
+-->
+<!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
 <div
   {id}
   class={classNames('cinder-jse', className)}

--- a/packages/components/src/components/json-schema-editor/json-schema-toolbar.svelte
+++ b/packages/components/src/components/json-schema-editor/json-schema-toolbar.svelte
@@ -139,6 +139,7 @@
 <div
   class={classNames('cinder-jse-toolbar', className)}
   role="toolbar"
+  tabindex="-1"
   aria-label="Schema editor actions"
   onkeydown={handleKeydown}
 >

--- a/packages/components/src/components/json-viewer/_json-viewer-node.svelte
+++ b/packages/components/src/components/json-viewer/_json-viewer-node.svelte
@@ -13,6 +13,7 @@
 </script>
 
 <script lang="ts">
+  import { untrack } from 'svelte';
   import Self from './_json-viewer-node.svelte';
   import { cn } from '../../utilities/class-names.ts';
 
@@ -22,7 +23,8 @@
   const isArray = $derived(Array.isArray(value));
   const tooDeep = $derived(depth >= maxDepth);
 
-  let collapsed = $state(depth >= initialDepth);
+  // Seeded once from the initial depth vs. the configured initialDepth.
+  let collapsed = $state(untrack(() => depth >= initialDepth));
 
   const entries = $derived.by(() => {
     if (!isObject || tooDeep) return [];

--- a/packages/components/src/components/line-chart/line-chart.svelte
+++ b/packages/components/src/components/line-chart/line-chart.svelte
@@ -289,6 +289,7 @@
         {#if model.targets.length > 0}
           <rect
             class="cinder-line-chart__hit-surface"
+            role="presentation"
             width={model.geometry.plotWidth}
             height={model.geometry.plotHeight}
             onpointermove={activateByPointer}

--- a/packages/components/src/components/menu-bar/menu-bar-dropdown-context.svelte
+++ b/packages/components/src/components/menu-bar/menu-bar-dropdown-context.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import type { Snippet } from 'svelte';
-  import { setContext } from 'svelte';
+  import { setContext, untrack } from 'svelte';
 
   import {
     DROPDOWN_CONTEXT,
@@ -20,10 +20,24 @@
 
   const { context, registerMenu, registerTrigger, setOpen, children }: Props = $props();
 
-  setContext(DROPDOWN_CONTEXT, context);
-  setContext(DROPDOWN_REGISTER, registerMenu);
-  setContext(DROPDOWN_REGISTER_TRIGGER, registerTrigger);
-  setContext(DROPDOWN_SET_OPEN, setOpen);
+  // Context is established once at setup; read the bridge values untracked so
+  // they are not treated as reactive dependencies.
+  setContext(
+    DROPDOWN_CONTEXT,
+    untrack(() => context),
+  );
+  setContext(
+    DROPDOWN_REGISTER,
+    untrack(() => registerMenu),
+  );
+  setContext(
+    DROPDOWN_REGISTER_TRIGGER,
+    untrack(() => registerTrigger),
+  );
+  setContext(
+    DROPDOWN_SET_OPEN,
+    untrack(() => setOpen),
+  );
 </script>
 
 {@render children()}

--- a/packages/components/src/components/modal/modal.hydration.test.ts
+++ b/packages/components/src/components/modal/modal.hydration.test.ts
@@ -13,9 +13,13 @@
  *    we assert that the open dialog's `aria-labelledby` resolves to the title
  *    element and that `aria-describedby` is wired through.
  *
- * The open-dialog assertions render on the client: Modal's open body uses an
- * attachment, and the SSR-recompile helper nulls `document` during the server
- * pass, which is incompatible with rendering raw-snippet children server-side.
+ * KNOWN GAP: the open-dialog test below is a CLIENT-ONLY render, not a hydration
+ * round-trip. Modal's open body uses an attachment, and the SSR-recompile helper
+ * nulls `document` during the server pass, which is incompatible with rendering
+ * raw-snippet children server-side. So that test proves the client wires
+ * `aria-labelledby`/`aria-describedby` correctly, but does NOT prove the SSR HTML
+ * and the hydrated client agree on those ids for an initially-open dialog. The
+ * deterministic-id derivation makes drift unlikely, but it is not asserted here.
  */
 import { describe, expect, test } from 'bun:test';
 import { createRawSnippet } from 'svelte';

--- a/packages/components/src/components/modal/modal.hydration.test.ts
+++ b/packages/components/src/components/modal/modal.hydration.test.ts
@@ -1,0 +1,80 @@
+/// <reference lib="dom" />
+/**
+ * Hydration contract for Modal.
+ *
+ * Modal renders a native `<dialog role="dialog">` whose `aria-labelledby` points
+ * at a `useId`-generated title id and whose optional `aria-describedby` is
+ * consumer-supplied. Two things matter for hydration:
+ *
+ * 1. A closed modal emits no dialog on the server, then mounts cleanly on the
+ *    client without hydration warnings.
+ * 2. The title id is derived deterministically, so the `aria-labelledby`
+ *    relationship the server would emit is exactly the one the client resolves —
+ *    we assert that the open dialog's `aria-labelledby` resolves to the title
+ *    element and that `aria-describedby` is wired through.
+ *
+ * The open-dialog assertions render on the client: Modal's open body uses an
+ * attachment, and the SSR-recompile helper nulls `document` during the server
+ * pass, which is incompatible with rendering raw-snippet children server-side.
+ */
+import { describe, expect, test } from 'bun:test';
+import { createRawSnippet } from 'svelte';
+
+import { setupHappyDom } from '../../test/happy-dom.ts';
+import { renderThenHydrate } from '../../test/hydrate.ts';
+
+setupHappyDom();
+
+const { render } = await import('@testing-library/svelte');
+const { default: Modal } = await import('./modal.svelte');
+const sourcePath = new URL('./modal.svelte', import.meta.url).pathname;
+
+const bodyContent = createRawSnippet(() => ({
+  render: () => `<p id="modal-body-copy">Are you sure?</p>`,
+}));
+
+describe('Modal hydration', () => {
+  test('a closed modal SSRs to empty markup and mounts without hydration warnings', async () => {
+    const result = await renderThenHydrate(Modal, sourcePath, {
+      open: false,
+      title: 'Confirm',
+      children: bodyContent,
+    });
+
+    try {
+      // Closed modal emits no dialog on the server (only empty {#if} markers).
+      expect(result.ssrHtml).not.toContain('<dialog');
+      expect(result.ssrHtml).not.toContain('role="dialog"');
+      const hydrationWarnings = result.warnings.filter((w) =>
+        w.toLowerCase().includes('hydration'),
+      );
+      expect(hydrationWarnings).toEqual([]);
+    } finally {
+      result.cleanup();
+    }
+  });
+
+  test('the open dialog wires aria-labelledby to the title and aria-describedby through', () => {
+    const { container } = render(Modal, {
+      props: {
+        open: true,
+        title: 'Delete file',
+        describedById: 'modal-body-copy',
+        children: bodyContent,
+      },
+    });
+
+    const dialog = container.querySelector('[role="dialog"]');
+    expect(dialog).not.toBeNull();
+    expect(dialog?.getAttribute('aria-modal')).toBe('true');
+
+    // aria-labelledby resolves to the title <h2>, whose id comes from useId.
+    const labelledBy = dialog?.getAttribute('aria-labelledby');
+    expect(labelledBy).toBeTruthy();
+    const titleElement = container.querySelector(`#${labelledBy}`);
+    expect(titleElement?.textContent).toContain('Delete file');
+
+    // The consumer-supplied describedById is forwarded verbatim.
+    expect(dialog?.getAttribute('aria-describedby')).toBe('modal-body-copy');
+  });
+});

--- a/packages/components/src/components/number-input/number-input.svelte
+++ b/packages/components/src/components/number-input/number-input.svelte
@@ -17,7 +17,7 @@
 
 <script lang="ts">
   import type { NumberInputProps } from './number-input.types.ts';
-  import { onMount } from 'svelte';
+  import { onMount, untrack } from 'svelte';
 
   import {
     ariaInvalid,
@@ -63,9 +63,12 @@
   let requiredEmptyError = $state(false);
 
   // Seed the bindable from defaultValue when the parent didn't supply a value.
-  if (value === null && defaultValue !== null) {
-    value = defaultValue;
-  }
+  // Read untracked: this is a one-time mount seed, not a reactive sync.
+  untrack(() => {
+    if (value === null && defaultValue !== null) {
+      value = defaultValue;
+    }
+  });
 
   onMount(() => {
     hasMounted = true;
@@ -233,7 +236,7 @@
   const parentValueSignature = $derived(
     `${value ?? ''}|${resolvedLocale}|${JSON.stringify(format ?? null)}`,
   );
-  let lastSeenParentSignature = parentValueSignature;
+  let lastSeenParentSignature = untrack(() => parentValueSignature);
   $effect(() => {
     const signature = parentValueSignature;
     if (signature === lastSeenParentSignature) return;

--- a/packages/components/src/components/phone-input/phone-input.svelte
+++ b/packages/components/src/components/phone-input/phone-input.svelte
@@ -435,6 +435,14 @@
     </span>
   {/if}
 
+  <!--
+    aria-invalid / aria-required on the role="group" wrapper are a deliberate
+    supplemental signal and are ALSO set on the inner <select> and <input>
+    (where they are formally supported and tested). The visible error is
+    referenced via aria-describedby. ARIA does not list these states for
+    role=group, so the lint rule is a false positive for this tested tradeoff.
+  -->
+  <!-- svelte-ignore a11y_role_supports_aria_props -->
   <div
     class="cinder-phone-input"
     role="group"

--- a/packages/components/src/components/pin-input/pin-input.svelte
+++ b/packages/components/src/components/pin-input/pin-input.svelte
@@ -18,6 +18,7 @@
 <script lang="ts">
   import type { PinInputProps } from './pin-input.types.ts';
   import { DEV } from 'esm-env';
+  import { untrack } from 'svelte';
 
   import {
     ariaInvalid,
@@ -76,7 +77,9 @@
   // Internal segment state. Synced whenever the joined view drifts from the
   // current normalized value; never fires `onchange` because that represents
   // prop synchronization, not user input.
-  let segments = $state<string[]>(Array.from({ length: normalizedLength }, () => ''));
+  let segments = $state<string[]>(
+    Array.from({ length: untrack(() => normalizedLength) }, () => ''),
+  );
 
   function writeSegmentsFromValue(next: string): void {
     const filtered = filterValue(next);
@@ -288,6 +291,14 @@
     </span>
   {/if}
 
+  <!--
+    aria-invalid on the role="group" wrapper is a deliberate, tested signal:
+    pin-input.test.ts asserts it lives on the group (not the segments, to avoid
+    screen-reader double-announcement) with the visible error referenced via
+    aria-describedby. ARIA does not list aria-invalid for role=group, so the
+    lint rule is a false positive for this documented tradeoff.
+  -->
+  <!-- svelte-ignore a11y_role_supports_aria_props -->
   <div
     class="cinder-pin-input"
     role="group"

--- a/packages/components/src/components/pin-input/pin-input.test.ts
+++ b/packages/components/src/components/pin-input/pin-input.test.ts
@@ -8,33 +8,51 @@ setupHappyDom();
 const { render, fireEvent } = await import('@testing-library/svelte');
 const { default: PinInput } = await import('./pin-input.svelte');
 
+/**
+ * Render PinInput with a default accessible name so the dev `No accessible name
+ * source` warning does not flood the test output. If the test already supplies
+ * a name source (`label`, `aria-label`, or `aria-labelledby`), it is preserved
+ * untouched so name-resolution tests still exercise the real precedence.
+ *
+ * Mirrors the render(PinInput, { props }) shape so call sites only swap the
+ * function name.
+ */
+function renderPin(options: {
+  props: { id: string; value: string } & Record<string, unknown>;
+}): ReturnType<typeof render> {
+  const { props } = options;
+  const hasName = 'label' in props || 'aria-label' in props || 'aria-labelledby' in props;
+  const resolvedProps = hasName ? props : { ...props, 'aria-label': 'Code' };
+  return render(PinInput, { props: resolvedProps });
+}
+
 function segments(container: Element): HTMLInputElement[] {
   return Array.from(container.querySelectorAll<HTMLInputElement>('input[data-cinder-pin-segment]'));
 }
 
 describe('PinInput rendering', () => {
   test('renders 6 segments by default', () => {
-    const { container } = render(PinInput, { props: { id: 'otp', value: '' } });
+    const { container } = renderPin({ props: { id: 'otp', value: '' } });
     expect(segments(container)).toHaveLength(6);
   });
 
   test('honors configurable length', () => {
-    const { container } = render(PinInput, { props: { id: 'otp', value: '', length: 4 } });
+    const { container } = renderPin({ props: { id: 'otp', value: '', length: 4 } });
     expect(segments(container)).toHaveLength(4);
   });
 
   test('clamps length below 1 to 1', () => {
-    const { container } = render(PinInput, { props: { id: 'otp', value: '', length: 0 } });
+    const { container } = renderPin({ props: { id: 'otp', value: '', length: 0 } });
     expect(segments(container)).toHaveLength(1);
   });
 
   test('clamps length above 12 to 12', () => {
-    const { container } = render(PinInput, { props: { id: 'otp', value: '', length: 99 } });
+    const { container } = renderPin({ props: { id: 'otp', value: '', length: 99 } });
     expect(segments(container)).toHaveLength(12);
   });
 
   test('group has role="group" and references the label', () => {
-    const { container } = render(PinInput, {
+    const { container } = renderPin({
       props: { id: 'otp', value: '', label: 'Verification code' },
     });
     const group = container.querySelector('[role="group"]')!;
@@ -46,7 +64,7 @@ describe('PinInput rendering', () => {
   });
 
   test('falls back to aria-label when no other name source is supplied', () => {
-    const { container } = render(PinInput, {
+    const { container } = renderPin({
       props: { id: 'otp', value: '', 'aria-label': 'Security code' },
     });
     const group = container.querySelector('[role="group"]')!;
@@ -55,7 +73,7 @@ describe('PinInput rendering', () => {
   });
 
   test('each segment has a unique visually hidden position label', () => {
-    const { container } = render(PinInput, {
+    const { container } = renderPin({
       props: { id: 'otp', value: '', length: 3, label: 'Code' },
     });
     const ids = ['otp-segment-0-label', 'otp-segment-1-label', 'otp-segment-2-label'];
@@ -67,10 +85,10 @@ describe('PinInput rendering', () => {
   });
 
   test('renders hidden input only when name is provided', () => {
-    const { container: noName } = render(PinInput, { props: { id: 'a', value: '' } });
+    const { container: noName } = renderPin({ props: { id: 'a', value: '' } });
     expect(noName.querySelector('input[type="hidden"]')).toBeNull();
 
-    const { container: withName } = render(PinInput, {
+    const { container: withName } = renderPin({
       props: { id: 'b', value: '123', name: 'otp' },
     });
     const hidden = withName.querySelector<HTMLInputElement>('input[type="hidden"]')!;
@@ -80,7 +98,7 @@ describe('PinInput rendering', () => {
   });
 
   test('first segment carries the one-time-code autocomplete hint', () => {
-    const { container } = render(PinInput, { props: { id: 'otp', value: '' } });
+    const { container } = renderPin({ props: { id: 'otp', value: '' } });
     const all = segments(container);
     expect(all[0]?.getAttribute('autocomplete')).toBe('one-time-code');
     expect(all[1]?.getAttribute('autocomplete')).toBe('off');
@@ -89,20 +107,20 @@ describe('PinInput rendering', () => {
 
 describe('PinInput numeric filtering', () => {
   test('filters non-digits in numeric mode on initial value', () => {
-    const { container } = render(PinInput, { props: { id: 'otp', value: 'a1b2c3' } });
+    const { container } = renderPin({ props: { id: 'otp', value: 'a1b2c3' } });
     const all = segments(container);
     expect(all.map((segment) => segment.value).join('')).toBe('123');
   });
 
   test('rejects typed letters in numeric mode', async () => {
-    const { container } = render(PinInput, { props: { id: 'otp', value: '' } });
+    const { container } = renderPin({ props: { id: 'otp', value: '' } });
     const first = segments(container)[0]!;
     await fireEvent.input(first, { target: { value: 'a' } });
     expect(first.value).toBe('');
   });
 
   test('accepts typed digits in numeric mode and auto-advances', async () => {
-    const { container } = render(PinInput, { props: { id: 'otp', value: '', length: 4 } });
+    const { container } = renderPin({ props: { id: 'otp', value: '', length: 4 } });
     const all = segments(container);
     await fireEvent.input(all[0]!, { target: { value: '1' } });
     expect(all[0]!.value).toBe('1');
@@ -112,7 +130,7 @@ describe('PinInput numeric filtering', () => {
 
 describe('PinInput alphanumeric mode', () => {
   test('accepts letters and digits', () => {
-    const { container } = render(PinInput, {
+    const { container } = renderPin({
       props: { id: 'otp', value: 'ab12!@cd', mode: 'alphanumeric', length: 6 },
     });
     const all = segments(container);
@@ -122,7 +140,7 @@ describe('PinInput alphanumeric mode', () => {
 
 describe('PinInput keyboard navigation', () => {
   test('Backspace on empty segment moves focus back and clears previous', async () => {
-    const { container } = render(PinInput, { props: { id: 'otp', value: '12', length: 4 } });
+    const { container } = renderPin({ props: { id: 'otp', value: '12', length: 4 } });
     const all = segments(container);
     all[2]!.focus();
     await fireEvent.keyDown(all[2]!, { key: 'Backspace' });
@@ -131,7 +149,7 @@ describe('PinInput keyboard navigation', () => {
   });
 
   test('Backspace on filled segment clears it without moving focus', async () => {
-    const { container } = render(PinInput, { props: { id: 'otp', value: '12', length: 4 } });
+    const { container } = renderPin({ props: { id: 'otp', value: '12', length: 4 } });
     const all = segments(container);
     all[1]!.focus();
     await fireEvent.keyDown(all[1]!, { key: 'Backspace' });
@@ -140,7 +158,7 @@ describe('PinInput keyboard navigation', () => {
   });
 
   test('arrow keys navigate between segments', async () => {
-    const { container } = render(PinInput, { props: { id: 'otp', value: '12', length: 4 } });
+    const { container } = renderPin({ props: { id: 'otp', value: '12', length: 4 } });
     const all = segments(container);
     all[0]!.focus();
     await fireEvent.keyDown(all[0]!, { key: 'ArrowRight' });
@@ -150,7 +168,7 @@ describe('PinInput keyboard navigation', () => {
   });
 
   test('ArrowLeft on the first segment does not wrap or move focus', async () => {
-    const { container } = render(PinInput, { props: { id: 'otp', value: '12', length: 4 } });
+    const { container } = renderPin({ props: { id: 'otp', value: '12', length: 4 } });
     const all = segments(container);
     all[0]!.focus();
     await fireEvent.keyDown(all[0]!, { key: 'ArrowLeft' });
@@ -158,7 +176,7 @@ describe('PinInput keyboard navigation', () => {
   });
 
   test('ArrowRight on the last segment does not wrap or move focus', async () => {
-    const { container } = render(PinInput, { props: { id: 'otp', value: '1234', length: 4 } });
+    const { container } = renderPin({ props: { id: 'otp', value: '1234', length: 4 } });
     const all = segments(container);
     all[3]!.focus();
     await fireEvent.keyDown(all[3]!, { key: 'ArrowRight' });
@@ -166,7 +184,7 @@ describe('PinInput keyboard navigation', () => {
   });
 
   test('Home focuses the first segment from any position', async () => {
-    const { container } = render(PinInput, { props: { id: 'otp', value: '1234', length: 4 } });
+    const { container } = renderPin({ props: { id: 'otp', value: '1234', length: 4 } });
     const all = segments(container);
     all[2]!.focus();
     await fireEvent.keyDown(all[2]!, { key: 'Home' });
@@ -174,7 +192,7 @@ describe('PinInput keyboard navigation', () => {
   });
 
   test('End focuses the last segment from any position', async () => {
-    const { container } = render(PinInput, { props: { id: 'otp', value: '1', length: 4 } });
+    const { container } = renderPin({ props: { id: 'otp', value: '1', length: 4 } });
     const all = segments(container);
     all[0]!.focus();
     await fireEvent.keyDown(all[0]!, { key: 'End' });
@@ -184,7 +202,7 @@ describe('PinInput keyboard navigation', () => {
 
 describe('PinInput paste and autofill', () => {
   test('paste distributes characters across segments from the focused one', async () => {
-    const { container } = render(PinInput, { props: { id: 'otp', value: '', length: 6 } });
+    const { container } = renderPin({ props: { id: 'otp', value: '', length: 6 } });
     const all = segments(container);
     all[0]!.focus();
     const data = new DataTransfer();
@@ -194,7 +212,7 @@ describe('PinInput paste and autofill', () => {
   });
 
   test('multi-character autofill into first segment distributes across', async () => {
-    const { container } = render(PinInput, { props: { id: 'otp', value: '', length: 4 } });
+    const { container } = renderPin({ props: { id: 'otp', value: '', length: 4 } });
     const all = segments(container);
     await fireEvent.input(all[0]!, { target: { value: '4321' } });
     expect(all.map((segment) => segment.value).join('')).toBe('4321');
@@ -203,7 +221,7 @@ describe('PinInput paste and autofill', () => {
 
 describe('PinInput masked mode', () => {
   test('renders type="password" segments but emits raw value', () => {
-    const { container } = render(PinInput, {
+    const { container } = renderPin({
       props: { id: 'otp', value: '1234', masked: true, length: 4 },
     });
     const all = segments(container);
@@ -218,7 +236,7 @@ describe('PinInput masked mode', () => {
 
 describe('PinInput error / disabled / required', () => {
   test('error sets aria-invalid on the group and renders message', () => {
-    const { container } = render(PinInput, {
+    const { container } = renderPin({
       props: { id: 'otp', value: '', error: 'Invalid code', length: 3 },
     });
     const group = container.querySelector<HTMLElement>('[role="group"]');
@@ -232,7 +250,7 @@ describe('PinInput error / disabled / required', () => {
   });
 
   test('description wires aria-describedby on every segment', () => {
-    const { container } = render(PinInput, {
+    const { container } = renderPin({
       props: { id: 'otp', value: '', description: 'Enter the 6-digit code we sent you.' },
     });
     const all = segments(container);
@@ -242,7 +260,7 @@ describe('PinInput error / disabled / required', () => {
   });
 
   test('disabled disables every segment and the hidden input', () => {
-    const { container } = render(PinInput, {
+    const { container } = renderPin({
       props: { id: 'otp', value: '1', name: 'otp', disabled: true },
     });
     const all = segments(container);
@@ -255,7 +273,7 @@ describe('PinInput error / disabled / required', () => {
 describe('PinInput onchange', () => {
   test('fires for user-initiated input', async () => {
     const onchange = mock((_value: string) => {});
-    const { container } = render(PinInput, {
+    const { container } = renderPin({
       props: { id: 'otp', value: '', length: 4, onchange },
     });
     const all = segments(container);
@@ -265,7 +283,7 @@ describe('PinInput onchange', () => {
 
   test('fires for paste', async () => {
     const onchange = mock((_value: string) => {});
-    const { container } = render(PinInput, {
+    const { container } = renderPin({
       props: { id: 'otp', value: '', length: 4, onchange },
     });
     const all = segments(container);
@@ -278,7 +296,7 @@ describe('PinInput onchange', () => {
 
   test('does not fire on external value prop synchronization', async () => {
     const onchange = mock((_value: string) => {});
-    const { rerender } = render(PinInput, {
+    const { rerender } = renderPin({
       props: { id: 'otp', value: '', length: 4, onchange },
     });
     await rerender({ id: 'otp', value: '12', length: 4, onchange });
@@ -288,7 +306,7 @@ describe('PinInput onchange', () => {
 
 describe('PinInput accessibility wiring', () => {
   test('Backspace on the first segment does not move focus away', async () => {
-    const { container } = render(PinInput, { props: { id: 'otp', value: '1', length: 4 } });
+    const { container } = renderPin({ props: { id: 'otp', value: '1', length: 4 } });
     const all = segments(container);
     all[0]!.focus();
     await fireEvent.keyDown(all[0]!, { key: 'Backspace' });
@@ -296,7 +314,7 @@ describe('PinInput accessibility wiring', () => {
   });
 
   test('description + error compose into a single aria-describedby on every segment', () => {
-    const { container } = render(PinInput, {
+    const { container } = renderPin({
       props: {
         id: 'otp',
         value: '',
@@ -313,7 +331,7 @@ describe('PinInput accessibility wiring', () => {
   });
 
   test('aria-required is announced on every segment, not on the group', () => {
-    const { container } = render(PinInput, {
+    const { container } = renderPin({
       props: { id: 'otp', value: '', required: true },
     });
     const all = segments(container);
@@ -323,7 +341,7 @@ describe('PinInput accessibility wiring', () => {
   });
 
   test('aria-label-only group falls back to per-segment aria-label (no aria-labelledby)', () => {
-    const { container } = render(PinInput, {
+    const { container } = renderPin({
       props: { id: 'otp', value: '', 'aria-label': 'Security code' },
     });
     const all = segments(container);

--- a/packages/components/src/components/popover/popover.test.ts
+++ b/packages/components/src/components/popover/popover.test.ts
@@ -125,8 +125,13 @@ afterEach(() => {
   const unexpected = warnSpy.mock.calls
     .map((args) => args.map(String).join(' '))
     .filter((message) => !KNOWN_POPOVER_WARNINGS.some((known) => message.includes(known)));
-  warnSpy.mockRestore();
-  expect(unexpected).toEqual([]);
+  // Restore in `finally` so an unexpected-warning failure can't leave
+  // `console.warn` patched for every subsequent test in the suite.
+  try {
+    expect(unexpected).toEqual([]);
+  } finally {
+    warnSpy.mockRestore();
+  }
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/components/src/components/popover/popover.test.ts
+++ b/packages/components/src/components/popover/popover.test.ts
@@ -1,5 +1,5 @@
 /// <reference lib="dom" />
-import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
+import { afterEach, beforeEach, describe, expect, mock, spyOn, test } from 'bun:test';
 import { createRawSnippet, tick } from 'svelte';
 
 import { setupHappyDom } from '../../test/happy-dom.ts';
@@ -84,7 +84,16 @@ function attachScratch(node: HTMLElement): void {
   document.body.appendChild(node);
 }
 
-const originalConsoleWarn = console.warn;
+// Popover emits dev-only guidance warnings (see popover.svelte). Several tests
+// open the popover in configurations that intentionally trip them, so we spy
+// (rather than blanket-silence) and assert in afterEach that every warning
+// matches one of these known patterns — any UNEXPECTED warning fails the test.
+const KNOWN_POPOVER_WARNINGS = [
+  'open without a trigger anchor',
+  'role="dialog" without `label` or `ariaLabelledby`',
+  'role="listbox" only sets the surface role',
+];
+let warnSpy: ReturnType<typeof spyOn<typeof console, 'warn'>>;
 
 beforeEach(() => {
   deferComputePosition = false;
@@ -95,7 +104,7 @@ beforeEach(() => {
     placement: 'bottom-start',
     middlewareData: {},
   };
-  console.warn = () => {};
+  warnSpy = spyOn(console, 'warn').mockImplementation(() => {});
 });
 
 afterEach(() => {
@@ -112,7 +121,12 @@ afterEach(() => {
   shiftSpy.mockClear();
   offsetSpy.mockClear();
   _resetEscapeStack();
-  console.warn = originalConsoleWarn;
+
+  const unexpected = warnSpy.mock.calls
+    .map((args) => args.map(String).join(' '))
+    .filter((message) => !KNOWN_POPOVER_WARNINGS.some((known) => message.includes(known)));
+  warnSpy.mockRestore();
+  expect(unexpected).toEqual([]);
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/components/src/components/portal/portal.test.ts
+++ b/packages/components/src/components/portal/portal.test.ts
@@ -78,8 +78,11 @@ describe('Portal', () => {
       disabled: false,
     });
 
-    expect(result.ssrHtml).not.toContain('Portaled child');
-    result.cleanup();
+    try {
+      expect(result.ssrHtml).not.toContain('Portaled child');
+    } finally {
+      result.cleanup();
+    }
   });
 
   test('retargets when the target prop changes after mount', async () => {

--- a/packages/components/src/components/radio-group/radio-group.svelte
+++ b/packages/components/src/components/radio-group/radio-group.svelte
@@ -69,6 +69,14 @@
   });
 </script>
 
+<!--
+  `aria-invalid` on the <fieldset> (implicit role=group) is a deliberate
+  best-effort supplemental signal; per-radio invalidity is also set on each
+  <input type="radio"> via context, and the visible error is referenced through
+  aria-describedby. ARIA does not formally list aria-invalid for role=group, so
+  the lint rule is a false positive for this documented, tested tradeoff.
+-->
+<!-- svelte-ignore a11y_role_supports_aria_props_implicit -->
 <fieldset
   class={cn('cinder-radio-group', className)}
   aria-invalid={ariaInvalid(!!error)}

--- a/packages/components/src/components/radio/radio.svelte
+++ b/packages/components/src/components/radio/radio.svelte
@@ -63,6 +63,13 @@
   data-has-description={description ? '' : undefined}
 >
   <span class="cinder-radio-row__control">
+    <!--
+      aria-invalid mirrors the group's validity onto the native radio so screen
+      readers announce invalidity on focus. It is a global ARIA state and the
+      standard way to mark form-control validity; the implicit-role lint rule
+      does not list it for role=radio, but applying it here is correct.
+    -->
+    <!-- svelte-ignore a11y_role_supports_aria_props_implicit -->
     <input
       {id}
       type="radio"

--- a/packages/components/src/components/radio/radio.test.ts
+++ b/packages/components/src/components/radio/radio.test.ts
@@ -1,0 +1,52 @@
+/// <reference lib="dom" />
+import { describe, expect, test } from 'bun:test';
+import { createRawSnippet } from 'svelte';
+
+import { setupHappyDom } from '../../test/happy-dom.ts';
+
+setupHappyDom();
+
+const { render } = await import('@testing-library/svelte');
+const { default: Wrapper } = await import('../../test/fixtures/radio-group-fixture.svelte');
+const { default: Radio } = await import('./radio.svelte');
+
+const options = [
+  { id: 'r-a', value: 'a', label: 'Option A' },
+  { id: 'r-b', value: 'b', label: 'Option B' },
+];
+
+describe('Radio', () => {
+  test('throws when rendered outside a RadioGroup', () => {
+    expect(() =>
+      render(Radio, {
+        props: {
+          id: 'lonely',
+          value: 'x',
+          label: 'Lonely',
+          children: createRawSnippet(() => ({ render: () => '<span></span>', setup: () => {} })),
+        },
+      }),
+    ).toThrow(/must be used inside a RadioGroup component/);
+  });
+
+  test('renders a native <input type="radio"> per option sharing the group name', () => {
+    const { container } = render(Wrapper, { name: 'choice', value: 'a', options });
+    const radios = Array.from(container.querySelectorAll<HTMLInputElement>('input[type="radio"]'));
+    expect(radios).toHaveLength(2);
+    expect(radios.every((radio) => radio.getAttribute('name') === 'choice')).toBe(true);
+  });
+
+  test('checked state reflects the selected group value', () => {
+    const { container } = render(Wrapper, { name: 'choice', value: 'b', options });
+    const radios = Array.from(container.querySelectorAll<HTMLInputElement>('input[type="radio"]'));
+    expect(radios[0]?.checked).toBe(false);
+    expect(radios[1]?.checked).toBe(true);
+  });
+
+  test('each radio is associated with its label via for/id', () => {
+    const { container } = render(Wrapper, { name: 'choice', value: 'a', options });
+    const label = container.querySelector('label[for="r-a"]');
+    expect(label).not.toBeNull();
+    expect(container.querySelector('#r-a')).not.toBeNull();
+  });
+});

--- a/packages/components/src/components/rating/rating.svelte
+++ b/packages/components/src/components/rating/rating.svelte
@@ -327,6 +327,7 @@
     <div
       class="cinder-rating"
       role="radiogroup"
+      tabindex="-1"
       aria-labelledby={resolvedGroupLabelledBy}
       aria-label={groupAriaLabel}
       aria-describedby={describedBy}

--- a/packages/components/src/components/review-editor/front-matter-fields.svelte
+++ b/packages/components/src/components/review-editor/front-matter-fields.svelte
@@ -9,6 +9,7 @@
 </script>
 
 <script lang="ts">
+  import { untrack } from 'svelte';
   import { parseFrontMatter, validateFrontMatter } from 'cinder/markdown/pipeline';
   import Checkbox from '../checkbox/checkbox.svelte';
   import Input from '../input/input.svelte';
@@ -21,7 +22,7 @@
   const hasParsedFields = $derived(data !== null && entries.length > 0);
   const shouldShowRawYaml = $derived(!hasParsedFields && raw !== null);
 
-  let rawDraft = $state(raw ?? '');
+  let rawDraft = $state(untrack(() => raw) ?? '');
   let rawError = $state<string | undefined>();
   let lastRaw = $state<string | null>(null);
   let complexDrafts = $state<Record<string, string>>({});

--- a/packages/components/src/components/search-field/search-field.svelte
+++ b/packages/components/src/components/search-field/search-field.svelte
@@ -16,6 +16,7 @@
 
 <script lang="ts">
   import { DEV } from 'esm-env';
+  import { untrack } from 'svelte';
   import type { Attachment } from 'svelte/attachments';
 
   import { Search, X } from '../icons/index.ts';
@@ -45,7 +46,7 @@
   const resolvedId = $derived(id ?? context?.controlId);
 
   let inputElement = $state<HTMLInputElement | null>(null);
-  let uncontrolledValue = $state(defaultValue ?? '');
+  let uncontrolledValue = $state(untrack(() => defaultValue) ?? '');
 
   const isControlled = $derived(value !== undefined);
   const currentValue = $derived(isControlled ? (value ?? '') : uncontrolledValue);

--- a/packages/components/src/components/segment/segment.test.ts
+++ b/packages/components/src/components/segment/segment.test.ts
@@ -1,0 +1,45 @@
+/// <reference lib="dom" />
+import { afterEach, describe, expect, test } from 'bun:test';
+
+import { setupHappyDom } from '../../test/happy-dom.ts';
+
+setupHappyDom();
+
+const { cleanup, render, screen } = await import('@testing-library/svelte');
+const { default: Fixture } = await import('../../test/fixtures/segmented-control-fixture.svelte');
+
+afterEach(() => cleanup());
+
+const options = [
+  { value: 'source', label: 'Source' },
+  { value: 'rendered', label: 'Rendered' },
+  { value: 'diff', label: 'Diff', disabled: true },
+];
+
+function renderControl(value: string) {
+  return render(Fixture, {
+    props: { id: 'view', value, label: 'View', options },
+  });
+}
+
+describe('Segment', () => {
+  test('renders each segment as a button with role="radio" in single mode', () => {
+    const { container } = renderControl('source');
+    const segments = container.querySelectorAll('[role="radio"]');
+    expect(segments).toHaveLength(3);
+    expect(segments[0]?.tagName.toLowerCase()).toBe('button');
+  });
+
+  test('aria-checked reflects the selected value', () => {
+    renderControl('source');
+    expect(screen.getByRole('radio', { name: 'Source' }).getAttribute('aria-checked')).toBe('true');
+    expect(screen.getByRole('radio', { name: 'Rendered' }).getAttribute('aria-checked')).toBe(
+      'false',
+    );
+  });
+
+  test('a disabled option surfaces aria-disabled', () => {
+    renderControl('source');
+    expect(screen.getByRole('radio', { name: 'Diff' }).getAttribute('aria-disabled')).toBe('true');
+  });
+});

--- a/packages/components/src/components/select/select.hydration.test.ts
+++ b/packages/components/src/components/select/select.hydration.test.ts
@@ -1,0 +1,70 @@
+/// <reference lib="dom" />
+/**
+ * Hydration contract for Select.
+ *
+ * Select wires aria/description ids derived from `id` and renders a native
+ * `<select>` with one `<option>` per entry. The hydrated client must reuse the
+ * exact ids the server emitted so ARIA wiring and the option list stay intact.
+ */
+import { describe, expect, test } from 'bun:test';
+
+import { setupHappyDom } from '../../test/happy-dom.ts';
+import { renderThenHydrate } from '../../test/hydrate.ts';
+
+setupHappyDom();
+
+const { default: Select } = await import('./select.svelte');
+const sourcePath = new URL('./select.svelte', import.meta.url).pathname;
+
+const options = [
+  { value: 'a', label: 'Option A' },
+  { value: 'b', label: 'Option B' },
+  { value: 'c', label: 'Option C' },
+];
+
+describe('Select hydration', () => {
+  test('hydrates without warnings and preserves the native select id', async () => {
+    const result = await renderThenHydrate(Select, sourcePath, {
+      id: 'fruit',
+      value: 'b',
+      label: 'Fruit',
+      options,
+    });
+
+    try {
+      const select = result.container.querySelector<HTMLSelectElement>('select#fruit');
+      expect(select).not.toBeNull();
+      expect(result.container.querySelectorAll('option')).toHaveLength(3);
+
+      const hydrationWarnings = result.warnings.filter((w) =>
+        w.toLowerCase().includes('hydration'),
+      );
+      expect(hydrationWarnings).toEqual([]);
+    } finally {
+      result.cleanup();
+    }
+  });
+
+  test('description and error ids survive hydration consistently', async () => {
+    const result = await renderThenHydrate(Select, sourcePath, {
+      id: 'sized',
+      value: 'a',
+      label: 'Sized',
+      description: 'Pick one',
+      error: 'Required',
+      options,
+    });
+
+    try {
+      const select = result.container.querySelector<HTMLSelectElement>('select#sized');
+      const describedBy = select?.getAttribute('aria-describedby') ?? '';
+      expect(describedBy).toContain('sized');
+      // Every referenced description/error node exists in the hydrated tree.
+      for (const referencedId of describedBy.split(/\s+/).filter(Boolean)) {
+        expect(result.container.querySelector(`#${referencedId}`)).not.toBeNull();
+      }
+    } finally {
+      result.cleanup();
+    }
+  });
+});

--- a/packages/components/src/components/slider/slider.svelte
+++ b/packages/components/src/components/slider/slider.svelte
@@ -23,6 +23,7 @@
 
 <script lang="ts">
   import type { SliderProps, SliderValue } from './slider.types.ts';
+  import { untrack } from 'svelte';
   import { getFormFieldContext } from '../../_internal/form-field-context.ts';
   import { classNames } from '../../utilities/class-names.ts';
 
@@ -111,7 +112,7 @@
   // Normalize at construction so the stored state never carries an
   // out-of-bounds or inverted-tuple value, even before the first commit.
   let uncontrolledInternal = $state<SliderValue>(
-    normalizeValueForMode(defaultValue ?? (mode === 'range' ? [min, max] : min)),
+    untrack(() => normalizeValueForMode(defaultValue ?? (mode === 'range' ? [min, max] : min))),
   );
 
   // Controlled flag and current value. When `value` is provided we read

--- a/packages/components/src/components/sortable-list/sortable-list.svelte
+++ b/packages/components/src/components/sortable-list/sortable-list.svelte
@@ -16,6 +16,7 @@
 </script>
 
 <script lang="ts" generics="Item">
+  import { untrack } from 'svelte';
   import { cn } from '../../utilities/class-names.ts';
   import {
     SortableController,
@@ -41,10 +42,12 @@
   }: SortableListProps<Item> = $props();
 
   const announcer = useAnnouncer({ clearDelay: 5000 });
-  const controller = new SortableController<Item>({
-    announce: (msg) => announcer.announce(msg),
-    ...(announcements !== undefined ? { announcements } : {}),
-  });
+  const controller = new SortableController<Item>(
+    untrack(() => ({
+      announce: (msg: string) => announcer.announce(msg),
+      ...(announcements !== undefined ? { announcements } : {}),
+    })),
+  );
 
   const instructionsId = useId('cinder-sortable-instructions');
 

--- a/packages/components/src/components/tab-list/tab-list.test.ts
+++ b/packages/components/src/components/tab-list/tab-list.test.ts
@@ -1,0 +1,52 @@
+/// <reference lib="dom" />
+import { describe, expect, test } from 'bun:test';
+import { createRawSnippet } from 'svelte';
+
+import { setupHappyDom } from '../../test/happy-dom.ts';
+
+setupHappyDom();
+
+const { render } = await import('@testing-library/svelte');
+const { default: Wrapper } = await import('../../test/fixtures/tabs-fixture.svelte');
+const { default: TabList } = await import('./tab-list.svelte');
+
+const items = [
+  { value: 'a', title: 'A tab', body: 'A body' },
+  { value: 'b', title: 'B tab', body: 'B body' },
+];
+
+describe('TabList', () => {
+  test('throws when rendered outside a Tabs component', () => {
+    expect(() =>
+      render(TabList, {
+        props: {
+          children: createRawSnippet(() => ({ render: () => '<span></span>', setup: () => {} })),
+        },
+      }),
+    ).toThrow(/must be used inside a Tabs component/);
+  });
+
+  test('root carries role="tablist"', () => {
+    const { container } = render(Wrapper, { value: 'a', items });
+    expect(container.querySelector('[role="tablist"]')).not.toBeNull();
+  });
+
+  test('aria-orientation reflects the Tabs orientation prop', () => {
+    const horizontal = render(Wrapper, { value: 'a', orientation: 'horizontal', items });
+    expect(
+      horizontal.container.querySelector('[role="tablist"]')?.getAttribute('aria-orientation'),
+    ).toBe('horizontal');
+
+    const vertical = render(Wrapper, { value: 'a', orientation: 'vertical', items });
+    expect(
+      vertical.container.querySelector('[role="tablist"]')?.getAttribute('aria-orientation'),
+    ).toBe('vertical');
+  });
+
+  test('aria-label is wired from the label prop', () => {
+    const { container } = render(Wrapper, { value: 'a', items });
+    expect(container.querySelector('[role="tablist"]')?.getAttribute('aria-label')).toBe(
+      'Test tabs',
+    );
+  });
+});

--- a/packages/components/src/components/tab-panel/tab-panel.svelte
+++ b/packages/components/src/components/tab-panel/tab-panel.svelte
@@ -36,8 +36,8 @@
   // parent's registry. Tab uses the same default id pattern unless the
   // consumer supplies a custom `id` prop, in which case the consumer is
   // responsible for setting `aria-labelledby` on their own.
-  const panelId = `cinder-tab-panel-${value}`;
-  const labelledBy = `cinder-tab-${value}`;
+  const panelId = $derived(`cinder-tab-panel-${value}`);
+  const labelledBy = $derived(`cinder-tab-${value}`);
 </script>
 
 {#if isActive}

--- a/packages/components/src/components/tab-panel/tab-panel.test.ts
+++ b/packages/components/src/components/tab-panel/tab-panel.test.ts
@@ -1,0 +1,47 @@
+/// <reference lib="dom" />
+import { describe, expect, test } from 'bun:test';
+import { createRawSnippet } from 'svelte';
+
+import { setupHappyDom } from '../../test/happy-dom.ts';
+
+setupHappyDom();
+
+const { render } = await import('@testing-library/svelte');
+const { default: Wrapper } = await import('../../test/fixtures/tabs-fixture.svelte');
+const { default: TabPanel } = await import('./tab-panel.svelte');
+
+const emptySnippet = createRawSnippet(() => ({ render: () => '<span></span>', setup: () => {} }));
+
+const items = [
+  { value: 'a', title: 'A tab', body: 'A body' },
+  { value: 'b', title: 'B tab', body: 'B body' },
+];
+
+describe('TabPanel', () => {
+  test('throws when rendered outside a Tabs component', () => {
+    expect(() => render(TabPanel, { props: { value: 'lonely', children: emptySnippet } })).toThrow(
+      /must be used inside a Tabs component/,
+    );
+  });
+
+  test('only the active panel renders and carries role="tabpanel"', () => {
+    const { container } = render(Wrapper, { value: 'a', items });
+    const panels = Array.from(container.querySelectorAll('[role="tabpanel"]'));
+    expect(panels).toHaveLength(1);
+    expect(panels[0]?.textContent).toContain('A body');
+  });
+
+  test('panel id and aria-labelledby derive deterministically from the value', () => {
+    const { container } = render(Wrapper, { value: 'b', items });
+    const panel = container.querySelector('[role="tabpanel"]');
+    expect(panel?.id).toBe('cinder-tab-panel-b');
+    expect(panel?.getAttribute('aria-labelledby')).toBe('cinder-tab-b');
+  });
+
+  test('the rendered panel id matches the active tab aria-controls', () => {
+    const { container } = render(Wrapper, { value: 'a', items });
+    const tab = container.querySelector('[role="tab"][aria-selected="true"]');
+    const panel = container.querySelector('[role="tabpanel"]');
+    expect(tab?.getAttribute('aria-controls')).toBe(panel?.id);
+  });
+});

--- a/packages/components/src/components/tab/tab.svelte
+++ b/packages/components/src/components/tab/tab.svelte
@@ -38,8 +38,8 @@
   // Derive both ids from `value` so TabPanel can independently compute the
   // same id without coordinating through context. Consumers can still override
   // the tab id via the `id` prop; the panel id stays deterministic.
-  const tabId = id ?? `cinder-tab-${value}`;
-  const panelId = `cinder-tab-panel-${value}`;
+  const tabId = $derived(id ?? `cinder-tab-${value}`);
+  const panelId = $derived(`cinder-tab-panel-${value}`);
 
   const isActive = $derived(tabs.isActive(value));
   const isFocusable = $derived(tabs.isFocusable(value));

--- a/packages/components/src/components/tab/tab.test.ts
+++ b/packages/components/src/components/tab/tab.test.ts
@@ -1,0 +1,61 @@
+/// <reference lib="dom" />
+import { describe, expect, test } from 'bun:test';
+import { createRawSnippet } from 'svelte';
+
+import { setupHappyDom } from '../../test/happy-dom.ts';
+
+setupHappyDom();
+
+const { render } = await import('@testing-library/svelte');
+const { default: Wrapper } = await import('../../test/fixtures/tabs-fixture.svelte');
+const { default: Tab } = await import('./tab.svelte');
+
+const items = [
+  { value: 'a', title: 'A tab', body: 'A body' },
+  { value: 'b', title: 'B tab', body: 'B body', disabled: true },
+];
+
+describe('Tab', () => {
+  test('throws when rendered outside a Tabs component', () => {
+    expect(() =>
+      render(Tab, {
+        props: {
+          value: 'lonely',
+          children: createRawSnippet(() => ({
+            render: () => '<span>Lonely</span>',
+            setup: () => {},
+          })),
+        },
+      }),
+    ).toThrow(/must be used inside a Tabs component/);
+  });
+
+  test('each Tab carries role="tab" and a stable id', () => {
+    const { container } = render(Wrapper, { value: 'a', items });
+    const tabs = Array.from(container.querySelectorAll('[role="tab"]'));
+    expect(tabs).toHaveLength(2);
+    expect(tabs[0]?.id).toBe('cinder-tab-a');
+    expect(tabs[1]?.id).toBe('cinder-tab-b');
+  });
+
+  test('aria-selected and roving tabindex respond to the active value', () => {
+    const { container } = render(Wrapper, { value: 'a', items });
+    const tabs = Array.from(container.querySelectorAll('[role="tab"]'));
+    expect(tabs[0]?.getAttribute('aria-selected')).toBe('true');
+    expect(tabs[0]?.getAttribute('tabindex')).toBe('0');
+    expect(tabs[1]?.getAttribute('aria-selected')).toBe('false');
+    expect(tabs[1]?.getAttribute('tabindex')).toBe('-1');
+  });
+
+  test('disabled Tab reflects its disabled prop without erroring', () => {
+    const { container } = render(Wrapper, { value: 'a', items });
+    const disabledTab = container.querySelectorAll('[role="tab"]')[1];
+    expect(disabledTab?.hasAttribute('disabled')).toBe(true);
+  });
+
+  test('aria-controls points at the matching panel id', () => {
+    const { container } = render(Wrapper, { value: 'a', items });
+    const tab = container.querySelector('[role="tab"][aria-selected="true"]');
+    expect(tab?.getAttribute('aria-controls')).toBe('cinder-tab-panel-a');
+  });
+});

--- a/packages/components/src/components/table-body/table-body.test.ts
+++ b/packages/components/src/components/table-body/table-body.test.ts
@@ -1,0 +1,35 @@
+/// <reference lib="dom" />
+import { describe, expect, test } from 'bun:test';
+
+import { setupHappyDom } from '../../test/happy-dom.ts';
+
+setupHappyDom();
+
+const { render } = await import('@testing-library/svelte');
+const { default: Wrapper } = await import('../../test/fixtures/table-fixture.svelte');
+
+const columns = [{ key: 'name', label: 'Name' }];
+const rows = [
+  { id: '1', cells: ['Alice'] },
+  { id: '2', cells: ['Bob'] },
+];
+
+describe('TableBody', () => {
+  test('renders a semantic <tbody> element', () => {
+    const { container } = render(Wrapper, { columns, rows });
+    const body = container.querySelector('tbody');
+    expect(body).not.toBeNull();
+    expect(body?.classList.contains('cinder-table__body')).toBe(true);
+  });
+
+  test('renders one body row per data row inside the <tbody>', () => {
+    const { container } = render(Wrapper, { columns, rows });
+    expect(container.querySelectorAll('tbody tr')).toHaveLength(2);
+  });
+
+  test('renders without errors when there are no rows', () => {
+    const { container } = render(Wrapper, { columns, rows: [] });
+    expect(container.querySelector('tbody')).not.toBeNull();
+    expect(container.querySelectorAll('tbody tr')).toHaveLength(0);
+  });
+});

--- a/packages/components/src/components/table-cell/table-cell.test.ts
+++ b/packages/components/src/components/table-cell/table-cell.test.ts
@@ -1,0 +1,33 @@
+/// <reference lib="dom" />
+import { describe, expect, test } from 'bun:test';
+
+import { setupHappyDom } from '../../test/happy-dom.ts';
+
+setupHappyDom();
+
+const { render } = await import('@testing-library/svelte');
+const { default: Wrapper } = await import('../../test/fixtures/table-fixture.svelte');
+
+const columns = [{ key: 'name', label: 'Name' }];
+const rows = [{ id: '1', cells: ['Alice'] }];
+
+describe('TableCell', () => {
+  test('renders a semantic <td> with the cinder cell class', () => {
+    const { container } = render(Wrapper, { columns, rows });
+    const cell = container.querySelector('tbody td');
+    expect(cell).not.toBeNull();
+    expect(cell?.classList.contains('cinder-table__cell')).toBe(true);
+  });
+
+  test('renders the provided cell content', () => {
+    const { container } = render(Wrapper, { columns, rows });
+    const cell = container.querySelector('tbody td');
+    expect(cell?.textContent).toContain('Alice');
+  });
+
+  test('default alignment is reflected via the data-cinder-align attribute', () => {
+    const { container } = render(Wrapper, { columns, rows });
+    const cell = container.querySelector('tbody td');
+    expect(cell?.getAttribute('data-cinder-align')).toBe('left');
+  });
+});

--- a/packages/components/src/components/table-header/table-header.svelte
+++ b/packages/components/src/components/table-header/table-header.svelte
@@ -15,7 +15,7 @@
 
 <script lang="ts">
   import type { TableHeaderProps } from './table-header.types.ts';
-  import { getContext, setContext } from 'svelte';
+  import { getContext, setContext, untrack } from 'svelte';
 
   import {
     TABLE_CONTEXT_KEY,
@@ -41,9 +41,10 @@
   const table = getContext<TableContext | undefined>(TABLE_CONTEXT_KEY);
   const selectionEnabled = table?.selectionEnabled ?? false;
 
+  // One-time mount-time guard; read the props untracked.
   if (
     selectionEnabled &&
-    (allSelected === undefined || someSelected === undefined || !onSelectAll)
+    untrack(() => allSelected === undefined || someSelected === undefined || !onSelectAll)
   ) {
     throw new Error(
       '[Cinder] TableHeader: `allSelected`, `someSelected`, and `onSelectAll` are required when Table.selectable is true.',

--- a/packages/components/src/components/table-header/table-header.test.ts
+++ b/packages/components/src/components/table-header/table-header.test.ts
@@ -1,0 +1,49 @@
+/// <reference lib="dom" />
+import { describe, expect, test } from 'bun:test';
+
+import { setupHappyDom } from '../../test/happy-dom.ts';
+
+setupHappyDom();
+
+const { render } = await import('@testing-library/svelte');
+const { default: Wrapper } = await import('../../test/fixtures/table-fixture.svelte');
+
+const columns = [
+  { key: 'name', label: 'Name' },
+  { key: 'age', label: 'Age' },
+];
+const rows = [{ id: '1', cells: ['Alice', '30'] }];
+
+describe('TableHeader', () => {
+  test('renders a semantic <thead> with the cinder header class', () => {
+    const { container } = render(Wrapper, { columns, rows });
+    const head = container.querySelector('thead');
+    expect(head).not.toBeNull();
+    expect(head?.classList.contains('cinder-table__header')).toBe(true);
+  });
+
+  test('renders the header row with one cell per column', () => {
+    const { container } = render(Wrapper, { columns, rows });
+    const headerCells = container.querySelectorAll('thead th');
+    expect(headerCells.length).toBeGreaterThanOrEqual(2);
+  });
+
+  test('renders a leading select-all header cell when the table is selectable', () => {
+    const { container } = render(Wrapper, { columns, rows, selectable: true });
+    const selectionCell = container.querySelector('thead .cinder-table__header-cell--selection');
+    expect(selectionCell).not.toBeNull();
+    expect(selectionCell?.querySelector<HTMLInputElement>('input[type="checkbox"]')).not.toBeNull();
+  });
+
+  test('throws when selection is enabled but required selection props are absent', () => {
+    expect(() =>
+      render(Wrapper, {
+        columns,
+        rows,
+        selectable: true,
+        includeHeaderSelectionState: false,
+        includeHeaderSelectionHandler: false,
+      }),
+    ).toThrow(/required when Table.selectable is true/);
+  });
+});

--- a/packages/components/src/components/table-row/table-row.svelte
+++ b/packages/components/src/components/table-row/table-row.svelte
@@ -16,7 +16,7 @@
 
 <script lang="ts">
   import type { TableRowProps } from './table-row.types.ts';
-  import { getContext } from 'svelte';
+  import { getContext, untrack } from 'svelte';
 
   import {
     TABLE_CONTEXT_KEY,
@@ -47,22 +47,25 @@
     TABLE_HEADER_SELECTION_CONTEXT_KEY,
   );
 
-  // Validate body rows when selection is enabled.
+  // Validate body rows when selection is enabled. This is a one-time mount-time
+  // guard, so the prop reads are untracked.
   if (selectionEnabled && section === 'body') {
-    const hasDisabled = selectionDisabled === true;
-    if (!hasDisabled) {
-      // All three must be present — reject partial trios.
-      const hasSelected = selected !== undefined;
-      const hasOnChange = onSelectedChange !== undefined;
-      const hasLabel = selectionLabel !== undefined;
-      if (!hasSelected || !hasOnChange || !hasLabel) {
-        throw new Error(
-          '[Cinder] TableRow: when Table.selectable is true, each body row must supply ' +
-            'selected + onSelectedChange + selectionLabel together, or set selectionDisabled={true}. ' +
-            `Missing: ${[!hasSelected && 'selected', !hasOnChange && 'onSelectedChange', !hasLabel && 'selectionLabel'].filter(Boolean).join(', ')}.`,
-        );
+    untrack(() => {
+      const hasDisabled = selectionDisabled === true;
+      if (!hasDisabled) {
+        // All three must be present — reject partial trios.
+        const hasSelected = selected !== undefined;
+        const hasOnChange = onSelectedChange !== undefined;
+        const hasLabel = selectionLabel !== undefined;
+        if (!hasSelected || !hasOnChange || !hasLabel) {
+          throw new Error(
+            '[Cinder] TableRow: when Table.selectable is true, each body row must supply ' +
+              'selected + onSelectedChange + selectionLabel together, or set selectionDisabled={true}. ' +
+              `Missing: ${[!hasSelected && 'selected', !hasOnChange && 'onSelectedChange', !hasLabel && 'selectionLabel'].filter(Boolean).join(', ')}.`,
+          );
+        }
       }
-    }
+    });
   }
 
   // Warn when a row is rendered directly under Table (no section context) with selection on.

--- a/packages/components/src/components/table-row/table-row.test.ts
+++ b/packages/components/src/components/table-row/table-row.test.ts
@@ -1,0 +1,46 @@
+/// <reference lib="dom" />
+import { describe, expect, test } from 'bun:test';
+
+import { setupHappyDom } from '../../test/happy-dom.ts';
+
+setupHappyDom();
+
+const { render } = await import('@testing-library/svelte');
+const { default: Wrapper } = await import('../../test/fixtures/table-fixture.svelte');
+
+const columns = [{ key: 'name', label: 'Name' }];
+const rows = [{ id: '1', cells: ['Alice'] }];
+
+describe('TableRow', () => {
+  test('renders a semantic <tr> with the cinder row class', () => {
+    const { container } = render(Wrapper, { columns, rows });
+    const bodyRow = container.querySelector('tbody tr');
+    expect(bodyRow).not.toBeNull();
+    expect(bodyRow?.classList.contains('cinder-table__row')).toBe(true);
+  });
+
+  test('renders its cell children inside the row', () => {
+    const { container } = render(Wrapper, { columns, rows });
+    const bodyRow = container.querySelector('tbody tr');
+    expect(bodyRow?.querySelector('td')?.textContent).toContain('Alice');
+  });
+
+  test('selectable body rows render a per-row selection checkbox with an accessible name', () => {
+    const { container } = render(Wrapper, { columns, rows, selectable: true });
+    const bodyRow = container.querySelector('tbody tr');
+    const checkbox = bodyRow?.querySelector<HTMLInputElement>('input[type="checkbox"]');
+    expect(checkbox).not.toBeNull();
+    expect(checkbox?.getAttribute('aria-label')).toBe('Select Alice');
+  });
+
+  test('a selection-disabled row renders a disabled checkbox cell instead of an active control', () => {
+    const { container } = render(Wrapper, {
+      columns,
+      rows: [{ id: '1', cells: ['Alice'], selectionDisabled: true }],
+      selectable: true,
+    });
+    const bodyRow = container.querySelector('tbody tr');
+    const checkbox = bodyRow?.querySelector<HTMLInputElement>('input[type="checkbox"]');
+    expect(checkbox?.disabled).toBe(true);
+  });
+});

--- a/packages/components/src/components/toast-region/toast-region.test.ts
+++ b/packages/components/src/components/toast-region/toast-region.test.ts
@@ -6,6 +6,7 @@ import { afterEach, describe, expect, jest, test } from 'bun:test';
 import { _resetEscapeStack, pushEscapeHandler } from '../../_internal/overlay.ts';
 import type { ToastApi } from '../../_internal/toast-context.ts';
 import { setupHappyDom } from '../../test/happy-dom.ts';
+import { expectNoLeakedTimers, trackTimers } from '../../test/lifecycle.ts';
 
 setupHappyDom();
 
@@ -527,6 +528,30 @@ describe('useToast api', () => {
 
     expect(jest.getTimerCount()).toBe(0);
     expect(document.body.textContent ?? '').not.toContain('Saved');
+  });
+
+  // Real-timer counterpart to the deterministic leak test above: tracks the
+  // global setTimeout/setInterval table directly (no fake timers) so a toast
+  // that schedules an auto-dismiss timer must clear it on unmount.
+  test('unmounting the region leaves no real auto-dismiss timer pending', async () => {
+    const timers = trackTimers();
+    try {
+      let api: ToastApi | null = null;
+      const { unmount } = render(Wrapper, {
+        onReady: (a: ToastApi) => {
+          api = a;
+        },
+      });
+      await waitFor(() => expect(api).not.toBeNull());
+      api!.show('Heads up', { duration: 10_000 });
+      await tick();
+
+      unmount();
+      await tick();
+      expectNoLeakedTimers(timers.active());
+    } finally {
+      timers.release();
+    }
   });
 
   test('action fires once and dismisses by default even when not otherwise dismissible', async () => {

--- a/packages/components/src/components/toggle/toggle.svelte
+++ b/packages/components/src/components/toggle/toggle.svelte
@@ -58,10 +58,10 @@
     onclick gives click-to-toggle. toggle() is disabled-guarded, so clicking the
     label of a disabled toggle is a no-op.
   -->
-  <!-- svelte-ignore a11y_click_events_have_key_events a11y_no_static_element_interactions -->
   <span
     id={labelId}
     class="cinder-toggle-field__label"
+    role="presentation"
     data-hidden={hideLabel || undefined}
     data-disabled={disabled || undefined}
     onclick={toggle}

--- a/packages/components/src/components/tooltip/tooltip.svelte
+++ b/packages/components/src/components/tooltip/tooltip.svelte
@@ -20,6 +20,7 @@
   import type { Attachment } from 'svelte/attachments';
   import type { Placement } from '@floating-ui/dom';
   import { autoUpdate, computePosition, flip, offset, shift } from '@floating-ui/dom';
+  import { untrack } from 'svelte';
   import { cn } from '../../utilities/class-names.ts';
   import { useId } from '../../utilities/use-id.ts';
 
@@ -55,7 +56,9 @@
   let wrapperElement: HTMLSpanElement | undefined = $state();
   let tooltipElement: HTMLSpanElement | undefined = $state();
   let anchorElement = $state<HTMLElement | null>(null);
-  let computedPlacement = $state<Placement>(placement);
+  // Seeded once from the initial `placement`; the position effect (below) keeps
+  // it in sync as the prop or floating-ui's flip result changes.
+  let computedPlacement = $state<Placement>(untrack(() => placement));
   let positionStyle = $state('');
   let positionReady = $state(false);
   const isTooltipExposed = $derived(visible && positionReady);
@@ -228,8 +231,15 @@
   });
 </script>
 
+<!--
+  Presentational positioning wrapper. The hover/focus handlers only toggle
+  tooltip visibility; the accessible tooltip semantics live on the role="tooltip"
+  span below and the consumer's trigger child. role="presentation" keeps this
+  wrapper out of the accessibility tree.
+-->
 <span
   class={cn('cinder-tooltip-wrapper', className)}
+  role="presentation"
   onmouseenter={handleMouseEnter}
   onmouseleave={handleMouseLeave}
   onfocusin={handleFocusIn}

--- a/packages/components/src/components/tooltip/tooltip.test.ts
+++ b/packages/components/src/components/tooltip/tooltip.test.ts
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
 import { createRawSnippet } from 'svelte';
 
 import { setupHappyDom } from '../../test/happy-dom.ts';
+import { expectNoLeakedTimers, trackTimers } from '../../test/lifecycle.ts';
 
 setupHappyDom();
 
@@ -83,6 +84,10 @@ function queryTooltip(): HTMLElement | null {
   return document.body.querySelector('[role="tooltip"]');
 }
 
+// Tooltip schedules show/hide via setTimeout; track timers per test so a
+// component that forgets to clear its pending timer on unmount is caught here.
+let timers: ReturnType<typeof trackTimers>;
+
 beforeEach(() => {
   computePositionResult = {
     x: 16,
@@ -92,10 +97,13 @@ beforeEach(() => {
   computePositionShouldReject = false;
   deferComputePosition = false;
   deferredResolvers = [];
+  timers = trackTimers();
 });
 
 afterEach(() => {
   cleanup();
+  const leaked = timers.active();
+  timers.release();
   computePositionSpy.mockClear();
   autoUpdateSpy.mockClear();
   autoUpdateTeardown.mockClear();
@@ -103,6 +111,7 @@ afterEach(() => {
   flipSpy.mockClear();
   shiftSpy.mockClear();
   offsetSpy.mockClear();
+  expectNoLeakedTimers(leaked);
 });
 
 describe('Tooltip', () => {

--- a/packages/components/src/components/tree-item/tree-item.test.ts
+++ b/packages/components/src/components/tree-item/tree-item.test.ts
@@ -1,0 +1,36 @@
+/// <reference lib="dom" />
+import { describe, expect, test } from 'bun:test';
+
+import { setupHappyDom } from '../../test/happy-dom.ts';
+
+setupHappyDom();
+
+const { render } = await import('@testing-library/svelte');
+const { default: Wrapper } = await import('../../test/fixtures/tree-attach-fixture.svelte');
+const { default: TreeItem } = await import('./tree-item.svelte');
+
+describe('TreeItem', () => {
+  test('throws when rendered outside a Tree', () => {
+    expect(() => render(TreeItem, { props: { id: 'lonely', label: 'Lonely' } })).toThrow(
+      /must be used inside a Tree component/,
+    );
+  });
+
+  test('renders one element with role="treeitem" per item', () => {
+    const { container } = render(Wrapper, { ids: ['a', 'b', 'c'] });
+    expect(container.querySelectorAll('[role="treeitem"]')).toHaveLength(3);
+  });
+
+  test('treeitems expose aria-level', () => {
+    const { container } = render(Wrapper, { ids: ['a', 'b'] });
+    const items = Array.from(container.querySelectorAll('[role="treeitem"]'));
+    expect(items.every((item) => item.getAttribute('aria-level') === '1')).toBe(true);
+  });
+
+  test('roving tabindex puts exactly one treeitem in the tab order', () => {
+    const { container } = render(Wrapper, { ids: ['a', 'b', 'c'] });
+    const items = Array.from(container.querySelectorAll('[role="treeitem"]'));
+    const focusable = items.filter((item) => item.getAttribute('tabindex') === '0');
+    expect(focusable).toHaveLength(1);
+  });
+});

--- a/packages/components/src/components/tree-select-all/tree-select-all.test.ts
+++ b/packages/components/src/components/tree-select-all/tree-select-all.test.ts
@@ -1,0 +1,87 @@
+/// <reference lib="dom" />
+import { describe, expect, test } from 'bun:test';
+import { createRawSnippet, mount, unmount } from 'svelte';
+
+import { setupHappyDom } from '../../test/happy-dom.ts';
+
+setupHappyDom();
+
+const { render, fireEvent } = await import('@testing-library/svelte');
+const { default: Tree } = await import('../tree/tree.svelte');
+const { default: TreeItem } = await import('../tree-item/tree-item.svelte');
+const { default: TreeSelectAll } = await import('./tree-select-all.svelte');
+
+/**
+ * Render TreeSelectAll inside a multi-select Tree's `selectionControls` slot,
+ * which is the only context in which it is valid. Returns the Tree container.
+ */
+function renderSelectAll(captured: { selectedIds: string[] }) {
+  const selectionControls = createRawSnippet(() => ({
+    render: () => `<div class="controls"></div>`,
+    setup: (node: Element) => {
+      const instance = mount(TreeSelectAll, { target: node, props: { parentId: null } });
+      return () => unmount(instance);
+    },
+  }));
+
+  const children = createRawSnippet(() => ({
+    render: () => `<div class="items"></div>`,
+    setup: (node: Element) => {
+      const a = mount(TreeItem, { target: node, props: { id: 'a', label: 'A' } });
+      const b = mount(TreeItem, { target: node, props: { id: 'b', label: 'B' } });
+      return () => {
+        unmount(a);
+        unmount(b);
+      };
+    },
+  }));
+
+  return render(Tree, {
+    props: {
+      'aria-label': 'Files',
+      selectionMode: 'multiple',
+      get selectedIds() {
+        return captured.selectedIds;
+      },
+      set selectedIds(value: string[]) {
+        captured.selectedIds = value;
+      },
+      selectionControls,
+      children,
+    },
+  });
+}
+
+describe('TreeSelectAll', () => {
+  test('renders select and clear buttons with accessible names', () => {
+    const captured = { selectedIds: [] as string[] };
+    const { container } = renderSelectAll(captured);
+    const buttons = container.querySelectorAll<HTMLButtonElement>(
+      '.cinder-tree-select-all__button',
+    );
+    expect(buttons).toHaveLength(2);
+    // Default labels: "Select all: Tree selection" / "Select none: Tree selection".
+    expect(buttons[0]?.getAttribute('aria-label')).toContain('Select all');
+    expect(buttons[1]?.getAttribute('aria-label')).toContain('Select none');
+  });
+
+  test('the select button selects every registered id at the level', async () => {
+    const captured = { selectedIds: [] as string[] };
+    const { container } = renderSelectAll(captured);
+    const buttons = container.querySelectorAll<HTMLButtonElement>(
+      '.cinder-tree-select-all__button',
+    );
+    await fireEvent.click(buttons[0]!);
+    expect(captured.selectedIds).toEqual(['a', 'b']);
+  });
+
+  test('the clear button removes the level ids from the selection', async () => {
+    const captured = { selectedIds: ['a', 'b'] };
+    const { container } = renderSelectAll(captured);
+    const buttons = container.querySelectorAll<HTMLButtonElement>(
+      '.cinder-tree-select-all__button',
+    );
+    await fireEvent.click(buttons[1]!);
+    expect(captured.selectedIds).toEqual([]);
+  });
+});

--- a/packages/components/src/components/tree/tree.svelte
+++ b/packages/components/src/components/tree/tree.svelte
@@ -416,6 +416,7 @@
 
     <div
       role="tree"
+      tabindex="-1"
       class={classNames('cinder-tree', className)}
       aria-label={ariaLabel}
       aria-labelledby={ariaLabelledBy}
@@ -429,6 +430,7 @@
 {:else}
   <div
     role="tree"
+    tabindex="-1"
     class={classNames('cinder-tree', className)}
     aria-label={ariaLabel}
     aria-labelledby={ariaLabelledBy}

--- a/packages/components/src/convention.test.ts
+++ b/packages/components/src/convention.test.ts
@@ -91,26 +91,8 @@ const NO_CLASS_MERGING_ALLOW_LIST = new Set<string>([]);
  */
 const NO_TEST_REQUIRED_ALLOW_LIST = new Set([
   'command-item', // TODO: add tests and remove from allow-list
-  'context-menu-trigger', // TODO: add tests and remove from allow-list
-  'dropdown-group', // TODO: add tests and remove from allow-list
-  'dropdown-item', // TODO: add tests and remove from allow-list
-  'dropdown-label', // TODO: add tests and remove from allow-list
-  'dropdown-menu', // TODO: add tests and remove from allow-list
-  'dropdown-separator', // TODO: add tests and remove from allow-list
-  'dropdown-trigger', // TODO: add tests and remove from allow-list
   'markdown-editor', // TODO: add tests and remove from allow-list
-  'radio', // TODO: add tests and remove from allow-list
   'review-editor', // TODO: add tests and remove from allow-list
-  'segment', // TODO: add tests and remove from allow-list
-  'tab', // TODO: add tests and remove from allow-list
-  'tab-list', // TODO: add tests and remove from allow-list
-  'tab-panel', // TODO: add tests and remove from allow-list
-  'table-body', // TODO: add tests and remove from allow-list
-  'table-cell', // TODO: add tests and remove from allow-list
-  'table-header', // TODO: add tests and remove from allow-list
-  'table-row', // TODO: add tests and remove from allow-list
-  'tree-item', // TODO: add tests and remove from allow-list
-  'tree-select-all', // TODO: add tests and remove from allow-list
 ]);
 
 /**

--- a/packages/components/src/test/fixtures/command-menu-fixture.svelte
+++ b/packages/components/src/test/fixtures/command-menu-fixture.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { untrack } from 'svelte';
   import CommandItem from '../../components/command-item/command-item.svelte';
   import CommandMenu from '../../components/command-menu/command-menu.svelte';
 
@@ -20,9 +21,9 @@
   };
 
   const props: Props = $props();
-  const initialValue = props.initialValue ?? '/a';
-  const initialQuery = props.initialQuery ?? '';
-  const initialOpen = props.initialOpen ?? true;
+  const initialValue = untrack(() => props.initialValue) ?? '/a';
+  const initialQuery = untrack(() => props.initialQuery) ?? '';
+  const initialOpen = untrack(() => props.initialOpen) ?? true;
   const commandItems = $derived(
     props.items ?? [
       { value: 'alpha', label: 'Alpha' },

--- a/packages/components/src/test/fixtures/command-menu-host-fixture.svelte
+++ b/packages/components/src/test/fixtures/command-menu-host-fixture.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { untrack } from 'svelte';
   import CommandItem from '../../components/command-item/command-item.svelte';
   import CommandMenu from '../../components/command-menu/command-menu.svelte';
   import { detectTrigger } from '../../components/command-menu/command-menu-trigger.ts';
@@ -12,7 +13,7 @@
   };
 
   const props: Props = $props();
-  const fieldKind = props.fieldKind ?? 'textarea';
+  const fieldKind = untrack(() => props.fieldKind) ?? 'textarea';
   const onSelected = $derived(props.onSelected ?? (() => {}));
   const onDismissed = $derived(props.onDismissed ?? (() => {}));
 

--- a/packages/components/src/test/fixtures/command-palette-fixture.svelte
+++ b/packages/components/src/test/fixtures/command-palette-fixture.svelte
@@ -16,6 +16,7 @@
 </script>
 
 <script lang="ts">
+  import { untrack } from 'svelte';
   import CommandItem from '../../components/command-item/command-item.svelte';
   import CommandPalette from '../../components/command-palette/command-palette.svelte';
 
@@ -32,8 +33,8 @@
     onSelected,
   }: CommandPaletteFixtureProps = $props();
 
-  let open = $state(initialOpen);
-  let query = $state(initialQuery);
+  let open = $state(untrack(() => initialOpen));
+  let query = $state(untrack(() => initialQuery));
   let triggerRef: HTMLButtonElement | null = $state(null);
 
   const visibleItems = $derived(

--- a/packages/components/src/test/fixtures/form-field-autocomplete-fixture.svelte
+++ b/packages/components/src/test/fixtures/form-field-autocomplete-fixture.svelte
@@ -29,23 +29,23 @@
     suggestionSource = () => [],
   }: Props = $props();
 
-  const formFieldProps = {
+  const formFieldProps = $derived({
     id: fieldId,
     label: fieldLabel,
     ...(fieldDescription !== undefined ? { description: fieldDescription } : {}),
     ...(fieldError !== undefined ? { error: fieldError } : {}),
     ...(disabled ? { disabled: true } : {}),
     ...(required ? { required: true } : {}),
-  };
+  });
 
-  const resolvedAutocompleteProps = {
+  const resolvedAutocompleteProps = $derived({
     id: fieldId,
     value,
     suggestionSource,
     placeholder: 'Start typing',
     ...(controlError !== undefined ? { error: controlError } : {}),
     ...autocompleteProps,
-  };
+  });
 </script>
 
 <FormField {...formFieldProps}>

--- a/packages/components/src/test/fixtures/popover-bindable-fixture.svelte
+++ b/packages/components/src/test/fixtures/popover-bindable-fixture.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { untrack } from 'svelte';
   import Popover from '../../components/popover/popover.svelte';
   import type { PopoverProps } from '../../components/popover/popover.types.ts';
 
@@ -19,15 +20,15 @@
     role,
   }: Props = $props();
 
-  let open = $state(initialOpen);
+  let open = $state(untrack(() => initialOpen));
 
-  const popoverProps = {
+  const popoverProps = $derived({
     ...(focusManagement !== undefined ? { focusManagement } : {}),
     ...(triggerRef !== null ? { triggerRef } : {}),
     ...(wireTriggerAria !== undefined ? { wireTriggerAria } : {}),
     ...(id !== undefined ? { id } : {}),
     ...(role !== undefined ? { role } : {}),
-  };
+  });
 </script>
 
 <div>

--- a/packages/components/src/test/fixtures/segmented-control-fixture.svelte
+++ b/packages/components/src/test/fixtures/segmented-control-fixture.svelte
@@ -32,6 +32,7 @@
 </script>
 
 <script lang="ts">
+  import { untrack } from 'svelte';
   import Segment from '../../components/segment/segment.svelte';
   import SegmentedControl from '../../components/segmented-control/segmented-control.svelte';
 
@@ -57,7 +58,7 @@
     rest = {},
   }: FixtureProps = $props();
 
-  void onValueChange;
+  void untrack(() => onValueChange);
 </script>
 
 <!--

--- a/packages/components/src/test/fixtures/surface-tone-mutator.svelte
+++ b/packages/components/src/test/fixtures/surface-tone-mutator.svelte
@@ -12,14 +12,14 @@
 </script>
 
 <script lang="ts">
-  import { onMount } from 'svelte';
+  import { onMount, untrack } from 'svelte';
 
   import Surface from '../../components/surface/surface.svelte';
   import SurfaceContextProbe from './surface-context-probe.svelte';
 
   let { initial, onReady, testid = 'mutator-probe', children }: SurfaceToneMutatorProps = $props();
 
-  let tone = $state<SurfaceTone>(initial);
+  let tone = $state<SurfaceTone>(untrack(() => initial));
 
   onMount(() => {
     onReady({

--- a/packages/components/src/test/fixtures/toast-probe.svelte
+++ b/packages/components/src/test/fixtures/toast-probe.svelte
@@ -14,6 +14,7 @@
 </script>
 
 <script lang="ts">
+  import { untrack } from 'svelte';
   import { useToast } from '../../utilities/use-toast.ts';
 
   let { onReady, onInitialize }: ToastProbeProps = $props();
@@ -21,7 +22,7 @@
   // useToast() must run during this component's setup, when getContext walks
   // the parent chain and finds ToastRegion's context.
   const api = useToast();
-  onInitialize?.(api);
+  untrack(() => onInitialize)?.(api);
   // Hand the api to the test once mounted.
   $effect(() => {
     onReady(api);

--- a/packages/components/src/test/hydrate.test.ts
+++ b/packages/components/src/test/hydrate.test.ts
@@ -87,7 +87,10 @@ describe('renderThenHydrate', () => {
     expect(registered.every((path) => existsSync(path))).toBe(false);
     expect(__tempFileRegistryForTests.paths.size).toBe(0);
 
-    // The orphaned container is harmless to leave, but tidy it for the suite.
-    result.container.remove();
+    // The safety net is proven. Now run the real cleanup() to unmount the
+    // component instance (not just remove the container) so its effects and
+    // listeners don't leak into later tests. The temp file is already gone, so
+    // cleanup()'s own unlink is a harmless no-op.
+    result.cleanup();
   });
 });

--- a/packages/components/src/test/hydrate.test.ts
+++ b/packages/components/src/test/hydrate.test.ts
@@ -8,6 +8,7 @@
  * the Phase 1 form controls too.
  */
 
+import { existsSync } from 'node:fs';
 import { join } from 'node:path';
 
 import { describe, expect, test } from 'bun:test';
@@ -16,7 +17,7 @@ import { setupHappyDom } from './happy-dom.ts';
 
 setupHappyDom();
 
-const { renderThenHydrate } = await import('./hydrate.ts');
+const { renderThenHydrate, __tempFileRegistryForTests } = await import('./hydrate.ts');
 const { default: Input } = await import('../components/input/input.svelte');
 
 const INPUT_SOURCE = join(import.meta.dir, '..', 'components', 'input', 'input.svelte');
@@ -63,5 +64,30 @@ describe('renderThenHydrate', () => {
     } finally {
       result.cleanup();
     }
+  });
+
+  test('exit-handler safety net unlinks temp files when cleanup() is skipped', async () => {
+    // Deliberately do NOT call result.cleanup() — simulate a test that throws
+    // or a process interruption before per-test cleanup runs.
+    const result = await renderThenHydrate(Input, INPUT_SOURCE, {
+      id: 'hydrate-orphan',
+      value: '',
+      label: 'Orphan',
+    });
+
+    // The temp SSR module is on disk and registered for exit cleanup.
+    const registered = [...__tempFileRegistryForTests.paths];
+    expect(registered.length).toBeGreaterThan(0);
+    expect(registered.every((path) => existsSync(path))).toBe(true);
+
+    // Run exactly what the process-exit handler runs.
+    __tempFileRegistryForTests.runExitCleanup();
+
+    // Every registered temp file is gone and the registry is drained.
+    expect(registered.every((path) => existsSync(path))).toBe(false);
+    expect(__tempFileRegistryForTests.paths.size).toBe(0);
+
+    // The orphaned container is harmless to leave, but tidy it for the suite.
+    result.container.remove();
   });
 });

--- a/packages/components/src/test/hydrate.ts
+++ b/packages/components/src/test/hydrate.ts
@@ -27,7 +27,7 @@
 /// <reference lib="dom" />
 
 import { unlinkSync } from 'node:fs';
-import { rm, writeFile } from 'node:fs/promises';
+import { writeFile } from 'node:fs/promises';
 import { dirname, join } from 'node:path';
 import { pathToFileURL } from 'node:url';
 
@@ -245,11 +245,18 @@ export async function renderThenHydrate<Props extends Record<string, unknown>>(
         }
       }
       container.remove();
-      // Remove the temp SSR file we created next to the source and deregister
-      // it from the exit-handler safety net. Best-effort — failures don't break
-      // the test, just leave a stray file the exit handler will sweep later.
-      pendingTempFiles.delete(file);
-      void rm(file, { force: true }).catch(() => {});
+      // Remove the temp SSR file we created next to the source, then deregister
+      // it from the exit-handler safety net. Unlink SYNCHRONOUSLY and deregister
+      // only AFTER removal: an async rm() + immediate deregister would lose the
+      // file if rm() failed or the process exited before it settled (the exit
+      // handler skips already-deregistered paths). Best-effort — a unlink failure
+      // doesn't break the test; the path stays registered for the exit sweep.
+      try {
+        unlinkSync(file);
+        pendingTempFiles.delete(file);
+      } catch {
+        // Leave it registered so the exit-handler safety net still sweeps it.
+      }
     },
   };
 }

--- a/packages/components/src/test/hydrate.ts
+++ b/packages/components/src/test/hydrate.ts
@@ -26,6 +26,7 @@
 
 /// <reference lib="dom" />
 
+import { unlinkSync } from 'node:fs';
 import { rm, writeFile } from 'node:fs/promises';
 import { dirname, join } from 'node:path';
 import { pathToFileURL } from 'node:url';
@@ -34,6 +35,58 @@ import { hydrate, type Component } from 'svelte';
 import { compile } from 'svelte/compiler';
 
 import { setupHappyDom } from './happy-dom.ts';
+
+/**
+ * Every temp SSR module this helper writes is registered here. The per-test
+ * `cleanup()` removes its own file and deregisters it; the process-exit handler
+ * below is the safety net that synchronously unlinks anything still registered
+ * if a test throws or the process is interrupted before `cleanup()` runs.
+ */
+const pendingTempFiles = new Set<string>();
+
+let exitHandlersRegistered = false;
+
+/** Synchronously remove every still-registered temp file. Safe to call twice. */
+function cleanupRegisteredTempFiles(): void {
+  for (const path of pendingTempFiles) {
+    try {
+      unlinkSync(path);
+    } catch {
+      // Already gone (per-test cleanup beat us to it) — ignore.
+    }
+    pendingTempFiles.delete(path);
+  }
+}
+
+/**
+ * Install process-exit / signal handlers exactly once. The `exit` handler must
+ * be fully synchronous (Node ignores async work during exit), so it uses
+ * `unlinkSync`. SIGINT/SIGTERM clean up, then re-raise the default behaviour so
+ * the process still terminates.
+ */
+function ensureExitHandlersRegistered(): void {
+  if (exitHandlersRegistered) return;
+  exitHandlersRegistered = true;
+
+  process.on('exit', cleanupRegisteredTempFiles);
+  for (const signal of ['SIGINT', 'SIGTERM'] as const) {
+    process.on(signal, () => {
+      cleanupRegisteredTempFiles();
+      // Restore default disposition and re-raise so exit codes stay correct.
+      process.removeAllListeners(signal);
+      process.kill(process.pid, signal);
+    });
+  }
+}
+
+/**
+ * Test-only accessors for the temp-file registry. Exposed so `hydrate.test.ts`
+ * can verify the exit-handler safety net without actually exiting the process.
+ */
+export const __tempFileRegistryForTests = {
+  paths: pendingTempFiles,
+  runExitCleanup: cleanupRegisteredTempFiles,
+};
 
 /** Result of a single render-then-hydrate pass. */
 export type HydrateResult = {
@@ -97,6 +150,8 @@ export async function renderThenHydrate<Props extends Record<string, unknown>>(
   const sourceDir = dirname(sourcePath);
   const ssrFileName = `.cinder-ssr-${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2)}.mjs`;
   const file = join(sourceDir, ssrFileName);
+  ensureExitHandlersRegistered();
+  pendingTempFiles.add(file);
   await writeFile(file, serverCode, 'utf-8');
 
   // The SSR module's default export is a server-only render function whose
@@ -159,8 +214,10 @@ export async function renderThenHydrate<Props extends Record<string, unknown>>(
         }
       }
       container.remove();
-      // Remove the temp SSR file we created next to the source. Best-effort —
-      // failures don't break the test, just leave a stray file.
+      // Remove the temp SSR file we created next to the source and deregister
+      // it from the exit-handler safety net. Best-effort — failures don't break
+      // the test, just leave a stray file the exit handler will sweep later.
+      pendingTempFiles.delete(file);
       void rm(file, { force: true }).catch(() => {});
     },
   };

--- a/packages/components/src/test/hydrate.ts
+++ b/packages/components/src/test/hydrate.ts
@@ -70,12 +70,16 @@ function ensureExitHandlersRegistered(): void {
 
   process.on('exit', cleanupRegisteredTempFiles);
   for (const signal of ['SIGINT', 'SIGTERM'] as const) {
-    process.on(signal, () => {
+    // Install a *named* handler and, on fire, remove only this handler before
+    // re-raising — `process.removeAllListeners(signal)` would wipe unrelated
+    // signal handlers owned by the test runner or other infrastructure.
+    const handler = () => {
       cleanupRegisteredTempFiles();
-      // Restore default disposition and re-raise so exit codes stay correct.
-      process.removeAllListeners(signal);
+      process.off(signal, handler);
+      // Re-raise so the default disposition runs and exit codes stay correct.
       process.kill(process.pid, signal);
-    });
+    };
+    process.on(signal, handler);
   }
 }
 
@@ -83,7 +87,10 @@ function ensureExitHandlersRegistered(): void {
  * Test-only accessors for the temp-file registry. Exposed so `hydrate.test.ts`
  * can verify the exit-handler safety net without actually exiting the process.
  */
-export const __tempFileRegistryForTests = {
+export const __tempFileRegistryForTests: {
+  paths: ReadonlySet<string>;
+  runExitCleanup: () => void;
+} = {
   paths: pendingTempFiles,
   runExitCleanup: cleanupRegisteredTempFiles,
 };
@@ -152,46 +159,61 @@ export async function renderThenHydrate<Props extends Record<string, unknown>>(
   const file = join(sourceDir, ssrFileName);
   ensureExitHandlersRegistered();
   pendingTempFiles.add(file);
-  await writeFile(file, serverCode, 'utf-8');
 
-  // The SSR module's default export is a server-only render function whose
-  // shape (`($$renderer, $$props) => void`) doesn't match the public
-  // `Component<Props>` type. `svelte/server.render` accepts both shapes at
-  // runtime; we route through `unknown` because the public types are too
-  // narrow to express the dual-target reality.
-  const ssrModule = (await import(file)) as { default: unknown };
-
-  const { render } = (await import('svelte/server')) as typeof import('svelte/server');
-  const originalDocument = globalThis.document;
-  const originalWindow = globalThis.window;
-  globalThis.document = undefined as unknown as Document;
-  globalThis.window = undefined as unknown as Window & typeof globalThis;
+  // Everything from the temp-file write through the hydrate is wrapped so that
+  // any failure BEFORE we return a `cleanup()` to the caller still removes and
+  // deregisters the temp file. Without this, a throw in import/render/hydrate
+  // would orphan the file until process exit — the exact leak this helper exists
+  // to prevent.
   let ssrHtml = '';
-  try {
-    ssrHtml = render(ssrModule.default as Component<Props>, { props }).body;
-  } finally {
-    globalThis.document = originalDocument;
-    globalThis.window = originalWindow;
-  }
-
-  const container = document.createElement('div');
-  container.innerHTML = ssrHtml;
-  document.body.appendChild(container);
-
+  let container: HTMLElement;
   const warnings: string[] = [];
-  const originalWarn = console.warn;
-  console.warn = (...args: unknown[]) => {
-    warnings.push(args.map((a) => (typeof a === 'string' ? a : JSON.stringify(a))).join(' '));
-  };
-
   let instance: Record<string, unknown> | undefined;
   try {
-    instance = hydrate(clientComponent, {
-      target: container,
-      props,
-    }) as Record<string, unknown>;
-  } finally {
-    console.warn = originalWarn;
+    await writeFile(file, serverCode, 'utf-8');
+
+    // The SSR module's default export is a server-only render function whose
+    // shape (`($$renderer, $$props) => void`) doesn't match the public
+    // `Component<Props>` type. `svelte/server.render` accepts both shapes at
+    // runtime; we route through `unknown` because the public types are too
+    // narrow to express the dual-target reality.
+    const ssrModule = (await import(file)) as { default: unknown };
+
+    const { render } = (await import('svelte/server')) as typeof import('svelte/server');
+    const originalDocument = globalThis.document;
+    const originalWindow = globalThis.window;
+    globalThis.document = undefined as unknown as Document;
+    globalThis.window = undefined as unknown as Window & typeof globalThis;
+    try {
+      ssrHtml = render(ssrModule.default as Component<Props>, { props }).body;
+    } finally {
+      globalThis.document = originalDocument;
+      globalThis.window = originalWindow;
+    }
+
+    container = document.createElement('div');
+    container.innerHTML = ssrHtml;
+    document.body.appendChild(container);
+
+    const originalWarn = console.warn;
+    console.warn = (...args: unknown[]) => {
+      warnings.push(args.map((a) => (typeof a === 'string' ? a : JSON.stringify(a))).join(' '));
+    };
+
+    try {
+      instance = hydrate(clientComponent, {
+        target: container,
+        props,
+      }) as Record<string, unknown>;
+    } finally {
+      console.warn = originalWarn;
+    }
+  } catch (error) {
+    // Pre-return failure: remove the temp file and deregister it so it doesn't
+    // linger in the registry, then rethrow for the test to observe.
+    pendingTempFiles.delete(file);
+    void rm(file, { force: true }).catch(() => {});
+    throw error;
   }
 
   return {

--- a/packages/components/src/test/hydrate.ts
+++ b/packages/components/src/test/hydrate.ts
@@ -166,7 +166,7 @@ export async function renderThenHydrate<Props extends Record<string, unknown>>(
   // would orphan the file until process exit — the exact leak this helper exists
   // to prevent.
   let ssrHtml = '';
-  let container: HTMLElement;
+  let container: HTMLElement | undefined;
   const warnings: string[] = [];
   let instance: Record<string, unknown> | undefined;
   try {
@@ -209,10 +209,19 @@ export async function renderThenHydrate<Props extends Record<string, unknown>>(
       console.warn = originalWarn;
     }
   } catch (error) {
-    // Pre-return failure: remove the temp file and deregister it so it doesn't
-    // linger in the registry, then rethrow for the test to observe.
+    // Pre-return failure. Remove the SSR container if it made it into the DOM,
+    // or it would orphan markup that contaminates later tests. Then unlink the
+    // temp file SYNCHRONOUSLY and only deregister it AFTER removal — an async
+    // rm() + immediate deregister would lose the file if the process exited
+    // before the rm settled (the exit handler skips deregistered paths). Finally
+    // rethrow for the test to observe.
+    container?.remove();
+    try {
+      unlinkSync(file);
+    } catch {
+      // Already gone — ignore.
+    }
     pendingTempFiles.delete(file);
-    void rm(file, { force: true }).catch(() => {});
     throw error;
   }
 

--- a/packages/components/src/test/lifecycle.ts
+++ b/packages/components/src/test/lifecycle.ts
@@ -21,6 +21,14 @@ type GlobalWithTimers = typeof globalThis & {
 };
 
 /**
+ * The id `setTimeout`/`setInterval` return in the test runtime (happy-dom + the
+ * DOM lib), which is a numeric handle. Tracking ids by this type means the
+ * wrapper assignments need no casts — the old `as unknown as number` chain was
+ * defensive cruft, not a real requirement.
+ */
+type TimerId = number;
+
+/**
  * Returns a snapshot of currently-active timer IDs. Use as a baseline before
  * mounting a component, then call {@link expectNoLeakedTimers} after unmount.
  *
@@ -29,7 +37,7 @@ type GlobalWithTimers = typeof globalThis & {
  * `release()` is called.
  */
 export function trackTimers(): {
-  active: () => Set<number>;
+  active: () => Set<TimerId>;
   release: () => void;
 } {
   const g = globalThis as GlobalWithTimers;
@@ -38,14 +46,17 @@ export function trackTimers(): {
   const originalClearTimeout = g.clearTimeout;
   const originalClearInterval = g.clearInterval;
 
-  const active = new Set<number>();
+  const active = new Set<TimerId>();
 
-  // Best-effort wrappers. happy-dom's timer types differ slightly from lib.dom;
-  // we coerce IDs to numbers since that's what the standard says.
+  // Best-effort wrappers. The ids are tracked by their real `TimerId` type, so
+  // no casting is needed — `originalSetTimeout` returns exactly what `active`
+  // stores. Note: a `setInterval` id is never auto-removed when the interval
+  // fires (intervals repeat), so a running interval always reads as a leak until
+  // it is explicitly `clearInterval`-ed; no currently-tracked component uses one.
   g.setTimeout = ((handler: TimerHandler, timeout?: number, ...args: unknown[]) => {
     const id = originalSetTimeout(
       ((...a: unknown[]) => {
-        active.delete(id as unknown as number);
+        active.delete(id);
         if (typeof handler === 'function') {
           (handler as (...args: unknown[]) => unknown)(...a);
         }
@@ -53,22 +64,22 @@ export function trackTimers(): {
       timeout,
       ...args,
     );
-    active.add(id as unknown as number);
+    active.add(id);
     return id;
   }) as typeof setTimeout;
 
   g.setInterval = ((handler: TimerHandler, timeout?: number, ...args: unknown[]) => {
     const id = originalSetInterval(handler, timeout, ...args);
-    active.add(id as unknown as number);
+    active.add(id);
     return id;
   }) as typeof setInterval;
 
-  g.clearTimeout = ((id?: number) => {
+  g.clearTimeout = ((id?: TimerId) => {
     if (id !== undefined) active.delete(id);
     return originalClearTimeout(id);
   }) as typeof clearTimeout;
 
-  g.clearInterval = ((id?: number) => {
+  g.clearInterval = ((id?: TimerId) => {
     if (id !== undefined) active.delete(id);
     return originalClearInterval(id);
   }) as typeof clearInterval;
@@ -88,7 +99,7 @@ export function trackTimers(): {
  * Asserts that the `active` set returned from {@link trackTimers} is empty
  * after the component has been unmounted. Throws with the leaked IDs if not.
  */
-export function expectNoLeakedTimers(active: Set<number>): void {
+export function expectNoLeakedTimers(active: Set<TimerId>): void {
   if (active.size > 0) {
     throw new Error(
       `expected no leaked timers after unmount, got ${active.size}: ${[...active].join(', ')}`,

--- a/packages/components/src/utilities/use-history.svelte.test.ts
+++ b/packages/components/src/utilities/use-history.svelte.test.ts
@@ -1,19 +1,23 @@
-import { describe, expect, test } from 'bun:test';
+import { describe, expect, spyOn, test } from 'bun:test';
 
 import { useHistory } from './use-history.svelte.ts';
 
+/**
+ * Runs `run` while Svelte's internal `$state.snapshot` clone warning/error is
+ * suppressed via scoped spies. Only the paths that deliberately commit a
+ * non-cloneable value (a function) trip this, and the real assertion is the
+ * thrown error — not the incidental Svelte log. Spies are restored afterward so
+ * unexpected warnings in other tests still surface.
+ */
 function withSilencedSvelteSnapshotWarning(run: () => void) {
-  const originalError = console.error;
-  const originalWarn = console.warn;
-
-  console.error = () => {};
-  console.warn = () => {};
+  const errorSpy = spyOn(console, 'error').mockImplementation(() => {});
+  const warnSpy = spyOn(console, 'warn').mockImplementation(() => {});
 
   try {
     run();
   } finally {
-    console.error = originalError;
-    console.warn = originalWarn;
+    errorSpy.mockRestore();
+    warnSpy.mockRestore();
   }
 }
 


### PR DESCRIPTION
## Summary

Batch PR consolidating 8 backlog tasks in `packages/components` (svelte-check cleanup + test hardening + coverage). Part of a 26-task backlog batch grouped into 6 PRs.

**Tasks landed:**
- **ef5d64d9** — fix all `state_referenced_locally` svelte-check warnings (~30 files) via `untrack()` for one-time seeds and `$derived` for template-bound values. Each fix evaluated individually; svelte-check now reports 0 such warnings.
- **66f7b3eb** — fix svelte-check a11y warnings: `tabindex="-1"` on composite-widget containers (toolbar/tree/radiogroup), `role="presentation"` on SVG chart hit-rects and positioning wrappers, split multi-code `svelte-ignore` comments. Group-level `aria-invalid` on `role=group` kept as a documented supplemental signal (primary signal is the `aria-live` error region).
- **828357cb** — replace blanket `console.warn` suppression with scoped `spyOn` + allowlist assertions in 4 test files, so unexpected warnings now fail tests.
- **8f9269e1** — PinInput test fixtures get accessible names (0 `No accessible name source` warnings).
- **28d09aef** — wire `trackTimers()`/`expectNoLeakedTimers()` into tooltip + toast-region tests. The 7 other timer components are tracked as follow-up `33d17057`.
- **893f467e** — `hydrate.ts` temp-file cleanup via a process exit/SIGINT/SIGTERM registry + regression test.
- **2708617b** — 18 new sub-component test files (tab/radio/segment/dropdown-*/table-*/tree-*) asserting ARIA roles + attribute responses.
- **771ec011** — `renderThenHydrate()` hydration tests for Checkbox/Modal/Select/Combobox.
- **9644acea** — coverage thresholds in `bunfig.toml` at the measured baseline (65.87% lines / 63.67% functions, floor-not-ceiling); `validate` runs `test:coverage`; ratchet policy documented in `CONTRIBUTING.md`.

## Review committee

Pre-reviewed by: svelte-expert, testing-expert, typescript-expert, simplicity-engineer, ux-designer
- Codex (gpt-5.4, xhigh reasoning) — 3 rounds
- 3 rounds of review; all must-fix items addressed

Notable committee catches (all fixed): Codex found a temp-file-leak race and a DOM-orphan-on-hydrate-throw in `hydrate.ts` (twice — original code and the first fix); testing-expert caught a `mockRestore` ordering bug that would contaminate later tests; typescript-expert flagged a banned `as unknown as number` cast; ux-designer caught a misleading `aria-invalid` propagation comment.

## Test plan

- `bun run --filter=cinder test` — full suite green: **3904 pass / 1 skip / 0 fail** across 262 files.
- `bun run --filter=cinder typecheck` — exit 0 (svelte-check: 0 `state_referenced_locally`, 0 targeted a11y warnings; 1 pre-existing out-of-scope `timeline.svelte` warning remains).
- oxlint type-aware clean. Pre-commit + pre-push hooks green.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches many interactive components’ reactivity and ARIA wiring plus CI validate behavior; risk is mitigated by broad new tests and unchanged public APIs, but regressions could show up in controlled inputs, overlays, or hydration.
> 
> **Overview**
> This PR hardens **`packages/components`** quality gates and clears a large batch of **Svelte 5 reactivity / a11y** issues while expanding automated tests.
> 
> **Coverage & CI:** `bunfig.toml` adds **coverage floors** (~65% lines / ~63% functions); `validate` now runs **`test:coverage`** instead of plain `test`. **CONTRIBUTING** documents the **ratchet-only-up** policy.
> 
> **Reactivity / svelte-check:** Many components and fixtures use **`untrack()`** for one-time mount seeds and **`$derived`** where template-bound values must stay reactive (e.g. **Button** `rest` attrs, **Combobox** listbox id, tabs). **Convention** allow-list shrinks as new sub-component tests land.
> 
> **A11y:** Composite widgets get **`tabindex="-1"`** where appropriate; chart hit surfaces and delegation wrappers use **`role="presentation"`**; documented **`svelte-ignore`** for intentional group-level **`aria-invalid`** and listbox patterns.
> 
> **Tests:** **18** new compound-component tests (dropdown, table, tabs, tree, etc.); **hydration** contracts for Checkbox, Combobox, Select, Modal; **scoped `console.warn` spies** with allowlists; **timer leak** checks for tooltip/toast; **`hydrate.ts`** temp SSR modules registered with **sync unlink + process exit/signal cleanup** and a regression test; **PinInput** fixtures always get an accessible name.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 144907d8dec57951aa65b39fc7ce1c68563de87e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->