### PR TITLE
Theme color checkerboard tokens

### DIFF
--- a/docs/tokens.md
+++ b/docs/tokens.md
@@ -231,6 +231,8 @@ Foreground / background / border triples for soft tinted surfaces. Use these in 
 | `--cinder-color-danger-bg`      | `light-dark(oklch(96% 0.04 25), oklch(28% 0.09 25))`    |
 | `--cinder-color-danger-fg`      | `light-dark(oklch(42% 0.16 25), oklch(90% 0.12 25))`    |
 | `--cinder-color-danger-border`  | `light-dark(oklch(80% 0.06 25), oklch(50% 0.11 25))`    |
+| `--cinder-color-checker-base`   | `light-dark(#fff, oklch(28% 0.02 245))`                 |
+| `--cinder-color-checker-tile`   | `light-dark(#ccc, oklch(38% 0.02 245))`                 |
 
 ## Scrollbar
 

--- a/docs/tokens.md
+++ b/docs/tokens.md
@@ -231,8 +231,15 @@ Foreground / background / border triples for soft tinted surfaces. Use these in 
 | `--cinder-color-danger-bg`      | `light-dark(oklch(96% 0.04 25), oklch(28% 0.09 25))`    |
 | `--cinder-color-danger-fg`      | `light-dark(oklch(42% 0.16 25), oklch(90% 0.12 25))`    |
 | `--cinder-color-danger-border`  | `light-dark(oklch(80% 0.06 25), oklch(50% 0.11 25))`    |
-| `--cinder-color-checker-base`   | `light-dark(#fff, oklch(28% 0.02 245))`                 |
-| `--cinder-color-checker-tile`   | `light-dark(#ccc, oklch(38% 0.02 245))`                 |
+
+## Transparency checkerboard
+
+Shared checkerboard colors for color-domain components that need to show alpha over a structural pattern.
+
+| Token                         | Default                                 |
+| ----------------------------- | --------------------------------------- |
+| `--cinder-color-checker-base` | `light-dark(#fff, oklch(28% 0.02 245))` |
+| `--cinder-color-checker-tile` | `light-dark(#ccc, oklch(38% 0.02 245))` |
 
 ## Scrollbar
 

--- a/packages/components/scripts/component-graph.test.ts
+++ b/packages/components/scripts/component-graph.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'bun:test';
+import { describe, expect, it, setDefaultTimeout } from 'bun:test';
 
 import {
   assertNoAmbiguousImports,
@@ -15,6 +15,11 @@ import {
   UNMODELLABLE_IMPORT_ALLOWLIST,
   type ComputeScopeOptions,
 } from './component-graph.ts';
+
+// This file includes real-tree scans over every component source file. Under
+// parallel CI or multi-worktree local runs, Bun's default 5s test timeout can
+// expire while the scan is still making progress.
+setDefaultTimeout(30_000);
 
 // ---------------------------------------------------------------------------
 // extractImports

--- a/packages/components/src/components/color-field/color-field.css
+++ b/packages/components/src/components/color-field/color-field.css
@@ -36,20 +36,17 @@
 
   .cinder-color-field__swatch[data-cinder-alpha]:not([data-cinder-empty]) {
     /* structural-pattern: transparency checkerboard so partially-transparent
-     * swatches stay visible — a fixed light/neutral grid signalling "see-through",
-     * not a themeable surface. Raw values declared once here with markers. */
-    --_cinder-color-field-checker-base: #fff; /* cinder-allow-raw-color: structural-pattern — checkerboard backing */
-    --_cinder-color-field-checker-tile: #ccc; /* cinder-allow-raw-color: structural-pattern — checkerboard tile */
-    background-color: var(--_cinder-color-field-checker-base);
+     * swatches stay visible while following the shared checker tokens. */
+    background-color: var(--cinder-color-checker-base);
     background-image:
       linear-gradient(
         var(--cinder-color-field-swatch, transparent),
         var(--cinder-color-field-swatch, transparent)
       ),
-      linear-gradient(45deg, var(--_cinder-color-field-checker-tile) 25%, transparent 25%),
-      linear-gradient(-45deg, var(--_cinder-color-field-checker-tile) 25%, transparent 25%),
-      linear-gradient(45deg, transparent 75%, var(--_cinder-color-field-checker-tile) 75%),
-      linear-gradient(-45deg, transparent 75%, var(--_cinder-color-field-checker-tile) 75%);
+      linear-gradient(45deg, var(--cinder-color-checker-tile) 25%, transparent 25%),
+      linear-gradient(-45deg, var(--cinder-color-checker-tile) 25%, transparent 25%),
+      linear-gradient(45deg, transparent 75%, var(--cinder-color-checker-tile) 75%),
+      linear-gradient(-45deg, transparent 75%, var(--cinder-color-checker-tile) 75%);
     background-size:
       auto,
       6px 6px,

--- a/packages/components/src/components/color-picker/color-picker.css
+++ b/packages/components/src/components/color-picker/color-picker.css
@@ -14,23 +14,24 @@
     max-width: 280px;
 
     /* structural-pattern: the thumb sits over arbitrary picked colors, so the
-     * ring stays fixed while the outline flips to remain visible in dark chrome. */
+     * white ring and dark edge stay fixed; dark chrome gets one extra outer ring. */
     --_cinder-color-picker-thumb-border: #fff; /* cinder-allow-raw-color: structural-pattern — thumb contrast ring over arbitrary picked color */
-    --_cinder-color-picker-thumb-shadow-light: rgba(
+    --_cinder-color-picker-thumb-shadow-edge: rgba(
       0,
       0,
       0,
       0.5
     ); /* cinder-allow-raw-color: structural-pattern — thumb outline over arbitrary picked color */
-    --_cinder-color-picker-thumb-shadow-dark: rgba(
+    --_cinder-color-picker-thumb-shadow-support: rgba(
       255,
       255,
       255,
       0.65
     ); /* cinder-allow-raw-color: structural-pattern — thumb outline over dark chrome */
     --_cinder-color-picker-thumb-shadow: light-dark(
-      var(--_cinder-color-picker-thumb-shadow-light),
-      var(--_cinder-color-picker-thumb-shadow-dark)
+      0 0 0 1px var(--_cinder-color-picker-thumb-shadow-edge),
+      0 0 0 1px var(--_cinder-color-picker-thumb-shadow-edge),
+      0 0 0 2px var(--_cinder-color-picker-thumb-shadow-support)
     ); /* cinder-allow-raw-color: structural-pattern — thumb outline theme switch */
   }
 
@@ -79,7 +80,7 @@
     border: 2px solid var(--_cinder-color-picker-thumb-border);
     border-radius: 50%;
     transform: translate(-50%, -50%);
-    box-shadow: 0 0 0 1px var(--_cinder-color-picker-thumb-shadow);
+    box-shadow: var(--_cinder-color-picker-thumb-shadow);
     pointer-events: none;
   }
 
@@ -143,7 +144,7 @@
     border-radius: 50%;
     background: transparent;
     transform: translate(-50%, -50%);
-    box-shadow: 0 0 0 1px var(--_cinder-color-picker-thumb-shadow);
+    box-shadow: var(--_cinder-color-picker-thumb-shadow);
     pointer-events: none;
   }
 

--- a/packages/components/src/components/color-picker/color-picker.css
+++ b/packages/components/src/components/color-picker/color-picker.css
@@ -16,19 +16,11 @@
     /* structural-pattern: the thumb sits over arbitrary picked colors, so the
      * white ring and dark edge stay fixed; dark chrome gets one extra outer ring. */
     --_cinder-color-picker-thumb-border: #fff; /* cinder-allow-raw-color: structural-pattern — thumb contrast ring over arbitrary picked color */
-    --_cinder-color-picker-thumb-shadow-edge: rgba(
-      0,
-      0,
-      0,
-      0.5
-    ); /* cinder-allow-raw-color: structural-pattern — thumb outline over arbitrary picked color */
+    /* prettier-ignore */
+    --_cinder-color-picker-thumb-shadow-edge: rgba(0, 0, 0, 0.5); /* cinder-allow-raw-color: structural-pattern — thumb outline over arbitrary picked color */
     --_cinder-color-picker-thumb-shadow-support-light: transparent;
-    --_cinder-color-picker-thumb-shadow-support-dark: rgba(
-      255,
-      255,
-      255,
-      0.65
-    ); /* cinder-allow-raw-color: structural-pattern — thumb outline over dark chrome */
+    /* prettier-ignore */
+    --_cinder-color-picker-thumb-shadow-support-dark: rgba(255, 255, 255, 0.65); /* cinder-allow-raw-color: structural-pattern — thumb outline over dark chrome */
     --_cinder-color-picker-thumb-shadow-support: light-dark(
       var(--_cinder-color-picker-thumb-shadow-support-light),
       var(--_cinder-color-picker-thumb-shadow-support-dark)

--- a/packages/components/src/components/color-picker/color-picker.css
+++ b/packages/components/src/components/color-picker/color-picker.css
@@ -13,12 +13,25 @@
     width: 100%;
     max-width: 280px;
 
-    /* structural-pattern: the transparency checkerboard (shown behind alpha
-     * channels by the alpha slider and the preview chip) is a fixed light/neutral
-     * grid that signals "see-through", not a themeable surface. Declared once here
-     * and reused by both checkerboards below so the raw values have a single home. */
-    --_cinder-color-picker-checker-base: #fff; /* cinder-allow-raw-color: structural-pattern — checkerboard backing */
-    --_cinder-color-picker-checker-tile: #ccc; /* cinder-allow-raw-color: structural-pattern — checkerboard tile */
+    /* structural-pattern: the thumb sits over arbitrary picked colors, so the
+     * ring stays fixed while the outline flips to remain visible in dark chrome. */
+    --_cinder-color-picker-thumb-border: #fff; /* cinder-allow-raw-color: structural-pattern — thumb contrast ring over arbitrary picked color */
+    --_cinder-color-picker-thumb-shadow-light: rgba(
+      0,
+      0,
+      0,
+      0.5
+    ); /* cinder-allow-raw-color: structural-pattern — thumb outline over arbitrary picked color */
+    --_cinder-color-picker-thumb-shadow-dark: rgba(
+      255,
+      255,
+      255,
+      0.65
+    ); /* cinder-allow-raw-color: structural-pattern — thumb outline over dark chrome */
+    --_cinder-color-picker-thumb-shadow: light-dark(
+      var(--_cinder-color-picker-thumb-shadow-light),
+      var(--_cinder-color-picker-thumb-shadow-dark)
+    ); /* cinder-allow-raw-color: structural-pattern — thumb outline theme switch */
   }
 
   .cinder-color-picker[data-cinder-disabled] {
@@ -62,12 +75,11 @@
     width: 14px;
     height: 14px;
     /* structural-pattern: the draggable thumb sits over the user's chosen color,
-     * so its white ring + dark outline are fixed contrast devices (visible on any
-     * hue), not themeable chrome. */
-    border: 2px solid #fff; /* cinder-allow-raw-color: structural-pattern — thumb contrast ring over arbitrary picked color */
+     * so its white ring + contrast outline are hue-agnostic devices. */
+    border: 2px solid var(--_cinder-color-picker-thumb-border);
     border-radius: 50%;
     transform: translate(-50%, -50%);
-    box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.5); /* cinder-allow-raw-color: structural-pattern — thumb dark outline for contrast on light hues */
+    box-shadow: 0 0 0 1px var(--_cinder-color-picker-thumb-shadow);
     pointer-events: none;
   }
 
@@ -92,13 +104,13 @@
   }
 
   .cinder-color-picker__alpha {
-    background-color: var(--_cinder-color-picker-checker-base);
+    background-color: var(--cinder-color-checker-base);
     background-image:
       linear-gradient(to right, transparent, var(--cinder-color-picker-base, currentColor)),
-      linear-gradient(45deg, var(--_cinder-color-picker-checker-tile) 25%, transparent 25%),
-      linear-gradient(-45deg, var(--_cinder-color-picker-checker-tile) 25%, transparent 25%),
-      linear-gradient(45deg, transparent 75%, var(--_cinder-color-picker-checker-tile) 75%),
-      linear-gradient(-45deg, transparent 75%, var(--_cinder-color-picker-checker-tile) 75%);
+      linear-gradient(45deg, var(--cinder-color-checker-tile) 25%, transparent 25%),
+      linear-gradient(-45deg, var(--cinder-color-checker-tile) 25%, transparent 25%),
+      linear-gradient(45deg, transparent 75%, var(--cinder-color-checker-tile) 75%),
+      linear-gradient(-45deg, transparent 75%, var(--cinder-color-checker-tile) 75%);
     background-size:
       auto,
       8px 8px,
@@ -126,13 +138,12 @@
     width: 14px;
     height: 14px;
     /* structural-pattern: slider thumb sits over the hue rail / alpha
-     * checkerboard, so its white ring + dark outline are fixed contrast devices,
-     * not themeable chrome (same rationale as the gradient handle). */
-    border: 2px solid #fff; /* cinder-allow-raw-color: structural-pattern — slider thumb contrast ring */
+     * checkerboard, so its ring + outline follow the gradient handle. */
+    border: 2px solid var(--_cinder-color-picker-thumb-border);
     border-radius: 50%;
     background: transparent;
     transform: translate(-50%, -50%);
-    box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.5); /* cinder-allow-raw-color: structural-pattern — slider thumb dark outline */
+    box-shadow: 0 0 0 1px var(--_cinder-color-picker-thumb-shadow);
     pointer-events: none;
   }
 
@@ -154,16 +165,16 @@
   }
 
   .cinder-color-picker__preview[data-cinder-alpha] {
-    background-color: var(--_cinder-color-picker-checker-base);
+    background-color: var(--cinder-color-checker-base);
     background-image:
       linear-gradient(
         var(--cinder-color-picker-preview, transparent),
         var(--cinder-color-picker-preview, transparent)
       ),
-      linear-gradient(45deg, var(--_cinder-color-picker-checker-tile) 25%, transparent 25%),
-      linear-gradient(-45deg, var(--_cinder-color-picker-checker-tile) 25%, transparent 25%),
-      linear-gradient(45deg, transparent 75%, var(--_cinder-color-picker-checker-tile) 75%),
-      linear-gradient(-45deg, transparent 75%, var(--_cinder-color-picker-checker-tile) 75%);
+      linear-gradient(45deg, var(--cinder-color-checker-tile) 25%, transparent 25%),
+      linear-gradient(-45deg, var(--cinder-color-checker-tile) 25%, transparent 25%),
+      linear-gradient(45deg, transparent 75%, var(--cinder-color-checker-tile) 75%),
+      linear-gradient(-45deg, transparent 75%, var(--cinder-color-checker-tile) 75%);
     background-size:
       auto,
       8px 8px,

--- a/packages/components/src/components/color-picker/color-picker.css
+++ b/packages/components/src/components/color-picker/color-picker.css
@@ -22,17 +22,20 @@
       0,
       0.5
     ); /* cinder-allow-raw-color: structural-pattern — thumb outline over arbitrary picked color */
-    --_cinder-color-picker-thumb-shadow-support: rgba(
+    --_cinder-color-picker-thumb-shadow-support-light: transparent;
+    --_cinder-color-picker-thumb-shadow-support-dark: rgba(
       255,
       255,
       255,
       0.65
     ); /* cinder-allow-raw-color: structural-pattern — thumb outline over dark chrome */
-    --_cinder-color-picker-thumb-shadow: light-dark(
+    --_cinder-color-picker-thumb-shadow-support: light-dark(
+      var(--_cinder-color-picker-thumb-shadow-support-light),
+      var(--_cinder-color-picker-thumb-shadow-support-dark)
+    );
+    --_cinder-color-picker-thumb-shadow:
       0 0 0 1px var(--_cinder-color-picker-thumb-shadow-edge),
-      0 0 0 1px var(--_cinder-color-picker-thumb-shadow-edge),
-      0 0 0 2px var(--_cinder-color-picker-thumb-shadow-support)
-    ); /* cinder-allow-raw-color: structural-pattern — thumb outline theme switch */
+      0 0 0 2px var(--_cinder-color-picker-thumb-shadow-support);
   }
 
   .cinder-color-picker[data-cinder-disabled] {

--- a/packages/components/src/components/color-picker/color-picker.css.test.ts
+++ b/packages/components/src/components/color-picker/color-picker.css.test.ts
@@ -1,0 +1,94 @@
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, test } from 'bun:test';
+
+import { parse, type Declaration } from 'postcss';
+
+function loadCss(relativePath: string): string {
+  const fullPath = fileURLToPath(new URL(relativePath, import.meta.url));
+  return readFileSync(fullPath, 'utf8');
+}
+
+function declarationValue(source: string, property: string): string {
+  const root = parse(source);
+  let value: string | undefined;
+  root.walkDecls(property, (declaration: Declaration) => {
+    value = declaration.value;
+    return false;
+  });
+  if (!value) throw new Error(`declaration not found: ${property}`);
+  return value;
+}
+
+function compactCssValue(value: string): string {
+  return value.replace(/\s+/g, ' ').replace(/\(\s+/g, '(').replace(/\s+\)/g, ')').trim();
+}
+
+function lightDarkArms(value: string): [string, string] {
+  const match = /^light-dark\(([\s\S]+)\)$/.exec(value.trim());
+  if (!match?.[1]) throw new Error(`expected light-dark(), got: ${value}`);
+  const inner = match[1];
+  let depth = 0;
+  for (let index = 0; index < inner.length; index += 1) {
+    const char = inner[index];
+    if (char === '(') depth += 1;
+    else if (char === ')') depth -= 1;
+    else if (char === ',' && depth === 0) {
+      return [inner.slice(0, index).trim(), inner.slice(index + 1).trim()];
+    }
+  }
+  throw new Error(`light-dark() missing comma separator: ${value}`);
+}
+
+const tokensCss = loadCss('../../styles/tokens-base.css');
+const colorPickerCss = loadCss('./color-picker.css');
+const colorFieldCss = loadCss('../color-field/color-field.css');
+const colorSwatchPickerCss = loadCss('../color-swatch-picker/color-swatch-picker.css');
+
+describe('color checker tokens', () => {
+  test('checkerboard tokens keep the light arm and define a distinct dark arm', () => {
+    const base = lightDarkArms(declarationValue(tokensCss, '--cinder-color-checker-base'));
+    const tile = lightDarkArms(declarationValue(tokensCss, '--cinder-color-checker-tile'));
+
+    expect(base).toEqual(['#fff', 'oklch(28% 0.02 245)']);
+    expect(tile).toEqual(['#ccc', 'oklch(38% 0.02 245)']);
+    expect(base[0]).not.toBe(base[1]);
+    expect(tile[0]).not.toBe(tile[1]);
+  });
+
+  test('color components consume the public checker tokens without private checker aliases', () => {
+    const componentSources = [colorPickerCss, colorFieldCss, colorSwatchPickerCss];
+
+    for (const source of componentSources) {
+      expect(source).toContain('var(--cinder-color-checker-base)');
+      expect(source).toContain('var(--cinder-color-checker-tile)');
+      expect(source).not.toContain('--_cinder-color-picker-checker-');
+      expect(source).not.toContain('--_cinder-color-field-checker-');
+      expect(source).not.toContain('--_cinder-color-swatch-picker-checker-');
+    }
+  });
+});
+
+describe('color picker thumb contrast outline', () => {
+  test('thumb shadow uses a distinct dark arm while the border remains fixed', () => {
+    const shadow = lightDarkArms(
+      declarationValue(colorPickerCss, '--_cinder-color-picker-thumb-shadow'),
+    );
+
+    expect(declarationValue(colorPickerCss, '--_cinder-color-picker-thumb-border')).toBe('#fff');
+    expect(
+      compactCssValue(
+        declarationValue(colorPickerCss, '--_cinder-color-picker-thumb-shadow-light'),
+      ),
+    ).toBe('rgba(0, 0, 0, 0.5)');
+    expect(
+      compactCssValue(declarationValue(colorPickerCss, '--_cinder-color-picker-thumb-shadow-dark')),
+    ).toBe('rgba(255, 255, 255, 0.65)');
+    expect(shadow).toEqual([
+      'var(--_cinder-color-picker-thumb-shadow-light)',
+      'var(--_cinder-color-picker-thumb-shadow-dark)',
+    ]);
+    expect(shadow[0]).not.toBe(shadow[1]);
+  });
+});

--- a/packages/components/src/components/color-picker/color-picker.css.test.ts
+++ b/packages/components/src/components/color-picker/color-picker.css.test.ts
@@ -71,24 +71,23 @@ describe('color checker tokens', () => {
 });
 
 describe('color picker thumb contrast outline', () => {
-  test('thumb shadow uses a distinct dark arm while the border remains fixed', () => {
+  test('thumb shadow keeps a dark edge and adds a dark-mode support ring', () => {
     const shadow = lightDarkArms(
       declarationValue(colorPickerCss, '--_cinder-color-picker-thumb-shadow'),
-    );
+    ).map(compactCssValue);
 
     expect(declarationValue(colorPickerCss, '--_cinder-color-picker-thumb-border')).toBe('#fff');
     expect(
-      compactCssValue(
-        declarationValue(colorPickerCss, '--_cinder-color-picker-thumb-shadow-light'),
-      ),
+      compactCssValue(declarationValue(colorPickerCss, '--_cinder-color-picker-thumb-shadow-edge')),
     ).toBe('rgba(0, 0, 0, 0.5)');
     expect(
-      compactCssValue(declarationValue(colorPickerCss, '--_cinder-color-picker-thumb-shadow-dark')),
+      compactCssValue(
+        declarationValue(colorPickerCss, '--_cinder-color-picker-thumb-shadow-support'),
+      ),
     ).toBe('rgba(255, 255, 255, 0.65)');
     expect(shadow).toEqual([
-      'var(--_cinder-color-picker-thumb-shadow-light)',
-      'var(--_cinder-color-picker-thumb-shadow-dark)',
+      '0 0 0 1px var(--_cinder-color-picker-thumb-shadow-edge)',
+      '0 0 0 1px var(--_cinder-color-picker-thumb-shadow-edge), 0 0 0 2px var(--_cinder-color-picker-thumb-shadow-support)',
     ]);
-    expect(shadow[0]).not.toBe(shadow[1]);
   });
 });

--- a/packages/components/src/components/color-picker/color-picker.css.test.ts
+++ b/packages/components/src/components/color-picker/color-picker.css.test.ts
@@ -72,22 +72,31 @@ describe('color checker tokens', () => {
 
 describe('color picker thumb contrast outline', () => {
   test('thumb shadow keeps a dark edge and adds a dark-mode support ring', () => {
-    const shadow = lightDarkArms(
-      declarationValue(colorPickerCss, '--_cinder-color-picker-thumb-shadow'),
+    const support = lightDarkArms(
+      declarationValue(colorPickerCss, '--_cinder-color-picker-thumb-shadow-support'),
     ).map(compactCssValue);
+    const shadow = compactCssValue(
+      declarationValue(colorPickerCss, '--_cinder-color-picker-thumb-shadow'),
+    );
 
     expect(declarationValue(colorPickerCss, '--_cinder-color-picker-thumb-border')).toBe('#fff');
     expect(
       compactCssValue(declarationValue(colorPickerCss, '--_cinder-color-picker-thumb-shadow-edge')),
     ).toBe('rgba(0, 0, 0, 0.5)');
     expect(
+      declarationValue(colorPickerCss, '--_cinder-color-picker-thumb-shadow-support-light'),
+    ).toBe('transparent');
+    expect(
       compactCssValue(
-        declarationValue(colorPickerCss, '--_cinder-color-picker-thumb-shadow-support'),
+        declarationValue(colorPickerCss, '--_cinder-color-picker-thumb-shadow-support-dark'),
       ),
     ).toBe('rgba(255, 255, 255, 0.65)');
-    expect(shadow).toEqual([
-      '0 0 0 1px var(--_cinder-color-picker-thumb-shadow-edge)',
-      '0 0 0 1px var(--_cinder-color-picker-thumb-shadow-edge), 0 0 0 2px var(--_cinder-color-picker-thumb-shadow-support)',
+    expect(support).toEqual([
+      'var(--_cinder-color-picker-thumb-shadow-support-light)',
+      'var(--_cinder-color-picker-thumb-shadow-support-dark)',
     ]);
+    expect(shadow).toBe(
+      '0 0 0 1px var(--_cinder-color-picker-thumb-shadow-edge), 0 0 0 2px var(--_cinder-color-picker-thumb-shadow-support)',
+    );
   });
 });

--- a/packages/components/src/components/color-swatch-picker/color-swatch-picker.css
+++ b/packages/components/src/components/color-swatch-picker/color-swatch-picker.css
@@ -71,17 +71,14 @@
 
   .cinder-color-swatch-picker__swatch[data-cinder-alpha] {
     /* structural-pattern: transparency checkerboard beneath the color layer — a
-     * fixed light/neutral grid signalling "see-through", not a themeable surface.
-     * Raw values declared once here with markers. */
-    --_cinder-color-swatch-picker-checker-base: #fff; /* cinder-allow-raw-color: structural-pattern — checkerboard backing */
-    --_cinder-color-swatch-picker-checker-tile: #ccc; /* cinder-allow-raw-color: structural-pattern — checkerboard tile */
-    background-color: var(--_cinder-color-swatch-picker-checker-base);
+     * shared grid signalling "see-through" in both light and dark chrome. */
+    background-color: var(--cinder-color-checker-base);
     background-image:
       linear-gradient(var(--swatch-color), var(--swatch-color)),
-      linear-gradient(45deg, var(--_cinder-color-swatch-picker-checker-tile) 25%, transparent 25%),
-      linear-gradient(-45deg, var(--_cinder-color-swatch-picker-checker-tile) 25%, transparent 25%),
-      linear-gradient(45deg, transparent 75%, var(--_cinder-color-swatch-picker-checker-tile) 75%),
-      linear-gradient(-45deg, transparent 75%, var(--_cinder-color-swatch-picker-checker-tile) 75%);
+      linear-gradient(45deg, var(--cinder-color-checker-tile) 25%, transparent 25%),
+      linear-gradient(-45deg, var(--cinder-color-checker-tile) 25%, transparent 25%),
+      linear-gradient(45deg, transparent 75%, var(--cinder-color-checker-tile) 75%),
+      linear-gradient(-45deg, transparent 75%, var(--cinder-color-checker-tile) 75%);
     background-size:
       auto,
       8px 8px,

--- a/packages/components/src/styles/component-css-layer-invariant.test.ts
+++ b/packages/components/src/styles/component-css-layer-invariant.test.ts
@@ -1,6 +1,6 @@
 import { join } from 'node:path';
 
-import { describe, expect, test } from 'bun:test';
+import { describe, expect, setDefaultTimeout, test } from 'bun:test';
 import { parse, type ChildNode } from 'postcss';
 
 import { COMPONENT_LAYER_NAME, isSingleComponentLayer } from '../../scripts/check-component-css.ts';
@@ -25,6 +25,11 @@ import { COMPONENT_LAYER_NAME, isSingleComponentLayer } from '../../scripts/chec
  */
 
 const repoRoot = join(import.meta.dir, '..', '..');
+
+// This file scans and parses every component CSS file. Under parallel CI or
+// multi-worktree local runs, Bun's default 5s test timeout can expire while the
+// scan is still making progress.
+setDefaultTimeout(30_000);
 
 /**
  * CSS files that legitimately do NOT carry the wrapper, by exact path under the

--- a/packages/components/src/styles/component-variables-contract.test.ts
+++ b/packages/components/src/styles/component-variables-contract.test.ts
@@ -36,9 +36,14 @@
 import { readdir } from 'node:fs/promises';
 import { join } from 'node:path';
 
-import { describe, expect, test } from 'bun:test';
+import { describe, expect, setDefaultTimeout, test } from 'bun:test';
 
 const COMPONENTS_DIR = join(import.meta.dir, '..', 'components');
+
+// This file scans every component variables manifest. Under parallel CI or
+// multi-worktree local runs, Bun's default 5s test timeout can expire while the
+// scan is still making progress.
+setDefaultTimeout(30_000);
 
 /**
  * Runtime-state variable names that the generator currently mis-emits as public

--- a/packages/components/src/styles/tokens-base.css
+++ b/packages/components/src/styles/tokens-base.css
@@ -283,6 +283,12 @@
   --cinder-color-danger-fg: light-dark(oklch(42% 0.16 25), oklch(90% 0.12 25));
   --cinder-color-danger-border: light-dark(oklch(80% 0.06 25), oklch(50% 0.11 25));
 
+  /* Transparency checkerboard tokens shared by color-domain components. Light
+     mode preserves the historical white/gray grid; dark mode keeps the pattern
+     visible without flashing a white backing inside dark chrome. */
+  --cinder-color-checker-base: light-dark(#fff, oklch(28% 0.02 245));
+  --cinder-color-checker-tile: light-dark(#ccc, oklch(38% 0.02 245));
+
   /* Scrollbars — used by the ScrollArea component and any consumer that
      opts into themed native scrollbars via `scrollbar-width` and
      `::-webkit-scrollbar-*`. Thumb alpha is tuned so the resolved


### PR DESCRIPTION
## Summary

- promote transparency checkerboard colors to public theme-aware tokens
- repoint color picker, color field, and swatch picker alpha checkerboards to the shared tokens
- keep the color picker thumb's dark contrast edge across themes while adding a dark-mode support ring
- add CSS-source regression coverage and token documentation
- raise the component-graph real-tree test timeout to match other whole-tree scan tests under load

## Review committee

Pre-reviewed by: frontend-architect, ux-designer, testing-expert, simplicity-engineer, prose-editor, Codex
- Codex (review-only) — 3 rounds
- 3 rounds of committee review
- All must-fix items addressed

## Test plan

- `bun run --filter=@lostgradient/cinder test -- color-picker.css color-field color-swatch-picker callout tokens-doc-drift tokens`
- `bun run --filter=@lostgradient/cinder colors:audit -- --strict`
- `bun run --filter=@lostgradient/cinder components:check`
- `bun run --filter=@lostgradient/cinder typecheck`
- `bun test packages/components/scripts/component-graph.test.ts -t "no-unmodellable-imports guard"`
- pre-commit hook: lint-staged, `@lostgradient/cinder typecheck`, full `@lostgradient/cinder test`
- pre-push hook: scoped validation passed for 2 of 7 packages
- visual verification in playground for light/dark checkerboard and thumb outline behavior

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped visual/theming changes to color-domain CSS and new public tokens, with postcss regression tests; no auth, data, or API behavior changes.
> 
> **Overview**
> Introduces shared **`--cinder-color-checker-base`** and **`--cinder-color-checker-tile`** on `:root` with `light-dark()` so alpha checkerboards stay readable in dark chrome without a white flash, and documents them in **`docs/tokens.md`**.
> 
> **Color field**, **color picker**, and **color swatch picker** drop per-component private checker variables and wire alpha swatches, alpha slider, and preview chips to the public tokens.
> 
> **Color picker** centralizes gradient/hue/alpha thumb contrast in private `--_cinder-color-picker-thumb-*` variables: fixed white ring and dark edge in both themes, plus an extra outer support ring in dark mode via `light-dark()`.
> 
> Adds **`color-picker.css.test.ts`** to lock checker token values, forbid revived private checker aliases, and assert thumb shadow structure. Raises Bun’s default test timeout to **30s** on whole-repo scan tests (`component-graph`, component CSS layer invariant, component variables contract) to reduce flaky CI timeouts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5477424a82e9f9c337b83353c87edbedbd409e2e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->