### PR TITLE
fix(#401): resolve duplicate "When to use" H2 + steps focus-ring bisected by connector

### DIFF
--- a/packages/components/src/components/alert-dialog/README.md
+++ b/packages/components/src/components/alert-dialog/README.md
@@ -15,13 +15,13 @@ The key distinction between AlertDialog and ConfirmDialog is _who initiates_ the
 - ConfirmDialog is for user-initiated actions that need a safety gate. Pressing Escape means "never mind" — a safe, expected exit. This includes high-impact destructive actions the user initiated, even ones that affect other people.
 - AlertDialog is for conditions the _system_ surfaces that require the user to acknowledge before continuing. Pressing Escape would bypass acknowledgement, which is unsafe because the session state has already changed and proceeding without reading the message is incorrect.
 
-## When to use
+## Choosing this component
 
 - Session expiry, authentication loss, or network disconnection that requires the user to re-authenticate before continuing.
 - System-level errors or process failures where the user must acknowledge the condition before taking any other action.
 - Any situation where the dialog is triggered by a system event — not a user click — and dismissal by Escape or backdrop click would be incorrect because the user _must_ read and respond.
 
-## When not to use
+## Choosing something else
 
 - User-initiated destructive actions (including high-impact ones like "Delete workspace" or "Remove all collaborators") — use [`ConfirmDialog`](../confirm-dialog/README.md). Even when the action is irreversible or affects other people, Escape is a valid "never mind" because the _user_ chose to open the dialog. ConfirmDialog's cancel-button autofocus is the right affordance.
 - Rich body content (markup, lists, multiple paragraphs) — `description` is a plain-text string. For rich body, compose [`Modal`](../modal/README.md) with `role="alertdialog"` directly (see Modal's `role` prop documentation for the required companion props).

--- a/packages/components/src/components/confirm-dialog/README.md
+++ b/packages/components/src/components/confirm-dialog/README.md
@@ -15,13 +15,13 @@ The key distinction between ConfirmDialog and AlertDialog is _who initiates_ the
 - ConfirmDialog is for user-initiated actions that need a safety gate ("You clicked Delete — are you sure?"). Escape is a safe exit; cancel is the default focus.
 - AlertDialog is for system-initiated or out-of-band urgency ("Your session expired", "This action affects others"). Escape is blocked; acknowledgement is mandatory.
 
-## When to use
+## Choosing this component
 
 - Asking the user to confirm before deleting, discarding, or publishing something that cannot easily be undone.
 - Any two-action flow where the only choices are "proceed" and "cancel" — ConfirmDialog saves you from composing Modal + two Buttons manually.
 - Destructive actions: set `destructive` to apply the danger variant to the confirm button.
 
-## When not to use
+## Choosing something else
 
 - When the dialog body needs rich content (lists, markup, multiple paragraphs) — compose [`Modal`](../modal/README.md) directly instead, since `aria-describedby` collapses to a single continuous string for screen readers.
 - When more than two actions are needed — use [`Modal`](../modal/README.md) with a custom `footer` snippet.

--- a/packages/components/src/components/diff-statistics/README.md
+++ b/packages/components/src/components/diff-statistics/README.md
@@ -2,13 +2,13 @@
 
 Compact inline display of added, modified, and removed line counts for a file diff.
 
-## When to use
+## Choosing this component
 
 - Showing the line-change summary for a single file or commit in a code review, pull-request list, or activity feed.
 - Toolbars and compact layouts — use `density="toolbar"` to snap to the shared control-height tier.
 - Suppressing zero-count values cleanly with `hideZero` when a file has only additions or only deletions.
 
-## When not to use
+## Choosing something else
 
 - General numeric metrics (revenue, users, errors) — use [`Stat`](../stat/README.md) or [`StatGroup`](../stat-group/README.md) for dashboard figures.
 - Full diff rendering (side-by-side or unified views of the actual line changes) — DiffStatistics only summarises counts; use a diff renderer component for the actual content.

--- a/packages/components/src/components/drawer/README.md
+++ b/packages/components/src/components/drawer/README.md
@@ -2,13 +2,13 @@
 
 Side-anchored overlay panel for supplementary content without leaving the current page.
 
-## When to use
+## Choosing this component
 
 - Showing detail or edit forms alongside a list or table where the user needs to stay in context.
 - Navigation trees, filter panels, or settings that the user may want to keep open while interacting with the page.
 - Secondary workflows that complement the current view rather than replacing it.
 
-## When not to use
+## Choosing something else
 
 - Full-screen workflows that require the user's full attention — use a [`Modal`](../modal/README.md) or navigate to a new page.
 - Mobile-style bottom sheets — use [`Sheet`](../sheet/README.md) for the bottom-anchored variant.

--- a/packages/components/src/components/modal/README.md
+++ b/packages/components/src/components/modal/README.md
@@ -2,13 +2,13 @@
 
 Generic modal shell for rich content, forms, and structured workflows. Use the more specialised components when the content fits their narrower contract.
 
-## When to use
+## Choosing this component
 
 - Presenting rich or structured content (forms, multi-step wizards, detail views) inside a blocking overlay.
 - Collecting structured input — especially when multiple fields or widgets are involved.
 - Displaying content that requires user interaction before the page can continue, but where the interaction is more than a simple yes/no.
 
-## When not to use
+## Choosing something else
 
 - Two-action confirm/cancel prompts — use [`ConfirmDialog`](../confirm-dialog/README.md) instead. It handles autofocus on the cancel button, `aria-describedby`, and the destructive-variant button automatically.
 - Urgent blocking acknowledgements that must not be dismissed by Escape or backdrop click — use [`AlertDialog`](../alert-dialog/README.md) instead.

--- a/packages/components/src/components/popover/README.md
+++ b/packages/components/src/components/popover/README.md
@@ -23,7 +23,7 @@ Non-blocking floating panel anchored to a trigger element for contextual content
 </Popover>
 ```
 
-## When to use
+## Choosing this component
 
 Use Popover for rich, interactive contextual content anchored to a trigger — help panels, color pickers, settings cards, and similar surfaces that do not need to interrupt the user.
 

--- a/packages/components/src/components/selection-popover/README.md
+++ b/packages/components/src/components/selection-popover/README.md
@@ -2,7 +2,7 @@
 
 A floating toolbar that appears near a text selection and offers a comment-on-selection action with an inline composer. The component uses fixed-position Floating UI geometry, so the supplied selection anchor can flip or shift when it is near a viewport edge.
 
-## When to use
+## Choosing this component
 
 Use `SelectionPopover` when you want readers to annotate or comment on a highlighted range of text — for example, in a document editor, review tool, or article surface. It is designed specifically for selection-scoped actions. For generic floating content or popovers unrelated to text selection, use the `Popover` component instead.
 

--- a/packages/components/src/components/sheet/README.md
+++ b/packages/components/src/components/sheet/README.md
@@ -2,12 +2,12 @@
 
 Bottom-anchored overlay panel optimised for mobile-style drawer interactions.
 
-## When to use
+## Choosing this component
 
 - Action sheets and option pickers on mobile or touch-first layouts where a bottom-up slide feels natural.
 - Quick-select panels (share, sort, filter) that need to feel native on small screens.
 
-## When not to use
+## Choosing something else
 
 - Desktop-first side panels — use [`Drawer`](../drawer/README.md) for left/right edge placement.
 - Full-attention blocking dialogs — use [`Modal`](../modal/README.md) when the user must act before continuing.

--- a/packages/components/src/components/stat/README.md
+++ b/packages/components/src/components/stat/README.md
@@ -2,13 +2,13 @@
 
 Single metric tile displaying a labelled numeric value with optional trend or unit.
 
-## When to use
+## Choosing this component
 
 - Surfacing a single KPI or headline number in a dashboard or summary card (revenue, users, uptime).
 - Pairing related figures — wrap multiple `Stat` tiles in [`StatGroup`](../stat-group/README.md) for consistent grid layout.
 - Showing a trend or change value alongside the primary number via the `change` prop.
 
-## When not to use
+## Choosing something else
 
 - Code-change line counts (+/- additions and removals) — use [`DiffStatistics`](../diff-statistics/README.md), which is purpose-built for that display.
 - Long lists of data points — use a [`Table`](../table/README.md) or [`DataList`](../data-list/README.md) instead.

--- a/packages/components/src/components/steps/steps.css
+++ b/packages/components/src/components/steps/steps.css
@@ -57,9 +57,15 @@
   }
 
   .cinder-steps[data-cinder-orientation='horizontal'] .cinder-steps__marker {
-    /* Lift the marker above the connector line that passes behind it. */
+    /* Lift the marker above BOTH the connector line (z-index: 0) that passes
+       behind it AND the focusable body (z-index: 1) whose box overlaps the
+       marker via a negative block-start margin. The body must out-rank the
+       connector so its focus ring paints above the line, but it must stay
+       below the marker: the body paints LATER in flow and its :hover background
+       is opaque (--cinder-surface-hover), so at equal z-index it would occlude
+       the marker on hover. z-index: 2 keeps the marker on top in every state. */
     position: relative;
-    z-index: 1;
+    z-index: 2;
   }
 
   .cinder-steps[data-cinder-orientation='horizontal'] .cinder-steps__connector {
@@ -101,9 +107,10 @@
    *      `anchor.contains(marker) === false`), so instead of nesting it we raise
    *      the box's top edge up to the marker's top with a negative block-start
    *      margin, and add an equal block-start padding so the label/description
-   *      stay exactly where they were. The marker keeps `z-index: 1` and the body
-   *      background is transparent, so the marker paints over the (transparent)
-   *      box with no occlusion. Net: the ring encloses marker + body as one unit,
+   *      stay exactly where they were. The body takes `z-index: 1` so its focus
+   *      ring paints above the connector, while the marker takes `z-index: 2` so
+   *      it stays above the body's overlapping box even when the body's :hover
+   *      background is opaque. Net: the ring encloses marker + body as one unit,
    *      the connector (pinned to the marker center) now sits inside the ring's
    *      vertical span, and the visible content y/x position is invariant.
    *
@@ -117,6 +124,12 @@
     align-self: center;
     margin-block-start: calc(-1 * var(--_marker-size));
     padding-block-start: calc(var(--_marker-size) + var(--cinder-space-2));
+    /* Lift the focusable body above the connector line (z-index: 0) so its
+       :focus-visible box-shadow ring paints ABOVE the line instead of being
+       bisected by it. The marker sits one level higher (z-index: 2) so it is
+       never occluded by the body's overlapping box — see the marker rule. */
+    position: relative;
+    z-index: 1;
   }
 
   /* ----------------------------------------

--- a/packages/components/src/components/steps/steps.test.ts
+++ b/packages/components/src/components/steps/steps.test.ts
@@ -359,12 +359,15 @@ describe('Steps — horizontal layout geometry (CSS contract)', () => {
     expect(body).toMatch(/z-index:\s*0;/);
   });
 
-  test('horizontal marker stacks above the connector line passing behind it', () => {
+  test('horizontal marker stacks above both the connector line and the focusable body', () => {
     const body = ruleBody(
       /\.cinder-steps\[data-cinder-orientation='horizontal'\]\s*\.cinder-steps__marker\s*\{/,
     );
     expect(body).toMatch(/position:\s*relative;/);
-    expect(body).toMatch(/z-index:\s*1;/);
+    // z-index: 2 — one level above the focusable body (z-index: 1), whose box
+    // overlaps the marker and whose :hover background is opaque, so the marker
+    // must out-rank it to avoid being occluded on hover.
+    expect(body).toMatch(/z-index:\s*2;/);
   });
 
   test('horizontal body centers its label and description under the marker', () => {
@@ -404,6 +407,43 @@ describe('Steps — horizontal layout geometry (CSS contract)', () => {
     expect(body).toMatch(
       /padding-block-start:\s*calc\(var\(--_marker-size\) \+ var\(--cinder-space-2\)\);/,
     );
+  });
+
+  test('horizontal interactive body lifts its focus ring above the connector line', () => {
+    // The focusable body must be positioned with a z-index so its :focus-visible
+    // box-shadow ring paints ABOVE the connector (z-index: 0) instead of being
+    // bisected by it. Regression guard for #401 (connector bisects focus ring).
+    const body = ruleBody(
+      /\.cinder-steps\[data-cinder-orientation='horizontal'\]\s*\.cinder-steps__interactive\.cinder-steps__body\s*\{[^}]*margin-block-start/,
+    );
+    expect(body).toMatch(/position:\s*relative;/);
+    expect(body).toMatch(/z-index:\s*1;/);
+  });
+
+  test('horizontal stacking order is connector < focusable body < marker', () => {
+    // The three painted layers in a horizontal step overlap geometrically (the
+    // connector runs through the marker center; the body's negative block-start
+    // margin pulls its box up over the marker). The required paint order is:
+    //   connector (behind) < focusable body (focus ring above the line) < marker.
+    // The marker must out-rank the body specifically because the body paints
+    // LATER in DOM order and its :hover background is opaque, so equal z-index
+    // would let the body occlude the marker on hover (#401 committee finding).
+    const zIndexOf = (selector: RegExp): number => {
+      const match = ruleBody(selector).match(/z-index:\s*(-?\d+);/);
+      expect(match, `z-index not found for ${selector}`).not.toBeNull();
+      return Number(match?.[1]);
+    };
+    const connector = zIndexOf(
+      /\.cinder-steps\[data-cinder-orientation='horizontal'\]\s*\.cinder-steps__connector\s*\{/,
+    );
+    const interactiveBody = zIndexOf(
+      /\.cinder-steps\[data-cinder-orientation='horizontal'\]\s*\.cinder-steps__interactive\.cinder-steps__body\s*\{[^}]*margin-block-start/,
+    );
+    const marker = zIndexOf(
+      /\.cinder-steps\[data-cinder-orientation='horizontal'\]\s*\.cinder-steps__marker\s*\{/,
+    );
+    expect(connector).toBeLessThan(interactiveBody);
+    expect(interactiveBody).toBeLessThan(marker);
   });
 });
 


### PR DESCRIPTION
## Summary

Resolves the two verified-open items from the visual/a11y audit issue #401.

### 1. Duplicate "When to use" H2 in 9 component doc pages

Nine component READMEs carried prose `## When to use` / `## When not to use` headings. The doc page (`component-page.svelte`) renders a *separate generated* "When to use" section (the Use-when / Avoid-when cards driven by `@useWhen` / `@avoidWhen` schema annotations) as its own `<h2>`. The prose H2 therefore collided with the generated one — two `When to use` headings on the same page.

Fix: rename the prose headings to **`## Choosing this component`** / **`## Choosing something else`** (kept at H2). Renaming — rather than demoting to H3 — avoids a skipped heading level (H1→H3) in the standalone READMEs where the heading is the first one after the title, while still eliminating the text collision with the generated section.

Affected READMEs: `alert-dialog`, `confirm-dialog`, `diff-statistics`, `drawer`, `modal`, `popover`, `selection-popover`, `sheet`, `stat`. (All nine carry `@useWhen`/`@avoidWhen` annotations, so all nine render the generated section that collided.) These are prose-only changes — `components:check` stays green because prose headings are not part of the generated manifest.

### 2. Horizontal steps: focus ring bisected by the connector line

In horizontal orientation the focusable step body sat at the same stacking level as the connector line, so the keyboard focus ring was visually bisected by the connector. Raising the body to `z-index: 1` (above the connector at `0`) fixed the bisection but, at equal `z-index`, the body's opaque `:hover` background would then paint *over* the step marker (the body is later in DOM order). 

Fix: establish a strict paint hierarchy — **connector (0) < focusable body (1) < marker (2)**. The marker is raised to `z-index: 2` so it always out-ranks the body's hover background; the body keeps `z-index: 1` so its focus ring clears the connector.

### Tests

- `steps.test.ts`: updated the marker stacking assertion to `z-index: 2` and added a new test, *"horizontal stacking order is connector < focusable body < marker"*, that parses all three `z-index` values and asserts the full hierarchy (not just individual declarations). Full file: 34 pass / 0 fail.

## Committee review

Reviewed by ux-designer, testing-expert, prose-editor, svelte-expert, simplicity-engineer, and Codex (gpt-5.4 / xhigh). Two Codex must-fixes (marker/body z-index collision; test should assert the hierarchy, not just declarations) and one prose-editor must-fix (avoid the skipped heading level) were all addressed before this PR opened. Codex round 2: APPROVED.

Closes #401

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation wording and localized CSS stacking for horizontal Steps only; behavior is guarded by CSS contract tests with no API changes.
> 
> **Overview**
> Addresses audit **#401** with doc-only heading renames and a **Steps** paint-order fix.
> 
> **Component READMEs (nine files):** Prose `## When to use` / `## When not to use` are renamed to **`## Choosing this component`** and **`## Choosing something else`** so they no longer duplicate the doc site’s generated “When to use” `<h2>` (from `@useWhen` / `@avoidWhen`). Headings stay at H2 to avoid skipping levels in standalone READMEs.
> 
> **Horizontal `Steps`:** Establishes stacking **connector (0) &lt; focusable body (1) &lt; marker (2)** so `:focus-visible` rings are not cut by the connector and the marker is not covered by the body’s opaque `:hover` background. **`steps.test.ts`** asserts the full z-index hierarchy and the interactive body’s `position` / `z-index`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8a508a50a5c575df348e9a8b733a562d7bd1dde1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->