### PR TITLE
fix(playground): shared doc-page template defects — status, props table, playground preview, code-block focus (#372 #388 #389 #391 #392 #374 #380 #381 #384 #401 #404)

### DIFF
--- a/packages/playground/src/component-page-documentation.test.ts
+++ b/packages/playground/src/component-page-documentation.test.ts
@@ -213,6 +213,24 @@ describe('component-page single-scroll layout', () => {
     await tick();
   });
 
+  test('renders the status dot as decorative so it does not re-announce the badge text', async () => {
+    // Regression for #388/#372: the spec-row StatusDot sits next to a Badge that
+    // already names the status visibly. The dot must be decorative
+    // (`aria-hidden`) — if it carried `aria-label={status}` it would speak the
+    // same word the Badge already announces (the audible duplication).
+    const { unmount } = render(ComponentPage);
+    await screen.findByRole('heading', { level: 1, name: 'Button' });
+
+    const dot = document.querySelector('.dx-spec__val [role="img"]');
+    expect(dot).not.toBeNull();
+    expect(dot?.getAttribute('aria-hidden')).toBe('true');
+    // The decorative dot carries no accessible name of its own.
+    expect(dot?.getAttribute('aria-label')).toBeNull();
+
+    unmount();
+    await tick();
+  });
+
   test('builds a TOC from the sections that have data', async () => {
     const { unmount } = render(ComponentPage);
     await screen.findByRole('heading', { level: 1, name: 'Button' });
@@ -308,7 +326,7 @@ describe('component-page single-scroll layout', () => {
     const required = baseFixture();
     // A required `unknown` prop with no default can't be synthesized, so the
     // generated interactive playground is suppressed. A context-note section
-    // IS rendered instead, pointing the reader to the Examples section.
+    // IS rendered instead, linking to the first `avoidWhen` alternative's page.
     // The Playground TOC link is still omitted.
     required.propsManifest.props = [
       {
@@ -326,7 +344,12 @@ describe('component-page single-scroll layout', () => {
     // The playground section renders a context note, not interactive controls.
     const section = document.getElementById('playground');
     expect(section).not.toBeNull();
-    expect(section?.querySelector('.dx-play__context-note')).not.toBeNull();
+    const note = section?.querySelector('.dx-play__context-note');
+    expect(note).not.toBeNull();
+    // The base fixture's first `avoidWhen` alternative is `segmented-control`, so
+    // the note links to that component's page rather than the in-page Examples.
+    const noteLink = note?.querySelector('a');
+    expect(noteLink?.getAttribute('href')).toBe('/c/segmented-control');
     // No control widgets are rendered.
     expect(section?.querySelector('.dx-ctl')).toBeNull();
 
@@ -335,6 +358,32 @@ describe('component-page single-scroll layout', () => {
     const nav = screen.getByRole('navigation', { name: 'On this page' });
     const labels = Array.from(nav.querySelectorAll('a')).map((a) => a.textContent?.trim() ?? '');
     expect(labels.some((label) => label.includes('Playground'))).toBe(false);
+
+    unmount();
+    await tick();
+  });
+
+  test('context note falls back to the Examples anchor when there is no avoidWhen alternative', async () => {
+    const required = baseFixture();
+    // Same unsatisfiable required prop, but with no `avoidWhen` alternative to
+    // link to — the note should fall back to the in-page Examples anchor.
+    required.component.avoidWhen = [];
+    required.propsManifest.props = [
+      {
+        name: 'value',
+        control: { kind: 'unknown', rawType: 'CustomValue' },
+        bindable: false,
+        optional: false,
+      },
+    ];
+    installDocumentationFetch(required);
+
+    const { unmount } = render(ComponentPage);
+    await screen.findByRole('heading', { level: 1, name: 'Button' });
+
+    const note = document.getElementById('playground')?.querySelector('.dx-play__context-note');
+    expect(note).not.toBeNull();
+    expect(note?.querySelector('a')?.getAttribute('href')).toBe('#examples');
 
     unmount();
     await tick();

--- a/packages/playground/src/component-page-documentation.test.ts
+++ b/packages/playground/src/component-page-documentation.test.ts
@@ -279,6 +279,53 @@ describe('component-page single-scroll layout', () => {
     await tick();
   });
 
+  test('stacked union props type has no leading separator before the first member', async () => {
+    // A 5-option select exceeds the inline `isShortUnion` budget (≤4 members),
+    // so the props-table renders the stacked union layout: one `.props-type__member`
+    // per union member, each prefixed by a `.props-type__sep` "|" — EXCEPT the
+    // first, which must stand alone. An earlier pass emitted a leading separator
+    // before every member including the first, producing `| 'alpha'` at the top
+    // of the list. The separator is now gated on the member's index.
+    const fixture = baseFixture();
+    fixture.propsManifest.props = [
+      {
+        name: 'variant',
+        control: {
+          kind: 'select',
+          options: ['alpha', 'beta', 'gamma', 'delta', 'epsilon'],
+        },
+        bindable: false,
+        optional: true,
+        defaultValue: 'alpha',
+      },
+    ];
+    installDocumentationFetch(fixture);
+
+    const { unmount } = render(ComponentPage);
+    await screen.findByRole('heading', { level: 1, name: 'Button' });
+
+    const union = document.querySelector('.props-type--union');
+    expect(union).not.toBeNull();
+
+    const members = Array.from(union?.querySelectorAll('.props-type__member') ?? []);
+    expect(members).toHaveLength(5);
+
+    // The first member carries only its value — no separator precedes it.
+    expect(members[0]?.querySelector('.props-type__sep')).toBeNull();
+    expect(members[0]?.querySelector('.props-type__value')?.textContent).toBe("'alpha'");
+
+    // Every subsequent member is prefixed by exactly one separator.
+    for (const member of members.slice(1)) {
+      expect(member.querySelectorAll('.props-type__sep')).toHaveLength(1);
+    }
+
+    // Separator count equals members − 1 (no leading pipe anywhere).
+    expect(union?.querySelectorAll('.props-type__sep')).toHaveLength(members.length - 1);
+
+    unmount();
+    await tick();
+  });
+
   test('omits the Related section when there are no related components', async () => {
     const noRelated = baseFixture();
     noRelated.component.related = [];

--- a/packages/playground/src/component-page-documentation.test.ts
+++ b/packages/playground/src/component-page-documentation.test.ts
@@ -304,10 +304,12 @@ describe('component-page single-scroll layout', () => {
     await tick();
   });
 
-  test('omits the Playground when a required non-snippet prop has no default', async () => {
+  test('shows a context note (not controls) when a required non-snippet prop has no default', async () => {
     const required = baseFixture();
     // A required `unknown` prop with no default can't be synthesized, so the
-    // generated playground is suppressed entirely (and dropped from the TOC).
+    // generated interactive playground is suppressed. A context-note section
+    // IS rendered instead, pointing the reader to the Examples section.
+    // The Playground TOC link is still omitted.
     required.propsManifest.props = [
       {
         name: 'value',
@@ -320,8 +322,16 @@ describe('component-page single-scroll layout', () => {
 
     const { unmount } = render(ComponentPage);
     await screen.findByRole('heading', { level: 1, name: 'Button' });
-    expect(document.getElementById('playground')).toBeNull();
 
+    // The playground section renders a context note, not interactive controls.
+    const section = document.getElementById('playground');
+    expect(section).not.toBeNull();
+    expect(section?.querySelector('.dx-play__context-note')).not.toBeNull();
+    // No control widgets are rendered.
+    expect(section?.querySelector('.dx-ctl')).toBeNull();
+
+    // The TOC still does NOT include a Playground link — the context-note
+    // section is shown outside the TOC-driven flow.
     const nav = screen.getByRole('navigation', { name: 'On this page' });
     const labels = Array.from(nav.querySelectorAll('a')).map((a) => a.textContent?.trim() ?? '');
     expect(labels.some((label) => label.includes('Playground'))).toBe(false);

--- a/packages/playground/src/component-page-documentation.test.ts
+++ b/packages/playground/src/component-page-documentation.test.ts
@@ -393,6 +393,13 @@ describe('component-page single-scroll layout', () => {
     expect(section).not.toBeNull();
     const note = section?.querySelector('.dx-play__context-note');
     expect(note).not.toBeNull();
+    // The note describes the ACTUAL condition — a required prop the playground
+    // can't fill in automatically — rather than over-claiming a specific cause
+    // like "must be nested inside a parent", which only applies to some of the
+    // components this branch covers.
+    const noteText = note?.textContent ?? '';
+    expect(noteText).toContain("can't fill in automatically");
+    expect(noteText).not.toMatch(/nested inside/i);
     // The base fixture's first `avoidWhen` alternative is `segmented-control`, so
     // the note links to that component's page rather than the in-page Examples.
     const noteLink = note?.querySelector('a');

--- a/packages/playground/src/component-page-playground.test.ts
+++ b/packages/playground/src/component-page-playground.test.ts
@@ -42,10 +42,10 @@ describe('buildPlaygroundModel', () => {
       ]),
     );
     expect(model.controls).toEqual([
-      { name: 'flag', kind: 'boolean', value: true },
-      { name: 'variant', kind: 'select', options: ['a', 'b'], value: 'b' },
-      { name: 'title', kind: 'text', value: 'hi' },
-      { name: 'count', kind: 'number', value: 3 },
+      { name: 'flag', hasDefault: true, kind: 'boolean', value: true },
+      { name: 'variant', hasDefault: true, kind: 'select', options: ['a', 'b'], value: 'b' },
+      { name: 'title', hasDefault: true, kind: 'text', value: 'hi' },
+      { name: 'count', hasDefault: true, kind: 'number', value: 3 },
     ]);
     expect(model.skipped).toEqual([]);
     expect(model.hasUnsatisfiedRequired).toBe(false);
@@ -127,6 +127,7 @@ describe('buildPlaygroundModel', () => {
     );
     expect(model.controls[0]).toEqual({
       name: 'variant',
+      hasDefault: false,
       kind: 'select',
       options: ['primary', 'secondary'],
       value: 'primary',
@@ -264,5 +265,60 @@ describe('buildSnippet', () => {
     ).controls;
     expect(buildSnippet('Comp', numberControls, { count: 0 })).toBe('<Comp />');
     expect(buildSnippet('Comp', numberControls, { count: 42 })).toBe('<Comp count={42} />');
+  });
+
+  test('emits name={false} when a boolean defaulting to true is toggled off', () => {
+    // Regression: omitting the prop would render the default `true`, so a snippet
+    // that drops a user-selected `false` silently contradicts the live UI.
+    const trueByDefault = buildPlaygroundModel(
+      manifest([
+        {
+          name: 'closable',
+          control: { kind: 'boolean' },
+          bindable: false,
+          optional: true,
+          defaultValue: true,
+        },
+      ]),
+    ).controls;
+    // At its `true` default → omitted (omitting renders `true`, the same state).
+    expect(buildSnippet('Modal', trueByDefault, { closable: true })).toBe('<Modal />');
+    // Toggled to `false` → must be explicit, not dropped.
+    expect(buildSnippet('Modal', trueByDefault, { closable: false })).toBe(
+      '<Modal closable={false} />',
+    );
+  });
+
+  test('keeps a synthesized seed visible when the prop has no manifest default', () => {
+    // Regression: a control without a manifest default seeds a placeholder
+    // (first option / `0` / `false`) that is NOT the component's real default,
+    // so it must stay in the snippet rather than being elided as if it were one.
+    const noDefault = buildPlaygroundModel(
+      manifest([
+        {
+          name: 'variant',
+          control: { kind: 'select', options: ['primary', 'secondary'] },
+          bindable: false,
+          optional: true,
+        },
+        {
+          name: 'disabled',
+          control: { kind: 'boolean' },
+          bindable: false,
+          optional: true,
+        },
+        {
+          name: 'count',
+          control: { kind: 'number' },
+          bindable: false,
+          optional: true,
+        },
+      ]),
+    ).controls;
+    // The seeded values (first option / `false` / `0`) are surfaced explicitly,
+    // because we cannot prove they match the component's own defaults.
+    expect(
+      buildSnippet('Widget', noDefault, { variant: 'primary', disabled: false, count: 0 }),
+    ).toBe('<Widget\n  variant="primary"\n  disabled={false}\n  count={0}\n/>');
   });
 });

--- a/packages/playground/src/component-page-playground.test.ts
+++ b/packages/playground/src/component-page-playground.test.ts
@@ -156,13 +156,15 @@ describe('buildSnippet', () => {
   ).controls;
 
   test('omits a false boolean and renders self-closing when no attributes', () => {
-    expect(buildSnippet('Accordion', controls, { multiple: false, size: '' })).toBe(
+    // `size` stays at its 'md' default (a select is never empty at runtime), so
+    // it is omitted; `multiple` is at its `false` default, so it is too.
+    expect(buildSnippet('Accordion', controls, { multiple: false, size: 'md' })).toBe(
       '<Accordion />',
     );
   });
 
   test('renders a true boolean as a bare attribute', () => {
-    expect(buildSnippet('Accordion', controls, { multiple: true, size: '' })).toBe(
+    expect(buildSnippet('Accordion', controls, { multiple: true, size: 'md' })).toBe(
       '<Accordion multiple />',
     );
   });
@@ -249,6 +251,49 @@ describe('buildSnippet', () => {
     expect(buildSnippet('Table', mixedControls, { align: 'center', as: 'td' })).toBe(
       '<Table align="center" />',
     );
+  });
+
+  test('emits name="" when a text prop with a non-empty default is cleared', () => {
+    // Regression: clearing a non-empty default to '' is a real state change, so
+    // the snippet must preserve `label=""`. Omitting it would silently revert to
+    // the default ('Submit') when pasted, contradicting the live UI.
+    const withDefault = buildPlaygroundModel(
+      manifest([
+        {
+          name: 'label',
+          control: { kind: 'text' },
+          bindable: false,
+          optional: true,
+          defaultValue: 'Submit',
+        },
+      ]),
+    ).controls;
+    // Cleared to '' (differs from the 'Submit' default) → emitted as label="".
+    expect(buildSnippet('Comp', withDefault, { label: '' })).toBe('<Comp label="" />');
+    // Still at the default → omitted.
+    expect(buildSnippet('Comp', withDefault, { label: 'Submit' })).toBe('<Comp />');
+  });
+
+  test('omits an empty string when the prop has no default or an empty default', () => {
+    // No manifest default: the seeded '' is noise — `name=""` adds nothing.
+    const noDefault = buildPlaygroundModel(
+      manifest([{ name: 'label', control: { kind: 'text' }, bindable: false, optional: true }]),
+    ).controls;
+    expect(buildSnippet('Comp', noDefault, { label: '' })).toBe('<Comp />');
+
+    // Explicit empty-string default: '' equals the default → still omitted.
+    const emptyDefault = buildPlaygroundModel(
+      manifest([
+        {
+          name: 'label',
+          control: { kind: 'text' },
+          bindable: false,
+          optional: true,
+          defaultValue: '',
+        },
+      ]),
+    ).controls;
+    expect(buildSnippet('Comp', emptyDefault, { label: '' })).toBe('<Comp />');
   });
 
   test('omits a number control at its default 0, emits it when changed', () => {

--- a/packages/playground/src/component-page-playground.test.ts
+++ b/packages/playground/src/component-page-playground.test.ts
@@ -208,4 +208,61 @@ describe('buildSnippet', () => {
     // A safe value keeps the plain quoted-attribute form.
     expect(buildSnippet('Comp', textControls, { label: 'plain' })).toBe('<Comp label="plain" />');
   });
+
+  test('omits a control at its default value from the snippet', () => {
+    // A select at its default value ('left') should produce a self-closing tag.
+    const selectControls = buildPlaygroundModel(
+      manifest([
+        {
+          name: 'align',
+          control: { kind: 'select', options: ['left', 'center', 'right'] },
+          bindable: false,
+          optional: true,
+          defaultValue: 'left',
+        },
+      ]),
+    ).controls;
+    expect(buildSnippet('Table', selectControls, { align: 'left' })).toBe('<Table />');
+  });
+
+  test('emits only controls that have changed from their default', () => {
+    const mixedControls = buildPlaygroundModel(
+      manifest([
+        {
+          name: 'align',
+          control: { kind: 'select', options: ['left', 'center', 'right'] },
+          bindable: false,
+          optional: true,
+          defaultValue: 'left',
+        },
+        {
+          name: 'as',
+          control: { kind: 'select', options: ['td', 'th'] },
+          bindable: false,
+          optional: true,
+          defaultValue: 'td',
+        },
+      ]),
+    ).controls;
+    // Only 'align' changed; 'as' is still at its default 'td'.
+    expect(buildSnippet('Table', mixedControls, { align: 'center', as: 'td' })).toBe(
+      '<Table align="center" />',
+    );
+  });
+
+  test('omits a number control at its default 0, emits it when changed', () => {
+    const numberControls = buildPlaygroundModel(
+      manifest([
+        {
+          name: 'count',
+          control: { kind: 'number' },
+          bindable: false,
+          optional: true,
+          defaultValue: 0,
+        },
+      ]),
+    ).controls;
+    expect(buildSnippet('Comp', numberControls, { count: 0 })).toBe('<Comp />');
+    expect(buildSnippet('Comp', numberControls, { count: 42 })).toBe('<Comp count={42} />');
+  });
 });

--- a/packages/playground/src/component-page-playground.ts
+++ b/packages/playground/src/component-page-playground.ts
@@ -10,8 +10,16 @@
  */
 import type { ComponentManifest, PropManifest } from './types.ts';
 
-/** Fields common to every {@link PlaygroundControl}, regardless of kind. */
-type PlaygroundControlBase = { name: string; description?: string };
+/**
+ * Fields common to every {@link PlaygroundControl}, regardless of kind.
+ *
+ * `value` is the control's seeded initial state — for props without a manifest
+ * default it is a synthesized placeholder (first option / `0` / `''` / `false`),
+ * not the component's real default. `hasDefault` records whether the manifest
+ * actually declared a default; the snippet uses it to decide what to omit, so a
+ * synthesized placeholder is never silently dropped from the copyable code.
+ */
+type PlaygroundControlBase = { name: string; description?: string; hasDefault: boolean };
 
 /** A single adjustable control derived from a supported prop shape. */
 export type PlaygroundControl = PlaygroundControlBase &
@@ -94,6 +102,7 @@ export function buildPlaygroundModel(manifest: ComponentManifest): PlaygroundMod
     // `description?: string` under `exactOptionalPropertyTypes`.
     const base = {
       name: prop.name,
+      hasDefault: prop.defaultValue !== undefined,
       ...(prop.description !== undefined ? { description: prop.description } : {}),
     };
     switch (prop.control.kind) {
@@ -127,24 +136,47 @@ export function buildPlaygroundModel(manifest: ComponentManifest): PlaygroundMod
 }
 
 /**
- * Render one control's current value as a Svelte attribute fragment, or `null`
- * to omit it. String values that are safe for a double-quoted attribute use the
- * plain `name="value"` form; values containing a quote, ampersand, or angle
- * bracket would break that form, so they fall back to a `name={"..."}`
- * expression with a JSON-escaped literal that copy-pastes as valid Svelte.
+ * Render one control's current value as a Svelte attribute fragment.
+ *
+ * Booleans always render explicitly — bare `name` for `true`, `name={false}` for
+ * `false` — so a snippet faithfully reproduces the selected state even when the
+ * component's default for that prop is `true` (omitting it would otherwise show
+ * the default, contradicting the UI). String values that are safe for a
+ * double-quoted attribute use the plain `name="value"` form; values containing a
+ * quote, ampersand, or angle bracket fall back to a `name={"..."}` expression
+ * with a JSON-escaped literal that copy-pastes as valid Svelte. Whether a prop is
+ * emitted at all is decided by {@link buildSnippet}; this only formats it.
  */
-function attributeFor(name: string, value: PlaygroundValue): string | null {
-  if (typeof value === 'boolean') return value ? name : null;
+function attributeFor(name: string, value: PlaygroundValue): string {
+  if (typeof value === 'boolean') return value ? name : `${name}={false}`;
   if (typeof value === 'number') return `${name}={${value}}`;
-  if (value === '') return null;
   if (/["&<>]/.test(value)) return `${name}={${JSON.stringify(value)}}`;
   return `${name}="${value}"`;
 }
 
 /**
+ * Decide whether a control's current value should appear in the snippet.
+ *
+ * A prop is omitted only when it has a real manifest default AND the current
+ * value equals that default — omitting it then renders identically, so the
+ * snippet stays minimal. A prop WITHOUT a manifest default keeps its
+ * synthesized seed (first option / `0` / `''` / `false`) visible: we cannot
+ * prove the component's own default matches the placeholder, so dropping it
+ * could silently change what the snippet renders. Empty strings are the one
+ * exception — `name=""` is noise that adds nothing over omission.
+ */
+function shouldEmit(control: PlaygroundControl, current: PlaygroundValue): boolean {
+  if (current === '') return false;
+  if (control.hasDefault && current === control.value) return false;
+  return true;
+}
+
+/**
  * Generate a copy-able Svelte snippet for the component from the live control
- * values. Boolean controls render as bare attributes when true (and are omitted
- * when false); string/number controls render as `name="value"` / `name={value}`.
+ * values. Each emitted control renders explicitly — booleans as bare `name` /
+ * `name={false}`, strings as `name="value"`, numbers as `name={value}` — so the
+ * snippet always reproduces the live UI state. {@link shouldEmit} governs which
+ * props are included.
  *
  * @param exportName - The component's PascalCase export name, e.g. `Accordion`.
  * @param controls - The controls in display order.
@@ -157,12 +189,8 @@ export function buildSnippet(
   values: Record<string, PlaygroundValue>,
 ): string {
   const attributes = controls
-    .map((control) => {
-      const current = values[control.name] ?? control.value;
-      if (current === control.value) return null;
-      return attributeFor(control.name, current);
-    })
-    .filter((fragment): fragment is string => fragment !== null);
+    .filter((control) => shouldEmit(control, values[control.name] ?? control.value))
+    .map((control) => attributeFor(control.name, values[control.name] ?? control.value));
 
   if (attributes.length === 0) return `<${exportName} />`;
   if (attributes.length === 1) return `<${exportName} ${attributes[0]} />`;

--- a/packages/playground/src/component-page-playground.ts
+++ b/packages/playground/src/component-page-playground.ts
@@ -157,7 +157,11 @@ export function buildSnippet(
   values: Record<string, PlaygroundValue>,
 ): string {
   const attributes = controls
-    .map((control) => attributeFor(control.name, values[control.name] ?? control.value))
+    .map((control) => {
+      const current = values[control.name] ?? control.value;
+      if (current === control.value) return null;
+      return attributeFor(control.name, current);
+    })
     .filter((fragment): fragment is string => fragment !== null);
 
   if (attributes.length === 0) return `<${exportName} />`;

--- a/packages/playground/src/component-page-playground.ts
+++ b/packages/playground/src/component-page-playground.ts
@@ -157,18 +157,20 @@ function attributeFor(name: string, value: PlaygroundValue): string {
 /**
  * Decide whether a control's current value should appear in the snippet.
  *
- * A prop is omitted only when it has a real manifest default AND the current
- * value equals that default — omitting it then renders identically, so the
- * snippet stays minimal. A prop WITHOUT a manifest default keeps its
- * synthesized seed (first option / `0` / `''` / `false`) visible: we cannot
- * prove the component's own default matches the placeholder, so dropping it
- * could silently change what the snippet renders. Empty strings are the one
- * exception — `name=""` is noise that adds nothing over omission.
+ * When the prop has a real manifest default, emit it only when the current
+ * value DIFFERS from that default — omitting an unchanged value renders
+ * identically, keeping the snippet minimal. Crucially, clearing a non-empty
+ * default to `''` differs from it, so `name=""` IS emitted (otherwise a paste
+ * would silently revert to the default, contradicting the live UI).
+ *
+ * When the prop has NO manifest default, it carries a synthesized seed (first
+ * option / `0` / `''` / `false`). A seeded `''` is noise — `name=""` adds
+ * nothing over omission — so empty strings are dropped; any other value stays
+ * visible, since we cannot prove the component's own default matches the seed.
  */
 function shouldEmit(control: PlaygroundControl, current: PlaygroundValue): boolean {
-  if (current === '') return false;
-  if (control.hasDefault && current === control.value) return false;
-  return true;
+  if (control.hasDefault) return current !== control.value;
+  return current !== '';
 }
 
 /**

--- a/packages/playground/src/component-page-status-dot-mock.svelte
+++ b/packages/playground/src/component-page-status-dot-mock.svelte
@@ -1,5 +1,12 @@
 <script lang="ts">
-  let { status = 'neutral', label = '' }: { status?: string; label?: string } = $props();
+  // Mirrors the real StatusDot's prop surface for the doc-page tests: `status`
+  // and `label` are named, and the rest (e.g. `aria-hidden`) is spread onto the
+  // element just as the real component spreads `{...rest}`.
+  let {
+    status = 'neutral',
+    label = '',
+    ...rest
+  }: { status?: string; label?: string; [key: string]: unknown } = $props();
 </script>
 
-<span role="img" data-status={status} aria-label={label || undefined}></span>
+<span {...rest} role="img" data-status={status} aria-label={label || undefined}></span>

--- a/packages/playground/src/component-page.svelte
+++ b/packages/playground/src/component-page.svelte
@@ -924,7 +924,7 @@
                   <span class="dx-section__rule" aria-hidden="true"></span>
                 </div>
                 <p class="dx-play__context-note">
-                  {humanizeId(componentName)} must be nested inside a parent component to render.
+                  This component requires a prop value the playground can't fill in automatically.
                   {#if firstAlternative !== undefined}
                     See the <a href="/c/{firstAlternative}">{humanizeId(firstAlternative)}</a> page for
                     a live demo.

--- a/packages/playground/src/component-page.svelte
+++ b/packages/playground/src/component-page.svelte
@@ -37,7 +37,11 @@
     ComponentDocumentationPayload,
     JsonValue,
   } from './component-documentation-types.ts';
-  import { splitUnionType, toPropReferenceRows } from './manifest-reference.ts';
+  import {
+    renderPropDescription,
+    splitUnionType,
+    toPropReferenceRows,
+  } from './manifest-reference.ts';
   import { computeActiveSection, type SectionOffset } from './component-page-scroll-spy.ts';
   import {
     buildPlaygroundModel,
@@ -172,7 +176,7 @@
   $effect(() => {
     for (const entry of exampleDisclosures) {
       if (
-        entry.expandedIds.includes('source') &&
+        entry.expandedIds.includes(`source-${entry.scenario}`) &&
         fetchedSource[entry.scenario] === undefined &&
         !loadingSource[entry.scenario]
       ) {
@@ -212,7 +216,10 @@
       }
       let app: ReturnType<typeof mount> | undefined;
       try {
-        app = mount(Component as Parameters<typeof mount>[0], { target: element });
+        app = mount(Component as Parameters<typeof mount>[0], {
+          target: element,
+          props: { mountIdPrefix: mountKey },
+        });
         mountErrors[mountKey] = undefined;
       } catch (error) {
         console.error(`[cinder playground] failed to mount example "${scenario}":`, error);
@@ -239,8 +246,12 @@
     documentation === null ? [] : toPropReferenceRows(documentation.propsManifest),
   );
 
-  function propsTypeClass(typeMembers: readonly string[]): string {
-    return typeMembers.length > 1 ? 'props-type props-type--union' : 'props-type';
+  /**
+   * A union is "short" when it has ≤4 members and every member is ≤20
+   * characters, so the whole type fits comfortably inline as `A | B | C`.
+   */
+  function isShortUnion(members: readonly string[]): boolean {
+    return members.length <= 4 && members.every((member) => member.length <= 20);
   }
 
   function statusDotStatus(status: string): StatusDotStatus {
@@ -504,7 +515,9 @@
           {#if documentation !== null}
             <span>{documentation.component.categoryLabel}</span>
             <span class="dx-crumbs__sep" aria-hidden="true">/</span>
-            <span class="dx-crumbs__current">{documentation.component.name}</span>
+            <span class="dx-crumbs__current" aria-current="page"
+              >{documentation.component.name}</span
+            >
           {/if}
         </nav>
         <div class="dx-topbar__actions">
@@ -592,7 +605,10 @@
               <div class="dx-spec__row">
                 <span class="dx-spec__key">Status</span>
                 <span class="dx-spec__val">
-                  <StatusDot status={statusDotStatus(component.status)} label={component.status} />
+                  <StatusDot
+                    status={statusDotStatus(component.status)}
+                    aria-label={component.status}
+                  />
                   <Badge variant={statusBadgeVariant(component.status)} size="sm">
                     {component.status}
                   </Badge>
@@ -760,8 +776,31 @@
                 <p class="dx-prose dx-play__intro">
                   Adjust the props below — the snippet updates live. Copy it when it looks right.
                 </p>
+
                 <div class="dx-play">
                   <div class="dx-play__preview">
+                    {#if overviewExample !== undefined && !snapshotMode}
+                      <div class="dx-stage">
+                        <div class="dx-stage__bar">
+                          <span class="dx-stage__dot" aria-hidden="true"></span>
+                          <span class="dx-stage__label">Live preview</span>
+                        </div>
+                        <div class="dx-stage__canvas">
+                          {#if mountErrors[`playground-mount-${overviewExample.scenario}`] !== undefined}
+                            {@const error =
+                              mountErrors[`playground-mount-${overviewExample.scenario}`]}
+                            <Callout variant="danger" title="This preview failed to render">
+                              <p>{error?.message}</p>
+                            </Callout>
+                          {/if}
+                          <div
+                            class="example-preview"
+                            id="playground-mount-{overviewExample.scenario}"
+                            {@attach mountScenario(overviewExample.scenario)}
+                          ></div>
+                        </div>
+                      </div>
+                    {/if}
                     <CodeBlock code={playgroundSnippet} language="svelte" copyable />
                     {#if playgroundModel.skipped.length > 0}
                       <p class="dx-play__skipped">
@@ -777,9 +816,11 @@
                     {#each playgroundModel.controls as control (control.name)}
                       <div class="dx-ctl">
                         <div class="dx-ctl__text">
-                          <div class="dx-ctl__name">{control.name}</div>
+                          <div class="dx-ctl__name" title={control.name}>{control.name}</div>
                           {#if control.description !== undefined}
-                            <div class="dx-ctl__desc">{control.description}</div>
+                            <div class="dx-ctl__desc">
+                              {@html renderPropDescription(control.description)}
+                            </div>
                           {/if}
                         </div>
                         {#if control.kind === 'boolean'}
@@ -833,6 +874,24 @@
                     {/each}
                   </div>
                 </div>
+              </section>
+            {:else if documentation !== null && playgroundModel.hasUnsatisfiedRequired}
+              {@const firstAlternative = documentation.component.avoidWhen[0]?.alternative}
+              <section id="playground" class="dx-section">
+                <div class="dx-section__head">
+                  <span class="dx-section__num">{sectionNumber.get('playground') ?? ''}</span>
+                  <h2 class="dx-section__title">Playground</h2>
+                  <span class="dx-section__rule" aria-hidden="true"></span>
+                </div>
+                <p class="dx-play__context-note">
+                  {humanizeId(componentName)} must be nested inside a parent component to render.
+                  {#if firstAlternative !== undefined}
+                    See the <a href="/c/{firstAlternative}">{humanizeId(firstAlternative)}</a> page for
+                    a live demo.
+                  {:else}
+                    See the <a href="#examples">Examples</a> section for usage.
+                  {/if}
+                </p>
               </section>
             {/if}
 
@@ -893,7 +952,7 @@
                           {/if}
 
                           <Accordion bind:expandedIds={disclosure.expandedIds}>
-                            <AccordionItem id="source" title="Show code">
+                            <AccordionItem id={`source-${scenario}`} title="Show code">
                               {#if loadingSource[scenario]}
                                 <p class="source-loading">Loading…</p>
                               {:else if source === null}
@@ -971,15 +1030,19 @@
                           </Table.Cell>
                           <Table.Cell>
                             {@const typeMembers = splitUnionType(prop.type)}
-                            <code class={propsTypeClass(typeMembers)}>
-                              {#each typeMembers as member, index (index)}
-                                <span class="props-type__member">
-                                  {#if index > 0}<span class="props-type__sep" aria-hidden="true"
-                                      >|
-                                    </span>{/if}<span class="props-type__value">{member}</span>
-                                </span>
-                              {/each}
-                            </code>
+                            {#if typeMembers.length === 1 || isShortUnion(typeMembers)}
+                              <code class="props-type">{typeMembers.join(' | ')}</code>
+                            {:else}
+                              <code class="props-type props-type--union">
+                                {#each typeMembers as member, index (index)}
+                                  <span class="props-type__member"
+                                    ><span class="props-type__sep" aria-hidden="true">|</span><span
+                                      class="props-type__value">{member}</span
+                                    ></span
+                                  >
+                                {/each}
+                              </code>
+                            {/if}
                           </Table.Cell>
                           <Table.Cell>
                             {#if prop.defaultValue !== undefined}
@@ -1004,7 +1067,9 @@
                           </Table.Cell>
                           <Table.Cell>
                             {#if prop.description !== undefined}
-                              <span class="props-description">{prop.description}</span>
+                              <span class="props-description"
+                                >{@html renderPropDescription(prop.description)}</span
+                              >
                             {:else}
                               <span class="props-dash" aria-hidden="true">—</span>
                             {/if}
@@ -1551,6 +1616,32 @@
   .readme-content :global(code) {
     font-family: var(--cinder-font-mono);
     font-size: 0.95em;
+    background: var(--cinder-surface-raised);
+    padding-inline: 0.2em;
+    border-radius: var(--cinder-radius-sm);
+  }
+
+  /* ===== Doc-page code-block overrides =====
+     Fix #380: The outer .cinder-code-block has overflow:hidden (for border-radius
+     clipping). An outset focus outline on its scroll-container children is clipped,
+     producing a partial or invisible ring. Override with an inset box-shadow ring.
+     Fix #381: Ensure code-block scroll containers show a visible scrollbar track
+     and that inner pre.shiki contributes its full content width to the scroll port. */
+  .dx :global(.cinder-code-block__highlighted),
+  .dx :global(.cinder-code-block__pre) {
+    overflow-x: auto;
+    scrollbar-width: auto;
+  }
+  .dx :global(.cinder-code-block__highlighted:focus-visible),
+  .dx :global(.cinder-code-block__pre:focus-visible) {
+    outline: var(--cinder-ring-width) solid transparent;
+    box-shadow: inset 0 0 0 var(--cinder-ring-width) var(--cinder-ring-color);
+  }
+  /* Allow pre.shiki to expand to its natural content width so the parent
+     .cinder-code-block__highlighted scroll port becomes scrollable. (#398
+     addresses the root in the component; this override is scoped to .dx.) */
+  .dx :global(.cinder-code-block__highlighted) :global(pre.shiki) {
+    overflow-x: visible;
   }
 
   /* ===== Preview stage ===== */
@@ -1724,6 +1815,24 @@
     font-size: var(--cinder-text-xs);
     color: var(--cinder-text-subtle);
   }
+  .dx-play__context-note {
+    margin: 0;
+    font-size: var(--cinder-text-sm);
+    color: var(--cinder-text-subtle);
+    line-height: var(--cinder-leading-relaxed);
+  }
+  .dx-play__context-note a {
+    color: var(--cinder-accent-text);
+    text-decoration: none;
+  }
+  .dx-play__context-note a:hover {
+    text-decoration: underline;
+  }
+  .dx-play__context-note a:focus-visible {
+    outline: var(--cinder-ring-width) solid transparent;
+    box-shadow: var(--_cinder-focus-ring-shadow);
+    border-radius: var(--cinder-radius-sm);
+  }
   .dx-play__controls {
     border: 1px solid var(--cinder-border);
     border-radius: var(--cinder-radius-lg);
@@ -1766,6 +1875,8 @@
     font-family: var(--cinder-font-mono);
     font-size: var(--cinder-text-sm);
     color: var(--cinder-text);
+    overflow-wrap: break-word;
+    word-break: break-all;
   }
   .dx-ctl__desc {
     font-size: var(--cinder-text-xs);
@@ -1775,6 +1886,7 @@
   }
   .dx-ctl__select,
   .dx-ctl__input {
+    color-scheme: inherit;
     border: 1px solid var(--cinder-border);
     border-radius: var(--cinder-radius-md);
     background: var(--cinder-surface-inset);
@@ -1782,7 +1894,7 @@
     font-family: inherit;
     font-size: var(--cinder-text-sm);
     padding: var(--cinder-space-1) var(--cinder-space-2);
-    max-width: 8rem;
+    max-width: 14rem;
   }
 
   /* ===== Examples ===== */
@@ -1867,6 +1979,7 @@
   }
   .props-table-scroll {
     overflow-x: auto;
+    overscroll-behavior-x: contain;
     border-radius: var(--cinder-radius-sm);
   }
   .props-table-scroll:focus-visible {
@@ -1890,6 +2003,9 @@
     font-family: var(--cinder-font-mono);
     font-size: var(--cinder-text-sm);
   }
+  .props-default {
+    white-space: nowrap;
+  }
   .props-name {
     font-weight: var(--cinder-font-medium);
     color: var(--cinder-accent-text);
@@ -1901,18 +2017,21 @@
     align-items: flex-start;
   }
   .props-type__member {
-    white-space: nowrap;
+    white-space: pre-wrap;
+    max-width: 28rem;
   }
   .props-type--union .props-type__member {
-    padding-inline-start: 1ch;
+    display: flex;
+    align-items: baseline;
+    gap: 0.35ch;
   }
   .props-type__sep {
-    margin-inline-start: -1ch;
     color: var(--cinder-text-subtle);
+    user-select: none;
   }
   .dx-prop-flag {
     font-family: var(--cinder-font-mono);
-    font-size: var(--cinder-text-2xs);
+    font-size: var(--cinder-text-xs);
     letter-spacing: 0.04em;
     text-transform: uppercase;
     padding: var(--cinder-space-0-5, 0.125rem) var(--cinder-space-1-5, 0.375rem);
@@ -1938,10 +2057,34 @@
     color: var(--cinder-text-subtle);
   }
 
+  .props-table-scroll {
+    position: relative;
+  }
+  .props-table-scroll::after {
+    content: '';
+    position: absolute;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    width: 3rem;
+    pointer-events: none;
+    background: linear-gradient(
+      to right,
+      transparent,
+      var(--cinder-surface-raised, var(--cinder-surface)) 80%
+    );
+  }
+  /* NOTE: A JS-driven .is-scrollable sentinel is the robust approach for
+     showing the fade only when overflow exists. This CSS-only version always
+     renders the fade; a follow-up issue should implement the sentinel. */
+
   /* Narrow container → stacked cards (same ::before-label pattern as before). */
   @container props-section (max-width: 34rem) {
     .props-table-scroll {
       overflow-x: visible;
+    }
+    .props-table-scroll::after {
+      display: none;
     }
     .props-section :global(.cinder-table) {
       display: block;
@@ -2115,6 +2258,9 @@
     color: var(--cinder-text);
     margin: 0 0 var(--cinder-space-2);
   }
+  .dx-raw__panel :global(.cinder-code-block) {
+    overflow-x: auto;
+  }
 
   /* ===== Responsive ===== */
   @media (max-width: 1080px) {
@@ -2214,6 +2360,13 @@
        the container with a negative offset — mirroring the inset `box-shadow`
        the non-forced-colors `:focus-visible` rule already uses. */
     .props-table-scroll:focus-visible {
+      outline: var(--cinder-ring-width) solid ButtonText;
+      outline-offset: calc(var(--cinder-ring-width) * -1);
+    }
+    /* Same inset treatment for code-block scroll containers — the outer
+       overflow:hidden clips an outset outline just as it does for the props table. */
+    .dx :global(.cinder-code-block__highlighted:focus-visible),
+    .dx :global(.cinder-code-block__pre:focus-visible) {
       outline: var(--cinder-ring-width) solid ButtonText;
       outline-offset: calc(var(--cinder-ring-width) * -1);
     }

--- a/packages/playground/src/component-page.svelte
+++ b/packages/playground/src/component-page.svelte
@@ -236,6 +236,34 @@
     };
   }
 
+  // Whether the props table currently overflows horizontally. Drives the
+  // `is-scrollable` modifier on the scroll container so the `::after` fade
+  // affordance renders ONLY while content actually overflows — a non-overflowing
+  // table must not show a misleading fade over its right edge. Held in `$state`
+  // (rather than toggled imperatively) so the binding is statically analysable.
+  let propsTableOverflows = $state(false);
+
+  /**
+   * Measure a horizontal scroll container and keep {@link propsTableOverflows}
+   * in sync with its overflow state, re-measuring on element + content resize
+   * via `ResizeObserver`.
+   */
+  function scrollOverflowSentinel(element: HTMLElement): () => void {
+    const update = () => {
+      // A 1px tolerance avoids flicker from sub-pixel layout rounding.
+      propsTableOverflows = element.scrollWidth - element.clientWidth > 1;
+    };
+    update();
+    const observer = new ResizeObserver(update);
+    observer.observe(element);
+    // Table content can change width without the container resizing (e.g. async
+    // prop rows arriving), so observe the first child too when present.
+    if (element.firstElementChild instanceof HTMLElement) {
+      observer.observe(element.firstElementChild);
+    }
+    return () => observer.disconnect();
+  }
+
   // --- Documentation payload (fetched once) -----------------------------
   let documentation = $state<ComponentDocumentationPayload | null>(null);
   let documentationLoading = $state(true);
@@ -605,10 +633,11 @@
               <div class="dx-spec__row">
                 <span class="dx-spec__key">Status</span>
                 <span class="dx-spec__val">
-                  <StatusDot
-                    status={statusDotStatus(component.status)}
-                    aria-label={component.status}
-                  />
+                  <!-- The adjacent Badge is the accessible status text. The dot
+                       is a redundant color cue, so mark it decorative — otherwise
+                       its role="img" name re-announces the same word the Badge
+                       already speaks (the audible half of #388). -->
+                  <StatusDot status={statusDotStatus(component.status)} aria-hidden="true" />
                   <Badge variant={statusBadgeVariant(component.status)} size="sm">
                     {component.status}
                   </Badge>
@@ -779,11 +808,19 @@
 
                 <div class="dx-play">
                   <div class="dx-play__preview">
+                    <!-- This stage mounts the component's featured example so the
+                         Playground section shows a rendered instance, not just a
+                         snippet (#374). It renders the static featured scenario —
+                         it does NOT yet re-render from the prop controls, so it is
+                         deliberately NOT labelled "Live preview" (that would be a
+                         false promise: only the snippet is prop-driven today).
+                         Driving this mount from `playgroundValues` is tracked as a
+                         follow-up. -->
                     {#if overviewExample !== undefined && !snapshotMode}
                       <div class="dx-stage">
                         <div class="dx-stage__bar">
                           <span class="dx-stage__dot" aria-hidden="true"></span>
-                          <span class="dx-stage__label">Live preview</span>
+                          <span class="dx-stage__label">Featured example</span>
                         </div>
                         <div class="dx-stage__canvas">
                           {#if mountErrors[`playground-mount-${overviewExample.scenario}`] !== undefined}
@@ -799,6 +836,9 @@
                             {@attach mountScenario(overviewExample.scenario)}
                           ></div>
                         </div>
+                        <p class="dx-stage__note">
+                          Shows the featured example. Adjust the controls to update the snippet.
+                        </p>
                       </div>
                     {/if}
                     <CodeBlock code={playgroundSnippet} language="svelte" copyable />
@@ -1003,10 +1043,11 @@
                 <!-- tabindex makes the scroll region keyboard-accessible (WCAG 2.1.1). -->
                 <!-- svelte-ignore a11y_no_noninteractive_tabindex -->
                 <div
-                  class="props-table-scroll"
+                  class={['props-table-scroll', { 'is-scrollable': propsTableOverflows }]}
                   role="region"
                   aria-label="Props for {componentName}"
                   tabindex="0"
+                  {@attach scrollOverflowSentinel}
                 >
                   <Table caption={`Props for ${componentName}`} density="condensed">
                     <Table.Header>
@@ -1677,6 +1718,13 @@
   .dx-stage__canvas {
     padding: clamp(1.5rem, 4vw, 3rem);
   }
+  .dx-stage__note {
+    margin: 0;
+    padding: var(--cinder-space-1) var(--cinder-space-3) var(--cinder-space-2);
+    font-size: var(--cinder-text-xs);
+    color: var(--cinder-text-subtle);
+    border-block-start: 1px solid var(--cinder-border-subtle, var(--cinder-border));
+  }
   /* Snapshot-mode body: just the mounted examples, no docs chrome, so the
      visual-regression / a11y harness captures a clean component mount. The light
      surface is pure white (carried over from the docs page) so translucent
@@ -2060,7 +2108,12 @@
   .props-table-scroll {
     position: relative;
   }
-  .props-table-scroll::after {
+  /* The fade affordance renders ONLY when the table actually overflows
+     horizontally — gated by the `is-scrollable` class that `scrollOverflowSentinel`
+     toggles via ResizeObserver. Without this gate a non-overflowing table would
+     show a misleading fade over its right edge (the always-on version reviewers
+     flagged). */
+  .props-table-scroll.is-scrollable::after {
     content: '';
     position: absolute;
     top: 0;
@@ -2074,16 +2127,13 @@
       var(--cinder-surface-raised, var(--cinder-surface)) 80%
     );
   }
-  /* NOTE: A JS-driven .is-scrollable sentinel is the robust approach for
-     showing the fade only when overflow exists. This CSS-only version always
-     renders the fade; a follow-up issue should implement the sentinel. */
 
   /* Narrow container → stacked cards (same ::before-label pattern as before). */
   @container props-section (max-width: 34rem) {
     .props-table-scroll {
       overflow-x: visible;
     }
-    .props-table-scroll::after {
+    .props-table-scroll.is-scrollable::after {
       display: none;
     }
     .props-section :global(.cinder-table) {

--- a/packages/playground/src/component-page.svelte
+++ b/packages/playground/src/component-page.svelte
@@ -1077,9 +1077,9 @@
                               <code class="props-type props-type--union">
                                 {#each typeMembers as member, index (index)}
                                   <span class="props-type__member"
-                                    ><span class="props-type__sep" aria-hidden="true">|</span><span
-                                      class="props-type__value">{member}</span
-                                    ></span
+                                    >{#if index > 0}<span class="props-type__sep" aria-hidden="true"
+                                        >|</span
+                                      >{/if}<span class="props-type__value">{member}</span></span
                                   >
                                 {/each}
                               </code>

--- a/packages/playground/src/manifest-reference.test.ts
+++ b/packages/playground/src/manifest-reference.test.ts
@@ -16,6 +16,7 @@ import {
   describeDefaultValue,
   fetchComponentManifest,
   isComponentManifest,
+  renderPropDescription,
   splitUnionType,
   toPropReferenceRow,
   toPropReferenceRows,
@@ -63,6 +64,61 @@ describe('describeControlType', () => {
     expect(describeControlType({ kind: 'number' })).toBe('number');
     expect(describeControlType({ kind: 'boolean' })).toBe('boolean');
     expect(describeControlType({ kind: 'snippet' })).toBe('snippet');
+  });
+});
+
+describe('describeControlType unknown newline normalization', () => {
+  it('collapses literal newlines in multi-line type strings', () => {
+    expect(
+      describeControlType({
+        kind: 'unknown',
+        rawType: "Exclude<\n  keyof HTMLElementTagNameMap,\n  'script'>",
+      }),
+    ).toBe("Exclude<keyof HTMLElementTagNameMap, 'script'>");
+  });
+
+  it('maps a newline-only type that trims to "?" to "unknown"', () => {
+    expect(describeControlType({ kind: 'unknown', rawType: '\n?' })).toBe('unknown');
+  });
+
+  it('maps whitespace-only types to "unknown"', () => {
+    expect(describeControlType({ kind: 'unknown', rawType: '  \n  ' })).toBe('unknown');
+  });
+});
+
+describe('renderPropDescription', () => {
+  it('passes plain text through unchanged', () => {
+    expect(renderPropDescription('A simple description.')).toBe('A simple description.');
+  });
+
+  it('converts backtick spans to <code> elements', () => {
+    expect(renderPropDescription('Use `align` prop.')).toBe('Use <code>align</code> prop.');
+  });
+
+  it('converts **bold** spans to <strong> elements', () => {
+    expect(renderPropDescription('This is **required**.')).toBe(
+      'This is <strong>required</strong>.',
+    );
+  });
+
+  it('handles mixed backtick and bold in the same string', () => {
+    expect(renderPropDescription('Set `value` or **bind** it.')).toBe(
+      'Set <code>value</code> or <strong>bind</strong> it.',
+    );
+  });
+
+  it('HTML-escapes angle brackets before Markdown conversion (injection prevention)', () => {
+    expect(renderPropDescription('<script>alert(1)</script> `code`')).toBe(
+      '&lt;script&gt;alert(1)&lt;/script&gt; <code>code</code>',
+    );
+  });
+
+  it('HTML-escapes ampersands', () => {
+    expect(renderPropDescription('A & B')).toBe('A &amp; B');
+  });
+
+  it('returns empty string for empty input', () => {
+    expect(renderPropDescription('')).toBe('');
   });
 });
 

--- a/packages/playground/src/manifest-reference.ts
+++ b/packages/playground/src/manifest-reference.ts
@@ -44,7 +44,19 @@ export function describeControlType(control: ControlKind): string {
     case 'select':
       return control.options.map((option) => `'${option}'`).join(' | ');
     case 'unknown': {
-      const raw = control.rawType.trim();
+      // Collapse multi-line analyzer types (e.g. `Exclude<\n  keyof …,\n  …>`)
+      // to a single line. The replacement is context-sensitive:
+      // - After `<`, `(`, `[` — no space (bracket already separates tokens).
+      // - After `,` — a single space (produces `, nextToken`).
+      // - Otherwise — a single space.
+      const normalized = control.rawType.replace(
+        /([<([,])\s*\n\s*|(\S)\s*\n\s*/g,
+        (_, bracket, nonBracket) => {
+          if (bracket !== undefined) return bracket === ',' ? ', ' : bracket;
+          return `${nonBracket} `;
+        },
+      );
+      const raw = normalized.trim();
       return raw === '' || raw === '?' ? 'unknown' : raw;
     }
     default:
@@ -228,6 +240,33 @@ function isPropManifest(value: unknown): value is PropManifest {
     typeof readProperty(value, 'optional') === 'boolean' &&
     (description === undefined || typeof description === 'string')
   );
+}
+
+/**
+ * Convert a prop/control description string that may contain inline Markdown
+ * into a safe HTML fragment for rendering via `{@html ...}`.
+ *
+ * Conversion rules (applied in order):
+ * 1. HTML-escape the entire string first (prevents injection).
+ * 2. Backtick spans — `` `...` `` → `<code>...</code>`.
+ * 3. Bold spans — `**...**` → `<strong>...</strong>`.
+ *
+ * Only inline Markdown is handled; block-level constructs are intentionally
+ * left as plain text because prop descriptions are single short sentences.
+ *
+ * @param description - The raw description string from a {@link PropManifest}
+ *   or a {@link ControlKind}.
+ * @returns A safe HTML string suitable for `{@html ...}`.
+ */
+export function renderPropDescription(description: string): string {
+  const escaped = description
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+  const withCode = escaped.replace(/`([^`]+)`/g, '<code>$1</code>');
+  const withStrong = withCode.replace(/\*\*([^*]+)\*\*/g, '<strong>$1</strong>');
+  return withStrong;
 }
 
 /**


### PR DESCRIPTION
## Summary

Group A of the GitHub-issue drain: fixes to the **shared component doc-page template** (`packages/playground/src/component-page.svelte` + `manifest-reference.ts`). Every fix here is in the one shared template, so it lands library-wide across all component pages in a single PR.

Resolves: #372 #388 #389 #391 #392 #374 #380 #381 #384 #401 #404

## What changed

**Status row (#372, #388)** — the doc-header Status row no longer shows the status word multiple times. The `StatusDot` is now decorative (`aria-hidden`), so the adjacent `Badge` is the single visible *and* announced status; the dot no longer re-speaks it to a screen reader.

**Props table (#389, #391)** — prop descriptions and union types render correctly: inline Markdown (`` `code` ``, `**bold**`) is converted via `renderPropDescription` (HTML-escaped first, then a fixed allow-list of `<code>`/`<strong>`), short unions render inline `A | B | C`, long unions stack per-member, multi-line analyzer types collapse to one line, and the verbose-type layout no longer traps the page scroll or hides columns. A ResizeObserver sentinel shows the right-edge fade affordance **only** when the table actually overflows.

**Playground (#374, #392)** — the Playground section now renders the component's **featured example** (so it's not just a code snippet). It's honestly labelled "Featured example" with a note that the controls drive the snippet; driving the preview itself from the live prop values is tracked as follow-up #405 (explicitly permitted by #374's acceptance criteria). Prop labels no longer truncate and the two-column panel dead-space is tightened.

**Code blocks on the doc page (#380, #381)** — focus rings on the doc page's code-block scroll containers are drawn inset (the outer `overflow:hidden` clipped the outset ring), and the scroll containers expose a usable scrollbar. (The root component-level code-block fix, #398, lands in the component-fixes PR; this PR carries only the `.dx`-scoped doc-page portion.)

**Layout / a11y polish (#384, #401, #404)** — breadcrumb `aria-current="page"`, reduced dead layout space, and assorted ARIA/semantic correctness on the shared template.

## Review

Reviewed via committee-review. All six persona reviewers plus the mandatory Codex member ran through the **Codex fallback** (the Claude `Agent` dispatch hit the known `/usage-credits` error this session); each persona was reviewed via a parallel `codex-review.sh` pass. svelte-expert and security-reviewer APPROVED outright; ux-designer / testing-expert / junior-engineer must-fixes were resolved (honest preview relabel + #405 follow-up, overflow-gated fade sentinel, decorative status dot, both context-note link branches pinned by tests). Codex round-2 (high) re-reviewed the fix delta and APPROVED with no new findings. Full triage in `tmp/committee-state.md`.

## Tests

- `bun run test` (playground): **669 + 8 pass, 0 fail**
- `bun run typecheck` (playground): **0 errors**, no new svelte-check warnings
- New regression tests: decorative status dot, context-note link target (both branches), `buildSnippet` default-omission, `describeControlType` newline normalization, `renderPropDescription` XSS-inertness.

cc @copilot

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches `{@html renderPropDescription}` (mitigated by escaping tests) and broad shared template behavior; regression coverage is strong but blast radius is library-wide.
> 
> **Overview**
> This PR updates the **shared** playground component doc template (`component-page.svelte`, `manifest-reference.ts`, `component-page-playground.ts`) so fixes apply to every component page at once.
> 
> **Status & navigation** — `StatusDot` is now `aria-hidden` so the adjacent `Badge` is the only announced status. Breadcrumb current page gets `aria-current="page"`.
> 
> **Props table** — Descriptions use new `renderPropDescription` (escape-first, then limited `` `code` `` / `**bold**`). Short unions render inline; long unions stack with `|` only between members (not before the first). Multi-line `unknown` types collapse to one line. Horizontal overflow drives an `is-scrollable` fade via `ResizeObserver`, not always-on.
> 
> **Playground** — Copyable snippets omit props at manifest defaults via `hasDefault` / `shouldEmit`, but keep explicit `false`, cleared strings, and synthesized seeds. Interactive playground is hidden when a required prop can’t be filled; a **context note** section replaces it (link to `avoidWhen` alternative or `#examples`). When controls work, a **Featured example** mount appears above the snippet (controls still only drive the snippet). Per-example accordion ids are `source-${scenario}`; mounts pass `mountIdPrefix`.
> 
> **Doc-page polish** — `.dx` code-block inset focus rings and scroll behavior; props/playground layout and control styling tweaks; forced-colors parity for code blocks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 34f3b969c981b590e6648245685d69df81f06f88. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->