### PR TITLE
feat(components): visible pointer drag preview for Sortable/KanbanBoard (2252e84d)

### DIFF
--- a/packages/components/src/components/_sortable-item.svelte
+++ b/packages/components/src/components/_sortable-item.svelte
@@ -45,6 +45,7 @@
   const rowId = useId('cinder-sortable-row');
 
   let handleEl = $state<HTMLButtonElement | null>(null);
+  let rowEl = $state<HTMLLIElement | null>(null);
 
   // Pointer session state — plain let (not $state) since these values do not
   // drive template rendering or $derived expressions; they are bookkeeping only.
@@ -56,6 +57,17 @@
   let latestPointerY = 0;
   let latestPointerX = 0;
   let listEl: HTMLElement | null = null;
+
+  // Preview overlay state — reactive so the template can render the portal div.
+  // These only change during a pointer drag, never during keyboard lifts.
+  let previewX = $state(0);
+  let previewY = $state(0);
+  let previewWidth = $state(0);
+  let previewHeight = $state(0);
+  let isDraggingWithPointer = $state(false);
+
+  // The portal element appended to document.body during a pointer drag.
+  let previewPortalEl: HTMLElement | null = null;
 
   const isLifted = $derived(
     context.controller.phase === 'lifted' && context.controller.liftedKey === itemKey,
@@ -82,6 +94,76 @@
 
   const handleLabel = $derived(formatHandleLabel(itemLabel));
 
+  // Create a fixed-position portal overlay that follows the pointer.
+  // The overlay clones the visual appearance of the lifted row so the user
+  // can see what they are dragging regardless of where the placeholder sits.
+  function createPreviewPortal(): void {
+    if (typeof document === 'undefined') return;
+    if (previewPortalEl) return;
+    if (!rowEl) return;
+
+    const rect = rowEl.getBoundingClientRect();
+    previewWidth = rect.width;
+    previewHeight = rect.height;
+
+    const portal = document.createElement('div');
+    portal.setAttribute('data-cinder-drag-preview', '');
+    portal.setAttribute('aria-hidden', 'true');
+    portal.className = 'cinder-sortable-drag-preview';
+
+    // Clone the row's inner HTML into the preview so the user sees the
+    // card content at the pointer location.
+    const clone = rowEl.cloneNode(true) as HTMLElement;
+    // Remove pointer/keyboard event attributes from the clone so the preview
+    // is entirely inert. The clone is aria-hidden at the portal level.
+    clone.removeAttribute('data-sortable-row');
+    clone.removeAttribute('data-key');
+    clone.removeAttribute('data-row-id');
+    portal.appendChild(clone);
+
+    // Position the portal so its top-left aligns with the row's bounding rect
+    // at the moment of lift — the transform will then track the pointer delta.
+    portal.style.setProperty('--preview-width', `${previewWidth}px`);
+    portal.style.setProperty('--preview-height', `${previewHeight}px`);
+    portal.style.setProperty('--preview-left', `${rect.left}px`);
+    portal.style.setProperty('--preview-top', `${rect.top}px`);
+    portal.style.setProperty('--preview-dx', '0px');
+    portal.style.setProperty('--preview-dy', '0px');
+
+    document.body.appendChild(portal);
+    previewPortalEl = portal;
+    isDraggingWithPointer = true;
+  }
+
+  // Update the portal's translate offset so it follows the pointer.
+  function updatePreviewPosition(pointerX: number, pointerY: number): void {
+    if (!previewPortalEl || !rowEl) return;
+    if (typeof document === 'undefined') return;
+
+    const rect = rowEl.getBoundingClientRect();
+    // Delta from original position to current pointer center.
+    const dx = pointerX - (rect.left + rect.width / 2);
+    const dy = pointerY - (rect.top + rect.height / 2);
+
+    previewPortalEl.style.setProperty('--preview-left', `${rect.left}px`);
+    previewPortalEl.style.setProperty('--preview-top', `${rect.top}px`);
+    previewPortalEl.style.setProperty('--preview-dx', `${dx}px`);
+    previewPortalEl.style.setProperty('--preview-dy', `${dy}px`);
+
+    // Keep reactive state in sync so tests can read it from data-attributes or
+    // computed style rather than CSS custom properties.
+    previewX = pointerX;
+    previewY = pointerY;
+  }
+
+  function destroyPreviewPortal(): void {
+    if (previewPortalEl) {
+      previewPortalEl.remove();
+      previewPortalEl = null;
+    }
+    isDraggingWithPointer = false;
+  }
+
   function endPointerSession(reason: 'drop' | 'cancel'): void {
     if (moveRafHandle !== null) {
       cancelAnimationFrame(moveRafHandle);
@@ -99,6 +181,8 @@
         // Browser may have already revoked capture (common on pointercancel).
       }
     }
+
+    destroyPreviewPortal();
 
     pointerActive = false;
     pointerId = null;
@@ -184,6 +268,11 @@
 
     handleEl.setPointerCapture(event.pointerId);
     context.lift(itemKey, index, itemLabel, total);
+
+    // Create the drag preview after lift so the row is in lifted state
+    // when we clone it, then position relative to the pointer.
+    createPreviewPortal();
+    updatePreviewPosition(event.clientX, event.clientY);
     scheduleAutoScroll();
   }
 
@@ -197,6 +286,7 @@
       moveRafHandle = requestAnimationFrame(() => {
         moveRafHandle = null;
         recomputeTarget();
+        updatePreviewPosition(latestPointerX, latestPointerY);
       });
     }
     // Restart auto-scroll loop if it has stopped (e.g. pointer entered edge zone
@@ -316,6 +406,7 @@
         handleEl.releasePointerCapture(pointerId);
       } catch {}
     }
+    destroyPreviewPortal();
     pointerActive = false;
     pointerId = null;
     listEl = null;
@@ -346,6 +437,7 @@
             // Already revoked.
           }
         }
+        destroyPreviewPortal();
         pointerActive = false;
         pointerId = null;
         listEl = null;
@@ -355,13 +447,17 @@
 </script>
 
 <li
+  bind:this={rowEl}
   data-sortable-row
   data-key={itemKey}
   data-row-id={rowId}
+  data-preview-x={isDraggingWithPointer ? previewX : undefined}
+  data-preview-y={isDraggingWithPointer ? previewY : undefined}
   aria-roledescription="sortable item"
   class={cn(
     'cinder-sortable-item',
-    isLifted && 'cinder-sortable-item--lifted',
+    isLifted && isDraggingWithPointer && 'cinder-sortable-item--placeholder',
+    isLifted && !isDraggingWithPointer && 'cinder-sortable-item--lifted',
     !isLifted && context.controller.phase === 'lifted' && 'cinder-sortable-item--shifting',
     className,
   )}

--- a/packages/components/src/components/_sortable-item.svelte
+++ b/packages/components/src/components/_sortable-item.svelte
@@ -58,13 +58,19 @@
   let latestPointerX = 0;
   let listEl: HTMLElement | null = null;
 
-  // Preview overlay state — reactive so the template can render the portal div.
-  // These only change during a pointer drag, never during keyboard lifts.
+  // Reactive state for the pointer-drag preview portal.
+  // previewX / previewY drive data-preview-x / data-preview-y on the row element
+  // and the --placeholder / --lifted class toggle — they must be $state.
+  // isDraggingWithPointer gates both the class toggle and the data-attribute output.
   let previewX = $state(0);
   let previewY = $state(0);
-  let previewWidth = $state(0);
-  let previewHeight = $state(0);
   let isDraggingWithPointer = $state(false);
+
+  // Portal dimensions are captured at lift time and written imperatively to the
+  // portal's CSS custom properties inside createPreviewPortal. They never drive
+  // reactive rendering, so plain let is correct here.
+  let previewWidth = 0;
+  let previewHeight = 0;
 
   // The portal element appended to document.body during a pointer drag.
   let previewPortalEl: HTMLElement | null = null;

--- a/packages/components/src/components/_sortable-item.svelte
+++ b/packages/components/src/components/_sortable-item.svelte
@@ -94,10 +94,16 @@
 
   const handleLabel = $derived(formatHandleLabel(itemLabel));
 
+  // Grab offset: distance from the pointer to the row's top-left corner at lift
+  // time. Stored so subsequent moves keep the preview under the original grab
+  // point rather than jumping to the row's center.
+  let grabOffsetX = 0;
+  let grabOffsetY = 0;
+
   // Create a fixed-position portal overlay that follows the pointer.
   // The overlay clones the visual appearance of the lifted row so the user
   // can see what they are dragging regardless of where the placeholder sits.
-  function createPreviewPortal(): void {
+  function createPreviewPortal(pointerX: number, pointerY: number): void {
     if (typeof document === 'undefined') return;
     if (previewPortalEl) return;
     if (!rowEl) return;
@@ -106,19 +112,32 @@
     previewWidth = rect.width;
     previewHeight = rect.height;
 
+    // Capture the pointer's offset from the row's top-left at lift time so the
+    // preview stays anchored under the grab point (not the row's center).
+    grabOffsetX = pointerX - rect.left;
+    grabOffsetY = pointerY - rect.top;
+
     const portal = document.createElement('div');
     portal.setAttribute('data-cinder-drag-preview', '');
     portal.setAttribute('aria-hidden', 'true');
+    portal.setAttribute('inert', '');
     portal.className = 'cinder-sortable-drag-preview';
 
     // Clone the row's inner HTML into the preview so the user sees the
     // card content at the pointer location.
     const clone = rowEl.cloneNode(true) as HTMLElement;
     // Remove pointer/keyboard event attributes from the clone so the preview
-    // is entirely inert. The clone is aria-hidden at the portal level.
+    // is entirely inert. The clone is aria-hidden / inert at the portal level.
     clone.removeAttribute('data-sortable-row');
     clone.removeAttribute('data-key');
     clone.removeAttribute('data-row-id');
+    // Strip all id attributes from the clone and its descendants to prevent
+    // duplicate id values in the document, which would break getElementById,
+    // label/for associations, and aria relationships during a drag.
+    clone.removeAttribute('id');
+    clone.querySelectorAll('[id]').forEach((descendant) => {
+      descendant.removeAttribute('id');
+    });
     portal.appendChild(clone);
 
     // Position the portal so its top-left aligns with the row's bounding rect
@@ -141,9 +160,12 @@
     if (typeof document === 'undefined') return;
 
     const rect = rowEl.getBoundingClientRect();
-    // Delta from original position to current pointer center.
-    const dx = pointerX - (rect.left + rect.width / 2);
-    const dy = pointerY - (rect.top + rect.height / 2);
+    // Compute the top-left position that keeps the grab point under the pointer.
+    // The portal's origin (--preview-left / --preview-top) is the row's bounding
+    // rect; --preview-dx / --preview-dy shift it so the grab point aligns with
+    // the current pointer. Equivalent to: newLeft = pointerX - grabOffsetX.
+    const dx = pointerX - grabOffsetX - rect.left;
+    const dy = pointerY - grabOffsetY - rect.top;
 
     previewPortalEl.style.setProperty('--preview-left', `${rect.left}px`);
     previewPortalEl.style.setProperty('--preview-top', `${rect.top}px`);
@@ -157,6 +179,13 @@
   }
 
   function destroyPreviewPortal(): void {
+    // Cancel any queued move-rAF before removing the portal so a pending frame
+    // cannot write to a stale or removed portal element, or interfere with a
+    // subsequent drag session that starts before the frame fires.
+    if (moveRafHandle !== null) {
+      cancelAnimationFrame(moveRafHandle);
+      moveRafHandle = null;
+    }
     if (previewPortalEl) {
       previewPortalEl.remove();
       previewPortalEl = null;
@@ -271,7 +300,7 @@
 
     // Create the drag preview after lift so the row is in lifted state
     // when we clone it, then position relative to the pointer.
-    createPreviewPortal();
+    createPreviewPortal(event.clientX, event.clientY);
     updatePreviewPosition(event.clientX, event.clientY);
     scheduleAutoScroll();
   }

--- a/packages/components/src/components/_sortable-item.svelte
+++ b/packages/components/src/components/_sortable-item.svelte
@@ -304,6 +304,22 @@
     handleEl.setPointerCapture(event.pointerId);
     context.lift(itemKey, index, itemLabel, total);
 
+    // Guard portal creation on a successful lift. The controller rejects concurrent
+    // lifts (returns void but leaves phase === 'lifted' with a *different* key if
+    // another item is already active). Only proceed when this item is now the
+    // lifted key — otherwise release capture and bail without creating the portal.
+    if (context.controller.phase !== 'lifted' || context.controller.liftedKey !== itemKey) {
+      try {
+        handleEl.releasePointerCapture(event.pointerId);
+      } catch {
+        // Already revoked by the browser.
+      }
+      pointerActive = false;
+      pointerId = null;
+      listEl = null;
+      return;
+    }
+
     // Create the drag preview after lift so the row is in lifted state
     // when we clone it, then position relative to the pointer.
     createPreviewPortal(event.clientX, event.clientY);

--- a/packages/components/src/components/kanban-board/kanban-board.a11y.md
+++ b/packages/components/src/components/kanban-board/kanban-board.a11y.md
@@ -12,7 +12,7 @@ The component does not use deprecated `aria-grabbed` or `aria-dropeffect`. Annou
 
 Pointer dragging uses the shared cinder sortable handle implementation and recomputes board column geometry during the gesture.
 
-During a pointer drag a fixed-position overlay (`.cinder-sortable-drag-preview`, appended to `document.body`) shows what is being dragged. The card's source row becomes a placeholder (dashed border, reduced opacity) marking the current drop insertion position. Both the overlay and the placeholder class are removed on drop, cancel, or any cleanup path.
+During a pointer drag a fixed-position overlay (`.cinder-sortable-drag-preview`, appended to `document.body`) shows what is being dragged. The card's source row becomes a placeholder (dashed outline, reduced opacity) marking the current drop insertion position. The placeholder hides its child content via `visibility: hidden` so only the drop slot shape is visible, not a duplicate of the card content. Both the overlay and the placeholder class are removed on drop, cancel, or any cleanup path.
 
 **Auto-scroll limitations for KanbanBoard:**
 

--- a/packages/components/src/components/kanban-board/kanban-board.a11y.md
+++ b/packages/components/src/components/kanban-board/kanban-board.a11y.md
@@ -10,6 +10,14 @@ Collapsed columns keep their headers, column handles, and collapse controls reac
 
 The component does not use deprecated `aria-grabbed` or `aria-dropeffect`. Announcements are sent through one live region and include the moved card or column, destination, position, drop, cancellation, and collapse or expand state.
 
-Pointer dragging uses the shared cinder sortable handle implementation and recomputes board column geometry during the gesture. Nested scroll-container auto-scroll is out of scope for this version; window-edge auto-scroll is inherited from the shared sortable handle behavior.
+Pointer dragging uses the shared cinder sortable handle implementation and recomputes board column geometry during the gesture.
+
+During a pointer drag a fixed-position overlay (`.cinder-sortable-drag-preview`, appended to `document.body`) shows what is being dragged. The card's source row becomes a placeholder (dashed border, reduced opacity) marking the current drop insertion position. Both the overlay and the placeholder class are removed on drop, cancel, or any cleanup path.
+
+**Auto-scroll limitations for KanbanBoard:**
+
+- Vertical window-edge auto-scroll is inherited from the shared sortable handle behavior. When the pointer is near the top or bottom of the viewport the page scrolls vertically.
+- **Horizontal auto-scroll is not implemented.** Dragging a card toward the right or left edge of a horizontally scrolling board will not scroll the columns container to reveal off-screen columns. Users must scroll the board horizontally before beginning a drag to expose the target column, or use keyboard navigation (ArrowLeft/ArrowRight while lifted) to move across columns without scrolling.
+- **Nested scroll containers** within a column are not auto-scrolled.
 
 Column ids and card keys must be unique. Duplicate keys trigger a `[cinder-kanban-board]` warning, set `data-cinder-invalid-keys` on the root, and disable card and column lift operations until keys are unique.

--- a/packages/components/src/components/kanban-board/kanban-board.css
+++ b/packages/components/src/components/kanban-board/kanban-board.css
@@ -158,6 +158,12 @@
     font-size: var(--cinder-text-sm);
   }
 
+  @media (prefers-reduced-motion: reduce) {
+    .cinder-kanban-board__card.cinder-sortable-item--placeholder {
+      opacity: 0.6;
+    }
+  }
+
   @media (prefers-reduced-motion: no-preference) {
     .cinder-kanban-board__card,
     .cinder-kanban-board__column {

--- a/packages/components/src/components/kanban-board/kanban-board.css
+++ b/packages/components/src/components/kanban-board/kanban-board.css
@@ -126,11 +126,17 @@
    */
   .cinder-kanban-board__card.cinder-sortable-item--placeholder {
     min-block-size: var(--cinder-space-12, 3rem);
+    opacity: 0.4;
     border-color: transparent;
     outline: 2px dashed var(--cinder-ring-color, currentColor);
     outline-offset: -1px;
     background: transparent;
     box-shadow: none;
+  }
+
+  .cinder-kanban-board__card.cinder-sortable-item--placeholder > * {
+    /* Hide card content from sight; placeholder conveys drop position only. */
+    visibility: hidden;
   }
 
   .cinder-kanban-board__card-content {

--- a/packages/components/src/components/kanban-board/kanban-board.css
+++ b/packages/components/src/components/kanban-board/kanban-board.css
@@ -199,8 +199,8 @@
     position: fixed;
     top: calc(var(--preview-top, 0px) + var(--preview-dy, 0px));
     left: calc(var(--preview-left, 0px) + var(--preview-dx, 0px));
-    inline-size: var(--preview-width, auto);
-    block-size: var(--preview-height, auto);
+    width: var(--preview-width, auto);
+    height: var(--preview-height, auto);
     z-index: var(--cinder-z-drag-preview, 9999);
     pointer-events: none;
     box-shadow: var(--cinder-shadow-elevated, 0 4px 16px rgb(0 0 0 / 0.15));

--- a/packages/components/src/components/kanban-board/kanban-board.css
+++ b/packages/components/src/components/kanban-board/kanban-board.css
@@ -179,19 +179,20 @@
    * in the cascade is harmless — the last identical declaration wins.
    *
    * Positioning uses CSS custom properties set by _sortable-item.svelte:
-   *   --preview-left / --preview-top   — row's bounding rect at lift time
+   *   --preview-left / --preview-top   — row's bounding rect at lift time (physical viewport coords)
    *   --preview-dx / --preview-dy      — pointer delta since lift
    *   --preview-width / --preview-height — row dimensions at lift time
    *
-   * Position is computed via inset-block-start / inset-inline-start using the
-   * custom properties above. The transform applies only a subtle rotate + scale
-   * to visually distinguish the preview from the placeholder — it does not
-   * translate the preview.
+   * Physical left/top (not logical inset-inline-start/inset-block-start) are used
+   * because --preview-left/--preview-top come from getBoundingClientRect(), which
+   * always returns physical viewport distances regardless of writing direction.
+   * Using inset-inline-start would map to the right edge in RTL layouts, causing
+   * the preview to appear on the wrong side of the viewport.
    */
   .cinder-sortable-drag-preview {
     position: fixed;
-    inset-block-start: calc(var(--preview-top, 0px) + var(--preview-dy, 0px));
-    inset-inline-start: calc(var(--preview-left, 0px) + var(--preview-dx, 0px));
+    top: calc(var(--preview-top, 0px) + var(--preview-dy, 0px));
+    left: calc(var(--preview-left, 0px) + var(--preview-dx, 0px));
     inline-size: var(--preview-width, auto);
     block-size: var(--preview-height, auto);
     z-index: var(--cinder-z-drag-preview, 9999);

--- a/packages/components/src/components/kanban-board/kanban-board.css
+++ b/packages/components/src/components/kanban-board/kanban-board.css
@@ -114,6 +114,18 @@
     box-shadow: var(--cinder-shadow-md);
   }
 
+  /*
+   * During a pointer drag the card in the list becomes a placeholder showing
+   * the drop target position. The preview overlay (in sortable-list.css) is
+   * what follows the pointer; this keeps the drop slot visible in the column.
+   */
+  .cinder-kanban-board__card.cinder-sortable-item--placeholder {
+    min-block-size: var(--cinder-space-12, 3rem);
+    border: 2px dashed var(--cinder-ring-color, currentColor);
+    background: transparent;
+    box-shadow: none;
+  }
+
   .cinder-kanban-board__card-content {
     min-inline-size: 0;
   }

--- a/packages/components/src/components/kanban-board/kanban-board.css
+++ b/packages/components/src/components/kanban-board/kanban-board.css
@@ -154,4 +154,60 @@
         background-color var(--cinder-duration-fast) var(--cinder-ease-standard);
     }
   }
+
+  /* ========================================
+   * DRAG PREVIEW OVERLAY (shared with sortable-list)
+   * ======================================== */
+
+  /*
+   * The drag preview portal is created by _sortable-item.svelte and appended
+   * to <body> — outside the component tree. A consumer importing only
+   * cinder/kanban-board/styles would miss sortable-list.css and therefore
+   * miss these rules, leaving the portal unstyled and unpositioned.
+   *
+   * These rules are intentionally kept identical to the ones in
+   * sortable-list.css so both subpath import paths (cinder/sortable-list/styles
+   * and cinder/kanban-board/styles) produce a correctly positioned preview.
+   * The cinder/styles aggregator loads both CSS files; having the rule twice
+   * in the cascade is harmless — the last identical declaration wins.
+   *
+   * Positioning uses CSS custom properties set by _sortable-item.svelte:
+   *   --preview-left / --preview-top   — row's bounding rect at lift time
+   *   --preview-dx / --preview-dy      — pointer delta since lift
+   *   --preview-width / --preview-height — row dimensions at lift time
+   */
+  .cinder-sortable-drag-preview {
+    position: fixed;
+    inset-block-start: calc(var(--preview-top, 0px) + var(--preview-dy, 0px));
+    inset-inline-start: calc(var(--preview-left, 0px) + var(--preview-dx, 0px));
+    inline-size: var(--preview-width, auto);
+    block-size: var(--preview-height, auto);
+    z-index: var(--cinder-z-drag-preview, 9999);
+    pointer-events: none;
+    box-shadow: var(--cinder-shadow-elevated, 0 4px 16px rgb(0 0 0 / 0.15));
+    border-radius: var(--cinder-radius-md, 4px);
+    /* Subtle rotation and scale to distinguish preview from the placeholder. */
+    transform: rotate(2deg) scale(1.02);
+    transform-origin: center top;
+    will-change: top, left;
+    overflow: hidden;
+  }
+
+  /* Restore full opacity and visibility inside the preview clone. */
+  .cinder-sortable-drag-preview > * {
+    opacity: 1;
+    visibility: visible;
+  }
+
+  /* Inside the preview clone keep children visible even if the source
+     had placeholder--hidden children. */
+  .cinder-sortable-drag-preview > * > * {
+    visibility: visible;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .cinder-sortable-drag-preview {
+      transform: none;
+    }
+  }
 }

--- a/packages/components/src/components/kanban-board/kanban-board.css
+++ b/packages/components/src/components/kanban-board/kanban-board.css
@@ -118,10 +118,17 @@
    * During a pointer drag the card in the list becomes a placeholder showing
    * the drop target position. The preview overlay (in sortable-list.css) is
    * what follows the pointer; this keeps the drop slot visible in the column.
+   *
+   * Outline is used for the dashed drop indicator rather than changing border
+   * width. The card rests at border-width 1px; switching to 2px during drag
+   * would resize the box by 1px on each side, causing layout jitter and
+   * skewing the midpoint geometry used by drop-target calculations.
    */
   .cinder-kanban-board__card.cinder-sortable-item--placeholder {
     min-block-size: var(--cinder-space-12, 3rem);
-    border: 2px dashed var(--cinder-ring-color, currentColor);
+    border-color: transparent;
+    outline: 2px dashed var(--cinder-ring-color, currentColor);
+    outline-offset: -1px;
     background: transparent;
     box-shadow: none;
   }
@@ -175,6 +182,11 @@
    *   --preview-left / --preview-top   — row's bounding rect at lift time
    *   --preview-dx / --preview-dy      — pointer delta since lift
    *   --preview-width / --preview-height — row dimensions at lift time
+   *
+   * Position is computed via inset-block-start / inset-inline-start using the
+   * custom properties above. The transform applies only a subtle rotate + scale
+   * to visually distinguish the preview from the placeholder — it does not
+   * translate the preview.
    */
   .cinder-sortable-drag-preview {
     position: fixed;

--- a/packages/components/src/components/kanban-board/kanban-board.svelte
+++ b/packages/components/src/components/kanban-board/kanban-board.svelte
@@ -199,11 +199,16 @@
     const cardList = columnElement.querySelector<HTMLElement>(
       ':scope > .cinder-kanban-board__cards',
     );
+    // Exclude the dragged card by its stable data-key attribute so the filter
+    // works regardless of whether the card is in the keyboard-drag state
+    // (cinder-sortable-item--lifted) or the pointer-drag state
+    // (cinder-sortable-item--placeholder). Both states carry the same data-key.
+    const draggedKey = cardController.liftedKey;
     const rows = Array.from(cardList?.children ?? []).filter(
       (row): row is HTMLElement =>
         row instanceof HTMLElement &&
         row.hasAttribute('data-sortable-row') &&
-        !row.classList.contains('cinder-sortable-item--lifted'),
+        row.getAttribute('data-key') !== String(draggedKey),
     );
     const insertionIndex = rows.filter((row) => {
       const rect = row.getBoundingClientRect();

--- a/packages/components/src/components/kanban-board/kanban-board.test.ts
+++ b/packages/components/src/components/kanban-board/kanban-board.test.ts
@@ -772,11 +772,10 @@ describe('KanbanBoard pointer drag preview', () => {
 
     // After drop, the card row is at its new logical position. Query by key.
     const cardRow = container.querySelector('[data-key="a"]') as HTMLElement;
-    if (cardRow) {
-      expect(cardRow.classList.contains('cinder-sortable-item--placeholder')).toBe(false);
-      expect(cardRow.hasAttribute('data-preview-x')).toBe(false);
-      expect(cardRow.hasAttribute('data-preview-y')).toBe(false);
-    }
+    expect(cardRow).not.toBeNull();
+    expect(cardRow.classList.contains('cinder-sortable-item--placeholder')).toBe(false);
+    expect(cardRow.hasAttribute('data-preview-x')).toBe(false);
+    expect(cardRow.hasAttribute('data-preview-y')).toBe(false);
   });
 
   test('pointercancel removes the preview portal', async () => {
@@ -854,6 +853,42 @@ describe('KanbanBoard pointer drag preview', () => {
     expect(cardRow?.classList.contains('cinder-sortable-item--placeholder')).toBe(false);
 
     await fireEvent.keyDown(handle, { key: 'Escape' });
+  });
+
+  test('rejected lift (another card already lifted) does NOT create an orphaned preview portal', async () => {
+    const { container } = renderBoard();
+    installPointerGeometry(container);
+    const alphaHandle = container.querySelector('[aria-label="Move Alpha"]') as HTMLElement;
+    const betaHandle = container.querySelector('[aria-label="Move Beta"]') as HTMLElement;
+    installPointerCapture(alphaHandle);
+    installPointerCapture(betaHandle);
+
+    // Lift Alpha.
+    await fireEvent.pointerDown(alphaHandle, {
+      button: 0,
+      clientX: 20,
+      clientY: 20,
+      pointerId: 1,
+      pointerType: 'mouse',
+    });
+
+    expect(document.querySelectorAll('[data-cinder-drag-preview]').length).toBe(1);
+
+    // Attempt a concurrent lift on Beta while Alpha is already lifted.
+    // The controller rejects the second lift; no second portal must be created.
+    await fireEvent.pointerDown(betaHandle, {
+      button: 0,
+      clientX: 20,
+      clientY: 60,
+      pointerId: 2,
+      pointerType: 'mouse',
+    });
+
+    expect(document.querySelectorAll('[data-cinder-drag-preview]').length).toBe(1);
+
+    // Clean up.
+    await fireEvent.pointerUp(alphaHandle, { pointerId: 1, pointerType: 'mouse' });
+    expect(document.querySelectorAll('[data-cinder-drag-preview]').length).toBe(0);
   });
 
   test('cross-column pointer drag creates a preview and a placeholder in the source column', async () => {

--- a/packages/components/src/components/kanban-board/kanban-board.test.ts
+++ b/packages/components/src/components/kanban-board/kanban-board.test.ts
@@ -887,4 +887,68 @@ describe('KanbanBoard pointer drag preview', () => {
     await fireEvent.pointerUp(handle, { pointerId: 1, pointerType: 'mouse' });
     expect(document.querySelector('[data-cinder-drag-preview]')).toBeNull();
   });
+
+  // ---------------------------------------------------------------------------
+  // Regression: drop-target filter must exclude the dragged card in both
+  // keyboard-drag state (--lifted) and pointer-drag state (--placeholder).
+  //
+  // Before the fix, locatePointerTarget filtered rows by
+  // !row.classList.contains('cinder-sortable-item--lifted'). During a pointer
+  // drag the lifted card carries cinder-sortable-item--placeholder instead, so
+  // the dragged card was NOT excluded — skewing midpoint calculations. The fix
+  // filters by data-key, which is present and stable in both drag states.
+  //
+  // Note: happy-dom does not support ':scope >' in Element.querySelector, so
+  // locatePointerTarget's card-list lookup returns null in this environment and
+  // all pointer-drag cardIndex values always resolve to 0 (empty row set →
+  // insertionIndex 0). The full midpoint-computation path is correct in real
+  // browsers; the tests below verify the class-state invariant that the old
+  // filter would have broken.
+  // ---------------------------------------------------------------------------
+
+  test('pointer drag: dragged row gets --placeholder (not --lifted) — old class filter would miss it', async () => {
+    // This test documents the core of the regression. During a pointer drag the
+    // dragged row carries cinder-sortable-item--placeholder, NOT --lifted. The
+    // old locatePointerTarget filter excluded only --lifted rows, so the dragged
+    // card would be included in midpoint calculations during pointer drags.
+    const { container } = renderBoard();
+    installPointerGeometry(container);
+    const handle = container.querySelector('[aria-label="Move Alpha"]') as HTMLElement;
+    installPointerCapture(handle);
+
+    await fireEvent.pointerDown(handle, {
+      button: 0,
+      clientX: 20,
+      clientY: 20,
+      pointerId: 1,
+      pointerType: 'mouse',
+    });
+
+    const alphaRow = container.querySelector('[data-key="a"]') as HTMLElement;
+    // The class the old filter keyed on is NOT present during a pointer drag.
+    expect(alphaRow?.classList.contains('cinder-sortable-item--lifted')).toBe(false);
+    // The actual class during a pointer drag IS present — and carries the data-key
+    // that the fixed filter now uses to identify and exclude the dragged row.
+    expect(alphaRow?.classList.contains('cinder-sortable-item--placeholder')).toBe(true);
+    // data-key is present and stable regardless of drag state.
+    expect(alphaRow?.getAttribute('data-key')).toBe('a');
+
+    await fireEvent.pointerUp(handle, { pointerId: 1, pointerType: 'mouse' });
+  });
+
+  test('keyboard drag: dragged row gets --lifted (not --placeholder) — data-key filter still excludes it', async () => {
+    // Mirror of the previous test for keyboard drags. data-key is present in
+    // both states, making it the correct stable exclusion marker.
+    const { container } = renderBoard();
+    const handle = container.querySelector('[aria-label="Move Alpha"]') as HTMLElement;
+
+    await fireEvent.keyDown(handle, { key: ' ' });
+
+    const alphaRow = container.querySelector('[data-key="a"]') as HTMLElement;
+    expect(alphaRow?.classList.contains('cinder-sortable-item--lifted')).toBe(true);
+    expect(alphaRow?.classList.contains('cinder-sortable-item--placeholder')).toBe(false);
+    expect(alphaRow?.getAttribute('data-key')).toBe('a');
+
+    await fireEvent.keyDown(handle, { key: 'Escape' });
+  });
 });

--- a/packages/components/src/components/kanban-board/kanban-board.test.ts
+++ b/packages/components/src/components/kanban-board/kanban-board.test.ts
@@ -1,6 +1,6 @@
 // @ts-nocheck — component tests exercise generic snippets and DOM APIs.
 /// <reference lib="dom" />
-import { describe, expect, mock, test } from 'bun:test';
+import { afterEach, describe, expect, mock, test } from 'bun:test';
 import { createRawSnippet, tick } from 'svelte';
 
 import { setupHappyDom } from '../../test/happy-dom.ts';
@@ -601,5 +601,290 @@ describe('KanbanBoard', () => {
     } finally {
       console.warn = originalWarn;
     }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// KanbanBoard pointer drag preview state contract tests
+// ---------------------------------------------------------------------------
+//
+// Verifies the drag preview lifecycle for KanbanBoard card drags:
+//   - Pointer drag creates a [data-cinder-drag-preview] portal on body.
+//   - Card row becomes placeholder during pointer drag.
+//   - Drop removes the portal.
+//   - Cancel / Escape removes the portal.
+//   - Keyboard lift does not create a portal.
+//   - Cross-column drag keeps a preview and placeholder visible.
+
+describe('KanbanBoard pointer drag preview', () => {
+  afterEach(() => {
+    document.querySelectorAll('[data-cinder-drag-preview]').forEach((element) => element.remove());
+  });
+
+  test('pointer drag creates a preview portal on document.body', async () => {
+    const { container } = renderBoard();
+    installPointerGeometry(container);
+    const handle = container.querySelector('[aria-label="Move Alpha"]') as HTMLElement;
+    installPointerCapture(handle);
+
+    await fireEvent.pointerDown(handle, {
+      button: 0,
+      clientX: 20,
+      clientY: 20,
+      pointerId: 1,
+      pointerType: 'mouse',
+    });
+
+    const preview = document.querySelector('[data-cinder-drag-preview]');
+    expect(preview).not.toBeNull();
+    expect(document.body.contains(preview)).toBe(true);
+    expect(container.contains(preview)).toBe(false);
+
+    await fireEvent.pointerUp(handle, { pointerId: 1, pointerType: 'mouse' });
+  });
+
+  test('preview portal has aria-hidden=true', async () => {
+    const { container } = renderBoard();
+    installPointerGeometry(container);
+    const handle = container.querySelector('[aria-label="Move Alpha"]') as HTMLElement;
+    installPointerCapture(handle);
+
+    await fireEvent.pointerDown(handle, {
+      button: 0,
+      clientX: 20,
+      clientY: 20,
+      pointerId: 1,
+      pointerType: 'mouse',
+    });
+
+    const preview = document.querySelector('[data-cinder-drag-preview]');
+    expect(preview?.getAttribute('aria-hidden')).toBe('true');
+
+    await fireEvent.pointerUp(handle, { pointerId: 1, pointerType: 'mouse' });
+  });
+
+  test('lifted card row has --placeholder class during pointer drag', async () => {
+    const { container } = renderBoard();
+    installPointerGeometry(container);
+    const handle = container.querySelector('[aria-label="Move Alpha"]') as HTMLElement;
+    installPointerCapture(handle);
+
+    await fireEvent.pointerDown(handle, {
+      button: 0,
+      clientX: 20,
+      clientY: 20,
+      pointerId: 1,
+      pointerType: 'mouse',
+    });
+
+    const cardRow = container.querySelector('[data-key="a"]') as HTMLElement;
+    expect(cardRow?.classList.contains('cinder-sortable-item--placeholder')).toBe(true);
+    expect(cardRow?.classList.contains('cinder-sortable-item--lifted')).toBe(false);
+
+    await fireEvent.pointerUp(handle, { pointerId: 1, pointerType: 'mouse' });
+  });
+
+  test('card row exposes data-preview-x/y during pointer drag', async () => {
+    const { container } = renderBoard();
+    installPointerGeometry(container);
+    const handle = container.querySelector('[aria-label="Move Alpha"]') as HTMLElement;
+    installPointerCapture(handle);
+
+    await fireEvent.pointerDown(handle, {
+      button: 0,
+      clientX: 20,
+      clientY: 30,
+      pointerId: 1,
+      pointerType: 'mouse',
+    });
+
+    const cardRow = container.querySelector('[data-key="a"]') as HTMLElement;
+    expect(cardRow?.getAttribute('data-preview-x')).toBe('20');
+    expect(cardRow?.getAttribute('data-preview-y')).toBe('30');
+
+    await fireEvent.pointerUp(handle, { pointerId: 1, pointerType: 'mouse' });
+  });
+
+  test('preview position updates on pointer move', async () => {
+    const { container } = renderBoard();
+    installPointerGeometry(container);
+    const handle = container.querySelector('[aria-label="Move Alpha"]') as HTMLElement;
+    installPointerCapture(handle);
+
+    await fireEvent.pointerDown(handle, {
+      button: 0,
+      clientX: 20,
+      clientY: 20,
+      pointerId: 1,
+      pointerType: 'mouse',
+    });
+
+    await fireEvent.pointerMove(handle, {
+      clientX: 100,
+      clientY: 50,
+      pointerId: 1,
+      pointerType: 'mouse',
+    });
+    await waitForAnimationFrame();
+
+    const cardRow = container.querySelector('[data-key="a"]') as HTMLElement;
+    expect(cardRow?.getAttribute('data-preview-x')).toBe('100');
+    expect(cardRow?.getAttribute('data-preview-y')).toBe('50');
+
+    await fireEvent.pointerUp(handle, { pointerId: 1, pointerType: 'mouse' });
+  });
+
+  test('drop removes the preview portal', async () => {
+    const { container } = renderBoard();
+    installPointerGeometry(container);
+    const handle = container.querySelector('[aria-label="Move Alpha"]') as HTMLElement;
+    installPointerCapture(handle);
+
+    await fireEvent.pointerDown(handle, {
+      button: 0,
+      clientX: 20,
+      clientY: 20,
+      pointerId: 1,
+      pointerType: 'mouse',
+    });
+
+    expect(document.querySelector('[data-cinder-drag-preview]')).not.toBeNull();
+
+    await fireEvent.pointerUp(handle, { pointerId: 1, pointerType: 'mouse' });
+
+    expect(document.querySelector('[data-cinder-drag-preview]')).toBeNull();
+  });
+
+  test('drop clears placeholder class and preview attributes', async () => {
+    const { container } = renderBoard();
+    installPointerGeometry(container);
+    const handle = container.querySelector('[aria-label="Move Alpha"]') as HTMLElement;
+    installPointerCapture(handle);
+
+    await fireEvent.pointerDown(handle, {
+      button: 0,
+      clientX: 20,
+      clientY: 20,
+      pointerId: 1,
+      pointerType: 'mouse',
+    });
+    await fireEvent.pointerUp(handle, { pointerId: 1, pointerType: 'mouse' });
+
+    // After drop, the card row is at its new logical position. Query by key.
+    const cardRow = container.querySelector('[data-key="a"]') as HTMLElement;
+    if (cardRow) {
+      expect(cardRow.classList.contains('cinder-sortable-item--placeholder')).toBe(false);
+      expect(cardRow.hasAttribute('data-preview-x')).toBe(false);
+      expect(cardRow.hasAttribute('data-preview-y')).toBe(false);
+    }
+  });
+
+  test('pointercancel removes the preview portal', async () => {
+    const { container } = renderBoard();
+    installPointerGeometry(container);
+    const handle = container.querySelector('[aria-label="Move Alpha"]') as HTMLElement;
+    installPointerCapture(handle);
+
+    await fireEvent.pointerDown(handle, {
+      button: 0,
+      clientX: 20,
+      clientY: 20,
+      pointerId: 1,
+      pointerType: 'mouse',
+    });
+
+    expect(document.querySelector('[data-cinder-drag-preview]')).not.toBeNull();
+
+    await fireEvent.pointerCancel(handle, { pointerId: 1, pointerType: 'mouse' });
+
+    expect(document.querySelector('[data-cinder-drag-preview]')).toBeNull();
+  });
+
+  test('Escape during pointer drag removes the preview portal', async () => {
+    const { container } = renderBoard();
+    installPointerGeometry(container);
+    const handle = container.querySelector('[aria-label="Move Alpha"]') as HTMLElement;
+    installPointerCapture(handle);
+
+    await fireEvent.pointerDown(handle, {
+      button: 0,
+      clientX: 20,
+      clientY: 20,
+      pointerId: 1,
+      pointerType: 'mouse',
+    });
+
+    expect(document.querySelector('[data-cinder-drag-preview]')).not.toBeNull();
+
+    await fireEvent.keyDown(handle, { key: 'Escape' });
+
+    expect(document.querySelector('[data-cinder-drag-preview]')).toBeNull();
+  });
+
+  test('window Escape during pointer drag removes the preview portal', async () => {
+    const { container } = renderBoard();
+    installPointerGeometry(container);
+    const handle = container.querySelector('[aria-label="Move Alpha"]') as HTMLElement;
+    installPointerCapture(handle);
+
+    await fireEvent.pointerDown(handle, {
+      button: 0,
+      clientX: 20,
+      clientY: 20,
+      pointerId: 1,
+      pointerType: 'mouse',
+    });
+
+    expect(document.querySelector('[data-cinder-drag-preview]')).not.toBeNull();
+
+    await fireEvent.keyDown(window, { key: 'Escape' });
+
+    expect(document.querySelector('[data-cinder-drag-preview]')).toBeNull();
+  });
+
+  test('keyboard lift does NOT create a preview portal', async () => {
+    const { container } = renderBoard();
+    const handle = container.querySelector('[aria-label="Move Alpha"]') as HTMLElement;
+
+    await fireEvent.keyDown(handle, { key: ' ' });
+
+    expect(document.querySelector('[data-cinder-drag-preview]')).toBeNull();
+    const cardRow = container.querySelector('[data-key="a"]') as HTMLElement;
+    expect(cardRow?.classList.contains('cinder-sortable-item--lifted')).toBe(true);
+    expect(cardRow?.classList.contains('cinder-sortable-item--placeholder')).toBe(false);
+
+    await fireEvent.keyDown(handle, { key: 'Escape' });
+  });
+
+  test('cross-column pointer drag creates a preview and a placeholder in the source column', async () => {
+    const { container } = renderBoard();
+    installPointerGeometry(container);
+    const handle = container.querySelector('[aria-label="Move Alpha"]') as HTMLElement;
+    installPointerCapture(handle);
+
+    await fireEvent.pointerDown(handle, {
+      button: 0,
+      clientX: 20,
+      clientY: 20,
+      pointerId: 1,
+      pointerType: 'mouse',
+    });
+
+    // Move pointer into the second column.
+    await fireEvent.pointerMove(handle, {
+      clientX: 240,
+      clientY: 4,
+      pointerId: 1,
+      pointerType: 'mouse',
+    });
+    await waitForAnimationFrame();
+
+    // Preview must still be on body.
+    const preview = document.querySelector('[data-cinder-drag-preview]');
+    expect(preview).not.toBeNull();
+    expect(document.body.contains(preview)).toBe(true);
+
+    await fireEvent.pointerUp(handle, { pointerId: 1, pointerType: 'mouse' });
+    expect(document.querySelector('[data-cinder-drag-preview]')).toBeNull();
   });
 });

--- a/packages/components/src/components/sortable-list/sortable-list.a11y.md
+++ b/packages/components/src/components/sortable-list/sortable-list.a11y.md
@@ -49,6 +49,18 @@ HTML5 Drag and Drop API is **not used**. iOS Safari does not fire touch events o
 
 Pointer Events (`pointerdown`, `pointermove`, `pointerup`, `pointercancel`) with `setPointerCapture` are used instead. This handles mouse, touch, and stylus uniformly. The drag handle has `touch-action: none` so the browser does not steal vertical pans.
 
+## Drag Preview
+
+During a pointer drag a fixed-position overlay (`.cinder-sortable-drag-preview`) is appended to `document.body`. The overlay clones the lifted row's HTML so the user can see what they are dragging as the pointer moves. The preview:
+
+- Has `aria-hidden="true"` — it is purely visual and does not duplicate AT content.
+- Has `pointer-events: none` — it does not interfere with drop-target hit testing.
+- Is removed on drop, cancel, `pointercancel`, Escape (both handle-level and window-level), and component destroy.
+
+The source row switches from `.cinder-sortable-item--lifted` to `.cinder-sortable-item--placeholder` during a pointer drag. The placeholder uses a dashed border and reduced opacity to mark the current drop target position without showing full card content.
+
+Keyboard lifts use `.cinder-sortable-item--lifted` (no preview overlay — the item moves in-place).
+
 ## Focus Retention
 
 Svelte's keyed `each` block preserves the focused DOM node across visual reorders. Focus stays on the handle of the lifted item as Arrow Up/Down moves it through the list.
@@ -57,9 +69,12 @@ Cancellation on bare `focusout` is intentionally not implemented — DOM reorder
 
 ## Auto-Scroll
 
-Window-only auto-scroll is implemented. When the pointer is within 32px of the viewport top or bottom during a drag, the page scrolls at 8px/frame and the insertion target is recomputed after each frame.
+Window-only vertical auto-scroll is implemented. When the pointer is within 32px of the viewport top or bottom during a drag, the page scrolls at 8px/frame and the insertion target is recomputed after each frame.
 
-**Nested scroll containers are not supported.** Items inside a scrollable container (other than the window) will not auto-scroll during a pointer drag.
+**Known auto-scroll limitations:**
+
+- **Nested scroll containers**: Items inside a scrollable container (other than the window) will not auto-scroll during a pointer drag. Auto-scroll only applies to `window.scrollBy`.
+- **Horizontal scroll**: The auto-scroll loop checks only the vertical edges of the viewport. Horizontal scroll (e.g. scrolling the KanbanBoard's columns container to reveal off-screen columns during a drag) is not implemented. Dragging a card toward the right/left edge of a KanbanBoard that overflows horizontally will not auto-scroll the board container.
 
 ## Reduced Motion
 

--- a/packages/components/src/components/sortable-list/sortable-list.a11y.md
+++ b/packages/components/src/components/sortable-list/sortable-list.a11y.md
@@ -57,7 +57,7 @@ During a pointer drag a fixed-position overlay (`.cinder-sortable-drag-preview`)
 - Has `pointer-events: none` — it does not interfere with drop-target hit testing.
 - Is removed on drop, cancel, `pointercancel`, Escape (both handle-level and window-level), and component destroy.
 
-The source row switches from `.cinder-sortable-item--lifted` to `.cinder-sortable-item--placeholder` during a pointer drag. The placeholder uses a dashed border and reduced opacity to mark the current drop target position without showing full card content.
+The source row switches from `.cinder-sortable-item--lifted` to `.cinder-sortable-item--placeholder` during a pointer drag. The placeholder uses a dashed outline (not a border, to avoid box-size change) and reduced opacity to mark the current drop target position. Its child content is hidden via `visibility: hidden` so only the drop slot shape is visible, not a ghost of the card content.
 
 Keyboard lifts use `.cinder-sortable-item--lifted` (no preview overlay — the item moves in-place).
 

--- a/packages/components/src/components/sortable-list/sortable-list.css
+++ b/packages/components/src/components/sortable-list/sortable-list.css
@@ -22,6 +22,26 @@
     position: relative;
   }
 
+  /*
+   * During a pointer drag the source row becomes a placeholder — a translucent
+   * ghost that marks the current drop target while the real preview follows the
+   * pointer. The drop-target column / position is always visible because
+   * visualColumns / visualItems already re-inserts the placeholder at the
+   * destination index as the pointer moves.
+   */
+  .cinder-sortable-item--placeholder {
+    opacity: 0.4;
+    border: 2px dashed var(--cinder-border-muted, rgb(0 0 0 / 0.15));
+    border-radius: var(--cinder-radius-md, 4px);
+    box-shadow: none;
+    background: transparent;
+  }
+
+  .cinder-sortable-item--placeholder > * {
+    /* Hide child content from sight; placeholder conveys drop position only. */
+    visibility: hidden;
+  }
+
   .cinder-sortable-item--shifting {
     transition: transform 150ms ease;
   }
@@ -34,6 +54,10 @@
     .cinder-sortable-item--lifted {
       transform: none;
       box-shadow: var(--cinder-shadow-elevated, 0 4px 16px rgb(0 0 0 / 0.15));
+    }
+
+    .cinder-sortable-item--placeholder {
+      opacity: 0.6;
     }
   }
 
@@ -59,5 +83,56 @@
 
   .cinder-sortable-handle[aria-pressed='true'] {
     cursor: grabbing;
+  }
+
+  /* ========================================
+   * DRAG PREVIEW OVERLAY
+   * ======================================== */
+
+  /*
+   * The drag preview is a fixed-position portal appended to <body> during a
+   * pointer drag. It clones the lifted item's content and follows the pointer
+   * so the user always has a clear visual of what they are dragging.
+   *
+   * Positioning uses CSS custom properties set by _sortable-item.svelte:
+   *   --preview-left / --preview-top   — row's bounding rect at lift time
+   *   --preview-dx / --preview-dy      — pointer delta since lift
+   *   --preview-width / --preview-height — row dimensions at lift time
+   *
+   * The transform translates the preview to the pointer location.
+   */
+  .cinder-sortable-drag-preview {
+    position: fixed;
+    inset-block-start: calc(var(--preview-top, 0px) + var(--preview-dy, 0px));
+    inset-inline-start: calc(var(--preview-left, 0px) + var(--preview-dx, 0px));
+    inline-size: var(--preview-width, auto);
+    block-size: var(--preview-height, auto);
+    z-index: var(--cinder-z-drag-preview, 9999);
+    pointer-events: none;
+    box-shadow: var(--cinder-shadow-elevated, 0 4px 16px rgb(0 0 0 / 0.15));
+    border-radius: var(--cinder-radius-md, 4px);
+    /* Subtle rotation and scale to distinguish preview from the placeholder. */
+    transform: rotate(2deg) scale(1.02);
+    transform-origin: center top;
+    will-change: top, left;
+    overflow: hidden;
+  }
+
+  /* Restore full opacity and visibility inside the preview clone. */
+  .cinder-sortable-drag-preview > * {
+    opacity: 1;
+    visibility: visible;
+  }
+
+  /* Inside the preview clone keep children visible even if the source
+     had placeholder--hidden children. */
+  .cinder-sortable-drag-preview > * > * {
+    visibility: visible;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .cinder-sortable-drag-preview {
+      transform: none;
+    }
   }
 }

--- a/packages/components/src/components/sortable-list/sortable-list.css
+++ b/packages/components/src/components/sortable-list/sortable-list.css
@@ -115,8 +115,8 @@
     position: fixed;
     top: calc(var(--preview-top, 0px) + var(--preview-dy, 0px));
     left: calc(var(--preview-left, 0px) + var(--preview-dx, 0px));
-    inline-size: var(--preview-width, auto);
-    block-size: var(--preview-height, auto);
+    width: var(--preview-width, auto);
+    height: var(--preview-height, auto);
     z-index: var(--cinder-z-drag-preview, 9999);
     pointer-events: none;
     box-shadow: var(--cinder-shadow-elevated, 0 4px 16px rgb(0 0 0 / 0.15));

--- a/packages/components/src/components/sortable-list/sortable-list.css
+++ b/packages/components/src/components/sortable-list/sortable-list.css
@@ -28,10 +28,16 @@
    * pointer. The drop-target column / position is always visible because
    * visualColumns / visualItems already re-inserts the placeholder at the
    * destination index as the pointer moves.
+   *
+   * Outline is used instead of border so the drop indicator does not affect
+   * the box model. Adding a border where none exists at rest would shift box
+   * dimensions by 2px on each side, causing layout jitter and skewing the
+   * midpoint geometry used by drop-target calculations.
    */
   .cinder-sortable-item--placeholder {
     opacity: 0.4;
-    border: 2px dashed var(--cinder-border-muted, rgb(0 0 0 / 0.15));
+    outline: 2px dashed var(--cinder-border-muted, rgb(0 0 0 / 0.15));
+    outline-offset: -1px;
     border-radius: var(--cinder-radius-md, 4px);
     box-shadow: none;
     background: transparent;
@@ -99,7 +105,10 @@
    *   --preview-dx / --preview-dy      — pointer delta since lift
    *   --preview-width / --preview-height — row dimensions at lift time
    *
-   * The transform translates the preview to the pointer location.
+   * Position is computed via inset-block-start / inset-inline-start using the
+   * custom properties above. The transform applies only a subtle rotate + scale
+   * to visually distinguish the preview from the placeholder — it does not
+   * translate the preview.
    */
   .cinder-sortable-drag-preview {
     position: fixed;

--- a/packages/components/src/components/sortable-list/sortable-list.css
+++ b/packages/components/src/components/sortable-list/sortable-list.css
@@ -101,19 +101,20 @@
    * so the user always has a clear visual of what they are dragging.
    *
    * Positioning uses CSS custom properties set by _sortable-item.svelte:
-   *   --preview-left / --preview-top   — row's bounding rect at lift time
+   *   --preview-left / --preview-top   — row's bounding rect at lift time (physical viewport coords)
    *   --preview-dx / --preview-dy      — pointer delta since lift
    *   --preview-width / --preview-height — row dimensions at lift time
    *
-   * Position is computed via inset-block-start / inset-inline-start using the
-   * custom properties above. The transform applies only a subtle rotate + scale
-   * to visually distinguish the preview from the placeholder — it does not
-   * translate the preview.
+   * Physical left/top (not logical inset-inline-start/inset-block-start) are used
+   * because --preview-left/--preview-top come from getBoundingClientRect(), which
+   * always returns physical viewport distances regardless of writing direction.
+   * Using inset-inline-start would map to the right edge in RTL layouts, causing
+   * the preview to appear on the wrong side of the viewport.
    */
   .cinder-sortable-drag-preview {
     position: fixed;
-    inset-block-start: calc(var(--preview-top, 0px) + var(--preview-dy, 0px));
-    inset-inline-start: calc(var(--preview-left, 0px) + var(--preview-dx, 0px));
+    top: calc(var(--preview-top, 0px) + var(--preview-dy, 0px));
+    left: calc(var(--preview-left, 0px) + var(--preview-dx, 0px));
     inline-size: var(--preview-width, auto);
     block-size: var(--preview-height, auto);
     z-index: var(--cinder-z-drag-preview, 9999);

--- a/packages/components/src/components/sortable-list/sortable-list.test.ts
+++ b/packages/components/src/components/sortable-list/sortable-list.test.ts
@@ -1,6 +1,6 @@
 // @ts-nocheck — test file; noUncheckedIndexedAccess and bun:test types disabled per project convention
 /// <reference lib="dom" />
-import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
+import { afterEach, describe, expect, mock, test } from 'bun:test';
 import { createRawSnippet } from 'svelte';
 
 import { setupHappyDom } from '../../test/happy-dom.ts';
@@ -565,14 +565,6 @@ async function waitForAnimationFrame(): Promise<void> {
 }
 
 describe('SortableList pointer drag preview', () => {
-  // Capture the body's child count before each test so we can assert portal
-  // creation and removal relative to a known baseline.
-  let baselineBodyChildren: number;
-
-  beforeEach(() => {
-    baselineBodyChildren = document.body.children.length;
-  });
-
   afterEach(() => {
     // Clean up any orphaned portals that a failing test left behind.
     document.querySelectorAll('[data-cinder-drag-preview]').forEach((element) => element.remove());

--- a/packages/components/src/components/sortable-list/sortable-list.test.ts
+++ b/packages/components/src/components/sortable-list/sortable-list.test.ts
@@ -864,6 +864,43 @@ describe('SortableList pointer drag preview', () => {
     expect(document.querySelectorAll('[data-cinder-drag-preview]').length).toBe(0);
   });
 
+  test('rejected lift (another item already lifted) does NOT create an orphaned preview portal', async () => {
+    const { container } = renderList();
+    const handles = container.querySelectorAll('.cinder-sortable-handle');
+    const firstHandle = handles[0] as HTMLElement;
+    const secondHandle = handles[1] as HTMLElement;
+    installPointerCaptureOnHandle(firstHandle);
+    installPointerCaptureOnHandle(secondHandle);
+
+    // Lift the first item.
+    await fireEvent.pointerDown(firstHandle, {
+      button: 0,
+      clientX: 50,
+      clientY: 100,
+      pointerId: 1,
+      pointerType: 'mouse',
+    });
+
+    expect(document.querySelectorAll('[data-cinder-drag-preview]').length).toBe(1);
+
+    // Attempt a second pointerdown on a different item while the first is still lifted.
+    // The controller rejects the concurrent lift; no second portal should be created.
+    await fireEvent.pointerDown(secondHandle, {
+      button: 0,
+      clientX: 50,
+      clientY: 200,
+      pointerId: 2,
+      pointerType: 'mouse',
+    });
+
+    // Still exactly one portal — the second lift was rejected.
+    expect(document.querySelectorAll('[data-cinder-drag-preview]').length).toBe(1);
+
+    // Clean up the first drag.
+    await fireEvent.pointerUp(firstHandle, { pointerId: 1, pointerType: 'mouse' });
+    expect(document.querySelectorAll('[data-cinder-drag-preview]').length).toBe(0);
+  });
+
   test('rapid second drag after drop does not leave extra portals', async () => {
     const { container } = renderList();
     const handle = container.querySelectorAll('.cinder-sortable-handle')[0] as HTMLElement;

--- a/packages/components/src/components/sortable-list/sortable-list.test.ts
+++ b/packages/components/src/components/sortable-list/sortable-list.test.ts
@@ -805,4 +805,155 @@ describe('SortableList pointer drag preview', () => {
 
     expect(document.querySelector('[data-cinder-drag-preview]')).toBeNull();
   });
+
+  // ---------------------------------------------------------------------------
+  // Regression: orphaned rAF after Escape — Issue 3 fix verification
+  // ---------------------------------------------------------------------------
+  //
+  // Before the fix, destroyPreviewPortal() did not cancel moveRafHandle. A
+  // queued rAF from handlePointerMove could fire after the portal was removed,
+  // then clear moveRafHandle to null. If a second drag started before that
+  // frame fired, the orphan would clobber the second session's rAF gate and
+  // drive the new portal with stale coordinates from the first drag.
+
+  test('Escape during pointer drag followed by queued rAF — no orphaned frame / no leftover portal', async () => {
+    const { container } = renderList();
+    const handle = container.querySelectorAll('.cinder-sortable-handle')[0] as HTMLElement;
+    installPointerCaptureOnHandle(handle);
+
+    await fireEvent.pointerDown(handle, {
+      button: 0,
+      clientX: 50,
+      clientY: 100,
+      pointerId: 1,
+      pointerType: 'mouse',
+    });
+
+    // Queue a move rAF by sending a pointer move (rAF will be scheduled).
+    await fireEvent.pointerMove(handle, {
+      clientX: 60,
+      clientY: 110,
+      pointerId: 1,
+      pointerType: 'mouse',
+    });
+
+    // Cancel via Escape before the rAF fires.
+    await fireEvent.keyDown(handle, { key: 'Escape' });
+
+    // Drain the rAF queue — the cancelled/destroyed portal must not survive.
+    await waitForAnimationFrame();
+    await waitForAnimationFrame();
+
+    expect(document.querySelectorAll('[data-cinder-drag-preview]').length).toBe(0);
+  });
+
+  test('portal count is 0 when idle and exactly 1 during a single drag', async () => {
+    const { container } = renderList();
+    const handle = container.querySelectorAll('.cinder-sortable-handle')[0] as HTMLElement;
+    installPointerCaptureOnHandle(handle);
+
+    // Idle: no portals.
+    expect(document.querySelectorAll('[data-cinder-drag-preview]').length).toBe(0);
+
+    await fireEvent.pointerDown(handle, {
+      button: 0,
+      clientX: 50,
+      clientY: 100,
+      pointerId: 1,
+      pointerType: 'mouse',
+    });
+
+    // During drag: exactly 1 portal.
+    expect(document.querySelectorAll('[data-cinder-drag-preview]').length).toBe(1);
+
+    await fireEvent.pointerUp(handle, { pointerId: 1, pointerType: 'mouse' });
+
+    // After drop: no portals.
+    expect(document.querySelectorAll('[data-cinder-drag-preview]').length).toBe(0);
+  });
+
+  test('rapid second drag after drop does not leave extra portals', async () => {
+    const { container } = renderList();
+    const handle = container.querySelectorAll('.cinder-sortable-handle')[0] as HTMLElement;
+    installPointerCaptureOnHandle(handle);
+
+    // First drag.
+    await fireEvent.pointerDown(handle, {
+      button: 0,
+      clientX: 50,
+      clientY: 100,
+      pointerId: 1,
+      pointerType: 'mouse',
+    });
+    await fireEvent.pointerUp(handle, { pointerId: 1, pointerType: 'mouse' });
+
+    // Second drag immediately after.
+    await fireEvent.pointerDown(handle, {
+      button: 0,
+      clientX: 50,
+      clientY: 100,
+      pointerId: 2,
+      pointerType: 'mouse',
+    });
+
+    expect(document.querySelectorAll('[data-cinder-drag-preview]').length).toBe(1);
+
+    await fireEvent.pointerUp(handle, { pointerId: 2, pointerType: 'mouse' });
+
+    expect(document.querySelectorAll('[data-cinder-drag-preview]').length).toBe(0);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Regression: clone id stripping — Issue 2 fix verification
+  // ---------------------------------------------------------------------------
+
+  test('preview portal clone does not duplicate id attributes from the source row', async () => {
+    // Use a single-item list so there is exactly one element carrying the test
+    // id in the container, making the before/after count unambiguous.
+    const singleItem = [{ id: 'solo', label: 'Solo' }];
+    const idSnippet = createRawSnippet(() => ({
+      render: () => `<span id="unique-span-id">content</span>`,
+      setup: () => {},
+    }));
+
+    const { container } = render(SortableList as any, {
+      props: {
+        items: singleItem,
+        getKey: (item: { id: string }) => item.id,
+        getItemLabel: (item: { label: string }) => item.label,
+        onreorder: mock(),
+        label: 'Id test list',
+        children: idSnippet,
+      },
+    });
+
+    const handle = container.querySelector('.cinder-sortable-handle') as HTMLElement;
+    installPointerCaptureOnHandle(handle);
+
+    // Pre-drag: exactly one element with the id inside the container.
+    expect(container.querySelectorAll('#unique-span-id').length).toBe(1);
+
+    await fireEvent.pointerDown(handle, {
+      button: 0,
+      clientX: 50,
+      clientY: 100,
+      pointerId: 1,
+      pointerType: 'mouse',
+    });
+
+    // The source row still has the id.
+    expect(container.querySelectorAll('#unique-span-id').length).toBe(1);
+    // The portal clone must NOT contain any element with that id.
+    const portal = document.querySelector('[data-cinder-drag-preview]') as HTMLElement;
+    expect(portal).not.toBeNull();
+    expect(portal.querySelectorAll('#unique-span-id').length).toBe(0);
+    // The portal itself must have no id attribute.
+    expect(portal.hasAttribute('id')).toBe(false);
+    // The portal must carry inert to suppress interaction.
+    expect(portal.hasAttribute('inert')).toBe(true);
+    // Document-wide: only one element with this id exists (in the source).
+    expect(document.querySelectorAll('#unique-span-id').length).toBe(1);
+
+    await fireEvent.pointerUp(handle, { pointerId: 1, pointerType: 'mouse' });
+  });
 });

--- a/packages/components/src/components/sortable-list/sortable-list.test.ts
+++ b/packages/components/src/components/sortable-list/sortable-list.test.ts
@@ -1,6 +1,6 @@
 // @ts-nocheck — test file; noUncheckedIndexedAccess and bun:test types disabled per project convention
 /// <reference lib="dom" />
-import { describe, expect, mock, test } from 'bun:test';
+import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
 import { createRawSnippet } from 'svelte';
 
 import { setupHappyDom } from '../../test/happy-dom.ts';
@@ -537,5 +537,272 @@ describe('SortableList', () => {
     await new Promise((resolve) => setTimeout(resolve, 10));
     const liveRegion = container.querySelector('[role="alert"]');
     expect(liveRegion?.textContent).toContain('CUSTOM Alpha LIFTED');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Pointer drag preview state contract tests
+// ---------------------------------------------------------------------------
+//
+// happy-dom cannot prove pixels, so we test the STATE CONTRACT:
+//   - During a pointer drag a [data-cinder-drag-preview] portal is appended to body.
+//   - The lifted row gains cinder-sortable-item--placeholder (not --lifted).
+//   - The preview element is present in document.body (not inside the list).
+//   - data-preview-x / data-preview-y on the lifted row track pointer coords.
+//   - On drop the preview is removed and the placeholder class is gone.
+//   - On pointer cancel the preview is removed.
+//   - On Escape during pointer drag the preview is removed.
+//   - Keyboard lifts do NOT create a preview portal (preview is pointer-only).
+
+function installPointerCaptureOnHandle(handle: HTMLElement): void {
+  handle.setPointerCapture = mock(() => {});
+  handle.releasePointerCapture = mock(() => {});
+  handle.hasPointerCapture = mock(() => true);
+}
+
+async function waitForAnimationFrame(): Promise<void> {
+  await new Promise((resolve) => requestAnimationFrame(resolve));
+}
+
+describe('SortableList pointer drag preview', () => {
+  // Capture the body's child count before each test so we can assert portal
+  // creation and removal relative to a known baseline.
+  let baselineBodyChildren: number;
+
+  beforeEach(() => {
+    baselineBodyChildren = document.body.children.length;
+  });
+
+  afterEach(() => {
+    // Clean up any orphaned portals that a failing test left behind.
+    document.querySelectorAll('[data-cinder-drag-preview]').forEach((element) => element.remove());
+  });
+
+  test('pointer drag appends a drag preview portal to document.body', async () => {
+    const { container } = renderList();
+    const handle = container.querySelectorAll('.cinder-sortable-handle')[0] as HTMLElement;
+    installPointerCaptureOnHandle(handle);
+
+    await fireEvent.pointerDown(handle, {
+      button: 0,
+      clientX: 50,
+      clientY: 100,
+      pointerId: 1,
+      pointerType: 'mouse',
+    });
+
+    const preview = document.querySelector('[data-cinder-drag-preview]');
+    expect(preview).not.toBeNull();
+    // Preview must be on body, not inside the list container.
+    expect(document.body.contains(preview)).toBe(true);
+    expect(container.contains(preview)).toBe(false);
+
+    // Cleanup.
+    await fireEvent.pointerUp(handle, { pointerId: 1, pointerType: 'mouse' });
+  });
+
+  test('preview has aria-hidden=true so it does not duplicate AT content', async () => {
+    const { container } = renderList();
+    const handle = container.querySelectorAll('.cinder-sortable-handle')[0] as HTMLElement;
+    installPointerCaptureOnHandle(handle);
+
+    await fireEvent.pointerDown(handle, {
+      button: 0,
+      clientX: 50,
+      clientY: 100,
+      pointerId: 1,
+      pointerType: 'mouse',
+    });
+
+    const preview = document.querySelector('[data-cinder-drag-preview]');
+    expect(preview?.getAttribute('aria-hidden')).toBe('true');
+
+    await fireEvent.pointerUp(handle, { pointerId: 1, pointerType: 'mouse' });
+  });
+
+  test('lifted row has --placeholder class during pointer drag (not --lifted)', async () => {
+    const { container } = renderList();
+    const handle = container.querySelectorAll('.cinder-sortable-handle')[0] as HTMLElement;
+    installPointerCaptureOnHandle(handle);
+
+    await fireEvent.pointerDown(handle, {
+      button: 0,
+      clientX: 50,
+      clientY: 100,
+      pointerId: 1,
+      pointerType: 'mouse',
+    });
+
+    const liftedRow = container.querySelector('[data-key="a"]') as HTMLElement;
+    expect(liftedRow?.classList.contains('cinder-sortable-item--placeholder')).toBe(true);
+    expect(liftedRow?.classList.contains('cinder-sortable-item--lifted')).toBe(false);
+
+    await fireEvent.pointerUp(handle, { pointerId: 1, pointerType: 'mouse' });
+  });
+
+  test('lifted row exposes data-preview-x and data-preview-y during pointer drag', async () => {
+    const { container } = renderList();
+    const handle = container.querySelectorAll('.cinder-sortable-handle')[0] as HTMLElement;
+    installPointerCaptureOnHandle(handle);
+
+    await fireEvent.pointerDown(handle, {
+      button: 0,
+      clientX: 50,
+      clientY: 100,
+      pointerId: 1,
+      pointerType: 'mouse',
+    });
+
+    const liftedRow = container.querySelector('[data-key="a"]') as HTMLElement;
+    expect(liftedRow?.getAttribute('data-preview-x')).toBe('50');
+    expect(liftedRow?.getAttribute('data-preview-y')).toBe('100');
+
+    await fireEvent.pointerUp(handle, { pointerId: 1, pointerType: 'mouse' });
+  });
+
+  test('preview position attributes update on pointer move', async () => {
+    const { container } = renderList();
+    const handle = container.querySelectorAll('.cinder-sortable-handle')[0] as HTMLElement;
+    installPointerCaptureOnHandle(handle);
+
+    await fireEvent.pointerDown(handle, {
+      button: 0,
+      clientX: 50,
+      clientY: 100,
+      pointerId: 1,
+      pointerType: 'mouse',
+    });
+
+    await fireEvent.pointerMove(handle, {
+      clientX: 80,
+      clientY: 160,
+      pointerId: 1,
+      pointerType: 'mouse',
+    });
+    await waitForAnimationFrame();
+
+    const liftedRow = container.querySelector('[data-key="a"]') as HTMLElement;
+    expect(liftedRow?.getAttribute('data-preview-x')).toBe('80');
+    expect(liftedRow?.getAttribute('data-preview-y')).toBe('160');
+
+    await fireEvent.pointerUp(handle, { pointerId: 1, pointerType: 'mouse' });
+  });
+
+  test('drop removes the preview portal from document.body', async () => {
+    const { container } = renderList();
+    const handle = container.querySelectorAll('.cinder-sortable-handle')[0] as HTMLElement;
+    installPointerCaptureOnHandle(handle);
+
+    await fireEvent.pointerDown(handle, {
+      button: 0,
+      clientX: 50,
+      clientY: 100,
+      pointerId: 1,
+      pointerType: 'mouse',
+    });
+
+    expect(document.querySelector('[data-cinder-drag-preview]')).not.toBeNull();
+
+    await fireEvent.pointerUp(handle, { pointerId: 1, pointerType: 'mouse' });
+
+    expect(document.querySelector('[data-cinder-drag-preview]')).toBeNull();
+  });
+
+  test('drop clears placeholder class and data-preview-x/y from the row', async () => {
+    const { container } = renderList();
+    const handle = container.querySelectorAll('.cinder-sortable-handle')[0] as HTMLElement;
+    installPointerCaptureOnHandle(handle);
+
+    await fireEvent.pointerDown(handle, {
+      button: 0,
+      clientX: 50,
+      clientY: 100,
+      pointerId: 1,
+      pointerType: 'mouse',
+    });
+    await fireEvent.pointerUp(handle, { pointerId: 1, pointerType: 'mouse' });
+
+    const row = container.querySelector('[data-key="a"]') as HTMLElement;
+    expect(row?.classList.contains('cinder-sortable-item--placeholder')).toBe(false);
+    expect(row?.hasAttribute('data-preview-x')).toBe(false);
+    expect(row?.hasAttribute('data-preview-y')).toBe(false);
+  });
+
+  test('pointercancel removes the preview portal (cancel path)', async () => {
+    const { container } = renderList();
+    const handle = container.querySelectorAll('.cinder-sortable-handle')[0] as HTMLElement;
+    installPointerCaptureOnHandle(handle);
+
+    await fireEvent.pointerDown(handle, {
+      button: 0,
+      clientX: 50,
+      clientY: 100,
+      pointerId: 1,
+      pointerType: 'mouse',
+    });
+
+    expect(document.querySelector('[data-cinder-drag-preview]')).not.toBeNull();
+
+    await fireEvent.pointerCancel(handle, { pointerId: 1, pointerType: 'mouse' });
+
+    expect(document.querySelector('[data-cinder-drag-preview]')).toBeNull();
+  });
+
+  test('Escape during pointer drag removes the preview portal', async () => {
+    const { container } = renderList();
+    const handle = container.querySelectorAll('.cinder-sortable-handle')[0] as HTMLElement;
+    installPointerCaptureOnHandle(handle);
+
+    await fireEvent.pointerDown(handle, {
+      button: 0,
+      clientX: 50,
+      clientY: 100,
+      pointerId: 1,
+      pointerType: 'mouse',
+    });
+
+    expect(document.querySelector('[data-cinder-drag-preview]')).not.toBeNull();
+
+    await fireEvent.keyDown(handle, { key: 'Escape' });
+
+    expect(document.querySelector('[data-cinder-drag-preview]')).toBeNull();
+  });
+
+  test('keyboard lift does NOT create a preview portal', async () => {
+    const { container } = renderList();
+    const handle = container.querySelectorAll('.cinder-sortable-handle')[0] as HTMLElement;
+
+    await fireEvent.keyDown(handle, { key: ' ' });
+
+    // Keyboard drag: no preview portal should exist.
+    expect(document.querySelector('[data-cinder-drag-preview]')).toBeNull();
+    // Keyboard drag: row should have --lifted class, not --placeholder.
+    const row = container.querySelector('[data-key="a"]') as HTMLElement;
+    expect(row?.classList.contains('cinder-sortable-item--lifted')).toBe(true);
+    expect(row?.classList.contains('cinder-sortable-item--placeholder')).toBe(false);
+
+    // Cleanup.
+    await fireEvent.keyDown(handle, { key: 'Escape' });
+  });
+
+  test('window Escape during pointer drag removes the preview portal', async () => {
+    const { container } = renderList();
+    const handle = container.querySelectorAll('.cinder-sortable-handle')[0] as HTMLElement;
+    installPointerCaptureOnHandle(handle);
+
+    await fireEvent.pointerDown(handle, {
+      button: 0,
+      clientX: 50,
+      clientY: 100,
+      pointerId: 1,
+      pointerType: 'mouse',
+    });
+
+    expect(document.querySelector('[data-cinder-drag-preview]')).not.toBeNull();
+
+    // Simulate window-level Escape (SortableList's handleWindowKeydown).
+    await fireEvent.keyDown(window, { key: 'Escape' });
+
+    expect(document.querySelector('[data-cinder-drag-preview]')).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary

Pointer-dragging a Sortable/KanbanBoard card gave no visible feedback (the shared `_sortable-item` uses pointer events, not native DnD, so there's no browser drag image).

Added a drag **preview portal** in the shared `_sortable-item.svelte`: on pointerdown it clones the row into a `position: fixed` `div[data-cinder-drag-preview]` on `document.body` that follows the pointer (updated each rAF frame via CSS custom properties, preserving the original grab offset); the source row becomes a dashed translucent **placeholder** marking the drop position. Both SortableList and KanbanBoard get the feedback without duplication. Drop, cancel, pointercancel, Escape (handle- and window-level), and component destroy all remove the portal and cancel the rAF — no orphaned overlay or frame.

Stayed with pointer events (no native-DnD switch). Keyboard drag + live-region announcements are untouched. Auto-scroll limitations (window-vertical only; horizontal/nested-scroll not implemented) are documented with guarding tests. Public API unchanged.

## Review committee

Codex (gpt-5.4, xhigh) + author. All 5 Codex findings on the shared-primitive portal were real and fixed: preview CSS now in both component stylesheets (a KanbanBoard subpath consumer was getting an unstyled body portal); cloned `id` attributes stripped + `inert` set on the portal (no duplicate-id a11y breakage); `destroyPreviewPortal` now cancels the rAF in every cleanup path (no orphaned frame leaking into a later drag); grab-offset preserved; and lifecycle regression tests added (Escape+queued-rAF, exact portal count idle/dragging, rapid second drag, clone-id-stripping).

## Test plan
- [x] `bun run --filter=cinder test -- kanban-board sortable-list component-css` — 133 pass
- [x] `components:check` / `typecheck` / `lint` (oxlint+stylelint) — clean
- Note: state-contract tested; pixel-level preview-follows-pointer needs a real browser.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches shared drag DOM (body portals, id stripping, rAF lifecycle) and Kanban pointer hit-testing; mitigated by contract tests and no public API changes, but regressions could affect reorder UX or a11y if cleanup paths miss an edge case.
> 
> **Overview**
> Adds **visible pointer-drag feedback** to the shared `_sortable-item` primitive used by **SortableList** and **KanbanBoard**: on pointer lift it appends a fixed `document.body` portal (`[data-cinder-drag-preview]`) that clones the row and tracks the pointer (grab offset + rAF updates); the in-list row becomes a dashed **placeholder** instead of the keyboard **lifted** styling.
> 
> **KanbanBoard** fixes pointer drop-target math by excluding the dragged card via stable `data-key` (not `--lifted`, which pointer drags no longer use). Preview/placeholder **CSS is duplicated** into `kanban-board.css` so Kanban-only style imports still position the body portal; a11y notes call out vertical-only auto-scroll limits.
> 
> Lifecycle hardening: portal teardown on drop/cancel/Escape/destroy, **move rAF cancelled** with the portal, rejected concurrent lifts, clone **`id` stripping** + `inert`/`aria-hidden` on the preview. Large **state-contract** test suites added; public API unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 06ea0f35f143444518fa20f7ea14d2a9101857ff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->