### PR TITLE
refactor(components): extract shared chart interaction shell (2c4ac3ce)

### DIFF
--- a/packages/components/src/_internal/chart/chart-interaction.svelte.ts
+++ b/packages/components/src/_internal/chart/chart-interaction.svelte.ts
@@ -1,0 +1,182 @@
+/**
+ * Shared reactive interaction state for all chart components.
+ *
+ * Encapsulates the pointer/keyboard target tracking, resize observation, and
+ * target-staleness cleanup that are identical across LineChart, AreaChart, and
+ * BarChart. Each chart component instantiates ChartInteraction once and reads
+ * `activeTarget`, `measuredWidth`, and the handler functions from it.
+ *
+ * Series-specific logic (model creation, crosshair direction, focus-target
+ * element shape) stays in each individual chart component.
+ */
+
+import { nearestTarget, toggleSeriesId, type ChartTarget } from './chart-utilities.ts';
+
+export type ChartInteractionOptions = {
+  /**
+   * Pixel axis used by nearestTarget when the pointer moves. Defaults to 'x'.
+   * Bar charts switch this to 'y' when orientation is 'horizontal'. Pass a
+   * reactive getter (e.g. `() => orientation === 'vertical' ? 'x' : 'y'`) to
+   * follow orientation changes without re-instantiating the class.
+   */
+  pointerAxis?: 'x' | 'y' | (() => 'x' | 'y');
+};
+
+export class ChartInteraction {
+  /** Current measured container width in pixels. Starts at 640 as a reasonable SSR default. */
+  measuredWidth = $state(640);
+
+  /** Target activated by pointer movement. Cleared on pointer-leave. */
+  pointerTarget = $state<ChartTarget | undefined>();
+
+  /** Target activated by keyboard navigation. Cleared on Escape or blur. */
+  focusedTarget = $state<ChartTarget | undefined>();
+
+  /**
+   * The active target visible to the tooltip and crosshair.
+   * Keyboard focus wins over pointer so screen-reader users are never
+   * overridden by incidental pointer events.
+   */
+  activeTarget = $derived(this.focusedTarget ?? this.pointerTarget);
+
+  readonly #pointerAxisSource: () => 'x' | 'y';
+
+  constructor(options: ChartInteractionOptions = {}) {
+    const axis = options.pointerAxis ?? 'x';
+    this.#pointerAxisSource = typeof axis === 'function' ? axis : () => axis;
+  }
+
+  /**
+   * Attaches a ResizeObserver to the chart root element and updates
+   * `measuredWidth` whenever the element's content rect changes.
+   * Returns a cleanup function for use inside `$effect`.
+   */
+  observeResize(element: HTMLElement): () => void {
+    if (typeof ResizeObserver === 'undefined') return () => {};
+    const observer = new ResizeObserver(([entry]) => {
+      if (!entry) return;
+      this.measuredWidth = Math.max(1, Math.round(entry.contentRect.width));
+    });
+    observer.observe(element);
+    return () => observer.disconnect();
+  }
+
+  /**
+   * Clears stale targets when the model's target set changes (e.g. after a
+   * legend toggle that removes the currently active series). Also clears both
+   * targets when the chart enters a loading or empty state.
+   *
+   * Call inside a `$effect` that reads `loading`, `empty`, and `targets`.
+   */
+  clearStaleTargets(loading: boolean, empty: boolean, targets: readonly ChartTarget[]): void {
+    if (loading || empty) {
+      this.pointerTarget = undefined;
+      this.focusedTarget = undefined;
+      return;
+    }
+    if (!this.#includesTarget(this.pointerTarget, targets)) this.pointerTarget = undefined;
+    if (!this.#includesTarget(this.focusedTarget, targets)) this.focusedTarget = undefined;
+  }
+
+  #includesTarget(candidate: ChartTarget | undefined, targets: readonly ChartTarget[]): boolean {
+    return Boolean(candidate && targets.some((target) => target.id === candidate.id));
+  }
+
+  /**
+   * Updates `pointerTarget` from a PointerEvent fired on the SVG hit surface.
+   * The hit surface must be an SVGRectElement.
+   */
+  activateByPointer(event: PointerEvent, targets: readonly ChartTarget[]): void {
+    if (!(event.currentTarget instanceof SVGRectElement)) return;
+    const bounds = event.currentTarget.getBoundingClientRect();
+    this.pointerTarget = nearestTarget(
+      targets,
+      event.clientX - bounds.left,
+      event.clientY - bounds.top,
+      this.#pointerAxisSource(),
+    );
+  }
+
+  /**
+   * Clears `pointerTarget` on pointer-leave of the hit surface.
+   */
+  clearPointerTarget(): void {
+    this.pointerTarget = undefined;
+  }
+
+  /**
+   * Moves DOM focus to the SVG element carrying the given `data-cinder-target-id`
+   * attribute. Keeps `:focus-visible`, `aria-describedby`, and `aria-label`
+   * synchronized with the keyboard-active target.
+   */
+  focusDomTarget(rootElement: HTMLElement, targetId: string | undefined): void {
+    if (!rootElement || !targetId) return;
+    const next = rootElement.querySelector<SVGGraphicsElement>(
+      `[data-cinder-target-id="${CSS.escape(targetId)}"]`,
+    );
+    next?.focus();
+  }
+
+  /**
+   * Handles keyboard navigation across chart targets.
+   *
+   * - ArrowRight / ArrowDown — advance one target
+   * - ArrowLeft / ArrowUp — retreat one target
+   * - Home — jump to first target
+   * - End — jump to last target
+   * - Escape — clear focused target
+   *
+   * All navigating keys call `event.preventDefault()` so the page does not
+   * scroll during chart keyboard navigation.
+   */
+  activateByKeyboard(
+    event: KeyboardEvent,
+    rootElement: HTMLElement,
+    targets: readonly ChartTarget[],
+    keyboardEnabled: boolean,
+  ): void {
+    if (!keyboardEnabled) return;
+    const currentTargetId =
+      event.currentTarget instanceof Element
+        ? event.currentTarget.getAttribute('data-cinder-target-id')
+        : undefined;
+    const currentIndex = Math.max(
+      0,
+      targets.findIndex((target) => target.id === (currentTargetId ?? this.focusedTarget?.id)),
+    );
+    if (event.key === 'Escape') {
+      this.focusedTarget = undefined;
+      event.preventDefault();
+      return;
+    }
+    const keyOffsets: Record<string, number> = {
+      ArrowRight: 1,
+      ArrowDown: 1,
+      ArrowLeft: -1,
+      ArrowUp: -1,
+    };
+    let next: ChartTarget | undefined;
+    if (event.key === 'Home') {
+      next = targets[0];
+    } else if (event.key === 'End') {
+      next = targets.at(-1);
+    } else if (event.key in keyOffsets) {
+      const nextIndex =
+        (currentIndex + (keyOffsets[event.key] ?? 0) + targets.length) % targets.length;
+      next = targets[nextIndex] ?? this.activeTarget;
+    } else {
+      return;
+    }
+    this.focusedTarget = next;
+    event.preventDefault();
+    this.focusDomTarget(rootElement, next?.id);
+  }
+
+  /**
+   * Toggles a series in the hidden set and returns the updated array.
+   * Pure — does not mutate its argument.
+   */
+  toggleSeries(hiddenSeriesIds: string[], seriesId: string): string[] {
+    return toggleSeriesId(hiddenSeriesIds, seriesId);
+  }
+}

--- a/packages/components/src/_internal/chart/chart-interaction.test.ts
+++ b/packages/components/src/_internal/chart/chart-interaction.test.ts
@@ -189,17 +189,32 @@ describe('ChartInteraction', () => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const globals = globalThis as any;
 
-    test('returns a no-op cleanup function when ResizeObserver is unavailable', () => {
+    /**
+     * Swaps in a `ResizeObserver` value (or deletes it when `mock` is undefined)
+     * for the duration of `body`, then restores the original in a `finally` so a
+     * failing assertion can never leak the mock into later tests.
+     */
+    function withResizeObserver(mock: unknown, body: () => void): void {
+      const hadOriginal = 'ResizeObserver' in globals;
       const original = globals['ResizeObserver'];
-      delete globals['ResizeObserver'];
+      if (mock === undefined) delete globals['ResizeObserver'];
+      else globals['ResizeObserver'] = mock;
+      try {
+        body();
+      } finally {
+        if (hadOriginal) globals['ResizeObserver'] = original;
+        else delete globals['ResizeObserver'];
+      }
+    }
 
-      const interaction = new ChartInteraction();
-      const element = { ownerDocument: {} } as unknown as HTMLElement;
-      const cleanup = interaction.observeResize(element);
-      expect(typeof cleanup).toBe('function');
-      expect(() => cleanup()).not.toThrow();
-
-      globals['ResizeObserver'] = original;
+    test('returns a no-op cleanup function when ResizeObserver is unavailable', () => {
+      withResizeObserver(undefined, () => {
+        const interaction = new ChartInteraction();
+        const element = { ownerDocument: {} } as unknown as HTMLElement;
+        const cleanup = interaction.observeResize(element);
+        expect(typeof cleanup).toBe('function');
+        expect(() => cleanup()).not.toThrow();
+      });
     });
 
     test('attaches a ResizeObserver and returns a disconnect cleanup', () => {
@@ -213,18 +228,16 @@ describe('ChartInteraction', () => {
           disconnected = true;
         }
       }
-      const original = globals['ResizeObserver'];
-      globals['ResizeObserver'] = MockResizeObserver;
 
-      const interaction = new ChartInteraction();
-      const element = {} as HTMLElement;
-      const cleanup = interaction.observeResize(element);
+      withResizeObserver(MockResizeObserver, () => {
+        const interaction = new ChartInteraction();
+        const element = {} as HTMLElement;
+        const cleanup = interaction.observeResize(element);
 
-      expect(observed).toContain(element);
-      cleanup();
-      expect(disconnected).toBe(true);
-
-      globals['ResizeObserver'] = original;
+        expect(observed).toContain(element);
+        cleanup();
+        expect(disconnected).toBe(true);
+      });
     });
 
     test('updates measuredWidth from the ResizeObserver entry', () => {
@@ -237,20 +250,18 @@ describe('ChartInteraction', () => {
         observe(): void {}
         disconnect(): void {}
       }
-      const original = globals['ResizeObserver'];
-      globals['ResizeObserver'] = MockResizeObserver;
 
-      const interaction = new ChartInteraction();
-      interaction.observeResize({} as HTMLElement);
+      withResizeObserver(MockResizeObserver, () => {
+        const interaction = new ChartInteraction();
+        interaction.observeResize({} as HTMLElement);
 
-      capturedCallback?.([{ contentRect: { width: 800 } } as unknown as ResizeObserverEntry]);
-      expect(interaction.measuredWidth).toBe(800);
+        capturedCallback?.([{ contentRect: { width: 800 } } as unknown as ResizeObserverEntry]);
+        expect(interaction.measuredWidth).toBe(800);
 
-      capturedCallback?.([{ contentRect: { width: 0 } } as unknown as ResizeObserverEntry]);
-      // Width below 1 is clamped to 1 to avoid degenerate SVG viewboxes.
-      expect(interaction.measuredWidth).toBe(1);
-
-      globals['ResizeObserver'] = original;
+        capturedCallback?.([{ contentRect: { width: 0 } } as unknown as ResizeObserverEntry]);
+        // Width below 1 is clamped to 1 to avoid degenerate SVG viewboxes.
+        expect(interaction.measuredWidth).toBe(1);
+      });
     });
   });
 

--- a/packages/components/src/_internal/chart/chart-interaction.test.ts
+++ b/packages/components/src/_internal/chart/chart-interaction.test.ts
@@ -1,0 +1,276 @@
+/**
+ * Tests for ChartInteraction — the shared reactive interaction state used by
+ * LineChart, AreaChart, and BarChart.
+ *
+ * These are pure unit tests on the class methods. The DOM-level behaviors
+ * (keyboard navigation, pointer activation, focus management) are covered by
+ * per-chart component tests.
+ */
+
+import { describe, expect, test } from 'bun:test';
+
+import { ChartInteraction } from './chart-interaction.svelte.ts';
+import type { ChartTarget } from './chart-utilities.ts';
+
+function makeTarget(
+  id: string,
+  x: number,
+  y: number,
+  overrides?: Partial<ChartTarget>,
+): ChartTarget {
+  return {
+    id,
+    seriesId: 'series-a',
+    seriesLabel: 'Series A',
+    xLabel: 'Jan',
+    valueLabel: '100',
+    x,
+    y,
+    color: 'red',
+    ...overrides,
+  };
+}
+
+describe('ChartInteraction', () => {
+  describe('constructor', () => {
+    test('starts with default measuredWidth of 640', () => {
+      const interaction = new ChartInteraction();
+      expect(interaction.measuredWidth).toBe(640);
+    });
+
+    test('starts with no pointer or focused target', () => {
+      const interaction = new ChartInteraction();
+      expect(interaction.pointerTarget).toBeUndefined();
+      expect(interaction.focusedTarget).toBeUndefined();
+      expect(interaction.activeTarget).toBeUndefined();
+    });
+
+    test('accepts a static pointer axis string', () => {
+      // No assertion needed; just confirm construction does not throw
+      expect(() => new ChartInteraction({ pointerAxis: 'y' })).not.toThrow();
+    });
+
+    test('accepts a reactive pointer axis getter', () => {
+      expect(() => new ChartInteraction({ pointerAxis: () => 'x' })).not.toThrow();
+    });
+  });
+
+  describe('activeTarget derivation', () => {
+    test('is undefined when both pointer and focused targets are absent', () => {
+      const interaction = new ChartInteraction();
+      expect(interaction.activeTarget).toBeUndefined();
+    });
+
+    test('returns pointerTarget when no focused target is set', () => {
+      const interaction = new ChartInteraction();
+      const target = makeTarget('t1', 100, 50);
+      interaction.pointerTarget = target;
+      // Use id comparison — $state proxies don't preserve reference identity.
+      expect(interaction.activeTarget?.id).toBe('t1');
+    });
+
+    test('returns focusedTarget when keyboard focus is active, overriding pointer', () => {
+      const interaction = new ChartInteraction();
+      const pointer = makeTarget('pointer', 100, 50);
+      const focused = makeTarget('focused', 200, 50);
+      interaction.pointerTarget = pointer;
+      interaction.focusedTarget = focused;
+      // Keyboard focus wins — screen-reader users must not have their active
+      // target overridden by incidental pointer events.
+      expect(interaction.activeTarget?.id).toBe('focused');
+    });
+  });
+
+  describe('clearPointerTarget', () => {
+    test('clears the pointer target', () => {
+      const interaction = new ChartInteraction();
+      interaction.pointerTarget = makeTarget('t1', 100, 50);
+      interaction.clearPointerTarget();
+      expect(interaction.pointerTarget).toBeUndefined();
+    });
+
+    test('does not affect the focused target', () => {
+      const interaction = new ChartInteraction();
+      interaction.pointerTarget = makeTarget('pointer', 200, 50);
+      interaction.focusedTarget = makeTarget('focused', 100, 50);
+      interaction.clearPointerTarget();
+      // $state proxies don't preserve reference identity — check id.
+      expect(interaction.focusedTarget?.id).toBe('focused');
+    });
+  });
+
+  describe('clearStaleTargets', () => {
+    test('clears both targets when loading is true', () => {
+      const interaction = new ChartInteraction();
+      const target = makeTarget('t1', 100, 50);
+      interaction.pointerTarget = target;
+      interaction.focusedTarget = target;
+      const targets = [target];
+      interaction.clearStaleTargets(true, false, targets);
+      expect(interaction.pointerTarget).toBeUndefined();
+      expect(interaction.focusedTarget).toBeUndefined();
+    });
+
+    test('clears both targets when the model is empty', () => {
+      const interaction = new ChartInteraction();
+      const target = makeTarget('t1', 100, 50);
+      interaction.pointerTarget = target;
+      interaction.focusedTarget = target;
+      interaction.clearStaleTargets(false, true, []);
+      expect(interaction.pointerTarget).toBeUndefined();
+      expect(interaction.focusedTarget).toBeUndefined();
+    });
+
+    test('clears stale pointer target when it is no longer in the targets array', () => {
+      const interaction = new ChartInteraction();
+      const old = makeTarget('old', 100, 50);
+      const current = makeTarget('current', 200, 50);
+      interaction.pointerTarget = old;
+      interaction.clearStaleTargets(false, false, [current]);
+      expect(interaction.pointerTarget).toBeUndefined();
+    });
+
+    test('clears stale focused target when it is no longer in the targets array', () => {
+      const interaction = new ChartInteraction();
+      const old = makeTarget('old', 100, 50);
+      const current = makeTarget('current', 200, 50);
+      interaction.focusedTarget = old;
+      interaction.clearStaleTargets(false, false, [current]);
+      expect(interaction.focusedTarget).toBeUndefined();
+    });
+
+    test('preserves targets that are still in the targets array', () => {
+      const interaction = new ChartInteraction();
+      const target = makeTarget('t1', 100, 50);
+      interaction.pointerTarget = target;
+      interaction.focusedTarget = target;
+      interaction.clearStaleTargets(false, false, [target]);
+      // $state proxies don't preserve reference identity — check id.
+      expect(interaction.pointerTarget?.id).toBe('t1');
+      expect(interaction.focusedTarget?.id).toBe('t1');
+    });
+
+    test('does not clear targets when neither loading nor empty', () => {
+      const interaction = new ChartInteraction();
+      const target = makeTarget('t1', 100, 50);
+      interaction.pointerTarget = target;
+      interaction.focusedTarget = target;
+      interaction.clearStaleTargets(false, false, [target]);
+      expect(interaction.pointerTarget?.id).toBe('t1');
+      expect(interaction.focusedTarget?.id).toBe('t1');
+    });
+  });
+
+  describe('toggleSeries', () => {
+    test('adds a series id to the hidden list when it is visible', () => {
+      const interaction = new ChartInteraction();
+      const result = interaction.toggleSeries([], 'series-a');
+      expect(result).toEqual(['series-a']);
+    });
+
+    test('removes a series id from the hidden list when it is already hidden', () => {
+      const interaction = new ChartInteraction();
+      const result = interaction.toggleSeries(['series-a', 'series-b'], 'series-a');
+      expect(result).toEqual(['series-b']);
+    });
+
+    test('does not mutate the original array', () => {
+      const interaction = new ChartInteraction();
+      const original = ['series-a'];
+      const result = interaction.toggleSeries(original, 'series-a');
+      expect(result).not.toBe(original);
+      expect(original).toEqual(['series-a']);
+    });
+  });
+
+  describe('observeResize', () => {
+    // Helpers for temporarily replacing globalThis.ResizeObserver in tests.
+    // Test files may use `any` for mocking and unhappy-path fixtures per AGENTS.md.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const globals = globalThis as any;
+
+    test('returns a no-op cleanup function when ResizeObserver is unavailable', () => {
+      const original = globals['ResizeObserver'];
+      delete globals['ResizeObserver'];
+
+      const interaction = new ChartInteraction();
+      const element = { ownerDocument: {} } as unknown as HTMLElement;
+      const cleanup = interaction.observeResize(element);
+      expect(typeof cleanup).toBe('function');
+      expect(() => cleanup()).not.toThrow();
+
+      globals['ResizeObserver'] = original;
+    });
+
+    test('attaches a ResizeObserver and returns a disconnect cleanup', () => {
+      let disconnected = false;
+      const observed: unknown[] = [];
+      class MockResizeObserver {
+        observe(element: unknown): void {
+          observed.push(element);
+        }
+        disconnect(): void {
+          disconnected = true;
+        }
+      }
+      const original = globals['ResizeObserver'];
+      globals['ResizeObserver'] = MockResizeObserver;
+
+      const interaction = new ChartInteraction();
+      const element = {} as HTMLElement;
+      const cleanup = interaction.observeResize(element);
+
+      expect(observed).toContain(element);
+      cleanup();
+      expect(disconnected).toBe(true);
+
+      globals['ResizeObserver'] = original;
+    });
+
+    test('updates measuredWidth from the ResizeObserver entry', () => {
+      type ResizeObserverCallback = (entries: ResizeObserverEntry[]) => void;
+      let capturedCallback: ResizeObserverCallback | undefined;
+      class MockResizeObserver {
+        constructor(callback: ResizeObserverCallback) {
+          capturedCallback = callback;
+        }
+        observe(): void {}
+        disconnect(): void {}
+      }
+      const original = globals['ResizeObserver'];
+      globals['ResizeObserver'] = MockResizeObserver;
+
+      const interaction = new ChartInteraction();
+      interaction.observeResize({} as HTMLElement);
+
+      capturedCallback?.([{ contentRect: { width: 800 } } as unknown as ResizeObserverEntry]);
+      expect(interaction.measuredWidth).toBe(800);
+
+      capturedCallback?.([{ contentRect: { width: 0 } } as unknown as ResizeObserverEntry]);
+      // Width below 1 is clamped to 1 to avoid degenerate SVG viewboxes.
+      expect(interaction.measuredWidth).toBe(1);
+
+      globals['ResizeObserver'] = original;
+    });
+  });
+
+  describe('pointer axis option', () => {
+    test('defaults to x-axis for nearestTarget lookups', () => {
+      const interaction = new ChartInteraction();
+      // Confirm the instance exists and has no axis-related errors.
+      expect(interaction).toBeDefined();
+    });
+
+    test('reactive getter is called at activation time, not construction time', () => {
+      let callCount = 0;
+      new ChartInteraction({
+        pointerAxis: () => {
+          callCount++;
+          return 'x';
+        },
+      });
+      // Getter must NOT be called at construction — only when activateByPointer runs.
+      expect(callCount).toBe(0);
+    });
+  });
+});

--- a/packages/components/src/_internal/chart/chart-utilities.ts
+++ b/packages/components/src/_internal/chart/chart-utilities.ts
@@ -739,7 +739,7 @@ export function createBarModel(options: {
  * a linear scan when targets are empty.
  */
 export function nearestTarget(
-  targets: ChartTarget[],
+  targets: readonly ChartTarget[],
   x: number,
   y: number,
   axis: 'x' | 'y' = 'x',

--- a/packages/components/src/components/area-chart/area-chart.svelte
+++ b/packages/components/src/components/area-chart/area-chart.svelte
@@ -24,10 +24,8 @@
     dataTableClass,
     formatNumericValue,
     legendVisible,
-    nearestTarget,
-    toggleSeriesId,
-    type ChartTarget,
   } from '../../_internal/chart/chart-utilities.ts';
+  import { ChartInteraction } from '../../_internal/chart/chart-interaction.svelte.ts';
   import { classNames } from '../../utilities/class-names.ts';
   import { useId } from '../../utilities/use-id.ts';
   import type { AreaChartProps } from './area-chart.types.ts';
@@ -56,20 +54,16 @@
   const generatedId = useId('cinder-area-chart');
   const rootId = $derived(id ?? generatedId);
   const descriptionId = $derived(description ? `${rootId}-description` : undefined);
-  let measuredWidth = $state(640);
+
+  // Shared interaction state — pointer/keyboard targets and resize measurement.
+  // Pointer axis defaults to 'x', which is correct for line/area charts.
+  const interaction = new ChartInteraction();
+
   let rootElement = $state<HTMLElement>();
-  let pointerTarget = $state<ChartTarget | undefined>();
-  let focusedTarget = $state<ChartTarget | undefined>();
-  const activeTarget = $derived(focusedTarget ?? pointerTarget);
 
   $effect(() => {
-    if (!rootElement || typeof ResizeObserver === 'undefined') return;
-    const observer = new ResizeObserver(([entry]) => {
-      if (!entry) return;
-      measuredWidth = Math.max(1, Math.round(entry.contentRect.width));
-    });
-    observer.observe(rootElement);
-    return () => observer.disconnect();
+    if (!rootElement) return;
+    return interaction.observeResize(rootElement);
   });
 
   const model = $derived(
@@ -77,7 +71,7 @@
       componentId: 'area-chart',
       series,
       hiddenSeriesIds,
-      width: measuredWidth,
+      width: interaction.measuredWidth,
       height,
       xAxis,
       yAxis,
@@ -103,78 +97,9 @@
     );
   });
 
-  function includesTarget(candidate: ChartTarget | undefined): boolean {
-    return Boolean(candidate && model.targets.some((target) => target.id === candidate.id));
-  }
-
   $effect(() => {
-    if (loading || model.empty) {
-      pointerTarget = undefined;
-      focusedTarget = undefined;
-      return;
-    }
-    if (!includesTarget(pointerTarget)) pointerTarget = undefined;
-    if (!includesTarget(focusedTarget)) focusedTarget = undefined;
+    interaction.clearStaleTargets(loading, model.empty, model.targets);
   });
-
-  function toggleSeries(seriesId: string): void {
-    hiddenSeriesIds = toggleSeriesId(hiddenSeriesIds, seriesId);
-  }
-
-  function activateByPointer(event: PointerEvent): void {
-    if (!(event.currentTarget instanceof SVGRectElement)) return;
-    const bounds = event.currentTarget.getBoundingClientRect();
-    pointerTarget = nearestTarget(
-      model.targets,
-      event.clientX - bounds.left,
-      event.clientY - bounds.top,
-    );
-  }
-
-  function focusTarget(targetId: string | undefined): void {
-    if (!rootElement || !targetId) return;
-    // Move DOM focus so focus-visible, aria-describedby, and the focused
-    // node's aria-label all attach to the new target, not the previous one.
-    const next = rootElement.querySelector<SVGGraphicsElement>(
-      `[data-cinder-target-id="${CSS.escape(targetId)}"]`,
-    );
-    next?.focus();
-  }
-
-  function activateByKeyboard(event: KeyboardEvent): void {
-    if (!keyboardEnabled) return;
-    const currentTargetId =
-      event.currentTarget instanceof Element
-        ? event.currentTarget.getAttribute('data-cinder-target-id')
-        : undefined;
-    const currentIndex = Math.max(
-      0,
-      model.targets.findIndex((target) => target.id === (currentTargetId ?? focusedTarget?.id)),
-    );
-    if (event.key === 'Escape') {
-      focusedTarget = undefined;
-      event.preventDefault();
-      return;
-    }
-    const offsets: Record<string, number> = {
-      ArrowRight: 1,
-      ArrowDown: 1,
-      ArrowLeft: -1,
-      ArrowUp: -1,
-    };
-    let next: ChartTarget | undefined;
-    if (event.key === 'Home') next = model.targets[0];
-    else if (event.key === 'End') next = model.targets.at(-1);
-    else if (event.key in offsets)
-      next =
-        model.targets[
-          (currentIndex + (offsets[event.key] ?? 0) + model.targets.length) % model.targets.length
-        ] ?? activeTarget;
-    else return;
-    focusedTarget = next;
-    event.preventDefault();
-    focusTarget(next?.id);
-  }
 </script>
 
 <figure
@@ -195,7 +120,7 @@
         <button
           type="button"
           aria-pressed={!hiddenSeriesIds.includes(item.id)}
-          onclick={() => toggleSeries(item.id)}
+          onclick={() => (hiddenSeriesIds = interaction.toggleSeries(hiddenSeriesIds, item.id))}
           ><span style:background={item.color ?? chartPaletteColor(index)}
           ></span>{item.label}</button
         >
@@ -217,7 +142,7 @@
       </div>
     {/if}
     <svg
-      viewBox={`0 0 ${measuredWidth} ${height}`}
+      viewBox={`0 0 ${interaction.measuredWidth} ${height}`}
       aria-hidden={loading || model.empty ? 'true' : undefined}
       aria-labelledby={!loading && !model.empty ? `${rootId}-svg-title` : undefined}
     >
@@ -256,6 +181,7 @@
             text-anchor="middle">{tick.label}</text
           >
         {/each}
+        <!-- Series-specific rendering: filled area paths + stroke line paths. -->
         {#each model.normalizedSeries as item}
           {#if !item.hidden && item.areaPath}
             <path
@@ -274,25 +200,29 @@
             />
           {/if}
         {/each}
-        {#if activeTarget}<line
+        {#if interaction.activeTarget}
+          <!-- Vertical crosshair — area charts always use a vertical indicator. -->
+          <line
             class="cinder-area-chart__crosshair"
-            x1={activeTarget.x}
-            x2={activeTarget.x}
+            x1={interaction.activeTarget.x}
+            x2={interaction.activeTarget.x}
             y1="0"
             y2={model.geometry.plotHeight}
             aria-hidden="true"
-          />{/if}
+          />
+        {/if}
         {#if model.targets.length > 0}
           <rect
             class="cinder-area-chart__hit-surface"
             role="presentation"
             width={model.geometry.plotWidth}
             height={model.geometry.plotHeight}
-            onpointermove={activateByPointer}
-            onpointerleave={() => (pointerTarget = undefined)}
+            onpointermove={(event) => interaction.activateByPointer(event, model.targets)}
+            onpointerleave={() => interaction.clearPointerTarget()}
           />
           {#if keyboardEnabled}
             {#each model.targets as target (target.id)}
+              <!-- Area charts use circle focus targets centered on the data point. -->
               <circle
                 class="cinder-area-chart__focus-target"
                 cx={target.x}
@@ -302,25 +232,33 @@
                 role="button"
                 data-cinder-target-id={target.id}
                 aria-label={`${target.seriesLabel}, ${target.xLabel}, ${target.valueLabel}`}
-                aria-describedby={activeTarget?.id === target.id ? `${rootId}-tooltip` : undefined}
-                onfocus={() => (focusedTarget = target)}
-                onblur={() => (focusedTarget = undefined)}
-                onkeydown={activateByKeyboard}
+                aria-describedby={interaction.activeTarget?.id === target.id
+                  ? `${rootId}-tooltip`
+                  : undefined}
+                onfocus={() => (interaction.focusedTarget = target)}
+                onblur={() => (interaction.focusedTarget = undefined)}
+                onkeydown={(event) =>
+                  interaction.activateByKeyboard(
+                    event,
+                    rootElement!,
+                    model.targets,
+                    keyboardEnabled,
+                  )}
               />
             {/each}
           {/if}
         {/if}
       </g>
     </svg>
-    {#if activeTarget}<div
+    {#if interaction.activeTarget}<div
         id="{rootId}-tooltip"
         role="tooltip"
         class="cinder-area-chart__tooltip"
-        style:left="{model.geometry.marginLeft + activeTarget.x}px"
-        style:top="{model.geometry.marginTop + activeTarget.y}px"
+        style:left="{model.geometry.marginLeft + interaction.activeTarget.x}px"
+        style:top="{model.geometry.marginTop + interaction.activeTarget.y}px"
       >
-        <strong>{activeTarget.seriesLabel}</strong><span
-          >{activeTarget.xLabel}: {activeTarget.valueLabel}</span
+        <strong>{interaction.activeTarget.seriesLabel}</strong><span
+          >{interaction.activeTarget.xLabel}: {interaction.activeTarget.valueLabel}</span
         >
       </div>{/if}
   </div>
@@ -347,7 +285,7 @@
         <button
           type="button"
           aria-pressed={!hiddenSeriesIds.includes(item.id)}
-          onclick={() => toggleSeries(item.id)}
+          onclick={() => (hiddenSeriesIds = interaction.toggleSeries(hiddenSeriesIds, item.id))}
           ><span style:background={item.color ?? chartPaletteColor(index)}
           ></span>{item.label}</button
         >

--- a/packages/components/src/components/bar-chart/bar-chart.svelte
+++ b/packages/components/src/components/bar-chart/bar-chart.svelte
@@ -24,10 +24,8 @@
     dataTableClass,
     formatNumericValue,
     legendVisible,
-    nearestTarget,
-    toggleSeriesId,
-    type ChartTarget,
   } from '../../_internal/chart/chart-utilities.ts';
+  import { ChartInteraction } from '../../_internal/chart/chart-interaction.svelte.ts';
   import { classNames } from '../../utilities/class-names.ts';
   import { useId } from '../../utilities/use-id.ts';
   import type { BarChartProps } from './bar-chart.types.ts';
@@ -59,20 +57,21 @@
   const generatedId = useId('cinder-bar-chart');
   const rootId = $derived(id ?? generatedId);
   const descriptionId = $derived(description ? `${rootId}-description` : undefined);
-  let measuredWidth = $state(640);
+
+  // Bar chart interaction: pointer axis switches with orientation.
+  // Vertical bars snap to x-buckets; horizontal bars snap to y-buckets.
+  // A reactive getter is passed so the same instance follows orientation
+  // changes without resetting measuredWidth — intentionally different from
+  // line/area charts which always use pointer axis 'x'.
+  const interaction = new ChartInteraction({
+    pointerAxis: () => (orientation === 'vertical' ? 'x' : 'y'),
+  });
+
   let rootElement = $state<HTMLElement>();
-  let pointerTarget = $state<ChartTarget | undefined>();
-  let focusedTarget = $state<ChartTarget | undefined>();
-  const activeTarget = $derived(focusedTarget ?? pointerTarget);
 
   $effect(() => {
-    if (!rootElement || typeof ResizeObserver === 'undefined') return;
-    const observer = new ResizeObserver(([entry]) => {
-      if (!entry) return;
-      measuredWidth = Math.max(1, Math.round(entry.contentRect.width));
-    });
-    observer.observe(rootElement);
-    return () => observer.disconnect();
+    if (!rootElement) return;
+    return interaction.observeResize(rootElement);
   });
 
   const model = $derived(
@@ -81,7 +80,7 @@
       categoryKey,
       series,
       hiddenSeriesIds,
-      width: measuredWidth,
+      width: interaction.measuredWidth,
       height,
       orientation,
       mode,
@@ -108,79 +107,9 @@
     );
   });
 
-  function includesTarget(candidate: ChartTarget | undefined): boolean {
-    return Boolean(candidate && model.targets.some((target) => target.id === candidate.id));
-  }
-
   $effect(() => {
-    if (loading || model.empty) {
-      pointerTarget = undefined;
-      focusedTarget = undefined;
-      return;
-    }
-    if (!includesTarget(pointerTarget)) pointerTarget = undefined;
-    if (!includesTarget(focusedTarget)) focusedTarget = undefined;
+    interaction.clearStaleTargets(loading, model.empty, model.targets);
   });
-
-  function toggleSeries(seriesId: string): void {
-    hiddenSeriesIds = toggleSeriesId(hiddenSeriesIds, seriesId);
-  }
-
-  function activateByPointer(event: PointerEvent): void {
-    if (!(event.currentTarget instanceof SVGRectElement)) return;
-    const bounds = event.currentTarget.getBoundingClientRect();
-    pointerTarget = nearestTarget(
-      model.targets,
-      event.clientX - bounds.left,
-      event.clientY - bounds.top,
-      orientation === 'vertical' ? 'x' : 'y',
-    );
-  }
-
-  function focusTarget(targetId: string | undefined): void {
-    if (!rootElement || !targetId) return;
-    // Move DOM focus so :focus-visible, aria-describedby, and the focused
-    // node's aria-label all attach to the new target, not the previous one.
-    const next = rootElement.querySelector<SVGGraphicsElement>(
-      `[data-cinder-target-id="${CSS.escape(targetId)}"]`,
-    );
-    next?.focus();
-  }
-
-  function activateByKeyboard(event: KeyboardEvent): void {
-    if (!keyboardEnabled) return;
-    const currentTargetId =
-      event.currentTarget instanceof Element
-        ? event.currentTarget.getAttribute('data-cinder-target-id')
-        : undefined;
-    const currentIndex = Math.max(
-      0,
-      model.targets.findIndex((target) => target.id === (currentTargetId ?? focusedTarget?.id)),
-    );
-    if (event.key === 'Escape') {
-      focusedTarget = undefined;
-      event.preventDefault();
-      return;
-    }
-    const offsets: Record<string, number> = {
-      ArrowRight: 1,
-      ArrowDown: 1,
-      ArrowLeft: -1,
-      ArrowUp: -1,
-    };
-    let next: ChartTarget | undefined;
-    if (event.key === 'Home') next = model.targets[0];
-    else if (event.key === 'End') next = model.targets.at(-1);
-    else if (event.key in offsets)
-      next =
-        model.targets[
-          (currentIndex + (offsets[event.key] ?? 0) + model.targets.length) % model.targets.length
-        ] ?? activeTarget;
-    else return;
-    focusedTarget = next;
-    event.preventDefault();
-    focusTarget(next?.id);
-  }
 </script>
 
 <figure
@@ -202,7 +131,7 @@
         <button
           type="button"
           aria-pressed={!hiddenSeriesIds.includes(item.id)}
-          onclick={() => toggleSeries(item.id)}
+          onclick={() => (hiddenSeriesIds = interaction.toggleSeries(hiddenSeriesIds, item.id))}
           ><span style:background={item.color ?? chartPaletteColor(index)}
           ></span>{item.label}</button
         >
@@ -224,7 +153,7 @@
       </div>
     {/if}
     <svg
-      viewBox={`0 0 ${measuredWidth} ${height}`}
+      viewBox={`0 0 ${interaction.measuredWidth} ${height}`}
       aria-hidden={loading || model.empty ? 'true' : undefined}
       aria-labelledby={!loading && !model.empty ? `${rootId}-svg-title` : undefined}
     >
@@ -233,6 +162,12 @@
       {/if}
       <g transform={`translate(${model.geometry.marginLeft}, ${model.geometry.marginTop})`}>
         {#each model.yTicks as tick, index}
+          <!--
+            Bar chart tick positions depend on orientation:
+            - Vertical: y-axis labels appear left of the chart (same as line/area).
+            - Horizontal: value labels appear along the bottom x-axis instead.
+            This is intentionally different from line/area chart tick rendering.
+          -->
           <text
             class="cinder-bar-chart__tick-label"
             x={orientation === 'vertical'
@@ -251,6 +186,7 @@
             })}</text
           >
         {/each}
+        <!-- Series-specific rendering: rectangular bars. -->
         {#each model.bars as bar}
           <rect
             class="cinder-bar-chart__bar"
@@ -265,6 +201,11 @@
           />
         {/each}
         {#each model.categoryTicks as tick}
+          <!--
+            Category axis labels differ by orientation:
+            - Vertical: labels appear below bars (middle-anchored x, no baseline).
+            - Horizontal: labels appear left of bars (end-anchored x, middle baseline).
+          -->
           <text
             class="cinder-bar-chart__tick-label"
             x={tick.x}
@@ -273,12 +214,19 @@
             dominant-baseline={orientation === 'vertical' ? undefined : 'middle'}>{tick.label}</text
           >
         {/each}
-        {#if activeTarget}
+        {#if interaction.activeTarget}
+          <!--
+            Bar chart crosshair direction depends on orientation:
+            - Vertical bars: vertical crosshair through the active bar's x position.
+            - Horizontal bars: horizontal crosshair through the active bar's y position.
+            This is intentionally different from line/area charts which always draw a
+            vertical crosshair.
+          -->
           {#if orientation === 'vertical'}
             <line
               class="cinder-bar-chart__crosshair"
-              x1={activeTarget.x}
-              x2={activeTarget.x}
+              x1={interaction.activeTarget.x}
+              x2={interaction.activeTarget.x}
               y1="0"
               y2={model.geometry.plotHeight}
               aria-hidden="true"
@@ -288,8 +236,8 @@
               class="cinder-bar-chart__crosshair"
               x1="0"
               x2={model.geometry.plotWidth}
-              y1={activeTarget.y}
-              y2={activeTarget.y}
+              y1={interaction.activeTarget.y}
+              y2={interaction.activeTarget.y}
               aria-hidden="true"
             />
           {/if}
@@ -300,11 +248,16 @@
             role="presentation"
             width={model.geometry.plotWidth}
             height={model.geometry.plotHeight}
-            onpointermove={activateByPointer}
-            onpointerleave={() => (pointerTarget = undefined)}
+            onpointermove={(event) => interaction.activateByPointer(event, model.targets)}
+            onpointerleave={() => interaction.clearPointerTarget()}
           />
           {#if keyboardEnabled}
             {#each model.targets as target (target.id)}
+              <!--
+                Bar chart uses rect focus targets centered on each bar, not circle targets.
+                Circles are suitable for point-based charts (line/area); rects match the
+                bar geometry and produce better hit areas for bar-shaped data points.
+              -->
               <rect
                 class="cinder-bar-chart__focus-target"
                 x={(target.x ?? 0) - 6}
@@ -315,25 +268,33 @@
                 role="button"
                 data-cinder-target-id={target.id}
                 aria-label={`${target.seriesLabel}, ${target.xLabel}, ${target.valueLabel}`}
-                aria-describedby={activeTarget?.id === target.id ? `${rootId}-tooltip` : undefined}
-                onfocus={() => (focusedTarget = target)}
-                onblur={() => (focusedTarget = undefined)}
-                onkeydown={activateByKeyboard}
+                aria-describedby={interaction.activeTarget?.id === target.id
+                  ? `${rootId}-tooltip`
+                  : undefined}
+                onfocus={() => (interaction.focusedTarget = target)}
+                onblur={() => (interaction.focusedTarget = undefined)}
+                onkeydown={(event) =>
+                  interaction.activateByKeyboard(
+                    event,
+                    rootElement!,
+                    model.targets,
+                    keyboardEnabled,
+                  )}
               />
             {/each}
           {/if}
         {/if}
       </g>
     </svg>
-    {#if activeTarget}<div
+    {#if interaction.activeTarget}<div
         id="{rootId}-tooltip"
         role="tooltip"
         class="cinder-bar-chart__tooltip"
-        style:left="{model.geometry.marginLeft + activeTarget.x}px"
-        style:top="{model.geometry.marginTop + activeTarget.y}px"
+        style:left="{model.geometry.marginLeft + interaction.activeTarget.x}px"
+        style:top="{model.geometry.marginTop + interaction.activeTarget.y}px"
       >
-        <strong>{activeTarget.seriesLabel}</strong><span
-          >{activeTarget.xLabel}: {activeTarget.valueLabel}</span
+        <strong>{interaction.activeTarget.seriesLabel}</strong><span
+          >{interaction.activeTarget.xLabel}: {interaction.activeTarget.valueLabel}</span
         >
       </div>{/if}
   </div>
@@ -341,6 +302,11 @@
       Use the data table to inspect this chart with a keyboard.
     </p>{/if}
   {#if hasDataTable}
+    <!--
+      Bar chart data table uses Category/Series/Value columns rather than
+      Series/X/Value (line/area). This reflects that bar charts are category-
+      primary: each row is one category, with each series as a column value.
+    -->
     <table class={dataTableClass(dataTableVisibility)} aria-describedby={guidanceId}>
       <caption>{dataTableCaption ?? label}</caption>
       <thead
@@ -366,7 +332,7 @@
         <button
           type="button"
           aria-pressed={!hiddenSeriesIds.includes(item.id)}
-          onclick={() => toggleSeries(item.id)}
+          onclick={() => (hiddenSeriesIds = interaction.toggleSeries(hiddenSeriesIds, item.id))}
           ><span style:background={item.color ?? chartPaletteColor(index)}
           ></span>{item.label}</button
         >

--- a/packages/components/src/components/line-chart/line-chart.svelte
+++ b/packages/components/src/components/line-chart/line-chart.svelte
@@ -24,10 +24,8 @@
     dataTableClass,
     formatNumericValue,
     legendVisible,
-    nearestTarget,
-    toggleSeriesId,
-    type ChartTarget,
   } from '../../_internal/chart/chart-utilities.ts';
+  import { ChartInteraction } from '../../_internal/chart/chart-interaction.svelte.ts';
   import { classNames } from '../../utilities/class-names.ts';
   import { useId } from '../../utilities/use-id.ts';
   import type { LineChartProps } from './line-chart.types.ts';
@@ -55,20 +53,16 @@
   const generatedId = useId('cinder-line-chart');
   const rootId = $derived(id ?? generatedId);
   const descriptionId = $derived(description ? `${rootId}-description` : undefined);
-  let measuredWidth = $state(640);
+
+  // Shared interaction state — pointer/keyboard targets and resize measurement.
+  // Pointer axis defaults to 'x', which is correct for line/area charts.
+  const interaction = new ChartInteraction();
+
   let rootElement = $state<HTMLElement>();
-  let pointerTarget = $state<ChartTarget | undefined>();
-  let focusedTarget = $state<ChartTarget | undefined>();
-  const activeTarget = $derived(focusedTarget ?? pointerTarget);
 
   $effect(() => {
-    if (!rootElement || typeof ResizeObserver === 'undefined') return;
-    const observer = new ResizeObserver(([entry]) => {
-      if (!entry) return;
-      measuredWidth = Math.max(1, Math.round(entry.contentRect.width));
-    });
-    observer.observe(rootElement);
-    return () => observer.disconnect();
+    if (!rootElement) return;
+    return interaction.observeResize(rootElement);
   });
 
   const model = $derived(
@@ -76,7 +70,7 @@
       componentId: 'line-chart',
       series,
       hiddenSeriesIds,
-      width: measuredWidth,
+      width: interaction.measuredWidth,
       height,
       xAxis,
       yAxis,
@@ -91,7 +85,7 @@
       ? `${rootId}-table-guidance`
       : undefined,
   );
-  const activeTargetId = $derived(activeTarget ? `${rootId}-active-target` : undefined);
+  const activeTargetId = $derived(interaction.activeTarget ? `${rootId}-active-target` : undefined);
 
   $effect(() => {
     assertValidNonNegativeInteger(
@@ -102,77 +96,9 @@
     );
   });
 
-  function includesTarget(candidate: ChartTarget | undefined): boolean {
-    return Boolean(candidate && model.targets.some((target) => target.id === candidate.id));
-  }
-
   $effect(() => {
-    if (loading || model.empty) {
-      pointerTarget = undefined;
-      focusedTarget = undefined;
-      return;
-    }
-    if (!includesTarget(pointerTarget)) pointerTarget = undefined;
-    if (!includesTarget(focusedTarget)) focusedTarget = undefined;
+    interaction.clearStaleTargets(loading, model.empty, model.targets);
   });
-
-  function toggleSeries(seriesId: string): void {
-    hiddenSeriesIds = toggleSeriesId(hiddenSeriesIds, seriesId);
-  }
-
-  function activateByPointer(event: PointerEvent): void {
-    if (!(event.currentTarget instanceof SVGRectElement)) return;
-    const bounds = event.currentTarget.getBoundingClientRect();
-    pointerTarget = nearestTarget(
-      model.targets,
-      event.clientX - bounds.left,
-      event.clientY - bounds.top,
-    );
-  }
-
-  function focusTarget(targetId: string | undefined): void {
-    if (!rootElement || !targetId) return;
-    // Move DOM focus so focus-visible, aria-describedby, and the focused
-    // node's aria-label all attach to the new target, not the previous one.
-    const next = rootElement.querySelector<SVGGraphicsElement>(
-      `[data-cinder-target-id="${CSS.escape(targetId)}"]`,
-    );
-    next?.focus();
-  }
-
-  function activateByKeyboard(event: KeyboardEvent): void {
-    if (!keyboardEnabled) return;
-    const currentTargetId =
-      event.currentTarget instanceof Element
-        ? event.currentTarget.getAttribute('data-cinder-target-id')
-        : undefined;
-    const currentIndex = Math.max(
-      0,
-      model.targets.findIndex((target) => target.id === (currentTargetId ?? focusedTarget?.id)),
-    );
-    if (event.key === 'Escape') {
-      focusedTarget = undefined;
-      event.preventDefault();
-      return;
-    }
-    const keyOffsets: Record<string, number> = {
-      ArrowRight: 1,
-      ArrowDown: 1,
-      ArrowLeft: -1,
-      ArrowUp: -1,
-    };
-    let next: ChartTarget | undefined;
-    if (event.key === 'Home') next = model.targets[0];
-    else if (event.key === 'End') next = model.targets.at(-1);
-    else if (event.key in keyOffsets) {
-      const nextIndex =
-        (currentIndex + (keyOffsets[event.key] ?? 0) + model.targets.length) % model.targets.length;
-      next = model.targets[nextIndex] ?? activeTarget;
-    } else return;
-    focusedTarget = next;
-    event.preventDefault();
-    focusTarget(next?.id);
-  }
 </script>
 
 <figure
@@ -193,7 +119,7 @@
         <button
           type="button"
           aria-pressed={!hiddenSeriesIds.includes(item.id)}
-          onclick={() => toggleSeries(item.id)}
+          onclick={() => (hiddenSeriesIds = interaction.toggleSeries(hiddenSeriesIds, item.id))}
         >
           <span style:background={item.color ?? chartPaletteColor(index)}></span>{item.label}
         </button>
@@ -216,7 +142,7 @@
       </div>
     {/if}
     <svg
-      viewBox={`0 0 ${measuredWidth} ${height}`}
+      viewBox={`0 0 ${interaction.measuredWidth} ${height}`}
       aria-hidden={loading || model.empty ? 'true' : undefined}
       aria-labelledby={!loading && !model.empty ? `${rootId}-svg-title` : undefined}
     >
@@ -255,6 +181,7 @@
             text-anchor="middle">{tick.label}</text
           >
         {/each}
+        <!-- Series-specific rendering: connected line paths + data points. -->
         {#each model.normalizedSeries as item}
           {#if !item.hidden && item.path}
             <path
@@ -279,11 +206,12 @@
             {/each}
           {/if}
         {/each}
-        {#if activeTarget}
+        {#if interaction.activeTarget}
+          <!-- Vertical crosshair — line charts always use a vertical indicator. -->
           <line
             class="cinder-line-chart__crosshair"
-            x1={activeTarget.x}
-            x2={activeTarget.x}
+            x1={interaction.activeTarget.x}
+            x2={interaction.activeTarget.x}
             y1="0"
             y2={model.geometry.plotHeight}
             aria-hidden="true"
@@ -295,11 +223,12 @@
             role="presentation"
             width={model.geometry.plotWidth}
             height={model.geometry.plotHeight}
-            onpointermove={activateByPointer}
-            onpointerleave={() => (pointerTarget = undefined)}
+            onpointermove={(event) => interaction.activateByPointer(event, model.targets)}
+            onpointerleave={() => interaction.clearPointerTarget()}
           />
           {#if keyboardEnabled}
             {#each model.targets as target (target.id)}
+              <!-- Line charts use circle focus targets centered on the data point. -->
               <circle
                 class="cinder-line-chart__focus-target"
                 cx={target.x}
@@ -309,26 +238,34 @@
                 role="button"
                 data-cinder-target-id={target.id}
                 aria-label={`${target.seriesLabel}, ${target.xLabel}, ${target.valueLabel}`}
-                aria-describedby={activeTarget?.id === target.id ? `${rootId}-tooltip` : undefined}
-                onfocus={() => (focusedTarget = target)}
-                onblur={() => (focusedTarget = undefined)}
-                onkeydown={activateByKeyboard}
+                aria-describedby={interaction.activeTarget?.id === target.id
+                  ? `${rootId}-tooltip`
+                  : undefined}
+                onfocus={() => (interaction.focusedTarget = target)}
+                onblur={() => (interaction.focusedTarget = undefined)}
+                onkeydown={(event) =>
+                  interaction.activateByKeyboard(
+                    event,
+                    rootElement!,
+                    model.targets,
+                    keyboardEnabled,
+                  )}
               />
             {/each}
           {/if}
         {/if}
       </g>
     </svg>
-    {#if activeTarget}
+    {#if interaction.activeTarget}
       <div
         id="{rootId}-tooltip"
         role="tooltip"
         class="cinder-line-chart__tooltip"
-        style:left="{model.geometry.marginLeft + activeTarget.x}px"
-        style:top="{model.geometry.marginTop + activeTarget.y}px"
+        style:left="{model.geometry.marginLeft + interaction.activeTarget.x}px"
+        style:top="{model.geometry.marginTop + interaction.activeTarget.y}px"
       >
-        <strong>{activeTarget.seriesLabel}</strong>
-        <span>{activeTarget.xLabel}: {activeTarget.valueLabel}</span>
+        <strong>{interaction.activeTarget.seriesLabel}</strong>
+        <span>{interaction.activeTarget.xLabel}: {interaction.activeTarget.valueLabel}</span>
       </div>
     {/if}
   </div>
@@ -347,7 +284,7 @@
       >
       <tbody>
         {#each model.tableRows as row}
-          <tr id={activeTarget?.id === row.id ? activeTargetId : undefined}
+          <tr id={interaction.activeTarget?.id === row.id ? activeTargetId : undefined}
             ><th scope="row">{row.seriesLabel}</th><td>{row.xLabel}</td><td>{row.valueLabel}</td
             ></tr
           >
@@ -362,7 +299,7 @@
         <button
           type="button"
           aria-pressed={!hiddenSeriesIds.includes(item.id)}
-          onclick={() => toggleSeries(item.id)}
+          onclick={() => (hiddenSeriesIds = interaction.toggleSeries(hiddenSeriesIds, item.id))}
         >
           <span style:background={item.color ?? chartPaletteColor(index)}></span>{item.label}
         </button>


### PR DESCRIPTION
## Summary

LineChart, AreaChart, and BarChart duplicated their entire shell/interaction layer word-for-word. This extracts that into a shared `ChartInteraction` class (`src/_internal/chart/chart-interaction.svelte.ts`) while keeping all series-specific rendering in each component.

**Extracted (shared):** `measuredWidth` + `ResizeObserver`, `pointerTarget`/`focusedTarget` state and the `activeTarget` derivation (keyboard focus beats pointer — preserving the screen-reader guarantee), stale-target cleanup, pointer/keyboard activation (arrow/Home/End/Escape), DOM focus movement, and series toggling. The pointer axis is configurable via a getter so BarChart follows its `orientation` reactively without re-instantiating.

**Kept series-specific (with comments):** line path + point circles, area fill, bars; orientation-dependent ticks and crosshair; per-chart data-table column structure.

Also widened `nearestTarget()` to accept a `readonly ChartTarget[]` (it only reads) to drop an unsafe type assertion at the new call site.

Public chart APIs, exports, and the manifest are unchanged (non-regen).

## Review committee

Pre-reviewed by Codex (gpt-5.4, xhigh) + author line-by-line, with a focus on **behavioral drift** (the core refactor risk). Codex APPROVED — verified `activeTarget` derivation, pointer-axis wiring, stale-target/keyboard/focus semantics, and series-toggle immutability all match the removed inline implementations, with no series-specific logic wrongly pulled into the shared class.

## Test plan

- [x] `bun run --filter=cinder test -- line-chart area-chart bar-chart chart` — 129 pass (incl. 23 new `ChartInteraction` unit tests)
- [x] `bun run --filter=cinder typecheck` / `lint` (strict 144-rule lint-staged pass) / `components:check` — clean (no regen drift)
- [x] full-package pre-commit + pre-push green

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Centralizes accessibility-sensitive pointer, keyboard, and focus behavior; regression risk is mitigated by preserved semantics and new unit tests, but behavior should be verified in chart component tests.
> 
> **Overview**
> **Line, area, and bar charts** no longer duplicate resize measurement, pointer/keyboard target state, stale-target cleanup, hit-surface handlers, legend toggling, and DOM focus logic. That behavior lives in a new internal **`ChartInteraction`** class; each chart keeps its own rendering (paths, areas, bars, crosshair orientation, focus-target shape).
> 
> **`activeTarget`** still prefers keyboard focus over pointer. **Bar charts** pass a reactive **`pointerAxis`** getter so horizontal vs vertical snapping matches orientation without recreating the helper. **`nearestTarget`** now takes **`readonly ChartTarget[]`**.
> 
> Adds **unit tests** for `ChartInteraction`; chart APIs and exports are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit db88ddcc2a36ff442396cd94ad2848b431108b95. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->