### PR TITLE
chore(release): 0.1.1 — release-pipeline hardening

### DIFF
--- a/.github/workflows/release-manual.yaml
+++ b/.github/workflows/release-manual.yaml
@@ -33,7 +33,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v1
         with:
-          bun-version: 1.3.2
+          bun-version: 1.3.13
 
       - name: Verify tag matches package.json version
         working-directory: packages/components
@@ -83,7 +83,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v1
         with:
-          bun-version: 1.3.2
+          bun-version: 1.3.13
 
       - name: Install dependencies
         run: bun install --frozen-lockfile
@@ -100,22 +100,22 @@ jobs:
       - name: Check package artifact budget
         run: bun run --filter=@lostgradient/cinder package:weight:check -- --existing-tarball
 
-      # Break-glass publish. The primary release path (release.yaml) uses npm
-      # Trusted Publishing (OIDC) and requires no long-lived token. This manual
-      # fallback uses NPM_TOKEN intentionally as an emergency-only alternative
-      # for when the Changesets/OIDC primary path is unavailable. Do NOT use
-      # this workflow for routine releases. Provenance is still emitted via
-      # NPM_CONFIG_PROVENANCE and the `id-token: write` permission on this job.
+      # Break-glass publish. The primary release path (release.yaml) is the
+      # Changesets/OIDC route; this manual fallback uses NPM_TOKEN as an
+      # emergency-only alternative for when that path is unavailable. Do NOT
+      # use this workflow for routine releases.
+      #
+      # Provenance is DISABLED here: `publish:release` runs `npm publish` under
+      # Bun, and npm's provenance signing fails under Bun's BoringSSL with
+      # ERR_OSSL_NO_DEFAULT_DIGEST. Disabled in BOTH the env below AND
+      # package.json#publishConfig.provenance so npm config precedence is
+      # irrelevant — they agree. Re-enable provenance only once it's proven to
+      # sign cleanly under the publish runtime (needs a Node publish path or a
+      # verified Bun/BoringSSL fix).
       #
       # Token rotation: NPM_TOKEN should be rotated at least every 90 days per
       # security policy. The token is a Granular Access Token scoped to the
       # `cinder` package only — never use a full-access automation token.
-      # Provenance is DISABLED for this break-glass first publish: npm's
-      # provenance signing fails under Bun's BoringSSL with
-      # ERR_OSSL_NO_DEFAULT_DIGEST. Disabled in both the env here AND
-      # package.json#publishConfig.provenance so npm config precedence is
-      # irrelevant — they agree. Restore provenance when migrating back to
-      # the OIDC release.yaml path (Node runtime, working sigstore).
       - name: Publish to npm
         env:
           NPM_CONFIG_PROVENANCE: 'false'

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -43,7 +43,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v1
         with:
-          bun-version: 1.3.2
+          bun-version: 1.3.13
 
       - name: Setup Node
         uses: actions/setup-node@v5
@@ -91,8 +91,14 @@ jobs:
       # Primary publish path: npm Trusted Publishing (OIDC). No long-lived token.
       # npm >= 11.5.1 (installed above) + id-token: write (on this job) + the npm
       # package's Trusted Publisher configured at registry.npmjs.org automatically
-      # exchanges the GitHub OIDC token for a publish grant. NPM_CONFIG_PROVENANCE
-      # and publishConfig.provenance=true in package.json both stay active.
+      # exchanges the GitHub OIDC token for a publish grant.
+      #
+      # Provenance is DISABLED to match package.json#publishConfig.provenance
+      # (false) — `publish:release` runs `npm publish` under Bun, whose BoringSSL
+      # fails provenance signing with ERR_OSSL_NO_DEFAULT_DIGEST. The env and
+      # publishConfig agree at false so npm config precedence can't reintroduce
+      # the failure. Re-enable provenance in BOTH places only once signing is
+      # proven under the publish runtime.
       #
       # If this path breaks and a token-based emergency publish is required, use
       # .github/workflows/release-manual.yaml instead (see CONTRIBUTING.md).
@@ -100,7 +106,7 @@ jobs:
         if: github.event_name == 'push' && steps.changesets.outputs.hasChangesets == 'false'
         run: bun run --filter=@lostgradient/cinder publish:release -- --skip-validation
         env:
-          NPM_CONFIG_PROVENANCE: 'true'
+          NPM_CONFIG_PROVENANCE: 'false'
 
       # Diagnostic dry-run: publish the same staged tarball that
       # validate:consumer installs into the fixture apps.

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @lostgradient/cinder
 
+## 0.1.1
+
+### Patch Changes
+
+- Harden the release pipeline (no library/runtime changes):
+  - `verify-release-version.ts` now prefers `TAG_NAME` over `GITHUB_REF_NAME`, so a `workflow_dispatch` release no longer needs a tag-ref workaround to pass the version check.
+  - Pin Bun to `1.3.13` in `release.yaml` and `release-manual.yaml` (was the stale `1.3.2`), aligning them with the rest of CI and fixing the `dequal` bundler "Multiple files share the same output path" collision.
+  - Disable npm provenance consistently in both `NPM_CONFIG_PROVENANCE` and `publishConfig.provenance`, since `npm publish` runs under Bun's BoringSSL which fails provenance signing (`ERR_OSSL_NO_DEFAULT_DIGEST`).
+
 ## 0.1.0
 
 ### Major Changes

--- a/packages/components/components.json
+++ b/packages/components/components.json
@@ -3,7 +3,7 @@
   "manifestVersion": 1,
   "package": {
     "name": "@lostgradient/cinder",
-    "version": "0.1.0",
+    "version": "0.1.1",
     "framework": "svelte",
     "frameworkVersionRange": ">=5.55.0 <6",
     "classPrefix": "cinder-",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lostgradient/cinder",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "A Svelte 5 component library and design system focused on accessibility, theming, and per-component tree-shaking.",
   "keywords": [
     "svelte",

--- a/packages/components/scripts/verify-release-version.ts
+++ b/packages/components/scripts/verify-release-version.ts
@@ -3,7 +3,12 @@ import path from 'node:path';
 
 const tagArg = process.argv.find((arg) => arg.startsWith('--tag='));
 const explicitTag = tagArg ? tagArg.slice('--tag='.length) : undefined;
-const refTag = process.env['GITHUB_REF_NAME'] ?? process.env['TAG_NAME'] ?? '';
+// `TAG_NAME` is the deliberate, workflow-supplied tag and must win over
+// `GITHUB_REF_NAME`. On a `workflow_dispatch` run `GITHUB_REF_NAME` is the
+// dispatch ref (the branch, e.g. `main`), NOT the release tag — so preferring it
+// would always fail the version check even though the workflow checked out the
+// correct `refs/tags/vX.Y.Z` and passed `TAG_NAME` explicitly.
+const refTag = process.env['TAG_NAME'] ?? process.env['GITHUB_REF_NAME'] ?? '';
 const tag = explicitTag ?? refTag;
 
 if (!tag) {


### PR DESCRIPTION
## Summary

Patch release of `@lostgradient/cinder` (0.1.0 → 0.1.1). **No library or runtime changes** — this bundles the post-0.1.0 release-pipeline follow-ups so the next publish is push-button instead of the four-failure cascade 0.1.0 took.

Three substantive changes:

1. **`verify-release-version.ts` precedence.** Prefer `TAG_NAME` over `GITHUB_REF_NAME`. On a `workflow_dispatch` run, `GITHUB_REF_NAME` is the dispatch ref (the branch, e.g. `main`), not the release tag — so preferring it always failed the version check even though the workflow checked out `refs/tags/vX.Y.Z` and passed `TAG_NAME` explicitly. This removes the `--ref v0.1.0` workaround future dispatches needed.

2. **Bun pin `1.3.2` → `1.3.13`** in `release.yaml` and `release-manual.yaml` (both pins). These were the only two workflows still on the stale `1.3.2`; every other workflow already uses `BUN_VERSION: 1.3.13`. Fixes the `dequal` bundler `Multiple files share the same output path` collision under 1.3.2 that kept `release.yaml`'s `bun run validate` step red on main.

3. **Provenance disabled consistently** — `NPM_CONFIG_PROVENANCE: 'false'` in both workflows, matching `package.json#publishConfig.provenance: false`. `npm publish` runs under Bun's BoringSSL, which fails provenance signing with `ERR_OSSL_NO_DEFAULT_DIGEST`. Both sources agree so npm config precedence can't reintroduce the failure. Stale/contradictory comment blocks in both workflows were rewritten to match.

Generated by `changeset version` + `components:generate`: `CHANGELOG.md`, `components.json`, `package.json` version.

## Publish sequencing (important)

The Bun bump **unmasks** `release.yaml`'s publish step: for 0.1.0 that workflow died at `validate` (the dequal collision) and never reached publish. With validate now passing, the publish step becomes reachable — but its OIDC auth isn't configured yet, so publishing *from it* would fail.

The plan, which keeps main green:
1. Publish 0.1.1 via **`release-manual`** first (token auth, the proven path), tag `v0.1.1`.
2. **Then** merge this PR. `release.yaml` fires, `validate` passes, and `publish-release.ts` finds 0.1.1 already on npm (`packageVersionExists` short-circuit) → "nothing to publish" → exit 0 → release.yaml green.

## Known limitation (out of scope, user-blocked)

Full OIDC migration — letting `release.yaml` publish on its own and retiring the manual dance — needs a **Trusted Publisher configured on npmjs.com** (a manual web-UI action) plus a verified fix for provenance-signing under the publish runtime. Reported, not attempted here.

## Review committee

Pre-reviewed by Codex (gpt-5.4; xhigh round 1, high round 2) — 2 rounds, consensus reached.
- **Round 1 (must-fix):** the CHANGELOG 0.1.1 entry credited the fixture `app.css` scoped-import fix, but that shipped in **0.1.0** (commit `db73ae52`, an ancestor of the `v0.1.0` tag), not this release. Bullet removed; release commit amended.
- **Round 2:** APPROVED, no new issues.

> [!NOTE]
> The four Claude subagents (dx-engineer, typescript-expert, simplicity-engineer, junior-engineer) were dispatched but blocked by the session-wide "Usage credits required for 1M context" gate and never ran. Codex carried the review, consistent with the 0.1.0 PRs.

## Test plan

- `verify-release-version.ts` precedence verified locally across three scenarios: main-ref dispatch (the original bug) now passes, tag-ref dispatch passes, genuine version mismatch still exits 1.
- Both workflow YAMLs parse cleanly.
- `@lostgradient/cinder` typecheck + full test suite green via pre-commit.
- `changeset version` correctly computed 0.1.1; `components.json` regenerated to 0.1.1 (version-only diff).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches npm publish configuration and release workflows; mistaken version or publish settings could block or mis-tag releases, but there is no consumer-facing API change.
> 
> **Overview**
> **Patch release `@lostgradient/cinder` 0.1.0 → 0.1.1** with **no library/runtime changes**—only release pipeline and version metadata.
> 
> **`verify-release-version.ts`** now resolves the tag as `TAG_NAME` before `GITHUB_REF_NAME`, so manual `release-manual` runs that checkout a tag but dispatch from `main` pass the version check without a tag-ref workaround.
> 
> **CI:** `release.yaml` and `release-manual.yaml` pin **Bun 1.3.13** (was 1.3.2), matching other workflows and avoiding the stale Bun `dequal` bundler collision on validate.
> 
> **npm publish:** **`NPM_CONFIG_PROVENANCE` is set to `false`** on the primary `release.yaml` publish step (was `true`), aligned with `publishConfig.provenance` and workflow comments—`npm publish` under Bun’s BoringSSL fails provenance signing (`ERR_OSSL_NO_DEFAULT_DIGEST`).
> 
> **Versioning artifacts:** `CHANGELOG.md` 0.1.1 entry, `package.json`, and `components.json` bumped to **0.1.1**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1bbdfd99eb83978ef29a187bd711f40b5c747108. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->