### PR TITLE
fix(components): dark-mode/contrast/focus/hover CSS + ARIA/live-region/focus-trap semantics (Groups C+D, 13 issues)

### DIFF
--- a/docs/tokens.md
+++ b/docs/tokens.md
@@ -134,14 +134,20 @@ Durations and easing curves. `--cinder-duration-normal` is an alias for `--cinde
 
 Background and surface tokens for the three core elevations — page background, default surface, and raised surface — plus an inset variant for sunken regions and `hover`/`pressed` derivatives that lift or darken via `color-mix`.
 
-| Token                      | Default                                                                                     |
-| -------------------------- | ------------------------------------------------------------------------------------------- |
-| `--cinder-bg`              | `light-dark(oklch(96% 0.01 245), oklch(15% 0.035 245))`                                     |
-| `--cinder-surface`         | `light-dark(oklch(98.5% 0.008 245), oklch(20% 0.04 245))`                                   |
-| `--cinder-surface-raised`  | `light-dark(oklch(100% 0.006 245), oklch(26% 0.045 245))`                                   |
-| `--cinder-surface-inset`   | `light-dark(oklch(95.5% 0.01 245), oklch(11% 0.03 245))`                                    |
-| `--cinder-surface-hover`   | `color-mix(in oklch, var(--cinder-surface), light-dark(oklch(0% 0 0), oklch(100% 0 0)) 3%)` |
-| `--cinder-surface-pressed` | `color-mix(in oklch, var(--cinder-surface), light-dark(oklch(0% 0 0), oklch(100% 0 0)) 8%)` |
+| Token                              | Default                                                                                     |
+| ---------------------------------- | ------------------------------------------------------------------------------------------- |
+| `--cinder-bg`                      | `light-dark(oklch(96% 0.01 245), oklch(15% 0.035 245))`                                     |
+| `--cinder-surface`                 | `light-dark(oklch(98.5% 0.008 245), oklch(20% 0.04 245))`                                   |
+| `--cinder-surface-raised`          | `light-dark(oklch(100% 0.006 245), oklch(26% 0.045 245))`                                   |
+| `--cinder-surface-inset`           | `light-dark(oklch(95.5% 0.01 245), oklch(11% 0.03 245))`                                    |
+| `--cinder-surface-hover`           | `color-mix(in oklch, var(--cinder-surface), light-dark(oklch(0% 0 0), oklch(100% 0 0)) 3%)` |
+| `--cinder-surface-pressed`         | `color-mix(in oklch, var(--cinder-surface), light-dark(oklch(0% 0 0), oklch(100% 0 0)) 8%)` |
+| `--cinder-surface-upcoming-marker` | `light-dark(var(--cinder-surface-inset), var(--cinder-surface))`                            |
+| `--cinder-surface-inverse`         | `light-dark(var(--cinder-text), var(--cinder-surface-raised))`                              |
+| `--cinder-text-inverse`            | `light-dark(var(--cinder-surface), var(--cinder-text))`                                     |
+| `--cinder-border-inverse`          | `light-dark(transparent, var(--cinder-border-strong))`                                      |
+
+`--cinder-surface-upcoming-marker` is the background for Steps component upcoming-state markers. In light mode it resolves to `--cinder-surface-inset` (visibly recessed); in dark mode it lifts to `--cinder-surface` so the marker is visible against the dark stage. `--cinder-surface-inverse`, `--cinder-text-inverse`, and `--cinder-border-inverse` form the dark-overlay triple used by Tooltip — both arms render a dark overlay with legible light text (no theme inversion occurs in dark mode).
 
 ## Text colors
 
@@ -153,15 +159,19 @@ Foreground colors keyed to readability against the surface tokens. `--cinder-tex
 | `--cinder-text-muted`    | `light-dark(oklch(32% 0.014 245), oklch(82% 0.02 245))` |
 | `--cinder-text-subtle`   | `light-dark(oklch(42% 0.012 245), oklch(72% 0.02 245))` |
 | `--cinder-text-disabled` | `light-dark(oklch(52% 0.01 245), oklch(64% 0.02 245))`  |
-| `--cinder-fill-disabled` | `light-dark(oklch(88% 0.01 245), oklch(30% 0.04 245))`  |
+| `--cinder-fill-disabled` | `light-dark(oklch(88% 0.01 245), oklch(30% 0.015 245))` |
 
 ## Borders
 
-| Token                    | Default                                                 |
-| ------------------------ | ------------------------------------------------------- |
-| `--cinder-border`        | `light-dark(oklch(79% 0.013 245), oklch(40% 0.05 245))` |
-| `--cinder-border-muted`  | `light-dark(oklch(88% 0.01 245), oklch(30% 0.04 245))`  |
-| `--cinder-border-strong` | `light-dark(oklch(72% 0.014 245), oklch(45% 0.06 245))` |
+| Token                                     | Default                                                       |
+| ----------------------------------------- | ------------------------------------------------------------- |
+| `--cinder-border`                         | `light-dark(oklch(79% 0.013 245), oklch(40% 0.05 245))`       |
+| `--cinder-border-muted`                   | `light-dark(oklch(88% 0.01 245), oklch(30% 0.04 245))`        |
+| `--cinder-border-strong`                  | `light-dark(oklch(72% 0.014 245), oklch(45% 0.06 245))`       |
+| `--cinder-toggle-track-off-resting`       | `light-dark(var(--cinder-border-muted), oklch(45% 0.02 245))` |
+| `--cinder-toggle-track-off-hover-resting` | `light-dark(var(--cinder-border), oklch(52% 0.02 245))`       |
+
+`--cinder-toggle-track-off-resting` and `--cinder-toggle-track-off-hover-resting` are the default fill colors for an unchecked Toggle track. In light mode they alias the existing muted and default border tokens. In dark mode they lift to L≈0.45 (rest) and L≈0.52 (hover) so the track has ≥3:1 shape contrast against the dark surface. The `--cinder-toggle-track-off` consumer override hook still takes priority.
 
 ## Accent
 
@@ -279,6 +289,9 @@ The ring tokens drive the focus-visible outline used across interactive primitiv
 | `--cinder-ring-offset`       | `1px`                                                                                                   |
 | `--cinder-ring-offset-color` | `var(--cinder-bg)`                                                                                      |
 | `--cinder-ring-color`        | `light-dark(oklch(from var(--cinder-accent) 0.58 0.16 h), oklch(from var(--cinder-accent) 0.7 0.14 h))` |
+| `--cinder-ring-on-accent`    | `light-dark(oklch(20% 0.02 245), oklch(95% 0.01 245))`                                                  |
+
+`--cinder-ring-on-accent` is a high-contrast focus ring for use on solid accent-fill surfaces (e.g. the primary `FloatingActionButton`). The light arm is a near-black that contrasts both the accent fill (≥11:1) and the page background (≥19:1). The dark arm is a near-white that contrasts the bright dark-mode accent (≥5:1) and the dark page background (≥18:1). Regular interactive elements on neutral surfaces use `--cinder-ring-color` instead.
 
 ## Z-index layers
 
@@ -322,12 +335,12 @@ Component-specific tokens for [`Button`](../packages/components/src/components/b
 
 ### Base
 
-| Token                    | Default                        |
-| ------------------------ | ------------------------------ |
-| `--cinder-button-bg`     | `var(--cinder-surface-raised)` |
-| `--cinder-button-fg`     | `var(--cinder-text)`           |
-| `--cinder-button-border` | `var(--cinder-border)`         |
-| `--cinder-button-radius` | `var(--cinder-radius-md)`      |
+| Token                    | Default                                                         |
+| ------------------------ | --------------------------------------------------------------- |
+| `--cinder-button-bg`     | `var(--cinder-surface-raised)`                                  |
+| `--cinder-button-fg`     | `var(--cinder-text)`                                            |
+| `--cinder-button-border` | `light-dark(var(--cinder-border), var(--cinder-border-strong))` |
+| `--cinder-button-radius` | `var(--cinder-radius-md)`                                       |
 
 ### Size: xs
 

--- a/packages/components/scripts/lib/atomic-swap-dist.mock.test.ts
+++ b/packages/components/scripts/lib/atomic-swap-dist.mock.test.ts
@@ -61,7 +61,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-  process.on = originalProcessOn as typeof process.on;
+  process.on = originalProcessOn;
   for (const listener of exitListeners) process.off('exit', listener);
   exitListeners.length = 0;
 });

--- a/packages/components/scripts/lib/atomic-swap-dist.test.ts
+++ b/packages/components/scripts/lib/atomic-swap-dist.test.ts
@@ -31,7 +31,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-  process.on = originalProcessOn as typeof process.on;
+  process.on = originalProcessOn;
   for (const listener of exitListeners) process.off('exit', listener);
   exitListeners.length = 0;
   rmSync(testRoot, { recursive: true, force: true });

--- a/packages/components/src/_internal/overlay.ts
+++ b/packages/components/src/_internal/overlay.ts
@@ -84,17 +84,25 @@ export function useHydrated(): { value: boolean } {
  * once). The stack is also keyed-set semantics: pushing the same handler
  * twice is a no-op; popping a handler not on the stack is a no-op.
  */
-const escapeStack: Array<() => void> = [];
+/**
+ * An escape-stack handler. Receives the originating `KeyboardEvent` so a
+ * handler that owns the keystroke (e.g. a nested interactive popup closing on
+ * Escape) can call `event.preventDefault()` to stop the key from also reaching
+ * the page's default action. Most overlays ignore the argument and just close.
+ */
+type EscapeHandler = (event: KeyboardEvent) => void;
+
+const escapeStack: EscapeHandler[] = [];
 
 /**
  * Register a handler to be called when ESC is pressed and this overlay is at
- * the top of the stack. Returns a `release` function the overlay must call
- * on close.
+ * the top of the stack. The handler receives the originating `KeyboardEvent`.
+ * Returns a `release` function the overlay must call on close.
  *
  * The first handler pushed installs the global keydown listener; the last
  * handler popped removes it.
  */
-export function pushEscapeHandler(handler: () => void): () => void {
+export function pushEscapeHandler(handler: EscapeHandler): () => void {
   escapeStack.push(handler);
   if (escapeStack.length === 1 && typeof window !== 'undefined') {
     window.addEventListener('keydown', onEscapeKeydown, { capture: true });
@@ -115,9 +123,11 @@ function onEscapeKeydown(event: KeyboardEvent): void {
   if (event.key !== 'Escape') return;
   const handler = escapeStack.at(-1);
   if (!handler) return;
-  // Don't preventDefault — native dialog ESC and consumer keydown handlers
-  // may want to react too. We just invoke the topmost overlay's close.
-  handler();
+  // We don't preventDefault here — whether the keystroke should be swallowed is
+  // the topmost handler's call, so we pass the event through and let it decide
+  // (a nested popup that owns Escape calls event.preventDefault(); a plain
+  // overlay that's fine letting native dialog ESC also fire does not).
+  handler(event);
 }
 
 /**

--- a/packages/components/src/_internal/overlay.ts
+++ b/packages/components/src/_internal/overlay.ts
@@ -78,10 +78,12 @@ export function useHydrated(): { value: boolean } {
  * Stack of ESC handlers. Top-most overlay handles ESC; lower overlays ignore
  * the event. Each overlay registers a handler on open and unregisters on close.
  *
- * The stack lives in module scope so all Cinder overlays share it. This is
- * fine for tests (each test runs against a fresh module instance) and fine
- * for production (a real app has at most a handful of stacked overlays at
- * once). It is a plain LIFO stack: each `pushEscapeHandler` call appends one
+ * The stack lives in module scope so all Cinder overlays share it. It persists
+ * for the lifetime of the JS module — under bun:test that means it is shared
+ * across every test in a file, so suites that leave handlers registered must
+ * call `_resetEscapeStack()` between cases to avoid leaking state. In
+ * production this is fine (a real app has at most a handful of stacked overlays
+ * at once). It is a plain LIFO stack: each `pushEscapeHandler` call appends one
  * entry and returns a one-shot `release` token that removes that entry's most
  * recent occurrence. Overlays push exactly once per open and release via the
  * returned token, so duplicates don't arise in practice; releasing a token

--- a/packages/components/src/_internal/overlay.ts
+++ b/packages/components/src/_internal/overlay.ts
@@ -81,8 +81,11 @@ export function useHydrated(): { value: boolean } {
  * The stack lives in module scope so all Cinder overlays share it. This is
  * fine for tests (each test runs against a fresh module instance) and fine
  * for production (a real app has at most a handful of stacked overlays at
- * once). The stack is also keyed-set semantics: pushing the same handler
- * twice is a no-op; popping a handler not on the stack is a no-op.
+ * once). It is a plain LIFO stack: each `pushEscapeHandler` call appends one
+ * entry and returns a one-shot `release` token that removes that entry's most
+ * recent occurrence. Overlays push exactly once per open and release via the
+ * returned token, so duplicates don't arise in practice; releasing a token
+ * twice (or releasing a handler already gone) is a no-op.
  */
 /**
  * An escape-stack handler. Receives the originating `KeyboardEvent` so a

--- a/packages/components/src/_internal/toast-context.ts
+++ b/packages/components/src/_internal/toast-context.ts
@@ -46,6 +46,12 @@ export type ToastOptions = {
    */
   icon?: Snippet;
   /**
+   * When true, renders a per-variant default icon before the message. Defaults
+   * to false. Has no effect when a custom icon snippet is provided via the icon
+   * prop.
+   */
+  showIcon?: boolean;
+  /**
    * Optional action paired with the message. Renders a button after the
    * message text and invokes `onAction` when clicked. The toast is dismissed
    * after the action runs unless `keepOpen` is true, even when `dismissible`
@@ -61,6 +67,8 @@ export type ToastItem = {
   variant: ToastVariant;
   duration: number;
   dismissible: boolean;
+  /** Normalized from ToastOptions.showIcon; defaults to false. */
+  showIcon: boolean;
   icon?: Snippet;
   action?: { label: string; onAction: () => void; keepOpen?: boolean };
 };

--- a/packages/components/src/components/_visually-hidden-live-region.same-message-fixture.svelte
+++ b/packages/components/src/components/_visually-hidden-live-region.same-message-fixture.svelte
@@ -1,0 +1,23 @@
+<script lang="ts">
+  /**
+   * Test-only fixture: a parent that holds the announcement in `$state` and
+   * re-assigns the SAME string on each click while bumping `announcementSequence`.
+   * This reproduces the real consumer path (e.g. tag-input adding the same tag
+   * twice) that a `rerender({ message })` call cannot — `rerender` always drives
+   * the prop from outside and so never exercises Svelte 5's same-value `$state`
+   * no-op. Used by `_visually-hidden-live-region.test.ts`.
+   */
+  import VisuallyHiddenLiveRegion from './_visually-hidden-live-region.svelte';
+
+  let message = $state('');
+  let announcementSequence = $state(0);
+
+  function announceCopied(): void {
+    message = 'Copied.';
+    announcementSequence += 1;
+  }
+</script>
+
+<button type="button" onclick={announceCopied}>Announce copied</button>
+
+<VisuallyHiddenLiveRegion {message} {announcementSequence} />

--- a/packages/components/src/components/_visually-hidden-live-region.svelte
+++ b/packages/components/src/components/_visually-hidden-live-region.svelte
@@ -38,10 +38,20 @@
 
   let {
     message = '',
+    announcementSequence = 0,
     priority = 'polite',
     class: className,
   }: {
     message?: string;
+    /**
+     * Bump this (monotonically) to force a re-announcement of an identical
+     * `message`. In Svelte 5, assigning the same string to a `$state` is a no-op,
+     * so a consumer that announces the same text twice in a row (e.g. adding the
+     * same tag again) would not re-run this component's effect. Reading the
+     * sequence inside the effect registers it as a dependency, so incrementing it
+     * — even with `message` unchanged — re-fires the blank-then-set dance.
+     */
+    announcementSequence?: number;
     priority?: LiveRegionPriority;
     class?: string;
   } = $props();
@@ -69,6 +79,9 @@
   // then PERSISTS until the consumer changes it (no auto-clear of an active status).
   $effect(() => {
     const next = message;
+    // Read the sequence so it is tracked as a dependency: bumping it re-runs this
+    // effect even when `message` is byte-identical to the previous announcement.
+    void announcementSequence;
     const current = ++version;
 
     if (setTimeoutId) {

--- a/packages/components/src/components/_visually-hidden-live-region.test.ts
+++ b/packages/components/src/components/_visually-hidden-live-region.test.ts
@@ -1,16 +1,21 @@
 /// <reference lib="dom" />
-import { describe, expect, test } from 'bun:test';
+import { afterEach, describe, expect, test } from 'bun:test';
 
 import { setupHappyDom } from '../test/happy-dom.ts';
 
 setupHappyDom();
 
-const { render, waitFor, fireEvent } = await import('@testing-library/svelte');
+const { cleanup, render, waitFor, fireEvent } = await import('@testing-library/svelte');
 const { tick } = await import('svelte');
+
+// `@testing-library/svelte` v5 auto-cleanup does not register under bun:test, so
+// each test's rendered tree would otherwise leak into the shared happy-dom
+// document and interfere with later cases (and other suites). Tear down after
+// every test, matching the rest of the component suites.
+afterEach(() => cleanup());
 const { default: VisuallyHiddenLiveRegion } = await import('./_visually-hidden-live-region.svelte');
-const { default: SameMessageFixture } = await import(
-  './_visually-hidden-live-region.same-message-fixture.svelte'
-);
+const { default: SameMessageFixture } =
+  await import('./_visually-hidden-live-region.same-message-fixture.svelte');
 
 describe('VisuallyHiddenLiveRegion', () => {
   test('renders a polite role=status region with aria-atomic by default', () => {

--- a/packages/components/src/components/_visually-hidden-live-region.test.ts
+++ b/packages/components/src/components/_visually-hidden-live-region.test.ts
@@ -5,8 +5,12 @@ import { setupHappyDom } from '../test/happy-dom.ts';
 
 setupHappyDom();
 
-const { render, waitFor } = await import('@testing-library/svelte');
+const { render, waitFor, fireEvent } = await import('@testing-library/svelte');
+const { tick } = await import('svelte');
 const { default: VisuallyHiddenLiveRegion } = await import('./_visually-hidden-live-region.svelte');
+const { default: SameMessageFixture } = await import(
+  './_visually-hidden-live-region.same-message-fixture.svelte'
+);
 
 describe('VisuallyHiddenLiveRegion', () => {
   test('renders a polite role=status region with aria-atomic by default', () => {
@@ -99,5 +103,38 @@ describe('VisuallyHiddenLiveRegion', () => {
     });
     // Confirm the stale 'First' never briefly appeared.
     expect(region()?.textContent?.trim()).toBe('Second');
+  });
+
+  test('re-announces when the parent re-assigns the same $state string (announcementSequence bump)', async () => {
+    // Regression for #400: a consumer (e.g. tag-input adding the same tag twice)
+    // assigns the SAME announcement string to a `$state`. In Svelte 5 that is a
+    // no-op, so without `announcementSequence` the effect never re-runs and the
+    // region is never re-announced. `rerender({ message })` cannot reproduce this
+    // (it drives the prop from outside) — only a real parent holding `$state` does,
+    // hence the fixture.
+    const { container } = render(SameMessageFixture);
+    const region = () => container.querySelector('[role="status"]');
+    const button = container.querySelector('button');
+    expect(button).not.toBeNull();
+
+    // First announcement lands after the blank-then-set setTimeout(0).
+    await fireEvent.click(button as HTMLButtonElement);
+    await waitFor(() => {
+      expect(region()?.textContent?.trim()).toBe('Copied.');
+    });
+
+    // Second click assigns the identical string 'Copied.' again. The sequence bump
+    // re-runs the effect, which blanks the region first. This intermediate blank is
+    // the load-bearing assertion: if the fix is reverted, the effect never runs and
+    // the content stays 'Copied.' — this assertion then fails.
+    await fireEvent.click(button as HTMLButtonElement);
+    await tick();
+    expect(region()?.textContent?.trim()).toBe('');
+
+    // Then the deferred set re-announces the same text, so the AT sees a genuine
+    // content change.
+    await waitFor(() => {
+      expect(region()?.textContent?.trim()).toBe('Copied.');
+    });
   });
 });

--- a/packages/components/src/components/alert-dialog/alert-dialog.test.ts
+++ b/packages/components/src/components/alert-dialog/alert-dialog.test.ts
@@ -1,6 +1,7 @@
 /// <reference lib="dom" />
-import { describe, expect, test } from 'bun:test';
+import { afterEach, describe, expect, test } from 'bun:test';
 
+import { _resetEscapeStack, _resetScrollLock } from '../../_internal/overlay.ts';
 import { setupHappyDom } from '../../test/happy-dom.ts';
 
 setupHappyDom();
@@ -26,8 +27,21 @@ if (typeof HTMLDialogElement !== 'undefined') {
   }
 }
 
-const { render, fireEvent } = await import('@testing-library/svelte');
+const { cleanup, render, fireEvent } = await import('@testing-library/svelte');
 const { default: AlertDialog } = await import('./alert-dialog.svelte');
+
+// AlertDialog renders a native <dialog> via showModal(); without this teardown the
+// dialog (and its title "Session expired") leaks into the shared happy-dom document,
+// so a later `getByRole('alertdialog', { name: 'Session expired' })` finds duplicates
+// once these tests run in the same `bun test` invocation as the modal/drawer suites.
+// Mirror the sibling overlay suites: unmount, clear the body, and reset the overlay
+// scroll-lock refcount + escape stack so neither leaks across tests.
+afterEach(() => {
+  cleanup();
+  document.body.replaceChildren();
+  _resetScrollLock();
+  _resetEscapeStack();
+});
 
 describe('AlertDialog', () => {
   test('renders alertdialog semantics with required description', () => {

--- a/packages/components/src/components/area-chart/area-chart.svelte
+++ b/packages/components/src/components/area-chart/area-chart.svelte
@@ -155,15 +155,6 @@
 
   function handleTargetKeydown(event: KeyboardEvent): void {
     rememberKeyboardFocusModality(event);
-    // Enter and Space activate the focused data point — a role="button" element
-    // must respond to these keys per ARIA 1.2 §6.6.3 (button widget).
-    if (event.key === 'Enter' || event.key === ' ') {
-      event.preventDefault();
-      if (event.currentTarget instanceof Element) {
-        event.currentTarget.dispatchEvent(new MouseEvent('click', { bubbles: true }));
-      }
-      return;
-    }
     interaction.activateByKeyboard(event, rootElement!, model.targets, keyboardEnabled);
   }
 </script>

--- a/packages/components/src/components/area-chart/area-chart.svelte
+++ b/packages/components/src/components/area-chart/area-chart.svelte
@@ -155,6 +155,15 @@
 
   function handleTargetKeydown(event: KeyboardEvent): void {
     rememberKeyboardFocusModality(event);
+    // Enter and Space activate the focused data point — a role="button" element
+    // must respond to these keys per ARIA 1.2 §6.6.3 (button widget).
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault();
+      if (event.currentTarget instanceof Element) {
+        event.currentTarget.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      }
+      return;
+    }
     interaction.activateByKeyboard(event, rootElement!, model.targets, keyboardEnabled);
   }
 </script>

--- a/packages/components/src/components/area-chart/area-chart.test.ts
+++ b/packages/components/src/components/area-chart/area-chart.test.ts
@@ -322,4 +322,35 @@ describe('AreaChart', () => {
     await fireEvent.click(getByRole('button', { name: 'Storage' }));
     expect(getByText('No chart data')).toBeTruthy();
   });
+
+  test('Enter key on a role="button" focus target activates it (ARIA button widget contract)', async () => {
+    // ARIA 1.2 §6.6.3: a role="button" element must respond to Enter and Space
+    // by dispatching a click. This test verifies Enter triggers the same click
+    // event that pointer interaction would, keeping the keyboard-accessible path parity.
+    let clickCount = 0;
+    const { getByRole } = render(AreaChart, { label: 'Usage trend', series });
+    const target = getByRole('button', { name: 'Usage, Jan, 30' });
+    target.addEventListener('click', () => {
+      clickCount++;
+    });
+
+    await fireEvent.focus(target);
+    await fireEvent.keyDown(target, { key: 'Enter' });
+
+    expect(clickCount).toBe(1);
+  });
+
+  test('Space key on a role="button" focus target activates it (ARIA button widget contract)', async () => {
+    let clickCount = 0;
+    const { getByRole } = render(AreaChart, { label: 'Usage trend', series });
+    const target = getByRole('button', { name: 'Usage, Jan, 30' });
+    target.addEventListener('click', () => {
+      clickCount++;
+    });
+
+    await fireEvent.focus(target);
+    await fireEvent.keyDown(target, { key: ' ' });
+
+    expect(clickCount).toBe(1);
+  });
 });

--- a/packages/components/src/components/area-chart/area-chart.test.ts
+++ b/packages/components/src/components/area-chart/area-chart.test.ts
@@ -322,35 +322,4 @@ describe('AreaChart', () => {
     await fireEvent.click(getByRole('button', { name: 'Storage' }));
     expect(getByText('No chart data')).toBeTruthy();
   });
-
-  test('Enter key on a role="button" focus target activates it (ARIA button widget contract)', async () => {
-    // ARIA 1.2 §6.6.3: a role="button" element must respond to Enter and Space
-    // by dispatching a click. This test verifies Enter triggers the same click
-    // event that pointer interaction would, keeping the keyboard-accessible path parity.
-    let clickCount = 0;
-    const { getByRole } = render(AreaChart, { label: 'Usage trend', series });
-    const target = getByRole('button', { name: 'Usage, Jan, 30' });
-    target.addEventListener('click', () => {
-      clickCount++;
-    });
-
-    await fireEvent.focus(target);
-    await fireEvent.keyDown(target, { key: 'Enter' });
-
-    expect(clickCount).toBe(1);
-  });
-
-  test('Space key on a role="button" focus target activates it (ARIA button widget contract)', async () => {
-    let clickCount = 0;
-    const { getByRole } = render(AreaChart, { label: 'Usage trend', series });
-    const target = getByRole('button', { name: 'Usage, Jan, 30' });
-    target.addEventListener('click', () => {
-      clickCount++;
-    });
-
-    await fireEvent.focus(target);
-    await fireEvent.keyDown(target, { key: ' ' });
-
-    expect(clickCount).toBe(1);
-  });
 });

--- a/packages/components/src/components/avatar-group/avatar-group.svelte
+++ b/packages/components/src/components/avatar-group/avatar-group.svelte
@@ -36,10 +36,17 @@
     shape = 'circle',
     overflowLabel,
     label = 'Collaborators',
+    'aria-label': consumerAriaLabel,
     class: className,
     style,
     ...rest
   }: AvatarGroupProps = $props();
+
+  // A consumer-provided `aria-label` wins over the `label` default; destructuring
+  // it out of `rest` (rather than letting `{...rest}` spread it) lets us resolve
+  // the accessible name explicitly instead of having the hard-coded default
+  // silently clobber it after the spread.
+  const accessibleName = $derived(consumerAriaLabel ?? label);
 
   const normalizedMaxVisible = $derived(normalizeMaxVisible(maxVisible));
   const visibleCount = $derived(Math.min(normalizedMaxVisible, avatars.length));
@@ -122,7 +129,7 @@
   class={classNames('cinder-avatar-group', className)}
   style={rootStyle}
   role="list"
-  aria-label={label}
+  aria-label={accessibleName}
   data-cinder-size={size}
   data-cinder-shape={shape}
   data-cinder-z-order={zOrder}

--- a/packages/components/src/components/avatar-group/avatar-group.svelte
+++ b/packages/components/src/components/avatar-group/avatar-group.svelte
@@ -35,6 +35,7 @@
     size = 'md',
     shape = 'circle',
     overflowLabel,
+    label = 'Collaborators',
     class: className,
     style,
     ...rest
@@ -121,6 +122,7 @@
   class={classNames('cinder-avatar-group', className)}
   style={rootStyle}
   role="list"
+  aria-label={label}
   data-cinder-size={size}
   data-cinder-shape={shape}
   data-cinder-z-order={zOrder}

--- a/packages/components/src/components/avatar-group/avatar-group.svelte
+++ b/packages/components/src/components/avatar-group/avatar-group.svelte
@@ -45,8 +45,15 @@
   // A consumer-provided `aria-label` wins over the `label` default; destructuring
   // it out of `rest` (rather than letting `{...rest}` spread it) lets us resolve
   // the accessible name explicitly instead of having the hard-coded default
-  // silently clobber it after the spread.
-  const accessibleName = $derived(consumerAriaLabel ?? label);
+  // silently clobber it after the spread. An empty or whitespace-only
+  // `aria-label` is treated as absent (rendering `aria-label=""` would suppress
+  // the accessible-name computation per ARIA §4.3.2 without naming the region),
+  // so it falls back to `label` rather than producing a nameless `role="list"`.
+  const accessibleName = $derived(
+    typeof consumerAriaLabel === 'string' && consumerAriaLabel.trim().length > 0
+      ? consumerAriaLabel
+      : label,
+  );
 
   const normalizedMaxVisible = $derived(normalizeMaxVisible(maxVisible));
   const visibleCount = $derived(Math.min(normalizedMaxVisible, avatars.length));

--- a/packages/components/src/components/avatar-group/avatar-group.test.ts
+++ b/packages/components/src/components/avatar-group/avatar-group.test.ts
@@ -364,3 +364,32 @@ describe('AvatarGroup', () => {
     expect(RootAvatarGroup).toBe(AvatarGroup);
   });
 });
+
+describe('AvatarGroup accessible name', () => {
+  test('root list carries aria-label defaulting to Collaborators', () => {
+    const { container } = render(AvatarGroup, { avatars: collaborators.slice(0, 2) });
+    const list = container.querySelector('[role="list"]');
+    expect(list?.getAttribute('aria-label')).toBe('Collaborators');
+  });
+
+  test('label prop overrides default accessible name', () => {
+    const { container } = render(AvatarGroup, {
+      avatars: collaborators.slice(0, 2),
+      label: 'Team members',
+    });
+    const list = container.querySelector('[role="list"]');
+    expect(list?.getAttribute('aria-label')).toBe('Team members');
+  });
+
+  test('explicit aria-label in rest is overridden by the label prop default', () => {
+    // Because aria-label={label} comes AFTER {...rest} in the markup, the
+    // explicit label prop always wins. Consumers must use label= to customize.
+    const { container } = render(AvatarGroup, {
+      avatars: collaborators.slice(0, 1),
+      'aria-label': 'Override attempt',
+    });
+    const list = container.querySelector('[role="list"]');
+    // label defaults to 'Collaborators', which overrides the rest spread
+    expect(list?.getAttribute('aria-label')).toBe('Collaborators');
+  });
+});

--- a/packages/components/src/components/avatar-group/avatar-group.test.ts
+++ b/packages/components/src/components/avatar-group/avatar-group.test.ts
@@ -381,15 +381,27 @@ describe('AvatarGroup accessible name', () => {
     expect(list?.getAttribute('aria-label')).toBe('Team members');
   });
 
-  test('explicit aria-label in rest is overridden by the label prop default', () => {
-    // Because aria-label={label} comes AFTER {...rest} in the markup, the
-    // explicit label prop always wins. Consumers must use label= to customize.
+  test('an explicit consumer aria-label wins over the label default', () => {
+    // ARIA passthrough must work: a consumer-provided aria-label is the
+    // accessible name, not silently clobbered by the 'Collaborators' default.
     const { container } = render(AvatarGroup, {
       avatars: collaborators.slice(0, 1),
-      'aria-label': 'Override attempt',
+      'aria-label': 'Project team',
     });
     const list = container.querySelector('[role="list"]');
-    // label defaults to 'Collaborators', which overrides the rest spread
-    expect(list?.getAttribute('aria-label')).toBe('Collaborators');
+    expect(list?.getAttribute('aria-label')).toBe('Project team');
+  });
+
+  test('an explicit aria-label also wins over an explicit label prop', () => {
+    // When both are supplied, the consumer's raw ARIA value takes precedence —
+    // aria-label is the lower-level escape hatch and should not be overridable
+    // by the component's higher-level `label` convenience prop.
+    const { container } = render(AvatarGroup, {
+      avatars: collaborators.slice(0, 1),
+      label: 'Team members',
+      'aria-label': 'Project team',
+    });
+    const list = container.querySelector('[role="list"]');
+    expect(list?.getAttribute('aria-label')).toBe('Project team');
   });
 });

--- a/packages/components/src/components/avatar-group/avatar-group.test.ts
+++ b/packages/components/src/components/avatar-group/avatar-group.test.ts
@@ -404,4 +404,27 @@ describe('AvatarGroup accessible name', () => {
     const list = container.querySelector('[role="list"]');
     expect(list?.getAttribute('aria-label')).toBe('Project team');
   });
+
+  // Regression: an empty or whitespace-only consumer aria-label must be treated
+  // as absent and fall back to `label`. Rendering aria-label="" suppresses the
+  // accessible-name computation (ARIA §4.3.2) without naming the region, leaving
+  // a nameless role="list".
+  test('an empty or whitespace-only aria-label falls back to the label', () => {
+    const empty = render(AvatarGroup, {
+      avatars: collaborators.slice(0, 1),
+      'aria-label': '',
+    });
+    expect(empty.container.querySelector('[role="list"]')?.getAttribute('aria-label')).toBe(
+      'Collaborators',
+    );
+
+    const whitespace = render(AvatarGroup, {
+      avatars: collaborators.slice(0, 1),
+      label: 'Team members',
+      'aria-label': '   ',
+    });
+    expect(whitespace.container.querySelector('[role="list"]')?.getAttribute('aria-label')).toBe(
+      'Team members',
+    );
+  });
 });

--- a/packages/components/src/components/avatar-group/avatar-group.types.ts
+++ b/packages/components/src/components/avatar-group/avatar-group.types.ts
@@ -21,6 +21,11 @@ export type AvatarGroupProps = AvatarGroupRootAttributes & {
   /** Collaborators to render in the stack. */
   avatars: AvatarGroupItem[];
   /**
+   * Accessible name for the avatar stack list.
+   * @default "Collaborators"
+   */
+  label?: string;
+  /**
    * Maximum visible avatars before overflow.
    * @default 5
    */
@@ -55,6 +60,11 @@ export type AvatarGroupProps = AvatarGroupRootAttributes & {
 export interface AvatarGroupSchemaProps {
   /** Collaborators to render in the stack. */
   avatars: AvatarGroupItem[];
+  /**
+   * Accessible name for the avatar stack list.
+   * @default "Collaborators"
+   */
+  label?: string;
   /**
    * Maximum visible avatars before overflow.
    * @default 5

--- a/packages/components/src/components/avatar/avatar.css
+++ b/packages/components/src/components/avatar/avatar.css
@@ -11,6 +11,7 @@
     justify-content: center;
     overflow: hidden;
     background: var(--cinder-surface-inset);
+    border: 1px solid var(--cinder-border-muted);
     color: var(--cinder-text-muted);
     font-weight: var(--cinder-font-medium);
     user-select: none;

--- a/packages/components/src/components/badge/badge.css
+++ b/packages/components/src/components/badge/badge.css
@@ -48,7 +48,7 @@
  * ---------------------------------------- */
 
   .cinder-badge[data-cinder-variant='neutral'] {
-    background: var(--cinder-surface-inset);
+    background: color-mix(in oklch, var(--cinder-surface-inset), var(--cinder-surface) 40%);
     color: var(--cinder-text);
     border-color: var(--cinder-border);
   }

--- a/packages/components/src/components/bar-chart/bar-chart.css
+++ b/packages/components/src/components/bar-chart/bar-chart.css
@@ -56,6 +56,10 @@
     rx: 3;
   }
 
+  .cinder-bar-chart__bar[data-cinder-active] {
+    filter: brightness(1.15);
+  }
+
   .cinder-bar-chart__crosshair {
     stroke: var(--cinder-text-muted);
     stroke-dasharray: 4 4;

--- a/packages/components/src/components/bar-chart/bar-chart.svelte
+++ b/packages/components/src/components/bar-chart/bar-chart.svelte
@@ -165,15 +165,6 @@
 
   function handleTargetKeydown(event: KeyboardEvent): void {
     rememberKeyboardFocusModality(event);
-    // Enter and Space activate the focused data point — a role="button" element
-    // must respond to these keys per ARIA 1.2 §6.6.3 (button widget).
-    if (event.key === 'Enter' || event.key === ' ') {
-      event.preventDefault();
-      if (event.currentTarget instanceof Element) {
-        event.currentTarget.dispatchEvent(new MouseEvent('click', { bubbles: true }));
-      }
-      return;
-    }
     interaction.activateByKeyboard(event, rootElement!, model.targets, keyboardEnabled);
   }
 </script>

--- a/packages/components/src/components/bar-chart/bar-chart.svelte
+++ b/packages/components/src/components/bar-chart/bar-chart.svelte
@@ -165,6 +165,15 @@
 
   function handleTargetKeydown(event: KeyboardEvent): void {
     rememberKeyboardFocusModality(event);
+    // Enter and Space activate the focused data point — a role="button" element
+    // must respond to these keys per ARIA 1.2 §6.6.3 (button widget).
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault();
+      if (event.currentTarget instanceof Element) {
+        event.currentTarget.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      }
+      return;
+    }
     interaction.activateByKeyboard(event, rootElement!, model.targets, keyboardEnabled);
   }
 </script>
@@ -260,6 +269,10 @@
             aria-hidden="true"
             data-cinder-series={bar.seriesId}
             data-cinder-category={bar.categoryLabel}
+            data-cinder-active={interaction.activeTarget?.seriesId === bar.seriesId &&
+            interaction.activeTarget?.xLabel === bar.categoryLabel
+              ? ''
+              : undefined}
           />
         {/each}
         {#each model.categoryTicks as tick (tick.categoryKey)}

--- a/packages/components/src/components/bar-chart/bar-chart.test.ts
+++ b/packages/components/src/components/bar-chart/bar-chart.test.ts
@@ -441,4 +441,74 @@ describe('BarChart', () => {
     expect(container.querySelector('table')?.textContent).toContain('30');
     expect(tableCellText).not.toContain('Revenue');
   });
+
+  test('Enter key on a role="button" focus target activates it (ARIA button widget contract)', async () => {
+    // ARIA 1.2 §6.6.3: a role="button" element must respond to Enter and Space.
+    let clickCount = 0;
+    const { getByRole } = render(BarChart, {
+      label: 'Revenue by month',
+      data,
+      categoryKey: 'month',
+      series,
+    });
+    const target = getByRole('button', { name: 'Revenue, Jan, 120' });
+    target.addEventListener('click', () => {
+      clickCount++;
+    });
+
+    await fireEvent.focus(target);
+    await fireEvent.keyDown(target, { key: 'Enter' });
+
+    expect(clickCount).toBe(1);
+  });
+
+  test('Space key on a role="button" focus target activates it (ARIA button widget contract)', async () => {
+    let clickCount = 0;
+    const { getByRole } = render(BarChart, {
+      label: 'Revenue by month',
+      data,
+      categoryKey: 'month',
+      series,
+    });
+    const target = getByRole('button', { name: 'Revenue, Jan, 120' });
+    target.addEventListener('click', () => {
+      clickCount++;
+    });
+
+    await fireEvent.focus(target);
+    await fireEvent.keyDown(target, { key: ' ' });
+
+    expect(clickCount).toBe(1);
+  });
+
+  test('hovered bar gets data-cinder-active attribute for CSS hover engagement', async () => {
+    const { container, getByRole } = render(BarChart, {
+      label: 'Revenue by month',
+      data,
+      categoryKey: 'month',
+      series,
+    });
+
+    // Before hover: no bar has data-cinder-active.
+    expect(container.querySelector('.cinder-bar-chart__bar[data-cinder-active]')).toBeNull();
+
+    // Focus a target to set activeTarget via the keyboard path (no pointer move needed).
+    const target = getByRole('button', { name: 'Revenue, Jan, 120' });
+    await fireEvent.focus(target);
+
+    // The Revenue Jan bar should now be data-cinder-active.
+    const activeBar = container.querySelector('.cinder-bar-chart__bar[data-cinder-active]');
+    expect(activeBar).not.toBeNull();
+    expect(activeBar?.getAttribute('data-cinder-series')).toBe('revenue');
+    expect(activeBar?.getAttribute('data-cinder-category')).toBe('Jan');
+
+    // After blur, the active bar should clear.
+    await fireEvent.blur(target);
+    expect(container.querySelector('.cinder-bar-chart__bar[data-cinder-active]')).toBeNull();
+  });
+
+  test('bar-chart CSS has a rule for data-cinder-active bars', async () => {
+    const cssText = await Bun.file(new URL('./bar-chart.css', import.meta.url)).text();
+    expect(cssText).toContain('.cinder-bar-chart__bar[data-cinder-active]');
+  });
 });

--- a/packages/components/src/components/bar-chart/bar-chart.test.ts
+++ b/packages/components/src/components/bar-chart/bar-chart.test.ts
@@ -442,45 +442,6 @@ describe('BarChart', () => {
     expect(tableCellText).not.toContain('Revenue');
   });
 
-  test('Enter key on a role="button" focus target activates it (ARIA button widget contract)', async () => {
-    // ARIA 1.2 §6.6.3: a role="button" element must respond to Enter and Space.
-    let clickCount = 0;
-    const { getByRole } = render(BarChart, {
-      label: 'Revenue by month',
-      data,
-      categoryKey: 'month',
-      series,
-    });
-    const target = getByRole('button', { name: 'Revenue, Jan, 120' });
-    target.addEventListener('click', () => {
-      clickCount++;
-    });
-
-    await fireEvent.focus(target);
-    await fireEvent.keyDown(target, { key: 'Enter' });
-
-    expect(clickCount).toBe(1);
-  });
-
-  test('Space key on a role="button" focus target activates it (ARIA button widget contract)', async () => {
-    let clickCount = 0;
-    const { getByRole } = render(BarChart, {
-      label: 'Revenue by month',
-      data,
-      categoryKey: 'month',
-      series,
-    });
-    const target = getByRole('button', { name: 'Revenue, Jan, 120' });
-    target.addEventListener('click', () => {
-      clickCount++;
-    });
-
-    await fireEvent.focus(target);
-    await fireEvent.keyDown(target, { key: ' ' });
-
-    expect(clickCount).toBe(1);
-  });
-
   test('hovered bar gets data-cinder-active attribute for CSS hover engagement', async () => {
     const { container, getByRole } = render(BarChart, {
       label: 'Revenue by month',

--- a/packages/components/src/components/button/button.css
+++ b/packages/components/src/components/button/button.css
@@ -235,6 +235,13 @@
 
   .cinder-button[data-cinder-variant='ghost'] {
     background: transparent;
+    /* --cinder-text-muted is intentional for the ghost variant — it reads as
+     * intentionally de-emphasised (visually secondary to primary/secondary actions)
+     * while still meeting WCAG 1.4.3 AA (4.5:1) against the typical page surfaces
+     * in both themes: light-dark oklch(32% 0.014 245 / 82% 0.02 245) clears 4.5:1
+     * against --cinder-surface (L≈98.5%/20%) and --cinder-surface-raised (L≈100%/26%).
+     * Switching to --cinder-text (L≈20%/92%) would meet a higher bar but remove
+     * the visual hierarchy distinction from secondary buttons. */
     color: var(--cinder-text-muted);
     border-color: transparent;
   }

--- a/packages/components/src/components/capability-gate/capability-gate.css
+++ b/packages/components/src/components/capability-gate/capability-gate.css
@@ -125,7 +125,10 @@
     margin-inline-start: auto;
   }
 
-  .cinder-capability-gate__dismiss:hover {
-    color: var(--cinder-text);
+  @media (hover: hover) {
+    .cinder-capability-gate__dismiss:hover {
+      background-color: var(--cinder-surface-hover);
+      color: var(--cinder-text);
+    }
   }
 }

--- a/packages/components/src/components/chip/chip.svelte
+++ b/packages/components/src/components/chip/chip.svelte
@@ -111,6 +111,16 @@
     }
     return result;
   });
+
+  // A bare `role="group"` needs an accessible name, so removable mode names the
+  // group with its `label` by default. But `aria-label` flows through `rest` for
+  // display/removable modes (see above), so a consumer-supplied `aria-label`
+  // must win. Resolve to the consumer's value when present, falling back to
+  // `label` — and apply it explicitly so it can't be clobbered by the spread.
+  const removableAriaLabel = $derived.by(() => {
+    const forwarded = rest['aria-label'];
+    return typeof forwarded === 'string' && forwarded.trim().length > 0 ? forwarded : label;
+  });
 </script>
 
 {#if mode === 'toggle'}
@@ -142,7 +152,7 @@
   <span
     {...rest}
     role="group"
-    aria-label={label}
+    aria-label={removableAriaLabel}
     data-cinder-mode="removable"
     data-cinder-variant={variant}
     data-cinder-size={size}

--- a/packages/components/src/components/chip/chip.svelte
+++ b/packages/components/src/components/chip/chip.svelte
@@ -141,6 +141,8 @@
 {:else if mode === 'removable'}
   <span
     {...rest}
+    role="group"
+    aria-label={label}
     data-cinder-mode="removable"
     data-cinder-variant={variant}
     data-cinder-size={size}

--- a/packages/components/src/components/chip/chip.test.ts
+++ b/packages/components/src/components/chip/chip.test.ts
@@ -451,6 +451,23 @@ describe('Chip', () => {
   });
 });
 
+describe('Chip removable mode ARIA group', () => {
+  test('outer span carries role=group and aria-label matching the label prop', () => {
+    const { container } = render(Chip, { mode: 'removable', label: 'JavaScript' });
+    const root = container.querySelector('[role="group"]');
+    expect(root).not.toBeNull();
+    expect(root?.tagName.toLowerCase()).toBe('span');
+    expect(root?.getAttribute('aria-label')).toBe('JavaScript');
+  });
+
+  test('group aria-label matches the label prop value', () => {
+    const { container } = render(Chip, { mode: 'removable', label: 'TypeScript' });
+    const root = container.querySelector('span.cinder-chip');
+    expect(root?.getAttribute('role')).toBe('group');
+    expect(root?.getAttribute('aria-label')).toBe('TypeScript');
+  });
+});
+
 // Source-level guard for the disabled-chip contrast fix. The disabled label must
 // resolve to --cinder-text-disabled (4.61:1 on --cinder-surface-inset) AND must
 // not be trapped under a parent `opacity` that would composite it down — opacity

--- a/packages/components/src/components/chip/chip.test.ts
+++ b/packages/components/src/components/chip/chip.test.ts
@@ -164,6 +164,27 @@ describe('Chip', () => {
     expect(removeBtn?.getAttribute('aria-label')).toBe('Remove JavaScript');
   });
 
+  test('removable mode names its role="group" with the label by default', () => {
+    const { container } = render(Chip, { mode: 'removable', label: 'JavaScript' });
+    const chip = container.querySelector('.cinder-chip');
+    expect(chip?.getAttribute('role')).toBe('group');
+    expect(chip?.getAttribute('aria-label')).toBe('JavaScript');
+  });
+
+  // Regression: removable mode forwards `aria-label` through `rest` (it is not a
+  // bespoke key). A consumer-supplied `aria-label` must win over the default
+  // `label`-derived group name — an explicit `aria-label={label}` after the
+  // spread silently clobbered it.
+  test('removable mode lets a consumer-supplied aria-label override the default group name', () => {
+    const { container } = render(Chip, {
+      mode: 'removable',
+      label: 'JavaScript',
+      'aria-label': 'Programming language: JavaScript',
+    });
+    const chip = container.querySelector('.cinder-chip');
+    expect(chip?.getAttribute('aria-label')).toBe('Programming language: JavaScript');
+  });
+
   test('all modes share the same root class without mode-specific surface classes', () => {
     const display = render(Chip, { label: 'Display chip' });
     const toggle = render(Chip, { mode: 'toggle', label: 'Toggle chip', pressed: false });

--- a/packages/components/src/components/click-away-listener/click-away-listener.test.ts
+++ b/packages/components/src/components/click-away-listener/click-away-listener.test.ts
@@ -227,6 +227,11 @@ describe('ClickAwayListener — TouchEvent-undefined regression', () => {
   // Window object installed on globalThis. We need to shadow it there.
   const win = (g['window'] ?? g) as Record<string, unknown>;
 
+  // Save originals before any override so afterEach can restore exactly.
+  const originalPointerEventWin = win['PointerEvent'];
+  const originalPointerEventG = g['PointerEvent'];
+  const originalTouchEventG = g['TouchEvent'];
+
   beforeEach(() => {
     // Override PointerEvent on both globalThis and the window object to force
     // the mousedown+touchstart fallback path.
@@ -248,24 +253,25 @@ describe('ClickAwayListener — TouchEvent-undefined regression', () => {
   });
 
   afterEach(() => {
-    // happy-dom restores its own globals; just remove our overrides.
-    // Deletion restores the prototype-chain value, which is sufficient for
-    // happy-dom's own property defined via defineProperty on the Window ctor.
-    try {
-      delete win['PointerEvent'];
-    } catch {
-      /* non-configurable in some environments — ignore */
-    }
-    try {
-      delete g['PointerEvent'];
-    } catch {
-      /* non-configurable in some environments — ignore */
-    }
-    try {
-      delete g['TouchEvent'];
-    } catch {
-      /* non-configurable in some environments — ignore */
-    }
+    // Restore the saved originals so that later test files see the real globals.
+    // Simple `delete` is not sufficient here because we installed own-properties
+    // via Object.defineProperty on globalThis itself (not on a prototype), so
+    // deleting the own-property leaves the name unresolvable in subsequent files.
+    Object.defineProperty(win, 'PointerEvent', {
+      value: originalPointerEventWin,
+      configurable: true,
+      writable: true,
+    });
+    Object.defineProperty(g, 'PointerEvent', {
+      value: originalPointerEventG,
+      configurable: true,
+      writable: true,
+    });
+    Object.defineProperty(g, 'TouchEvent', {
+      value: originalTouchEventG,
+      configurable: true,
+      writable: true,
+    });
     cleanup();
     document.body.replaceChildren();
   });

--- a/packages/components/src/components/code-block/code-block.css
+++ b/packages/components/src/components/code-block/code-block.css
@@ -168,6 +168,27 @@
     overflow-x: auto;
   }
 
+  /* .cinder-code-block has `overflow: hidden`, so an OUTSET ring from the
+   * foundation.css :focus-visible fallback is clipped to the top edge only.
+   * Use Strategy B-inset: single-band inset box-shadow contained within the
+   * element's own border box so the parent overflow can never clip it.
+   * tabindex="0" is set in code-block.svelte on this div (highlighted variant)
+   * and on .cinder-code-block__pre (plain variant). */
+  .cinder-code-block__highlighted:focus-visible,
+  .cinder-code-block__pre:focus-visible {
+    outline: var(--cinder-ring-width) solid transparent;
+    box-shadow: inset 0 0 0 var(--cinder-ring-width) var(--cinder-ring-color);
+  }
+
+  @media (forced-colors: active) {
+    .cinder-code-block__highlighted:focus-visible,
+    .cinder-code-block__pre:focus-visible {
+      outline: var(--cinder-ring-width) solid ButtonText;
+      outline-offset: calc(var(--cinder-ring-width) * -1);
+      box-shadow: none;
+    }
+  }
+
   /* The shiki <pre> must NOT own a scroll port — the parent
    .cinder-code-block__highlighted is the single keyboard-reachable scroll
    region (axe scrollable-region-focusable wants one, not a nested pair). But it

--- a/packages/components/src/components/code-block/code-block.svelte
+++ b/packages/components/src/components/code-block/code-block.svelte
@@ -127,7 +127,17 @@
            so there is exactly one focusable scroll region. No role="region":
            a landmark per code block would flood landmark navigation with
            identically-named "Code" regions on docs pages with many snippets —
-           tabindex alone satisfies the keyboard-scroll requirement. -->
+           tabindex alone satisfies the keyboard-scroll requirement.
+
+           The tabindex is UNCONDITIONAL on purpose (see #380). Making it
+           conditional on actual overflow (scrollWidth > clientWidth) would drop
+           the empty tab stop on short, non-overflowing snippets — but any
+           "start non-focusable, add tabindex after measuring" scheme races
+           font-load reflow and hydration: an overflowing block could be briefly
+           keyboard-unreachable, a hard WCAG 2.1.1 failure. axe only flags
+           scrollable-region-focusable on elements that actually scroll, so the
+           always-on tabindex adds NO axe exposure on short blocks. An extra tab
+           stop on a short snippet is the lesser failure mode; keep it always-on. -->
       <div class="cinder-code-block__highlighted" tabindex="0">
         {@html highlighted}
       </div>

--- a/packages/components/src/components/code-block/code-block.test.ts
+++ b/packages/components/src/components/code-block/code-block.test.ts
@@ -128,6 +128,27 @@ describe('CodeBlock — static structure', () => {
     const css = await Bun.file(new URL('./code-block.css', import.meta.url)).text();
     expect(css).toContain('@media (prefers-color-scheme: dark)');
   });
+
+  test('highlighted and plain scroll containers carry inset focus ring (regression #398)', async () => {
+    // .cinder-code-block has overflow:hidden, so the standard outset focus ring is
+    // clipped. The fix adds an INSET box-shadow ring to both focusable scroll
+    // containers. This test locks that pattern so it cannot silently regress.
+    const css = await Bun.file(new URL('./code-block.css', import.meta.url)).text();
+    // Both selectors must appear together in a combined rule.
+    expect(css).toContain('.cinder-code-block__highlighted:focus-visible');
+    expect(css).toContain('.cinder-code-block__pre:focus-visible');
+    // The rule must use an inset box-shadow (not an outset ring that would be clipped).
+    expect(css).toMatch(
+      /\.cinder-code-block__highlighted:focus-visible[\s\S]*?box-shadow:\s*inset\s+0\s+0\s+0\s+var\(--cinder-ring-width\)\s+var\(--cinder-ring-color\)/,
+    );
+    expect(css).toMatch(
+      /\.cinder-code-block__pre:focus-visible[\s\S]*?box-shadow:\s*inset\s+0\s+0\s+0\s+var\(--cinder-ring-width\)\s+var\(--cinder-ring-color\)/,
+    );
+    // The outline must be set to transparent so the inset shadow is the visible ring.
+    expect(css).toMatch(
+      /\.cinder-code-block__highlighted:focus-visible[\s\S]*?outline:\s*var\(--cinder-ring-width\)\s+solid\s+transparent/,
+    );
+  });
 });
 
 describe('CodeBlock — automatic highlighting (bundled default)', () => {

--- a/packages/components/src/components/code-block/code-block.test.ts
+++ b/packages/components/src/components/code-block/code-block.test.ts
@@ -23,7 +23,7 @@ mock.module('./code-block-default-highlighter.ts', () => ({
   loadDefaultHighlighter,
 }));
 
-const { render, waitFor } = await import('@testing-library/svelte');
+const { cleanup, render, waitFor } = await import('@testing-library/svelte');
 const { default: CodeBlock } = await import('./code-block.svelte');
 
 // CodeBlock emits a dev warning when a highlighter throws / fails to load (it
@@ -40,6 +40,12 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  // Unmount rendered components BEFORE the warning assertion: component teardown
+  // may emit console.warn, so cleanup must run while warnSpy is still installed.
+  // @testing-library/svelte v5's auto-cleanup does not register under bun:test, so
+  // without this the mounted code blocks leak into the shared happy-dom
+  // document.body and later sibling files (e.g. copy-button) see duplicate elements.
+  cleanup();
   const unexpected = warnSpy.mock.calls
     .map((args) => args.map(String).join(' '))
     .filter((message) => !message.includes(KNOWN_CODE_BLOCK_WARNING));

--- a/packages/components/src/components/combobox/combobox.svelte
+++ b/packages/components/src/components/combobox/combobox.svelte
@@ -25,6 +25,7 @@
     describeId,
     errorId as buildErrorId,
   } from '../../_internal/field-control.ts';
+  import { pushEscapeHandler } from '../../_internal/overlay.ts';
   import { classNames } from '../../utilities/class-names.ts';
   import Popover from '../popover/popover.svelte';
 
@@ -109,6 +110,41 @@
     }
   });
 
+  // Escape ownership.
+  //
+  // The combobox is the single Escape owner for the whole time it is open. The
+  // option Popover is told `closeOnEscape={false}`, so it never registers its
+  // own escape-stack handler — otherwise, while options are visible, the
+  // Popover's handler would sit on top of the shared LIFO stack and shadow this
+  // one. With the Popover opting out, this combobox's handler is the top-most
+  // Escape consumer for the entire open session, including the empty-filter gap
+  // (`open && filteredOptions.length === 0`) where the Popover is unmounted.
+  //
+  // That matters most when the combobox is nested inside a Modal/Sheet: the
+  // shared escape stack's window listener is capture-phase and invokes ONLY its
+  // top handler, so this combobox consumes Escape and `preventDefault()`s it
+  // before the parent overlay ever sees the key — Escape dismisses just the
+  // combobox, never the enclosing overlay.
+  function handleEscape(event?: KeyboardEvent): void {
+    const wasOpen = open;
+    open = false;
+    // Restore the committed label whenever the live text drifted from it.
+    if (inputValue !== committedLabel) {
+      inputValue = committedLabel;
+      if (inputElement) inputElement.value = committedLabel;
+    }
+    // Swallow the key if the combobox actually consumed this Escape (it was
+    // open) so the same keystroke doesn't also dismiss an enclosing overlay or
+    // trigger a page-level default.
+    if (wasOpen) event?.preventDefault();
+  }
+
+  $effect(() => {
+    if (!open) return;
+    const releaseEscape = pushEscapeHandler(handleEscape);
+    return releaseEscape;
+  });
+
   const activeOptionId = $derived(
     activeIndex >= 0 && activeIndex < filteredOptions.length
       ? `${id}-option-${activeIndex}`
@@ -169,21 +205,14 @@
         selectOption(option);
       }
     } else if (event.key === 'Escape') {
-      // Close the dropdown directly. When the Popover is rendered, its
-      // capture-phase escape-stack handler already set open = false before this
-      // handler runs; this assignment is then an idempotent no-op. But the
-      // Popover only mounts while there are filtered options to show, so an open
-      // combobox whose input filtered every option away (open && filtered === 0)
-      // has NO escape handler on the stack — without this line Escape would
-      // leave it stuck open.
-      open = false;
-      // Restore inputValue unconditionally when Escape is pressed while the
-      // input is focused, regardless of whether open was still true.
-      if (inputValue !== committedLabel) {
-        event.preventDefault();
-        inputValue = committedLabel;
-        if (inputElement) inputElement.value = committedLabel;
-      }
+      // Fallback path. In a real browser the capture-phase escape-stack listener
+      // (installed by the $effect's pushEscapeHandler) runs first and has
+      // already closed + restored + preventDefault'd; `defaultPrevented` is true
+      // here and we bail. This branch only does real work when the stack
+      // listener never ran — SSR/no-window environments where `window` is
+      // absent so `pushEscapeHandler` installed nothing.
+      if (event.defaultPrevented) return;
+      handleEscape(event);
     }
   }
 </script>
@@ -229,6 +258,7 @@
       role="listbox"
       focusManagement="preserve"
       wireTriggerAria={false}
+      closeOnEscape={false}
       widthMode="match-anchor"
       class="cinder-combobox__panel"
     >

--- a/packages/components/src/components/combobox/combobox.svelte
+++ b/packages/components/src/components/combobox/combobox.svelte
@@ -75,6 +75,7 @@
   let activeIndex = $state(-1);
   let inputElement = $state<HTMLInputElement | null>(null);
   let listboxElement = $state<HTMLElement | null>(null);
+  let committedLabel = $state('');
 
   // Reset active index whenever the filtered set changes so we don't point
   // at a stale option.
@@ -92,11 +93,13 @@
       // Clearing the value (deselect/reset) must also clear the visible text;
       // otherwise the input keeps showing the previously selected option's label.
       if (untrack(() => inputValue)) inputValue = '';
+      committedLabel = '';
       return;
     }
     const matched = options.find((option) => option.value === value);
     if (matched && untrack(() => inputValue) !== matched.label) {
       inputValue = matched.label;
+      committedLabel = matched.label;
     }
   });
 
@@ -130,6 +133,7 @@
     if (option.disabled) return;
     value = option.value;
     inputValue = option.label;
+    committedLabel = option.label;
     open = false;
   }
 
@@ -159,9 +163,14 @@
         selectOption(option);
       }
     } else if (event.key === 'Escape') {
-      if (open) {
+      // The Popover's escape-stack handler already closed the dropdown (set
+      // open = false) before this keydown handler runs (capture-phase listener
+      // fires first). Restore inputValue unconditionally when Escape is pressed
+      // while the input is focused, regardless of whether open is still true.
+      if (inputValue !== committedLabel) {
         event.preventDefault();
-        open = false;
+        inputValue = committedLabel;
+        if (inputElement) inputElement.value = committedLabel;
       }
     }
   }

--- a/packages/components/src/components/combobox/combobox.svelte
+++ b/packages/components/src/components/combobox/combobox.svelte
@@ -169,6 +169,13 @@
     const next = event.relatedTarget as Node | null;
     if (next && listboxElement?.contains(next)) return;
     open = false;
+    // Restore the committed label if the live text drifted from it. Leaving the
+    // field on a stale edit (without selecting an option) would desync the
+    // visible text from the unchanged `value` — the same mismatch Escape fixes.
+    if (inputValue !== committedLabel) {
+      inputValue = committedLabel;
+      if (inputElement) inputElement.value = committedLabel;
+    }
   }
 
   function selectOption(option: ComboboxOption<T>) {

--- a/packages/components/src/components/combobox/combobox.svelte
+++ b/packages/components/src/components/combobox/combobox.svelte
@@ -97,9 +97,15 @@
       return;
     }
     const matched = options.find((option) => option.value === value);
-    if (matched && untrack(() => inputValue) !== matched.label) {
-      inputValue = matched.label;
+    if (matched) {
+      // `committedLabel` tracks the committed `value`'s label and must stay in
+      // sync whenever a match exists — even when `inputValue` already shows that
+      // label. Gating it behind the `inputValue !== matched.label` check left
+      // `committedLabel` stale (''), so a later Escape restored to empty text.
       committedLabel = matched.label;
+      if (untrack(() => inputValue) !== matched.label) {
+        inputValue = matched.label;
+      }
     }
   });
 
@@ -163,10 +169,16 @@
         selectOption(option);
       }
     } else if (event.key === 'Escape') {
-      // The Popover's escape-stack handler already closed the dropdown (set
-      // open = false) before this keydown handler runs (capture-phase listener
-      // fires first). Restore inputValue unconditionally when Escape is pressed
-      // while the input is focused, regardless of whether open is still true.
+      // Close the dropdown directly. When the Popover is rendered, its
+      // capture-phase escape-stack handler already set open = false before this
+      // handler runs; this assignment is then an idempotent no-op. But the
+      // Popover only mounts while there are filtered options to show, so an open
+      // combobox whose input filtered every option away (open && filtered === 0)
+      // has NO escape handler on the stack — without this line Escape would
+      // leave it stuck open.
+      open = false;
+      // Restore inputValue unconditionally when Escape is pressed while the
+      // input is focused, regardless of whether open was still true.
       if (inputValue !== committedLabel) {
         event.preventDefault();
         inputValue = committedLabel;

--- a/packages/components/src/components/combobox/combobox.test.ts
+++ b/packages/components/src/components/combobox/combobox.test.ts
@@ -2,6 +2,7 @@
 import * as matchers from '@testing-library/jest-dom/matchers';
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
 import { readFileSync } from 'node:fs';
+import { tick } from 'svelte';
 
 import { stripCinderComponentsLayer } from '../../test/css.ts';
 import { setupHappyDom } from '../../test/happy-dom.ts';
@@ -507,5 +508,56 @@ describe('Combobox rich option rows', () => {
         'Banana',
       );
     });
+  });
+});
+
+describe('Combobox Escape restores committed label', () => {
+  const escapeFruits = [
+    { label: 'Apple', value: 'apple' },
+    { label: 'Banana', value: 'banana' },
+    { label: 'Cherry', value: 'cherry' },
+  ];
+
+  test('Escape restores inputValue to the committed option label when the dropdown is open with partial text', async () => {
+    const { container } = render(Combobox, { id: 'escape-test', options: escapeFruits });
+    const input = container.querySelector('#escape-test') as HTMLInputElement;
+
+    // Open the dropdown and select Apple
+    input.focus();
+    await fireEvent.focus(input);
+    await waitFor(() => expect(container.querySelector('[role="listbox"]')).not.toBeNull());
+    const appleOption = await findOption('Apple');
+    await fireEvent.mouseDown(appleOption);
+    await waitFor(() => expect(container.querySelector('[role="listbox"]')).toBeNull());
+    expect(input.value).toBe('Apple');
+
+    // Type partial text to open the dropdown again
+    await fireEvent.input(input, { target: { value: 'ban' } });
+    await waitFor(() => expect(container.querySelector('[role="listbox"]')).not.toBeNull());
+
+    // Press Escape — should restore to committed label 'Apple'
+    await fireEvent.keyDown(input, { key: 'Escape' });
+    await tick();
+    // After Escape, input should show the committed label
+    expect(input.value).toBe('Apple');
+    expect(container.querySelector('[role="listbox"]')).toBeNull();
+  });
+
+  test('Escape clears inputValue when no option has been committed', async () => {
+    const { container } = render(Combobox, { id: 'escape-empty', options: escapeFruits });
+    const input = container.querySelector('#escape-empty') as HTMLInputElement;
+
+    // Type something without selecting to open the dropdown
+    input.focus();
+    await fireEvent.focus(input);
+    await fireEvent.input(input, { target: { value: 'ban' } });
+    await waitFor(() => expect(container.querySelector('[role="listbox"]')).not.toBeNull());
+
+    // Press Escape — should clear since nothing was committed
+    await fireEvent.keyDown(input, { key: 'Escape' });
+    await tick();
+    // input.value should be '' since committedLabel defaults to ''
+    expect(input.value).toBe('');
+    expect(container.querySelector('[role="listbox"]')).toBeNull();
   });
 });

--- a/packages/components/src/components/combobox/combobox.test.ts
+++ b/packages/components/src/components/combobox/combobox.test.ts
@@ -560,4 +560,51 @@ describe('Combobox Escape restores committed label', () => {
     expect(input.value).toBe('');
     expect(container.querySelector('[role="listbox"]')).toBeNull();
   });
+
+  test('Escape restores the label of a value committed via the value prop (no desync)', async () => {
+    // Regression: the value-sync effect set `committedLabel` only when it ALSO
+    // had to change `inputValue`. With value+inputValue pre-supplied to the same
+    // label, `committedLabel` stayed '' and Escape wrongly cleared the input.
+    const { container } = render(Combobox, {
+      id: 'escape-prefilled',
+      options: escapeFruits,
+      value: 'banana',
+      inputValue: 'Banana',
+    });
+    const input = container.querySelector('#escape-prefilled') as HTMLInputElement;
+    await tick();
+    expect(input.value).toBe('Banana');
+
+    // Edit to dirty the input, then Escape — should restore to the committed
+    // label 'Banana', not clear to ''.
+    input.focus();
+    await fireEvent.focus(input);
+    await fireEvent.input(input, { target: { value: 'Ban' } });
+    await waitFor(() => expect(container.querySelector('[role="listbox"]')).not.toBeNull());
+    await fireEvent.keyDown(input, { key: 'Escape' });
+    await tick();
+    expect(input.value).toBe('Banana');
+    expect(container.querySelector('[role="listbox"]')).toBeNull();
+  });
+
+  test('Escape closes an open combobox even when every option is filtered away', async () => {
+    // Regression: when the input filters out all options the Popover does not
+    // mount, so its capture-phase escape-stack handler is absent. Escape must
+    // still close the combobox directly rather than leaving it stuck open.
+    const { container } = render(Combobox, { id: 'escape-no-popover', options: escapeFruits });
+    const input = container.querySelector('#escape-no-popover') as HTMLInputElement;
+
+    input.focus();
+    await fireEvent.focus(input);
+    // Type text matching no option — the empty state activates and the option
+    // Popover (gated on filteredOptions.length > 0) does not render.
+    await fireEvent.input(input, { target: { value: 'zzz' } });
+    await waitForListbox();
+    expect(container.querySelector('.cinder-combobox__empty[data-cinder-active]')).not.toBeNull();
+
+    await fireEvent.keyDown(input, { key: 'Escape' });
+    await tick();
+    // The combobox is closed: the active empty-state marker is gone.
+    expect(container.querySelector('.cinder-combobox__empty[data-cinder-active]')).toBeNull();
+  });
 });

--- a/packages/components/src/components/combobox/combobox.test.ts
+++ b/packages/components/src/components/combobox/combobox.test.ts
@@ -18,6 +18,7 @@ const {
   cleanup,
 } = await import('@testing-library/svelte');
 const { default: Combobox } = await import('./combobox.svelte');
+const { pushEscapeHandler, _resetEscapeStack } = await import('../../_internal/overlay.ts');
 
 // These tests render into the shared `document.body` (see `render` below). The
 // listbox opens on focus through Svelte effects, so options are not guaranteed
@@ -30,7 +31,12 @@ const { default: Combobox } = await import('./combobox.svelte');
 // `replaceChildren()` before each test additionally wipes any listbox nodes a
 // prior test left appended to `document.body` that `cleanup()` doesn't track,
 // so `findOption` can never match a stale option from another test.
-beforeEach(() => document.body.replaceChildren());
+beforeEach(() => {
+  document.body.replaceChildren();
+  // Clear the shared module-level escape stack so a sibling-overlay handler
+  // registered by one test can't leak into the next and skew the LIFO order.
+  _resetEscapeStack();
+});
 afterEach(() => cleanup());
 
 const fruits = [
@@ -606,5 +612,53 @@ describe('Combobox Escape restores committed label', () => {
     await tick();
     // The combobox is closed: the active empty-state marker is gone.
     expect(container.querySelector('.cinder-combobox__empty[data-cinder-active]')).toBeNull();
+  });
+
+  test('nested in an overlay, Escape closes only the combobox and is swallowed (zero filtered options)', async () => {
+    // Regression for the escape-stack ownership contract. A parent overlay
+    // (Modal/Sheet/etc.) registers its escape handler first. The combobox then
+    // opens and — because it pushes its own handler whenever open and its
+    // Popover opts out via closeOnEscape={false} — must sit on top of the LIFO
+    // stack. The window listener is capture-phase and invokes ONLY the topmost
+    // handler, so Escape must route to the combobox, never the parent. The
+    // combobox must also preventDefault so the same keystroke can't bubble to a
+    // page-level default. The empty-filter state is the hardest case: the
+    // Popover is unmounted there, so without the always-on registration the
+    // parent would win.
+    let parentEscapeCount = 0;
+    const releaseParentEscape = pushEscapeHandler(() => {
+      parentEscapeCount += 1;
+    });
+
+    try {
+      const { container } = render(Combobox, { id: 'escape-nested', options: escapeFruits });
+      const input = container.querySelector('#escape-nested') as HTMLInputElement;
+
+      input.focus();
+      await fireEvent.focus(input);
+      // Filter every option away so the Popover does not mount — the gap state.
+      await fireEvent.input(input, { target: { value: 'zzz' } });
+      await waitForListbox();
+      expect(container.querySelector('.cinder-combobox__empty[data-cinder-active]')).not.toBeNull();
+
+      // Dispatch a cancelable, bubbling Escape so the capture-phase window
+      // listener receives it and `defaultPrevented` is observable afterward.
+      const escapeEvent = new KeyboardEvent('keydown', {
+        key: 'Escape',
+        bubbles: true,
+        cancelable: true,
+      });
+      input.dispatchEvent(escapeEvent);
+      await tick();
+
+      // The combobox consumed and swallowed the key...
+      expect(escapeEvent.defaultPrevented).toBe(true);
+      // ...closed itself...
+      expect(container.querySelector('.cinder-combobox__empty[data-cinder-active]')).toBeNull();
+      // ...and the parent overlay's handler never fired (combobox was topmost).
+      expect(parentEscapeCount).toBe(0);
+    } finally {
+      releaseParentEscape();
+    }
   });
 });

--- a/packages/components/src/components/combobox/combobox.test.ts
+++ b/packages/components/src/components/combobox/combobox.test.ts
@@ -661,4 +661,31 @@ describe('Combobox Escape restores committed label', () => {
       releaseParentEscape();
     }
   });
+
+  test('blur restores the committed label when the live text drifted (no stale edit left behind)', async () => {
+    // Regression: blurring after editing a committed selection (tab/click away
+    // without choosing an option) must restore the committed label, mirroring
+    // Escape — otherwise the input shows stale text while `value` is unchanged.
+    const { container } = render(Combobox, { id: 'blur-restore', options: escapeFruits });
+    const input = container.querySelector('#blur-restore') as HTMLInputElement;
+
+    // Commit Apple.
+    input.focus();
+    await fireEvent.focus(input);
+    await waitFor(() => expect(container.querySelector('[role="listbox"]')).not.toBeNull());
+    const appleOption = await findOption('Apple');
+    await fireEvent.mouseDown(appleOption);
+    await waitFor(() => expect(container.querySelector('[role="listbox"]')).toBeNull());
+    expect(input.value).toBe('Apple');
+
+    // Dirty the input, then blur to nowhere (relatedTarget outside the listbox).
+    await fireEvent.input(input, { target: { value: 'App' } });
+    expect(input.value).toBe('App');
+    await fireEvent.blur(input, { relatedTarget: null });
+    await tick();
+
+    // The stale edit is gone; the committed label is restored.
+    expect(input.value).toBe('Apple');
+    expect(container.querySelector('[role="listbox"]')).toBeNull();
+  });
 });

--- a/packages/components/src/components/confirm-dialog/confirm-dialog.test.ts
+++ b/packages/components/src/components/confirm-dialog/confirm-dialog.test.ts
@@ -563,9 +563,11 @@ describe('ConfirmDialog focus trap', () => {
   // ConfirmDialog inherits Modal's focus trap. These tests verify that the inherited
   // Tab-wrap behavior works for ConfirmDialog's footer buttons.
 
-  test('Tab on the close button (last tabbable) wraps back — focus trap prevents default', async () => {
-    // Modal's focus trap is active on the panel when open. The close button is the last
-    // tabbable element; Tab on it must be intercepted so focus never reaches <body>.
+  test('Tab on the close button (last tabbable) wraps to the cancel button — focus moves + default prevented', async () => {
+    // Modal's focus trap is active on the panel when open. The tabbable order is
+    // cancel → confirm → close (the close button renders last in DOM order). Tab
+    // on the close button must wrap to the first tabbable (cancel), and asserting
+    // the destination — not just `defaultPrevented` — proves focus actually moved.
     const { container } = render(ConfirmDialog, {
       props: {
         open: true,
@@ -579,20 +581,23 @@ describe('ConfirmDialog focus trap', () => {
     expect(panel).not.toBeNull();
 
     const closeButton = container.querySelector('.cinder-modal__close') as HTMLButtonElement;
+    const [cancelButton] = footerButtons(container);
     expect(closeButton).not.toBeNull();
+    expect(cancelButton).not.toBeNull();
 
     closeButton.focus();
+    expect(document.activeElement).toBe(closeButton);
 
-    const tabEvent = new KeyboardEvent('keydown', { key: 'Tab', bubbles: true, cancelable: true });
-    panel.dispatchEvent(tabEvent);
+    const result = await fireEvent.keyDown(panel, { key: 'Tab' });
 
-    // The focus trap must have prevented default — Tab wraps within the dialog.
-    expect(tabEvent.defaultPrevented).toBe(true);
+    expect(result).toBe(false);
+    // Focus wrapped to the first tabbable (cancel), never reaching <body>.
+    expect(document.activeElement).toBe(cancelButton);
   });
 
-  test('Shift+Tab on the cancel button (first tabbable) wraps to last — focus trap prevents default', async () => {
-    // The cancel button carries autofocus and is the first tabbable element in the footer.
-    // Shift+Tab on it must wrap to the last element inside the dialog.
+  test('Shift+Tab on the cancel button (first tabbable) wraps to the close button — focus moves + default prevented', async () => {
+    // The cancel button carries autofocus and is the first tabbable element.
+    // Shift+Tab on it must wrap to the last tabbable (the close button).
     const { container } = render(ConfirmDialog, {
       props: {
         open: true,
@@ -606,22 +611,18 @@ describe('ConfirmDialog focus trap', () => {
     const panel = container.querySelector('.cinder-modal__panel') as HTMLElement;
     expect(panel).not.toBeNull();
 
-    // The first tabbable element in the ConfirmDialog panel is the cancel button
-    // (the modal body has tabindex=-1 and is excluded from tabbable set).
     const [cancelButton] = footerButtons(container);
+    const closeButton = container.querySelector('.cinder-modal__close') as HTMLButtonElement;
     expect(cancelButton).not.toBeNull();
+    expect(closeButton).not.toBeNull();
 
     cancelButton.focus();
+    expect(document.activeElement).toBe(cancelButton);
 
-    const shiftTabEvent = new KeyboardEvent('keydown', {
-      key: 'Tab',
-      shiftKey: true,
-      bubbles: true,
-      cancelable: true,
-    });
-    panel.dispatchEvent(shiftTabEvent);
+    const result = await fireEvent.keyDown(panel, { key: 'Tab', shiftKey: true });
 
-    // The focus trap must have prevented default — Shift+Tab wraps within the dialog.
-    expect(shiftTabEvent.defaultPrevented).toBe(true);
+    expect(result).toBe(false);
+    // Focus wrapped to the last tabbable (the close button).
+    expect(document.activeElement).toBe(closeButton);
   });
 });

--- a/packages/components/src/components/confirm-dialog/confirm-dialog.test.ts
+++ b/packages/components/src/components/confirm-dialog/confirm-dialog.test.ts
@@ -558,3 +558,70 @@ describe('ConfirmDialog', () => {
     expect(cancelCount).toBe(1);
   });
 });
+
+describe('ConfirmDialog focus trap', () => {
+  // ConfirmDialog inherits Modal's focus trap. These tests verify that the inherited
+  // Tab-wrap behavior works for ConfirmDialog's footer buttons.
+
+  test('Tab on the close button (last tabbable) wraps back — focus trap prevents default', async () => {
+    // Modal's focus trap is active on the panel when open. The close button is the last
+    // tabbable element; Tab on it must be intercepted so focus never reaches <body>.
+    const { container } = render(ConfirmDialog, {
+      props: {
+        open: true,
+        title: 'Delete account?',
+        confirmLabel: 'Delete',
+        onconfirm: () => {},
+      },
+    });
+
+    const panel = container.querySelector('.cinder-modal__panel') as HTMLElement;
+    expect(panel).not.toBeNull();
+
+    const closeButton = container.querySelector('.cinder-modal__close') as HTMLButtonElement;
+    expect(closeButton).not.toBeNull();
+
+    closeButton.focus();
+
+    const tabEvent = new KeyboardEvent('keydown', { key: 'Tab', bubbles: true, cancelable: true });
+    panel.dispatchEvent(tabEvent);
+
+    // The focus trap must have prevented default — Tab wraps within the dialog.
+    expect(tabEvent.defaultPrevented).toBe(true);
+  });
+
+  test('Shift+Tab on the cancel button (first tabbable) wraps to last — focus trap prevents default', async () => {
+    // The cancel button carries autofocus and is the first tabbable element in the footer.
+    // Shift+Tab on it must wrap to the last element inside the dialog.
+    const { container } = render(ConfirmDialog, {
+      props: {
+        open: true,
+        title: 'Delete account?',
+        cancelLabel: 'Cancel',
+        confirmLabel: 'Delete',
+        onconfirm: () => {},
+      },
+    });
+
+    const panel = container.querySelector('.cinder-modal__panel') as HTMLElement;
+    expect(panel).not.toBeNull();
+
+    // The first tabbable element in the ConfirmDialog panel is the cancel button
+    // (the modal body has tabindex=-1 and is excluded from tabbable set).
+    const [cancelButton] = footerButtons(container);
+    expect(cancelButton).not.toBeNull();
+
+    cancelButton.focus();
+
+    const shiftTabEvent = new KeyboardEvent('keydown', {
+      key: 'Tab',
+      shiftKey: true,
+      bubbles: true,
+      cancelable: true,
+    });
+    panel.dispatchEvent(shiftTabEvent);
+
+    // The focus trap must have prevented default — Shift+Tab wraps within the dialog.
+    expect(shiftTabEvent.defaultPrevented).toBe(true);
+  });
+});

--- a/packages/components/src/components/context-menu-trigger/context-menu-trigger.svelte
+++ b/packages/components/src/components/context-menu-trigger/context-menu-trigger.svelte
@@ -166,7 +166,6 @@
   bind:this={triggerElement}
   class={classNames('cinder-context-menu-trigger', className)}
   aria-haspopup="menu"
-  aria-expanded={context.isOpen}
   oncontextmenu={handleContextmenu}
   onpointerdown={handlePointerdown}
   onpointerup={handlePointerup}

--- a/packages/components/src/components/context-menu-trigger/context-menu-trigger.svelte
+++ b/packages/components/src/components/context-menu-trigger/context-menu-trigger.svelte
@@ -129,6 +129,12 @@
       callTriggerHandler(onkeydown, event);
       return;
     }
+    if (event.key === 'Escape' && context.isOpen) {
+      event.preventDefault();
+      context.close();
+      callTriggerHandler(onkeydown, event);
+      return;
+    }
     if (event.key !== 'ContextMenu' && !(event.shiftKey && event.key === 'F10')) {
       callTriggerHandler(onkeydown, event);
       return;

--- a/packages/components/src/components/context-menu-trigger/context-menu-trigger.svelte
+++ b/packages/components/src/components/context-menu-trigger/context-menu-trigger.svelte
@@ -166,6 +166,7 @@
   bind:this={triggerElement}
   class={classNames('cinder-context-menu-trigger', className)}
   aria-haspopup="menu"
+  aria-expanded={context.isOpen}
   oncontextmenu={handleContextmenu}
   onpointerdown={handlePointerdown}
   onpointerup={handlePointerup}

--- a/packages/components/src/components/context-menu-trigger/context-menu-trigger.test.ts
+++ b/packages/components/src/components/context-menu-trigger/context-menu-trigger.test.ts
@@ -84,19 +84,25 @@ describe('ContextMenuTrigger', () => {
     expect(menu.getAttribute('aria-orientation')).toBe('vertical');
   });
 
-  test('aria-expanded is false initially and toggles to true when the menu opens', async () => {
+  test('trigger advertises a menu popup without an aria-expanded the role-less div cannot carry', async () => {
     const { container } = render(Harness);
     const region = container.querySelector('.cinder-context-menu-trigger') as HTMLElement;
 
-    // Initially the menu is closed — aria-expanded must reflect that.
-    expect(region.getAttribute('aria-expanded')).toBe('false');
+    // aria-haspopup is globally allowed and correctly advertises the menu popup.
+    expect(region.getAttribute('aria-haspopup')).toBe('menu');
+    // aria-expanded is NOT a globally-allowed attribute: on a role-less <div> it
+    // is a critical aria-allowed-attr violation. The region is not a disclosure
+    // widget — the menu's open state is announced via focus moving into the
+    // role="menu" popup — so the trigger must never set aria-expanded, opened or
+    // not.
+    expect(region.hasAttribute('aria-expanded')).toBe(false);
 
     await fireEvent.contextMenu(region, { clientX: 12, clientY: 18 });
 
     await waitFor(() => {
       expect(document.body.querySelector('[role="menu"]')).not.toBeNull();
-      expect(region.getAttribute('aria-expanded')).toBe('true');
     });
+    expect(region.hasAttribute('aria-expanded')).toBe(false);
   });
 
   // Regression test: handlePointerdown schedules longPressTimer when the pointer

--- a/packages/components/src/components/context-menu-trigger/context-menu-trigger.test.ts
+++ b/packages/components/src/components/context-menu-trigger/context-menu-trigger.test.ts
@@ -84,6 +84,21 @@ describe('ContextMenuTrigger', () => {
     expect(menu.getAttribute('aria-orientation')).toBe('vertical');
   });
 
+  test('aria-expanded is false initially and toggles to true when the menu opens', async () => {
+    const { container } = render(Harness);
+    const region = container.querySelector('.cinder-context-menu-trigger') as HTMLElement;
+
+    // Initially the menu is closed — aria-expanded must reflect that.
+    expect(region.getAttribute('aria-expanded')).toBe('false');
+
+    await fireEvent.contextMenu(region, { clientX: 12, clientY: 18 });
+
+    await waitFor(() => {
+      expect(document.body.querySelector('[role="menu"]')).not.toBeNull();
+      expect(region.getAttribute('aria-expanded')).toBe('true');
+    });
+  });
+
   // Regression test: handlePointerdown schedules longPressTimer when the pointer
   // type is "touch". onDestroy must call clearLongPress() so the timer does not
   // outlive the component. Use a very large longPressDelay so the timer is still

--- a/packages/components/src/components/context-menu/context-menu.context.ts
+++ b/packages/components/src/components/context-menu/context-menu.context.ts
@@ -2,8 +2,10 @@ import { createContext } from 'svelte';
 
 export type ContextMenuContext = {
   get disabled(): boolean;
+  get isOpen(): boolean;
   get longPressDelay(): number;
   openAt: (x: number, y: number) => void;
+  close: () => void;
 };
 
 const [getContextMenuContextStrict, setContextMenuContext] = createContext<ContextMenuContext>();

--- a/packages/components/src/components/context-menu/context-menu.svelte
+++ b/packages/components/src/components/context-menu/context-menu.svelte
@@ -146,10 +146,14 @@
     get disabled() {
       return disabled;
     },
+    get isOpen() {
+      return open;
+    },
     get longPressDelay() {
       return longPressDelay;
     },
     openAt,
+    close,
   });
 
   $effect(() => {

--- a/packages/components/src/components/context-menu/context-menu.test.ts
+++ b/packages/components/src/components/context-menu/context-menu.test.ts
@@ -451,6 +451,19 @@ describe('ContextMenu', () => {
     expect(region.contains(document.activeElement)).toBe(true);
   });
 
+  test('Escape closes the menu when focus is on the trigger region not the menu panel', async () => {
+    const { container, getByRole, queryByRole } = render(ContextMenuHarness);
+    const region = container.querySelector('.context-menu-region') as HTMLElement;
+
+    // Open the context menu via right-click
+    await fireEvent.contextMenu(region, { clientX: 50, clientY: 50 });
+    await waitFor(() => getByRole('menu'));
+
+    // Fire Escape on the trigger region (not inside the menu)
+    await fireEvent.keyDown(region, { key: 'Escape' });
+    await waitFor(() => expect(queryByRole('menu')).toBeNull());
+  });
+
   test('keyboard context menu keys open at the focused target edge', async () => {
     const { container } = render(ContextMenuHarness);
     const button = container.querySelector('.context-menu-button') as HTMLButtonElement;

--- a/packages/components/src/components/copy-button/copy-button.test.ts
+++ b/packages/components/src/components/copy-button/copy-button.test.ts
@@ -6,7 +6,7 @@ import { expectNoLeakedTimers, trackTimers } from '../../test/lifecycle.ts';
 
 setupHappyDom();
 
-const { render, fireEvent, waitFor } = await import('@testing-library/svelte');
+const { cleanup, render, fireEvent, waitFor } = await import('@testing-library/svelte');
 const { default: CopyButton } = await import('./copy-button.svelte');
 
 type ClipboardLike = { writeText: (text: string) => Promise<void> };
@@ -32,6 +32,11 @@ describe('CopyButton', () => {
   });
 
   afterEach(() => {
+    // Unmount rendered components first: @testing-library/svelte v5's auto-cleanup
+    // does not register under bun:test (no global afterEach), so without this the
+    // mounted buttons leak into the shared happy-dom document.body and later tests
+    // (here and in sibling files) see duplicate elements.
+    cleanup();
     if (originalClipboard) {
       Object.defineProperty(globalThis.navigator, 'clipboard', {
         configurable: true,

--- a/packages/components/src/components/copy-button/use-copy-state.svelte.test.ts
+++ b/packages/components/src/components/copy-button/use-copy-state.svelte.test.ts
@@ -7,7 +7,7 @@ import { expectNoLeakedTimers, trackTimers } from '../../test/lifecycle.ts';
 setupHappyDom();
 
 // Import as dynamic to allow happy-dom to be fully set up first
-const { render, waitFor } = await import('@testing-library/svelte');
+const { cleanup, render, waitFor } = await import('@testing-library/svelte');
 // We exercise createCopyState indirectly through a minimal mounted Svelte component
 // to verify the reactive state and onDestroy cleanup work correctly.
 // We also test the factory directly in unit form.
@@ -46,6 +46,11 @@ describe('createCopyState', () => {
   });
 
   afterEach(() => {
+    // Unmount rendered components first: @testing-library/svelte v5's auto-cleanup
+    // does not register under bun:test (no global afterEach), so without this the
+    // mounted wrappers leak into the shared happy-dom document.body and later tests
+    // (here and in sibling files) see duplicate elements.
+    cleanup();
     if (originalClipboard) {
       Object.defineProperty(globalThis.navigator, 'clipboard', {
         configurable: true,

--- a/packages/components/src/components/drawer/drawer.svelte
+++ b/packages/components/src/components/drawer/drawer.svelte
@@ -17,12 +17,13 @@
 
 <script lang="ts">
   import type { DrawerProps } from './drawer.types.ts';
-  import { onDestroy, tick } from 'svelte';
+  import { onDestroy } from 'svelte';
 
   import { captureFocus, lockBodyScroll, pushEscapeHandler } from '../../_internal/overlay.ts';
   import { waitForTransitionCompletion } from '../../_internal/transition-completion.ts';
   import { overflowFade } from '../../utilities/attachments.ts';
   import { classNames } from '../../utilities/class-names.ts';
+  import { createFocusTrap } from '../focus-trap/index.ts';
   import { restoreFocusTo } from '../../utilities/focus.ts';
   import { useReducedMotion } from '../../utilities/use-reduced-motion.svelte.ts';
 
@@ -43,13 +44,11 @@
   const titleId = $props.id();
 
   let dialogElement: HTMLDialogElement | undefined = $state();
-  let bodyElement: HTMLDivElement | undefined = $state();
   let panelElement: HTMLDivElement | undefined = $state();
   let hydrated = $state(false);
   let renderPanel = $state(open);
   let isClosing = $state(false);
   let closeGeneration = $state(0);
-  let pendingOpenFocus = $state(false);
   /**
    * The side that was active when the current open/close cycle began.
    * Snapshotted at open time so that a side-prop change while the drawer
@@ -105,7 +104,6 @@
 
       if (!dialogElement.open) {
         capturedFocus = captureFocus();
-        pendingOpenFocus = true;
         dialogElement.showModal();
         acquireScrollLock();
         acquireEscapeMarker();
@@ -117,35 +115,30 @@
       beginClosing();
     } else {
       renderPanel = false;
-      pendingOpenFocus = false;
     }
   });
 
-  $effect(() => {
-    if (!pendingOpenFocus || !dialogElement?.open) return;
-    pendingOpenFocus = false;
-    void tick().then(() => {
-      if (!open || !dialogElement?.open) return;
-      const hasExplicitAutofocus =
-        dialogElement.querySelector('[autofocus]') !== null ||
-        Array.from(dialogElement.querySelectorAll<HTMLElement>('*')).some(
-          (element) => element.autofocus === true,
-        );
-      if (!hasExplicitAutofocus) {
-        // Prefer the first naturally focusable element inside the panel body.
-        // Falling back to the body container (tabindex=-1) ensures a focus trap
-        // is always established even when the drawer has no interactive content.
-        const focusableSelectors =
-          'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])';
-        const firstFocusable = panelElement?.querySelector<HTMLElement>(focusableSelectors);
-        if (firstFocusable) {
-          firstFocusable.focus();
-        } else if (bodyElement) {
-          bodyElement.focus();
-        }
-      }
-    });
-  });
+  /**
+   * Resolve the drawer's initial focus target for the shared focus trap.
+   *
+   * When the consumer marked a child with `autofocus`, the native <dialog>
+   * already focused it — honour that by handing the element back so the trap
+   * does not steal focus to the first tabbable. Otherwise return `null`, which
+   * lets `createFocusTrap` fall through to its first-tabbable → body-fallback
+   * strategy (the close button, then the `tabindex="-1"` body container). This
+   * replaces the prior ad-hoc selector, which accepted any `[tabindex]` other
+   * than `-1` (e.g. `-2`) and CSS-hidden elements that are not Tab-reachable.
+   */
+  function resolveInitialFocus(): HTMLElement | null {
+    if (!dialogElement) return null;
+    const explicitlyAutofocused =
+      dialogElement.querySelector<HTMLElement>('[autofocus]') ??
+      Array.from(dialogElement.querySelectorAll<HTMLElement>('*')).find(
+        (element) => element.autofocus === true,
+      ) ??
+      null;
+    return explicitlyAutofocused;
+  }
 
   function beginClosing(): void {
     if (!dialogElement?.open || isClosing) return;
@@ -170,7 +163,6 @@
     cancelPendingClose = null;
     isClosing = false;
     renderPanel = false;
-    pendingOpenFocus = false;
     if (dialogElement?.open) {
       dialogElement.close();
     }
@@ -274,6 +266,13 @@
     {/snippet}
 
     {#if renderPanel}
+      <!--
+        The native <dialog> (showModal) traps focus in supporting browsers; the
+        shared focus-trap is the defence-in-depth fallback and owns initial focus.
+        It carefully filters hidden/inert/disabled/`tabindex="-1"` elements, so it
+        replaces the prior ad-hoc selector. Drawer owns focus restoration
+        (returnFocus), so the trap runs with `restoreFocus: false`.
+      -->
       <div
         bind:this={panelElement}
         class="cinder-drawer__panel"
@@ -281,6 +280,11 @@
         data-cinder-size={size}
         data-cinder-closing={isClosing ? '' : undefined}
         inert={isClosing}
+        {@attach createFocusTrap({
+          active: () => open && !isClosing,
+          restoreFocus: false,
+          initialFocus: resolveInitialFocus,
+        })}
       >
         <header class="cinder-drawer__header">
           {#if header}
@@ -294,12 +298,7 @@
           {@render closeButton()}
         </header>
 
-        <div
-          bind:this={bodyElement}
-          class="cinder-drawer__body"
-          tabindex="-1"
-          {@attach bodyOverflowFade}
-        >
+        <div class="cinder-drawer__body" tabindex="-1" {@attach bodyOverflowFade}>
           {@render children()}
         </div>
 

--- a/packages/components/src/components/drawer/drawer.svelte
+++ b/packages/components/src/components/drawer/drawer.svelte
@@ -131,8 +131,18 @@
         Array.from(dialogElement.querySelectorAll<HTMLElement>('*')).some(
           (element) => element.autofocus === true,
         );
-      if (!hasExplicitAutofocus && bodyElement) {
-        bodyElement.focus();
+      if (!hasExplicitAutofocus) {
+        // Prefer the first naturally focusable element inside the panel body.
+        // Falling back to the body container (tabindex=-1) ensures a focus trap
+        // is always established even when the drawer has no interactive content.
+        const focusableSelectors =
+          'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])';
+        const firstFocusable = panelElement?.querySelector<HTMLElement>(focusableSelectors);
+        if (firstFocusable) {
+          firstFocusable.focus();
+        } else if (bodyElement) {
+          bodyElement.focus();
+        }
       }
     });
   });

--- a/packages/components/src/components/drawer/drawer.svelte
+++ b/packages/components/src/components/drawer/drawer.svelte
@@ -124,10 +124,13 @@
    * When the consumer marked a child with `autofocus`, the native <dialog>
    * already focused it — honour that by handing the element back so the trap
    * does not steal focus to the first tabbable. Otherwise return `null`, which
-   * lets `createFocusTrap` fall through to its first-tabbable → body-fallback
-   * strategy (the close button, then the `tabindex="-1"` body container). This
-   * replaces the prior ad-hoc selector, which accepted any `[tabindex]` other
-   * than `-1` (e.g. `-2`) and CSS-hidden elements that are not Tab-reachable.
+   * lets `createFocusTrap` fall through to the first tabbable element inside the
+   * drawer — typically the close button. (The Drawer passes no `fallbackFocus`,
+   * so when there is nothing tabbable the trap focuses the trap root itself;
+   * unlike Modal/Sheet, the Drawer does not opt into host-managed body focus.)
+   * This replaces the prior ad-hoc selector, which accepted any `[tabindex]`
+   * other than `-1` (e.g. `-2`) and CSS-hidden elements that are not
+   * Tab-reachable.
    */
   function resolveInitialFocus(): HTMLElement | null {
     if (!dialogElement) return null;

--- a/packages/components/src/components/drawer/drawer.test.ts
+++ b/packages/components/src/components/drawer/drawer.test.ts
@@ -697,6 +697,22 @@ describe('Drawer', () => {
     const closeButton = container.querySelector('.cinder-drawer__close');
     expect(closeButton?.getAttribute('aria-label')).toBe('Close drawer');
   });
+
+  // ---- Initial focus on open: first focusable element inside the panel ----
+  test('opening focuses the first focusable element inside the panel when one exists', async () => {
+    // The close button inside the header is the first focusable element in the panel.
+    // The drawer renders: header (close button) → body → footer.
+    const { container } = render(Drawer, {
+      props: { open: true, title: 'Test', children: emptySnippet },
+    });
+    // Svelte schedules the open-focus effect with tick().then(). In happy-dom,
+    // effects run synchronously but the tick().then() microtask needs to drain.
+    // Wait for two microtask cycles to ensure both the effect and the tick resolve.
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    const closeButton = container.querySelector('.cinder-drawer__close') as HTMLButtonElement;
+    expect(closeButton).not.toBeNull();
+    expect(document.activeElement).toBe(closeButton);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/components/src/components/event-stream-viewer/event-stream-viewer.css
+++ b/packages/components/src/components/event-stream-viewer/event-stream-viewer.css
@@ -61,14 +61,19 @@
     }
   }
 
+  /* The root .cinder-event-stream-viewer has `overflow: hidden`; an outset ring
+   * is clipped. Use Strategy B-inset so the ring stays within the button's own
+   * border box. Matches the pattern used by .cinder-drawer__close (drawer.css). */
   .cinder-event-stream-viewer__resume-button:focus-visible {
     outline: var(--cinder-ring-width) solid transparent;
-    box-shadow: var(--_cinder-focus-ring-shadow);
+    box-shadow: inset 0 0 0 var(--cinder-ring-width) var(--cinder-ring-color);
   }
 
   @media (forced-colors: active) {
     .cinder-event-stream-viewer__resume-button:focus-visible {
       outline: var(--cinder-ring-width) solid ButtonText;
+      outline-offset: calc(var(--cinder-ring-width) * -1);
+      box-shadow: none;
     }
   }
 
@@ -156,7 +161,7 @@
   }
 
   .cinder-event-stream-viewer__viewport:focus-visible {
-    box-shadow: inset var(--_cinder-focus-ring-shadow);
+    box-shadow: inset 0 0 0 var(--cinder-ring-width) var(--cinder-ring-color);
   }
 
   @media (forced-colors: active) {

--- a/packages/components/src/components/floating-action-button/floating-action-button.css
+++ b/packages/components/src/components/floating-action-button/floating-action-button.css
@@ -41,7 +41,8 @@
     outline: var(--cinder-ring-width) solid transparent;
     box-shadow:
       0 0 0 var(--cinder-ring-offset) var(--cinder-ring-offset-color),
-      0 0 0 calc(var(--cinder-ring-offset) + var(--cinder-ring-width)) var(--cinder-ring-color),
+      0 0 0 calc(var(--cinder-ring-offset) + var(--cinder-ring-width))
+        var(--_cinder-fab-ring, var(--cinder-ring-color)),
       var(--_cinder-fab-elevation);
   }
 
@@ -119,6 +120,7 @@
 
   /* primary — accent fill with contrast foreground */
   .cinder-fab[data-cinder-color='primary'] {
+    --_cinder-fab-ring: var(--cinder-ring-on-accent);
     background: var(--cinder-accent);
     color: var(--cinder-accent-contrast);
   }

--- a/packages/components/src/components/focus-trap/focus-trap.test.ts
+++ b/packages/components/src/components/focus-trap/focus-trap.test.ts
@@ -42,6 +42,19 @@ const fallbackFocusChildren = createRawSnippet(() => ({
   render: () => '<div data-testid="fallback-target" tabindex="-1">Fallback</div>',
 }));
 
+// A `tabindex="-2"` element is programmatically focusable but NOT reachable via
+// sequential Tab. It is placed AFTER the real last button so that, if the trap
+// wrongly counted it as tabbable, it would become the "last" boundary element.
+const negativeTabindexChildren = createRawSnippet(() => ({
+  render: () => `
+    <div>
+      <button data-testid="first-button">First</button>
+      <button data-testid="last-button">Last</button>
+      <div data-testid="negative-tabindex" tabindex="-2">Not tabbable</div>
+    </div>
+  `,
+}));
+
 beforeEach(() => {
   document.body.replaceChildren();
 });
@@ -80,6 +93,26 @@ describe('FocusTrap', () => {
     await fireEvent.keyDown(first, { key: 'Tab', shiftKey: true, bubbles: true });
 
     expect(document.activeElement).toBe(last);
+  });
+
+  test('excludes negative tabindex (other than -1) from the tab-wrap boundary', async () => {
+    // Regression: the tabbable filter rejected only `tabindex="-1"`, so a
+    // `tabindex="-2"` element after the last button was counted as the "last"
+    // tabbable and corrupted the wrap boundary. Tab from the real last button
+    // must still wrap to first, and the negative-tabindex node never gets focus.
+    const { getByTestId } = render(FocusTrap, {
+      props: { children: negativeTabindexChildren },
+    });
+
+    const first = getByTestId('first-button') as HTMLButtonElement;
+    const last = getByTestId('last-button') as HTMLButtonElement;
+    await tick();
+    last.focus();
+
+    await fireEvent.keyDown(last, { key: 'Tab' });
+
+    expect(document.activeElement).toBe(first);
+    expect(document.activeElement).not.toBe(getByTestId('negative-tabindex'));
   });
 
   test('restores focus to the previously focused element on teardown', async () => {

--- a/packages/components/src/components/focus-trap/focus-trap.utilities.svelte.ts
+++ b/packages/components/src/components/focus-trap/focus-trap.utilities.svelte.ts
@@ -15,6 +15,20 @@ export type FocusTrapOptions = {
   restoreFocus?: boolean;
   initialFocus?: FocusTargetInput;
   fallbackFocus?: FocusTargetInput;
+  /**
+   * Whether the trap moves focus into its panel when it activates. Defaults to
+   * `true` — the trap focuses {@link initialFocus} → first tabbable → fallback →
+   * the root on open, which is what stand-alone overlays (popovers, menus) want.
+   *
+   * Set to `false` for hosts that perform their OWN initial focus (native
+   * `<dialog>.showModal()` already focuses, and Modal/Sheet/Drawer then deliberately
+   * move focus to a `tabindex="-1"` body container so reading starts at the content,
+   * not the close button). With `manageInitialFocus: false` the trap still provides
+   * Tab-wrapping and trap-stack membership, but never overrides the host's chosen
+   * initial focus. Such hosts also own focus restoration, so they pair this with
+   * `restoreFocus: false`.
+   */
+  manageInitialFocus?: boolean;
 };
 
 type TrapInstance = {
@@ -52,7 +66,14 @@ function isHiddenByTree(element: HTMLElement): boolean {
 function isFocusableCandidate(element: HTMLElement): boolean {
   if (isHiddenByTree(element)) return false;
   if (element.hasAttribute('disabled')) return false;
-  if (element.getAttribute('tabindex') === '-1') return false;
+  // Reject ALL explicit negative tabindex values (not just "-1"). `tabindex="-2"`
+  // is programmatically focusable but NOT reachable via sequential Tab, so
+  // including it in `getTabbableElements` would corrupt the first/last boundary
+  // the Tab-wrap logic relies on. Gate on `hasAttribute` first so the IDL
+  // `tabIndex` property is only read for elements that actually set it — natively
+  // focusable elements without the attribute keep their default tabbability
+  // without depending on the DOM environment's IDL defaults (happy-dom vs real).
+  if (element.hasAttribute('tabindex') && element.tabIndex < 0) return false;
   return true;
 }
 
@@ -153,6 +174,7 @@ export function createFocusTrap(options: FocusTrapOptions = {}): Attachment<HTML
     const restoreFocus = options.restoreFocus ?? true;
     const initialFocus = options.initialFocus ?? null;
     const fallbackFocus = options.fallbackFocus ?? null;
+    const manageInitialFocus = options.manageInitialFocus ?? true;
 
     let activated = false;
     // Bumped on every `activate()`. The deferred `focusTrapTarget` microtask snapshots this value
@@ -191,12 +213,19 @@ export function createFocusTrap(options: FocusTrapOptions = {}): Attachment<HTML
           ? document.activeElement
           : null;
       pushTrap({ id: trapId, node });
+      // Hosts that own their own initial focus (Modal/Sheet/Drawer focus a body
+      // container after showModal()) opt out so the trap never overrides that choice
+      // by yanking focus to the first tabbable (the close button) on the next microtask.
+      if (!manageInitialFocus) return;
       // Defer focusing so the trap's content is in the DOM. Guard against the trap being
       // deactivated (or deactivated then reactivated) before this microtask drains — moving focus
       // into a no-longer-current activation would steal it back after `deactivate()` already
-      // restored it to the previously-focused element.
+      // restored it to the previously-focused element. The `!isActive()` check covers the
+      // synchronous open→close window: `deactivate()` runs on the next effect flush (after this
+      // microtask), but the live reactive `active` getter already reads false, so a host that
+      // closes immediately after opening does not have focus dragged into the trap post-close.
       queueMicrotask(() => {
-        if (!activated || generation !== activationGeneration) return;
+        if (!activated || generation !== activationGeneration || !isActive()) return;
         focusTrapTarget();
       });
     }

--- a/packages/components/src/components/json-schema-editor/json-schema-toolbar.test.ts
+++ b/packages/components/src/components/json-schema-editor/json-schema-toolbar.test.ts
@@ -9,8 +9,14 @@ import { setupHappyDom } from '../../test/happy-dom.ts';
 
 setupHappyDom();
 
-const { render } = await import('@testing-library/svelte');
+const { cleanup, render } = await import('@testing-library/svelte');
 const { default: JsonSchemaToolbar } = await import('./json-schema-toolbar.svelte');
+
+// @testing-library/svelte v5's auto-cleanup does not register under bun:test (no
+// global afterEach), so unmount every rendered toolbar after each test. Without
+// this the mounted toolbars leak into the shared happy-dom document.body and
+// sibling files (e.g. json-schema-editor.test.ts) see duplicate elements.
+afterEach(() => cleanup());
 
 /** Minimal fake EditorState for toolbar rendering. */
 function makeFakeState(

--- a/packages/components/src/components/json-schema-editor/property-list.test.ts
+++ b/packages/components/src/components/json-schema-editor/property-list.test.ts
@@ -1,12 +1,18 @@
 /// <reference lib="dom" />
-import { describe, expect, test } from 'bun:test';
+import { afterEach, describe, expect, test } from 'bun:test';
 
 import { setupHappyDom } from '../../test/happy-dom.ts';
 
 setupHappyDom();
 
-const { fireEvent, render } = await import('@testing-library/svelte');
+const { cleanup, fireEvent, render } = await import('@testing-library/svelte');
 const { default: PropertyList } = await import('./property-list.svelte');
+
+// @testing-library/svelte v5's auto-cleanup does not register under bun:test (no
+// global afterEach), so unmount the rendered list after each test. Without this
+// the mounted list leaks into the shared happy-dom document.body and sibling
+// files (e.g. json-schema-editor.test.ts) see duplicate elements.
+afterEach(() => cleanup());
 
 describe('PropertyList', () => {
   test('can add the first required-only property name', async () => {

--- a/packages/components/src/components/json-viewer/_json-viewer-node.svelte
+++ b/packages/components/src/components/json-viewer/_json-viewer-node.svelte
@@ -34,10 +34,10 @@
     return Object.entries(value as Record<string, unknown>);
   });
 
-  // The key label renders in a sibling <span> outside the <button>, so a screen
-  // reader announces the toggle without any indication of which node it belongs
-  // to. Compose a distinguishing accessible name from the key (when present) and
-  // the collection shape so sibling toggles are tellable apart.
+  // The key label renders inside the <button> so the focus ring encloses the
+  // full row label + caret. The aria-label on the button provides a distinguishing
+  // accessible name from the key (when present) and the collection shape so
+  // sibling toggles are tellable apart.
   const itemCount = $derived(entries.length);
   const collectionLabel = $derived(
     `${isArray ? 'array' : 'object'}, ${itemCount} ${itemCount === 1 ? 'item' : 'items'}`,
@@ -57,9 +57,6 @@
 
 {#if isObject && !tooDeep}
   <span class={classNames('cinder-json-viewer__node')}>
-    {#if keyName !== undefined}
-      <span class="cinder-json-viewer__key">{keyName}:</span>
-    {/if}
     <button
       type="button"
       class="cinder-json-viewer__toggle"
@@ -67,6 +64,9 @@
       aria-label={toggleLabel}
       onclick={() => (collapsed = !collapsed)}
     >
+      {#if keyName !== undefined}
+        <span class="cinder-json-viewer__key">{keyName}:</span>
+      {/if}
       <span class="cinder-json-viewer__caret" data-cinder-collapsed={collapsed || undefined}></span>
       <span class="cinder-json-viewer__brace">
         {isArray ? '[' : '{'}

--- a/packages/components/src/components/json-viewer/json-viewer.css
+++ b/packages/components/src/components/json-viewer/json-viewer.css
@@ -50,6 +50,12 @@
     border-radius: var(--cinder-radius-sm);
   }
 
+  @media (hover: hover) {
+    .cinder-json-viewer__toggle:hover {
+      background: var(--cinder-surface-hover);
+    }
+  }
+
   .cinder-json-viewer__toggle:focus-visible {
     outline: var(--cinder-ring-width) solid transparent;
     box-shadow: var(--_cinder-focus-ring-shadow);

--- a/packages/components/src/components/json-viewer/json-viewer.test.ts
+++ b/packages/components/src/components/json-viewer/json-viewer.test.ts
@@ -24,6 +24,33 @@ describe('JsonViewer', () => {
     expect(labels).toContain('age:');
   });
 
+  test('key label for an expandable node sits INSIDE the toggle button (focus ring covers the full row)', () => {
+    // The nested object means the root is expandable. Its key label (the property
+    // name) must be a child of the .cinder-json-viewer__toggle button so that
+    // the focus ring drawn on the button surrounds the key text as well.
+    const { container } = render(JsonViewer, { value: { config: { a: 1 } } });
+    // Find the toggle button for the nested expandable node whose key is "config"
+    const toggleButtons = Array.from(container.querySelectorAll('.cinder-json-viewer__toggle'));
+    const configButton = toggleButtons.find((button) =>
+      button.querySelector('.cinder-json-viewer__key')?.textContent?.trim() === 'config:',
+    );
+    expect(configButton).not.toBeNull();
+    // The key span must be a DESCENDANT of the button, not a sibling
+    const keySpan = configButton?.querySelector('.cinder-json-viewer__key');
+    expect(keySpan).not.toBeNull();
+    expect(keySpan?.textContent?.trim()).toBe('config:');
+  });
+
+  test('toggle button aria-label includes the key name for an expandable node', () => {
+    const { container } = render(JsonViewer, { value: { items: [1, 2, 3] } });
+    const toggleButtons = Array.from(container.querySelectorAll('.cinder-json-viewer__toggle'));
+    const itemsButton = toggleButtons.find((button) =>
+      button.getAttribute('aria-label')?.startsWith('items:'),
+    );
+    expect(itemsButton).not.toBeNull();
+    expect(itemsButton?.getAttribute('aria-label')).toBe('items: array, 3 items');
+  });
+
   test('renders an array with index labels', () => {
     const { container } = render(JsonViewer, { value: [10, 20, 30] });
     const keys = Array.from(container.querySelectorAll('.cinder-json-viewer__key'));

--- a/packages/components/src/components/matrix-chart/matrix-chart.css
+++ b/packages/components/src/components/matrix-chart/matrix-chart.css
@@ -32,10 +32,6 @@
     filter: brightness(1.15);
   }
 
-  .cinder-matrix-chart__hit-surface {
-    fill: transparent;
-  }
-
   .cinder-matrix-chart__cell-label {
     font-size: var(--cinder-text-xs);
     pointer-events: none;

--- a/packages/components/src/components/matrix-chart/matrix-chart.css
+++ b/packages/components/src/components/matrix-chart/matrix-chart.css
@@ -28,6 +28,14 @@
     stroke-width: 1.5;
   }
 
+  .cinder-matrix-chart__cell[data-cinder-active] {
+    filter: brightness(1.15);
+  }
+
+  .cinder-matrix-chart__hit-surface {
+    fill: transparent;
+  }
+
   .cinder-matrix-chart__cell-label {
     font-size: var(--cinder-text-xs);
     pointer-events: none;

--- a/packages/components/src/components/matrix-chart/matrix-chart.svelte
+++ b/packages/components/src/components/matrix-chart/matrix-chart.svelte
@@ -201,31 +201,11 @@
   const hasDataTable = $derived(dataTableVisibility !== 'hidden');
 
   // Pointer hover tracking: the key of the cell under the pointer, or null.
+  // Each cell rect sets this on pointerenter; the plot group clears it on leave.
+  // Hovering a cell also surfaces its native <title> (the value-on-hover tooltip).
   let hoveredCellKey = $state<string | null>(null);
 
-  /**
-   * Maps a pointer position (relative to the plot's translated origin) to the
-   * cell that contains it, returning that cell's key or null if outside the grid.
-   */
-  function cellKeyAtPlotPoint(plotX: number, plotY: number): string | null {
-    if (cellWidth <= 0 || cellHeight <= 0) return null;
-    const xIndex = Math.floor(plotX / cellWidth);
-    const yIndex = Math.floor(plotY / cellHeight);
-    if (xIndex < 0 || xIndex >= xLabels.length || yIndex < 0 || yIndex >= yLabels.length) {
-      return null;
-    }
-    return `${xIndex}:${yIndex}`;
-  }
-
-  function handleHitSurfacePointerMove(event: PointerEvent): void {
-    if (!(event.currentTarget instanceof SVGRectElement)) return;
-    const bounds = event.currentTarget.getBoundingClientRect();
-    const plotX = event.clientX - bounds.left;
-    const plotY = event.clientY - bounds.top;
-    hoveredCellKey = cellKeyAtPlotPoint(plotX, plotY);
-  }
-
-  function handleHitSurfacePointerLeave(): void {
+  function handlePlotPointerLeave(): void {
     hoveredCellKey = null;
   }
 
@@ -281,7 +261,14 @@
            heatmap cells/labels would draw under the loading or empty overlay
            (data may be present while loading, so isEmpty alone is not enough). -->
       {#if !loading && !isEmpty}
-        <g transform={`translate(${marginLeft}, ${marginTop})`}>
+        <!-- Clearing on plot-level leave (not per-cell) avoids a stale highlight
+             flickering at the sub-pixel seams between cells, whose dimensions are
+             fractional (plotWidth / xLabels.length). -->
+        <g
+          role="presentation"
+          transform={`translate(${marginLeft}, ${marginTop})`}
+          onpointerleave={handlePlotPointerLeave}
+        >
           <!-- X-axis labels (column headers) -->
           {#each xLabels as xLabel, index (xLabel)}
             <text
@@ -316,6 +303,7 @@
                 data-cinder-x={cell.xLabel}
                 data-cinder-y={cell.yLabel}
                 data-cinder-active={hoveredCellKey === cell.key ? '' : undefined}
+                onpointerenter={() => (hoveredCellKey = cell.key)}
               >
                 <title
                   >{cell.xLabel} × {cell.yLabel}: {cell.value !== null
@@ -336,17 +324,6 @@
               {/if}
             </g>
           {/each}
-          <!-- Transparent hit surface captures pointer events for cell hover tracking.
-               Rendered above cells so pointer events reach it without interference
-               from cell rect pointer-event quirks in SVG. -->
-          <rect
-            class="cinder-matrix-chart__hit-surface"
-            role="presentation"
-            width={plotWidth}
-            height={plotHeight}
-            onpointermove={handleHitSurfacePointerMove}
-            onpointerleave={handleHitSurfacePointerLeave}
-          />
         </g>
       {/if}
     </svg>

--- a/packages/components/src/components/matrix-chart/matrix-chart.svelte
+++ b/packages/components/src/components/matrix-chart/matrix-chart.svelte
@@ -200,6 +200,35 @@
 
   const hasDataTable = $derived(dataTableVisibility !== 'hidden');
 
+  // Pointer hover tracking: the key of the cell under the pointer, or null.
+  let hoveredCellKey = $state<string | null>(null);
+
+  /**
+   * Maps a pointer position (relative to the plot's translated origin) to the
+   * cell that contains it, returning that cell's key or null if outside the grid.
+   */
+  function cellKeyAtPlotPoint(plotX: number, plotY: number): string | null {
+    if (cellWidth <= 0 || cellHeight <= 0) return null;
+    const xIndex = Math.floor(plotX / cellWidth);
+    const yIndex = Math.floor(plotY / cellHeight);
+    if (xIndex < 0 || xIndex >= xLabels.length || yIndex < 0 || yIndex >= yLabels.length) {
+      return null;
+    }
+    return `${xIndex}:${yIndex}`;
+  }
+
+  function handleHitSurfacePointerMove(event: PointerEvent): void {
+    if (!(event.currentTarget instanceof SVGRectElement)) return;
+    const bounds = event.currentTarget.getBoundingClientRect();
+    const plotX = event.clientX - bounds.left;
+    const plotY = event.clientY - bounds.top;
+    hoveredCellKey = cellKeyAtPlotPoint(plotX, plotY);
+  }
+
+  function handleHitSurfacePointerLeave(): void {
+    hoveredCellKey = null;
+  }
+
   // Table rows for the data table fallback: xLabel × yLabel grid. Reuses the
   // nested lookup (O(1) per cell) instead of scanning the flattened cells array.
   const tableRows = $derived.by(() => {
@@ -286,6 +315,7 @@
                 aria-hidden="true"
                 data-cinder-x={cell.xLabel}
                 data-cinder-y={cell.yLabel}
+                data-cinder-active={hoveredCellKey === cell.key ? '' : undefined}
               >
                 <title
                   >{cell.xLabel} × {cell.yLabel}: {cell.value !== null
@@ -306,6 +336,17 @@
               {/if}
             </g>
           {/each}
+          <!-- Transparent hit surface captures pointer events for cell hover tracking.
+               Rendered above cells so pointer events reach it without interference
+               from cell rect pointer-event quirks in SVG. -->
+          <rect
+            class="cinder-matrix-chart__hit-surface"
+            role="presentation"
+            width={plotWidth}
+            height={plotHeight}
+            onpointermove={handleHitSurfacePointerMove}
+            onpointerleave={handleHitSurfacePointerLeave}
+          />
         </g>
       {/if}
     </svg>

--- a/packages/components/src/components/matrix-chart/matrix-chart.test.ts
+++ b/packages/components/src/components/matrix-chart/matrix-chart.test.ts
@@ -293,7 +293,7 @@ describe('MatrixChart', () => {
     expect(tableText).toContain('22');
   });
 
-  test('pointer move over the hit surface marks the hovered cell data-cinder-active', async () => {
+  test('pointer enter on a cell marks it data-cinder-active and leaving the plot clears it', async () => {
     const { container } = render(MatrixChart, {
       label: 'Confusion matrix',
       data: confusionData,
@@ -301,33 +301,35 @@ describe('MatrixChart', () => {
       yField: 'actual',
       valueField: 'count',
     });
-
-    const hitSurface = container.querySelector(
-      '.cinder-matrix-chart__hit-surface',
-    ) as SVGRectElement;
-    expect(hitSurface).not.toBeNull();
 
     // Before hover: no cell is active.
     expect(container.querySelector('.cinder-matrix-chart__cell[data-cinder-active]')).toBeNull();
 
-    // Move the pointer over the hit surface. clientX/Y map into the cell grid.
-    // The hit surface getBoundingClientRect is (0,0,0,0) in happy-dom so the
-    // computed plotX/plotY will both be 0, placing the pointer in the first cell
-    // (xIndex=0, yIndex=0 → key "0:0").
-    await fireEvent.pointerMove(hitSurface, { clientX: 0, clientY: 0 });
+    // Pointer enters the first cell directly — no overlay intercepting, so the
+    // cell's own native <title> (the value-on-hover tooltip) stays reachable.
+    const firstCell = container.querySelector('.cinder-matrix-chart__cell') as SVGRectElement;
+    expect(firstCell).not.toBeNull();
+    await fireEvent.pointerEnter(firstCell);
 
     const activeCell = container.querySelector('.cinder-matrix-chart__cell[data-cinder-active]');
-    // The first cell (top-left) should be marked active.
-    expect(activeCell).not.toBeNull();
-    expect(activeCell?.getAttribute('data-cinder-x')).toBeTruthy();
-    expect(activeCell?.getAttribute('data-cinder-y')).toBeTruthy();
+    expect(activeCell).toBe(firstCell);
+    // The first cell is the first predicted (x) × first actual (y) combination.
+    // `confusionData` lists Cat before Dog for both fields, so the first cell is
+    // Cat × Cat. Asserting the exact coordinates (not merely truthy) pins which
+    // cell the pointer handler activated — a regression that activated the wrong
+    // cell, or dropped the coordinate data attributes, would fail here.
+    expect(activeCell?.getAttribute('data-cinder-x')).toBe('Cat');
+    expect(activeCell?.getAttribute('data-cinder-y')).toBe('Cat');
 
-    // Pointer leave clears the active cell.
-    await fireEvent.pointerLeave(hitSurface);
+    // Leaving the plot group (the presentation <g> that owns onpointerleave)
+    // clears the active cell.
+    const plotGroup = firstCell.closest('g[role="presentation"]');
+    expect(plotGroup).not.toBeNull();
+    await fireEvent.pointerLeave(plotGroup as SVGGElement);
     expect(container.querySelector('.cinder-matrix-chart__cell[data-cinder-active]')).toBeNull();
   });
 
-  test('hit surface is present when data is available and not loading', () => {
+  test('each cell carries a native <title> so pointer users get value-on-hover', () => {
     const { container } = render(MatrixChart, {
       label: 'Confusion matrix',
       data: confusionData,
@@ -335,12 +337,17 @@ describe('MatrixChart', () => {
       yField: 'actual',
       valueField: 'count',
     });
-    expect(container.querySelector('.cinder-matrix-chart__hit-surface')).not.toBeNull();
+    const cells = container.querySelectorAll('.cinder-matrix-chart__cell');
+    expect(cells.length).toBeGreaterThan(0);
+    // Every cell owns a <title> child — the affordance an intercepting overlay
+    // would have hidden from pointer hover. The text mirrors the formatted value.
+    for (const cell of cells) {
+      expect(cell.querySelector('title')?.textContent).toContain('×');
+    }
   });
 
-  test('matrix-chart CSS has rules for data-cinder-active and hit-surface', async () => {
+  test('matrix-chart CSS has a rule for data-cinder-active', async () => {
     const cssText = await Bun.file(new URL('./matrix-chart.css', import.meta.url)).text();
     expect(cssText).toContain('.cinder-matrix-chart__cell[data-cinder-active]');
-    expect(cssText).toContain('.cinder-matrix-chart__hit-surface');
   });
 });

--- a/packages/components/src/components/matrix-chart/matrix-chart.test.ts
+++ b/packages/components/src/components/matrix-chart/matrix-chart.test.ts
@@ -15,7 +15,7 @@ class TestResizeObserver {
 const originalResizeObserver = globalThis.ResizeObserver;
 globalThis.ResizeObserver = TestResizeObserver as unknown as typeof ResizeObserver;
 
-const { cleanup, render } = await import('@testing-library/svelte');
+const { cleanup, fireEvent, render } = await import('@testing-library/svelte');
 const { default: MatrixChart } = await import('./matrix-chart.svelte');
 
 afterEach(() => cleanup());
@@ -291,5 +291,56 @@ describe('MatrixChart', () => {
     const tableText = container.querySelector('table')?.textContent ?? '';
     expect(tableText).toContain('11');
     expect(tableText).toContain('22');
+  });
+
+  test('pointer move over the hit surface marks the hovered cell data-cinder-active', async () => {
+    const { container } = render(MatrixChart, {
+      label: 'Confusion matrix',
+      data: confusionData,
+      xField: 'predicted',
+      yField: 'actual',
+      valueField: 'count',
+    });
+
+    const hitSurface = container.querySelector(
+      '.cinder-matrix-chart__hit-surface',
+    ) as SVGRectElement;
+    expect(hitSurface).not.toBeNull();
+
+    // Before hover: no cell is active.
+    expect(container.querySelector('.cinder-matrix-chart__cell[data-cinder-active]')).toBeNull();
+
+    // Move the pointer over the hit surface. clientX/Y map into the cell grid.
+    // The hit surface getBoundingClientRect is (0,0,0,0) in happy-dom so the
+    // computed plotX/plotY will both be 0, placing the pointer in the first cell
+    // (xIndex=0, yIndex=0 → key "0:0").
+    await fireEvent.pointerMove(hitSurface, { clientX: 0, clientY: 0 });
+
+    const activeCell = container.querySelector('.cinder-matrix-chart__cell[data-cinder-active]');
+    // The first cell (top-left) should be marked active.
+    expect(activeCell).not.toBeNull();
+    expect(activeCell?.getAttribute('data-cinder-x')).toBeTruthy();
+    expect(activeCell?.getAttribute('data-cinder-y')).toBeTruthy();
+
+    // Pointer leave clears the active cell.
+    await fireEvent.pointerLeave(hitSurface);
+    expect(container.querySelector('.cinder-matrix-chart__cell[data-cinder-active]')).toBeNull();
+  });
+
+  test('hit surface is present when data is available and not loading', () => {
+    const { container } = render(MatrixChart, {
+      label: 'Confusion matrix',
+      data: confusionData,
+      xField: 'predicted',
+      yField: 'actual',
+      valueField: 'count',
+    });
+    expect(container.querySelector('.cinder-matrix-chart__hit-surface')).not.toBeNull();
+  });
+
+  test('matrix-chart CSS has rules for data-cinder-active and hit-surface', async () => {
+    const cssText = await Bun.file(new URL('./matrix-chart.css', import.meta.url)).text();
+    expect(cssText).toContain('.cinder-matrix-chart__cell[data-cinder-active]');
+    expect(cssText).toContain('.cinder-matrix-chart__hit-surface');
   });
 });

--- a/packages/components/src/components/menu-bar/menu-bar.svelte
+++ b/packages/components/src/components/menu-bar/menu-bar.svelte
@@ -281,6 +281,12 @@
       return;
     }
 
+    if (event.key === 'Escape') {
+      event.preventDefault();
+      closeAll();
+      return;
+    }
+
     if (event.key === 'ArrowUp') {
       event.preventDefault();
       openMenu(index, 'last');

--- a/packages/components/src/components/menu-bar/menu-bar.svelte
+++ b/packages/components/src/components/menu-bar/menu-bar.svelte
@@ -281,7 +281,10 @@
       return;
     }
 
-    if (event.key === 'Escape') {
+    // Only consume Escape when a menu or submenu is actually open. On a closed
+    // menubar item, swallowing Escape (preventDefault + a no-op closeAll) would
+    // block an enclosing overlay or page-level Escape handler from ever running.
+    if (event.key === 'Escape' && (openMenuIndex !== null || openSubmenuKey !== null)) {
       event.preventDefault();
       closeAll();
       return;

--- a/packages/components/src/components/menu-bar/menu-bar.test.ts
+++ b/packages/components/src/components/menu-bar/menu-bar.test.ts
@@ -292,6 +292,40 @@ describe('MenuBar', () => {
     expect(fileButton.getAttribute('aria-expanded')).toBe('false');
   });
 
+  test('Escape on a closed menubar item is not consumed, so enclosing handlers still run', async () => {
+    const { getByRole } = render(MenuBar, { menus: fileEditViewMenus() });
+    const fileButton = getByRole('menuitem', { name: 'File' });
+    fileButton.focus();
+    expect(fileButton.getAttribute('aria-expanded')).toBe('false');
+
+    // Construct a cancelable KeyboardEvent so we can assert `defaultPrevented`
+    // after dispatch. With nothing open, the menu bar must let Escape through —
+    // calling preventDefault here would swallow it from an enclosing overlay or
+    // page-level Escape handler.
+    const closedEscape = new KeyboardEvent('keydown', {
+      key: 'Escape',
+      bubbles: true,
+      cancelable: true,
+    });
+    fileButton.dispatchEvent(closedEscape);
+    await tick();
+    expect(closedEscape.defaultPrevented).toBe(false);
+
+    // Open the menu, then Escape IS consumed (it has something to close).
+    await fireEvent.click(fileButton);
+    await tick();
+    expect(fileButton.getAttribute('aria-expanded')).toBe('true');
+    const openEscape = new KeyboardEvent('keydown', {
+      key: 'Escape',
+      bubbles: true,
+      cancelable: true,
+    });
+    fileButton.dispatchEvent(openEscape);
+    await tick();
+    expect(openEscape.defaultPrevented).toBe(true);
+    expect(fileButton.getAttribute('aria-expanded')).toBe('false');
+  });
+
   test('reuses dropdown primitives instead of copying their markup classes', async () => {
     const source = await Bun.file(new URL('./menu-bar.svelte', import.meta.url)).text();
 

--- a/packages/components/src/components/menu-bar/menu-bar.test.ts
+++ b/packages/components/src/components/menu-bar/menu-bar.test.ts
@@ -277,6 +277,21 @@ describe('MenuBar', () => {
     expect(file.getAttribute('aria-expanded')).toBe('false');
   });
 
+  test('Escape closes the open top-level menu when focus is on the trigger button', async () => {
+    const { getByRole } = render(MenuBar, { menus: fileEditViewMenus() });
+    const fileButton = getByRole('menuitem', { name: 'File' });
+
+    // Open the File menu
+    await fireEvent.click(fileButton);
+    await tick();
+    expect(fileButton.getAttribute('aria-expanded')).toBe('true');
+
+    // Press Escape while focus is on the trigger button
+    await fireEvent.keyDown(fileButton, { key: 'Escape' });
+    await tick();
+    expect(fileButton.getAttribute('aria-expanded')).toBe('false');
+  });
+
   test('reuses dropdown primitives instead of copying their markup classes', async () => {
     const source = await Bun.file(new URL('./menu-bar.svelte', import.meta.url)).text();
 

--- a/packages/components/src/components/modal/modal.svelte
+++ b/packages/components/src/components/modal/modal.svelte
@@ -25,71 +25,7 @@
   import { overflowFade } from '../../utilities/attachments.ts';
   import { classNames } from '../../utilities/class-names.ts';
   import { restoreFocusTo } from '../../utilities/focus.ts';
-
-  // Selector for elements that participate in sequential Tab navigation.
-  // Mirrors the selector used in the shared focus-trap utility.
-  const FOCUSABLE_SELECTOR = [
-    'a[href]',
-    'button:not([disabled])',
-    'input:not([disabled])',
-    'select:not([disabled])',
-    'textarea:not([disabled])',
-    'summary',
-    '[tabindex]:not([tabindex="-1"])',
-    '[contenteditable]:not([contenteditable="false"])',
-  ].join(', ');
-
-  /**
-   * Returns all elements in `root` that are reachable via the Tab key. Elements
-   * with `tabindex="-1"` are excluded because they opt out of sequential focus
-   * navigation (they remain programmatically focusable but not Tab-reachable).
-   */
-  function getTabbableElements(root: HTMLElement): HTMLElement[] {
-    return Array.from(root.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR)).filter((element) => {
-      if (element.hidden) return false;
-      if (element.matches('[inert], [aria-hidden="true"]')) return false;
-      const ancestor = element.closest<HTMLElement>('[hidden], [inert], [aria-hidden="true"]');
-      if (ancestor !== null && ancestor !== element) return false;
-      return true;
-    });
-  }
-
-  /**
-   * Attachment that wraps Tab / Shift+Tab navigation within a container so focus
-   * never escapes to `<body>` while the modal is open.
-   *
-   * Intentionally avoids any initial-focus or focus-restore side effects — the
-   * modal's own `$effect` and `returnFocus()` own those concerns. This attachment
-   * purely intercepts Tab keystrokes and re-routes them to keep focus trapped.
-   */
-  function tabWrap(node: HTMLElement) {
-    function handleKeydown(event: KeyboardEvent) {
-      if (event.key !== 'Tab') return;
-
-      const tabbable = getTabbableElements(node);
-      if (tabbable.length === 0) {
-        event.preventDefault();
-        return;
-      }
-
-      const first = tabbable[0];
-      const last = tabbable[tabbable.length - 1];
-      const active = document.activeElement;
-
-      if (event.shiftKey && active === first) {
-        event.preventDefault();
-        last?.focus();
-      } else if (!event.shiftKey && active === last) {
-        event.preventDefault();
-        first?.focus();
-      }
-    }
-
-    node.addEventListener('keydown', handleKeydown);
-    return () => {
-      node.removeEventListener('keydown', handleKeydown);
-    };
-  }
+  import { createFocusTrap } from '../focus-trap/index.ts';
 
   const titleId = $props.id();
 
@@ -267,9 +203,23 @@
     oncancel={handleNativeCancel}
   >
     {#if open}
+      <!--
+        The native <dialog> opened with showModal() already traps focus in
+        supporting browsers. The shared focus-trap is a defence-in-depth fallback
+        that keeps Tab / Shift+Tab cycling inside the panel; it carefully filters
+        hidden/inert/disabled/`tabindex="-1"` elements. Modal owns its own initial
+        focus (the body container, below) and focus restoration (returnFocus), so
+        the trap runs with `manageInitialFocus: false` and `restoreFocus: false` —
+        without the former the trap would yank focus off the body onto the close
+        button on the next microtask.
+      -->
       <div
         class="cinder-modal__panel"
-        {@attach tabWrap}
+        {@attach createFocusTrap({
+          active: () => open,
+          restoreFocus: false,
+          manageInitialFocus: false,
+        })}
       >
         <div class="cinder-modal__header">
           <h2 id={titleId} class="cinder-modal__title">{title}</h2>

--- a/packages/components/src/components/modal/modal.svelte
+++ b/packages/components/src/components/modal/modal.svelte
@@ -26,6 +26,71 @@
   import { classNames } from '../../utilities/class-names.ts';
   import { restoreFocusTo } from '../../utilities/focus.ts';
 
+  // Selector for elements that participate in sequential Tab navigation.
+  // Mirrors the selector used in the shared focus-trap utility.
+  const FOCUSABLE_SELECTOR = [
+    'a[href]',
+    'button:not([disabled])',
+    'input:not([disabled])',
+    'select:not([disabled])',
+    'textarea:not([disabled])',
+    'summary',
+    '[tabindex]:not([tabindex="-1"])',
+    '[contenteditable]:not([contenteditable="false"])',
+  ].join(', ');
+
+  /**
+   * Returns all elements in `root` that are reachable via the Tab key. Elements
+   * with `tabindex="-1"` are excluded because they opt out of sequential focus
+   * navigation (they remain programmatically focusable but not Tab-reachable).
+   */
+  function getTabbableElements(root: HTMLElement): HTMLElement[] {
+    return Array.from(root.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR)).filter((element) => {
+      if (element.hidden) return false;
+      if (element.matches('[inert], [aria-hidden="true"]')) return false;
+      const ancestor = element.closest<HTMLElement>('[hidden], [inert], [aria-hidden="true"]');
+      if (ancestor !== null && ancestor !== element) return false;
+      return true;
+    });
+  }
+
+  /**
+   * Attachment that wraps Tab / Shift+Tab navigation within a container so focus
+   * never escapes to `<body>` while the modal is open.
+   *
+   * Intentionally avoids any initial-focus or focus-restore side effects — the
+   * modal's own `$effect` and `returnFocus()` own those concerns. This attachment
+   * purely intercepts Tab keystrokes and re-routes them to keep focus trapped.
+   */
+  function tabWrap(node: HTMLElement) {
+    function handleKeydown(event: KeyboardEvent) {
+      if (event.key !== 'Tab') return;
+
+      const tabbable = getTabbableElements(node);
+      if (tabbable.length === 0) {
+        event.preventDefault();
+        return;
+      }
+
+      const first = tabbable[0];
+      const last = tabbable[tabbable.length - 1];
+      const active = document.activeElement;
+
+      if (event.shiftKey && active === first) {
+        event.preventDefault();
+        last?.focus();
+      } else if (!event.shiftKey && active === last) {
+        event.preventDefault();
+        first?.focus();
+      }
+    }
+
+    node.addEventListener('keydown', handleKeydown);
+    return () => {
+      node.removeEventListener('keydown', handleKeydown);
+    };
+  }
+
   const titleId = $props.id();
 
   let {
@@ -202,7 +267,10 @@
     oncancel={handleNativeCancel}
   >
     {#if open}
-      <div class="cinder-modal__panel">
+      <div
+        class="cinder-modal__panel"
+        {@attach tabWrap}
+      >
         <div class="cinder-modal__header">
           <h2 id={titleId} class="cinder-modal__title">{title}</h2>
         </div>

--- a/packages/components/src/components/modal/modal.test.ts
+++ b/packages/components/src/components/modal/modal.test.ts
@@ -916,12 +916,16 @@ describe('Modal focus containment', () => {
     expect(container.querySelector('dialog')?.getAttribute('aria-modal')).toBe('true');
   });
 
-  test('Tab on the last focusable element wraps back to the first (focus trap prevents default)', async () => {
-    // tabWrap attaches a keydown listener to the panel that intercepts Tab when
-    // document.activeElement is the last tabbable element. Verifying preventDefault() was
-    // called proves the trap is active and wrapping — body cannot receive focus.
+  test('Tab on the last focusable element wraps back to the first (focus moves + default prevented)', async () => {
+    // The trap attaches a keydown listener to the panel that intercepts Tab when
+    // document.activeElement is the last tabbable element. Asserting BOTH that
+    // preventDefault() fired AND that focus actually landed on the first tabbable
+    // makes this fail if the trap is removed or wraps to the wrong boundary —
+    // `defaultPrevented` alone would still pass with a no-op handler that never
+    // moves focus.
     const childrenWithButtons = createRawSnippet(() => ({
-      render: () => `<div><button id="inner-first">First</button><button id="inner-second">Second</button></div>`,
+      render: () =>
+        `<div><button id="inner-first">First</button><button id="inner-second">Second</button></div>`,
       setup: () => {},
     }));
 
@@ -932,25 +936,31 @@ describe('Modal focus containment', () => {
     const panel = container.querySelector('.cinder-modal__panel') as HTMLElement;
     expect(panel).not.toBeNull();
 
-    // The close button is the last tabbable element in the panel (rendered after footer).
+    const firstButton = container.querySelector('#inner-first') as HTMLButtonElement;
+    // The close button is rendered last in DOM order, so it is the LAST tabbable.
     const closeButton = container.querySelector('.cinder-modal__close') as HTMLButtonElement;
+    expect(firstButton).not.toBeNull();
     expect(closeButton).not.toBeNull();
 
-    // Move focus to the close button (last focusable element).
+    // Move focus to the close button (last tabbable element) and Tab forward.
     closeButton.focus();
+    expect(document.activeElement).toBe(closeButton);
 
-    // Fire a Tab keydown event on the panel. The focus trap's handler intercepts it.
-    const tabEvent = new KeyboardEvent('keydown', { key: 'Tab', bubbles: true, cancelable: true });
-    panel.dispatchEvent(tabEvent);
+    const result = await fireEvent.keyDown(panel, { key: 'Tab' });
 
-    // The trap must have called event.preventDefault() to wrap focus back to the first element.
-    expect(tabEvent.defaultPrevented).toBe(true);
+    // fireEvent returns false when the handler called preventDefault().
+    expect(result).toBe(false);
+    // Focus wrapped to the first tabbable, never escaping to <body>.
+    expect(document.activeElement).toBe(firstButton);
   });
 
-  test('Shift+Tab on the first focusable element wraps to the last (focus trap prevents default)', async () => {
-    // tabWrap intercepts Shift+Tab when document.activeElement is the first tabbable element.
+  test('Shift+Tab on the first focusable element wraps to the last (focus moves + default prevented)', async () => {
+    // Children render two buttons; with the close button rendered last, the tab
+    // order is inner-first → inner-second → close. Shift+Tab from inner-first
+    // (the first tabbable) must wrap to the close button (the last tabbable).
     const childrenWithButtons = createRawSnippet(() => ({
-      render: () => `<span><button id="inner-first">First</button></span>`,
+      render: () =>
+        `<div><button id="inner-first">First</button><button id="inner-second">Second</button></div>`,
       setup: () => {},
     }));
 
@@ -962,24 +972,20 @@ describe('Modal focus containment', () => {
     expect(panel).not.toBeNull();
 
     // The body container has tabindex="-1" and is not in the tabbable set.
-    // The first tabbable element is the inner button rendered by children.
     const firstButton = container.querySelector('#inner-first') as HTMLButtonElement;
+    const closeButton = container.querySelector('.cinder-modal__close') as HTMLButtonElement;
     expect(firstButton).not.toBeNull();
+    expect(closeButton).not.toBeNull();
 
-    // Move focus to the first tabbable element.
+    // Move focus to the first tabbable element and Shift+Tab backward.
     firstButton.focus();
+    expect(document.activeElement).toBe(firstButton);
 
-    // Fire a Shift+Tab keydown event on the panel.
-    const shiftTabEvent = new KeyboardEvent('keydown', {
-      key: 'Tab',
-      shiftKey: true,
-      bubbles: true,
-      cancelable: true,
-    });
-    panel.dispatchEvent(shiftTabEvent);
+    const result = await fireEvent.keyDown(panel, { key: 'Tab', shiftKey: true });
 
-    // The trap must have called event.preventDefault() to wrap focus to the last element.
-    expect(shiftTabEvent.defaultPrevented).toBe(true);
+    expect(result).toBe(false);
+    // Focus wrapped to the last tabbable (the close button).
+    expect(document.activeElement).toBe(closeButton);
   });
 
   test('focus trap is inactive when modal is closed — Tab events are not intercepted', async () => {

--- a/packages/components/src/components/modal/modal.test.ts
+++ b/packages/components/src/components/modal/modal.test.ts
@@ -898,10 +898,9 @@ describe('Modal', () => {
 
 describe('Modal focus containment', () => {
   // The <dialog> element natively traps focus via its showModal() API in real browsers.
-  // happy-dom stubs showModal() as an attribute setter, so browser-level Tab-wrap
-  // cannot be exercised here. These tests verify the structural conditions that
-  // allow native focus trapping to work: the panel is in the DOM when open,
-  // focusable content is present, and the dialog has `aria-modal="true"`.
+  // The modal also uses a `tabWrap` attachment on the panel that intercepts Tab/Shift+Tab
+  // keystrokes to keep focus within the panel, providing defense-in-depth for environments
+  // where the native dialog focus trap is not available (e.g. happy-dom in tests).
 
   test('panel is rendered while open', () => {
     const { container } = render(Modal, {
@@ -915,5 +914,104 @@ describe('Modal focus containment', () => {
       props: { open: true, title: 'Focus test', children: emptySnippet },
     });
     expect(container.querySelector('dialog')?.getAttribute('aria-modal')).toBe('true');
+  });
+
+  test('Tab on the last focusable element wraps back to the first (focus trap prevents default)', async () => {
+    // tabWrap attaches a keydown listener to the panel that intercepts Tab when
+    // document.activeElement is the last tabbable element. Verifying preventDefault() was
+    // called proves the trap is active and wrapping — body cannot receive focus.
+    const childrenWithButtons = createRawSnippet(() => ({
+      render: () => `<div><button id="inner-first">First</button><button id="inner-second">Second</button></div>`,
+      setup: () => {},
+    }));
+
+    const { container } = render(Modal, {
+      props: { open: true, title: 'Trap test', children: childrenWithButtons },
+    });
+
+    const panel = container.querySelector('.cinder-modal__panel') as HTMLElement;
+    expect(panel).not.toBeNull();
+
+    // The close button is the last tabbable element in the panel (rendered after footer).
+    const closeButton = container.querySelector('.cinder-modal__close') as HTMLButtonElement;
+    expect(closeButton).not.toBeNull();
+
+    // Move focus to the close button (last focusable element).
+    closeButton.focus();
+
+    // Fire a Tab keydown event on the panel. The focus trap's handler intercepts it.
+    const tabEvent = new KeyboardEvent('keydown', { key: 'Tab', bubbles: true, cancelable: true });
+    panel.dispatchEvent(tabEvent);
+
+    // The trap must have called event.preventDefault() to wrap focus back to the first element.
+    expect(tabEvent.defaultPrevented).toBe(true);
+  });
+
+  test('Shift+Tab on the first focusable element wraps to the last (focus trap prevents default)', async () => {
+    // tabWrap intercepts Shift+Tab when document.activeElement is the first tabbable element.
+    const childrenWithButtons = createRawSnippet(() => ({
+      render: () => `<span><button id="inner-first">First</button></span>`,
+      setup: () => {},
+    }));
+
+    const { container } = render(Modal, {
+      props: { open: true, title: 'Trap test', children: childrenWithButtons },
+    });
+
+    const panel = container.querySelector('.cinder-modal__panel') as HTMLElement;
+    expect(panel).not.toBeNull();
+
+    // The body container has tabindex="-1" and is not in the tabbable set.
+    // The first tabbable element is the inner button rendered by children.
+    const firstButton = container.querySelector('#inner-first') as HTMLButtonElement;
+    expect(firstButton).not.toBeNull();
+
+    // Move focus to the first tabbable element.
+    firstButton.focus();
+
+    // Fire a Shift+Tab keydown event on the panel.
+    const shiftTabEvent = new KeyboardEvent('keydown', {
+      key: 'Tab',
+      shiftKey: true,
+      bubbles: true,
+      cancelable: true,
+    });
+    panel.dispatchEvent(shiftTabEvent);
+
+    // The trap must have called event.preventDefault() to wrap focus to the last element.
+    expect(shiftTabEvent.defaultPrevented).toBe(true);
+  });
+
+  test('focus trap is inactive when modal is closed — Tab events are not intercepted', async () => {
+    // When open=false, the panel is unmounted and the trap is torn down. A Tab event
+    // dispatched before opening must pass through without preventDefault().
+    const { container } = render(Modal, {
+      props: { open: false, title: 'Trap test', children: emptySnippet },
+    });
+
+    // With open=false the panel is absent — no focus trap is active.
+    const panel = container.querySelector('.cinder-modal__panel');
+    expect(panel).toBeNull();
+  });
+
+  test('focus trap wraps even when modal has no explicit children buttons (uses close button)', async () => {
+    // The close button is always the last tabbable element. The body (tabindex=-1) is programmatically
+    // focusable but not tabbable. So with no children buttons, the close button IS both first and last.
+    const { container } = render(Modal, {
+      props: { open: true, title: 'Trap test', children: emptySnippet },
+    });
+
+    const panel = container.querySelector('.cinder-modal__panel') as HTMLElement;
+    const closeButton = container.querySelector('.cinder-modal__close') as HTMLButtonElement;
+    expect(closeButton).not.toBeNull();
+
+    // Focus the only tabbable element (close button).
+    closeButton.focus();
+
+    // Tab forward should wrap (preventDefault), since close is also the first element.
+    const tabEvent = new KeyboardEvent('keydown', { key: 'Tab', bubbles: true, cancelable: true });
+    panel.dispatchEvent(tabEvent);
+
+    expect(tabEvent.defaultPrevented).toBe(true);
   });
 });

--- a/packages/components/src/components/modal/modal.test.ts
+++ b/packages/components/src/components/modal/modal.test.ts
@@ -895,3 +895,25 @@ describe('Modal', () => {
     expect(container.querySelector('.cinder-modal__close')).toBeNull();
   });
 });
+
+describe('Modal focus containment', () => {
+  // The <dialog> element natively traps focus via its showModal() API in real browsers.
+  // happy-dom stubs showModal() as an attribute setter, so browser-level Tab-wrap
+  // cannot be exercised here. These tests verify the structural conditions that
+  // allow native focus trapping to work: the panel is in the DOM when open,
+  // focusable content is present, and the dialog has `aria-modal="true"`.
+
+  test('panel is rendered while open', () => {
+    const { container } = render(Modal, {
+      props: { open: true, title: 'Focus test', children: emptySnippet },
+    });
+    expect(container.querySelector('.cinder-modal__panel')).not.toBeNull();
+  });
+
+  test('dialog carries aria-modal="true" to signal focus containment to AT', () => {
+    const { container } = render(Modal, {
+      props: { open: true, title: 'Focus test', children: emptySnippet },
+    });
+    expect(container.querySelector('dialog')?.getAttribute('aria-modal')).toBe('true');
+  });
+});

--- a/packages/components/src/components/pagination/pagination.css
+++ b/packages/components/src/components/pagination/pagination.css
@@ -123,7 +123,6 @@
     color: var(--cinder-text-disabled, var(--cinder-text-muted));
     cursor: not-allowed;
     pointer-events: none;
-    opacity: 0.4;
   }
 
   /* opacity is ignored under forced colors, so signal the disabled boundary with

--- a/packages/components/src/components/popover/popover.svelte
+++ b/packages/components/src/components/popover/popover.svelte
@@ -47,6 +47,7 @@
     role = 'dialog',
     focusManagement = 'panel',
     wireTriggerAria = true,
+    closeOnEscape = true,
     widthMode = 'content',
     class: className,
   }: PopoverProps = $props();
@@ -160,9 +161,15 @@
     // open don't retrigger this effect; positioning rebind is the positioning
     // effect's responsibility.
     resolvedAnchorAtOpen = untrack(() => anchorElement);
-    const releaseEscape = pushEscapeHandler(() => {
-      open = false;
-    });
+    // Skip the Escape registration entirely when a parent owns Escape (e.g.
+    // Combobox passes closeOnEscape={false}); registering here would put the
+    // Popover on top of the shared stack and shadow the parent's handler while
+    // options are visible.
+    const releaseEscape = closeOnEscape
+      ? pushEscapeHandler(() => {
+          open = false;
+        })
+      : () => {};
 
     return () => {
       releaseEscape();

--- a/packages/components/src/components/popover/popover.types.ts
+++ b/packages/components/src/components/popover/popover.types.ts
@@ -47,6 +47,14 @@ export type PopoverProps = {
   focusManagement?: PopoverFocusManagement;
   /** Whether Popover owns trigger ARIA wiring. Default `true`. */
   wireTriggerAria?: boolean;
+  /**
+   * Whether the Popover registers its own handler on the shared Escape stack.
+   * Default `true`. Set `false` when a parent component (e.g. Combobox) owns
+   * Escape for the whole interaction and must remain the single, top-most
+   * Escape consumer — otherwise both would register and the Popover's handler
+   * would shadow the parent's while options are visible.
+   */
+  closeOnEscape?: boolean;
   /** Floating panel width strategy. Default `'content'`. */
   widthMode?: PopoverWidthMode;
   /** Extra class merged onto `.cinder-popover`. */

--- a/packages/components/src/components/segmented-control/segmented-control.css
+++ b/packages/components/src/components/segmented-control/segmented-control.css
@@ -261,6 +261,23 @@
     box-shadow: var(--cinder-shadow-sm);
   }
 
+  /* For the default pill variant: the `[data-cinder-selected]` rule (specificity
+   * 0,1,0) is declared after `:focus-visible` (0,1,0) and wins by cascade order,
+   * replacing the focus ring's box-shadow with shadow-sm. Re-assert the ring so
+   * the selected+focused segment still shows a visible ring in single and multiple
+   * selection modes. Scope to :not([data-cinder-variant='tablist']) so this does
+   * not conflict with the tablist re-assert below.
+   * Specificity 0,3,0 beats the base shadow-sm rule's 0,2,0 — intentional. */
+  .cinder-segmented-control:not([data-cinder-variant='tablist'])
+    .cinder-segmented-control-option[data-cinder-selected]:focus-visible,
+  .cinder-segmented-control:not([data-cinder-variant='tablist'])
+    .cinder-segmented-control-option[data-cinder-pressed]:focus-visible {
+    box-shadow:
+      0 0 0 var(--cinder-ring-offset) var(--cinder-ring-offset-color),
+      0 0 0 calc(var(--cinder-ring-offset) + var(--cinder-ring-width)) var(--cinder-ring-color);
+    z-index: 1;
+  }
+
   /* ── Tablist variant (single mode only) ─────────────────────────────────────
  * See docs/decisions/segmented-control-tablist-variant.md. The tablist variant
  * carries tab semantics for externally owned panels, so it must read as a

--- a/packages/components/src/components/sheet/sheet.svelte
+++ b/packages/components/src/components/sheet/sheet.svelte
@@ -247,7 +247,11 @@
         class="cinder-sheet__panel"
         data-cinder-closing={isClosing ? '' : undefined}
         inert={isClosing}
-        {@attach createFocusTrap({ active: () => open && !isClosing, restoreFocus: false, initialFocus: null })}
+        {@attach createFocusTrap({
+          active: () => open && !isClosing,
+          restoreFocus: false,
+          manageInitialFocus: false,
+        })}
       >
         {#if showDragHandle}
           <div class="cinder-sheet__drag-handle" aria-hidden="true">

--- a/packages/components/src/components/sheet/sheet.svelte
+++ b/packages/components/src/components/sheet/sheet.svelte
@@ -22,6 +22,7 @@
   import { captureFocus, lockBodyScroll, pushEscapeHandler } from '../../_internal/overlay.ts';
   import { waitForTransitionCompletion } from '../../_internal/transition-completion.ts';
   import { overflowFade } from '../../utilities/attachments.ts';
+  import { createFocusTrap } from '../focus-trap/index.ts';
   import { classNames } from '../../utilities/class-names.ts';
   import { restoreFocusTo } from '../../utilities/focus.ts';
   import { useReducedMotion } from '../../utilities/use-reduced-motion.svelte.ts';
@@ -246,6 +247,7 @@
         class="cinder-sheet__panel"
         data-cinder-closing={isClosing ? '' : undefined}
         inert={isClosing}
+        {@attach createFocusTrap({ active: () => open && !isClosing, restoreFocus: false, initialFocus: null })}
       >
         {#if showDragHandle}
           <div class="cinder-sheet__drag-handle" aria-hidden="true">

--- a/packages/components/src/components/sheet/sheet.test.ts
+++ b/packages/components/src/components/sheet/sheet.test.ts
@@ -792,6 +792,77 @@ describe('Sheet', () => {
   });
 });
 
+describe('Sheet focus trap', () => {
+  function makeSnippetWithInput() {
+    return createRawSnippet(() => ({
+      render: () => `<input type="text" data-testid="sheet-input" />`,
+      setup: () => {},
+    }));
+  }
+
+  test('Tab from last focusable element wraps to first inside open sheet', async () => {
+    const { container } = render(Sheet, {
+      props: {
+        open: true,
+        title: 'Test Sheet',
+        children: makeSnippetWithInput(),
+      },
+    });
+
+    const panel = container.querySelector('.cinder-sheet__panel') as HTMLElement;
+    expect(panel).not.toBeNull();
+
+    const closeButton = container.querySelector('.cinder-sheet__close') as HTMLElement;
+    expect(closeButton).not.toBeNull();
+
+    // Focus the close button (last tabbable element in the panel header)
+    closeButton.focus();
+
+    // Tab forward — focus trap should wrap to first focusable in the panel
+    await fireEvent.keyDown(panel, { key: 'Tab', shiftKey: false });
+    expect(panel.contains(document.activeElement) || document.activeElement === panel).toBe(true);
+  });
+
+  test('Shift+Tab from first focusable wraps to last inside open sheet', async () => {
+    const { container } = render(Sheet, {
+      props: {
+        open: true,
+        title: 'Test Sheet',
+        children: makeSnippetWithInput(),
+      },
+    });
+
+    const panel = container.querySelector('.cinder-sheet__panel') as HTMLElement;
+    const input = container.querySelector('input[data-testid="sheet-input"]') as HTMLElement;
+    expect(input).not.toBeNull();
+
+    // Focus the input (first tabbable element in the body)
+    input.focus();
+
+    // Shift+Tab should wrap to the last focusable element
+    await fireEvent.keyDown(panel, { key: 'Tab', shiftKey: true });
+    expect(panel.contains(document.activeElement) || document.activeElement === panel).toBe(true);
+  });
+
+  test('document.body does not receive focus while sheet is open', async () => {
+    const { container } = render(Sheet, {
+      props: {
+        open: true,
+        title: 'Test Sheet',
+        children: makeSnippetWithInput(),
+      },
+    });
+
+    const panel = container.querySelector('.cinder-sheet__panel') as HTMLElement;
+
+    // Tab multiple times — focus should always remain inside the panel
+    for (let i = 0; i < 5; i++) {
+      await fireEvent.keyDown(panel, { key: 'Tab', shiftKey: false });
+      expect(panel.contains(document.activeElement) || document.activeElement === panel).toBe(true);
+    }
+  });
+});
+
 // The sheet's <dialog> is gated behind a `hydrated` $state set inside an
 // $effect, which never runs on the server. These tests render the component in
 // Svelte's server compiler and assert the gated markup is absent server-side —

--- a/packages/components/src/components/sheet/sheet.test.ts
+++ b/packages/components/src/components/sheet/sheet.test.ts
@@ -2,7 +2,7 @@
 import { join } from 'node:path';
 
 import { afterAll, afterEach, describe, expect, test } from 'bun:test';
-import { createRawSnippet } from 'svelte';
+import { createRawSnippet, tick } from 'svelte';
 
 import { _resetEscapeStack, _resetScrollLock, pushEscapeHandler } from '../../_internal/overlay.ts';
 import { setupHappyDom } from '../../test/happy-dom.ts';
@@ -800,7 +800,18 @@ describe('Sheet focus trap', () => {
     }));
   }
 
-  test('Tab from last focusable element wraps to first inside open sheet', async () => {
+  // DOM order inside the panel: the close button lives in the <header> first,
+  // then the body <input>. So the close button is the FIRST tabbable and the
+  // input is the LAST — asserting exact wrap destinations (not mere panel
+  // containment, which is already true before the event) makes these tests fail
+  // if the shared trap is removed or its boundary logic breaks.
+  //
+  // Each test `await tick()`s after render: on open, the sheet defers its own
+  // initial focus to the body via `tick().then(() => bodyElement.focus())`. That
+  // microtask must drain BEFORE we exercise the trap, otherwise it races in
+  // during the `await fireEvent` and clobbers the trap's wrap destination. In
+  // real usage the deferred focus has long settled before a user tabs.
+  test('Tab from the last focusable element wraps to the first and prevents default', async () => {
     const { container } = render(Sheet, {
       props: {
         open: true,
@@ -808,22 +819,27 @@ describe('Sheet focus trap', () => {
         children: makeSnippetWithInput(),
       },
     });
+    await tick();
 
     const panel = container.querySelector('.cinder-sheet__panel') as HTMLElement;
-    expect(panel).not.toBeNull();
-
     const closeButton = container.querySelector('.cinder-sheet__close') as HTMLElement;
+    const input = container.querySelector('input[data-testid="sheet-input"]') as HTMLElement;
+    expect(panel).not.toBeNull();
     expect(closeButton).not.toBeNull();
+    expect(input).not.toBeNull();
 
-    // Focus the close button (last tabbable element in the panel header)
-    closeButton.focus();
+    // The input is the LAST tabbable (close button is first, in the header).
+    input.focus();
+    expect(document.activeElement).toBe(input);
 
-    // Tab forward — focus trap should wrap to first focusable in the panel
-    await fireEvent.keyDown(panel, { key: 'Tab', shiftKey: false });
-    expect(panel.contains(document.activeElement) || document.activeElement === panel).toBe(true);
+    const result = await fireEvent.keyDown(panel, { key: 'Tab', shiftKey: false });
+
+    // Trap intercepted the boundary Tab and wrapped focus to the first tabbable.
+    expect(result).toBe(false); // fireEvent returns false when preventDefault was called
+    expect(document.activeElement).toBe(closeButton);
   });
 
-  test('Shift+Tab from first focusable wraps to last inside open sheet', async () => {
+  test('Shift+Tab from the first focusable element wraps to the last and prevents default', async () => {
     const { container } = render(Sheet, {
       props: {
         open: true,
@@ -831,34 +847,41 @@ describe('Sheet focus trap', () => {
         children: makeSnippetWithInput(),
       },
     });
+    await tick();
+
+    const panel = container.querySelector('.cinder-sheet__panel') as HTMLElement;
+    const closeButton = container.querySelector('.cinder-sheet__close') as HTMLElement;
+    const input = container.querySelector('input[data-testid="sheet-input"]') as HTMLElement;
+
+    // The close button is the FIRST tabbable (header precedes the body input).
+    closeButton.focus();
+    expect(document.activeElement).toBe(closeButton);
+
+    const result = await fireEvent.keyDown(panel, { key: 'Tab', shiftKey: true });
+
+    expect(result).toBe(false);
+    expect(document.activeElement).toBe(input);
+  });
+
+  test('document.body never receives focus while tabbing inside an open sheet', async () => {
+    const { container } = render(Sheet, {
+      props: {
+        open: true,
+        title: 'Test Sheet',
+        children: makeSnippetWithInput(),
+      },
+    });
+    await tick();
 
     const panel = container.querySelector('.cinder-sheet__panel') as HTMLElement;
     const input = container.querySelector('input[data-testid="sheet-input"]') as HTMLElement;
-    expect(input).not.toBeNull();
-
-    // Focus the input (first tabbable element in the body)
     input.focus();
 
-    // Shift+Tab should wrap to the last focusable element
-    await fireEvent.keyDown(panel, { key: 'Tab', shiftKey: true });
-    expect(panel.contains(document.activeElement) || document.activeElement === panel).toBe(true);
-  });
-
-  test('document.body does not receive focus while sheet is open', async () => {
-    const { container } = render(Sheet, {
-      props: {
-        open: true,
-        title: 'Test Sheet',
-        children: makeSnippetWithInput(),
-      },
-    });
-
-    const panel = container.querySelector('.cinder-sheet__panel') as HTMLElement;
-
-    // Tab multiple times — focus should always remain inside the panel
+    // Tab repeatedly from the boundary — focus must never escape to the body.
     for (let i = 0; i < 5; i++) {
       await fireEvent.keyDown(panel, { key: 'Tab', shiftKey: false });
-      expect(panel.contains(document.activeElement) || document.activeElement === panel).toBe(true);
+      expect(document.activeElement).not.toBe(document.body);
+      expect(panel.contains(document.activeElement)).toBe(true);
     }
   });
 });

--- a/packages/components/src/components/spectrogram/spectrogram.css
+++ b/packages/components/src/components/spectrogram/spectrogram.css
@@ -23,7 +23,8 @@
   }
 
   .cinder-spectrogram__cell {
-    stroke: none;
+    stroke: color-mix(in oklch, var(--cinder-text), transparent 88%);
+    stroke-width: 0.5;
   }
 
   .cinder-spectrogram__tick-label {

--- a/packages/components/src/components/stat/stat.svelte
+++ b/packages/components/src/components/stat/stat.svelte
@@ -64,7 +64,7 @@
   {id}
   class={classNames('cinder-stat', customClassName)}
   role="group"
-  aria-labelledby={`${labelId} ${valueId}`}
+  aria-labelledby={labelId}
   data-cinder-has-icon={icon ? '' : undefined}
 >
   {#if icon}

--- a/packages/components/src/components/stat/stat.svelte
+++ b/packages/components/src/components/stat/stat.svelte
@@ -64,7 +64,7 @@
   {id}
   class={classNames('cinder-stat', customClassName)}
   role="group"
-  aria-labelledby={labelId}
+  aria-labelledby={`${labelId} ${valueId}`}
   data-cinder-has-icon={icon ? '' : undefined}
 >
   {#if icon}

--- a/packages/components/src/components/stat/stat.test.ts
+++ b/packages/components/src/components/stat/stat.test.ts
@@ -25,14 +25,17 @@ describe('Stat', () => {
     expect(el?.getAttribute('role')).toBe('group');
   });
 
-  test('aria-labelledby references only the label element id', () => {
+  test('aria-labelledby references both the label and value element ids', () => {
     const { container } = render(Stat, { label: 'Revenue', value: '$1,000' });
     const root = container.querySelector('.cinder-stat');
     const ariaLabelledby = root?.getAttribute('aria-labelledby') ?? '';
-    // Must be a single id (no space-separated list)
-    expect(ariaLabelledby).not.toContain(' ');
-    const labelEl = container.querySelector('#' + ariaLabelledby);
-    expect(labelEl?.textContent).toContain('Revenue');
+    // A statistic is announced as label + value together (see stat.a11y.md):
+    // aria-labelledby points at both the label span and the value span so a
+    // screen reader user hears "Revenue $1,000" as one atomic accessible name.
+    const ids = ariaLabelledby.split(' ').filter(Boolean);
+    expect(ids).toHaveLength(2);
+    expect(container.querySelector('#' + ids[0])?.textContent).toContain('Revenue');
+    expect(container.querySelector('#' + ids[1])?.textContent).toContain('$1,000');
   });
 
   test('renders the label and value text', () => {
@@ -174,9 +177,13 @@ describe('Stat', () => {
     const root = container.querySelector('.cinder-stat');
     const ariaLabelledby = root?.getAttribute('aria-labelledby') ?? '';
     expect(ariaLabelledby).not.toBe('custom-id');
-    // Should reference only the label span (not value id, which was the old double-read pattern)
-    expect(ariaLabelledby).not.toContain(' ');
-    expect(container.querySelector('#' + ariaLabelledby)).not.toBeNull();
+    // The component owns aria-labelledby and points it at its own label + value
+    // spans, so a consumer-forwarded value cannot break the statistic's name.
+    const ids = ariaLabelledby.split(' ').filter(Boolean);
+    expect(ids).toHaveLength(2);
+    for (const id of ids) {
+      expect(container.querySelector('#' + id)).not.toBeNull();
+    }
   });
 
   test('data-cinder-direction on change element reflects change.direction', () => {
@@ -248,10 +255,9 @@ describe('Stat', () => {
     const root = container.querySelector('.cinder-stat');
     expect(root?.getAttribute('id')).toBe('my-revenue-stat');
     const ariaLabelledby = root?.getAttribute('aria-labelledby') ?? '';
-    // aria-labelledby now references only the label element
-    expect(ariaLabelledby).toBe('my-revenue-stat-label');
+    // aria-labelledby derives both ids from the explicit id base
+    expect(ariaLabelledby).toBe('my-revenue-stat-label my-revenue-stat-value');
     expect(container.querySelector('#my-revenue-stat-label')?.textContent).toContain('Revenue');
-    // valueId element still exists (may be referenced by stat-group consumers)
     expect(container.querySelector('#my-revenue-stat-value')?.textContent).toContain('$1,000');
   });
 

--- a/packages/components/src/components/stat/stat.test.ts
+++ b/packages/components/src/components/stat/stat.test.ts
@@ -25,15 +25,14 @@ describe('Stat', () => {
     expect(el?.getAttribute('role')).toBe('group');
   });
 
-  test('aria-labelledby references both label and value element ids', () => {
+  test('aria-labelledby references only the label element id', () => {
     const { container } = render(Stat, { label: 'Revenue', value: '$1,000' });
     const root = container.querySelector('.cinder-stat');
     const ariaLabelledby = root?.getAttribute('aria-labelledby') ?? '';
-    const [labelId, valueId] = ariaLabelledby.split(' ');
-    const labelEl = container.querySelector(`#${labelId}`);
-    const valueEl = container.querySelector(`#${valueId}`);
+    // Must be a single id (no space-separated list)
+    expect(ariaLabelledby).not.toContain(' ');
+    const labelEl = container.querySelector('#' + ariaLabelledby);
     expect(labelEl?.textContent).toContain('Revenue');
-    expect(valueEl?.textContent).toContain('$1,000');
   });
 
   test('renders the label and value text', () => {
@@ -175,10 +174,9 @@ describe('Stat', () => {
     const root = container.querySelector('.cinder-stat');
     const ariaLabelledby = root?.getAttribute('aria-labelledby') ?? '';
     expect(ariaLabelledby).not.toBe('custom-id');
-    // Should still reference label and value spans
-    const [labelId, valueId] = ariaLabelledby.split(' ');
-    expect(container.querySelector(`#${labelId}`)).not.toBeNull();
-    expect(container.querySelector(`#${valueId}`)).not.toBeNull();
+    // Should reference only the label span (not value id, which was the old double-read pattern)
+    expect(ariaLabelledby).not.toContain(' ');
+    expect(container.querySelector('#' + ariaLabelledby)).not.toBeNull();
   });
 
   test('data-cinder-direction on change element reflects change.direction', () => {
@@ -241,7 +239,7 @@ describe('Stat', () => {
     expect(root?.getAttribute('data-testid')).toBe('revenue-stat');
   });
 
-  test('explicit id prop sets the base for labelId and valueId', () => {
+  test('explicit id prop sets the base for labelId', () => {
     const { container } = render(Stat, {
       id: 'my-revenue-stat',
       label: 'Revenue',
@@ -250,8 +248,10 @@ describe('Stat', () => {
     const root = container.querySelector('.cinder-stat');
     expect(root?.getAttribute('id')).toBe('my-revenue-stat');
     const ariaLabelledby = root?.getAttribute('aria-labelledby') ?? '';
-    expect(ariaLabelledby).toBe('my-revenue-stat-label my-revenue-stat-value');
+    // aria-labelledby now references only the label element
+    expect(ariaLabelledby).toBe('my-revenue-stat-label');
     expect(container.querySelector('#my-revenue-stat-label')?.textContent).toContain('Revenue');
+    // valueId element still exists (may be referenced by stat-group consumers)
     expect(container.querySelector('#my-revenue-stat-value')?.textContent).toContain('$1,000');
   });
 

--- a/packages/components/src/components/status-dot/status-dot.css
+++ b/packages/components/src/components/status-dot/status-dot.css
@@ -75,7 +75,7 @@
   }
 
   .cinder-status-dot[data-cinder-status='neutral'] {
-    --cinder-status-dot-color: var(--cinder-text-muted);
+    --cinder-status-dot-color: var(--cinder-border-strong);
   }
 
   .cinder-status-dot[data-cinder-status='success'] {

--- a/packages/components/src/components/status-dot/status-dot.test.ts
+++ b/packages/components/src/components/status-dot/status-dot.test.ts
@@ -205,3 +205,14 @@ describe('StatusDot accessible name (WCAG 1.4.1)', () => {
     expect(container.querySelector('.cinder-status-dot')?.getAttribute('aria-label')).toBe('error');
   });
 });
+
+describe('StatusDot CSS contract', () => {
+  test('neutral status uses --cinder-border-strong not --cinder-text-muted', async () => {
+    const css = await Bun.file(new URL('./status-dot.css', import.meta.url)).text();
+    expect(css).toContain("data-cinder-status='neutral']");
+    expect(css).toContain('--cinder-status-dot-color: var(--cinder-border-strong)');
+    // Ensure the neutral rule no longer points to text-muted (which offline also uses)
+    const neutralBlock = css.match(/\[data-cinder-status='neutral'\]\s*\{[^}]*\}/)?.[0] ?? '';
+    expect(neutralBlock).not.toContain('--cinder-text-muted');
+  });
+});

--- a/packages/components/src/components/steps/steps.css
+++ b/packages/components/src/components/steps/steps.css
@@ -163,7 +163,7 @@
     width: var(--_marker-size);
     height: var(--_marker-size);
     border-radius: var(--cinder-radius-full);
-    background: var(--cinder-surface-inset);
+    background: var(--cinder-surface-upcoming-marker);
     flex-shrink: 0;
   }
 
@@ -256,6 +256,12 @@
 
   .cinder-steps[data-cinder-orientation='vertical'] .cinder-steps__interactive.cinder-steps__body {
     padding-bottom: var(--cinder-space-4);
+  }
+
+  @media (hover: hover) {
+    .cinder-steps__interactive:hover {
+      background: var(--cinder-surface-hover);
+    }
   }
 
   .cinder-steps__interactive:focus-visible {

--- a/packages/components/src/components/subscription-badge/subscription-badge.svelte
+++ b/packages/components/src/components/subscription-badge/subscription-badge.svelte
@@ -47,7 +47,7 @@
     'past-due': { tone: 'warning', icon: TriangleAlert, label: 'Past due' },
     canceled: { tone: 'neutral', icon: CircleX, label: 'Canceled' },
     expired: { tone: 'danger', icon: CalendarX, label: 'Expired' },
-    refunded: { tone: 'info', icon: RotateCcw, label: 'Refunded' },
+    refunded: { tone: 'neutral', icon: RotateCcw, label: 'Refunded' },
   };
 
   let { state, class: customClassName, ...rest }: SubscriptionBadgeProps = $props();

--- a/packages/components/src/components/subscription-badge/subscription-badge.test.ts
+++ b/packages/components/src/components/subscription-badge/subscription-badge.test.ts
@@ -21,7 +21,7 @@ const STATE_TABLE: Record<SubscriptionState, { tone: string; label: string }> = 
   'past-due': { tone: 'warning', label: 'Past due' },
   canceled: { tone: 'neutral', label: 'Canceled' },
   expired: { tone: 'danger', label: 'Expired' },
-  refunded: { tone: 'info', label: 'Refunded' },
+  refunded: { tone: 'neutral', label: 'Refunded' },
 };
 
 const ALL_STATES = Object.keys(STATE_TABLE) as SubscriptionState[];
@@ -108,6 +108,24 @@ describe('SubscriptionBadge — data-cinder-state per state', () => {
     const { container } = render(SubscriptionBadge, { props: { state } });
     const badge = container.querySelector('.cinder-badge');
     expect(badge?.getAttribute('data-cinder-state')).toBe(state);
+  });
+});
+
+describe('SubscriptionBadge — tone differentiation', () => {
+  test('refunded has a distinct tone from trialing so they are visually distinguishable', () => {
+    const refundedContainer = render(SubscriptionBadge, { props: { state: 'refunded' } });
+    const refundedBadge = refundedContainer.container.querySelector('.cinder-badge');
+    const refundedTone = refundedBadge?.getAttribute('data-cinder-variant');
+
+    const trialingContainer = render(SubscriptionBadge, { props: { state: 'trialing' } });
+    const trialingBadge = trialingContainer.container.querySelector('.cinder-badge');
+    const trialingTone = trialingBadge?.getAttribute('data-cinder-variant');
+
+    expect(refundedTone).toBe('neutral');
+    expect(trialingTone).toBe('info');
+    // Key invariant: the two states must not share the same tone so users can
+    // distinguish them by color/appearance alone (WCAG 1.4.1).
+    expect(refundedTone).not.toBe(trialingTone);
   });
 });
 

--- a/packages/components/src/components/table/table.css
+++ b/packages/components/src/components/table/table.css
@@ -16,6 +16,23 @@
  *              Table > TableBody   > TableRow > TableCell
  * ======================================== */
 
+  /* ----------------------------------------
+ * Table root wrapper
+ * Normally a structural pass-through (`display: contents`) so the inner
+ * <table> participates directly in the parent layout. When a caption is
+ * hoisted above a sticky-header table the wrapper generates a block to stack
+ * the caption div above the table.
+ * ---------------------------------------- */
+
+  .cinder-table-root {
+    display: contents;
+  }
+
+  .cinder-table-root--captioned {
+    display: flex;
+    flex-direction: column;
+  }
+
   .cinder-table {
     width: 100%;
     border-collapse: collapse;
@@ -32,7 +49,12 @@
     -webkit-overflow-scrolling: touch;
   }
 
-  .cinder-table-scroll > .cinder-table {
+  /* The .cinder-table-root wrapper uses display:contents and is a transparent
+   * pass-through in the box model, but it still appears in the DOM. Use a
+   * descendant combinator so the table is targeted whether or not the wrapper
+   * is present. The selector is scoped tightly enough: nested tables are not
+   * a pattern in this component family. */
+  .cinder-table-scroll .cinder-table {
     min-inline-size: max-content;
   }
 

--- a/packages/components/src/components/table/table.css
+++ b/packages/components/src/components/table/table.css
@@ -45,6 +45,14 @@
     color: var(--cinder-text);
   }
 
+  .cinder-table__caption--hoisted {
+    text-align: left;
+    padding-block: var(--cinder-space-3) var(--cinder-space-2);
+    padding-inline: var(--cinder-space-3);
+    font-weight: var(--cinder-font-medium);
+    color: var(--cinder-text);
+  }
+
   /* ----------------------------------------
  * Header
  * ---------------------------------------- */
@@ -65,7 +73,7 @@
     text-align: left;
     font-weight: var(--cinder-font-medium);
     color: var(--cinder-text-muted);
-    border-bottom: 1px solid var(--cinder-border-muted);
+    border-bottom: 1px solid var(--cinder-border);
     text-wrap: balance;
   }
 
@@ -149,6 +157,12 @@
     z-index: 2;
   }
 
+  @media (hover: hover) {
+    .cinder-table__sort-button:hover {
+      background: var(--cinder-surface-hover);
+    }
+  }
+
   .cinder-table__sort-indicator {
     display: inline-flex;
     color: var(--cinder-text-subtle);
@@ -161,7 +175,7 @@
 
   .cinder-table__sort-indicator[data-cinder-direction='ascending'] .cinder-table__sort-chevron-down,
   .cinder-table__sort-indicator[data-cinder-direction='descending'] .cinder-table__sort-chevron-up {
-    opacity: 0.3;
+    opacity: 0.15;
   }
 
   /* ----------------------------------------
@@ -181,7 +195,7 @@
   .cinder-table__cell {
     padding-block: var(--cinder-space-2);
     padding-inline: var(--cinder-space-3);
-    border-bottom: 1px solid var(--cinder-border-muted);
+    border-bottom: 1px solid var(--cinder-border);
   }
 
   .cinder-table__cell[data-cinder-align='center'] {

--- a/packages/components/src/components/table/table.css
+++ b/packages/components/src/components/table/table.css
@@ -16,23 +16,6 @@
  *              Table > TableBody   > TableRow > TableCell
  * ======================================== */
 
-  /* ----------------------------------------
- * Table root wrapper
- * Normally a structural pass-through (`display: contents`) so the inner
- * <table> participates directly in the parent layout. When a caption is
- * hoisted above a sticky-header table the wrapper generates a block to stack
- * the caption div above the table.
- * ---------------------------------------- */
-
-  .cinder-table-root {
-    display: contents;
-  }
-
-  .cinder-table-root--captioned {
-    display: flex;
-    flex-direction: column;
-  }
-
   .cinder-table {
     width: 100%;
     border-collapse: collapse;
@@ -49,25 +32,12 @@
     -webkit-overflow-scrolling: touch;
   }
 
-  /* The .cinder-table-root wrapper uses display:contents and is a transparent
-   * pass-through in the box model, but it still appears in the DOM. Use a
-   * descendant combinator so the table is targeted whether or not the wrapper
-   * is present. The selector is scoped tightly enough: nested tables are not
-   * a pattern in this component family. */
   .cinder-table-scroll .cinder-table {
     min-inline-size: max-content;
   }
 
   .cinder-table__caption {
     caption-side: top;
-    text-align: left;
-    padding-block: var(--cinder-space-3) var(--cinder-space-2);
-    padding-inline: var(--cinder-space-3);
-    font-weight: var(--cinder-font-medium);
-    color: var(--cinder-text);
-  }
-
-  .cinder-table__caption--hoisted {
     text-align: left;
     padding-block: var(--cinder-space-3) var(--cinder-space-2);
     padding-inline: var(--cinder-space-3);
@@ -87,6 +57,16 @@
     position: sticky;
     top: 0;
     z-index: 1;
+  }
+
+  /* A native <caption> (caption-side: top) renders above the table's border box
+   * but inside the same scroll container, so a sticky <thead> pinned at top: 0
+   * would scroll up and overlap it. Offset the sticky threshold by the caption's
+   * rendered block size — padding-block (space-3 + space-2) plus one line box —
+   * so the header pins just below the caption instead of over it. Scoped with
+   * :has(caption) so a caption-less sticky table keeps top: 0. */
+  .cinder-table[data-cinder-sticky-header]:has(caption) .cinder-table__header {
+    top: calc(var(--cinder-space-3) + var(--cinder-space-2) + 1lh);
   }
 
   .cinder-table__header-cell {

--- a/packages/components/src/components/table/table.css
+++ b/packages/components/src/components/table/table.css
@@ -62,11 +62,14 @@
   /* A native <caption> (caption-side: top) renders above the table's border box
    * but inside the same scroll container, so a sticky <thead> pinned at top: 0
    * would scroll up and overlap it. Offset the sticky threshold by the caption's
-   * rendered block size — padding-block (space-3 + space-2) plus one line box —
-   * so the header pins just below the caption instead of over it. Scoped with
-   * :has(caption) so a caption-less sticky table keeps top: 0. */
+   * MEASURED border-box height (set on the table by a ResizeObserver in
+   * table.svelte as --cinder-table-caption-height) so the header pins just below
+   * the real caption — including when the caption wraps to multiple lines, which
+   * a hard-coded `1lh` assumption could not handle. Scoped with :has(caption) so
+   * a caption-less sticky table keeps top: 0; the var falls back to 0px before
+   * the first measurement. */
   .cinder-table[data-cinder-sticky-header]:has(caption) .cinder-table__header {
-    top: calc(var(--cinder-space-3) + var(--cinder-space-2) + 1lh);
+    top: var(--cinder-table-caption-height, 0px);
   }
 
   .cinder-table__header-cell {

--- a/packages/components/src/components/table/table.svelte
+++ b/packages/components/src/components/table/table.svelte
@@ -53,7 +53,7 @@
     (entries) => {
       const entry = entries[0];
       if (!entry) return;
-      captionHeight = entry.borderBoxSize[0]?.blockSize ?? entry.contentRect.height;
+      captionHeight = entry.borderBoxSize?.[0]?.blockSize ?? entry.contentRect.height;
     },
     { box: 'border-box' },
   );

--- a/packages/components/src/components/table/table.svelte
+++ b/packages/components/src/components/table/table.svelte
@@ -49,13 +49,16 @@
   // calc consumes, so the header always pins just below the real caption.
   let captionHeight = $state(0);
 
+  // Only the sticky-header `top` calc consumes `captionHeight`, so a non-sticky
+  // captioned table has no reason to run a ResizeObserver. Gate observation on
+  // `stickyHeader` to avoid the work in the common case.
   const measureCaption = useResizeObserver(
     (entries) => {
       const entry = entries[0];
       if (!entry) return;
       captionHeight = entry.borderBoxSize?.[0]?.blockSize ?? entry.contentRect.height;
     },
-    { box: 'border-box' },
+    { box: 'border-box', enabled: () => stickyHeader },
   );
 
   function onSortChange(column: string): void {

--- a/packages/components/src/components/table/table.svelte
+++ b/packages/components/src/components/table/table.svelte
@@ -28,6 +28,7 @@
   import type { TableProps } from './table.types.ts';
 
   import { classNames } from '../../utilities/class-names.ts';
+  import { useResizeObserver } from '../../utilities/use-resize-observer.svelte.ts';
 
   let {
     sort = $bindable(),
@@ -38,6 +39,24 @@
     class: className,
     children,
   }: TableProps = $props();
+
+  // A native <caption> (caption-side: top) renders above the table's border box
+  // but inside the same scroll container, so a sticky <thead> pinned at top: 0
+  // would overlap it. The caption's height is not knowable in pure CSS — `1lh`
+  // would assume a single line and break when the caption wraps (narrow
+  // container, long/localized text, large text settings). Measure the caption's
+  // border-box block size and expose it as a custom property the sticky `top`
+  // calc consumes, so the header always pins just below the real caption.
+  let captionHeight = $state(0);
+
+  const measureCaption = useResizeObserver(
+    (entries) => {
+      const entry = entries[0];
+      if (!entry) return;
+      captionHeight = entry.borderBoxSize[0]?.blockSize ?? entry.contentRect.height;
+    },
+    { box: 'border-box' },
+  );
 
   function onSortChange(column: string): void {
     if (!sort || sort.column !== column) {
@@ -67,9 +86,10 @@
   data-cinder-sticky-header={stickyHeader || undefined}
   data-cinder-density={density}
   data-cinder-selectable={selectable || undefined}
+  style:--cinder-table-caption-height={caption ? `${captionHeight}px` : undefined}
 >
   {#if caption}
-    <caption class="cinder-table__caption">{caption}</caption>
+    <caption class="cinder-table__caption" {@attach measureCaption}>{caption}</caption>
   {/if}
   {@render children()}
 </table>

--- a/packages/components/src/components/table/table.svelte
+++ b/packages/components/src/components/table/table.svelte
@@ -39,6 +39,10 @@
     children,
   }: TableProps = $props();
 
+  // A stable per-instance ID used to associate the hoisted caption div with the
+  // table via aria-labelledby when stickyHeader is true.
+  const captionId = $props.id();
+
   function onSortChange(column: string): void {
     if (!sort || sort.column !== column) {
       sort = { column, direction: 'ascending' };
@@ -62,14 +66,20 @@
   });
 </script>
 
-<table
-  class={classNames('cinder-table', className)}
-  data-cinder-sticky-header={stickyHeader || undefined}
-  data-cinder-density={density}
-  data-cinder-selectable={selectable || undefined}
->
-  {#if caption}
-    <caption class="cinder-table__caption">{caption}</caption>
+<div class={classNames('cinder-table-root', caption && stickyHeader ? 'cinder-table-root--captioned' : undefined)}>
+  {#if caption && stickyHeader}
+    <div id={captionId} class="cinder-table__caption--hoisted">{caption}</div>
   {/if}
-  {@render children()}
-</table>
+  <table
+    class={classNames('cinder-table', className)}
+    data-cinder-sticky-header={stickyHeader || undefined}
+    data-cinder-density={density}
+    data-cinder-selectable={selectable || undefined}
+    aria-labelledby={caption && stickyHeader ? captionId : undefined}
+  >
+    {#if caption && !stickyHeader}
+      <caption class="cinder-table__caption">{caption}</caption>
+    {/if}
+    {@render children()}
+  </table>
+</div>

--- a/packages/components/src/components/table/table.svelte
+++ b/packages/components/src/components/table/table.svelte
@@ -39,10 +39,6 @@
     children,
   }: TableProps = $props();
 
-  // A stable per-instance ID used to associate the hoisted caption div with the
-  // table via aria-labelledby when stickyHeader is true.
-  const captionId = $props.id();
-
   function onSortChange(column: string): void {
     if (!sort || sort.column !== column) {
       sort = { column, direction: 'ascending' };
@@ -66,20 +62,14 @@
   });
 </script>
 
-<div class={classNames('cinder-table-root', caption && stickyHeader ? 'cinder-table-root--captioned' : undefined)}>
-  {#if caption && stickyHeader}
-    <div id={captionId} class="cinder-table__caption--hoisted">{caption}</div>
+<table
+  class={classNames('cinder-table', className)}
+  data-cinder-sticky-header={stickyHeader || undefined}
+  data-cinder-density={density}
+  data-cinder-selectable={selectable || undefined}
+>
+  {#if caption}
+    <caption class="cinder-table__caption">{caption}</caption>
   {/if}
-  <table
-    class={classNames('cinder-table', className)}
-    data-cinder-sticky-header={stickyHeader || undefined}
-    data-cinder-density={density}
-    data-cinder-selectable={selectable || undefined}
-    aria-labelledby={caption && stickyHeader ? captionId : undefined}
-  >
-    {#if caption && !stickyHeader}
-      <caption class="cinder-table__caption">{caption}</caption>
-    {/if}
-    {@render children()}
-  </table>
-</div>
+  {@render children()}
+</table>

--- a/packages/components/src/components/table/table.test.ts
+++ b/packages/components/src/components/table/table.test.ts
@@ -1,5 +1,6 @@
 /// <reference lib="dom" />
 import { describe, expect, mock, test } from 'bun:test';
+import { tick } from 'svelte';
 
 import { stripCinderComponentsLayer } from '../../test/css.ts';
 import { setupHappyDom } from '../../test/happy-dom.ts';
@@ -167,6 +168,113 @@ describe('Table sticky header', () => {
     const { container } = render(Wrapper, { columns, rows, stickyHeader: true });
     expect(container.querySelector('.cinder-table__caption--hoisted')).toBeNull();
     expect(container.querySelector('caption')).toBeNull();
+  });
+});
+
+// A wrapped, multi-line caption is taller than `1lh`, so the prior hard-coded
+// sticky offset (`calc(space-3 + space-2 + 1lh)`) would let the pinned header
+// overlap the caption's lower lines. The fix measures the caption's real
+// border-box height with a ResizeObserver and feeds it to the sticky `top` via
+// the `--cinder-table-caption-height` custom property. happy-dom has no layout
+// engine, so the visual non-overlap is a Playwright concern — here we verify the
+// measurement WIRING (observer entry → custom property), which is the part that
+// regresses in JS. The hard-coded-to-variable swap in the CSS is asserted below.
+describe('Table sticky-header caption measurement', () => {
+  /** Captures the ResizeObserver callback the table registers so the test can
+   *  drive it with a synthetic entry carrying a known border-box height. */
+  class CapturingResizeObserver implements ResizeObserver {
+    static lastCallback: ResizeObserverCallback | null = null;
+    static lastObserver: CapturingResizeObserver | null = null;
+    readonly observed: Element[] = [];
+    constructor(callback: ResizeObserverCallback) {
+      CapturingResizeObserver.lastCallback = callback;
+      CapturingResizeObserver.lastObserver = this;
+    }
+    observe(target: Element): void {
+      this.observed.push(target);
+    }
+    unobserve(): void {}
+    disconnect(): void {}
+  }
+
+  async function withResizeObserver(run: () => void | Promise<void>): Promise<void> {
+    const original = globalThis.ResizeObserver;
+    CapturingResizeObserver.lastCallback = null;
+    CapturingResizeObserver.lastObserver = null;
+    globalThis.ResizeObserver = CapturingResizeObserver as unknown as typeof ResizeObserver;
+    try {
+      await run();
+    } finally {
+      globalThis.ResizeObserver = original;
+    }
+  }
+
+  test('writes the measured caption border-box height into --cinder-table-caption-height', async () => {
+    await withResizeObserver(async () => {
+      const { container } = render(Wrapper, {
+        columns,
+        rows,
+        stickyHeader: true,
+        caption: 'A caption long enough to wrap onto several lines in a narrow table',
+      });
+      // Let the attachment's $effect run so the observer is constructed and the
+      // <caption> is observed.
+      await tick();
+      const table = container.querySelector('table') as HTMLTableElement;
+      const caption = container.querySelector('caption') as HTMLTableCaptionElement;
+
+      // The attachment observed the real <caption> element.
+      expect(CapturingResizeObserver.lastObserver?.observed).toContain(caption);
+      // Before any measurement the custom property reads 0px (the CSS fallback).
+      expect(table.style.getPropertyValue('--cinder-table-caption-height')).toBe('0px');
+
+      // Drive the observer with a synthetic two-line caption height.
+      const entry = {
+        target: caption,
+        borderBoxSize: [{ blockSize: 60, inlineSize: 200 }],
+        contentRect: { height: 60 },
+      } as unknown as ResizeObserverEntry;
+      CapturingResizeObserver.lastCallback?.([entry], CapturingResizeObserver.lastObserver!);
+      // The callback updates the captionHeight $state; flush so the style: binding
+      // writes the new custom-property value to the DOM.
+      await tick();
+
+      expect(table.style.getPropertyValue('--cinder-table-caption-height')).toBe('60px');
+    });
+  });
+
+  test('falls back to contentRect.height when borderBoxSize is unavailable', async () => {
+    await withResizeObserver(async () => {
+      const { container } = render(Wrapper, {
+        columns,
+        rows,
+        stickyHeader: true,
+        caption: 'Wraps',
+      });
+      await tick();
+      const table = container.querySelector('table') as HTMLTableElement;
+      const caption = container.querySelector('caption') as HTMLTableCaptionElement;
+
+      const entry = {
+        target: caption,
+        borderBoxSize: [],
+        contentRect: { height: 42 },
+      } as unknown as ResizeObserverEntry;
+      CapturingResizeObserver.lastCallback?.([entry], CapturingResizeObserver.lastObserver!);
+      await tick();
+
+      expect(table.style.getPropertyValue('--cinder-table-caption-height')).toBe('42px');
+    });
+  });
+
+  test('a caption-less table does not emit the custom property', async () => {
+    await withResizeObserver(async () => {
+      const { container } = render(Wrapper, { columns, rows, stickyHeader: true });
+      await tick();
+      const table = container.querySelector('table') as HTMLTableElement;
+      // No caption → the `caption ? ... : undefined` guard omits the property.
+      expect(table.style.getPropertyValue('--cinder-table-caption-height')).toBe('');
+    });
   });
 });
 
@@ -600,16 +708,19 @@ describe('CSS rule assertions — sort indicator and focus ring', () => {
     expect(tableRule?.style.minInlineSize).toBe('max-content');
   });
 
-  test('sticky header offsets its top by the caption block size only when a caption is present', () => {
+  test('sticky header offsets its top by the measured caption height only when a caption is present', () => {
     // The native <caption> renders above the table border box; the sticky thead
     // must pin below it (not over it). The offset is scoped with :has(caption) so
-    // a caption-less sticky table keeps top: 0.
+    // a caption-less sticky table keeps top: 0. The offset is the caption's
+    // MEASURED border-box height (--cinder-table-caption-height, set by a
+    // ResizeObserver in table.svelte), not a hard-coded `1lh` — so a wrapped,
+    // multi-line caption no longer overlaps the pinned header.
     //
-    // Assert against the raw source: happy-dom's CSSOM drops a `top` whose calc()
-    // contains var() (it serializes to ""), so style.top is unreadable here even
+    // Assert against the raw source: happy-dom's CSSOM drops a `top` whose value
+    // is a var() (it serializes to ""), so style.top is unreadable here even
     // though the declaration is valid in real browsers. The presence of the rule
     // confirms the :has(caption) selector parsed; the source check confirms the
-    // 1lh-plus-padding offset is the value.
+    // measured-height variable is the value.
     const rule = injectTableCssAndFind(
       '.cinder-table[data-cinder-sticky-header]:has(caption) .cinder-table__header',
     );
@@ -617,7 +728,14 @@ describe('CSS rule assertions — sort indicator and focus ring', () => {
     expect(tableCss).toContain(
       '.cinder-table[data-cinder-sticky-header]:has(caption) .cinder-table__header',
     );
-    expect(tableCss).toContain('top: calc(var(--cinder-space-3) + var(--cinder-space-2) + 1lh)');
+    expect(tableCss).toContain('top: var(--cinder-table-caption-height, 0px)');
+    // Guard against a regression to the line-height assumption: the sticky-offset
+    // declaration must not resolve to a `1lh`-based calc. (The explanatory CSS
+    // comment may still mention `1lh` in prose, so match the declaration, not a
+    // bare substring.)
+    expect(tableCss).not.toContain(
+      'top: calc(var(--cinder-space-3) + var(--cinder-space-2) + 1lh)',
+    );
   });
 
   test('right-aligned sortable headers justify the sort button content to the end', () => {

--- a/packages/components/src/components/table/table.test.ts
+++ b/packages/components/src/components/table/table.test.ts
@@ -137,44 +137,33 @@ describe('Table sticky header', () => {
     expect(container.querySelector('table')?.hasAttribute('data-cinder-sticky-header')).toBe(false);
   });
 
-  test('stickyHeader=true with caption renders a hoisted div caption above the table (not a <caption> element)', () => {
-    const { container } = render(Wrapper, { columns, rows, stickyHeader: true, caption: 'Hoisted' });
-    // The hoisted div must exist and contain the caption text
-    const hoisted = container.querySelector('.cinder-table__caption--hoisted');
-    expect(hoisted).not.toBeNull();
-    expect(hoisted?.textContent?.trim()).toBe('Hoisted');
-    // No native <caption> element should be present in the sticky-header case
-    expect(container.querySelector('caption')).toBeNull();
+  test('stickyHeader=true with caption renders a native <caption> inside the table (not a hoisted div)', () => {
+    const { container } = render(Wrapper, { columns, rows, stickyHeader: true, caption: 'Sticky' });
+    // A real <caption> is the accessible name source; the sticky case must NOT
+    // downgrade to an external aria-labelledby'd div (lost table-caption semantics).
+    const caption = container.querySelector('caption');
+    expect(caption).not.toBeNull();
+    expect(caption?.textContent?.trim()).toBe('Sticky');
+    // The caption lives in the table subtree.
+    expect(caption?.closest('table')).not.toBeNull();
+    // No hoisted div, no external label.
+    expect(container.querySelector('.cinder-table__caption--hoisted')).toBeNull();
+    expect(container.querySelector('table')?.hasAttribute('aria-labelledby')).toBe(false);
   });
 
-  test('stickyHeader=true with caption: hoisted div appears before the <table> in the DOM', () => {
-    const { container } = render(Wrapper, { columns, rows, stickyHeader: true, caption: 'Hoisted' });
-    const hoisted = container.querySelector('.cinder-table__caption--hoisted');
-    const table = container.querySelector('table');
-    expect(hoisted).not.toBeNull();
-    expect(table).not.toBeNull();
-    // compareDocumentPosition returns a bitmask; DOCUMENT_POSITION_FOLLOWING (4) means
-    // table comes after hoisted, i.e. hoisted is before table.
-    expect(hoisted!.compareDocumentPosition(table!)).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
-  });
-
-  test('stickyHeader=true with caption: table has aria-labelledby pointing at the hoisted div id', () => {
-    const { container } = render(Wrapper, { columns, rows, stickyHeader: true, caption: 'Hoisted' });
-    const hoisted = container.querySelector('.cinder-table__caption--hoisted');
-    const table = container.querySelector('table');
-    const hoistedId = hoisted?.getAttribute('id');
-    expect(hoistedId).not.toBeNull();
-    expect(table?.getAttribute('aria-labelledby')).toBe(hoistedId);
-  });
-
-  test('stickyHeader=false with caption renders native <caption> element and no hoisted div', () => {
-    const { container } = render(Wrapper, { columns, rows, stickyHeader: false, caption: 'Native' });
+  test('stickyHeader=false with caption renders the same native <caption> (one code path)', () => {
+    const { container } = render(Wrapper, {
+      columns,
+      rows,
+      stickyHeader: false,
+      caption: 'Native',
+    });
     expect(container.querySelector('caption')?.textContent?.trim()).toBe('Native');
     expect(container.querySelector('.cinder-table__caption--hoisted')).toBeNull();
     expect(container.querySelector('table')?.hasAttribute('aria-labelledby')).toBe(false);
   });
 
-  test('stickyHeader=true without caption renders neither hoisted div nor <caption>', () => {
+  test('stickyHeader=true without caption renders no caption at all', () => {
     const { container } = render(Wrapper, { columns, rows, stickyHeader: true });
     expect(container.querySelector('.cinder-table__caption--hoisted')).toBeNull();
     expect(container.querySelector('caption')).toBeNull();
@@ -604,12 +593,31 @@ describe('CSS rule assertions — sort indicator and focus ring', () => {
 
   test('scroll wrapper owns horizontal overflow without changing table semantics', () => {
     const wrapperRule = injectTableCssAndFind('.cinder-table-scroll');
-    // The .cinder-table-root wrapper uses display:contents so the table appears
-    // as a direct layout child of .cinder-table-scroll; the CSS uses a descendant
-    // combinator to account for the transparent wrapper div in the DOM.
+    // The scroll wrapper owns horizontal overflow; the table inside it grows to
+    // its intrinsic width via a descendant combinator on `.cinder-table-scroll`.
     const tableRule = injectTableCssAndFind('.cinder-table-scroll .cinder-table');
     expect(wrapperRule?.style.overflowX).toBe('auto');
     expect(tableRule?.style.minInlineSize).toBe('max-content');
+  });
+
+  test('sticky header offsets its top by the caption block size only when a caption is present', () => {
+    // The native <caption> renders above the table border box; the sticky thead
+    // must pin below it (not over it). The offset is scoped with :has(caption) so
+    // a caption-less sticky table keeps top: 0.
+    //
+    // Assert against the raw source: happy-dom's CSSOM drops a `top` whose calc()
+    // contains var() (it serializes to ""), so style.top is unreadable here even
+    // though the declaration is valid in real browsers. The presence of the rule
+    // confirms the :has(caption) selector parsed; the source check confirms the
+    // 1lh-plus-padding offset is the value.
+    const rule = injectTableCssAndFind(
+      '.cinder-table[data-cinder-sticky-header]:has(caption) .cinder-table__header',
+    );
+    expect(rule).not.toBeNull();
+    expect(tableCss).toContain(
+      '.cinder-table[data-cinder-sticky-header]:has(caption) .cinder-table__header',
+    );
+    expect(tableCss).toContain('top: calc(var(--cinder-space-3) + var(--cinder-space-2) + 1lh)');
   });
 
   test('right-aligned sortable headers justify the sort button content to the end', () => {

--- a/packages/components/src/components/table/table.test.ts
+++ b/packages/components/src/components/table/table.test.ts
@@ -136,6 +136,49 @@ describe('Table sticky header', () => {
     const { container } = render(Wrapper, { columns, rows });
     expect(container.querySelector('table')?.hasAttribute('data-cinder-sticky-header')).toBe(false);
   });
+
+  test('stickyHeader=true with caption renders a hoisted div caption above the table (not a <caption> element)', () => {
+    const { container } = render(Wrapper, { columns, rows, stickyHeader: true, caption: 'Hoisted' });
+    // The hoisted div must exist and contain the caption text
+    const hoisted = container.querySelector('.cinder-table__caption--hoisted');
+    expect(hoisted).not.toBeNull();
+    expect(hoisted?.textContent?.trim()).toBe('Hoisted');
+    // No native <caption> element should be present in the sticky-header case
+    expect(container.querySelector('caption')).toBeNull();
+  });
+
+  test('stickyHeader=true with caption: hoisted div appears before the <table> in the DOM', () => {
+    const { container } = render(Wrapper, { columns, rows, stickyHeader: true, caption: 'Hoisted' });
+    const hoisted = container.querySelector('.cinder-table__caption--hoisted');
+    const table = container.querySelector('table');
+    expect(hoisted).not.toBeNull();
+    expect(table).not.toBeNull();
+    // compareDocumentPosition returns a bitmask; DOCUMENT_POSITION_FOLLOWING (4) means
+    // table comes after hoisted, i.e. hoisted is before table.
+    expect(hoisted!.compareDocumentPosition(table!)).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
+  });
+
+  test('stickyHeader=true with caption: table has aria-labelledby pointing at the hoisted div id', () => {
+    const { container } = render(Wrapper, { columns, rows, stickyHeader: true, caption: 'Hoisted' });
+    const hoisted = container.querySelector('.cinder-table__caption--hoisted');
+    const table = container.querySelector('table');
+    const hoistedId = hoisted?.getAttribute('id');
+    expect(hoistedId).not.toBeNull();
+    expect(table?.getAttribute('aria-labelledby')).toBe(hoistedId);
+  });
+
+  test('stickyHeader=false with caption renders native <caption> element and no hoisted div', () => {
+    const { container } = render(Wrapper, { columns, rows, stickyHeader: false, caption: 'Native' });
+    expect(container.querySelector('caption')?.textContent?.trim()).toBe('Native');
+    expect(container.querySelector('.cinder-table__caption--hoisted')).toBeNull();
+    expect(container.querySelector('table')?.hasAttribute('aria-labelledby')).toBe(false);
+  });
+
+  test('stickyHeader=true without caption renders neither hoisted div nor <caption>', () => {
+    const { container } = render(Wrapper, { columns, rows, stickyHeader: true });
+    expect(container.querySelector('.cinder-table__caption--hoisted')).toBeNull();
+    expect(container.querySelector('caption')).toBeNull();
+  });
 });
 
 describe('Table density', () => {
@@ -561,7 +604,10 @@ describe('CSS rule assertions — sort indicator and focus ring', () => {
 
   test('scroll wrapper owns horizontal overflow without changing table semantics', () => {
     const wrapperRule = injectTableCssAndFind('.cinder-table-scroll');
-    const tableRule = injectTableCssAndFind('.cinder-table-scroll > .cinder-table');
+    // The .cinder-table-root wrapper uses display:contents so the table appears
+    // as a direct layout child of .cinder-table-scroll; the CSS uses a descendant
+    // combinator to account for the transparent wrapper div in the DOM.
+    const tableRule = injectTableCssAndFind('.cinder-table-scroll .cinder-table');
     expect(wrapperRule?.style.overflowX).toBe('auto');
     expect(tableRule?.style.minInlineSize).toBe('max-content');
   });

--- a/packages/components/src/components/table/table.test.ts
+++ b/packages/components/src/components/table/table.test.ts
@@ -276,6 +276,18 @@ describe('Table sticky-header caption measurement', () => {
       expect(table.style.getPropertyValue('--cinder-table-caption-height')).toBe('');
     });
   });
+
+  test('a non-sticky captioned table does not observe the caption (no wasted observer)', async () => {
+    // captionHeight is only consumed by the sticky-header offset, so the
+    // observer is gated on `stickyHeader`. A common non-sticky captioned table
+    // must not run a ResizeObserver.
+    await withResizeObserver(async () => {
+      render(Wrapper, { columns, rows, stickyHeader: false, caption: 'Plain caption' });
+      await tick();
+      // The `enabled: () => stickyHeader` gate skips observation entirely.
+      expect(CapturingResizeObserver.lastObserver?.observed ?? []).toHaveLength(0);
+    });
+  });
 });
 
 describe('Table density', () => {

--- a/packages/components/src/components/tabs/tabs.css
+++ b/packages/components/src/components/tabs/tabs.css
@@ -57,6 +57,7 @@
     padding: var(--cinder-space-2) var(--cinder-space-3);
     font: inherit;
     font-size: var(--cinder-text-sm);
+    font-weight: var(--cinder-font-medium);
     color: var(--cinder-text-muted);
     cursor: pointer;
     position: relative;
@@ -96,7 +97,6 @@
 
   .cinder-tab[data-cinder-active] {
     color: var(--cinder-accent-text);
-    font-weight: var(--cinder-font-medium);
   }
 
   /* Active indicator — bottom (horizontal) / right (vertical) accent stripe. */

--- a/packages/components/src/components/tabs/tabs.test.ts
+++ b/packages/components/src/components/tabs/tabs.test.ts
@@ -82,6 +82,31 @@ describe('Tabs responsive CSS', () => {
   });
 });
 
+describe('Tabs font-weight layout stability (regression #402)', () => {
+  // The fix for #402 moved font-weight from [data-cinder-active] to the base
+  // .cinder-tab rule so that activating a sibling does not toggle a tab's weight
+  // and cause layout shift / offsetWidth change in neighbouring tabs.
+
+  test('base .cinder-tab rule carries font-weight (weight is always applied)', () => {
+    // The base rule must set font-weight so the weight never changes on activation.
+    expect(tabsCss).toMatch(/\.cinder-tab\s*\{[^}]*font-weight\s*:/);
+  });
+
+  test('[data-cinder-active] rule does NOT set font-weight (no weight toggle)', () => {
+    // Extracting just the [data-cinder-active] block and asserting font-weight is absent
+    // prevents the sibling-jank regression: an inactive tab's offsetWidth must not
+    // change when a sibling activates.
+    const activeBlockMatch = tabsCss.match(
+      /\.cinder-tab\[data-cinder-active\]\s*\{([^}]*)\}/,
+    );
+    // The selector must exist (active state is styled).
+    expect(activeBlockMatch).not.toBeNull();
+    // The block must NOT contain font-weight.
+    const activeBlock = activeBlockMatch![1];
+    expect(activeBlock).not.toContain('font-weight');
+  });
+});
+
 describe('Tabs activation', () => {
   test('clicking a tab activates it and reveals its panel', async () => {
     const { container } = render(Wrapper, { value: 'a', items });

--- a/packages/components/src/components/tag-input/tag-input.css
+++ b/packages/components/src/components/tag-input/tag-input.css
@@ -77,9 +77,9 @@
     max-inline-size: 100%;
     padding-inline: var(--cinder-space-2);
     padding-block: var(--cinder-space-1);
-    border: 1px solid var(--cinder-border-muted);
+    border: 1px solid var(--cinder-border);
     border-radius: var(--cinder-radius-full);
-    background: var(--cinder-surface-inset);
+    background: color-mix(in oklch, var(--cinder-surface-inset), var(--cinder-surface) 60%);
     color: var(--cinder-text);
     cursor: default;
   }

--- a/packages/components/src/components/tag-input/tag-input.svelte
+++ b/packages/components/src/components/tag-input/tag-input.svelte
@@ -25,6 +25,7 @@
     composeDescribedBy,
     resolveFieldControl,
   } from '../../_internal/field-control.ts';
+  import VisuallyHiddenLiveRegion from '../_visually-hidden-live-region.svelte';
   import { getFormFieldContext } from '../../_internal/form-field-context.ts';
   import { classNames } from '../../utilities/class-names.ts';
   import { handleRovingKeydown, isRovingKey } from '../../utilities/roving-tabindex.ts';
@@ -69,6 +70,7 @@
   let inlineError = $state<string | null>(null);
   let uncontrolledTags = $state(initialDefaultTags);
   let focusedChipIndex = $state(-1);
+  let statusAnnouncement = $state('');
 
   const isControlled = $derived(value !== undefined);
   const currentTags = $derived(isControlled ? (value ?? []) : uncontrolledTags);
@@ -228,14 +230,17 @@
     draftValue = '';
     focusedChipIndex = -1;
     setTags([...currentTags, candidate]);
+    statusAnnouncement = `${candidate} added.`;
     return true;
   }
 
   function removeTag(index: number): void {
     if (field.disabled || resolvedReadonly) return;
     inlineError = null;
+    const removed = currentTags[index] ?? '';
     const nextTags = currentTags.filter((_, candidateIndex) => candidateIndex !== index);
     setTags(nextTags);
+    if (removed) statusAnnouncement = `${removed} removed.`;
   }
 
   function focusAfterRemove(index: number): void {
@@ -416,4 +421,5 @@
       <input type="hidden" {name} value={tag} disabled={field.disabled} />
     {/each}
   {/if}
+  <VisuallyHiddenLiveRegion message={statusAnnouncement} />
 </div>

--- a/packages/components/src/components/tag-input/tag-input.svelte
+++ b/packages/components/src/components/tag-input/tag-input.svelte
@@ -71,6 +71,15 @@
   let uncontrolledTags = $state(initialDefaultTags);
   let focusedChipIndex = $state(-1);
   let statusAnnouncement = $state('');
+  // Bumped on every announce so the live region re-fires even when two consecutive
+  // announcements share the same text (e.g. adding the same tag again) — a same-value
+  // `$state` assignment is a no-op in Svelte 5 and would otherwise be swallowed.
+  let statusAnnouncementSequence = $state(0);
+
+  function announceStatus(announcement: string): void {
+    statusAnnouncement = announcement;
+    statusAnnouncementSequence += 1;
+  }
 
   const isControlled = $derived(value !== undefined);
   const currentTags = $derived(isControlled ? (value ?? []) : uncontrolledTags);
@@ -230,7 +239,7 @@
     draftValue = '';
     focusedChipIndex = -1;
     setTags([...currentTags, candidate]);
-    statusAnnouncement = `${candidate} added.`;
+    announceStatus(`${candidate} added.`);
     return true;
   }
 
@@ -240,7 +249,7 @@
     const removed = currentTags[index] ?? '';
     const nextTags = currentTags.filter((_, candidateIndex) => candidateIndex !== index);
     setTags(nextTags);
-    if (removed) statusAnnouncement = `${removed} removed.`;
+    if (removed) announceStatus(`${removed} removed.`);
   }
 
   function focusAfterRemove(index: number): void {
@@ -421,5 +430,8 @@
       <input type="hidden" {name} value={tag} disabled={field.disabled} />
     {/each}
   {/if}
-  <VisuallyHiddenLiveRegion message={statusAnnouncement} />
+  <VisuallyHiddenLiveRegion
+    message={statusAnnouncement}
+    announcementSequence={statusAnnouncementSequence}
+  />
 </div>

--- a/packages/components/src/components/tag-input/tag-input.test.ts
+++ b/packages/components/src/components/tag-input/tag-input.test.ts
@@ -612,14 +612,24 @@ describe('TagInput ARIA live announcements', () => {
     expect(liveRegion?.textContent).toContain('Svelte added.');
 
     // Second add of the SAME value (allowDuplicates=true, no intervening removal).
-    // The live region still holds "Svelte added." — the blank-then-set cycle
-    // must set it to '' first so the identical string re-triggers the AT.
+    // The live region still holds "Svelte added." — the announcementSequence bump
+    // re-runs the region's effect, which blanks the text to '' first so the
+    // identical string re-triggers the AT.
     await fireEvent.input(input, { target: { value: 'Svelte' } });
     await fireEvent.keyDown(input, { key: 'Enter' });
+
+    // Load-bearing assertion: after the second add (before the deferred setTimeout(0)
+    // fires) the region must transition through the blank state. Without the
+    // announcementSequence fix, the same-value $state assignment is a Svelte 5 no-op,
+    // the effect never runs, and the content stays "Svelte added." — making THIS
+    // assertion fail. That is what makes this a genuine regression guard.
+    await tick();
+    expect(container.querySelector('[role="status"]')?.textContent?.trim()).toBe('');
+
     await flushLiveRegion();
 
-    // After the macro-task the content must be back to "Svelte added." — not
-    // still the blank state or something else.
+    // After the macro-task the content must be back to "Svelte added." — proving the
+    // identical message was genuinely re-announced.
     expect(container.querySelector('[role="status"]')?.textContent).toContain('Svelte added.');
   });
 });

--- a/packages/components/src/components/tag-input/tag-input.test.ts
+++ b/packages/components/src/components/tag-input/tag-input.test.ts
@@ -561,6 +561,68 @@ describe('TagInput FormField wiring', () => {
   });
 });
 
+describe('TagInput ARIA live announcements', () => {
+  async function flushLiveRegion() {
+    // VisuallyHiddenLiveRegion uses setTimeout(0) for blank-then-set timing;
+    // we need to let that macro-task complete.
+    await new Promise<void>((resolve) => setTimeout(resolve, 0));
+    await tick();
+  }
+
+  test('announces "<tag> added." in the live region after committing via Enter', async () => {
+    const { container } = render(TagInput, { id: 'live-add' });
+    const input = container.querySelector('input') as HTMLInputElement;
+
+    await fireEvent.input(input, { target: { value: 'Svelte' } });
+    await fireEvent.keyDown(input, { key: 'Enter' });
+    await flushLiveRegion();
+
+    const liveRegion = container.querySelector('[role="status"]');
+    expect(liveRegion?.textContent).toContain('Svelte added.');
+  });
+
+  test('announces "<tag> removed." after clicking the remove button', async () => {
+    const { container } = render(TagInput, { id: 'live-remove', defaultValue: ['Svelte'] });
+
+    const removeButton = container.querySelector('.cinder-tag-input__remove') as HTMLElement;
+    expect(removeButton).not.toBeNull();
+
+    await fireEvent.click(removeButton);
+    await flushLiveRegion();
+
+    const liveRegion = container.querySelector('[role="status"]');
+    expect(liveRegion?.textContent).toContain('Svelte removed.');
+  });
+
+  test('consecutive identical add announcements both fire via blank-then-set', async () => {
+    const { container } = render(TagInput, { id: 'live-repeat', allowDuplicates: true });
+    const input = container.querySelector('input') as HTMLInputElement;
+
+    // First add
+    await fireEvent.input(input, { target: { value: 'Svelte' } });
+    await fireEvent.keyDown(input, { key: 'Enter' });
+    await flushLiveRegion();
+
+    let liveRegion = container.querySelector('[role="status"]');
+    expect(liveRegion?.textContent).toContain('Svelte added.');
+
+    // Remove it (to have something to re-add)
+    const removeButton = container.querySelector('.cinder-tag-input__remove') as HTMLElement;
+    await fireEvent.click(removeButton);
+    await flushLiveRegion();
+
+    expect(container.querySelector('[role="status"]')?.textContent).toContain('Svelte removed.');
+
+    // Second add of same value — live region should re-announce
+    await fireEvent.input(input, { target: { value: 'Svelte' } });
+    await fireEvent.keyDown(input, { key: 'Enter' });
+    await flushLiveRegion();
+
+    liveRegion = container.querySelector('[role="status"]');
+    expect(liveRegion?.textContent).toContain('Svelte added.');
+  });
+});
+
 describe('TagInput CSS contract', () => {
   test('focus-within ring, invalid override, and forced-colors fallback stay encoded in the CSS', async () => {
     const css = await Bun.file(new URL('./tag-input.css', import.meta.url)).text();

--- a/packages/components/src/components/tag-input/tag-input.test.ts
+++ b/packages/components/src/components/tag-input/tag-input.test.ts
@@ -595,31 +595,32 @@ describe('TagInput ARIA live announcements', () => {
   });
 
   test('consecutive identical add announcements both fire via blank-then-set', async () => {
+    // This test specifically exercises the blank-then-set reset path: the same
+    // announcement string ("Svelte added.") must re-fire even when the live
+    // region already contains that exact text from the previous commit. A naive
+    // assignment of the same string would be a no-op for the AT; blank-then-set
+    // is the only mechanism that guarantees re-announcement.
     const { container } = render(TagInput, { id: 'live-repeat', allowDuplicates: true });
     const input = container.querySelector('input') as HTMLInputElement;
 
-    // First add
+    // First add — live region should show "Svelte added."
     await fireEvent.input(input, { target: { value: 'Svelte' } });
     await fireEvent.keyDown(input, { key: 'Enter' });
     await flushLiveRegion();
 
-    let liveRegion = container.querySelector('[role="status"]');
+    const liveRegion = container.querySelector('[role="status"]');
     expect(liveRegion?.textContent).toContain('Svelte added.');
 
-    // Remove it (to have something to re-add)
-    const removeButton = container.querySelector('.cinder-tag-input__remove') as HTMLElement;
-    await fireEvent.click(removeButton);
-    await flushLiveRegion();
-
-    expect(container.querySelector('[role="status"]')?.textContent).toContain('Svelte removed.');
-
-    // Second add of same value — live region should re-announce
+    // Second add of the SAME value (allowDuplicates=true, no intervening removal).
+    // The live region still holds "Svelte added." — the blank-then-set cycle
+    // must set it to '' first so the identical string re-triggers the AT.
     await fireEvent.input(input, { target: { value: 'Svelte' } });
     await fireEvent.keyDown(input, { key: 'Enter' });
     await flushLiveRegion();
 
-    liveRegion = container.querySelector('[role="status"]');
-    expect(liveRegion?.textContent).toContain('Svelte added.');
+    // After the macro-task the content must be back to "Svelte added." — not
+    // still the blank state or something else.
+    expect(container.querySelector('[role="status"]')?.textContent).toContain('Svelte added.');
   });
 });
 

--- a/packages/components/src/components/textarea/textarea.css
+++ b/packages/components/src/components/textarea/textarea.css
@@ -93,6 +93,7 @@
   }
 
   .cinder-textarea[aria-invalid='true']:focus-visible {
+    border-color: transparent;
     box-shadow:
       0 0 0 var(--cinder-ring-offset) var(--cinder-ring-offset-color),
       0 0 0 calc(var(--cinder-ring-offset) + var(--cinder-ring-width)) var(--cinder-danger);

--- a/packages/components/src/components/toast-region/toast-region.svelte
+++ b/packages/components/src/components/toast-region/toast-region.svelte
@@ -565,6 +565,18 @@
 
   setToastContext({ show, dismiss, dismissAll, promise });
 
+  // The dismiss button's accessible name embeds the message so stacked toasts
+  // have distinguishable controls ("Dismiss: File saved" vs "Dismiss: Upload
+  // failed"). The full message is already announced by the live region, so a
+  // long (rich/error) message is bounded here to keep the control name short.
+  const DISMISS_LABEL_MAX = 60;
+
+  function dismissLabel(message: string): string {
+    const trimmed = message.trim();
+    if (trimmed.length <= DISMISS_LABEL_MAX) return `Dismiss: ${trimmed}`;
+    return `Dismiss: ${trimmed.slice(0, DISMISS_LABEL_MAX - 1).trimEnd()}…`;
+  }
+
   onDestroy(() => {
     // Tear down timers so unmounting the region (e.g., during route change)
     // doesn't leak timers that fire later and try to mutate disposed state.
@@ -606,19 +618,35 @@
         <div class="cinder-toast__icon" aria-hidden="true">
           {#if toast.variant === 'success'}
             <svg viewBox="0 0 20 20" fill="currentColor" style="color: var(--_cinder-toast-accent)">
-              <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.857-9.809a.75.75 0 00-1.214-.882l-3.483 4.79-1.88-1.88a.75.75 0 10-1.06 1.061l2.5 2.5a.75.75 0 001.137-.089l4-5.5z" clip-rule="evenodd" />
+              <path
+                fill-rule="evenodd"
+                d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.857-9.809a.75.75 0 00-1.214-.882l-3.483 4.79-1.88-1.88a.75.75 0 10-1.06 1.061l2.5 2.5a.75.75 0 001.137-.089l4-5.5z"
+                clip-rule="evenodd"
+              />
             </svg>
           {:else if toast.variant === 'warning'}
             <svg viewBox="0 0 20 20" fill="currentColor" style="color: var(--_cinder-toast-accent)">
-              <path fill-rule="evenodd" d="M8.485 2.495c.673-1.167 2.357-1.167 3.03 0l6.28 10.875c.673 1.167-.17 2.625-1.516 2.625H3.72c-1.347 0-2.189-1.458-1.515-2.625L8.485 2.495zM10 5a.75.75 0 01.75.75v3.5a.75.75 0 01-1.5 0v-3.5A.75.75 0 0110 5zm0 9a1 1 0 100-2 1 1 0 000 2z" clip-rule="evenodd" />
+              <path
+                fill-rule="evenodd"
+                d="M8.485 2.495c.673-1.167 2.357-1.167 3.03 0l6.28 10.875c.673 1.167-.17 2.625-1.516 2.625H3.72c-1.347 0-2.189-1.458-1.515-2.625L8.485 2.495zM10 5a.75.75 0 01.75.75v3.5a.75.75 0 01-1.5 0v-3.5A.75.75 0 0110 5zm0 9a1 1 0 100-2 1 1 0 000 2z"
+                clip-rule="evenodd"
+              />
             </svg>
           {:else if toast.variant === 'danger'}
             <svg viewBox="0 0 20 20" fill="currentColor" style="color: var(--_cinder-toast-accent)">
-              <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM8.28 7.22a.75.75 0 00-1.06 1.06L8.94 10l-1.72 1.72a.75.75 0 101.06 1.06L10 11.06l1.72 1.72a.75.75 0 101.06-1.06L11.06 10l1.72-1.72a.75.75 0 00-1.06-1.06L10 8.94 8.28 7.22z" clip-rule="evenodd" />
+              <path
+                fill-rule="evenodd"
+                d="M10 18a8 8 0 100-16 8 8 0 000 16zM8.28 7.22a.75.75 0 00-1.06 1.06L8.94 10l-1.72 1.72a.75.75 0 101.06 1.06L10 11.06l1.72 1.72a.75.75 0 101.06-1.06L11.06 10l1.72-1.72a.75.75 0 00-1.06-1.06L10 8.94 8.28 7.22z"
+                clip-rule="evenodd"
+              />
             </svg>
           {:else}
             <svg viewBox="0 0 20 20" fill="currentColor" style="color: var(--_cinder-toast-accent)">
-              <path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a.75.75 0 000 1.5h.253a.25.25 0 01.244.304l-.459 2.066A1.75 1.75 0 0010.747 15H11a.75.75 0 000-1.5h-.253a.25.25 0 01-.244-.304l.459-2.066A1.75 1.75 0 009.253 9H9z" clip-rule="evenodd" />
+              <path
+                fill-rule="evenodd"
+                d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a.75.75 0 000 1.5h.253a.25.25 0 01.244.304l-.459 2.066A1.75 1.75 0 0010.747 15H11a.75.75 0 000-1.5h-.253a.25.25 0 01-.244-.304l.459-2.066A1.75 1.75 0 009.253 9H9z"
+                clip-rule="evenodd"
+              />
             </svg>
           {/if}
         </div>
@@ -641,7 +669,7 @@
         <button
           type="button"
           class="cinder-toast__dismiss"
-          aria-label={`Dismiss: ${toast.message}`}
+          aria-label={dismissLabel(toast.message)}
           disabled={toast.leaving}
           onclick={() => beginDismiss(toast.id, 'dismiss-button')}
         >

--- a/packages/components/src/components/toast-region/toast-region.svelte
+++ b/packages/components/src/components/toast-region/toast-region.svelte
@@ -170,6 +170,7 @@
         variant,
         duration,
         dismissible,
+        showIcon: options.showIcon ?? false,
         generation: 0,
         pending: options.pending ?? false,
         leaving: false,
@@ -188,6 +189,7 @@
       variant,
       duration,
       dismissible,
+      showIcon: options.showIcon ?? false,
       generation: nextGeneration(id),
       pending: options.pending ?? false,
       leaving: false,
@@ -600,6 +602,26 @@
     >
       {#if toast.icon}
         <div class="cinder-toast__icon" aria-hidden="true">{@render toast.icon()}</div>
+      {:else if toast.showIcon}
+        <div class="cinder-toast__icon" aria-hidden="true">
+          {#if toast.variant === 'success'}
+            <svg viewBox="0 0 20 20" fill="currentColor" style="color: var(--_cinder-toast-accent)">
+              <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.857-9.809a.75.75 0 00-1.214-.882l-3.483 4.79-1.88-1.88a.75.75 0 10-1.06 1.061l2.5 2.5a.75.75 0 001.137-.089l4-5.5z" clip-rule="evenodd" />
+            </svg>
+          {:else if toast.variant === 'warning'}
+            <svg viewBox="0 0 20 20" fill="currentColor" style="color: var(--_cinder-toast-accent)">
+              <path fill-rule="evenodd" d="M8.485 2.495c.673-1.167 2.357-1.167 3.03 0l6.28 10.875c.673 1.167-.17 2.625-1.516 2.625H3.72c-1.347 0-2.189-1.458-1.515-2.625L8.485 2.495zM10 5a.75.75 0 01.75.75v3.5a.75.75 0 01-1.5 0v-3.5A.75.75 0 0110 5zm0 9a1 1 0 100-2 1 1 0 000 2z" clip-rule="evenodd" />
+            </svg>
+          {:else if toast.variant === 'danger'}
+            <svg viewBox="0 0 20 20" fill="currentColor" style="color: var(--_cinder-toast-accent)">
+              <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM8.28 7.22a.75.75 0 00-1.06 1.06L8.94 10l-1.72 1.72a.75.75 0 101.06 1.06L10 11.06l1.72 1.72a.75.75 0 101.06-1.06L11.06 10l1.72-1.72a.75.75 0 00-1.06-1.06L10 8.94 8.28 7.22z" clip-rule="evenodd" />
+            </svg>
+          {:else}
+            <svg viewBox="0 0 20 20" fill="currentColor" style="color: var(--_cinder-toast-accent)">
+              <path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a.75.75 0 000 1.5h.253a.25.25 0 01.244.304l-.459 2.066A1.75 1.75 0 0010.747 15H11a.75.75 0 000-1.5h-.253a.25.25 0 01-.244-.304l.459-2.066A1.75 1.75 0 009.253 9H9z" clip-rule="evenodd" />
+            </svg>
+          {/if}
+        </div>
       {/if}
       {#if toast.pending}
         <span class="cinder-toast__spinner" aria-hidden="true"></span>
@@ -619,7 +641,7 @@
         <button
           type="button"
           class="cinder-toast__dismiss"
-          aria-label="Dismiss notification"
+          aria-label={`Dismiss: ${toast.message}`}
           disabled={toast.leaving}
           onclick={() => beginDismiss(toast.id, 'dismiss-button')}
         >

--- a/packages/components/src/components/toast-region/toast-region.svelte
+++ b/packages/components/src/components/toast-region/toast-region.svelte
@@ -573,6 +573,9 @@
 
   function dismissLabel(message: string): string {
     const trimmed = message.trim();
+    // An empty/whitespace message would yield a dangling "Dismiss: " — a
+    // low-quality control name for assistive tech. Fall back to a generic label.
+    if (trimmed.length === 0) return 'Dismiss notification';
     if (trimmed.length <= DISMISS_LABEL_MAX) return `Dismiss: ${trimmed}`;
     return `Dismiss: ${trimmed.slice(0, DISMISS_LABEL_MAX - 1).trimEnd()}…`;
   }

--- a/packages/components/src/components/toast-region/toast-region.test.ts
+++ b/packages/components/src/components/toast-region/toast-region.test.ts
@@ -1039,6 +1039,27 @@ describe('toast dismiss button label', () => {
       expect(label).toEndWith('…');
     });
   });
+
+  test('dismiss button aria-label falls back to a generic label for an empty/whitespace message', async () => {
+    // A blank message would otherwise yield a dangling "Dismiss: " — a
+    // low-quality control name for assistive tech.
+    let api: ToastApi | null = null;
+    const { container } = render(Wrapper, {
+      props: {
+        onReady: (a: ToastApi) => {
+          api = a;
+        },
+      },
+    });
+    await waitFor(() => expect(api).not.toBeNull());
+
+    api!.show('   ', { dismissible: true, duration: 0 });
+    await waitFor(() => {
+      const dismissButton = container.querySelector('.cinder-toast__dismiss');
+      expect(dismissButton).not.toBeNull();
+      expect(dismissButton?.getAttribute('aria-label')).toBe('Dismiss notification');
+    });
+  });
 });
 
 describe('toast variant icons', () => {

--- a/packages/components/src/components/toast-region/toast-region.test.ts
+++ b/packages/components/src/components/toast-region/toast-region.test.ts
@@ -971,6 +971,109 @@ describe('useToast api', () => {
   });
 });
 
+describe('toast dismiss button label', () => {
+  test('dismiss button aria-label includes the toast message', async () => {
+    let api: ToastApi | null = null;
+    const { container } = render(Wrapper, {
+      props: {
+        onReady: (a: ToastApi) => {
+          api = a;
+        },
+      },
+    });
+    await waitFor(() => expect(api).not.toBeNull());
+
+    api!.show('File saved', { dismissible: true, duration: 0 });
+    await waitFor(() => {
+      const dismissButton = container.querySelector('.cinder-toast__dismiss');
+      expect(dismissButton).not.toBeNull();
+      expect(dismissButton?.getAttribute('aria-label')).toBe('Dismiss: File saved');
+    });
+  });
+
+  test('stacked toasts each have a distinct dismiss aria-label', async () => {
+    let api: ToastApi | null = null;
+    const { container } = render(Wrapper, {
+      props: {
+        onReady: (a: ToastApi) => {
+          api = a;
+        },
+      },
+    });
+    await waitFor(() => expect(api).not.toBeNull());
+
+    api!.show('File saved', { dismissible: true, duration: 0, id: 'msg-1' });
+    api!.show('Upload failed', { dismissible: true, duration: 0, id: 'msg-2', variant: 'danger' });
+
+    await waitFor(() => {
+      const buttons = Array.from(container.querySelectorAll('.cinder-toast__dismiss'));
+      expect(buttons.length).toBeGreaterThanOrEqual(2);
+      const labels = buttons.map((b) => b.getAttribute('aria-label'));
+      expect(labels).toContain('Dismiss: File saved');
+      expect(labels).toContain('Dismiss: Upload failed');
+    });
+  });
+});
+
+describe('toast variant icons', () => {
+  test('info toast renders default icon when showIcon=true', async () => {
+    let api: ToastApi | null = null;
+    const { container } = render(Wrapper, {
+      props: {
+        onReady: (a: ToastApi) => {
+          api = a;
+        },
+      },
+    });
+    await waitFor(() => expect(api).not.toBeNull());
+
+    api!.show('Information message', { variant: 'info', duration: 0, showIcon: true });
+    await waitFor(() => {
+      const toastIcon = container.querySelector('.cinder-toast__icon');
+      expect(toastIcon).not.toBeNull();
+    });
+  });
+
+  test('showIcon=false suppresses the default icon', async () => {
+    let api: ToastApi | null = null;
+    const { container } = render(Wrapper, {
+      props: {
+        onReady: (a: ToastApi) => {
+          api = a;
+        },
+      },
+    });
+    await waitFor(() => expect(api).not.toBeNull());
+
+    api!.show('No icon', { variant: 'info', duration: 0, showIcon: false });
+    await waitFor(() => {
+      expect(container.querySelector('.cinder-toast__icon')).toBeNull();
+    });
+  });
+
+  test('consumer icon prop overrides default icon regardless of showIcon', async () => {
+    let api: ToastApi | null = null;
+    const { container } = render(Wrapper, {
+      props: {
+        onReady: (a: ToastApi) => {
+          api = a;
+        },
+      },
+    });
+    await waitFor(() => expect(api).not.toBeNull());
+
+    const customIcon = createRawSnippet(() => ({
+      render: () => `<span data-testid="custom-icon">★</span>`,
+    }));
+
+    api!.show('Custom icon', { variant: 'info', duration: 0, icon: customIcon });
+    await waitFor(() => {
+      const customEl = container.querySelector('[data-testid="custom-icon"]');
+      expect(customEl).not.toBeNull();
+    });
+  });
+});
+
 describe('useToast outside a region', () => {
   test('throws when called outside of any component (getContext lifecycle)', async () => {
     // useToast() ultimately calls getContext, which Svelte requires to run

--- a/packages/components/src/components/toast-region/toast-region.test.ts
+++ b/packages/components/src/components/toast-region/toast-region.test.ts
@@ -1013,6 +1013,32 @@ describe('toast dismiss button label', () => {
       expect(labels).toContain('Dismiss: Upload failed');
     });
   });
+
+  test('dismiss button aria-label is bounded for a long message (the full text is in the live region)', async () => {
+    let api: ToastApi | null = null;
+    const { container } = render(Wrapper, {
+      props: {
+        onReady: (a: ToastApi) => {
+          api = a;
+        },
+      },
+    });
+    await waitFor(() => expect(api).not.toBeNull());
+
+    const longMessage =
+      'Upload failed because the connection to the server was interrupted partway through the transfer; please retry.';
+    api!.show(longMessage, { dismissible: true, duration: 0, variant: 'danger' });
+
+    await waitFor(() => {
+      const dismissButton = container.querySelector('.cinder-toast__dismiss');
+      expect(dismissButton).not.toBeNull();
+      const label = dismissButton?.getAttribute('aria-label') ?? '';
+      // Bounded: not the entire message dumped into the control name.
+      expect(label.length).toBeLessThan(longMessage.length);
+      expect(label).toStartWith('Dismiss: ');
+      expect(label).toEndWith('…');
+    });
+  });
 });
 
 describe('toast variant icons', () => {

--- a/packages/components/src/components/toast-region/toast-region.test.ts
+++ b/packages/components/src/components/toast-region/toast-region.test.ts
@@ -1051,6 +1051,96 @@ describe('toast variant icons', () => {
     });
   });
 
+  test('success toast renders its distinct checkmark icon when showIcon=true', async () => {
+    let api: ToastApi | null = null;
+    const { container } = render(Wrapper, {
+      props: {
+        onReady: (a: ToastApi) => {
+          api = a;
+        },
+      },
+    });
+    await waitFor(() => expect(api).not.toBeNull());
+
+    api!.show('Saved', { variant: 'success', duration: 0, showIcon: true });
+    await waitFor(() => {
+      const iconWrapper = container.querySelector('.cinder-toast__icon');
+      expect(iconWrapper).not.toBeNull();
+      // Success branch: fill-rule="evenodd" path contains the checkmark shape.
+      const svg = iconWrapper?.querySelector('svg');
+      expect(svg).not.toBeNull();
+      const path = svg?.querySelector('path');
+      // The success path includes the clip-rule="evenodd" checkmark.
+      expect(path?.getAttribute('d')).toContain('3.857-9.809');
+    });
+  });
+
+  test('warning toast renders its distinct triangle icon when showIcon=true', async () => {
+    let api: ToastApi | null = null;
+    const { container } = render(Wrapper, {
+      props: {
+        onReady: (a: ToastApi) => {
+          api = a;
+        },
+      },
+    });
+    await waitFor(() => expect(api).not.toBeNull());
+
+    api!.show('Caution', { variant: 'warning', duration: 0, showIcon: true });
+    await waitFor(() => {
+      const assertive = container.querySelector('[role="alert"]');
+      const iconWrapper = assertive?.querySelector('.cinder-toast__icon');
+      expect(iconWrapper).not.toBeNull();
+      const svg = iconWrapper?.querySelector('svg');
+      expect(svg).not.toBeNull();
+      const path = svg?.querySelector('path');
+      // The warning path contains the triangle/exclamation shape.
+      expect(path?.getAttribute('d')).toContain('8.485 2.495');
+    });
+  });
+
+  test('danger toast renders its distinct X-circle icon when showIcon=true', async () => {
+    let api: ToastApi | null = null;
+    const { container } = render(Wrapper, {
+      props: {
+        onReady: (a: ToastApi) => {
+          api = a;
+        },
+      },
+    });
+    await waitFor(() => expect(api).not.toBeNull());
+
+    api!.show('Error', { variant: 'danger', duration: 0, showIcon: true });
+    await waitFor(() => {
+      const assertive = container.querySelector('[role="alert"]');
+      const iconWrapper = assertive?.querySelector('.cinder-toast__icon');
+      expect(iconWrapper).not.toBeNull();
+      const svg = iconWrapper?.querySelector('svg');
+      expect(svg).not.toBeNull();
+      const path = svg?.querySelector('path');
+      // The danger path contains the X-circle shape with 8.28 7.22 coords.
+      expect(path?.getAttribute('d')).toContain('8.28 7.22');
+    });
+  });
+
+  test('showIcon=false suppresses the variant icon for success', async () => {
+    let api: ToastApi | null = null;
+    const { container } = render(Wrapper, {
+      props: {
+        onReady: (a: ToastApi) => {
+          api = a;
+        },
+      },
+    });
+    await waitFor(() => expect(api).not.toBeNull());
+
+    api!.show('Saved silently', { variant: 'success', duration: 0, showIcon: false });
+    await waitFor(() => {
+      expect(container.querySelector('[role="status"]')?.textContent).toContain('Saved silently');
+    });
+    expect(container.querySelector('.cinder-toast__icon')).toBeNull();
+  });
+
   test('consumer icon prop overrides default icon regardless of showIcon', async () => {
     let api: ToastApi | null = null;
     const { container } = render(Wrapper, {

--- a/packages/components/src/components/toggle/toggle.css
+++ b/packages/components/src/components/toggle/toggle.css
@@ -64,7 +64,7 @@
     vertical-align: middle;
 
     /* Track background — unset (off) state. */
-    background: var(--cinder-toggle-track-off, var(--cinder-border-muted));
+    background: var(--cinder-toggle-track-off, var(--cinder-toggle-track-off-resting));
 
     transition:
       background-color var(--cinder-duration-fast, 150ms) var(--cinder-ease-standard, ease),
@@ -107,7 +107,10 @@
 
   @media (hover: hover) {
     .cinder-toggle:hover:not(:disabled) {
-      background: var(--cinder-toggle-track-off-hover, var(--cinder-border));
+      background: var(
+        --cinder-toggle-track-off-hover,
+        var(--cinder-toggle-track-off-hover-resting)
+      );
     }
 
     .cinder-toggle[data-cinder-checked]:hover:not(:disabled) {

--- a/packages/components/src/components/tooltip/tooltip.css
+++ b/packages/components/src/components/tooltip/tooltip.css
@@ -23,8 +23,17 @@
     padding: var(--cinder-space-1-5) var(--cinder-space-2-5);
 
     border-radius: var(--cinder-radius-md);
-    background: var(--cinder-text);
-    color: var(--cinder-surface);
+    /* Dark-overlay in both themes.
+     * Light: --cinder-surface-inverse → --cinder-text (dark ink bg);
+     *        --cinder-text-inverse → --cinder-surface (near-white text).
+     * Dark:  --cinder-surface-inverse → --cinder-surface-raised (elevated dark
+     *        surface); --cinder-text-inverse → --cinder-text (near-white, ~8.3:1).
+     *        --cinder-border-inverse adds 1px strong border so tooltip separates
+     *        from the dark stage. Both arms render a dark overlay with legible
+     *        light text — no theme inversion occurs. */
+    background: var(--cinder-surface-inverse);
+    color: var(--cinder-text-inverse);
+    border: 1px solid var(--cinder-border-inverse);
     font-size: var(--cinder-text-xs);
     line-height: var(--cinder-leading-snug);
     white-space: nowrap;

--- a/packages/components/src/components/tree/tree.css
+++ b/packages/components/src/components/tree/tree.css
@@ -32,17 +32,22 @@
 
   /* Tree items are full-bleed rows whose first/last siblings sit flush against
    the tree's clipping bounds; an outset ring would be trimmed there. Paint the
-   ring INSET (Strategy B-inset) so it stays inside each row's own border box. */
-  .cinder-tree-item:focus-visible {
+   ring INSET (Strategy B-inset) so it stays inside each row's own border box.
+   The ring is scoped to .cinder-tree-item__row (the direct child row) so that
+   when a branch item is expanded the ring surrounds only the label row, not
+   the entire subtree that the outer .cinder-tree-item div also wraps. The
+   tabindex/role attributes stay on the outer .cinder-tree-item. */
+  .cinder-tree-item:focus-visible > .cinder-tree-item__row {
     outline: var(--cinder-ring-width) solid transparent;
     box-shadow: inset 0 0 0 var(--cinder-ring-width)
       var(--_cinder-tree-item-ring, var(--cinder-ring-color));
   }
 
   @media (forced-colors: active) {
-    .cinder-tree-item:focus-visible {
+    .cinder-tree-item:focus-visible > .cinder-tree-item__row {
       outline: var(--cinder-ring-width) solid ButtonText;
       outline-offset: calc(var(--cinder-ring-width) * -1);
+      box-shadow: none;
     }
   }
 

--- a/packages/components/src/styles/components/_dismiss-button.css
+++ b/packages/components/src/styles/components/_dismiss-button.css
@@ -50,7 +50,7 @@
    * doesn't "stick" after tap. */
   @media (hover: hover) {
     .cinder-_dismiss-button:hover {
-      background: color-mix(in oklch, currentColor, transparent 80%);
+      background: color-mix(in oklch, currentColor, transparent 75%);
     }
   }
 }

--- a/packages/components/src/styles/components/_input-frame.css
+++ b/packages/components/src/styles/components/_input-frame.css
@@ -20,6 +20,13 @@
     border-color: var(--cinder-danger);
   }
 
+  .cinder-_input-frame[aria-invalid='true']:focus-visible,
+  .cinder-_input-frame[aria-invalid='true']:focus-within,
+  .cinder-_input-frame[data-invalid]:focus-visible,
+  .cinder-_input-frame[data-invalid]:focus-within {
+    border-color: transparent;
+  }
+
   .cinder-_input-frame:disabled,
   .cinder-_input-frame[data-disabled] {
     background: var(--cinder-surface-inset);

--- a/packages/components/src/styles/components/_input-frame.css
+++ b/packages/components/src/styles/components/_input-frame.css
@@ -20,11 +20,19 @@
     border-color: var(--cinder-danger);
   }
 
+  /* On focus, swap the danger border for a danger-colored focus ring so the
+     invalid state still reads as an error (the neutral box-shadow ring alone
+     does not signal "error"). Zeroing the border without this replacement —
+     as an earlier pass did — left a focused invalid Select with no error
+     affordance at all. Mirrors the danger ring in textarea.css. */
   .cinder-_input-frame[aria-invalid='true']:focus-visible,
   .cinder-_input-frame[aria-invalid='true']:focus-within,
   .cinder-_input-frame[data-invalid]:focus-visible,
   .cinder-_input-frame[data-invalid]:focus-within {
     border-color: transparent;
+    box-shadow:
+      0 0 0 var(--cinder-ring-offset) var(--cinder-ring-offset-color),
+      0 0 0 calc(var(--cinder-ring-offset) + var(--cinder-ring-width)) var(--cinder-danger);
   }
 
   .cinder-_input-frame:disabled,
@@ -46,6 +54,20 @@
     .cinder-_input-frame:focus-within {
       outline: var(--cinder-ring-width) solid ButtonText;
       outline-offset: 3px;
+    }
+
+    /* In forced-colors mode the box-shadow danger ring is suppressed and
+       --cinder-danger is not a system color, so the focused invalid state
+       above would otherwise read as a plain neutral focus outline with no
+       error signal. Restore an error-emphasis affordance with the `Mark`
+       system color (the WHCM keyword for flagged/annotated content). */
+    .cinder-_input-frame[aria-invalid='true']:focus-visible,
+    .cinder-_input-frame[aria-invalid='true']:focus-within,
+    .cinder-_input-frame[data-invalid]:focus-visible,
+    .cinder-_input-frame[data-invalid]:focus-within {
+      border-color: Mark;
+      outline-color: Mark;
+      box-shadow: none;
     }
   }
 }

--- a/packages/components/src/styles/tokens-base.css
+++ b/packages/components/src/styles/tokens-base.css
@@ -188,6 +188,20 @@
   --cinder-surface: light-dark(oklch(98.5% 0.008 245), oklch(20% 0.04 245));
   --cinder-surface-raised: light-dark(oklch(100% 0.006 245), oklch(26% 0.045 245));
   --cinder-surface-inset: light-dark(oklch(95.5% 0.01 245), oklch(11% 0.03 245));
+
+  /* Upcoming step marker background — keeps the inset treatment in light mode
+     (surface-inset is visibly recessed vs surface), but lifts to surface in dark
+     mode where surface-inset (0.11) is nearly invisible against dark stage (0.15-0.20). */
+  --cinder-surface-upcoming-marker: light-dark(var(--cinder-surface-inset), var(--cinder-surface));
+
+  /* Inverse surface — used by Tooltip to stay a dark overlay in both themes.
+   * Light arm mirrors the text/surface swap (dark bg, light fg).
+   * Dark arm uses the elevated surface + near-white text so the tooltip reads as
+   * a dark elevated layer rather than inverting to light.
+   * --cinder-border-inverse adds a 1px delineation in dark mode only. */
+  --cinder-surface-inverse: light-dark(var(--cinder-text), var(--cinder-surface-raised));
+  --cinder-text-inverse: light-dark(var(--cinder-surface), var(--cinder-text));
+  --cinder-border-inverse: light-dark(transparent, var(--cinder-border-strong));
   /* Hover/pressed surface derivatives. The mix DIRECTION is per-theme — the
      `light-dark(black, white)` mix target darkens the surface in light mode and
      lightens it in dark mode — so only the PERCENTAGE is shared across themes.
@@ -215,12 +229,20 @@
      inert. NOTE the glyph on top must use --cinder-text-disabled, NOT --cinder-accent-contrast:
      accent-contrast is dark ink in both arms and would be ~1.45:1 on the dark-arm fill (0.30) —
      invisible. --cinder-text-disabled clears the 3:1 UI floor in both themes (light ~3.8:1, dark ~4.1:1). */
-  --cinder-fill-disabled: light-dark(oklch(88% 0.01 245), oklch(30% 0.04 245));
+  --cinder-fill-disabled: light-dark(oklch(88% 0.01 245), oklch(30% 0.015 245));
 
   /* Borders */
   --cinder-border: light-dark(oklch(79% 0.013 245), oklch(40% 0.05 245));
   --cinder-border-muted: light-dark(oklch(88% 0.01 245), oklch(30% 0.04 245));
   --cinder-border-strong: light-dark(oklch(72% 0.014 245), oklch(45% 0.06 245));
+
+  /* Toggle track off-state defaults — encode dark-arm contrast improvement here
+     so toggle.css uses only var() references and stays guard-clean.
+     Light arm preserves existing --cinder-border-muted look; dark arm raises L
+     to 0.45 (vs surface 0.20) for ≥3:1 shape contrast. Chroma kept at 0.02
+     (near-neutral). Hover steps up by 0.07 to be distinguishable from rest. */
+  --cinder-toggle-track-off-resting: light-dark(var(--cinder-border-muted), oklch(45% 0.02 245));
+  --cinder-toggle-track-off-hover-resting: light-dark(var(--cinder-border), oklch(52% 0.02 245));
 
   /* Accent - cyan (hue 195) */
   --cinder-accent: light-dark(oklch(66% 0.16 195), oklch(78% 0.13 195));
@@ -299,6 +321,14 @@
   --cinder-scrollbar-thumb: light-dark(oklch(0% 0 0 / 0.45), oklch(100% 0 0 / 0.45));
   --cinder-scrollbar-thumb-hover: light-dark(oklch(0% 0 0 / 0.65), oklch(100% 0 0 / 0.65));
 
+  /* Ring color tuned for use on solid accent/fill surfaces. Light arm is a
+   * near-black that contrasts both the accent fill (≥11:1) and the page bg
+   * (≥19:1). Dark arm is a near-white that contrasts the bright dark-mode
+   * accent (≥5:1) and the dark page bg (≥18:1). Used by FloatingActionButton
+   * primary variant. Raw oklch is legitimate here (tokens-base.css is the
+   * one place raw colors are allowed). */
+  --cinder-ring-on-accent: light-dark(oklch(20% 0.02 245), oklch(95% 0.01 245));
+
   /* Focus ring */
   --cinder-ring-width: 3px;
   --cinder-ring-offset: 1px;
@@ -343,7 +373,7 @@
   /* Base button tokens (secondary defaults) */
   --cinder-button-bg: var(--cinder-surface-raised);
   --cinder-button-fg: var(--cinder-text);
-  --cinder-button-border: var(--cinder-border);
+  --cinder-button-border: light-dark(var(--cinder-border), var(--cinder-border-strong));
   --cinder-button-radius: var(--cinder-radius-md);
 
   /* Size: xs */

--- a/packages/components/src/test/focus-ring-recipe.test.ts
+++ b/packages/components/src/test/focus-ring-recipe.test.ts
@@ -674,7 +674,11 @@ function assertOuterRecipe(css: string, selector: string, parser = parse): void 
 
 describe('focus-ring sweep — Strategy B-inset CSS selectors', () => {
   const insetCases: Array<{ name: string; css: string; selector: string }> = [
-    { name: 'tree item', css: treeCss, selector: '.cinder-tree-item:focus-visible' },
+    {
+      name: 'tree item',
+      css: treeCss,
+      selector: '.cinder-tree-item:focus-visible > .cinder-tree-item__row',
+    },
     {
       name: 'accordion trigger',
       css: accordionItemCss,

--- a/packages/testing/tests/focus-family-rings.playwright.ts
+++ b/packages/testing/tests/focus-family-rings.playwright.ts
@@ -171,7 +171,7 @@ test.describe('focus-ring sweep — rendered keyboard-focus rings', () => {
     expect(elementRect.bottom).toBeLessThanOrEqual(clipRect!.bottom + PIXEL_TOLERANCE);
   });
 
-  test('Tree item (Strategy B-inset): keyboard ring is an inset ring within the tree bounds', async ({
+  test('Tree item (Strategy B-inset): keyboard ring paints on the label row, not the whole subtree', async ({
     page,
   }) => {
     await page.goto('/page/tree?snapshot=1', { waitUntil: 'load' });
@@ -180,14 +180,36 @@ test.describe('focus-ring sweep — rendered keyboard-focus rings', () => {
 
     // Tree items receive focus via roving tabindex; the first item carries
     // tabindex=0, so Tab lands on it. (Arrow keys move within once focused.)
+    // The focus target is the OUTER .cinder-tree-item (it owns tabindex/role),
+    // but per #398 the inset ring must paint on its direct-child label ROW —
+    // NOT the outer item, which wraps the entire (potentially expanded) subtree
+    // and would draw a ring around all descendants.
     const item = page.locator('.cinder-tree-item').first();
+    const row = item.locator(':scope > .cinder-tree-item__row');
+    await expect(row).toBeVisible();
+
+    const ringColor = await resolvedRingColor(item);
+
+    // Pre-focus negative: before any keyboard focus, the row must NOT already
+    // carry the ring color — otherwise a permanently-styled row would pass the
+    // post-focus assertion vacuously.
+    const ringBeforeFocus = await row.evaluate((element) => getComputedStyle(element).boxShadow);
+    expect(ringBeforeFocus).not.toContain('inset');
+
     const landed = await tabUntilFocused(page, item);
     expect(landed, 'Tab walk should reach the first tree item').toBe(true);
     await expect(item).toBeFocused();
 
-    const ringColor = await resolvedRingColor(item);
-    const result = await item.evaluate((element) => {
-      const styles = getComputedStyle(element as HTMLElement);
+    // The outer item is the :focus-visible target (focus lives there)...
+    expect(await item.evaluate((element) => element.matches(':focus-visible'))).toBe(true);
+    // ...and it must NOT itself carry the inset ring color (the ring moved to
+    // the row; the old bug painted it here, around the whole subtree).
+    const outerBoxShadow = await item.evaluate((element) => getComputedStyle(element).boxShadow);
+    expect(outerBoxShadow).not.toContain(ringColor);
+
+    // The direct-child row carries the rendered inset ring.
+    const result = await row.evaluate((element) => {
+      const styles = getComputedStyle(element);
       const elementRect = element.getBoundingClientRect();
       let clip: Element | null = element.parentElement;
       let clipRect: DOMRect | null = null;
@@ -200,7 +222,6 @@ test.describe('focus-ring sweep — rendered keyboard-focus rings', () => {
         clip = clip.parentElement;
       }
       return {
-        matchesFocusVisible: element.matches(':focus-visible'),
         boxShadow: styles.boxShadow,
         outline: styles.outlineColor,
         clipRect: clipRect
@@ -216,16 +237,22 @@ test.describe('focus-ring sweep — rendered keyboard-focus rings', () => {
           left: elementRect.left,
           right: elementRect.right,
           bottom: elementRect.bottom,
+          width: elementRect.width,
+          height: elementRect.height,
         },
       };
     });
 
-    expect(result.matchesFocusVisible).toBe(true);
+    // Guard against a "present in computed style but invisible" false pass: the
+    // row that carries the ring must actually occupy space.
+    expect(result.elementRect.width).toBeGreaterThan(0);
+    expect(result.elementRect.height).toBeGreaterThan(0);
+
     expect(result.boxShadow).not.toBe('none');
     expect(result.boxShadow).toContain('inset');
     expect(result.boxShadow).toContain(ringColor);
-    // If a clipping ancestor exists, the inset ring (inside the item border box)
-    // is contained by it; assert containment when present.
+    // If a clipping ancestor exists, the inset ring (inside the row's border
+    // box) is contained by it; assert containment when present.
     if (result.clipRect) {
       const { elementRect, clipRect } = result;
       expect(elementRect.top).toBeGreaterThanOrEqual(clipRect.top - PIXEL_TOLERANCE);

--- a/packages/testing/tests/tabs-focus-ring.playwright.ts
+++ b/packages/testing/tests/tabs-focus-ring.playwright.ts
@@ -433,8 +433,14 @@ test.describe('Tabs — activating a tab does not reflow sibling widths (regress
     expect(watched, 'need an inactive enabled tab to watch').toBeTruthy();
     expect(toActivate, 'need a second enabled tab to activate').toBeTruthy();
 
-    // Activate the other tab by clicking it (selection, not just focus).
-    await page.getByRole('tab', { name: toActivate!.label, exact: true }).click();
+    // Activate the other tab by clicking it (selection, not just focus). Scope
+    // the locator to the horizontal list: /page/tabs mounts a second (vertical)
+    // tab list that reuses the same labels, so a page-global getByRole('tab')
+    // resolves to two elements and trips Playwright strict mode.
+    await page
+      .locator(HORIZONTAL_LIST)
+      .getByRole('tab', { name: toActivate!.label, exact: true })
+      .click();
     await page.waitForFunction(
       ({ selector, label }) => {
         const list = document.querySelector(selector);

--- a/packages/testing/tests/tabs-focus-ring.playwright.ts
+++ b/packages/testing/tests/tabs-focus-ring.playwright.ts
@@ -411,7 +411,7 @@ test.describe('Tabs — activating a tab does not reflow sibling widths (regress
       page.evaluate((selector) => {
         const list = document.querySelector(selector);
         if (!(list instanceof HTMLElement)) throw new Error(`No list ${selector}`);
-        const tabs = [...list.querySelectorAll('.cinder-tab')].filter(
+        const tabs = Array.from(list.querySelectorAll('.cinder-tab')).filter(
           (tab): tab is HTMLElement => tab instanceof HTMLElement,
         );
         return tabs.map((tab) => ({

--- a/packages/testing/tests/tabs-focus-ring.playwright.ts
+++ b/packages/testing/tests/tabs-focus-ring.playwright.ts
@@ -375,3 +375,86 @@ test.describe('Tabs — focus-visible ring is complete and unclipped in the tab 
     expect(metrics.resolvedRingColor).toBe(ringColor);
   });
 });
+
+/**
+ * Regression test for #402 — "Active tab font-weight shift causes sibling tabs
+ * to jump laterally on selection."
+ *
+ * The fix moves `font-weight: var(--cinder-font-medium)` from the
+ * `.cinder-tab[data-cinder-active]` rule to the base `.cinder-tab` rule, so the
+ * weight is constant and activation no longer reflows the row. A unit test can
+ * only assert the CSS shape (happy-dom does no layout); this spec proves the
+ * BEHAVIOUR in a real browser by measuring an inactive sibling tab's
+ * `offsetWidth` before and after a different tab is activated and asserting it
+ * does not change.
+ *
+ * Pre-fix, activating a sibling promoted that tab to weight 500, which widened
+ * it and pushed the row — the measured inactive tab's `offsetWidth` shifted by
+ * 1-3px and this assertion fails.
+ */
+test.describe('Tabs — activating a tab does not reflow sibling widths (regression #402)', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto(TABS_ROUTE, { waitUntil: 'load' });
+    await page.waitForLoadState('networkidle');
+    await page.waitForSelector(`${HORIZONTAL_LIST} .cinder-tab`, { state: 'visible' });
+    await page.waitForFunction((selector) => {
+      const tab = document.querySelector(`${selector} .cinder-tab`);
+      return tab instanceof HTMLElement && tab.getBoundingClientRect().width > 0;
+    }, HORIZONTAL_LIST);
+  });
+
+  test('an inactive sibling tab keeps its offsetWidth when another tab is activated', async ({
+    page,
+  }) => {
+    // Read every tab's label + offsetWidth, plus which tab is currently active.
+    const readTabs = () =>
+      page.evaluate((selector) => {
+        const list = document.querySelector(selector);
+        if (!(list instanceof HTMLElement)) throw new Error(`No list ${selector}`);
+        const tabs = [...list.querySelectorAll('.cinder-tab')].filter(
+          (tab): tab is HTMLElement => tab instanceof HTMLElement,
+        );
+        return tabs.map((tab) => ({
+          label: tab.textContent?.trim() ?? '',
+          width: tab.offsetWidth,
+          active: tab.getAttribute('data-cinder-active') !== null,
+          disabled: tab.hasAttribute('disabled') || tab.getAttribute('aria-disabled') === 'true',
+        }));
+      }, HORIZONTAL_LIST);
+
+    const before = await readTabs();
+    expect(before.length, 'expected multiple tabs to measure').toBeGreaterThan(1);
+
+    // Pick an INACTIVE, enabled tab to watch, and a DIFFERENT enabled tab to activate.
+    const watched = before.find((tab) => !tab.active && !tab.disabled);
+    const toActivate = before.find(
+      (tab) => !tab.disabled && tab.label !== watched?.label && !tab.active,
+    );
+    expect(watched, 'need an inactive enabled tab to watch').toBeTruthy();
+    expect(toActivate, 'need a second enabled tab to activate').toBeTruthy();
+
+    // Activate the other tab by clicking it (selection, not just focus).
+    await page.getByRole('tab', { name: toActivate!.label, exact: true }).click();
+    await page.waitForFunction(
+      ({ selector, label }) => {
+        const list = document.querySelector(selector);
+        if (!(list instanceof HTMLElement)) return false;
+        const active = list.querySelector('.cinder-tab[data-cinder-active]');
+        return active instanceof HTMLElement && active.textContent?.trim() === label;
+      },
+      { selector: HORIZONTAL_LIST, label: toActivate!.label },
+    );
+
+    const after = await readTabs();
+    const watchedAfter = after.find((tab) => tab.label === watched!.label);
+    expect(watchedAfter, 'watched tab disappeared after activation').toBeTruthy();
+
+    // The load-bearing assertion: the watched inactive tab's width must be
+    // unchanged. Pre-fix, the newly-active sibling widened and reflowed the row,
+    // shifting this width by 1-3px.
+    expect(
+      watchedAfter!.width,
+      `inactive tab "${watched!.label}" offsetWidth changed on sibling activation (jank)`,
+    ).toBe(watched!.width);
+  });
+});


### PR DESCRIPTION
## Summary

Consolidated **Group C (CSS / dark-mode / contrast / focus / hover / tokens)** and **Group D (ARIA / semantics / live-region / focus-trap)** remediation from the visual + a11y audit. The two groups share component `.svelte` and `.css` files, so they ship as one PR to avoid same-file merge churn.

Closes the following audit issues:

- Closes #378 — Dark mode: low-contrast / invisible elements (borders, tracks, inputs)
- Closes #379 — Missing or invisible focus indicators on interactive elements
- Closes #380 — Code blocks focusable twice / redundant tab stops with no focus ring
- Closes #385 — Missing or near-invisible hover states
- Closes #386 — Low-contrast borders/elements in light mode
- Closes #395 — Dark-mode contrast failures (inputs, toggle tracks, disabled controls, row dividers below 3:1)
- Closes #396 — Components disappear in dark mode (surface-inset matches dark stage background)
- Closes #397 — textarea double border on error+focus; ghost/secondary buttons low-visibility in dark mode
- Closes #398 — code-block focus ring clipped to top edge; tree-item focus ring encloses entire subtree
- Closes #400 — Missing aria-live for tag add/remove; toast dismiss buttons share an accessible name
- Closes #402 — Active-tab font-weight shift causes sibling tabs to jump laterally
- Closes #403 — Table sticky caption scrolls away; empty-state row lacks colspan; missing hover states
- Closes #404 — Miscellaneous spacing, layout, and content nits

## What changed

**Tokens / theming**
- `tokens-base.css` + `docs/tokens.md`: raised border/track/divider contrast to clear 3:1 in both schemes; fixed the dark-mode surface-inset that matched the stage background.

**Focus & keyboard**
- Focus rings made visible and correctly clipped across button, code-block, tree, tabs, input-frame, and dismiss-button surfaces.
- code-block: removed the redundant second tab stop; focus ring no longer clipped to the top edge.
- focus-trap utilities hardened (see Known limitations).

**ARIA / live regions**
- tag-input: aria-live announcements on tag add/remove.
- toast-region / dismiss buttons: distinct accessible names.
- Live-region re-announcement of identical consecutive messages fixed.

**Layout**
- tabs: active-tab weight shift no longer reflows siblings.
- table: sticky caption stays pinned; empty-state row spans all columns.

**Combobox Escape ownership (committee round-2 must-fix)**
- The combobox is now the single Escape owner for its entire open session via the shared LIFO escape stack (`_internal/overlay.ts`), including the empty-filter gap where the option Popover is unmounted. Popover gained a `closeOnEscape` prop (default `true`); the combobox passes `false` so the two never both register. The escape-stack handler type now receives the originating `KeyboardEvent` so the top-most owner can `preventDefault()`. Escape is swallowed whenever the combobox was open, regardless of label state. The input keydown branch is a `defaultPrevented`-guarded SSR/no-window fallback.

**Table caption sticky offset (committee round-2 must-fix)**
- Replaced the hard-coded `calc(... + 1lh)` sticky offset (which assumed a single-line caption) with the caption's **measured** border-box height via `useResizeObserver`, exposed as `--cinder-table-caption-height`. A wrapped multi-line caption no longer overlaps the pinned header.

## Review

Reviewed by the committee-review skill across svelte, frontend-architecture, UX, testing, TypeScript, simplicity, and security lenses, plus **Codex (gpt-5.4)** as the mandatory hostile second opinion across three rounds. Codex round-3 verdict: **APPROVED** — all three round-2 must-fixes (combobox escape-stack ownership, combobox `preventDefault` contract, table caption measurement) verified resolved, no new must-fix introduced.

Verification: full official suite green — **5482 pass / 5 skip / 0 fail across 323 files**; `typecheck` exit 0; touched files have 0 new svelte-check warnings and 0 lint errors. Pre-commit gate (lint-staged + full package typecheck + test) passed.

## Disclosures

1. **Folded-in pre-existing lint fix (Closes #407).** The whole-package pre-push lint (which type-aware-lints `scripts/**`, unlike the per-changed-file pre-commit scope) surfaced two pre-existing `no-unnecessary-type-assertion` errors in `packages/components/scripts/lib/atomic-swap-dist.test.ts` and `atomic-swap-dist.mock.test.ts` — redundant `as typeof process.on` casts that landed in PR #371 (the current main tip) and that main-green CI never caught. They were **byte-identical to `origin/main`** and are the thing physically blocking this otherwise-clean, fully-reviewed push. Rather than `--no-verify` (forbidden) or serialize the drain behind a separate PR for two lines, the redundant casts are removed in their own isolated commit (`64ffdce2`), disclosed here, closing **#407**. Behavior unchanged; both test files still pass (18/18). #407 also notes the CI-scope gap (type-aware lint over `scripts/**` is absent from main-green CI) as a follow-up.

2. **avatar-group.svelte intentional `role="img" tabindex="0"`** carries a pre-existing `a11y_no_noninteractive_tabindex` warning on a line this PR did not modify. It is documented-intentional and left as-is.

3. **Table wrapped-caption fix is unit-tested, not Playwright-tested.** The change is a `top:` value swap from a hard-coded constant to a measured custom property. The wiring (ResizeObserver → custom property, border-box measurement, `contentRect.height` fallback, no-op when no caption) is fully unit-tested, and the CSS-variable consumption is asserted. Pixel-level non-overlap is a layout concern Playwright would cover, but for a `top:` swap a screenshot test was judged over-engineering relative to the unit coverage.

## Known limitations

- **focus-trap positive-tabindex ordering:** the trap walks DOM order and does not re-sort by positive `tabindex` values. Positive tabindex is an anti-pattern we don't author internally; documenting rather than building a tabindex sorter.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Broad touch across overlay keyboard/focus and shared escape-stack semantics; behavior is heavily unit-tested but affects nested combobox-in-modal and dialog focus paths.
> 
> **Overview**
> This PR tightens **design tokens** and documents new surface, toggle, inverse, button-border, and `--cinder-ring-on-accent` variables so dark/light borders, tracks, and focus on accent fills meet contrast goals.
> 
> **Visual / interaction polish** spans many primitives: stronger borders and hover states on tables, tags, avatars, and badges; inset or accent-specific focus rings where `overflow: hidden` clipped rings; chart cell hover highlights; tab font-weight moved to the base rule to stop layout shift; sticky table headers offset by a **measured** caption height instead of `1lh`.
> 
> **Accessibility and keyboard behavior** get the bulk of the logic changes. `VisuallyHiddenLiveRegion` gains `announcementSequence` so identical messages re-announce; tag-input wires add/remove announcements. Toast dismiss labels include the message (truncated); optional `showIcon` renders variant icons. Avatar groups, removable chips, and context menus gain clearer naming and Escape handling; context-menu triggers drop invalid `aria-expanded`. The shared escape stack passes `KeyboardEvent` to handlers so owners can `preventDefault()`; combobox owns Escape for the full open session (restore committed label on Escape/blur) with Popover `closeOnEscape={false}`; menu-bar only consumes Escape when a menu is open.
> 
> **Focus trapping** is extended to modal, sheet, and drawer panels via `createFocusTrap`, with `manageInitialFocus: false` where dialogs already set initial focus; tabbable detection ignores negative `tabindex` values other than `-1`. Drawer drops ad-hoc open-focus in favor of the trap’s initial-focus resolution.
> 
> **Tests** add regression coverage and `cleanup()` / overlay resets so bun:test runs don’t leak DOM or escape-stack state across suites.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5fddc3c81e4a384f1e9fd44e85cf9674392830e2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->