### PR TITLE
fix(hooks): serialize the pre-push test phase to stop shared-dist races

### DIFF
--- a/packages/components/scripts/husky/pre-push.ts
+++ b/packages/components/scripts/husky/pre-push.ts
@@ -124,14 +124,8 @@ type BatchOutcome = {
  * and return a {@link BatchOutcome} so the caller can render a digest and write
  * the full log.
  *
- * `maxConcurrency` caps the pool. The default (CPU-bound, up to 4) is right for
- * lint/typecheck, which only read sources. The `test` phase must pass `1`: each
- * package's `test` script runs inline `bun run --filter=<dep> build` steps that
- * `rm -rf dist` and re-emit a shared dependency's `dist/` (e.g. `@cinder/markdown`,
- * `@cinder/editor`). Run in parallel, two jobs rebuild the same `dist/` while a
- * third job's bundler reads it mid-write, yielding non-deterministic
- * "X is not declared in this file" errors. Serializing the test phase removes the
- * shared-`dist/` write hazard.
+ * `maxConcurrency` caps the pool; the default is CPU-bound (up to 4). The test
+ * phase passes `1` to serialize — see the call site in `runScoped` for why.
  */
 async function runJobs(
   jobs: readonly Job[],
@@ -242,6 +236,11 @@ async function runFull(): Promise<boolean> {
     // The full-suite path can produce very large output. Stream it directly so
     // Bun never keeps the hook alive waiting on captured pipe readers after the
     // command has exited.
+    // NOTE: the root `test` script is `bun run --filter='*' test`, which runs
+    // every package's tests concurrently — so the same shared-`dist/` rebuild
+    // race the scoped path serializes around (see `runScoped`) can still occur
+    // here. The atomic-build-output follow-up is the real fix; this path is
+    // taken only on root-config escalation / fail-safe, not routine pushes.
     const result = await runHookCommand('bun', ['run', script], {
       cwd: REPO_ROOT,
       stderr: 'inherit',
@@ -443,9 +442,13 @@ async function runScoped(
 
     if (phaseJobs.length === 0) continue;
     info(`Running ${script} (${phaseJobs.map((job) => job.packageName).join(', ')})…`);
-    // The `test` phase runs serially (concurrency 1): test scripts rebuild shared
-    // dependency `dist/` dirs in place, so parallel jobs race each other's
-    // `rm -rf dist` + re-emit. Typecheck is read-only and stays parallel.
+    // The `test` phase runs serially (concurrency 1). Each package's `test`
+    // script runs inline `bun run --filter=<dep> build` steps that `rm -rf dist`
+    // and re-emit shared dependency `dist/` dirs (e.g. `@cinder/markdown`,
+    // `@cinder/editor`). Run in parallel, two jobs race those writes while a
+    // third job's bundler reads the dist mid-write, yielding non-deterministic
+    // `error: "<name>" is not declared in this file`. Lint (oxlint) and typecheck
+    // (`tsc --noEmit`) are read-only, so they stay parallel.
     const phase = await runJobs(phaseJobs, script === 'test' ? 1 : undefined);
     fullOutput += phase.output;
     allFailures.push(...phase.failures);

--- a/packages/components/scripts/husky/pre-push.ts
+++ b/packages/components/scripts/husky/pre-push.ts
@@ -132,11 +132,13 @@ async function runJobs(
   maxConcurrency = Math.max(1, Math.min(navigator.hardwareConcurrency ?? 1, 4)),
 ): Promise<BatchOutcome> {
   if (jobs.length === 0) return { ok: true, failures: [], output: '' };
-  // Clamp to at least 1: if `navigator.hardwareConcurrency` is ever undefined,
-  // `Math.min(undefined, 4)` is NaN, no workers would start, and every job would
-  // be silently treated as passing — a false green. `?? 1` and `Math.max(1, …)`
-  // prevent that.
-  const concurrency = Math.max(1, maxConcurrency);
+  // Floor to a finite integer ≥ 1. A non-finite `maxConcurrency` (e.g. a caller
+  // computing `Math.min(navigator.hardwareConcurrency, 4)` where
+  // `hardwareConcurrency` is undefined → `NaN`) must NOT slip through: `NaN`
+  // would make `Math.min(concurrency, jobs.length)` NaN, start zero workers, and
+  // silently pass every job — a false green. `Number.isFinite` rejects NaN and
+  // ±Infinity; the `Math.max(1, …)` then guards 0 / negatives.
+  const concurrency = Number.isFinite(maxConcurrency) ? Math.max(1, Math.floor(maxConcurrency)) : 1;
   const results: JobResult[] = [];
   let nextIndex = 0;
   const workers: Promise<void>[] = [];

--- a/packages/components/scripts/husky/pre-push.ts
+++ b/packages/components/scripts/husky/pre-push.ts
@@ -123,14 +123,26 @@ type BatchOutcome = {
  * Run a batch of jobs through a small async pool, print any failures inline,
  * and return a {@link BatchOutcome} so the caller can render a digest and write
  * the full log.
+ *
+ * `maxConcurrency` caps the pool. The default (CPU-bound, up to 4) is right for
+ * lint/typecheck, which only read sources. The `test` phase must pass `1`: each
+ * package's `test` script runs inline `bun run --filter=<dep> build` steps that
+ * `rm -rf dist` and re-emit a shared dependency's `dist/` (e.g. `@cinder/markdown`,
+ * `@cinder/editor`). Run in parallel, two jobs rebuild the same `dist/` while a
+ * third job's bundler reads it mid-write, yielding non-deterministic
+ * "X is not declared in this file" errors. Serializing the test phase removes the
+ * shared-`dist/` write hazard.
  */
-async function runJobs(jobs: readonly Job[]): Promise<BatchOutcome> {
+async function runJobs(
+  jobs: readonly Job[],
+  maxConcurrency = Math.max(1, Math.min(navigator.hardwareConcurrency ?? 1, 4)),
+): Promise<BatchOutcome> {
   if (jobs.length === 0) return { ok: true, failures: [], output: '' };
   // Clamp to at least 1: if `navigator.hardwareConcurrency` is ever undefined,
   // `Math.min(undefined, 4)` is NaN, no workers would start, and every job would
   // be silently treated as passing — a false green. `?? 1` and `Math.max(1, …)`
   // prevent that.
-  const concurrency = Math.max(1, Math.min(navigator.hardwareConcurrency ?? 1, 4));
+  const concurrency = Math.max(1, maxConcurrency);
   const results: JobResult[] = [];
   let nextIndex = 0;
   const workers: Promise<void>[] = [];
@@ -431,7 +443,10 @@ async function runScoped(
 
     if (phaseJobs.length === 0) continue;
     info(`Running ${script} (${phaseJobs.map((job) => job.packageName).join(', ')})…`);
-    const phase = await runJobs(phaseJobs);
+    // The `test` phase runs serially (concurrency 1): test scripts rebuild shared
+    // dependency `dist/` dirs in place, so parallel jobs race each other's
+    // `rm -rf dist` + re-emit. Typecheck is read-only and stays parallel.
+    const phase = await runJobs(phaseJobs, script === 'test' ? 1 : undefined);
     fullOutput += phase.output;
     allFailures.push(...phase.failures);
     ok = phase.ok && ok;


### PR DESCRIPTION
## Problem

The scoped pre-push hook (`packages/components/scripts/husky/pre-push.ts`) runs validation in three phases (lint → typecheck → test), **parallel within a phase** via an async pool capped at `min(hardwareConcurrency, 4)`.

Each package's `test` npm-script runs **inline build steps** for its workspace dependencies, and those `build` scripts do `rm -rf dist` then re-emit:

```jsonc
// packages/editor/package.json
"test": "bun run --filter='@cinder/diff' build && bun run --filter='@cinder/markdown' build && bun test"
// packages/markdown/scripts/build.ts
await $`rm -rf dist`; const buildResult = await Bun.build({ outdir, ... });
```

When the pool runs `@cinder/editor test`, `@cinder/commentary test`, and `@cinder/playground test` **concurrently**, two of them rebuild the **same** shared `@cinder/markdown` / `@cinder/editor` `dist/` while `@cinder/playground`'s page-bundle test reads it mid-rewrite, producing non-deterministic:

```
error: "renderMarkdown" is not declared in this file
    at packages/markdown/dist/rendering/index.js:NN:N
```

This **blocked every push** whose reverse-dependency closure spans a shared-`dist/` dependency plus ≥2 dependents.

## Fix

Serialize the **test** phase (`runJobs(phaseJobs, 1)`). Lint (oxlint) and typecheck (`tsc --noEmit`) are read-only and stay parallel — no latency change for them. Most pushes touch few packages, so the serialization cost is negligible in the common case; it only appears on wide closures touching base deps.

## Verification

Reproduced deterministically (no `git push` needed):

```bash
bun run --filter=@cinder/playground test & \
bun run --filter=@cinder/editor test & \
bun run --filter=@cinder/commentary test & wait
# → playground exits 1 ("X is not declared in this file")
# Serial → all pass 617/617.
```

- `tsc --noEmit` clean; pre-commit full `@lostgradient/cinder` typecheck + test exit 0.
- Pushing this branch ran the **fixed** hook serially and passed (`Pre-push validation passed (scoped)`) — the end-to-end integration proof.

## Why no unit test in this PR

A call-site regression test ("test phase invoked with concurrency 1") requires importing this gate script, which runs module-scope side effects (`isContinuousIntegration() → process.exit(0)`, stdin read, lock). Guarding those behind `import.meta.main` to make it importable risks a silent-skip false green **on the push gate itself** — the exact failure mode the file's `?? 1` NaN-guard is paranoid about. The honest regression artifact is the deterministic repro above. Extracting the phase runner into the side-effect-free `utilities.ts` for a safe test is filed as a follow-up.

## Follow-ups (issue #364)

1. `runFull` (root `bun run --filter='*' test`) has the same latent race — annotated in this PR, not serialized (it's a fail-safe/escalation path, not routine pushes).
2. **Atomic build output** (temp-dir + rename instead of `rm -rf dist`) is the root fix — would make concurrent builds+reads safe and remove the sum-vs-max latency, fixing (1) too.
3. Phase-runner extraction for a real regression test.

## Committee review

dx-engineer, simplicity-engineer, typescript-expert, and Codex (gpt-5.4) — all APPROVED, zero must-fix. All suggestions addressed (comment de-duplication, `runFull` hazard note; defensive clamp kept per typescript-expert).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes only local git hook orchestration in `pre-push.ts`; no runtime app, auth, or data paths.
> 
> **Overview**
> The scoped pre-push hook **runs the test phase one package at a time** so parallel `test` jobs no longer race on shared dependency `dist/` rebuilds (`rm -rf dist` + rewrite), which was causing flaky `"<name>" is not declared in this file` failures and blocking pushes.
> 
> **`runJobs`** now accepts an optional **`maxConcurrency`** (default unchanged: up to 4 workers from `hardwareConcurrency`). Concurrency is **clamped with `Number.isFinite`** so a bad value (e.g. `NaN`) cannot start zero workers and falsely pass every job. Lint and typecheck still use the default parallel pool.
> 
> Comments document why test is serialized and that **`runFull`**’s root `bun run --filter='*' test` can still hit the same race on escalation paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1ea02d6a668e250014c26fbc8b7a45f402c1e27d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->