### PR TITLE
ci(#411): gate PRs on components:check so generated-artifact drift can't reach main

### DIFF
--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -148,13 +148,16 @@ jobs:
       - name: Check styles aggregator completeness
         run: bun run --filter=@lostgradient/cinder aggregator:check
 
-      # Unconditional whole-repo invariant: the generated component artifacts
-      # (component manifest, examples manifests, exports map) must match what the
-      # generator would produce from the current sources. Drift ships stale docs
-      # and packaging metadata to consumers. Runs regardless of scope because a
-      # source change (e.g. a *.example.svelte edit) can desync the committed
-      # manifest while the generator's own files are unchanged (so `test:changed`
-      # would miss it). Sub-second; mirrors the aggregator gate above.
+      # Unconditional whole-repo invariant: the generated component artifacts —
+      # per-component schemas (.schema.json/.schema.ts), constraints (.constraints.json),
+      # examples manifests (.examples.json), generated README regions, and the
+      # aggregate components.json manifest — must match what the generator would
+      # produce from the current sources. (The package exports map is a separate
+      # generator, gated by exports-drift.test.ts, not by this step.) Drift ships
+      # stale docs and metadata to consumers. Runs regardless of scope because a
+      # source change (e.g. a *.example.svelte edit) can desync a committed manifest
+      # while the generator's own files are unchanged (so `test:changed` would miss
+      # it). Sub-second; mirrors the aggregator gate above.
       - name: Check generated component artifacts are up to date
         run: bun run --filter=@lostgradient/cinder components:check
 

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -148,6 +148,16 @@ jobs:
       - name: Check styles aggregator completeness
         run: bun run --filter=@lostgradient/cinder aggregator:check
 
+      # Unconditional whole-repo invariant: the generated component artifacts
+      # (component manifest, examples manifests, exports map) must match what the
+      # generator would produce from the current sources. Drift ships stale docs
+      # and packaging metadata to consumers. Runs regardless of scope because a
+      # source change (e.g. a *.example.svelte edit) can desync the committed
+      # manifest while the generator's own files are unchanged (so `test:changed`
+      # would miss it). Sub-second; mirrors the aggregator gate above.
+      - name: Check generated component artifacts are up to date
+        run: bun run --filter=@lostgradient/cinder components:check
+
       - name: Run component unit tests (scoped)
         # Scopes the `@lostgradient/cinder` (components) package to the changed components and
         # their dependents. Sibling @cinder/* package suites are intentionally

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -4099,7 +4099,7 @@
     "test:coverage": "TZ=UTC LANG=en_US.UTF-8 bun test --conditions browser --conditions svelte --parallel=1 --coverage --coverage-reporter=lcov && bun run scripts/check-coverage-ratchet.ts",
     "tokens:audit": "bun run scripts/check-component-css-token-usage.ts",
     "typecheck": "tsc --noEmit -p tsconfig.check.json && bunx svelte-check --workspace src --tsconfig ../tsconfig.json --threshold error",
-    "validate": "bun run lint && bun run typecheck && bun run check:placeholder-docs && bun run test:coverage && bun run platform:audit -- --strict && bun run colors:audit -- --strict && bun run tokens:audit -- --strict && bun run aggregator:check && bun run validate:workflow && bun run validate:svelte-peer && bun run validate:consumer && bun run package:weight:check -- --existing-tarball",
+    "validate": "bun run lint && bun run typecheck && bun run check:placeholder-docs && bun run test:coverage && bun run platform:audit -- --strict && bun run colors:audit -- --strict && bun run tokens:audit -- --strict && bun run aggregator:check && bun run components:check && bun run validate:workflow && bun run validate:svelte-peer && bun run validate:consumer && bun run package:weight:check -- --existing-tarball",
     "validate:consumer": "bun run scripts/validate-consumers.ts",
     "validate:release-workflow": "bun run scripts/validate-release-workflow.ts",
     "validate:svelte-peer": "bun run scripts/validate-svelte-peer-contract.ts",


### PR DESCRIPTION
## What

Wires the existing `components:check` script into PR-gating CI so generated-artifact drift can no longer reach `main` undetected.

`components:check` (`generate-component-artifacts.ts --check`) verifies that the committed generated artifacts — `components.json` manifest, per-component `*.examples.json`, the exports map, generated README regions, `*.schema.json`, `*.variables.json` — match what the generator would produce from current sources, exiting non-zero on drift. It previously ran in **no** PR-gating workflow (the only existing artifact-drift gate in CI was `aggregator:check`, which covers CSS only), so a `*.example.svelte` / schema / constraints edit could land stale generated metadata on `main` with all checks green.

## Changes

1. **`.github/workflows/unit-tests.yaml`** — add an unconditional `components:check` step to the `unit-tests` job, placed right after the existing `aggregator:check` gate and modeled on it.
2. **`packages/components/package.json`** — chain `components:check` into the local `validate` script (right after `aggregator:check`) so `bun run validate` stops giving a false-green for artifact drift, matching the CI gate.

## Why unconditional (not under the changed-components scope filter)

A source-only edit (e.g. a `*.example.svelte` change) can desync the committed manifest while the generator's own files are unchanged, so the scoped `test:changed` pass would miss it. This is the same reasoning the adjacent `aggregator:check` step documents.

## Safety

- The check reads only source + committed artifacts — **no `dist/` or build-step dependency**. It relies only on prettier, already installed by the job's `bun install --frozen-lockfile`.
- It passes clean (exit 0) on current `main`, so this gate does **not** turn `main` red on landing — it only catches *future* drift.
- The workflow's `paths` filter already includes `packages/**`, covering every drift source.
- Sub-second runtime.

## Review

Committee-reviewed (dx-engineer, simplicity-engineer, Codex/gpt-5.4 xhigh) — unanimous APPROVED, no must-fix findings. The `validate`-chain addition was a dx-engineer finding folded in during review.

Closes #411

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI and validate wiring only; no runtime or generator logic changes.
> 
> **Overview**
> PRs now fail if committed generated component metadata is out of sync with sources, closing a gap where only CSS aggregator drift was gated in CI.
> 
> The **unit-tests** workflow runs `components:check` unconditionally (right after `aggregator:check`), before scoped unit tests. Source-only edits—e.g. `*.example.svelte`—can desync manifests without touching generator files, so this step is not limited to changed-component scope.
> 
> Local **`bun run validate`** in `@lostgradient/cinder` also runs `components:check` after `aggregator:check`, so a full validate no longer passes when schemas, examples JSON, constraints, README regions, or `components.json` are stale.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cdab78671d5b5123b006e25a004dbee3a40efdd2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->