### PR TITLE
ci(release): move primary npm publish to Trusted Publishing (OIDC) (532c3ad7)

### DIFF
--- a/.github/workflows/release-manual.yaml
+++ b/.github/workflows/release-manual.yaml
@@ -92,12 +92,16 @@ jobs:
       - name: Check package artifact budget
         run: bun run --filter=cinder package:weight:check -- --existing-tarball
 
-      # Break-glass publish. Authentication uses NPM_TOKEN intentionally
-      # (the same secret release.yaml uses) rather than npm trusted
-      # publishing — trusted publishing requires additional registry-side
-      # configuration that is out of scope for this fallback path.
-      # Provenance is still emitted via NPM_CONFIG_PROVENANCE and the
-      # `id-token: write` permission on this job.
+      # Break-glass publish. The primary release path (release.yaml) uses npm
+      # Trusted Publishing (OIDC) and requires no long-lived token. This manual
+      # fallback uses NPM_TOKEN intentionally as an emergency-only alternative
+      # for when the Changesets/OIDC primary path is unavailable. Do NOT use
+      # this workflow for routine releases. Provenance is still emitted via
+      # NPM_CONFIG_PROVENANCE and the `id-token: write` permission on this job.
+      #
+      # Token rotation: NPM_TOKEN should be rotated at least every 90 days per
+      # security policy. The token is a Granular Access Token scoped to the
+      # `cinder` package only — never use a full-access automation token.
       - name: Publish to npm
         env:
           NPM_CONFIG_PROVENANCE: 'true'

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -50,7 +50,21 @@ jobs:
         with:
           node-version: '22'
           registry-url: 'https://registry.npmjs.org'
-          always-auth: true
+
+      # actions/setup-node writes a .npmrc with _authToken=${NODE_AUTH_TOKEN}.
+      # Override it before the npm upgrade so npm never sends an empty or
+      # undefined Authorization header on the OIDC publish path.
+      - name: Configure npm for trusted publishing
+        shell: bash
+        run: |
+          echo "NPM_CONFIG_USERCONFIG=$HOME/.npmrc" >> "$GITHUB_ENV"
+          cat > "$HOME/.npmrc" <<'EOF'
+          registry=https://registry.npmjs.org/
+          always-auth=false
+          EOF
+
+      - name: Upgrade npm
+        run: npm install -g npm@11.5.1
 
       - name: Install dependencies
         run: bun install --frozen-lockfile
@@ -74,12 +88,18 @@ jobs:
         if: github.event_name == 'push' && steps.changesets.outputs.hasChangesets == 'false'
         run: bun run --filter=cinder package:weight:check -- --existing-tarball
 
+      # Primary publish path: npm Trusted Publishing (OIDC). No long-lived token.
+      # npm >= 11.5.1 (installed above) + id-token: write (on this job) + the npm
+      # package's Trusted Publisher configured at registry.npmjs.org automatically
+      # exchanges the GitHub OIDC token for a publish grant. NPM_CONFIG_PROVENANCE
+      # and publishConfig.provenance=true in package.json both stay active.
+      #
+      # If this path breaks and a token-based emergency publish is required, use
+      # .github/workflows/release-manual.yaml instead (see CONTRIBUTING.md).
       - name: Publish validated package artifact to npm
         if: github.event_name == 'push' && steps.changesets.outputs.hasChangesets == 'false'
         run: bun run --filter=cinder publish:release -- --skip-validation
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_CONFIG_PROVENANCE: 'true'
 
       # Diagnostic dry-run: publish the same staged tarball that

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -169,3 +169,46 @@ The npm artifact has one source of truth: `packages/components/scripts/pack-for-
 Before a release, `bun run --filter=cinder validate:consumer` installs the staged tarball into consumer fixtures, runs the Svelte peer compatibility matrix (`5.55.0`, workspace `~5.55.0`, latest `svelte@^5`), and checks tarball hygiene. `bun run --filter=cinder package:weight:check` reports packed size, unpacked size, file count, largest entry directories, and largest files, then fails on budget drift.
 
 Only `cinder` (the workspace at `packages/components/`) publishes to npm; the other `@cinder/*` workspaces are private. Changes confined to `@cinder/playground` (the only private workspace with no dependents and listed under `ignore` in `.changeset/config.json`) do not need a changeset. The remaining private workspaces (`@cinder/commentary`, `@cinder/diff`, `@cinder/editor`, `@cinder/markdown`, `@cinder/testing`) are `workspace:*` dependencies of `cinder`, so changes to them generally do warrant a `cinder` changeset — they ship inside the published package.
+
+### Publishing to npm
+
+The primary release workflow (`.github/workflows/release.yaml`) uses **npm Trusted Publishing (OIDC)**. No long-lived npm token is stored in GitHub Actions secrets for normal releases. The `id-token: write` job permission grants the workflow an OIDC token, and npm >= 11.5.1 exchanges that token for a publish grant automatically.
+
+#### One-time registry configuration (a maintainer must do this once in the npm web UI)
+
+npm Trusted Publishing must be configured on the `cinder` package page at [npmjs.com](https://www.npmjs.com/package/cinder):
+
+1. Navigate to the `cinder` package → **Settings** → **Publishing** → **Add a publisher**.
+2. Select **GitHub Actions** as the provider.
+3. Set these values exactly:
+
+   | Field             | Value           |
+   | ----------------- | --------------- |
+   | Repository owner  | `stevekinney`   |
+   | Repository name   | `cinder`        |
+   | Workflow filename | `release.yaml`  |
+   | Environment       | _(leave blank)_ |
+
+4. Save. The registry will now accept OIDC tokens from that workflow without a static secret.
+
+Until this is configured on npmjs.com, OIDC publishes will be rejected by the registry even though the workflow is otherwise correct. This is a one-time setup step performed on the npm website; it is not automated by this repository.
+
+#### The workflow validation guard
+
+`bun run --filter=cinder validate:workflow` (part of the full `bun run validate` suite) includes a check that asserts `release.yaml` does not contain `NODE_AUTH_TOKEN` or `NPM_TOKEN` anywhere outside comments — not in the publish step's `env:`, and not in a job-level or workflow-level `env:` block that the publish step would silently inherit. If either token reappears, CI fails with a clear message. The guard lives at `packages/components/scripts/validate-release-workflow.ts`.
+
+#### Break-glass fallback
+
+If the Changesets/OIDC path fails and a release is urgent, `.github/workflows/release-manual.yaml` is the documented fallback. It:
+
+- Requires a manually dispatched `workflow_dispatch` event with a version tag input.
+- Uses `NPM_TOKEN` (a Granular Access Token scoped to the `cinder` package only, stored in repository secrets).
+- Still emits provenance via `NPM_CONFIG_PROVENANCE=true` and `id-token: write`.
+
+**Use this workflow only when the primary path is broken.** Routine releases must go through the Changesets PR flow into `main` and the primary `release.yaml`.
+
+Token hygiene for the break-glass secret:
+
+- Rotate `NPM_TOKEN` at least every 90 days.
+- Use a Granular Access Token scoped to the `cinder` package — never a full-access automation token.
+- After a break-glass publish, investigate and restore the primary OIDC path before the next release.

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -3542,8 +3542,9 @@
     "typecheck": "tsc --noEmit -p tsconfig.check.json && bunx svelte-check --workspace src --tsconfig ../tsconfig.json --threshold error",
     "validate": "bun run lint && bun run typecheck && bun run check:placeholder-docs && bun run test:coverage && bun run platform:audit -- --strict && bun run colors:audit -- --strict && bun run tokens:audit -- --strict && bun run validate:workflow && bun run validate:svelte-peer && bun run validate:consumer && bun run package:weight:check -- --existing-tarball",
     "validate:consumer": "bun run scripts/validate-consumers.ts",
+    "validate:release-workflow": "bun run scripts/validate-release-workflow.ts",
     "validate:svelte-peer": "bun run scripts/validate-svelte-peer-contract.ts",
-    "validate:workflow": "bun run scripts/validate-commit-workflow.ts",
+    "validate:workflow": "bun run scripts/validate-commit-workflow.ts && bun run scripts/validate-release-workflow.ts",
     "verify:release-version": "bun run scripts/verify-release-version.ts"
   },
   "dependencies": {

--- a/packages/components/scripts/validate-release-workflow.ts
+++ b/packages/components/scripts/validate-release-workflow.ts
@@ -55,8 +55,22 @@ const workflowContent = (() => {
 
 const lines = workflowContent.split('\n');
 
+/**
+ * Whether a YAML line is a comment. We treat any line whose first non-whitespace
+ * character is `#` as a comment so that documentation (e.g. the explanatory note
+ * about setup-node's _authToken, or a `# id-token: write` example) can never
+ * satisfy OR defeat a guard. This intentionally does not handle inline trailing
+ * `#` comments after real YAML — none of the patterns we scan for legitimately
+ * appear mid-line after a value, and a real `id-token: write` or `- name:` is
+ * never written as a trailing comment.
+ */
+function isComment(line: string): boolean {
+  return line.trimStart().startsWith('#');
+}
+
 // ── Guard 1: id-token: write must be present ────────────────────────────────
-const hasIdTokenWrite = lines.some((line) => /id-token\s*:\s*write/.test(line));
+// Skip comments: a commented-out `# id-token: write` must NOT satisfy the check.
+const hasIdTokenWrite = lines.some((line) => !isComment(line) && /id-token\s*:\s*write/.test(line));
 if (!hasIdTokenWrite) {
   fail(
     'release.yaml is missing `id-token: write`. The primary publish path requires this ' +
@@ -73,8 +87,13 @@ pass('id-token: write is present');
 // upward to the `- name:` that opens this step and downward to the next `- name:`
 // or end of file. Within that range, assert no env key matches the token names.
 
-const publishRunPattern = /bun run --filter=cinder publish:release/;
-const publishRunLineIndex = lines.findIndex((line) => publishRunPattern.test(line));
+// Match the publish step's actual `run:` command, not a comment that mentions it.
+// `^\s*run:` anchors to a real YAML key so a `# ... bun run ... publish:release`
+// note can't be mistaken for the step.
+const publishRunPattern = /^\s*run\s*:.*bun run --filter=cinder publish:release/;
+const publishRunLineIndex = lines.findIndex(
+  (line) => !isComment(line) && publishRunPattern.test(line),
+);
 
 if (publishRunLineIndex === -1) {
   fail(
@@ -83,10 +102,10 @@ if (publishRunLineIndex === -1) {
   );
 }
 
-// Walk backward to find the `- name:` opening of this step.
+// Walk backward to find the `- name:` opening of this step (skipping comments).
 let stepStartIndex = publishRunLineIndex;
 for (let index = publishRunLineIndex - 1; index >= 0; index--) {
-  if (/^\s+-\s+name\s*:/.test(lines[index]!)) {
+  if (!isComment(lines[index]!) && /^\s+-\s+name\s*:/.test(lines[index]!)) {
     stepStartIndex = index;
     break;
   }
@@ -95,7 +114,7 @@ for (let index = publishRunLineIndex - 1; index >= 0; index--) {
 // Walk forward to find the next `- name:` opening (start of the next step) or EOF.
 let stepEndIndex = lines.length;
 for (let index = publishRunLineIndex + 1; index < lines.length; index++) {
-  if (/^\s+-\s+name\s*:/.test(lines[index]!)) {
+  if (!isComment(lines[index]!) && /^\s+-\s+name\s*:/.test(lines[index]!)) {
     stepEndIndex = index;
     break;
   }
@@ -110,7 +129,7 @@ const forbiddenPatterns: Array<{ pattern: RegExp; label: string }> = [
 ];
 
 for (const { pattern, label } of forbiddenPatterns) {
-  const offendingLine = publishStepLines.find((line) => pattern.test(line));
+  const offendingLine = publishStepLines.find((line) => !isComment(line) && pattern.test(line));
   if (offendingLine !== undefined) {
     fail(
       `release.yaml's primary publish step contains ${label}:\n` +
@@ -135,11 +154,7 @@ pass('No NODE_AUTH_TOKEN or NPM_TOKEN in the primary publish step');
 // comment lines (e.g. the explanatory note about setup-node's _authToken) but
 // reject any real `KEY:` assignment.
 for (const { pattern, label } of forbiddenPatterns) {
-  const offendingLine = lines.find((line) => {
-    const trimmed = line.trimStart();
-    if (trimmed.startsWith('#')) return false; // comments are documentation, not config
-    return pattern.test(line);
-  });
+  const offendingLine = lines.find((line) => !isComment(line) && pattern.test(line));
   if (offendingLine !== undefined) {
     fail(
       `release.yaml references ${label} outside a comment:\n` +

--- a/packages/components/scripts/validate-release-workflow.ts
+++ b/packages/components/scripts/validate-release-workflow.ts
@@ -1,0 +1,156 @@
+/**
+ * validate-release-workflow.ts
+ *
+ * Guards the primary release workflow against reintroducing long-lived npm tokens
+ * on the Trusted Publishing publish path. Fails loudly if NODE_AUTH_TOKEN or
+ * NPM_TOKEN appear anywhere in .github/workflows/release.yaml (outside comments).
+ *
+ * What this checks:
+ *   - The file .github/workflows/release.yaml is present.
+ *   - The file has `id-token: write` (the OIDC permission required for Trusted
+ *     Publishing) somewhere in its permissions declarations.
+ *   - The primary publish step (the `run: bun run --filter=cinder publish:release`
+ *     step) does NOT have NODE_AUTH_TOKEN or NPM_TOKEN in its `env:` block
+ *     (precise, well-messaged check).
+ *   - NODE_AUTH_TOKEN / NPM_TOKEN do NOT appear anywhere else in release.yaml
+ *     either — a token in a JOB-level or WORKFLOW-level `env:` block would be
+ *     inherited by the publish step without appearing in the step's own lines,
+ *     so the whole-file check closes that evasion path. Comment lines are
+ *     allowed (they document the OIDC rationale).
+ *   - release-manual.yaml is NOT checked — that file intentionally uses a token
+ *     as a documented break-glass fallback.
+ *
+ * What this does NOT check:
+ *   - Whether the npm registry has a Trusted Publisher configured (that is a
+ *     manual registry-side action; see CONTRIBUTING.md § Publishing to npm).
+ *   - Whether npm >= 11.5.1 is installed at runtime (validated by the workflow
+ *     itself via the "Upgrade npm" step; this script only inspects YAML structure).
+ */
+
+import { readFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const scriptDirectory = dirname(fileURLToPath(import.meta.url));
+const packageRoot = resolve(scriptDirectory, '..');
+const workspaceRoot = resolve(packageRoot, '../..');
+const releaseWorkflowPath = join(workspaceRoot, '.github/workflows/release.yaml');
+
+function fail(message: string): never {
+  process.stderr.write(`[validate-release-workflow] FAIL: ${message}\n`);
+  process.exit(1);
+}
+
+function pass(message: string): void {
+  process.stdout.write(`[validate-release-workflow] PASS: ${message}\n`);
+}
+
+const workflowContent = (() => {
+  try {
+    return readFileSync(releaseWorkflowPath, 'utf8');
+  } catch {
+    fail(`release workflow not found at ${releaseWorkflowPath}`);
+  }
+})();
+
+const lines = workflowContent.split('\n');
+
+// ── Guard 1: id-token: write must be present ────────────────────────────────
+const hasIdTokenWrite = lines.some((line) => /id-token\s*:\s*write/.test(line));
+if (!hasIdTokenWrite) {
+  fail(
+    'release.yaml is missing `id-token: write`. The primary publish path requires this ' +
+      'OIDC permission for npm Trusted Publishing.',
+  );
+}
+pass('id-token: write is present');
+
+// ── Guard 2: locate the primary publish step ────────────────────────────────
+// The primary publish step is identified by the run: command that calls publish:release.
+// We scan for the step boundary and extract its env: block, then check for tokens.
+//
+// Strategy: find the line index of the publish:release `run:` command, then walk
+// upward to the `- name:` that opens this step and downward to the next `- name:`
+// or end of file. Within that range, assert no env key matches the token names.
+
+const publishRunPattern = /bun run --filter=cinder publish:release/;
+const publishRunLineIndex = lines.findIndex((line) => publishRunPattern.test(line));
+
+if (publishRunLineIndex === -1) {
+  fail(
+    'Could not locate the primary publish step in release.yaml. ' +
+      'Expected a step with `run: bun run --filter=cinder publish:release`.',
+  );
+}
+
+// Walk backward to find the `- name:` opening of this step.
+let stepStartIndex = publishRunLineIndex;
+for (let index = publishRunLineIndex - 1; index >= 0; index--) {
+  if (/^\s+-\s+name\s*:/.test(lines[index]!)) {
+    stepStartIndex = index;
+    break;
+  }
+}
+
+// Walk forward to find the next `- name:` opening (start of the next step) or EOF.
+let stepEndIndex = lines.length;
+for (let index = publishRunLineIndex + 1; index < lines.length; index++) {
+  if (/^\s+-\s+name\s*:/.test(lines[index]!)) {
+    stepEndIndex = index;
+    break;
+  }
+}
+
+const publishStepLines = lines.slice(stepStartIndex, stepEndIndex);
+
+// ── Guard 3: no token env vars in the publish step ──────────────────────────
+const forbiddenPatterns: Array<{ pattern: RegExp; label: string }> = [
+  { pattern: /NODE_AUTH_TOKEN\s*:/, label: 'NODE_AUTH_TOKEN' },
+  { pattern: /NPM_TOKEN\s*:/, label: 'NPM_TOKEN' },
+];
+
+for (const { pattern, label } of forbiddenPatterns) {
+  const offendingLine = publishStepLines.find((line) => pattern.test(line));
+  if (offendingLine !== undefined) {
+    fail(
+      `release.yaml's primary publish step contains ${label}:\n` +
+        `  ${offendingLine.trim()}\n\n` +
+        'The primary publish path must use npm Trusted Publishing (OIDC), not a long-lived token.\n' +
+        'Remove the token env var from this step.\n' +
+        'For break-glass token publishing, use release-manual.yaml instead.',
+    );
+  }
+}
+
+pass('No NODE_AUTH_TOKEN or NPM_TOKEN in the primary publish step');
+
+// ── Guard 4: no token env vars ANYWHERE in release.yaml ─────────────────────
+// The step-scoped check above is precise, but a token placed in a `env:` block
+// at the JOB level or the WORKFLOW level would be inherited by the publish step
+// without appearing inside the step's own lines — a real evasion path. Because
+// the entire OIDC release path is tokenless (the only legitimate token use lives
+// in release-manual.yaml's break-glass flow), the correct, evasion-proof
+// invariant is simply: these token names appear NOWHERE in release.yaml — not in
+// a step env, not in a job env, not in a workflow env. We allow them inside
+// comment lines (e.g. the explanatory note about setup-node's _authToken) but
+// reject any real `KEY:` assignment.
+for (const { pattern, label } of forbiddenPatterns) {
+  const offendingLine = lines.find((line) => {
+    const trimmed = line.trimStart();
+    if (trimmed.startsWith('#')) return false; // comments are documentation, not config
+    return pattern.test(line);
+  });
+  if (offendingLine !== undefined) {
+    fail(
+      `release.yaml references ${label} outside a comment:\n` +
+        `  ${offendingLine.trim()}\n\n` +
+        'The OIDC release path must be fully tokenless. A token in a job-level or\n' +
+        'workflow-level `env:` block would be inherited by the publish step and\n' +
+        'silently re-enable token publishing. Remove it.\n' +
+        'For break-glass token publishing, use release-manual.yaml instead.',
+    );
+  }
+}
+
+pass('No NODE_AUTH_TOKEN or NPM_TOKEN anywhere in release.yaml (job/workflow env safe)');
+pass('release.yaml is correctly configured for npm Trusted Publishing');


### PR DESCRIPTION
## Summary

Migrates the **primary** `release.yaml` publish path from a long-lived `NPM_TOKEN` to tokenless npm Trusted Publishing (OIDC).

- Remove `always-auth: true` from `setup-node`; add a step that overwrites `$HOME/.npmrc` with `always-auth=false` so npm uses OIDC instead of sending an empty `Authorization` header (the 401 trap when no token is present)
- Upgrade npm to `11.5.1` before publish (Trusted Publishing requires npm ≥ 11.5.1)
- Remove `NODE_AUTH_TOKEN` + `NPM_TOKEN` from the publish step's `env`
- Keep provenance via `NPM_CONFIG_PROVENANCE=true` + `publishConfig.provenance: true`

`release-manual.yaml` keeps the granular-token path as **break-glass only** (workflow_dispatch, documented with 90-day rotation + package-scoped granular-token requirements).

Adds `validate-release-workflow.ts` (wired into `validate:workflow`, part of the `validate` gate) which fails if `NODE_AUTH_TOKEN`/`NPM_TOKEN` appear **anywhere in `release.yaml` outside comments** — not just the publish step, but also any job-level or workflow-level `env:` block the publish step would silently inherit. Documents the one-time npm-web-UI Trusted Publisher config + the break-glass policy in CONTRIBUTING.md.

> [!IMPORTANT]
> A maintainer must configure the npm-registry Trusted Publisher in the npm web UI (repo `stevekinney/cinder`, workflow `release.yaml`) before OIDC publishes succeed. Until then the break-glass path remains functional. Details in CONTRIBUTING.md § Publishing to npm.

## Review committee

Pre-reviewed by security-reviewer + aws-platform-architect. The security review surfaced a real gap — the original guard only scanned the publish *step*, so a token added at the **job-level `env:`** would be inherited but missed. The guard now scans the whole file (verified: it FAILS on an injected job-level `NPM_TOKEN` and PASSES on the clean file). Two other flagged items (always-auth still present; npm upgrade missing) were false positives — both are correctly handled in the actual diff.

## Test plan

- `bun run --filter=cinder validate:workflow` → passes (guard wired in)
- Adversarial guard test: injected `NPM_TOKEN` at job-level env → guard fails with clear message; restored file → guard passes
- `rg "NODE_AUTH_TOKEN|NPM_TOKEN" .github/workflows/release.yaml` → only in comments

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes how production packages are authenticated and published; OIDC will fail until npm Trusted Publisher is configured, though `release-manual.yaml` remains as fallback.
> 
> **Overview**
> **Primary npm releases** now use **npm Trusted Publishing (OIDC)** in `release.yaml`: long-lived `NODE_AUTH_TOKEN` / `NPM_TOKEN` are removed from the publish step, `setup-node` no longer forces `always-auth`, a step rewrites `$HOME/.npmrc` with `always-auth=false` (avoids empty `Authorization` on OIDC), and **npm 11.5.1** is installed before publish. Provenance stays on via `NPM_CONFIG_PROVENANCE`.
> 
> **Break-glass** `release-manual.yaml` still publishes with a scoped `NPM_TOKEN`; comments now spell out emergency-only use and 90-day rotation.
> 
> **CI guard:** new `validate-release-workflow.ts` (via `validate:workflow`) fails if `release.yaml` lacks `id-token: write` or assigns `NODE_AUTH_TOKEN` / `NPM_TOKEN` anywhere outside comments (including job/workflow `env:`). **CONTRIBUTING.md** documents one-time npm Trusted Publisher setup and the manual fallback.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bb450ce8a2975cafc4d8c544ad1ceb4c8171c1bb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->