### PR TITLE
fix(audit): guard required-Snippet renders with optional chaining (04fc4eb6)

### DIFF
--- a/packages/components/src/components/badge/badge.svelte
+++ b/packages/components/src/components/badge/badge.svelte
@@ -35,5 +35,5 @@
   data-cinder-size={size}
   {...rest}
 >
-  {@render children()}
+  {@render children?.()}
 </span>

--- a/packages/components/src/components/badge/badge.test.ts
+++ b/packages/components/src/components/badge/badge.test.ts
@@ -84,3 +84,12 @@ describe('Badge', () => {
     expect(smRule).toContain('line-height: 1rem');
   });
 });
+
+describe('Badge — omitted children (runtime safety net)', () => {
+  test('renders without throwing when children is omitted (JS consumer safety)', () => {
+    // children: Snippet is required in TypeScript, but the optional-chain guard
+    // ensures a JS consumer who omits it gets an empty badge rather than a crash.
+    const { container } = render(Badge, { variant: 'info' } as never);
+    expect(container.querySelector('.cinder-badge')).not.toBeNull();
+  });
+});

--- a/packages/components/src/components/badge/badge.types.ts
+++ b/packages/components/src/components/badge/badge.types.ts
@@ -12,6 +12,11 @@ export type BadgeProps = HTMLAttributes<HTMLSpanElement> & {
   variant?: BadgeVariant;
   size?: BadgeSize;
   class?: string;
+  /**
+   * Badge content — intentionally required. A badge without content is
+   * semantically meaningless. The render site uses optional chaining
+   * (`children?.()`) as a runtime safety net for JS consumers.
+   */
   children: Snippet;
 };
 

--- a/packages/components/src/components/data-list/data-list.types.ts
+++ b/packages/components/src/components/data-list/data-list.types.ts
@@ -44,6 +44,13 @@ export type DataListProps<T> = Omit<
    * leading/title/description/meta/trailing slots.
    */
   children: Snippet<[T]>;
-  /** Rendered (wrapped in an `<li>`) when `items` is empty. */
+  /**
+   * Rendered when `items` is empty. The component automatically wraps the
+   * snippet output in `<li class="cinder-data-list-empty">`.
+   *
+   * **Do NOT wrap in an `<li>` yourself** — the component provides the `<li>`
+   * wrapper automatically. Pass only inner content (e.g. a `<p>`, a `<div>`,
+   * or plain text). Contrast with `children`, which must render an `<li>`.
+   */
   empty?: Snippet;
 };

--- a/packages/components/src/components/message/message.svelte
+++ b/packages/components/src/components/message/message.svelte
@@ -46,7 +46,11 @@
       <time class="cinder-message__time" {datetime}>{timestamp ?? datetime}</time>
     {/if}
   </header>
-  <div class="cinder-message__body">
-    {@render children()}
-  </div>
+  <!-- children is required by MessageProps; optional-chain guards against dynamic
+       JS consumers or future relaxation of the type contract. -->
+  {#if children}
+    <div class="cinder-message__body">
+      {@render children()}
+    </div>
+  {/if}
 </article>

--- a/packages/components/src/components/message/message.test.ts
+++ b/packages/components/src/components/message/message.test.ts
@@ -73,6 +73,20 @@ describe('Message', () => {
     expect(article?.getAttribute('id')).toBe('msg-1');
   });
 
+  test('omitting children renders without throwing and omits the body wrapper', () => {
+    // children is typed as required but the render is guarded so a dynamic JS
+    // consumer that omits children gets a silent no-op rather than a runtime throw.
+    expect(() => {
+      const { container } = render(Message, {
+        role: 'assistant',
+      } as never);
+      // No body div should be present when children is absent.
+      expect(container.querySelector('.cinder-message__body')).toBeNull();
+      // The article element itself still renders.
+      expect(container.querySelector('article.cinder-message')).not.toBeNull();
+    }).not.toThrow();
+  });
+
   test('consumer cannot clobber the controlled data-cinder-role attribute', () => {
     const { container } = render(Message, {
       role: 'user',

--- a/packages/components/src/components/segment/segment.svelte
+++ b/packages/components/src/components/segment/segment.svelte
@@ -95,7 +95,7 @@
       {@render leading()}
     </span>
   {/if}
-  {@render children()}
+  {@render children?.()}
   {#if trailing}
     <span class="cinder-segmented-control-option-trailing" aria-hidden="true">
       {@render trailing()}

--- a/packages/components/src/components/segment/segment.svelte
+++ b/packages/components/src/components/segment/segment.svelte
@@ -95,6 +95,9 @@
       {@render leading()}
     </span>
   {/if}
+  <!-- children: Snippet is required in TypeScript but the optional-chain is a
+     JS-caller safety net. Segment requires SegmentedControl's group context to
+     render so it can't be tested standalone; the guard is verified at code level. -->
   {@render children?.()}
   {#if trailing}
     <span class="cinder-segmented-control-option-trailing" aria-hidden="true">

--- a/packages/components/src/components/sidebar/sidebar.css
+++ b/packages/components/src/components/sidebar/sidebar.css
@@ -58,6 +58,10 @@
   }
 
   .cinder-sidebar__footer {
+    /* margin-block-start: auto pins the footer to the bottom of the column independent
+     * of siblings — so it stays bottom-aligned even when the optional nav (which carried
+     * flex: 1) is omitted, instead of collapsing up under the brand. */
+    margin-block-start: auto;
     padding-block: var(--cinder-space-3);
     padding-inline: var(--cinder-space-3);
     border-block-start: 1px solid var(--cinder-border);

--- a/packages/components/src/components/sidebar/sidebar.svelte
+++ b/packages/components/src/components/sidebar/sidebar.svelte
@@ -89,7 +89,9 @@
       {/if}
 
       <nav class="cinder-sidebar__nav" aria-label={navigationLabel}>
-        {@render navigationSnippet()}
+        {#if navigationSnippet}
+          {@render navigationSnippet()}
+        {/if}
       </nav>
 
       {#if footerSnippet}
@@ -114,7 +116,9 @@
     {/if}
 
     <nav class="cinder-sidebar__nav" aria-label={navigationLabel}>
-      {@render navigationSnippet()}
+      {#if navigationSnippet}
+        {@render navigationSnippet()}
+      {/if}
     </nav>
 
     {#if footerSnippet}

--- a/packages/components/src/components/sidebar/sidebar.svelte
+++ b/packages/components/src/components/sidebar/sidebar.svelte
@@ -88,11 +88,15 @@
         </div>
       {/if}
 
-      <nav class="cinder-sidebar__nav" aria-label={navigationLabel}>
-        {#if navigationSnippet}
+      {#if navigationSnippet}
+        <!-- Guard the entire <nav> landmark, not just its contents. An empty <nav>
+             is an accessibility problem (screen readers announce a navigation landmark
+             with no destinations). navigation is optional so a sidebar can be used as
+             app chrome without a nav list. -->
+        <nav class="cinder-sidebar__nav" aria-label={navigationLabel}>
           {@render navigationSnippet()}
-        {/if}
-      </nav>
+        </nav>
+      {/if}
 
       {#if footerSnippet}
         <div class="cinder-sidebar__footer cinder-sidebar__footer--mobile">
@@ -115,11 +119,13 @@
       </div>
     {/if}
 
-    <nav class="cinder-sidebar__nav" aria-label={navigationLabel}>
-      {#if navigationSnippet}
+    {#if navigationSnippet}
+      <!-- Same guard: keep the <nav> landmark out of the DOM when navigation is absent
+           so screen readers don't announce an empty navigation region. -->
+      <nav class="cinder-sidebar__nav" aria-label={navigationLabel}>
         {@render navigationSnippet()}
-      {/if}
-    </nav>
+      </nav>
+    {/if}
 
     {#if footerSnippet}
       <div class="cinder-sidebar__footer">

--- a/packages/components/src/components/sidebar/sidebar.test.ts
+++ b/packages/components/src/components/sidebar/sidebar.test.ts
@@ -717,3 +717,16 @@ describe('Sidebar collapsed CSS contract', () => {
     expect(css).toContain('clip-path: inset(50%);');
   });
 });
+
+describe('Sidebar — optional navigation snippet', () => {
+  test('omitting navigation renders no <nav> landmark (no empty navigation region)', () => {
+    // navigation is now optional (Snippet?). Without it, the <nav> landmark must be
+    // absent entirely — an empty <nav> is an a11y violation (screen readers announce
+    // a navigation region with no destinations).
+    const { container } = render(Sidebar, {
+      label: 'Main',
+      children: textSnippet('Content'),
+    } as never);
+    expect(container.querySelector('nav')).toBeNull();
+  });
+});

--- a/packages/components/src/components/sidebar/sidebar.test.ts
+++ b/packages/components/src/components/sidebar/sidebar.test.ts
@@ -722,11 +722,13 @@ describe('Sidebar — optional navigation snippet', () => {
   test('omitting navigation renders no <nav> landmark (no empty navigation region)', () => {
     // navigation is now optional (Snippet?). Without it, the <nav> landmark must be
     // absent entirely — an empty <nav> is an a11y violation (screen readers announce
-    // a navigation region with no destinations).
+    // a navigation region with no destinations). Render with a real ariaLabel and NO
+    // navigation prop (every other test passes navigation; this one deliberately omits it).
     const { container } = render(Sidebar, {
-      label: 'Main',
-      children: textSnippet('Content'),
-    } as never);
+      props: { ariaLabel: 'Main' },
+    });
+    // The <aside> renders, but there is no <nav> child because navigation was omitted.
+    expect(container.querySelector('aside')).not.toBeNull();
     expect(container.querySelector('nav')).toBeNull();
   });
 });

--- a/packages/components/src/components/sidebar/sidebar.types.ts
+++ b/packages/components/src/components/sidebar/sidebar.types.ts
@@ -26,7 +26,7 @@ export type SidebarProps = Omit<
   /** Optional branding region rendered above the navigation. */
   brand?: Snippet;
   /** Navigation region. Typically a `<SideNavigation>` subtree. Required. */
-  navigation: Snippet;
+  navigation?: Snippet;
   /** Optional footer region (e.g. user account, sign-out). */
   footer?: Snippet;
 };

--- a/packages/components/src/components/sidebar/sidebar.types.ts
+++ b/packages/components/src/components/sidebar/sidebar.types.ts
@@ -25,7 +25,11 @@ export type SidebarProps = Omit<
   class?: string;
   /** Optional branding region rendered above the navigation. */
   brand?: Snippet;
-  /** Navigation region. Typically a `<SideNavigation>` subtree. Required. */
+  /**
+   * Navigation region. Typically a `<SideNavigation>` subtree. Optional — when
+   * omitted, no `<nav>` landmark is rendered (so the sidebar can serve as app chrome
+   * without a navigation list, and an empty `<nav>` isn't announced to screen readers).
+   */
   navigation?: Snippet;
   /** Optional footer region (e.g. user account, sign-out). */
   footer?: Snippet;

--- a/packages/components/src/components/steps/steps.css
+++ b/packages/components/src/components/steps/steps.css
@@ -168,6 +168,12 @@
     padding-top: var(--cinder-space-2);
   }
 
+  /* Inner wrapper rendered by the stepBody snippet — transparent to the parent
+   flex layout so the label and description remain direct flex children. */
+  .cinder-steps__body-content {
+    display: contents;
+  }
+
   /* ----------------------------------------
  * Interactive body — an <a>/<button> occupying the body cell. Resets native
  * chrome so both elements render identically to the static body, then layers

--- a/packages/components/src/components/steps/steps.svelte
+++ b/packages/components/src/components/steps/steps.svelte
@@ -53,6 +53,8 @@
       {@const isComplete = state === 'complete'}
       {@const hasHref = step.href !== undefined}
       {@const isInteractive = hasHref || step.onclick !== undefined}
+      {@const stepLabel = step.label}
+      {@const stepDescription = step.description}
       <li
         class="cinder-steps__item"
         data-cinder-state={state}
@@ -72,14 +74,7 @@
             onclick={step.onclick}
             aria-current={isCurrent ? 'step' : undefined}
           >
-            {#if isComplete}
-              <span class="cinder-steps__sr-only">{completedLabel}</span>
-              <span class="cinder-steps__sr-only-separator"> </span>
-            {/if}
-            <span class="cinder-steps__label">{step.label}</span>
-            {#if step.description}
-              <span class="cinder-steps__description">{step.description}</span>
-            {/if}
+            {@render stepBody(stepLabel, stepDescription, isComplete, completedLabel)}
           </a>
         {:else if step.onclick}
           <button
@@ -88,25 +83,11 @@
             onclick={step.onclick}
             aria-current={isCurrent ? 'step' : undefined}
           >
-            {#if isComplete}
-              <span class="cinder-steps__sr-only">{completedLabel}</span>
-              <span class="cinder-steps__sr-only-separator"> </span>
-            {/if}
-            <span class="cinder-steps__label">{step.label}</span>
-            {#if step.description}
-              <span class="cinder-steps__description">{step.description}</span>
-            {/if}
+            {@render stepBody(stepLabel, stepDescription, isComplete, completedLabel)}
           </button>
         {:else}
           <span class="cinder-steps__body">
-            {#if isComplete}
-              <span class="cinder-steps__sr-only">{completedLabel}</span>
-              <span class="cinder-steps__sr-only-separator"> </span>
-            {/if}
-            <span class="cinder-steps__label">{step.label}</span>
-            {#if step.description}
-              <span class="cinder-steps__description">{step.description}</span>
-            {/if}
+            {@render stepBody(stepLabel, stepDescription, isComplete, completedLabel)}
           </span>
         {/if}
         {#if index < steps.length - 1}
@@ -120,3 +101,21 @@
     {/each}
   </ol>
 </nav>
+
+{#snippet stepBody(
+  bodyLabel: string,
+  bodyDescription: string | undefined,
+  bodyIsComplete: boolean,
+  bodyCompletedLabel: string,
+)}
+  <span class="cinder-steps__body-content">
+    {#if bodyIsComplete}
+      <span class="cinder-steps__sr-only">{bodyCompletedLabel}</span>
+      <span class="cinder-steps__sr-only-separator"> </span>
+    {/if}
+    <span class="cinder-steps__label">{bodyLabel}</span>
+    {#if bodyDescription}
+      <span class="cinder-steps__description">{bodyDescription}</span>
+    {/if}
+  </span>
+{/snippet}

--- a/packages/components/src/components/surface/surface.svelte
+++ b/packages/components/src/components/surface/surface.svelte
@@ -31,7 +31,5 @@
 </script>
 
 <div class={classNames('cinder-surface', className)} data-cinder-tone={tone} {...rest}>
-  {#if children}
-    {@render children()}
-  {/if}
+  {@render children?.()}
 </div>

--- a/packages/components/src/components/surface/surface.test.ts
+++ b/packages/components/src/components/surface/surface.test.ts
@@ -161,3 +161,12 @@ describe('Surface CSS contract', () => {
     expect(transparentBlock).toContain('border-color: transparent');
   });
 });
+
+describe('Surface — omitted children (optional-chain guard)', () => {
+  test('renders an empty surface without throwing when no children provided', () => {
+    // The guard changed from {#if children}{@render children()}{/if} to {@render children?.()}.
+    // Verify the optional-chain path (children===undefined) is safe.
+    const { container } = render(Surface, {} as never);
+    expect(container.querySelector('.cinder-surface')).not.toBeNull();
+  });
+});

--- a/packages/components/src/components/table-cell/table-cell.svelte
+++ b/packages/components/src/components/table-cell/table-cell.svelte
@@ -22,5 +22,5 @@
 </script>
 
 <td {...rest} class={cn('cinder-table__cell', className)} data-cinder-align={align}>
-  {@render children()}
+  {@render children?.()}
 </td>

--- a/packages/components/src/components/table-cell/table-cell.test.ts
+++ b/packages/components/src/components/table-cell/table-cell.test.ts
@@ -7,6 +7,8 @@ setupHappyDom();
 
 const { render } = await import('@testing-library/svelte');
 const { default: Wrapper } = await import('../../test/fixtures/table-fixture.svelte');
+const { default: EmptyTableCellFixture } =
+  await import('../../test/fixtures/empty-table-cell-fixture.svelte');
 
 const columns = [{ key: 'name', label: 'Name' }];
 const rows = [{ id: '1', cells: ['Alice'] }];
@@ -65,5 +67,19 @@ describe('TableCell', () => {
     });
     const cell = container.querySelector('tbody td');
     expect(cell?.getAttribute('data-cinder-align')).toBe('left');
+  });
+});
+
+describe('TableCell — empty children', () => {
+  test('renders an empty <td> without throwing when no children are provided', () => {
+    // children is now optional (children?: Snippet) so empty <td> cells used in
+    // spanning layouts are a valid, non-throwing state. The optional-chain guard
+    // at the render site ({@render children?.()}) ensures undefined children is a
+    // safe no-op rather than a runtime throw.
+    const { container } = render(EmptyTableCellFixture, {});
+    const cell = container.querySelector('tbody td');
+    expect(cell).not.toBeNull();
+    expect(cell?.classList.contains('cinder-table__cell')).toBe(true);
+    expect(cell?.textContent?.trim()).toBe('');
   });
 });

--- a/packages/components/src/components/table-cell/table-cell.types.ts
+++ b/packages/components/src/components/table-cell/table-cell.types.ts
@@ -10,6 +10,11 @@ export type TableCellProps = Omit<HTMLTdAttributes, 'class' | 'align'> & {
    * Cell content. Optional so that empty `<td>` cells (used in spanning
    * table layouts) are a valid, non-throwing state. When omitted the cell
    * renders empty, which is valid HTML for a `<td>`.
+   *
+   * **Note for TypeScript consumers:** the Snippet type is never called externally
+   * by consuming code — Svelte's compiler handles invocation internally. Making
+   * this optional is therefore safe as an API change: no external caller calls
+   * `props.children()` on a Svelte component's props.
    */
   children?: Snippet;
 };

--- a/packages/components/src/components/table-cell/table-cell.types.ts
+++ b/packages/components/src/components/table-cell/table-cell.types.ts
@@ -6,6 +6,10 @@ export type TableCellProps = Omit<HTMLTdAttributes, 'class' | 'align'> & {
   align?: 'left' | 'center' | 'right';
   /** Additional class names merged with `.cinder-table__cell`. */
   class?: string;
-  /** Cell content. */
-  children: Snippet;
+  /**
+   * Cell content. Optional so that empty `<td>` cells (used in spanning
+   * table layouts) are a valid, non-throwing state. When omitted the cell
+   * renders empty, which is valid HTML for a `<td>`.
+   */
+  children?: Snippet;
 };

--- a/packages/components/src/components/visually-hidden/visually-hidden.svelte
+++ b/packages/components/src/components/visually-hidden/visually-hidden.svelte
@@ -33,4 +33,4 @@
   );
 </script>
 
-<svelte:element this={as} class={mergedClass} {...rest}>{@render children()}</svelte:element>
+<svelte:element this={as} class={mergedClass} {...rest}>{@render children?.()}</svelte:element>

--- a/packages/components/src/components/visually-hidden/visually-hidden.test.ts
+++ b/packages/components/src/components/visually-hidden/visually-hidden.test.ts
@@ -135,3 +135,13 @@ describe('VisuallyHidden', () => {
     expect(el?.textContent).toContain('Hidden label text');
   });
 });
+
+describe('VisuallyHidden — omitted children (runtime safety net)', () => {
+  test('renders without throwing when children is omitted (JS consumer safety)', () => {
+    // children: Snippet is required in TS, but the optional-chain guard prevents a
+    // runtime throw for untyped callers. NOTE: an empty VisuallyHidden silently defeats
+    // its a11y purpose — only TypeScript consumers calling with children is valid.
+    const { container } = render(VisuallyHidden, {} as never);
+    expect(container.querySelector('.cinder-sr-only')).not.toBeNull();
+  });
+});

--- a/packages/components/src/components/visually-hidden/visually-hidden.types.ts
+++ b/packages/components/src/components/visually-hidden/visually-hidden.types.ts
@@ -44,7 +44,12 @@ export type VisuallyHiddenProps = Omit<
   focusable?: boolean;
   /** Additional classes merged after the utility classes. */
   class?: string;
-  /** Required content — must render something assistive technology can announce. */
+  /**
+   * Required content — must render something assistive technology can announce.
+   * The render site uses optional chaining (`children?.()`) as a JS-consumer safety
+   * net, but omitting children defeats the entire purpose of this component: an empty
+   * `.cinder-sr-only` announces nothing to AT. Always provide meaningful content.
+   */
   children: Snippet;
 };
 

--- a/packages/components/src/test/fixtures/empty-table-cell-fixture.svelte
+++ b/packages/components/src/test/fixtures/empty-table-cell-fixture.svelte
@@ -1,0 +1,25 @@
+<script lang="ts">
+  import Table from '../../components/table/table.svelte';
+  import TableBody from '../../components/table-body/table-body.svelte';
+  import TableCell from '../../components/table-cell/table-cell.svelte';
+  import TableHeader from '../../components/table-header/table-header.svelte';
+  import TableHeaderCell from '../../components/table-header-cell/table-header-cell.svelte';
+  import TableRow from '../../components/table-row/table-row.svelte';
+</script>
+
+<!--
+  Minimal table fixture that renders a single TableCell with no children
+  snippet to verify the omitted-children case does not throw.
+-->
+<Table>
+  <TableHeader>
+    <TableRow>
+      <TableHeaderCell>Column</TableHeaderCell>
+    </TableRow>
+  </TableHeader>
+  <TableBody>
+    <TableRow>
+      <TableCell></TableCell>
+    </TableRow>
+  </TableBody>
+</Table>


### PR DESCRIPTION
## Summary

Audit sweep `04fc4eb6` — fixes 9 `snippet-children` findings where components rendered a snippet unconditionally (runtime throw if a consumer omitted it).

- **badge, segment, surface, visually-hidden**: `{@render children()}` → `{@render children?.()}`.
- **message**: body wrapped so omitted `children` renders nothing (+ test).
- **table-cell**: `children` made optional; empty cell renders without throwing (+ test + fixture).
- **sidebar**: `navigation` made optional (`Snippet?`), and the entire `<nav>` landmark is now guarded — an absent navigation no longer produces an empty `<nav>` that screen readers announce.
- **data-list**: documented the empty-snippet wrapping contract.
- **steps**: deduplicated the body triplicated across 3 branches into one `{#snippet}` (the `display:contents` wrapper is verified necessary — removing it fails 20 tests with Svelte 5's text-node anchor error).

## Review committee

Pre-reviewed by: svelte-expert, testing-expert
- Codex (gpt-5.4, xhigh)
- Round 1 caught a real a11y bug (sidebar empty `<nav>` landmark) and 4 test-coverage gaps — all addressed. Codex's `table-cell children?` "must-fix" was respectfully disagreed (Svelte Snippets are compiler-invoked, never called externally by TS consumers) with a JSDoc note added.

## Test plan
- `bun run --filter=cinder test` — 4426 pass, 0 fail.
- `typecheck` 0 errors; `components:check` / `exports:check` OK; `lint` 0 errors.

Closes 04fc4eb6.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Defensive rendering, documentation, and optional prop relaxations in UI components; no auth, data, or payment paths.
> 
> **Overview**
> Addresses audit findings where **required `children` snippets** were rendered unconditionally and could **throw at runtime** if omitted (e.g. untyped JS callers).
> 
> Several components now use **`{@render children?.()}`** or guard the body (**Badge**, **Segment**, **Surface**, **VisuallyHidden**, **TableCell**; **Message** skips the body wrapper when `children` is absent). **TableCell** also makes **`children` optional** in types so empty `<td>` cells are valid. Docs clarify **DataList** empty-state wrapping (do not supply your own `<li>`).
> 
> **Sidebar** treats **`navigation` as optional** and only mounts a **`<nav>`** when the snippet is provided, avoiding an empty navigation landmark; footer layout uses **`margin-block-start: auto`** when nav is omitted. **Steps** deduplicates shared label/description markup into a **`stepBody` snippet** with a **`display: contents`** wrapper.
> 
> New tests cover omitted-snippet behavior and the sidebar/nav contract.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f3a2ef03f86f0c488787d2632fc8f20041a1df38. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->