### PR TITLE
refactor(color-domain): classify intrinsic raw colors via cinder-allow-raw-color markers (2f6e14c8)

### DIFF
--- a/packages/components/scripts/raw-color-baseline.json
+++ b/packages/components/scripts/raw-color-baseline.json
@@ -31,33 +31,13 @@
   },
   {
     "filePath": "src/components/color-field/color-field.css",
-    "colorClass": "hex",
-    "allowedCount": 5
-  },
-  {
-    "filePath": "src/components/color-field/color-field.css",
     "colorClass": "rgb",
     "allowedCount": 3
   },
   {
     "filePath": "src/components/color-picker/color-picker.css",
-    "colorClass": "hex",
-    "allowedCount": 14
-  },
-  {
-    "filePath": "src/components/color-picker/color-picker.css",
-    "colorClass": "hsl",
-    "allowedCount": 8
-  },
-  {
-    "filePath": "src/components/color-picker/color-picker.css",
     "colorClass": "rgb",
-    "allowedCount": 3
-  },
-  {
-    "filePath": "src/components/color-swatch-picker/color-swatch-picker.css",
-    "colorClass": "hex",
-    "allowedCount": 5
+    "allowedCount": 1
   },
   {
     "filePath": "src/components/command-menu/command-menu.css",

--- a/packages/components/src/components/color-field/color-field.css
+++ b/packages/components/src/components/color-field/color-field.css
@@ -34,17 +34,21 @@
   }
 
   .cinder-color-field__swatch[data-cinder-alpha]:not([data-cinder-empty]) {
-    /* Checker pattern so partially-transparent swatches remain visible. */
-    background-color: #fff;
+    /* structural-pattern: transparency checkerboard so partially-transparent
+     * swatches stay visible — a fixed light/neutral grid signalling "see-through",
+     * not a themeable surface. Raw values declared once here with markers. */
+    --_cinder-color-field-checker-base: #fff; /* cinder-allow-raw-color: structural-pattern — checkerboard backing */
+    --_cinder-color-field-checker-tile: #ccc; /* cinder-allow-raw-color: structural-pattern — checkerboard tile */
+    background-color: var(--_cinder-color-field-checker-base);
     background-image:
       linear-gradient(
         var(--cinder-color-field-swatch, transparent),
         var(--cinder-color-field-swatch, transparent)
       ),
-      linear-gradient(45deg, #ccc 25%, transparent 25%),
-      linear-gradient(-45deg, #ccc 25%, transparent 25%),
-      linear-gradient(45deg, transparent 75%, #ccc 75%),
-      linear-gradient(-45deg, transparent 75%, #ccc 75%);
+      linear-gradient(45deg, var(--_cinder-color-field-checker-tile) 25%, transparent 25%),
+      linear-gradient(-45deg, var(--_cinder-color-field-checker-tile) 25%, transparent 25%),
+      linear-gradient(45deg, transparent 75%, var(--_cinder-color-field-checker-tile) 75%),
+      linear-gradient(-45deg, transparent 75%, var(--_cinder-color-field-checker-tile) 75%);
     background-size:
       auto,
       6px 6px,

--- a/packages/components/src/components/color-picker/color-picker.css
+++ b/packages/components/src/components/color-picker/color-picker.css
@@ -11,6 +11,13 @@
     gap: var(--cinder-space-2);
     width: 100%;
     max-width: 280px;
+
+    /* structural-pattern: the transparency checkerboard (shown behind alpha
+     * channels by the alpha slider and the preview chip) is a fixed light/neutral
+     * grid that signals "see-through", not a themeable surface. Declared once here
+     * and reused by both checkerboards below so the raw values have a single home. */
+    --_cinder-color-picker-checker-base: #fff; /* cinder-allow-raw-color: structural-pattern — checkerboard backing */
+    --_cinder-color-picker-checker-tile: #ccc; /* cinder-allow-raw-color: structural-pattern — checkerboard tile */
   }
 
   .cinder-color-picker[data-cinder-disabled] {
@@ -25,9 +32,20 @@
     width: 100%;
     aspect-ratio: 4 / 3;
     border-radius: var(--cinder-radius-sm, 4px);
-    background-color: var(--cinder-color-picker-hue, hsl(0, 100%, 50%));
+    /* domain-rendering: the saturation/value square paints the full color space
+     * the user is picking from — its hue fill (fallback) and the black/white
+     * value+saturation axes are intrinsic to the control, not themeable. The raw
+     * values are declared once as custom properties (each with a same-line
+     * marker) so the multi-line gradient value carries no unmarked color. */
+    /* prettier-ignore */
+    --_cinder-color-picker-hue-fill: var(--cinder-color-picker-hue, hsl(0, 100%, 50%)); /* cinder-allow-raw-color: domain-rendering — hue fill fallback */
+    /* prettier-ignore */
+    --_cinder-color-picker-value-axis: linear-gradient(to top, #000, transparent); /* cinder-allow-raw-color: domain-rendering — value (black) axis */
+    /* prettier-ignore */
+    --_cinder-color-picker-saturation-axis: linear-gradient(to right, #fff, transparent); /* cinder-allow-raw-color: domain-rendering — saturation (white) axis */
+    background-color: var(--_cinder-color-picker-hue-fill);
     background-image:
-      linear-gradient(to top, #000, transparent), linear-gradient(to right, #fff, transparent);
+      var(--_cinder-color-picker-value-axis), var(--_cinder-color-picker-saturation-axis);
     touch-action: none;
     cursor: crosshair;
     outline: none;
@@ -42,10 +60,13 @@
     position: absolute;
     width: 14px;
     height: 14px;
-    border: 2px solid #fff;
+    /* structural-pattern: the draggable thumb sits over the user's chosen color,
+     * so its white ring + dark outline are fixed contrast devices (visible on any
+     * hue), not themeable chrome. */
+    border: 2px solid #fff; /* cinder-allow-raw-color: structural-pattern — thumb contrast ring over arbitrary picked color */
     border-radius: 50%;
     transform: translate(-50%, -50%);
-    box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.5);
+    box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.5); /* cinder-allow-raw-color: structural-pattern — thumb dark outline for contrast on light hues */
     pointer-events: none;
   }
 
@@ -61,27 +82,22 @@
   }
 
   .cinder-color-picker__hue {
-    background: linear-gradient(
-      to right,
-      hsl(0, 100%, 50%),
-      hsl(60, 100%, 50%),
-      hsl(120, 100%, 50%),
-      hsl(180, 100%, 50%),
-      hsl(240, 100%, 50%),
-      hsl(300, 100%, 50%),
-      hsl(360, 100%, 50%)
-    );
+    /* domain-rendering: the full-spectrum hue rail IS the control's data — the
+     * user picks a hue along it. Declared on one line so the marker covers every
+     * stop; it is the literal color wheel, never a theme surface. */
+    /* prettier-ignore */
+    --_cinder-color-picker-hue-spectrum: linear-gradient(to right, hsl(0, 100%, 50%), hsl(60, 100%, 50%), hsl(120, 100%, 50%), hsl(180, 100%, 50%), hsl(240, 100%, 50%), hsl(300, 100%, 50%), hsl(360, 100%, 50%)); /* cinder-allow-raw-color: domain-rendering — full hue spectrum rail */
+    background: var(--_cinder-color-picker-hue-spectrum);
   }
 
   .cinder-color-picker__alpha {
-    /* Intentional: literal white backing for the transparency checkerboard, not a theme surface. */
-    background-color: #fff;
+    background-color: var(--_cinder-color-picker-checker-base);
     background-image:
       linear-gradient(to right, transparent, var(--cinder-color-picker-base, currentColor)),
-      linear-gradient(45deg, #ccc 25%, transparent 25%),
-      linear-gradient(-45deg, #ccc 25%, transparent 25%),
-      linear-gradient(45deg, transparent 75%, #ccc 75%),
-      linear-gradient(-45deg, transparent 75%, #ccc 75%);
+      linear-gradient(45deg, var(--_cinder-color-picker-checker-tile) 25%, transparent 25%),
+      linear-gradient(-45deg, var(--_cinder-color-picker-checker-tile) 25%, transparent 25%),
+      linear-gradient(45deg, transparent 75%, var(--_cinder-color-picker-checker-tile) 75%),
+      linear-gradient(-45deg, transparent 75%, var(--_cinder-color-picker-checker-tile) 75%);
     background-size:
       auto,
       8px 8px,
@@ -108,11 +124,14 @@
     top: 50%;
     width: 14px;
     height: 14px;
-    border: 2px solid #fff;
+    /* structural-pattern: slider thumb sits over the hue rail / alpha
+     * checkerboard, so its white ring + dark outline are fixed contrast devices,
+     * not themeable chrome (same rationale as the gradient handle). */
+    border: 2px solid #fff; /* cinder-allow-raw-color: structural-pattern — slider thumb contrast ring */
     border-radius: 50%;
     background: transparent;
     transform: translate(-50%, -50%);
-    box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.5);
+    box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.5); /* cinder-allow-raw-color: structural-pattern — slider thumb dark outline */
     pointer-events: none;
   }
 
@@ -134,17 +153,16 @@
   }
 
   .cinder-color-picker__preview[data-cinder-alpha] {
-    /* Intentional: literal white backing for the transparency checkerboard, not a theme surface. */
-    background-color: #fff;
+    background-color: var(--_cinder-color-picker-checker-base);
     background-image:
       linear-gradient(
         var(--cinder-color-picker-preview, transparent),
         var(--cinder-color-picker-preview, transparent)
       ),
-      linear-gradient(45deg, #ccc 25%, transparent 25%),
-      linear-gradient(-45deg, #ccc 25%, transparent 25%),
-      linear-gradient(45deg, transparent 75%, #ccc 75%),
-      linear-gradient(-45deg, transparent 75%, #ccc 75%);
+      linear-gradient(45deg, var(--_cinder-color-picker-checker-tile) 25%, transparent 25%),
+      linear-gradient(-45deg, var(--_cinder-color-picker-checker-tile) 25%, transparent 25%),
+      linear-gradient(45deg, transparent 75%, var(--_cinder-color-picker-checker-tile) 75%),
+      linear-gradient(-45deg, transparent 75%, var(--_cinder-color-picker-checker-tile) 75%);
     background-size:
       auto,
       8px 8px,

--- a/packages/components/src/components/color-swatch-picker/color-swatch-picker.css
+++ b/packages/components/src/components/color-swatch-picker/color-swatch-picker.css
@@ -69,14 +69,18 @@
   /* ── Alpha checkerboard — color layer on top, checkerboard beneath ──────── */
 
   .cinder-color-swatch-picker__swatch[data-cinder-alpha] {
-    /* Intentional: literal white backing for the transparency checkerboard, not a theme surface. */
-    background-color: #fff;
+    /* structural-pattern: transparency checkerboard beneath the color layer — a
+     * fixed light/neutral grid signalling "see-through", not a themeable surface.
+     * Raw values declared once here with markers. */
+    --_cinder-color-swatch-picker-checker-base: #fff; /* cinder-allow-raw-color: structural-pattern — checkerboard backing */
+    --_cinder-color-swatch-picker-checker-tile: #ccc; /* cinder-allow-raw-color: structural-pattern — checkerboard tile */
+    background-color: var(--_cinder-color-swatch-picker-checker-base);
     background-image:
       linear-gradient(var(--swatch-color), var(--swatch-color)),
-      linear-gradient(45deg, #ccc 25%, transparent 25%),
-      linear-gradient(-45deg, #ccc 25%, transparent 25%),
-      linear-gradient(45deg, transparent 75%, #ccc 75%),
-      linear-gradient(-45deg, transparent 75%, #ccc 75%);
+      linear-gradient(45deg, var(--_cinder-color-swatch-picker-checker-tile) 25%, transparent 25%),
+      linear-gradient(-45deg, var(--_cinder-color-swatch-picker-checker-tile) 25%, transparent 25%),
+      linear-gradient(45deg, transparent 75%, var(--_cinder-color-swatch-picker-checker-tile) 75%),
+      linear-gradient(-45deg, transparent 75%, var(--_cinder-color-swatch-picker-checker-tile) 75%);
     background-size:
       auto,
       8px 8px,


### PR DESCRIPTION
## Summary

The color picker / field / swatch-picker paint colors that are **intrinsic to the control**, not themeable surfaces:
- the **hue spectrum** rail and the **saturation/value square** (the color space the user picks from) → `domain-rendering`
- the draggable **thumb contrast rings** (white border + dark outline, must stay visible over any picked color) → `structural-pattern`
- the **transparency checkerboards** behind alpha channels (`#fff`/`#ccc` grid) → `structural-pattern`

These are now annotated with inline `/* cinder-allow-raw-color: <reason> */` markers so the raw-color audit guard classifies them correctly instead of counting them as migration debt. **Values are unchanged** — relocated into `--_cinder-*` custom properties (referenced via `var()`); rendering is byte-identical (verified: all component tests pass, Codex confirmed computed-value-time substitution equivalence).

Implementation notes:
- Multi-line gradient values are extracted to single-line `--_cinder-*` properties with `/* prettier-ignore */` so the formatter can't re-wrap them and break same-line marker coverage.
- Duplicated checkerboard colors are deduped into shared per-component `--_cinder-*-checker-{base,tile}` properties.

**Honest scope** — these stay tracked as migration debt (token-able fallbacks, NOT marked intentional): `toggle.css`'s hardcoded `var()` fallbacks (`#6366f1` accent, grays, `rgb` shadow fallbacks) and the `var(--cinder-border, rgba(...))` border fallbacks. Those want real tokens, not an allow-marker; `toggle.css` is left untouched.

raw-color migration debt: **112 → 78** (34 intrinsic sites classified). Touches only per-component CSS — no shared style aggregators.

## Review committee

Pre-reviewed by: ux-designer, simplicity-engineer
- Codex (gpt-5.4, high reasoning) — APPROVED (render-equivalence + classification honesty confirmed)
- ux-designer raised promoting the checkerboard to **public** dark-mode tokens; simplicity-engineer (tie-breaker) ruled that scope creep for a classify+dedup PR with no dark theme yet to test against. Filed as follow-up task `5ff4b43f` (dark-mode checkerboard + thumb-shadow theming). This PR ships values-unchanged.

## Test plan

```bash
bun run --filter=cinder test -- color-picker color-field color-swatch-picker
bun run --filter=cinder colors:audit            # report: 78 debt, 10 domain-rendering, 13 structural-pattern
bun run --filter=cinder colors:audit -- --strict # gate passes at the new baseline
```

Part of themeability task `2f6e14c8` (collision-safe per-component slice).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CSS-only refactor with equivalent computed values; scope is color UI styling and audit baselines, not auth, data, or APIs.
> 
> **Overview**
> Classifies **intrinsic** raw colors in `color-field`, `color-picker`, and `color-swatch-picker` CSS so the raw-color audit treats them as intentional (`domain-rendering` / `structural-pattern`) instead of migration debt. **Rendered colors are unchanged**: literals move into private `--_cinder-*` custom properties and are consumed via `var()`, with same-line `/* cinder-allow-raw-color: … */` markers (including `prettier-ignore` on single-line gradient vars for marker coverage).
> 
> **Hue/saturation/value UI** (spectrum rail, SV square axes, hue fill fallback) is tagged as domain-rendering; **checkerboards** and **thumb contrast rings** are tagged as structural-pattern, with shared checker `base`/`tile` vars deduped per component. **`raw-color-baseline.json`** drops hex/hsl allowance rows for those files and tightens remaining rgb counts to match the new classification.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 06239d42c2a97106c65d8405fdc3b4b859843edd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->