### PR TITLE
chore: guard the release manifest + styles aggregator

### DIFF
--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -140,6 +140,14 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
+      # Unconditional whole-repo invariant: every component CSS partial must be
+      # reachable from the aggregate styles/components.css @import chain, or the
+      # component ships UNSTYLED to `/styles` consumers. Runs regardless of scope
+      # because the gap can be introduced by a CSS-file change while the checker's
+      # own test file is unchanged (so `test:changed` would miss it). Sub-second.
+      - name: Check styles aggregator completeness
+        run: bun run --filter=@lostgradient/cinder aggregator:check
+
       - name: Run component unit tests (scoped)
         # Scopes the `@lostgradient/cinder` (components) package to the changed components and
         # their dependents. Sibling @cinder/* package suites are intentionally

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "changeset": "changeset",
     "changeset:publish": "changeset publish",
     "changeset:publish:dry": "bun run --filter=@lostgradient/cinder validate:consumer && bun run --filter=@lostgradient/cinder publish:release -- --dry-run --skip-validation",
-    "changeset:version": "changeset version",
+    "changeset:version": "changeset version && bun run --filter=@lostgradient/cinder components:generate",
     "clean": "bun run --filter='*' clean",
     "dev": "bun run --filter='@cinder/playground' dev",
     "format": "prettier --write \"**/*.{ts,tsx,svelte,js,jsx,json,md,css}\"",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -3886,6 +3886,7 @@
     "examples-exclusions.json"
   ],
   "scripts": {
+    "aggregator:check": "bun run scripts/check-aggregator-completeness.ts",
     "build": "bun run scripts/build.ts",
     "check:no-bare-console-warn": "bun run scripts/check-no-bare-console-warn.ts",
     "check:no-cycle-imports": "bun run scripts/check-no-cycle-imports.ts",
@@ -3919,7 +3920,7 @@
     "test:coverage": "TZ=UTC LANG=en_US.UTF-8 bun test --conditions browser --conditions svelte --parallel=1 --coverage --coverage-reporter=lcov && bun run scripts/check-coverage-ratchet.ts",
     "tokens:audit": "bun run scripts/check-component-css-token-usage.ts",
     "typecheck": "tsc --noEmit -p tsconfig.check.json && bunx svelte-check --workspace src --tsconfig ../tsconfig.json --threshold error",
-    "validate": "bun run lint && bun run typecheck && bun run check:placeholder-docs && bun run test:coverage && bun run platform:audit -- --strict && bun run colors:audit -- --strict && bun run tokens:audit -- --strict && bun run validate:workflow && bun run validate:svelte-peer && bun run validate:consumer && bun run package:weight:check -- --existing-tarball",
+    "validate": "bun run lint && bun run typecheck && bun run check:placeholder-docs && bun run test:coverage && bun run platform:audit -- --strict && bun run colors:audit -- --strict && bun run tokens:audit -- --strict && bun run aggregator:check && bun run validate:workflow && bun run validate:svelte-peer && bun run validate:consumer && bun run package:weight:check -- --existing-tarball",
     "validate:consumer": "bun run scripts/validate-consumers.ts",
     "validate:release-workflow": "bun run scripts/validate-release-workflow.ts",
     "validate:svelte-peer": "bun run scripts/validate-svelte-peer-contract.ts",

--- a/packages/components/scripts/check-aggregator-completeness.test.ts
+++ b/packages/components/scripts/check-aggregator-completeness.test.ts
@@ -175,6 +175,65 @@ describe('computeImportClosure', () => {
     expect(reachable.has(join(componentsDirectory, 'alpha/alpha.css'))).toBe(true);
     expect(reachable.has(join(componentsDirectory, 'beta/beta.css'))).toBe(true);
   });
+
+  // CSS only honors @import at the top level of the stylesheet prelude. An import
+  // nested inside @media (or @supports) is NOT applied by the bundle, so counting
+  // it would be a false-pass — exactly what walkAtRules() would have done.
+  it('does NOT follow an @import nested inside @media', () => {
+    const { componentsDirectory, aggregatorFile } = makeFixture({
+      components: ['alpha', 'beta'],
+      aggregatorImports: ['../components/alpha/alpha.css'],
+      extraFiles: [
+        {
+          path: 'alpha/alpha.css',
+          content: `@media (min-width: 1px) {\n  @import '../beta/beta.css';\n}\n.cinder-alpha {}\n`,
+        },
+      ],
+    });
+
+    const reachable = computeImportClosure(aggregatorFile);
+    expect(reachable.has(join(componentsDirectory, 'beta/beta.css'))).toBe(false);
+  });
+
+  // A @import that appears AFTER a style rule is past the prelude and is ignored
+  // by the bundle — it must not count as coverage.
+  it('does NOT follow a late @import after a style rule', () => {
+    const { componentsDirectory, aggregatorFile } = makeFixture({
+      components: ['alpha', 'beta'],
+      aggregatorImports: ['../components/alpha/alpha.css'],
+      extraFiles: [
+        {
+          path: 'alpha/alpha.css',
+          content: `.cinder-alpha {}\n@import '../beta/beta.css';\n`,
+        },
+      ],
+    });
+
+    const reachable = computeImportClosure(aggregatorFile);
+    expect(reachable.has(join(componentsDirectory, 'beta/beta.css'))).toBe(false);
+  });
+
+  // The real cinder partials open with a `@layer …;` statement prelude before
+  // their sibling-leaf @import (e.g. command-menu.css). That statement must NOT
+  // end the prelude, so the @import after it is still honored.
+  it('honors an @import that follows a leading @layer statement', () => {
+    const { componentsDirectory, aggregatorFile } = makeFixture({
+      components: ['alpha', 'beta'],
+      aggregatorImports: ['../components/alpha/alpha.css'],
+      extraFiles: [
+        {
+          path: 'alpha/alpha.css',
+          content:
+            `@layer cinder.tokens, cinder.components;\n` +
+            `@import '../beta/beta.css';\n` +
+            `@layer cinder.components {\n  .cinder-alpha {}\n}\n`,
+        },
+      ],
+    });
+
+    const reachable = computeImportClosure(aggregatorFile);
+    expect(reachable.has(join(componentsDirectory, 'beta/beta.css'))).toBe(true);
+  });
 });
 
 describe('checkAggregatorCompleteness', () => {

--- a/packages/components/scripts/check-aggregator-completeness.test.ts
+++ b/packages/components/scripts/check-aggregator-completeness.test.ts
@@ -27,11 +27,12 @@ afterEach(() => {
 
 /**
  * Build a throwaway component tree on disk: a `components/` directory with one
- * `<name>/<name>.css` per entry, plus a `styles/components.css` aggregator that
- * imports the given names. Extra raw files can be dropped in per component to
- * model sub-component partials, nested partials, and JS-only imports. The
- * aggregator import lines are written verbatim, so a caller can pass a
- * commented-out or `url(...)`-wrapped specifier to exercise the parser.
+ * `<name>/<name>.css` per entry, plus a `styles/components.css` aggregator. Each
+ * `aggregatorImports` entry is emitted as `@import '<specifier>';` (quoted bare
+ * form). Extra raw files can be dropped in per component to model sub-component
+ * partials, nested partials, and JS-only imports. Tests that need a non-standard
+ * aggregator (a commented-out or `url(...)`-wrapped import) write the
+ * `components.css` themselves rather than going through `aggregatorImports`.
  */
 function makeFixture(options: {
   components: string[];
@@ -313,7 +314,11 @@ describe('checkAggregatorCompleteness', () => {
     });
 
     const violations = checkAggregatorCompleteness(componentsDirectory, aggregatorFile);
+    // Reported with forward slashes (a multi-segment path), never backslashes —
+    // so the value is stable across platforms and matches the POSIX-keyed
+    // exclusion list on Windows too.
     expect(violations.map((violation) => violation.path)).toEqual(['alpha/internal/extra.css']);
+    expect(violations[0]?.path).not.toContain('\\');
   });
 
   it('treats a second component CSS file as covered when the first @imports it', () => {

--- a/packages/components/scripts/check-aggregator-completeness.test.ts
+++ b/packages/components/scripts/check-aggregator-completeness.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, it } from 'bun:test';
-import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
+import { afterEach, describe, expect, it } from 'bun:test';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -16,11 +16,22 @@ const componentsSource = join(componentsRoot, 'src');
 const realComponentsDirectory = join(componentsSource, 'components');
 const realAggregator = join(componentsSource, 'styles', 'components.css');
 
+// Track every temp tree so it's removed after each test — otherwise repeated
+// local + CI runs leak fixture directories into the system temp dir.
+const fixtureRoots: string[] = [];
+afterEach(() => {
+  while (fixtureRoots.length > 0) {
+    rmSync(fixtureRoots.pop()!, { recursive: true, force: true });
+  }
+});
+
 /**
  * Build a throwaway component tree on disk: a `components/` directory with one
  * `<name>/<name>.css` per entry, plus a `styles/components.css` aggregator that
  * imports the given names. Extra raw files can be dropped in per component to
- * model sub-component partials and JS-only imports.
+ * model sub-component partials, nested partials, and JS-only imports. The
+ * aggregator import lines are written verbatim, so a caller can pass a
+ * commented-out or `url(...)`-wrapped specifier to exercise the parser.
  */
 function makeFixture(options: {
   components: string[];
@@ -28,6 +39,7 @@ function makeFixture(options: {
   extraFiles?: Array<{ path: string; content: string }>;
 }): { componentsDirectory: string; aggregatorFile: string } {
   const root = mkdtempSync(join(tmpdir(), 'aggregator-gate-'));
+  fixtureRoots.push(root);
   const componentsDirectory = join(root, 'components');
   const stylesDirectory = join(root, 'styles');
   mkdirSync(stylesDirectory, { recursive: true });
@@ -92,6 +104,77 @@ describe('computeImportClosure', () => {
     // Nothing outside the relative graph leaked in.
     expect([...reachable].some((file) => file.includes('some-package'))).toBe(false);
   });
+
+  // The parser must NOT count a commented-out @import as coverage. A regex would
+  // treat `/* @import '…'; */` as real and let an unstyled component pass the
+  // gate — the exact false-pass this gate exists to prevent. postcss parses it
+  // as a comment node, so the closure never reaches it.
+  it('does NOT count a commented-out @import as coverage', () => {
+    const root = mkdtempSync(join(tmpdir(), 'aggregator-gate-'));
+    fixtureRoots.push(root);
+    const stylesDirectory = join(root, 'styles');
+    mkdirSync(stylesDirectory, { recursive: true });
+    const componentsDirectory = join(root, 'components');
+    mkdirSync(join(componentsDirectory, 'beta'), { recursive: true });
+    writeFileSync(join(componentsDirectory, 'beta', 'beta.css'), '.cinder-beta {}\n');
+    const aggregatorFile = join(stylesDirectory, 'components.css');
+    writeFileSync(aggregatorFile, `/* @import '../components/beta/beta.css'; */\n`);
+
+    const reachable = computeImportClosure(aggregatorFile);
+    expect(reachable.has(join(componentsDirectory, 'beta', 'beta.css'))).toBe(false);
+  });
+
+  it('follows the unquoted and quoted url(...) @import forms', () => {
+    const { componentsDirectory, aggregatorFile } = makeFixture({
+      components: ['alpha', 'beta', 'gamma'],
+      aggregatorImports: ['../components/alpha/alpha.css'],
+      extraFiles: [
+        {
+          path: 'alpha/alpha.css',
+          content:
+            `@import url(../beta/beta.css);\n` +
+            `@import url('../gamma/gamma.css');\n` +
+            `.cinder-alpha {}\n`,
+        },
+      ],
+    });
+
+    const reachable = computeImportClosure(aggregatorFile);
+    expect(reachable.has(join(componentsDirectory, 'beta/beta.css'))).toBe(true);
+    expect(reachable.has(join(componentsDirectory, 'gamma/gamma.css'))).toBe(true);
+  });
+
+  it('follows an @import with a trailing layer()/media clause', () => {
+    const { componentsDirectory, aggregatorFile } = makeFixture({
+      components: ['alpha', 'beta'],
+      aggregatorImports: ['../components/alpha/alpha.css'],
+      extraFiles: [
+        {
+          path: 'alpha/alpha.css',
+          content: `@import '../beta/beta.css' layer(cinder.components);\n.cinder-alpha {}\n`,
+        },
+      ],
+    });
+
+    const reachable = computeImportClosure(aggregatorFile);
+    expect(reachable.has(join(componentsDirectory, 'beta/beta.css'))).toBe(true);
+  });
+
+  it('terminates on an import cycle', () => {
+    const { componentsDirectory, aggregatorFile } = makeFixture({
+      components: ['alpha', 'beta'],
+      aggregatorImports: ['../components/alpha/alpha.css'],
+      extraFiles: [
+        // alpha -> beta -> alpha. The `reachable` set must break the cycle.
+        { path: 'alpha/alpha.css', content: `@import '../beta/beta.css';\n.cinder-alpha {}\n` },
+        { path: 'beta/beta.css', content: `@import '../alpha/alpha.css';\n.cinder-beta {}\n` },
+      ],
+    });
+
+    const reachable = computeImportClosure(aggregatorFile);
+    expect(reachable.has(join(componentsDirectory, 'alpha/alpha.css'))).toBe(true);
+    expect(reachable.has(join(componentsDirectory, 'beta/beta.css'))).toBe(true);
+  });
 });
 
 describe('checkAggregatorCompleteness', () => {
@@ -135,8 +218,10 @@ describe('checkAggregatorCompleteness', () => {
       ],
     });
 
+    // Exactly the unstyled file is flagged — and nothing else (e.g. alpha,
+    // which IS covered, must not appear).
     const violations = checkAggregatorCompleteness(componentsDirectory, aggregatorFile);
-    expect(violations.map((violation) => violation.path)).toContain('data-table/data-table.css');
+    expect(violations.map((violation) => violation.path)).toEqual(['data-table/data-table.css']);
   });
 
   it('treats a transitively-imported sub-component partial as covered', () => {
@@ -154,7 +239,36 @@ describe('checkAggregatorCompleteness', () => {
 
     // choice-grid-item.css is reachable via choice-grid.css — no violation.
     expect(checkAggregatorCompleteness(componentsDirectory, aggregatorFile)).toEqual([]);
-    void componentsDirectory;
+  });
+
+  it('flags a DEEPER nested partial that is not in the @import chain', () => {
+    const { componentsDirectory, aggregatorFile } = makeFixture({
+      components: ['alpha'],
+      aggregatorImports: ['../components/alpha/alpha.css'],
+      extraFiles: [
+        // A second, deeper CSS file under the component dir, NOT @imported by
+        // alpha.css — it would ship unstyled and must be caught (the `**/*.css`
+        // scan, not `*/*.css`, is what makes this visible).
+        { path: 'alpha/internal/extra.css', content: '.cinder-alpha-extra {}\n' },
+      ],
+    });
+
+    const violations = checkAggregatorCompleteness(componentsDirectory, aggregatorFile);
+    expect(violations.map((violation) => violation.path)).toEqual(['alpha/internal/extra.css']);
+  });
+
+  it('treats a second component CSS file as covered when the first @imports it', () => {
+    const { componentsDirectory, aggregatorFile } = makeFixture({
+      components: ['alpha'],
+      aggregatorImports: ['../components/alpha/alpha.css'],
+      extraFiles: [
+        // alpha.css pulls in a sibling partial in the same dir — covered.
+        { path: 'alpha/alpha.css', content: `@import './alpha-extra.css';\n.cinder-alpha {}\n` },
+        { path: 'alpha/alpha-extra.css', content: '.cinder-alpha-extra {}\n' },
+      ],
+    });
+
+    expect(checkAggregatorCompleteness(componentsDirectory, aggregatorFile)).toEqual([]);
   });
 });
 

--- a/packages/components/scripts/check-aggregator-completeness.test.ts
+++ b/packages/components/scripts/check-aggregator-completeness.test.ts
@@ -1,0 +1,181 @@
+import { describe, expect, it } from 'bun:test';
+import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import {
+  AGGREGATOR_EXCLUSIONS,
+  checkAggregatorCompleteness,
+  computeImportClosure,
+} from './check-aggregator-completeness.ts';
+
+const scriptDirectory = dirname(fileURLToPath(import.meta.url));
+const componentsRoot = resolve(scriptDirectory, '..');
+const componentsSource = join(componentsRoot, 'src');
+const realComponentsDirectory = join(componentsSource, 'components');
+const realAggregator = join(componentsSource, 'styles', 'components.css');
+
+/**
+ * Build a throwaway component tree on disk: a `components/` directory with one
+ * `<name>/<name>.css` per entry, plus a `styles/components.css` aggregator that
+ * imports the given names. Extra raw files can be dropped in per component to
+ * model sub-component partials and JS-only imports.
+ */
+function makeFixture(options: {
+  components: string[];
+  aggregatorImports: string[];
+  extraFiles?: Array<{ path: string; content: string }>;
+}): { componentsDirectory: string; aggregatorFile: string } {
+  const root = mkdtempSync(join(tmpdir(), 'aggregator-gate-'));
+  const componentsDirectory = join(root, 'components');
+  const stylesDirectory = join(root, 'styles');
+  mkdirSync(stylesDirectory, { recursive: true });
+
+  for (const name of options.components) {
+    const dir = join(componentsDirectory, name);
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, `${name}.css`), `.cinder-${name} { color: red; }\n`);
+  }
+
+  for (const file of options.extraFiles ?? []) {
+    const absolute = join(componentsDirectory, file.path);
+    mkdirSync(dirname(absolute), { recursive: true });
+    writeFileSync(absolute, file.content);
+  }
+
+  const importLines = options.aggregatorImports
+    .map((specifier) => `@import '${specifier}';`)
+    .join('\n');
+  writeFileSync(join(stylesDirectory, 'components.css'), `${importLines}\n`);
+
+  return {
+    componentsDirectory,
+    aggregatorFile: join(stylesDirectory, 'components.css'),
+  };
+}
+
+describe('computeImportClosure', () => {
+  it('follows transitive relative @import chains', () => {
+    const { componentsDirectory, aggregatorFile } = makeFixture({
+      components: ['alpha', 'beta'],
+      // aggregator imports alpha; alpha imports beta — beta is transitively reachable.
+      aggregatorImports: ['../components/alpha/alpha.css'],
+      extraFiles: [
+        {
+          path: 'alpha/alpha.css',
+          content: `@import '../beta/beta.css';\n.cinder-alpha { color: red; }\n`,
+        },
+      ],
+    });
+
+    const reachable = computeImportClosure(aggregatorFile);
+    expect(reachable.has(join(componentsDirectory, 'alpha/alpha.css'))).toBe(true);
+    expect(reachable.has(join(componentsDirectory, 'beta/beta.css'))).toBe(true);
+  });
+
+  it('does not follow bare-specifier (package) imports', () => {
+    const { componentsDirectory, aggregatorFile } = makeFixture({
+      components: ['alpha'],
+      aggregatorImports: ['../components/alpha/alpha.css'],
+      extraFiles: [
+        {
+          path: 'alpha/alpha.css',
+          // A bare specifier is not an on-disk relative path — must not be chased.
+          content: `@import 'some-package/styles.css';\n.cinder-alpha {}\n`,
+        },
+      ],
+    });
+
+    const reachable = computeImportClosure(aggregatorFile);
+    expect(reachable.has(join(componentsDirectory, 'alpha/alpha.css'))).toBe(true);
+    // Nothing outside the relative graph leaked in.
+    expect([...reachable].some((file) => file.includes('some-package'))).toBe(false);
+  });
+});
+
+describe('checkAggregatorCompleteness', () => {
+  it('passes when every component CSS is reachable from the aggregator', () => {
+    const { componentsDirectory, aggregatorFile } = makeFixture({
+      components: ['alpha', 'beta'],
+      aggregatorImports: ['../components/alpha/alpha.css', '../components/beta/beta.css'],
+    });
+
+    expect(checkAggregatorCompleteness(componentsDirectory, aggregatorFile)).toEqual([]);
+  });
+
+  it('flags a component missing from the aggregator', () => {
+    const { componentsDirectory, aggregatorFile } = makeFixture({
+      components: ['alpha', 'beta'],
+      // beta is omitted from the aggregator — it ships unstyled to /styles.
+      aggregatorImports: ['../components/alpha/alpha.css'],
+    });
+
+    const violations = checkAggregatorCompleteness(componentsDirectory, aggregatorFile);
+    expect(violations).toHaveLength(1);
+    expect(violations[0]?.path).toBe('beta/beta.css');
+    expect(violations[0]?.message).toContain('UNSTYLED');
+  });
+
+  // The defining regression: the DataTable bug had data-table/index.ts doing
+  // `import './data-table.css'` yet was still missing from components.css and
+  // shipped unstyled. A JS/index.ts import MUST NOT count as coverage, or the
+  // gate would bless the exact bug it exists to catch.
+  it('does NOT treat an index.ts JS import as aggregator coverage', () => {
+    const { componentsDirectory, aggregatorFile } = makeFixture({
+      components: ['alpha', 'data-table'],
+      // Only alpha is in the aggregator. data-table is covered only by its
+      // index.ts JS import (modeled below) — which the gate must ignore.
+      aggregatorImports: ['../components/alpha/alpha.css'],
+      extraFiles: [
+        {
+          path: 'data-table/index.ts',
+          content: `import './data-table.css';\nexport { default as DataTable } from './data-table.svelte';\n`,
+        },
+      ],
+    });
+
+    const violations = checkAggregatorCompleteness(componentsDirectory, aggregatorFile);
+    expect(violations.map((violation) => violation.path)).toContain('data-table/data-table.css');
+  });
+
+  it('treats a transitively-imported sub-component partial as covered', () => {
+    const { componentsDirectory, aggregatorFile } = makeFixture({
+      components: ['choice-grid', 'choice-grid-item'],
+      // Only the parent is in the aggregator; it @imports the item partial.
+      aggregatorImports: ['../components/choice-grid/choice-grid.css'],
+      extraFiles: [
+        {
+          path: 'choice-grid/choice-grid.css',
+          content: `@import '../choice-grid-item/choice-grid-item.css';\n.cinder-choice-grid {}\n`,
+        },
+      ],
+    });
+
+    // choice-grid-item.css is reachable via choice-grid.css — no violation.
+    expect(checkAggregatorCompleteness(componentsDirectory, aggregatorFile)).toEqual([]);
+    void componentsDirectory;
+  });
+});
+
+describe('the real cinder aggregator', () => {
+  it('imports every component CSS partial (or excludes it with a reason)', () => {
+    const violations = checkAggregatorCompleteness(realComponentsDirectory, realAggregator);
+    // A failure here lists each component CSS that would ship unstyled to
+    // /styles consumers. Add the @import (alphabetical) or an exclusion entry.
+    expect(violations).toEqual([]);
+  });
+
+  it('keeps every exclusion honest — each excluded file actually exists and is uncovered', () => {
+    const reachable = computeImportClosure(realAggregator);
+    for (const exclusion of AGGREGATOR_EXCLUSIONS) {
+      const absolute = join(realComponentsDirectory, exclusion.path);
+      // The file must exist (no stale exclusions) …
+      expect(Bun.file(absolute).size).toBeGreaterThan(0);
+      // … and must genuinely be outside the CSS chain (else the exclusion is
+      // dead weight masking nothing).
+      expect(reachable.has(absolute)).toBe(false);
+      expect(exclusion.reason.length).toBeGreaterThan(0);
+    }
+  });
+});

--- a/packages/components/scripts/check-aggregator-completeness.ts
+++ b/packages/components/scripts/check-aggregator-completeness.ts
@@ -3,7 +3,7 @@ import { dirname, join, relative, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import { Glob } from 'bun';
-import { parse } from 'postcss';
+import { parse, type Root } from 'postcss';
 
 /**
  * Aggregator-completeness gate for `src/styles/components.css`.
@@ -64,8 +64,8 @@ export type AggregatorViolation = {
  * the first whitespace-delimited token (dropping any trailing layer/media), and
  * accept it only if it's a relative path (`.`-prefixed). Bare/aliased/absolute
  * specifiers don't resolve to a local component file on disk, so they're not
- * part of the on-disk closure — see `aggregateImportContractViolations` for the
- * separate check that flags them as unsupported in the aggregate stylesheet.
+ * part of the on-disk closure and are simply ignored (cinder's aggregate
+ * stylesheet uses only relative imports).
  */
 function extractRelativeImportSpecifier(params: string): string | undefined {
   let raw = params.trim();
@@ -89,10 +89,45 @@ function extractRelativeImportSpecifier(params: string): string | undefined {
 }
 
 /**
+ * Collect the relative specifiers of the **honored** top-level `@import` rules
+ * of one parsed stylesheet, in source order.
+ *
+ * Matches CSS semantics, not a naive tree walk: a `@import` is honored by the
+ * browser/bundler only at the top level (NOT nested inside `@media`/`@supports`)
+ * and only in the stylesheet prelude — before any style rule. Per the spec the
+ * prelude may also contain a leading `@charset` and `@layer` statements; once a
+ * style rule or any other at-rule appears, later `@import`s are ignored. We
+ * mirror that: walk only `root.nodes` (top level), stop honoring `@import` after
+ * the prelude ends. This is what prevents a nested or late `@import` from being
+ * falsely counted as coverage when the real bundle would drop it.
+ */
+function honoredImportSpecifiers(root: Root): string[] {
+  const specifiers: string[] = [];
+  for (const node of root.nodes) {
+    if (node.type === 'comment') continue;
+    if (node.type === 'atrule') {
+      if (node.name === 'import') {
+        const specifier = extractRelativeImportSpecifier(node.params);
+        if (specifier !== undefined) specifiers.push(specifier);
+        continue;
+      }
+      // `@charset` and the statement form of `@layer` (no block) may legally
+      // precede imports without ending the prelude.
+      if (node.name === 'charset') continue;
+      if (node.name === 'layer' && node.nodes === undefined) continue;
+    }
+    // Any style rule, declaration, or other at-rule (incl. @media/@supports
+    // and a block-form @layer) ends the import prelude — stop honoring imports.
+    break;
+  }
+  return specifiers;
+}
+
+/**
  * Compute the set of absolute file paths reachable from `entryFile` by
- * following `@import` statements over the **CSS** import graph. The entry file
- * itself is included. Missing targets are skipped rather than thrown — a
- * dangling `@import` is a different defect, governed by the build.
+ * following the **honored** CSS `@import` chain (see {@link honoredImportSpecifiers}).
+ * The entry file itself is included. Missing targets are skipped rather than
+ * thrown — a dangling `@import` is a different defect, governed by the build.
  *
  * Uses a real CSS parser (postcss) rather than a regex so that commented-out
  * imports (`/* @import '…'; *\/`) are NOT counted as coverage — a regex would
@@ -111,12 +146,9 @@ export function computeImportClosure(entryFile: string): Set<string> {
     reachable.add(file);
 
     const root = parse(readFileSync(file, 'utf8'), { from: file });
-    root.walkAtRules('import', (atRule) => {
-      const specifier = extractRelativeImportSpecifier(atRule.params);
-      if (specifier !== undefined) {
-        stack.push(resolve(dirname(file), specifier));
-      }
-    });
+    for (const specifier of honoredImportSpecifiers(root)) {
+      stack.push(resolve(dirname(file), specifier));
+    }
   }
 
   return reachable;

--- a/packages/components/scripts/check-aggregator-completeness.ts
+++ b/packages/components/scripts/check-aggregator-completeness.ts
@@ -1,5 +1,5 @@
 import { existsSync, readFileSync } from 'node:fs';
-import { dirname, join, relative, resolve } from 'node:path';
+import { dirname, join, sep as pathSeparator, relative, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import { Glob } from 'bun';
@@ -178,7 +178,10 @@ export function checkAggregatorCompleteness(
   const violations: AggregatorViolation[] = [];
   for (const absolutePath of componentCssFiles) {
     if (reachable.has(absolutePath)) continue;
-    const relativePath = relative(componentsDirectory, absolutePath);
+    // Normalize to forward slashes so the comparison against the (POSIX-keyed)
+    // exclusion list — and the reported path — are stable on Windows, where
+    // `relative()` yields backslashes.
+    const relativePath = relative(componentsDirectory, absolutePath).split(pathSeparator).join('/');
     if (excludedPaths.has(relativePath)) continue;
 
     violations.push({

--- a/packages/components/scripts/check-aggregator-completeness.ts
+++ b/packages/components/scripts/check-aggregator-completeness.ts
@@ -1,0 +1,148 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { dirname, join, relative, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { Glob } from 'bun';
+
+/**
+ * Aggregator-completeness gate for `src/styles/components.css`.
+ *
+ * The aggregate `/styles` (and `/styles/all`) bundle is a single CSS file that
+ * `@import`s every component's CSS partial. Consumers who opt into the bundle —
+ * rather than the per-component `@lostgradient/cinder/<name>` subpaths — get
+ * styling for a component ONLY if that component's CSS is reachable from
+ * `components.css` through the CSS `@import` chain.
+ *
+ * A component's own `index.ts` doing `import './<name>.css'` does NOT count:
+ * aggregate consumers never execute that JS, so a component covered only by its
+ * `index.ts` ships unstyled to the bundle. (This is the exact `DataTable` bug
+ * that motivated the gate: data-table.css had its `index.ts` import but was
+ * missing from `components.css`, so `/styles` consumers rendered it unstyled and
+ * no existing check — build, typecheck, components:check, exports:check — caught
+ * it.) Coverage is therefore defined strictly as reachability from
+ * `components.css` over the CSS `@import` graph.
+ */
+
+/** A component CSS file that is intentionally NOT in the aggregate bundle. */
+type AggregatorExclusion = {
+  /** Path relative to `src/components`, e.g. `markdown-editor/prosemirror.css`. */
+  readonly path: string;
+  /** Why it is excluded — must justify why aggregate consumers don't need it. */
+  readonly reason: string;
+};
+
+/**
+ * Component CSS files deliberately excluded from the aggregate bundle. Every
+ * entry needs a reason; the gate fails on any uncovered file NOT listed here, so
+ * a new genuinely-missing import can't hide behind a silent category.
+ */
+export const AGGREGATOR_EXCLUSIONS: readonly AggregatorExclusion[] = [
+  {
+    path: 'markdown-editor/prosemirror.css',
+    reason:
+      'Third-party ProseMirror editor stylesheet, JS-imported directly by ' +
+      'markdown-editor.svelte. It is intentionally out of the global bundle so ' +
+      'apps not using the markdown editor do not pay for ProseMirror styling.',
+  },
+];
+
+export type AggregatorViolation = {
+  /** Component CSS path relative to `src/components`. */
+  readonly path: string;
+  readonly message: string;
+};
+
+/**
+ * Compute the set of absolute file paths reachable from `entryFile` by
+ * following `@import` statements (CSS chain only). The entry file itself is
+ * included. Missing targets are skipped rather than thrown — a dangling
+ * `@import` is a different defect, governed by the build.
+ */
+export function computeImportClosure(entryFile: string): Set<string> {
+  const reachable = new Set<string>();
+  const stack: string[] = [resolve(entryFile)];
+  const importPattern = /@import\s+(?:url\()?['"]([^'"]+)['"]/g;
+
+  while (stack.length > 0) {
+    const file = stack.pop()!;
+    if (reachable.has(file) || !existsSync(file)) continue;
+    reachable.add(file);
+
+    const source = readFileSync(file, 'utf8');
+    for (const match of source.matchAll(importPattern)) {
+      const specifier = match[1];
+      // Only relative specifiers participate in the on-disk import graph.
+      // (The capture group is always present on a match, but narrow it
+      // explicitly to satisfy noUncheckedIndexedAccess.)
+      if (specifier !== undefined && specifier.startsWith('.')) {
+        stack.push(resolve(dirname(file), specifier));
+      }
+    }
+  }
+
+  return reachable;
+}
+
+/**
+ * Check that every component CSS partial under `componentsDirectory` is either
+ * reachable from `aggregatorFile` through the CSS `@import` chain or listed in
+ * `AGGREGATOR_EXCLUSIONS`. Returns one violation per uncovered, non-excluded
+ * file. An empty array means the aggregate bundle is complete.
+ */
+export function checkAggregatorCompleteness(
+  componentsDirectory: string,
+  aggregatorFile: string,
+): AggregatorViolation[] {
+  const reachable = computeImportClosure(aggregatorFile);
+  const excludedPaths = new Set(AGGREGATOR_EXCLUSIONS.map((exclusion) => exclusion.path));
+
+  const componentCssGlob = new Glob('*/*.css');
+  const componentCssFiles = [
+    ...componentCssGlob.scanSync({ cwd: componentsDirectory, absolute: true }),
+  ].toSorted();
+
+  const violations: AggregatorViolation[] = [];
+  for (const absolutePath of componentCssFiles) {
+    if (reachable.has(absolutePath)) continue;
+    const relativePath = relative(componentsDirectory, absolutePath);
+    if (excludedPaths.has(relativePath)) continue;
+
+    violations.push({
+      path: relativePath,
+      message:
+        `${relativePath} is not reachable from styles/components.css through the ` +
+        `CSS @import chain, so it ships UNSTYLED to /styles (aggregate) consumers. ` +
+        `Add \`@import '../components/${relativePath}';\` to ` +
+        `src/styles/components.css in alphabetical order — or, if it is ` +
+        `intentionally excluded, add it to AGGREGATOR_EXCLUSIONS with a reason.`,
+    });
+  }
+
+  return violations;
+}
+
+async function main(): Promise<void> {
+  const scriptDirectory = dirname(fileURLToPath(import.meta.url));
+  const componentsSource = join(resolve(scriptDirectory, '..'), 'src');
+  const componentsDirectory = join(componentsSource, 'components');
+  const aggregatorFile = join(componentsSource, 'styles', 'components.css');
+
+  const violations = checkAggregatorCompleteness(componentsDirectory, aggregatorFile);
+  if (violations.length === 0) {
+    process.stdout.write('aggregator:check — styles/components.css imports every component CSS.\n');
+    process.exitCode = 0;
+    return;
+  }
+
+  process.stderr.write(
+    `aggregator:check — ${violations.length} component CSS partial(s) missing from styles/components.css:\n`,
+  );
+  for (const violation of violations) {
+    process.stderr.write(`  ${violation.message}\n`);
+  }
+  process.exitCode = 1;
+}
+
+if (import.meta.main) {
+  await main();
+}

--- a/packages/components/scripts/check-aggregator-completeness.ts
+++ b/packages/components/scripts/check-aggregator-completeness.ts
@@ -3,6 +3,7 @@ import { dirname, join, relative, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import { Glob } from 'bun';
+import { parse } from 'postcss';
 
 /**
  * Aggregator-completeness gate for `src/styles/components.css`.
@@ -53,31 +54,69 @@ export type AggregatorViolation = {
 };
 
 /**
+ * Extract the relative specifier from a postcss `@import` at-rule's params, or
+ * `undefined` if the import isn't a relative on-disk reference we should chase.
+ *
+ * postcss hands us the raw params after `@import ` — every valid CSS form:
+ *   `'./x.css'`  `"../x.css"`  `url(./x.css)`  `url('../x.css')`  `url("./x.css")`
+ * each optionally trailed by `layer(...)`, `supports(...)`, or a media query.
+ * We unwrap an optional `url(...)`, strip surrounding quotes, then keep only
+ * the first whitespace-delimited token (dropping any trailing layer/media), and
+ * accept it only if it's a relative path (`.`-prefixed). Bare/aliased/absolute
+ * specifiers don't resolve to a local component file on disk, so they're not
+ * part of the on-disk closure — see `aggregateImportContractViolations` for the
+ * separate check that flags them as unsupported in the aggregate stylesheet.
+ */
+function extractRelativeImportSpecifier(params: string): string | undefined {
+  let raw = params.trim();
+
+  const urlMatch = /^url\(\s*(.*?)\s*\)/i.exec(raw);
+  if (urlMatch?.[1] !== undefined) {
+    raw = urlMatch[1].trim();
+  } else {
+    // Non-url form: the specifier is the first token; drop trailing
+    // layer()/supports()/media-query clauses.
+    raw = raw.split(/\s+/)[0] ?? '';
+  }
+
+  // Strip a single pair of surrounding quotes, if present.
+  const quoted = /^(['"])(.*)\1$/.exec(raw);
+  if (quoted?.[2] !== undefined) {
+    raw = quoted[2];
+  }
+
+  return raw.startsWith('.') ? raw : undefined;
+}
+
+/**
  * Compute the set of absolute file paths reachable from `entryFile` by
- * following `@import` statements (CSS chain only). The entry file itself is
- * included. Missing targets are skipped rather than thrown — a dangling
- * `@import` is a different defect, governed by the build.
+ * following `@import` statements over the **CSS** import graph. The entry file
+ * itself is included. Missing targets are skipped rather than thrown — a
+ * dangling `@import` is a different defect, governed by the build.
+ *
+ * Uses a real CSS parser (postcss) rather than a regex so that commented-out
+ * imports (`/* @import '…'; *\/`) are NOT counted as coverage — a regex would
+ * treat them as real and let an unstyled component pass the gate. postcss parses
+ * them as `comment` nodes, never `atrule` nodes, so they're correctly ignored.
+ * Both quoted and `url(...)` import forms are handled via
+ * {@link extractRelativeImportSpecifier}.
  */
 export function computeImportClosure(entryFile: string): Set<string> {
   const reachable = new Set<string>();
   const stack: string[] = [resolve(entryFile)];
-  const importPattern = /@import\s+(?:url\()?['"]([^'"]+)['"]/g;
 
   while (stack.length > 0) {
-    const file = stack.pop()!;
-    if (reachable.has(file) || !existsSync(file)) continue;
+    const file = stack.pop();
+    if (file === undefined || reachable.has(file) || !existsSync(file)) continue;
     reachable.add(file);
 
-    const source = readFileSync(file, 'utf8');
-    for (const match of source.matchAll(importPattern)) {
-      const specifier = match[1];
-      // Only relative specifiers participate in the on-disk import graph.
-      // (The capture group is always present on a match, but narrow it
-      // explicitly to satisfy noUncheckedIndexedAccess.)
-      if (specifier !== undefined && specifier.startsWith('.')) {
+    const root = parse(readFileSync(file, 'utf8'), { from: file });
+    root.walkAtRules('import', (atRule) => {
+      const specifier = extractRelativeImportSpecifier(atRule.params);
+      if (specifier !== undefined) {
         stack.push(resolve(dirname(file), specifier));
       }
-    }
+    });
   }
 
   return reachable;
@@ -96,7 +135,10 @@ export function checkAggregatorCompleteness(
   const reachable = computeImportClosure(aggregatorFile);
   const excludedPaths = new Set(AGGREGATOR_EXCLUSIONS.map((exclusion) => exclusion.path));
 
-  const componentCssGlob = new Glob('*/*.css');
+  // `**/*.css` (not `*/*.css`) so a deeper partial like
+  // `<component>/internal/<name>.css` can't ship unstyled by hiding below the
+  // first directory level.
+  const componentCssGlob = new Glob('**/*.css');
   const componentCssFiles = [
     ...componentCssGlob.scanSync({ cwd: componentsDirectory, absolute: true }),
   ].toSorted();
@@ -121,7 +163,7 @@ export function checkAggregatorCompleteness(
   return violations;
 }
 
-async function main(): Promise<void> {
+function main(): void {
   const scriptDirectory = dirname(fileURLToPath(import.meta.url));
   const componentsSource = join(resolve(scriptDirectory, '..'), 'src');
   const componentsDirectory = join(componentsSource, 'components');
@@ -144,5 +186,5 @@ async function main(): Promise<void> {
 }
 
 if (import.meta.main) {
-  await main();
+  main();
 }

--- a/packages/components/src/styles/components.css
+++ b/packages/components/src/styles/components.css
@@ -37,6 +37,7 @@
 @import '../components/color-picker/color-picker.css';
 @import '../components/color-swatch-picker/color-swatch-picker.css';
 @import '../components/combobox/combobox.css';
+@import '../components/command-menu/command-menu.css';
 @import '../components/command-palette/command-palette.css';
 @import '../components/confirm-dialog/confirm-dialog.css';
 @import '../components/connection-indicator/connection-indicator.css';


### PR DESCRIPTION
## Summary

Two release-pipeline guards that close recurring publish-defect classes, plus the fix for a real instance the second guard caught.

**Guard 1 — chain `components:generate` into `changeset:version`.** `changeset version` bumps `packages/components/package.json` but not `components.json`, whose manifest embeds the package version. On the 0.2.0 release that left the manifest stale and the post-merge publish build aborted on `components:check` drift (it had to be regenerated by hand). Chaining the regen keeps them in lockstep on every future release.

**Guard 2 — aggregator-completeness gate.** A new `aggregator:check` (`scripts/check-aggregator-completeness.ts` + test) asserts that `src/styles/components.css` reaches **every** component CSS partial through the CSS `@import` chain. Consumers of the aggregate `/styles` bundle get a component's styling only if it's reachable that way — a component's own `index.ts` JS import does **not** count (aggregate consumers never run it). That's the exact DataTable bug that shipped unstyled with no check catching it.

The gate immediately surfaced a real, unfixed instance: **`command-menu.css` was missing from the aggregator** — a stable exported component (`@lostgradient/cinder/command-menu`, rendering its own `cinder-command-menu` classes) that shipped **unstyled** to `/styles` consumers in 0.2.0. Added the import. `prosemirror.css` (third-party editor CSS, JS-imported by `markdown-editor.svelte`) is the one allowlisted exclusion, with a documented reason.

The gate runs in `validate` (release/main-green) **and** as an unconditional step in the PR-gating `unit-tests` workflow — so a missing import fails the PR check, not just post-merge.

## Why the checker uses postcss + honors only prelude imports

Coverage = reachability from `components.css` over the **honored** CSS `@import` graph. Two subtleties the committee pushed on, both now correct:

- It parses with **postcss**, not a regex — so a commented-out `/* @import '…'; */` is not counted as coverage (a regex would treat it as real and let an unstyled component pass the gate).
- It follows only **top-level prelude** `@import`s (matching CSS semantics): an `@import` nested in `@media`/`@supports`, or placed after a style rule, is ignored by the real bundle and so must not count as coverage. `@charset` and statement-form `@layer` may precede imports without ending the prelude.

## Review committee

Pre-reviewed by:
- Codex (gpt-5.4, xhigh→high reasoning) — 3 rounds
- typescript-expert, testing-expert, dx-engineer, simplicity-engineer (Codex fallback / medium — the Claude `Agent` path was exhausted on `/usage-credits` all session, so each persona ran via `codex-review.sh`)
- All must-fix items addressed

The committee caught two real false-pass bugs in the gate's first cuts: (1) the regex counted commented-out `@import`s as coverage → switched to postcss; (2) the postcss `walkAtRules` counted nested/late `@import`s past the prelude → switched to honored-prelude-only traversal. Each was fixed with regression tests.

## Test plan

- `bun run --filter=@lostgradient/cinder test -- scripts/check-aggregator-completeness.test.ts` — 17 tests: transitive closure, bare/url()/quoted/commented/nested/late `@import` forms, cycles, nested-partial detection, the real-tree completeness + exclusion-honesty assertions.
- `bun run --filter=@lostgradient/cinder aggregator:check` — passes on the real tree (and fails with a precise message if any component CSS is dropped — verified by temporarily removing the `command-menu.css` import).
- `bun run --filter=@lostgradient/cinder typecheck` + `lint` — clean.

cc @copilot

(These are internal follow-up items from the 0.2.0 release work — the release-pipeline manifest gap and the styles-aggregator gate — not GitHub issue numbers.)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build/CI guardrails and one aggregator import fix; no runtime auth, data, or API behavior changes.
> 
> **Overview**
> Adds **release and styling guards** so publish drift and unstyled aggregate `/styles` bundles are caught before they ship.
> 
> **`changeset:version`** now runs **`components:generate`** right after `changeset version`, keeping `components.json` (and related generated artifacts) aligned with the bumped package version instead of leaving manifest drift for publish.
> 
> A new **`aggregator:check`** walks the honored CSS `@import` graph from `styles/components.css` (postcss, prelude-only—no commented, nested, or late imports) and fails if any component `**/*.css` is unreachable unless listed in **`AGGREGATOR_EXCLUSIONS`** (e.g. `prosemirror.css`). JS `index.ts` CSS imports do not count. The check runs in **`validate`**, unconditionally in the PR **`unit-tests`** workflow, and ships with broad unit tests plus a real-tree assertion.
> 
> **Fix:** adds the missing **`command-menu.css`** `@import` to `components.css`—the gate caught a component that would ship unstyled to `/styles` consumers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit af14695dfdbcba8e52464c8ce366549983523295. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->