### PR TITLE
fix(#420): make example-metadata extraction escape-aware

### DIFF
--- a/.changeset/generator-escape-aware-metadata.md
+++ b/.changeset/generator-escape-aware-metadata.md
@@ -1,0 +1,11 @@
+---
+'@lostgradient/cinder': patch
+---
+
+Fix the component-example generator's metadata extraction so escaped delimiters
+and line continuations inside an example's `title`/`description` string literal
+no longer truncate the value or leak the `<script module>` block into the
+published `code` field (#420). The extraction grammar is now escape-aware and
+the parsed value is decoded to its true string. No existing example artifact
+changes — this only affects future examples whose metadata contains an escape
+sequence.

--- a/packages/components/scripts/generate-component-examples.test.ts
+++ b/packages/components/scripts/generate-component-examples.test.ts
@@ -174,16 +174,26 @@ describe('extractExampleFile — happy path', () => {
 
 describe('extractExampleFile — escape-aware metadata literals (#420)', () => {
   /**
-   * Builds a minimal valid source whose `description` is the GIVEN literal text
-   * (delimiters and escapes intact), inserted verbatim into the module block.
-   * This lets each case exercise a specific delimiter + escape combination that
-   * the shared `buildSource` helper (single-quote-only) cannot express.
+   * Builds a minimal valid source whose `title`/`description` are the GIVEN
+   * literal texts (delimiters and escapes intact), inserted verbatim into the
+   * module block. This lets each case exercise a specific delimiter + escape
+   * combination that the shared `buildSource` helper (single-quote-only) cannot
+   * express. `extraModuleContent` is appended inside the module block so a case
+   * can introduce a non-metadata export and assert the block is preserved.
    */
-  function buildSourceWithDescriptionLiteral(descriptionLiteral: string): string {
+  function buildSourceWithLiterals({
+    titleLiteral = `'Auto columns'`,
+    descriptionLiteral,
+    extraModuleContent = '',
+  }: {
+    titleLiteral?: string;
+    descriptionLiteral: string;
+    extraModuleContent?: string;
+  }): string {
     return `<script lang="ts" module>
-  export const title = 'Auto columns';
+  export const title = ${titleLiteral};
   export const description = ${descriptionLiteral};
-</script>
+${extraModuleContent}</script>
 
 <script lang="ts">
   import { Button } from '@lostgradient/cinder/button';
@@ -191,6 +201,11 @@ describe('extractExampleFile — escape-aware metadata literals (#420)', () => {
 
 <Button label="Click" />
 `;
+  }
+
+  /** Convenience wrapper for cases that only vary the `description` literal. */
+  function buildSourceWithDescriptionLiteral(descriptionLiteral: string): string {
+    return buildSourceWithLiterals({ descriptionLiteral });
   }
 
   // Before the fix, the extraction regex stopped at the first RAW delimiter
@@ -266,6 +281,64 @@ describe('extractExampleFile — escape-aware metadata literals (#420)', () => {
     // embedded newline in the source statement.
     expect(result.example.code).not.toContain('export const description');
     expect(result.example.code).not.toMatch(/<script[^>]*\bmodule\b/);
+  });
+
+  it('cooks a CRLF line continuation away to nothing', () => {
+    // The CRLF alternative must precede the single-terminator branch so `\r\n`
+    // is consumed as one continuation rather than `\r` alone.
+    const source = buildSourceWithDescriptionLiteral("'one \\\r\ntwo'");
+    const result = extractExampleFile(buildInput(source));
+
+    expect(result.kind).toBe('example');
+    if (result.kind !== 'example') return;
+    expect(result.example.description).toBe('one two');
+  });
+
+  it('decodes a \\uHHHH unicode escape in metadata', () => {
+    const source = buildSourceWithDescriptionLiteral(String.raw`'café au lait'`);
+    const result = extractExampleFile(buildInput(source));
+
+    expect(result.kind).toBe('example');
+    if (result.kind !== 'example') return;
+    expect(result.example.description).toBe('café au lait');
+  });
+
+  it('round-trips an escaped delimiter in title and strips the module block', () => {
+    const source = buildSourceWithLiterals({
+      titleLiteral: String.raw`"Set \"auto\" columns"`,
+      descriptionLiteral: `'A description.'`,
+    });
+    const result = extractExampleFile(buildInput(source));
+
+    expect(result.kind).toBe('example');
+    if (result.kind !== 'example') return;
+    // `title` goes through the same extraction + strip path as `description`.
+    expect(result.example.title).toBe('Set "auto" columns');
+    expect(result.example.code).not.toContain('export const title');
+    expect(result.example.code).not.toMatch(/<script[^>]*\bmodule\b/);
+  });
+
+  it('keeps the module block verbatim when a non-metadata export sits beside an escaped literal', () => {
+    // The invariant the bug broke: an escaped literal must not make a
+    // non-metadata-only block look metadata-only (or vice versa). The structural
+    // strip-detection must remove the escaped metadata statement so the block is
+    // correctly classified — here as NON-metadata-only (it has an extra export),
+    // so the whole module block is preserved verbatim in `code`.
+    const source = buildSourceWithLiterals({
+      descriptionLiteral: String.raw`"Set \"auto\" mode."`,
+      extraModuleContent: `  export type Mode = 'auto' | 'manual';\n`,
+    });
+    const result = extractExampleFile(buildInput(source));
+
+    expect(result.kind).toBe('example');
+    if (result.kind !== 'example') return;
+    // The description still decodes correctly.
+    expect(result.example.description).toBe('Set "auto" mode.');
+    // The block has a non-metadata export, so it is kept verbatim.
+    expect(result.example.code).toContain('export const title');
+    expect(result.example.code).toContain('export const description');
+    expect(result.example.code).toContain("export type Mode = 'auto' | 'manual'");
+    expect(result.example.code).toMatch(/<script[^>]*\bmodule\b/);
   });
 });
 

--- a/packages/components/scripts/generate-component-examples.test.ts
+++ b/packages/components/scripts/generate-component-examples.test.ts
@@ -169,6 +169,107 @@ describe('extractExampleFile — happy path', () => {
 });
 
 // ---------------------------------------------------------------------------
+// Escape-aware metadata extraction (#420)
+// ---------------------------------------------------------------------------
+
+describe('extractExampleFile — escape-aware metadata literals (#420)', () => {
+  /**
+   * Builds a minimal valid source whose `description` is the GIVEN literal text
+   * (delimiters and escapes intact), inserted verbatim into the module block.
+   * This lets each case exercise a specific delimiter + escape combination that
+   * the shared `buildSource` helper (single-quote-only) cannot express.
+   */
+  function buildSourceWithDescriptionLiteral(descriptionLiteral: string): string {
+    return `<script lang="ts" module>
+  export const title = 'Auto columns';
+  export const description = ${descriptionLiteral};
+</script>
+
+<script lang="ts">
+  import { Button } from '@lostgradient/cinder/button';
+</script>
+
+<Button label="Click" />
+`;
+  }
+
+  // Before the fix, the extraction regex stopped at the first RAW delimiter
+  // character even when it was backslash-escaped, truncating the description and
+  // leaving the (now-unmatched) export statement in place — which made the
+  // module block look non-metadata-only and leaked it into the published `code`.
+  const cases: Array<{ name: string; literal: string; expected: string }> = [
+    {
+      name: 'escaped double-quote inside a double-quote literal',
+      literal: String.raw`"Set \"auto\" mode."`,
+      expected: 'Set "auto" mode.',
+    },
+    {
+      name: 'escaped single-quote inside a single-quote literal',
+      literal: String.raw`'It\'s auto.'`,
+      expected: "It's auto.",
+    },
+    {
+      name: 'escaped backtick inside a backtick literal',
+      literal: '`Use \\`columns\\` with "auto".`',
+      expected: 'Use `columns` with "auto".',
+    },
+  ];
+
+  for (const { name, literal, expected } of cases) {
+    it(`round-trips the description and strips the module block for ${name}`, () => {
+      const source = buildSourceWithDescriptionLiteral(literal);
+      const result = extractExampleFile(buildInput(source));
+
+      expect(result.kind).toBe('example');
+      if (result.kind !== 'example') return;
+
+      // The description is the true unescaped string, not the truncated prefix.
+      expect(result.example.description).toBe(expected);
+      // The metadata-only module block is still recognized and stripped.
+      expect(result.example.code).not.toContain('export const title');
+      expect(result.example.code).not.toContain('export const description');
+      expect(result.example.code).not.toMatch(/<script[^>]*\bmodule\b/);
+      // The instance code is preserved.
+      expect(result.example.code).toContain("import { Button } from '@lostgradient/cinder/button'");
+    });
+  }
+
+  it('preserves a raw embedded double-quote in a single-quote literal (no regression)', () => {
+    const source = buildSourceWithDescriptionLiteral(`'Set "auto" mode.'`);
+    const result = extractExampleFile(buildInput(source));
+
+    expect(result.kind).toBe('example');
+    if (result.kind !== 'example') return;
+    expect(result.example.description).toBe('Set "auto" mode.');
+    expect(result.example.code).not.toContain('export const description');
+  });
+
+  it('decodes common escape sequences (newline) in metadata', () => {
+    const source = buildSourceWithDescriptionLiteral(String.raw`'Line one.\nLine two.'`);
+    const result = extractExampleFile(buildInput(source));
+
+    expect(result.kind).toBe('example');
+    if (result.kind !== 'example') return;
+    expect(result.example.description).toBe('Line one.\nLine two.');
+  });
+
+  it('cooks a line continuation (backslash + newline) away to nothing', () => {
+    // A `\` immediately followed by a line terminator is a JS line continuation:
+    // both characters are discarded, so the two source lines join with no gap.
+    const source = buildSourceWithDescriptionLiteral("'one \\\ntwo'");
+    const result = extractExampleFile(buildInput(source));
+
+    expect(result.kind).toBe('example');
+    if (result.kind !== 'example') return;
+    expect(result.example.description).toBe('one two');
+    // The metadata-only block is still recognized and stripped despite the
+    // embedded newline in the source statement.
+    expect(result.example.code).not.toContain('export const description');
+    expect(result.example.code).not.toMatch(/<script[^>]*\bmodule\b/);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Doc-page mount-isolation harness strip (#399)
 // ---------------------------------------------------------------------------
 

--- a/packages/components/scripts/generate-component-examples.test.ts
+++ b/packages/components/scripts/generate-component-examples.test.ts
@@ -295,12 +295,38 @@ ${extraModuleContent}</script>
   });
 
   it('decodes a \\uHHHH unicode escape in metadata', () => {
-    const source = buildSourceWithDescriptionLiteral(String.raw`'café au lait'`);
+    // The SOURCE literal must carry the real six-character escape sequence
+    // (backslash, u, 0, 0, e, 9), NOT a literal é — otherwise the extraction
+    // regex matches it via [^\\] and never exercises unescapeStringLiteral's
+    // \u branch. Build it from an explicit backslash so the on-disk bytes are
+    // unambiguous.
+    const escape = String.fromCharCode(92); // single backslash
+    const source = buildSourceWithDescriptionLiteral(`'caf${escape}u00e9 au lait'`);
     const result = extractExampleFile(buildInput(source));
 
     expect(result.kind).toBe('example');
     if (result.kind !== 'example') return;
-    expect(result.example.description).toBe('café au lait');
+    expect(result.example.description).toBe('caf' + String.fromCodePoint(0xe9) + ' au lait');
+  });
+
+  it('decodes a \\u{...} unicode code-point escape in metadata', () => {
+    const escape = String.fromCharCode(92);
+    const source = buildSourceWithDescriptionLiteral(`'caf${escape}u{e9} au lait'`);
+    const result = extractExampleFile(buildInput(source));
+
+    expect(result.kind).toBe('example');
+    if (result.kind !== 'example') return;
+    expect(result.example.description).toBe('caf' + String.fromCodePoint(0xe9) + ' au lait');
+  });
+
+  it('decodes a \\xHH hex escape in metadata', () => {
+    const escape = String.fromCharCode(92);
+    const source = buildSourceWithDescriptionLiteral(`'caf${escape}xe9 au lait'`);
+    const result = extractExampleFile(buildInput(source));
+
+    expect(result.kind).toBe('example');
+    if (result.kind !== 'example') return;
+    expect(result.example.description).toBe('caf' + String.fromCodePoint(0xe9) + ' au lait');
   });
 
   it('round-trips an escaped delimiter in title and strips the module block', () => {

--- a/packages/components/scripts/generate-component-examples.ts
+++ b/packages/components/scripts/generate-component-examples.ts
@@ -128,8 +128,21 @@ const MODULE_SCRIPT_REGEX =
 /** Matches the presence of any `<style>` block. */
 const STYLE_BLOCK_REGEX = /<style\b[^>]*>/;
 
-/** Matches all `export const <name> = '...'` statements in a block. */
-const ALL_STRING_EXPORTS_REGEX = /export\s+const\s+(\w+)\s*=\s*(['"`])([\s\S]*?)\2\s*;?/gm;
+/**
+ * Matches all `export const <name> = '...'` statements in a block.
+ *
+ * The value capture is escape-aware: `(?:\\[\s\S]|[^\\])*?` consumes any
+ * backslash-escape sequence (`\"`, `\'`, `` \` ``, `\\`, `\n`, a line
+ * continuation `\` + newline, …) as a unit, so an escaped delimiter inside the
+ * literal does NOT prematurely terminate the match. The escaped half uses
+ * `[\s\S]` rather than `.` so a backslash-newline line continuation is also
+ * consumed. A naive `([\s\S]*?)\2` stops at the first raw delimiter char and
+ * truncates literals like `"Set \"auto\" mode."` — the #420 corruption. The
+ * captured value is still the RAW (escaped) source text; callers must run it
+ * through `unescapeStringLiteral` to recover the true string value.
+ */
+const ALL_STRING_EXPORTS_REGEX =
+  /export\s+const\s+(\w+)\s*=\s*(['"`])((?:\\[\s\S]|[^\\])*?)\2\s*;?/gm;
 
 /** Matches `from 'specifier'` or `from "specifier"` in import statements. */
 const IMPORT_FROM_REGEX = /^\s*import\b[^;]*\bfrom\s+['"]([^'"]+)['"]/gm;
@@ -319,9 +332,66 @@ export function extractExampleFile(input: ExampleFileInput): ExampleFileResult {
 // ---------------------------------------------------------------------------
 
 /**
+ * Decodes the standard JavaScript string-escape sequences that can appear in a
+ * single-, double-, or backtick-delimited literal so the stored metadata value
+ * is the true string the author intended (`It's`, not `It\'s`). Handles the
+ * common single-character escapes, line continuations (`\` + a line terminator,
+ * which JS cooks away to nothing), and the `\xHH`, `\uHHHH`, and `\u{H…}`
+ * numeric forms; an unrecognized `\<char>` (including a literal escaped
+ * delimiter) yields `<char>` verbatim, matching JS semantics. Octal escapes and
+ * malformed `\x`/`\u` forms are illegal in the strict-mode module scripts this
+ * generator parses, so upstream `svelte-check`/`bun build` rejects them before
+ * generation — they are not handled here.
+ */
+function unescapeStringLiteral(raw: string): string {
+  return raw.replace(
+    // A line continuation is `\` followed by a line terminator (LF, CR, CRLF,
+    // U+2028, or U+2029). Its CRLF / single-terminator alternatives precede the
+    // catch-all `[\s\S]` branch so the terminator is consumed as part of the
+    // continuation rather than returned verbatim.
+    /\\(\r\n|[\n\r\u2028\u2029]|u\{[0-9a-fA-F]+\}|u[0-9a-fA-F]{4}|x[0-9a-fA-F]{2}|[\s\S])/g,
+    (_match, escape: string) => {
+      switch (escape) {
+        case 'n':
+          return '\n';
+        case 't':
+          return '\t';
+        case 'r':
+          return '\r';
+        case 'b':
+          return '\b';
+        case 'f':
+          return '\f';
+        case 'v':
+          return '\v';
+        case '0':
+          return '\0';
+      }
+      // Line continuation: `\` + a line terminator cooks away to nothing.
+      if (/^(?:\r\n|[\n\r\u2028\u2029])$/.test(escape)) {
+        return '';
+      }
+      if (escape[0] === 'x') {
+        return String.fromCodePoint(Number.parseInt(escape.slice(1), 16));
+      }
+      if (escape[0] === 'u') {
+        const hex = escape[1] === '{' ? escape.slice(2, -1) : escape.slice(1);
+        return String.fromCodePoint(Number.parseInt(hex, 16));
+      }
+      // Escaped delimiter (`\"`, `\'`, `` \` ``), escaped backslash (`\\`),
+      // or any other `\<char>` → the char itself.
+      return escape;
+    },
+  );
+}
+
+/**
  * Parses all `export const <name> = '<literal>'` statements from a module
  * block's content. Returns a map from export name → string value.
  * Non-string-literal exports are not included in the map.
+ *
+ * The captured value is escape-decoded so the stored metadata is the true
+ * string value, free of source-level escape sequences (#420).
  */
 function parseStringExports(moduleBlockContent: string): Map<string, string> {
   const result = new Map<string, string>();
@@ -331,7 +401,7 @@ function parseStringExports(moduleBlockContent: string): Map<string, string> {
     const name = match[1];
     const value = match[3];
     if (name !== undefined && value !== undefined) {
-      result.set(name, value);
+      result.set(name, unescapeStringLiteral(value));
     }
   }
   return result;
@@ -461,19 +531,23 @@ function buildCodeField(
   metadataExports: Map<string, string>,
 ): string {
   // Check whether the module block contains ONLY metadata exports.
-  // Strategy: remove all metadata export statements from the block content
-  // and check that only whitespace and comments remain.
+  // Strategy: remove every metadata export statement from the block content and
+  // check that only whitespace and comments remain.
+  //
+  // The string-export statements are matched STRUCTURALLY with the same
+  // escape-aware literal grammar as ALL_STRING_EXPORTS_REGEX, NOT by
+  // reconstructing the statement from the parsed value. metadataExports holds
+  // the UNESCAPED value (#420), so a value-based pattern would fail to match
+  // the raw source whenever a literal contains an escape sequence — and the
+  // unremoved statement would then make the block look non-metadata-only,
+  // leaking the `<script module>` block into the published `code` field.
   const metadataKeys = new Set(['title', 'description', 'component']);
   let remaining = moduleBlockContent;
 
   for (const key of metadataKeys) {
     if (!metadataExports.has(key)) continue;
-    // Remove the export const statement for this key.
-    const value = metadataExports.get(key)!;
-    // Escape the value for regex use.
-    const escapedValue = value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
     const removePattern = new RegExp(
-      `export\\s+const\\s+${key}\\s*=\\s*(['"\`])${escapedValue}\\1\\s*;?\\s*`,
+      `export\\s+const\\s+${key}\\s*=\\s*(['"\`])(?:\\\\[\\s\\S]|[^\\\\])*?\\1\\s*;?\\s*`,
       'g',
     );
     remaining = remaining.replace(removePattern, '');


### PR DESCRIPTION
## Summary

Fixes the component-example generator's metadata extraction so a backslash-escaped delimiter (or a line continuation) inside an example's `title`/`description` string literal no longer truncates the value or leaks the `<script module>` block into the published `code` field.

Closes #420.

## Root cause

`ALL_STRING_EXPORTS_REGEX`'s value capture was `([\s\S]*?)\2` — non-greedy and **not escape-aware**. It stopped at the first *raw* delimiter character even when that character was backslash-escaped inside the literal. So:

```ts
export const description = "Set \"auto\" mode.";
```

extracted only `Set \` (truncated at the first escaped `"`). Worse, the now-mismatched export statement was no longer recognized by `buildCodeField`'s metadata-only check, so the block was misclassified as *not* metadata-only and the entire `<script module>` block leaked into the copyable `code` field of the generated `.examples.json`.

## The fix (three coordinated parts, one shared grammar)

1. **`ALL_STRING_EXPORTS_REGEX`** value capture is now escape-aware: `(?:\\[\s\S]|[^\\])*?`. The escaped half uses `[\s\S]` rather than `.` so a backslash-newline line continuation is consumed as a unit.
2. **New `unescapeStringLiteral` helper** decodes the captured raw value to the true string (`It\'s` → `It's`), wired into `parseStringExports`. It handles the common single-character escapes, JS line continuations (`\` + LF/CR/CRLF/LS/PS → nothing), and the `\xHH`, `\uHHHH`, `\u{H…}` numeric forms. Octal and malformed numeric escapes are illegal in the strict-mode module scripts this generator parses (rejected upstream by `svelte-check`/`bun build`), so they are intentionally not handled — documented in the helper's doc comment.
3. **`buildCodeField`'s metadata-only detection** now matches each metadata statement **structurally** with the same escape-aware grammar, instead of reconstructing the pattern from the (now-unescaped) parsed value. Reconstructing from the unescaped value would fail to match the raw source whenever a literal contains an escape — re-introducing the leak.

## Tests

New `describe('extractExampleFile — escape-aware metadata literals (#420)')` block (37 generator unit tests total, all passing):
- Escaped `"` / `'` / backtick inside a matching-delimiter literal — description round-trips to the true string **and** the module block is stripped.
- Raw embedded double-quote in a single-quote literal (no-regression control).
- `\n` decode; `\uHHHH` unicode decode.
- LF **and** CRLF line continuations cook away to nothing.
- Escaped delimiter in `title` (not just `description`).
- **Non-metadata export beside an escaped literal → module block kept verbatim** — the exact metadata-only classification invariant the bug broke.

## Verification

- `bun test scripts/generate-component-examples.test.ts` — 37 pass / 0 fail.
- `bun run components:check` — **OK, zero drift** across all 332 existing examples. No published artifact changes; this only affects future examples whose metadata contains an escape sequence.
- `bun run typecheck` — 0 errors.
- Pre-commit hook green: `@lostgradient/cinder` typecheck (exit 0) + full test suite (exit 0).
- Changeset: `patch` bump for `@lostgradient/cinder`.

## Review

Committee-reviewed before opening (typescript-expert, testing-expert, simplicity-engineer) plus a prior codex-advisor adversarial pass (different model family) on the same diff. The codex pass caught a line-continuation silent-wrong-value bug, now fixed with dedicated LF + CRLF regression tests. testing-expert's must-fix (non-metadata-export-beside-escape) and three suggestions are all implemented.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build-time generator and test-only changes; no runtime API or shipped artifact drift for current examples.
> 
> **Overview**
> Fixes **#420** in the component-example generator: `title`/`description` literals with escaped delimiters or line continuations no longer truncate metadata or leak the `<script module>` block into published `code`.
> 
> **`ALL_STRING_EXPORTS_REGEX`** now uses an escape-aware value capture so `\"` inside `"..."` does not end the match early. **`unescapeStringLiteral`** decodes captures (common escapes, line continuations, `\x`/`\u`) before metadata is stored. **`buildCodeField`** strips metadata exports with the same structural grammar instead of matching on unescaped values, so metadata-only detection stays correct when escapes are present.
> 
> Adds a large **`#420`** unit-test block and a **patch** changeset for `@lostgradient/cinder`; existing committed examples are unchanged unless metadata uses escapes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit edd8e8bda1897b420189ea04075f60a311ee960a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->