### PR TITLE
refactor(shadows): drop dead raw-color fallbacks from existing shadow-token refs (2f6e14c8)

### DIFF
--- a/packages/components/scripts/raw-color-baseline.json
+++ b/packages/components/scripts/raw-color-baseline.json
@@ -45,11 +45,6 @@
     "allowedCount": 1
   },
   {
-    "filePath": "src/components/dropdown/dropdown.css",
-    "colorClass": "rgb",
-    "allowedCount": 1
-  },
-  {
     "filePath": "src/components/input/input.css",
     "colorClass": "oklch",
     "allowedCount": 2
@@ -85,28 +80,13 @@
     "allowedCount": 1
   },
   {
-    "filePath": "src/components/segmented-control/segmented-control.css",
-    "colorClass": "rgb",
-    "allowedCount": 2
-  },
-  {
     "filePath": "src/components/select/select.css",
     "colorClass": "oklch",
     "allowedCount": 1
   },
   {
-    "filePath": "src/components/selection-popover/selection-popover.css",
-    "colorClass": "rgb",
-    "allowedCount": 3
-  },
-  {
     "filePath": "src/components/skeleton/skeleton.css",
     "colorClass": "oklch",
-    "allowedCount": 1
-  },
-  {
-    "filePath": "src/components/slider/slider.css",
-    "colorClass": "rgb",
     "allowedCount": 1
   },
   {
@@ -117,11 +97,6 @@
   {
     "filePath": "src/components/spinner/spinner.css",
     "colorClass": "hex",
-    "allowedCount": 1
-  },
-  {
-    "filePath": "src/components/stat-group/stat-group.css",
-    "colorClass": "rgb",
     "allowedCount": 1
   },
   {

--- a/packages/components/src/components/dropdown/dropdown.css
+++ b/packages/components/src/components/dropdown/dropdown.css
@@ -92,7 +92,7 @@
     border-radius: var(--cinder-radius-md);
     background: var(--cinder-surface-raised);
     color: var(--cinder-text);
-    box-shadow: var(--cinder-shadow-lg, 0 10px 15px rgb(0 0 0 / 0.15));
+    box-shadow: var(--cinder-shadow-lg);
   }
 
   .cinder-dropdown__menu {

--- a/packages/components/src/components/segmented-control/segmented-control.css
+++ b/packages/components/src/components/segmented-control/segmented-control.css
@@ -245,7 +245,7 @@
   .cinder-segmented-control-option[data-cinder-selected] {
     background: var(--cinder-accent);
     color: var(--cinder-accent-contrast);
-    box-shadow: var(--cinder-shadow-sm, 0 1px 2px rgb(0 0 0 / 0.1));
+    box-shadow: var(--cinder-shadow-sm);
   }
 
   .cinder-segmented-control-option-icon {
@@ -257,7 +257,7 @@
   .cinder-segmented-control-option[data-cinder-pressed] {
     background: var(--cinder-accent);
     color: var(--cinder-accent-contrast);
-    box-shadow: var(--cinder-shadow-sm, 0 1px 2px rgb(0 0 0 / 0.1));
+    box-shadow: var(--cinder-shadow-sm);
   }
 
   /* ── Tablist variant (single mode only) ─────────────────────────────────────

--- a/packages/components/src/components/selection-popover/selection-popover.css
+++ b/packages/components/src/components/selection-popover/selection-popover.css
@@ -29,7 +29,7 @@
     cursor: pointer;
     font-size: var(--cinder-text-xs);
     font-weight: var(--cinder-font-medium);
-    box-shadow: var(--cinder-shadow-md, 0 4px 6px rgb(0 0 0 / 0.12));
+    box-shadow: var(--cinder-shadow-md);
     transition:
       background-color var(--cinder-duration-fast) var(--cinder-ease-standard),
       transform var(--cinder-duration-fast) var(--cinder-ease-standard);
@@ -44,8 +44,7 @@
   .cinder-selection-popover__button:focus-visible {
     outline: var(--cinder-ring-width) solid transparent;
     outline-offset: var(--cinder-ring-offset);
-    box-shadow:
-      var(--_cinder-focus-ring-shadow), var(--cinder-shadow-md, 0 4px 6px rgb(0 0 0 / 0.12));
+    box-shadow: var(--_cinder-focus-ring-shadow), var(--cinder-shadow-md);
   }
 
   @media (forced-colors: active) {
@@ -68,7 +67,7 @@
     border: 1px solid var(--cinder-border);
     border-radius: var(--cinder-radius-md);
     background: var(--cinder-surface-raised);
-    box-shadow: var(--cinder-shadow-lg, 0 10px 15px rgb(0 0 0 / 0.15));
+    box-shadow: var(--cinder-shadow-lg);
   }
 
   .cinder-selection-popover__textarea {

--- a/packages/components/src/components/slider/slider.css
+++ b/packages/components/src/components/slider/slider.css
@@ -82,7 +82,7 @@
     border-radius: var(--cinder-radius-full);
     transform: translate(-50%, -50%);
     cursor: grab;
-    box-shadow: var(--cinder-shadow-sm, 0 1px 2px rgba(0, 0, 0, 0.1));
+    box-shadow: var(--cinder-shadow-sm);
     /* Touch-action is set on the track for the same reason; explicitly setting
    * it on the thumb prevents older Chromium-on-Android from intercepting the
    * gesture for scrolling when pointerdown lands directly on the thumb. */

--- a/packages/components/src/components/stat-group/stat-group.css
+++ b/packages/components/src/components/stat-group/stat-group.css
@@ -53,7 +53,7 @@
     background: var(--cinder-surface-raised);
     border: 1px solid var(--cinder-border);
     border-radius: var(--cinder-radius-md, 0.5rem);
-    box-shadow: var(--cinder-shadow-sm, 0 1px 2px rgba(0, 0, 0, 0.05));
+    box-shadow: var(--cinder-shadow-sm);
   }
 
   /*


### PR DESCRIPTION
## Summary

Five components referenced `--cinder-shadow-{sm,md,lg}` with a raw `rgb()`/`rgba()` fallback, e.g.:

```css
box-shadow: var(--cinder-shadow-sm, 0 1px 2px rgb(0 0 0 / 0.1));
```

Those tokens **are** declared in `tokens-base.css` and always load via `cinder/styles`, so the fallback is dead in supported usage — and it is **categorically wrong in dark mode**, because the shadow tokens are `light-dark(oklch(...))` while the fallback is a fixed light-mode black. A partial base-load would render a light-only shadow on a dark surface (worse than no shadow). Removing the fallbacks makes every shadow track the themeable token.

```css
box-shadow: var(--cinder-shadow-sm);
```

Files: `segmented-control`, `slider`, `stat-group`, `dropdown`, `selection-popover` (the two-shadow focus composition in selection-popover is preserved). Skipped `command-menu` — owned by the concurrent compound-imports task.

**Left untouched (separate debt):** refs to *missing* shadow tokens (`--cinder-shadow-elevated`, `--cinder-shadow-xs` → stale-token reconciliation) and toggle's hardcoded `var()` fallbacks.

raw-color migration debt: **78 → 70**. Per-component CSS only; no shared aggregators.

## Review committee

Pre-reviewed by: frontend-architect, simplicity-engineer — both APPROVED.
- Codex (gpt-5.4, high) — APPROVED (verified each hunk removed only the fallback; composition survived; baseline delta consistent)
- Design pre-vetted with codex-advisor before implementation.

## Test plan

```bash
bun run --filter=cinder test -- segmented-control slider stat-group dropdown selection-popover
bun run --filter=cinder colors:audit -- --strict   # passes at the new baseline (70)
```

Part of themeability task `2f6e14c8` (collision-safe per-component slice).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Visual-only CSS cleanup on established shadow tokens; no logic, API, or security surface changes.
> 
> **Overview**
> Removes **dead `rgb()`/`rgba()` fallbacks** from `box-shadow` declarations that already reference `--cinder-shadow-sm`, `--cinder-shadow-md`, and `--cinder-shadow-lg` in **dropdown**, **segmented-control**, **selection-popover**, **slider**, and **stat-group** CSS. Usages now rely on the theme tokens only (e.g. `var(--cinder-shadow-sm)`), so shadows follow **light/dark** instead of a fixed light-mode black if a fallback ever applied.
> 
> **`raw-color-baseline.json`** drops the corresponding per-file `rgb` allowances for those components, in line with the stricter raw-color audit.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 555400df42280c64e0cff2f5984c50360415e301. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->