### PR TITLE
Add SearchField example export coverage

### DIFF
--- a/packages/components/components.json
+++ b/packages/components/components.json
@@ -2365,10 +2365,11 @@
       "avoidWhen": ["Selecting from a constrained list of known options — use combobox instead."],
       "related": ["input", "combobox"],
       "hasConstraints": false,
-      "hasExamples": false,
+      "hasExamples": true,
       "artifacts": {
         "schema": "@lostgradient/cinder/search-field/schema",
-        "variables": "@lostgradient/cinder/search-field/variables"
+        "variables": "@lostgradient/cinder/search-field/variables",
+        "examples": "@lostgradient/cinder/search-field/examples"
       }
     },
     {

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -2214,6 +2214,10 @@
     "./search-field/styles": {
       "default": "./dist/components/search-field/search-field.css"
     },
+    "./search-field/examples": {
+      "import": "./src/components/search-field/search-field.examples.json",
+      "default": "./src/components/search-field/search-field.examples.json"
+    },
     "./section-heading": {
       "types": "./dist/components/section-heading/index.d.ts",
       "svelte": "./src/components/section-heading/index.ts",

--- a/packages/components/src/components/search-field/search-field.examples.json
+++ b/packages/components/src/components/search-field/search-field.examples.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "../../schemas/examples.schema.json",
+  "component": "search-field",
+  "import": "@lostgradient/cinder/search-field",
+  "examples": [
+    {
+      "id": "basic",
+      "title": "Clearable search field",
+      "description": "Search input with an initial value so the clear button is visible.",
+      "code": "<script lang=\"ts\">\n  import { SearchField } from '@lostgradient/cinder/search-field';\n</script>\n\n<SearchField\n  id=\"search-field-basic\"\n  aria-label=\"Search components\"\n  defaultValue=\"cinder\"\n  placeholder=\"Filter by name\"\n/>\n"
+    }
+  ]
+}

--- a/packages/components/src/components/search-field/search-field.test.ts
+++ b/packages/components/src/components/search-field/search-field.test.ts
@@ -25,6 +25,21 @@ describe('SearchField rendering', () => {
     expect(input.getAttribute('type')).toBe('search');
   });
 
+  test('forwards accessible input attributes while preserving the search role', () => {
+    const { getByRole } = render(SearchField, {
+      props: {
+        id: 'search',
+        'aria-label': 'Search components',
+        defaultValue: 'cinder',
+      },
+    });
+
+    const input = getByRole('searchbox', { name: 'Search components' });
+    expect(input).toBeInstanceOf(HTMLInputElement);
+    expect((input as HTMLInputElement).value).toBe('cinder');
+    expect((input as HTMLInputElement).type).toBe('search');
+  });
+
   test('renders the leading search icon as aria-hidden', () => {
     const { container } = render(SearchField, { props: { id: 'search' } });
     const leading = container.querySelector('.cinder-search-field__leading');

--- a/packages/playground/src/examples/search-field/basic.example.svelte
+++ b/packages/playground/src/examples/search-field/basic.example.svelte
@@ -1,0 +1,15 @@
+<script lang="ts" module>
+  export const title = 'Clearable search field';
+  export const description = 'Search input with an initial value so the clear button is visible.';
+</script>
+
+<script lang="ts">
+  import { SearchField } from '@lostgradient/cinder/search-field';
+</script>
+
+<SearchField
+  id="search-field-basic"
+  aria-label="Search components"
+  defaultValue="cinder"
+  placeholder="Filter by name"
+/>


### PR DESCRIPTION
## Summary

- Add a standalone SearchField playground example with a real accessible name, initial value, and placeholder hint.
- Generate the SearchField examples artifact, manifest metadata, and `./search-field/examples` package export.
- Add a SearchField regression test proving forwarded accessible input attributes preserve the native search input role and value.

## Review committee

Pre-reviewed by:

- frontend-architect
- ux-designer
- testing-expert
- simplicity-engineer
- prose-editor
- svelte-expert
- Codex (gpt-5.4, xhigh/high reasoning)

2 rounds of review. All must-fix items addressed.

## Test plan

- `bun run --filter=@lostgradient/cinder test -- ./src/components/toast-region/toast-region.test.ts ./src/components/search-field/search-field.test.ts ./src/test/focus-ring-recipe.test.ts`
- `bun run --filter=@lostgradient/cinder components:check`
- `bun run --filter=@lostgradient/cinder exports:check`
- `bunx prettier --check docs/focus-ring-policy.md packages/components/src/components/search-field/search-field.test.ts packages/components/components.json packages/components/package.json packages/components/src/components/search-field/search-field.examples.json packages/playground/src/examples/search-field/basic.example.svelte`
- `bun run --filter=@lostgradient/cinder validate:consumer`
- `bun run --filter=@cinder/playground typecheck`
- `bun run lint`
- Source/generated manifest/export smoke assertions for the SearchField example
- Pre-commit checks passed
- Pre-push scoped validation passed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation, manifest/export wiring, playground, and tests only—no SearchField implementation changes.
> 
> **Overview**
> **SearchField** now ships documented usage examples: a `search-field.examples.json` artifact, manifest flags (`hasExamples`, `examples` artifact), and a public `@lostgradient/cinder/search-field/examples` package export.
> 
> A matching **playground** example shows a clearable field with `aria-label`, placeholder, and an initial value so the clear control is visible.
> 
> A **regression test** asserts that forwarded input props (e.g. `aria-label`, `defaultValue`) still expose a native `type="search"` **searchbox** with the expected value—no redundant `role="searchbox"`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c043d8252dc5bd01326d7894ac8955f1740d899a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->