### PR TITLE
chore(testing): timer-leak coverage, manifest-consumer alias fix, visual-diff docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,6 +52,24 @@ When `left`/`right` carries semantic placement (e.g. `data-placement="left"` sel
 - Component browser tests live in `packages/testing` and run under Playwright (`bun run test:browser`).
 - Every fix should land with a regression test.
 
+### Visual regression
+
+The Playwright sweep can compare each component screenshot against a committed baseline PNG. The mode is controlled by the `CINDER_VISUAL_DIFF` environment variable, surfaced as the `mode` input on the `browser-tests` workflow's manual dispatch:
+
+- **`off`** (default) — screenshots are captured and uploaded as artifacts, but never compared. This is the current PR-gating default: visual diffs do not block PRs.
+- **`report`** — screenshots are compared against baselines; mismatches are summarized in the job summary and a sticky PR comment, but the run still passes (soak mode).
+- **`block`** — mismatches fail the job. **A missing baseline is a hard error in this mode**, so `block` cannot be enabled until a baseline set is committed.
+
+> [!IMPORTANT]
+> `block` mode is wired but **not yet active on PRs**, because no baselines are committed (`packages/testing/snapshots/` is empty). Flipping the PR-gating default to `block` before committing baselines would red every PR. Commit baselines first (below), then enable `block` in a single-line follow-up.
+
+**When a visual change is intentional**, regenerate the baselines rather than fighting the diff:
+
+1. Trigger the `browser-tests` workflow manually (`workflow_dispatch`) with `update_baselines=true`, `source_ref` set to your branch, and `base_ref` set to the branch the snapshot PR should target. The `update-baselines` job renders inside the canonical Playwright Docker image (so PNGs match CI byte-for-byte) and opens a snapshot-only follow-up PR.
+2. Review and merge that snapshot PR alongside your change.
+
+Locally, `bun run --filter='@cinder/testing' test:browser:update` regenerates baselines on your machine, but only the Docker-rendered PNGs from the workflow are authoritative for CI comparison — local PNGs differ by platform/font rendering and should not be committed.
+
 ### Coverage ratchet
 
 `packages/components` enforces a coverage floor through `coverageThreshold` in `packages/components/bunfig.toml`. The package `validate` script runs `test:coverage`, so the floor is checked in CI and in the pre-commit hook — a change that drops coverage below the floor fails the gate.

--- a/packages/components/fixtures/manifest-consumer/check.mjs
+++ b/packages/components/fixtures/manifest-consumer/check.mjs
@@ -144,8 +144,11 @@ const allowedNonComponentExportKeys = new Set([
   './package.json',
   './manifest',
   './styles',
+  './styles/all',
   './styles/tokens',
   './styles/foundation',
+  './styles/utilities',
+  './styles/guard',
   './highlighters/shiki',
   // Upstream re-export root barrels. These (and their `/subpath` children,
   // skipped below) are not component exports; node-consumer validates them.
@@ -264,10 +267,30 @@ assertRuntimeResolvable('cinder/styles');
 //    the manifest-derived expected set; anything else is an orphan.
 // ---------------------------------------------------------------------------
 
+// Experimental deprecation-alias exports: `./experimental/<name>` (and its
+// `/schema`, `/variables`, `/styles` subpaths) are generated shims that
+// re-export a component promoted out of `experimental/` to the top level. They
+// are legitimate package exports the manifest does not enumerate — but only
+// when the promoted target `./<name>` is itself a real component export. An
+// `experimental/*` alias whose base is NOT a known export is a genuine orphan
+// (a stale or typo'd alias), so we validate the relationship rather than
+// blanket-skipping the whole namespace.
+const EXPERIMENTAL_ALIAS_PATTERN =
+  /^\.\/experimental\/([a-z0-9][a-z0-9-]*)(?:\/(?:schema|variables|styles|examples|constraints))?$/;
+function isValidExperimentalAlias(key) {
+  const match = EXPERIMENTAL_ALIAS_PATTERN.exec(key);
+  if (match === null) return false;
+  const promotedBase = `./${match[1]}`;
+  // The promoted target must ship as a real top-level component export.
+  return expectedComponentExportKeys.has(promotedBase) || exportKeys.has(promotedBase);
+}
+
 const orphanExports = [];
 for (const key of exportKeys) {
   if (allowedNonComponentExportKeys.has(key)) continue;
   if (expectedComponentExportKeys.has(key)) continue;
+  // Experimental deprecation aliases that point at a real promoted component.
+  if (isValidExperimentalAlias(key)) continue;
   // Upstream re-export sub-paths (cinder/markdown/*, cinder/diff/*, etc.) are
   // not component exports and are validated by node-consumer; skip them here.
   if (

--- a/packages/components/fixtures/manifest-consumer/check.mjs
+++ b/packages/components/fixtures/manifest-consumer/check.mjs
@@ -267,25 +267,25 @@ assertRuntimeResolvable('cinder/styles');
 //    the manifest-derived expected set; anything else is an orphan.
 // ---------------------------------------------------------------------------
 
-// Experimental deprecation-alias exports: `./experimental/<name>` (and its
-// `/schema`, `/variables`, `/styles` subpaths) are generated shims that
-// re-export a component promoted out of `experimental/` to the top level. They
-// are legitimate package exports the manifest does not enumerate — but only
-// when the promoted target `./<name>` is itself a real component export. An
-// `experimental/*` alias whose base is NOT a known export is a genuine orphan
-// (a stale or typo'd alias), so we validate the relationship rather than
-// blanket-skipping the whole namespace.
+// Experimental deprecation-alias exports: `./experimental/<name>` and its
+// `/schema`, `/variables`, `/styles`, `/examples`, and `/constraints` subpaths
+// are generated shims that re-export a component promoted out of `experimental/`
+// to the top level. They are legitimate package exports the manifest does not
+// enumerate — but only when the promoted target `./<name>` is itself a real
+// component export. An `experimental/*` alias whose base is NOT a known export is
+// a genuine orphan (a stale or typo'd alias), so we validate the relationship
+// rather than blanket-skipping the whole namespace.
 const EXPERIMENTAL_ALIAS_PATTERN =
-  /^\.\/experimental\/([a-z0-9][a-z0-9-]*)(?:\/(?:schema|variables|styles|examples|constraints))?$/;
+  /^\.\/experimental\/([a-z0-9][a-z0-9-]*)(\/(?:schema|variables|styles|examples|constraints))?$/;
 function isValidExperimentalAlias(key) {
   const match = EXPERIMENTAL_ALIAS_PATTERN.exec(key);
   if (match === null) return false;
-  const promotedBase = `./${match[1]}`;
-  // The promoted target must be a real COMPONENT export (manifest-derived), not
-  // merely any package export. Checking `exportKeys` here would wrongly accept
-  // `./experimental/styles` (base `./styles` is a non-component export) or a
-  // stale alias whose base only survives as a top-level reserved export.
-  return expectedComponentExportKeys.has(promotedBase);
+  const promotedKey = `./${match[1]}${match[2] ?? ''}`;
+  // The promoted target must be the exact manifest-derived component export, not
+  // merely any package export or any component base export. Checking only the
+  // base would wrongly accept stale sidecar aliases such as
+  // `./experimental/foo/examples` when `./foo/examples` is not published.
+  return expectedComponentExportKeys.has(promotedKey);
 }
 
 const orphanExports = [];

--- a/packages/components/fixtures/manifest-consumer/check.mjs
+++ b/packages/components/fixtures/manifest-consumer/check.mjs
@@ -281,8 +281,11 @@ function isValidExperimentalAlias(key) {
   const match = EXPERIMENTAL_ALIAS_PATTERN.exec(key);
   if (match === null) return false;
   const promotedBase = `./${match[1]}`;
-  // The promoted target must ship as a real top-level component export.
-  return expectedComponentExportKeys.has(promotedBase) || exportKeys.has(promotedBase);
+  // The promoted target must be a real COMPONENT export (manifest-derived), not
+  // merely any package export. Checking `exportKeys` here would wrongly accept
+  // `./experimental/styles` (base `./styles` is a non-component export) or a
+  // stale alias whose base only survives as a top-level reserved export.
+  return expectedComponentExportKeys.has(promotedBase);
 }
 
 const orphanExports = [];

--- a/packages/components/src/components/context-menu-trigger/context-menu-trigger.test.ts
+++ b/packages/components/src/components/context-menu-trigger/context-menu-trigger.test.ts
@@ -3,6 +3,7 @@ import { afterEach, describe, expect, mock, test } from 'bun:test';
 import { createRawSnippet } from 'svelte';
 
 import { setupHappyDom } from '../../test/happy-dom.ts';
+import { expectNoLeakedTimers, trackTimers } from '../../test/lifecycle.ts';
 
 setupHappyDom();
 
@@ -79,5 +80,27 @@ describe('ContextMenuTrigger', () => {
     const menu = await screen.findByRole('menu');
     expect(menu).not.toBeNull();
     expect(menu.getAttribute('aria-orientation')).toBe('vertical');
+  });
+
+  // Regression test: handlePointerdown schedules longPressTimer when the pointer
+  // type is "touch". onDestroy must call clearLongPress() so the timer does not
+  // outlive the component. Use a very large longPressDelay so the timer is still
+  // pending at the moment unmount() is called.
+  test('unmounting after a touch pointerdown leaves no pending long-press timer', () => {
+    const timers = trackTimers();
+    try {
+      const { container, unmount } = render(Harness, { longPressDelay: 60_000 });
+      const region = container.querySelector('.cinder-context-menu-trigger') as HTMLElement;
+
+      // A touch pointerdown is the exact event that schedules longPressTimer
+      // (handlePointerdown guards on event.pointerType === 'touch').
+      fireEvent.pointerDown(region, { pointerType: 'touch', clientX: 50, clientY: 50 });
+
+      // Unmount before the 60-second timer fires — onDestroy must clear it.
+      unmount();
+      expectNoLeakedTimers(timers.active());
+    } finally {
+      timers.release();
+    }
   });
 });

--- a/packages/components/src/components/copy-button/copy-button.test.ts
+++ b/packages/components/src/components/copy-button/copy-button.test.ts
@@ -2,6 +2,7 @@
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
 
 import { setupHappyDom } from '../../test/happy-dom.ts';
+import { expectNoLeakedTimers, trackTimers } from '../../test/lifecycle.ts';
 
 setupHappyDom();
 
@@ -149,5 +150,25 @@ describe('CopyButton', () => {
     await waitFor(() => {
       expect(button.textContent?.trim()).toBe('Copied');
     });
+  });
+
+  test('unmounting after a copy leaves no pending reset timer', async () => {
+    // handleClick schedules a setTimeout(confirmDuration) to flip `copied`
+    // back to false. onDestroy must clear it — otherwise the callback fires
+    // against an unmounted component. Tracks the real timer table directly.
+    mockClipboard();
+    const timers = trackTimers();
+    try {
+      const { container, unmount } = render(CopyButton, { value: 'hi', confirmDuration: 10_000 });
+      const button = container.querySelector('button') as HTMLButtonElement;
+      await fireEvent.click(button);
+      await waitFor(() => expect(button.getAttribute('aria-label')).toBe('Copied'));
+
+      // The reset timer is now pending (confirmDuration is far in the future).
+      unmount();
+      expectNoLeakedTimers(timers.active());
+    } finally {
+      timers.release();
+    }
   });
 });

--- a/packages/components/src/components/hover-card/hover-card.test.ts
+++ b/packages/components/src/components/hover-card/hover-card.test.ts
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
 import { createRawSnippet } from 'svelte';
 
 import { setupHappyDom } from '../../test/happy-dom.ts';
+import { expectNoLeakedTimers, trackTimers } from '../../test/lifecycle.ts';
 
 setupHappyDom();
 
@@ -73,6 +74,27 @@ afterEach(() => {
 });
 
 describe('HoverCard', () => {
+  test('unmounting while an open timer is pending leaves no leaked timer', async () => {
+    const timers = trackTimers();
+    try {
+      const { container, unmount } = render(HoverCard, {
+        props: {
+          description: 'Preview',
+          openDelay: 10_000, // far in the future so the timer is still pending at unmount
+          trigger: triggerSnippet,
+          children: textSnippet('Preview'),
+        },
+      });
+      const wrapper = container.querySelector('.cinder-hover-card__trigger') as HTMLElement;
+      await fireEvent.mouseEnter(wrapper); // schedules openTimer via scheduleOpen
+
+      unmount(); // onDestroy(clearTimers) must clear it
+      expectNoLeakedTimers(timers.active());
+    } finally {
+      timers.release();
+    }
+  });
+
   test('focus opens a portaled hover card and wires ARIA from the trigger wrapper', async () => {
     const { container } = render(HoverCard, {
       props: {

--- a/packages/components/src/components/review-editor/live-region.test.ts
+++ b/packages/components/src/components/review-editor/live-region.test.ts
@@ -7,7 +7,7 @@ import { expectNoLeakedTimers, trackTimers } from '../../test/lifecycle.ts';
 
 setupHappyDom();
 
-// Dynamic import so @testing-library/svelte initialises after happy-dom is installed.
+// Dynamic import so the Svelte component loads after happy-dom is installed.
 const { default: LiveRegion } = await import('./live-region.svelte');
 
 // ---------------------------------------------------------------------------

--- a/packages/components/src/components/review-editor/live-region.test.ts
+++ b/packages/components/src/components/review-editor/live-region.test.ts
@@ -1,0 +1,68 @@
+/// <reference lib="dom" />
+import { describe, expect, test } from 'bun:test';
+import { mount, unmount } from 'svelte';
+
+import { setupHappyDom } from '../../test/happy-dom.ts';
+import { expectNoLeakedTimers, trackTimers } from '../../test/lifecycle.ts';
+
+setupHappyDom();
+
+// Dynamic import so @testing-library/svelte initialises after happy-dom is installed.
+const { default: LiveRegion } = await import('./live-region.svelte');
+
+// ---------------------------------------------------------------------------
+// Timer-leak regression: LiveRegion.announce() schedules a 1000ms clearTimeout.
+//
+// live-region.svelte schedules `clearTimeoutId = setTimeout(() => { message = '' }, 1000)`
+// via a queueMicrotask inside announce(). The $effect cleanup sets isDestroyed = true and
+// calls clearTimeout(clearTimeoutId). This test triggers the timer path, then unmounts
+// synchronously (before the 1000ms fires) to verify the timer is cleared and does not leak.
+// ---------------------------------------------------------------------------
+
+describe('LiveRegion', () => {
+  test('mounts and renders an aria live region', () => {
+    const target = document.createElement('div');
+    document.body.appendChild(target);
+    try {
+      const instance = mount(LiveRegion, { target });
+      expect(target.querySelector('[role="status"]')).not.toBeNull();
+      unmount(instance);
+    } finally {
+      target.remove();
+    }
+  });
+
+  test('unmounting after announce() leaves no pending clear-message timer', async () => {
+    // announce() calls queueMicrotask, then inside the microtask schedules
+    // clearTimeoutId = setTimeout(..., 1000). The $effect cleanup runs
+    // clearTimeout(clearTimeoutId) when the component is destroyed, so the
+    // 1000ms timer must NOT be pending after unmount.
+    const target = document.createElement('div');
+    document.body.appendChild(target);
+    const timers = trackTimers();
+    try {
+      const instance = mount(LiveRegion, { target });
+
+      // Call the exported announce() function to schedule the 1000ms timer.
+      // The timer is set inside queueMicrotask, so await a microtask boundary
+      // before unmounting to ensure it is actually pending at unmount time.
+      (
+        instance as unknown as {
+          announce: (text: string, announcePriority?: 'polite' | 'assertive') => void;
+        }
+      ).announce('Comment added', 'polite');
+
+      // Let the queueMicrotask callback run so the 1000ms setTimeout is scheduled.
+      await Promise.resolve();
+
+      // Unmount synchronously before the 1000ms fires. The $effect cleanup must
+      // call clearTimeout(clearTimeoutId) and prevent the timer from leaking.
+      unmount(instance);
+
+      expectNoLeakedTimers(timers.active());
+    } finally {
+      timers.release();
+      target.remove();
+    }
+  });
+});

--- a/packages/components/src/components/transition/transition.test.ts
+++ b/packages/components/src/components/transition/transition.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, test } from 'bun:test';
 import { createRawSnippet, tick } from 'svelte';
 
 import { setupHappyDom } from '../../test/happy-dom.ts';
+import { expectNoLeakedTimers, trackTimers } from '../../test/lifecycle.ts';
 
 setupHappyDom();
 
@@ -278,6 +279,50 @@ describe('Presence', () => {
 
       expect(exitCount).toBe(0);
     } finally {
+      globalThis.getComputedStyle = originalGetComputedStyle;
+    }
+  });
+
+  test('unmounting during exit leaves no pending exitTimer', async () => {
+    // Regression: presence.svelte schedules exitTimer = setTimeout(..., requiredElapsed + 34)
+    // inside a requestAnimationFrame when the exit transition duration is non-zero. The timer
+    // must be cleared via clearExitTimer() during onDestroy (via the $effect cleanup). If it
+    // leaks, the callback fires against a torn-down component.
+    //
+    // To force the timer path we need a non-zero requiredElapsed, which getPresenceExitDuration
+    // derives from getComputedStyle. We stub it to return a long duration (10 s) so the timer
+    // is still pending at the point we unmount — allowing us to assert no leak.
+    const originalGetComputedStyle = globalThis.getComputedStyle;
+    globalThis.getComputedStyle = (() =>
+      ({
+        transitionDuration: '10000ms',
+        transitionDelay: '0ms',
+        animationDuration: '',
+        animationDelay: '',
+        animationIterationCount: '',
+      }) as CSSStyleDeclaration) as typeof getComputedStyle;
+
+    const timers = trackTimers();
+    try {
+      const { rerender, unmount } = render(Presence, {
+        props: {
+          present: true,
+          children: transitionChildren,
+        },
+      });
+
+      await tick();
+      await rerender({ present: false, children: transitionChildren });
+
+      // Let the exitFrame rAF fire so exitTimer gets scheduled (10 000 + 34 ms from now).
+      await waitForAnimationFrame();
+
+      // Unmount before the timer fires — cleanupLifecycle() must clear it.
+      unmount();
+
+      expectNoLeakedTimers(timers.active());
+    } finally {
+      timers.release();
       globalThis.getComputedStyle = originalGetComputedStyle;
     }
   });

--- a/packages/components/src/components/tree/tree.test.ts
+++ b/packages/components/src/components/tree/tree.test.ts
@@ -4,6 +4,7 @@ import type { Snippet } from 'svelte';
 import { createRawSnippet, mount, unmount } from 'svelte';
 
 import { setupHappyDom } from '../../test/happy-dom.ts';
+import { expectNoLeakedTimers, trackTimers } from '../../test/lifecycle.ts';
 
 setupHappyDom();
 
@@ -1923,6 +1924,36 @@ describe('Tree — typeahead', () => {
     await fireEvent.keyDown(banana, { key: 'a' });
     const apple = treeItem(container, 'Apple');
     expect(apple?.getAttribute('tabindex')).toBe('0');
+  });
+
+  test('unmounting before the reset timer fires leaves no leaked timer', async () => {
+    // handleTypeahead schedules a 500 ms setTimeout to clear typeaheadBuffer.
+    // The $effect cleanup in tree.svelte must clearTimeout on destroy —
+    // otherwise the callback fires against an unmounted component.
+    const timers = trackTimers();
+    try {
+      const { container, unmount } = render(Tree, {
+        props: {
+          'aria-label': 'T',
+          children: treeItemsSnippet([
+            { id: 'banana', label: 'Banana' },
+            { id: 'apple', label: 'Apple' },
+          ]),
+        },
+      });
+
+      // Fire a single printable-character keydown on the first treeitem to
+      // trigger handleTypeahead, which schedules typeaheadTimer = setTimeout(..., 500).
+      const firstItem = treeItem(container, 'Banana') as HTMLElement;
+      firstItem.focus();
+      await fireEvent.keyDown(firstItem, { key: 'a' });
+
+      // Unmount immediately — the 500 ms timer is still pending.
+      unmount();
+      expectNoLeakedTimers(timers.active());
+    } finally {
+      timers.release();
+    }
   });
 
   test('disableTypeahead prevents typeahead from moving focus', async () => {


### PR DESCRIPTION
## Summary

Batches three independent ready tasks into one low-risk PR:

### 33d17057 — `trackTimers()` leak coverage
Adds timer-leak regression tests to 6 components that schedule and clear timers across their lifecycle: **copy-button**, **hover-card**, **context-menu-trigger**, **transition** (`presence.svelte` exit timer), **tree** (typeahead), and **review-editor** (`live-region`). Each test fires the *real* event that schedules the timer, unmounts before it fires, and asserts `onDestroy`/`$effect` cleanup cleared it — following the established `toast-region.test.ts` pattern. `time-picker` is excluded with evidence: its only `setTimeout` is a self-resolving `await new Promise(r => setTimeout(r, 0))` (`time-picker.svelte:288`) with no retained timer to leak.

### 12eb203a — manifest-consumer deprecation-alias orphans
The packed-tarball consumer check (`check.mjs`) flagged the generated `./experimental/<name>` deprecation-alias exports as orphans. Now an `./experimental/<name>[/schema|variables|styles|examples|constraints]` export is accounted for **iff the promoted `./<name>` is a real component export** (`expectedComponentExportKeys`) — validating the alias relationship rather than blanket-skipping, so a stale or typo'd alias (or one whose base is a non-component export like `./styles`) is still caught. Also allowlists the pre-existing `./styles/all`, `./styles/utilities`, `./styles/guard` global-style orphans. Verified against the packed tarball: `manifest-consumer OK — 138 components`.

### 0f4f01d5 — visual-regression workflow docs
Documents the `CINDER_VISUAL_DIFF` `off`/`report`/`block` path and the `update-baselines` workflow in `CONTRIBUTING.md`. The input is already wired (default `off`); `block` stays off until baselines are committed (it hard-errors on every missing baseline otherwise). Reopens 51dc302d, whose acceptance (committed baselines) is unmet.

## Review committee
Pre-reviewed by: testing-expert, simplicity-engineer, prose-editor
- Codex (gpt-5.4, xhigh→high reasoning) — 2 rounds
- All APPROVED in round 2. Must-fix addressed: tightened experimental-alias validation to a component-export-only check (Codex + simplicity-engineer converged), re-verified against the tarball.

## Test plan
- `cd packages/components && bun run test:changed` (or the full `test`) — 177+ component tests incl. the 6 new leak tests, all green under `--parallel=1`.
- `bun run --filter=cinder validate:consumer` — manifest-consumer passes against the packed tarball (138 components, no orphans).
- typecheck + svelte-check clean; pre-commit coverage gate passed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test and documentation changes plus a stricter but targeted consumer-check allowlist; no production component runtime behavior changes in the diff.
> 
> **Overview**
> Adds **timer-leak regression tests** across six components (`copy-button`, `hover-card`, `context-menu-trigger`, `transition`/`Presence` exit, `tree` typeahead, `review-editor` `live-region`) using shared `trackTimers()` / `expectNoLeakedTimers`: schedule the real timer path, unmount before it fires, assert cleanup leaves no pending timers.
> 
> Tightens **packed-tarball `manifest-consumer`**: allowlists `./styles/all`, `./styles/utilities`, `./styles/guard`; treats `./experimental/<name>[/sidecar]` as valid only when the promoted manifest export exists (stale aliases still fail).
> 
> Documents **Playwright visual regression** in `CONTRIBUTING.md` (`CINDER_VISUAL_DIFF` off/report/block, baseline update workflow, why `block` stays off until baselines exist).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3d48fb6632b261c2d1706c27b405751dc4767a17. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->