### PR TITLE
fix(tokens): swap 3 undeclared tokens to canonical names; ratchet baselines (2f6e14c8)

### DIFF
--- a/packages/components/scripts/raw-color-baseline.json
+++ b/packages/components/scripts/raw-color-baseline.json
@@ -10,11 +10,6 @@
     "allowedCount": 2
   },
   {
-    "filePath": "src/components/autocomplete/autocomplete.css",
-    "colorClass": "oklch",
-    "allowedCount": 1
-  },
-  {
     "filePath": "src/components/chat/input/chat-input.svelte",
     "colorClass": "oklch",
     "allowedCount": 1
@@ -38,11 +33,6 @@
     "filePath": "src/components/input/input.css",
     "colorClass": "oklch",
     "allowedCount": 2
-  },
-  {
-    "filePath": "src/components/kanban-board/kanban-board.css",
-    "colorClass": "rgb",
-    "allowedCount": 1
   },
   {
     "filePath": "src/components/markdown-editor/markdown-editor.svelte",
@@ -73,11 +63,6 @@
     "filePath": "src/components/skeleton/skeleton.css",
     "colorClass": "oklch",
     "allowedCount": 1
-  },
-  {
-    "filePath": "src/components/sortable-list/sortable-list.css",
-    "colorClass": "rgb",
-    "allowedCount": 3
   },
   {
     "filePath": "src/components/spinner/spinner.css",

--- a/packages/components/scripts/token-usage-baseline.json
+++ b/packages/components/scripts/token-usage-baseline.json
@@ -1,18 +1,8 @@
 [
   {
-    "filePath": "src/components/autocomplete/autocomplete.css",
-    "name": "--cinder-font-weight-medium",
-    "allowedCount": 2
-  },
-  {
     "filePath": "src/components/avatar-group/avatar-group.css",
     "name": "--cinder-ring-offset-width",
     "allowedCount": 2
-  },
-  {
-    "filePath": "src/components/callout/callout.css",
-    "name": "--cinder-font-weight-semibold",
-    "allowedCount": 1
   },
   {
     "filePath": "src/components/chat/container/chat-jump-controls.svelte",
@@ -27,31 +17,6 @@
   {
     "filePath": "src/components/color-picker/color-picker.css",
     "name": "--cinder-text-secondary",
-    "allowedCount": 1
-  },
-  {
-    "filePath": "src/components/feed/feed.css",
-    "name": "--cinder-surface-muted",
-    "allowedCount": 1
-  },
-  {
-    "filePath": "src/components/file-upload/file-upload.css",
-    "name": "--cinder-font-weight-medium",
-    "allowedCount": 2
-  },
-  {
-    "filePath": "src/components/file-upload/file-upload.css",
-    "name": "--cinder-font-weight-semibold",
-    "allowedCount": 1
-  },
-  {
-    "filePath": "src/components/hover-card/hover-card.css",
-    "name": "--cinder-ease-out",
-    "allowedCount": 2
-  },
-  {
-    "filePath": "src/components/kanban-board/kanban-board.css",
-    "name": "--cinder-shadow-elevated",
     "allowedCount": 1
   },
   {
@@ -70,43 +35,13 @@
     "allowedCount": 2
   },
   {
-    "filePath": "src/components/modal/modal.css",
-    "name": "--cinder-radius-xl",
-    "allowedCount": 2
-  },
-  {
-    "filePath": "src/components/phone-input/phone-input.css",
-    "name": "--cinder-surface-muted",
-    "allowedCount": 1
-  },
-  {
-    "filePath": "src/components/pin-input/pin-input.css",
-    "name": "--cinder-surface-muted",
-    "allowedCount": 1
-  },
-  {
-    "filePath": "src/components/radio-group/radio-group.css",
-    "name": "--cinder-surface-selected",
-    "allowedCount": 1
-  },
-  {
     "filePath": "src/components/select/select.css",
     "name": "--cinder-control-height",
     "allowedCount": 1
   },
   {
     "filePath": "src/components/sortable-list/sortable-list.css",
-    "name": "--cinder-shadow-elevated",
-    "allowedCount": 3
-  },
-  {
-    "filePath": "src/components/sortable-list/sortable-list.css",
     "name": "--cinder-z-drag-preview",
-    "allowedCount": 1
-  },
-  {
-    "filePath": "src/components/textarea/textarea.css",
-    "name": "--cinder-text-placeholder",
     "allowedCount": 1
   },
   {

--- a/packages/components/src/components/kanban-board/kanban-board.css
+++ b/packages/components/src/components/kanban-board/kanban-board.css
@@ -210,7 +210,7 @@
     height: var(--preview-height, auto);
     z-index: var(--cinder-z-drag-preview, 9999);
     pointer-events: none;
-    box-shadow: var(--cinder-shadow-elevated, 0 4px 16px rgb(0 0 0 / 0.15));
+    box-shadow: var(--cinder-shadow-lg);
     border-radius: var(--cinder-radius-md, 4px);
     /* Subtle rotation and scale to distinguish preview from the placeholder. */
     transform: rotate(2deg) scale(1.02);

--- a/packages/components/src/components/radio-group/radio-group.css
+++ b/packages/components/src/components/radio-group/radio-group.css
@@ -247,7 +247,7 @@
   /* Selection reinforcement — NOT the sole indicator. */
   .cinder-radio-group[data-variant='card'] .cinder-radio-row[data-checked] {
     border-color: var(--cinder-accent);
-    background: var(--cinder-surface-selected, var(--cinder-surface-raised));
+    background: var(--cinder-surface-raised);
   }
 
   /* Invalid state on the card surface. Driven by `data-invalid` on the row. */

--- a/packages/components/src/components/sortable-list/sortable-list.css
+++ b/packages/components/src/components/sortable-list/sortable-list.css
@@ -18,7 +18,7 @@
 
   .cinder-sortable-item--lifted {
     transform: scale(1.02);
-    box-shadow: var(--cinder-shadow-elevated, 0 4px 16px rgb(0 0 0 / 0.15));
+    box-shadow: var(--cinder-shadow-lg);
     z-index: 1;
     position: relative;
   }
@@ -60,7 +60,7 @@
 
     .cinder-sortable-item--lifted {
       transform: none;
-      box-shadow: var(--cinder-shadow-elevated, 0 4px 16px rgb(0 0 0 / 0.15));
+      box-shadow: var(--cinder-shadow-lg);
     }
 
     .cinder-sortable-item--placeholder {
@@ -135,7 +135,7 @@
     height: var(--preview-height, auto);
     z-index: var(--cinder-z-drag-preview, 9999);
     pointer-events: none;
-    box-shadow: var(--cinder-shadow-elevated, 0 4px 16px rgb(0 0 0 / 0.15));
+    box-shadow: var(--cinder-shadow-lg);
     border-radius: var(--cinder-radius-md, 4px);
     /* Subtle rotation and scale to distinguish preview from the placeholder. */
     transform: rotate(2deg) scale(1.02);

--- a/packages/components/src/components/textarea/textarea.css
+++ b/packages/components/src/components/textarea/textarea.css
@@ -61,7 +61,7 @@
   }
 
   .cinder-textarea::placeholder {
-    color: var(--cinder-text-placeholder, var(--cinder-text-muted));
+    color: var(--cinder-text-muted);
   }
 
   @media (hover: hover) {


### PR DESCRIPTION
## Summary

Replaces undeclared CSS token references with declared canonical equivalents and ratchets the audit baselines down. Slice A of the themeability continuation.

- `--cinder-shadow-elevated` → `--cinder-shadow-lg` (sortable-list ×3, kanban-board ×1). Also **drops the raw-color fallback** `0 4px 16px rgb(0 0 0 / 0.15)`, removing 4 raw-color migration-debt sites. `shadow-lg` is the documented `light-dark()`-aware elevation token already used by modal/drawer/popover/etc — the correct tier for a lifted drag preview, and theme-aware (the old fixed rgb shadow was not).
- `--cinder-text-placeholder` → `--cinder-text-muted` (textarea). Fallback was already the canonical token — zero visual change.
- `--cinder-surface-selected` → `--cinder-surface-raised` (radio-group). Fallback was already canonical — zero visual change.

Ratchets `raw-color-baseline.json` (56→51) and `token-usage-baseline.json` (33→14) down to current actuals via `--update-baseline`. This also swept up already-fixed-but-never-ratcheted entries from #291 (autocomplete, callout, feed/phone/pin, hover-card, modal, file-upload) — correct hygiene that syncs the committed baseline with reality. Both audits pass `--strict`.

~14 other undeclared tokens (control-height, ring-offset-width, text-3xs/4xs, etc.) are deliberately left for follow-up: control-height is design-gated, control-item.css is slated for deletion in slice B, and the rest need individual triage rather than a bulk swap.

## Review committee

Pre-reviewed by frontend-architect — APPROVED. (Noted: sortable-list `--lifted` now uses `shadow-lg` while kanban `--lifted` uses `shadow-md` — a pre-existing inconsistency flagged for the design-system backlog, not a blocker.)

## Test plan

- `bun run --filter=cinder test -- sortable-list kanban-board textarea radio-group` → all pass
- `bun run --filter=cinder colors:audit -- --strict` and `tokens:audit -- --strict` → both pass (below ratcheted baselines)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Styling-only token renames with fallbacks already matching canonical tokens; main visible change is theme-aware shadows on drag previews instead of fixed rgb fallbacks.
> 
> **Overview**
> This PR **replaces undeclared Cinder CSS custom properties** with declared canonical tokens in four component stylesheets, and **ratchets** `raw-color-baseline.json` and `token-usage-baseline.json` so strict color/token audits match current usage.
> 
> **Drag / lift chrome:** `--cinder-shadow-elevated` (with a fixed `rgb` fallback) becomes **`--cinder-shadow-lg`** on sortable-list (lifted row, reduced-motion lifted, drag preview) and kanban-board (drag preview). That removes four raw-color debt sites and aligns drag previews with the theme-aware elevation token used elsewhere.
> 
> **Form controls:** Textarea placeholders use **`--cinder-text-muted`** instead of `--cinder-text-placeholder`. Card-variant radio rows use **`--cinder-surface-raised`** instead of `--cinder-surface-selected` (both had already fallen back to the same canonical values).
> 
> Baseline JSON shrinks accordingly and drops entries for components that no longer violate audits (including hygiene from prior fixes never ratcheted).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c871d98eaae9cb3875a51a5f68cd8c079a46d0b2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->