### PR TITLE
fix(markdown): kill the main-green EISDIR flake via static import-graph traversal

### DIFF
--- a/packages/markdown/src/import-graph.test.ts
+++ b/packages/markdown/src/import-graph.test.ts
@@ -1,277 +1,293 @@
 /**
  * Import-graph leanness guard.
  *
- * The bundle-bloat regression we just fixed (rendering pipeline pulled in
- * by every consumer of @cinder/markdown) is the kind of thing that's
- * easy to re-introduce — one accidental `export *` or a barrel import
- * across subpaths and the rendering stack creeps back into diff-only
- * consumers.
+ * The bundle-bloat regression this protects against (the rendering pipeline
+ * pulled in by every consumer of @cinder/markdown) is easy to re-introduce —
+ * one accidental `export *` or a barrel import across subpaths and the rendering
+ * stack creeps back into diff-only consumers.
  *
- * This test bundles each subpath in isolation via Bun.build and
- * asserts the resulting bundle text does NOT contain any of the heavy
- * rendering-only modules. It does NOT enforce a "no unified" rule on
- * the pipeline barrels — the parser/serializer legitimately depend on
- * unified/remark-parse/remark-stringify, and forcing those out would
- * defeat the purpose of the aggregate.
+ * HOW THIS WORKS (and why it no longer uses Bun.build):
+ *
+ * It used to bundle each subpath with `Bun.build` and grep the output for
+ * rendering-library strings. On Linux CI that intermittently failed with
+ * `EISDIR reading file: ".../packages/diff/src/line-diff.ts"` — a Bun
+ * bundler / libuv / overlayfs path-confusion surfaced as a spurious filesystem
+ * error when `Bun.build` walked the live workspace graph while @cinder/diff's
+ * own test process touched the same file. Retries (PRs #213/#214) only reduced
+ * the probability; they never eliminated it.
+ *
+ * Instead we now walk the import graph STATICALLY: resolve each subpath to its
+ * source file via the package `exports` map, read each file with `readFileSync`,
+ * extract its runtime imports with `Bun.Transpiler.scanImports` (which excludes
+ * `import type` / `export type`), resolve each specifier, and recurse. A subpath
+ * is "lean" iff no FORBIDDEN rendering package is reachable from it. This is
+ * deterministic, immune to filesystem races, and a stricter guarantee than
+ * grepping bundle text (it catches a rendering import even if the bundler would
+ * have tree-shaken or renamed the telltale strings).
  *
  * Categories:
  *
- * A. **Narrow / leaf subpaths** — must contain none of the rendering
- *    payload (shiki, katex, rehype-katex). The diff/line-diff path is
- *    the canonical "tiny consumer" — nothing in there should drag the
- *    rendering graph.
- *
- * B. **Aggregate barrels** — must contain none of the rendering payload
- *    even though they may legitimately contain unified for the parser.
- *
- * C. **Bare root** — currently re-exports `diff` and `pipeline` only.
- *    Must contain none of the rendering payload regardless of which
- *    namespace a consumer reaches into.
+ * A. **Narrow / leaf subpaths** — no rendering package reachable. `diff/line-diff`
+ *    is the canonical "tiny consumer"; nothing in it should drag rendering.
+ * B. **Aggregate barrels** — no rendering package reachable, even though they may
+ *    legitimately reach unified/remark for the parser.
+ * C. **Bare root** — re-exports `diff` and `pipeline` only; no rendering reachable
+ *    regardless of which namespace a consumer uses.
+ * D. **Sanity** — the rendering subpath MUST reach the rendering packages, so the
+ *    leanness assertions above cannot pass vacuously.
  */
 
 import { describe, expect, it } from 'bun:test';
-import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
-import { join } from 'node:path';
+import { existsSync, readFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
 
-// Markers that the rendering bundle MUST contain. The sanity check below
-// asserts every marker is present in the rendering bundle; the leanness
-// tests assert none are present in lean bundles. Markers must be strings
-// that survive bundling — module-specifier paths (e.g. `shiki/core`) get
-// inlined and don't appear as literals, but identifier names from the
-// modules' source DO appear because Bun emits the module bodies inline.
+// Rendering-only packages that cinder's source imports DIRECTLY. A lean subpath
+// must not reach any of these; the rendering subpath must reach all of them.
+// Matched as exact package names or scoped-package prefixes (e.g. any
+// `@shikijs/*` matches `@shikijs/`).
 //
-// `scopeName` is a TextMate grammar property used heavily by shiki's
-// language registrations; `katex` appears in CSS class generation
-// throughout the KaTeX library body. Both are stable across versions.
-// `@shikijs` and `shiki` are present in passthrough strings the libraries
-// reference internally (worker comm, error messages, etc.).
-const RENDERING_MARKERS = ['scopeName', 'katex', '@shikijs', 'shiki'] as const;
+// NB: bare `katex` is intentionally NOT listed — cinder does not import `katex`
+// directly; it imports `rehype-katex` + `remark-math`, which pull katex in
+// transitively. The old Bun.build test saw the string "katex" only because the
+// bundler inlined rehype-katex's transitive katex body. This static graph tracks
+// DIRECT imports, so we forbid the packages cinder actually imports. Reaching
+// rehype-katex/remark-math from a lean subpath still fails correctly.
+const FORBIDDEN_RENDERING_PACKAGES = ['shiki', '@shikijs/', 'rehype-katex', 'remark-math'] as const;
 
-// This test file lives at packages/markdown/src/, so `import.meta.dirname` is
-// that `src` directory and three levels up is the workspace root (the directory
-// holding `package.json` + `bun.lock` + the `packages/` folder).
-//
-// The temp entry file MUST live somewhere inside the workspace tree so Bun's
-// module resolution walks up to the workspace `node_modules` and the
-// `@cinder/markdown` self-reference resolves — an entry placed in `os.tmpdir()`
-// fails with `Could not resolve: "@cinder/markdown/..."`. But it must NOT live
-// inside `packages/markdown` itself: see `bundleSnippet` for why.
-const WORKSPACE_ROOT = join(import.meta.dirname, '..', '..', '..');
+const WORKSPACE_ROOT = resolve(import.meta.dirname, '..', '..', '..');
+const PACKAGES_DIR = join(WORKSPACE_ROOT, 'packages');
 
-// Maximum number of Bun.build attempts per snippet. See `isTransientReadError`.
-const MAX_BUILD_ATTEMPTS = 5;
+// The import conditions a bundler/runtime applies, in priority order, when
+// picking a target from an `exports` entry. We mirror what the lean consumers
+// use (`bun`/`import`) so the traversed graph matches what actually ships.
+const EXPORT_CONDITIONS = ['bun', 'import', 'default'] as const;
 
-/**
- * Pull every stringy field out of a thrown bundler error so the retry matcher
- * can see the real errno text.
- *
- * Bun.build surfaces failures two ways: it may *throw* (most failures, including
- * the transient read errors here), or — for some cases — return
- * `{ success: false, logs }` (which `buildOnce` handles separately above). When
- * it throws, the value is typically an `AggregateError` whose own
- * `String(error)` is only `"AggregateError: Bundle failed"`; the actual
- * per-module diagnostic — e.g. `EISDIR reading file: ".../line-diff.ts"` —
- * lives one level down, on each entry of `error.errors`. We concatenate the
- * top-level string/message with every inner error's string/message and match
- * against that. (Matching `String(error)` alone, as the original guard did,
- * could never catch the read error — which is why the earlier retry was inert.)
- */
-function collectErrorText(error: unknown): string {
-  const parts: string[] = [];
-  const push = (value: unknown): void => {
-    if (value === undefined || value === null) return;
-    if (typeof value === 'string') {
-      parts.push(value);
-      return;
+type PackageJson = {
+  name?: string;
+  exports?: Record<string, unknown>;
+};
+
+const packageJsonCache = new Map<string, PackageJson | null>();
+const scanCache = new Map<string, string[]>();
+const transpiler = new Bun.Transpiler({ loader: 'ts' });
+
+function readPackageJson(packageDir: string): PackageJson | null {
+  if (packageJsonCache.has(packageDir)) return packageJsonCache.get(packageDir) ?? null;
+  const path = join(packageDir, 'package.json');
+  const parsed = existsSync(path) ? (JSON.parse(readFileSync(path, 'utf-8')) as PackageJson) : null;
+  packageJsonCache.set(packageDir, parsed);
+  return parsed;
+}
+
+/** Pick a target string from an `exports` entry, applying conditions in order. */
+function pickConditionTarget(entry: unknown): string | undefined {
+  if (typeof entry === 'string') return entry;
+  if (entry === null || typeof entry !== 'object') return undefined;
+  const record = entry as Record<string, unknown>;
+  for (const condition of EXPORT_CONDITIONS) {
+    if (condition in record) {
+      const picked = pickConditionTarget(record[condition]);
+      if (picked) return picked;
     }
-    if (value instanceof Error) {
-      // `Error.prototype.toString()` yields "Name: message" — the form the
-      // bundler uses for its per-module diagnostics (e.g. the EISDIR text).
-      parts.push(value.toString());
-    } else {
-      const message = (value as { message?: unknown }).message;
-      if (typeof message === 'string') parts.push(message);
-    }
-    const inner = (value as { errors?: unknown }).errors;
-    if (Array.isArray(inner)) {
-      for (const entry of inner) push(entry);
-    }
-  };
-  push(error);
-  return parts.join('\n');
+  }
+  return undefined;
 }
 
 /**
- * Detect the transient filesystem read errors Bun's bundler emits when a source
- * file in the module graph is touched concurrently by another process.
- *
- * Under CI the whole workspace runs `bun run --filter='*' test`, so the
- * `@cinder/diff` package's own `bun test` process reads
- * `packages/diff/src/line-diff.ts` at the same moment this test's `Bun.build`
- * resolves that file through the `@cinder/diff/line-diff` re-export. On Linux
- * (ext4/overlayfs) that cross-process read can momentarily surface as
- * `EISDIR`/`ENOTDIR` while reading a regular `.ts` file; the bundler reports it
- * as `EISDIR reading file: ".../line-diff.ts"` /
- * `Unexpected reading file: ".../line-diff.ts"`, and the underlying libuv form
- * is `EISDIR: illegal operation on a directory, read`. The file is never a
- * directory and a fresh read succeeds; it does not reproduce on macOS/APFS.
- *
- * This retry is a defence-in-depth backstop only — the primary fix is
- * structural (see `bundleSnippet`). It is deliberately narrow: it matches the
- * read-errno families, never a genuine resolution failure or a rendering-payload
- * leak, so a real regression still fails immediately.
+ * Resolve a workspace package subpath (e.g. `@cinder/markdown/diff/line-diff`)
+ * to an absolute SOURCE file path via that package's `exports` map. Returns
+ * undefined for non-workspace (external) packages — those are leaves we only
+ * check by name.
  */
-function isTransientReadError(message: string): boolean {
-  // Match only the known transient forms, never a bare EISDIR/ENOTDIR anywhere
-  // in the message (which could be an unrelated, genuine failure we must not
-  // retry past): the bundler's `<errno> reading file: ...` diagnostic, and the
-  // underlying libuv `EISDIR: illegal operation on a directory, read` form.
-  return /(?:EISDIR|ENOTDIR|Unexpected)[^\n]*reading file|E(?:IS|NOT)DIR:[^\n]*read/.test(
-    message,
+function resolveWorkspaceSubpath(specifier: string): string | undefined {
+  if (!specifier.startsWith('@cinder/')) return undefined;
+  const withoutScope = specifier.slice('@cinder/'.length);
+  const packageName = withoutScope.split('/')[0]!;
+  const subpath = withoutScope.slice(packageName.length); // '' or '/diff/line-diff'
+  const packageDir = join(PACKAGES_DIR, packageName);
+  const packageJson = readPackageJson(packageDir);
+  if (!packageJson?.exports) return undefined;
+
+  const exportKey = subpath === '' ? '.' : `.${subpath}`;
+  const entry = packageJson.exports[exportKey];
+  if (entry === undefined) return undefined;
+  const target = pickConditionTarget(entry);
+  if (!target) return undefined;
+
+  // Prefer the source (.ts) target over a built (.js) one so we traverse the
+  // real graph, not a stale dist build. The `bun` condition already points at
+  // src; if a target resolved to dist, map it back to the src twin.
+  const resolved = resolve(packageDir, target);
+  return toSourcePath(resolved);
+}
+
+/** Map a `dist/.../x.js` path back to its `src/.../x.ts` twin when one exists. */
+function toSourcePath(filePath: string): string | undefined {
+  const candidates = [filePath];
+  if (filePath.includes('/dist/')) {
+    const srcGuess = filePath.replace('/dist/', '/src/').replace(/\.js$/, '.ts');
+    candidates.unshift(srcGuess);
+  }
+  for (const candidate of candidates) {
+    if (existsSync(candidate)) return candidate;
+  }
+  return undefined;
+}
+
+/**
+ * Resolve a relative import specifier (e.g. `./types.js`) from an importer file
+ * to an absolute source path, mapping `.js` → `.ts` and bare dirs → `index.ts`.
+ */
+function resolveRelative(importer: string, specifier: string): string | undefined {
+  const base = resolve(dirname(importer), specifier);
+  const candidates = [
+    base,
+    base.replace(/\.js$/, '.ts'),
+    base.replace(/\.jsx$/, '.tsx'),
+    `${base}.ts`,
+    `${base}.tsx`,
+    join(base, 'index.ts'),
+    join(base, 'index.tsx'),
+  ];
+  for (const candidate of candidates) {
+    if (existsSync(candidate)) return candidate;
+  }
+  return undefined;
+}
+
+/** Runtime import specifiers in a source file (type-only imports excluded). */
+function scanRuntimeImports(filePath: string): string[] {
+  const cached = scanCache.get(filePath);
+  if (cached) return cached;
+  const code = readFileSync(filePath, 'utf-8');
+  const specifiers = transpiler.scanImports(code).map((entry) => entry.path);
+  scanCache.set(filePath, specifiers);
+  return specifiers;
+}
+
+function isForbiddenPackage(specifier: string): boolean {
+  return FORBIDDEN_RENDERING_PACKAGES.some((pkg) =>
+    pkg.endsWith('/')
+      ? specifier.startsWith(pkg)
+      : specifier === pkg || specifier.startsWith(`${pkg}/`),
   );
 }
 
-async function buildOnce(entry: string): Promise<string> {
-  const result = await Bun.build({
-    entrypoints: [entry],
-    target: 'browser',
-    format: 'esm',
-    conditions: ['bun'],
-  });
-  if (!result.success) {
-    throw new Error(`Build failed:\n${result.logs.map(String).join('\n')}`);
-  }
-  const output = result.outputs[0];
-  if (!output) throw new Error('Build produced no output');
-  return await output.text();
-}
+type ReachResult = {
+  /** Forbidden rendering packages reached from the entry subpath. */
+  forbiddenReached: Set<string>;
+  /** Every external (non-relative, non-workspace) bare import reached. */
+  externalsReached: Set<string>;
+};
 
-async function bundleSnippet(snippet: string): Promise<string> {
-  // Build from a temp dir at the WORKSPACE ROOT, never inside packages/markdown.
-  //
-  // Root cause of the Linux-only CI flake: when the entry lived inside
-  // packages/markdown, several of these tests ran concurrently, each doing
-  // `mkdtemp`/`rmSync` of a `.import-graph-*` dir inside the very package tree
-  // that `Bun.build` scans while resolving `@cinder/markdown/*`. On Linux a
-  // directory entry appearing or vanishing inside a tree the resolver is
-  // walking can make it stat a path mid-deletion and report a spurious read
-  // error, which propagates as the EISDIR/Unexpected failure on the deepest
-  // leaf of the graph (`line-diff.ts`). Placing the temp dirs at the workspace
-  // root — siblings of `packages/`, not children of it — removes that
-  // interference entirely while keeping module resolution working.
-  const dir = mkdtempSync(join(WORKSPACE_ROOT, '.import-graph-'));
-  const entry = join(dir, 'entry.ts');
-  writeFileSync(entry, snippet);
-  try {
-    let lastError: unknown;
-    for (let attempt = 1; attempt <= MAX_BUILD_ATTEMPTS; attempt++) {
-      try {
-        return await buildOnce(entry);
-      } catch (error) {
-        lastError = error;
-        // Inspect the AggregateError's inner errors, not just String(error):
-        // the errno text lives there (see collectErrorText).
-        if (attempt < MAX_BUILD_ATTEMPTS && isTransientReadError(collectErrorText(error))) {
-          // Brief backoff so the concurrent reader's file-access window can
-          // close before we retry, instead of re-hitting the race instantly.
-          await Bun.sleep(25 * attempt);
-          continue;
-        }
-        throw error;
+/**
+ * Walk the import graph from a workspace subpath and report which forbidden
+ * rendering packages (and all externals) are reachable. Pure file reads —
+ * no bundler, no resolver that can hit the EISDIR race.
+ */
+function reachFromSubpath(entrySubpath: string): ReachResult {
+  const forbiddenReached = new Set<string>();
+  const externalsReached = new Set<string>();
+  const entryFile = resolveWorkspaceSubpath(entrySubpath);
+  if (!entryFile) {
+    throw new Error(
+      `Could not resolve subpath "${entrySubpath}" to a source file via package exports. ` +
+        `Check the package.json "exports" map and the EXPORT_CONDITIONS order.`,
+    );
+  }
+
+  const visited = new Set<string>();
+  const queue: string[] = [entryFile];
+  while (queue.length > 0) {
+    const file = queue.pop()!;
+    if (visited.has(file)) continue;
+    visited.add(file);
+
+    for (const specifier of scanRuntimeImports(file)) {
+      if (specifier.startsWith('.')) {
+        const next = resolveRelative(file, specifier);
+        if (next) queue.push(next);
+        // An unresolved relative import is a real problem, but not this test's
+        // concern — typecheck/build would catch it. We simply can't follow it.
+        continue;
       }
+      if (specifier.startsWith('@cinder/')) {
+        const next = resolveWorkspaceSubpath(specifier);
+        if (next) queue.push(next);
+        continue;
+      }
+      // External bare import — a graph leaf. Record it; flag if forbidden.
+      externalsReached.add(specifier);
+      if (isForbiddenPackage(specifier)) forbiddenReached.add(specifier);
     }
-    // Unreachable: the loop either returns or throws, but TypeScript needs a
-    // terminal statement after the bounded retry.
-    throw lastError;
-  } finally {
-    rmSync(dir, { recursive: true, force: true });
   }
+
+  return { forbiddenReached, externalsReached };
 }
 
-function assertNoRenderingPayload(bundle: string, label: string): void {
-  for (const marker of RENDERING_MARKERS) {
-    if (bundle.includes(marker)) {
-      throw new Error(
-        `${label}: rendering payload "${marker}" leaked into the bundle. ` +
-          `Importing this subpath should not drag the rendering pipeline. ` +
-          `Check whether a recent change added an "export *" or a deep import ` +
-          `that crosses from a non-rendering module into rendering.`,
-      );
-    }
+function assertLean(entrySubpath: string): void {
+  const { forbiddenReached } = reachFromSubpath(entrySubpath);
+  if (forbiddenReached.size > 0) {
+    throw new Error(
+      `${entrySubpath}: reaches rendering package(s) [${[...forbiddenReached].join(', ')}]. ` +
+        `Importing this subpath should not drag the rendering pipeline. Check for an ` +
+        `"export *" or a deep import that crosses from a non-rendering module into rendering.`,
+    );
   }
 }
 
 describe('import-graph leanness', () => {
   describe('narrow subpaths (no rendering)', () => {
-    it('@cinder/markdown/diff/line-diff does not pull in shiki/katex/rehype-katex', async () => {
-      const bundle = await bundleSnippet(
-        `import * as m from '@cinder/markdown/diff/line-diff';\nglobalThis.__leanGuard__ = m;\n`,
-      );
-      assertNoRenderingPayload(bundle, '@cinder/markdown/diff/line-diff');
-      // Not also asserting "no unified" — line-diff is pure
-      // string-level diff via diff-match-patch; if a regression adds
-      // unified here it'd be caught implicitly by entry-bundle size
-      // budgets in the playground.
-    }, 30_000);
+    it('@cinder/markdown/diff/line-diff does not reach shiki/katex/rehype-katex', () => {
+      assertLean('@cinder/markdown/diff/line-diff');
+    });
   });
 
   describe('aggregate barrels (no rendering; unified allowed)', () => {
-    it('@cinder/markdown/pipeline does not pull in shiki/katex/rehype-katex', async () => {
-      const bundle = await bundleSnippet(
-        `import * as m from '@cinder/markdown/pipeline';\nglobalThis.__leanGuard__ = m;\n`,
-      );
-      assertNoRenderingPayload(bundle, '@cinder/markdown/pipeline');
-    }, 30_000);
+    it('@cinder/markdown/pipeline does not reach shiki/katex/rehype-katex', () => {
+      assertLean('@cinder/markdown/pipeline');
+    });
 
-    it('@cinder/markdown/diff does not pull in shiki/katex/rehype-katex', async () => {
-      const bundle = await bundleSnippet(
-        `import * as m from '@cinder/markdown/diff';\nglobalThis.__leanGuard__ = m;\n`,
-      );
-      assertNoRenderingPayload(bundle, '@cinder/markdown/diff');
-    }, 30_000);
+    it('@cinder/markdown/diff does not reach shiki/katex/rehype-katex', () => {
+      assertLean('@cinder/markdown/diff');
+    });
   });
 
   describe('bare root (no rendering reachable)', () => {
-    it('@cinder/markdown root via diff namespace does not pull rendering', async () => {
-      const bundle = await bundleSnippet(
-        `import { diff } from '@cinder/markdown';\nglobalThis.__leanGuard__ = diff;\n`,
-      );
-      assertNoRenderingPayload(bundle, '@cinder/markdown (diff usage)');
-    }, 30_000);
-
-    it('@cinder/markdown root via pipeline namespace does not pull rendering', async () => {
-      const bundle = await bundleSnippet(
-        `import { pipeline } from '@cinder/markdown';\nglobalThis.__leanGuard__ = pipeline;\n`,
-      );
-      assertNoRenderingPayload(bundle, '@cinder/markdown (pipeline usage)');
-    }, 30_000);
+    it('@cinder/markdown root does not reach rendering', () => {
+      // The root barrel re-exports diff + pipeline only. Whichever namespace a
+      // consumer reaches into, the rendering graph must not be reachable from
+      // the package entry.
+      assertLean('@cinder/markdown');
+    });
   });
 
-  describe('rendering subpath does pull in shiki/katex (sanity check)', () => {
-    // Inverse assertion: importing the rendering namespace MUST contain
-    // EVERY rendering marker. We require all-present rather than
-    // any-present because a subset would let the leanness tests pass
-    // vacuously: if a future bundler change inlines `shiki/core` so the
-    // string no longer appears literally in bundle text, the leanness
-    // tests would also stop seeing it for the lean subpaths — they'd
-    // pass for the wrong reason. Requiring `=== RENDERING_MARKERS.length`
-    // here forces the test suite to fail loudly if a marker becomes
-    // undetectable, prompting an update to the marker list.
-    it('@cinder/markdown/rendering contains every rendering marker', async () => {
-      const bundle = await bundleSnippet(
-        `import * as m from '@cinder/markdown/rendering';\nglobalThis.__leanGuard__ = m;\n`,
-      );
-      const missing = RENDERING_MARKERS.filter((marker) => !bundle.includes(marker));
+  describe('rendering subpath does reach shiki/katex (sanity check)', () => {
+    // Inverse assertion: the rendering namespace MUST reach EVERY forbidden
+    // rendering package. We require all-present (not any-present) so the leanness
+    // tests above cannot pass vacuously — if the rendering graph stopped reaching
+    // one of these (e.g. a dependency was renamed), this fails loudly and prompts
+    // an update to FORBIDDEN_RENDERING_PACKAGES rather than silently weakening the
+    // leanness guarantee.
+    it('@cinder/markdown/rendering reaches every rendering package', () => {
+      const { externalsReached } = reachFromSubpath('@cinder/markdown/rendering');
+      const missing = FORBIDDEN_RENDERING_PACKAGES.filter((pkg) => {
+        const matcher = pkg.endsWith('/') ? pkg : `${pkg}`;
+        return ![...externalsReached].some((reached) =>
+          matcher.endsWith('/')
+            ? reached.startsWith(matcher)
+            : reached === matcher || reached.startsWith(`${matcher}/`),
+        );
+      });
       if (missing.length > 0) {
         throw new Error(
-          `Sanity check failed: rendering bundle is missing markers ${missing.join(', ')}. ` +
-            `The marker list in import-graph.test.ts (RENDERING_MARKERS) is stale relative ` +
-            `to the actual bundle output — likely because of a shiki/katex/bundler version ` +
-            `change. Update RENDERING_MARKERS to use strings that still appear literally ` +
-            `in the rendering bundle, otherwise the leanness tests above can pass vacuously.`,
+          `Sanity check failed: the rendering subpath no longer reaches [${missing.join(', ')}]. ` +
+            `FORBIDDEN_RENDERING_PACKAGES is stale relative to the actual import graph — likely a ` +
+            `dependency rename or refactor. Update the list, otherwise the leanness tests can pass ` +
+            `vacuously. Externals actually reached: [${[...externalsReached].toSorted().join(', ')}].`,
         );
       }
       expect(missing.length).toBe(0);
-    }, 30_000);
+    });
   });
 });

--- a/packages/markdown/src/import-graph.test.ts
+++ b/packages/markdown/src/import-graph.test.ts
@@ -28,12 +28,16 @@
  * does NOT traverse into node_modules, so it would not catch a third-party
  * wrapper that itself pulls in `rehype-katex`. That tradeoff is deliberate and
  * safe here: cinder controls its own direct dependencies, every rendering package
- * cinder could import is in FORBIDDEN_RENDERING_PACKAGES, and the traversal FAILS
- * LOUDLY on any internal edge (relative or `@cinder/*`) it cannot follow — so a
- * rendering dependency can never hide behind a silently-dropped edge. Within
- * cinder's source it is actually STRICTER than the old bundle-text grep: it sees
- * the import even when the bundler would have tree-shaken or renamed the telltale
- * string.
+ * cinder could import is in FORBIDDEN_RENDERING_PACKAGES, and the traversal closes
+ * the two ways an edge could otherwise hide a dependency —
+ *   1. it FAILS LOUDLY on any internal edge (relative or `@cinder/*`) it cannot
+ *      follow, and
+ *   2. it BANS computed dynamic imports (`import(variable)` / interpolated
+ *      `` import(`…${x}…`) ``) in guarded source, since those are invisible to
+ *      static analysis (see `assertNoComputedImport`).
+ * Within cinder's source it is actually STRICTER than the old bundle-text grep:
+ * it sees the import even when the bundler would have tree-shaken or renamed the
+ * telltale string.
  *
  * Categories:
  *
@@ -190,18 +194,44 @@ function resolveRelative(importer: string, specifier: string): string | undefine
  *     loudly (rendering subpath stops reaching them) rather than silently
  *     weakening the leanness tests — which is the safe failure direction.
  *
- * LIMITATION: a COMPUTED dynamic import (`import(someVariable)`) is invisible to
- * static analysis and cannot be followed. None exist in @cinder/markdown source;
- * if one is ever introduced to conditionally load a rendering package, this test
- * (like any static or bundle-grep approach) could not catch it.
+ * COMPUTED dynamic imports (`import(someVariable)`) are invisible to static
+ * analysis and cannot be followed — so rather than silently accept that blind
+ * spot, the traversal BANS them in guarded source (see `assertNoComputedImport`).
+ * A guarded file must use only string-literal dynamic imports, which we CAN see.
  */
 function scanRuntimeImports(filePath: string): string[] {
   const cached = scanCache.get(filePath);
   if (cached) return cached;
   const code = readFileSync(filePath, 'utf-8');
+  assertNoComputedImport(filePath, code);
   const specifiers = transpiler.scanImports(code).map((entry) => entry.path);
   scanCache.set(filePath, specifiers);
   return specifiers;
+}
+
+// A real `import(` call whose first argument is NOT a plain string literal — a
+// computed specifier the traversal could not follow. `scanImports` reports a
+// plain `'…'` / `"…"` / non-interpolated `` `…` `` import (followable) but NOT a
+// variable or an interpolated `` `…${x}…` `` (invisible). So we ban the two
+// invisible forms:
+//   (a) `import(` followed by a first char that is not a quote → a bare
+//       expression like `import(name)` or `import(cond ? a : b)`.
+//   (b) `import(` followed by a backtick whose contents contain `${` → an
+//       interpolated template.
+// `import` must not be preceded by an identifier char (so `reimport(` / `.import(`
+// don't trip it). `import type` and `import {…}` statements aren't `import(`.
+const COMPUTED_IMPORT_BARE = /(?<![\w.$])import\s*\(\s*(?!['"`])/;
+const COMPUTED_IMPORT_TEMPLATE = /(?<![\w.$])import\s*\(\s*`[^`]*\$\{/;
+
+function assertNoComputedImport(filePath: string, code: string): void {
+  if (COMPUTED_IMPORT_BARE.test(code) || COMPUTED_IMPORT_TEMPLATE.test(code)) {
+    throw new Error(
+      `Computed dynamic import found in "${filePath}". A guarded module must use only ` +
+        `string-literal dynamic imports (import('pkg')) so the leanness traversal can follow ` +
+        `them — a computed import(variable) or interpolated import(\`…\${x}…\`) is invisible to ` +
+        `static analysis and could hide a rendering dependency. Use a literal, or restructure.`,
+    );
+  }
 }
 
 /**
@@ -358,28 +388,39 @@ describe('import-graph leanness', () => {
     });
   });
 
-  describe('known limitation: computed dynamic imports are invisible (documented)', () => {
-    // This guards against a SILENT regression in our own assumptions, not in
-    // cinder source: it pins the fact that `scanImports` sees a string-literal
-    // dynamic import but NOT a computed one. If a future Bun started resolving
-    // computed imports (or stopped seeing literal ones), this test changes and
-    // forces us to revisit the traversal's completeness. cinder source contains
-    // no computed dynamic imports today; if one is ever added to conditionally
-    // load a rendering package, neither this static traversal nor the old
-    // bundle-grep could catch it — hence it is called out, not silently ignored.
+  describe('computed dynamic imports are banned in guarded source (not just documented)', () => {
+    // The blind spot — `import(variable)` is invisible to scanImports — is not
+    // merely documented; the traversal BANS it. These tests pin both halves:
+    // (1) scanImports really cannot see a computed specifier (so the ban is the
+    // only thing standing between us and a false negative), and (2) the ban's
+    // detector actually fires on the computed form and stays quiet on the literal
+    // form that the traversal CAN follow.
     it('scanImports sees a literal dynamic import but not a computed one', () => {
       const probe = new Bun.Transpiler({ loader: 'ts' });
       const literal = probe.scanImports(`await import('rehype-katex');`).map((entry) => entry.path);
       const computed = probe
         .scanImports(`const renderer = 'rehype-katex';\nawait import(renderer);`)
         .map((entry) => entry.path);
-
-      // A literal specifier IS seen — so a real `import('rehype-katex')` in source
-      // would be caught by the leanness traversal.
       expect(literal).toContain('rehype-katex');
-      // A computed specifier is NOT seen — the documented blind spot. If this ever
-      // flips, revisit the traversal and this file's header note.
-      expect(computed).not.toContain('rehype-katex');
+      expect(computed).not.toContain('rehype-katex'); // the invisible case the ban covers
+    });
+
+    it('assertNoComputedImport throws on a computed import and accepts a literal one', () => {
+      // Literal forms are fine — the traversal can follow them.
+      expect(() => assertNoComputedImport('ok.ts', `await import('rehype-katex');`)).not.toThrow();
+      expect(() =>
+        assertNoComputedImport('ok.ts', `import { x } from './x.js';\nexport * from './y.js';`),
+      ).not.toThrow();
+      // These must NOT be mistaken for computed dynamic imports.
+      expect(() => assertNoComputedImport('ok.ts', `const reimport = (f) => f;`)).not.toThrow();
+      expect(() => assertNoComputedImport('ok.ts', `obj.import(thing);`)).not.toThrow();
+      // Computed specifiers must throw.
+      expect(() =>
+        assertNoComputedImport('bad.ts', `const r = 'rehype-katex';\nawait import(r);`),
+      ).toThrow(/Computed dynamic import/);
+      expect(() => assertNoComputedImport('bad.ts', `await import(\`./\${name}.js\`);`)).toThrow(
+        /Computed dynamic import/,
+      );
     });
   });
 });

--- a/packages/markdown/src/import-graph.test.ts
+++ b/packages/markdown/src/import-graph.test.ts
@@ -20,10 +20,20 @@
  * source file via the package `exports` map, read each file with `readFileSync`,
  * extract its runtime imports with `Bun.Transpiler.scanImports` (which excludes
  * `import type` / `export type`), resolve each specifier, and recurse. A subpath
- * is "lean" iff no FORBIDDEN rendering package is reachable from it. This is
- * deterministic, immune to filesystem races, and a stricter guarantee than
- * grepping bundle text (it catches a rendering import even if the bundler would
- * have tree-shaken or renamed the telltale strings).
+ * is "lean" iff no FORBIDDEN rendering package is reachable from it. Deterministic
+ * and immune to filesystem races.
+ *
+ * GUARANTEE (and the one way it differs from the old bundler test): this asserts
+ * that cinder's own SOURCE graph never DIRECTLY imports a rendering package. It
+ * does NOT traverse into node_modules, so it would not catch a third-party
+ * wrapper that itself pulls in `rehype-katex`. That tradeoff is deliberate and
+ * safe here: cinder controls its own direct dependencies, every rendering package
+ * cinder could import is in FORBIDDEN_RENDERING_PACKAGES, and the traversal FAILS
+ * LOUDLY on any internal edge (relative or `@cinder/*`) it cannot follow — so a
+ * rendering dependency can never hide behind a silently-dropped edge. Within
+ * cinder's source it is actually STRICTER than the old bundle-text grep: it sees
+ * the import even when the bundler would have tree-shaken or renamed the telltale
+ * string.
  *
  * Categories:
  *
@@ -57,10 +67,15 @@ const FORBIDDEN_RENDERING_PACKAGES = ['shiki', '@shikijs/', 'rehype-katex', 'rem
 const WORKSPACE_ROOT = resolve(import.meta.dirname, '..', '..', '..');
 const PACKAGES_DIR = join(WORKSPACE_ROOT, 'packages');
 
-// The import conditions a bundler/runtime applies, in priority order, when
-// picking a target from an `exports` entry. We mirror what the lean consumers
-// use (`bun`/`import`) so the traversed graph matches what actually ships.
-const EXPORT_CONDITIONS = ['bun', 'import', 'default'] as const;
+// The import conditions to apply, in priority order, when picking a target from
+// an `exports` entry. The old Bun.build version resolved with `target: 'browser'`
+// + `conditions: ['bun']`, so we mirror that: `bun` first, then the implicit
+// browser/import/default chain. (No @cinder/* package actually declares a
+// `browser` condition today, so for cinder's own graph this resolves identically
+// to `bun`→src; `browser` is included so the resolver stays faithful if one is
+// added later.) `types` is intentionally absent — we must never follow a
+// type-only target.
+const EXPORT_CONDITIONS = ['bun', 'browser', 'import', 'default'] as const;
 
 type PackageJson = {
   name?: string;
@@ -82,7 +97,9 @@ function readPackageJson(packageDir: string): PackageJson | null {
 /** Pick a target string from an `exports` entry, applying conditions in order. */
 function pickConditionTarget(entry: unknown): string | undefined {
   if (typeof entry === 'string') return entry;
-  if (entry === null || typeof entry !== 'object') return undefined;
+  // Array-form exports (`["./a.js", "./b.js"]`) and null/primitives are not
+  // condition objects — bail rather than treating an array index as a condition.
+  if (entry === null || typeof entry !== 'object' || Array.isArray(entry)) return undefined;
   const record = entry as Record<string, unknown>;
   for (const condition of EXPORT_CONDITIONS) {
     if (condition in record) {
@@ -121,12 +138,13 @@ function resolveWorkspaceSubpath(specifier: string): string | undefined {
   return toSourcePath(resolved);
 }
 
-/** Map a `dist/.../x.js` path back to its `src/.../x.ts` twin when one exists. */
+/** Map a `dist/.../x.js` export target back to its `src/.../x.ts` twin. */
 function toSourcePath(filePath: string): string | undefined {
   const candidates = [filePath];
   if (filePath.includes('/dist/')) {
-    const srcGuess = filePath.replace('/dist/', '/src/').replace(/\.js$/, '.ts');
-    candidates.unshift(srcGuess);
+    const srcBase = filePath.replace('/dist/', '/src/');
+    // Prefer the source twin; cover both .js→.ts and .jsx→.tsx.
+    candidates.unshift(srcBase.replace(/\.jsx$/, '.tsx'), srcBase.replace(/\.js$/, '.ts'));
   }
   for (const candidate of candidates) {
     if (existsSync(candidate)) return candidate;
@@ -186,12 +204,21 @@ function scanRuntimeImports(filePath: string): string[] {
   return specifiers;
 }
 
+/**
+ * Whether an imported `specifier` belongs to a forbidden-package `entry`. A
+ * trailing-slash entry (e.g. `@shikijs/`) matches any scoped subpath; a plain
+ * entry (e.g. `shiki`) matches the package itself or any of its subpaths
+ * (`shiki`, `shiki/core`, …) but not an unrelated package that merely shares a
+ * prefix (`shiki-foo`).
+ */
+function matchesPackage(specifier: string, entry: string): boolean {
+  return entry.endsWith('/')
+    ? specifier.startsWith(entry)
+    : specifier === entry || specifier.startsWith(`${entry}/`);
+}
+
 function isForbiddenPackage(specifier: string): boolean {
-  return FORBIDDEN_RENDERING_PACKAGES.some((pkg) =>
-    pkg.endsWith('/')
-      ? specifier.startsWith(pkg)
-      : specifier === pkg || specifier.startsWith(`${pkg}/`),
-  );
+  return FORBIDDEN_RENDERING_PACKAGES.some((entry) => matchesPackage(specifier, entry));
 }
 
 type ReachResult = {
@@ -225,19 +252,42 @@ function reachFromSubpath(entrySubpath: string): ReachResult {
     visited.add(file);
 
     for (const specifier of scanRuntimeImports(file)) {
+      // A relative or workspace (@cinder/*) import MUST resolve to a source file
+      // we can follow. If it doesn't, we'd silently drop that subgraph — the
+      // exact false negative this test exists to prevent (a rendering dependency
+      // could hide behind an unfollowed edge). So fail loudly instead of skipping.
       if (specifier.startsWith('.')) {
         const next = resolveRelative(file, specifier);
-        if (next) queue.push(next);
-        // An unresolved relative import is a real problem, but not this test's
-        // concern — typecheck/build would catch it. We simply can't follow it.
+        if (!next) {
+          throw new Error(
+            `Unresolvable relative import "${specifier}" from "${file}". The leanness ` +
+              `traversal must follow every internal edge — a dropped edge could hide a ` +
+              `rendering dependency. Fix the resolver's extension/index candidates or the import.`,
+          );
+        }
+        queue.push(next);
         continue;
       }
       if (specifier.startsWith('@cinder/')) {
         const next = resolveWorkspaceSubpath(specifier);
-        if (next) queue.push(next);
+        if (!next) {
+          throw new Error(
+            `Unresolvable workspace import "${specifier}" from "${file}". It does not map to a ` +
+              `declared export in the target package's package.json "exports". The traversal must ` +
+              `follow every @cinder/* edge; an internal deep import that bypasses exports (or a ` +
+              `missing export entry) could hide a rendering dependency. Declare the export or fix the import.`,
+          );
+        }
+        queue.push(next);
         continue;
       }
-      // External bare import — a graph leaf. Record it; flag if forbidden.
+      // External (non-workspace) bare import — a graph leaf. We record its NAME
+      // and flag it if forbidden, but do NOT traverse into node_modules. This
+      // means the guarantee is "cinder source does not DIRECTLY import a rendering
+      // package", not "no rendering bytes are transitively bundled". See the file
+      // header. A `wrapper-pkg` that itself imports `rehype-katex` would not be
+      // caught here — but cinder controls its own direct deps, and the forbidden
+      // list names every rendering package cinder could import.
       externalsReached.add(specifier);
       if (isForbiddenPackage(specifier)) forbiddenReached.add(specifier);
     }
@@ -292,14 +342,10 @@ describe('import-graph leanness', () => {
     // leanness guarantee.
     it('@cinder/markdown/rendering reaches every rendering package', () => {
       const { externalsReached } = reachFromSubpath('@cinder/markdown/rendering');
-      const missing = FORBIDDEN_RENDERING_PACKAGES.filter((pkg) => {
-        const matcher = pkg.endsWith('/') ? pkg : `${pkg}`;
-        return ![...externalsReached].some((reached) =>
-          matcher.endsWith('/')
-            ? reached.startsWith(matcher)
-            : reached === matcher || reached.startsWith(`${matcher}/`),
-        );
-      });
+      const reached = [...externalsReached];
+      const missing = FORBIDDEN_RENDERING_PACKAGES.filter(
+        (entry) => !reached.some((specifier) => matchesPackage(specifier, entry)),
+      );
       if (missing.length > 0) {
         throw new Error(
           `Sanity check failed: the rendering subpath no longer reaches [${missing.join(', ')}]. ` +
@@ -309,6 +355,31 @@ describe('import-graph leanness', () => {
         );
       }
       expect(missing.length).toBe(0);
+    });
+  });
+
+  describe('known limitation: computed dynamic imports are invisible (documented)', () => {
+    // This guards against a SILENT regression in our own assumptions, not in
+    // cinder source: it pins the fact that `scanImports` sees a string-literal
+    // dynamic import but NOT a computed one. If a future Bun started resolving
+    // computed imports (or stopped seeing literal ones), this test changes and
+    // forces us to revisit the traversal's completeness. cinder source contains
+    // no computed dynamic imports today; if one is ever added to conditionally
+    // load a rendering package, neither this static traversal nor the old
+    // bundle-grep could catch it — hence it is called out, not silently ignored.
+    it('scanImports sees a literal dynamic import but not a computed one', () => {
+      const probe = new Bun.Transpiler({ loader: 'ts' });
+      const literal = probe.scanImports(`await import('rehype-katex');`).map((entry) => entry.path);
+      const computed = probe
+        .scanImports(`const renderer = 'rehype-katex';\nawait import(renderer);`)
+        .map((entry) => entry.path);
+
+      // A literal specifier IS seen — so a real `import('rehype-katex')` in source
+      // would be caught by the leanness traversal.
+      expect(literal).toContain('rehype-katex');
+      // A computed specifier is NOT seen — the documented blind spot. If this ever
+      // flips, revisit the traversal and this file's header note.
+      expect(computed).not.toContain('rehype-katex');
     });
   });
 });

--- a/packages/markdown/src/import-graph.test.ts
+++ b/packages/markdown/src/import-graph.test.ts
@@ -32,9 +32,10 @@
  * the two ways an edge could otherwise hide a dependency —
  *   1. it FAILS LOUDLY on any internal edge (relative or `@cinder/*`) it cannot
  *      follow, and
- *   2. it BANS computed dynamic imports (`import(variable)` / interpolated
- *      `` import(`…${x}…`) ``) in guarded source, since those are invisible to
- *      static analysis (see `assertNoComputedImport`).
+ *   2. it BANS computed dynamic imports AND computed `require(...)` calls
+ *      (`import(variable)`, `require('a'+b)`, interpolated `` import(`…${x}…`) ``)
+ *      in guarded source, since those are invisible to static analysis (see
+ *      `assertNoComputedImport`).
  * Within cinder's source it is actually STRICTER than the old bundle-text grep:
  * it sees the import even when the bundler would have tree-shaken or renamed the
  * telltale string.
@@ -211,30 +212,41 @@ function scanRuntimeImports(filePath: string): string[] {
   return specifiers;
 }
 
-// Ban any dynamic `import()` whose specifier is NOT a plain string literal or a
-// no-substitution template — those are the only forms `scanImports` (and any
-// static analysis) can follow. Anything else — `import(variable)`,
-// `import('a' + b)`, `import(\`./\${x}\`)`, `import(cond ? a : c)` — is a computed
-// specifier that could hide a rendering dependency at runtime.
+// Ban any dynamic `import(...)` OR `require(...)` whose specifier is NOT a plain
+// string literal or a no-substitution template — those are the only forms
+// `scanImports` (and any static analysis) can follow. `scanImports` reports both
+// `dynamic-import` and `require-call` entries, so both have the SAME blind spot:
+// a computed specifier — `import(variable)`, `require('a' + b)`,
+// `import(\`./\${x}\`)`, `require(cond ? a : c)` — could hide a rendering
+// dependency at runtime while being invisible to the traversal.
 //
 // This uses a real TypeScript AST rather than a regex: a textual scan both MISSES
 // computed expressions that begin with a literal (`import('a' + name)`) and
-// FALSE-POSITIVES on `import(` text inside comments or strings. The AST sees only
-// genuine `import(...)` call expressions and inspects the actual first argument.
+// FALSE-POSITIVES on `import(`/`require(` text inside comments or strings. The AST
+// sees only genuine call expressions and inspects the actual first argument.
 function assertNoComputedImport(filePath: string, code: string): void {
   const sourceFile = ts.createSourceFile(filePath, code, ts.ScriptTarget.Latest, true);
   const offenders: string[] = [];
 
+  const isDynamicImport = (node: ts.CallExpression): boolean =>
+    node.expression.kind === ts.SyntaxKind.ImportKeyword;
+  // A bare `require(...)` call (require as a plain identifier, not `foo.require`).
+  const isRequireCall = (node: ts.CallExpression): boolean =>
+    ts.isIdentifier(node.expression) && node.expression.text === 'require';
+
   const visit = (node: ts.Node): void => {
     if (
       ts.isCallExpression(node) &&
-      node.expression.kind === ts.SyntaxKind.ImportKeyword &&
-      node.arguments.length > 0
+      node.arguments.length > 0 &&
+      (isDynamicImport(node) || isRequireCall(node))
     ) {
       const specifier = node.arguments[0]!;
       const isFollowable =
         ts.isStringLiteral(specifier) || ts.isNoSubstitutionTemplateLiteral(specifier);
-      if (!isFollowable) offenders.push(specifier.getText(sourceFile));
+      if (!isFollowable) {
+        const kind = isRequireCall(node) ? 'require' : 'import';
+        offenders.push(`${kind}(${specifier.getText(sourceFile)})`);
+      }
     }
     ts.forEachChild(node, visit);
   };
@@ -242,10 +254,10 @@ function assertNoComputedImport(filePath: string, code: string): void {
 
   if (offenders.length > 0) {
     throw new Error(
-      `Computed dynamic import(s) found in "${filePath}": ${offenders.join(', ')}. A guarded ` +
-        `module must use only string-literal dynamic imports (import('pkg')) so the leanness ` +
-        `traversal can follow them — a computed specifier is invisible to static analysis and ` +
-        `could hide a rendering dependency. Use a literal, or restructure.`,
+      `Computed dynamic import/require found in "${filePath}": ${offenders.join(', ')}. A guarded ` +
+        `module must use only string-literal dynamic imports/requires so the leanness traversal can ` +
+        `follow them — a computed specifier is invisible to static analysis and could hide a ` +
+        `rendering dependency. Use a literal, or restructure.`,
     );
   }
 }
@@ -429,10 +441,15 @@ describe('import-graph leanness', () => {
       expect(() =>
         assertNoComputedImport('ok.ts', `import { x } from './x.js';\nexport * from './y.js';`),
       ).not.toThrow();
-      // Not dynamic imports at all — must NOT false-positive (the AST sees these
-      // for what they are: an identifier, a member call, a comment, a string).
+      // Literal require() is followable too (scanImports reports require-call).
+      expect(() =>
+        assertNoComputedImport('ok.ts', `const x = require('rehype-katex');`),
+      ).not.toThrow();
+      // Not dynamic imports/requires at all — must NOT false-positive (the AST
+      // sees these for what they are: an identifier, member calls, a comment, a string).
       expect(() => assertNoComputedImport('ok.ts', `const reimport = (f) => f;`)).not.toThrow();
       expect(() => assertNoComputedImport('ok.ts', `obj.import(thing);`)).not.toThrow();
+      expect(() => assertNoComputedImport('ok.ts', `mod.require(thing);`)).not.toThrow();
       expect(() =>
         assertNoComputedImport('ok.ts', `// do not write import(renderer)\nconst s = "import(x)";`),
       ).not.toThrow();
@@ -440,15 +457,22 @@ describe('import-graph leanness', () => {
       // bare variable, string concatenation, interpolated template, conditional.
       expect(() =>
         assertNoComputedImport('bad.ts', `const r = 'rehype-katex';\nawait import(r);`),
-      ).toThrow(/Computed dynamic import/);
+      ).toThrow(/Computed dynamic import\/require/);
       expect(() => assertNoComputedImport('bad.ts', `await import('rehype-' + name);`)).toThrow(
-        /Computed dynamic import/,
+        /Computed dynamic import\/require/,
       );
       expect(() => assertNoComputedImport('bad.ts', `await import(\`./\${name}.js\`);`)).toThrow(
-        /Computed dynamic import/,
+        /Computed dynamic import\/require/,
       );
       expect(() => assertNoComputedImport('bad.ts', `await import(flag ? 'a' : 'b');`)).toThrow(
-        /Computed dynamic import/,
+        /Computed dynamic import\/require/,
+      );
+      // Computed require() has the same blind spot and must throw too.
+      expect(() => assertNoComputedImport('bad.ts', `const x = require(pkgName);`)).toThrow(
+        /Computed dynamic import\/require/,
+      );
+      expect(() => assertNoComputedImport('bad.ts', `const x = require('rehype-' + n);`)).toThrow(
+        /Computed dynamic import\/require/,
       );
     });
   });

--- a/packages/markdown/src/import-graph.test.ts
+++ b/packages/markdown/src/import-graph.test.ts
@@ -155,7 +155,28 @@ function resolveRelative(importer: string, specifier: string): string | undefine
   return undefined;
 }
 
-/** Runtime import specifiers in a source file (type-only imports excluded). */
+/**
+ * Runtime import specifiers in a source file.
+ *
+ * `scanImports` returns `import-statement` (static `import`/`export … from`,
+ * including `export * from`), `dynamic-import` (`import('…')`), and
+ * `require-call` entries, and EXCLUDES `import type` / `export type`. We keep ALL
+ * of those kinds deliberately:
+ *   - `export * from`/`export { } from` are exactly the accidental re-exports
+ *     this leanness guard exists to catch — they must be followed.
+ *   - a `dynamic-import` is still a real bundle dependency (it ships in the
+ *     artifact), so we treat it as reachable. This is also load-bearing for the
+ *     sanity check: @cinder/markdown/rendering reaches `remark-math` /
+ *     `rehype-katex` only via dynamic imports in render.ts. If a future Bun
+ *     dropped dynamic imports from scanImports, the sanity check would fail
+ *     loudly (rendering subpath stops reaching them) rather than silently
+ *     weakening the leanness tests — which is the safe failure direction.
+ *
+ * LIMITATION: a COMPUTED dynamic import (`import(someVariable)`) is invisible to
+ * static analysis and cannot be followed. None exist in @cinder/markdown source;
+ * if one is ever introduced to conditionally load a rendering package, this test
+ * (like any static or bundle-grep approach) could not catch it.
+ */
 function scanRuntimeImports(filePath: string): string[] {
   const cached = scanCache.get(filePath);
   if (cached) return cached;

--- a/packages/markdown/src/import-graph.test.ts
+++ b/packages/markdown/src/import-graph.test.ts
@@ -55,6 +55,8 @@ import { describe, expect, it } from 'bun:test';
 import { existsSync, readFileSync } from 'node:fs';
 import { dirname, join, resolve } from 'node:path';
 
+import ts from 'typescript';
+
 // Rendering-only packages that cinder's source imports DIRECTLY. A lean subpath
 // must not reach any of these; the rendering subpath must reach all of them.
 // Matched as exact package names or scoped-package prefixes (e.g. any
@@ -209,27 +211,41 @@ function scanRuntimeImports(filePath: string): string[] {
   return specifiers;
 }
 
-// A real `import(` call whose first argument is NOT a plain string literal — a
-// computed specifier the traversal could not follow. `scanImports` reports a
-// plain `'…'` / `"…"` / non-interpolated `` `…` `` import (followable) but NOT a
-// variable or an interpolated `` `…${x}…` `` (invisible). So we ban the two
-// invisible forms:
-//   (a) `import(` followed by a first char that is not a quote → a bare
-//       expression like `import(name)` or `import(cond ? a : b)`.
-//   (b) `import(` followed by a backtick whose contents contain `${` → an
-//       interpolated template.
-// `import` must not be preceded by an identifier char (so `reimport(` / `.import(`
-// don't trip it). `import type` and `import {…}` statements aren't `import(`.
-const COMPUTED_IMPORT_BARE = /(?<![\w.$])import\s*\(\s*(?!['"`])/;
-const COMPUTED_IMPORT_TEMPLATE = /(?<![\w.$])import\s*\(\s*`[^`]*\$\{/;
-
+// Ban any dynamic `import()` whose specifier is NOT a plain string literal or a
+// no-substitution template — those are the only forms `scanImports` (and any
+// static analysis) can follow. Anything else — `import(variable)`,
+// `import('a' + b)`, `import(\`./\${x}\`)`, `import(cond ? a : c)` — is a computed
+// specifier that could hide a rendering dependency at runtime.
+//
+// This uses a real TypeScript AST rather than a regex: a textual scan both MISSES
+// computed expressions that begin with a literal (`import('a' + name)`) and
+// FALSE-POSITIVES on `import(` text inside comments or strings. The AST sees only
+// genuine `import(...)` call expressions and inspects the actual first argument.
 function assertNoComputedImport(filePath: string, code: string): void {
-  if (COMPUTED_IMPORT_BARE.test(code) || COMPUTED_IMPORT_TEMPLATE.test(code)) {
+  const sourceFile = ts.createSourceFile(filePath, code, ts.ScriptTarget.Latest, true);
+  const offenders: string[] = [];
+
+  const visit = (node: ts.Node): void => {
+    if (
+      ts.isCallExpression(node) &&
+      node.expression.kind === ts.SyntaxKind.ImportKeyword &&
+      node.arguments.length > 0
+    ) {
+      const specifier = node.arguments[0]!;
+      const isFollowable =
+        ts.isStringLiteral(specifier) || ts.isNoSubstitutionTemplateLiteral(specifier);
+      if (!isFollowable) offenders.push(specifier.getText(sourceFile));
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(sourceFile);
+
+  if (offenders.length > 0) {
     throw new Error(
-      `Computed dynamic import found in "${filePath}". A guarded module must use only ` +
-        `string-literal dynamic imports (import('pkg')) so the leanness traversal can follow ` +
-        `them — a computed import(variable) or interpolated import(\`…\${x}…\`) is invisible to ` +
-        `static analysis and could hide a rendering dependency. Use a literal, or restructure.`,
+      `Computed dynamic import(s) found in "${filePath}": ${offenders.join(', ')}. A guarded ` +
+        `module must use only string-literal dynamic imports (import('pkg')) so the leanness ` +
+        `traversal can follow them — a computed specifier is invisible to static analysis and ` +
+        `could hide a rendering dependency. Use a literal, or restructure.`,
     );
   }
 }
@@ -405,20 +421,33 @@ describe('import-graph leanness', () => {
       expect(computed).not.toContain('rehype-katex'); // the invisible case the ban covers
     });
 
-    it('assertNoComputedImport throws on a computed import and accepts a literal one', () => {
-      // Literal forms are fine — the traversal can follow them.
+    it('assertNoComputedImport allows only literal specifiers and catches every computed shape', () => {
+      // Followable forms — string literal, no-substitution template, static
+      // statements — are fine.
       expect(() => assertNoComputedImport('ok.ts', `await import('rehype-katex');`)).not.toThrow();
+      expect(() => assertNoComputedImport('ok.ts', `await import(\`./plain.js\`);`)).not.toThrow();
       expect(() =>
         assertNoComputedImport('ok.ts', `import { x } from './x.js';\nexport * from './y.js';`),
       ).not.toThrow();
-      // These must NOT be mistaken for computed dynamic imports.
+      // Not dynamic imports at all — must NOT false-positive (the AST sees these
+      // for what they are: an identifier, a member call, a comment, a string).
       expect(() => assertNoComputedImport('ok.ts', `const reimport = (f) => f;`)).not.toThrow();
       expect(() => assertNoComputedImport('ok.ts', `obj.import(thing);`)).not.toThrow();
-      // Computed specifiers must throw.
+      expect(() =>
+        assertNoComputedImport('ok.ts', `// do not write import(renderer)\nconst s = "import(x)";`),
+      ).not.toThrow();
+      // Every computed shape must throw — including the ones a regex bypass missed:
+      // bare variable, string concatenation, interpolated template, conditional.
       expect(() =>
         assertNoComputedImport('bad.ts', `const r = 'rehype-katex';\nawait import(r);`),
       ).toThrow(/Computed dynamic import/);
+      expect(() => assertNoComputedImport('bad.ts', `await import('rehype-' + name);`)).toThrow(
+        /Computed dynamic import/,
+      );
       expect(() => assertNoComputedImport('bad.ts', `await import(\`./\${name}.js\`);`)).toThrow(
+        /Computed dynamic import/,
+      );
+      expect(() => assertNoComputedImport('bad.ts', `await import(flag ? 'a' : 'b');`)).toThrow(
         /Computed dynamic import/,
       );
     });


### PR DESCRIPTION
## Summary

`packages/markdown/src/import-graph.test.ts` intermittently fails `main-green` on Linux CI with `EISDIR reading file: ".../packages/diff/src/line-diff.ts"`. This rewrites the test to eliminate the race at its root.

**Root cause** (confirmed via a second-opinion analysis): *not* a normal concurrent-read race (POSIX allows that). It's a **Bun bundler / libuv / overlayfs path-confusion** that surfaces when `Bun.build` walks the live workspace graph (reading `line-diff.ts` as the deepest leaf) while `@cinder/diff`'s own `bun test` process touches that same file under `bun run --filter='*' test`. Prior PRs #213/#214 added retries — those only lowered the probability.

**Fix:** replace `Bun.build` with a **static import-graph traversal**. Resolve each subpath to its source `.ts` via the package `exports` map (conditions `bun > browser > import > default`), read with `readFileSync`, extract runtime imports via `Bun.Transpiler.scanImports` (excludes `import type`; includes `export * from` + dynamic imports), resolve + recurse, and fail if a forbidden rendering package (`shiki`/`@shikijs/`/`rehype-katex`/`remark-math`) is reachable. Pure file reads — no bundler, immune to the race, ~18ms vs ~340ms/assertion.

**Stricter, and closes every edge-hiding path** the committee surfaced:
- FAILS LOUDLY on any internal (relative or `@cinder/*`) edge it cannot follow — a dropped edge can't silently hide a dependency.
- BANS computed dynamic imports (`import(variable)`, `import('a'+b)`, interpolated templates, conditionals) in guarded source via a **TypeScript AST** check — those are invisible to static analysis.
- Guarantee made explicit: asserts cinder *source* never *directly* imports a rendering package (does not traverse node_modules); safe because cinder controls its direct deps and the forbidden list is complete.

## Review committee

Pre-reviewed by: testing-expert, typescript-expert, simplicity-engineer
- Codex (gpt-5.4, xhigh reasoning) — **4 rounds**
- All must-fix items addressed

Codex drove the robustness: it caught the silent-unresolved-edge false negative, then that computed imports were documented-but-not-enforced, then a regex bypass for literal-prefixed computed expressions — leading to the final AST-based detector.

## Test plan

- `bun test src/import-graph.test.ts` — 7 pass / 0 fail (incl. computed-import enforcement covering variable / concatenation / interpolated-template / conditional, and must-not-trip cases: `reimport(`, `obj.import()`, `import(` in comments and strings).
- Full `@cinder/markdown` suite: 752 tests / 0 fail. Verified clean across repeated runs **and concurrently with `@cinder/diff`** (the original race scenario).
- typecheck + lint + format clean; pre-commit + pre-push green.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change in import-graph.test.ts; no production runtime or API behavior changes, only how bundle-bloat regressions are guarded in CI.
> 
> **Overview**
> Replaces the `@cinder/markdown` **import-graph leanness** guard so it no longer bundles subpaths with `Bun.build` (which caused intermittent Linux CI `EISDIR` failures on `line-diff.ts`). The test now **walks the workspace source graph statically**: resolve entries via `package.json` `exports`, read files, collect runtime imports with `Bun.Transpiler.scanImports`, and recurse while flagging direct imports of forbidden rendering packages (`shiki`, `@shikijs/*`, `rehype-katex`, `remark-math`).
> 
> The new approach is **stricter in-repo** than grepping bundle text: unresolved relative or `@cinder/*` edges **fail loudly**, and **computed** `import(...)` / `require(...)` specifiers are **banned** via a TypeScript AST check so dependencies cannot hide from static analysis. Leanness cases stay the same (lean subpaths/root/barrels); the rendering subpath sanity check now asserts those packages are **reachable** in the graph, with added tests pinning `scanImports` behavior and the computed-import ban.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 621e03e2448297eba8b0551a091ba976835df83d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->