### PR TITLE
refactor(components): migrate raw Symbol contexts to createContext (task 9691a8d6)

### DIFF
--- a/packages/components/AGENTS.md
+++ b/packages/components/AGENTS.md
@@ -510,6 +510,35 @@ Dropdown/DropdownTrigger/DropdownMenu/…). For these families:
   demonstrate `Parent.Leaf` composition and list every namespaced leaf in
   their `Subcomponents` region. Leaf READMEs point back at the parent for
   composed usage instead of duplicating a standalone snippet.
+- **Context uses `createContext`, never raw `Symbol` keys.** Define the
+  family's context in a dedicated `*-context.ts` module (`<family>.context.ts`
+  beside the parent, or `_internal/<family>-context.ts` for shared internals)
+  with Svelte's `createContext<T>()`:
+
+  ```ts
+  import { createContext } from 'svelte';
+
+  export type FooContext = {
+    /* … */
+  };
+
+  const [getFooContextStrict, setFooContext] = createContext<FooContext>();
+  export { setFooContext };
+  // Required (a leaf outside its parent is a programmer error): export the
+  // strict getter directly — it throws automatically on a missing provider.
+  export const getFooContext = getFooContextStrict;
+  // Optional (a leaf may legitimately run with no provider): wrap with
+  // optionalContext so a missing provider yields `undefined` instead of throwing.
+  // export const tryGetFooContext = optionalContext(getFooContextStrict);
+  ```
+
+  Do **not** hand-roll `setContext<T>(SYMBOL, …)` / `getContext<T | undefined>(SYMBOL)`
+  with a manual `if (!ctx) throw` — `createContext` provides the typed get/set
+  pair and the throw-on-missing-provider guard for you, and consumers get
+  compile-time narrowing without the `rawCtx`→`ctx` two-step cast. The Symbol
+  key must not be exported from the family barrel. See `tabs/tabs-context.ts`,
+  `dropdown/dropdown.context.ts`, and `_internal/side-navigation-group-context.ts`
+  (optional) for the canonical shapes.
 
 ### Generators
 

--- a/packages/components/src/_internal/toast-context.ts
+++ b/packages/components/src/_internal/toast-context.ts
@@ -1,7 +1,7 @@
 /**
  * Internal toast context shape, factored out of `toast-region.svelte` so that
  * plain `.ts` consumers (the `useToast` hook in `src/utilities/use-toast.ts`)
- * can import the symbol key and types without going through the `.svelte`
+ * can import the context accessors and types without going through the `.svelte`
  * module path. The ambient `*.svelte` declaration only exposes the default
  * export to plain TS, so any context bridge needs a `.ts` home.
  *
@@ -10,9 +10,7 @@
  */
 
 import type { Snippet } from 'svelte';
-
-/** Symbol key for the toast Svelte context. */
-export const TOAST_CONTEXT_KEY = Symbol('cinder-toast');
+import { createContext } from 'svelte';
 
 /** Toast variant — drives both visual treatment and live-region routing. */
 export type ToastVariant = 'info' | 'success' | 'warning' | 'danger';
@@ -89,3 +87,16 @@ export type ToastApi = {
     } & Pick<ToastOptions, 'id' | 'duration' | 'dismissible' | 'action'>,
   ) => string;
 };
+
+const [getToastContextStrict, setToastContext] = createContext<ToastApi>();
+
+export { setToastContext };
+
+/**
+ * Returns the toast API from the nearest enclosing `<ToastRegion />`.
+ *
+ * Throws when no `<ToastRegion />` ancestor has called `setToastContext` —
+ * a missing region is always a programmer error, never a valid runtime state.
+ * `createContext`'s strict getter provides this guarantee automatically.
+ */
+export const getToastContext = getToastContextStrict;

--- a/packages/components/src/_internal/tree-context.ts
+++ b/packages/components/src/_internal/tree-context.ts
@@ -1,4 +1,7 @@
+import { createContext } from 'svelte';
+
 import type { TreeSelectionState } from '../components/tree/tree-selection.ts';
+import { optionalContext } from './optional-context.ts';
 import type { TreeNodeRegistration } from './tree-registry.svelte.ts';
 
 // Inline the selection mode type here to avoid a circular import with
@@ -16,7 +19,7 @@ export type TreeItemSelectionState = TreeSelectionState;
  * rune-only constraint on `.svelte.ts` files.
  *
  * The context object itself lives in `tree.svelte` (instance block); this file
- * only holds the shared type.
+ * only holds the shared type and the typed context handles.
  */
 export type TreeContext = {
   readonly selectionMode: TreeSelectionMode;
@@ -62,3 +65,26 @@ export type TreeItemParentContext = {
   parentId: string | null;
   level: number;
 };
+
+const [getTreeContextStrict, setTreeContextRaw] = createContext<TreeContext>();
+
+export { setTreeContextRaw as setTreeContext };
+
+/**
+ * Required read — a TreeItem or TreeSelectAll outside a Tree is a programmer
+ * error; the strict getter throws automatically when no provider exists.
+ */
+export const getTreeContext: () => TreeContext = getTreeContextStrict;
+
+const [getTreeItemParentContextStrict, setTreeItemParentContextRaw] =
+  createContext<TreeItemParentContext>();
+
+export { setTreeItemParentContextRaw as setTreeItemParentContext };
+
+/**
+ * Optional read — a TreeItem at the root level has no TreeItem parent provider;
+ * a missing context is a valid state (top-level item, parentId = null, level = 1).
+ */
+export const tryGetTreeItemParentContext: () => TreeItemParentContext | undefined = optionalContext(
+  getTreeItemParentContextStrict,
+);

--- a/packages/components/src/components/_radio/radio.svelte
+++ b/packages/components/src/components/_radio/radio.svelte
@@ -17,13 +17,9 @@
 
 <script lang="ts">
   import type { RadioProps } from './radio.types.ts';
-  import { getContext } from 'svelte';
 
   import { ariaInvalid, composeDescribedBy, describeId } from '../../_internal/field-control.ts';
-  import {
-    RADIO_GROUP_CONTEXT_KEY,
-    type RadioGroupContext,
-  } from '../radio-group/radio-group.svelte';
+  import { getRadioGroupContext } from '../radio-group/radio-group-context.ts';
   import { cn } from '../../utilities/class-names.ts';
 
   let {
@@ -37,11 +33,7 @@
     ...rest
   }: RadioProps = $props();
 
-  const rawGroup = getContext<RadioGroupContext | undefined>(RADIO_GROUP_CONTEXT_KEY);
-  if (!rawGroup) {
-    throw new Error('Radio must be used inside a RadioGroup component.');
-  }
-  const group: RadioGroupContext = rawGroup;
+  const group = getRadioGroupContext();
 
   const checked = $derived(group.value === value);
   const effectiveDisabled = $derived(disabled ?? group.disabled);

--- a/packages/components/src/components/_radio/radio.test.ts
+++ b/packages/components/src/components/_radio/radio.test.ts
@@ -26,7 +26,7 @@ describe('Radio', () => {
           children: createRawSnippet(() => ({ render: () => '<span></span>', setup: () => {} })),
         },
       }),
-    ).toThrow();
+    ).toThrow(/missing_context/);
   });
 
   test('renders a native <input type="radio"> per option sharing the group name', () => {

--- a/packages/components/src/components/_radio/radio.test.ts
+++ b/packages/components/src/components/_radio/radio.test.ts
@@ -26,7 +26,7 @@ describe('Radio', () => {
           children: createRawSnippet(() => ({ render: () => '<span></span>', setup: () => {} })),
         },
       }),
-    ).toThrow(/must be used inside a RadioGroup component/);
+    ).toThrow();
   });
 
   test('renders a native <input type="radio"> per option sharing the group name', () => {

--- a/packages/components/src/components/_tree-select-all/tree-select-all.svelte
+++ b/packages/components/src/components/_tree-select-all/tree-select-all.svelte
@@ -16,11 +16,9 @@
 </script>
 
 <script lang="ts">
-  import { getContext } from 'svelte';
-
   import type { TreeContext } from '../../_internal/tree-context.ts';
+  import { getTreeContext } from '../../_internal/tree-context.ts';
   import { classNames } from '../../utilities/class-names.ts';
-  import { TREE_CONTEXT_KEY } from '../tree/tree.svelte';
   import type { TreeSelectAllProps } from './tree-select-all.types.ts';
 
   let {
@@ -32,11 +30,7 @@
     class: className,
   }: TreeSelectAllProps = $props();
 
-  const treeContext = getContext<TreeContext | undefined>(TREE_CONTEXT_KEY);
-  if (!treeContext) {
-    throw new Error('TreeSelectAll must be rendered from a Tree selectionControls snippet.');
-  }
-  const context = treeContext;
+  const context: TreeContext = getTreeContext();
 
   const disabled = $derived(
     !context.multiselectable || !context.hasSelectableSelectionScope(parentId, includeDescendants),

--- a/packages/components/src/components/accordion-item/accordion-item.svelte
+++ b/packages/components/src/components/accordion-item/accordion-item.svelte
@@ -15,20 +15,13 @@
 </script>
 
 <script lang="ts">
-  import { getContext } from 'svelte';
-
-  import { ACCORDION_CONTEXT_KEY } from '../accordion/accordion.context.ts';
-  import type { AccordionContext } from '../accordion/accordion.types.ts';
+  import { getAccordionContext } from '../accordion/accordion.context.ts';
   import { classNames } from '../../utilities/class-names.ts';
   import type { AccordionItemProps } from './accordion-item.types.ts';
 
   let { id, title, disabled = false, class: className, children }: AccordionItemProps = $props();
 
-  const rawContext = getContext<AccordionContext | undefined>(ACCORDION_CONTEXT_KEY);
-  if (!rawContext) {
-    throw new Error('AccordionItem must be used inside an Accordion component.');
-  }
-  const context: AccordionContext = rawContext;
+  const context = getAccordionContext();
 
   const isExpanded = $derived(context.expandedIds.includes(id));
 

--- a/packages/components/src/components/accordion-item/accordion-item.test.ts
+++ b/packages/components/src/components/accordion-item/accordion-item.test.ts
@@ -100,7 +100,7 @@ test('throws if rendered outside an Accordion', () => {
         })),
       },
     });
-  }).toThrow(/Context was not set in a parent component/);
+  }).toThrow(/missing_context/);
 });
 
 describe('AccordionItem', () => {

--- a/packages/components/src/components/accordion-item/accordion-item.test.ts
+++ b/packages/components/src/components/accordion-item/accordion-item.test.ts
@@ -23,7 +23,7 @@ function textSnippet(text: string) {
 
 /**
  * Render a single AccordionItem inside an Accordion so the Svelte context is
- * established before AccordionItem calls `getContext`.
+ * established before AccordionItem calls `getAccordionContext`.
  *
  * `createRawSnippet` render must return a single-root element; we use a
  * wrapper div and mount AccordionItem into it via Svelte's `mount`.
@@ -88,7 +88,7 @@ function renderItem(options: {
 // ---------------------------------------------------------------------------
 
 test('throws if rendered outside an Accordion', () => {
-  // No Accordion context set — getContext() returns undefined
+  // No Accordion context set — createContext strict getter throws
   expect(() => {
     render(AccordionItem, {
       props: {
@@ -100,7 +100,7 @@ test('throws if rendered outside an Accordion', () => {
         })),
       },
     });
-  }).toThrow(/must be used inside an Accordion/);
+  }).toThrow(/Context was not set in a parent component/);
 });
 
 describe('AccordionItem', () => {

--- a/packages/components/src/components/accordion/accordion.context.ts
+++ b/packages/components/src/components/accordion/accordion.context.ts
@@ -1,2 +1,16 @@
-/** Symbol key for the accordion Svelte context. */
-export const ACCORDION_CONTEXT_KEY = Symbol('cinder-accordion');
+import { createContext } from 'svelte';
+
+import type { AccordionContext } from './accordion.types.ts';
+
+export type { AccordionContext };
+
+const [getAccordionContextStrict, setAccordionContext] = createContext<AccordionContext>();
+
+export { setAccordionContext };
+
+/**
+ * Read the nearest enclosing `<Accordion>` context. Throws when no `<Accordion>`
+ * ancestor has provided the context — an `<AccordionItem>` outside an `<Accordion>`
+ * is a programmer error, not a supported state.
+ */
+export const getAccordionContext = getAccordionContextStrict;

--- a/packages/components/src/components/accordion/accordion.svelte
+++ b/packages/components/src/components/accordion/accordion.svelte
@@ -12,17 +12,14 @@
    * @avoidWhen Hiding a single optional region — use a plain disclosure or details element.
    * @related accordion-item, tabs, tree
    */
-  export { ACCORDION_CONTEXT_KEY } from './accordion.context.ts';
   export type { AccordionContext, AccordionProps } from './accordion.types.ts';
 </script>
 
 <script lang="ts">
-  import { setContext } from 'svelte';
-
   import { createMultiSelection } from '../../_internal/collection.ts';
   import { classNames } from '../../utilities/class-names.ts';
-  import { ACCORDION_CONTEXT_KEY } from './accordion.context.ts';
-  import type { AccordionContext, AccordionProps } from './accordion.types.ts';
+  import { setAccordionContext } from './accordion.context.ts';
+  import type { AccordionProps } from './accordion.types.ts';
 
   let {
     multiple = false,
@@ -49,7 +46,7 @@
     }
   }
 
-  setContext<AccordionContext>(ACCORDION_CONTEXT_KEY, {
+  setAccordionContext({
     get expandedIds() {
       return expandedIds;
     },

--- a/packages/components/src/components/accordion/index.ts
+++ b/packages/components/src/components/accordion/index.ts
@@ -12,6 +12,5 @@ const Accordion = Object.assign(AccordionRoot, {
 });
 
 export default Accordion;
-export { ACCORDION_CONTEXT_KEY } from './accordion.context.ts';
 export type { AccordionContext, AccordionItemProps, AccordionProps } from './accordion.types.ts';
 export { Accordion };

--- a/packages/components/src/components/context-menu-trigger/context-menu-trigger.svelte
+++ b/packages/components/src/components/context-menu-trigger/context-menu-trigger.svelte
@@ -17,17 +17,12 @@
 
 <script lang="ts">
   import type { ContextMenuTriggerProps } from './context-menu-trigger.types.ts';
-  import { getContext, hasContext, onDestroy } from 'svelte';
+  import { onDestroy } from 'svelte';
   import { classNames } from '../../utilities/class-names.ts';
-  import { DROPDOWN_REGISTER_TRIGGER } from '../dropdown/dropdown.context.ts';
-  import {
-    CONTEXT_MENU_CONTEXT,
-    type ContextMenuContext,
-  } from '../context-menu/context-menu.context.ts';
+  import { getDropdownRegisterTrigger } from '../dropdown/dropdown.context.ts';
+  import { getContextMenuContext } from '../context-menu/context-menu.context.ts';
 
-  if (!hasContext(DROPDOWN_REGISTER_TRIGGER) || !hasContext(CONTEXT_MENU_CONTEXT)) {
-    throw new Error('ContextMenu.Trigger must be used within a ContextMenu.');
-  }
+  const context = getContextMenuContext();
 
   let {
     class: className,
@@ -43,9 +38,7 @@
     ...rest
   }: ContextMenuTriggerProps = $props();
 
-  const registerTrigger =
-    getContext<(element: HTMLElement | null) => void>(DROPDOWN_REGISTER_TRIGGER);
-  const context = getContext<ContextMenuContext>(CONTEXT_MENU_CONTEXT);
+  const registerTrigger = getDropdownRegisterTrigger();
 
   let triggerElement = $state<HTMLDivElement | null>(null);
   let longPressTimer: ReturnType<typeof setTimeout> | undefined;

--- a/packages/components/src/components/context-menu-trigger/context-menu-trigger.test.ts
+++ b/packages/components/src/components/context-menu-trigger/context-menu-trigger.test.ts
@@ -39,7 +39,7 @@ describe('ContextMenuTrigger', () => {
           children: createRawSnippet(() => ({ render: () => '<span>x</span>', setup: () => {} })),
         },
       }),
-    ).toThrow();
+    ).toThrow(/missing_context/);
   });
 
   test('renders a trigger region wrapping its child content', () => {

--- a/packages/components/src/components/context-menu-trigger/context-menu-trigger.test.ts
+++ b/packages/components/src/components/context-menu-trigger/context-menu-trigger.test.ts
@@ -39,7 +39,7 @@ describe('ContextMenuTrigger', () => {
           children: createRawSnippet(() => ({ render: () => '<span>x</span>', setup: () => {} })),
         },
       }),
-    ).toThrow(/must be used within a ContextMenu/);
+    ).toThrow();
   });
 
   test('renders a trigger region wrapping its child content', () => {

--- a/packages/components/src/components/context-menu/context-menu.context.ts
+++ b/packages/components/src/components/context-menu/context-menu.context.ts
@@ -1,7 +1,18 @@
-export const CONTEXT_MENU_CONTEXT = Symbol('cinder-context-menu');
+import { createContext } from 'svelte';
 
 export type ContextMenuContext = {
   get disabled(): boolean;
   get longPressDelay(): number;
   openAt: (x: number, y: number) => void;
 };
+
+const [getContextMenuContextStrict, setContextMenuContext] = createContext<ContextMenuContext>();
+
+export { setContextMenuContext };
+
+/**
+ * Read the nearest enclosing `<ContextMenu>` context. Throws when no
+ * `<ContextMenu>` ancestor exists — using `<ContextMenuTrigger>` outside a
+ * provider is a programmer error.
+ */
+export const getContextMenuContext = getContextMenuContextStrict;

--- a/packages/components/src/components/context-menu/context-menu.svelte
+++ b/packages/components/src/components/context-menu/context-menu.svelte
@@ -17,20 +17,19 @@
 
 <script lang="ts">
   import type { ContextMenuProps } from './context-menu.types.ts';
-  import { setContext, tick } from 'svelte';
+  import { tick } from 'svelte';
   import type { VirtualElement } from '@floating-ui/dom';
   import { createAnchoredOverlay } from '../../_internal/anchored-overlay.svelte.ts';
   import { captureFocus } from '../../_internal/overlay.ts';
   import { classNames } from '../../utilities/class-names.ts';
   import { restoreFocusTo } from '../../utilities/focus.ts';
   import {
-    DROPDOWN_CONTEXT,
-    DROPDOWN_REGISTER,
-    DROPDOWN_REGISTER_TRIGGER,
-    DROPDOWN_SET_OPEN,
+    setDropdownContext,
+    setDropdownRegister,
+    setDropdownRegisterTrigger,
+    setDropdownSetOpen,
   } from '../dropdown/dropdown.context.ts';
-  import type { DropdownContext } from '../dropdown/dropdown.types.ts';
-  import { CONTEXT_MENU_CONTEXT, type ContextMenuContext } from './context-menu.context.ts';
+  import { setContextMenuContext } from './context-menu.context.ts';
 
   let {
     open = $bindable(false),
@@ -125,7 +124,7 @@
     close();
   }
 
-  setContext<DropdownContext>(DROPDOWN_CONTEXT, {
+  setDropdownContext({
     get menuId() {
       return menuId;
     },
@@ -141,10 +140,10 @@
     close,
     focusTrigger,
   });
-  setContext<(element: HTMLElement | null) => void>(DROPDOWN_REGISTER, registerMenu);
-  setContext<(element: HTMLElement | null) => void>(DROPDOWN_REGISTER_TRIGGER, registerTrigger);
-  setContext<(nextOpen: boolean) => void>(DROPDOWN_SET_OPEN, setOpen);
-  setContext<ContextMenuContext>(CONTEXT_MENU_CONTEXT, {
+  setDropdownRegister(registerMenu);
+  setDropdownRegisterTrigger(registerTrigger);
+  setDropdownSetOpen(setOpen);
+  setContextMenuContext({
     get disabled() {
       return disabled;
     },

--- a/packages/components/src/components/dropdown-item/dropdown-item.svelte
+++ b/packages/components/src/components/dropdown-item/dropdown-item.svelte
@@ -17,15 +17,9 @@
 
 <script lang="ts">
   import type { DropdownItemProps } from './dropdown-item.types.ts';
-  import { getContext, hasContext } from 'svelte';
 
   import { classNames } from '../../utilities/class-names.ts';
-  import { DROPDOWN_CONTEXT } from '../dropdown/dropdown.context.ts';
-  import type { DropdownContext } from '../dropdown/dropdown.types.ts';
-
-  if (!hasContext(DROPDOWN_CONTEXT)) {
-    throw new Error('DropdownItem must be used within a Dropdown.');
-  }
+  import { getDropdownContext } from '../dropdown/dropdown.context.ts';
 
   let {
     variant = 'default',
@@ -38,7 +32,7 @@
     ...rest
   }: DropdownItemProps = $props();
 
-  const context = getContext<DropdownContext>(DROPDOWN_CONTEXT);
+  const context = getDropdownContext();
 
   type DropdownItemClickHandler = (
     event: MouseEvent & { currentTarget: EventTarget & HTMLButtonElement },

--- a/packages/components/src/components/dropdown-item/dropdown-item.test.ts
+++ b/packages/components/src/components/dropdown-item/dropdown-item.test.ts
@@ -25,7 +25,7 @@ describe('DropdownItem', () => {
           children: createRawSnippet(() => ({ render: () => '<span>x</span>', setup: () => {} })),
         },
       }),
-    ).toThrow(/must be used within a Dropdown/);
+    ).toThrow(/missing_context/);
   });
 
   test('renders as a button with role="menuitem"', async () => {

--- a/packages/components/src/components/dropdown-menu/dropdown-menu.svelte
+++ b/packages/components/src/components/dropdown-menu/dropdown-menu.svelte
@@ -17,27 +17,22 @@
 
 <script lang="ts">
   import type { DropdownMenuProps } from './dropdown-menu.types.ts';
-  import { getContext, hasContext, tick } from 'svelte';
+  import { tick } from 'svelte';
 
   import { createAnchoredOverlay } from '../../_internal/anchored-overlay.svelte.ts';
   import { classNames } from '../../utilities/class-names.ts';
   import {
-    DROPDOWN_CONTEXT,
-    DROPDOWN_REGISTER,
-    DROPDOWN_SET_OPEN,
+    getDropdownContext,
+    getDropdownRegister,
+    getDropdownSetOpen,
   } from '../dropdown/dropdown.context.ts';
-  import type { DropdownContext } from '../dropdown/dropdown.types.ts';
   import { createPortalAttachment } from '../portal/index.ts';
-
-  if (!hasContext(DROPDOWN_CONTEXT)) {
-    throw new Error('DropdownMenu must be used within a Dropdown.');
-  }
 
   let { class: customClassName, children, ...rest }: DropdownMenuProps = $props();
 
-  const context = getContext<DropdownContext>(DROPDOWN_CONTEXT);
-  const registerMenu = getContext<(element: HTMLElement | null) => void>(DROPDOWN_REGISTER);
-  const setOpen = getContext<(open: boolean) => void>(DROPDOWN_SET_OPEN);
+  const context = getDropdownContext();
+  const registerMenu = getDropdownRegister();
+  const setOpen = getDropdownSetOpen();
 
   let menuElement = $state<HTMLDivElement | null>(null);
   let focusedFallbackOpen = false;

--- a/packages/components/src/components/dropdown-menu/dropdown-menu.test.ts
+++ b/packages/components/src/components/dropdown-menu/dropdown-menu.test.ts
@@ -23,7 +23,7 @@ describe('DropdownMenu', () => {
           children: createRawSnippet(() => ({ render: () => '<span></span>', setup: () => {} })),
         },
       }),
-    ).toThrow(/must be used within a Dropdown/);
+    ).toThrow(/missing_context/);
   });
 
   test('is absent until the trigger opens it, then renders with role="menu"', async () => {

--- a/packages/components/src/components/dropdown-trigger/dropdown-trigger.svelte
+++ b/packages/components/src/components/dropdown-trigger/dropdown-trigger.svelte
@@ -16,19 +16,13 @@
 
 <script lang="ts">
   import type { DropdownTriggerProps } from './dropdown-trigger.types.ts';
-  import { getContext, hasContext } from 'svelte';
 
   import { classNames } from '../../utilities/class-names.ts';
   import {
-    DROPDOWN_CONTEXT,
-    DROPDOWN_REGISTER_TRIGGER,
-    DROPDOWN_SET_OPEN,
+    getDropdownContext,
+    getDropdownRegisterTrigger,
+    getDropdownSetOpen,
   } from '../dropdown/dropdown.context.ts';
-  import type { DropdownContext } from '../dropdown/dropdown.types.ts';
-
-  if (!hasContext(DROPDOWN_CONTEXT)) {
-    throw new Error('DropdownTrigger must be used within a Dropdown.');
-  }
 
   let {
     class: customClassName,
@@ -38,10 +32,9 @@
     ...rest
   }: DropdownTriggerProps = $props();
 
-  const context = getContext<DropdownContext>(DROPDOWN_CONTEXT);
-  const registerTrigger =
-    getContext<(element: HTMLElement | null) => void>(DROPDOWN_REGISTER_TRIGGER);
-  const setOpen = getContext<(open: boolean) => void>(DROPDOWN_SET_OPEN);
+  const context = getDropdownContext();
+  const registerTrigger = getDropdownRegisterTrigger();
+  const setOpen = getDropdownSetOpen();
 
   let triggerElement = $state<HTMLButtonElement | null>(null);
 

--- a/packages/components/src/components/dropdown-trigger/dropdown-trigger.test.ts
+++ b/packages/components/src/components/dropdown-trigger/dropdown-trigger.test.ts
@@ -18,7 +18,7 @@ describe('DropdownTrigger', () => {
           children: createRawSnippet(() => ({ render: () => '<span>x</span>', setup: () => {} })),
         },
       }),
-    ).toThrow(/must be used within a Dropdown/);
+    ).toThrow(/missing_context/);
   });
 
   test('renders a button with aria-haspopup="menu"', () => {

--- a/packages/components/src/components/dropdown/dropdown.context.ts
+++ b/packages/components/src/components/dropdown/dropdown.context.ts
@@ -1,4 +1,23 @@
-export const DROPDOWN_CONTEXT = Symbol('cinder-dropdown');
-export const DROPDOWN_REGISTER = Symbol('cinder-dropdown-register');
-export const DROPDOWN_REGISTER_TRIGGER = Symbol('cinder-dropdown-register-trigger');
-export const DROPDOWN_SET_OPEN = Symbol('cinder-dropdown-set-open');
+import { createContext } from 'svelte';
+
+import type { DropdownContext } from './dropdown.types.ts';
+
+export type { DropdownContext };
+
+const [getDropdownContextStrict, setDropdownContext] = createContext<DropdownContext>();
+export { setDropdownContext };
+export const getDropdownContext = getDropdownContextStrict;
+
+const [getDropdownRegisterStrict, setDropdownRegister] =
+  createContext<(element: HTMLElement | null) => void>();
+export { setDropdownRegister };
+export const getDropdownRegister = getDropdownRegisterStrict;
+
+const [getDropdownRegisterTriggerStrict, setDropdownRegisterTrigger] =
+  createContext<(element: HTMLElement | null) => void>();
+export { setDropdownRegisterTrigger };
+export const getDropdownRegisterTrigger = getDropdownRegisterTriggerStrict;
+
+const [getDropdownSetOpenStrict, setDropdownSetOpen] = createContext<(nextOpen: boolean) => void>();
+export { setDropdownSetOpen };
+export const getDropdownSetOpen = getDropdownSetOpenStrict;

--- a/packages/components/src/components/dropdown/dropdown.svelte
+++ b/packages/components/src/components/dropdown/dropdown.svelte
@@ -12,26 +12,18 @@
    * @avoidWhen Showing supplementary content rather than a menu of choices — use popover.
    * @related dropdown-trigger, dropdown-menu, dropdown-item, dropdown-label, dropdown-separator
    */
-  export {
-    DROPDOWN_CONTEXT,
-    DROPDOWN_REGISTER,
-    DROPDOWN_REGISTER_TRIGGER,
-    DROPDOWN_SET_OPEN,
-  } from './dropdown.context.ts';
   export type { DropdownContext, DropdownPlacement, DropdownProps } from './dropdown.types.ts';
 </script>
 
 <script lang="ts">
-  import { setContext } from 'svelte';
-
   import { classNames } from '../../utilities/class-names.ts';
   import {
-    DROPDOWN_CONTEXT,
-    DROPDOWN_REGISTER,
-    DROPDOWN_REGISTER_TRIGGER,
-    DROPDOWN_SET_OPEN,
+    setDropdownContext,
+    setDropdownRegister,
+    setDropdownRegisterTrigger,
+    setDropdownSetOpen,
   } from './dropdown.context.ts';
-  import type { DropdownContext, DropdownProps } from './dropdown.types.ts';
+  import type { DropdownProps } from './dropdown.types.ts';
 
   const generatedId = $props.id();
 
@@ -93,7 +85,7 @@
     compoundOpen = nextOpen;
   }
 
-  setContext<DropdownContext>(DROPDOWN_CONTEXT, {
+  setDropdownContext({
     get menuId() {
       return compoundMenuId;
     },
@@ -118,12 +110,9 @@
     close: closeCompoundMenu,
     focusTrigger: focusCompoundTrigger,
   });
-  setContext<(element: HTMLElement | null) => void>(DROPDOWN_REGISTER, registerCompoundMenu);
-  setContext<(element: HTMLElement | null) => void>(
-    DROPDOWN_REGISTER_TRIGGER,
-    registerCompoundTrigger,
-  );
-  setContext<(nextOpen: boolean) => void>(DROPDOWN_SET_OPEN, setCompoundOpen);
+  setDropdownRegister(registerCompoundMenu);
+  setDropdownRegisterTrigger(registerCompoundTrigger);
+  setDropdownSetOpen(setCompoundOpen);
 
   // Keep aria-expanded on the trigger element in sync with open state.
   $effect(() => {

--- a/packages/components/src/components/dropdown/index.ts
+++ b/packages/components/src/components/dropdown/index.ts
@@ -24,15 +24,9 @@ const Dropdown = Object.assign(DropdownRoot, {
 });
 
 export default Dropdown;
-export {
-  getDropdownContext,
-  getDropdownRegister,
-  getDropdownRegisterTrigger,
-  getDropdownSetOpen,
-  setDropdownContext,
-  setDropdownRegister,
-  setDropdownRegisterTrigger,
-  setDropdownSetOpen,
-} from './dropdown.context.ts';
+// Context getter functions are intentionally excluded from the public barrel:
+// setters would allow external code to hijack the dropdown wiring of any subtree,
+// and raw getters without the provider are not a supported use case for consumers.
+// Internal bridges (menu-bar, context-menu) import from dropdown.context.ts directly.
 export type { DropdownContext, DropdownPlacement, DropdownProps } from './dropdown.types.ts';
 export { Dropdown };

--- a/packages/components/src/components/dropdown/index.ts
+++ b/packages/components/src/components/dropdown/index.ts
@@ -25,10 +25,14 @@ const Dropdown = Object.assign(DropdownRoot, {
 
 export default Dropdown;
 export {
-  DROPDOWN_CONTEXT,
-  DROPDOWN_REGISTER,
-  DROPDOWN_REGISTER_TRIGGER,
-  DROPDOWN_SET_OPEN,
+  getDropdownContext,
+  getDropdownRegister,
+  getDropdownRegisterTrigger,
+  getDropdownSetOpen,
+  setDropdownContext,
+  setDropdownRegister,
+  setDropdownRegisterTrigger,
+  setDropdownSetOpen,
 } from './dropdown.context.ts';
 export type { DropdownContext, DropdownPlacement, DropdownProps } from './dropdown.types.ts';
 export { Dropdown };

--- a/packages/components/src/components/menu-bar/menu-bar-dropdown-context.svelte
+++ b/packages/components/src/components/menu-bar/menu-bar-dropdown-context.svelte
@@ -1,12 +1,12 @@
 <script lang="ts">
   import type { Snippet } from 'svelte';
-  import { setContext, untrack } from 'svelte';
+  import { untrack } from 'svelte';
 
   import {
-    DROPDOWN_CONTEXT,
-    DROPDOWN_REGISTER,
-    DROPDOWN_REGISTER_TRIGGER,
-    DROPDOWN_SET_OPEN,
+    setDropdownContext,
+    setDropdownRegister,
+    setDropdownRegisterTrigger,
+    setDropdownSetOpen,
   } from '../dropdown/dropdown.context.ts';
   import type { DropdownContext } from '../dropdown/dropdown.types.ts';
 
@@ -22,22 +22,10 @@
 
   // Context is established once at setup; read the bridge values untracked so
   // they are not treated as reactive dependencies.
-  setContext(
-    DROPDOWN_CONTEXT,
-    untrack(() => context),
-  );
-  setContext(
-    DROPDOWN_REGISTER,
-    untrack(() => registerMenu),
-  );
-  setContext(
-    DROPDOWN_REGISTER_TRIGGER,
-    untrack(() => registerTrigger),
-  );
-  setContext(
-    DROPDOWN_SET_OPEN,
-    untrack(() => setOpen),
-  );
+  setDropdownContext(untrack(() => context));
+  setDropdownRegister(untrack(() => registerMenu));
+  setDropdownRegisterTrigger(untrack(() => registerTrigger));
+  setDropdownSetOpen(untrack(() => setOpen));
 </script>
 
 {@render children()}

--- a/packages/components/src/components/radio-group/radio-group-context.ts
+++ b/packages/components/src/components/radio-group/radio-group-context.ts
@@ -1,5 +1,12 @@
 import { createContext } from 'svelte';
 
+// The canonical type definition lives in radio-group.types.ts (the public
+// barrel re-exports it from there). Import rather than redefine to keep a
+// single source of truth — field additions only need to go in one place.
+import type { RadioGroupContext } from './radio-group.types.ts';
+
+export type { RadioGroupContext };
+
 /**
  * Context published by `<RadioGroup>` for descendant `<Radio>` children.
  *
@@ -13,14 +20,6 @@ import { createContext } from 'svelte';
  * programmer error. The `getRadioGroupContext` getter therefore throws
  * (via Svelte 5's `createContext`) when no provider exists.
  */
-export type RadioGroupContext = {
-  readonly name: string;
-  readonly value: string;
-  readonly disabled: boolean;
-  readonly invalid: boolean;
-  readonly required: boolean;
-  select: (next: string) => void;
-};
 
 const [getRadioGroupContextStrict, setRadioGroupContext] = createContext<RadioGroupContext>();
 

--- a/packages/components/src/components/radio-group/radio-group-context.ts
+++ b/packages/components/src/components/radio-group/radio-group-context.ts
@@ -1,0 +1,34 @@
+import { createContext } from 'svelte';
+
+/**
+ * Context published by `<RadioGroup>` for descendant `<Radio>` children.
+ *
+ * All members are getter properties on the context object so reads stay
+ * reactive — when a consumer reads `context.value` inside a `$derived`,
+ * the read flows through the getter, which returns a value recomputed from
+ * RadioGroup's `$derived` internals. Destructuring breaks reactivity;
+ * getter reads preserve it.
+ *
+ * The context is *required* — a `<Radio>` outside a `<RadioGroup>` is a
+ * programmer error. The `getRadioGroupContext` getter therefore throws
+ * (via Svelte 5's `createContext`) when no provider exists.
+ */
+export type RadioGroupContext = {
+  readonly name: string;
+  readonly value: string;
+  readonly disabled: boolean;
+  readonly invalid: boolean;
+  readonly required: boolean;
+  select: (next: string) => void;
+};
+
+const [getRadioGroupContextStrict, setRadioGroupContext] = createContext<RadioGroupContext>();
+
+export { setRadioGroupContext };
+
+/**
+ * Read the enclosing `<RadioGroup>` context. Throws via Svelte 5's
+ * `createContext` when no provider exists — a `<Radio>` rendered outside
+ * a `<RadioGroup>` is a programmer error.
+ */
+export const getRadioGroupContext = getRadioGroupContextStrict;

--- a/packages/components/src/components/radio-group/radio-group.svelte
+++ b/packages/components/src/components/radio-group/radio-group.svelte
@@ -11,15 +11,12 @@
    * @avoidWhen Selecting zero or more independent options — use checkbox-group instead.
    * @related checkbox-group
    */
-  /** Symbol key for the radio-group Svelte context. */
-  export const RADIO_GROUP_CONTEXT_KEY = Symbol('cinder-radio-group');
-
   export type { RadioGroupContext, RadioGroupProps } from './radio-group.types.ts';
 </script>
 
 <script lang="ts">
-  import type { RadioGroupContext, RadioGroupProps } from './radio-group.types.ts';
-  import { setContext } from 'svelte';
+  import type { RadioGroupProps } from './radio-group.types.ts';
+  import { setRadioGroupContext } from './radio-group-context.ts';
 
   import {
     ariaInvalid,
@@ -49,7 +46,7 @@
   const errId = $derived(buildErrorId(groupId, !!error));
   const describedBy = $derived(composeDescribedBy(descriptionId, errId));
 
-  setContext<RadioGroupContext>(RADIO_GROUP_CONTEXT_KEY, {
+  setRadioGroupContext({
     get name() {
       return name;
     },

--- a/packages/components/src/components/radio-group/radio-group.test.ts
+++ b/packages/components/src/components/radio-group/radio-group.test.ts
@@ -133,6 +133,9 @@ describe('RadioGroup', () => {
       error = err instanceof Error ? err : new Error(String(err));
     }
     expect(error).not.toBeNull();
+    // Verify the throw comes from Svelte's context machinery (createContext missing_context),
+    // not from an unrelated code path.
+    expect(error?.message).toMatch(/missing_context/);
   });
 
   // Reference imports so tree-shaking doesn't drop them; they're used through

--- a/packages/components/src/components/radio-group/radio-group.test.ts
+++ b/packages/components/src/components/radio-group/radio-group.test.ts
@@ -133,7 +133,6 @@ describe('RadioGroup', () => {
       error = err instanceof Error ? err : new Error(String(err));
     }
     expect(error).not.toBeNull();
-    expect(error?.message).toContain('RadioGroup');
   });
 
   // Reference imports so tree-shaking doesn't drop them; they're used through

--- a/packages/components/src/components/tab-list/tab-list.svelte
+++ b/packages/components/src/components/tab-list/tab-list.svelte
@@ -17,18 +17,13 @@
 
 <script lang="ts">
   import type { TabListProps } from './tab-list.types.ts';
-  import { getContext } from 'svelte';
 
-  import { TABS_CONTEXT_KEY, type TabsContext } from '../tabs/tabs.svelte';
+  import { getTabsContext } from '../tabs/tabs-context.ts';
   import { cn } from '../../utilities/class-names.ts';
 
   let { label, labelledBy, class: className, children }: TabListProps = $props();
 
-  const rawTabs = getContext<TabsContext | undefined>(TABS_CONTEXT_KEY);
-  if (!rawTabs) {
-    throw new Error('TabList must be used inside a Tabs component.');
-  }
-  const tabs: TabsContext = rawTabs;
+  const tabs = getTabsContext();
 </script>
 
 <div

--- a/packages/components/src/components/tab-list/tab-list.test.ts
+++ b/packages/components/src/components/tab-list/tab-list.test.ts
@@ -23,7 +23,7 @@ describe('TabList', () => {
           children: createRawSnippet(() => ({ render: () => '<span></span>', setup: () => {} })),
         },
       }),
-    ).toThrow();
+    ).toThrow(/missing_context/);
   });
 
   test('root carries role="tablist"', () => {

--- a/packages/components/src/components/tab-list/tab-list.test.ts
+++ b/packages/components/src/components/tab-list/tab-list.test.ts
@@ -23,7 +23,7 @@ describe('TabList', () => {
           children: createRawSnippet(() => ({ render: () => '<span></span>', setup: () => {} })),
         },
       }),
-    ).toThrow(/must be used inside a Tabs component/);
+    ).toThrow();
   });
 
   test('root carries role="tablist"', () => {

--- a/packages/components/src/components/tab-panel/tab-panel.svelte
+++ b/packages/components/src/components/tab-panel/tab-panel.svelte
@@ -17,18 +17,13 @@
 
 <script lang="ts">
   import type { TabPanelProps } from './tab-panel.types.ts';
-  import { getContext } from 'svelte';
 
-  import { TABS_CONTEXT_KEY, type TabsContext } from '../tabs/tabs.svelte';
+  import { getTabsContext } from '../tabs/tabs-context.ts';
   import { cn } from '../../utilities/class-names.ts';
 
   let { value, class: className, children }: TabPanelProps = $props();
 
-  const rawTabs = getContext<TabsContext | undefined>(TABS_CONTEXT_KEY);
-  if (!rawTabs) {
-    throw new Error('TabPanel must be used inside a Tabs component.');
-  }
-  const tabs: TabsContext = rawTabs;
+  const tabs = getTabsContext();
 
   const isActive = $derived(tabs.isActive(value));
   // Both ids are derived from the root's baseId and this panel's value so

--- a/packages/components/src/components/tab-panel/tab-panel.test.ts
+++ b/packages/components/src/components/tab-panel/tab-panel.test.ts
@@ -19,9 +19,9 @@ const items = [
 
 describe('TabPanel', () => {
   test('throws when rendered outside a Tabs component', () => {
-    expect(() =>
-      render(TabPanel, { props: { value: 'lonely', children: emptySnippet } }),
-    ).toThrow();
+    expect(() => render(TabPanel, { props: { value: 'lonely', children: emptySnippet } })).toThrow(
+      /missing_context/,
+    );
   });
 
   test('only the active panel renders and carries role="tabpanel"', () => {

--- a/packages/components/src/components/tab-panel/tab-panel.test.ts
+++ b/packages/components/src/components/tab-panel/tab-panel.test.ts
@@ -19,9 +19,9 @@ const items = [
 
 describe('TabPanel', () => {
   test('throws when rendered outside a Tabs component', () => {
-    expect(() => render(TabPanel, { props: { value: 'lonely', children: emptySnippet } })).toThrow(
-      /must be used inside a Tabs component/,
-    );
+    expect(() =>
+      render(TabPanel, { props: { value: 'lonely', children: emptySnippet } }),
+    ).toThrow();
   });
 
   test('only the active panel renders and carries role="tabpanel"', () => {

--- a/packages/components/src/components/tab/tab.svelte
+++ b/packages/components/src/components/tab/tab.svelte
@@ -21,19 +21,15 @@
 
 <script lang="ts">
   import type { TabProps } from './tab.types.ts';
-  import { getContext, untrack } from 'svelte';
+  import { untrack } from 'svelte';
 
   import { rovingTabIndex } from '../../_internal/collection.ts';
-  import { TABS_CONTEXT_KEY, type TabsContext } from '../tabs/tabs.svelte';
+  import { getTabsContext } from '../tabs/tabs-context.ts';
   import { classNames } from '../../utilities/class-names.ts';
 
   let { value, id, disabled = false, class: className, children, trailing }: TabProps = $props();
 
-  const rawTabs = getContext<TabsContext | undefined>(TABS_CONTEXT_KEY);
-  if (!rawTabs) {
-    throw new Error('Tab must be used inside a Tabs component.');
-  }
-  const tabs: TabsContext = rawTabs;
+  const tabs = getTabsContext();
 
   // Derive both ids from the root's baseId and the tab's value so that two
   // Tabs instances sharing the same value produce distinct DOM ids. The panel

--- a/packages/components/src/components/tab/tab.test.ts
+++ b/packages/components/src/components/tab/tab.test.ts
@@ -27,7 +27,7 @@ describe('Tab', () => {
           })),
         },
       }),
-    ).toThrow(/must be used inside a Tabs component/);
+    ).toThrow();
   });
 
   test('each Tab carries role="tab" and a per-instance, value-suffixed id', () => {

--- a/packages/components/src/components/tab/tab.test.ts
+++ b/packages/components/src/components/tab/tab.test.ts
@@ -27,7 +27,7 @@ describe('Tab', () => {
           })),
         },
       }),
-    ).toThrow();
+    ).toThrow(/missing_context/);
   });
 
   test('each Tab carries role="tab" and a per-instance, value-suffixed id', () => {

--- a/packages/components/src/components/table-body/table-body.svelte
+++ b/packages/components/src/components/table-body/table-body.svelte
@@ -15,15 +15,13 @@
 
 <script lang="ts">
   import type { TableBodyProps } from './table-body.types.ts';
-  import { setContext } from 'svelte';
 
-  import { TABLE_SECTION_CONTEXT_KEY } from '../table/table.context.ts';
-  import type { TableSectionContext } from '../table/table.types.ts';
+  import { setTableSectionContext } from '../table/table.context.ts';
   import { cn } from '../../utilities/class-names.ts';
 
   let { class: className, children }: TableBodyProps = $props();
 
-  setContext<TableSectionContext>(TABLE_SECTION_CONTEXT_KEY, 'body');
+  setTableSectionContext('body');
 </script>
 
 <tbody class={cn('cinder-table__body', className)}>

--- a/packages/components/src/components/table-header-cell/table-header-cell.svelte
+++ b/packages/components/src/components/table-header-cell/table-header-cell.svelte
@@ -16,10 +16,8 @@
 
 <script lang="ts">
   import type { TableHeaderCellProps } from './table-header-cell.types.ts';
-  import { getContext } from 'svelte';
 
-  import { TABLE_CONTEXT_KEY } from '../table/table.context.ts';
-  import type { TableContext } from '../table/table.types.ts';
+  import { getTableContext } from '../table/table.context.ts';
   import { cn } from '../../utilities/class-names.ts';
 
   let {
@@ -31,11 +29,7 @@
     children,
   }: TableHeaderCellProps = $props();
 
-  const rawTable = getContext<TableContext | undefined>(TABLE_CONTEXT_KEY);
-  if (!rawTable) {
-    throw new Error('TableHeaderCell must be used inside a Table component.');
-  }
-  const table: TableContext = rawTable;
+  const table = getTableContext();
 
   // aria-sort lives on the <th> per WAI-ARIA. The accessible name and
   // keyboard activation live on the inner <button> when sortable.

--- a/packages/components/src/components/table-header/table-header.svelte
+++ b/packages/components/src/components/table-header/table-header.svelte
@@ -15,18 +15,13 @@
 
 <script lang="ts">
   import type { TableHeaderProps } from './table-header.types.ts';
-  import { getContext, setContext, untrack } from 'svelte';
+  import { untrack } from 'svelte';
 
   import {
-    TABLE_CONTEXT_KEY,
-    TABLE_HEADER_SELECTION_CONTEXT_KEY,
-    TABLE_SECTION_CONTEXT_KEY,
+    setTableHeaderSelectionContext,
+    setTableSectionContext,
+    tryGetTableContext,
   } from '../table/table.context.ts';
-  import type {
-    TableContext,
-    TableHeaderSelectionContext,
-    TableSectionContext,
-  } from '../table/table.types.ts';
   import { cn } from '../../utilities/class-names.ts';
 
   let {
@@ -38,7 +33,7 @@
     selectAllLabel = 'Select all rows',
   }: TableHeaderProps = $props();
 
-  const table = getContext<TableContext | undefined>(TABLE_CONTEXT_KEY);
+  const table = tryGetTableContext();
   const selectionEnabled = table?.selectionEnabled ?? false;
 
   // One-time mount-time guard; read the props untracked.
@@ -62,9 +57,9 @@
     hasSelectionHeaderCell = true;
   }
 
-  setContext<TableSectionContext>(TABLE_SECTION_CONTEXT_KEY, 'header');
+  setTableSectionContext('header');
 
-  setContext<TableHeaderSelectionContext>(TABLE_HEADER_SELECTION_CONTEXT_KEY, {
+  setTableHeaderSelectionContext({
     get allSelected() {
       return allSelected ?? false;
     },

--- a/packages/components/src/components/table-row/table-row.svelte
+++ b/packages/components/src/components/table-row/table-row.svelte
@@ -16,18 +16,13 @@
 
 <script lang="ts">
   import type { TableRowProps } from './table-row.types.ts';
-  import { getContext, untrack } from 'svelte';
+  import { untrack } from 'svelte';
 
   import {
-    TABLE_CONTEXT_KEY,
-    TABLE_HEADER_SELECTION_CONTEXT_KEY,
-    TABLE_SECTION_CONTEXT_KEY,
+    tryGetTableContext,
+    tryGetTableHeaderSelectionContext,
+    tryGetTableSectionContext,
   } from '../table/table.context.ts';
-  import type {
-    TableContext,
-    TableHeaderSelectionContext,
-    TableSectionContext,
-  } from '../table/table.types.ts';
   import { cn } from '../../utilities/class-names.ts';
 
   let {
@@ -39,13 +34,11 @@
     selectionDisabled,
   }: TableRowProps = $props();
 
-  const table = getContext<TableContext | undefined>(TABLE_CONTEXT_KEY);
+  const table = tryGetTableContext();
   const selectionEnabled = table?.selectionEnabled ?? false;
 
-  const section = getContext<TableSectionContext | undefined>(TABLE_SECTION_CONTEXT_KEY);
-  const headerSelection = getContext<TableHeaderSelectionContext | undefined>(
-    TABLE_HEADER_SELECTION_CONTEXT_KEY,
-  );
+  const section = tryGetTableSectionContext();
+  const headerSelection = tryGetTableHeaderSelectionContext();
 
   // Validate body rows when selection is enabled. This is a one-time mount-time
   // guard, so the prop reads are untracked.

--- a/packages/components/src/components/table/index.ts
+++ b/packages/components/src/components/table/index.ts
@@ -21,11 +21,6 @@ const Table = Object.assign(TableRoot, {
 });
 
 export default Table;
-export {
-  TABLE_CONTEXT_KEY,
-  TABLE_HEADER_SELECTION_CONTEXT_KEY,
-  TABLE_SECTION_CONTEXT_KEY,
-} from './table.context.ts';
 export type {
   SortDirection,
   TableContext,

--- a/packages/components/src/components/table/table.context.ts
+++ b/packages/components/src/components/table/table.context.ts
@@ -1,8 +1,65 @@
-/** Symbol key for the table Svelte context. */
-export const TABLE_CONTEXT_KEY = Symbol('cinder-table');
+import { createContext } from 'svelte';
 
-/** Symbol key for the section context (header vs body). */
-export const TABLE_SECTION_CONTEXT_KEY = Symbol('cinder-table-section');
+import { optionalContext } from '../../_internal/optional-context.ts';
+import type {
+  TableContext,
+  TableHeaderSelectionContext,
+  TableSectionContext,
+} from './table.types.ts';
 
-/** Symbol key for the header selection context (select-all data). */
-export const TABLE_HEADER_SELECTION_CONTEXT_KEY = Symbol('cinder-table-header-selection');
+// ---------------------------------------------------------------------------
+// TableContext — the root table context set by <Table>.
+//
+// Required by TableHeaderCell (missing provider = programmer error → throw).
+// Optional in TableHeader and TableRow (they degrade gracefully without it).
+// ---------------------------------------------------------------------------
+const [getTableContextStrict, setTableContext] = createContext<TableContext>();
+
+export { setTableContext };
+
+/**
+ * Strict read — throws when no `<Table>` ancestor has provided the context.
+ * Use inside components that cannot function without a parent table (e.g.
+ * TableHeaderCell).
+ */
+export const getTableContext = getTableContextStrict;
+
+/**
+ * Optional read — returns `undefined` when no `<Table>` ancestor is present.
+ * Use inside components that degrade gracefully without a parent table (e.g.
+ * TableHeader, TableRow).
+ */
+export const tryGetTableContext: () => TableContext | undefined =
+  optionalContext(getTableContextStrict);
+
+// ---------------------------------------------------------------------------
+// TableSectionContext — set by <TableHeader> ('header') and <TableBody> ('body').
+// Optional: a TableRow rendered directly under Table with no section is allowed
+// (it warns but does not throw).
+// ---------------------------------------------------------------------------
+const [getTableSectionContextStrict, setTableSectionContext] = createContext<TableSectionContext>();
+
+export { setTableSectionContext };
+
+/**
+ * Optional read — returns `undefined` when no section ancestor is present.
+ */
+export const tryGetTableSectionContext: () => TableSectionContext | undefined = optionalContext(
+  getTableSectionContextStrict,
+);
+
+// ---------------------------------------------------------------------------
+// TableHeaderSelectionContext — set by <TableHeader>.
+// Optional: TableRow uses it only when a header selection context exists.
+// ---------------------------------------------------------------------------
+const [getTableHeaderSelectionContextStrict, setTableHeaderSelectionContext] =
+  createContext<TableHeaderSelectionContext>();
+
+export { setTableHeaderSelectionContext };
+
+/**
+ * Optional read — returns `undefined` when no TableHeader selection context is
+ * present (i.e. the row is inside a body or the table is not selectable).
+ */
+export const tryGetTableHeaderSelectionContext: () => TableHeaderSelectionContext | undefined =
+  optionalContext(getTableHeaderSelectionContextStrict);

--- a/packages/components/src/components/table/table.svelte
+++ b/packages/components/src/components/table/table.svelte
@@ -12,11 +12,6 @@
    * @avoidWhen Listing key-value attributes of one entity — use description-list instead.
    * @related table-header, table-body, table-row, table-cell, table-header-cell
    */
-  export {
-    TABLE_CONTEXT_KEY,
-    TABLE_HEADER_SELECTION_CONTEXT_KEY,
-    TABLE_SECTION_CONTEXT_KEY,
-  } from './table.context.ts';
   export type {
     SortDirection,
     TableContext,
@@ -29,9 +24,8 @@
 </script>
 
 <script lang="ts">
-  import { TABLE_CONTEXT_KEY } from './table.context.ts';
-  import type { TableContext, TableProps } from './table.types.ts';
-  import { setContext } from 'svelte';
+  import { setTableContext } from './table.context.ts';
+  import type { TableProps } from './table.types.ts';
 
   import { cn } from '../../utilities/class-names.ts';
 
@@ -57,7 +51,7 @@
     };
   }
 
-  setContext<TableContext>(TABLE_CONTEXT_KEY, {
+  setTableContext({
     get sort() {
       return sort;
     },

--- a/packages/components/src/components/tabs/tabs-context.ts
+++ b/packages/components/src/components/tabs/tabs-context.ts
@@ -1,0 +1,29 @@
+/**
+ * Shared context contract between Tabs (producer) and Tab, TabList, and
+ * TabPanel (consumers).
+ *
+ * Kept inside `tabs/` so the handles are co-located with the type definition
+ * in `tabs.types.ts` and reachable by the leaf components without being part
+ * of the package's public surface.
+ *
+ * The context is *required* — a Tab, TabList, or TabPanel outside a Tabs
+ * provider is a programmer error. The `getTabsContext` getter therefore throws
+ * (via Svelte 5's `createContext`) when no ancestor has called `setTabsContext`.
+ */
+
+import { createContext } from 'svelte';
+
+import type { TabsContext } from './tabs.types.ts';
+
+export type { TabsContext };
+
+const [getTabsContextStrict, setTabsContext] = createContext<TabsContext>();
+
+export { setTabsContext };
+
+/**
+ * Read the nearest enclosing `<Tabs>` context. Throws when no `<Tabs>`
+ * ancestor exists — using Tab, TabList, or TabPanel outside a provider is a
+ * programmer error.
+ */
+export const getTabsContext = getTabsContextStrict;

--- a/packages/components/src/components/tabs/tabs.svelte
+++ b/packages/components/src/components/tabs/tabs.svelte
@@ -12,15 +12,12 @@
    * @avoidWhen Showing ordered progress through a wizard — use steps instead.
    * @related tab, tab-list, tab-panel, segmented-control
    */
-  /** Symbol key for the tabs Svelte context. */
-  export const TABS_CONTEXT_KEY = Symbol('cinder-tabs');
-
   export type { TabsContext, TabsOrientation, TabsProps } from './tabs.types.ts';
 </script>
 
 <script lang="ts">
-  import type { TabsContext, TabsProps } from './tabs.types.ts';
-  import { setContext } from 'svelte';
+  import type { TabsProps } from './tabs.types.ts';
+  import { setTabsContext } from './tabs-context.ts';
 
   import { handleRovingKeydown, isRovingKey } from '../../utilities/roving-tabindex.ts';
   import { classNames } from '../../utilities/class-names.ts';
@@ -161,7 +158,7 @@
     }
   }
 
-  setContext<TabsContext>(TABS_CONTEXT_KEY, {
+  setTabsContext({
     get value() {
       return value;
     },

--- a/packages/components/src/components/toast-region/index.ts
+++ b/packages/components/src/components/toast-region/index.ts
@@ -2,7 +2,6 @@ import './toast-region.css';
 import ToastRegion from './toast-region.svelte';
 
 export default ToastRegion;
-export { TOAST_CONTEXT_KEY } from '../../_internal/toast-context.ts';
 export type {
   ToastApi,
   ToastItem,

--- a/packages/components/src/components/toast-region/toast-region.svelte
+++ b/packages/components/src/components/toast-region/toast-region.svelte
@@ -12,13 +12,7 @@
    * @avoidWhen Reporting an urgent error that must remain on screen — use alert.
    * @related alert, banner
    */
-  import { TOAST_CONTEXT_KEY } from '../../_internal/toast-context.ts';
-
-  // Re-export so consumers using the public package surface get a single
-  // import path; internal modules import directly from _internal.
-  export { TOAST_CONTEXT_KEY };
   export type {
-    ToastApi,
     ToastItem,
     ToastOptions,
     ToastPosition,
@@ -28,14 +22,14 @@
 </script>
 
 <script lang="ts">
-  import { onDestroy, setContext } from 'svelte';
+  import { onDestroy } from 'svelte';
   import type { Attachment } from 'svelte/attachments';
 
+  import { setToastContext } from '../../_internal/toast-context.ts';
   import { pushEscapeHandler } from '../../_internal/overlay.ts';
   import { waitForTransitionCompletion } from '../../_internal/transition-completion.ts';
   import { cn } from '../../utilities/class-names.ts';
   import type {
-    ToastApi,
     ToastItem,
     ToastOptions,
     ToastRegionProps,
@@ -568,7 +562,7 @@
     };
   }
 
-  setContext<ToastApi>(TOAST_CONTEXT_KEY, { show, dismiss, dismissAll, promise });
+  setToastContext({ show, dismiss, dismissAll, promise });
 
   onDestroy(() => {
     // Tear down timers so unmounting the region (e.g., during route change)

--- a/packages/components/src/components/tree-item/tree-item.svelte
+++ b/packages/components/src/components/tree-item/tree-item.svelte
@@ -19,7 +19,7 @@
   import { untrack } from 'svelte';
   import type { Attachment } from 'svelte/attachments';
 
-  import type { TreeContext, TreeItemParentContext } from '../../_internal/tree-context.ts';
+  import type { TreeContext } from '../../_internal/tree-context.ts';
   import {
     getTreeContext,
     setTreeItemParentContext,
@@ -62,7 +62,7 @@
     get level() {
       return level + 1;
     },
-  } as TreeItemParentContext);
+  });
 
   // ---------------------------------------------------------------------------
   // Local state

--- a/packages/components/src/components/tree-item/tree-item.svelte
+++ b/packages/components/src/components/tree-item/tree-item.svelte
@@ -16,11 +16,15 @@
 
 <script lang="ts">
   import type { TreeItemProps } from './tree-item.types.ts';
-  import { getContext, setContext, untrack } from 'svelte';
+  import { untrack } from 'svelte';
   import type { Attachment } from 'svelte/attachments';
 
   import type { TreeContext, TreeItemParentContext } from '../../_internal/tree-context.ts';
-  import { TREE_CONTEXT_KEY, TREE_ITEM_PARENT_KEY } from '../tree/tree.svelte';
+  import {
+    getTreeContext,
+    setTreeItemParentContext,
+    tryGetTreeItemParentContext,
+  } from '../../_internal/tree-context.ts';
   import { classNames } from '../../utilities/class-names.ts';
 
   // ---------------------------------------------------------------------------
@@ -44,25 +48,21 @@
   // Contexts (read at init time — must not be inside onMount)
   // ---------------------------------------------------------------------------
 
-  const treeContext = getContext<TreeContext | undefined>(TREE_CONTEXT_KEY);
-  if (!treeContext) {
-    throw new Error('TreeItem must be used inside a Tree component.');
-  }
-  const context: TreeContext = treeContext;
+  const context: TreeContext = getTreeContext();
 
-  const parentContext = getContext<TreeItemParentContext | undefined>(TREE_ITEM_PARENT_KEY);
+  const parentContext = tryGetTreeItemParentContext();
   const parentId = parentContext?.parentId ?? null;
   const level = parentContext?.level ?? 1;
 
   // Publish context for our own children
-  setContext<TreeItemParentContext>(TREE_ITEM_PARENT_KEY, {
+  setTreeItemParentContext({
     get parentId() {
       return id;
     },
     get level() {
       return level + 1;
     },
-  });
+  } as TreeItemParentContext);
 
   // ---------------------------------------------------------------------------
   // Local state

--- a/packages/components/src/components/tree-item/tree-item.test.ts
+++ b/packages/components/src/components/tree-item/tree-item.test.ts
@@ -12,7 +12,7 @@ const { default: TreeItem } = await import('./tree-item.svelte');
 describe('TreeItem', () => {
   test('throws when rendered outside a Tree', () => {
     expect(() => render(TreeItem, { props: { id: 'lonely', label: 'Lonely' } })).toThrow(
-      /must be used inside a Tree component/,
+      /missing_context/,
     );
   });
 

--- a/packages/components/src/components/tree/tree.svelte
+++ b/packages/components/src/components/tree/tree.svelte
@@ -18,7 +18,7 @@
 <script lang="ts">
   import type { TreeProps } from './tree.types.ts';
 
-  import type { TreeContext, TreeItemParentContext } from '../../_internal/tree-context.ts';
+  import type { TreeContext } from '../../_internal/tree-context.ts';
   import { setTreeContext, setTreeItemParentContext } from '../../_internal/tree-context.ts';
   import { TreeRegistry } from '../../_internal/tree-registry.svelte.ts';
   import { classNames } from '../../utilities/class-names.ts';
@@ -391,7 +391,7 @@
   };
 
   setTreeContext(context);
-  setTreeItemParentContext({ parentId: null, level: 1 } as TreeItemParentContext);
+  setTreeItemParentContext({ parentId: null, level: 1 });
 
   // ---------------------------------------------------------------------------
   // Keyboard handler (Ctrl/Cmd+A handled at tree level)

--- a/packages/components/src/components/tree/tree.svelte
+++ b/packages/components/src/components/tree/tree.svelte
@@ -12,17 +12,14 @@
    * @avoidWhen Switching between sibling views of the same region — use tabs instead.
    * @related tree-item, accordion
    */
-  export const TREE_CONTEXT_KEY = Symbol('cinder-tree');
-  export const TREE_ITEM_PARENT_KEY = Symbol('cinder-tree-item-parent');
-
   export type { TreeProps, TreeSelectionBehavior, TreeSelectionMode } from './tree.types.ts';
 </script>
 
 <script lang="ts">
   import type { TreeProps } from './tree.types.ts';
-  import { setContext } from 'svelte';
 
   import type { TreeContext, TreeItemParentContext } from '../../_internal/tree-context.ts';
+  import { setTreeContext, setTreeItemParentContext } from '../../_internal/tree-context.ts';
   import { TreeRegistry } from '../../_internal/tree-registry.svelte.ts';
   import { classNames } from '../../utilities/class-names.ts';
   import {
@@ -393,8 +390,8 @@
     },
   };
 
-  setContext(TREE_CONTEXT_KEY, context);
-  setContext(TREE_ITEM_PARENT_KEY, { parentId: null, level: 1 } as TreeItemParentContext);
+  setTreeContext(context);
+  setTreeItemParentContext({ parentId: null, level: 1 } as TreeItemParentContext);
 
   // ---------------------------------------------------------------------------
   // Keyboard handler (Ctrl/Cmd+A handled at tree level)

--- a/packages/components/src/components/tree/tree.test.ts
+++ b/packages/components/src/components/tree/tree.test.ts
@@ -1590,7 +1590,7 @@ describe('Tree — selection', () => {
   });
 
   test('TreeSelectAll outside tree context throws a clear usage error', () => {
-    expect(() => render(TreeSelectAll, { props: {} })).toThrow(/TreeSelectAll.*selectionControls/);
+    expect(() => render(TreeSelectAll, { props: {} })).toThrow(/missing_context/);
   });
 });
 

--- a/packages/components/src/utilities/use-toast.ts
+++ b/packages/components/src/utilities/use-toast.ts
@@ -12,6 +12,7 @@
  * impossible with this model.
  */
 
+import type { ToastApi } from '../_internal/toast-context.ts';
 import { getToastContext } from '../_internal/toast-context.ts';
 
 /**
@@ -21,7 +22,7 @@ import { getToastContext } from '../_internal/toast-context.ts';
  * intentionally loud — calling `useToast()` outside a region is always a
  * setup bug, not something to silently no-op.
  */
-export function useToast() {
+export function useToast(): ToastApi {
   return getToastContext();
 }
 

--- a/packages/components/src/utilities/use-toast.ts
+++ b/packages/components/src/utilities/use-toast.ts
@@ -12,9 +12,7 @@
  * impossible with this model.
  */
 
-import { getContext } from 'svelte';
-
-import { TOAST_CONTEXT_KEY, type ToastApi } from '../_internal/toast-context.ts';
+import { getToastContext } from '../_internal/toast-context.ts';
 
 /**
  * Returns the toast API for the nearest enclosing `<ToastRegion />`.
@@ -23,14 +21,8 @@ import { TOAST_CONTEXT_KEY, type ToastApi } from '../_internal/toast-context.ts'
  * intentionally loud — calling `useToast()` outside a region is always a
  * setup bug, not something to silently no-op.
  */
-export function useToast(): ToastApi {
-  const api = getContext<ToastApi | undefined>(TOAST_CONTEXT_KEY);
-  if (!api) {
-    throw new Error(
-      'useToast() must be called inside a <ToastRegion />. Mount one in your root layout.',
-    );
-  }
-  return api;
+export function useToast() {
+  return getToastContext();
 }
 
 export type {


### PR DESCRIPTION
## Summary
Migrates 13 compound-component context families from raw `Symbol`-keyed `setContext`/`getContext` (with hand-rolled throw guards + unsafe casts) to Svelte 5's `createContext()` — typed `[get, set]` pairs that throw automatically on a missing provider. Removes the duplicated guards, the `rawCtx`→`ctx` casts, and the exported Symbol keys; restores compile-time context-type narrowing.

Families: tabs (tabs/tab/tab-list/tab-panel), _radio/radio-group, tree (tree/tree-item/_tree-select-all), table (table + section + header-selection contexts), accordion, dropdown (5 consumers incl. menu-bar), context-menu, toast-region. Required contexts use the strict getter; optional contexts wrap it with `optionalContext`. All context fields preserved (incl. `TabsContext.baseId` + `RadioGroupContext.required` from #262).

AGENTS.md § Compound components documents the createContext convention and bans raw Symbol contexts in new families. (The matching oxlint guard is deferred to a follow-up — it's a root-config change that triggers a full-workspace pre-commit escalation.)

## Review committee
Pre-reviewed by svelte-expert, testing-expert, typescript-expert, dx-engineer, simplicity-engineer, Codex (gpt-5.4 xhigh). 1 round; all must-fix addressed: dropdown setter exports removed from the public barrel, RadioGroupContext de-duplicated (single source in types.ts), all throw assertions standardized to `.toThrow(/missing_context/)`, `as TreeItemParentContext` casts removed, `useToast(): ToastApi` return type restored.

## Test plan
typecheck 0, lint 0, full suite 4283 tests / 0 fail, components:check OK, exports:check OK.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Wide internal refactor across many compound families (dropdown, table, tree, tabs); behavior should be equivalent but any missed context wiring or external use of removed Symbol exports could break consumers at runtime.
> 
> **Overview**
> This PR **standardizes compound-component context** across tabs, radio-group, tree, table, accordion, dropdown (and context-menu / menu-bar bridges), and toast on **Svelte 5 `createContext()`**, replacing hand-rolled `Symbol` keys, `setContext`/`getContext`, and per-leaf `if (!ctx) throw` guards.
> 
> Each family now exposes typed **`set*` / `get*`** (and **`tryGet*`** via `optionalContext` where a missing provider is valid, e.g. table section/header selection and root-level tree items). Leaves call the strict getters directly; missing providers surface Svelte’s **`missing_context`** error. **Public barrels no longer export context Symbol keys or dropdown setters**—internal code imports `*.context.ts` directly.
> 
> **`AGENTS.md`** documents the `createContext` convention for new compound families. Tests that asserted custom error strings now expect **`/missing_context/`**. **`useToast`** delegates to `getToastContext()` with the same throw semantics.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0c7a271fddb1a9c3999a108543b6f01cdd8a4cb9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->