### PR TITLE
Fix playground chrome focus rings

### DIFF
--- a/packages/playground/src/component-page.svelte
+++ b/packages/playground/src/component-page.svelte
@@ -319,7 +319,8 @@
     <!-- tabindex="0" makes the scrollable region keyboard-accessible (axe
          scrollable-region-focusable / WCAG 2.1.1) — at narrow widths the wide
          props table can overflow horizontally and must be reachable by keyboard. -->
-    <div class="props-table-scroll" tabindex="0">
+    <!-- svelte-ignore a11y_no_noninteractive_tabindex -->
+    <div class="props-table-scroll" role="region" aria-labelledby="props-heading" tabindex="0">
       <Table caption={`Props for ${componentName}`} density="condensed">
         <Table.Header>
           <Table.Row>
@@ -536,6 +537,19 @@
   /* Wide container: a normal horizontally-scrollable table. */
   .props-table-scroll {
     overflow-x: auto;
+    border-radius: var(--cinder-radius-sm);
+  }
+
+  .props-table-scroll:focus-visible {
+    outline: var(--cinder-ring-width) solid transparent;
+    box-shadow: inset 0 0 0 var(--cinder-ring-width) var(--cinder-ring-color);
+  }
+
+  @media (forced-colors: active) {
+    .props-table-scroll:focus-visible {
+      outline: var(--cinder-ring-width) solid ButtonText;
+      outline-offset: calc(var(--cinder-ring-width) * -1);
+    }
   }
 
   .props-error,

--- a/packages/playground/src/component-page.svelte
+++ b/packages/playground/src/component-page.svelte
@@ -303,7 +303,7 @@
 <!-- Heading level is h3 to match the example Card titles (cinder Card renders
      its title as <h3>), keeping the iframe document's heading outline ordered
      rather than inverting to a higher level after the example cards. -->
-<section class="props-section" aria-labelledby="props-heading">
+<section class="props-section">
   <h3 id="props-heading" class="props-heading">API reference</h3>
   {#if propsLoading}
     <div class="props-skeleton" aria-hidden="true">

--- a/packages/testing/tests/playground-page-chrome-focus-rings.playwright.ts
+++ b/packages/testing/tests/playground-page-chrome-focus-rings.playwright.ts
@@ -143,7 +143,7 @@ async function openButtonPage(page: Page): Promise<{
   expect(
     propsTableCount,
     '/page/button no longer exposes `.props-table-scroll`; update the stable page-chrome fixture.',
-  ).toBeGreaterThan(0);
+  ).toBe(1);
 
   const firstCard = page.locator('.example-list .cinder-card').first();
   await expect(firstCard).toBeVisible();
@@ -175,6 +175,7 @@ test.describe('playground page chrome focus rings', () => {
     page,
   }) => {
     await page.emulateMedia({ forcedColors: 'active' });
+    await page.waitForFunction(() => matchMedia('(forced-colors: active)').matches);
     const { propsTableScroll } = await openButtonPage(page);
 
     await tabUntilFocused(page, propsTableScroll, 'props table scroll region');

--- a/packages/testing/tests/playground-page-chrome-focus-rings.playwright.ts
+++ b/packages/testing/tests/playground-page-chrome-focus-rings.playwright.ts
@@ -1,0 +1,196 @@
+/// <reference lib="dom" />
+/**
+ * Regression coverage for playground-owned page chrome on `/page/:name`.
+ *
+ * The broad focus sweep should be able to separate component-under-test focus
+ * rings from reusable playground chrome. These assertions therefore target the
+ * component page's own `View source` accordion trigger and props-table scroll
+ * region on a stable non-Accordion page.
+ */
+
+import { expect, test, type Locator, type Page } from '@playwright/test';
+
+const PIXEL_TOLERANCE = 0.5;
+
+type ActiveElementSummary = {
+  ariaLabel: string | null;
+  className: string;
+  id: string;
+  role: string | null;
+  tagName: string;
+  text: string;
+};
+
+type FocusPaint = {
+  boxShadow: string;
+  matchesFocusVisible: boolean;
+  outlineColor: string;
+  outlineOffset: number;
+  outlineStyle: string;
+  outlineWidth: number;
+  ringColor: string;
+  ringWidth: number;
+};
+
+async function activeElementSummary(page: Page): Promise<ActiveElementSummary | null> {
+  return page.evaluate(() => {
+    const active = document.activeElement;
+    if (!(active instanceof HTMLElement)) return null;
+    return {
+      ariaLabel: active.getAttribute('aria-label'),
+      className: active.className,
+      id: active.id,
+      role: active.getAttribute('role'),
+      tagName: active.tagName.toLowerCase(),
+      text: (active.textContent ?? '').trim().replaceAll(/\s+/g, ' ').slice(0, 120),
+    };
+  });
+}
+
+async function tabUntilFocused(page: Page, target: Locator, label: string): Promise<void> {
+  await page.evaluate(() => {
+    if (document.activeElement instanceof HTMLElement) document.activeElement.blur();
+    document.body.focus();
+  });
+
+  for (let attempt = 0; attempt < 50; attempt += 1) {
+    await page.keyboard.press('Tab');
+    const landed = await target.evaluate((element) => element === document.activeElement);
+    if (landed) return;
+  }
+
+  throw new Error(
+    `Tab walk did not reach ${label}. Active element: ${JSON.stringify(
+      await activeElementSummary(page),
+    )}`,
+  );
+}
+
+async function focusPaint(locator: Locator): Promise<FocusPaint> {
+  return locator.evaluate((element) => {
+    const styles = getComputedStyle(element as HTMLElement);
+    const ringColorToken = styles.getPropertyValue('--cinder-ring-color').trim();
+    const probe = document.createElement('span');
+    probe.style.color = ringColorToken;
+    document.body.append(probe);
+    const ringColor = getComputedStyle(probe).color;
+    probe.remove();
+
+    return {
+      boxShadow: styles.boxShadow,
+      matchesFocusVisible: element.matches(':focus-visible'),
+      outlineColor: styles.outlineColor,
+      outlineOffset: Number.parseFloat(styles.outlineOffset),
+      outlineStyle: styles.outlineStyle,
+      outlineWidth: Number.parseFloat(styles.outlineWidth),
+      ringColor,
+      ringWidth: Number.parseFloat(styles.getPropertyValue('--cinder-ring-width')),
+    };
+  });
+}
+
+function isTransparentColor(color: string): boolean {
+  const normalizedColor = color.toLowerCase().replaceAll(/\s+/g, '');
+  return (
+    normalizedColor === 'transparent' ||
+    normalizedColor === 'rgba(0,0,0,0)' ||
+    /\/\s*0(?:[)\s]|$)/.test(color)
+  );
+}
+
+function splitBoxShadowLayers(boxShadow: string): string[] {
+  return boxShadow.split(/,(?![^(]*\))/).map((layer) => layer.trim());
+}
+
+function insetSpreadForRing(boxShadow: string, ringColor: string): number | null {
+  const layer = splitBoxShadowLayers(boxShadow).find(
+    (candidate) => candidate.includes('inset') && candidate.includes(ringColor),
+  );
+  if (layer === undefined) return null;
+  const lengths = [...layer.matchAll(/-?\d*\.?\d+px/g)].map(([value]) => Number.parseFloat(value));
+  return lengths[3] ?? null;
+}
+
+function expectInsetFocusPaint(paint: FocusPaint, label: string): void {
+  expect(paint.matchesFocusVisible, `${label} should match :focus-visible`).toBe(true);
+  expect(paint.outlineStyle, `${label} should keep the outline channel`).toBe('solid');
+  expect(isTransparentColor(paint.outlineColor), `${label} outline should be transparent`).toBe(
+    true,
+  );
+  expect(paint.boxShadow, `${label} should paint a focus shadow`).not.toBe('none');
+  expect(paint.boxShadow, `${label} should use an inset focus shadow`).toContain('inset');
+  expect(paint.boxShadow, `${label} should include the resolved ring color`).toContain(
+    paint.ringColor,
+  );
+
+  const spread = insetSpreadForRing(paint.boxShadow, paint.ringColor);
+  expect(spread, `${label} should expose an inset spread for the ring layer`).not.toBeNull();
+  expect(
+    Math.abs(spread! - paint.ringWidth),
+    `${label} spread should match ring width`,
+  ).toBeLessThanOrEqual(PIXEL_TOLERANCE);
+}
+
+async function openButtonPage(page: Page): Promise<{
+  propsTableScroll: Locator;
+  viewSourceTrigger: Locator;
+}> {
+  await page.goto('/page/button?snapshot=1', { waitUntil: 'load' });
+  await page.waitForLoadState('networkidle');
+
+  const propsTableScroll = page.locator('.props-table-scroll').first();
+  const propsTableCount = await page.locator('.props-table-scroll').count();
+  expect(
+    propsTableCount,
+    '/page/button no longer exposes `.props-table-scroll`; update the stable page-chrome fixture.',
+  ).toBeGreaterThan(0);
+
+  const firstCard = page.locator('.example-list .cinder-card').first();
+  await expect(firstCard).toBeVisible();
+  const viewSourceTrigger = firstCard.getByRole('button', {
+    exact: true,
+    name: 'View source',
+  });
+  await expect(viewSourceTrigger).toHaveCount(1);
+
+  return { propsTableScroll, viewSourceTrigger };
+}
+
+test.describe('playground page chrome focus rings', () => {
+  test('source accordion and props-table chrome use intentional inset keyboard rings', async ({
+    page,
+  }) => {
+    const { propsTableScroll, viewSourceTrigger } = await openButtonPage(page);
+
+    await tabUntilFocused(page, viewSourceTrigger, 'first View source trigger');
+    await expect(viewSourceTrigger).toBeFocused();
+    expectInsetFocusPaint(await focusPaint(viewSourceTrigger), 'View source trigger');
+
+    await tabUntilFocused(page, propsTableScroll, 'props table scroll region');
+    await expect(propsTableScroll).toBeFocused();
+    expectInsetFocusPaint(await focusPaint(propsTableScroll), 'props table scroll region');
+  });
+
+  test('forced-colors mode repaints the props-table focus outline inside the scroll container', async ({
+    page,
+  }) => {
+    await page.emulateMedia({ forcedColors: 'active' });
+    const { propsTableScroll } = await openButtonPage(page);
+
+    await tabUntilFocused(page, propsTableScroll, 'props table scroll region');
+    await expect(propsTableScroll).toBeFocused();
+
+    const paint = await focusPaint(propsTableScroll);
+    expect(paint.matchesFocusVisible, 'props table should match :focus-visible').toBe(true);
+    expect(paint.outlineStyle, 'forced-colors outline should be solid').toBe('solid');
+    expect(
+      isTransparentColor(paint.outlineColor),
+      'forced-colors outline should repaint with a system color',
+    ).toBe(false);
+    expect(
+      Math.abs(paint.outlineWidth - paint.ringWidth),
+      'forced-colors outline width should match ring width',
+    ).toBeLessThanOrEqual(PIXEL_TOLERANCE);
+    expect(paint.outlineOffset, 'forced-colors outline should be drawn inside').toBeLessThan(0);
+  });
+});


### PR DESCRIPTION
## Summary

- Move the playground props-table scroll region to an intentional inset focus-ring recipe with a forced-colors fallback.
- Give the focusable props scroll region an accessible `region` label tied to the API reference heading.
- Add a targeted Playwright regression that separates playground page chrome focus rings from component-under-test focus audits.

## Review committee

Pre-reviewed by:
- frontend-architect - approved
- testing-expert - approved
- simplicity-engineer - approved
- Codex (gpt-5.4, xhigh reasoning) - approved
- 1 round of review
- All must-fix items addressed

## Test plan

- `bun run --filter=@cinder/testing test:playwright -- playground-page-chrome-focus-rings`
- `bun run --filter=@cinder/playground test`
- `bun run --filter=@lostgradient/cinder test -- focus-ring-recipe component-css`
- `bun run --filter=@lostgradient/cinder components:check`
- Browser check with `bun run dev`: keyboard sweep on `/page/button?snapshot=1`, `/page/accordion?snapshot=1`, `/page/tabs?snapshot=1`, and `/page/tree?snapshot=1` confirmed `View source` and props-table chrome use transparent outlines plus inset focus rings.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to dev playground UI styling and test-only assertions; no auth, data, or production component API changes.
> 
> **Overview**
> Aligns playground **page chrome** keyboard focus with Cinder’s **inset focus-ring** pattern on the API props table scroll container, plus clearer labeling for that focusable region.
> 
> The horizontally scrollable `.props-table-scroll` wrapper now uses `role="region"` and `aria-labelledby="props-heading"` (with `aria-labelledby` removed from the outer section), a Svelte a11y ignore for intentional `tabindex="0"`, and `:focus-visible` styles: transparent outline plus inset `box-shadow` using `--cinder-ring-*` tokens, with a **forced-colors** fallback that paints an inside `ButtonText` outline.
> 
> Adds Playwright coverage on `/page/button?snapshot=1` that tabs to the first **View source** accordion trigger and the props scroll region and asserts `:focus-visible` plus inset ring paint (including forced-colors behavior for the props region), so broad component focus sweeps can treat this chrome separately from the component under test.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c4a6e83dd4749613146fc7c249cbc0be0cc2a983. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->