### PR TITLE
test(collapsible): pin aria-controls absent when closed (df33f5f5)

### DIFF
--- a/packages/components/src/components/collapsible/collapsible.test.ts
+++ b/packages/components/src/components/collapsible/collapsible.test.ts
@@ -60,6 +60,31 @@ describe('Collapsible (uncontrolled)', () => {
     expect(region?.getAttribute('aria-labelledby')).toBe(button.getAttribute('id'));
   });
 
+  test('omits aria-controls while closed so the reference never dangles', async () => {
+    // The panel is removed from the DOM when closed (the {#if} has no Transition
+    // layer keeping it mounted). aria-controls={open ? panelId : undefined} must
+    // therefore drop the attribute entirely when closed — pointing aria-controls
+    // at a non-existent id is an invalid ARIA reference. This component is the
+    // sole owner of that behavior since the Transition removal (bbb08520, #253).
+    const { container } = render(Collapsible, { trigger: 'Toggle', children: bodySnippet() });
+
+    // Closed by default: no panel in the DOM, no aria-controls on the trigger.
+    expect(panel(container)).toBeNull();
+    expect(trigger(container).hasAttribute('aria-controls')).toBe(false);
+
+    // Open → aria-controls appears and resolves to the live panel id.
+    await fireEvent.click(trigger(container));
+    const openPanelId = panel(container)?.getAttribute('id') ?? null;
+    expect(openPanelId).not.toBeNull();
+    expect(trigger(container).getAttribute('aria-controls')).toBe(openPanelId);
+
+    // Close again → the panel unmounts and aria-controls is dropped, not left
+    // pointing at the now-absent panel.
+    await fireEvent.click(trigger(container));
+    expect(panel(container)).toBeNull();
+    expect(trigger(container).hasAttribute('aria-controls')).toBe(false);
+  });
+
   test('renders initially open when open=true and toggles closed on click', async () => {
     const { container } = render(Collapsible, {
       trigger: 'Toggle',


### PR DESCRIPTION
## Summary

Adds a regression test asserting `aria-controls` is **absent** when the Collapsible is closed. `collapsible.svelte` sets `aria-controls={open ? panelId : undefined}` and the panel is removed from the DOM when closed — leaving `aria-controls` pointing at a now-absent id would be an invalid ARIA reference. The existing test only asserted the open-state value; this covers the full closed → open → closed lifecycle.

This component became the sole owner of that behavior after the Transition removal (bbb08520 / #253), where the `{#if}` no longer keeps the panel mounted.

The task also flagged a reduced-motion coverage gap. That `matches: true` branch is **already covered at the `use-reduced-motion.svelte.ts` hook level** (the task's preferred location), so no collapsible-level reduced-motion test was added.

## Review committee

Pre-reviewed by testing-expert — APPROVED.

## Test plan

`bun run --filter=cinder test -- collapsible` → 15/15 pass (+1 new).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change with no runtime behavior modifications.
> 
> **Overview**
> Adds a **regression test** for `Collapsible` so the trigger never keeps a dangling `aria-controls` when the panel is unmounted.
> 
> The new case walks **closed → open → closed** and asserts `aria-controls` is absent while closed, present and matching the live panel id when open, then removed again after close. That pins the existing `aria-controls={open ? panelId : undefined}` behavior now that the closed panel is not kept in the DOM (post–Transition removal).
> 
> No component or a11y implementation changes—test coverage only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d641814e0a12137a8aebb968c311ead6173fcd81. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->