### PR TITLE
refactor(audit): remove cn alias; enforce classNames as canonical import (e666ce92)

### DIFF
--- a/packages/components/src/components/_radio/radio.svelte
+++ b/packages/components/src/components/_radio/radio.svelte
@@ -20,7 +20,7 @@
 
   import { ariaInvalid, composeDescribedBy, describeId } from '../../_internal/field-control.ts';
   import { getRadioGroupContext } from '../radio-group/radio-group-context.ts';
-  import { cn } from '../../utilities/class-names.ts';
+  import { classNames } from '../../utilities/class-names.ts';
 
   let {
     id,
@@ -72,7 +72,7 @@
       required={group.required || undefined}
       aria-invalid={ariaInvalid(group.invalid)}
       onchange={handleChange}
-      class={cn('cinder-radio', className)}
+      class={classNames('cinder-radio', className)}
       {...rest}
       aria-describedby={describedBy}
     />

--- a/packages/components/src/components/_sortable-item.svelte
+++ b/packages/components/src/components/_sortable-item.svelte
@@ -23,7 +23,7 @@
 
 <script lang="ts" generics="Item">
   import { getSortableContext } from '../utilities/sortable-controller.svelte.ts';
-  import { cn } from '../utilities/class-names.ts';
+  import { classNames } from '../utilities/class-names.ts';
 
   let {
     item: _item,
@@ -504,7 +504,7 @@
   data-preview-x={isDraggingWithPointer ? previewX : undefined}
   data-preview-y={isDraggingWithPointer ? previewY : undefined}
   aria-roledescription="sortable item"
-  class={cn(
+  class={classNames(
     'cinder-sortable-item',
     isLifted && isDraggingWithPointer && 'cinder-sortable-item--placeholder',
     isLifted && !isDraggingWithPointer && 'cinder-sortable-item--lifted',

--- a/packages/components/src/components/alert/alert.svelte
+++ b/packages/components/src/components/alert/alert.svelte
@@ -19,7 +19,7 @@
   import type { HTMLAttributes } from 'svelte/elements';
   import { tick } from 'svelte';
 
-  import { cn } from '../../utilities/class-names.ts';
+  import { classNames } from '../../utilities/class-names.ts';
   import type { AlertProps } from './alert.types.ts';
 
   const FOCUSABLE_SELECTOR =
@@ -113,7 +113,7 @@
   <div
     bind:this={rootElement}
     {...restWithoutForbidden}
-    class={cn('cinder-alert', 'cinder-_status-surface', className)}
+    class={classNames('cinder-alert', 'cinder-_status-surface', className)}
     data-cinder-variant={variant}
     role="alert"
   >

--- a/packages/components/src/components/avatar/avatar.svelte
+++ b/packages/components/src/components/avatar/avatar.svelte
@@ -16,7 +16,7 @@
 
 <script lang="ts">
   import type { AvatarProps } from './avatar.types.ts';
-  import { cn } from '../../utilities/class-names.ts';
+  import { classNames } from '../../utilities/class-names.ts';
   import VisuallyHidden from '../visually-hidden/visually-hidden.svelte';
 
   let {
@@ -46,7 +46,7 @@
 </script>
 
 <span
-  class={cn('cinder-avatar', className)}
+  class={classNames('cinder-avatar', className)}
   data-cinder-size={size}
   data-cinder-shape={shape}
   {...rest}

--- a/packages/components/src/components/breadcrumbs/breadcrumbs.svelte
+++ b/packages/components/src/components/breadcrumbs/breadcrumbs.svelte
@@ -16,7 +16,7 @@
 </script>
 
 <script lang="ts">
-  import { cn } from '../../utilities/class-names.ts';
+  import { classNames } from '../../utilities/class-names.ts';
   import type { BreadcrumbsProps } from './breadcrumbs.types.ts';
 
   let {
@@ -27,7 +27,7 @@
   }: BreadcrumbsProps = $props();
 </script>
 
-<nav class={cn('cinder-breadcrumbs', className)} aria-label={label}>
+<nav class={classNames('cinder-breadcrumbs', className)} aria-label={label}>
   <ol class="cinder-breadcrumbs__list">
     {#each items as item, index (index)}
       {@const isLast = index === items.length - 1}

--- a/packages/components/src/components/card/card.svelte
+++ b/packages/components/src/components/card/card.svelte
@@ -17,7 +17,7 @@
 
 <script lang="ts">
   import type { CardProps } from './card.types.ts';
-  import { cn } from '../../utilities/class-names.ts';
+  import { classNames } from '../../utilities/class-names.ts';
 
   let {
     class: className,
@@ -46,7 +46,7 @@
 </script>
 
 <div
-  class={cn('cinder-card', className)}
+  class={classNames('cinder-card', className)}
   data-cinder-variant={variant}
   data-cinder-edge-to-edge-mobile={edgeToEdgeOnMobile ? '' : undefined}
   {...rest}

--- a/packages/components/src/components/checkbox-group/checkbox-group.svelte
+++ b/packages/components/src/components/checkbox-group/checkbox-group.svelte
@@ -22,7 +22,7 @@
     describeId,
     errorId as buildErrorId,
   } from '../../_internal/field-control.ts';
-  import { cn } from '../../utilities/class-names.ts';
+  import { classNames } from '../../utilities/class-names.ts';
 
   const groupId = $props.id();
 
@@ -54,7 +54,7 @@
 -->
 <!-- svelte-ignore a11y_role_supports_aria_props_implicit -->
 <fieldset
-  class={cn('cinder-checkbox-group', className)}
+  class={classNames('cinder-checkbox-group', className)}
   {disabled}
   aria-invalid={ariaInvalid(!!error)}
   aria-describedby={describedBy}

--- a/packages/components/src/components/color-swatch-picker/color-swatch-picker.svelte
+++ b/packages/components/src/components/color-swatch-picker/color-swatch-picker.svelte
@@ -18,7 +18,7 @@
   import type { ColorSwatchPickerProps } from './color-swatch-picker.types.ts';
   import { tick, untrack } from 'svelte';
 
-  import { cn } from '../../utilities/class-names.ts';
+  import { classNames } from '../../utilities/class-names.ts';
   import { devWarn } from '../../utilities/dev-warn.ts';
   import { hasAlpha, pickContrastColor } from '../../utilities/color-luminance.ts';
   import { handleRovingKeydown } from '../../utilities/roving-tabindex.ts';
@@ -151,7 +151,7 @@
   aria-label={label}
   aria-disabled={disabled ? 'true' : undefined}
   aria-orientation={layout === 'stack' ? 'vertical' : undefined}
-  class={cn('cinder-color-swatch-picker', className)}
+  class={classNames('cinder-color-swatch-picker', className)}
   data-cinder-size={size}
   data-cinder-shape={shape}
   data-cinder-layout={layout}

--- a/packages/components/src/components/combobox/combobox.svelte
+++ b/packages/components/src/components/combobox/combobox.svelte
@@ -25,7 +25,7 @@
     describeId,
     errorId as buildErrorId,
   } from '../../_internal/field-control.ts';
-  import { cn } from '../../utilities/class-names.ts';
+  import { classNames } from '../../utilities/class-names.ts';
   import Popover from '../popover/popover.svelte';
 
   let {
@@ -167,7 +167,7 @@
   }
 </script>
 
-<div class={cn('cinder-combobox', className)}>
+<div class={classNames('cinder-combobox', className)}>
   {#if label}
     <label for={id} class="cinder-combobox__label" data-disabled={disabled || undefined}>
       {label}

--- a/packages/components/src/components/command-item/command-item.svelte
+++ b/packages/components/src/components/command-item/command-item.svelte
@@ -20,7 +20,7 @@
   import { untrack } from 'svelte';
   import type { Attachment } from 'svelte/attachments';
 
-  import { cn } from '../../utilities/class-names.ts';
+  import { classNames } from '../../utilities/class-names.ts';
   import {
     getCommandListContext,
     hasCommandListContext,
@@ -101,7 +101,7 @@
   {@attach registerWithPalette}
   id={itemId ?? undefined}
   role="option"
-  class={cn('cinder-command-item', className)}
+  class={classNames('cinder-command-item', className)}
   aria-selected={isActive}
   aria-disabled={disabled || undefined}
   data-cinder-active={isActive ? '' : undefined}

--- a/packages/components/src/components/confirm-dialog/confirm-dialog.svelte
+++ b/packages/components/src/components/confirm-dialog/confirm-dialog.svelte
@@ -19,7 +19,7 @@
   import type { ConfirmDialogProps } from './confirm-dialog.types.ts';
   import Button from '../button/button.svelte';
   import Modal from '../modal/modal.svelte';
-  import { cn } from '../../utilities/class-names.ts';
+  import { classNames } from '../../utilities/class-names.ts';
 
   const descriptionId = $props.id();
 
@@ -55,7 +55,7 @@
   bind:open
   {title}
   {triggerRef}
-  class={cn('cinder-confirm-dialog', className)}
+  class={classNames('cinder-confirm-dialog', className)}
   {...describedById ? { describedById } : {}}
   {...oncancel ? { ondismiss: oncancel } : {}}
 >

--- a/packages/components/src/components/connection-indicator/connection-indicator.svelte
+++ b/packages/components/src/components/connection-indicator/connection-indicator.svelte
@@ -17,7 +17,7 @@
 
 <script lang="ts">
   import type { ConnectionIndicatorProps, ConnectionState } from './connection-indicator.types.ts';
-  import { cn } from '../../utilities/class-names.ts';
+  import { classNames } from '../../utilities/class-names.ts';
 
   let { state, label, class: className, ...rest }: ConnectionIndicatorProps = $props();
 
@@ -33,7 +33,7 @@
 
 <span
   {...rest}
-  class={cn('cinder-connection-indicator', className)}
+  class={classNames('cinder-connection-indicator', className)}
   data-cinder-state={state}
   role="status"
   aria-live="polite"

--- a/packages/components/src/components/copy-button/copy-button.svelte
+++ b/packages/components/src/components/copy-button/copy-button.svelte
@@ -22,7 +22,7 @@
   import Check from 'lucide-svelte/icons/check';
   import Copy from 'lucide-svelte/icons/copy';
   import { copyToClipboard } from '../../utilities/clipboard.ts';
-  import { cn } from '../../utilities/class-names.ts';
+  import { classNames } from '../../utilities/class-names.ts';
   import VisuallyHiddenLiveRegion from '../_visually-hidden-live-region.svelte';
 
   let {
@@ -78,7 +78,7 @@
   data-cinder-copied={copied || undefined}
   aria-label={label ?? 'Copy to clipboard'}
   onclick={handleClick}
-  class={cn('cinder-copy-button', className)}
+  class={classNames('cinder-copy-button', className)}
 >
   <!-- Accessible name comes from `aria-label`. In iconOnly mode the icon is
        decorative (`aria-hidden`). Visible "Copied" text is presentational only;

--- a/packages/components/src/components/feed-event/feed-event.svelte
+++ b/packages/components/src/components/feed-event/feed-event.svelte
@@ -17,7 +17,7 @@
 <script lang="ts">
   import type { Snippet } from 'svelte';
 
-  import { cn } from '../../utilities/class-names.ts';
+  import { classNames } from '../../utilities/class-names.ts';
   import type { FeedEventProps } from './feed-event.types.ts';
 
   let {
@@ -32,7 +32,7 @@
   }: FeedEventProps = $props();
 </script>
 
-<li {...rest} class={cn('cinder-feed-event', className)} data-cinder-variant={variant}>
+<li {...rest} class={classNames('cinder-feed-event', className)} data-cinder-variant={variant}>
   <span class="cinder-feed-event-rail" aria-hidden="true">
     {#if variant === 'icon'}
       <span class="cinder-feed-event-icon">{@render (icon as Snippet)()}</span>

--- a/packages/components/src/components/feed/feed.svelte
+++ b/packages/components/src/components/feed/feed.svelte
@@ -16,7 +16,7 @@
 
 <script lang="ts">
   import type { FeedProps } from './feed.types.ts';
-  import { cn } from '../../utilities/class-names.ts';
+  import { classNames } from '../../utilities/class-names.ts';
 
   let { live = false, class: className, children, ...rest }: FeedProps = $props();
 
@@ -25,6 +25,6 @@
   );
 </script>
 
-<ol {...rest} {...liveRegionAttributes} class={cn('cinder-feed', className)}>
+<ol {...rest} {...liveRegionAttributes} class={classNames('cinder-feed', className)}>
   {@render children()}
 </ol>

--- a/packages/components/src/components/image/image.svelte
+++ b/packages/components/src/components/image/image.svelte
@@ -17,7 +17,7 @@
 
 <script lang="ts">
   import type { ImageProps } from './image.types.ts';
-  import { cn } from '../../utilities/class-names.ts';
+  import { classNames } from '../../utilities/class-names.ts';
 
   let {
     src,
@@ -86,7 +86,7 @@
 </script>
 
 <div
-  class={cn('cinder-image', className)}
+  class={classNames('cinder-image', className)}
   data-cinder-loaded={loaded ? '' : undefined}
   data-cinder-errored={errored ? '' : undefined}
   data-cinder-fallback={showFallback ? '' : undefined}

--- a/packages/components/src/components/input/input.svelte
+++ b/packages/components/src/components/input/input.svelte
@@ -25,7 +25,7 @@
     errorId as buildErrorId,
   } from '../../_internal/field-control.ts';
   import { getFormFieldContext } from '../../_internal/form-field-context.ts';
-  import { cn } from '../../utilities/class-names.ts';
+  import { classNames } from '../../utilities/class-names.ts';
   import { devWarn } from '../../utilities/dev-warn.ts';
 
   let {
@@ -111,7 +111,7 @@
     disabled={resolvedDisabled}
     required={resolvedRequired}
     bind:value
-    class={cn('cinder-input', className)}
+    class={classNames('cinder-input', className)}
     data-cinder-native-date={rendersNativeDateIcon ? '' : undefined}
     aria-invalid={resolvedAriaInvalid}
     aria-describedby={describedBy}

--- a/packages/components/src/components/json-viewer/_json-viewer-node.svelte
+++ b/packages/components/src/components/json-viewer/_json-viewer-node.svelte
@@ -15,7 +15,7 @@
 <script lang="ts">
   import { untrack } from 'svelte';
   import Self from './_json-viewer-node.svelte';
-  import { cn } from '../../utilities/class-names.ts';
+  import { classNames } from '../../utilities/class-names.ts';
 
   let { value, keyName, depth, initialDepth, maxDepth }: JsonViewerNodeProps = $props();
 
@@ -56,7 +56,7 @@
 </script>
 
 {#if isObject && !tooDeep}
-  <span class={cn('cinder-json-viewer__node')}>
+  <span class={classNames('cinder-json-viewer__node')}>
     {#if keyName !== undefined}
       <span class="cinder-json-viewer__key">{keyName}:</span>
     {/if}

--- a/packages/components/src/components/json-viewer/json-viewer.svelte
+++ b/packages/components/src/components/json-viewer/json-viewer.svelte
@@ -19,7 +19,7 @@
 <script lang="ts">
   import type { JsonViewerProps } from './json-viewer.types.ts';
   import JsonViewerNode from './_json-viewer-node.svelte';
-  import { cn } from '../../utilities/class-names.ts';
+  import { classNames } from '../../utilities/class-names.ts';
 
   let {
     value,
@@ -50,7 +50,7 @@
   const tooLarge = $derived(serialized.ok && serialized.size > maxBytes);
 </script>
 
-<div class={cn('cinder-json-viewer', className)}>
+<div class={classNames('cinder-json-viewer', className)}>
   {#if unserializable}
     <div class="cinder-json-viewer__fallback" role="status">
       <p>

--- a/packages/components/src/components/kanban-board/kanban-board.svelte
+++ b/packages/components/src/components/kanban-board/kanban-board.svelte
@@ -24,7 +24,7 @@
 </script>
 
 <script lang="ts" generics="Card">
-  import { cn } from '../../utilities/class-names.ts';
+  import { classNames } from '../../utilities/class-names.ts';
   import { devWarn } from '../../utilities/dev-warn.ts';
   import {
     SortableController,
@@ -456,7 +456,7 @@
 <svelte:window onkeydown={handleWindowKeydown} />
 
 <section
-  class={cn('cinder-kanban-board', className)}
+  class={classNames('cinder-kanban-board', className)}
   aria-label={label}
   data-cinder-invalid-keys={invalidKeys ? '' : undefined}
 >

--- a/packages/components/src/components/label/label.svelte
+++ b/packages/components/src/components/label/label.svelte
@@ -16,7 +16,7 @@
 
 <script lang="ts">
   import type { LabelProps } from './label.types.ts';
-  import { cn } from '../../utilities/class-names.ts';
+  import { classNames } from '../../utilities/class-names.ts';
 
   let {
     for: forId,
@@ -30,7 +30,7 @@
 
 <label
   for={forId}
-  class={cn('cinder-label', className)}
+  class={classNames('cinder-label', className)}
   data-disabled={disabled || undefined}
   {...rest}
 >

--- a/packages/components/src/components/message/message.svelte
+++ b/packages/components/src/components/message/message.svelte
@@ -28,7 +28,7 @@
 
 <script lang="ts">
   import type { MessageProps } from './message.types.ts';
-  import { cn } from '../../utilities/class-names.ts';
+  import { classNames } from '../../utilities/class-names.ts';
 
   let {
     role,
@@ -43,7 +43,7 @@
   const visibleName = $derived(name ?? defaultNames[role]);
 </script>
 
-<article {...rest} data-cinder-role={role} class={cn('cinder-message', className)}>
+<article {...rest} data-cinder-role={role} class={classNames('cinder-message', className)}>
   <header class="cinder-message__header">
     <span class="cinder-message__name">{visibleName}</span>
     {#if datetime}

--- a/packages/components/src/components/navigation-bar/navigation-bar.svelte
+++ b/packages/components/src/components/navigation-bar/navigation-bar.svelte
@@ -22,7 +22,7 @@
 
 <script lang="ts">
   import type { NavigationBarProps, NavigationVariant } from './navigation-bar.types.ts';
-  import { cn } from '../../utilities/class-names.ts';
+  import { classNames } from '../../utilities/class-names.ts';
 
   const regionId = $props.id();
 
@@ -127,7 +127,7 @@
 <nav
   {...rest}
   aria-label={navAriaLabel}
-  class={cn('cinder-navigation-bar', className)}
+  class={classNames('cinder-navigation-bar', className)}
   data-collapsible={menuToggle !== undefined ? 'true' : 'false'}
   onkeydown={handleKeyDown}
 >

--- a/packages/components/src/components/number-input/number-input.svelte
+++ b/packages/components/src/components/number-input/number-input.svelte
@@ -26,7 +26,7 @@
     errorId as buildErrorId,
   } from '../../_internal/field-control.ts';
   import { getFormFieldContext } from '../../_internal/form-field-context.ts';
-  import { cn } from '../../utilities/class-names.ts';
+  import { classNames } from '../../utilities/class-names.ts';
   import { formatNumber } from '../../utilities/format-number.ts';
   import { parseLocaleNumber } from '../../utilities/parse-locale-number.ts';
 
@@ -506,7 +506,7 @@
   );
 </script>
 
-<div class={cn('cinder-input-field', className)}>
+<div class={classNames('cinder-input-field', className)}>
   {#if label}
     <label for={id} class="cinder-input-field__label" data-disabled={resolvedDisabled || undefined}>
       {label}

--- a/packages/components/src/components/progress/progress.svelte
+++ b/packages/components/src/components/progress/progress.svelte
@@ -17,7 +17,7 @@
 
 <script lang="ts">
   import type { ProgressProps } from './progress.types.ts';
-  import { cn } from '../../utilities/class-names.ts';
+  import { classNames } from '../../utilities/class-names.ts';
   import { devWarn } from '../../utilities/dev-warn.ts';
 
   let {
@@ -67,7 +67,7 @@
 
 {#if variant === 'ring'}
   <div
-    class={cn('cinder-progress', 'cinder-progress--ring', className)}
+    class={classNames('cinder-progress', 'cinder-progress--ring', className)}
     role="progressbar"
     aria-label={ariaLabel}
     aria-labelledby={ariaLabelledby}
@@ -100,7 +100,7 @@
   </div>
 {:else}
   <div
-    class={cn('cinder-progress', 'cinder-progress--bar', className)}
+    class={classNames('cinder-progress', 'cinder-progress--bar', className)}
     role="progressbar"
     aria-label={ariaLabel}
     aria-labelledby={ariaLabelledby}

--- a/packages/components/src/components/radio-group/radio-group.svelte
+++ b/packages/components/src/components/radio-group/radio-group.svelte
@@ -24,7 +24,7 @@
     describeId,
     errorId as buildErrorId,
   } from '../../_internal/field-control.ts';
-  import { cn } from '../../utilities/class-names.ts';
+  import { classNames } from '../../utilities/class-names.ts';
 
   let {
     value = $bindable(''),
@@ -77,7 +77,7 @@
 -->
 <!-- svelte-ignore a11y_role_supports_aria_props_implicit -->
 <fieldset
-  class={cn('cinder-radio-group', className)}
+  class={classNames('cinder-radio-group', className)}
   aria-invalid={ariaInvalid(!!error)}
   aria-required={required || undefined}
   aria-describedby={describedBy}

--- a/packages/components/src/components/sheet/sheet.svelte
+++ b/packages/components/src/components/sheet/sheet.svelte
@@ -22,7 +22,7 @@
   import { captureFocus, lockBodyScroll, pushEscapeHandler } from '../../_internal/overlay.ts';
   import { waitForTransitionCompletion } from '../../_internal/transition-completion.ts';
   import { overflowFade } from '../../utilities/attachments.ts';
-  import { cn } from '../../utilities/class-names.ts';
+  import { classNames } from '../../utilities/class-names.ts';
   import { restoreFocusTo } from '../../utilities/focus.ts';
   import { useReducedMotion } from '../../utilities/use-reduced-motion.svelte.ts';
 
@@ -211,7 +211,7 @@
   <dialog
     {...rest}
     bind:this={dialogElement}
-    class={cn('cinder-sheet', className)}
+    class={classNames('cinder-sheet', className)}
     aria-modal="true"
     aria-labelledby={ariaLabelledBy ?? titleId}
     data-cinder-closing={isClosing ? '' : undefined}

--- a/packages/components/src/components/skeleton/skeleton.svelte
+++ b/packages/components/src/components/skeleton/skeleton.svelte
@@ -17,7 +17,7 @@
 
 <script lang="ts">
   import type { SkeletonProps } from './skeleton.types.ts';
-  import { cn } from '../../utilities/class-names.ts';
+  import { classNames } from '../../utilities/class-names.ts';
 
   let { width, height, radius, class: className }: SkeletonProps = $props();
 
@@ -32,4 +32,4 @@
   );
 </script>
 
-<div class={cn('cinder-skeleton', className)} aria-hidden="true" {style}></div>
+<div class={classNames('cinder-skeleton', className)} aria-hidden="true" {style}></div>

--- a/packages/components/src/components/sortable-list/sortable-list.svelte
+++ b/packages/components/src/components/sortable-list/sortable-list.svelte
@@ -17,7 +17,7 @@
 
 <script lang="ts" generics="Item">
   import { untrack } from 'svelte';
-  import { cn } from '../../utilities/class-names.ts';
+  import { classNames } from '../../utilities/class-names.ts';
   import {
     SortableController,
     setSortableContext,
@@ -112,7 +112,7 @@
 
 <svelte:window onkeydown={handleWindowKeydown} />
 
-<ul class={cn('cinder-sortable-list', className)} role="list" aria-label={label}>
+<ul class={classNames('cinder-sortable-list', className)} role="list" aria-label={label}>
   <!--
     Instructions live inside the <ul> as a visually hidden <li> so the element is
     present in the DOM before any handle buttons that reference it via aria-describedby.

--- a/packages/components/src/components/spinner/spinner.svelte
+++ b/packages/components/src/components/spinner/spinner.svelte
@@ -16,7 +16,7 @@
 </script>
 
 <script lang="ts">
-  import { cn } from '../../utilities/class-names.ts';
+  import { classNames } from '../../utilities/class-names.ts';
   import type { SpinnerProps } from './spinner.types.ts';
 
   const { size = 'md', label = 'Loading', class: className, ...rest }: SpinnerProps = $props();
@@ -24,7 +24,7 @@
 
 <span
   {...rest}
-  class={cn('cinder-spinner', className)}
+  class={classNames('cinder-spinner', className)}
   role="status"
   aria-label={label}
   data-cinder-size={size}

--- a/packages/components/src/components/spinner/spinner.types.ts
+++ b/packages/components/src/components/spinner/spinner.types.ts
@@ -7,7 +7,7 @@ export type SpinnerSize = 'sm' | 'md' | 'lg';
 // `{...rest}` spread sits before the explicit attrs), and Omit-ing them here makes
 // that protection part of the type: `<Spinner role="img" />` is a compile error.
 // `class` is omitted because the component re-declares it as an owned prop (merged
-// via `cn`), matching StatusDotProps / AlertProps.
+// via `classNames`), matching StatusDotProps / AlertProps.
 export type SpinnerProps = Omit<
   HTMLAttributes<HTMLSpanElement>,
   'role' | 'aria-label' | 'class'

--- a/packages/components/src/components/steps/steps.svelte
+++ b/packages/components/src/components/steps/steps.svelte
@@ -17,7 +17,7 @@
 
 <script lang="ts">
   import type { StepsProps } from './steps.types.ts';
-  import { cn } from '../../utilities/class-names.ts';
+  import { classNames } from '../../utilities/class-names.ts';
   import Check from 'lucide-svelte/icons/check';
 
   let {
@@ -45,7 +45,11 @@
   );
 </script>
 
-<nav class={cn('cinder-steps', className)} aria-label={label} data-cinder-orientation={orientation}>
+<nav
+  class={classNames('cinder-steps', className)}
+  aria-label={label}
+  data-cinder-orientation={orientation}
+>
   <ol class="cinder-steps__list">
     {#each steps as step, index (step.id)}
       {@const state = stepStates[index]}

--- a/packages/components/src/components/tab-list/tab-list.svelte
+++ b/packages/components/src/components/tab-list/tab-list.svelte
@@ -19,7 +19,7 @@
   import type { TabListProps } from './tab-list.types.ts';
 
   import { getTabsContext } from '../tabs/tabs-context.ts';
-  import { cn } from '../../utilities/class-names.ts';
+  import { classNames } from '../../utilities/class-names.ts';
 
   let { label, labelledBy, class: className, children }: TabListProps = $props();
 
@@ -28,7 +28,7 @@
 
 <div
   role="tablist"
-  class={cn('cinder-tab-list', className)}
+  class={classNames('cinder-tab-list', className)}
   data-cinder-orientation={tabs.orientation}
   aria-label={label}
   aria-labelledby={labelledBy}

--- a/packages/components/src/components/tab-panel/tab-panel.svelte
+++ b/packages/components/src/components/tab-panel/tab-panel.svelte
@@ -19,7 +19,7 @@
   import type { TabPanelProps } from './tab-panel.types.ts';
 
   import { getTabsContext } from '../tabs/tabs-context.ts';
-  import { cn } from '../../utilities/class-names.ts';
+  import { classNames } from '../../utilities/class-names.ts';
 
   let { value, ariaLabelledby, class: className, children }: TabPanelProps = $props();
 
@@ -41,7 +41,7 @@
   <div
     id={panelId}
     role="tabpanel"
-    class={cn('cinder-tab-panel', className)}
+    class={classNames('cinder-tab-panel', className)}
     data-cinder-value={value}
     aria-labelledby={labelledBy}
     tabindex="0"

--- a/packages/components/src/components/table-body/table-body.svelte
+++ b/packages/components/src/components/table-body/table-body.svelte
@@ -17,13 +17,13 @@
   import type { TableBodyProps } from './table-body.types.ts';
 
   import { setTableSectionContext } from '../table/table.context.ts';
-  import { cn } from '../../utilities/class-names.ts';
+  import { classNames } from '../../utilities/class-names.ts';
 
   let { class: className, children }: TableBodyProps = $props();
 
   setTableSectionContext('body');
 </script>
 
-<tbody class={cn('cinder-table__body', className)}>
+<tbody class={classNames('cinder-table__body', className)}>
   {@render children()}
 </tbody>

--- a/packages/components/src/components/table-cell/table-cell.svelte
+++ b/packages/components/src/components/table-cell/table-cell.svelte
@@ -16,11 +16,11 @@
 
 <script lang="ts">
   import type { TableCellProps } from './table-cell.types.ts';
-  import { cn } from '../../utilities/class-names.ts';
+  import { classNames } from '../../utilities/class-names.ts';
 
   let { align = 'left', class: className, children, ...rest }: TableCellProps = $props();
 </script>
 
-<td {...rest} class={cn('cinder-table__cell', className)} data-cinder-align={align}>
+<td {...rest} class={classNames('cinder-table__cell', className)} data-cinder-align={align}>
   {@render children?.()}
 </td>

--- a/packages/components/src/components/table-header-cell/table-header-cell.svelte
+++ b/packages/components/src/components/table-header-cell/table-header-cell.svelte
@@ -18,7 +18,7 @@
   import type { TableHeaderCellProps } from './table-header-cell.types.ts';
 
   import { getTableContext } from '../table/table.context.ts';
-  import { cn } from '../../utilities/class-names.ts';
+  import { classNames } from '../../utilities/class-names.ts';
 
   let {
     column,
@@ -58,7 +58,7 @@
 <th
   {...rest}
   {scope}
-  class={cn('cinder-table__header-cell', className)}
+  class={classNames('cinder-table__header-cell', className)}
   data-cinder-align={align}
   data-cinder-sortable={isSortable || undefined}
   aria-sort={ariaSort}

--- a/packages/components/src/components/table-header/table-header.svelte
+++ b/packages/components/src/components/table-header/table-header.svelte
@@ -22,7 +22,7 @@
     setTableSectionContext,
     tryGetTableContext,
   } from '../table/table.context.ts';
-  import { cn } from '../../utilities/class-names.ts';
+  import { classNames } from '../../utilities/class-names.ts';
 
   let {
     class: className,
@@ -76,6 +76,6 @@
   });
 </script>
 
-<thead class={cn('cinder-table__header', className)}>
+<thead class={classNames('cinder-table__header', className)}>
   {@render children()}
 </thead>

--- a/packages/components/src/components/table-row/table-row.svelte
+++ b/packages/components/src/components/table-row/table-row.svelte
@@ -23,7 +23,7 @@
     tryGetTableHeaderSelectionContext,
     tryGetTableSectionContext,
   } from '../table/table.context.ts';
-  import { cn } from '../../utilities/class-names.ts';
+  import { classNames } from '../../utilities/class-names.ts';
   import { devWarn } from '../../utilities/dev-warn.ts';
 
   let {
@@ -88,7 +88,7 @@
   }
 </script>
 
-<tr class={cn('cinder-table__row', className)}>
+<tr class={classNames('cinder-table__row', className)}>
   {#if shouldRenderHeaderSelectionCell && headerSelection}
     <th scope="col" class="cinder-table__header-cell cinder-table__header-cell--selection">
       <input

--- a/packages/components/src/components/table/table.svelte
+++ b/packages/components/src/components/table/table.svelte
@@ -27,7 +27,7 @@
   import { setTableContext } from './table.context.ts';
   import type { TableProps } from './table.types.ts';
 
-  import { cn } from '../../utilities/class-names.ts';
+  import { classNames } from '../../utilities/class-names.ts';
 
   let {
     sort = $bindable(),
@@ -63,7 +63,7 @@
 </script>
 
 <table
-  class={cn('cinder-table', className)}
+  class={classNames('cinder-table', className)}
   data-cinder-sticky-header={stickyHeader || undefined}
   data-cinder-density={density}
   data-cinder-selectable={selectable || undefined}

--- a/packages/components/src/components/timeline-item/timeline-item.svelte
+++ b/packages/components/src/components/timeline-item/timeline-item.svelte
@@ -15,7 +15,7 @@
 </script>
 
 <script lang="ts">
-  import { cn } from '../../utilities/class-names.ts';
+  import { classNames } from '../../utilities/class-names.ts';
   import type { TimelineHeadingLevel } from '../timeline/timeline.types.ts';
   import type { TimelineItemProps } from './timeline-item.types.ts';
 
@@ -48,7 +48,7 @@
 
 <li
   {...rest}
-  class={cn('cinder-timeline-item', className)}
+  class={classNames('cinder-timeline-item', className)}
   data-cinder-tone={tone}
   data-cinder-connector-after={connectorAfter}
 >

--- a/packages/components/src/components/timeline/timeline.svelte
+++ b/packages/components/src/components/timeline/timeline.svelte
@@ -25,7 +25,7 @@
 </script>
 
 <script lang="ts">
-  import { cn } from '../../utilities/class-names.ts';
+  import { classNames } from '../../utilities/class-names.ts';
   import TimelineItem from '../timeline-item/timeline-item.svelte';
   import { buildTimelineRenderPlan } from './timeline-groups.ts';
   import type { TimelineProps } from './timeline.types.ts';
@@ -65,7 +65,7 @@
 
 <ol
   {...rest}
-  class={cn('cinder-timeline', className)}
+  class={classNames('cinder-timeline', className)}
   data-cinder-orientation={orientation}
   aria-label={resolvedAriaLabel}
   aria-labelledby={ariaLabelledby}

--- a/packages/components/src/components/toast-region/toast-region.svelte
+++ b/packages/components/src/components/toast-region/toast-region.svelte
@@ -28,7 +28,7 @@
   import { setToastContext } from '../../_internal/toast-context.ts';
   import { pushEscapeHandler } from '../../_internal/overlay.ts';
   import { waitForTransitionCompletion } from '../../_internal/transition-completion.ts';
-  import { cn } from '../../utilities/class-names.ts';
+  import { classNames } from '../../utilities/class-names.ts';
   import { useReducedMotion } from '../../utilities/use-reduced-motion.svelte.ts';
   import type {
     ToastItem,
@@ -637,7 +637,7 @@
 {#if hydrated}
   <div
     bind:this={regionElement}
-    class={cn('cinder-toast-region', className)}
+    class={classNames('cinder-toast-region', className)}
     role="presentation"
     data-cinder-position={position}
     onpointerenter={() => setRegionPointerInside(true)}

--- a/packages/components/src/components/tooltip/tooltip.svelte
+++ b/packages/components/src/components/tooltip/tooltip.svelte
@@ -20,7 +20,7 @@
   import type { Attachment } from 'svelte/attachments';
   import type { Placement } from '@floating-ui/dom';
   import { createAnchoredOverlay } from '../../_internal/anchored-overlay.svelte.ts';
-  import { cn } from '../../utilities/class-names.ts';
+  import { classNames } from '../../utilities/class-names.ts';
   import { createPortalAttachment } from '../portal/index.ts';
 
   let {
@@ -178,7 +178,7 @@
   wrapper out of the accessibility tree.
 -->
 <span
-  class={cn('cinder-tooltip-wrapper', className)}
+  class={classNames('cinder-tooltip-wrapper', className)}
   role="presentation"
   onmouseenter={handleMouseEnter}
   onmouseleave={handleMouseLeave}

--- a/packages/components/src/convention.test.ts
+++ b/packages/components/src/convention.test.ts
@@ -65,7 +65,7 @@ const DOMAIN_SUITE_STYLE_ALLOW_LIST = new Set([
 
 /**
  * Components that intentionally render no class-bearing root element and
- * therefore do not need `cn()` / `classNames()`. This is empty today: every
+ * therefore do not need `classNames()`. This is empty today: every
  * public component renders a class-bearing root.
  *
  * **When to add a component here:** the component's entire template is
@@ -329,16 +329,12 @@ describe('component conventions', () => {
         );
       }
 
-      // 5. Source contains cn( or classNames( for class merging.
+      // 5. Source contains classNames( for class merging.
       //    Pure pass-through components that render no class-bearing root
       //    element (see NO_CLASS_MERGING_ALLOW_LIST) are exempt — they have
       //    no element to merge classes onto.
-      if (
-        !NO_CLASS_MERGING_ALLOW_LIST.has(name) &&
-        !source.includes('cn(') &&
-        !source.includes('classNames(')
-      ) {
-        errors.push(`${file}: must use cn() or classNames() for class merging`);
+      if (!NO_CLASS_MERGING_ALLOW_LIST.has(name) && !source.includes('classNames(')) {
+        errors.push(`${file}: must use classNames() for class merging`);
       }
 
       // 6. No Snippet | undefined — optional snippets must use Snippet? syntax.

--- a/packages/components/src/utilities/class-names.ts
+++ b/packages/components/src/utilities/class-names.ts
@@ -7,5 +7,3 @@ export function classNames(...parts: Array<string | null | undefined | false>): 
     .filter((part): part is string => typeof part === 'string' && part.length > 0)
     .join(' ');
 }
-
-export const cn = classNames;


### PR DESCRIPTION
## Summary

`utilities/class-names.ts` exported both `classNames` and a `cn` alias (`export const cn = classNames`) — an undocumented split the consistency lens flags and which contradicts the repo convention of full names over abbreviations. This PR:

- Removes `export const cn = classNames` from `class-names.ts`
- Renames all 43 `import { cn }` and `cn(` call sites to `classNames` across `components/src`
- Updates `convention.test.ts` to enforce only `classNames(` (removing the old `cn( OR classNames(` dual-check, making the enforcement stricter)

`cn` was never exported in `index.ts` — it was always internal-only. No consumer-facing API change.

**Self-enforcing:** removing the alias means any missed `import { cn }` fails at compile time via TypeScript, making coverage provably complete.

## Review committee

Pre-reviewed by: simplicity-engineer, codex (gpt-5.4, xhigh reasoning)
- 1 round of review
- Both approved with no issues
- Codex noted: "removing `cn` should make any missed `import { cn }` fail at compile/test time" — self-enforcing

## Test plan

- `bun run --filter=cinder test` — **4516 pass / 0 fail** (4520 tests)
- `bun run --filter=cinder typecheck` — 0 errors
- `bun run --filter=cinder lint` — 0 errors
- Convention test passes (simplified to `classNames(` only)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical rename with no runtime or public API change; missed `cn` imports fail at compile time.
> 
> **Overview**
> Standardizes class merging on **`classNames`** by dropping the internal **`cn`** alias and updating every component import/call site to match.
> 
> **`utilities/class-names.ts`** now exports only **`classNames`** (no **`export const cn = classNames`**). Across **`components/src`**, Svelte roots that merged consumer **`class`** props switched from **`cn(...)`** to **`classNames(...)`**—same behavior, one name. **`convention.test.ts`** was tightened so components must contain **`classNames(`** (the old **`cn(` OR `classNames(`** check is gone). A **`spinner.types.ts`** comment was updated to reference **`classNames`**.
> 
> No public package API change: **`cn`** was never part of **`index.ts`** exports.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0486aa60ebf8d36b2ac802f0210f4fe3f83113d6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->