### PR TITLE
refactor(status): extract shared soft status-surface recipe (5b849512)

### DIFF
--- a/packages/components/docs/css-audit/status-triple-equivalence.md
+++ b/packages/components/docs/css-audit/status-triple-equivalence.md
@@ -228,3 +228,42 @@ comment block pointing at this doc — those comment lines also contain the
 literal pattern text in backticks, so `rg` will report a slightly higher raw
 hit count post-audit (one extra match per file = 3 added). Filter to lines
 starting with whitespace + `oklch(` to count only real declarations.
+
+---
+
+## 7. Consolidation into a shared recipe (task 5b849512)
+
+The Batch-D conclusion above — keep the synthesized soft surface, do **not**
+adopt the triples — still holds. What changed is **where** the synthesis lives.
+
+The identical `light-dark(oklch(from … L C h))` algebra that was duplicated
+across Alert, Banner, and Callout now lives **once** in the shared partial
+`src/styles/components/_status-surface.css`, decomposed by emitted
+responsibility:
+
+| Class                            | Emits                        | Composed by            |
+| -------------------------------- | ---------------------------- | ---------------------- |
+| `.cinder-_status-surface`        | `background-color` + `color` | Alert, Banner, Callout |
+| `.cinder-_status-surface-border` | `border-color`               | Banner, Callout        |
+| `.cinder-_status-surface-stripe` | `border-inline-start-color`  | Callout only           |
+
+Alert composes the surface only (P7 neutral border); Banner adds the soft
+border; Callout adds the border and the saturated stripe. Each component sets
+the recipe's inputs per variant on its own root element:
+
+- `--_cinder-status-base` — the status base color (`var(--cinder-info)` etc.;
+  Alert keeps `var(--cinder-alert-info)` for its info variant).
+- `--_cinder-status-fg-chroma-light` / `--_cinder-status-fg-chroma-dark` — the
+  foreground chroma, which **escalates per status severity** (info `0.12` →
+  danger `0.18` light) and so cannot be a single baked constant.
+- `--_cinder-status-stripe-chroma` — Callout's stripe chroma (info `0.13` →
+  danger `0.18`).
+
+The L values and the background/border chroma are uniform across variants, so
+they are baked into the recipe; only the foreground and stripe chroma vary.
+
+**This consolidation preserves every rendered value exactly** — it is a pure
+dedup, not a visual change. The L=20% dark soft-surface background that this
+document measured against the L=28% triple is unchanged; the ~8-oklch-L-point
+discrepancy that blocked the triple migration is preserved verbatim. Reconciling
+the soft surface with the triples remains separate, screenshot-gated work.

--- a/packages/components/scripts/raw-color-baseline.json
+++ b/packages/components/scripts/raw-color-baseline.json
@@ -2,37 +2,17 @@
   {
     "filePath": "src/components/alert/alert.css",
     "colorClass": "light-dark",
-    "allowedCount": 9
+    "allowedCount": 1
   },
   {
     "filePath": "src/components/alert/alert.css",
     "colorClass": "oklch",
-    "allowedCount": 18
+    "allowedCount": 2
   },
   {
     "filePath": "src/components/autocomplete/autocomplete.css",
     "colorClass": "oklch",
     "allowedCount": 1
-  },
-  {
-    "filePath": "src/components/banner/banner.css",
-    "colorClass": "light-dark",
-    "allowedCount": 12
-  },
-  {
-    "filePath": "src/components/banner/banner.css",
-    "colorClass": "oklch",
-    "allowedCount": 24
-  },
-  {
-    "filePath": "src/components/callout/callout.css",
-    "colorClass": "light-dark",
-    "allowedCount": 16
-  },
-  {
-    "filePath": "src/components/callout/callout.css",
-    "colorClass": "oklch",
-    "allowedCount": 32
   },
   {
     "filePath": "src/components/chat/input/chat-input.svelte",
@@ -43,16 +23,6 @@
     "filePath": "src/components/chat/message/image-lightbox.svelte",
     "colorClass": "rgb",
     "allowedCount": 9
-  },
-  {
-    "filePath": "src/components/chip/chip.css",
-    "colorClass": "light-dark",
-    "allowedCount": 2
-  },
-  {
-    "filePath": "src/components/chip/chip.css",
-    "colorClass": "oklch",
-    "allowedCount": 4
   },
   {
     "filePath": "src/components/code-block/code-block.css",
@@ -193,6 +163,16 @@
     "filePath": "src/components/toggle/toggle.css",
     "colorClass": "rgb",
     "allowedCount": 2
+  },
+  {
+    "filePath": "src/styles/components/_status-surface.css",
+    "colorClass": "light-dark",
+    "allowedCount": 4
+  },
+  {
+    "filePath": "src/styles/components/_status-surface.css",
+    "colorClass": "oklch",
+    "allowedCount": 8
   },
   {
     "filePath": "src/styles/components/experimental/popover.css",

--- a/packages/components/src/components/alert/alert.css
+++ b/packages/components/src/components/alert/alert.css
@@ -4,9 +4,11 @@
  * ======================================== */
 
   /*
- * --cinder-info is not defined in tokens-base.css (the project only ships
- * success / warning / danger status tokens). Define it here, scoped to
- * .cinder-alert, so it doesn't bleed into other components.
+ * Alert's info hue. The global `--cinder-info` token now exists in
+ * tokens-base.css, but Alert keeps a component-local base whose dark arm sits
+ * at a slightly higher chroma (0.15 vs the global 0.13) — the tint Alert was
+ * designed around. Scoped to `.cinder-alert` so it does not bleed elsewhere.
+ * Reconciling this with the global token is a separate visual-design decision.
  */
   .cinder-alert {
     --cinder-alert-info: light-dark(oklch(45% 0.14 245), oklch(78% 0.15 245));
@@ -99,101 +101,57 @@
   }
 
   /* ----------------------------------------
- * Variant: info
+ * Status variants
  *
- * NOTE (CSS audit, Batch D): The four status variants below intentionally
- * keep the inline `oklch(from var(--cinder-{status}) …)` math for
- * background-color and color instead of switching to the
- * `--cinder-color-{status}-{bg,fg,border}` triples in tokens-base.css. The
- * dark-theme triple background sits 8 oklch-L points lighter than the surface
- * synthesized here (28% L vs 20% L), which exceeds the audit's 0.02 ΔL
- * threshold. See docs/css-audit/status-triple-equivalence.md for the table.
+ * The soft-surface background + foreground algebra lives in the shared
+ * `_status-surface.css` partial, consumed via `.cinder-_status-surface` on the
+ * root (see alert.svelte). Each variant sets the partial's inputs (base color +
+ * per-variant foreground chroma) plus the alert-local focus-ring color.
  *
- * NOTE (P7): The variant `border-color` is intentionally removed so every
- * variant inherits the base `border: 1px solid var(--cinder-border)`. P7 sheds
- * Alert's persistent status-colored frame; the directional color cue (an
- * inline-start stripe) now belongs exclusively to Callout. Alert keeps its
- * soft variant background tint and variant text color — only the colored frame
- * is gone. Do not reintroduce any border-affecting declaration here.
+ * NOTE (CSS audit, Batch D): the soft surface is synthesized rather than read
+ * from the `--cinder-color-{status}-{bg,fg,border}` triples because the
+ * dark-theme triple background sits ~8 oklch-L points lighter (28% vs 20% L),
+ * exceeding the 0.02 ΔL threshold. See docs/css-audit/status-triple-equivalence.md.
  *
- * Accessibility (WCAG 1.4.1): with the border neutralized, the variant's
- * background tint and text color are hue-only signals. The non-color channel
- * that conveys status is the alert's own text content (e.g. "Failed to connect
- * to the server.") together with `role="alert"`, plus the optional `icon`
- * slot. The pre-P7 colored border was itself sub-3:1 against the tinted
- * background (see the Batch-D audit), so it was never a reliable non-color
- * cue; removing it does not regress 1.4.1. Authors should pass meaningful
- * message text (and an icon where practical) rather than relying on tint.
+ * NOTE (P7): Alert composes ONLY `.cinder-_status-surface` (background + text),
+ * NOT `.cinder-_status-surface-border` or `-stripe`. Every variant inherits the
+ * base `border: 1px solid var(--cinder-border)`; P7 sheds Alert's persistent
+ * status-colored frame, leaving the directional color cue (the stripe)
+ * exclusively to Callout. Do not add a border/stripe surface class or any
+ * border-affecting declaration here.
+ *
+ * Accessibility (WCAG 1.4.1): with the border neutral, the variant tint + text
+ * color are hue-only signals; the non-color status channel is the alert's own
+ * message text plus `role="alert"` and the optional `icon` slot. The pre-P7
+ * colored border was itself sub-3:1 against the tint (Batch-D audit), so it was
+ * never a reliable non-color cue; its absence does not regress 1.4.1.
  * ---------------------------------------- */
 
   .cinder-alert[data-cinder-variant='info'] {
     --_cinder-alert-ring: var(--cinder-alert-info);
-
-    background-color: light-dark(
-      oklch(from var(--cinder-alert-info) 96.5% 0.015 h),
-      oklch(from var(--cinder-alert-info) 20% 0.03 h)
-    );
-    /* border-color intentionally omitted: every Alert variant falls through to
-   * the base `border: 1px solid var(--cinder-border)`. P7 sheds the persistent
-   * status-colored frame so Alert reads as a flat tinted notification, leaving
-   * the directional color cue (the stripe) exclusively to Callout. */
-    color: light-dark(
-      oklch(from var(--cinder-alert-info) 35% 0.12 h),
-      oklch(from var(--cinder-alert-info) 88% 0.12 h)
-    );
+    --_cinder-status-base: var(--cinder-alert-info);
+    --_cinder-status-fg-chroma-light: 0.12;
+    --_cinder-status-fg-chroma-dark: 0.12;
   }
-
-  /* ----------------------------------------
- * Variant: success
- * ---------------------------------------- */
 
   .cinder-alert[data-cinder-variant='success'] {
     --_cinder-alert-ring: var(--cinder-success);
-
-    background-color: light-dark(
-      oklch(from var(--cinder-success) 96.5% 0.015 h),
-      oklch(from var(--cinder-success) 20% 0.03 h)
-    );
-    /* border-color intentionally omitted — inherits var(--cinder-border). */
-    color: light-dark(
-      oklch(from var(--cinder-success) 35% 0.14 h),
-      oklch(from var(--cinder-success) 88% 0.12 h)
-    );
+    --_cinder-status-base: var(--cinder-success);
+    --_cinder-status-fg-chroma-light: 0.14;
+    --_cinder-status-fg-chroma-dark: 0.12;
   }
-
-  /* ----------------------------------------
- * Variant: warning
- * ---------------------------------------- */
 
   .cinder-alert[data-cinder-variant='warning'] {
     --_cinder-alert-ring: var(--cinder-warning);
-
-    background-color: light-dark(
-      oklch(from var(--cinder-warning) 96.5% 0.015 h),
-      oklch(from var(--cinder-warning) 20% 0.03 h)
-    );
-    /* border-color intentionally omitted — inherits var(--cinder-border). */
-    color: light-dark(
-      oklch(from var(--cinder-warning) 35% 0.16 h),
-      oklch(from var(--cinder-warning) 88% 0.14 h)
-    );
+    --_cinder-status-base: var(--cinder-warning);
+    --_cinder-status-fg-chroma-light: 0.16;
+    --_cinder-status-fg-chroma-dark: 0.14;
   }
-
-  /* ----------------------------------------
- * Variant: error
- * ---------------------------------------- */
 
   .cinder-alert[data-cinder-variant='error'] {
     --_cinder-alert-ring: var(--cinder-danger);
-
-    background-color: light-dark(
-      oklch(from var(--cinder-danger) 96.5% 0.015 h),
-      oklch(from var(--cinder-danger) 20% 0.03 h)
-    );
-    /* border-color intentionally omitted — inherits var(--cinder-border). */
-    color: light-dark(
-      oklch(from var(--cinder-danger) 35% 0.18 h),
-      oklch(from var(--cinder-danger) 88% 0.16 h)
-    );
+    --_cinder-status-base: var(--cinder-danger);
+    --_cinder-status-fg-chroma-light: 0.18;
+    --_cinder-status-fg-chroma-dark: 0.16;
   }
 }

--- a/packages/components/src/components/alert/alert.css.test.ts
+++ b/packages/components/src/components/alert/alert.css.test.ts
@@ -35,6 +35,29 @@ function loadCss(relativePath: string): string {
 const alertCss = loadCss('./alert.css');
 const root = parse(alertCss);
 
+// The variant-tinted background + foreground algebra now lives in the shared
+// `_status-surface.css` partial; Alert composes `.cinder-_status-surface` (and
+// does NOT compose the border/stripe classes — P7 keeps the border neutral).
+// Variant rules set the partial's `--_cinder-status-base` tint input. So the
+// "still tinted, not flattened to surface" criterion is pinned in two places:
+// the variant rule sets a status-derived base here, and the partial synthesizes
+// the tint from it.
+const statusSurfaceCss = loadCss('../../styles/components/_status-surface.css');
+const statusSurfaceRoot = parse(statusSurfaceCss);
+
+function findRuleInPartial(selector: string): Rule {
+  let match: Rule | undefined;
+  statusSurfaceRoot.walkRules((rule) => {
+    if (rule.selectors.includes(selector)) {
+      match = rule;
+      return false;
+    }
+    return undefined;
+  });
+  if (!match) throw new Error(`partial rule not found: ${selector}`);
+  return match;
+}
+
 /**
  * Every property that can paint or size a border edge — shorthands, longhands,
  * physical sides, logical sides, and the `border-image` family (which can draw
@@ -170,15 +193,33 @@ describe('alert chrome reduction — border-equals-base', () => {
         expect(borderProps).toEqual([]);
       });
 
-      test('background-color is still a variant-tinted light-dark(oklch(...)) (not flattened to surface)', () => {
-        let background: string | undefined;
-        rule.walkDecls('background-color', (decl) => {
-          background = decl.value;
+      test('sets a status-derived base tint input (not flattened to surface)', () => {
+        // The variant tint is no longer an inline background-color; it is driven
+        // by the --_cinder-status-base input the shared partial consumes. Assert
+        // the variant routes to a status color (a --cinder-* token), so the
+        // surface stays tinted rather than collapsing to the neutral base.
+        let base: string | undefined;
+        rule.walkDecls('--_cinder-status-base', (decl) => {
+          base = decl.value;
         });
-        expect(background).toBeDefined();
-        expect(background).toMatch(/^light-dark\(/);
-        expect(background).toMatch(/oklch\(\s*from\s+var\(--cinder-/);
+        expect(base).toBeDefined();
+        expect(base).toMatch(/^var\(--cinder-/);
       });
     });
   }
+
+  test('the composed surface partial synthesizes a variant-tinted light-dark(oklch(...)) background', () => {
+    // The actual tint lives in the partial Alert composes; confirm it is still a
+    // relative-color light-dark surface derived from the base input, so no future
+    // edit flattens Alert to a plain neutral surface.
+    // Selector is self-doubled (.x.x) for (0,2,0) specificity over the component base.
+    const surfaceRule = findRuleInPartial('.cinder-_status-surface.cinder-_status-surface');
+    let background: string | undefined;
+    surfaceRule.walkDecls('background-color', (decl) => {
+      background = decl.value;
+    });
+    expect(background).toBeDefined();
+    expect(background).toMatch(/^light-dark\(/);
+    expect(background).toMatch(/oklch\(\s*from\s+var\(--_cinder-status-base\)/);
+  });
 });

--- a/packages/components/src/components/alert/alert.svelte
+++ b/packages/components/src/components/alert/alert.svelte
@@ -60,7 +60,7 @@
 {#if visible}
   <div
     {...restWithoutForbidden}
-    class={cn('cinder-alert', className)}
+    class={cn('cinder-alert', 'cinder-_status-surface', className)}
     data-cinder-variant={variant}
     role="alert"
   >

--- a/packages/components/src/components/banner/banner.css
+++ b/packages/components/src/components/banner/banner.css
@@ -86,95 +86,47 @@
   }
 
   /* ----------------------------------------
- * Variant: info
+ * Status variants
  *
- * NOTE (CSS audit, Batch D): The four status variants below intentionally
- * keep the inline `oklch(from var(--cinder-{status}) …)` math instead of
- * switching to the `--cinder-color-{status}-{bg,fg,border}` triples in
- * tokens-base.css. The dark-theme triple background sits 8 oklch-L points
- * lighter than the surface synthesized here (28% L vs 20% L), which exceeds
- * the audit's 0.02 ΔL threshold. See
- * docs/css-audit/status-triple-equivalence.md for the full pre-flight table.
+ * The soft-surface color algebra (background, border, foreground) lives in the
+ * shared `_status-surface.css` partial, consumed via `.cinder-_status-surface`
+ * + `.cinder-_status-surface-border` on the root (see banner.svelte). Banner
+ * draws no inline-start stripe, so it does not compose the stripe class. Each
+ * variant sets the partial's inputs (base color + per-variant foreground chroma)
+ * plus the banner-local focus-ring color.
+ *
+ * NOTE (CSS audit, Batch D): the soft surface is synthesized rather than read
+ * from the `--cinder-color-{status}-{bg,fg,border}` triples because the
+ * dark-theme triple background sits ~8 oklch-L points lighter (28% vs 20% L),
+ * exceeding the 0.02 ΔL threshold. See docs/css-audit/status-triple-equivalence.md.
  * ---------------------------------------- */
 
   .cinder-banner[data-cinder-variant='info'] {
     --_cinder-banner-ring: var(--cinder-info);
-
-    background-color: light-dark(
-      oklch(from var(--cinder-info) 96.5% 0.015 h),
-      oklch(from var(--cinder-info) 20% 0.03 h)
-    );
-    border-color: light-dark(
-      oklch(from var(--cinder-info) 85% 0.05 h),
-      oklch(from var(--cinder-info) 35% 0.08 h)
-    );
-    color: light-dark(
-      oklch(from var(--cinder-info) 35% 0.12 h),
-      oklch(from var(--cinder-info) 88% 0.12 h)
-    );
+    --_cinder-status-base: var(--cinder-info);
+    --_cinder-status-fg-chroma-light: 0.12;
+    --_cinder-status-fg-chroma-dark: 0.12;
   }
-
-  /* ----------------------------------------
- * Variant: success
- * ---------------------------------------- */
 
   .cinder-banner[data-cinder-variant='success'] {
     --_cinder-banner-ring: var(--cinder-success);
-
-    background-color: light-dark(
-      oklch(from var(--cinder-success) 96.5% 0.015 h),
-      oklch(from var(--cinder-success) 20% 0.03 h)
-    );
-    border-color: light-dark(
-      oklch(from var(--cinder-success) 85% 0.05 h),
-      oklch(from var(--cinder-success) 35% 0.08 h)
-    );
-    color: light-dark(
-      oklch(from var(--cinder-success) 35% 0.14 h),
-      oklch(from var(--cinder-success) 88% 0.12 h)
-    );
+    --_cinder-status-base: var(--cinder-success);
+    --_cinder-status-fg-chroma-light: 0.14;
+    --_cinder-status-fg-chroma-dark: 0.12;
   }
-
-  /* ----------------------------------------
- * Variant: warning
- * ---------------------------------------- */
 
   .cinder-banner[data-cinder-variant='warning'] {
     --_cinder-banner-ring: var(--cinder-warning);
-
-    background-color: light-dark(
-      oklch(from var(--cinder-warning) 96.5% 0.015 h),
-      oklch(from var(--cinder-warning) 20% 0.03 h)
-    );
-    border-color: light-dark(
-      oklch(from var(--cinder-warning) 85% 0.05 h),
-      oklch(from var(--cinder-warning) 35% 0.08 h)
-    );
-    color: light-dark(
-      oklch(from var(--cinder-warning) 35% 0.16 h),
-      oklch(from var(--cinder-warning) 88% 0.14 h)
-    );
+    --_cinder-status-base: var(--cinder-warning);
+    --_cinder-status-fg-chroma-light: 0.16;
+    --_cinder-status-fg-chroma-dark: 0.14;
   }
-
-  /* ----------------------------------------
- * Variant: danger
- * ---------------------------------------- */
 
   .cinder-banner[data-cinder-variant='danger'] {
     --_cinder-banner-ring: var(--cinder-danger);
-
-    background-color: light-dark(
-      oklch(from var(--cinder-danger) 96.5% 0.015 h),
-      oklch(from var(--cinder-danger) 20% 0.03 h)
-    );
-    border-color: light-dark(
-      oklch(from var(--cinder-danger) 85% 0.05 h),
-      oklch(from var(--cinder-danger) 35% 0.08 h)
-    );
-    color: light-dark(
-      oklch(from var(--cinder-danger) 35% 0.18 h),
-      oklch(from var(--cinder-danger) 88% 0.16 h)
-    );
+    --_cinder-status-base: var(--cinder-danger);
+    --_cinder-status-fg-chroma-light: 0.18;
+    --_cinder-status-fg-chroma-dark: 0.16;
   }
 
   /* ----------------------------------------

--- a/packages/components/src/components/banner/banner.svelte
+++ b/packages/components/src/components/banner/banner.svelte
@@ -112,7 +112,12 @@
   <div
     bind:this={rootElement}
     {...restWithoutLiveRegion}
-    class={classNames('cinder-banner', className)}
+    class={classNames(
+      'cinder-banner',
+      'cinder-_status-surface',
+      'cinder-_status-surface-border',
+      className,
+    )}
     data-cinder-variant={variant}
     role="region"
     aria-label={ariaLabel}

--- a/packages/components/src/components/callout/callout.css
+++ b/packages/components/src/components/callout/callout.css
@@ -79,105 +79,47 @@
   }
 
   /* ----------------------------------------
- * Variant: info
+ * Status variants
  *
- * NOTE (CSS audit, Batch D): The four status variants below intentionally
- * keep the inline `oklch(from var(--cinder-{status}) …)` math instead of
- * switching to the `--cinder-color-{status}-{bg,fg,border}` triples in
- * tokens-base.css. The dark-theme triple background sits 8 oklch-L points
- * lighter than the surface synthesized here (28% L vs 20% L), which exceeds
- * the audit's 0.02 ΔL threshold. See
- * docs/css-audit/status-triple-equivalence.md for the full pre-flight table.
+ * The soft-surface color algebra (background, border, foreground, stripe) lives
+ * in the shared `_status-surface.css` partial, consumed via the
+ * `.cinder-_status-surface*` classes on the root (see callout.svelte). Each
+ * variant only sets the partial's inputs: the base status color and the
+ * per-variant foreground/stripe chroma (which escalate with status severity).
+ *
+ * NOTE (CSS audit, Batch D): the soft surface is synthesized rather than read
+ * from the `--cinder-color-{status}-{bg,fg,border}` triples in tokens-base.css
+ * because the dark-theme triple background sits ~8 oklch-L points lighter than
+ * the surface here (28% L vs 20% L), exceeding the audit's 0.02 ΔL threshold.
+ * See docs/css-audit/status-triple-equivalence.md for the full table.
  * ---------------------------------------- */
 
   .cinder-callout[data-cinder-variant='info'] {
-    background-color: light-dark(
-      oklch(from var(--cinder-info) 96.5% 0.015 h),
-      oklch(from var(--cinder-info) 20% 0.03 h)
-    );
-    border-color: light-dark(
-      oklch(from var(--cinder-info) 85% 0.05 h),
-      oklch(from var(--cinder-info) 35% 0.08 h)
-    );
-    color: light-dark(
-      oklch(from var(--cinder-info) 35% 0.12 h),
-      oklch(from var(--cinder-info) 88% 0.12 h)
-    );
-    /* Saturated stripe — declared after border-color so the inline-start edge
-   * resolves to this high-chroma rule rather than the soft border above. */
-    border-inline-start-color: light-dark(
-      oklch(from var(--cinder-info) 55% 0.13 h),
-      oklch(from var(--cinder-info) 70% 0.13 h)
-    );
+    --_cinder-status-base: var(--cinder-info);
+    --_cinder-status-fg-chroma-light: 0.12;
+    --_cinder-status-fg-chroma-dark: 0.12;
+    --_cinder-status-stripe-chroma: 0.13;
   }
-
-  /* ----------------------------------------
- * Variant: success
- * ---------------------------------------- */
 
   .cinder-callout[data-cinder-variant='success'] {
-    background-color: light-dark(
-      oklch(from var(--cinder-success) 96.5% 0.015 h),
-      oklch(from var(--cinder-success) 20% 0.03 h)
-    );
-    border-color: light-dark(
-      oklch(from var(--cinder-success) 85% 0.05 h),
-      oklch(from var(--cinder-success) 35% 0.08 h)
-    );
-    color: light-dark(
-      oklch(from var(--cinder-success) 35% 0.14 h),
-      oklch(from var(--cinder-success) 88% 0.12 h)
-    );
-    border-inline-start-color: light-dark(
-      oklch(from var(--cinder-success) 55% 0.14 h),
-      oklch(from var(--cinder-success) 70% 0.14 h)
-    );
+    --_cinder-status-base: var(--cinder-success);
+    --_cinder-status-fg-chroma-light: 0.14;
+    --_cinder-status-fg-chroma-dark: 0.12;
+    --_cinder-status-stripe-chroma: 0.14;
   }
-
-  /* ----------------------------------------
- * Variant: warning
- * ---------------------------------------- */
 
   .cinder-callout[data-cinder-variant='warning'] {
-    background-color: light-dark(
-      oklch(from var(--cinder-warning) 96.5% 0.015 h),
-      oklch(from var(--cinder-warning) 20% 0.03 h)
-    );
-    border-color: light-dark(
-      oklch(from var(--cinder-warning) 85% 0.05 h),
-      oklch(from var(--cinder-warning) 35% 0.08 h)
-    );
-    color: light-dark(
-      oklch(from var(--cinder-warning) 35% 0.16 h),
-      oklch(from var(--cinder-warning) 88% 0.14 h)
-    );
-    border-inline-start-color: light-dark(
-      oklch(from var(--cinder-warning) 55% 0.16 h),
-      oklch(from var(--cinder-warning) 70% 0.16 h)
-    );
+    --_cinder-status-base: var(--cinder-warning);
+    --_cinder-status-fg-chroma-light: 0.16;
+    --_cinder-status-fg-chroma-dark: 0.14;
+    --_cinder-status-stripe-chroma: 0.16;
   }
 
-  /* ----------------------------------------
- * Variant: danger
- * ---------------------------------------- */
-
   .cinder-callout[data-cinder-variant='danger'] {
-    background-color: light-dark(
-      oklch(from var(--cinder-danger) 96.5% 0.015 h),
-      oklch(from var(--cinder-danger) 20% 0.03 h)
-    );
-    border-color: light-dark(
-      oklch(from var(--cinder-danger) 85% 0.05 h),
-      oklch(from var(--cinder-danger) 35% 0.08 h)
-    );
-    color: light-dark(
-      oklch(from var(--cinder-danger) 35% 0.18 h),
-      oklch(from var(--cinder-danger) 88% 0.16 h)
-    );
-    border-inline-start-color: light-dark(
-      oklch(from var(--cinder-danger) 55% 0.18 h),
-      oklch(from var(--cinder-danger) 70% 0.18 h)
-    );
+    --_cinder-status-base: var(--cinder-danger);
+    --_cinder-status-fg-chroma-light: 0.18;
+    --_cinder-status-fg-chroma-dark: 0.16;
+    --_cinder-status-stripe-chroma: 0.18;
   }
 
   /* ----------------------------------------

--- a/packages/components/src/components/callout/callout.css.test.ts
+++ b/packages/components/src/components/callout/callout.css.test.ts
@@ -5,14 +5,15 @@
  * from stylesheets, and the package ships no browser-test harness).
  *
  * The Callout CSS is deliberate and narrow: the base rule sets the box border
- * plus the 4px inline-start stripe width, and each variant rule sets exactly
- * the soft `border-color` and the saturated `border-inline-start-color`. So
- * rather than simulating the full cascade, the tests pin that exact shape — a
- * variant rule may only touch those two border properties (any other
- * border-affecting declaration, shorthand or longhand, fails the test), the
- * stripe color is declared after the soft border so it wins the cascade, both
- * derive from the matching status token, and the stripe's chroma is strictly
- * higher than the soft border's so the stripe reads as "visibly stronger."
+ * plus the 4px inline-start stripe width. The soft `border-color` and saturated
+ * `border-inline-start-color` algebra now lives in the shared
+ * `_status-surface.css` partial, so each variant rule only sets the partial's
+ * per-variant inputs (`--_cinder-status-base` + the foreground/stripe chroma).
+ * The tests pin that split shape: a variant rule may carry NO border-affecting
+ * declaration (any shorthand or longhand fails the test), and the partial
+ * declares the stripe after the soft border so it wins the cascade, both derive
+ * from `--_cinder-status-base`, and the stripe chroma strictly exceeds the
+ * fixed soft-border chroma so the stripe reads as "visibly stronger."
  */
 
 import { readFileSync } from 'node:fs';
@@ -30,12 +31,39 @@ function loadCss(relativePath: string): string {
 const calloutCss = loadCss('./callout.css');
 const root = parse(calloutCss);
 
+// The soft-surface color algebra (border + stripe) now lives in the shared
+// `_status-surface.css` partial, consumed by Callout via the
+// `.cinder-_status-surface*` classes. Callout's variant rules only set the
+// partial's per-variant inputs. The stripe-vs-border acceptance criteria are
+// therefore split: the input wiring is pinned on the variant rules here, and the
+// algebra (stripe declared after border, both derive from --_cinder-status-base,
+// stripe chroma exceeds the fixed soft-border chroma) is pinned on the partial.
+const statusSurfaceCss = loadCss('../../styles/components/_status-surface.css');
+const statusSurfaceRoot = parse(statusSurfaceCss);
+
+function findRuleIn(parsedRoot: ReturnType<typeof parse>, selector: string): Rule {
+  let match: Rule | undefined;
+  parsedRoot.walkRules((rule) => {
+    if (rule.selectors.includes(selector)) {
+      match = rule;
+      return false;
+    }
+    return undefined;
+  });
+  if (!match) throw new Error(`rule not found: ${selector}`);
+  return match;
+}
+
+/** The fixed soft-border chroma in the partial (uniform across variants). */
+const SOFT_BORDER_CHROMA = { light: 0.05, dark: 0.08 };
+
 /**
  * Every property that can paint or size a border edge — shorthands, longhands,
  * physical sides, logical sides, and the `border-image` family (which can draw
  * a directional stripe without touching `border-color`/`border-width` at all).
- * A variant rule is allowed to use only the subset in `ALLOWED_VARIANT_BORDER`;
- * anything else here is an escape hatch the tests must reject.
+ * A variant rule may carry NONE of these; the soft border and stripe colors all
+ * live in the shared partial now, so any border-affecting declaration appearing
+ * on a variant rule is an escape hatch the tests must reject.
  */
 const BORDER_AFFECTING = new Set([
   'border',
@@ -79,14 +107,6 @@ const BORDER_AFFECTING = new Set([
   'border-image-outset',
   'border-image-repeat',
 ]);
-
-/**
- * The only border declarations a Callout variant rule may carry: the soft box
- * border color and the saturated inline-start stripe color. Everything else in
- * BORDER_AFFECTING would either lift a non-start edge to the stripe width, mute
- * the stripe, or paint a competing border-image — all regressions.
- */
-const ALLOWED_VARIANT_BORDER = ['border-color', 'border-inline-start-color'];
 
 /**
  * Find the single non-`@media` rule for a selector. The forced-colors block
@@ -229,51 +249,99 @@ describe('callout stripe — directional treatment', () => {
   });
 
   for (const { variant, token } of VARIANTS) {
-    const tokenPattern = new RegExp(`oklch\\(\\s*from\\s+var\\(${token}\\)`);
-
     describe(`variant: ${variant}`, () => {
       const rule = findRule(`.cinder-callout[data-cinder-variant='${variant}']`);
 
-      test('touches only the soft border-color and the inline-start stripe color', () => {
-        // Rejects every other border escape hatch: a `border`/`border-width`
-        // shorthand or a physical/block longhand that would lift a non-start
-        // edge to 4px, and any `border-image` that would paint a competing
-        // stripe. With only these two, the non-start edges stay at the base
-        // rule's 1px and the stripe stays 4px.
-        expect(borderProps(rule).toSorted()).toEqual(ALLOWED_VARIANT_BORDER);
+      test('carries no border declarations — the algebra lives in the shared partial', () => {
+        // The soft border and stripe colors moved to `_status-surface.css`.
+        // A variant rule must NOT reintroduce any border-affecting declaration
+        // (shorthand or longhand): doing so would lift a non-start edge to 4px,
+        // mute the stripe, or paint a competing border-image — all regressions.
+        expect(borderProps(rule)).toEqual([]);
       });
 
-      test('stripe color is declared after border-color so it wins the cascade', () => {
-        const props = rule.nodes
-          .filter((node): node is Declaration => node.type === 'decl')
-          .map((decl) => decl.prop);
-        expect(props.indexOf('border-inline-start-color')).toBeGreaterThan(
-          props.indexOf('border-color'),
-        );
+      test('sets the status base color to the matching status token', () => {
+        expect(declValue(rule, '--_cinder-status-base')).toBe(`var(${token})`);
       });
 
-      test('stripe color derives from the matching status token in both schemes', () => {
-        const stripe = declValue(rule, 'border-inline-start-color');
-        expect(stripe).toBeDefined();
-        const [light, dark] = lightDarkArms(stripe!);
-        expect(light).toMatch(tokenPattern);
-        expect(dark).toMatch(tokenPattern);
+      test('sets a stripe chroma input that strictly exceeds the fixed soft-border chroma', () => {
+        // "Visibly stronger" is now pinned as: the per-variant stripe chroma
+        // input is greater than the partial's fixed soft-border chroma in both
+        // schemes, so a future edit cannot mute the stripe to the soft chroma.
+        const stripeChroma = Number(declValue(rule, '--_cinder-status-stripe-chroma'));
+        expect(stripeChroma).not.toBeNaN();
+        expect(stripeChroma).toBeGreaterThan(SOFT_BORDER_CHROMA.light);
+        expect(stripeChroma).toBeGreaterThan(SOFT_BORDER_CHROMA.dark);
       });
 
-      test('stripe chroma strictly exceeds the soft border chroma in both schemes', () => {
-        // Pins "visibly stronger": soft border and stripe both use
-        // oklch(from var(--cinder-<status>) L C h); assert C(stripe) > C(soft)
-        // per scheme so a future edit can't mute the stripe to the soft chroma.
-        const soft = declValue(rule, 'border-color');
-        const stripe = declValue(rule, 'border-inline-start-color');
-        expect(soft).toBeDefined();
-        expect(stripe).toBeDefined();
-
-        const [softLight, softDark] = lightDarkArms(soft!);
-        const [stripeLight, stripeDark] = lightDarkArms(stripe!);
-        expect(oklchChroma(stripeLight)).toBeGreaterThan(oklchChroma(softLight));
-        expect(oklchChroma(stripeDark)).toBeGreaterThan(oklchChroma(softDark));
+      test('sets both foreground chroma inputs (light + dark)', () => {
+        expect(Number(declValue(rule, '--_cinder-status-fg-chroma-light'))).not.toBeNaN();
+        expect(Number(declValue(rule, '--_cinder-status-fg-chroma-dark'))).not.toBeNaN();
       });
     });
   }
+
+  describe('shared _status-surface partial — the relocated algebra', () => {
+    // The recipe selectors are self-doubled (`.x.x`) to reach specificity (0,2,0)
+    // — see the partial's header and the specificity test below.
+    const borderRule = findRuleIn(
+      statusSurfaceRoot,
+      '.cinder-_status-surface-border.cinder-_status-surface-border',
+    );
+    const stripeRule = findRuleIn(
+      statusSurfaceRoot,
+      '.cinder-_status-surface-stripe.cinder-_status-surface-stripe',
+    );
+
+    test('recipe selectors are self-doubled for (0,2,0) specificity over the component base', () => {
+      // The component base (`.cinder-callout`, etc.) sets `background`/`border` at
+      // (0,1,0). The recipe must win regardless of import order (sidecar mode loads
+      // the base AFTER the recipe), so each recipe selector doubles its class to
+      // (0,2,0) — matching the pre-extraction variant-selector specificity. A
+      // single-class selector here would regress to a source-order tie.
+      const selectors: string[] = [];
+      statusSurfaceRoot.walkRules((rule) => {
+        for (const selector of rule.selectors) {
+          if (/cinder-_status-surface/.test(selector)) selectors.push(selector);
+        }
+      });
+      expect(selectors.length).toBeGreaterThan(0);
+      for (const selector of selectors) {
+        // Each must repeat its single class (e.g. `.x.x`) — reject a bare `.x`.
+        const match = /^(\.cinder-_status-surface[a-z-]*)\1$/.exec(selector);
+        expect(match, `selector "${selector}" must be self-doubled for (0,2,0)`).not.toBeNull();
+      }
+    });
+
+    test('stripe rule is declared after the border rule so it wins the inline-start edge', () => {
+      // Compare real RULE positions in the parsed AST, not substring offsets in
+      // the source — the selector strings also appear in the header comment, so a
+      // text search could pass even if the actual rules were swapped.
+      const layer = stripeRule.parent;
+      expect(layer).toBe(borderRule.parent);
+      const nodes = (layer as { nodes?: unknown[] }).nodes ?? [];
+      expect(nodes.indexOf(stripeRule)).toBeGreaterThan(nodes.indexOf(borderRule));
+    });
+
+    test('soft border and stripe both derive from --_cinder-status-base', () => {
+      const border = declValue(borderRule, 'border-color');
+      const stripe = declValue(stripeRule, 'border-inline-start-color');
+      expect(border).toBeDefined();
+      expect(stripe).toBeDefined();
+      const basePattern = /oklch\(\s*from\s+var\(--_cinder-status-base\)/;
+      const [bLight, bDark] = lightDarkArms(border!);
+      const [sLight, sDark] = lightDarkArms(stripe!);
+      expect(bLight).toMatch(basePattern);
+      expect(bDark).toMatch(basePattern);
+      expect(sLight).toMatch(basePattern);
+      expect(sDark).toMatch(basePattern);
+    });
+
+    test('soft border uses the fixed soft-border chroma values', () => {
+      const border = declValue(borderRule, 'border-color');
+      const [light, dark] = lightDarkArms(border!);
+      expect(oklchChroma(light)).toBe(SOFT_BORDER_CHROMA.light);
+      expect(oklchChroma(dark)).toBe(SOFT_BORDER_CHROMA.dark);
+    });
+  });
 });

--- a/packages/components/src/components/callout/callout.svelte
+++ b/packages/components/src/components/callout/callout.svelte
@@ -60,7 +60,13 @@
 
 <aside
   {...restWithoutForbidden}
-  class={classNames('cinder-callout', className)}
+  class={classNames(
+    'cinder-callout',
+    'cinder-_status-surface',
+    'cinder-_status-surface-border',
+    'cinder-_status-surface-stripe',
+    className,
+  )}
   data-cinder-variant={variant}
   aria-label={ariaLabel}
 >

--- a/packages/components/src/components/chip/chip.css
+++ b/packages/components/src/components/chip/chip.css
@@ -113,9 +113,16 @@
  * "stick" after tap on touch devices that emulate :hover. */
   @media (hover: hover) {
     button.cinder-chip:hover:not(:disabled) {
+      /* The flat hover overlay is a single neutral black/white tint, declared
+       * once here so its raw value has one home. It is a structural device (a
+       * darken/lighten film over whatever the chip background is), not a
+       * themeable status surface. */
+      /* cinder-allow-raw-color: structural-pattern — neutral hover overlay tint, not a themeable surface */
+      --_cinder-chip-hover-overlay: light-dark(oklch(0% 0 0 / 0.08), oklch(100% 0 0 / 0.1));
+
       background-image: linear-gradient(
-        light-dark(oklch(0% 0 0 / 0.08), oklch(100% 0 0 / 0.1)),
-        light-dark(oklch(0% 0 0 / 0.08), oklch(100% 0 0 / 0.1))
+        var(--_cinder-chip-hover-overlay),
+        var(--_cinder-chip-hover-overlay)
       );
     }
   }

--- a/packages/components/src/styles/components.css
+++ b/packages/components/src/styles/components.css
@@ -132,3 +132,18 @@
  * Imported last to preserve the original source order of the inline rule it
  * replaced (it previously sat after every component import). */
 @import './components/_dismiss-button.css';
+
+/* Shared internal partial — soft status-surface recipe for Alert/Banner/Callout.
+ * The recipe is import-order-independent by design: its classes are self-doubled
+ * (`.x.x`, specificity 0,2,0) so they beat the component base (0,1,0) whether the
+ * partial loads before or after the component CSS — which matters because in
+ * slim/sidecar mode (`cinder/styles` + `cinder/<component>/styles`) the component
+ * base loads AFTER this partial. The stripe-wins-over-border behavior and the
+ * forced-colors reset are both resolved WITHIN the partial (rule order +
+ * specificity there), not by this import's position. The placement here is just
+ * conventional grouping with the other shared partials.
+ * Like every shared partial here (_dismiss-button, _input-frame, …), this is part
+ * of `cinder/styles` only — a per-component sidecar (`cinder/alert/styles`) does
+ * NOT include it; the documented contract requires importing `cinder/styles`
+ * first (enforced by `cinder/styles/guard`). */
+@import './components/_status-surface.css';

--- a/packages/components/src/styles/components/_status-surface.css
+++ b/packages/components/src/styles/components/_status-surface.css
@@ -1,0 +1,108 @@
+/* INTERNAL — soft status-surface recipe shared by Alert, Banner, and Callout.
+ *
+ * These three components paint a "soft surface" for each status variant
+ * (info / success / warning / danger): a tinted background, a soft border, a
+ * status-tinted foreground, and (Callout only) a saturated inline-start stripe.
+ * Before this partial the four `light-dark(oklch(from var(--cinder-{status}) …))`
+ * declarations were duplicated — byte-for-byte between Callout and Banner, and
+ * with a custom-hue indirection in Alert. This file is the single source of that
+ * algebra.
+ *
+ * WHY NOT the `--cinder-color-{status}-{bg,fg,border}` triples in tokens-base?
+ * The dark-theme triple background sits ~8 oklch-L points lighter than the
+ * surface synthesized here (28% vs 20% L), exceeding the 0.02 ΔL audit
+ * threshold. Switching to the triples would shift every soft surface in dark
+ * mode. See docs/css-audit/status-triple-equivalence.md for the full table. This
+ * partial intentionally preserves the synthesized values exactly — reconciling
+ * with the triples is separate, screenshot-gated visual work.
+ *
+ * COMPOSITION — decomposed by emitted responsibility so each component opts into
+ * only what it needs (Alert keeps a neutral border by design; only Callout draws
+ * the stripe):
+ *   - `.cinder-_status-surface`        → background-color + color (bg + fg)
+ *   - `.cinder-_status-surface-border` → border-color (soft border)
+ *   - `.cinder-_status-surface-stripe` → border-inline-start-color (saturated)
+ * Alert composes surface only; Banner composes surface + border; Callout composes
+ * all three.
+ *
+ * INPUTS — each composing element sets these per variant, on the SAME element as
+ * the class (so they resolve with no inheritance distance):
+ *   --_cinder-status-base            the status base color, e.g. var(--cinder-info)
+ *   --_cinder-status-fg-chroma-light foreground chroma in light mode  (info 0.12 → danger 0.18)
+ *   --_cinder-status-fg-chroma-dark  foreground chroma in dark mode   (info 0.12 → danger 0.16)
+ *   --_cinder-status-stripe-chroma   stripe chroma, both modes        (info 0.13 → danger 0.18)
+ * The L values and the bg/border chroma are uniform across variants, so they are
+ * baked into the recipe; only the foreground and stripe chroma escalate per
+ * status severity, so those are inputs.
+ *
+ * Per-component layout stays component-local. The forced-colors reset for the
+ * surface/border/stripe is owned by THIS partial (see the @media block below)
+ * so it is import-order-independent; components keep only their own
+ * forced-colors chrome (focus rings, dismiss-button outlines, etc.).
+ *
+ * SPECIFICITY (0,2,0 via the self-doubled `.x.x` selector): the soft surface
+ * must override the component's base `.cinder-<component>` rule, which sets
+ * `background: var(--cinder-surface)` and `border: 1px solid var(--cinder-border)`
+ * at specificity (0,1,0). Before this extraction the tint lived on the variant
+ * selector `.cinder-<component>[data-cinder-variant='…']` — (0,2,0), which always
+ * won. A single recipe class would be (0,1,0), tying the base and resolving by
+ * SOURCE ORDER. That tie breaks the wrong way in sidecar mode (`cinder/styles`
+ * loads this partial, then `cinder/<component>/styles` loads the base LATER, so
+ * the neutral base would win and flatten the tint). Doubling the class to (0,2,0)
+ * restores the original specificity contract and is import-order-independent.
+ */
+@layer cinder.components {
+  .cinder-_status-surface.cinder-_status-surface {
+    background-color: light-dark(
+      oklch(from var(--_cinder-status-base) 96.5% 0.015 h),
+      oklch(from var(--_cinder-status-base) 20% 0.03 h)
+    );
+    color: light-dark(
+      oklch(from var(--_cinder-status-base) 35% var(--_cinder-status-fg-chroma-light) h),
+      oklch(from var(--_cinder-status-base) 88% var(--_cinder-status-fg-chroma-dark) h)
+    );
+  }
+
+  .cinder-_status-surface-border.cinder-_status-surface-border {
+    border-color: light-dark(
+      oklch(from var(--_cinder-status-base) 85% 0.05 h),
+      oklch(from var(--_cinder-status-base) 35% 0.08 h)
+    );
+  }
+
+  /* Saturated directional stripe (Callout). Declared as its own class so it can
+   * be composed AFTER the soft border, keeping the inline-start edge resolving to
+   * this high-chroma value rather than the soft border-color above. Also (0,2,0). */
+  .cinder-_status-surface-stripe.cinder-_status-surface-stripe {
+    border-inline-start-color: light-dark(
+      oklch(from var(--_cinder-status-base) 55% var(--_cinder-status-stripe-chroma) h),
+      oklch(from var(--_cinder-status-base) 70% var(--_cinder-status-stripe-chroma) h)
+    );
+  }
+
+  /* Forced-colors / high-contrast.
+   *
+   * The recipe owns its own forced-colors reset so the behavior holds regardless
+   * of import order or which stylesheet (aggregate vs slim/sidecar) loaded it.
+   * These overrides carry the same self-doubled (0,2,0) specificity as the normal
+   * rules above and sit later in this file, so they win over the normal recipe in
+   * forced-colors mode. The tinted surface collapses to the system Canvas/
+   * CanvasText pair, and the border + stripe pin to CanvasText — matching what
+   * Alert/Banner/Callout declared inline before the extraction. The stripe's 4px
+   * WIDTH (set by Callout's base rule) survives as the directional cue even though
+   * its color collapses to CanvasText. */
+  @media (forced-colors: active) {
+    .cinder-_status-surface.cinder-_status-surface {
+      background-color: Canvas;
+      color: CanvasText;
+    }
+
+    .cinder-_status-surface-border.cinder-_status-surface-border {
+      border-color: CanvasText;
+    }
+
+    .cinder-_status-surface-stripe.cinder-_status-surface-stripe {
+      border-inline-start-color: CanvasText;
+    }
+  }
+}

--- a/packages/components/src/styles/index.css
+++ b/packages/components/src/styles/index.css
@@ -35,4 +35,5 @@
 @import './components/_floating-surface.css';
 @import './components/_control-item.css';
 @import './components/_input-frame.css';
+@import './components/_status-surface.css';
 @import './utilities.css' layer(cinder.utilities);

--- a/packages/testing/tests/status-surface-recipe.playwright.ts
+++ b/packages/testing/tests/status-surface-recipe.playwright.ts
@@ -1,0 +1,151 @@
+/// <reference lib="dom" />
+/**
+ * Verifies the shared `_status-surface.css` recipe (task 5b849512) renders the
+ * soft status surfaces for Alert, Banner, and Callout correctly in a real
+ * browser — the consolidation moved the `light-dark(oklch(from …))` algebra out
+ * of each component and into a shared partial driven by `--_cinder-status-base`
+ * plus per-variant chroma inputs. These checks confirm the composed recipe
+ * actually paints (not flattened to the neutral surface) and that Callout's
+ * decomposed stripe reads as visibly stronger than its soft border — the
+ * properties the unit tests can only assert against CSS source.
+ *
+ * Markup is injected directly (rather than relying on whichever playground
+ * examples happen to render which variant) so the recipe is exercised
+ * deterministically. The page is loaded first so `cinder/styles` and the
+ * component CSS sidecars are present and `color-scheme` is established.
+ */
+
+import { expect, test, type Page } from '@playwright/test';
+
+/** Load any cinder page so the global styles + component sidecars are applied. */
+async function loadStyledPage(page: Page): Promise<void> {
+  await page.goto('/page/callout', { waitUntil: 'load' });
+}
+
+/**
+ * Inject fixture markup into the page body, replacing any fixture from a prior
+ * call so the helper is safe to reuse on the same page (no duplicate IDs).
+ */
+async function inject(page: Page, html: string): Promise<void> {
+  await page.evaluate((markup) => {
+    document.getElementById('status-surface-fixture')?.remove();
+    const host = document.createElement('div');
+    host.id = 'status-surface-fixture';
+    host.innerHTML = markup;
+    document.body.appendChild(host);
+  }, html);
+}
+
+test.describe('status-surface recipe — composed soft surfaces paint correctly', () => {
+  test('Callout variants get a tinted background distinct from the neutral surface', async ({
+    page,
+  }) => {
+    await loadStyledPage(page);
+    await inject(
+      page,
+      `<aside class="cinder-callout cinder-_status-surface cinder-_status-surface-border cinder-_status-surface-stripe" data-cinder-variant="danger">danger</aside>
+       <aside class="cinder-callout cinder-_status-surface cinder-_status-surface-border cinder-_status-surface-stripe" data-cinder-variant="info">info</aside>`,
+    );
+
+    const dangerBg = await page
+      .locator(".cinder-callout[data-cinder-variant='danger']")
+      .first()
+      .evaluate((node) => getComputedStyle(node).backgroundColor);
+    const infoBg = await page
+      .locator(".cinder-callout[data-cinder-variant='info']")
+      .first()
+      .evaluate((node) => getComputedStyle(node).backgroundColor);
+
+    expect(dangerBg).not.toBe('');
+    expect(dangerBg).not.toBe('rgba(0, 0, 0, 0)');
+    // Distinct status hues must produce distinct backgrounds — proves the
+    // --_cinder-status-base input flows through the shared recipe per variant.
+    expect(dangerBg).not.toBe(infoBg);
+  });
+
+  test('Callout stripe reads stronger than its soft border (decomposed recipe)', async ({
+    page,
+  }) => {
+    await loadStyledPage(page);
+    await inject(
+      page,
+      `<aside class="cinder-callout cinder-_status-surface cinder-_status-surface-border cinder-_status-surface-stripe" data-cinder-variant="danger">danger</aside>`,
+    );
+
+    const { stripe, border } = await page
+      .locator(".cinder-callout[data-cinder-variant='danger']")
+      .first()
+      .evaluate((node) => {
+        const style = getComputedStyle(node);
+        return {
+          stripe: style.borderInlineStartColor,
+          border: style.borderTopColor,
+        };
+      });
+
+    // Both resolve to real colors, and the stripe differs from the soft border —
+    // the stripe class composes after the border class and wins the inline-start
+    // edge with a higher chroma.
+    expect(stripe).not.toBe('');
+    expect(border).not.toBe('');
+    expect(stripe).not.toBe(border);
+  });
+
+  test('Alert keeps a neutral border (P7) — variant does not tint the frame', async ({ page }) => {
+    await loadStyledPage(page);
+    await inject(
+      page,
+      `<div class="cinder-alert cinder-_status-surface" data-cinder-variant="error" role="alert">error</div>
+       <div class="cinder-alert cinder-_status-surface" data-cinder-variant="success" role="alert">success</div>`,
+    );
+
+    const errorBorder = await page
+      .locator(".cinder-alert[data-cinder-variant='error']")
+      .first()
+      .evaluate((node) => getComputedStyle(node).borderTopColor);
+    const successBorder = await page
+      .locator(".cinder-alert[data-cinder-variant='success']")
+      .first()
+      .evaluate((node) => getComputedStyle(node).borderTopColor);
+
+    expect(errorBorder).not.toBe('');
+    // Alert composes the surface only — its border stays the neutral base border,
+    // identical across variants (the variant tint is background + text only).
+    expect(errorBorder).toBe(successBorder);
+  });
+
+  test('forced-colors: the recipe yields to system colors (border/stripe → CanvasText)', async ({
+    browser,
+  }) => {
+    // The recipe is imported after the component CSS, so its own
+    // @media (forced-colors: active) reset must keep the stripe/border pinned to
+    // the system color rather than letting the oklch() value win by source order.
+    const context = await browser.newContext({ forcedColors: 'active' });
+    try {
+      const page = await context.newPage();
+      await loadStyledPage(page);
+      await inject(
+        page,
+        `<aside class="cinder-callout cinder-_status-surface cinder-_status-surface-border cinder-_status-surface-stripe" data-cinder-variant="danger">danger</aside>`,
+      );
+
+      const { stripe, border } = await page
+        .locator(".cinder-callout[data-cinder-variant='danger']")
+        .first()
+        .evaluate((node) => {
+          const style = getComputedStyle(node);
+          return { stripe: style.borderInlineStartColor, border: style.borderTopColor };
+        });
+
+      // In forced-colors mode both resolve to the SAME system color (CanvasText)
+      // — the oklch tint does not leak through. Before the recipe's own
+      // forced-colors reset, the relocated stripe oklch() would have won the
+      // inline-start edge and differed from the border.
+      expect(stripe).not.toBe('');
+      expect(border).not.toBe('');
+      expect(stripe).toBe(border);
+    } finally {
+      await context.close();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Alert, Banner, and Callout each synthesized soft status surfaces (tinted background + border + text + Callout's inline-start stripe) for info/success/warning/danger using **identical** `light-dark(oklch(from var(--cinder-{status}) L C h))` math — byte-for-byte duplicated between Callout and Banner, with a custom-hue indirection in Alert. This extracts that algebra into one shared partial, `src/styles/components/_status-surface.css`, decomposed by emitted responsibility:

- `.cinder-_status-surface` → background + foreground (all three)
- `.cinder-_status-surface-border` → soft border (Banner, Callout)
- `.cinder-_status-surface-stripe` → saturated stripe (Callout only)

Each component composes only what it needs (Alert keeps a neutral border per P7; only Callout draws the stripe) and sets the recipe inputs per variant: `--_cinder-status-base` plus the foreground/stripe chroma that escalate with status severity. **Values are preserved exactly — a pure dedup with zero visual change.**

Also: chip's neutral hover overlay is deduped into a single marked `--_cinder-chip-hover-overlay` custom property (it is a structural darken/lighten film, not a themeable status surface); a stale comment in alert.css claiming `--cinder-info` is undefined is corrected; `status-triple-equivalence.md` documents the consolidation.

raw-color migration debt: **214 → 112**. Badge/Chip already share status styling via the semantic triples; status-dot already consumes status tokens directly — no change needed there.

## Review committee

Pre-reviewed by: frontend-architect, simplicity-engineer
- Codex (gpt-5.4, high reasoning) — 1 round
- All must-fix items addressed:
  1. **Forced-colors cascade** (Codex): the recipe imports after components' `@media (forced-colors: active)` `CanvasText` overrides, so its `oklch()` border/stripe would win by source order and leak the tint in forced-colors mode. Fixed — the recipe now owns its own forced-colors reset (bg→`Canvas`, color/border/stripe→`CanvasText`), verified by a new browser test case.
  2. **Sidecar contract** (frontend-architect, Codex): a standalone `cinder/alert/styles` import lacks the recipe. Confirmed this matches every existing shared partial (`_dismiss-button`, `_input-frame`, …) and the documented, guard-enforced contract requiring `cinder/styles` first; documented inline rather than diverging from the established pattern.
  3. **Inaccurate import-order comment** (frontend-architect): rewritten with the correct source-order + forced-colors rationale.
- simplicity-engineer APPROVED the 3-class decomposition and 4-input surface.

## Test plan

```bash
# Unit tests (callout/alert architecture pins rewritten for the shared partial)
bun run --filter=cinder test -- callout
bun run --filter=cinder test -- alert
bun run --filter=cinder test -- banner
bun run --filter=cinder test -- chip

# Guards (regression-gated; debt dropped, strict passes)
bun run --filter=cinder colors:audit -- --strict
bun run --filter=cinder tokens:audit -- --strict

# Browser parity — proves the recipe paints correctly + yields to forced-colors
cd packages/testing && bun run test:playwright -- status-surface-recipe.playwright.ts
```

Part of themeability task `2f6e14c8` (first per-family migration).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor-only visual parity with explicit specificity, forced-colors handling, and source + browser tests; no auth or data paths touched.
> 
> **Overview**
> This PR **deduplicates** the identical soft status-surface `light-dark(oklch(from …))` math that lived inline in **Alert**, **Banner**, and **Callout** into a single shared partial, `_status-surface.css`, split into composable classes (surface, border, stripe). Components now wire **CSS custom-property inputs** per variant and add the matching classes on their roots in Svelte; **rendered colors are unchanged** (still not using token triples per Batch D).
> 
> **Cascade / a11y:** Recipe selectors are **self-doubled** for `(0,2,0)` so tints win when component CSS loads after the partial (sidecar). The partial owns a **forced-colors** reset so oklch borders do not leak past system colors.
> 
> **Tests & tooling:** Alert/Callout unit tests assert the partial + variant wiring; new Playwright coverage checks computed tints, stripe vs border, Alert neutral border, and forced-colors. `raw-color-baseline.json` moves allowed raw-color counts to the partial; chip hover overlay is a single marked custom property. Audit doc section 7 documents the consolidation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ea51a32244c7d9ed22b6b115cfd40544f68538bd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->