### PR TITLE
fix(packaging): peer-dep lucide-svelte (#311) + types condition on CSS style subpaths (#314)

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -80,6 +80,7 @@
     ".bun/**",
     "node_modules/**",
     "packages/components/fixtures/**",
+    "**/*.css.d.ts",
     "**/*.svelte",
     "packages/playground/src/**/*.svelte",
     "*.lock"

--- a/bun.lock
+++ b/bun.lock
@@ -43,7 +43,7 @@
     },
     "packages/components": {
       "name": "@lostgradient/cinder",
-      "version": "0.0.1",
+      "version": "0.1.1",
       "dependencies": {
         "@floating-ui/dom": "1.7.6",
         "@lasercat/homogenaize": "^1.2.41",
@@ -58,7 +58,6 @@
         "hast-util-sanitize": "^5.0.0",
         "js-yaml": "^4.1.0",
         "libphonenumber-js": "^1.13.3",
-        "lucide-svelte": "^0.503.0",
         "prosemirror-inputrules": "^1.5.1",
         "prosemirror-model": "^1.25.4",
         "prosemirror-state": "^1.4.4",
@@ -89,6 +88,7 @@
         "chalk": "^5.6.2",
         "change-case": "^5.4.4",
         "happy-dom": "^15.11.7",
+        "lucide-svelte": "^0.503.0",
         "oxlint": "^1.56.0",
         "oxlint-tsgolint": "^0.17.0",
         "postcss": "^8.5.15",
@@ -105,6 +105,7 @@
         "zod": "4.4.1",
       },
       "peerDependencies": {
+        "lucide-svelte": ">=0.400.0",
         "svelte": ">=5.55.0 <6",
       },
     },

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -34,18 +34,23 @@
     },
     "./package.json": "./package.json",
     "./styles": {
+      "types": "./src/styles/index.css.d.ts",
       "default": "./src/styles/index.css"
     },
     "./styles/all": {
+      "types": "./src/styles/all.css.d.ts",
       "default": "./src/styles/all.css"
     },
     "./styles/tokens": {
+      "types": "./src/styles/tokens.css.d.ts",
       "default": "./src/styles/tokens.css"
     },
     "./styles/foundation": {
+      "types": "./src/styles/foundation.css.d.ts",
       "default": "./src/styles/foundation.css"
     },
     "./styles/utilities": {
+      "types": "./src/styles/utilities.css.d.ts",
       "default": "./src/styles/utilities.css"
     },
     "./styles/guard": {
@@ -3496,6 +3501,7 @@
     "src/_internal/**/*.ts",
     "!src/_internal/**/*.test.ts",
     "src/styles/**/*.css",
+    "src/styles/**/*.css.d.ts",
     "src/styles/base-guard.ts",
     "src/components/icons/index.ts",
     "src/utilities/**/*.ts",
@@ -3562,7 +3568,6 @@
     "hast-util-sanitize": "^5.0.0",
     "js-yaml": "^4.1.0",
     "libphonenumber-js": "^1.13.3",
-    "lucide-svelte": "^0.503.0",
     "prosemirror-inputrules": "^1.5.1",
     "prosemirror-model": "^1.25.4",
     "prosemirror-state": "^1.4.4",
@@ -3593,6 +3598,7 @@
     "chalk": "^5.6.2",
     "change-case": "^5.4.4",
     "happy-dom": "^15.11.7",
+    "lucide-svelte": "^0.503.0",
     "oxlint": "^1.56.0",
     "oxlint-tsgolint": "^0.17.0",
     "postcss": "^8.5.15",
@@ -3609,6 +3615,7 @@
     "zod": "4.4.1"
   },
   "peerDependencies": {
+    "lucide-svelte": ">=0.400.0",
     "svelte": ">=5.55.0 <6"
   },
   "engines": {

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -3615,7 +3615,7 @@
     "zod": "4.4.1"
   },
   "peerDependencies": {
-    "lucide-svelte": ">=0.400.0",
+    "lucide-svelte": ">=0.400.0 <1",
     "svelte": ">=5.55.0 <6"
   },
   "engines": {

--- a/packages/components/scripts/generate-exports.test.ts
+++ b/packages/components/scripts/generate-exports.test.ts
@@ -24,6 +24,7 @@ import {
   orderedExportEntry,
   rootLevelExportTargets,
   STATIC_FILES_GLOBS,
+  stylesExport,
   stylesGuardExport,
 } from './generate-exports.ts';
 
@@ -57,6 +58,28 @@ describe('computeRootExport', () => {
       default: './dist/index.js',
     });
     expect(Object.keys(root)).toEqual(['types', 'svelte', 'node', 'default']);
+  });
+});
+
+describe('stylesExport', () => {
+  it('emits types first, pointing at the .d.ts companion, followed by default for the CSS', () => {
+    const entry = stylesExport('./src/styles/index.css');
+    expect(entry).toEqual({
+      types: './src/styles/index.css.d.ts',
+      default: './src/styles/index.css',
+    });
+    expect(Object.keys(entry)).toEqual(['types', 'default']);
+  });
+
+  it('derives the .d.ts path by appending .d.ts to the css path', () => {
+    expect(stylesExport('./src/styles/all.css').types).toBe('./src/styles/all.css.d.ts');
+    expect(stylesExport('./src/styles/tokens.css').types).toBe('./src/styles/tokens.css.d.ts');
+    expect(stylesExport('./src/styles/foundation.css').types).toBe(
+      './src/styles/foundation.css.d.ts',
+    );
+    expect(stylesExport('./src/styles/utilities.css').types).toBe(
+      './src/styles/utilities.css.d.ts',
+    );
   });
 });
 
@@ -125,6 +148,7 @@ describe('computeExports', () => {
 
   it('emits a default-only /styles sidecar export only when hasCss is true', () => {
     const withCss = computeExports([{ name: 'button', isExperimental: false, hasCss: true }]);
+    // Per-component /styles subpaths remain default-only (CSS sidecar, no .d.ts companion).
     expect(withCss['./button/styles']).toEqual({
       default: './dist/components/button/button.css',
     });
@@ -302,5 +326,13 @@ describe('computeFiles', () => {
   it('does not duplicate a root artifact already covered by a static glob', () => {
     const files = computeFiles({ './foo': { default: './foo.json' } }, ['dist', 'foo.json'], []);
     expect(files.filter((entry) => entry === 'foo.json')).toHaveLength(1);
+  });
+
+  it('includes the src/styles/**/*.css.d.ts glob so reserved style type stubs are published', () => {
+    // The type stubs for reserved CSS subpaths live in src/styles/ alongside the
+    // CSS sources. Without this glob they would not be included in the published
+    // tarball, making the `types` condition in every ./styles* subpath point at a
+    // missing file for consumers.
+    expect(STATIC_FILES_GLOBS).toContain('src/styles/**/*.css.d.ts');
   });
 });

--- a/packages/components/scripts/generate-exports.ts
+++ b/packages/components/scripts/generate-exports.ts
@@ -126,9 +126,9 @@ const RESERVED_STYLES_ENTRIES: ReadonlyArray<readonly [string, string]> = [
   [STYLES_UTILITIES_KEY, './src/styles/utilities.css'],
 ];
 
-/** Canonical `{ default: <css> }` entry for a reserved styles subpath. */
-function stylesExport(cssPath: string): ExportEntry {
-  return { default: cssPath };
+/** Canonical `{ types: <dts>, default: <css> }` entry for a reserved styles subpath. */
+export function stylesExport(cssPath: string): ExportEntry {
+  return orderedExportEntry({ types: `${cssPath}.d.ts`, default: cssPath });
 }
 
 /**
@@ -492,6 +492,7 @@ export const STATIC_FILES_GLOBS: readonly string[] = [
   'src/_internal/**/*.ts',
   '!src/_internal/**/*.test.ts',
   'src/styles/**/*.css',
+  'src/styles/**/*.css.d.ts',
   'src/styles/base-guard.ts',
   'src/components/icons/index.ts',
   'src/utilities/**/*.ts',

--- a/packages/components/src/exports-drift.test.ts
+++ b/packages/components/src/exports-drift.test.ts
@@ -136,8 +136,17 @@ describe('exports drift', () => {
     expect(exports['./styles/utilities']).toBeDefined();
     // The slim base points at the layer-order + tokens/foundation/utilities
     // aggregator; the all-in entry points at the full-cascade aggregator.
-    expect(exports['./styles']).toEqual({ default: './src/styles/index.css' });
-    expect(exports['./styles/all']).toEqual({ default: './src/styles/all.css' });
+    // Each CSS-only subpath also carries a `types` condition (first, per
+    // nodenext ordering) pointing at an `export {};` stub so a side-effect
+    // import typechecks under `moduleResolution: bundler`.
+    expect(exports['./styles']).toEqual({
+      types: './src/styles/index.css.d.ts',
+      default: './src/styles/index.css',
+    });
+    expect(exports['./styles/all']).toEqual({
+      types: './src/styles/all.css.d.ts',
+      default: './src/styles/all.css',
+    });
   });
 
   test('checked-in exports contain no forbidden keys', async () => {

--- a/packages/components/src/styles/all.css.d.ts
+++ b/packages/components/src/styles/all.css.d.ts
@@ -1,0 +1,6 @@
+// Type stub for the CSS-only `@lostgradient/cinder/styles[...]` subpath. The
+// matching `types` condition in package.json#exports points here so a
+// side-effect `import` of the stylesheet typechecks under
+// `moduleResolution: bundler` (an ambient `declare module` in the consumer is
+// ignored once the specifier resolves to a real file). A CSS module exposes no
+// bindings, so this declares an empty module.

--- a/packages/components/src/styles/all.css.d.ts
+++ b/packages/components/src/styles/all.css.d.ts
@@ -2,5 +2,6 @@
 // matching `types` condition in package.json#exports points here so a
 // side-effect `import` of the stylesheet typechecks under
 // `moduleResolution: bundler` (an ambient `declare module` in the consumer is
-// ignored once the specifier resolves to a real file). A CSS module exposes no
-// bindings, so this declares an empty module.
+// ignored once the specifier resolves to a real file). `export {}` makes this
+// a module (not a global script) exposing no bindings — a CSS side-effect import.
+export {};

--- a/packages/components/src/styles/foundation.css.d.ts
+++ b/packages/components/src/styles/foundation.css.d.ts
@@ -1,0 +1,6 @@
+// Type stub for the CSS-only `@lostgradient/cinder/styles[...]` subpath. The
+// matching `types` condition in package.json#exports points here so a
+// side-effect `import` of the stylesheet typechecks under
+// `moduleResolution: bundler` (an ambient `declare module` in the consumer is
+// ignored once the specifier resolves to a real file). A CSS module exposes no
+// bindings, so this declares an empty module.

--- a/packages/components/src/styles/foundation.css.d.ts
+++ b/packages/components/src/styles/foundation.css.d.ts
@@ -2,5 +2,6 @@
 // matching `types` condition in package.json#exports points here so a
 // side-effect `import` of the stylesheet typechecks under
 // `moduleResolution: bundler` (an ambient `declare module` in the consumer is
-// ignored once the specifier resolves to a real file). A CSS module exposes no
-// bindings, so this declares an empty module.
+// ignored once the specifier resolves to a real file). `export {}` makes this
+// a module (not a global script) exposing no bindings — a CSS side-effect import.
+export {};

--- a/packages/components/src/styles/index.css.d.ts
+++ b/packages/components/src/styles/index.css.d.ts
@@ -1,0 +1,6 @@
+// Type stub for the CSS-only `@lostgradient/cinder/styles[...]` subpath. The
+// matching `types` condition in package.json#exports points here so a
+// side-effect `import` of the stylesheet typechecks under
+// `moduleResolution: bundler` (an ambient `declare module` in the consumer is
+// ignored once the specifier resolves to a real file). A CSS module exposes no
+// bindings, so this declares an empty module.

--- a/packages/components/src/styles/index.css.d.ts
+++ b/packages/components/src/styles/index.css.d.ts
@@ -2,5 +2,6 @@
 // matching `types` condition in package.json#exports points here so a
 // side-effect `import` of the stylesheet typechecks under
 // `moduleResolution: bundler` (an ambient `declare module` in the consumer is
-// ignored once the specifier resolves to a real file). A CSS module exposes no
-// bindings, so this declares an empty module.
+// ignored once the specifier resolves to a real file). `export {}` makes this
+// a module (not a global script) exposing no bindings — a CSS side-effect import.
+export {};

--- a/packages/components/src/styles/tokens.css.d.ts
+++ b/packages/components/src/styles/tokens.css.d.ts
@@ -1,0 +1,6 @@
+// Type stub for the CSS-only `@lostgradient/cinder/styles[...]` subpath. The
+// matching `types` condition in package.json#exports points here so a
+// side-effect `import` of the stylesheet typechecks under
+// `moduleResolution: bundler` (an ambient `declare module` in the consumer is
+// ignored once the specifier resolves to a real file). A CSS module exposes no
+// bindings, so this declares an empty module.

--- a/packages/components/src/styles/tokens.css.d.ts
+++ b/packages/components/src/styles/tokens.css.d.ts
@@ -2,5 +2,6 @@
 // matching `types` condition in package.json#exports points here so a
 // side-effect `import` of the stylesheet typechecks under
 // `moduleResolution: bundler` (an ambient `declare module` in the consumer is
-// ignored once the specifier resolves to a real file). A CSS module exposes no
-// bindings, so this declares an empty module.
+// ignored once the specifier resolves to a real file). `export {}` makes this
+// a module (not a global script) exposing no bindings — a CSS side-effect import.
+export {};

--- a/packages/components/src/styles/utilities.css.d.ts
+++ b/packages/components/src/styles/utilities.css.d.ts
@@ -1,0 +1,6 @@
+// Type stub for the CSS-only `@lostgradient/cinder/styles[...]` subpath. The
+// matching `types` condition in package.json#exports points here so a
+// side-effect `import` of the stylesheet typechecks under
+// `moduleResolution: bundler` (an ambient `declare module` in the consumer is
+// ignored once the specifier resolves to a real file). A CSS module exposes no
+// bindings, so this declares an empty module.

--- a/packages/components/src/styles/utilities.css.d.ts
+++ b/packages/components/src/styles/utilities.css.d.ts
@@ -2,5 +2,6 @@
 // matching `types` condition in package.json#exports points here so a
 // side-effect `import` of the stylesheet typechecks under
 // `moduleResolution: bundler` (an ambient `declare module` in the consumer is
-// ignored once the specifier resolves to a real file). A CSS module exposes no
-// bindings, so this declares an empty module.
+// ignored once the specifier resolves to a real file). `export {}` makes this
+// a module (not a global script) exposing no bindings — a CSS side-effect import.
+export {};


### PR DESCRIPTION
## Summary

Two consumer-facing packaging fixes surfaced while migrating real apps onto cinder.

**#311 — `lucide-svelte` as a peer dependency.** It was a regular `dependency`, so consumers got a nested duplicate copy (e.g. `0.503.0` alongside their own `0.561.0`), bloating bundles and defeating cross-version tree-shaking. Moved to `peerDependencies` (`>=0.400.0 <1`) so the consumer's copy is used; kept as a `devDependency` (`^0.503.0`) so cinder's own build/tests/playground still resolve the icons it imports internally. Not marked optional — it is effectively required for any consumer rendering icon-bearing components. The range is bounded `<1` because lucide-svelte's latest is now `1.0.1`, a major cinder has not tested against.

**#314 — `types` condition on the CSS-only style subpaths.** `./styles`, `./styles/all`, `./styles/tokens`, `./styles/foundation`, `./styles/utilities` exposed only a `default` condition pointing at a real `.css` file. Under `moduleResolution: bundler` (the SvelteKit default), a side-effect `import '@lostgradient/cinder/styles'` failed type resolution — ambient `declare module` fallbacks are ignored once the specifier resolves. `stylesExport()` in `generate-exports.ts` now emits a `types` condition first, pointing at a colocated `export {};` empty-module `.d.ts` stub. The stubs ship via `STATIC_FILES_GLOBS` and are exempt from oxlint's `no-empty-file` rule (intentional empty type stubs). Verified a side-effect import now typechecks under `moduleResolution: bundler` (tsc exit 0).

Closes #311
Closes #314

## Review committee

Pre-reviewed by:
- **Codex (gpt-5.4, xhigh→high reasoning)** — 2 rounds, APPROVED. Round 1 caught two must-fix items, both fixed:
  1. The `.d.ts` stubs were initially comment-only (global scripts, not modules) — the `types` condition would have resolved to a non-module and not actually proven the side-effect-import resolution. Added `export {};`.
  2. The lucide peer range was initially unbounded (`>=0.400.0`); bounded to `<1`.

> [!WARNING]
> The Claude-based subagent reviewers (typescript-expert, dx-engineer) could not run — they hit a 1M-context usage-credit ceiling and returned no output. Codex (the adversarial second-opinion reviewer) ran both rounds and the author reviewed every line of this focused 280-line diff.

## Test plan

- `bun run build` (packages/components) — clean, 133 components.
- `bun run exports:check` + `components:check` — drift-free.
- Full component suite: 4686 pass / 0 fail.
- All 5 `.d.ts` stubs exist at the exact `types` paths and ship via `STATIC_FILES_GLOBS`.
- `lucide-svelte` absent from `dependencies`; present in `peerDependencies` (`>=0.400.0 <1`) and `devDependencies` (`^0.503.0`).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Peer-dep change can break installs that lack lucide-svelte; export-map changes affect all consumers importing style entrypoints.
> 
> **Overview**
> Two consumer packaging fixes for `@lostgradient/cinder`.
> 
> **`lucide-svelte` peer dependency:** It is removed from `dependencies` and declared as `peerDependencies` (`>=0.400.0 <1`) so apps supply a single copy; it stays in `devDependencies` for the library build. Lockfile and version bump to `0.1.1` reflect that.
> 
> **CSS style subpaths and TypeScript:** Reserved exports (`./styles`, `./styles/all`, tokens, foundation, utilities) now emit a **`types`** condition (before `default`) via `stylesExport()` in `generate-exports.ts`, pointing at colocated `export {}` **`.css.d.ts`** stubs so side-effect stylesheet imports typecheck under `moduleResolution: bundler`. Stubs are included in publish globs; oxlint ignores `**/*.css.d.ts`. Drift tests and generator tests cover the new export shape.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 253fe75f16c17a0a5e1ffda6fc5ecb47a492ce7f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->