### PR TITLE
fix(components): remediate 9 standalone correctness bugs (Svelte 5 audit, task 0419a325)

### DIFF
--- a/packages/components/scripts/check-platform-features.test.ts
+++ b/packages/components/scripts/check-platform-features.test.ts
@@ -259,5 +259,10 @@ describe('scan — live inventory against the real source tree', () => {
       expect(flag.lineNumber).toBeGreaterThan(0);
       expect(VIEWPORT_WIDTH_MEDIA.test(flag.query)).toBe(true);
     }
-  }, 30_000);
+    // This probe walks the entire component source tree from disk. It runs in
+    // ~9s on an idle machine but is starved well past 30s when the full cinder
+    // suite (or a concurrent worktree's suite) saturates the CPU — the failure
+    // mode is a timeout, never an assertion. Budget generously so a loaded
+    // machine doesn't flag a green scan as broken.
+  }, 90_000);
 });

--- a/packages/components/src/components/_radio/radio.svelte
+++ b/packages/components/src/components/_radio/radio.svelte
@@ -77,6 +77,7 @@
       {value}
       {checked}
       disabled={effectiveDisabled}
+      required={group.required || undefined}
       aria-invalid={ariaInvalid(group.invalid)}
       onchange={handleChange}
       class={cn('cinder-radio', className)}

--- a/packages/components/src/components/command-menu/command-menu.svelte
+++ b/packages/components/src/components/command-menu/command-menu.svelte
@@ -135,6 +135,10 @@
   function activateItemById(id: string) {
     const record = registrations.find((registration) => registration.id === id);
     if (!record || record.getDisabled()) return;
+    // Fire the per-item `onselect` callback first (matching command-palette's
+    // shared-context contract), then the menu-level `onselect` prop. Without the
+    // first call, an item's own onselect is silently dropped on activation.
+    record.getOnselect()();
     onselect?.({ value: record.getValue(), query });
   }
 

--- a/packages/components/src/components/command-menu/command-menu.test.ts
+++ b/packages/components/src/components/command-menu/command-menu.test.ts
@@ -132,7 +132,11 @@ describe('CommandMenu', () => {
     expect(anchor.value).toBe('/a');
   });
 
-  test('click activation calls only the menu-level onselect callback', async () => {
+  test('click activation fires the per-item onselect and the menu-level callback', async () => {
+    // Regression: command-menu previously dropped the per-item `onselect`
+    // callback on activation, firing only the menu-level prop. command-palette's
+    // shared-context contract fires both (the per-item callback first), so
+    // command-menu now matches it.
     const itemSelect = mock(() => {});
     const selected: string[] = [];
     render(CommandMenuFixture, {
@@ -146,7 +150,7 @@ describe('CommandMenu', () => {
     await fireEvent.click(option);
 
     expect(selected).toEqual(['alpha']);
-    expect(itemSelect).not.toHaveBeenCalled();
+    expect(itemSelect).toHaveBeenCalledTimes(1);
   });
 
   test('Escape dismisses the menu', async () => {

--- a/packages/components/src/components/context-menu/context-menu.test.ts
+++ b/packages/components/src/components/context-menu/context-menu.test.ts
@@ -346,10 +346,12 @@ describe('ContextMenu', () => {
     await fireEvent.keyDown(document.activeElement as HTMLElement, { key: 'ArrowDown' });
     expect(document.activeElement?.textContent).toContain('Rename');
 
-    // DropdownItem dispatches a synthetic click on Enter, so selection and
-    // close-on-select both fire even though happy-dom does not synthesize the
-    // click from keydown on its own.
-    await fireEvent.keyDown(document.activeElement as HTMLElement, { key: 'Enter' });
+    // In a real browser, pressing Enter on a focused <button> dispatches a native
+    // click, which drives selection + close-on-select. DropdownItem no longer
+    // synthesizes its own click on keydown (that caused double-activation), and
+    // happy-dom does not synthesize the native click from keydown — so we fire
+    // the click directly on the focused item to exercise the same native path.
+    await fireEvent.click(document.activeElement as HTMLElement);
 
     await waitFor(() => expect(queryMenu()).toBeNull());
     expect(container.querySelector('.context-menu-selected')?.textContent).toBe('rename');
@@ -402,10 +404,13 @@ describe('ContextMenu', () => {
     await fireEvent.keyDown(document.activeElement as HTMLElement, { key: 'ArrowUp' });
     expect(document.activeElement).toBe(getByRole('menuitem', { name: 'Open' }));
 
-    // Enter on the focused item selects it and closes the menu.
+    // Enter on the focused item selects it and closes the menu. In a real
+    // browser Enter on a <button> dispatches a native click; DropdownItem relies
+    // on that (it no longer synthesizes its own click) and happy-dom does not
+    // synthesize it from keydown, so we fire the click to drive the native path.
     await fireEvent.keyDown(document.activeElement as HTMLElement, { key: 'ArrowDown' });
     expect(document.activeElement).toBe(getByRole('menuitem', { name: 'Rename' }));
-    await fireEvent.keyDown(document.activeElement as HTMLElement, { key: 'Enter' });
+    await fireEvent.click(document.activeElement as HTMLElement);
 
     await waitFor(() => expect(queryByRole('menu')).toBeNull());
     expect(container.querySelector('.context-menu-selected')?.textContent).toBe('rename');

--- a/packages/components/src/components/diff-viewer/diff-viewer.svelte
+++ b/packages/components/src/components/diff-viewer/diff-viewer.svelte
@@ -85,6 +85,8 @@
     };
   }
 
+  const instanceId = $props.id();
+
   let {
     original,
     current,
@@ -365,7 +367,7 @@
     <!-- Front Matter Section (DEP-61) -->
     {#if hasFrontMatter}
       <DiffFrontMatter
-        id="front-matter"
+        id={`${instanceId}-front-matter`}
         diffs={frontMatterDiffs}
         {viewMode}
         bind:expanded={frontMatterExpanded}

--- a/packages/components/src/components/diff-viewer/diff-viewer.test.ts
+++ b/packages/components/src/components/diff-viewer/diff-viewer.test.ts
@@ -32,9 +32,8 @@ import { setupHappyDom } from '../../test/happy-dom.ts';
 setupHappyDom();
 
 const { render, fireEvent } = await import('@testing-library/svelte');
-const { computeLineDiff, computeWordChanges, getDiffStats, groupIntoHunks } = await import(
-  'cinder/markdown/diff/line-diff'
-);
+const { computeLineDiff, computeWordChanges, getDiffStats, groupIntoHunks } =
+  await import('cinder/markdown/diff/line-diff');
 const { default: DiffLine } = await import('./diff-line.svelte');
 const { default: DiffToolbar } = await import('./diff-toolbar.svelte');
 const { default: DiffFrontMatter } = await import('./diff-front-matter.svelte');
@@ -56,7 +55,10 @@ function hasButtonLabelled(container: HTMLElement, label: string): boolean {
 
 describe('DiffViewer: identical input (basic mount)', () => {
   test('two identical strings produce only unchanged lines and zero stats', () => {
-    const diffs = computeLineDiff('line one\nline two\nline three', 'line one\nline two\nline three');
+    const diffs = computeLineDiff(
+      'line one\nline two\nline three',
+      'line one\nline two\nline three',
+    );
 
     expect(diffs.every((diff) => diff.type === 'same')).toBe(true);
     expect(diffs).toHaveLength(3);
@@ -146,7 +148,10 @@ describe('DiffViewer: changed input (renders hunks)', () => {
 
 describe('DiffViewer: view-mode toggle', () => {
   test('unified view shows a removed line; final view hides it', () => {
-    const unified = render(DiffLine, { diff: { type: 'removed', text: 'gone' }, viewMode: 'unified' });
+    const unified = render(DiffLine, {
+      diff: { type: 'removed', text: 'gone' },
+      viewMode: 'unified',
+    });
     expect(unified.container.textContent).toContain('gone');
     expect(unified.container.querySelector('.diff-line')).not.toBeNull();
 
@@ -157,7 +162,10 @@ describe('DiffViewer: view-mode toggle', () => {
   });
 
   test('original view hides an added line; final view shows it', () => {
-    const original = render(DiffLine, { diff: { type: 'added', text: 'plus' }, viewMode: 'original' });
+    const original = render(DiffLine, {
+      diff: { type: 'added', text: 'plus' },
+      viewMode: 'original',
+    });
     // Original view reflects the baseline, so added lines are hidden.
     expect(original.container.querySelector('.diff-line')).toBeNull();
     expect(original.container.textContent).not.toContain('plus');
@@ -331,5 +339,74 @@ describe('DiffViewer: front-matter section', () => {
     const section = container.querySelector('.front-matter-section');
     expect(section?.getAttribute('data-has-changes')).toBe('true');
     expect(container.textContent).toContain('Changed');
+  });
+
+  test('two DiffFrontMatter instances with distinct ids produce non-colliding toggle and content ids', () => {
+    // This test documents the bug: when diff-viewer passed the literal id="front-matter"
+    // to every DiffFrontMatter it rendered, every instance produced the same
+    // toggle id ("front-matter-toggle") and content id ("front-matter-content").
+    // The fix is that diff-viewer now passes a per-instance prefix derived from
+    // $props.id(), so the ids are unique across instances on the same page.
+    //
+    // We simulate what TWO diff-viewer instances produce by rendering DiffFrontMatter
+    // twice with the distinct ids the fixed diff-viewer would pass.
+
+    const diffs = computeLineDiff('---\ntitle: Old\n---', '---\ntitle: New\n---');
+
+    const { container: containerA } = render(DiffFrontMatter, {
+      id: 'diff-viewer-1-front-matter',
+      diffs,
+      viewMode: 'unified',
+      expanded: true,
+    });
+
+    const { container: containerB } = render(DiffFrontMatter, {
+      id: 'diff-viewer-2-front-matter',
+      diffs,
+      viewMode: 'unified',
+      expanded: true,
+    });
+
+    // Each instance must have its own unique toggle id and content id.
+    const toggleA = containerA.querySelector('[id]');
+    const toggleB = containerB.querySelector('[id]');
+
+    // The ids must not be identical — this would catch the original literal collision.
+    expect(toggleA?.id).not.toBe(toggleB?.id);
+    expect(toggleA?.id).toBe('diff-viewer-1-front-matter-toggle');
+    expect(toggleB?.id).toBe('diff-viewer-2-front-matter-toggle');
+
+    // aria-controls on each toggle must resolve within its own container, not the other's.
+    const ariaControlsA = toggleA?.getAttribute('aria-controls');
+    const ariaControlsB = toggleB?.getAttribute('aria-controls');
+
+    expect(ariaControlsA).toBe('diff-viewer-1-front-matter-content');
+    expect(ariaControlsB).toBe('diff-viewer-2-front-matter-content');
+
+    // The actual content elements must exist with matching ids in the correct containers.
+    expect(containerA.querySelector(`#${ariaControlsA}`)).not.toBeNull();
+    expect(containerB.querySelector(`#${ariaControlsB}`)).not.toBeNull();
+
+    // Cross-instance: each toggle's aria-controls must NOT resolve in the OTHER container.
+    expect(containerA.querySelector(`#${ariaControlsB}`)).toBeNull();
+    expect(containerB.querySelector(`#${ariaControlsA}`)).toBeNull();
+  });
+
+  test('diff-viewer.svelte passes a $props.id()-derived front-matter id, not the colliding literal', async () => {
+    // The behavioural test above proves DiffFrontMatter namespaces ids from
+    // whatever `id` it receives — but the actual bug lived in diff-viewer.svelte,
+    // which hardcoded id="front-matter" on EVERY instance. The composed shell
+    // cannot be mounted under happy-dom (see the file header), so we guard the
+    // shell-level fix at the source level: it must derive a per-instance id from
+    // $props.id() and must not pass the bare literal. Reverting the fix fails here.
+    const source = await Bun.file(new URL('./diff-viewer.svelte', import.meta.url)).text();
+
+    // The per-instance base id is generated with $props.id().
+    expect(source).toContain('$props.id()');
+
+    // The front-matter id passed to <DiffFrontMatter> is namespaced by that base
+    // id, not the bare literal that collided across instances.
+    expect(source).not.toMatch(/id=["']front-matter["']/);
+    expect(source).toMatch(/id=\{`\$\{instanceId\}-front-matter`\}/);
   });
 });

--- a/packages/components/src/components/dropdown-item/dropdown-item.svelte
+++ b/packages/components/src/components/dropdown-item/dropdown-item.svelte
@@ -55,16 +55,6 @@
       context.close();
     }
   }
-
-  function handleKeydown(event: KeyboardEvent): void {
-    if (disabled) return;
-    if (event.key === 'Enter' || event.key === ' ') {
-      event.preventDefault();
-      if (event.currentTarget instanceof HTMLButtonElement) {
-        event.currentTarget.dispatchEvent(new MouseEvent('click', { bubbles: true }));
-      }
-    }
-  }
 </script>
 
 <button
@@ -77,11 +67,10 @@
     customClassName,
   )}
   data-cinder-variant={variant}
-  tabindex={disabled ? -1 : 0}
+  tabindex={-1}
   data-disabled={disabled ? '' : undefined}
   aria-disabled={disabled ? 'true' : undefined}
   onclick={handleClick}
-  onkeydown={handleKeydown}
   {...rest}
 >
   {#if children}

--- a/packages/components/src/components/dropdown-item/dropdown-item.svelte
+++ b/packages/components/src/components/dropdown-item/dropdown-item.svelte
@@ -57,7 +57,13 @@
   }
 </script>
 
+<!--
+  {...rest} is spread BEFORE the component-controlled attributes so a consumer
+  cannot override role="menuitem", tabindex (the roving-focus model), aria-disabled,
+  or the click handler — overriding any of those would break menu semantics.
+-->
 <button
+  {...rest}
   type="button"
   role="menuitem"
   class={classNames(
@@ -71,7 +77,6 @@
   data-disabled={disabled ? '' : undefined}
   aria-disabled={disabled ? 'true' : undefined}
   onclick={handleClick}
-  {...rest}
 >
   {#if children}
     {@render children()}

--- a/packages/components/src/components/dropdown-item/dropdown-item.test.ts
+++ b/packages/components/src/components/dropdown-item/dropdown-item.test.ts
@@ -42,11 +42,33 @@ describe('DropdownItem', () => {
     await waitFor(() => expect(container.querySelector('[role="menu"]')).toBeNull());
   });
 
-  test('Enter activates the item via the keydown-to-click bridge', async () => {
+  test('button has tabindex=-1 for roving-focus compatibility', async () => {
+    const { container } = await openMenu();
+    const item = container.querySelector('[role="menuitem"]') as HTMLElement;
+    expect(item.getAttribute('tabindex')).toBe('-1');
+  });
+
+  test('keydown Enter/Space does not synthesize a click (no double-fire)', async () => {
     const { container } = await openMenu();
     const item = container.querySelector('[role="menuitem"]') as HTMLElement;
     item.focus();
+
+    // Fire multiple keydown events as would happen when a key is held — a
+    // Space held down produces repeated keydown events. With the old
+    // handleKeydown bridge each repetition dispatched a synthetic click,
+    // causing multi-fire.  After the fix, keydown alone must not trigger
+    // activation; only a real click event should.
+    await fireEvent.keyDown(item, { key: ' ' });
+    await fireEvent.keyDown(item, { key: ' ' });
     await fireEvent.keyDown(item, { key: 'Enter' });
+    await fireEvent.keyDown(item, { key: 'Enter' });
+
+    // After all those keydowns the output must still be empty — none should
+    // have fired the onclick handler via a synthetic MouseEvent('click').
+    expect(container.querySelector('output')?.textContent).toBe('');
+
+    // A real click still works.
+    await fireEvent.click(item);
     await waitFor(() => expect(container.querySelector('output')?.textContent).toBe('copy'));
   });
 });

--- a/packages/components/src/components/dropdown/dropdown.test.ts
+++ b/packages/components/src/components/dropdown/dropdown.test.ts
@@ -528,10 +528,12 @@ describe('Dropdown', () => {
     await fireEvent.keyDown(document.activeElement as HTMLElement, { key: 'ArrowDown' });
     expect(document.activeElement?.textContent).toContain('Invite people');
 
-    // DropdownItem dispatches a synthetic click on Enter, so activation and
-    // close-on-select both run even though happy-dom does not synthesize the
-    // click from keydown on a <button> itself.
-    await fireEvent.keyDown(document.activeElement as HTMLElement, { key: 'Enter' });
+    // In a real browser, pressing Enter on a focused <button> dispatches a native
+    // click, which drives activation + close-on-select. DropdownItem no longer
+    // synthesizes its own click on keydown (that caused double-activation), and
+    // happy-dom does not synthesize the native click from keydown — so we fire
+    // the click directly on the focused item to exercise the same native path.
+    await fireEvent.click(document.activeElement as HTMLElement);
 
     await waitFor(() => {
       expect(container.querySelector('[role="menu"]')).toBeNull();

--- a/packages/components/src/components/grid-list-item/README.md
+++ b/packages/components/src/components/grid-list-item/README.md
@@ -16,10 +16,10 @@ snippet. The flat `cinder/grid-list-item` subpath remains exported for
 
 | Prop       | Type               | Required | Default | Description                                                                                                                |
 | ---------- | ------------------ | -------- | ------- | -------------------------------------------------------------------------------------------------------------------------- |
+| `class`    | `string`           | no       | —       |                                                                                                                            |
 | `href`     | `string`           | no       | —       |                                                                                                                            |
 | `rel`      | `string` \| `null` | no       | —       |                                                                                                                            |
 | `actions`  | `(opaque)`         | no       | —       | A function or snippet prop. Its shape is not captured by the JSON schema; see the component types for the exact signature. |
-| `class`    | `(opaque)`         | no       | —       | A prop whose shape is not captured by the JSON schema; see the component types for the exact signature.                    |
 | `image`    | `(opaque)`         | no       | —       | A function or snippet prop. Its shape is not captured by the JSON schema; see the component types for the exact signature. |
 | `meta`     | `(opaque)`         | no       | —       | A function or snippet prop. Its shape is not captured by the JSON schema; see the component types for the exact signature. |
 | `subtitle` | `(opaque)`         | no       | —       | A function or snippet prop. Its shape is not captured by the JSON schema; see the component types for the exact signature. |

--- a/packages/components/src/components/grid-list-item/grid-list-item.schema.json
+++ b/packages/components/src/components/grid-list-item/grid-list-item.schema.json
@@ -2,6 +2,9 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "type": "object",
   "properties": {
+    "class": {
+      "type": "string"
+    },
     "href": {
       "type": "string"
     },
@@ -22,10 +25,6 @@
       {
         "name": "actions",
         "reason": "function-or-snippet"
-      },
-      {
-        "name": "class",
-        "reason": "unknown-shape"
       },
       {
         "name": "image",

--- a/packages/components/src/components/grid-list-item/grid-list-item.schema.ts
+++ b/packages/components/src/components/grid-list-item/grid-list-item.schema.ts
@@ -4,6 +4,9 @@ const schema = {
   $schema: 'https://json-schema.org/draft/2020-12/schema',
   type: 'object',
   properties: {
+    class: {
+      type: 'string',
+    },
     href: {
       type: 'string',
     },
@@ -24,10 +27,6 @@ const schema = {
       {
         name: 'actions',
         reason: 'function-or-snippet',
-      },
-      {
-        name: 'class',
-        reason: 'unknown-shape',
       },
       {
         name: 'image',

--- a/packages/components/src/components/grid-list-item/grid-list-item.test.ts
+++ b/packages/components/src/components/grid-list-item/grid-list-item.test.ts
@@ -73,9 +73,14 @@ describe('GridListItem', () => {
     expect(container.querySelector('.cinder-grid-list__title')?.textContent).toContain('Jane');
   });
 
-  test('href without title renders no anchor', () => {
+  test('href without title renders no anchor (runtime defensive guard)', () => {
+    // The type system now rejects href without title at compile time.
+    // This test exercises the runtime defensive behavior for JS callers that
+    // bypass TypeScript — the component must not render an inaccessible anchor.
     const { container } = render(GridListItem, {
-      props: { href: '/people/jane' },
+      props: {
+        href: '/people/jane',
+      } as unknown as import('./grid-list-item.types.ts').GridListItemProps,
     });
     expect(container.querySelector('a.cinder-grid-list__link')).toBeNull();
   });
@@ -198,5 +203,48 @@ describe('GridListItem', () => {
     const relTokens = (anchor?.getAttribute('rel') ?? '').split(/\s+/);
     expect(relTokens).not.toContain('noopener');
     expect(relTokens).not.toContain('noreferrer');
+  });
+
+  // ── Type-level regression tests ────────────────────────────────────────────
+  // These blocks assert compile-time rejections for the two high-severity
+  // defects: (1) href without title must be a type error in GridListItemLinked,
+  // and (2) onclick/role/tabindex must not be accepted by GridListItemBase.
+
+  test('type: GridListItemLinked requires title when href is set', () => {
+    // href without title must not satisfy GridListItemProps.
+    // GridListItemLinked requires title: Snippet; GridListItemStatic forbids href.
+    // @ts-expect-error href without title must be a type error — GridListItemLinked requires title: Snippet
+    const _missingTitle: import('./grid-list-item.types.ts').GridListItemProps = {
+      href: '/people/jane',
+    };
+    void _missingTitle;
+    expect(true).toBe(true);
+  });
+
+  test('type: onclick is not accepted on GridListItemProps', () => {
+    const _withOnClick: import('./grid-list-item.types.ts').GridListItemProps = {
+      // @ts-expect-error onclick is stripped from GridListItemBase — must be a type error
+      onclick: () => {},
+    };
+    void _withOnClick;
+    expect(true).toBe(true);
+  });
+
+  test('type: role is not accepted on GridListItemProps', () => {
+    const _withRole: import('./grid-list-item.types.ts').GridListItemProps = {
+      // @ts-expect-error role is stripped from GridListItemBase — must be a type error
+      role: 'button',
+    };
+    void _withRole;
+    expect(true).toBe(true);
+  });
+
+  test('type: tabindex is not accepted on GridListItemProps', () => {
+    const _withTabIndex: import('./grid-list-item.types.ts').GridListItemProps = {
+      // @ts-expect-error tabindex is stripped from GridListItemBase — must be a type error
+      tabindex: 0,
+    };
+    void _withTabIndex;
+    expect(true).toBe(true);
   });
 });

--- a/packages/components/src/components/grid-list-item/grid-list-item.types.ts
+++ b/packages/components/src/components/grid-list-item/grid-list-item.types.ts
@@ -1,6 +1,10 @@
 import type { Snippet } from 'svelte';
 import type { HTMLAnchorAttributes, HTMLAttributes } from 'svelte/elements';
-type GridListItemBase = Omit<HTMLAttributes<HTMLLIElement>, 'title'> & {
+type LiEventAttribute = Extract<keyof HTMLAttributes<HTMLLIElement>, `on${string}`>;
+type GridListItemBase = Omit<
+  HTMLAttributes<HTMLLIElement>,
+  'title' | 'class' | 'role' | 'tabindex' | LiEventAttribute
+> & {
   class?: string;
   /** Optional image region (avatar, thumbnail). */
   image?: Snippet;
@@ -27,10 +31,14 @@ type GridListItemStatic = GridListItemBase & {
  * via a pseudo-element overlay. Only `actions` (and descendants marked with
  * `data-cinder-stretched-link-escape`) remain pointer-operable above the overlay.
  *
- * If `title` is absent, no anchor is rendered even when `href` is set.
+ * `title` is required when `href` is set: it provides the accessible name for
+ * the stretched-link anchor. An item with `href` but no `title` would render a
+ * pseudo-element overlay with no reachable `<a>` and no accessible name.
  */
 type GridListItemLinked = GridListItemBase & {
   href: string;
+  /** Required when href is set — provides the accessible name for the anchor. */
+  title: Snippet;
   /**
    * When `target` matches `"_blank"` (case-insensitive), the component
    * automatically composes `rel="noopener noreferrer"` with any

--- a/packages/components/src/components/kanban-board/kanban-board.svelte
+++ b/packages/components/src/components/kanban-board/kanban-board.svelte
@@ -399,10 +399,10 @@
   ): void {
     if (!reorderColumns || invalidKeys || cardController.phase === 'lifted') return;
     if (columnLiftedKey === null) {
-      if (event.key === ' ' || event.key === 'Enter') {
-        event.preventDefault();
-        liftColumn(column, columnIndex);
-      }
+      // Space/Enter in the idle state: do nothing here. The native button will
+      // synthesize a click on Space/Enter keyup, which handleColumnClick will
+      // handle to liftColumn. Handling Space/Enter in both keydown and the
+      // subsequent synthesized click caused an immediate lift-then-drop.
       return;
     }
     if (columnLiftedKey !== column.id) return;
@@ -417,7 +417,11 @@
       return;
     }
     if (event.key === ' ' || event.key === 'Enter') {
+      // Prevent the default action and stop propagation so the synthesized
+      // click that the browser fires on keyup does not reach handleColumnClick
+      // after the column has already been dropped and columnLiftedKey is null.
       event.preventDefault();
+      event.stopPropagation();
       dropColumn(column, currentTarget);
       return;
     }

--- a/packages/components/src/components/kanban-board/kanban-board.svelte
+++ b/packages/components/src/components/kanban-board/kanban-board.svelte
@@ -417,11 +417,11 @@
       return;
     }
     if (event.key === ' ' || event.key === 'Enter') {
-      // Prevent the default action and stop propagation so the synthesized
-      // click that the browser fires on keyup does not reach handleColumnClick
-      // after the column has already been dropped and columnLiftedKey is null.
+      // Prevent the default action so the browser does not synthesize a click
+      // event on keyup — for Space, preventDefault() on keydown suppresses the
+      // synthetic keyup-click, so handleColumnClick never fires after the column
+      // is already dropped and columnLiftedKey is null again.
       event.preventDefault();
-      event.stopPropagation();
       dropColumn(column, currentTarget);
       return;
     }

--- a/packages/components/src/components/kanban-board/kanban-board.test.ts
+++ b/packages/components/src/components/kanban-board/kanban-board.test.ts
@@ -424,7 +424,7 @@ describe('KanbanBoard', () => {
     const { container, onchange } = renderBoard();
     const handle = container.querySelector('[aria-label="Reorder To do column"]') as HTMLElement;
 
-    await fireEvent.keyDown(handle, { key: ' ' });
+    await fireEvent.click(handle);
     await fireEvent.keyDown(handle, { key: 'ArrowRight' });
     await fireEvent.keyDown(handle, { key: ' ' });
     await waitForAnnouncement();
@@ -464,11 +464,35 @@ describe('KanbanBoard', () => {
     });
   });
 
+  test('Space keydown + synthesized click leaves the column lifted, not immediately dropped', async () => {
+    // Regression: before the fix, handleColumnKeydown lifted on Space keydown
+    // (idle branch) AND handleColumnClick dropped on the subsequent browser-
+    // synthesized click, so one Space press performed lift-then-drop in a single
+    // interaction, making keyboard column reordering non-functional.
+    //
+    // The fix removes Space/Enter from the idle keydown path and lets the native
+    // synthesized click drive handleColumnClick → liftColumn. We simulate the
+    // real chain that a browser produces: keydown(Space) followed immediately by
+    // a click on the same element.
+    const { container } = renderBoard();
+    const handle = container.querySelector('[aria-label="Reorder To do column"]') as HTMLElement;
+
+    // Simulate the browser sequence: keydown fires first, then on keyup the
+    // browser synthesizes a click. We fire both in order.
+    await fireEvent.keyDown(handle, { key: ' ' });
+    await fireEvent.click(handle);
+    await tick();
+
+    // After a single Space press the column must be LIFTED (aria-pressed=true),
+    // not lifted-then-dropped back to idle (aria-pressed=false).
+    expect(handle.getAttribute('aria-pressed')).toBe('true');
+  });
+
   test('window Escape cancels a lifted column after focus leaves the handle', async () => {
     const { container, onchange } = renderBoard();
     const handle = container.querySelector('[aria-label="Reorder To do column"]') as HTMLElement;
 
-    await fireEvent.keyDown(handle, { key: ' ' });
+    await fireEvent.click(handle);
     await tick();
     expect(handle.getAttribute('aria-pressed')).toBe('true');
 
@@ -486,7 +510,7 @@ describe('KanbanBoard', () => {
     const { container, onchange } = renderBoard();
     const handle = container.querySelector('[aria-label="Reorder To do column"]') as HTMLElement;
 
-    await fireEvent.keyDown(handle, { key: ' ' });
+    await fireEvent.click(handle);
     await tick();
     const tabEvent = new KeyboardEvent('keydown', { key: 'Tab', bubbles: true, cancelable: true });
     handle.dispatchEvent(tabEvent);
@@ -583,7 +607,7 @@ describe('KanbanBoard', () => {
       const { container, rerender } = render(KanbanBoard as any, { props });
       const handle = container.querySelector('[aria-label="Reorder To do column"]') as HTMLElement;
 
-      await fireEvent.keyDown(handle, { key: ' ' });
+      await fireEvent.click(handle);
       expect(handle.getAttribute('aria-pressed')).toBe('true');
 
       await rerender({

--- a/packages/components/src/components/navigation-item/navigation-item.svelte
+++ b/packages/components/src/components/navigation-item/navigation-item.svelte
@@ -53,8 +53,10 @@
     deliberate product decision — a disabled navigation link represents a route
     the user cannot access, and hiding it from the links list (screen reader
     VO+U / NVDA Insert+F7) is preferable to a greyed-out unreachable destination.
-    If you need the link to remain discoverable as a named link in AT, set
-    `aria-disabled` but keep `href` — the click is still blocked by handleClick.
+    NavigationItem owns this behavior: href/tabindex/aria-disabled are derived
+    from the `disabled` prop, not passed through, so there is no escape hatch to
+    keep a disabled link discoverable. If your use case needs that, render a
+    plain <a aria-disabled> yourself instead of a disabled NavigationItem.
   -->
   <a
     href={disabled ? undefined : (props as LinkArm).href}

--- a/packages/components/src/components/navigation-item/navigation-item.svelte
+++ b/packages/components/src/components/navigation-item/navigation-item.svelte
@@ -47,6 +47,15 @@
 </script>
 
 {#if isLink}
+  <!--
+    Disabled anchor: href is stripped (not just aria-disabled) so the element
+    loses its link role and is removed from the tab order entirely. This is a
+    deliberate product decision — a disabled navigation link represents a route
+    the user cannot access, and hiding it from the links list (screen reader
+    VO+U / NVDA Insert+F7) is preferable to a greyed-out unreachable destination.
+    If you need the link to remain discoverable as a named link in AT, set
+    `aria-disabled` but keep `href` — the click is still blocked by handleClick.
+  -->
   <a
     href={disabled ? undefined : (props as LinkArm).href}
     class={resolvedClass}

--- a/packages/components/src/components/navigation-item/navigation-item.svelte
+++ b/packages/components/src/components/navigation-item/navigation-item.svelte
@@ -48,10 +48,11 @@
 
 {#if isLink}
   <a
-    href={(props as LinkArm).href}
+    href={disabled ? undefined : (props as LinkArm).href}
     class={resolvedClass}
     aria-current={active ? 'page' : undefined}
     aria-disabled={disabled ? true : undefined}
+    tabindex={disabled ? -1 : undefined}
     data-active={active}
     data-cinder-navigation-item
     data-variant={variant}
@@ -65,6 +66,7 @@
     class={resolvedClass}
     aria-current={active ? 'page' : undefined}
     aria-disabled={disabled ? true : undefined}
+    {disabled}
     data-active={active}
     data-cinder-navigation-item
     data-variant={variant}

--- a/packages/components/src/components/navigation-item/navigation-item.test.ts
+++ b/packages/components/src/components/navigation-item/navigation-item.test.ts
@@ -81,7 +81,7 @@ describe('NavigationItem rendering', () => {
     expect(clickCount).toBe(0);
   });
 
-  test('disabled link keeps href so it remains discoverable as a link', () => {
+  test('disabled link drops href to prevent keyboard navigation', () => {
     const { container } = render(NavigationItem, {
       props: {
         href: '/protected',
@@ -90,10 +90,10 @@ describe('NavigationItem rendering', () => {
       },
     });
     const anchor = container.querySelector('a');
-    expect(anchor?.getAttribute('href')).toBe('/protected');
+    expect(anchor?.hasAttribute('href')).toBe(false);
   });
 
-  test('disabled link does not override tabindex so it remains discoverable by keyboard', () => {
+  test('disabled link sets tabindex=-1 to remove it from tab order', () => {
     const { container } = render(NavigationItem, {
       props: {
         href: '/protected',
@@ -102,7 +102,7 @@ describe('NavigationItem rendering', () => {
       },
     });
     const anchor = container.querySelector('a');
-    expect(anchor?.hasAttribute('tabindex')).toBe(false);
+    expect(anchor?.getAttribute('tabindex')).toBe('-1');
   });
 
   test('enabled link has its href and no tabindex override', () => {
@@ -115,6 +115,18 @@ describe('NavigationItem rendering', () => {
     const anchor = container.querySelector('a');
     expect(anchor?.getAttribute('href')).toBe('/dashboard');
     expect(anchor?.hasAttribute('tabindex')).toBe(false);
+  });
+
+  test('disabled button has native disabled attribute removing it from tab order', () => {
+    const { container } = render(NavigationItem, {
+      props: {
+        onclick: () => {},
+        disabled: true,
+        children: (() => {}) as never,
+      },
+    });
+    const button = container.querySelector('button');
+    expect(button?.hasAttribute('disabled')).toBe(true);
   });
 
   test('disabled button has aria-disabled and blocks onclick', () => {

--- a/packages/components/src/components/radio-group/radio-group.svelte
+++ b/packages/components/src/components/radio-group/radio-group.svelte
@@ -63,6 +63,9 @@
     get invalid() {
       return !!error;
     },
+    get required() {
+      return required;
+    },
     select(next) {
       value = next;
     },
@@ -80,6 +83,7 @@
 <fieldset
   class={cn('cinder-radio-group', className)}
   aria-invalid={ariaInvalid(!!error)}
+  aria-required={required || undefined}
   aria-describedby={describedBy}
   data-cinder-disabled={disabled || undefined}
   data-cinder-required={required || undefined}

--- a/packages/components/src/components/radio-group/radio-group.test.ts
+++ b/packages/components/src/components/radio-group/radio-group.test.ts
@@ -379,6 +379,52 @@ describe('RadioGroup', () => {
     const rows3 = Array.from(c3.querySelectorAll('.cinder-radio-row'));
     rows3.forEach((row) => expect((row as HTMLElement).hasAttribute('data-disabled')).toBe(false));
   });
+  // ── required propagation ────────────────────────────────────────────────
+
+  test('required=true sets the native required attribute on every radio input', () => {
+    const { container } = render(Wrapper, {
+      name: 'choice',
+      value: 'a',
+      required: true,
+      options: [
+        { id: 'r-a', value: 'a', label: 'A' },
+        { id: 'r-b', value: 'b', label: 'B' },
+      ],
+    });
+    const radios = Array.from(container.querySelectorAll<HTMLInputElement>('input[type="radio"]'));
+    expect(radios.length).toBe(2);
+    radios.forEach((radio) => {
+      expect(radio.required).toBe(true);
+    });
+  });
+
+  test('required=true sets aria-required="true" on the fieldset', () => {
+    const { container } = render(Wrapper, {
+      name: 'choice',
+      value: 'a',
+      required: true,
+      options: [{ id: 'r-a', value: 'a', label: 'A' }],
+    });
+    const fieldset = container.querySelector('fieldset');
+    expect(fieldset?.getAttribute('aria-required')).toBe('true');
+  });
+
+  test('required defaults to false — inputs lack the required attribute and fieldset lacks aria-required', () => {
+    const { container } = render(Wrapper, {
+      name: 'choice',
+      value: 'a',
+      options: [
+        { id: 'r-a', value: 'a', label: 'A' },
+        { id: 'r-b', value: 'b', label: 'B' },
+      ],
+    });
+    const radios = Array.from(container.querySelectorAll<HTMLInputElement>('input[type="radio"]'));
+    radios.forEach((radio) => {
+      expect(radio.required).toBe(false);
+    });
+    const fieldset = container.querySelector('fieldset');
+    expect(fieldset?.hasAttribute('aria-required')).toBe(false);
+  });
 });
 
 describe('Radio indicator', () => {

--- a/packages/components/src/components/radio-group/radio-group.types.ts
+++ b/packages/components/src/components/radio-group/radio-group.types.ts
@@ -9,6 +9,7 @@ export type RadioGroupContext = {
   readonly value: string;
   readonly disabled: boolean;
   readonly invalid: boolean;
+  readonly required: boolean;
   select: (next: string) => void;
 };
 /**

--- a/packages/components/src/components/review-editor/review-editor-impl.svelte
+++ b/packages/components/src/components/review-editor/review-editor-impl.svelte
@@ -69,7 +69,7 @@
 
   let {
     id,
-    original = '',
+    original = $bindable(''),
     value = $bindable(''),
     threads = $bindable<Thread[]>([]),
     mode = 'edit',

--- a/packages/components/src/components/review-editor/review-editor.smoke.test.ts
+++ b/packages/components/src/components/review-editor/review-editor.smoke.test.ts
@@ -1,5 +1,42 @@
 import { describe, expect, test } from 'bun:test';
 
+const implementationSource = await Bun.file(
+  new URL('./review-editor-impl.svelte', import.meta.url).pathname,
+).text();
+
+const wrapperSource = await Bun.file(
+  new URL('./review-editor.svelte', import.meta.url).pathname,
+).text();
+
+describe('review-editor original bindable regression', () => {
+  /**
+   * The bug: `original` was a plain prop (`original = ''`), not $bindable.
+   * setState() assigned `original = state.original` locally, but the write
+   * never propagated to the parent — when the parent re-rendered it reverted
+   * the baseline, silently breaking diffStats/hasContentChanges/exportUnifiedDiff.
+   *
+   * Fix: `original = $bindable('')` in review-editor-impl.svelte (matching
+   * value and threads), and `bind:original` forwarded in review-editor.svelte.
+   */
+  test('review-editor-impl.svelte declares original as $bindable so setState writes propagate to the parent', () => {
+    // Must match: original = $bindable('') in the $props() destructure.
+    // A plain `original = ''` would fail this assertion.
+    expect(implementationSource).toMatch(/original\s*=\s*\$bindable\s*\(\s*['"]{2}\s*\)/);
+  });
+
+  test('review-editor.svelte destructures original as $bindable to support two-way binding from callers', () => {
+    // The outer wrapper must also declare the prop as $bindable so callers
+    // using bind:original on the public ReviewEditor component work correctly.
+    expect(wrapperSource).toMatch(/original\s*=\s*\$bindable\s*\(\s*['"]{2}\s*\)/);
+  });
+
+  test('review-editor.svelte forwards bind:original to the implementation component', () => {
+    // Without bind:original on the inner ReviewEditorImplementation, setState
+    // writes to original in the impl never reach the outer wrapper's binding.
+    expect(wrapperSource).toMatch(/bind:original/);
+  });
+});
+
 describe('review-editor public entrypoint', () => {
   test('exports the component from the package subpath and root barrel', async () => {
     const packageJson = await Bun.file(`${import.meta.dir}/../../../package.json`).json();

--- a/packages/components/src/components/review-editor/review-editor.svelte
+++ b/packages/components/src/components/review-editor/review-editor.svelte
@@ -23,6 +23,7 @@
 
   let {
     class: customClassName,
+    original = $bindable(''),
     value = $bindable(''),
     threads = $bindable([]),
     ...rest
@@ -31,4 +32,10 @@
   const mergedClassName = $derived(classNames(customClassName));
 </script>
 
-<ReviewEditorImplementation class={mergedClassName} bind:value bind:threads {...rest} />
+<ReviewEditorImplementation
+  class={mergedClassName}
+  bind:original
+  bind:value
+  bind:threads
+  {...rest}
+/>

--- a/packages/components/src/components/tab-panel/tab-panel.svelte
+++ b/packages/components/src/components/tab-panel/tab-panel.svelte
@@ -31,13 +31,12 @@
   const tabs: TabsContext = rawTabs;
 
   const isActive = $derived(tabs.isActive(value));
-  // Both ids are derived deterministically from `value` so the
-  // aria-labelledby relationship works without round-tripping through the
-  // parent's registry. Tab uses the same default id pattern unless the
-  // consumer supplies a custom `id` prop, in which case the consumer is
-  // responsible for setting `aria-labelledby` on their own.
-  const panelId = $derived(`cinder-tab-panel-${value}`);
-  const labelledBy = $derived(`cinder-tab-${value}`);
+  // Both ids are derived from the root's baseId and this panel's value so
+  // that two Tabs instances sharing the same value produce distinct DOM ids.
+  // This mirrors the pattern in tab.svelte; the root Tabs provides `baseId`
+  // via context to namespace every Tab/TabPanel pair it owns.
+  const panelId = $derived(`${tabs.baseId}-panel-${value}`);
+  const labelledBy = $derived(`${tabs.baseId}-tab-${value}`);
 </script>
 
 {#if isActive}

--- a/packages/components/src/components/tab-panel/tab-panel.test.ts
+++ b/packages/components/src/components/tab-panel/tab-panel.test.ts
@@ -31,11 +31,19 @@ describe('TabPanel', () => {
     expect(panels[0]?.textContent).toContain('A body');
   });
 
-  test('panel id and aria-labelledby derive deterministically from the value', () => {
+  test('panel id and aria-labelledby derive from the instance baseId and the value', () => {
     const { container } = render(Wrapper, { value: 'b', items });
     const panel = container.querySelector('[role="tabpanel"]');
-    expect(panel?.id).toBe('cinder-tab-panel-b');
-    expect(panel?.getAttribute('aria-labelledby')).toBe('cinder-tab-b');
+    // Ids are namespaced by the root Tabs instance's $props.id() baseId so that
+    // sibling Tabs sharing a value do not collide; the value-suffix is stable
+    // and the panel's labelledby points back at the matching tab in the same
+    // instance (same baseId prefix).
+    expect(panel?.id).toMatch(/-panel-b$/);
+    expect(panel?.getAttribute('aria-labelledby')).toMatch(/-tab-b$/);
+    const panelBase = panel?.id.replace(/-panel-b$/, '');
+    const labelBase = panel?.getAttribute('aria-labelledby')?.replace(/-tab-b$/, '');
+    expect(panelBase).toBe(labelBase);
+    expect(panelBase).toBeTruthy();
   });
 
   test('the rendered panel id matches the active tab aria-controls', () => {

--- a/packages/components/src/components/tab/tab.svelte
+++ b/packages/components/src/components/tab/tab.svelte
@@ -35,11 +35,12 @@
   }
   const tabs: TabsContext = rawTabs;
 
-  // Derive both ids from `value` so TabPanel can independently compute the
-  // same id without coordinating through context. Consumers can still override
-  // the tab id via the `id` prop; the panel id stays deterministic.
-  const tabId = $derived(id ?? `cinder-tab-${value}`);
-  const panelId = $derived(`cinder-tab-panel-${value}`);
+  // Derive both ids from the root's baseId and the tab's value so that two
+  // Tabs instances sharing the same value produce distinct DOM ids. Consumers
+  // can still override the tab id via the `id` prop; the panel id stays
+  // deterministic and namespace-scoped to this Tabs instance.
+  const tabId = $derived(id ?? `${tabs.baseId}-tab-${value}`);
+  const panelId = $derived(`${tabs.baseId}-panel-${value}`);
 
   const isActive = $derived(tabs.isActive(value));
   const isFocusable = $derived(tabs.isFocusable(value));

--- a/packages/components/src/components/tab/tab.svelte
+++ b/packages/components/src/components/tab/tab.svelte
@@ -36,9 +36,17 @@
   const tabs: TabsContext = rawTabs;
 
   // Derive both ids from the root's baseId and the tab's value so that two
-  // Tabs instances sharing the same value produce distinct DOM ids. Consumers
-  // can still override the tab id via the `id` prop; the panel id stays
-  // deterministic and namespace-scoped to this Tabs instance.
+  // Tabs instances sharing the same value produce distinct DOM ids. The panel
+  // id is always computed from baseId and value; it does not track a custom
+  // `id` prop on this Tab.
+  //
+  // ⚠️  Known limitation: if you supply a custom `id` prop to override this
+  // Tab's element id, the paired TabPanel's `aria-labelledby` will still point
+  // at the baseId-derived id (e.g. `${baseId}-tab-${value}`) — which will no
+  // longer match the button's id. This breaks the ARIA tab→panel relationship
+  // for the custom-id case. If you need a custom id, you must also set a
+  // matching `aria-labelledby` on the TabPanel manually. Removing the custom
+  // `id` override restores automatic wiring.
   const tabId = $derived(id ?? `${tabs.baseId}-tab-${value}`);
   const panelId = $derived(`${tabs.baseId}-panel-${value}`);
 

--- a/packages/components/src/components/tab/tab.test.ts
+++ b/packages/components/src/components/tab/tab.test.ts
@@ -30,12 +30,19 @@ describe('Tab', () => {
     ).toThrow(/must be used inside a Tabs component/);
   });
 
-  test('each Tab carries role="tab" and a stable id', () => {
+  test('each Tab carries role="tab" and a per-instance, value-suffixed id', () => {
     const { container } = render(Wrapper, { value: 'a', items });
     const tabs = Array.from(container.querySelectorAll('[role="tab"]'));
     expect(tabs).toHaveLength(2);
-    expect(tabs[0]?.id).toBe('cinder-tab-a');
-    expect(tabs[1]?.id).toBe('cinder-tab-b');
+    // Ids are namespaced by the root Tabs instance's $props.id() baseId so that
+    // sibling Tabs sharing a value do not collide; the per-tab suffix is stable.
+    expect(tabs[0]?.id).toMatch(/-tab-a$/);
+    expect(tabs[1]?.id).toMatch(/-tab-b$/);
+    // Both tabs share the same instance base id (everything before the suffix).
+    const baseA = tabs[0]?.id.replace(/-tab-a$/, '');
+    const baseB = tabs[1]?.id.replace(/-tab-b$/, '');
+    expect(baseA).toBe(baseB);
+    expect(baseA).toBeTruthy();
   });
 
   test('aria-selected and roving tabindex respond to the active value', () => {
@@ -56,6 +63,10 @@ describe('Tab', () => {
   test('aria-controls points at the matching panel id', () => {
     const { container } = render(Wrapper, { value: 'a', items });
     const tab = container.querySelector('[role="tab"][aria-selected="true"]');
-    expect(tab?.getAttribute('aria-controls')).toBe('cinder-tab-panel-a');
+    const ariaControls = tab?.getAttribute('aria-controls');
+    // The panel id is namespaced by the same per-instance baseId and suffixed
+    // with the active value; it must resolve to a real element in the document.
+    expect(ariaControls).toMatch(/-panel-a$/);
+    expect(container.querySelector(`#${ariaControls}`)).not.toBeNull();
   });
 });

--- a/packages/components/src/components/tab/tab.test.ts
+++ b/packages/components/src/components/tab/tab.test.ts
@@ -70,6 +70,8 @@ describe('Tab', () => {
     // The panel id is namespaced by the same per-instance baseId and suffixed
     // with the active value; it must resolve to a real element in the document.
     expect(ariaControls).toMatch(/-panel-a$/);
-    expect(container.querySelector(`#${ariaControls}`)).not.toBeNull();
+    // ids include a $props.id()-generated baseId which can contain characters
+    // that need escaping in a CSS selector, so escape before querying.
+    expect(container.querySelector(`#${CSS.escape(ariaControls!)}`)).not.toBeNull();
   });
 });

--- a/packages/components/src/components/tab/tab.test.ts
+++ b/packages/components/src/components/tab/tab.test.ts
@@ -43,6 +43,9 @@ describe('Tab', () => {
     const baseB = tabs[1]?.id.replace(/-tab-b$/, '');
     expect(baseA).toBe(baseB);
     expect(baseA).toBeTruthy();
+    // Guard against a regression that re-introduces a hardcoded global prefix
+    // like 'cinder-tab' — the whole point is that the base is per-instance.
+    expect(baseA).not.toBe('cinder-tab');
   });
 
   test('aria-selected and roving tabindex respond to the active value', () => {

--- a/packages/components/src/components/tabs/tabs.svelte
+++ b/packages/components/src/components/tabs/tabs.svelte
@@ -25,6 +25,8 @@
   import { handleRovingKeydown, isRovingKey } from '../../utilities/roving-tabindex.ts';
   import { classNames } from '../../utilities/class-names.ts';
 
+  const baseId = $props.id();
+
   let {
     value = $bindable(''),
     orientation = 'horizontal',
@@ -168,6 +170,9 @@
     },
     get activateOnFocus() {
       return effectiveActivateOnFocus;
+    },
+    get baseId() {
+      return baseId;
     },
     select(next) {
       value = next;

--- a/packages/components/src/components/tabs/tabs.test.ts
+++ b/packages/components/src/components/tabs/tabs.test.ts
@@ -10,6 +10,7 @@ const { render, fireEvent } = await import('@testing-library/svelte');
 const { default: Wrapper } = await import('../../test/fixtures/tabs-fixture.svelte');
 const { default: TrailingWrapper } =
   await import('../../test/fixtures/tabs-trailing-fixture.svelte');
+const { default: SiblingWrapper } = await import('../../test/fixtures/tabs-sibling-fixture.svelte');
 
 const tabsCss = readFileSync(new URL('./tabs.css', import.meta.url), 'utf8');
 
@@ -626,6 +627,74 @@ describe('Tab data-variant reflects tabs orientation', () => {
     const tabs = Array.from(container.querySelectorAll('[role="tab"]'));
     for (const tab of tabs) {
       expect(tab.getAttribute('data-variant')).toBe('vertical');
+    }
+  });
+});
+
+describe('Tabs sibling id isolation', () => {
+  test('two Tabs sharing a value produce distinct panel ids and tab ids', () => {
+    // Regression for: tab/panel ids were derived from value alone (e.g.
+    // `cinder-tab-panel-overview`) which collided across sibling Tabs instances,
+    // causing aria-controls to resolve to the first matching element in tree
+    // order rather than the panel in the same Tabs instance.
+    const { container } = render(SiblingWrapper, { sharedValue: 'overview' });
+
+    // Collect all tab buttons and panels that carry the shared value.
+    const allTabs = Array.from(container.querySelectorAll('[role="tab"]'));
+    const allPanels = Array.from(container.querySelectorAll('[role="tabpanel"]'));
+
+    // Both Tabs instances are active on the shared value, so both panels are
+    // rendered. There must be exactly two panels visible.
+    expect(allPanels.length).toBe(2);
+
+    // Collect every id present in the document — ids must be unique.
+    const tabIds = allTabs.map((tab) => tab.getAttribute('id')).filter(Boolean) as string[];
+    const panelIds = allPanels.map((panel) => panel.getAttribute('id')).filter(Boolean) as string[];
+
+    // No duplicate ids anywhere in the document.
+    expect(new Set(tabIds).size).toBe(tabIds.length);
+    expect(new Set(panelIds).size).toBe(panelIds.length);
+
+    // Each Tab's aria-controls must point to the panel in ITS OWN Tabs instance.
+    // Find the two "overview" tab buttons (one per Tabs instance).
+    const overviewTabs = allTabs.filter(
+      (tab) => tab.getAttribute('data-cinder-value') === 'overview',
+    );
+    expect(overviewTabs.length).toBe(2);
+
+    for (const overviewTab of overviewTabs) {
+      const ariaControls = overviewTab.getAttribute('aria-controls');
+      expect(ariaControls).not.toBeNull();
+
+      // The panel pointed at by aria-controls must exist exactly once in the DOM.
+      const targetPanels = container.querySelectorAll(`#${CSS.escape(ariaControls!)}`);
+      expect(targetPanels.length).toBe(1);
+
+      // That panel must be inside the same Tabs root as the tab button itself.
+      const tabsRoot = overviewTab.closest('.cinder-tabs');
+      expect(tabsRoot).not.toBeNull();
+      expect(tabsRoot!.contains(targetPanels[0]!)).toBe(true);
+    }
+  });
+
+  test('aria-labelledby on each panel points back to its own tab (cross-instance safety)', () => {
+    const { container } = render(SiblingWrapper, { sharedValue: 'overview' });
+
+    const allPanels = Array.from(container.querySelectorAll('[role="tabpanel"]'));
+    expect(allPanels.length).toBe(2);
+
+    for (const panel of allPanels) {
+      const labelledBy = panel.getAttribute('aria-labelledby');
+      expect(labelledBy).not.toBeNull();
+
+      // The tab referenced by aria-labelledby must exist exactly once.
+      const referencedTabs = container.querySelectorAll(`#${CSS.escape(labelledBy!)}`);
+      expect(referencedTabs.length).toBe(1);
+
+      // The referenced tab must live in the same Tabs root as the panel.
+      const tabsRoot = panel.closest('.cinder-tabs');
+      expect(tabsRoot).not.toBeNull();
+      expect(tabsRoot!.contains(referencedTabs[0]!)).toBe(true);
     }
   });
 });

--- a/packages/components/src/components/tabs/tabs.types.ts
+++ b/packages/components/src/components/tabs/tabs.types.ts
@@ -18,6 +18,13 @@ export type TabsContext = {
   readonly orientation: TabsOrientation;
   /** Whether focus movement also activates a tab (per WAI-ARIA pattern). */
   readonly activateOnFocus: boolean;
+  /**
+   * Per-root base id used to namespace tab and panel ids so that two Tabs
+   * instances sharing the same tab value do not produce duplicate DOM ids.
+   * Derived ids take the form `${baseId}-tab-${value}` and
+   * `${baseId}-panel-${value}`.
+   */
+  readonly baseId: string;
   /** Activate a tab by value. */
   select: (next: string) => void;
   /** True when `candidate` is the active tab. */

--- a/packages/components/src/test/fixtures/radio-group-fixture.svelte
+++ b/packages/components/src/test/fixtures/radio-group-fixture.svelte
@@ -7,6 +7,7 @@
     description?: string;
     error?: string;
     disabled?: boolean;
+    required?: boolean;
     variant?: 'default' | 'card';
     options: Array<{
       id: string;
@@ -31,6 +32,7 @@
     description,
     error,
     disabled = false,
+    required = false,
     variant,
     options,
   }: RadioGroupFixtureProps = $props();
@@ -44,6 +46,7 @@
   {...error !== undefined ? { error } : {}}
   {...variant !== undefined ? { variant } : {}}
   {disabled}
+  {required}
 >
   {#each options as option (option.id)}
     <Radio

--- a/packages/components/src/test/fixtures/tabs-sibling-fixture.svelte
+++ b/packages/components/src/test/fixtures/tabs-sibling-fixture.svelte
@@ -1,0 +1,33 @@
+<script lang="ts" module>
+  /** Test-only fixture rendering two independent Tabs instances sharing a common tab value. */
+  export type TabsSiblingFixtureProps = {
+    sharedValue: string;
+  };
+</script>
+
+<script lang="ts">
+  import Tab from '../../components/tab/tab.svelte';
+  import TabList from '../../components/tab-list/tab-list.svelte';
+  import TabPanel from '../../components/tab-panel/tab-panel.svelte';
+  import Tabs from '../../components/tabs/tabs.svelte';
+
+  let { sharedValue }: TabsSiblingFixtureProps = $props();
+</script>
+
+<Tabs value={sharedValue}>
+  <TabList label="First tabs">
+    <Tab value={sharedValue}>First {sharedValue}</Tab>
+    <Tab value="other-first">Other First</Tab>
+  </TabList>
+  <TabPanel value={sharedValue}>First {sharedValue} panel</TabPanel>
+  <TabPanel value="other-first">First other panel</TabPanel>
+</Tabs>
+
+<Tabs value={sharedValue}>
+  <TabList label="Second tabs">
+    <Tab value={sharedValue}>Second {sharedValue}</Tab>
+    <Tab value="other-second">Other Second</Tab>
+  </TabList>
+  <TabPanel value={sharedValue}>Second {sharedValue} panel</TabPanel>
+  <TabPanel value="other-second">Second other panel</TabPanel>
+</Tabs>


### PR DESCRIPTION
## Summary

Fixes 9 user-visible correctness and accessibility defects identified in `docs/audits/svelte-5-audit-2026-06-02.md` (task **0419a325**). Each bug is fixed at the root with a regression test. Scoped narrowly to the named defect — does NOT migrate `useId()→$props.id()` (task 090408fa) or `setContext→createContext` (task 9691a8d6); those remain separate audit-cohort tasks.

| # | Component | Defect | Fix |
|---|-----------|--------|-----|
| 1 | command-menu | per-item `onselect` silently dropped on activation | call `record.getOnselect()()` before menu-level prop |
| 2 | radio-group | `required` never reached child inputs | forwarded via `RadioGroupContext` + `aria-required` on fieldset + native `required` on inputs |
| 3 | review-editor | `original` mutated in `setState` without `$bindable` | marked `$bindable`, forwarded in wrapper |
| 4 | dropdown-item | `handleKeydown` re-implemented native button activation (double-fire) | deleted handler; `tabindex=-1` for roving-focus model |
| 5 | kanban-board | column handle Space/Enter caused lift-then-immediate-drop | removed idle Space/Enter from keydown handler; lift driven by native click |
| 6 | grid-list-item | `href` without `title` = inaccessible stretched-link; event/role/tabindex leaked onto `<li>` | `title` required on linked variant; disallowed attrs omitted at type level |
| 7 | tabs | value-derived ids collide across sibling Tabs instances | per-root `$props.id()` `baseId` via `TabsContext` |
| 8 | navigation-item | button arm uses `aria-disabled` not native `disabled` | added native `disabled`; disabled anchor drops `href` + `tabindex=-1` |
| 9 | diff-viewer | hardcoded `id="front-matter"` collides across instances | derived per-instance id from `$props.id()` |

**Test fallout fixed (same PR, caused by the above):**
- `dropdown` + `context-menu` tests relied on dropdown-item's removed synthetic click; switched to `fireEvent.click()`.
- `tab` + `tab-panel` per-component tests asserted old literal id format; updated to regex/relational assertions.
- `check-platform-features.test.ts` full-tree-scan timeout bumped 30s→90s (timeout flake under CPU saturation, never an assertion failure).

**Breaking changes (pre-1.0 context types):**
`TabsContext` and `RadioGroupContext` are publicly exported. This PR adds required fields (`baseId: string` and `required: boolean` respectively). Any consumer who constructs these types as object literals will get a compile error until the new field is added. Both additions are correct and necessary; this is MVP hardening, not a stable-API release.

## Review committee

Pre-reviewed by: svelte-expert, typescript-expert, ux-designer, testing-expert, junior-engineer, simplicity-engineer, Codex (gpt-5.4, xhigh reasoning)
- 1 round of review
- All must-fix items addressed:
  - kanban: `stopPropagation()` removed (inert); `preventDefault()` is what suppresses synthesized click; comment corrected
  - tabs: JSDoc warning added to `Tab` documenting that custom `id` prop breaks `aria-labelledby` wiring (pre-existing gap, not introduced by this PR)
  - navigation-item: HTML comment added documenting the href-strip-on-disable product decision
  - tab.test.ts: added `not.toBe('cinder-tab')` guard against legacy literal regression
  - `aria-required` lint: existing `svelte-ignore a11y_role_supports_aria_props_implicit` at fieldset level already covers it (no change needed)
- Codex overrides (2): grid-list-item runtime safeRest (type-level is the correct/stated audit fix; simplicity-engineer approved); nav-item anchor revert (audit explicitly recommends href-strip as [high] a11y fix; ux-designer confirmed as defensible product choice)

## Test plan

All gates verified locally:
- `bun run --filter=cinder typecheck` — 0 errors
- `bun run --filter=cinder lint` — 0 errors
- `bun run --filter=cinder test` — 4257 tests, 0 failures (on rebase onto #257)
- `bun run --filter=cinder components:check` — OK
- `bun run --filter=cinder exports:check` — OK (not a public export-surface change)

Key test coverage added:
- radio-group: 3 new tests verifying `required` propagates to inputs and `aria-required` to fieldset
- tabs: sibling-fixture renders two Tabs sharing a value; asserts `aria-controls` resolves within its own root
- diff-viewer: multi-instance + source-guard tests for id non-collision
- dropdown-item: keydown-no-fire + tabindex=-1 tests
- kanban: lift-then-drop regression (keyDown(Space) + click, assert stays lifted)
- navigation-item: native `disabled` on button arm; `tabindex=-1` + no `href` on disabled anchor

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches keyboard activation, form required state, exported context shapes, and disabled-link semantics across many stable components; compile-time breaks for manual context literals.
> 
> **Overview**
> Fixes **nine standalone correctness bugs** in the Cinder component library (Svelte 5 audit), each with targeted code changes and regression tests.
> 
> **Behavior & a11y:** `command-menu` now invokes per-item `onselect` before the menu callback (aligned with command-palette). `radio-group` propagates `required` to inputs and `aria-required` on the fieldset. `review-editor` makes `original` **`$bindable`** so `setState` updates reach parents. `dropdown-item` drops synthetic Enter/Space→click (fixes double activation) and uses **`tabindex={-1}`** for roving focus; related menu tests use explicit clicks under happy-dom.
> 
> **Keyboard & IDs:** `kanban-board` column reorder no longer lift-then-drop on Space (idle keydown removed; native click lifts; `preventDefault` on drop). **`Tabs`** namespaces tab/panel DOM ids via per-root **`baseId`** from `$props.id()` (fixes collisions when two tab sets share values). `diff-viewer` passes instance-scoped front-matter ids instead of a shared literal.
> 
> **Types & nav:** `grid-list-item` requires **`title`** when `href` is set; blocks `onclick`/`role`/`tabindex` on the list item; documents `class` in schema. `navigation-item` uses native **`disabled`** on buttons; disabled links lose **`href`** and get **`tabindex={-1}`**.
> 
> **Tests/infra:** Platform feature scan timeout **30s → 90s** under CPU load. **Breaking (pre-1.0):** exported `TabsContext` gains `baseId`; `RadioGroupContext` gains `required`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fe87de25c5309e921ea63d44cc8b2b4b5e2f5255. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->