### PR TITLE
fix(markdown): fix HTML entity double-encoding in Shiki code blocks

### DIFF
--- a/packages/markdown/src/rendering/rehype-shiki-sync.test.ts
+++ b/packages/markdown/src/rendering/rehype-shiki-sync.test.ts
@@ -81,13 +81,17 @@ function extractLanguageFromClass(element: Element): string | null {
 // Helper to decode HTML entities (mirrors internal decodeHtmlEntities)
 function decodeHtmlEntities(text: string): string {
   return text
+    .replace(/&#x3C;/gi, '<')
+    .replace(/&#x3E;/gi, '>')
+    .replace(/&#x22;/gi, '"')
+    .replace(/&#x27;/gi, "'")
     .replace(/&lt;/g, '<')
     .replace(/&gt;/g, '>')
-    .replace(/&amp;/g, '&')
     .replace(/&quot;/g, '"')
     .replace(/&#39;/g, "'")
-    .replace(/&#x27;/g, "'")
-    .replace(/&#x2F;/g, '/');
+    .replace(/&#x2F;/g, '/')
+    .replace(/&#x26;/gi, '&')
+    .replace(/&amp;/g, '&');
 }
 
 // Helper to collect all text from an element (handles nested spans from Shiki)
@@ -287,6 +291,30 @@ describe('rehype-shiki-sync', () => {
 
     it('handles empty string', () => {
       expect(decodeHtmlEntities('')).toBe('');
+    });
+
+    it('decodes &#x3C; to <', () => {
+      expect(decodeHtmlEntities('&#x3C;div&#x3E;')).toBe('<div>');
+    });
+
+    it('decodes &#x26; to &', () => {
+      expect(decodeHtmlEntities('foo&#x26;bar')).toBe('foo&bar');
+    });
+
+    it('decodes &#x22; to "', () => {
+      expect(decodeHtmlEntities('&#x22;hello&#x22;')).toBe('"hello"');
+    });
+
+    it('does not cascade &#x26;lt; into <', () => {
+      // &#x26;lt; represents the literal text "&lt;" — must stay as "&lt;", not become "<"
+      expect(decodeHtmlEntities('&#x26;lt;')).toBe('&lt;');
+    });
+
+    it('does not cascade &#x26;#x3C; into <', () => {
+      // &#x26;#x3C; represents the literal text "&#x3C;" in source code.
+      // Decoding &#x26; last means it becomes &#x3C; after all passes complete —
+      // the &#x3C; replace already ran (no match), so the result stays &#x3C;.
+      expect(decodeHtmlEntities('&#x26;#x3C;')).toBe('&#x3C;');
     });
   });
 

--- a/packages/markdown/src/rendering/rehype-shiki-sync.test.ts
+++ b/packages/markdown/src/rendering/rehype-shiki-sync.test.ts
@@ -294,8 +294,20 @@ describe('rehype-shiki-sync', () => {
 
     it('does not cascade &#x26;amp; into &', () => {
       // &#x26;amp; is what Shiki emits when source code contains literal "&amp;".
-      // &amp; must be decoded before &#x26; so this stays as &amp;, not &.
+      // Single-pass prevents re-scanning: &#x26; → & but the resulting &amp; is not re-decoded.
       expect(decodeHtmlEntities('&#x26;amp;')).toBe('&amp;');
+    });
+
+    it('does not cascade &amp;#x26; into &', () => {
+      // &amp;#x26; represents literal "&#x26;" in source code.
+      // Single-pass: &amp; → & and #x26; is literal text, so the result is &#x26; not &.
+      expect(decodeHtmlEntities('&amp;#x26;')).toBe('&#x26;');
+    });
+
+    it('does not cascade &amp;#x26;lt; into <', () => {
+      // &amp;#x26;lt; represents literal "&#x26;lt;" in source code.
+      // Single-pass: &amp; → & leaves #x26;lt; as literal, result is &#x26;lt; not &lt; or <.
+      expect(decodeHtmlEntities('&amp;#x26;lt;')).toBe('&#x26;lt;');
     });
   });
 

--- a/packages/markdown/src/rendering/rehype-shiki-sync.test.ts
+++ b/packages/markdown/src/rendering/rehype-shiki-sync.test.ts
@@ -7,16 +7,7 @@
 import { beforeAll, beforeEach, describe, expect, it } from 'bun:test';
 import type { Element, ElementContent, Text } from 'hast';
 import { initializeHighlighter, resetHighlighter } from './highlighter.js';
-import { rehypeShikiSync } from './rehype-shiki-sync.js';
-
-/**
- * To test internal functions, we need to either:
- * 1. Export them (which exposes implementation details)
- * 2. Test through the public API
- *
- * We'll test through the public API (rehypeShikiSync) for integration behavior,
- * and create minimal test helpers that mirror the internal logic for unit tests.
- */
+import { decodeHtmlEntities, rehypeShikiSync } from './rehype-shiki-sync.js';
 
 // Helper to create a mock hast tree with a code block
 function createCodeBlockTree(
@@ -76,22 +67,6 @@ function extractLanguageFromClass(element: Element): string | null {
   }
 
   return null;
-}
-
-// Helper to decode HTML entities (mirrors internal decodeHtmlEntities)
-function decodeHtmlEntities(text: string): string {
-  return text
-    .replace(/&#x3C;/gi, '<')
-    .replace(/&#x3E;/gi, '>')
-    .replace(/&#x22;/gi, '"')
-    .replace(/&#x27;/gi, "'")
-    .replace(/&lt;/g, '<')
-    .replace(/&gt;/g, '>')
-    .replace(/&quot;/g, '"')
-    .replace(/&#39;/g, "'")
-    .replace(/&#x2F;/g, '/')
-    .replace(/&#x26;/gi, '&')
-    .replace(/&amp;/g, '&');
 }
 
 // Helper to collect all text from an element (handles nested spans from Shiki)
@@ -312,9 +287,15 @@ describe('rehype-shiki-sync', () => {
 
     it('does not cascade &#x26;#x3C; into <', () => {
       // &#x26;#x3C; represents the literal text "&#x3C;" in source code.
-      // Decoding &#x26; last means it becomes &#x3C; after all passes complete —
-      // the &#x3C; replace already ran (no match), so the result stays &#x3C;.
+      // Because &#x26; is decoded last, the earlier &#x3C; pass already ran
+      // and did not match, so the result stays &#x3C; (not <).
       expect(decodeHtmlEntities('&#x26;#x3C;')).toBe('&#x3C;');
+    });
+
+    it('does not cascade &#x26;amp; into &', () => {
+      // &#x26;amp; is what Shiki emits when source code contains literal "&amp;".
+      // &amp; must be decoded before &#x26; so this stays as &amp;, not &.
+      expect(decodeHtmlEntities('&#x26;amp;')).toBe('&amp;');
     });
   });
 

--- a/packages/markdown/src/rendering/rehype-shiki-sync.test.ts
+++ b/packages/markdown/src/rendering/rehype-shiki-sync.test.ts
@@ -287,8 +287,8 @@ describe('rehype-shiki-sync', () => {
 
     it('does not cascade &#x26;#x3C; into <', () => {
       // &#x26;#x3C; represents the literal text "&#x3C;" in source code.
-      // Because &#x26; is decoded last, the earlier &#x3C; pass already ran
-      // and did not match, so the result stays &#x3C; (not <).
+      // Single-pass: &#x26; → & in one match, leaving #x3C; as unmatched literal text,
+      // so the result is &#x3C; (not <).
       expect(decodeHtmlEntities('&#x26;#x3C;')).toBe('&#x3C;');
     });
 

--- a/packages/markdown/src/rendering/rehype-shiki-sync.ts
+++ b/packages/markdown/src/rendering/rehype-shiki-sync.ts
@@ -265,12 +265,16 @@ function parseSpans(html: string): ElementContent[] {
  */
 function decodeHtmlEntities(text: string): string {
   return text
+    .replace(/&#x3C;/gi, '<')
+    .replace(/&#x3E;/gi, '>')
+    .replace(/&#x26;/gi, '&')
+    .replace(/&#x22;/gi, '"')
+    .replace(/&#x27;/gi, "'")
     .replace(/&lt;/g, '<')
     .replace(/&gt;/g, '>')
     .replace(/&amp;/g, '&')
     .replace(/&quot;/g, '"')
     .replace(/&#39;/g, "'")
-    .replace(/&#x27;/g, "'")
     .replace(/&#x2F;/g, '/');
 }
 

--- a/packages/markdown/src/rendering/rehype-shiki-sync.ts
+++ b/packages/markdown/src/rendering/rehype-shiki-sync.ts
@@ -262,20 +262,24 @@ function parseSpans(html: string): ElementContent[] {
 
 /**
  * Decode HTML entities in text content.
+ *
+ * Ampersand forms (&amp; and &#x26;) must be decoded LAST. Decoding them
+ * earlier would cascade: &#x26;lt; → &lt; → < instead of &lt; (a literal
+ * less-than entity in source code).
  */
 function decodeHtmlEntities(text: string): string {
   return text
     .replace(/&#x3C;/gi, '<')
     .replace(/&#x3E;/gi, '>')
-    .replace(/&#x26;/gi, '&')
     .replace(/&#x22;/gi, '"')
     .replace(/&#x27;/gi, "'")
     .replace(/&lt;/g, '<')
     .replace(/&gt;/g, '>')
-    .replace(/&amp;/g, '&')
     .replace(/&quot;/g, '"')
     .replace(/&#39;/g, "'")
-    .replace(/&#x2F;/g, '/');
+    .replace(/&#x2F;/g, '/')
+    .replace(/&#x26;/gi, '&') // ampersand last — must not cascade into other entity decodes
+    .replace(/&amp;/g, '&');
 }
 
 /**

--- a/packages/markdown/src/rendering/rehype-shiki-sync.ts
+++ b/packages/markdown/src/rendering/rehype-shiki-sync.ts
@@ -263,11 +263,14 @@ function parseSpans(html: string): ElementContent[] {
 /**
  * Decode HTML entities in text content.
  *
- * Ampersand forms (&amp; and &#x26;) must be decoded LAST. Decoding them
- * earlier would cascade: &#x26;lt; → &lt; → < instead of &lt; (a literal
- * less-than entity in source code).
+ * Ampersand forms must be decoded LAST, with &amp; before &#x26;. Decoding
+ * them earlier would cascade: &#x26;lt; → &lt; → < instead of &lt;. The
+ * &amp; step must precede &#x26; so that &#x26;amp; → &#x26;amp; → &amp;
+ * (correct), not &#x26;amp; → &amp; → & (loses the entity).
+ *
+ * @internal exported for unit testing only
  */
-function decodeHtmlEntities(text: string): string {
+export function decodeHtmlEntities(text: string): string {
   return text
     .replace(/&#x3C;/gi, '<')
     .replace(/&#x3E;/gi, '>')
@@ -277,9 +280,9 @@ function decodeHtmlEntities(text: string): string {
     .replace(/&gt;/g, '>')
     .replace(/&quot;/g, '"')
     .replace(/&#39;/g, "'")
-    .replace(/&#x2F;/g, '/')
-    .replace(/&#x26;/gi, '&') // ampersand last — must not cascade into other entity decodes
-    .replace(/&amp;/g, '&');
+    .replace(/&#x2F;/gi, '/')
+    .replace(/&amp;/g, '&') // &amp; before &#x26; — prevents &#x26;amp; cascading to &
+    .replace(/&#x26;/gi, '&'); // hex ampersand last
 }
 
 /**

--- a/packages/markdown/src/rendering/rehype-shiki-sync.ts
+++ b/packages/markdown/src/rendering/rehype-shiki-sync.ts
@@ -260,29 +260,36 @@ function parseSpans(html: string): ElementContent[] {
   return children;
 }
 
+const HTML_ENTITY_PATTERN = /&(?:lt|gt|amp|quot|apos|#39|#x27|#x2F|#x3C|#x3E|#x22|#x26);/gi;
+
+const HTML_ENTITY_MAP: Record<string, string> = {
+  '&lt;': '<',
+  '&gt;': '>',
+  '&amp;': '&',
+  '&quot;': '"',
+  '&apos;': "'",
+  '&#39;': "'",
+  '&#x27;': "'",
+  '&#x2f;': '/',
+  '&#x3c;': '<',
+  '&#x3e;': '>',
+  '&#x22;': '"',
+  '&#x26;': '&',
+};
+
 /**
- * Decode HTML entities in text content.
+ * Decode HTML entities in text content using a single-pass replacement.
  *
- * Ampersand forms must be decoded LAST, with &amp; before &#x26;. Decoding
- * them earlier would cascade: &#x26;lt; → &lt; → < instead of &lt;. The
- * &amp; step must precede &#x26; so that &#x26;amp; → &#x26;amp; → &amp;
- * (correct), not &#x26;amp; → &amp; → & (loses the entity).
+ * Single-pass prevents cascade: `&#x26;amp;` → `&amp;` (not `&`) because
+ * the `&amp;` produced by decoding `&#x26;` is never re-scanned.
  *
  * @internal exported for unit testing only
  */
 export function decodeHtmlEntities(text: string): string {
-  return text
-    .replace(/&#x3C;/gi, '<')
-    .replace(/&#x3E;/gi, '>')
-    .replace(/&#x22;/gi, '"')
-    .replace(/&#x27;/gi, "'")
-    .replace(/&lt;/g, '<')
-    .replace(/&gt;/g, '>')
-    .replace(/&quot;/g, '"')
-    .replace(/&#39;/g, "'")
-    .replace(/&#x2F;/gi, '/')
-    .replace(/&amp;/g, '&') // &amp; before &#x26; — prevents &#x26;amp; cascading to &
-    .replace(/&#x26;/gi, '&'); // hex ampersand last
+  return text.replace(
+    HTML_ENTITY_PATTERN,
+    (match) => HTML_ENTITY_MAP[match.toLowerCase()] ?? match,
+  );
 }
 
 /**

--- a/packages/markdown/src/rendering/render.test.ts
+++ b/packages/markdown/src/rendering/render.test.ts
@@ -556,9 +556,17 @@ py = "Python"
       expect(result.html).toContain('script');
       // The key assertion: no executable script tag
       expect(result.html).not.toContain('<script>alert');
-      // Must not double-encode: Shiki outputs &#x3C; and rehype-stringify
-      // must not further encode the & to &#x26;
+      // Must not double-encode: Shiki outputs &#x3C; for < and rehype-stringify
+      // must not further encode the & to produce &#x26;#x3C;
+      expect(result.html).not.toContain('&#x26;#x3C;');
+    });
+
+    it('does not double-encode ampersand in highlighted code', () => {
+      const result = renderMarkdown('```javascript\nconst x = a && b;\n```');
+      // & in source → Shiki may emit &#x26; → must decode to & → rehype-stringify re-encodes as &amp;
+      // The final output must contain &amp; for the ampersand, never &#x26;
       expect(result.html).not.toContain('&#x26;');
+      expect(result.html).toContain('&amp;');
     });
   });
 });

--- a/packages/markdown/src/rendering/render.test.ts
+++ b/packages/markdown/src/rendering/render.test.ts
@@ -552,10 +552,13 @@ py = "Python"
       // Should not contain raw script tags
       expect(result.html).not.toMatch(/<script>/);
       // Content should be preserved (escaped) - the exact encoding varies
-      // (could be &lt;, &#x3C;, or double-encoded &#x26;#x3C;)
+      // (could be &lt; or &#x3C;) but must NOT be double-encoded &#x26;#x3C;
       expect(result.html).toContain('script');
       // The key assertion: no executable script tag
       expect(result.html).not.toContain('<script>alert');
+      // Must not double-encode: Shiki outputs &#x3C; and rehype-stringify
+      // must not further encode the & to &#x26;
+      expect(result.html).not.toContain('&#x26;');
     });
   });
 });

--- a/packages/markdown/src/rendering/render.ts
+++ b/packages/markdown/src/rendering/render.ts
@@ -29,8 +29,8 @@ import type {
   Html,
   ImageReference,
   LinkReference,
-  Root as MdastRoot,
   Nodes as MdastNodes,
+  Root as MdastRoot,
   Parent,
 } from 'mdast';
 import rehypeSanitize from 'rehype-sanitize';
@@ -401,8 +401,14 @@ function renderFromMdast(
     // eslint-disable-next-line no-unsafe-type-assertion -- unified's `runSync` returns the broad unist `Node`; the prior rehype steps guarantee a hast `Root` here.
     .runSync(highlightedHast as HastRoot);
 
-  // Stringify the sanitized hast to HTML
-  const html = unified().use(rehypeStringify).stringify(sanitizedHast);
+  // Stringify the sanitized hast to HTML.
+  // useNamedReferences: true makes rehype-stringify emit &amp; instead of &#x26;
+  // for & in text nodes. Without this, & in highlighted code (from Shiki's
+  // &#x26; output decoded back to &) would be re-encoded as &#x26; — which
+  // browsers render correctly but which is unnecessarily verbose.
+  const html = unified()
+    .use(rehypeStringify, { characterReferences: { useNamedReferences: true } })
+    .stringify(sanitizedHast);
 
   return {
     rawMarkdown: markdown,

--- a/packages/playground/src/component-documentation.test.ts
+++ b/packages/playground/src/component-documentation.test.ts
@@ -70,10 +70,10 @@ describe('buildComponentDocumentation', () => {
 `);
 
     expect(readme.hadUnsafeContent).toBe(false);
-    expect(readme.html).toContain('&#x3C;Modal>');
-    expect(readme.html).toContain('&#x3C;p>');
-    expect(readme.html).toContain('&#x3C;script>');
-    expect(readme.html).toContain('&#x3C;style>');
+    expect(readme.html).toContain('&lt;Modal>');
+    expect(readme.html).toContain('&lt;p>');
+    expect(readme.html).toContain('&lt;script>');
+    expect(readme.html).toContain('&lt;style>');
     expect(readme.html).not.toContain('<script>');
     expect(readme.html).not.toContain('<style>');
     expect(readme.html).not.toContain('<img');


### PR DESCRIPTION
## Summary

- **Root cause**: Shiki emits hex HTML entities (`&#x3C;` for `<`, `&#x26;` for `&`) in highlighted code. The old `decodeHtmlEntities` function didn't handle these hex forms, so `rehype-stringify` saw undecoded `&#x26;` and re-encoded the `&` again, producing `&#x26;#x3C;` double-encoding in the final HTML.
- **`decodeHtmlEntities` rewrite**: Replaced the chained `.replace()` chain with a single-pass regex decoder (`HTML_ENTITY_PATTERN` alternation + `HTML_ENTITY_MAP` lookup). Single-pass is the only correct approach — chained replacements cascade in both directions (`&#x26;amp;` → `&amp;` → `&` and `&amp;#x26;` → `&#x26;` → `&`), regardless of ordering.
- **`rehypeStringify` option**: Added `characterReferences: { useNamedReferences: true }` so the serializer emits `&amp;` instead of `&#x26;` for ampersands in text nodes.
- **Playground background**: Applied `background: var(--cinder-surface-raised)` to the tab panel container so all three tabs (Documentation, Examples, Raw Artifacts) get the correct white surface rather than the grey-blue page background showing through.

## Review committee

Pre-reviewed by: testing-expert, typescript-expert, simplicity-engineer, junior-engineer, Codex (gpt-5.4, xhigh reasoning)
- 3 rounds of review
- All must-fix items addressed
- Unanimous approval on round 3

Round 1 must-fixes: cascade bug, duplicate test function, missing regression test.
Round 2 must-fix (Codex): reverse cascade in chained replaces — `&amp;#x26;` → `&`. Fixed by switching to single-pass decoder.
Round 3: all approved.

## Test plan

- `bun run --filter=@cinder/markdown test` — 735 pass, includes 8 cascade regression tests
- `bun run --filter=@cinder/playground test` — 617 pass
- Cascade cases verified: `&#x26;amp;` → `&amp;`, `&amp;#x26;` → `&#x26;`, `&#x26;lt;` → `&lt;`, `&#x26;#x3C;` → `&#x3C;`, `&amp;#x26;lt;` → `&#x26;lt;`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches markdown HTML serialization and entity decoding on the XSS-sensitive render path; behavior is heavily regression-tested but output encoding for highlighted code changes.
> 
> **Overview**
> Fixes **double-encoded HTML entities** in Shiki-highlighted code blocks by decoding Shiki’s hex entities (`&#x3C;`, `&#x26;`, etc.) in one pass so literals like `&#x26;amp;` are not decoded twice.
> 
> **`decodeHtmlEntities`** in `rehype-shiki-sync` is now a single regex pass with a lookup map (replacing chained `.replace()` calls) and is exported for unit tests, including cascade regression cases.
> 
> **`renderMarkdown`** passes `characterReferences: { useNamedReferences: true }` to `rehype-stringify` so ampersands in highlighted text serialize as `&amp;` instead of `&#x26;`.
> 
> Integration and playground README tests now assert no `&#x26;#x3C;` / `&#x26;` in output and expect named entities (`&lt;…`) where prose mentions tags as literal text.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 47e849c1ba64abfcf94cc60571920ebdc6e6fe33. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->