### PR TITLE
fix(playground): stabilize Playwright sweep + screenshot taxonomy

### DIFF
--- a/packages/playground/src/component-page.svelte
+++ b/packages/playground/src/component-page.svelte
@@ -414,6 +414,16 @@
     gap: var(--cinder-space-4);
   }
 
+  /* Column counterpart to -row: stacks example variants vertically. Same
+     scoping rationale (:global inner selector, .example-preview anchor) so the
+     helper stays confined to the preview surface. */
+  .example-preview :global(.example-preview-column) {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: var(--cinder-space-4);
+  }
+
   .source-loading,
   .source-error {
     margin: 0;

--- a/packages/playground/src/discover.test.ts
+++ b/packages/playground/src/discover.test.ts
@@ -204,7 +204,7 @@ describe('discoverSidebarComponents', () => {
     }
   });
 
-  it('keeps the sidebar at or below the 93-entry product gate', async () => {
+  it('keeps the sidebar at or below the 97-entry product gate', async () => {
     // The plan named a 70-entry cap based on a 99-component baseline. The
     // repository has grown to 134 components since then; adding the four
     // new parent families (feed, grid-list, stat-group, side-navigation)
@@ -215,10 +215,14 @@ describe('discoverSidebarComponents', () => {
     // the overlay variants (alert-dialog, context-menu, hover-card) plus
     // ContextMenu and inline-command additions landed the deduped sidebar at
     // 92. Promoting Timeline out of experimental/ into the main tree — it
-    // ships playground examples, so it now surfaces in the sidebar — lands it
-    // at 93 distinct families, measured empirically via discoverSidebarComponents().
+    // ships playground examples, so it now surfaces in the sidebar — landed it
+    // at 93. The Playwright-sweep stabilization (task 27cd940c) added the four
+    // missing examples for standalone components that were rendering "No
+    // examples found" and timing out the sweep — status-dot, message,
+    // description-list, color-field — surfacing them in the sidebar and landing
+    // it at 97 distinct families, measured empirically via discoverSidebarComponents().
     const sidebar = await discoverSidebarComponents();
-    expect(sidebar.length).toBeLessThanOrEqual(93);
+    expect(sidebar.length).toBeLessThanOrEqual(97);
   });
 
   it('keeps the sidebar strictly smaller than the full component list', async () => {

--- a/packages/playground/src/examples/color-field/basic.example.svelte
+++ b/packages/playground/src/examples/color-field/basic.example.svelte
@@ -17,7 +17,6 @@
   <ColorField
     id="color-field-basic"
     defaultValue="#3b82f6"
-    ariaLabel="Brand color"
     onchange={(value) => {
       committed = value;
     }}

--- a/packages/playground/src/examples/color-field/basic.example.svelte
+++ b/packages/playground/src/examples/color-field/basic.example.svelte
@@ -1,0 +1,28 @@
+<script lang="ts" module>
+  export const title = 'Basic color field';
+  export const description =
+    'An uncontrolled color field that accepts hex, rgb(), and hsl() strings and normalizes them to hex on commit.';
+</script>
+
+<script lang="ts">
+  import { ColorField } from 'cinder/color-field';
+
+  let committed = $state('');
+</script>
+
+<div style="display: flex; flex-direction: column; gap: 0.5rem; max-width: 20rem;">
+  <label for="color-field-basic" style="font-size: 0.875rem; font-weight: 500;">
+    Brand color
+  </label>
+  <ColorField
+    id="color-field-basic"
+    defaultValue="#3b82f6"
+    ariaLabel="Brand color"
+    onchange={(value) => {
+      committed = value;
+    }}
+  />
+  {#if committed}
+    <p style="font-size: 0.75rem; color: var(--cinder-text-muted);">Committed: {committed}</p>
+  {/if}
+</div>

--- a/packages/playground/src/examples/color-field/states.example.svelte
+++ b/packages/playground/src/examples/color-field/states.example.svelte
@@ -1,0 +1,25 @@
+<script lang="ts" module>
+  export const title = 'Disabled and readonly states';
+  export const description =
+    'A disabled color field rejects all interaction; a readonly field displays the value but blocks editing.';
+</script>
+
+<script lang="ts">
+  import { ColorField } from 'cinder/color-field';
+</script>
+
+<div style="display: flex; flex-direction: column; gap: 1rem; max-width: 20rem;">
+  <div style="display: flex; flex-direction: column; gap: 0.5rem;">
+    <label for="color-field-disabled" style="font-size: 0.875rem; font-weight: 500;">
+      Disabled
+    </label>
+    <ColorField id="color-field-disabled" value="#ef4444" ariaLabel="Disabled color" disabled />
+  </div>
+
+  <div style="display: flex; flex-direction: column; gap: 0.5rem;">
+    <label for="color-field-readonly" style="font-size: 0.875rem; font-weight: 500;">
+      Read-only
+    </label>
+    <ColorField id="color-field-readonly" value="#22c55e" ariaLabel="Read-only color" readonly />
+  </div>
+</div>

--- a/packages/playground/src/examples/color-field/states.example.svelte
+++ b/packages/playground/src/examples/color-field/states.example.svelte
@@ -13,13 +13,13 @@
     <label for="color-field-disabled" style="font-size: 0.875rem; font-weight: 500;">
       Disabled
     </label>
-    <ColorField id="color-field-disabled" value="#ef4444" ariaLabel="Disabled color" disabled />
+    <ColorField id="color-field-disabled" value="#ef4444" disabled />
   </div>
 
   <div style="display: flex; flex-direction: column; gap: 0.5rem;">
     <label for="color-field-readonly" style="font-size: 0.875rem; font-weight: 500;">
       Read-only
     </label>
-    <ColorField id="color-field-readonly" value="#22c55e" ariaLabel="Read-only color" readonly />
+    <ColorField id="color-field-readonly" value="#22c55e" readonly />
   </div>
 </div>

--- a/packages/playground/src/examples/description-list/basic.example.svelte
+++ b/packages/playground/src/examples/description-list/basic.example.svelte
@@ -1,0 +1,19 @@
+<script lang="ts" module>
+  export const title = 'Description list';
+  export const description = 'Key–value metadata pairs in the default stacked layout.';
+</script>
+
+<script lang="ts">
+  import { DescriptionList } from 'cinder/description-list';
+  import type { DescriptionListItem } from 'cinder/description-list';
+
+  const items: DescriptionListItem[] = [
+    { term: 'Component', definition: 'DescriptionList' },
+    { term: 'Status', definition: 'Stable' },
+    { term: 'Version', definition: '1.0.0' },
+    { term: 'License', definition: 'MIT' },
+    { term: 'Maintainer', definition: 'Cinder team' },
+  ];
+</script>
+
+<DescriptionList {items} />

--- a/packages/playground/src/examples/description-list/variants.example.svelte
+++ b/packages/playground/src/examples/description-list/variants.example.svelte
@@ -1,0 +1,21 @@
+<script lang="ts" module>
+  export const title = 'Description list variants';
+  export const description = 'Striped and two-column layout variants.';
+</script>
+
+<script lang="ts">
+  import { DescriptionList } from 'cinder/description-list';
+  import type { DescriptionListItem } from 'cinder/description-list';
+
+  const items: DescriptionListItem[] = [
+    { term: 'Repository', definition: 'cinder' },
+    { term: 'Language', definition: 'TypeScript' },
+    { term: 'Framework', definition: 'Svelte 5' },
+    { term: 'Runtime', definition: 'Bun' },
+  ];
+</script>
+
+<div class="example-preview-column">
+  <DescriptionList {items} variant="striped" />
+  <DescriptionList {items} variant="two-column" />
+</div>

--- a/packages/playground/src/examples/message/roles.example.svelte
+++ b/packages/playground/src/examples/message/roles.example.svelte
@@ -1,0 +1,21 @@
+<script lang="ts" module>
+  export const title = 'Message roles';
+  export const description = 'User, assistant, and system role variants with a timestamp.';
+</script>
+
+<script lang="ts">
+  import { Message } from 'cinder/message';
+</script>
+
+<div class="example-preview-column">
+  <Message role="user" name="Ada Lovelace" time="9:41 AM">
+    Can you explain how transformers work?
+  </Message>
+  <Message role="assistant" time="9:41 AM">
+    Transformers use self-attention to relate every token in a sequence to every other token,
+    letting the model weigh context regardless of distance.
+  </Message>
+  <Message role="system">
+    You are a helpful assistant that explains technical concepts clearly and concisely.
+  </Message>
+</div>

--- a/packages/playground/src/examples/status-dot/label-and-size.example.svelte
+++ b/packages/playground/src/examples/status-dot/label-and-size.example.svelte
@@ -1,0 +1,20 @@
+<script lang="ts" module>
+  export const title = 'Status dot label and size';
+  export const description = 'Visible label toggle and sm vs md sizes.';
+</script>
+
+<script lang="ts">
+  import { StatusDot } from 'cinder/status-dot';
+</script>
+
+<div class="example-preview-column">
+  <div class="example-preview-row">
+    <StatusDot status="online" label="Online" showLabel={true} />
+    <StatusDot status="offline" label="Offline" showLabel={true} />
+    <StatusDot status="pending" label="Pending" showLabel={true} />
+  </div>
+  <div class="example-preview-row" style="align-items: center;">
+    <StatusDot status="online" label="Small" size="sm" showLabel={true} />
+    <StatusDot status="online" label="Medium" size="md" showLabel={true} />
+  </div>
+</div>

--- a/packages/playground/src/examples/status-dot/statuses.example.svelte
+++ b/packages/playground/src/examples/status-dot/statuses.example.svelte
@@ -1,0 +1,17 @@
+<script lang="ts" module>
+  export const title = 'Status dot statuses';
+  export const description = 'All six semantic status values.';
+</script>
+
+<script lang="ts">
+  import { StatusDot } from 'cinder/status-dot';
+</script>
+
+<div class="example-preview-row">
+  <StatusDot status="online" label="Online" />
+  <StatusDot status="offline" label="Offline" />
+  <StatusDot status="warning" label="Warning" />
+  <StatusDot status="error" label="Error" />
+  <StatusDot status="pending" label="Pending" />
+  <StatusDot status="neutral" label="Neutral" />
+</div>

--- a/packages/playground/src/playground-server.test.ts
+++ b/packages/playground/src/playground-server.test.ts
@@ -13,6 +13,7 @@ import { afterEach, beforeAll, describe, expect, it } from 'bun:test';
 import { join } from 'node:path';
 
 import type { ComponentManifest } from './analyze.ts';
+import { COMPOSE_ONLY_COMPONENTS } from './discover.ts';
 import {
   PORT,
   createHttpServerOnAvailablePort,
@@ -23,6 +24,7 @@ import { jsonForScriptTag } from './render-shell.ts';
 
 const FIXTURE_COMPONENT = 'button';
 const FIXTURE_SCENARIO = 'primary';
+const COMPOSE_ONLY_FIXTURE_COMPONENT = Array.from(COMPOSE_ONLY_COMPONENTS)[0]!;
 const FIXTURE_PATH = join(
   import.meta.dirname,
   'examples',
@@ -726,6 +728,28 @@ describe('/api/manifest', () => {
     const button = manifests.find((entry) => entry.kebabName === 'button');
     expect(button).toBeDefined();
   }, 30_000);
+
+  it('includes compose-only leaves in the canonical /api/manifest', async () => {
+    // The full manifest keeps compose-only leaves so direct /page/<name> routes
+    // and the static export (which fetch /api/manifest/<name> by name) still
+    // resolve them. The Playwright sweep uses ?standalone=1 to drop them.
+    const response = await handleRequest(req('/api/manifest'));
+    const manifests = (await response.json()) as ComponentManifest[];
+    const manifestNames = new Set(manifests.map((entry) => entry.kebabName));
+    expect(manifestNames.has(COMPOSE_ONLY_FIXTURE_COMPONENT)).toBe(true);
+  }, 30_000);
+
+  it('excludes compose-only leaves from /api/manifest?standalone=1', async () => {
+    // ?standalone=1 is the Playwright-sweep input: compose-only leaves are
+    // covered through their parent examples, so a standalone page for them would
+    // render "No examples found" and time out the sweep's `#app > *` wait.
+    const response = await handleRequest(req('/api/manifest?standalone=1'));
+    const manifests = (await response.json()) as ComponentManifest[];
+    const manifestNames = new Set(manifests.map((entry) => entry.kebabName));
+    for (const componentName of COMPOSE_ONLY_COMPONENTS) {
+      expect(manifestNames.has(componentName)).toBe(false);
+    }
+  }, 30_000);
 });
 
 describe('/api/manifest/:name', () => {
@@ -740,6 +764,13 @@ describe('/api/manifest/:name', () => {
     const result = (await response.json()) as ComponentManifest;
     expect(result.name).toBe('Button');
     expect(result.kebabName).toBe('button');
+  }, 30_000);
+
+  it('returns parsed JSON for a compose-only component by name', async () => {
+    const response = await handleRequest(req(`/api/manifest/${COMPOSE_ONLY_FIXTURE_COMPONENT}`));
+    const result = (await response.json()) as ComponentManifest;
+    expect(response.status).toBe(200);
+    expect(result.kebabName).toBe(COMPOSE_ONLY_FIXTURE_COMPONENT);
   }, 30_000);
 
   it('returns 404 for an unknown component', async () => {

--- a/packages/playground/src/playground-server.test.ts
+++ b/packages/playground/src/playground-server.test.ts
@@ -768,8 +768,11 @@ describe('/api/manifest/:name', () => {
 
   it('returns parsed JSON for a compose-only component by name', async () => {
     const response = await handleRequest(req(`/api/manifest/${COMPOSE_ONLY_FIXTURE_COMPONENT}`));
-    const result = (await response.json()) as ComponentManifest;
+    // Assert status BEFORE consuming the body: a 404 is a text/plain response,
+    // so calling response.json() first would throw an opaque JSON parse error
+    // and mask the real "expected 200, got 404" failure.
     expect(response.status).toBe(200);
+    const result = (await response.json()) as ComponentManifest;
     expect(result.kebabName).toBe(COMPOSE_ONLY_FIXTURE_COMPONENT);
   }, 30_000);
 

--- a/packages/playground/src/playground-server.ts
+++ b/packages/playground/src/playground-server.ts
@@ -30,6 +30,7 @@ import type { BuildArtifact } from 'bun';
 import { sveltePlugin } from '../../components/scripts/svelte-plugin.ts';
 import { analyzeAll, resetProject } from './analyze.ts';
 import {
+  COMPOSE_ONLY_COMPONENTS,
   discoverComponents,
   discoverExamples,
   discoverSidebarComponents,
@@ -884,7 +885,13 @@ async function getManifests(): Promise<ComponentManifest[]> {
   // Reuse the in-flight promise so concurrent callers don't each start analyzeAll().
   manifestPromise ??= analyzeAll(join(COMPONENTS_ROOT, 'src', 'components'));
   try {
-    manifestCache = await manifestPromise;
+    const all = await manifestPromise;
+    // Exclude compose-only leaves (Table.Cell, Tabs.List, Dropdown.Label, …):
+    // they only render meaningfully inside a parent and have no standalone
+    // `.example.svelte`, so a standalone page renders "No examples found" — which
+    // also times out the Playwright sweep's `#app > *` wait. They are demonstrated
+    // on their parent's page (mirrors discoverSidebarComponents).
+    manifestCache = all.filter((entry) => !COMPOSE_ONLY_COMPONENTS.has(entry.kebabName));
     return manifestCache;
   } finally {
     manifestPromise = null;

--- a/packages/playground/src/playground-server.ts
+++ b/packages/playground/src/playground-server.ts
@@ -885,17 +885,21 @@ async function getManifests(): Promise<ComponentManifest[]> {
   // Reuse the in-flight promise so concurrent callers don't each start analyzeAll().
   manifestPromise ??= analyzeAll(join(COMPONENTS_ROOT, 'src', 'components'));
   try {
-    const all = await manifestPromise;
-    // Exclude compose-only leaves (Table.Cell, Tabs.List, Dropdown.Label, …):
-    // they only render meaningfully inside a parent and have no standalone
-    // `.example.svelte`, so a standalone page renders "No examples found" — which
-    // also times out the Playwright sweep's `#app > *` wait. They are demonstrated
-    // on their parent's page (mirrors discoverSidebarComponents).
-    manifestCache = all.filter((entry) => !COMPOSE_ONLY_COMPONENTS.has(entry.kebabName));
+    manifestCache = await manifestPromise;
     return manifestCache;
   } finally {
     manifestPromise = null;
   }
+}
+
+/**
+ * Return only components that have meaningful standalone screenshot pages.
+ * Compose-only leaves still belong in the canonical manifest API because
+ * direct pages and static export fetch their prop manifests by name.
+ */
+async function getStandaloneManifests(): Promise<ComponentManifest[]> {
+  const manifests = await getManifests();
+  return manifests.filter((entry) => !COMPOSE_ONLY_COMPONENTS.has(entry.kebabName));
 }
 
 /**
@@ -1201,10 +1205,16 @@ export async function handleRequest(request: Request): Promise<Response> {
     });
   }
 
-  // GET /api/manifest — full manifest array
+  // GET /api/manifest — full manifest array.
+  // Add ?standalone=1 for the Playwright sweep input, where compose-only
+  // leaves are covered through their parent examples instead of standalone
+  // pages that would render "No examples found".
   if (pathname === '/api/manifest') {
     await awaitWarmCache();
-    const manifests = await getManifests();
+    const manifests =
+      url.searchParams.get('standalone') === '1'
+        ? await getStandaloneManifests()
+        : await getManifests();
     return new Response(JSON.stringify(manifests), {
       headers: { 'Content-Type': 'application/json' },
     });

--- a/packages/testing/scripts/prepare-manifest.ts
+++ b/packages/testing/scripts/prepare-manifest.ts
@@ -18,7 +18,7 @@ type RawManifestEntry = {
 };
 
 async function main(): Promise<void> {
-  const response = await fetch(`${PLAYGROUND_URL}/api/manifest`);
+  const response = await fetch(`${PLAYGROUND_URL}/api/manifest?standalone=1`);
   if (!response.ok) {
     throw new Error(`Failed to fetch manifest: ${response.status} ${response.statusText}`);
   }
@@ -27,7 +27,7 @@ async function main(): Promise<void> {
 
   if (raw.length === 0) {
     throw new Error(
-      `Manifest at ${PLAYGROUND_URL}/api/manifest returned zero entries. The playground discovered no components.`,
+      `Manifest at ${PLAYGROUND_URL}/api/manifest?standalone=1 returned zero entries. The playground discovered no standalone components.`,
     );
   }
 

--- a/packages/testing/src/helpers/fixture-schema.test.ts
+++ b/packages/testing/src/helpers/fixture-schema.test.ts
@@ -308,3 +308,55 @@ describe('happy path', () => {
     ).not.toThrow();
   });
 });
+
+// ---------------------------------------------------------------------------
+// category — screenshot taxonomy with default resolution
+// ---------------------------------------------------------------------------
+
+describe('fixture category (screenshot taxonomy)', () => {
+  it("defaults to 'visual-contract' when omitted and there are no interactions", () => {
+    const { fixtures } = parse({ fixtures: [{ name: 'plain', props: {} }] });
+    expect(fixtures[0]!.category).toBe('visual-contract');
+  });
+
+  it("defaults to 'interaction-state' when the fixture has interact steps", () => {
+    const { fixtures } = parse({
+      fixtures: [
+        {
+          name: 'hovered',
+          props: {},
+          interact: [{ action: 'hover', target: { testId: 'trigger' } }],
+        },
+      ],
+    });
+    expect(fixtures[0]!.category).toBe('interaction-state');
+  });
+
+  it('honors an explicit category over the interact-based default', () => {
+    const { fixtures } = parse({
+      fixtures: [
+        {
+          name: 'open-doc',
+          props: {},
+          interact: [{ action: 'click', target: { testId: 'trigger' } }],
+          category: 'documentation',
+        },
+      ],
+    });
+    expect(fixtures[0]!.category).toBe('documentation');
+  });
+
+  it('accepts every taxonomy value and rejects an unknown one', () => {
+    const categories = [
+      'visual-contract',
+      'primitive-composition',
+      'interaction-state',
+      'documentation',
+    ] as const;
+    for (const category of categories) {
+      const { fixtures } = parse({ fixtures: [{ name: 'f', props: {}, category }] });
+      expect(fixtures[0]!.category).toBe(category);
+    }
+    expect(() => parse({ fixtures: [{ name: 'f', props: {}, category: 'nonsense' }] })).toThrow();
+  });
+});

--- a/packages/testing/src/helpers/fixture-schema.ts
+++ b/packages/testing/src/helpers/fixture-schema.ts
@@ -40,6 +40,32 @@ export const MASK_REASONS = [
 /** Closed enum of supported interaction actions. */
 export const INTERACTION_ACTIONS = ['focus', 'click', 'hover', 'press'] as const;
 
+/**
+ * Screenshot taxonomy — the kind of review artifact a fixture produces. Lets
+ * reviewers (and the contact-sheet tooling) tell a component's canonical visual
+ * contract apart from a documentation page, a primitive shown only in a
+ * composition, or an interaction-state capture.
+ *
+ *   - `visual-contract`: the component's own default/canonical rendered states.
+ *   - `primitive-composition`: a low-level primitive shown inside the smallest
+ *     realistic composition that proves it works (it has no meaningful
+ *     standalone visual).
+ *   - `interaction-state`: a capture taken AFTER `interact` steps — hover,
+ *     focus, selected/current, open, disabled — where brand/usability lives.
+ *   - `documentation`: playground chrome / doc-oriented pages, not a component
+ *     visual contract.
+ *
+ * Defaults to `visual-contract` when a fixture omits it.
+ */
+export const FIXTURE_CATEGORIES = [
+  'visual-contract',
+  'primitive-composition',
+  'interaction-state',
+  'documentation',
+] as const;
+
+export type FixtureCategory = (typeof FIXTURE_CATEGORIES)[number];
+
 // ---------------------------------------------------------------------------
 // JsonValue — recursive schema, plain objects only
 // ---------------------------------------------------------------------------
@@ -107,23 +133,38 @@ const MaskRuleSchema = z.object({
  * - `interact`: optional ordered list of interaction steps to perform before
  *   capturing the snapshot.
  * - `mask`: optional list of regions to hide during pixel comparison.
+ * - `category`: the screenshot-taxonomy bucket (see {@link FIXTURE_CATEGORIES}).
+ *   Defaults to `interaction-state` when the fixture has `interact` steps,
+ *   otherwise `visual-contract`.
  */
-export const VisualFixtureSchema = z.object({
-  name: z
-    .string()
-    .regex(FIXTURE_NAME_PATTERN, {
-      message: `Fixture name must match ${String(FIXTURE_NAME_PATTERN)} (lowercase kebab-case starting with a letter)`,
-    })
-    .max(FIXTURE_NAME_MAX_LENGTH, {
-      message: `Fixture name must not exceed ${FIXTURE_NAME_MAX_LENGTH} characters`,
-    })
-    .refine((value) => !(RESERVED_FIXTURE_NAMES as readonly string[]).includes(value), {
-      message: `Fixture name '${RESERVED_FIXTURE_NAMES.join("', '")}' is reserved`,
-    }),
-  props: JsonValueSchema,
-  interact: z.array(InteractionStepSchema).optional(),
-  mask: z.array(MaskRuleSchema).optional(),
-});
+export const VisualFixtureSchema = z
+  .object({
+    name: z
+      .string()
+      .regex(FIXTURE_NAME_PATTERN, {
+        message: `Fixture name must match ${String(FIXTURE_NAME_PATTERN)} (lowercase kebab-case starting with a letter)`,
+      })
+      .max(FIXTURE_NAME_MAX_LENGTH, {
+        message: `Fixture name must not exceed ${FIXTURE_NAME_MAX_LENGTH} characters`,
+      })
+      .refine((value) => !(RESERVED_FIXTURE_NAMES as readonly string[]).includes(value), {
+        message: `Fixture name '${RESERVED_FIXTURE_NAMES.join("', '")}' is reserved`,
+      }),
+    props: JsonValueSchema,
+    interact: z.array(InteractionStepSchema).optional(),
+    mask: z.array(MaskRuleSchema).optional(),
+    category: z.enum(FIXTURE_CATEGORIES).optional(),
+  })
+  .transform((fixture) => ({
+    ...fixture,
+    // Resolve the taxonomy default: an interaction fixture is an
+    // interaction-state capture unless it says otherwise.
+    category:
+      fixture.category ??
+      (fixture.interact && fixture.interact.length > 0
+        ? ('interaction-state' as const)
+        : ('visual-contract' as const)),
+  }));
 
 /**
  * Zod schema for the optional metadata constant exported alongside a fixture

--- a/packages/testing/src/helpers/fixture-schema.ts
+++ b/packages/testing/src/helpers/fixture-schema.ts
@@ -55,7 +55,9 @@ export const INTERACTION_ACTIONS = ['focus', 'click', 'hover', 'press'] as const
  *   - `documentation`: playground chrome / doc-oriented pages, not a component
  *     visual contract.
  *
- * Defaults to `visual-contract` when a fixture omits it.
+ * When a fixture omits `category`, the schema resolves it from the fixture
+ * shape: `interaction-state` if it has `interact` steps, otherwise
+ * `visual-contract` (see {@link VisualFixtureSchema}).
  */
 export const FIXTURE_CATEGORIES = [
   'visual-contract',

--- a/packages/testing/tests/components.playwright.ts
+++ b/packages/testing/tests/components.playwright.ts
@@ -9,10 +9,10 @@ import { loadManifest, manifestDigest, THEMES, VIEWPORTS } from '../src/helpers/
 import { captureScreenshot } from '../src/helpers/screenshot.ts';
 
 test.describe('server identity', () => {
-  test('cached manifest matches live /api/manifest', async ({ request }) => {
+  test('cached manifest matches live standalone manifest', async ({ request }) => {
     // `request` honors playwright.config.ts's `use.baseURL`, which resolves
     // via `src/helpers/playground-url.ts`.
-    const response = await request.get('/api/manifest');
+    const response = await request.get('/api/manifest?standalone=1');
     expect(response.ok()).toBeTruthy();
 
     const live = (await response.json()) as Array<{ name: string; kebabName: string }>;

--- a/packages/testing/tests/components.playwright.ts
+++ b/packages/testing/tests/components.playwright.ts
@@ -102,10 +102,18 @@ for (const entry of entries) {
               description: `C/S/M/m: ${buckets.critical.length}/${buckets.serious.length}/${buckets.moderate.length}/${buckets.minor.length}`,
             });
 
-            // Record the screenshot taxonomy so the contact-sheet tooling can
-            // group captures by intent (visual contract vs interaction state
-            // vs primitive composition vs documentation). The fixture schema
-            // resolves `category` to a default when omitted.
+            // Record the screenshot taxonomy so the (future) contact-sheet
+            // tooling can group captures by intent (visual contract vs
+            // interaction state vs primitive composition vs documentation).
+            //
+            // NOTE: today this resolves to 'visual-contract' for EVERY capture,
+            // because the manifest pipeline (prepare-manifest.ts →
+            // ComponentEntry.fixtures) does not yet carry `category`/`interact`,
+            // so the sweep only ever sees the synthesized `default` fixture.
+            // Threading category/interact through the manifest — so interaction
+            // fixtures annotate as 'interaction-state' — is part of the deferred
+            // fixture-rendering pipeline (see task b5af46f8). The annotation is
+            // wired now so it goes live for free once that pipeline lands.
             const category =
               'category' in fixture && typeof fixture.category === 'string'
                 ? fixture.category

--- a/packages/testing/tests/components.playwright.ts
+++ b/packages/testing/tests/components.playwright.ts
@@ -102,6 +102,16 @@ for (const entry of entries) {
               description: `C/S/M/m: ${buckets.critical.length}/${buckets.serious.length}/${buckets.moderate.length}/${buckets.minor.length}`,
             });
 
+            // Record the screenshot taxonomy so the contact-sheet tooling can
+            // group captures by intent (visual contract vs interaction state
+            // vs primitive composition vs documentation). The fixture schema
+            // resolves `category` to a default when omitted.
+            const category =
+              'category' in fixture && typeof fixture.category === 'string'
+                ? fixture.category
+                : 'visual-contract';
+            test.info().annotations.push({ type: 'category', description: category });
+
             // Pass mask rules from the fixture so toHaveScreenshot can exclude
             // dynamic regions from the pixel comparison.
             const masks =


### PR DESCRIPTION
## Summary

Kills the `#app > *` render timeouts in the Playwright component sweep (task 27cd940c) and lays the screenshot-taxonomy foundation.

### Why the sweep timed out
Nine components rendered "No examples found" (an empty `#app`), so the sweep's 20s `#app > *` visibility wait never resolved. Two distinct causes, two fixes:

1. **Four standalone components were genuinely missing examples** — `status-dot`, `message`, `description-list`, `color-field`. Added purposeful, browser-verified examples (each renders meaningful visible content, confirmed by real screenshots — not just HTTP 200). They now surface in the playground sidebar (product gate `93 → 97`, documented).

2. **Five compose-only leaves were being swept as standalone pages** — `table-cell`, `table-header`, `tab-list`, `dropdown-label`, `context-menu-trigger`. They only render meaningfully inside a parent (`Table`, `Tabs`, `Dropdown`, `ContextMenu`) and are already exercised through their parent's examples. The Playwright sweep input (`/api/manifest?standalone=1`) now excludes `COMPOSE_ONLY_COMPONENTS`, while the **canonical `/api/manifest` keeps them** so direct `/page/<name>` routes and the static export (which resolve `/api/manifest/<name>` by name) still work.

### Screenshot taxonomy
Adds a `category` field to the visual-fixture schema (`visual-contract` / `primitive-composition` / `interaction-state` / `documentation`) with default resolution, plus a sweep category annotation, so the eventual contact-sheet tooling can group artifacts by intent.

### Deferred (filed as follow-up)
The broader **fixture-rendering pipeline** (so `interact` fixtures actually render with props in the playground → real interaction-state coverage) and the **contact-sheet tooling** are deferred to task `b5af46f8`. Two rounds of adversarial plan-review (50 findings) showed that path is a fragile end-to-end feature build (package boundaries, Bun ESM module-cache, parallel-compile races, manifest/runtime drift) deserving its own design + PR.

## Review committee
Pre-reviewed by: svelte-expert, testing-expert, simplicity-engineer
- Codex (gpt-5.4, xhigh→high reasoning) — 2 rounds
- All APPROVED. testing-expert's must-fix (category annotation always `visual-contract` until the manifest carries it) addressed by documenting the deferral.

> [!NOTE]
> The compose-only exclusion was refined AFTER committee approval from an unconditional `/api/manifest` filter to the `?standalone=1` variant above — a strictly safer design (preserves the canonical manifest for direct-page/static-export consumers, exactly the concern Codex raised in plan-review). Covered by new `playground-server.test.ts` assertions (canonical includes compose-only; `?standalone=1` excludes them).

## Test plan
- `bun run --filter='@cinder/playground' test` → 422+4 green (incl. the new manifest include/exclude assertions).
- `bun run --filter='@cinder/testing' test` → 175 green (incl. category schema tests).
- Scoped browser sweep on the affected components → zero `#app > *` timeouts; all 9 render meaningful visible content (browser-confirmed by screenshots).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to playground discovery/manifest filtering, new example files, CSS helpers, and testing schema annotations; no production component runtime or auth paths are modified.
> 
> **Overview**
> Stops Playwright component sweeps from hanging on empty preview pages by fixing missing playground examples and narrowing which components the sweep visits.
> 
> **Playwright / manifest:** `/api/manifest?standalone=1` now omits `COMPOSE_ONLY_COMPONENTS` (leaves that only make sense inside a parent), while the default `/api/manifest` still lists them for direct `/page/<name>` and per-name manifest routes. `prepare-manifest.ts` and the sweep identity test use the standalone manifest so compose-only leaves are not swept as standalone pages that show “No examples found.”
> 
> **New examples:** Adds playground examples for `color-field`, `description-list`, `message`, and `status-dot`, and raises the sidebar product gate from 93 to 97 entries in `discover.test.ts`.
> 
> **Playground UI:** Introduces scoped `.example-preview-column` layout helper (counterpart to `.example-preview-row`) for stacked variant demos.
> 
> **Screenshot taxonomy:** Extends visual fixture schema with optional `category` (`visual-contract`, `primitive-composition`, `interaction-state`, `documentation`) and defaults (`interaction-state` when `interact` is present, else `visual-contract`). The Playwright sweep pushes a `category` test annotation (still mostly `visual-contract` until manifest carries fixture metadata).
> 
> **Tests:** New manifest assertions for canonical vs `?standalone=1` behavior and compose-only `/api/manifest/:name` resolution; fixture-schema category tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f4a759de246835c09235db4585eadf793dc914f6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->