### PR TITLE
Style playground shell chrome

### DIFF
--- a/packages/components/components.json
+++ b/packages/components/components.json
@@ -721,10 +721,11 @@
       ],
       "related": ["color-picker", "color-swatch-picker", "input", "form-field"],
       "hasConstraints": false,
-      "hasExamples": false,
+      "hasExamples": true,
       "artifacts": {
         "schema": "cinder/color-field/schema",
-        "variables": "cinder/color-field/variables"
+        "variables": "cinder/color-field/variables",
+        "examples": "cinder/color-field/examples"
       }
     },
     {
@@ -1075,10 +1076,11 @@
       ],
       "related": ["data-list", "table"],
       "hasConstraints": false,
-      "hasExamples": false,
+      "hasExamples": true,
       "artifacts": {
         "schema": "cinder/description-list/schema",
-        "variables": "cinder/description-list/variables"
+        "variables": "cinder/description-list/variables",
+        "examples": "cinder/description-list/examples"
       }
     },
     {
@@ -1938,10 +1940,11 @@
       ],
       "related": ["chat", "callout"],
       "hasConstraints": false,
-      "hasExamples": false,
+      "hasExamples": true,
       "artifacts": {
         "schema": "cinder/message/schema",
-        "variables": "cinder/message/variables"
+        "variables": "cinder/message/variables",
+        "examples": "cinder/message/examples"
       }
     },
     {
@@ -2910,10 +2913,11 @@
       ],
       "related": ["badge"],
       "hasConstraints": false,
-      "hasExamples": false,
+      "hasExamples": true,
       "artifacts": {
         "schema": "cinder/status-dot/schema",
-        "variables": "cinder/status-dot/variables"
+        "variables": "cinder/status-dot/variables",
+        "examples": "cinder/status-dot/examples"
       }
     },
     {

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -695,6 +695,10 @@
     "./color-field/styles": {
       "default": "./dist/components/color-field/color-field.css"
     },
+    "./color-field/examples": {
+      "import": "./src/components/color-field/color-field.examples.json",
+      "default": "./src/components/color-field/color-field.examples.json"
+    },
     "./color-picker": {
       "types": "./dist/components/color-picker/index.d.ts",
       "svelte": "./src/components/color-picker/index.ts",
@@ -1018,6 +1022,10 @@
     },
     "./description-list/styles": {
       "default": "./dist/components/description-list/description-list.css"
+    },
+    "./description-list/examples": {
+      "import": "./src/components/description-list/description-list.examples.json",
+      "default": "./src/components/description-list/description-list.examples.json"
     },
     "./diff-statistics": {
       "types": "./dist/components/diff-statistics/index.d.ts",
@@ -1787,6 +1795,10 @@
     },
     "./message/styles": {
       "default": "./dist/components/message/message.css"
+    },
+    "./message/examples": {
+      "import": "./src/components/message/message.examples.json",
+      "default": "./src/components/message/message.examples.json"
     },
     "./modal": {
       "types": "./dist/components/modal/index.d.ts",
@@ -2688,6 +2700,10 @@
     },
     "./status-dot/styles": {
       "default": "./dist/components/status-dot/status-dot.css"
+    },
+    "./status-dot/examples": {
+      "import": "./src/components/status-dot/status-dot.examples.json",
+      "default": "./src/components/status-dot/status-dot.examples.json"
     },
     "./steps": {
       "types": "./dist/components/steps/index.d.ts",

--- a/packages/components/src/components/color-field/color-field.examples.json
+++ b/packages/components/src/components/color-field/color-field.examples.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "../../schemas/examples.schema.json",
+  "component": "color-field",
+  "import": "cinder/color-field",
+  "examples": [
+    {
+      "id": "basic",
+      "title": "Basic color field",
+      "description": "An uncontrolled color field that accepts hex, rgb(), and hsl() strings and normalizes them to hex on commit.",
+      "code": "<script lang=\"ts\">\n  import { ColorField } from 'cinder/color-field';\n\n  let committed = $state('');\n</script>\n\n<div style=\"display: flex; flex-direction: column; gap: 0.5rem; max-width: 20rem;\">\n  <label for=\"color-field-basic\" style=\"font-size: 0.875rem; font-weight: 500;\">\n    Brand color\n  </label>\n  <ColorField\n    id=\"color-field-basic\"\n    defaultValue=\"#3b82f6\"\n    onchange={(value) => {\n      committed = value;\n    }}\n  />\n  {#if committed}\n    <p style=\"font-size: 0.75rem; color: var(--cinder-text-muted);\">Committed: {committed}</p>\n  {/if}\n</div>\n"
+    },
+    {
+      "id": "states",
+      "title": "Disabled and readonly states",
+      "description": "A disabled color field rejects all interaction; a readonly field displays the value but blocks editing.",
+      "code": "<script lang=\"ts\">\n  import { ColorField } from 'cinder/color-field';\n</script>\n\n<div style=\"display: flex; flex-direction: column; gap: 1rem; max-width: 20rem;\">\n  <div style=\"display: flex; flex-direction: column; gap: 0.5rem;\">\n    <label for=\"color-field-disabled\" style=\"font-size: 0.875rem; font-weight: 500;\">\n      Disabled\n    </label>\n    <ColorField id=\"color-field-disabled\" value=\"#ef4444\" disabled />\n  </div>\n\n  <div style=\"display: flex; flex-direction: column; gap: 0.5rem;\">\n    <label for=\"color-field-readonly\" style=\"font-size: 0.875rem; font-weight: 500;\">\n      Read-only\n    </label>\n    <ColorField id=\"color-field-readonly\" value=\"#22c55e\" readonly />\n  </div>\n</div>\n"
+    }
+  ]
+}

--- a/packages/components/src/components/description-list/description-list.examples.json
+++ b/packages/components/src/components/description-list/description-list.examples.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "../../schemas/examples.schema.json",
+  "component": "description-list",
+  "import": "cinder/description-list",
+  "examples": [
+    {
+      "id": "basic",
+      "title": "Description list",
+      "description": "Key–value metadata pairs in the default stacked layout.",
+      "code": "<script lang=\"ts\">\n  import { DescriptionList } from 'cinder/description-list';\n  import type { DescriptionListItem } from 'cinder/description-list';\n\n  const items: DescriptionListItem[] = [\n    { term: 'Component', definition: 'DescriptionList' },\n    { term: 'Status', definition: 'Stable' },\n    { term: 'Version', definition: '1.0.0' },\n    { term: 'License', definition: 'MIT' },\n    { term: 'Maintainer', definition: 'Cinder team' },\n  ];\n</script>\n\n<DescriptionList {items} />\n"
+    },
+    {
+      "id": "variants",
+      "title": "Description list variants",
+      "description": "Striped and two-column layout variants.",
+      "code": "<script lang=\"ts\">\n  import { DescriptionList } from 'cinder/description-list';\n  import type { DescriptionListItem } from 'cinder/description-list';\n\n  const items: DescriptionListItem[] = [\n    { term: 'Repository', definition: 'cinder' },\n    { term: 'Language', definition: 'TypeScript' },\n    { term: 'Framework', definition: 'Svelte 5' },\n    { term: 'Runtime', definition: 'Bun' },\n  ];\n</script>\n\n<div class=\"example-preview-column\">\n  <DescriptionList {items} variant=\"striped\" />\n  <DescriptionList {items} variant=\"two-column\" />\n</div>\n"
+    }
+  ]
+}

--- a/packages/components/src/components/message/message.examples.json
+++ b/packages/components/src/components/message/message.examples.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "../../schemas/examples.schema.json",
+  "component": "message",
+  "import": "cinder/message",
+  "examples": [
+    {
+      "id": "roles",
+      "title": "Message roles",
+      "description": "User, assistant, and system role variants with a timestamp.",
+      "code": "<script lang=\"ts\">\n  import { Message } from 'cinder/message';\n</script>\n\n<div class=\"example-preview-column\">\n  <Message role=\"user\" name=\"Ada Lovelace\" time=\"9:41 AM\">\n    Can you explain how transformers work?\n  </Message>\n  <Message role=\"assistant\" time=\"9:41 AM\">\n    Transformers use self-attention to relate every token in a sequence to every other token,\n    letting the model weigh context regardless of distance.\n  </Message>\n  <Message role=\"system\">\n    You are a helpful assistant that explains technical concepts clearly and concisely.\n  </Message>\n</div>\n"
+    }
+  ]
+}

--- a/packages/components/src/components/status-dot/status-dot.examples.json
+++ b/packages/components/src/components/status-dot/status-dot.examples.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "../../schemas/examples.schema.json",
+  "component": "status-dot",
+  "import": "cinder/status-dot",
+  "examples": [
+    {
+      "id": "label-and-size",
+      "title": "Status dot label and size",
+      "description": "Visible label toggle and sm vs md sizes.",
+      "code": "<script lang=\"ts\">\n  import { StatusDot } from 'cinder/status-dot';\n</script>\n\n<div class=\"example-preview-column\">\n  <div class=\"example-preview-row\">\n    <StatusDot status=\"online\" label=\"Online\" showLabel={true} />\n    <StatusDot status=\"offline\" label=\"Offline\" showLabel={true} />\n    <StatusDot status=\"pending\" label=\"Pending\" showLabel={true} />\n  </div>\n  <div class=\"example-preview-row\" style=\"align-items: center;\">\n    <StatusDot status=\"online\" label=\"Small\" size=\"sm\" showLabel={true} />\n    <StatusDot status=\"online\" label=\"Medium\" size=\"md\" showLabel={true} />\n  </div>\n</div>\n"
+    },
+    {
+      "id": "statuses",
+      "title": "Status dot statuses",
+      "description": "All six semantic status values.",
+      "code": "<script lang=\"ts\">\n  import { StatusDot } from 'cinder/status-dot';\n</script>\n\n<div class=\"example-preview-row\">\n  <StatusDot status=\"online\" label=\"Online\" />\n  <StatusDot status=\"offline\" label=\"Offline\" />\n  <StatusDot status=\"warning\" label=\"Warning\" />\n  <StatusDot status=\"error\" label=\"Error\" />\n  <StatusDot status=\"pending\" label=\"Pending\" />\n  <StatusDot status=\"neutral\" label=\"Neutral\" />\n</div>\n"
+    }
+  ]
+}

--- a/packages/components/src/styles/shell.css
+++ b/packages/components/src/styles/shell.css
@@ -1,0 +1,15 @@
+/*
+ * Playground shell stylesheet.
+ *
+ * The playground shell imports Cinder primitives directly for its own chrome.
+ * Keep that chrome styled without loading every component stylesheet into the
+ * outer document.
+ */
+
+@import './index.css';
+@import '../components/button/button.css';
+@import '../components/input/input.css';
+@import '../components/number-input/number-input.css';
+@import '../components/segmented-control/segmented-control.css';
+@import '../components/side-navigation/side-navigation.css';
+@import '../components/toolbar/toolbar.css';

--- a/packages/playground/src/playground-server.test.ts
+++ b/packages/playground/src/playground-server.test.ts
@@ -53,6 +53,55 @@ function req(path: string, options?: RequestInit): Request {
   return new Request(`http://localhost:${PORT}${path}`, options);
 }
 
+function cssImportUrlsFrom(cssUrl: string, css: string): string[] {
+  const urls = new Set<string>();
+  const importRule = /@import\s+(?:url\(\s*)?["']?([^"')\s]+\.css)["']?/g;
+  let match: RegExpExecArray | null;
+
+  while ((match = importRule.exec(css)) !== null) {
+    const specifier = match[1]!;
+    if (specifier.startsWith('/')) {
+      urls.add(specifier);
+      continue;
+    }
+    if (!specifier.startsWith('.')) continue;
+
+    urls.add(new URL(specifier, `http://localhost:${PORT}${cssUrl}`).pathname);
+  }
+
+  return [...urls];
+}
+
+function shellStylesheetUrl(html: string): string {
+  const match = html.match(/<link rel="stylesheet" href="([^"]+)" \/>/);
+  if (match === null) throw new Error('Shell HTML did not contain a stylesheet link');
+  return match[1]!;
+}
+
+async function reachableCssFrom(entryUrl: string): Promise<{ css: string; urls: Set<string> }> {
+  const queue = [entryUrl];
+  const visited = new Set<string>();
+  const parts: string[] = [];
+
+  while (queue.length > 0) {
+    const url = queue.shift()!;
+    if (visited.has(url)) continue;
+    visited.add(url);
+
+    const response = await handleRequest(req(url));
+    expect(response.status).toBe(200);
+    expect(response.headers.get('Content-Type')?.startsWith('text/css')).toBe(true);
+    const css = await response.text();
+    parts.push(`/* ${url} */\n${css}`);
+
+    for (const importUrl of cssImportUrlsFrom(url, css)) {
+      if (!visited.has(importUrl)) queue.push(importUrl);
+    }
+  }
+
+  return { css: parts.join('\n'), urls: visited };
+}
+
 function reservePort(start: number): ReturnType<typeof Bun.serve> {
   for (let port = start; port < start + 100; port++) {
     try {
@@ -153,6 +202,43 @@ describe('/c/:name', () => {
     expect(payload.component).toBe('button');
     expect(payload.components).toContain('button');
     expect(payload.components).toContain('avatar');
+  });
+
+  it('loads the shell CSS bundle so Cinder shell chrome is styled', async () => {
+    const response = await handleRequest(req('/c/button'));
+    const html = await response.text();
+    expect(shellStylesheetUrl(html)).toBe('/styles/shell.css');
+    expect(html).not.toContain('href="/styles/all.css"');
+    expect(html).not.toContain('href="/styles/index.css"');
+  });
+
+  it('makes component CSS for shell primitives reachable from the shell stylesheet', async () => {
+    const shellResponse = await handleRequest(req('/c/button'));
+    const shellHtml = await shellResponse.text();
+    const stylesheetUrl = shellStylesheetUrl(shellHtml);
+    const { css, urls } = await reachableCssFrom(stylesheetUrl);
+
+    expect(urls.has('/styles/shell.css')).toBe(true);
+    expect(urls.has('/styles/index.css')).toBe(true);
+    expect(urls.has('/styles/components.css')).toBe(false);
+    expect(urls.has('/components/toolbar/toolbar.css')).toBe(true);
+    expect(urls.has('/components/segmented-control/segmented-control.css')).toBe(true);
+    expect(urls.has('/components/button/button.css')).toBe(true);
+    expect(urls.has('/components/input/input.css')).toBe(true);
+    expect(urls.has('/components/number-input/number-input.css')).toBe(true);
+    expect(urls.has('/components/side-navigation/side-navigation.css')).toBe(true);
+
+    for (const selector of [
+      '.cinder-toolbar',
+      '.cinder-segmented-control',
+      '.cinder-button',
+      '.cinder-input',
+      '.cinder-number-input',
+      '.cinder-side-navigation',
+      '.cinder-side-navigation__list',
+    ]) {
+      expect(css).toContain(selector);
+    }
   });
 
   it('returns 404 for an unknown component', async () => {

--- a/packages/playground/src/playground-server.test.ts
+++ b/packages/playground/src/playground-server.test.ts
@@ -73,7 +73,7 @@ function cssImportUrlsFrom(cssUrl: string, css: string): string[] {
 }
 
 function shellStylesheetUrl(html: string): string {
-  const match = html.match(/<link rel="stylesheet" href="([^"]+)" \/>/);
+  const match = html.match(/<link\s+[^>]*rel="stylesheet"[^>]*href="([^"]+)"[^>]*\/?>/);
   if (match === null) throw new Error('Shell HTML did not contain a stylesheet link');
   return match[1]!;
 }

--- a/packages/playground/src/playground-server.ts
+++ b/packages/playground/src/playground-server.ts
@@ -13,6 +13,7 @@
  *                              resolve through this single route.
  *   GET /bundle/:name/:scenario.js → compiled example bundle (standalone — useful for tests/debugging)
  *   GET /styles.css    → raw contents of src/styles/index.css (slim base — no per-component CSS)
+ *   GET /styles/shell.css → shell chrome styles (base CSS plus shell component CSS)
  *   GET /styles/all.css → full cascade aggregator (all component CSS — used by the preview iframe)
  *   GET /example-src/:name/:scenario → raw .example.svelte source
  *   GET /events        → Server-Sent Events stream for live reload

--- a/packages/playground/src/render-shell.test.ts
+++ b/packages/playground/src/render-shell.test.ts
@@ -76,7 +76,14 @@ describe('renderShell', () => {
     expect(html).toContain('id="cinder-initial"');
   });
 
-  it('registers cinder.reset layer before /styles/index.css so component CSS wins', () => {
+  it('loads the shell CSS bundle for Cinder components used by the shell', () => {
+    const html = renderShell('button', ['button']);
+    expect(html).toContain('href="/styles/shell.css"');
+    expect(html).not.toContain('href="/styles/all.css"');
+    expect(html).not.toContain('href="/styles/index.css"');
+  });
+
+  it('registers cinder.reset layer before /styles/shell.css so component CSS wins', () => {
     // Regression: when the universal `* { padding: 0 }` reset was unlayered
     // it beat every cinder.components layered rule, leaving SegmentedControl,
     // NumberInput, Card, Accordion all rendered without padding in the shell.
@@ -86,7 +93,7 @@ describe('renderShell', () => {
     const html = renderShell('button', ['button']);
     const layerDeclaration =
       '@layer cinder.reset, cinder.tokens, cinder.foundation, cinder.components, cinder.utilities';
-    const stylesheetLink = '<link rel="stylesheet" href="/styles/index.css"';
+    const stylesheetLink = '<link rel="stylesheet" href="/styles/shell.css"';
     const layerIndex = html.indexOf(layerDeclaration);
     const linkIndex = html.indexOf(stylesheetLink);
     expect(layerIndex).toBeGreaterThan(-1);

--- a/packages/playground/src/render-shell.ts
+++ b/packages/playground/src/render-shell.ts
@@ -182,13 +182,14 @@ export function renderShell(
     <style>
       /* Register cinder.reset as the FIRST layer (least priority) so the universal
          box/margin/padding reset below can never beat component styles. This
-         declaration runs before /styles/index.css so the reset slot is reserved
-         at the bottom of the cascade — index.css then registers the rest of the
-         order (cinder.tokens, foundation, components, utilities) which all come
-         later and therefore win over the reset. */
+         declaration runs before /styles/shell.css so the reset slot is reserved
+         at the bottom of the cascade — shell.css then registers the rest of the
+         order (cinder.tokens, foundation, components, utilities) and imports the
+         Cinder component styles used by the shell, all of which come later and
+         therefore win over the reset. */
       @layer cinder.reset, cinder.tokens, cinder.foundation, cinder.components, cinder.utilities;
     </style>
-    <link rel="stylesheet" href="/styles/index.css" />
+    <link rel="stylesheet" href="/styles/shell.css" />
     <style>
       @layer cinder.reset {
         *, *::before, *::after {

--- a/packages/playground/src/shell-app/sidebar.test.ts
+++ b/packages/playground/src/shell-app/sidebar.test.ts
@@ -99,6 +99,19 @@ function dispatchClick(
 }
 
 describe('Sidebar', () => {
+  test('renders Cinder chrome hooks required by the shell stylesheet', () => {
+    const { container } = render(Sidebar, {
+      props: { components: COMPONENTS, currentComponent: 'button', onSelect: () => {} },
+    });
+
+    expect(container.querySelector('input.cinder-input#sidebar-filter')).not.toBeNull();
+    expect(container.querySelector('nav.cinder-side-navigation')).not.toBeNull();
+    expect(container.querySelector('.cinder-side-navigation__list')).not.toBeNull();
+    expect(container.querySelectorAll('.cinder-side-navigation__item').length).toBe(
+      COMPONENTS.length,
+    );
+  });
+
   test('renders every component as a humanized label', () => {
     const { container } = render(Sidebar, {
       props: { components: COMPONENTS, currentComponent: 'button', onSelect: () => {} },

--- a/packages/playground/src/shell-app/top-bar.test.ts
+++ b/packages/playground/src/shell-app/top-bar.test.ts
@@ -94,6 +94,24 @@ function liveRegion(container: HTMLElement): HTMLElement {
 }
 
 describe('top-bar open-in-new-tab button', () => {
+  test('renders Cinder chrome hooks required by the shell stylesheet', async () => {
+    const store = new PreviewStore('button');
+    store.previewWidth = 375;
+    const { container, unmount } = render(TopBarFixture, { store });
+    await tick();
+
+    expect(container.querySelector('.cinder-toolbar')).not.toBeNull();
+    expect(container.querySelectorAll('.cinder-toolbar__group').length).toBeGreaterThanOrEqual(4);
+    expect(container.querySelector('.cinder-toolbar__spacer')).not.toBeNull();
+    expect(container.querySelectorAll('.cinder-segmented-control').length).toBeGreaterThanOrEqual(
+      2,
+    );
+    expect(container.querySelectorAll('.cinder-button').length).toBeGreaterThanOrEqual(3);
+    expect(container.querySelector('input.cinder-input')).not.toBeNull();
+
+    unmount();
+  });
+
   test('renders the button when a component is selected', async () => {
     const { container, unmount } = render(TopBarFixture, { currentComponent: 'button' });
     await tick();
@@ -143,7 +161,7 @@ describe('top-bar theme selection', () => {
     const { container } = render(TopBarFixture, { store });
     await tick();
 
-    buttonByText(container as HTMLElement, 'Dark theme').click();
+    buttonByText(container, 'Dark theme').click();
     await tick();
 
     expect(themeCalls).toEqual(['dark']);
@@ -159,7 +177,7 @@ describe('top-bar theme selection', () => {
     const { container } = render(TopBarFixture, { store });
     await tick();
 
-    buttonByText(container as HTMLElement, 'Light theme').click();
+    buttonByText(container, 'Light theme').click();
     await tick();
 
     expect(themeCalls).toEqual(['light']);
@@ -172,12 +190,12 @@ describe('top-bar announcements', () => {
     const { container } = render(TopBarFixture, { store });
     await tick();
 
-    const region = liveRegion(container as HTMLElement);
+    const region = liveRegion(container);
     expect(region.textContent?.trim()).toBe('');
 
     // Toggling the checkerboard button triggers announce(). The 50 ms
     // empty-then-set gap means the message is NOT yet present right after.
-    buttonByLabel(container as HTMLElement, 'Show transparency grid').click();
+    buttonByLabel(container, 'Show transparency grid').click();
     await tick();
     expect(region.textContent?.trim()).toBe('');
 
@@ -192,16 +210,16 @@ describe('top-bar announcements', () => {
     const { container } = render(TopBarFixture, { store });
     await tick();
 
-    const region = liveRegion(container as HTMLElement);
+    const region = liveRegion(container);
 
-    buttonByLabel(container as HTMLElement, 'Show transparency grid').click();
+    buttonByLabel(container, 'Show transparency grid').click();
     await wait(80);
     await tick();
     expect(region.textContent?.trim()).toBe('Checkerboard background on');
 
     // Toggle again — off this time. The region clears immediately, then fills
     // with the new message after the gap.
-    buttonByLabel(container as HTMLElement, 'Show transparency grid').click();
+    buttonByLabel(container, 'Show transparency grid').click();
     await tick();
     expect(region.textContent?.trim()).toBe('');
 

--- a/packages/testing/tests/playground-shell-styles.playwright.ts
+++ b/packages/testing/tests/playground-shell-styles.playwright.ts
@@ -1,0 +1,131 @@
+import { expect, test, type Locator, type Page } from '@playwright/test';
+
+const PIXEL_TOLERANCE = 0.5;
+
+type ComputedMetrics = {
+  appearance: string;
+  borderBlockStartWidth: number;
+  borderRadius: number;
+  display: string;
+  flexDirection: string;
+  height: number;
+  listStyleType: string;
+  paddingInlineStart: number;
+  width: number;
+};
+
+async function computedMetrics(locator: Locator): Promise<ComputedMetrics> {
+  return locator.evaluate((element) => {
+    if (!(element instanceof HTMLElement)) {
+      throw new Error('Expected an HTMLElement');
+    }
+    const styles = getComputedStyle(element);
+    const rect = element.getBoundingClientRect();
+    return {
+      appearance: styles.appearance,
+      borderBlockStartWidth: Number.parseFloat(
+        styles.borderBlockStartWidth || styles.borderTopWidth,
+      ),
+      borderRadius: Number.parseFloat(styles.borderStartStartRadius || styles.borderRadius),
+      display: styles.display,
+      flexDirection: styles.flexDirection,
+      height: rect.height,
+      listStyleType: styles.listStyleType,
+      paddingInlineStart: Number.parseFloat(styles.paddingInlineStart || styles.paddingLeft),
+      width: rect.width,
+    };
+  });
+}
+
+async function waitForShellLayout(page: Page): Promise<void> {
+  await page.waitForSelector('#viewport-preset.cinder-segmented-control', { state: 'visible' });
+  await page.waitForSelector('#sidebar-filter.cinder-input', { state: 'visible' });
+  await page.waitForSelector('.cinder-side-navigation__list', { state: 'visible' });
+  await page.waitForFunction(() => {
+    const control = document.querySelector('#viewport-preset.cinder-segmented-control');
+    const option = document.querySelector('#viewport-preset .cinder-segmented-control-option');
+    const sidebarList = document.querySelector('.cinder-side-navigation__list');
+    const filter = document.querySelector('#sidebar-filter.cinder-input');
+    return [control, option, sidebarList, filter].every(
+      (element) => element instanceof HTMLElement && element.getBoundingClientRect().height > 0,
+    );
+  });
+}
+
+test.describe('playground shell styles', () => {
+  test('outer shell chrome loads Cinder component styles', async ({ page }) => {
+    await page.goto('/c/slider', { waitUntil: 'load' });
+    await page.waitForLoadState('networkidle');
+    await waitForShellLayout(page);
+
+    const viewportControl = page.locator('#viewport-preset.cinder-segmented-control');
+    const viewportOption = viewportControl.locator('.cinder-segmented-control-option').first();
+    const sidebarList = page.locator('.cinder-side-navigation__list');
+    const filterInput = page.locator('#sidebar-filter.cinder-input');
+
+    const viewportMetrics = await computedMetrics(viewportControl);
+    expect(['flex', 'inline-flex']).toContain(viewportMetrics.display);
+    expect(viewportMetrics.borderBlockStartWidth).toBeGreaterThan(0);
+    expect(viewportMetrics.borderRadius).toBeGreaterThan(0);
+
+    const optionMetrics = await computedMetrics(viewportOption);
+    expect(['flex', 'inline-flex']).toContain(optionMetrics.display);
+    expect(optionMetrics.paddingInlineStart).toBeGreaterThanOrEqual(7.5);
+    expect(optionMetrics.height).toBeGreaterThan(20);
+
+    const sidebarMetrics = await computedMetrics(sidebarList);
+    expect(sidebarMetrics.display).toBe('flex');
+    expect(sidebarMetrics.flexDirection).toBe('column');
+    expect(sidebarMetrics.listStyleType).toBe('none');
+
+    const filterMetrics = await computedMetrics(filterInput);
+    expect(filterMetrics.appearance).toBe('none');
+    expect(filterMetrics.borderBlockStartWidth).toBeGreaterThan(0);
+    expect(filterMetrics.borderRadius).toBeGreaterThan(0);
+    expect(filterMetrics.height).toBeGreaterThan(30);
+
+    await page.getByRole('radio', { name: 'Tablet (768 pixels)' }).click();
+    await expect(viewportControl.locator('[data-cinder-selected]')).toContainText('Tablet');
+
+    const numberInput = page.locator('.cinder-number-input:has(#viewport-width-input)');
+    const numberInputMetrics = await computedMetrics(numberInput);
+    expect(['flex', 'inline-flex']).toContain(numberInputMetrics.display);
+    expect(numberInputMetrics.borderBlockStartWidth).toBeGreaterThan(0);
+    expect(numberInputMetrics.borderRadius).toBeGreaterThan(0);
+
+    const customWidth = page.getByLabel('Custom viewport width in pixels (200 to 3840)');
+    await customWidth.fill('640');
+    await customWidth.blur();
+    await expect(customWidth).toHaveValue('640');
+
+    await page.getByRole('radio', { name: 'Dark theme' }).click();
+    await expect(page.locator('html')).toHaveAttribute('data-cinder-theme', 'dark');
+
+    const checkerButton = page.getByRole('button', { name: 'Show transparency grid' });
+    await checkerButton.click();
+    await expect(checkerButton).toHaveAttribute('aria-pressed', 'true');
+
+    const focusModeButton = page.getByRole('button', { name: /Focus mode/ });
+    await focusModeButton.click();
+    await expect(page.locator('.shell')).toHaveClass(/focus-mode/);
+    await page.keyboard.press('Escape');
+    await expect(page.locator('.shell')).not.toHaveClass(/focus-mode/);
+
+    const navigationItems = page.locator('.cinder-side-navigation__item');
+    const unfilteredNavigationCount = await navigationItems.count();
+    await filterInput.fill('slider');
+    await expect(page.locator('a[href="/c/slider"]')).toBeVisible();
+    await expect(page.locator('a[href="/c/button"]')).toHaveCount(0);
+    await expect(navigationItems).not.toHaveCount(unfilteredNavigationCount);
+
+    await page.screenshot({
+      path: 'test-results/playwright/playground-shell-styles-slider.png',
+      fullPage: true,
+    });
+
+    const filteredSidebarMetrics = await computedMetrics(sidebarList);
+    expect(Math.abs(filteredSidebarMetrics.width - sidebarMetrics.width)).toBeLessThanOrEqual(
+      PIXEL_TOLERANCE,
+    );
+  });
+});

--- a/packages/testing/tests/playground-shell-styles.playwright.ts
+++ b/packages/testing/tests/playground-shell-styles.playwright.ts
@@ -53,9 +53,8 @@ async function waitForShellLayout(page: Page): Promise<void> {
 }
 
 test.describe('playground shell styles', () => {
-  test('outer shell chrome loads Cinder component styles', async ({ page }) => {
+  test('outer shell chrome loads Cinder component styles', async ({ page }, testInfo) => {
     await page.goto('/c/slider', { waitUntil: 'load' });
-    await page.waitForLoadState('networkidle');
     await waitForShellLayout(page);
 
     const viewportControl = page.locator('#viewport-preset.cinder-segmented-control');
@@ -119,7 +118,9 @@ test.describe('playground shell styles', () => {
     await expect(navigationItems).not.toHaveCount(unfilteredNavigationCount);
 
     await page.screenshot({
-      path: 'test-results/playwright/playground-shell-styles-slider.png',
+      path: testInfo.outputPath('playground-shell-styles-slider.png'),
+      animations: 'disabled',
+      caret: 'hide',
       fullPage: true,
     });
 


### PR DESCRIPTION
## Summary
- load a dedicated `/styles/shell.css` bundle for the playground shell so Cinder toolbar, segmented control, button, input, number-input, and side-navigation chrome is styled without pulling every component stylesheet into the outer document
- keep iframe preview pages on `/styles/all.css` and add server/component regression coverage for both contracts
- add a Playwright regression for `/c/slider` that checks styled shell chrome with computed styles and captures a browser screenshot
- regenerate component example artifacts and export subpaths surfaced by `components:check`

## Review committee
Pre-reviewed by: frontend-architect, testing-expert, simplicity-engineer, Codex
- 2 rounds of review
- All must-fix items addressed
- Post-creation reviewer requested: @copilot

## Test plan
- `bun run --filter=@cinder/playground test`
- `bun run --filter=cinder components:check`
- `bun run --filter=@cinder/testing test:playwright -- playground-shell-styles.playwright.ts`
- `bun run --filter=cinder test`
- pre-commit hook: passed
- pre-push hook: passed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Playground styling and documentation/example metadata only; no auth, data, or public API behavior changes beyond new optional example import paths.
> 
> **Overview**
> The playground **outer shell** now loads **`/styles/shell.css`** instead of the slim base or full component aggregator, so toolbar, segmented control, button, input, number-input, and side-navigation chrome get Cinder styles without pulling every component stylesheet into the parent document. Preview iframes stay on the full cascade bundle; layer-order comments and links were updated so **`cinder.reset`** still registers before the shell stylesheet.
> 
> **`packages/components`** adds **`*.examples.json`** and **`cinder/*/examples`** exports for **color-field**, **description-list**, **message**, and **status-dot**, with **`components.json`** marking **`hasExamples: true`**.
> 
> Regression coverage includes server tests that walk **`@import`** from the shell CSS, unit tests that shell markup exposes expected Cinder class hooks, and a Playwright test on **`/c/slider`** that asserts computed styles on shell controls.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0817c59ad489c7e19cf5e5a17800be5d33d4c979. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->