### PR TITLE
Add visible SVG focus rings for chart marks

### DIFF
--- a/docs/focus-ring-policy.md
+++ b/docs/focus-ring-policy.md
@@ -3,7 +3,7 @@
 This document defines the approved strategies for `:focus-visible` rings in Cinder component CSS. Pick from this list. Do not invent a third approach.
 
 > [!NOTE] Default recipe
-> Component `:focus-visible` rules should use **Strategy B** — the transparent-outline placeholder paired with `box-shadow: var(--_cinder-focus-ring-shadow)`. The `cinder/no-focus-visible-colored-outline` Stylelint rule enforces this: colored `outline` channels are rejected outside `@media (forced-colors: active)`. Strategy A (a colored outline) is retained for the bare `:focus-visible` global default in `foundation.css` only.
+> Component `:focus-visible` rules should use **Strategy B** — the transparent-outline placeholder paired with `box-shadow: var(--_cinder-focus-ring-shadow)` — unless the component matches the documented SVG chart-mark exception below. The `cinder/no-focus-visible-colored-outline` Stylelint rule enforces this: colored `outline` channels are rejected outside `@media (forced-colors: active)`. Strategy A (a colored outline) is retained for the bare `:focus-visible` global default in `foundation.css` only.
 
 ## Token Reference
 
@@ -109,6 +109,12 @@ The offset color band is intentionally omitted — there is no usable space insi
 
 The 2026-06 sweep also adopted B-inset for a batch of clipped/full-bleed children (see the Deviations Appendix). Adding a further component requires documenting the justification here.
 
+## SVG Chart Marks — Stroke ring layer
+
+Use this exception only for keyboard-focusable SVG chart marks, such as the `circle` data targets in AreaChart/LineChart and the `rect` bar targets in BarChart. SVG shapes do not reliably paint HTML `box-shadow`, and chart `svg` viewports intentionally clip overflow, so the normal Strategy B and B-inset recipes are not load-bearing for these marks.
+
+Chart marks keep their transparent focus target for DOM focus and accessible naming, then render a separate `aria-hidden="true"` SVG focus-ring layer above the plot. The layer uses tokenized `stroke`, `stroke-width: var(--cinder-ring-width)`, `vector-effect: non-scaling-stroke`, and `pointer-events: none`; geometry is clamped inside the SVG viewport so edge marks still have a complete visible ring. In forced-colors mode the halo is hidden and the ring stroke uses `ButtonText` with `filter: none`.
+
 ## Picking Between A, B, and B-inset
 
 | Situation                                                        | Strategy                                                       |
@@ -116,6 +122,7 @@ The 2026-06 sweep also adopted B-inset for a batch of clipped/full-bleed childre
 | Component already has a `box-shadow` for elevation or decoration | A                                                              |
 | Form field or button-shaped pressable on the page surface        | B                                                              |
 | Focusable child of an `overflow: hidden` parent                  | B-inset                                                        |
+| Keyboard-focusable SVG chart mark                                | SVG chart mark stroke layer                                    |
 | Variant needs its own ring color                                 | B or B-inset with a `--_cinder-<component>-ring` fallback hook |
 
 ## Variant Ring Colors

--- a/packages/components/src/_internal/chart/chart-focus-ring.test.ts
+++ b/packages/components/src/_internal/chart/chart-focus-ring.test.ts
@@ -1,0 +1,294 @@
+import { describe, expect, test } from 'bun:test';
+
+import {
+  DEFAULT_CHART_FOCUS_RING_STROKE_PADDING,
+  createBarFocusRingGeometry,
+  createPointFocusRingGeometry,
+} from './chart-focus-ring.ts';
+import { createBarModel, type ChartTarget } from './chart-utilities.ts';
+
+function target(overrides: Partial<ChartTarget> = {}): ChartTarget {
+  return {
+    id: 'target',
+    seriesId: 'series',
+    seriesLabel: 'Series',
+    xLabel: 'Jan',
+    valueLabel: '10',
+    x: 50,
+    y: 50,
+    color: 'red',
+    ...overrides,
+  };
+}
+
+describe('createPointFocusRingGeometry', () => {
+  test('keeps an in-bounds point centered with no connector', () => {
+    const geometry = createPointFocusRingGeometry({
+      target: target({ x: 50, y: 40 }),
+      plotWidth: 120,
+      plotHeight: 100,
+    });
+
+    expect(geometry?.kind).toBe('point');
+    if (geometry?.kind !== 'point') throw new Error('Expected point focus-ring geometry.');
+    expect(geometry.cx).toBe(50);
+    expect(geometry.cy).toBe(40);
+    expect(geometry.radius).toBe(10);
+    expect(geometry.offsetDistance).toBe(0);
+    expect(geometry.connector).toBeUndefined();
+    expect(geometry.dot).toBeUndefined();
+  });
+
+  test('clamps an edge point inside the plot and keeps the visible offset within the ring', () => {
+    const geometry = createPointFocusRingGeometry({
+      target: target({ x: 0, y: 40 }),
+      plotWidth: 120,
+      plotHeight: 100,
+    });
+
+    expect(geometry?.kind).toBe('point');
+    if (geometry?.kind !== 'point') throw new Error('Expected point focus-ring geometry.');
+    expect(geometry.cx).toBe(DEFAULT_CHART_FOCUS_RING_STROKE_PADDING + geometry.radius);
+    expect(geometry.cy).toBe(40);
+    expect(geometry.targetX).toBe(DEFAULT_CHART_FOCUS_RING_STROKE_PADDING + 2.5);
+    expect(geometry.targetY).toBe(40);
+    expect(geometry.offsetDistance).toBeLessThanOrEqual(geometry.radius);
+    expect(geometry.connector).toEqual({
+      x1: geometry.targetX,
+      y1: geometry.targetY,
+      x2: geometry.cx,
+      y2: geometry.cy,
+    });
+    expect(geometry.dot).toEqual({
+      cx: geometry.targetX,
+      cy: geometry.targetY,
+      radius: 2.5,
+    });
+  });
+
+  test('keeps the edge-marker dot fully inside the plot on every edge', () => {
+    const cases = [
+      target({ x: 0, y: 50 }),
+      target({ x: 120, y: 50 }),
+      target({ x: 60, y: 0 }),
+      target({ x: 60, y: 100 }),
+      target({ x: 0, y: 0 }),
+    ];
+
+    for (const item of cases) {
+      const geometry = createPointFocusRingGeometry({
+        target: item,
+        plotWidth: 120,
+        plotHeight: 100,
+      });
+
+      expect(geometry?.kind).toBe('point');
+      if (geometry?.kind !== 'point') throw new Error('Expected point focus-ring geometry.');
+      expect(geometry.dot).toBeDefined();
+      expect(geometry.dot!.cx - geometry.dot!.radius).toBeGreaterThanOrEqual(
+        DEFAULT_CHART_FOCUS_RING_STROKE_PADDING,
+      );
+      expect(geometry.dot!.cy - geometry.dot!.radius).toBeGreaterThanOrEqual(
+        DEFAULT_CHART_FOCUS_RING_STROKE_PADDING,
+      );
+      expect(geometry.dot!.cx + geometry.dot!.radius).toBeLessThanOrEqual(
+        120 - DEFAULT_CHART_FOCUS_RING_STROKE_PADDING,
+      );
+      expect(geometry.dot!.cy + geometry.dot!.radius).toBeLessThanOrEqual(
+        100 - DEFAULT_CHART_FOCUS_RING_STROKE_PADDING,
+      );
+      expect(geometry.offsetDistance).toBeLessThanOrEqual(geometry.radius);
+    }
+  });
+
+  test('keeps adjacent dense-edge point indicators associated with their own coordinates', () => {
+    const first = createPointFocusRingGeometry({
+      target: target({ id: 'first', x: 0, y: 12 }),
+      plotWidth: 120,
+      plotHeight: 100,
+    });
+    const second = createPointFocusRingGeometry({
+      target: target({ id: 'second', x: 0, y: 28 }),
+      plotWidth: 120,
+      plotHeight: 100,
+    });
+
+    expect(first?.kind).toBe('point');
+    expect(second?.kind).toBe('point');
+    if (first?.kind !== 'point' || second?.kind !== 'point') {
+      throw new Error('Expected point focus-ring geometry.');
+    }
+    expect(first.dot?.cy).toBe(first.targetY);
+    expect(second.dot?.cy).toBe(second.targetY);
+    expect(first.connector?.y1).toBe(first.targetY);
+    expect(second.connector?.y1).toBe(second.targetY);
+    expect(first.dot?.cy).not.toBe(second.dot?.cy);
+  });
+
+  test('uses the supplied stroke padding in the clamp math', () => {
+    const geometry = createPointFocusRingGeometry({
+      target: target({ x: 0, y: 0 }),
+      plotWidth: 120,
+      plotHeight: 100,
+      strokePadding: 16,
+    });
+
+    expect(geometry?.kind).toBe('point');
+    if (geometry?.kind !== 'point') throw new Error('Expected point focus-ring geometry.');
+    expect(geometry.cx).toBe(26);
+    expect(geometry.cy).toBe(26);
+    expect(geometry.targetX).toBeGreaterThanOrEqual(18.5);
+    expect(geometry.targetY).toBeGreaterThanOrEqual(18.5);
+    expect(geometry.offsetDistance).toBeLessThanOrEqual(geometry.radius);
+  });
+
+  test('falls back to the plot frame for tiny positive plot dimensions', () => {
+    const geometry = createPointFocusRingGeometry({
+      target: target({ x: 1, y: 1 }),
+      plotWidth: 12,
+      plotHeight: 12,
+    });
+
+    expect(geometry).toEqual({ kind: 'plot-frame', x: 5, y: 5, width: 2, height: 2, radius: 0 });
+  });
+
+  test('falls back to the plot frame when the connector dot cannot fit inside the stroke padding', () => {
+    const geometry = createPointFocusRingGeometry({
+      target: target({ x: 0, y: 10 }),
+      plotWidth: 20,
+      plotHeight: 80,
+    });
+
+    expect(geometry).toEqual({ kind: 'plot-frame', x: 8, y: 8, width: 4, height: 64, radius: 0 });
+  });
+
+  test('returns null only when the plot has no positive area', () => {
+    expect(
+      createPointFocusRingGeometry({
+        target: target(),
+        plotWidth: 0,
+        plotHeight: 100,
+      }),
+    ).toBeNull();
+    expect(
+      createPointFocusRingGeometry({
+        target: target(),
+        plotWidth: 100,
+        plotHeight: 0,
+      }),
+    ).toBeNull();
+  });
+});
+
+describe('createBarFocusRingGeometry', () => {
+  test('frames a normal in-bounds bar around the target center', () => {
+    const geometry = createBarFocusRingGeometry({
+      target: target({ x: 60, y: 40, width: 30, height: 80 }),
+      plotWidth: 140,
+      plotHeight: 120,
+    });
+
+    expect(geometry).toEqual({ kind: 'bar', x: 45, y: 8, width: 30, height: 80, radius: 4 });
+  });
+
+  test('uses minimum dimensions for zero-height and zero-width bars', () => {
+    const zeroHeight = createBarFocusRingGeometry({
+      target: target({ x: 40, y: 80, width: 28, height: 0 }),
+      plotWidth: 140,
+      plotHeight: 120,
+    });
+    const zeroWidth = createBarFocusRingGeometry({
+      target: target({ x: 40, y: 80, width: 0, height: 28 }),
+      plotWidth: 140,
+      plotHeight: 120,
+    });
+
+    expect(zeroHeight).toEqual({ kind: 'bar', x: 26, y: 74, width: 28, height: 12, radius: 4 });
+    expect(zeroWidth).toEqual({ kind: 'bar', x: 34, y: 66, width: 12, height: 28, radius: 4 });
+  });
+
+  test('clamps bar rings inside the drawable plot area', () => {
+    const geometry = createBarFocusRingGeometry({
+      target: target({ x: 0, y: 0, width: 40, height: 30 }),
+      plotWidth: 120,
+      plotHeight: 100,
+    });
+
+    expect(geometry).toEqual({ kind: 'bar', x: 8, y: 8, width: 40, height: 30, radius: 4 });
+  });
+
+  test('shrinks to the largest drawable clipped rectangle before using the plot-frame fallback', () => {
+    const geometry = createBarFocusRingGeometry({
+      target: target({ x: 12, y: 12, width: 40, height: 40 }),
+      plotWidth: 28,
+      plotHeight: 30,
+    });
+
+    expect(geometry).toEqual({ kind: 'bar', x: 8, y: 8, width: 12, height: 14, radius: 4 });
+  });
+
+  test('falls back to the plot frame when the drawable bar rectangle cannot fit', () => {
+    const geometry = createBarFocusRingGeometry({
+      target: target({ x: 2, y: 2, width: 12, height: 12 }),
+      plotWidth: 12,
+      plotHeight: 12,
+    });
+
+    expect(geometry).toEqual({ kind: 'plot-frame', x: 5, y: 5, width: 2, height: 2, radius: 0 });
+  });
+
+  test('returns null only when the plot has no positive area', () => {
+    expect(
+      createBarFocusRingGeometry({
+        target: target(),
+        plotWidth: 0,
+        plotHeight: 100,
+      }),
+    ).toBeNull();
+    expect(
+      createBarFocusRingGeometry({
+        target: target(),
+        plotWidth: 100,
+        plotHeight: 0,
+      }),
+    ).toBeNull();
+  });
+});
+
+describe('bar chart target geometry contract', () => {
+  const data = [
+    { category: 'Jan', revenue: 120, expansion: 30 },
+    { category: 'Feb', revenue: 180, expansion: 45 },
+  ];
+  const series = [
+    { id: 'revenue', label: 'Revenue', valueKey: 'revenue' },
+    { id: 'expansion', label: 'Expansion', valueKey: 'expansion' },
+  ];
+
+  test.each([
+    ['vertical grouped', 'vertical', 'grouped'],
+    ['vertical stacked', 'vertical', 'stacked'],
+    ['horizontal grouped', 'horizontal', 'grouped'],
+    ['horizontal stacked', 'horizontal', 'stacked'],
+  ] as const)('targets expose centered bar bounds for %s charts', (_label, orientation, mode) => {
+    const model = createBarModel({
+      data,
+      categoryKey: 'category',
+      series,
+      hiddenSeriesIds: [],
+      width: 640,
+      height: 280,
+      orientation,
+      mode,
+    });
+
+    for (const targetItem of model.targets) {
+      const bar = model.bars.find((candidate) => candidate.id === targetItem.id);
+      expect(bar).toBeDefined();
+      expect(targetItem.x).toBeCloseTo((bar?.x ?? 0) + (bar?.width ?? 0) / 2);
+      expect(targetItem.y).toBeCloseTo((bar?.y ?? 0) + (bar?.height ?? 0) / 2);
+      expect(targetItem.width).toBeCloseTo(bar?.width ?? 0);
+      expect(targetItem.height).toBeCloseTo(bar?.height ?? 0);
+    }
+  });
+});

--- a/packages/components/src/_internal/chart/chart-focus-ring.ts
+++ b/packages/components/src/_internal/chart/chart-focus-ring.ts
@@ -1,0 +1,209 @@
+import type { ChartTarget } from './chart-utilities.ts';
+
+export const DEFAULT_CHART_FOCUS_RING_STROKE_PADDING = 8;
+
+const DEFAULT_POINT_FOCUS_RING_RADIUS = 10;
+const MINIMUM_FOCUS_RING_SIZE = 2;
+const MINIMUM_BAR_FOCUS_RING_SIZE = 12;
+const FOCUS_RING_DOT_RADIUS = 2.5;
+
+export type ChartFocusRingConnectorGeometry = {
+  x1: number;
+  y1: number;
+  x2: number;
+  y2: number;
+};
+
+export type ChartFocusRingDotGeometry = {
+  cx: number;
+  cy: number;
+  radius: number;
+};
+
+export type ChartPointFocusRingGeometry =
+  | {
+      kind: 'point';
+      cx: number;
+      cy: number;
+      radius: number;
+      targetX: number;
+      targetY: number;
+      offsetX: number;
+      offsetY: number;
+      offsetDistance: number;
+      connector?: ChartFocusRingConnectorGeometry;
+      dot?: ChartFocusRingDotGeometry;
+    }
+  | ChartPlotFrameFocusRingGeometry;
+
+export type ChartBarFocusRingGeometry =
+  | {
+      kind: 'bar';
+      x: number;
+      y: number;
+      width: number;
+      height: number;
+      radius: number;
+    }
+  | ChartPlotFrameFocusRingGeometry;
+
+export type ChartPlotFrameFocusRingGeometry = {
+  kind: 'plot-frame';
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  radius: number;
+};
+
+export function createPointFocusRingGeometry(options: {
+  target: Pick<ChartTarget, 'x' | 'y'>;
+  plotWidth: number;
+  plotHeight: number;
+  strokePadding?: number;
+  radius?: number;
+}): ChartPointFocusRingGeometry | null {
+  const {
+    target,
+    plotWidth,
+    plotHeight,
+    strokePadding = DEFAULT_CHART_FOCUS_RING_STROKE_PADDING,
+    radius = DEFAULT_POINT_FOCUS_RING_RADIUS,
+  } = options;
+
+  if (plotWidth <= 0 || plotHeight <= 0) return null;
+
+  const drawableWidth = plotWidth - strokePadding * 2;
+  const drawableHeight = plotHeight - strokePadding * 2;
+  const largestDrawableRadius = Math.min(drawableWidth, drawableHeight) / 2;
+
+  if (
+    largestDrawableRadius < MINIMUM_FOCUS_RING_SIZE ||
+    drawableWidth < FOCUS_RING_DOT_RADIUS * 2 ||
+    drawableHeight < FOCUS_RING_DOT_RADIUS * 2
+  ) {
+    return createPlotFrameFocusRingGeometry(plotWidth, plotHeight, strokePadding);
+  }
+
+  const resolvedRadius = Math.min(Math.max(radius, MINIMUM_FOCUS_RING_SIZE), largestDrawableRadius);
+  const minimumCenterX = strokePadding + resolvedRadius;
+  const maximumCenterX = plotWidth - strokePadding - resolvedRadius;
+  const minimumCenterY = strokePadding + resolvedRadius;
+  const maximumCenterY = plotHeight - strokePadding - resolvedRadius;
+
+  const cx = clamp(target.x, minimumCenterX, maximumCenterX);
+  const cy = clamp(target.y, minimumCenterY, maximumCenterY);
+  const dotInset = strokePadding + FOCUS_RING_DOT_RADIUS;
+  let targetX = clamp(target.x, dotInset, plotWidth - dotInset);
+  let targetY = clamp(target.y, dotInset, plotHeight - dotInset);
+  const initialOffsetX = targetX - cx;
+  const initialOffsetY = targetY - cy;
+  const initialOffsetDistance = Math.hypot(initialOffsetX, initialOffsetY);
+
+  if (initialOffsetDistance > resolvedRadius) {
+    const scale = resolvedRadius / initialOffsetDistance;
+    targetX = cx + initialOffsetX * scale;
+    targetY = cy + initialOffsetY * scale;
+  }
+
+  const offsetX = targetX - cx;
+  const offsetY = targetY - cy;
+  const offsetDistance = Math.hypot(offsetX, offsetY);
+
+  const geometry = {
+    kind: 'point' as const,
+    cx,
+    cy,
+    radius: resolvedRadius,
+    targetX,
+    targetY,
+    offsetX,
+    offsetY,
+    offsetDistance,
+  };
+
+  if (offsetDistance <= 0) return geometry;
+
+  return {
+    ...geometry,
+    connector: {
+      x1: targetX,
+      y1: targetY,
+      x2: cx,
+      y2: cy,
+    },
+    dot: {
+      cx: targetX,
+      cy: targetY,
+      radius: FOCUS_RING_DOT_RADIUS,
+    },
+  };
+}
+
+export function createBarFocusRingGeometry(options: {
+  target: Pick<ChartTarget, 'x' | 'y' | 'width' | 'height'>;
+  plotWidth: number;
+  plotHeight: number;
+  strokePadding?: number;
+  minimumWidth?: number;
+  minimumHeight?: number;
+}): ChartBarFocusRingGeometry | null {
+  const {
+    target,
+    plotWidth,
+    plotHeight,
+    strokePadding = DEFAULT_CHART_FOCUS_RING_STROKE_PADDING,
+    minimumWidth = MINIMUM_BAR_FOCUS_RING_SIZE,
+    minimumHeight = MINIMUM_BAR_FOCUS_RING_SIZE,
+  } = options;
+
+  if (plotWidth <= 0 || plotHeight <= 0) return null;
+
+  const requestedWidth = Math.max(target.width ?? 0, minimumWidth);
+  const requestedHeight = Math.max(target.height ?? 0, minimumHeight);
+  const drawableWidth = plotWidth - strokePadding * 2;
+  const drawableHeight = plotHeight - strokePadding * 2;
+
+  if (drawableWidth < MINIMUM_FOCUS_RING_SIZE || drawableHeight < MINIMUM_FOCUS_RING_SIZE) {
+    return createPlotFrameFocusRingGeometry(plotWidth, plotHeight, strokePadding);
+  }
+
+  const width = Math.min(requestedWidth, drawableWidth);
+  const height = Math.min(requestedHeight, drawableHeight);
+  const x = clamp(target.x - width / 2, strokePadding, plotWidth - width - strokePadding);
+  const y = clamp(target.y - height / 2, strokePadding, plotHeight - height - strokePadding);
+
+  return {
+    kind: 'bar',
+    x,
+    y,
+    width,
+    height,
+    radius: Math.min(4, width / 2, height / 2),
+  };
+}
+
+function createPlotFrameFocusRingGeometry(
+  plotWidth: number,
+  plotHeight: number,
+  strokePadding: number,
+): ChartPlotFrameFocusRingGeometry {
+  const inset = Math.min(
+    strokePadding,
+    Math.max(0, plotWidth - MINIMUM_FOCUS_RING_SIZE) / 2,
+    Math.max(0, plotHeight - MINIMUM_FOCUS_RING_SIZE) / 2,
+  );
+  return {
+    kind: 'plot-frame',
+    x: inset,
+    y: inset,
+    width: Math.max(0, plotWidth - inset * 2),
+    height: Math.max(0, plotHeight - inset * 2),
+    radius: 0,
+  };
+}
+
+function clamp(value: number, minimum: number, maximum: number): number {
+  if (maximum < minimum) return (minimum + maximum) / 2;
+  return Math.min(Math.max(value, minimum), maximum);
+}

--- a/packages/components/src/_internal/chart/chart-utilities.ts
+++ b/packages/components/src/_internal/chart/chart-utilities.ts
@@ -122,6 +122,7 @@ export type BarChartModel = {
   categories: NormalizedXValue[];
   yTicks: number[];
   categoryTicks: Array<{
+    categoryKey: string;
     label: string;
     x: number;
     y: number;
@@ -140,6 +141,7 @@ export type BarChartModel = {
     hidden: boolean;
   }>;
   tableRows: Array<{
+    categoryKey: string;
     categoryLabel: string;
     values: Array<{ seriesId: string; seriesLabel: string; valueLabel: string }>;
   }>;
@@ -616,6 +618,7 @@ export function createBarModel(options: {
   const categoryTicks = sortedCategories.map((category, index) => {
     const categoryPosition = categoryScale(category.key) ?? 0;
     return {
+      categoryKey: category.key,
       label: formatXValue(category, orientation === 'vertical' ? xAxis : yAxis, { index }),
       x: orientation === 'vertical' ? categoryPosition + categoryScale.bandwidth() / 2 : -8,
       y:
@@ -707,6 +710,7 @@ export function createBarModel(options: {
     });
     if (rowValues.length > 0) {
       tableRows.push({
+        categoryKey: category.key,
         categoryLabel: formatXValue(category, orientation === 'vertical' ? xAxis : yAxis, {
           index: tableRows.length,
         }),

--- a/packages/components/src/components/area-chart/area-chart.css
+++ b/packages/components/src/components/area-chart/area-chart.css
@@ -81,14 +81,64 @@
     pointer-events: none;
   }
 
-  /*
- * SVG focus indicator: drop-shadow renders a visible ring around the focused
- * element on any background. Matches line-chart and bar-chart.
- */
-  .cinder-area-chart__focus-target:focus-visible {
-    stroke: var(--cinder-accent);
+  .cinder-area-chart__focus-target:focus-visible:not([data-cinder-focus-ring-active='true']) {
+    fill: transparent;
+    stroke: var(--cinder-ring-color);
     stroke-width: var(--cinder-ring-width);
-    filter: drop-shadow(0 0 var(--cinder-ring-width) var(--cinder-ring-color));
+    vector-effect: non-scaling-stroke;
+    filter: none;
+  }
+
+  .cinder-area-chart__focus-ring-layer {
+    pointer-events: none;
+  }
+
+  .cinder-area-chart__focus-ring,
+  .cinder-area-chart__focus-ring-halo,
+  .cinder-area-chart__focus-ring-connector,
+  .cinder-area-chart__focus-ring-dot {
+    fill: none;
+    pointer-events: none;
+    vector-effect: non-scaling-stroke;
+    stroke-linecap: round;
+    stroke-linejoin: round;
+  }
+
+  .cinder-area-chart__focus-ring {
+    stroke: var(--cinder-ring-color);
+    stroke-width: var(--cinder-ring-width);
+    filter: none;
+  }
+
+  .cinder-area-chart__focus-ring-halo {
+    stroke: var(--cinder-ring-offset-color);
+    stroke-width: calc(
+      var(--cinder-ring-width) + var(--cinder-ring-offset) + var(--cinder-ring-offset)
+    );
+    filter: none;
+  }
+
+  @media (forced-colors: active) {
+    .cinder-area-chart__focus-ring-halo {
+      display: none;
+    }
+
+    .cinder-area-chart__focus-ring,
+    .cinder-area-chart__focus-ring-connector,
+    .cinder-area-chart__focus-ring-dot {
+      fill: none;
+      stroke: ButtonText;
+      stroke-width: var(--cinder-ring-width);
+      filter: none;
+    }
+
+    .cinder-area-chart__focus-target:focus-visible:not([data-cinder-focus-ring-active='true']) {
+      fill: transparent;
+      stroke: ButtonText;
+      stroke-width: var(--cinder-ring-width);
+      vector-effect: non-scaling-stroke;
+      filter: none;
+    }
   }
 
   .cinder-area-chart__tick-label {

--- a/packages/components/src/components/area-chart/area-chart.svelte
+++ b/packages/components/src/components/area-chart/area-chart.svelte
@@ -99,7 +99,9 @@
   let keyboardFocusModality = $state(false);
   let focusVisibleTargetId = $state<string>();
   const focusRingTarget = $derived(
-    focusedTarget && focusVisibleTargetId === focusedTarget.id ? focusedTarget : undefined,
+    keyboardFocusModality && focusedTarget && focusVisibleTargetId === focusedTarget.id
+      ? focusedTarget
+      : undefined,
   );
   const pointFocusRing = $derived(
     focusRingTarget
@@ -138,6 +140,7 @@
 
   function clearKeyboardFocusModality(): void {
     keyboardFocusModality = false;
+    focusVisibleTargetId = undefined;
   }
 
   function handleTargetFocus(target: ChartTarget): void {

--- a/packages/components/src/components/area-chart/area-chart.svelte
+++ b/packages/components/src/components/area-chart/area-chart.svelte
@@ -24,7 +24,12 @@
     dataTableClass,
     formatNumericValue,
     legendVisible,
+    type ChartTarget,
   } from '../../_internal/chart/chart-utilities.ts';
+  import {
+    DEFAULT_CHART_FOCUS_RING_STROKE_PADDING,
+    createPointFocusRingGeometry,
+  } from '../../_internal/chart/chart-focus-ring.ts';
   import { ChartInteraction } from '../../_internal/chart/chart-interaction.svelte.ts';
   import { classNames } from '../../utilities/class-names.ts';
   import type { AreaChartProps } from './area-chart.types.ts';
@@ -86,6 +91,26 @@
       ? `${rootId}-table-guidance`
       : undefined,
   );
+  const focusedTarget = $derived.by(() => {
+    const currentTarget = interaction.focusedTarget;
+    if (!currentTarget) return undefined;
+    return model.targets.find((target) => target.id === currentTarget.id);
+  });
+  let keyboardFocusModality = $state(false);
+  let focusVisibleTargetId = $state<string>();
+  const focusRingTarget = $derived(
+    focusedTarget && focusVisibleTargetId === focusedTarget.id ? focusedTarget : undefined,
+  );
+  const pointFocusRing = $derived(
+    focusRingTarget
+      ? createPointFocusRingGeometry({
+          target: focusRingTarget,
+          plotWidth: model.geometry.plotWidth,
+          plotHeight: model.geometry.plotHeight,
+          strokePadding: DEFAULT_CHART_FOCUS_RING_STROKE_PADDING,
+        })
+      : null,
+  );
 
   $effect(() => {
     assertValidNonNegativeInteger(
@@ -99,7 +124,42 @@
   $effect(() => {
     interaction.clearStaleTargets(loading, model.empty, model.targets);
   });
+
+  function rememberKeyboardFocusModality(event: KeyboardEvent): void {
+    if (
+      event.key === 'Tab' ||
+      event.key === 'Home' ||
+      event.key === 'End' ||
+      event.key.startsWith('Arrow')
+    ) {
+      keyboardFocusModality = true;
+    }
+  }
+
+  function clearKeyboardFocusModality(): void {
+    keyboardFocusModality = false;
+  }
+
+  function handleTargetFocus(target: ChartTarget): void {
+    interaction.focusedTarget = target;
+    focusVisibleTargetId = keyboardFocusModality ? target.id : undefined;
+  }
+
+  function handleTargetBlur(): void {
+    interaction.focusedTarget = undefined;
+    focusVisibleTargetId = undefined;
+  }
+
+  function handleTargetKeydown(event: KeyboardEvent): void {
+    rememberKeyboardFocusModality(event);
+    interaction.activateByKeyboard(event, rootElement!, model.targets, keyboardEnabled);
+  }
 </script>
+
+<svelte:window
+  onkeydown={rememberKeyboardFocusModality}
+  onpointerdown={clearKeyboardFocusModality}
+/>
 
 <figure
   {...rest}
@@ -149,7 +209,7 @@
         <title id="{rootId}-svg-title">{label}</title>
       {/if}
       <g transform={`translate(${model.geometry.marginLeft}, ${model.geometry.marginTop})`}>
-        {#each model.yTicks as tick, index}
+        {#each model.yTicks as tick, index (tick)}
           {@const tickY =
             model.geometry.plotHeight -
             ((tick - model.yDomain[0]) / (model.yDomain[1] - model.yDomain[0])) *
@@ -228,22 +288,77 @@
                 tabindex="0"
                 role="button"
                 data-cinder-target-id={target.id}
+                data-cinder-series-id={target.seriesId}
+                data-cinder-focus-ring-active={pointFocusRing && focusRingTarget?.id === target.id
+                  ? 'true'
+                  : undefined}
                 aria-label={`${target.seriesLabel}, ${target.xLabel}, ${target.valueLabel}`}
                 aria-describedby={interaction.activeTarget?.id === target.id
                   ? `${rootId}-tooltip`
                   : undefined}
-                onfocus={() => (interaction.focusedTarget = target)}
-                onblur={() => (interaction.focusedTarget = undefined)}
-                onkeydown={(event) =>
-                  interaction.activateByKeyboard(
-                    event,
-                    rootElement!,
-                    model.targets,
-                    keyboardEnabled,
-                  )}
+                onfocus={() => handleTargetFocus(target)}
+                onblur={handleTargetBlur}
+                onkeydown={handleTargetKeydown}
               />
             {/each}
           {/if}
+        {/if}
+        {#if pointFocusRing}
+          <g class="cinder-area-chart__focus-ring-layer" aria-hidden="true">
+            {#if pointFocusRing.kind === 'point'}
+              <circle
+                class="cinder-area-chart__focus-ring-halo"
+                cx={pointFocusRing.cx}
+                cy={pointFocusRing.cy}
+                r={pointFocusRing.radius}
+              />
+              <circle
+                class="cinder-area-chart__focus-ring"
+                cx={pointFocusRing.cx}
+                cy={pointFocusRing.cy}
+                r={pointFocusRing.radius}
+              />
+              {#if pointFocusRing.connector && pointFocusRing.dot}
+                <path
+                  class="cinder-area-chart__focus-ring-connector cinder-area-chart__focus-ring-halo"
+                  d={`M ${pointFocusRing.connector.x1} ${pointFocusRing.connector.y1} L ${pointFocusRing.connector.x2} ${pointFocusRing.connector.y2}`}
+                />
+                <path
+                  class="cinder-area-chart__focus-ring-connector cinder-area-chart__focus-ring"
+                  d={`M ${pointFocusRing.connector.x1} ${pointFocusRing.connector.y1} L ${pointFocusRing.connector.x2} ${pointFocusRing.connector.y2}`}
+                />
+                <circle
+                  class="cinder-area-chart__focus-ring-dot cinder-area-chart__focus-ring-halo"
+                  cx={pointFocusRing.dot.cx}
+                  cy={pointFocusRing.dot.cy}
+                  r={pointFocusRing.dot.radius}
+                />
+                <circle
+                  class="cinder-area-chart__focus-ring-dot cinder-area-chart__focus-ring"
+                  cx={pointFocusRing.dot.cx}
+                  cy={pointFocusRing.dot.cy}
+                  r={pointFocusRing.dot.radius}
+                />
+              {/if}
+            {:else}
+              <rect
+                class="cinder-area-chart__focus-ring-halo"
+                x={pointFocusRing.x}
+                y={pointFocusRing.y}
+                width={pointFocusRing.width}
+                height={pointFocusRing.height}
+                rx={pointFocusRing.radius}
+              />
+              <rect
+                class="cinder-area-chart__focus-ring"
+                x={pointFocusRing.x}
+                y={pointFocusRing.y}
+                width={pointFocusRing.width}
+                height={pointFocusRing.height}
+                rx={pointFocusRing.radius}
+              />
+            {/if}
+          </g>
         {/if}
       </g>
     </svg>

--- a/packages/components/src/components/area-chart/area-chart.test.ts
+++ b/packages/components/src/components/area-chart/area-chart.test.ts
@@ -77,8 +77,12 @@ describe('AreaChart', () => {
   test('legend toggle hides area geometry', async () => {
     const { getByRole, container } = render(AreaChart, { label: 'Usage trend', series });
     const button = getByRole('button', { name: 'Usage' });
+    expect(container.querySelectorAll('[data-cinder-series-id="usage"]').length).toBeGreaterThan(0);
+
     await fireEvent.click(button);
+
     expect(container.querySelectorAll('[data-cinder-series="usage"]').length).toBe(0);
+    expect(container.querySelectorAll('[data-cinder-series-id="usage"]').length).toBe(0);
   });
 
   test('svg has an accessible title matching the label when data is present', () => {
@@ -166,15 +170,83 @@ describe('AreaChart', () => {
     expect(queryByText('Jan: 30')).toBeNull();
   });
 
+  test('keyboard focus renders one visual-only SVG focus-ring layer', async () => {
+    const { container, getByRole } = render(AreaChart, { label: 'Usage trend', series });
+    const target = getByRole('button', { name: 'Usage, Jan, 30' });
+
+    await fireEvent.focus(target);
+    expect(container.querySelector('.cinder-area-chart__focus-ring-layer')).toBeNull();
+    await fireEvent.blur(target);
+    await fireEvent.keyDown(window, { key: 'Tab' });
+    await fireEvent.focus(target);
+
+    expect(target.getAttribute('data-cinder-series-id')).toBe('usage');
+    expect(target.getAttribute('data-cinder-focus-ring-active')).toBe('true');
+    const layers = container.querySelectorAll('.cinder-area-chart__focus-ring-layer');
+    expect(layers.length).toBe(1);
+    const layer = layers[0];
+    expect(layer?.getAttribute('aria-hidden')).toBe('true');
+    expect(layer?.getAttribute('tabindex')).toBeNull();
+    expect(layer?.getAttribute('role')).toBeNull();
+    expect(layer?.getAttribute('aria-label')).toBeNull();
+    expect(layer?.querySelectorAll('.cinder-area-chart__focus-ring').length).toBeGreaterThan(0);
+    expect(layer?.querySelectorAll('[tabindex], [role], [aria-label]').length).toBe(0);
+  });
+
+  test('hiding the focused series clears focus-ring and tooltip state', async () => {
+    const { container, getByRole, queryByText } = render(AreaChart, {
+      label: 'Usage trend',
+      series,
+    });
+    const target = getByRole('button', { name: 'Usage, Jan, 30' });
+
+    await fireEvent.keyDown(window, { key: 'Tab' });
+    await fireEvent.focus(target);
+    expect(container.querySelector('.cinder-area-chart__focus-ring-layer')).not.toBeNull();
+
+    await fireEvent.click(getByRole('button', { name: 'Usage' }));
+
+    expect(container.querySelectorAll('[data-cinder-series-id="usage"]').length).toBe(0);
+    expect(container.querySelector('.cinder-area-chart__focus-ring-layer')).toBeNull();
+    expect(queryByText('Jan: 30')).toBeNull();
+    expect(document.activeElement).not.toBe(target);
+  });
+
+  test('controlled hiddenSeriesIds clears stale focus-ring and tooltip state without a legend click', async () => {
+    const { container, getByRole, queryByText, rerender } = render(AreaChart, {
+      label: 'Usage trend',
+      series,
+    });
+    const target = getByRole('button', { name: 'Usage, Jan, 30' });
+
+    await fireEvent.keyDown(window, { key: 'Tab' });
+    await fireEvent.focus(target);
+    expect(container.querySelector('.cinder-area-chart__focus-ring-layer')).not.toBeNull();
+    expect(queryByText('Jan: 30')).toBeTruthy();
+
+    await rerender({ label: 'Usage trend', hiddenSeriesIds: ['usage'], series });
+
+    expect(container.querySelectorAll('[data-cinder-series-id="usage"]').length).toBe(0);
+    expect(container.querySelector('.cinder-area-chart__focus-ring-layer')).toBeNull();
+    expect(queryByText('Jan: 30')).toBeNull();
+    expect(document.activeElement).not.toBe(target);
+  });
+
   test('arrow keys move DOM focus to the active target', async () => {
-    const { getByRole, queryByText } = render(AreaChart, { label: 'Usage trend', series });
+    const { container, getByRole, queryByText } = render(AreaChart, {
+      label: 'Usage trend',
+      series,
+    });
     const firstTarget = getByRole('button', { name: 'Usage, Jan, 30' });
     const secondTarget = getByRole('button', { name: 'Storage, Jan, 15' });
 
     await fireEvent.focus(firstTarget);
+    expect(container.querySelector('.cinder-area-chart__focus-ring-layer')).toBeNull();
     await fireEvent.keyDown(firstTarget, { key: 'ArrowRight' });
 
     expect(document.activeElement).toBe(secondTarget);
+    expect(secondTarget.getAttribute('data-cinder-focus-ring-active')).toBe('true');
+    expect(container.querySelectorAll('.cinder-area-chart__focus-ring-layer').length).toBe(1);
     expect(secondTarget?.getAttribute('aria-describedby')).toBeTruthy();
     expect(queryByText('Jan: 15')).toBeTruthy();
   });

--- a/packages/components/src/components/area-chart/area-chart.test.ts
+++ b/packages/components/src/components/area-chart/area-chart.test.ts
@@ -193,6 +193,26 @@ describe('AreaChart', () => {
     expect(layer?.querySelectorAll('[tabindex], [role], [aria-label]').length).toBe(0);
   });
 
+  test('pointer input hides a keyboard focus-ring layer without clearing the focused tooltip', async () => {
+    const { container, getByRole, queryByText } = render(AreaChart, {
+      label: 'Usage trend',
+      series,
+    });
+    const target = getByRole('button', { name: 'Usage, Jan, 30' });
+
+    await fireEvent.keyDown(window, { key: 'Tab' });
+    await fireEvent.focus(target);
+    expect(container.querySelector('.cinder-area-chart__focus-ring-layer')).not.toBeNull();
+    expect(queryByText('Jan: 30')).toBeTruthy();
+
+    await fireEvent.pointerDown(window);
+
+    expect(target.getAttribute('data-cinder-focus-ring-active')).toBeNull();
+    expect(container.querySelector('.cinder-area-chart__focus-ring-layer')).toBeNull();
+    expect(target.getAttribute('aria-describedby')).toBeTruthy();
+    expect(queryByText('Jan: 30')).toBeTruthy();
+  });
+
   test('hiding the focused series clears focus-ring and tooltip state', async () => {
     const { container, getByRole, queryByText } = render(AreaChart, {
       label: 'Usage trend',

--- a/packages/components/src/components/bar-chart/bar-chart.css
+++ b/packages/components/src/components/bar-chart/bar-chart.css
@@ -71,14 +71,64 @@
     pointer-events: none;
   }
 
-  /*
- * SVG focus indicator: drop-shadow renders a visible ring around the focused
- * element on any background. Matches line-chart and area-chart.
- */
-  .cinder-bar-chart__focus-target:focus-visible {
-    stroke: var(--cinder-accent);
+  .cinder-bar-chart__focus-target:focus-visible:not([data-cinder-focus-ring-active='true']) {
+    fill: transparent;
+    stroke: var(--cinder-ring-color);
     stroke-width: var(--cinder-ring-width);
-    filter: drop-shadow(0 0 var(--cinder-ring-width) var(--cinder-ring-color));
+    vector-effect: non-scaling-stroke;
+    filter: none;
+  }
+
+  .cinder-bar-chart__focus-ring-layer {
+    pointer-events: none;
+  }
+
+  .cinder-bar-chart__focus-ring,
+  .cinder-bar-chart__focus-ring-halo,
+  .cinder-bar-chart__focus-ring-connector,
+  .cinder-bar-chart__focus-ring-dot {
+    fill: none;
+    pointer-events: none;
+    vector-effect: non-scaling-stroke;
+    stroke-linecap: round;
+    stroke-linejoin: round;
+  }
+
+  .cinder-bar-chart__focus-ring {
+    stroke: var(--cinder-ring-color);
+    stroke-width: var(--cinder-ring-width);
+    filter: none;
+  }
+
+  .cinder-bar-chart__focus-ring-halo {
+    stroke: var(--cinder-ring-offset-color);
+    stroke-width: calc(
+      var(--cinder-ring-width) + var(--cinder-ring-offset) + var(--cinder-ring-offset)
+    );
+    filter: none;
+  }
+
+  @media (forced-colors: active) {
+    .cinder-bar-chart__focus-ring-halo {
+      display: none;
+    }
+
+    .cinder-bar-chart__focus-ring,
+    .cinder-bar-chart__focus-ring-connector,
+    .cinder-bar-chart__focus-ring-dot {
+      fill: none;
+      stroke: ButtonText;
+      stroke-width: var(--cinder-ring-width);
+      filter: none;
+    }
+
+    .cinder-bar-chart__focus-target:focus-visible:not([data-cinder-focus-ring-active='true']) {
+      fill: transparent;
+      stroke: ButtonText;
+      stroke-width: var(--cinder-ring-width);
+      vector-effect: non-scaling-stroke;
+      filter: none;
+    }
   }
 
   .cinder-bar-chart__tick-label {

--- a/packages/components/src/components/bar-chart/bar-chart.svelte
+++ b/packages/components/src/components/bar-chart/bar-chart.svelte
@@ -24,7 +24,12 @@
     dataTableClass,
     formatNumericValue,
     legendVisible,
+    type ChartTarget,
   } from '../../_internal/chart/chart-utilities.ts';
+  import {
+    DEFAULT_CHART_FOCUS_RING_STROKE_PADDING,
+    createBarFocusRingGeometry,
+  } from '../../_internal/chart/chart-focus-ring.ts';
   import { ChartInteraction } from '../../_internal/chart/chart-interaction.svelte.ts';
   import { classNames } from '../../utilities/class-names.ts';
   import type { BarChartProps } from './bar-chart.types.ts';
@@ -96,6 +101,26 @@
       ? `${rootId}-table-guidance`
       : undefined,
   );
+  const focusedTarget = $derived.by(() => {
+    const currentTarget = interaction.focusedTarget;
+    if (!currentTarget) return undefined;
+    return model.targets.find((target) => target.id === currentTarget.id);
+  });
+  let keyboardFocusModality = $state(false);
+  let focusVisibleTargetId = $state<string>();
+  const focusRingTarget = $derived(
+    focusedTarget && focusVisibleTargetId === focusedTarget.id ? focusedTarget : undefined,
+  );
+  const barFocusRing = $derived(
+    focusRingTarget
+      ? createBarFocusRingGeometry({
+          target: focusRingTarget,
+          plotWidth: model.geometry.plotWidth,
+          plotHeight: model.geometry.plotHeight,
+          strokePadding: DEFAULT_CHART_FOCUS_RING_STROKE_PADDING,
+        })
+      : null,
+  );
 
   $effect(() => {
     assertValidNonNegativeInteger(
@@ -109,7 +134,42 @@
   $effect(() => {
     interaction.clearStaleTargets(loading, model.empty, model.targets);
   });
+
+  function rememberKeyboardFocusModality(event: KeyboardEvent): void {
+    if (
+      event.key === 'Tab' ||
+      event.key === 'Home' ||
+      event.key === 'End' ||
+      event.key.startsWith('Arrow')
+    ) {
+      keyboardFocusModality = true;
+    }
+  }
+
+  function clearKeyboardFocusModality(): void {
+    keyboardFocusModality = false;
+  }
+
+  function handleTargetFocus(target: ChartTarget): void {
+    interaction.focusedTarget = target;
+    focusVisibleTargetId = keyboardFocusModality ? target.id : undefined;
+  }
+
+  function handleTargetBlur(): void {
+    interaction.focusedTarget = undefined;
+    focusVisibleTargetId = undefined;
+  }
+
+  function handleTargetKeydown(event: KeyboardEvent): void {
+    rememberKeyboardFocusModality(event);
+    interaction.activateByKeyboard(event, rootElement!, model.targets, keyboardEnabled);
+  }
 </script>
+
+<svelte:window
+  onkeydown={rememberKeyboardFocusModality}
+  onpointerdown={clearKeyboardFocusModality}
+/>
 
 <figure
   {...rest}
@@ -160,7 +220,7 @@
         <title id="{rootId}-svg-title">{label}</title>
       {/if}
       <g transform={`translate(${model.geometry.marginLeft}, ${model.geometry.marginTop})`}>
-        {#each model.yTicks as tick, index}
+        {#each model.yTicks as tick, index (tick)}
           <!--
             Bar chart tick positions depend on orientation:
             - Vertical: y-axis labels appear left of the chart (same as line/area).
@@ -199,7 +259,7 @@
             data-cinder-category={bar.categoryLabel}
           />
         {/each}
-        {#each model.categoryTicks as tick (tick.label)}
+        {#each model.categoryTicks as tick (tick.categoryKey)}
           <!--
             Category axis labels differ by orientation:
             - Vertical: labels appear below bars (middle-anchored x, no baseline).
@@ -266,22 +326,40 @@
                 tabindex="0"
                 role="button"
                 data-cinder-target-id={target.id}
+                data-cinder-series-id={target.seriesId}
+                data-cinder-focus-ring-active={barFocusRing && focusRingTarget?.id === target.id
+                  ? 'true'
+                  : undefined}
                 aria-label={`${target.seriesLabel}, ${target.xLabel}, ${target.valueLabel}`}
                 aria-describedby={interaction.activeTarget?.id === target.id
                   ? `${rootId}-tooltip`
                   : undefined}
-                onfocus={() => (interaction.focusedTarget = target)}
-                onblur={() => (interaction.focusedTarget = undefined)}
-                onkeydown={(event) =>
-                  interaction.activateByKeyboard(
-                    event,
-                    rootElement!,
-                    model.targets,
-                    keyboardEnabled,
-                  )}
+                onfocus={() => handleTargetFocus(target)}
+                onblur={handleTargetBlur}
+                onkeydown={handleTargetKeydown}
               />
             {/each}
           {/if}
+        {/if}
+        {#if barFocusRing}
+          <g class="cinder-bar-chart__focus-ring-layer" aria-hidden="true">
+            <rect
+              class="cinder-bar-chart__focus-ring-halo"
+              x={barFocusRing.x}
+              y={barFocusRing.y}
+              width={barFocusRing.width}
+              height={barFocusRing.height}
+              rx={barFocusRing.radius}
+            />
+            <rect
+              class="cinder-bar-chart__focus-ring"
+              x={barFocusRing.x}
+              y={barFocusRing.y}
+              width={barFocusRing.width}
+              height={barFocusRing.height}
+              rx={barFocusRing.radius}
+            />
+          </g>
         {/if}
       </g>
     </svg>
@@ -313,8 +391,8 @@
         ></thead
       >
       <tbody>
-        {#each model.tableRows as row}
-          {#each row.values as value}
+        {#each model.tableRows as row (row.categoryKey)}
+          {#each row.values as value (value.seriesId)}
             <tr
               ><th scope="row">{row.categoryLabel}</th><td>{value.seriesLabel}</td><td
                 >{value.valueLabel}</td

--- a/packages/components/src/components/bar-chart/bar-chart.svelte
+++ b/packages/components/src/components/bar-chart/bar-chart.svelte
@@ -109,7 +109,9 @@
   let keyboardFocusModality = $state(false);
   let focusVisibleTargetId = $state<string>();
   const focusRingTarget = $derived(
-    focusedTarget && focusVisibleTargetId === focusedTarget.id ? focusedTarget : undefined,
+    keyboardFocusModality && focusedTarget && focusVisibleTargetId === focusedTarget.id
+      ? focusedTarget
+      : undefined,
   );
   const barFocusRing = $derived(
     focusRingTarget
@@ -148,6 +150,7 @@
 
   function clearKeyboardFocusModality(): void {
     keyboardFocusModality = false;
+    focusVisibleTargetId = undefined;
   }
 
   function handleTargetFocus(target: ChartTarget): void {

--- a/packages/components/src/components/bar-chart/bar-chart.test.ts
+++ b/packages/components/src/components/bar-chart/bar-chart.test.ts
@@ -254,6 +254,28 @@ describe('BarChart', () => {
     expect(layer?.querySelectorAll('[tabindex], [role], [aria-label]').length).toBe(0);
   });
 
+  test('pointer input hides a keyboard focus-ring layer without clearing the focused tooltip', async () => {
+    const { container, getByRole, queryByText } = render(BarChart, {
+      label: 'Revenue by month',
+      data,
+      categoryKey: 'month',
+      series,
+    });
+    const target = getByRole('button', { name: 'Revenue, Jan, 120' });
+
+    await fireEvent.keyDown(window, { key: 'Tab' });
+    await fireEvent.focus(target);
+    expect(container.querySelector('.cinder-bar-chart__focus-ring-layer')).not.toBeNull();
+    expect(queryByText('Jan: 120')).toBeTruthy();
+
+    await fireEvent.pointerDown(window);
+
+    expect(target.getAttribute('data-cinder-focus-ring-active')).toBeNull();
+    expect(container.querySelector('.cinder-bar-chart__focus-ring-layer')).toBeNull();
+    expect(target.getAttribute('aria-describedby')).toBeTruthy();
+    expect(queryByText('Jan: 120')).toBeTruthy();
+  });
+
   test('hiding the focused series clears focus-ring and tooltip state', async () => {
     const { container, getByRole, queryByText } = render(BarChart, {
       label: 'Revenue by month',

--- a/packages/components/src/components/bar-chart/bar-chart.test.ts
+++ b/packages/components/src/components/bar-chart/bar-chart.test.ts
@@ -46,6 +46,20 @@ describe('BarChart', () => {
     expect(container.querySelector('table')?.className).not.toContain('cinder-sr-only');
   });
 
+  test('data table supports distinct categories with the same formatted label', () => {
+    const { container } = render(BarChart, {
+      label: 'Revenue by month',
+      dataTableVisibility: 'visible',
+      data,
+      categoryKey: 'month',
+      series: [{ id: 'revenue', label: 'Revenue', valueKey: 'revenue' }],
+      xAxis: { format: () => 'Same period' },
+    });
+
+    const rowHeaders = [...container.querySelectorAll('tbody th[scope="row"]')];
+    expect(rowHeaders.map((header) => header.textContent)).toEqual(['Same period', 'Same period']);
+  });
+
   test('renders horizontal stacked bars with distinct attributes', () => {
     const { container } = render(BarChart, {
       label: 'Revenue by month',
@@ -68,8 +82,14 @@ describe('BarChart', () => {
       series,
     });
     const button = getByRole('button', { name: 'Revenue' });
+    expect(container.querySelectorAll('[data-cinder-series-id="revenue"]').length).toBeGreaterThan(
+      0,
+    );
+
     await fireEvent.click(button);
+
     expect(container.querySelectorAll('[data-cinder-series="revenue"]').length).toBe(0);
+    expect(container.querySelectorAll('[data-cinder-series-id="revenue"]').length).toBe(0);
   });
 
   test('invalid value keys throw stable developer errors', () => {
@@ -206,8 +226,85 @@ describe('BarChart', () => {
     expect(queryByText('Jan: 120')).toBeNull();
   });
 
+  test('keyboard focus renders one visual-only SVG focus-ring layer', async () => {
+    const { container, getByRole } = render(BarChart, {
+      label: 'Revenue by month',
+      data,
+      categoryKey: 'month',
+      series,
+    });
+    const target = getByRole('button', { name: 'Revenue, Jan, 120' });
+
+    await fireEvent.focus(target);
+    expect(container.querySelector('.cinder-bar-chart__focus-ring-layer')).toBeNull();
+    await fireEvent.blur(target);
+    await fireEvent.keyDown(window, { key: 'Tab' });
+    await fireEvent.focus(target);
+
+    expect(target.getAttribute('data-cinder-series-id')).toBe('revenue');
+    expect(target.getAttribute('data-cinder-focus-ring-active')).toBe('true');
+    const layers = container.querySelectorAll('.cinder-bar-chart__focus-ring-layer');
+    expect(layers.length).toBe(1);
+    const layer = layers[0];
+    expect(layer?.getAttribute('aria-hidden')).toBe('true');
+    expect(layer?.getAttribute('tabindex')).toBeNull();
+    expect(layer?.getAttribute('role')).toBeNull();
+    expect(layer?.getAttribute('aria-label')).toBeNull();
+    expect(layer?.querySelectorAll('.cinder-bar-chart__focus-ring').length).toBeGreaterThan(0);
+    expect(layer?.querySelectorAll('[tabindex], [role], [aria-label]').length).toBe(0);
+  });
+
+  test('hiding the focused series clears focus-ring and tooltip state', async () => {
+    const { container, getByRole, queryByText } = render(BarChart, {
+      label: 'Revenue by month',
+      data,
+      categoryKey: 'month',
+      series,
+    });
+    const target = getByRole('button', { name: 'Revenue, Jan, 120' });
+
+    await fireEvent.keyDown(window, { key: 'Tab' });
+    await fireEvent.focus(target);
+    expect(container.querySelector('.cinder-bar-chart__focus-ring-layer')).not.toBeNull();
+
+    await fireEvent.click(getByRole('button', { name: 'Revenue' }));
+
+    expect(container.querySelectorAll('[data-cinder-series-id="revenue"]').length).toBe(0);
+    expect(container.querySelector('.cinder-bar-chart__focus-ring-layer')).toBeNull();
+    expect(queryByText('Jan: 120')).toBeNull();
+    expect(document.activeElement).not.toBe(target);
+  });
+
+  test('controlled hiddenSeriesIds clears stale focus-ring and tooltip state without a legend click', async () => {
+    const { container, getByRole, queryByText, rerender } = render(BarChart, {
+      label: 'Revenue by month',
+      data,
+      categoryKey: 'month',
+      series,
+    });
+    const target = getByRole('button', { name: 'Revenue, Jan, 120' });
+
+    await fireEvent.keyDown(window, { key: 'Tab' });
+    await fireEvent.focus(target);
+    expect(container.querySelector('.cinder-bar-chart__focus-ring-layer')).not.toBeNull();
+    expect(queryByText('Jan: 120')).toBeTruthy();
+
+    await rerender({
+      label: 'Revenue by month',
+      data,
+      categoryKey: 'month',
+      hiddenSeriesIds: ['revenue'],
+      series,
+    });
+
+    expect(container.querySelectorAll('[data-cinder-series-id="revenue"]').length).toBe(0);
+    expect(container.querySelector('.cinder-bar-chart__focus-ring-layer')).toBeNull();
+    expect(queryByText('Jan: 120')).toBeNull();
+    expect(document.activeElement).not.toBe(target);
+  });
+
   test('arrow keys move DOM focus to the active target', async () => {
-    const { getByRole, queryByText } = render(BarChart, {
+    const { container, getByRole, queryByText } = render(BarChart, {
       label: 'Revenue by month',
       data,
       categoryKey: 'month',
@@ -217,9 +314,12 @@ describe('BarChart', () => {
     const secondTarget = getByRole('button', { name: 'Expansion, Jan, 30' });
 
     await fireEvent.focus(firstTarget);
+    expect(container.querySelector('.cinder-bar-chart__focus-ring-layer')).toBeNull();
     await fireEvent.keyDown(firstTarget, { key: 'ArrowRight' });
 
     expect(document.activeElement).toBe(secondTarget);
+    expect(secondTarget.getAttribute('data-cinder-focus-ring-active')).toBe('true');
+    expect(container.querySelectorAll('.cinder-bar-chart__focus-ring-layer').length).toBe(1);
     expect(secondTarget?.getAttribute('aria-describedby')).toBeTruthy();
     expect(queryByText('Jan: 30')).toBeTruthy();
   });

--- a/packages/components/src/components/line-chart/line-chart.css
+++ b/packages/components/src/components/line-chart/line-chart.css
@@ -81,15 +81,64 @@
     pointer-events: none;
   }
 
-  /*
- * SVG focus indicator: drop-shadow filter renders an outline-equivalent ring
- * around the focused circle that stays visible on any background. Stroke alone
- * was invisible against transparent fills.
- */
-  .cinder-line-chart__focus-target:focus-visible {
-    stroke: var(--cinder-accent);
+  .cinder-line-chart__focus-target:focus-visible:not([data-cinder-focus-ring-active='true']) {
+    fill: transparent;
+    stroke: var(--cinder-ring-color);
     stroke-width: var(--cinder-ring-width);
-    filter: drop-shadow(0 0 var(--cinder-ring-width) var(--cinder-ring-color));
+    vector-effect: non-scaling-stroke;
+    filter: none;
+  }
+
+  .cinder-line-chart__focus-ring-layer {
+    pointer-events: none;
+  }
+
+  .cinder-line-chart__focus-ring,
+  .cinder-line-chart__focus-ring-halo,
+  .cinder-line-chart__focus-ring-connector,
+  .cinder-line-chart__focus-ring-dot {
+    fill: none;
+    pointer-events: none;
+    vector-effect: non-scaling-stroke;
+    stroke-linecap: round;
+    stroke-linejoin: round;
+  }
+
+  .cinder-line-chart__focus-ring {
+    stroke: var(--cinder-ring-color);
+    stroke-width: var(--cinder-ring-width);
+    filter: none;
+  }
+
+  .cinder-line-chart__focus-ring-halo {
+    stroke: var(--cinder-ring-offset-color);
+    stroke-width: calc(
+      var(--cinder-ring-width) + var(--cinder-ring-offset) + var(--cinder-ring-offset)
+    );
+    filter: none;
+  }
+
+  @media (forced-colors: active) {
+    .cinder-line-chart__focus-ring-halo {
+      display: none;
+    }
+
+    .cinder-line-chart__focus-ring,
+    .cinder-line-chart__focus-ring-connector,
+    .cinder-line-chart__focus-ring-dot {
+      fill: none;
+      stroke: ButtonText;
+      stroke-width: var(--cinder-ring-width);
+      filter: none;
+    }
+
+    .cinder-line-chart__focus-target:focus-visible:not([data-cinder-focus-ring-active='true']) {
+      fill: transparent;
+      stroke: ButtonText;
+      stroke-width: var(--cinder-ring-width);
+      vector-effect: non-scaling-stroke;
+      filter: none;
+    }
   }
 
   .cinder-line-chart__tick-label {

--- a/packages/components/src/components/line-chart/line-chart.svelte
+++ b/packages/components/src/components/line-chart/line-chart.svelte
@@ -24,7 +24,12 @@
     dataTableClass,
     formatNumericValue,
     legendVisible,
+    type ChartTarget,
   } from '../../_internal/chart/chart-utilities.ts';
+  import {
+    DEFAULT_CHART_FOCUS_RING_STROKE_PADDING,
+    createPointFocusRingGeometry,
+  } from '../../_internal/chart/chart-focus-ring.ts';
   import { ChartInteraction } from '../../_internal/chart/chart-interaction.svelte.ts';
   import { classNames } from '../../utilities/class-names.ts';
   import type { LineChartProps } from './line-chart.types.ts';
@@ -84,6 +89,26 @@
       ? `${rootId}-table-guidance`
       : undefined,
   );
+  const focusedTarget = $derived.by(() => {
+    const currentTarget = interaction.focusedTarget;
+    if (!currentTarget) return undefined;
+    return model.targets.find((target) => target.id === currentTarget.id);
+  });
+  let keyboardFocusModality = $state(false);
+  let focusVisibleTargetId = $state<string>();
+  const focusRingTarget = $derived(
+    focusedTarget && focusVisibleTargetId === focusedTarget.id ? focusedTarget : undefined,
+  );
+  const pointFocusRing = $derived(
+    focusRingTarget
+      ? createPointFocusRingGeometry({
+          target: focusRingTarget,
+          plotWidth: model.geometry.plotWidth,
+          plotHeight: model.geometry.plotHeight,
+          strokePadding: DEFAULT_CHART_FOCUS_RING_STROKE_PADDING,
+        })
+      : null,
+  );
 
   $effect(() => {
     assertValidNonNegativeInteger(
@@ -97,7 +122,42 @@
   $effect(() => {
     interaction.clearStaleTargets(loading, model.empty, model.targets);
   });
+
+  function rememberKeyboardFocusModality(event: KeyboardEvent): void {
+    if (
+      event.key === 'Tab' ||
+      event.key === 'Home' ||
+      event.key === 'End' ||
+      event.key.startsWith('Arrow')
+    ) {
+      keyboardFocusModality = true;
+    }
+  }
+
+  function clearKeyboardFocusModality(): void {
+    keyboardFocusModality = false;
+  }
+
+  function handleTargetFocus(target: ChartTarget): void {
+    interaction.focusedTarget = target;
+    focusVisibleTargetId = keyboardFocusModality ? target.id : undefined;
+  }
+
+  function handleTargetBlur(): void {
+    interaction.focusedTarget = undefined;
+    focusVisibleTargetId = undefined;
+  }
+
+  function handleTargetKeydown(event: KeyboardEvent): void {
+    rememberKeyboardFocusModality(event);
+    interaction.activateByKeyboard(event, rootElement!, model.targets, keyboardEnabled);
+  }
 </script>
+
+<svelte:window
+  onkeydown={rememberKeyboardFocusModality}
+  onpointerdown={clearKeyboardFocusModality}
+/>
 
 <figure
   {...rest}
@@ -148,7 +208,7 @@
         <title id="{rootId}-svg-title">{label}</title>
       {/if}
       <g transform={`translate(${model.geometry.marginLeft}, ${model.geometry.marginTop})`}>
-        {#each model.yTicks as tick, index}
+        {#each model.yTicks as tick, index (tick)}
           {@const tickY =
             model.geometry.plotHeight -
             ((tick - model.yDomain[0]) / (model.yDomain[1] - model.yDomain[0])) *
@@ -233,22 +293,77 @@
                 tabindex="0"
                 role="button"
                 data-cinder-target-id={target.id}
+                data-cinder-series-id={target.seriesId}
+                data-cinder-focus-ring-active={pointFocusRing && focusRingTarget?.id === target.id
+                  ? 'true'
+                  : undefined}
                 aria-label={`${target.seriesLabel}, ${target.xLabel}, ${target.valueLabel}`}
                 aria-describedby={interaction.activeTarget?.id === target.id
                   ? `${rootId}-tooltip`
                   : undefined}
-                onfocus={() => (interaction.focusedTarget = target)}
-                onblur={() => (interaction.focusedTarget = undefined)}
-                onkeydown={(event) =>
-                  interaction.activateByKeyboard(
-                    event,
-                    rootElement!,
-                    model.targets,
-                    keyboardEnabled,
-                  )}
+                onfocus={() => handleTargetFocus(target)}
+                onblur={handleTargetBlur}
+                onkeydown={handleTargetKeydown}
               />
             {/each}
           {/if}
+        {/if}
+        {#if pointFocusRing}
+          <g class="cinder-line-chart__focus-ring-layer" aria-hidden="true">
+            {#if pointFocusRing.kind === 'point'}
+              <circle
+                class="cinder-line-chart__focus-ring-halo"
+                cx={pointFocusRing.cx}
+                cy={pointFocusRing.cy}
+                r={pointFocusRing.radius}
+              />
+              <circle
+                class="cinder-line-chart__focus-ring"
+                cx={pointFocusRing.cx}
+                cy={pointFocusRing.cy}
+                r={pointFocusRing.radius}
+              />
+              {#if pointFocusRing.connector && pointFocusRing.dot}
+                <path
+                  class="cinder-line-chart__focus-ring-connector cinder-line-chart__focus-ring-halo"
+                  d={`M ${pointFocusRing.connector.x1} ${pointFocusRing.connector.y1} L ${pointFocusRing.connector.x2} ${pointFocusRing.connector.y2}`}
+                />
+                <path
+                  class="cinder-line-chart__focus-ring-connector cinder-line-chart__focus-ring"
+                  d={`M ${pointFocusRing.connector.x1} ${pointFocusRing.connector.y1} L ${pointFocusRing.connector.x2} ${pointFocusRing.connector.y2}`}
+                />
+                <circle
+                  class="cinder-line-chart__focus-ring-dot cinder-line-chart__focus-ring-halo"
+                  cx={pointFocusRing.dot.cx}
+                  cy={pointFocusRing.dot.cy}
+                  r={pointFocusRing.dot.radius}
+                />
+                <circle
+                  class="cinder-line-chart__focus-ring-dot cinder-line-chart__focus-ring"
+                  cx={pointFocusRing.dot.cx}
+                  cy={pointFocusRing.dot.cy}
+                  r={pointFocusRing.dot.radius}
+                />
+              {/if}
+            {:else}
+              <rect
+                class="cinder-line-chart__focus-ring-halo"
+                x={pointFocusRing.x}
+                y={pointFocusRing.y}
+                width={pointFocusRing.width}
+                height={pointFocusRing.height}
+                rx={pointFocusRing.radius}
+              />
+              <rect
+                class="cinder-line-chart__focus-ring"
+                x={pointFocusRing.x}
+                y={pointFocusRing.y}
+                width={pointFocusRing.width}
+                height={pointFocusRing.height}
+                rx={pointFocusRing.radius}
+              />
+            {/if}
+          </g>
         {/if}
       </g>
     </svg>

--- a/packages/components/src/components/line-chart/line-chart.svelte
+++ b/packages/components/src/components/line-chart/line-chart.svelte
@@ -97,7 +97,9 @@
   let keyboardFocusModality = $state(false);
   let focusVisibleTargetId = $state<string>();
   const focusRingTarget = $derived(
-    focusedTarget && focusVisibleTargetId === focusedTarget.id ? focusedTarget : undefined,
+    keyboardFocusModality && focusedTarget && focusVisibleTargetId === focusedTarget.id
+      ? focusedTarget
+      : undefined,
   );
   const pointFocusRing = $derived(
     focusRingTarget
@@ -136,6 +138,7 @@
 
   function clearKeyboardFocusModality(): void {
     keyboardFocusModality = false;
+    focusVisibleTargetId = undefined;
   }
 
   function handleTargetFocus(target: ChartTarget): void {

--- a/packages/components/src/components/line-chart/line-chart.test.ts
+++ b/packages/components/src/components/line-chart/line-chart.test.ts
@@ -111,15 +111,22 @@ describe('LineChart', () => {
   test('legend toggle hides and restores rendered series geometry', async () => {
     const { getByRole, container } = render(LineChart, { label: 'Monthly revenue', series });
     expect(container.querySelectorAll('[data-cinder-series="revenue"]').length).toBeGreaterThan(0);
+    expect(container.querySelectorAll('[data-cinder-series-id="revenue"]').length).toBeGreaterThan(
+      0,
+    );
 
     const button = getByRole('button', { name: 'Revenue' });
     await fireEvent.click(button);
     expect(button.getAttribute('aria-pressed')).toBe('false');
     expect(container.querySelectorAll('[data-cinder-series="revenue"]').length).toBe(0);
+    expect(container.querySelectorAll('[data-cinder-series-id="revenue"]').length).toBe(0);
 
     await fireEvent.click(button);
     expect(button.getAttribute('aria-pressed')).toBe('true');
     expect(container.querySelectorAll('[data-cinder-series="revenue"]').length).toBeGreaterThan(0);
+    expect(container.querySelectorAll('[data-cinder-series-id="revenue"]').length).toBeGreaterThan(
+      0,
+    );
   });
 
   test('keyboard focus shows tooltip and escape clears it', async () => {
@@ -133,15 +140,83 @@ describe('LineChart', () => {
     expect(queryByText('Jan: 120')).toBeNull();
   });
 
+  test('keyboard focus renders one visual-only SVG focus-ring layer', async () => {
+    const { container, getByRole } = render(LineChart, { label: 'Monthly revenue', series });
+    const target = getByRole('button', { name: 'Revenue, Jan, 120' });
+
+    await fireEvent.focus(target);
+    expect(container.querySelector('.cinder-line-chart__focus-ring-layer')).toBeNull();
+    await fireEvent.blur(target);
+    await fireEvent.keyDown(window, { key: 'Tab' });
+    await fireEvent.focus(target);
+
+    expect(target.getAttribute('data-cinder-series-id')).toBe('revenue');
+    expect(target.getAttribute('data-cinder-focus-ring-active')).toBe('true');
+    const layers = container.querySelectorAll('.cinder-line-chart__focus-ring-layer');
+    expect(layers.length).toBe(1);
+    const layer = layers[0];
+    expect(layer?.getAttribute('aria-hidden')).toBe('true');
+    expect(layer?.getAttribute('tabindex')).toBeNull();
+    expect(layer?.getAttribute('role')).toBeNull();
+    expect(layer?.getAttribute('aria-label')).toBeNull();
+    expect(layer?.querySelectorAll('.cinder-line-chart__focus-ring').length).toBeGreaterThan(0);
+    expect(layer?.querySelectorAll('[tabindex], [role], [aria-label]').length).toBe(0);
+  });
+
+  test('hiding the focused series clears focus-ring and tooltip state', async () => {
+    const { container, getByRole, queryByText } = render(LineChart, {
+      label: 'Monthly revenue',
+      series,
+    });
+    const target = getByRole('button', { name: 'Revenue, Jan, 120' });
+
+    await fireEvent.keyDown(window, { key: 'Tab' });
+    await fireEvent.focus(target);
+    expect(container.querySelector('.cinder-line-chart__focus-ring-layer')).not.toBeNull();
+
+    await fireEvent.click(getByRole('button', { name: 'Revenue' }));
+
+    expect(container.querySelectorAll('[data-cinder-series-id="revenue"]').length).toBe(0);
+    expect(container.querySelector('.cinder-line-chart__focus-ring-layer')).toBeNull();
+    expect(queryByText('Jan: 120')).toBeNull();
+    expect(document.activeElement).not.toBe(target);
+  });
+
+  test('controlled hiddenSeriesIds clears stale focus-ring and tooltip state without a legend click', async () => {
+    const { container, getByRole, queryByText, rerender } = render(LineChart, {
+      label: 'Monthly revenue',
+      series,
+    });
+    const target = getByRole('button', { name: 'Revenue, Jan, 120' });
+
+    await fireEvent.keyDown(window, { key: 'Tab' });
+    await fireEvent.focus(target);
+    expect(container.querySelector('.cinder-line-chart__focus-ring-layer')).not.toBeNull();
+    expect(queryByText('Jan: 120')).toBeTruthy();
+
+    await rerender({ label: 'Monthly revenue', hiddenSeriesIds: ['revenue'], series });
+
+    expect(container.querySelectorAll('[data-cinder-series-id="revenue"]').length).toBe(0);
+    expect(container.querySelector('.cinder-line-chart__focus-ring-layer')).toBeNull();
+    expect(queryByText('Jan: 120')).toBeNull();
+    expect(document.activeElement).not.toBe(target);
+  });
+
   test('arrow keys move DOM focus to the active target', async () => {
-    const { getByRole, queryByText } = render(LineChart, { label: 'Monthly revenue', series });
+    const { container, getByRole, queryByText } = render(LineChart, {
+      label: 'Monthly revenue',
+      series,
+    });
     const firstTarget = getByRole('button', { name: 'Revenue, Jan, 120' });
     const secondTarget = getByRole('button', { name: 'Signups, Jan, 40' });
 
     await fireEvent.focus(firstTarget);
+    expect(container.querySelector('.cinder-line-chart__focus-ring-layer')).toBeNull();
     await fireEvent.keyDown(firstTarget, { key: 'ArrowRight' });
 
     expect(document.activeElement).toBe(secondTarget);
+    expect(secondTarget.getAttribute('data-cinder-focus-ring-active')).toBe('true');
+    expect(container.querySelectorAll('.cinder-line-chart__focus-ring-layer').length).toBe(1);
     expect(secondTarget?.getAttribute('aria-describedby')).toBeTruthy();
     expect(queryByText('Jan: 40')).toBeTruthy();
   });

--- a/packages/components/src/components/line-chart/line-chart.test.ts
+++ b/packages/components/src/components/line-chart/line-chart.test.ts
@@ -163,6 +163,26 @@ describe('LineChart', () => {
     expect(layer?.querySelectorAll('[tabindex], [role], [aria-label]').length).toBe(0);
   });
 
+  test('pointer input hides a keyboard focus-ring layer without clearing the focused tooltip', async () => {
+    const { container, getByRole, queryByText } = render(LineChart, {
+      label: 'Monthly revenue',
+      series,
+    });
+    const target = getByRole('button', { name: 'Revenue, Jan, 120' });
+
+    await fireEvent.keyDown(window, { key: 'Tab' });
+    await fireEvent.focus(target);
+    expect(container.querySelector('.cinder-line-chart__focus-ring-layer')).not.toBeNull();
+    expect(queryByText('Jan: 120')).toBeTruthy();
+
+    await fireEvent.pointerDown(window);
+
+    expect(target.getAttribute('data-cinder-focus-ring-active')).toBeNull();
+    expect(container.querySelector('.cinder-line-chart__focus-ring-layer')).toBeNull();
+    expect(target.getAttribute('aria-describedby')).toBeTruthy();
+    expect(queryByText('Jan: 120')).toBeTruthy();
+  });
+
   test('hiding the focused series clears focus-ring and tooltip state', async () => {
     const { container, getByRole, queryByText } = render(LineChart, {
       label: 'Monthly revenue',

--- a/packages/components/src/test/focus-ring-recipe.test.ts
+++ b/packages/components/src/test/focus-ring-recipe.test.ts
@@ -22,6 +22,7 @@ import stylelint from 'stylelint';
 // Keeping it in one place means the two enforcement layers can't disagree
 // about whether a rule is inside `@media (forced-colors: active)`.
 import { isUnderForcedColors } from '../../scripts/stylelint/focus-ring-helpers.mjs';
+import { DEFAULT_CHART_FOCUS_RING_STROKE_PADDING } from '../_internal/chart/chart-focus-ring.ts';
 
 function loadCss(relativePath: string): string {
   const fullPath = fileURLToPath(new URL(relativePath, import.meta.url));
@@ -53,6 +54,10 @@ const sideNavigationGroupCss = loadCss(
 );
 const sliderCss = loadCss('../components/slider/slider.css');
 const tabsCss = loadCss('../components/tabs/tabs.css');
+const areaChartCss = loadCss('../components/area-chart/area-chart.css');
+const barChartCss = loadCss('../components/bar-chart/bar-chart.css');
+const lineChartCss = loadCss('../components/line-chart/line-chart.css');
+const tokensBaseCss = loadCss('../styles/tokens-base.css');
 
 // Focus-ring sweep targets (15f4d777) — colored outline-only recipes converted
 // to the shared Strategy B / B-inset recipe.
@@ -156,6 +161,10 @@ function declValue(rule: Rule, property: string): string | undefined {
     value = decl.value;
   });
   return value;
+}
+
+function normalizeCssValue(value: string): string {
+  return value.replaceAll(/\s+/g, ' ').replaceAll('( ', '(').replaceAll(' )', ')').trim();
 }
 
 const recipes: Array<{
@@ -756,6 +765,132 @@ describe('focus-ring sweep — Strategy B (outer) Svelte selectors', () => {
       assertOuterRecipe(style, selector);
     });
   }
+});
+
+function cssVariablePixelValue(css: string, property: string): number {
+  let value: string | undefined;
+  parse(css).walkDecls(property, (declaration) => {
+    value = declaration.value;
+  });
+  if (!value?.endsWith('px')) {
+    throw new Error(`Expected ${property} to be a px value; received ${value ?? '(missing)'}.`);
+  }
+  return Number.parseFloat(value);
+}
+
+function resolveChartStrokeWidth(value: string, ringWidth: number, ringOffset: number): number {
+  const normalizedValue = normalizeCssValue(value);
+  if (normalizedValue === 'var(--cinder-ring-width)') return ringWidth;
+  if (
+    normalizedValue ===
+    'calc(var(--cinder-ring-width) + var(--cinder-ring-offset) + var(--cinder-ring-offset))'
+  ) {
+    return ringWidth + ringOffset * 2;
+  }
+  throw new Error(`Unsupported chart focus-ring stroke-width expression: ${value}`);
+}
+
+function assertSvgChartFocusRingRecipe(css: string, prefix: string): void {
+  const root = parse(css);
+  const sharedSelectors = [
+    `.${prefix}__focus-ring`,
+    `.${prefix}__focus-ring-halo`,
+    `.${prefix}__focus-ring-connector`,
+    `.${prefix}__focus-ring-dot`,
+  ];
+
+  for (const selector of sharedSelectors) {
+    const rules = findRules(root, selector).filter((rule) => !isUnderForcedColors(rule));
+    expect(rules.length, `${selector} base rule count`).toBeGreaterThanOrEqual(1);
+    const sharedRule = rules.find((rule) => declValue(rule, 'vector-effect') !== undefined);
+    expect(sharedRule, `${selector} shared SVG rule`).toBeDefined();
+    expect(declValue(sharedRule!, 'fill')).toBe('none');
+    expect(declValue(sharedRule!, 'pointer-events')).toBe('none');
+    expect(declValue(sharedRule!, 'vector-effect')).toBe('non-scaling-stroke');
+  }
+
+  const ring = findRules(root, `.${prefix}__focus-ring`).find(
+    (rule) => !isUnderForcedColors(rule) && declValue(rule, 'stroke') !== undefined,
+  );
+  expect(ring, `${prefix} ring rule`).toBeDefined();
+  expect(declValue(ring!, 'stroke')).toBe('var(--cinder-ring-color)');
+  expect(declValue(ring!, 'stroke-width')).toBe('var(--cinder-ring-width)');
+  expect(declValue(ring!, 'filter')).toBe('none');
+
+  const halo = findRules(root, `.${prefix}__focus-ring-halo`).find(
+    (rule) => !isUnderForcedColors(rule) && declValue(rule, 'stroke') !== undefined,
+  );
+  expect(halo, `${prefix} halo rule`).toBeDefined();
+  expect(declValue(halo!, 'stroke')).toBe('var(--cinder-ring-offset-color)');
+  expect(normalizeCssValue(declValue(halo!, 'stroke-width')!)).toBe(
+    'calc(var(--cinder-ring-width) + var(--cinder-ring-offset) + var(--cinder-ring-offset))',
+  );
+  expect(declValue(halo!, 'filter')).toBe('none');
+
+  const fallbackSelector = `.${prefix}__focus-target:focus-visible:not([data-cinder-focus-ring-active='true'])`;
+  const fallback = findRules(root, fallbackSelector).find((rule) => !isUnderForcedColors(rule));
+  expect(fallback, `${prefix} focus-target fallback`).toBeDefined();
+  expect(declValue(fallback!, 'stroke')).toBe('var(--cinder-ring-color)');
+  expect(declValue(fallback!, 'stroke-width')).toBe('var(--cinder-ring-width)');
+  expect(declValue(fallback!, 'vector-effect')).toBe('non-scaling-stroke');
+  expect(declValue(fallback!, 'filter')).toBe('none');
+
+  const forcedRing = findRules(root, `.${prefix}__focus-ring`).find((rule) =>
+    isUnderForcedColors(rule),
+  );
+  expect(forcedRing, `${prefix} forced-colors ring`).toBeDefined();
+  expect(declValue(forcedRing!, 'fill')).toBe('none');
+  expect(declValue(forcedRing!, 'stroke')).toBe('ButtonText');
+  expect(declValue(forcedRing!, 'stroke-width')).toBe('var(--cinder-ring-width)');
+  expect(declValue(forcedRing!, 'filter')).toBe('none');
+
+  const forcedHalo = findRules(root, `.${prefix}__focus-ring-halo`).find((rule) =>
+    isUnderForcedColors(rule),
+  );
+  expect(forcedHalo, `${prefix} forced-colors halo`).toBeDefined();
+  expect(declValue(forcedHalo!, 'display')).toBe('none');
+
+  const forcedFallback = findRules(root, fallbackSelector).find((rule) =>
+    isUnderForcedColors(rule),
+  );
+  expect(forcedFallback, `${prefix} forced-colors target fallback`).toBeDefined();
+  expect(declValue(forcedFallback!, 'stroke')).toBe('ButtonText');
+  expect(declValue(forcedFallback!, 'stroke-width')).toBe('var(--cinder-ring-width)');
+  expect(declValue(forcedFallback!, 'filter')).toBe('none');
+}
+
+describe('SVG chart focus-ring recipe', () => {
+  const chartCases = [
+    { name: 'area-chart', css: areaChartCss, prefix: 'cinder-area-chart' },
+    { name: 'line-chart', css: lineChartCss, prefix: 'cinder-line-chart' },
+    { name: 'bar-chart', css: barChartCss, prefix: 'cinder-bar-chart' },
+  ];
+
+  for (const { name, css, prefix } of chartCases) {
+    test(`${name}: SVG focus-ring layer uses tokenized non-scaling stroke with forced-colors fallback`, () => {
+      assertSvgChartFocusRingRecipe(css, prefix);
+    });
+  }
+
+  test('halo plus ring stroke budget stays within the geometry stroke padding', () => {
+    const ringWidth = cssVariablePixelValue(tokensBaseCss, '--cinder-ring-width');
+    const ringOffset = cssVariablePixelValue(tokensBaseCss, '--cinder-ring-offset');
+    const root = parse(areaChartCss);
+    const ring = findRules(root, '.cinder-area-chart__focus-ring').find(
+      (rule) => !isUnderForcedColors(rule) && declValue(rule, 'stroke-width') !== undefined,
+    );
+    const halo = findRules(root, '.cinder-area-chart__focus-ring-halo').find(
+      (rule) => !isUnderForcedColors(rule) && declValue(rule, 'stroke-width') !== undefined,
+    );
+
+    expect(ring).toBeDefined();
+    expect(halo).toBeDefined();
+    const totalStrokeBudget =
+      resolveChartStrokeWidth(declValue(ring!, 'stroke-width')!, ringWidth, ringOffset) +
+      resolveChartStrokeWidth(declValue(halo!, 'stroke-width')!, ringWidth, ringOffset);
+
+    expect(totalStrokeBudget).toBeLessThanOrEqual(DEFAULT_CHART_FOCUS_RING_STROKE_PADDING);
+  });
 });
 
 describe('chat-input attachment-remove — inset ring painted on the visible chip', () => {

--- a/packages/testing/tests/chart-focus-rings.playwright.ts
+++ b/packages/testing/tests/chart-focus-rings.playwright.ts
@@ -1,0 +1,447 @@
+import { expect, test, type Locator, type Page } from '@playwright/test';
+import pixelmatch from 'pixelmatch';
+import { PNG } from 'pngjs';
+
+type ChartDefinition = {
+  slug: 'area-chart' | 'line-chart' | 'bar-chart';
+  rootClass: string;
+  targetClass: string;
+  hitSurfaceClass: string;
+  targetId: string;
+  seriesId: string;
+  accessibleName: string;
+  tooltipText: string;
+};
+
+type ElementBox = {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+};
+
+type ScreenshotClip = ElementBox;
+
+type TabbableSummary = {
+  tagName: string;
+  role: string | null;
+  ariaLabel: string | null;
+  text: string;
+  targetId: string | null;
+  seriesId: string | null;
+};
+
+const charts: ChartDefinition[] = [
+  {
+    slug: 'area-chart',
+    rootClass: 'cinder-area-chart',
+    targetClass: 'cinder-area-chart__focus-target',
+    hitSurfaceClass: 'cinder-area-chart__hit-surface',
+    targetId: 'usage-string:Jan',
+    seriesId: 'usage',
+    accessibleName: 'Usage, Jan, 44',
+    tooltipText: 'Jan: 44',
+  },
+  {
+    slug: 'line-chart',
+    rootClass: 'cinder-line-chart',
+    targetClass: 'cinder-line-chart__focus-target',
+    hitSurfaceClass: 'cinder-line-chart__hit-surface',
+    targetId: 'revenue-string:Jan',
+    seriesId: 'revenue',
+    accessibleName: 'Revenue, Jan, 120',
+    tooltipText: 'Jan: 120',
+  },
+  {
+    slug: 'bar-chart',
+    rootClass: 'cinder-bar-chart',
+    targetClass: 'cinder-bar-chart__focus-target',
+    hitSurfaceClass: 'cinder-bar-chart__hit-surface',
+    targetId: 'active-string:Starter',
+    seriesId: 'active',
+    accessibleName: 'Active users, Starter, 120',
+    tooltipText: 'Starter: 120',
+  },
+];
+
+function routeFor(chart: ChartDefinition): string {
+  return `/page/${chart.slug}?snapshot=1`;
+}
+
+function targetSelector(chart: ChartDefinition): string {
+  return `.${chart.targetClass}[data-cinder-target-id="${chart.targetId}"][data-cinder-series-id="${chart.seriesId}"]`;
+}
+
+function primaryRingSelector(chart: ChartDefinition): string {
+  return `.${chart.rootClass}__focus-ring:not(.${chart.rootClass}__focus-ring-connector):not(.${chart.rootClass}__focus-ring-dot)`;
+}
+
+async function chartRoot(page: Page, chart: ChartDefinition): Promise<Locator> {
+  const target = page.locator(targetSelector(chart)).first();
+  await expect(target).toHaveAttribute('aria-label', chart.accessibleName);
+  const root = page.locator(`.${chart.rootClass}`).filter({ has: target }).first();
+  await expect(root).toBeVisible();
+  return root;
+}
+
+async function focusTargetDirectly(page: Page, chart: ChartDefinition): Promise<Locator> {
+  const target = page.locator(targetSelector(chart)).first();
+  await target.focus();
+  await expect(target).toBeFocused();
+  return target;
+}
+
+async function activeElementSummary(page: Page): Promise<TabbableSummary> {
+  return page.evaluate(() => {
+    const active = document.activeElement;
+    if (!(active instanceof Element)) {
+      return {
+        tagName: '(none)',
+        role: null,
+        ariaLabel: null,
+        text: '',
+        targetId: null,
+        seriesId: null,
+      };
+    }
+    return {
+      tagName: active.tagName.toLowerCase(),
+      role: active.getAttribute('role'),
+      ariaLabel: active.getAttribute('aria-label'),
+      text: active.textContent?.trim().replace(/\s+/g, ' ').slice(0, 80) ?? '',
+      targetId: active.getAttribute('data-cinder-target-id'),
+      seriesId: active.getAttribute('data-cinder-series-id'),
+    };
+  });
+}
+
+async function tabUntilChartTargetFocused(
+  page: Page,
+  chart: ChartDefinition,
+  maximumAttempts = 100,
+): Promise<TabbableSummary[]> {
+  const encountered: TabbableSummary[] = [];
+  for (let attempt = 0; attempt < maximumAttempts; attempt += 1) {
+    await page.keyboard.press('Tab');
+    const summary = await activeElementSummary(page);
+    encountered.push(summary);
+    if (summary.targetId === chart.targetId && summary.seriesId === chart.seriesId) {
+      return encountered;
+    }
+  }
+  throw new Error(
+    `${chart.slug}: Tab did not reach ${chart.targetId}. Encountered: ${JSON.stringify(
+      encountered,
+      null,
+      2,
+    )}`,
+  );
+}
+
+async function resetFocusToBody(page: Page): Promise<void> {
+  await page.evaluate(() => {
+    if (
+      document.activeElement instanceof HTMLElement ||
+      document.activeElement instanceof SVGElement
+    ) {
+      (document.activeElement as HTMLElement | SVGElement).blur();
+    }
+    document.body.setAttribute('tabindex', '-1');
+    document.body.focus();
+    document.body.removeAttribute('tabindex');
+  });
+}
+
+async function insertSentinelBeforeChartViewport(
+  root: Locator,
+  chart: ChartDefinition,
+): Promise<void> {
+  const svg = root.locator('svg').first();
+  const documentBox = async (): Promise<ElementBox> =>
+    svg.evaluate((element) => {
+      const box = element.getBoundingClientRect();
+      return {
+        x: box.x + window.scrollX,
+        y: box.y + window.scrollY,
+        width: box.width,
+        height: box.height,
+      };
+    });
+  const before = await documentBox();
+
+  await root.evaluate((element, rootClass) => {
+    const viewport = element.querySelector(`.${rootClass}__viewport`);
+    if (!viewport?.parentElement) throw new Error(`Missing .${rootClass}__viewport`);
+    const sentinel = document.createElement('button');
+    sentinel.type = 'button';
+    sentinel.textContent = 'chart focus sentinel';
+    sentinel.setAttribute('data-chart-focus-sentinel', '');
+    Object.assign(sentinel.style, {
+      position: 'fixed',
+      inset: '0 auto auto 0',
+      width: '1px',
+      height: '1px',
+      padding: '0',
+      margin: '0',
+      border: '0',
+      overflow: 'hidden',
+      clipPath: 'inset(50%)',
+      whiteSpace: 'nowrap',
+    });
+    viewport.parentElement.insertBefore(sentinel, viewport);
+  }, chart.rootClass);
+
+  const after = await documentBox();
+  expect(Math.abs(after.x - before.x), `${chart.slug}: sentinel changed SVG x`).toBeLessThanOrEqual(
+    0.5,
+  );
+  expect(Math.abs(after.y - before.y), `${chart.slug}: sentinel changed SVG y`).toBeLessThanOrEqual(
+    0.5,
+  );
+  expect(
+    Math.abs(after.width - before.width),
+    `${chart.slug}: sentinel changed SVG width`,
+  ).toBeLessThanOrEqual(0.5);
+  expect(
+    Math.abs(after.height - before.height),
+    `${chart.slug}: sentinel changed SVG height`,
+  ).toBeLessThanOrEqual(0.5);
+}
+
+async function focusFromSentinel(page: Page, chart: ChartDefinition): Promise<TabbableSummary[]> {
+  const sentinel = page.locator('[data-chart-focus-sentinel]').first();
+  await sentinel.focus();
+  await expect(sentinel).toBeFocused();
+  const encountered = await tabUntilChartTargetFocused(page, chart);
+  await expect(page.locator(targetSelector(chart)).first()).toBeFocused();
+  return encountered;
+}
+
+async function ringStyleSnapshot(root: Locator, chart: ChartDefinition) {
+  const layer = root.locator(`.${chart.rootClass}__focus-ring-layer`);
+  await expect(layer).toHaveCount(1);
+  await expect(layer).toHaveAttribute('aria-hidden', 'true');
+  const ring = root.locator(primaryRingSelector(chart)).first();
+  const halo = root.locator(`.${chart.rootClass}__focus-ring-halo`).first();
+  await expect(ring).toHaveCount(1);
+  await expect(halo).toHaveCount(1);
+  return ring.evaluate((element, haloClass) => {
+    const boxToObject = (box: DOMRect): ElementBox => ({
+      x: box.x,
+      y: box.y,
+      width: box.width,
+      height: box.height,
+    });
+    const styles = getComputedStyle(element);
+    const halo = element.closest('g')?.querySelector(`.${haloClass}`);
+    if (!(halo instanceof SVGElement)) throw new Error('Focus ring halo is missing.');
+    const haloStyles = getComputedStyle(halo);
+    const ringBox = element.getBoundingClientRect();
+    const svg = element.closest('svg');
+    if (!(svg instanceof SVGElement)) throw new Error('Focus ring is not inside an SVG.');
+    const svgBox = svg.getBoundingClientRect();
+    const stroke = styles.stroke;
+    const strokeWidth = Number.parseFloat(styles.strokeWidth);
+    return {
+      stroke,
+      strokeWidth,
+      filter: styles.filter,
+      haloDisplay: haloStyles.display,
+      pointerEvents: styles.pointerEvents,
+      vectorEffect: styles.getPropertyValue('vector-effect'),
+      ringBox: boxToObject(ringBox),
+      svgBox: boxToObject(svgBox),
+    };
+  }, `${chart.rootClass}__focus-ring-halo`);
+}
+
+function expectNonTransparentStroke(stroke: string): void {
+  expect(stroke).toBeTruthy();
+  expect(stroke).not.toBe('none');
+  expect(stroke).not.toBe('transparent');
+  expect(stroke).not.toMatch(/rgba\([^)]*,\s*0(?:\s*\)|\s*%)/i);
+  expect(stroke).not.toMatch(/rgb\([^)]*\/\s*0(?:\s*\)|\s*%)/i);
+}
+
+function expectBoxInside(inner: ElementBox, outer: ElementBox, label: string): void {
+  const tolerance = 1;
+  expect(inner.x, `${label}: left edge`).toBeGreaterThanOrEqual(outer.x - tolerance);
+  expect(inner.y, `${label}: top edge`).toBeGreaterThanOrEqual(outer.y - tolerance);
+  expect(inner.x + inner.width, `${label}: right edge`).toBeLessThanOrEqual(
+    outer.x + outer.width + tolerance,
+  );
+  expect(inner.y + inner.height, `${label}: bottom edge`).toBeLessThanOrEqual(
+    outer.y + outer.height + tolerance,
+  );
+}
+
+async function assertVisibleRing(root: Locator, chart: ChartDefinition, forcedColors = false) {
+  const snapshot = await ringStyleSnapshot(root, chart);
+  expectNonTransparentStroke(snapshot.stroke);
+  expect(snapshot.strokeWidth).toBeGreaterThan(0);
+  expect(snapshot.pointerEvents).toBe('none');
+  expect(snapshot.vectorEffect).toBe('non-scaling-stroke');
+  expect(snapshot.ringBox.width).toBeGreaterThan(0);
+  expect(snapshot.ringBox.height).toBeGreaterThan(0);
+  expectBoxInside(snapshot.ringBox, snapshot.svgBox, `${chart.slug} focus ring inside SVG`);
+
+  if (forcedColors) {
+    expect(snapshot.filter).toBe('none');
+    expect(snapshot.haloDisplay).toBe('none');
+  }
+}
+
+async function ringScreenshotClip(
+  page: Page,
+  root: Locator,
+  chart: ChartDefinition,
+): Promise<ScreenshotClip> {
+  const ring = root.locator(primaryRingSelector(chart)).first();
+  const svg = root.locator('svg').first();
+  const ringBox = await ring.boundingBox();
+  const svgBox = await svg.boundingBox();
+  if (!ringBox || !svgBox) throw new Error(`${chart.slug}: missing ring or SVG screenshot clip.`);
+  const deviceScaleFactor = await page.evaluate(() => window.devicePixelRatio || 1);
+  const padding = Math.ceil(deviceScaleFactor * 4);
+  const x = Math.max(svgBox.x, ringBox.x - padding);
+  const y = Math.max(svgBox.y, ringBox.y - padding);
+  const right = Math.min(svgBox.x + svgBox.width, ringBox.x + ringBox.width + padding);
+  const bottom = Math.min(svgBox.y + svgBox.height, ringBox.y + ringBox.height + padding);
+
+  return {
+    x,
+    y,
+    width: Math.max(1, right - x),
+    height: Math.max(1, bottom - y),
+  };
+}
+
+async function clippedScreenshot(page: Page, clip: ScreenshotClip): Promise<Buffer> {
+  return page.screenshot({ clip });
+}
+
+function changedPixelCount(beforeBuffer: Buffer, afterBuffer: Buffer): number {
+  const before = PNG.sync.read(beforeBuffer);
+  const after = PNG.sync.read(afterBuffer);
+  expect(after.width).toBe(before.width);
+  expect(after.height).toBe(before.height);
+  return pixelmatch(before.data, after.data, undefined, before.width, before.height, {
+    threshold: 0.1,
+  });
+}
+
+test.describe('chart SVG focus rings', () => {
+  for (const chart of charts) {
+    test(`${chart.slug}: real Tab focus creates one visible SVG ring and a pixel delta`, async ({
+      page,
+    }) => {
+      await page.emulateMedia({ colorScheme: 'light' });
+      await page.goto(routeFor(chart), { waitUntil: 'load' });
+      await page.waitForLoadState('networkidle');
+
+      const root = await chartRoot(page, chart);
+      await resetFocusToBody(page);
+      const encountered = await tabUntilChartTargetFocused(page, chart);
+      expect(encountered.at(-1)?.ariaLabel).toBe(chart.accessibleName);
+      const target = page.locator(targetSelector(chart)).first();
+      await expect(target).toBeFocused();
+      const diagnostic = await target.evaluate((element) => ({
+        ariaLabel: element.getAttribute('aria-label'),
+        matchesFocusVisible: element.matches(':focus-visible'),
+      }));
+      expect(diagnostic.ariaLabel).toBe(chart.accessibleName);
+
+      await assertVisibleRing(root, chart);
+
+      await page.addStyleTag({
+        content: '[role="tooltip"] { visibility: hidden !important; }',
+      });
+      await insertSentinelBeforeChartViewport(root, chart);
+      const clip = await ringScreenshotClip(page, root, chart);
+      const afterFocus = await clippedScreenshot(page, clip);
+      await page.locator('[data-chart-focus-sentinel]').first().focus();
+      const beforeFocus = await clippedScreenshot(page, clip);
+      await focusFromSentinel(page, chart);
+      await expect(target).toHaveAttribute('data-cinder-target-id', chart.targetId);
+      const afterRefocus = await clippedScreenshot(page, clip);
+
+      expect(
+        changedPixelCount(beforeFocus, afterFocus),
+        `${chart.slug}: initial focus pixel delta`,
+      ).toBeGreaterThanOrEqual(8);
+      expect(
+        changedPixelCount(beforeFocus, afterRefocus),
+        `${chart.slug}: refocus pixel delta`,
+      ).toBeGreaterThanOrEqual(8);
+    });
+
+    for (const mode of ['light', 'dark', 'forced-colors'] as const) {
+      test(`${chart.slug}: computed SVG ring contract in ${mode}`, async ({ page }) => {
+        await page.emulateMedia({
+          colorScheme: mode === 'dark' ? 'dark' : 'light',
+          forcedColors: mode === 'forced-colors' ? 'active' : 'none',
+        });
+        await page.goto(routeFor(chart), { waitUntil: 'load' });
+        await page.waitForLoadState('networkidle');
+        const root = await chartRoot(page, chart);
+        await insertSentinelBeforeChartViewport(root, chart);
+        await focusFromSentinel(page, chart);
+        await assertVisibleRing(root, chart, mode === 'forced-colors');
+      });
+    }
+  }
+
+  test('programmatic area-chart focus updates tooltip state without rendering the keyboard ring', async ({
+    page,
+  }) => {
+    const chart = charts[0]!;
+    await page.goto(routeFor(chart), { waitUntil: 'load' });
+    await page.waitForLoadState('networkidle');
+    const root = await chartRoot(page, chart);
+    const target = await focusTargetDirectly(page, chart);
+
+    await expect(target).toHaveAttribute('aria-describedby', /-tooltip$/);
+    await expect(root.locator(`.${chart.rootClass}__focus-ring-layer`)).toHaveCount(0);
+    await expect(root.locator('[role="tooltip"]').first()).toContainText(chart.tooltipText);
+  });
+
+  test('tooltip does not fully cover a focused area-chart ring', async ({ page }) => {
+    const chart = charts[0]!;
+    await page.goto(routeFor(chart), { waitUntil: 'load' });
+    await page.waitForLoadState('networkidle');
+    const root = await chartRoot(page, chart);
+    await insertSentinelBeforeChartViewport(root, chart);
+    await focusFromSentinel(page, chart);
+    const tooltip = root.locator('[role="tooltip"]').first();
+    await expect(tooltip).toContainText(chart.tooltipText);
+
+    const ringBox = await root.locator(primaryRingSelector(chart)).first().boundingBox();
+    const tooltipBox = await tooltip.boundingBox();
+    if (!ringBox || !tooltipBox) throw new Error('Missing ring or tooltip bounds.');
+
+    const tooltipFullyCoversRing =
+      tooltipBox.x <= ringBox.x &&
+      tooltipBox.y <= ringBox.y &&
+      tooltipBox.x + tooltipBox.width >= ringBox.x + ringBox.width &&
+      tooltipBox.y + tooltipBox.height >= ringBox.y + ringBox.height;
+
+    expect(tooltipFullyCoversRing).toBe(false);
+  });
+
+  test('visual focus-ring layer does not intercept chart hover hit surfaces', async ({ page }) => {
+    const chart = charts[1]!;
+    await page.goto(routeFor(chart), { waitUntil: 'load' });
+    await page.waitForLoadState('networkidle');
+    const root = await chartRoot(page, chart);
+    const target = page.locator(targetSelector(chart)).first();
+    await target.scrollIntoViewIfNeeded();
+    const targetBox = await target.boundingBox();
+    if (!targetBox) throw new Error('Missing line-chart target bounds.');
+
+    await page.mouse.move(targetBox.x + targetBox.width / 2, targetBox.y + targetBox.height / 2);
+
+    await expect(root.locator(`.${chart.rootClass}__focus-ring-layer`)).toHaveCount(0);
+    await expect(root.locator('[role="tooltip"]').first()).toContainText(chart.tooltipText);
+    await expect(root.locator(`.${chart.hitSurfaceClass}`).first()).toBeVisible();
+  });
+});


### PR DESCRIPTION
## Summary

- Adds SVG-native visual focus-ring layers for AreaChart, LineChart, and BarChart keyboard-focusable data marks.
- Clamps point and bar focus-ring geometry inside the chart SVG viewport, with edge connectors/dots for clamped point marks.
- Adds regression coverage for keyboard-origin focus, programmatic focus, hidden-series stale focus, forced-colors behavior, and real browser pixel visibility.

## Review Committee

Pre-reviewed by: testing-expert, svelte-expert, frontend-architect, ux-designer, typescript-expert, simplicity-engineer, codex.
- Codex (gpt-5.4) reviewed 4 rounds and approved the final keyboard-modality ordering fix.
- All must-fix items were addressed before PR creation.
- Post-creation reviewer requested: @copilot.

## Test Plan

- `bun run --filter=@lostgradient/cinder test -- src/components/area-chart/area-chart.test.ts src/components/line-chart/line-chart.test.ts src/components/bar-chart/bar-chart.test.ts src/_internal/chart/chart-focus-ring.test.ts src/test/focus-ring-recipe.test.ts`
- `env PLAYGROUND_URL=http://localhost:5556 bun run --filter=@cinder/testing test:playwright -- tests/chart-focus-rings.playwright.ts`
- `bun run --filter=@lostgradient/cinder components:check`
- `bun run --filter=@lostgradient/cinder test`
- `bun run --filter=@lostgradient/cinder typecheck`
- `bun run lint`
- `bun run typecheck`
- Pre-commit touched-package checks passed.
- Pre-push scoped validation passed.

## Version Metadata

No package version metadata or `bun.lock` changes are included in this pull request.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches shared chart interaction and accessibility behavior across three chart types; risk is mitigated by extensive unit and Playwright regression tests.
> 
> **Overview**
> Adds **SVG stroke-based keyboard focus rings** for Area, Line, and Bar chart data marks, replacing `drop-shadow` on transparent focus targets with a dedicated `aria-hidden` ring layer and tokenized halo/connector styling.
> 
> New `chart-focus-ring` geometry clamps point and bar rings inside the plot (edge connectors/dots for points; plot-frame fallback when space is tight). Charts track **keyboard vs pointer** modality so programmatic or mouse focus keeps tooltips without showing the decorative ring; hiding a series or controlled `hiddenSeriesIds` clears stale ring/focus state.
> 
> **`focus-ring-policy.md`** documents the SVG chart-mark exception. Bar chart models gain stable **`categoryKey`** for list keys and duplicate formatted labels. Coverage spans unit tests, focus-ring recipe assertions, and Playwright pixel/forced-colors checks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1be2c65a056337ea9f24ee0aa384c6df25c5fe6b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->