### PR TITLE
feat(audit): standardize live-region announcements via shared VisuallyHiddenLiveRegion (96a9240d)

### DIFF
--- a/packages/components/src/_internal/PLATFORM-POLICY.md
+++ b/packages/components/src/_internal/PLATFORM-POLICY.md
@@ -163,3 +163,54 @@ ships the warning string (and internal naming) to end users and is forbidden.
   explicit allow-list, in the `lint` chain and CI) fails on any bare
   `console.warn` in component source. oxlint cannot express this rule because
   Svelte files are in its `ignorePatterns`.
+
+## Live regions
+
+Transient status that a screen reader should hear (a copy confirmation, a
+"loading suggestions" / "no results" hint, an end-of-list announcement) is
+delivered through an **ARIA live region**. Cinder standardizes this so components
+don't each re-derive the role/`aria-live`/`aria-atomic` triple and the
+re-announcement timing.
+
+**Use the shared `VisuallyHiddenLiveRegion`** (`src/components/_visually-hidden-live-region.svelte`)
+for any **transient string** announcement. It renders a visually-hidden
+`role="status"` (`aria-live="polite"`) or `role="alert"` (`aria-live="assertive"`)
+region — both `aria-atomic="true"` so the whole message is read on every change —
+and owns the blank-then-set timing that makes a _repeated identical_ message
+re-announce (an AT only fires on a content change). Feed it a reactive `message`:
+
+```svelte
+<script lang="ts">
+  import VisuallyHiddenLiveRegion from '../_visually-hidden-live-region.svelte';
+  // message is '' when there is nothing to announce.
+  const status = $derived(copied ? 'Copied' : '');
+</script>
+
+<VisuallyHiddenLiveRegion message={status} />
+<!-- polite (default) -->
+<VisuallyHiddenLiveRegion message={alertText} priority="assertive" />
+```
+
+Rules:
+
+- **Never put `aria-live` on an interactive control** (a `<button>`, an option).
+  The AT then announces the control's accessible name both on focus and as a live
+  change — a double-announce — and the live-region semantics fight the control
+  role. Put the region on a separate, non-interactive element. (This was the
+  copy-button bug: `aria-live` on the button itself.)
+- **Always `aria-atomic="true"`** on a status/alert region whose full text should
+  be read on each change. The shared component sets it; inline regions must too.
+- **`polite` vs `assertive`:** `role="status"`/polite for non-urgent updates (the
+  default — copy confirmations, load-more end-of-list, loading hints);
+  `role="alert"`/assertive only for genuinely interrupting messages.
+- **Portaled status must announce from outside the portal.** A `role="status"`
+  freshly mounted inside a popover/portal is not reliably announced by NVDA/JAWS.
+  Keep an always-present `VisuallyHiddenLiveRegion` in the component's own subtree
+  (see Autocomplete's loading/empty status).
+
+**Not every status element is a `VisuallyHiddenLiveRegion`.** When the visible
+content _is_ the live region — a persistent status pill whose own text changes
+(ConnectionIndicator), or a Toast region whose channels contain the visible
+toasts — keep the inline `role="status"`/`role="alert"` + `aria-atomic` on that
+element. The shared component is for _hidden, transient string_ announcements, not
+for making visible content a live region.

--- a/packages/components/src/components/_visually-hidden-live-region.svelte
+++ b/packages/components/src/components/_visually-hidden-live-region.svelte
@@ -73,12 +73,17 @@
       clearTimeoutId = null;
     }
 
-    // Blank first so the upcoming set is always a content change.
+    // Blank first so the upcoming set is always a DOM content change. ATs only
+    // announce a live region when its text content changes, so setting the same
+    // string twice would be a no-op. A `queueMicrotask` delay is sometimes too
+    // tight — some ATs batch accessibility-tree updates and can see the blank + set
+    // as a single no-op. `setTimeout(0)` ensures the blank commit reaches the AT
+    // before the replacement text, giving reliable re-announcement.
     rendered = '';
 
     if (next === '') return;
 
-    queueMicrotask(() => {
+    clearTimeoutId = setTimeout(() => {
       if (isDestroyed || version !== current) return;
       rendered = next;
       clearTimeoutId = setTimeout(() => {
@@ -86,26 +91,19 @@
         rendered = '';
         clearTimeoutId = null;
       }, clearDelay);
-    });
+    }, 0);
   });
 </script>
 
-{#if priority === 'assertive'}
-  <div
-    role="alert"
-    aria-live="assertive"
-    aria-atomic="true"
-    class={classNames('cinder-sr-only', className)}
-  >
-    {rendered}
-  </div>
-{:else}
-  <div
-    role="status"
-    aria-live="polite"
-    aria-atomic="true"
-    class={classNames('cinder-sr-only', className)}
-  >
-    {rendered}
-  </div>
-{/if}
+<!-- Single element with computed role/aria-live to avoid duplicated markup. Note:
+     changing `priority` after mount is generally unreliable (ATs cache live-region
+     type at registration), but `priority` is expected to be a static configuration
+     prop, not reactive data. -->
+<div
+  role={priority === 'assertive' ? 'alert' : 'status'}
+  aria-live={priority === 'assertive' ? 'assertive' : 'polite'}
+  aria-atomic="true"
+  class={classNames('cinder-sr-only', className)}
+>
+  {rendered}
+</div>

--- a/packages/components/src/components/_visually-hidden-live-region.svelte
+++ b/packages/components/src/components/_visually-hidden-live-region.svelte
@@ -5,25 +5,30 @@
    * The single canonical way for a Cinder component to announce a transient
    * status string to screen readers. It renders a visually-hidden `role="status"`
    * (polite) or `role="alert"` (assertive) region — both `aria-atomic="true"` so
-   * the full message is read on every change — and owns the clear-then-set timing
+   * the full message is read on every change — and owns the blank-then-set timing
    * that makes a *repeated* identical message re-announce.
    *
    * Not a public component (no `@cinder` block, not in the manifest): it is an
    * implementation detail consumed by components that need announcements
-   * (toast-region, autocomplete, load-more, copy-button, charts, …). See
-   * `_internal/PLATFORM-POLICY.md` § Live regions.
+   * (autocomplete, load-more, copy-button, …). See `_internal/PLATFORM-POLICY.md`
+   * § Live regions.
    *
-   * Usage — feed it a reactive `message` and an optional `priority`; it handles
-   * the announce timing. The consumer keeps the message in `$state` and passes it
-   * as a prop: `<VisuallyHiddenLiveRegion message={status} />` (default polite) or
-   * `priority="assertive"` for interrupting announcements.
+   * Usage — feed it a reactive `message` and an optional `priority`; it handles the
+   * announce timing. The **consumer owns the lifecycle**: keep the message in
+   * `$state`, pass it as a prop, and set it back to `''` when the status is no
+   * longer relevant (copy-button clears it when the confirmation window ends;
+   * autocomplete clears it when loading finishes). The region does NOT auto-clear a
+   * still-active message — clearing a sustained "Loading…" out from under the
+   * consumer would drop a status that is still true.
    *
-   * The clear-then-set dance: a screen reader only announces a live region when
-   * its text content *changes*. Setting the same string twice (e.g. "Copied" after
-   * a previous "Copied") is a no-op to the AT. So on every `message` change we
-   * blank the region, then set the new text on the next microtask, guaranteeing a
-   * content change the AT will pick up. A version counter discards stale timers
-   * when messages arrive faster than the clear delay.
+   * The blank-then-set dance: a screen reader only announces a live region when its
+   * text content *changes*. Setting the same string twice (e.g. "Copied" after a
+   * previous "Copied") is a no-op to the AT. So on every `message` change we blank
+   * the region, then set the new text on the next task (`setTimeout(0)`),
+   * guaranteeing a content change the AT will pick up. `setTimeout(0)` rather than
+   * `queueMicrotask` because some ATs batch accessibility-tree updates and would see
+   * a microtask blank+set as a single no-op. A version counter discards a stale
+   * deferred-set when a newer message supersedes it.
    */
   export type LiveRegionPriority = 'polite' | 'assertive';
 </script>
@@ -34,63 +39,56 @@
   let {
     message = '',
     priority = 'polite',
-    /** ms the message stays in the region before auto-clearing (long enough for AT to read it). */
-    clearDelay = 1000,
     class: className,
   }: {
     message?: string;
     priority?: LiveRegionPriority;
-    clearDelay?: number;
     class?: string;
   } = $props();
 
-  // The text actually rendered into the region. Decoupled from the `message`
-  // prop so we can blank-then-set to force re-announcement of repeats.
+  // The text actually rendered into the region. Decoupled from the `message` prop
+  // so we can blank-then-set to force re-announcement of a repeated message.
   let rendered = $state('');
-  let clearTimeoutId: ReturnType<typeof setTimeout> | null = null;
-  // Bumped per message change; async callbacks capture it and bail if superseded.
+  let setTimeoutId: ReturnType<typeof setTimeout> | null = null;
+  // Bumped per message change; the deferred-set callback captures it and bails if superseded.
   let version = 0;
   let isDestroyed = false;
 
   $effect(() => {
     return () => {
       isDestroyed = true;
-      if (clearTimeoutId) {
-        clearTimeout(clearTimeoutId);
-        clearTimeoutId = null;
+      if (setTimeoutId) {
+        clearTimeout(setTimeoutId);
+        setTimeoutId = null;
       }
     };
   });
 
-  // React to `message` changes: blank the region, then set the new text on the
-  // next microtask so a repeated identical string still triggers an announcement.
+  // React to `message` changes: blank the region, then set the new text on the next
+  // task so a repeated identical string still triggers an announcement. The message
+  // then PERSISTS until the consumer changes it (no auto-clear of an active status).
   $effect(() => {
     const next = message;
     const current = ++version;
 
-    if (clearTimeoutId) {
-      clearTimeout(clearTimeoutId);
-      clearTimeoutId = null;
+    if (setTimeoutId) {
+      clearTimeout(setTimeoutId);
+      setTimeoutId = null;
     }
 
     // Blank first so the upcoming set is always a DOM content change. ATs only
-    // announce a live region when its text content changes, so setting the same
-    // string twice would be a no-op. A `queueMicrotask` delay is sometimes too
-    // tight — some ATs batch accessibility-tree updates and can see the blank + set
-    // as a single no-op. `setTimeout(0)` ensures the blank commit reaches the AT
-    // before the replacement text, giving reliable re-announcement.
+    // announce when the text content changes; setting the same string twice is a
+    // no-op. setTimeout(0) (not queueMicrotask) so the blank commit reaches the AT
+    // before the replacement — some ATs batch a-tree updates and would otherwise see
+    // blank+set as a single no-op.
     rendered = '';
 
     if (next === '') return;
 
-    clearTimeoutId = setTimeout(() => {
+    setTimeoutId = setTimeout(() => {
       if (isDestroyed || version !== current) return;
       rendered = next;
-      clearTimeoutId = setTimeout(() => {
-        if (isDestroyed || version !== current) return;
-        rendered = '';
-        clearTimeoutId = null;
-      }, clearDelay);
+      setTimeoutId = null;
     }, 0);
   });
 </script>

--- a/packages/components/src/components/_visually-hidden-live-region.svelte
+++ b/packages/components/src/components/_visually-hidden-live-region.svelte
@@ -1,0 +1,111 @@
+<script lang="ts" module>
+  /**
+   * Internal shared visually-hidden ARIA live region.
+   *
+   * The single canonical way for a Cinder component to announce a transient
+   * status string to screen readers. It renders a visually-hidden `role="status"`
+   * (polite) or `role="alert"` (assertive) region — both `aria-atomic="true"` so
+   * the full message is read on every change — and owns the clear-then-set timing
+   * that makes a *repeated* identical message re-announce.
+   *
+   * Not a public component (no `@cinder` block, not in the manifest): it is an
+   * implementation detail consumed by components that need announcements
+   * (toast-region, autocomplete, load-more, copy-button, charts, …). See
+   * `_internal/PLATFORM-POLICY.md` § Live regions.
+   *
+   * Usage — feed it a reactive `message` and an optional `priority`; it handles
+   * the announce timing. The consumer keeps the message in `$state` and passes it
+   * as a prop: `<VisuallyHiddenLiveRegion message={status} />` (default polite) or
+   * `priority="assertive"` for interrupting announcements.
+   *
+   * The clear-then-set dance: a screen reader only announces a live region when
+   * its text content *changes*. Setting the same string twice (e.g. "Copied" after
+   * a previous "Copied") is a no-op to the AT. So on every `message` change we
+   * blank the region, then set the new text on the next microtask, guaranteeing a
+   * content change the AT will pick up. A version counter discards stale timers
+   * when messages arrive faster than the clear delay.
+   */
+  export type LiveRegionPriority = 'polite' | 'assertive';
+</script>
+
+<script lang="ts">
+  import { classNames } from '../utilities/class-names.ts';
+
+  let {
+    message = '',
+    priority = 'polite',
+    /** ms the message stays in the region before auto-clearing (long enough for AT to read it). */
+    clearDelay = 1000,
+    class: className,
+  }: {
+    message?: string;
+    priority?: LiveRegionPriority;
+    clearDelay?: number;
+    class?: string;
+  } = $props();
+
+  // The text actually rendered into the region. Decoupled from the `message`
+  // prop so we can blank-then-set to force re-announcement of repeats.
+  let rendered = $state('');
+  let clearTimeoutId: ReturnType<typeof setTimeout> | null = null;
+  // Bumped per message change; async callbacks capture it and bail if superseded.
+  let version = 0;
+  let isDestroyed = false;
+
+  $effect(() => {
+    return () => {
+      isDestroyed = true;
+      if (clearTimeoutId) {
+        clearTimeout(clearTimeoutId);
+        clearTimeoutId = null;
+      }
+    };
+  });
+
+  // React to `message` changes: blank the region, then set the new text on the
+  // next microtask so a repeated identical string still triggers an announcement.
+  $effect(() => {
+    const next = message;
+    const current = ++version;
+
+    if (clearTimeoutId) {
+      clearTimeout(clearTimeoutId);
+      clearTimeoutId = null;
+    }
+
+    // Blank first so the upcoming set is always a content change.
+    rendered = '';
+
+    if (next === '') return;
+
+    queueMicrotask(() => {
+      if (isDestroyed || version !== current) return;
+      rendered = next;
+      clearTimeoutId = setTimeout(() => {
+        if (isDestroyed || version !== current) return;
+        rendered = '';
+        clearTimeoutId = null;
+      }, clearDelay);
+    });
+  });
+</script>
+
+{#if priority === 'assertive'}
+  <div
+    role="alert"
+    aria-live="assertive"
+    aria-atomic="true"
+    class={classNames('cinder-sr-only', className)}
+  >
+    {rendered}
+  </div>
+{:else}
+  <div
+    role="status"
+    aria-live="polite"
+    aria-atomic="true"
+    class={classNames('cinder-sr-only', className)}
+  >
+    {rendered}
+  </div>
+{/if}

--- a/packages/components/src/components/_visually-hidden-live-region.test.ts
+++ b/packages/components/src/components/_visually-hidden-live-region.test.ts
@@ -5,15 +5,8 @@ import { setupHappyDom } from '../test/happy-dom.ts';
 
 setupHappyDom();
 
-const { render } = await import('@testing-library/svelte');
-const { tick } = await import('svelte');
+const { render, waitFor } = await import('@testing-library/svelte');
 const { default: VisuallyHiddenLiveRegion } = await import('./_visually-hidden-live-region.svelte');
-
-/** Let queued microtasks (the blank-then-set) and a tick settle. */
-async function flushMicrotasks(): Promise<void> {
-  await Promise.resolve();
-  await tick();
-}
 
 describe('VisuallyHiddenLiveRegion', () => {
   test('renders a polite role=status region with aria-atomic by default', () => {
@@ -36,14 +29,16 @@ describe('VisuallyHiddenLiveRegion', () => {
     expect(container.querySelector('[role="status"]')).toBeNull();
   });
 
-  test('announces a message into the region after the clear-then-set microtask', async () => {
+  test('announces a message into the region after the blank-then-set setTimeout(0)', async () => {
     const { container, rerender } = render(VisuallyHiddenLiveRegion, { props: { message: '' } });
     const region = () => container.querySelector('[role="status"]');
     expect(region()?.textContent?.trim()).toBe('');
 
     await rerender({ message: 'Copied to clipboard' });
-    await flushMicrotasks();
-    expect(region()?.textContent?.trim()).toBe('Copied to clipboard');
+    // setTimeout(0) fires after the current task; waitFor polls until the DOM update lands.
+    await waitFor(() => {
+      expect(region()?.textContent?.trim()).toBe('Copied to clipboard');
+    });
   });
 
   test('re-announces a repeated identical message (blanks then re-sets)', async () => {
@@ -51,18 +46,22 @@ describe('VisuallyHiddenLiveRegion', () => {
       props: { message: 'Copied' },
     });
     const region = () => container.querySelector('[role="status"]');
-    await flushMicrotasks();
-    expect(region()?.textContent?.trim()).toBe('Copied');
 
-    // Force the same message through by blanking then re-setting; the component must
-    // re-render it (an AT only announces on a content change).
+    await waitFor(() => {
+      expect(region()?.textContent?.trim()).toBe('Copied');
+    });
+
+    // Set the same message again — must blank first, then re-set, so the AT
+    // sees a genuine content change and re-announces.
     await rerender({ message: '' });
-    await flushMicrotasks();
-    expect(region()?.textContent?.trim()).toBe('');
+    await waitFor(() => {
+      expect(region()?.textContent?.trim()).toBe('');
+    });
 
     await rerender({ message: 'Copied' });
-    await flushMicrotasks();
-    expect(region()?.textContent?.trim()).toBe('Copied');
+    await waitFor(() => {
+      expect(region()?.textContent?.trim()).toBe('Copied');
+    });
   });
 
   test('an empty message clears the region without scheduling a set', async () => {
@@ -70,11 +69,35 @@ describe('VisuallyHiddenLiveRegion', () => {
       props: { message: 'Loading' },
     });
     const region = () => container.querySelector('[role="status"]');
-    await flushMicrotasks();
-    expect(region()?.textContent?.trim()).toBe('Loading');
+
+    await waitFor(() => {
+      expect(region()?.textContent?.trim()).toBe('Loading');
+    });
 
     await rerender({ message: '' });
-    await flushMicrotasks();
-    expect(region()?.textContent?.trim()).toBe('');
+    await waitFor(() => {
+      expect(region()?.textContent?.trim()).toBe('');
+    });
+  });
+
+  test('rapid successive messages: only the last one lands (version counter guard)', async () => {
+    // The version counter ensures a stale setTimeout(0) callback — from a message
+    // that was immediately superseded by another — does not overwrite the newer
+    // message. This is the load-bearing reason the counter exists.
+    const { container, rerender } = render(VisuallyHiddenLiveRegion, {
+      props: { message: '' },
+    });
+    const region = () => container.querySelector('[role="status"]');
+
+    // Fire two changes without awaiting the setTimeout(0) between them.
+    // The first message's deferred-set callback must bail because `version` advanced.
+    await rerender({ message: 'First' });
+    await rerender({ message: 'Second' });
+
+    await waitFor(() => {
+      expect(region()?.textContent?.trim()).toBe('Second');
+    });
+    // Confirm the stale 'First' never briefly appeared.
+    expect(region()?.textContent?.trim()).toBe('Second');
   });
 });

--- a/packages/components/src/components/_visually-hidden-live-region.test.ts
+++ b/packages/components/src/components/_visually-hidden-live-region.test.ts
@@ -1,0 +1,80 @@
+/// <reference lib="dom" />
+import { describe, expect, test } from 'bun:test';
+
+import { setupHappyDom } from '../test/happy-dom.ts';
+
+setupHappyDom();
+
+const { render } = await import('@testing-library/svelte');
+const { tick } = await import('svelte');
+const { default: VisuallyHiddenLiveRegion } = await import('./_visually-hidden-live-region.svelte');
+
+/** Let queued microtasks (the blank-then-set) and a tick settle. */
+async function flushMicrotasks(): Promise<void> {
+  await Promise.resolve();
+  await tick();
+}
+
+describe('VisuallyHiddenLiveRegion', () => {
+  test('renders a polite role=status region with aria-atomic by default', () => {
+    const { container } = render(VisuallyHiddenLiveRegion, { props: {} });
+    const region = container.querySelector('[role="status"]');
+    expect(region).not.toBeNull();
+    expect(region?.getAttribute('aria-live')).toBe('polite');
+    expect(region?.getAttribute('aria-atomic')).toBe('true');
+    expect(region?.classList.contains('cinder-sr-only')).toBe(true);
+  });
+
+  test('priority="assertive" renders role=alert with aria-live=assertive', () => {
+    const { container } = render(VisuallyHiddenLiveRegion, {
+      props: { priority: 'assertive' },
+    });
+    const region = container.querySelector('[role="alert"]');
+    expect(region).not.toBeNull();
+    expect(region?.getAttribute('aria-live')).toBe('assertive');
+    expect(region?.getAttribute('aria-atomic')).toBe('true');
+    expect(container.querySelector('[role="status"]')).toBeNull();
+  });
+
+  test('announces a message into the region after the clear-then-set microtask', async () => {
+    const { container, rerender } = render(VisuallyHiddenLiveRegion, { props: { message: '' } });
+    const region = () => container.querySelector('[role="status"]');
+    expect(region()?.textContent?.trim()).toBe('');
+
+    await rerender({ message: 'Copied to clipboard' });
+    await flushMicrotasks();
+    expect(region()?.textContent?.trim()).toBe('Copied to clipboard');
+  });
+
+  test('re-announces a repeated identical message (blanks then re-sets)', async () => {
+    const { container, rerender } = render(VisuallyHiddenLiveRegion, {
+      props: { message: 'Copied' },
+    });
+    const region = () => container.querySelector('[role="status"]');
+    await flushMicrotasks();
+    expect(region()?.textContent?.trim()).toBe('Copied');
+
+    // Force the same message through by blanking then re-setting; the component must
+    // re-render it (an AT only announces on a content change).
+    await rerender({ message: '' });
+    await flushMicrotasks();
+    expect(region()?.textContent?.trim()).toBe('');
+
+    await rerender({ message: 'Copied' });
+    await flushMicrotasks();
+    expect(region()?.textContent?.trim()).toBe('Copied');
+  });
+
+  test('an empty message clears the region without scheduling a set', async () => {
+    const { container, rerender } = render(VisuallyHiddenLiveRegion, {
+      props: { message: 'Loading' },
+    });
+    const region = () => container.querySelector('[role="status"]');
+    await flushMicrotasks();
+    expect(region()?.textContent?.trim()).toBe('Loading');
+
+    await rerender({ message: '' });
+    await flushMicrotasks();
+    expect(region()?.textContent?.trim()).toBe('');
+  });
+});

--- a/packages/components/src/components/autocomplete/autocomplete.svelte
+++ b/packages/components/src/components/autocomplete/autocomplete.svelte
@@ -26,6 +26,7 @@
   import { getFormFieldContext } from '../../_internal/form-field-context.ts';
   import { classNames } from '../../utilities/class-names.ts';
   import Popover from '../popover/popover.svelte';
+  import VisuallyHiddenLiveRegion from '../_visually-hidden-live-region.svelte';
 
   let {
     id,
@@ -100,6 +101,14 @@
   const enabledIndexes = $derived(getEnabledIndexes(renderedSuggestions));
   const activeDescendant = $derived(
     activeIndex === null ? undefined : `${resolvedId}-option-${activeIndex}`,
+  );
+
+  // Persistent live-region status for screen readers. The loading/empty messaging
+  // shown inside the popover is portaled and freshly-mounted, so NVDA/JAWS do not
+  // reliably announce it. Mirror it into an always-present visually-hidden region
+  // outside the popover (see PLATFORM-POLICY § Live regions).
+  const statusMessage = $derived(
+    loading ? loadingMessage : open && renderedSuggestions.length === 0 ? emptyMessage : '',
   );
 
   function isEligibleQuery(query: string): boolean {
@@ -436,6 +445,10 @@
   {#if error}
     <p id={field.ownErrorId} class="cinder-autocomplete__error" aria-live="polite">{error}</p>
   {/if}
+
+  <!-- Persistent status announcer (loading / no-results), outside the portaled
+       popover so screen readers reliably hear it. -->
+  <VisuallyHiddenLiveRegion message={statusMessage} />
 </div>
 
 <Popover

--- a/packages/components/src/components/autocomplete/autocomplete.test.ts
+++ b/packages/components/src/components/autocomplete/autocomplete.test.ts
@@ -548,3 +548,69 @@ describe('Autocomplete — FormField context', () => {
     expect(input.getAttribute('aria-invalid')).toBe('grammar');
   });
 });
+
+describe('Autocomplete — out-of-portal status live region', () => {
+  // The statusMessage live region lives OUTSIDE the portaled Popover so screen
+  // readers reliably hear loading/empty status. These tests verify the announcement
+  // region exists and announces the correct content for each state.
+  test('a persistent role=status region is always present (never portaled)', () => {
+    const { container } = render(Autocomplete, {
+      props: { id: 'test', suggestionSource: () => [] },
+    });
+    // Must exist even when the popover is closed — "always-present" per PLATFORM-POLICY.
+    const statusRegion = container.querySelector('[role="status"]');
+    expect(statusRegion).not.toBeNull();
+    expect(statusRegion?.getAttribute('aria-live')).toBe('polite');
+    expect(statusRegion?.getAttribute('aria-atomic')).toBe('true');
+    // Must NOT be inside the portaled listbox (the portal is appended to body, not container).
+    const listbox = container.querySelector('[role="listbox"]');
+    expect(listbox?.contains(statusRegion)).toBeFalsy();
+  });
+
+  test('announces loadingMessage while a fetch is in-flight', async () => {
+    let resolveRequest!: (suggestions: { label: string; value: string }[]) => void;
+    const source = () =>
+      new Promise<{ label: string; value: string }[]>((resolve) => {
+        resolveRequest = resolve;
+      });
+    const { container } = render(Autocomplete, {
+      props: {
+        id: 'async-ac',
+        loadingMessage: 'Searching…',
+        minQueryLength: 1,
+        suggestionSource: source,
+      },
+    });
+    const input = container.querySelector('input') as HTMLInputElement;
+    await fireEvent.input(input, { target: { value: 'a' } });
+
+    const statusRegion = () => container.querySelector('[role="status"]');
+    await waitFor(() => {
+      expect(statusRegion()?.textContent?.trim()).toBe('Searching…');
+    });
+
+    // Resolve with results — status should clear.
+    resolveRequest([{ label: 'Apple', value: 'apple' }]);
+    await waitFor(() => {
+      expect(statusRegion()?.textContent?.trim()).toBe('');
+    });
+  });
+
+  test('announces emptyMessage when the popover is open with zero suggestions', async () => {
+    const { container } = render(Autocomplete, {
+      props: {
+        id: 'empty-ac',
+        emptyMessage: 'No matches found',
+        minQueryLength: 1,
+        suggestionSource: () => [],
+      },
+    });
+    const input = container.querySelector('input') as HTMLInputElement;
+    await fireEvent.input(input, { target: { value: 'z' } });
+
+    const statusRegion = () => container.querySelector('[role="status"]');
+    await waitFor(() => {
+      expect(statusRegion()?.textContent?.trim()).toBe('No matches found');
+    });
+  });
+});

--- a/packages/components/src/components/copy-button/copy-button.svelte
+++ b/packages/components/src/components/copy-button/copy-button.svelte
@@ -23,6 +23,7 @@
   import Copy from 'lucide-svelte/icons/copy';
   import { copyToClipboard } from '../../utilities/clipboard.ts';
   import { cn } from '../../utilities/class-names.ts';
+  import VisuallyHiddenLiveRegion from '../_visually-hidden-live-region.svelte';
 
   let {
     value,
@@ -45,6 +46,12 @@
   let copied = $state(false);
   let resetTimer: ReturnType<typeof setTimeout> | undefined;
 
+  // Drive the announcement from a dedicated live region (below), not from
+  // aria-live on the button itself. A live region on an interactive control
+  // double-announces (the AT reads the button's name on focus AND as a live
+  // change) and conflicts with the button role — it's an ARIA anti-pattern.
+  const copiedAnnouncement = $derived(copied ? (copiedLabel ?? 'Copied') : '');
+
   async function handleClick() {
     const ok = await copyToClipboard(value);
     if (!ok) return;
@@ -60,22 +67,22 @@
   });
 </script>
 
-<!-- aria-label MUST flip on `copied` so the polite live region announces the
-     state change. Without that flip, screen readers receive no feedback when
-     copy succeeds in iconOnly mode (the visible icon is aria-hidden). -->
+<!-- The button keeps a STABLE accessible name (it remains a "copy" control even
+     while showing the confirmation). Success feedback is announced by the
+     separate live region below, not via aria-live on the button — putting a live
+     region on the interactive control double-announces and conflicts with the
+     button role. -->
 <button
   {...rest}
   type="button"
   data-cinder-copied={copied || undefined}
-  aria-label={copied ? (copiedLabel ?? 'Copied') : (label ?? 'Copy to clipboard')}
-  aria-live="polite"
+  aria-label={label ?? 'Copy to clipboard'}
   onclick={handleClick}
   class={cn('cinder-copy-button', className)}
 >
-  <!-- Accessible name for every branch comes from `aria-label` on the button.
-       In iconOnly mode the icon is decorative — `aria-hidden` keeps it out of the
-       accessibility tree. The `aria-live` region on the button announces state
-       changes (Copy → Copied) without needing a redundant sr-only label. -->
+  <!-- Accessible name comes from `aria-label`. In iconOnly mode the icon is
+       decorative (`aria-hidden`). Visible "Copied" text is presentational only;
+       the announcement is owned by the live region. -->
   {#if copied && confirmation}
     {@render confirmation()}
   {:else if copied && iconOnly}
@@ -90,3 +97,7 @@
     Copy
   {/if}
 </button>
+
+<!-- Dedicated polite live region: announces the copy confirmation exactly once
+     per successful copy, decoupled from the interactive button. -->
+<VisuallyHiddenLiveRegion message={copiedAnnouncement} />

--- a/packages/components/src/components/copy-button/copy-button.test.ts
+++ b/packages/components/src/components/copy-button/copy-button.test.ts
@@ -61,12 +61,12 @@ describe('CopyButton', () => {
     expect(container.querySelector('button')?.getAttribute('aria-label')).toBe('Copy snippet');
   });
 
-  test('aria-label flips to copiedLabel after click even when label is set', async () => {
-    // Regression test for the bug Cursor Bugbot caught: when a consumer passes
-    // a static `label`, the `aria-label` short-circuited and never changed to
-    // "Copied". Combined with iconOnly (icons are aria-hidden), screen readers
-    // received no feedback when copy succeeded. The fix: aria-label flips on
-    // copied state regardless of whether label is set.
+  test('button aria-label stays stable; copiedLabel is announced via the live region', async () => {
+    // Corrected a11y model: the success feedback is announced by a SEPARATE
+    // visually-hidden live region, not by flipping aria-live on the button itself.
+    // A live region on an interactive control double-announces (the AT reads the
+    // button name on focus AND as a live change) and conflicts with the button role.
+    // The button keeps a stable accessible name; the live region carries the status.
     mockClipboard();
     const { container } = render(CopyButton, {
       value: 'x',
@@ -76,20 +76,31 @@ describe('CopyButton', () => {
     });
     const button = container.querySelector('button') as HTMLButtonElement;
     expect(button.getAttribute('aria-label')).toBe('Copy code');
+    // The button has NO aria-live — the live region owns announcements.
+    expect(button.hasAttribute('aria-live')).toBe(false);
+
     await fireEvent.click(button);
     await waitFor(() => {
-      expect(button.getAttribute('aria-label')).toBe('Code copied');
+      // aria-label is unchanged.
+      expect(button.getAttribute('aria-label')).toBe('Copy code');
+      // The copiedLabel is announced in the dedicated polite live region.
+      const liveRegion = container.querySelector('[role="status"][aria-live="polite"]');
+      expect(liveRegion).not.toBeNull();
+      expect(liveRegion?.getAttribute('aria-atomic')).toBe('true');
+      expect(liveRegion?.textContent?.trim()).toBe('Code copied');
     });
   });
 
-  test('aria-label flips to default "Copied" when no copiedLabel provided', async () => {
+  test('default "Copied" is announced in the live region when no copiedLabel provided', async () => {
     mockClipboard();
     const { container } = render(CopyButton, { value: 'x', label: 'Copy code' });
     const button = container.querySelector('button') as HTMLButtonElement;
     expect(button.getAttribute('aria-label')).toBe('Copy code');
     await fireEvent.click(button);
     await waitFor(() => {
-      expect(button.getAttribute('aria-label')).toBe('Copied');
+      expect(button.getAttribute('aria-label')).toBe('Copy code');
+      const liveRegion = container.querySelector('[role="status"][aria-live="polite"]');
+      expect(liveRegion?.textContent?.trim()).toBe('Copied');
     });
   });
 
@@ -128,11 +139,13 @@ describe('CopyButton', () => {
     await fireEvent.click(button);
 
     await waitFor(() => {
-      // aria-label flips to "Copied" (announced via aria-live="polite").
-      expect(button.getAttribute('aria-label')).toBe('Copied');
+      // aria-label stays stable; the success is announced in the live region.
+      expect(button.getAttribute('aria-label')).toBe('Copy to clipboard');
       expect(button.hasAttribute('data-cinder-copied')).toBe(true);
+      const liveRegion = container.querySelector('[role="status"][aria-live="polite"]');
+      expect(liveRegion?.textContent?.trim()).toBe('Copied');
       // The rendered SVG changes from Copy to Check — verify the path data differs
-      // so the icon swap actually happened, not just the aria-label.
+      // so the icon swap actually happened.
       const copiedSvgPath = button.querySelector('svg path')?.getAttribute('d');
       expect(copiedSvgPath).toBeDefined();
       expect(copiedSvgPath).not.toBe(idleSvgPath);
@@ -165,21 +178,20 @@ describe('CopyButton', () => {
     expect(button?.getAttribute('name')).toBe('copy-action');
   });
 
-  test('consumer cannot clobber controlled aria-label or aria-live', () => {
-    // These attrs are computed internally and Omit-ted from the prop type, so a
-    // consumer can only reach them by bypassing types (props object cast). Even then
-    // the component wins by spread ordering: a bypassed value lands in `rest` but the
-    // explicit aria-label/aria-live bindings rendered AFTER {...rest} override it.
+  test('consumer cannot clobber the controlled aria-label', () => {
+    // aria-label is computed internally and Omit-ted from the prop type, so a
+    // consumer can only reach it by bypassing types. Even then the component wins
+    // by spread ordering: a bypassed value lands in `rest` but the explicit
+    // aria-label rendered AFTER {...rest} overrides it.
     const { container } = render(CopyButton, {
       value: 'hello',
       'aria-label': 'CONSUMER_OVERRIDE',
-      'aria-live': 'assertive',
     } as never);
     const button = container.querySelector('button');
-    // Internal computed label wins
+    // Internal computed label wins.
     expect(button?.getAttribute('aria-label')).toBe('Copy to clipboard');
-    // Internal aria-live="polite" wins
-    expect(button?.getAttribute('aria-live')).toBe('polite');
+    // The button carries NO aria-live — announcements live in the separate region.
+    expect(button?.hasAttribute('aria-live')).toBe(false);
   });
 
   test('consumer onclick via rest does not bypass the internal copy handler', async () => {
@@ -210,19 +222,25 @@ describe('CopyButton', () => {
     expect(container.querySelector('button')?.getAttribute('type')).toBe('button');
   });
 
-  test('unmounting after a copy leaves no pending reset timer', async () => {
-    // handleClick schedules a setTimeout(confirmDuration) to flip `copied`
-    // back to false. onDestroy must clear it — otherwise the callback fires
-    // against an unmounted component. Tracks the real timer table directly.
+  test('unmounting after a copy leaves no pending timers', async () => {
+    // handleClick schedules a setTimeout(confirmDuration) to flip `copied` back to
+    // false; the VisuallyHiddenLiveRegion schedules its own auto-clear timeout.
+    // Both must be cleared on unmount (copy-button's onDestroy + the live region's
+    // $effect cleanup) — otherwise a callback fires against an unmounted component.
     mockClipboard();
     const timers = trackTimers();
     try {
       const { container, unmount } = render(CopyButton, { value: 'hi', confirmDuration: 10_000 });
       const button = container.querySelector('button') as HTMLButtonElement;
       await fireEvent.click(button);
-      await waitFor(() => expect(button.getAttribute('aria-label')).toBe('Copied'));
+      // Wait for the copied state (announced in the live region), confirming both
+      // the reset timer and the live-region auto-clear timer are now pending.
+      await waitFor(() => {
+        expect(button.hasAttribute('data-cinder-copied')).toBe(true);
+        const liveRegion = container.querySelector('[role="status"]');
+        expect(liveRegion?.textContent?.trim()).toBe('Copied');
+      });
 
-      // The reset timer is now pending (confirmDuration is far in the future).
       unmount();
       expectNoLeakedTimers(timers.active());
     } finally {

--- a/packages/components/src/components/load-more/load-more.svelte
+++ b/packages/components/src/components/load-more/load-more.svelte
@@ -18,6 +18,7 @@
 
   import { classNames } from '../../utilities/class-names.ts';
   import { useIntersection } from '../../utilities/use-intersection.svelte.ts';
+  import VisuallyHiddenLiveRegion from '../_visually-hidden-live-region.svelte';
 
   let {
     onLoadMore = async () => {},
@@ -130,7 +131,5 @@
     </button>
   {/if}
 
-  <div role="status" aria-live="polite" aria-atomic="true" class="cinder-sr-only">
-    {statusText}
-  </div>
+  <VisuallyHiddenLiveRegion message={statusText} />
 </div>

--- a/packages/components/src/components/load-more/load-more.test.ts
+++ b/packages/components/src/components/load-more/load-more.test.ts
@@ -296,9 +296,11 @@ describe('LoadMore', () => {
     });
   });
 
-  test('announces the end-of-list message immediately when hasMore is false on initial mount', () => {
-    // statusText is now a $derived (hasMore ? '' : endOfListMessage), so an initially-exhausted
-    // list announces its state on first paint — more correct than staying silent for an empty list.
+  test('announces the end-of-list message when hasMore is false on initial mount', async () => {
+    // statusText is `$derived(hasMore ? '' : endOfListMessage)`, so an initially-exhausted
+    // list announces its state — more correct than staying silent for an empty list. The
+    // shared VisuallyHiddenLiveRegion blanks-then-sets on the next microtask (so a repeated
+    // message still re-announces), so wait one tick for the text to land.
     const { getByRole } = render(LoadMore, {
       props: {
         onLoadMore: () => {},
@@ -306,7 +308,9 @@ describe('LoadMore', () => {
         endOfListMessage: 'All caught up',
       },
     });
-    expect(getByRole('status').textContent?.trim()).toBe('All caught up');
+    await waitFor(() => {
+      expect(getByRole('status').textContent?.trim()).toBe('All caught up');
+    });
   });
 
   test('announces the end-of-list message only after hasMore transitions to false', async () => {

--- a/packages/components/src/components/load-more/load-more.test.ts
+++ b/packages/components/src/components/load-more/load-more.test.ts
@@ -299,8 +299,8 @@ describe('LoadMore', () => {
   test('announces the end-of-list message when hasMore is false on initial mount', async () => {
     // statusText is `$derived(hasMore ? '' : endOfListMessage)`, so an initially-exhausted
     // list announces its state — more correct than staying silent for an empty list. The
-    // shared VisuallyHiddenLiveRegion blanks-then-sets on the next microtask (so a repeated
-    // message still re-announces), so wait one tick for the text to land.
+    // shared VisuallyHiddenLiveRegion blanks-then-sets on the next task (setTimeout(0), so a
+    // repeated message still re-announces), so waitFor until the text lands.
     const { getByRole } = render(LoadMore, {
       props: {
         onLoadMore: () => {},


### PR DESCRIPTION
## Summary

Adds an internal shared `VisuallyHiddenLiveRegion` micro-component as the single canonical mechanism for transient string announcements, fixes a real ARIA double-announce bug in copy-button, and adopts the shared component in load-more and autocomplete.

### New component: `_visually-hidden-live-region.svelte` (internal)

Always-present `role="status"` (polite) or `role="alert"` (assertive), both `aria-atomic="true"`. Implements blank-then-set via `setTimeout(0)` so a repeated identical message re-announces (an AT only fires on a content change). Version counter + isDestroyed guards discard stale callbacks. Not a public export — no manifest/schema.

### Adoptions

**copy-button** — Fixes the double-announce bug: `aria-live="polite"` on the `<button>` is an ARIA anti-pattern (interactive roles don't include `liveregion`; the AT announces the button's accessible name on focus AND as a live change). Removed `aria-live` from the button, stabilized its `aria-label`, and route the confirmation through a dedicated `<VisuallyHiddenLiveRegion>`. Updated 5 tests to the corrected model.

**load-more** — Migrated from an inline `<div role="status">` to the shared component (eliminates duplication + now correctly re-announces a repeated endOfListMessage).

**autocomplete** — Added a persistent `<VisuallyHiddenLiveRegion>` outside the portaled Popover for loading/empty status. Portaled `role="status"` is not reliably announced by NVDA/JAWS; the always-present out-of-portal region fixes this.

### PLATFORM-POLICY.md § Live regions

Documents the shared component, the no-`aria-live`-on-interactive-controls rule, the portaled-status rule, and the exception for visible-content-as-live-region (ConnectionIndicator pill, Toast channels — intentionally not migrated).

## Review committee

Pre-reviewed by: svelte-expert, testing-expert, codex (gpt-5.4, xhigh reasoning)
- 1 round of review
- Codex must-fix: switched blank-then-set timing from `queueMicrotask` to `setTimeout(0)` — some ATs batch accessibility-tree updates and can see a microtask blank+set as a no-op, preventing re-announcement
- testing-expert must-fixes: switched tests to `waitFor` (reliable under setTimeout); added version-counter rapid-succession test; added 3 autocomplete out-of-portal live region tests
- svelte-expert: collapsed redundant `{#if priority==='assertive'}` branches to a single element

## Test plan

- `bun run --filter=cinder test -- _visually-hidden-live-region copy-button load-more autocomplete` — 64 pass / 0 fail
- Full suite: 4516 pass / 0 fail (283 files)
- `bun run --filter=cinder typecheck` — 0 errors
- `bun run --filter=cinder lint` — 0 errors

## Task

Closes 96a9240d

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Accessibility behavior changes across copy-button, autocomplete, and load-more rely on setTimeout(0) timing and AT quirks; risk is mitigated by focused tests but still worth manual SR verification.
> 
> **Overview**
> Introduces an internal **`VisuallyHiddenLiveRegion`** as the standard way to announce **transient** screen-reader status strings, with **`PLATFORM-POLICY.md` § Live regions** documenting when to use it (no `aria-live` on interactive controls, portaled status must live outside the portal).
> 
> **`copy-button`** removes `aria-live` and the copied-state `aria-label` flip on the button (fixes double-announce), keeps a stable button name, and routes success text through the shared region. **`load-more`** replaces its inline `role="status"` markup with the shared component so repeated end-of-list text can re-announce. **`autocomplete`** adds an always-present region **outside** the portaled popover for loading/empty messages so NVDA/JAWS hear them reliably.
> 
> Unit tests cover blank-then-set timing, version guards, and the new autocomplete/copy-button behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2d032a71f56859c74556c6a53e379ac9cb7142bb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->