### PR TITLE
feat(tooling): exports files-sync + schema/variables runtime conditions, interact types, styles guard (PR2)

### DIFF
--- a/packages/components/AGENTS.md
+++ b/packages/components/AGENTS.md
@@ -209,11 +209,11 @@ type ButtonSchemaToo = typeof ButtonSchemaModule.default;
 
 > [!WARNING]
 > Do **not** use a default-only `import type ButtonSchemaModule from '…'` to
-> reach the _type_. The failure mode depends on your `moduleResolution`: under
-> `bundler`, `node16`, or `nodenext`-with-ESM-interop it errors with `TS2339:
-Property 'default' does not exist on type 'ComponentSchema'`; under
-> `nodenext`'s CJS interop path it silently widens `typeof
-ButtonSchemaModule.default` to `any`. For the runtime _value_ a plain
+> reach the _type_. The failure mode depends on your `moduleResolution`.
+> Under `bundler`, `node16`, or `nodenext`-with-ESM-interop it errors with
+> `TS2339: Property 'default' does not exist on type 'ComponentSchema'`.
+> Under `nodenext`'s CJS interop path it silently widens the default type to
+> `any`. For the runtime _value_ a plain
 > `import buttonSchema from 'cinder/button/schema'` is correct; the namespace
 > form is only needed when you want the `typeof` type.
 

--- a/packages/components/AGENTS.md
+++ b/packages/components/AGENTS.md
@@ -183,54 +183,47 @@ subpaths you fetch next.
 type ButtonSchema = typeof import('cinder/button/schema').default;
 ```
 
-`cinder/<name>/schema` and `cinder/<name>/variables` are **type-only metadata
-modules**. They ship `types` + `svelte` conditions only — no `node`/`default`
-runtime condition, because the build emits no `.schema.js`/`.variables.js`. The
-default export is a **value** (`declare const _default: ComponentSchema`), so
-reach its type with `typeof`. Take it through `import(...)` as shown above, or
-off the namespace binding of an `import type * as`:
+`cinder/<name>/schema` and `cinder/<name>/variables` are full runtime entry
+points. They ship the four-condition shape (`types` + `svelte` + `node` +
+`default`): the build compiles each `<name>.schema.ts` / `<name>.variables.ts`
+to its own JS, so a plain Node or Vite (non-Svelte) consumer can import the
+default-exported value directly:
 
 ```ts
+import buttonSchema from 'cinder/button/schema';
+import buttonVariables from 'cinder/button/variables';
+```
+
+`buttonSchema` is a JSON Schema draft 2020-12 document (required props, prop
+types, enum values, and defaults); `buttonVariables` is the component's CSS
+custom-property names. To reach the **type** instead of the value, use `typeof`
+on the default export through `import(...)` or an `import type * as` namespace
+binding:
+
+```ts
+type ButtonSchema = typeof import('cinder/button/schema').default;
+
 import type * as ButtonSchemaModule from 'cinder/button/schema';
-type ButtonSchema = typeof ButtonSchemaModule.default;
+type ButtonSchemaToo = typeof ButtonSchemaModule.default;
 ```
 
 > [!WARNING]
-> Do **not** use a default-only `import type ButtonSchemaModule from '…'`. The failure
-> mode depends on your `moduleResolution`: under `bundler`, `node16`, or
-> `nodenext`-with-ESM-interop it errors with `TS2339: Property 'default' does not exist
-on type 'ComponentSchema'`; under `nodenext`'s CJS interop path it silently widens
-> `typeof ButtonSchemaModule.default` to `any`—no error, but you lose the schema type
-> entirely. Either way the default-import form is wrong. Use `import type * as` (namespace
-> import) to bind the module namespace, where `.default` correctly refers to the
-> default-exported value under every resolver.
+> Do **not** use a default-only `import type ButtonSchemaModule from '…'` to
+> reach the _type_. The failure mode depends on your `moduleResolution`: under
+> `bundler`, `node16`, or `nodenext`-with-ESM-interop it errors with `TS2339:
+Property 'default' does not exist on type 'ComponentSchema'`; under
+> `nodenext`'s CJS interop path it silently widens `typeof
+ButtonSchemaModule.default` to `any`. For the runtime _value_ a plain
+> `import buttonSchema from 'cinder/button/schema'` is correct; the namespace
+> form is only needed when you want the `typeof` type.
 
-The resulting type describes a JSON Schema draft 2020-12 document: required
-props, prop types, enum values, and defaults are all there.
-
-> [!WARNING]
-> Do not `import` these for their runtime value from a plain Node or Vite
-> (non-Svelte) consumer. Because there is no `default` condition, the runtime
-> resolver throws `ERR_PACKAGE_PATH_NOT_EXPORTED`. That is intentional — these
-> subpaths are metadata, not runtime entry points.
-
-If you genuinely need the schema as a runtime **value** (e.g. to feed a form
-generator or validator), read the JSON sidecar that ships alongside the module.
-Anchor the path off the package root — resolve `cinder/package.json` (which _is_
-an export) and join to the sidecar so you never hardcode a `node_modules` layout:
-
-```ts
-import { readFile } from 'node:fs/promises';
-import { dirname, join } from 'node:path';
-import { fileURLToPath } from 'node:url';
-
-const packageRoot = dirname(fileURLToPath(import.meta.resolve('cinder/package.json')));
-const sidecar = join(packageRoot, 'src/components/button/button.schema.json');
-const buttonSchema = JSON.parse(await readFile(sidecar, 'utf-8'));
-```
+A JSON sidecar (`<name>.schema.json` / `<name>.variables.json`) still ships
+alongside each module for tooling that prefers reading raw JSON off disk, but
+importing the subpath is the simpler path now that it carries a runtime
+`default` condition.
 
 The authoritative, machine-readable index for every component is `cinder/manifest`
-(step 1) — prefer it over hand-resolving sidecar paths whenever you can.
+(step 1) — prefer it whenever you can.
 
 **3. Fetch the cross-prop constraints — when `hasConstraints` is true.**
 

--- a/packages/components/fixtures/manifest-consumer/check.mjs
+++ b/packages/components/fixtures/manifest-consumer/check.mjs
@@ -16,13 +16,13 @@
  *      AND CJS `createRequire().resolve`, and the resolved target exists and is
  *      non-empty. The two resolvers can pick different export conditions, so we
  *      check both.
- *   3. The `schema`/`variables` subpaths are TYPE+SVELTE-only by the generator's
- *      explicit design (no runtime JS is emitted — see generate-exports.ts).
- *      We assert their declaration (`types`) target exists in the tarball, and
- *      we POSITIVELY assert that Node default runtime resolution of them THROWS
- *      `ERR_PACKAGE_PATH_NOT_EXPORTED`. That makes the current intentional
- *      limitation a tested contract: if task 4176c51c later makes these runtime
- *      entry points, this assertion goes red and the fixture must be updated.
+ *   3. The `schema`/`variables` subpaths are full runtime entry points (task
+ *      4176c51c): the build compiles each `<name>.schema.ts` / `.variables.ts`
+ *      to its own JS, so the `node`/`default` export conditions resolve to real
+ *      files. We assert their declaration (`types`) target exists in the tarball
+ *      AND that Node default runtime resolution of them succeeds via BOTH the
+ *      ESM and CJS resolvers — a plain Node/Vite consumer can therefore import
+ *      `cinder/<name>/schema` for its default-exported JSON Schema value.
  *   4. Two-way export <-> manifest consistency: every runtime artifact the
  *      manifest advertises has a matching package export, and every per-component
  *      export the package ships is accounted for by the manifest (or the
@@ -92,49 +92,6 @@ function assertRuntimeResolvable(specifier) {
     assertResolvedTargetUsable(`${specifier} [cjs]`, cjsResolved);
   } catch (error) {
     record(`${specifier} [cjs]: require.resolve threw — ${error.code ?? error.message}`);
-  }
-}
-
-/**
- * Assert a specifier is NOT runtime-resolvable under the default condition.
- *
- * This is a deliberate TRIPWIRE, not a bug check. The schema/variables subpaths
- * ship `types` + `svelte` conditions only — no `node`/`default` and no runtime
- * JS — by `generate-exports.ts` design (they are metadata, not runtime entry
- * points). Resolving them under Node's default condition therefore throws.
- *
- * If task 4176c51c (or any change) later makes schema/variables runtime entry
- * points, this assertion goes RED — that is the signal to update this fixture
- * to assert runtime resolution instead of asserting it throws.
- *
- * We require ERR_PACKAGE_PATH_NOT_EXPORTED specifically — it proves the runtime
- * condition is ABSENT from the package's exports map. We deliberately do NOT
- * accept ERR_MODULE_NOT_FOUND: that code means the subpath IS runtime-exported
- * but resolves to a missing file — a different, broken contract that this
- * tripwire must NOT silently tolerate. Any other outcome — a successful
- * resolve, or a different error code — fails.
- */
-function assertNotRuntimeResolvable(specifier, reason) {
-  for (const [resolverLabel, resolve] of [
-    ['esm', (s) => import.meta.resolve(s)],
-    ['cjs', (s) => require.resolve(s)],
-  ]) {
-    let resolved;
-    try {
-      resolved = resolve(specifier);
-    } catch (error) {
-      if (error.code === 'ERR_PACKAGE_PATH_NOT_EXPORTED') continue; // expected tripwire state
-      record(
-        `${specifier} [${resolverLabel}]: expected ERR_PACKAGE_PATH_NOT_EXPORTED (no runtime ` +
-          `condition in the exports map) but got ${error.code ?? error.message}`,
-      );
-      continue;
-    }
-    record(
-      `${specifier} [${resolverLabel}]: expected NOT to resolve (${reason}) but resolved to ${resolved}. ` +
-        `This is the task-4176c51c tripwire: if schema/variables intentionally became runtime entry ` +
-        `points, update manifest-consumer to assert runtime resolution instead of non-resolution.`,
-    );
   }
 }
 
@@ -220,8 +177,9 @@ for (const component of manifest.components) {
   assertRuntimeResolvable(importSpecifier);
   expectedComponentExportKeys.add(specifierToExportKey(importSpecifier));
 
-  // 2b. schema + variables: type/svelte-only by design. The `types` target must
-  //     exist in the tarball, but runtime default resolution must NOT resolve.
+  // 2b. schema + variables: full runtime entry points (task 4176c51c). The
+  //     `types` declaration target must exist AND the subpath must runtime-resolve
+  //     via both the ESM and CJS resolvers.
   for (const metadataKey of ['schema', 'variables']) {
     const specifier = artifacts[metadataKey];
     // Accumulate (don't throw) so one malformed component doesn't mask the rest.
@@ -243,18 +201,13 @@ for (const component of manifest.components) {
       if (typeof typesTarget !== 'string') {
         record(`${id}: export "${exportKey}" has no string "types" condition`);
       } else {
-        assertResolvedTargetUsable(
-          `${specifier} [types]`,
-          packageRelativeToAbsolute(typesTarget),
-        );
+        assertResolvedTargetUsable(`${specifier} [types]`, packageRelativeToAbsolute(typesTarget));
       }
     }
 
-    // The tripwire: these subpaths intentionally do not runtime-resolve today.
-    assertNotRuntimeResolvable(
-      specifier,
-      `${metadataKey} is type/svelte-only by generate-exports.ts design`,
-    );
+    // Runtime entry point: the default-exported JSON Schema / variables value
+    // must be importable from a plain Node/Vite consumer.
+    assertRuntimeResolvable(specifier);
   }
 
   // 2c. examples + constraints: JSON sidecars — genuine runtime entry points
@@ -263,7 +216,9 @@ for (const component of manifest.components) {
     const specifier = artifacts[sidecarKey];
     if (specifier === undefined) continue; // not all components ship these
     if (specifier !== `${importSpecifier}/${sidecarKey}`) {
-      record(`${id}: artifacts.${sidecarKey} ("${specifier}") must equal import + "/${sidecarKey}"`);
+      record(
+        `${id}: artifacts.${sidecarKey} ("${specifier}") must equal import + "/${sidecarKey}"`,
+      );
       continue;
     }
     assertRuntimeResolvable(specifier);
@@ -330,7 +285,7 @@ if (failures.length > 0) {
 
 process.stdout.write(
   `manifest-consumer OK — verified ${manifest.components.length} components ` +
-    `(import + examples/constraints/styles runtime-resolvable via ESM+CJS; ` +
-    `schema/variables type-target present and intentionally not runtime-resolvable; ` +
+    `(import + schema/variables/examples/constraints/styles runtime-resolvable via ESM+CJS; ` +
+    `schema/variables type-target present; ` +
     `two-way export↔manifest consistency holds).\n`,
 );

--- a/packages/components/fixtures/manifest-consumer/check.mjs
+++ b/packages/components/fixtures/manifest-consumer/check.mjs
@@ -203,6 +203,22 @@ for (const component of manifest.components) {
       } else {
         assertResolvedTargetUsable(`${specifier} [types]`, packageRelativeToAbsolute(typesTarget));
       }
+      // The resolver only ever selects ONE condition (node wins for both ESM and
+      // CJS here), so assertRuntimeResolvable never touches the `default` target.
+      // Assert BOTH the `node` and `default` runtime targets exist on disk — a
+      // missing `default` build artifact would 404 for a plain Vite/bundler
+      // consumer that resolves `default` while the fixture stayed green.
+      for (const condition of ['node', 'default']) {
+        const target = exportEntry[condition];
+        if (typeof target !== 'string') {
+          record(`${id}: export "${exportKey}" has no string "${condition}" condition`);
+        } else {
+          assertResolvedTargetUsable(
+            `${specifier} [${condition}]`,
+            packageRelativeToAbsolute(target),
+          );
+        }
+      }
     }
 
     // Runtime entry point: the default-exported JSON Schema / variables value

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -72,11 +72,15 @@
     },
     "./accordion/schema": {
       "types": "./dist/components/accordion/accordion.schema.d.ts",
-      "svelte": "./src/components/accordion/accordion.schema.ts"
+      "svelte": "./src/components/accordion/accordion.schema.ts",
+      "node": "./dist/server/components/accordion/accordion.schema.js",
+      "default": "./dist/components/accordion/accordion.schema.js"
     },
     "./accordion/variables": {
       "types": "./dist/components/accordion/accordion.variables.d.ts",
-      "svelte": "./src/components/accordion/accordion.variables.ts"
+      "svelte": "./src/components/accordion/accordion.variables.ts",
+      "node": "./dist/server/components/accordion/accordion.variables.js",
+      "default": "./dist/components/accordion/accordion.variables.js"
     },
     "./accordion/styles": {
       "default": "./dist/components/accordion/accordion.css"
@@ -93,11 +97,15 @@
     },
     "./accordion-item/schema": {
       "types": "./dist/components/accordion-item/accordion-item.schema.d.ts",
-      "svelte": "./src/components/accordion-item/accordion-item.schema.ts"
+      "svelte": "./src/components/accordion-item/accordion-item.schema.ts",
+      "node": "./dist/server/components/accordion-item/accordion-item.schema.js",
+      "default": "./dist/components/accordion-item/accordion-item.schema.js"
     },
     "./accordion-item/variables": {
       "types": "./dist/components/accordion-item/accordion-item.variables.d.ts",
-      "svelte": "./src/components/accordion-item/accordion-item.variables.ts"
+      "svelte": "./src/components/accordion-item/accordion-item.variables.ts",
+      "node": "./dist/server/components/accordion-item/accordion-item.variables.js",
+      "default": "./dist/components/accordion-item/accordion-item.variables.js"
     },
     "./accordion-item/styles": {
       "default": "./dist/components/accordion-item/accordion-item.css"
@@ -110,11 +118,15 @@
     },
     "./alert/schema": {
       "types": "./dist/components/alert/alert.schema.d.ts",
-      "svelte": "./src/components/alert/alert.schema.ts"
+      "svelte": "./src/components/alert/alert.schema.ts",
+      "node": "./dist/server/components/alert/alert.schema.js",
+      "default": "./dist/components/alert/alert.schema.js"
     },
     "./alert/variables": {
       "types": "./dist/components/alert/alert.variables.d.ts",
-      "svelte": "./src/components/alert/alert.variables.ts"
+      "svelte": "./src/components/alert/alert.variables.ts",
+      "node": "./dist/server/components/alert/alert.variables.js",
+      "default": "./dist/components/alert/alert.variables.js"
     },
     "./alert/styles": {
       "default": "./dist/components/alert/alert.css"
@@ -131,11 +143,15 @@
     },
     "./alert-dialog/schema": {
       "types": "./dist/components/alert-dialog/alert-dialog.schema.d.ts",
-      "svelte": "./src/components/alert-dialog/alert-dialog.schema.ts"
+      "svelte": "./src/components/alert-dialog/alert-dialog.schema.ts",
+      "node": "./dist/server/components/alert-dialog/alert-dialog.schema.js",
+      "default": "./dist/components/alert-dialog/alert-dialog.schema.js"
     },
     "./alert-dialog/variables": {
       "types": "./dist/components/alert-dialog/alert-dialog.variables.d.ts",
-      "svelte": "./src/components/alert-dialog/alert-dialog.variables.ts"
+      "svelte": "./src/components/alert-dialog/alert-dialog.variables.ts",
+      "node": "./dist/server/components/alert-dialog/alert-dialog.variables.js",
+      "default": "./dist/components/alert-dialog/alert-dialog.variables.js"
     },
     "./alert-dialog/styles": {
       "default": "./dist/components/alert-dialog/alert-dialog.css"
@@ -152,11 +168,15 @@
     },
     "./area-chart/schema": {
       "types": "./dist/components/area-chart/area-chart.schema.d.ts",
-      "svelte": "./src/components/area-chart/area-chart.schema.ts"
+      "svelte": "./src/components/area-chart/area-chart.schema.ts",
+      "node": "./dist/server/components/area-chart/area-chart.schema.js",
+      "default": "./dist/components/area-chart/area-chart.schema.js"
     },
     "./area-chart/variables": {
       "types": "./dist/components/area-chart/area-chart.variables.d.ts",
-      "svelte": "./src/components/area-chart/area-chart.variables.ts"
+      "svelte": "./src/components/area-chart/area-chart.variables.ts",
+      "node": "./dist/server/components/area-chart/area-chart.variables.js",
+      "default": "./dist/components/area-chart/area-chart.variables.js"
     },
     "./area-chart/styles": {
       "default": "./dist/components/area-chart/area-chart.css"
@@ -173,11 +193,15 @@
     },
     "./aspect-ratio/schema": {
       "types": "./dist/components/aspect-ratio/aspect-ratio.schema.d.ts",
-      "svelte": "./src/components/aspect-ratio/aspect-ratio.schema.ts"
+      "svelte": "./src/components/aspect-ratio/aspect-ratio.schema.ts",
+      "node": "./dist/server/components/aspect-ratio/aspect-ratio.schema.js",
+      "default": "./dist/components/aspect-ratio/aspect-ratio.schema.js"
     },
     "./aspect-ratio/variables": {
       "types": "./dist/components/aspect-ratio/aspect-ratio.variables.d.ts",
-      "svelte": "./src/components/aspect-ratio/aspect-ratio.variables.ts"
+      "svelte": "./src/components/aspect-ratio/aspect-ratio.variables.ts",
+      "node": "./dist/server/components/aspect-ratio/aspect-ratio.variables.js",
+      "default": "./dist/components/aspect-ratio/aspect-ratio.variables.js"
     },
     "./aspect-ratio/styles": {
       "default": "./dist/components/aspect-ratio/aspect-ratio.css"
@@ -194,11 +218,15 @@
     },
     "./autocomplete/schema": {
       "types": "./dist/components/autocomplete/autocomplete.schema.d.ts",
-      "svelte": "./src/components/autocomplete/autocomplete.schema.ts"
+      "svelte": "./src/components/autocomplete/autocomplete.schema.ts",
+      "node": "./dist/server/components/autocomplete/autocomplete.schema.js",
+      "default": "./dist/components/autocomplete/autocomplete.schema.js"
     },
     "./autocomplete/variables": {
       "types": "./dist/components/autocomplete/autocomplete.variables.d.ts",
-      "svelte": "./src/components/autocomplete/autocomplete.variables.ts"
+      "svelte": "./src/components/autocomplete/autocomplete.variables.ts",
+      "node": "./dist/server/components/autocomplete/autocomplete.variables.js",
+      "default": "./dist/components/autocomplete/autocomplete.variables.js"
     },
     "./autocomplete/styles": {
       "default": "./dist/components/autocomplete/autocomplete.css"
@@ -215,11 +243,15 @@
     },
     "./avatar/schema": {
       "types": "./dist/components/avatar/avatar.schema.d.ts",
-      "svelte": "./src/components/avatar/avatar.schema.ts"
+      "svelte": "./src/components/avatar/avatar.schema.ts",
+      "node": "./dist/server/components/avatar/avatar.schema.js",
+      "default": "./dist/components/avatar/avatar.schema.js"
     },
     "./avatar/variables": {
       "types": "./dist/components/avatar/avatar.variables.d.ts",
-      "svelte": "./src/components/avatar/avatar.variables.ts"
+      "svelte": "./src/components/avatar/avatar.variables.ts",
+      "node": "./dist/server/components/avatar/avatar.variables.js",
+      "default": "./dist/components/avatar/avatar.variables.js"
     },
     "./avatar/styles": {
       "default": "./dist/components/avatar/avatar.css"
@@ -236,11 +268,15 @@
     },
     "./avatar-group/schema": {
       "types": "./dist/components/avatar-group/avatar-group.schema.d.ts",
-      "svelte": "./src/components/avatar-group/avatar-group.schema.ts"
+      "svelte": "./src/components/avatar-group/avatar-group.schema.ts",
+      "node": "./dist/server/components/avatar-group/avatar-group.schema.js",
+      "default": "./dist/components/avatar-group/avatar-group.schema.js"
     },
     "./avatar-group/variables": {
       "types": "./dist/components/avatar-group/avatar-group.variables.d.ts",
-      "svelte": "./src/components/avatar-group/avatar-group.variables.ts"
+      "svelte": "./src/components/avatar-group/avatar-group.variables.ts",
+      "node": "./dist/server/components/avatar-group/avatar-group.variables.js",
+      "default": "./dist/components/avatar-group/avatar-group.variables.js"
     },
     "./avatar-group/styles": {
       "default": "./dist/components/avatar-group/avatar-group.css"
@@ -257,11 +293,15 @@
     },
     "./badge/schema": {
       "types": "./dist/components/badge/badge.schema.d.ts",
-      "svelte": "./src/components/badge/badge.schema.ts"
+      "svelte": "./src/components/badge/badge.schema.ts",
+      "node": "./dist/server/components/badge/badge.schema.js",
+      "default": "./dist/components/badge/badge.schema.js"
     },
     "./badge/variables": {
       "types": "./dist/components/badge/badge.variables.d.ts",
-      "svelte": "./src/components/badge/badge.variables.ts"
+      "svelte": "./src/components/badge/badge.variables.ts",
+      "node": "./dist/server/components/badge/badge.variables.js",
+      "default": "./dist/components/badge/badge.variables.js"
     },
     "./badge/styles": {
       "default": "./dist/components/badge/badge.css"
@@ -278,11 +318,15 @@
     },
     "./banner/schema": {
       "types": "./dist/components/banner/banner.schema.d.ts",
-      "svelte": "./src/components/banner/banner.schema.ts"
+      "svelte": "./src/components/banner/banner.schema.ts",
+      "node": "./dist/server/components/banner/banner.schema.js",
+      "default": "./dist/components/banner/banner.schema.js"
     },
     "./banner/variables": {
       "types": "./dist/components/banner/banner.variables.d.ts",
-      "svelte": "./src/components/banner/banner.variables.ts"
+      "svelte": "./src/components/banner/banner.variables.ts",
+      "node": "./dist/server/components/banner/banner.variables.js",
+      "default": "./dist/components/banner/banner.variables.js"
     },
     "./banner/styles": {
       "default": "./dist/components/banner/banner.css"
@@ -295,11 +339,15 @@
     },
     "./bar-chart/schema": {
       "types": "./dist/components/bar-chart/bar-chart.schema.d.ts",
-      "svelte": "./src/components/bar-chart/bar-chart.schema.ts"
+      "svelte": "./src/components/bar-chart/bar-chart.schema.ts",
+      "node": "./dist/server/components/bar-chart/bar-chart.schema.js",
+      "default": "./dist/components/bar-chart/bar-chart.schema.js"
     },
     "./bar-chart/variables": {
       "types": "./dist/components/bar-chart/bar-chart.variables.d.ts",
-      "svelte": "./src/components/bar-chart/bar-chart.variables.ts"
+      "svelte": "./src/components/bar-chart/bar-chart.variables.ts",
+      "node": "./dist/server/components/bar-chart/bar-chart.variables.js",
+      "default": "./dist/components/bar-chart/bar-chart.variables.js"
     },
     "./bar-chart/styles": {
       "default": "./dist/components/bar-chart/bar-chart.css"
@@ -316,11 +364,15 @@
     },
     "./breadcrumbs/schema": {
       "types": "./dist/components/breadcrumbs/breadcrumbs.schema.d.ts",
-      "svelte": "./src/components/breadcrumbs/breadcrumbs.schema.ts"
+      "svelte": "./src/components/breadcrumbs/breadcrumbs.schema.ts",
+      "node": "./dist/server/components/breadcrumbs/breadcrumbs.schema.js",
+      "default": "./dist/components/breadcrumbs/breadcrumbs.schema.js"
     },
     "./breadcrumbs/variables": {
       "types": "./dist/components/breadcrumbs/breadcrumbs.variables.d.ts",
-      "svelte": "./src/components/breadcrumbs/breadcrumbs.variables.ts"
+      "svelte": "./src/components/breadcrumbs/breadcrumbs.variables.ts",
+      "node": "./dist/server/components/breadcrumbs/breadcrumbs.variables.js",
+      "default": "./dist/components/breadcrumbs/breadcrumbs.variables.js"
     },
     "./breadcrumbs/styles": {
       "default": "./dist/components/breadcrumbs/breadcrumbs.css"
@@ -337,11 +389,15 @@
     },
     "./button/schema": {
       "types": "./dist/components/button/button.schema.d.ts",
-      "svelte": "./src/components/button/button.schema.ts"
+      "svelte": "./src/components/button/button.schema.ts",
+      "node": "./dist/server/components/button/button.schema.js",
+      "default": "./dist/components/button/button.schema.js"
     },
     "./button/variables": {
       "types": "./dist/components/button/button.variables.d.ts",
-      "svelte": "./src/components/button/button.variables.ts"
+      "svelte": "./src/components/button/button.variables.ts",
+      "node": "./dist/server/components/button/button.variables.js",
+      "default": "./dist/components/button/button.variables.js"
     },
     "./button/styles": {
       "default": "./dist/components/button/button.css"
@@ -362,11 +418,15 @@
     },
     "./button-group/schema": {
       "types": "./dist/components/button-group/button-group.schema.d.ts",
-      "svelte": "./src/components/button-group/button-group.schema.ts"
+      "svelte": "./src/components/button-group/button-group.schema.ts",
+      "node": "./dist/server/components/button-group/button-group.schema.js",
+      "default": "./dist/components/button-group/button-group.schema.js"
     },
     "./button-group/variables": {
       "types": "./dist/components/button-group/button-group.variables.d.ts",
-      "svelte": "./src/components/button-group/button-group.variables.ts"
+      "svelte": "./src/components/button-group/button-group.variables.ts",
+      "node": "./dist/server/components/button-group/button-group.variables.js",
+      "default": "./dist/components/button-group/button-group.variables.js"
     },
     "./button-group/styles": {
       "default": "./dist/components/button-group/button-group.css"
@@ -383,11 +443,15 @@
     },
     "./callout/schema": {
       "types": "./dist/components/callout/callout.schema.d.ts",
-      "svelte": "./src/components/callout/callout.schema.ts"
+      "svelte": "./src/components/callout/callout.schema.ts",
+      "node": "./dist/server/components/callout/callout.schema.js",
+      "default": "./dist/components/callout/callout.schema.js"
     },
     "./callout/variables": {
       "types": "./dist/components/callout/callout.variables.d.ts",
-      "svelte": "./src/components/callout/callout.variables.ts"
+      "svelte": "./src/components/callout/callout.variables.ts",
+      "node": "./dist/server/components/callout/callout.variables.js",
+      "default": "./dist/components/callout/callout.variables.js"
     },
     "./callout/styles": {
       "default": "./dist/components/callout/callout.css"
@@ -400,11 +464,15 @@
     },
     "./card/schema": {
       "types": "./dist/components/card/card.schema.d.ts",
-      "svelte": "./src/components/card/card.schema.ts"
+      "svelte": "./src/components/card/card.schema.ts",
+      "node": "./dist/server/components/card/card.schema.js",
+      "default": "./dist/components/card/card.schema.js"
     },
     "./card/variables": {
       "types": "./dist/components/card/card.variables.d.ts",
-      "svelte": "./src/components/card/card.variables.ts"
+      "svelte": "./src/components/card/card.variables.ts",
+      "node": "./dist/server/components/card/card.variables.js",
+      "default": "./dist/components/card/card.variables.js"
     },
     "./card/styles": {
       "default": "./dist/components/card/card.css"
@@ -421,11 +489,15 @@
     },
     "./center/schema": {
       "types": "./dist/components/center/center.schema.d.ts",
-      "svelte": "./src/components/center/center.schema.ts"
+      "svelte": "./src/components/center/center.schema.ts",
+      "node": "./dist/server/components/center/center.schema.js",
+      "default": "./dist/components/center/center.schema.js"
     },
     "./center/variables": {
       "types": "./dist/components/center/center.variables.d.ts",
-      "svelte": "./src/components/center/center.variables.ts"
+      "svelte": "./src/components/center/center.variables.ts",
+      "node": "./dist/server/components/center/center.variables.js",
+      "default": "./dist/components/center/center.variables.js"
     },
     "./center/styles": {
       "default": "./dist/components/center/center.css"
@@ -442,11 +514,15 @@
     },
     "./chat/schema": {
       "types": "./dist/components/chat/chat.schema.d.ts",
-      "svelte": "./src/components/chat/chat.schema.ts"
+      "svelte": "./src/components/chat/chat.schema.ts",
+      "node": "./dist/server/components/chat/chat.schema.js",
+      "default": "./dist/components/chat/chat.schema.js"
     },
     "./chat/variables": {
       "types": "./dist/components/chat/chat.variables.d.ts",
-      "svelte": "./src/components/chat/chat.variables.ts"
+      "svelte": "./src/components/chat/chat.variables.ts",
+      "node": "./dist/server/components/chat/chat.variables.js",
+      "default": "./dist/components/chat/chat.variables.js"
     },
     "./chat/examples": {
       "import": "./src/components/chat/chat.examples.json",
@@ -460,11 +536,15 @@
     },
     "./checkbox/schema": {
       "types": "./dist/components/checkbox/checkbox.schema.d.ts",
-      "svelte": "./src/components/checkbox/checkbox.schema.ts"
+      "svelte": "./src/components/checkbox/checkbox.schema.ts",
+      "node": "./dist/server/components/checkbox/checkbox.schema.js",
+      "default": "./dist/components/checkbox/checkbox.schema.js"
     },
     "./checkbox/variables": {
       "types": "./dist/components/checkbox/checkbox.variables.d.ts",
-      "svelte": "./src/components/checkbox/checkbox.variables.ts"
+      "svelte": "./src/components/checkbox/checkbox.variables.ts",
+      "node": "./dist/server/components/checkbox/checkbox.variables.js",
+      "default": "./dist/components/checkbox/checkbox.variables.js"
     },
     "./checkbox/styles": {
       "default": "./dist/components/checkbox/checkbox.css"
@@ -481,11 +561,15 @@
     },
     "./checkbox-group/schema": {
       "types": "./dist/components/checkbox-group/checkbox-group.schema.d.ts",
-      "svelte": "./src/components/checkbox-group/checkbox-group.schema.ts"
+      "svelte": "./src/components/checkbox-group/checkbox-group.schema.ts",
+      "node": "./dist/server/components/checkbox-group/checkbox-group.schema.js",
+      "default": "./dist/components/checkbox-group/checkbox-group.schema.js"
     },
     "./checkbox-group/variables": {
       "types": "./dist/components/checkbox-group/checkbox-group.variables.d.ts",
-      "svelte": "./src/components/checkbox-group/checkbox-group.variables.ts"
+      "svelte": "./src/components/checkbox-group/checkbox-group.variables.ts",
+      "node": "./dist/server/components/checkbox-group/checkbox-group.variables.js",
+      "default": "./dist/components/checkbox-group/checkbox-group.variables.js"
     },
     "./checkbox-group/styles": {
       "default": "./dist/components/checkbox-group/checkbox-group.css"
@@ -498,11 +582,15 @@
     },
     "./chip/schema": {
       "types": "./dist/components/chip/chip.schema.d.ts",
-      "svelte": "./src/components/chip/chip.schema.ts"
+      "svelte": "./src/components/chip/chip.schema.ts",
+      "node": "./dist/server/components/chip/chip.schema.js",
+      "default": "./dist/components/chip/chip.schema.js"
     },
     "./chip/variables": {
       "types": "./dist/components/chip/chip.variables.d.ts",
-      "svelte": "./src/components/chip/chip.variables.ts"
+      "svelte": "./src/components/chip/chip.variables.ts",
+      "node": "./dist/server/components/chip/chip.variables.js",
+      "default": "./dist/components/chip/chip.variables.js"
     },
     "./chip/styles": {
       "default": "./dist/components/chip/chip.css"
@@ -519,11 +607,15 @@
     },
     "./cluster/schema": {
       "types": "./dist/components/cluster/cluster.schema.d.ts",
-      "svelte": "./src/components/cluster/cluster.schema.ts"
+      "svelte": "./src/components/cluster/cluster.schema.ts",
+      "node": "./dist/server/components/cluster/cluster.schema.js",
+      "default": "./dist/components/cluster/cluster.schema.js"
     },
     "./cluster/variables": {
       "types": "./dist/components/cluster/cluster.variables.d.ts",
-      "svelte": "./src/components/cluster/cluster.variables.ts"
+      "svelte": "./src/components/cluster/cluster.variables.ts",
+      "node": "./dist/server/components/cluster/cluster.variables.js",
+      "default": "./dist/components/cluster/cluster.variables.js"
     },
     "./cluster/styles": {
       "default": "./dist/components/cluster/cluster.css"
@@ -540,11 +632,15 @@
     },
     "./code-block/schema": {
       "types": "./dist/components/code-block/code-block.schema.d.ts",
-      "svelte": "./src/components/code-block/code-block.schema.ts"
+      "svelte": "./src/components/code-block/code-block.schema.ts",
+      "node": "./dist/server/components/code-block/code-block.schema.js",
+      "default": "./dist/components/code-block/code-block.schema.js"
     },
     "./code-block/variables": {
       "types": "./dist/components/code-block/code-block.variables.d.ts",
-      "svelte": "./src/components/code-block/code-block.variables.ts"
+      "svelte": "./src/components/code-block/code-block.variables.ts",
+      "node": "./dist/server/components/code-block/code-block.variables.js",
+      "default": "./dist/components/code-block/code-block.variables.js"
     },
     "./code-block/styles": {
       "default": "./dist/components/code-block/code-block.css"
@@ -561,11 +657,15 @@
     },
     "./collapsible/schema": {
       "types": "./dist/components/collapsible/collapsible.schema.d.ts",
-      "svelte": "./src/components/collapsible/collapsible.schema.ts"
+      "svelte": "./src/components/collapsible/collapsible.schema.ts",
+      "node": "./dist/server/components/collapsible/collapsible.schema.js",
+      "default": "./dist/components/collapsible/collapsible.schema.js"
     },
     "./collapsible/variables": {
       "types": "./dist/components/collapsible/collapsible.variables.d.ts",
-      "svelte": "./src/components/collapsible/collapsible.variables.ts"
+      "svelte": "./src/components/collapsible/collapsible.variables.ts",
+      "node": "./dist/server/components/collapsible/collapsible.variables.js",
+      "default": "./dist/components/collapsible/collapsible.variables.js"
     },
     "./collapsible/styles": {
       "default": "./dist/components/collapsible/collapsible.css"
@@ -582,11 +682,15 @@
     },
     "./color-field/schema": {
       "types": "./dist/components/color-field/color-field.schema.d.ts",
-      "svelte": "./src/components/color-field/color-field.schema.ts"
+      "svelte": "./src/components/color-field/color-field.schema.ts",
+      "node": "./dist/server/components/color-field/color-field.schema.js",
+      "default": "./dist/components/color-field/color-field.schema.js"
     },
     "./color-field/variables": {
       "types": "./dist/components/color-field/color-field.variables.d.ts",
-      "svelte": "./src/components/color-field/color-field.variables.ts"
+      "svelte": "./src/components/color-field/color-field.variables.ts",
+      "node": "./dist/server/components/color-field/color-field.variables.js",
+      "default": "./dist/components/color-field/color-field.variables.js"
     },
     "./color-field/styles": {
       "default": "./dist/components/color-field/color-field.css"
@@ -599,11 +703,15 @@
     },
     "./color-picker/schema": {
       "types": "./dist/components/color-picker/color-picker.schema.d.ts",
-      "svelte": "./src/components/color-picker/color-picker.schema.ts"
+      "svelte": "./src/components/color-picker/color-picker.schema.ts",
+      "node": "./dist/server/components/color-picker/color-picker.schema.js",
+      "default": "./dist/components/color-picker/color-picker.schema.js"
     },
     "./color-picker/variables": {
       "types": "./dist/components/color-picker/color-picker.variables.d.ts",
-      "svelte": "./src/components/color-picker/color-picker.variables.ts"
+      "svelte": "./src/components/color-picker/color-picker.variables.ts",
+      "node": "./dist/server/components/color-picker/color-picker.variables.js",
+      "default": "./dist/components/color-picker/color-picker.variables.js"
     },
     "./color-picker/styles": {
       "default": "./dist/components/color-picker/color-picker.css"
@@ -620,11 +728,15 @@
     },
     "./color-swatch-picker/schema": {
       "types": "./dist/components/color-swatch-picker/color-swatch-picker.schema.d.ts",
-      "svelte": "./src/components/color-swatch-picker/color-swatch-picker.schema.ts"
+      "svelte": "./src/components/color-swatch-picker/color-swatch-picker.schema.ts",
+      "node": "./dist/server/components/color-swatch-picker/color-swatch-picker.schema.js",
+      "default": "./dist/components/color-swatch-picker/color-swatch-picker.schema.js"
     },
     "./color-swatch-picker/variables": {
       "types": "./dist/components/color-swatch-picker/color-swatch-picker.variables.d.ts",
-      "svelte": "./src/components/color-swatch-picker/color-swatch-picker.variables.ts"
+      "svelte": "./src/components/color-swatch-picker/color-swatch-picker.variables.ts",
+      "node": "./dist/server/components/color-swatch-picker/color-swatch-picker.variables.js",
+      "default": "./dist/components/color-swatch-picker/color-swatch-picker.variables.js"
     },
     "./color-swatch-picker/styles": {
       "default": "./dist/components/color-swatch-picker/color-swatch-picker.css"
@@ -637,11 +749,15 @@
     },
     "./combobox/schema": {
       "types": "./dist/components/combobox/combobox.schema.d.ts",
-      "svelte": "./src/components/combobox/combobox.schema.ts"
+      "svelte": "./src/components/combobox/combobox.schema.ts",
+      "node": "./dist/server/components/combobox/combobox.schema.js",
+      "default": "./dist/components/combobox/combobox.schema.js"
     },
     "./combobox/variables": {
       "types": "./dist/components/combobox/combobox.variables.d.ts",
-      "svelte": "./src/components/combobox/combobox.variables.ts"
+      "svelte": "./src/components/combobox/combobox.variables.ts",
+      "node": "./dist/server/components/combobox/combobox.variables.js",
+      "default": "./dist/components/combobox/combobox.variables.js"
     },
     "./combobox/styles": {
       "default": "./dist/components/combobox/combobox.css"
@@ -658,11 +774,15 @@
     },
     "./command-item/schema": {
       "types": "./dist/components/command-item/command-item.schema.d.ts",
-      "svelte": "./src/components/command-item/command-item.schema.ts"
+      "svelte": "./src/components/command-item/command-item.schema.ts",
+      "node": "./dist/server/components/command-item/command-item.schema.js",
+      "default": "./dist/components/command-item/command-item.schema.js"
     },
     "./command-item/variables": {
       "types": "./dist/components/command-item/command-item.variables.d.ts",
-      "svelte": "./src/components/command-item/command-item.variables.ts"
+      "svelte": "./src/components/command-item/command-item.variables.ts",
+      "node": "./dist/server/components/command-item/command-item.variables.js",
+      "default": "./dist/components/command-item/command-item.variables.js"
     },
     "./command-menu": {
       "types": "./dist/components/command-menu/index.d.ts",
@@ -672,11 +792,15 @@
     },
     "./command-menu/schema": {
       "types": "./dist/components/command-menu/command-menu.schema.d.ts",
-      "svelte": "./src/components/command-menu/command-menu.schema.ts"
+      "svelte": "./src/components/command-menu/command-menu.schema.ts",
+      "node": "./dist/server/components/command-menu/command-menu.schema.js",
+      "default": "./dist/components/command-menu/command-menu.schema.js"
     },
     "./command-menu/variables": {
       "types": "./dist/components/command-menu/command-menu.variables.d.ts",
-      "svelte": "./src/components/command-menu/command-menu.variables.ts"
+      "svelte": "./src/components/command-menu/command-menu.variables.ts",
+      "node": "./dist/server/components/command-menu/command-menu.variables.js",
+      "default": "./dist/components/command-menu/command-menu.variables.js"
     },
     "./command-menu/styles": {
       "default": "./dist/components/command-menu/command-menu.css"
@@ -693,11 +817,15 @@
     },
     "./command-palette/schema": {
       "types": "./dist/components/command-palette/command-palette.schema.d.ts",
-      "svelte": "./src/components/command-palette/command-palette.schema.ts"
+      "svelte": "./src/components/command-palette/command-palette.schema.ts",
+      "node": "./dist/server/components/command-palette/command-palette.schema.js",
+      "default": "./dist/components/command-palette/command-palette.schema.js"
     },
     "./command-palette/variables": {
       "types": "./dist/components/command-palette/command-palette.variables.d.ts",
-      "svelte": "./src/components/command-palette/command-palette.variables.ts"
+      "svelte": "./src/components/command-palette/command-palette.variables.ts",
+      "node": "./dist/server/components/command-palette/command-palette.variables.js",
+      "default": "./dist/components/command-palette/command-palette.variables.js"
     },
     "./command-palette/styles": {
       "default": "./dist/components/command-palette/command-palette.css"
@@ -714,11 +842,15 @@
     },
     "./confirm-dialog/schema": {
       "types": "./dist/components/confirm-dialog/confirm-dialog.schema.d.ts",
-      "svelte": "./src/components/confirm-dialog/confirm-dialog.schema.ts"
+      "svelte": "./src/components/confirm-dialog/confirm-dialog.schema.ts",
+      "node": "./dist/server/components/confirm-dialog/confirm-dialog.schema.js",
+      "default": "./dist/components/confirm-dialog/confirm-dialog.schema.js"
     },
     "./confirm-dialog/variables": {
       "types": "./dist/components/confirm-dialog/confirm-dialog.variables.d.ts",
-      "svelte": "./src/components/confirm-dialog/confirm-dialog.variables.ts"
+      "svelte": "./src/components/confirm-dialog/confirm-dialog.variables.ts",
+      "node": "./dist/server/components/confirm-dialog/confirm-dialog.variables.js",
+      "default": "./dist/components/confirm-dialog/confirm-dialog.variables.js"
     },
     "./confirm-dialog/styles": {
       "default": "./dist/components/confirm-dialog/confirm-dialog.css"
@@ -735,11 +867,15 @@
     },
     "./connection-indicator/schema": {
       "types": "./dist/components/connection-indicator/connection-indicator.schema.d.ts",
-      "svelte": "./src/components/connection-indicator/connection-indicator.schema.ts"
+      "svelte": "./src/components/connection-indicator/connection-indicator.schema.ts",
+      "node": "./dist/server/components/connection-indicator/connection-indicator.schema.js",
+      "default": "./dist/components/connection-indicator/connection-indicator.schema.js"
     },
     "./connection-indicator/variables": {
       "types": "./dist/components/connection-indicator/connection-indicator.variables.d.ts",
-      "svelte": "./src/components/connection-indicator/connection-indicator.variables.ts"
+      "svelte": "./src/components/connection-indicator/connection-indicator.variables.ts",
+      "node": "./dist/server/components/connection-indicator/connection-indicator.variables.js",
+      "default": "./dist/components/connection-indicator/connection-indicator.variables.js"
     },
     "./connection-indicator/styles": {
       "default": "./dist/components/connection-indicator/connection-indicator.css"
@@ -752,11 +888,15 @@
     },
     "./container/schema": {
       "types": "./dist/components/container/container.schema.d.ts",
-      "svelte": "./src/components/container/container.schema.ts"
+      "svelte": "./src/components/container/container.schema.ts",
+      "node": "./dist/server/components/container/container.schema.js",
+      "default": "./dist/components/container/container.schema.js"
     },
     "./container/variables": {
       "types": "./dist/components/container/container.variables.d.ts",
-      "svelte": "./src/components/container/container.variables.ts"
+      "svelte": "./src/components/container/container.variables.ts",
+      "node": "./dist/server/components/container/container.variables.js",
+      "default": "./dist/components/container/container.variables.js"
     },
     "./container/styles": {
       "default": "./dist/components/container/container.css"
@@ -773,11 +913,15 @@
     },
     "./context-menu/schema": {
       "types": "./dist/components/context-menu/context-menu.schema.d.ts",
-      "svelte": "./src/components/context-menu/context-menu.schema.ts"
+      "svelte": "./src/components/context-menu/context-menu.schema.ts",
+      "node": "./dist/server/components/context-menu/context-menu.schema.js",
+      "default": "./dist/components/context-menu/context-menu.schema.js"
     },
     "./context-menu/variables": {
       "types": "./dist/components/context-menu/context-menu.variables.d.ts",
-      "svelte": "./src/components/context-menu/context-menu.variables.ts"
+      "svelte": "./src/components/context-menu/context-menu.variables.ts",
+      "node": "./dist/server/components/context-menu/context-menu.variables.js",
+      "default": "./dist/components/context-menu/context-menu.variables.js"
     },
     "./context-menu/styles": {
       "default": "./dist/components/context-menu/context-menu.css"
@@ -794,11 +938,15 @@
     },
     "./context-menu-trigger/schema": {
       "types": "./dist/components/context-menu-trigger/context-menu-trigger.schema.d.ts",
-      "svelte": "./src/components/context-menu-trigger/context-menu-trigger.schema.ts"
+      "svelte": "./src/components/context-menu-trigger/context-menu-trigger.schema.ts",
+      "node": "./dist/server/components/context-menu-trigger/context-menu-trigger.schema.js",
+      "default": "./dist/components/context-menu-trigger/context-menu-trigger.schema.js"
     },
     "./context-menu-trigger/variables": {
       "types": "./dist/components/context-menu-trigger/context-menu-trigger.variables.d.ts",
-      "svelte": "./src/components/context-menu-trigger/context-menu-trigger.variables.ts"
+      "svelte": "./src/components/context-menu-trigger/context-menu-trigger.variables.ts",
+      "node": "./dist/server/components/context-menu-trigger/context-menu-trigger.variables.js",
+      "default": "./dist/components/context-menu-trigger/context-menu-trigger.variables.js"
     },
     "./copy-button": {
       "types": "./dist/components/copy-button/index.d.ts",
@@ -808,11 +956,15 @@
     },
     "./copy-button/schema": {
       "types": "./dist/components/copy-button/copy-button.schema.d.ts",
-      "svelte": "./src/components/copy-button/copy-button.schema.ts"
+      "svelte": "./src/components/copy-button/copy-button.schema.ts",
+      "node": "./dist/server/components/copy-button/copy-button.schema.js",
+      "default": "./dist/components/copy-button/copy-button.schema.js"
     },
     "./copy-button/variables": {
       "types": "./dist/components/copy-button/copy-button.variables.d.ts",
-      "svelte": "./src/components/copy-button/copy-button.variables.ts"
+      "svelte": "./src/components/copy-button/copy-button.variables.ts",
+      "node": "./dist/server/components/copy-button/copy-button.variables.js",
+      "default": "./dist/components/copy-button/copy-button.variables.js"
     },
     "./copy-button/styles": {
       "default": "./dist/components/copy-button/copy-button.css"
@@ -829,11 +981,15 @@
     },
     "./data-list/schema": {
       "types": "./dist/components/data-list/data-list.schema.d.ts",
-      "svelte": "./src/components/data-list/data-list.schema.ts"
+      "svelte": "./src/components/data-list/data-list.schema.ts",
+      "node": "./dist/server/components/data-list/data-list.schema.js",
+      "default": "./dist/components/data-list/data-list.schema.js"
     },
     "./data-list/variables": {
       "types": "./dist/components/data-list/data-list.variables.d.ts",
-      "svelte": "./src/components/data-list/data-list.variables.ts"
+      "svelte": "./src/components/data-list/data-list.variables.ts",
+      "node": "./dist/server/components/data-list/data-list.variables.js",
+      "default": "./dist/components/data-list/data-list.variables.js"
     },
     "./data-list/styles": {
       "default": "./dist/components/data-list/data-list.css"
@@ -850,11 +1006,15 @@
     },
     "./description-list/schema": {
       "types": "./dist/components/description-list/description-list.schema.d.ts",
-      "svelte": "./src/components/description-list/description-list.schema.ts"
+      "svelte": "./src/components/description-list/description-list.schema.ts",
+      "node": "./dist/server/components/description-list/description-list.schema.js",
+      "default": "./dist/components/description-list/description-list.schema.js"
     },
     "./description-list/variables": {
       "types": "./dist/components/description-list/description-list.variables.d.ts",
-      "svelte": "./src/components/description-list/description-list.variables.ts"
+      "svelte": "./src/components/description-list/description-list.variables.ts",
+      "node": "./dist/server/components/description-list/description-list.variables.js",
+      "default": "./dist/components/description-list/description-list.variables.js"
     },
     "./description-list/styles": {
       "default": "./dist/components/description-list/description-list.css"
@@ -867,11 +1027,15 @@
     },
     "./diff-statistics/schema": {
       "types": "./dist/components/diff-statistics/diff-statistics.schema.d.ts",
-      "svelte": "./src/components/diff-statistics/diff-statistics.schema.ts"
+      "svelte": "./src/components/diff-statistics/diff-statistics.schema.ts",
+      "node": "./dist/server/components/diff-statistics/diff-statistics.schema.js",
+      "default": "./dist/components/diff-statistics/diff-statistics.schema.js"
     },
     "./diff-statistics/variables": {
       "types": "./dist/components/diff-statistics/diff-statistics.variables.d.ts",
-      "svelte": "./src/components/diff-statistics/diff-statistics.variables.ts"
+      "svelte": "./src/components/diff-statistics/diff-statistics.variables.ts",
+      "node": "./dist/server/components/diff-statistics/diff-statistics.variables.js",
+      "default": "./dist/components/diff-statistics/diff-statistics.variables.js"
     },
     "./diff-statistics/styles": {
       "default": "./dist/components/diff-statistics/diff-statistics.css"
@@ -888,11 +1052,15 @@
     },
     "./diff-viewer/schema": {
       "types": "./dist/components/diff-viewer/diff-viewer.schema.d.ts",
-      "svelte": "./src/components/diff-viewer/diff-viewer.schema.ts"
+      "svelte": "./src/components/diff-viewer/diff-viewer.schema.ts",
+      "node": "./dist/server/components/diff-viewer/diff-viewer.schema.js",
+      "default": "./dist/components/diff-viewer/diff-viewer.schema.js"
     },
     "./diff-viewer/variables": {
       "types": "./dist/components/diff-viewer/diff-viewer.variables.d.ts",
-      "svelte": "./src/components/diff-viewer/diff-viewer.variables.ts"
+      "svelte": "./src/components/diff-viewer/diff-viewer.variables.ts",
+      "node": "./dist/server/components/diff-viewer/diff-viewer.variables.js",
+      "default": "./dist/components/diff-viewer/diff-viewer.variables.js"
     },
     "./diff-viewer/examples": {
       "import": "./src/components/diff-viewer/diff-viewer.examples.json",
@@ -906,11 +1074,15 @@
     },
     "./divider/schema": {
       "types": "./dist/components/divider/divider.schema.d.ts",
-      "svelte": "./src/components/divider/divider.schema.ts"
+      "svelte": "./src/components/divider/divider.schema.ts",
+      "node": "./dist/server/components/divider/divider.schema.js",
+      "default": "./dist/components/divider/divider.schema.js"
     },
     "./divider/variables": {
       "types": "./dist/components/divider/divider.variables.d.ts",
-      "svelte": "./src/components/divider/divider.variables.ts"
+      "svelte": "./src/components/divider/divider.variables.ts",
+      "node": "./dist/server/components/divider/divider.variables.js",
+      "default": "./dist/components/divider/divider.variables.js"
     },
     "./divider/styles": {
       "default": "./dist/components/divider/divider.css"
@@ -927,11 +1099,15 @@
     },
     "./drawer/schema": {
       "types": "./dist/components/drawer/drawer.schema.d.ts",
-      "svelte": "./src/components/drawer/drawer.schema.ts"
+      "svelte": "./src/components/drawer/drawer.schema.ts",
+      "node": "./dist/server/components/drawer/drawer.schema.js",
+      "default": "./dist/components/drawer/drawer.schema.js"
     },
     "./drawer/variables": {
       "types": "./dist/components/drawer/drawer.variables.d.ts",
-      "svelte": "./src/components/drawer/drawer.variables.ts"
+      "svelte": "./src/components/drawer/drawer.variables.ts",
+      "node": "./dist/server/components/drawer/drawer.variables.js",
+      "default": "./dist/components/drawer/drawer.variables.js"
     },
     "./drawer/styles": {
       "default": "./dist/components/drawer/drawer.css"
@@ -948,11 +1124,15 @@
     },
     "./dropdown/schema": {
       "types": "./dist/components/dropdown/dropdown.schema.d.ts",
-      "svelte": "./src/components/dropdown/dropdown.schema.ts"
+      "svelte": "./src/components/dropdown/dropdown.schema.ts",
+      "node": "./dist/server/components/dropdown/dropdown.schema.js",
+      "default": "./dist/components/dropdown/dropdown.schema.js"
     },
     "./dropdown/variables": {
       "types": "./dist/components/dropdown/dropdown.variables.d.ts",
-      "svelte": "./src/components/dropdown/dropdown.variables.ts"
+      "svelte": "./src/components/dropdown/dropdown.variables.ts",
+      "node": "./dist/server/components/dropdown/dropdown.variables.js",
+      "default": "./dist/components/dropdown/dropdown.variables.js"
     },
     "./dropdown/styles": {
       "default": "./dist/components/dropdown/dropdown.css"
@@ -969,11 +1149,15 @@
     },
     "./dropdown-group/schema": {
       "types": "./dist/components/dropdown-group/dropdown-group.schema.d.ts",
-      "svelte": "./src/components/dropdown-group/dropdown-group.schema.ts"
+      "svelte": "./src/components/dropdown-group/dropdown-group.schema.ts",
+      "node": "./dist/server/components/dropdown-group/dropdown-group.schema.js",
+      "default": "./dist/components/dropdown-group/dropdown-group.schema.js"
     },
     "./dropdown-group/variables": {
       "types": "./dist/components/dropdown-group/dropdown-group.variables.d.ts",
-      "svelte": "./src/components/dropdown-group/dropdown-group.variables.ts"
+      "svelte": "./src/components/dropdown-group/dropdown-group.variables.ts",
+      "node": "./dist/server/components/dropdown-group/dropdown-group.variables.js",
+      "default": "./dist/components/dropdown-group/dropdown-group.variables.js"
     },
     "./dropdown-item": {
       "types": "./dist/components/dropdown-item/index.d.ts",
@@ -983,11 +1167,15 @@
     },
     "./dropdown-item/schema": {
       "types": "./dist/components/dropdown-item/dropdown-item.schema.d.ts",
-      "svelte": "./src/components/dropdown-item/dropdown-item.schema.ts"
+      "svelte": "./src/components/dropdown-item/dropdown-item.schema.ts",
+      "node": "./dist/server/components/dropdown-item/dropdown-item.schema.js",
+      "default": "./dist/components/dropdown-item/dropdown-item.schema.js"
     },
     "./dropdown-item/variables": {
       "types": "./dist/components/dropdown-item/dropdown-item.variables.d.ts",
-      "svelte": "./src/components/dropdown-item/dropdown-item.variables.ts"
+      "svelte": "./src/components/dropdown-item/dropdown-item.variables.ts",
+      "node": "./dist/server/components/dropdown-item/dropdown-item.variables.js",
+      "default": "./dist/components/dropdown-item/dropdown-item.variables.js"
     },
     "./dropdown-label": {
       "types": "./dist/components/dropdown-label/index.d.ts",
@@ -997,11 +1185,15 @@
     },
     "./dropdown-label/schema": {
       "types": "./dist/components/dropdown-label/dropdown-label.schema.d.ts",
-      "svelte": "./src/components/dropdown-label/dropdown-label.schema.ts"
+      "svelte": "./src/components/dropdown-label/dropdown-label.schema.ts",
+      "node": "./dist/server/components/dropdown-label/dropdown-label.schema.js",
+      "default": "./dist/components/dropdown-label/dropdown-label.schema.js"
     },
     "./dropdown-label/variables": {
       "types": "./dist/components/dropdown-label/dropdown-label.variables.d.ts",
-      "svelte": "./src/components/dropdown-label/dropdown-label.variables.ts"
+      "svelte": "./src/components/dropdown-label/dropdown-label.variables.ts",
+      "node": "./dist/server/components/dropdown-label/dropdown-label.variables.js",
+      "default": "./dist/components/dropdown-label/dropdown-label.variables.js"
     },
     "./dropdown-menu": {
       "types": "./dist/components/dropdown-menu/index.d.ts",
@@ -1011,11 +1203,15 @@
     },
     "./dropdown-menu/schema": {
       "types": "./dist/components/dropdown-menu/dropdown-menu.schema.d.ts",
-      "svelte": "./src/components/dropdown-menu/dropdown-menu.schema.ts"
+      "svelte": "./src/components/dropdown-menu/dropdown-menu.schema.ts",
+      "node": "./dist/server/components/dropdown-menu/dropdown-menu.schema.js",
+      "default": "./dist/components/dropdown-menu/dropdown-menu.schema.js"
     },
     "./dropdown-menu/variables": {
       "types": "./dist/components/dropdown-menu/dropdown-menu.variables.d.ts",
-      "svelte": "./src/components/dropdown-menu/dropdown-menu.variables.ts"
+      "svelte": "./src/components/dropdown-menu/dropdown-menu.variables.ts",
+      "node": "./dist/server/components/dropdown-menu/dropdown-menu.variables.js",
+      "default": "./dist/components/dropdown-menu/dropdown-menu.variables.js"
     },
     "./dropdown-separator": {
       "types": "./dist/components/dropdown-separator/index.d.ts",
@@ -1025,11 +1221,15 @@
     },
     "./dropdown-separator/schema": {
       "types": "./dist/components/dropdown-separator/dropdown-separator.schema.d.ts",
-      "svelte": "./src/components/dropdown-separator/dropdown-separator.schema.ts"
+      "svelte": "./src/components/dropdown-separator/dropdown-separator.schema.ts",
+      "node": "./dist/server/components/dropdown-separator/dropdown-separator.schema.js",
+      "default": "./dist/components/dropdown-separator/dropdown-separator.schema.js"
     },
     "./dropdown-separator/variables": {
       "types": "./dist/components/dropdown-separator/dropdown-separator.variables.d.ts",
-      "svelte": "./src/components/dropdown-separator/dropdown-separator.variables.ts"
+      "svelte": "./src/components/dropdown-separator/dropdown-separator.variables.ts",
+      "node": "./dist/server/components/dropdown-separator/dropdown-separator.variables.js",
+      "default": "./dist/components/dropdown-separator/dropdown-separator.variables.js"
     },
     "./dropdown-trigger": {
       "types": "./dist/components/dropdown-trigger/index.d.ts",
@@ -1039,11 +1239,15 @@
     },
     "./dropdown-trigger/schema": {
       "types": "./dist/components/dropdown-trigger/dropdown-trigger.schema.d.ts",
-      "svelte": "./src/components/dropdown-trigger/dropdown-trigger.schema.ts"
+      "svelte": "./src/components/dropdown-trigger/dropdown-trigger.schema.ts",
+      "node": "./dist/server/components/dropdown-trigger/dropdown-trigger.schema.js",
+      "default": "./dist/components/dropdown-trigger/dropdown-trigger.schema.js"
     },
     "./dropdown-trigger/variables": {
       "types": "./dist/components/dropdown-trigger/dropdown-trigger.variables.d.ts",
-      "svelte": "./src/components/dropdown-trigger/dropdown-trigger.variables.ts"
+      "svelte": "./src/components/dropdown-trigger/dropdown-trigger.variables.ts",
+      "node": "./dist/server/components/dropdown-trigger/dropdown-trigger.variables.js",
+      "default": "./dist/components/dropdown-trigger/dropdown-trigger.variables.js"
     },
     "./empty-state": {
       "types": "./dist/components/empty-state/index.d.ts",
@@ -1053,11 +1257,15 @@
     },
     "./empty-state/schema": {
       "types": "./dist/components/empty-state/empty-state.schema.d.ts",
-      "svelte": "./src/components/empty-state/empty-state.schema.ts"
+      "svelte": "./src/components/empty-state/empty-state.schema.ts",
+      "node": "./dist/server/components/empty-state/empty-state.schema.js",
+      "default": "./dist/components/empty-state/empty-state.schema.js"
     },
     "./empty-state/variables": {
       "types": "./dist/components/empty-state/empty-state.variables.d.ts",
-      "svelte": "./src/components/empty-state/empty-state.variables.ts"
+      "svelte": "./src/components/empty-state/empty-state.variables.ts",
+      "node": "./dist/server/components/empty-state/empty-state.variables.js",
+      "default": "./dist/components/empty-state/empty-state.variables.js"
     },
     "./empty-state/styles": {
       "default": "./dist/components/empty-state/empty-state.css"
@@ -1074,11 +1282,15 @@
     },
     "./feed/schema": {
       "types": "./dist/components/feed/feed.schema.d.ts",
-      "svelte": "./src/components/feed/feed.schema.ts"
+      "svelte": "./src/components/feed/feed.schema.ts",
+      "node": "./dist/server/components/feed/feed.schema.js",
+      "default": "./dist/components/feed/feed.schema.js"
     },
     "./feed/variables": {
       "types": "./dist/components/feed/feed.variables.d.ts",
-      "svelte": "./src/components/feed/feed.variables.ts"
+      "svelte": "./src/components/feed/feed.variables.ts",
+      "node": "./dist/server/components/feed/feed.variables.js",
+      "default": "./dist/components/feed/feed.variables.js"
     },
     "./feed/styles": {
       "default": "./dist/components/feed/feed.css"
@@ -1095,11 +1307,15 @@
     },
     "./feed-event/schema": {
       "types": "./dist/components/feed-event/feed-event.schema.d.ts",
-      "svelte": "./src/components/feed-event/feed-event.schema.ts"
+      "svelte": "./src/components/feed-event/feed-event.schema.ts",
+      "node": "./dist/server/components/feed-event/feed-event.schema.js",
+      "default": "./dist/components/feed-event/feed-event.schema.js"
     },
     "./feed-event/variables": {
       "types": "./dist/components/feed-event/feed-event.variables.d.ts",
-      "svelte": "./src/components/feed-event/feed-event.variables.ts"
+      "svelte": "./src/components/feed-event/feed-event.variables.ts",
+      "node": "./dist/server/components/feed-event/feed-event.variables.js",
+      "default": "./dist/components/feed-event/feed-event.variables.js"
     },
     "./file-upload": {
       "types": "./dist/components/file-upload/index.d.ts",
@@ -1109,11 +1325,15 @@
     },
     "./file-upload/schema": {
       "types": "./dist/components/file-upload/file-upload.schema.d.ts",
-      "svelte": "./src/components/file-upload/file-upload.schema.ts"
+      "svelte": "./src/components/file-upload/file-upload.schema.ts",
+      "node": "./dist/server/components/file-upload/file-upload.schema.js",
+      "default": "./dist/components/file-upload/file-upload.schema.js"
     },
     "./file-upload/variables": {
       "types": "./dist/components/file-upload/file-upload.variables.d.ts",
-      "svelte": "./src/components/file-upload/file-upload.variables.ts"
+      "svelte": "./src/components/file-upload/file-upload.variables.ts",
+      "node": "./dist/server/components/file-upload/file-upload.variables.js",
+      "default": "./dist/components/file-upload/file-upload.variables.js"
     },
     "./file-upload/styles": {
       "default": "./dist/components/file-upload/file-upload.css"
@@ -1126,11 +1346,15 @@
     },
     "./focus-trap/schema": {
       "types": "./dist/components/focus-trap/focus-trap.schema.d.ts",
-      "svelte": "./src/components/focus-trap/focus-trap.schema.ts"
+      "svelte": "./src/components/focus-trap/focus-trap.schema.ts",
+      "node": "./dist/server/components/focus-trap/focus-trap.schema.js",
+      "default": "./dist/components/focus-trap/focus-trap.schema.js"
     },
     "./focus-trap/variables": {
       "types": "./dist/components/focus-trap/focus-trap.variables.d.ts",
-      "svelte": "./src/components/focus-trap/focus-trap.variables.ts"
+      "svelte": "./src/components/focus-trap/focus-trap.variables.ts",
+      "node": "./dist/server/components/focus-trap/focus-trap.variables.js",
+      "default": "./dist/components/focus-trap/focus-trap.variables.js"
     },
     "./focus-trap/examples": {
       "import": "./src/components/focus-trap/focus-trap.examples.json",
@@ -1144,11 +1368,15 @@
     },
     "./form-field/schema": {
       "types": "./dist/components/form-field/form-field.schema.d.ts",
-      "svelte": "./src/components/form-field/form-field.schema.ts"
+      "svelte": "./src/components/form-field/form-field.schema.ts",
+      "node": "./dist/server/components/form-field/form-field.schema.js",
+      "default": "./dist/components/form-field/form-field.schema.js"
     },
     "./form-field/variables": {
       "types": "./dist/components/form-field/form-field.variables.d.ts",
-      "svelte": "./src/components/form-field/form-field.variables.ts"
+      "svelte": "./src/components/form-field/form-field.variables.ts",
+      "node": "./dist/server/components/form-field/form-field.variables.js",
+      "default": "./dist/components/form-field/form-field.variables.js"
     },
     "./form-field/styles": {
       "default": "./dist/components/form-field/form-field.css"
@@ -1165,11 +1393,15 @@
     },
     "./form-section/schema": {
       "types": "./dist/components/form-section/form-section.schema.d.ts",
-      "svelte": "./src/components/form-section/form-section.schema.ts"
+      "svelte": "./src/components/form-section/form-section.schema.ts",
+      "node": "./dist/server/components/form-section/form-section.schema.js",
+      "default": "./dist/components/form-section/form-section.schema.js"
     },
     "./form-section/variables": {
       "types": "./dist/components/form-section/form-section.variables.d.ts",
-      "svelte": "./src/components/form-section/form-section.variables.ts"
+      "svelte": "./src/components/form-section/form-section.variables.ts",
+      "node": "./dist/server/components/form-section/form-section.variables.js",
+      "default": "./dist/components/form-section/form-section.variables.js"
     },
     "./form-section/styles": {
       "default": "./dist/components/form-section/form-section.css"
@@ -1186,11 +1418,15 @@
     },
     "./grid-list/schema": {
       "types": "./dist/components/grid-list/grid-list.schema.d.ts",
-      "svelte": "./src/components/grid-list/grid-list.schema.ts"
+      "svelte": "./src/components/grid-list/grid-list.schema.ts",
+      "node": "./dist/server/components/grid-list/grid-list.schema.js",
+      "default": "./dist/components/grid-list/grid-list.schema.js"
     },
     "./grid-list/variables": {
       "types": "./dist/components/grid-list/grid-list.variables.d.ts",
-      "svelte": "./src/components/grid-list/grid-list.variables.ts"
+      "svelte": "./src/components/grid-list/grid-list.variables.ts",
+      "node": "./dist/server/components/grid-list/grid-list.variables.js",
+      "default": "./dist/components/grid-list/grid-list.variables.js"
     },
     "./grid-list/styles": {
       "default": "./dist/components/grid-list/grid-list.css"
@@ -1207,11 +1443,15 @@
     },
     "./grid-list-item/schema": {
       "types": "./dist/components/grid-list-item/grid-list-item.schema.d.ts",
-      "svelte": "./src/components/grid-list-item/grid-list-item.schema.ts"
+      "svelte": "./src/components/grid-list-item/grid-list-item.schema.ts",
+      "node": "./dist/server/components/grid-list-item/grid-list-item.schema.js",
+      "default": "./dist/components/grid-list-item/grid-list-item.schema.js"
     },
     "./grid-list-item/variables": {
       "types": "./dist/components/grid-list-item/grid-list-item.variables.d.ts",
-      "svelte": "./src/components/grid-list-item/grid-list-item.variables.ts"
+      "svelte": "./src/components/grid-list-item/grid-list-item.variables.ts",
+      "node": "./dist/server/components/grid-list-item/grid-list-item.variables.js",
+      "default": "./dist/components/grid-list-item/grid-list-item.variables.js"
     },
     "./hover-card": {
       "types": "./dist/components/hover-card/index.d.ts",
@@ -1221,11 +1461,15 @@
     },
     "./hover-card/schema": {
       "types": "./dist/components/hover-card/hover-card.schema.d.ts",
-      "svelte": "./src/components/hover-card/hover-card.schema.ts"
+      "svelte": "./src/components/hover-card/hover-card.schema.ts",
+      "node": "./dist/server/components/hover-card/hover-card.schema.js",
+      "default": "./dist/components/hover-card/hover-card.schema.js"
     },
     "./hover-card/variables": {
       "types": "./dist/components/hover-card/hover-card.variables.d.ts",
-      "svelte": "./src/components/hover-card/hover-card.variables.ts"
+      "svelte": "./src/components/hover-card/hover-card.variables.ts",
+      "node": "./dist/server/components/hover-card/hover-card.variables.js",
+      "default": "./dist/components/hover-card/hover-card.variables.js"
     },
     "./hover-card/styles": {
       "default": "./dist/components/hover-card/hover-card.css"
@@ -1242,11 +1486,15 @@
     },
     "./image/schema": {
       "types": "./dist/components/image/image.schema.d.ts",
-      "svelte": "./src/components/image/image.schema.ts"
+      "svelte": "./src/components/image/image.schema.ts",
+      "node": "./dist/server/components/image/image.schema.js",
+      "default": "./dist/components/image/image.schema.js"
     },
     "./image/variables": {
       "types": "./dist/components/image/image.variables.d.ts",
-      "svelte": "./src/components/image/image.variables.ts"
+      "svelte": "./src/components/image/image.variables.ts",
+      "node": "./dist/server/components/image/image.variables.js",
+      "default": "./dist/components/image/image.variables.js"
     },
     "./image/styles": {
       "default": "./dist/components/image/image.css"
@@ -1259,11 +1507,15 @@
     },
     "./inline/schema": {
       "types": "./dist/components/inline/inline.schema.d.ts",
-      "svelte": "./src/components/inline/inline.schema.ts"
+      "svelte": "./src/components/inline/inline.schema.ts",
+      "node": "./dist/server/components/inline/inline.schema.js",
+      "default": "./dist/components/inline/inline.schema.js"
     },
     "./inline/variables": {
       "types": "./dist/components/inline/inline.variables.d.ts",
-      "svelte": "./src/components/inline/inline.variables.ts"
+      "svelte": "./src/components/inline/inline.variables.ts",
+      "node": "./dist/server/components/inline/inline.variables.js",
+      "default": "./dist/components/inline/inline.variables.js"
     },
     "./inline/styles": {
       "default": "./dist/components/inline/inline.css"
@@ -1280,11 +1532,15 @@
     },
     "./input/schema": {
       "types": "./dist/components/input/input.schema.d.ts",
-      "svelte": "./src/components/input/input.schema.ts"
+      "svelte": "./src/components/input/input.schema.ts",
+      "node": "./dist/server/components/input/input.schema.js",
+      "default": "./dist/components/input/input.schema.js"
     },
     "./input/variables": {
       "types": "./dist/components/input/input.variables.d.ts",
-      "svelte": "./src/components/input/input.variables.ts"
+      "svelte": "./src/components/input/input.variables.ts",
+      "node": "./dist/server/components/input/input.variables.js",
+      "default": "./dist/components/input/input.variables.js"
     },
     "./input/styles": {
       "default": "./dist/components/input/input.css"
@@ -1305,11 +1561,15 @@
     },
     "./json-schema-editor/schema": {
       "types": "./dist/components/json-schema-editor/json-schema-editor.schema.d.ts",
-      "svelte": "./src/components/json-schema-editor/json-schema-editor.schema.ts"
+      "svelte": "./src/components/json-schema-editor/json-schema-editor.schema.ts",
+      "node": "./dist/server/components/json-schema-editor/json-schema-editor.schema.js",
+      "default": "./dist/components/json-schema-editor/json-schema-editor.schema.js"
     },
     "./json-schema-editor/variables": {
       "types": "./dist/components/json-schema-editor/json-schema-editor.variables.d.ts",
-      "svelte": "./src/components/json-schema-editor/json-schema-editor.variables.ts"
+      "svelte": "./src/components/json-schema-editor/json-schema-editor.variables.ts",
+      "node": "./dist/server/components/json-schema-editor/json-schema-editor.variables.js",
+      "default": "./dist/components/json-schema-editor/json-schema-editor.variables.js"
     },
     "./json-schema-editor/styles": {
       "default": "./dist/components/json-schema-editor/json-schema-editor.css"
@@ -1326,11 +1586,15 @@
     },
     "./json-viewer/schema": {
       "types": "./dist/components/json-viewer/json-viewer.schema.d.ts",
-      "svelte": "./src/components/json-viewer/json-viewer.schema.ts"
+      "svelte": "./src/components/json-viewer/json-viewer.schema.ts",
+      "node": "./dist/server/components/json-viewer/json-viewer.schema.js",
+      "default": "./dist/components/json-viewer/json-viewer.schema.js"
     },
     "./json-viewer/variables": {
       "types": "./dist/components/json-viewer/json-viewer.variables.d.ts",
-      "svelte": "./src/components/json-viewer/json-viewer.variables.ts"
+      "svelte": "./src/components/json-viewer/json-viewer.variables.ts",
+      "node": "./dist/server/components/json-viewer/json-viewer.variables.js",
+      "default": "./dist/components/json-viewer/json-viewer.variables.js"
     },
     "./json-viewer/styles": {
       "default": "./dist/components/json-viewer/json-viewer.css"
@@ -1343,11 +1607,15 @@
     },
     "./kanban-board/schema": {
       "types": "./dist/components/kanban-board/kanban-board.schema.d.ts",
-      "svelte": "./src/components/kanban-board/kanban-board.schema.ts"
+      "svelte": "./src/components/kanban-board/kanban-board.schema.ts",
+      "node": "./dist/server/components/kanban-board/kanban-board.schema.js",
+      "default": "./dist/components/kanban-board/kanban-board.schema.js"
     },
     "./kanban-board/variables": {
       "types": "./dist/components/kanban-board/kanban-board.variables.d.ts",
-      "svelte": "./src/components/kanban-board/kanban-board.variables.ts"
+      "svelte": "./src/components/kanban-board/kanban-board.variables.ts",
+      "node": "./dist/server/components/kanban-board/kanban-board.variables.js",
+      "default": "./dist/components/kanban-board/kanban-board.variables.js"
     },
     "./kanban-board/styles": {
       "default": "./dist/components/kanban-board/kanban-board.css"
@@ -1364,11 +1632,15 @@
     },
     "./kbd/schema": {
       "types": "./dist/components/kbd/kbd.schema.d.ts",
-      "svelte": "./src/components/kbd/kbd.schema.ts"
+      "svelte": "./src/components/kbd/kbd.schema.ts",
+      "node": "./dist/server/components/kbd/kbd.schema.js",
+      "default": "./dist/components/kbd/kbd.schema.js"
     },
     "./kbd/variables": {
       "types": "./dist/components/kbd/kbd.variables.d.ts",
-      "svelte": "./src/components/kbd/kbd.variables.ts"
+      "svelte": "./src/components/kbd/kbd.variables.ts",
+      "node": "./dist/server/components/kbd/kbd.variables.js",
+      "default": "./dist/components/kbd/kbd.variables.js"
     },
     "./kbd/styles": {
       "default": "./dist/components/kbd/kbd.css"
@@ -1385,11 +1657,15 @@
     },
     "./label/schema": {
       "types": "./dist/components/label/label.schema.d.ts",
-      "svelte": "./src/components/label/label.schema.ts"
+      "svelte": "./src/components/label/label.schema.ts",
+      "node": "./dist/server/components/label/label.schema.js",
+      "default": "./dist/components/label/label.schema.js"
     },
     "./label/variables": {
       "types": "./dist/components/label/label.variables.d.ts",
-      "svelte": "./src/components/label/label.variables.ts"
+      "svelte": "./src/components/label/label.variables.ts",
+      "node": "./dist/server/components/label/label.variables.js",
+      "default": "./dist/components/label/label.variables.js"
     },
     "./label/styles": {
       "default": "./dist/components/label/label.css"
@@ -1402,11 +1678,15 @@
     },
     "./line-chart/schema": {
       "types": "./dist/components/line-chart/line-chart.schema.d.ts",
-      "svelte": "./src/components/line-chart/line-chart.schema.ts"
+      "svelte": "./src/components/line-chart/line-chart.schema.ts",
+      "node": "./dist/server/components/line-chart/line-chart.schema.js",
+      "default": "./dist/components/line-chart/line-chart.schema.js"
     },
     "./line-chart/variables": {
       "types": "./dist/components/line-chart/line-chart.variables.d.ts",
-      "svelte": "./src/components/line-chart/line-chart.variables.ts"
+      "svelte": "./src/components/line-chart/line-chart.variables.ts",
+      "node": "./dist/server/components/line-chart/line-chart.variables.js",
+      "default": "./dist/components/line-chart/line-chart.variables.js"
     },
     "./line-chart/styles": {
       "default": "./dist/components/line-chart/line-chart.css"
@@ -1423,11 +1703,15 @@
     },
     "./load-more/schema": {
       "types": "./dist/components/load-more/load-more.schema.d.ts",
-      "svelte": "./src/components/load-more/load-more.schema.ts"
+      "svelte": "./src/components/load-more/load-more.schema.ts",
+      "node": "./dist/server/components/load-more/load-more.schema.js",
+      "default": "./dist/components/load-more/load-more.schema.js"
     },
     "./load-more/variables": {
       "types": "./dist/components/load-more/load-more.variables.d.ts",
-      "svelte": "./src/components/load-more/load-more.variables.ts"
+      "svelte": "./src/components/load-more/load-more.variables.ts",
+      "node": "./dist/server/components/load-more/load-more.variables.js",
+      "default": "./dist/components/load-more/load-more.variables.js"
     },
     "./load-more/styles": {
       "default": "./dist/components/load-more/load-more.css"
@@ -1444,11 +1728,15 @@
     },
     "./markdown-editor/schema": {
       "types": "./dist/components/markdown-editor/markdown-editor.schema.d.ts",
-      "svelte": "./src/components/markdown-editor/markdown-editor.schema.ts"
+      "svelte": "./src/components/markdown-editor/markdown-editor.schema.ts",
+      "node": "./dist/server/components/markdown-editor/markdown-editor.schema.js",
+      "default": "./dist/components/markdown-editor/markdown-editor.schema.js"
     },
     "./markdown-editor/variables": {
       "types": "./dist/components/markdown-editor/markdown-editor.variables.d.ts",
-      "svelte": "./src/components/markdown-editor/markdown-editor.variables.ts"
+      "svelte": "./src/components/markdown-editor/markdown-editor.variables.ts",
+      "node": "./dist/server/components/markdown-editor/markdown-editor.variables.js",
+      "default": "./dist/components/markdown-editor/markdown-editor.variables.js"
     },
     "./markdown-editor/examples": {
       "import": "./src/components/markdown-editor/markdown-editor.examples.json",
@@ -1462,11 +1750,15 @@
     },
     "./menu-bar/schema": {
       "types": "./dist/components/menu-bar/menu-bar.schema.d.ts",
-      "svelte": "./src/components/menu-bar/menu-bar.schema.ts"
+      "svelte": "./src/components/menu-bar/menu-bar.schema.ts",
+      "node": "./dist/server/components/menu-bar/menu-bar.schema.js",
+      "default": "./dist/components/menu-bar/menu-bar.schema.js"
     },
     "./menu-bar/variables": {
       "types": "./dist/components/menu-bar/menu-bar.variables.d.ts",
-      "svelte": "./src/components/menu-bar/menu-bar.variables.ts"
+      "svelte": "./src/components/menu-bar/menu-bar.variables.ts",
+      "node": "./dist/server/components/menu-bar/menu-bar.variables.js",
+      "default": "./dist/components/menu-bar/menu-bar.variables.js"
     },
     "./menu-bar/styles": {
       "default": "./dist/components/menu-bar/menu-bar.css"
@@ -1483,11 +1775,15 @@
     },
     "./message/schema": {
       "types": "./dist/components/message/message.schema.d.ts",
-      "svelte": "./src/components/message/message.schema.ts"
+      "svelte": "./src/components/message/message.schema.ts",
+      "node": "./dist/server/components/message/message.schema.js",
+      "default": "./dist/components/message/message.schema.js"
     },
     "./message/variables": {
       "types": "./dist/components/message/message.variables.d.ts",
-      "svelte": "./src/components/message/message.variables.ts"
+      "svelte": "./src/components/message/message.variables.ts",
+      "node": "./dist/server/components/message/message.variables.js",
+      "default": "./dist/components/message/message.variables.js"
     },
     "./message/styles": {
       "default": "./dist/components/message/message.css"
@@ -1500,11 +1796,15 @@
     },
     "./modal/schema": {
       "types": "./dist/components/modal/modal.schema.d.ts",
-      "svelte": "./src/components/modal/modal.schema.ts"
+      "svelte": "./src/components/modal/modal.schema.ts",
+      "node": "./dist/server/components/modal/modal.schema.js",
+      "default": "./dist/components/modal/modal.schema.js"
     },
     "./modal/variables": {
       "types": "./dist/components/modal/modal.variables.d.ts",
-      "svelte": "./src/components/modal/modal.variables.ts"
+      "svelte": "./src/components/modal/modal.variables.ts",
+      "node": "./dist/server/components/modal/modal.variables.js",
+      "default": "./dist/components/modal/modal.variables.js"
     },
     "./modal/styles": {
       "default": "./dist/components/modal/modal.css"
@@ -1525,11 +1825,15 @@
     },
     "./navigation-bar/schema": {
       "types": "./dist/components/navigation-bar/navigation-bar.schema.d.ts",
-      "svelte": "./src/components/navigation-bar/navigation-bar.schema.ts"
+      "svelte": "./src/components/navigation-bar/navigation-bar.schema.ts",
+      "node": "./dist/server/components/navigation-bar/navigation-bar.schema.js",
+      "default": "./dist/components/navigation-bar/navigation-bar.schema.js"
     },
     "./navigation-bar/variables": {
       "types": "./dist/components/navigation-bar/navigation-bar.variables.d.ts",
-      "svelte": "./src/components/navigation-bar/navigation-bar.variables.ts"
+      "svelte": "./src/components/navigation-bar/navigation-bar.variables.ts",
+      "node": "./dist/server/components/navigation-bar/navigation-bar.variables.js",
+      "default": "./dist/components/navigation-bar/navigation-bar.variables.js"
     },
     "./navigation-bar/styles": {
       "default": "./dist/components/navigation-bar/navigation-bar.css"
@@ -1546,11 +1850,15 @@
     },
     "./navigation-item/schema": {
       "types": "./dist/components/navigation-item/navigation-item.schema.d.ts",
-      "svelte": "./src/components/navigation-item/navigation-item.schema.ts"
+      "svelte": "./src/components/navigation-item/navigation-item.schema.ts",
+      "node": "./dist/server/components/navigation-item/navigation-item.schema.js",
+      "default": "./dist/components/navigation-item/navigation-item.schema.js"
     },
     "./navigation-item/variables": {
       "types": "./dist/components/navigation-item/navigation-item.variables.d.ts",
-      "svelte": "./src/components/navigation-item/navigation-item.variables.ts"
+      "svelte": "./src/components/navigation-item/navigation-item.variables.ts",
+      "node": "./dist/server/components/navigation-item/navigation-item.variables.js",
+      "default": "./dist/components/navigation-item/navigation-item.variables.js"
     },
     "./navigation-item/styles": {
       "default": "./dist/components/navigation-item/navigation-item.css"
@@ -1563,11 +1871,15 @@
     },
     "./number-input/schema": {
       "types": "./dist/components/number-input/number-input.schema.d.ts",
-      "svelte": "./src/components/number-input/number-input.schema.ts"
+      "svelte": "./src/components/number-input/number-input.schema.ts",
+      "node": "./dist/server/components/number-input/number-input.schema.js",
+      "default": "./dist/components/number-input/number-input.schema.js"
     },
     "./number-input/variables": {
       "types": "./dist/components/number-input/number-input.variables.d.ts",
-      "svelte": "./src/components/number-input/number-input.variables.ts"
+      "svelte": "./src/components/number-input/number-input.variables.ts",
+      "node": "./dist/server/components/number-input/number-input.variables.js",
+      "default": "./dist/components/number-input/number-input.variables.js"
     },
     "./number-input/styles": {
       "default": "./dist/components/number-input/number-input.css"
@@ -1580,11 +1892,15 @@
     },
     "./page-layout/schema": {
       "types": "./dist/components/page-layout/page-layout.schema.d.ts",
-      "svelte": "./src/components/page-layout/page-layout.schema.ts"
+      "svelte": "./src/components/page-layout/page-layout.schema.ts",
+      "node": "./dist/server/components/page-layout/page-layout.schema.js",
+      "default": "./dist/components/page-layout/page-layout.schema.js"
     },
     "./page-layout/variables": {
       "types": "./dist/components/page-layout/page-layout.variables.d.ts",
-      "svelte": "./src/components/page-layout/page-layout.variables.ts"
+      "svelte": "./src/components/page-layout/page-layout.variables.ts",
+      "node": "./dist/server/components/page-layout/page-layout.variables.js",
+      "default": "./dist/components/page-layout/page-layout.variables.js"
     },
     "./page-layout/styles": {
       "default": "./dist/components/page-layout/page-layout.css"
@@ -1601,11 +1917,15 @@
     },
     "./pagination/schema": {
       "types": "./dist/components/pagination/pagination.schema.d.ts",
-      "svelte": "./src/components/pagination/pagination.schema.ts"
+      "svelte": "./src/components/pagination/pagination.schema.ts",
+      "node": "./dist/server/components/pagination/pagination.schema.js",
+      "default": "./dist/components/pagination/pagination.schema.js"
     },
     "./pagination/variables": {
       "types": "./dist/components/pagination/pagination.variables.d.ts",
-      "svelte": "./src/components/pagination/pagination.variables.ts"
+      "svelte": "./src/components/pagination/pagination.variables.ts",
+      "node": "./dist/server/components/pagination/pagination.variables.js",
+      "default": "./dist/components/pagination/pagination.variables.js"
     },
     "./pagination/styles": {
       "default": "./dist/components/pagination/pagination.css"
@@ -1622,11 +1942,15 @@
     },
     "./phone-input/schema": {
       "types": "./dist/components/phone-input/phone-input.schema.d.ts",
-      "svelte": "./src/components/phone-input/phone-input.schema.ts"
+      "svelte": "./src/components/phone-input/phone-input.schema.ts",
+      "node": "./dist/server/components/phone-input/phone-input.schema.js",
+      "default": "./dist/components/phone-input/phone-input.schema.js"
     },
     "./phone-input/variables": {
       "types": "./dist/components/phone-input/phone-input.variables.d.ts",
-      "svelte": "./src/components/phone-input/phone-input.variables.ts"
+      "svelte": "./src/components/phone-input/phone-input.variables.ts",
+      "node": "./dist/server/components/phone-input/phone-input.variables.js",
+      "default": "./dist/components/phone-input/phone-input.variables.js"
     },
     "./phone-input/styles": {
       "default": "./dist/components/phone-input/phone-input.css"
@@ -1643,11 +1967,15 @@
     },
     "./pin-input/schema": {
       "types": "./dist/components/pin-input/pin-input.schema.d.ts",
-      "svelte": "./src/components/pin-input/pin-input.schema.ts"
+      "svelte": "./src/components/pin-input/pin-input.schema.ts",
+      "node": "./dist/server/components/pin-input/pin-input.schema.js",
+      "default": "./dist/components/pin-input/pin-input.schema.js"
     },
     "./pin-input/variables": {
       "types": "./dist/components/pin-input/pin-input.variables.d.ts",
-      "svelte": "./src/components/pin-input/pin-input.variables.ts"
+      "svelte": "./src/components/pin-input/pin-input.variables.ts",
+      "node": "./dist/server/components/pin-input/pin-input.variables.js",
+      "default": "./dist/components/pin-input/pin-input.variables.js"
     },
     "./pin-input/styles": {
       "default": "./dist/components/pin-input/pin-input.css"
@@ -1664,11 +1992,15 @@
     },
     "./popover/schema": {
       "types": "./dist/components/popover/popover.schema.d.ts",
-      "svelte": "./src/components/popover/popover.schema.ts"
+      "svelte": "./src/components/popover/popover.schema.ts",
+      "node": "./dist/server/components/popover/popover.schema.js",
+      "default": "./dist/components/popover/popover.schema.js"
     },
     "./popover/variables": {
       "types": "./dist/components/popover/popover.variables.d.ts",
-      "svelte": "./src/components/popover/popover.variables.ts"
+      "svelte": "./src/components/popover/popover.variables.ts",
+      "node": "./dist/server/components/popover/popover.variables.js",
+      "default": "./dist/components/popover/popover.variables.js"
     },
     "./popover/styles": {
       "default": "./dist/components/popover/popover.css"
@@ -1685,11 +2017,15 @@
     },
     "./portal/schema": {
       "types": "./dist/components/portal/portal.schema.d.ts",
-      "svelte": "./src/components/portal/portal.schema.ts"
+      "svelte": "./src/components/portal/portal.schema.ts",
+      "node": "./dist/server/components/portal/portal.schema.js",
+      "default": "./dist/components/portal/portal.schema.js"
     },
     "./portal/variables": {
       "types": "./dist/components/portal/portal.variables.d.ts",
-      "svelte": "./src/components/portal/portal.variables.ts"
+      "svelte": "./src/components/portal/portal.variables.ts",
+      "node": "./dist/server/components/portal/portal.variables.js",
+      "default": "./dist/components/portal/portal.variables.js"
     },
     "./portal/examples": {
       "import": "./src/components/portal/portal.examples.json",
@@ -1703,11 +2039,15 @@
     },
     "./progress/schema": {
       "types": "./dist/components/progress/progress.schema.d.ts",
-      "svelte": "./src/components/progress/progress.schema.ts"
+      "svelte": "./src/components/progress/progress.schema.ts",
+      "node": "./dist/server/components/progress/progress.schema.js",
+      "default": "./dist/components/progress/progress.schema.js"
     },
     "./progress/variables": {
       "types": "./dist/components/progress/progress.variables.d.ts",
-      "svelte": "./src/components/progress/progress.variables.ts"
+      "svelte": "./src/components/progress/progress.variables.ts",
+      "node": "./dist/server/components/progress/progress.variables.js",
+      "default": "./dist/components/progress/progress.variables.js"
     },
     "./progress/styles": {
       "default": "./dist/components/progress/progress.css"
@@ -1724,11 +2064,15 @@
     },
     "./radio/schema": {
       "types": "./dist/components/radio/radio.schema.d.ts",
-      "svelte": "./src/components/radio/radio.schema.ts"
+      "svelte": "./src/components/radio/radio.schema.ts",
+      "node": "./dist/server/components/radio/radio.schema.js",
+      "default": "./dist/components/radio/radio.schema.js"
     },
     "./radio/variables": {
       "types": "./dist/components/radio/radio.variables.d.ts",
-      "svelte": "./src/components/radio/radio.variables.ts"
+      "svelte": "./src/components/radio/radio.variables.ts",
+      "node": "./dist/server/components/radio/radio.variables.js",
+      "default": "./dist/components/radio/radio.variables.js"
     },
     "./radio/styles": {
       "default": "./dist/components/radio/radio.css"
@@ -1741,11 +2085,15 @@
     },
     "./radio-group/schema": {
       "types": "./dist/components/radio-group/radio-group.schema.d.ts",
-      "svelte": "./src/components/radio-group/radio-group.schema.ts"
+      "svelte": "./src/components/radio-group/radio-group.schema.ts",
+      "node": "./dist/server/components/radio-group/radio-group.schema.js",
+      "default": "./dist/components/radio-group/radio-group.schema.js"
     },
     "./radio-group/variables": {
       "types": "./dist/components/radio-group/radio-group.variables.d.ts",
-      "svelte": "./src/components/radio-group/radio-group.variables.ts"
+      "svelte": "./src/components/radio-group/radio-group.variables.ts",
+      "node": "./dist/server/components/radio-group/radio-group.variables.js",
+      "default": "./dist/components/radio-group/radio-group.variables.js"
     },
     "./radio-group/styles": {
       "default": "./dist/components/radio-group/radio-group.css"
@@ -1762,11 +2110,15 @@
     },
     "./rating/schema": {
       "types": "./dist/components/rating/rating.schema.d.ts",
-      "svelte": "./src/components/rating/rating.schema.ts"
+      "svelte": "./src/components/rating/rating.schema.ts",
+      "node": "./dist/server/components/rating/rating.schema.js",
+      "default": "./dist/components/rating/rating.schema.js"
     },
     "./rating/variables": {
       "types": "./dist/components/rating/rating.variables.d.ts",
-      "svelte": "./src/components/rating/rating.variables.ts"
+      "svelte": "./src/components/rating/rating.variables.ts",
+      "node": "./dist/server/components/rating/rating.variables.js",
+      "default": "./dist/components/rating/rating.variables.js"
     },
     "./rating/styles": {
       "default": "./dist/components/rating/rating.css"
@@ -1783,11 +2135,15 @@
     },
     "./resizable-panels/schema": {
       "types": "./dist/components/resizable-panels/resizable-panels.schema.d.ts",
-      "svelte": "./src/components/resizable-panels/resizable-panels.schema.ts"
+      "svelte": "./src/components/resizable-panels/resizable-panels.schema.ts",
+      "node": "./dist/server/components/resizable-panels/resizable-panels.schema.js",
+      "default": "./dist/components/resizable-panels/resizable-panels.schema.js"
     },
     "./resizable-panels/variables": {
       "types": "./dist/components/resizable-panels/resizable-panels.variables.d.ts",
-      "svelte": "./src/components/resizable-panels/resizable-panels.variables.ts"
+      "svelte": "./src/components/resizable-panels/resizable-panels.variables.ts",
+      "node": "./dist/server/components/resizable-panels/resizable-panels.variables.js",
+      "default": "./dist/components/resizable-panels/resizable-panels.variables.js"
     },
     "./resizable-panels/styles": {
       "default": "./dist/components/resizable-panels/resizable-panels.css"
@@ -1804,11 +2160,15 @@
     },
     "./review-editor/schema": {
       "types": "./dist/components/review-editor/review-editor.schema.d.ts",
-      "svelte": "./src/components/review-editor/review-editor.schema.ts"
+      "svelte": "./src/components/review-editor/review-editor.schema.ts",
+      "node": "./dist/server/components/review-editor/review-editor.schema.js",
+      "default": "./dist/components/review-editor/review-editor.schema.js"
     },
     "./review-editor/variables": {
       "types": "./dist/components/review-editor/review-editor.variables.d.ts",
-      "svelte": "./src/components/review-editor/review-editor.variables.ts"
+      "svelte": "./src/components/review-editor/review-editor.variables.ts",
+      "node": "./dist/server/components/review-editor/review-editor.variables.js",
+      "default": "./dist/components/review-editor/review-editor.variables.js"
     },
     "./review-editor/styles": {
       "default": "./dist/components/review-editor/review-editor.css"
@@ -1825,11 +2185,15 @@
     },
     "./scroll-area/schema": {
       "types": "./dist/components/scroll-area/scroll-area.schema.d.ts",
-      "svelte": "./src/components/scroll-area/scroll-area.schema.ts"
+      "svelte": "./src/components/scroll-area/scroll-area.schema.ts",
+      "node": "./dist/server/components/scroll-area/scroll-area.schema.js",
+      "default": "./dist/components/scroll-area/scroll-area.schema.js"
     },
     "./scroll-area/variables": {
       "types": "./dist/components/scroll-area/scroll-area.variables.d.ts",
-      "svelte": "./src/components/scroll-area/scroll-area.variables.ts"
+      "svelte": "./src/components/scroll-area/scroll-area.variables.ts",
+      "node": "./dist/server/components/scroll-area/scroll-area.variables.js",
+      "default": "./dist/components/scroll-area/scroll-area.variables.js"
     },
     "./scroll-area/styles": {
       "default": "./dist/components/scroll-area/scroll-area.css"
@@ -1846,11 +2210,15 @@
     },
     "./search-field/schema": {
       "types": "./dist/components/search-field/search-field.schema.d.ts",
-      "svelte": "./src/components/search-field/search-field.schema.ts"
+      "svelte": "./src/components/search-field/search-field.schema.ts",
+      "node": "./dist/server/components/search-field/search-field.schema.js",
+      "default": "./dist/components/search-field/search-field.schema.js"
     },
     "./search-field/variables": {
       "types": "./dist/components/search-field/search-field.variables.d.ts",
-      "svelte": "./src/components/search-field/search-field.variables.ts"
+      "svelte": "./src/components/search-field/search-field.variables.ts",
+      "node": "./dist/server/components/search-field/search-field.variables.js",
+      "default": "./dist/components/search-field/search-field.variables.js"
     },
     "./search-field/styles": {
       "default": "./dist/components/search-field/search-field.css"
@@ -1863,11 +2231,15 @@
     },
     "./section-heading/schema": {
       "types": "./dist/components/section-heading/section-heading.schema.d.ts",
-      "svelte": "./src/components/section-heading/section-heading.schema.ts"
+      "svelte": "./src/components/section-heading/section-heading.schema.ts",
+      "node": "./dist/server/components/section-heading/section-heading.schema.js",
+      "default": "./dist/components/section-heading/section-heading.schema.js"
     },
     "./section-heading/variables": {
       "types": "./dist/components/section-heading/section-heading.variables.d.ts",
-      "svelte": "./src/components/section-heading/section-heading.variables.ts"
+      "svelte": "./src/components/section-heading/section-heading.variables.ts",
+      "node": "./dist/server/components/section-heading/section-heading.variables.js",
+      "default": "./dist/components/section-heading/section-heading.variables.js"
     },
     "./section-heading/styles": {
       "default": "./dist/components/section-heading/section-heading.css"
@@ -1884,11 +2256,15 @@
     },
     "./segment/schema": {
       "types": "./dist/components/segment/segment.schema.d.ts",
-      "svelte": "./src/components/segment/segment.schema.ts"
+      "svelte": "./src/components/segment/segment.schema.ts",
+      "node": "./dist/server/components/segment/segment.schema.js",
+      "default": "./dist/components/segment/segment.schema.js"
     },
     "./segment/variables": {
       "types": "./dist/components/segment/segment.variables.d.ts",
-      "svelte": "./src/components/segment/segment.variables.ts"
+      "svelte": "./src/components/segment/segment.variables.ts",
+      "node": "./dist/server/components/segment/segment.variables.js",
+      "default": "./dist/components/segment/segment.variables.js"
     },
     "./segmented-control": {
       "types": "./dist/components/segmented-control/index.d.ts",
@@ -1898,11 +2274,15 @@
     },
     "./segmented-control/schema": {
       "types": "./dist/components/segmented-control/segmented-control.schema.d.ts",
-      "svelte": "./src/components/segmented-control/segmented-control.schema.ts"
+      "svelte": "./src/components/segmented-control/segmented-control.schema.ts",
+      "node": "./dist/server/components/segmented-control/segmented-control.schema.js",
+      "default": "./dist/components/segmented-control/segmented-control.schema.js"
     },
     "./segmented-control/variables": {
       "types": "./dist/components/segmented-control/segmented-control.variables.d.ts",
-      "svelte": "./src/components/segmented-control/segmented-control.variables.ts"
+      "svelte": "./src/components/segmented-control/segmented-control.variables.ts",
+      "node": "./dist/server/components/segmented-control/segmented-control.variables.js",
+      "default": "./dist/components/segmented-control/segmented-control.variables.js"
     },
     "./segmented-control/styles": {
       "default": "./dist/components/segmented-control/segmented-control.css"
@@ -1919,11 +2299,15 @@
     },
     "./select/schema": {
       "types": "./dist/components/select/select.schema.d.ts",
-      "svelte": "./src/components/select/select.schema.ts"
+      "svelte": "./src/components/select/select.schema.ts",
+      "node": "./dist/server/components/select/select.schema.js",
+      "default": "./dist/components/select/select.schema.js"
     },
     "./select/variables": {
       "types": "./dist/components/select/select.variables.d.ts",
-      "svelte": "./src/components/select/select.variables.ts"
+      "svelte": "./src/components/select/select.variables.ts",
+      "node": "./dist/server/components/select/select.variables.js",
+      "default": "./dist/components/select/select.variables.js"
     },
     "./select/styles": {
       "default": "./dist/components/select/select.css"
@@ -1940,11 +2324,15 @@
     },
     "./selection-popover/schema": {
       "types": "./dist/components/selection-popover/selection-popover.schema.d.ts",
-      "svelte": "./src/components/selection-popover/selection-popover.schema.ts"
+      "svelte": "./src/components/selection-popover/selection-popover.schema.ts",
+      "node": "./dist/server/components/selection-popover/selection-popover.schema.js",
+      "default": "./dist/components/selection-popover/selection-popover.schema.js"
     },
     "./selection-popover/variables": {
       "types": "./dist/components/selection-popover/selection-popover.variables.d.ts",
-      "svelte": "./src/components/selection-popover/selection-popover.variables.ts"
+      "svelte": "./src/components/selection-popover/selection-popover.variables.ts",
+      "node": "./dist/server/components/selection-popover/selection-popover.variables.js",
+      "default": "./dist/components/selection-popover/selection-popover.variables.js"
     },
     "./selection-popover/styles": {
       "default": "./dist/components/selection-popover/selection-popover.css"
@@ -1961,11 +2349,15 @@
     },
     "./sheet/schema": {
       "types": "./dist/components/sheet/sheet.schema.d.ts",
-      "svelte": "./src/components/sheet/sheet.schema.ts"
+      "svelte": "./src/components/sheet/sheet.schema.ts",
+      "node": "./dist/server/components/sheet/sheet.schema.js",
+      "default": "./dist/components/sheet/sheet.schema.js"
     },
     "./sheet/variables": {
       "types": "./dist/components/sheet/sheet.variables.d.ts",
-      "svelte": "./src/components/sheet/sheet.variables.ts"
+      "svelte": "./src/components/sheet/sheet.variables.ts",
+      "node": "./dist/server/components/sheet/sheet.variables.js",
+      "default": "./dist/components/sheet/sheet.variables.js"
     },
     "./sheet/styles": {
       "default": "./dist/components/sheet/sheet.css"
@@ -1982,11 +2374,15 @@
     },
     "./side-navigation/schema": {
       "types": "./dist/components/side-navigation/side-navigation.schema.d.ts",
-      "svelte": "./src/components/side-navigation/side-navigation.schema.ts"
+      "svelte": "./src/components/side-navigation/side-navigation.schema.ts",
+      "node": "./dist/server/components/side-navigation/side-navigation.schema.js",
+      "default": "./dist/components/side-navigation/side-navigation.schema.js"
     },
     "./side-navigation/variables": {
       "types": "./dist/components/side-navigation/side-navigation.variables.d.ts",
-      "svelte": "./src/components/side-navigation/side-navigation.variables.ts"
+      "svelte": "./src/components/side-navigation/side-navigation.variables.ts",
+      "node": "./dist/server/components/side-navigation/side-navigation.variables.js",
+      "default": "./dist/components/side-navigation/side-navigation.variables.js"
     },
     "./side-navigation/styles": {
       "default": "./dist/components/side-navigation/side-navigation.css"
@@ -2003,11 +2399,15 @@
     },
     "./side-navigation-group/schema": {
       "types": "./dist/components/side-navigation-group/side-navigation-group.schema.d.ts",
-      "svelte": "./src/components/side-navigation-group/side-navigation-group.schema.ts"
+      "svelte": "./src/components/side-navigation-group/side-navigation-group.schema.ts",
+      "node": "./dist/server/components/side-navigation-group/side-navigation-group.schema.js",
+      "default": "./dist/components/side-navigation-group/side-navigation-group.schema.js"
     },
     "./side-navigation-group/variables": {
       "types": "./dist/components/side-navigation-group/side-navigation-group.variables.d.ts",
-      "svelte": "./src/components/side-navigation-group/side-navigation-group.variables.ts"
+      "svelte": "./src/components/side-navigation-group/side-navigation-group.variables.ts",
+      "node": "./dist/server/components/side-navigation-group/side-navigation-group.variables.js",
+      "default": "./dist/components/side-navigation-group/side-navigation-group.variables.js"
     },
     "./side-navigation-group/styles": {
       "default": "./dist/components/side-navigation-group/side-navigation-group.css"
@@ -2020,11 +2420,15 @@
     },
     "./side-navigation-item/schema": {
       "types": "./dist/components/side-navigation-item/side-navigation-item.schema.d.ts",
-      "svelte": "./src/components/side-navigation-item/side-navigation-item.schema.ts"
+      "svelte": "./src/components/side-navigation-item/side-navigation-item.schema.ts",
+      "node": "./dist/server/components/side-navigation-item/side-navigation-item.schema.js",
+      "default": "./dist/components/side-navigation-item/side-navigation-item.schema.js"
     },
     "./side-navigation-item/variables": {
       "types": "./dist/components/side-navigation-item/side-navigation-item.variables.d.ts",
-      "svelte": "./src/components/side-navigation-item/side-navigation-item.variables.ts"
+      "svelte": "./src/components/side-navigation-item/side-navigation-item.variables.ts",
+      "node": "./dist/server/components/side-navigation-item/side-navigation-item.variables.js",
+      "default": "./dist/components/side-navigation-item/side-navigation-item.variables.js"
     },
     "./sidebar": {
       "types": "./dist/components/sidebar/index.d.ts",
@@ -2034,11 +2438,15 @@
     },
     "./sidebar/schema": {
       "types": "./dist/components/sidebar/sidebar.schema.d.ts",
-      "svelte": "./src/components/sidebar/sidebar.schema.ts"
+      "svelte": "./src/components/sidebar/sidebar.schema.ts",
+      "node": "./dist/server/components/sidebar/sidebar.schema.js",
+      "default": "./dist/components/sidebar/sidebar.schema.js"
     },
     "./sidebar/variables": {
       "types": "./dist/components/sidebar/sidebar.variables.d.ts",
-      "svelte": "./src/components/sidebar/sidebar.variables.ts"
+      "svelte": "./src/components/sidebar/sidebar.variables.ts",
+      "node": "./dist/server/components/sidebar/sidebar.variables.js",
+      "default": "./dist/components/sidebar/sidebar.variables.js"
     },
     "./sidebar/styles": {
       "default": "./dist/components/sidebar/sidebar.css"
@@ -2055,11 +2463,15 @@
     },
     "./skeleton/schema": {
       "types": "./dist/components/skeleton/skeleton.schema.d.ts",
-      "svelte": "./src/components/skeleton/skeleton.schema.ts"
+      "svelte": "./src/components/skeleton/skeleton.schema.ts",
+      "node": "./dist/server/components/skeleton/skeleton.schema.js",
+      "default": "./dist/components/skeleton/skeleton.schema.js"
     },
     "./skeleton/variables": {
       "types": "./dist/components/skeleton/skeleton.variables.d.ts",
-      "svelte": "./src/components/skeleton/skeleton.variables.ts"
+      "svelte": "./src/components/skeleton/skeleton.variables.ts",
+      "node": "./dist/server/components/skeleton/skeleton.variables.js",
+      "default": "./dist/components/skeleton/skeleton.variables.js"
     },
     "./skeleton/styles": {
       "default": "./dist/components/skeleton/skeleton.css"
@@ -2076,11 +2488,15 @@
     },
     "./slider/schema": {
       "types": "./dist/components/slider/slider.schema.d.ts",
-      "svelte": "./src/components/slider/slider.schema.ts"
+      "svelte": "./src/components/slider/slider.schema.ts",
+      "node": "./dist/server/components/slider/slider.schema.js",
+      "default": "./dist/components/slider/slider.schema.js"
     },
     "./slider/variables": {
       "types": "./dist/components/slider/slider.variables.d.ts",
-      "svelte": "./src/components/slider/slider.variables.ts"
+      "svelte": "./src/components/slider/slider.variables.ts",
+      "node": "./dist/server/components/slider/slider.variables.js",
+      "default": "./dist/components/slider/slider.variables.js"
     },
     "./slider/styles": {
       "default": "./dist/components/slider/slider.css"
@@ -2097,11 +2513,15 @@
     },
     "./sortable-list/schema": {
       "types": "./dist/components/sortable-list/sortable-list.schema.d.ts",
-      "svelte": "./src/components/sortable-list/sortable-list.schema.ts"
+      "svelte": "./src/components/sortable-list/sortable-list.schema.ts",
+      "node": "./dist/server/components/sortable-list/sortable-list.schema.js",
+      "default": "./dist/components/sortable-list/sortable-list.schema.js"
     },
     "./sortable-list/variables": {
       "types": "./dist/components/sortable-list/sortable-list.variables.d.ts",
-      "svelte": "./src/components/sortable-list/sortable-list.variables.ts"
+      "svelte": "./src/components/sortable-list/sortable-list.variables.ts",
+      "node": "./dist/server/components/sortable-list/sortable-list.variables.js",
+      "default": "./dist/components/sortable-list/sortable-list.variables.js"
     },
     "./sortable-list/styles": {
       "default": "./dist/components/sortable-list/sortable-list.css"
@@ -2114,11 +2534,15 @@
     },
     "./spacer/schema": {
       "types": "./dist/components/spacer/spacer.schema.d.ts",
-      "svelte": "./src/components/spacer/spacer.schema.ts"
+      "svelte": "./src/components/spacer/spacer.schema.ts",
+      "node": "./dist/server/components/spacer/spacer.schema.js",
+      "default": "./dist/components/spacer/spacer.schema.js"
     },
     "./spacer/variables": {
       "types": "./dist/components/spacer/spacer.variables.d.ts",
-      "svelte": "./src/components/spacer/spacer.variables.ts"
+      "svelte": "./src/components/spacer/spacer.variables.ts",
+      "node": "./dist/server/components/spacer/spacer.variables.js",
+      "default": "./dist/components/spacer/spacer.variables.js"
     },
     "./spacer/styles": {
       "default": "./dist/components/spacer/spacer.css"
@@ -2135,11 +2559,15 @@
     },
     "./spinner/schema": {
       "types": "./dist/components/spinner/spinner.schema.d.ts",
-      "svelte": "./src/components/spinner/spinner.schema.ts"
+      "svelte": "./src/components/spinner/spinner.schema.ts",
+      "node": "./dist/server/components/spinner/spinner.schema.js",
+      "default": "./dist/components/spinner/spinner.schema.js"
     },
     "./spinner/variables": {
       "types": "./dist/components/spinner/spinner.variables.d.ts",
-      "svelte": "./src/components/spinner/spinner.variables.ts"
+      "svelte": "./src/components/spinner/spinner.variables.ts",
+      "node": "./dist/server/components/spinner/spinner.variables.js",
+      "default": "./dist/components/spinner/spinner.variables.js"
     },
     "./spinner/styles": {
       "default": "./dist/components/spinner/spinner.css"
@@ -2156,11 +2584,15 @@
     },
     "./stack/schema": {
       "types": "./dist/components/stack/stack.schema.d.ts",
-      "svelte": "./src/components/stack/stack.schema.ts"
+      "svelte": "./src/components/stack/stack.schema.ts",
+      "node": "./dist/server/components/stack/stack.schema.js",
+      "default": "./dist/components/stack/stack.schema.js"
     },
     "./stack/variables": {
       "types": "./dist/components/stack/stack.variables.d.ts",
-      "svelte": "./src/components/stack/stack.variables.ts"
+      "svelte": "./src/components/stack/stack.variables.ts",
+      "node": "./dist/server/components/stack/stack.variables.js",
+      "default": "./dist/components/stack/stack.variables.js"
     },
     "./stack/styles": {
       "default": "./dist/components/stack/stack.css"
@@ -2177,11 +2609,15 @@
     },
     "./stacked-list-item/schema": {
       "types": "./dist/components/stacked-list-item/stacked-list-item.schema.d.ts",
-      "svelte": "./src/components/stacked-list-item/stacked-list-item.schema.ts"
+      "svelte": "./src/components/stacked-list-item/stacked-list-item.schema.ts",
+      "node": "./dist/server/components/stacked-list-item/stacked-list-item.schema.js",
+      "default": "./dist/components/stacked-list-item/stacked-list-item.schema.js"
     },
     "./stacked-list-item/variables": {
       "types": "./dist/components/stacked-list-item/stacked-list-item.variables.d.ts",
-      "svelte": "./src/components/stacked-list-item/stacked-list-item.variables.ts"
+      "svelte": "./src/components/stacked-list-item/stacked-list-item.variables.ts",
+      "node": "./dist/server/components/stacked-list-item/stacked-list-item.variables.js",
+      "default": "./dist/components/stacked-list-item/stacked-list-item.variables.js"
     },
     "./stacked-list-item/styles": {
       "default": "./dist/components/stacked-list-item/stacked-list-item.css"
@@ -2194,11 +2630,15 @@
     },
     "./stat/schema": {
       "types": "./dist/components/stat/stat.schema.d.ts",
-      "svelte": "./src/components/stat/stat.schema.ts"
+      "svelte": "./src/components/stat/stat.schema.ts",
+      "node": "./dist/server/components/stat/stat.schema.js",
+      "default": "./dist/components/stat/stat.schema.js"
     },
     "./stat/variables": {
       "types": "./dist/components/stat/stat.variables.d.ts",
-      "svelte": "./src/components/stat/stat.variables.ts"
+      "svelte": "./src/components/stat/stat.variables.ts",
+      "node": "./dist/server/components/stat/stat.variables.js",
+      "default": "./dist/components/stat/stat.variables.js"
     },
     "./stat/styles": {
       "default": "./dist/components/stat/stat.css"
@@ -2211,11 +2651,15 @@
     },
     "./stat-group/schema": {
       "types": "./dist/components/stat-group/stat-group.schema.d.ts",
-      "svelte": "./src/components/stat-group/stat-group.schema.ts"
+      "svelte": "./src/components/stat-group/stat-group.schema.ts",
+      "node": "./dist/server/components/stat-group/stat-group.schema.js",
+      "default": "./dist/components/stat-group/stat-group.schema.js"
     },
     "./stat-group/variables": {
       "types": "./dist/components/stat-group/stat-group.variables.d.ts",
-      "svelte": "./src/components/stat-group/stat-group.variables.ts"
+      "svelte": "./src/components/stat-group/stat-group.variables.ts",
+      "node": "./dist/server/components/stat-group/stat-group.variables.js",
+      "default": "./dist/components/stat-group/stat-group.variables.js"
     },
     "./stat-group/styles": {
       "default": "./dist/components/stat-group/stat-group.css"
@@ -2232,11 +2676,15 @@
     },
     "./status-dot/schema": {
       "types": "./dist/components/status-dot/status-dot.schema.d.ts",
-      "svelte": "./src/components/status-dot/status-dot.schema.ts"
+      "svelte": "./src/components/status-dot/status-dot.schema.ts",
+      "node": "./dist/server/components/status-dot/status-dot.schema.js",
+      "default": "./dist/components/status-dot/status-dot.schema.js"
     },
     "./status-dot/variables": {
       "types": "./dist/components/status-dot/status-dot.variables.d.ts",
-      "svelte": "./src/components/status-dot/status-dot.variables.ts"
+      "svelte": "./src/components/status-dot/status-dot.variables.ts",
+      "node": "./dist/server/components/status-dot/status-dot.variables.js",
+      "default": "./dist/components/status-dot/status-dot.variables.js"
     },
     "./status-dot/styles": {
       "default": "./dist/components/status-dot/status-dot.css"
@@ -2249,11 +2697,15 @@
     },
     "./steps/schema": {
       "types": "./dist/components/steps/steps.schema.d.ts",
-      "svelte": "./src/components/steps/steps.schema.ts"
+      "svelte": "./src/components/steps/steps.schema.ts",
+      "node": "./dist/server/components/steps/steps.schema.js",
+      "default": "./dist/components/steps/steps.schema.js"
     },
     "./steps/variables": {
       "types": "./dist/components/steps/steps.variables.d.ts",
-      "svelte": "./src/components/steps/steps.variables.ts"
+      "svelte": "./src/components/steps/steps.variables.ts",
+      "node": "./dist/server/components/steps/steps.variables.js",
+      "default": "./dist/components/steps/steps.variables.js"
     },
     "./steps/styles": {
       "default": "./dist/components/steps/steps.css"
@@ -2270,11 +2722,15 @@
     },
     "./surface/schema": {
       "types": "./dist/components/surface/surface.schema.d.ts",
-      "svelte": "./src/components/surface/surface.schema.ts"
+      "svelte": "./src/components/surface/surface.schema.ts",
+      "node": "./dist/server/components/surface/surface.schema.js",
+      "default": "./dist/components/surface/surface.schema.js"
     },
     "./surface/variables": {
       "types": "./dist/components/surface/surface.variables.d.ts",
-      "svelte": "./src/components/surface/surface.variables.ts"
+      "svelte": "./src/components/surface/surface.variables.ts",
+      "node": "./dist/server/components/surface/surface.variables.js",
+      "default": "./dist/components/surface/surface.variables.js"
     },
     "./surface/styles": {
       "default": "./dist/components/surface/surface.css"
@@ -2291,11 +2747,15 @@
     },
     "./tab/schema": {
       "types": "./dist/components/tab/tab.schema.d.ts",
-      "svelte": "./src/components/tab/tab.schema.ts"
+      "svelte": "./src/components/tab/tab.schema.ts",
+      "node": "./dist/server/components/tab/tab.schema.js",
+      "default": "./dist/components/tab/tab.schema.js"
     },
     "./tab/variables": {
       "types": "./dist/components/tab/tab.variables.d.ts",
-      "svelte": "./src/components/tab/tab.variables.ts"
+      "svelte": "./src/components/tab/tab.variables.ts",
+      "node": "./dist/server/components/tab/tab.variables.js",
+      "default": "./dist/components/tab/tab.variables.js"
     },
     "./tab/styles": {
       "default": "./dist/components/tab/tab.css"
@@ -2308,11 +2768,15 @@
     },
     "./tab-list/schema": {
       "types": "./dist/components/tab-list/tab-list.schema.d.ts",
-      "svelte": "./src/components/tab-list/tab-list.schema.ts"
+      "svelte": "./src/components/tab-list/tab-list.schema.ts",
+      "node": "./dist/server/components/tab-list/tab-list.schema.js",
+      "default": "./dist/components/tab-list/tab-list.schema.js"
     },
     "./tab-list/variables": {
       "types": "./dist/components/tab-list/tab-list.variables.d.ts",
-      "svelte": "./src/components/tab-list/tab-list.variables.ts"
+      "svelte": "./src/components/tab-list/tab-list.variables.ts",
+      "node": "./dist/server/components/tab-list/tab-list.variables.js",
+      "default": "./dist/components/tab-list/tab-list.variables.js"
     },
     "./tab-list/styles": {
       "default": "./dist/components/tab-list/tab-list.css"
@@ -2325,11 +2789,15 @@
     },
     "./tab-panel/schema": {
       "types": "./dist/components/tab-panel/tab-panel.schema.d.ts",
-      "svelte": "./src/components/tab-panel/tab-panel.schema.ts"
+      "svelte": "./src/components/tab-panel/tab-panel.schema.ts",
+      "node": "./dist/server/components/tab-panel/tab-panel.schema.js",
+      "default": "./dist/components/tab-panel/tab-panel.schema.js"
     },
     "./tab-panel/variables": {
       "types": "./dist/components/tab-panel/tab-panel.variables.d.ts",
-      "svelte": "./src/components/tab-panel/tab-panel.variables.ts"
+      "svelte": "./src/components/tab-panel/tab-panel.variables.ts",
+      "node": "./dist/server/components/tab-panel/tab-panel.variables.js",
+      "default": "./dist/components/tab-panel/tab-panel.variables.js"
     },
     "./tab-panel/styles": {
       "default": "./dist/components/tab-panel/tab-panel.css"
@@ -2342,11 +2810,15 @@
     },
     "./table/schema": {
       "types": "./dist/components/table/table.schema.d.ts",
-      "svelte": "./src/components/table/table.schema.ts"
+      "svelte": "./src/components/table/table.schema.ts",
+      "node": "./dist/server/components/table/table.schema.js",
+      "default": "./dist/components/table/table.schema.js"
     },
     "./table/variables": {
       "types": "./dist/components/table/table.variables.d.ts",
-      "svelte": "./src/components/table/table.variables.ts"
+      "svelte": "./src/components/table/table.variables.ts",
+      "node": "./dist/server/components/table/table.variables.js",
+      "default": "./dist/components/table/table.variables.js"
     },
     "./table/styles": {
       "default": "./dist/components/table/table.css"
@@ -2363,11 +2835,15 @@
     },
     "./table-body/schema": {
       "types": "./dist/components/table-body/table-body.schema.d.ts",
-      "svelte": "./src/components/table-body/table-body.schema.ts"
+      "svelte": "./src/components/table-body/table-body.schema.ts",
+      "node": "./dist/server/components/table-body/table-body.schema.js",
+      "default": "./dist/components/table-body/table-body.schema.js"
     },
     "./table-body/variables": {
       "types": "./dist/components/table-body/table-body.variables.d.ts",
-      "svelte": "./src/components/table-body/table-body.variables.ts"
+      "svelte": "./src/components/table-body/table-body.variables.ts",
+      "node": "./dist/server/components/table-body/table-body.variables.js",
+      "default": "./dist/components/table-body/table-body.variables.js"
     },
     "./table-body/styles": {
       "default": "./dist/components/table-body/table-body.css"
@@ -2380,11 +2856,15 @@
     },
     "./table-cell/schema": {
       "types": "./dist/components/table-cell/table-cell.schema.d.ts",
-      "svelte": "./src/components/table-cell/table-cell.schema.ts"
+      "svelte": "./src/components/table-cell/table-cell.schema.ts",
+      "node": "./dist/server/components/table-cell/table-cell.schema.js",
+      "default": "./dist/components/table-cell/table-cell.schema.js"
     },
     "./table-cell/variables": {
       "types": "./dist/components/table-cell/table-cell.variables.d.ts",
-      "svelte": "./src/components/table-cell/table-cell.variables.ts"
+      "svelte": "./src/components/table-cell/table-cell.variables.ts",
+      "node": "./dist/server/components/table-cell/table-cell.variables.js",
+      "default": "./dist/components/table-cell/table-cell.variables.js"
     },
     "./table-cell/styles": {
       "default": "./dist/components/table-cell/table-cell.css"
@@ -2397,11 +2877,15 @@
     },
     "./table-header/schema": {
       "types": "./dist/components/table-header/table-header.schema.d.ts",
-      "svelte": "./src/components/table-header/table-header.schema.ts"
+      "svelte": "./src/components/table-header/table-header.schema.ts",
+      "node": "./dist/server/components/table-header/table-header.schema.js",
+      "default": "./dist/components/table-header/table-header.schema.js"
     },
     "./table-header/variables": {
       "types": "./dist/components/table-header/table-header.variables.d.ts",
-      "svelte": "./src/components/table-header/table-header.variables.ts"
+      "svelte": "./src/components/table-header/table-header.variables.ts",
+      "node": "./dist/server/components/table-header/table-header.variables.js",
+      "default": "./dist/components/table-header/table-header.variables.js"
     },
     "./table-header/styles": {
       "default": "./dist/components/table-header/table-header.css"
@@ -2414,11 +2898,15 @@
     },
     "./table-header-cell/schema": {
       "types": "./dist/components/table-header-cell/table-header-cell.schema.d.ts",
-      "svelte": "./src/components/table-header-cell/table-header-cell.schema.ts"
+      "svelte": "./src/components/table-header-cell/table-header-cell.schema.ts",
+      "node": "./dist/server/components/table-header-cell/table-header-cell.schema.js",
+      "default": "./dist/components/table-header-cell/table-header-cell.schema.js"
     },
     "./table-header-cell/variables": {
       "types": "./dist/components/table-header-cell/table-header-cell.variables.d.ts",
-      "svelte": "./src/components/table-header-cell/table-header-cell.variables.ts"
+      "svelte": "./src/components/table-header-cell/table-header-cell.variables.ts",
+      "node": "./dist/server/components/table-header-cell/table-header-cell.variables.js",
+      "default": "./dist/components/table-header-cell/table-header-cell.variables.js"
     },
     "./table-header-cell/styles": {
       "default": "./dist/components/table-header-cell/table-header-cell.css"
@@ -2431,11 +2919,15 @@
     },
     "./table-row/schema": {
       "types": "./dist/components/table-row/table-row.schema.d.ts",
-      "svelte": "./src/components/table-row/table-row.schema.ts"
+      "svelte": "./src/components/table-row/table-row.schema.ts",
+      "node": "./dist/server/components/table-row/table-row.schema.js",
+      "default": "./dist/components/table-row/table-row.schema.js"
     },
     "./table-row/variables": {
       "types": "./dist/components/table-row/table-row.variables.d.ts",
-      "svelte": "./src/components/table-row/table-row.variables.ts"
+      "svelte": "./src/components/table-row/table-row.variables.ts",
+      "node": "./dist/server/components/table-row/table-row.variables.js",
+      "default": "./dist/components/table-row/table-row.variables.js"
     },
     "./table-row/styles": {
       "default": "./dist/components/table-row/table-row.css"
@@ -2448,11 +2940,15 @@
     },
     "./tabs/schema": {
       "types": "./dist/components/tabs/tabs.schema.d.ts",
-      "svelte": "./src/components/tabs/tabs.schema.ts"
+      "svelte": "./src/components/tabs/tabs.schema.ts",
+      "node": "./dist/server/components/tabs/tabs.schema.js",
+      "default": "./dist/components/tabs/tabs.schema.js"
     },
     "./tabs/variables": {
       "types": "./dist/components/tabs/tabs.variables.d.ts",
-      "svelte": "./src/components/tabs/tabs.variables.ts"
+      "svelte": "./src/components/tabs/tabs.variables.ts",
+      "node": "./dist/server/components/tabs/tabs.variables.js",
+      "default": "./dist/components/tabs/tabs.variables.js"
     },
     "./tabs/styles": {
       "default": "./dist/components/tabs/tabs.css"
@@ -2469,11 +2965,15 @@
     },
     "./tag-input/schema": {
       "types": "./dist/components/tag-input/tag-input.schema.d.ts",
-      "svelte": "./src/components/tag-input/tag-input.schema.ts"
+      "svelte": "./src/components/tag-input/tag-input.schema.ts",
+      "node": "./dist/server/components/tag-input/tag-input.schema.js",
+      "default": "./dist/components/tag-input/tag-input.schema.js"
     },
     "./tag-input/variables": {
       "types": "./dist/components/tag-input/tag-input.variables.d.ts",
-      "svelte": "./src/components/tag-input/tag-input.variables.ts"
+      "svelte": "./src/components/tag-input/tag-input.variables.ts",
+      "node": "./dist/server/components/tag-input/tag-input.variables.js",
+      "default": "./dist/components/tag-input/tag-input.variables.js"
     },
     "./tag-input/styles": {
       "default": "./dist/components/tag-input/tag-input.css"
@@ -2490,11 +2990,15 @@
     },
     "./textarea/schema": {
       "types": "./dist/components/textarea/textarea.schema.d.ts",
-      "svelte": "./src/components/textarea/textarea.schema.ts"
+      "svelte": "./src/components/textarea/textarea.schema.ts",
+      "node": "./dist/server/components/textarea/textarea.schema.js",
+      "default": "./dist/components/textarea/textarea.schema.js"
     },
     "./textarea/variables": {
       "types": "./dist/components/textarea/textarea.variables.d.ts",
-      "svelte": "./src/components/textarea/textarea.variables.ts"
+      "svelte": "./src/components/textarea/textarea.variables.ts",
+      "node": "./dist/server/components/textarea/textarea.variables.js",
+      "default": "./dist/components/textarea/textarea.variables.js"
     },
     "./textarea/styles": {
       "default": "./dist/components/textarea/textarea.css"
@@ -2511,11 +3015,15 @@
     },
     "./time-picker/schema": {
       "types": "./dist/components/time-picker/time-picker.schema.d.ts",
-      "svelte": "./src/components/time-picker/time-picker.schema.ts"
+      "svelte": "./src/components/time-picker/time-picker.schema.ts",
+      "node": "./dist/server/components/time-picker/time-picker.schema.js",
+      "default": "./dist/components/time-picker/time-picker.schema.js"
     },
     "./time-picker/variables": {
       "types": "./dist/components/time-picker/time-picker.variables.d.ts",
-      "svelte": "./src/components/time-picker/time-picker.variables.ts"
+      "svelte": "./src/components/time-picker/time-picker.variables.ts",
+      "node": "./dist/server/components/time-picker/time-picker.variables.js",
+      "default": "./dist/components/time-picker/time-picker.variables.js"
     },
     "./time-picker/styles": {
       "default": "./dist/components/time-picker/time-picker.css"
@@ -2532,11 +3040,15 @@
     },
     "./timeline/schema": {
       "types": "./dist/components/timeline/timeline.schema.d.ts",
-      "svelte": "./src/components/timeline/timeline.schema.ts"
+      "svelte": "./src/components/timeline/timeline.schema.ts",
+      "node": "./dist/server/components/timeline/timeline.schema.js",
+      "default": "./dist/components/timeline/timeline.schema.js"
     },
     "./timeline/variables": {
       "types": "./dist/components/timeline/timeline.variables.d.ts",
-      "svelte": "./src/components/timeline/timeline.variables.ts"
+      "svelte": "./src/components/timeline/timeline.variables.ts",
+      "node": "./dist/server/components/timeline/timeline.variables.js",
+      "default": "./dist/components/timeline/timeline.variables.js"
     },
     "./timeline/styles": {
       "default": "./dist/components/timeline/timeline.css"
@@ -2553,11 +3065,15 @@
     },
     "./timeline-item/schema": {
       "types": "./dist/components/timeline-item/timeline-item.schema.d.ts",
-      "svelte": "./src/components/timeline-item/timeline-item.schema.ts"
+      "svelte": "./src/components/timeline-item/timeline-item.schema.ts",
+      "node": "./dist/server/components/timeline-item/timeline-item.schema.js",
+      "default": "./dist/components/timeline-item/timeline-item.schema.js"
     },
     "./timeline-item/variables": {
       "types": "./dist/components/timeline-item/timeline-item.variables.d.ts",
-      "svelte": "./src/components/timeline-item/timeline-item.variables.ts"
+      "svelte": "./src/components/timeline-item/timeline-item.variables.ts",
+      "node": "./dist/server/components/timeline-item/timeline-item.variables.js",
+      "default": "./dist/components/timeline-item/timeline-item.variables.js"
     },
     "./timeline-item/styles": {
       "default": "./dist/components/timeline-item/timeline-item.css"
@@ -2570,11 +3086,15 @@
     },
     "./toast-region/schema": {
       "types": "./dist/components/toast-region/toast-region.schema.d.ts",
-      "svelte": "./src/components/toast-region/toast-region.schema.ts"
+      "svelte": "./src/components/toast-region/toast-region.schema.ts",
+      "node": "./dist/server/components/toast-region/toast-region.schema.js",
+      "default": "./dist/components/toast-region/toast-region.schema.js"
     },
     "./toast-region/variables": {
       "types": "./dist/components/toast-region/toast-region.variables.d.ts",
-      "svelte": "./src/components/toast-region/toast-region.variables.ts"
+      "svelte": "./src/components/toast-region/toast-region.variables.ts",
+      "node": "./dist/server/components/toast-region/toast-region.variables.js",
+      "default": "./dist/components/toast-region/toast-region.variables.js"
     },
     "./toast-region/styles": {
       "default": "./dist/components/toast-region/toast-region.css"
@@ -2591,11 +3111,15 @@
     },
     "./toggle/schema": {
       "types": "./dist/components/toggle/toggle.schema.d.ts",
-      "svelte": "./src/components/toggle/toggle.schema.ts"
+      "svelte": "./src/components/toggle/toggle.schema.ts",
+      "node": "./dist/server/components/toggle/toggle.schema.js",
+      "default": "./dist/components/toggle/toggle.schema.js"
     },
     "./toggle/variables": {
       "types": "./dist/components/toggle/toggle.variables.d.ts",
-      "svelte": "./src/components/toggle/toggle.variables.ts"
+      "svelte": "./src/components/toggle/toggle.variables.ts",
+      "node": "./dist/server/components/toggle/toggle.variables.js",
+      "default": "./dist/components/toggle/toggle.variables.js"
     },
     "./toggle/styles": {
       "default": "./dist/components/toggle/toggle.css"
@@ -2612,11 +3136,15 @@
     },
     "./toolbar/schema": {
       "types": "./dist/components/toolbar/toolbar.schema.d.ts",
-      "svelte": "./src/components/toolbar/toolbar.schema.ts"
+      "svelte": "./src/components/toolbar/toolbar.schema.ts",
+      "node": "./dist/server/components/toolbar/toolbar.schema.js",
+      "default": "./dist/components/toolbar/toolbar.schema.js"
     },
     "./toolbar/variables": {
       "types": "./dist/components/toolbar/toolbar.variables.d.ts",
-      "svelte": "./src/components/toolbar/toolbar.variables.ts"
+      "svelte": "./src/components/toolbar/toolbar.variables.ts",
+      "node": "./dist/server/components/toolbar/toolbar.variables.js",
+      "default": "./dist/components/toolbar/toolbar.variables.js"
     },
     "./toolbar/styles": {
       "default": "./dist/components/toolbar/toolbar.css"
@@ -2633,11 +3161,15 @@
     },
     "./tooltip/schema": {
       "types": "./dist/components/tooltip/tooltip.schema.d.ts",
-      "svelte": "./src/components/tooltip/tooltip.schema.ts"
+      "svelte": "./src/components/tooltip/tooltip.schema.ts",
+      "node": "./dist/server/components/tooltip/tooltip.schema.js",
+      "default": "./dist/components/tooltip/tooltip.schema.js"
     },
     "./tooltip/variables": {
       "types": "./dist/components/tooltip/tooltip.variables.d.ts",
-      "svelte": "./src/components/tooltip/tooltip.variables.ts"
+      "svelte": "./src/components/tooltip/tooltip.variables.ts",
+      "node": "./dist/server/components/tooltip/tooltip.variables.js",
+      "default": "./dist/components/tooltip/tooltip.variables.js"
     },
     "./tooltip/styles": {
       "default": "./dist/components/tooltip/tooltip.css"
@@ -2654,11 +3186,15 @@
     },
     "./transition/schema": {
       "types": "./dist/components/transition/transition.schema.d.ts",
-      "svelte": "./src/components/transition/transition.schema.ts"
+      "svelte": "./src/components/transition/transition.schema.ts",
+      "node": "./dist/server/components/transition/transition.schema.js",
+      "default": "./dist/components/transition/transition.schema.js"
     },
     "./transition/variables": {
       "types": "./dist/components/transition/transition.variables.d.ts",
-      "svelte": "./src/components/transition/transition.variables.ts"
+      "svelte": "./src/components/transition/transition.variables.ts",
+      "node": "./dist/server/components/transition/transition.variables.js",
+      "default": "./dist/components/transition/transition.variables.js"
     },
     "./transition/examples": {
       "import": "./src/components/transition/transition.examples.json",
@@ -2672,11 +3208,15 @@
     },
     "./tree/schema": {
       "types": "./dist/components/tree/tree.schema.d.ts",
-      "svelte": "./src/components/tree/tree.schema.ts"
+      "svelte": "./src/components/tree/tree.schema.ts",
+      "node": "./dist/server/components/tree/tree.schema.js",
+      "default": "./dist/components/tree/tree.schema.js"
     },
     "./tree/variables": {
       "types": "./dist/components/tree/tree.variables.d.ts",
-      "svelte": "./src/components/tree/tree.variables.ts"
+      "svelte": "./src/components/tree/tree.variables.ts",
+      "node": "./dist/server/components/tree/tree.variables.js",
+      "default": "./dist/components/tree/tree.variables.js"
     },
     "./tree/styles": {
       "default": "./dist/components/tree/tree.css"
@@ -2693,11 +3233,15 @@
     },
     "./tree-item/schema": {
       "types": "./dist/components/tree-item/tree-item.schema.d.ts",
-      "svelte": "./src/components/tree-item/tree-item.schema.ts"
+      "svelte": "./src/components/tree-item/tree-item.schema.ts",
+      "node": "./dist/server/components/tree-item/tree-item.schema.js",
+      "default": "./dist/components/tree-item/tree-item.schema.js"
     },
     "./tree-item/variables": {
       "types": "./dist/components/tree-item/tree-item.variables.d.ts",
-      "svelte": "./src/components/tree-item/tree-item.variables.ts"
+      "svelte": "./src/components/tree-item/tree-item.variables.ts",
+      "node": "./dist/server/components/tree-item/tree-item.variables.js",
+      "default": "./dist/components/tree-item/tree-item.variables.js"
     },
     "./tree-select-all": {
       "types": "./dist/components/tree-select-all/index.d.ts",
@@ -2707,11 +3251,15 @@
     },
     "./tree-select-all/schema": {
       "types": "./dist/components/tree-select-all/tree-select-all.schema.d.ts",
-      "svelte": "./src/components/tree-select-all/tree-select-all.schema.ts"
+      "svelte": "./src/components/tree-select-all/tree-select-all.schema.ts",
+      "node": "./dist/server/components/tree-select-all/tree-select-all.schema.js",
+      "default": "./dist/components/tree-select-all/tree-select-all.schema.js"
     },
     "./tree-select-all/variables": {
       "types": "./dist/components/tree-select-all/tree-select-all.variables.d.ts",
-      "svelte": "./src/components/tree-select-all/tree-select-all.variables.ts"
+      "svelte": "./src/components/tree-select-all/tree-select-all.variables.ts",
+      "node": "./dist/server/components/tree-select-all/tree-select-all.variables.js",
+      "default": "./dist/components/tree-select-all/tree-select-all.variables.js"
     },
     "./tree-select-all/styles": {
       "default": "./dist/components/tree-select-all/tree-select-all.css"
@@ -2724,11 +3272,15 @@
     },
     "./visually-hidden/schema": {
       "types": "./dist/components/visually-hidden/visually-hidden.schema.d.ts",
-      "svelte": "./src/components/visually-hidden/visually-hidden.schema.ts"
+      "svelte": "./src/components/visually-hidden/visually-hidden.schema.ts",
+      "node": "./dist/server/components/visually-hidden/visually-hidden.schema.js",
+      "default": "./dist/components/visually-hidden/visually-hidden.schema.js"
     },
     "./visually-hidden/variables": {
       "types": "./dist/components/visually-hidden/visually-hidden.variables.d.ts",
-      "svelte": "./src/components/visually-hidden/visually-hidden.variables.ts"
+      "svelte": "./src/components/visually-hidden/visually-hidden.variables.ts",
+      "node": "./dist/server/components/visually-hidden/visually-hidden.variables.js",
+      "default": "./dist/components/visually-hidden/visually-hidden.variables.js"
     },
     "./visually-hidden/examples": {
       "import": "./src/components/visually-hidden/visually-hidden.examples.json",
@@ -2922,11 +3474,15 @@
     },
     "./experimental/connection-indicator/schema": {
       "types": "./dist/components/connection-indicator/connection-indicator.schema.d.ts",
-      "svelte": "./src/components/connection-indicator/connection-indicator.schema.ts"
+      "svelte": "./src/components/connection-indicator/connection-indicator.schema.ts",
+      "node": "./dist/server/components/connection-indicator/connection-indicator.schema.js",
+      "default": "./dist/components/connection-indicator/connection-indicator.schema.js"
     },
     "./experimental/connection-indicator/variables": {
       "types": "./dist/components/connection-indicator/connection-indicator.variables.d.ts",
-      "svelte": "./src/components/connection-indicator/connection-indicator.variables.ts"
+      "svelte": "./src/components/connection-indicator/connection-indicator.variables.ts",
+      "node": "./dist/server/components/connection-indicator/connection-indicator.variables.js",
+      "default": "./dist/components/connection-indicator/connection-indicator.variables.js"
     },
     "./experimental/connection-indicator/styles": {
       "default": "./dist/components/connection-indicator/connection-indicator.css"
@@ -2939,11 +3495,15 @@
     },
     "./experimental/json-viewer/schema": {
       "types": "./dist/components/json-viewer/json-viewer.schema.d.ts",
-      "svelte": "./src/components/json-viewer/json-viewer.schema.ts"
+      "svelte": "./src/components/json-viewer/json-viewer.schema.ts",
+      "node": "./dist/server/components/json-viewer/json-viewer.schema.js",
+      "default": "./dist/components/json-viewer/json-viewer.schema.js"
     },
     "./experimental/json-viewer/variables": {
       "types": "./dist/components/json-viewer/json-viewer.variables.d.ts",
-      "svelte": "./src/components/json-viewer/json-viewer.variables.ts"
+      "svelte": "./src/components/json-viewer/json-viewer.variables.ts",
+      "node": "./dist/server/components/json-viewer/json-viewer.variables.js",
+      "default": "./dist/components/json-viewer/json-viewer.variables.js"
     },
     "./experimental/json-viewer/styles": {
       "default": "./dist/components/json-viewer/json-viewer.css"
@@ -2956,11 +3516,15 @@
     },
     "./experimental/message/schema": {
       "types": "./dist/components/message/message.schema.d.ts",
-      "svelte": "./src/components/message/message.schema.ts"
+      "svelte": "./src/components/message/message.schema.ts",
+      "node": "./dist/server/components/message/message.schema.js",
+      "default": "./dist/components/message/message.schema.js"
     },
     "./experimental/message/variables": {
       "types": "./dist/components/message/message.variables.d.ts",
-      "svelte": "./src/components/message/message.variables.ts"
+      "svelte": "./src/components/message/message.variables.ts",
+      "node": "./dist/server/components/message/message.variables.js",
+      "default": "./dist/components/message/message.variables.js"
     },
     "./experimental/message/styles": {
       "default": "./dist/components/message/message.css"
@@ -2973,11 +3537,15 @@
     },
     "./experimental/timeline/schema": {
       "types": "./dist/components/timeline/timeline.schema.d.ts",
-      "svelte": "./src/components/timeline/timeline.schema.ts"
+      "svelte": "./src/components/timeline/timeline.schema.ts",
+      "node": "./dist/server/components/timeline/timeline.schema.js",
+      "default": "./dist/components/timeline/timeline.schema.js"
     },
     "./experimental/timeline/variables": {
       "types": "./dist/components/timeline/timeline.variables.d.ts",
-      "svelte": "./src/components/timeline/timeline.variables.ts"
+      "svelte": "./src/components/timeline/timeline.variables.ts",
+      "node": "./dist/server/components/timeline/timeline.variables.js",
+      "default": "./dist/components/timeline/timeline.variables.js"
     },
     "./experimental/timeline/styles": {
       "default": "./dist/components/timeline/timeline.css"
@@ -2994,11 +3562,15 @@
     },
     "./experimental/timeline-item/schema": {
       "types": "./dist/components/timeline-item/timeline-item.schema.d.ts",
-      "svelte": "./src/components/timeline-item/timeline-item.schema.ts"
+      "svelte": "./src/components/timeline-item/timeline-item.schema.ts",
+      "node": "./dist/server/components/timeline-item/timeline-item.schema.js",
+      "default": "./dist/components/timeline-item/timeline-item.schema.js"
     },
     "./experimental/timeline-item/variables": {
       "types": "./dist/components/timeline-item/timeline-item.variables.d.ts",
-      "svelte": "./src/components/timeline-item/timeline-item.variables.ts"
+      "svelte": "./src/components/timeline-item/timeline-item.variables.ts",
+      "node": "./dist/server/components/timeline-item/timeline-item.variables.js",
+      "default": "./dist/components/timeline-item/timeline-item.variables.js"
     },
     "./experimental/timeline-item/styles": {
       "default": "./dist/components/timeline-item/timeline-item.css"
@@ -3029,7 +3601,9 @@
     "src/highlighters/**/*.ts",
     "!src/highlighters/**/*.test.ts",
     "!src/highlighters/**/*.spec.ts",
-    "README.md"
+    "README.md",
+    "components.json",
+    "examples-exclusions.json"
   ],
   "scripts": {
     "build": "bun run scripts/build.ts",

--- a/packages/components/scripts/build.ts
+++ b/packages/components/scripts/build.ts
@@ -40,6 +40,24 @@ function componentEntrypoint(component: ComponentDiscovery): string {
 }
 
 /**
+ * Build the absolute path to a component's `<name>.schema.ts` /
+ * `<name>.variables.ts` metadata source. These compile to standalone JS
+ * entrypoints (`<name>.schema.js` / `<name>.variables.js`) so the
+ * `cinder/<name>/schema` and `cinder/<name>/variables` subpaths are runtime
+ * entry points (their `node`/`default` export conditions resolve to real files).
+ * Every discovered component ships both, so callers list these unconditionally.
+ */
+function componentMetadataEntrypoints(component: ComponentDiscovery): string[] {
+  const directory = component.isExperimental
+    ? `${sourceRoot}/components/experimental/${component.name}`
+    : `${sourceRoot}/components/${component.name}`;
+  return [
+    `${directory}/${component.name}.schema.ts`,
+    `${directory}/${component.name}.variables.ts`,
+  ];
+}
+
+/**
  * Per-component CSS sidecar location under `src/`. Not every component has a
  * sidecar — domain-suite components (`chat`, `markdown-editor`, etc.) inject
  * styles directly, and several smaller composition components have no styles
@@ -199,6 +217,14 @@ if (!serverBuildResult.success) {
 
 const perComponentEntrypoints = components.map((component) => componentEntrypoint(component));
 
+// Per-component schema/variables metadata sources compile to their own JS so
+// `cinder/<name>/schema` and `cinder/<name>/variables` are runtime entry points.
+// Listed for both the browser and server builds so the `default` and `node`
+// export conditions each resolve to a real file.
+const perComponentMetadataEntrypoints = components.flatMap((component) =>
+  componentMetadataEntrypoints(component),
+);
+
 /**
  * Static sub-paths cinder exposes outside the `components/` tree. Today this
  * is the first-party Shiki adapter at `cinder/highlighters/shiki` and the
@@ -229,6 +255,7 @@ const deprecatedAliasEntrypoints = DEPRECATED_EXPERIMENTAL_ALIASES.map(
 const browserEntrypoints = [
   `${sourceRoot}/index.ts`,
   ...perComponentEntrypoints,
+  ...perComponentMetadataEntrypoints,
   ...staticSubpathEntrypoints,
   ...deprecatedAliasEntrypoints,
 ];
@@ -286,6 +313,7 @@ if (!browserBuildResult.success) {
 const perComponentServerBuildResult = await Bun.build({
   entrypoints: [
     ...perComponentEntrypoints,
+    ...perComponentMetadataEntrypoints,
     ...staticSubpathEntrypoints,
     ...deprecatedAliasEntrypoints,
   ],
@@ -621,6 +649,16 @@ for (const component of components) {
       ? `${distributionDirectory}/server/components/experimental/${component.name}/index.js`
       : `${distributionDirectory}/server/components/${component.name}/index.js`,
   );
+  // Schema/variables metadata JS — both builds. These back the `node`/`default`
+  // export conditions for `cinder/<name>/schema` and `cinder/<name>/variables`.
+  const serverDirectory = component.isExperimental
+    ? `${distributionDirectory}/server/components/experimental/${component.name}`
+    : `${distributionDirectory}/server/components/${component.name}`;
+  for (const metadataKind of ['schema', 'variables'] as const) {
+    expectedPaths.push(`${directory}/${component.name}.${metadataKind}.js`);
+    expectedPaths.push(`${directory}/${component.name}.${metadataKind}.d.ts`);
+    expectedPaths.push(`${serverDirectory}/${component.name}.${metadataKind}.js`);
+  }
   if (existsSync(componentCssSource(component))) {
     expectedPaths.push(componentCssDestination(component));
   }

--- a/packages/components/scripts/generate-exports.test.ts
+++ b/packages/components/scripts/generate-exports.test.ts
@@ -17,9 +17,13 @@ import { describe, expect, it } from 'bun:test';
 import {
   assertNoForbiddenExportKeys,
   computeExports,
+  computeFiles,
   computeRootExport,
+  EXPLICIT_ROOT_FILE_ENTRIES,
   FORBIDDEN_EXPORT_KEY_PATTERN,
   orderedExportEntry,
+  rootLevelExportTargets,
+  STATIC_FILES_GLOBS,
   stylesGuardExport,
 } from './generate-exports.ts';
 
@@ -68,45 +72,44 @@ describe('computeExports', () => {
     expect(Object.keys(out['./button']!)).toEqual(['types', 'svelte', 'node', 'default']);
   });
 
-  it('emits source+types only for /schema and /variables (no JS is built)', () => {
+  it('emits the four-condition runtime shape for /schema and /variables', () => {
     const out = computeExports([{ name: 'button', isExperimental: false, hasCss: false }]);
     expect(out['./button/schema']).toEqual({
       types: './dist/components/button/button.schema.d.ts',
       svelte: './src/components/button/button.schema.ts',
+      node: './dist/server/components/button/button.schema.js',
+      default: './dist/components/button/button.schema.js',
     });
     expect(out['./button/variables']).toEqual({
       types: './dist/components/button/button.variables.d.ts',
       svelte: './src/components/button/button.variables.ts',
+      node: './dist/server/components/button/button.variables.js',
+      default: './dist/components/button/button.variables.js',
     });
   });
 
-  // Tripwire (the inverse of the test above). The schema/variables subpaths are
-  // metadata, not runtime entry points: the build emits no `.schema.js` /
-  // `.variables.js`, so there is no target a runtime condition could point at.
-  // Adding `node`/`default`/`import` here would advertise a runtime export that
-  // resolves to a non-existent file — the exact regression task 4176c51c was
-  // filed against. The manifest-consumer fixture positively asserts these throw
-  // ERR_PACKAGE_PATH_NOT_EXPORTED at Node runtime; this unit test pins the same
-  // contract at the generator so a stray `default` is caught before it ships.
-  it('never emits a runtime condition on /schema or /variables', () => {
+  // Task 4176c51c: schema/variables are runtime entry points. The build compiles
+  // each `<name>.schema.ts` / `<name>.variables.ts` to its own JS, so a plain
+  // Node/Vite consumer resolving `cinder/<name>/schema` under the `default`
+  // condition gets a real module — no ERR_PACKAGE_PATH_NOT_EXPORTED. This test
+  // pins the `default` (and `node`) condition at the generator so a regression
+  // that drops the runtime condition is caught before it ships. The
+  // manifest-consumer fixture asserts the same at Node runtime.
+  it('emits a default (and node) runtime condition on every /schema and /variables export', () => {
     const out = computeExports([
       { name: 'button', isExperimental: false, hasCss: false },
       { name: 'lab', isExperimental: true, hasCss: false },
     ]);
-    const runtimeConditions = ['node', 'default', 'import'] as const;
-    for (const key of [
-      './button/schema',
-      './button/variables',
-      './experimental/lab/schema',
-      './experimental/lab/variables',
-    ]) {
+    const metadataKeys = Object.keys(out).filter(
+      (key) => key.endsWith('/schema') || key.endsWith('/variables'),
+    );
+    expect(metadataKeys.length).toBeGreaterThan(0);
+    for (const key of metadataKeys) {
       const entry = out[key]!;
-      expect(entry).toBeDefined();
-      for (const condition of runtimeConditions) {
-        expect(entry).not.toHaveProperty(condition);
-      }
-      // Only the type-narrowing conditions are present.
-      expect(Object.keys(entry)).toEqual(['types', 'svelte']);
+      expect(entry).toHaveProperty('default');
+      expect(entry).toHaveProperty('node');
+      // Full four-condition shape in the canonical order.
+      expect(Object.keys(entry)).toEqual(['types', 'svelte', 'node', 'default']);
     }
   });
 
@@ -214,5 +217,90 @@ describe('assertNoForbiddenExportKeys', () => {
     expect(FORBIDDEN_EXPORT_KEY_PATTERN.test('./template')).toBe(false);
     expect(FORBIDDEN_EXPORT_KEY_PATTERN.test('./temporal')).toBe(false);
     expect(FORBIDDEN_EXPORT_KEY_PATTERN.test('./testament')).toBe(false);
+  });
+});
+
+describe('rootLevelExportTargets', () => {
+  it('collects root-level artifact targets and excludes package.json', () => {
+    const targets = rootLevelExportTargets({
+      '.': { default: './dist/index.js' },
+      './manifest': { import: './components.json', default: './components.json' },
+      './package.json': './package.json',
+      './button/styles': { default: './dist/components/button/button.css' },
+      './styles': { default: './src/styles/index.css' },
+    });
+    expect(targets.toSorted()).toEqual(['components.json']);
+  });
+
+  it('ignores non-root and non-relative targets', () => {
+    const targets = rootLevelExportTargets({
+      './button': {
+        types: './dist/components/button/index.d.ts',
+        default: './dist/components/button/index.js',
+      },
+    });
+    // Every target has a directory segment, so nothing is root-level.
+    expect(targets).toEqual([]);
+  });
+});
+
+describe('computeFiles', () => {
+  const exportsWithManifest = {
+    './manifest': { import: './components.json', default: './components.json' },
+    './package.json': './package.json',
+  };
+
+  it('keeps the static globs verbatim and in order at the front', () => {
+    const files = computeFiles(exportsWithManifest);
+    expect(files.slice(0, STATIC_FILES_GLOBS.length)).toEqual([...STATIC_FILES_GLOBS]);
+  });
+
+  it('appends both explicit root JSON entries', () => {
+    const files = computeFiles(exportsWithManifest);
+    expect(files).toContain('components.json');
+    expect(files).toContain('examples-exclusions.json');
+  });
+
+  it('appends computed root entries alphabetically after the static globs', () => {
+    const files = computeFiles(exportsWithManifest);
+    const appended = files.slice(STATIC_FILES_GLOBS.length);
+    // explicit entries: components.json, examples-exclusions.json — already sorted.
+    expect(appended).toEqual(['components.json', 'examples-exclusions.json']);
+  });
+
+  it('dedupes a root export target that also appears in the explicit entries', () => {
+    // `components.json` is both an explicit entry AND a root-level export target.
+    const files = computeFiles(exportsWithManifest);
+    const occurrences = files.filter((entry) => entry === 'components.json');
+    expect(occurrences).toHaveLength(1);
+  });
+
+  it('does not flatten into explicit per-component paths', () => {
+    const files = computeFiles(exportsWithManifest);
+    // No entry should reference a concrete component directory path.
+    expect(files.some((entry) => entry.startsWith('dist/components/'))).toBe(false);
+    expect(files.some((entry) => entry.startsWith('src/components/accordion'))).toBe(false);
+  });
+
+  it('includes a new root-level artifact the exports reference but the globs do not cover', () => {
+    const files = computeFiles(
+      {
+        ...exportsWithManifest,
+        './extra': { import: './extra-artifact.json', default: './extra-artifact.json' },
+      },
+      STATIC_FILES_GLOBS,
+      EXPLICIT_ROOT_FILE_ENTRIES,
+    );
+    const appended = files.slice(STATIC_FILES_GLOBS.length);
+    expect(appended).toEqual([
+      'components.json',
+      'examples-exclusions.json',
+      'extra-artifact.json',
+    ]);
+  });
+
+  it('does not duplicate a root artifact already covered by a static glob', () => {
+    const files = computeFiles({ './foo': { default: './foo.json' } }, ['dist', 'foo.json'], []);
+    expect(files.filter((entry) => entry === 'foo.json')).toHaveLength(1);
   });
 });

--- a/packages/components/scripts/generate-exports.ts
+++ b/packages/components/scripts/generate-exports.ts
@@ -572,7 +572,9 @@ export function computeFiles(
       computedRoots.add(target);
     }
   }
-  const appended = [...computedRoots].toSorted((a, b) => a.localeCompare(b));
+  // Bytewise (not localeCompare) so the generated order is identical on every
+  // machine regardless of locale/ICU — the generator's output must be stable.
+  const appended = [...computedRoots].toSorted((a, b) => (a < b ? -1 : a > b ? 1 : 0));
   return [...staticGlobs, ...appended];
 }
 

--- a/packages/components/scripts/generate-exports.ts
+++ b/packages/components/scripts/generate-exports.ts
@@ -3,8 +3,8 @@
  * `src/components/`. Each component contributes up to six subpaths:
  *
  *   ./<name>             → component (types/svelte/node/default conditions)
- *   ./<name>/schema      → schema module (types + svelte only)
- *   ./<name>/variables   → variables module (types + svelte only)
+ *   ./<name>/schema      → schema module (types/svelte/node/default conditions)
+ *   ./<name>/variables   → variables module (types/svelte/node/default conditions)
  *   ./<name>/styles      → layer-wrapped CSS sidecar (default condition; emitted when the component ships a source <name>.css). Compound parents (tabs/table/accordion/side-navigation) @import their leaves' sidecars so the family arrives together.
  *   ./<name>/examples    → examples JSON (import/default only; emitted when file exists)
  *   ./<name>/constraints → constraints JSON (import/default only; emitted when file exists)
@@ -278,6 +278,7 @@ export function computeDeprecatedExperimentalAliases(
     // component, so they resolve at the promoted (non-experimental) location.
     const newSrcDir = `./src/components/${name}`;
     const newDistDir = `./dist/components/${name}`;
+    const newServerDistDir = `./dist/server/components/${name}`;
 
     out[aliasPrefix] = orderedExportEntry({
       types: `${shimDistDir}/index.d.ts`,
@@ -286,13 +287,21 @@ export function computeDeprecatedExperimentalAliases(
       default: `${shimDistDir}/index.js`,
     });
 
+    // Schema/variables are runtime entry points (see computeExports). The
+    // promoted component's `<name>.schema.ts` / `.variables.ts` are compiled by
+    // the build at the non-experimental location, so the alias's `node`/`default`
+    // conditions resolve there too.
     out[`${aliasPrefix}/schema`] = orderedExportEntry({
       types: `${newDistDir}/${name}.schema.d.ts`,
       svelte: `${newSrcDir}/${name}.schema.ts`,
+      node: `${newServerDistDir}/${name}.schema.js`,
+      default: `${newDistDir}/${name}.schema.js`,
     });
     out[`${aliasPrefix}/variables`] = orderedExportEntry({
       types: `${newDistDir}/${name}.variables.d.ts`,
       svelte: `${newSrcDir}/${name}.variables.ts`,
+      node: `${newServerDistDir}/${name}.variables.js`,
+      default: `${newDistDir}/${name}.variables.js`,
     });
 
     if (hasCss) {
@@ -358,31 +367,35 @@ export function computeExports(
       default: `${distDir}/index.js`,
     });
 
-    // Schema and variables modules ship as source + types only. They are
-    // metadata, not runtime entry points; no JS is emitted for them (the build
-    // produces only `.schema.d.ts` / `.variables.d.ts`, never `.schema.js`), so
-    // there is no target a `node`/`default`/`import` condition could point at.
+    // Schema and variables modules are full four-condition runtime entry
+    // points, exactly like the component barrel. Each ships:
+    //   • `types`   → `<name>.schema.d.ts` / `<name>.variables.d.ts`
+    //   • `svelte`  → the `.ts` source (so in-repo Svelte tooling resolves source)
+    //   • `node`    → the per-component SSR build `<name>.schema.js`
+    //   • `default` → the per-component browser build `<name>.schema.js`
     //
-    // This is a deliberate contract, NOT a missing-`default` bug: adding a
-    // runtime condition here would advertise an export that resolves to a
-    // non-existent file. A Node/Vite consumer that resolves the default
-    // condition therefore gets `ERR_PACKAGE_PATH_NOT_EXPORTED` — by design.
-    //   • The unit test "never emits a runtime condition on /schema or
-    //     /variables" (generate-exports.test.ts) pins this at the generator.
-    //   • The manifest-consumer fixture (fixtures/manifest-consumer/check.mjs)
-    //     positively asserts the throw against the packed tarball at runtime.
-    //   • AGENTS.md § Discovery recipe documents the type-only contract and the
-    //     runtime escape hatch (read the `<name>.schema.json` sidecar) for the
-    //     rare consumer that genuinely needs the JSON value at runtime.
-    // If schema/variables ever become runtime entry points, all three must move
-    // together.
+    // The build (scripts/build.ts) compiles each `<name>.schema.ts` /
+    // `<name>.variables.ts` as its own browser + server entrypoint, so the
+    // `node`/`default` targets resolve to real files. A plain Node or Vite
+    // consumer can therefore `import schema from 'cinder/<name>/schema'` and get
+    // the default-exported JSON Schema value at runtime — no
+    // `ERR_PACKAGE_PATH_NOT_EXPORTED`.
+    //
+    // The unit test "emits a runtime condition on /schema and /variables"
+    // (generate-exports.test.ts) and the manifest-consumer fixture
+    // (fixtures/manifest-consumer/check.mjs) both pin this runtime-resolvable
+    // contract.
     out[`${prefix}/schema`] = orderedExportEntry({
       types: `${distDir}/${name}.schema.d.ts`,
       svelte: `${srcDir}/${name}.schema.ts`,
+      node: `${serverDistDir}/${name}.schema.js`,
+      default: `${distDir}/${name}.schema.js`,
     });
     out[`${prefix}/variables`] = orderedExportEntry({
       types: `${distDir}/${name}.variables.d.ts`,
       svelte: `${srcDir}/${name}.variables.ts`,
+      node: `${serverDistDir}/${name}.variables.js`,
+      default: `${distDir}/${name}.variables.js`,
     });
 
     // Per-component CSS sidecar — layer-WRAPPED (the sidecar self-declares
@@ -452,7 +465,115 @@ export function assertNoForbiddenExportKeys(
 
 interface PackageJson {
   exports: Record<string, ExportEntry | JsonExportEntry | string>;
+  files: string[];
   [key: string]: unknown;
+}
+
+/**
+ * The static `files` globs the package always ships, listed verbatim and in
+ * order. The generator preserves these exactly (it does NOT flatten them into
+ * hundreds of explicit per-component paths) and appends any computed root-level
+ * artifact entries after them. Keep this in sync with the publishable source
+ * surface — it is the single source of truth for the static portion of
+ * `package.json#files`.
+ */
+export const STATIC_FILES_GLOBS: readonly string[] = [
+  'dist',
+  'src/index.ts',
+  'src/schema-types.ts',
+  'src/components/**/*.ts',
+  '!src/components/**/*.test.ts',
+  '!src/components/**/*.spec.ts',
+  'src/components/**/*.svelte',
+  'src/components/**/*.json',
+  'src/components/**/*.md',
+  '!src/components/**/*.a11y.md',
+  'src/components/**/*.css',
+  'src/_internal/**/*.ts',
+  '!src/_internal/**/*.test.ts',
+  'src/styles/**/*.css',
+  'src/styles/base-guard.ts',
+  'src/components/icons/index.ts',
+  'src/utilities/**/*.ts',
+  '!src/utilities/**/*.test.ts',
+  'src/highlighters/**/*.ts',
+  '!src/highlighters/**/*.test.ts',
+  '!src/highlighters/**/*.spec.ts',
+  'README.md',
+];
+
+/**
+ * Root-level JSON artifacts the package must always ship explicitly. They live
+ * at the package root (no directory prefix), so none of the `dist`/`src/**`
+ * globs cover them:
+ *   • `components.json`          — the machine-readable manifest (`./manifest` export target).
+ *   • `examples-exclusions.json` — read by `generate-component-examples.ts`.
+ * `package.json` is intentionally NOT listed: npm always publishes it.
+ */
+export const EXPLICIT_ROOT_FILE_ENTRIES: readonly string[] = [
+  'components.json',
+  'examples-exclusions.json',
+];
+
+/**
+ * A static `files` glob "covers" a root-level artifact path when the glob would
+ * already publish that exact file. Our static globs only ever match inside
+ * `dist/`, `src/`, or the exact file `README.md`, so a root-level `*.json`
+ * artifact is covered only when a glob names it verbatim. This conservative
+ * check is enough to dedupe `computeFiles`'s root-entry computation against the
+ * static globs without pulling in a full glob engine.
+ */
+function isRootArtifactGlobCovered(rootArtifact: string, globs: readonly string[]): boolean {
+  return globs.includes(rootArtifact);
+}
+
+/**
+ * Extract the set of root-level artifact paths (e.g. `components.json`) that the
+ * exports map points at. A "root-level" target has no directory segment after
+ * the leading `./`. `package.json` is excluded because npm always publishes it
+ * and listing it in `files` is redundant.
+ */
+export function rootLevelExportTargets(
+  exportsMap: Record<string, ExportEntry | JsonExportEntry | string>,
+): string[] {
+  const out = new Set<string>();
+  for (const value of Object.values(exportsMap)) {
+    const targets = typeof value === 'string' ? [value] : Object.values(value);
+    for (const target of targets) {
+      if (typeof target !== 'string') continue;
+      if (!target.startsWith('./')) continue;
+      const rest = target.slice(2);
+      if (rest.length === 0 || rest.includes('/')) continue; // not root-level
+      if (rest === 'package.json') continue; // always published by npm
+      out.add(rest);
+    }
+  }
+  return [...out];
+}
+
+/**
+ * Compute the canonical `package.json#files` array: the static globs verbatim,
+ * followed by the computed root-level artifact entries appended in deterministic
+ * (alphabetical) order. The computed set is the union of the explicit root
+ * entries and any root-level artifact path the exports map references that the
+ * static globs do not already cover — deduped, then sorted.
+ *
+ * This extends (never replaces) the static globs and never flattens the
+ * per-component tree into explicit paths.
+ */
+export function computeFiles(
+  exportsMap: Record<string, ExportEntry | JsonExportEntry | string>,
+  staticGlobs: readonly string[] = STATIC_FILES_GLOBS,
+  explicitRootEntries: readonly string[] = EXPLICIT_ROOT_FILE_ENTRIES,
+): string[] {
+  const computedRoots = new Set<string>(explicitRootEntries);
+  for (const target of rootLevelExportTargets(exportsMap)) {
+    if (!isRootArtifactGlobCovered(target, staticGlobs)) {
+      computedRoots.add(target);
+    }
+  }
+  const appended = [...computedRoots].toSorted((a, b) => a.localeCompare(b));
+  return [...staticGlobs, ...appended];
 }
 
 async function main(): Promise<void> {
@@ -504,6 +625,64 @@ async function main(): Promise<void> {
       );
       process.exit(1);
     }
+  }
+
+  /**
+   * Build the next exports map in deterministic order:
+   *   1. `.` (root, four-condition shape)
+   *   2. `./package.json` self-export
+   *   3. `./styles*` reserved entries (canonical, base-first)
+   *   4. `./styles/guard` dev-only base-loaded guard
+   *   5. `./highlighters/shiki`
+   *   6. computed component subpaths (incl. /examples, /constraints when present)
+   *   7. preserved legacy flat component subpaths (partial-migration window)
+   *
+   * Shared by both check and generate mode so the `files` array is computed from
+   * the SAME exports map the generator would write — a newly-added root artifact
+   * export is therefore reflected in `files` the very run it lands.
+   */
+  function buildNextExports(): Record<string, ExportEntry | JsonExportEntry | string> {
+    const next: Record<string, ExportEntry | JsonExportEntry | string> = {};
+    next[ROOT_KEY] = rootExport;
+    next[PACKAGE_JSON_KEY] = './package.json';
+    for (const [key, cssPath] of RESERVED_STYLES_ENTRIES) {
+      next[key] = stylesExport(cssPath);
+    }
+    next[STYLES_GUARD_KEY] = stylesGuardExport();
+    next[HIGHLIGHTERS_SHIKI_KEY] = highlightersShikiExport();
+
+    // Preserve legacy flat component subpaths whose component still exists as
+    // a flat .svelte file (not yet migrated to a directory).
+    const migratedNames = new Set(
+      components.map((c) => (c.isExperimental ? `./experimental/${c.name}` : `./${c.name}`)),
+    );
+    const legacy: Record<string, ExportEntry | JsonExportEntry | string> = {};
+    for (const [key, entry] of Object.entries(packageJson.exports)) {
+      if (RESERVED_KEYS.has(key)) continue;
+      if (migratedNames.has(key)) continue;
+      // Deprecated experimental aliases own their `./experimental/<name>` keys
+      // via `computed`; never let a stale verbatim copy survive as "legacy".
+      if (key in computed) continue;
+      if (
+        key.endsWith('/schema') ||
+        key.endsWith('/variables') ||
+        key.endsWith('/styles') ||
+        key.endsWith('/examples') ||
+        key.endsWith('/constraints')
+      )
+        continue;
+      if (key === './manifest') continue;
+      const flatPattern = /^\.\/(experimental\/)?[a-z][a-z0-9-]*$/;
+      if (flatPattern.test(key)) legacy[key] = entry;
+    }
+
+    for (const [key, entry] of Object.entries(computed)) {
+      next[key] = entry;
+    }
+    for (const [key, entry] of Object.entries(legacy)) {
+      next[key] = entry;
+    }
+    return next;
   }
 
   if (checkMode) {
@@ -585,6 +764,27 @@ async function main(): Promise<void> {
     // The forbidden-key guard already ran at the top of main() against
     // packageJson.exports; we don't need to repeat it here.
 
+    // `files` drift: the on-disk array must equal the computed one exactly. The
+    // computed `files` is derived from the COMPUTED exports map (`next` below in
+    // generate mode) so a freshly-added root artifact export is reflected the
+    // same run it lands. We surface each missing/extra root entry distinctly so
+    // the failure points at the precise drift rather than a wall of globs.
+    const expectedFiles = computeFiles(buildNextExports());
+    const actualFiles = packageJson.files ?? [];
+    if (JSON.stringify(actualFiles) !== JSON.stringify(expectedFiles)) {
+      const actualSet = new Set(actualFiles);
+      const expectedSet = new Set(expectedFiles);
+      const missing = expectedFiles.filter((entry) => !actualSet.has(entry));
+      const extra = actualFiles.filter((entry) => !expectedSet.has(entry));
+      if (missing.length === 0 && extra.length === 0) {
+        // Same membership, wrong order — report the ordering drift explicitly.
+        issues.push('files entries are out of order; run `bun run exports:generate` to fix');
+      } else {
+        for (const entry of missing) issues.push(`Missing files entry: "${entry}"`);
+        for (const entry of extra) issues.push(`Extra files entry: "${entry}"`);
+      }
+    }
+
     if (issues.length > 0) {
       process.stderr.write(
         'exports:check — drift detected. Run `bun run exports:generate` to fix:\n',
@@ -597,58 +797,14 @@ async function main(): Promise<void> {
     return;
   }
 
-  // Generate mode: build the next exports map in deterministic order:
-  //   1. `.` (root, four-condition shape)
-  //   2. `./package.json` self-export
-  //   3. `./styles*` reserved entries (canonical, base-first)
-  //   4. `./styles/guard` dev-only base-loaded guard
-  //   5. `./highlighters/shiki`
-  //   6. computed component subpaths (incl. /examples, /constraints when present)
-  //   7. preserved legacy flat component subpaths (partial-migration window)
-  const next: Record<string, ExportEntry | JsonExportEntry | string> = {};
-  next[ROOT_KEY] = rootExport;
-  next[PACKAGE_JSON_KEY] = './package.json';
-  for (const [key, cssPath] of RESERVED_STYLES_ENTRIES) {
-    next[key] = stylesExport(cssPath);
-  }
-  next[STYLES_GUARD_KEY] = stylesGuardExport();
-  next[HIGHLIGHTERS_SHIKI_KEY] = highlightersShikiExport();
-
-  // Preserve legacy flat component subpaths whose component still exists as
-  // a flat .svelte file (not yet migrated to a directory).
-  const migratedNames = new Set(
-    components.map((c) => (c.isExperimental ? `./experimental/${c.name}` : `./${c.name}`)),
-  );
-  const legacy: Record<string, ExportEntry | JsonExportEntry | string> = {};
-  for (const [key, entry] of Object.entries(packageJson.exports)) {
-    if (RESERVED_KEYS.has(key)) continue;
-    if (migratedNames.has(key)) continue;
-    // Deprecated experimental aliases own their `./experimental/<name>` keys
-    // via `computed`; never let a stale verbatim copy survive as "legacy".
-    if (key in computed) continue;
-    if (
-      key.endsWith('/schema') ||
-      key.endsWith('/variables') ||
-      key.endsWith('/styles') ||
-      key.endsWith('/examples') ||
-      key.endsWith('/constraints')
-    )
-      continue;
-    if (key === './manifest') continue;
-    const flatPattern = /^\.\/(experimental\/)?[a-z][a-z0-9-]*$/;
-    if (flatPattern.test(key)) legacy[key] = entry;
-  }
-
-  for (const [key, entry] of Object.entries(computed)) {
-    next[key] = entry;
-  }
-  for (const [key, entry] of Object.entries(legacy)) {
-    next[key] = entry;
-  }
+  // Generate mode: build the next exports map (shared with check mode) and the
+  // computed `files` array, then write both back to package.json.
+  const next = buildNextExports();
 
   assertNoForbiddenExportKeys(next, FORBIDDEN_EXPORT_KEY_PATTERN, upstreamAllowList);
 
   packageJson.exports = next;
+  packageJson.files = computeFiles(next);
   await Bun.write(packageJsonPath, JSON.stringify(packageJson, null, 2) + '\n');
 
   // Emit (or refresh) the generated re-export source files. They are part of
@@ -661,7 +817,8 @@ async function main(): Promise<void> {
 
   process.stdout.write(
     `exports:generate — wrote ${Object.keys(computed).length} computed subpaths ` +
-      `(${components.length} components, ${upstreamReexports.length} upstream re-exports)\n`,
+      `(${components.length} components, ${upstreamReexports.length} upstream re-exports) ` +
+      `and ${packageJson.files.length} files entries\n`,
   );
 }
 

--- a/packages/components/src/styles/base-guard.test.ts
+++ b/packages/components/src/styles/base-guard.test.ts
@@ -249,4 +249,22 @@ describe('consumer fixture: component style imported without the base', () => {
     expect(MISSING_BASE_WARNING).toContain("import 'cinder/styles'");
     expect(MISSING_BASE_WARNING).toContain('cinder/<component>/styles');
   });
+
+  // Package-boundary tripwire: the simulation above would keep passing even if
+  // the guard stopped being wired into the package. Assert the real export
+  // surface the BAD/GOOD sequences depend on actually exists, so deleting
+  // `cinder/styles/guard`, the base `cinder/styles`, or a component `/styles`
+  // subpath fails here. The base stylesheet's `--cinder-base-loaded` marker
+  // itself is covered in css-tree-shake.test.ts.
+  test('the package exports the entry points the guard sequence relies on', async () => {
+    const packageManifest = (await import('../../package.json', {
+      with: { type: 'json' },
+    })) as unknown as { default: { exports: Record<string, unknown> } };
+    const { exports } = packageManifest.default;
+    // The base that sets the marker, the guard module, and at least one
+    // per-component style subpath must all be exported.
+    expect(exports['./styles']).toBeDefined();
+    expect(exports['./styles/guard']).toBeDefined();
+    expect(exports['./button/styles']).toBeDefined();
+  });
 });

--- a/packages/components/src/styles/base-guard.test.ts
+++ b/packages/components/src/styles/base-guard.test.ts
@@ -205,3 +205,48 @@ describe('warn side-effect: base absent triggers console.warn exactly once', () 
     expect(warnSpy).not.toHaveBeenCalled();
   });
 });
+
+// ---------------------------------------------------------------------------
+// Consumer fixture (task ad7ea1e7)
+//
+// Models the two consumer import sequences end-to-end through the guard's real
+// exported logic, so the "import cinder/styles first" rule has fixture coverage
+// at the consumer boundary — not just at the `isBaseLoaded` primitive.
+//
+// A real consumer's app entry is one of:
+//
+//   BAD  — component style imported WITHOUT the base:
+//     import 'cinder/styles/guard';
+//     import 'cinder/button/styles';   // a stylesheet is attached, but
+//                                       // `--cinder-base-loaded` is never set
+//
+//   GOOD — base imported first:
+//     import 'cinder/styles';          // sets `--cinder-base-loaded: 1`
+//     import 'cinder/styles/guard';
+//     import 'cinder/button/styles';
+//
+// The guard must warn for the BAD sequence and stay silent for the GOOD one.
+// `styleSheetsLength: 1` represents the component stylesheet the consumer
+// imported; `baseLoadedValue` is whether `cinder/styles` ran (`'1'`) or not
+// (`''`).
+// ---------------------------------------------------------------------------
+
+describe('consumer fixture: component style imported without the base', () => {
+  test('BAD sequence — component style without `cinder/styles` → guard warns once', () => {
+    const warnSpy = mock(() => {});
+    simulateGuardSideEffect({ styleSheetsLength: 1, baseLoadedValue: '', warnSpy });
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy).toHaveBeenCalledWith(MISSING_BASE_WARNING);
+  });
+
+  test('GOOD sequence — `cinder/styles` imported first → guard stays silent', () => {
+    const warnSpy = mock(() => {});
+    simulateGuardSideEffect({ styleSheetsLength: 1, baseLoadedValue: '1', warnSpy });
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  test("the warning points the consumer at the fix (`import 'cinder/styles'` first)", () => {
+    expect(MISSING_BASE_WARNING).toContain("import 'cinder/styles'");
+    expect(MISSING_BASE_WARNING).toContain('cinder/<component>/styles');
+  });
+});

--- a/packages/testing/src/helpers/fixture-schema.ts
+++ b/packages/testing/src/helpers/fixture-schema.ts
@@ -70,7 +70,7 @@ const JsonValueSchema: z.ZodType<JsonValue> = z.lazy(() =>
  * Schema for a single interaction step. An interaction targets an element
  * identified by its `data-testid` value and performs one supported action.
  */
-const InteractionStepSchema = z
+export const InteractionStepSchema = z
   .object({
     action: z.enum(INTERACTION_ACTIONS),
     target: z.object({

--- a/packages/testing/src/helpers/interact.test.ts
+++ b/packages/testing/src/helpers/interact.test.ts
@@ -1,11 +1,7 @@
 import { describe, expect, it, mock } from 'bun:test';
 
-import {
-  AmbiguousTestIdError,
-  MissingTestIdError,
-  applyInteractions,
-  type InteractionStep,
-} from './interact.ts';
+import { InteractionStepSchema, type InteractionStep } from './fixture-schema.ts';
+import { AmbiguousTestIdError, MissingTestIdError, applyInteractions } from './interact.ts';
 
 // ---------------------------------------------------------------------------
 // Mock Page factory
@@ -312,5 +308,66 @@ describe('applyInteractions — press without key', () => {
     ];
 
     await expect(applyInteractions(page as never, steps)).rejects.toThrow(/1/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Canonical-schema binding (task f1ed0bed)
+//
+// `applyInteractions` consumes `InteractionStep` values; a fixture file's
+// `interact` array is validated at load time by `InteractionStepSchema` in
+// `fixture-schema.ts`. Both must agree on the shape, otherwise a fixture could
+// pass validation yet fail at `applyInteractions`, or vice versa. These tests
+// pin that the canonical schema accepts exactly the well-formed steps
+// `applyInteractions` handles and rejects the malformed `press` steps it throws
+// on — the "interact arrays validate against the canonical InteractionStep
+// before the Playwright run" guarantee.
+// ---------------------------------------------------------------------------
+
+describe('interact steps validate against the canonical InteractionStepSchema', () => {
+  it('accepts every well-formed action this module applies', () => {
+    const wellFormed: InteractionStep[] = [
+      { action: 'focus', target: { testId: 'field' } },
+      { action: 'click', target: { testId: 'button' } },
+      { action: 'hover', target: { testId: 'menu' } },
+      { action: 'press', target: { testId: 'input' }, key: 'Enter' },
+    ];
+    for (const step of wellFormed) {
+      const result = InteractionStepSchema.safeParse(step);
+      expect(result.success).toBe(true);
+    }
+  });
+
+  it("rejects a 'press' step with no key — the exact case applyInteractions throws on", () => {
+    const result = InteractionStepSchema.safeParse({
+      action: 'press',
+      target: { testId: 'input' },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects a 'press' step with an empty key", () => {
+    const result = InteractionStepSchema.safeParse({
+      action: 'press',
+      target: { testId: 'input' },
+      key: '',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects a target that uses selector instead of testId', () => {
+    const result = InteractionStepSchema.safeParse({
+      action: 'click',
+      target: { selector: '.foo' },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects an unknown action', () => {
+    const result = InteractionStepSchema.safeParse({
+      action: 'doubleclick',
+      target: { testId: 'button' },
+    });
+    expect(result.success).toBe(false);
   });
 });

--- a/packages/testing/src/helpers/interact.ts
+++ b/packages/testing/src/helpers/interact.ts
@@ -1,16 +1,10 @@
 import type { Page } from '@playwright/test';
 
-// TODO: Replace this local definition with the import from '../fixtures/fixture-schema.ts'
-// once P2a lands. The shape must remain compatible: { action, target: { testId }, key? }.
-/**
- * A single interaction step that can be applied to a Playwright page.
- * The `key` field is only meaningful when `action` is `'press'`.
- */
-export type InteractionStep = {
-  action: 'focus' | 'click' | 'hover' | 'press';
-  target: { testId: string };
-  key?: string;
-};
+// The canonical `InteractionStep` lives in `fixture-schema.ts` (inferred from the
+// Zod `InteractionStepSchema` that validates fixture `interact` arrays). The
+// shape — `{ action, target: { testId }, key? }` — is identical, so this module
+// consumes the single source of truth rather than duplicating it.
+import type { InteractionStep } from './fixture-schema.ts';
 
 /**
  * Thrown when no element with the given `data-testid` can be found on the page.


### PR DESCRIPTION
## Summary

Batch PR (4 tooling tasks). Part of the 26-task backlog batch.

- **4176c51c** — add `node` + `default` runtime conditions to every per-component `*/schema` and `*/variables` export, and emit standalone `.schema.js`/`.variables.js` from `build.ts` so they resolve. A plain Node/Vite consumer can now `import schema from 'cinder/<name>/schema'` without `ERR_PACKAGE_PATH_NOT_EXPORTED`.
  > [!IMPORTANT]
  > This **deliberately supersedes #212**, which had affirmed these subpaths as type-only metadata and added a tripwire asserting they never carry a runtime condition. That tripwire is replaced with the inverse assertion. This reversal was explicitly chosen by the maintainer because real consumers were hitting `ERR_PACKAGE_PATH_NOT_EXPORTED`.
- **269b9a99** — `generate-exports.ts` now also owns `package.json#files`: static globs verbatim + appended root artifacts (`components.json`, `examples-exclusions.json`), deterministic order, with `--check` drift detection. Does not flatten into per-component paths.
- **f1ed0bed** — unify `InteractionStep`: remove the local duplicate in `interact.ts`, import the canonical type from `fixture-schema.ts`, add schema-validation binding tests.
- **ad7ea1e7** — fill the `import cinder/styles first` guard's fixture-coverage gap (the runtime guard itself already shipped in #211): a consumer-boundary test exercising BAD/GOOD import sequences plus an export-wiring tripwire.

Note: `d1e74789` (analyzer hints) was already shipped by #203, so it is **not** in this PR.

## Review committee

Pre-reviewed by: typescript-expert, dx-engineer, simplicity-engineer
- Codex (gpt-5.4, xhigh reasoning) — 2 rounds
- All must-fix items addressed

Codex caught: a `localeCompare` determinism leak in the generator (now bytewise), a manifest fixture that never exercised the `default` target (now asserts both `node`+`default` exist), and a styles-guard test that lacked a package-boundary tripwire (now added).

## Test plan

- Full `bun run build` exit 0; verified both `dist/components/<n>/<n>.schema.js` and `dist/server/.../<n>.schema.js` emit, and a Node consumer imports `cinder/button/schema` (type object).
- `bun run exports:check` and `bun run components:check` exit 0.
- generate-exports tests 31/0, interact tests 23/0, base-guard tests 19/0.
- Pre-commit + pre-push hooks green (scoped typecheck + full test suite).

## Known pre-existing issue (NOT introduced by this PR)

The `manifest-consumer` fixture (run only by `validate:consumer`, not in pre-push or `main-green` CI) reports orphan exports for the experimental **deprecation-alias** subpaths (`./experimental/timeline`, etc.) and some style subpaths. These export keys exist on `origin/main` and PR2 does not touch the fixture's orphan/allowlist logic — the gap predates this PR. Flagged for a separate follow-up (decide whether deprecation aliases should be manifest-advertised or allowlisted).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Wide public API/export-map change across all components; behavior is intentional and heavily tested, but any consumer that relied on type-only resolution or the old tripwire must adapt.
> 
> **Overview**
> This PR turns every `cinder/<component>/schema` and `/variables` subpath into a **full runtime entry point** (adds `node` and `default` alongside `types` and `svelte`), reversing the earlier type-only contract.
> 
> **Build & exports:** `build.ts` now compiles each `<name>.schema.ts` and `<name>.variables.ts` as separate browser and server bundles, and the generated `package.json` exports map points those conditions at the new `.js` artifacts. Post-build checks expect matching `.js`/`.d.ts` for every component.
> 
> **Contract tests & docs:** The `manifest-consumer` fixture drops the “must not resolve at runtime” tripwire and instead asserts ESM/CJS resolution succeeds and that both `node` and `default` targets exist on disk (so bundlers that pick `default` are covered). **AGENTS.md** tells consumers to `import` schema/variables directly instead of reading JSON sidecars from disk.
> 
> **Packaging:** `package.json#files` gains root artifacts (`components.json`, `examples-exclusions.json`), with unit tests for the `computeFiles` helper that merges static globs and export-derived root paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2a7c850bd13d438717a323e77a6067bc14c710b0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->