### PR TITLE
refactor(components): route developer warnings through a shared devWarn() helper (2ac468df)

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -3384,6 +3384,7 @@
   ],
   "scripts": {
     "build": "bun run scripts/build.ts",
+    "check:no-bare-console-warn": "bun run scripts/check-no-bare-console-warn.ts",
     "check:no-cycle-imports": "bun run scripts/check-no-cycle-imports.ts",
     "check:placeholder-docs": "bun run scripts/check-placeholder-docs.ts",
     "clean": "rm -rf dist coverage tsconfig.tsbuildinfo cinder-*.tgz tmp fixtures/node-consumer/node_modules fixtures/node-consumer/dist fixtures/sveltekit-consumer/node_modules fixtures/sveltekit-consumer/.svelte-kit fixtures/sveltekit-consumer/build fixtures/manifest-consumer/node_modules fixtures/typescript-consumer/node_modules fixtures/typescript-consumer/src/generated fixtures/examples-consumer/node_modules fixtures/examples-consumer/.svelte-kit fixtures/examples-consumer/build fixtures/examples-consumer/src/generated fixtures/examples-consumer/src/routes/+page.svelte",
@@ -3395,7 +3396,7 @@
     "components:promotion-check": "bun run scripts/check-promotion-readiness.ts",
     "exports:check": "bun run scripts/generate-exports.ts --check",
     "exports:generate": "bun run scripts/generate-exports.ts",
-    "lint": "oxlint --type-aware --tsconfig ./tsconfig.json && bun run check:no-cycle-imports",
+    "lint": "oxlint --type-aware --tsconfig ./tsconfig.json && bun run check:no-cycle-imports && bun run check:no-bare-console-warn",
     "lint:fix": "oxlint --fix --type-aware --tsconfig ./tsconfig.json",
     "prepack": "bun run build",
     "package:weight": "bun run scripts/report-package-weight.ts",

--- a/packages/components/scripts/check-no-bare-console-warn.test.ts
+++ b/packages/components/scripts/check-no-bare-console-warn.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, test } from 'bun:test';
+
+const scriptPath = new URL('./check-no-bare-console-warn.ts', import.meta.url).pathname;
+
+describe('check-no-bare-console-warn', () => {
+  test('component source contains no bare console.warn (all route through devWarn)', async () => {
+    const proc = Bun.spawn(['bun', 'run', scriptPath], {
+      stdout: 'pipe',
+      stderr: 'pipe',
+    });
+    const [exitCode, stdout, stderr] = await Promise.all([
+      proc.exited,
+      new Response(proc.stdout).text(),
+      new Response(proc.stderr).text(),
+    ]);
+    // If this fails, stderr lists every offending file:line — replace the bare
+    // console.warn with devWarn(...) from utilities/dev-warn.ts.
+    expect(stderr, stderr).toBe('');
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain('OK');
+  });
+});

--- a/packages/components/scripts/check-no-bare-console-warn.ts
+++ b/packages/components/scripts/check-no-bare-console-warn.ts
@@ -1,0 +1,91 @@
+/**
+ * Development-only-diagnostics guard.
+ *
+ * Component contract-misuse warnings (a missing required prop, an id that does
+ * not match the wrapping FormField, a duplicate key, …) are diagnostics for the
+ * developer building the app — never for the end user. They must route through
+ * `utilities/dev-warn.ts`'s `devWarn(...)`, which gates on `DEV` from `esm-env`
+ * and is dead-code-eliminated from production bundles. A bare `console.warn` in
+ * component source ships the warning string (and internal naming) to end users.
+ *
+ * This script walks `packages/components/src/components/**` and fails on any
+ * `.svelte` or `.ts` file that calls `console.warn` directly. `dev-warn.ts`
+ * itself is the single allowed `console.warn` call site.
+ *
+ * oxlint cannot express this rule: Svelte files are in oxlint's `ignorePatterns`
+ * (they are linted by stylelint/svelte-check, not oxlint), so a
+ * `no-restricted-syntax` rule would never see the component source where the
+ * warnings live. A scanned grep with an explicit allow-list is the simplest
+ * durable enforcement, matching `check-no-cycle-imports.ts`. Wired into
+ * `bun run lint` (and therefore CI).
+ */
+
+import { Glob } from 'bun';
+import { dirname, relative, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const scriptDirectory = dirname(fileURLToPath(import.meta.url));
+const componentsRoot = resolve(scriptDirectory, '..', 'src', 'components');
+
+/**
+ * Component-relative paths permitted to call `console.warn` directly. Currently
+ * empty: `dev-warn.ts` — the one sanctioned `console.warn` seam — lives under
+ * `utilities/`, outside the `components/` tree scanned here, so it needs no
+ * entry. Add a path here only if a component genuinely needs a raw `console.warn`
+ * (none do today), with a comment explaining why.
+ */
+const ALLOWED_FILES = new Set<string>([]);
+
+/** Matches a `console.warn(` call (with optional whitespace). */
+const CONSOLE_WARN_PATTERN = /\bconsole\s*\.\s*warn\s*\(/;
+
+type Violation = { filePath: string; lineNumber: number; line: string };
+
+async function scan(): Promise<Violation[]> {
+  const violations: Violation[] = [];
+  const glob = new Glob('**/*.{svelte,ts}');
+  for await (const relativePath of glob.scan({ cwd: componentsRoot })) {
+    if (ALLOWED_FILES.has(relativePath)) continue;
+    const absolutePath = resolve(componentsRoot, relativePath);
+    const source = await Bun.file(absolutePath).text();
+    const lines = source.split('\n');
+    for (let index = 0; index < lines.length; index++) {
+      const line = lines[index]!;
+      if (CONSOLE_WARN_PATTERN.test(line)) {
+        violations.push({
+          filePath: relative(resolve(componentsRoot, '..', '..', '..'), absolutePath),
+          lineNumber: index + 1,
+          line: line.trim(),
+        });
+      }
+    }
+  }
+  return violations;
+}
+
+async function main(): Promise<void> {
+  const violations = await scan();
+  if (violations.length === 0) {
+    process.stdout.write('check-no-bare-console-warn — OK (component source uses devWarn).\n');
+    return;
+  }
+  process.stderr.write(
+    'check-no-bare-console-warn — bare `console.warn` detected in component source.\n' +
+      'Developer warnings must route through `devWarn(...)` from `utilities/dev-warn.ts` so they ' +
+      'are gated on DEV and stripped from production bundles. Replace `console.warn(...)` with ' +
+      '`devWarn(...)`.\n\n',
+  );
+  for (const violation of violations) {
+    process.stderr.write(
+      `  ${violation.filePath}:${violation.lineNumber}\n    ${violation.line}\n`,
+    );
+  }
+  process.exit(1);
+}
+
+if (import.meta.main) {
+  main().catch((error: unknown) => {
+    console.error('check-no-bare-console-warn failed:', error);
+    process.exit(1);
+  });
+}

--- a/packages/components/src/_internal/PLATFORM-POLICY.md
+++ b/packages/components/src/_internal/PLATFORM-POLICY.md
@@ -88,3 +88,26 @@ for human judgment rather than banning features outright. It runs in the
 When a new modern feature enters the codebase, add a row to the classification
 table above (with its tier and rule) in the same change. A feature with no row is
 unclassified and will be flagged in review.
+
+## Development-only diagnostics
+
+Component contract-misuse warnings — a missing required prop, an `id` that does
+not match the wrapping `FormField`, a duplicate key, an unresolved portal target,
+a deprecated import path — are diagnostics for the **developer building the app**,
+never for the end user. They must route through `devWarn(...)` from
+`utilities/dev-warn.ts`, which gates on `DEV` from `esm-env` and is dead-code-
+eliminated from production bundles. A bare `console.warn` in component source
+ships the warning string (and internal naming) to end users and is forbidden.
+
+- **Rule:** no bare `console.warn` in `src/components/**` (`.svelte` or `.ts`).
+  Use `devWarn(message, ...args)` instead. `devWarn` self-gates on `DEV`, so do
+  **not** wrap it in `if (DEV) { … }` or add a `!DEV` early-return around it.
+- **Don't keep a `$effect` alive solely to warn.** A reactive effect whose only
+  job is to log re-subscribes on every state change for no runtime benefit. Warn
+  from a plain guard at the point of misuse (e.g. right after the `$props()`
+  destructure for a "missing required prop" check) unless the condition is
+  genuinely reactive and a test asserts the warning fires on a specific change.
+- **Enforcement:** `bun run check:no-bare-console-warn` (a scanned grep with an
+  explicit allow-list, in the `lint` chain and CI) fails on any bare
+  `console.warn` in component source. oxlint cannot express this rule because
+  Svelte files are in its `ignorePatterns`.

--- a/packages/components/src/components/autocomplete/autocomplete.svelte
+++ b/packages/components/src/components/autocomplete/autocomplete.svelte
@@ -20,9 +20,8 @@
 </script>
 
 <script lang="ts">
-  import { DEV } from 'esm-env';
-
   import type { AutocompleteProps, AutocompleteSuggestion } from './autocomplete.types.ts';
+  import { devWarn } from '../../utilities/dev-warn.ts';
   import {
     ariaInvalid,
     composeDescribedBy,
@@ -63,9 +62,8 @@
   const resolvedMaxVisibleSuggestions = $derived(toNonNegativeInteger(maxVisibleSuggestions, 50));
 
   $effect(() => {
-    if (!DEV) return;
     if (context && id && context.controlId !== id) {
-      console.warn(
+      devWarn(
         `[cinder/Autocomplete] id mismatch: Autocomplete id="${id}" but wrapping FormField expects controlId="${context.controlId}". Set the same id on both.`,
       );
     }
@@ -209,9 +207,7 @@
       if (controller.signal.aborted || currentVersion !== requestVersion) return;
       suggestions = [];
       closePopup();
-      if (DEV) {
-        console.warn('[cinder/autocomplete] suggestionSource failed.', errorValue);
-      }
+      devWarn('[cinder/autocomplete] suggestionSource failed.', errorValue);
       return;
     }
 
@@ -239,9 +235,7 @@
         }
         suggestions = [];
         closePopup();
-        if (DEV) {
-          console.warn('[cinder/autocomplete] suggestionSource failed.', errorValue);
-        }
+        devWarn('[cinder/autocomplete] suggestionSource failed.', errorValue);
       })
       .finally(() => {
         if (pendingRequestController === controller) {

--- a/packages/components/src/components/button-group/button-group.svelte
+++ b/packages/components/src/components/button-group/button-group.svelte
@@ -20,9 +20,9 @@
 <script lang="ts">
   import type { ButtonGroupProps } from './button-group.types.ts';
   import type { Attachment } from 'svelte/attachments';
-  import { DEV } from 'esm-env';
 
   import { classNames } from '../../utilities/class-names.ts';
+  import { devWarn } from '../../utilities/dev-warn.ts';
 
   let {
     label,
@@ -89,26 +89,24 @@
   };
 
   $effect(() => {
-    if (!DEV) return;
-
     const hasLabel = typeof label === 'string';
     const hasLabelledBy = typeof labelledBy === 'string';
 
     if (!hasLabel && !hasLabelledBy) {
-      console.warn(
+      devWarn(
         "[cinder/ButtonGroup] rendered without a non-empty accessible name — pass a non-empty 'label' or 'labelledBy'.",
       );
       return;
     }
 
     if (hasLabel && label.trim().length === 0) {
-      console.warn(
+      devWarn(
         "[cinder/ButtonGroup] rendered without a non-empty accessible name — pass a non-empty 'label' or 'labelledBy'.",
       );
     }
 
     if (hasLabelledBy && labelledBy.trim().length === 0) {
-      console.warn(
+      devWarn(
         "[cinder/ButtonGroup] rendered without a non-empty accessible name — pass a non-empty 'label' or 'labelledBy'.",
       );
     }

--- a/packages/components/src/components/button/button.svelte
+++ b/packages/components/src/components/button/button.svelte
@@ -16,10 +16,10 @@
 </script>
 
 <script lang="ts">
-  import { DEV } from 'esm-env';
   import type { HTMLAnchorAttributes, HTMLButtonAttributes } from 'svelte/elements';
 
   import { classNames } from '../../utilities/class-names.ts';
+  import { devWarn } from '../../utilities/dev-warn.ts';
   import type { ButtonProps } from './button.types.ts';
 
   // Destructured props let the Phase 4 analyzer read names + defaults straight off the AST.
@@ -150,12 +150,9 @@
     }
   }
 
-  // Dev-mode guards. DEV from esm-env is a bundler-replaced constant: true in dev, false in
-  // prod — the whole $effect body is tree-shaken in production. Guards run reactively so prop
-  // changes after mount also surface issues.
+  // Dev-mode guards. devWarn no-ops in production (bundler DCE strips the call when DEV=false).
+  // Guards run reactively so prop changes after mount also surface issues.
   $effect(() => {
-    if (!DEV) return;
-
     // Guard 1 — Updated baseline: warn when the button has no accessible name at all.
     // Use the normalized resolved values so an empty aria-label="" doesn't falsely satisfy the check.
     const hasLabel = typeof label === 'string' && label.trim().length > 0;
@@ -163,7 +160,7 @@
     const hasAriaLabel = resolvedAriaLabel !== undefined;
     const hasAriaLabelledBy = resolvedAriaLabelledBy !== undefined;
     if (!hasLabel && !hasChildren && !hasAriaLabel && !hasAriaLabelledBy) {
-      console.warn(
+      devWarn(
         '[cinder/Button] rendered without an accessible name — pass a non-empty `label`, `children`, `aria-label`, or `aria-labelledby`.',
       );
     }
@@ -171,14 +168,14 @@
     // Guard 2 — icon-only accessible name: children alone does not count because it may be a
     // non-text SVG. Requires aria-label, aria-labelledby, or a non-empty label string.
     if (iconOnly && !hasAriaLabel && !hasAriaLabelledBy && !hasLabel) {
-      console.warn(
+      devWarn(
         '[cinder/Button] iconOnly=true requires aria-label, aria-labelledby, or a non-empty label.',
       );
     }
 
     // Guard 3 — icon-only visual: a blank square is a real UI failure, not just an a11y issue.
     if (iconOnly && !leadingIcon && !trailingIcon && !children) {
-      console.warn(
+      devWarn(
         '[cinder/Button] iconOnly=true requires a visible icon — pass leadingIcon, trailingIcon, or children.',
       );
     }

--- a/packages/components/src/components/code-block/code-block.svelte
+++ b/packages/components/src/components/code-block/code-block.svelte
@@ -18,6 +18,7 @@
 <script lang="ts">
   import { loadDefaultHighlighter } from './code-block-default-highlighter.ts';
   import { classNames } from '../../utilities/class-names.ts';
+  import { devWarn } from '../../utilities/dev-warn.ts';
   import CopyButton from '../copy-button/copy-button.svelte';
   import type { CodeBlockProps } from './code-block.types.ts';
 
@@ -81,10 +82,7 @@
         // Never log the code itself — a code block can contain secrets. Log
         // the language and the error class/message only.
         const detail = error instanceof Error ? `${error.name}: ${error.message}` : String(error);
-        console.warn(
-          `[cinder/CodeBlock] highlight failed for language "${pendingLanguage}":`,
-          detail,
-        );
+        devWarn(`[cinder/CodeBlock] highlight failed for language "${pendingLanguage}":`, detail);
       }
     })();
 

--- a/packages/components/src/components/color-field/color-field.svelte
+++ b/packages/components/src/components/color-field/color-field.svelte
@@ -16,10 +16,10 @@
 </script>
 
 <script lang="ts">
-  import { DEV } from 'esm-env';
   import { untrack } from 'svelte';
 
   import { classNames } from '../../utilities/class-names.ts';
+  import { devWarn } from '../../utilities/dev-warn.ts';
   import { parseColor } from '../../utilities/color-luminance.ts';
   import Input from '../input/input.svelte';
   import type { ColorFieldProps } from './color-field.types.ts';
@@ -187,9 +187,7 @@
   $effect(() => {
     if (!isControlled) return;
     if (value === undefined) {
-      if (DEV) {
-        console.warn('[cinder/ColorField] runtime mode switch ignored (controlled -> undefined)');
-      }
+      devWarn('[cinder/ColorField] runtime mode switch ignored (controlled -> undefined)');
       return;
     }
     if (value === lastReconciledValue) return;

--- a/packages/components/src/components/color-swatch-picker/color-swatch-picker.svelte
+++ b/packages/components/src/components/color-swatch-picker/color-swatch-picker.svelte
@@ -17,9 +17,9 @@
 <script lang="ts">
   import type { ColorSwatchPickerProps } from './color-swatch-picker.types.ts';
   import { tick, untrack } from 'svelte';
-  import { DEV } from 'esm-env';
 
   import { cn } from '../../utilities/class-names.ts';
+  import { devWarn } from '../../utilities/dev-warn.ts';
   import { hasAlpha, pickContrastColor } from '../../utilities/color-luminance.ts';
   import { handleRovingKeydown } from '../../utilities/roving-tabindex.ts';
   import Check from 'lucide-svelte/icons/check';
@@ -136,14 +136,12 @@
 
   // Warn in dev mode when duplicate colors appear in the palette.
   $effect(() => {
-    if (DEV) {
-      const colorValues = colors.map((c) => c.color);
-      if (new Set(colorValues).size !== colorValues.length) {
-        console.warn(
-          '[ColorSwatchPicker] Duplicate color values detected in palette. ' +
-            'Only the first matching swatch will be shown as selected.',
-        );
-      }
+    const colorValues = colors.map((c) => c.color);
+    if (new Set(colorValues).size !== colorValues.length) {
+      devWarn(
+        '[ColorSwatchPicker] Duplicate color values detected in palette. ' +
+          'Only the first matching swatch will be shown as selected.',
+      );
     }
   });
 </script>

--- a/packages/components/src/components/experimental/connection-indicator/index.ts
+++ b/packages/components/src/components/experimental/connection-indicator/index.ts
@@ -6,14 +6,12 @@
 // and warns once (dev only) so consumers migrate before the alias is removed
 // in the next major. Generated/managed by scripts/generate-exports.ts.
 
-import { DEV } from 'esm-env';
+import { devWarn } from '../../../utilities/dev-warn.ts';
 
-if (DEV) {
-  console.warn(
-    "[cinder] 'cinder/experimental/connection-indicator' is deprecated and will be removed in the next major. " +
-      "Import from 'cinder/connection-indicator' instead.",
-  );
-}
+devWarn(
+  "[cinder] 'cinder/experimental/connection-indicator' is deprecated and will be removed in the next major. " +
+    "Import from 'cinder/connection-indicator' instead.",
+);
 
 export { ConnectionIndicator, default } from '../../connection-indicator/index.ts';
 export type {

--- a/packages/components/src/components/experimental/json-viewer/index.ts
+++ b/packages/components/src/components/experimental/json-viewer/index.ts
@@ -6,14 +6,12 @@
 // once (dev only) so consumers migrate before the alias is removed in the
 // next major. Generated/managed by scripts/generate-exports.ts.
 
-import { DEV } from 'esm-env';
+import { devWarn } from '../../../utilities/dev-warn.ts';
 
-if (DEV) {
-  console.warn(
-    "[cinder] 'cinder/experimental/json-viewer' is deprecated and will be removed in the next major. " +
-      "Import from 'cinder/json-viewer' instead.",
-  );
-}
+devWarn(
+  "[cinder] 'cinder/experimental/json-viewer' is deprecated and will be removed in the next major. " +
+    "Import from 'cinder/json-viewer' instead.",
+);
 
 export { default, JsonViewer } from '../../json-viewer/index.ts';
 export type { JsonViewerProps } from '../../json-viewer/index.ts';

--- a/packages/components/src/components/experimental/message/index.ts
+++ b/packages/components/src/components/experimental/message/index.ts
@@ -6,14 +6,12 @@
 // only) so consumers migrate before the alias is removed in the next major.
 // Generated/managed by scripts/generate-exports.ts.
 
-import { DEV } from 'esm-env';
+import { devWarn } from '../../../utilities/dev-warn.ts';
 
-if (DEV) {
-  console.warn(
-    "[cinder] 'cinder/experimental/message' is deprecated and will be removed in the next major. " +
-      "Import from 'cinder/message' instead.",
-  );
-}
+devWarn(
+  "[cinder] 'cinder/experimental/message' is deprecated and will be removed in the next major. " +
+    "Import from 'cinder/message' instead.",
+);
 
 export { default, Message } from '../../message/index.ts';
 export type { MessageProps, MessageRole } from '../../message/index.ts';

--- a/packages/components/src/components/experimental/timeline-item/index.ts
+++ b/packages/components/src/components/experimental/timeline-item/index.ts
@@ -6,14 +6,12 @@
 // once (dev only) so consumers migrate before the alias is removed in the
 // next major. Generated/managed by scripts/generate-exports.ts.
 
-import { DEV } from 'esm-env';
+import { devWarn } from '../../../utilities/dev-warn.ts';
 
-if (DEV) {
-  console.warn(
-    "[cinder] 'cinder/experimental/timeline-item' is deprecated and will be removed in the next major. " +
-      "Import from 'cinder/timeline-item' instead.",
-  );
-}
+devWarn(
+  "[cinder] 'cinder/experimental/timeline-item' is deprecated and will be removed in the next major. " +
+    "Import from 'cinder/timeline-item' instead.",
+);
 
 export { default, TimelineItem } from '../../timeline-item/index.ts';
 export type { TimelineItemProps } from '../../timeline-item/index.ts';

--- a/packages/components/src/components/experimental/timeline/index.ts
+++ b/packages/components/src/components/experimental/timeline/index.ts
@@ -6,14 +6,12 @@
 // only) so consumers migrate before the alias is removed in the next major.
 // Generated/managed by scripts/generate-exports.ts.
 
-import { DEV } from 'esm-env';
+import { devWarn } from '../../../utilities/dev-warn.ts';
 
-if (DEV) {
-  console.warn(
-    "[cinder] 'cinder/experimental/timeline' is deprecated and will be removed in the next major. " +
-      "Import from 'cinder/timeline' instead.",
-  );
-}
+devWarn(
+  "[cinder] 'cinder/experimental/timeline' is deprecated and will be removed in the next major. " +
+    "Import from 'cinder/timeline' instead.",
+);
 
 export { default, Timeline } from '../../timeline/index.ts';
 export type {

--- a/packages/components/src/components/file-upload/file-upload.svelte
+++ b/packages/components/src/components/file-upload/file-upload.svelte
@@ -21,11 +21,10 @@
 </script>
 
 <script lang="ts">
-  import { DEV } from 'esm-env';
-
   import { ariaInvalid, composeDescribedBy } from '../../_internal/field-control.ts';
   import { getFormFieldContext } from '../../_internal/form-field-context.ts';
   import { classNames } from '../../utilities/class-names.ts';
+  import { devWarn } from '../../utilities/dev-warn.ts';
   import { formatBytes } from '../../utilities/format-bytes.ts';
   import { useAnnouncer } from '../../utilities/use-announcer.svelte.ts';
   import type { FileUploadEntry, FileUploadProps, RejectedFile } from './file-upload.types.ts';
@@ -73,9 +72,8 @@
   const renderedEntries = $derived(files ?? internalEntries);
 
   $effect(() => {
-    if (!DEV) return;
     if (context && id && context.controlId !== id) {
-      console.warn(
+      devWarn(
         `[cinder/FileUpload] id mismatch: FileUpload id="${id}" but wrapping FormField expects controlId="${context.controlId}". Set the same id on both.`,
       );
     }

--- a/packages/components/src/components/form-section/form-section.svelte
+++ b/packages/components/src/components/form-section/form-section.svelte
@@ -11,8 +11,6 @@
    * @avoidWhen Wrapping a single control with its label and error — use form-field instead.
    * @related form-field, section-heading
    */
-  import { DEV } from 'esm-env';
-
   const headingTags: Record<FormSectionHeadingLevel, string> = {
     2: 'h2',
     3: 'h3',
@@ -27,6 +25,7 @@
 <script lang="ts">
   import type { FormSectionHeadingLevel, FormSectionProps } from './form-section.types.ts';
   import { classNames } from '../../utilities/class-names.ts';
+  import { devWarn } from '../../utilities/dev-warn.ts';
 
   let {
     as = 'section',
@@ -38,16 +37,18 @@
     children,
   }: FormSectionProps = $props();
 
-  const headingTag = $derived(headingTags[headingLevel as FormSectionHeadingLevel] ?? 'h2');
-
+  // Re-check reactively: `as` and `heading` are ordinary (non-bindable) props
+  // that a parent can change on re-render, so the warning must fire whenever the
+  // combination becomes invalid, not only at mount. devWarn self-gates on DEV.
   $effect(() => {
-    if (!DEV) return;
     if (as === 'fieldset' && !heading) {
-      console.warn(
+      devWarn(
         '[cinder/FormSection] `as="fieldset"` requires a `heading` prop — a fieldset without a legend has no accessible group name.',
       );
     }
   });
+
+  const headingTag = $derived(headingTags[headingLevel as FormSectionHeadingLevel] ?? 'h2');
 </script>
 
 {#if as === 'fieldset'}

--- a/packages/components/src/components/hover-card/hover-card.svelte
+++ b/packages/components/src/components/hover-card/hover-card.svelte
@@ -17,8 +17,8 @@
 
 <script lang="ts">
   import type { HoverCardProps } from './hover-card.types.ts';
-  import { DEV } from 'esm-env';
   import { onDestroy } from 'svelte';
+  import { devWarn } from '../../utilities/dev-warn.ts';
   import type { Placement } from '@floating-ui/dom';
   import { createAnchoredOverlay } from '../../_internal/anchored-overlay.svelte.ts';
   import { classNames } from '../../utilities/class-names.ts';
@@ -206,12 +206,10 @@
   });
 
   $effect(() => {
-    if (!DEV || !open || !cardElement) return;
+    if (!open || !cardElement) return;
     const focusable = cardElement.querySelector(focusableSelector);
     if (focusable) {
-      console.warn(
-        'HoverCard content should be non-interactive. Use Popover for focusable content.',
-      );
+      devWarn('HoverCard content should be non-interactive. Use Popover for focusable content.');
     }
   });
 </script>

--- a/packages/components/src/components/input/input.svelte
+++ b/packages/components/src/components/input/input.svelte
@@ -17,7 +17,6 @@
 
 <script lang="ts">
   import type { InputProps } from './input.types.ts';
-  import { DEV } from 'esm-env';
 
   import {
     ariaInvalid,
@@ -27,6 +26,7 @@
   } from '../../_internal/field-control.ts';
   import { getFormFieldContext } from '../../_internal/form-field-context.ts';
   import { cn } from '../../utilities/class-names.ts';
+  import { devWarn } from '../../utilities/dev-warn.ts';
 
   let {
     id,
@@ -48,9 +48,8 @@
   const context = getFormFieldContext();
 
   $effect(() => {
-    if (!DEV) return;
     if (context && context.controlId !== id) {
-      console.warn(
+      devWarn(
         `[cinder/Input] id mismatch: Input id="${id}" but wrapping FormField expects controlId="${context.controlId}". Set the same id on both.`,
       );
     }

--- a/packages/components/src/components/kanban-board/kanban-board.svelte
+++ b/packages/components/src/components/kanban-board/kanban-board.svelte
@@ -25,6 +25,7 @@
 
 <script lang="ts" generics="Card">
   import { cn } from '../../utilities/class-names.ts';
+  import { devWarn } from '../../utilities/dev-warn.ts';
   import {
     SortableController,
     setSortableContext,
@@ -111,7 +112,7 @@
     const warningSignature = `${duplicateColumns}|${duplicateCards}`;
     if (warningSignature === lastInvalidKeyWarning) return;
     lastInvalidKeyWarning = warningSignature;
-    console.warn(
+    devWarn(
       `[cinder-kanban-board] duplicate keys disable reordering. Duplicate columns: ${duplicateColumns || 'none'}. Duplicate cards: ${duplicateCards || 'none'}.`,
     );
   });

--- a/packages/components/src/components/markdown-editor/markdown-editor.svelte
+++ b/packages/components/src/components/markdown-editor/markdown-editor.svelte
@@ -24,6 +24,7 @@
 <script lang="ts">
   import { BROWSER as browser } from 'esm-env';
   import { onDestroy } from 'svelte';
+  import { devWarn } from '../../utilities/dev-warn.ts';
   import type { Ctx } from '@milkdown/kit/ctx';
   import type {
     ActiveBlockType,
@@ -132,7 +133,7 @@
     try {
       return pipelineUtilities?.normalize(markdown) ?? normalizeForEditor(markdown);
     } catch (error) {
-      console.warn('Failed to normalize markdown, using raw value:', error);
+      devWarn('Failed to normalize markdown, using raw value:', error);
       return markdown;
     }
   }
@@ -495,7 +496,7 @@
         try {
           latestMarkdown = editorState.getMarkdown();
         } catch (error) {
-          console.warn('Failed to read markdown from editor during mode switch:', error);
+          devWarn('Failed to read markdown from editor during mode switch:', error);
         }
         editorState.clearPendingTimers();
       }

--- a/packages/components/src/components/modal/modal.svelte
+++ b/packages/components/src/components/modal/modal.svelte
@@ -20,8 +20,8 @@
 <script lang="ts">
   import type { ModalProps } from './modal.types.ts';
   import { onDestroy } from 'svelte';
-  import { DEV } from 'esm-env';
   import { captureFocus, lockBodyScroll, pushEscapeHandler } from '../../_internal/overlay.ts';
+  import { devWarn } from '../../utilities/dev-warn.ts';
   import { overflowFade } from '../../utilities/attachments.ts';
   import { classNames } from '../../utilities/class-names.ts';
   import { restoreFocusTo } from '../../utilities/focus.ts';
@@ -94,12 +94,11 @@
   });
 
   $effect(() => {
-    if (!DEV) return;
     if (
       role === 'alertdialog' &&
       (dismissOnBackdropClick !== false || dismissOnEscape !== false || showCloseButton !== false)
     ) {
-      console.warn(
+      devWarn(
         '[cinder/Modal] role="alertdialog" requires dismissOnBackdropClick={false}, dismissOnEscape={false}, and showCloseButton={false}. ' +
           'Without these, Escape or backdrop click can bypass the mandatory acknowledgement. ' +
           'Use <AlertDialog> instead, or pass all three companion props explicitly.',

--- a/packages/components/src/components/phone-input/phone-input.svelte
+++ b/packages/components/src/components/phone-input/phone-input.svelte
@@ -27,7 +27,7 @@
     PhoneInputCountryOption,
     PhoneInputProps,
   } from './phone-input.types.ts';
-  import { DEV } from 'esm-env';
+  import { devWarn } from '../../utilities/dev-warn.ts';
 
   import {
     ariaInvalid,
@@ -73,9 +73,8 @@
   );
 
   $effect(() => {
-    if (!DEV) return;
     if (usedFallback) {
-      console.warn(
+      devWarn(
         `[cinder/PhoneInput] No supported country in the provided countries allow-list — falling back to ['US'].`,
       );
     }
@@ -183,11 +182,9 @@
     if (country === knownCountry) return;
     knownCountry = country;
     if (!isAllowed(country)) {
-      if (DEV) {
-        console.warn(
-          `[cinder/PhoneInput] country="${country}" is not in the countries allow-list — falling back to "${fallbackCountry()}".`,
-        );
-      }
+      devWarn(
+        `[cinder/PhoneInput] country="${country}" is not in the countries allow-list — falling back to "${fallbackCountry()}".`,
+      );
       country = fallbackCountry();
       return;
     }
@@ -391,9 +388,8 @@
   );
 
   $effect(() => {
-    if (!DEV) return;
     if (!hasGroupAccessibleName) {
-      console.warn(
+      devWarn(
         `[cinder/PhoneInput] No accessible name source for id="${id}". Provide a label, aria-label, aria-labelledby, or wrap in a FormField.`,
       );
     }

--- a/packages/components/src/components/pin-input/pin-input.svelte
+++ b/packages/components/src/components/pin-input/pin-input.svelte
@@ -17,8 +17,9 @@
 
 <script lang="ts">
   import type { PinInputProps } from './pin-input.types.ts';
-  import { DEV } from 'esm-env';
   import { untrack } from 'svelte';
+
+  import { devWarn } from '../../utilities/dev-warn.ts';
 
   import {
     ariaInvalid,
@@ -137,9 +138,8 @@
   );
 
   $effect(() => {
-    if (!DEV) return;
     if (!hasGroupAccessibleName) {
-      console.warn(
+      devWarn(
         `[cinder/PinInput] No accessible name source for id="${id}". Provide a label, aria-label, aria-labelledby, or wrap in a FormField.`,
       );
     }

--- a/packages/components/src/components/popover/popover.svelte
+++ b/packages/components/src/components/popover/popover.svelte
@@ -24,10 +24,10 @@
 <script lang="ts">
   import type { PopoverProps } from './popover.types.ts';
   import { onDestroy, untrack } from 'svelte';
-  import { DEV } from 'esm-env';
   import type { Placement } from '@floating-ui/dom';
   import { createAnchoredOverlay } from '../../_internal/anchored-overlay.svelte.ts';
   import { captureFocus, pushEscapeHandler } from '../../_internal/overlay.ts';
+  import { devWarn } from '../../utilities/dev-warn.ts';
   import { classNames } from '../../utilities/class-names.ts';
   import { restoreFocusTo } from '../../utilities/focus.ts';
   import { createPortalAttachment } from '../portal/index.ts';
@@ -203,22 +203,21 @@
   // Effect: dev-only guidance warnings. Single effect, fires on each open
   // transition; the cost of repeat warnings is acceptable for dev mode.
   $effect(() => {
-    if (!DEV) return;
     if (!open) return;
     if (!anchorElement) {
-      console.warn(
+      devWarn(
         '[cinder/popover] open without a trigger anchor. ' +
           'Provide either a `trigger` snippet with a focusable child or a `triggerRef`.',
       );
     }
     if (role === 'dialog' && !label && !ariaLabelledby) {
-      console.warn(
+      devWarn(
         '[cinder/popover] role="dialog" without `label` or `ariaLabelledby` falls back to ' +
           'aria-label="Popover". Pass a descriptive name for production usage.',
       );
     }
     if (role === 'listbox' && wireTriggerAria) {
-      console.warn(
+      devWarn(
         '[cinder/popover] role="listbox" only sets the surface role. ' +
           'You must render role="option" children and own selection/keyboard semantics. ' +
           'See popover.a11y.md §Role.',

--- a/packages/components/src/components/portal/portal.utilities.svelte.ts
+++ b/packages/components/src/components/portal/portal.utilities.svelte.ts
@@ -1,6 +1,6 @@
 import type { Attachment } from 'svelte/attachments';
 
-import { DEV } from 'esm-env';
+import { devWarn } from '../../utilities/dev-warn.ts';
 
 import { readOption } from '../../utilities/read-option.ts';
 
@@ -141,8 +141,8 @@ export function createPortalAttachment(
         // Target unresolved: keep the wrapper inline at the anchor so children remain rendered
         // (with a dev warning) instead of vanishing from the DOM entirely.
         restoreInline();
-        if (DEV && lastWarnedUnresolvedKey !== resolved.key) {
-          console.warn(
+        if (lastWarnedUnresolvedKey !== resolved.key) {
+          devWarn(
             `[cinder/portal] could not resolve portal target ${JSON.stringify(resolved.key)}.`,
           );
           lastWarnedUnresolvedKey = resolved.key;

--- a/packages/components/src/components/rating/rating.svelte
+++ b/packages/components/src/components/rating/rating.svelte
@@ -17,7 +17,6 @@
 
 <script lang="ts">
   import type { RatingProps } from './rating.types.ts';
-  import { DEV } from 'esm-env';
 
   import {
     ariaInvalid,
@@ -27,6 +26,7 @@
   } from '../../_internal/field-control.ts';
   import { getFormFieldContext } from '../../_internal/form-field-context.ts';
   import { classNames } from '../../utilities/class-names.ts';
+  import { devWarn } from '../../utilities/dev-warn.ts';
 
   let {
     id,
@@ -124,9 +124,8 @@
   );
 
   $effect(() => {
-    if (!DEV) return;
     if (!hasGroupAccessibleName) {
-      console.warn(
+      devWarn(
         `[cinder/Rating] No accessible name source for id="${id}". Provide a label, aria-label, aria-labelledby, or wrap in a FormField.`,
       );
     }

--- a/packages/components/src/components/resizable-panels/resizable-panels.svelte
+++ b/packages/components/src/components/resizable-panels/resizable-panels.svelte
@@ -29,6 +29,7 @@
 
 <script lang="ts">
   import { classNames } from '../../utilities/class-names.ts';
+  import { devWarn } from '../../utilities/dev-warn.ts';
   import {
     applyPointerDragDelta,
     applyPairDelta,
@@ -213,9 +214,9 @@
   });
 
   $effect(() => {
-    if (!issues.length || typeof console === 'undefined') return;
+    if (!issues.length) return;
     for (const issue of issues) {
-      console.warn(`[cinder/ResizablePanels] ${issue}`);
+      devWarn(`[cinder/ResizablePanels] ${issue}`);
     }
   });
 

--- a/packages/components/src/components/review-editor/review-editor-impl.svelte
+++ b/packages/components/src/components/review-editor/review-editor-impl.svelte
@@ -17,6 +17,7 @@
 
 <script lang="ts">
   import { classNames } from '../../utilities/class-names.ts';
+  import { devWarn } from '../../utilities/dev-warn.ts';
   import { createFocusRegionNavigator, type FocusRegion } from './focus-navigation.ts';
   import { createChangeTracker } from '../../utilities/change-tracker.svelte.ts';
   import { stringifyOrNull } from '../../utilities/stringify.ts';
@@ -917,7 +918,7 @@
    */
   function handleAddDocumentComment(body: string): void {
     if (!currentUserId) {
-      console.warn('Cannot add document comment: no currentUserId');
+      devWarn('Cannot add document comment: no currentUserId');
       return;
     }
 
@@ -1130,7 +1131,7 @@
   function handleSelectionComment(body: string): void {
     // Helper to clear popover state and announce failure
     function failWithMessage(message: string): void {
-      console.warn(message);
+      devWarn(message);
       selectionPopoverPosition = null;
       capturedSelectionForPopover = null;
       selectionPopoverExpanded = false;
@@ -1243,18 +1244,18 @@
    */
   export function createThread(body: string, authorId: string): string | null {
     if (!currentSelection || currentSelection.isCollapsed) {
-      console.warn('Cannot create thread: no text selected');
+      devWarn('Cannot create thread: no text selected');
       return null;
     }
 
     if (mode === 'readonly') {
-      console.warn('Cannot create thread: editor is readonly');
+      devWarn('Cannot create thread: editor is readonly');
       return null;
     }
 
     const view = editorRef?.getView();
     if (!view) {
-      console.warn('Cannot create thread: editor view not available');
+      devWarn('Cannot create thread: editor view not available');
       return null;
     }
 
@@ -1297,7 +1298,7 @@
    */
   export function createDocumentThread(body: string, authorId: string): string | null {
     if (mode === 'readonly') {
-      console.warn('Cannot create thread: editor is readonly');
+      devWarn('Cannot create thread: editor is readonly');
       return null;
     }
 
@@ -1475,13 +1476,13 @@
    */
   export function createBlockThread(body: string, authorId: string): string | null {
     if (mode === 'readonly') {
-      console.warn('Cannot create block thread: editor is readonly');
+      devWarn('Cannot create block thread: editor is readonly');
       return null;
     }
 
     const view = editorRef?.getView();
     if (!view) {
-      console.warn('Cannot create block thread: editor view not available');
+      devWarn('Cannot create block thread: editor view not available');
       return null;
     }
 
@@ -1520,7 +1521,7 @@
       return requestId;
     }
 
-    console.warn('Cannot create block thread: cursor not inside a block');
+    devWarn('Cannot create block thread: cursor not inside a block');
     return null;
   }
 

--- a/packages/components/src/components/review-editor/review-editor-selection.svelte.ts
+++ b/packages/components/src/components/review-editor/review-editor-selection.svelte.ts
@@ -23,6 +23,7 @@ import type { EditorView } from '@milkdown/kit/prose/view';
 import { buildAnchorFromSelection } from 'cinder/commentary/anchoring';
 import type { ThreadCreateEvent } from 'cinder/commentary/comments';
 import { extractMentions, generateId } from 'cinder/commentary/comments';
+import { devWarn } from '../../utilities/dev-warn.ts';
 import type {
   PopoverPosition,
   ReviewMode,
@@ -206,7 +207,7 @@ export function createSelectionPopover(options: SelectionPopoverOptions): Select
   function handleComment(body: string): void {
     // Helper to clear state and announce failure
     function failWithMessage(message: string): void {
-      console.warn(message);
+      devWarn(message);
       clear();
       announce('Could not add comment. Please try selecting text again.', 'assertive');
     }

--- a/packages/components/src/components/review-editor/review-editor-threads.svelte.ts
+++ b/packages/components/src/components/review-editor/review-editor-threads.svelte.ts
@@ -30,6 +30,7 @@ import type {
   ThreadDeleteEvent,
 } from 'cinder/commentary/comments';
 import { createDocumentAnchor, extractMentions, generateId } from 'cinder/commentary/comments';
+import { devWarn } from '../../utilities/dev-warn.ts';
 import type { PopoverPosition, ReviewMode } from './review-editor-types';
 
 /** Type alias for thread ID to improve readability */
@@ -378,18 +379,18 @@ export function createThreadManager(options: ThreadManagerOptions): ThreadManage
     selection: { from: number; to: number } | null,
   ): string | null {
     if (!selection || selection.from === selection.to) {
-      console.warn('Cannot create thread: no text selected');
+      devWarn('Cannot create thread: no text selected');
       return null;
     }
 
     if (getMode() === 'readonly') {
-      console.warn('Cannot create thread: editor is readonly');
+      devWarn('Cannot create thread: editor is readonly');
       return null;
     }
 
     const view = getEditorView();
     if (!view) {
-      console.warn('Cannot create thread: editor view not available');
+      devWarn('Cannot create thread: editor view not available');
       return null;
     }
 
@@ -413,7 +414,7 @@ export function createThreadManager(options: ThreadManagerOptions): ThreadManage
 
   function createDocumentThread(body: string, authorId: string): string | null {
     if (getMode() === 'readonly') {
-      console.warn('Cannot create thread: editor is readonly');
+      devWarn('Cannot create thread: editor is readonly');
       return null;
     }
 
@@ -436,13 +437,13 @@ export function createThreadManager(options: ThreadManagerOptions): ThreadManage
 
   function createBlockThread(body: string, authorId: string): string | null {
     if (getMode() === 'readonly') {
-      console.warn('Cannot create block thread: editor is readonly');
+      devWarn('Cannot create block thread: editor is readonly');
       return null;
     }
 
     const view = getEditorView();
     if (!view) {
-      console.warn('Cannot create block thread: editor view not available');
+      devWarn('Cannot create block thread: editor view not available');
       return null;
     }
 
@@ -470,7 +471,7 @@ export function createThreadManager(options: ThreadManagerOptions): ThreadManage
       return requestId;
     }
 
-    console.warn('Cannot create block thread: cursor not inside a block');
+    devWarn('Cannot create block thread: cursor not inside a block');
     return null;
   }
 

--- a/packages/components/src/components/search-field/search-field.svelte
+++ b/packages/components/src/components/search-field/search-field.svelte
@@ -15,12 +15,12 @@
 </script>
 
 <script lang="ts">
-  import { DEV } from 'esm-env';
   import { untrack } from 'svelte';
   import type { Attachment } from 'svelte/attachments';
 
   import Search from 'lucide-svelte/icons/search';
   import X from 'lucide-svelte/icons/x';
+  import { devWarn } from '../../utilities/dev-warn.ts';
   import type { SearchFieldProps } from './search-field.types.ts';
   import { ariaInvalid, composeDescribedBy } from '../../_internal/field-control.ts';
   import { getFormFieldContext } from '../../_internal/form-field-context.ts';
@@ -66,9 +66,8 @@
   const clearInert = $derived(resolvedDisabled || readonly === true);
 
   $effect(() => {
-    if (!DEV) return;
     if (context && id && context.controlId !== id) {
-      console.warn(
+      devWarn(
         `[cinder/SearchField] id mismatch: SearchField id="${id}" but wrapping FormField expects controlId="${context.controlId}". Set the same id on both.`,
       );
     }

--- a/packages/components/src/components/select/select.svelte
+++ b/packages/components/src/components/select/select.svelte
@@ -20,6 +20,7 @@
   import { resolveFieldControl } from '../../_internal/field-control.ts';
   import { getFormFieldContext } from '../../_internal/form-field-context.ts';
   import { classNames } from '../../utilities/class-names.ts';
+  import { devWarn } from '../../utilities/dev-warn.ts';
 
   let {
     id,
@@ -60,7 +61,7 @@
   // server output with warnings. $effect never runs on the server in Svelte 5.
   $effect(() => {
     if (typeof window !== 'undefined' && options.length === 0) {
-      console.warn('Select: options is empty');
+      devWarn('Select: options is empty');
     }
   });
 </script>

--- a/packages/components/src/components/slider/slider.svelte
+++ b/packages/components/src/components/slider/slider.svelte
@@ -26,6 +26,7 @@
   import { untrack } from 'svelte';
   import { getFormFieldContext } from '../../_internal/form-field-context.ts';
   import { classNames } from '../../utilities/class-names.ts';
+  import { devWarn } from '../../utilities/dev-warn.ts';
 
   let {
     value,
@@ -48,30 +49,30 @@
   const disabled = $derived(disabledProp || (formField?.disabled ?? false));
 
   // Guarantee a usable step. `0`, `NaN`, and negative values would let the
-  // tick generator loop forever, so fall back to `1` and warn during dev.
-  const safeStep = $derived.by(() => {
-    if (!Number.isFinite(step) || step <= 0) {
-      if (typeof console !== 'undefined') {
-        console.warn(
-          `[cinder/Slider] step must be a positive finite number — received ${step}. Falling back to 1.`,
-        );
-      }
-      return 1;
-    }
-    return step;
-  });
+  // tick generator loop forever, so fall back to `1`. Keep the derived pure — the
+  // invalid-value warning lives in a $effect below, since $derived expressions
+  // must be side-effect free (Svelte 5 may re-evaluate them speculatively).
+  const safeStep = $derived(!Number.isFinite(step) || step <= 0 ? 1 : step);
 
   const safePageStep = $derived.by(() => {
     if (pageStep === undefined) return safeStep * 10;
-    if (!Number.isFinite(pageStep) || pageStep <= 0) {
-      if (typeof console !== 'undefined') {
-        console.warn(
-          `[cinder/Slider] pageStep must be a positive finite number — received ${pageStep}. Falling back to ${safeStep * 10}.`,
-        );
-      }
-      return safeStep * 10;
-    }
+    if (!Number.isFinite(pageStep) || pageStep <= 0) return safeStep * 10;
     return pageStep;
+  });
+
+  // Dev-only validation of step / pageStep, kept out of the deriveds so those
+  // stay pure. devWarn self-gates on DEV and is stripped from production.
+  $effect(() => {
+    if (!Number.isFinite(step) || step <= 0) {
+      devWarn(
+        `[cinder/Slider] step must be a positive finite number — received ${step}. Falling back to 1.`,
+      );
+    }
+    if (pageStep !== undefined && (!Number.isFinite(pageStep) || pageStep <= 0)) {
+      devWarn(
+        `[cinder/Slider] pageStep must be a positive finite number — received ${pageStep}. Falling back to ${safeStep * 10}.`,
+      );
+    }
   });
 
   // Normalize a tick array (or boolean) once. The list is filtered to

--- a/packages/components/src/components/table-row/table-row.svelte
+++ b/packages/components/src/components/table-row/table-row.svelte
@@ -24,6 +24,7 @@
     tryGetTableSectionContext,
   } from '../table/table.context.ts';
   import { cn } from '../../utilities/class-names.ts';
+  import { devWarn } from '../../utilities/dev-warn.ts';
 
   let {
     class: className,
@@ -63,7 +64,7 @@
 
   // Warn when a row is rendered directly under Table (no section context) with selection on.
   if (selectionEnabled && section === undefined) {
-    console.warn(
+    devWarn(
       '[Cinder] TableRow: rendered outside TableHeader or TableBody while Table.selectable is true. ' +
         'The leading selection cell will not be rendered.',
     );

--- a/packages/components/src/components/tag-input/tag-input.svelte
+++ b/packages/components/src/components/tag-input/tag-input.svelte
@@ -16,8 +16,9 @@
 </script>
 
 <script lang="ts">
-  import { DEV } from 'esm-env';
   import { tick, untrack } from 'svelte';
+
+  import { devWarn } from '../../utilities/dev-warn.ts';
 
   import { ariaInvalid, composeDescribedBy } from '../../_internal/field-control.ts';
   import { getFormFieldContext } from '../../_internal/form-field-context.ts';
@@ -111,9 +112,8 @@
   const isInvalid = $derived(resolvedAriaInvalid === 'true' || resolvedAriaInvalid === true);
 
   $effect(() => {
-    if (!DEV) return;
     if (context && id && context.controlId !== id) {
-      console.warn(
+      devWarn(
         `[cinder/TagInput] id mismatch: TagInput id="${id}" but wrapping FormField expects controlId="${context.controlId}". Set the same id on both.`,
       );
     }

--- a/packages/components/src/components/toolbar/toolbar-spacer.svelte
+++ b/packages/components/src/components/toolbar/toolbar-spacer.svelte
@@ -14,11 +14,10 @@
 </script>
 
 <script lang="ts">
-  import { DEV } from 'esm-env';
-
   import type { ToolbarSpacerProps } from './toolbar.types.ts';
 
   import { classNames } from '../../utilities/class-names.ts';
+  import { devWarn } from '../../utilities/dev-warn.ts';
 
   let { class: className, flex = 1, ...rest }: ToolbarSpacerProps = $props();
 
@@ -27,11 +26,8 @@
   );
 
   $effect(() => {
-    if (!DEV) return;
     if (typeof flex === 'number' && Number.isFinite(flex) && flex > 0) return;
-    console.warn(
-      '[cinder/Toolbar.Spacer] `flex` must be a positive finite number. Falling back to 1.',
-    );
+    devWarn('[cinder/Toolbar.Spacer] `flex` must be a positive finite number. Falling back to 1.');
   });
 </script>
 

--- a/packages/components/src/components/toolbar/toolbar.svelte
+++ b/packages/components/src/components/toolbar/toolbar.svelte
@@ -15,12 +15,12 @@
 </script>
 
 <script lang="ts">
-  import { DEV } from 'esm-env';
   import { untrack } from 'svelte';
   import type { HTMLAttributes } from 'svelte/elements';
   import { on } from 'svelte/events';
 
   import { classNames } from '../../utilities/class-names.ts';
+  import { devWarn } from '../../utilities/dev-warn.ts';
   import { getFocusableIndex, handleRovingKeydown } from '../../utilities/roving-tabindex.ts';
   import type { ToolbarProps } from './toolbar.types.ts';
 
@@ -336,7 +336,7 @@
   }
 
   function warnAboutAccessibleName(): void {
-    if (!DEV || !rootElement) return;
+    if (!rootElement) return;
     const warningKey = `${ariaLabel ?? ''}|${ariaLabelledBy ?? ''}`;
     if (warningKey === lastWarnedNameSource) return;
 
@@ -345,7 +345,7 @@
     if (ariaLabelledBy?.trim() && hasResolvedLabelledByText()) return;
 
     lastWarnedNameSource = warningKey;
-    console.warn(
+    devWarn(
       '[cinder/Toolbar] rendered without a resolvable accessible name. Pass a non-empty `aria-label` or `aria-labelledby` that points to non-empty text.',
     );
   }

--- a/packages/components/src/components/tree/tree.a11y.md
+++ b/packages/components/src/components/tree/tree.a11y.md
@@ -7,7 +7,7 @@ The tree implementation follows the [WAI-ARIA Tree pattern](https://www.w3.org/W
 ### Tree root
 
 - `role="tree"` — identifies the container as a tree widget.
-- `aria-label` or `aria-labelledby` — required. The component emits `console.warn` once per mount (with `[cinder-tree]` prefix) when neither is provided, in both development and production builds. No synthetic fallback label is invented.
+- `aria-label` or `aria-labelledby` — required. The component emits a development-only warning (`devWarn`, `[cinder-tree]` prefix) once per mount when neither is provided; it is stripped from production bundles. No synthetic fallback label is invented.
 - `aria-multiselectable="true"` — present only when `selectionMode="multiple"`. Omitted in `'none'` and `'single'` modes.
 
 ### TreeItem nodes

--- a/packages/components/src/components/tree/tree.svelte
+++ b/packages/components/src/components/tree/tree.svelte
@@ -22,6 +22,7 @@
   import { setTreeContext, setTreeItemParentContext } from '../../_internal/tree-context.ts';
   import { TreeRegistry } from '../../_internal/tree-registry.svelte.ts';
   import { classNames } from '../../utilities/class-names.ts';
+  import { devWarn } from '../../utilities/dev-warn.ts';
   import {
     deselectIds,
     selectIds,
@@ -68,7 +69,7 @@
   $effect(() => {
     if (!ariaLabel && !ariaLabelledBy && !hasWarnedNoLabel) {
       hasWarnedNoLabel = true;
-      console.warn('[cinder-tree] Tree requires either aria-label or aria-labelledby.');
+      devWarn('[cinder-tree] Tree requires either aria-label or aria-labelledby.');
     }
   });
 

--- a/packages/components/src/utilities/dev-warn.test.ts
+++ b/packages/components/src/utilities/dev-warn.test.ts
@@ -1,0 +1,36 @@
+import { afterEach, describe, expect, mock, test } from 'bun:test';
+
+import { devWarn } from './dev-warn.ts';
+
+describe('devWarn', () => {
+  afterEach(() => {
+    mock.restore();
+  });
+
+  test('forwards the message and extra args to console.warn in DEV', () => {
+    // The test runner builds with DEV truthy (esm-env resolves DEV from the
+    // bundle condition; under bun:test it is dev), so the call goes through.
+    const warn = mock(() => {});
+    const original = console.warn;
+    console.warn = warn;
+    try {
+      devWarn('[cinder/Thing] bad', { id: 'x' }, 42);
+    } finally {
+      console.warn = original;
+    }
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn).toHaveBeenCalledWith('[cinder/Thing] bad', { id: 'x' }, 42);
+  });
+
+  test('works with just a message', () => {
+    const warn = mock(() => {});
+    const original = console.warn;
+    console.warn = warn;
+    try {
+      devWarn('[cinder/Thing] solo');
+    } finally {
+      console.warn = original;
+    }
+    expect(warn).toHaveBeenCalledWith('[cinder/Thing] solo');
+  });
+});

--- a/packages/components/src/utilities/dev-warn.ts
+++ b/packages/components/src/utilities/dev-warn.ts
@@ -1,0 +1,30 @@
+import { DEV } from 'esm-env';
+
+/**
+ * Emit a development-only `console.warn`.
+ *
+ * Component contract-misuse warnings (a missing required prop, an id that does
+ * not match the wrapping FormField, a duplicate key, …) are diagnostics for the
+ * developer building the app — never for the end user. Routing them through
+ * `devWarn` instead of a bare `console.warn` means:
+ *
+ * - **They are stripped from production bundles.** `DEV` from `esm-env` resolves
+ *   to a literal `false` under a production build, so a bundler dead-code-
+ *   eliminates the whole call. End users never see internal naming, and the
+ *   warning string is not shipped.
+ * - **One named, greppable seam.** Every diagnostic flows through one helper, so
+ *   the policy ("warnings are dev-only") is enforceable with a single lint rule
+ *   that bans bare `console.warn` in component source.
+ *
+ * Prefer calling this from a plain guard at the point of misuse rather than from
+ * a `$effect` whose only purpose is to warn — a reactive effect kept alive solely
+ * to log re-subscribes on every state change for no runtime benefit.
+ *
+ * @param message The warning message. Conventionally prefixed with the component
+ *   tag, e.g. `[cinder/Select] …`.
+ * @param args Additional values forwarded to `console.warn` (objects, ids, …).
+ */
+export function devWarn(message: string, ...args: unknown[]): void {
+  if (!DEV) return;
+  console.warn(message, ...args);
+}


### PR DESCRIPTION
## Summary
~48 `console.warn` calls across 30+ component files were inconsistently DEV-gated, so contract-misuse diagnostics shipped in production bundles (leaking internal naming + warning strings to end users).

- **`utilities/dev-warn.ts`** — `devWarn(message, ...args)`: imports `DEV` from `esm-env`, no-ops in production (the bundler dead-code-eliminates the call). One named, greppable seam for dev-only diagnostics.
- Replaced **every** bare `console.warn` in `src/components/**` (`.svelte`, `.svelte.ts`, and the experimental deprecation-alias `index.ts` shims) with `devWarn`, and dropped the now-redundant `if (!DEV)` / `if (DEV)` / `DEV &&` gating (devWarn self-gates).
- **`scripts/check-no-bare-console-warn.ts`** — a scanned guard (oxlint can't see `.svelte`), wired into `bun run lint` + CI, with a colocated test. Plus a **PLATFORM-POLICY.md § Development-only diagnostics** section.

## Review committee
svelte-expert + simplicity-engineer (Codex returned empty output — fail-warn). All 3 must-fixes addressed:
- `tree.a11y.md` corrected (warn is now dev-only, was documented as production).
- `slider.svelte`: moved `devWarn` out of `$derived.by` into a `$effect` (deriveds must be pure).
- `form-section.svelte`: reverted the mount-only inline guard to a `$effect` (re-fires on reactive `as`/`heading` changes).
Suggestions taken: removed a redundant `typeof console === 'undefined'` guard in resizable-panels; corrected the guard-script comment.

## Test plan
- `bun run --filter=cinder lint` → 0 errors (now includes `check:no-bare-console-warn` → OK).
- `bun run --filter=cinder typecheck` → 0 errors. Full suite green. The guard test + dev-warn test pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit f16e041d55193d1ee1b22c03b5349acedc63b59f. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->