### PR TITLE
test(hydration): add a build-flag hydration-safety helper

### DIFF
--- a/packages/components/scripts/component-graph.ts
+++ b/packages/components/scripts/component-graph.ts
@@ -90,6 +90,11 @@ export function isTestFile(repoRelativePath: string): boolean {
 export const UNMODELLABLE_IMPORT_ALLOWLIST: ReadonlySet<string> = new Set([
   'packages/components/src/test/hydrate.ts',
   'packages/components/src/test/server-render.ts',
+  // Dynamic-imports the temp SSR modules it builds at runtime (a computed
+  // `import(pathToFileURL(modulePath))`), same as hydrate.ts/server-render.ts.
+  // The imported module is a generated build artifact, never a tracked source
+  // component, so it cannot create a component→component edge the scoper misses.
+  'packages/components/src/test/hydration-safety.ts',
 ]);
 
 // ---------------------------------------------------------------------------

--- a/packages/components/src/components/share-card/share-card.hydration-safety.test.ts
+++ b/packages/components/src/components/share-card/share-card.hydration-safety.test.ts
@@ -13,11 +13,11 @@
  *
  * What this proves and what it does not: it documents that the SHIPPED ShareCard
  * is build-flag-invariant — its SSR output is identical under `BROWSER=false` and
- * `BROWSER=true`. It is NOT a complete regression net on its own: because the
- * native-share affordance is gated on `hydrated && navigator.share` and the
- * helper clears browser globals for both renders, a regression that re-introduced
- * a bare `{#if BROWSER}` gate could still render the button absent in both passes
- * (the `navigator.share` half is never satisfied in SSR) and slip through here.
+ * `BROWSER=true`. It is NOT a complete regression net on its own: the native-share
+ * affordance is gated on `hydrated && navigator.share`, and `hydrated` is false in
+ * both SSR passes, so a regression that re-introduced a bare `{#if BROWSER}` gate
+ * could still render the button absent in both passes (the `navigator.share` half
+ * is never reached) and slip through here.
  * The proof that the harness CATCHES a `{#if BROWSER}` regression lives in the
  * synthetic `hydration-probe-child-browser-flag` fixture (a ShareCard-shaped
  * parent with an unconditional child), which the helper reports as

--- a/packages/components/src/components/share-card/share-card.hydration-safety.test.ts
+++ b/packages/components/src/components/share-card/share-card.hydration-safety.test.ts
@@ -1,0 +1,35 @@
+/// <reference lib="dom" />
+/**
+ * Build-flag hydration-safety regression for ShareCard (issue #11 / #324).
+ *
+ * ShareCard's native-share button is a client-only affordance. It originally
+ * gated on `esm-env`'s `BROWSER` build flag, which made the SSR markup
+ * (`BROWSER=false`) disagree with the client's initial hydration render
+ * (`BROWSER=true`) — a hydration mismatch. The fix gates it on a `hydrated`
+ * `$effect` instead, so the SSR render is identical regardless of the build
+ * flag. ShareCard also unconditionally renders a child component
+ * (`VisuallyHiddenLiveRegion`), making it the "component with unconditional
+ * child-effects" case the helper is built for.
+ *
+ * This pins the fix: render ShareCard's SSR output under `BROWSER=false` and
+ * `BROWSER=true` and assert they agree. A regression to a build-flag gate would
+ * make the two diverge and fail here.
+ */
+import { describe, expect, test } from 'bun:test';
+
+import { checkBuildFlagHydrationSafety } from '../../test/hydration-safety.ts';
+
+const shareCardPath = new URL('./share-card.svelte', import.meta.url).pathname;
+
+describe('ShareCard build-flag hydration safety', () => {
+  test('SSR markup is invariant under the BROWSER build-flag flip', async () => {
+    const result = await checkBuildFlagHydrationSafety(shareCardPath, {
+      value: 'https://example.com/share/abc',
+    });
+    expect(result.buildFlagInvariant).toBe(true);
+    // The native-share affordance must be absent from BOTH renders — it only
+    // appears after the `hydrated` $effect runs post-hydration, never in SSR.
+    expect(result.serverHtml).not.toContain('data-cinder-action="native-share"');
+    expect(result.clientHtml).not.toContain('data-cinder-action="native-share"');
+  });
+});

--- a/packages/components/src/components/share-card/share-card.hydration-safety.test.ts
+++ b/packages/components/src/components/share-card/share-card.hydration-safety.test.ts
@@ -11,9 +11,18 @@
  * (`VisuallyHiddenLiveRegion`), making it the "component with unconditional
  * child-effects" case the helper is built for.
  *
- * This pins the fix: render ShareCard's SSR output under `BROWSER=false` and
- * `BROWSER=true` and assert they agree. A regression to a build-flag gate would
- * make the two diverge and fail here.
+ * What this proves and what it does not: it documents that the SHIPPED ShareCard
+ * is build-flag-invariant — its SSR output is identical under `BROWSER=false` and
+ * `BROWSER=true`. It is NOT a complete regression net on its own: because the
+ * native-share affordance is gated on `hydrated && navigator.share` and the
+ * helper clears browser globals for both renders, a regression that re-introduced
+ * a bare `{#if BROWSER}` gate could still render the button absent in both passes
+ * (the `navigator.share` half is never satisfied in SSR) and slip through here.
+ * The proof that the harness CATCHES a `{#if BROWSER}` regression lives in the
+ * synthetic `hydration-probe-child-browser-flag` fixture (a ShareCard-shaped
+ * parent with an unconditional child), which the helper reports as
+ * `buildFlagInvariant: false`. This test is the real-world companion to that
+ * synthetic proof.
  */
 import { describe, expect, test } from 'bun:test';
 

--- a/packages/components/src/test/fixtures/hydration-probe-browser-flag.svelte
+++ b/packages/components/src/test/fixtures/hydration-probe-browser-flag.svelte
@@ -1,0 +1,18 @@
+<!--
+  PROBE FIXTURE (#17): a client-only affordance gated on esm-env's `BROWSER`
+  build flag — the buggy pattern from the original ShareCard native-share bug.
+
+  `BROWSER` is a compile-time constant: false in the server build, true in the
+  client build. So the affordance is absent in SSR HTML; whether it ever appears
+  after hydration depends entirely on what `BROWSER` resolves to in the CLIENT
+  compilation the test hydrates with. This fixture exists only to measure that.
+-->
+<script lang="ts">
+  import { BROWSER } from 'esm-env';
+</script>
+
+<div data-testid="probe-root">
+  {#if BROWSER}
+    <span data-testid="client-only">visible only in the browser</span>
+  {/if}
+</div>

--- a/packages/components/src/test/fixtures/hydration-probe-browser-flag.svelte
+++ b/packages/components/src/test/fixtures/hydration-probe-browser-flag.svelte
@@ -3,9 +3,9 @@
   build flag — the buggy pattern from the original ShareCard native-share bug.
 
   `BROWSER` is a compile-time constant: false in the server build, true in the
-  client build. So the affordance is absent in SSR HTML; whether it ever appears
-  after hydration depends entirely on what `BROWSER` resolves to in the CLIENT
-  compilation the test hydrates with. This fixture exists only to measure that.
+  client build. So the affordance is ABSENT from the server-condition SSR render
+  and PRESENT in the browser-condition SSR render. checkBuildFlagHydrationSafety
+  compares those two renders and flags the divergence (buildFlagInvariant: false).
 -->
 <script lang="ts">
   import { BROWSER } from 'esm-env';

--- a/packages/components/src/test/fixtures/hydration-probe-child-browser-flag.svelte
+++ b/packages/components/src/test/fixtures/hydration-probe-child-browser-flag.svelte
@@ -1,0 +1,20 @@
+<!--
+  PROBE FIXTURE (#17): a parent that UNCONDITIONALLY renders a child component
+  (with its own $effect) AND gates a client-only affordance on the `BROWSER`
+  build flag — the buggy pattern, but with the child-effect wrinkle the task is
+  named for. The child renders identically under both build conditions; only the
+  BROWSER-gated span diverges, so checkBuildFlagHydrationSafety must still flag
+  this component as unsafe (the child must not mask the divergence).
+-->
+<script lang="ts">
+  import { BROWSER } from 'esm-env';
+
+  import HydrationProbeChild from './hydration-probe-child.svelte';
+</script>
+
+<div data-testid="probe-root">
+  <HydrationProbeChild />
+  {#if BROWSER}
+    <span data-testid="client-only">visible only in the browser</span>
+  {/if}
+</div>

--- a/packages/components/src/test/fixtures/hydration-probe-child-effect-gate.svelte
+++ b/packages/components/src/test/fixtures/hydration-probe-child-effect-gate.svelte
@@ -1,0 +1,23 @@
+<!--
+  PROBE FIXTURE (#17): the SAFE counterpart of hydration-probe-child-browser-flag
+  — an unconditionally-rendered child with its own $effect, plus a client-only
+  affordance gated on a `hydrated` $effect (the correct pattern) instead of the
+  BROWSER build flag. The SSR render is identical under both build conditions, so
+  checkBuildFlagHydrationSafety must report this component as safe even though it
+  renders a child component with effects.
+-->
+<script lang="ts">
+  import HydrationProbeChild from './hydration-probe-child.svelte';
+
+  let hydrated = $state(false);
+  $effect(() => {
+    hydrated = true;
+  });
+</script>
+
+<div data-testid="probe-root">
+  <HydrationProbeChild />
+  {#if hydrated}
+    <span data-testid="client-only">visible only after hydration</span>
+  {/if}
+</div>

--- a/packages/components/src/test/fixtures/hydration-probe-child.svelte
+++ b/packages/components/src/test/fixtures/hydration-probe-child.svelte
@@ -1,0 +1,15 @@
+<!--
+  PROBE CHILD FIXTURE (#17): an UNCONDITIONALLY-rendered child component with its
+  own $effect. This is the "components with unconditional child-effects" case the
+  task is named for — renderThenHydrate can't server-compile this child (only the
+  top-level component), but checkBuildFlagHydrationSafety bundles the whole import
+  graph via Bun.build, so the child renders natively on the server.
+-->
+<script lang="ts">
+  let mounted = $state(false);
+  $effect(() => {
+    mounted = true;
+  });
+</script>
+
+<span data-testid="child" data-mounted={mounted}>child content</span>

--- a/packages/components/src/test/fixtures/hydration-probe-effect-gate.svelte
+++ b/packages/components/src/test/fixtures/hydration-probe-effect-gate.svelte
@@ -1,0 +1,19 @@
+<!--
+  PROBE FIXTURE (#17): a client-only affordance gated on a `hydrated` $effect —
+  the CORRECT pattern (the ShareCard fix). `hydrated` starts false, so the
+  affordance is absent in SSR HTML AND in the initial hydration render; the
+  $effect then flips it true on the client, so the affordance appears after
+  hydration's effects flush. This fixture exists only to measure that transition.
+-->
+<script lang="ts">
+  let hydrated = $state(false);
+  $effect(() => {
+    hydrated = true;
+  });
+</script>
+
+<div data-testid="probe-root">
+  {#if hydrated}
+    <span data-testid="client-only">visible only after hydration</span>
+  {/if}
+</div>

--- a/packages/components/src/test/fixtures/hydration-probe-effect-gate.svelte
+++ b/packages/components/src/test/fixtures/hydration-probe-effect-gate.svelte
@@ -1,9 +1,11 @@
 <!--
   PROBE FIXTURE (#17): a client-only affordance gated on a `hydrated` $effect —
-  the CORRECT pattern (the ShareCard fix). `hydrated` starts false, so the
-  affordance is absent in SSR HTML AND in the initial hydration render; the
-  $effect then flips it true on the client, so the affordance appears after
-  hydration's effects flush. This fixture exists only to measure that transition.
+  the CORRECT pattern (the ShareCard fix). `hydrated` starts false and $effect
+  does not run during SSR, so the affordance is ABSENT from the SSR render under
+  BOTH build conditions — server and browser. checkBuildFlagHydrationSafety sees
+  identical output either way and reports it safe (buildFlagInvariant: true). At
+  runtime the $effect flips `hydrated` true after hydration; that transition is
+  outside what this static SSR-comparison harness checks.
 -->
 <script lang="ts">
   let hydrated = $state(false);

--- a/packages/components/src/test/hydration-safety.test.ts
+++ b/packages/components/src/test/hydration-safety.test.ts
@@ -1,0 +1,73 @@
+/// <reference lib="dom" />
+/**
+ * Contract for the build-flag hydration-safety helper (#17).
+ *
+ * The helper renders a component's SSR output twice — `BROWSER=false` (server)
+ * and `BROWSER=true` (client-intent) — and reports whether they agree. The two
+ * fixture pairs below pin both halves of its contract:
+ *
+ *   - a `{#if BROWSER}` gate is build-flag-DEPENDENT → the helper reports it
+ *     UNSAFE (the original ShareCard native-share bug class);
+ *   - a `hydrated` `$effect` gate is build-flag-INVARIANT → the helper reports
+ *     it SAFE (the fix).
+ *
+ * Each pattern is tested both standalone and with an unconditionally-rendered
+ * child component that owns its own `$effect` — the "components with
+ * unconditional child-effects" case the task is named for, which the helper
+ * handles natively because `Bun.build` bundles the whole import graph.
+ */
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, setDefaultTimeout, test } from 'bun:test';
+
+import { checkBuildFlagHydrationSafety } from './hydration-safety.ts';
+
+const fixturesDir = join(dirname(fileURLToPath(import.meta.url)), 'fixtures');
+const fixture = (name: string): string => join(fixturesDir, `${name}.svelte`);
+
+// Each check runs two Bun.build + render passes — slower than the 5s default
+// under CPU contention. Match the schema-fallback suite's headroom.
+setDefaultTimeout(60_000);
+
+describe('checkBuildFlagHydrationSafety', () => {
+  test('flags a {#if BROWSER}-gated component as UNSAFE', async () => {
+    const result = await checkBuildFlagHydrationSafety(fixture('hydration-probe-browser-flag'));
+    expect(result.buildFlagInvariant).toBe(false);
+    // The divergence is precisely the client-only affordance: absent server-side,
+    // present client-side.
+    expect(result.serverHtml).not.toContain('data-testid="client-only"');
+    expect(result.clientHtml).toContain('data-testid="client-only"');
+  });
+
+  test('reports a `hydrated` $effect-gated component as SAFE', async () => {
+    const result = await checkBuildFlagHydrationSafety(fixture('hydration-probe-effect-gate'));
+    expect(result.buildFlagInvariant).toBe(true);
+    // The affordance is absent under BOTH conditions — `hydrated` is false in SSR
+    // regardless of BROWSER, so there is nothing to mismatch.
+    expect(result.serverHtml).not.toContain('data-testid="client-only"');
+    expect(result.clientHtml).not.toContain('data-testid="client-only"');
+  });
+
+  test('flags a BROWSER-gated component as UNSAFE even with an unconditional child-effect', async () => {
+    const result = await checkBuildFlagHydrationSafety(
+      fixture('hydration-probe-child-browser-flag'),
+    );
+    expect(result.buildFlagInvariant).toBe(false);
+    // The unconditionally-rendered child is present under BOTH conditions — it
+    // does not mask the BROWSER-gated divergence.
+    expect(result.serverHtml).toContain('data-testid="child"');
+    expect(result.clientHtml).toContain('data-testid="child"');
+    expect(result.serverHtml).not.toContain('data-testid="client-only"');
+    expect(result.clientHtml).toContain('data-testid="client-only"');
+  });
+
+  test('reports an $effect-gated component as SAFE even with an unconditional child-effect', async () => {
+    const result = await checkBuildFlagHydrationSafety(
+      fixture('hydration-probe-child-effect-gate'),
+    );
+    expect(result.buildFlagInvariant).toBe(true);
+    expect(result.serverHtml).toContain('data-testid="child"');
+    expect(result.clientHtml).toContain('data-testid="child"');
+  });
+});

--- a/packages/components/src/test/hydration-safety.test.ts
+++ b/packages/components/src/test/hydration-safety.test.ts
@@ -69,5 +69,9 @@ describe('checkBuildFlagHydrationSafety', () => {
     expect(result.buildFlagInvariant).toBe(true);
     expect(result.serverHtml).toContain('data-testid="child"');
     expect(result.clientHtml).toContain('data-testid="child"');
+    // The gated affordance is absent under BOTH conditions — same as the
+    // childless safe case; the child does not smuggle it into either render.
+    expect(result.serverHtml).not.toContain('data-testid="client-only"');
+    expect(result.clientHtml).not.toContain('data-testid="client-only"');
   });
 });

--- a/packages/components/src/test/hydration-safety.ts
+++ b/packages/components/src/test/hydration-safety.ts
@@ -3,50 +3,40 @@
  * Build-flag hydration-safety test helper.
  *
  * Catches the class of hydration bug where a component's server-rendered markup
- * depends on a *build-time* environment flag — the canonical example being
- * `esm-env`'s `BROWSER`, which is `false` in the server build and `true` in the
- * client build. A `{#if BROWSER}` branch then renders nothing on the server but
- * something on the client's initial hydration pass, so the SSR HTML and the
- * client's hydration target disagree. This is exactly the original ShareCard
- * native-share bug; the fix is to gate client-only affordances on a `hydrated`
- * `$effect` (false during SSR *and* the initial hydration render, flipped true
- * by an effect afterwards) rather than on the build flag.
+ * depends on a *build-time* flag — canonically `esm-env`'s `BROWSER` (`false` in
+ * the server build, `true` in the client build). A `{#if BROWSER}` branch then
+ * renders nothing on the server but something on the client's initial hydration
+ * render, so the two disagree. This was the original ShareCard native-share bug;
+ * the fix gates client-only affordances on a `hydrated` `$effect` (false during
+ * SSR *and* the initial hydration render) instead of the build flag.
  *
- * How it works — two-sided invariance under the browser-condition flip:
- *   1. Build + server-render the component with the `browser` export condition
- *      OFF → esm-env resolves `BROWSER=false` → the SSR markup a real server
- *      produces.
- *   2. Build + server-render the SAME component with the `browser` condition ON
- *      → `BROWSER=true` → the markup the client's initial hydration render
- *      WANTS.
- *   3. Compare. If they differ, the component's render depends on the build-flag
- *      split — a hydration mismatch waiting to happen. If they match, it is
- *      build-flag-invariant and hydration-safe in this respect.
+ * Mechanism — two-sided invariance under the browser-condition flip: build +
+ * server-render the component twice, with the `browser` export condition off
+ * (`BROWSER=false`, real server markup) and on (`BROWSER=true`, the declarative
+ * markup the client's initial render wants), and compare. Differ → the render
+ * depends on the build flag. Match → it is build-flag-invariant.
  *
- * A `hydrated`-`$effect` gate is build-flag-invariant (the SSR render is the
- * same regardless of `BROWSER`, because `hydrated` starts `false` either way),
- * so it passes. A `{#if BROWSER}` gate is not, so it fails. That contrast is the
- * helper's whole contract.
+ * Why a static double-render rather than a real hydrate: Svelte 5 does not
+ * reliably emit a `hydration_mismatch` warning for an `{#if}` condition that
+ * merely evaluates differently — that warning is tied to hydration-walk
+ * structure failures, while a build-flag branch divergence is reconciled
+ * silently (confirmed in both happy-dom and a real Chromium dev hydrate). So
+ * runtime warning capture cannot observe this bug; the build-time render
+ * divergence is the deterministic signal. (See the PR for the full evidence.)
  *
- * Why static double-render, not a real hydrate: Svelte 5 only emits its
- * `hydration_mismatch` console warning for STRUCTURAL hydration-walk failures
- * (misaligned anchors, a missing expected node), NOT for an `{#if}` condition
- * that merely evaluates differently — it reconciles that silently, in both
- * happy-dom and a real browser. So neither a bun-test `hydrate()` nor a
- * Playwright console capture can observe this bug at runtime. The faithful,
- * deterministic signal is the build-time render divergence itself.
- *
- * Scope: this covers control-flow that branches on the build flag (`{#if}`,
- * `{#each}` over flag-derived data, attribute presence) — the #17 bug class. It
- * is a "build-flag hydration-safety check", not a universal hydration-mismatch
- * detector; it does not exercise bindings, actions, or runtime-only effects.
+ * Scope: build-flag control flow (`{#if BROWSER}`, `{#each}` over flag-derived
+ * data, flag-derived attribute presence). This is a proxy for the client
+ * compilation's initial declarative markup shape, NOT a full hydration pass — it
+ * does not validate bindings, actions, event attachment, lifecycle ordering, or
+ * DOM mutation during hydration. See {@link HydrationSafetyResult.buildFlagInvariant}.
  *
  * `Bun.build` resolves the full import graph, so a component that unconditionally
- * renders child `.svelte` components is handled natively — no special casing for
- * child effects (unlike `renderThenHydrate`, which only server-compiles the
+ * renders child `.svelte` components is handled natively — the "unconditional
+ * child-effects" case `renderThenHydrate` cannot (it server-compiles only the
  * top-level component).
  */
 import type { BunPlugin } from 'bun';
+import { unlinkSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 
@@ -60,10 +50,13 @@ const hydrationSafetyTempDir = join(here, '..', '..', 'tmp', 'hydration-safety')
 /**
  * Minimal server-target Svelte plugin with `dev: false`. Dev mode is wrong here:
  * its element instrumentation (`push_element`) reads a component context that a
- * bare `render()` on a bundled module never establishes, and the server half
- * never needs a dev warning. Components carrying a `<style>` block are out of
- * scope for this helper (library components keep styles in `src/styles/`); CSS
- * is injected so the rare style-bearing fixture still compiles.
+ * bare `render()` on a bundled module never establishes. This is acceptable
+ * because the helper only compares production SSR HTML under two build
+ * conditions — it is not a warning-capture or development-hydration validator,
+ * and `{#if BROWSER}` markup divergence shows up in production output regardless.
+ * Components carrying a `<style>` block are out of scope (library components keep
+ * styles in `src/styles/`); CSS is injected so the rare style-bearing fixture
+ * still compiles.
  */
 function serverCompilePlugin(): BunPlugin {
   return {
@@ -114,11 +107,14 @@ async function renderWithConditions(
   const artifact = build.outputs[0];
   if (!artifact) throw new Error(`hydration-safety: no server artifact for ${componentPath}`);
 
-  // External svelte alone isn't enough: the test process runs under the
-  // `browser` export condition, so a runtime-resolved bare `svelte` import
-  // lands on the CLIENT build, whose `onDestroy`/`setContext` throw during a
-  // server render. Repoint the bare svelte specifiers at Svelte's server index
-  // (and server internals) — the same rewrite renderToServerHtml/hydrate.ts use.
+  // External svelte alone isn't enough: the test process runs under the `browser`
+  // export condition, so a runtime-resolved `svelte`/`svelte/internal/server`
+  // import lands on the CLIENT build, whose `onDestroy`/`setContext` throw during
+  // a server render. Repoint those at Svelte's server index — the same rewrite
+  // renderToServerHtml/hydrate.ts use. Other `svelte/*` subpaths
+  // (`svelte/reactivity`, `svelte/store`, …) stay runtime-resolved: they are
+  // isomorphic across the browser/server condition for SSR (verified with a
+  // `SvelteMap` child), so they don't fork the rendered markup.
   const sveltePackageUrl = import.meta.resolve('svelte/package.json');
   const serverIndexUrl = new URL('./src/index-server.js', sveltePackageUrl).href;
   const serverInternalUrl = new URL('./src/internal/server/index.js', sveltePackageUrl).href;
@@ -130,31 +126,24 @@ async function renderWithConditions(
     )
     .replaceAll(/from\s*['"]svelte['"]/g, `from ${JSON.stringify(serverIndexUrl)}`);
 
-  const moduleName = `${conditions.includes('browser') ? 'client' : 'server'}-${Bun.hash(
-    componentPath,
-  ).toString(36)}.mjs`;
+  // Unique per-call filename + finally cleanup so parallel checks on the SAME
+  // component path never race the same module file (mirrors hydrate.ts).
+  const moduleName = `${conditions.includes('browser') ? 'client' : 'server'}-${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2)}.mjs`;
   const modulePath = join(hydrationSafetyTempDir, moduleName);
   await Bun.write(modulePath, code);
 
   const { render } = (await import('svelte/server')) as typeof import('svelte/server');
-  const module = (await import(pathToFileURL(modulePath).href)) as { default: unknown };
 
   // Clear the happy-dom globals the surrounding test suite installs at module
-  // scope, so a component that branches on `typeof document`/`navigator` takes
-  // the server path during this server-only render (mirrors server-render.ts).
+  // scope, so a component that branches on `typeof document`/`typeof window`
+  // takes the server path during this server-only render (mirrors
+  // server-render.ts, which clears exactly these two).
   const originalDocument = globalThis.document;
   const originalWindow = globalThis.window;
-  const originalNavigator = globalThis.navigator;
   globalThis.document = undefined as unknown as Document;
   globalThis.window = undefined as unknown as Window & typeof globalThis;
-  // `navigator` is a getter-only global in some runtimes; delete defensively.
   try {
-    delete (globalThis as { navigator?: unknown }).navigator;
-  } catch {
-    // Non-configurable in this runtime — leave it; `hydrated`-gated reads still
-    // take the server path because `hydrated` is false during SSR.
-  }
-  try {
+    const module = (await import(pathToFileURL(modulePath).href)) as { default: unknown };
     // The SSR module's default export is a server render function whose shape
     // doesn't match the public `Component` type; `render` accepts it at runtime.
     // Route through `Component<Record<string, unknown>>` (not `never`) so the
@@ -163,12 +152,10 @@ async function renderWithConditions(
   } finally {
     globalThis.document = originalDocument;
     globalThis.window = originalWindow;
-    if (originalNavigator !== undefined) {
-      try {
-        (globalThis as { navigator?: unknown }).navigator = originalNavigator;
-      } catch {
-        // Restore best-effort.
-      }
+    try {
+      unlinkSync(modulePath);
+    } catch {
+      // Best-effort — a stray temp module never breaks a test.
     }
   }
 }
@@ -198,17 +185,8 @@ export type HydrationSafetyResult = {
  * will hydration-mismatch; gate the offending markup on a `hydrated` `$effect`
  * instead.
  *
- * Scope — what this catches and what it does NOT: it catches the build-flag
- * (esm-env `BROWSER`-style) divergence — the #11/ShareCard bug class. It does
- * NOT catch a component that gates on a *runtime* environment check
- * (`{#if typeof window !== 'undefined'}`, `typeof navigator`) that is not also
- * behind a `hydrated` guard: both renders clear those globals identically, so
- * such a divergence is invisible here and would be reported `buildFlagInvariant:
- * true` despite mismatching in production. A `buildFlagInvariant: true` result
- * means "render does not depend on the build flag", not "hydration-safe in every
- * respect". ShareCard passes precisely because its `navigator` read sits behind
- * `hydrated &&` — which is the correct fix and what this helper guards against
- * regressing.
+ * See {@link HydrationSafetyResult.buildFlagInvariant} for what a `true` result
+ * does and does not guarantee.
  *
  * @param componentPath Absolute path to the component's `.svelte` file.
  * @param props Props forwarded to BOTH server renders (must be identical so the
@@ -218,7 +196,36 @@ export async function checkBuildFlagHydrationSafety(
   componentPath: string,
   props: Record<string, unknown> = {},
 ): Promise<HydrationSafetyResult> {
+  await assertDiscriminatorWorks();
   const serverHtml = await renderWithConditions(componentPath, ['svelte'], props);
   const clientHtml = await renderWithConditions(componentPath, ['browser', 'svelte'], props);
   return { buildFlagInvariant: serverHtml === clientHtml, serverHtml, clientHtml };
+}
+
+/**
+ * Memoized fail-closed self-check: the whole helper rests on `Bun.build`'s
+ * `conditions` flipping esm-env's `BROWSER` between the two renders. If that ever
+ * stops working (an esm-env export-map change, a resolution-cache quirk), every
+ * `{#if BROWSER}` component would render identically both ways and be silently
+ * reported `buildFlagInvariant: true` — a false negative on the exact bug class
+ * this exists to catch. So before the first real check, render a sentinel that
+ * is KNOWN to diverge on `BROWSER` and assert it actually does. Memoized to one
+ * build pair per process so it doesn't double the cost of every call.
+ */
+let discriminatorVerified: Promise<void> | null = null;
+function assertDiscriminatorWorks(): Promise<void> {
+  discriminatorVerified ??= (async () => {
+    const sentinel = join(here, 'fixtures', 'hydration-probe-browser-flag.svelte');
+    const off = await renderWithConditions(sentinel, ['svelte'], {});
+    const on = await renderWithConditions(sentinel, ['browser', 'svelte'], {});
+    if (off === on) {
+      throw new Error(
+        'hydration-safety: the BROWSER build-flag discriminator is not working — the ' +
+          '`{#if BROWSER}` sentinel rendered identically under both build conditions. ' +
+          'Every check would be a false negative. Investigate esm-env resolution / Bun.build ' +
+          'conditions before trusting any `buildFlagInvariant` result.',
+      );
+    }
+  })();
+  return discriminatorVerified;
 }

--- a/packages/components/src/test/hydration-safety.ts
+++ b/packages/components/src/test/hydration-safety.ts
@@ -165,11 +165,15 @@ export type HydrationSafetyResult = {
   /**
    * `true` when the SSR markup is identical under `BROWSER=false` and
    * `BROWSER=true` — i.e. the render does not depend on the esm-env build-flag
-   * split. This is NOT a blanket "hydration-safe" verdict: it says nothing about
-   * runtime environment checks (`{#if typeof window !== 'undefined'}`,
-   * `typeof navigator`) that aren't already behind a `hydrated` guard — both
-   * renders clear those globals identically, so such a divergence is invisible
-   * here. Read it as "invariant under the build flag", not "safe in general".
+   * split. This is NOT a blanket "hydration-safe" verdict. Both renders clear
+   * `document` and `window` (so a `{#if typeof window !== 'undefined'}` branch
+   * takes the server path in each), but `navigator` is intentionally left
+   * ambient. So a runtime capability check — `navigator.share`, `navigator.clipboard`
+   * — is outside this helper's guarantee unless it sits behind a `hydrated`
+   * guard: whether it renders depends on what the surrounding test environment
+   * exposes, not on the build-flag split. Read a `true` result as "invariant
+   * under the build flag", not "safe in general". (ShareCard is invariant
+   * precisely because its `navigator.share` read is behind `hydrated &&`.)
    */
   buildFlagInvariant: boolean;
   /** SSR markup with the `browser` condition OFF (`BROWSER=false`) — real server output. */

--- a/packages/components/src/test/hydration-safety.ts
+++ b/packages/components/src/test/hydration-safety.ts
@@ -1,0 +1,224 @@
+/// <reference lib="dom" />
+/**
+ * Build-flag hydration-safety test helper.
+ *
+ * Catches the class of hydration bug where a component's server-rendered markup
+ * depends on a *build-time* environment flag — the canonical example being
+ * `esm-env`'s `BROWSER`, which is `false` in the server build and `true` in the
+ * client build. A `{#if BROWSER}` branch then renders nothing on the server but
+ * something on the client's initial hydration pass, so the SSR HTML and the
+ * client's hydration target disagree. This is exactly the original ShareCard
+ * native-share bug; the fix is to gate client-only affordances on a `hydrated`
+ * `$effect` (false during SSR *and* the initial hydration render, flipped true
+ * by an effect afterwards) rather than on the build flag.
+ *
+ * How it works — two-sided invariance under the browser-condition flip:
+ *   1. Build + server-render the component with the `browser` export condition
+ *      OFF → esm-env resolves `BROWSER=false` → the SSR markup a real server
+ *      produces.
+ *   2. Build + server-render the SAME component with the `browser` condition ON
+ *      → `BROWSER=true` → the markup the client's initial hydration render
+ *      WANTS.
+ *   3. Compare. If they differ, the component's render depends on the build-flag
+ *      split — a hydration mismatch waiting to happen. If they match, it is
+ *      build-flag-invariant and hydration-safe in this respect.
+ *
+ * A `hydrated`-`$effect` gate is build-flag-invariant (the SSR render is the
+ * same regardless of `BROWSER`, because `hydrated` starts `false` either way),
+ * so it passes. A `{#if BROWSER}` gate is not, so it fails. That contrast is the
+ * helper's whole contract.
+ *
+ * Why static double-render, not a real hydrate: Svelte 5 only emits its
+ * `hydration_mismatch` console warning for STRUCTURAL hydration-walk failures
+ * (misaligned anchors, a missing expected node), NOT for an `{#if}` condition
+ * that merely evaluates differently — it reconciles that silently, in both
+ * happy-dom and a real browser. So neither a bun-test `hydrate()` nor a
+ * Playwright console capture can observe this bug at runtime. The faithful,
+ * deterministic signal is the build-time render divergence itself.
+ *
+ * Scope: this covers control-flow that branches on the build flag (`{#if}`,
+ * `{#each}` over flag-derived data, attribute presence) — the #17 bug class. It
+ * is a "build-flag hydration-safety check", not a universal hydration-mismatch
+ * detector; it does not exercise bindings, actions, or runtime-only effects.
+ *
+ * `Bun.build` resolves the full import graph, so a component that unconditionally
+ * renders child `.svelte` components is handled natively — no special casing for
+ * child effects (unlike `renderThenHydrate`, which only server-compiles the
+ * top-level component).
+ */
+import type { BunPlugin } from 'bun';
+import { dirname, join } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+import type { Component } from 'svelte';
+import { compile } from 'svelte/compiler';
+
+const here = dirname(fileURLToPath(import.meta.url));
+/** Scratch directory for the per-render server modules this helper emits. */
+const hydrationSafetyTempDir = join(here, '..', '..', 'tmp', 'hydration-safety');
+
+/**
+ * Minimal server-target Svelte plugin with `dev: false`. Dev mode is wrong here:
+ * its element instrumentation (`push_element`) reads a component context that a
+ * bare `render()` on a bundled module never establishes, and the server half
+ * never needs a dev warning. Components carrying a `<style>` block are out of
+ * scope for this helper (library components keep styles in `src/styles/`); CSS
+ * is injected so the rare style-bearing fixture still compiles.
+ */
+function serverCompilePlugin(): BunPlugin {
+  return {
+    name: 'hydration-safety-svelte-server',
+    setup(builder) {
+      builder.onLoad({ filter: /\.svelte$/ }, async ({ path }) => {
+        const source = await Bun.file(path).text();
+        const result = compile(source, {
+          filename: path,
+          generate: 'server',
+          css: 'injected',
+          dev: false,
+        });
+        return { contents: result.js.code, loader: 'js' };
+      });
+    },
+  };
+}
+
+/**
+ * Build `componentPath` for the server with the given export `conditions`, then
+ * server-render it and return the HTML body. `browser` in `conditions` makes
+ * esm-env resolve `BROWSER=true`; omitting it resolves `BROWSER=false`.
+ */
+async function renderWithConditions(
+  componentPath: string,
+  conditions: readonly string[],
+  props: Record<string, unknown>,
+): Promise<string> {
+  const build = await Bun.build({
+    entrypoints: [componentPath],
+    target: 'bun',
+    conditions: [...conditions],
+    // Svelte MUST stay a single shared instance, not bundled. If Bun.build
+    // inlined svelte's server internals, the component module would carry its
+    // own `ssr_context` module state, separate from the `render()` we import
+    // below — `render()` would initialize ITS copy's context while the bundled
+    // component reads its own (null) copy, crashing any component that touches a
+    // lifecycle/context API (`onDestroy`, `getContext`). esm-env, by contrast,
+    // stays bundled so `conditions` still flips BROWSER — that's the discriminator.
+    external: ['svelte', 'svelte/*'],
+    plugins: [serverCompilePlugin()],
+  });
+  if (!build.success) {
+    const logText = build.logs.map((log) => String(log.message ?? log)).join('\n');
+    throw new Error(`hydration-safety: server build failed for ${componentPath}\n${logText}`);
+  }
+  const artifact = build.outputs[0];
+  if (!artifact) throw new Error(`hydration-safety: no server artifact for ${componentPath}`);
+
+  // External svelte alone isn't enough: the test process runs under the
+  // `browser` export condition, so a runtime-resolved bare `svelte` import
+  // lands on the CLIENT build, whose `onDestroy`/`setContext` throw during a
+  // server render. Repoint the bare svelte specifiers at Svelte's server index
+  // (and server internals) — the same rewrite renderToServerHtml/hydrate.ts use.
+  const sveltePackageUrl = import.meta.resolve('svelte/package.json');
+  const serverIndexUrl = new URL('./src/index-server.js', sveltePackageUrl).href;
+  const serverInternalUrl = new URL('./src/internal/server/index.js', sveltePackageUrl).href;
+  let code = await artifact.text();
+  code = code
+    .replaceAll(
+      /from\s*['"]svelte\/internal\/server['"]/g,
+      `from ${JSON.stringify(serverInternalUrl)}`,
+    )
+    .replaceAll(/from\s*['"]svelte['"]/g, `from ${JSON.stringify(serverIndexUrl)}`);
+
+  const moduleName = `${conditions.includes('browser') ? 'client' : 'server'}-${Bun.hash(
+    componentPath,
+  ).toString(36)}.mjs`;
+  const modulePath = join(hydrationSafetyTempDir, moduleName);
+  await Bun.write(modulePath, code);
+
+  const { render } = (await import('svelte/server')) as typeof import('svelte/server');
+  const module = (await import(pathToFileURL(modulePath).href)) as { default: unknown };
+
+  // Clear the happy-dom globals the surrounding test suite installs at module
+  // scope, so a component that branches on `typeof document`/`navigator` takes
+  // the server path during this server-only render (mirrors server-render.ts).
+  const originalDocument = globalThis.document;
+  const originalWindow = globalThis.window;
+  const originalNavigator = globalThis.navigator;
+  globalThis.document = undefined as unknown as Document;
+  globalThis.window = undefined as unknown as Window & typeof globalThis;
+  // `navigator` is a getter-only global in some runtimes; delete defensively.
+  try {
+    delete (globalThis as { navigator?: unknown }).navigator;
+  } catch {
+    // Non-configurable in this runtime — leave it; `hydrated`-gated reads still
+    // take the server path because `hydrated` is false during SSR.
+  }
+  try {
+    // The SSR module's default export is a server render function whose shape
+    // doesn't match the public `Component` type; `render` accepts it at runtime.
+    // Route through `Component<Record<string, unknown>>` (not `never`) so the
+    // `props` argument typechecks — mirrors server-render.ts.
+    return render(module.default as Component<Record<string, unknown>>, { props }).body;
+  } finally {
+    globalThis.document = originalDocument;
+    globalThis.window = originalWindow;
+    if (originalNavigator !== undefined) {
+      try {
+        (globalThis as { navigator?: unknown }).navigator = originalNavigator;
+      } catch {
+        // Restore best-effort.
+      }
+    }
+  }
+}
+
+/** Result of a build-flag hydration-safety check. */
+export type HydrationSafetyResult = {
+  /**
+   * `true` when the SSR markup is identical under `BROWSER=false` and
+   * `BROWSER=true` — i.e. the render does not depend on the esm-env build-flag
+   * split. This is NOT a blanket "hydration-safe" verdict: it says nothing about
+   * runtime environment checks (`{#if typeof window !== 'undefined'}`,
+   * `typeof navigator`) that aren't already behind a `hydrated` guard — both
+   * renders clear those globals identically, so such a divergence is invisible
+   * here. Read it as "invariant under the build flag", not "safe in general".
+   */
+  buildFlagInvariant: boolean;
+  /** SSR markup with the `browser` condition OFF (`BROWSER=false`) — real server output. */
+  serverHtml: string;
+  /** SSR markup with the `browser` condition ON (`BROWSER=true`) — client-intent output. */
+  clientHtml: string;
+};
+
+/**
+ * Render `componentPath` twice — once with `BROWSER=false`, once with
+ * `BROWSER=true` — and report whether the two SSR outputs agree. When they
+ * differ, the component's render depends on the esm-env build-flag split and
+ * will hydration-mismatch; gate the offending markup on a `hydrated` `$effect`
+ * instead.
+ *
+ * Scope — what this catches and what it does NOT: it catches the build-flag
+ * (esm-env `BROWSER`-style) divergence — the #11/ShareCard bug class. It does
+ * NOT catch a component that gates on a *runtime* environment check
+ * (`{#if typeof window !== 'undefined'}`, `typeof navigator`) that is not also
+ * behind a `hydrated` guard: both renders clear those globals identically, so
+ * such a divergence is invisible here and would be reported `buildFlagInvariant:
+ * true` despite mismatching in production. A `buildFlagInvariant: true` result
+ * means "render does not depend on the build flag", not "hydration-safe in every
+ * respect". ShareCard passes precisely because its `navigator` read sits behind
+ * `hydrated &&` — which is the correct fix and what this helper guards against
+ * regressing.
+ *
+ * @param componentPath Absolute path to the component's `.svelte` file.
+ * @param props Props forwarded to BOTH server renders (must be identical so the
+ *   only varying input is the build flag).
+ */
+export async function checkBuildFlagHydrationSafety(
+  componentPath: string,
+  props: Record<string, unknown> = {},
+): Promise<HydrationSafetyResult> {
+  const serverHtml = await renderWithConditions(componentPath, ['svelte'], props);
+  const clientHtml = await renderWithConditions(componentPath, ['browser', 'svelte'], props);
+  return { buildFlagInvariant: serverHtml === clientHtml, serverHtml, clientHtml };
+}


### PR DESCRIPTION
## Summary

Adds `checkBuildFlagHydrationSafety` — a reusable, deterministic check for the class of hydration bug where a component's server-rendered markup depends on a **build-time** flag (esm-env's `BROWSER`: `false` in the server build, `true` in the client build). A `{#if BROWSER}` branch renders nothing on the server but something on the client's initial hydration render, so the two disagree. This was the original ShareCard native-share bug (#11/#324); the fix gates client-only affordances on a `hydrated` `$effect` instead of the build flag.

Resolves follow-up task #17 (reusable hydration-mismatch harness for components with unconditional child-effects).

**Mechanism — two-sided invariance under the browser-condition flip:** build + server-render the component twice, once with the `browser` export condition off (`BROWSER=false`, real server markup) and once on (`BROWSER=true`, the declarative markup the client's initial render wants), and assert the two SSR outputs are equal. A `{#if BROWSER}` gate makes them differ (`buildFlagInvariant: false`); a `hydrated` `$effect` gate keeps them identical (`true`). That is exactly the acceptance criterion "fails on the BROWSER gate, passes on the `$effect` gate", met in pure bun-test.

`Bun.build` resolves the full import graph, so a component that **unconditionally renders child `.svelte` components** is handled natively — the case the task names, which `renderThenHydrate` cannot do (it server-compiles only the top-level component).

## The B→C pivot (why static double-render, not a runtime warning)

The task name suggests observing a hydration-mismatch *warning*. That approach was tried and proven **empirically infeasible**:

- **bun-test `hydrate()` (approach A):** under bun-test, esm-env's `BROWSER` resolves `true` in *both* compile halves, and happy-dom's synthetic `hydrate()` reconciles an SSR-absent→client-present `{#if}` divergence **silently** (no warning).
- **Playwright + real Chromium dev `hydrate()` (approach B):** I built a real SSR→hydrate page (server `BROWSER=false`, client `BROWSER=true`, dev mode) and captured console. Result: **no warning fired** — the span rendered, `afterHydrateCount=1`, console empty. Svelte 5 does not reliably emit `hydration_mismatch` for an `{#if}` condition that merely evaluates differently (that warning is tied to hydration-walk *structure* failures); it reconciles a branch divergence silently, in both happy-dom and a real browser.

So no runtime-observation harness can see this bug. The faithful, deterministic signal is the build-time render divergence itself (approach C, shipped here). The cinder playground is also a pure client-mounted SPA (`mount()`, never `hydrate()`), so there is no existing SSR→hydrate route to capture a warning in even if one fired.

## Scope (honest boundary)

Covers build-flag (esm-env `BROWSER`-style) control-flow divergence — the motivating bug class. It is a proxy for the client compilation's initial declarative markup shape, **not** a full hydration pass: it does not validate bindings, actions, event attachment, lifecycle ordering, or DOM mutation during hydration. `document`/`window` are cleared for both renders; `navigator` is intentionally left ambient, so a runtime capability check (`navigator.share`) is outside the guarantee unless it sits behind a `hydrated` guard (which is why ShareCard is invariant). The result field is named `buildFlagInvariant`, not `safe`, to prevent over-reading.

## Implementation notes

- Svelte is kept **external** (one shared instance) and its `svelte`/`svelte/internal/server` specifiers are repointed at the server index, so lifecycle-using components (`onDestroy`) server-render without an `ssr_context` crash. esm-env stays **bundled** so the `conditions` flip — the discriminator — survives.
- Server compile uses `dev: false` (dev-mode `push_element` instrumentation crashes a bare `render()` with no component context); the helper compares production SSR HTML, so this is sound.
- A memoized one-time `assertDiscriminatorWorks()` fails closed: if the `BROWSER` condition flip ever breaks, the sentinel renders identically both ways and the helper throws rather than silently returning false negatives.
- Temp modules use unique per-call filenames + `finally` cleanup (mirrors `hydrate.ts`); verified zero leftovers after the suite.

## Review committee

Pre-reviewed by: testing-expert, svelte-expert, typescript-expert, simplicity-engineer (each as a Codex persona-fallback at medium effort — the Claude Agent subagents hit the known `/usage-credits` 1M-context bug), plus Codex (gpt-5.4, xhigh round 1 / high round 2) as the mandatory adversarial member.

- 2 rounds of review.
- Round 1: 5 must-fix items (svelte-subpath repoint gap, temp-file race, navigator silent-failure, missing discriminator self-check, ShareCard regression over-claim) + suggestions. All addressed — the subpath "gap" was probed (a `SvelteMap` child renders clean) and documented as a boundary rather than over-built into a parser; navigator mutation removed; self-check added; ShareCard test reframed honestly.
- Round 2: unanimous APPROVED; one doc-accuracy suggestion (stale navigator wording) resolved.

## Test plan

- `cd packages/components && bun run test --conditions browser --conditions svelte src/test/hydration-safety.test.ts` — 4 fixture tests (childless + child-bearing × buggy + safe).
- `bun run test --conditions browser --conditions svelte src/components/share-card/share-card.hydration-safety.test.ts` — real-world regression proving #349's `hydrated`-`$effect` fix is build-flag-invariant even with ShareCard's unconditional `VisuallyHiddenLiveRegion` child.
- Full `@lostgradient/cinder` suite green at pre-commit.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to test harnesses, fixtures, and a scoper allowlist entry; no production component or runtime behavior is modified.
> 
> **Overview**
> Adds **`checkBuildFlagHydrationSafety`**, a test helper that server-renders a component twice (with and without the `browser` export condition so `esm-env` flips `BROWSER`) and reports whether the HTML matches (`buildFlagInvariant`). It uses `Bun.build` with a Svelte server plugin, keeps `svelte` external with server-index rewrites, clears `document`/`window` for SSR, and includes a memoized sentinel self-check so a broken discriminator fails closed instead of false negatives.
> 
> **Contract tests** use probe fixtures for `{#if BROWSER}` (unsafe) vs `hydrated` `$effect` gates (safe), including parents with unconditional child components. A **ShareCard** regression test asserts the shipped component stays build-flag-invariant with an unconditional child.
> 
> **Scoping:** `hydration-safety.ts` is added to `UNMODELLABLE_IMPORT_ALLOWLIST` in `component-graph.ts` because it dynamically imports temp SSR bundles, same as existing hydrate helpers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8e158f757afa0e09f4135c7383ee442231e6bdbf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->