### PR TITLE
fix(tokens): replace undeclared CSS token references with canonical names

### DIFF
--- a/packages/components/src/components/autocomplete/autocomplete.css
+++ b/packages/components/src/components/autocomplete/autocomplete.css
@@ -8,7 +8,7 @@
   .cinder-autocomplete__label {
     color: var(--cinder-text);
     font-size: var(--cinder-text-sm);
-    font-weight: var(--cinder-font-weight-medium);
+    font-weight: var(--cinder-font-medium);
   }
 
   .cinder-autocomplete__input {
@@ -68,7 +68,7 @@
   }
 
   .cinder-autocomplete__option-label {
-    font-weight: var(--cinder-font-weight-medium);
+    font-weight: var(--cinder-font-medium);
   }
 
   .cinder-autocomplete__option-description {

--- a/packages/components/src/components/callout/callout.css
+++ b/packages/components/src/components/callout/callout.css
@@ -74,7 +74,7 @@
 
   .cinder-callout__title {
     margin: 0 0 var(--cinder-space-1);
-    font-weight: var(--cinder-font-weight-semibold, 600);
+    font-weight: var(--cinder-font-semibold);
     line-height: var(--cinder-leading-snug, 1.3);
     color: inherit;
   }

--- a/packages/components/src/components/feed/feed.css
+++ b/packages/components/src/components/feed/feed.css
@@ -31,7 +31,7 @@
     inline-size: var(--cinder-feed-rail-size);
     block-size: var(--cinder-feed-rail-size);
     border-radius: var(--cinder-radius-full);
-    background: var(--cinder-surface-muted);
+    background: var(--cinder-surface-inset);
     color: var(--cinder-text-muted);
     flex-shrink: 0;
   }

--- a/packages/components/src/components/file-upload/file-upload.css
+++ b/packages/components/src/components/file-upload/file-upload.css
@@ -83,7 +83,7 @@
     min-block-size: 2.75rem;
     padding-inline: var(--cinder-space-4);
     padding-block: var(--cinder-space-2);
-    font-weight: var(--cinder-font-weight-semibold);
+    font-weight: var(--cinder-font-semibold);
   }
 
   .cinder-file-upload__hint {

--- a/packages/components/src/components/file-upload/file-upload.css
+++ b/packages/components/src/components/file-upload/file-upload.css
@@ -64,7 +64,7 @@
     gap: var(--cinder-space-2);
     color: var(--cinder-text);
     font-size: var(--cinder-text-sm);
-    font-weight: var(--cinder-font-weight-medium);
+    font-weight: var(--cinder-font-medium);
   }
 
   .cinder-file-upload__eyebrow-icon {
@@ -127,7 +127,7 @@
     overflow-wrap: anywhere;
     color: var(--cinder-text);
     font-size: var(--cinder-text-sm);
-    font-weight: var(--cinder-font-weight-medium);
+    font-weight: var(--cinder-font-medium);
   }
 
   .cinder-file-upload__file-size {

--- a/packages/components/src/components/hover-card/hover-card.css
+++ b/packages/components/src/components/hover-card/hover-card.css
@@ -19,8 +19,8 @@
     opacity: 0;
     transform: translateY(2px) scale(0.98);
     transition:
-      opacity var(--cinder-duration-fast) var(--cinder-ease-out),
-      transform var(--cinder-duration-fast) var(--cinder-ease-out);
+      opacity var(--cinder-duration-fast) var(--cinder-ease-standard),
+      transform var(--cinder-duration-fast) var(--cinder-ease-standard);
   }
 
   /* Reset browser-default paragraph margins on first/last flow children so

--- a/packages/components/src/components/modal/modal.css
+++ b/packages/components/src/components/modal/modal.css
@@ -9,7 +9,7 @@
     margin: auto;
     padding: 0;
     border: none;
-    border-radius: var(--cinder-radius-xl);
+    border-radius: var(--cinder-radius-lg);
     background: transparent;
     color: var(--cinder-text);
     max-width: min(90vw, 32rem);
@@ -36,7 +36,7 @@
     flex-direction: column;
     background: var(--cinder-surface-raised);
     border: 1px solid var(--cinder-border);
-    border-radius: var(--cinder-radius-xl);
+    border-radius: var(--cinder-radius-lg);
     box-shadow: var(--cinder-shadow-lg);
     max-height: inherit;
     overflow: hidden;

--- a/packages/components/src/components/phone-input/phone-input.css
+++ b/packages/components/src/components/phone-input/phone-input.css
@@ -103,7 +103,7 @@
   .cinder-phone-input__national:disabled {
     cursor: not-allowed;
     color: var(--cinder-text-disabled);
-    background-color: var(--cinder-surface-muted);
+    background-color: var(--cinder-surface-inset);
   }
 
   @media (forced-colors: active) {

--- a/packages/components/src/components/pin-input/pin-input.css
+++ b/packages/components/src/components/pin-input/pin-input.css
@@ -73,7 +73,7 @@
   .cinder-pin-input__segment:disabled {
     cursor: not-allowed;
     color: var(--cinder-text-disabled);
-    background: var(--cinder-surface-muted);
+    background: var(--cinder-surface-inset);
   }
 
   @media (forced-colors: active) {


### PR DESCRIPTION
## Summary

Replaces undeclared CSS custom property references with their canonical equivalents from `tokens-base.css`. These tokens were referenced in component CSS but never declared, meaning they would silently resolve to nothing (or an inherited/fallback value) for consumers who override the design token set — defeating the themeability contract.

**Replacements:**

| Stale (undeclared) | Canonical (declared in tokens-base.css) | Files |
| --- | --- | --- |
| `--cinder-font-weight-semibold` | `--cinder-font-semibold` | `callout.css`, `file-upload.css` |
| `--cinder-font-weight-medium` | `--cinder-font-medium` | `autocomplete.css`, `file-upload.css` |
| `--cinder-ease-out` | `--cinder-ease-standard` | `hover-card.css` |
| `--cinder-radius-xl` | `--cinder-radius-lg` | `modal.css` |
| `--cinder-surface-muted` | `--cinder-surface-inset` | `feed.css`, `phone-input.css`, `pin-input.css` |

Rationale for each choice:
- `--cinder-font-semibold`/`--cinder-font-medium` — direct canonical names; other components (Button, Tabs, etc.) already use these correctly
- `--cinder-ease-standard` — Tooltip and Popover both use `--cinder-ease-standard` for opacity transitions; aligns HoverCard with the pattern
- `--cinder-radius-lg` — no `xl` variant exists; CommandPalette and other large overlay surfaces use `--cinder-radius-lg` (0.75rem)
- `--cinder-surface-inset` — the canonical subdued surface token; Input uses it for disabled state backgrounds (same semantic context as phone-input/pin-input)

This is the stale-token-rename slice of the themeability audit (`task 2f6e14c8`). The full themeability task continues with token classification, shared partials, and light/dark parity work.

## Review committee

Pre-reviewed by: frontend-architect, codex (gpt-5.4, xhigh reasoning)
- 1 round of review
- No must-fixes
- frontend-architect identified `--cinder-font-weight-medium` as same class of undeclared token → fixed in commit 2
- Codex noted radius-xl→radius-lg may change visible rounding; confirmed correct per CommandPalette precedent

## Test plan

- `bun run --filter=cinder test -- hover-card` → 48/48 pass
- `bun run --filter=cinder test -- modal` → 51/51 pass
- `bun run --filter=cinder test -- pin-input` → 34/34 pass
- `bun run --filter=cinder test -- callout` → 12/12 pass
- `bun run --filter=cinder test -- check-component-css-token` → 29/29 pass

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CSS-only token alias swaps with minor possible visual deltas (modal radius, inset backgrounds); no runtime or security impact.
> 
> **Overview**
> Component styles now reference **declared** design tokens from `tokens-base.css` instead of stale custom property names that were never defined, so theme overrides apply reliably instead of silently falling through.
> 
> **Typography:** `--cinder-font-weight-medium` / `--cinder-font-weight-semibold` → `--cinder-font-medium` / `--cinder-font-semibold` in autocomplete, callout, and file-upload.
> 
> **Motion:** Hover card open/close transitions use `--cinder-ease-standard` instead of undeclared `--cinder-ease-out`, matching tooltip/popover.
> 
> **Surfaces:** Feed event rails and disabled phone/pin fields use `--cinder-surface-inset` instead of `--cinder-surface-muted`.
> 
> **Shape:** Modal dialog and panel corners use `--cinder-radius-lg` (no `xl` token exists), aligning with other large overlays.
> 
> Callout title drops the redundant `600` fallback on semibold now that the canonical token is used.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 33b6b53ad3030f187d1c3ffff460ed429c669dd5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->