### PR TITLE
fix(playground): allowlist chat interactive-harness raw controls

### DIFF
--- a/packages/playground/scripts/check-raw-native-controls.ts
+++ b/packages/playground/scripts/check-raw-native-controls.ts
@@ -148,6 +148,34 @@ export const ALLOWLIST: AllowlistEntry[] = [
     reason:
       'CommandPalette requires a triggerRef (HTMLElement) for focus-return. The trigger button uses bind:this to capture the element reference for that purpose. It also applies heavy inline styles that exist to demo the styled-keyboard-shortcut pattern; until the example is rewritten with a styled Cinder Button, the raw element is intentional.',
   },
+  {
+    relativePath: 'chat/interactive-harness.example.svelte',
+    tagName: 'textarea',
+    occurrenceIndex: 0,
+    reason:
+      'The interactive harness is test instrumentation, not exemplary consumer usage — its control panel drives the Chat component under Playwright to exercise every callback. This is the "reply text" input bound to local harness state; a raw textarea keeps the harness decoupled from the components it tests.',
+  },
+  {
+    relativePath: 'chat/interactive-harness.example.svelte',
+    tagName: 'textarea',
+    occurrenceIndex: 1,
+    reason:
+      'Harness control-panel input ("tool arguments" JSON editor) bound to local state to inject tool calls into the Chat component under test. Intentionally raw test instrumentation, not a usage example.',
+  },
+  {
+    relativePath: 'chat/interactive-harness.example.svelte',
+    tagName: 'input',
+    occurrenceIndex: 0,
+    reason:
+      'Harness control-panel input ("tool name") bound to local state to inject tool calls into the Chat component under test. Intentionally raw test instrumentation, not a usage example.',
+  },
+  {
+    relativePath: 'chat/interactive-harness.example.svelte',
+    tagName: 'button',
+    occurrenceIndex: 0,
+    reason:
+      'Harness message-action control rendered into Chat’s messageActions snippet to verify callback wiring under Playwright. Intentionally raw test instrumentation, not a usage example.',
+  },
 ];
 
 // ── Comment/String Stripping ───────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

The example-guard (`check-raw-native-controls --strict`, from #261) flags 4 raw native controls in `chat/interactive-harness.example.svelte` — 2 textareas, 1 input, 1 button — that #260 added without allowlisting. This **fails the guard's gating test**, which blocks every `cinder` PR's push: `cinder` is a dependency of `@cinder/playground`, so the pre-push hook validates playground as a touched dependent on any cinder change.

These 4 controls are **test instrumentation**: the harness is a control panel that drives the Chat component under Playwright to exercise every callback. Keeping them raw (rather than Cinder primitives) intentionally decouples the harness from the components it tests. This is exactly the "genuinely intentional raw control" case the allowlist exists for.

## What changed

Added 4 entries to the `ALLOWLIST` array in `check-raw-native-controls.ts`, keyed by `relativePath + tagName + occurrenceIndex`, each with a documented reason — matching the existing nav-bar / popover / command-palette entries. The example file itself is **untouched**.

Used the array (not inline `<!-- examples-audit-allow -->` markers) deliberately: inline markers are honored regardless of the passed allowlist, which would break the `respects a custom empty allowlist (nothing is allowlisted)` test (`scan(dir, []) → 0 allowlisted`). Array entries zero out correctly under an empty allowlist.

## Test plan

- `bun run packages/playground/scripts/check-raw-native-controls.ts --strict` → 0 flagged, 7 allowlisted, exit 0
- `bun run --filter=@cinder/playground test -- check-raw-native-controls` → 561 pass, 0 fail (the previously-failing gating test and the empty-allowlist invariant test both pass)

## Note

This is a focused infra-unblock, not a feature change. The right longer-term fix may be to replace the harness controls with Cinder primitives (Textarea/Input/Button all support bind:value + data-* passthrough), but that risks #260's Playwright selectors and is out of scope here.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Infra-only allowlist additions in an audit script; no runtime product or auth/data paths change.
> 
> **Overview**
> Adds **four `ALLOWLIST` entries** in `check-raw-native-controls.ts` for raw `<textarea>`, `<input>`, and `<button>` controls in `chat/interactive-harness.example.svelte`, so `examples:audit --strict` no longer fails on that Playwright harness.
> 
> Each entry uses `relativePath` + `tagName` + `occurrenceIndex` with a documented reason (test instrumentation, not consumer examples). The harness `.svelte` file is **unchanged**; only the audit script is updated to unblock dependent-repo validation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1b7c0abbebba61d36e6f3f649e8cbdb7221e0718. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->