### PR TITLE
fix(audit): two HIGH overlay focus-restore bugs (cd08a44f)

### DIFF
--- a/packages/components/src/components/focus-trap/focus-trap.test.ts
+++ b/packages/components/src/components/focus-trap/focus-trap.test.ts
@@ -174,6 +174,36 @@ describe('FocusTrap', () => {
     expect(document.activeElement).toBe(trigger);
   });
 
+  test('does not steal focus when deactivated before the deferred focus microtask drains', async () => {
+    // Regression for a focus-restore race: `activate()` defers `focusTrapTarget` via
+    // `queueMicrotask`. If the trap deactivates before that microtask drains, `deactivate()`
+    // restores focus to the previously-focused element — but the stale, still-queued
+    // `focusTrapTarget` would then fire and steal focus back into the now-deactivated trap.
+    // The deferred body is guarded by the `activated` flag and an activation generation, so a
+    // deactivation that lands before the microtask drains makes the queued focus a no-op.
+    //
+    // Activate then deactivate within the same microtask turn: `render` mounts and runs the
+    // activation `$effect` synchronously (queuing the focus microtask), and `rerender` flips
+    // `active` to false synchronously (running `deactivate()` and restoring focus) — all before
+    // the first `await` lets the microtask queue drain. The node stays mounted, so a missing
+    // guard would let the queued `focusTrapTarget` find the (still-present) tabbable buttons and
+    // steal focus back in.
+    const trigger = document.createElement('button');
+    document.body.appendChild(trigger);
+    trigger.focus();
+
+    const { rerender } = render(FocusTrap, {
+      props: { active: true, children: focusTrapChildren },
+    });
+    // No `await` between mount and deactivation: the deferred `focusTrapTarget` is still queued.
+    await rerender({ active: false, children: focusTrapChildren });
+
+    // Drain microtasks: the stale `focusTrapTarget` must be a no-op now that the trap is inactive.
+    await tick();
+
+    expect(document.activeElement).toBe(trigger);
+  });
+
   test('restores focus on reactive deactivation, before unmount', async () => {
     // Regression for Codex round 2 finding: the `activated` flag alone did not handle the case
     // where `active` flipped false while the component remained mounted. The nested `$effect` now

--- a/packages/components/src/components/focus-trap/focus-trap.utilities.svelte.ts
+++ b/packages/components/src/components/focus-trap/focus-trap.utilities.svelte.ts
@@ -155,6 +155,10 @@ export function createFocusTrap(options: FocusTrapOptions = {}): Attachment<HTML
     const fallbackFocus = options.fallbackFocus ?? null;
 
     let activated = false;
+    // Bumped on every `activate()`. The deferred `focusTrapTarget` microtask snapshots this value
+    // and bails if it no longer matches, so a deactivate (or deactivate→reactivate) that lands
+    // before the microtask drains can't let a stale activation steal focus into the trap.
+    let activationGeneration = 0;
     let capturedFocus: HTMLElement | null = null;
     let restoreRootFocusability = noop;
 
@@ -181,12 +185,20 @@ export function createFocusTrap(options: FocusTrapOptions = {}): Attachment<HTML
     function activate() {
       if (activated) return;
       activated = true;
+      const generation = ++activationGeneration;
       capturedFocus =
         document.activeElement instanceof HTMLElement && document.activeElement !== document.body
           ? document.activeElement
           : null;
       pushTrap({ id: trapId, node });
-      queueMicrotask(focusTrapTarget);
+      // Defer focusing so the trap's content is in the DOM. Guard against the trap being
+      // deactivated (or deactivated then reactivated) before this microtask drains — moving focus
+      // into a no-longer-current activation would steal it back after `deactivate()` already
+      // restored it to the previously-focused element.
+      queueMicrotask(() => {
+        if (!activated || generation !== activationGeneration) return;
+        focusTrapTarget();
+      });
     }
 
     function deactivate() {

--- a/packages/components/src/components/selection-popover/selection-popover.svelte
+++ b/packages/components/src/components/selection-popover/selection-popover.svelte
@@ -43,6 +43,7 @@
   let restoreFocusElement = $state<HTMLElement | null>(null);
   let measuredWidth = $state(0);
   let measuredHeight = $state(0);
+  let wasOpen = false;
 
   const VIEWPORT_MARGIN = 16;
 
@@ -161,10 +162,29 @@
 
   $effect(() => {
     if (!open) {
-      expanded = false;
-      commentBody = '';
-      restoreFocusElement = null;
+      // Only act on the true -> false transition. This keeps the close logic
+      // (state reset + focus restore) from re-running on unrelated effect
+      // re-evaluations while already closed.
+      if (wasOpen) {
+        wasOpen = false;
+        expanded = false;
+        commentBody = '';
+        // Return focus to wherever it was before the popover opened.
+        // restoreFocus() null-guards and clears the ref, so an internal close
+        // that already restored leaves this a safe no-op (no double-restore).
+        restoreFocus();
+      }
       return;
+    }
+
+    // Capture the pre-open focus owner once, on the false -> true transition,
+    // before focus can move into the popover. This guarantees something to
+    // restore to on an external close even if the popover is never expanded,
+    // while never re-capturing mid-open (which would otherwise re-grab focus
+    // after an internal close-and-restore left the popover open).
+    if (!wasOpen) {
+      wasOpen = true;
+      rememberFocus();
     }
 
     document.addEventListener('pointerdown', handleDocumentPointerdown);

--- a/packages/components/src/components/selection-popover/selection-popover.test.ts
+++ b/packages/components/src/components/selection-popover/selection-popover.test.ts
@@ -121,4 +121,131 @@ describe('SelectionPopover', () => {
     expect(screen.queryByPlaceholderText('Add a comment...')).toBeNull();
     expect(screen.getByRole('button', { name: 'Add comment' })).not.toBeNull();
   });
+
+  test('restores focus to the prior element when closed externally via the open prop', async () => {
+    const trigger = document.createElement('button');
+    trigger.textContent = 'Open selection actions';
+    document.body.append(trigger);
+    trigger.focus();
+    expect(document.activeElement).toBe(trigger);
+
+    const { rerender } = render(SelectionPopover, {
+      props: {
+        id: 'selection-comment',
+        open: true,
+        position: { x: 120, y: 80 },
+      },
+    });
+
+    // The consumer flips `open` to false directly (not via cancel/submit/close).
+    await rerender({ open: false, position: { x: 120, y: 80 } });
+
+    expect(document.activeElement).toBe(trigger);
+
+    trigger.remove();
+  });
+
+  test('does nothing on external close when no focus was captured', async () => {
+    document.body.focus();
+    const initialActive = document.activeElement;
+
+    const { rerender } = render(SelectionPopover, {
+      props: {
+        id: 'selection-comment',
+        // Never opened (and never expanded), so nothing is captured.
+        open: false,
+        position: { x: 120, y: 80 },
+      },
+    });
+
+    // Toggling the already-closed popover must not throw and must not steal focus.
+    await rerender({ open: false, position: { x: 120, y: 80 } });
+
+    expect(document.activeElement).toBe(initialActive);
+  });
+
+  test('internal cancel restores focus exactly once and the external effect is a no-op', async () => {
+    const trigger = document.createElement('button');
+    trigger.textContent = 'Open selection actions';
+    document.body.append(trigger);
+    trigger.focus();
+
+    let focusCalls = 0;
+    const originalFocus = trigger.focus.bind(trigger);
+    trigger.focus = () => {
+      focusCalls += 1;
+      originalFocus();
+    };
+
+    let canceled = false;
+
+    const { rerender } = render(SelectionPopover, {
+      props: {
+        id: 'selection-comment',
+        open: true,
+        position: { x: 120, y: 80 },
+        oncancel: () => {
+          canceled = true;
+        },
+      },
+    });
+
+    // Expand so a focus owner is captured, then cancel internally.
+    await fireEvent.click(screen.getByRole('button', { name: 'Add comment' }));
+    await fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+
+    expect(canceled).toBe(true);
+    expect(focusCalls).toBe(1);
+    expect(document.activeElement).toBe(trigger);
+
+    // The consumer's onclose handler subsequently flips `open` to false; because
+    // the internal cancel already restored (and nulled the ref), the open->false
+    // effect's restore is a no-op — focus is not driven a second time.
+    await rerender({ open: false, position: { x: 120, y: 80 } });
+
+    expect(focusCalls).toBe(1);
+
+    trigger.remove();
+  });
+
+  test('internal submit restores focus exactly once', async () => {
+    const trigger = document.createElement('button');
+    trigger.textContent = 'Open selection actions';
+    document.body.append(trigger);
+    trigger.focus();
+
+    let focusCalls = 0;
+    const originalFocus = trigger.focus.bind(trigger);
+    trigger.focus = () => {
+      focusCalls += 1;
+      originalFocus();
+    };
+
+    const submitted: string[] = [];
+
+    const { rerender } = render(SelectionPopover, {
+      props: {
+        id: 'selection-comment',
+        open: true,
+        position: { x: 120, y: 80 },
+        oncommentsubmit: (body: string) => submitted.push(body),
+      },
+    });
+
+    await fireEvent.click(screen.getByRole('button', { name: 'Add comment' }));
+    await fireEvent.input(screen.getByPlaceholderText('Add a comment...'), {
+      target: { value: 'Ship it.' },
+    });
+    await fireEvent.click(screen.getByRole('button', { name: 'Submit comment' }));
+
+    expect(submitted).toEqual(['Ship it.']);
+    expect(focusCalls).toBe(1);
+    expect(document.activeElement).toBe(trigger);
+
+    // External close after submit is idempotent — no second focus call.
+    await rerender({ open: false, position: { x: 120, y: 80 } });
+    expect(focusCalls).toBe(1);
+
+    trigger.remove();
+  });
 });

--- a/packages/components/src/components/selection-popover/selection-popover.test.ts
+++ b/packages/components/src/components/selection-popover/selection-popover.test.ts
@@ -146,13 +146,19 @@ describe('SelectionPopover', () => {
   });
 
   test('does nothing on external close when no focus was captured', async () => {
-    document.body.focus();
-    const initialActive = document.activeElement;
+    // Use a real focusable element so `document.activeElement` is deterministic.
+    // `document.body.focus()` is unreliable in HappyDOM (body is not focusable
+    // without tabindex), so focus may not move to body at all.
+    const trigger = document.createElement('button');
+    trigger.textContent = 'Trigger';
+    document.body.append(trigger);
+    trigger.focus();
+    expect(document.activeElement).toBe(trigger);
 
     const { rerender } = render(SelectionPopover, {
       props: {
         id: 'selection-comment',
-        // Never opened (and never expanded), so nothing is captured.
+        // Never opened — wasOpen latch is never set, so restoreFocus is never called.
         open: false,
         position: { x: 120, y: 80 },
       },
@@ -161,7 +167,8 @@ describe('SelectionPopover', () => {
     // Toggling the already-closed popover must not throw and must not steal focus.
     await rerender({ open: false, position: { x: 120, y: 80 } });
 
-    expect(document.activeElement).toBe(initialActive);
+    expect(document.activeElement).toBe(trigger);
+    trigger.remove();
   });
 
   test('internal cancel restores focus exactly once and the external effect is a no-op', async () => {


### PR DESCRIPTION
## Summary

Two HIGH-severity focus-restore bugs from the Svelte 5 component audit (task cd08a44f), both with regression tests. The task also included deduping the `useHydrated()` mount-gate pattern across 8 overlays; that part is intentionally NOT included — see _Why the dedup was abandoned_ below.

### Bug 1 — focus-trap: queueMicrotask steals focus back after deactivation

`activate()` defers `focusTrapTarget` via `queueMicrotask` so the trap's content is in the DOM first. If the trap is deactivated (or deactivated then reactivated) before that microtask drains, `deactivate()` already restored focus to the previously-focused element — and the stale queued `focusTrapTarget` would then fire and steal focus back into the dead trap.

**Fix:** `activationGeneration` counter, bumped on every `activate()`. The deferred closure snapshots the generation and bails if `!activated || generation !== activationGeneration`. Covers: simple deactivate; deactivate-then-reactivate within one microtask turn.

### Bug 2 — selection-popover: external `open=false` didn't restore focus

The component correctly restores focus via the internal close paths (`closePopover`, `handleCancel`, `handleSubmit`). But when a consumer set `open=false` directly (externally), the `$effect`'s `!open` branch nulled `restoreFocusElement` without calling `restoreFocus()`. Focus fell to `<body>` — a keyboard/AT trap.

**Fix:** `wasOpen` plain-`let` transition latch inside the `$effect`. On `false → true`: capture the pre-open focus owner via `rememberFocus()`. On `true → false`: call `restoreFocus()` (which null-guards and clears the ref, so an internal close that already restored leaves this a safe no-op — no double-restore).

### Why the dedup was abandoned

The task's other half was replacing the inlined `$state(false)` + `$effect(() => { mounted = true })` gate across 8 overlays with a shared `useMounted()` rune helper. This is architecturally infeasible here:

A `.svelte.ts` module that evaluates `$state()` synchronously during the init call crashes in overlay SSR-contract tests. Several overlays (toast-region, sheet, modal) have tests that recompile the component with `svelte/compiler generate:'server'` but do NOT recompile relative `.svelte.ts` imports — so the rune resolves to `undefined` and throws `ReferenceError: $state is not defined`. Existing `.svelte.ts` rune helpers survive SSR because their runes live inside attachment closures never invoked server-side; a mount-gate can't use that pattern.

Confirmed with codex-advisor: the two-line inline idiom stays (it's documented in `_internal/overlay.ts` and already enforced by the per-overlay SSR-contract tests). The dedup abstraction would be net-negative.

## Review committee

Pre-reviewed by: svelte-expert, testing-expert, typescript-expert, codex (gpt-5.4 / xhigh)
- 1 round of review
- Must-fix addressed: testing-expert flagged unreliable `document.body.focus()` in one test (not focusable in HappyDOM without tabindex); replaced with a real button trigger

## Test plan

- `bun run --filter=cinder test -- focus-trap` — regression: activate + immediately deactivate (no await between), drain via `await tick()`, assert focus stays on the prior element
- `bun run --filter=cinder test -- selection-popover` — 4 regression tests: external-close restore, no-capture no-op, internal-cancel exactly-once restore, internal-submit exactly-once restore
- Full suite: `bun run --filter=cinder test` — 4490 pass, 0 fail

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes keyboard focus and trap activation timing in overlay components; behavior is narrow and covered by new regression tests.
> 
> **Overview**
> Fixes two **focus-restore** regressions in overlay utilities, each with targeted regression tests.
> 
> **Focus trap:** Deferred initial focus (`queueMicrotask`) is now tied to an **`activationGeneration`** counter and the **`activated`** flag. If the trap deactivates (or reactivates) before that microtask runs, the stale callback no longer moves focus back into the trap after `deactivate()` has already restored the prior element.
> 
> **Selection popover:** A **`wasOpen`** latch in the `open` `$effect` runs close logic only on **true → false** (reset + `restoreFocus()`) and captures pre-open focus on **false → true** via `rememberFocus()`. External `open={false}` restores keyboard focus; internal cancel/submit paths stay idempotent because `restoreFocus()` clears the stored ref.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a6ed2d9fd0455ec8485cef36ab817ce5f0f6c6b5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->