### PR TITLE
fix(components): Link reverse-tabnabbing + disabled-tabindex + href-optional (follow-up to #274)

### DIFF
--- a/packages/components/src/components/link/link.schema.json
+++ b/packages/components/src/components/link/link.schema.json
@@ -9,7 +9,7 @@
     },
     "href": {
       "type": "string",
-      "description": "The URL the link points to. Optional because a `disabled` link renders a\n`<span>` with no href — provide it for any enabled (non-disabled) link."
+      "description": "The URL the link points to. Optional ONLY because a `disabled` link renders a\n`<span>` with no href. For any enabled (non-disabled) link you must provide it —\nan `<a>` without `href` is not keyboard-focusable and is not exposed as a link to\nassistive technology, so an enabled Link without `href` is a bug, not a feature."
     },
     "underline": {
       "enum": ["always", "hover", "none"],

--- a/packages/components/src/components/link/link.schema.json
+++ b/packages/components/src/components/link/link.schema.json
@@ -35,7 +35,7 @@
           "type": "null"
         }
       ],
-      "description": "Forwarded to the rendered `<a>`. Merged with `external`-derived `noopener noreferrer` when `external` is true."
+      "description": "Forwarded to the rendered `<a>`. `\"noopener noreferrer\"` is merged in whenever the link\nopens in a new tab — `external` is true OR the resolved target is `\"_blank\"`\n(case-insensitive) — and the whole value is de-duplicated case-insensitively."
     },
     "class": {
       "type": "string",

--- a/packages/components/src/components/link/link.schema.json
+++ b/packages/components/src/components/link/link.schema.json
@@ -9,7 +9,7 @@
     },
     "href": {
       "type": "string",
-      "description": "The URL the link points to. Required for enabled links; ignored when `disabled` is true."
+      "description": "The URL the link points to. Optional because a `disabled` link renders a\n`<span>` with no href — provide it for any enabled (non-disabled) link."
     },
     "underline": {
       "enum": ["always", "hover", "none"],
@@ -43,7 +43,6 @@
     }
   },
   "additionalProperties": false,
-  "required": ["href"],
   "metadata": {
     "unsupportedProps": [
       {

--- a/packages/components/src/components/link/link.schema.ts
+++ b/packages/components/src/components/link/link.schema.ts
@@ -13,7 +13,7 @@ const schema = {
     href: {
       type: 'string',
       description:
-        'The URL the link points to. Optional because a `disabled` link renders a\n`<span>` with no href — provide it for any enabled (non-disabled) link.',
+        'The URL the link points to. Optional ONLY because a `disabled` link renders a\n`<span>` with no href. For any enabled (non-disabled) link you must provide it —\nan `<a>` without `href` is not keyboard-focusable and is not exposed as a link to\nassistive technology, so an enabled Link without `href` is a bug, not a feature.',
     },
     underline: {
       enum: ['always', 'hover', 'none'],

--- a/packages/components/src/components/link/link.schema.ts
+++ b/packages/components/src/components/link/link.schema.ts
@@ -13,7 +13,7 @@ const schema = {
     href: {
       type: 'string',
       description:
-        'The URL the link points to. Required for enabled links; ignored when `disabled` is true.',
+        'The URL the link points to. Optional because a `disabled` link renders a\n`<span>` with no href — provide it for any enabled (non-disabled) link.',
     },
     underline: {
       enum: ['always', 'hover', 'none'],
@@ -51,7 +51,6 @@ const schema = {
     },
   },
   additionalProperties: false,
-  required: ['href'],
   metadata: {
     unsupportedProps: [
       {

--- a/packages/components/src/components/link/link.schema.ts
+++ b/packages/components/src/components/link/link.schema.ts
@@ -43,7 +43,7 @@ const schema = {
         },
       ],
       description:
-        'Forwarded to the rendered `<a>`. Merged with `external`-derived `noopener noreferrer` when `external` is true.',
+        'Forwarded to the rendered `<a>`. `"noopener noreferrer"` is merged in whenever the link\nopens in a new tab — `external` is true OR the resolved target is `"_blank"`\n(case-insensitive) — and the whole value is de-duplicated case-insensitively.',
     },
     class: {
       type: 'string',

--- a/packages/components/src/components/link/link.svelte
+++ b/packages/components/src/components/link/link.svelte
@@ -27,6 +27,9 @@
     disabled = false,
     target,
     rel,
+    // Pulled out of `rest` so a consumer-supplied tabindex never lands on the disabled
+    // <span> (which would make a "disabled" link focusable). Applied only to the enabled <a>.
+    tabindex,
     class: className,
     children,
     ...rest
@@ -40,21 +43,29 @@
     rest as Omit<HTMLAttributes<HTMLSpanElement>, 'class' | 'aria-disabled'>,
   );
 
-  // Merge external-derived values with consumer-supplied values.
-  // Consumer target takes precedence; external only supplies "_blank" when the consumer
-  // did not pass a target. For rel, "noopener noreferrer" is always appended when external
-  // is true so the security guarantee is not accidentally stripped by a consumer rel.
+  // Consumer target takes precedence; `external` only supplies "_blank" when the consumer
+  // did not pass a target.
   const resolvedTarget = $derived(disabled ? undefined : external && !target ? '_blank' : target);
 
+  // Merge "noopener noreferrer" into rel whenever the link opens in a NEW TAB —
+  // either via `external` or any resolved target of "_blank" — so a `target="_blank"`
+  // passed without `external` can't open a reverse-tabnabbing window. The merge is
+  // case-insensitive and de-dupes, so a consumer rel of "noopener noopener" or
+  // "NoOpener" won't produce duplicates.
   const resolvedRel = $derived.by(() => {
     if (disabled) return undefined;
-    if (!external) return rel ?? undefined;
-    const externalRel = 'noopener noreferrer';
-    if (!rel) return externalRel;
-    // Avoid duplicating rel values that the consumer already supplied.
-    const existingParts = rel.split(/\s+/).filter(Boolean);
-    const missing = externalRel.split(/\s+/).filter((part) => !existingParts.includes(part));
-    return missing.length > 0 ? `${rel} ${missing.join(' ')}` : rel;
+    const needsSafeRel = external || resolvedTarget === '_blank';
+    const consumerParts = (rel ?? '').split(/\s+/).filter(Boolean);
+    if (!needsSafeRel) return consumerParts.length > 0 ? consumerParts.join(' ') : undefined;
+    const seen = new Set(consumerParts.map((part) => part.toLowerCase()));
+    const merged = [...consumerParts];
+    for (const part of ['noopener', 'noreferrer']) {
+      if (!seen.has(part)) {
+        merged.push(part);
+        seen.add(part);
+      }
+    }
+    return merged.join(' ');
   });
 
   const resolvedClass = $derived(classNames('cinder-link', className));
@@ -81,6 +92,7 @@
   <a
     {...rest}
     {href}
+    {tabindex}
     target={resolvedTarget}
     rel={resolvedRel}
     class={resolvedClass}

--- a/packages/components/src/components/link/link.svelte
+++ b/packages/components/src/components/link/link.svelte
@@ -48,24 +48,34 @@
   const resolvedTarget = $derived(disabled ? undefined : external && !target ? '_blank' : target);
 
   // Merge "noopener noreferrer" into rel whenever the link opens in a NEW TAB —
-  // either via `external` or any resolved target of "_blank" — so a `target="_blank"`
-  // passed without `external` can't open a reverse-tabnabbing window. The merge is
-  // case-insensitive and de-dupes, so a consumer rel of "noopener noopener" or
-  // "NoOpener" won't produce duplicates.
+  // either via `external` or any resolved target of "_blank" (case-insensitively, since
+  // HTML target keywords are case-insensitive) — so a `target="_blank"` passed without
+  // `external` can't open a reverse-tabnabbing window. The whole rel is de-duplicated
+  // case-insensitively: a consumer rel of "noopener noopener" or "NoOpener" collapses to
+  // a single token and the safe tokens aren't re-added.
   const resolvedRel = $derived.by(() => {
     if (disabled) return undefined;
-    const needsSafeRel = external || resolvedTarget === '_blank';
+    const needsSafeRel = external || resolvedTarget?.toLowerCase() === '_blank';
     const consumerParts = (rel ?? '').split(/\s+/).filter(Boolean);
-    if (!needsSafeRel) return consumerParts.length > 0 ? consumerParts.join(' ') : undefined;
-    const seen = new Set(consumerParts.map((part) => part.toLowerCase()));
-    const merged = [...consumerParts];
-    for (const part of ['noopener', 'noreferrer']) {
-      if (!seen.has(part)) {
+    const seen = new Set<string>();
+    const merged: string[] = [];
+    // De-dupe consumer-provided tokens too (keep first occurrence, original casing).
+    for (const part of consumerParts) {
+      const key = part.toLowerCase();
+      if (!seen.has(key)) {
+        seen.add(key);
         merged.push(part);
-        seen.add(part);
       }
     }
-    return merged.join(' ');
+    if (needsSafeRel) {
+      for (const part of ['noopener', 'noreferrer']) {
+        if (!seen.has(part)) {
+          seen.add(part);
+          merged.push(part);
+        }
+      }
+    }
+    return merged.length > 0 ? merged.join(' ') : undefined;
   });
 
   const resolvedClass = $derived(classNames('cinder-link', className));

--- a/packages/components/src/components/link/link.test.ts
+++ b/packages/components/src/components/link/link.test.ts
@@ -189,6 +189,31 @@ describe('Link external prop', () => {
     expect(rel.toLowerCase().split('noopener').length - 1).toBe(1);
     expect(rel).toContain('noreferrer');
   });
+
+  test('adds the safe rel for a case-variant target like "_BLANK"', () => {
+    // HTML target keywords are case-insensitive, so _BLANK still opens a new tab and
+    // must get the reverse-tabnabbing guard.
+    const { container } = render(Link, {
+      props: { href: 'https://example.com', target: '_BLANK', children: textSnippet('Blank') },
+    });
+    const rel = container.querySelector('a')?.getAttribute('rel') ?? '';
+    expect(rel).toContain('noopener');
+    expect(rel).toContain('noreferrer');
+  });
+
+  test('de-duplicates tokens already duplicated in a consumer rel', () => {
+    const { container } = render(Link, {
+      props: {
+        href: 'https://example.com',
+        external: true,
+        rel: 'noopener noopener sponsored',
+        children: textSnippet('External'),
+      },
+    });
+    const rel = container.querySelector('a')?.getAttribute('rel') ?? '';
+    expect(rel.split('noopener').length - 1).toBe(1);
+    expect(rel).toContain('sponsored');
+  });
 });
 
 describe('Link disabled prop', () => {

--- a/packages/components/src/components/link/link.test.ts
+++ b/packages/components/src/components/link/link.test.ts
@@ -163,6 +163,32 @@ describe('Link external prop', () => {
     });
     expect(container.querySelector('a')?.getAttribute('target')).toBeNull();
   });
+
+  test('adds noopener noreferrer when target="_blank" is passed without external', () => {
+    // Reverse-tabnabbing guard: any link opening in a new tab gets the safe rel,
+    // not just ones flagged external.
+    const { container } = render(Link, {
+      props: { href: 'https://example.com', target: '_blank', children: textSnippet('Blank') },
+    });
+    const rel = container.querySelector('a')?.getAttribute('rel') ?? '';
+    expect(rel).toContain('noopener');
+    expect(rel).toContain('noreferrer');
+  });
+
+  test('de-dupes rel case-insensitively (no duplicate noopener for "NoOpener")', () => {
+    const { container } = render(Link, {
+      props: {
+        href: 'https://example.com',
+        external: true,
+        rel: 'NoOpener',
+        children: textSnippet('External'),
+      },
+    });
+    const rel = container.querySelector('a')?.getAttribute('rel') ?? '';
+    // Only the consumer's "NoOpener" remains for that token; "noreferrer" is appended.
+    expect(rel.toLowerCase().split('noopener').length - 1).toBe(1);
+    expect(rel).toContain('noreferrer');
+  });
 });
 
 describe('Link disabled prop', () => {
@@ -215,6 +241,22 @@ describe('Link disabled prop', () => {
       props: { href: '/about', children: textSnippet('About') },
     });
     expect(container.querySelector('[data-disabled]')).toBeNull();
+  });
+
+  test('a consumer tabindex is NOT forwarded onto the disabled <span>', () => {
+    // tabindex is pulled out of rest and applied only to the enabled <a>, so a disabled
+    // link can't be made focusable via a passthrough tabindex.
+    const { container } = render(Link, {
+      props: { href: '/about', disabled: true, tabindex: 0, children: textSnippet('About') },
+    });
+    expect(container.querySelector('span')?.hasAttribute('tabindex')).toBe(false);
+  });
+
+  test('a consumer tabindex IS forwarded onto the enabled <a>', () => {
+    const { container } = render(Link, {
+      props: { href: '/about', tabindex: -1, children: textSnippet('About') },
+    });
+    expect(container.querySelector('a')?.getAttribute('tabindex')).toBe('-1');
   });
 });
 

--- a/packages/components/src/components/link/link.types.ts
+++ b/packages/components/src/components/link/link.types.ts
@@ -52,9 +52,13 @@ export type LinkProps = Omit<HTMLAnchorAttributes, 'class' | 'href' | 'target' |
    * @default false
    */
   disabled?: boolean;
-  /** Forwarded to the rendered `<a>`. Merged with `external`-derived values when `external` is true. */
+  /** Forwarded to the rendered `<a>`. `external` supplies `"_blank"` only when no target is given. */
   target?: HTMLAnchorAttributes['target'];
-  /** Forwarded to the rendered `<a>`. Merged with `external`-derived `noopener noreferrer` when `external` is true. */
+  /**
+   * Forwarded to the rendered `<a>`. `"noopener noreferrer"` is merged in whenever the link
+   * opens in a new tab — `external` is true OR the resolved target is `"_blank"`
+   * (case-insensitive) — and the whole value is de-duplicated case-insensitively.
+   */
   rel?: HTMLAnchorAttributes['rel'];
   /** Additional class names merged with `.cinder-link`. */
   class?: string;

--- a/packages/components/src/components/link/link.types.ts
+++ b/packages/components/src/components/link/link.types.ts
@@ -19,8 +19,11 @@ export type LinkColor = 'primary' | 'inherit';
  * the component needs to add to them).
  */
 export type LinkProps = Omit<HTMLAnchorAttributes, 'class' | 'href' | 'target' | 'rel'> & {
-  /** The URL the link points to. Required for enabled links; ignored when `disabled` is true. */
-  href: string;
+  /**
+   * The URL the link points to. Optional because a `disabled` link renders a
+   * `<span>` with no href — provide it for any enabled (non-disabled) link.
+   */
+  href?: string;
   /**
    * Controls text-decoration behavior.
    * - `'always'` — underline is always visible.

--- a/packages/components/src/components/link/link.types.ts
+++ b/packages/components/src/components/link/link.types.ts
@@ -20,8 +20,10 @@ export type LinkColor = 'primary' | 'inherit';
  */
 export type LinkProps = Omit<HTMLAnchorAttributes, 'class' | 'href' | 'target' | 'rel'> & {
   /**
-   * The URL the link points to. Optional because a `disabled` link renders a
-   * `<span>` with no href — provide it for any enabled (non-disabled) link.
+   * The URL the link points to. Optional ONLY because a `disabled` link renders a
+   * `<span>` with no href. For any enabled (non-disabled) link you must provide it —
+   * an `<a>` without `href` is not keyboard-focusable and is not exposed as a link to
+   * assistive technology, so an enabled Link without `href` is a bug, not a feature.
    */
   href?: string;
   /**


### PR DESCRIPTION
## Summary

Re-lands the review fixes for the `Link` component that were addressed on #274 but missed the merge (#274 merged the pre-fix commit while this fix-push was still completing).

- **Security:** `rel="noopener noreferrer"` is now merged whenever the link opens in a new tab — `external` is true OR the resolved `target` is `"_blank"` (case-insensitive, since HTML target keywords are case-insensitive). A `target="_blank"` (or `"_BLANK"`) passed without `external` no longer opens a reverse-tabnabbing window.
- **rel de-dup:** the whole `rel` is de-duplicated case-insensitively (first occurrence wins, original casing kept), so `"noopener noopener"` / `"NoOpener"` collapse to one token.
- **Disabled tabindex:** `tabindex` is pulled out of `rest` and applied only to the enabled `<a>`, so a consumer `tabindex` can't make a disabled link's `<span>` focusable; it's forwarded to the `<a>`.
- **href optional:** `href` is now `href?: string` in `LinkProps` + schema — a disabled link withholds `href`, and the docs already said `href` is ignored when disabled.

## Review committee

Pre-reviewed by: svelte-expert
- Codex (gpt-5.4, xhigh) — caught a HIGH-severity case-sensitive `_blank` security gap and a consumer-rel de-dup gap, both fixed in this PR.
- The underlying changes were also reviewed by Cursor + Copilot on #274 (6 threads, all resolved).

## Test plan
- `bun run --filter=cinder test -- link` — 45 pass, 0 fail (new tests for `_BLANK`, consumer-dup rel, disabled/enabled tabindex).
- `typecheck` 0 errors; `components:check` / `exports:check` OK.

Follow-up to 2834798d / #274.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches security-sensitive `rel`/`target` merging and a public props/schema change (`href` no longer required at schema level); behavior is well-tested but consumers could misuse optional `href` on enabled links.
> 
> **Overview**
> Hardens **`Link`** for new-tab security, disabled accessibility, and schema/types alignment with disabled rendering.
> 
> **`rel` / new-tab safety:** `noopener` and `noreferrer` are merged whenever the link opens in a new tab — not only when `external` is true, but also when the resolved `target` is `_blank` (case-insensitive). Consumer `rel` tokens are de-duplicated case-insensitively (first occurrence keeps casing).
> 
> **Disabled focus:** `tabindex` is taken out of spread props and applied only on the enabled `<a>`, so a disabled `<span>` cannot become focusable via passthrough `tabindex`.
> 
> **`href` contract:** `href` is optional in `LinkProps` and JSON schema (`required: ['href']` removed); docs stress that enabled links must still pass `href`, while disabled links correctly omit it on the `<span>`.
> 
> Tests cover `_blank` without `external`, `_BLANK`, rel de-dupe, and tabindex on disabled vs enabled branches.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 96f841b93a4add1f60bec4eb3a9e26abd28f2874. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->