### PR TITLE
Fix Kanban cross-column drag placeholder freeze

### DIFF
--- a/packages/components/src/components/_sortable-item.svelte
+++ b/packages/components/src/components/_sortable-item.svelte
@@ -135,6 +135,7 @@
     // is entirely inert. The clone is aria-hidden / inert at the portal level.
     clone.removeAttribute('data-sortable-row');
     clone.removeAttribute('data-key');
+    clone.removeAttribute('data-key-type');
     clone.removeAttribute('data-row-id');
     // Strip all id attributes from the clone and its descendants to prevent
     // duplicate id values in the document, which would break getElementById,
@@ -199,9 +200,18 @@
   }
 
   function endPointerSession(reason: 'drop' | 'cancel'): void {
-    if (moveRafHandle !== null) {
-      cancelAnimationFrame(moveRafHandle);
-      moveRafHandle = null;
+    if (reason === 'drop') {
+      if (moveRafHandle !== null) {
+        cancelAnimationFrame(moveRafHandle);
+        moveRafHandle = null;
+      }
+      recomputeTarget();
+      updatePreviewPosition(latestPointerX, latestPointerY);
+    } else {
+      if (moveRafHandle !== null) {
+        cancelAnimationFrame(moveRafHandle);
+        moveRafHandle = null;
+      }
     }
     if (scrollRafHandle !== null) {
       cancelAnimationFrame(scrollRafHandle);
@@ -356,6 +366,16 @@
     endPointerSession('cancel');
   }
 
+  function handleWindowPointerUp(event: PointerEvent): void {
+    if (!pointerActive || (pointerId !== null && event.pointerId !== pointerId)) return;
+    endPointerSession('drop');
+  }
+
+  function handleWindowPointerCancel(event: PointerEvent): void {
+    if (!pointerActive || (pointerId !== null && event.pointerId !== pointerId)) return;
+    endPointerSession('cancel');
+  }
+
   function handleKeyDown(event: KeyboardEvent): void {
     const { key } = event;
 
@@ -496,10 +516,13 @@
   });
 </script>
 
+<svelte:window onpointerup={handleWindowPointerUp} onpointercancel={handleWindowPointerCancel} />
+
 <li
   bind:this={rowEl}
   data-sortable-row
   data-key={itemKey}
+  data-key-type={typeof itemKey}
   data-row-id={rowId}
   data-preview-x={isDraggingWithPointer ? previewX : undefined}
   data-preview-y={isDraggingWithPointer ? previewY : undefined}

--- a/packages/components/src/components/_sortable-item.svelte
+++ b/packages/components/src/components/_sortable-item.svelte
@@ -56,6 +56,7 @@
   let latestPointerY = 0;
   let latestPointerX = 0;
   let listEl: HTMLElement | null = null;
+  let windowPointerListenersActive = false;
 
   // Reactive state for the pointer-drag preview portal.
   // previewX / previewY drive data-preview-x / data-preview-y on the row element
@@ -199,6 +200,20 @@
     isDraggingWithPointer = false;
   }
 
+  function addWindowPointerListeners(): void {
+    if (windowPointerListenersActive || typeof window === 'undefined') return;
+    window.addEventListener('pointerup', handleWindowPointerUp);
+    window.addEventListener('pointercancel', handleWindowPointerCancel);
+    windowPointerListenersActive = true;
+  }
+
+  function removeWindowPointerListeners(): void {
+    if (!windowPointerListenersActive || typeof window === 'undefined') return;
+    window.removeEventListener('pointerup', handleWindowPointerUp);
+    window.removeEventListener('pointercancel', handleWindowPointerCancel);
+    windowPointerListenersActive = false;
+  }
+
   function endPointerSession(reason: 'drop' | 'cancel'): void {
     if (reason === 'drop') {
       if (moveRafHandle !== null) {
@@ -227,6 +242,7 @@
     }
 
     destroyPreviewPortal();
+    removeWindowPointerListeners();
 
     pointerActive = false;
     pointerId = null;
@@ -333,6 +349,7 @@
     // when we clone it, then position relative to the pointer.
     createPreviewPortal(event.clientX, event.clientY);
     updatePreviewPosition(event.clientX, event.clientY);
+    addWindowPointerListeners();
     scheduleAutoScroll();
   }
 
@@ -477,6 +494,7 @@
       } catch {}
     }
     destroyPreviewPortal();
+    removeWindowPointerListeners();
     pointerActive = false;
     pointerId = null;
     listEl = null;
@@ -508,6 +526,7 @@
           }
         }
         destroyPreviewPortal();
+        removeWindowPointerListeners();
         pointerActive = false;
         pointerId = null;
         listEl = null;
@@ -515,8 +534,6 @@
     };
   });
 </script>
-
-<svelte:window onpointerup={handleWindowPointerUp} onpointercancel={handleWindowPointerCancel} />
 
 <li
   bind:this={rowEl}

--- a/packages/components/src/components/kanban-board/kanban-board.css
+++ b/packages/components/src/components/kanban-board/kanban-board.css
@@ -126,6 +126,7 @@
    * skewing the midpoint geometry used by drop-target calculations.
    */
   .cinder-kanban-board__card.cinder-sortable-item--placeholder {
+    block-size: var(--cinder-kanban-board-drop-placeholder-block-size, auto);
     min-block-size: var(--cinder-space-12, 3rem);
     opacity: 0.4;
     border-color: transparent;
@@ -138,6 +139,10 @@
   .cinder-kanban-board__card.cinder-sortable-item--placeholder > * {
     /* Hide card content from sight; placeholder conveys drop position only. */
     visibility: hidden;
+  }
+
+  .cinder-kanban-board__drop-placeholder {
+    pointer-events: none;
   }
 
   .cinder-kanban-board__card-content {

--- a/packages/components/src/components/kanban-board/kanban-board.svelte
+++ b/packages/components/src/components/kanban-board/kanban-board.svelte
@@ -86,6 +86,7 @@
   let pointerColumnIndex = $state<number | null>(null);
   let columnLiftedKey = $state<string | number | null>(null);
   let columnTargetIndex = $state<number | null>(null);
+  let crossColumnPlaceholderBlockSize = $state<string | null>(null);
   let lastInvalidKeyWarning = '';
 
   const keyValidation = $derived(validateKanbanBoardKeys(columns, getCardKey));
@@ -109,6 +110,25 @@
     );
   });
 
+  const crossColumnCardTarget = $derived.by((): CardMoveTarget | null => {
+    if (cardController.phase !== 'lifted' || cardController.liftedKey === null || !cardTarget) {
+      return null;
+    }
+    const located = findCard(columns, getCardKey, cardController.liftedKey);
+    const targetColumn = columns[cardTarget.columnIndex];
+    if (!located || !targetColumn || targetColumn.collapsed) return null;
+    if (located.columnIndex === cardTarget.columnIndex) return null;
+    return {
+      columnIndex: cardTarget.columnIndex,
+      cardIndex: Math.max(0, Math.min(cardTarget.cardIndex, targetColumn.cards.length)),
+    };
+  });
+  const crossColumnPlaceholderStyle = $derived(
+    crossColumnPlaceholderBlockSize
+      ? `--cinder-kanban-board-drop-placeholder-block-size: ${crossColumnPlaceholderBlockSize};`
+      : undefined,
+  );
+
   $effect(() => {
     if (!invalidKeys) {
       lastInvalidKeyWarning = '';
@@ -128,6 +148,18 @@
     if (!invalidKeys) return;
     if (cardController.phase === 'lifted') cancelCardLift();
     if (columnLiftedKey !== null) cancelColumnLift();
+  });
+
+  $effect(() => {
+    if (!columnsElement || !crossColumnCardTarget || cardController.liftedKey === null) {
+      crossColumnPlaceholderBlockSize = null;
+      return;
+    }
+
+    const liftedRow = getLiftedRowElement();
+    const liftedHeight = liftedRow?.getBoundingClientRect().height ?? 0;
+
+    crossColumnPlaceholderBlockSize = liftedHeight > 0 ? `${liftedHeight}px` : null;
   });
 
   $effect(() => {
@@ -186,6 +218,39 @@
     };
   }
 
+  function getColumnCardListElement(columnElement: HTMLElement): HTMLElement | null {
+    return (
+      Array.from(columnElement.children).find(
+        (child): child is HTMLElement =>
+          child instanceof HTMLElement && child.classList.contains('cinder-kanban-board__cards'),
+      ) ?? null
+    );
+  }
+
+  function sortableRowMatchesKey(row: HTMLElement, key: string | number): boolean {
+    return (
+      row.getAttribute('data-key') === String(key) &&
+      row.getAttribute('data-key-type') === typeof key
+    );
+  }
+
+  function getLiftedRowElement(): HTMLElement | null {
+    if (!columnsElement || cardController.liftedKey === null) return null;
+    return (
+      Array.from(columnsElement.querySelectorAll<HTMLElement>('[data-sortable-row]')).find((row) =>
+        sortableRowMatchesKey(row, cardController.liftedKey as string | number),
+      ) ?? null
+    );
+  }
+
+  function getLiftedRowBlockSize(): number {
+    return getLiftedRowElement()?.getBoundingClientRect().height ?? 0;
+  }
+
+  function getColumnDropZoneBottom(cardList: HTMLElement): number {
+    return cardList.getBoundingClientRect().bottom + getLiftedRowBlockSize();
+  }
+
   function locatePointerTarget(pointerX: number, pointerY: number): CardMoveTarget | null {
     if (!columnsElement) return null;
     const columnElements = Array.from(columnsElement.children).filter(
@@ -194,19 +259,19 @@
     );
     const columnIndex = columnElements.findIndex((element) => {
       const rect = element.getBoundingClientRect();
+      const cardList = getColumnCardListElement(element);
+      if (!cardList) return false;
       return (
         pointerX >= rect.left &&
         pointerX <= rect.right &&
         pointerY >= rect.top &&
-        pointerY <= rect.bottom
+        pointerY <= getColumnDropZoneBottom(cardList)
       );
     });
     if (columnIndex < 0 || columns[columnIndex]?.collapsed) return null;
     const columnElement = columnElements[columnIndex];
     if (!columnElement) return null;
-    const cardList = columnElement.querySelector<HTMLElement>(
-      ':scope > .cinder-kanban-board__cards',
-    );
+    const cardList = getColumnCardListElement(columnElement);
     // Exclude the dragged card by its stable data-key attribute so the filter
     // works regardless of whether the card is in the keyboard-drag state
     // (cinder-sortable-item--lifted) or the pointer-drag state
@@ -216,13 +281,34 @@
       (row): row is HTMLElement =>
         row instanceof HTMLElement &&
         row.hasAttribute('data-sortable-row') &&
-        row.getAttribute('data-key') !== String(draggedKey),
+        (draggedKey === null || !sortableRowMatchesKey(row, draggedKey)),
     );
     const insertionIndex = rows.filter((row) => {
       const rect = row.getBoundingClientRect();
       return rect.top + rect.height / 2 < pointerY;
     }).length;
     return { columnIndex, cardIndex: insertionIndex };
+  }
+
+  function hasCrossColumnPlaceholder(columnIndex: number): boolean {
+    return crossColumnCardTarget?.columnIndex === columnIndex;
+  }
+
+  function shouldRenderCrossColumnPlaceholder(columnIndex: number, cardIndex: number): boolean {
+    return (
+      crossColumnCardTarget?.columnIndex === columnIndex &&
+      crossColumnCardTarget.cardIndex === cardIndex
+    );
+  }
+
+  function shouldRenderCrossColumnAppendPlaceholder(
+    column: KanbanBoardColumn<Card>,
+    columnIndex: number,
+  ): boolean {
+    return (
+      crossColumnCardTarget?.columnIndex === columnIndex &&
+      crossColumnCardTarget.cardIndex >= column.cards.length
+    );
   }
 
   function getDestinationTotal(target: CardMoveTarget, itemKey: string | number | null): number {
@@ -526,6 +612,14 @@
             aria-label={`${column.title} cards`}
           >
             {#each column.cards as currentCard, cardIndex (invalidKeys ? `${getCardKey(currentCard)}-${cardIndex}` : getCardKey(currentCard))}
+              {#if shouldRenderCrossColumnPlaceholder(columnIndex, cardIndex)}
+                <li
+                  class="cinder-kanban-board__card cinder-kanban-board__drop-placeholder cinder-sortable-item--placeholder"
+                  role="presentation"
+                  aria-hidden="true"
+                  style={crossColumnPlaceholderStyle}
+                ></li>
+              {/if}
               {@const cardKey = getCardKey(currentCard)}
               {@const original = cardLocations.get(cardKey) ?? null}
               {@const itemLabel = getCardLabel(
@@ -560,7 +654,15 @@
                 {/snippet}
               </SortableItem>
             {/each}
-            {#if column.cards.length === 0}
+            {#if shouldRenderCrossColumnAppendPlaceholder(column, columnIndex)}
+              <li
+                class="cinder-kanban-board__card cinder-kanban-board__drop-placeholder cinder-sortable-item--placeholder"
+                role="presentation"
+                aria-hidden="true"
+                style={crossColumnPlaceholderStyle}
+              ></li>
+            {/if}
+            {#if column.cards.length === 0 && !hasCrossColumnPlaceholder(columnIndex)}
               <li class="cinder-kanban-board__empty">
                 {#if emptyColumn}
                   {@render emptyColumn(column)}

--- a/packages/components/src/components/kanban-board/kanban-board.svelte
+++ b/packages/components/src/components/kanban-board/kanban-board.svelte
@@ -247,12 +247,13 @@
     return getLiftedRowElement()?.getBoundingClientRect().height ?? 0;
   }
 
-  function getColumnDropZoneBottom(cardList: HTMLElement): number {
-    return cardList.getBoundingClientRect().bottom + getLiftedRowBlockSize();
+  function getColumnDropZoneBottom(cardList: HTMLElement, liftedRowBlockSize: number): number {
+    return cardList.getBoundingClientRect().bottom + liftedRowBlockSize;
   }
 
   function locatePointerTarget(pointerX: number, pointerY: number): CardMoveTarget | null {
     if (!columnsElement) return null;
+    const liftedRowBlockSize = getLiftedRowBlockSize();
     const columnElements = Array.from(columnsElement.children).filter(
       (element): element is HTMLElement =>
         element instanceof HTMLElement && element.classList.contains('cinder-kanban-board__column'),
@@ -265,7 +266,7 @@
         pointerX >= rect.left &&
         pointerX <= rect.right &&
         pointerY >= rect.top &&
-        pointerY <= getColumnDropZoneBottom(cardList)
+        pointerY <= getColumnDropZoneBottom(cardList, liftedRowBlockSize)
       );
     });
     if (columnIndex < 0 || columns[columnIndex]?.collapsed) return null;

--- a/packages/components/src/components/kanban-board/kanban-board.test.ts
+++ b/packages/components/src/components/kanban-board/kanban-board.test.ts
@@ -81,16 +81,30 @@ function installPointerGeometry(container: HTMLElement): void {
   const columns = Array.from(
     container.querySelectorAll<HTMLElement>('.cinder-kanban-board__column'),
   );
+  const columnsElement = container.querySelector<HTMLElement>('.cinder-kanban-board__columns');
+  if (columnsElement) columnsElement.getBoundingClientRect = () => makeRect(0, 0, 660, 400);
+
   columns.forEach((column, index) => {
     column.getBoundingClientRect = () => makeRect(index * 220, 0, 200, 400);
   });
 
+  const nextRowIndexByColumn = new Map<HTMLElement, number>();
   const cards = Array.from(container.querySelectorAll<HTMLElement>('[data-sortable-row]'));
-  cards.forEach((card, index) => {
+  cards.forEach((card) => {
     const column = card.closest('.cinder-kanban-board__column') as HTMLElement;
     const columnIndex = columns.indexOf(column);
-    const rowIndex = columnIndex === 0 ? index : 0;
+    const rowIndex = nextRowIndexByColumn.get(column) ?? 0;
+    nextRowIndexByColumn.set(column, rowIndex + 1);
     card.getBoundingClientRect = () => makeRect(columnIndex * 220, rowIndex * 56, 180, 48);
+  });
+
+  columns.forEach((column, columnIndex) => {
+    const rowCount = nextRowIndexByColumn.get(column) ?? 0;
+    const cardList = column.querySelector<HTMLElement>('.cinder-kanban-board__cards');
+    if (cardList) {
+      cardList.getBoundingClientRect = () =>
+        makeRect(columnIndex * 220, 0, 200, Math.max(48, rowCount * 56));
+    }
   });
 }
 
@@ -915,7 +929,7 @@ describe('KanbanBoard pointer drag preview', () => {
     expect(document.querySelectorAll('[data-cinder-drag-preview]').length).toBe(0);
   });
 
-  test('cross-column pointer drag creates a preview and a placeholder in the source column', async () => {
+  test('cross-column pointer drag reserves space in the target column', async () => {
     const { container } = renderBoard();
     installPointerGeometry(container);
     const handle = container.querySelector('[aria-label="Move Alpha"]') as HTMLElement;
@@ -943,8 +957,231 @@ describe('KanbanBoard pointer drag preview', () => {
     expect(preview).not.toBeNull();
     expect(document.body.contains(preview)).toBe(true);
 
+    const columns = Array.from(
+      container.querySelectorAll<HTMLElement>('.cinder-kanban-board__column'),
+    );
+    const targetColumn = columns[1] as HTMLElement;
+    const placeholder = targetColumn.querySelector<HTMLElement>(
+      '.cinder-kanban-board__drop-placeholder',
+    );
+    const targetList = targetColumn.querySelector<HTMLElement>('.cinder-kanban-board__cards');
+
+    expect(container.querySelectorAll('.cinder-kanban-board__drop-placeholder').length).toBe(1);
+    expect(placeholder).not.toBeNull();
+    expect(placeholder?.hasAttribute('data-sortable-row')).toBe(false);
+    expect(
+      placeholder?.style.getPropertyValue('--cinder-kanban-board-drop-placeholder-block-size'),
+    ).toBe('48px');
+    expect(Array.from(targetList?.children ?? []).indexOf(placeholder as Element)).toBe(0);
+
     await fireEvent.pointerUp(handle, { pointerId: 1, pointerType: 'mouse' });
     expect(document.querySelector('[data-cinder-drag-preview]')).toBeNull();
+    expect(container.querySelector('.cinder-kanban-board__drop-placeholder')).toBeNull();
+  });
+
+  test('cross-column pointer drag can reserve append space below existing target cards', async () => {
+    const { container, onchange } = renderBoard();
+    installPointerGeometry(container);
+    const handle = container.querySelector('[aria-label="Move Alpha"]') as HTMLElement;
+    installPointerCapture(handle);
+
+    await fireEvent.pointerDown(handle, {
+      button: 0,
+      clientX: 20,
+      clientY: 20,
+      pointerId: 1,
+      pointerType: 'mouse',
+    });
+
+    await fireEvent.pointerMove(handle, {
+      clientX: 240,
+      clientY: 80,
+      pointerId: 1,
+      pointerType: 'mouse',
+    });
+    await waitForAnimationFrame();
+
+    const columns = Array.from(
+      container.querySelectorAll<HTMLElement>('.cinder-kanban-board__column'),
+    );
+    const targetColumn = columns[1] as HTMLElement;
+    const placeholder = targetColumn.querySelector<HTMLElement>(
+      '.cinder-kanban-board__drop-placeholder',
+    );
+    const targetList = targetColumn.querySelector<HTMLElement>('.cinder-kanban-board__cards');
+
+    expect(placeholder).not.toBeNull();
+    expect(Array.from(targetList?.children ?? []).indexOf(placeholder as Element)).toBe(1);
+
+    await fireEvent.pointerUp(handle, { pointerId: 1, pointerType: 'mouse' });
+
+    expect(container.querySelector('.cinder-kanban-board__drop-placeholder')).toBeNull();
+    const [nextColumns, change] = onchange.mock.calls[0];
+    expect(nextColumns[1].cards.map(getCardKey)).toEqual(['c', 'a']);
+    expect(change).toMatchObject({ toColumnKey: 'doing', toIndex: 1 });
+  });
+
+  test('cross-column pointer drag ignores a horizontal lane below the target drop zone', async () => {
+    const { container, onchange } = renderBoard();
+    installPointerGeometry(container);
+    const columns = Array.from(
+      container.querySelectorAll<HTMLElement>('.cinder-kanban-board__column'),
+    );
+    const targetColumn = columns[1] as HTMLElement;
+    const handle = container.querySelector('[aria-label="Move Alpha"]') as HTMLElement;
+    installPointerCapture(handle);
+
+    await fireEvent.pointerDown(handle, {
+      button: 0,
+      clientX: 20,
+      clientY: 20,
+      pointerId: 1,
+      pointerType: 'mouse',
+    });
+
+    await fireEvent.pointerMove(handle, {
+      clientX: 240,
+      clientY: 220,
+      pointerId: 1,
+      pointerType: 'mouse',
+    });
+    await waitForAnimationFrame();
+
+    expect(targetColumn.querySelector('.cinder-kanban-board__drop-placeholder')).toBeNull();
+
+    await fireEvent.pointerUp(window, { pointerId: 1, pointerType: 'mouse' });
+
+    expect(document.querySelector('[data-cinder-drag-preview]')).toBeNull();
+    expect(container.querySelector('.cinder-kanban-board__drop-placeholder')).toBeNull();
+    expect(handle.getAttribute('aria-pressed')).toBe('false');
+    expect(onchange).not.toHaveBeenCalled();
+  });
+
+  test('cross-column pointer drag commits when pointerup lands outside the handle', async () => {
+    const { container, onchange } = renderBoard();
+    installPointerGeometry(container);
+    const handle = container.querySelector('[aria-label="Move Alpha"]') as HTMLElement;
+    installPointerCapture(handle);
+
+    await fireEvent.pointerDown(handle, {
+      button: 0,
+      clientX: 20,
+      clientY: 20,
+      pointerId: 1,
+      pointerType: 'mouse',
+    });
+
+    await fireEvent.pointerMove(handle, {
+      clientX: 240,
+      clientY: 80,
+      pointerId: 1,
+      pointerType: 'mouse',
+    });
+    await waitForAnimationFrame();
+
+    expect(container.querySelector('.cinder-kanban-board__drop-placeholder')).not.toBeNull();
+
+    await fireEvent.pointerUp(window, { pointerId: 1, pointerType: 'mouse' });
+
+    expect(document.querySelector('[data-cinder-drag-preview]')).toBeNull();
+    expect(container.querySelector('.cinder-kanban-board__drop-placeholder')).toBeNull();
+    expect(handle.getAttribute('aria-pressed')).toBe('false');
+    const [nextColumns, change] = onchange.mock.calls[0];
+    expect(nextColumns[1].cards.map(getCardKey)).toEqual(['c', 'a']);
+    expect(change).toMatchObject({ toColumnKey: 'doing', toIndex: 1 });
+  });
+
+  test('cross-column pointer drag commits the latest target when released before the move frame', async () => {
+    const { container, onchange } = renderBoard();
+    installPointerGeometry(container);
+    const handle = container.querySelector('[aria-label="Move Alpha"]') as HTMLElement;
+    installPointerCapture(handle);
+
+    await fireEvent.pointerDown(handle, {
+      button: 0,
+      clientX: 20,
+      clientY: 20,
+      pointerId: 1,
+      pointerType: 'mouse',
+    });
+
+    await fireEvent.pointerMove(handle, {
+      clientX: 240,
+      clientY: 80,
+      pointerId: 1,
+      pointerType: 'mouse',
+    });
+    await fireEvent.pointerUp(window, { pointerId: 1, pointerType: 'mouse' });
+
+    expect(document.querySelector('[data-cinder-drag-preview]')).toBeNull();
+    expect(container.querySelector('.cinder-kanban-board__drop-placeholder')).toBeNull();
+    expect(handle.getAttribute('aria-pressed')).toBe('false');
+    const [nextColumns, change] = onchange.mock.calls[0];
+    expect(nextColumns[1].cards.map(getCardKey)).toEqual(['c', 'a']);
+    expect(change).toMatchObject({ toColumnKey: 'doing', toIndex: 1 });
+  });
+
+  test('cross-column pointer drag reserves space in an empty target column', async () => {
+    const { container } = renderBoard();
+    installPointerGeometry(container);
+    const handle = container.querySelector('[aria-label="Move Alpha"]') as HTMLElement;
+    installPointerCapture(handle);
+
+    await fireEvent.pointerDown(handle, {
+      button: 0,
+      clientX: 20,
+      clientY: 20,
+      pointerId: 1,
+      pointerType: 'mouse',
+    });
+
+    await fireEvent.pointerMove(handle, {
+      clientX: 460,
+      clientY: 4,
+      pointerId: 1,
+      pointerType: 'mouse',
+    });
+    await waitForAnimationFrame();
+
+    const columns = Array.from(
+      container.querySelectorAll<HTMLElement>('.cinder-kanban-board__column'),
+    );
+    const targetColumn = columns[2] as HTMLElement;
+
+    expect(targetColumn.querySelector('.cinder-kanban-board__drop-placeholder')).not.toBeNull();
+    expect(targetColumn.querySelector('.cinder-kanban-board__empty')).toBeNull();
+
+    await fireEvent.pointerUp(handle, { pointerId: 1, pointerType: 'mouse' });
+  });
+
+  test('pointercancel clears cross-column target placeholder without committing', async () => {
+    const { container, onchange } = renderBoard();
+    installPointerGeometry(container);
+    const handle = container.querySelector('[aria-label="Move Alpha"]') as HTMLElement;
+    installPointerCapture(handle);
+
+    await fireEvent.pointerDown(handle, {
+      button: 0,
+      clientX: 20,
+      clientY: 20,
+      pointerId: 1,
+      pointerType: 'mouse',
+    });
+
+    await fireEvent.pointerMove(handle, {
+      clientX: 240,
+      clientY: 80,
+      pointerId: 1,
+      pointerType: 'mouse',
+    });
+    await waitForAnimationFrame();
+
+    expect(container.querySelector('.cinder-kanban-board__drop-placeholder')).not.toBeNull();
+
+    await fireEvent.pointerCancel(handle, { pointerId: 1, pointerType: 'mouse' });
+
+    expect(container.querySelector('.cinder-kanban-board__drop-placeholder')).toBeNull();
+    expect(onchange).not.toHaveBeenCalled();
   });
 
   // ---------------------------------------------------------------------------
@@ -957,12 +1194,9 @@ describe('KanbanBoard pointer drag preview', () => {
   // the dragged card was NOT excluded — skewing midpoint calculations. The fix
   // filters by data-key, which is present and stable in both drag states.
   //
-  // Note: happy-dom does not support ':scope >' in Element.querySelector, so
-  // locatePointerTarget's card-list lookup returns null in this environment and
-  // all pointer-drag cardIndex values always resolve to 0 (empty row set →
-  // insertionIndex 0). The full midpoint-computation path is correct in real
-  // browsers; the tests below verify the class-state invariant that the old
-  // filter would have broken.
+  // The tests below verify the class-state invariant that the old filter would
+  // have broken: data-key is the stable exclusion marker across pointer and
+  // keyboard drag states.
   // ---------------------------------------------------------------------------
 
   test('pointer drag: dragged row gets --placeholder (not --lifted) — old class filter would miss it', async () => {


### PR DESCRIPTION
## Summary

- keep the active dragged Kanban card mounted while rendering an inert in-flow placeholder in the cross-column target column
- reserve append and empty-column space with a measured placeholder height, while keeping same-column preview behavior unchanged
- flush pending pointer target updates on drop and finish pointer sessions from window-level pointerup/pointercancel so selection state cannot get stuck
- bound pointer hit testing to each column card-list drop zone plus append room instead of the full board height

## Review committee

Pre-reviewed by: frontend-architect, testing-expert, ux-designer, typescript-expert, simplicity-engineer, junior-engineer, Codex

- 4 rounds of review
- All must-fix items addressed
- Post-creation reviewer requested: @copilot

## Test plan

- `bun run --filter='@lostgradient/cinder' test kanban-board`
- `bun run --filter='@lostgradient/cinder' test sortable-list`
- `bun run --filter='@lostgradient/cinder' typecheck`
- `bun run --filter='@lostgradient/cinder' lint`
- `bunx stylelint packages/components/src/components/kanban-board/kanban-board.css`
- `bunx prettier --check packages/components/src/components/_sortable-item.svelte packages/components/src/components/kanban-board/kanban-board.svelte packages/components/src/components/kanban-board/kanban-board.css packages/components/src/components/kanban-board/kanban-board.test.ts`
- `git diff --check`
- pre-commit hook: lint-staged, `@lostgradient/cinder typecheck`, `@lostgradient/cinder test`
- pre-push hook: scoped validation for `@lostgradient/cinder` and `@cinder/playground`
- browser verification: Playwright mouse drag in the Kanban playground confirmed one target placeholder during drag, drop committed to Active at the expected index, and preview/pressed state cleared

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches pointer/drag lifecycle and DOM hit-testing for card reordering; regressions could affect drop commits or stuck drag state, but scope is UI interaction only.
> 
> **Overview**
> Fixes **Kanban cross-column pointer drags** so the source card stays mounted while the **target column** shows an in-flow, height-matched drop slot (including append and empty columns), without changing same-column placeholder/preview behavior.
> 
> **Sortable item** now listens for **window `pointerup` / `pointercancel`**, flushes a pending move **before commit on drop**, and tags rows with **`data-key-type`** so keys are matched reliably when excluding the dragged row from hit-testing.
> 
> **Kanban board** tightens pointer targeting to each column’s **card-list drop zone plus append room** (not the full column height), renders **`.cinder-kanban-board__drop-placeholder`** from derived cross-column target state, and styles placeholders via **`--cinder-kanban-board-drop-placeholder-block-size`**. Tests cover placeholders, window release, cancel, and drop-zone bounds.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 642df6a41ec031af8a9db0edcb8eaf76a5560f25. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->