### PR TITLE
feat(components): Toggle form participation props (name, value, form) (PR5)

### DIFF
--- a/packages/components/components.json
+++ b/packages/components/components.json
@@ -3359,7 +3359,10 @@
       "useWhen": [
         "Flipping a single setting on or off with immediate effect such as notifications or dark mode."
       ],
-      "avoidWhen": ["Picking one option from a small fixed set — use segmented-control instead."],
+      "avoidWhen": [
+        "Picking one option from a small fixed set — use segmented-control instead.",
+        "Collecting a deferred boolean (agreement, opt-in) in a Submit-style form — a switch implies immediate effect; use checkbox instead."
+      ],
       "related": ["checkbox", "segmented-control"],
       "hasConstraints": false,
       "hasExamples": true,

--- a/packages/components/components.json
+++ b/packages/components/components.json
@@ -3359,10 +3359,7 @@
       "useWhen": [
         "Flipping a single setting on or off with immediate effect such as notifications or dark mode."
       ],
-      "avoidWhen": [
-        "Selecting zero or more options inside a form submission — use checkbox instead.",
-        "Picking one option from a small fixed set — use segmented-control instead."
-      ],
+      "avoidWhen": ["Picking one option from a small fixed set — use segmented-control instead."],
       "related": ["checkbox", "segmented-control"],
       "hasConstraints": false,
       "hasExamples": true,

--- a/packages/components/src/components/toggle/README.md
+++ b/packages/components/src/components/toggle/README.md
@@ -16,14 +16,17 @@ A Toggle component. Replace this sentence with a one-line purpose statement once
 
 <!-- generated:props:start -->
 
-| Prop        | Type      | Required | Default | Description                                                                                                                      |
-| ----------- | --------- | -------- | ------- | -------------------------------------------------------------------------------------------------------------------------------- |
-| `checked`   | `boolean` | no       | —       | Whether the toggle is currently checked. Bindable — defaults to false.                                                           |
-| `class`     | `string`  | no       | —       | Additional class names merged with `.cinder-toggle` on the switch button.                                                        |
-| `disabled`  | `boolean` | no       | —       | Prevents interaction when true. Sets `disabled` attribute.                                                                       |
-| `hideLabel` | `boolean` | no       | —       | Visually hide the rendered label while keeping it as the accessible name. Use for icon-only or inline contexts.                  |
-| `id`        | `string`  | yes      | —       | Native id placed on the `<button>`; the rendered label uses `aria-labelledby` to name it (label id is derived as `${id}-label`). |
-| `label`     | `string`  | yes      | —       | Visible label text. Always the accessible name, even when `hideLabel` is set. Required.                                          |
+| Prop        | Type      | Required | Default | Description                                                                                                                                                                                                        |
+| ----------- | --------- | -------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `checked`   | `boolean` | no       | —       | Whether the toggle is currently checked. Bindable — defaults to false.                                                                                                                                             |
+| `class`     | `string`  | no       | —       | Additional class names merged with `.cinder-toggle` on the switch button.                                                                                                                                          |
+| `disabled`  | `boolean` | no       | —       | Prevents interaction when true. Sets `disabled` attribute.                                                                                                                                                         |
+| `form`      | `string`  | no       | —       | Associates the hidden checkbox with a form by id, matching the native `form` attribute. Lets the toggle submit with a form it is not nested in. Ignored when `name` is unset.                                      |
+| `hideLabel` | `boolean` | no       | —       | Visually hide the rendered label while keeping it as the accessible name. Use for icon-only or inline contexts.                                                                                                    |
+| `id`        | `string`  | yes      | —       | Native id placed on the `<button>`; the rendered label uses `aria-labelledby` to name it (label id is derived as `${id}-label`).                                                                                   |
+| `label`     | `string`  | yes      | —       | Visible label text. Always the accessible name, even when `hideLabel` is set. Required.                                                                                                                            |
+| `name`      | `string`  | no       | —       | Form field name. When set, a hidden checkbox mirrors `checked` so the toggle participates in native form submission. Omit for purely client-side toggles (no hidden input is rendered, so there is zero overhead). |
+| `value`     | `string`  | no       | —       | Value submitted for the hidden checkbox when `checked` and `name` is set. Mirrors native checkbox semantics: the pair `name=value` is sent only while checked. Defaults to `'on'`. Ignored when `name` is unset.   |
 
 <!-- generated:props:end -->
 

--- a/packages/components/src/components/toggle/toggle.schema.json
+++ b/packages/components/src/components/toggle/toggle.schema.json
@@ -22,6 +22,18 @@
       "type": "boolean",
       "description": "Visually hide the rendered label while keeping it as the accessible name. Use for icon-only or inline contexts."
     },
+    "name": {
+      "type": "string",
+      "description": "Form field name. When set, a hidden checkbox mirrors `checked` so the toggle\nparticipates in native form submission. Omit for purely client-side toggles\n(no hidden input is rendered, so there is zero overhead)."
+    },
+    "value": {
+      "type": "string",
+      "description": "Value submitted for the hidden checkbox when `checked` and `name` is set.\nMirrors native checkbox semantics: the pair `name=value` is sent only while\nchecked. Defaults to `'on'`. Ignored when `name` is unset."
+    },
+    "form": {
+      "type": "string",
+      "description": "Associates the hidden checkbox with a form by id, matching the native\n`form` attribute. Lets the toggle submit with a form it is not nested in.\nIgnored when `name` is unset."
+    },
     "class": {
       "type": "string",
       "description": "Additional class names merged with `.cinder-toggle` on the switch button."

--- a/packages/components/src/components/toggle/toggle.schema.ts
+++ b/packages/components/src/components/toggle/toggle.schema.ts
@@ -27,6 +27,21 @@ const schema = {
       description:
         'Visually hide the rendered label while keeping it as the accessible name. Use for icon-only or inline contexts.',
     },
+    name: {
+      type: 'string',
+      description:
+        'Form field name. When set, a hidden checkbox mirrors `checked` so the toggle\nparticipates in native form submission. Omit for purely client-side toggles\n(no hidden input is rendered, so there is zero overhead).',
+    },
+    value: {
+      type: 'string',
+      description:
+        "Value submitted for the hidden checkbox when `checked` and `name` is set.\nMirrors native checkbox semantics: the pair `name=value` is sent only while\nchecked. Defaults to `'on'`. Ignored when `name` is unset.",
+    },
+    form: {
+      type: 'string',
+      description:
+        'Associates the hidden checkbox with a form by id, matching the native\n`form` attribute. Lets the toggle submit with a form it is not nested in.\nIgnored when `name` is unset.',
+    },
     class: {
       type: 'string',
       description: 'Additional class names merged with `.cinder-toggle` on the switch button.',

--- a/packages/components/src/components/toggle/toggle.svelte
+++ b/packages/components/src/components/toggle/toggle.svelte
@@ -52,7 +52,7 @@
   >
     <span aria-hidden="true" class="cinder-toggle__thumb"></span>
   </button>
-  {#if name !== undefined}
+  {#if name}
     <!--
       Form participation: a hidden, non-interactive checkbox mirrors `checked` so
       the toggle submits with a native form. The <button> stays the only thing
@@ -68,7 +68,7 @@
       {value}
       {form}
       {disabled}
-      {checked}
+      bind:checked
       style="position:absolute;opacity:0;pointer-events:none;"
     />
   {/if}

--- a/packages/components/src/components/toggle/toggle.svelte
+++ b/packages/components/src/components/toggle/toggle.svelte
@@ -8,6 +8,7 @@
    * @tag switch
    * @useWhen Flipping a single setting on or off with immediate effect such as notifications or dark mode.
    * @avoidWhen Picking one option from a small fixed set — use segmented-control instead.
+   * @avoidWhen Collecting a deferred boolean (agreement, opt-in) in a Submit-style form — a switch implies immediate effect; use checkbox instead.
    * @related checkbox, segmented-control
    */
   export type { ToggleProps } from './toggle.types.ts';
@@ -54,23 +55,17 @@
   </button>
   {#if name}
     <!--
-      Form participation: a hidden, non-interactive checkbox mirrors `checked` so
-      the toggle submits with a native form. The <button> stays the only thing
-      users tab to or operate; this input is removed from the tab order
-      (tabindex="-1") and the a11y tree (aria-hidden), and is visually inert.
+      Form participation: a `hidden` checkbox mirrors `checked` so the toggle
+      submits with a native form. The <button role="switch"> stays the only thing
+      users tab to or operate. We use the `hidden` attribute (display:none) rather
+      than a visually-hidden + aria-hidden + tabindex="-1" input: a display:none
+      control is genuinely non-focusable and out of the accessibility tree, so it
+      avoids the aria-hidden-focus WCAG violation (aria-hidden on a still-focusable
+      element). `hidden` form controls STILL submit when named, checked, and not
+      disabled — only `disabled` excludes a control from the form data set.
       Rendered only when `name` is set, so a client-side-only toggle pays nothing.
     -->
-    <input
-      type="checkbox"
-      tabindex="-1"
-      aria-hidden="true"
-      {name}
-      {value}
-      {form}
-      {disabled}
-      bind:checked
-      style="position:absolute;opacity:0;pointer-events:none;"
-    />
+    <input type="checkbox" hidden {name} {value} {form} {disabled} bind:checked />
   {/if}
   <!--
     The label is a <span> (not a <label for>) named via aria-labelledby. A native

--- a/packages/components/src/components/toggle/toggle.svelte
+++ b/packages/components/src/components/toggle/toggle.svelte
@@ -7,7 +7,6 @@
    * @tag form
    * @tag switch
    * @useWhen Flipping a single setting on or off with immediate effect such as notifications or dark mode.
-   * @avoidWhen Selecting zero or more options inside a form submission — use checkbox instead.
    * @avoidWhen Picking one option from a small fixed set — use segmented-control instead.
    * @related checkbox, segmented-control
    */
@@ -24,6 +23,9 @@
     label,
     disabled = false,
     hideLabel = false,
+    name,
+    value = 'on',
+    form,
     class: customClassName,
   }: ToggleProps = $props();
 
@@ -50,6 +52,26 @@
   >
     <span aria-hidden="true" class="cinder-toggle__thumb"></span>
   </button>
+  {#if name !== undefined}
+    <!--
+      Form participation: a hidden, non-interactive checkbox mirrors `checked` so
+      the toggle submits with a native form. The <button> stays the only thing
+      users tab to or operate; this input is removed from the tab order
+      (tabindex="-1") and the a11y tree (aria-hidden), and is visually inert.
+      Rendered only when `name` is set, so a client-side-only toggle pays nothing.
+    -->
+    <input
+      type="checkbox"
+      tabindex="-1"
+      aria-hidden="true"
+      {name}
+      {value}
+      {form}
+      {disabled}
+      {checked}
+      style="position:absolute;opacity:0;pointer-events:none;"
+    />
+  {/if}
   <!--
     The label is a <span> (not a <label for>) named via aria-labelledby. A native
     <label for> targeting the <button> would forward a synthetic click to it,

--- a/packages/components/src/components/toggle/toggle.test.ts
+++ b/packages/components/src/components/toggle/toggle.test.ts
@@ -248,9 +248,9 @@ describe('Toggle — form participation', () => {
   });
 
   test('hidden input defaults its submitted value to "on"', () => {
-    // For a checkbox the submitted value is the `value` DOM *property*. Svelte
-    // omits the attribute when it equals the native default ("on"), so assert on
-    // the property — that is exactly what a form submission would carry.
+    // Form submission reads the input's `value` DOM *property*, which defaults to
+    // the native checkbox default "on" when no explicit value is passed. We assert
+    // the property (not the attribute) because that is exactly what FormData carries.
     const { container } = render(Toggle, {
       props: { id: 'tf3', checked: false, label: 'Notifications', name: 'notifications' },
     });

--- a/packages/components/src/components/toggle/toggle.test.ts
+++ b/packages/components/src/components/toggle/toggle.test.ts
@@ -229,6 +229,99 @@ describe('Toggle — rendered label', () => {
   });
 });
 
+describe('Toggle — form participation', () => {
+  test('no hidden input is rendered when name is unset', () => {
+    const { container } = render(Toggle, {
+      props: { id: 'tf1', checked: false, label: 'Notifications' },
+    });
+    expect(container.querySelector('input[type="checkbox"]')).toBeNull();
+  });
+
+  test('hidden checkbox input appears when name is set', () => {
+    const { container } = render(Toggle, {
+      props: { id: 'tf2', checked: false, label: 'Notifications', name: 'notifications' },
+    });
+    const input = container.querySelector('input[type="checkbox"]');
+    expect(input).not.toBeNull();
+    expect(input?.getAttribute('name')).toBe('notifications');
+  });
+
+  test('hidden input defaults its submitted value to "on"', () => {
+    // For a checkbox the submitted value is the `value` DOM *property*. Svelte
+    // omits the attribute when it equals the native default ("on"), so assert on
+    // the property — that is exactly what a form submission would carry.
+    const { container } = render(Toggle, {
+      props: { id: 'tf3', checked: false, label: 'Notifications', name: 'notifications' },
+    });
+    const input = container.querySelector('input[type="checkbox"]') as HTMLInputElement;
+    expect(input.value).toBe('on');
+  });
+
+  test('hidden input carries a custom value', () => {
+    const { container } = render(Toggle, {
+      props: {
+        id: 'tf4',
+        checked: false,
+        label: 'Notifications',
+        name: 'notifications',
+        value: 'enabled',
+      },
+    });
+    const input = container.querySelector('input[type="checkbox"]') as HTMLInputElement;
+    expect(input.value).toBe('enabled');
+  });
+
+  test('hidden input reflects checked=true', () => {
+    const { container } = render(Toggle, {
+      props: { id: 'tf5', checked: true, label: 'Notifications', name: 'notifications' },
+    });
+    const input = container.querySelector('input[type="checkbox"]') as HTMLInputElement;
+    expect(input.checked).toBe(true);
+  });
+
+  test('hidden input reflects checked=false', () => {
+    const { container } = render(Toggle, {
+      props: { id: 'tf6', checked: false, label: 'Notifications', name: 'notifications' },
+    });
+    const input = container.querySelector('input[type="checkbox"]') as HTMLInputElement;
+    expect(input.checked).toBe(false);
+  });
+
+  test('hidden input tracks checked after a click', async () => {
+    const { container } = render(Toggle, {
+      props: { id: 'tf7', checked: false, label: 'Notifications', name: 'notifications' },
+    });
+    const button = container.querySelector('button') as HTMLButtonElement;
+    const input = container.querySelector('input[type="checkbox"]') as HTMLInputElement;
+    expect(input.checked).toBe(false);
+    await fireEvent.click(button);
+    expect(input.checked).toBe(true);
+  });
+
+  test('hidden input is removed from the tab order and a11y tree', () => {
+    const { container } = render(Toggle, {
+      props: { id: 'tf8', checked: false, label: 'Notifications', name: 'notifications' },
+    });
+    const input = container.querySelector('input[type="checkbox"]');
+    expect(input?.getAttribute('tabindex')).toBe('-1');
+    expect(input?.getAttribute('aria-hidden')).toBe('true');
+  });
+
+  test('form prop associates the hidden input with a form by id', () => {
+    const { container } = render(Toggle, {
+      props: {
+        id: 'tf9',
+        checked: false,
+        label: 'Notifications',
+        name: 'notifications',
+        form: 'settings-form',
+      },
+    });
+    const input = container.querySelector('input[type="checkbox"]');
+    expect(input?.getAttribute('form')).toBe('settings-form');
+  });
+});
+
 describe('Toggle — hideLabel', () => {
   test('accessible name is preserved when hideLabel is set', () => {
     render(Toggle, {

--- a/packages/components/src/components/toggle/toggle.test.ts
+++ b/packages/components/src/components/toggle/toggle.test.ts
@@ -299,13 +299,17 @@ describe('Toggle — form participation', () => {
     expect(input.checked).toBe(true);
   });
 
-  test('hidden input is removed from the tab order and a11y tree', () => {
+  test('hidden input uses the `hidden` attribute (non-focusable, out of the a11y tree)', () => {
     const { container } = render(Toggle, {
       props: { id: 'tf8', checked: false, label: 'Notifications', name: 'notifications' },
     });
-    const input = container.querySelector('input[type="checkbox"]');
-    expect(input?.getAttribute('tabindex')).toBe('-1');
-    expect(input?.getAttribute('aria-hidden')).toBe('true');
+    const input = container.querySelector('input[type="checkbox"]') as HTMLInputElement;
+    // `hidden` (display:none) makes the control genuinely non-focusable and absent
+    // from the accessibility tree — no aria-hidden-focus violation. It must NOT
+    // carry aria-hidden/tabindex (those would imply a focusable-but-hidden element).
+    expect(input.hidden).toBe(true);
+    expect(input.hasAttribute('aria-hidden')).toBe(false);
+    expect(input.hasAttribute('tabindex')).toBe(false);
   });
 
   test('form prop associates the hidden input with a form by id', () => {
@@ -320,6 +324,29 @@ describe('Toggle — form participation', () => {
     });
     const input = container.querySelector('input[type="checkbox"]');
     expect(input?.getAttribute('form')).toBe('settings-form');
+  });
+
+  test('form prop associates the input with an EXTERNAL form by id (real association)', () => {
+    const externalForm = document.createElement('form');
+    externalForm.id = 'external-settings-form';
+    document.body.appendChild(externalForm);
+    try {
+      // Render the toggle OUTSIDE the form; the `form` attribute must associate
+      // the hidden input with the external form so it submits with it.
+      const { container } = render(Toggle, {
+        props: {
+          id: 'tf9b',
+          checked: true,
+          label: 'Notifications',
+          name: 'notifications',
+          form: 'external-settings-form',
+        },
+      });
+      const input = container.querySelector('input[type="checkbox"]') as HTMLInputElement;
+      expect(input.form).toBe(externalForm);
+    } finally {
+      externalForm.remove();
+    }
   });
 
   // The feature's actual contract is native form serialization. We render the

--- a/packages/components/src/components/toggle/toggle.test.ts
+++ b/packages/components/src/components/toggle/toggle.test.ts
@@ -1,5 +1,6 @@
 /// <reference lib="dom" />
 import { describe, expect, test } from 'bun:test';
+import type { ComponentProps } from 'svelte';
 
 import { setupHappyDom } from '../../test/happy-dom.ts';
 
@@ -319,6 +320,93 @@ describe('Toggle — form participation', () => {
     });
     const input = container.querySelector('input[type="checkbox"]');
     expect(input?.getAttribute('form')).toBe('settings-form');
+  });
+
+  // The feature's actual contract is native form serialization. We render the
+  // toggle INTO a real <form> and assert the hidden input is form-associated and
+  // carries the exact properties a browser's FormData reads (`name`, live
+  // `.checked` and `.value` DOM properties, `disabled`). We assert the DOM
+  // properties rather than `new FormData(form)` because happy-dom's FormData
+  // serializer does not pick up a checkbox nested under wrapper elements (it
+  // returns null even though `input.form === form` and `input.checked` is true);
+  // the properties below ARE what a real browser serializes, so this proves the
+  // contract without depending on the test environment's FormData implementation.
+  function renderInForm(props: ComponentProps<typeof Toggle>) {
+    const form = document.createElement('form');
+    document.body.appendChild(form);
+    const result = render(Toggle, { target: form, props });
+    const input = form.querySelector('input[type="checkbox"]') as HTMLInputElement;
+    return { form, input, ...result, teardown: () => form.remove() };
+  }
+
+  test('checked toggle: input is form-associated and submits name=on', () => {
+    const { form, input, teardown } = renderInForm({
+      id: 'tf10',
+      checked: true,
+      label: 'Notifications',
+      name: 'notifications',
+    });
+    try {
+      expect(input.form).toBe(form); // associated with THIS form → included in submission
+      expect(input.name).toBe('notifications');
+      expect(input.checked).toBe(true); // checked → field is submitted
+      expect(input.value).toBe('on'); // default submitted value
+      expect(input.disabled).toBe(false);
+    } finally {
+      teardown();
+    }
+  });
+
+  test('checked toggle carries a custom submitted value', () => {
+    const { input, teardown } = renderInForm({
+      id: 'tf11',
+      checked: true,
+      label: 'Notifications',
+      name: 'notifications',
+      value: 'enabled',
+    });
+    try {
+      expect(input.checked).toBe(true);
+      expect(input.value).toBe('enabled');
+    } finally {
+      teardown();
+    }
+  });
+
+  test('unchecked toggle: input is present but checked=false (omitted from submission)', () => {
+    const { input, teardown } = renderInForm({
+      id: 'tf12',
+      checked: false,
+      label: 'Notifications',
+      name: 'notifications',
+    });
+    try {
+      expect(input.checked).toBe(false); // unchecked checkboxes are omitted from FormData
+    } finally {
+      teardown();
+    }
+  });
+
+  // Note: the click→input.checked-tracks assertion (which proves `bind:checked`
+  // updates the live property, not just the initial attribute) is covered by the
+  // "hidden input tracks checked after a click" test above using the standard
+  // render. fireEvent.click does not propagate through testing-library's
+  // `target: <form>` mount, so it is asserted there, not here.
+
+  test('disabled toggle: hidden input is disabled (excluded from submission) even when checked', () => {
+    const { input, teardown } = renderInForm({
+      id: 'tf14',
+      checked: true,
+      label: 'Notifications',
+      name: 'notifications',
+      disabled: true,
+    });
+    try {
+      expect(input.disabled).toBe(true); // disabled controls are excluded from FormData
+      expect(input.checked).toBe(true);
+    } finally {
+      teardown();
+    }
   });
 });
 

--- a/packages/components/src/components/toggle/toggle.types.ts
+++ b/packages/components/src/components/toggle/toggle.types.ts
@@ -24,6 +24,24 @@ export type ToggleProps = {
   disabled?: boolean;
   /** Visually hide the rendered label while keeping it as the accessible name. Use for icon-only or inline contexts. */
   hideLabel?: boolean;
+  /**
+   * Form field name. When set, a hidden checkbox mirrors `checked` so the toggle
+   * participates in native form submission. Omit for purely client-side toggles
+   * (no hidden input is rendered, so there is zero overhead).
+   */
+  name?: string;
+  /**
+   * Value submitted for the hidden checkbox when `checked` and `name` is set.
+   * Mirrors native checkbox semantics: the pair `name=value` is sent only while
+   * checked. Defaults to `'on'`. Ignored when `name` is unset.
+   */
+  value?: string;
+  /**
+   * Associates the hidden checkbox with a form by id, matching the native
+   * `form` attribute. Lets the toggle submit with a form it is not nested in.
+   * Ignored when `name` is unset.
+   */
+  form?: string;
   /** Additional class names merged with `.cinder-toggle` on the switch button. */
   class?: string;
 };


### PR DESCRIPTION
## Summary

Adds form-participation props to **Toggle** (task `9aa17a95`). Part of the 26-task backlog batch.

Toggle is a `<button role="switch">` and couldn't participate in native form submission. It now renders a `hidden` `<input type="checkbox">` (only when `name` is set) that mirrors `checked` via `bind:checked`, so the toggle's state appears in `FormData`. New props: `name?`, `value?` (default `'on'`), `form?`.

> [!NOTE]
> The other two tasks in this group were already shipped: `cb694a12` (axe-blocking) by #199, `51dc302d` (visual baselines) by #103/#205. Only the Toggle work was real.

## Review committee

Pre-reviewed by: svelte-expert, testing-expert, ux-designer
- Codex (gpt-5.4, xhigh reasoning) — 2 rounds
- All must-fix items addressed

The committee caught two real bugs in the original implementation:
- **`{checked}` → `bind:checked`** (svelte-expert): the attribute form sets `defaultChecked` (read once at mount), so after a click the live `.checked` property a browser serializes would never update. `bind:checked` keeps the DOM property in sync.
- **`aria-hidden` on a focusable input → `hidden` attribute** (Codex): `aria-hidden="true"` on a still-(programmatically-)focusable control is the `aria-hidden-focus` WCAG violation. A `hidden` (display:none) control is genuinely non-focusable and out of the a11y tree, and still submits when named/checked/not-disabled.

Also: form-submission tests now render into a real `<form>` and assert form association + the `.name`/`.checked`/`.value`/`.disabled` DOM properties (happy-dom's `FormData` serializer drops checkboxes nested under wrapper elements, so the properties — which are what a browser actually serializes — are asserted instead); an external-form association test; and a narrowed `@avoidWhen` (a switch implies immediate effect, so it's still wrong for deferred-submit booleans even though it can carry a value).

## Test plan

- `bun test src/components/toggle/toggle.test.ts` — 41 pass / 0 fail (14 form-participation tests).
- `bun run components:check` exit 0 (regenerated components.json for the JSDoc change).
- Pre-commit + pre-push hooks green (scoped typecheck + full test suite); lint clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive optional API and tests on a stable form component; no change when name is omitted, with accessibility handled via hidden rather than aria-hidden on a focusable input.
> 
> **Overview**
> **Toggle** can now participate in native HTML form submission while keeping the visible control as a `role="switch"` button.
> 
> Optional props **`name`**, **`value`** (default `'on'`), and **`form`** are added across types, JSON/TS schemas, README, and `components.json`. When **`name`** is set, a **`hidden`** checkbox mirrors **`checked`** via **`bind:checked`** so submit/`FormData` see checkbox semantics; with no **`name`**, no extra input is rendered. Guidance is tightened: deferred submit-style booleans should use **checkbox**, not toggle.
> 
> Tests add a **form participation** suite (association, values, disabled, external **`form`**, a11y of the hidden control).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e3e616a66cb499af494dfa7f1d0a7075962981b6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->