### PR TITLE
fix(css): wire missing @import chains for compound component style deps

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -785,6 +785,9 @@
       "node": "./dist/server/components/command-item/command-item.variables.js",
       "default": "./dist/components/command-item/command-item.variables.js"
     },
+    "./command-item/styles": {
+      "default": "./dist/components/command-item/command-item.css"
+    },
     "./command-menu": {
       "types": "./dist/components/command-menu/index.d.ts",
       "svelte": "./src/components/command-menu/index.ts",

--- a/packages/components/scripts/check-compound-css.test.ts
+++ b/packages/components/scripts/check-compound-css.test.ts
@@ -1,0 +1,127 @@
+/**
+ * Regression tests for compound-component CSS dependency contracts.
+ *
+ * A compound component is self-sufficient when importing its namespace style
+ * path (`cinder/<name>`) styles all public leaf components it renders.
+ * Previously some parent namespaces were missing @import statements for their
+ * leaf component styles, so consumers had to import both parent and leaf
+ * separately — breaking the contract.
+ *
+ * Each test reads the parent CSS file as text and asserts the required @import
+ * is present, confirming the import chain is wired without needing to run the
+ * full build. This is the mechanical guard requested by task e4f2e104.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const COMPONENTS = join(import.meta.dir, '../src/components');
+
+function readCss(componentPath: string): string {
+  return readFileSync(join(COMPONENTS, componentPath), 'utf-8');
+}
+
+describe('Compound component CSS dependency contracts', () => {
+  describe('CommandMenu — imports CommandItem styles', () => {
+    const commandMenuCss = readCss('command-menu/command-menu.css');
+
+    test('command-menu.css @imports command-item.css', () => {
+      expect(commandMenuCss).toMatch(/@import\s+['"]\.\.\/command-item\/command-item\.css['"]/);
+    });
+  });
+
+  describe('CommandPalette — imports CommandItem styles', () => {
+    const commandPaletteCss = readCss('command-palette/command-palette.css');
+
+    test('command-palette.css @imports command-item.css', () => {
+      expect(commandPaletteCss).toMatch(/@import\s+['"]\.\.\/command-item\/command-item\.css['"]/);
+    });
+
+    test('CommandItem rules are NOT duplicated inline in command-palette.css', () => {
+      // The rules were extracted to command-item.css. If someone later moves them
+      // back AND forgets to remove the @import, both tests catch the duplication.
+      // This assertion confirms the extraction is in effect.
+      expect(commandPaletteCss).not.toMatch(/\.cinder-command-item\s*\{[^@]/);
+    });
+  });
+
+  describe('CommandItem — has its own CSS sidecar', () => {
+    const commandItemCss = readCss('command-item/command-item.css');
+
+    test('command-item.css exists and contains .cinder-command-item rules', () => {
+      expect(commandItemCss).toMatch(/\.cinder-command-item\s*\{/);
+    });
+
+    test('command-item.css carries the correct layer prelude', () => {
+      expect(commandItemCss).toMatch(
+        /@layer cinder\.tokens, cinder\.foundation, cinder\.components, cinder\.utilities;/,
+      );
+    });
+  });
+
+  describe('ContextMenu — imports Dropdown styles', () => {
+    const contextMenuCss = readCss('context-menu/context-menu.css');
+
+    test('context-menu.css @imports dropdown.css', () => {
+      // ContextMenu renders DropdownItem, DropdownMenu, DropdownGroup, DropdownLabel,
+      // and DropdownSeparator. Their styles live in dropdown/dropdown.css.
+      expect(contextMenuCss).toMatch(/@import\s+['"]\.\.\/dropdown\/dropdown\.css['"]/);
+    });
+  });
+
+  describe('MenuBar — imports Dropdown styles', () => {
+    const menuBarCss = readCss('menu-bar/menu-bar.css');
+
+    test('menu-bar.css @imports dropdown.css', () => {
+      // MenuBar renders DropdownItem as its overflow-menu items.
+      expect(menuBarCss).toMatch(/@import\s+['"]\.\.\/dropdown\/dropdown\.css['"]/);
+    });
+  });
+
+  describe('SideNavigation — imports NavigationItem styles', () => {
+    const sideNavigationCss = readCss('side-navigation/side-navigation.css');
+
+    test('side-navigation.css @imports navigation-item.css', () => {
+      // SideNavigationItem delegates rendering to NavigationItem.
+      expect(sideNavigationCss).toMatch(
+        /@import\s+['"]\.\.\/navigation-item\/navigation-item\.css['"]/,
+      );
+    });
+
+    test('side-navigation.css still @imports side-navigation-group.css', () => {
+      // Pre-existing import that must not be removed.
+      expect(sideNavigationCss).toMatch(
+        /@import\s+['"]\.\.\/side-navigation-group\/side-navigation-group\.css['"]/,
+      );
+    });
+  });
+
+  describe('Already self-sufficient: Tabs', () => {
+    const tabsCss = readCss('tabs/tabs.css');
+
+    test('tabs.css @imports tab.css', () => {
+      expect(tabsCss).toMatch(/@import\s+['"]\.\.\/tab\/tab\.css['"]/);
+    });
+
+    test('tabs.css @imports tab-list.css', () => {
+      expect(tabsCss).toMatch(/@import\s+['"]\.\.\/tab-list\/tab-list\.css['"]/);
+    });
+
+    test('tabs.css @imports tab-panel.css', () => {
+      expect(tabsCss).toMatch(/@import\s+['"]\.\.\/tab-panel\/tab-panel\.css['"]/);
+    });
+  });
+
+  describe('Already self-sufficient: Table', () => {
+    const tableCss = readCss('table/table.css');
+
+    test('table.css @imports table-row.css', () => {
+      expect(tableCss).toMatch(/@import\s+['"]\.\.\/table-row\/table-row\.css['"]/);
+    });
+
+    test('table.css @imports table-header.css', () => {
+      expect(tableCss).toMatch(/@import\s+['"]\.\.\/table-header\/table-header\.css['"]/);
+    });
+  });
+});

--- a/packages/components/scripts/check-compound-css.test.ts
+++ b/packages/components/scripts/check-compound-css.test.ts
@@ -1,8 +1,8 @@
 /**
  * Regression tests for compound-component CSS dependency contracts.
  *
- * A compound component is self-sufficient when importing its namespace style
- * path (`cinder/<name>`) styles all public leaf components it renders.
+ * A compound component is self-sufficient when importing its CSS style subpath
+ * (`cinder/<name>/styles`) styles all public leaf components it renders.
  * Previously some parent namespaces were missing @import statements for their
  * leaf component styles, so consumers had to import both parent and leaf
  * separately — breaking the contract.

--- a/packages/components/src/components/command-item/command-item.css
+++ b/packages/components/src/components/command-item/command-item.css
@@ -1,0 +1,96 @@
+@layer cinder.tokens, cinder.foundation, cinder.components, cinder.utilities;
+@layer cinder.components {
+  /* ========================================
+ * COMMAND ITEM
+ * Styles for the CommandItem leaf component used by CommandMenu and
+ * CommandPalette. Extracted here so both parent namespaces can import it
+ * without duplicating rules.
+ * ======================================== */
+
+  .cinder-command-item {
+    position: relative;
+    display: flex;
+    align-items: center;
+    gap: var(--cinder-space-3);
+    overflow: hidden;
+    min-block-size: 2.75rem;
+    padding: var(--cinder-space-2-5) var(--cinder-space-5);
+    cursor: pointer;
+    border-radius: 0;
+    margin: 0;
+    font-size: var(--cinder-text-base);
+    color: var(--cinder-text);
+    user-select: none;
+    transition:
+      background-color var(--cinder-duration-fast) var(--cinder-ease-standard),
+      color var(--cinder-duration-fast) var(--cinder-ease-standard);
+  }
+
+  .cinder-command-item[data-cinder-active] {
+    background: var(--cinder-accent);
+    color: var(--cinder-accent-contrast);
+  }
+
+  @media (forced-colors: active) {
+    .cinder-command-item[data-cinder-active] {
+      background: Highlight;
+      color: HighlightText;
+      box-shadow: none;
+      outline: 2px solid Highlight;
+      outline-offset: -2px;
+    }
+  }
+
+  .cinder-command-item[data-cinder-disabled] {
+    opacity: 0.45;
+    cursor: not-allowed;
+    pointer-events: none;
+  }
+
+  .cinder-command-item__leading {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+    inline-size: 2rem;
+    block-size: 2rem;
+    border-radius: var(--cinder-radius-md);
+    background: color-mix(in oklch, currentColor 10%, transparent);
+    color: var(--cinder-text-muted);
+  }
+
+  .cinder-command-item[data-cinder-active] .cinder-command-item__leading {
+    color: currentColor;
+  }
+
+  .cinder-command-item__content {
+    flex: 1;
+    min-width: 0;
+    display: flex;
+    flex-direction: column;
+    gap: var(--cinder-space-0-5);
+  }
+
+  .cinder-command-item__description {
+    color: var(--cinder-text-muted);
+    font-size: var(--cinder-text-xs);
+    line-height: var(--cinder-leading-normal);
+  }
+
+  .cinder-command-item[data-cinder-active] .cinder-command-item__description {
+    color: currentColor;
+  }
+
+  .cinder-command-item__trailing {
+    display: inline-flex;
+    align-items: center;
+    flex-shrink: 0;
+    margin-inline-start: auto;
+    color: var(--cinder-text-muted);
+    font-size: var(--cinder-text-xs);
+  }
+
+  .cinder-command-item[data-cinder-active] .cinder-command-item__trailing {
+    color: currentColor;
+  }
+}

--- a/packages/components/src/components/command-item/index.ts
+++ b/packages/components/src/components/command-item/index.ts
@@ -1,3 +1,4 @@
+import './command-item.css';
 import CommandItem from './command-item.svelte';
 
 export default CommandItem;

--- a/packages/components/src/components/command-menu/command-menu.css
+++ b/packages/components/src/components/command-menu/command-menu.css
@@ -1,4 +1,8 @@
 @layer cinder.tokens, cinder.foundation, cinder.components, cinder.utilities;
+/* CommandMenu renders CommandItem as its list entries. Pull in CommandItem
+ * styles so that importing `cinder/command-menu` is self-sufficient. */
+@import '../command-item/command-item.css';
+
 @layer cinder.components {
   /* ========================================
  * COMMAND MENU

--- a/packages/components/src/components/command-palette/command-palette.css
+++ b/packages/components/src/components/command-palette/command-palette.css
@@ -1,4 +1,8 @@
 @layer cinder.tokens, cinder.foundation, cinder.components, cinder.utilities;
+/* CommandItem styles live in their own sidecar. Pull them in here so that
+ * importing `cinder/command-palette` brings in CommandItem styles. */
+@import '../command-item/command-item.css';
+
 @layer cinder.components {
   /* ========================================
  * COMMAND PALETTE
@@ -168,96 +172,9 @@
     color: var(--cinder-text-muted);
   }
 
-  /* ========================================
- * COMMAND ITEM
- * ======================================== */
-
-  .cinder-command-item {
-    position: relative;
-    display: flex;
-    align-items: center;
-    gap: var(--cinder-space-3);
-    overflow: hidden;
-    min-block-size: 2.75rem;
-    padding: var(--cinder-space-2-5) var(--cinder-space-5);
-    cursor: pointer;
-    border-radius: 0;
-    margin: 0;
-    font-size: var(--cinder-text-base);
-    color: var(--cinder-text);
-    user-select: none;
-    transition:
-      background-color var(--cinder-duration-fast) var(--cinder-ease-standard),
-      color var(--cinder-duration-fast) var(--cinder-ease-standard);
-  }
-
-  .cinder-command-item[data-cinder-active] {
-    background: var(--cinder-accent);
-    color: var(--cinder-accent-contrast);
-  }
-
-  @media (forced-colors: active) {
-    .cinder-command-item[data-cinder-active] {
-      background: Highlight;
-      color: HighlightText;
-      box-shadow: none;
-      outline: 2px solid Highlight;
-      outline-offset: -2px;
-    }
-  }
-
-  .cinder-command-item[data-cinder-disabled] {
-    opacity: 0.45;
-    cursor: not-allowed;
-    pointer-events: none;
-  }
-
-  .cinder-command-item__leading {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    flex-shrink: 0;
-    inline-size: 2rem;
-    block-size: 2rem;
-    border-radius: var(--cinder-radius-md);
-    background: color-mix(in oklch, currentColor 10%, transparent);
-    color: var(--cinder-text-muted);
-  }
-
-  .cinder-command-item[data-cinder-active] .cinder-command-item__leading {
-    color: currentColor;
-  }
-
-  .cinder-command-item__content {
-    flex: 1;
-    min-width: 0;
-    display: flex;
-    flex-direction: column;
-    gap: var(--cinder-space-0-5);
-  }
-
-  .cinder-command-item__description {
-    color: var(--cinder-text-muted);
-    font-size: var(--cinder-text-xs);
-    line-height: var(--cinder-leading-normal);
-  }
-
-  .cinder-command-item[data-cinder-active] .cinder-command-item__description {
-    color: currentColor;
-  }
-
-  .cinder-command-item__trailing {
-    display: inline-flex;
-    align-items: center;
-    flex-shrink: 0;
-    margin-inline-start: auto;
-    color: var(--cinder-text-muted);
-    font-size: var(--cinder-text-xs);
-  }
-
-  .cinder-command-item[data-cinder-active] .cinder-command-item__trailing {
-    color: currentColor;
-  }
+  /* CommandItem styles have been extracted to command-item/command-item.css
+   * so both CommandPalette and CommandMenu can @import them without
+   * duplicating rules. The import is placed outside the @layer block above. */
 
   /* ----------------------------------------
  * Reduced motion — panel enter animation

--- a/packages/components/src/components/command-palette/command-palette.test.ts
+++ b/packages/components/src/components/command-palette/command-palette.test.ts
@@ -737,15 +737,23 @@ describe('CommandPalette — visual contract', () => {
   });
 
   test('listbox has correct padding and command items span full width', async () => {
-    const css = await Bun.file(new URL('./command-palette.css', import.meta.url)).text();
+    const paletteCss = await Bun.file(new URL('./command-palette.css', import.meta.url)).text();
+    // CommandItem rules were extracted to command-item/command-item.css so both
+    // CommandPalette and CommandMenu can import them without duplication.
+    const commandItemCss = await Bun.file(
+      new URL('../command-item/command-item.css', import.meta.url),
+    ).text();
 
-    expect(css).toMatch(
+    expect(paletteCss).toMatch(
       /\.cinder-command-palette__listbox\s*\{[\s\S]*?padding:\s*var\(--cinder-space-2\)\s*0;/,
     );
-    expect(css).toMatch(/\.cinder-command-item\s*\{[\s\S]*?margin:\s*0;/);
-    expect(css).toMatch(
+    // CommandItem rules now live in command-item.css (imported by command-palette.css).
+    expect(commandItemCss).toMatch(/\.cinder-command-item\s*\{[\s\S]*?margin:\s*0;/);
+    expect(commandItemCss).toMatch(
       /\.cinder-command-item\[data-cinder-active\]\s*\{[\s\S]*?background:\s*var\(--cinder-accent\);[\s\S]*?color:\s*var\(--cinder-accent-contrast\);/,
     );
+    // Confirm command-palette.css now @imports command-item.css (import chain).
+    expect(paletteCss).toMatch(/@import\s+['"]\.\.\/command-item\/command-item\.css['"]/);
   });
 });
 

--- a/packages/components/src/components/context-menu/context-menu.css
+++ b/packages/components/src/components/context-menu/context-menu.css
@@ -1,4 +1,10 @@
 @layer cinder.tokens, cinder.foundation, cinder.components, cinder.utilities;
+/* ContextMenu renders DropdownItem, DropdownMenu, DropdownGroup, DropdownLabel,
+ * and DropdownSeparator as its leaf components. Pull in their styles so that
+ * importing `cinder/context-menu` is self-sufficient without a separate
+ * `cinder/dropdown` import. */
+@import '../dropdown/dropdown.css';
+
 @layer cinder.components {
   .cinder-context-menu {
     display: contents;

--- a/packages/components/src/components/menu-bar/menu-bar.css
+++ b/packages/components/src/components/menu-bar/menu-bar.css
@@ -1,4 +1,9 @@
 @layer cinder.tokens, cinder.foundation, cinder.components, cinder.utilities;
+/* MenuBar renders DropdownItem, DropdownMenu, DropdownGroup, DropdownLabel,
+ * and DropdownSeparator inside its overflow menus. Pull in their styles so
+ * that importing `cinder/menu-bar` is self-sufficient. */
+@import '../dropdown/dropdown.css';
+
 @layer cinder.components {
   .cinder-menu-bar {
     display: flex;

--- a/packages/components/src/components/side-navigation/side-navigation.css
+++ b/packages/components/src/components/side-navigation/side-navigation.css
@@ -1,8 +1,11 @@
 @layer cinder.tokens, cinder.foundation, cinder.components, cinder.utilities;
 /* Compound family aggregation: importing `cinder/side-navigation/styles` pulls
- * in SideNavigationGroup. Sibling-leaf paths resolve identically in `src/` and
- * the verbatim-copied `dist/` because the layout mirrors. */
+ * in SideNavigationGroup and NavigationItem. SideNavigationItem delegates its
+ * rendering to NavigationItem, so its styles must be included here.
+ * Sibling-leaf paths resolve identically in `src/` and the verbatim-copied
+ * `dist/` because the layout mirrors. */
 @import '../side-navigation-group/side-navigation-group.css';
+@import '../navigation-item/navigation-item.css';
 
 @layer cinder.components {
   /* ========================================


### PR DESCRIPTION
## Summary

Four compound component namespaces were missing `@import` statements for their leaf component styles, breaking the documented contract (AGENTS.md §Compound components): "parent CSS aggregates the family" via `@import` statements. Consumers importing `cinder/context-menu`, `cinder/menu-bar`, `cinder/side-navigation`, or `cinder/command-menu` received no styles for the leaf components those surfaces render.

**Fixes:**
- `context-menu.css` → `@import '../dropdown/dropdown.css'` (ContextMenu renders DropdownItem, DropdownMenu, DropdownLabel, DropdownSeparator)
- `menu-bar.css` → `@import '../dropdown/dropdown.css'` (MenuBar renders DropdownItem in its overflow menus)
- `side-navigation.css` → `@import '../navigation-item/navigation-item.css'` (SideNavigationItem delegates rendering to NavigationItem)
- `command-menu.css` → `@import '../command-item/command-item.css'` (CommandMenu renders CommandItem as its list entries)

**CommandItem extraction:**
- Extracts `.cinder-command-item` rules (90 lines) from `command-palette.css` into a dedicated `command-item/command-item.css` sidecar — eliminates duplication since both CommandPalette and CommandMenu need these styles
- `command-item/index.ts` imports `command-item.css` (following the universal project convention: every component with a CSS sidecar imports it from `index.ts`)
- Adds `./command-item/styles` to `package.json` exports

**Regression tests:** `scripts/check-compound-css.test.ts` (14 tests) asserts `@import` chains for all compound families — the same CSS-contract approach the rest of the test suite uses (text-matching the CSS source file).

## Review committee

Pre-reviewed by: simplicity-engineer, codex (gpt-5.4, xhigh reasoning)
- 1 round of review
- All "must-fix" items were false positives based on wrong premises or direct contradictions of established codebase patterns:
  - simplicity-engineer: assumed command-item.css was missing (it's in the commit); argued for integration tests (CSS-contract text tests are the established convention)
  - codex: flagged @layer-before-@import (PostCSS handles at build time; side-navigation.css uses the same pattern already), and flagged index.ts CSS import as inconsistent (it IS the universal convention — every component with a CSS sidecar does this)

## Test plan

- `bun run --filter=cinder test -- check-compound-css` → 14/14 pass
- `bun run --filter=cinder test -- command` → 75/75 pass (including updated command-palette.test.ts)
- `bun run --filter=cinder test -- exports-drift` → 5/5 pass
- `bun run --filter=cinder test -- context-menu` → 31/31 pass
- `bun run --filter=cinder test -- side-navigation` → 52/52 pass

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CSS packaging and style aggregation only; no runtime, auth, or data-path changes—risk is limited to missing or duplicate styles if imports regress.
> 
> **Overview**
> Restores the **compound component** CSS contract: importing a parent `cinder/<name>/styles` path again bundles styles for the leaf components that parent renders, without requiring separate leaf style imports.
> 
> **New `@import` wiring:** `context-menu.css` and `menu-bar.css` pull in `dropdown.css`; `side-navigation.css` adds `navigation-item.css` (alongside existing `side-navigation-group`); `command-menu.css` and `command-palette.css` pull in `command-item.css`.
> 
> **CommandItem extraction:** `.cinder-command-item` rules move out of `command-palette.css` into a dedicated `command-item/command-item.css` sidecar (imported from `command-item/index.ts`), with a new **`./command-item/styles`** package export so both command parents share one source of truth.
> 
> **Regression guard:** `scripts/check-compound-css.test.ts` asserts required `@import` chains (and that palette no longer inlines command-item rules); `command-palette.test.ts` is updated to assert against the split files.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 89d0fd889662f018ec80b15f80b9a7383ea12082. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->