### PR TITLE
fix(components): TimePicker shows one picker affordance, not a duplicate native icon (908e3c60)

### DIFF
--- a/packages/components/src/components/time-picker/README.md
+++ b/packages/components/src/components/time-picker/README.md
@@ -10,7 +10,7 @@ A plain `<input type="time">` works, but its native picker surface differs signi
 - **Consistent picker surface** — the scroll-list popover behaves identically across browsers, with the same keyboard navigation, hour-cycle display, and optional seconds column.
 - **Locale-aware hour cycles** — the `locale` and `hourCycle` props resolve the correct h11/h12/h23/h24 cycle for any locale, whereas the native picker always uses the OS locale.
 
-TimePicker intentionally hides the browser's native picker indicator (the `::calendar-picker-indicator` pseudo-element) so only the Cinder toggle button is visible. The `<input type="time">` element stays in place as the value source: it still accepts direct keyboard entry, enforces `min`/`max`/`step`, participates in form submission, and surfaces native validation. Only the redundant visual affordance for the native picker surface is suppressed.
+TimePicker intentionally hides the browser's native picker indicator (the `::-webkit-calendar-picker-indicator` pseudo-element, present in Chromium and WebKit) so only the Cinder toggle button is visible. The `<input type="time">` element stays in place as the value source: it still accepts direct keyboard entry, enforces `min`/`max`/`step`, participates in form submission, and surfaces native validation. Only the redundant visual affordance for the native picker surface is suppressed.
 
 ## Usage
 

--- a/packages/components/src/components/time-picker/README.md
+++ b/packages/components/src/components/time-picker/README.md
@@ -2,6 +2,16 @@
 
 A TimePicker component for entering a time with an optional scroll-list popover.
 
+## Why TimePicker instead of `<input type="time">`?
+
+A plain `<input type="time">` works, but its native picker surface differs significantly across browsers and operating systems — Chrome on Android shows a clock face, Safari on macOS shows a draggable column, Firefox shows a dropdown. TimePicker gives you:
+
+- **Consistent styling** — the input and toggle share the Cinder design token system on every platform.
+- **Consistent picker surface** — the scroll-list popover behaves identically across browsers, with the same keyboard navigation, hour-cycle display, and optional seconds column.
+- **Locale-aware hour cycles** — the `locale` and `hourCycle` props resolve the correct h11/h12/h23/h24 cycle for any locale, whereas the native picker always uses the OS locale.
+
+TimePicker intentionally hides the browser's native picker indicator (the `::calendar-picker-indicator` pseudo-element) so only the Cinder toggle button is visible. The `<input type="time">` element stays in place as the value source: it still accepts direct keyboard entry, enforces `min`/`max`/`step`, participates in form submission, and surfaces native validation. Only the redundant visual affordance for the native picker surface is suppressed.
+
 ## Usage
 
 ```svelte

--- a/packages/components/src/components/time-picker/time-picker.a11y.md
+++ b/packages/components/src/components/time-picker/time-picker.a11y.md
@@ -4,3 +4,22 @@
 - Each scroll column uses `role="listbox"` with `role="option"` children, and the AM/PM chooser uses `role="radiogroup"`.
 - Arrow keys move within a column, `Tab` advances between columns, and `Escape` closes the popover through the shared popover primitive.
 - When used inside `FormField`, the component composes the field-provided `aria-describedby`, `required`, and `disabled` state instead of duplicating label wiring.
+
+## Native indicator suppression
+
+Chrome and other WebKit-based browsers render a clock icon inside `<input type="time">` as a `::calendar-picker-indicator` pseudo-element that opens the browser's own native time picker. TimePicker intentionally suppresses this indicator with:
+
+```css
+.cinder-time-picker__input::-webkit-calendar-picker-indicator {
+  display: none;
+}
+```
+
+This hides the browser's affordance so only the Cinder toggle button is visible, giving users one coherent entry point to the scroll-list popover. The `<input type="time">` element itself is _not_ replaced — it continues to:
+
+- Accept keyboard-typed values directly.
+- Enforce `min`, `max`, and `step` constraints natively.
+- Participate in form submission and reset.
+- Expose native validation messages.
+
+The Cinder toggle opens the scroll-list popover, which exposes the same range of values through a keyboard-navigable listbox. Both entry paths write to the same underlying `<input>`, so they are always in sync.

--- a/packages/components/src/components/time-picker/time-picker.a11y.md
+++ b/packages/components/src/components/time-picker/time-picker.a11y.md
@@ -7,7 +7,7 @@
 
 ## Native indicator suppression
 
-Chrome and other WebKit-based browsers render a clock icon inside `<input type="time">` as a `::calendar-picker-indicator` pseudo-element that opens the browser's own native time picker. TimePicker intentionally suppresses this indicator with:
+Chromium and WebKit browsers render a clock icon inside `<input type="time">` as a `::-webkit-calendar-picker-indicator` pseudo-element that opens the browser's own native time picker. Firefox does not expose this pseudo-element. TimePicker intentionally suppresses this indicator with:
 
 ```css
 .cinder-time-picker__input::-webkit-calendar-picker-indicator {

--- a/packages/components/src/components/time-picker/time-picker.css
+++ b/packages/components/src/components/time-picker/time-picker.css
@@ -21,6 +21,16 @@
     padding-inline-end: calc(var(--cinder-space-10) + var(--cinder-space-2));
   }
 
+  /*
+   * Suppress the browser's native calendar-picker indicator so only the Cinder
+   * toggle button is visible. The <input type="time"> stays the source of truth
+   * for value, min/max/step, typed entry, and form participation — only the
+   * redundant visual affordance for the native picker is hidden.
+   */
+  .cinder-time-picker__input::-webkit-calendar-picker-indicator {
+    display: none;
+  }
+
   .cinder-time-picker__toggle {
     position: absolute;
     inset-block: var(--cinder-space-1);
@@ -65,6 +75,8 @@
   }
 
   .cinder-time-picker__popover {
+    container-type: inline-size;
+    container-name: cinder-time-picker-popover;
     padding: var(--cinder-space-3);
     inline-size: min(18rem, calc(100vw - var(--cinder-space-4)));
   }
@@ -73,6 +85,15 @@
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(4rem, 1fr));
     gap: var(--cinder-space-3);
+  }
+
+  /* On very narrow containers (e.g. 375px mobile viewport) the column grid
+   * shrinks proportionally so all columns remain visible without clipping. */
+  @container cinder-time-picker-popover (max-width: 15rem) {
+    .cinder-time-picker__columns {
+      grid-template-columns: repeat(auto-fit, minmax(3rem, 1fr));
+      gap: var(--cinder-space-2);
+    }
   }
 
   .cinder-time-picker__column {

--- a/packages/components/src/components/time-picker/time-picker.css
+++ b/packages/components/src/components/time-picker/time-picker.css
@@ -75,8 +75,6 @@
   }
 
   .cinder-time-picker__popover {
-    container-type: inline-size;
-    container-name: cinder-time-picker-popover;
     padding: var(--cinder-space-3);
     inline-size: min(18rem, calc(100vw - var(--cinder-space-4)));
   }
@@ -85,15 +83,6 @@
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(4rem, 1fr));
     gap: var(--cinder-space-3);
-  }
-
-  /* On very narrow containers (e.g. 375px mobile viewport) the column grid
-   * shrinks proportionally so all columns remain visible without clipping. */
-  @container cinder-time-picker-popover (max-width: 15rem) {
-    .cinder-time-picker__columns {
-      grid-template-columns: repeat(auto-fit, minmax(3rem, 1fr));
-      gap: var(--cinder-space-2);
-    }
   }
 
   .cinder-time-picker__column {

--- a/packages/components/src/components/time-picker/time-picker.examples.json
+++ b/packages/components/src/components/time-picker/time-picker.examples.json
@@ -6,13 +6,13 @@
     {
       "id": "basic",
       "title": "Basic time picker",
-      "description": "Choose a time with direct input or the popover list.",
+      "description": "Type a time directly or click the clock icon to open the scroll-list picker.",
       "code": "<script lang=\"ts\">\n  import { TimePicker } from 'cinder';\n\n  let value = $state('09:30');\n</script>\n\n<div style=\"max-width: 18rem;\">\n  <TimePicker id=\"appointment-time\" bind:value label=\"Appointment time\" />\n  <p>Selected: {value || 'none'}</p>\n</div>\n"
     },
     {
       "id": "locales",
       "title": "Locale hour cycles",
-      "description": "Compare how the picker presents the same time across locales.",
+      "description": "The Cinder scroll-list picker uses the locale hour cycle consistently across browsers. Click any clock icon to open the picker.",
       "code": "<script lang=\"ts\">\n  import { TimePicker } from 'cinder';\n\n  let usValue = $state('13:15');\n  let deValue = $state('13:15');\n  let jaValue = $state('13:15');\n</script>\n\n<div style=\"display: grid; gap: 1rem; max-width: 20rem;\">\n  <TimePicker id=\"locale-us\" bind:value={usValue} label=\"United States\" locale=\"en-US\" />\n  <TimePicker id=\"locale-de\" bind:value={deValue} label=\"Germany\" locale=\"de-DE\" />\n  <TimePicker id=\"locale-ja\" bind:value={jaValue} label=\"Japan\" locale=\"ja-JP\" />\n</div>\n"
     },
     {

--- a/packages/components/src/components/time-picker/time-picker.test.ts
+++ b/packages/components/src/components/time-picker/time-picker.test.ts
@@ -394,10 +394,13 @@ describe('TimePicker — single picker affordance (double-icon regression)', () 
 
   test('the CSS sidecar suppresses the native calendar-picker-indicator', async () => {
     const cssText = await Bun.file(cssPath).text();
-    // The rule must be present to prevent Chrome from rendering its own clock
-    // icon alongside the Cinder toggle button.
-    expect(cssText).toContain('::-webkit-calendar-picker-indicator');
-    expect(cssText).toMatch(/::-webkit-calendar-picker-indicator\s*\{[^}]*display\s*:\s*none/);
+    // The rule must target the input's OWN native indicator and hide it, to stop
+    // Chrome from rendering its clock icon alongside the Cinder toggle. Anchored to
+    // the full `.cinder-time-picker__input` selector so a stray/commented mention
+    // of the pseudo-element elsewhere can't satisfy the assertion.
+    expect(cssText).toMatch(
+      /\.cinder-time-picker__input::-webkit-calendar-picker-indicator\s*\{[^}]*display\s*:\s*none/,
+    );
   });
 
   test('renders exactly one toggle affordance and no native picker button in the DOM', () => {

--- a/packages/components/src/components/time-picker/time-picker.test.ts
+++ b/packages/components/src/components/time-picker/time-picker.test.ts
@@ -1,5 +1,7 @@
 /// <reference lib="dom" />
 import { afterEach, describe, expect, mock, test } from 'bun:test';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 import { setupHappyDom } from '../../test/happy-dom.ts';
 import { expectNoLeakedTimers, trackTimers } from '../../test/lifecycle.ts';
@@ -384,5 +386,40 @@ describe('TimePicker', () => {
     } finally {
       timers.release();
     }
+  });
+});
+
+describe('TimePicker — single picker affordance (double-icon regression)', () => {
+  const cssPath = resolve(dirname(fileURLToPath(import.meta.url)), 'time-picker.css');
+
+  test('the CSS sidecar suppresses the native calendar-picker-indicator', async () => {
+    const cssText = await Bun.file(cssPath).text();
+    // The rule must be present to prevent Chrome from rendering its own clock
+    // icon alongside the Cinder toggle button.
+    expect(cssText).toContain('::-webkit-calendar-picker-indicator');
+    expect(cssText).toMatch(/::-webkit-calendar-picker-indicator\s*\{[^}]*display\s*:\s*none/);
+  });
+
+  test('renders exactly one toggle affordance and no native picker button in the DOM', () => {
+    const { container, getByLabelText } = render(TimePicker, {
+      id: 'affordance-check',
+      label: 'Meeting time',
+    });
+
+    // Exactly one "Choose time" button — the Cinder toggle.
+    const toggleButtons = container.querySelectorAll('[aria-label="Choose time"]');
+    expect(toggleButtons).toHaveLength(1);
+
+    // That single button is the Cinder toggle, not a native control.
+    const toggle = getByLabelText('Choose time');
+    expect(toggle.tagName.toLowerCase()).toBe('button');
+    expect(toggle.getAttribute('type')).toBe('button');
+
+    // happy-dom does not render the native ::-webkit-calendar-picker-indicator
+    // pseudo-element, but we can verify no second button has appeared in the
+    // input wrapper from any other source.
+    const inputWrapper = container.querySelector('.cinder-time-picker');
+    const buttonsInWrapper = inputWrapper?.querySelectorAll('button') ?? [];
+    expect(buttonsInWrapper).toHaveLength(1);
   });
 });

--- a/packages/playground/src/examples/time-picker/basic.example.svelte
+++ b/packages/playground/src/examples/time-picker/basic.example.svelte
@@ -1,6 +1,7 @@
 <script lang="ts" module>
   export const title = 'Basic time picker';
-  export const description = 'Choose a time with direct input or the popover list.';
+  export const description =
+    'Type a time directly or click the clock icon to open the scroll-list picker.';
 </script>
 
 <script lang="ts">

--- a/packages/playground/src/examples/time-picker/locales.example.svelte
+++ b/packages/playground/src/examples/time-picker/locales.example.svelte
@@ -1,6 +1,7 @@
 <script lang="ts" module>
   export const title = 'Locale hour cycles';
-  export const description = 'Compare how the picker presents the same time across locales.';
+  export const description =
+    'The Cinder scroll-list picker uses the locale hour cycle consistently across browsers. Click any clock icon to open the picker.';
 </script>
 
 <script lang="ts">


### PR DESCRIPTION
## Summary

Chrome rendered **two** clock icons on TimePicker — the native `input[type=time]` picker indicator and Cinder's custom toggle — opening two inconsistent picker surfaces.

**Decision: cinder-picker-first.** Hide the native indicator (`::-webkit-calendar-picker-indicator { display: none }`) so only the Cinder toggle shows and opens the Cinder scroll-list popover. The `<input type="time">` remains the value source — typed entry, `min`/`max`/`step`, seconds, native validation, and form participation are unchanged. Documented why TimePicker exists over raw native input (consistent styling + a consistent locale/hour-cycle scroll-list picker), naming the exact `::-webkit-calendar-picker-indicator` selector (Chromium/WebKit; Firefox doesn't expose it).

Regression coverage asserts the indicator-hiding rule exists and exactly one toggle affordance renders. Public API unchanged (non-regen).

## Review committee

Codex (gpt-5.4, xhigh) + author. Codex flagged that a `@container (max-width: 15rem)` query I'd added never triggered at 375px (the popover is 288px there, fitting fine) — verified with width math and **removed the dead CSS** rather than keep churn that does nothing. Doc selector naming corrected per Codex.

## Test plan
- [x] `bun run --filter=cinder test -- time-picker` — 16 pass
- [x] `components:check` (non-regen), `typecheck`, `lint` (oxlint+stylelint), playground — clean

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Visual/CSS and documentation only; native input behavior and public API are unchanged.
> 
> **Overview**
> Fixes **duplicate clock icons** in Chromium/WebKit by hiding the native `::-webkit-calendar-picker-indicator` on `.cinder-time-picker__input` so only the Cinder **Choose time** toggle opens the scroll-list popover. The underlying `<input type="time">` is unchanged for typing, `min`/`max`/`step`, validation, and forms.
> 
> **Docs** add rationale for TimePicker vs raw native input and document indicator suppression in README and `time-picker.a11y.md`. **Examples** copy is updated to describe the clock toggle. **Tests** assert the CSS rule exists and exactly one toggle button renders in the wrapper.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 79fc8f8cd35727688891eab3b49b83753b446478. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->