### PR TITLE
test(#409): regression guard for focused invalid-state danger ring (Select)

### DIFF
--- a/packages/components/src/components/select/select.examples.json
+++ b/packages/components/src/components/select/select.examples.json
@@ -20,6 +20,12 @@
       "title": "Typed options with as const",
       "description": "Use `as const` on the options array to infer a precise literal-union type for `T`. TypeScript then rejects any `value` that is not a member of the union at compile time.",
       "code": "<script lang=\"ts\">\n  import { Select } from '@lostgradient/cinder/select';\n\n  // `as const` narrows value types to the literal union 'us' | 'ca' | 'gb' | 'au'.\n  // T is inferred from `options`; passing value=\"invalid\" would be a compile error.\n  const options = [\n    { value: 'us', label: 'United States' },\n    { value: 'ca', label: 'Canada' },\n    { value: 'gb', label: 'United Kingdom' },\n    { value: 'au', label: 'Australia' },\n  ] as const;\n\n  type CountryCode = (typeof options)[number]['value'];\n  let country = $state<CountryCode>('us');\n</script>\n\n<Select id=\"country-typed\" bind:value={country} {options} label=\"Country\" />\n<p style=\"margin-top: 0.5rem; color: var(--cinder-text-muted);\">Selected: {country}</p>\n"
+    },
+    {
+      "id": "with-error",
+      "title": "Select with an error",
+      "description": "A required Select whose placeholder is still selected is invalid: pass a non-empty `error` string to mark it. The control gets `aria-invalid=\"true\"`, the message is wired via `aria-describedby`, and a danger ring replaces the focus ring when the invalid control is focused.",
+      "code": "<script lang=\"ts\">\n  import { Select } from '@lostgradient/cinder/select';\n\n  // A `disabled` placeholder paired with `required` is the accessible pattern for\n  // a \"must pick one\" Select: the empty value can be the initial state but cannot\n  // be re-selected, and native constraint validation agrees with the `error` prop.\n  const options = [\n    { value: '', label: 'Select a plan…', disabled: true },\n    { value: 'free', label: 'Free' },\n    { value: 'pro', label: 'Pro' },\n    { value: 'enterprise', label: 'Enterprise' },\n  ];\n\n  let plan = $state('');\n</script>\n\n<Select\n  id=\"plan-error\"\n  bind:value={plan}\n  {options}\n  label=\"Plan\"\n  required\n  error=\"Choose a plan to continue.\"\n/>\n"
     }
   ]
 }

--- a/packages/playground/src/examples/select/with-error.example.svelte
+++ b/packages/playground/src/examples/select/with-error.example.svelte
@@ -1,0 +1,30 @@
+<script lang="ts" module>
+  export const title = 'Select with an error';
+  export const description =
+    'A required Select whose placeholder is still selected is invalid: pass a non-empty `error` string to mark it. The control gets `aria-invalid="true"`, the message is wired via `aria-describedby`, and a danger ring replaces the focus ring when the invalid control is focused.';
+</script>
+
+<script lang="ts">
+  import { Select } from '@lostgradient/cinder/select';
+
+  // A `disabled` placeholder paired with `required` is the accessible pattern for
+  // a "must pick one" Select: the empty value can be the initial state but cannot
+  // be re-selected, and native constraint validation agrees with the `error` prop.
+  const options = [
+    { value: '', label: 'Select a plan…', disabled: true },
+    { value: 'free', label: 'Free' },
+    { value: 'pro', label: 'Pro' },
+    { value: 'enterprise', label: 'Enterprise' },
+  ];
+
+  let plan = $state('');
+</script>
+
+<Select
+  id="plan-error"
+  bind:value={plan}
+  {options}
+  label="Plan"
+  required
+  error="Choose a plan to continue."
+/>

--- a/packages/testing/src/helpers/focus-ring.ts
+++ b/packages/testing/src/helpers/focus-ring.ts
@@ -6,8 +6,10 @@
  * does not engage `:focus-visible` in Chromium), so these helpers drive the
  * keyboard, resolve design tokens through the engine, and read computed style.
  *
- * This is the canonical home for the keyboard-walk idiom; `*-focus-rings`
- * specs should import from here rather than re-declaring it.
+ * These helpers are the shared home for the keyboard-walk idiom. New
+ * focus-ring specs should import them rather than re-declaring the idiom; the
+ * existing `*-focus-rings` specs predate this module and still inline their own
+ * copies.
  */
 
 import type { Locator, Page } from '@playwright/test';
@@ -39,12 +41,22 @@ export async function tabUntilFocused(
  * string by painting the token onto a probe span and reading its computed
  * color. Lets a test match the resolved token against a `box-shadow` value
  * without hard-coding the engine's serialization (rgb/oklch/etc).
+ *
+ * Throws if the token resolves to empty: an unset custom property would leave
+ * the probe at its inherited/default color, and a caller matching a
+ * `box-shadow` against that bogus color could pass vacuously. A missing token
+ * is a setup error, so fail loudly rather than silently weaken the guard.
  */
 export async function resolvedTokenColor(target: Locator, token: string): Promise<string> {
   return target.evaluate((element, tokenName) => {
     const value = getComputedStyle(element as HTMLElement)
       .getPropertyValue(tokenName)
       .trim();
+    if (value === '') {
+      throw new Error(
+        `resolvedTokenColor: custom property "${tokenName}" is unset on the target element`,
+      );
+    }
     const probe = document.createElement('span');
     probe.style.color = value;
     document.body.append(probe);
@@ -56,7 +68,13 @@ export async function resolvedTokenColor(target: Locator, token: string): Promis
   }, token);
 }
 
-/** Count comma-separated top-level box-shadow layers (commas inside fn args ignored). */
+/**
+ * Count comma-separated top-level box-shadow layers (commas inside fn args
+ * ignored). Returns 0 for the `none` keyword and the empty string so a caller
+ * cannot read a "1 layer" count off a box-shadow that paints nothing.
+ */
 export function boxShadowLayerCount(boxShadow: string): number {
-  return boxShadow.split(/,(?![^(]*\))/).length;
+  const value = boxShadow.trim();
+  if (value === '' || value === 'none') return 0;
+  return value.split(/,(?![^(]*\))/).length;
 }

--- a/packages/testing/src/helpers/focus-ring.ts
+++ b/packages/testing/src/helpers/focus-ring.ts
@@ -1,0 +1,62 @@
+/// <reference lib="dom" />
+/**
+ * Shared utilities for the focus-ring Playwright specs. Rendered focus/error
+ * rings can only be proven with a REAL browser (happy-dom does not compute
+ * `box-shadow`/`border-color`) and a REAL keyboard (a programmatic `.focus()`
+ * does not engage `:focus-visible` in Chromium), so these helpers drive the
+ * keyboard, resolve design tokens through the engine, and read computed style.
+ *
+ * This is the canonical home for the keyboard-walk idiom; `*-focus-rings`
+ * specs should import from here rather than re-declaring it.
+ */
+
+import type { Locator, Page } from '@playwright/test';
+
+/**
+ * Walk Tab from `document.body` until `target` is the active element, capped at
+ * `maxPresses`. Returns true when focus landed on the target. Blurs first so the
+ * walk is deterministic regardless of any prior autofocus.
+ */
+export async function tabUntilFocused(
+  page: Page,
+  target: Locator,
+  maxPresses = 50,
+): Promise<boolean> {
+  await page.evaluate(() => {
+    if (document.activeElement instanceof HTMLElement) document.activeElement.blur();
+    document.body.focus();
+  });
+  for (let attempt = 0; attempt < maxPresses; attempt += 1) {
+    await page.keyboard.press('Tab');
+    const landed = await target.evaluate((element) => element === document.activeElement);
+    if (landed) return true;
+  }
+  return false;
+}
+
+/**
+ * Resolve a CSS custom property on `element` to a browser-normalized color
+ * string by painting the token onto a probe span and reading its computed
+ * color. Lets a test match the resolved token against a `box-shadow` value
+ * without hard-coding the engine's serialization (rgb/oklch/etc).
+ */
+export async function resolvedTokenColor(target: Locator, token: string): Promise<string> {
+  return target.evaluate((element, tokenName) => {
+    const value = getComputedStyle(element as HTMLElement)
+      .getPropertyValue(tokenName)
+      .trim();
+    const probe = document.createElement('span');
+    probe.style.color = value;
+    document.body.append(probe);
+    try {
+      return getComputedStyle(probe).color;
+    } finally {
+      probe.remove();
+    }
+  }, token);
+}
+
+/** Count comma-separated top-level box-shadow layers (commas inside fn args ignored). */
+export function boxShadowLayerCount(boxShadow: string): number {
+  return boxShadow.split(/,(?![^(]*\))/).length;
+}

--- a/packages/testing/tests/input-frame-danger-ring.playwright.ts
+++ b/packages/testing/tests/input-frame-danger-ring.playwright.ts
@@ -1,0 +1,78 @@
+/// <reference lib="dom" />
+/**
+ * Regression guard for the focused invalid-state error affordance on the shared
+ * `.cinder-_input-frame` partial (issue #409).
+ *
+ * PR #408 briefly set `border-color: transparent` on
+ * `[aria-invalid='true']:focus-visible` WITHOUT a replacement danger ring, so a
+ * focused invalid Select lost its red error boundary entirely. No unit test
+ * could catch this: happy-dom does not compute `box-shadow`/`border-color`, and
+ * `select.test.ts` only asserts the `aria-invalid` attribute. The guarded rule
+ * lives in `packages/components/src/styles/components/_input-frame.css`.
+ *
+ * Select is the critical consumer: its danger ring comes ONLY from that shared
+ * rule (`select.css` has no focused danger ring of its own), so it is the case
+ * that regresses if the shared rule is removed again.
+ */
+
+import { expect, test } from '@playwright/test';
+import {
+  boxShadowLayerCount,
+  resolvedTokenColor,
+  tabUntilFocused,
+} from '../src/helpers/focus-ring.ts';
+
+test.describe('input-frame danger ring — focused invalid-state error affordance (#409)', () => {
+  test('a focused invalid select keeps a danger-colored ring', async ({ page }) => {
+    await page.goto('/page/select?snapshot=1', { waitUntil: 'load' });
+    await page.waitForLoadState('networkidle');
+
+    // The `with-error` example mounts a Select with `error="…"`, so its native
+    // `<select>` carries `aria-invalid="true"` and `.cinder-_input-frame` from
+    // the moment it renders — no interaction needed to reach the invalid state.
+    const select = page.locator(
+      '#example-mount-with-error select.cinder-_input-frame[aria-invalid="true"]',
+    );
+    await expect(select).toBeVisible();
+
+    const landed = await tabUntilFocused(page, select);
+    expect(landed, 'Tab walk should reach the invalid select').toBe(true);
+    await expect(select).toBeFocused();
+
+    const dangerColor = await resolvedTokenColor(select, '--cinder-danger');
+    const result = await select.evaluate((element) => {
+      const styles = getComputedStyle(element as HTMLElement);
+      // Paint the border color onto a 1×1 canvas and read its alpha channel so
+      // the transparent-border check does not depend on the engine serializing
+      // `transparent` to a specific string.
+      const canvas = document.createElement('canvas');
+      canvas.width = 1;
+      canvas.height = 1;
+      const context = canvas.getContext('2d');
+      let borderAlpha = -1;
+      if (context) {
+        context.fillStyle = styles.borderTopColor;
+        context.fillRect(0, 0, 1, 1);
+        borderAlpha = context.getImageData(0, 0, 1, 1).data[3] ?? -1;
+      }
+      return {
+        matchesFocusVisible: element.matches(':focus-visible'),
+        boxShadow: styles.boxShadow,
+        borderAlpha,
+      };
+    });
+
+    // The keyboard drove :focus-visible (a programmatic focus would not).
+    expect(result.matchesFocusVisible).toBe(true);
+    // The danger ring lives in box-shadow, and it is the danger color — not the
+    // neutral focus-ring color the broken #408 state fell back to.
+    expect(result.boxShadow).not.toBe('none');
+    expect(result.boxShadow).toContain(dangerColor);
+    expect(result.boxShadow).not.toContain('inset');
+    // The two-stop recipe is offset band + danger ring.
+    expect(boxShadowLayerCount(result.boxShadow)).toBeGreaterThanOrEqual(2);
+    // The danger border is swapped for the ring while focused, so the border is
+    // transparent — the regression left it transparent with NO ring to replace it.
+    expect(result.borderAlpha).toBe(0);
+  });
+});


### PR DESCRIPTION
## What

Adds a **Select `with-error` example** plus a **Playwright regression guard** for the focused invalid-state error affordance on the shared `.cinder-_input-frame` partial.

The CSS fix already landed in #408: when an invalid control is focused, the danger *border* is swapped for a danger-colored *box-shadow ring* (the neutral focus ring alone does not read as "error"). This PR pins that behavior so it can't silently regress again.

## Why Select is the critical consumer

The focused danger ring lives **only** in the shared `_input-frame.css` partial. `textarea.css` carries its own duplicate danger ring, so Textarea survives deletion of the shared rule — but `select.css` does **not**. Select is therefore the case that regresses if the shared rule is removed, so the guard targets Select specifically.

## The guard

`packages/testing/tests/input-frame-danger-ring.playwright.ts` (Chromium):

1. Navigates to `/page/select?snapshot=1`, finds the `with-error` mount's native `<select aria-invalid="true">`.
2. **Keyboard** Tab-walks to it (a programmatic `.focus()` would not engage `:focus-visible`).
3. Asserts: `:focus-visible` engaged, `box-shadow` is non-`none`, contains the resolved `--cinder-danger` color (not the neutral focus-ring color the broken #408 state fell back to), is **not** `inset`, has **≥2 layers** (offset band + danger ring), and the border alpha is **0** (the danger border is swapped for the ring while focused).

**Proven non-vacuous:** with the danger `box-shadow` removed from `_input-frame.css` (reproducing the exact #408 regression), the test goes **RED**; restored, it's **GREEN**.

## Example

`packages/playground/src/examples/select/with-error.example.svelte` — a `required` Select with a `disabled` placeholder option (the accessible "must pick one" pattern) and a non-empty `error` string, which sets `aria-invalid="true"` and wires the message via `aria-describedby`.

## Refactor

Extracts the keyboard-walk / token-resolve / box-shadow-layer-count idiom (previously inline in `focus-family-rings.playwright.ts`) into a shared `packages/testing/src/helpers/focus-ring.ts`.

## Verification

- ✅ `components:check` — no drift
- ✅ playground `validate` — 314 example titles, 155 component + 155 doc routes 200
- ✅ typecheck (components, playground, testing) — 0 errors
- ✅ full pre-commit test suites — all 3 packages green
- ✅ Playwright guard — RED on regression, GREEN restored

## Committee

Reviewed by testing-expert, svelte-expert, ux-designer, simplicity-engineer, and Codex (gpt-5.4/xhigh). All must-fixes implemented (shared-helper extraction, Select-only test, disabled-placeholder example, canvas-alpha border check). All APPROVED.

Closes #409

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to examples and Playwright test infrastructure; no production component or CSS logic is modified in this diff.
> 
> **Overview**
> Adds a **Select with error** playground example and documents it in `select.examples.json`, showing the required + disabled-placeholder + `error` pattern for invalid state.
> 
> Introduces **`packages/testing/src/helpers/focus-ring.ts`** with shared Playwright helpers (`tabUntilFocused`, `resolvedTokenColor`, `boxShadowLayerCount`) for keyboard-driven `:focus-visible` and computed-style checks.
> 
> Adds **`input-frame-danger-ring.playwright.ts`**, which targets the `with-error` mount and asserts a focused invalid Select keeps a **danger-colored `box-shadow` ring** (not a transparent border with no replacement), guarding the shared `_input-frame.css` behavior that Select alone depends on.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6929bd59ddb2d25864858b0e0f5904a275c84fb4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->