### PR TITLE
fix(audit): add useResizeObserver/useMutationObserver factories; adopt {@attach} (83d9adf9)

### DIFF
--- a/packages/components/src/components/button-group/button-group.svelte
+++ b/packages/components/src/components/button-group/button-group.svelte
@@ -23,6 +23,7 @@
 
   import { classNames } from '../../utilities/class-names.ts';
   import { devWarn } from '../../utilities/dev-warn.ts';
+  import { useMutationObserver } from '../../utilities/use-mutation-observer.svelte.ts';
 
   let {
     label,
@@ -75,10 +76,10 @@
 
     sync();
 
-    const observer = new MutationObserver(sync);
-    observer.observe(element, { childList: true });
+    const detachObserver = useMutationObserver(sync, { childList: true })(element as HTMLElement);
+
     return () => {
-      observer.disconnect();
+      detachObserver?.();
       // Release ownership on unmount for any remaining tagged children.
       for (const child of Array.from(tagged)) {
         if (child.getAttribute(ATTR) === groupId) {

--- a/packages/components/src/components/chat/container/chat.svelte
+++ b/packages/components/src/components/chat/container/chat.svelte
@@ -231,6 +231,17 @@
 
   const viewportAttach = $derived(viewportAttachment ?? noopAttachment);
 
+  // Stable bottom-sentinel attachment. Wrapping useIntersection in $derived (matching
+  // load-more) means the IntersectionObserver is only torn down + recreated when
+  // `viewport` or `bottomThreshold` actually change — NOT on every chat re-render
+  // (which is frequent during streaming and would otherwise make bottom detection flicker).
+  const sentinelAttach = $derived(
+    useIntersection(scrollState.handleSentinelEntry, {
+      root: viewport,
+      rootMargin: `0px 0px ${bottomThreshold}px 0px`,
+    }),
+  );
+
   // Accessibility IDs
   const timelineId = $derived(`${id}-timeline`);
   const inputId = $derived(`${id}-input`);
@@ -666,14 +677,7 @@
       {/if}
 
       <!-- Bottom sentinel for IntersectionObserver -->
-      <div
-        class="chat-bottom-sentinel"
-        aria-hidden="true"
-        {@attach useIntersection(scrollState.handleSentinelEntry, {
-          root: viewport,
-          rootMargin: `0px 0px ${bottomThreshold}px 0px`,
-        })}
-      ></div>
+      <div class="chat-bottom-sentinel" aria-hidden="true" {@attach sentinelAttach}></div>
     {/if}
   </div>
 

--- a/packages/components/src/components/chat/container/chat.svelte
+++ b/packages/components/src/components/chat/container/chat.svelte
@@ -118,6 +118,7 @@
   import { useChatKeyboardNav } from './use-chat-keyboard-nav.svelte';
   import { useChatMessageGroups } from './use-chat-message-groups.svelte';
   import { useChatSearch } from './use-chat-search.svelte';
+  import { useIntersection } from '../../../utilities/use-intersection.svelte.ts';
   import ChatJumpControls from './chat-jump-controls.svelte';
   import ChatStatusAnnouncer from './chat-status-announcer.svelte';
   import ChatSearchBar from './chat-search-bar.svelte';
@@ -166,7 +167,6 @@
   // ==========================================================================
 
   let viewport = $state<HTMLElement | null>(null);
-  let bottomSentinel = $state<HTMLElement | null>(null);
   let containerRef = $state<HTMLElement | null>(null);
   let inputRef:
     | {
@@ -294,14 +294,6 @@
     // Pass a getter function for isAtBottom to avoid creating a scroll dependency.
     // The effect should only re-run when messages change, not on every scroll.
     unreadState.processMessages(messages, conversation.id, () => scrollState.isAtBottom);
-  });
-
-  // ==========================================================================
-  // IntersectionObserver for Bottom Sentinel
-  // ==========================================================================
-
-  $effect(() => {
-    return scrollState.createSentinelObserver(viewport, bottomSentinel);
   });
 
   // ==========================================================================
@@ -674,7 +666,14 @@
       {/if}
 
       <!-- Bottom sentinel for IntersectionObserver -->
-      <div bind:this={bottomSentinel} class="chat-bottom-sentinel" aria-hidden="true"></div>
+      <div
+        class="chat-bottom-sentinel"
+        aria-hidden="true"
+        {@attach useIntersection(scrollState.handleSentinelEntry, {
+          root: viewport,
+          rootMargin: `0px 0px ${bottomThreshold}px 0px`,
+        })}
+      ></div>
     {/if}
   </div>
 

--- a/packages/components/src/components/chat/container/use-chat-scroll-state.svelte.ts
+++ b/packages/components/src/components/chat/container/use-chat-scroll-state.svelte.ts
@@ -139,15 +139,19 @@ function getScrollBehavior(): ScrollBehavior {
  *
  *   const scrollAttachment = scrollState.createScrollAttachment();
  *
- *   // Set up IntersectionObserver in an $effect
- *   $effect(() => {
- *     return scrollState.createSentinelObserver(viewport, bottomSentinel);
- *   });
+ *   // Wire the bottom sentinel with useIntersection via {@attach}. Wrap in $derived so
+ *   // the observer is stable across re-renders (recreated only when root/threshold change).
+ *   const sentinelAttach = $derived(
+ *     useIntersection(scrollState.handleSentinelEntry, {
+ *       root: viewport,
+ *       rootMargin: `0px 0px 150px 0px`,
+ *     }),
+ *   );
  * </script>
  *
  * <div bind:this={viewport} {@attach scrollAttachment}>
  *   <!-- content -->
- *   <div bind:this={bottomSentinel}></div>
+ *   <div {@attach sentinelAttach}></div>
  * </div>
  *
  * {#if scrollState.showJumpButton}

--- a/packages/components/src/components/chat/container/use-chat-scroll-state.svelte.ts
+++ b/packages/components/src/components/chat/container/use-chat-scroll-state.svelte.ts
@@ -76,6 +76,12 @@ export interface UseChatScrollStateReturn {
     viewport: HTMLElement | null,
     sentinel: HTMLElement | null,
   ): (() => void) | undefined;
+  /**
+   * IntersectionObserver callback for the bottom sentinel element.
+   * Use with useIntersection for attachment-based wiring:
+   * `{@attach useIntersection(scrollState.handleSentinelEntry, { root: viewport, ... })}`.
+   */
+  handleSentinelEntry(entry: IntersectionObserverEntry): void;
   /** Scroll to the bottom of the viewport */
   scrollToBottom(viewport: HTMLElement | null): void;
   /** Scroll to the top of the viewport */
@@ -224,7 +230,20 @@ export function useChatScrollState(options?: UseChatScrollStateOptions): UseChat
   }
 
   /**
+   * IntersectionObserver callback for the bottom sentinel element.
+   * Exposed for use with useIntersection attachment-based wiring.
+   */
+  function handleSentinelEntry(entry: IntersectionObserverEntry): void {
+    const atBottom = entry.isIntersecting;
+    if (atBottom && !isAtBottom) {
+      isAtBottom = true;
+      onReachBottom?.();
+    }
+  }
+
+  /**
    * Create an IntersectionObserver for the bottom sentinel.
+   * @deprecated Prefer `{@attach useIntersection(scrollState.handleSentinelEntry, { root: viewport, rootMargin })}` on the sentinel element.
    */
   function createSentinelObserver(
     viewport: HTMLElement | null,
@@ -235,16 +254,12 @@ export function useChatScrollState(options?: UseChatScrollStateOptions): UseChat
     const observer = new IntersectionObserver(
       ([entry]) => {
         if (!entry) return;
-        const atBottom = entry.isIntersecting;
-        if (atBottom && !isAtBottom) {
-          isAtBottom = true;
-          onReachBottom?.();
-        }
+        handleSentinelEntry(entry);
       },
       {
         root: viewport,
         threshold: 0,
-        rootMargin: `0px 0px ${bottomThreshold}px 0px`,
+        rootMargin: `0px 0px ${getBottomThreshold?.() ?? bottomThreshold}px 0px`,
       },
     );
 
@@ -303,6 +318,7 @@ export function useChatScrollState(options?: UseChatScrollStateOptions): UseChat
     setIsAtBottom,
     createScrollAttachment,
     createSentinelObserver,
+    handleSentinelEntry,
     scrollToBottom,
     scrollToTop,
     jumpToLatest,

--- a/packages/components/src/components/resizable-panels/resizable-panels.svelte
+++ b/packages/components/src/components/resizable-panels/resizable-panels.svelte
@@ -179,7 +179,7 @@
     }
   }
 
-  function measureRoot(element: HTMLElement = rootElement!): void {
+  function measureRoot(element: HTMLElement | undefined = rootElement): void {
     if (!element) return;
     const rect = element.getBoundingClientRect();
     const rootPixels = orientation === 'horizontal' ? rect.width : rect.height;

--- a/packages/components/src/components/resizable-panels/resizable-panels.svelte
+++ b/packages/components/src/components/resizable-panels/resizable-panels.svelte
@@ -54,6 +54,7 @@
     ResizablePanelsResizeReason,
   } from './resizable-panels.types.ts';
   import type { ResizablePanelsLayoutState } from './resizable-panels-sizing.ts';
+  import { useResizeObserver } from '../../utilities/use-resize-observer.svelte.ts';
 
   let {
     panes,
@@ -178,11 +179,11 @@
     }
   }
 
-  function measureRoot(): void {
-    if (!rootElement) return;
-    const rect = rootElement.getBoundingClientRect();
+  function measureRoot(element: HTMLElement = rootElement!): void {
+    if (!element) return;
+    const rect = element.getBoundingClientRect();
     const rootPixels = orientation === 'horizontal' ? rect.width : rect.height;
-    const firstHandle = rootElement.querySelector<HTMLElement>('.cinder-resizable-panels__handle');
+    const firstHandle = element.querySelector<HTMLElement>('.cinder-resizable-panels__handle');
     let handlePixels = measuredHandlePixels;
     if (firstHandle) {
       const handleRect = firstHandle.getBoundingClientRect();
@@ -193,14 +194,8 @@
     syncMeasuredLayout(computeAvailablePanePixels(rootPixels, handlePixels));
   }
 
-  $effect(() => {
-    if (!rootElement || typeof ResizeObserver === 'undefined') return;
+  const resizeAttachment = useResizeObserver(() => {
     measureRoot();
-    const resizeObserver = new ResizeObserver(() => {
-      measureRoot();
-    });
-    resizeObserver.observe(rootElement);
-    return () => resizeObserver.disconnect();
   });
 
   $effect(() => {
@@ -423,6 +418,7 @@
 <div
   {...rest}
   bind:this={rootElement}
+  {@attach resizeAttachment}
   class={classNames('cinder-resizable-panels', className)}
   data-cinder-orientation={orientation}
 >

--- a/packages/components/src/components/table-row/table-row.svelte
+++ b/packages/components/src/components/table-row/table-row.svelte
@@ -80,14 +80,6 @@
     onSelectedChange?.(input.checked);
   }
 
-  // Sync indeterminate state on the select-all checkbox via DOM property.
-  let selectAllInput: HTMLInputElement | undefined = $state();
-  $effect(() => {
-    if (selectAllInput && headerSelection) {
-      selectAllInput.indeterminate = headerSelection.someSelected && !headerSelection.allSelected;
-    }
-  });
-
   const shouldRenderHeaderSelectionCell =
     selectionEnabled && section === 'header' && headerSelection !== undefined;
 
@@ -100,12 +92,16 @@
   {#if shouldRenderHeaderSelectionCell && headerSelection}
     <th scope="col" class="cinder-table__header-cell cinder-table__header-cell--selection">
       <input
-        bind:this={selectAllInput}
         type="checkbox"
         class="cinder-table__selection-checkbox"
         checked={headerSelection.allSelected}
         aria-label={headerSelection.selectAllLabel}
         onchange={handleSelectAllChange}
+        {@attach (node: HTMLInputElement) => {
+          $effect(() => {
+            node.indeterminate = headerSelection.someSelected && !headerSelection.allSelected;
+          });
+        }}
       />
     </th>
   {/if}

--- a/packages/components/src/components/toolbar/toolbar.svelte
+++ b/packages/components/src/components/toolbar/toolbar.svelte
@@ -22,6 +22,7 @@
   import { classNames } from '../../utilities/class-names.ts';
   import { devWarn } from '../../utilities/dev-warn.ts';
   import { getFocusableIndex, handleRovingKeydown } from '../../utilities/roving-tabindex.ts';
+  import { useMutationObserver } from '../../utilities/use-mutation-observer.svelte.ts';
   import type { ToolbarProps } from './toolbar.types.ts';
 
   type EditableElement = HTMLInputElement | HTMLTextAreaElement | HTMLElement;
@@ -55,15 +56,12 @@
     ...rest
   }: ToolbarRuntimeProps = $props();
 
-  let rootElement = $state<HTMLDivElement | null>(null);
+  let rootElement: HTMLDivElement | null = null;
   let toolbarItems = $state<HTMLElement[]>([]);
   let activeItem = $state<HTMLElement | null>(null);
 
   const originalTabIndexes = new WeakMap<HTMLElement, string | null>();
   let previousManagedItems = new Set<HTMLElement>();
-  let cleanupKeyboardListener: (() => void) | null = null;
-  let cleanupFocusInListener: (() => void) | null = null;
-  let mutationObserver: MutationObserver | null = null;
   let lastWarnedNameSource = '';
 
   function isHTMLElement(value: Element | EventTarget | null): value is HTMLElement {
@@ -350,57 +348,55 @@
     );
   }
 
-  $effect(() => {
-    if (!rootElement) return;
+  function toolbarSetup(node: HTMLDivElement) {
+    rootElement = node;
 
     syncToolbarItems(untrack(() => activeItem));
-    cleanupKeyboardListener?.();
-    cleanupFocusInListener?.();
-    cleanupKeyboardListener = on(rootElement, 'keydown', handleToolbarKeyDown, { capture: true });
-    cleanupFocusInListener = on(rootElement, 'focusin', handleToolbarFocusIn);
 
-    mutationObserver?.disconnect();
-    mutationObserver = new MutationObserver(() => {
-      syncToolbarItems(activeItem);
-      warnAboutAccessibleName();
-    });
-    mutationObserver.observe(rootElement, {
-      subtree: true,
-      childList: true,
-      attributes: true,
-      attributeFilter: [
-        'aria-disabled',
-        'aria-hidden',
-        'aria-label',
-        'aria-labelledby',
-        'class',
-        'data-cinder-toolbar-exclude',
-        'data-cinder-toolbar-item',
-        'disabled',
-        'hidden',
-        'inert',
-        'style',
-        'type',
-      ],
-    });
+    const cleanupKeyboardListener = on(node, 'keydown', handleToolbarKeyDown, { capture: true });
+    const cleanupFocusInListener = on(node, 'focusin', handleToolbarFocusIn);
+
+    const detachMutationObserver = useMutationObserver(
+      () => {
+        syncToolbarItems(activeItem);
+        warnAboutAccessibleName();
+      },
+      {
+        subtree: true,
+        childList: true,
+        attributes: true,
+        attributeFilter: [
+          'aria-disabled',
+          'aria-hidden',
+          'aria-label',
+          'aria-labelledby',
+          'class',
+          'data-cinder-toolbar-exclude',
+          'data-cinder-toolbar-item',
+          'disabled',
+          'hidden',
+          'inert',
+          'style',
+          'type',
+        ],
+      },
+    )(node);
 
     warnAboutAccessibleName();
 
     return () => {
-      cleanupKeyboardListener?.();
-      cleanupFocusInListener?.();
-      cleanupKeyboardListener = null;
-      cleanupFocusInListener = null;
-      mutationObserver?.disconnect();
-      mutationObserver = null;
+      cleanupKeyboardListener();
+      cleanupFocusInListener();
+      detachMutationObserver?.();
+      rootElement = null;
       restoreDepartedItems([]);
     };
-  });
+  }
 </script>
 
 <div
-  bind:this={rootElement}
   {...rest}
+  {@attach toolbarSetup}
   role="toolbar"
   aria-label={ariaLabel}
   aria-labelledby={ariaLabelledBy}

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -604,8 +604,10 @@ export type {
 } from './utilities/use-history.svelte.ts';
 
 export { useIntersection } from './utilities/use-intersection.svelte.ts';
+export { useMutationObserver } from './utilities/use-mutation-observer.svelte.ts';
 export { useReducedMotion } from './utilities/use-reduced-motion.svelte.ts';
 export type { UseReducedMotion } from './utilities/use-reduced-motion.svelte.ts';
+export { useResizeObserver } from './utilities/use-resize-observer.svelte.ts';
 
 export { useToast } from './utilities/use-toast.ts';
 

--- a/packages/components/src/test/fixtures/use-mutation-observer-attach-fixture.svelte
+++ b/packages/components/src/test/fixtures/use-mutation-observer-attach-fixture.svelte
@@ -1,0 +1,19 @@
+<script lang="ts" module>
+  import type {
+    MutationCallback,
+    UseMutationObserverOptions,
+  } from '../../utilities/use-mutation-observer.svelte.ts';
+
+  export type UseMutationObserverAttachFixtureProps = {
+    onMutate: MutationCallback;
+    options?: UseMutationObserverOptions;
+  };
+</script>
+
+<script lang="ts">
+  import { useMutationObserver } from '../../utilities/use-mutation-observer.svelte.ts';
+
+  let { onMutate, options }: UseMutationObserverAttachFixtureProps = $props();
+</script>
+
+<div data-testid="sentinel" {@attach useMutationObserver(onMutate, options)}></div>

--- a/packages/components/src/test/fixtures/use-resize-observer-attach-fixture.svelte
+++ b/packages/components/src/test/fixtures/use-resize-observer-attach-fixture.svelte
@@ -1,0 +1,19 @@
+<script lang="ts" module>
+  import type {
+    ResizeCallback,
+    UseResizeObserverOptions,
+  } from '../../utilities/use-resize-observer.svelte.ts';
+
+  export type UseResizeObserverAttachFixtureProps = {
+    onResize: ResizeCallback;
+    options?: UseResizeObserverOptions;
+  };
+</script>
+
+<script lang="ts">
+  import { useResizeObserver } from '../../utilities/use-resize-observer.svelte.ts';
+
+  let { onResize, options }: UseResizeObserverAttachFixtureProps = $props();
+</script>
+
+<div data-testid="sentinel" {@attach useResizeObserver(onResize, options)}></div>

--- a/packages/components/src/utilities/use-mutation-observer.svelte.test.ts
+++ b/packages/components/src/utilities/use-mutation-observer.svelte.test.ts
@@ -1,0 +1,251 @@
+/// <reference lib="dom" />
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+
+import { setupHappyDom } from '../test/happy-dom.ts';
+
+setupHappyDom();
+
+const { render, cleanup } = await import('@testing-library/svelte');
+const { default: UseMutationObserverAttachFixture } =
+  await import('../test/fixtures/use-mutation-observer-attach-fixture.svelte');
+
+type ObserverRecord = {
+  callback: MutationCallback;
+  init: MutationObserverInit | undefined;
+  observeCalls: { target: Element; init: MutationObserverInit | undefined }[];
+  disconnectCalls: number;
+};
+
+class FakeMutationObserver {
+  static records: ObserverRecord[] = [];
+
+  private readonly record: ObserverRecord;
+
+  constructor(callback: MutationCallback) {
+    this.record = {
+      callback,
+      init: undefined,
+      observeCalls: [],
+      disconnectCalls: 0,
+    };
+    FakeMutationObserver.records.push(this.record);
+  }
+
+  observe(target: Element, init?: MutationObserverInit) {
+    this.record.init = init;
+    this.record.observeCalls.push({ target, init });
+  }
+
+  disconnect() {
+    this.record.disconnectCalls += 1;
+  }
+
+  takeRecords(): MutationRecord[] {
+    return [];
+  }
+}
+
+const originalMutationObserver = globalThis.MutationObserver;
+
+function createMutationRecord(target: Element): MutationRecord {
+  return {
+    type: 'childList',
+    target,
+    addedNodes: [] as unknown as NodeList,
+    removedNodes: [] as unknown as NodeList,
+    previousSibling: null,
+    nextSibling: null,
+    attributeName: null,
+    attributeNamespace: null,
+    oldValue: null,
+  };
+}
+
+beforeEach(() => {
+  FakeMutationObserver.records = [];
+  globalThis.MutationObserver = FakeMutationObserver as unknown as typeof MutationObserver;
+});
+
+afterEach(() => {
+  cleanup();
+  globalThis.MutationObserver = originalMutationObserver;
+});
+
+describe('useMutationObserver', () => {
+  test('constructs an observer with the provided init options', () => {
+    const { getByTestId } = render(UseMutationObserverAttachFixture, {
+      props: {
+        onMutate: () => {},
+        options: {
+          childList: true,
+          subtree: true,
+          attributes: true,
+          attributeFilter: ['class', 'disabled'],
+        },
+      },
+    });
+
+    const sentinel = getByTestId('sentinel');
+    const [record] = FakeMutationObserver.records;
+
+    expect(record?.observeCalls).toHaveLength(1);
+    expect(record?.observeCalls[0]?.target).toBe(sentinel);
+    expect(record?.init).toEqual({
+      childList: true,
+      subtree: true,
+      attributes: true,
+      attributeFilter: ['class', 'disabled'],
+    });
+  });
+
+  test('invokes the callback with the mutations array', () => {
+    const seen: Element[] = [];
+    const { getByTestId } = render(UseMutationObserverAttachFixture, {
+      props: {
+        onMutate: (mutations: MutationRecord[]) => {
+          for (const mutation of mutations) {
+            seen.push(mutation.target as Element);
+          }
+        },
+        options: { childList: true },
+      },
+    });
+
+    const sentinel = getByTestId('sentinel');
+    const [record] = FakeMutationObserver.records;
+
+    record?.callback([createMutationRecord(sentinel)], {} as MutationObserver);
+
+    expect(seen).toEqual([sentinel]);
+  });
+
+  test('ignores queued observer entries after enabled flips false', async () => {
+    let enabled = true;
+    const seen: Element[] = [];
+
+    const rendered = render(UseMutationObserverAttachFixture, {
+      props: {
+        onMutate: (mutations: MutationRecord[]) => {
+          for (const mutation of mutations) {
+            seen.push(mutation.target as Element);
+          }
+        },
+        options: {
+          childList: true,
+          enabled: () => enabled,
+        },
+      },
+    });
+
+    const sentinel = rendered.getByTestId('sentinel');
+    const [record] = FakeMutationObserver.records;
+
+    enabled = false;
+    await rendered.rerender({
+      onMutate: (mutations: MutationRecord[]) => {
+        for (const mutation of mutations) {
+          seen.push(mutation.target as Element);
+        }
+      },
+      options: {
+        childList: true,
+        enabled: () => enabled,
+      },
+    });
+
+    record?.callback([createMutationRecord(sentinel)], {} as MutationObserver);
+
+    expect(seen).toEqual([]);
+  });
+
+  test('disconnects when the attachment is destroyed', () => {
+    const rendered = render(UseMutationObserverAttachFixture, {
+      props: {
+        onMutate: () => {},
+        options: { childList: true },
+      },
+    });
+
+    const [record] = FakeMutationObserver.records;
+
+    rendered.unmount();
+
+    expect(record?.disconnectCalls).toBeGreaterThanOrEqual(1);
+  });
+
+  test('does not observe while enabled returns false, then reconnects when it flips true', async () => {
+    let enabled = false;
+
+    const rendered = render(UseMutationObserverAttachFixture, {
+      props: {
+        onMutate: () => {},
+        options: {
+          childList: true,
+          enabled: () => enabled,
+        },
+      },
+    });
+
+    expect(FakeMutationObserver.records).toHaveLength(0);
+
+    enabled = true;
+    await rendered.rerender({
+      onMutate: () => {},
+      options: {
+        childList: true,
+        enabled: () => enabled,
+      },
+    });
+
+    expect(FakeMutationObserver.records).toHaveLength(1);
+    expect(FakeMutationObserver.records[0]?.observeCalls).toHaveLength(1);
+
+    enabled = false;
+    await rendered.rerender({
+      onMutate: () => {},
+      options: {
+        childList: true,
+        enabled: () => enabled,
+      },
+    });
+
+    expect(FakeMutationObserver.records[0]?.disconnectCalls).toBeGreaterThanOrEqual(1);
+
+    enabled = true;
+    await rendered.rerender({
+      onMutate: () => {},
+      options: {
+        childList: true,
+        enabled: () => enabled,
+      },
+    });
+
+    expect(FakeMutationObserver.records).toHaveLength(2);
+  });
+
+  test('observes immediately when enabled is omitted', () => {
+    render(UseMutationObserverAttachFixture, {
+      props: {
+        onMutate: () => {},
+        options: { childList: true },
+      },
+    });
+
+    expect(FakeMutationObserver.records).toHaveLength(1);
+  });
+
+  test('is a safe no-op when MutationObserver is unavailable', () => {
+    globalThis.MutationObserver = undefined as unknown as typeof MutationObserver;
+
+    const rendered = render(UseMutationObserverAttachFixture, {
+      props: {
+        onMutate: () => {},
+        options: { childList: true },
+      },
+    });
+
+    expect(FakeMutationObserver.records).toHaveLength(0);
+
+    rendered.unmount();
+  });
+});

--- a/packages/components/src/utilities/use-mutation-observer.svelte.ts
+++ b/packages/components/src/utilities/use-mutation-observer.svelte.ts
@@ -1,0 +1,92 @@
+import type { Attachment } from 'svelte/attachments';
+
+export type MutationCallback = (mutations: MutationRecord[]) => void;
+
+export type UseMutationObserverOptions = {
+  /** Whether to observe child node additions and removals. */
+  childList?: boolean;
+  /** Whether to observe changes to the target's attributes. */
+  attributes?: boolean;
+  /** Whether to observe changes to the target's character data. */
+  characterData?: boolean;
+  /** Whether to extend observation to the entire subtree. */
+  subtree?: boolean;
+  /** Specific attribute names to observe. Only relevant when `attributes` is true. */
+  attributeFilter?: string[];
+  /** Whether to record the old attribute value before a change. */
+  attributeOldValue?: boolean;
+  /** Whether to record the old character data before a change. */
+  characterDataOldValue?: boolean;
+  /** Getter for whether observation is enabled. Defaults to `() => true`. */
+  enabled?: () => boolean;
+};
+
+/**
+ * Creates an attachment that observes the element with MutationObserver.
+ *
+ * All MutationObserver init options (`childList`, `attributes`, etc.) are
+ * captured for each attachment instance. If the caller needs different values,
+ * create a new attachment instance so a new observer is created.
+ */
+export function useMutationObserver(
+  onMutate: MutationCallback,
+  options: UseMutationObserverOptions = {},
+): Attachment<HTMLElement> {
+  const {
+    childList,
+    attributes,
+    characterData,
+    subtree,
+    attributeFilter,
+    attributeOldValue,
+    characterDataOldValue,
+    enabled = () => true,
+  } = options;
+
+  const init: MutationObserverInit = {};
+  if (childList !== undefined) init.childList = childList;
+  if (attributes !== undefined) init.attributes = attributes;
+  if (characterData !== undefined) init.characterData = characterData;
+  if (subtree !== undefined) init.subtree = subtree;
+  if (attributeFilter !== undefined) init.attributeFilter = attributeFilter;
+  if (attributeOldValue !== undefined) init.attributeOldValue = attributeOldValue;
+  if (characterDataOldValue !== undefined) init.characterDataOldValue = characterDataOldValue;
+
+  return (node: HTMLElement) => {
+    if (typeof MutationObserver === 'undefined') {
+      return () => {};
+    }
+
+    let observer: MutationObserver | null = null;
+
+    const disconnectObserver = () => {
+      observer?.disconnect();
+      observer = null;
+    };
+
+    $effect(() => {
+      if (!enabled()) {
+        disconnectObserver();
+        return;
+      }
+
+      observer = new MutationObserver((mutations) => {
+        if (!enabled()) {
+          return;
+        }
+
+        onMutate(mutations);
+      });
+
+      observer.observe(node, init);
+
+      return () => {
+        disconnectObserver();
+      };
+    });
+
+    return () => {
+      disconnectObserver();
+    };
+  };
+}

--- a/packages/components/src/utilities/use-mutation-observer.svelte.ts
+++ b/packages/components/src/utilities/use-mutation-observer.svelte.ts
@@ -52,6 +52,17 @@ export function useMutationObserver(
   if (attributeOldValue !== undefined) init.attributeOldValue = attributeOldValue;
   if (characterDataOldValue !== undefined) init.characterDataOldValue = characterDataOldValue;
 
+  // MutationObserver.observe() throws a TypeError unless at least one of childList /
+  // attributes / characterData is set. If a caller passed only modifiers (or nothing),
+  // default to observing childList so the attachment never throws at runtime.
+  if (
+    init.childList === undefined &&
+    init.attributes === undefined &&
+    init.characterData === undefined
+  ) {
+    init.childList = true;
+  }
+
   return (node: HTMLElement) => {
     if (typeof MutationObserver === 'undefined') {
       return () => {};

--- a/packages/components/src/utilities/use-resize-observer.svelte.test.ts
+++ b/packages/components/src/utilities/use-resize-observer.svelte.test.ts
@@ -1,0 +1,224 @@
+/// <reference lib="dom" />
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+
+import { setupHappyDom } from '../test/happy-dom.ts';
+
+setupHappyDom();
+
+const { render, cleanup } = await import('@testing-library/svelte');
+const { default: UseResizeObserverAttachFixture } =
+  await import('../test/fixtures/use-resize-observer-attach-fixture.svelte');
+
+type ObserverRecord = {
+  callback: ResizeObserverCallback;
+  observeCalls: { target: Element; options: ResizeObserverOptions | undefined }[];
+  disconnectCalls: number;
+};
+
+class FakeResizeObserver {
+  static records: ObserverRecord[] = [];
+
+  private readonly record: ObserverRecord;
+
+  constructor(callback: ResizeObserverCallback) {
+    this.record = {
+      callback,
+      observeCalls: [],
+      disconnectCalls: 0,
+    };
+    FakeResizeObserver.records.push(this.record);
+  }
+
+  observe(target: Element, options?: ResizeObserverOptions) {
+    this.record.observeCalls.push({ target, options });
+  }
+
+  disconnect() {
+    this.record.disconnectCalls += 1;
+  }
+
+  unobserve() {}
+}
+
+const originalResizeObserver = globalThis.ResizeObserver;
+
+function createEntry(target: Element): ResizeObserverEntry {
+  return {
+    borderBoxSize: [],
+    contentBoxSize: [],
+    contentRect: target.getBoundingClientRect(),
+    devicePixelContentBoxSize: [],
+    target,
+  };
+}
+
+beforeEach(() => {
+  FakeResizeObserver.records = [];
+  globalThis.ResizeObserver = FakeResizeObserver as unknown as typeof ResizeObserver;
+});
+
+afterEach(() => {
+  cleanup();
+  globalThis.ResizeObserver = originalResizeObserver;
+});
+
+describe('useResizeObserver', () => {
+  test('constructs an observer with the provided box option', () => {
+    const { getByTestId } = render(UseResizeObserverAttachFixture, {
+      props: {
+        onResize: () => {},
+        options: {
+          box: 'border-box',
+        },
+      },
+    });
+
+    const sentinel = getByTestId('sentinel');
+    const [record] = FakeResizeObserver.records;
+
+    expect(record?.observeCalls).toHaveLength(1);
+    expect(record?.observeCalls[0]?.target).toBe(sentinel);
+    expect(record?.observeCalls[0]?.options).toEqual({ box: 'border-box' });
+  });
+
+  test('invokes the callback with the entries array', () => {
+    const seen: Element[] = [];
+    const { getByTestId } = render(UseResizeObserverAttachFixture, {
+      props: {
+        onResize: (entries: ResizeObserverEntry[]) => {
+          for (const entry of entries) {
+            seen.push(entry.target);
+          }
+        },
+      },
+    });
+
+    const sentinel = getByTestId('sentinel');
+    const [record] = FakeResizeObserver.records;
+
+    record?.callback([createEntry(sentinel)], {} as ResizeObserver);
+
+    expect(seen).toEqual([sentinel]);
+  });
+
+  test('ignores queued observer entries after enabled flips false', async () => {
+    let enabled = true;
+    const seen: Element[] = [];
+
+    const rendered = render(UseResizeObserverAttachFixture, {
+      props: {
+        onResize: (entries: ResizeObserverEntry[]) => {
+          for (const entry of entries) {
+            seen.push(entry.target);
+          }
+        },
+        options: {
+          enabled: () => enabled,
+        },
+      },
+    });
+
+    const sentinel = rendered.getByTestId('sentinel');
+    const [record] = FakeResizeObserver.records;
+
+    enabled = false;
+    await rendered.rerender({
+      onResize: (entries: ResizeObserverEntry[]) => {
+        for (const entry of entries) {
+          seen.push(entry.target);
+        }
+      },
+      options: {
+        enabled: () => enabled,
+      },
+    });
+
+    record?.callback([createEntry(sentinel)], {} as ResizeObserver);
+
+    expect(seen).toEqual([]);
+  });
+
+  test('disconnects when the attachment is destroyed', () => {
+    const rendered = render(UseResizeObserverAttachFixture, {
+      props: {
+        onResize: () => {},
+      },
+    });
+
+    const [record] = FakeResizeObserver.records;
+
+    rendered.unmount();
+
+    expect(record?.disconnectCalls).toBeGreaterThanOrEqual(1);
+  });
+
+  test('does not observe while enabled returns false, then reconnects when it flips true', async () => {
+    let enabled = false;
+
+    const rendered = render(UseResizeObserverAttachFixture, {
+      props: {
+        onResize: () => {},
+        options: {
+          enabled: () => enabled,
+        },
+      },
+    });
+
+    expect(FakeResizeObserver.records).toHaveLength(0);
+
+    enabled = true;
+    await rendered.rerender({
+      onResize: () => {},
+      options: {
+        enabled: () => enabled,
+      },
+    });
+
+    expect(FakeResizeObserver.records).toHaveLength(1);
+    expect(FakeResizeObserver.records[0]?.observeCalls).toHaveLength(1);
+
+    enabled = false;
+    await rendered.rerender({
+      onResize: () => {},
+      options: {
+        enabled: () => enabled,
+      },
+    });
+
+    expect(FakeResizeObserver.records[0]?.disconnectCalls).toBeGreaterThanOrEqual(1);
+
+    enabled = true;
+    await rendered.rerender({
+      onResize: () => {},
+      options: {
+        enabled: () => enabled,
+      },
+    });
+
+    expect(FakeResizeObserver.records).toHaveLength(2);
+  });
+
+  test('observes immediately when enabled is omitted', () => {
+    render(UseResizeObserverAttachFixture, {
+      props: {
+        onResize: () => {},
+      },
+    });
+
+    expect(FakeResizeObserver.records).toHaveLength(1);
+  });
+
+  test('is a safe no-op when ResizeObserver is unavailable', () => {
+    globalThis.ResizeObserver = undefined as unknown as typeof ResizeObserver;
+
+    const rendered = render(UseResizeObserverAttachFixture, {
+      props: {
+        onResize: () => {},
+      },
+    });
+
+    expect(FakeResizeObserver.records).toHaveLength(0);
+
+    rendered.unmount();
+  });
+});

--- a/packages/components/src/utilities/use-resize-observer.svelte.ts
+++ b/packages/components/src/utilities/use-resize-observer.svelte.ts
@@ -1,0 +1,62 @@
+import type { Attachment } from 'svelte/attachments';
+
+export type ResizeCallback = (entries: ResizeObserverEntry[]) => void;
+
+export type UseResizeObserverOptions = {
+  /** Which box model to observe. Defaults to the ResizeObserver constructor default. */
+  box?: ResizeObserverBoxOptions;
+  /** Getter for whether observation is enabled. Defaults to `() => true`. */
+  enabled?: () => boolean;
+};
+
+/**
+ * Creates an attachment that observes the element with ResizeObserver.
+ *
+ * `box` is captured for each attachment instance. If the caller needs a
+ * different value, create a new attachment instance so a new observer is
+ * created.
+ */
+export function useResizeObserver(
+  onResize: ResizeCallback,
+  options: UseResizeObserverOptions = {},
+): Attachment<HTMLElement> {
+  const { box, enabled = () => true } = options;
+
+  return (node: HTMLElement) => {
+    if (typeof ResizeObserver === 'undefined') {
+      return () => {};
+    }
+
+    let observer: ResizeObserver | null = null;
+
+    const disconnectObserver = () => {
+      observer?.disconnect();
+      observer = null;
+    };
+
+    $effect(() => {
+      if (!enabled()) {
+        disconnectObserver();
+        return;
+      }
+
+      observer = new ResizeObserver((entries) => {
+        if (!enabled()) {
+          return;
+        }
+
+        onResize(entries);
+      });
+
+      observer.observe(node, box !== undefined ? { box } : undefined);
+
+      return () => {
+        disconnectObserver();
+      };
+    });
+
+    return () => {
+      disconnectObserver();
+    };
+  };
+}


### PR DESCRIPTION
## Summary

Audit sweep `83d9adf9`. Several components hand-rolled `bind:this` + `$effect` to wire observers, which the audit flags as both missing-modern-feature and effect-misuse. Adds two attachment factories mirroring `useIntersection`:

- `useResizeObserver(onResize, options)` and `useMutationObserver(onMutate, options)`, each returning an Attachment usable via `{@attach}`, with full cleanup.

Converts the hand-rolled blocks to `{@attach}`:
- **resizable-panels** (ResizeObserver), **toolbar** (DOM-setup block), **button-group** (MutationObserver), **table-row** (indeterminate sync → inline attachment), **chat** (createSentinelObserver → useIntersection, which also fixes a stale `bottomThreshold` closure bug surfaced by the audit).

Exports the two utilities from `src/index.ts` (value-only, matching useIntersection).

## Review committee

Pre-reviewed by: svelte-expert — APPROVED (utilities match the useIntersection contract exactly; all 6 conversions preserve behavior; the chat stale-closure fix is correct; clean observer disconnect on teardown)
- Codex (gpt-5.4, xhigh) — APPROVED (no findings)

## Test plan
- `bun run --filter=cinder test` — 4405 pass, 0 fail (the two new utility suites + converted components).
- `typecheck` 0 errors; `components:check` / `exports:check` OK; `lint` 0 errors.

Closes 83d9adf9.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches chat scroll/unread behavior and toolbar roving-tabindex DOM setup; changes are behavior-preserving but regression-prone in those interaction paths.
> 
> **Overview**
> Adds **`useResizeObserver`** and **`useMutationObserver`** attachment factories (same pattern as **`useIntersection`**) and exports them from the package entry.
> 
> Replaces hand-rolled **`bind:this` + `$effect` + `MutationObserver`/`ResizeObserver`** wiring with **`{@attach}`** in **button-group**, **toolbar**, **resizable-panels**, and **table-row** (select-all **indeterminate** via an inline attachment).
> 
> **Chat** bottom detection moves to a **`$derived`** **`useIntersection`** sentinel (stable across streaming re-renders) and **`handleSentinelEntry`** on the scroll helper; the old sentinel **`$effect`** path is removed, and **`createSentinelObserver`** now reads **`getBottomThreshold`** for margin.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4bed9e43efae0a9ac47a66a9afc349f86c29a964. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->