### PR TITLE
fix(steps): center each horizontal step as a unit; fix narrow connector

### DIFF
--- a/packages/components/src/components/steps/steps.css
+++ b/packages/components/src/components/steps/steps.css
@@ -297,6 +297,10 @@
        column. Narrow steps read like the vertical orientation: marker in
        column 1, body in column 2, connector running down column 1. */
       display: grid;
+      /* Reset align-items from the wide flex-column rule (where it centers
+       the flex children horizontally). On a grid container align-items
+       would vertically center grid items; stretch is the correct default. */
+      align-items: stretch;
       grid-template-columns: auto 1fr;
       grid-template-rows: auto 1fr;
       gap: 0 var(--cinder-space-3);

--- a/packages/components/src/components/steps/steps.css
+++ b/packages/components/src/components/steps/steps.css
@@ -11,6 +11,9 @@
     display: block;
     container-type: inline-size;
     container-name: cinder-steps;
+    /* Marker diameter — referenced by the horizontal connector's `top` offset so
+     both values stay in sync if the size ever changes. */
+    --_marker-size: 1.5rem;
   }
 
   /* ----------------------------------------
@@ -61,13 +64,15 @@
 
   .cinder-steps[data-cinder-orientation='horizontal'] .cinder-steps__connector {
     position: absolute;
-    /* Vertically centered on the marker (markers are 1.5rem tall). */
-    top: calc(1.5rem / 2);
+    /* Vertically centered on the marker. Uses --_marker-size so this offset
+     stays in sync if the marker diameter is ever changed. */
+    top: calc(var(--_marker-size) / 2);
     height: 1px;
-    /* Start at this marker's center and run to the next marker's center. Items
-     are equal-width (flex: 1 1 0), so the next center is exactly one item-width
-     to the inline-end — hence left:50% + width:100%. Logical props keep this
-     correct under RTL. */
+    /* Start at this marker's center (50%) and run to the next marker's center.
+     This geometry is correct only when every flex item shares the same computed
+     width (flex: 1 1 0 with no gap or min-width overrides). If variable-width
+     steps are ever needed, revisit this calculation.
+     Logical props keep the direction correct under RTL. */
     inset-inline-start: 50%;
     width: 100%;
     z-index: 0;
@@ -121,8 +126,8 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    width: 1.5rem;
-    height: 1.5rem;
+    width: var(--_marker-size);
+    height: var(--_marker-size);
     border-radius: var(--cinder-radius-full);
     background: var(--cinder-surface-inset);
     flex-shrink: 0;

--- a/packages/components/src/components/steps/steps.css
+++ b/packages/components/src/components/steps/steps.css
@@ -36,38 +36,48 @@
 
   /* ----------------------------------------
  * Item — horizontal layout
- * Marker (top-left) | Connector (top-right, centered vertically)
- * Body spans full width in second row
+ * Each step is a centered column: marker on top, label/description centered
+ * directly beneath it so the three read as one unit. The connector is painted
+ * as a line running between this marker's center and the next marker's center
+ * (absolutely positioned, behind the markers).
  * ---------------------------------------- */
 
   .cinder-steps[data-cinder-orientation='horizontal'] .cinder-steps__item {
     flex: 1 1 0;
-    display: grid;
-    grid-template-columns: auto 1fr;
-    grid-template-rows: auto auto;
-    gap: 0 var(--cinder-space-2);
+    /* Equal-width columns even when labels differ in length, so every marker
+     sits at the horizontal center of its share of the track. */
+    min-width: 0;
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
   }
 
   .cinder-steps[data-cinder-orientation='horizontal'] .cinder-steps__marker {
-    grid-column: 1;
-    grid-row: 1;
+    /* Lift the marker above the connector line that passes behind it. */
+    position: relative;
+    z-index: 1;
   }
 
   .cinder-steps[data-cinder-orientation='horizontal'] .cinder-steps__connector {
-    grid-column: 2;
-    grid-row: 1;
-    align-self: center;
+    position: absolute;
+    /* Vertically centered on the marker (markers are 1.5rem tall). */
+    top: calc(1.5rem / 2);
     height: 1px;
-    /* Shorten the painted line by the leading gap and push it clear of the
-     marker, so the total inline footprint of the cell is unchanged (no
-     overshoot into the next marker). */
-    width: calc(100% - var(--cinder-space-2));
-    margin-inline-start: var(--cinder-space-2);
+    /* Start at this marker's center and run to the next marker's center. Items
+     are equal-width (flex: 1 1 0), so the next center is exactly one item-width
+     to the inline-end — hence left:50% + width:100%. Logical props keep this
+     correct under RTL. */
+    inset-inline-start: 50%;
+    width: 100%;
+    z-index: 0;
   }
 
   .cinder-steps[data-cinder-orientation='horizontal'] .cinder-steps__body {
-    grid-column: 1 / -1;
-    grid-row: 2;
+    text-align: center;
+    align-items: center;
+    /* Keep long labels from colliding with adjacent steps; they wrap instead. */
+    max-width: 100%;
   }
 
   /* ----------------------------------------
@@ -278,22 +288,43 @@
 
     .cinder-steps[data-cinder-orientation='horizontal'] .cinder-steps__item {
       flex: none;
+      /* Re-establish the grid the wide layout replaced with a centered flex
+       column. Narrow steps read like the vertical orientation: marker in
+       column 1, body in column 2, connector running down column 1. */
+      display: grid;
       grid-template-columns: auto 1fr;
       grid-template-rows: auto 1fr;
       gap: 0 var(--cinder-space-3);
     }
 
+    .cinder-steps[data-cinder-orientation='horizontal'] .cinder-steps__marker {
+      /* Drop the wide layout's stacking context; the marker is back in flow. */
+      position: static;
+      z-index: auto;
+    }
+
     .cinder-steps[data-cinder-orientation='horizontal'] .cinder-steps__connector {
+      /* Undo the wide layout's absolute, behind-the-marker connector and return
+       to an in-flow vertical line beneath the marker. */
+      position: static;
+      inset-inline-start: auto;
+      top: auto;
+      z-index: auto;
       grid-column: 1;
       grid-row: 2;
       justify-self: center;
       width: 1px;
+      height: auto;
       min-height: var(--cinder-space-6);
       margin-inline-start: 0;
       align-self: stretch;
     }
 
     .cinder-steps[data-cinder-orientation='horizontal'] .cinder-steps__body {
+      /* Left-aligned beside the marker, undoing the wide layout's centering. */
+      text-align: start;
+      align-items: stretch;
+      max-width: none;
       grid-column: 2;
       grid-row: 1 / span 2;
       padding-bottom: var(--cinder-space-4);

--- a/packages/components/src/components/steps/steps.test.ts
+++ b/packages/components/src/components/steps/steps.test.ts
@@ -405,6 +405,9 @@ describe('Steps — narrow horizontal fallback (CSS contract)', () => {
       /\.cinder-steps\[data-cinder-orientation='horizontal'\]\s*\.cinder-steps__item\s*\{/,
     );
     expect(body).toMatch(/display:\s*grid;/);
+    // Must reset align-items so the wide flex-column value (center) does not
+    // vertically center grid items, which would float labels mid-track.
+    expect(body).toMatch(/align-items:\s*stretch;/);
   });
 
   test('narrow connector returns to an in-flow vertical line under the marker', () => {

--- a/packages/components/src/components/steps/steps.test.ts
+++ b/packages/components/src/components/steps/steps.test.ts
@@ -8,6 +8,10 @@ setupHappyDom();
 const { render } = await import('@testing-library/svelte');
 const { default: Steps } = await import('./steps.svelte');
 
+// Read once at module load — `describe` callbacks are synchronous, so the
+// CSS-contract tests below reference this constant instead of awaiting inside them.
+const stepsCss = await Bun.file(new URL('./steps.css', import.meta.url)).text();
+
 const defaultSteps = [
   { id: 'a', label: 'Set up profile', description: 'Tell us about yourself' },
   { id: 'b', label: 'Connect account', description: 'Link your services' },
@@ -305,11 +309,115 @@ describe('Steps — interactive step items', () => {
     expect(container.querySelector('li[aria-current="step"]')).not.toBeNull();
   });
 
-  test('vertical interactive step bodies preserve static bottom spacing', async () => {
-    const css = await Bun.file(new URL('./steps.css', import.meta.url)).text();
-
-    expect(css).toMatch(
+  test('vertical interactive step bodies preserve static bottom spacing', () => {
+    expect(stepsCss).toMatch(
       /\.cinder-steps\[data-cinder-orientation='vertical'\]\s*\.cinder-steps__interactive\.cinder-steps__body\s*\{[^}]*padding-bottom:\s*var\(--cinder-space-4\);/m,
     );
+  });
+});
+
+// Layout geometry is not observable in happy-dom (no layout engine), so these
+// pin the CSS contract by reading steps.css as text — the same approach the
+// vertical-spacing test above uses. They guard the wide-horizontal "each step
+// reads as one centered unit" design and the narrow stacked fallback.
+describe('Steps — horizontal layout geometry (CSS contract)', () => {
+  /** Extract the body of the first rule whose selector matches `selectorRegex`. */
+  const ruleBody = (selectorRegex: RegExp): string => {
+    const source = stepsCss.slice(stepsCss.search(selectorRegex));
+    const open = source.indexOf('{');
+    const close = source.indexOf('}', open);
+    expect(open).toBeGreaterThan(-1);
+    expect(close).toBeGreaterThan(open);
+    return source.slice(open + 1, close);
+  };
+
+  test('horizontal item is a centered flex column so marker + label read as a unit', () => {
+    const body = ruleBody(
+      /\.cinder-steps\[data-cinder-orientation='horizontal'\]\s*\.cinder-steps__item\s*\{/,
+    );
+    expect(body).toMatch(/display:\s*flex;/);
+    expect(body).toMatch(/flex-direction:\s*column;/);
+    expect(body).toMatch(/align-items:\s*center;/);
+    // Must be positioned so the absolutely-positioned connector anchors to it.
+    expect(body).toMatch(/position:\s*relative;/);
+    // Equal-width columns keep every marker at the center of its track share.
+    expect(body).toMatch(/flex:\s*1 1 0;/);
+  });
+
+  test('horizontal connector spans from this marker center to the next marker center', () => {
+    const body = ruleBody(
+      /\.cinder-steps\[data-cinder-orientation='horizontal'\]\s*\.cinder-steps__connector\s*\{/,
+    );
+    expect(body).toMatch(/position:\s*absolute;/);
+    // Starts at this marker's center (50%) and runs one full item-width to the
+    // next center (100%). Logical inset keeps it correct under RTL.
+    expect(body).toMatch(/inset-inline-start:\s*50%;/);
+    expect(body).toMatch(/width:\s*100%;/);
+    // Painted as a thin line behind the markers.
+    expect(body).toMatch(/z-index:\s*0;/);
+  });
+
+  test('horizontal marker stacks above the connector line passing behind it', () => {
+    const body = ruleBody(
+      /\.cinder-steps\[data-cinder-orientation='horizontal'\]\s*\.cinder-steps__marker\s*\{/,
+    );
+    expect(body).toMatch(/position:\s*relative;/);
+    expect(body).toMatch(/z-index:\s*1;/);
+  });
+
+  test('horizontal body centers its label and description under the marker', () => {
+    const body = ruleBody(
+      /\.cinder-steps\[data-cinder-orientation='horizontal'\]\s*\.cinder-steps__body\s*\{/,
+    );
+    expect(body).toMatch(/text-align:\s*center;/);
+    expect(body).toMatch(/align-items:\s*center;/);
+  });
+});
+
+describe('Steps — narrow horizontal fallback (CSS contract)', () => {
+  // The narrow container query must fully undo the wide flex column and return
+  // to the grid-based vertical-style layout. This guards the exact regression
+  // where the flex base left the narrow connector collapsed to a stub.
+  const narrowBlock = (() => {
+    const start = stepsCss.search(/@container cinder-steps \(max-width: 32rem\)/);
+    expect(start).toBeGreaterThan(-1);
+    // The container query is the last block in the file; take everything after it.
+    return stepsCss.slice(start);
+  })();
+
+  const ruleBody = (selectorRegex: RegExp): string => {
+    const source = narrowBlock.slice(narrowBlock.search(selectorRegex));
+    const open = source.indexOf('{');
+    const close = source.indexOf('}', open);
+    expect(open).toBeGreaterThan(-1);
+    expect(close).toBeGreaterThan(open);
+    return source.slice(open + 1, close);
+  };
+
+  test('narrow item re-establishes the grid the wide flex column replaced', () => {
+    const body = ruleBody(
+      /\.cinder-steps\[data-cinder-orientation='horizontal'\]\s*\.cinder-steps__item\s*\{/,
+    );
+    expect(body).toMatch(/display:\s*grid;/);
+  });
+
+  test('narrow connector returns to an in-flow vertical line under the marker', () => {
+    const body = ruleBody(
+      /\.cinder-steps\[data-cinder-orientation='horizontal'\]\s*\.cinder-steps__connector\s*\{/,
+    );
+    // Undo the wide layout's absolute positioning…
+    expect(body).toMatch(/position:\s*static;/);
+    expect(body).toMatch(/inset-inline-start:\s*auto;/);
+    // …and place it as a vertical line in grid row 2 below the marker.
+    expect(body).toMatch(/grid-row:\s*2;/);
+    expect(body).toMatch(/width:\s*1px;/);
+    expect(body).toMatch(/align-self:\s*stretch;/);
+  });
+
+  test('narrow body left-aligns beside the marker, undoing the centered wide layout', () => {
+    const body = ruleBody(
+      /\.cinder-steps\[data-cinder-orientation='horizontal'\]\s*\.cinder-steps__body\s*\{/,
+    );
+    expect(body).toMatch(/text-align:\s*start;/);
   });
 });

--- a/packages/components/src/components/steps/steps.test.ts
+++ b/packages/components/src/components/steps/steps.test.ts
@@ -323,7 +323,9 @@ describe('Steps — interactive step items', () => {
 describe('Steps — horizontal layout geometry (CSS contract)', () => {
   /** Extract the body of the first rule whose selector matches `selectorRegex`. */
   const ruleBody = (selectorRegex: RegExp): string => {
-    const source = stepsCss.slice(stepsCss.search(selectorRegex));
+    const pos = stepsCss.search(selectorRegex);
+    expect(pos, `selector not found: ${selectorRegex}`).toBeGreaterThan(-1);
+    const source = stepsCss.slice(pos);
     const open = source.indexOf('{');
     const close = source.indexOf('}', open);
     expect(open).toBeGreaterThan(-1);
@@ -380,13 +382,17 @@ describe('Steps — narrow horizontal fallback (CSS contract)', () => {
   // where the flex base left the narrow connector collapsed to a stub.
   const narrowBlock = (() => {
     const start = stepsCss.search(/@container cinder-steps \(max-width: 32rem\)/);
-    expect(start).toBeGreaterThan(-1);
+    expect(start, '@container cinder-steps (max-width: 32rem) not found in CSS').toBeGreaterThan(
+      -1,
+    );
     // The container query is the last block in the file; take everything after it.
     return stepsCss.slice(start);
   })();
 
   const ruleBody = (selectorRegex: RegExp): string => {
-    const source = narrowBlock.slice(narrowBlock.search(selectorRegex));
+    const pos = narrowBlock.search(selectorRegex);
+    expect(pos, `selector not found in narrow block: ${selectorRegex}`).toBeGreaterThan(-1);
+    const source = narrowBlock.slice(pos);
     const open = source.indexOf('{');
     const close = source.indexOf('}', open);
     expect(open).toBeGreaterThan(-1);


### PR DESCRIPTION
## Summary

Redesigns the wide horizontal Steps layout so each step reads as a centered unit: the marker sits at the top of its track share, with the label and description centered directly beneath it. Replaces the prior grid layout where labels clustered at each item's left edge while markers drifted to the connector end — especially visible on steps 2+ which showed a clear marker/label disconnect.

- Each `.cinder-steps__item` is now a centered flex column (`flex-direction: column; align-items: center; position: relative`)
- Connector runs as an absolutely-positioned `1px` line between adjacent marker centers (`inset-inline-start: 50%; width: 100%`) — correct for equal-width flex items
- Marker has `z-index: 1` so it reads cleanly above the connector line passing behind it
- Narrow container-query fallback (`≤32rem`) explicitly re-establishes `display: grid` and resets the connector to `position: static` with vertical grid placement — fixes the regression where the flex base left the narrow connector collapsed to a stub
- Marker diameter extracted to `--_marker-size` CSS custom property so the connector `top: calc(var(--_marker-size) / 2)` stays in sync if the marker size ever changes
- Equal-width flex invariant documented in the connector rule comment

Adds 7 CSS-contract regression tests (following the established `ruleBody()` pattern) pinning both the wide centered-unit geometry and the narrow grid fallback, with labeled `expect()` messages for selector-not-found diagnostics.

## Review committee

Pre-reviewed by: ux-designer, testing-expert, codex (gpt-5.4, xhigh reasoning)
- 2 rounds of review
- All suggestions addressed: marker-size custom property, equal-width invariant comment, labeled test assertions
- Codex APPROVED in round 2; testing-expert APPROVED in round 1; ux-designer confirmed APPROVED after narrow-block clarification

## Test plan

- `bun run --filter=cinder test -- steps` → 29/29 pass, 128 assertions
- Visual (dark, full width): markers centered over labels, connectors running between marker centers ✓
- Visual (dark, 375px mobile): vertical stack, vertical connector line, left-aligned body ✓
- Visual (light, full width): same centered-unit layout ✓

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only layout and stylesheet tests in the Steps component; no auth, data, or API changes.
> 
> **Overview**
> **Redesigns wide horizontal `Steps`** so each step is a centered column: marker on top, label/description centered underneath, with connectors drawn as a line between adjacent marker centers (absolute positioning + stacking).
> 
> Introduces **`--_marker-size`** so marker diameter and connector vertical alignment stay linked. The **`≤32rem` container query** now fully resets the wide flex layout back to grid and restores an in-flow vertical connector—fixing the narrow-view regression where the connector collapsed.
> 
> Adds **CSS-contract regression tests** (reading `steps.css` as text) for the wide geometry and narrow fallback, reusing a module-level `stepsCss` load.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 25cfc1a07ec29d1d68c73d72bc11efc16cf3c1f2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->