### PR TITLE
fix(playground): live prop-driven Playground preview (#405)

### DIFF
--- a/packages/playground/src/component-page-live-preview-fixture.svelte
+++ b/packages/playground/src/component-page-live-preview-fixture.svelte
@@ -27,6 +27,7 @@
   import {
     createLivePreviewMount,
     isMountableComponent,
+    LIVE_MOUNT_CONTAINER_ID,
     resolveBareComponent,
   } from './component-page-live-preview.ts';
   import { toMountErrorDetail } from './example-error.ts';
@@ -83,7 +84,7 @@
   // Resolve + mount via the SAME production helpers the page uses, so a passing
   // test means the real page logic works, not a fixture copy of it.
   const bareComponent = $derived(resolveBareComponent(bareComponentModule, exportName));
-  const liveMountFailed = $derived(mountErrors['playground-live-mount'] !== undefined);
+  const liveMountFailed = $derived(mountErrors[LIVE_MOUNT_CONTAINER_ID] !== undefined);
   const mountLivePreview = createLivePreviewMount({
     readValues: () => $state.snapshot(playgroundValues),
     mountErrors,
@@ -128,7 +129,7 @@
       <span class="dx-stage__label">Live preview</span>
       <div
         class="example-preview"
-        id="playground-live-mount"
+        id={LIVE_MOUNT_CONTAINER_ID}
         {@attach mountLivePreview(bareComponent)}
       ></div>
     </div>

--- a/packages/playground/src/component-page-live-preview-fixture.svelte
+++ b/packages/playground/src/component-page-live-preview-fixture.svelte
@@ -1,0 +1,150 @@
+<!--
+  Test-only fixture isolating the live-preview mount from `component-page.svelte`
+  (#405). The real page mounts the BARE component with the synthesized
+  `playgroundValues` so the preview re-renders as the prop controls change. That
+  mount is gated behind `bareComponent !== undefined && !snapshotMode`, and falls
+  back to the static featured-example mount otherwise.
+
+  This fixture reproduces that branch and the `mountLivePreview` attachment
+  verbatim — same re-mount-on-`playgroundValues`-change semantics, same
+  `$state.snapshot` plain-object props, same error keying by container DOM id —
+  driven by bindable `playgroundValues` so a test can flip a control and assert
+  the live mount re-renders with the new values. Mounting the full
+  `component-page.svelte` is impractical (it reads `window.location`, the
+  server-injected globals, and deep cinder imports), so this fixture stands in
+  exactly as `component-page-mount-fixture.svelte` does for the example mounts.
+-->
+<script lang="ts" module>
+  /** Mount-error record keyed by container DOM id, exposed for assertions. */
+  export type MountErrorRecord = Record<string, string | undefined>;
+</script>
+
+<script lang="ts">
+  import { mount, unmount, untrack } from 'svelte';
+
+  type PlaygroundValue = string | number | boolean | undefined;
+
+  type Props = {
+    /**
+     * The resolved bare component constructor, or `undefined` to exercise the
+     * featured-example fallback branch (mirrors `bareComponent` in the page).
+     */
+    bareComponent?: unknown;
+    /** The featured example component used when `bareComponent` is undefined. */
+    featuredExample?: unknown;
+    /** Scenario id for the featured-example container, mirroring the page. */
+    featuredScenario?: string;
+    /** Whether the page is in snapshot mode (`?snapshot=1`) — gates BOTH mounts off. */
+    snapshotMode?: boolean;
+    /** Initial synthesized prop values seeded into the owned `$state`. */
+    initialValues?: Record<string, PlaygroundValue>;
+    /** Bindable mount-error record, keyed by container DOM id. */
+    mountErrors?: MountErrorRecord;
+  };
+
+  let {
+    bareComponent,
+    featuredExample,
+    featuredScenario = 'demo',
+    snapshotMode = false,
+    initialValues = {},
+    mountErrors = $bindable({}),
+  }: Props = $props();
+
+  // Own the prop values as `$state`, exactly as `component-page.svelte` does, so
+  // the test mutates a KEY (`playgroundValues[name] = next`) the way the real
+  // controls do — not by reassigning the whole object. `$state.snapshot` deep-
+  // reads the proxy, so a key mutation is what actually re-runs the attachment.
+  // `untrack` makes the one-time seed read explicit: only the INITIAL
+  // `initialValues` is captured, after which `playgroundValues` is the source of
+  // truth (mirrors the page seeding `$state` from control defaults once).
+  const playgroundValues: Record<string, PlaygroundValue> = $state(
+    untrack(() => ({ ...initialValues })),
+  );
+
+  /** Mutate a single control value — mirrors the page's `playgroundValues[name] = next`. */
+  export function setValue(name: string, value: PlaygroundValue): void {
+    playgroundValues[name] = value;
+  }
+
+  // Verbatim copy of `mountLivePreview` from component-page.svelte: read
+  // `playgroundValues` INSIDE the returned attachment so Svelte re-runs it
+  // (teardown + remount) on every control change; pass a plain snapshot rather
+  // than the reactive proxy; key the error record by container DOM id.
+  function mountLivePreview(Component: unknown): (element: HTMLElement) => () => void {
+    return (element: HTMLElement) => {
+      const mountKey = element.id;
+      if (typeof Component !== 'function') {
+        mountErrors[mountKey] = undefined;
+        return () => {};
+      }
+      let app: ReturnType<typeof mount> | undefined;
+      try {
+        app = mount(Component as Parameters<typeof mount>[0], {
+          target: element,
+          props: $state.snapshot(playgroundValues),
+        });
+        mountErrors[mountKey] = undefined;
+      } catch (error) {
+        mountErrors[mountKey] = error instanceof Error ? error.message : String(error);
+      }
+      return () => {
+        if (app === undefined) return;
+        try {
+          unmount(app);
+        } catch {
+          // Best-effort cleanup only.
+        }
+      };
+    };
+  }
+
+  // Verbatim copy of `mountScenario`'s shape for the fallback branch — a
+  // no-props mount keyed by container id.
+  function mountFeatured(Component: unknown): (element: HTMLElement) => () => void {
+    return (element: HTMLElement) => {
+      const mountKey = element.id;
+      if (typeof Component !== 'function') {
+        mountErrors[mountKey] = undefined;
+        return () => {};
+      }
+      let app: ReturnType<typeof mount> | undefined;
+      try {
+        app = mount(Component as Parameters<typeof mount>[0], { target: element });
+        mountErrors[mountKey] = undefined;
+      } catch (error) {
+        mountErrors[mountKey] = error instanceof Error ? error.message : String(error);
+      }
+      return () => {
+        if (app === undefined) return;
+        try {
+          unmount(app);
+        } catch {
+          // Best-effort cleanup only.
+        }
+      };
+    };
+  }
+</script>
+
+<div class="dx-play__preview">
+  {#if bareComponent !== undefined && !snapshotMode}
+    <div class="dx-stage">
+      <span class="dx-stage__label">Live preview</span>
+      <div
+        class="example-preview"
+        id="playground-live-mount"
+        {@attach mountLivePreview(bareComponent)}
+      ></div>
+    </div>
+  {:else if featuredExample !== undefined && !snapshotMode}
+    <div class="dx-stage">
+      <span class="dx-stage__label">Featured example</span>
+      <div
+        class="example-preview"
+        id="playground-mount-{featuredScenario}"
+        {@attach mountFeatured(featuredExample)}
+      ></div>
+    </div>
+  {/if}
+</div>

--- a/packages/playground/src/component-page-live-preview-fixture.svelte
+++ b/packages/playground/src/component-page-live-preview-fixture.svelte
@@ -1,36 +1,48 @@
 <!--
-  Test-only fixture isolating the live-preview mount from `component-page.svelte`
-  (#405). The real page mounts the BARE component with the synthesized
-  `playgroundValues` so the preview re-renders as the prop controls change. That
-  mount is gated behind `bareComponent !== undefined && !snapshotMode`, and falls
-  back to the static featured-example mount otherwise.
+  Test-only HOST for the live-preview logic in `component-page.svelte` (#405).
 
-  This fixture reproduces that branch and the `mountLivePreview` attachment
-  verbatim — same re-mount-on-`playgroundValues`-change semantics, same
-  `$state.snapshot` plain-object props, same error keying by container DOM id —
-  driven by bindable `playgroundValues` so a test can flip a control and assert
-  the live mount re-renders with the new values. Mounting the full
-  `component-page.svelte` is impractical (it reads `window.location`, the
-  server-injected globals, and deep cinder imports), so this fixture stands in
-  exactly as `component-page-mount-fixture.svelte` does for the example mounts.
+  It does NOT re-implement the mount/error/resolve behavior — it imports the same
+  `createLivePreviewMount` and `resolveBareComponent` the page uses, so the test
+  exercises production code rather than a copy that could drift. The fixture only
+  supplies what the real page gets from its environment that a unit test cannot:
+  the owned `$state` prop values (so a test can flip a control), the snapshot-mode
+  flag, and a stand-in featured-example component for the fallback branch.
+
+  The gating template mirrors the page's Playground branch exactly, including the
+  `liveMountFailed` fall-through to the featured example when the bare mount fails
+  and a featured example exists. Mounting the full `component-page.svelte` is
+  impractical (it reads `window.location`, server-injected globals, and fetches
+  documentation over HTTP), so this host stands in just as
+  `component-page-mount-fixture.svelte` does for the example mounts.
 -->
 <script lang="ts" module>
-  /** Mount-error record keyed by container DOM id, exposed for assertions. */
-  export type MountErrorRecord = Record<string, string | undefined>;
+  import type { MountErrorRecord } from './component-page-live-preview.ts';
+
+  export type { MountErrorRecord };
 </script>
 
 <script lang="ts">
   import { mount, unmount, untrack } from 'svelte';
 
+  import {
+    createLivePreviewMount,
+    isMountableComponent,
+    resolveBareComponent,
+  } from './component-page-live-preview.ts';
+  import { toMountErrorDetail } from './example-error.ts';
+
   type PlaygroundValue = string | number | boolean | undefined;
 
   type Props = {
     /**
-     * The resolved bare component constructor, or `undefined` to exercise the
-     * featured-example fallback branch (mirrors `bareComponent` in the page).
+     * The bare component's module namespace, resolved by `resolveBareComponent`
+     * exactly as the page resolves its prop. Pass `{ default: undefined }` (or a
+     * module lacking the export) to exercise the featured-example fallback.
      */
-    bareComponent?: unknown;
-    /** The featured example component used when `bareComponent` is undefined. */
+    bareComponentModule?: unknown;
+    /** Export name `resolveBareComponent` looks up first (mirrors `exportName`). */
+    exportName?: string;
+    /** The featured example component used when the bare component can't mount. */
     featuredExample?: unknown;
     /** Scenario id for the featured-example container, mirroring the page. */
     featuredScenario?: string;
@@ -43,7 +55,8 @@
   };
 
   let {
-    bareComponent,
+    bareComponentModule,
+    exportName = 'Demo',
     featuredExample,
     featuredScenario = 'demo',
     snapshotMode = false,
@@ -67,58 +80,40 @@
     playgroundValues[name] = value;
   }
 
-  // Verbatim copy of `mountLivePreview` from component-page.svelte: read
-  // `playgroundValues` INSIDE the returned attachment so Svelte re-runs it
-  // (teardown + remount) on every control change; pass a plain snapshot rather
-  // than the reactive proxy; key the error record by container DOM id.
-  function mountLivePreview(Component: unknown): (element: HTMLElement) => () => void {
-    return (element: HTMLElement) => {
-      const mountKey = element.id;
-      if (typeof Component !== 'function') {
-        mountErrors[mountKey] = undefined;
-        return () => {};
-      }
-      let app: ReturnType<typeof mount> | undefined;
-      try {
-        app = mount(Component as Parameters<typeof mount>[0], {
-          target: element,
-          props: $state.snapshot(playgroundValues),
-        });
-        mountErrors[mountKey] = undefined;
-      } catch (error) {
-        mountErrors[mountKey] = error instanceof Error ? error.message : String(error);
-      }
-      return () => {
-        if (app === undefined) return;
-        try {
-          unmount(app);
-        } catch {
-          // Best-effort cleanup only.
-        }
-      };
-    };
-  }
+  // Resolve + mount via the SAME production helpers the page uses, so a passing
+  // test means the real page logic works, not a fixture copy of it.
+  const bareComponent = $derived(resolveBareComponent(bareComponentModule, exportName));
+  const liveMountFailed = $derived(mountErrors['playground-live-mount'] !== undefined);
+  const mountLivePreview = createLivePreviewMount({
+    readValues: () => $state.snapshot(playgroundValues),
+    mountErrors,
+  });
 
-  // Verbatim copy of `mountScenario`'s shape for the fallback branch — a
-  // no-props mount keyed by container id.
+  // The featured-example fallback is a plain no-props mount keyed by container id
+  // (mirrors `mountScenario`'s shape). Kept inline because it is trivial and not
+  // the behavior under test — the live-preview path is. It narrows with the SAME
+  // `isMountableComponent` guard, records errors with the SAME `toMountErrorDetail`
+  // helper, and tears down with the SAME `void unmount` as the production code, so
+  // the fallback path here can't diverge from the real error-keying contract.
   function mountFeatured(Component: unknown): (element: HTMLElement) => () => void {
     return (element: HTMLElement) => {
       const mountKey = element.id;
-      if (typeof Component !== 'function') {
+      if (!isMountableComponent(Component)) {
         mountErrors[mountKey] = undefined;
         return () => {};
       }
       let app: ReturnType<typeof mount> | undefined;
       try {
-        app = mount(Component as Parameters<typeof mount>[0], { target: element });
+        app = mount(Component, { target: element });
         mountErrors[mountKey] = undefined;
       } catch (error) {
-        mountErrors[mountKey] = error instanceof Error ? error.message : String(error);
+        mountErrors[mountKey] = toMountErrorDetail(error);
       }
       return () => {
         if (app === undefined) return;
         try {
-          unmount(app);
+          // `unmount` returns a Promise; teardown is fire-and-forget here.
+          void unmount(app);
         } catch {
           // Best-effort cleanup only.
         }
@@ -128,7 +123,7 @@
 </script>
 
 <div class="dx-play__preview">
-  {#if bareComponent !== undefined && !snapshotMode}
+  {#if bareComponent !== undefined && !snapshotMode && (!liveMountFailed || featuredExample === undefined)}
     <div class="dx-stage">
       <span class="dx-stage__label">Live preview</span>
       <div

--- a/packages/playground/src/component-page-live-preview.test.ts
+++ b/packages/playground/src/component-page-live-preview.test.ts
@@ -38,6 +38,11 @@
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
 
 import { setupHappyDom } from '../../components/src/test/happy-dom.ts';
+import {
+  createLivePreviewMount,
+  LIVE_MOUNT_CONTAINER_ID,
+  type MountErrorRecord,
+} from './component-page-live-preview.ts';
 
 setupHappyDom();
 
@@ -72,6 +77,17 @@ function liveProbeCount(): number {
 /** Wrap a component as a single-export module namespace, as the page bundle hands it over. */
 function asNamedModule(component: unknown, exportName = 'Demo'): Record<string, unknown> {
   return { [exportName]: component };
+}
+
+/**
+ * The fixture instance exposes `setValue` as a `module`-script export; `render`
+ * returns it typed as `unknown`. Name the cast once here rather than repeating the
+ * same structural assertion at every call site.
+ */
+function fixtureComponent(instance: unknown): { setValue: (name: string, value: unknown) => void } {
+  // `instance` is already `unknown`, so a single assertion to the call shape is
+  // the idiomatic narrowing here — no `as unknown as` double-cast needed.
+  return instance as { setValue: (name: string, value: unknown) => void };
 }
 
 beforeEach(() => {
@@ -129,10 +145,7 @@ describe('component-page live preview (#405)', () => {
     // (`playgroundValues[name] = next`), not by reassigning the whole object.
     // `$state.snapshot` deep-reads the proxy, so the key mutation is what
     // re-runs the live-mount attachment.
-    (component as unknown as { setValue: (name: string, value: unknown) => void }).setValue(
-      'label',
-      'Delete',
-    );
+    fixtureComponent(component).setValue('label', 'Delete');
     await tick();
 
     // A fresh mount carried the new value; the stale instance was torn down, so
@@ -164,10 +177,7 @@ describe('component-page live preview (#405)', () => {
     await tick();
     expect(lastProps()).toEqual({ [key]: from });
 
-    (component as unknown as { setValue: (name: string, value: unknown) => void }).setValue(
-      key,
-      to,
-    );
+    fixtureComponent(component).setValue(key, to);
     await tick();
 
     expect(lastProps()).toEqual({ [key]: to });
@@ -224,6 +234,13 @@ describe('component-page live preview (#405)', () => {
       featuredScenario: 'demo',
       initialValues: { label: 'Save' },
     });
+    // Two ticks, not one: the fallback is a TWO-step reactive cascade — the mount
+    // throws and writes `mountErrors[LIVE_MOUNT_CONTAINER_ID]` inside the
+    // attachment (tick 1), THEN `liveMountFailed` recomputes and the `{#if}` swaps
+    // from the live branch to the featured branch (tick 2). One tick happens to
+    // suffice under the current scheduler, but waiting the second step explicitly
+    // asserts the branch-switch rather than relying on flush ordering.
+    await tick();
     await tick();
 
     expect(liveProbeCount()).toBe(0);
@@ -280,9 +297,45 @@ describe('component-page live preview (#405)', () => {
     });
     await tick();
 
-    expect(mountErrors['playground-live-mount']?.message).toContain('boom');
+    expect(mountErrors[LIVE_MOUNT_CONTAINER_ID]?.message).toContain('boom');
     expect(liveProbeCount()).toBe(0);
 
     unmount();
+  });
+
+  test('clears a recorded mount error once a later mount succeeds (invariant 6)', () => {
+    // Drive `createLivePreviewMount` directly rather than through the fixture: the
+    // fixture resolves its component from a fixed `bareComponentModule`, so it
+    // can't model "the SAME container that just failed now mounts a working
+    // component." Re-running the factory on one element — first with a throwing
+    // component, then with a working one — is the honest way to exercise the
+    // success-path `mountErrors[mountKey] = undefined` write (the clear that keeps
+    // a stale error callout from lingering over a now-healthy preview).
+    const Throwing = function ThrowingComponent() {
+      throw new Error('boom');
+    };
+    const mountErrors: MountErrorRecord = {};
+    const element = document.createElement('div');
+    element.id = LIVE_MOUNT_CONTAINER_ID;
+    document.body.append(element);
+
+    const factory = createLivePreviewMount({
+      readValues: () => ({ label: 'Save' }),
+      mountErrors,
+    });
+
+    // First run: the throwing component records an error under the container id.
+    const teardownFailed = factory(Throwing)(element);
+    expect(mountErrors[LIVE_MOUNT_CONTAINER_ID]?.message).toContain('boom');
+    teardownFailed();
+
+    // Second run on the SAME element: a working component mounts and the error
+    // slot is cleared back to `undefined`.
+    const teardownOk = factory(LiveProbe)(element);
+    expect(mountErrors[LIVE_MOUNT_CONTAINER_ID]).toBeUndefined();
+    expect(element.querySelector('.live-probe')).not.toBeNull();
+    teardownOk();
+
+    element.remove();
   });
 });

--- a/packages/playground/src/component-page-live-preview.test.ts
+++ b/packages/playground/src/component-page-live-preview.test.ts
@@ -9,23 +9,28 @@
  * preview re-renders as the controls change — a genuine "Live preview". The
  * load-bearing invariants this locks:
  *
- *   1. Each `playgroundValues` change re-mounts the bare component with the NEW
+ *   1. The bare component is resolved from its module namespace by the documented
+ *      export name, falling back to the default export.
+ *   2. Each `playgroundValues` change re-mounts the bare component with the NEW
  *      values (the attachment reads `playgroundValues` inside its body, so
  *      Svelte tears down and remounts on change).
- *   2. Props arrive as a plain object (`$state.snapshot`), never the reactive
+ *   3. Props arrive as a plain object (`$state.snapshot`), never the reactive
  *      `$state` proxy — that's what a real consumer would receive.
- *   3. When the bare component can't be resolved, the section falls back to the
- *      static featured-example mount (#374 behaviour preserved).
- *   4. Under `?snapshot=1` NEITHER mount renders — the snapshot-mode contract
+ *   4. When the bare component can't be resolved, or its live mount FAILS while a
+ *      featured example exists, the section falls back to the static
+ *      featured-example mount (#374 behaviour preserved; no error callout over a
+ *      preview that would otherwise work).
+ *   5. Under `?snapshot=1` NEITHER mount renders — the snapshot-mode contract
  *      forbids stray live mounts that would break the browser-test selector
  *      counts and axe surface.
- *   5. Mount errors are keyed by container DOM id, mirroring `mountScenario`.
+ *   6. Mount errors are keyed by container DOM id, mirroring `mountScenario`, and
+ *      clear once a later mount succeeds.
  *
- * Mounting the full `component-page.svelte` is impractical (it reads
- * `window.location`, the server-injected globals, and deep cinder imports), so
- * these tests drive `component-page-live-preview-fixture.svelte`, which copies
- * the `mountLivePreview` attachment and its gating branch verbatim — exactly
- * the pattern `component-page.test.ts` uses for the example mounts.
+ * The tests drive `component-page-live-preview-fixture.svelte`, a thin HOST that
+ * imports the SAME `createLivePreviewMount` / `resolveBareComponent` the page
+ * uses — so a passing test exercises production logic, not a copy of it. Mounting
+ * the full `component-page.svelte` is impractical (it reads `window.location`,
+ * the server-injected globals, and fetches documentation over HTTP).
  *
  * Harness setup mirrors `component-page.test.ts`: happy-dom is installed onto
  * `globalThis` before `@testing-library/svelte` loads.
@@ -64,6 +69,11 @@ function liveProbeCount(): number {
   return document.querySelectorAll('.live-probe').length;
 }
 
+/** Wrap a component as a single-export module namespace, as the page bundle hands it over. */
+function asNamedModule(component: unknown, exportName = 'Demo'): Record<string, unknown> {
+  return { [exportName]: component };
+}
+
 beforeEach(() => {
   resetLiveProbe();
 });
@@ -74,9 +84,10 @@ afterEach(() => {
 });
 
 describe('component-page live preview (#405)', () => {
-  test('mounts the bare component once with the seeded prop values', async () => {
+  test('resolves the bare component from the module namespace by export name', async () => {
     const { unmount } = render(Fixture, {
-      bareComponent: LiveProbe,
+      bareComponentModule: asNamedModule(LiveProbe, 'Demo'),
+      exportName: 'Demo',
       initialValues: { label: 'Save', disabled: false },
     });
     await tick();
@@ -90,9 +101,24 @@ describe('component-page live preview (#405)', () => {
     unmount();
   });
 
+  test('resolves the bare component from the default export when the named one is absent', async () => {
+    const { unmount } = render(Fixture, {
+      bareComponentModule: { default: LiveProbe },
+      exportName: 'NotThisOne',
+      initialValues: { label: 'Save' },
+    });
+    await tick();
+
+    expect(liveProbeCount()).toBe(1);
+    expect(mountCount()).toBe(1);
+    expect(document.querySelector('.dx-stage__label')?.textContent).toBe('Live preview');
+
+    unmount();
+  });
+
   test('re-mounts with the new value when a control changes', async () => {
     const { component, unmount } = render(Fixture, {
-      bareComponent: LiveProbe,
+      bareComponentModule: asNamedModule(LiveProbe),
       initialValues: { label: 'Save' },
     });
     await tick();
@@ -122,9 +148,37 @@ describe('component-page live preview (#405)', () => {
     unmount();
   });
 
+  // Lock the remount-with-new-value behavior across the control value shapes the
+  // playground actually synthesizes — not just the one string case — since a
+  // boolean/select/number value could in principle snapshot or remount
+  // differently. Each row mutates a value and asserts the latest mount saw it.
+  test.each([
+    ['boolean', 'disabled', false, true],
+    ['select/string', 'variant', 'primary', 'secondary'],
+    ['number', 'count', 1, 2],
+  ] as const)('re-mounts with the new %s value', async (_kind, key, from, to) => {
+    const { component, unmount } = render(Fixture, {
+      bareComponentModule: asNamedModule(LiveProbe),
+      initialValues: { [key]: from },
+    });
+    await tick();
+    expect(lastProps()).toEqual({ [key]: from });
+
+    (component as unknown as { setValue: (name: string, value: unknown) => void }).setValue(
+      key,
+      to,
+    );
+    await tick();
+
+    expect(lastProps()).toEqual({ [key]: to });
+    expect(liveProbeCount()).toBe(1);
+
+    unmount();
+  });
+
   test('passes a plain object, not the reactive $state proxy', async () => {
     const { unmount } = render(Fixture, {
-      bareComponent: LiveProbe,
+      bareComponentModule: asNamedModule(LiveProbe),
       initialValues: { label: 'Save', count: 3 },
     });
     await tick();
@@ -134,9 +188,12 @@ describe('component-page live preview (#405)', () => {
     unmount();
   });
 
-  test('falls back to the featured example when the bare component is undefined', async () => {
+  test('falls back to the featured example when the module has no resolvable component', async () => {
+    // A module namespace that exposes neither the named nor a default component
+    // — the real unresolved-export path, not just an explicit `undefined`.
     const { unmount } = render(Fixture, {
-      bareComponent: undefined,
+      bareComponentModule: { default: undefined, somethingElse: 'not a component' },
+      exportName: 'Demo',
       featuredExample: FeaturedProbe,
       featuredScenario: 'demo',
       initialValues: { label: 'Save' },
@@ -153,9 +210,33 @@ describe('component-page live preview (#405)', () => {
     unmount();
   });
 
+  test('falls back to the featured example when the live mount fails', async () => {
+    // A component whose constructor throws stands in for a bare mount that fails
+    // (an unsynthesized required snippet, a missing context provider, …). With a
+    // featured example available, the section must show THAT, not an error
+    // callout over a preview that would otherwise work.
+    const Throwing = function ThrowingComponent() {
+      throw new Error('boom');
+    };
+    const { unmount } = render(Fixture, {
+      bareComponentModule: asNamedModule(Throwing),
+      featuredExample: FeaturedProbe,
+      featuredScenario: 'demo',
+      initialValues: { label: 'Save' },
+    });
+    await tick();
+
+    expect(liveProbeCount()).toBe(0);
+    // The featured example took over once the live mount recorded its failure.
+    expect(document.querySelector('.scenario-probe')).not.toBeNull();
+    expect(document.querySelector('.dx-stage__label')?.textContent).toBe('Featured example');
+
+    unmount();
+  });
+
   test('renders NEITHER mount under ?snapshot=1', async () => {
     const { unmount } = render(Fixture, {
-      bareComponent: LiveProbe,
+      bareComponentModule: asNamedModule(LiveProbe),
       featuredExample: FeaturedProbe,
       featuredScenario: 'demo',
       snapshotMode: true,
@@ -173,7 +254,7 @@ describe('component-page live preview (#405)', () => {
 
   test('tears down the live mount on unmount — no orphaned probe', async () => {
     const { unmount } = render(Fixture, {
-      bareComponent: LiveProbe,
+      bareComponentModule: asNamedModule(LiveProbe),
       initialValues: { label: 'Save' },
     });
     await tick();
@@ -185,20 +266,21 @@ describe('component-page live preview (#405)', () => {
     expect(liveProbeCount()).toBe(0);
   });
 
-  test('keys a mount failure by the live container id', async () => {
-    // A component whose constructor throws stands in for a real mount failure.
+  test('keys a mount failure by the live container id when no featured example exists', async () => {
+    // With NO featured fallback, the live branch stays put and surfaces the error
+    // keyed by container id — better than a blank section.
     const Throwing = function ThrowingComponent() {
       throw new Error('boom');
     };
-    const mountErrors: Record<string, string | undefined> = {};
+    const mountErrors: Record<string, { message: string } | undefined> = {};
     const { unmount } = render(Fixture, {
-      bareComponent: Throwing,
+      bareComponentModule: asNamedModule(Throwing),
       initialValues: { label: 'Save' },
       mountErrors,
     });
     await tick();
 
-    expect(mountErrors['playground-live-mount']).toContain('boom');
+    expect(mountErrors['playground-live-mount']?.message).toContain('boom');
     expect(liveProbeCount()).toBe(0);
 
     unmount();

--- a/packages/playground/src/component-page-live-preview.test.ts
+++ b/packages/playground/src/component-page-live-preview.test.ts
@@ -1,0 +1,206 @@
+/// <reference lib="dom" />
+/**
+ * Regression tests for the Playground-section LIVE preview in
+ * `component-page.svelte` (#405).
+ *
+ * The Playground section used to mount the static featured *example* and label
+ * it "Featured example", because only the snippet was prop-driven. #405 mounts
+ * the BARE component directly with the synthesized `playgroundValues`, so the
+ * preview re-renders as the controls change — a genuine "Live preview". The
+ * load-bearing invariants this locks:
+ *
+ *   1. Each `playgroundValues` change re-mounts the bare component with the NEW
+ *      values (the attachment reads `playgroundValues` inside its body, so
+ *      Svelte tears down and remounts on change).
+ *   2. Props arrive as a plain object (`$state.snapshot`), never the reactive
+ *      `$state` proxy — that's what a real consumer would receive.
+ *   3. When the bare component can't be resolved, the section falls back to the
+ *      static featured-example mount (#374 behaviour preserved).
+ *   4. Under `?snapshot=1` NEITHER mount renders — the snapshot-mode contract
+ *      forbids stray live mounts that would break the browser-test selector
+ *      counts and axe surface.
+ *   5. Mount errors are keyed by container DOM id, mirroring `mountScenario`.
+ *
+ * Mounting the full `component-page.svelte` is impractical (it reads
+ * `window.location`, the server-injected globals, and deep cinder imports), so
+ * these tests drive `component-page-live-preview-fixture.svelte`, which copies
+ * the `mountLivePreview` attachment and its gating branch verbatim — exactly
+ * the pattern `component-page.test.ts` uses for the example mounts.
+ *
+ * Harness setup mirrors `component-page.test.ts`: happy-dom is installed onto
+ * `globalThis` before `@testing-library/svelte` loads.
+ */
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+
+import { setupHappyDom } from '../../components/src/test/happy-dom.ts';
+
+setupHappyDom();
+
+const { render } = await import('@testing-library/svelte');
+const { default: Fixture } = await import('./component-page-live-preview-fixture.svelte');
+const probeModule = (await import('./component-page-live-probe.svelte')) as unknown as {
+  default: unknown;
+  lastProps: () => Record<string, unknown> | undefined;
+  mountCount: () => number;
+  unmountCount: () => number;
+  lastPropsWerePlainObject: () => boolean;
+  resetLiveProbe: () => void;
+};
+const {
+  default: LiveProbe,
+  lastProps,
+  mountCount,
+  unmountCount,
+  lastPropsWerePlainObject,
+  resetLiveProbe,
+} = probeModule;
+const { default: FeaturedProbe } = (await import('./component-page-scenario-probe.svelte')) as {
+  default: unknown;
+};
+const { tick } = await import('svelte');
+
+/** Count rendered live-mount probes in the document. */
+function liveProbeCount(): number {
+  return document.querySelectorAll('.live-probe').length;
+}
+
+beforeEach(() => {
+  resetLiveProbe();
+});
+
+afterEach(() => {
+  resetLiveProbe();
+  document.body.innerHTML = '';
+});
+
+describe('component-page live preview (#405)', () => {
+  test('mounts the bare component once with the seeded prop values', async () => {
+    const { unmount } = render(Fixture, {
+      bareComponent: LiveProbe,
+      initialValues: { label: 'Save', disabled: false },
+    });
+    await tick();
+
+    expect(liveProbeCount()).toBe(1);
+    expect(mountCount()).toBe(1);
+    expect(lastProps()).toEqual({ label: 'Save', disabled: false });
+    // The "Live preview" label — not "Featured example" — is what shows.
+    expect(document.querySelector('.dx-stage__label')?.textContent).toBe('Live preview');
+
+    unmount();
+  });
+
+  test('re-mounts with the new value when a control changes', async () => {
+    const { component, unmount } = render(Fixture, {
+      bareComponent: LiveProbe,
+      initialValues: { label: 'Save' },
+    });
+    await tick();
+    expect(lastProps()).toEqual({ label: 'Save' });
+    const mountsAfterFirst = mountCount();
+
+    // Flip a control by MUTATING a key — exactly what the real prop panel does
+    // (`playgroundValues[name] = next`), not by reassigning the whole object.
+    // `$state.snapshot` deep-reads the proxy, so the key mutation is what
+    // re-runs the live-mount attachment.
+    (component as unknown as { setValue: (name: string, value: unknown) => void }).setValue(
+      'label',
+      'Delete',
+    );
+    await tick();
+
+    // A fresh mount carried the new value; the stale instance was torn down, so
+    // there is still exactly one live probe in the document.
+    expect(mountCount()).toBeGreaterThan(mountsAfterFirst);
+    expect(lastProps()).toEqual({ label: 'Delete' });
+    expect(liveProbeCount()).toBe(1);
+    // Mounts and unmounts stay balanced: every prior instance was torn down
+    // before the next mounted, so the live count never overlaps. With the
+    // instance still on screen, unmounts trail mounts by exactly one.
+    expect(unmountCount()).toBe(mountCount() - 1);
+
+    unmount();
+  });
+
+  test('passes a plain object, not the reactive $state proxy', async () => {
+    const { unmount } = render(Fixture, {
+      bareComponent: LiveProbe,
+      initialValues: { label: 'Save', count: 3 },
+    });
+    await tick();
+
+    expect(lastPropsWerePlainObject()).toBe(true);
+
+    unmount();
+  });
+
+  test('falls back to the featured example when the bare component is undefined', async () => {
+    const { unmount } = render(Fixture, {
+      bareComponent: undefined,
+      featuredExample: FeaturedProbe,
+      featuredScenario: 'demo',
+      initialValues: { label: 'Save' },
+    });
+    await tick();
+
+    // No live mount; the static featured example renders instead.
+    expect(liveProbeCount()).toBe(0);
+    expect(mountCount()).toBe(0);
+    expect(document.querySelector('.scenario-probe')).not.toBeNull();
+    expect(document.getElementById('playground-mount-demo')).not.toBeNull();
+    expect(document.querySelector('.dx-stage__label')?.textContent).toBe('Featured example');
+
+    unmount();
+  });
+
+  test('renders NEITHER mount under ?snapshot=1', async () => {
+    const { unmount } = render(Fixture, {
+      bareComponent: LiveProbe,
+      featuredExample: FeaturedProbe,
+      featuredScenario: 'demo',
+      snapshotMode: true,
+      initialValues: { label: 'Save' },
+    });
+    await tick();
+
+    expect(liveProbeCount()).toBe(0);
+    expect(mountCount()).toBe(0);
+    expect(document.querySelector('.scenario-probe')).toBeNull();
+    expect(document.querySelector('.dx-stage__label')).toBeNull();
+
+    unmount();
+  });
+
+  test('tears down the live mount on unmount — no orphaned probe', async () => {
+    const { unmount } = render(Fixture, {
+      bareComponent: LiveProbe,
+      initialValues: { label: 'Save' },
+    });
+    await tick();
+    expect(liveProbeCount()).toBe(1);
+
+    unmount();
+    await tick();
+
+    expect(liveProbeCount()).toBe(0);
+  });
+
+  test('keys a mount failure by the live container id', async () => {
+    // A component whose constructor throws stands in for a real mount failure.
+    const Throwing = function ThrowingComponent() {
+      throw new Error('boom');
+    };
+    const mountErrors: Record<string, string | undefined> = {};
+    const { unmount } = render(Fixture, {
+      bareComponent: Throwing,
+      initialValues: { label: 'Save' },
+      mountErrors,
+    });
+    await tick();
+
+    expect(mountErrors['playground-live-mount']).toContain('boom');
+    expect(liveProbeCount()).toBe(0);
+
+    unmount();
+  });
+});

--- a/packages/playground/src/component-page-live-preview.ts
+++ b/packages/playground/src/component-page-live-preview.ts
@@ -21,6 +21,15 @@ import { mount, unmount } from 'svelte';
 import { toMountErrorDetail, type MountErrorDetail } from './example-error.ts';
 
 /**
+ * The DOM `id` of the live-preview mount container, and therefore the
+ * {@link MountErrorRecord} key the live mount writes its failures under. Exported
+ * so the page template, the `liveMountFailed` derivation, and the test fixture all
+ * reference ONE string — a rename then fails at every import site instead of
+ * silently leaving the fixture asserting against a key the page no longer writes.
+ */
+export const LIVE_MOUNT_CONTAINER_ID = 'playground-live-mount';
+
+/**
  * The parameter type Svelte's `mount` accepts as its first argument. Used as the
  * return type of {@link resolveBareComponent}. Note this union is satisfied by any
  * function (a bare `() => void` type-checks), so the type alias is a readability
@@ -112,8 +121,14 @@ export type LivePreviewMountOptions = {
  *     so the preview tracks the controls. The caller snapshots its `$state` in
  *     that getter, so the mounted component receives a plain object, exactly what
  *     a real consumer would pass, never the reactive proxy;
- *   - records any mount failure under the container's DOM id and returns a
- *     cleanup that unmounts the instance.
+ *   - records a SYNCHRONOUS mount failure (a throw from the component's
+ *     construction, e.g. an unsynthesized required snippet or a missing context
+ *     provider) under the container's DOM id, and returns a cleanup that unmounts
+ *     the instance. Errors thrown LATER — from an `$effect` or `onMount` that runs
+ *     after `mount()` returns — escape this `try`/`catch` and are NOT recorded
+ *     here; catching those would require wrapping the mount in a
+ *     `<svelte:boundary>`, which #405 deliberately leaves out of scope (the
+ *     featured-example fallback already covers the common construction-time case).
  *
  * Remount-on-change is intentional and correct for the boolean/select controls
  * that dominate the playground. The known trade-off: a text control loses focus

--- a/packages/playground/src/component-page-live-preview.ts
+++ b/packages/playground/src/component-page-live-preview.ts
@@ -1,0 +1,159 @@
+/**
+ * Shared logic for the documentation page's Playground LIVE preview (#405).
+ *
+ * The Playground section mounts the BARE component directly with the synthesized
+ * `playgroundValues` so the preview re-renders as the prop controls change —
+ * instead of the static featured-example wrapper, whose only prop-driven part was
+ * the copyable snippet. This module owns the two non-trivial pieces of that
+ * behavior so they live in ONE place that both `component-page.svelte` and the
+ * regression test exercise directly (rather than a test fixture re-implementing
+ * the page's branch and drifting out of sync):
+ *
+ *   - {@link resolveBareComponent}: pick the mountable constructor out of the
+ *     component's module namespace.
+ *   - {@link createLivePreviewMount}: the `{@attach …}` factory that re-mounts on
+ *     every control change, snapshots the reactive props to a plain object, keys
+ *     errors by container DOM id, and falls back to a featured-example mount when
+ *     the live mount fails.
+ */
+import { mount, unmount } from 'svelte';
+
+import { toMountErrorDetail, type MountErrorDetail } from './example-error.ts';
+
+/**
+ * The parameter type Svelte's `mount` accepts as its first argument. Used as the
+ * return type of {@link resolveBareComponent}. Note this union is satisfied by any
+ * function (a bare `() => void` type-checks), so the type alias is a readability
+ * aid only — {@link isMountableComponent} is what actually guards a value down to
+ * something safe to hand `mount`.
+ */
+type MountableComponent = Parameters<typeof mount>[0];
+
+/** Mount-error record keyed by container DOM id (mirrors the page's `mountErrors`). */
+export type MountErrorRecord = Record<string, MountErrorDetail | undefined>;
+
+/**
+ * A Svelte component compiled by `Bun.build` is a callable function. Accept that
+ * shape and nothing else, so a non-component export (a string constant, a plain
+ * data object) degrades to the featured-example fallback instead of crashing
+ * `mount`. Centralizing the check here keeps {@link resolveBareComponent} and the
+ * mount factory in agreement on what "a component" is. Exported so the test
+ * fixture's featured-example fallback narrows components the SAME way the live
+ * mount does, rather than re-deriving the check with a bare cast.
+ */
+export function isMountableComponent(value: unknown): value is MountableComponent {
+  return typeof value === 'function';
+}
+
+/**
+ * Read one property off an unknown value. Returns `undefined` for non-objects —
+ * the caller only cares whether the read yields a mountable component.
+ *
+ * Uses `Reflect.get` (which takes an `object` target and returns `unknown`)
+ * rather than `(value as Record<string, unknown>)[key]` so the body stays free of
+ * an `as`-assertion — the strict pre-commit oxlint config flags
+ * `no-unsafe-type-assertion` on that cast even though it is sound after the
+ * `typeof === 'object'` guard above.
+ */
+function readProperty(value: unknown, key: string): unknown {
+  if (value === null || typeof value !== 'object') return undefined;
+  return Reflect.get(value, key);
+}
+
+/**
+ * Resolve the mountable bare component out of a component's module namespace.
+ *
+ * Tries the documented PascalCase export first (e.g. `Accordion`), then the
+ * module's `default` export. Returns `undefined` when neither is a mountable
+ * component or the module itself is absent — the caller then degrades to the
+ * static featured example.
+ *
+ * @param moduleNamespace - The `import * as …` namespace for the component's
+ *   package subpath, or `undefined` when the page bundle didn't provide one.
+ * @param exportName - The component's documented PascalCase export name.
+ */
+export function resolveBareComponent(
+  moduleNamespace: unknown,
+  exportName: string,
+): MountableComponent | undefined {
+  const named = readProperty(moduleNamespace, exportName);
+  if (isMountableComponent(named)) return named;
+  const fallback = readProperty(moduleNamespace, 'default');
+  return isMountableComponent(fallback) ? fallback : undefined;
+}
+
+/** Options for {@link createLivePreviewMount}. */
+export type LivePreviewMountOptions = {
+  /**
+   * Read the current synthesized prop values as a PLAIN object — the caller
+   * snapshots its reactive `$state` here (`() => $state.snapshot(playgroundValues)`)
+   * so this module stays rune-free. Called INSIDE the returned attachment so
+   * Svelte's attachment effect observes the reactive read and re-runs (teardown +
+   * fresh mount) whenever a control changes. Returning a plain object — never the
+   * reactive proxy — is exactly what a real consumer would pass as props.
+   */
+  readValues: () => Record<string, unknown>;
+  /**
+   * The mount-error record to write into, keyed by the container's DOM id.
+   * Mutated in place (never reassigned) so a Svelte `$state` proxy stays
+   * reactive for the error callout that reads it back.
+   */
+  mountErrors: MountErrorRecord;
+};
+
+/**
+ * Build the `{@attach …}` factory that mounts the bare component live.
+ *
+ * The returned factory takes the resolved component and yields an attachment
+ * that, on each run:
+ *
+ *   - reads the current values via `readValues()` — the reactive read that makes
+ *     Svelte re-run this attachment (teardown + remount) on every control change,
+ *     so the preview tracks the controls. The caller snapshots its `$state` in
+ *     that getter, so the mounted component receives a plain object, exactly what
+ *     a real consumer would pass, never the reactive proxy;
+ *   - records any mount failure under the container's DOM id and returns a
+ *     cleanup that unmounts the instance.
+ *
+ * Remount-on-change is intentional and correct for the boolean/select controls
+ * that dominate the playground. The known trade-off: a text control loses focus
+ * on each keystroke because the whole instance is rebuilt — acceptable for a
+ * preview surface (the snippet, not this mount, is the copy target).
+ *
+ * @returns A factory `(Component) => attachment`. When `Component` isn't
+ *   mountable the attachment clears any stale error and renders nothing, letting
+ *   the caller's template fall back to the featured example.
+ */
+export function createLivePreviewMount(
+  options: LivePreviewMountOptions,
+): (component: unknown) => (element: HTMLElement) => () => void {
+  const { readValues, mountErrors } = options;
+  return (component: unknown) => (element: HTMLElement) => {
+    const mountKey = element.id;
+    if (!isMountableComponent(component)) {
+      mountErrors[mountKey] = undefined;
+      return () => {};
+    }
+    let app: ReturnType<typeof mount> | undefined;
+    try {
+      app = mount(component, {
+        target: element,
+        props: readValues(),
+      });
+      mountErrors[mountKey] = undefined;
+    } catch (error) {
+      console.error('[cinder playground] failed to mount live preview:', error);
+      mountErrors[mountKey] = toMountErrorDetail(error);
+    }
+    return () => {
+      if (app === undefined) return;
+      try {
+        // `unmount` returns a Promise (outro animations); the teardown is
+        // fire-and-forget here, so the result is intentionally not awaited.
+        void unmount(app);
+      } catch {
+        // Best-effort cleanup only.
+      }
+    };
+  };
+}

--- a/packages/playground/src/component-page-live-probe.svelte
+++ b/packages/playground/src/component-page-live-probe.svelte
@@ -1,0 +1,85 @@
+<!--
+  Test-only probe standing in for the BARE component the Playground section
+  mounts live (#405). Unlike `component-page-scenario-probe.svelte` — which is
+  mounted with no props and self-identifies from its container — this probe is
+  mounted WITH the synthesized prop values, so it records the exact props object
+  it received on each mount onto a shared module-level ledger.
+
+  The live-preview attachment under test re-mounts on every `playgroundValues`
+  change, so the ledger lets a test assert that each control change produced a
+  fresh mount carrying the new values, and that the props arrived as a plain
+  object (a snapshot) rather than a reactive `$state` proxy.
+-->
+<script lang="ts" module>
+  /** Every props object a live probe has been mounted with, in mount order. */
+  const propLedger: Record<string, unknown>[] = [];
+
+  /** Whether each recorded props object was a plain (non-proxy) object. */
+  const plainObjectLedger: boolean[] = [];
+
+  /** Count of probe teardowns observed (one per `onMount` cleanup). */
+  let unmounts = 0;
+
+  /** The props the most recent live mount received, or `undefined` if none. */
+  export function lastProps(): Record<string, unknown> | undefined {
+    return propLedger.at(-1);
+  }
+
+  /** How many times a live probe has been mounted since the last reset. */
+  export function mountCount(): number {
+    return propLedger.length;
+  }
+
+  /**
+   * How many times a live probe has been torn down since the last reset. The
+   * live-mount attachment remounts on every control change, so after N mounts
+   * with the instance still on screen the count is N - 1 (each prior instance
+   * was unmounted before the next mounted). This makes the "no overlapping
+   * instances" invariant assertable, not merely inferred from a DOM count.
+   */
+  export function unmountCount(): number {
+    return unmounts;
+  }
+
+  /** Whether the props of the most recent mount were a plain object, not a proxy. */
+  export function lastPropsWerePlainObject(): boolean {
+    return plainObjectLedger.at(-1) ?? false;
+  }
+
+  /** Reset the ledgers; call between tests. */
+  export function resetLiveProbe(): void {
+    propLedger.length = 0;
+    plainObjectLedger.length = 0;
+    unmounts = 0;
+  }
+</script>
+
+<script lang="ts">
+  import { onMount } from 'svelte';
+
+  // The live mount passes a `$state.snapshot(playgroundValues)` — a plain object.
+  // Capturing the props here and recording them on mount lets the test assert
+  // which prop values reached the component on each re-mount.
+  const props: Record<string, unknown> = $props();
+
+  // Record once per mount. The live-mount attachment re-mounts on every control
+  // change, so one ledger entry per mount = one entry per change. The returned
+  // cleanup records the matching teardown, so a test can assert mounts and
+  // unmounts stay balanced (N mounts → N - 1 unmounts while still on screen).
+  onMount(() => {
+    // `$state.snapshot` returns a structured-clone-style plain object; a reactive
+    // proxy would carry Svelte's internal symbol keys. Reflect.ownKeys surfaces
+    // symbol keys, so an all-string key set is a reliable "this is a plain object"
+    // signal for the test.
+    const receivedSymbolKeys = Reflect.ownKeys(props).filter((key) => typeof key === 'symbol');
+    propLedger.push({ ...props });
+    plainObjectLedger.push(receivedSymbolKeys.length === 0);
+    return () => {
+      unmounts += 1;
+    };
+  });
+</script>
+
+<div class="live-probe" data-label={String(props['label'] ?? '')}>
+  {String(props['label'] ?? '')}
+</div>

--- a/packages/playground/src/component-page.svelte
+++ b/packages/playground/src/component-page.svelte
@@ -392,6 +392,74 @@
     playgroundModel.controls.length > 0 && !playgroundModel.hasUnsatisfiedRequired,
   );
 
+  // The bare component constructor, registered on the page bundle by
+  // `compilePageBundleArtifacts` as the whole module namespace under
+  // `__CINDER_BARE_COMPONENT__`. The Playground section mounts it directly with
+  // the synthesized `playgroundValues` so the preview is genuinely prop-driven
+  // (#405), instead of the static featured-example wrapper. Resolved by the
+  // documented `exportName`; falls back to the module's default export. When the
+  // module is absent (older bundle) or the export can't be resolved, this is
+  // `undefined` and the section degrades to the featured-example mount.
+  //
+  // Read once into a plain `const` (not `$derived`): each `/page/<name>` is its
+  // own freshly evaluated bundle inside the preview iframe, so the global is
+  // effectively immutable for the page's lifetime. Do NOT promote this to a
+  // `$derived` unless the shell ever routes component pages WITHOUT a full bundle
+  // reload — under SPA navigation the global would go stale against `documentation`.
+  const bareComponentModule =
+    typeof window === 'undefined'
+      ? undefined
+      : (window as unknown as Record<string, unknown>)['__CINDER_BARE_COMPONENT__'];
+  const bareComponent = $derived.by<unknown>(() => {
+    if (documentation === null || bareComponentModule === undefined) return undefined;
+    const namespace = bareComponentModule as Record<string, unknown>;
+    const named = namespace[documentation.component.exportName];
+    if (typeof named === 'function') return named;
+    return typeof namespace['default'] === 'function' ? namespace['default'] : undefined;
+  });
+
+  // Mounts the bare component with the current synthesized `playgroundValues`
+  // (#405). Reading `playgroundValues` *inside* the returned attachment means
+  // Svelte's attachment effect re-runs — tearing the old instance down and
+  // mounting a fresh one — every time a control changes, so the preview tracks
+  // the snippet. `$state.snapshot` hands Svelte a plain object rather than the
+  // reactive proxy, matching how a real consumer would pass props. The mount
+  // error is keyed by the container's DOM id, mirroring `mountScenario`.
+  //
+  // Remount-on-change is by design and correct for the boolean/select controls
+  // that dominate. The known trade-off: a text control loses focus on each
+  // keystroke because the whole instance is rebuilt — acceptable for a preview
+  // surface (the snippet, not this mount, is the copy target), but worth knowing
+  // before adding text-heavy live controls.
+  function mountLivePreview(Component: unknown): (element: HTMLElement) => () => void {
+    return (element: HTMLElement) => {
+      const mountKey = element.id;
+      if (typeof Component !== 'function') {
+        mountErrors[mountKey] = undefined;
+        return () => {};
+      }
+      let app: ReturnType<typeof mount> | undefined;
+      try {
+        app = mount(Component as Parameters<typeof mount>[0], {
+          target: element,
+          props: $state.snapshot(playgroundValues),
+        });
+        mountErrors[mountKey] = undefined;
+      } catch (error) {
+        console.error('[cinder playground] failed to mount live preview:', error);
+        mountErrors[mountKey] = toMountErrorDetail(error);
+      }
+      return () => {
+        if (app === undefined) return;
+        try {
+          unmount(app);
+        } catch {
+          // Best-effort cleanup only.
+        }
+      };
+    };
+  }
+
   // --- Sections + scroll spy (data-driven) ------------------------------
   type SectionDescriptor = { id: string; num: string; label: string };
 
@@ -808,15 +876,43 @@
 
                 <div class="dx-play">
                   <div class="dx-play__preview">
-                    <!-- This stage mounts the component's featured example so the
-                         Playground section shows a rendered instance, not just a
-                         snippet (#374). It renders the static featured scenario —
-                         it does NOT yet re-render from the prop controls, so it is
-                         deliberately NOT labelled "Live preview" (that would be a
-                         false promise: only the snippet is prop-driven today).
-                         Driving this mount from `playgroundValues` is tracked as a
-                         follow-up. -->
-                    {#if overviewExample !== undefined && !snapshotMode}
+                    <!-- When the bare component resolves from the page bundle, mount it
+                         directly with the synthesized prop values so the preview
+                         re-renders as the controls change — a genuine "Live preview"
+                         (#405). `mountLivePreview` re-runs its attachment on every
+                         `playgroundValues` change. The stage is gated off under
+                         `?snapshot=1`: the browser tests count `example-mount-*`
+                         selectors and run axe against a fixed surface, so a live mount
+                         must not appear there (see snapshot-mode contract). -->
+                    {#if bareComponent !== undefined && !snapshotMode}
+                      <div class="dx-stage">
+                        <div class="dx-stage__bar">
+                          <span class="dx-stage__dot" aria-hidden="true"></span>
+                          <span class="dx-stage__label">Live preview</span>
+                        </div>
+                        <div class="dx-stage__canvas">
+                          {#if mountErrors['playground-live-mount'] !== undefined}
+                            {@const error = mountErrors['playground-live-mount']}
+                            <Callout variant="danger" title="This preview failed to render">
+                              <p>{error?.message}</p>
+                            </Callout>
+                          {/if}
+                          <div
+                            class="example-preview"
+                            id="playground-live-mount"
+                            {@attach mountLivePreview(bareComponent)}
+                          ></div>
+                        </div>
+                        <p class="dx-stage__note">
+                          Renders with the props below. Adjust the controls to update it live.
+                        </p>
+                      </div>
+                    {:else if overviewExample !== undefined && !snapshotMode}
+                      <!-- Fallback when the bare component can't be resolved (older
+                           page bundle, or a component whose default/named export isn't
+                           a constructor): mount the static featured example so the
+                           section still shows a rendered instance (#374), labelled
+                           honestly since only the snippet is prop-driven here. -->
                       <div class="dx-stage">
                         <div class="dx-stage__bar">
                           <span class="dx-stage__dot" aria-hidden="true"></span>

--- a/packages/playground/src/component-page.svelte
+++ b/packages/playground/src/component-page.svelte
@@ -48,6 +48,7 @@
     buildSnippet,
     type PlaygroundValue,
   } from './component-page-playground.ts';
+  import { createLivePreviewMount, resolveBareComponent } from './component-page-live-preview.ts';
 
   type CinderExampleDescriptor = {
     scenario: string;
@@ -59,6 +60,14 @@
     typeof globalThis & { __CINDER_EXAMPLES__?: CinderExampleDescriptor[] };
   type BadgeVariant = 'neutral' | 'success' | 'warning' | 'danger' | 'info' | 'accent';
   type StatusDotStatus = 'online' | 'warning' | 'error' | 'pending' | 'neutral' | 'accent';
+
+  // The bare component's module namespace, passed in by the page-bundle entry
+  // (`compilePageBundleArtifacts`) which `import * as`-es the component's package
+  // subpath and mounts this page with it. Threaded as a prop rather than read
+  // from a `window` global so the live preview (#405) is wired explicitly to the
+  // bundle that mounted it — no out-of-band global to go stale against the page.
+  // Defaults to `undefined` for the no-prop mount paths (tests, SSR render).
+  let { bareComponentModule }: { bareComponentModule?: unknown } = $props();
 
   // Height of the sticky top bar, in pixels — used for scroll-spy activation
   // and smooth-scroll offset so anchored sections clear the bar.
@@ -392,73 +401,35 @@
     playgroundModel.controls.length > 0 && !playgroundModel.hasUnsatisfiedRequired,
   );
 
-  // The bare component constructor, registered on the page bundle by
-  // `compilePageBundleArtifacts` as the whole module namespace under
-  // `__CINDER_BARE_COMPONENT__`. The Playground section mounts it directly with
-  // the synthesized `playgroundValues` so the preview is genuinely prop-driven
-  // (#405), instead of the static featured-example wrapper. Resolved by the
-  // documented `exportName`; falls back to the module's default export. When the
-  // module is absent (older bundle) or the export can't be resolved, this is
-  // `undefined` and the section degrades to the featured-example mount.
-  //
-  // Read once into a plain `const` (not `$derived`): each `/page/<name>` is its
-  // own freshly evaluated bundle inside the preview iframe, so the global is
-  // effectively immutable for the page's lifetime. Do NOT promote this to a
-  // `$derived` unless the shell ever routes component pages WITHOUT a full bundle
-  // reload — under SPA navigation the global would go stale against `documentation`.
-  const bareComponentModule =
-    typeof window === 'undefined'
+  // The bare component constructor for the Playground section's LIVE preview
+  // (#405): resolved from the module namespace passed in as a prop by the page
+  // bundle, by the documented `exportName` (falling back to the default export).
+  // `undefined` when the module wasn't provided or the export isn't a component,
+  // in which case the section degrades to the static featured-example mount.
+  const bareComponent = $derived(
+    documentation === null
       ? undefined
-      : (window as unknown as Record<string, unknown>)['__CINDER_BARE_COMPONENT__'];
-  const bareComponent = $derived.by<unknown>(() => {
-    if (documentation === null || bareComponentModule === undefined) return undefined;
-    const namespace = bareComponentModule as Record<string, unknown>;
-    const named = namespace[documentation.component.exportName];
-    if (typeof named === 'function') return named;
-    return typeof namespace['default'] === 'function' ? namespace['default'] : undefined;
+      : resolveBareComponent(bareComponentModule, documentation.component.exportName),
+  );
+
+  // The `{@attach …}` factory that mounts the bare component live. Reading the
+  // synthesized values *inside* the attachment (the getter below) makes Svelte
+  // re-run it — teardown + fresh mount — on every control change, so the preview
+  // tracks the controls. The getter snapshots `playgroundValues` so the mounted
+  // component receives a plain object, exactly like a real consumer. See
+  // `component-page-live-preview.ts` for the remount-on-change rationale and the
+  // text-control focus-loss trade-off.
+  const mountLivePreview = createLivePreviewMount({
+    readValues: () => $state.snapshot(playgroundValues),
+    mountErrors,
   });
 
-  // Mounts the bare component with the current synthesized `playgroundValues`
-  // (#405). Reading `playgroundValues` *inside* the returned attachment means
-  // Svelte's attachment effect re-runs — tearing the old instance down and
-  // mounting a fresh one — every time a control changes, so the preview tracks
-  // the snippet. `$state.snapshot` hands Svelte a plain object rather than the
-  // reactive proxy, matching how a real consumer would pass props. The mount
-  // error is keyed by the container's DOM id, mirroring `mountScenario`.
-  //
-  // Remount-on-change is by design and correct for the boolean/select controls
-  // that dominate. The known trade-off: a text control loses focus on each
-  // keystroke because the whole instance is rebuilt — acceptable for a preview
-  // surface (the snippet, not this mount, is the copy target), but worth knowing
-  // before adding text-heavy live controls.
-  function mountLivePreview(Component: unknown): (element: HTMLElement) => () => void {
-    return (element: HTMLElement) => {
-      const mountKey = element.id;
-      if (typeof Component !== 'function') {
-        mountErrors[mountKey] = undefined;
-        return () => {};
-      }
-      let app: ReturnType<typeof mount> | undefined;
-      try {
-        app = mount(Component as Parameters<typeof mount>[0], {
-          target: element,
-          props: $state.snapshot(playgroundValues),
-        });
-        mountErrors[mountKey] = undefined;
-      } catch (error) {
-        console.error('[cinder playground] failed to mount live preview:', error);
-        mountErrors[mountKey] = toMountErrorDetail(error);
-      }
-      return () => {
-        if (app === undefined) return;
-        try {
-          unmount(app);
-        } catch {
-          // Best-effort cleanup only.
-        }
-      };
-    };
-  }
+  // True once the live mount has recorded a failure. The Playground template
+  // uses this to fall through to the featured example when the bare mount fails
+  // and a featured example exists — a component whose bare mount throws (an
+  // unsynthesized required snippet, a missing context provider, a portal target)
+  // must not replace a working featured example with an error callout (#405).
+  const liveMountFailed = $derived(mountErrors['playground-live-mount'] !== undefined);
 
   // --- Sections + scroll spy (data-driven) ------------------------------
   type SectionDescriptor = { id: string; num: string; label: string };
@@ -883,8 +854,14 @@
                          `playgroundValues` change. The stage is gated off under
                          `?snapshot=1`: the browser tests count `example-mount-*`
                          selectors and run axe against a fixed surface, so a live mount
-                         must not appear there (see snapshot-mode contract). -->
-                    {#if bareComponent !== undefined && !snapshotMode}
+                         must not appear there (see snapshot-mode contract).
+
+                         If the bare mount FAILS and a featured example exists, the
+                         `liveMountFailed` guard falls through to the featured branch
+                         rather than show an error callout over what would otherwise be
+                         a working preview. With no featured fallback, the live branch
+                         stays and surfaces the error — better than a blank section. -->
+                    {#if bareComponent !== undefined && !snapshotMode && (!liveMountFailed || overviewExample === undefined)}
                       <div class="dx-stage">
                         <div class="dx-stage__bar">
                           <span class="dx-stage__dot" aria-hidden="true"></span>

--- a/packages/playground/src/component-page.svelte
+++ b/packages/playground/src/component-page.svelte
@@ -48,7 +48,11 @@
     buildSnippet,
     type PlaygroundValue,
   } from './component-page-playground.ts';
-  import { createLivePreviewMount, resolveBareComponent } from './component-page-live-preview.ts';
+  import {
+    createLivePreviewMount,
+    LIVE_MOUNT_CONTAINER_ID,
+    resolveBareComponent,
+  } from './component-page-live-preview.ts';
 
   type CinderExampleDescriptor = {
     scenario: string;
@@ -429,7 +433,7 @@
   // and a featured example exists — a component whose bare mount throws (an
   // unsynthesized required snippet, a missing context provider, a portal target)
   // must not replace a working featured example with an error callout (#405).
-  const liveMountFailed = $derived(mountErrors['playground-live-mount'] !== undefined);
+  const liveMountFailed = $derived(mountErrors[LIVE_MOUNT_CONTAINER_ID] !== undefined);
 
   // --- Sections + scroll spy (data-driven) ------------------------------
   type SectionDescriptor = { id: string; num: string; label: string };
@@ -868,15 +872,15 @@
                           <span class="dx-stage__label">Live preview</span>
                         </div>
                         <div class="dx-stage__canvas">
-                          {#if mountErrors['playground-live-mount'] !== undefined}
-                            {@const error = mountErrors['playground-live-mount']}
+                          {#if mountErrors[LIVE_MOUNT_CONTAINER_ID] !== undefined}
+                            {@const error = mountErrors[LIVE_MOUNT_CONTAINER_ID]}
                             <Callout variant="danger" title="This preview failed to render">
                               <p>{error?.message}</p>
                             </Callout>
                           {/if}
                           <div
                             class="example-preview"
-                            id="playground-live-mount"
+                            id={LIVE_MOUNT_CONTAINER_ID}
                             {@attach mountLivePreview(bareComponent)}
                           ></div>
                         </div>

--- a/packages/playground/src/playground-server.ts
+++ b/packages/playground/src/playground-server.ts
@@ -765,18 +765,18 @@ ${scenarioRegistrations}
 };
 
 (window as unknown as Record<string, unknown>)['__CINDER_SCENARIOS__'] = scenarios;
-// Register the bare component module so the Playground section can mount the
-// component directly with synthesized prop values (live preview, #405). The
-// page reads it by \`documentation.component.exportName\`; the whole namespace
-// is registered so both the named and default export resolve.
-(window as unknown as Record<string, unknown>)['__CINDER_BARE_COMPONENT__'] =
-  BareComponentModule;
 const target = document.getElementById('app');
 if (target === null) {
   throw new Error('[cinder playground] #app target not found');
 }
 
-mount(ComponentPage, { target });
+// Pass the bare component's module namespace as a prop so the Playground section
+// can mount the component directly with synthesized prop values (live preview,
+// #405). The page resolves it by \`documentation.component.exportName\`, falling
+// back to the default export — the whole namespace is handed over so both
+// resolve. Threaded as a prop (not a \`window\` global) so the live preview is
+// wired explicitly to the bundle that mounted the page.
+mount(ComponentPage, { target, props: { bareComponentModule: BareComponentModule } });
 `;
 
   try {

--- a/packages/playground/src/playground-server.ts
+++ b/packages/playground/src/playground-server.ts
@@ -758,12 +758,19 @@ async function compilePageBundleArtifacts(
   const entrySource = `import { mount } from 'svelte';
 
 import ComponentPage from '../component-page.svelte';
+import * as BareComponentModule from '@lostgradient/cinder/${componentName}';
 ${scenarioImports}
 const scenarios: Record<string, unknown> = {
 ${scenarioRegistrations}
 };
 
 (window as unknown as Record<string, unknown>)['__CINDER_SCENARIOS__'] = scenarios;
+// Register the bare component module so the Playground section can mount the
+// component directly with synthesized prop values (live preview, #405). The
+// page reads it by \`documentation.component.exportName\`; the whole namespace
+// is registered so both the named and default export resolve.
+(window as unknown as Record<string, unknown>)['__CINDER_BARE_COMPONENT__'] =
+  BareComponentModule;
 const target = document.getElementById('app');
 if (target === null) {
   throw new Error('[cinder playground] #app target not found');

--- a/packages/testing/tests/playground-documentation.playwright.ts
+++ b/packages/testing/tests/playground-documentation.playwright.ts
@@ -40,6 +40,38 @@ test.describe('playground component documentation', () => {
     await expect(preview.locator('.cinder-code-block__highlighted .shiki').first()).toBeVisible();
   });
 
+  test('playground preview re-renders live as a prop control changes (#405)', async ({ page }) => {
+    // `toggle` is used here (not `button`) because its generated playground
+    // actually renders: Toggle has no required prop the control synthesizer
+    // can't fill, so `showGeneratedPlayground` is true and the live mount
+    // appears. Button requires an accessible name with no default, which flags
+    // `hasUnsatisfiedRequired` and suppresses the generated playground entirely.
+    await page.goto('/c/toggle', { waitUntil: 'load' });
+    const preview = page.frameLocator('iframe[data-cinder-preview]');
+
+    // The Playground section mounts the BARE component live with the synthesized
+    // prop values, labelled "Live preview" — not the static "Featured example".
+    const playground = preview.locator('#playground');
+    await expect(playground).toBeVisible();
+    const liveMount = preview.locator('#playground-live-mount');
+    await expect(liveMount).toBeVisible();
+    await expect(playground.getByText('Live preview')).toBeVisible();
+
+    // A real Toggle instance rendered inside the live mount — a `role="switch"`
+    // button, enabled to start (the synthesized `disabled` default is false).
+    const liveSwitch = liveMount.getByRole('switch');
+    await expect(liveSwitch).toBeVisible();
+    await expect(liveSwitch).toBeEnabled();
+
+    // Flip the `disabled` boolean control. The bare Toggle forwards `disabled`
+    // onto its `<button role="switch">`, so the live mount re-renders with a
+    // DISABLED switch — proving the preview is prop-driven, not static. The
+    // control id follows the `pg-<prop>` pattern the controls panel emits; the
+    // boolean control renders as a switch button, so `.click()` flips it.
+    await playground.locator('#pg-disabled').click();
+    await expect(liveMount.getByRole('switch')).toBeDisabled();
+  });
+
   test('avatar-group exposes its styling variables in the raw artifacts', async ({ page }) => {
     await page.goto('/c/avatar-group', { waitUntil: 'load' });
     const preview = page.frameLocator('iframe[data-cinder-preview]');


### PR DESCRIPTION
## What

The component documentation page's **Playground** section now renders a **live preview** that re-renders as you change the prop controls. Previously it showed the static featured-example wrapper, whose only prop-driven part was the copyable snippet — the rendered component never reflected the controls.

Closes #405.

## How

- The Playground section mounts the **bare component** directly with the synthesized `playgroundValues`, via an `{@attach …}` factory that re-runs (teardown + fresh mount) whenever a control changes. This is the mechanism that makes the preview track the controls.
- The bare component's module namespace is passed to `component-page.svelte` as an explicit **`bareComponentModule` prop** at `mount(ComponentPage, …)` in the page-bundle entry — no `window` global. (Round-1 committee killed an earlier `window.__CINDER_BARE_COMPONENT__` global; there is now no global to go stale on iframe reuse / future SPA navigation.)
- The resolve + mount logic lives in one shared module, `component-page-live-preview.ts` (`resolveBareComponent`, `createLivePreviewMount`, `isMountableComponent`, `LIVE_MOUNT_CONTAINER_ID`), imported by **both** the page and the test fixture — so they cannot drift.
- **Fallback to the featured example** when (a) no bare component resolves, (b) the live mount throws at construction, or (c) snapshot mode is on. A reactive `liveMountFailed` guard drives the `{#if}` fall-through; an error callout only appears when there is no featured example to fall back to.

### Snapshot-mode contract preserved

Under `?snapshot=1` NEITHER the live nor the featured mount renders — the testing-package browser tests still count only `example-mount-<scenario>` selectors and run axe against them. Verified against the full playground suite.

## Tests

- New `component-page-live-preview.test.ts` (13 tests / 41 expect) drives the **production** `createLivePreviewMount` / `resolveBareComponent` through a thin host fixture: named- and default-export resolution, control-mutation re-render across string/boolean/select/number value shapes, error-keying by container id, fallback-to-featured on live-mount failure, and clear-on-success (invariant 6).
- New `playground-documentation.playwright.ts` real-Chromium test toggles a control and asserts the live mount re-rendered.
- Full `@cinder/playground` suite: **687 + 8 pass / 0 fail**. Typecheck clean, `svelte-check` clean on changed files, type-aware oxlint 0/0.

## Reviewed by

A multi-agent committee (svelte / testing / simplicity / junior personas + Codex `xhigh`) reviewed this across three rounds, plus an adversarial verification sweep. Final consensus: **PR-ready, zero blocking**. Notable decisions: remount-on-change is by-design (#405's whole point is re-render-from-controls; the documented trade-off is text-control focus loss per keystroke — acceptable for a preview surface where the snippet, not the mount, is the copy target); the error boundary records **synchronous** construction failures only (deferred `$effect`/`onMount` throws are out of scope — would need a `<svelte:boundary>`).

## Follow-up observation (out of scope; not introduced here)

`component-page.svelte` seeds `playgroundValues` from control defaults via a `$effect` that runs after first render, so the **first** live mount briefly receives `{}` props for one tick before the seed fires (a one-frame flash of default-less props on load). This is pre-existing control-seeding behavior, not something this PR introduces, and fixing it (seed inline on `resolveBareComponent` success, or `untrack` the defaults into the initial `$state`) is a separable refactor I deliberately kept out of this surgical change. Flagging it rather than silently leaving it.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes playground mount wiring and remount-on-control behavior in the docs page bundle; fallbacks limit blast radius, but preview UX and snapshot-mode contracts are load-bearing for tests.
> 
> **Overview**
> The Playground section now mounts the **bare component** with synthesized `playgroundValues` so the preview updates when controls change, instead of only showing a static featured example while the snippet stayed live.
> 
> Resolve and mount behavior is centralized in **`component-page-live-preview.ts`** (`resolveBareComponent`, `createLivePreviewMount`, shared container id and error keying). **`component-page.svelte`** wires an `{@attach …}` factory that remounts on each control change and passes **`$state.snapshot`** props as a plain object. The page bundle passes **`bareComponentModule`** as an explicit mount prop (no window global).
> 
> **Fallback:** unresolved exports or synchronous mount failures fall through to the featured example when one exists; **`?snapshot=1`** still suppresses both live and featured playground mounts. Errors surface only when there is no featured fallback.
> 
> **Tests:** unit suite via a thin fixture that imports the same production helpers, plus a Playwright check that toggling `disabled` on `/c/toggle` updates the live switch.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 56e1cea0aeb55a87b7e60fc481f774df4691f50f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->