### PR TITLE
fix(ci): build playground bundle dependencies before the main-green test suite

### DIFF
--- a/.github/workflows/main-green.yaml
+++ b/.github/workflows/main-green.yaml
@@ -49,5 +49,24 @@ jobs:
       - name: Typecheck workspace
         run: bun run typecheck
 
+      # The full `bun run test` suite includes @cinder/playground's bundle/route
+      # tests (playground-server.test.ts), which bundle the playground FROM
+      # SOURCE and resolve these private packages through their built `dist/`
+      # subpath exports (e.g. @cinder/markdown/pipeline, @cinder/editor/
+      # component-runtime, @cinder/commentary/anchor-decorations). Without a
+      # prior build those imports fail to resolve and the bundle tests error.
+      # The package list is the SAME one the Playwright runner builds in
+      # packages/testing/scripts/start-server.ts and is pinned by the
+      # "playground bundle dependency build preflight" test in start-server.test.ts
+      # — keep this filter list in sync with that test's `toEqual` assertion.
+      - name: Build playground bundle dependencies
+        run: >-
+          bun run
+          --filter=@cinder/diff
+          --filter=@cinder/markdown
+          --filter=@cinder/editor
+          --filter=@cinder/commentary
+          build
+
       - name: Test workspace
         run: bun run test

--- a/packages/playground/src/playground-server.test.ts
+++ b/packages/playground/src/playground-server.test.ts
@@ -7,6 +7,16 @@
  * Tests that hit /bundle/button/primary.js and /example-src/button/primary rely
  * on scripts/playground/examples/button/primary.example.svelte existing. A
  * beforeAll guard asserts this up front so failures are diagnosable.
+ *
+ * PRECONDITION: the /bundle/* and /page-bundle/* "build artifact" tests bundle
+ * the playground FROM SOURCE, which resolves @cinder/diff, @cinder/markdown,
+ * @cinder/editor, and @cinder/commentary through their built `dist/` subpath
+ * exports. Run `bun run --filter=@cinder/diff --filter=@cinder/markdown
+ * --filter=@cinder/editor --filter=@cinder/commentary build` before this file
+ * in a fresh checkout, or those tests fail with "Could not resolve" import
+ * errors. CI does this in the main-green `Build playground bundle dependencies`
+ * step; the Playwright runner does it via start-server.ts. The package list is
+ * pinned by the "playground bundle dependency build preflight" test.
  */
 
 import { afterEach, beforeAll, describe, expect, it } from 'bun:test';


### PR DESCRIPTION
## Summary

`main-green`'s `workspace-gates` job runs the full `bun run test`, which includes `@cinder/playground`'s bundle/route tests (`playground-server.test.ts`). Those tests bundle the playground **from source** and resolve `@cinder/diff`, `@cinder/markdown`, `@cinder/editor`, and `@cinder/commentary` through their built `dist/` subpath exports (e.g. `@cinder/markdown/pipeline`, `@cinder/editor/component-runtime`, `@cinder/commentary/anchor-decorations`).

The job had **no build step**, so since #316 added those tests (`df1f2083`, 2026-06-08) the imports failed to resolve and `main-green` has been red on 8 "Could not resolve" errors. This is a CI-ordering gap, **not a product defect**:
- the gating `browser-tests` job stayed green,
- the scoped `unit-tests` job stayed green (it intentionally does not run the playground suite),
- the playground deploys fine.

Reproduced locally: a fresh checkout fails those 8 tests; building the 4 dep packages takes it `5 fail → 1 fail → 0 fail` as each is built.

## Fix

- Adds a `Build playground bundle dependencies` step (after typecheck, before test) that builds the **same** four packages the Playwright runner builds in `packages/testing/scripts/start-server.ts` — the list is pinned by the `playground bundle dependency build preflight` test in `start-server.test.ts`, and the workflow comment points reviewers there to keep the two in sync.
- Documents the fresh-checkout precondition at the top of `playground-server.test.ts` so a local `bun run test` failure is self-diagnosing.

## Review

Pre-reviewed by Codex (gpt-5.4, high reasoning) — APPROVED: build step in the right place (typecheck against source first, then the bundle-time `dist/` prerequisites), hardcoded package list mitigated by the pinning test + comment, no correctness or efficiency blocker.

## Test plan

- This turns `main-green` / `workspace-gates` green by satisfying the bundle tests' `dist/` prerequisite. The `release` job's separate red (provenance/OIDC) is out of scope for this PR.
- Verify the `Build playground bundle dependencies` step runs before `Test workspace` in the `main-green` workflow run for this branch's merge.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI ordering and documentation only; no product or runtime behavior changes.
> 
> **Overview**
> Fixes **`main-green`** by building the four playground bundle dependencies (`@cinder/diff`, `@cinder/markdown`, `@cinder/editor`, `@cinder/commentary`) **after typecheck and before** `bun run test`. Full-workspace tests include `playground-server.test.ts`, which bundles from source and needs those packages’ built `dist/` subpath exports; without this step CI fails with “Could not resolve” import errors.
> 
> The workflow comment ties the filter list to the Playwright **`start-server.ts`** build list and the **`playground bundle dependency build preflight`** test in `start-server.test.ts`. **`playground-server.test.ts`** now documents the same fresh-checkout precondition and points to CI and the Playwright runner.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cf1546ad9183f95b60c20a422c8039e9d9e52ac0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->