### PR TITLE
feat(testing): dependency-aware test scoping

### DIFF
--- a/.github/workflows/browser-tests.yaml
+++ b/.github/workflows/browser-tests.yaml
@@ -97,7 +97,9 @@ jobs:
             exit 0
           fi
 
-          changed=$(git diff --name-only "origin/${BASE_REF}..HEAD")
+          # Three-dot: diff against the merge base, so only the PR's own changes
+          # are considered (not commits that landed on the base since the fork).
+          changed=$(git diff --name-only "origin/${BASE_REF}...HEAD")
           echo "Changed files:"
           printf '%s\n' "$changed"
 

--- a/.github/workflows/browser-tests.yaml
+++ b/.github/workflows/browser-tests.yaml
@@ -1,12 +1,19 @@
 name: browser-tests
 
 on:
+  # This paths list must include every root path that the scoper's
+  # pathForceFullReason() force-fulls; otherwise a PR changing only such a file
+  # would not trigger this workflow and the change would skip the suite entirely.
   pull_request:
     paths:
       - 'packages/**'
-      - '.github/workflows/browser-tests.yaml'
+      - '.github/workflows/**'
       - 'package.json'
       - 'bun.lock'
+      - 'bun.lockb'
+      - 'bunfig.toml'
+      - '.npmrc'
+      - 'tsconfig*.json'
       - '!packages/**/*.md'
       - '!packages/**/README*'
       - '!packages/**/CHANGELOG*'
@@ -15,9 +22,13 @@ on:
       - main
     paths:
       - 'packages/**'
-      - '.github/workflows/browser-tests.yaml'
+      - '.github/workflows/**'
       - 'package.json'
       - 'bun.lock'
+      - 'bun.lockb'
+      - 'bunfig.toml'
+      - '.npmrc'
+      - 'tsconfig*.json'
       - '!packages/**/*.md'
       - '!packages/**/README*'
       - '!packages/**/CHANGELOG*'

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -16,12 +16,21 @@ name: unit-tests
 # silently skip a test.
 
 on:
+  # NOTE: this paths list must include EVERY root path that
+  # pathForceFullReason() treats as a force-full trigger. If a force-full path
+  # is omitted here, a PR changing only that file would not trigger the
+  # workflow at all — the scoper would never run and a change that should
+  # force-full the suite would silently run nothing. Keep the two in sync.
   pull_request:
     paths:
       - 'packages/**'
-      - '.github/workflows/unit-tests.yaml'
+      - '.github/workflows/**'
       - 'package.json'
       - 'bun.lock'
+      - 'bun.lockb'
+      - 'bunfig.toml'
+      - '.npmrc'
+      - 'tsconfig*.json'
       - '!packages/**/*.md'
       - '!packages/**/README*'
       - '!packages/**/CHANGELOG*'
@@ -30,9 +39,13 @@ on:
       - main
     paths:
       - 'packages/**'
-      - '.github/workflows/unit-tests.yaml'
+      - '.github/workflows/**'
       - 'package.json'
       - 'bun.lock'
+      - 'bun.lockb'
+      - 'bunfig.toml'
+      - '.npmrc'
+      - 'tsconfig*.json'
       - '!packages/**/*.md'
       - '!packages/**/README*'
       - '!packages/**/CHANGELOG*'
@@ -72,6 +85,13 @@ jobs:
         uses: oven-sh/setup-bun@v1
         with:
           bun-version: ${{ env.BUN_VERSION }}
+
+      # No `bun install` here by design: changed-components.ts and the
+      # component-graph module it imports use ONLY Bun/Node built-ins and
+      # relative-path imports — no npm dependencies, no workspace package
+      # resolution. Verified to run in a fresh checkout with no node_modules.
+      # If the graph ever gains a third-party import, add a cache + `bun install
+      # --frozen-lockfile` step here (mirroring the unit-tests job).
 
       - name: Decide scope
         id: decide

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -42,8 +42,11 @@ permissions:
   contents: read
 
 concurrency:
-  group: unit-tests-${{ github.ref }}
-  cancel-in-progress: true
+  # PR runs cancel each other (superseded by a new push to the same PR). Push-to-main
+  # runs each get a unique group (keyed by SHA) so a rapid follow-up merge never cancels
+  # the in-flight full-suite safety-net run.
+  group: unit-tests-${{ github.ref }}-${{ github.event_name == 'pull_request' && github.event.pull_request.number || github.sha }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:
   BUN_VERSION: 1.3.13
@@ -52,6 +55,7 @@ jobs:
   scope:
     # Compute the scoped slug set for a pull request. Non-PR events run full.
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     outputs:
       mode: ${{ steps.decide.outputs.mode }}
       components: ${{ steps.decide.outputs.components }}
@@ -83,7 +87,10 @@ jobs:
             exit 0
           fi
 
-          changed=$(git diff --name-only "origin/${BASE_REF}..HEAD")
+          # Three-dot: diff against the merge base, so only the PR's own changes
+          # are considered (not commits that landed on the base since the fork).
+          # Matches test-changed.ts's local behavior.
+          changed=$(git diff --name-only "origin/${BASE_REF}...HEAD")
           echo "Changed files:"
           printf '%s\n' "$changed"
 
@@ -120,8 +127,10 @@ jobs:
         # (and the ~11-min playground suite would otherwise tax every PR).
         # Per-package dependency scoping is the deferred follow-up.
         env:
-          # Empty when mode=full → test-changed.ts runs the full suite.
-          # Comma-separated slug list when filtered → scoped to those dirs.
+          # CINDER_TEST_MODE is the explicit signal: `full` → test-changed.ts runs
+          # the full suite without touching git (the checkout here is shallow).
+          # `filtered` → CINDER_TEST_COMPONENTS carries the scoped slug list.
+          CINDER_TEST_MODE: ${{ needs.scope.outputs.mode }}
           CINDER_TEST_COMPONENTS: ${{ needs.scope.outputs.mode == 'filtered' && needs.scope.outputs.components || '' }}
         run: |
           if [ -n "${CINDER_TEST_COMPONENTS:-}" ]; then

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -1,0 +1,132 @@
+name: unit-tests
+
+# Dependency-aware unit tests for the component library.
+#
+# On a pull request this scopes `bun test` to the changed components AND their
+# transitive dependents (the same import-graph the browser-tests `scope` job
+# uses), giving fast per-PR unit feedback that previously only existed
+# post-merge in `main-green`. On push to `main` and `workflow_dispatch` it runs
+# the FULL unit suite — `main-green` remains the authoritative full-suite gate,
+# and this push run is a redundant safety net.
+#
+# Scope decision lives in packages/testing/scripts/changed-components.ts
+# (delegating to packages/components/scripts/component-graph.ts). It force-fulls
+# on any uncertainty (shared/harness/config change, deletion, computed dynamic
+# import, ambiguous resolution, unknown slug), so a missed edge can never
+# silently skip a test.
+
+on:
+  pull_request:
+    paths:
+      - 'packages/**'
+      - '.github/workflows/unit-tests.yaml'
+      - 'package.json'
+      - 'bun.lock'
+      - '!packages/**/*.md'
+      - '!packages/**/README*'
+      - '!packages/**/CHANGELOG*'
+  push:
+    branches:
+      - main
+    paths:
+      - 'packages/**'
+      - '.github/workflows/unit-tests.yaml'
+      - 'package.json'
+      - 'bun.lock'
+      - '!packages/**/*.md'
+      - '!packages/**/README*'
+      - '!packages/**/CHANGELOG*'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: unit-tests-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  BUN_VERSION: 1.3.13
+
+jobs:
+  scope:
+    # Compute the scoped slug set for a pull request. Non-PR events run full.
+    runs-on: ubuntu-latest
+    outputs:
+      mode: ${{ steps.decide.outputs.mode }}
+      components: ${{ steps.decide.outputs.components }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          # The graph reads source files at HEAD and detects deletions by disk
+          # absence; the diff needs the merge base. fetch-depth: 0 is the
+          # simplest reliable option (the scope job is fast regardless).
+          fetch-depth: 0
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v1
+        with:
+          bun-version: ${{ env.BUN_VERSION }}
+
+      - name: Decide scope
+        id: decide
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          BASE_REF: ${{ github.base_ref }}
+        run: |
+          set -euo pipefail
+          if [ "$EVENT_NAME" != "pull_request" ]; then
+            echo "Non-PR event ($EVENT_NAME): running full unit suite."
+            echo "mode=full" >> "$GITHUB_OUTPUT"
+            echo "components=" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          changed=$(git diff --name-only "origin/${BASE_REF}..HEAD")
+          echo "Changed files:"
+          printf '%s\n' "$changed"
+
+          printf '%s\n' "$changed" | bun run packages/testing/scripts/changed-components.ts
+
+  unit-tests:
+    needs: scope
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v1
+        with:
+          bun-version: ${{ env.BUN_VERSION }}
+
+      - name: Cache Bun install
+        uses: actions/cache@v4
+        with:
+          path: ~/.bun/install/cache
+          key: bun-${{ runner.os }}-${{ runner.arch }}-${{ env.BUN_VERSION }}-${{ hashFiles('bun.lock') }}
+          restore-keys: |
+            bun-${{ runner.os }}-${{ runner.arch }}-${{ env.BUN_VERSION }}-
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Run component unit tests (scoped)
+        # Scopes the `cinder` (components) package to the changed components and
+        # their dependents. Sibling @cinder/* package suites are intentionally
+        # NOT run here — they keep their authoritative coverage in `main-green`
+        # (and the ~11-min playground suite would otherwise tax every PR).
+        # Per-package dependency scoping is the deferred follow-up.
+        env:
+          # Empty when mode=full → test-changed.ts runs the full suite.
+          # Comma-separated slug list when filtered → scoped to those dirs.
+          CINDER_TEST_COMPONENTS: ${{ needs.scope.outputs.mode == 'filtered' && needs.scope.outputs.components || '' }}
+        run: |
+          if [ -n "${CINDER_TEST_COMPONENTS:-}" ]; then
+            echo "Scoped unit tests: $CINDER_TEST_COMPONENTS"
+          else
+            echo "Full unit suite (mode=${{ needs.scope.outputs.mode }})."
+          fi
+          bun run --filter=cinder test:changed

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -3622,6 +3622,7 @@
     "prepare": "cd ../.. && husky",
     "prepublishOnly": "bun run validate && bun run build",
     "test": "TZ=UTC LANG=en_US.UTF-8 bun test --conditions browser --conditions svelte --parallel=1",
+    "test:changed": "bun run scripts/test-changed.ts",
     "test:coverage": "TZ=UTC LANG=en_US.UTF-8 bun test --conditions browser --conditions svelte --parallel=1 --coverage",
     "typecheck": "tsc --noEmit -p tsconfig.check.json && bunx svelte-check --workspace src --tsconfig ../tsconfig.json --threshold error",
     "validate": "bun run lint && bun run typecheck && bun run test:coverage && bun run validate:workflow && bun run validate:consumer",

--- a/packages/components/scripts/component-graph.test.ts
+++ b/packages/components/scripts/component-graph.test.ts
@@ -1,0 +1,542 @@
+import { describe, expect, it } from 'bun:test';
+
+import {
+  assertNoUnmodellableImports,
+  buildImportGraph,
+  computeScope,
+  dependentsClosure,
+  extractImports,
+  loadKnownSlugs,
+  loadSourceFiles,
+  pathForceFullReason,
+  resolveImport,
+  slugForFile,
+  type ComputeScopeOptions,
+} from './component-graph.ts';
+
+// ---------------------------------------------------------------------------
+// extractImports
+// ---------------------------------------------------------------------------
+
+describe('extractImports', () => {
+  it('extracts default, named, and type imports', () => {
+    const content = `
+      import Button from '../button/button.svelte';
+      import { foo } from '../../utilities/foo.ts';
+      import type { Bar } from './bar.ts';
+    `;
+    const { specifiers, hasUnmodellableImport } = extractImports(content);
+    expect(specifiers.toSorted()).toEqual([
+      '../../utilities/foo.ts',
+      '../button/button.svelte',
+      './bar.ts',
+    ]);
+    expect(hasUnmodellableImport).toBe(false);
+  });
+
+  it('extracts side-effect imports', () => {
+    const { specifiers } = extractImports(`import './styles.css';`);
+    expect(specifiers).toEqual(['./styles.css']);
+  });
+
+  it('extracts export … from and export * from re-exports', () => {
+    const content = `
+      export { Thing } from './thing.ts';
+      export * from './all.ts';
+      export type { T } from './types.ts';
+      export * as ns from './ns.ts';
+    `;
+    expect(extractImports(content).specifiers.toSorted()).toEqual([
+      './all.ts',
+      './ns.ts',
+      './thing.ts',
+      './types.ts',
+    ]);
+  });
+
+  it('extracts MULTILINE import clauses (Prettier output)', () => {
+    const content = `
+      import {
+        A,
+        B,
+      } from './foo.ts';
+      import Button, {
+        type ButtonProps,
+      } from './button.ts';
+      export {
+        x as y,
+      } from './bar.ts';
+    `;
+    expect(extractImports(content).specifiers.toSorted()).toEqual([
+      './bar.ts',
+      './button.ts',
+      './foo.ts',
+    ]);
+  });
+
+  it('extracts an import in a single-line svelte <script> tag', () => {
+    expect(extractImports(`<script>import Foo from './foo.ts';</script>`).specifiers).toEqual([
+      './foo.ts',
+    ]);
+  });
+
+  it('flags a computed dynamic import even with a comment before the paren', () => {
+    expect(extractImports('await import /* c */ (specifier);').hasUnmodellableImport).toBe(true);
+  });
+
+  it('flags TS 5.5 string-literal specifier-name imports as unmodellable', () => {
+    // The quote inside the clause defeats the static pattern, so force full
+    // rather than silently drop the edge.
+    expect(extractImports(`import { "x-y" as z } from './foo.ts';`).hasUnmodellableImport).toBe(
+      true,
+    );
+    expect(extractImports(`export { a as "b-c" } from './bar.ts';`).hasUnmodellableImport).toBe(
+      true,
+    );
+    // A plain string elsewhere must NOT trip the guard.
+    expect(
+      extractImports(`import { A } from './a.ts';\nconst s = 'hi from there';`)
+        .hasUnmodellableImport,
+    ).toBe(false);
+  });
+
+  it('extracts string-literal dynamic imports as edges', () => {
+    const { specifiers, hasUnmodellableImport } = extractImports(
+      `const m = await import('./lazy.ts');`,
+    );
+    expect(specifiers).toEqual(['./lazy.ts']);
+    expect(hasUnmodellableImport).toBe(false);
+  });
+
+  it('flags computed dynamic imports as unmodellable', () => {
+    const { specifiers, hasUnmodellableImport } = extractImports(
+      `const m = await import(componentPath);`,
+    );
+    expect(specifiers).toEqual([]);
+    expect(hasUnmodellableImport).toBe(true);
+  });
+
+  it('flags template-literal dynamic imports as unmodellable', () => {
+    expect(extractImports('await import(`./pages/${name}.ts`);').hasUnmodellableImport).toBe(true);
+  });
+
+  it('does not treat import.meta as a dynamic import', () => {
+    const { hasUnmodellableImport, specifiers } = extractImports(
+      `const u = import.meta.url; import x from './x.ts';`,
+    );
+    expect(hasUnmodellableImport).toBe(false);
+    expect(specifiers).toEqual(['./x.ts']);
+  });
+
+  it('extracts imports from inside svelte <script> blocks', () => {
+    const content = `
+      <script lang="ts">
+        import Button from '../button/button.svelte';
+      </script>
+      <div>markup</div>
+    `;
+    expect(extractImports(content).specifiers).toEqual(['../button/button.svelte']);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveImport
+// ---------------------------------------------------------------------------
+
+describe('resolveImport', () => {
+  const from = 'packages/components/src/components/dialog/dialog.svelte';
+
+  it('treats bare specifiers as external', () => {
+    const exists = () => true;
+    expect(resolveImport(from, 'zod', exists).kind).toBe('external');
+    expect(resolveImport(from, '@cinder/markdown', exists).kind).toBe('external');
+    expect(resolveImport(from, 'svelte', exists).kind).toBe('external');
+  });
+
+  it('resolves an explicit .svelte specifier', () => {
+    const target = 'packages/components/src/components/button/button.svelte';
+    const result = resolveImport(from, '../button/button.svelte', (p) => p === target);
+    expect(result).toEqual({ kind: 'resolved', path: target });
+  });
+
+  it('rewrites .js specifiers to .ts on disk', () => {
+    const fromTs = 'packages/components/src/components/chat/input/chat-input.svelte';
+    const target = 'packages/components/src/components/chat/input/attachment-kind.ts';
+    const result = resolveImport(fromTs, './attachment-kind.js', (p) => p === target);
+    expect(result).toEqual({ kind: 'resolved', path: target });
+  });
+
+  it('resolves an extensionless specifier to <base>.ts', () => {
+    const target = 'packages/components/src/schema-types.ts';
+    const fromUtil = 'packages/components/src/components/button/button.types.ts';
+    const result = resolveImport(fromUtil, '../../schema-types', (p) => p === target);
+    expect(result).toEqual({ kind: 'resolved', path: target });
+  });
+
+  it('resolves an extensionless directory specifier to index.ts', () => {
+    const target = 'packages/components/src/components/dropdown/index.ts';
+    const result = resolveImport(from, '../dropdown', (p) => p === target);
+    expect(result).toEqual({ kind: 'resolved', path: target });
+  });
+
+  it('returns ambiguous when both foo.svelte and foo.svelte.ts exist', () => {
+    const a = 'packages/components/src/components/x/foo.svelte';
+    const b = 'packages/components/src/components/x/foo.svelte.ts';
+    const fromX = 'packages/components/src/components/x/x.svelte';
+    const result = resolveImport(fromX, './foo', (p) => p === a || p === b);
+    expect(result.kind).toBe('ambiguous');
+  });
+
+  it('returns external when nothing resolves on disk', () => {
+    expect(resolveImport(from, './does-not-exist', () => false).kind).toBe('external');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// slugForFile
+// ---------------------------------------------------------------------------
+
+describe('slugForFile', () => {
+  it('maps a top-level component file to its slug', () => {
+    expect(slugForFile('packages/components/src/components/button/button.svelte')).toBe('button');
+  });
+
+  it('maps a nested subdirectory file to its top-level slug', () => {
+    expect(slugForFile('packages/components/src/components/chat/input/chat-input.svelte')).toBe(
+      'chat',
+    );
+  });
+
+  it('returns null for _internal and underscore files', () => {
+    expect(slugForFile('packages/components/src/components/_internal/focus.ts')).toBeNull();
+    expect(slugForFile('packages/components/src/components/_sortable-item.svelte')).toBeNull();
+  });
+
+  it('returns null for a bare file directly under components/', () => {
+    expect(slugForFile('packages/components/src/components/chart.types.ts')).toBeNull();
+  });
+
+  it('returns null for shared utilities and sibling packages', () => {
+    expect(slugForFile('packages/components/src/utilities/class-names.ts')).toBeNull();
+    expect(slugForFile('packages/editor/src/index.ts')).toBeNull();
+  });
+
+  it('returns null for experimental deprecation-alias shims', () => {
+    // `experimental/<name>/index.ts` re-exports the promoted top-level component;
+    // it is not a slug of its own (no .svelte, no test suite).
+    expect(
+      slugForFile('packages/components/src/components/experimental/timeline/index.ts'),
+    ).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// graph + dependents closure
+// ---------------------------------------------------------------------------
+
+describe('buildImportGraph + dependentsClosure', () => {
+  const C = 'packages/components/src/components';
+  const U = 'packages/components/src/utilities';
+
+  const files = new Map<string, string>([
+    [`${C}/button/button.svelte`, `import { cx } from '../../utilities/class-names.ts';`],
+    [`${C}/dialog/dialog.svelte`, `import Button from '../button/button.svelte';`],
+    [`${C}/confirm-dialog/confirm-dialog.svelte`, `import Dialog from '../dialog/dialog.svelte';`],
+    [`${C}/unrelated/unrelated.svelte`, `import { cx } from '../../utilities/class-names.ts';`],
+    [`${U}/class-names.ts`, `export const cx = () => '';`],
+  ]);
+
+  it('builds forward and reverse edges', () => {
+    const graph = buildImportGraph(files);
+    expect(graph.forward.get(`${C}/dialog/dialog.svelte`)).toContain(`${C}/button/button.svelte`);
+    expect(graph.reverse.get(`${C}/button/button.svelte`)).toContain(`${C}/dialog/dialog.svelte`);
+  });
+
+  it('computes the transitive dependents closure', () => {
+    const graph = buildImportGraph(files);
+    const closure = dependentsClosure(graph, [`${C}/button/button.svelte`]);
+    // button → dialog → confirm-dialog
+    expect(closure).toContain(`${C}/button/button.svelte`);
+    expect(closure).toContain(`${C}/dialog/dialog.svelte`);
+    expect(closure).toContain(`${C}/confirm-dialog/confirm-dialog.svelte`);
+    expect(closure).not.toContain(`${C}/unrelated/unrelated.svelte`);
+  });
+
+  it('fans a shared utility out to every importer', () => {
+    const graph = buildImportGraph(files);
+    const closure = dependentsClosure(graph, [`${U}/class-names.ts`]);
+    expect(closure).toContain(`${C}/button/button.svelte`);
+    expect(closure).toContain(`${C}/unrelated/unrelated.svelte`);
+    // and transitively button's dependents
+    expect(closure).toContain(`${C}/dialog/dialog.svelte`);
+  });
+
+  it('terminates on import cycles', () => {
+    const cyclic = new Map<string, string>([
+      [`${C}/a/a.svelte`, `import B from '../b/b.svelte';`],
+      [`${C}/b/b.svelte`, `import A from '../a/a.svelte';`],
+    ]);
+    const graph = buildImportGraph(cyclic);
+    const closure = dependentsClosure(graph, [`${C}/a/a.svelte`]);
+    expect(closure).toEqual(new Set([`${C}/a/a.svelte`, `${C}/b/b.svelte`]));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// pathForceFullReason (golden per category)
+// ---------------------------------------------------------------------------
+
+describe('pathForceFullReason', () => {
+  it('forces full for testing-harness changes', () => {
+    expect(pathForceFullReason('packages/testing/playwright.config.ts')).not.toBeNull();
+    expect(pathForceFullReason('packages/testing/src/helpers/screenshot.ts')).not.toBeNull();
+  });
+
+  it('allow-lists only the README inside testing; the scope script forces full', () => {
+    expect(pathForceFullReason('packages/testing/README.md')).toBeNull();
+    // The scope script itself force-fulls — a scoper bug must not under-test its own PR.
+    expect(pathForceFullReason('packages/testing/scripts/changed-components.ts')).not.toBeNull();
+  });
+
+  it('forces full for lockfile, root manifest, and tsconfig', () => {
+    expect(pathForceFullReason('bun.lock')).not.toBeNull();
+    expect(pathForceFullReason('package.json')).not.toBeNull();
+    expect(pathForceFullReason('tsconfig.base.json')).not.toBeNull();
+    expect(pathForceFullReason('packages/components/tsconfig.json')).not.toBeNull();
+  });
+
+  it('forces full for any script change, including the scope scripts', () => {
+    expect(pathForceFullReason('packages/components/scripts/build.ts')).not.toBeNull();
+    expect(pathForceFullReason('packages/components/scripts/generate-exports.ts')).not.toBeNull();
+    // The scope scripts themselves force full — a scoper bug must not be able to
+    // under-test the PR that introduced it.
+    expect(pathForceFullReason('packages/components/scripts/component-graph.ts')).not.toBeNull();
+    expect(pathForceFullReason('packages/components/scripts/test-changed.ts')).not.toBeNull();
+    expect(pathForceFullReason('packages/testing/scripts/changed-components.ts')).not.toBeNull();
+  });
+
+  it('forces full for global styles', () => {
+    expect(pathForceFullReason('packages/components/src/styles/tokens.css')).not.toBeNull();
+  });
+
+  it('forces full for any workflow change, including browser-tests itself', () => {
+    expect(pathForceFullReason('.github/workflows/main-green.yaml')).not.toBeNull();
+    // A browser-tests.yaml edit can change which tests run / how the scoper is
+    // invoked, so it force-fulls too — no self-edit exception.
+    expect(pathForceFullReason('.github/workflows/browser-tests.yaml')).not.toBeNull();
+  });
+
+  it('forces full for runtime config and per-package manifests', () => {
+    expect(pathForceFullReason('bun.lockb')).not.toBeNull();
+    expect(pathForceFullReason('bunfig.toml')).not.toBeNull();
+    expect(pathForceFullReason('.npmrc')).not.toBeNull();
+    expect(pathForceFullReason('packages/editor/package.json')).not.toBeNull();
+    expect(pathForceFullReason('packages/markdown/package.json')).not.toBeNull();
+  });
+
+  it('returns null for an ordinary component source file', () => {
+    expect(
+      pathForceFullReason('packages/components/src/components/button/button.svelte'),
+    ).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// computeScope (the composed decision)
+// ---------------------------------------------------------------------------
+
+describe('computeScope', () => {
+  const C = 'packages/components/src/components';
+  const U = 'packages/components/src/utilities';
+
+  const sourceFiles = new Map<string, string>([
+    [`${C}/button/button.svelte`, `import { cx } from '../../utilities/class-names.ts';`],
+    [`${C}/dialog/dialog.svelte`, `import Button from '../button/button.svelte';`],
+    [`${C}/badge/badge.svelte`, `export let label = '';`],
+    [`${U}/class-names.ts`, `export const cx = () => '';`],
+  ]);
+  const knownSlugs = new Set(['button', 'dialog', 'badge']);
+
+  const base = (overrides: Partial<ComputeScopeOptions>): ComputeScopeOptions => ({
+    changedFiles: [],
+    sourceFiles,
+    knownSlugs,
+    ...overrides,
+  });
+
+  it('filters to a single component and its dependents', () => {
+    const decision = computeScope(base({ changedFiles: [`${C}/button/button.svelte`] }));
+    expect(decision).toEqual({ mode: 'filtered', slugs: ['button', 'dialog'] });
+  });
+
+  it('filters to just the leaf when nothing depends on it', () => {
+    const decision = computeScope(base({ changedFiles: [`${C}/badge/badge.svelte`] }));
+    expect(decision).toEqual({ mode: 'filtered', slugs: ['badge'] });
+  });
+
+  it('fans a shared utility out to all dependents', () => {
+    const decision = computeScope(base({ changedFiles: [`${U}/class-names.ts`] }));
+    expect(decision).toEqual({ mode: 'filtered', slugs: ['button', 'dialog'] });
+  });
+
+  it('forces full on a path-based trigger', () => {
+    const decision = computeScope(base({ changedFiles: ['bun.lock'] }));
+    expect(decision.mode).toBe('full');
+  });
+
+  it('forces full on a deleted file', () => {
+    const decision = computeScope(
+      base({
+        changedFiles: [`${C}/button/button.svelte`],
+        deletedFiles: [`${C}/old/old.svelte`],
+      }),
+    );
+    expect(decision.mode).toBe('full');
+  });
+
+  it('forces full when an unmodellable import exists outside the allow-list', () => {
+    const poisoned = new Map(sourceFiles);
+    poisoned.set(`${C}/lazy/lazy.svelte`, `const m = await import(dynamicPath);`);
+    const decision = computeScope(
+      base({ sourceFiles: poisoned, changedFiles: [`${C}/badge/badge.svelte`] }),
+    );
+    expect(decision.mode).toBe('full');
+    expect((decision as { reason: string }).reason).toContain('computed dynamic import');
+  });
+
+  it('forces full when a changed file resolves to no known slug and is not shared', () => {
+    const withBareFile = new Map(sourceFiles);
+    withBareFile.set(`${C}/chart.types.ts`, `export type Chart = unknown;`);
+    const decision = computeScope(
+      base({ sourceFiles: withBareFile, changedFiles: [`${C}/chart.types.ts`] }),
+    );
+    expect(decision.mode).toBe('full');
+  });
+
+  it('forces full when the closure reaches an unknown slug', () => {
+    const decision = computeScope(
+      base({ changedFiles: [`${C}/button/button.svelte`], knownSlugs: new Set(['button']) }),
+    );
+    // dialog is in the closure but not in knownSlugs
+    expect(decision.mode).toBe('full');
+  });
+
+  it('forces full when no source files changed', () => {
+    const decision = computeScope(base({ changedFiles: ['docs/readme.md'] }));
+    expect(decision.mode).toBe('full');
+  });
+
+  // --- silent-miss regressions (found by codex-advisor) ---
+
+  it('includes a co-changed test file’s slug even when another component also changed', () => {
+    // button.test.ts is not in the graph, but a change to it must still run
+    // button's tests — even when badge.svelte is co-changed and "wins" the graph.
+    const decision = computeScope(
+      base({ changedFiles: [`${C}/button/button.test.ts`, `${C}/badge/badge.svelte`] }),
+    );
+    expect(decision.mode).toBe('filtered');
+    if (decision.mode === 'filtered') {
+      expect(decision.slugs).toContain('button');
+      expect(decision.slugs).toContain('badge');
+    }
+  });
+
+  it('forces full when an unaccounted file is co-changed with a component', () => {
+    // A non-source, non-force-full, non-example file must not be silently dropped
+    // just because a co-changed component produced a slug.
+    const decision = computeScope(
+      base({ changedFiles: [`${C}/badge/badge.svelte`, 'some/random/asset.bin'] }),
+    );
+    expect(decision.mode).toBe('full');
+    expect((decision as { reason: string }).reason).toContain('unaccounted');
+  });
+
+  it('ignores docs/markdown co-changes (does not force full)', () => {
+    // A README or doc co-changed with a component is harmless — scope to the
+    // component, do not force full.
+    const decision = computeScope(
+      base({
+        changedFiles: [`${C}/badge/badge.svelte`, `${C}/badge/README.md`, 'docs/guide.md'],
+      }),
+    );
+    expect(decision).toEqual({ mode: 'filtered', slugs: ['badge'] });
+  });
+
+  it('maps a non-graph component sidecar (CSS) to its slug', () => {
+    const decision = computeScope(base({ changedFiles: [`${C}/badge/badge.css`] }));
+    expect(decision).toEqual({ mode: 'filtered', slugs: ['badge'] });
+  });
+
+  it('force-fulls an ambiguous import via reverse edges when a candidate changes', () => {
+    // card imports '../button/button' (extensionless); both button.ts and
+    // button.svelte exist → ambiguous. A change to button.svelte must reach card
+    // through the ambiguous reverse edges and force full.
+    const ambiguous = new Map<string, string>([
+      [`${C}/button/button.ts`, `export const x = 1;`],
+      [`${C}/button/button.svelte`, `<script>export let y = 1;</script>`],
+      [`${C}/card/card.svelte`, `<script>import Button from '../button/button';</script>`],
+    ]);
+    const decision = computeScope({
+      changedFiles: [`${C}/button/button.svelte`],
+      sourceFiles: ambiguous,
+      knownSlugs: new Set(['button', 'card']),
+    });
+    expect(decision.mode).toBe('full');
+    expect((decision as { reason: string }).reason).toContain('ambiguous');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Guard against the real tree
+// ---------------------------------------------------------------------------
+
+describe('no-unmodellable-imports guard (real tree)', () => {
+  it('the harness allow-list is exhaustive — no stray computed imports', async () => {
+    const files = await loadSourceFiles();
+    expect(() => assertNoUnmodellableImports(files)).not.toThrow();
+  });
+
+  it('discovers a sane number of component slugs', async () => {
+    const slugs = await loadKnownSlugs();
+    // Sanity floor: the library has well over 100 components.
+    expect(slugs.size).toBeGreaterThan(100);
+    expect(slugs.has('button')).toBe(true);
+    expect(slugs.has('confirm-dialog')).toBe(true);
+  });
+
+  it('a real button change scopes to button + its real dependents', async () => {
+    const sourceFiles = await loadSourceFiles();
+    const knownSlugs = await loadKnownSlugs();
+    const decision = computeScope({
+      changedFiles: ['packages/components/src/components/button/button.svelte'],
+      sourceFiles,
+      knownSlugs,
+    });
+    expect(decision.mode).toBe('filtered');
+    if (decision.mode === 'filtered') {
+      expect(decision.slugs).toContain('button');
+      // alert-dialog and confirm-dialog import button — verified in the tree.
+      expect(decision.slugs).toContain('confirm-dialog');
+      expect(decision.slugs).toContain('alert-dialog');
+    }
+  });
+
+  it('a widely-imported utility fans out to (real) slugs, not full-on-alias', async () => {
+    // class-names.ts is imported across the library; its closure reaches the
+    // `experimental/*` deprecation aliases. Those must map to null (not an
+    // unknown `experimental` slug that would force full).
+    const sourceFiles = await loadSourceFiles();
+    const knownSlugs = await loadKnownSlugs();
+    const decision = computeScope({
+      changedFiles: ['packages/components/src/utilities/class-names.ts'],
+      sourceFiles,
+      knownSlugs,
+    });
+    expect(decision.mode).toBe('filtered');
+    if (decision.mode === 'filtered') {
+      expect(decision.slugs.length).toBeGreaterThan(50);
+      // every returned slug is a real, known component
+      for (const slug of decision.slugs) expect(knownSlugs.has(slug)).toBe(true);
+    }
+  });
+});

--- a/packages/components/scripts/component-graph.test.ts
+++ b/packages/components/scripts/component-graph.test.ts
@@ -493,6 +493,34 @@ describe('computeScope', () => {
     expect(decision).toEqual({ mode: 'filtered', slugs: ['badge'] });
   });
 
+  it('force-fulls a shared seed that reaches no component, even with a co-changed component', () => {
+    // packages/markdown/src/foo.ts is a traceable shared module, but no component
+    // in the graph imports it (markdown is consumed via bare `cinder/markdown/...`
+    // specifiers → external → no edge). Co-changed with badge, the naive result
+    // would be filtered: [badge], silently dropping the markdown change. The
+    // per-seed reachability guard must force full instead. (copilot finding, PR #222)
+    const withMarkdown = new Map(sourceFiles);
+    withMarkdown.set('packages/markdown/src/foo.ts', `export const foo = 1;`);
+    const decision = computeScope(
+      base({
+        sourceFiles: withMarkdown,
+        changedFiles: ['packages/markdown/src/foo.ts', `${C}/badge/badge.svelte`],
+      }),
+    );
+    expect(decision.mode).toBe('full');
+    expect((decision as { reason: string }).reason).toContain('reaches no component');
+  });
+
+  it('keeps filtered when a shared seed DOES reach a component', () => {
+    // class-names.ts is imported by button → its closure reaches a component, so
+    // a shared change that genuinely fans out stays filtered (not over-fulled).
+    const decision = computeScope(base({ changedFiles: [`${U}/class-names.ts`] }));
+    expect(decision.mode).toBe('filtered');
+    if (decision.mode === 'filtered') {
+      expect(decision.slugs).toContain('button');
+    }
+  });
+
   it('force-fulls globally when ANY ambiguous import exists in the graph', () => {
     // card imports '../button/button' (extensionless); both button.ts and
     // button.svelte exist → ambiguous. Any ambiguous import in the scanned graph

--- a/packages/components/scripts/component-graph.test.ts
+++ b/packages/components/scripts/component-graph.test.ts
@@ -11,6 +11,7 @@ import {
   pathForceFullReason,
   resolveImport,
   slugForFile,
+  UNMODELLABLE_IMPORT_ALLOWLIST,
   type ComputeScopeOptions,
 } from './component-graph.ts';
 
@@ -185,6 +186,22 @@ describe('resolveImport', () => {
     const fromX = 'packages/components/src/components/x/x.svelte';
     const result = resolveImport(fromX, './foo', (p) => p === a || p === b);
     expect(result.kind).toBe('ambiguous');
+  });
+
+  it('rewrites .mjs specifiers to .mts on disk', () => {
+    const target = 'packages/components/src/utilities/helpers.mts';
+    const result = resolveImport(from, '../../utilities/helpers.mjs', (p) => p === target);
+    expect(result).toEqual({ kind: 'resolved', path: target });
+  });
+
+  it('resolves an explicit .svelte.ts specifier as-is (compound extension)', () => {
+    const target = 'packages/components/src/utilities/use-history.svelte.ts';
+    const result = resolveImport(
+      from,
+      '../../utilities/use-history.svelte.ts',
+      (p) => p === target,
+    );
+    expect(result).toEqual({ kind: 'resolved', path: target });
   });
 
   it('returns external when nothing resolves on disk', () => {
@@ -467,22 +484,34 @@ describe('computeScope', () => {
     expect(decision).toEqual({ mode: 'filtered', slugs: ['badge'] });
   });
 
-  it('force-fulls an ambiguous import via reverse edges when a candidate changes', () => {
+  it('force-fulls globally when ANY ambiguous import exists in the graph', () => {
     // card imports '../button/button' (extensionless); both button.ts and
-    // button.svelte exist → ambiguous. A change to button.svelte must reach card
-    // through the ambiguous reverse edges and force full.
+    // button.svelte exist → ambiguous. Any ambiguous import in the scanned graph
+    // forces full (the closure could be incomplete), even when the changed file
+    // is unrelated to it.
     const ambiguous = new Map<string, string>([
       [`${C}/button/button.ts`, `export const x = 1;`],
       [`${C}/button/button.svelte`, `<script>export let y = 1;</script>`],
       [`${C}/card/card.svelte`, `<script>import Button from '../button/button';</script>`],
+      [`${C}/badge/badge.svelte`, `<script>let z = 1;</script>`],
     ]);
     const decision = computeScope({
-      changedFiles: [`${C}/button/button.svelte`],
+      changedFiles: [`${C}/badge/badge.svelte`], // unrelated to the ambiguous import
       sourceFiles: ambiguous,
-      knownSlugs: new Set(['button', 'card']),
+      knownSlugs: new Set(['button', 'card', 'badge']),
     });
     expect(decision.mode).toBe('full');
     expect((decision as { reason: string }).reason).toContain('ambiguous');
+  });
+
+  it('force-fulls when the shared test harness (src/test) changes', () => {
+    const decision = computeScope(
+      base({
+        changedFiles: ['packages/components/src/test/lifecycle.ts', `${C}/badge/badge.svelte`],
+      }),
+    );
+    expect(decision.mode).toBe('full');
+    expect((decision as { reason: string }).reason).toContain('test-harness');
   });
 });
 
@@ -494,6 +523,12 @@ describe('no-unmodellable-imports guard (real tree)', () => {
   it('the harness allow-list is exhaustive — no stray computed imports', async () => {
     const files = await loadSourceFiles();
     expect(() => assertNoUnmodellableImports(files)).not.toThrow();
+  });
+
+  it('every allow-list entry is under src/test/ (cannot wave through component source)', () => {
+    for (const entry of UNMODELLABLE_IMPORT_ALLOWLIST) {
+      expect(entry.startsWith('packages/components/src/test/')).toBe(true);
+    }
   });
 
   it('discovers a sane number of component slugs', async () => {

--- a/packages/components/scripts/component-graph.test.ts
+++ b/packages/components/scripts/component-graph.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'bun:test';
 
 import {
+  assertNoAmbiguousImports,
   assertNoUnmodellableImports,
   buildImportGraph,
   computeScope,
@@ -443,6 +444,14 @@ describe('computeScope', () => {
     expect(decision.mode).toBe('full');
   });
 
+  it('uses the EXACT "no component-mapped changes detected" reason (decide() depends on it)', () => {
+    // changed-components.ts decide() string-matches this reason to let an
+    // example-only change recover a filtered scope. Pin the wording so a rename
+    // fails here loudly instead of silently breaking that rescue path.
+    const decision = computeScope(base({ changedFiles: ['docs/readme.md'] }));
+    expect(decision).toEqual({ mode: 'full', reason: 'no component-mapped changes detected' });
+  });
+
   // --- silent-miss regressions (found by codex-advisor) ---
 
   it('includes a co-changed test file’s slug even when another component also changed', () => {
@@ -523,6 +532,11 @@ describe('no-unmodellable-imports guard (real tree)', () => {
   it('the harness allow-list is exhaustive — no stray computed imports', async () => {
     const files = await loadSourceFiles();
     expect(() => assertNoUnmodellableImports(files)).not.toThrow();
+  });
+
+  it('the real tree has no ambiguous imports that would make scoping permanently full', async () => {
+    const files = await loadSourceFiles();
+    expect(() => assertNoAmbiguousImports(files)).not.toThrow();
   });
 
   it('every allow-list entry is under src/test/ (cannot wave through component source)', () => {

--- a/packages/components/scripts/component-graph.ts
+++ b/packages/components/scripts/component-graph.ts
@@ -760,3 +760,24 @@ export function assertNoUnmodellableImports(files: ReadonlyMap<string, string>):
     );
   }
 }
+
+/**
+ * Guard used by the test suite: assert that the real tree has no ambiguous
+ * imports. An ambiguous import is safe at runtime because scoping force-fulls,
+ * but leaving one on `main` would make every future scoped run permanently full.
+ */
+export function assertNoAmbiguousImports(files: ReadonlyMap<string, string>): void {
+  const graph = buildImportGraph(files);
+  if (graph.ambiguousFiles.size === 0) return;
+
+  throw new Error(
+    `Ambiguous import(s) found in the dependency-aware test graph:\n` +
+      [...graph.ambiguousFiles]
+        .toSorted()
+        .map((file) => `  • ${file}`)
+        .join('\n') +
+      `\n\nThese imports cannot be resolved to exactly one on-disk source file, so ` +
+      `dependency-aware scoping would force the full suite for every change.\n` +
+      `Fix by adding an explicit extension or removing the competing candidate file.`,
+  );
+}

--- a/packages/components/scripts/component-graph.ts
+++ b/packages/components/scripts/component-graph.ts
@@ -587,20 +587,32 @@ export function computeScope(options: ComputeScopeOptions): ScopeDecision {
   // because the component's slug "won".
   const closureSeeds: string[] = [];
   const directSlugs = new Set<string>();
+  // Non-component seeds (shared modules / sibling-package source that are not
+  // themselves a component slug). EACH of these must prove it reaches at least
+  // one component slug in the closure — otherwise its change is invisible to the
+  // scoped run and we must force full. See the per-seed reachability check below.
+  const sharedSeeds: string[] = [];
   for (const file of changedFiles) {
     if (isIgnorableFile(file)) continue; // docs/markdown/etc. cannot affect tests
-    if (sourceFiles.has(file)) {
-      closureSeeds.push(file);
-      continue;
-    }
     const slug = slugForFile(file);
     if (slug !== null) {
-      // A component-tree file (e.g. test/CSS sidecar) not in the graph.
+      // A component-tree file (e.g. test/CSS sidecar) — a slug whether or not it
+      // is in the graph. Seed the closure AND record the slug directly.
       directSlugs.add(slug);
+      if (sourceFiles.has(file)) closureSeeds.push(file);
+      continue;
+    }
+    if (sourceFiles.has(file)) {
+      // A graph source file with no slug → a shared module. Seed + track.
+      closureSeeds.push(file);
+      sharedSeeds.push(file);
       continue;
     }
     if (isTraceableSharedModule(file)) {
+      // A shared module not in the graph map (rare) — still seed + track so its
+      // reachability is verified.
       closureSeeds.push(file);
+      sharedSeeds.push(file);
       continue;
     }
     return { mode: 'full', reason: `unaccounted changed file: ${file}` };
@@ -614,6 +626,26 @@ export function computeScope(options: ComputeScopeOptions): ScopeDecision {
   for (const file of closure) {
     const slug = slugForFile(file);
     if (slug !== null) slugs.add(slug);
+  }
+
+  // Per-seed reachability guard. A shared/sibling-package seed whose OWN
+  // dependents closure reaches no component slug (e.g. `packages/markdown/src/x`
+  // consumed only via bare `cinder/markdown/...` specifiers, which resolve as
+  // external → no graph edge) would otherwise be silently dropped when a
+  // CO-CHANGED component supplies a slug and flips the decision to `filtered`.
+  // Force full if any shared seed cannot be proven to reach a component.
+  for (const seed of sharedSeeds) {
+    const seedClosure = dependentsClosure(graph, [seed]);
+    const reachesComponent = [...seedClosure].some((file) => {
+      const slug = slugForFile(file);
+      return slug !== null && knownSlugs.has(slug);
+    });
+    if (!reachesComponent) {
+      return {
+        mode: 'full',
+        reason: `shared change reaches no component slug (can't prove its dependents are tested): ${seed}`,
+      };
+    }
   }
 
   // Every slug must be a real, known component; an unknown slug means the

--- a/packages/components/scripts/component-graph.ts
+++ b/packages/components/scripts/component-graph.ts
@@ -1,0 +1,741 @@
+/**
+ * Dependency-aware test scoping: the import graph that powers it.
+ *
+ * Cinder has ~140 components, each in its own directory under
+ * `src/components/<slug>/`, and they import each other via relative paths
+ * (`import Button from '../button/button.svelte'`). When a single component
+ * changes, CI should retest that component AND every component that
+ * (transitively) depends on it — not the full matrix, and not just the one
+ * file. This module builds the file-level import graph, inverts it to find
+ * dependents, and maps the affected files back to component slugs.
+ *
+ * Design contract (intentionally conservative — a MISSED edge silently skips a
+ * test, which is worse than a redundant full run):
+ *
+ *   - We model static imports, side-effect imports, `export … from` /
+ *     `export * from` re-exports, and STRING-LITERAL dynamic `import('…')`.
+ *   - A COMPUTED dynamic import (`import(variable)`) creates an edge the graph
+ *     cannot see. Any such import outside a tiny known-safe harness allow-list
+ *     forces the FULL suite, and {@link assertNoUnmodellableImports} keeps the
+ *     allow-list honest so a newly-introduced computed import fails loudly
+ *     instead of silently poisoning scoping forever.
+ *   - The resolver mirrors the `moduleResolution: "bundler"` rules this repo
+ *     uses (`.js` specifiers map to `.ts` on disk, extensionless specifiers
+ *     probe `.ts`/`.svelte`/`index.*`). A specifier that resolves to TWO
+ *     plausible on-disk files is AMBIGUOUS and forces full rather than guess.
+ *
+ * Pure and unit-testable: callers pass file contents in, so the same logic is
+ * exercised in tests without touching the filesystem. The thin filesystem
+ * wrappers ({@link loadSourceFiles}) live at the bottom.
+ *
+ * Mirrors the scanning idiom of `check-no-cycle-imports.ts` (Bun `Glob` over
+ * `src/**`, regex extraction). Consumed by
+ * `packages/testing/scripts/changed-components.ts`.
+ */
+
+import { Glob } from 'bun';
+import { dirname, join, relative, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const scriptDirectory = dirname(fileURLToPath(import.meta.url));
+/** Absolute path to `packages/components`. */
+export const componentsPackageRoot = resolve(scriptDirectory, '..');
+/** Absolute path to the repo root (`packages/components` → up two). */
+export const workspaceRoot = resolve(componentsPackageRoot, '..', '..');
+
+/**
+ * Source roots scanned to build the graph. Components live in the first;
+ * the sibling `@cinder/*` packages are included because a handful of
+ * components import from `../../editor`, `../../markdown`, etc., and a change
+ * in those packages must reach its component dependents.
+ */
+export const SCANNED_ROOTS: readonly string[] = [
+  'packages/components/src',
+  'packages/editor/src',
+  'packages/markdown/src',
+  'packages/diff/src',
+  'packages/commentary/src',
+];
+
+/** Prefix (repo-relative, POSIX) under which component slugs are rooted. */
+const COMPONENTS_PREFIX = 'packages/components/src/components/';
+
+/**
+ * Test files are EXCLUDED from the production import graph. A test's own
+ * imports (and any computed `import()` it uses to exercise lazy-loading paths)
+ * cannot create a component→component SOURCE edge — they are test machinery.
+ * Including them would (a) flag legitimate test-only computed imports as
+ * unmodellable, and (b) pollute the dependents closure with test-only edges.
+ * What a changed component's tests ARE is decided by slug, not by graph edges.
+ */
+export function isTestFile(repoRelativePath: string): boolean {
+  // Matches `*.test.ts`, `*.spec.ts`, `*.test.tsx`, and the rune-module
+  // variants `*.svelte.test.ts` / `*.type-test.ts` used in this tree.
+  return /\.(test|spec|type-test)\.(ts|tsx)$/.test(repoRelativePath);
+}
+
+/**
+ * The ONLY known-safe computed dynamic imports in component source. Both load
+ * a temp SSR module written to disk at test time — they never create a
+ * component→component edge — and live in the always-run `src/test/**` bucket.
+ * Keyed by repo-relative POSIX path. {@link assertNoUnmodellableImports}
+ * fails if a computed import appears anywhere NOT in this set.
+ */
+export const UNMODELLABLE_IMPORT_ALLOWLIST: ReadonlySet<string> = new Set([
+  'packages/components/src/test/hydrate.ts',
+  'packages/components/src/test/server-render.ts',
+]);
+
+// ---------------------------------------------------------------------------
+// Import extraction
+// ---------------------------------------------------------------------------
+
+/**
+ * Matches `import … from '…'` and `export … from '…'` statements — including
+ * the MULTILINE clause forms Prettier produces, which are the norm in this
+ * codebase:
+ *
+ *   import X from '…'                 export { X } from '…'
+ *   import { A, B } from '…'          export * from '…'
+ *   import X, {                       export {
+ *     type Y,                            a as b,
+ *   } from '…'                         } from '…'
+ *   import type { X } from '…'        export * as ns from '…'
+ *
+ * Strategy: anchor on a statement boundary (`^`, newline, `;`, `{`, `}`, or
+ * `>` for inline Svelte `<script>` tags), require the `import`/`export`
+ * keyword followed by whitespace, then consume the clause — which MAY span
+ * newlines and contain braces (`[\s\S]`) — lazily up to the ` from ` keyword,
+ * then capture the quoted specifier. The clause cannot contain a quote (so it
+ * cannot swallow a later statement's specifier) and must contain ` from `
+ * (so bare side-effect `import '…'` is handled by the dedicated pattern
+ * below, and `import.meta` / `import(` never match — no ` from `).
+ *
+ * Group 2 is the specifier. False positives (e.g. an import inside a block
+ * comment) only add redundant edges — harmless. False NEGATIVES are the
+ * danger, so the pattern errs toward matching.
+ */
+const STATIC_IMPORT_PATTERN =
+  /(?:^|[\n;{}>])\s*(?:import|export)\s[^'"]*?\sfrom\s*(['"])([^'"]+)\1/g;
+
+/** Matches a side-effect `import '…';` (no clause), e.g. `import './styles.css';`. */
+const SIDE_EFFECT_IMPORT_PATTERN = /(?:^|[\n;{}>])\s*import\s+(['"])([^'"]+)\1/g;
+
+/**
+ * Matches EVERY dynamic `import(` call, tolerating a comment between the
+ * keyword and the paren (`import /* … *​/ (…)`). Group 1 is the raw argument
+ * text up to the first `)`.
+ */
+const DYNAMIC_IMPORT_PATTERN = /\bimport\s*(?:\/\*[\s\S]*?\*\/\s*)?\(\s*([^)]*?)\s*\)/g;
+
+/** A string-literal dynamic-import argument: `import('…')`. */
+const DYNAMIC_LITERAL_ARGUMENT = /^(['"])([^'"]+)\1$/;
+
+/**
+ * Detects a TS 5.5+ string-literal specifier NAME inside an import/export
+ * clause — `import { "x" as y } from …` / `export { x as "y" } from …`. The
+ * quote inside the clause defeats {@link STATIC_IMPORT_PATTERN}, so its
+ * presence means an edge may have been dropped; callers treat the file as
+ * unmodellable (force full) instead. Conservative — matches a braced clause
+ * containing a quoted token followed by `from`.
+ */
+const STRING_LITERAL_SPECIFIER_NAME = /(?:import|export)\s*\{[^}]*['"][^}]*\}\s*from\s/;
+
+export type ExtractedImports = {
+  /** String-literal specifiers (static, side-effect, and literal dynamic). */
+  readonly specifiers: string[];
+  /**
+   * True when the file contains a dynamic `import()` whose argument is NOT a
+   * plain string literal — an edge the graph cannot model.
+   */
+  readonly hasUnmodellableImport: boolean;
+};
+
+/**
+ * Extract every modellable import specifier from a source file, and flag any
+ * unmodellable (computed) dynamic import.
+ *
+ * Svelte files are handled transparently: the patterns match `import`
+ * statements wherever they appear, including inside `<script>` /
+ * `<script module>` blocks, so no Svelte-specific preprocessing is needed.
+ */
+export function extractImports(content: string): ExtractedImports {
+  const specifiers = new Set<string>();
+
+  for (const pattern of [STATIC_IMPORT_PATTERN, SIDE_EFFECT_IMPORT_PATTERN]) {
+    pattern.lastIndex = 0;
+    let match: RegExpExecArray | null;
+    while ((match = pattern.exec(content)) !== null) {
+      const specifier = match[2];
+      if (specifier !== undefined) specifiers.add(specifier);
+    }
+  }
+
+  let hasUnmodellableImport = false;
+  DYNAMIC_IMPORT_PATTERN.lastIndex = 0;
+  let dynamicMatch: RegExpExecArray | null;
+  while ((dynamicMatch = DYNAMIC_IMPORT_PATTERN.exec(content)) !== null) {
+    const argument = dynamicMatch[1]?.trim() ?? '';
+    // `import.meta`, `import type`, etc. never match `import(` — only real calls do.
+    const literal = DYNAMIC_LITERAL_ARGUMENT.exec(argument);
+    if (literal?.[2] !== undefined) {
+      specifiers.add(literal[2]);
+    } else if (argument.length > 0) {
+      hasUnmodellableImport = true;
+    }
+  }
+
+  // TS 5.5+ string-literal specifier NAMES inside an import clause
+  // (`import { "x-y" as z } from '…'`) contain quotes the static pattern cannot
+  // cross, so its specifier would be silently dropped. None exist in this tree
+  // today; flag any as unmodellable (→ force full) so a future one fails safe
+  // rather than silently dropping a graph edge.
+  if (STRING_LITERAL_SPECIFIER_NAME.test(content)) {
+    hasUnmodellableImport = true;
+  }
+
+  return { specifiers: [...specifiers], hasUnmodellableImport };
+}
+
+// ---------------------------------------------------------------------------
+// Resolution
+// ---------------------------------------------------------------------------
+
+export type ResolveResult =
+  | { kind: 'resolved'; path: string }
+  | { kind: 'ambiguous'; candidates: string[] }
+  | { kind: 'external' };
+
+/**
+ * Candidate on-disk paths for a relative specifier, in priority order,
+ * applying the repo's `moduleResolution: "bundler"` conventions:
+ *
+ *   - `.js` specifiers map to `.ts` on disk (TS rewrites the extension).
+ *   - an explicit `.ts`/`.svelte`/`.json`/`.css`/`.tsx` extension resolves as-is.
+ *   - an extensionless specifier probes `<base>.ts`, `<base>.tsx`,
+ *     `<base>.svelte`, `<base>.svelte.ts`, then `<base>/index.{ts,tsx,svelte,svelte.ts}`.
+ *
+ * The `.js`/`.mjs`/`.cjs` → `.ts`/`.mts`/`.cts` rewrites mirror TypeScript's
+ * `moduleResolution: "bundler"` extension substitution.
+ *
+ * Returns the candidates that actually EXIST (per `exists`). Zero → external
+ * or missing; one → resolved; two or more → ambiguous.
+ */
+export function resolveCandidates(absoluteBase: string): string[] {
+  const candidates: string[] = [];
+  const ext = extensionOf(absoluteBase);
+
+  if (ext === '.js' || ext === '.mjs' || ext === '.cjs') {
+    // `./x.js` → `./x.ts`, `./x.mjs` → `./x.mts`, `./x.cjs` → `./x.cts` (TS
+    // source convention). Keep the original too in case a real JS file ships.
+    const withoutExt = absoluteBase.slice(0, -ext.length);
+    const tsCounterpart = ext === '.mjs' ? '.mts' : ext === '.cjs' ? '.cts' : '.ts';
+    candidates.push(`${withoutExt}${tsCounterpart}`, `${withoutExt}.ts`, absoluteBase);
+  } else if (ext !== '') {
+    candidates.push(absoluteBase);
+  } else {
+    candidates.push(
+      `${absoluteBase}.ts`,
+      `${absoluteBase}.tsx`,
+      `${absoluteBase}.svelte`,
+      `${absoluteBase}.svelte.ts`,
+      join(absoluteBase, 'index.ts'),
+      join(absoluteBase, 'index.tsx'),
+      join(absoluteBase, 'index.svelte'),
+      join(absoluteBase, 'index.svelte.ts'),
+    );
+  }
+
+  return candidates;
+}
+
+function extensionOf(path: string): string {
+  const base = path.slice(path.lastIndexOf('/') + 1);
+  const dot = base.lastIndexOf('.');
+  return dot <= 0 ? '' : base.slice(dot);
+}
+
+/**
+ * Resolve a single import specifier against the importing file.
+ *
+ * @param fromFile - repo-relative POSIX path of the importing file.
+ * @param specifier - the import specifier as written.
+ * @param exists - predicate over repo-relative POSIX paths (injected so the
+ *   resolver is pure/testable; the filesystem wrapper supplies the real one).
+ *
+ * Bare specifiers (`zod`, `@cinder/markdown`, `svelte`) are `external` — they
+ * cannot change inside a component-source diff, so they create no edge.
+ * Relative specifiers resolve to exactly one file, or `ambiguous` when two
+ * plausible on-disk targets exist (e.g. both `x.svelte` and `x.svelte.ts`).
+ */
+export function resolveImport(
+  fromFile: string,
+  specifier: string,
+  exists: (repoRelativePath: string) => boolean,
+): ResolveResult {
+  if (!specifier.startsWith('.')) {
+    return { kind: 'external' };
+  }
+
+  const fromDirectory = dirname(fromFile);
+  const absoluteBase = join(fromDirectory, specifier);
+  const candidates = resolveCandidates(absoluteBase).map(normalizeRepoPath);
+  // Dedupe AFTER normalization: distinct candidate strings can normalize to the
+  // same path (e.g. the `.js`→`.ts` rewrite and the literal `.ts` probe), and a
+  // duplicate that exists would otherwise be miscounted as a 2-candidate ambiguity.
+  const present = [...new Set(candidates)].filter((candidate) => exists(candidate));
+
+  if (present.length === 0) return { kind: 'external' };
+  if (present.length === 1) return { kind: 'resolved', path: present[0]! };
+  return { kind: 'ambiguous', candidates: present };
+}
+
+/** Normalize a joined path to a clean repo-relative POSIX path. */
+function normalizeRepoPath(path: string): string {
+  return path.split('\\').join('/');
+}
+
+// ---------------------------------------------------------------------------
+// Slug mapping
+// ---------------------------------------------------------------------------
+
+/**
+ * The component slug a file belongs to: the directory directly under
+ * `src/components/`. Files in nested subdirectories (`chat/input/…`) map to
+ * the top-level slug (`chat`). Files outside the components tree (utilities,
+ * `_internal`, sibling packages) return `null` — they are shared, not a slug.
+ */
+export function slugForFile(repoRelativePath: string): string | null {
+  if (!repoRelativePath.startsWith(COMPONENTS_PREFIX)) return null;
+  const rest = repoRelativePath.slice(COMPONENTS_PREFIX.length);
+  const firstSegment = rest.split('/')[0] ?? '';
+  // `_internal`, `_sortable-item.svelte`, bare files like `chart.types.ts` at
+  // the components root are not component slugs.
+  if (firstSegment === '' || firstSegment.startsWith('_')) return null;
+  if (!rest.includes('/')) return null; // a bare file directly in components/
+  // `experimental/<name>/index.ts` is a generated DEPRECATION-ALIAS shim that
+  // re-exports the promoted top-level component (`../../<name>`). It has no
+  // `.svelte` and no test suite of its own; its only graph role is the edge to
+  // the real component, which is already mapped to that component's slug. So it
+  // is not itself a slug — treat the alias container like `_internal`.
+  if (firstSegment === 'experimental') return null;
+  return firstSegment;
+}
+
+// ---------------------------------------------------------------------------
+// Graph
+// ---------------------------------------------------------------------------
+
+export type ImportGraph = {
+  /** file → set of files it imports (forward edges). */
+  readonly forward: Map<string, Set<string>>;
+  /** file → set of files that import it (reverse edges / dependents). */
+  readonly reverse: Map<string, Set<string>>;
+  /** files whose imports could not be fully modelled (computed dynamic import). */
+  readonly unmodellableFiles: Set<string>;
+  /** files containing an ambiguous import the resolver refused to guess. */
+  readonly ambiguousFiles: Set<string>;
+};
+
+/**
+ * Build the import graph from a map of repo-relative POSIX path → file
+ * contents. `exists` defaults to "is a key in the map", which is correct when
+ * the map contains the full scanned source set.
+ */
+export function buildImportGraph(
+  files: ReadonlyMap<string, string>,
+  exists: (repoRelativePath: string) => boolean = (path) => files.has(path),
+): ImportGraph {
+  const forward = new Map<string, Set<string>>();
+  const reverse = new Map<string, Set<string>>();
+  const unmodellableFiles = new Set<string>();
+  const ambiguousFiles = new Set<string>();
+
+  for (const [file, content] of files) {
+    const { specifiers, hasUnmodellableImport } = extractImports(content);
+    if (hasUnmodellableImport) unmodellableFiles.add(file);
+
+    const edges = forward.get(file) ?? new Set<string>();
+    forward.set(file, edges);
+
+    for (const specifier of specifiers) {
+      const result = resolveImport(file, specifier, exists);
+      if (result.kind === 'resolved') {
+        edges.add(result.path);
+        const back = reverse.get(result.path) ?? new Set<string>();
+        back.add(file);
+        reverse.set(result.path, back);
+      } else if (result.kind === 'ambiguous') {
+        ambiguousFiles.add(file);
+        // CRITICAL: add a reverse edge from EVERY ambiguous candidate to this
+        // file. Without it, a change to one candidate would never reach this
+        // importing file in the dependents BFS, so the `ambiguousInClosure`
+        // guard could not fire and the file would be silently dropped. With
+        // the edges, any candidate's change reaches this file, the guard
+        // detects the ambiguity, and the run force-fulls — the safe outcome.
+        for (const candidate of result.candidates) {
+          const back = reverse.get(candidate) ?? new Set<string>();
+          back.add(file);
+          reverse.set(candidate, back);
+        }
+      }
+    }
+  }
+
+  return { forward, reverse, unmodellableFiles, ambiguousFiles };
+}
+
+/**
+ * Every file reachable by following reverse (dependent) edges from the seed
+ * set, INCLUDING the seeds. BFS with a visited set, so the known import cycles
+ * in the tree terminate cleanly.
+ */
+export function dependentsClosure(graph: ImportGraph, changedFiles: Iterable<string>): Set<string> {
+  const visited = new Set<string>();
+  const queue: string[] = [];
+
+  for (const file of changedFiles) {
+    if (!visited.has(file)) {
+      visited.add(file);
+      queue.push(file);
+    }
+  }
+
+  while (queue.length > 0) {
+    const current = queue.shift()!;
+    const dependents = graph.reverse.get(current);
+    if (dependents === undefined) continue;
+    for (const dependent of dependents) {
+      if (!visited.has(dependent)) {
+        visited.add(dependent);
+        queue.push(dependent);
+      }
+    }
+  }
+
+  return visited;
+}
+
+// ---------------------------------------------------------------------------
+// Force-full classification
+// ---------------------------------------------------------------------------
+
+/**
+ * Path-only force-full rules: a changed file matching any of these can affect
+ * every component's bundle or the whole test harness, so it forces the full
+ * suite. Pure function of the path string — no disk or content access.
+ *
+ * Returns a human-readable reason, or `null` when the path is not a path-based
+ * force-full trigger (it may still force full for content/diff reasons).
+ */
+export function pathForceFullReason(repoRelativePath: string): string | null {
+  const path = normalizeRepoPath(repoRelativePath);
+
+  // The testing package: fixtures, Playwright config, helpers, AND the scope
+  // script itself all affect how/which tests run. Force full on any change here
+  // except documentation. A change to the scope script forcing full is the safe
+  // default — a scoper bug must not be able to under-test the very PR that
+  // introduced it.
+  if (path.startsWith('packages/testing/')) {
+    if (path === 'packages/testing/README.md') return null;
+    return `testing-harness change: ${path}`;
+  }
+
+  // Lockfile / runtime config / TS config: can change resolution for everything.
+  if (path === 'bun.lock' || path === 'bun.lockb') return 'lockfile change';
+  if (path === 'bunfig.toml') return 'bun config change';
+  if (path === '.npmrc') return 'npm config change';
+  if (/(^|\/)tsconfig[^/]*\.json$/.test(path)) return `tsconfig change: ${path}`;
+
+  // Any package manifest (root or per-package) can change a dependency version,
+  // exports map, or script — all of which can affect every component.
+  if (path === 'package.json') return 'root manifest change';
+  if (/^packages\/[^/]+\/package\.json$/.test(path)) return `package manifest change: ${path}`;
+
+  // Build / generate / manifest / scope scripts shape every component's
+  // artifacts or the test scoping itself. Any change under a package's
+  // `scripts/` forces full — including the scope scripts, so a scoper bug
+  // cannot under-test the PR that introduced it.
+  if (/^packages\/[^/]+\/scripts\//.test(path)) {
+    return `build/generate script change: ${path}`;
+  }
+
+  // Global styles / design tokens affect every component visually.
+  if (path.startsWith('packages/components/src/styles/')) {
+    return `global styles change: ${path}`;
+  }
+
+  // CI workflow changes force full: a workflow edit can alter which tests run,
+  // the environment, or how the scoper is invoked. No exceptions — including the
+  // browser-tests workflow itself, whose `scope` job drives the very selection
+  // this scoper feeds.
+  if (path.startsWith('.github/workflows/')) {
+    return `workflow change: ${path}`;
+  }
+
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Scope decision
+// ---------------------------------------------------------------------------
+
+export type ScopeDecision =
+  | { mode: 'full'; reason: string }
+  | { mode: 'filtered'; slugs: string[] };
+
+export type ComputeScopeOptions = {
+  /** Repo-relative POSIX paths of files the diff touched. */
+  readonly changedFiles: readonly string[];
+  /** Repo-relative POSIX paths of CHANGED files that no longer exist on disk (deletions/renames). */
+  readonly deletedFiles?: readonly string[];
+  /** The full scanned source set (path → contents) used to build the graph. */
+  readonly sourceFiles: ReadonlyMap<string, string>;
+  /** Known component slugs (directories with a `<slug>.svelte`). */
+  readonly knownSlugs: ReadonlySet<string>;
+};
+
+/**
+ * The core decision. Composes the three force-full classifiers (path, diff
+ * status, content/import) with the dependents-closure mapping.
+ *
+ * Force-full when ANY of:
+ *   - a changed path matches {@link pathForceFullReason};
+ *   - a changed file was DELETED (we do not reconstruct the base-state graph,
+ *     so we cannot know who depended on it — force full);
+ *   - a NON-allow-listed computed dynamic import exists anywhere in the scanned
+ *     source (it is an edge the graph cannot see — globally unsafe);
+ *   - a changed file (or a file on a closure path) has an AMBIGUOUS import;
+ *   - a changed source file maps to NO component slug and is not a known shared
+ *     module the graph could trace to slugs.
+ *
+ * Otherwise filtered: the dependents closure of the changed component-source
+ * files, mapped to slugs.
+ */
+export function computeScope(options: ComputeScopeOptions): ScopeDecision {
+  const { changedFiles, deletedFiles = [], sourceFiles, knownSlugs } = options;
+
+  // 1. Path-based force-full.
+  for (const path of changedFiles) {
+    const reason = pathForceFullReason(path);
+    if (reason !== null) return { mode: 'full', reason };
+  }
+
+  // 2. Deletions / renames force full.
+  if (deletedFiles.length > 0) {
+    return {
+      mode: 'full',
+      reason: `deleted/renamed file(s): ${[...deletedFiles].toSorted().join(', ')}`,
+    };
+  }
+
+  // 3. Globally-unsafe computed imports.
+  const graph = buildImportGraph(sourceFiles);
+  const offendingUnmodellable = [...graph.unmodellableFiles].filter(
+    (file) => !UNMODELLABLE_IMPORT_ALLOWLIST.has(file),
+  );
+  if (offendingUnmodellable.length > 0) {
+    return {
+      mode: 'full',
+      reason: `computed dynamic import (unmodellable edge) in: ${offendingUnmodellable.toSorted().join(', ')}`,
+    };
+  }
+
+  // Classify every changed file. A file is accounted for if it is one of:
+  //   - a graph source file (in `sourceFiles`) → seeds the dependents closure;
+  //   - a component-tree file with a slug (e.g. a `*.test.ts`, `*.css`, or
+  //     other sidecar NOT in the graph) → contributes its slug directly, so a
+  //     co-changed test file is never dropped just because the graph excludes it;
+  //   - a traceable shared module → seeds the closure (its dependents resolve
+  //     to slugs) even if it is not itself a slug.
+  // ANYTHING ELSE that reaches here (a changed file not in the graph, not a
+  // component-tree file, not a known force-full path, not an example — examples
+  // are handled by the caller) is UNACCOUNTED FOR and forces full. This closes
+  // the silent-miss hole where a non-source change (bunfig.toml, a sibling
+  // package.json, a stray asset) co-changed with a component would be ignored
+  // because the component's slug "won".
+  const closureSeeds: string[] = [];
+  const directSlugs = new Set<string>();
+  for (const file of changedFiles) {
+    if (isIgnorableFile(file)) continue; // docs/markdown/etc. cannot affect tests
+    if (sourceFiles.has(file)) {
+      closureSeeds.push(file);
+      continue;
+    }
+    const slug = slugForFile(file);
+    if (slug !== null) {
+      // A component-tree file (e.g. test/CSS sidecar) not in the graph.
+      directSlugs.add(slug);
+      continue;
+    }
+    if (isTraceableSharedModule(file)) {
+      closureSeeds.push(file);
+      continue;
+    }
+    return { mode: 'full', reason: `unaccounted changed file: ${file}` };
+  }
+
+  // 4. Dependents closure → slugs.
+  const closure = dependentsClosure(graph, closureSeeds);
+
+  // Ambiguous import on any file in the closure → full (we refused to guess its
+  // edges, so the closure may be incomplete).
+  const ambiguousInClosure = [...closure].filter((file) => graph.ambiguousFiles.has(file));
+  if (ambiguousInClosure.length > 0) {
+    return {
+      mode: 'full',
+      reason: `ambiguous import on closure file(s): ${ambiguousInClosure.toSorted().join(', ')}`,
+    };
+  }
+
+  const slugs = new Set<string>(directSlugs);
+  for (const file of closure) {
+    const slug = slugForFile(file);
+    if (slug !== null) slugs.add(slug);
+  }
+
+  // Every slug must be a real, known component; an unknown slug means the
+  // closure (or a direct component-tree change) reached something the manifest
+  // does not know → fail safe to full.
+  const unknown = [...slugs].filter((slug) => !knownSlugs.has(slug));
+  if (unknown.length > 0) {
+    return {
+      mode: 'full',
+      reason: `closure reached unknown slug(s): ${unknown.toSorted().join(', ')}`,
+    };
+  }
+
+  if (slugs.size === 0) {
+    return { mode: 'full', reason: 'no component-mapped changes detected' };
+  }
+
+  return { mode: 'filtered', slugs: [...slugs].toSorted() };
+}
+
+/**
+ * Files that genuinely cannot affect any test outcome: documentation, license,
+ * changelogs, and editor/VCS dotfiles. These contribute no scope and — unlike
+ * an unrecognized source/config file — must NOT force full. Kept narrow:
+ * anything that could plausibly change a test (config, lockfiles, scripts) is
+ * deliberately excluded so it falls through to the force-full path.
+ *
+ * Markdown is ignorable ANYWHERE (it cannot change runtime behavior). The
+ * LICENSE/CHANGELOG/dotfile basenames are ignored ONLY outside the component
+ * source tree: a position-insensitive basename match could otherwise swallow a
+ * (hypothetical) test-relevant `components/<slug>/LICENSE`, a silent miss. Any
+ * such file inside `src/components/**` instead force-fulls via the unaccounted
+ * path — safe and loud.
+ */
+function isIgnorableFile(repoRelativePath: string): boolean {
+  const path = normalizeRepoPath(repoRelativePath);
+  if (/\.(md|mdx|markdown)$/i.test(path)) return true;
+  if (path.startsWith('packages/components/src/')) return false;
+  const base = path.slice(path.lastIndexOf('/') + 1);
+  const IGNORABLE_BASENAMES = new Set([
+    'LICENSE',
+    '.gitignore',
+    '.gitattributes',
+    '.editorconfig',
+    '.prettierignore',
+  ]);
+  return IGNORABLE_BASENAMES.has(base);
+}
+
+/**
+ * Shared modules whose changes ARE traceable to component slugs via the graph
+ * (so they should not force full just for lacking a slug). These are the
+ * non-component source areas components import from.
+ */
+function isTraceableSharedModule(repoRelativePath: string): boolean {
+  const path = normalizeRepoPath(repoRelativePath);
+  return (
+    path.startsWith('packages/components/src/utilities/') ||
+    path.startsWith('packages/components/src/_internal/') ||
+    path.startsWith('packages/components/src/schemas/') ||
+    path.startsWith('packages/components/src/highlighters/') ||
+    path === 'packages/components/src/schema-types.ts' ||
+    path.startsWith('packages/components/src/test/') ||
+    path.startsWith('packages/editor/src/') ||
+    path.startsWith('packages/markdown/src/') ||
+    path.startsWith('packages/diff/src/') ||
+    path.startsWith('packages/commentary/src/')
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Filesystem wrappers (thin; the logic above is pure)
+// ---------------------------------------------------------------------------
+
+/**
+ * Read every scannable source file under {@link SCANNED_ROOTS} into a map of
+ * repo-relative POSIX path → contents. Excludes the test harness's own
+ * compiled output and node_modules (the globs are scoped to `src`).
+ */
+export async function loadSourceFiles(): Promise<Map<string, string>> {
+  const files = new Map<string, string>();
+  const glob = new Glob('**/*.{ts,tsx,svelte,mts,cts,js,mjs,cjs}');
+
+  for (const root of SCANNED_ROOTS) {
+    const absoluteRoot = join(workspaceRoot, root);
+    for await (const relativePath of glob.scan({ cwd: absoluteRoot })) {
+      const absolute = join(absoluteRoot, relativePath);
+      const repoRelative = normalizeRepoPath(relative(workspaceRoot, absolute));
+      // Test files are not part of the production graph (see isTestFile).
+      if (isTestFile(repoRelative)) continue;
+      files.set(repoRelative, await Bun.file(absolute).text());
+    }
+  }
+
+  return files;
+}
+
+/**
+ * Discover known component slugs by reading the components source directory:
+ * a slug is a directory directly under `src/components/` that contains a
+ * `<slug>.svelte`. Mirrors the playground's own discovery and the legacy
+ * `loadKnownSlugs` this graph replaces.
+ */
+export async function loadKnownSlugs(): Promise<Set<string>> {
+  const { readdir } = await import('node:fs/promises');
+  const componentsDirectory = join(workspaceRoot, COMPONENTS_PREFIX);
+  const entries = await readdir(componentsDirectory, { withFileTypes: true });
+  const slugs = new Set<string>();
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue;
+    if (entry.name.startsWith('_')) continue;
+    const svelte = join(componentsDirectory, entry.name, `${entry.name}.svelte`);
+    if (await Bun.file(svelte).exists()) slugs.add(entry.name);
+  }
+  return slugs;
+}
+
+/**
+ * Guard used by the test suite: assert that the ONLY computed dynamic imports
+ * in scanned source are the known-safe harness sites. If this throws, a new
+ * computed `import()` was introduced and the author must either refactor it to
+ * a string literal or add it to {@link UNMODELLABLE_IMPORT_ALLOWLIST} with a
+ * justification — otherwise scoping silently degrades to always-full.
+ */
+export function assertNoUnmodellableImports(files: ReadonlyMap<string, string>): void {
+  const offenders: string[] = [];
+  for (const [file, content] of files) {
+    if (isTestFile(file)) continue; // test-only computed imports are not graph edges
+    if (extractImports(content).hasUnmodellableImport && !UNMODELLABLE_IMPORT_ALLOWLIST.has(file)) {
+      offenders.push(file);
+    }
+  }
+  if (offenders.length > 0) {
+    throw new Error(
+      `Unmodellable computed dynamic import(s) found outside the allow-list:\n` +
+        offenders
+          .toSorted()
+          .map((file) => `  • ${file}`)
+          .join('\n') +
+        `\n\nThese create import edges the dependency-aware test scoper cannot see, so a change ` +
+        `to the imported module would silently skip the dependent's tests.\n` +
+        `Fix by refactoring to a string-literal import, or — if the import genuinely cannot ` +
+        `create a component→component edge — add the file to UNMODELLABLE_IMPORT_ALLOWLIST in ` +
+        `component-graph.ts with a comment explaining why.`,
+    );
+  }
+}

--- a/packages/components/scripts/component-graph.ts
+++ b/packages/components/scripts/component-graph.ts
@@ -75,11 +75,17 @@ export function isTestFile(repoRelativePath: string): boolean {
 }
 
 /**
- * The ONLY known-safe computed dynamic imports in component source. Both load
- * a temp SSR module written to disk at test time — they never create a
- * component→component edge — and live in the always-run `src/test/**` bucket.
- * Keyed by repo-relative POSIX path. {@link assertNoUnmodellableImports}
- * fails if a computed import appears anywhere NOT in this set.
+ * The ONLY known-safe computed dynamic imports. Both load a temp SSR module
+ * written to disk at test time — they never create a component→component edge.
+ * Keyed by repo-relative POSIX path.
+ *
+ * INVARIANT: every entry MUST be under `packages/components/src/test/`, which
+ * itself force-fulls when changed (see {@link pathForceFullReason}). This keeps
+ * the allow-list strictly test-harness-scoped: it exists only so the GLOBAL
+ * unmodellable scan in {@link computeScope} does not force-full on every run for
+ * these dormant harness imports — it can NEVER be used to wave through a
+ * computed import in real component source (that still force-fulls). The
+ * invariant is enforced by a unit test and by {@link assertNoUnmodellableImports}.
  */
 export const UNMODELLABLE_IMPORT_ALLOWLIST: ReadonlySet<string> = new Set([
   'packages/components/src/test/hydrate.ts',
@@ -203,7 +209,7 @@ export function extractImports(content: string): ExtractedImports {
 
 export type ResolveResult =
   | { kind: 'resolved'; path: string }
-  | { kind: 'ambiguous'; candidates: string[] }
+  | { kind: 'ambiguous'; candidates: readonly string[] }
   | { kind: 'external' };
 
 /**
@@ -249,8 +255,17 @@ export function resolveCandidates(absoluteBase: string): string[] {
   return candidates;
 }
 
+/** Compound extensions checked before the generic single-dot fallback. */
+const COMPOUND_EXTENSIONS = ['.svelte.ts', '.svelte.tsx'] as const;
+
 function extensionOf(path: string): string {
   const base = path.slice(path.lastIndexOf('/') + 1);
+  // `button.svelte.ts` must report `.svelte.ts`, not `.ts` — otherwise an
+  // explicit `./button.svelte.ts` specifier would skip the extensionless probe
+  // that generates the `.svelte.ts` candidate.
+  for (const compound of COMPOUND_EXTENSIONS) {
+    if (base.endsWith(compound)) return compound;
+  }
   const dot = base.lastIndexOf('.');
   return dot <= 0 ? '' : base.slice(dot);
 }
@@ -366,18 +381,12 @@ export function buildImportGraph(
         back.add(file);
         reverse.set(result.path, back);
       } else if (result.kind === 'ambiguous') {
+        // Record the file as ambiguous. We do NOT synthesize reverse edges for
+        // the candidates: any ambiguous import in the scanned graph forces a
+        // full run globally (see computeScope step 3), so the closure never
+        // needs to "reach" this file. Keeping the graph free of speculative
+        // edges keeps it an honest model of the real imports.
         ambiguousFiles.add(file);
-        // CRITICAL: add a reverse edge from EVERY ambiguous candidate to this
-        // file. Without it, a change to one candidate would never reach this
-        // importing file in the dependents BFS, so the `ambiguousInClosure`
-        // guard could not fire and the file would be silently dropped. With
-        // the edges, any candidate's change reaches this file, the guard
-        // detects the ambiguity, and the run force-fulls — the safe outcome.
-        for (const candidate of result.candidates) {
-          const back = reverse.get(candidate) ?? new Set<string>();
-          back.add(file);
-          reverse.set(candidate, back);
-        }
       }
     }
   }
@@ -437,8 +446,19 @@ export function pathForceFullReason(repoRelativePath: string): string | null {
   // default — a scoper bug must not be able to under-test the very PR that
   // introduced it.
   if (path.startsWith('packages/testing/')) {
-    if (path === 'packages/testing/README.md') return null;
+    // Markdown in the testing package (README, auto-generated CHANGELOG) cannot
+    // affect test behavior.
+    if (/\.(md|mdx)$/.test(path)) return null;
     return `testing-harness change: ${path}`;
+  }
+
+  // The components package's SHARED test harness (`src/test/**`: lifecycle
+  // helpers, render/hydrate utilities) is imported by component tests but is
+  // excluded from the import graph, so it has no reverse edges to map. A change
+  // there can affect EVERY component test, so force full rather than let it be
+  // silently dropped when co-changed with a single component.
+  if (path.startsWith('packages/components/src/test/')) {
+    return `shared test-harness change: ${path}`;
   }
 
   // Lockfile / runtime config / TS config: can change resolution for everything.
@@ -482,7 +502,7 @@ export function pathForceFullReason(repoRelativePath: string): string | null {
 
 export type ScopeDecision =
   | { mode: 'full'; reason: string }
-  | { mode: 'filtered'; slugs: string[] };
+  | { mode: 'filtered'; slugs: readonly string[] };
 
 export type ComputeScopeOptions = {
   /** Repo-relative POSIX paths of files the diff touched. */
@@ -529,7 +549,12 @@ export function computeScope(options: ComputeScopeOptions): ScopeDecision {
     };
   }
 
-  // 3. Globally-unsafe computed imports.
+  // 3. Globally-unsafe edges force full, regardless of what changed. Both
+  //    represent edges the graph could not model, so ANY closure built from
+  //    this graph might be incomplete — the only safe response is full.
+  //    Handling them globally (rather than only when reached in the closure)
+  //    also lets us avoid synthesizing speculative reverse edges for ambiguous
+  //    imports: we never need the closure to "reach" them.
   const graph = buildImportGraph(sourceFiles);
   const offendingUnmodellable = [...graph.unmodellableFiles].filter(
     (file) => !UNMODELLABLE_IMPORT_ALLOWLIST.has(file),
@@ -538,6 +563,12 @@ export function computeScope(options: ComputeScopeOptions): ScopeDecision {
     return {
       mode: 'full',
       reason: `computed dynamic import (unmodellable edge) in: ${offendingUnmodellable.toSorted().join(', ')}`,
+    };
+  }
+  if (graph.ambiguousFiles.size > 0) {
+    return {
+      mode: 'full',
+      reason: `ambiguous import (unresolvable edge) in: ${[...graph.ambiguousFiles].toSorted().join(', ')}`,
     };
   }
 
@@ -575,18 +606,9 @@ export function computeScope(options: ComputeScopeOptions): ScopeDecision {
     return { mode: 'full', reason: `unaccounted changed file: ${file}` };
   }
 
-  // 4. Dependents closure → slugs.
+  // 4. Dependents closure → slugs. (Ambiguity is already handled globally in
+  //    step 3, so the closure here is built from a fully-modelled graph.)
   const closure = dependentsClosure(graph, closureSeeds);
-
-  // Ambiguous import on any file in the closure → full (we refused to guess its
-  // edges, so the closure may be incomplete).
-  const ambiguousInClosure = [...closure].filter((file) => graph.ambiguousFiles.has(file));
-  if (ambiguousInClosure.length > 0) {
-    return {
-      mode: 'full',
-      reason: `ambiguous import on closure file(s): ${ambiguousInClosure.toSorted().join(', ')}`,
-    };
-  }
 
   const slugs = new Set<string>(directSlugs);
   for (const file of closure) {
@@ -654,7 +676,6 @@ function isTraceableSharedModule(repoRelativePath: string): boolean {
     path.startsWith('packages/components/src/schemas/') ||
     path.startsWith('packages/components/src/highlighters/') ||
     path === 'packages/components/src/schema-types.ts' ||
-    path.startsWith('packages/components/src/test/') ||
     path.startsWith('packages/editor/src/') ||
     path.startsWith('packages/markdown/src/') ||
     path.startsWith('packages/diff/src/') ||

--- a/packages/components/scripts/test-changed.test.ts
+++ b/packages/components/scripts/test-changed.test.ts
@@ -26,14 +26,27 @@ describe('testPathsForScope', () => {
     expect(testPathsForScope({ mode: 'filtered', slugs: [] })).toBeNull();
   });
 
-  it('maps slugs to component directories plus the always-run shared test dir', () => {
+  it('maps slugs to component dirs plus the always-run shared dirs and root tests', () => {
     const paths = testPathsForScope({ mode: 'filtered', slugs: ['button', 'badge'] });
-    expect(paths).toEqual(['src/test', 'src/components/button', 'src/components/badge']);
+    // Shared-source dirs whose own tests must run when a shared change widens slugs.
+    expect(paths).toContain('src/test');
+    expect(paths).toContain('src/utilities');
+    expect(paths).toContain('src/_internal');
+    expect(paths).toContain('src/highlighters');
+    // Package-level invariant tests (export drift, manifest, conventions).
+    expect(paths).toContain('src/exports-drift.test.ts');
+    expect(paths).toContain('src/api-contract.test.ts');
+    expect(paths).toContain('src/manifest.test.ts');
+    // The scoped component dirs.
+    expect(paths).toContain('src/components/button');
+    expect(paths).toContain('src/components/badge');
   });
 
-  it('always includes the shared test infra dir but NOT scripts/', () => {
+  it('always includes shared dirs + root invariant tests but NOT scripts/', () => {
     const paths = testPathsForScope({ mode: 'filtered', slugs: ['accordion'] });
     expect(paths).toContain('src/test');
+    expect(paths).toContain('src/utilities');
+    expect(paths).toContain('src/exports-drift.test.ts');
     // scripts/ tooling tests run only when scripts/ changes (which force-fulls).
     expect(paths).not.toContain('scripts');
     expect(paths).toContain('src/components/accordion');

--- a/packages/components/scripts/test-changed.test.ts
+++ b/packages/components/scripts/test-changed.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'bun:test';
+
+import { parseEnvSlugs, testPathsForScope } from './test-changed.ts';
+
+describe('parseEnvSlugs', () => {
+  it('returns an empty list when unset', () => {
+    expect(parseEnvSlugs(undefined)).toEqual([]);
+  });
+
+  it('returns an empty list for an empty/whitespace value', () => {
+    expect(parseEnvSlugs('')).toEqual([]);
+    expect(parseEnvSlugs('   ')).toEqual([]);
+  });
+
+  it('parses, trims, and drops empties', () => {
+    expect(parseEnvSlugs('button, badge ,, dialog')).toEqual(['button', 'badge', 'dialog']);
+  });
+});
+
+describe('testPathsForScope', () => {
+  it('returns null (full suite) for a full decision', () => {
+    expect(testPathsForScope({ mode: 'full', reason: 'lockfile change' })).toBeNull();
+  });
+
+  it('returns null (full suite) when filtered but empty', () => {
+    expect(testPathsForScope({ mode: 'filtered', slugs: [] })).toBeNull();
+  });
+
+  it('maps slugs to component directories plus the always-run shared test dir', () => {
+    const paths = testPathsForScope({ mode: 'filtered', slugs: ['button', 'badge'] });
+    expect(paths).toEqual(['src/test', 'src/components/button', 'src/components/badge']);
+  });
+
+  it('always includes the shared test infra dir but NOT scripts/', () => {
+    const paths = testPathsForScope({ mode: 'filtered', slugs: ['accordion'] });
+    expect(paths).toContain('src/test');
+    // scripts/ tooling tests run only when scripts/ changes (which force-fulls).
+    expect(paths).not.toContain('scripts');
+    expect(paths).toContain('src/components/accordion');
+  });
+});

--- a/packages/components/scripts/test-changed.ts
+++ b/packages/components/scripts/test-changed.ts
@@ -90,6 +90,14 @@ export function parseEnvSlugs(raw: string | undefined): string[] {
 
 /** Resolve the scope decision: env var first, else `git diff` against the base. */
 async function resolveScope(baseRef: string): Promise<ScopeDecision> {
+  // CI sets CINDER_TEST_MODE explicitly. `full` short-circuits to the full
+  // suite WITHOUT touching git — the CI checkout is shallow, so the git-diff
+  // fallback below would be unreliable there. This makes "CI says full" an
+  // explicit signal rather than inferring it from an empty component list.
+  if (process.env['CINDER_TEST_MODE'] === 'full') {
+    return { mode: 'full', reason: 'CINDER_TEST_MODE=full' };
+  }
+
   const envSlugs = parseEnvSlugs(process.env['CINDER_TEST_COMPONENTS']);
   if (envSlugs.length > 0) {
     // CI already computed the scope; trust it. Validate against known slugs so a

--- a/packages/components/scripts/test-changed.ts
+++ b/packages/components/scripts/test-changed.ts
@@ -39,18 +39,51 @@ const packageRoot = resolve(scriptDirectory, '..');
 const workspaceRoot = resolve(packageRoot, '..', '..');
 
 /**
- * Directories whose tests ALWAYS run regardless of scope.
+ * Paths whose tests ALWAYS run with any filtered (scoped) set.
  *
- * `src/test` holds the shared test harness (lifecycle helpers, render
- * utilities) that component tests import; a change there is force-full anyway,
- * but its own unit tests are cheap and worth running with any scoped set.
+ * A filtered decision widens component slugs when a SHARED module changes
+ * (`utilities/`, `_internal/`, `highlighters/`, `schema-types.ts`, etc.) — but
+ * the shared module's OWN tests, and the package-level invariant tests
+ * (`exports-drift`, `api-contract`, `manifest`, `tree-shake`, …), live OUTSIDE
+ * any `src/components/<slug>/` dir. Without these, a scoped run could pass while
+ * a shared module or the export surface is broken (the slugs widened, but only
+ * the component dirs were tested). So every scoped run also runs:
+ *   - the shared test harness + shared-source dirs (cheap unit tests), and
+ *   - the package-level invariant tests directly under `src/`.
  *
  * `scripts/` is deliberately NOT here: a component change must not drag in all
- * ~17 build/generate-tooling test files. Those tests run only when `scripts/`
- * itself changes — and a `scripts/` change force-fulls (see
- * `pathForceFullReason`), which runs them via the full suite.
+ * ~17 build/generate-tooling test files. Those run only when `scripts/` itself
+ * changes — and a `scripts/` change force-fulls (see `pathForceFullReason`),
+ * which runs them via the full suite.
  */
-const ALWAYS_RUN_PATHS = ['src/test'] as const;
+const ALWAYS_RUN_PATHS = [
+  'src/test',
+  'src/utilities',
+  'src/_internal',
+  'src/highlighters',
+  'src/schemas',
+] as const;
+
+/**
+ * Package-level invariant test files that sit directly under `src/` (not in a
+ * component dir). These guard the export surface, manifest, and conventions —
+ * exactly the things a shared-module change can break — so they run with every
+ * scoped set. Listed explicitly (not by dir) because `src/` itself recurses
+ * into every component.
+ */
+const ALWAYS_RUN_ROOT_TESTS = [
+  'src/api-contract.test.ts',
+  'src/components.test.ts',
+  'src/compound-leaf-import-boundary.test.ts',
+  'src/compound-namespace.test.ts',
+  'src/convention.test.ts',
+  'src/domain-suite.test.ts',
+  'src/experimental-aliases.test.ts',
+  'src/exports-drift.test.ts',
+  'src/index.test.ts',
+  'src/manifest.test.ts',
+  'src/tree-shake.test.ts',
+] as const;
 
 /** The `bun test` flags the components package uses (browser+svelte conditions). */
 const BUN_TEST_FLAGS = [
@@ -72,7 +105,7 @@ export function testPathsForScope(decision: ScopeDecision): string[] | null {
   if (decision.mode === 'full') return null;
   if (decision.slugs.length === 0) return null;
 
-  const paths: string[] = [...ALWAYS_RUN_PATHS];
+  const paths: string[] = [...ALWAYS_RUN_PATHS, ...ALWAYS_RUN_ROOT_TESTS];
   for (const slug of decision.slugs) {
     paths.push(`src/components/${slug}`);
   }

--- a/packages/components/scripts/test-changed.ts
+++ b/packages/components/scripts/test-changed.ts
@@ -1,0 +1,167 @@
+/**
+ * Run the component unit tests scoped to the components a diff affects (the
+ * changed components AND their transitive dependents), instead of the full
+ * ~1000-file suite.
+ *
+ * Scope comes from the same dependency graph the Playwright scope job uses
+ * (`component-graph.ts`): either a `CINDER_TEST_COMPONENTS` env var (a
+ * comma-separated slug list, as CI sets it) or, when that is absent, computed
+ * locally from `git diff` against a base ref.
+ *
+ * Falls back to the FULL suite whenever scope is `full` or no slugs resolve —
+ * a missed edge silently skips a test, so "run everything" is the safe default.
+ *
+ * Test layout: each component's tests live under
+ * `src/components/<slug>/**` (including nested subdirectories like
+ * `chat/input/`), so scoping a slug means handing `bun test` that directory.
+ * Shared test infrastructure under `src/test/**` and the scripts' own tests
+ * always run, because a change anywhere can rely on them.
+ *
+ * Usage:
+ *   bun run scripts/test-changed.ts                 # CINDER_TEST_COMPONENTS or git diff
+ *   CINDER_TEST_COMPONENTS=button,badge bun run scripts/test-changed.ts
+ *   bun run scripts/test-changed.ts --base origin/main
+ */
+
+import { existsSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import {
+  computeScope,
+  loadKnownSlugs,
+  loadSourceFiles,
+  type ScopeDecision,
+} from './component-graph.ts';
+
+const scriptDirectory = dirname(fileURLToPath(import.meta.url));
+const packageRoot = resolve(scriptDirectory, '..');
+const workspaceRoot = resolve(packageRoot, '..', '..');
+
+/**
+ * Directories whose tests ALWAYS run regardless of scope.
+ *
+ * `src/test` holds the shared test harness (lifecycle helpers, render
+ * utilities) that component tests import; a change there is force-full anyway,
+ * but its own unit tests are cheap and worth running with any scoped set.
+ *
+ * `scripts/` is deliberately NOT here: a component change must not drag in all
+ * ~17 build/generate-tooling test files. Those tests run only when `scripts/`
+ * itself changes — and a `scripts/` change force-fulls (see
+ * `pathForceFullReason`), which runs them via the full suite.
+ */
+const ALWAYS_RUN_PATHS = ['src/test'] as const;
+
+/** The `bun test` flags the components package uses (browser+svelte conditions). */
+const BUN_TEST_FLAGS = [
+  '--conditions',
+  'browser',
+  '--conditions',
+  'svelte',
+  '--parallel=1',
+] as const;
+
+/**
+ * Map a scope decision to the positional path arguments for `bun test`.
+ *
+ * Returns `null` to signal "run the full suite" (no positional filters). A
+ * filtered decision returns the always-run shared dirs plus one directory per
+ * scoped slug. Pure + exported for unit testing.
+ */
+export function testPathsForScope(decision: ScopeDecision): string[] | null {
+  if (decision.mode === 'full') return null;
+  if (decision.slugs.length === 0) return null;
+
+  const paths: string[] = [...ALWAYS_RUN_PATHS];
+  for (const slug of decision.slugs) {
+    paths.push(`src/components/${slug}`);
+  }
+  return paths;
+}
+
+/** Parse the `CINDER_TEST_COMPONENTS` env var into a slug list (empty = unset). */
+export function parseEnvSlugs(raw: string | undefined): string[] {
+  if (raw === undefined) return [];
+  return raw
+    .split(',')
+    .map((slug) => slug.trim())
+    .filter((slug) => slug.length > 0);
+}
+
+/** Resolve the scope decision: env var first, else `git diff` against the base. */
+async function resolveScope(baseRef: string): Promise<ScopeDecision> {
+  const envSlugs = parseEnvSlugs(process.env['CINDER_TEST_COMPONENTS']);
+  if (envSlugs.length > 0) {
+    // CI already computed the scope; trust it. Validate against known slugs so a
+    // stale/typo'd value fails loud rather than silently testing nothing.
+    const knownSlugs = await loadKnownSlugs();
+    const unknown = envSlugs.filter((slug) => !knownSlugs.has(slug));
+    if (unknown.length > 0) {
+      throw new Error(
+        `CINDER_TEST_COMPONENTS has unknown slug(s): ${unknown.toSorted().join(', ')}`,
+      );
+    }
+    return { mode: 'filtered', slugs: [...envSlugs].toSorted() };
+  }
+
+  // No env scope: compute from the working tree's diff against the base.
+  const diff = Bun.spawnSync(['git', 'diff', '--name-only', `${baseRef}...HEAD`], {
+    cwd: workspaceRoot,
+  });
+  const changedFiles = new TextDecoder()
+    .decode(diff.stdout)
+    .split('\n')
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0);
+
+  if (changedFiles.length === 0) {
+    return { mode: 'full', reason: 'no diff against base — running full suite' };
+  }
+
+  // Detect deletions/renames by disk absence rather than `--diff-filter=D`:
+  // without `-M`, a rename reports only the new path under D, so the old
+  // (source) side would be missed. A changed path absent at HEAD is gone,
+  // however it was removed. Mirrors changed-components.ts.
+  const deletedFiles = changedFiles.filter((file) => !existsSync(join(workspaceRoot, file)));
+
+  const [sourceFiles, knownSlugs] = await Promise.all([loadSourceFiles(), loadKnownSlugs()]);
+  return computeScope({ changedFiles, deletedFiles, sourceFiles, knownSlugs });
+}
+
+function parseBaseRef(argv: string[]): string {
+  const index = argv.indexOf('--base');
+  if (index !== -1 && argv[index + 1] !== undefined) return argv[index + 1]!;
+  return 'origin/main';
+}
+
+async function main(): Promise<void> {
+  const baseRef = parseBaseRef(process.argv.slice(2));
+  const decision = await resolveScope(baseRef);
+  const paths = testPathsForScope(decision);
+
+  if (paths === null) {
+    const reason = decision.mode === 'full' ? decision.reason : 'no scoped slugs';
+    process.stderr.write(`test-changed: full suite (${reason})\n`);
+  } else {
+    process.stderr.write(
+      `test-changed: ${decision.mode === 'filtered' ? decision.slugs.length : 0} component(s): ` +
+        `${decision.mode === 'filtered' ? decision.slugs.join(', ') : ''}\n`,
+    );
+  }
+
+  const positional = paths ?? [];
+  const child = Bun.spawn(['bun', 'test', ...BUN_TEST_FLAGS, ...positional], {
+    cwd: packageRoot,
+    stdio: ['inherit', 'inherit', 'inherit'],
+    env: { ...process.env, TZ: 'UTC', LANG: 'en_US.UTF-8' },
+  });
+  const exitCode = await child.exited;
+  process.exit(exitCode);
+}
+
+if (import.meta.main) {
+  main().catch((error: unknown) => {
+    process.stderr.write(`test-changed failed: ${String(error)}\n`);
+    process.exit(1);
+  });
+}

--- a/packages/components/scripts/test-changed.ts
+++ b/packages/components/scripts/test-changed.ts
@@ -116,6 +116,17 @@ async function resolveScope(baseRef: string): Promise<ScopeDecision> {
   const diff = Bun.spawnSync(['git', 'diff', '--name-only', `${baseRef}...HEAD`], {
     cwd: workspaceRoot,
   });
+  // A failed git invocation (e.g. base ref not fetched on a shallow clone) must
+  // NOT be misread as "empty diff → full". Surface it as full WITH the reason,
+  // so the run is safe (full) and the failure is visible in the log rather than
+  // silently swallowed. This path is local-only; CI sets CINDER_TEST_MODE.
+  if (diff.exitCode !== 0) {
+    const stderr = new TextDecoder().decode(diff.stderr).trim();
+    return {
+      mode: 'full',
+      reason: `git diff against '${baseRef}' failed (running full): ${stderr || `exit ${diff.exitCode}`}`,
+    };
+  }
   const changedFiles = new TextDecoder()
     .decode(diff.stdout)
     .split('\n')

--- a/packages/testing/scripts/changed-components.test.ts
+++ b/packages/testing/scripts/changed-components.test.ts
@@ -103,6 +103,30 @@ describe('changed-components decide()', () => {
     const result = decide(['', `${C}/badge/badge.svelte`, '  '], sourceFiles, knownSlugs);
     expect(result).toEqual({ mode: 'filtered', components: ['badge'] });
   });
+
+  it('forces full when an example is co-changed with a real force-full trigger', () => {
+    // The example slug must NOT rescue a genuine force-full (e.g. lockfile). This
+    // pins the string-match branch in decide() that distinguishes "no component
+    // changes" (example wins) from a real force-full reason (full wins).
+    const result = decide(
+      ['packages/playground/src/examples/accordion/basic.example.svelte', 'bun.lock'],
+      sourceFiles,
+      knownSlugs,
+    );
+    expect(result.mode).toBe('full');
+  });
+
+  it('filters to the example slug when the only co-change is an ignorable doc', () => {
+    const result = decide(
+      [
+        'packages/playground/src/examples/accordion/basic.example.svelte',
+        'packages/playground/README.md',
+      ],
+      sourceFiles,
+      knownSlugs,
+    );
+    expect(result).toEqual({ mode: 'filtered', components: ['accordion'] });
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/testing/scripts/changed-components.test.ts
+++ b/packages/testing/scripts/changed-components.test.ts
@@ -1,153 +1,149 @@
 import { describe, expect, it } from 'bun:test';
+import { spawnSync } from 'node:child_process';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 import { decide } from './changed-components.ts';
 
+const scriptDirectory = dirname(fileURLToPath(import.meta.url));
+const workspaceRoot = resolve(scriptDirectory, '..', '..', '..');
+
+const C = 'packages/components/src/components';
+const U = 'packages/components/src/utilities';
+
+/**
+ * A small synthetic source tree exercising the dependents graph without the
+ * filesystem:
+ *   button  ← dialog ← confirm
+ *   badge   (leaf)
+ *   class-names.ts ← button, badge
+ */
+const sourceFiles = new Map<string, string>([
+  [`${C}/button/button.svelte`, `import { cx } from '../../utilities/class-names.ts';`],
+  [`${C}/dialog/dialog.svelte`, `import Button from '../button/button.svelte';`],
+  [`${C}/confirm/confirm.svelte`, `import Dialog from '../dialog/dialog.svelte';`],
+  [`${C}/badge/badge.svelte`, `import { cx } from '../../utilities/class-names.ts';`],
+  [`${U}/class-names.ts`, `export const cx = () => '';`],
+]);
+const knownSlugs = new Set(['button', 'dialog', 'confirm', 'badge', 'accordion']);
+
 describe('changed-components decide()', () => {
-  it('returns filtered list for a single component change', () => {
-    const result = decide(['packages/components/src/components/accordion.svelte']);
-    expect(result).toEqual({ mode: 'filtered', components: ['accordion'] });
-  });
-
-  it('returns filtered list for multiple components, sorted and deduped', () => {
-    const result = decide([
-      'packages/components/src/components/button.svelte',
-      'packages/components/src/components/accordion.svelte',
-      'packages/components/src/components/button.test.ts',
-      'packages/playground/src/examples/accordion/basic.example.svelte',
-    ]);
-    expect(result).toEqual({ mode: 'filtered', components: ['accordion', 'button'] });
-  });
-
-  it('matches .a11y.md, .test.ts, and .type-test.ts siblings', () => {
-    const result = decide([
-      'packages/components/src/components/accordion.a11y.md',
-      'packages/components/src/components/button-group.test.ts',
-      'packages/components/src/components/button-group.type-test.ts',
-    ]);
-    expect(result).toEqual({ mode: 'filtered', components: ['accordion', 'button-group'] });
-  });
-
-  it('returns full when an _internal helper is touched', () => {
-    const result = decide([
-      'packages/components/src/_internal/focus.ts',
-      'packages/components/src/components/button.svelte',
-    ]);
-    expect(result.mode).toBe('full');
-  });
-
-  it('returns full when a utilities/* file is touched', () => {
-    const result = decide(['packages/components/src/utilities/class-names.ts']);
-    expect(result.mode).toBe('full');
-  });
-
-  it('returns full for changes in editor / markdown / commentary / diff packages', () => {
-    for (const file of [
-      'packages/editor/src/index.ts',
-      'packages/markdown/src/parse.ts',
-      'packages/commentary/src/index.ts',
-      'packages/diff/src/render.ts',
-    ]) {
-      expect(decide([file]).mode).toBe('full');
-    }
-  });
-
-  it('returns full when the playground server is touched', () => {
-    const result = decide(['packages/playground/src/server.ts']);
-    expect(result.mode).toBe('full');
-  });
-
-  it('returns full when the changed-set is empty', () => {
-    expect(decide([]).mode).toBe('full');
-    expect(decide(['', '   ', '\n']).mode).toBe('full');
-  });
-
-  it('ignores workflow + own-script files but falls back to full if nothing else changed', () => {
-    const result = decide([
-      '.github/workflows/browser-tests.yaml',
-      'packages/testing/scripts/changed-components.ts',
-      'packages/testing/scripts/changed-components.test.ts',
-    ]);
-    expect(result.mode).toBe('full');
-  });
-
-  it('treats workflow + own-script files as ignorable when paired with component changes', () => {
-    const result = decide([
-      '.github/workflows/browser-tests.yaml',
-      'packages/testing/scripts/changed-components.ts',
-      'packages/components/src/components/badge.svelte',
-    ]);
+  it('filters to a single component when nothing depends on it', () => {
+    const result = decide([`${C}/badge/badge.svelte`], sourceFiles, knownSlugs);
     expect(result).toEqual({ mode: 'filtered', components: ['badge'] });
   });
 
-  it('returns full when packages/testing/playwright.config.ts is touched', () => {
-    // The Playwright config affects every test run; changes here must
-    // trigger the full matrix, not be silently ignored.
-    const result = decide(['packages/testing/playwright.config.ts']);
-    expect(result.mode).toBe('full');
+  it('includes transitive dependents of a changed component', () => {
+    const result = decide([`${C}/button/button.svelte`], sourceFiles, knownSlugs);
+    expect(result).toEqual({ mode: 'filtered', components: ['button', 'confirm', 'dialog'] });
   });
 
-  it('returns full when a packages/testing fixture is touched', () => {
-    // Fixtures (component-page.ts, theme.ts, etc.) affect every test.
-    const result = decide(['packages/testing/src/fixtures/component-page.ts']);
-    expect(result.mode).toBe('full');
+  it('fans a shared utility out to every dependent', () => {
+    const result = decide([`${U}/class-names.ts`], sourceFiles, knownSlugs);
+    expect(result).toEqual({
+      mode: 'filtered',
+      components: ['badge', 'button', 'confirm', 'dialog'],
+    });
   });
 
-  it('returns full when packages/testing/tests/* is touched', () => {
-    // The spec file itself drives the matrix; changes there can affect
-    // every component's run.
-    const result = decide(['packages/testing/tests/components.spec.ts']);
-    expect(result.mode).toBe('full');
-  });
-
-  it('returns full for a root-level file like package.json', () => {
-    const result = decide(['package.json']);
-    expect(result.mode).toBe('full');
-  });
-
-  it('returns full for bun.lock changes', () => {
-    const result = decide(['bun.lock']);
-    expect(result.mode).toBe('full');
-  });
-
-  it('falls back to full when an extracted slug is not in the manifest', () => {
-    // A cross-cutting helper directory under examples that happens to
-    // match the slug regex must not silently be treated as a component.
-    const knownSlugs = new Set(['accordion', 'button']);
-    const result = decide(['packages/playground/src/examples/shared/helper.svelte'], knownSlugs);
-    expect(result.mode).toBe('full');
-    if (result.mode === 'full') {
-      expect(result.reason).toContain('shared');
-    }
-  });
-
-  it('keeps filtered mode when every extracted slug is in the manifest', () => {
-    const knownSlugs = new Set(['accordion', 'button', 'badge']);
-    const result = decide(['packages/components/src/components/accordion.svelte'], knownSlugs);
+  it('maps a playground example change to its slug', () => {
+    const result = decide(
+      ['packages/playground/src/examples/accordion/basic.example.svelte'],
+      sourceFiles,
+      knownSlugs,
+    );
     expect(result).toEqual({ mode: 'filtered', components: ['accordion'] });
   });
 
-  it('falls back to full when a deleted component slug is extracted', () => {
-    // A PR that removes `view-switcher.svelte` will have the deleted file
-    // path in `git diff --name-only`. The known-slug set no longer contains
-    // it, so the suite must run in full mode rather than throw at slug
-    // validation in components.spec.ts.
-    const knownSlugs = new Set(['accordion', 'button']);
-    const result = decide(['packages/components/src/components/view-switcher.svelte'], knownSlugs);
+  it('merges example slugs with component-source slugs', () => {
+    const result = decide(
+      [`${C}/badge/badge.svelte`, 'packages/playground/src/examples/accordion/x.example.svelte'],
+      sourceFiles,
+      knownSlugs,
+    );
+    expect(result).toEqual({ mode: 'filtered', components: ['accordion', 'badge'] });
+  });
+
+  it('forces full for an example of an unknown slug', () => {
+    const result = decide(
+      ['packages/playground/src/examples/ghost/x.example.svelte'],
+      sourceFiles,
+      knownSlugs,
+    );
     expect(result.mode).toBe('full');
   });
 
-  it('returns full for shared CSS / utility files in packages/components/src', () => {
-    expect(decide(['packages/components/src/styles/shared.css']).mode).toBe('full');
-    expect(decide(['packages/components/src/styles/components.css']).mode).toBe('full');
+  it('forces full when a testing-harness file is touched', () => {
+    const result = decide(
+      [`${C}/button/button.svelte`, 'packages/testing/playwright.config.ts'],
+      sourceFiles,
+      knownSlugs,
+    );
+    expect(result.mode).toBe('full');
   });
 
-  it('returns full for component-package manifest / public-export files', () => {
-    expect(decide(['packages/components/src/index.ts']).mode).toBe('full');
-    expect(decide(['packages/components/package.json']).mode).toBe('full');
+  it('forces full for the lockfile and root manifest', () => {
+    expect(decide(['bun.lock'], sourceFiles, knownSlugs).mode).toBe('full');
+    expect(decide(['package.json'], sourceFiles, knownSlugs).mode).toBe('full');
   });
 
-  it('returns full for playground server / discovery files outside examples/', () => {
-    expect(decide(['packages/playground/src/discover.ts']).mode).toBe('full');
-    expect(decide(['packages/playground/src/shell-app/routing.ts']).mode).toBe('full');
+  it('forces full for global style changes', () => {
+    const result = decide(['packages/components/src/styles/tokens.css'], sourceFiles, knownSlugs);
+    expect(result.mode).toBe('full');
+  });
+
+  it('forces full when a changed file was deleted', () => {
+    const result = decide([`${C}/button/button.svelte`], sourceFiles, knownSlugs, [
+      `${C}/old/old.svelte`,
+    ]);
+    expect(result.mode).toBe('full');
+  });
+
+  it('ignores blank lines in the changed-file list', () => {
+    const result = decide(['', `${C}/badge/badge.svelte`, '  '], sourceFiles, knownSlugs);
+    expect(result).toEqual({ mode: 'filtered', components: ['badge'] });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Integration: run the ACTUAL CLI from the repo root, exactly as CI does.
+// ---------------------------------------------------------------------------
+
+describe('changed-components CLI (integration, real tree)', () => {
+  function runCli(changedPaths: string[]): { mode: string; components: string } {
+    const result = spawnSync('bun', ['run', 'packages/testing/scripts/changed-components.ts'], {
+      cwd: workspaceRoot,
+      input: changedPaths.join('\n') + '\n',
+      encoding: 'utf-8',
+      env: { ...process.env, GITHUB_OUTPUT: '' },
+    });
+    expect(result.status).toBe(0);
+    const stdout = result.stdout ?? '';
+    const mode = /mode=(\w+)/.exec(stdout)?.[1] ?? '';
+    const components = /components=([^\n]*)/.exec(stdout)?.[1] ?? '';
+    return { mode, components };
+  }
+
+  it('a real button change is filtered to button + real dependents', () => {
+    const { mode, components } = runCli([
+      'packages/components/src/components/button/button.svelte',
+    ]);
+    expect(mode).toBe('filtered');
+    const slugs = components.split(',');
+    expect(slugs).toContain('button');
+    expect(slugs).toContain('confirm-dialog');
+    expect(slugs).toContain('alert-dialog');
+  });
+
+  it('the lockfile forces full', () => {
+    expect(runCli(['bun.lock'])).toEqual({ mode: 'full', components: '' });
+  });
+
+  it('a real example change is filtered to its slug', () => {
+    const { mode, components } = runCli([
+      'packages/playground/src/examples/accordion/basic.example.svelte',
+    ]);
+    expect(mode).toBe('filtered');
+    expect(components.split(',')).toContain('accordion');
   });
 });

--- a/packages/testing/scripts/changed-components.ts
+++ b/packages/testing/scripts/changed-components.ts
@@ -1,151 +1,132 @@
 /**
- * Compute the set of component slugs touched by a diff, or signal that the
- * full matrix must run.
+ * Decide which component test scope a diff requires: the full matrix, or a
+ * filtered slug list covering the changed components AND every component that
+ * (transitively) depends on them.
  *
- * Reads newline-separated file paths from stdin (the output of
- * `git diff --name-only <base>..HEAD`) and either writes to `$GITHUB_OUTPUT`
- * (when present, for CI consumption) or prints the decision as `key=value`
- * lines to stdout (for local debugging).
+ * Reads newline-separated changed file paths from stdin (the output of
+ * `git diff --name-only <base>..HEAD`) and either appends `mode=`/`components=`
+ * to `$GITHUB_OUTPUT` (CI) or prints them to stdout (local debugging).
  *
- * The decision is `mode=full` when:
+ * The real dependency logic lives in
+ * `packages/components/scripts/component-graph.ts` — a pure, file-level import
+ * graph. This script is the thin CLI adapter: it loads the source files and
+ * known slugs, classifies the diff, and emits the decision in the format the
+ * `browser-tests.yaml` `scope` job expects.
  *
- *   - any changed file falls outside the "safe" per-component scope (shared
- *     utilities, `_internal/*` helpers, the playground server, sibling
- *     `editor` / `markdown` / `commentary` / `diff` packages, etc.) — these
- *     can affect every component's bundle, and
- *   - any file under `packages/testing/` other than this narrow allow-list:
- *     the README and this script's own files. Test fixtures, the Playwright
- *     config, and helper modules all affect every test, so changes there
- *     force the full matrix.
+ * Scope is `full` whenever anything is uncertain (a shared/harness/config
+ * change, a deletion, a computed dynamic import, an ambiguous resolution, or a
+ * closure that reaches an unknown slug) — a missed edge silently skips a test,
+ * which is strictly worse than a redundant full run. It is `filtered` only when
+ * every changed file maps cleanly to a known component slug or its dependents.
  *
- * It is `mode=filtered` with a comma-separated, sorted `components` list when
- * every non-ignorable changed file maps to a known component slug — which
- * is verified against the set of `*.svelte` filenames currently living in
- * `packages/components/src/components/`. Slugs that don't exist there
- * (deleted components, or cross-cutting example directories like
- * `packages/playground/src/examples/shared/` that happen to match the
- * extraction regex) trigger a fallback to full so the spec file's own
- * unknown-slug guard never has to throw at suite-load time.
- *
- * Designed for CI: invoked from `.github/workflows/browser-tests.yaml` to
- * decide whether to set `CINDER_TEST_COMPONENTS` for the Playwright suite.
+ * Beyond component source, two diff categories also map to slugs directly:
+ *   - `packages/playground/src/examples/<slug>/…` — a component's playground
+ *     example feeds its rendered fixture, so an example change retests `<slug>`.
+ * Everything the graph cannot place falls through to `computeScope`, which
+ * force-fulls on anything it cannot map.
  */
 
-import { readdir } from 'node:fs/promises';
-import { dirname, resolve } from 'node:path';
+import { existsSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-const componentFilePattern =
-  /^packages\/components\/src\/components\/([a-z0-9][a-z0-9-]*)\.(svelte|a11y\.md|test\.ts|type-test\.ts)$/;
-const exampleFilePattern = /^packages\/playground\/src\/examples\/([a-z0-9][a-z0-9-]*)\//;
+import {
+  computeScope,
+  loadKnownSlugs,
+  loadSourceFiles,
+  type ScopeDecision,
+} from '../../components/scripts/component-graph.ts';
 
-/**
- * Files that don't affect component bundles or the test harness, and can be
- * ignored when deciding scope. Touching only these falls through to "no
- * components changed" and the caller drops to `mode=full` to keep main
- * branches safe. Kept deliberately narrow: anything that could change how
- * tests run (fixtures, Playwright config, manifest helpers) must force the
- * full matrix.
- */
-const ignorablePatterns: readonly RegExp[] = [
-  /^\.github\/workflows\/browser-tests\.yaml$/,
-  /^packages\/testing\/README\.md$/,
-  /^packages\/testing\/scripts\/changed-components\.(ts|test\.ts)$/,
-  /^README\.md$/,
-  /^\.gitignore$/,
-];
+const scriptDirectory = dirname(fileURLToPath(import.meta.url));
+// scripts/ → packages/testing → packages → repo root
+const workspaceRoot = resolve(scriptDirectory, '..', '..', '..');
+
+/** `packages/playground/src/examples/<slug>/…` → `<slug>`. */
+const examplePattern = /^packages\/playground\/src\/examples\/([a-z0-9][a-z0-9-]*)\//;
 
 export type Decision =
   | { mode: 'full'; reason: string }
   | { mode: 'filtered'; components: string[] };
 
 /**
- * Decide whether the suite should run in full or filtered mode based on a
- * list of changed file paths.
+ * Decide scope from a list of changed file paths.
  *
- * @param changedFiles - newline-stripped file paths from `git diff --name-only`.
- * @param knownSlugs - the set of component slugs derived from the
- *   `packages/components/src/components/*.svelte` source tree. When omitted,
- *   slug validation is skipped (used by unit tests for the
- *   path-classification logic in isolation).
+ * Pure-ish: the source-file map and known-slug set are injected so unit tests
+ * exercise the classification without the filesystem. `deletedFiles` lists the
+ * changed paths that no longer exist on disk (deletions/renames) — those force
+ * full because the current-state graph cannot know who depended on them.
+ *
+ * @param changedFiles - newline-stripped paths from `git diff --name-only`.
+ * @param sourceFiles - the scanned source set (repo-relative POSIX path → text).
+ * @param knownSlugs - component slugs derived from the source tree.
+ * @param deletedFiles - changed paths absent on disk.
  */
-export function decide(changedFiles: string[], knownSlugs?: ReadonlySet<string>): Decision {
-  const slugs = new Set<string>();
+export function decide(
+  changedFiles: string[],
+  sourceFiles: ReadonlyMap<string, string>,
+  knownSlugs: ReadonlySet<string>,
+  deletedFiles: string[] = [],
+): Decision {
+  const cleaned = changedFiles.map((line) => line.trim()).filter((line) => line.length > 0);
 
-  for (const raw of changedFiles) {
-    const path = raw.trim();
-    if (path.length === 0) continue;
-
-    if (ignorablePatterns.some((pattern) => pattern.test(path))) continue;
-
-    const componentMatch = componentFilePattern.exec(path);
-    if (componentMatch && componentMatch[1] !== undefined) {
-      slugs.add(componentMatch[1]);
-      continue;
-    }
-
-    const exampleMatch = exampleFilePattern.exec(path);
-    if (exampleMatch && exampleMatch[1] !== undefined) {
-      slugs.add(exampleMatch[1]);
-      continue;
-    }
-
-    return {
-      mode: 'full',
-      reason: `Changed file outside per-component scope: ${path}`,
-    };
-  }
-
-  if (slugs.size === 0) {
-    return { mode: 'full', reason: 'No component-scoped changes detected.' };
-  }
-
-  if (knownSlugs !== undefined) {
-    const unknown = [...slugs].filter((slug) => !knownSlugs.has(slug));
-    if (unknown.length > 0) {
-      return {
-        mode: 'full',
-        reason: `Extracted slug(s) not present in manifest: ${unknown.toSorted().join(', ')}`,
-      };
+  // Example changes map directly to a slug. Collect them, and hand the rest to
+  // the graph. An example for an UNKNOWN slug forces full (mirrors the graph's
+  // unknown-slug guard) rather than silently inventing a slug.
+  const exampleSlugs = new Set<string>();
+  const nonExampleChanges: string[] = [];
+  for (const path of cleaned) {
+    const match = examplePattern.exec(path);
+    if (match?.[1] !== undefined) {
+      if (!knownSlugs.has(match[1])) {
+        return { mode: 'full', reason: `example for unknown slug: ${path}` };
+      }
+      exampleSlugs.add(match[1]);
+    } else {
+      nonExampleChanges.push(path);
     }
   }
 
-  return { mode: 'filtered', components: [...slugs].toSorted() };
+  const graphDecision: ScopeDecision = computeScope({
+    changedFiles: nonExampleChanges,
+    deletedFiles,
+    sourceFiles,
+    knownSlugs,
+  });
+
+  if (graphDecision.mode === 'full') {
+    // If the ONLY changes were examples (the graph saw nothing to map and said
+    // "no component-mapped changes"), the example slugs are still a valid
+    // filtered scope. Any other full reason (real force-full trigger) wins.
+    if (exampleSlugs.size > 0 && graphDecision.reason === 'no component-mapped changes detected') {
+      return { mode: 'filtered', components: [...exampleSlugs].toSorted() };
+    }
+    return { mode: 'full', reason: graphDecision.reason };
+  }
+
+  const components = new Set<string>([...graphDecision.slugs, ...exampleSlugs]);
+  return { mode: 'filtered', components: [...components].toSorted() };
 }
 
 /**
- * Discover known component slugs by reading the components source directory
- * directly. The playground manifest is built lazily and is not available at
- * the point the scope job runs in CI (no test setup has happened yet), so
- * the source tree is the only reliable slug source at decision time.
- *
- * Slugs are derived from `<slug>.svelte` filenames under
- * `packages/components/src/components/`, mirroring the discovery logic the
- * playground itself uses. Files prefixed with `_` (test harnesses, private
- * helpers) and known non-component conventions are skipped.
+ * Partition the raw changed-file list into (all, deleted). A path is "deleted"
+ * when it does not exist on disk at HEAD — the working tree CI checked out.
  */
-async function loadKnownSlugs(): Promise<ReadonlySet<string>> {
-  const here = dirname(fileURLToPath(import.meta.url));
-  // scripts/ → ../../components/src/components
-  const componentsDirectory = resolve(here, '..', '..', 'components', 'src', 'components');
-  const entries = await readdir(componentsDirectory);
-  const slugs = new Set<string>();
-  for (const entry of entries) {
-    if (!entry.endsWith('.svelte')) continue;
-    if (entry.startsWith('_')) continue;
-    slugs.add(entry.slice(0, -'.svelte'.length));
+function partitionDeleted(changedFiles: string[]): { all: string[]; deleted: string[] } {
+  const all: string[] = [];
+  const deleted: string[] = [];
+  for (const raw of changedFiles) {
+    const path = raw.trim();
+    if (path.length === 0) continue;
+    all.push(path);
+    if (!existsSync(join(workspaceRoot, path))) deleted.push(path);
   }
-  return slugs;
+  return { all, deleted };
 }
 
 async function emit(decision: Decision): Promise<void> {
   const githubOutput = process.env['GITHUB_OUTPUT'];
-  // Always write both `mode` and `components` so the workflow's downstream
-  // expressions can read `needs.scope.outputs.components` unconditionally.
-  // Full-mode runs emit an empty `components=` value.
   const componentsValue = decision.mode === 'filtered' ? decision.components.join(',') : '';
-  const lines = [`mode=${decision.mode}`, `components=${componentsValue}`, ''];
-  const payload = lines.join('\n');
+  const payload = [`mode=${decision.mode}`, `components=${componentsValue}`, ''].join('\n');
 
   if (githubOutput !== undefined && githubOutput.length > 0) {
     const { appendFile } = await import('node:fs/promises');
@@ -155,7 +136,7 @@ async function emit(decision: Decision): Promise<void> {
   }
 
   if (decision.mode === 'full') {
-    process.stderr.write(`changed-components: ${decision.reason}\n`);
+    process.stderr.write(`changed-components: full — ${decision.reason}\n`);
   } else {
     process.stderr.write(
       `changed-components: ${decision.components.length} component(s): ${decision.components.join(', ')}\n`,
@@ -165,9 +146,9 @@ async function emit(decision: Decision): Promise<void> {
 
 async function main(): Promise<void> {
   const input = await Bun.stdin.text();
-  const lines = input.split('\n');
-  const knownSlugs = await loadKnownSlugs();
-  const decision = decide(lines, knownSlugs);
+  const { all, deleted } = partitionDeleted(input.split('\n'));
+  const [sourceFiles, knownSlugs] = await Promise.all([loadSourceFiles(), loadKnownSlugs()]);
+  const decision = decide(all, sourceFiles, knownSlugs, deleted);
   await emit(decision);
 }
 


### PR DESCRIPTION
## Summary

Cinder has ~140 components that import each other via relative paths. CI ran the **full** Playwright matrix and full `bun test` on every PR — and the existing `changed-components.ts` scoping was **dead code** (it matched the old flat `components/<slug>.svelte` layout, but components moved to subdirectories, so every PR fell through to `mode=full`).

This builds a **file-level import graph** over the component packages, inverts it for dependents, and scopes both the Playwright sweep and a **new PR unit-test job** to the changed components **and their transitive dependents**.

The design biases hard toward **force-full on any uncertainty** — a missed edge silently skips a test, which is strictly worse than a redundant full run. It force-fulls on: shared/harness/config changes, deletions/renames, computed dynamic imports, ambiguous resolutions, unknown slugs, and any unaccounted changed file.

### What's in the box
- `packages/components/scripts/component-graph.ts` — the graph: import extraction (static, side-effect, `export … from`, multiline, dynamic), a bundler-style resolver (`.js`→`.ts`, extensionless/index probing, compound `.svelte.ts`), dependents BFS closure, three force-full classifiers, and `computeScope`. Plus `assertNoUnmodellableImports` / `assertNoAmbiguousImports` guards that keep the real tree scopable.
- `packages/testing/scripts/changed-components.ts` — rewritten to delegate to the graph; same `mode=`/`components=` CLI contract the `scope` job already consumes (so Playwright filtering activates immediately).
- `packages/components/scripts/test-changed.ts` + `test:changed` — scoped unit runner.
- `.github/workflows/unit-tests.yaml` — new scoped PR unit job (`main-green` stays the authoritative full gate; this push run is a redundant net).

### Authoritative-immediately
Per the repo owner's call, scoped Playwright + scoped unit are the PR gate now; `main-green`'s full run is the post-merge safety net.

## Review committee
Pre-reviewed by: typescript-expert, testing-expert, simplicity-engineer, dx-engineer, junior-engineer
- Codex (gpt-5.4, xhigh→high reasoning) — 2 rounds
- 2 rounds of committee review; all must-fix items addressed; all reviewers APPROVED in round 2
- Notable catches fixed: silent-miss on co-changed test files & shared harness, speculative ambiguous-edge removal (global force-full instead), workflow `paths:` omitting force-full triggers, two-dot→three-dot diff, scope-job timeout + push-to-main concurrency, `CINDER_TEST_MODE=full` sentinel for shallow clones.

## Test plan
- `bun test packages/components/scripts/ packages/testing/scripts/changed-components.test.ts` — 500+ unit + integration tests (resolver, closure, every force-full category, real-tree goldens, CLI-from-root).
- Verified against the real tree: a `button` change → `button` + 7 real dependents; a `utilities/class-names.ts` change → fans out to all importers; `bun.lock` / `src/test/**` / ambiguous import → full.
- Verified the scope CLI runs in a fresh clone with **no** `node_modules` (the scope job needs no `bun install`).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which tests run on every PR; the design force-fulls on ambiguity, but incorrect scoping could still miss regressions until post-merge full gates.
> 
> **Overview**
> Introduces **dependency-aware test scoping** so PR CI can run Playwright and component unit tests for only the changed components and their **transitive dependents**, instead of always running the full matrix.
> 
> A new **`component-graph`** module builds a file-level import graph (static/side-effect/re-exports and string-literal dynamic imports), resolves imports with bundler-style rules, and **`computeScope`** maps diffs to slugs or **force-full** on uncertainty (lockfiles, harness/config, deletions, unmodellable/ambiguous imports, unaccounted paths). **`changed-components.ts`** is rewritten to delegate to that graph while keeping the same `mode=` / `components=` contract for browser tests; playground example paths still map to slugs.
> 
> **`test-changed.ts`** and a **`test:changed`** script scope `bun test` via `CINDER_TEST_MODE` / `CINDER_TEST_COMPONENTS`. A new **`unit-tests`** workflow mirrors browser-tests scoping on PRs and runs the full suite on `main` / dispatch.
> 
> **Workflow fixes:** `git diff` uses **three-dot** (merge base); **`paths:`** filters align with `pathForceFullReason()` so force-full-only edits still trigger jobs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 72c763ad0b9a968b79b5e8dbfdc8d60c4f064735. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->