### PR TITLE
feat(playground): report-only raw-native-control authoring guard (8b445569 part 1)

### DIFF
--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "bun --watch run src/playground-server.ts",
+    "examples:audit": "bun run scripts/check-raw-native-controls.ts",
     "lint": "oxlint src/ scripts/",
     "lint:fix": "oxlint --fix src/ scripts/",
     "test": "bun run scripts/run-tests.ts",

--- a/packages/playground/scripts/check-raw-native-controls.test.ts
+++ b/packages/playground/scripts/check-raw-native-controls.test.ts
@@ -104,6 +104,19 @@ describe('stripCommentsAndStrings — comment and string removal', () => {
     expect(stripped).toContain('<button>');
   });
 
+  test('an element whose name starts with "script" does NOT enter script state', () => {
+    // `<scripting>` shares the first 7 characters with `<script` but is not the
+    // script element. Without a tag-name boundary check it would wrongly switch
+    // to script state and start stripping its following template content (e.g. a
+    // string literal). Here the real <button> after it must survive.
+    const source = '<scripting>\n  const s = "<select>";\n</scripting>\n<button>OK</button>';
+    const stripped = stripCommentsAndStrings(source);
+    // Still in template state, so the JS-string `<select>` is NOT stripped...
+    expect(stripped).toContain('<select>');
+    // ...and the real <button> is preserved.
+    expect(stripped).toContain('<button>');
+  });
+
   test('html-comment inside <script> returns to script state — block comment after it is still stripped', () => {
     // If the html-comment exit incorrectly resets to 'template', the /* block comment */
     // that follows would NOT be stripped (template state does not handle /* */), and

--- a/packages/playground/scripts/check-raw-native-controls.test.ts
+++ b/packages/playground/scripts/check-raw-native-controls.test.ts
@@ -1,0 +1,303 @@
+import { describe, expect, test } from 'bun:test';
+
+import {
+  ALLOWLIST,
+  allowlistKey,
+  buildAllowlistIndex,
+  detectRawControl,
+  RAW_CONTROL_TAG_NAMES,
+  renderReport,
+  scan,
+  toPosixPath,
+  type AllowlistEntry,
+  type RawControlOccurrence,
+} from './check-raw-native-controls.ts';
+
+// ── detectRawControl ───────────────────────────────────────────────────────────
+
+describe('detectRawControl — raw tag detection', () => {
+  test('detects <button> tag', () => {
+    expect(detectRawControl('<button type="button">Click</button>')).toBe('button');
+  });
+
+  test('detects <input> tag', () => {
+    expect(detectRawControl('<input type="checkbox" />')).toBe('input');
+  });
+
+  test('detects <select> tag', () => {
+    expect(detectRawControl('<select value={x}>')).toBe('select');
+  });
+
+  test('detects <textarea> tag', () => {
+    expect(detectRawControl('<textarea rows={4}>')).toBe('textarea');
+  });
+
+  test('detects tag when preceded by whitespace (indented templates)', () => {
+    expect(detectRawControl('        <button type="button">Submit</button>')).toBe('button');
+  });
+
+  test('detects self-closing <input />', () => {
+    expect(detectRawControl('  <input />')).toBe('input');
+  });
+
+  test('detects multi-line opening tag (just the first line)', () => {
+    // In practice the scanner sees one line at a time; the opening line has the tag.
+    expect(detectRawControl('        <button')).toBe('button');
+  });
+
+  test('does NOT detect Cinder <Button> (uppercase — a Svelte component)', () => {
+    expect(detectRawControl('<Button label="Submit" />')).toBeNull();
+  });
+
+  test('does NOT detect <ButtonGroup>', () => {
+    expect(detectRawControl('<ButtonGroup>')).toBeNull();
+  });
+
+  test('does NOT detect <selectField> (camel-variant name)', () => {
+    expect(detectRawControl('<selectField>')).toBeNull();
+  });
+
+  test('does NOT detect <inputGroup>', () => {
+    expect(detectRawControl('<inputGroup>')).toBeNull();
+  });
+
+  test('does NOT detect a non-control element (<div>)', () => {
+    expect(detectRawControl('<div class="container">')).toBeNull();
+  });
+
+  test('does NOT detect a <span>', () => {
+    expect(detectRawControl('<span>text</span>')).toBeNull();
+  });
+
+  test('returns null for empty lines', () => {
+    expect(detectRawControl('')).toBeNull();
+  });
+
+  test('returns null for text content (not markup)', () => {
+    expect(detectRawControl('The button should be pressed.')).toBeNull();
+  });
+
+  test('all four RAW_CONTROL_TAG_NAMES are detectable', () => {
+    for (const tagName of RAW_CONTROL_TAG_NAMES) {
+      expect(detectRawControl(`<${tagName}>`)).toBe(tagName);
+    }
+  });
+});
+
+// ── toPosixPath ────────────────────────────────────────────────────────────────
+
+describe('toPosixPath — OS-independent path keys', () => {
+  test('converts backslashes to forward slashes (Windows scan paths)', () => {
+    expect(toPosixPath('button\\basic.example.svelte')).toBe('button/basic.example.svelte');
+  });
+
+  test('leaves POSIX paths unchanged', () => {
+    expect(toPosixPath('button/basic.example.svelte')).toBe('button/basic.example.svelte');
+  });
+});
+
+// ── allowlistKey ───────────────────────────────────────────────────────────────
+
+describe('allowlistKey — key format', () => {
+  test('builds a stable file::line key', () => {
+    expect(allowlistKey('navigation-bar/basic.example.svelte', 20)).toBe(
+      'navigation-bar/basic.example.svelte::20',
+    );
+  });
+
+  test('normalizes backslashes in the path component', () => {
+    expect(allowlistKey('navigation-bar\\basic.example.svelte', 20)).toBe(
+      'navigation-bar/basic.example.svelte::20',
+    );
+  });
+});
+
+// ── buildAllowlistIndex ────────────────────────────────────────────────────────
+
+describe('buildAllowlistIndex — fast lookup set', () => {
+  const entries: AllowlistEntry[] = [
+    {
+      relativePath: 'navigation-bar/basic.example.svelte',
+      lineNumber: 20,
+      reason: 'receives forwarded attrs from NavigationBar menuToggle snippet',
+    },
+    {
+      relativePath: 'popover/transformed-ancestor.example.svelte',
+      lineNumber: 33,
+      reason: 'uses bind:this for triggerRef — requires a native HTMLButtonElement',
+    },
+  ];
+
+  test('contains an entry for each allowlisted file+line', () => {
+    const index = buildAllowlistIndex(entries);
+    expect(index.has('navigation-bar/basic.example.svelte::20')).toBe(true);
+    expect(index.has('popover/transformed-ancestor.example.svelte::33')).toBe(true);
+  });
+
+  test('does not contain a key for a different line on an allowlisted file', () => {
+    const index = buildAllowlistIndex(entries);
+    expect(index.has('navigation-bar/basic.example.svelte::99')).toBe(false);
+  });
+
+  test('does not contain a key for an entirely different file', () => {
+    const index = buildAllowlistIndex(entries);
+    expect(index.has('button/basic.example.svelte::20')).toBe(false);
+  });
+
+  test('empty allowlist produces an empty set', () => {
+    expect(buildAllowlistIndex([])).toEqual(new Set());
+  });
+});
+
+// ── ALLOWLIST canonical entries ────────────────────────────────────────────────
+
+describe('ALLOWLIST — canonical checked-in entries', () => {
+  test('every entry has a non-empty reason', () => {
+    for (const entry of ALLOWLIST) {
+      expect(entry.reason.trim().length).toBeGreaterThan(0);
+    }
+  });
+
+  test('every entry has a relativePath that looks like an example file', () => {
+    for (const entry of ALLOWLIST) {
+      expect(entry.relativePath).toMatch(/\.example\.svelte$/);
+    }
+  });
+
+  test('every entry has a positive line number', () => {
+    for (const entry of ALLOWLIST) {
+      expect(entry.lineNumber).toBeGreaterThan(0);
+    }
+  });
+});
+
+// ── renderReport ───────────────────────────────────────────────────────────────
+
+describe('renderReport — human-readable output', () => {
+  const makeOccurrence = (overrides: Partial<RawControlOccurrence> = {}): RawControlOccurrence => ({
+    relativePath: 'button/basic.example.svelte',
+    lineNumber: 12,
+    tagName: 'button',
+    lineText: '<button type="button">Click</button>',
+    ...overrides,
+  });
+
+  test('includes the total count in the header', () => {
+    const result = {
+      allowlisted: [makeOccurrence()],
+      flagged: [makeOccurrence({ relativePath: 'inline/basic.example.svelte', lineNumber: 11 })],
+    };
+    const report = renderReport(result);
+    expect(report).toContain('Total raw controls found: 2');
+    expect(report).toContain('1 flagged');
+    expect(report).toContain('1 allowlisted');
+  });
+
+  test('reports zero flagged when all controls are allowlisted', () => {
+    const result = { allowlisted: [makeOccurrence()], flagged: [] };
+    const report = renderReport(result);
+    expect(report).toContain('Flagged: none');
+  });
+
+  test('includes relative path and line number for flagged items', () => {
+    const result = {
+      allowlisted: [],
+      flagged: [makeOccurrence({ relativePath: 'inline/basic.example.svelte', lineNumber: 11 })],
+    };
+    const report = renderReport(result);
+    expect(report).toContain('inline/basic.example.svelte:11');
+  });
+
+  test('includes <tagName> in the rendered line', () => {
+    const result = { allowlisted: [], flagged: [makeOccurrence({ tagName: 'input' })] };
+    const report = renderReport(result);
+    expect(report).toContain('<input>');
+  });
+});
+
+// ── scan — integration against real example files ──────────────────────────────
+
+describe('scan — live inventory against the real examples directory', () => {
+  // scan() walks the real examples tree; give it generous headroom on slow CI.
+  test('returns a ScanResult with allowlisted and flagged arrays', async () => {
+    const examplesDirectory = new URL('../src/examples', import.meta.url).pathname;
+    const result = await scan(examplesDirectory);
+
+    // Both arrays must be present (possibly empty).
+    expect(Array.isArray(result.allowlisted)).toBe(true);
+    expect(Array.isArray(result.flagged)).toBe(true);
+  }, 15_000);
+
+  test('detects at least one raw control across all example files', async () => {
+    const examplesDirectory = new URL('../src/examples', import.meta.url).pathname;
+    const result = await scan(examplesDirectory);
+    const total = result.allowlisted.length + result.flagged.length;
+    // We know from the current state there are 18 raw control lines.
+    expect(total).toBeGreaterThan(0);
+  }, 15_000);
+
+  test('does NOT flag the navigation-bar menuToggle button (it is allowlisted)', async () => {
+    const examplesDirectory = new URL('../src/examples', import.meta.url).pathname;
+    const result = await scan(examplesDirectory);
+
+    const navigationBarFlagged = result.flagged.filter(
+      (occurrence) => occurrence.relativePath === 'navigation-bar/basic.example.svelte',
+    );
+    expect(navigationBarFlagged).toHaveLength(0);
+
+    const navigationBarAllowlisted = result.allowlisted.filter(
+      (occurrence) => occurrence.relativePath === 'navigation-bar/basic.example.svelte',
+    );
+    expect(navigationBarAllowlisted.length).toBeGreaterThan(0);
+  }, 15_000);
+
+  test('does NOT flag the popover transformed-ancestor trigger button (it is allowlisted)', async () => {
+    const examplesDirectory = new URL('../src/examples', import.meta.url).pathname;
+    const result = await scan(examplesDirectory);
+
+    const popoverFlagged = result.flagged.filter(
+      (occurrence) => occurrence.relativePath === 'popover/transformed-ancestor.example.svelte',
+    );
+    expect(popoverFlagged).toHaveLength(0);
+  }, 15_000);
+
+  test('every returned occurrence has a positive lineNumber and a non-empty relativePath', async () => {
+    const examplesDirectory = new URL('../src/examples', import.meta.url).pathname;
+    const result = await scan(examplesDirectory);
+
+    for (const occurrence of [...result.allowlisted, ...result.flagged]) {
+      expect(occurrence.lineNumber).toBeGreaterThan(0);
+      expect(occurrence.relativePath.length).toBeGreaterThan(0);
+      expect(RAW_CONTROL_TAG_NAMES).toContain(occurrence.tagName);
+    }
+  }, 15_000);
+
+  test('respects a custom empty allowlist (nothing is allowlisted)', async () => {
+    const examplesDirectory = new URL('../src/examples', import.meta.url).pathname;
+    const result = await scan(examplesDirectory, []);
+    // With an empty allowlist all occurrences land in flagged.
+    expect(result.allowlisted).toHaveLength(0);
+    expect(result.flagged.length).toBeGreaterThan(0);
+  }, 15_000);
+
+  test('results are sorted by relativePath then lineNumber', async () => {
+    const examplesDirectory = new URL('../src/examples', import.meta.url).pathname;
+    const result = await scan(examplesDirectory);
+    const all = [...result.allowlisted, ...result.flagged];
+    // Check each array is sorted independently.
+    for (const list of [result.allowlisted, result.flagged]) {
+      for (let index = 1; index < list.length; index++) {
+        const previous = list[index - 1]!;
+        const current = list[index]!;
+        const pathCompare = previous.relativePath.localeCompare(current.relativePath);
+        if (pathCompare === 0) {
+          expect(previous.lineNumber).toBeLessThanOrEqual(current.lineNumber);
+        } else {
+          expect(pathCompare).toBeLessThan(0);
+        }
+      }
+    }
+    // Suppress unused variable warning from the spread above.
+    void all;
+  }, 15_000);
+});

--- a/packages/playground/scripts/check-raw-native-controls.test.ts
+++ b/packages/playground/scripts/check-raw-native-controls.test.ts
@@ -1,4 +1,7 @@
 import { describe, expect, test } from 'bun:test';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 
 import {
   ALLOWLIST,
@@ -677,4 +680,46 @@ describe('scan — live inventory against the real examples directory', () => {
     // The wrongTagEntry itself is stale (no <input> at index 0 in that file).
     expect(result.staleAllowlistEntries.some((entry) => entry.tagName === 'input')).toBe(true);
   }, 15_000);
+});
+
+describe('scan — inline marker line boundaries (temp fixtures)', () => {
+  async function scanFixture(contents: string): Promise<ScanResult> {
+    const directory = await mkdtemp(join(tmpdir(), 'raw-native-guard-'));
+    try {
+      await Bun.write(join(directory, 'fixture', 'basic.example.svelte'), contents);
+      return await scan(directory, []);
+    } finally {
+      await rm(directory, { recursive: true, force: true });
+    }
+  }
+
+  test('a same-line marker does NOT bleed its exemption onto the next line', async () => {
+    // Line 1 carries a raw control AND a same-line marker (covers line 1 only).
+    // Line 2 carries a raw control with NO marker of its own — it must be flagged.
+    // Regression: previously the line-2 control picked up line 1's marker as a
+    // "previous-line marker" and was silently exempted.
+    const result = await scanFixture(
+      [
+        `<input type="text" /> <!-- examples-audit-allow: line one is intentional -->`,
+        `<input type="text" />`,
+      ].join('\n'),
+    );
+
+    const allowlistedLines = result.allowlisted.map((occurrence) => occurrence.lineNumber);
+    const flaggedLines = result.flagged.map((occurrence) => occurrence.lineNumber);
+
+    expect(allowlistedLines).toEqual([1]);
+    expect(flaggedLines).toEqual([2]);
+  });
+
+  test('a standalone marker on its own line still exempts the control below it', async () => {
+    const result = await scanFixture(
+      [`<!-- examples-audit-allow: native control needed here -->`, `<input type="text" />`].join(
+        '\n',
+      ),
+    );
+
+    expect(result.flagged).toHaveLength(0);
+    expect(result.allowlisted.map((occurrence) => occurrence.lineNumber)).toEqual([2]);
+  });
 });

--- a/packages/playground/scripts/check-raw-native-controls.test.ts
+++ b/packages/playground/scripts/check-raw-native-controls.test.ts
@@ -95,6 +95,65 @@ describe('stripCommentsAndStrings — comment and string removal', () => {
     expect(stripped).toContain('<button>');
   });
 
+  test('html-comment inside <script> returns to script state — block comment after it is still stripped', () => {
+    // If the html-comment exit incorrectly resets to 'template', the /* block comment */
+    // that follows would NOT be stripped (template state does not handle /* */), and
+    // <button> inside the block comment would survive into the stripped output.
+    const source = [
+      '<script lang="ts">',
+      '<!-- html-like sequence inside script -->',
+      '/* <button> inside block comment after html-comment */',
+      'const x = 1;',
+      '</script>',
+    ].join('\n');
+    const stripped = stripCommentsAndStrings(source);
+    expect(stripped).not.toContain('<button>');
+    expect(stripped.split('\n').length).toBe(source.split('\n').length);
+  });
+
+  test('html-comment inside <script> returns to script state — line comment after it is still stripped', () => {
+    // Same test but with a // line comment after the html-comment sequence.
+    const source = [
+      '<script lang="ts">',
+      '<!-- sequence inside script -->',
+      '// <input type="text"> inside line comment',
+      'const x = 1;',
+      '</script>',
+    ].join('\n');
+    const stripped = stripCommentsAndStrings(source);
+    expect(stripped).not.toContain('<input');
+    expect(stripped.split('\n').length).toBe(source.split('\n').length);
+  });
+
+  test('html-comment inside <script> returns to script state — raw control after it is NOT misclassified', () => {
+    // A real <button> in the template AFTER the script block must still be detected.
+    // This ensures the state machine correctly handles both a script-internal html-comment
+    // and subsequent template content.
+    const source = [
+      '<script lang="ts">',
+      '<!-- comment-like sequence inside script -->',
+      'const x = 1;',
+      '</script>',
+      '<button type="button">Click</button>',
+    ].join('\n');
+    const stripped = stripCommentsAndStrings(source);
+    // The real template <button> must survive stripping.
+    expect(stripped).toContain('<button');
+  });
+
+  test('block comment inside <script> returns to script state — subsequent code is not suppressed', () => {
+    // Ensures block-comment exit (which already hardcoded 'script') leaves subsequent
+    // script content visible so a raw tag in a string literal after the comment is stripped.
+    const source = [
+      '<script lang="ts">',
+      "/* comment */ const tag = '<select>';",
+      '</script>',
+    ].join('\n');
+    const stripped = stripCommentsAndStrings(source);
+    expect(stripped).not.toContain('<select>');
+    expect(stripped.split('\n').length).toBe(source.split('\n').length);
+  });
+
   test('preserves exact line count for a realistic Svelte file with mixed content', () => {
     const source = [
       '<script lang="ts">',
@@ -279,6 +338,19 @@ describe('extractInlineAllowReason — inline allow marker', () => {
 
   test('returns null for an empty line', () => {
     expect(extractInlineAllowReason('')).toBeNull();
+  });
+
+  test('returns null for a whitespace-only reason (spaces between colon and -->)', () => {
+    // A whitespace-only reason must NOT count as a valid exemption — a reason is required.
+    expect(extractInlineAllowReason('<!-- examples-audit-allow:    -->')).toBeNull();
+  });
+
+  test('returns null for a marker with nothing after the colon', () => {
+    expect(extractInlineAllowReason('<!-- examples-audit-allow: -->')).toBeNull();
+  });
+
+  test('returns the reason when at least one non-space character is present', () => {
+    expect(extractInlineAllowReason('<!-- examples-audit-allow: x -->')).toBe('x');
   });
 });
 

--- a/packages/playground/scripts/check-raw-native-controls.test.ts
+++ b/packages/playground/scripts/check-raw-native-controls.test.ts
@@ -4,18 +4,123 @@ import {
   ALLOWLIST,
   allowlistKey,
   buildAllowlistIndex,
+  detectAllRawControls,
   detectRawControl,
+  extractInlineAllowReason,
   RAW_CONTROL_TAG_NAMES,
   renderReport,
   scan,
+  stripCommentsAndStrings,
   toPosixPath,
   type AllowlistEntry,
   type RawControlOccurrence,
+  type ScanResult,
 } from './check-raw-native-controls.ts';
+
+// ── stripCommentsAndStrings ───────────────────────────────────────────────────
+
+describe('stripCommentsAndStrings — comment and string removal', () => {
+  test('strips a single-line HTML comment containing a raw control tag', () => {
+    const source = '<!-- <button> -->';
+    const stripped = stripCommentsAndStrings(source);
+    expect(stripped).not.toContain('<button>');
+    // Line count must be preserved (no newlines here).
+    expect(stripped.split('\n').length).toBe(1);
+  });
+
+  test('strips a multi-line HTML comment containing a raw control tag', () => {
+    const source = '<!--\n  <button>\n-->';
+    const stripped = stripCommentsAndStrings(source);
+    expect(stripped).not.toContain('<button>');
+    // Three lines in, three lines out.
+    expect(stripped.split('\n').length).toBe(3);
+  });
+
+  test('preserves line count after stripping multi-line HTML comment', () => {
+    const source = 'line1\n<!-- \n<button>\n -->\nline5';
+    const stripped = stripCommentsAndStrings(source);
+    expect(stripped.split('\n').length).toBe(source.split('\n').length);
+    expect(stripped).not.toContain('<button>');
+  });
+
+  test('strips a JS block comment containing a raw control tag (inside script)', () => {
+    const source = '<script lang="ts">\n/* <button> */\nconst x = 1;\n</script>';
+    const stripped = stripCommentsAndStrings(source);
+    expect(stripped).not.toContain('<button>');
+    expect(stripped.split('\n').length).toBe(source.split('\n').length);
+  });
+
+  test('strips a multi-line JS block comment containing a raw control tag', () => {
+    const source = '<script lang="ts">\n/*\n  <textarea>\n*/\nconst x = 1;\n</script>';
+    const stripped = stripCommentsAndStrings(source);
+    expect(stripped).not.toContain('<textarea>');
+    expect(stripped.split('\n').length).toBe(source.split('\n').length);
+  });
+
+  test('strips a JS line comment containing a raw control tag', () => {
+    const source = '<script lang="ts">\n// <input type="text">\nconst x = 1;\n</script>';
+    const stripped = stripCommentsAndStrings(source);
+    expect(stripped).not.toContain('<input');
+    expect(stripped.split('\n').length).toBe(source.split('\n').length);
+  });
+
+  test('strips a single-quoted string literal containing a raw control tag', () => {
+    const source = '<script lang="ts">\nconst tag = \'<button>\';\n</script>';
+    const stripped = stripCommentsAndStrings(source);
+    expect(stripped).not.toContain('<button>');
+    expect(stripped.split('\n').length).toBe(source.split('\n').length);
+  });
+
+  test('strips a double-quoted string literal containing a raw control tag', () => {
+    const source = '<script lang="ts">\nconst tag = "<input>";\n</script>';
+    const stripped = stripCommentsAndStrings(source);
+    expect(stripped).not.toContain('<input>');
+  });
+
+  test('strips a template literal containing a raw control tag', () => {
+    const source = '<script lang="ts">\nconst tag = `<select>`;\n</script>';
+    const stripped = stripCommentsAndStrings(source);
+    expect(stripped).not.toContain('<select>');
+  });
+
+  test('does NOT strip a real raw control in template content', () => {
+    const source = '<div>\n  <button type="button">Click</button>\n</div>';
+    const stripped = stripCommentsAndStrings(source);
+    expect(stripped).toContain('<button');
+  });
+
+  test('does NOT strip a raw control in a Svelte template outside any comment', () => {
+    const source = '<script lang="ts">\nlet x = 1;\n</script>\n<button>OK</button>';
+    const stripped = stripCommentsAndStrings(source);
+    expect(stripped).toContain('<button>');
+  });
+
+  test('preserves exact line count for a realistic Svelte file with mixed content', () => {
+    const source = [
+      '<script lang="ts">',
+      '  // This is a comment with <button> inside',
+      '  /* block comment <input> */',
+      "  const label = '<select>';",
+      '</script>',
+      '<!-- <textarea> in HTML comment -->',
+      '<button>Real button</button>',
+    ].join('\n');
+    const stripped = stripCommentsAndStrings(source);
+    expect(stripped.split('\n').length).toBe(source.split('\n').length);
+    // Real button must survive; commented/string ones must not.
+    const lines = stripped.split('\n');
+    expect(lines[6]).toContain('<button>');
+    // Commented/string occurrences must be gone from their respective lines.
+    expect(lines[1]).not.toContain('<button>');
+    expect(lines[2]).not.toContain('<input>');
+    expect(lines[3]).not.toContain('<select>');
+    expect(lines[5]).not.toContain('<textarea>');
+  });
+});
 
 // ── detectRawControl ───────────────────────────────────────────────────────────
 
-describe('detectRawControl — raw tag detection', () => {
+describe('detectRawControl — raw tag detection (first match)', () => {
   test('detects <button> tag', () => {
     expect(detectRawControl('<button type="button">Click</button>')).toBe('button');
   });
@@ -84,6 +189,99 @@ describe('detectRawControl — raw tag detection', () => {
   });
 });
 
+// ── detectAllRawControls ───────────────────────────────────────────────────────
+
+describe('detectAllRawControls — all matches per line', () => {
+  test('returns an empty array for a line with no raw controls', () => {
+    expect(detectAllRawControls('<div class="x">')).toEqual([]);
+  });
+
+  test('returns a single match for a line with one raw control', () => {
+    const matches = detectAllRawControls('<button type="button">Click</button>');
+    expect(matches).toHaveLength(1);
+    expect(matches[0]?.tagName).toBe('button');
+    expect(matches[0]?.columnIndex).toBe(0);
+  });
+
+  test('returns ALL matches for two raw controls on the same line', () => {
+    const matches = detectAllRawControls('<button /><input />');
+    expect(matches).toHaveLength(2);
+    expect(matches[0]?.tagName).toBe('button');
+    expect(matches[1]?.tagName).toBe('input');
+  });
+
+  test('returns ALL matches for three raw controls on the same line', () => {
+    const matches = detectAllRawControls('<button /><input /><select>');
+    expect(matches).toHaveLength(3);
+    expect(matches[0]?.tagName).toBe('button');
+    expect(matches[1]?.tagName).toBe('input');
+    expect(matches[2]?.tagName).toBe('select');
+  });
+
+  test('reports correct columnIndex for each match', () => {
+    // '  <button />' — button starts at col 2
+    const matches = detectAllRawControls('  <button />');
+    expect(matches[0]?.columnIndex).toBe(2);
+  });
+
+  test('reports correct columnIndex for the second match on a line', () => {
+    // '<button /><input />' — input starts at col 10
+    const matches = detectAllRawControls('<button /><input />');
+    expect(matches[1]?.columnIndex).toBe(10);
+  });
+
+  test('does NOT return Cinder <Button> (uppercase) as a match', () => {
+    const matches = detectAllRawControls('<Button /><input />');
+    expect(matches).toHaveLength(1);
+    expect(matches[0]?.tagName).toBe('input');
+  });
+
+  test('calling detectAllRawControls twice gives the same result (no global-regex state leak)', () => {
+    const line = '<button /><input />';
+    const first = detectAllRawControls(line);
+    const second = detectAllRawControls(line);
+    expect(first).toEqual(second);
+  });
+});
+
+// ── extractInlineAllowReason ──────────────────────────────────────────────────
+
+describe('extractInlineAllowReason — inline allow marker', () => {
+  test('extracts reason from a well-formed marker', () => {
+    expect(
+      extractInlineAllowReason(
+        '<button bind:this={el}>Open</button> <!-- examples-audit-allow: triggerRef needs native element -->',
+      ),
+    ).toBe('triggerRef needs native element');
+  });
+
+  test('extracts reason from a marker on its own line', () => {
+    expect(
+      extractInlineAllowReason(
+        '<!-- examples-audit-allow: forwards spread attrs from parent snippet -->',
+      ),
+    ).toBe('forwards spread attrs from parent snippet');
+  });
+
+  test('trims whitespace from the reason', () => {
+    expect(extractInlineAllowReason('<!-- examples-audit-allow:   extra spaces   -->')).toBe(
+      'extra spaces',
+    );
+  });
+
+  test('returns null when the marker is absent', () => {
+    expect(extractInlineAllowReason('<button type="button">Click</button>')).toBeNull();
+  });
+
+  test('returns null for an ordinary HTML comment', () => {
+    expect(extractInlineAllowReason('<!-- this is just a comment -->')).toBeNull();
+  });
+
+  test('returns null for an empty line', () => {
+    expect(extractInlineAllowReason('')).toBeNull();
+  });
+});
+
 // ── toPosixPath ────────────────────────────────────────────────────────────────
 
 describe('toPosixPath — OS-independent path keys', () => {
@@ -99,15 +297,27 @@ describe('toPosixPath — OS-independent path keys', () => {
 // ── allowlistKey ───────────────────────────────────────────────────────────────
 
 describe('allowlistKey — key format', () => {
-  test('builds a stable file::line key', () => {
-    expect(allowlistKey('navigation-bar/basic.example.svelte', 20)).toBe(
-      'navigation-bar/basic.example.svelte::20',
+  test('builds a stable file::tagName::occurrenceIndex key', () => {
+    expect(allowlistKey('navigation-bar/basic.example.svelte', 'button', 0)).toBe(
+      'navigation-bar/basic.example.svelte::button::0',
     );
   });
 
+  test('differentiates the first and second occurrence of the same tag', () => {
+    const key0 = allowlistKey('foo/bar.example.svelte', 'input', 0);
+    const key1 = allowlistKey('foo/bar.example.svelte', 'input', 1);
+    expect(key0).not.toBe(key1);
+  });
+
+  test('differentiates two different tag names at occurrence 0', () => {
+    const keyButton = allowlistKey('foo/bar.example.svelte', 'button', 0);
+    const keyInput = allowlistKey('foo/bar.example.svelte', 'input', 0);
+    expect(keyButton).not.toBe(keyInput);
+  });
+
   test('normalizes backslashes in the path component', () => {
-    expect(allowlistKey('navigation-bar\\basic.example.svelte', 20)).toBe(
-      'navigation-bar/basic.example.svelte::20',
+    expect(allowlistKey('navigation-bar\\basic.example.svelte', 'button', 0)).toBe(
+      'navigation-bar/basic.example.svelte::button::0',
     );
   });
 });
@@ -118,30 +328,37 @@ describe('buildAllowlistIndex — fast lookup set', () => {
   const entries: AllowlistEntry[] = [
     {
       relativePath: 'navigation-bar/basic.example.svelte',
-      lineNumber: 20,
+      tagName: 'button',
+      occurrenceIndex: 0,
       reason: 'receives forwarded attrs from NavigationBar menuToggle snippet',
     },
     {
       relativePath: 'popover/transformed-ancestor.example.svelte',
-      lineNumber: 33,
+      tagName: 'button',
+      occurrenceIndex: 0,
       reason: 'uses bind:this for triggerRef — requires a native HTMLButtonElement',
     },
   ];
 
-  test('contains an entry for each allowlisted file+line', () => {
+  test('contains an entry for each allowlisted file+tag+index', () => {
     const index = buildAllowlistIndex(entries);
-    expect(index.has('navigation-bar/basic.example.svelte::20')).toBe(true);
-    expect(index.has('popover/transformed-ancestor.example.svelte::33')).toBe(true);
+    expect(index.has('navigation-bar/basic.example.svelte::button::0')).toBe(true);
+    expect(index.has('popover/transformed-ancestor.example.svelte::button::0')).toBe(true);
   });
 
-  test('does not contain a key for a different line on an allowlisted file', () => {
+  test('does not contain a key for a different occurrenceIndex', () => {
     const index = buildAllowlistIndex(entries);
-    expect(index.has('navigation-bar/basic.example.svelte::99')).toBe(false);
+    expect(index.has('navigation-bar/basic.example.svelte::button::1')).toBe(false);
+  });
+
+  test('does not contain a key for a different tagName', () => {
+    const index = buildAllowlistIndex(entries);
+    expect(index.has('navigation-bar/basic.example.svelte::input::0')).toBe(false);
   });
 
   test('does not contain a key for an entirely different file', () => {
     const index = buildAllowlistIndex(entries);
-    expect(index.has('button/basic.example.svelte::20')).toBe(false);
+    expect(index.has('button/basic.example.svelte::button::0')).toBe(false);
   });
 
   test('empty allowlist produces an empty set', () => {
@@ -164,9 +381,15 @@ describe('ALLOWLIST — canonical checked-in entries', () => {
     }
   });
 
-  test('every entry has a positive line number', () => {
+  test('every entry has a valid tagName', () => {
     for (const entry of ALLOWLIST) {
-      expect(entry.lineNumber).toBeGreaterThan(0);
+      expect(RAW_CONTROL_TAG_NAMES).toContain(entry.tagName);
+    }
+  });
+
+  test('every entry has a non-negative occurrenceIndex', () => {
+    for (const entry of ALLOWLIST) {
+      expect(entry.occurrenceIndex).toBeGreaterThanOrEqual(0);
     }
   });
 });
@@ -177,16 +400,24 @@ describe('renderReport — human-readable output', () => {
   const makeOccurrence = (overrides: Partial<RawControlOccurrence> = {}): RawControlOccurrence => ({
     relativePath: 'button/basic.example.svelte',
     lineNumber: 12,
+    columnIndex: 0,
     tagName: 'button',
     lineText: '<button type="button">Click</button>',
     ...overrides,
   });
 
+  const makeResult = (overrides: Partial<ScanResult> = {}): ScanResult => ({
+    allowlisted: [],
+    flagged: [],
+    staleAllowlistEntries: [],
+    ...overrides,
+  });
+
   test('includes the total count in the header', () => {
-    const result = {
+    const result = makeResult({
       allowlisted: [makeOccurrence()],
       flagged: [makeOccurrence({ relativePath: 'inline/basic.example.svelte', lineNumber: 11 })],
-    };
+    });
     const report = renderReport(result);
     expect(report).toContain('Total raw controls found: 2');
     expect(report).toContain('1 flagged');
@@ -194,24 +425,43 @@ describe('renderReport — human-readable output', () => {
   });
 
   test('reports zero flagged when all controls are allowlisted', () => {
-    const result = { allowlisted: [makeOccurrence()], flagged: [] };
+    const result = makeResult({ allowlisted: [makeOccurrence()] });
     const report = renderReport(result);
     expect(report).toContain('Flagged: none');
   });
 
   test('includes relative path and line number for flagged items', () => {
-    const result = {
-      allowlisted: [],
+    const result = makeResult({
       flagged: [makeOccurrence({ relativePath: 'inline/basic.example.svelte', lineNumber: 11 })],
-    };
+    });
     const report = renderReport(result);
     expect(report).toContain('inline/basic.example.svelte:11');
   });
 
   test('includes <tagName> in the rendered line', () => {
-    const result = { allowlisted: [], flagged: [makeOccurrence({ tagName: 'input' })] };
+    const result = makeResult({ flagged: [makeOccurrence({ tagName: 'input' })] });
     const report = renderReport(result);
     expect(report).toContain('<input>');
+  });
+
+  test('reports stale allowlist entries when present', () => {
+    const staleEntry: AllowlistEntry = {
+      relativePath: 'button/basic.example.svelte',
+      tagName: 'button',
+      occurrenceIndex: 5,
+      reason: 'old entry that no longer matches',
+    };
+    const result = makeResult({ staleAllowlistEntries: [staleEntry] });
+    const report = renderReport(result);
+    expect(report).toContain('Stale allowlist entries');
+    expect(report).toContain('button/basic.example.svelte');
+    expect(report).toContain('old entry that no longer matches');
+  });
+
+  test('does NOT include stale section when there are no stale entries', () => {
+    const result = makeResult();
+    const report = renderReport(result);
+    expect(report).not.toContain('Stale allowlist entries');
   });
 });
 
@@ -219,20 +469,19 @@ describe('renderReport — human-readable output', () => {
 
 describe('scan — live inventory against the real examples directory', () => {
   // scan() walks the real examples tree; give it generous headroom on slow CI.
-  test('returns a ScanResult with allowlisted and flagged arrays', async () => {
+  test('returns a ScanResult with allowlisted, flagged, and staleAllowlistEntries arrays', async () => {
     const examplesDirectory = new URL('../src/examples', import.meta.url).pathname;
     const result = await scan(examplesDirectory);
 
-    // Both arrays must be present (possibly empty).
     expect(Array.isArray(result.allowlisted)).toBe(true);
     expect(Array.isArray(result.flagged)).toBe(true);
+    expect(Array.isArray(result.staleAllowlistEntries)).toBe(true);
   }, 15_000);
 
   test('detects at least one raw control across all example files', async () => {
     const examplesDirectory = new URL('../src/examples', import.meta.url).pathname;
     const result = await scan(examplesDirectory);
     const total = result.allowlisted.length + result.flagged.length;
-    // We know from the current state there are 18 raw control lines.
     expect(total).toBeGreaterThan(0);
   }, 15_000);
 
@@ -283,7 +532,6 @@ describe('scan — live inventory against the real examples directory', () => {
   test('results are sorted by relativePath then lineNumber', async () => {
     const examplesDirectory = new URL('../src/examples', import.meta.url).pathname;
     const result = await scan(examplesDirectory);
-    const all = [...result.allowlisted, ...result.flagged];
     // Check each array is sorted independently.
     for (const list of [result.allowlisted, result.flagged]) {
       for (let index = 1; index < list.length; index++) {
@@ -297,7 +545,64 @@ describe('scan — live inventory against the real examples directory', () => {
         }
       }
     }
-    // Suppress unused variable warning from the spread above.
-    void all;
+  }, 15_000);
+
+  test('does NOT flag raw controls inside HTML/Svelte comments in real files', async () => {
+    const examplesDirectory = new URL('../src/examples', import.meta.url).pathname;
+    const result = await scan(examplesDirectory);
+    // command-palette/search-recent-actions.example.svelte has several <!-- ... -->
+    // comment blocks in the template; those must not be counted as raw controls.
+    // We verify this indirectly: the file has exactly 1 <button> (the trigger),
+    // which is allowlisted — so the flagged list should contain 0 from that file.
+    const commandPaletteFlagged = result.flagged.filter((occurrence) =>
+      occurrence.relativePath.includes('command-palette/search-recent-actions'),
+    );
+    expect(commandPaletteFlagged).toHaveLength(0);
+  }, 15_000);
+
+  test('the canonical ALLOWLIST has no stale entries against the real files', async () => {
+    const examplesDirectory = new URL('../src/examples', import.meta.url).pathname;
+    const result = await scan(examplesDirectory);
+    // If this fails, the file was refactored and the ALLOWLIST entry needs updating.
+    expect(result.staleAllowlistEntries).toHaveLength(0);
+  }, 15_000);
+
+  test('a deliberately stale allowlist entry is reported as stale', async () => {
+    const examplesDirectory = new URL('../src/examples', import.meta.url).pathname;
+    const staleEntry: AllowlistEntry = {
+      relativePath: 'navigation-bar/basic.example.svelte',
+      tagName: 'button',
+      // occurrenceIndex 99 — no file has 100 buttons.
+      occurrenceIndex: 99,
+      reason: 'deliberate stale entry for test',
+    };
+    const result = await scan(examplesDirectory, [staleEntry]);
+    expect(result.staleAllowlistEntries).toHaveLength(1);
+    expect(result.staleAllowlistEntries[0]?.occurrenceIndex).toBe(99);
+  }, 15_000);
+
+  test('right tag on a line is exempted; wrong tag on the same line is still flagged', async () => {
+    // This exercises that the allowlist is tag-specific: if a file had <button> and
+    // <input> on the same line and only <button> is allowlisted, <input> is still flagged.
+    // We construct a minimal fixture via a custom allowlist with the wrong tag.
+    const examplesDirectory = new URL('../src/examples', import.meta.url).pathname;
+    // Use an allowlist that covers 'input' at index 0 for the nav-bar file (which
+    // actually has a <button> there, not an <input>). The <button> should be flagged.
+    const wrongTagEntry: AllowlistEntry = {
+      relativePath: 'navigation-bar/basic.example.svelte',
+      tagName: 'input', // wrong tag
+      occurrenceIndex: 0,
+      reason: 'wrong tag entry for test',
+    };
+    const result = await scan(examplesDirectory, [wrongTagEntry]);
+    // The <button> in nav-bar is NOT allowlisted (we gave the wrong tag), so it is flagged.
+    const navigationBarFlagged = result.flagged.filter(
+      (occurrence) =>
+        occurrence.relativePath === 'navigation-bar/basic.example.svelte' &&
+        occurrence.tagName === 'button',
+    );
+    expect(navigationBarFlagged.length).toBeGreaterThan(0);
+    // The wrongTagEntry itself is stale (no <input> at index 0 in that file).
+    expect(result.staleAllowlistEntries.some((entry) => entry.tagName === 'input')).toBe(true);
   }, 15_000);
 });

--- a/packages/playground/scripts/check-raw-native-controls.test.ts
+++ b/packages/playground/scripts/check-raw-native-controls.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from 'bun:test';
 import { mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 import {
   ALLOWLIST,
@@ -19,6 +20,11 @@ import {
   type RawControlOccurrence,
   type ScanResult,
 } from './check-raw-native-controls.ts';
+
+// Resolve via fileURLToPath (not `new URL(...).pathname`) so the path is a valid
+// filesystem path on every platform — `.pathname` yields a broken `/C:/...` on
+// Windows. Mirrors the script's own `fileURLToPath(import.meta.url)` usage.
+const examplesDirectory = fileURLToPath(new URL('../src/examples', import.meta.url));
 
 // ── stripCommentsAndStrings ───────────────────────────────────────────────────
 
@@ -545,7 +551,6 @@ describe('renderReport — human-readable output', () => {
 describe('scan — live inventory against the real examples directory', () => {
   // scan() walks the real examples tree; give it generous headroom on slow CI.
   test('returns a ScanResult with allowlisted, flagged, and staleAllowlistEntries arrays', async () => {
-    const examplesDirectory = new URL('../src/examples', import.meta.url).pathname;
     const result = await scan(examplesDirectory);
 
     expect(Array.isArray(result.allowlisted)).toBe(true);
@@ -554,14 +559,12 @@ describe('scan — live inventory against the real examples directory', () => {
   }, 15_000);
 
   test('detects at least one raw control across all example files', async () => {
-    const examplesDirectory = new URL('../src/examples', import.meta.url).pathname;
     const result = await scan(examplesDirectory);
     const total = result.allowlisted.length + result.flagged.length;
     expect(total).toBeGreaterThan(0);
   }, 15_000);
 
   test('does NOT flag the navigation-bar menuToggle button (it is allowlisted)', async () => {
-    const examplesDirectory = new URL('../src/examples', import.meta.url).pathname;
     const result = await scan(examplesDirectory);
 
     const navigationBarFlagged = result.flagged.filter(
@@ -576,7 +579,6 @@ describe('scan — live inventory against the real examples directory', () => {
   }, 15_000);
 
   test('does NOT flag the popover transformed-ancestor trigger button (it is allowlisted)', async () => {
-    const examplesDirectory = new URL('../src/examples', import.meta.url).pathname;
     const result = await scan(examplesDirectory);
 
     const popoverFlagged = result.flagged.filter(
@@ -586,7 +588,6 @@ describe('scan — live inventory against the real examples directory', () => {
   }, 15_000);
 
   test('every returned occurrence has a positive lineNumber and a non-empty relativePath', async () => {
-    const examplesDirectory = new URL('../src/examples', import.meta.url).pathname;
     const result = await scan(examplesDirectory);
 
     for (const occurrence of [...result.allowlisted, ...result.flagged]) {
@@ -597,7 +598,6 @@ describe('scan — live inventory against the real examples directory', () => {
   }, 15_000);
 
   test('respects a custom empty allowlist (nothing is allowlisted)', async () => {
-    const examplesDirectory = new URL('../src/examples', import.meta.url).pathname;
     const result = await scan(examplesDirectory, []);
     // With an empty allowlist all occurrences land in flagged.
     expect(result.allowlisted).toHaveLength(0);
@@ -605,7 +605,6 @@ describe('scan — live inventory against the real examples directory', () => {
   }, 15_000);
 
   test('results are sorted by relativePath then lineNumber', async () => {
-    const examplesDirectory = new URL('../src/examples', import.meta.url).pathname;
     const result = await scan(examplesDirectory);
     // Check each array is sorted independently.
     for (const list of [result.allowlisted, result.flagged]) {
@@ -623,7 +622,6 @@ describe('scan — live inventory against the real examples directory', () => {
   }, 15_000);
 
   test('does NOT flag raw controls inside HTML/Svelte comments in real files', async () => {
-    const examplesDirectory = new URL('../src/examples', import.meta.url).pathname;
     const result = await scan(examplesDirectory);
     // command-palette/search-recent-actions.example.svelte has several <!-- ... -->
     // comment blocks in the template; those must not be counted as raw controls.
@@ -636,14 +634,12 @@ describe('scan — live inventory against the real examples directory', () => {
   }, 15_000);
 
   test('the canonical ALLOWLIST has no stale entries against the real files', async () => {
-    const examplesDirectory = new URL('../src/examples', import.meta.url).pathname;
     const result = await scan(examplesDirectory);
     // If this fails, the file was refactored and the ALLOWLIST entry needs updating.
     expect(result.staleAllowlistEntries).toHaveLength(0);
   }, 15_000);
 
   test('a deliberately stale allowlist entry is reported as stale', async () => {
-    const examplesDirectory = new URL('../src/examples', import.meta.url).pathname;
     const staleEntry: AllowlistEntry = {
       relativePath: 'navigation-bar/basic.example.svelte',
       tagName: 'button',
@@ -660,7 +656,6 @@ describe('scan — live inventory against the real examples directory', () => {
     // This exercises that the allowlist is tag-specific: if a file had <button> and
     // <input> on the same line and only <button> is allowlisted, <input> is still flagged.
     // We construct a minimal fixture via a custom allowlist with the wrong tag.
-    const examplesDirectory = new URL('../src/examples', import.meta.url).pathname;
     // Use an allowlist that covers 'input' at index 0 for the nav-bar file (which
     // actually has a <button> there, not an <input>). The <button> should be flagged.
     const wrongTagEntry: AllowlistEntry = {

--- a/packages/playground/scripts/check-raw-native-controls.test.ts
+++ b/packages/playground/scripts/check-raw-native-controls.test.ts
@@ -686,7 +686,9 @@ describe('scan — inline marker line boundaries (temp fixtures)', () => {
   async function scanFixture(contents: string): Promise<ScanResult> {
     const directory = await mkdtemp(join(tmpdir(), 'raw-native-guard-'));
     try {
-      await Bun.write(join(directory, 'fixture', 'basic.example.svelte'), contents);
+      // Write at the temp-dir root (the scan glob is `**/*.example.svelte`, so a
+      // root-level file matches) to avoid depending on any subdirectory creation.
+      await Bun.write(join(directory, 'basic.example.svelte'), contents);
       return await scan(directory, []);
     } finally {
       await rm(directory, { recursive: true, force: true });

--- a/packages/playground/scripts/check-raw-native-controls.ts
+++ b/packages/playground/scripts/check-raw-native-controls.ts
@@ -184,6 +184,16 @@ function suppressCharacter(character: string): string {
   return character === '\n' ? '\n' : ' ';
 }
 
+/**
+ * A character that legitimately terminates an opening tag name: whitespace, the
+ * tag close `>`, or the self-close `/`. Empty string (end of source) also counts
+ * so a trailing `<script` at EOF still matches. Used to ensure `<script` matches
+ * the real element and not `<scripting>` / `<scriptlet>`.
+ */
+function isTagNameBoundary(value: string): boolean {
+  return value === '' || value === '>' || value === '/' || /\s/.test(value);
+}
+
 export function stripCommentsAndStrings(source: string): string {
   // We do a single linear pass using a state machine rather than multiple
   // regex replacements so that overlapping / nested patterns don't interact.
@@ -241,7 +251,8 @@ export function stripCommentsAndStrings(source: string): string {
           peek(3) === 'r' &&
           peek(4) === 'i' &&
           peek(5) === 'p' &&
-          peek(6) === 't'
+          peek(6) === 't' &&
+          isTagNameBoundary(peek(7))
         ) {
           // Emit the <script...> tag verbatim (we need to find the closing >)
           output += character;

--- a/packages/playground/scripts/check-raw-native-controls.ts
+++ b/packages/playground/scripts/check-raw-native-controls.ts
@@ -200,6 +200,14 @@ export function stripCommentsAndStrings(source: string): string {
     | 'string-double' // Inside "..." (script only)
     | 'string-template'; // Inside `...` (script only)
 
+  // returnState tracks which state to resume after exiting a comment.
+  // html-comment can appear in both 'template' and 'script' contexts; we must
+  // return to whichever one we came from, not unconditionally to 'template'.
+  // block-comment and line-comment only appear in 'script', but we track the
+  // same way for consistency and future safety.
+  type ReturnableState = 'template' | 'script';
+  let returnState: ReturnableState = 'template';
+
   let state: State = 'template';
   let output = '';
   let index = 0;
@@ -217,7 +225,9 @@ export function stripCommentsAndStrings(source: string): string {
       case 'template': {
         // Detect start of HTML comment <!-- (applies in template AND inside script tags' text content)
         if (character === '<' && peek(1) === '!' && peek(2) === '-' && peek(3) === '-') {
-          // Enter html-comment — emit the opening <!-- suppressed
+          // Enter html-comment — emit the opening <!-- suppressed.
+          // Record 'template' as the state to return to when --> is found.
+          returnState = 'template';
           output += suppress('<') + suppress('!') + suppress('-') + suppress('-');
           index += 4;
           state = 'html-comment';
@@ -275,6 +285,8 @@ export function stripCommentsAndStrings(source: string): string {
       case 'script': {
         // Detect <!-- comment start (can appear in script text? unlikely but safe)
         if (character === '<' && peek(1) === '!' && peek(2) === '-' && peek(3) === '-') {
+          // Record 'script' as the state to return to when --> is found.
+          returnState = 'script';
           output += suppress('<') + suppress('!') + suppress('-') + suppress('-');
           index += 4;
           state = 'html-comment';
@@ -341,18 +353,10 @@ export function stripCommentsAndStrings(source: string): string {
         if (character === '-' && peek(1) === '-' && peek(2) === '>') {
           output += suppress('-') + suppress('-') + suppress('>');
           index += 3;
-          // Return to whichever state we came from — we need to track that.
-          // Since html-comment can appear in both template and script, and we always
-          // return to template after (HTML comments don't nest inside script blocks
-          // in practice), we determine context by looking at output for the last
-          // </script> vs <script.
-          // Simpler: track previous state explicitly.
-          // Since we already emitted the state machine above without tracking, we
-          // default to template (html comments in script blocks are unusual).
-          // This is safe: the only side effect is that after a <!-- --> inside a
-          // <script>, we'd be in 'template' state — but the next </script> would
-          // switch us back, so at worst we'd miss stripping one JS comment.
-          state = 'template';
+          // Restore the state we were in before entering this comment.
+          // returnState was set to 'template' or 'script' when we entered html-comment,
+          // so we correctly resume whichever context the comment appeared in.
+          state = returnState;
           break;
         }
         // Suppress the character, keep newlines
@@ -533,13 +537,19 @@ export const INLINE_ALLOW_MARKER = /<!--\s*examples-audit-allow\s*:\s*(.+?)\s*--
 
 /**
  * Returns the reason string from an inline allow marker in `line`, or `null` if
- * the marker is not present.
+ * the marker is not present OR the reason is empty/whitespace-only.
+ *
+ * A whitespace-only reason is treated the same as no reason — the docs require
+ * a non-empty rationale. `<!-- examples-audit-allow:    -->` returns null and
+ * leaves the control flagged.
  *
  * Pure — no I/O. Exported for unit tests.
  */
 export function extractInlineAllowReason(line: string): string | null {
   const match = INLINE_ALLOW_MARKER.exec(line);
-  return match ? (match[1]?.trim() ?? null) : null;
+  if (!match) return null;
+  const reason = match[1]?.trim() ?? '';
+  return reason.length > 0 ? reason : null;
 }
 
 // ── Allowlist Key ─────────────────────────────────────────────────────────────

--- a/packages/playground/scripts/check-raw-native-controls.ts
+++ b/packages/playground/scripts/check-raw-native-controls.ts
@@ -8,13 +8,16 @@
  *
  * This script scans every `packages/playground/src/examples/**\/*.example.svelte`
  * file for raw interactive native control tags and reports them, partitioned into:
- *   - allowlisted: genuinely intentional raw controls (see ALLOWLIST below)
+ *   - allowlisted: genuinely intentional raw controls (see ALLOWLIST below, or
+ *     inline `<!-- examples-audit-allow: <reason> -->` markers)
  *   - flagged: raw controls that should be swapped for a Cinder primitive
+ *   - stale: allowlist entries that no longer match any raw control in the file
  *
  * Two modes:
  *   - default (report-only): prints the full inventory. Always exits 0.
  *     Intended for human review and CI audit visibility.
- *   - `--strict`: exits non-zero when any NON-allowlisted raw controls are found.
+ *   - `--strict`: exits non-zero when any NON-allowlisted raw controls are found,
+ *     OR when any stale allowlist entries are present.
  *     Wire this into the validate gate after the sweep PR merges.
  *
  * Run via:
@@ -22,6 +25,24 @@
  *   bun run --filter=@cinder/playground examples:audit --strict (gate)
  *
  * Model: mirrors check-platform-features.ts's report-then-strict pattern.
+ *
+ * ── Allowlist Mechanism ────────────────────────────────────────────────────────
+ *
+ * Two complementary approaches — use the one that fits best:
+ *
+ * 1. INLINE MARKER (preferred): place `<!-- examples-audit-allow: <reason> -->`
+ *    on the SAME line as the raw control, or on the line immediately above it.
+ *    The reason is self-documenting at the call site and survives line-number drift.
+ *
+ *      <!-- examples-audit-allow: triggerRef requires a native HTMLButtonElement -->
+ *      <button bind:this={triggerElement}>…</button>
+ *
+ *    Or on the same line:
+ *
+ *      <button bind:this={triggerElement}>…</button> <!-- examples-audit-allow: triggerRef ref path -->
+ *
+ * 2. ALLOWLIST ARRAY (below): key by relativePath + tagName + occurrenceIndex.
+ *    Use this for files where the inline marker would be awkward.
  */
 
 import { Glob } from 'bun';
@@ -40,6 +61,8 @@ export type RawControlOccurrence = {
   relativePath: string;
   /** 1-based line number where the tag opens. */
   lineNumber: number;
+  /** 0-based column where the tag opens. */
+  columnIndex: number;
   /** The tag name: `button`, `input`, `select`, or `textarea`. */
   tagName: RawControlTagName;
   /** The raw line text (trimmed). */
@@ -53,24 +76,35 @@ export type RawControlTagName = 'button' | 'input' | 'select' | 'textarea';
 export type ScanResult = {
   allowlisted: RawControlOccurrence[];
   flagged: RawControlOccurrence[];
+  /** Allowlist entries that did not match any occurrence in the scanned files. */
+  staleAllowlistEntries: AllowlistEntry[];
 };
 
 // ── Allowlist ─────────────────────────────────────────────────────────────────
 
 /**
- * An allowlist entry grandfathers a specific file+line combination that cannot
- * use a Cinder primitive. Each entry documents why the raw element is required.
+ * An allowlist entry grandfathers a specific raw control that cannot use a Cinder
+ * primitive. Each entry documents why the raw element is required.
  *
- * Identity is file+line (not file+tag), because two different raw tags on the
- * same line would be unusual and detecting them together is acceptable. When a
- * file is refactored and line numbers drift, the allowlist entry simply stops
- * matching and the occurrence is re-flagged — forcing a fresh review.
+ * Identity is file + tagName + occurrenceIndex (0-based count of that tag in the
+ * file). This is more stable than line-based identity: unrelated edits above the
+ * line do not break the match. When the file is refactored and the tag is removed
+ * or the occurrence order changes, the entry becomes stale and is reported — forcing
+ * a fresh review.
+ *
+ * Note: occurrenceIndex counts only detected occurrences (i.e. in non-comment,
+ * non-string-literal content) for the given tagName in the file.
  */
 export type AllowlistEntry = {
   /** Relative path from examples root, forward-slash separated. */
   relativePath: string;
-  /** 1-based line number of the raw control's opening tag. */
-  lineNumber: number;
+  /** The raw control tag name this entry covers. */
+  tagName: RawControlTagName;
+  /**
+   * 0-based index among all detected occurrences of this tagName in this file.
+   * 0 = the first <button>, 1 = the second <button>, etc.
+   */
+  occurrenceIndex: number;
   /**
    * Human-readable rationale for the exemption. Required so reviewers
    * understand intent at a glance rather than re-reading the example.
@@ -87,27 +121,333 @@ export type AllowlistEntry = {
  *
  * Be conservative: only allowlist controls that GENUINELY cannot use a Cinder
  * primitive. Everything else stays flagged for the sweep PR.
+ *
+ * Alternatively, place `<!-- examples-audit-allow: <reason> -->` on the same line
+ * or the line immediately above the raw control — that approach is more robust
+ * than this array for long-lived exemptions.
  */
 export const ALLOWLIST: AllowlistEntry[] = [
   {
     relativePath: 'navigation-bar/basic.example.svelte',
-    lineNumber: 20,
+    tagName: 'button',
+    occurrenceIndex: 0,
     reason:
       'The NavigationBar menuToggle snippet forwards spread attrs (including aria and focus management) onto the trigger element. The consumer MUST supply a native <button> so the attrs land on an interactive element; the Cinder Button component does not expose a pass-through for arbitrary component-forwarded attrs.',
   },
   {
     relativePath: 'popover/transformed-ancestor.example.svelte',
-    lineNumber: 33,
+    tagName: 'button',
+    occurrenceIndex: 0,
     reason:
       'This fixture tests low-level `triggerRef` anchoring with bind:this={triggerElement}. The Popover component needs a raw HTMLButtonElement reference — the example intentionally exercises the ref path rather than the trigger-slot path, so a raw <button> is the correct primitive here.',
   },
   {
     relativePath: 'command-palette/search-recent-actions.example.svelte',
-    lineNumber: 81,
+    tagName: 'button',
+    occurrenceIndex: 0,
     reason:
       'CommandPalette requires a triggerRef (HTMLElement) for focus-return. The trigger button uses bind:this to capture the element reference for that purpose. It also applies heavy inline styles that exist to demo the styled-keyboard-shortcut pattern; until the example is rewritten with a styled Cinder Button, the raw element is intentional.',
   },
 ];
+
+// ── Comment/String Stripping ───────────────────────────────────────────────────
+
+/**
+ * Strips comment and string-literal content from a Svelte/HTML source string while
+ * preserving line structure so that line numbers computed against the result still
+ * map to the original source. Each stripped region is replaced with whitespace
+ * (one space per non-newline character), keeping all newlines in place.
+ *
+ * Regions stripped (in order):
+ *   1. HTML/Svelte block comments: `<!-- ... -->` (multi-line safe)
+ *   2. JS/TS block comments inside <script>: `/* ... *\/` (multi-line safe)
+ *   3. JS/TS line comments inside <script>: `// ...` (single line)
+ *   4. JS/TS string literals (single-quoted, double-quoted, template literals)
+ *      inside <script> blocks — prevents `"<button>"` from being flagged.
+ *
+ * We only strip string literals inside `<script ... >...</script>` blocks because
+ * Svelte template strings are not JS strings and their content is markup, not data.
+ * A `{`<button>`}` expression in a template would be unusual and is intentionally
+ * kept detectable (it would render a raw control).
+ *
+ * Line numbers are preserved: every newline in a stripped region is kept as-is;
+ * only non-newline characters are replaced with spaces. This means:
+ *   - A single-line `<!-- <button> -->` becomes `<!--               -->` (spaces).
+ *   - A multi-line comment keeps the same number of lines.
+ */
+/**
+ * Replace a character with a space, preserving newlines.
+ * Used by `stripCommentsAndStrings` to blank out comment/string content while
+ * keeping line structure intact so line numbers remain correct.
+ */
+function suppressCharacter(character: string): string {
+  return character === '\n' ? '\n' : ' ';
+}
+
+export function stripCommentsAndStrings(source: string): string {
+  // We do a single linear pass using a state machine rather than multiple
+  // regex replacements so that overlapping / nested patterns don't interact.
+  // The output buffer is built character-by-character, replacing non-newline
+  // characters in suppressed regions with a space.
+
+  type State =
+    | 'template' // Svelte template content (outside <script>)
+    | 'script' // Inside <script ...> ... </script>
+    | 'html-comment' // Inside <!-- ... -->
+    | 'block-comment' // Inside /* ... */ (script only)
+    | 'line-comment' // Inside // ... \n (script only)
+    | 'string-single' // Inside '...' (script only)
+    | 'string-double' // Inside "..." (script only)
+    | 'string-template'; // Inside `...` (script only)
+
+  let state: State = 'template';
+  let output = '';
+  let index = 0;
+  const length = source.length;
+
+  const peek = (offset: number) => source[index + offset] ?? '';
+  const current = () => source[index] ?? '';
+
+  const suppress = suppressCharacter;
+
+  while (index < length) {
+    const character = current();
+
+    switch (state) {
+      case 'template': {
+        // Detect start of HTML comment <!-- (applies in template AND inside script tags' text content)
+        if (character === '<' && peek(1) === '!' && peek(2) === '-' && peek(3) === '-') {
+          // Enter html-comment — emit the opening <!-- suppressed
+          output += suppress('<') + suppress('!') + suppress('-') + suppress('-');
+          index += 4;
+          state = 'html-comment';
+          break;
+        }
+        // Detect <script (transition to script mode after the closing >)
+        if (
+          character === '<' &&
+          peek(1) === 's' &&
+          peek(2) === 'c' &&
+          peek(3) === 'r' &&
+          peek(4) === 'i' &&
+          peek(5) === 'p' &&
+          peek(6) === 't'
+        ) {
+          // Emit the <script...> tag verbatim (we need to find the closing >)
+          output += character;
+          index++;
+          // Scan forward until we find the closing > of the <script> open tag,
+          // then switch to 'script' state.
+          while (index < length && current() !== '>') {
+            output += current();
+            index++;
+          }
+          if (index < length) {
+            output += current(); // emit the >
+            index++;
+          }
+          state = 'script';
+          break;
+        }
+        // Detect </script> — switch back to template
+        if (
+          character === '<' &&
+          peek(1) === '/' &&
+          peek(2) === 's' &&
+          peek(3) === 'c' &&
+          peek(4) === 'r' &&
+          peek(5) === 'i' &&
+          peek(6) === 'p' &&
+          peek(7) === 't' &&
+          peek(8) === '>'
+        ) {
+          output += '</script>';
+          index += 9;
+          state = 'template';
+          break;
+        }
+        // Normal template character — emit verbatim
+        output += character;
+        index++;
+        break;
+      }
+
+      case 'script': {
+        // Detect <!-- comment start (can appear in script text? unlikely but safe)
+        if (character === '<' && peek(1) === '!' && peek(2) === '-' && peek(3) === '-') {
+          output += suppress('<') + suppress('!') + suppress('-') + suppress('-');
+          index += 4;
+          state = 'html-comment';
+          break;
+        }
+        // Detect </script> — switch back to template
+        if (
+          character === '<' &&
+          peek(1) === '/' &&
+          peek(2) === 's' &&
+          peek(3) === 'c' &&
+          peek(4) === 'r' &&
+          peek(5) === 'i' &&
+          peek(6) === 'p' &&
+          peek(7) === 't' &&
+          peek(8) === '>'
+        ) {
+          output += '</script>';
+          index += 9;
+          state = 'template';
+          break;
+        }
+        // Detect block comment /*
+        if (character === '/' && peek(1) === '*') {
+          output += suppress('/') + suppress('*');
+          index += 2;
+          state = 'block-comment';
+          break;
+        }
+        // Detect line comment //
+        if (character === '/' && peek(1) === '/') {
+          output += suppress('/') + suppress('/');
+          index += 2;
+          state = 'line-comment';
+          break;
+        }
+        // Detect string literals
+        if (character === "'") {
+          output += suppress("'");
+          index++;
+          state = 'string-single';
+          break;
+        }
+        if (character === '"') {
+          output += suppress('"');
+          index++;
+          state = 'string-double';
+          break;
+        }
+        if (character === '`') {
+          output += suppress('`');
+          index++;
+          state = 'string-template';
+          break;
+        }
+        // Normal script character — emit verbatim
+        output += character;
+        index++;
+        break;
+      }
+
+      case 'html-comment': {
+        // Looking for -->
+        if (character === '-' && peek(1) === '-' && peek(2) === '>') {
+          output += suppress('-') + suppress('-') + suppress('>');
+          index += 3;
+          // Return to whichever state we came from — we need to track that.
+          // Since html-comment can appear in both template and script, and we always
+          // return to template after (HTML comments don't nest inside script blocks
+          // in practice), we determine context by looking at output for the last
+          // </script> vs <script.
+          // Simpler: track previous state explicitly.
+          // Since we already emitted the state machine above without tracking, we
+          // default to template (html comments in script blocks are unusual).
+          // This is safe: the only side effect is that after a <!-- --> inside a
+          // <script>, we'd be in 'template' state — but the next </script> would
+          // switch us back, so at worst we'd miss stripping one JS comment.
+          state = 'template';
+          break;
+        }
+        // Suppress the character, keep newlines
+        output += suppress(character);
+        index++;
+        break;
+      }
+
+      case 'block-comment': {
+        // Looking for */
+        if (character === '*' && peek(1) === '/') {
+          output += suppress('*') + suppress('/');
+          index += 2;
+          state = 'script';
+          break;
+        }
+        output += suppress(character);
+        index++;
+        break;
+      }
+
+      case 'line-comment': {
+        // End at newline
+        if (character === '\n') {
+          output += '\n';
+          index++;
+          state = 'script';
+          break;
+        }
+        output += suppress(character);
+        index++;
+        break;
+      }
+
+      case 'string-single': {
+        if (character === '\\') {
+          // Escape sequence — suppress both chars
+          output += suppress(character) + suppress(peek(1));
+          index += 2;
+          break;
+        }
+        if (character === "'") {
+          output += suppress("'");
+          index++;
+          state = 'script';
+          break;
+        }
+        output += suppress(character);
+        index++;
+        break;
+      }
+
+      case 'string-double': {
+        if (character === '\\') {
+          output += suppress(character) + suppress(peek(1));
+          index += 2;
+          break;
+        }
+        if (character === '"') {
+          output += suppress('"');
+          index++;
+          state = 'script';
+          break;
+        }
+        output += suppress(character);
+        index++;
+        break;
+      }
+
+      case 'string-template': {
+        if (character === '\\') {
+          output += suppress(character) + suppress(peek(1));
+          index += 2;
+          break;
+        }
+        if (character === '`') {
+          output += suppress('`');
+          index++;
+          state = 'script';
+          break;
+        }
+        // Note: we do NOT descend into ${...} template expressions — this is a
+        // deliberate simplification. A `<button>` inside a ${} would be suppressed
+        // along with the surrounding template literal, which is acceptable: if
+        // someone is building a raw button tag string in a template expression it is
+        // not a rendered native control.
+        output += suppress(character);
+        index++;
+        break;
+      }
+    }
+  }
+
+  return output;
+}
 
 // ── Detection ─────────────────────────────────────────────────────────────────
 
@@ -120,24 +460,52 @@ export const ALLOWLIST: AllowlistEntry[] = [
  * Specifically does NOT match:
  *   - `<Button` (capital B — a Cinder component)
  *   - `<selectField` (longer identifier — not a raw <select>)
- *   - `<!-- <button> -->` (commented — not currently stripped, so commented raw
- *     controls are intentionally NOT reported; they carry no runtime impact)
+ *
+ * The `g` flag is required: `detectAllRawControls` calls `.exec()` in a loop to
+ * find every occurrence on a line.
  */
-export const RAW_CONTROL_PATTERN = /<(button|input|select|textarea)(?=[\s\t\r\n>\/]|$)/;
+export const RAW_CONTROL_PATTERN = /<(button|input|select|textarea)(?=[\s\t\r\n>/]|$)/g;
 
 /** All tag names this guard enforces. */
 export const RAW_CONTROL_TAG_NAMES: RawControlTagName[] = ['button', 'input', 'select', 'textarea'];
 
 /**
+ * Returns ALL raw native-control opening tags found on a single line, each with
+ * the matched tag name and 0-based column index of the `<` character.
+ *
+ * Returns an empty array if no raw controls are present.
+ *
+ * Pure — no I/O. Exported for unit tests.
+ */
+export function detectAllRawControls(
+  line: string,
+): Array<{ tagName: RawControlTagName; columnIndex: number }> {
+  const results: Array<{ tagName: RawControlTagName; columnIndex: number }> = [];
+  // Reset lastIndex before using the global regex.
+  RAW_CONTROL_PATTERN.lastIndex = 0;
+  let match: RegExpExecArray | null;
+  while ((match = RAW_CONTROL_PATTERN.exec(line)) !== null) {
+    results.push({
+      tagName: match[1] as RawControlTagName,
+      columnIndex: match.index,
+    });
+  }
+  return results;
+}
+
+/**
  * Test whether a single source line contains a raw native control opening tag.
  * Returns the matched tag name, or `null` if no raw control is present.
+ *
+ * NOTE: only returns the FIRST match. Use `detectAllRawControls` when you need
+ * all matches on a line. This function is kept for backward compatibility with
+ * tests that check single-detection semantics.
  *
  * Pure — no I/O. Exported for unit tests.
  */
 export function detectRawControl(line: string): RawControlTagName | null {
-  const match = RAW_CONTROL_PATTERN.exec(line);
-  if (!match) return null;
-  return match[1] as RawControlTagName;
+  const matches = detectAllRawControls(line);
+  return matches[0]?.tagName ?? null;
 }
 
 /** Normalize a path to forward slashes for cross-platform stability. */
@@ -145,13 +513,49 @@ export function toPosixPath(path: string): string {
   return path.replaceAll('\\', '/');
 }
 
+// ── Inline Allow-Marker ───────────────────────────────────────────────────────
+
 /**
- * Build the allowlist lookup key: `relativePath::lineNumber`.
- * Line-based identity catches drifted entries loudly (they stop matching)
- * rather than silently grandfathering the wrong occurrence.
+ * The inline allow marker syntax.
+ * A line (or the line above a raw control) may contain this marker to exempt
+ * ALL raw controls on that line from being flagged.
+ *
+ * Format: `<!-- examples-audit-allow: <reason> -->`
+ * The reason is required (non-empty after trimming).
+ *
+ * Examples:
+ *   <button bind:this={el}>…</button> <!-- examples-audit-allow: triggerRef needs native element -->
+ *
+ *   <!-- examples-audit-allow: forwards spread attrs from parent snippet -->
+ *   <button type="button" {...attrs}>…</button>
  */
-export function allowlistKey(relativePath: string, lineNumber: number): string {
-  return `${toPosixPath(relativePath)}::${lineNumber}`;
+export const INLINE_ALLOW_MARKER = /<!--\s*examples-audit-allow\s*:\s*(.+?)\s*-->/;
+
+/**
+ * Returns the reason string from an inline allow marker in `line`, or `null` if
+ * the marker is not present.
+ *
+ * Pure — no I/O. Exported for unit tests.
+ */
+export function extractInlineAllowReason(line: string): string | null {
+  const match = INLINE_ALLOW_MARKER.exec(line);
+  return match ? (match[1]?.trim() ?? null) : null;
+}
+
+// ── Allowlist Key ─────────────────────────────────────────────────────────────
+
+/**
+ * Build the allowlist lookup key: `relativePath::tagName::occurrenceIndex`.
+ * This is stable across line-number drift (unrelated edits above don't break it)
+ * and catches both file moves (path changes) and structural refactors (occurrence
+ * count changes).
+ */
+export function allowlistKey(
+  relativePath: string,
+  tagName: RawControlTagName,
+  occurrenceIndex: number,
+): string {
+  return `${toPosixPath(relativePath)}::${tagName}::${occurrenceIndex}`;
 }
 
 /**
@@ -161,16 +565,35 @@ export function allowlistKey(relativePath: string, lineNumber: number): string {
 export function buildAllowlistIndex(entries: AllowlistEntry[]): Set<string> {
   const index = new Set<string>();
   for (const entry of entries) {
-    index.add(allowlistKey(entry.relativePath, entry.lineNumber));
+    index.add(allowlistKey(entry.relativePath, entry.tagName, entry.occurrenceIndex));
   }
   return index;
 }
 
 // ── Scanning ──────────────────────────────────────────────────────────────────
 
+/** Sort occurrences for stable output: alphabetical file then ascending line number. */
+function sortOccurrences(items: RawControlOccurrence[]): RawControlOccurrence[] {
+  return items.toSorted(
+    (a, b) => a.relativePath.localeCompare(b.relativePath) || a.lineNumber - b.lineNumber,
+  );
+}
+
 /**
  * Scan all `*.example.svelte` files under `examplesDirectory` for raw native
  * controls, partitioning them into allowlisted and flagged occurrences.
+ *
+ * Exemption hierarchy (checked in order):
+ *  1. Inline allow-marker on the control's line, or on the line immediately above.
+ *  2. ALLOWLIST entry matching relativePath + tagName + occurrenceIndex.
+ *
+ * Comment/string stripping is applied before scanning so that raw controls inside
+ * HTML/Svelte comments, JS block/line comments, and JS string literals are not
+ * reported. Line numbers in the result always refer to the ORIGINAL (unstripped)
+ * source.
+ *
+ * After scanning, any ALLOWLIST entries that did not match any occurrence are
+ * collected in `staleAllowlistEntries` — the caller should report these.
  *
  * Exported so unit tests can call it with a fixture directory.
  */
@@ -179,6 +602,7 @@ export async function scan(
   allowlist: AllowlistEntry[] = ALLOWLIST,
 ): Promise<ScanResult> {
   const allowlistIndex = buildAllowlistIndex(allowlist);
+  const matchedAllowlistKeys = new Set<string>();
   const allowlisted: RawControlOccurrence[] = [];
   const flagged: RawControlOccurrence[] = [];
 
@@ -186,37 +610,75 @@ export async function scan(
   for await (const relativePath of glob.scan({ cwd: examplesDirectory })) {
     const posixPath = toPosixPath(relativePath);
     const filePath = join(examplesDirectory, relativePath);
-    const source = await Bun.file(filePath).text();
-    const lines = source.split('\n');
+    const rawSource = await Bun.file(filePath).text();
+    const strippedSource = stripCommentsAndStrings(rawSource);
 
-    for (let index = 0; index < lines.length; index++) {
-      const lineNumber = index + 1;
-      const line = lines[index] ?? '';
-      const tagName = detectRawControl(line);
-      if (!tagName) continue;
+    // Split BOTH sources into lines so we can reference the original text for
+    // display while scanning the stripped text for detection.
+    const originalLines = rawSource.split('\n');
+    const strippedLines = strippedSource.split('\n');
 
-      const occurrence: RawControlOccurrence = {
-        relativePath: posixPath,
-        lineNumber,
-        tagName,
-        lineText: line.trim(),
-      };
+    // Per-file occurrence counters: how many times each tagName has been detected
+    // so far in this file (in document order). Used to compute occurrenceIndex.
+    const occurrenceCounts: Partial<Record<RawControlTagName, number>> = {};
 
-      if (allowlistIndex.has(allowlistKey(posixPath, lineNumber))) {
-        allowlisted.push(occurrence);
-      } else {
-        flagged.push(occurrence);
+    for (let lineIndex = 0; lineIndex < strippedLines.length; lineIndex++) {
+      const lineNumber = lineIndex + 1;
+      const strippedLine = strippedLines[lineIndex] ?? '';
+      const originalLine = originalLines[lineIndex] ?? '';
+
+      const matches = detectAllRawControls(strippedLine);
+      if (matches.length === 0) continue;
+
+      // Check for an inline allow-marker on this line or the line immediately above.
+      const markerOnSameLine = extractInlineAllowReason(originalLine);
+      const markerOnPreviousLine =
+        lineIndex > 0 ? extractInlineAllowReason(originalLines[lineIndex - 1] ?? '') : null;
+      const inlineAllowReason = markerOnSameLine ?? markerOnPreviousLine;
+
+      for (const { tagName, columnIndex } of matches) {
+        const currentIndex = occurrenceCounts[tagName] ?? 0;
+        occurrenceCounts[tagName] = currentIndex + 1;
+
+        const occurrence: RawControlOccurrence = {
+          relativePath: posixPath,
+          lineNumber,
+          columnIndex,
+          tagName,
+          lineText: originalLine.trim(),
+        };
+
+        // Inline marker exempts ALL controls on the covered line(s).
+        if (inlineAllowReason !== null) {
+          allowlisted.push(occurrence);
+          continue;
+        }
+
+        // Check the ALLOWLIST array.
+        const key = allowlistKey(posixPath, tagName, currentIndex);
+        if (allowlistIndex.has(key)) {
+          matchedAllowlistKeys.add(key);
+          allowlisted.push(occurrence);
+        } else {
+          flagged.push(occurrence);
+        }
       }
     }
   }
 
-  // Sort for stable output: alphabetical file then ascending line number.
-  const sort = (items: RawControlOccurrence[]) =>
-    items.toSorted(
-      (a, b) => a.relativePath.localeCompare(b.relativePath) || a.lineNumber - b.lineNumber,
-    );
+  // Collect stale entries: ALLOWLIST entries that never matched any occurrence.
+  const staleAllowlistEntries = allowlist.filter(
+    (entry) =>
+      !matchedAllowlistKeys.has(
+        allowlistKey(entry.relativePath, entry.tagName, entry.occurrenceIndex),
+      ),
+  );
 
-  return { allowlisted: sort(allowlisted), flagged: sort(flagged) };
+  return {
+    allowlisted: sortOccurrences(allowlisted),
+    flagged: sortOccurrences(flagged),
+    staleAllowlistEntries,
+  };
 }
 
 // ── Rendering ─────────────────────────────────────────────────────────────────
@@ -251,9 +713,16 @@ export function renderReport(result: ScanResult): string {
   }
 
   if (result.allowlisted.length > 0) {
-    report += `  Allowlisted (intentional — documented in ALLOWLIST): ${result.allowlisted.length}\n`;
+    report += `  Allowlisted (intentional — documented in ALLOWLIST or inline marker): ${result.allowlisted.length}\n`;
     report += renderOccurrenceList(result.allowlisted);
     report += '\n';
+  }
+
+  if (result.staleAllowlistEntries.length > 0) {
+    report += `\n  Stale allowlist entries (no longer match any raw control): ${result.staleAllowlistEntries.length}\n`;
+    for (const entry of result.staleAllowlistEntries) {
+      report += `    ${entry.relativePath}  <${entry.tagName}>  occurrence #${entry.occurrenceIndex}  — ${entry.reason}\n`;
+    }
   }
 
   return report;
@@ -276,16 +745,35 @@ async function main(): Promise<void> {
           `  Run with --strict to make this check fail on non-allowlisted raw controls.\n`,
       );
     }
+    if (result.staleAllowlistEntries.length > 0) {
+      process.stdout.write(
+        `  (report-only) ${result.staleAllowlistEntries.length} stale allowlist entr${result.staleAllowlistEntries.length === 1 ? 'y' : 'ies'} above — remove them from ALLOWLIST.\n`,
+      );
+    }
     return;
   }
 
-  // Strict mode: exit non-zero if any flagged (non-allowlisted) raw controls remain.
+  // Strict mode: exit non-zero if any flagged (non-allowlisted) raw controls remain,
+  // or if any stale allowlist entries are present.
+  const strictFailures: string[] = [];
+
   if (result.flagged.length > 0) {
-    process.stderr.write(
-      `examples:audit — ${result.flagged.length} non-allowlisted raw native control${result.flagged.length === 1 ? '' : 's'} found.\n` +
+    strictFailures.push(
+      `  ${result.flagged.length} non-allowlisted raw native control${result.flagged.length === 1 ? '' : 's'} found.\n` +
         `  Replace each with the Cinder equivalent (Button, Checkbox, Select, Textarea, Input),\n` +
-        `  or add an entry to the ALLOWLIST in scripts/check-raw-native-controls.ts with a reason.\n`,
+        `  or add an exemption via an inline <!-- examples-audit-allow: <reason> --> marker\n` +
+        `  or an ALLOWLIST entry in scripts/check-raw-native-controls.ts.`,
     );
+  }
+
+  if (result.staleAllowlistEntries.length > 0) {
+    strictFailures.push(
+      `  ${result.staleAllowlistEntries.length} stale allowlist entr${result.staleAllowlistEntries.length === 1 ? 'y' : 'ies'} — remove from ALLOWLIST in scripts/check-raw-native-controls.ts.`,
+    );
+  }
+
+  if (strictFailures.length > 0) {
+    process.stderr.write(`examples:audit (strict) — failures:\n${strictFailures.join('\n')}\n`);
     process.exit(1);
   }
 

--- a/packages/playground/scripts/check-raw-native-controls.ts
+++ b/packages/playground/scripts/check-raw-native-controls.ts
@@ -1,0 +1,300 @@
+/**
+ * Raw-native-control authoring guard for playground examples.
+ *
+ * Cinder's playground examples should use Cinder primitives (Button, Checkbox,
+ * Select, Textarea, Input) instead of raw HTML interactive controls (<button>,
+ * <input>, <select>, <textarea>). Raw controls in examples imply a usability
+ * inconsistency visible to every developer who views the docs.
+ *
+ * This script scans every `packages/playground/src/examples/**\/*.example.svelte`
+ * file for raw interactive native control tags and reports them, partitioned into:
+ *   - allowlisted: genuinely intentional raw controls (see ALLOWLIST below)
+ *   - flagged: raw controls that should be swapped for a Cinder primitive
+ *
+ * Two modes:
+ *   - default (report-only): prints the full inventory. Always exits 0.
+ *     Intended for human review and CI audit visibility.
+ *   - `--strict`: exits non-zero when any NON-allowlisted raw controls are found.
+ *     Wire this into the validate gate after the sweep PR merges.
+ *
+ * Run via:
+ *   bun run --filter=@cinder/playground examples:audit          (report)
+ *   bun run --filter=@cinder/playground examples:audit --strict (gate)
+ *
+ * Model: mirrors check-platform-features.ts's report-then-strict pattern.
+ */
+
+import { Glob } from 'bun';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const scriptDirectory = dirname(fileURLToPath(import.meta.url));
+const playgroundRoot = resolve(scriptDirectory, '..');
+const examplesRoot = join(playgroundRoot, 'src', 'examples');
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+/** A detected raw native-control occurrence. */
+export type RawControlOccurrence = {
+  /** Relative path from the examples root (e.g. `button/basic.example.svelte`). */
+  relativePath: string;
+  /** 1-based line number where the tag opens. */
+  lineNumber: number;
+  /** The tag name: `button`, `input`, `select`, or `textarea`. */
+  tagName: RawControlTagName;
+  /** The raw line text (trimmed). */
+  lineText: string;
+};
+
+/** The four raw interactive native HTML elements we enforce against. */
+export type RawControlTagName = 'button' | 'input' | 'select' | 'textarea';
+
+/** Reported result: all occurrences split into allowlisted vs flagged. */
+export type ScanResult = {
+  allowlisted: RawControlOccurrence[];
+  flagged: RawControlOccurrence[];
+};
+
+// ── Allowlist ─────────────────────────────────────────────────────────────────
+
+/**
+ * An allowlist entry grandfathers a specific file+line combination that cannot
+ * use a Cinder primitive. Each entry documents why the raw element is required.
+ *
+ * Identity is file+line (not file+tag), because two different raw tags on the
+ * same line would be unusual and detecting them together is acceptable. When a
+ * file is refactored and line numbers drift, the allowlist entry simply stops
+ * matching and the occurrence is re-flagged — forcing a fresh review.
+ */
+export type AllowlistEntry = {
+  /** Relative path from examples root, forward-slash separated. */
+  relativePath: string;
+  /** 1-based line number of the raw control's opening tag. */
+  lineNumber: number;
+  /**
+   * Human-readable rationale for the exemption. Required so reviewers
+   * understand intent at a glance rather than re-reading the example.
+   */
+  reason: string;
+};
+
+/**
+ * Allowlisted raw controls. Each entry represents a case where a Cinder
+ * primitive cannot be used — either because the snippet contract requires the
+ * consumer to supply a native element that accepts forwarded attributes, or
+ * because the example explicitly tests a low-level behavior that requires a
+ * native element (e.g. triggerRef with bind:this).
+ *
+ * Be conservative: only allowlist controls that GENUINELY cannot use a Cinder
+ * primitive. Everything else stays flagged for the sweep PR.
+ */
+export const ALLOWLIST: AllowlistEntry[] = [
+  {
+    relativePath: 'navigation-bar/basic.example.svelte',
+    lineNumber: 20,
+    reason:
+      'The NavigationBar menuToggle snippet forwards spread attrs (including aria and focus management) onto the trigger element. The consumer MUST supply a native <button> so the attrs land on an interactive element; the Cinder Button component does not expose a pass-through for arbitrary component-forwarded attrs.',
+  },
+  {
+    relativePath: 'popover/transformed-ancestor.example.svelte',
+    lineNumber: 33,
+    reason:
+      'This fixture tests low-level `triggerRef` anchoring with bind:this={triggerElement}. The Popover component needs a raw HTMLButtonElement reference — the example intentionally exercises the ref path rather than the trigger-slot path, so a raw <button> is the correct primitive here.',
+  },
+  {
+    relativePath: 'command-palette/search-recent-actions.example.svelte',
+    lineNumber: 81,
+    reason:
+      'CommandPalette requires a triggerRef (HTMLElement) for focus-return. The trigger button uses bind:this to capture the element reference for that purpose. It also applies heavy inline styles that exist to demo the styled-keyboard-shortcut pattern; until the example is rewritten with a styled Cinder Button, the raw element is intentional.',
+  },
+];
+
+// ── Detection ─────────────────────────────────────────────────────────────────
+
+/**
+ * The regex that identifies an opening raw native control tag.
+ * Matches `<button`, `<input`, `<select`, `<textarea` at a tag boundary — i.e.
+ * the tag name is followed by whitespace, `>`, or `/` (self-closing). This
+ * avoids false positives on Svelte component names like `<InputField>`.
+ *
+ * Specifically does NOT match:
+ *   - `<Button` (capital B — a Cinder component)
+ *   - `<selectField` (longer identifier — not a raw <select>)
+ *   - `<!-- <button> -->` (commented — not currently stripped, so commented raw
+ *     controls are intentionally NOT reported; they carry no runtime impact)
+ */
+export const RAW_CONTROL_PATTERN = /<(button|input|select|textarea)(?=[\s\t\r\n>\/]|$)/;
+
+/** All tag names this guard enforces. */
+export const RAW_CONTROL_TAG_NAMES: RawControlTagName[] = ['button', 'input', 'select', 'textarea'];
+
+/**
+ * Test whether a single source line contains a raw native control opening tag.
+ * Returns the matched tag name, or `null` if no raw control is present.
+ *
+ * Pure — no I/O. Exported for unit tests.
+ */
+export function detectRawControl(line: string): RawControlTagName | null {
+  const match = RAW_CONTROL_PATTERN.exec(line);
+  if (!match) return null;
+  return match[1] as RawControlTagName;
+}
+
+/** Normalize a path to forward slashes for cross-platform stability. */
+export function toPosixPath(path: string): string {
+  return path.replaceAll('\\', '/');
+}
+
+/**
+ * Build the allowlist lookup key: `relativePath::lineNumber`.
+ * Line-based identity catches drifted entries loudly (they stop matching)
+ * rather than silently grandfathering the wrong occurrence.
+ */
+export function allowlistKey(relativePath: string, lineNumber: number): string {
+  return `${toPosixPath(relativePath)}::${lineNumber}`;
+}
+
+/**
+ * Build a fast lookup set from the allowlist array.
+ * Pure — no I/O. Exported for unit tests.
+ */
+export function buildAllowlistIndex(entries: AllowlistEntry[]): Set<string> {
+  const index = new Set<string>();
+  for (const entry of entries) {
+    index.add(allowlistKey(entry.relativePath, entry.lineNumber));
+  }
+  return index;
+}
+
+// ── Scanning ──────────────────────────────────────────────────────────────────
+
+/**
+ * Scan all `*.example.svelte` files under `examplesDirectory` for raw native
+ * controls, partitioning them into allowlisted and flagged occurrences.
+ *
+ * Exported so unit tests can call it with a fixture directory.
+ */
+export async function scan(
+  examplesDirectory: string,
+  allowlist: AllowlistEntry[] = ALLOWLIST,
+): Promise<ScanResult> {
+  const allowlistIndex = buildAllowlistIndex(allowlist);
+  const allowlisted: RawControlOccurrence[] = [];
+  const flagged: RawControlOccurrence[] = [];
+
+  const glob = new Glob('**/*.example.svelte');
+  for await (const relativePath of glob.scan({ cwd: examplesDirectory })) {
+    const posixPath = toPosixPath(relativePath);
+    const filePath = join(examplesDirectory, relativePath);
+    const source = await Bun.file(filePath).text();
+    const lines = source.split('\n');
+
+    for (let index = 0; index < lines.length; index++) {
+      const lineNumber = index + 1;
+      const line = lines[index] ?? '';
+      const tagName = detectRawControl(line);
+      if (!tagName) continue;
+
+      const occurrence: RawControlOccurrence = {
+        relativePath: posixPath,
+        lineNumber,
+        tagName,
+        lineText: line.trim(),
+      };
+
+      if (allowlistIndex.has(allowlistKey(posixPath, lineNumber))) {
+        allowlisted.push(occurrence);
+      } else {
+        flagged.push(occurrence);
+      }
+    }
+  }
+
+  // Sort for stable output: alphabetical file then ascending line number.
+  const sort = (items: RawControlOccurrence[]) =>
+    items.toSorted(
+      (a, b) => a.relativePath.localeCompare(b.relativePath) || a.lineNumber - b.lineNumber,
+    );
+
+  return { allowlisted: sort(allowlisted), flagged: sort(flagged) };
+}
+
+// ── Rendering ─────────────────────────────────────────────────────────────────
+
+/**
+ * Render an occurrence list as indented text lines.
+ */
+function renderOccurrenceList(occurrences: RawControlOccurrence[]): string {
+  return occurrences
+    .map(
+      (occurrence) =>
+        `    ${occurrence.relativePath}:${occurrence.lineNumber}  <${occurrence.tagName}>  ${occurrence.lineText}`,
+    )
+    .join('\n');
+}
+
+/**
+ * Render the full audit report as a string.
+ * Pure — no I/O. Exported for unit tests.
+ */
+export function renderReport(result: ScanResult): string {
+  const total = result.allowlisted.length + result.flagged.length;
+  let report = `examples:audit — raw native control inventory\n`;
+  report += `  Total raw controls found: ${total} (${result.flagged.length} flagged, ${result.allowlisted.length} allowlisted)\n\n`;
+
+  if (result.flagged.length > 0) {
+    report += `  Flagged (should use a Cinder primitive): ${result.flagged.length}\n`;
+    report += renderOccurrenceList(result.flagged);
+    report += '\n\n';
+  } else {
+    report += `  Flagged: none — all raw controls are allowlisted or absent.\n\n`;
+  }
+
+  if (result.allowlisted.length > 0) {
+    report += `  Allowlisted (intentional — documented in ALLOWLIST): ${result.allowlisted.length}\n`;
+    report += renderOccurrenceList(result.allowlisted);
+    report += '\n';
+  }
+
+  return report;
+}
+
+// ── Main ──────────────────────────────────────────────────────────────────────
+
+async function main(): Promise<void> {
+  const strict = process.argv.includes('--strict');
+  const result = await scan(examplesRoot);
+
+  process.stdout.write(renderReport(result));
+
+  if (!strict) {
+    // Report-only mode: always exit 0 regardless of flagged count.
+    // A later PR will flip strict mode on after the sweep.
+    if (result.flagged.length > 0) {
+      process.stdout.write(
+        `  (report-only) ${result.flagged.length} flagged control${result.flagged.length === 1 ? '' : 's'} above should be replaced with Cinder primitives.\n` +
+          `  Run with --strict to make this check fail on non-allowlisted raw controls.\n`,
+      );
+    }
+    return;
+  }
+
+  // Strict mode: exit non-zero if any flagged (non-allowlisted) raw controls remain.
+  if (result.flagged.length > 0) {
+    process.stderr.write(
+      `examples:audit — ${result.flagged.length} non-allowlisted raw native control${result.flagged.length === 1 ? '' : 's'} found.\n` +
+        `  Replace each with the Cinder equivalent (Button, Checkbox, Select, Textarea, Input),\n` +
+        `  or add an entry to the ALLOWLIST in scripts/check-raw-native-controls.ts with a reason.\n`,
+    );
+    process.exit(1);
+  }
+
+  process.stdout.write(`  examples:audit (strict) — no non-allowlisted raw controls. OK.\n`);
+}
+
+if (import.meta.main) {
+  main().catch((error: unknown) => {
+    console.error('examples:audit failed:', error);
+    process.exit(1);
+  });
+}

--- a/packages/playground/scripts/check-raw-native-controls.ts
+++ b/packages/playground/scripts/check-raw-native-controls.ts
@@ -642,8 +642,18 @@ export async function scan(
 
       // Check for an inline allow-marker on this line or the line immediately above.
       const markerOnSameLine = extractInlineAllowReason(originalLine);
+
+      // A previous-line marker only covers THIS line when it sits on its own —
+      // i.e. line N-1 carries the marker but no raw control of its own. If line
+      // N-1 also had a raw control, its marker was a SAME-LINE marker scoped to
+      // N-1 and must not bleed its exemption down onto line N.
+      const previousStrippedLine = lineIndex > 0 ? (strippedLines[lineIndex - 1] ?? '') : '';
+      const previousLineHasOwnControl =
+        lineIndex > 0 && detectAllRawControls(previousStrippedLine).length > 0;
       const markerOnPreviousLine =
-        lineIndex > 0 ? extractInlineAllowReason(originalLines[lineIndex - 1] ?? '') : null;
+        lineIndex > 0 && !previousLineHasOwnControl
+          ? extractInlineAllowReason(originalLines[lineIndex - 1] ?? '')
+          : null;
       const inlineAllowReason = markerOnSameLine ?? markerOnPreviousLine;
 
       for (const { tagName, columnIndex } of matches) {


### PR DESCRIPTION
## Summary

First slice of the playground native-control task: a **report-only authoring guard**, not the example sweep (the sweep + enforce comes last, after the remaining component-example edits settle).

`examples:audit` (`packages/playground/scripts/check-raw-native-controls.ts`) scans `*.example.svelte` for raw `<button>`/`<input>`/`<select>`/`<textarea>` and reports each `file:line`, modeled on the `platform:audit` report-then-`--strict` pattern (default exits 0; `--strict` exits non-zero on non-allowlisted controls, for the later enforce flip). A documented allowlist (path + tag + occurrence index, plus an inline `<!-- examples-audit-allow: reason -->` marker mechanism) seeds the 3 currently-intentional raw controls. Currently **18 raw controls: 15 flagged for the sweep, 3 allowlisted, 0 stale.**

Does **not** edit any example files (that's the later sweep PR). Also includes the shared pre-existing `schema.ts` unsafe-assertion fix needed to make the cinder package lint green for push.

## Review committee

Codex (gpt-5.4, xhigh) + author. Codex's 5 findings on guard robustness were all addressed: a line-number-preserving comment/string-strip pass (so `<button>` in comments/strings isn't falsely flagged — the original falsely claimed this), all-matches-per-line detection, tag+occurrence-index allowlist keys + inline markers, stale-allowlist-entry reporting, and the full regression test set.

## Test plan
- [x] guard tests pass (comments, multiline, strings, multi-per-line, tag-specific allowlist, stale entries)
- [x] `bun run --filter=@cinder/playground test` — 533 pass
- [x] `examples:audit` reports the inventory and exits 0; `--strict` exits 1 on the 15 flagged
- [x] typecheck / lint / prettier — clean

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Playground-only static audit tooling with default exit 0; no runtime or example content changes in this diff.
> 
> **Overview**
> Adds a **report-only** playground audit (`examples:audit`) that inventories raw native interactive tags (`button`, `input`, `select`, `textarea`) in `*.example.svelte` files and splits findings into **flagged** vs **allowlisted**, with optional **`--strict`** to fail CI once enforcement is enabled later.
> 
> The scanner strips comments and script string literals (line-preserving state machine), detects all matches per line without false positives on Cinder components like `Button`, and supports exemptions via a checked-in **ALLOWLIST** (path + tag + occurrence index) or inline `<!-- examples-audit-allow: reason -->`, including **stale allowlist** reporting. A large regression test suite covers stripping edge cases, allowlist keys, marker scoping (no bleed to the next line), and live scans against the real examples tree.
> 
> No example `.svelte` files are modified in this PR—only the guard script, tests, and the new npm script entry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c3d688df69da81951066e9ec1698df3f56f1e003. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->