### PR TITLE
fix(playground): white background, Cinder tabs, CodeBlock rendering, Examples as default

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -43,7 +43,7 @@
     },
     "packages/components": {
       "name": "@lostgradient/cinder",
-      "version": "0.1.1",
+      "version": "0.2.0",
       "dependencies": {
         "@floating-ui/dom": "1.7.6",
         "@lasercat/homogenaize": "^1.2.41",

--- a/packages/playground/src/component-page-documentation.test.ts
+++ b/packages/playground/src/component-page-documentation.test.ts
@@ -300,6 +300,11 @@ describe('component-page documentation tabs', () => {
     const examples = screen.getByRole('tab', { name: 'Examples' });
     const rawArtifacts = screen.getByRole('tab', { name: 'Raw Artifacts' });
 
+    // Click Documentation first so ArrowRight proves a real transition (examples → not selected).
+    await fireEvent.click(documentation);
+    await tick();
+    expect(documentation.getAttribute('aria-selected')).toBe('true');
+
     documentation.focus();
     await fireEvent.keyDown(documentation, { key: 'ArrowRight' });
     await tick();

--- a/packages/playground/src/component-page-documentation.test.ts
+++ b/packages/playground/src/component-page-documentation.test.ts
@@ -177,13 +177,15 @@ describe('component-page documentation tabs', () => {
 
     const { unmount } = render(ComponentPage);
 
-    for (const label of ['Overview', 'Examples', 'Raw Artifacts']) {
+    for (const label of ['Documentation', 'Examples', 'Raw Artifacts']) {
       expect(screen.getByRole('tab', { name: label })).toBeTruthy();
     }
     for (const removedTab of ['API', 'Styling', 'Constraints']) {
       expect(screen.queryByRole('tab', { name: removedTab })).toBeNull();
     }
 
+    // Examples is the default tab. Switch to Documentation to verify its content.
+    await fireEvent.click(screen.getByRole('tab', { name: 'Documentation' }));
     await screen.findByText('Fixture purpose for a documentation page.');
     expect(screen.getByText('Rendered README body.')).toBeTruthy();
     expect(screen.queryByRole('heading', { level: 2, name: 'Overview' })).toBeNull();
@@ -220,6 +222,9 @@ describe('component-page documentation tabs', () => {
 
     const { unmount } = render(ComponentPage);
 
+    // Status badge is in the Documentation tab panel — click it first.
+    await fireEvent.click(screen.getByRole('tab', { name: 'Documentation' }));
+    await tick();
     const statusBadge = await screen.findByText('beta');
     expect(statusBadge.getAttribute('data-variant')).toBe('info');
 
@@ -227,18 +232,18 @@ describe('component-page documentation tabs', () => {
     await tick();
   });
 
-  test('keeps tab panels in the DOM and mounts hidden examples on first render', async () => {
+  test('mounts examples on first render (examples is the default tab)', async () => {
     Reflect.set(window, '__CINDER_EXAMPLES__', [{ scenario: 'primary', title: 'Primary' }]);
     Reflect.set(window, '__CINDER_SCENARIOS__', { primary: Probe });
 
     const { unmount } = render(ComponentPage);
     await tick();
 
-    for (const tab of screen.getAllByRole('tab')) {
-      const controlledPanel = tab.getAttribute('aria-controls');
-      expect(typeof controlledPanel).toBe('string');
-      expect(document.getElementById(controlledPanel ?? '')).toBeTruthy();
-    }
+    // Active tab's panel is in DOM; aria-controls points to the panel id.
+    const activeTab = screen.getByRole('tab', { name: 'Examples' });
+    const controlledPanel = activeTab.getAttribute('aria-controls');
+    expect(typeof controlledPanel).toBe('string');
+    expect(document.getElementById(controlledPanel ?? '')).toBeTruthy();
 
     const exampleMount = document.getElementById('example-mount-primary');
     expect(exampleMount).toBeTruthy();
@@ -249,20 +254,18 @@ describe('component-page documentation tabs', () => {
     await tick();
   });
 
-  test('opens the Examples tab by default in snapshot mode', async () => {
-    const happyWindow = window as unknown as { happyDOM: { setURL(url: string): void } };
-    happyWindow.happyDOM.setURL('http://localhost/page/button?snapshot=1');
+  test('opens the Examples tab by default', async () => {
     Reflect.set(window, '__CINDER_EXAMPLES__', [{ scenario: 'primary', title: 'Primary' }]);
     Reflect.set(window, '__CINDER_SCENARIOS__', { primary: Probe });
 
     const { unmount } = render(ComponentPage);
     await tick();
 
-    expect(screen.getByRole('tab', { name: 'Examples' }).getAttribute('aria-selected')).toBe(
-      'true',
-    );
-    expect(document.getElementById('tabpanel-examples')?.hasAttribute('hidden')).toBe(false);
-    expect(document.getElementById('tabpanel-overview')?.hasAttribute('hidden')).toBe(true);
+    const examplesTab = screen.getByRole('tab', { name: 'Examples' });
+    expect(examplesTab.getAttribute('aria-selected')).toBe('true');
+    // Active panel is in DOM; inactive panels are unmounted by Cinder TabPanel.
+    const examplesPanel = document.getElementById(examplesTab.getAttribute('aria-controls') ?? '');
+    expect(examplesPanel).toBeTruthy();
     expect(document.getElementById('example-mount-primary')).toBeTruthy();
 
     unmount();
@@ -271,18 +274,18 @@ describe('component-page documentation tabs', () => {
 
   test('opens a requested documentation tab from the tab query parameter', async () => {
     const happyWindow = window as unknown as { happyDOM: { setURL(url: string): void } };
-    happyWindow.happyDOM.setURL('http://localhost/page/button?tab=examples');
+    happyWindow.happyDOM.setURL('http://localhost/page/button?tab=overview');
     Reflect.set(window, '__CINDER_EXAMPLES__', [{ scenario: 'primary', title: 'Primary' }]);
     Reflect.set(window, '__CINDER_SCENARIOS__', { primary: Probe });
 
     const { unmount } = render(ComponentPage);
     await tick();
 
-    expect(screen.getByRole('tab', { name: 'Examples' }).getAttribute('aria-selected')).toBe(
-      'true',
-    );
-    expect(document.getElementById('tabpanel-examples')?.hasAttribute('hidden')).toBe(false);
-    expect(document.getElementById('tabpanel-overview')?.hasAttribute('hidden')).toBe(true);
+    const docTab = screen.getByRole('tab', { name: 'Documentation' });
+    expect(docTab.getAttribute('aria-selected')).toBe('true');
+    // Active panel is in DOM; inactive panels are unmounted by Cinder TabPanel.
+    const docPanel = document.getElementById(docTab.getAttribute('aria-controls') ?? '');
+    expect(docPanel).toBeTruthy();
 
     unmount();
     await tick();
@@ -290,21 +293,25 @@ describe('component-page documentation tabs', () => {
 
   test('supports ARIA tab keyboard navigation', async () => {
     const { unmount } = render(ComponentPage);
-    await screen.findByText('Fixture purpose for a documentation page.');
+    // Examples tab is active by default; wait for the fetch to populate the panel.
+    await screen.findByText(/No examples found for/);
 
-    const overview = screen.getByRole('tab', { name: 'Overview' });
+    const documentation = screen.getByRole('tab', { name: 'Documentation' });
     const examples = screen.getByRole('tab', { name: 'Examples' });
     const rawArtifacts = screen.getByRole('tab', { name: 'Raw Artifacts' });
 
-    overview.focus();
-    await fireEvent.keyDown(overview, { key: 'ArrowRight' });
+    documentation.focus();
+    await fireEvent.keyDown(documentation, { key: 'ArrowRight' });
+    await tick();
     expect(examples.getAttribute('aria-selected')).toBe('true');
 
     await fireEvent.keyDown(examples, { key: 'End' });
+    await tick();
     expect(rawArtifacts.getAttribute('aria-selected')).toBe('true');
 
     await fireEvent.keyDown(rawArtifacts, { key: 'Home' });
-    expect(overview.getAttribute('aria-selected')).toBe('true');
+    await tick();
+    expect(documentation.getAttribute('aria-selected')).toBe('true');
 
     unmount();
     await tick();

--- a/packages/playground/src/component-page.svelte
+++ b/packages/playground/src/component-page.svelte
@@ -10,6 +10,10 @@
   import { CodeBlock } from '@lostgradient/cinder/code-block';
   import { Skeleton } from '@lostgradient/cinder/skeleton';
   import { Table } from '@lostgradient/cinder/table';
+  import { Tab } from '@lostgradient/cinder/tab';
+  import { TabList } from '@lostgradient/cinder/tab-list';
+  import { TabPanel } from '@lostgradient/cinder/tab-panel';
+  import { Tabs } from '@lostgradient/cinder/tabs';
   import {
     formatErrorForClipboard,
     toMountErrorDetail,
@@ -51,7 +55,7 @@
   };
 
   const documentationTabs: { id: DocumentationTabId; label: string }[] = [
-    { id: 'overview', label: 'Overview' },
+    { id: 'overview', label: 'Documentation' },
     { id: 'examples', label: 'Examples' },
     { id: 'raw-artifacts', label: 'Raw Artifacts' },
   ];
@@ -103,7 +107,7 @@
       parentSearchParams()?.get(documentationTabSearchParam) ??
       null;
     if (isDocumentationTabId(requestedTab)) return requestedTab;
-    return searchParams.get('snapshot') === '1' ? 'examples' : 'overview';
+    return 'examples';
   }
 
   let activeTab: DocumentationTabId = $state(initialDocumentationTab());
@@ -369,55 +373,40 @@
     return JSON.stringify(value, null, 2);
   }
 
-  function documentationTabClass(tab: DocumentationTabId): string {
-    return activeTab === tab ? 'documentation-tab documentation-tab--active' : 'documentation-tab';
-  }
-
   function propsTypeClass(typeMembers: readonly string[]): string {
     return typeMembers.length > 1 ? 'props-type props-type--union' : 'props-type';
-  }
-
-  function focusTab(tab: DocumentationTabId): void {
-    requestAnimationFrame(() => document.getElementById(`tab-${tab}`)?.focus());
   }
 
   function selectTab(tab: DocumentationTabId): void {
     activeTab = tab;
   }
 
-  function selectAndFocusTab(tab: DocumentationTabId): void {
-    activeTab = tab;
-    focusTab(tab);
-  }
+  type ReadmeSegment = { type: 'html'; content: string } | { type: 'code'; index: number };
 
-  function onDocumentationTabKeydown(event: KeyboardEvent): void {
-    const currentIndex = documentationTabs.findIndex((tab) => tab.id === activeTab);
-    if (currentIndex === -1) return;
+  function splitReadmeHtml(html: string): ReadmeSegment[] {
+    const segments: ReadmeSegment[] = [];
+    let codeIndex = 0;
+    let remaining = html;
 
-    const lastIndex = documentationTabs.length - 1;
-    let nextIndex: number | null = null;
-
-    switch (event.key) {
-      case 'ArrowLeft':
-      case 'ArrowUp':
-        nextIndex = currentIndex === 0 ? lastIndex : currentIndex - 1;
+    while (remaining.length > 0) {
+      const preStart = remaining.indexOf('<pre');
+      if (preStart === -1) {
+        segments.push({ type: 'html', content: remaining });
         break;
-      case 'ArrowRight':
-      case 'ArrowDown':
-        nextIndex = currentIndex === lastIndex ? 0 : currentIndex + 1;
+      }
+      if (preStart > 0) {
+        segments.push({ type: 'html', content: remaining.slice(0, preStart) });
+      }
+      const preEnd = remaining.indexOf('</pre>', preStart);
+      if (preEnd === -1) {
+        segments.push({ type: 'html', content: remaining.slice(preStart) });
         break;
-      case 'Home':
-        nextIndex = 0;
-        break;
-      case 'End':
-        nextIndex = lastIndex;
-        break;
-      default:
-        return;
+      }
+      segments.push({ type: 'code', index: codeIndex++ });
+      remaining = remaining.slice(preEnd + 6);
     }
 
-    event.preventDefault();
-    selectAndFocusTab(documentationTabs[nextIndex]!.id);
+    return segments;
   }
 
   function statusBadgeVariant(status: string): BadgeVariant {
@@ -494,32 +483,14 @@
 </script>
 
 <div class="documentation-page">
-  <div class="documentation-tabs" role="tablist" aria-label="Component documentation">
-    {#each documentationTabs as tab (tab.id)}
-      <button
-        type="button"
-        class={documentationTabClass(tab.id)}
-        role="tab"
-        id="tab-{tab.id}"
-        aria-selected={activeTab === tab.id}
-        aria-controls="tabpanel-{tab.id}"
-        tabindex={activeTab === tab.id ? 0 : -1}
-        onclick={() => selectTab(tab.id)}
-        onkeydown={onDocumentationTabKeydown}
-      >
-        {tab.label}
-      </button>
-    {/each}
-  </div>
+  <Tabs bind:value={activeTab} class="documentation-tabs-root">
+    <TabList label="Component documentation" class="documentation-tabs">
+      {#each documentationTabs as tab (tab.id)}
+        <Tab value={tab.id}>{tab.label}</Tab>
+      {/each}
+    </TabList>
 
-  <div
-    class="documentation-panel documentation-panel--overview"
-    id="tabpanel-overview"
-    role="tabpanel"
-    aria-labelledby="tab-overview"
-    hidden={activeTab !== 'overview'}
-  >
-    {#if activeTab === 'overview'}
+    <TabPanel value="overview" class="documentation-panel documentation-panel--overview">
       {#if documentationLoading}
         <div class="documentation-skeleton" aria-hidden="true">
           {#each Array.from({ length: skeletonRowCount }, (_, index) => index) as row (row)}
@@ -615,7 +586,16 @@
 
         <section class="overview-section" aria-label="{documentation.component.name} README">
           <div class="readme-content">
-            {@html documentation.readme.html}
+            {#each splitReadmeHtml(documentation.readme.html) as segment, i (i)}
+              {#if segment.type === 'html'}
+                {@html segment.content}
+              {:else}
+                {@const block = documentation.readme.codeBlocks[segment.index]}
+                {#if block !== undefined}
+                  <CodeBlock code={block.value} language={block.language ?? 'plaintext'} copyable />
+                {/if}
+              {/if}
+            {/each}
           </div>
         </section>
 
@@ -841,157 +821,145 @@
           {/if}
         </section>
       {/if}
-    {/if}
-  </div>
-  <div
-    class="documentation-panel"
-    id="tabpanel-examples"
-    role="tabpanel"
-    aria-labelledby="tab-examples"
-    hidden={activeTab !== 'examples'}
-  >
-    <h2>Examples</h2>
-    <div class="example-list">
-      {#if examples.length === 0}
-        <p class="no-examples">No examples found for <code>{componentName}</code>.</p>
-      {/if}
-
-      {#each examples as { scenario, title, description } (scenario)}
-        {@const accordionEntry = getAccordionEntry(scenario)}
-        {@const source = fetchedSource[scenario]}
-        {@const mountError = mountErrors[scenario]}
-        {@const sourceError = sourceErrors[scenario]}
-        {#if accordionEntry}
-          <section id="example-card-{scenario}" class="example-card-anchor">
-            <Card {title} {...description !== undefined ? { description } : {}}>
-              <div class="example-preview" id="example-mount-{scenario}"></div>
-
-              {#if mountError !== undefined}
-                <div class="example-error">
-                  <Callout variant="danger" title="This example failed to render">
-                    <p class="example-error__message">{mountError.message}</p>
-                    {#if mountError.stack !== undefined}
-                      <pre
-                        class="example-error__stack"
-                        aria-label="Stack trace">{mountError.stack}</pre>
-                    {/if}
-                    <div class="example-error__actions">
-                      <Button
-                        size="sm"
-                        variant="secondary"
-                        aria-label="Copy error for {title}"
-                        onclick={() => copyError(mountError)}
-                      >
-                        Copy error
-                      </Button>
-                    </div>
-                  </Callout>
-                </div>
-              {/if}
-
-              <Accordion bind:expandedIds={accordionEntry.expandedIds}>
-                <AccordionItem id="source" title="View source">
-                  {#if loadingSource[scenario]}
-                    <p class="source-loading">Loading…</p>
-                  {:else if source === null}
-                    <div class="example-error">
-                      <Callout variant="danger" title="Could not load source">
-                        <dl class="example-error__detail">
-                          <dt>Requested</dt>
-                          <dd>
-                            <code>
-                              {sourceError?.url ?? `/example-src/${componentName}/${scenario}`}
-                            </code>
-                          </dd>
-                          <dt>Reason</dt>
-                          <dd>{sourceError?.detail ?? 'Unknown error'}</dd>
-                        </dl>
-                        <div class="example-error__actions">
-                          <Button
-                            size="sm"
-                            variant="secondary"
-                            aria-label="Retry loading source for {title}"
-                            onclick={() => fetchSource(scenario)}
-                          >
-                            Retry
-                          </Button>
-                        </div>
-                      </Callout>
-                    </div>
-                  {:else if source !== undefined}
-                    <CodeBlock code={source} language="svelte" copyable />
-                  {/if}
-                </AccordionItem>
-              </Accordion>
-            </Card>
-          </section>
+    </TabPanel>
+    <TabPanel value="examples" class="documentation-panel">
+      <h2>Examples</h2>
+      <div class="example-list">
+        {#if examples.length === 0}
+          <p class="no-examples">No examples found for <code>{componentName}</code>.</p>
         {/if}
-      {/each}
-    </div>
-  </div>
-  <div
-    class="documentation-panel"
-    id="tabpanel-raw-artifacts"
-    role="tabpanel"
-    aria-labelledby="tab-raw-artifacts"
-    hidden={activeTab !== 'raw-artifacts'}
-  >
-    {#if activeTab === 'raw-artifacts'}
-      <h2>Raw Artifacts</h2>
-      {#if documentationLoading}
-        <div class="documentation-skeleton" aria-hidden="true">
-          {#each Array.from({ length: skeletonRowCount }, (_, index) => index) as row (row)}
-            <Skeleton height="1.5rem" radius="var(--cinder-radius-sm)" />
-          {/each}
-        </div>
-      {:else if documentationError !== null}
-        <p class="props-error">Could not load documentation: {documentationError}</p>
-      {:else if documentation !== null}
-        <div class="raw-artifact-grid">
-          <section class="raw-artifact-panel" aria-labelledby="manifest-entry-heading">
-            <h3 id="manifest-entry-heading">Manifest Entry</h3>
-            <CodeBlock
-              code={jsonBlock(documentation.rawArtifacts.manifestEntry)}
-              language="json"
-              copyable
-            />
-          </section>
-          <section class="raw-artifact-panel" aria-labelledby="schema-artifact-heading">
-            <h3 id="schema-artifact-heading">Schema</h3>
-            <CodeBlock
-              code={jsonBlock(documentation.rawArtifacts.schema)}
-              language="json"
-              copyable
-            />
-          </section>
-          <section class="raw-artifact-panel" aria-labelledby="variables-artifact-heading">
-            <h3 id="variables-artifact-heading">Variables</h3>
-            <CodeBlock
-              code={jsonBlock(documentation.rawArtifacts.variables)}
-              language="json"
-              copyable
-            />
-          </section>
-          <section class="raw-artifact-panel" aria-labelledby="constraints-artifact-heading">
-            <h3 id="constraints-artifact-heading">Constraints</h3>
-            <CodeBlock
-              code={jsonBlock(documentation.rawArtifacts.constraints)}
-              language="json"
-              copyable
-            />
-          </section>
-          <section class="raw-artifact-panel" aria-labelledby="examples-artifact-heading">
-            <h3 id="examples-artifact-heading">Examples</h3>
-            <CodeBlock
-              code={jsonBlock(documentation.rawArtifacts.examples)}
-              language="json"
-              copyable
-            />
-          </section>
-        </div>
+
+        {#each examples as { scenario, title, description } (scenario)}
+          {@const accordionEntry = getAccordionEntry(scenario)}
+          {@const source = fetchedSource[scenario]}
+          {@const mountError = mountErrors[scenario]}
+          {@const sourceError = sourceErrors[scenario]}
+          {#if accordionEntry}
+            <section id="example-card-{scenario}" class="example-card-anchor">
+              <Card {title} {...description !== undefined ? { description } : {}}>
+                <div class="example-preview" id="example-mount-{scenario}"></div>
+
+                {#if mountError !== undefined}
+                  <div class="example-error">
+                    <Callout variant="danger" title="This example failed to render">
+                      <p class="example-error__message">{mountError.message}</p>
+                      {#if mountError.stack !== undefined}
+                        <pre
+                          class="example-error__stack"
+                          aria-label="Stack trace">{mountError.stack}</pre>
+                      {/if}
+                      <div class="example-error__actions">
+                        <Button
+                          size="sm"
+                          variant="secondary"
+                          aria-label="Copy error for {title}"
+                          onclick={() => copyError(mountError)}
+                        >
+                          Copy error
+                        </Button>
+                      </div>
+                    </Callout>
+                  </div>
+                {/if}
+
+                <Accordion bind:expandedIds={accordionEntry.expandedIds}>
+                  <AccordionItem id="source" title="View source">
+                    {#if loadingSource[scenario]}
+                      <p class="source-loading">Loading…</p>
+                    {:else if source === null}
+                      <div class="example-error">
+                        <Callout variant="danger" title="Could not load source">
+                          <dl class="example-error__detail">
+                            <dt>Requested</dt>
+                            <dd>
+                              <code>
+                                {sourceError?.url ?? `/example-src/${componentName}/${scenario}`}
+                              </code>
+                            </dd>
+                            <dt>Reason</dt>
+                            <dd>{sourceError?.detail ?? 'Unknown error'}</dd>
+                          </dl>
+                          <div class="example-error__actions">
+                            <Button
+                              size="sm"
+                              variant="secondary"
+                              aria-label="Retry loading source for {title}"
+                              onclick={() => fetchSource(scenario)}
+                            >
+                              Retry
+                            </Button>
+                          </div>
+                        </Callout>
+                      </div>
+                    {:else if source !== undefined}
+                      <CodeBlock code={source} language="svelte" copyable />
+                    {/if}
+                  </AccordionItem>
+                </Accordion>
+              </Card>
+            </section>
+          {/if}
+        {/each}
+      </div>
+    </TabPanel>
+    <TabPanel value="raw-artifacts" class="documentation-panel">
+      {#if activeTab === 'raw-artifacts'}
+        <h2>Raw Artifacts</h2>
+        {#if documentationLoading}
+          <div class="documentation-skeleton" aria-hidden="true">
+            {#each Array.from({ length: skeletonRowCount }, (_, index) => index) as row (row)}
+              <Skeleton height="1.5rem" radius="var(--cinder-radius-sm)" />
+            {/each}
+          </div>
+        {:else if documentationError !== null}
+          <p class="props-error">Could not load documentation: {documentationError}</p>
+        {:else if documentation !== null}
+          <div class="raw-artifact-grid">
+            <section class="raw-artifact-panel" aria-labelledby="manifest-entry-heading">
+              <h3 id="manifest-entry-heading">Manifest Entry</h3>
+              <CodeBlock
+                code={jsonBlock(documentation.rawArtifacts.manifestEntry)}
+                language="json"
+                copyable
+              />
+            </section>
+            <section class="raw-artifact-panel" aria-labelledby="schema-artifact-heading">
+              <h3 id="schema-artifact-heading">Schema</h3>
+              <CodeBlock
+                code={jsonBlock(documentation.rawArtifacts.schema)}
+                language="json"
+                copyable
+              />
+            </section>
+            <section class="raw-artifact-panel" aria-labelledby="variables-artifact-heading">
+              <h3 id="variables-artifact-heading">Variables</h3>
+              <CodeBlock
+                code={jsonBlock(documentation.rawArtifacts.variables)}
+                language="json"
+                copyable
+              />
+            </section>
+            <section class="raw-artifact-panel" aria-labelledby="constraints-artifact-heading">
+              <h3 id="constraints-artifact-heading">Constraints</h3>
+              <CodeBlock
+                code={jsonBlock(documentation.rawArtifacts.constraints)}
+                language="json"
+                copyable
+              />
+            </section>
+            <section class="raw-artifact-panel" aria-labelledby="examples-artifact-heading">
+              <h3 id="examples-artifact-heading">Examples</h3>
+              <CodeBlock
+                code={jsonBlock(documentation.rawArtifacts.examples)}
+                language="json"
+                copyable
+              />
+            </section>
+          </div>
+        {/if}
       {/if}
-    {/if}
-  </div>
+    </TabPanel>
+  </Tabs>
 </div>
 
 <style>
@@ -1002,7 +970,14 @@
     min-height: 100%;
   }
 
-  .documentation-tabs {
+  :global(.documentation-tabs-root) {
+    display: flex;
+    flex-direction: column;
+    gap: var(--cinder-space-6);
+    min-height: 100%;
+  }
+
+  :global(.documentation-tabs) {
     display: flex;
     align-items: center;
     gap: var(--cinder-space-2);
@@ -1011,79 +986,30 @@
     padding-block-end: var(--cinder-space-2);
   }
 
-  .documentation-tab {
-    appearance: none;
-    border: 1px solid transparent;
-    border-radius: var(--cinder-radius-sm);
-    background: transparent;
-    color: var(--cinder-text-muted);
-    cursor: pointer;
-    flex: 0 0 auto;
-    font: inherit;
-    font-size: var(--cinder-text-sm);
-    font-weight: var(--cinder-font-medium);
-    padding: var(--cinder-space-3) var(--cinder-space-4);
-  }
-
-  @media (hover: hover) {
-    .documentation-tab:hover {
-      color: var(--cinder-text);
-      background: var(--cinder-surface-hover);
-    }
-  }
-
-  .documentation-tab:focus-visible {
-    outline: var(--cinder-ring-width) solid transparent;
-    box-shadow: inset 0 0 0 var(--cinder-ring-width) var(--cinder-ring-color);
-  }
-
-  .documentation-tab--active {
-    background: var(--cinder-surface-inset);
-    color: var(--cinder-text);
-    box-shadow: inset 0 -2px 0 var(--cinder-accent);
-  }
-
-  .documentation-tab--active:focus-visible {
-    box-shadow:
-      inset 0 0 0 var(--cinder-ring-width) var(--cinder-ring-color),
-      inset 0 -2px 0 var(--cinder-accent);
-  }
-
-  @media (forced-colors: active) {
-    .documentation-tab:focus-visible {
-      outline: var(--cinder-ring-width) solid ButtonText;
-      outline-offset: calc(var(--cinder-ring-width) * -1);
-    }
-  }
-
-  .documentation-panel {
+  :global(.documentation-panel) {
     display: flex;
     flex-direction: column;
     gap: var(--cinder-space-6);
     min-width: 0;
   }
 
-  .documentation-panel[hidden] {
-    display: none;
-  }
-
-  .documentation-panel h2,
-  .documentation-panel h3,
-  .documentation-panel h4 {
+  :global(.documentation-panel h2),
+  :global(.documentation-panel h3),
+  :global(.documentation-panel h4) {
     color: var(--cinder-text);
     font-weight: var(--cinder-font-semibold);
     margin: 0;
   }
 
-  .documentation-panel h2 {
+  :global(.documentation-panel h2) {
     font-size: var(--cinder-text-xl);
   }
 
-  .documentation-panel h3 {
+  :global(.documentation-panel h3) {
     font-size: var(--cinder-text-lg);
   }
 
-  .documentation-panel h4 {
+  :global(.documentation-panel h4) {
     font-size: var(--cinder-text-base);
   }
 
@@ -1266,7 +1192,6 @@
   .readme-content :global(p),
   .readme-content :global(ul),
   .readme-content :global(ol),
-  .readme-content :global(pre),
   .readme-content :global(table) {
     margin: 0 0 var(--cinder-space-4);
   }
@@ -1276,7 +1201,6 @@
     font-size: 0.95em;
   }
 
-  .readme-content :global(pre),
   .readme-content :global(table) {
     overflow-x: auto;
   }

--- a/packages/playground/src/component-page.svelte
+++ b/packages/playground/src/component-page.svelte
@@ -242,6 +242,11 @@
   // every scenario for this component together with this page, sharing one
   // Svelte runtime, and exposes the components on window.__CINDER_SCENARIOS__.
   $effect(() => {
+    // Depend on activeTab so the effect reruns when the Examples panel mounts
+    // (e.g. if the user loads with ?tab=overview, the containers don't exist
+    // on first run — re-tracking means we retry once Examples becomes active).
+    if (activeTab !== 'examples') return;
+
     // Per-run local collection so the cleanup only unmounts this run's mounts.
     // Svelte 5 disposal is unmount(component), not component.destroy().
     const localApps: ReturnType<typeof mount>[] = [];

--- a/packages/playground/src/component-page.svelte
+++ b/packages/playground/src/component-page.svelte
@@ -572,7 +572,7 @@
                 {#if block !== undefined}
                   <CodeBlock code={block.value} language={block.language ?? 'plaintext'} copyable />
                 {:else}
-                  {@html segment.fallbackHtml}
+                  <div class="readme-pre-fallback">{@html segment.fallbackHtml}</div>
                 {/if}
               {/if}
             {/each}
@@ -1172,6 +1172,18 @@
   .readme-content :global(ol),
   .readme-content :global(table) {
     margin: 0 0 var(--cinder-space-4);
+  }
+
+  /* CodeBlock and its fallback get the same bottom-margin as prose elements
+   * so code-to-paragraph transitions don't collapse. The fallback wrapper also
+   * provides an overflow-x scroll container for wide pre blocks. */
+  .readme-content :global(.cinder-code-block),
+  .readme-pre-fallback {
+    margin-block-end: var(--cinder-space-4);
+  }
+
+  .readme-pre-fallback {
+    overflow-x: auto;
   }
 
   .readme-content :global(code) {

--- a/packages/playground/src/component-page.svelte
+++ b/packages/playground/src/component-page.svelte
@@ -14,6 +14,7 @@
   import { TabList } from '@lostgradient/cinder/tab-list';
   import { TabPanel } from '@lostgradient/cinder/tab-panel';
   import { Tabs } from '@lostgradient/cinder/tabs';
+  import { splitReadmeHtml } from './split-readme-html.ts';
   import {
     formatErrorForClipboard,
     toMountErrorDetail,
@@ -381,34 +382,6 @@
     activeTab = tab;
   }
 
-  type ReadmeSegment = { type: 'html'; content: string } | { type: 'code'; index: number };
-
-  function splitReadmeHtml(html: string): ReadmeSegment[] {
-    const segments: ReadmeSegment[] = [];
-    let codeIndex = 0;
-    let remaining = html;
-
-    while (remaining.length > 0) {
-      const preStart = remaining.indexOf('<pre');
-      if (preStart === -1) {
-        segments.push({ type: 'html', content: remaining });
-        break;
-      }
-      if (preStart > 0) {
-        segments.push({ type: 'html', content: remaining.slice(0, preStart) });
-      }
-      const preEnd = remaining.indexOf('</pre>', preStart);
-      if (preEnd === -1) {
-        segments.push({ type: 'html', content: remaining.slice(preStart) });
-        break;
-      }
-      segments.push({ type: 'code', index: codeIndex++ });
-      remaining = remaining.slice(preEnd + 6);
-    }
-
-    return segments;
-  }
-
   function statusBadgeVariant(status: string): BadgeVariant {
     switch (status) {
       case 'stable':
@@ -593,6 +566,8 @@
                 {@const block = documentation.readme.codeBlocks[segment.index]}
                 {#if block !== undefined}
                   <CodeBlock code={block.value} language={block.language ?? 'plaintext'} copyable />
+                {:else}
+                  {@html segment.fallbackHtml}
                 {/if}
               {/if}
             {/each}
@@ -903,60 +878,58 @@
       </div>
     </TabPanel>
     <TabPanel value="raw-artifacts" class="documentation-panel">
-      {#if activeTab === 'raw-artifacts'}
-        <h2>Raw Artifacts</h2>
-        {#if documentationLoading}
-          <div class="documentation-skeleton" aria-hidden="true">
-            {#each Array.from({ length: skeletonRowCount }, (_, index) => index) as row (row)}
-              <Skeleton height="1.5rem" radius="var(--cinder-radius-sm)" />
-            {/each}
-          </div>
-        {:else if documentationError !== null}
-          <p class="props-error">Could not load documentation: {documentationError}</p>
-        {:else if documentation !== null}
-          <div class="raw-artifact-grid">
-            <section class="raw-artifact-panel" aria-labelledby="manifest-entry-heading">
-              <h3 id="manifest-entry-heading">Manifest Entry</h3>
-              <CodeBlock
-                code={jsonBlock(documentation.rawArtifacts.manifestEntry)}
-                language="json"
-                copyable
-              />
-            </section>
-            <section class="raw-artifact-panel" aria-labelledby="schema-artifact-heading">
-              <h3 id="schema-artifact-heading">Schema</h3>
-              <CodeBlock
-                code={jsonBlock(documentation.rawArtifacts.schema)}
-                language="json"
-                copyable
-              />
-            </section>
-            <section class="raw-artifact-panel" aria-labelledby="variables-artifact-heading">
-              <h3 id="variables-artifact-heading">Variables</h3>
-              <CodeBlock
-                code={jsonBlock(documentation.rawArtifacts.variables)}
-                language="json"
-                copyable
-              />
-            </section>
-            <section class="raw-artifact-panel" aria-labelledby="constraints-artifact-heading">
-              <h3 id="constraints-artifact-heading">Constraints</h3>
-              <CodeBlock
-                code={jsonBlock(documentation.rawArtifacts.constraints)}
-                language="json"
-                copyable
-              />
-            </section>
-            <section class="raw-artifact-panel" aria-labelledby="examples-artifact-heading">
-              <h3 id="examples-artifact-heading">Examples</h3>
-              <CodeBlock
-                code={jsonBlock(documentation.rawArtifacts.examples)}
-                language="json"
-                copyable
-              />
-            </section>
-          </div>
-        {/if}
+      <h2>Raw Artifacts</h2>
+      {#if documentationLoading}
+        <div class="documentation-skeleton" aria-hidden="true">
+          {#each Array.from({ length: skeletonRowCount }, (_, index) => index) as row (row)}
+            <Skeleton height="1.5rem" radius="var(--cinder-radius-sm)" />
+          {/each}
+        </div>
+      {:else if documentationError !== null}
+        <p class="props-error">Could not load documentation: {documentationError}</p>
+      {:else if documentation !== null}
+        <div class="raw-artifact-grid">
+          <section class="raw-artifact-panel" aria-labelledby="manifest-entry-heading">
+            <h3 id="manifest-entry-heading">Manifest Entry</h3>
+            <CodeBlock
+              code={jsonBlock(documentation.rawArtifacts.manifestEntry)}
+              language="json"
+              copyable
+            />
+          </section>
+          <section class="raw-artifact-panel" aria-labelledby="schema-artifact-heading">
+            <h3 id="schema-artifact-heading">Schema</h3>
+            <CodeBlock
+              code={jsonBlock(documentation.rawArtifacts.schema)}
+              language="json"
+              copyable
+            />
+          </section>
+          <section class="raw-artifact-panel" aria-labelledby="variables-artifact-heading">
+            <h3 id="variables-artifact-heading">Variables</h3>
+            <CodeBlock
+              code={jsonBlock(documentation.rawArtifacts.variables)}
+              language="json"
+              copyable
+            />
+          </section>
+          <section class="raw-artifact-panel" aria-labelledby="constraints-artifact-heading">
+            <h3 id="constraints-artifact-heading">Constraints</h3>
+            <CodeBlock
+              code={jsonBlock(documentation.rawArtifacts.constraints)}
+              language="json"
+              copyable
+            />
+          </section>
+          <section class="raw-artifact-panel" aria-labelledby="examples-artifact-heading">
+            <h3 id="examples-artifact-heading">Examples</h3>
+            <CodeBlock
+              code={jsonBlock(documentation.rawArtifacts.examples)}
+              language="json"
+              copyable
+            />
+          </section>
+        </div>
       {/if}
     </TabPanel>
   </Tabs>

--- a/packages/playground/src/playground-server.ts
+++ b/packages/playground/src/playground-server.ts
@@ -1235,7 +1235,7 @@ async function renderComponentPage(componentName: string, snapshotMode: boolean)
       *, *::before, *::after { box-sizing: border-box; }
       html, body { margin: 0; padding: 0; min-height: 100%; }
       body {
-        background-color: var(--cinder-surface-raised);
+        background-color: var(--cinder-bg);
         color: var(--cinder-text);
         font-family: var(--cinder-font-sans);
         font-size: var(--cinder-text-base);
@@ -1287,7 +1287,7 @@ function renderFixturePageHtml(
       *, *::before, *::after { box-sizing: border-box; }
       html, body { margin: 0; padding: 0; min-height: 100%; }
       body {
-        background-color: var(--cinder-surface-raised);
+        background-color: var(--cinder-bg);
         color: var(--cinder-text);
         font-family: var(--cinder-font-sans);
         font-size: var(--cinder-text-base);

--- a/packages/playground/src/playground-server.ts
+++ b/packages/playground/src/playground-server.ts
@@ -1235,7 +1235,7 @@ async function renderComponentPage(componentName: string, snapshotMode: boolean)
       *, *::before, *::after { box-sizing: border-box; }
       html, body { margin: 0; padding: 0; min-height: 100%; }
       body {
-        background-color: var(--cinder-bg);
+        background-color: var(--cinder-surface-raised);
         color: var(--cinder-text);
         font-family: var(--cinder-font-sans);
         font-size: var(--cinder-text-base);
@@ -1287,7 +1287,7 @@ function renderFixturePageHtml(
       *, *::before, *::after { box-sizing: border-box; }
       html, body { margin: 0; padding: 0; min-height: 100%; }
       body {
-        background-color: var(--cinder-bg);
+        background-color: var(--cinder-surface-raised);
         color: var(--cinder-text);
         font-family: var(--cinder-font-sans);
         font-size: var(--cinder-text-base);

--- a/packages/playground/src/render-shell.ts
+++ b/packages/playground/src/render-shell.ts
@@ -240,7 +240,7 @@ export function renderShell(
       body {
         font-family: var(--cinder-font-sans);
         font-size: var(--cinder-text-base);
-        background: var(--cinder-bg);
+        background: var(--cinder-surface-raised);
         color: var(--cinder-text);
       }
     </style>

--- a/packages/playground/src/shell-app/shell.svelte
+++ b/packages/playground/src/shell-app/shell.svelte
@@ -334,7 +334,7 @@
     height: 100vh;
     font-family: var(--cinder-font-sans);
     font-size: var(--cinder-text-base);
-    background: var(--cinder-bg);
+    background: var(--cinder-surface-raised);
     color: var(--cinder-text);
   }
 

--- a/packages/playground/src/split-readme-html.test.ts
+++ b/packages/playground/src/split-readme-html.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, test } from 'bun:test';
+
+import { splitReadmeHtml } from './split-readme-html.ts';
+
+describe('splitReadmeHtml', () => {
+  test('returns single html segment when no <pre> blocks present', () => {
+    const html = '<h1>Title</h1><p>Some prose.</p>';
+    expect(splitReadmeHtml(html)).toEqual([{ type: 'html', content: html }]);
+  });
+
+  test('returns empty array for empty string', () => {
+    expect(splitReadmeHtml('')).toEqual([]);
+  });
+
+  test('splits a single <pre> block with surrounding prose', () => {
+    const html = '<p>Before</p><pre class="shiki"><code>foo</code></pre><p>After</p>';
+    expect(splitReadmeHtml(html)).toEqual([
+      { type: 'html', content: '<p>Before</p>' },
+      {
+        type: 'code',
+        index: 0,
+        fallbackHtml: '<pre class="shiki"><code>foo</code></pre>',
+      },
+      { type: 'html', content: '<p>After</p>' },
+    ]);
+  });
+
+  test('splits multiple <pre> blocks and increments index', () => {
+    const html = '<pre><code>a</code></pre><p>middle</p><pre><code>b</code></pre>';
+    expect(splitReadmeHtml(html)).toEqual([
+      { type: 'code', index: 0, fallbackHtml: '<pre><code>a</code></pre>' },
+      { type: 'html', content: '<p>middle</p>' },
+      { type: 'code', index: 1, fallbackHtml: '<pre><code>b</code></pre>' },
+    ]);
+  });
+
+  test('handles adjacent <pre> blocks with no intervening HTML', () => {
+    const html = '<pre><code>a</code></pre><pre><code>b</code></pre>';
+    expect(splitReadmeHtml(html)).toEqual([
+      { type: 'code', index: 0, fallbackHtml: '<pre><code>a</code></pre>' },
+      { type: 'code', index: 1, fallbackHtml: '<pre><code>b</code></pre>' },
+    ]);
+  });
+
+  test('treats unclosed <pre> (no </pre>) as trailing html segment', () => {
+    const html = '<p>Before</p><pre><code>unclosed';
+    expect(splitReadmeHtml(html)).toEqual([
+      { type: 'html', content: '<p>Before</p>' },
+      { type: 'html', content: '<pre><code>unclosed' },
+    ]);
+  });
+
+  test('handles leading <pre> with no preceding prose', () => {
+    const html = '<pre><code>first</code></pre><p>after</p>';
+    expect(splitReadmeHtml(html)).toEqual([
+      { type: 'code', index: 0, fallbackHtml: '<pre><code>first</code></pre>' },
+      { type: 'html', content: '<p>after</p>' },
+    ]);
+  });
+
+  test('handles trailing <pre> with no following prose', () => {
+    const html = '<p>before</p><pre><code>last</code></pre>';
+    expect(splitReadmeHtml(html)).toEqual([
+      { type: 'html', content: '<p>before</p>' },
+      { type: 'code', index: 0, fallbackHtml: '<pre><code>last</code></pre>' },
+    ]);
+  });
+
+  test('fallbackHtml captures the exact <pre>...</pre> slice', () => {
+    const preBlock =
+      '<pre class="shiki" style="background:#fff"><code><span>hello</span></code></pre>';
+    const html = `<p>intro</p>${preBlock}<p>outro</p>`;
+    const segments = splitReadmeHtml(html);
+    const codeSegment = segments.find((s) => s.type === 'code');
+    expect(codeSegment).toBeDefined();
+    if (codeSegment?.type === 'code') {
+      expect(codeSegment.fallbackHtml).toBe(preBlock);
+    }
+  });
+});

--- a/packages/playground/src/split-readme-html.ts
+++ b/packages/playground/src/split-readme-html.ts
@@ -1,0 +1,43 @@
+export type ReadmeSegment =
+  | { type: 'html'; content: string }
+  | { type: 'code'; index: number; fallbackHtml: string };
+
+/**
+ * Split rendered README HTML into alternating prose and code segments.
+ *
+ * Each `<pre>...</pre>` block is replaced by a `{ type: 'code' }` entry whose
+ * `index` corresponds to the matching entry in `readme.codeBlocks[]`. If no
+ * matching `codeBlocks` entry exists at render time, `fallbackHtml` contains
+ * the original `<pre>` HTML so the content is preserved rather than silently
+ * dropped.
+ *
+ * The split is string-based and assumes each `<pre>` in the rendered HTML
+ * corresponds one-to-one in order with the `codeBlocks[]` array — which holds
+ * for markdown-rendered READMEs where Shiki generates all `<pre>` blocks.
+ */
+export function splitReadmeHtml(html: string): ReadmeSegment[] {
+  const segments: ReadmeSegment[] = [];
+  let codeIndex = 0;
+  let remaining = html;
+
+  while (remaining.length > 0) {
+    const preStart = remaining.indexOf('<pre');
+    if (preStart === -1) {
+      segments.push({ type: 'html', content: remaining });
+      break;
+    }
+    if (preStart > 0) {
+      segments.push({ type: 'html', content: remaining.slice(0, preStart) });
+    }
+    const preEnd = remaining.indexOf('</pre>', preStart);
+    if (preEnd === -1) {
+      segments.push({ type: 'html', content: remaining.slice(preStart) });
+      break;
+    }
+    const fallbackHtml = remaining.slice(preStart, preEnd + 6);
+    segments.push({ type: 'code', index: codeIndex++, fallbackHtml });
+    remaining = remaining.slice(preEnd + 6);
+  }
+
+  return segments;
+}

--- a/packages/playground/src/split-readme-html.ts
+++ b/packages/playground/src/split-readme-html.ts
@@ -34,9 +34,10 @@ export function splitReadmeHtml(html: string): ReadmeSegment[] {
       segments.push({ type: 'html', content: remaining.slice(preStart) });
       break;
     }
-    const fallbackHtml = remaining.slice(preStart, preEnd + 6);
+    const closeTag = '</pre>';
+    const fallbackHtml = remaining.slice(preStart, preEnd + closeTag.length);
     segments.push({ type: 'code', index: codeIndex++, fallbackHtml });
-    remaining = remaining.slice(preEnd + 6);
+    remaining = remaining.slice(preEnd + closeTag.length);
   }
 
   return segments;

--- a/packages/testing/tests/playground-documentation.playwright.ts
+++ b/packages/testing/tests/playground-documentation.playwright.ts
@@ -5,15 +5,16 @@ test.describe('playground component documentation', () => {
     await page.goto('/c/button', { waitUntil: 'load' });
     const preview = page.frameLocator('iframe[data-cinder-preview]');
 
-    for (const tabName of ['Overview', 'Examples', 'Raw Artifacts']) {
+    for (const tabName of ['Documentation', 'Examples', 'Raw Artifacts']) {
       await expect(preview.getByRole('tab', { name: tabName })).toBeVisible();
     }
     for (const removedTab of ['API', 'Styling', 'Constraints']) {
       await expect(preview.getByRole('tab', { name: removedTab })).toHaveCount(0);
     }
 
+    // Switch to Documentation tab to verify its content (Examples is the default tab).
+    await preview.getByRole('tab', { name: 'Documentation' }).click();
     await expect(preview.getByRole('heading', { name: 'Button' })).toBeVisible();
-    await expect(preview.getByRole('heading', { name: 'Overview' })).toHaveCount(0);
     await expect(preview.getByRole('heading', { name: 'API' })).toBeVisible();
     await expect(preview.getByRole('heading', { name: 'JSON Schema' })).toBeVisible();
     await expect(preview.getByRole('heading', { name: 'Constraints' })).toBeVisible();
@@ -36,6 +37,8 @@ test.describe('playground component documentation', () => {
     await page.goto('/c/avatar-group', { waitUntil: 'load' });
     const preview = page.frameLocator('iframe[data-cinder-preview]');
 
+    // Switch to Documentation tab (Examples is the default tab).
+    await preview.getByRole('tab', { name: 'Documentation' }).click();
     await expect(preview.getByRole('heading', { name: 'Styling' })).toBeVisible();
     await expect(
       preview.locator('.variable-list code', { hasText: '--cinder-avatar-group-overlap' }),

--- a/packages/testing/tests/playground-page-chrome-focus-rings.playwright.ts
+++ b/packages/testing/tests/playground-page-chrome-focus-rings.playwright.ts
@@ -167,7 +167,7 @@ async function showButtonExamplesTab(frame: Frame): Promise<Locator> {
 }
 
 async function showButtonOverviewApiSection(frame: Frame): Promise<Locator> {
-  await frame.getByRole('tab', { name: 'Overview' }).click();
+  await frame.getByRole('tab', { name: 'Documentation' }).click();
   const propsTableScroll = frame.locator('.props-table-scroll').first();
   const propsTableCount = await frame.locator('.props-table-scroll').count();
   expect(


### PR DESCRIPTION
## Summary

- **White background**: Replace `--cinder-bg` (grey-blue) with `--cinder-surface-raised` (white) in `render-shell.ts`, `playground-server.ts`, and `shell.svelte`
- **Cinder tabs**: Replace hand-rolled `tablist`/`tab`/`tabpanel` markup (custom keyboard handler, manual `hidden` attributes) with Cinder `Tabs`/`TabList`/`Tab`/`TabPanel` components — full WAI-ARIA keyboard nav included
- **Rename + default tab**: "Overview" → "Documentation"; Examples is now the default tab instead of Documentation
- **Fix code rendering**: README code blocks were double-encoding HTML entities (`&#x3C;` showing as literal text). Fixed by splitting rendered HTML on `<pre>` boundaries via `splitReadmeHtml()` and rendering each code block with Cinder `CodeBlock` using the raw unescaped `codeBlocks[].value` from the API — no markdown pipeline changes needed
- **splitReadmeHtml extracted + tested**: Pure function extracted to `split-readme-html.ts` with 9 unit tests covering all branches (no-pre, single, multiple, adjacent, unclosed, leading, trailing, fallback, empty)
- **Fallback for missing codeBlocks**: If the API returns fewer `codeBlocks[]` entries than `<pre>` blocks found, the original `<pre>` HTML is rendered as fallback instead of silently dropping content

## Test plan

- [ ] All pre-existing tests pass (608 total, 0 fail)
- [ ] `splitReadmeHtml` unit tests: 9/9 pass
- [ ] Documentation tab: purpose text, status badge, README code blocks render correctly (no `&#x3C;` entities)
- [ ] Examples tab is the default on page load
- [ ] Tab keyboard navigation: ArrowRight/Left/Home/End all switch tabs correctly
- [ ] Background is crisp white (not grey) in both light and dark mode
- [ ] Raw Artifacts tab renders JSON code blocks correctly

/cc @copilot

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Playground UI and documentation rendering only; no auth, data, or API contract changes beyond tab labels and default selection.
> 
> **Overview**
> Refreshes the playground component documentation page UX: **Examples** is now the default tab (unless `?tab=` overrides), the former **Overview** tab is labeled **Documentation**, and hand-rolled tab markup is replaced with Cinder **`Tabs` / `TabList` / `Tab` / `TabPanel`** (inactive panels unmount instead of staying `hidden` in the DOM).
> 
> README rendering no longer dumps a single `{@html}` blob for code fences. **`splitReadmeHtml()`** splits HTML on `<pre>` boundaries and renders each block with **`CodeBlock`** from `readme.codeBlocks[]`, with original `<pre>` HTML as fallback when indices are missing—fixing double-encoded entity display in prose.
> 
> Shell chrome switches page background from **`--cinder-bg`** to **`--cinder-surface-raised`**. Example-mount **`$effect`** now depends on **`activeTab`** so mounts retry when the Examples panel appears after loading on a non-default tab. Unit, component-page, and Playwright tests are updated for the new tab names and default tab; **`@lostgradient/cinder`** lockfile version bumps to **0.2.0**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 733da7099509de6e35880a7835c2f91793ec131c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->