### PR TITLE
Fix AvatarGroup focus ring token

### DIFF
--- a/packages/components/src/components/avatar-group/avatar-group.css
+++ b/packages/components/src/components/avatar-group/avatar-group.css
@@ -47,9 +47,8 @@
        ring; the outline is intentionally suppressed. */
     outline: none;
     box-shadow:
-      0 0 0 var(--cinder-ring-offset-width) var(--cinder-ring-offset-color),
-      0 0 0 calc(var(--cinder-ring-offset-width) + var(--cinder-ring-width))
-        var(--cinder-ring-color);
+      0 0 0 var(--cinder-ring-offset, 1px) var(--cinder-ring-offset-color),
+      0 0 0 calc(var(--cinder-ring-offset, 1px) + var(--cinder-ring-width)) var(--cinder-ring-color);
   }
 
   .cinder-avatar-group__overflow {

--- a/packages/testing/tests/avatar-group-focus-rings.playwright.ts
+++ b/packages/testing/tests/avatar-group-focus-rings.playwright.ts
@@ -1,0 +1,79 @@
+/// <reference lib="dom" />
+import { expect, test, type Locator, type Page } from '@playwright/test';
+
+const AVATAR_GROUP_ROUTE = '/page/avatar-group?snapshot=1';
+const BASIC_EXAMPLE = '#example-mount-basic';
+
+async function blurToBody(page: Page): Promise<void> {
+  await page.evaluate(() => {
+    if (document.activeElement instanceof HTMLElement) document.activeElement.blur();
+    document.body.focus();
+  });
+}
+
+async function activeElementSummary(page: Page): Promise<string> {
+  return page.evaluate(() => {
+    const activeElement = document.activeElement;
+    if (!(activeElement instanceof HTMLElement)) return '<none>';
+
+    const className =
+      typeof activeElement.className === 'string' && activeElement.className
+        ? `.${activeElement.className.trim().replace(/\s+/g, '.')}`
+        : '';
+    const label = activeElement.getAttribute('aria-label');
+    const labelSuffix = label ? `[aria-label="${label}"]` : '';
+
+    return `${activeElement.tagName.toLowerCase()}${className}${labelSuffix}`;
+  });
+}
+
+async function tabUntilFocused(
+  page: Page,
+  target: Locator,
+  label: string,
+  maxPresses = 40,
+): Promise<void> {
+  for (let attempt = 0; attempt < maxPresses; attempt += 1) {
+    await page.keyboard.press('Tab');
+    const landed = await target.evaluate((element) => element === document.activeElement);
+    if (landed) return;
+  }
+
+  throw new Error(
+    `Tab walk did not reach ${label}; active element is ${await activeElementSummary(page)}`,
+  );
+}
+
+function boxShadowLayerCount(boxShadow: string): number {
+  return boxShadow.split(/,(?![^(]*\))/).length;
+}
+
+test.describe('avatar-group focus rings', () => {
+  test('avatar-group keyboard focus paints the trigger ring', async ({ page }) => {
+    await page.goto(AVATAR_GROUP_ROUTE, { waitUntil: 'load' });
+    await page.waitForSelector(BASIC_EXAMPLE, { state: 'visible', timeout: 20_000 });
+
+    const trigger = page.locator(
+      `${BASIC_EXAMPLE} .cinder-avatar-group__trigger[aria-label="Ada Lovelace"]`,
+    );
+    await expect(trigger).toBeVisible();
+
+    await blurToBody(page);
+    await tabUntilFocused(page, trigger, 'Ada Lovelace avatar trigger');
+    await expect(trigger).toBeFocused();
+
+    const paint = await trigger.evaluate((element) => {
+      const styles = getComputedStyle(element as HTMLElement);
+      return {
+        boxShadow: styles.boxShadow,
+        matchesFocusVisible: element.matches(':focus-visible'),
+        ringWidth: styles.getPropertyValue('--cinder-ring-width').trim(),
+      };
+    });
+
+    expect(paint.matchesFocusVisible).toBe(true);
+    expect(paint.boxShadow).not.toBe('none');
+    expect(boxShadowLayerCount(paint.boxShadow)).toBeGreaterThanOrEqual(2);
+    expect(paint.ringWidth).not.toBe('');
+  });
+});

--- a/packages/testing/tests/avatar-group-focus-rings.playwright.ts
+++ b/packages/testing/tests/avatar-group-focus-rings.playwright.ts
@@ -31,7 +31,7 @@ async function tabUntilFocused(
   page: Page,
   target: Locator,
   label: string,
-  maxPresses = 40,
+  maxPresses = 80,
 ): Promise<void> {
   for (let attempt = 0; attempt < maxPresses; attempt += 1) {
     await page.keyboard.press('Tab');
@@ -52,6 +52,7 @@ test.describe('avatar-group focus rings', () => {
   test('avatar-group keyboard focus paints the trigger ring', async ({ page }) => {
     await page.goto(AVATAR_GROUP_ROUTE, { waitUntil: 'load' });
     await page.waitForSelector(BASIC_EXAMPLE, { state: 'visible', timeout: 20_000 });
+    await page.waitForLoadState('networkidle');
 
     const trigger = page.locator(
       `${BASIC_EXAMPLE} .cinder-avatar-group__trigger[aria-label="Ada Lovelace"]`,


### PR DESCRIPTION
## Summary
- restore AvatarGroup trigger focus ring by replacing an invalid offset token with `--cinder-ring-offset` plus fallback
- add keyboard-driven Playwright regression coverage for `/page/avatar-group?snapshot=1`

## Review committee
Pre-reviewed by:
- frontend-architect (Codex fallback / medium)
- testing-expert (Codex fallback / medium)
- typescript-expert (Codex fallback / medium)
- ux-designer (Codex fallback / medium)
- simplicity-engineer (Codex fallback / medium)
- junior-engineer (Codex fallback / medium)
- Codex (gpt-5.4/xhigh, 3 rounds)
- All must-fix items addressed

## Test plan
- `bun run --filter=@lostgradient/cinder test -- avatar avatar-group tooltip focus`
- `bun run --filter=@lostgradient/cinder components:check`
- `bun run --filter=@cinder/testing typecheck`
- `bunx prettier --check packages/testing/tests/avatar-group-focus-rings.playwright.ts packages/components/src/components/avatar-group/avatar-group.css`
- `bun run --filter=@cinder/testing test:playwright -- --grep avatar-group`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped CSS token correction and a focused accessibility regression test; no auth, data, or API changes.
> 
> **Overview**
> **AvatarGroup** keyboard focus rings were broken because `:focus-visible` on `.cinder-avatar-group__trigger` used a non-existent **`--cinder-ring-offset-width`** token. The PR switches the box-shadow ring to the shared **`--cinder-ring-offset`** (with a **`1px`** fallback), matching the rest of the design system’s focus-ring pattern.
> 
> A new **Playwright** spec tabs to an avatar trigger on the snapshot page and asserts **`:focus-visible`**, a non-empty multi-layer **`box-shadow`**, and that **`--cinder-ring-width`** is present—guarding against regressions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 56070a542f73573b40efed7890597b49231f1b95. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->