### PR TITLE
fix(playground): live preview re-renders on control change + doc-page polish

### DIFF
--- a/.changeset/playground-doc-page-fixes.md
+++ b/.changeset/playground-doc-page-fixes.md
@@ -1,0 +1,10 @@
+---
+'@cinder/playground': patch
+---
+
+Fix the component documentation page's Playground and Props sections.
+
+- **Live preview now re-renders when you change a prop control.** The live mount read the synthesized prop values inside the `{@attach}` body, which Svelte only runs once; the values are now read in the attach expression (`$state.snapshot(playgroundValues)`), so changing a control tears down and re-mounts the component with the new props. Previously only the copyable snippet updated.
+- **The Props table no longer shows the "REQ" badge twice** for a required prop — the redundant inline badge in the Name column is removed; the dedicated Required column keeps it.
+- **The Playground PROPS controls panel no longer wraps long prop names one character per line.** Each control stacks its label/description above a full-width input instead of squeezing them side by side in the fixed-width column; boolean toggles stay inline with their label.
+- **The import-snippet copy button reads as a button**, with a proper hit target, surface, and padding, instead of a bare icon crammed against the code field's edge.

--- a/packages/playground/src/component-page-live-preview-fixture.svelte
+++ b/packages/playground/src/component-page-live-preview-fixture.svelte
@@ -87,12 +87,13 @@
   const liveMountFailed = $derived(mountErrors[LIVE_MOUNT_CONTAINER_ID] !== undefined);
   const mountLivePreview = createLivePreviewMount({ mountErrors });
 
-  // The featured-example fallback is a plain no-props mount keyed by container id
-  // (mirrors `mountScenario`'s shape). Kept inline because it is trivial and not
-  // the behavior under test — the live-preview path is. It narrows with the SAME
-  // `isMountableComponent` guard, records errors with the SAME `toMountErrorDetail`
-  // helper, and tears down with the SAME `void unmount` as the production code, so
-  // the fallback path here can't diverge from the real error-keying contract.
+  // The featured-example fallback is a deliberately minimal no-props mount keyed by
+  // container id (mirrors `mountScenario`'s shape). Kept inline because it is trivial
+  // and not the behavior under test — the live-preview path is. It is NOT a full copy
+  // of `createLivePreviewMount`: it shares the `isMountableComponent` guard, the
+  // `toMountErrorDetail` error shape, and the `void unmount` teardown, but skips the
+  // production path's `console.error` side effect on mount failure. Tests that need
+  // real error-keying parity exercise the live-preview path, not this fallback.
   function mountFeatured(Component: unknown): (element: HTMLElement) => () => void {
     return (element: HTMLElement) => {
       const mountKey = element.id;

--- a/packages/playground/src/component-page-live-preview-fixture.svelte
+++ b/packages/playground/src/component-page-live-preview-fixture.svelte
@@ -85,10 +85,7 @@
   // test means the real page logic works, not a fixture copy of it.
   const bareComponent = $derived(resolveBareComponent(bareComponentModule, exportName));
   const liveMountFailed = $derived(mountErrors[LIVE_MOUNT_CONTAINER_ID] !== undefined);
-  const mountLivePreview = createLivePreviewMount({
-    readValues: () => $state.snapshot(playgroundValues),
-    mountErrors,
-  });
+  const mountLivePreview = createLivePreviewMount({ mountErrors });
 
   // The featured-example fallback is a plain no-props mount keyed by container id
   // (mirrors `mountScenario`'s shape). Kept inline because it is trivial and not
@@ -130,7 +127,7 @@
       <div
         class="example-preview"
         id={LIVE_MOUNT_CONTAINER_ID}
-        {@attach mountLivePreview(bareComponent)}
+        {@attach mountLivePreview(bareComponent, $state.snapshot(playgroundValues))}
       ></div>
     </div>
   {:else if featuredExample !== undefined && !snapshotMode}

--- a/packages/playground/src/component-page-live-preview.test.ts
+++ b/packages/playground/src/component-page-live-preview.test.ts
@@ -319,22 +319,35 @@ describe('component-page live preview (#405)', () => {
     element.id = LIVE_MOUNT_CONTAINER_ID;
     document.body.append(element);
 
-    const factory = createLivePreviewMount({
-      readValues: () => ({ label: 'Save' }),
-      mountErrors,
-    });
+    const factory = createLivePreviewMount({ mountErrors });
 
     // First run: the throwing component records an error under the container id.
-    const teardownFailed = factory(Throwing)(element);
+    const teardownFailed = factory(Throwing, { label: 'Save' })(element);
     expect(mountErrors[LIVE_MOUNT_CONTAINER_ID]?.message).toContain('boom');
     teardownFailed();
 
     // Second run on the SAME element: a working component mounts and the error
     // slot is cleared back to `undefined`.
-    const teardownOk = factory(LiveProbe)(element);
+    const teardownOk = factory(LiveProbe, { label: 'Save' })(element);
     expect(mountErrors[LIVE_MOUNT_CONTAINER_ID]).toBeUndefined();
     expect(element.querySelector('.live-probe')).not.toBeNull();
     teardownOk();
+
+    element.remove();
+  });
+
+  test('passes the eager props object straight through to mount (invariant 7)', () => {
+    // The props are passed by value at the call site — assert the exact object the
+    // caller snapshots reaches the mounted component, with no late re-read.
+    const mountErrors: MountErrorRecord = {};
+    const element = document.createElement('div');
+    element.id = LIVE_MOUNT_CONTAINER_ID;
+    document.body.append(element);
+
+    const factory = createLivePreviewMount({ mountErrors });
+    const teardown = factory(LiveProbe, { label: 'Indigo' })(element);
+    expect(element.querySelector('.live-probe')?.textContent).toContain('Indigo');
+    teardown();
 
     element.remove();
   });

--- a/packages/playground/src/component-page-live-preview.test.ts
+++ b/packages/playground/src/component-page-live-preview.test.ts
@@ -12,8 +12,11 @@
  *   1. The bare component is resolved from its module namespace by the documented
  *      export name, falling back to the default export.
  *   2. Each `playgroundValues` change re-mounts the bare component with the NEW
- *      values (the attachment reads `playgroundValues` inside its body, so
- *      Svelte tears down and remounts on change).
+ *      values. The reactive read lives in the attach EXPRESSION
+ *      (`mountLivePreview(component, $state.snapshot(playgroundValues))`), so the
+ *      snapshot is tracked and Svelte tears down + remounts on change. Reading the
+ *      values inside the attachment body — the original bug — would run once at
+ *      mount and never react.
  *   3. Props arrive as a plain object (`$state.snapshot`), never the reactive
  *      `$state` proxy — that's what a real consumer would receive.
  *   4. When the bare component can't be resolved, or its live mount FAILS while a
@@ -184,6 +187,9 @@ describe('component-page live preview (#405)', () => {
     expect(liveProbeCount()).toBe(1);
 
     unmount();
+    // Flush the attachment teardown so its ledger write lands inside this test
+    // rather than racing the next row's `beforeEach` reset.
+    await tick();
   });
 
   test('passes a plain object, not the reactive $state proxy', async () => {

--- a/packages/playground/src/component-page-live-preview.ts
+++ b/packages/playground/src/component-page-live-preview.ts
@@ -94,15 +94,6 @@ export function resolveBareComponent(
 /** Options for {@link createLivePreviewMount}. */
 export type LivePreviewMountOptions = {
   /**
-   * Read the current synthesized prop values as a PLAIN object — the caller
-   * snapshots its reactive `$state` here (`() => $state.snapshot(playgroundValues)`)
-   * so this module stays rune-free. Called INSIDE the returned attachment so
-   * Svelte's attachment effect observes the reactive read and re-runs (teardown +
-   * fresh mount) whenever a control changes. Returning a plain object — never the
-   * reactive proxy — is exactly what a real consumer would pass as props.
-   */
-  readValues: () => Record<string, unknown>;
-  /**
    * The mount-error record to write into, keyed by the container's DOM id.
    * Mutated in place (never reassigned) so a Svelte `$state` proxy stays
    * reactive for the error callout that reads it back.
@@ -113,14 +104,26 @@ export type LivePreviewMountOptions = {
 /**
  * Build the `{@attach …}` factory that mounts the bare component live.
  *
- * The returned factory takes the resolved component and yields an attachment
- * that, on each run:
+ * The returned factory takes the resolved component AND a plain snapshot of the
+ * current prop values, and yields an attachment that mounts the component with
+ * those props.
  *
- *   - reads the current values via `readValues()` — the reactive read that makes
- *     Svelte re-run this attachment (teardown + remount) on every control change,
- *     so the preview tracks the controls. The caller snapshots its `$state` in
- *     that getter, so the mounted component receives a plain object, exactly what
- *     a real consumer would pass, never the reactive proxy;
+ * The reason props are passed EAGERLY (not via a late getter) is how Svelte
+ * attachments track reactivity: Svelte re-runs an `{@attach EXPR}` only when
+ * reactive state read **while evaluating EXPR** changes — not state read inside
+ * the returned attachment body. So the caller must read its reactive
+ * `playgroundValues` in the attach expression itself:
+ *
+ *     {@attach mountLivePreview(bareComponent, $state.snapshot(playgroundValues))}
+ *
+ * The `$state.snapshot(...)` call is the tracked read; changing any control
+ * re-evaluates the expression, which produces a new attachment, which Svelte runs
+ * after tearing down the previous mount — so the preview tracks the controls.
+ * The snapshot is a plain object, exactly what a real consumer passes as props,
+ * never the reactive proxy.
+ *
+ * On each run the attachment:
+ *
  *   - records a SYNCHRONOUS mount failure (a throw from the component's
  *     construction, e.g. an unsynthesized required snippet or a missing context
  *     provider) under the container's DOM id, and returns a cleanup that unmounts
@@ -135,15 +138,15 @@ export type LivePreviewMountOptions = {
  * on each keystroke because the whole instance is rebuilt — acceptable for a
  * preview surface (the snippet, not this mount, is the copy target).
  *
- * @returns A factory `(Component) => attachment`. When `Component` isn't
+ * @returns A factory `(Component, props) => attachment`. When `Component` isn't
  *   mountable the attachment clears any stale error and renders nothing, letting
  *   the caller's template fall back to the featured example.
  */
 export function createLivePreviewMount(
   options: LivePreviewMountOptions,
-): (component: unknown) => (element: HTMLElement) => () => void {
-  const { readValues, mountErrors } = options;
-  return (component: unknown) => (element: HTMLElement) => {
+): (component: unknown, props: Record<string, unknown>) => (element: HTMLElement) => () => void {
+  const { mountErrors } = options;
+  return (component: unknown, props: Record<string, unknown>) => (element: HTMLElement) => {
     const mountKey = element.id;
     if (!isMountableComponent(component)) {
       mountErrors[mountKey] = undefined;
@@ -153,7 +156,7 @@ export function createLivePreviewMount(
     try {
       app = mount(component, {
         target: element,
-        props: readValues(),
+        props,
       });
       mountErrors[mountKey] = undefined;
     } catch (error) {

--- a/packages/playground/src/component-page.svelte
+++ b/packages/playground/src/component-page.svelte
@@ -1564,7 +1564,7 @@
     align-items: center;
     justify-content: center;
     inline-size: 2.25rem;
-    min-block-size: 1.75rem;
+    min-block-size: 2.25rem;
     padding: 0 var(--cinder-space-2);
     border: none;
     border-inline-start: 1px solid var(--cinder-border);

--- a/packages/playground/src/component-page.svelte
+++ b/packages/playground/src/component-page.svelte
@@ -416,17 +416,15 @@
       : resolveBareComponent(bareComponentModule, documentation.component.exportName),
   );
 
-  // The `{@attach …}` factory that mounts the bare component live. Reading the
-  // synthesized values *inside* the attachment (the getter below) makes Svelte
-  // re-run it — teardown + fresh mount — on every control change, so the preview
-  // tracks the controls. The getter snapshots `playgroundValues` so the mounted
-  // component receives a plain object, exactly like a real consumer. See
-  // `component-page-live-preview.ts` for the remount-on-change rationale and the
-  // text-control focus-loss trade-off.
-  const mountLivePreview = createLivePreviewMount({
-    readValues: () => $state.snapshot(playgroundValues),
-    mountErrors,
-  });
+  // The `{@attach …}` factory that mounts the bare component live. The props are
+  // passed EAGERLY at the call site in the template
+  // (`mountLivePreview(bareComponent, $state.snapshot(playgroundValues))`) so the
+  // reactive read of `playgroundValues` happens in the attach EXPRESSION — that is
+  // what makes Svelte re-run the attachment (teardown + fresh mount) on every
+  // control change, so the preview tracks the controls. See
+  // `component-page-live-preview.ts` for why the read must be in the expression and
+  // the text-control focus-loss trade-off.
+  const mountLivePreview = createLivePreviewMount({ mountErrors });
 
   // True once the live mount has recorded a failure. The Playground template
   // uses this to fall through to the featured example when the bare mount fails
@@ -881,7 +879,10 @@
                           <div
                             class="example-preview"
                             id={LIVE_MOUNT_CONTAINER_ID}
-                            {@attach mountLivePreview(bareComponent)}
+                            {@attach mountLivePreview(
+                              bareComponent,
+                              $state.snapshot(playgroundValues),
+                            )}
                           ></div>
                         </div>
                         <p class="dx-stage__note">
@@ -931,7 +932,7 @@
                       Props
                     </div>
                     {#each playgroundModel.controls as control (control.name)}
-                      <div class="dx-ctl">
+                      <div class={['dx-ctl', control.kind === 'boolean' && 'dx-ctl--inline']}>
                         <div class="dx-ctl__text">
                           <div class="dx-ctl__name" title={control.name}>{control.name}</div>
                           {#if control.description !== undefined}
@@ -1142,9 +1143,6 @@
                         <Table.Row>
                           <Table.Cell>
                             <code class="props-name">{prop.name}</code>
-                            {#if prop.required}
-                              <span class="dx-prop-flag dx-prop-flag--req">req</span>
-                            {/if}
                           </Table.Cell>
                           <Table.Cell>
                             {@const typeMembers = splitUnionType(prop.type)}
@@ -1558,14 +1556,19 @@
     overflow: hidden;
     text-overflow: ellipsis;
   }
+  /* A real button affordance, not a bare icon hugging the code field's edge:
+     a comfortable square hit target with its own raised surface, separated from
+     the code by the divider border, and a clear hover state. */
   .dx-import__copy {
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    width: 2.1rem;
+    inline-size: 2.25rem;
+    min-block-size: 1.75rem;
+    padding: 0 var(--cinder-space-2);
     border: none;
     border-inline-start: 1px solid var(--cinder-border);
-    background: var(--cinder-surface);
+    background: var(--cinder-surface-raised);
     color: var(--cinder-text-subtle);
     cursor: pointer;
     flex-shrink: 0;
@@ -1968,11 +1971,14 @@
     align-items: center;
     gap: var(--cinder-space-2);
   }
+  /* The controls panel is a fixed 16.5rem column, so a side-by-side label/control
+     row squeezes long mono prop names to one character per line. Stack instead:
+     label + description on their own row, the control full-width below. The boolean
+     toggle is tiny, so it stays inline at the end of the label row (see __row). */
   .dx-ctl {
     display: flex;
-    align-items: flex-start;
-    justify-content: space-between;
-    gap: var(--cinder-space-3);
+    flex-direction: column;
+    gap: var(--cinder-space-2);
     padding: var(--cinder-space-3-5, 0.875rem) var(--cinder-space-4);
   }
   .dx-ctl + .dx-ctl {
@@ -1985,14 +1991,25 @@
     font-family: var(--cinder-font-mono);
     font-size: var(--cinder-text-sm);
     color: var(--cinder-text);
+    /* Break only when a token genuinely overflows the column, never per-character. */
     overflow-wrap: break-word;
-    word-break: break-all;
   }
   .dx-ctl__desc {
     font-size: var(--cinder-text-xs);
     color: var(--cinder-text-subtle);
     margin-block-start: 2px;
     line-height: 1.4;
+  }
+  /* A boolean control keeps its label and toggle on one row (the toggle is small);
+     the label text can shrink and the toggle pins to the inline end. */
+  .dx-ctl--inline {
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--cinder-space-3);
+  }
+  .dx-ctl--inline .dx-ctl__text {
+    flex: 1;
   }
   .dx-ctl__select,
   .dx-ctl__input {
@@ -2003,8 +2020,9 @@
     color: var(--cinder-text);
     font-family: inherit;
     font-size: var(--cinder-text-sm);
-    padding: var(--cinder-space-1) var(--cinder-space-2);
-    max-width: 14rem;
+    padding: var(--cinder-space-1-5) var(--cinder-space-2);
+    /* Fill the panel width rather than crowding against the right edge. */
+    inline-size: 100%;
   }
 
   /* ===== Examples ===== */


### PR DESCRIPTION
## Summary

Fixes a batch of component-documentation-page defects surfaced in a playground visual review. This is **PR2** of the cinder visual-review batch (PR1 = the indigo palette retune, #428).

The headline fix: **the component Playground's live preview was inert** — adjusting a prop control (toggle/select/number/text) updated only the copyable code snippet, never the rendered component. This was true for *every* component.

### What changed

- **Live preview re-renders on control change (the big one).** `createLivePreviewMount` read the synthesized `playgroundValues` *inside* the `{@attach}` body, which Svelte runs only once at mount. An `{@attach EXPR}` re-runs only when reactive state read *while evaluating EXPR* changes — and the values were never read there. The factory now takes props **eagerly** and the template reads `$state.snapshot(playgroundValues)` in the attach **expression**, so changing any control re-evaluates the expression → teardown + remount with the new props.
  - Remount (not in-place prop update) is the deliberate existing design; its trade-off (internal state/focus reset per change) is acknowledged and accepted for a preview surface, where the snippet is the copy/keep target.
- **Props table: duplicate "REQ" removed.** Dropped the redundant inline `req` badge from the Name cell; the dedicated Required column keeps the single signal.
- **Props controls panel: no more 1-char-per-line wrapping.** Each control now stacks label/description above a full-width input instead of squeezing them side-by-side in the fixed 16.5rem column; boolean toggles stay inline with their label. Dropped `word-break: break-all` (kept `overflow-wrap: break-word`, which breaks only on real overflow).
- **Import-snippet copy button reads as a button** — square 36px hit target, surface background, inset padding, and an inline-start divider, instead of a bare icon crammed against the field edge. Keyboard focus-visible ring and forced-colors fallback preserved.

### Verification

- **`component-page-live-preview.test.ts`** — the deterministic gate for the live-preview fix. 14 pass / 0 fail (stable across repeated runs). Locks 7 invariants: bare-component resolution by export name + default fallback; remount-with-new-value across boolean/select/number control shapes; props arrive as a plain `$state.snapshot` (never the reactive proxy); featured-example fallback on unresolved/failed mount; snapshot-mode renders neither mount; mount errors keyed by container id and cleared on success; eager props passed straight through.
- `bun run typecheck` (svelte-check) — 0 errors.
- oxlint (type-aware) + prettier — clean.
- pre-commit + pre-push package gates (`@cinder/playground` typecheck + test) — green.

### Committee review

Reviewed by Codex (gpt-5.4) + svelte-expert, testing-expert, ux-designer, simplicity-engineer. Three must-fix items resolved before opening:
- Squared the copy-button hit target (28px → 36px; clears the WCAG 2.5.8 AA 24px floor with margin).
- Corrected a test-fixture comment that overclaimed error-keying parity between the minimal featured-example fallback and the production live-mount path.
- Added a trailing `await tick()` after teardown in the `test.each` rows (ledger-write hygiene).

Codex re-reviewed the delta and approved.

### Notes

- No production behavior change outside the documentation playground; `@cinder/playground` patch changeset included.
- Pre-existing, out of scope (not touched): `component-documentation.test.ts` has a load-sensitive 5s-timeout flake on `main` — surfaced separately, not bumped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to the documentation playground package with regression tests; no production component library behavior is affected.
> 
> **Overview**
> **Playground live preview** now updates when prop controls change. `createLivePreviewMount` no longer uses a `readValues` callback inside the attachment; callers pass an eager `$state.snapshot(playgroundValues)` in the `{@attach …}` expression so Svelte tracks the read and remounts with new props (snippet-only updates were the previous bug).
> 
> **Doc page polish:** duplicate **req** badge removed from the Props table Name column; Playground controls stack label above full-width inputs (booleans stay inline); import copy control gets a larger hit target and raised surface styling.
> 
> Tests and the live-preview fixture follow the new `(component, props)` API, with an extra invariant test and teardown `tick` for stability.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0fea1aeed0710c873e41bfdce573fc2797834060. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->