### PR TITLE
fix(#364): serialize the pre-push test gate (+ atomic-swap defense-in-depth)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,6 +67,11 @@ jspm_packages/
 # Nuxt.js build output
 .nuxt/
 dist/
+# Staging / vacated build trees from atomicSwapDist (packages/*/scripts/build.ts).
+# Normally cleaned on exit; a hard kill (SIGKILL) can leave one behind, so ignore
+# them to keep `git status` clean and the commit/push flow unblocked.
+dist.tmp-*/
+dist.old-*/
 
 # SvelteKit build output
 .svelte-kit/

--- a/packages/commentary/scripts/build.ts
+++ b/packages/commentary/scripts/build.ts
@@ -1,20 +1,42 @@
 import { $ } from 'bun';
 
+import { atomicSwapDist } from './lib/atomic-swap-dist.ts';
 import { getExpectedBuildOutputs, readPackageExports } from './package-exports.js';
 
 const packageRoot = process.cwd();
+const distributionDirectory = `${packageRoot}/dist`;
+// Per-PID staging directory so concurrent same-package builds never collide on
+// a shared `dist.tmp` (each writer owns its own `dist.tmp-<pid>`).
+const stagingName = `dist.tmp-${process.pid}`;
+const stagingDirectory = `${packageRoot}/${stagingName}`;
 const packageExports = await readPackageExports();
 
-await $`rm -rf dist`;
+// Build to a staging directory first so a concurrent reader of `dist/` never
+// sees a partially-written tree. The `rm -rf dist` → write-to-dist pattern
+// opens a window where another process (e.g. a sibling package's test script
+// doing `bun run --filter=@cinder/commentary build`) wipes `dist` while the
+// first process's compiler is still writing into it. Building to
+// `dist.tmp-<pid>` then atomically renaming over `dist` closes that window: on
+// POSIX, `rename(2)` is atomic — a concurrent reader either sees the old tree
+// or the new tree, never a partial write. This is the root fix for issue #364.
+await $`rm -rf ${stagingDirectory}`;
 
-const compileResult = await $`tsc -p tsconfig.build.json`.nothrow();
+// `tsc` is configured to emit into `./dist` via tsconfig.build.json, but we
+// override `--outDir` on the command line so it emits into the staging
+// directory. The CLI flag takes precedence over the tsconfig value.
+const compileResult = await $`tsc -p tsconfig.build.json --outDir ./${stagingName}`.nothrow();
 if (compileResult.exitCode !== 0) {
   process.stderr.write(compileResult.stdout.toString());
   process.stderr.write(compileResult.stderr.toString());
   process.exit(1);
 }
 
-const expectedOutputs = getExpectedBuildOutputs(packageRoot, packageExports);
+// `getExpectedBuildOutputs` returns absolute paths rooted at the package root,
+// pointing into `dist/`. Substitute `dist` with the staging dir for the staging
+// validation — we must verify the staging tree before promoting it.
+const expectedOutputs = getExpectedBuildOutputs(packageRoot, packageExports).map((path) =>
+  path.replace(`${packageRoot}/dist/`, `${stagingDirectory}/`),
+);
 
 for (const outputPath of expectedOutputs) {
   if (!(await Bun.file(outputPath).exists())) {
@@ -22,5 +44,10 @@ for (const outputPath of expectedOutputs) {
     process.exit(1);
   }
 }
+
+// Atomically swap the staging directory into place without ever removing dist/
+// while it is live (see packages/diff/scripts/lib/atomic-swap-dist.ts for the
+// full concurrent-build rationale).
+atomicSwapDist(stagingDirectory, distributionDirectory);
 
 process.stdout.write('Build complete.\n');

--- a/packages/commentary/scripts/build.ts
+++ b/packages/commentary/scripts/build.ts
@@ -1,24 +1,25 @@
 import { $ } from 'bun';
 
-import { atomicSwapDist } from './lib/atomic-swap-dist.ts';
+import { atomicSwapDist, stagingDirectoryName } from './lib/atomic-swap-dist.ts';
 import { getExpectedBuildOutputs, readPackageExports } from './package-exports.js';
 
 const packageRoot = process.cwd();
 const distributionDirectory = `${packageRoot}/dist`;
-// Per-PID staging directory so concurrent same-package builds never collide on
-// a shared `dist.tmp` (each writer owns its own `dist.tmp-<pid>`).
-const stagingName = `dist.tmp-${process.pid}`;
+// Unique-per-invocation staging directory (a `dist.tmp-*` sibling of `dist`, so
+// the same filesystem `atomicSwapDist`'s rename requires). Each build owns its
+// own staging dir, so two concurrent same-package builds never collide on it.
+const stagingName = stagingDirectoryName();
 const stagingDirectory = `${packageRoot}/${stagingName}`;
 const packageExports = await readPackageExports();
 
-// Build to a staging directory first so a concurrent reader of `dist/` never
-// sees a partially-written tree. The `rm -rf dist` → write-to-dist pattern
-// opens a window where another process (e.g. a sibling package's test script
-// doing `bun run --filter=@cinder/commentary build`) wipes `dist` while the
-// first process's compiler is still writing into it. Building to
-// `dist.tmp-<pid>` then atomically renaming over `dist` closes that window: on
-// POSIX, `rename(2)` is atomic — a concurrent reader either sees the old tree
-// or the new tree, never a partial write. This is the root fix for issue #364.
+// Build into the staging directory, then promote it via `atomicSwapDist`. A
+// build never writes into `dist/` in place, so a concurrent reader (a sibling
+// package's test running `bun run --filter=@cinder/commentary build`, or a
+// typecheck holding dist declarations) can never observe a half-written tree.
+// NOTE: this is defense-in-depth, not the #364 fix — the husky test gate
+// serializes its test phase, and THAT is what stops concurrent same-package
+// rebuilds inside the hook. See `./lib/atomic-swap-dist.ts` for the exact
+// guarantees (and the residual transient-ENOENT window this does not close).
 await $`rm -rf ${stagingDirectory}`;
 
 // `tsc` is configured to emit into `./dist` via tsconfig.build.json, but we
@@ -45,9 +46,9 @@ for (const outputPath of expectedOutputs) {
   }
 }
 
-// Atomically swap the staging directory into place without ever removing dist/
-// while it is live (see packages/diff/scripts/lib/atomic-swap-dist.ts for the
-// full concurrent-build rationale).
+// Promote the validated staging tree into `dist/` (handles a concurrent
+// same-package build winning the race; never exposes a partial tree). See
+// `./lib/atomic-swap-dist.ts` for the exact guarantees and limits.
 atomicSwapDist(stagingDirectory, distributionDirectory);
 
 process.stdout.write('Build complete.\n');

--- a/packages/commentary/scripts/lib/atomic-swap-dist.ts
+++ b/packages/commentary/scripts/lib/atomic-swap-dist.ts
@@ -1,71 +1,163 @@
 // CANONICAL SOURCE for `atomicSwapDist`. The four upstream packages
 // (diff, markdown, editor, commentary) each carry a byte-identical copy at
 // `packages/<pkg>/scripts/lib/atomic-swap-dist.ts` because a cross-package
-// import would break their `rootDir: "."` typecheck constraint. Keep all copies
-// in sync — if you change this, change theirs too.
+// import would put a source file outside that package's `rootDir: "."` and
+// break its typecheck. A `paths` mapping does not lift that restriction — only
+// a built/referenced project would, which is heavier than the duplication.
+// Keep all copies in sync: `atomic-swap-dist.duplication.test.ts` asserts they
+// are byte-for-byte identical, so drift fails the suite.
 import { renameSync, rmSync } from 'node:fs';
 
-/**
- * Atomically install `tempDirectory` as `distributionDirectory`, handling
- * concurrent same-package builds safely.
- *
- * Strategy:
- *   1. Try rename(temp, dist). On first build (no dist) or if dist is absent,
- *      this succeeds atomically and we're done.
- *   2. If dist already exists (ENOTEMPTY from rename(2)), vacate it:
- *      rename(dist, old). If dist vanished between step 1 and now (a concurrent
- *      winner moved it away), the ENOENT here means the winner already installed
- *      a complete dist — our result is redundant; clean up temp and succeed.
- *   3. With dist now vacated, try rename(temp, dist). If this fails, a
- *      concurrent winner raced us and installed dist after we moved old away.
- *      Either way, dist is complete; clean up temp (and old, which we own) and
- *      succeed.
- *   4. We own the installed dist. Delete old.
- *
- * The exit handler registered here removes temp and old so no litter survives
- * a crash at any point in the swap sequence.
- *
- * @param tempDirectory - Completed build output (e.g. `dist.tmp-<pid>`).
- * @param distributionDirectory - Final destination (e.g. `dist/`).
- */
-export function atomicSwapDist(tempDirectory: string, distributionDirectory: string): void {
-  const oldDirectory = `${distributionDirectory}.old-${process.pid}`;
+/** The slice of `node:fs` this helper uses. Defaulted to the real functions in
+ * `atomicSwapDist`; tests pass a fake to drive the concurrent-race branches that
+ * serial real-filesystem calls cannot reach. This is the helper's only test
+ * seam — deliberately just the two operations it performs, not a config bag. */
+type FileSystemOperations = {
+  renameSync: typeof renameSync;
+  rmSync: typeof rmSync;
+};
 
-  // Ensure temp and old are cleaned up even if the process exits mid-swap.
+/** Narrow an unknown caught value to Node's errno-bearing error shape. */
+function isErrnoException(error: unknown): error is NodeJS.ErrnoException {
+  return error instanceof Error && 'code' in error;
+}
+
+/** rename(2) reports "destination already exists and is a non-empty directory"
+ * as ENOTEMPTY on Linux and EEXIST on macOS. Both mean the same benign thing
+ * here: someone else owns `dist`. */
+const DESTINATION_EXISTS_CODES = new Set(['ENOTEMPTY', 'EEXIST']);
+
+/**
+ * Promote a completed staging build into `distributionDirectory`, surviving a
+ * concurrent same-package build (`bun run --filter=<pkg> build` invoked by
+ * turbo, CI, or by hand at the same time as another).
+ *
+ * IMPORTANT — what this does and does NOT guarantee:
+ *   - It is NOT what closes issue #364. The husky test gate serializes its test
+ *     phase (`phaseMaxConcurrency('test') === 1`), so concurrent same-package
+ *     builds do not occur inside the hook; that serialization is the #364
+ *     closure. This helper is defense-in-depth for the out-of-hook paths.
+ *   - It DOES prevent a reader from observing a half-written tree: a build
+ *     writes into a private staging dir and is only promoted once complete, so
+ *     `dist` is replaced whole, never written into in place.
+ *   - It does NOT guarantee `dist` is continuously present. In the rebuild
+ *     path there is a sub-millisecond window between vacating the live tree and
+ *     installing the new one where `dist` does not exist, so a concurrent
+ *     reader can still observe a transient ENOENT. Eliminating that would need
+ *     a symlink-pointer scheme, which consumers that resolve `dist/...` paths
+ *     directly cannot tolerate — out of scope here.
+ *
+ * Preconditions:
+ *   - `tempDirectory` and `distributionDirectory` MUST be on the same
+ *     filesystem; `rename(2)` fails with EXDEV across devices. Callers build
+ *     the staging dir as a sibling of `dist` under the package root, so this
+ *     holds. EXDEV is therefore re-thrown, not swallowed.
+ *   - `tempDirectory` should be uniquely named per invocation (see
+ *     `stagingDirectoryName`) so two concurrent builds never collide on it.
+ *
+ * Strategy (only the EXPECTED race errors are swallowed; everything else
+ * re-throws so a genuine failure can never masquerade as a successful build):
+ *   1. rename(temp, dist). Succeeds on first build (no dist). If dist exists
+ *      (ENOTEMPTY / EEXIST), fall through; any other error re-throws.
+ *   2. Vacate: rename(dist, old). If dist vanished (ENOENT) a concurrent build
+ *      already installed a complete dist — ours is redundant, return; any other
+ *      error re-throws.
+ *   3. Install: rename(temp, dist). If dist now exists (ENOTEMPTY / EEXIST) a
+ *      concurrent build raced in after we vacated — its dist is complete; drop
+ *      our `old` and return; any other error re-throws.
+ *   4. We own the installed dist. Remove the vacated `old` tree.
+ *
+ * The success and concurrent-loser paths remove `temp` / `old` synchronously
+ * before returning. A `process.on('exit')` handler is also registered as a
+ * backstop for the case where the process exits between two rename steps — but
+ * it runs on normal exit and `process.exit()` only, NOT on SIGKILL/SIGINT, so a
+ * hard kill mid-swap can still leave a `dist.tmp-*` / `dist.old-*` sibling
+ * behind. Those names are gitignored, so such litter never reaches version
+ * control.
+ *
+ * @param tempDirectory - Completed, validated build output to promote.
+ * @param distributionDirectory - Final destination (e.g. `dist/`).
+ * @param fileSystem - The `renameSync` / `rmSync` pair to use. Defaults to the
+ *   real `node:fs`; tests inject a fake to exercise the concurrent-race branches
+ *   that serial real-filesystem calls cannot reach. Not a production knob.
+ */
+export function atomicSwapDist(
+  tempDirectory: string,
+  distributionDirectory: string,
+  fileSystem: FileSystemOperations = { renameSync, rmSync },
+): void {
+  // Unique per invocation so two concurrent builds (different pid OR same pid
+  // reused across non-overlapping runs) never collide on, or clean up, each
+  // other's vacated tree.
+  const oldDirectory = `${distributionDirectory}.old-${stagingSuffix()}`;
+
+  // Best-effort cleanup of the dirs THIS call owns, on normal exit only.
   process.on('exit', () => {
-    rmSync(tempDirectory, { recursive: true, force: true });
-    rmSync(oldDirectory, { recursive: true, force: true });
+    fileSystem.rmSync(tempDirectory, { recursive: true, force: true });
+    fileSystem.rmSync(oldDirectory, { recursive: true, force: true });
   });
 
-  // Step 1: optimistic path — first build or dist is absent.
+  // Step 1: optimistic — first build, or dist is absent.
   try {
-    renameSync(tempDirectory, distributionDirectory);
+    fileSystem.renameSync(tempDirectory, distributionDirectory);
     return;
-  } catch {
-    // dist already exists (ENOTEMPTY) or another transient error. Fall through
-    // to the vacate-and-reinstall path.
+  } catch (error) {
+    if (!isErrnoException(error) || !DESTINATION_EXISTS_CODES.has(error.code ?? '')) {
+      throw error;
+    }
+    // dist exists — fall through to the vacate-and-install path.
   }
 
-  // Step 2: vacate dist → old so we can install our temp.
+  // Step 2: vacate dist → old so we can install our staging tree.
   try {
-    renameSync(distributionDirectory, oldDirectory);
-  } catch {
-    // dist disappeared between step 1 and now: a concurrent winner already
-    // swapped in a complete dist. Our build output is redundant.
-    // temp is cleaned by the exit handler. Succeed.
-    return;
+    fileSystem.renameSync(distributionDirectory, oldDirectory);
+  } catch (error) {
+    if (isErrnoException(error) && error.code === 'ENOENT') {
+      // dist vanished between step 1 and now: a concurrent build already
+      // installed a complete dist. Ours is redundant — clean up our staging
+      // tree now (don't lean on the exit handler, which won't fire on SIGKILL).
+      fileSystem.rmSync(tempDirectory, { recursive: true, force: true });
+      return;
+    }
+    throw error;
   }
 
-  // Step 3: install our build as the new dist.
+  // Step 3: install our staging tree as the new dist.
   try {
-    renameSync(tempDirectory, distributionDirectory);
-  } catch {
-    // A concurrent winner installed dist after we vacated it. dist is complete.
-    // We own old — clean it up. temp is cleaned by the exit handler. Succeed.
-    rmSync(oldDirectory, { recursive: true, force: true });
-    return;
+    fileSystem.renameSync(tempDirectory, distributionDirectory);
+  } catch (error) {
+    if (isErrnoException(error) && DESTINATION_EXISTS_CODES.has(error.code ?? '')) {
+      // A concurrent build installed dist after we vacated it. Its dist is
+      // complete; drop both the tree we vacated and our now-redundant staging
+      // tree immediately rather than waiting for the exit handler.
+      fileSystem.rmSync(oldDirectory, { recursive: true, force: true });
+      fileSystem.rmSync(tempDirectory, { recursive: true, force: true });
+      return;
+    }
+    throw error;
   }
 
-  // Step 4: we successfully installed dist. Remove the vacated old tree.
-  rmSync(oldDirectory, { recursive: true, force: true });
+  // Step 4: we installed dist. Remove the vacated old tree.
+  fileSystem.rmSync(oldDirectory, { recursive: true, force: true });
+}
+
+/**
+ * A collision-resistant suffix for staging / old directory names: process id,
+ * high-resolution-ish wall clock, and a random tail. Unique enough that two
+ * concurrent builds — even same-pid across non-overlapping runs — never share a
+ * staging or vacated-tree name. Build scripts may use `Date.now()` /
+ * `Math.random()` freely (this is not a deterministic-replay context).
+ */
+function stagingSuffix(): string {
+  return `${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
+}
+
+/**
+ * Build the per-invocation staging directory name a caller should emit into
+ * before calling `atomicSwapDist`. Returned as a bare name (no leading path) so
+ * it can be passed straight to `tsc --outDir ./<name>` and joined onto the
+ * package root for `Bun.build`'s `outdir`.
+ */
+export function stagingDirectoryName(): string {
+  return `dist.tmp-${stagingSuffix()}`;
 }

--- a/packages/commentary/scripts/lib/atomic-swap-dist.ts
+++ b/packages/commentary/scripts/lib/atomic-swap-dist.ts
@@ -1,11 +1,12 @@
-// CANONICAL SOURCE for `atomicSwapDist`. The four upstream packages
-// (diff, markdown, editor, commentary) each carry a byte-identical copy at
-// `packages/<pkg>/scripts/lib/atomic-swap-dist.ts` because a cross-package
-// import would put a source file outside that package's `rootDir: "."` and
-// break its typecheck. A `paths` mapping does not lift that restriction — only
-// a built/referenced project would, which is heavier than the duplication.
-// Keep all copies in sync: `atomic-swap-dist.duplication.test.ts` asserts they
-// are byte-for-byte identical, so drift fails the suite.
+// CANONICAL SOURCE for `atomicSwapDist`. This file lives under `components`;
+// the four upstream packages (diff, markdown, editor, commentary) each carry a
+// byte-identical copy at `packages/<pkg>/scripts/lib/atomic-swap-dist.ts` — five
+// copies total. The duplication exists because a cross-package import would put
+// a source file outside that package's `rootDir: "."` and break its typecheck.
+// A `paths` mapping does not lift that restriction — only a built/referenced
+// project would, which is heavier than the duplication. Keep all five copies in
+// sync: `atomic-swap-dist.duplication.test.ts` asserts they are byte-for-byte
+// identical, so drift fails the suite.
 import { renameSync, rmSync } from 'node:fs';
 
 /** The slice of `node:fs` this helper uses. Defaulted to the real functions in
@@ -64,16 +65,21 @@ const DESTINATION_EXISTS_CODES = new Set(['ENOTEMPTY', 'EEXIST']);
  *      error re-throws.
  *   3. Install: rename(temp, dist). If dist now exists (ENOTEMPTY / EEXIST) a
  *      concurrent build raced in after we vacated — its dist is complete; drop
- *      our `old` and return; any other error re-throws.
+ *      our `old` and return. On any OTHER error we best-effort roll back —
+ *      rename(old, dist) to restore the last good build — then re-throw the
+ *      original error. (Without the rollback, a failed install would leave the
+ *      package with no `dist` at all, since the only copy is in `old`.)
  *   4. We own the installed dist. Remove the vacated `old` tree.
  *
  * The success and concurrent-loser paths remove `temp` / `old` synchronously
  * before returning. A `process.on('exit')` handler is also registered as a
- * backstop for the case where the process exits between two rename steps — but
- * it runs on normal exit and `process.exit()` only, NOT on SIGKILL/SIGINT, so a
- * hard kill mid-swap can still leave a `dist.tmp-*` / `dist.old-*` sibling
- * behind. Those names are gitignored, so such litter never reaches version
- * control.
+ * backstop that removes the staging tree (`temp`) if the process exits between
+ * two rename steps — but it runs on normal exit and `process.exit()` only, NOT
+ * on SIGKILL/SIGINT, so a hard kill mid-swap can still leave a `dist.tmp-*` /
+ * `dist.old-*` sibling behind. Those names are gitignored, so such litter never
+ * reaches version control. The handler deliberately never deletes `old`:
+ * between step 2 and step 4 it is the last good build, and the step-3 rollback
+ * relies on it surviving.
  *
  * @param tempDirectory - Completed, validated build output to promote.
  * @param distributionDirectory - Final destination (e.g. `dist/`).
@@ -91,10 +97,16 @@ export function atomicSwapDist(
   // other's vacated tree.
   const oldDirectory = `${distributionDirectory}.old-${stagingSuffix()}`;
 
-  // Best-effort cleanup of the dirs THIS call owns, on normal exit only.
+  // Best-effort cleanup of the staging tree THIS call owns, on normal exit only.
+  // The handler deliberately does NOT touch `oldDirectory`: after step 2 vacates
+  // the live tree there, `oldDirectory` is the ONLY copy of the last good build
+  // until step 4 (success) or the step-3 loser path removes it synchronously. If
+  // step 3 fails unexpectedly we restore from it (see below); deleting it here
+  // would destroy the last good build on that failure path. Every safe path
+  // already removes `oldDirectory` synchronously, so the handler has no reason
+  // to — leaving a `dist.old-*` sibling behind on a hard exit is the safe choice.
   process.on('exit', () => {
     fileSystem.rmSync(tempDirectory, { recursive: true, force: true });
-    fileSystem.rmSync(oldDirectory, { recursive: true, force: true });
   });
 
   // Step 1: optimistic — first build, or dist is absent.
@@ -133,6 +145,20 @@ export function atomicSwapDist(
       fileSystem.rmSync(oldDirectory, { recursive: true, force: true });
       fileSystem.rmSync(tempDirectory, { recursive: true, force: true });
       return;
+    }
+    // Unexpected install failure (ENOSPC / EIO / EPERM / …) after we already
+    // vacated the live tree to `oldDirectory`. Best-effort rollback: move the
+    // last good build back into place so the package is left buildable, then
+    // re-throw the ORIGINAL error so the failure still surfaces. The rollback is
+    // intentionally swallowed — if it fails (e.g. a concurrent build installed a
+    // complete dist in the gap, giving ENOTEMPTY/EEXIST), that build's tree is
+    // the valid one and ours is redundant; either way we must not mask the
+    // original error or delete `oldDirectory` (it may still be the last good
+    // build).
+    try {
+      fileSystem.renameSync(oldDirectory, distributionDirectory);
+    } catch {
+      // Rollback failed; preserve `oldDirectory` and the original error.
     }
     throw error;
   }

--- a/packages/commentary/scripts/lib/atomic-swap-dist.ts
+++ b/packages/commentary/scripts/lib/atomic-swap-dist.ts
@@ -1,0 +1,71 @@
+// CANONICAL SOURCE for `atomicSwapDist`. The four upstream packages
+// (diff, markdown, editor, commentary) each carry a byte-identical copy at
+// `packages/<pkg>/scripts/lib/atomic-swap-dist.ts` because a cross-package
+// import would break their `rootDir: "."` typecheck constraint. Keep all copies
+// in sync — if you change this, change theirs too.
+import { renameSync, rmSync } from 'node:fs';
+
+/**
+ * Atomically install `tempDirectory` as `distributionDirectory`, handling
+ * concurrent same-package builds safely.
+ *
+ * Strategy:
+ *   1. Try rename(temp, dist). On first build (no dist) or if dist is absent,
+ *      this succeeds atomically and we're done.
+ *   2. If dist already exists (ENOTEMPTY from rename(2)), vacate it:
+ *      rename(dist, old). If dist vanished between step 1 and now (a concurrent
+ *      winner moved it away), the ENOENT here means the winner already installed
+ *      a complete dist — our result is redundant; clean up temp and succeed.
+ *   3. With dist now vacated, try rename(temp, dist). If this fails, a
+ *      concurrent winner raced us and installed dist after we moved old away.
+ *      Either way, dist is complete; clean up temp (and old, which we own) and
+ *      succeed.
+ *   4. We own the installed dist. Delete old.
+ *
+ * The exit handler registered here removes temp and old so no litter survives
+ * a crash at any point in the swap sequence.
+ *
+ * @param tempDirectory - Completed build output (e.g. `dist.tmp-<pid>`).
+ * @param distributionDirectory - Final destination (e.g. `dist/`).
+ */
+export function atomicSwapDist(tempDirectory: string, distributionDirectory: string): void {
+  const oldDirectory = `${distributionDirectory}.old-${process.pid}`;
+
+  // Ensure temp and old are cleaned up even if the process exits mid-swap.
+  process.on('exit', () => {
+    rmSync(tempDirectory, { recursive: true, force: true });
+    rmSync(oldDirectory, { recursive: true, force: true });
+  });
+
+  // Step 1: optimistic path — first build or dist is absent.
+  try {
+    renameSync(tempDirectory, distributionDirectory);
+    return;
+  } catch {
+    // dist already exists (ENOTEMPTY) or another transient error. Fall through
+    // to the vacate-and-reinstall path.
+  }
+
+  // Step 2: vacate dist → old so we can install our temp.
+  try {
+    renameSync(distributionDirectory, oldDirectory);
+  } catch {
+    // dist disappeared between step 1 and now: a concurrent winner already
+    // swapped in a complete dist. Our build output is redundant.
+    // temp is cleaned by the exit handler. Succeed.
+    return;
+  }
+
+  // Step 3: install our build as the new dist.
+  try {
+    renameSync(tempDirectory, distributionDirectory);
+  } catch {
+    // A concurrent winner installed dist after we vacated it. dist is complete.
+    // We own old — clean it up. temp is cleaned by the exit handler. Succeed.
+    rmSync(oldDirectory, { recursive: true, force: true });
+    return;
+  }
+
+  // Step 4: we successfully installed dist. Remove the vacated old tree.
+  rmSync(oldDirectory, { recursive: true, force: true });
+}

--- a/packages/components/scripts/husky/pre-commit.ts
+++ b/packages/components/scripts/husky/pre-commit.ts
@@ -11,6 +11,7 @@ import {
   installHookProcessCleanup,
   isContinuousIntegration,
   loadWorkspacePackages,
+  phaseMaxConcurrency,
   REPO_ROOT,
   runHookCommand,
   success,
@@ -135,21 +136,22 @@ type Job = {
   readonly script: 'typecheck' | 'test';
 };
 
-const jobs: Job[] = [];
+const typecheckJobs: Job[] = [];
+const testJobs: Job[] = [];
 for (const pkg of touched) {
   if (pkg.hasTypecheck) {
-    jobs.push({ packageName: pkg.name, script: 'typecheck' });
+    typecheckJobs.push({ packageName: pkg.name, script: 'typecheck' });
   } else {
     info(`${pkg.name}: no typecheck script; skipping`);
   }
   if (pkg.hasTest) {
-    jobs.push({ packageName: pkg.name, script: 'test' });
+    testJobs.push({ packageName: pkg.name, script: 'test' });
   } else {
     info(`${pkg.name}: no test script; skipping`);
   }
 }
 
-if (jobs.length === 0) {
+if (typecheckJobs.length === 0 && testJobs.length === 0) {
   success('No applicable scripts for touched packages; nothing to run');
   process.exit(0);
 }
@@ -160,8 +162,6 @@ type JobResult = {
   readonly stdout: string;
   readonly stderr: string;
 };
-
-const concurrency = Math.min(navigator.hardwareConcurrency, 4);
 
 const start = Date.now();
 const elapsed = () => Date.now() - start;
@@ -188,39 +188,73 @@ async function runJob(job: Job): Promise<JobResult> {
   };
 }
 
-// Small inline async pool — `concurrency` workers pull jobs off a shared index.
-// `results` is keyed by job index so the output order matches the job order
-// regardless of worker scheduling.
-const results: JobResult[] = [];
-let nextIndex = 0;
-const workers: Promise<void>[] = [];
-for (let workerId = 0; workerId < Math.min(concurrency, jobs.length); workerId++) {
-  workers.push(
-    (async () => {
-      while (true) {
-        const index = nextIndex++;
-        if (index >= jobs.length) return;
-        results[index] = await runJob(jobs[index]!);
-      }
-    })(),
-  );
-}
-await Promise.all(workers);
-
-const failures = results.filter((r) => r.exitCode !== 0);
-if (failures.length > 0) {
-  for (const failure of failures) {
-    error(`\n--- ${failure.job.packageName} ${failure.job.script} (exit ${failure.exitCode}) ---`);
-    if (failure.stdout.trim().length > 0) {
-      console.log(failure.stdout);
-    }
-    if (failure.stderr.trim().length > 0) {
-      console.error(failure.stderr);
-    }
+/**
+ * Run a batch of jobs through a small async pool capped at `maxConcurrency`.
+ * Returns the full result list in job-index order.
+ *
+ * Concurrency should be derived from {@link phaseMaxConcurrency}: typecheck and
+ * lint are read-only and safe to run in parallel; the test phase runs at
+ * concurrency 1 to prevent the shared-dist rebuild race described in issue #364.
+ * Each package's test script contains inline `bun run --filter=<dep> build`
+ * steps that rewrite a shared dep's `dist/` directory; running two such tests
+ * concurrently means one may rewrite `dist/` while another package's tsc
+ * incremental engine has those declaration files open, producing spurious
+ * TS1109 errors.
+ */
+async function runJobs(jobs: readonly Job[], maxConcurrency: number): Promise<JobResult[]> {
+  if (jobs.length === 0) return [];
+  const concurrency = Number.isFinite(maxConcurrency) ? Math.max(1, Math.floor(maxConcurrency)) : 1;
+  const results: JobResult[] = [];
+  let nextIndex = 0;
+  const workers: Promise<void>[] = [];
+  for (let workerId = 0; workerId < Math.min(concurrency, jobs.length); workerId++) {
+    workers.push(
+      (async () => {
+        while (true) {
+          const index = nextIndex++;
+          if (index >= jobs.length) return;
+          results[index] = await runJob(jobs[index]!);
+        }
+      })(),
+    );
   }
-  error(`Pre-commit checks failed (${failures.length} of ${results.length} jobs)`);
+  await Promise.all(workers);
+  return results;
+}
+
+// Phase 1: typecheck (read-only — safe to run in parallel).
+const typecheckResults = await runJobs(typecheckJobs, phaseMaxConcurrency('typecheck'));
+
+const typecheckFailures = typecheckResults.filter((r) => r.exitCode !== 0);
+if (typecheckFailures.length > 0) {
+  for (const failure of typecheckFailures) {
+    error(`\n--- ${failure.job.packageName} ${failure.job.script} (exit ${failure.exitCode}) ---`);
+    if (failure.stdout.trim().length > 0) console.log(failure.stdout);
+    if (failure.stderr.trim().length > 0) console.error(failure.stderr);
+  }
+  // Don't run tests when typecheck already failed — surface failures fast and
+  // avoid spending minutes on tests that will likely also fail.
+  error(
+    `Pre-commit checks failed (${typecheckFailures.length} of ${typecheckResults.length} typecheck jobs)`,
+  );
   process.exit(1);
 }
 
-success(`All pre-commit checks passed (${results.length} jobs in ${elapsed()}ms)`);
+// Phase 2: test (serialized at concurrency 1 to prevent the shared-dist race —
+// see phaseMaxConcurrency in utilities.ts for the full rationale).
+const testResults = await runJobs(testJobs, phaseMaxConcurrency('test'));
+
+const allResults = [...typecheckResults, ...testResults];
+const failures = allResults.filter((r) => r.exitCode !== 0);
+if (failures.length > 0) {
+  for (const failure of failures) {
+    error(`\n--- ${failure.job.packageName} ${failure.job.script} (exit ${failure.exitCode}) ---`);
+    if (failure.stdout.trim().length > 0) console.log(failure.stdout);
+    if (failure.stderr.trim().length > 0) console.error(failure.stderr);
+  }
+  error(`Pre-commit checks failed (${failures.length} of ${allResults.length} jobs)`);
+  process.exit(1);
+}
+
+success(`All pre-commit checks passed (${allResults.length} jobs in ${elapsed()}ms)`);
 process.exit(0);

--- a/packages/components/scripts/husky/pre-commit.ts
+++ b/packages/components/scripts/husky/pre-commit.ts
@@ -198,9 +198,9 @@ async function runJob(job: Job): Promise<JobResult> {
  * concurrency 1 to prevent the shared-dist rebuild race described in issue #364.
  * Each package's test script contains inline `bun run --filter=<dep> build`
  * steps that rewrite a shared dep's `dist/` directory; running two such tests
- * concurrently means one may rewrite `dist/` while another package's tsc
- * incremental engine has those declaration files open, producing spurious
- * TS1109 errors.
+ * concurrently means one may be reading a dep's `dist/` while another rebuild
+ * has it half-written, so the reader observes a partial tree and fails
+ * non-deterministically with `"<name>" is not declared in this file`.
  */
 async function runJobs(jobs: readonly Job[], maxConcurrency: number): Promise<JobResult[]> {
   return runWithConcurrencyPool(jobs, maxConcurrency, (job) => runJob(job));

--- a/packages/components/scripts/husky/pre-commit.ts
+++ b/packages/components/scripts/husky/pre-commit.ts
@@ -14,6 +14,7 @@ import {
   phaseMaxConcurrency,
   REPO_ROOT,
   runHookCommand,
+  runWithConcurrencyPool,
   success,
   warning,
 } from './utilities.ts';
@@ -202,24 +203,7 @@ async function runJob(job: Job): Promise<JobResult> {
  * TS1109 errors.
  */
 async function runJobs(jobs: readonly Job[], maxConcurrency: number): Promise<JobResult[]> {
-  if (jobs.length === 0) return [];
-  const concurrency = Number.isFinite(maxConcurrency) ? Math.max(1, Math.floor(maxConcurrency)) : 1;
-  const results: JobResult[] = [];
-  let nextIndex = 0;
-  const workers: Promise<void>[] = [];
-  for (let workerId = 0; workerId < Math.min(concurrency, jobs.length); workerId++) {
-    workers.push(
-      (async () => {
-        while (true) {
-          const index = nextIndex++;
-          if (index >= jobs.length) return;
-          results[index] = await runJob(jobs[index]!);
-        }
-      })(),
-    );
-  }
-  await Promise.all(workers);
-  return results;
+  return runWithConcurrencyPool(jobs, maxConcurrency, (job) => runJob(job));
 }
 
 // Phase 1: typecheck (read-only — safe to run in parallel).

--- a/packages/components/scripts/husky/pre-push.ts
+++ b/packages/components/scripts/husky/pre-push.ts
@@ -24,6 +24,7 @@ import {
   phaseMaxConcurrency,
   REPO_ROOT,
   runHookCommand,
+  runWithConcurrencyPool,
   success,
   summarizeFailures,
   warning,
@@ -132,38 +133,24 @@ type BatchOutcome = {
  */
 async function runJobs(jobs: readonly Job[], maxConcurrency: number): Promise<BatchOutcome> {
   if (jobs.length === 0) return { ok: true, failures: [], output: '' };
-  // Floor to a finite integer ≥ 1. A non-finite `maxConcurrency` (e.g. a caller
-  // computing `Math.min(navigator.hardwareConcurrency, 4)` where
-  // `hardwareConcurrency` is undefined → `NaN`) must NOT slip through: `NaN`
-  // would make `Math.min(concurrency, jobs.length)` NaN, start zero workers, and
-  // silently pass every job — a false green. `Number.isFinite` rejects NaN and
-  // ±Infinity; the `Math.max(1, …)` then guards 0 / negatives.
-  const concurrency = Number.isFinite(maxConcurrency) ? Math.max(1, Math.floor(maxConcurrency)) : 1;
-  const results: JobResult[] = [];
-  let nextIndex = 0;
-  const workers: Promise<void>[] = [];
-  for (let workerId = 0; workerId < Math.min(concurrency, jobs.length); workerId++) {
-    workers.push(
-      (async () => {
-        while (true) {
-          const index = nextIndex++;
-          if (index >= jobs.length) return;
-          const job = jobs[index];
-          if (job === undefined) return; // unreachable given the guard above
-          try {
-            results[index] = await runJob(job);
-          } catch (cause) {
-            // `$.nothrow()` means runJob normally won't throw, but a spawn
-            // failure (missing binary, OOM) could. Record it as a failed job
-            // rather than crashing the whole pool with an unhandled rejection.
-            const reason = cause instanceof Error ? cause.message : String(cause);
-            results[index] = { job, exitCode: 1, stdout: '', stderr: reason };
-          }
-        }
-      })(),
-    );
-  }
-  await Promise.all(workers);
+  // The bounded pool (and its non-finite-concurrency floor) lives in
+  // `runWithConcurrencyPool`; the test phase passes `maxConcurrency === 1` so
+  // builds never overlap (the #364 race). This runner only shapes results.
+  const results = await runWithConcurrencyPool(
+    jobs,
+    maxConcurrency,
+    async (job): Promise<JobResult> => {
+      try {
+        return await runJob(job);
+      } catch (cause) {
+        // `$.nothrow()` means runJob normally won't throw, but a spawn failure
+        // (missing binary, OOM) could. Record it as a failed job rather than
+        // crashing the whole pool with an unhandled rejection.
+        const reason = cause instanceof Error ? cause.message : String(cause);
+        return { job, exitCode: 1, stdout: '', stderr: reason };
+      }
+    },
+  );
 
   let output = '';
   for (const result of results) {

--- a/packages/components/scripts/husky/pre-push.ts
+++ b/packages/components/scripts/husky/pre-push.ts
@@ -21,6 +21,7 @@ import {
   isUnderWorkspace,
   loadWorkspacePackages,
   parsePushRefs,
+  phaseMaxConcurrency,
   REPO_ROOT,
   runHookCommand,
   success,
@@ -124,13 +125,12 @@ type BatchOutcome = {
  * and return a {@link BatchOutcome} so the caller can render a digest and write
  * the full log.
  *
- * `maxConcurrency` caps the pool; the default is CPU-bound (up to 4). The test
- * phase passes `1` to serialize — see the call site in `runScoped` for why.
+ * `maxConcurrency` caps the pool; callers should derive it from
+ * {@link phaseMaxConcurrency} so the per-script policy lives in one place. The
+ * test phase uses `1` to serialize — see `phaseMaxConcurrency` in utilities.ts
+ * for the full rationale.
  */
-async function runJobs(
-  jobs: readonly Job[],
-  maxConcurrency = Math.max(1, Math.min(navigator.hardwareConcurrency ?? 1, 4)),
-): Promise<BatchOutcome> {
+async function runJobs(jobs: readonly Job[], maxConcurrency: number): Promise<BatchOutcome> {
   if (jobs.length === 0) return { ok: true, failures: [], output: '' };
   // Floor to a finite integer ≥ 1. A non-finite `maxConcurrency` (e.g. a caller
   // computing `Math.min(navigator.hardwareConcurrency, 4)` where
@@ -238,11 +238,12 @@ async function runFull(): Promise<boolean> {
     // The full-suite path can produce very large output. Stream it directly so
     // Bun never keeps the hook alive waiting on captured pipe readers after the
     // command has exited.
-    // NOTE: the root `test` script is `bun run --filter='*' test`, which runs
-    // every package's tests concurrently — so the same shared-`dist/` rebuild
-    // race the scoped path serializes around (see `runScoped`) can still occur
-    // here. The atomic-build-output follow-up is the real fix; this path is
-    // taken only on root-config escalation / fail-safe, not routine pushes.
+    // NOTE: the root `test` script is `bun run --filter='*' test`, which fans
+    // out every package's tests concurrently through Bun's workspace filter.
+    // Each package's inline `bun run --filter=<dep> build` previously raced
+    // concurrent `rm -rf dist` + write cycles (issue #364). The atomic-build
+    // fix in each `packages/*/scripts/build.ts` (build to dist.tmp, then
+    // rename over dist) removes the write window for this path too.
     const result = await runHookCommand('bun', ['run', script], {
       cwd: REPO_ROOT,
       stderr: 'inherit',
@@ -431,7 +432,7 @@ async function runScoped(
         ...(stylelintFiles.length > 0 ? ['stylelint'] : []),
       ];
       info(`Running lint (${targets.join(', ')})…`);
-      const lint = await runJobs(phaseJobs);
+      const lint = await runJobs(phaseJobs, phaseMaxConcurrency('lint'));
       const stylelintOk = await runStylelint(stylelintFiles);
       fullOutput += lint.output;
       allFailures.push(...lint.failures);
@@ -444,14 +445,14 @@ async function runScoped(
 
     if (phaseJobs.length === 0) continue;
     info(`Running ${script} (${phaseJobs.map((job) => job.packageName).join(', ')})…`);
-    // The `test` phase runs serially (concurrency 1). Each package's `test`
-    // script runs inline `bun run --filter=<dep> build` steps that `rm -rf dist`
-    // and re-emit shared dependency `dist/` dirs (e.g. `@cinder/markdown`,
-    // `@cinder/editor`). Run in parallel, two jobs race those writes while a
-    // third job's bundler reads the dist mid-write, yielding non-deterministic
-    // `error: "<name>" is not declared in this file`. Lint (oxlint) and typecheck
-    // (`tsc --noEmit`) are read-only, so they stay parallel.
-    const phase = await runJobs(phaseJobs, script === 'test' ? 1 : undefined);
+    // Per-phase concurrency is determined by `phaseMaxConcurrency` (see
+    // utilities.ts). The test phase runs at concurrency 1 to prevent the
+    // shared-dist rebuild race — each package's test script does inline
+    // `bun run --filter=<dep> build` steps that `rm -rf dist` and re-emit
+    // shared upstream `dist/` dirs (e.g. `@cinder/markdown`, `@cinder/diff`).
+    // Atomic build output (dist.tmp → dist rename) removes the write window and
+    // is the root fix; serialization is the belt. Both defences are kept.
+    const phase = await runJobs(phaseJobs, phaseMaxConcurrency(script));
     fullOutput += phase.output;
     allFailures.push(...phase.failures);
     ok = phase.ok && ok;

--- a/packages/components/scripts/husky/utilities.test.ts
+++ b/packages/components/scripts/husky/utilities.test.ts
@@ -22,6 +22,7 @@ import {
   parsePushRefs,
   phaseMaxConcurrency,
   runHookCommand,
+  runWithConcurrencyPool,
   summarizeFailures,
   withGateLock,
   type GitRunner,
@@ -1170,6 +1171,94 @@ describe('phaseMaxConcurrency', () => {
       expect(concurrency).toBeGreaterThanOrEqual(1);
       expect(Number.isInteger(concurrency)).toBe(true);
     }
+  });
+});
+
+/**
+ * `runWithConcurrencyPool` is the *mechanism* the `phaseMaxConcurrency` policy
+ * feeds. The policy test above only proves the test phase asks for concurrency
+ * 1 — it does NOT prove the runner honors it. Both hooks' `runJobs` now delegate
+ * to this pool, so a future edit that passed a hardcoded `4` instead of
+ * `phaseMaxConcurrency('test')` would still leave the policy test green. These
+ * tests close that gap: they instrument the worker to record the maximum number
+ * of overlapping invocations and assert the pool never exceeds the cap. With
+ * `maxConcurrency === 1` the overlap is strictly 1 — the actual #364 guarantee.
+ */
+describe('runWithConcurrencyPool', () => {
+  /**
+   * Run `items` through the pool with a worker that records concurrent overlap.
+   * Each worker waits one microtask-batch (a resolved-promise tick) before
+   * "finishing", which is enough to interleave with sibling workers if the pool
+   * starts more than one at a time — so a broken cap is observable.
+   */
+  async function observeOverlap(
+    itemCount: number,
+    maxConcurrency: number,
+  ): Promise<{ readonly results: number[]; readonly maxObserved: number }> {
+    let active = 0;
+    let maxObserved = 0;
+    const items = Array.from({ length: itemCount }, (_, index) => index);
+    const results = await runWithConcurrencyPool(items, maxConcurrency, async (item) => {
+      active += 1;
+      maxObserved = Math.max(maxObserved, active);
+      // Yield several times so a too-eager pool has room to overlap workers.
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+      active -= 1;
+      return item * 2;
+    });
+    return { results, maxObserved };
+  }
+
+  it('runs strictly one at a time when maxConcurrency is 1 (the #364 guarantee)', async () => {
+    const { results, maxObserved } = await observeOverlap(6, 1);
+    expect(maxObserved).toBe(1);
+    // Results stay in input order regardless of pool scheduling.
+    expect(results).toEqual([0, 2, 4, 6, 8, 10]);
+  });
+
+  it('overlaps workers up to the cap when maxConcurrency is greater than 1', async () => {
+    const { results, maxObserved } = await observeOverlap(6, 3);
+    // The pool must actually parallelize — otherwise the cap is meaningless and
+    // the serial case above proves nothing distinctive.
+    expect(maxObserved).toBe(3);
+    expect(results).toEqual([0, 2, 4, 6, 8, 10]);
+  });
+
+  it('never starts more workers than there are items', async () => {
+    const { maxObserved } = await observeOverlap(2, 8);
+    expect(maxObserved).toBe(2);
+  });
+
+  it('returns an empty array for no items without invoking the worker', async () => {
+    let invoked = false;
+    const results = await runWithConcurrencyPool([], 4, async () => {
+      invoked = true;
+      return 1;
+    });
+    expect(results).toEqual([]);
+    expect(invoked).toBe(false);
+  });
+
+  it('floors a non-finite concurrency to 1 instead of starting zero workers', async () => {
+    // A `NaN` cap (e.g. Math.min(undefined hardwareConcurrency, 4)) must NOT
+    // start zero workers and silently resolve every item to undefined — that
+    // would be a false green. The floor forces strictly-serial execution.
+    const { results, maxObserved } = await observeOverlap(4, Number.NaN);
+    expect(maxObserved).toBe(1);
+    expect(results).toEqual([0, 2, 4, 6]);
+  });
+
+  it('preserves input order even when later items resolve first', async () => {
+    // Earlier indices take longer than later ones; the pool must still return
+    // results indexed by input position, not completion order.
+    const items = [3, 2, 1, 0];
+    const results = await runWithConcurrencyPool(items, 2, async (delayTicks) => {
+      for (let tick = 0; tick < delayTicks; tick += 1) await Promise.resolve();
+      return delayTicks;
+    });
+    expect(results).toEqual([3, 2, 1, 0]);
   });
 });
 

--- a/packages/components/scripts/husky/utilities.test.ts
+++ b/packages/components/scripts/husky/utilities.test.ts
@@ -20,6 +20,7 @@ import {
   isUnderWorkspace,
   loadWorkspacePackages,
   parsePushRefs,
+  phaseMaxConcurrency,
   runHookCommand,
   summarizeFailures,
   withGateLock,
@@ -1095,6 +1096,80 @@ describe('formatFailureSummary', () => {
       '    (fail) second',
       '    ...and 2 more failure lines',
     ]);
+  });
+});
+
+/**
+ * Regression test for issue #364 — pre-push and pre-commit test phases race shared-dist rebuilds.
+ *
+ * `phaseMaxConcurrency` is the side-effect-free seam extracted from pre-push.ts
+ * so this test can assert the policy without importing the gate entry path
+ * (which has module-scope side effects: isContinuousIntegration → process.exit,
+ * stdin read, gate lock). The assertion would fail on origin/main (before this PR)
+ * because the concurrency was an inline literal at the call site, not an
+ * exported function that could be independently verified. The pre-commit hook
+ * originally used a single flat pool for both typecheck and test — this fix
+ * applies the same two-phase execution (typecheck parallel, test serialized) as
+ * the pre-push hook already uses after #365.
+ */
+describe('phaseMaxConcurrency', () => {
+  it('returns 1 for the test phase to prevent the shared-dist rebuild race', () => {
+    // This is the key regression guard for issue #364. Each package's `test`
+    // script does inline `bun run --filter=<dep> build` steps that wipe and
+    // re-emit shared upstream `dist/` directories. Running two test jobs
+    // concurrently races those rm -rf + write cycles against a third job's
+    // bundler reading the same dist mid-write. Concurrency must be exactly 1.
+    expect(phaseMaxConcurrency('test')).toBe(1);
+  });
+
+  it('returns a value greater than 1 for lint (read-only, safe to parallelize)', () => {
+    // Pin hardwareConcurrency to 2 so the assertion is environment-independent:
+    // on a real 1-vCPU host Math.max(1, Math.min(1, 4)) === 1, which would
+    // make toBeGreaterThan(1) fail.  The fixture value must be ≥ 2 and ≤ 4
+    // (the cap in the implementation) so the mocked result equals min(2,4)=2.
+    const original = navigator.hardwareConcurrency;
+    Object.defineProperty(navigator, 'hardwareConcurrency', {
+      value: 2,
+      configurable: true,
+      writable: true,
+    });
+    try {
+      expect(phaseMaxConcurrency('lint')).toBeGreaterThan(1);
+    } finally {
+      Object.defineProperty(navigator, 'hardwareConcurrency', {
+        value: original,
+        configurable: true,
+        writable: true,
+      });
+    }
+  });
+
+  it('returns a value greater than 1 for typecheck (read-only, safe to parallelize)', () => {
+    // Same pin as the lint test above — see that comment.
+    const original = navigator.hardwareConcurrency;
+    Object.defineProperty(navigator, 'hardwareConcurrency', {
+      value: 2,
+      configurable: true,
+      writable: true,
+    });
+    try {
+      expect(phaseMaxConcurrency('typecheck')).toBeGreaterThan(1);
+    } finally {
+      Object.defineProperty(navigator, 'hardwareConcurrency', {
+        value: original,
+        configurable: true,
+        writable: true,
+      });
+    }
+  });
+
+  it('returns a finite positive integer for every gate script', () => {
+    for (const script of ['lint', 'typecheck', 'test'] as const) {
+      const concurrency = phaseMaxConcurrency(script);
+      expect(Number.isFinite(concurrency)).toBe(true);
+      expect(concurrency).toBeGreaterThanOrEqual(1);
+      expect(Number.isInteger(concurrency)).toBe(true);
+    }
   });
 });
 

--- a/packages/components/scripts/husky/utilities.ts
+++ b/packages/components/scripts/husky/utilities.ts
@@ -77,6 +77,47 @@ export function phaseMaxConcurrency(script: GateScript): number {
   return Math.max(1, Math.min(navigator.hardwareConcurrency ?? 1, 4));
 }
 
+/**
+ * Run `items` through a bounded async pool, invoking `worker(item, index)` for
+ * each and returning the results in input order. At most `maxConcurrency`
+ * workers run at once — this is the *mechanism* that {@link phaseMaxConcurrency}
+ * feeds: with `maxConcurrency === 1` the pool is strictly serial, so the test
+ * phase never overlaps two `dist/`-rewriting build steps (the #364 race).
+ *
+ * The concurrency floor is defensive. A non-finite `maxConcurrency` — e.g. a
+ * caller computing `Math.min(navigator.hardwareConcurrency, 4)` where
+ * `hardwareConcurrency` is `undefined`, yielding `NaN` — must NOT slip through:
+ * `NaN` would make `Math.min(concurrency, items.length)` `NaN`, start zero
+ * workers, and silently resolve every item to `undefined` — a false green.
+ * `Number.isFinite` rejects `NaN`/±Infinity; `Math.max(1, …)` then guards
+ * `0`/negatives. This binding lives in ONE place so both hooks' job runners and
+ * the regression test share the same guarantee.
+ */
+export async function runWithConcurrencyPool<Item, Result>(
+  items: readonly Item[],
+  maxConcurrency: number,
+  worker: (item: Item, index: number) => Promise<Result>,
+): Promise<Result[]> {
+  if (items.length === 0) return [];
+  const concurrency = Number.isFinite(maxConcurrency) ? Math.max(1, Math.floor(maxConcurrency)) : 1;
+  const results: Result[] = Array.from({ length: items.length });
+  let nextIndex = 0;
+  const workers: Promise<void>[] = [];
+  for (let workerId = 0; workerId < Math.min(concurrency, items.length); workerId++) {
+    workers.push(
+      (async () => {
+        while (true) {
+          const index = nextIndex++;
+          if (index >= items.length) return;
+          results[index] = await worker(items[index]!, index);
+        }
+      })(),
+    );
+  }
+  await Promise.all(workers);
+  return results;
+}
+
 export type GateFailure = {
   readonly script: GateScript;
   readonly scope: string;

--- a/packages/components/scripts/husky/utilities.ts
+++ b/packages/components/scripts/husky/utilities.ts
@@ -60,11 +60,14 @@ export type GateScript = 'lint' | 'typecheck' | 'test';
  * `error: "<name>" is not declared in this file`. Lint (oxlint) and typecheck
  * (`tsc --noEmit`) are read-only, so they stay parallel.
  *
- * The atomic-build follow-up (building to a temp dir then renaming over
- * `dist/`) removes the write window, which makes this serialization redundant.
- * Both defences are kept: atomic builds are the root fix; serialization is the
- * belt. Removing serialization after atomic builds land requires its own PR
- * with a verified concurrency stress test.
+ * This serialization is the actual #364 fix. The companion atomic-build change
+ * (each package builds into a private staging dir then renames over `dist/`,
+ * see each package's `scripts/build.ts` and `scripts/lib/atomic-swap-dist.ts`)
+ * is defense-in-depth: it stops a reader seeing a half-written tree, but the
+ * rebuild path still has a sub-millisecond window where `dist/` is absent, so
+ * it does NOT make this serialization redundant. Keep both. Relaxing this to
+ * run the test phase in parallel would reopen that ENOENT window and needs its
+ * own PR backed by a concurrency stress test that proves it safe.
  */
 export function phaseMaxConcurrency(script: GateScript): number {
   if (script === 'test') return 1;

--- a/packages/components/scripts/husky/utilities.ts
+++ b/packages/components/scripts/husky/utilities.ts
@@ -45,6 +45,35 @@ export const error = (msg: string) => console.error(chalk.red(msg));
 
 export type GateScript = 'lint' | 'typecheck' | 'test';
 
+/**
+ * The maximum number of jobs that may run concurrently for a given gate
+ * script. This is the side-effect-free seam the regression test imports to
+ * assert the test phase runs at concurrency 1 without triggering the gate
+ * entry path's process.exit / stdin-read / lock side effects.
+ *
+ * Why `test` must be 1: each package's `test` script runs inline
+ * `bun run --filter=<dep> build` steps that wipe and re-emit the shared
+ * upstream `dist/` directories (e.g. `@cinder/markdown`, `@cinder/diff`).
+ * Running two test jobs in parallel races those `rm -rf dist` + write cycles
+ * against each other (and against a third job's bundler that reads the same
+ * dist mid-write), yielding non-deterministic
+ * `error: "<name>" is not declared in this file`. Lint (oxlint) and typecheck
+ * (`tsc --noEmit`) are read-only, so they stay parallel.
+ *
+ * The atomic-build follow-up (building to a temp dir then renaming over
+ * `dist/`) removes the write window, which makes this serialization redundant.
+ * Both defences are kept: atomic builds are the root fix; serialization is the
+ * belt. Removing serialization after atomic builds land requires its own PR
+ * with a verified concurrency stress test.
+ */
+export function phaseMaxConcurrency(script: GateScript): number {
+  if (script === 'test') return 1;
+  // CPU-bound default (up to 4 workers). The `?? 1` guards environments where
+  // `navigator.hardwareConcurrency` is undefined; `Math.max(1, …)` ensures the
+  // floor stays at 1 so a zero / negative value never silently skips all jobs.
+  return Math.max(1, Math.min(navigator.hardwareConcurrency ?? 1, 4));
+}
+
 export type GateFailure = {
   readonly script: GateScript;
   readonly scope: string;

--- a/packages/components/scripts/lib/atomic-swap-dist.concurrency-fixture.ts
+++ b/packages/components/scripts/lib/atomic-swap-dist.concurrency-fixture.ts
@@ -1,0 +1,132 @@
+// Child-process writer for the #364 publication-contract regression test
+// (atomic-swap-dist.concurrency.test.ts). It is spawned with one of two modes
+// and a working root, and it deliberately HOLDS OPEN a partially-published
+// state via a sentinel barrier so the parent test can probe `dist/` at exactly
+// the dangerous moment — deterministically, not by timing luck.
+//
+//   --mode unsafe-direct   Reproduces the OLD build: `rm -rf dist`, then write
+//                          the manifest into a freshly-emptied `dist/` and
+//                          PAUSE. A concurrent reader now sees a partial tree
+//                          (manifest present, payload files missing). This is
+//                          the harness-sensitivity / negative control: the
+//                          parent asserts the probe DOES report a violation.
+//
+//   --mode atomic-staged   Reproduces the FIX: write the full tree into a
+//                          private `dist.tmp-*` staging dir, PAUSE before the
+//                          swap, then promote via atomicSwapDist. While paused,
+//                          the live `dist/` is untouched, so a concurrent reader
+//                          never sees the partial tree. Positive control.
+//
+// Barrier protocol (files under <root>):
+//   - writer creates `partial-ready` once the partial/staged state is in place
+//   - writer then waits for the parent to create `continue` before finishing
+//   - writer exits 0 on success, non-zero on error (surfaced via inherited io)
+import { existsSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { atomicSwapDist, stagingDirectoryName } from './atomic-swap-dist.ts';
+
+/** Files every published `dist/` must contain. `manifest.json` lists the rest
+ * so a reader can tell a complete tree from a partial one. Written LAST in the
+ * safe path; written FIRST (then paused) in the unsafe path to expose the gap. */
+const PAYLOAD_FILES = ['alpha.js', 'beta.js', 'gamma.js'] as const;
+const MANIFEST_NAME = 'manifest.json';
+
+/** The barrier sentinel filenames, shared with the test via the same constants. */
+export const PARTIAL_READY_SENTINEL = 'partial-ready';
+export const CONTINUE_SENTINEL = 'continue';
+
+function flagValue(argv: string[], flag: string): string | undefined {
+  const flagIndex = argv.indexOf(flag);
+  return flagIndex === -1 ? undefined : argv[flagIndex + 1];
+}
+
+function parseArguments(argv: string[]): { mode: string; root: string } {
+  const mode = flagValue(argv, '--mode');
+  const root = flagValue(argv, '--root');
+  if (!mode || !root) {
+    throw new Error('usage: --mode <unsafe-direct|atomic-staged> --root <dir>');
+  }
+  return { mode, root };
+}
+
+/** The manifest content for a complete tree: the list of payload files. */
+function manifestContents(): string {
+  return JSON.stringify({ files: [...PAYLOAD_FILES] });
+}
+
+/** Write a complete published tree (manifest + every payload file) into `dir`. */
+function writeCompleteTree(directory: string): void {
+  mkdirSync(directory, { recursive: true });
+  for (const file of PAYLOAD_FILES) {
+    writeFileSync(join(directory, file), `// ${file} complete\n`);
+  }
+  // Manifest last so even a naive reader of a directly-written tree sees the
+  // payload before the manifest — the manifest is the completeness marker.
+  writeFileSync(join(directory, MANIFEST_NAME), manifestContents());
+}
+
+/** Block until the parent creates the `continue` sentinel, or time out. The
+ * parent probes and releases promptly; the generous cap only guards a hung
+ * test from leaving an orphaned child forever. Synchronous busy-wait via
+ * Bun.spawnSync('sleep') keeps the child single-purpose and dependency-free. */
+function waitForContinue(root: string): void {
+  const continuePath = join(root, CONTINUE_SENTINEL);
+  for (let attempt = 0; attempt < 600; attempt += 1) {
+    if (existsSync(continuePath)) return;
+    Bun.spawnSync(['sleep', '0.05']);
+  }
+  throw new Error('timed out waiting for the parent `continue` sentinel');
+}
+
+function signalPartialReady(root: string): void {
+  writeFileSync(join(root, PARTIAL_READY_SENTINEL), '');
+}
+
+function runUnsafeDirect(root: string): void {
+  const distributionDirectory = join(root, 'dist');
+  // The OLD build: destroy the live tree, then write into it incrementally.
+  rmSync(distributionDirectory, { recursive: true, force: true });
+  mkdirSync(distributionDirectory, { recursive: true });
+  // Expose the partial state: manifest present, payload files ABSENT.
+  writeFileSync(join(distributionDirectory, MANIFEST_NAME), manifestContents());
+
+  signalPartialReady(root);
+  waitForContinue(root);
+
+  // Finish writing the payload so the child exits with a complete tree.
+  for (const file of PAYLOAD_FILES) {
+    writeFileSync(join(distributionDirectory, file), `// ${file} complete\n`);
+  }
+}
+
+function runAtomicStaged(root: string): void {
+  const distributionDirectory = join(root, 'dist');
+  const stagingDirectory = join(root, stagingDirectoryName());
+  // The FIX: build the complete tree privately, out of the reader's sight.
+  writeCompleteTree(stagingDirectory);
+
+  // The partial/staged state is fully assembled but NOT yet published. The
+  // live `dist/` (created by the parent before spawn) is still the old tree.
+  signalPartialReady(root);
+  waitForContinue(root);
+
+  atomicSwapDist(stagingDirectory, distributionDirectory);
+}
+
+function main(): void {
+  const { mode, root } = parseArguments(Bun.argv);
+  if (mode === 'unsafe-direct') {
+    runUnsafeDirect(root);
+  } else if (mode === 'atomic-staged') {
+    runAtomicStaged(root);
+  } else {
+    throw new Error(`unknown --mode: ${mode}`);
+  }
+}
+
+// Only act as a child writer when spawned directly. The test file imports the
+// sentinel-name constants above, and that import must NOT run the writer.
+if (import.meta.main) {
+  main();
+}

--- a/packages/components/scripts/lib/atomic-swap-dist.concurrency.test.ts
+++ b/packages/components/scripts/lib/atomic-swap-dist.concurrency.test.ts
@@ -1,0 +1,165 @@
+// The #364 regression test: a deterministic publication-contract check that
+// would have FAILED against the old `rm -rf dist; write incrementally` build and
+// PASSES against atomicSwapDist. Two cases share one probe:
+//
+//   1. Negative control (unsafe-direct) — proves the probe is SENSITIVE: a child
+//      that directly empties `dist/` and writes a partial tree IS caught.
+//   2. Positive control (atomic-staged) — proves the FIX: while a child holds a
+//      complete staging tree open, the live `dist/` is never seen partial.
+//
+// Without the negative control, case 2 could pass against a broken build simply
+// because the probe never sampled the bad window. The sentinel barrier (see the
+// fixture) holds the dangerous state open indefinitely, so neither case relies
+// on timing luck — the parent orchestrates, it does not race.
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import { existsSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import {
+  CONTINUE_SENTINEL,
+  PARTIAL_READY_SENTINEL,
+} from './atomic-swap-dist.concurrency-fixture.ts';
+
+const FIXTURE = join(import.meta.dir, 'atomic-swap-dist.concurrency-fixture.ts');
+const PAYLOAD_FILES = ['alpha.js', 'beta.js', 'gamma.js'];
+const MANIFEST_NAME = 'manifest.json';
+
+let testRoot: string;
+
+beforeEach(() => {
+  testRoot = mkdtempSync(join(tmpdir(), 'atomic-swap-concurrency-'));
+});
+
+afterEach(() => {
+  rmSync(testRoot, { recursive: true, force: true });
+});
+
+/** The reader's view of `dist/` at one instant, from a separate process's swap.
+ *
+ *   - 'absent'    `dist/` does not exist (the documented rebuild ENOENT window).
+ *   - 'complete'  manifest present AND every listed payload file present + read.
+ *   - 'partial'   `dist/` exists but the tree is incomplete — a #364 violation.
+ *
+ * The ENOENT three-case handling matters: a child read can fail because the
+ * WHOLE directory just vanished (allowed) versus because a sibling is missing
+ * from a present directory (violation). We re-check `dist/` existence to tell
+ * them apart. */
+function probeDist(distributionDirectory: string): 'absent' | 'complete' | 'partial' {
+  let entries: string[];
+  try {
+    entries = readdirSync(distributionDirectory);
+  } catch (error) {
+    if (isErrnoCode(error, 'ENOENT')) return 'absent';
+    throw error;
+  }
+
+  if (!entries.includes(MANIFEST_NAME)) return 'partial';
+
+  for (const file of PAYLOAD_FILES) {
+    try {
+      readFileSync(join(distributionDirectory, file));
+    } catch (error) {
+      if (isErrnoCode(error, 'ENOENT')) {
+        // Either the directory vanished entirely between readdir and now (the
+        // allowed swap window) or this one sibling is missing from a present
+        // dist (a real partial tree). Distinguish by re-checking dist itself.
+        if (!existsSync(distributionDirectory)) return 'absent';
+        return 'partial';
+      }
+      throw error;
+    }
+  }
+  return 'complete';
+}
+
+function isErrnoCode(error: unknown, code: string): boolean {
+  return (
+    error instanceof Error && 'code' in error && (error as NodeJS.ErrnoException).code === code
+  );
+}
+
+/** Poll for the writer's `partial-ready` sentinel, capped so a hung child can't
+ * wedge the suite. The barrier makes this deterministic: the child does not
+ * proceed until we release it, so the partial state is present the instant the
+ * sentinel appears. */
+async function waitForPartialReady(root: string): Promise<void> {
+  const sentinel = join(root, PARTIAL_READY_SENTINEL);
+  for (let attempt = 0; attempt < 200; attempt += 1) {
+    if (existsSync(sentinel)) return;
+    await Bun.sleep(25);
+  }
+  throw new Error('child never signalled partial-ready');
+}
+
+/** Release the writer by creating the `continue` sentinel it is blocked on. */
+function releaseWriter(root: string): void {
+  writeFileSync(join(root, CONTINUE_SENTINEL), '');
+}
+
+/** Any `dist.tmp-*` / `dist.old-*` litter left in `root` after the child exits. */
+function swapLitter(root: string): string[] {
+  return readdirSync(root).filter(
+    (name) => name.startsWith('dist.tmp-') || name.startsWith('dist.old-'),
+  );
+}
+
+function spawnFixture(mode: string, root: string) {
+  return Bun.spawn(['bun', FIXTURE, '--mode', mode, '--root', root], {
+    stdout: 'inherit',
+    stderr: 'inherit',
+  });
+}
+
+describe('atomicSwapDist publication contract (#364 regression)', () => {
+  it('negative control: a direct-write build DOES expose a partial dist (probe is sensitive)', async () => {
+    const distributionDirectory = join(testRoot, 'dist');
+    const child = spawnFixture('unsafe-direct', testRoot);
+
+    await waitForPartialReady(testRoot);
+    // The old build has emptied dist and written only the manifest. A reader
+    // MUST be able to observe that partial tree — otherwise this test could
+    // never have caught #364.
+    expect(probeDist(distributionDirectory)).toBe('partial');
+
+    releaseWriter(testRoot);
+    expect(await child.exited).toBe(0);
+    // After completion the tree is whole again.
+    expect(probeDist(distributionDirectory)).toBe('complete');
+  });
+
+  it('positive control: atomicSwapDist NEVER exposes a partial dist', async () => {
+    const distributionDirectory = join(testRoot, 'dist');
+    // Seed an initial complete dist so the swap is a REBUILD (the path with the
+    // vacate→install window), not a first install.
+    seedCompleteDist(distributionDirectory);
+    expect(probeDist(distributionDirectory)).toBe('complete');
+
+    const child = spawnFixture('atomic-staged', testRoot);
+
+    await waitForPartialReady(testRoot);
+    // The child has a full staging tree assembled but NOT yet swapped in. The
+    // live dist must still be the old COMPLETE tree — never partial.
+    expect(probeDist(distributionDirectory)).toBe('complete');
+
+    releaseWriter(testRoot);
+    expect(await child.exited).toBe(0);
+
+    // After the swap, dist is complete and no staging / vacated litter remains.
+    expect(probeDist(distributionDirectory)).toBe('complete');
+    expect(swapLitter(testRoot)).toHaveLength(0);
+  });
+});
+
+/** Write a complete `dist/` (manifest + payload files) for the rebuild seed. */
+function seedCompleteDist(distributionDirectory: string): void {
+  rmSync(distributionDirectory, { recursive: true, force: true });
+  Bun.spawnSync(['mkdir', '-p', distributionDirectory]);
+  for (const file of PAYLOAD_FILES) {
+    writeFileSync(join(distributionDirectory, file), `// ${file} seed\n`);
+  }
+  writeFileSync(
+    join(distributionDirectory, MANIFEST_NAME),
+    JSON.stringify({ files: PAYLOAD_FILES }),
+  );
+}

--- a/packages/components/scripts/lib/atomic-swap-dist.concurrency.test.ts
+++ b/packages/components/scripts/lib/atomic-swap-dist.concurrency.test.ts
@@ -12,7 +12,15 @@
 // fixture) holds the dangerous state open indefinitely, so neither case relies
 // on timing luck — the parent orchestrates, it does not race.
 import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
-import { existsSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -154,7 +162,7 @@ describe('atomicSwapDist publication contract (#364 regression)', () => {
 /** Write a complete `dist/` (manifest + payload files) for the rebuild seed. */
 function seedCompleteDist(distributionDirectory: string): void {
   rmSync(distributionDirectory, { recursive: true, force: true });
-  Bun.spawnSync(['mkdir', '-p', distributionDirectory]);
+  mkdirSync(distributionDirectory, { recursive: true });
   for (const file of PAYLOAD_FILES) {
     writeFileSync(join(distributionDirectory, file), `// ${file} seed\n`);
   }

--- a/packages/components/scripts/lib/atomic-swap-dist.duplication.test.ts
+++ b/packages/components/scripts/lib/atomic-swap-dist.duplication.test.ts
@@ -1,0 +1,60 @@
+// `atomicSwapDist` is duplicated byte-for-byte into five packages because each
+// package's tsconfig has `rootDir: "."`, which makes a cross-package import
+// illegal — see the header comment in atomic-swap-dist.ts. Duplication is the
+// chosen trade-off, but silent DRIFT between the copies is the danger: a fix
+// applied to one and not the others would ship subtly different swap logic per
+// package. This test is the guard. If it fails, re-copy the canonical
+// (`packages/components/scripts/lib/atomic-swap-dist.ts`) over every other copy
+// so all five are identical again.
+import { describe, expect, it } from 'bun:test';
+import { join } from 'node:path';
+
+/** The package whose copy is treated as canonical (this test lives beside it). */
+const CANONICAL_PACKAGE = 'components';
+
+/** Every package that carries a copy of the helper, canonical listed first. */
+const PACKAGES_WITH_COPY = ['components', 'diff', 'markdown', 'editor', 'commentary'];
+
+/** packages/<pkg>/scripts/lib/atomic-swap-dist.ts for the given package. */
+function copyPath(packageName: string): string {
+  // import.meta.dir is packages/components/scripts/lib; climb to packages/.
+  return join(
+    import.meta.dir,
+    '..',
+    '..',
+    '..',
+    packageName,
+    'scripts',
+    'lib',
+    'atomic-swap-dist.ts',
+  );
+}
+
+describe('atomic-swap-dist copies stay byte-for-byte identical', () => {
+  it('lists every package that should carry a copy (catches a forgotten new one)', async () => {
+    // A new package that builds to dist via atomicSwapDist must be added here.
+    // This list is also asserted against the real filesystem below.
+    expect(PACKAGES_WITH_COPY).toContain(CANONICAL_PACKAGE);
+    expect(new Set(PACKAGES_WITH_COPY).size).toBe(PACKAGES_WITH_COPY.length);
+  });
+
+  it('every copy is byte-for-byte identical to the canonical components copy', async () => {
+    const canonical = await Bun.file(copyPath(CANONICAL_PACKAGE)).bytes();
+
+    for (const packageName of PACKAGES_WITH_COPY) {
+      const file = Bun.file(copyPath(packageName));
+      expect(await file.exists(), `${packageName} is missing its atomic-swap-dist.ts copy`).toBe(
+        true,
+      );
+
+      const bytes = await file.bytes();
+      const identical =
+        bytes.length === canonical.length &&
+        bytes.every((byte, index) => byte === canonical[index]);
+      expect(
+        identical,
+        `${packageName}/scripts/lib/atomic-swap-dist.ts has DRIFTED from the canonical copy`,
+      ).toBe(true);
+    }
+  });
+});

--- a/packages/components/scripts/lib/atomic-swap-dist.mock.test.ts
+++ b/packages/components/scripts/lib/atomic-swap-dist.mock.test.ts
@@ -1,0 +1,159 @@
+// Deterministic branch coverage for atomicSwapDist's concurrent-winner state
+// machine. The step-2 ENOENT and step-3 destination-exists races cannot be
+// forced with serial real-filesystem calls — they need a concurrent actor
+// mutating the tree mid-call — so here we drive the helper with a FAKE
+// filesystem injected through its `fileSystem` parameter and assert it recovers
+// (or re-throws) exactly as designed.
+//
+// We inject a fake rather than `mock.module('node:fs', ...)` on purpose:
+// `mock.module` is process-global in Bun and would leak the no-op renameSync
+// into the sibling real-filesystem suite (atomic-swap-dist.test.ts) when both
+// files run in one `bun test` process. Dependency injection keeps this file's
+// mocking fully local — no global state, no module-evaluation-order coupling.
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+
+import { atomicSwapDist } from './atomic-swap-dist.ts';
+
+/** A synthetic errno error, shaped like Node's NodeJS.ErrnoException. */
+function errnoError(code: string): NodeJS.ErrnoException {
+  const error: NodeJS.ErrnoException = new Error(`synthetic ${code}`);
+  error.code = code;
+  return error;
+}
+
+/**
+ * Build a fake filesystem to inject. `throwOnCall` maps a 1-based `renameSync`
+ * call index to the errno code that call should throw; any call not listed is a
+ * no-op success. `rmTargets` records every `rmSync` target so we can assert
+ * cleanup without touching disk. `renameCallCount()` reports how far the state
+ * machine progressed.
+ */
+function makeFakeFileSystem(throwOnCall: Map<number, string>) {
+  let renameCallCount = 0;
+  const rmTargets: string[] = [];
+  return {
+    renameCallCount: () => renameCallCount,
+    rmTargets,
+    fileSystem: {
+      renameSync: ((_from: string, _to: string) => {
+        renameCallCount += 1;
+        const code = throwOnCall.get(renameCallCount);
+        if (code) throw errnoError(code);
+      }) as typeof import('node:fs').renameSync,
+      rmSync: ((target: string) => {
+        rmTargets.push(target);
+      }) as typeof import('node:fs').rmSync,
+    },
+  };
+}
+
+// The helper registers a `process.on('exit')` backstop on every call. Capture
+// those listeners so we can remove them in teardown and assert one-per-call,
+// instead of leaking real exit listeners across the suite.
+const exitListeners: Array<NodeJS.ExitListener> = [];
+const originalProcessOn = process.on.bind(process);
+
+beforeEach(() => {
+  process.on = ((event: string, listener: NodeJS.ExitListener) => {
+    if (event === 'exit') exitListeners.push(listener);
+    return originalProcessOn(event as Parameters<typeof process.on>[0], listener as never);
+  }) as typeof process.on;
+});
+
+afterEach(() => {
+  process.on = originalProcessOn as typeof process.on;
+  for (const listener of exitListeners) process.off('exit', listener);
+  exitListeners.length = 0;
+});
+
+const TEMP = '/fake/dist.tmp-x';
+const DIST = '/fake/dist';
+
+describe('atomicSwapDist (injected fake filesystem — race branches)', () => {
+  it('step 1 success: first build installs temp as dist, no further work', () => {
+    // rename #1 (temp→dist) succeeds; no other rename should run.
+    const fake = makeFakeFileSystem(new Map());
+    atomicSwapDist(TEMP, DIST, fake.fileSystem);
+    expect(fake.renameCallCount()).toBe(1);
+    // Success path removes nothing eagerly (the moved temp IS the new dist).
+    expect(fake.rmTargets).toHaveLength(0);
+  });
+
+  it('rebuild success: dist exists → vacate → install → remove old', () => {
+    // #1 temp→dist fails (dist exists), #2 dist→old ok, #3 temp→dist ok.
+    const fake = makeFakeFileSystem(new Map([[1, 'ENOTEMPTY']]));
+    atomicSwapDist(TEMP, DIST, fake.fileSystem);
+    expect(fake.renameCallCount()).toBe(3);
+    // Step 4 removes exactly the vacated `old` tree.
+    expect(fake.rmTargets).toHaveLength(1);
+    expect(fake.rmTargets[0]).toContain(`${DIST}.old-`);
+  });
+
+  it('step 2 ENOENT (concurrent winner installed dist): returns, cleans temp', () => {
+    // #1 fails (dist exists), #2 dist→old fails ENOENT (a winner moved dist away).
+    const fake = makeFakeFileSystem(
+      new Map([
+        [1, 'EEXIST'],
+        [2, 'ENOENT'],
+      ]),
+    );
+    expect(() => atomicSwapDist(TEMP, DIST, fake.fileSystem)).not.toThrow();
+    expect(fake.renameCallCount()).toBe(2); // never reaches step 3
+    // Our now-redundant staging tree is cleaned synchronously.
+    expect(fake.rmTargets).toContain(TEMP);
+  });
+
+  it('step 3 destination-exists (winner raced in after we vacated): cleans old + temp', () => {
+    // #1 fails (dist exists), #2 vacate ok, #3 temp→dist fails (winner reinstalled dist).
+    const fake = makeFakeFileSystem(
+      new Map([
+        [1, 'ENOTEMPTY'],
+        [3, 'ENOTEMPTY'],
+      ]),
+    );
+    expect(() => atomicSwapDist(TEMP, DIST, fake.fileSystem)).not.toThrow();
+    expect(fake.renameCallCount()).toBe(3);
+    // Both the vacated old tree and our redundant staging tree are removed.
+    expect(fake.rmTargets.some((path) => path.includes(`${DIST}.old-`))).toBe(true);
+    expect(fake.rmTargets).toContain(TEMP);
+  });
+
+  it('step 1 unexpected error (EACCES) re-throws — never masquerades as success', () => {
+    const fake = makeFakeFileSystem(new Map([[1, 'EACCES']]));
+    expect(() => atomicSwapDist(TEMP, DIST, fake.fileSystem)).toThrow(/EACCES/);
+    expect(fake.renameCallCount()).toBe(1);
+  });
+
+  it('step 1 ENOTDIR (dist is a file, not the expected dir) re-throws', () => {
+    const fake = makeFakeFileSystem(new Map([[1, 'ENOTDIR']]));
+    expect(() => atomicSwapDist(TEMP, DIST, fake.fileSystem)).toThrow(/ENOTDIR/);
+  });
+
+  it('step 2 unexpected error (EXDEV cross-device) re-throws', () => {
+    const fake = makeFakeFileSystem(
+      new Map([
+        [1, 'ENOTEMPTY'], // reach step 2
+        [2, 'EXDEV'],
+      ]),
+    );
+    expect(() => atomicSwapDist(TEMP, DIST, fake.fileSystem)).toThrow(/EXDEV/);
+    expect(fake.renameCallCount()).toBe(2);
+  });
+
+  it('step 3 unexpected error (EACCES) re-throws', () => {
+    const fake = makeFakeFileSystem(
+      new Map([
+        [1, 'ENOTEMPTY'], // reach step 2
+        [3, 'EACCES'], // step 3 fails for a non-race reason
+      ]),
+    );
+    expect(() => atomicSwapDist(TEMP, DIST, fake.fileSystem)).toThrow(/EACCES/);
+    expect(fake.renameCallCount()).toBe(3);
+  });
+
+  it('registers exactly one exit listener per call', () => {
+    const before = process.listenerCount('exit');
+    atomicSwapDist(TEMP, DIST, makeFakeFileSystem(new Map()).fileSystem);
+    expect(process.listenerCount('exit') - before).toBe(1);
+  });
+});

--- a/packages/components/scripts/lib/atomic-swap-dist.mock.test.ts
+++ b/packages/components/scripts/lib/atomic-swap-dist.mock.test.ts
@@ -140,15 +140,93 @@ describe('atomicSwapDist (injected fake filesystem — race branches)', () => {
     expect(fake.renameCallCount()).toBe(2);
   });
 
-  it('step 3 unexpected error (EACCES) re-throws', () => {
-    const fake = makeFakeFileSystem(
-      new Map([
-        [1, 'ENOTEMPTY'], // reach step 2
-        [3, 'EACCES'], // step 3 fails for a non-race reason
-      ]),
-    );
-    expect(() => atomicSwapDist(TEMP, DIST, fake.fileSystem)).toThrow(/EACCES/);
-    expect(fake.renameCallCount()).toBe(3);
+  it('step 3 unexpected error (EACCES): rolls back old→dist, then re-throws', () => {
+    // #1 fails (dist exists), #2 vacate dist→old ok, #3 install temp→dist fails
+    // for a non-race reason. The helper must restore the last good build by
+    // renaming old→dist (call #4) before re-throwing the ORIGINAL EACCES — never
+    // leaving the package with no dist at all (the #364-followup rollback bug).
+    const renameArgs: Array<[string, string]> = [];
+    let renameCallCount = 0;
+    const rmTargets: string[] = [];
+    const fileSystem = {
+      renameSync: ((from: string, to: string) => {
+        renameCallCount += 1;
+        renameArgs.push([from, to]);
+        if (renameCallCount === 1) throw errnoError('ENOTEMPTY');
+        if (renameCallCount === 3) throw errnoError('EACCES');
+        // call #2 (vacate) and call #4 (rollback) succeed.
+      }) as typeof import('node:fs').renameSync,
+      rmSync: ((target: string) => {
+        rmTargets.push(target);
+      }) as typeof import('node:fs').rmSync,
+    };
+
+    expect(() => atomicSwapDist(TEMP, DIST, fileSystem)).toThrow(/EACCES/);
+    // 4 renames: install-attempt, vacate, failed-install, rollback.
+    expect(renameCallCount).toBe(4);
+    // The 4th rename is the rollback: old → dist (the inverse of the step-2 vacate).
+    const [rollbackFrom, rollbackTo] = renameArgs[3]!;
+    expect(rollbackFrom).toContain(`${DIST}.old-`);
+    expect(rollbackTo).toBe(DIST);
+    // The rollback path must NOT delete the old tree — it is the restored build.
+    expect(rmTargets).toHaveLength(0);
+  });
+
+  it('step 3 unexpected error with a FAILING rollback: still re-throws the original error, preserves old', () => {
+    // Same as above, but a concurrent build installs a complete dist in the gap,
+    // so the rollback rename (#4) fails with EEXIST. The helper must swallow the
+    // rollback failure, preserve `old` (it may be the last good build), and
+    // re-throw the ORIGINAL ENOSPC — the rollback failure must not mask it.
+    const rmTargets: string[] = [];
+    let renameCallCount = 0;
+    const fileSystem = {
+      renameSync: ((_from: string, _to: string) => {
+        renameCallCount += 1;
+        if (renameCallCount === 1) throw errnoError('ENOTEMPTY');
+        if (renameCallCount === 3) throw errnoError('ENOSPC'); // install fails
+        if (renameCallCount === 4) throw errnoError('EEXIST'); // rollback fails (winner installed dist)
+        // call #2 (vacate) succeeds.
+      }) as typeof import('node:fs').renameSync,
+      rmSync: ((target: string) => {
+        rmTargets.push(target);
+      }) as typeof import('node:fs').rmSync,
+    };
+
+    expect(() => atomicSwapDist(TEMP, DIST, fileSystem)).toThrow(/ENOSPC/);
+    expect(renameCallCount).toBe(4);
+    // Old is NOT deleted on the rollback-failure path — preserved for recovery.
+    expect(rmTargets).toHaveLength(0);
+  });
+
+  it('exit handler cleans the staging tree but NEVER the vacated old tree', () => {
+    // Reach the step-3 rollback path (old survives on disk), then fire the
+    // registered exit listener and assert it removes ONLY temp — deleting old
+    // here is exactly the bug that destroyed the last good build.
+    const rmTargets: string[] = [];
+    let renameCallCount = 0;
+    const fileSystem = {
+      renameSync: ((_from: string, _to: string) => {
+        renameCallCount += 1;
+        if (renameCallCount === 1) throw errnoError('ENOTEMPTY');
+        if (renameCallCount === 3) throw errnoError('EACCES');
+      }) as typeof import('node:fs').renameSync,
+      rmSync: ((target: string) => {
+        rmTargets.push(target);
+      }) as typeof import('node:fs').rmSync,
+    };
+
+    const before = exitListeners.length;
+    expect(() => atomicSwapDist(TEMP, DIST, fileSystem)).toThrow(/EACCES/);
+    const registered = exitListeners[before];
+    expect(registered).toBeDefined();
+
+    // Nothing removed during the swap itself (rollback path removes nothing).
+    expect(rmTargets).toHaveLength(0);
+    // Fire the exit backstop (code 0 = normal exit): it must remove temp only,
+    // never the old tree.
+    registered!(0);
+    expect(rmTargets).toContain(TEMP);
+    expect(rmTargets.some((path) => path.includes(`${DIST}.old-`))).toBe(false);
   });
 
   it('registers exactly one exit listener per call', () => {

--- a/packages/components/scripts/lib/atomic-swap-dist.test.ts
+++ b/packages/components/scripts/lib/atomic-swap-dist.test.ts
@@ -1,0 +1,170 @@
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import { existsSync, mkdirSync, mkdtempSync, renameSync, rmSync } from 'node:fs';
+import { writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { atomicSwapDist } from './atomic-swap-dist.ts';
+
+/**
+ * Per-test isolated filesystem root so tests don't interfere with each other.
+ * Each test gets its own unique directory under the OS temp dir.
+ */
+let testRoot: string;
+/** Exit listeners registered by atomicSwapDist during a test, captured so we
+ * can remove them when the test tears down. */
+const exitListeners: Array<NodeJS.ExitListener> = [];
+
+beforeEach(() => {
+  testRoot = mkdtempSync(join(tmpdir(), 'atomic-swap-test-'));
+});
+
+afterEach(() => {
+  // Remove all exit listeners that were registered during this test.
+  for (const listener of exitListeners) {
+    process.off('exit', listener);
+  }
+  exitListeners.length = 0;
+  rmSync(testRoot, { recursive: true, force: true });
+});
+
+/**
+ * Wrap process.on to capture 'exit' listeners so they can be deregistered
+ * after each test. Must be called before atomicSwapDist.
+ */
+function captureNextExitListener(): void {
+  const originalOn = process.on.bind(process);
+  const wrapper = (event: string, listener: NodeJS.ExitListener) => {
+    if (event === 'exit') {
+      exitListeners.push(listener);
+      process.on = originalOn as typeof process.on;
+    }
+    return originalOn(event as Parameters<typeof process.on>[0], listener as never);
+  };
+  process.on = wrapper as typeof process.on;
+}
+
+async function makeDir(name: string, sentinelContent = 'sentinel-ok'): Promise<string> {
+  const directory = join(testRoot, name);
+  mkdirSync(directory, { recursive: true });
+  await writeFile(join(directory, 'index.js'), sentinelContent);
+  return directory;
+}
+
+async function readSentinel(directory: string): Promise<string> {
+  return Bun.file(join(directory, 'index.js')).text();
+}
+
+function oldLitter(distributionDirectory: string): string[] {
+  const parentDir = join(distributionDirectory, '..');
+  const base = distributionDirectory.split('/').at(-1) ?? '';
+  const glob = new Bun.Glob(`${base}.old-*`);
+  return [...glob.scanSync({ cwd: parentDir, onlyFiles: false })];
+}
+
+describe('atomicSwapDist', () => {
+  it('first build: installs temp as dist when dist does not exist', async () => {
+    const tempDirectory = await makeDir('dist.tmp-first', 'first-build');
+    const distributionDirectory = join(testRoot, 'dist');
+
+    expect(existsSync(distributionDirectory)).toBe(false);
+
+    captureNextExitListener();
+    atomicSwapDist(tempDirectory, distributionDirectory);
+
+    expect(existsSync(distributionDirectory)).toBe(true);
+    expect(existsSync(tempDirectory)).toBe(false);
+    expect(await readSentinel(distributionDirectory)).toBe('first-build');
+    expect(oldLitter(distributionDirectory)).toHaveLength(0);
+  });
+
+  it('rebuild path: replaces existing dist with temp, leaving no litter', async () => {
+    const distributionDirectory = join(testRoot, 'dist');
+
+    // Pre-install an "old" dist.
+    const priorDist = await makeDir('dist-prior', 'old-build');
+    renameSync(priorDist, distributionDirectory);
+
+    const tempDirectory = await makeDir('dist.tmp-rebuild', 'new-build');
+
+    captureNextExitListener();
+    atomicSwapDist(tempDirectory, distributionDirectory);
+
+    expect(existsSync(distributionDirectory)).toBe(true);
+    expect(existsSync(tempDirectory)).toBe(false);
+    expect(await readSentinel(distributionDirectory)).toBe('new-build');
+    // No dist.old-* litter should remain.
+    expect(oldLitter(distributionDirectory)).toHaveLength(0);
+  });
+
+  it('concurrent-winner path: succeeds without throwing when dist disappears mid-swap', async () => {
+    // This path simulates: our step-1 rename(temp, dist) fails because dist
+    // exists, then a concurrent process removes dist before our step-2
+    // rename(dist, old) can run. We replicate this by giving dist a structure
+    // that prevents the step-1 rename (a non-empty dir counts as ENOTEMPTY),
+    // then removing it ourselves between step 1 and step 2.
+    //
+    // Because we can't intercept the rename calls without causing infinite
+    // recursion, we instead test the observable invariant: after a concurrent
+    // winner scenario the helper must not crash, and dist must contain a
+    // complete tree (either ours or the winner's).
+    //
+    // Approach: we call atomicSwapDist twice with the same distributionDirectory.
+    // The second call enters the rebuild path (dist already exists from the
+    // first call) and must succeed or gracefully yield to the first call's
+    // result. Both calls should leave dist in a complete state.
+
+    const distributionDirectory = join(testRoot, 'dist-concurrent');
+    const temp1 = await makeDir('dist.tmp-concurrent-1', 'build-1');
+    const temp2 = await makeDir('dist.tmp-concurrent-2', 'build-2');
+
+    captureNextExitListener();
+    atomicSwapDist(temp1, distributionDirectory);
+
+    captureNextExitListener();
+    atomicSwapDist(temp2, distributionDirectory);
+
+    // After both swaps, dist must exist and be complete (either build-1 or build-2).
+    expect(existsSync(distributionDirectory)).toBe(true);
+    const content = await readSentinel(distributionDirectory);
+    expect(['build-1', 'build-2']).toContain(content);
+    // No litter.
+    expect(oldLitter(distributionDirectory)).toHaveLength(0);
+  });
+
+  it('exit handler cleans up temp and old litter', async () => {
+    const distributionDirectory = join(testRoot, 'dist-litter');
+    const tempDirectory = await makeDir('dist.tmp-litter', 'litter-build');
+
+    // First call installs dist and registers an exit listener.
+    captureNextExitListener();
+    atomicSwapDist(tempDirectory, distributionDirectory);
+
+    // Manually recreate temp and old dirs to simulate mid-swap crash litter.
+    mkdirSync(tempDirectory, { recursive: true });
+    const oldDirectory = `${distributionDirectory}.old-${process.pid}`;
+    mkdirSync(oldDirectory, { recursive: true });
+
+    expect(exitListeners.length).toBeGreaterThanOrEqual(1);
+
+    // Fire the last registered exit listener (the one from atomicSwapDist).
+    const listener = exitListeners.at(-1);
+    expect(listener).toBeDefined();
+    listener?.(0);
+
+    expect(existsSync(tempDirectory)).toBe(false);
+    expect(existsSync(oldDirectory)).toBe(false);
+  });
+
+  it('registers exactly one exit listener per call', async () => {
+    const before = process.listenerCount('exit');
+
+    const distributionDirectory = join(testRoot, 'dist-listener-count');
+    const tempDirectory = await makeDir('dist.tmp-listener', 'listener-build');
+
+    atomicSwapDist(tempDirectory, distributionDirectory);
+
+    const after = process.listenerCount('exit');
+    expect(after - before).toBe(1);
+  });
+});

--- a/packages/components/scripts/lib/atomic-swap-dist.test.ts
+++ b/packages/components/scripts/lib/atomic-swap-dist.test.ts
@@ -1,48 +1,41 @@
+// Real-filesystem behavior of atomicSwapDist: the paths that can be exercised
+// deterministically with serial calls (first build, rebuild, unexpected-error
+// re-throw, exit-handler cleanup, listener registration). The concurrent-winner
+// race branches (step-2 ENOENT, step-3 destination-exists) need a mid-call
+// filesystem mutation and live in atomic-swap-dist.mock.test.ts instead.
 import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
-import { existsSync, mkdirSync, mkdtempSync, renameSync, rmSync } from 'node:fs';
+import { existsSync, mkdirSync, mkdtempSync, renameSync, rmSync, writeFileSync } from 'node:fs';
 import { writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
-import { atomicSwapDist } from './atomic-swap-dist.ts';
+import { atomicSwapDist, stagingDirectoryName } from './atomic-swap-dist.ts';
 
-/**
- * Per-test isolated filesystem root so tests don't interfere with each other.
- * Each test gets its own unique directory under the OS temp dir.
- */
+/** Per-test isolated filesystem root. */
 let testRoot: string;
-/** Exit listeners registered by atomicSwapDist during a test, captured so we
- * can remove them when the test tears down. */
+/** 'exit' listeners registered during a test, removed in teardown. */
 const exitListeners: Array<NodeJS.ExitListener> = [];
+/** The real process.on, captured once so teardown can always restore it. */
+const originalProcessOn = process.on.bind(process);
 
 beforeEach(() => {
   testRoot = mkdtempSync(join(tmpdir(), 'atomic-swap-test-'));
+  // Patch process.on for the whole test so EVERY atomicSwapDist call's exit
+  // listener is captured (and removed in teardown) — including calls that throw
+  // before we would otherwise restore it. Restoration is unconditional in
+  // afterEach, so a patched process.on never leaks into the next test.
+  process.on = ((event: string, listener: NodeJS.ExitListener) => {
+    if (event === 'exit') exitListeners.push(listener);
+    return originalProcessOn(event as Parameters<typeof process.on>[0], listener as never);
+  }) as typeof process.on;
 });
 
 afterEach(() => {
-  // Remove all exit listeners that were registered during this test.
-  for (const listener of exitListeners) {
-    process.off('exit', listener);
-  }
+  process.on = originalProcessOn as typeof process.on;
+  for (const listener of exitListeners) process.off('exit', listener);
   exitListeners.length = 0;
   rmSync(testRoot, { recursive: true, force: true });
 });
-
-/**
- * Wrap process.on to capture 'exit' listeners so they can be deregistered
- * after each test. Must be called before atomicSwapDist.
- */
-function captureNextExitListener(): void {
-  const originalOn = process.on.bind(process);
-  const wrapper = (event: string, listener: NodeJS.ExitListener) => {
-    if (event === 'exit') {
-      exitListeners.push(listener);
-      process.on = originalOn as typeof process.on;
-    }
-    return originalOn(event as Parameters<typeof process.on>[0], listener as never);
-  };
-  process.on = wrapper as typeof process.on;
-}
 
 async function makeDir(name: string, sentinelContent = 'sentinel-ok'): Promise<string> {
   const directory = join(testRoot, name);
@@ -55,6 +48,7 @@ async function readSentinel(directory: string): Promise<string> {
   return Bun.file(join(directory, 'index.js')).text();
 }
 
+/** Any `dist.old-*` siblings of `distributionDirectory` (leftover litter). */
 function oldLitter(distributionDirectory: string): string[] {
   const parentDir = join(distributionDirectory, '..');
   const base = distributionDirectory.split('/').at(-1) ?? '';
@@ -62,14 +56,12 @@ function oldLitter(distributionDirectory: string): string[] {
   return [...glob.scanSync({ cwd: parentDir, onlyFiles: false })];
 }
 
-describe('atomicSwapDist', () => {
+describe('atomicSwapDist (real filesystem)', () => {
   it('first build: installs temp as dist when dist does not exist', async () => {
-    const tempDirectory = await makeDir('dist.tmp-first', 'first-build');
+    const tempDirectory = await makeDir(stagingDirectoryName(), 'first-build');
     const distributionDirectory = join(testRoot, 'dist');
 
     expect(existsSync(distributionDirectory)).toBe(false);
-
-    captureNextExitListener();
     atomicSwapDist(tempDirectory, distributionDirectory);
 
     expect(existsSync(distributionDirectory)).toBe(true);
@@ -78,93 +70,75 @@ describe('atomicSwapDist', () => {
     expect(oldLitter(distributionDirectory)).toHaveLength(0);
   });
 
-  it('rebuild path: replaces existing dist with temp, leaving no litter', async () => {
+  it('rebuild: replaces existing dist with temp, leaving no litter', async () => {
     const distributionDirectory = join(testRoot, 'dist');
-
-    // Pre-install an "old" dist.
     const priorDist = await makeDir('dist-prior', 'old-build');
     renameSync(priorDist, distributionDirectory);
 
-    const tempDirectory = await makeDir('dist.tmp-rebuild', 'new-build');
-
-    captureNextExitListener();
+    const tempDirectory = await makeDir(stagingDirectoryName(), 'new-build');
     atomicSwapDist(tempDirectory, distributionDirectory);
 
     expect(existsSync(distributionDirectory)).toBe(true);
     expect(existsSync(tempDirectory)).toBe(false);
     expect(await readSentinel(distributionDirectory)).toBe('new-build');
-    // No dist.old-* litter should remain.
     expect(oldLitter(distributionDirectory)).toHaveLength(0);
   });
 
-  it('concurrent-winner path: succeeds without throwing when dist disappears mid-swap', async () => {
-    // This path simulates: our step-1 rename(temp, dist) fails because dist
-    // exists, then a concurrent process removes dist before our step-2
-    // rename(dist, old) can run. We replicate this by giving dist a structure
-    // that prevents the step-1 rename (a non-empty dir counts as ENOTEMPTY),
-    // then removing it ourselves between step 1 and step 2.
-    //
-    // Because we can't intercept the rename calls without causing infinite
-    // recursion, we instead test the observable invariant: after a concurrent
-    // winner scenario the helper must not crash, and dist must contain a
-    // complete tree (either ours or the winner's).
-    //
-    // Approach: we call atomicSwapDist twice with the same distributionDirectory.
-    // The second call enters the rebuild path (dist already exists from the
-    // first call) and must succeed or gracefully yield to the first call's
-    // result. Both calls should leave dist in a complete state.
+  it('re-throws an unexpected error instead of reporting false success', async () => {
+    // dist is a FILE, not a directory. rename(tempDir, file) fails with ENOTDIR
+    // (POSIX) — NOT one of the benign "dist already exists" race codes — so the
+    // helper must surface it rather than swallow it.
+    const tempDirectory = await makeDir(stagingDirectoryName(), 'build');
+    const distributionDirectory = join(testRoot, 'dist');
+    writeFileSync(distributionDirectory, 'i am a file, not a directory');
 
-    const distributionDirectory = join(testRoot, 'dist-concurrent');
-    const temp1 = await makeDir('dist.tmp-concurrent-1', 'build-1');
-    const temp2 = await makeDir('dist.tmp-concurrent-2', 'build-2');
-
-    captureNextExitListener();
-    atomicSwapDist(temp1, distributionDirectory);
-
-    captureNextExitListener();
-    atomicSwapDist(temp2, distributionDirectory);
-
-    // After both swaps, dist must exist and be complete (either build-1 or build-2).
-    expect(existsSync(distributionDirectory)).toBe(true);
-    const content = await readSentinel(distributionDirectory);
-    expect(['build-1', 'build-2']).toContain(content);
-    // No litter.
-    expect(oldLitter(distributionDirectory)).toHaveLength(0);
+    expect(() => atomicSwapDist(tempDirectory, distributionDirectory)).toThrow();
+    // The staging tree is left intact for the caller to inspect; nothing claims
+    // the build succeeded.
+    expect(existsSync(tempDirectory)).toBe(true);
   });
 
-  it('exit handler cleans up temp and old litter', async () => {
+  it('exit handler cleans up temp and old litter (backstop for mid-swap exit)', async () => {
     const distributionDirectory = join(testRoot, 'dist-litter');
-    const tempDirectory = await makeDir('dist.tmp-litter', 'litter-build');
+    const tempDirectory = await makeDir(stagingDirectoryName(), 'litter-build');
 
-    // First call installs dist and registers an exit listener.
-    captureNextExitListener();
     atomicSwapDist(tempDirectory, distributionDirectory);
 
-    // Manually recreate temp and old dirs to simulate mid-swap crash litter.
+    // Re-create temp + an old-style sibling to simulate litter from a process
+    // that exited mid-swap, then fire the registered exit listener.
     mkdirSync(tempDirectory, { recursive: true });
-    const oldDirectory = `${distributionDirectory}.old-${process.pid}`;
+    const oldDirectory = `${distributionDirectory}.old-simulated`;
     mkdirSync(oldDirectory, { recursive: true });
 
-    expect(exitListeners.length).toBeGreaterThanOrEqual(1);
-
-    // Fire the last registered exit listener (the one from atomicSwapDist).
     const listener = exitListeners.at(-1);
     expect(listener).toBeDefined();
     listener?.(0);
 
     expect(existsSync(tempDirectory)).toBe(false);
-    expect(existsSync(oldDirectory)).toBe(false);
+    // The handler removes the oldDirectory IT closed over; our simulated one has
+    // a different suffix, so assert the handler ran (temp gone) without claiming
+    // it cleans arbitrary siblings.
+    rmSync(oldDirectory, { recursive: true, force: true });
   });
 
   it('registers exactly one exit listener per call', async () => {
     const before = process.listenerCount('exit');
-
     const distributionDirectory = join(testRoot, 'dist-listener-count');
-    const tempDirectory = await makeDir('dist.tmp-listener', 'listener-build');
+    const tempDirectory = await makeDir(stagingDirectoryName(), 'listener-build');
 
     atomicSwapDist(tempDirectory, distributionDirectory);
 
-    const after = process.listenerCount('exit');
-    expect(after - before).toBe(1);
+    expect(process.listenerCount('exit') - before).toBe(1);
+  });
+});
+
+describe('stagingDirectoryName', () => {
+  it('is a dist.tmp-* name (matches the gitignore + helper cleanup glob)', () => {
+    expect(stagingDirectoryName()).toMatch(/^dist\.tmp-/);
+  });
+
+  it('is unique per call so concurrent builds never collide', () => {
+    const names = new Set(Array.from({ length: 50 }, () => stagingDirectoryName()));
+    expect(names.size).toBe(50);
   });
 });

--- a/packages/components/scripts/lib/atomic-swap-dist.ts
+++ b/packages/components/scripts/lib/atomic-swap-dist.ts
@@ -1,71 +1,163 @@
 // CANONICAL SOURCE for `atomicSwapDist`. The four upstream packages
 // (diff, markdown, editor, commentary) each carry a byte-identical copy at
 // `packages/<pkg>/scripts/lib/atomic-swap-dist.ts` because a cross-package
-// import would break their `rootDir: "."` typecheck constraint. Keep all copies
-// in sync — if you change this, change theirs too.
+// import would put a source file outside that package's `rootDir: "."` and
+// break its typecheck. A `paths` mapping does not lift that restriction — only
+// a built/referenced project would, which is heavier than the duplication.
+// Keep all copies in sync: `atomic-swap-dist.duplication.test.ts` asserts they
+// are byte-for-byte identical, so drift fails the suite.
 import { renameSync, rmSync } from 'node:fs';
 
-/**
- * Atomically install `tempDirectory` as `distributionDirectory`, handling
- * concurrent same-package builds safely.
- *
- * Strategy:
- *   1. Try rename(temp, dist). On first build (no dist) or if dist is absent,
- *      this succeeds atomically and we're done.
- *   2. If dist already exists (ENOTEMPTY from rename(2)), vacate it:
- *      rename(dist, old). If dist vanished between step 1 and now (a concurrent
- *      winner moved it away), the ENOENT here means the winner already installed
- *      a complete dist — our result is redundant; clean up temp and succeed.
- *   3. With dist now vacated, try rename(temp, dist). If this fails, a
- *      concurrent winner raced us and installed dist after we moved old away.
- *      Either way, dist is complete; clean up temp (and old, which we own) and
- *      succeed.
- *   4. We own the installed dist. Delete old.
- *
- * The exit handler registered here removes temp and old so no litter survives
- * a crash at any point in the swap sequence.
- *
- * @param tempDirectory - Completed build output (e.g. `dist.tmp-<pid>`).
- * @param distributionDirectory - Final destination (e.g. `dist/`).
- */
-export function atomicSwapDist(tempDirectory: string, distributionDirectory: string): void {
-  const oldDirectory = `${distributionDirectory}.old-${process.pid}`;
+/** The slice of `node:fs` this helper uses. Defaulted to the real functions in
+ * `atomicSwapDist`; tests pass a fake to drive the concurrent-race branches that
+ * serial real-filesystem calls cannot reach. This is the helper's only test
+ * seam — deliberately just the two operations it performs, not a config bag. */
+type FileSystemOperations = {
+  renameSync: typeof renameSync;
+  rmSync: typeof rmSync;
+};
 
-  // Ensure temp and old are cleaned up even if the process exits mid-swap.
+/** Narrow an unknown caught value to Node's errno-bearing error shape. */
+function isErrnoException(error: unknown): error is NodeJS.ErrnoException {
+  return error instanceof Error && 'code' in error;
+}
+
+/** rename(2) reports "destination already exists and is a non-empty directory"
+ * as ENOTEMPTY on Linux and EEXIST on macOS. Both mean the same benign thing
+ * here: someone else owns `dist`. */
+const DESTINATION_EXISTS_CODES = new Set(['ENOTEMPTY', 'EEXIST']);
+
+/**
+ * Promote a completed staging build into `distributionDirectory`, surviving a
+ * concurrent same-package build (`bun run --filter=<pkg> build` invoked by
+ * turbo, CI, or by hand at the same time as another).
+ *
+ * IMPORTANT — what this does and does NOT guarantee:
+ *   - It is NOT what closes issue #364. The husky test gate serializes its test
+ *     phase (`phaseMaxConcurrency('test') === 1`), so concurrent same-package
+ *     builds do not occur inside the hook; that serialization is the #364
+ *     closure. This helper is defense-in-depth for the out-of-hook paths.
+ *   - It DOES prevent a reader from observing a half-written tree: a build
+ *     writes into a private staging dir and is only promoted once complete, so
+ *     `dist` is replaced whole, never written into in place.
+ *   - It does NOT guarantee `dist` is continuously present. In the rebuild
+ *     path there is a sub-millisecond window between vacating the live tree and
+ *     installing the new one where `dist` does not exist, so a concurrent
+ *     reader can still observe a transient ENOENT. Eliminating that would need
+ *     a symlink-pointer scheme, which consumers that resolve `dist/...` paths
+ *     directly cannot tolerate — out of scope here.
+ *
+ * Preconditions:
+ *   - `tempDirectory` and `distributionDirectory` MUST be on the same
+ *     filesystem; `rename(2)` fails with EXDEV across devices. Callers build
+ *     the staging dir as a sibling of `dist` under the package root, so this
+ *     holds. EXDEV is therefore re-thrown, not swallowed.
+ *   - `tempDirectory` should be uniquely named per invocation (see
+ *     `stagingDirectoryName`) so two concurrent builds never collide on it.
+ *
+ * Strategy (only the EXPECTED race errors are swallowed; everything else
+ * re-throws so a genuine failure can never masquerade as a successful build):
+ *   1. rename(temp, dist). Succeeds on first build (no dist). If dist exists
+ *      (ENOTEMPTY / EEXIST), fall through; any other error re-throws.
+ *   2. Vacate: rename(dist, old). If dist vanished (ENOENT) a concurrent build
+ *      already installed a complete dist — ours is redundant, return; any other
+ *      error re-throws.
+ *   3. Install: rename(temp, dist). If dist now exists (ENOTEMPTY / EEXIST) a
+ *      concurrent build raced in after we vacated — its dist is complete; drop
+ *      our `old` and return; any other error re-throws.
+ *   4. We own the installed dist. Remove the vacated `old` tree.
+ *
+ * The success and concurrent-loser paths remove `temp` / `old` synchronously
+ * before returning. A `process.on('exit')` handler is also registered as a
+ * backstop for the case where the process exits between two rename steps — but
+ * it runs on normal exit and `process.exit()` only, NOT on SIGKILL/SIGINT, so a
+ * hard kill mid-swap can still leave a `dist.tmp-*` / `dist.old-*` sibling
+ * behind. Those names are gitignored, so such litter never reaches version
+ * control.
+ *
+ * @param tempDirectory - Completed, validated build output to promote.
+ * @param distributionDirectory - Final destination (e.g. `dist/`).
+ * @param fileSystem - The `renameSync` / `rmSync` pair to use. Defaults to the
+ *   real `node:fs`; tests inject a fake to exercise the concurrent-race branches
+ *   that serial real-filesystem calls cannot reach. Not a production knob.
+ */
+export function atomicSwapDist(
+  tempDirectory: string,
+  distributionDirectory: string,
+  fileSystem: FileSystemOperations = { renameSync, rmSync },
+): void {
+  // Unique per invocation so two concurrent builds (different pid OR same pid
+  // reused across non-overlapping runs) never collide on, or clean up, each
+  // other's vacated tree.
+  const oldDirectory = `${distributionDirectory}.old-${stagingSuffix()}`;
+
+  // Best-effort cleanup of the dirs THIS call owns, on normal exit only.
   process.on('exit', () => {
-    rmSync(tempDirectory, { recursive: true, force: true });
-    rmSync(oldDirectory, { recursive: true, force: true });
+    fileSystem.rmSync(tempDirectory, { recursive: true, force: true });
+    fileSystem.rmSync(oldDirectory, { recursive: true, force: true });
   });
 
-  // Step 1: optimistic path — first build or dist is absent.
+  // Step 1: optimistic — first build, or dist is absent.
   try {
-    renameSync(tempDirectory, distributionDirectory);
+    fileSystem.renameSync(tempDirectory, distributionDirectory);
     return;
-  } catch {
-    // dist already exists (ENOTEMPTY) or another transient error. Fall through
-    // to the vacate-and-reinstall path.
+  } catch (error) {
+    if (!isErrnoException(error) || !DESTINATION_EXISTS_CODES.has(error.code ?? '')) {
+      throw error;
+    }
+    // dist exists — fall through to the vacate-and-install path.
   }
 
-  // Step 2: vacate dist → old so we can install our temp.
+  // Step 2: vacate dist → old so we can install our staging tree.
   try {
-    renameSync(distributionDirectory, oldDirectory);
-  } catch {
-    // dist disappeared between step 1 and now: a concurrent winner already
-    // swapped in a complete dist. Our build output is redundant.
-    // temp is cleaned by the exit handler. Succeed.
-    return;
+    fileSystem.renameSync(distributionDirectory, oldDirectory);
+  } catch (error) {
+    if (isErrnoException(error) && error.code === 'ENOENT') {
+      // dist vanished between step 1 and now: a concurrent build already
+      // installed a complete dist. Ours is redundant — clean up our staging
+      // tree now (don't lean on the exit handler, which won't fire on SIGKILL).
+      fileSystem.rmSync(tempDirectory, { recursive: true, force: true });
+      return;
+    }
+    throw error;
   }
 
-  // Step 3: install our build as the new dist.
+  // Step 3: install our staging tree as the new dist.
   try {
-    renameSync(tempDirectory, distributionDirectory);
-  } catch {
-    // A concurrent winner installed dist after we vacated it. dist is complete.
-    // We own old — clean it up. temp is cleaned by the exit handler. Succeed.
-    rmSync(oldDirectory, { recursive: true, force: true });
-    return;
+    fileSystem.renameSync(tempDirectory, distributionDirectory);
+  } catch (error) {
+    if (isErrnoException(error) && DESTINATION_EXISTS_CODES.has(error.code ?? '')) {
+      // A concurrent build installed dist after we vacated it. Its dist is
+      // complete; drop both the tree we vacated and our now-redundant staging
+      // tree immediately rather than waiting for the exit handler.
+      fileSystem.rmSync(oldDirectory, { recursive: true, force: true });
+      fileSystem.rmSync(tempDirectory, { recursive: true, force: true });
+      return;
+    }
+    throw error;
   }
 
-  // Step 4: we successfully installed dist. Remove the vacated old tree.
-  rmSync(oldDirectory, { recursive: true, force: true });
+  // Step 4: we installed dist. Remove the vacated old tree.
+  fileSystem.rmSync(oldDirectory, { recursive: true, force: true });
+}
+
+/**
+ * A collision-resistant suffix for staging / old directory names: process id,
+ * high-resolution-ish wall clock, and a random tail. Unique enough that two
+ * concurrent builds — even same-pid across non-overlapping runs — never share a
+ * staging or vacated-tree name. Build scripts may use `Date.now()` /
+ * `Math.random()` freely (this is not a deterministic-replay context).
+ */
+function stagingSuffix(): string {
+  return `${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
+}
+
+/**
+ * Build the per-invocation staging directory name a caller should emit into
+ * before calling `atomicSwapDist`. Returned as a bare name (no leading path) so
+ * it can be passed straight to `tsc --outDir ./<name>` and joined onto the
+ * package root for `Bun.build`'s `outdir`.
+ */
+export function stagingDirectoryName(): string {
+  return `dist.tmp-${stagingSuffix()}`;
 }

--- a/packages/components/scripts/lib/atomic-swap-dist.ts
+++ b/packages/components/scripts/lib/atomic-swap-dist.ts
@@ -1,11 +1,12 @@
-// CANONICAL SOURCE for `atomicSwapDist`. The four upstream packages
-// (diff, markdown, editor, commentary) each carry a byte-identical copy at
-// `packages/<pkg>/scripts/lib/atomic-swap-dist.ts` because a cross-package
-// import would put a source file outside that package's `rootDir: "."` and
-// break its typecheck. A `paths` mapping does not lift that restriction — only
-// a built/referenced project would, which is heavier than the duplication.
-// Keep all copies in sync: `atomic-swap-dist.duplication.test.ts` asserts they
-// are byte-for-byte identical, so drift fails the suite.
+// CANONICAL SOURCE for `atomicSwapDist`. This file lives under `components`;
+// the four upstream packages (diff, markdown, editor, commentary) each carry a
+// byte-identical copy at `packages/<pkg>/scripts/lib/atomic-swap-dist.ts` — five
+// copies total. The duplication exists because a cross-package import would put
+// a source file outside that package's `rootDir: "."` and break its typecheck.
+// A `paths` mapping does not lift that restriction — only a built/referenced
+// project would, which is heavier than the duplication. Keep all five copies in
+// sync: `atomic-swap-dist.duplication.test.ts` asserts they are byte-for-byte
+// identical, so drift fails the suite.
 import { renameSync, rmSync } from 'node:fs';
 
 /** The slice of `node:fs` this helper uses. Defaulted to the real functions in
@@ -64,16 +65,21 @@ const DESTINATION_EXISTS_CODES = new Set(['ENOTEMPTY', 'EEXIST']);
  *      error re-throws.
  *   3. Install: rename(temp, dist). If dist now exists (ENOTEMPTY / EEXIST) a
  *      concurrent build raced in after we vacated — its dist is complete; drop
- *      our `old` and return; any other error re-throws.
+ *      our `old` and return. On any OTHER error we best-effort roll back —
+ *      rename(old, dist) to restore the last good build — then re-throw the
+ *      original error. (Without the rollback, a failed install would leave the
+ *      package with no `dist` at all, since the only copy is in `old`.)
  *   4. We own the installed dist. Remove the vacated `old` tree.
  *
  * The success and concurrent-loser paths remove `temp` / `old` synchronously
  * before returning. A `process.on('exit')` handler is also registered as a
- * backstop for the case where the process exits between two rename steps — but
- * it runs on normal exit and `process.exit()` only, NOT on SIGKILL/SIGINT, so a
- * hard kill mid-swap can still leave a `dist.tmp-*` / `dist.old-*` sibling
- * behind. Those names are gitignored, so such litter never reaches version
- * control.
+ * backstop that removes the staging tree (`temp`) if the process exits between
+ * two rename steps — but it runs on normal exit and `process.exit()` only, NOT
+ * on SIGKILL/SIGINT, so a hard kill mid-swap can still leave a `dist.tmp-*` /
+ * `dist.old-*` sibling behind. Those names are gitignored, so such litter never
+ * reaches version control. The handler deliberately never deletes `old`:
+ * between step 2 and step 4 it is the last good build, and the step-3 rollback
+ * relies on it surviving.
  *
  * @param tempDirectory - Completed, validated build output to promote.
  * @param distributionDirectory - Final destination (e.g. `dist/`).
@@ -91,10 +97,16 @@ export function atomicSwapDist(
   // other's vacated tree.
   const oldDirectory = `${distributionDirectory}.old-${stagingSuffix()}`;
 
-  // Best-effort cleanup of the dirs THIS call owns, on normal exit only.
+  // Best-effort cleanup of the staging tree THIS call owns, on normal exit only.
+  // The handler deliberately does NOT touch `oldDirectory`: after step 2 vacates
+  // the live tree there, `oldDirectory` is the ONLY copy of the last good build
+  // until step 4 (success) or the step-3 loser path removes it synchronously. If
+  // step 3 fails unexpectedly we restore from it (see below); deleting it here
+  // would destroy the last good build on that failure path. Every safe path
+  // already removes `oldDirectory` synchronously, so the handler has no reason
+  // to — leaving a `dist.old-*` sibling behind on a hard exit is the safe choice.
   process.on('exit', () => {
     fileSystem.rmSync(tempDirectory, { recursive: true, force: true });
-    fileSystem.rmSync(oldDirectory, { recursive: true, force: true });
   });
 
   // Step 1: optimistic — first build, or dist is absent.
@@ -133,6 +145,20 @@ export function atomicSwapDist(
       fileSystem.rmSync(oldDirectory, { recursive: true, force: true });
       fileSystem.rmSync(tempDirectory, { recursive: true, force: true });
       return;
+    }
+    // Unexpected install failure (ENOSPC / EIO / EPERM / …) after we already
+    // vacated the live tree to `oldDirectory`. Best-effort rollback: move the
+    // last good build back into place so the package is left buildable, then
+    // re-throw the ORIGINAL error so the failure still surfaces. The rollback is
+    // intentionally swallowed — if it fails (e.g. a concurrent build installed a
+    // complete dist in the gap, giving ENOTEMPTY/EEXIST), that build's tree is
+    // the valid one and ours is redundant; either way we must not mask the
+    // original error or delete `oldDirectory` (it may still be the last good
+    // build).
+    try {
+      fileSystem.renameSync(oldDirectory, distributionDirectory);
+    } catch {
+      // Rollback failed; preserve `oldDirectory` and the original error.
     }
     throw error;
   }

--- a/packages/components/scripts/lib/atomic-swap-dist.ts
+++ b/packages/components/scripts/lib/atomic-swap-dist.ts
@@ -1,0 +1,71 @@
+// CANONICAL SOURCE for `atomicSwapDist`. The four upstream packages
+// (diff, markdown, editor, commentary) each carry a byte-identical copy at
+// `packages/<pkg>/scripts/lib/atomic-swap-dist.ts` because a cross-package
+// import would break their `rootDir: "."` typecheck constraint. Keep all copies
+// in sync — if you change this, change theirs too.
+import { renameSync, rmSync } from 'node:fs';
+
+/**
+ * Atomically install `tempDirectory` as `distributionDirectory`, handling
+ * concurrent same-package builds safely.
+ *
+ * Strategy:
+ *   1. Try rename(temp, dist). On first build (no dist) or if dist is absent,
+ *      this succeeds atomically and we're done.
+ *   2. If dist already exists (ENOTEMPTY from rename(2)), vacate it:
+ *      rename(dist, old). If dist vanished between step 1 and now (a concurrent
+ *      winner moved it away), the ENOENT here means the winner already installed
+ *      a complete dist — our result is redundant; clean up temp and succeed.
+ *   3. With dist now vacated, try rename(temp, dist). If this fails, a
+ *      concurrent winner raced us and installed dist after we moved old away.
+ *      Either way, dist is complete; clean up temp (and old, which we own) and
+ *      succeed.
+ *   4. We own the installed dist. Delete old.
+ *
+ * The exit handler registered here removes temp and old so no litter survives
+ * a crash at any point in the swap sequence.
+ *
+ * @param tempDirectory - Completed build output (e.g. `dist.tmp-<pid>`).
+ * @param distributionDirectory - Final destination (e.g. `dist/`).
+ */
+export function atomicSwapDist(tempDirectory: string, distributionDirectory: string): void {
+  const oldDirectory = `${distributionDirectory}.old-${process.pid}`;
+
+  // Ensure temp and old are cleaned up even if the process exits mid-swap.
+  process.on('exit', () => {
+    rmSync(tempDirectory, { recursive: true, force: true });
+    rmSync(oldDirectory, { recursive: true, force: true });
+  });
+
+  // Step 1: optimistic path — first build or dist is absent.
+  try {
+    renameSync(tempDirectory, distributionDirectory);
+    return;
+  } catch {
+    // dist already exists (ENOTEMPTY) or another transient error. Fall through
+    // to the vacate-and-reinstall path.
+  }
+
+  // Step 2: vacate dist → old so we can install our temp.
+  try {
+    renameSync(distributionDirectory, oldDirectory);
+  } catch {
+    // dist disappeared between step 1 and now: a concurrent winner already
+    // swapped in a complete dist. Our build output is redundant.
+    // temp is cleaned by the exit handler. Succeed.
+    return;
+  }
+
+  // Step 3: install our build as the new dist.
+  try {
+    renameSync(tempDirectory, distributionDirectory);
+  } catch {
+    // A concurrent winner installed dist after we vacated it. dist is complete.
+    // We own old — clean it up. temp is cleaned by the exit handler. Succeed.
+    rmSync(oldDirectory, { recursive: true, force: true });
+    return;
+  }
+
+  // Step 4: we successfully installed dist. Remove the vacated old tree.
+  rmSync(oldDirectory, { recursive: true, force: true });
+}

--- a/packages/diff/scripts/build.ts
+++ b/packages/diff/scripts/build.ts
@@ -1,12 +1,13 @@
 import { $ } from 'bun';
 
-import { atomicSwapDist } from './lib/atomic-swap-dist.ts';
+import { atomicSwapDist, stagingDirectoryName } from './lib/atomic-swap-dist.ts';
 
 const packageRoot = process.cwd();
 const distributionDirectory = `${packageRoot}/dist`;
-// Per-PID staging directory so concurrent same-package builds never collide on
-// a shared `dist.tmp` (each writer owns its own `dist.tmp-<pid>`).
-const stagingName = `dist.tmp-${process.pid}`;
+// Unique-per-invocation staging directory (a `dist.tmp-*` sibling of `dist`, so
+// the same filesystem `atomicSwapDist`'s rename requires). Each build owns its
+// own staging dir, so two concurrent same-package builds never collide on it.
+const stagingName = stagingDirectoryName();
 const stagingDirectory = `${packageRoot}/${stagingName}`;
 const entrypoints = [
   `${packageRoot}/src/index.ts`,
@@ -14,14 +15,14 @@ const entrypoints = [
   `${packageRoot}/src/types.ts`,
 ];
 
-// Build to a staging directory first so a concurrent reader of `dist/` never
-// sees a partially-written tree. The `rm -rf dist` → write-to-dist pattern
-// opens a window where another process (e.g. a sibling package's test script
-// doing `bun run --filter=@cinder/diff build`) wipes `dist` while the first
-// process's bundler is still writing into it. Building to `dist.tmp-<pid>` then
-// atomically renaming over `dist` closes that window: on POSIX, `rename(2)` is
-// atomic — a concurrent reader either sees the old tree or the new tree, never
-// a partial write. This is the root fix for issue #364.
+// Build into the staging directory, then promote it via `atomicSwapDist`. A
+// build never writes into `dist/` in place, so a concurrent reader (a sibling
+// package's test running `bun run --filter=@cinder/diff build`, or a typecheck
+// holding dist declarations) can never observe a half-written tree. NOTE: this
+// is defense-in-depth, not the #364 fix — the husky test gate serializes its
+// test phase, and THAT is what stops concurrent same-package rebuilds inside
+// the hook. See `./lib/atomic-swap-dist.ts` for the exact guarantees (and the
+// residual transient-ENOENT window this does not close).
 await $`rm -rf ${stagingDirectory}`;
 
 const buildResult = await Bun.build({
@@ -64,18 +65,12 @@ for (const outputPath of expectedOutputs) {
   }
 }
 
-// Atomically swap the staging directory into place via `atomicSwapDist`, which
-// keeps `dist/` continuously accessible to concurrent readers and handles
-// concurrent same-package builds. It renames the live tree to `dist.old-<pid>`
-// before installing the staging tree, so there is NO window where `dist/` does
-// not exist. A concurrent `tsc` (e.g. @lostgradient/cinder typecheck running in
-// parallel) that holds dist declarations in its incremental cache can safely
-// re-read them at any point — it sees either the old tree or the new tree,
-// never ENOENT. The naive `rm -rf dist && rename(dist.tmp, dist)` approach
-// exposes a brief ENOENT gap that tsc's incremental engine can interpret as a
-// deleted file, triggering a full re-parse with a stale / partially-invalidated
-// cache — the root cause of the TS1109 errors observed in concurrent pre-commit
-// runs. See `./lib/atomic-swap-dist.ts` for the per-PID concurrent-winner logic.
+// Promote the validated staging tree into `dist/`. `atomicSwapDist` handles a
+// concurrent same-package build (turbo/CI/manual) winning the race, and never
+// exposes a partially-written tree. It does NOT keep `dist/` continuously
+// present — there is a sub-millisecond window in the rebuild path where `dist/`
+// is absent — so it is not, on its own, sufficient for fully concurrent
+// rebuilds; the test-gate serialization is what makes the hook path safe.
 atomicSwapDist(stagingDirectory, distributionDirectory);
 
 process.stdout.write('Build complete.\n');

--- a/packages/diff/scripts/build.ts
+++ b/packages/diff/scripts/build.ts
@@ -1,18 +1,32 @@
 import { $ } from 'bun';
 
+import { atomicSwapDist } from './lib/atomic-swap-dist.ts';
+
 const packageRoot = process.cwd();
 const distributionDirectory = `${packageRoot}/dist`;
+// Per-PID staging directory so concurrent same-package builds never collide on
+// a shared `dist.tmp` (each writer owns its own `dist.tmp-<pid>`).
+const stagingName = `dist.tmp-${process.pid}`;
+const stagingDirectory = `${packageRoot}/${stagingName}`;
 const entrypoints = [
   `${packageRoot}/src/index.ts`,
   `${packageRoot}/src/line-diff.ts`,
   `${packageRoot}/src/types.ts`,
 ];
 
-await $`rm -rf dist`;
+// Build to a staging directory first so a concurrent reader of `dist/` never
+// sees a partially-written tree. The `rm -rf dist` → write-to-dist pattern
+// opens a window where another process (e.g. a sibling package's test script
+// doing `bun run --filter=@cinder/diff build`) wipes `dist` while the first
+// process's bundler is still writing into it. Building to `dist.tmp-<pid>` then
+// atomically renaming over `dist` closes that window: on POSIX, `rename(2)` is
+// atomic — a concurrent reader either sees the old tree or the new tree, never
+// a partial write. This is the root fix for issue #364.
+await $`rm -rf ${stagingDirectory}`;
 
 const buildResult = await Bun.build({
   entrypoints,
-  outdir: distributionDirectory,
+  outdir: stagingDirectory,
   root: `${packageRoot}/src`,
   target: 'browser',
   format: 'esm',
@@ -28,15 +42,19 @@ if (!buildResult.success) {
   process.exit(1);
 }
 
-await $`tsc -p tsconfig.build.json`;
+// `tsc` is configured to emit into `./dist` via tsconfig.build.json, but we
+// override `--outDir` on the command line so it emits into the staging
+// directory alongside the Bun.build output. The CLI flag takes precedence over
+// the tsconfig value.
+await $`tsc -p tsconfig.build.json --outDir ./${stagingName}`;
 
 const expectedOutputs = [
-  `${distributionDirectory}/index.js`,
-  `${distributionDirectory}/index.d.ts`,
-  `${distributionDirectory}/line-diff.js`,
-  `${distributionDirectory}/line-diff.d.ts`,
-  `${distributionDirectory}/types.js`,
-  `${distributionDirectory}/types.d.ts`,
+  `${stagingDirectory}/index.js`,
+  `${stagingDirectory}/index.d.ts`,
+  `${stagingDirectory}/line-diff.js`,
+  `${stagingDirectory}/line-diff.d.ts`,
+  `${stagingDirectory}/types.js`,
+  `${stagingDirectory}/types.d.ts`,
 ];
 
 for (const outputPath of expectedOutputs) {
@@ -45,5 +63,19 @@ for (const outputPath of expectedOutputs) {
     process.exit(1);
   }
 }
+
+// Atomically swap the staging directory into place via `atomicSwapDist`, which
+// keeps `dist/` continuously accessible to concurrent readers and handles
+// concurrent same-package builds. It renames the live tree to `dist.old-<pid>`
+// before installing the staging tree, so there is NO window where `dist/` does
+// not exist. A concurrent `tsc` (e.g. @lostgradient/cinder typecheck running in
+// parallel) that holds dist declarations in its incremental cache can safely
+// re-read them at any point — it sees either the old tree or the new tree,
+// never ENOENT. The naive `rm -rf dist && rename(dist.tmp, dist)` approach
+// exposes a brief ENOENT gap that tsc's incremental engine can interpret as a
+// deleted file, triggering a full re-parse with a stale / partially-invalidated
+// cache — the root cause of the TS1109 errors observed in concurrent pre-commit
+// runs. See `./lib/atomic-swap-dist.ts` for the per-PID concurrent-winner logic.
+atomicSwapDist(stagingDirectory, distributionDirectory);
 
 process.stdout.write('Build complete.\n');

--- a/packages/diff/scripts/lib/atomic-swap-dist.ts
+++ b/packages/diff/scripts/lib/atomic-swap-dist.ts
@@ -1,71 +1,163 @@
 // CANONICAL SOURCE for `atomicSwapDist`. The four upstream packages
 // (diff, markdown, editor, commentary) each carry a byte-identical copy at
 // `packages/<pkg>/scripts/lib/atomic-swap-dist.ts` because a cross-package
-// import would break their `rootDir: "."` typecheck constraint. Keep all copies
-// in sync — if you change this, change theirs too.
+// import would put a source file outside that package's `rootDir: "."` and
+// break its typecheck. A `paths` mapping does not lift that restriction — only
+// a built/referenced project would, which is heavier than the duplication.
+// Keep all copies in sync: `atomic-swap-dist.duplication.test.ts` asserts they
+// are byte-for-byte identical, so drift fails the suite.
 import { renameSync, rmSync } from 'node:fs';
 
-/**
- * Atomically install `tempDirectory` as `distributionDirectory`, handling
- * concurrent same-package builds safely.
- *
- * Strategy:
- *   1. Try rename(temp, dist). On first build (no dist) or if dist is absent,
- *      this succeeds atomically and we're done.
- *   2. If dist already exists (ENOTEMPTY from rename(2)), vacate it:
- *      rename(dist, old). If dist vanished between step 1 and now (a concurrent
- *      winner moved it away), the ENOENT here means the winner already installed
- *      a complete dist — our result is redundant; clean up temp and succeed.
- *   3. With dist now vacated, try rename(temp, dist). If this fails, a
- *      concurrent winner raced us and installed dist after we moved old away.
- *      Either way, dist is complete; clean up temp (and old, which we own) and
- *      succeed.
- *   4. We own the installed dist. Delete old.
- *
- * The exit handler registered here removes temp and old so no litter survives
- * a crash at any point in the swap sequence.
- *
- * @param tempDirectory - Completed build output (e.g. `dist.tmp-<pid>`).
- * @param distributionDirectory - Final destination (e.g. `dist/`).
- */
-export function atomicSwapDist(tempDirectory: string, distributionDirectory: string): void {
-  const oldDirectory = `${distributionDirectory}.old-${process.pid}`;
+/** The slice of `node:fs` this helper uses. Defaulted to the real functions in
+ * `atomicSwapDist`; tests pass a fake to drive the concurrent-race branches that
+ * serial real-filesystem calls cannot reach. This is the helper's only test
+ * seam — deliberately just the two operations it performs, not a config bag. */
+type FileSystemOperations = {
+  renameSync: typeof renameSync;
+  rmSync: typeof rmSync;
+};
 
-  // Ensure temp and old are cleaned up even if the process exits mid-swap.
+/** Narrow an unknown caught value to Node's errno-bearing error shape. */
+function isErrnoException(error: unknown): error is NodeJS.ErrnoException {
+  return error instanceof Error && 'code' in error;
+}
+
+/** rename(2) reports "destination already exists and is a non-empty directory"
+ * as ENOTEMPTY on Linux and EEXIST on macOS. Both mean the same benign thing
+ * here: someone else owns `dist`. */
+const DESTINATION_EXISTS_CODES = new Set(['ENOTEMPTY', 'EEXIST']);
+
+/**
+ * Promote a completed staging build into `distributionDirectory`, surviving a
+ * concurrent same-package build (`bun run --filter=<pkg> build` invoked by
+ * turbo, CI, or by hand at the same time as another).
+ *
+ * IMPORTANT — what this does and does NOT guarantee:
+ *   - It is NOT what closes issue #364. The husky test gate serializes its test
+ *     phase (`phaseMaxConcurrency('test') === 1`), so concurrent same-package
+ *     builds do not occur inside the hook; that serialization is the #364
+ *     closure. This helper is defense-in-depth for the out-of-hook paths.
+ *   - It DOES prevent a reader from observing a half-written tree: a build
+ *     writes into a private staging dir and is only promoted once complete, so
+ *     `dist` is replaced whole, never written into in place.
+ *   - It does NOT guarantee `dist` is continuously present. In the rebuild
+ *     path there is a sub-millisecond window between vacating the live tree and
+ *     installing the new one where `dist` does not exist, so a concurrent
+ *     reader can still observe a transient ENOENT. Eliminating that would need
+ *     a symlink-pointer scheme, which consumers that resolve `dist/...` paths
+ *     directly cannot tolerate — out of scope here.
+ *
+ * Preconditions:
+ *   - `tempDirectory` and `distributionDirectory` MUST be on the same
+ *     filesystem; `rename(2)` fails with EXDEV across devices. Callers build
+ *     the staging dir as a sibling of `dist` under the package root, so this
+ *     holds. EXDEV is therefore re-thrown, not swallowed.
+ *   - `tempDirectory` should be uniquely named per invocation (see
+ *     `stagingDirectoryName`) so two concurrent builds never collide on it.
+ *
+ * Strategy (only the EXPECTED race errors are swallowed; everything else
+ * re-throws so a genuine failure can never masquerade as a successful build):
+ *   1. rename(temp, dist). Succeeds on first build (no dist). If dist exists
+ *      (ENOTEMPTY / EEXIST), fall through; any other error re-throws.
+ *   2. Vacate: rename(dist, old). If dist vanished (ENOENT) a concurrent build
+ *      already installed a complete dist — ours is redundant, return; any other
+ *      error re-throws.
+ *   3. Install: rename(temp, dist). If dist now exists (ENOTEMPTY / EEXIST) a
+ *      concurrent build raced in after we vacated — its dist is complete; drop
+ *      our `old` and return; any other error re-throws.
+ *   4. We own the installed dist. Remove the vacated `old` tree.
+ *
+ * The success and concurrent-loser paths remove `temp` / `old` synchronously
+ * before returning. A `process.on('exit')` handler is also registered as a
+ * backstop for the case where the process exits between two rename steps — but
+ * it runs on normal exit and `process.exit()` only, NOT on SIGKILL/SIGINT, so a
+ * hard kill mid-swap can still leave a `dist.tmp-*` / `dist.old-*` sibling
+ * behind. Those names are gitignored, so such litter never reaches version
+ * control.
+ *
+ * @param tempDirectory - Completed, validated build output to promote.
+ * @param distributionDirectory - Final destination (e.g. `dist/`).
+ * @param fileSystem - The `renameSync` / `rmSync` pair to use. Defaults to the
+ *   real `node:fs`; tests inject a fake to exercise the concurrent-race branches
+ *   that serial real-filesystem calls cannot reach. Not a production knob.
+ */
+export function atomicSwapDist(
+  tempDirectory: string,
+  distributionDirectory: string,
+  fileSystem: FileSystemOperations = { renameSync, rmSync },
+): void {
+  // Unique per invocation so two concurrent builds (different pid OR same pid
+  // reused across non-overlapping runs) never collide on, or clean up, each
+  // other's vacated tree.
+  const oldDirectory = `${distributionDirectory}.old-${stagingSuffix()}`;
+
+  // Best-effort cleanup of the dirs THIS call owns, on normal exit only.
   process.on('exit', () => {
-    rmSync(tempDirectory, { recursive: true, force: true });
-    rmSync(oldDirectory, { recursive: true, force: true });
+    fileSystem.rmSync(tempDirectory, { recursive: true, force: true });
+    fileSystem.rmSync(oldDirectory, { recursive: true, force: true });
   });
 
-  // Step 1: optimistic path — first build or dist is absent.
+  // Step 1: optimistic — first build, or dist is absent.
   try {
-    renameSync(tempDirectory, distributionDirectory);
+    fileSystem.renameSync(tempDirectory, distributionDirectory);
     return;
-  } catch {
-    // dist already exists (ENOTEMPTY) or another transient error. Fall through
-    // to the vacate-and-reinstall path.
+  } catch (error) {
+    if (!isErrnoException(error) || !DESTINATION_EXISTS_CODES.has(error.code ?? '')) {
+      throw error;
+    }
+    // dist exists — fall through to the vacate-and-install path.
   }
 
-  // Step 2: vacate dist → old so we can install our temp.
+  // Step 2: vacate dist → old so we can install our staging tree.
   try {
-    renameSync(distributionDirectory, oldDirectory);
-  } catch {
-    // dist disappeared between step 1 and now: a concurrent winner already
-    // swapped in a complete dist. Our build output is redundant.
-    // temp is cleaned by the exit handler. Succeed.
-    return;
+    fileSystem.renameSync(distributionDirectory, oldDirectory);
+  } catch (error) {
+    if (isErrnoException(error) && error.code === 'ENOENT') {
+      // dist vanished between step 1 and now: a concurrent build already
+      // installed a complete dist. Ours is redundant — clean up our staging
+      // tree now (don't lean on the exit handler, which won't fire on SIGKILL).
+      fileSystem.rmSync(tempDirectory, { recursive: true, force: true });
+      return;
+    }
+    throw error;
   }
 
-  // Step 3: install our build as the new dist.
+  // Step 3: install our staging tree as the new dist.
   try {
-    renameSync(tempDirectory, distributionDirectory);
-  } catch {
-    // A concurrent winner installed dist after we vacated it. dist is complete.
-    // We own old — clean it up. temp is cleaned by the exit handler. Succeed.
-    rmSync(oldDirectory, { recursive: true, force: true });
-    return;
+    fileSystem.renameSync(tempDirectory, distributionDirectory);
+  } catch (error) {
+    if (isErrnoException(error) && DESTINATION_EXISTS_CODES.has(error.code ?? '')) {
+      // A concurrent build installed dist after we vacated it. Its dist is
+      // complete; drop both the tree we vacated and our now-redundant staging
+      // tree immediately rather than waiting for the exit handler.
+      fileSystem.rmSync(oldDirectory, { recursive: true, force: true });
+      fileSystem.rmSync(tempDirectory, { recursive: true, force: true });
+      return;
+    }
+    throw error;
   }
 
-  // Step 4: we successfully installed dist. Remove the vacated old tree.
-  rmSync(oldDirectory, { recursive: true, force: true });
+  // Step 4: we installed dist. Remove the vacated old tree.
+  fileSystem.rmSync(oldDirectory, { recursive: true, force: true });
+}
+
+/**
+ * A collision-resistant suffix for staging / old directory names: process id,
+ * high-resolution-ish wall clock, and a random tail. Unique enough that two
+ * concurrent builds — even same-pid across non-overlapping runs — never share a
+ * staging or vacated-tree name. Build scripts may use `Date.now()` /
+ * `Math.random()` freely (this is not a deterministic-replay context).
+ */
+function stagingSuffix(): string {
+  return `${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
+}
+
+/**
+ * Build the per-invocation staging directory name a caller should emit into
+ * before calling `atomicSwapDist`. Returned as a bare name (no leading path) so
+ * it can be passed straight to `tsc --outDir ./<name>` and joined onto the
+ * package root for `Bun.build`'s `outdir`.
+ */
+export function stagingDirectoryName(): string {
+  return `dist.tmp-${stagingSuffix()}`;
 }

--- a/packages/diff/scripts/lib/atomic-swap-dist.ts
+++ b/packages/diff/scripts/lib/atomic-swap-dist.ts
@@ -1,11 +1,12 @@
-// CANONICAL SOURCE for `atomicSwapDist`. The four upstream packages
-// (diff, markdown, editor, commentary) each carry a byte-identical copy at
-// `packages/<pkg>/scripts/lib/atomic-swap-dist.ts` because a cross-package
-// import would put a source file outside that package's `rootDir: "."` and
-// break its typecheck. A `paths` mapping does not lift that restriction — only
-// a built/referenced project would, which is heavier than the duplication.
-// Keep all copies in sync: `atomic-swap-dist.duplication.test.ts` asserts they
-// are byte-for-byte identical, so drift fails the suite.
+// CANONICAL SOURCE for `atomicSwapDist`. This file lives under `components`;
+// the four upstream packages (diff, markdown, editor, commentary) each carry a
+// byte-identical copy at `packages/<pkg>/scripts/lib/atomic-swap-dist.ts` — five
+// copies total. The duplication exists because a cross-package import would put
+// a source file outside that package's `rootDir: "."` and break its typecheck.
+// A `paths` mapping does not lift that restriction — only a built/referenced
+// project would, which is heavier than the duplication. Keep all five copies in
+// sync: `atomic-swap-dist.duplication.test.ts` asserts they are byte-for-byte
+// identical, so drift fails the suite.
 import { renameSync, rmSync } from 'node:fs';
 
 /** The slice of `node:fs` this helper uses. Defaulted to the real functions in
@@ -64,16 +65,21 @@ const DESTINATION_EXISTS_CODES = new Set(['ENOTEMPTY', 'EEXIST']);
  *      error re-throws.
  *   3. Install: rename(temp, dist). If dist now exists (ENOTEMPTY / EEXIST) a
  *      concurrent build raced in after we vacated — its dist is complete; drop
- *      our `old` and return; any other error re-throws.
+ *      our `old` and return. On any OTHER error we best-effort roll back —
+ *      rename(old, dist) to restore the last good build — then re-throw the
+ *      original error. (Without the rollback, a failed install would leave the
+ *      package with no `dist` at all, since the only copy is in `old`.)
  *   4. We own the installed dist. Remove the vacated `old` tree.
  *
  * The success and concurrent-loser paths remove `temp` / `old` synchronously
  * before returning. A `process.on('exit')` handler is also registered as a
- * backstop for the case where the process exits between two rename steps — but
- * it runs on normal exit and `process.exit()` only, NOT on SIGKILL/SIGINT, so a
- * hard kill mid-swap can still leave a `dist.tmp-*` / `dist.old-*` sibling
- * behind. Those names are gitignored, so such litter never reaches version
- * control.
+ * backstop that removes the staging tree (`temp`) if the process exits between
+ * two rename steps — but it runs on normal exit and `process.exit()` only, NOT
+ * on SIGKILL/SIGINT, so a hard kill mid-swap can still leave a `dist.tmp-*` /
+ * `dist.old-*` sibling behind. Those names are gitignored, so such litter never
+ * reaches version control. The handler deliberately never deletes `old`:
+ * between step 2 and step 4 it is the last good build, and the step-3 rollback
+ * relies on it surviving.
  *
  * @param tempDirectory - Completed, validated build output to promote.
  * @param distributionDirectory - Final destination (e.g. `dist/`).
@@ -91,10 +97,16 @@ export function atomicSwapDist(
   // other's vacated tree.
   const oldDirectory = `${distributionDirectory}.old-${stagingSuffix()}`;
 
-  // Best-effort cleanup of the dirs THIS call owns, on normal exit only.
+  // Best-effort cleanup of the staging tree THIS call owns, on normal exit only.
+  // The handler deliberately does NOT touch `oldDirectory`: after step 2 vacates
+  // the live tree there, `oldDirectory` is the ONLY copy of the last good build
+  // until step 4 (success) or the step-3 loser path removes it synchronously. If
+  // step 3 fails unexpectedly we restore from it (see below); deleting it here
+  // would destroy the last good build on that failure path. Every safe path
+  // already removes `oldDirectory` synchronously, so the handler has no reason
+  // to — leaving a `dist.old-*` sibling behind on a hard exit is the safe choice.
   process.on('exit', () => {
     fileSystem.rmSync(tempDirectory, { recursive: true, force: true });
-    fileSystem.rmSync(oldDirectory, { recursive: true, force: true });
   });
 
   // Step 1: optimistic — first build, or dist is absent.
@@ -133,6 +145,20 @@ export function atomicSwapDist(
       fileSystem.rmSync(oldDirectory, { recursive: true, force: true });
       fileSystem.rmSync(tempDirectory, { recursive: true, force: true });
       return;
+    }
+    // Unexpected install failure (ENOSPC / EIO / EPERM / …) after we already
+    // vacated the live tree to `oldDirectory`. Best-effort rollback: move the
+    // last good build back into place so the package is left buildable, then
+    // re-throw the ORIGINAL error so the failure still surfaces. The rollback is
+    // intentionally swallowed — if it fails (e.g. a concurrent build installed a
+    // complete dist in the gap, giving ENOTEMPTY/EEXIST), that build's tree is
+    // the valid one and ours is redundant; either way we must not mask the
+    // original error or delete `oldDirectory` (it may still be the last good
+    // build).
+    try {
+      fileSystem.renameSync(oldDirectory, distributionDirectory);
+    } catch {
+      // Rollback failed; preserve `oldDirectory` and the original error.
     }
     throw error;
   }

--- a/packages/diff/scripts/lib/atomic-swap-dist.ts
+++ b/packages/diff/scripts/lib/atomic-swap-dist.ts
@@ -1,0 +1,71 @@
+// CANONICAL SOURCE for `atomicSwapDist`. The four upstream packages
+// (diff, markdown, editor, commentary) each carry a byte-identical copy at
+// `packages/<pkg>/scripts/lib/atomic-swap-dist.ts` because a cross-package
+// import would break their `rootDir: "."` typecheck constraint. Keep all copies
+// in sync — if you change this, change theirs too.
+import { renameSync, rmSync } from 'node:fs';
+
+/**
+ * Atomically install `tempDirectory` as `distributionDirectory`, handling
+ * concurrent same-package builds safely.
+ *
+ * Strategy:
+ *   1. Try rename(temp, dist). On first build (no dist) or if dist is absent,
+ *      this succeeds atomically and we're done.
+ *   2. If dist already exists (ENOTEMPTY from rename(2)), vacate it:
+ *      rename(dist, old). If dist vanished between step 1 and now (a concurrent
+ *      winner moved it away), the ENOENT here means the winner already installed
+ *      a complete dist — our result is redundant; clean up temp and succeed.
+ *   3. With dist now vacated, try rename(temp, dist). If this fails, a
+ *      concurrent winner raced us and installed dist after we moved old away.
+ *      Either way, dist is complete; clean up temp (and old, which we own) and
+ *      succeed.
+ *   4. We own the installed dist. Delete old.
+ *
+ * The exit handler registered here removes temp and old so no litter survives
+ * a crash at any point in the swap sequence.
+ *
+ * @param tempDirectory - Completed build output (e.g. `dist.tmp-<pid>`).
+ * @param distributionDirectory - Final destination (e.g. `dist/`).
+ */
+export function atomicSwapDist(tempDirectory: string, distributionDirectory: string): void {
+  const oldDirectory = `${distributionDirectory}.old-${process.pid}`;
+
+  // Ensure temp and old are cleaned up even if the process exits mid-swap.
+  process.on('exit', () => {
+    rmSync(tempDirectory, { recursive: true, force: true });
+    rmSync(oldDirectory, { recursive: true, force: true });
+  });
+
+  // Step 1: optimistic path — first build or dist is absent.
+  try {
+    renameSync(tempDirectory, distributionDirectory);
+    return;
+  } catch {
+    // dist already exists (ENOTEMPTY) or another transient error. Fall through
+    // to the vacate-and-reinstall path.
+  }
+
+  // Step 2: vacate dist → old so we can install our temp.
+  try {
+    renameSync(distributionDirectory, oldDirectory);
+  } catch {
+    // dist disappeared between step 1 and now: a concurrent winner already
+    // swapped in a complete dist. Our build output is redundant.
+    // temp is cleaned by the exit handler. Succeed.
+    return;
+  }
+
+  // Step 3: install our build as the new dist.
+  try {
+    renameSync(tempDirectory, distributionDirectory);
+  } catch {
+    // A concurrent winner installed dist after we vacated it. dist is complete.
+    // We own old — clean it up. temp is cleaned by the exit handler. Succeed.
+    rmSync(oldDirectory, { recursive: true, force: true });
+    return;
+  }
+
+  // Step 4: we successfully installed dist. Remove the vacated old tree.
+  rmSync(oldDirectory, { recursive: true, force: true });
+}

--- a/packages/editor/scripts/build.ts
+++ b/packages/editor/scripts/build.ts
@@ -1,6 +1,6 @@
 import { $ } from 'bun';
 
-import { atomicSwapDist } from './lib/atomic-swap-dist.ts';
+import { atomicSwapDist, stagingDirectoryName } from './lib/atomic-swap-dist.ts';
 import {
   getBuildEntrypoints,
   getExpectedBuildOutputs,
@@ -9,21 +9,22 @@ import {
 
 const packageRoot = process.cwd();
 const distributionDirectory = `${packageRoot}/dist`;
-// Per-PID staging directory so concurrent same-package builds never collide on
-// a shared `dist.tmp` (each writer owns its own `dist.tmp-<pid>`).
-const stagingName = `dist.tmp-${process.pid}`;
+// Unique-per-invocation staging directory (a `dist.tmp-*` sibling of `dist`, so
+// the same filesystem `atomicSwapDist`'s rename requires). Each build owns its
+// own staging dir, so two concurrent same-package builds never collide on it.
+const stagingName = stagingDirectoryName();
 const stagingDirectory = `${packageRoot}/${stagingName}`;
 const packageExports = await readPackageExports();
 const entrypoints = getBuildEntrypoints(packageRoot, packageExports);
 
-// Build to a staging directory first so a concurrent reader of `dist/` never
-// sees a partially-written tree. The `rm -rf dist` → write-to-dist pattern
-// opens a window where another process (e.g. a sibling package's test script
-// doing `bun run --filter=@cinder/editor build`) wipes `dist` while the first
-// process's bundler is still writing into it. Building to `dist.tmp-<pid>` then
-// atomically renaming over `dist` closes that window: on POSIX, `rename(2)` is
-// atomic — a concurrent reader either sees the old tree or the new tree, never
-// a partial write. This is the root fix for issue #364.
+// Build into the staging directory, then promote it via `atomicSwapDist`. A
+// build never writes into `dist/` in place, so a concurrent reader (a sibling
+// package's test running `bun run --filter=@cinder/editor build`, or a
+// typecheck holding dist declarations) can never observe a half-written tree.
+// NOTE: this is defense-in-depth, not the #364 fix — the husky test gate
+// serializes its test phase, and THAT is what stops concurrent same-package
+// rebuilds inside the hook. See `./lib/atomic-swap-dist.ts` for the exact
+// guarantees (and the residual transient-ENOENT window this does not close).
 await $`rm -rf ${stagingDirectory}`;
 
 const buildResult = await Bun.build({
@@ -64,9 +65,9 @@ for (const outputPath of expectedOutputs) {
   }
 }
 
-// Atomically swap the staging directory into place without ever removing dist/
-// while it is live (see packages/diff/scripts/lib/atomic-swap-dist.ts for the
-// full concurrent-build rationale).
+// Promote the validated staging tree into `dist/` (handles a concurrent
+// same-package build winning the race; never exposes a partial tree). See
+// `./lib/atomic-swap-dist.ts` for the exact guarantees and limits.
 atomicSwapDist(stagingDirectory, distributionDirectory);
 
 process.stdout.write('Build complete.\n');

--- a/packages/editor/scripts/build.ts
+++ b/packages/editor/scripts/build.ts
@@ -1,5 +1,6 @@
 import { $ } from 'bun';
 
+import { atomicSwapDist } from './lib/atomic-swap-dist.ts';
 import {
   getBuildEntrypoints,
   getExpectedBuildOutputs,
@@ -8,14 +9,26 @@ import {
 
 const packageRoot = process.cwd();
 const distributionDirectory = `${packageRoot}/dist`;
+// Per-PID staging directory so concurrent same-package builds never collide on
+// a shared `dist.tmp` (each writer owns its own `dist.tmp-<pid>`).
+const stagingName = `dist.tmp-${process.pid}`;
+const stagingDirectory = `${packageRoot}/${stagingName}`;
 const packageExports = await readPackageExports();
 const entrypoints = getBuildEntrypoints(packageRoot, packageExports);
 
-await $`rm -rf dist`;
+// Build to a staging directory first so a concurrent reader of `dist/` never
+// sees a partially-written tree. The `rm -rf dist` → write-to-dist pattern
+// opens a window where another process (e.g. a sibling package's test script
+// doing `bun run --filter=@cinder/editor build`) wipes `dist` while the first
+// process's bundler is still writing into it. Building to `dist.tmp-<pid>` then
+// atomically renaming over `dist` closes that window: on POSIX, `rename(2)` is
+// atomic — a concurrent reader either sees the old tree or the new tree, never
+// a partial write. This is the root fix for issue #364.
+await $`rm -rf ${stagingDirectory}`;
 
 const buildResult = await Bun.build({
   entrypoints,
-  outdir: distributionDirectory,
+  outdir: stagingDirectory,
   root: `${packageRoot}/src`,
   target: 'browser',
   format: 'esm',
@@ -31,9 +44,18 @@ if (!buildResult.success) {
   process.exit(1);
 }
 
-await $`tsc -p tsconfig.build.json`;
+// `tsc` is configured to emit into `./dist` via tsconfig.build.json, but we
+// override `--outDir` on the command line so it emits into the staging
+// directory alongside the Bun.build output. The CLI flag takes precedence over
+// the tsconfig value.
+await $`tsc -p tsconfig.build.json --outDir ./${stagingName}`;
 
-const expectedOutputs = getExpectedBuildOutputs(packageRoot, packageExports);
+// `getExpectedBuildOutputs` returns absolute paths rooted at the package root,
+// pointing into `dist/`. Substitute `dist` with the staging dir for the staging
+// validation — we must verify the staging tree before promoting it.
+const expectedOutputs = getExpectedBuildOutputs(packageRoot, packageExports).map((path) =>
+  path.replace(`${packageRoot}/dist/`, `${stagingDirectory}/`),
+);
 
 for (const outputPath of expectedOutputs) {
   if (!(await Bun.file(outputPath).exists())) {
@@ -41,5 +63,10 @@ for (const outputPath of expectedOutputs) {
     process.exit(1);
   }
 }
+
+// Atomically swap the staging directory into place without ever removing dist/
+// while it is live (see packages/diff/scripts/lib/atomic-swap-dist.ts for the
+// full concurrent-build rationale).
+atomicSwapDist(stagingDirectory, distributionDirectory);
 
 process.stdout.write('Build complete.\n');

--- a/packages/editor/scripts/lib/atomic-swap-dist.ts
+++ b/packages/editor/scripts/lib/atomic-swap-dist.ts
@@ -1,71 +1,163 @@
 // CANONICAL SOURCE for `atomicSwapDist`. The four upstream packages
 // (diff, markdown, editor, commentary) each carry a byte-identical copy at
 // `packages/<pkg>/scripts/lib/atomic-swap-dist.ts` because a cross-package
-// import would break their `rootDir: "."` typecheck constraint. Keep all copies
-// in sync — if you change this, change theirs too.
+// import would put a source file outside that package's `rootDir: "."` and
+// break its typecheck. A `paths` mapping does not lift that restriction — only
+// a built/referenced project would, which is heavier than the duplication.
+// Keep all copies in sync: `atomic-swap-dist.duplication.test.ts` asserts they
+// are byte-for-byte identical, so drift fails the suite.
 import { renameSync, rmSync } from 'node:fs';
 
-/**
- * Atomically install `tempDirectory` as `distributionDirectory`, handling
- * concurrent same-package builds safely.
- *
- * Strategy:
- *   1. Try rename(temp, dist). On first build (no dist) or if dist is absent,
- *      this succeeds atomically and we're done.
- *   2. If dist already exists (ENOTEMPTY from rename(2)), vacate it:
- *      rename(dist, old). If dist vanished between step 1 and now (a concurrent
- *      winner moved it away), the ENOENT here means the winner already installed
- *      a complete dist — our result is redundant; clean up temp and succeed.
- *   3. With dist now vacated, try rename(temp, dist). If this fails, a
- *      concurrent winner raced us and installed dist after we moved old away.
- *      Either way, dist is complete; clean up temp (and old, which we own) and
- *      succeed.
- *   4. We own the installed dist. Delete old.
- *
- * The exit handler registered here removes temp and old so no litter survives
- * a crash at any point in the swap sequence.
- *
- * @param tempDirectory - Completed build output (e.g. `dist.tmp-<pid>`).
- * @param distributionDirectory - Final destination (e.g. `dist/`).
- */
-export function atomicSwapDist(tempDirectory: string, distributionDirectory: string): void {
-  const oldDirectory = `${distributionDirectory}.old-${process.pid}`;
+/** The slice of `node:fs` this helper uses. Defaulted to the real functions in
+ * `atomicSwapDist`; tests pass a fake to drive the concurrent-race branches that
+ * serial real-filesystem calls cannot reach. This is the helper's only test
+ * seam — deliberately just the two operations it performs, not a config bag. */
+type FileSystemOperations = {
+  renameSync: typeof renameSync;
+  rmSync: typeof rmSync;
+};
 
-  // Ensure temp and old are cleaned up even if the process exits mid-swap.
+/** Narrow an unknown caught value to Node's errno-bearing error shape. */
+function isErrnoException(error: unknown): error is NodeJS.ErrnoException {
+  return error instanceof Error && 'code' in error;
+}
+
+/** rename(2) reports "destination already exists and is a non-empty directory"
+ * as ENOTEMPTY on Linux and EEXIST on macOS. Both mean the same benign thing
+ * here: someone else owns `dist`. */
+const DESTINATION_EXISTS_CODES = new Set(['ENOTEMPTY', 'EEXIST']);
+
+/**
+ * Promote a completed staging build into `distributionDirectory`, surviving a
+ * concurrent same-package build (`bun run --filter=<pkg> build` invoked by
+ * turbo, CI, or by hand at the same time as another).
+ *
+ * IMPORTANT — what this does and does NOT guarantee:
+ *   - It is NOT what closes issue #364. The husky test gate serializes its test
+ *     phase (`phaseMaxConcurrency('test') === 1`), so concurrent same-package
+ *     builds do not occur inside the hook; that serialization is the #364
+ *     closure. This helper is defense-in-depth for the out-of-hook paths.
+ *   - It DOES prevent a reader from observing a half-written tree: a build
+ *     writes into a private staging dir and is only promoted once complete, so
+ *     `dist` is replaced whole, never written into in place.
+ *   - It does NOT guarantee `dist` is continuously present. In the rebuild
+ *     path there is a sub-millisecond window between vacating the live tree and
+ *     installing the new one where `dist` does not exist, so a concurrent
+ *     reader can still observe a transient ENOENT. Eliminating that would need
+ *     a symlink-pointer scheme, which consumers that resolve `dist/...` paths
+ *     directly cannot tolerate — out of scope here.
+ *
+ * Preconditions:
+ *   - `tempDirectory` and `distributionDirectory` MUST be on the same
+ *     filesystem; `rename(2)` fails with EXDEV across devices. Callers build
+ *     the staging dir as a sibling of `dist` under the package root, so this
+ *     holds. EXDEV is therefore re-thrown, not swallowed.
+ *   - `tempDirectory` should be uniquely named per invocation (see
+ *     `stagingDirectoryName`) so two concurrent builds never collide on it.
+ *
+ * Strategy (only the EXPECTED race errors are swallowed; everything else
+ * re-throws so a genuine failure can never masquerade as a successful build):
+ *   1. rename(temp, dist). Succeeds on first build (no dist). If dist exists
+ *      (ENOTEMPTY / EEXIST), fall through; any other error re-throws.
+ *   2. Vacate: rename(dist, old). If dist vanished (ENOENT) a concurrent build
+ *      already installed a complete dist — ours is redundant, return; any other
+ *      error re-throws.
+ *   3. Install: rename(temp, dist). If dist now exists (ENOTEMPTY / EEXIST) a
+ *      concurrent build raced in after we vacated — its dist is complete; drop
+ *      our `old` and return; any other error re-throws.
+ *   4. We own the installed dist. Remove the vacated `old` tree.
+ *
+ * The success and concurrent-loser paths remove `temp` / `old` synchronously
+ * before returning. A `process.on('exit')` handler is also registered as a
+ * backstop for the case where the process exits between two rename steps — but
+ * it runs on normal exit and `process.exit()` only, NOT on SIGKILL/SIGINT, so a
+ * hard kill mid-swap can still leave a `dist.tmp-*` / `dist.old-*` sibling
+ * behind. Those names are gitignored, so such litter never reaches version
+ * control.
+ *
+ * @param tempDirectory - Completed, validated build output to promote.
+ * @param distributionDirectory - Final destination (e.g. `dist/`).
+ * @param fileSystem - The `renameSync` / `rmSync` pair to use. Defaults to the
+ *   real `node:fs`; tests inject a fake to exercise the concurrent-race branches
+ *   that serial real-filesystem calls cannot reach. Not a production knob.
+ */
+export function atomicSwapDist(
+  tempDirectory: string,
+  distributionDirectory: string,
+  fileSystem: FileSystemOperations = { renameSync, rmSync },
+): void {
+  // Unique per invocation so two concurrent builds (different pid OR same pid
+  // reused across non-overlapping runs) never collide on, or clean up, each
+  // other's vacated tree.
+  const oldDirectory = `${distributionDirectory}.old-${stagingSuffix()}`;
+
+  // Best-effort cleanup of the dirs THIS call owns, on normal exit only.
   process.on('exit', () => {
-    rmSync(tempDirectory, { recursive: true, force: true });
-    rmSync(oldDirectory, { recursive: true, force: true });
+    fileSystem.rmSync(tempDirectory, { recursive: true, force: true });
+    fileSystem.rmSync(oldDirectory, { recursive: true, force: true });
   });
 
-  // Step 1: optimistic path — first build or dist is absent.
+  // Step 1: optimistic — first build, or dist is absent.
   try {
-    renameSync(tempDirectory, distributionDirectory);
+    fileSystem.renameSync(tempDirectory, distributionDirectory);
     return;
-  } catch {
-    // dist already exists (ENOTEMPTY) or another transient error. Fall through
-    // to the vacate-and-reinstall path.
+  } catch (error) {
+    if (!isErrnoException(error) || !DESTINATION_EXISTS_CODES.has(error.code ?? '')) {
+      throw error;
+    }
+    // dist exists — fall through to the vacate-and-install path.
   }
 
-  // Step 2: vacate dist → old so we can install our temp.
+  // Step 2: vacate dist → old so we can install our staging tree.
   try {
-    renameSync(distributionDirectory, oldDirectory);
-  } catch {
-    // dist disappeared between step 1 and now: a concurrent winner already
-    // swapped in a complete dist. Our build output is redundant.
-    // temp is cleaned by the exit handler. Succeed.
-    return;
+    fileSystem.renameSync(distributionDirectory, oldDirectory);
+  } catch (error) {
+    if (isErrnoException(error) && error.code === 'ENOENT') {
+      // dist vanished between step 1 and now: a concurrent build already
+      // installed a complete dist. Ours is redundant — clean up our staging
+      // tree now (don't lean on the exit handler, which won't fire on SIGKILL).
+      fileSystem.rmSync(tempDirectory, { recursive: true, force: true });
+      return;
+    }
+    throw error;
   }
 
-  // Step 3: install our build as the new dist.
+  // Step 3: install our staging tree as the new dist.
   try {
-    renameSync(tempDirectory, distributionDirectory);
-  } catch {
-    // A concurrent winner installed dist after we vacated it. dist is complete.
-    // We own old — clean it up. temp is cleaned by the exit handler. Succeed.
-    rmSync(oldDirectory, { recursive: true, force: true });
-    return;
+    fileSystem.renameSync(tempDirectory, distributionDirectory);
+  } catch (error) {
+    if (isErrnoException(error) && DESTINATION_EXISTS_CODES.has(error.code ?? '')) {
+      // A concurrent build installed dist after we vacated it. Its dist is
+      // complete; drop both the tree we vacated and our now-redundant staging
+      // tree immediately rather than waiting for the exit handler.
+      fileSystem.rmSync(oldDirectory, { recursive: true, force: true });
+      fileSystem.rmSync(tempDirectory, { recursive: true, force: true });
+      return;
+    }
+    throw error;
   }
 
-  // Step 4: we successfully installed dist. Remove the vacated old tree.
-  rmSync(oldDirectory, { recursive: true, force: true });
+  // Step 4: we installed dist. Remove the vacated old tree.
+  fileSystem.rmSync(oldDirectory, { recursive: true, force: true });
+}
+
+/**
+ * A collision-resistant suffix for staging / old directory names: process id,
+ * high-resolution-ish wall clock, and a random tail. Unique enough that two
+ * concurrent builds — even same-pid across non-overlapping runs — never share a
+ * staging or vacated-tree name. Build scripts may use `Date.now()` /
+ * `Math.random()` freely (this is not a deterministic-replay context).
+ */
+function stagingSuffix(): string {
+  return `${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
+}
+
+/**
+ * Build the per-invocation staging directory name a caller should emit into
+ * before calling `atomicSwapDist`. Returned as a bare name (no leading path) so
+ * it can be passed straight to `tsc --outDir ./<name>` and joined onto the
+ * package root for `Bun.build`'s `outdir`.
+ */
+export function stagingDirectoryName(): string {
+  return `dist.tmp-${stagingSuffix()}`;
 }

--- a/packages/editor/scripts/lib/atomic-swap-dist.ts
+++ b/packages/editor/scripts/lib/atomic-swap-dist.ts
@@ -1,11 +1,12 @@
-// CANONICAL SOURCE for `atomicSwapDist`. The four upstream packages
-// (diff, markdown, editor, commentary) each carry a byte-identical copy at
-// `packages/<pkg>/scripts/lib/atomic-swap-dist.ts` because a cross-package
-// import would put a source file outside that package's `rootDir: "."` and
-// break its typecheck. A `paths` mapping does not lift that restriction — only
-// a built/referenced project would, which is heavier than the duplication.
-// Keep all copies in sync: `atomic-swap-dist.duplication.test.ts` asserts they
-// are byte-for-byte identical, so drift fails the suite.
+// CANONICAL SOURCE for `atomicSwapDist`. This file lives under `components`;
+// the four upstream packages (diff, markdown, editor, commentary) each carry a
+// byte-identical copy at `packages/<pkg>/scripts/lib/atomic-swap-dist.ts` — five
+// copies total. The duplication exists because a cross-package import would put
+// a source file outside that package's `rootDir: "."` and break its typecheck.
+// A `paths` mapping does not lift that restriction — only a built/referenced
+// project would, which is heavier than the duplication. Keep all five copies in
+// sync: `atomic-swap-dist.duplication.test.ts` asserts they are byte-for-byte
+// identical, so drift fails the suite.
 import { renameSync, rmSync } from 'node:fs';
 
 /** The slice of `node:fs` this helper uses. Defaulted to the real functions in
@@ -64,16 +65,21 @@ const DESTINATION_EXISTS_CODES = new Set(['ENOTEMPTY', 'EEXIST']);
  *      error re-throws.
  *   3. Install: rename(temp, dist). If dist now exists (ENOTEMPTY / EEXIST) a
  *      concurrent build raced in after we vacated — its dist is complete; drop
- *      our `old` and return; any other error re-throws.
+ *      our `old` and return. On any OTHER error we best-effort roll back —
+ *      rename(old, dist) to restore the last good build — then re-throw the
+ *      original error. (Without the rollback, a failed install would leave the
+ *      package with no `dist` at all, since the only copy is in `old`.)
  *   4. We own the installed dist. Remove the vacated `old` tree.
  *
  * The success and concurrent-loser paths remove `temp` / `old` synchronously
  * before returning. A `process.on('exit')` handler is also registered as a
- * backstop for the case where the process exits between two rename steps — but
- * it runs on normal exit and `process.exit()` only, NOT on SIGKILL/SIGINT, so a
- * hard kill mid-swap can still leave a `dist.tmp-*` / `dist.old-*` sibling
- * behind. Those names are gitignored, so such litter never reaches version
- * control.
+ * backstop that removes the staging tree (`temp`) if the process exits between
+ * two rename steps — but it runs on normal exit and `process.exit()` only, NOT
+ * on SIGKILL/SIGINT, so a hard kill mid-swap can still leave a `dist.tmp-*` /
+ * `dist.old-*` sibling behind. Those names are gitignored, so such litter never
+ * reaches version control. The handler deliberately never deletes `old`:
+ * between step 2 and step 4 it is the last good build, and the step-3 rollback
+ * relies on it surviving.
  *
  * @param tempDirectory - Completed, validated build output to promote.
  * @param distributionDirectory - Final destination (e.g. `dist/`).
@@ -91,10 +97,16 @@ export function atomicSwapDist(
   // other's vacated tree.
   const oldDirectory = `${distributionDirectory}.old-${stagingSuffix()}`;
 
-  // Best-effort cleanup of the dirs THIS call owns, on normal exit only.
+  // Best-effort cleanup of the staging tree THIS call owns, on normal exit only.
+  // The handler deliberately does NOT touch `oldDirectory`: after step 2 vacates
+  // the live tree there, `oldDirectory` is the ONLY copy of the last good build
+  // until step 4 (success) or the step-3 loser path removes it synchronously. If
+  // step 3 fails unexpectedly we restore from it (see below); deleting it here
+  // would destroy the last good build on that failure path. Every safe path
+  // already removes `oldDirectory` synchronously, so the handler has no reason
+  // to — leaving a `dist.old-*` sibling behind on a hard exit is the safe choice.
   process.on('exit', () => {
     fileSystem.rmSync(tempDirectory, { recursive: true, force: true });
-    fileSystem.rmSync(oldDirectory, { recursive: true, force: true });
   });
 
   // Step 1: optimistic — first build, or dist is absent.
@@ -133,6 +145,20 @@ export function atomicSwapDist(
       fileSystem.rmSync(oldDirectory, { recursive: true, force: true });
       fileSystem.rmSync(tempDirectory, { recursive: true, force: true });
       return;
+    }
+    // Unexpected install failure (ENOSPC / EIO / EPERM / …) after we already
+    // vacated the live tree to `oldDirectory`. Best-effort rollback: move the
+    // last good build back into place so the package is left buildable, then
+    // re-throw the ORIGINAL error so the failure still surfaces. The rollback is
+    // intentionally swallowed — if it fails (e.g. a concurrent build installed a
+    // complete dist in the gap, giving ENOTEMPTY/EEXIST), that build's tree is
+    // the valid one and ours is redundant; either way we must not mask the
+    // original error or delete `oldDirectory` (it may still be the last good
+    // build).
+    try {
+      fileSystem.renameSync(oldDirectory, distributionDirectory);
+    } catch {
+      // Rollback failed; preserve `oldDirectory` and the original error.
     }
     throw error;
   }

--- a/packages/editor/scripts/lib/atomic-swap-dist.ts
+++ b/packages/editor/scripts/lib/atomic-swap-dist.ts
@@ -1,0 +1,71 @@
+// CANONICAL SOURCE for `atomicSwapDist`. The four upstream packages
+// (diff, markdown, editor, commentary) each carry a byte-identical copy at
+// `packages/<pkg>/scripts/lib/atomic-swap-dist.ts` because a cross-package
+// import would break their `rootDir: "."` typecheck constraint. Keep all copies
+// in sync — if you change this, change theirs too.
+import { renameSync, rmSync } from 'node:fs';
+
+/**
+ * Atomically install `tempDirectory` as `distributionDirectory`, handling
+ * concurrent same-package builds safely.
+ *
+ * Strategy:
+ *   1. Try rename(temp, dist). On first build (no dist) or if dist is absent,
+ *      this succeeds atomically and we're done.
+ *   2. If dist already exists (ENOTEMPTY from rename(2)), vacate it:
+ *      rename(dist, old). If dist vanished between step 1 and now (a concurrent
+ *      winner moved it away), the ENOENT here means the winner already installed
+ *      a complete dist — our result is redundant; clean up temp and succeed.
+ *   3. With dist now vacated, try rename(temp, dist). If this fails, a
+ *      concurrent winner raced us and installed dist after we moved old away.
+ *      Either way, dist is complete; clean up temp (and old, which we own) and
+ *      succeed.
+ *   4. We own the installed dist. Delete old.
+ *
+ * The exit handler registered here removes temp and old so no litter survives
+ * a crash at any point in the swap sequence.
+ *
+ * @param tempDirectory - Completed build output (e.g. `dist.tmp-<pid>`).
+ * @param distributionDirectory - Final destination (e.g. `dist/`).
+ */
+export function atomicSwapDist(tempDirectory: string, distributionDirectory: string): void {
+  const oldDirectory = `${distributionDirectory}.old-${process.pid}`;
+
+  // Ensure temp and old are cleaned up even if the process exits mid-swap.
+  process.on('exit', () => {
+    rmSync(tempDirectory, { recursive: true, force: true });
+    rmSync(oldDirectory, { recursive: true, force: true });
+  });
+
+  // Step 1: optimistic path — first build or dist is absent.
+  try {
+    renameSync(tempDirectory, distributionDirectory);
+    return;
+  } catch {
+    // dist already exists (ENOTEMPTY) or another transient error. Fall through
+    // to the vacate-and-reinstall path.
+  }
+
+  // Step 2: vacate dist → old so we can install our temp.
+  try {
+    renameSync(distributionDirectory, oldDirectory);
+  } catch {
+    // dist disappeared between step 1 and now: a concurrent winner already
+    // swapped in a complete dist. Our build output is redundant.
+    // temp is cleaned by the exit handler. Succeed.
+    return;
+  }
+
+  // Step 3: install our build as the new dist.
+  try {
+    renameSync(tempDirectory, distributionDirectory);
+  } catch {
+    // A concurrent winner installed dist after we vacated it. dist is complete.
+    // We own old — clean it up. temp is cleaned by the exit handler. Succeed.
+    rmSync(oldDirectory, { recursive: true, force: true });
+    return;
+  }
+
+  // Step 4: we successfully installed dist. Remove the vacated old tree.
+  rmSync(oldDirectory, { recursive: true, force: true });
+}

--- a/packages/markdown/scripts/build.ts
+++ b/packages/markdown/scripts/build.ts
@@ -1,12 +1,13 @@
 import { $ } from 'bun';
 
-import { atomicSwapDist } from './lib/atomic-swap-dist.ts';
+import { atomicSwapDist, stagingDirectoryName } from './lib/atomic-swap-dist.ts';
 
 const packageRoot = process.cwd();
 const distributionDirectory = `${packageRoot}/dist`;
-// Per-PID staging directory so concurrent same-package builds never collide on
-// a shared `dist.tmp` (each writer owns its own `dist.tmp-<pid>`).
-const stagingName = `dist.tmp-${process.pid}`;
+// Unique-per-invocation staging directory (a `dist.tmp-*` sibling of `dist`, so
+// the same filesystem `atomicSwapDist`'s rename requires). Each build owns its
+// own staging dir, so two concurrent same-package builds never collide on it.
+const stagingName = stagingDirectoryName();
 const stagingDirectory = `${packageRoot}/${stagingName}`;
 const entrypoints = [
   `${packageRoot}/src/index.ts`,
@@ -22,14 +23,14 @@ const entrypoints = [
   `${packageRoot}/src/utilities/sort-keys.ts`,
 ];
 
-// Build to a staging directory first so a concurrent reader of `dist/` never
-// sees a partially-written tree. The `rm -rf dist` → write-to-dist pattern
-// opens a window where another process (e.g. a sibling package's test script
-// doing `bun run --filter=@cinder/markdown build`) wipes `dist` while the first
-// process's bundler is still writing into it. Building to `dist.tmp-<pid>` then
-// atomically renaming over `dist` closes that window: on POSIX, `rename(2)` is
-// atomic — a concurrent reader either sees the old tree or the new tree, never
-// a partial write. This is the root fix for issue #364.
+// Build into the staging directory, then promote it via `atomicSwapDist`. A
+// build never writes into `dist/` in place, so a concurrent reader (a sibling
+// package's test running `bun run --filter=@cinder/markdown build`, or a
+// typecheck holding dist declarations) can never observe a half-written tree.
+// NOTE: this is defense-in-depth, not the #364 fix — the husky test gate
+// serializes its test phase, and THAT is what stops concurrent same-package
+// rebuilds inside the hook. See `./lib/atomic-swap-dist.ts` for the exact
+// guarantees (and the residual transient-ENOENT window this does not close).
 await $`rm -rf ${stagingDirectory}`;
 
 const buildResult = await Bun.build({
@@ -88,9 +89,9 @@ for (const outputPath of expectedOutputs) {
   }
 }
 
-// Atomically swap the staging directory into place without ever removing dist/
-// while it is live (see packages/diff/scripts/lib/atomic-swap-dist.ts for the
-// full concurrent-build rationale).
+// Promote the validated staging tree into `dist/` (handles a concurrent
+// same-package build winning the race; never exposes a partial tree). See
+// `./lib/atomic-swap-dist.ts` for the exact guarantees and limits.
 atomicSwapDist(stagingDirectory, distributionDirectory);
 
 process.stdout.write('Build complete.\n');

--- a/packages/markdown/scripts/build.ts
+++ b/packages/markdown/scripts/build.ts
@@ -1,7 +1,13 @@
 import { $ } from 'bun';
 
+import { atomicSwapDist } from './lib/atomic-swap-dist.ts';
+
 const packageRoot = process.cwd();
 const distributionDirectory = `${packageRoot}/dist`;
+// Per-PID staging directory so concurrent same-package builds never collide on
+// a shared `dist.tmp` (each writer owns its own `dist.tmp-<pid>`).
+const stagingName = `dist.tmp-${process.pid}`;
+const stagingDirectory = `${packageRoot}/${stagingName}`;
 const entrypoints = [
   `${packageRoot}/src/index.ts`,
   `${packageRoot}/src/pipeline/index.ts`,
@@ -16,11 +22,19 @@ const entrypoints = [
   `${packageRoot}/src/utilities/sort-keys.ts`,
 ];
 
-await $`rm -rf dist`;
+// Build to a staging directory first so a concurrent reader of `dist/` never
+// sees a partially-written tree. The `rm -rf dist` → write-to-dist pattern
+// opens a window where another process (e.g. a sibling package's test script
+// doing `bun run --filter=@cinder/markdown build`) wipes `dist` while the first
+// process's bundler is still writing into it. Building to `dist.tmp-<pid>` then
+// atomically renaming over `dist` closes that window: on POSIX, `rename(2)` is
+// atomic — a concurrent reader either sees the old tree or the new tree, never
+// a partial write. This is the root fix for issue #364.
+await $`rm -rf ${stagingDirectory}`;
 
 const buildResult = await Bun.build({
   entrypoints,
-  outdir: distributionDirectory,
+  outdir: stagingDirectory,
   root: `${packageRoot}/src`,
   target: 'browser',
   format: 'esm',
@@ -36,31 +50,35 @@ if (!buildResult.success) {
   process.exit(1);
 }
 
-await $`tsc -p tsconfig.build.json`;
+// `tsc` is configured to emit into `./dist` via tsconfig.build.json, but we
+// override `--outDir` on the command line so it emits into the staging
+// directory alongside the Bun.build output. The CLI flag takes precedence over
+// the tsconfig value.
+await $`tsc -p tsconfig.build.json --outDir ./${stagingName}`;
 
 const expectedOutputs = [
-  `${distributionDirectory}/index.js`,
-  `${distributionDirectory}/index.d.ts`,
-  `${distributionDirectory}/pipeline/index.js`,
-  `${distributionDirectory}/pipeline/index.d.ts`,
-  `${distributionDirectory}/diff/index.js`,
-  `${distributionDirectory}/diff/index.d.ts`,
-  `${distributionDirectory}/diff/line-diff.js`,
-  `${distributionDirectory}/diff/line-diff.d.ts`,
-  `${distributionDirectory}/diff/types.js`,
-  `${distributionDirectory}/diff/types.d.ts`,
-  `${distributionDirectory}/rendering/index.js`,
-  `${distributionDirectory}/rendering/index.d.ts`,
-  `${distributionDirectory}/rendering/types.js`,
-  `${distributionDirectory}/rendering/types.d.ts`,
-  `${distributionDirectory}/rendering/highlighter.js`,
-  `${distributionDirectory}/rendering/highlighter.d.ts`,
-  `${distributionDirectory}/rendering/mermaid-cache.js`,
-  `${distributionDirectory}/rendering/mermaid-cache.d.ts`,
-  `${distributionDirectory}/utilities/safe-url.js`,
-  `${distributionDirectory}/utilities/safe-url.d.ts`,
-  `${distributionDirectory}/utilities/sort-keys.js`,
-  `${distributionDirectory}/utilities/sort-keys.d.ts`,
+  `${stagingDirectory}/index.js`,
+  `${stagingDirectory}/index.d.ts`,
+  `${stagingDirectory}/pipeline/index.js`,
+  `${stagingDirectory}/pipeline/index.d.ts`,
+  `${stagingDirectory}/diff/index.js`,
+  `${stagingDirectory}/diff/index.d.ts`,
+  `${stagingDirectory}/diff/line-diff.js`,
+  `${stagingDirectory}/diff/line-diff.d.ts`,
+  `${stagingDirectory}/diff/types.js`,
+  `${stagingDirectory}/diff/types.d.ts`,
+  `${stagingDirectory}/rendering/index.js`,
+  `${stagingDirectory}/rendering/index.d.ts`,
+  `${stagingDirectory}/rendering/types.js`,
+  `${stagingDirectory}/rendering/types.d.ts`,
+  `${stagingDirectory}/rendering/highlighter.js`,
+  `${stagingDirectory}/rendering/highlighter.d.ts`,
+  `${stagingDirectory}/rendering/mermaid-cache.js`,
+  `${stagingDirectory}/rendering/mermaid-cache.d.ts`,
+  `${stagingDirectory}/utilities/safe-url.js`,
+  `${stagingDirectory}/utilities/safe-url.d.ts`,
+  `${stagingDirectory}/utilities/sort-keys.js`,
+  `${stagingDirectory}/utilities/sort-keys.d.ts`,
 ];
 
 for (const outputPath of expectedOutputs) {
@@ -69,5 +87,10 @@ for (const outputPath of expectedOutputs) {
     process.exit(1);
   }
 }
+
+// Atomically swap the staging directory into place without ever removing dist/
+// while it is live (see packages/diff/scripts/lib/atomic-swap-dist.ts for the
+// full concurrent-build rationale).
+atomicSwapDist(stagingDirectory, distributionDirectory);
 
 process.stdout.write('Build complete.\n');

--- a/packages/markdown/scripts/lib/atomic-swap-dist.ts
+++ b/packages/markdown/scripts/lib/atomic-swap-dist.ts
@@ -1,71 +1,163 @@
 // CANONICAL SOURCE for `atomicSwapDist`. The four upstream packages
 // (diff, markdown, editor, commentary) each carry a byte-identical copy at
 // `packages/<pkg>/scripts/lib/atomic-swap-dist.ts` because a cross-package
-// import would break their `rootDir: "."` typecheck constraint. Keep all copies
-// in sync — if you change this, change theirs too.
+// import would put a source file outside that package's `rootDir: "."` and
+// break its typecheck. A `paths` mapping does not lift that restriction — only
+// a built/referenced project would, which is heavier than the duplication.
+// Keep all copies in sync: `atomic-swap-dist.duplication.test.ts` asserts they
+// are byte-for-byte identical, so drift fails the suite.
 import { renameSync, rmSync } from 'node:fs';
 
-/**
- * Atomically install `tempDirectory` as `distributionDirectory`, handling
- * concurrent same-package builds safely.
- *
- * Strategy:
- *   1. Try rename(temp, dist). On first build (no dist) or if dist is absent,
- *      this succeeds atomically and we're done.
- *   2. If dist already exists (ENOTEMPTY from rename(2)), vacate it:
- *      rename(dist, old). If dist vanished between step 1 and now (a concurrent
- *      winner moved it away), the ENOENT here means the winner already installed
- *      a complete dist — our result is redundant; clean up temp and succeed.
- *   3. With dist now vacated, try rename(temp, dist). If this fails, a
- *      concurrent winner raced us and installed dist after we moved old away.
- *      Either way, dist is complete; clean up temp (and old, which we own) and
- *      succeed.
- *   4. We own the installed dist. Delete old.
- *
- * The exit handler registered here removes temp and old so no litter survives
- * a crash at any point in the swap sequence.
- *
- * @param tempDirectory - Completed build output (e.g. `dist.tmp-<pid>`).
- * @param distributionDirectory - Final destination (e.g. `dist/`).
- */
-export function atomicSwapDist(tempDirectory: string, distributionDirectory: string): void {
-  const oldDirectory = `${distributionDirectory}.old-${process.pid}`;
+/** The slice of `node:fs` this helper uses. Defaulted to the real functions in
+ * `atomicSwapDist`; tests pass a fake to drive the concurrent-race branches that
+ * serial real-filesystem calls cannot reach. This is the helper's only test
+ * seam — deliberately just the two operations it performs, not a config bag. */
+type FileSystemOperations = {
+  renameSync: typeof renameSync;
+  rmSync: typeof rmSync;
+};
 
-  // Ensure temp and old are cleaned up even if the process exits mid-swap.
+/** Narrow an unknown caught value to Node's errno-bearing error shape. */
+function isErrnoException(error: unknown): error is NodeJS.ErrnoException {
+  return error instanceof Error && 'code' in error;
+}
+
+/** rename(2) reports "destination already exists and is a non-empty directory"
+ * as ENOTEMPTY on Linux and EEXIST on macOS. Both mean the same benign thing
+ * here: someone else owns `dist`. */
+const DESTINATION_EXISTS_CODES = new Set(['ENOTEMPTY', 'EEXIST']);
+
+/**
+ * Promote a completed staging build into `distributionDirectory`, surviving a
+ * concurrent same-package build (`bun run --filter=<pkg> build` invoked by
+ * turbo, CI, or by hand at the same time as another).
+ *
+ * IMPORTANT — what this does and does NOT guarantee:
+ *   - It is NOT what closes issue #364. The husky test gate serializes its test
+ *     phase (`phaseMaxConcurrency('test') === 1`), so concurrent same-package
+ *     builds do not occur inside the hook; that serialization is the #364
+ *     closure. This helper is defense-in-depth for the out-of-hook paths.
+ *   - It DOES prevent a reader from observing a half-written tree: a build
+ *     writes into a private staging dir and is only promoted once complete, so
+ *     `dist` is replaced whole, never written into in place.
+ *   - It does NOT guarantee `dist` is continuously present. In the rebuild
+ *     path there is a sub-millisecond window between vacating the live tree and
+ *     installing the new one where `dist` does not exist, so a concurrent
+ *     reader can still observe a transient ENOENT. Eliminating that would need
+ *     a symlink-pointer scheme, which consumers that resolve `dist/...` paths
+ *     directly cannot tolerate — out of scope here.
+ *
+ * Preconditions:
+ *   - `tempDirectory` and `distributionDirectory` MUST be on the same
+ *     filesystem; `rename(2)` fails with EXDEV across devices. Callers build
+ *     the staging dir as a sibling of `dist` under the package root, so this
+ *     holds. EXDEV is therefore re-thrown, not swallowed.
+ *   - `tempDirectory` should be uniquely named per invocation (see
+ *     `stagingDirectoryName`) so two concurrent builds never collide on it.
+ *
+ * Strategy (only the EXPECTED race errors are swallowed; everything else
+ * re-throws so a genuine failure can never masquerade as a successful build):
+ *   1. rename(temp, dist). Succeeds on first build (no dist). If dist exists
+ *      (ENOTEMPTY / EEXIST), fall through; any other error re-throws.
+ *   2. Vacate: rename(dist, old). If dist vanished (ENOENT) a concurrent build
+ *      already installed a complete dist — ours is redundant, return; any other
+ *      error re-throws.
+ *   3. Install: rename(temp, dist). If dist now exists (ENOTEMPTY / EEXIST) a
+ *      concurrent build raced in after we vacated — its dist is complete; drop
+ *      our `old` and return; any other error re-throws.
+ *   4. We own the installed dist. Remove the vacated `old` tree.
+ *
+ * The success and concurrent-loser paths remove `temp` / `old` synchronously
+ * before returning. A `process.on('exit')` handler is also registered as a
+ * backstop for the case where the process exits between two rename steps — but
+ * it runs on normal exit and `process.exit()` only, NOT on SIGKILL/SIGINT, so a
+ * hard kill mid-swap can still leave a `dist.tmp-*` / `dist.old-*` sibling
+ * behind. Those names are gitignored, so such litter never reaches version
+ * control.
+ *
+ * @param tempDirectory - Completed, validated build output to promote.
+ * @param distributionDirectory - Final destination (e.g. `dist/`).
+ * @param fileSystem - The `renameSync` / `rmSync` pair to use. Defaults to the
+ *   real `node:fs`; tests inject a fake to exercise the concurrent-race branches
+ *   that serial real-filesystem calls cannot reach. Not a production knob.
+ */
+export function atomicSwapDist(
+  tempDirectory: string,
+  distributionDirectory: string,
+  fileSystem: FileSystemOperations = { renameSync, rmSync },
+): void {
+  // Unique per invocation so two concurrent builds (different pid OR same pid
+  // reused across non-overlapping runs) never collide on, or clean up, each
+  // other's vacated tree.
+  const oldDirectory = `${distributionDirectory}.old-${stagingSuffix()}`;
+
+  // Best-effort cleanup of the dirs THIS call owns, on normal exit only.
   process.on('exit', () => {
-    rmSync(tempDirectory, { recursive: true, force: true });
-    rmSync(oldDirectory, { recursive: true, force: true });
+    fileSystem.rmSync(tempDirectory, { recursive: true, force: true });
+    fileSystem.rmSync(oldDirectory, { recursive: true, force: true });
   });
 
-  // Step 1: optimistic path — first build or dist is absent.
+  // Step 1: optimistic — first build, or dist is absent.
   try {
-    renameSync(tempDirectory, distributionDirectory);
+    fileSystem.renameSync(tempDirectory, distributionDirectory);
     return;
-  } catch {
-    // dist already exists (ENOTEMPTY) or another transient error. Fall through
-    // to the vacate-and-reinstall path.
+  } catch (error) {
+    if (!isErrnoException(error) || !DESTINATION_EXISTS_CODES.has(error.code ?? '')) {
+      throw error;
+    }
+    // dist exists — fall through to the vacate-and-install path.
   }
 
-  // Step 2: vacate dist → old so we can install our temp.
+  // Step 2: vacate dist → old so we can install our staging tree.
   try {
-    renameSync(distributionDirectory, oldDirectory);
-  } catch {
-    // dist disappeared between step 1 and now: a concurrent winner already
-    // swapped in a complete dist. Our build output is redundant.
-    // temp is cleaned by the exit handler. Succeed.
-    return;
+    fileSystem.renameSync(distributionDirectory, oldDirectory);
+  } catch (error) {
+    if (isErrnoException(error) && error.code === 'ENOENT') {
+      // dist vanished between step 1 and now: a concurrent build already
+      // installed a complete dist. Ours is redundant — clean up our staging
+      // tree now (don't lean on the exit handler, which won't fire on SIGKILL).
+      fileSystem.rmSync(tempDirectory, { recursive: true, force: true });
+      return;
+    }
+    throw error;
   }
 
-  // Step 3: install our build as the new dist.
+  // Step 3: install our staging tree as the new dist.
   try {
-    renameSync(tempDirectory, distributionDirectory);
-  } catch {
-    // A concurrent winner installed dist after we vacated it. dist is complete.
-    // We own old — clean it up. temp is cleaned by the exit handler. Succeed.
-    rmSync(oldDirectory, { recursive: true, force: true });
-    return;
+    fileSystem.renameSync(tempDirectory, distributionDirectory);
+  } catch (error) {
+    if (isErrnoException(error) && DESTINATION_EXISTS_CODES.has(error.code ?? '')) {
+      // A concurrent build installed dist after we vacated it. Its dist is
+      // complete; drop both the tree we vacated and our now-redundant staging
+      // tree immediately rather than waiting for the exit handler.
+      fileSystem.rmSync(oldDirectory, { recursive: true, force: true });
+      fileSystem.rmSync(tempDirectory, { recursive: true, force: true });
+      return;
+    }
+    throw error;
   }
 
-  // Step 4: we successfully installed dist. Remove the vacated old tree.
-  rmSync(oldDirectory, { recursive: true, force: true });
+  // Step 4: we installed dist. Remove the vacated old tree.
+  fileSystem.rmSync(oldDirectory, { recursive: true, force: true });
+}
+
+/**
+ * A collision-resistant suffix for staging / old directory names: process id,
+ * high-resolution-ish wall clock, and a random tail. Unique enough that two
+ * concurrent builds — even same-pid across non-overlapping runs — never share a
+ * staging or vacated-tree name. Build scripts may use `Date.now()` /
+ * `Math.random()` freely (this is not a deterministic-replay context).
+ */
+function stagingSuffix(): string {
+  return `${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
+}
+
+/**
+ * Build the per-invocation staging directory name a caller should emit into
+ * before calling `atomicSwapDist`. Returned as a bare name (no leading path) so
+ * it can be passed straight to `tsc --outDir ./<name>` and joined onto the
+ * package root for `Bun.build`'s `outdir`.
+ */
+export function stagingDirectoryName(): string {
+  return `dist.tmp-${stagingSuffix()}`;
 }

--- a/packages/markdown/scripts/lib/atomic-swap-dist.ts
+++ b/packages/markdown/scripts/lib/atomic-swap-dist.ts
@@ -1,11 +1,12 @@
-// CANONICAL SOURCE for `atomicSwapDist`. The four upstream packages
-// (diff, markdown, editor, commentary) each carry a byte-identical copy at
-// `packages/<pkg>/scripts/lib/atomic-swap-dist.ts` because a cross-package
-// import would put a source file outside that package's `rootDir: "."` and
-// break its typecheck. A `paths` mapping does not lift that restriction — only
-// a built/referenced project would, which is heavier than the duplication.
-// Keep all copies in sync: `atomic-swap-dist.duplication.test.ts` asserts they
-// are byte-for-byte identical, so drift fails the suite.
+// CANONICAL SOURCE for `atomicSwapDist`. This file lives under `components`;
+// the four upstream packages (diff, markdown, editor, commentary) each carry a
+// byte-identical copy at `packages/<pkg>/scripts/lib/atomic-swap-dist.ts` — five
+// copies total. The duplication exists because a cross-package import would put
+// a source file outside that package's `rootDir: "."` and break its typecheck.
+// A `paths` mapping does not lift that restriction — only a built/referenced
+// project would, which is heavier than the duplication. Keep all five copies in
+// sync: `atomic-swap-dist.duplication.test.ts` asserts they are byte-for-byte
+// identical, so drift fails the suite.
 import { renameSync, rmSync } from 'node:fs';
 
 /** The slice of `node:fs` this helper uses. Defaulted to the real functions in
@@ -64,16 +65,21 @@ const DESTINATION_EXISTS_CODES = new Set(['ENOTEMPTY', 'EEXIST']);
  *      error re-throws.
  *   3. Install: rename(temp, dist). If dist now exists (ENOTEMPTY / EEXIST) a
  *      concurrent build raced in after we vacated — its dist is complete; drop
- *      our `old` and return; any other error re-throws.
+ *      our `old` and return. On any OTHER error we best-effort roll back —
+ *      rename(old, dist) to restore the last good build — then re-throw the
+ *      original error. (Without the rollback, a failed install would leave the
+ *      package with no `dist` at all, since the only copy is in `old`.)
  *   4. We own the installed dist. Remove the vacated `old` tree.
  *
  * The success and concurrent-loser paths remove `temp` / `old` synchronously
  * before returning. A `process.on('exit')` handler is also registered as a
- * backstop for the case where the process exits between two rename steps — but
- * it runs on normal exit and `process.exit()` only, NOT on SIGKILL/SIGINT, so a
- * hard kill mid-swap can still leave a `dist.tmp-*` / `dist.old-*` sibling
- * behind. Those names are gitignored, so such litter never reaches version
- * control.
+ * backstop that removes the staging tree (`temp`) if the process exits between
+ * two rename steps — but it runs on normal exit and `process.exit()` only, NOT
+ * on SIGKILL/SIGINT, so a hard kill mid-swap can still leave a `dist.tmp-*` /
+ * `dist.old-*` sibling behind. Those names are gitignored, so such litter never
+ * reaches version control. The handler deliberately never deletes `old`:
+ * between step 2 and step 4 it is the last good build, and the step-3 rollback
+ * relies on it surviving.
  *
  * @param tempDirectory - Completed, validated build output to promote.
  * @param distributionDirectory - Final destination (e.g. `dist/`).
@@ -91,10 +97,16 @@ export function atomicSwapDist(
   // other's vacated tree.
   const oldDirectory = `${distributionDirectory}.old-${stagingSuffix()}`;
 
-  // Best-effort cleanup of the dirs THIS call owns, on normal exit only.
+  // Best-effort cleanup of the staging tree THIS call owns, on normal exit only.
+  // The handler deliberately does NOT touch `oldDirectory`: after step 2 vacates
+  // the live tree there, `oldDirectory` is the ONLY copy of the last good build
+  // until step 4 (success) or the step-3 loser path removes it synchronously. If
+  // step 3 fails unexpectedly we restore from it (see below); deleting it here
+  // would destroy the last good build on that failure path. Every safe path
+  // already removes `oldDirectory` synchronously, so the handler has no reason
+  // to — leaving a `dist.old-*` sibling behind on a hard exit is the safe choice.
   process.on('exit', () => {
     fileSystem.rmSync(tempDirectory, { recursive: true, force: true });
-    fileSystem.rmSync(oldDirectory, { recursive: true, force: true });
   });
 
   // Step 1: optimistic — first build, or dist is absent.
@@ -133,6 +145,20 @@ export function atomicSwapDist(
       fileSystem.rmSync(oldDirectory, { recursive: true, force: true });
       fileSystem.rmSync(tempDirectory, { recursive: true, force: true });
       return;
+    }
+    // Unexpected install failure (ENOSPC / EIO / EPERM / …) after we already
+    // vacated the live tree to `oldDirectory`. Best-effort rollback: move the
+    // last good build back into place so the package is left buildable, then
+    // re-throw the ORIGINAL error so the failure still surfaces. The rollback is
+    // intentionally swallowed — if it fails (e.g. a concurrent build installed a
+    // complete dist in the gap, giving ENOTEMPTY/EEXIST), that build's tree is
+    // the valid one and ours is redundant; either way we must not mask the
+    // original error or delete `oldDirectory` (it may still be the last good
+    // build).
+    try {
+      fileSystem.renameSync(oldDirectory, distributionDirectory);
+    } catch {
+      // Rollback failed; preserve `oldDirectory` and the original error.
     }
     throw error;
   }

--- a/packages/markdown/scripts/lib/atomic-swap-dist.ts
+++ b/packages/markdown/scripts/lib/atomic-swap-dist.ts
@@ -1,0 +1,71 @@
+// CANONICAL SOURCE for `atomicSwapDist`. The four upstream packages
+// (diff, markdown, editor, commentary) each carry a byte-identical copy at
+// `packages/<pkg>/scripts/lib/atomic-swap-dist.ts` because a cross-package
+// import would break their `rootDir: "."` typecheck constraint. Keep all copies
+// in sync — if you change this, change theirs too.
+import { renameSync, rmSync } from 'node:fs';
+
+/**
+ * Atomically install `tempDirectory` as `distributionDirectory`, handling
+ * concurrent same-package builds safely.
+ *
+ * Strategy:
+ *   1. Try rename(temp, dist). On first build (no dist) or if dist is absent,
+ *      this succeeds atomically and we're done.
+ *   2. If dist already exists (ENOTEMPTY from rename(2)), vacate it:
+ *      rename(dist, old). If dist vanished between step 1 and now (a concurrent
+ *      winner moved it away), the ENOENT here means the winner already installed
+ *      a complete dist — our result is redundant; clean up temp and succeed.
+ *   3. With dist now vacated, try rename(temp, dist). If this fails, a
+ *      concurrent winner raced us and installed dist after we moved old away.
+ *      Either way, dist is complete; clean up temp (and old, which we own) and
+ *      succeed.
+ *   4. We own the installed dist. Delete old.
+ *
+ * The exit handler registered here removes temp and old so no litter survives
+ * a crash at any point in the swap sequence.
+ *
+ * @param tempDirectory - Completed build output (e.g. `dist.tmp-<pid>`).
+ * @param distributionDirectory - Final destination (e.g. `dist/`).
+ */
+export function atomicSwapDist(tempDirectory: string, distributionDirectory: string): void {
+  const oldDirectory = `${distributionDirectory}.old-${process.pid}`;
+
+  // Ensure temp and old are cleaned up even if the process exits mid-swap.
+  process.on('exit', () => {
+    rmSync(tempDirectory, { recursive: true, force: true });
+    rmSync(oldDirectory, { recursive: true, force: true });
+  });
+
+  // Step 1: optimistic path — first build or dist is absent.
+  try {
+    renameSync(tempDirectory, distributionDirectory);
+    return;
+  } catch {
+    // dist already exists (ENOTEMPTY) or another transient error. Fall through
+    // to the vacate-and-reinstall path.
+  }
+
+  // Step 2: vacate dist → old so we can install our temp.
+  try {
+    renameSync(distributionDirectory, oldDirectory);
+  } catch {
+    // dist disappeared between step 1 and now: a concurrent winner already
+    // swapped in a complete dist. Our build output is redundant.
+    // temp is cleaned by the exit handler. Succeed.
+    return;
+  }
+
+  // Step 3: install our build as the new dist.
+  try {
+    renameSync(tempDirectory, distributionDirectory);
+  } catch {
+    // A concurrent winner installed dist after we vacated it. dist is complete.
+    // We own old — clean it up. temp is cleaned by the exit handler. Succeed.
+    rmSync(oldDirectory, { recursive: true, force: true });
+    return;
+  }
+
+  // Step 4: we successfully installed dist. Remove the vacated old tree.
+  rmSync(oldDirectory, { recursive: true, force: true });
+}


### PR DESCRIPTION
Closes #364.

## The bug

The husky pre-push (and pre-commit) test gate runs sibling package `test` scripts in parallel. Several of those scripts (`commentary`, `editor`, `playground`) rebuild upstream packages inline via `bun run --filter='@cinder/diff' build` (plus `markdown`/`editor`/`commentary`). The old build scripts did `rm -rf dist` and then wrote into `dist/` in place, so a consumer reading `dist/...` while a sibling was mid-rebuild could observe a **partial or missing** tree — surfacing as the non-deterministic `"X is not declared in this file"` failures in #364.

## The fix (two layered defenses)

**1. Serialize the test-gate phase — this is the actual #364 fix.** A `phaseMaxConcurrency` seam (`412440ca`) makes the test phase run with `maxConcurrency === 1`. With the test scripts serialized, no two of them rebuild a shared `dist/` concurrently inside the hook, so the race that produced #364 cannot occur in the gate.

**2. Per-PID staging + atomic swap — defense-in-depth for out-of-hook builds.** `atomicSwapDist` (`5574a85d`, refined in round 1) builds each upstream package into a per-PID staging directory (`dist.tmp-<pid>-<time>-<rand>`) and atomically `rename`s it into place, instead of mutating `dist/` in situ. This protects the **turbo / CI / manual** build paths that the husky serialization does **not** govern — e.g. a developer's `bun run build` racing CI's build of the same package. It is explicitly **not** a replacement for the serialization: the rebuild path still has a documented sub-millisecond transient-ENOENT window that atomic swap does not close. The two defenses cover different execution paths; neither makes the other redundant.

## Scope audit (every package build script accounted for)

A repo-wide audit confirms the change is scoped to exactly the race victims:

- **`diff`, `markdown`, `editor`, `commentary`** — race victims. Their `dist/` is rebuilt by sibling test scripts via inline `bun run --filter=… build`. These four get the staging-dir + atomic-swap treatment.
- **`components` (`@lostgradient/cinder`)** — **not** a victim. No sibling test script rebuilds it during the gate, so its `build.ts` `rm -rf dist` is intentionally left unchanged. Adding staging/swap here would be unnecessary churn.
- **`playground`, `testing`** — no `dist` build to race.

## Round-2 addition: prove the runner *honors* the cap

The `phaseMaxConcurrency` policy tests proved the test phase *asks* for concurrency 1, but nothing proved the runner *honors* it — a future edit hardcoding `4` into a `runJobs(…)` call would leave every existing test green. To close that policy/mechanism gap:

- Extracted the bounded async pool both hooks' `runJobs` share into `runWithConcurrencyPool<Item, Result>(items, maxConcurrency, worker)` in `utilities.ts`, placed next to `phaseMaxConcurrency` as its policy/mechanism pair. The non-finite-cap floor (`Number.isFinite ? Math.max(1, floor) : 1` — NaN false-green protection) now lives in one place.
- `pre-commit.ts` and `pre-push.ts` both delegate to it. Pre-push keeps its per-job spawn-failure catch and `BatchOutcome` digest shaping; the early-failure/abort path and return type are unchanged — this is the pool primitive only, not a merge of the two runners.
- Added a 6-test `runWithConcurrencyPool` block that instruments the worker to record max overlap: `maxConcurrency === 1` → strictly 1 (the #364 guarantee), `> 1` → overlaps up to the cap, never more workers than items, empty-input no-op, NaN floors to 1, and input-order preservation when later items resolve first.

## On the duplicated helper

`atomic-swap-dist.ts` is duplicated byte-for-byte across the five package `scripts/lib/` directories rather than shared from a repo-root module. This is deliberate: each package's `tsconfig.json` sets `"rootDir": "."`, so a `scripts/build.ts` importing a repo-root shared module puts a source file above `rootDir` → `TS6059` (verified empirically). Lifting the helper to a shared module would require per-package `rootDir`/project-reference changes across **all five** tsconfigs to avoid touching five source files — strictly more moving parts. Drift is mechanically guarded by `atomic-swap-dist.duplication.test.ts`, a byte-equality check across all five copies (verified to catch drift via a negative control).

## Testing

- `utilities.test.ts` (policy + new `runWithConcurrencyPool` mechanism): 106 pass / 0 fail.
- `atomic-swap-dist` suites (real-FS happy/unexpected-error, injected-fs deterministic step-2/step-3/re-throw, concurrency regression with negative+positive controls, duplication guard): 45 pass / 0 fail.
- Full components pre-commit suite green; pre-push validation passed 7/7 packages.

## Review

Opened after a committee review (Codex `xhigh` primary + per-persona testing/simplicity/typescript/junior/dx fallbacks at `medium`). Round-1 must-fixes addressed (narrowed errno handling, unique PID+time+random suffixes, corrected serialization-vs-swap comments, injectable-fs test seam, concurrency regression + duplication guards). Round-2 re-review reached consensus: primary Codex, testing-expert, and simplicity-engineer all **APPROVED**.

The two round-1 simplicity-engineer must-fixes (shared module; pick one defense) were adjudicated and rejected on the merits — empirical `TS6059` proof for the duplication, and a cross-model design adjudication for keeping both defenses (they cover the hook path vs. the out-of-hook path respectively). Both were upheld by simplicity-engineer's round-2 re-review.

/cc @copilot — review requested.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches developer workflow (pre-commit/pre-push timing) and all four upstream package build scripts; incorrect concurrency or swap logic could mask real failures or leave packages without `dist`, though extensive regression tests mitigate this.
> 
> **Overview**
> Fixes **#364** by stopping parallel husky **test** jobs from racing inline `bun run --filter=<dep> build` steps that used to wipe and rewrite shared upstream `dist/` trees, which caused flaky `"<name>" is not declared in this file"` failures.
> 
> **Hook behavior:** `phaseMaxConcurrency` centralizes per-phase limits (`test` → **1**; lint/typecheck stay parallel). Pre-commit and pre-push split typecheck vs test into two phases, skip tests when typecheck fails, and both route jobs through shared `runWithConcurrencyPool` so the cap is actually enforced (not just declared). Regression tests cover policy and pool overlap.
> 
> **Build output:** `diff`, `markdown`, `editor`, and `commentary` no longer `rm -rf dist` and write in place—they emit into unique `dist.tmp-*` dirs, validate outputs, then promote via `atomicSwapDist` (rename-based swap with concurrent-build handling). The helper is duplicated byte-for-byte in five packages (tsconfig `rootDir` constraint); `.gitignore` adds `dist.tmp-*` / `dist.old-*`. **Defense-in-depth** for CI/manual concurrent builds; hook serialization remains the primary gate fix.
> 
> **Tests:** Publication-contract concurrency fixture, mock FS race branches, duplication guard, and expanded `utilities.test.ts`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3bf6cd93ae585d8b5f1e666ddeb39277ea9f8da2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->