### PR TITLE
fix(a11y): clear all serious axe violations, empty the allow-list

### DIFF
--- a/packages/components/src/components/area-chart/area-chart.svelte
+++ b/packages/components/src/components/area-chart/area-chart.svelte
@@ -218,9 +218,12 @@
     {/if}
     <svg
       viewBox={`0 0 ${measuredWidth} ${height}`}
-      role="img"
       aria-hidden={loading || model.empty ? 'true' : undefined}
+      aria-labelledby={!loading && !model.empty ? `${rootId}-svg-title` : undefined}
     >
+      {#if !loading && !model.empty}
+        <title id="{rootId}-svg-title">{label}</title>
+      {/if}
       <g transform={`translate(${model.geometry.marginLeft}, ${model.geometry.marginTop})`}>
         {#each model.yTicks as tick, index}
           <line

--- a/packages/components/src/components/area-chart/area-chart.test.ts
+++ b/packages/components/src/components/area-chart/area-chart.test.ts
@@ -77,6 +77,45 @@ describe('AreaChart', () => {
     expect(container.querySelectorAll('[data-cinder-series="usage"]').length).toBe(0);
   });
 
+  test('svg has an accessible title matching the label when data is present', () => {
+    const { container } = render(AreaChart, { label: 'Usage trend', series });
+    const svg = container.querySelector('svg');
+    const title = svg?.querySelector('title');
+
+    expect(svg?.getAttribute('role')).toBeNull();
+    expect(title).not.toBeNull();
+    expect(title?.textContent).toBe('Usage trend');
+    expect(svg?.getAttribute('aria-labelledby')).toBeTruthy();
+  });
+
+  test('svg has no title and is aria-hidden when loading', () => {
+    const { container } = render(AreaChart, { label: 'Usage trend', loading: true, series });
+    const svg = container.querySelector('svg');
+
+    expect(svg?.getAttribute('aria-hidden')).toBe('true');
+    expect(svg?.querySelector('title')).toBeNull();
+  });
+
+  test('svg has no title and is aria-hidden when empty', () => {
+    const { container } = render(AreaChart, { label: 'Usage trend', series: [] });
+    const svg = container.querySelector('svg');
+
+    expect(svg?.getAttribute('aria-hidden')).toBe('true');
+    expect(svg?.querySelector('title')).toBeNull();
+  });
+
+  test('interactive focus targets are not inside an img-role element', () => {
+    const { container } = render(AreaChart, { label: 'Usage trend', series });
+    const svg = container.querySelector('svg');
+
+    // The svg must not carry role="img" — that is a leaf role that forbids
+    // interactive descendants (nested-interactive axe violation).
+    expect(svg?.getAttribute('role')).toBeNull();
+    // The interactive buttons must still be present and focusable.
+    const buttons = container.querySelectorAll('[role="button"][tabindex="0"]');
+    expect(buttons.length).toBeGreaterThan(0);
+  });
+
   test('loading state renders the loading indicator and hides the SVG', () => {
     const { getByText, container } = render(AreaChart, {
       label: 'Loading',

--- a/packages/components/src/components/avatar-group/avatar-group.svelte
+++ b/packages/components/src/components/avatar-group/avatar-group.svelte
@@ -133,14 +133,19 @@
     >
       {#if item.trimmedName}
         <Tooltip text={item.trimmedName} describe={false}>
-          <!-- The trigger is keyboard-focusable and reveals a tooltip on focus/hover,
-               so it is an interactive control, not a static image. role="button" makes
-               aria-label valid AND announces an actionable affordance — role="img" (a
-               non-interactive leaf role) would announce "image" on a focus stop with no
-               explanation of why it is focusable. -->
+          <!-- role="img" is the honest semantic: a NAMED composite image, not an
+               action control. The trigger only reveals a name tooltip on focus/
+               hover — it has no onclick/Enter/Space activation, so role="button"
+               would be a false affordance (announces "button" but does nothing →
+               WCAG 4.1.2). img takes its name from the author, so aria-label is
+               valid here (no aria-prohibited-attr). tabindex="0" on a non-
+               interactive role is permitted by ARIA and is purposeful: it gives
+               keyboard users the same name-disclosure pointer users get on hover.
+               The inner <Avatar> uses alt="" so its image doesn't double-name the
+               composite. -->
           <span
             class="cinder-avatar-group__trigger"
-            role="button"
+            role="img"
             tabindex="0"
             aria-label={item.trimmedName}
           >

--- a/packages/components/src/components/avatar-group/avatar-group.svelte
+++ b/packages/components/src/components/avatar-group/avatar-group.svelte
@@ -133,11 +133,14 @@
     >
       {#if item.trimmedName}
         <Tooltip text={item.trimmedName} describe={false}>
-          <!-- Focusable labeled avatar image. role="img" makes aria-label valid and -->
-          <!-- conveys that this element presents a named image, not an actionable control. -->
+          <!-- The trigger is keyboard-focusable and reveals a tooltip on focus/hover,
+               so it is an interactive control, not a static image. role="button" makes
+               aria-label valid AND announces an actionable affordance — role="img" (a
+               non-interactive leaf role) would announce "image" on a focus stop with no
+               explanation of why it is focusable. -->
           <span
             class="cinder-avatar-group__trigger"
-            role="img"
+            role="button"
             tabindex="0"
             aria-label={item.trimmedName}
           >

--- a/packages/components/src/components/avatar-group/avatar-group.svelte
+++ b/packages/components/src/components/avatar-group/avatar-group.svelte
@@ -133,9 +133,14 @@
     >
       {#if item.trimmedName}
         <Tooltip text={item.trimmedName} describe={false}>
-          <!-- Focusable tooltip disclosure target; not an actionable control. -->
-          <!-- svelte-ignore a11y_no_noninteractive_tabindex -->
-          <span class="cinder-avatar-group__trigger" tabindex="0" aria-label={item.trimmedName}>
+          <!-- Focusable labeled avatar image. role="img" makes aria-label valid and -->
+          <!-- conveys that this element presents a named image, not an actionable control. -->
+          <span
+            class="cinder-avatar-group__trigger"
+            role="img"
+            tabindex="0"
+            aria-label={item.trimmedName}
+          >
             <Avatar
               {...avatarSourceProps(item.avatar.src)}
               name={item.trimmedName}

--- a/packages/components/src/components/avatar-group/avatar-group.test.ts
+++ b/packages/components/src/components/avatar-group/avatar-group.test.ts
@@ -246,6 +246,16 @@ describe('AvatarGroup', () => {
     });
   });
 
+  test('named avatar triggers carry role="img" so aria-label is valid', () => {
+    const { container } = render(AvatarGroup, { avatars: collaborators.slice(0, 2) });
+
+    const triggers = container.querySelectorAll<HTMLElement>('.cinder-avatar-group__trigger');
+    for (const trigger of triggers) {
+      expect(trigger.getAttribute('role')).toBe('img');
+      expect(trigger.getAttribute('aria-label')).toBeTruthy();
+    }
+  });
+
   test('shows a named avatar tooltip on focus and hides it on Escape', async () => {
     const { container } = render(AvatarGroup, { avatars: collaborators.slice(0, 1) });
 

--- a/packages/components/src/components/avatar-group/avatar-group.test.ts
+++ b/packages/components/src/components/avatar-group/avatar-group.test.ts
@@ -246,15 +246,16 @@ describe('AvatarGroup', () => {
     });
   });
 
-  test('named avatar triggers carry role="button" so aria-label is valid', () => {
+  test('named avatar triggers carry role="img" so aria-label is valid', () => {
     const { container } = render(AvatarGroup, { avatars: collaborators.slice(0, 2) });
 
     const triggers = container.querySelectorAll<HTMLElement>('.cinder-avatar-group__trigger');
     for (const trigger of triggers) {
-      // The trigger is a focus-activated tooltip control, so role="button" (an
-      // interactive role) is correct — not role="img" (a non-interactive leaf
-      // role that would announce "image" on a focus stop with no affordance).
-      expect(trigger.getAttribute('role')).toBe('button');
+      // role="img" is the honest semantic for a focusable NAMED image. The
+      // trigger has no activation (only a focus/hover name tooltip), so
+      // role="button" would be a false affordance (WCAG 4.1.2). img takes its
+      // name from the author, so aria-label is valid (no aria-prohibited-attr).
+      expect(trigger.getAttribute('role')).toBe('img');
       expect(trigger.getAttribute('aria-label')).toBeTruthy();
     }
   });

--- a/packages/components/src/components/avatar-group/avatar-group.test.ts
+++ b/packages/components/src/components/avatar-group/avatar-group.test.ts
@@ -246,14 +246,31 @@ describe('AvatarGroup', () => {
     });
   });
 
-  test('named avatar triggers carry role="img" so aria-label is valid', () => {
+  test('named avatar triggers carry role="button" so aria-label is valid', () => {
     const { container } = render(AvatarGroup, { avatars: collaborators.slice(0, 2) });
 
     const triggers = container.querySelectorAll<HTMLElement>('.cinder-avatar-group__trigger');
     for (const trigger of triggers) {
-      expect(trigger.getAttribute('role')).toBe('img');
+      // The trigger is a focus-activated tooltip control, so role="button" (an
+      // interactive role) is correct — not role="img" (a non-interactive leaf
+      // role that would announce "image" on a focus stop with no affordance).
+      expect(trigger.getAttribute('role')).toBe('button');
       expect(trigger.getAttribute('aria-label')).toBeTruthy();
     }
+  });
+
+  test('unnamed avatar triggers carry neither role nor aria-label (no unnamed control)', () => {
+    // An avatar with no name still renders a trigger span, but it is NOT
+    // keyboard focusable and carries no role="button"/aria-label pair — so there
+    // is no interactive control lacking an accessible name.
+    const { container } = render(AvatarGroup, {
+      avatars: [{ name: '', src: 'https://example.test/a.png' }],
+    });
+    const trigger = container.querySelector('.cinder-avatar-group__trigger');
+    expect(trigger).not.toBeNull();
+    expect(trigger?.getAttribute('role')).toBeNull();
+    expect(trigger?.getAttribute('aria-label')).toBeNull();
+    expect(trigger?.hasAttribute('tabindex')).toBe(false);
   });
 
   test('shows a named avatar tooltip on focus and hides it on Escape', async () => {

--- a/packages/components/src/components/bar-chart/bar-chart.svelte
+++ b/packages/components/src/components/bar-chart/bar-chart.svelte
@@ -225,9 +225,12 @@
     {/if}
     <svg
       viewBox={`0 0 ${measuredWidth} ${height}`}
-      role="img"
       aria-hidden={loading || model.empty ? 'true' : undefined}
+      aria-labelledby={!loading && !model.empty ? `${rootId}-svg-title` : undefined}
     >
+      {#if !loading && !model.empty}
+        <title id="{rootId}-svg-title">{label}</title>
+      {/if}
       <g transform={`translate(${model.geometry.marginLeft}, ${model.geometry.marginTop})`}>
         {#each model.yTicks as tick, index}
           <text

--- a/packages/components/src/components/bar-chart/bar-chart.test.ts
+++ b/packages/components/src/components/bar-chart/bar-chart.test.ts
@@ -79,6 +79,66 @@ describe('BarChart', () => {
     ).toThrow('rule=invalid-bar-value');
   });
 
+  test('svg has an accessible title matching the label when data is present', () => {
+    const { container } = render(BarChart, {
+      label: 'Revenue by month',
+      data,
+      categoryKey: 'month',
+      series,
+    });
+    const svg = container.querySelector('svg');
+    const title = svg?.querySelector('title');
+
+    expect(svg?.getAttribute('role')).toBeNull();
+    expect(title).not.toBeNull();
+    expect(title?.textContent).toBe('Revenue by month');
+    expect(svg?.getAttribute('aria-labelledby')).toBeTruthy();
+  });
+
+  test('svg has no title and is aria-hidden when loading', () => {
+    const { container } = render(BarChart, {
+      label: 'Revenue by month',
+      loading: true,
+      data,
+      categoryKey: 'month',
+      series,
+    });
+    const svg = container.querySelector('svg');
+
+    expect(svg?.getAttribute('aria-hidden')).toBe('true');
+    expect(svg?.querySelector('title')).toBeNull();
+  });
+
+  test('svg has no title and is aria-hidden when empty', () => {
+    const { container } = render(BarChart, {
+      label: 'Revenue by month',
+      data: [],
+      categoryKey: 'month',
+      series,
+    });
+    const svg = container.querySelector('svg');
+
+    expect(svg?.getAttribute('aria-hidden')).toBe('true');
+    expect(svg?.querySelector('title')).toBeNull();
+  });
+
+  test('interactive focus targets are not inside an img-role element', () => {
+    const { container } = render(BarChart, {
+      label: 'Revenue by month',
+      data,
+      categoryKey: 'month',
+      series,
+    });
+    const svg = container.querySelector('svg');
+
+    // The svg must not carry role="img" — that is a leaf role that forbids
+    // interactive descendants (nested-interactive axe violation).
+    expect(svg?.getAttribute('role')).toBeNull();
+    // The interactive buttons must still be present and focusable.
+    const buttons = container.querySelectorAll('[role="button"][tabindex="0"]');
+    expect(buttons.length).toBeGreaterThan(0);
+  });
+
   test('loading state renders the loading indicator and hides the SVG', () => {
     const { getByText, container } = render(BarChart, {
       label: 'Loading',

--- a/packages/components/src/components/chip/chip.css
+++ b/packages/components/src/components/chip/chip.css
@@ -185,18 +185,38 @@
  * Disabled state
  * ---------------------------------------- */
 
-  button.cinder-chip:disabled {
-    opacity: 0.5;
+  /* Disabled visual is expressed with muted COLOR tokens, not `opacity`.
+   * A root `opacity: 0.5` creates a stacking context the children composite
+   * THROUGH — so the label can never be more opaque than its parent, and the
+   * disabled-text token (4.61:1 on its own) gets halved to ~1.9:1 and fails
+   * WCAG AA. Muting per-property instead lets the label keep full contrast
+   * via --cinder-text-disabled while the border/background still read as
+   * disabled. Covers both the removable/display path (data-cinder-disabled)
+   * and the toggle-button path (native :disabled). */
+  button.cinder-chip:disabled,
+  .cinder-chip[data-cinder-disabled] {
     cursor: not-allowed;
+    background: var(--cinder-surface-inset);
+    border-color: var(--cinder-border-muted);
   }
 
   .cinder-chip__remove:disabled {
     cursor: not-allowed;
   }
 
-  .cinder-chip[data-cinder-disabled] {
-    opacity: 0.5;
-    cursor: not-allowed;
+  .cinder-chip[data-cinder-disabled] .cinder-chip__label,
+  button.cinder-chip:disabled .cinder-chip__label {
+    color: var(--cinder-text-disabled);
+  }
+
+  /* Icons and the remove affordance carry the muted treatment so the chip still
+   * reads as disabled even though the label stays at full contrast. */
+  .cinder-chip[data-cinder-disabled] .cinder-chip__icon,
+  button.cinder-chip:disabled .cinder-chip__icon,
+  .cinder-chip[data-cinder-disabled] .cinder-chip__remove,
+  button.cinder-chip:disabled .cinder-chip__remove {
+    color: var(--cinder-text-disabled);
+    opacity: 0.6;
   }
 
   /* ----------------------------------------

--- a/packages/components/src/components/chip/chip.test.ts
+++ b/packages/components/src/components/chip/chip.test.ts
@@ -361,6 +361,37 @@ describe('Chip', () => {
   });
 });
 
+// Source-level guard for the disabled-chip contrast fix. The disabled label must
+// resolve to --cinder-text-disabled (4.61:1 on --cinder-surface-inset) AND must
+// not be trapped under a parent `opacity` that would composite it down — opacity
+// halving the disabled token is exactly the bug this guards against (the label
+// can never be more opaque than its ancestor, so a root opacity:0.5 dragged the
+// resolved label to ~1.9:1 and failed axe color-contrast).
+describe('Chip disabled-label contrast guard', () => {
+  const css = readFileSync(new URL('./chip.css', import.meta.url), 'utf8');
+
+  test('disabled chip label uses the --cinder-text-disabled token (both paths)', () => {
+    const block = css.match(
+      /\.cinder-chip\[data-cinder-disabled\]\s*\.cinder-chip__label,\s*button\.cinder-chip:disabled\s*\.cinder-chip__label[\s\S]*?\{[^}]*\}/,
+    )?.[0];
+    expect(block).toBeDefined();
+    expect(block).toContain('color: var(--cinder-text-disabled)');
+  });
+
+  test('the disabled chip root does NOT use opacity (would trap the label below AA)', () => {
+    // Mute is expressed via color tokens, never a root opacity that composites
+    // the label down. The two disabled-root selectors share one combined rule
+    // (`button.cinder-chip:disabled, .cinder-chip[data-cinder-disabled] { … }`).
+    // Assert no `opacity:` declaration appears in that rule body. The label and
+    // icon rules below it set their own colors and are matched separately.
+    const disabledRoot = css.match(
+      /button\.cinder-chip:disabled,\s*\.cinder-chip\[data-cinder-disabled\]\s*\{[^}]*\}/,
+    )?.[0];
+    expect(disabledRoot).toBeDefined();
+    expect(disabledRoot).not.toContain('opacity');
+  });
+});
+
 // Source-level guard: pressed semantic chips must pair the solid accent
 // background with its readable *-contrast foreground token, never the soft
 // `*-bg` tint that rendered unreadable. Asserting `aria-pressed` alone would

--- a/packages/components/src/components/chip/chip.test.ts
+++ b/packages/components/src/components/chip/chip.test.ts
@@ -382,11 +382,15 @@ describe('Chip disabled-label contrast guard', () => {
     // Mute is expressed via color tokens, never a root opacity that composites
     // the label down. The two disabled-root selectors share one combined rule
     // (`button.cinder-chip:disabled, .cinder-chip[data-cinder-disabled] { … }`).
-    // Assert no `opacity:` declaration appears in that rule body. The label and
-    // icon rules below it set their own colors and are matched separately.
-    const disabledRoot = css.match(
-      /button\.cinder-chip:disabled,\s*\.cinder-chip\[data-cinder-disabled\]\s*\{[^}]*\}/,
-    )?.[0];
+    // Match either selector order — grouped-selector order is cosmetic and a
+    // formatter could swap it without changing behavior. Assert no `opacity:`
+    // declaration appears in that rule body; the label and icon rules below it
+    // set their own colors and are matched separately.
+    const buttonFirst =
+      /button\.cinder-chip:disabled,\s*\.cinder-chip\[data-cinder-disabled\]\s*\{[^}]*\}/;
+    const attrFirst =
+      /\.cinder-chip\[data-cinder-disabled\],\s*button\.cinder-chip:disabled\s*\{[^}]*\}/;
+    const disabledRoot = (css.match(buttonFirst) ?? css.match(attrFirst))?.[0];
     expect(disabledRoot).toBeDefined();
     expect(disabledRoot).not.toContain('opacity');
   });

--- a/packages/components/src/components/code-block/code-block.css
+++ b/packages/components/src/components/code-block/code-block.css
@@ -80,13 +80,14 @@
    * (#24292e near-black, #d73a49 keyword red) against a dark surface — ratios
    * as low as 1.38 — failing axe color-contrast.
    *
-   * Cover all three cases in which a cinder dark theme is active:
-   *   1. An explicit `[data-cinder-theme="dark"]` set by the playground (or any
-   *      consumer that follows the cinder data attribute convention).
-   *   2. An explicit `[data-theme="dark"]` set by tokens-base.css helpers or
-   *      direct consumer usage.
-   *   3. `prefers-color-scheme: dark` (system preference) when no explicit
-   *      light/forced-system override is present.
+   * Cover the two cases in which a cinder dark theme is active. Both anchor on
+   * `[data-cinder-theme=…]` — the authoritative signal cinder sets on the
+   * document element (render-shell.ts) and the only theme anchor the
+   * component-CSS-sidecar lint accepts (`:root`/`[data-theme]` are
+   * foundation-layer selectors it rejects):
+   *   1. An explicit dark choice: `[data-cinder-theme="dark"]`.
+   *   2. The system choice resolving to dark: `[data-cinder-theme="system"]`
+   *      under `@media (prefers-color-scheme: dark)`.
    * ──────────────────────────────────────────────────────────────────────── */
 
   /* `!important` is required: Shiki writes the light color as an INLINE style
@@ -167,8 +168,11 @@
 
   /* Suppress the shiki <pre>'s own scroll since .cinder-code-block__highlighted
    owns the scroll container (axe scrollable-region-focusable requires only one
-   keyboard-reachable scroll region, not a nested pair). */
+   keyboard-reachable scroll region, not a nested pair). `clip` (not `visible`)
+   is used because a `visible` child of an overflow-x:auto parent is coerced
+   back to `auto` by the UA — `clip` is not, so the inner pre reliably never
+   establishes its own scroll port. */
   .cinder-code-block__highlighted :where(pre.shiki) {
-    overflow-x: visible;
+    overflow-x: clip;
   }
 }

--- a/packages/components/src/components/code-block/code-block.css
+++ b/packages/components/src/components/code-block/code-block.css
@@ -166,13 +166,20 @@
     overflow-x: auto;
   }
 
-  /* Suppress the shiki <pre>'s own scroll since .cinder-code-block__highlighted
-   owns the scroll container (axe scrollable-region-focusable requires only one
-   keyboard-reachable scroll region, not a nested pair). `clip` (not `visible`)
-   is used because a `visible` child of an overflow-x:auto parent is coerced
-   back to `auto` by the UA — `clip` is not, so the inner pre reliably never
-   establishes its own scroll port. */
+  /* The shiki <pre> must NOT own a scroll port — the parent
+   .cinder-code-block__highlighted is the single keyboard-reachable scroll
+   region (axe scrollable-region-focusable wants one, not a nested pair). But it
+   MUST still contribute its full content width to the parent's scrollable
+   overflow, or long lines get clipped and become unreachable. So: let the pre
+   grow to its intrinsic width (`width: max-content`, floored at `min-width:
+   100%` so short code still fills the box) and clip its own (now non-existent)
+   overflow. Because the element is sized to its content, `clip` is a no-op on
+   the pre itself, while the wider-than-viewport pre makes the PARENT scroll.
+   (Plain `overflow-x: clip` alone clipped the overflow out of existence so the
+   parent never became scrollable — verified in-browser.) */
   .cinder-code-block__highlighted :where(pre.shiki) {
+    width: max-content;
+    min-width: 100%;
     overflow-x: clip;
   }
 }

--- a/packages/components/src/components/code-block/code-block.css
+++ b/packages/components/src/components/code-block/code-block.css
@@ -41,12 +41,14 @@
 .cinder-code-block > pre {
     margin: 0;
     padding: var(--cinder-space-4);
-    overflow-x: auto;
     font-family: var(--cinder-font-mono);
     font-size: var(--cinder-text-sm);
     line-height: var(--cinder-leading-relaxed);
     color: var(--cinder-text);
-    background: var(--cinder-surface-inset);
+    /* Use near-white in light mode so github-light token colors (e.g. #d73a49
+     * keyword red) clear 4.5:1 WCAG AA. In dark mode keep the deep inset so
+     * github-dark tokens maintain contrast on a very dark surface. */
+    background: light-dark(var(--cinder-surface-raised), var(--cinder-surface-inset));
   }
 
   .cinder-code-block__code {
@@ -57,16 +59,64 @@
   .cinder-code-block :where(pre.shiki) {
     margin: 0 !important;
     padding: var(--cinder-space-3) var(--cinder-space-4) !important;
-    overflow-x: auto;
     font-family: var(--cinder-font-mono);
     font-size: var(--cinder-text-sm);
     line-height: var(--cinder-leading-relaxed);
-    background: var(--cinder-surface-inset) !important;
+    /* Same light/dark split as the plain __pre — near-white in light for
+     * github-light contrast, deep inset in dark for github-dark contrast. */
+    background: light-dark(var(--cinder-surface-raised), var(--cinder-surface-inset)) !important;
   }
 
   .cinder-code-block :where(pre.shiki code) {
     font-family: inherit;
     font-size: inherit;
+  }
+
+  /* ── Dark-theme Shiki dual-theme fix ─────────────────────────────────────
+   * Shiki's dual-theme output emits inline styles on every token span with
+   * BOTH the light value (`color: #24292E`) and the dark value
+   * (`--shiki-dark: #E1E4E8`). Without a CSS rule that swaps `color` to
+   * `var(--shiki-dark)` in dark mode, token spans show their light color
+   * (#24292e near-black, #d73a49 keyword red) against a dark surface — ratios
+   * as low as 1.38 — failing axe color-contrast.
+   *
+   * Cover all three cases in which a cinder dark theme is active:
+   *   1. An explicit `[data-cinder-theme="dark"]` set by the playground (or any
+   *      consumer that follows the cinder data attribute convention).
+   *   2. An explicit `[data-theme="dark"]` set by tokens-base.css helpers or
+   *      direct consumer usage.
+   *   3. `prefers-color-scheme: dark` (system preference) when no explicit
+   *      light/forced-system override is present.
+   * ──────────────────────────────────────────────────────────────────────── */
+
+  /* `!important` is required: Shiki writes the light color as an INLINE style
+   * (`style="color:#24292E"`) on every span, and an inline declaration beats a
+   * stylesheet rule on specificity. Without `!important` the light color wins in
+   * dark mode and the override is silently a no-op (contrast as low as 1.38).
+   * We override ONLY the foreground — the span background stays transparent so
+   * the dark `--cinder-surface-inset` forced on the <pre> shows through. (An
+   * earlier attempt set `background-color: var(--shiki-dark-bg)` here, which
+   * repainted each span with Shiki's own dark bg `#24292e` and re-broke contrast
+   * against the github-dark red — dropped.)
+   *
+   * The selectors anchor on `[data-cinder-theme=...]` — the authoritative theme
+   * signal cinder sets on the document element (see render-shell.ts). That
+   * `data-cinder-` namespace is also what the component-CSS-sidecar lint accepts
+   * as a scope anchor; a `:root`/`[data-theme]` prefix is a foundation-layer
+   * selector and is (correctly) rejected here. */
+
+  /* Explicit dark choice. */
+  [data-cinder-theme='dark'] .cinder-code-block :where(pre.shiki) span {
+    color: var(--shiki-dark, inherit) !important;
+  }
+
+  /* System choice that resolves to dark via the OS preference. cinder sets
+   * `data-cinder-theme="system"` and leaves `color-scheme: light dark` to follow
+   * `prefers-color-scheme`, so we mirror that here for the inline-style swap. */
+  @media (prefers-color-scheme: dark) {
+    [data-cinder-theme='system'] .cinder-code-block :where(pre.shiki) span {
+      color: var(--shiki-dark, inherit) !important;
+    }
   }
 
   /* Compact, borderless copy button when nested inside a code block header.
@@ -106,9 +156,19 @@
   /* Stable wrapper that anchors {@html highlighted} for Svelte 5 reconciliation —
    Svelte appends new nodes alongside the old when an `{@html}` value changes
    between two non-null strings unless it sits inside a stable parent element.
-   Purely structural: `display: contents` so it never affects layout. Target
-   the inner `<pre>` (Shiki-emitted) for styling, not this wrapper. */
+   This div is also the keyboard-accessible scroll container for the highlighted
+   code (tabindex="0" is set in the template). The inner shiki <pre> must NOT
+   independently scroll — overflow is owned here so keyboard users reach the
+   scroll region via a single focusable element. */
   .cinder-code-block__highlighted {
-    display: contents;
+    display: block;
+    overflow-x: auto;
+  }
+
+  /* Suppress the shiki <pre>'s own scroll since .cinder-code-block__highlighted
+   owns the scroll container (axe scrollable-region-focusable requires only one
+   keyboard-reachable scroll region, not a nested pair). */
+  .cinder-code-block__highlighted :where(pre.shiki) {
+    overflow-x: visible;
   }
 }

--- a/packages/components/src/components/code-block/code-block.css
+++ b/packages/components/src/components/code-block/code-block.css
@@ -41,6 +41,7 @@
 .cinder-code-block > pre {
     margin: 0;
     padding: var(--cinder-space-4);
+    overflow-x: auto;
     font-family: var(--cinder-font-mono);
     font-size: var(--cinder-text-sm);
     line-height: var(--cinder-leading-relaxed);

--- a/packages/components/src/components/code-block/code-block.svelte
+++ b/packages/components/src/components/code-block/code-block.svelte
@@ -122,12 +122,26 @@
        element Svelte can replace in place. -->
   <svelte:boundary>
     {#if highlighted !== null}
-      <div class="cinder-code-block__highlighted">{@html highlighted}</div>
+      <!-- tabindex="0" makes this scroll container keyboard-reachable so
+           keyboard-only users can scroll long highlighted code snippets
+           (WCAG 2.1 SC 2.1.1; axe scrollable-region-focusable). The div
+           owns overflow-x: auto in CSS; the inner shiki <pre> is set to
+           overflow-x: visible so there is exactly one focusable scroll region.
+           aria-label + role="region" expose the scroll region to assistive
+           technology as a landmark with an accessible name. -->
+      <div class="cinder-code-block__highlighted" tabindex="0" role="region" aria-label="Code">
+        {@html highlighted}
+      </div>
     {:else}
-      <pre class="cinder-code-block__pre"><code class="cinder-code-block__code">{code}</code></pre>
+      <!-- tabindex="0" makes the plain-code scroll container keyboard-reachable. -->
+      <pre class="cinder-code-block__pre" tabindex="0"><code class="cinder-code-block__code"
+          >{code}</code
+        ></pre>
     {/if}
     {#snippet failed()}
-      <pre class="cinder-code-block__pre"><code class="cinder-code-block__code">{code}</code></pre>
+      <pre class="cinder-code-block__pre" tabindex="0"><code class="cinder-code-block__code"
+          >{code}</code
+        ></pre>
     {/snippet}
   </svelte:boundary>
 </div>

--- a/packages/components/src/components/code-block/code-block.svelte
+++ b/packages/components/src/components/code-block/code-block.svelte
@@ -125,11 +125,12 @@
       <!-- tabindex="0" makes this scroll container keyboard-reachable so
            keyboard-only users can scroll long highlighted code snippets
            (WCAG 2.1 SC 2.1.1; axe scrollable-region-focusable). The div
-           owns overflow-x: auto in CSS; the inner shiki <pre> is set to
-           overflow-x: visible so there is exactly one focusable scroll region.
-           aria-label + role="region" expose the scroll region to assistive
-           technology as a landmark with an accessible name. -->
-      <div class="cinder-code-block__highlighted" tabindex="0" role="region" aria-label="Code">
+           owns overflow-x: auto in CSS; the inner shiki <pre> is clipped
+           so there is exactly one focusable scroll region. No role="region":
+           a landmark per code block would flood landmark navigation with
+           identically-named "Code" regions on docs pages with many snippets —
+           tabindex alone satisfies the keyboard-scroll requirement. -->
+      <div class="cinder-code-block__highlighted" tabindex="0">
         {@html highlighted}
       </div>
     {:else}

--- a/packages/components/src/components/code-block/code-block.test.ts
+++ b/packages/components/src/components/code-block/code-block.test.ts
@@ -67,6 +67,13 @@ describe('CodeBlock — static structure', () => {
     expect(loadDefaultHighlighter).not.toHaveBeenCalled();
   });
 
+  test('plain <pre> scroll container has tabindex="0" for keyboard access', () => {
+    const { container } = render(CodeBlock, { code: 'const x = 1;' });
+    const pre = container.querySelector('pre.cinder-code-block__pre');
+    expect(pre).not.toBeNull();
+    expect(pre?.getAttribute('tabindex')).toBe('0');
+  });
+
   test('language prop renders a language label in the header', () => {
     const { container } = render(CodeBlock, { code: 'const x', language: 'ts', highlight: false });
     const label = container.querySelector('.cinder-code-block__language');
@@ -108,6 +115,19 @@ describe('CodeBlock — static structure', () => {
     expect(css).toContain('outline-color: CanvasText;');
     expect(css).toContain('box-shadow: none;');
   });
+
+  test('CSS contains dark-theme rule that overrides shiki span color with --shiki-dark', async () => {
+    const css = await Bun.file(new URL('./code-block.css', import.meta.url)).text();
+    // The rule must cover the [data-cinder-theme='dark'] selector (playground uses this).
+    expect(css).toContain("data-cinder-theme='dark'");
+    // The rule must switch the inline `color:` to the --shiki-dark custom property.
+    expect(css).toContain('color: var(--shiki-dark, inherit)');
+  });
+
+  test('CSS contains prefers-color-scheme: dark fallback for system dark mode', async () => {
+    const css = await Bun.file(new URL('./code-block.css', import.meta.url)).text();
+    expect(css).toContain('@media (prefers-color-scheme: dark)');
+  });
 });
 
 describe('CodeBlock — automatic highlighting (bundled default)', () => {
@@ -121,6 +141,15 @@ describe('CodeBlock — automatic highlighting (bundled default)', () => {
     expect(loadDefaultHighlighter).toHaveBeenCalledTimes(1);
     // The default highlighter output replaces the plain fallback.
     expect(container.querySelector('.cinder-code-block__pre')).toBeNull();
+  });
+
+  test('highlighted wrapper div has tabindex="0" for keyboard scroll access', async () => {
+    const { container } = render(CodeBlock, { code: 'const x = 1;', language: 'js' });
+    await waitFor(() => {
+      const wrapper = container.querySelector('.cinder-code-block__highlighted');
+      expect(wrapper).not.toBeNull();
+      expect(wrapper?.getAttribute('tabindex')).toBe('0');
+    });
   });
 
   test('default-load failure falls back to escaped plain code (warn names language, never code)', async () => {

--- a/packages/components/src/components/copy-button/copy-button.examples.json
+++ b/packages/components/src/components/copy-button/copy-button.examples.json
@@ -7,7 +7,7 @@
       "id": "basic",
       "title": "Basic copy button",
       "description": "Click to copy. The button enters a confirmation state for a brief moment.",
-      "code": "<script lang=\"ts\">\n  import { CopyButton } from 'cinder/copy-button';\n</script>\n\n<div class=\"example-preview-row\" style=\"align-items: center;\">\n  <code style=\"padding: 0.25rem 0.5rem; background: #f4f4f4; border-radius: 4px;\"\n    >npx cinder install</code\n  >\n  <CopyButton value=\"npx cinder install\" label=\"Copy install command\" />\n</div>\n"
+      "code": "<script lang=\"ts\">\n  import { CopyButton } from 'cinder/copy-button';\n</script>\n\n<div class=\"example-preview-row\" style=\"align-items: center;\">\n  <code\n    style=\"padding: 0.25rem 0.5rem; background-color: var(--cinder-surface-inset); color: var(--cinder-text); border-radius: 4px;\"\n    >npx cinder install</code\n  >\n  <CopyButton value=\"npx cinder install\" label=\"Copy install command\" />\n</div>\n"
     }
   ]
 }

--- a/packages/components/src/components/line-chart/line-chart.svelte
+++ b/packages/components/src/components/line-chart/line-chart.svelte
@@ -217,9 +217,12 @@
     {/if}
     <svg
       viewBox={`0 0 ${measuredWidth} ${height}`}
-      role="img"
       aria-hidden={loading || model.empty ? 'true' : undefined}
+      aria-labelledby={!loading && !model.empty ? `${rootId}-svg-title` : undefined}
     >
+      {#if !loading && !model.empty}
+        <title id="{rootId}-svg-title">{label}</title>
+      {/if}
       <g transform={`translate(${model.geometry.marginLeft}, ${model.geometry.marginTop})`}>
         {#each model.yTicks as tick, index}
           <line

--- a/packages/components/src/components/line-chart/line-chart.test.ts
+++ b/packages/components/src/components/line-chart/line-chart.test.ts
@@ -39,14 +39,57 @@ const series = [
 
 describe('LineChart', () => {
   test('renders a semantic data table fallback with caption', () => {
-    const { getByText, container } = render(LineChart, {
+    const { container } = render(LineChart, {
       label: 'Monthly revenue',
       dataTableVisibility: 'visible',
       series,
     });
 
-    expect(getByText('Monthly revenue')).toBeTruthy();
+    expect(container.querySelector('table caption')?.textContent).toBe('Monthly revenue');
     expect(container.querySelector('table')?.className).not.toContain('cinder-sr-only');
+  });
+
+  test('svg has an accessible title matching the label when data is present', () => {
+    const { container } = render(LineChart, { label: 'Monthly revenue', series });
+    const svg = container.querySelector('svg');
+    const title = svg?.querySelector('title');
+
+    expect(svg?.getAttribute('role')).toBeNull();
+    expect(title).not.toBeNull();
+    expect(title?.textContent).toBe('Monthly revenue');
+    expect(svg?.getAttribute('aria-labelledby')).toBeTruthy();
+  });
+
+  test('svg has no title and is aria-hidden when loading', () => {
+    const { container } = render(LineChart, {
+      label: 'Monthly revenue',
+      loading: true,
+      series,
+    });
+    const svg = container.querySelector('svg');
+
+    expect(svg?.getAttribute('aria-hidden')).toBe('true');
+    expect(svg?.querySelector('title')).toBeNull();
+  });
+
+  test('svg has no title and is aria-hidden when empty', () => {
+    const { container } = render(LineChart, { label: 'Monthly revenue', series: [] });
+    const svg = container.querySelector('svg');
+
+    expect(svg?.getAttribute('aria-hidden')).toBe('true');
+    expect(svg?.querySelector('title')).toBeNull();
+  });
+
+  test('interactive focus targets are not inside an img-role element', () => {
+    const { container } = render(LineChart, { label: 'Monthly revenue', series });
+    const svg = container.querySelector('svg');
+
+    // The svg must not carry role="img" — that is a leaf role that forbids
+    // interactive descendants (nested-interactive axe violation).
+    expect(svg?.getAttribute('role')).toBeNull();
+    // The interactive buttons must still be present and focusable.
+    const buttons = container.querySelectorAll('[role="button"][tabindex="0"]');
+    expect(buttons.length).toBeGreaterThan(0);
   });
 
   test('hides data table when requested', () => {

--- a/packages/components/src/components/progress/README.md
+++ b/packages/components/src/components/progress/README.md
@@ -16,14 +16,16 @@ A Progress component. Replace this sentence with a one-line purpose statement on
 
 <!-- generated:props:start -->
 
-| Prop      | Type                       | Required | Default | Description                                            |
-| --------- | -------------------------- | -------- | ------- | ------------------------------------------------------ |
-| `class`   | `string`                   | no       | —       | Additional class names merged with `.cinder-progress`. |
-| `label`   | `string`                   | no       | —       | Human-readable status, exposed as `aria-valuetext`.    |
-| `max`     | `number`                   | no       | —       | Maximum value. Defaults to 100.                        |
-| `size`    | `"sm"` \| `"md"` \| `"lg"` | no       | —       | Size token. Default `md`.                              |
-| `value`   | `number`                   | no       | —       | Current progress value. Omit for indeterminate.        |
-| `variant` | `"bar"` \| `"ring"`        | no       | —       | Visual variant. Default `bar`.                         |
+| Prop             | Type                       | Required | Default | Description                                                                                                                               |
+| ---------------- | -------------------------- | -------- | ------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| `ariaLabel`      | `string`                   | no       | —       | Accessible name applied directly to the progressbar element when no visible label element is present in the page.                         |
+| `ariaLabelledby` | `string`                   | no       | —       | Id of a visible element that serves as the accessible name for the progressbar. Prefer this over `ariaLabel` when a visible label exists. |
+| `class`          | `string`                   | no       | —       | Additional class names merged with `.cinder-progress`.                                                                                    |
+| `label`          | `string`                   | no       | —       | Human-readable status, exposed as `aria-valuetext`.                                                                                       |
+| `max`            | `number`                   | no       | —       | Maximum value. Defaults to 100.                                                                                                           |
+| `size`           | `"sm"` \| `"md"` \| `"lg"` | no       | —       | Size token. Default `md`.                                                                                                                 |
+| `value`          | `number`                   | no       | —       | Current progress value. Omit for indeterminate.                                                                                           |
+| `variant`        | `"bar"` \| `"ring"`        | no       | —       | Visual variant. Default `bar`.                                                                                                            |
 
 <!-- generated:props:end -->
 

--- a/packages/components/src/components/progress/progress.examples.json
+++ b/packages/components/src/components/progress/progress.examples.json
@@ -7,19 +7,19 @@
       "id": "basic",
       "title": "Determinate progress",
       "description": "A progress bar with a known value out of 100.",
-      "code": "<script lang=\"ts\">\n  import { Progress } from 'cinder/progress';\n</script>\n\n<div style=\"display: flex; flex-direction: column; gap: 0.5rem;\">\n  <Progress value={50} />\n  <Progress value={75} />\n  <Progress value={100} />\n</div>\n"
+      "code": "<script lang=\"ts\">\n  import { Progress } from 'cinder/progress';\n</script>\n\n<div style=\"display: flex; flex-direction: column; gap: 0.5rem;\">\n  <Progress value={50} ariaLabel=\"File upload: 50% complete\" />\n  <Progress value={75} ariaLabel=\"File upload: 75% complete\" />\n  <Progress value={100} ariaLabel=\"File upload: 100% complete\" />\n</div>\n"
     },
     {
       "id": "indeterminate",
       "title": "Indeterminate progress",
       "description": "When value is omitted the bar loops; reduced-motion users see a static surface.",
-      "code": "<script lang=\"ts\">\n  import { Progress } from 'cinder/progress';\n</script>\n\n<div style=\"display: flex; flex-direction: column; gap: 0.75rem;\">\n  <Progress />\n  <Progress variant=\"ring\" size=\"lg\" />\n</div>\n"
+      "code": "<script lang=\"ts\">\n  import { Progress } from 'cinder/progress';\n</script>\n\n<div style=\"display: flex; flex-direction: column; gap: 0.75rem;\">\n  <Progress ariaLabel=\"Loading\" />\n  <Progress variant=\"ring\" size=\"lg\" ariaLabel=\"Loading\" />\n</div>\n"
     },
     {
       "id": "with-label",
       "title": "Progress with label",
       "description": "Custom label text is exposed via aria-valuetext for screen readers.",
-      "code": "<script lang=\"ts\">\n  import { Progress } from 'cinder/progress';\n</script>\n\n<div style=\"display: flex; flex-direction: column; gap: 0.4rem;\">\n  <span>Uploading photo (3 of 5)</span>\n  <Progress value={60} label=\"Uploading photo, 60 percent complete\" />\n</div>\n"
+      "code": "<script lang=\"ts\">\n  import { Progress } from 'cinder/progress';\n</script>\n\n<div style=\"display: flex; flex-direction: column; gap: 0.4rem;\">\n  <span id=\"upload-progress-label\">Uploading photo (3 of 5)</span>\n  <Progress\n    value={60}\n    label=\"Uploading photo, 60 percent complete\"\n    ariaLabelledby=\"upload-progress-label\"\n  />\n</div>\n"
     }
   ]
 }

--- a/packages/components/src/components/progress/progress.schema.json
+++ b/packages/components/src/components/progress/progress.schema.json
@@ -22,6 +22,14 @@
       "type": "string",
       "description": "Human-readable status, exposed as `aria-valuetext`."
     },
+    "ariaLabel": {
+      "type": "string",
+      "description": "Accessible name applied directly to the progressbar element when no\nvisible label element is present in the page."
+    },
+    "ariaLabelledby": {
+      "type": "string",
+      "description": "Id of a visible element that serves as the accessible name for the\nprogressbar. Prefer this over `ariaLabel` when a visible label exists."
+    },
     "class": {
       "type": "string",
       "description": "Additional class names merged with `.cinder-progress`."

--- a/packages/components/src/components/progress/progress.schema.ts
+++ b/packages/components/src/components/progress/progress.schema.ts
@@ -24,6 +24,16 @@ const schema = {
       type: 'string',
       description: 'Human-readable status, exposed as `aria-valuetext`.',
     },
+    ariaLabel: {
+      type: 'string',
+      description:
+        'Accessible name applied directly to the progressbar element when no\nvisible label element is present in the page.',
+    },
+    ariaLabelledby: {
+      type: 'string',
+      description:
+        'Id of a visible element that serves as the accessible name for the\nprogressbar. Prefer this over `ariaLabel` when a visible label exists.',
+    },
     class: {
       type: 'string',
       description: 'Additional class names merged with `.cinder-progress`.',

--- a/packages/components/src/components/progress/progress.svelte
+++ b/packages/components/src/components/progress/progress.svelte
@@ -25,6 +25,8 @@
     variant = 'bar',
     size = 'md',
     label,
+    ariaLabel,
+    ariaLabelledby,
     class: className,
   }: ProgressProps = $props();
 
@@ -46,6 +48,8 @@
   <div
     class={cn('cinder-progress', 'cinder-progress--ring', className)}
     role="progressbar"
+    aria-label={ariaLabel}
+    aria-labelledby={ariaLabelledby}
     aria-valuemin={0}
     aria-valuemax={max}
     aria-valuenow={clampedValue}
@@ -77,6 +81,8 @@
   <div
     class={cn('cinder-progress', 'cinder-progress--bar', className)}
     role="progressbar"
+    aria-label={ariaLabel}
+    aria-labelledby={ariaLabelledby}
     aria-valuemin={0}
     aria-valuemax={max}
     aria-valuenow={clampedValue}

--- a/packages/components/src/components/progress/progress.test.ts
+++ b/packages/components/src/components/progress/progress.test.ts
@@ -74,6 +74,58 @@ describe('Progress (ring)', () => {
   });
 });
 
+describe('Progress accessible name', () => {
+  test('ariaLabel is forwarded as aria-label on the bar progressbar element', () => {
+    const { container } = render(Progress, { value: 50, ariaLabel: 'Upload progress' });
+    const el = container.querySelector('[role="progressbar"]');
+    expect(el?.getAttribute('aria-label')).toBe('Upload progress');
+  });
+
+  test('ariaLabel is forwarded as aria-label on the ring progressbar element', () => {
+    const { container } = render(Progress, {
+      value: 50,
+      variant: 'ring',
+      ariaLabel: 'Upload progress',
+    });
+    const el = container.querySelector('[role="progressbar"]');
+    expect(el?.getAttribute('aria-label')).toBe('Upload progress');
+  });
+
+  test('ariaLabelledby is forwarded as aria-labelledby on the bar progressbar element', () => {
+    const { container } = render(Progress, { value: 50, ariaLabelledby: 'my-label' });
+    const el = container.querySelector('[role="progressbar"]');
+    expect(el?.getAttribute('aria-labelledby')).toBe('my-label');
+  });
+
+  test('ariaLabelledby is forwarded as aria-labelledby on the ring progressbar element', () => {
+    const { container } = render(Progress, {
+      value: 50,
+      variant: 'ring',
+      ariaLabelledby: 'my-label',
+    });
+    const el = container.querySelector('[role="progressbar"]');
+    expect(el?.getAttribute('aria-labelledby')).toBe('my-label');
+  });
+
+  test('aria-label is absent when ariaLabel is not provided', () => {
+    const { container } = render(Progress, { value: 50 });
+    const el = container.querySelector('[role="progressbar"]');
+    expect(el?.getAttribute('aria-label')).toBeNull();
+  });
+
+  test('aria-labelledby is absent when ariaLabelledby is not provided', () => {
+    const { container } = render(Progress, { value: 50 });
+    const el = container.querySelector('[role="progressbar"]');
+    expect(el?.getAttribute('aria-labelledby')).toBeNull();
+  });
+
+  test('indeterminate bar with ariaLabel has an accessible name', () => {
+    const { container } = render(Progress, { ariaLabel: 'Loading content' });
+    const el = container.querySelector('[role="progressbar"]');
+    expect(el?.getAttribute('aria-label')).toBe('Loading content');
+  });
+});
+
 /**
  * Extracts all @media (prefers-reduced-motion: reduce) block bodies from a CSS
  * string by balancing braces. Returns an array of block bodies (the content

--- a/packages/components/src/components/progress/progress.types.ts
+++ b/packages/components/src/components/progress/progress.types.ts
@@ -7,6 +7,10 @@ export type ProgressSize = 'sm' | 'md' | 'lg';
  * Indeterminate progress omits `value` (or passes `undefined`); the
  * component renders a looping animation under normal motion preferences
  * and a static surface under `prefers-reduced-motion: reduce`.
+ *
+ * Every progressbar must have an accessible name. Provide one via:
+ * - `ariaLabel` — a direct string label when no visible label element exists.
+ * - `ariaLabelledby` — the `id` of a visible label element in the page.
  */
 export type ProgressProps = {
   /** Current progress value. Omit for indeterminate. */
@@ -19,6 +23,16 @@ export type ProgressProps = {
   size?: ProgressSize;
   /** Human-readable status, exposed as `aria-valuetext`. */
   label?: string;
+  /**
+   * Accessible name applied directly to the progressbar element when no
+   * visible label element is present in the page.
+   */
+  ariaLabel?: string;
+  /**
+   * Id of a visible element that serves as the accessible name for the
+   * progressbar. Prefer this over `ariaLabel` when a visible label exists.
+   */
+  ariaLabelledby?: string;
   /** Additional class names merged with `.cinder-progress`. */
   class?: string;
 };

--- a/packages/components/src/components/table/table.examples.json
+++ b/packages/components/src/components/table/table.examples.json
@@ -13,7 +13,7 @@
       "id": "empty",
       "title": "Empty table",
       "description": "A table with no body rows still renders the header and caption.",
-      "code": "<script lang=\"ts\">\n  import { Table } from 'cinder/table';\n</script>\n\n<Table caption=\"Recent contributors (none yet)\">\n  <Table.Header>\n    <Table.Row>\n      <Table.HeaderCell>Name</Table.HeaderCell>\n      <Table.HeaderCell>Role</Table.HeaderCell>\n      <Table.HeaderCell align=\"right\">Commits</Table.HeaderCell>\n    </Table.Row>\n  </Table.Header>\n  <Table.Body>\n    <Table.Row>\n      <Table.Cell>\n        <span style=\"color: #888; font-style: italic;\"\n          >No contributors yet — invite your team to get started.</span\n        >\n      </Table.Cell>\n      <Table.Cell>—</Table.Cell>\n      <Table.Cell align=\"right\">0</Table.Cell>\n    </Table.Row>\n  </Table.Body>\n</Table>\n"
+      "code": "<script lang=\"ts\">\n  import { Table } from 'cinder/table';\n</script>\n\n<Table caption=\"Recent contributors (none yet)\">\n  <Table.Header>\n    <Table.Row>\n      <Table.HeaderCell>Name</Table.HeaderCell>\n      <Table.HeaderCell>Role</Table.HeaderCell>\n      <Table.HeaderCell align=\"right\">Commits</Table.HeaderCell>\n    </Table.Row>\n  </Table.Header>\n  <Table.Body>\n    <Table.Row>\n      <Table.Cell>\n        <span style=\"color: var(--cinder-text-muted); font-style: italic;\"\n          >No contributors yet — invite your team to get started.</span\n        >\n      </Table.Cell>\n      <Table.Cell>—</Table.Cell>\n      <Table.Cell align=\"right\">0</Table.Cell>\n    </Table.Row>\n  </Table.Body>\n</Table>\n"
     },
     {
       "id": "selection",

--- a/packages/components/src/components/tag-input/tag-input.a11y.md
+++ b/packages/components/src/components/tag-input/tag-input.a11y.md
@@ -5,34 +5,40 @@ tags move into a separate composite widget that users can revisit and edit.
 
 ## Structure
 
-- The committed tags render inside `<ul role="listbox" aria-multiselectable="true">`.
-- Each tag renders as `<li role="option" aria-selected="true">`.
-- The visible text input is a sibling that comes after the listbox in DOM order.
+- The committed tags render inside a plain `<ul>` (implicit `role="list"`) — NOT
+  a `role="listbox"`. Committed tags are confirmed values with a per-item remove
+  command, not selectable options. A listbox would force every child to be a
+  `role="option"`, which legally cannot contain the interactive remove button
+  (axe `aria-required-children` + `nested-interactive`).
+- Each tag renders as a `<li>` (implicit `role="listitem"`) holding the tag label
+  plus a real `<button aria-label="Remove {tag}">`.
+- The visible text input is a sibling that comes after the list in DOM order.
 
-This shape follows the task contract for a listbox-backed tag editor while still
-keeping native text entry in a real `<input>`.
+The remove button being a genuine, named control means it is reachable by
+keyboard, pointer, voice control (Dragon, Voice Control), and switch access.
 
 ## Keyboard model
 
 - `Enter` commits the pending text when the trimmed candidate is non-empty.
 - A configured delimiter key (comma by default) also commits the pending text.
-- `Backspace` on an empty input moves focus to the last tag.
-- `Backspace` or `Delete` on a focused tag removes it.
-- `ArrowLeft`, `ArrowRight`, `Home`, and `End` move focus across tags with a
-  roving-tabindex model.
+- `Backspace` on an empty input moves focus to the last tag's remove button.
+- `Backspace` or `Delete` on a focused remove button removes that tag.
+- `ArrowLeft`, `ArrowRight`, `Home`, and `End` move focus across the remove
+  buttons with a roving-tabindex model.
 - `ArrowRight` from the final tag returns focus to the text input.
 
-The tag options own DOM focus. The nested remove buttons are kept at
-`tabindex="-1"` so they do not create a second focus stop inside each option.
-Pointer users can still activate them directly.
+The remove buttons own DOM focus and carry the roving tabindex: exactly one is in
+the tab order at a time (the focused one, or the first when none is focused, so a
+Tab-only user can always reach the list). When the list is empty no button is in
+the tab order.
 
 ## Labels and descriptions
 
 - When wrapped in `FormField`, the text input inherits `aria-describedby`,
   `aria-invalid`, `aria-required`, and disabled state from context.
-- The listbox receives the `FormField` label through `aria-labelledby`.
+- The tag list receives the `FormField` label through `aria-labelledby`.
 - Standalone `aria-label` and `aria-labelledby` props apply to both the text
-  input and the listbox.
+  input and the tag list.
 
 ## Error messaging
 

--- a/packages/components/src/components/tag-input/tag-input.css
+++ b/packages/components/src/components/tag-input/tag-input.css
@@ -84,10 +84,11 @@
   }
 
   /* The remove <button> carries the roving tabindex, so the focus ring lives on
-     it. The button styling further down sets layout; this rule supplies the
-     visible focus indicator. */
+     it. The box-shadow IS the visible indicator; outline is suppressed (the
+     forced-colors block below restores a real outline where box-shadow is
+     ignored). */
   .cinder-tag-input__remove:focus-visible {
-    outline: var(--cinder-ring-width) solid transparent;
+    outline: none;
     box-shadow:
       0 0 0 var(--cinder-ring-offset) var(--cinder-ring-offset-color),
       0 0 0 calc(var(--cinder-ring-offset) + var(--cinder-ring-width)) var(--cinder-ring-color);
@@ -137,10 +138,6 @@
       color: var(--cinder-text);
       background: color-mix(in oklch, var(--cinder-text), transparent 92%);
     }
-  }
-
-  .cinder-tag-input__remove:focus-visible {
-    outline: none;
   }
 
   .cinder-tag-input__remove:disabled {

--- a/packages/components/src/components/tag-input/tag-input.css
+++ b/packages/components/src/components/tag-input/tag-input.css
@@ -83,7 +83,10 @@
     cursor: default;
   }
 
-  .cinder-tag-input__chip:focus-visible {
+  /* The remove <button> carries the roving tabindex, so the focus ring lives on
+     it. The button styling further down sets layout; this rule supplies the
+     visible focus indicator. */
+  .cinder-tag-input__remove:focus-visible {
     outline: var(--cinder-ring-width) solid transparent;
     box-shadow:
       0 0 0 var(--cinder-ring-offset) var(--cinder-ring-offset-color),
@@ -91,7 +94,7 @@
   }
 
   @media (forced-colors: active) {
-    .cinder-tag-input__chip:focus-visible {
+    .cinder-tag-input__remove:focus-visible {
       outline: var(--cinder-ring-width) solid Highlight;
       outline-offset: 1px;
     }

--- a/packages/components/src/components/tag-input/tag-input.svelte
+++ b/packages/components/src/components/tag-input/tag-input.svelte
@@ -68,6 +68,12 @@
   let uncontrolledTags = $state(initialDefaultTags);
   let focusedChipIndex = $state(-1);
 
+  // Roving tabindex: exactly one remove button is in the tab order at a time.
+  // When a chip is focused it owns the tab stop; otherwise the FIRST chip's
+  // button does, so a Tab-only user can always reach the tag list (the keyboard
+  // counterpart to the pointer/voice affordance the button provides).
+  const rovingChipIndex = $derived(focusedChipIndex === -1 ? 0 : focusedChipIndex);
+
   const isControlled = $derived(value !== undefined);
   const currentTags = $derived(isControlled ? (value ?? []) : uncontrolledTags);
   const resolvedDisabled = $derived(disabled ?? context?.disabled ?? false);
@@ -129,9 +135,12 @@
     return () => form.removeEventListener('reset', onReset);
   });
 
-  function getChipElements(): HTMLLIElement[] {
+  function getChipElements(): HTMLElement[] {
+    // The focusable, keyboard-removable element is the remove <button> — the
+    // <li> chip itself is a non-interactive listitem. Roving tabindex and the
+    // Backspace/Delete/arrow handlers all live on the button.
     return Array.from(
-      rootElement?.querySelectorAll<HTMLLIElement>('.cinder-tag-input__chip') ?? [],
+      rootElement?.querySelectorAll<HTMLElement>('.cinder-tag-input__remove') ?? [],
     );
   }
 
@@ -270,11 +279,6 @@
     focusedChipIndex = index;
   }
 
-  function handleChipClick(index: number): void {
-    focusedChipIndex = index;
-    void focusChip(index);
-  }
-
   function handleChipKeydown(index: number, event: KeyboardEvent): void {
     if (resolvedDisabled || resolvedReadonly) return;
 
@@ -308,42 +312,44 @@
   data-invalid={isInvalid ? '' : undefined}
 >
   <div class="cinder-tag-input__control" data-disabled={resolvedDisabled ? '' : undefined}>
+    <!-- Committed tags are confirmed VALUES with a per-item "remove" command,
+         not selectable options — so this is a plain list (implicit role="list"
+         / "listitem"), NOT a role="listbox". A listbox would force every child
+         to be a role="option", which legally cannot contain the interactive
+         remove <button> (aria-required-children + nested-interactive). As a
+         list, the remove <button> is a fully valid, named, focusable control
+         reachable by keyboard, pointer, voice control, and switch access. The
+         button carries the roving tabindex; arrow keys move between buttons and
+         Backspace/Delete removes the focused tag. -->
     <ul
       id={listboxId}
       class="cinder-tag-input__listbox"
-      role="listbox"
-      aria-multiselectable="true"
       aria-label={ariaLabel}
       aria-labelledby={labelledBy}
     >
       {#each currentTags as tag, index (`${index}:${tag}`)}
-        <li
-          class="cinder-tag-input__chip"
-          role="option"
-          aria-selected="true"
-          aria-label={`${tag}, press Backspace or Delete to remove`}
-          tabindex={focusedChipIndex === index ? 0 : -1}
-          onfocus={() => {
-            handleChipFocus(index);
-          }}
-          onclick={() => {
-            handleChipClick(index);
-          }}
-          onkeydown={(event) => {
-            handleChipKeydown(index, event);
-          }}
-        >
+        <li class="cinder-tag-input__chip">
           <span class="cinder-tag-input__chip-label">{tag}</span>
           {#if !resolvedDisabled && !resolvedReadonly}
-            <span
+            <button
+              type="button"
               class="cinder-tag-input__remove"
-              aria-hidden="true"
+              aria-label={`Remove ${tag}`}
+              tabindex={rovingChipIndex === index ? 0 : -1}
+              onfocus={() => {
+                handleChipFocus(index);
+              }}
               onclick={(event) => {
                 event.stopPropagation();
                 removeTag(index);
                 focusAfterRemove(index);
-              }}>×</span
+              }}
+              onkeydown={(event) => {
+                handleChipKeydown(index, event);
+              }}
             >
+              <span aria-hidden="true">×</span>
+            </button>
           {/if}
         </li>
       {/each}

--- a/packages/components/src/components/tag-input/tag-input.svelte
+++ b/packages/components/src/components/tag-input/tag-input.svelte
@@ -321,6 +321,7 @@
           class="cinder-tag-input__chip"
           role="option"
           aria-selected="true"
+          aria-label={`${tag}, press Backspace or Delete to remove`}
           tabindex={focusedChipIndex === index ? 0 : -1}
           onfocus={() => {
             handleChipFocus(index);
@@ -333,20 +334,17 @@
           }}
         >
           <span class="cinder-tag-input__chip-label">{tag}</span>
-          <button
-            type="button"
-            class="cinder-tag-input__remove"
-            tabindex="-1"
-            aria-label={`Remove ${tag}`}
-            disabled={resolvedDisabled || resolvedReadonly}
-            onclick={(event) => {
-              event.stopPropagation();
-              removeTag(index);
-              focusAfterRemove(index);
-            }}
-          >
-            <span aria-hidden="true">×</span>
-          </button>
+          {#if !resolvedDisabled && !resolvedReadonly}
+            <span
+              class="cinder-tag-input__remove"
+              aria-hidden="true"
+              onclick={(event) => {
+                event.stopPropagation();
+                removeTag(index);
+                focusAfterRemove(index);
+              }}>×</span
+            >
+          {/if}
         </li>
       {/each}
     </ul>

--- a/packages/components/src/components/tag-input/tag-input.svelte
+++ b/packages/components/src/components/tag-input/tag-input.svelte
@@ -58,7 +58,7 @@
 
   const context = getFormFieldContext();
   const resolvedId = $derived(id ?? context?.controlId ?? generatedId);
-  const listboxId = $derived(`${resolvedId}-listbox`);
+  const tagListId = $derived(`${resolvedId}-tags`);
   const inlineErrorId = $derived(`${resolvedId}-inline-error`);
 
   let rootElement = $state<HTMLDivElement | null>(null);
@@ -68,16 +68,25 @@
   let uncontrolledTags = $state(initialDefaultTags);
   let focusedChipIndex = $state(-1);
 
-  // Roving tabindex: exactly one remove button is in the tab order at a time.
-  // When a chip is focused it owns the tab stop; otherwise the FIRST chip's
-  // button does, so a Tab-only user can always reach the tag list (the keyboard
-  // counterpart to the pointer/voice affordance the button provides).
-  const rovingChipIndex = $derived(focusedChipIndex === -1 ? 0 : focusedChipIndex);
-
   const isControlled = $derived(value !== undefined);
   const currentTags = $derived(isControlled ? (value ?? []) : uncontrolledTags);
   const resolvedDisabled = $derived(disabled ?? context?.disabled ?? false);
   const resolvedReadonly = $derived(readonly === true);
+
+  // Roving tabindex: exactly one remove button is in the tab order at a time.
+  // When a chip is focused it owns the tab stop; otherwise the FIRST chip's
+  // button does, so a Tab-only user can always reach the tag list (the keyboard
+  // counterpart to the pointer/voice affordance the button provides).
+  //
+  // Clamp to the live tag count: with no tags there is no tab stop (-1), and a
+  // stale focusedChipIndex (e.g. after a controlled value shrinks) is pulled
+  // back into range — without this, every button could end up tabindex="-1" and
+  // the tag list would become Tab-unreachable.
+  const rovingChipIndex = $derived(
+    currentTags.length === 0
+      ? -1
+      : Math.min(focusedChipIndex === -1 ? 0 : focusedChipIndex, currentTags.length - 1),
+  );
   const resolvedRequired = $derived(context?.required ?? false);
   const resolvedMax = $derived(
     Number.isFinite(max) ? Math.max(0, Math.floor(max as number)) : undefined,
@@ -322,7 +331,7 @@
          button carries the roving tabindex; arrow keys move between buttons and
          Backspace/Delete removes the focused tag. -->
     <ul
-      id={listboxId}
+      id={tagListId}
       class="cinder-tag-input__listbox"
       aria-label={ariaLabel}
       aria-labelledby={labelledBy}

--- a/packages/components/src/components/tag-input/tag-input.test.ts
+++ b/packages/components/src/components/tag-input/tag-input.test.ts
@@ -17,12 +17,22 @@ function getInput(container: HTMLElement): HTMLInputElement {
   return container.querySelector('.cinder-tag-input__input') as HTMLInputElement;
 }
 
+// Committed tags render as a plain list (implicit role="list") of listitems,
+// not a listbox of options — see tag-input.svelte for why. These helpers keep
+// the historical names but target the list / chip elements so existing
+// count/text assertions stay meaningful across the model change.
 function getListbox(container: HTMLElement): HTMLElement {
-  return container.querySelector('[role="listbox"]') as HTMLElement;
+  return container.querySelector('.cinder-tag-input__listbox') as HTMLElement;
 }
 
 function getOptions(container: HTMLElement): HTMLElement[] {
-  return Array.from(container.querySelectorAll('[role="option"]'));
+  return Array.from(container.querySelectorAll('.cinder-tag-input__chip'));
+}
+
+// The focusable, keyboard-removable element per chip is the remove <button>.
+// Keyboard tests assert focus / fire keydown against these, not the listitems.
+function getRemoveButtons(container: HTMLElement): HTMLButtonElement[] {
+  return Array.from(container.querySelectorAll('.cinder-tag-input__remove'));
 }
 
 function renderTagInputInForm(props: Record<string, unknown>) {
@@ -40,7 +50,7 @@ function renderTagInputInForm(props: Record<string, unknown>) {
 }
 
 describe('TagInput rendering', () => {
-  test('renders committed tags as a listbox with the input after it in DOM order', () => {
+  test('renders committed tags as a list with the input after it in DOM order', () => {
     const { container } = render(TagInput, {
       props: { defaultValue: ['Svelte', 'Bun'] },
     });
@@ -50,12 +60,15 @@ describe('TagInput rendering', () => {
     const input = getInput(container);
 
     expect(listbox).not.toBeNull();
+    // The tag list is a plain list, NOT a listbox: it carries no role="listbox"
+    // and its items carry no role="option"/aria-selected. Each tag is a real
+    // listitem with a labeled remove button.
+    expect(listbox.hasAttribute('role')).toBe(false);
+    expect(container.querySelector('[role="listbox"]')).toBeNull();
+    expect(container.querySelector('[role="option"]')).toBeNull();
     expect(getOptions(container)).toHaveLength(2);
     expect(control?.children[0]).toBe(listbox);
     expect(control?.children[1]).toBe(input);
-    expect(
-      getOptions(container).every((option) => option.getAttribute('aria-selected') === 'true'),
-    ).toBe(true);
   });
 
   test('hidden input mirrors committed tags when name is provided', () => {
@@ -69,24 +82,33 @@ describe('TagInput rendering', () => {
     expect(hiddenInputs.map((input) => input.value)).toEqual(['Svelte', 'Bun']);
   });
 
-  test('the remove control is a decorative span with aria-hidden, not a focusable button', () => {
+  test('the remove control is a real labeled button (reachable by pointer, voice, switch)', () => {
     const { container } = render(TagInput, {
       props: { defaultValue: ['Svelte'] },
     });
 
-    const removeSpan = container.querySelector('.cinder-tag-input__remove');
-    expect(removeSpan?.tagName.toLowerCase()).toBe('span');
-    expect(removeSpan?.getAttribute('aria-hidden')).toBe('true');
-    expect(removeSpan?.hasAttribute('tabindex')).toBe(false);
+    const remove = container.querySelector('.cinder-tag-input__remove');
+    // A real <button> with an accessible name — reachable by pointer, voice
+    // control (Dragon, Voice Control), switch access, AND keyboard.
+    expect(remove?.tagName.toLowerCase()).toBe('button');
+    expect(remove?.getAttribute('aria-label')).toBe('Remove Svelte');
+    // The button is a legal interactive child of a non-interactive listitem —
+    // no nested-interactive, no aria-required-children (the list is not a
+    // listbox). The first chip's button carries the roving tabindex.
+    expect(remove?.getAttribute('tabindex')).toBe('0');
+
+    const chip = getOptions(container)[0]!;
+    expect(chip.getAttribute('role')).toBeNull();
+    expect(chip.contains(remove)).toBe(true);
   });
 
-  test('each option carries an aria-label describing the keyboard removal shortcut', () => {
+  test('the first chip button is in the tab order; later chip buttons are roving (-1)', () => {
     const { container } = render(TagInput, {
-      props: { defaultValue: ['Svelte'] },
+      props: { defaultValue: ['Svelte', 'Bun'] },
     });
-
-    const option = getOptions(container)[0]!;
-    expect(option.getAttribute('aria-label')).toBe('Svelte, press Backspace or Delete to remove');
+    const buttons = container.querySelectorAll<HTMLButtonElement>('.cinder-tag-input__remove');
+    expect(buttons[0]?.getAttribute('tabindex')).toBe('0');
+    expect(buttons[1]?.getAttribute('tabindex')).toBe('-1');
   });
 
   test('readonly hides the remove control entirely and keeps the input read-only', () => {
@@ -95,7 +117,7 @@ describe('TagInput rendering', () => {
     });
 
     expect(getInput(container).readOnly).toBe(true);
-    // In readonly mode the remove span is not rendered at all.
+    // In readonly mode the remove button is not rendered at all.
     expect(container.querySelector('.cinder-tag-input__remove')).toBeNull();
   });
 
@@ -236,6 +258,8 @@ describe('TagInput commits tags', () => {
 });
 
 describe('TagInput keyboard removal and navigation', () => {
+  // Keyboard focus lands on the remove <button> of a chip (the focusable,
+  // keyboard-removable element), so these assert against getRemoveButtons().
   test('Backspace on an empty input focuses the last chip, then removes it on a second Backspace', async () => {
     const { container } = render(TagInput, {
       props: { defaultValue: ['Svelte', 'Bun'] },
@@ -243,14 +267,12 @@ describe('TagInput keyboard removal and navigation', () => {
     const input = getInput(container);
 
     await fireEvent.keyDown(input, { key: 'Backspace' });
-    const options = getOptions(container);
-    const lastOption = options[1]!;
-    expect(document.activeElement).toBe(lastOption);
+    const lastButton = getRemoveButtons(container)[1]!;
+    expect(document.activeElement).toBe(lastButton);
 
-    await fireEvent.keyDown(lastOption, { key: 'Backspace' });
+    await fireEvent.keyDown(lastButton, { key: 'Backspace' });
     expect(getOptions(container)).toHaveLength(1);
-    const remainingOption = getOptions(container)[0]!;
-    expect(document.activeElement).toBe(remainingOption);
+    expect(document.activeElement).toBe(getRemoveButtons(container)[0]!);
   });
 
   test('Delete on a focused chip removes it and returns focus to the input when it was the only chip', async () => {
@@ -260,10 +282,10 @@ describe('TagInput keyboard removal and navigation', () => {
     const input = getInput(container);
 
     await fireEvent.keyDown(input, { key: 'Backspace' });
-    const option = getOptions(container)[0]!;
-    expect(document.activeElement).toBe(option);
+    const button = getRemoveButtons(container)[0]!;
+    expect(document.activeElement).toBe(button);
 
-    await fireEvent.keyDown(option, { key: 'Delete' });
+    await fireEvent.keyDown(button, { key: 'Delete' });
     expect(getOptions(container)).toHaveLength(0);
     expect(document.activeElement).toBe(input);
   });
@@ -277,8 +299,7 @@ describe('TagInput keyboard removal and navigation', () => {
     input.setSelectionRange(0, 0);
 
     await fireEvent.keyDown(input, { key: 'ArrowLeft' });
-    const lastOption = getOptions(container)[1]!;
-    expect(document.activeElement).toBe(lastOption);
+    expect(document.activeElement).toBe(getRemoveButtons(container)[1]!);
   });
 
   test('Home, End, and ArrowRight follow the roving focus contract', async () => {
@@ -290,34 +311,31 @@ describe('TagInput keyboard removal and navigation', () => {
     input.setSelectionRange(0, 0);
 
     await fireEvent.keyDown(input, { key: 'ArrowLeft' });
-    let options = getOptions(container);
-    expect(document.activeElement).toBe(options[2]!);
+    let buttons = getRemoveButtons(container);
+    expect(document.activeElement).toBe(buttons[2]!);
 
-    await fireEvent.keyDown(options[2]!, { key: 'Home' });
-    options = getOptions(container);
-    expect(document.activeElement).toBe(options[0]!);
+    await fireEvent.keyDown(buttons[2]!, { key: 'Home' });
+    buttons = getRemoveButtons(container);
+    expect(document.activeElement).toBe(buttons[0]!);
 
-    await fireEvent.keyDown(options[0]!, { key: 'End' });
-    options = getOptions(container);
-    expect(document.activeElement).toBe(options[2]!);
+    await fireEvent.keyDown(buttons[0]!, { key: 'End' });
+    buttons = getRemoveButtons(container);
+    expect(document.activeElement).toBe(buttons[2]!);
 
-    await fireEvent.keyDown(options[2]!, { key: 'ArrowRight' });
+    await fireEvent.keyDown(buttons[2]!, { key: 'ArrowRight' });
     expect(document.activeElement).toBe(input);
   });
 
-  test('clicking the remove span removes the chip and focuses the previous chip', async () => {
+  test('clicking the remove button removes the chip and focuses the previous chip', async () => {
     const { container } = render(TagInput, {
       props: { defaultValue: ['Svelte', 'Bun'] },
     });
 
-    const removeButtons = Array.from(
-      container.querySelectorAll<HTMLElement>('.cinder-tag-input__remove'),
-    );
+    const removeButtons = getRemoveButtons(container);
     await fireEvent.click(removeButtons[1]!);
 
-    const options = getOptions(container);
-    expect(options).toHaveLength(1);
-    expect(document.activeElement).toBe(options[0]!);
+    expect(getOptions(container)).toHaveLength(1);
+    expect(document.activeElement).toBe(getRemoveButtons(container)[0]!);
   });
 
   test('readonly blocks both commits and removals', async () => {
@@ -335,14 +353,10 @@ describe('TagInput keyboard removal and navigation', () => {
     await fireEvent.keyDown(input, { key: 'Backspace' });
     expect(document.activeElement).toBe(input);
 
-    const firstOption = getOptions(container)[0]!;
-    firstOption.focus();
-    await fireEvent.keyDown(firstOption, { key: 'Delete' });
-    expect(document.activeElement).toBe(firstOption);
-    expect(getOptions(container)).toHaveLength(2);
-
-    // In readonly mode the remove control is not rendered at all.
+    // In readonly mode there is no remove control at all — nothing to focus and
+    // no keyboard path to removal, so the tags are immutable.
     expect(container.querySelector('.cinder-tag-input__remove')).toBeNull();
+    expect(getOptions(container)).toHaveLength(2);
   });
 });
 
@@ -361,8 +375,8 @@ describe('TagInput form participation', () => {
     expect(hiddenInputs.map((hiddenInput) => hiddenInput.value)).toEqual(['Svelte', 'Bun']);
 
     await fireEvent.keyDown(input, { key: 'Backspace' });
-    const lastOption = getOptions(container)[1]!;
-    await fireEvent.keyDown(lastOption, { key: 'Delete' });
+    const lastButton = getRemoveButtons(container)[1]!;
+    await fireEvent.keyDown(lastButton, { key: 'Delete' });
 
     hiddenInputs = Array.from(
       container.querySelectorAll<HTMLInputElement>('input[type="hidden"][name="tags"]'),

--- a/packages/components/src/components/tag-input/tag-input.test.ts
+++ b/packages/components/src/components/tag-input/tag-input.test.ts
@@ -119,6 +119,31 @@ describe('TagInput rendering', () => {
     expect(getRemoveButtons(container)).toHaveLength(0);
   });
 
+  test('the tag list stays Tab-reachable after a controlled value shrinks below the focused index', async () => {
+    // End-to-end guard for the stale-index scenario: focus is on a high chip
+    // index, then the controlled value shrinks below it. The roving tab stop
+    // must land on a surviving button (not vanish to all -1, which would make
+    // the list Tab-unreachable). Two layers cooperate to guarantee this — the
+    // rovingChipIndex `Math.min` clamp (synchronous) and the focusedChipIndex
+    // reset $effect (after the DOM settles). This test asserts the user-facing
+    // result; if BOTH guards regressed, it fails.
+    const { container, rerender } = render(TagInput, { props: { value: ['A', 'B', 'C'] } });
+
+    // Move the roving focus to the last chip's remove button (index 2).
+    await fireEvent.focus(getRemoveButtons(container)[2]!);
+    await tick();
+    expect(getRemoveButtons(container)[2]!.getAttribute('tabindex')).toBe('0');
+
+    // Controlled shrink to a single tag — index 2 no longer exists.
+    await rerender({ value: ['A'] });
+    await tick();
+
+    const buttons = getRemoveButtons(container);
+    expect(buttons).toHaveLength(1);
+    // The surviving button must own the tab stop — the list is still reachable.
+    expect(buttons[0]!.getAttribute('tabindex')).toBe('0');
+  });
+
   test('readonly hides the remove control entirely and keeps the input read-only', () => {
     const { container } = render(TagInput, {
       props: { readonly: true, defaultValue: ['Svelte'] },

--- a/packages/components/src/components/tag-input/tag-input.test.ts
+++ b/packages/components/src/components/tag-input/tag-input.test.ts
@@ -69,25 +69,43 @@ describe('TagInput rendering', () => {
     expect(hiddenInputs.map((input) => input.value)).toEqual(['Svelte', 'Bun']);
   });
 
-  test('remove buttons expose the required aria-label', () => {
+  test('the remove control is a decorative span with aria-hidden, not a focusable button', () => {
     const { container } = render(TagInput, {
       props: { defaultValue: ['Svelte'] },
     });
 
-    const removeButton = container.querySelector('.cinder-tag-input__remove');
-    expect(removeButton?.getAttribute('aria-label')).toBe('Remove Svelte');
-    expect(removeButton?.getAttribute('tabindex')).toBe('-1');
+    const removeSpan = container.querySelector('.cinder-tag-input__remove');
+    expect(removeSpan?.tagName.toLowerCase()).toBe('span');
+    expect(removeSpan?.getAttribute('aria-hidden')).toBe('true');
+    expect(removeSpan?.hasAttribute('tabindex')).toBe(false);
   });
 
-  test('readonly forwards to the input and disables remove buttons', () => {
+  test('each option carries an aria-label describing the keyboard removal shortcut', () => {
+    const { container } = render(TagInput, {
+      props: { defaultValue: ['Svelte'] },
+    });
+
+    const option = getOptions(container)[0]!;
+    expect(option.getAttribute('aria-label')).toBe('Svelte, press Backspace or Delete to remove');
+  });
+
+  test('readonly hides the remove control entirely and keeps the input read-only', () => {
     const { container } = render(TagInput, {
       props: { readonly: true, defaultValue: ['Svelte'] },
     });
 
     expect(getInput(container).readOnly).toBe(true);
-    expect(container.querySelector<HTMLButtonElement>('.cinder-tag-input__remove')?.disabled).toBe(
-      true,
-    );
+    // In readonly mode the remove span is not rendered at all.
+    expect(container.querySelector('.cinder-tag-input__remove')).toBeNull();
+  });
+
+  test('disabled hides the remove control entirely and keeps the input disabled', () => {
+    const { container } = render(TagInput, {
+      props: { disabled: true, defaultValue: ['Svelte'] },
+    });
+
+    expect(getInput(container).disabled).toBe(true);
+    expect(container.querySelector('.cinder-tag-input__remove')).toBeNull();
   });
 
   test('standalone aria-label applies to both the input and the listbox', () => {
@@ -287,13 +305,13 @@ describe('TagInput keyboard removal and navigation', () => {
     expect(document.activeElement).toBe(input);
   });
 
-  test('clicking the remove button removes the chip and focuses the previous chip', async () => {
+  test('clicking the remove span removes the chip and focuses the previous chip', async () => {
     const { container } = render(TagInput, {
       props: { defaultValue: ['Svelte', 'Bun'] },
     });
 
     const removeButtons = Array.from(
-      container.querySelectorAll<HTMLButtonElement>('.cinder-tag-input__remove'),
+      container.querySelectorAll<HTMLElement>('.cinder-tag-input__remove'),
     );
     await fireEvent.click(removeButtons[1]!);
 
@@ -323,8 +341,8 @@ describe('TagInput keyboard removal and navigation', () => {
     expect(document.activeElement).toBe(firstOption);
     expect(getOptions(container)).toHaveLength(2);
 
-    await fireEvent.click(container.querySelector('.cinder-tag-input__remove')!);
-    expect(getOptions(container)).toHaveLength(2);
+    // In readonly mode the remove control is not rendered at all.
+    expect(container.querySelector('.cinder-tag-input__remove')).toBeNull();
   });
 });
 

--- a/packages/components/src/components/tag-input/tag-input.test.ts
+++ b/packages/components/src/components/tag-input/tag-input.test.ts
@@ -111,6 +111,14 @@ describe('TagInput rendering', () => {
     expect(buttons[1]?.getAttribute('tabindex')).toBe('-1');
   });
 
+  test('an empty tag input renders no remove buttons (roving index clamps to -1)', () => {
+    const { container } = render(TagInput, { props: {} });
+    // No tags → no buttons → no spurious tab stop. Guards the rovingChipIndex
+    // clamp: a default of 0 with zero tags would be a dangling tab-stop index.
+    expect(getOptions(container)).toHaveLength(0);
+    expect(getRemoveButtons(container)).toHaveLength(0);
+  });
+
   test('readonly hides the remove control entirely and keeps the input read-only', () => {
     const { container } = render(TagInput, {
       props: { readonly: true, defaultValue: ['Svelte'] },
@@ -250,8 +258,11 @@ describe('TagInput commits tags', () => {
     const input = getInput(container);
 
     await fireEvent.keyDown(input, { key: 'Backspace' });
-    const option = getOptions(container)[0]!;
-    await fireEvent.keyDown(option, { key: 'Delete' });
+    // Fire against the remove BUTTON — it owns the chip keydown handler in the
+    // list model. Firing at the <li> would miss the handler entirely and pass
+    // for the wrong reason (a false negative).
+    const removeButton = getRemoveButtons(container)[0]!;
+    await fireEvent.keyDown(removeButton, { key: 'Delete' });
 
     expect(onkeydown).toHaveBeenCalledTimes(1);
   });

--- a/packages/playground/src/examples/copy-button/basic.example.svelte
+++ b/packages/playground/src/examples/copy-button/basic.example.svelte
@@ -9,7 +9,8 @@
 </script>
 
 <div class="example-preview-row" style="align-items: center;">
-  <code style="padding: 0.25rem 0.5rem; background: #f4f4f4; border-radius: 4px;"
+  <code
+    style="padding: 0.25rem 0.5rem; background-color: var(--cinder-surface-inset); color: var(--cinder-text); border-radius: 4px;"
     >npx cinder install</code
   >
   <CopyButton value="npx cinder install" label="Copy install command" />

--- a/packages/playground/src/examples/progress/basic.example.svelte
+++ b/packages/playground/src/examples/progress/basic.example.svelte
@@ -8,7 +8,7 @@
 </script>
 
 <div style="display: flex; flex-direction: column; gap: 0.5rem;">
-  <Progress value={50} />
-  <Progress value={75} />
-  <Progress value={100} />
+  <Progress value={50} ariaLabel="File upload: 50% complete" />
+  <Progress value={75} ariaLabel="File upload: 75% complete" />
+  <Progress value={100} ariaLabel="File upload: 100% complete" />
 </div>

--- a/packages/playground/src/examples/progress/indeterminate.example.svelte
+++ b/packages/playground/src/examples/progress/indeterminate.example.svelte
@@ -9,6 +9,6 @@
 </script>
 
 <div style="display: flex; flex-direction: column; gap: 0.75rem;">
-  <Progress />
-  <Progress variant="ring" size="lg" />
+  <Progress ariaLabel="Loading" />
+  <Progress variant="ring" size="lg" ariaLabel="Loading" />
 </div>

--- a/packages/playground/src/examples/progress/with-label.example.svelte
+++ b/packages/playground/src/examples/progress/with-label.example.svelte
@@ -8,6 +8,10 @@
 </script>
 
 <div style="display: flex; flex-direction: column; gap: 0.4rem;">
-  <span>Uploading photo (3 of 5)</span>
-  <Progress value={60} label="Uploading photo, 60 percent complete" />
+  <span id="upload-progress-label">Uploading photo (3 of 5)</span>
+  <Progress
+    value={60}
+    label="Uploading photo, 60 percent complete"
+    ariaLabelledby="upload-progress-label"
+  />
 </div>

--- a/packages/playground/src/examples/table/empty.example.svelte
+++ b/packages/playground/src/examples/table/empty.example.svelte
@@ -18,7 +18,7 @@
   <Table.Body>
     <Table.Row>
       <Table.Cell>
-        <span style="color: #888; font-style: italic;"
+        <span style="color: var(--cinder-text-muted); font-style: italic;"
           >No contributors yet — invite your team to get started.</span
         >
       </Table.Cell>

--- a/packages/testing/src/helpers/axe-gate.test.ts
+++ b/packages/testing/src/helpers/axe-gate.test.ts
@@ -255,6 +255,28 @@ describe('evaluateAxeGate', () => {
     }
   });
 
+  it('surfaces only the un-allowed violation when a bucket mixes allowed and un-allowed rules', () => {
+    // Exercises the `unallowed` FILTER: the bucket contains both a tolerated
+    // rule (`color-contrast`) and a new regression (`label`). The gate must
+    // fail, but surface ONLY the un-allowed `label` — the tolerated contrast
+    // violation must not appear in the failure list or message. A single-
+    // violation bucket cannot catch a bug where the filter returns everything,
+    // since there `unallowed === violations`; this two-violation case can.
+    const buckets = makeBuckets({
+      serious: [makeViolation('color-contrast', 'serious'), makeViolation('label', 'serious')],
+    });
+    const allowList: AxeAllowEntry[] = [
+      { slug: 'button', ruleIds: ['color-contrast'], reason: 'contrast only, tracked in #42' },
+    ];
+    const decision = evaluateAxeGate(KEY, buckets, allowList);
+    expect(decision.status).toBe('fail');
+    if (decision.status === 'fail') {
+      expect(decision.violations.map((violation) => violation.id)).toEqual(['label']);
+      expect(decision.message).toContain('label');
+      expect(decision.message).not.toContain('color-contrast');
+    }
+  });
+
   it('does not treat moderate/minor violations as blocking', () => {
     const buckets = makeBuckets({
       moderate: [makeViolation('region', 'moderate')],

--- a/packages/testing/src/helpers/axe-gate.test.ts
+++ b/packages/testing/src/helpers/axe-gate.test.ts
@@ -55,24 +55,14 @@ describe('BLOCKING_IMPACTS', () => {
 });
 
 describe('AXE_ALLOW_LIST', () => {
-  it('documents every current pre-existing blocking violation captured by the sweep', () => {
-    // The baseline captured on 2026-05-29 by running the full broad sweep
-    // (134 components × 2 themes × 3 viewports) against the playground. If a
-    // violation is fixed, its entry is removed here; if a new one appears, the
-    // gate fails until it is fixed or added with a reason — that is the point.
-    const slugs = AXE_ALLOW_LIST.map((entry) => entry.slug).toSorted();
-    expect(slugs).toEqual([
-      'area-chart',
-      'avatar-group',
-      'bar-chart',
-      'chip',
-      'code-block',
-      'copy-button',
-      'line-chart',
-      'progress',
-      'table',
-      'tag-input',
-    ]);
+  it('is empty — every captured serious violation has been fixed at the source', () => {
+    // The 2026-05-29 baseline sweep surfaced serious violations on charts,
+    // avatar-group, progress, tag-input, code-block, copy-button, table, and
+    // chip. All were fixed at the source rather than tolerated, so the gate is
+    // now fully enforced: any new critical/serious violation fails CI. When a
+    // genuine exception is needed, add an entry with `ruleIds` + a `reason` —
+    // the invariants below keep such entries auditable.
+    expect(AXE_ALLOW_LIST).toHaveLength(0);
   });
 
   it('gives every entry a non-empty, auditable reason', () => {
@@ -108,20 +98,14 @@ describe('AXE_ALLOW_LIST', () => {
     expect(new Set(scopes).size).toBe(scopes.length);
   });
 
-  it('scopes the theme-dependent color-contrast exceptions to their failing theme', () => {
-    // color-contrast depends on the active palette, so these are narrowed to a
-    // single theme rather than blanket-allowing the component.
-    const table = AXE_ALLOW_LIST.find((entry) => entry.slug === 'table');
-    const chip = AXE_ALLOW_LIST.find((entry) => entry.slug === 'chip');
-    const copyButton = AXE_ALLOW_LIST.find((entry) => entry.slug === 'copy-button');
-    expect(table?.theme).toBe('light');
-    expect(chip?.theme).toBe('light');
-    expect(copyButton?.theme).toBe('dark');
-  });
-
-  it('downgrades a real allow-listed violation but still fails the same slug in an unscoped theme', () => {
-    // `table` is allow-listed only in the light theme; a serious violation in
-    // the dark theme must still fail (this is what keeps the narrowing honest).
+  it('downgrades a theme-scoped exception but still fails the same slug in an unscoped theme', () => {
+    // A theme-narrowed entry tolerates the violation only in its theme; a
+    // serious violation in the other theme must still fail. This keeps the
+    // narrowing honest. Exercised against a synthetic list so the test does not
+    // couple to the (currently empty) production allow-list.
+    const allowList: AxeAllowEntry[] = [
+      { slug: 'table', theme: 'light', ruleIds: ['color-contrast'], reason: 'color-contrast #42' },
+    ];
     const buckets = makeBuckets({ serious: [makeViolation('color-contrast', 'serious')] });
     const lightKey: ArtifactKey = {
       slug: 'table',
@@ -130,31 +114,8 @@ describe('AXE_ALLOW_LIST', () => {
       fixture: 'default',
     };
     const darkKey: ArtifactKey = { ...lightKey, theme: 'dark' };
-    expect(evaluateAxeGate(lightKey, buckets, AXE_ALLOW_LIST).status).toBe('allowed');
-    expect(evaluateAxeGate(darkKey, buckets, AXE_ALLOW_LIST).status).toBe('fail');
-  });
-
-  it('still fails an allow-listed slug when a NEW rule id (outside ruleIds) regresses', () => {
-    // `table` is allow-listed only for `color-contrast`. A brand-new serious
-    // violation with a different rule id must still fail the gate rather than
-    // being silently masked by the contrast exception.
-    const buckets = makeBuckets({
-      serious: [makeViolation('color-contrast', 'serious'), makeViolation('label', 'serious')],
-    });
-    const lightKey: ArtifactKey = {
-      slug: 'table',
-      theme: 'light',
-      viewport: 'desktop',
-      fixture: 'default',
-    };
-    const decision = evaluateAxeGate(lightKey, buckets, AXE_ALLOW_LIST);
-    expect(decision.status).toBe('fail');
-    if (decision.status === 'fail') {
-      // Only the un-allowed violation is surfaced, not the tolerated one.
-      expect(decision.violations.map((violation) => violation.id)).toEqual(['label']);
-      expect(decision.message).toContain('label');
-      expect(decision.message).not.toContain('color-contrast');
-    }
+    expect(evaluateAxeGate(lightKey, buckets, allowList).status).toBe('allowed');
+    expect(evaluateAxeGate(darkKey, buckets, allowList).status).toBe('fail');
   });
 });
 

--- a/packages/testing/src/helpers/axe-gate.ts
+++ b/packages/testing/src/helpers/axe-gate.ts
@@ -76,94 +76,16 @@ export type AxeAllowEntry = {
  * the gate globally. Each entry should be removed as the underlying violation
  * is fixed.
  *
- * The baseline below was captured by running the full broad sweep
- * (`bun run scripts/start-server.ts` → 134 components × 2 themes × 3 viewports)
- * against the playground on 2026-05-29. Every entry records the exact axe rule
- * ids it covers in `ruleIds`; only those rules are downgraded, so a *new*
- * critical/serious regression on an allow-listed component still fails the gate.
- * Color-contrast findings are theme-scoped because contrast depends on the
- * active palette; structural findings (nested-interactive, svg-img-alt, etc.)
- * reproduce across every theme/viewport, so those entries match by slug alone.
- *
- * An empty list would mean the gate is fully enforced for every component.
+ * The list is currently **empty**: every `serious` violation captured by the
+ * 2026-05-29 baseline sweep has since been fixed at the source (chart SVG
+ * roles + accessible names, avatar-group role, progressbar names, tag-input
+ * listbox restructure, code-block dark-theme contrast + scroll focus, and the
+ * copy-button/table/chip color-contrast fixes). The gate is therefore fully
+ * enforced for every component: any `critical`/`serious` violation now fails CI.
+ * When a new entry is genuinely needed, record the exact axe rule ids it covers
+ * in `ruleIds` (only those rules are downgraded) plus a tracking `reason`.
  */
-export const AXE_ALLOW_LIST: readonly AxeAllowEntry[] = [
-  {
-    slug: 'area-chart',
-    ruleIds: ['nested-interactive', 'svg-img-alt'],
-    reason:
-      'Pre-existing serious violations: nested-interactive and svg-img-alt on the SVG chart. ' +
-      'Charts render interactive data points inside the <svg> without a non-nested control and ' +
-      'without alt text for the img-role SVG. Tracking: chart-a11y follow-up.',
-  },
-  {
-    slug: 'bar-chart',
-    ruleIds: ['nested-interactive', 'svg-img-alt'],
-    reason:
-      'Pre-existing serious violations: nested-interactive and svg-img-alt on the SVG chart. ' +
-      'Same root cause as area-chart (shared chart primitives). Tracking: chart-a11y follow-up.',
-  },
-  {
-    slug: 'line-chart',
-    ruleIds: ['nested-interactive', 'svg-img-alt'],
-    reason:
-      'Pre-existing serious violations: nested-interactive and svg-img-alt on the SVG chart. ' +
-      'Same root cause as area-chart (shared chart primitives). Tracking: chart-a11y follow-up.',
-  },
-  {
-    slug: 'avatar-group',
-    ruleIds: ['aria-prohibited-attr'],
-    reason:
-      'Pre-existing serious violation: aria-prohibited-attr — an aria-* attribute is set on an ' +
-      'element whose role does not permit it. Tracking: avatar-group-a11y follow-up.',
-  },
-  {
-    slug: 'progress',
-    ruleIds: ['aria-progressbar-name'],
-    reason:
-      'Pre-existing serious violation: aria-progressbar-name — the progressbar node lacks an ' +
-      'accessible name. Tracking: progress-a11y follow-up.',
-  },
-  {
-    slug: 'tag-input',
-    ruleIds: ['nested-interactive'],
-    reason:
-      'Pre-existing serious violation: nested-interactive — the removable-tag control is nested ' +
-      'inside another interactive element. Tracking: tag-input-a11y follow-up.',
-  },
-  {
-    slug: 'code-block',
-    ruleIds: ['color-contrast', 'scrollable-region-focusable'],
-    reason:
-      'Pre-existing serious violations: color-contrast (all viewports) and ' +
-      'scrollable-region-focusable (the scrollable code region lacks keyboard access, surfaces in ' +
-      'the mobile viewport). Tracking: code-block-a11y follow-up.',
-  },
-  {
-    slug: 'table',
-    theme: 'light',
-    ruleIds: ['color-contrast'],
-    reason:
-      'Pre-existing serious violation: color-contrast in the light theme (all viewports). ' +
-      'Tracking: table-light-contrast follow-up.',
-  },
-  {
-    slug: 'chip',
-    theme: 'light',
-    ruleIds: ['color-contrast'],
-    reason:
-      'Pre-existing serious violation: color-contrast in the light theme (all viewports). ' +
-      'Tracking: chip-light-contrast follow-up.',
-  },
-  {
-    slug: 'copy-button',
-    theme: 'dark',
-    ruleIds: ['color-contrast'],
-    reason:
-      'Pre-existing serious violation: color-contrast in the dark theme (all viewports). ' +
-      'Tracking: copy-button-dark-contrast follow-up.',
-  },
-];
+export const AXE_ALLOW_LIST: readonly AxeAllowEntry[] = [];
 
 /**
  * Returns the blocking (`critical` + `serious`) violations from a bucketed axe


### PR DESCRIPTION
## Summary

Fixes every serious accessibility violation captured by the broad axe sweep **at the source** and empties `AXE_ALLOW_LIST` so the gate is fully enforced — any new critical/serious violation now fails CI.

### Structural fixes
- **charts (area/bar/line)**: drop `role="img"` — a leaf role that prohibits the charts' keyboard-navigable data-point buttons (fired `nested-interactive` + `svg-img-alt` simultaneously). Name the SVG via `<title>` + `aria-labelledby` from the existing `label` prop.
- **avatar-group**: `role="img"` on the focus-activated tooltip trigger. It only surfaces a name tooltip on focus/hover (no activation), so `role="button"` would be a false affordance (WCAG 4.1.2). `img` is the honest focusable-named-image semantic; `aria-label` is valid on it.
- **progress**: forward `ariaLabel`/`ariaLabelledby` to `role="progressbar"` (resolves `aria-progressbar-name`).
- **tag-input**: drop the `listbox`/`option` model entirely. Committed tags are values with a per-item remove command, not selectable options — a `role="listbox"` legally cannot host the interactive remove button (`aria-required-children` + `nested-interactive`). As a plain list (implicit `role=list`/`listitem`), each tag's remove `<button>` is a real, named control reachable by keyboard (roving tabindex + Backspace/Delete), pointer, voice control, and switch access.
- **code-block**: a single keyboard-reachable scroll region (`tabindex="0"`, no landmark pollution); consume Shiki's `--shiki-dark` dual-theme var in dark mode (`!important` to beat Shiki's inline `color`); a white-ish light surface so github-light red clears 4.5:1; and size the inner `<pre>` to `max-content`/`min-width:100%` so long lines stay reachable via the outer scroll region.

### Color/token fixes
- **copy-button + table** examples: theme tokens instead of hardcoded `#f4f4f4`/`#888`.
- **chip**: express the disabled visual with muted color tokens instead of a root `opacity:0.5` that composited the label below AA.

## Review committee
Pre-reviewed by: **svelte-expert, ux-designer, testing-expert, frontend-architect, simplicity-engineer**
- **Codex** (gpt-5.4) — 4 rounds
- **codex-advisor** consulted to adjudicate the tag-input ARIA model and the avatar-group role
- 4 rounds of review to full consensus; all must-fix items addressed
- Two contested CSS/ARIA decisions were resolved by **measuring in the browser** rather than picking a reviewer's side (the `overflow-x: clip` clipping bug and the avatar role)

## Test plan
- 277 component unit tests + 20 axe-gate tests green (`bun run test`).
- Clean browser axe sweep over the 9 affected components × 2 themes × 3 viewports: **0 critical / 0 serious violations** (64 result files).
- `AXE_ALLOW_LIST` is now **empty**; the gate fails any new critical/serious violation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches shared chart, form, and syntax-highlight patterns plus CI gating; regressions would surface as axe or keyboard-navigation failures rather than silent data bugs.
> 
> **Overview**
> Clears the serious accessibility baseline by fixing components in place and **emptying `AXE_ALLOW_LIST`**, so any new critical/serious axe finding fails CI.
> 
> **Charts** (area, bar, line): remove `role="img"` from the SVG so keyboard data-point controls are no longer nested inside a leaf image role; name the graphic with `<title>` + `aria-labelledby` from `label` when data is shown.
> 
> **Avatar group**: named tooltip triggers use `role="img"` with `aria-label` (and `alt=""` on the inner avatar) instead of a focusable unnamed span.
> 
> **Progress**: new `ariaLabel` / `ariaLabelledby` props wire through to `role="progressbar"`; examples and schema updated.
> 
> **Tag input**: committed tags move from `listbox`/`option` to a plain list with per-tag **remove buttons** (roving tabindex, focus on buttons); readonly/disabled omit remove controls.
> 
> **Code block**: one keyboard-scroll region (`tabindex="0"`), Shiki dark token override via `--shiki-dark`, lighter raised surface in light mode, and layout so long lines scroll in the wrapper.
> 
> **Chip**: disabled styling uses muted tokens instead of root `opacity` (contrast guard tests).
> 
> **Examples**: copy-button, table, and progress playground/docs examples use theme tokens and accessible progress names.
> 
> Broad unit and axe-gate tests lock in the new behavior; allow-list tests now expect zero entries.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fda6311702fe9e70641c92508ae921cb95a44f2b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->