### PR TITLE
fix(autocomplete): make the match highlight legible in dark mode

### DIFF
--- a/packages/components/src/components/autocomplete/autocomplete.css
+++ b/packages/components/src/components/autocomplete/autocomplete.css
@@ -77,9 +77,22 @@
   }
 
   .cinder-autocomplete__match {
-    padding: 0;
-    background: oklch(from var(--cinder-warning) 96.5% 0.015 h);
-    color: inherit;
+    /*
+     * Emphasize the matched substring with the theme-aware warning surface
+     * pair. The previous value hard-coded `oklch(from var(--cinder-warning)
+     * 96.5% …)` — a near-white background in BOTH themes — and kept `color:
+     * inherit`, so in dark mode the (light) inherited text sat on a near-white
+     * background and the matched glyph disappeared into a solid white box.
+     * `--cinder-color-warning-bg` / `--cinder-color-warning-fg` are a designed
+     * `light-dark()` pair (dark-on-light in light mode, light-on-dark in dark
+     * mode), so the highlight stays legible against either theme and against
+     * the active row's raised surface.
+     */
+    padding: 0 0.0625rem;
+    border-radius: var(--cinder-radius-sm);
+    background: var(--cinder-color-warning-bg);
+    color: var(--cinder-color-warning-fg);
+    font-weight: 600;
   }
 
   .cinder-autocomplete__status {

--- a/packages/components/src/components/autocomplete/autocomplete.test.ts
+++ b/packages/components/src/components/autocomplete/autocomplete.test.ts
@@ -141,12 +141,19 @@ describe('Autocomplete — suggestions and free-form input', () => {
     // / `--cinder-color-warning-fg` light-dark() pair, which contrasts in either
     // theme. happy-dom does not apply stylesheets, so assert against the CSS source.
     const css = await Bun.file(new URL('./autocomplete.css', import.meta.url)).text();
-    const matchRule = css.slice(css.indexOf('.cinder-autocomplete__match'));
+    // Strip CSS comments first — the explanatory comment in this rule intentionally
+    // quotes the old broken values, so the negative assertions below must run
+    // against the declarations only, not the comment text.
+    const cssWithoutComments = css.replace(/\/\*[\s\S]*?\*\//g, '');
+    const matchRule = cssWithoutComments.slice(
+      cssWithoutComments.indexOf('.cinder-autocomplete__match'),
+    );
     const ruleBody = matchRule.slice(0, matchRule.indexOf('}'));
-    expect(ruleBody).toContain('var(--cinder-color-warning-bg)');
-    expect(ruleBody).toContain('var(--cinder-color-warning-fg)');
-    // The broken hard-coded near-white background must be gone.
-    expect(ruleBody).not.toMatch(/oklch\(from var\(--cinder-warning\)\s*9[0-9]/);
+    // Pin to the actual background:/color: declarations.
+    expect(ruleBody).toMatch(/background:\s*var\(--cinder-color-warning-bg\)/);
+    expect(ruleBody).toMatch(/color:\s*var\(--cinder-color-warning-fg\)/);
+    // The broken hard-coded near-white background must be gone from the declarations.
+    expect(ruleBody).not.toMatch(/oklch\(from var\(--cinder-warning\)/);
     // color: inherit was the second half of the bug (light text on light bg).
     expect(ruleBody).not.toMatch(/color:\s*inherit/);
   });

--- a/packages/components/src/components/autocomplete/autocomplete.test.ts
+++ b/packages/components/src/components/autocomplete/autocomplete.test.ts
@@ -133,6 +133,24 @@ describe('Autocomplete — suggestions and free-form input', () => {
     });
   });
 
+  test('match highlight uses the theme-aware warning surface tokens, not a hard-coded light value', async () => {
+    // Regression: the highlight previously hard-coded a near-white background
+    // (`oklch(from var(--cinder-warning) 96.5% …)`) in BOTH themes with
+    // `color: inherit`, so in dark mode the matched glyph became a white-on-white
+    // box and the letter disappeared. The fix uses the `--cinder-color-warning-bg`
+    // / `--cinder-color-warning-fg` light-dark() pair, which contrasts in either
+    // theme. happy-dom does not apply stylesheets, so assert against the CSS source.
+    const css = await Bun.file(new URL('./autocomplete.css', import.meta.url)).text();
+    const matchRule = css.slice(css.indexOf('.cinder-autocomplete__match'));
+    const ruleBody = matchRule.slice(0, matchRule.indexOf('}'));
+    expect(ruleBody).toContain('var(--cinder-color-warning-bg)');
+    expect(ruleBody).toContain('var(--cinder-color-warning-fg)');
+    // The broken hard-coded near-white background must be gone.
+    expect(ruleBody).not.toMatch(/oklch\(from var\(--cinder-warning\)\s*9[0-9]/);
+    // color: inherit was the second half of the bug (light text on light bg).
+    expect(ruleBody).not.toMatch(/color:\s*inherit/);
+  });
+
   test('eligible empty results keep the popup open with the empty row', async () => {
     const { container } = render(Autocomplete, {
       props: {


### PR DESCRIPTION
## Summary
The matched-substring `<mark class="cinder-autocomplete__match">` hard-coded a near-white background (`oklch(from var(--cinder-warning) 96.5% …)`) in **both** themes and kept `color: inherit`. In dark mode the inherited light text sat on that near-white background, so the matched glyph rendered as a solid white box and the letter vanished (e.g. "Aucklan▮d", "Colora▮o", "Englan▮d" in the destination-city autocomplete).

Fix: use the designed `--cinder-color-warning-bg` / `--cinder-color-warning-fg` `light-dark()` token pair — dark-on-light in light mode, light-on-dark in dark mode — so the highlight is legible against either theme and against the active row's raised surface. Adds a small radius + medium weight so it reads as an emphasis chip rather than a box over the glyph.

## Review committee
Pre-reviewed by svelte-expert (verified the token pair's WCAG-AA lightness deltas in both themes) + Codex (gpt-5.4). Both APPROVED.

## Test plan
- New regression test asserts the rule uses the theme-aware tokens and no longer contains the hard-coded near-white background or `color: inherit`.
- `bun run --filter=cinder test -- autocomplete` → 19 pass, 0 fail. lint 0 errors.
- The browser-tests CI renders the component in both themes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped styling and test-only changes in the autocomplete component; no auth, data, or API behavior.
> 
> **Overview**
> Fixes **dark-mode legibility** for autocomplete substring highlights (`.cinder-autocomplete__match`). The rule no longer uses a near-white `oklch(from var(--cinder-warning) …)` background with `color: inherit`; it now uses **`--cinder-color-warning-bg`** / **`--cinder-color-warning-fg`**, with slight padding, radius, and **font-weight: 600** so the match reads as an emphasis chip in either theme.
> 
> Adds a **regression test** that reads `autocomplete.css` (comments stripped) and asserts the theme tokens are present and the old `oklch` / `color: inherit` declarations are gone—because happy-dom does not apply stylesheets.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f1b475da352f2159121bfa42819e9738deff51f1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->