### PR TITLE
Normalize domain focus rings

### DIFF
--- a/packages/components/scripts/stylelint/no-focus-visible-colored-outline.test.ts
+++ b/packages/components/scripts/stylelint/no-focus-visible-colored-outline.test.ts
@@ -17,9 +17,10 @@ async function lintWithDirectRule(css: string) {
   return result;
 }
 
-async function lintWithProjectConfig(css: string) {
+async function lintWithProjectConfig(css: string, codeFilename?: string) {
   const result = await stylelint.lint({
     code: css,
+    ...(codeFilename === undefined ? {} : { codeFilename }),
     configFile: new URL('../../../../.stylelintrc.json', import.meta.url).pathname,
   });
   return result;
@@ -250,5 +251,41 @@ describe('cinder/no-focus-visible-colored-outline — loaded through .stylelintr
       }
     `);
     expect(warningsFor(result).length).toBe(1);
+  });
+
+  test('colored outline inside a Svelte style block is rejected through the project config', async () => {
+    const result = await lintWithProjectConfig(
+      `
+        <button class="demo">Demo</button>
+
+        <style>
+          .demo:focus-visible {
+            outline: var(--cinder-ring-width) solid var(--cinder-ring-color);
+          }
+        </style>
+      `,
+      'fixture.svelte',
+    );
+    const hits = warningsFor(result);
+    expect(hits.length).toBe(1);
+    expect(hits[0]?.severity).toBe('error');
+    expect(result.errored).toBe(true);
+  });
+
+  test('canonical recipe inside a Svelte style block passes through the project config', async () => {
+    const result = await lintWithProjectConfig(
+      `
+        <button class="demo">Demo</button>
+
+        <style>
+          .demo:focus-visible {
+            outline: var(--cinder-ring-width) solid transparent;
+            box-shadow: var(--_cinder-focus-ring-shadow);
+          }
+        </style>
+      `,
+      'fixture.svelte',
+    );
+    expect(warningsFor(result)).toEqual([]);
   });
 });

--- a/packages/components/src/components/chat/container/chat-jump-controls.svelte
+++ b/packages/components/src/components/chat/container/chat-jump-controls.svelte
@@ -121,10 +121,8 @@
   }
 
   .chat-jump-button:focus-visible {
-    outline: 2px solid transparent;
-    box-shadow:
-      0 0 0 var(--cinder-ring-offset) var(--cinder-ring-offset-color),
-      0 0 0 calc(var(--cinder-ring-offset) + var(--cinder-ring-width)) var(--cinder-ring-color);
+    outline: var(--cinder-ring-width) solid transparent;
+    box-shadow: var(--_cinder-focus-ring-shadow);
   }
 
   /* Unread Count Badge */
@@ -180,11 +178,16 @@
   }
 
   .chat-new-indicator:focus-visible {
-    outline: 2px solid transparent;
-    box-shadow:
-      0 0 0 var(--cinder-ring-offset) var(--cinder-ring-offset-color),
-      0 0 0 calc(var(--cinder-ring-offset) + var(--cinder-ring-width)) var(--cinder-ring-color),
-      var(--cinder-shadow-lg);
+    outline: var(--cinder-ring-width) solid transparent;
+    box-shadow: var(--_cinder-focus-ring-shadow), var(--cinder-shadow-lg);
+  }
+
+  @media (forced-colors: active) {
+    .chat-jump-button:focus-visible,
+    .chat-new-indicator:focus-visible {
+      outline: var(--cinder-ring-width) solid ButtonText;
+      outline-offset: 3px;
+    }
   }
 
   @keyframes slide-up {

--- a/packages/components/src/components/chat/input/chat-input.svelte
+++ b/packages/components/src/components/chat/input/chat-input.svelte
@@ -854,10 +854,8 @@
   }
 
   .chat-input-send:focus-visible {
-    outline: 2px solid transparent;
-    box-shadow:
-      0 0 0 var(--cinder-ring-offset) var(--cinder-ring-offset-color),
-      0 0 0 calc(var(--cinder-ring-offset) + var(--cinder-ring-width)) var(--cinder-accent);
+    outline: var(--cinder-ring-width) solid transparent;
+    box-shadow: var(--_cinder-focus-ring-shadow);
   }
 
   /* Stop button variant - danger-tinted to signal urgency during streaming */
@@ -874,10 +872,11 @@
     }
   }
 
-  .chat-input-send[data-stop]:focus-visible {
-    box-shadow:
-      0 0 0 var(--cinder-ring-offset) var(--cinder-ring-offset-color),
-      0 0 0 calc(var(--cinder-ring-offset) + var(--cinder-ring-width)) var(--cinder-danger);
+  @media (forced-colors: active) {
+    .chat-input-send:focus-visible {
+      outline: var(--cinder-ring-width) solid ButtonText;
+      outline-offset: 3px;
+    }
   }
 
   /* Spinner */

--- a/packages/components/src/components/chat/message/chat-message.svelte
+++ b/packages/components/src/components/chat/message/chat-message.svelte
@@ -347,9 +347,7 @@
 
   .chat-message:focus-visible {
     outline: var(--cinder-ring-width) solid transparent;
-    box-shadow:
-      0 0 0 var(--cinder-ring-offset) var(--cinder-ring-offset-color),
-      0 0 0 calc(var(--cinder-ring-offset) + var(--cinder-ring-width)) var(--cinder-ring-color);
+    box-shadow: var(--_cinder-focus-ring-shadow);
   }
 
   /* Search match highlight — subtle accent-tinted ring */
@@ -571,9 +569,7 @@
 
   .chat-message-expand:focus-visible {
     outline: var(--cinder-ring-width) solid transparent;
-    box-shadow:
-      0 0 0 var(--cinder-ring-offset) var(--cinder-ring-offset-color),
-      0 0 0 calc(var(--cinder-ring-offset) + var(--cinder-ring-width)) var(--cinder-ring-color);
+    box-shadow: var(--_cinder-focus-ring-shadow);
   }
 
   /* Failed message styling */
@@ -622,9 +618,7 @@
 
   .chat-message-retry:focus-visible {
     outline: var(--cinder-ring-width) solid transparent;
-    box-shadow:
-      0 0 0 var(--cinder-ring-offset) var(--cinder-ring-offset-color),
-      0 0 0 calc(var(--cinder-ring-offset) + var(--cinder-ring-width)) var(--cinder-ring-color);
+    box-shadow: var(--_cinder-focus-ring-shadow);
   }
 
   /* Footer — absolutely positioned outside the bubble's flow so revealing it on
@@ -757,9 +751,7 @@
 
   :global(.chat-message-action-button:focus-visible) {
     outline: var(--cinder-ring-width) solid transparent;
-    box-shadow:
-      0 0 0 var(--cinder-ring-offset) var(--cinder-ring-offset-color),
-      0 0 0 calc(var(--cinder-ring-offset) + var(--cinder-ring-width)) var(--cinder-ring-color);
+    box-shadow: var(--_cinder-focus-ring-shadow);
   }
 
   /* Touch devices: without hover discoverability, bare icons read as
@@ -818,7 +810,9 @@
   }
 
   .chat-message-edit-textarea:focus {
-    box-shadow: 0 0 0 2px color-mix(in oklch, var(--cinder-accent), transparent 75%);
+    outline: var(--cinder-ring-width) solid transparent;
+    outline-offset: var(--cinder-ring-offset);
+    box-shadow: var(--_cinder-focus-ring-shadow);
   }
 
   .chat-message-edit-actions {
@@ -848,9 +842,7 @@
 
   .chat-message-edit-save:focus-visible {
     outline: var(--cinder-ring-width) solid transparent;
-    box-shadow:
-      0 0 0 var(--cinder-ring-offset) var(--cinder-ring-offset-color),
-      0 0 0 calc(var(--cinder-ring-offset) + var(--cinder-ring-width)) var(--cinder-ring-color);
+    box-shadow: var(--_cinder-focus-ring-shadow);
   }
 
   .chat-message-edit-cancel {
@@ -877,9 +869,7 @@
 
   .chat-message-edit-cancel:focus-visible {
     outline: var(--cinder-ring-width) solid transparent;
-    box-shadow:
-      0 0 0 var(--cinder-ring-offset) var(--cinder-ring-offset-color),
-      0 0 0 calc(var(--cinder-ring-offset) + var(--cinder-ring-width)) var(--cinder-ring-color);
+    box-shadow: var(--_cinder-focus-ring-shadow);
   }
 
   /* Responsive sizing for narrow viewports */
@@ -896,9 +886,14 @@
 
   /* Forced-colors: box-shadow rings are suppressed in Windows High Contrast Mode,
      so repaint the reserved transparent outline channel with a system color.
-     Every selector here is button-shaped or a clickable region → ButtonText.
+     Text-entry focus uses Highlight; pressable regions use ButtonText.
      Placed after the base rules per the focus-ring policy's cascade note. */
   @media (forced-colors: active) {
+    .chat-message-edit-textarea:focus {
+      outline: var(--cinder-ring-width) solid Highlight;
+      outline-offset: 1px;
+    }
+
     .chat-message:focus-visible,
     .chat-message-expand:focus-visible,
     .chat-message-retry:focus-visible,

--- a/packages/components/src/components/chat/message/tool-call-group.svelte
+++ b/packages/components/src/components/chat/message/tool-call-group.svelte
@@ -182,10 +182,16 @@
   /* Focus: ring travels via box-shadow, not outline, so it sits inside the
    * card's colored border instead of doubling up on top of it. */
   .tool-call-header:focus-visible {
-    /* cinder-focus-ring-owner: parent — this header self-owns its inset
-       box-shadow ring; the outline is intentionally suppressed. */
-    outline: none;
-    box-shadow: inset 0 0 0 var(--cinder-ring-width) var(--cinder-ring-color);
+    outline: var(--cinder-ring-width) solid transparent;
+    box-shadow: inset 0 0 0 var(--cinder-ring-width)
+      var(--_cinder-tool-call-header-ring, var(--cinder-ring-color));
+  }
+
+  @media (forced-colors: active) {
+    .tool-call-header:focus-visible {
+      outline: var(--cinder-ring-width) solid ButtonText;
+      outline-offset: calc(var(--cinder-ring-width) * -1);
+    }
   }
 
   .tool-call-icon {

--- a/packages/components/src/components/diff-viewer/front-matter-header.svelte
+++ b/packages/components/src/components/diff-viewer/front-matter-header.svelte
@@ -142,10 +142,26 @@
   }
 
   .front-matter-header:focus-visible {
-    outline: 2px solid transparent;
-    box-shadow:
-      0 0 0 var(--cinder-ring-offset) var(--cinder-ring-offset-color),
-      0 0 0 calc(var(--cinder-ring-offset) + var(--cinder-ring-width)) var(--cinder-ring-color);
+    outline: var(--cinder-ring-width) solid transparent;
+    box-shadow: var(--_cinder-focus-ring-shadow);
+  }
+
+  .front-matter-header[data-variant='inline']:focus-visible {
+    outline: var(--cinder-ring-width) solid transparent;
+    box-shadow: inset 0 0 0 var(--cinder-ring-width)
+      var(--_cinder-front-matter-header-ring, var(--cinder-ring-color));
+  }
+
+  @media (forced-colors: active) {
+    .front-matter-header:focus-visible {
+      outline: var(--cinder-ring-width) solid ButtonText;
+      outline-offset: 3px;
+    }
+
+    .front-matter-header[data-variant='inline']:focus-visible {
+      outline: var(--cinder-ring-width) solid ButtonText;
+      outline-offset: calc(var(--cinder-ring-width) * -1);
+    }
   }
 
   .front-matter-icon {

--- a/packages/components/src/components/markdown-editor/editor-toolbar/toolbar-button.svelte
+++ b/packages/components/src/components/markdown-editor/editor-toolbar/toolbar-button.svelte
@@ -94,10 +94,15 @@
   }
 
   .toolbar-button:focus-visible {
-    outline: 2px solid transparent;
-    box-shadow:
-      0 0 0 var(--cinder-ring-offset) var(--cinder-ring-offset-color),
-      0 0 0 calc(var(--cinder-ring-offset) + var(--cinder-ring-width)) var(--cinder-ring-color);
+    outline: var(--cinder-ring-width) solid transparent;
+    box-shadow: var(--_cinder-focus-ring-shadow);
+  }
+
+  @media (forced-colors: active) {
+    .toolbar-button:focus-visible {
+      outline: var(--cinder-ring-width) solid ButtonText;
+      outline-offset: 3px;
+    }
   }
 
   .toolbar-button:disabled {

--- a/packages/components/src/components/markdown-editor/editor-toolbar/toolbar-dropdown.svelte
+++ b/packages/components/src/components/markdown-editor/editor-toolbar/toolbar-dropdown.svelte
@@ -104,10 +104,15 @@
   }
 
   :global(.toolbar-dropdown-trigger:focus-visible) {
-    outline: 2px solid transparent;
-    box-shadow:
-      0 0 0 var(--cinder-ring-offset) var(--cinder-ring-offset-color),
-      0 0 0 calc(var(--cinder-ring-offset) + var(--cinder-ring-width)) var(--cinder-ring-color);
+    outline: var(--cinder-ring-width) solid transparent;
+    box-shadow: var(--_cinder-focus-ring-shadow);
+  }
+
+  @media (forced-colors: active) {
+    :global(.toolbar-dropdown-trigger:focus-visible) {
+      outline: var(--cinder-ring-width) solid ButtonText;
+      outline-offset: 3px;
+    }
   }
 
   :global(.toolbar-dropdown-trigger:disabled) {

--- a/packages/components/src/components/markdown-editor/prosemirror.css
+++ b/packages/components/src/components/markdown-editor/prosemirror.css
@@ -45,8 +45,10 @@
     user-select: text;
   }
 
+  /* Selected-node styling, not keyboard focus. Keep the geometry distinct from
+     the shared focus ring while using a theme token instead of an upstream literal. */
   .ProseMirror-selectednode {
-    outline: 2px solid #8cf;
+    outline: 2px solid var(--cinder-accent);
   }
 
   /* Make sure li selections wrap around markers */
@@ -61,7 +63,7 @@
     right: -2px;
     top: -2px;
     bottom: -2px;
-    border: 2px solid #8cf;
+    border: 2px solid var(--cinder-accent);
     pointer-events: none;
   }
 

--- a/packages/components/src/components/review-editor/comment-composer.svelte
+++ b/packages/components/src/components/review-editor/comment-composer.svelte
@@ -254,11 +254,10 @@
   }
 
   .comment-composer-textarea:focus {
-    outline: none;
     border-color: var(--cinder-accent);
-    box-shadow:
-      0 0 0 var(--cinder-ring-offset) var(--cinder-ring-offset-color),
-      0 0 0 calc(var(--cinder-ring-offset) + var(--cinder-ring-width)) var(--cinder-accent);
+    outline: var(--cinder-ring-width) solid transparent;
+    outline-offset: var(--cinder-ring-offset);
+    box-shadow: var(--_cinder-focus-ring-shadow);
   }
 
   .comment-composer-textarea:disabled {
@@ -271,10 +270,11 @@
     border-color: var(--cinder-danger);
   }
 
-  .comment-composer-textarea[data-has-error='true']:focus {
-    box-shadow:
-      0 0 0 var(--cinder-ring-offset) var(--cinder-ring-offset-color),
-      0 0 0 calc(var(--cinder-ring-offset) + var(--cinder-ring-width)) var(--cinder-danger);
+  @media (forced-colors: active) {
+    .comment-composer-textarea:focus {
+      outline: var(--cinder-ring-width) solid Highlight;
+      outline-offset: 1px;
+    }
   }
 
   .comment-composer-error {

--- a/packages/components/src/components/review-editor/comment-list.svelte
+++ b/packages/components/src/components/review-editor/comment-list.svelte
@@ -258,8 +258,17 @@
   }
 
   .comment-edit-textarea:focus {
-    outline: none;
     border-color: var(--cinder-accent);
+    outline: var(--cinder-ring-width) solid transparent;
+    outline-offset: var(--cinder-ring-offset);
+    box-shadow: var(--_cinder-focus-ring-shadow);
+  }
+
+  @media (forced-colors: active) {
+    .comment-edit-textarea:focus {
+      outline: var(--cinder-ring-width) solid Highlight;
+      outline-offset: 1px;
+    }
   }
 
   .comment-edit-actions {

--- a/packages/components/src/test/focus-ring-recipe.test.ts
+++ b/packages/components/src/test/focus-ring-recipe.test.ts
@@ -71,11 +71,23 @@ const treeCss = loadCss('../components/tree/tree.css');
 
 // Svelte component <style> blocks converted in the same sweep.
 const markdownEditorStyle = loadSvelteStyle('../components/markdown-editor/markdown-editor.svelte');
+const prosemirrorCss = loadCss('../components/markdown-editor/prosemirror.css');
+const toolbarButtonStyle = loadSvelteStyle(
+  '../components/markdown-editor/editor-toolbar/toolbar-button.svelte',
+);
+const toolbarDropdownStyle = loadSvelteStyle(
+  '../components/markdown-editor/editor-toolbar/toolbar-dropdown.svelte',
+);
 const linkPopoverStyle = loadSvelteStyle(
   '../components/markdown-editor/editor-toolbar/link-popover.svelte',
 );
 const diffLineStyle = loadSvelteStyle('../components/diff-viewer/diff-line.svelte');
+const frontMatterHeaderStyle = loadSvelteStyle(
+  '../components/diff-viewer/front-matter-header.svelte',
+);
 const threadPopoverStyle = loadSvelteStyle('../components/review-editor/thread-popover.svelte');
+const commentComposerStyle = loadSvelteStyle('../components/review-editor/comment-composer.svelte');
+const commentListStyle = loadSvelteStyle('../components/review-editor/comment-list.svelte');
 const commentSidebarStyle = loadSvelteStyle('../components/review-editor/comment-sidebar.svelte');
 const reviewExportActionsStyle = loadSvelteStyle(
   '../components/review-editor/export-actions.svelte',
@@ -85,7 +97,12 @@ const conversationExportActionsStyle = loadSvelteStyle(
 );
 const artifactPanelStyle = loadSvelteStyle('../components/chat/artifact/artifact-panel.svelte');
 const chatStyle = loadSvelteStyle('../components/chat/container/chat.svelte');
+const chatJumpControlsStyle = loadSvelteStyle(
+  '../components/chat/container/chat-jump-controls.svelte',
+);
 const chatSearchBarStyle = loadSvelteStyle('../components/chat/container/chat-search-bar.svelte');
+const chatMessageStyle = loadSvelteStyle('../components/chat/message/chat-message.svelte');
+const toolCallGroupStyle = loadSvelteStyle('../components/chat/message/tool-call-group.svelte');
 const messageAttachmentsStyle = loadSvelteStyle(
   '../components/chat/message/message-attachments.svelte',
 );
@@ -684,6 +701,11 @@ describe('focus-ring sweep — Strategy B-inset Svelte selectors', () => {
       selector: 'button.diff-line:focus-visible',
     },
     {
+      name: 'inline front-matter header',
+      style: frontMatterHeaderStyle,
+      selector: ".front-matter-header[data-variant='inline']:focus-visible",
+    },
+    {
       name: 'link-popover close',
       style: linkPopoverStyle,
       selector: '.link-popover-close:focus-visible',
@@ -712,6 +734,11 @@ describe('focus-ring sweep — Strategy B-inset Svelte selectors', () => {
       name: 'message attachment button',
       style: messageAttachmentsStyle,
       selector: '.message-attachment-button:focus-visible',
+    },
+    {
+      name: 'tool-call header',
+      style: toolCallGroupStyle,
+      selector: '.tool-call-header:focus-visible',
     },
   ];
 
@@ -749,6 +776,66 @@ describe('focus-ring sweep — Strategy B (outer) Svelte selectors', () => {
       style: chatSearchBarStyle,
       selector: '.chat-search-nav-button:focus-visible',
     },
+    {
+      name: 'diff front-matter header',
+      style: frontMatterHeaderStyle,
+      selector: '.front-matter-header:focus-visible',
+    },
+    {
+      name: 'markdown toolbar button',
+      style: toolbarButtonStyle,
+      selector: '.toolbar-button:focus-visible',
+    },
+    {
+      name: 'markdown toolbar dropdown trigger',
+      style: toolbarDropdownStyle,
+      selector: ':global(.toolbar-dropdown-trigger:focus-visible)',
+    },
+    {
+      name: 'chat jump button',
+      style: chatJumpControlsStyle,
+      selector: '.chat-jump-button:focus-visible',
+    },
+    {
+      name: 'chat new indicator',
+      style: chatJumpControlsStyle,
+      selector: '.chat-new-indicator:focus-visible',
+    },
+    {
+      name: 'chat send button',
+      style: chatInputStyle,
+      selector: '.chat-input-send:focus-visible',
+    },
+    {
+      name: 'chat message row',
+      style: chatMessageStyle,
+      selector: '.chat-message:focus-visible',
+    },
+    {
+      name: 'chat message expand button',
+      style: chatMessageStyle,
+      selector: '.chat-message-expand:focus-visible',
+    },
+    {
+      name: 'chat message retry button',
+      style: chatMessageStyle,
+      selector: '.chat-message-retry:focus-visible',
+    },
+    {
+      name: 'chat message action button',
+      style: chatMessageStyle,
+      selector: ':global(.chat-message-action-button:focus-visible)',
+    },
+    {
+      name: 'chat message edit save',
+      style: chatMessageStyle,
+      selector: '.chat-message-edit-save:focus-visible',
+    },
+    {
+      name: 'chat message edit cancel',
+      style: chatMessageStyle,
+      selector: '.chat-message-edit-cancel:focus-visible',
+    },
   ];
 
   for (const { name, style, selector } of outerCases) {
@@ -756,6 +843,76 @@ describe('focus-ring sweep — Strategy B (outer) Svelte selectors', () => {
       assertOuterRecipe(style, selector);
     });
   }
+});
+
+describe('focus-ring sweep — text-entry focus selectors', () => {
+  const textEntryCases: Array<{ name: string; style: string; selector: string }> = [
+    {
+      name: 'chat message edit textarea',
+      style: chatMessageStyle,
+      selector: '.chat-message-edit-textarea:focus',
+    },
+    {
+      name: 'review comment composer textarea',
+      style: commentComposerStyle,
+      selector: '.comment-composer-textarea:focus',
+    },
+    {
+      name: 'review comment edit textarea',
+      style: commentListStyle,
+      selector: '.comment-edit-textarea:focus',
+    },
+  ];
+
+  for (const { name, style, selector } of textEntryCases) {
+    test(`${name}: ${selector} uses the shared focus ring + Highlight forced-colors fallback`, () => {
+      assertOuterRecipe(style, selector);
+      const root = parse(style);
+      const fallback = findRules(root, selector).find((rule) => isUnderForcedColors(rule));
+      expect(fallback).toBeDefined();
+      expect(declValue(fallback!, 'outline')).toBe('var(--cinder-ring-width) solid Highlight');
+      expect(declValue(fallback!, 'outline-offset')).toBe('1px');
+    });
+  }
+
+  test('review comment composer error state keeps validation border but does not own a danger focus ring', () => {
+    const root = parse(commentComposerStyle);
+    const errorState = findRule(root, ".comment-composer-textarea[data-has-error='true']");
+    expect(errorState).toBeDefined();
+    expect(declValue(errorState!, 'border-color')).toBe('var(--cinder-danger)');
+
+    const errorFocusRules = findRules(
+      root,
+      ".comment-composer-textarea[data-has-error='true']:focus",
+    );
+    expect(errorFocusRules).toEqual([]);
+
+    const focusRules = findRules(root, '.comment-composer-textarea:focus').filter(
+      (rule) => !isUnderForcedColors(rule),
+    );
+    expect(focusRules.length).toBeGreaterThanOrEqual(1);
+    expect(declValue(focusRules[0]!, 'box-shadow')).toContain(SHARED_BOX_SHADOW);
+    expect(declValue(focusRules[0]!, 'box-shadow')).not.toContain('var(--cinder-danger)');
+  });
+});
+
+describe('focus-ring sweep — selected/current state boundaries', () => {
+  test('chat stop button does not override the shared send-button focus ring with danger color', () => {
+    const root = parse(chatInputStyle);
+    const rules = findRules(root, '.chat-input-send[data-stop]:focus-visible');
+    expect(rules).toEqual([]);
+  });
+
+  test('ProseMirror selected nodes use a tokenized selected-state outline, not a focus selector', () => {
+    const root = parse(prosemirrorCss);
+    const selectedNode = findRule(root, '.ProseMirror-selectednode');
+    const selectedListItem = findRule(root, 'li.ProseMirror-selectednode:after');
+    expect(selectedNode).toBeDefined();
+    expect(selectedListItem).toBeDefined();
+    expect(selectedNode!.selector).not.toContain(':focus');
+    expect(declValue(selectedNode!, 'outline')).toBe('2px solid var(--cinder-accent)');
+    expect(declValue(selectedListItem!, 'border')).toBe('2px solid var(--cinder-accent)');
+  });
 });
 
 describe('chat-input attachment-remove — inset ring painted on the visible chip', () => {

--- a/packages/testing/tests/domain-focus-rings.playwright.ts
+++ b/packages/testing/tests/domain-focus-rings.playwright.ts
@@ -1,0 +1,240 @@
+/// <reference lib="dom" />
+/**
+ * Browser proof for dense domain focus rings.
+ *
+ * The source-level focus-ring tests pin the CSS recipes. This spec proves the
+ * rendered behavior inside a real Chat surface with keyboard Tab navigation:
+ * focus must come from the keyboard so Chromium applies :focus-visible.
+ */
+import { expect, test, type Browser, type Locator, type Page } from '@playwright/test';
+
+import { PLAYGROUND_URL } from '../src/helpers/playground-url.ts';
+import { THEME_STORAGE_KEY } from '../src/helpers/theme.ts';
+
+const HARNESS = '#example-mount-interactive-harness';
+
+type ChatHarnessPage = {
+  page: Page;
+  harness: Locator;
+  dispose: () => Promise<void>;
+};
+
+async function openChatHarness(
+  browser: Browser,
+  options: { forcedColors?: 'active' } = {},
+): Promise<ChatHarnessPage> {
+  const context = await browser.newContext({
+    baseURL: PLAYGROUND_URL,
+    colorScheme: 'dark',
+    reducedMotion: 'reduce',
+    viewport: { width: 1280, height: 900 },
+    ...(options.forcedColors !== undefined ? { forcedColors: options.forcedColors } : {}),
+  });
+  await context.addInitScript(
+    ([key, value]) => {
+      try {
+        localStorage.setItem(key, value);
+      } catch {
+        /* ignore */
+      }
+    },
+    [THEME_STORAGE_KEY, 'dark'] as const,
+  );
+
+  const page = await context.newPage();
+  await page.goto('/page/chat?snapshot=1', { waitUntil: 'load' });
+  await page.waitForSelector('#app > *', { state: 'visible', timeout: 20_000 });
+
+  const harness = page.locator(HARNESS);
+  await harness.waitFor({ state: 'visible', timeout: 20_000 });
+
+  return { page, harness, dispose: () => context.close() };
+}
+
+async function blurToBody(page: Page): Promise<void> {
+  await page.evaluate(() => {
+    if (document.activeElement instanceof HTMLElement) document.activeElement.blur();
+    document.body.focus();
+  });
+}
+
+async function activeElementSummary(page: Page): Promise<string> {
+  return page.evaluate(() => {
+    const element = document.activeElement;
+    if (!element) return '<none>';
+    const id = element.id ? `#${element.id}` : '';
+    const classes =
+      element instanceof HTMLElement && element.className
+        ? `.${String(element.className).trim().replace(/\s+/g, '.')}`
+        : '';
+    return `${element.tagName.toLowerCase()}${id}${classes}`;
+  });
+}
+
+async function tabUntilFocused(
+  page: Page,
+  target: Locator,
+  label: string,
+  maxPresses = 80,
+  direction: 'forward' | 'backward' = 'forward',
+): Promise<void> {
+  for (let attempt = 0; attempt < maxPresses; attempt += 1) {
+    await page.keyboard.press(direction === 'forward' ? 'Tab' : 'Shift+Tab');
+    const landed = await target.evaluate((element) => element === document.activeElement);
+    if (landed) return;
+  }
+
+  throw new Error(
+    `Tab walk did not reach ${label}; active element is ${await activeElementSummary(page)}`,
+  );
+}
+
+function boxShadowLayerCount(boxShadow: string): number {
+  return boxShadow.split(/,(?![^(]*\))/).length;
+}
+
+async function focusPaint(target: Locator): Promise<{
+  boxShadow: string;
+  matchesFocusVisible: boolean;
+  outlineColorAlpha: number;
+  outlineStyle: string;
+  outlineWidth: string;
+}> {
+  return target.evaluate((element) => {
+    function colorAlpha(color: string): number {
+      const canvas = document.createElement('canvas');
+      canvas.width = 1;
+      canvas.height = 1;
+      const context = canvas.getContext('2d');
+      if (!context) return 0;
+      context.clearRect(0, 0, 1, 1);
+      context.fillStyle = color;
+      context.fillRect(0, 0, 1, 1);
+      return context.getImageData(0, 0, 1, 1).data[3] ?? 0;
+    }
+
+    const styles = getComputedStyle(element as HTMLElement);
+    return {
+      boxShadow: styles.boxShadow,
+      matchesFocusVisible: element.matches(':focus-visible'),
+      outlineColorAlpha: colorAlpha(styles.outlineColor),
+      outlineStyle: styles.outlineStyle,
+      outlineWidth: styles.outlineWidth,
+    };
+  });
+}
+
+async function assertSharedOuterRing(target: Locator, label: string): Promise<void> {
+  const paint = await focusPaint(target);
+
+  expect(paint.matchesFocusVisible, `${label} should match :focus-visible`).toBe(true);
+  expect(paint.outlineStyle, `${label} should reserve an outline channel`).toBe('solid');
+  expect(parseFloat(paint.outlineWidth), `${label} outline width`).toBeGreaterThan(0);
+  expect(paint.outlineColorAlpha, `${label} outline should be transparent`).toBe(0);
+  expect(paint.boxShadow, `${label} should paint a focus shadow`).not.toBe('none');
+  expect(
+    boxShadowLayerCount(paint.boxShadow),
+    `${label} should use the shared two-stop ring`,
+  ).toBeGreaterThanOrEqual(2);
+  expect(paint.boxShadow, `${label} should not use an inset ring`).not.toContain('inset');
+}
+
+async function assertInsetRing(target: Locator, label: string): Promise<void> {
+  const paint = await focusPaint(target);
+
+  expect(paint.matchesFocusVisible, `${label} should match :focus-visible`).toBe(true);
+  expect(paint.outlineStyle, `${label} should reserve an outline channel`).toBe('solid');
+  expect(parseFloat(paint.outlineWidth), `${label} outline width`).toBeGreaterThan(0);
+  expect(paint.outlineColorAlpha, `${label} outline should be transparent`).toBe(0);
+  expect(paint.boxShadow, `${label} should paint an inset focus shadow`).toContain('inset');
+}
+
+async function seedDenseChatSurface(harness: Locator): Promise<void> {
+  await harness.locator('[data-testid="seed-thread"]').click();
+  await expect(harness.locator('[data-role="assistant"]').first()).toBeVisible({ timeout: 5_000 });
+
+  const timeline = harness.locator('.chat-timeline');
+  await timeline.evaluate((element) => {
+    element.scrollTop = 0;
+    element.dispatchEvent(new Event('scroll', { bubbles: true }));
+  });
+  await expect.poll(async () => timeline.evaluate((element) => element.scrollTop)).toBe(0);
+  await expect(harness.locator('.chat-jump-button')).toBeVisible({ timeout: 5_000 });
+
+  const editor = harness
+    .locator('.chat-input-editor [contenteditable], .chat-input-editor [role="textbox"]')
+    .first();
+  await editor.click();
+  await editor.pressSequentially('Keyboard focus ring check');
+  await expect(harness.locator('.chat-input-send')).toBeEnabled();
+}
+
+test.describe('domain focus rings -- chat harness', () => {
+  test('keyboard tabs through dense chat targets with visible recipe-backed rings', async ({
+    browser,
+  }) => {
+    const { page, harness, dispose } = await openChatHarness(browser);
+    try {
+      await seedDenseChatSurface(harness);
+
+      const timeline = harness.locator('.chat-timeline');
+      const messageCopy = harness.locator('.chat-message-action-button.chat-message-copy').first();
+      const jumpToLatest = harness.locator('.chat-jump-button');
+      const sendButton = harness.locator('.chat-input-send');
+      const editor = harness
+        .locator('.chat-input-editor [contenteditable], .chat-input-editor [role="textbox"]')
+        .first();
+
+      await expect(timeline).toBeVisible();
+      await expect(messageCopy).toBeAttached();
+      await expect(jumpToLatest).toBeVisible();
+      await expect(editor).toBeVisible();
+      await expect(sendButton).toBeEnabled();
+
+      await blurToBody(page);
+
+      await tabUntilFocused(page, timeline, 'chat timeline', 120);
+      await expect(timeline).toBeFocused();
+      await assertInsetRing(timeline, 'chat timeline');
+
+      await tabUntilFocused(page, messageCopy, 'message copy action', 8);
+      await expect(messageCopy).toBeFocused();
+      await assertSharedOuterRing(messageCopy, 'message copy action');
+
+      await editor.click();
+      await tabUntilFocused(page, jumpToLatest, 'jump to latest', 8, 'backward');
+      await expect(jumpToLatest).toBeFocused();
+      await assertSharedOuterRing(jumpToLatest, 'jump to latest');
+
+      await editor.click();
+      await tabUntilFocused(page, sendButton, 'send button', 8);
+      await expect(sendButton).toBeFocused();
+      await assertSharedOuterRing(sendButton, 'send button');
+    } finally {
+      await dispose();
+    }
+  });
+
+  test('forced-colors fallback repaints the send button outline', async ({ browser }) => {
+    const { page, harness, dispose } = await openChatHarness(browser, { forcedColors: 'active' });
+    try {
+      await seedDenseChatSurface(harness);
+      await expect
+        .poll(() => page.evaluate(() => window.matchMedia('(forced-colors: active)').matches))
+        .toBe(true);
+
+      const sendButton = harness.locator('.chat-input-send');
+      await blurToBody(page);
+      await tabUntilFocused(page, sendButton, 'send button', 160);
+      await expect(sendButton).toBeFocused();
+
+      const paint = await focusPaint(sendButton);
+      expect(paint.matchesFocusVisible).toBe(true);
+      expect(paint.outlineStyle).toBe('solid');
+      expect(parseFloat(paint.outlineWidth)).toBeGreaterThan(0);
+      expect(paint.outlineColorAlpha).toBeGreaterThan(0);
+    } finally {
+      await dispose();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- Normalize domain/editor focus indicators in chat, review editor, diff viewer, and markdown editor surfaces to the shared focus-ring recipe.
- Preserve dense-surface geometry with documented inset variants where outer rings can be clipped.
- Expand focus-ring guards to Svelte style blocks and add a dense chat keyboard traversal Playwright regression.

## Review committee

Pre-reviewed by: frontend-architect, ux-designer, testing-expert, simplicity-engineer, junior-engineer, Codex.

- Codex (gpt-5.4) reviewed 2 rounds
- 2 rounds of committee review
- All must-fix items addressed

## Test plan

- `bun run --filter=@lostgradient/cinder test -- src/test/focus-ring-recipe.test.ts scripts/stylelint/no-focus-visible-colored-outline.test.ts`
- `bunx stylelint "packages/components/src/components/{chat,review-editor,diff-viewer,markdown-editor,json-schema-editor}/**/*.{css,svelte}"`
- `bun run --filter=@lostgradient/cinder test -- chat review-editor diff-viewer markdown-editor json-schema-editor focus-ring`
- `bun run --filter=@lostgradient/cinder components:check`
- `bun run --filter=@cinder/testing test:playwright -- tests/domain-focus-rings.playwright.ts`
- `bun run lint`
- `bun run --filter=@cinder/testing test:playwright -- --grep "focus-ring|domain focus|editor"`

`bun run lint` passed with one unrelated existing warning in `src/_internal/chart/chart-interaction.test.ts:277`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Visual/a11y styling only across UI surfaces; behavior is guarded by existing and new CSS/Playwright tests with no auth or data-path changes.
> 
> **Overview**
> Replaces ad-hoc `:focus-visible` / `:focus` styling across **chat**, **review editor**, **diff viewer**, and **markdown editor** with the shared Cinder focus-ring recipe (`transparent` outline + `var(--_cinder-focus-ring-shadow)`), plus **inset** rings where outer rings would clip (tool-call headers, inline front-matter).
> 
> Adds **`forced-colors`** fallbacks (`ButtonText` on controls, `Highlight` on text fields) and drops one-off rings (e.g. danger-colored stop-button focus, composer error-state danger shadow). **ProseMirror** selection outline now uses `var(--cinder-accent)` instead of a hardcoded color.
> 
> **Tests:** Stylelint project-config coverage for **Svelte** `<style>` blocks (`codeFilename`); expanded `focus-ring-recipe.test.ts` cases; new Playwright spec that **Tab**s through a dense chat harness and asserts computed focus paint (including forced-colors on send).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ee733cb885f8aeae015074eb976bdd09eb05e1b6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->