### PR TITLE
fix(audit): route bodyScrollLock through the counted lockBodyScroll (593d107a)

### DIFF
--- a/packages/components/src/components/chat/message/image-lightbox.svelte
+++ b/packages/components/src/components/chat/message/image-lightbox.svelte
@@ -22,7 +22,7 @@
   import ChevronRight from 'lucide-svelte/icons/chevron-right';
   import X from 'lucide-svelte/icons/x';
   import { createFocusTrap } from '../../focus-trap/index.ts';
-  import { bodyScrollLock } from '../../../utilities/attachments.ts';
+  import { createBodyScrollLock } from '../../../utilities/attachments.ts';
 
   let { images, initialIndex = 0, open = $bindable(false), onclose }: ImageLightboxProps = $props();
 
@@ -94,7 +94,7 @@
     onkeydown={handleKeyDown}
     tabindex="-1"
     transition:fade={{ duration: 150 }}
-    {@attach bodyScrollLock}
+    {@attach createBodyScrollLock()}
     {@attach createFocusTrap()}
   >
     <button type="button" class="lightbox-close" aria-label="Close image viewer" onclick={close}>

--- a/packages/components/src/components/chat/message/image-lightbox.test.ts
+++ b/packages/components/src/components/chat/message/image-lightbox.test.ts
@@ -31,7 +31,10 @@ afterEach(() => {
 describe('image-lightbox source contract', () => {
   test('imports createBodyScrollLock, not the legacy bodyScrollLock', () => {
     expect(source).toContain('createBodyScrollLock');
-    expect(source).not.toContain('bodyScrollLock');
+    // Assert against the legacy IDENTIFIER specifically (word boundary + lowercase b),
+    // so this isn't tripped by `createBodyScrollLock` (capital B) or an incidental mention
+    // in a comment. The legacy export was the bare `bodyScrollLock` symbol.
+    expect(source).not.toMatch(/\bbodyScrollLock\b/);
   });
 
   test('attaches createBodyScrollLock() to the overlay element', () => {

--- a/packages/components/src/components/chat/message/image-lightbox.test.ts
+++ b/packages/components/src/components/chat/message/image-lightbox.test.ts
@@ -1,0 +1,66 @@
+/**
+ * Regression tests for image-lightbox scroll-lock integration.
+ *
+ * These tests verify that the lightbox uses `createBodyScrollLock()` (the
+ * counted factory that delegates to `lockBodyScroll()` in `_internal/overlay`)
+ * rather than a plain `overflow: hidden` assignment that would bypass the
+ * global counter and prematurely restore scroll when nested overlays close.
+ */
+/// <reference lib="dom" />
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+import { _resetScrollLock, lockBodyScroll } from '../../../_internal/overlay.ts';
+import { setupHappyDom } from '../../../test/happy-dom.ts';
+import { createBodyScrollLock } from '../../../utilities/attachments.ts';
+
+const source = readFileSync(resolve(import.meta.dir, 'image-lightbox.svelte'), 'utf8');
+
+setupHappyDom();
+
+beforeEach(() => {
+  _resetScrollLock();
+});
+
+afterEach(() => {
+  _resetScrollLock();
+  document.body.innerHTML = '';
+});
+
+describe('image-lightbox source contract', () => {
+  test('imports createBodyScrollLock, not the legacy bodyScrollLock', () => {
+    expect(source).toContain('createBodyScrollLock');
+    expect(source).not.toContain('bodyScrollLock');
+  });
+
+  test('attaches createBodyScrollLock() to the overlay element', () => {
+    expect(source).toContain('{@attach createBodyScrollLock()}');
+  });
+});
+
+describe('image-lightbox scroll-lock counter sharing', () => {
+  test('a second overlay acquiring the lock keeps scroll hidden when the first releases', () => {
+    // Simulate what happens when a lightbox is opened inside another locking
+    // overlay (e.g. a Modal or Sheet that already holds the scroll lock).
+    const releaseOuter = lockBodyScroll(); // outer overlay acquires first
+    const releaseInner = createBodyScrollLock()(document.createElement('div')); // lightbox
+
+    expect(document.body.style.overflow).toBe('hidden');
+
+    // The outer overlay closes — scroll must stay locked because the lightbox is still open.
+    releaseOuter();
+    expect(document.body.style.overflow).toBe('hidden');
+
+    // Lightbox closes — counter reaches zero; scroll restores.
+    releaseInner?.();
+    expect(document.body.style.overflow).toBe('');
+  });
+
+  test('lightbox lock restores scroll when it is the sole lock holder', () => {
+    const release = createBodyScrollLock()(document.createElement('div'));
+    expect(document.body.style.overflow).toBe('hidden');
+    release?.();
+    expect(document.body.style.overflow).toBe('');
+  });
+});

--- a/packages/components/src/utilities/attachments.test.ts
+++ b/packages/components/src/utilities/attachments.test.ts
@@ -1,8 +1,9 @@
 /// <reference lib="dom" />
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
 
+import { _resetScrollLock } from '../_internal/overlay.ts';
 import { setupHappyDom } from '../test/happy-dom.ts';
-import { overflowFade } from './attachments.ts';
+import { createBodyScrollLock, overflowFade } from './attachments.ts';
 
 setupHappyDom();
 
@@ -125,6 +126,66 @@ afterEach(() => {
   globalThis.requestAnimationFrame = originalRequestAnimationFrame;
   globalThis.cancelAnimationFrame = originalCancelAnimationFrame;
   document.body.innerHTML = '';
+  _resetScrollLock();
+});
+
+describe('createBodyScrollLock', () => {
+  test('hides body overflow when attached', () => {
+    const node = document.createElement('div');
+    const cleanup = createBodyScrollLock()(node);
+
+    expect(document.body.style.overflow).toBe('hidden');
+
+    cleanup?.();
+  });
+
+  test('restores body overflow when released', () => {
+    document.body.style.overflow = '';
+    const node = document.createElement('div');
+    const cleanup = createBodyScrollLock()(node);
+
+    expect(document.body.style.overflow).toBe('hidden');
+    cleanup?.();
+
+    expect(document.body.style.overflow).toBe('');
+  });
+
+  test('two nested locks keep overflow hidden until both release (shared counter)', () => {
+    _resetScrollLock();
+    const nodeA = document.createElement('div');
+    const nodeB = document.createElement('div');
+
+    const cleanupA = createBodyScrollLock()(nodeA);
+    const cleanupB = createBodyScrollLock()(nodeB);
+
+    expect(document.body.style.overflow).toBe('hidden');
+
+    // Release first lock — page must still be locked because B is open.
+    cleanupA?.();
+    expect(document.body.style.overflow).toBe('hidden');
+
+    // Release second lock — now the count reaches zero; scroll restores.
+    cleanupB?.();
+    expect(document.body.style.overflow).toBe('');
+  });
+
+  test('releasing the same attachment twice does not double-decrement the counter', () => {
+    _resetScrollLock();
+    const nodeA = document.createElement('div');
+    const nodeB = document.createElement('div');
+
+    const cleanupA = createBodyScrollLock()(nodeA);
+    createBodyScrollLock()(nodeB);
+
+    expect(document.body.style.overflow).toBe('hidden');
+
+    // Call the same cleanup twice — idempotent; counter should not drop below 1.
+    cleanupA?.();
+    cleanupA?.();
+
+    // nodeB's lock is still active; overflow must remain hidden.
+    expect(document.body.style.overflow).toBe('hidden');
+  });
 });
 
 describe('overflowFade', () => {

--- a/packages/components/src/utilities/attachments.ts
+++ b/packages/components/src/utilities/attachments.ts
@@ -1,22 +1,26 @@
 import type { Attachment } from 'svelte/attachments';
+import { lockBodyScroll } from '../_internal/overlay.ts';
 
 /**
- * Locks body scroll while the element is mounted.
- * Useful for modals, sheets, and other overlays.
+ * Creates a body scroll lock attachment that participates in the shared
+ * counted lock from `_internal/overlay.ts`. Nested overlays each call this;
+ * the page scroll is only restored when the last attachment is torn down.
+ *
+ * Use this instead of a raw `overflow: hidden` assignment so that a Modal
+ * opened inside a Sheet (or any combination of locking overlays) cannot
+ * prematurely restore page scroll when only one of them closes.
  *
  * @example
  * ```svelte
- * <div {@attach bodyScrollLock}>Modal content</div>
+ * <div {@attach createBodyScrollLock()}>Modal content</div>
  * ```
  */
-export const bodyScrollLock: Attachment<HTMLElement> = () => {
-  const previousOverflow = document.body.style.overflow;
-  document.body.style.overflow = 'hidden';
-
+export function createBodyScrollLock(): Attachment<HTMLElement> {
   return () => {
-    document.body.style.overflow = previousOverflow;
+    const release = lockBodyScroll();
+    return release;
   };
-};
+}
 
 export type ClickOutsideOptions = {
   /** Callback when clicking outside the element */


### PR DESCRIPTION
## Summary

Audit sweep `593d107a`. `utilities/attachments.ts`'s `bodyScrollLock` attachment directly mutated `document.body.style.overflow`, bypassing the counted `lockBodyScroll()` in `_internal/overlay.ts` — so a Modal opened inside a Sheet (or any two locking overlays) would restore page scroll when only one closed.

Replaced it with a `createBodyScrollLock()` factory whose attachment calls `lockBodyScroll()` on attach and the returned `release()` on teardown, sharing the global counter. Updated the sole consumer (chat image-lightbox) and added tests asserting nested locks only restore scroll when the last releases.

## Review committee

Pre-reviewed by: svelte-expert — APPROVED
- Codex (gpt-5.4, xhigh) — APPROVED
- Both confirmed: correct acquire-on-attach/release-on-teardown, counted-lock semantics, no missed consumers of the old export, and adequate nested-lock test coverage.

## Test plan
- `bun run --filter=cinder test` — 4399 pass, 0 fail.
- `typecheck` 0 errors; `components:check` / `exports:check` OK; `lint` 0 errors.

Closes 593d107a.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes shared overlay scroll-lock behavior used when multiple locking UI layers stack; risk is mitigated by delegating to the existing counter and new nested-lock tests.
> 
> **Overview**
> Replaces the legacy **`bodyScrollLock`** Svelte attachment (which set **`document.body.style.overflow`** directly) with **`createBodyScrollLock()`**, a factory whose attach/teardown calls the shared **`lockBodyScroll()`** counter in **`_internal/overlay.ts`**.
> 
> **`image-lightbox`** is updated to **`{@attach createBodyScrollLock()}`** so opening the lightbox inside another scroll-locking overlay no longer restores page scroll when only the outer layer closes.
> 
> Adds regression tests on **`createBodyScrollLock`** (nested locks, idempotent release) and on the lightbox source/behavior contract.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c95302e38b35a7a6feb318fd0ddd58d12902a06a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->