### PR TITLE
test(themeability): expand alternate-theme fixture + add variables-contract drift test (2f6e14c8)

### DIFF
--- a/packages/components/src/styles/component-variables-contract.test.ts
+++ b/packages/components/src/styles/component-variables-contract.test.ts
@@ -68,12 +68,21 @@ async function loadAllComponentVariables(): Promise<ComponentVariables[]> {
 
   const results: ComponentVariables[] = [];
 
-  for (const componentName of componentDirs) {
-    const jsonPath = join(COMPONENTS_DIR, componentName, `${componentName}.variables.json`);
-    const file = Bun.file(jsonPath);
-    if (!(await file.exists())) continue;
+  for (const dirName of componentDirs) {
+    // Discover the actual `*.variables.json` inside the directory rather than
+    // assuming the stem equals the directory name. Some directories are
+    // underscore-prefixed (e.g. `_radio/`) but ship `radio.variables.json`, so a
+    // `${dirName}.variables.json` assumption would silently skip them — leaving
+    // their contract unenforced. The component name is the FILE stem (`radio`),
+    // which is also what the `--cinder-<name>-*` ownership prefix must match.
+    const dirEntries = await readdir(join(COMPONENTS_DIR, dirName));
+    const variablesFile = dirEntries.find((name) => name.endsWith('.variables.json'));
+    if (variablesFile === undefined) continue;
 
-    const variables = (await file.json()) as string[];
+    const componentName = variablesFile.slice(0, -'.variables.json'.length);
+    const variables = (await Bun.file(
+      join(COMPONENTS_DIR, dirName, variablesFile),
+    ).json()) as string[];
     results.push({ componentName, variables });
   }
 

--- a/packages/components/src/styles/component-variables-contract.test.ts
+++ b/packages/components/src/styles/component-variables-contract.test.ts
@@ -1,0 +1,194 @@
+/**
+ * Contract test for component *.variables.json files.
+ *
+ * The generator (`scripts/generate-component-variables.ts`) walks each
+ * component's CSS and emits every `--cinder-*` declaration it finds as a
+ * "public override variable".  The contract this test encodes is:
+ *
+ *   1. Every listed variable follows the `--cinder-<component>-*` public
+ *      naming convention (no `--_cinder-*` private/internal variables).
+ *
+ *   2. No variable is a bare global token (`--cinder-accent`, `--cinder-space-4`,
+ *      etc.) that belongs in `:root`, not in a component's override surface.
+ *
+ * These invariants hold across all 135+ component directories today. Any
+ * generator change or hand-edit that breaks them will be caught immediately.
+ *
+ * NOTE — file-upload runtime-state vars
+ * -------------------------------------
+ * `file-upload.variables.json` currently includes
+ * `--cinder-file-upload-progress-background` and
+ * `--cinder-file-upload-progress-fill`. These are declared as CSS custom
+ * properties in the component's `:root`-level `.cinder-file-upload {}` rule,
+ * which causes the generator to include them. However they describe the
+ * progress UI whose runtime state is driven by JS (the bare
+ * `--cinder-file-upload-progress` counter set via `style=`), making them
+ * semantically "runtime-state" rather than "consumer theme API".
+ *
+ * Fixing the generator is design-gated (task 2f6e14c8). The test below is
+ * written to assert the CORRECT contract; the file-upload case is marked
+ * `.skip` with an explicit note so it becomes a forcing function to fix the
+ * generator once the design question is resolved.
+ *
+ * Test files may use `any` per project conventions.
+ */
+
+import { readdir } from 'node:fs/promises';
+import { join } from 'node:path';
+
+import { describe, expect, test } from 'bun:test';
+
+const COMPONENTS_DIR = join(import.meta.dir, '..', 'components');
+
+/**
+ * Runtime-state variable names that the generator currently mis-emits as public
+ * override variables. Each entry is `{ component, variable }`. The test that
+ * checks for these is skipped until the generator is fixed.
+ *
+ * See: packages/components/scripts/generate-component-variables.ts
+ */
+const KNOWN_RUNTIME_STATE_LEAKS: Array<{ component: string; variable: string }> = [
+  // KNOWN: file-upload progress vars are runtime-state mis-emitted as public.
+  // The bare --cinder-file-upload-progress counter is set via inline style= from
+  // file-upload.svelte, and the *-background/*-fill tokens describe that dynamic
+  // UI. Un-skip when generate-component-variables.ts is fixed — task 2f6e14c8
+  // design-gated item.
+  { component: 'file-upload', variable: '--cinder-file-upload-progress-background' },
+  { component: 'file-upload', variable: '--cinder-file-upload-progress-fill' },
+];
+
+interface ComponentVariables {
+  componentName: string;
+  variables: string[];
+}
+
+async function loadAllComponentVariables(): Promise<ComponentVariables[]> {
+  const entries = await readdir(COMPONENTS_DIR, { withFileTypes: true });
+  const componentDirs = entries.filter((entry) => entry.isDirectory()).map((entry) => entry.name);
+
+  const results: ComponentVariables[] = [];
+
+  for (const componentName of componentDirs) {
+    const jsonPath = join(COMPONENTS_DIR, componentName, `${componentName}.variables.json`);
+    const file = Bun.file(jsonPath);
+    if (!(await file.exists())) continue;
+
+    const variables = (await file.json()) as string[];
+    results.push({ componentName, variables });
+  }
+
+  return results;
+}
+
+describe('component *.variables.json contract', () => {
+  // ACTIVE: no private --_cinder-* variables should appear in any variables.json.
+  //
+  // Private variables (prefixed `--_`) are internal implementation details;
+  // they are never part of the public theming API. If the generator emits one,
+  // it means either the naming convention was violated in the CSS or the regex
+  // in the generator is too broad.
+  test('no component variables.json contains a --_cinder-* private variable', async () => {
+    const allComponents = await loadAllComponentVariables();
+
+    // Sanity floor: we know we have 100+ component dirs with variables.json.
+    expect(allComponents.length).toBeGreaterThan(100);
+
+    const violations: string[] = [];
+
+    for (const { componentName, variables } of allComponents) {
+      for (const variable of variables) {
+        if (variable.startsWith('--_')) {
+          violations.push(`${componentName}: "${variable}" is a private variable (--_cinder-*)`);
+        }
+      }
+    }
+
+    expect(violations).toEqual([]);
+  });
+
+  // ACTIVE: every listed variable must be owned by the component (no cross-namespace leaks).
+  //
+  // The strict rule is a FULL-name prefix match: a component named `<name>` may
+  // only declare `--cinder-<name>-*` variables (e.g. `button` → `--cinder-button-*`,
+  // `kanban-board` → `--cinder-kanban-board-*`).
+  //
+  // A leading-segment match (e.g. allowing `kanban-board` to claim any
+  // `--cinder-kanban-*`) was deliberately rejected: it would let a component claim
+  // a variable that semantically belongs to a longer-named sibling sharing its
+  // leading segment (e.g. `avatar` claiming `--cinder-avatar-group-*`). The full-name
+  // rule attributes ownership unambiguously.
+  //
+  // The ONE legitimate cross-name case in the corpus is a compound parent that owns
+  // the override surface for its sub-structures. `kanban-board` declares
+  // `--cinder-kanban-column-*` and `--cinder-kanban-card-*` because the board element
+  // is the cascade scope for column/card layout tokens. That is allowlisted explicitly
+  // below — a deliberate, reviewed exception, not a loose rule that hides others.
+  //
+  // Variables of the form `--cinder-accent` (no component segment at all) are global
+  // tokens from tokens-base.css. If they appear in a component's variables.json it
+  // means the component declares a global alias or a typo in the CSS.
+  //
+  // Each allowlist entry is `{ component, prefixes }`: extra `--cinder-*-` prefixes
+  // that component is permitted to own beyond its own `--cinder-<name>-`.
+  const OWNERSHIP_ALLOWLIST: Record<string, string[]> = {
+    // The kanban board is the cascade scope for its columns and cards.
+    'kanban-board': ['--cinder-kanban-column-', '--cinder-kanban-card-'],
+  };
+
+  test('every variable in components variables.json is owned by the declaring component', async () => {
+    const allComponents = await loadAllComponentVariables();
+
+    const violations: string[] = [];
+
+    for (const { componentName, variables } of allComponents) {
+      const validPrefixes = [
+        `--cinder-${componentName}-`,
+        ...(OWNERSHIP_ALLOWLIST[componentName] ?? []),
+      ];
+
+      for (const variable of variables) {
+        const isOwned = validPrefixes.some((prefix) => variable.startsWith(prefix));
+        if (!isOwned) {
+          violations.push(
+            `${componentName}: "${variable}" does not match any expected prefix (${validPrefixes.map((p) => `"${p}*"`).join(', ')})`,
+          );
+        }
+      }
+    }
+
+    expect(violations).toEqual([]);
+  });
+
+  // SKIPPED — known generator regression for file-upload runtime-state variables.
+  //
+  // KNOWN: file-upload progress vars are runtime-state mis-emitted as public;
+  // un-skip when generate-component-variables.ts is fixed — task 2f6e14c8
+  // design-gated item.
+  //
+  // This test encodes the CORRECT contract: the runtime-state variables listed in
+  // KNOWN_RUNTIME_STATE_LEAKS should NOT appear in any variables.json because they
+  // are driven by JS at runtime (not by consumer CSS overrides). Once the
+  // generator is fixed to exclude them, remove the `.skip` and this comment.
+  test.skip('no component variables.json contains a known runtime-state variable', async () => {
+    const allComponents = await loadAllComponentVariables();
+
+    const allVariablesByComponent = new Map(
+      allComponents.map(({ componentName, variables }) => [componentName, variables]),
+    );
+
+    const violations: string[] = [];
+
+    for (const { component, variable } of KNOWN_RUNTIME_STATE_LEAKS) {
+      const componentVariables = allVariablesByComponent.get(component);
+      if (componentVariables === undefined) continue;
+
+      if (componentVariables.includes(variable)) {
+        violations.push(
+          `${component}: runtime-state variable "${variable}" is incorrectly listed as a public override variable`,
+        );
+      }
+    }
+
+    expect(violations).toEqual([]);
+  });
+});

--- a/packages/testing/tests/alternate-theme.playwright.ts
+++ b/packages/testing/tests/alternate-theme.playwright.ts
@@ -8,8 +8,8 @@
  * value that the token override cannot reach.
  *
  * This test proves the contract end-to-end for a representative spread of token
- * dimensions (accent color, surface, border, radius) against components that
- * consume them, by:
+ * dimensions (accent color, surface, border, radius, status color, focus ring,
+ * spacing) against components that consume them, by:
  *   1. Loading a real component page from the playground.
  *   2. Recording the component's computed style with the stock tokens.
  *   3. Injecting an alternate theme that overrides ONLY documented `:root`
@@ -38,6 +38,10 @@ const ALTERNATE_THEME = `
     --cinder-surface: oklch(95% 0.03 280);
     --cinder-border: oklch(60% 0.15 300);
     --cinder-radius-lg: 1.25rem;
+    --cinder-danger: oklch(55% 0.20 145);
+    --cinder-ring-color: oklch(70% 0.25 145);
+    --cinder-ring-width: 8px;
+    --cinder-space-4: 2.5rem;
   }
 `;
 
@@ -77,6 +81,148 @@ test.describe('alternate-theme — documented token overrides reach components',
     const themed = await computed(page, cardSelector, 'border-top-left-radius');
 
     // If the card hard-codes its radius the override is inert and these match.
+    expect(themed).not.toBe(stock);
+  });
+
+  // (a) --cinder-surface reaches a surface component's background-color.
+  // The Surface component's base rule is `background: var(--cinder-surface)`.
+  // A hard-coded background on .cinder-surface would leave these values equal.
+  test('overriding --cinder-surface reaches a Surface component background', async ({ page }) => {
+    await page.goto('/page/surface', { waitUntil: 'load' });
+
+    const surfaceSelector = '.cinder-surface';
+    const stock = await computed(page, surfaceSelector, 'background-color');
+
+    await page.addStyleTag({ content: ALTERNATE_THEME });
+
+    const themed = await computed(page, surfaceSelector, 'background-color');
+
+    // The surface token must drive the computed background. A hard-coded value
+    // would survive the override unchanged.
+    expect(themed).not.toBe(stock);
+  });
+
+  // (b) --cinder-border reaches a bordered component's border-color.
+  // Input CSS: `border: 1px solid var(--cinder-border)`.
+  // A hard-coded border-color on .cinder-input would leave these equal.
+  test('overriding --cinder-border reaches an Input border-color', async ({ page }) => {
+    await page.goto('/page/input', { waitUntil: 'load' });
+
+    const inputSelector = '.cinder-input';
+    const stock = await computed(page, inputSelector, 'border-top-color');
+
+    await page.addStyleTag({ content: ALTERNATE_THEME });
+
+    const themed = await computed(page, inputSelector, 'border-top-color');
+
+    // Equal means the input hard-codes its border instead of consuming
+    // --cinder-border, a real theming leak.
+    expect(themed).not.toBe(stock);
+  });
+
+  // (c) --cinder-danger reaches an Alert "error" variant's background.
+  //
+  // Alert[variant=error] sets `--_cinder-status-base: var(--cinder-danger)` which
+  // feeds the _status-surface recipe's `oklch(from var(--_cinder-status-base) ...)`.
+  // Overriding --cinder-danger to a different hue changes the synthesized background.
+  //
+  // Note: Alert composes `.cinder-_status-surface` only (not the border class per P7),
+  // so background-color is the most reliable property to assert on.
+  test('overriding --cinder-danger reaches an Alert error-variant background', async ({ page }) => {
+    await page.goto('/page/alert', { waitUntil: 'load' });
+
+    const errorAlertSelector = ".cinder-alert[data-cinder-variant='error']";
+    const stock = await computed(page, errorAlertSelector, 'background-color');
+
+    await page.addStyleTag({ content: ALTERNATE_THEME });
+
+    const themed = await computed(page, errorAlertSelector, 'background-color');
+
+    // The danger token drives the status-surface recipe's hue. A hard-coded
+    // background or a broken token chain leaves these equal.
+    expect(themed).not.toBe(stock);
+  });
+
+  // (d) --cinder-ring-width reaches a focused element's outline-width.
+  //
+  // The button's :focus-visible rule sets:
+  //   outline: var(--cinder-ring-width) solid transparent;
+  //
+  // Overriding --cinder-ring-width from 3px to 8px must change the resolved
+  // `outline-width` on the focused element.
+  //
+  // We assert on `outline-width` rather than `box-shadow` because the box-shadow
+  // color arms use `light-dark(oklch(from ...) ...)` relative-color syntax which
+  // resolves to `oklab(0 0 0 / 0)` in Playwright's Chromium (the browser-internal
+  // color-scheme context differs from a real page). The outline assertion avoids
+  // that serialization ambiguity while still proving the ring-width token flows.
+  //
+  // :focus-visible only activates for KEYBOARD focus in Chromium — programmatic
+  // locator.focus() does NOT set it on a <button>, so the outline rule would never
+  // apply and the test would compare two `0px` values (a vacuous pass). We therefore
+  // drive focus with Tab. To keep the Tab walk from silently never reaching the
+  // target (the brittleness of a bare iteration cap), `focusPrimaryButton` returns
+  // whether it landed AND we assert it did, and we assert :focus-visible is actually
+  // active before reading outline-width — so any failure to reach a keyboard-focused
+  // button fails loudly instead of passing vacuously.
+  async function focusPrimaryButton(page: Page): Promise<void> {
+    const primaryHasFocusVisible = () =>
+      page.evaluate(() => {
+        const active = document.activeElement;
+        return (
+          active instanceof HTMLElement &&
+          active.matches(".cinder-button[data-cinder-variant='primary']") &&
+          active.matches(':focus-visible')
+        );
+      });
+
+    for (let tabIndex = 0; tabIndex < 50; tabIndex++) {
+      await page.keyboard.press('Tab');
+      if (await primaryHasFocusVisible()) return;
+    }
+    throw new Error('Tab walk never reached a keyboard-focused primary button');
+  }
+
+  test('overriding --cinder-ring-width reaches a focused Button outline-width', async ({
+    page,
+  }) => {
+    await page.goto('/page/button', { waitUntil: 'load' });
+
+    await focusPrimaryButton(page);
+    const stock = await page.evaluate(() => getComputedStyle(document.activeElement!).outlineWidth);
+
+    await page.addStyleTag({ content: ALTERNATE_THEME });
+
+    // Re-acquire keyboard focus after injection (start over from the top of the
+    // tab order so the walk is deterministic).
+    await page.evaluate(() => (document.activeElement as HTMLElement | null)?.blur());
+    await focusPrimaryButton(page);
+    const themed = await page.evaluate(
+      () => getComputedStyle(document.activeElement!).outlineWidth,
+    );
+
+    // The ring-width token must change the focused button's outline-width.
+    // Stock: 3px; alternate: 8px. Equal values mean the button hard-codes its ring.
+    expect(themed).not.toBe(stock);
+  });
+
+  // (e) --cinder-space-4 reaches a Card body's padding.
+  //
+  // Card CSS: `.cinder-card__body { padding: var(--cinder-space-4); }`
+  // Stock value: 1rem (16px). Alternate theme: 2.5rem (40px).
+  // A hard-coded padding would not change, leaving these equal.
+  test('overriding --cinder-space-4 reaches a Card body padding', async ({ page }) => {
+    await page.goto('/page/card', { waitUntil: 'load' });
+
+    const bodySelector = '.cinder-card__body';
+    const stock = await computed(page, bodySelector, 'padding-top');
+
+    await page.addStyleTag({ content: ALTERNATE_THEME });
+
+    const themed = await computed(page, bodySelector, 'padding-top');
+
+    // Equal values mean the card body hard-codes its padding instead of consuming
+    // --cinder-space-4 — a real spacing-token leak.
     expect(themed).not.toBe(stock);
   });
 });


### PR DESCRIPTION
## Summary

Slice C of the themeability continuation (test-only — no CSS, generator, or baseline changes).

**Alternate-theme Playwright fixture** expanded from 2 to 7 token-override leak-detection assertions: adds surface (`--cinder-surface`→Surface bg), border (`--cinder-border`→Input border), status color (`--cinder-danger`→Alert error bg via the `_status-surface` recipe), focus-ring (`--cinder-ring-width`→focused Button `outline-width`), and spacing (`--cinder-space-4`→Card body padding). Each overrides one documented `:root` token and asserts the computed style changes — a hard-coded value would leave stock==themed and fail, catching leaks the static guards can't see. All 7 verified passing against a real browser.

The focus-ring test drives focus with keyboard Tab (the only way to activate `:focus-visible` in Chromium — programmatic `.focus()` does not), with a guard that asserts it actually reached a `:focus-visible` primary button so it can't pass vacuously. It asserts `outline-width` rather than `box-shadow` to dodge Chromium's `light-dark(oklch(from ...))` zero-alpha serialization.

**`component-variables-contract.test.ts`** asserts each `<name>.variables.json` lists only public `--cinder-<component>-*` override variables — no `--_cinder-*` privates, no runtime-state vars. Ownership uses a strict full-component-name prefix with a single documented allowlist entry (`kanban-board` legitimately owns `--cinder-kanban-column-*`/`--cinder-kanban-card-*` as the cascade scope). The file-upload runtime-var case (`--cinder-file-upload-progress-*`, JS-set state mis-emitted as public) is a documented `.skip` pending the generator fix — a design-gated item of this task. Active assertions pass across all source components.

## Review committee

Pre-reviewed by testing-expert + frontend-architect. Two real findings fixed: (1) the focus-ring test's bare 40×Tab loop was brittle — replaced with a guarded keyboard-focus walk that fails loudly if it never reaches a `:focus-visible` button (I verified the reviewer's suggested `locator.focus()` alternative does **not** trigger `:focus-visible` in this harness, so keyboard focus is required); (2) the ownership prefix rule was loosened to leading-segment — tightened to full-name + explicit allowlist. The "fixture scan scope" finding was a false positive (the test reads from `src/components`, not node_modules).

## Test plan

- `bun run --filter=cinder test -- component-variables-contract` → 2 pass + 1 skip
- alternate-theme fixture: 7/7 pass against a local playground server

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to new and extended automated tests; no runtime, auth, or styling source changes.
> 
> **Overview**
> Adds **test-only** coverage for the themeability contract (task 2f6e14c8): no production CSS or generator changes.
> 
> **`component-variables-contract.test.ts`** scans every component `*.variables.json` (resolving files by stem so dirs like `_radio/` still match `radio.variables.json`). Active checks: no `--_cinder-*` privates in the public override list, and each token is owned by `--cinder-<component>-*` with a single reviewed allowlist for `kanban-board` (`--cinder-kanban-column-*` / `--cinder-kanban-card-*`). A third case for **runtime-state** vars mis-listed as public (file-upload progress tokens) is implemented but **`.skip`** until the variables generator is fixed.
> 
> **`alternate-theme.playwright.ts`** grows from two token dimensions to seven by extending `:root` overrides (`--cinder-danger`, ring tokens, `--cinder-space-4`) and adding five browser assertions: Surface background, Input border, Alert error background, focused primary Button **`outline-width`** (keyboard Tab + `:focus-visible` guard to avoid vacuous passes), and Card body padding. The load-bearing pattern remains stock computed style ≠ themed after injecting only documented global tokens.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bab6fa453291233c247ae65ac51eb0611eac6900. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->