### PR TITLE
fix(ci): scope job must not emit compose-only leaf slugs

### DIFF
--- a/packages/components/scripts/component-graph.test.ts
+++ b/packages/components/scripts/component-graph.test.ts
@@ -508,7 +508,7 @@ describe('computeScope', () => {
       }),
     );
     expect(decision.mode).toBe('full');
-    expect((decision as { reason: string }).reason).toContain('reaches no component');
+    expect((decision as { reason: string }).reason).toContain('reaches no standalone component');
   });
 
   it('keeps filtered when a shared seed DOES reach a component', () => {

--- a/packages/components/scripts/component-graph.ts
+++ b/packages/components/scripts/component-graph.ts
@@ -513,6 +513,16 @@ export type ComputeScopeOptions = {
   readonly sourceFiles: ReadonlyMap<string, string>;
   /** Known component slugs (directories with a `<slug>.svelte`). */
   readonly knownSlugs: ReadonlySet<string>;
+  /**
+   * Compose-only component slugs — leaf components rendered only via a parent
+   * namespace (e.g. `feed-event` inside `feed`), with NO standalone playground
+   * page. They are part of the filesystem `knownSlugs` but NOT part of the
+   * Playwright runner's manifest vocabulary, so they must never be EMITTED as a
+   * test slug — emitting one makes the runner throw `unknown component slug`.
+   * They may still SEED the dependents closure (a change to `feed-event` retests
+   * `feed`, which imports it). Defaults to empty for backwards compatibility.
+   */
+  readonly composeOnlySlugs?: ReadonlySet<string>;
 };
 
 /**
@@ -533,7 +543,13 @@ export type ComputeScopeOptions = {
  * files, mapped to slugs.
  */
 export function computeScope(options: ComputeScopeOptions): ScopeDecision {
-  const { changedFiles, deletedFiles = [], sourceFiles, knownSlugs } = options;
+  const {
+    changedFiles,
+    deletedFiles = [],
+    sourceFiles,
+    knownSlugs,
+    composeOnlySlugs = new Set<string>(),
+  } = options;
 
   // 1. Path-based force-full.
   for (const path of changedFiles) {
@@ -592,13 +608,29 @@ export function computeScope(options: ComputeScopeOptions): ScopeDecision {
   // one component slug in the closure — otherwise its change is invisible to the
   // scoped run and we must force full. See the per-seed reachability check below.
   const sharedSeeds: string[] = [];
+  // Compose-only seeds (leaf components like `feed-event` with no standalone
+  // page). Like shared seeds, each must prove it reaches a real (non-compose)
+  // component slug through the closure — otherwise its change would be silently
+  // untested. They never contribute a DIRECT slug (the runner can't test them).
+  // Tracked by SLUG (not the changed file path): a compose-only change is often a
+  // sidecar (`<slug>.test.ts`, `<slug>.css`) that is NOT a graph node, so seeding
+  // the reachability closure from the literal path would be empty and force full.
+  // The reachability check below seeds from the slug's canonical `<slug>.svelte`
+  // entry instead, which IS a graph node.
+  const composeOnlySeedSlugs = new Set<string>();
   for (const file of changedFiles) {
     if (isIgnorableFile(file)) continue; // docs/markdown/etc. cannot affect tests
     const slug = slugForFile(file);
     if (slug !== null) {
       // A component-tree file (e.g. test/CSS sidecar) — a slug whether or not it
-      // is in the graph. Seed the closure AND record the slug directly.
-      directSlugs.add(slug);
+      // is in the graph. Seed the closure; record the slug directly UNLESS it is
+      // compose-only (no standalone page), in which case only the closure may map
+      // it to a testable parent slug.
+      if (composeOnlySlugs.has(slug)) {
+        composeOnlySeedSlugs.add(slug);
+      } else {
+        directSlugs.add(slug);
+      }
       if (sourceFiles.has(file)) closureSeeds.push(file);
       continue;
     }
@@ -618,6 +650,35 @@ export function computeScope(options: ComputeScopeOptions): ScopeDecision {
     return { mode: 'full', reason: `unaccounted changed file: ${file}` };
   }
 
+  // Compose-only leaves contribute through their CANONICAL `<slug>/<slug>.svelte`
+  // entry, not the literal changed path: the change is often a sidecar
+  // (`<slug>.test.ts`, `<slug>.css`) that is not a graph node, so seeding from
+  // the path would find no dependents and wrongly force full. Seed from the
+  // entry (a graph node) so the leaf's real parent is reached and emitted. A
+  // leaf whose entry is absent from the graph, or whose closure reaches no real
+  // standalone component (orphan), is uncertain → force full, matching the
+  // shared-seed guard below.
+  for (const slug of composeOnlySeedSlugs) {
+    const entry = `${COMPONENTS_PREFIX}${slug}/${slug}.svelte`;
+    const seedClosure = sourceFiles.has(entry)
+      ? dependentsClosure(graph, [entry])
+      : new Set<string>();
+    const reachesRealComponent = [...seedClosure].some((file) => {
+      const reachedSlug = slugForFile(file);
+      return (
+        reachedSlug !== null && knownSlugs.has(reachedSlug) && !composeOnlySlugs.has(reachedSlug)
+      );
+    });
+    if (!reachesRealComponent) {
+      return {
+        mode: 'full',
+        reason: `compose-only change reaches no standalone component (can't map to a testable slug): ${slug}`,
+      };
+    }
+    // Seed the main closure from the entry so the reached parent slug is emitted.
+    closureSeeds.push(entry);
+  }
+
   // 4. Dependents closure → slugs. (Ambiguity is already handled globally in
   //    step 3, so the closure here is built from a fully-modelled graph.)
   const closure = dependentsClosure(graph, closureSeeds);
@@ -625,25 +686,32 @@ export function computeScope(options: ComputeScopeOptions): ScopeDecision {
   const slugs = new Set<string>(directSlugs);
   for (const file of closure) {
     const slug = slugForFile(file);
-    if (slug !== null) slugs.add(slug);
+    // Compose-only slugs are never emitted (the runner has no page for them);
+    // the closure exists to map them to their real parent, which is added here
+    // like any other dependent.
+    if (slug !== null && !composeOnlySlugs.has(slug)) slugs.add(slug);
   }
 
   // Per-seed reachability guard. A shared/sibling-package seed whose OWN
-  // dependents closure reaches no component slug (e.g. `packages/markdown/src/x`
-  // consumed only via bare `cinder/markdown/...` specifiers, which resolve as
-  // external → no graph edge) would otherwise be silently dropped when a
-  // CO-CHANGED component supplies a slug and flips the decision to `filtered`.
-  // Force full if any shared seed cannot be proven to reach a component.
+  // dependents closure reaches no EMITTABLE component slug (e.g.
+  // `packages/markdown/src/x` consumed only via bare `cinder/markdown/...`
+  // specifiers, which resolve as external → no graph edge) would otherwise be
+  // silently dropped when a CO-CHANGED component supplies a slug and flips the
+  // decision to `filtered`. The reached slug must be a REAL (non-compose-only)
+  // known slug: compose-only slugs are never emitted, so a seed that reaches only
+  // compose-only leaves (e.g. an orphaned leaf with no standalone parent) has no
+  // testable slug covering it and must force full — same rule as the compose-only
+  // guard above. Force full if any shared seed cannot be proven to reach one.
   for (const seed of sharedSeeds) {
     const seedClosure = dependentsClosure(graph, [seed]);
     const reachesComponent = [...seedClosure].some((file) => {
       const slug = slugForFile(file);
-      return slug !== null && knownSlugs.has(slug);
+      return slug !== null && knownSlugs.has(slug) && !composeOnlySlugs.has(slug);
     });
     if (!reachesComponent) {
       return {
         mode: 'full',
-        reason: `shared change reaches no component slug (can't prove its dependents are tested): ${seed}`,
+        reason: `shared change reaches no standalone component slug (can't prove its dependents are tested): ${seed}`,
       };
     }
   }

--- a/packages/playground/src/discover.test.ts
+++ b/packages/playground/src/discover.test.ts
@@ -426,3 +426,33 @@ describe('discovery cache', () => {
     }
   });
 });
+
+describe('COMPOSE_ONLY_COMPONENTS — drift guard', () => {
+  // The browser-test scope job (changed-components.ts → computeScope) relies on
+  // this set to keep its emitted slugs inside the Playwright runner's manifest
+  // vocabulary: a compose-only leaf must never be emitted as a test slug. If a
+  // new compose-only component is added but missing here, the scope job re-emits
+  // the leaf and the runner throws `unknown component slugs`. These tests fail
+  // loudly the moment the set drifts from the filesystem reality.
+
+  it('every entry is a real component directory with a <slug>.svelte file', async () => {
+    for (const slug of COMPOSE_ONLY_COMPONENTS) {
+      const svelte = join(COMPONENTS_DIR, slug, `${slug}.svelte`);
+      const exists = await Bun.file(svelte).exists();
+      expect(
+        exists,
+        `COMPOSE_ONLY_COMPONENTS lists "${slug}" but ${slug}/${slug}.svelte is missing`,
+      ).toBe(true);
+    }
+  });
+
+  it('no entry has standalone playground examples (it is genuinely compose-only)', async () => {
+    for (const slug of COMPOSE_ONLY_COMPONENTS) {
+      const examples = await discoverExamples(slug);
+      expect(
+        examples,
+        `COMPOSE_ONLY_COMPONENTS lists "${slug}" but it has standalone examples — it is NOT compose-only`,
+      ).toEqual([]);
+    }
+  });
+});

--- a/packages/testing/scripts/changed-components.test.ts
+++ b/packages/testing/scripts/changed-components.test.ts
@@ -129,6 +129,87 @@ describe('changed-components decide()', () => {
   });
 });
 
+describe('changed-components compose-only leaves', () => {
+  // `feed-event` is a compose-only leaf (no standalone Playwright page); `feed`
+  // renders it. The scope job must never EMIT `feed-event` (the runner rejects
+  // unknown slugs) — a change to it should map to `feed` through the closure.
+  const feedTree = new Map<string, string>([
+    [`${C}/feed/feed.svelte`, `import FeedEvent from '../feed-event/feed-event.svelte';`],
+    [`${C}/feed-event/feed-event.svelte`, `export const x = 1;`],
+  ]);
+  const feedKnownSlugs = new Set(['feed', 'feed-event']);
+  const composeOnly = new Set(['feed-event']);
+
+  it('maps a compose-only leaf change to its parent slug, never emitting the leaf', () => {
+    const result = decide(
+      [`${C}/feed-event/feed-event.svelte`],
+      feedTree,
+      feedKnownSlugs,
+      [],
+      composeOnly,
+    );
+    expect(result).toEqual({ mode: 'filtered', components: ['feed'] });
+  });
+
+  it('maps a compose-only SIDECAR change (not a graph node) to its parent via the canonical entry', () => {
+    // `feed-event.test.ts` is a component-tree sidecar that is NOT in the graph
+    // (sourceFiles). Reachability must seed from the canonical feed-event.svelte
+    // entry, not the sidecar path — otherwise the closure is empty and it wrongly
+    // forces full. This is the exact case the reachability guard regressed on.
+    const result = decide(
+      [`${C}/feed-event/feed-event.test.ts`],
+      feedTree,
+      feedKnownSlugs,
+      [],
+      composeOnly,
+    );
+    expect(result).toEqual({ mode: 'filtered', components: ['feed'] });
+  });
+
+  it('forces full when a compose-only leaf reaches no standalone parent (orphaned)', () => {
+    // No parent imports the leaf — it cannot map to a testable slug, so emitting
+    // it would crash the runner and emitting nothing would silently skip it.
+    const orphanTree = new Map<string, string>([
+      [`${C}/feed-event/feed-event.svelte`, `export const x = 1;`],
+    ]);
+    const result = decide(
+      [`${C}/feed-event/feed-event.svelte`],
+      orphanTree,
+      feedKnownSlugs,
+      [],
+      composeOnly,
+    );
+    expect(result.mode).toBe('full');
+  });
+
+  it('still emits a standalone component’s own slug directly', () => {
+    // Guards against over-broadly dropping direct slugs: `feed` itself is not
+    // compose-only and must still appear when it changes.
+    const result = decide([`${C}/feed/feed.svelte`], feedTree, feedKnownSlugs, [], composeOnly);
+    expect(result).toEqual({ mode: 'filtered', components: ['feed'] });
+  });
+
+  it('forces full when a SHARED module reaches only compose-only components', () => {
+    // A shared util consumed only by an orphaned compose-only leaf reaches a
+    // "known" slug but no EMITTABLE (non-compose) one — so nothing would test the
+    // shared change. The shared-seed guard must force full, not accept the
+    // compose-only slug as coverage.
+    const sharedReachingOnlyComposeOnly = new Map<string, string>([
+      [`${U}/feed-helper.ts`, `export const h = () => '';`],
+      [`${C}/feed-event/feed-event.svelte`, `import { h } from '../../utilities/feed-helper.ts';`],
+      // No `feed` parent imports feed-event here → the only dependent is compose-only.
+    ]);
+    const result = decide(
+      [`${U}/feed-helper.ts`],
+      sharedReachingOnlyComposeOnly,
+      feedKnownSlugs,
+      [],
+      composeOnly,
+    );
+    expect(result.mode).toBe('full');
+  });
+});
+
 describe('changed-components explicit component scope', () => {
   it('treats an empty explicit component list as a full matrix', () => {
     expect(decideExplicitComponents('', knownSlugs)).toEqual({
@@ -198,6 +279,21 @@ describe('changed-components CLI (integration, real tree)', () => {
     expect(slugs).toContain('button');
     expect(slugs).toContain('confirm-dialog');
     expect(slugs).toContain('alert-dialog');
+  });
+
+  it('a real compose-only leaf change maps to its parent slug, never emitting the leaf', () => {
+    // End-to-end proof that the production COMPOSE_ONLY_COMPONENTS default is
+    // threaded: `feed-event` is compose-only (rendered by `feed`), so a change to
+    // it must emit `feed` and never `feed-event` (which the Playwright runner
+    // would reject as an unknown slug). Guards the original bug at the real-tree
+    // level, not just the synthetic-fixture level.
+    const { mode, components } = runCli([
+      'packages/components/src/components/feed-event/feed-event.svelte',
+    ]);
+    expect(mode).toBe('filtered');
+    const slugs = components.split(',');
+    expect(slugs).toContain('feed');
+    expect(slugs).not.toContain('feed-event');
   });
 
   it('the lockfile forces full', () => {

--- a/packages/testing/scripts/changed-components.test.ts
+++ b/packages/testing/scripts/changed-components.test.ts
@@ -228,6 +228,20 @@ describe('changed-components explicit component scope', () => {
   it('rejects unknown explicit component slugs', () => {
     expect(() => decideExplicitComponents('button,ghost', knownSlugs)).toThrow(/ghost/);
   });
+
+  // `knownSlugs` (filesystem) includes compose-only leaves with no standalone
+  // Playwright page. Dispatching one must fail FAST in the scope job, not get
+  // emitted and rejected later by the runner manifest.
+  it('rejects a compose-only leaf in explicit scope (fails fast, not in the runner)', () => {
+    const known = new Set(['feed', 'feed-event']);
+    const composeOnly = new Set(['feed-event']);
+    expect(() => decideExplicitComponents('feed-event', known, composeOnly)).toThrow(/feed-event/);
+    // A standalone slug in the same tree still resolves.
+    expect(decideExplicitComponents('feed', known, composeOnly)).toEqual({
+      mode: 'filtered',
+      components: ['feed'],
+    });
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/testing/scripts/changed-components.ts
+++ b/packages/testing/scripts/changed-components.ts
@@ -58,13 +58,22 @@ export type Decision =
 
 /**
  * Normalize an explicit component scope from `workflow_dispatch` inputs.
- * Empty input means "full matrix"; non-empty input must name known slugs.
+ * Empty input means "full matrix"; non-empty input must name a standalone slug.
+ *
+ * `knownSlugs` is the filesystem superset and includes compose-only leaves
+ * (e.g. `feed-event`) that have no standalone Playwright page. Dispatching one
+ * of those would pass shape validation here but be rejected later by the runner
+ * manifest as an unknown slug — a confusing late failure. Subtracting the
+ * compose-only set up front makes `parseComponentFilter` throw in the scope job
+ * instead, listing only the slugs the runner can actually test.
  */
 export function decideExplicitComponents(
   rawComponents: string | undefined,
   knownSlugs: ReadonlySet<string>,
+  composeOnlySlugs: ReadonlySet<string> = COMPOSE_ONLY_COMPONENTS,
 ): Decision {
-  const parsed = parseComponentFilter(rawComponents, knownSlugs);
+  const standaloneSlugs = new Set([...knownSlugs].filter((slug) => !composeOnlySlugs.has(slug)));
+  const parsed = parseComponentFilter(rawComponents, standaloneSlugs);
   if (parsed === null) {
     return { mode: 'full', reason: 'explicit component scope empty' };
   }

--- a/packages/testing/scripts/changed-components.ts
+++ b/packages/testing/scripts/changed-components.ts
@@ -37,6 +37,12 @@ import {
   loadSourceFiles,
   type ScopeDecision,
 } from '../../components/scripts/component-graph.ts';
+// Canonical compose-only list lives with the playground discovery logic. It is
+// import-light (only `node:path`), so pulling the constant here does not drag in
+// any playground runtime. Threaded into computeScope so the scope job's emitted
+// slugs match the Playwright runner's manifest vocabulary (compose-only leaves
+// like `feed-event` have no standalone page and must not be emitted).
+import { COMPOSE_ONLY_COMPONENTS } from '../../playground/src/discover.ts';
 import { parseComponentFilter } from '../src/helpers/component-filter.ts';
 
 const scriptDirectory = dirname(fileURLToPath(import.meta.url));
@@ -83,6 +89,7 @@ export function decide(
   sourceFiles: ReadonlyMap<string, string>,
   knownSlugs: ReadonlySet<string>,
   deletedFiles: string[] = [],
+  composeOnlySlugs: ReadonlySet<string> = COMPOSE_ONLY_COMPONENTS,
 ): Decision {
   const cleaned = changedFiles.map((line) => line.trim()).filter((line) => line.length > 0);
 
@@ -108,6 +115,7 @@ export function decide(
     deletedFiles,
     sourceFiles,
     knownSlugs,
+    composeOnlySlugs,
   });
 
   if (graphDecision.mode === 'full') {
@@ -177,6 +185,9 @@ async function main(): Promise<void> {
     const input = await Bun.stdin.text();
     const { all, deleted } = partitionDeleted(input.split('\n'));
     const sourceFiles = await loadSourceFiles();
+    // composeOnlySlugs defaults to COMPOSE_ONLY_COMPONENTS (decide()'s default),
+    // so the real CI run threads the canonical compose-only set; the discover.ts
+    // drift-guard test keeps that set in sync with the filesystem.
     decision = decide(all, sourceFiles, knownSlugs, deleted);
   }
 


### PR DESCRIPTION
## Summary

The browser-test `scope` job derives a filtered component-slug list from a diff (instead of running the full matrix). Its slug vocabulary (`loadKnownSlugs` = every `src/components/<dir>/` with a `<dir>.svelte`) is a **superset** of the Playwright runner's vocabulary (the manifest = standalone playground pages only). So a change to a compose-only **leaf** — `feed-event`, `dropdown-item`, `tree-item`, `stat`, etc., which render only via a parent namespace and have no standalone page — emitted that leaf as a test slug, and the runner threw `unknown component slugs: feed-event`.

**Root cause:** in `computeScope`, the `directSlugs.add(slug)` path short-circuited the graph's vocabulary. The dependents **closure** already resolves a leaf change to its real parent (`feed` imports `feed-event`); the direct path wrongly added the leaf alongside it.

**Fix:** thread `COMPOSE_ONLY_COMPONENTS` (canonical, from `playground/src/discover.ts` — import-light, only `node:path`) into `computeScope` as a parameter. Compose-only slugs are now **closure seeds only** — never direct, filtered out of the closure-derived emit set. A new per-seed **reachability guard** forces `mode=full` if a changed compose-only leaf reaches no standalone parent (orphan), matching the graph's force-full-on-uncertain philosophy. The runner's strict unknown-slug guard is left untouched (last line of defense vs. silently-skipped browser coverage).

**This unblocks the regen lane:** any PR touching a compose-only leaf's source (starting with FeedEvent #251) previously failed the playwright `scope` step. Verified: a `feed-event` diff now emits `components=feed`.

## Review committee

Pre-reviewed by: dx-engineer, Codex (gpt-5.4, high) — both APPROVED after fixes.
- **must-fix addressed** (dx-engineer): `COMPOSE_ONLY_COMPONENTS` had no drift guard. Added `discover.test.ts` tests asserting every entry exists as a `<slug>.svelte` AND has no standalone examples — fails loudly the moment a new compose-only component is added without updating the set (the exact recurrence class).
- **suggestions taken**: a real-tree CLI integration test proving the production default threads (`feed-event` → `feed`, never `feed-event`); a `main()` comment on the default wiring.

## Test plan

```bash
bun test packages/components/scripts/component-graph.test.ts        # 63
bun test packages/testing/scripts/changed-components.test.ts        # 24 (incl. compose-only + real-tree integration)
bun test packages/playground/src/discover.test.ts                  # 42 (incl. drift guard)
# end-to-end:
printf 'packages/components/src/components/feed-event/feed-event.svelte\n' | bun run packages/testing/scripts/changed-components.ts  # → components=feed
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core CI scoping logic (`computeScope`); mistakes could under-test PRs or over-run the matrix, but behavior is heavily covered by new unit and integration tests.
> 
> **Overview**
> The browser-test **scope** job was emitting compose-only leaf slugs (e.g. `feed-event`) that exist on disk but have no standalone Playwright page, so the runner failed with unknown slugs. **`computeScope`** now takes **`composeOnlySlugs`** (default empty): those slugs are **not** added as direct outputs and are **filtered out** of closure-derived slugs, while still **seeding** the graph so changes map to a testable parent like `feed`. **Reachability** for compose-only and shared seeds now requires a **standalone** (non-compose-only) known slug—sidecars seed from canonical `<slug>/<slug>.svelte`; orphans force **full**.
> 
> **`changed-components`** threads **`COMPOSE_ONLY_COMPONENTS`** from **`discover.ts`** into **`decide`** / **`computeScope`**, and **`decideExplicitComponents`** validates only standalone slugs so manual dispatch fails early. Tests cover compose-only mapping, drift on **`COMPOSE_ONLY_COMPONENTS`**, and a real-tree CLI check for **`feed-event` → `feed`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1619bbce055deb30e66139418d5893c4f6445e41. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->