### PR TITLE
refactor(themeability): drop dead raw-color fallbacks behind existing tokens, batch 2 (2f6e14c8)

### DIFF
--- a/packages/components/scripts/raw-color-baseline.json
+++ b/packages/components/scripts/raw-color-baseline.json
@@ -30,16 +30,6 @@
     "allowedCount": 2
   },
   {
-    "filePath": "src/components/color-field/color-field.css",
-    "colorClass": "rgb",
-    "allowedCount": 3
-  },
-  {
-    "filePath": "src/components/color-picker/color-picker.css",
-    "colorClass": "rgb",
-    "allowedCount": 1
-  },
-  {
     "filePath": "src/components/command-menu/command-menu.css",
     "colorClass": "rgb",
     "allowedCount": 1
@@ -70,11 +60,6 @@
     "allowedCount": 2
   },
   {
-    "filePath": "src/components/pagination/pagination.css",
-    "colorClass": "hex",
-    "allowedCount": 1
-  },
-  {
     "filePath": "src/components/rating/rating.css",
     "colorClass": "oklch",
     "allowedCount": 1
@@ -92,7 +77,7 @@
   {
     "filePath": "src/components/sortable-list/sortable-list.css",
     "colorClass": "rgb",
-    "allowedCount": 4
+    "allowedCount": 3
   },
   {
     "filePath": "src/components/spinner/spinner.css",
@@ -112,12 +97,7 @@
   {
     "filePath": "src/components/toggle/toggle.css",
     "colorClass": "hex",
-    "allowedCount": 7
-  },
-  {
-    "filePath": "src/components/toggle/toggle.css",
-    "colorClass": "rgb",
-    "allowedCount": 2
+    "allowedCount": 1
   },
   {
     "filePath": "src/styles/components/_status-surface.css",

--- a/packages/components/src/components/color-field/color-field.css
+++ b/packages/components/src/components/color-field/color-field.css
@@ -13,7 +13,7 @@
     height: 18px;
     border-radius: var(--cinder-radius-sm, 4px);
     background-color: var(--cinder-color-field-swatch, transparent);
-    border: 1px solid var(--cinder-border, rgba(0, 0, 0, 0.12));
+    border: 1px solid var(--cinder-border);
     vertical-align: middle;
   }
 
@@ -25,8 +25,8 @@
       135deg,
       transparent 0%,
       transparent 45%,
-      var(--cinder-border, rgba(0, 0, 0, 0.35)) 45%,
-      var(--cinder-border, rgba(0, 0, 0, 0.35)) 55%,
+      var(--cinder-border) 45%,
+      var(--cinder-border) 55%,
       transparent 55%,
       transparent 100%
     );

--- a/packages/components/src/components/color-picker/color-picker.css
+++ b/packages/components/src/components/color-picker/color-picker.css
@@ -149,7 +149,7 @@
     height: 24px;
     border-radius: 50%;
     background-color: var(--cinder-color-picker-preview, transparent);
-    border: 1px solid var(--cinder-border, rgba(0, 0, 0, 0.1));
+    border: 1px solid var(--cinder-border);
   }
 
   .cinder-color-picker__preview[data-cinder-alpha] {

--- a/packages/components/src/components/pagination/pagination.css
+++ b/packages/components/src/components/pagination/pagination.css
@@ -110,7 +110,7 @@
   .cinder-pagination__page[data-cinder-current] {
     background: var(--cinder-accent);
     border-color: var(--cinder-accent);
-    color: var(--cinder-accent-contrast, #fff);
+    color: var(--cinder-accent-contrast);
     cursor: default;
   }
 

--- a/packages/components/src/components/sortable-list/sortable-list.css
+++ b/packages/components/src/components/sortable-list/sortable-list.css
@@ -36,7 +36,7 @@
    */
   .cinder-sortable-item--placeholder {
     opacity: 0.4;
-    outline: 2px dashed var(--cinder-border-muted, rgb(0 0 0 / 0.15));
+    outline: 2px dashed var(--cinder-border-muted);
     outline-offset: -1px;
     border-radius: var(--cinder-radius-md, 4px);
     box-shadow: none;
@@ -82,9 +82,24 @@
   }
 
   .cinder-sortable-handle:focus-visible {
-    outline: var(--cinder-ring-width) solid var(--cinder-ring-color);
-    outline-offset: 2px;
+    /* Focus-ring policy (docs/focus-ring-policy.md): a transparent outline (for
+     * forced-colors / Windows High Contrast, replaced below) paired with the
+     * shared box-shadow ring, rather than a colored outline. The normal-mode gap
+     * is the shared `--cinder-ring-offset` baked into the box-shadow recipe — no
+     * explicit `outline-offset` here, matching every other migrated component;
+     * the old colored outline's hardcoded 2px offset is intentionally dropped.
+     * The 2px outline-offset is only meaningful in the forced-colors block below,
+     * where the real outline becomes visible. */
+    outline: var(--cinder-ring-width) solid transparent;
     border-radius: 2px;
+    box-shadow: var(--_cinder-focus-ring-shadow);
+  }
+
+  @media (forced-colors: active) {
+    .cinder-sortable-handle:focus-visible {
+      outline: var(--cinder-ring-width) solid ButtonText;
+      outline-offset: 2px;
+    }
   }
 
   .cinder-sortable-handle[aria-pressed='true'] {

--- a/packages/components/src/components/toggle/toggle.css
+++ b/packages/components/src/components/toggle/toggle.css
@@ -63,7 +63,7 @@
     vertical-align: middle;
 
     /* Track background — unset (off) state. */
-    background: var(--cinder-toggle-track-off, var(--cinder-border-muted, #d1d5db));
+    background: var(--cinder-toggle-track-off, var(--cinder-border-muted));
 
     transition:
       background-color var(--cinder-duration-fast, 150ms) var(--cinder-ease-standard, ease),
@@ -75,7 +75,7 @@
  * ---------------------------------------- */
 
   .cinder-toggle[data-cinder-checked] {
-    background: var(--cinder-toggle-track-on, var(--cinder-accent, #6366f1));
+    background: var(--cinder-toggle-track-on, var(--cinder-accent));
   }
 
   /* ----------------------------------------
@@ -85,10 +85,9 @@
   .cinder-toggle:focus-visible {
     outline: var(--cinder-ring-width, 2px) solid transparent;
     box-shadow:
-      0 0 0 var(--cinder-ring-offset, 2px)
-        var(--cinder-ring-offset-color, var(--cinder-surface, #fff)),
+      0 0 0 var(--cinder-ring-offset, 2px) var(--cinder-ring-offset-color, var(--cinder-surface)),
       0 0 0 calc(var(--cinder-ring-offset, 2px) + var(--cinder-ring-width, 2px))
-        var(--cinder-toggle-ring, var(--cinder-ring-color, #6366f1));
+        var(--cinder-toggle-ring, var(--cinder-ring-color));
   }
 
   /* Forced Colors Mode: box-shadow is suppressed by Windows High Contrast Mode, so
@@ -107,11 +106,11 @@
 
   @media (hover: hover) {
     .cinder-toggle:hover:not(:disabled) {
-      background: var(--cinder-toggle-track-off-hover, var(--cinder-border, #9ca3af));
+      background: var(--cinder-toggle-track-off-hover, var(--cinder-border));
     }
 
     .cinder-toggle[data-cinder-checked]:hover:not(:disabled) {
-      background: var(--cinder-toggle-track-on-hover, var(--cinder-accent-hover, #4f46e5));
+      background: var(--cinder-toggle-track-on-hover, var(--cinder-accent-hover));
     }
   }
 
@@ -146,11 +145,7 @@
     height: var(--cinder-toggle-thumb-size, 1.125rem);
     border-radius: 50%;
     background: var(--cinder-toggle-thumb-color, #ffffff);
-    box-shadow: var(
-      --cinder-shadow-sm,
-      0 1px 3px 0 rgb(0 0 0 / 0.1),
-      0 1px 2px -1px rgb(0 0 0 / 0.1)
-    );
+    box-shadow: var(--cinder-shadow-sm);
 
     /* Slide transition — mirrors the track transition duration. */
     transition: transform var(--cinder-duration-fast, 150ms) var(--cinder-ease-standard, ease);


### PR DESCRIPTION
## Summary

Continues the dead-fallback cleanup from #249. Removes raw-color fallbacks that never fire in supported usage (the referenced token is declared in `tokens-base.css` and always loads via `cinder/styles`) and are wrong in dark mode (the tokens are `light-dark(oklch(...))` while the fallbacks are fixed light-mode colors):

- **toggle.css** (8): six two-level chains `var(--cinder-toggle-X, var(--cinder-<global>, #hex))` (globals: accent/-hover, border/-muted, ring-color, surface) — drop the dead `#hex`; plus the thumb `var(--cinder-shadow-sm, <rgb>)` → `var(--cinder-shadow-sm)`.
- **color-field** (3), **color-picker** (1): `var(--cinder-border, rgba(...))` → `var(--cinder-border)`.
- **sortable-list** (1), **pagination** (2): `var(--cinder-border-muted, rgb(...))` and `var(--cinder-accent-contrast, #fff)` → token-only.

Also fixes a pre-existing stylelint warning in `sortable-list.css` (a file touched here): the sortable-handle `:focus-visible` used a colored outline; switched to the documented transparent-outline + `box-shadow: var(--_cinder-focus-ring-shadow)` recipe with a forced-colors `ButtonText` fallback (`docs/focus-ring-policy.md`). The normal-mode gap is now the shared `--cinder-ring-offset` (matching every other migrated component) — documented in the rule.

**Left as tracked debt:** `var(--cinder-toggle-thumb-color, #ffffff)` — the `#ffffff` is the default of a public component override variable; whether the thumb should track a surface token is a deliberate follow-up.

raw-color migration debt: **70 → 56**. Per-component CSS only; no shared aggregators.

## Review committee

Pre-reviewed by: frontend-architect, simplicity-engineer — both APPROVED.
- Codex (gpt-5.4, high) — APPROVED.
- frontend-architect's one confirm-or-document (the focus-ring normal-mode spacing) was resolved by documenting the deliberate 1px-gap decision; Codex confirmed it's not a visible regression (the normal-mode indicator is the box-shadow ring).

## Test plan

```bash
bun run --filter=cinder test -- toggle color-field color-picker sortable-list pagination
bun run --filter=cinder colors:audit -- --strict    # passes at the new baseline (56)
```

Part of themeability task `2f6e14c8`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CSS-only token cleanup and a localized focus-ring alignment; no runtime logic, auth, or data paths change.
> 
> **Overview**
> Continues themeability cleanup by **removing unused raw-color `var()` fallbacks** where the referenced design tokens are always provided (e.g. `--cinder-border`, `--cinder-accent`, `--cinder-shadow-sm`). Affected styles live in **`toggle`**, **`color-field`**, **`color-picker`**, **`pagination`**, and **`sortable-list`**.
> 
> The **raw-color audit baseline** (`raw-color-baseline.json`) is updated accordingly (overall debt **70 → 56** allowed raw usages). **`var(--cinder-toggle-thumb-color, #ffffff)`** is intentionally left as tracked debt.
> 
> **`sortable-list`** also aligns the drag-handle **`:focus-visible`** ring with the shared transparent-outline + `var(--_cinder-focus-ring-shadow)` pattern and adds a **forced-colors** outline fallback.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 344dd7daa2f09ba933c29de2c0ee405c39af6db7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->