### PR TITLE
fix(components): guard edge cases in Progress, JsonViewer, DiffStatistics, StatGroup, JsonSchemaEditor (addcfcd9)

### DIFF
--- a/packages/components/src/components/diff-statistics/diff-statistics.svelte
+++ b/packages/components/src/components/diff-statistics/diff-statistics.svelte
@@ -49,11 +49,17 @@
   const hasAnyStatistics = $derived(showAdded || showRemoved || showModified);
 </script>
 
+<!--
+  Static summary, not a live region: `role="img"` + `aria-label` reads the whole
+  figure as a single unit without announcing on every re-render the way
+  `role="status"` (an aria-live region) would. Diff stats describe a fixed diff;
+  they are not a value that updates in place.
+-->
 <div
   class={classNames('cinder-diff-statistics', customClassName)}
   data-cinder-variant={variant}
   data-cinder-density={density === 'toolbar' ? 'toolbar' : undefined}
-  role="status"
+  role="img"
   aria-label={`${total} ${pluralize(total, 'line', 'lines')} changed`}
   {...rest}
 >

--- a/packages/components/src/components/diff-statistics/diff-statistics.svelte
+++ b/packages/components/src/components/diff-statistics/diff-statistics.svelte
@@ -50,16 +50,17 @@
 </script>
 
 <!--
-  Static summary, not a live region: `role="img"` + `aria-label` reads the whole
-  figure as a single unit without announcing on every re-render the way
-  `role="status"` (an aria-live region) would. Diff stats describe a fixed diff;
-  they are not a value that updates in place.
+  Static summary, not a live region. `role="group"` + `aria-label` labels the
+  cluster ("N lines changed") while keeping the visible added/removed/modified
+  breakdown readable by assistive technology — unlike `role="img"`, which would
+  hide that inner text, and unlike `role="status"`, which would re-announce on
+  every render. Diff stats describe a fixed diff, not a value that updates in place.
 -->
 <div
   class={classNames('cinder-diff-statistics', customClassName)}
   data-cinder-variant={variant}
   data-cinder-density={density === 'toolbar' ? 'toolbar' : undefined}
-  role="img"
+  role="group"
   aria-label={`${total} ${pluralize(total, 'line', 'lines')} changed`}
   {...rest}
 >

--- a/packages/components/src/components/diff-statistics/diff-statistics.test.ts
+++ b/packages/components/src/components/diff-statistics/diff-statistics.test.ts
@@ -11,16 +11,29 @@ const { default: DiffStatistics } = await import('./diff-statistics.svelte');
 afterEach(() => cleanup());
 
 describe('DiffStatistics', () => {
-  test('announces the total number of changed lines', () => {
+  test('labels the total number of changed lines as a single figure', () => {
     const { container } = render(DiffStatistics, {
       props: { added: 2, removed: 1, modified: 3 },
     });
 
-    const status = container.querySelector('[role="status"]');
-    expect(status?.getAttribute('aria-label')).toBe('6 lines changed');
-    expect(status?.textContent).toContain('added');
-    expect(status?.textContent).toContain('removed');
-    expect(status?.textContent).toContain('modified');
+    const figure = container.querySelector('[role="img"]');
+    expect(figure?.getAttribute('aria-label')).toBe('6 lines changed');
+    expect(figure?.textContent).toContain('added');
+    expect(figure?.textContent).toContain('removed');
+    expect(figure?.textContent).toContain('modified');
+  });
+
+  test('is a static labeled figure, not a live region', () => {
+    // Regression: diff stats describe a fixed diff, so they must NOT use
+    // role="status" / aria-live (which would announce on every re-render).
+    const { container } = render(DiffStatistics, {
+      props: { added: 2, removed: 1, modified: 3 },
+    });
+
+    const root = container.querySelector('.cinder-diff-statistics');
+    expect(root?.getAttribute('role')).toBe('img');
+    expect(container.querySelector('[role="status"]')).toBeNull();
+    expect(root?.hasAttribute('aria-live')).toBe(false);
   });
 
   test('supports compact zero-hiding output', () => {
@@ -28,7 +41,7 @@ describe('DiffStatistics', () => {
       props: { added: 4, removed: 0, modified: 0, variant: 'compact', hideZero: true },
     });
 
-    const status = container.querySelector('[role="status"]');
+    const status = container.querySelector('[role="img"]');
     expect(status?.getAttribute('data-cinder-variant')).toBe('compact');
     expect(status?.textContent).toContain('4');
     expect(status?.textContent).not.toContain('0');
@@ -38,7 +51,7 @@ describe('DiffStatistics', () => {
     const { container } = render(DiffStatistics, {
       props: { added: 1, removed: 0, modified: 0, variant: 'compact', density: 'toolbar' },
     });
-    const status = container.querySelector('[role="status"]');
+    const status = container.querySelector('[role="img"]');
     expect(status?.getAttribute('data-cinder-density')).toBe('toolbar');
   });
 
@@ -46,7 +59,7 @@ describe('DiffStatistics', () => {
     const { container } = render(DiffStatistics, {
       props: { added: 1, removed: 0, modified: 0, variant: 'compact' },
     });
-    const status = container.querySelector('[role="status"]');
+    const status = container.querySelector('[role="img"]');
     expect(status?.hasAttribute('data-cinder-density')).toBe(false);
   });
 

--- a/packages/components/src/components/diff-statistics/diff-statistics.test.ts
+++ b/packages/components/src/components/diff-statistics/diff-statistics.test.ts
@@ -11,28 +11,31 @@ const { default: DiffStatistics } = await import('./diff-statistics.svelte');
 afterEach(() => cleanup());
 
 describe('DiffStatistics', () => {
-  test('labels the total number of changed lines as a single figure', () => {
+  test('labels the changed-line total on a group that keeps its breakdown readable', () => {
     const { container } = render(DiffStatistics, {
       props: { added: 2, removed: 1, modified: 3 },
     });
 
-    const figure = container.querySelector('[role="img"]');
-    expect(figure?.getAttribute('aria-label')).toBe('6 lines changed');
-    expect(figure?.textContent).toContain('added');
-    expect(figure?.textContent).toContain('removed');
-    expect(figure?.textContent).toContain('modified');
+    const group = container.querySelector('[role="group"]');
+    expect(group?.getAttribute('aria-label')).toBe('6 lines changed');
+    // role="group" (unlike role="img") keeps the visible breakdown exposed to AT.
+    expect(group?.textContent).toContain('added');
+    expect(group?.textContent).toContain('removed');
+    expect(group?.textContent).toContain('modified');
   });
 
-  test('is a static labeled figure, not a live region', () => {
+  test('is a static labeled group, not a live region and not an opaque image', () => {
     // Regression: diff stats describe a fixed diff, so they must NOT use
-    // role="status" / aria-live (which would announce on every re-render).
+    // role="status"/aria-live (announces on every re-render) — and NOT role="img"
+    // either, which would hide the added/removed/modified breakdown from AT.
     const { container } = render(DiffStatistics, {
       props: { added: 2, removed: 1, modified: 3 },
     });
 
     const root = container.querySelector('.cinder-diff-statistics');
-    expect(root?.getAttribute('role')).toBe('img');
+    expect(root?.getAttribute('role')).toBe('group');
     expect(container.querySelector('[role="status"]')).toBeNull();
+    expect(container.querySelector('[role="img"]')).toBeNull();
     expect(root?.hasAttribute('aria-live')).toBe(false);
   });
 
@@ -41,7 +44,7 @@ describe('DiffStatistics', () => {
       props: { added: 4, removed: 0, modified: 0, variant: 'compact', hideZero: true },
     });
 
-    const status = container.querySelector('[role="img"]');
+    const status = container.querySelector('[role="group"]');
     expect(status?.getAttribute('data-cinder-variant')).toBe('compact');
     expect(status?.textContent).toContain('4');
     expect(status?.textContent).not.toContain('0');
@@ -51,7 +54,7 @@ describe('DiffStatistics', () => {
     const { container } = render(DiffStatistics, {
       props: { added: 1, removed: 0, modified: 0, variant: 'compact', density: 'toolbar' },
     });
-    const status = container.querySelector('[role="img"]');
+    const status = container.querySelector('[role="group"]');
     expect(status?.getAttribute('data-cinder-density')).toBe('toolbar');
   });
 
@@ -59,7 +62,7 @@ describe('DiffStatistics', () => {
     const { container } = render(DiffStatistics, {
       props: { added: 1, removed: 0, modified: 0, variant: 'compact' },
     });
-    const status = container.querySelector('[role="img"]');
+    const status = container.querySelector('[role="group"]');
     expect(status?.hasAttribute('data-cinder-density')).toBe(false);
   });
 

--- a/packages/components/src/components/json-schema-editor/json-schema-editor.css
+++ b/packages/components/src/components/json-schema-editor/json-schema-editor.css
@@ -302,16 +302,8 @@
     padding: var(--cinder-space-2);
   }
 
-  .cinder-jse-required-only__chip {
-    display: inline-flex;
-    align-items: center;
-    gap: var(--cinder-space-1);
-    padding: var(--cinder-space-0-5) var(--cinder-space-2);
-    border: 1px solid var(--cinder-border-muted);
-    border-radius: var(--cinder-radius-full);
-    font-size: var(--cinder-text-xs);
-    background: var(--cinder-surface);
-  }
+  /* (Required-without-schema pills now render via the shared Chip component in
+     mode="removable" — its styling lives in chip.css, so no local chip rule.) */
 
   /* ===== Advanced row ($ref / preserved badges) ===== */
   .cinder-jse-advanced-row {

--- a/packages/components/src/components/json-schema-editor/property-list.svelte
+++ b/packages/components/src/components/json-schema-editor/property-list.svelte
@@ -15,6 +15,7 @@
 <script lang="ts">
   import Alert from '../alert/alert.svelte';
   import Button from '../button/button.svelte';
+  import Chip from '../chip/chip.svelte';
   import Input from '../input/input.svelte';
   import PropertyEditor from './property-editor.svelte';
 
@@ -265,18 +266,12 @@
       </summary>
       <div class="cinder-jse-required-only__panel">
         {#each requiredOnly as name (name)}
-          <span class="cinder-jse-required-only__chip">
-            {name}
-            <Button
-              variant="ghost"
-              size="xs"
-              disabled={readonly}
-              aria-label={`Remove ${name}`}
-              onclick={() => removeRequiredOnly(name)}
-            >
-              ×
-            </Button>
-          </span>
+          <Chip
+            mode="removable"
+            label={name}
+            disabled={readonly}
+            onremove={() => removeRequiredOnly(name)}
+          />
         {/each}
         <Input
           id={`${idPrefix}-required-only-add`}

--- a/packages/components/src/components/json-viewer/json-viewer.svelte
+++ b/packages/components/src/components/json-viewer/json-viewer.svelte
@@ -35,7 +35,12 @@
   // meaningful message instead of a garbage "~Infinity KB" size.
   const serialized = $derived.by((): { ok: true; size: number } | { ok: false } => {
     try {
-      return { ok: true, size: new Blob([JSON.stringify(value)]).size };
+      const json = JSON.stringify(value);
+      // `JSON.stringify` returns `undefined` (not a throw) for top-level
+      // `undefined`, a `Symbol`, or a function — none of which are valid JSON.
+      // Treat those as unserializable rather than measuring the string "undefined".
+      if (typeof json !== 'string') return { ok: false };
+      return { ok: true, size: new Blob([json]).size };
     } catch {
       return { ok: false };
     }

--- a/packages/components/src/components/json-viewer/json-viewer.svelte
+++ b/packages/components/src/components/json-viewer/json-viewer.svelte
@@ -29,26 +29,35 @@
     class: className,
   }: JsonViewerProps = $props();
 
-  // Compute serialized size up front so we can short-circuit oversized
-  // payloads before walking the tree.
-  const serializedSize = $derived.by(() => {
+  // Compute serialized size up front so we can short-circuit oversized payloads
+  // before walking the tree. `JSON.stringify` can throw (circular references) or
+  // throw on `BigInt`; distinguish that from "too large" so the fallback shows a
+  // meaningful message instead of a garbage "~Infinity KB" size.
+  const serialized = $derived.by((): { ok: true; size: number } | { ok: false } => {
     try {
-      return new Blob([JSON.stringify(value)]).size;
+      return { ok: true, size: new Blob([JSON.stringify(value)]).size };
     } catch {
-      return Number.POSITIVE_INFINITY;
+      return { ok: false };
     }
   });
 
-  const tooLarge = $derived(serializedSize > maxBytes);
+  const unserializable = $derived(!serialized.ok);
+  const tooLarge = $derived(serialized.ok && serialized.size > maxBytes);
 </script>
 
 <div class={cn('cinder-json-viewer', className)}>
-  {#if tooLarge}
+  {#if unserializable}
     <div class="cinder-json-viewer__fallback" role="status">
       <p>
-        Payload too large to render (~{Math.round(serializedSize / 1024)} KB; cap is {Math.round(
-          maxBytes / 1024,
-        )} KB).
+        This value can't be serialized as JSON (it may contain a circular reference or a BigInt).
+      </p>
+      <p>Pass a plain JSON-serializable value, or use the consumer's download or copy action.</p>
+    </div>
+  {:else if tooLarge}
+    <div class="cinder-json-viewer__fallback" role="status">
+      <p>
+        Payload too large to render (~{Math.round((serialized.ok ? serialized.size : 0) / 1024)} KB; cap
+        is {Math.round(maxBytes / 1024)} KB).
       </p>
       <p>Use the consumer's download or copy action to inspect the raw JSON.</p>
     </div>

--- a/packages/components/src/components/json-viewer/json-viewer.test.ts
+++ b/packages/components/src/components/json-viewer/json-viewer.test.ts
@@ -71,6 +71,22 @@ describe('JsonViewer — unserializable fallback', () => {
     expect(fallback?.textContent).toContain("can't be serialized");
   });
 
+  test.each([
+    ['undefined', undefined],
+    ['a symbol', Symbol('x')],
+    ['a function', () => 'noop'],
+  ])(
+    '%s (JSON.stringify returns undefined, not a throw) shows the unserializable fallback',
+    (_label, value) => {
+      const { container } = render(JsonViewer, { value });
+      const fallback = container.querySelector('.cinder-json-viewer__fallback');
+      expect(fallback).not.toBeNull();
+      expect(fallback?.textContent).toContain("can't be serialized");
+      expect(fallback?.textContent).not.toContain('Infinity');
+      expect(fallback?.textContent).not.toContain('undefined KB');
+    },
+  );
+
   test('a genuinely oversized payload still shows the size-based fallback', () => {
     const big = { blob: 'x'.repeat(2048) };
     const { container } = render(JsonViewer, { value: big, maxBytes: 100 });

--- a/packages/components/src/components/json-viewer/json-viewer.test.ts
+++ b/packages/components/src/components/json-viewer/json-viewer.test.ts
@@ -49,3 +49,33 @@ describe('JsonViewer', () => {
     expect(container.querySelector('.cinder-json-viewer__too-deep')).not.toBeNull();
   });
 });
+
+describe('JsonViewer — unserializable fallback', () => {
+  // JSON.stringify throws on circular refs and BigInt. The viewer must show a
+  // clear "can't be serialized" message, never a garbage "~Infinity KB" size.
+  test('circular reference shows the unserializable fallback, not a size error', () => {
+    const circular: Record<string, unknown> = {};
+    circular['self'] = circular;
+    const { container } = render(JsonViewer, { value: circular });
+    const fallback = container.querySelector('.cinder-json-viewer__fallback');
+    expect(fallback).not.toBeNull();
+    expect(fallback?.textContent).toContain("can't be serialized");
+    expect(fallback?.textContent).not.toContain('Infinity');
+    expect(fallback?.textContent).not.toContain('NaN');
+  });
+
+  test('BigInt value shows the unserializable fallback', () => {
+    const { container } = render(JsonViewer, { value: { big: 10n } });
+    const fallback = container.querySelector('.cinder-json-viewer__fallback');
+    expect(fallback).not.toBeNull();
+    expect(fallback?.textContent).toContain("can't be serialized");
+  });
+
+  test('a genuinely oversized payload still shows the size-based fallback', () => {
+    const big = { blob: 'x'.repeat(2048) };
+    const { container } = render(JsonViewer, { value: big, maxBytes: 100 });
+    const fallback = container.querySelector('.cinder-json-viewer__fallback');
+    expect(fallback?.textContent).toContain('too large');
+    expect(fallback?.textContent).not.toContain('Infinity');
+  });
+});

--- a/packages/components/src/components/progress/progress.svelte
+++ b/packages/components/src/components/progress/progress.svelte
@@ -30,12 +30,18 @@
     class: className,
   }: ProgressProps = $props();
 
-  const isIndeterminate = $derived(value === undefined);
+  // A usable upper bound: only a finite, strictly-positive `max` can define a
+  // determinate scale. Zero, negative, or non-finite `max` cannot, so the bar
+  // falls back to indeterminate rather than dividing by zero (NaN/Infinity).
+  const effectiveMax = $derived(Number.isFinite(max) && max > 0 ? max : undefined);
+  const isIndeterminate = $derived(
+    value === undefined || !Number.isFinite(value) || effectiveMax === undefined,
+  );
   const clampedValue = $derived(
-    value === undefined ? undefined : Math.max(0, Math.min(max, value)),
+    isIndeterminate ? undefined : Math.max(0, Math.min(effectiveMax!, value!)),
   );
   const percent = $derived(
-    clampedValue === undefined ? undefined : Math.round((clampedValue / max) * 100),
+    clampedValue === undefined ? undefined : Math.round((clampedValue / effectiveMax!) * 100),
   );
 
   // Default valuetext mirrors the percent for determinate; falls back to a
@@ -51,7 +57,7 @@
     aria-label={ariaLabel}
     aria-labelledby={ariaLabelledby}
     aria-valuemin={0}
-    aria-valuemax={max}
+    aria-valuemax={effectiveMax}
     aria-valuenow={clampedValue}
     aria-valuetext={valueText}
     data-cinder-size={size}
@@ -84,7 +90,7 @@
     aria-label={ariaLabel}
     aria-labelledby={ariaLabelledby}
     aria-valuemin={0}
-    aria-valuemax={max}
+    aria-valuemax={effectiveMax}
     aria-valuenow={clampedValue}
     aria-valuetext={valueText}
     data-cinder-size={size}

--- a/packages/components/src/components/progress/progress.test.ts
+++ b/packages/components/src/components/progress/progress.test.ts
@@ -213,3 +213,48 @@ describe('Progress CSS reduced-motion audit', () => {
     expect(ringRuleBlock).not.toBeUndefined();
   });
 });
+
+describe('Progress — degenerate max/value guards', () => {
+  // A determinate scale needs a finite, strictly-positive max. Anything else
+  // must fall back to indeterminate rather than dividing by zero (NaN/Infinity).
+  test('max=0 renders indeterminate, not NaN/Infinity', () => {
+    const { container } = render(Progress, { value: 10, max: 0 });
+    const el = container.querySelector('[role="progressbar"]');
+    expect(el?.getAttribute('data-cinder-indeterminate')).toBe('true');
+    expect(el?.getAttribute('aria-valuenow')).toBeNull();
+    expect(el?.getAttribute('aria-valuemax')).toBeNull();
+    // No NaN/Infinity leaks into the value text.
+    expect(el?.getAttribute('aria-valuetext')).toBe('Loading');
+  });
+
+  test('negative max renders indeterminate', () => {
+    const { container } = render(Progress, { value: 10, max: -5 });
+    const el = container.querySelector('[role="progressbar"]');
+    expect(el?.getAttribute('data-cinder-indeterminate')).toBe('true');
+    expect(el?.getAttribute('aria-valuenow')).toBeNull();
+  });
+
+  test('non-finite max (Infinity/NaN) renders indeterminate', () => {
+    for (const max of [Number.POSITIVE_INFINITY, Number.NaN]) {
+      const { container } = render(Progress, { value: 10, max });
+      const el = container.querySelector('[role="progressbar"]');
+      expect(el?.getAttribute('data-cinder-indeterminate')).toBe('true');
+    }
+  });
+
+  test('non-finite value renders indeterminate even with a valid max', () => {
+    const { container } = render(Progress, { value: Number.NaN, max: 100 });
+    const el = container.querySelector('[role="progressbar"]');
+    expect(el?.getAttribute('data-cinder-indeterminate')).toBe('true');
+    expect(el?.getAttribute('aria-valuenow')).toBeNull();
+  });
+
+  test('a valid finite max still computes a clamped determinate percent', () => {
+    const { container } = render(Progress, { value: 25, max: 50 });
+    const el = container.querySelector('[role="progressbar"]');
+    expect(el?.getAttribute('data-cinder-indeterminate')).toBeNull();
+    expect(el?.getAttribute('aria-valuenow')).toBe('25');
+    expect(el?.getAttribute('aria-valuemax')).toBe('50');
+    expect(el?.getAttribute('aria-valuetext')).toBe('50%');
+  });
+});

--- a/packages/components/src/components/stat-group/stat-group.css
+++ b/packages/components/src/components/stat-group/stat-group.css
@@ -2,6 +2,10 @@
   .cinder-stat-group {
     display: grid;
     gap: var(--cinder-space-4, 1rem);
+    /* Query the group's own inline size so fixed column counts can collapse when
+       the group is narrow — even inside a wide viewport (RESPONSIVE-POLICY.md). */
+    container-type: inline-size;
+    container-name: cinder-stat-group;
   }
 
   .cinder-stat-group[data-cinder-columns='auto'] {
@@ -22,6 +26,25 @@
 
   .cinder-stat-group[data-cinder-columns='4'] {
     grid-template-columns: repeat(4, minmax(0, 1fr));
+  }
+
+  /* Fixed multi-column layouts would squeeze each stat below readability on a
+     narrow group. Collapse to two columns under 30rem, then a single column
+     under 18rem, so values never crush. The `auto` mode already self-collapses
+     via auto-fit, so it is intentionally excluded. */
+  @container cinder-stat-group (max-width: 30rem) {
+    .cinder-stat-group[data-cinder-columns='3'],
+    .cinder-stat-group[data-cinder-columns='4'] {
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+  }
+
+  @container cinder-stat-group (max-width: 18rem) {
+    .cinder-stat-group[data-cinder-columns='2'],
+    .cinder-stat-group[data-cinder-columns='3'],
+    .cinder-stat-group[data-cinder-columns='4'] {
+      grid-template-columns: 1fr;
+    }
   }
 
   /* variant: cards — each stat gets a card-style border, background, and shadow */


### PR DESCRIPTION
## Summary

Concrete edge-case + duplication fixes across five small data-display components (task `addcfcd9`).

- **Progress**: a determinate scale now requires a finite, strictly-positive `max`. `max` of `0`/negative/non-finite (and a non-finite `value`) fall back to **indeterminate** instead of dividing by zero into `NaN`/`Infinity`; `aria-valuemax`/`aria-valuenow` are omitted in that state.
- **JsonViewer**: distinguishes "**can't serialize**" (circular reference, `BigInt` → `JSON.stringify` throws; and top-level `undefined`/`Symbol`/function → `JSON.stringify` returns `undefined`) from "**too large**", with a clear dedicated fallback message instead of a garbage "~Infinity KB" size.
- **DiffStatistics**: a static summary, so it moved off `role="status"` (an `aria-live` region that re-announces every render) to **`role="group"` + `aria-label`** — labels the cluster while keeping the visible added/removed/modified breakdown exposed to assistive tech (`role="img"` would have hidden it).
- **StatGroup**: fixed 2/3/4-column layouts now collapse via **`@container`** queries (`container-type` on the root) so stats don't crush on a narrow group; the `auto` mode already self-collapses. Uses `@container` per the RESPONSIVE/PLATFORM policy (verified it does not trip the new `platform:audit` viewport guard).
- **JsonSchemaEditor**: required-without-schema pills now reuse the shared **`Chip`** (`mode="removable"`) instead of a hand-rolled chip + remove button; removed the orphaned local chip CSS.

## Review committee

Pre-reviewed by Codex (gpt-5.4, xhigh) + author line-by-line. 2 rounds; APPROVED.
- Codex must-fixes addressed: `JSON.stringify` returning `undefined` (not a throw) was treated as renderable; `role="img"` hid the diff breakdown from AT. Both fixed with regression tests.

## Test plan

- [x] `bun run --filter=cinder test -- progress json-viewer json-schema-editor diff-statistics diff-viewer stat-group` — 157 pass
- [x] `bun run --filter=cinder typecheck` / `lint` / `components:check` — clean (no regen drift)
- [x] `bun run --filter=cinder platform:audit --strict` — clean (new @container not flagged)
- [x] full-package pre-commit + pre-push green

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only component fixes with expanded tests; no auth, data persistence, or API contract changes.
> 
> **Overview**
> Hardens several data-display components against edge cases and improves accessibility/layout behavior.
> 
> **Progress** now requires a finite, strictly positive `max` for a determinate bar; invalid `max` or non-finite `value` falls back to indeterminate and drops `aria-valuenow` / `aria-valuemax` instead of producing NaN/Infinity.
> 
> **JsonViewer** splits “can’t serialize as JSON” (throws, `BigInt`, or `JSON.stringify` returning non-string) from “payload too large,” with a dedicated fallback message instead of bogus size text.
> 
> **DiffStatistics** switches from `role="status"` to **`role="group"`** with `aria-label` so assistive tech keeps the added/removed/modified breakdown without live-region re-announcements on every render.
> 
> **StatGroup** adds **`@container`** rules so fixed 2–4 column grids collapse when the group itself is narrow.
> 
> **JsonSchemaEditor** “required without schema” pills use shared **`Chip`** (`mode="removable"`) and drop the local chip CSS.
> 
> Regression tests cover the new Progress, JsonViewer, and DiffStatistics behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 07bf97517910f25bed4f86afae37e39caf5b1d50. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->