### PR TITLE
Add playground README landing page

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,9 @@ bun install
 bun run dev
 ```
 
+The playground opens at `/` with this README as its landing page. Component examples live under
+`/c/<component-id>`; for example, `/c/accordion` opens the Accordion component page.
+
 Useful root commands:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # cinder
 
-Svelte 5 components for product interfaces.
+Components for product interfaces.
 
 The published package is `@lostgradient/cinder`: accessible primitives, domain-suite components, design-system tokens, per-component CSS, generated prop schemas, and examples that can be read by people or tooling. The current generated manifest lists 155 public component entries across action, data-display, domain, feedback, form, layout, navigation, overlay, and typography categories.
 
-Use Cinder when you want UI building blocks without adopting a framework-level router, form-state manager, data layer, or theme provider. The package is SSR-safe and targets Svelte `>=5.55.0 <6`.
+Use Cinder when you want UI building blocks without adopting a framework-level router, form-state manager, data layer, or theme provider. The package is SSR-safe.
 
 ## Install
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,9 @@ Use Cinder when you want UI building blocks without adopting a framework-level r
 bun add @lostgradient/cinder svelte lucide-svelte
 ```
 
-`svelte` and `lucide-svelte` are peer dependencies. Cinder uses Lucide for its own component chrome, but it does not provide a general icon library for your application-specific icons.
+`svelte` and `lucide-svelte` are peer dependencies. Cinder targets Svelte `>=5.55.0 <6`.
+It uses Lucide for its own component chrome, but it does not provide a general icon library for
+your application-specific icons.
 
 ## Quickstart
 

--- a/packages/playground/scripts/static-export.test.ts
+++ b/packages/playground/scripts/static-export.test.ts
@@ -1,0 +1,32 @@
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { describe, expect, test } from 'bun:test';
+
+import { runStaticExport } from './static-export.ts';
+
+describe('static export', () => {
+  test('writes the root landing shell instead of a redirect', async () => {
+    const outputDirectory = await mkdtemp(join(tmpdir(), 'cinder-static-export-'));
+    try {
+      const rendered = await runStaticExport({
+        outputDirectory,
+        sidebarComponents: ['button'],
+        allComponents: [],
+      });
+      const indexHtml = await readFile(join(outputDirectory, 'index.html'), 'utf8');
+
+      expect(indexHtml).toContain('id="shell-root"');
+      expect(indexHtml).toContain('id="cinder-initial"');
+      expect(indexHtml).toContain('readmeHtml');
+      expect(indexHtml).toContain('/shell-bundle/shell.js');
+      expect(indexHtml).toContain('/styles/shell.css');
+      expect(indexHtml).not.toContain('http-equiv="refresh"');
+      expect(rendered.has('/shell-bundle/shell.js')).toBe(true);
+      expect(rendered.has('/styles/shell.css')).toBe(true);
+    } finally {
+      await rm(outputDirectory, { recursive: true, force: true });
+    }
+  }, 90_000);
+});

--- a/packages/playground/scripts/static-export.ts
+++ b/packages/playground/scripts/static-export.ts
@@ -12,7 +12,7 @@
  *
  * What gets rendered (every route `handleRequest` answers, except the live SSE
  * `/events` stream, which has no static form):
- *   - `/` (the redirect to the first component, emitted as an index.html meta-refresh)
+ *   - `/` README-backed landing shell HTML
  *   - `/c/<name>` shell HTML, for every sidebar component
  *   - `/page/<name>` iframe HTML, for every component
  *   - `/shell-bundle/shell.js` + every hashed chunk it imports
@@ -41,8 +41,16 @@ const PLAYGROUND_ROOT = join(import.meta.dirname, '..');
 const OUTPUT_DIRECTORY = join(PLAYGROUND_ROOT, 'public');
 const ORIGIN = 'https://playground.local';
 
-/** Every path written, so we never render the same route twice. */
-const rendered = new Set<string>();
+type StaticExportContext = {
+  outputDirectory: string;
+  rendered: Set<string>;
+};
+
+export type StaticExportOptions = {
+  outputDirectory?: string;
+  sidebarComponents?: string[];
+  allComponents?: string[];
+};
 
 /**
  * Map a request pathname to the static file path under `public/`. A path with
@@ -53,14 +61,14 @@ const rendered = new Set<string>();
  * data routes (`/ping`, `/api/manifest/button`, `/example-src/x/y`) as a bare
  * file — NOT an `index.html` dir, which would mislabel JSON/text as HTML.
  */
-function outputPathFor(pathname: string, isHtml: boolean): string {
+function outputPathFor(pathname: string, isHtml: boolean, outputDirectory: string): string {
   const clean = pathname.replace(/^\/+/, '');
-  if (clean === '') return join(OUTPUT_DIRECTORY, 'index.html');
+  if (clean === '') return join(outputDirectory, 'index.html');
   const lastSegment = clean.split('/').pop() ?? '';
   const hasExtension = lastSegment.includes('.');
   // Only extensionless HTML pages get the index.html clean-URL treatment.
   const relative = !hasExtension && isHtml ? `${clean}/index.html` : clean;
-  return join(OUTPUT_DIRECTORY, relative);
+  return join(outputDirectory, relative);
 }
 
 /**
@@ -70,17 +78,18 @@ function outputPathFor(pathname: string, isHtml: boolean): string {
  * Non-2xx/3xx responses throw — a broken route must fail the build, not ship a
  * 404 page as if it were content.
  */
-async function render(pathname: string): Promise<string | null> {
+async function render(pathname: string, context: StaticExportContext): Promise<string | null> {
+  const { outputDirectory, rendered } = context;
   if (rendered.has(pathname)) return null;
   rendered.add(pathname);
 
   const response = await handleRequest(new Request(`${ORIGIN}${pathname}`));
-  // A redirect (the `/` → `/c/<first>` case) is materialized as a meta-refresh
-  // index.html so the static host has something to serve at `/`.
+  // Redirects are materialized as a meta-refresh index.html so the static host
+  // has something to serve at that path.
   if (response.status >= 300 && response.status < 400) {
     const location = response.headers.get('Location') ?? '/';
     const html = `<!DOCTYPE html><meta http-equiv="refresh" content="0; url=${location}"><link rel="canonical" href="${location}">`;
-    await writeFile(outputPathFor(pathname, true), html);
+    await writeFile(outputPathFor(pathname, true, outputDirectory), html);
     return null;
   }
   if (!response.ok) {
@@ -88,7 +97,7 @@ async function render(pathname: string): Promise<string | null> {
   }
   const isHtml = (response.headers.get('Content-Type') ?? '').includes('text/html');
   const body = await response.text();
-  await writeFile(outputPathFor(pathname, isHtml), body);
+  await writeFile(outputPathFor(pathname, isHtml, outputDirectory), body);
   return body;
 }
 
@@ -132,14 +141,14 @@ function chunkUrlsFromJs(js: string): string[] {
  * Render a JS bundle entry and recursively render every hashed chunk it
  * imports (and any chunks those import) until the graph is exhausted.
  */
-async function renderJsBundleGraph(entryPath: string): Promise<void> {
+async function renderJsBundleGraph(entryPath: string, context: StaticExportContext): Promise<void> {
   const queue = [entryPath];
   while (queue.length > 0) {
     const path = queue.shift()!;
-    const js = await render(path);
+    const js = await render(path, context);
     if (js === null) continue;
     for (const chunk of chunkUrlsFromJs(js)) {
-      if (!rendered.has(chunk)) queue.push(chunk);
+      if (!context.rendered.has(chunk)) queue.push(chunk);
     }
   }
 }
@@ -189,24 +198,29 @@ function cssImportUrlsFrom(fromUrl: string, css: string): string[] {
  * (and their imports) until the graph is exhausted — mirroring the JS chunk
  * graph so the full `@import` cascade is materialized as static files.
  */
-async function renderCssGraph(entryPath: string): Promise<void> {
+async function renderCssGraph(entryPath: string, context: StaticExportContext): Promise<void> {
   const queue = [entryPath];
   while (queue.length > 0) {
     const path = queue.shift()!;
-    const css = await render(path);
+    const css = await render(path, context);
     if (css === null) continue;
     for (const importUrl of cssImportUrlsFrom(path, css)) {
-      if (!rendered.has(importUrl)) queue.push(importUrl);
+      if (!context.rendered.has(importUrl)) queue.push(importUrl);
     }
   }
 }
 
-async function main(): Promise<void> {
+export async function runStaticExport(options: StaticExportOptions = {}): Promise<Set<string>> {
   const start = Date.now();
   process.stdout.write('[static-export] rendering playground to public/…\n');
+  const outputDirectory = options.outputDirectory ?? OUTPUT_DIRECTORY;
+  const context: StaticExportContext = {
+    outputDirectory,
+    rendered: new Set<string>(),
+  };
 
-  const sidebarComponents = await discoverSidebarComponents();
-  const allComponents = await discoverComponents();
+  const sidebarComponents = options.sidebarComponents ?? (await discoverSidebarComponents());
+  const allComponents = options.allComponents ?? (await discoverComponents());
   if (sidebarComponents.length === 0) {
     throw new Error('[static-export] no sidebar components discovered — nothing to render');
   }
@@ -217,10 +231,11 @@ async function main(): Promise<void> {
     for (const url of assetUrlsFromHtml(html)) assetUrls.add(url);
   };
 
-  // Root redirect + the shell bundle graph (shared by every shell page).
-  await render('/');
-  await renderJsBundleGraph('/shell-bundle/shell.js');
-  await render('/ping');
+  // Root landing page + the shell bundle graph (shared by every shell page).
+  const rootHtml = await render('/', context);
+  if (rootHtml !== null) collect(rootHtml);
+  await renderJsBundleGraph('/shell-bundle/shell.js', context);
+  await render('/ping', context);
   // NOTE: the full `/api/manifest` array is intentionally NOT rendered. The UI
   // only ever fetches the per-component `/api/manifest/<name>` route, and
   // writing both would collide on the static host (a file at `api/manifest` and
@@ -228,17 +243,17 @@ async function main(): Promise<void> {
 
   // Per-component: shell page, iframe page, page-bundle graph, manifest, sources.
   for (const name of allComponents) {
-    const pageHtml = await render(`/page/${name}`);
+    const pageHtml = await render(`/page/${name}`, context);
     if (pageHtml !== null) collect(pageHtml);
-    await renderJsBundleGraph(`/page-bundle/${name}.js`);
-    await render(`/api/manifest/${name}`);
-    await render(`/api/documentation/${name}`);
+    await renderJsBundleGraph(`/page-bundle/${name}.js`, context);
+    await render(`/api/manifest/${name}`, context);
+    await render(`/api/documentation/${name}`, context);
     for (const scenario of await discoverExamples(name)) {
-      await render(`/example-src/${name}/${scenario}`);
+      await render(`/example-src/${name}/${scenario}`, context);
     }
   }
   for (const name of sidebarComponents) {
-    const shellHtml = await render(`/c/${name}`);
+    const shellHtml = await render(`/c/${name}`, context);
     if (shellHtml !== null) collect(shellHtml);
   }
 
@@ -248,19 +263,22 @@ async function main(): Promise<void> {
   // those imported files are referenced by no HTML, so without this they 404
   // and the deployed site renders unstyled.
   for (const url of assetUrls) {
-    if (rendered.has(url)) continue;
-    if (url.endsWith('.css')) await renderCssGraph(url);
-    else await render(url);
+    if (context.rendered.has(url)) continue;
+    if (url.endsWith('.css')) await renderCssGraph(url, context);
+    else await render(url, context);
   }
 
   const seconds = ((Date.now() - start) / 1000).toFixed(1);
   process.stdout.write(
-    `[static-export] rendered ${rendered.size} files for ${sidebarComponents.length} components in ${seconds}s\n`,
+    `[static-export] rendered ${context.rendered.size} files for ${sidebarComponents.length} components in ${seconds}s\n`,
   );
+  return context.rendered;
 }
 
 // Fire-and-forget: surface any failure as a non-zero exit so the build fails.
-void main().catch((error: unknown) => {
-  console.error(error);
-  process.exit(1);
-});
+if (import.meta.main) {
+  void runStaticExport().catch((error: unknown) => {
+    console.error(error);
+    process.exit(1);
+  });
+}

--- a/packages/playground/src/component-page.svelte
+++ b/packages/playground/src/component-page.svelte
@@ -1340,6 +1340,7 @@
     --dx-rail: 14.5rem;
     --dx-topbar-h: 3.25rem;
     min-height: 100vh;
+    border: 1px solid var(--cinder-border);
     background: light-dark(oklch(100% 0 0), var(--cinder-bg));
   }
 

--- a/packages/playground/src/playground-server.test.ts
+++ b/packages/playground/src/playground-server.test.ts
@@ -259,6 +259,11 @@ describe('rewriteRepositoryRelativeReadmeLinks', () => {
       '<a href="https://example.com">external</a><a href="mailto:test@example.com">email</a>';
     expect(rewriteRepositoryRelativeReadmeLinks(html)).toBe(html);
   });
+
+  it('does not rewrite href text outside anchor tags', () => {
+    const html = '<code>&lt;a href="docs/tokens.md"&gt;tokens&lt;/a&gt;</code>';
+    expect(rewriteRepositoryRelativeReadmeLinks(html)).toBe(html);
+  });
 });
 
 describe('/c/:name', () => {

--- a/packages/playground/src/playground-server.test.ts
+++ b/packages/playground/src/playground-server.test.ts
@@ -34,6 +34,7 @@ import {
   PORT,
   createHttpServerOnAvailablePort,
   handleRequest,
+  rewriteRepositoryRelativeReadmeLinks,
   triggerReload,
 } from './playground-server.ts';
 import { jsonForScriptTag } from './render-shell.ts';
@@ -209,11 +210,54 @@ describe('/styles.css', () => {
 });
 
 describe('/', () => {
-  it('redirects to /c/<first-component>', async () => {
+  it('returns README-backed landing shell HTML', async () => {
     const response = await handleRequest(req('/'));
-    expect(response.status).toBe(302);
-    const location = response.headers.get('Location');
-    expect(location).toMatch(/^\/c\//);
+    expect(response.status).toBe(200);
+    expect(response.headers.get('Content-Type')).toBe('text/html');
+    const html = await response.text();
+    expect(html).toContain('<!DOCTYPE html>');
+    expect(html).toContain('id="shell-root"');
+    expect(html).toContain('id="cinder-initial"');
+    expect(html).toContain('/shell-bundle/shell.js');
+    expect(html).toContain('Svelte 5 components for product interfaces');
+    expect(html).toContain('readmeHtml');
+    expect(html).not.toContain('http-equiv="refresh"');
+  });
+
+  it('embeds parseable rendered README HTML in the cinder-initial data island', async () => {
+    const response = await handleRequest(req('/'));
+    const html = await response.text();
+    const match = html.match(
+      /<script type="application\/json" id="cinder-initial">([^<]+)<\/script>/,
+    );
+    expect(match).not.toBeNull();
+    const payload = JSON.parse(match![1]!) as { component: string; readmeHtml: string };
+    expect(payload.component).toBe('');
+    expect(payload.readmeHtml).toContain('<h1>cinder</h1>');
+    expect(payload.readmeHtml).toContain('<h2>Install</h2>');
+    expect(payload.readmeHtml).not.toContain('href="./docs/');
+    expect(payload.readmeHtml).not.toContain('href="docs/');
+    expect(payload.readmeHtml).toContain(
+      'href="https://github.com/stevekinney/cinder/blob/main/docs/tokens.md"',
+    );
+  });
+});
+
+describe('rewriteRepositoryRelativeReadmeLinks', () => {
+  it('rewrites repository-relative README links to GitHub source URLs', () => {
+    const html =
+      '<a href="./docs/tokens.md">tokens</a><a href="docs/recipes/README.md">recipes</a>';
+    expect(rewriteRepositoryRelativeReadmeLinks(html)).toBe(
+      '<a href="https://github.com/stevekinney/cinder/blob/main/docs/tokens.md">tokens</a>' +
+        '<a href="https://github.com/stevekinney/cinder/blob/main/docs/recipes/README.md">recipes</a>',
+    );
+  });
+
+  it('leaves anchors, absolute paths, and protocol URLs untouched', () => {
+    const html =
+      '<a href="#install">install</a><a href="/c/button">button</a>' +
+      '<a href="https://example.com">external</a><a href="mailto:test@example.com">email</a>';
+    expect(rewriteRepositoryRelativeReadmeLinks(html)).toBe(html);
   });
 });
 

--- a/packages/playground/src/playground-server.test.ts
+++ b/packages/playground/src/playground-server.test.ts
@@ -219,7 +219,7 @@ describe('/', () => {
     expect(html).toContain('id="shell-root"');
     expect(html).toContain('id="cinder-initial"');
     expect(html).toContain('/shell-bundle/shell.js');
-    expect(html).toContain('Svelte 5 components for product interfaces');
+    expect(html).toContain('Components for product interfaces.');
     expect(html).toContain('readmeHtml');
     expect(html).not.toContain('http-equiv="refresh"');
   });

--- a/packages/playground/src/playground-server.ts
+++ b/packages/playground/src/playground-server.ts
@@ -1427,7 +1427,9 @@ async function renderLandingReadmeHtml(): Promise<string> {
   const markdown = await Bun.file(join(PLAYGROUND_ROOT, '..', '..', 'README.md')).text();
   const rendered = renderMarkdown(markdown);
   if (rendered.hadUnsafeContent) {
-    throw new Error('Root README rendering stripped unsafe content');
+    throw new Error(
+      'Root README rendering stripped unsafe content. Update README.md to remove raw HTML, unsafe URLs, or other sanitizer-blocked content.',
+    );
   }
   return rewriteRepositoryRelativeReadmeLinks(rendered.html);
 }

--- a/packages/playground/src/playground-server.ts
+++ b/packages/playground/src/playground-server.ts
@@ -2,7 +2,7 @@
  * Cinder component playground dev server.
  *
  * Runs at http://localhost:5555 by default, or the next available port. Routes:
- *   GET /              → 302 redirect to /c/<first-component>
+ *   GET /              → shell HTML with README landing content
  *   GET /c/:name       → shell HTML (sidebar + iframe pointing at /page/:name)
  *   GET /page/:name    → component page HTML (the iframe target — lists examples)
  *   GET /page-bundle/:name.js → page-bundle entry OR a hashed code-split chunk.
@@ -28,6 +28,7 @@ import { randomUUID } from 'node:crypto';
 import { rmSync, watch, type FSWatcher } from 'node:fs';
 import { dirname, isAbsolute, join, relative as relativePath, sep } from 'node:path';
 
+import { initializeHighlighter, renderMarkdown } from '@cinder/markdown/rendering';
 import type { BuildArtifact } from 'bun';
 import {
   componentSourcePath,
@@ -85,6 +86,7 @@ const MAX_PORT_SCAN_ATTEMPTS = 100;
 // import.meta.dirname is packages/playground/src/
 const PLAYGROUND_ROOT = dirname(import.meta.dirname); // packages/playground/
 const COMPONENTS_ROOT = join(PLAYGROUND_ROOT, '..', 'components'); // packages/components/
+const REPOSITORY_README_LINK_BASE = 'https://github.com/stevekinney/cinder/blob/main/';
 
 /**
  * Page-bundle entries: keyed by component name → entry artifact path
@@ -1396,6 +1398,36 @@ function badRequest(message: string): Response {
   return new Response(message, { status: 400, headers: { 'Content-Type': 'text/plain' } });
 }
 
+function isRepositoryRelativeHref(href: string): boolean {
+  return (
+    href !== '' &&
+    !href.startsWith('#') &&
+    !href.startsWith('/') &&
+    !/^[a-z][a-z0-9+.-]*:/i.test(href)
+  );
+}
+
+function repositoryReadmeHref(href: string): string {
+  const normalized = href.replace(/^\.\//, '');
+  return `${REPOSITORY_README_LINK_BASE}${normalized}`;
+}
+
+export function rewriteRepositoryRelativeReadmeLinks(html: string): string {
+  return html.replace(/\shref="([^"]+)"/g, (match, href: string) =>
+    isRepositoryRelativeHref(href) ? ` href="${repositoryReadmeHref(href)}"` : match,
+  );
+}
+
+async function renderLandingReadmeHtml(): Promise<string> {
+  await initializeHighlighter();
+  const markdown = await Bun.file(join(PLAYGROUND_ROOT, '..', '..', 'README.md')).text();
+  const rendered = renderMarkdown(markdown);
+  if (rendered.hadUnsafeContent) {
+    throw new Error('Root README rendering stripped unsafe content');
+  }
+  return rewriteRepositoryRelativeReadmeLinks(rendered.html);
+}
+
 /**
  * Build the `/example-src/:name/:scenario` response: strip the doc-page
  * mount-isolation harness so the reader copies clean consumer usage, not the
@@ -1756,18 +1788,12 @@ export async function handleRequest(request: Request): Promise<Response> {
     return new Response(html, { headers: { 'Content-Type': 'text/html' } });
   }
 
-  // GET / → redirect to first component
+  // GET / → README-backed landing shell
   if (pathname === '/') {
     const sidebarComponents = await discoverSidebarComponents();
-    if (sidebarComponents.length === 0) {
-      const html = renderShell(null, []);
-      return new Response(html, { headers: { 'Content-Type': 'text/html' } });
-    }
-    const first = sidebarComponents[0];
-    return new Response(null, {
-      status: 302,
-      headers: { Location: `/c/${first}` },
-    });
+    const readmeHtml = await renderLandingReadmeHtml();
+    const html = renderShell(null, sidebarComponents, { readmeHtml });
+    return new Response(html, { headers: { 'Content-Type': 'text/html' } });
   }
 
   return notFound();

--- a/packages/playground/src/playground-server.ts
+++ b/packages/playground/src/playground-server.ts
@@ -1413,8 +1413,12 @@ function repositoryReadmeHref(href: string): string {
 }
 
 export function rewriteRepositoryRelativeReadmeLinks(html: string): string {
-  return html.replace(/\shref="([^"]+)"/g, (match, href: string) =>
-    isRepositoryRelativeHref(href) ? ` href="${repositoryReadmeHref(href)}"` : match,
+  return html.replace(
+    /<a\b([^>]*?)\shref="([^"]+)"([^>]*)>/gi,
+    (match: string, before: string, href: string, after: string) =>
+      isRepositoryRelativeHref(href)
+        ? `<a${before} href="${repositoryReadmeHref(href)}"${after}>`
+        : match,
   );
 }
 

--- a/packages/playground/src/render-shell.ts
+++ b/packages/playground/src/render-shell.ts
@@ -123,6 +123,11 @@ export type RenderShellOptions = {
    * string. Any trailing slashes are stripped before composing URLs.
    */
   baseUrl?: string;
+  /**
+   * Sanitized HTML rendered from the repository README. Embedded only on the
+   * root shell route, where the Svelte shell renders it as landing-page prose.
+   */
+  readmeHtml?: string;
 };
 
 /**
@@ -185,6 +190,7 @@ export function renderShell(
   const initialData = {
     component: activeComponent ?? '',
     components,
+    readmeHtml: options.readmeHtml ?? '',
   };
 
   return `<!DOCTYPE html>

--- a/packages/playground/src/shell-app/announcer-popstate-fixture.svelte
+++ b/packages/playground/src/shell-app/announcer-popstate-fixture.svelte
@@ -23,7 +23,11 @@
 
 <script lang="ts">
   import AnnouncerRegion from './announcer.svelte';
-  import { announceNavigation, setAnnouncer } from './announcer.svelte.ts';
+  import {
+    announceLandingNavigation,
+    announceNavigation,
+    setAnnouncer,
+  } from './announcer.svelte.ts';
   import { parseComponentFromPath } from './routing.ts';
 
   type Props = {
@@ -40,15 +44,21 @@
   let mainEl = $state<HTMLElement | null>(null);
 
   /**
-   * Replicates `shell.svelte`'s `handlePopState` exactly: guard on a resolved
-   * component, sync the toolbar from the URL first, then apply the navigation
-   * side effects (title + announcement + focus).
+   * Replicates `shell.svelte`'s `handlePopState` exactly: update the store for
+   * component routes and the root route, sync the toolbar from the URL first,
+   * then apply the navigation side effects (title + announcement + focus).
    */
   export async function popState(): Promise<void> {
     const parsed = parseComponentFromPath(window.location.pathname);
-    if (parsed !== null) store.currentComponent = parsed;
+    const isRootPath = window.location.pathname === '/';
+    if (parsed !== null) {
+      store.currentComponent = parsed;
+    } else if (isRootPath) {
+      store.currentComponent = '';
+    }
     store.syncFromUrl();
     if (parsed !== null) await announceNavigation(announcer, parsed, () => mainEl);
+    else if (isRootPath) await announceLandingNavigation(announcer, () => mainEl);
   }
 
   /** Imperative handle to the focus target. */

--- a/packages/playground/src/shell-app/announcer.svelte.ts
+++ b/packages/playground/src/shell-app/announcer.svelte.ts
@@ -97,6 +97,18 @@ export async function announceNavigation(
   getMain()?.focus();
 }
 
+export async function announceLandingNavigation(
+  announcer: Announcer,
+  getMain: () => HTMLElement | null,
+): Promise<void> {
+  if (typeof document !== 'undefined') {
+    document.title = 'cinder playground — Svelte 5 component library';
+  }
+  announcer.announce('Viewing cinder playground');
+  await tick();
+  getMain()?.focus();
+}
+
 /** Install the singleton announcer on the current component tree. */
 export function setAnnouncer(announcer: Announcer): void {
   setContext(ANNOUNCER_KEY, announcer);

--- a/packages/playground/src/shell-app/announcer.test.ts
+++ b/packages/playground/src/shell-app/announcer.test.ts
@@ -230,4 +230,24 @@ describe('popstate navigation (browser back/forward)', () => {
     const region = container.querySelector('[aria-live="polite"]');
     expect(region?.textContent).toBe('');
   });
+
+  test('applies title + announcement + focus when returning to the root landing page', async () => {
+    happyWindow.happyDOM.setURL('http://localhost/');
+    const announcer = new Announcer();
+    const store = makePopStateStore();
+    store.currentComponent = 'button';
+    const { container, component } = render(PopStateFixture, { announcer, store });
+    await tick();
+
+    await component['popState']();
+
+    expect(store.currentComponent).toBe('');
+    expect(store.syncFromUrlCalls).toBe(1);
+    expect(document.title).toBe('cinder playground — Svelte 5 component library');
+    expect(document.activeElement).toBe(component['getMain']());
+
+    await advance(70);
+    const region = container.querySelector('[aria-live="polite"]');
+    expect(region?.textContent).toBe('Viewing cinder playground');
+  });
 });

--- a/packages/playground/src/shell-app/landing-page.svelte
+++ b/packages/playground/src/shell-app/landing-page.svelte
@@ -1,0 +1,181 @@
+<script lang="ts">
+  import { Button } from '../../../components/src/index.ts';
+
+  type Props = {
+    readmeHtml: string;
+    firstComponent: string;
+    onBrowseComponent: (componentName: string) => void | Promise<void>;
+  };
+
+  let { readmeHtml, firstComponent, onBrowseComponent }: Props = $props();
+
+  function isPlainLeftClick(event: MouseEvent): boolean {
+    if (event.button !== 0) return false;
+    return !(event.metaKey || event.ctrlKey || event.shiftKey || event.altKey);
+  }
+
+  function handleBrowseClick(event: MouseEvent): void {
+    if (firstComponent === '' || !isPlainLeftClick(event)) return;
+    event.preventDefault();
+    void onBrowseComponent(firstComponent);
+  }
+</script>
+
+<section class="landing-page" aria-labelledby="landing-title">
+  <div class="landing-page__hero">
+    <p class="landing-page__eyebrow">Cinder Playground</p>
+    <h1 id="landing-title">Svelte 5 components for product interfaces</h1>
+    <p>
+      Browse runnable examples, inspect component contracts, and use the README as the starting
+      point for installing and shipping Cinder.
+    </p>
+    {#if firstComponent !== ''}
+      <Button
+        href="/c/{firstComponent}"
+        variant="primary"
+        label="Browse components"
+        onclick={handleBrowseClick}
+      />
+    {/if}
+  </div>
+
+  <article class="landing-page__readme" aria-label="Cinder README">
+    {@html readmeHtml}
+  </article>
+</section>
+
+<style>
+  .landing-page {
+    width: 100%;
+    min-height: 100%;
+    overflow-y: auto;
+    background: var(--cinder-bg);
+  }
+
+  .landing-page__hero,
+  .landing-page__readme {
+    width: min(100% - 2rem, 920px);
+    margin-inline: auto;
+  }
+
+  .landing-page__hero {
+    display: grid;
+    gap: var(--cinder-space-4);
+    padding-block: clamp(var(--cinder-space-8), 8vw, var(--cinder-space-16)) var(--cinder-space-8);
+  }
+
+  .landing-page__eyebrow {
+    color: var(--cinder-text-muted);
+    font-size: var(--cinder-text-sm);
+    font-weight: var(--cinder-font-weight-medium);
+    text-transform: uppercase;
+  }
+
+  .landing-page__hero h1 {
+    max-width: 14ch;
+    color: var(--cinder-text);
+    font-size: clamp(2.25rem, 6vw, 4.75rem);
+    line-height: 0.95;
+  }
+
+  .landing-page__hero p:not(.landing-page__eyebrow) {
+    max-width: 42rem;
+    color: var(--cinder-text-muted);
+    font-size: var(--cinder-text-lg);
+    line-height: var(--cinder-leading-relaxed);
+  }
+
+  .landing-page__readme {
+    padding-block: 0 var(--cinder-space-12);
+    color: var(--cinder-text);
+  }
+
+  .landing-page__readme :global(h1) {
+    display: none;
+  }
+
+  .landing-page__readme :global(h2) {
+    margin-block: var(--cinder-space-8) var(--cinder-space-3);
+    padding-block-start: var(--cinder-space-6);
+    border-top: 1px solid var(--cinder-border);
+    color: var(--cinder-text);
+    font-size: var(--cinder-text-2xl);
+    line-height: var(--cinder-leading-tight);
+  }
+
+  .landing-page__readme :global(h3) {
+    margin-block: var(--cinder-space-6) var(--cinder-space-2);
+    color: var(--cinder-text);
+    font-size: var(--cinder-text-xl);
+  }
+
+  .landing-page__readme :global(p),
+  .landing-page__readme :global(li) {
+    color: var(--cinder-text-muted);
+    line-height: var(--cinder-leading-relaxed);
+  }
+
+  .landing-page__readme :global(p),
+  .landing-page__readme :global(ul),
+  .landing-page__readme :global(ol),
+  .landing-page__readme :global(pre),
+  .landing-page__readme :global(table) {
+    margin-block: var(--cinder-space-4);
+  }
+
+  .landing-page__readme :global(ul),
+  .landing-page__readme :global(ol) {
+    padding-inline-start: var(--cinder-space-6);
+  }
+
+  .landing-page__readme :global(a) {
+    color: var(--cinder-accent-text);
+    text-underline-offset: 0.2em;
+  }
+
+  .landing-page__readme :global(code) {
+    border-radius: var(--cinder-radius-sm);
+    background: var(--cinder-surface-inset);
+    color: var(--cinder-text);
+    font-size: 0.92em;
+  }
+
+  .landing-page__readme :global(:not(pre) > code) {
+    padding: 0.1rem 0.3rem;
+  }
+
+  .landing-page__readme :global(pre) {
+    overflow-x: auto;
+    border: 1px solid var(--cinder-border);
+    border-radius: var(--cinder-radius-md);
+    background: var(--cinder-surface);
+    padding: var(--cinder-space-4);
+  }
+
+  .landing-page__readme :global(table) {
+    width: 100%;
+    border-collapse: collapse;
+    display: block;
+    overflow-x: auto;
+  }
+
+  .landing-page__readme :global(th),
+  .landing-page__readme :global(td) {
+    border-bottom: 1px solid var(--cinder-border);
+    padding: var(--cinder-space-2) var(--cinder-space-3);
+    text-align: start;
+    white-space: nowrap;
+  }
+
+  .landing-page__readme :global(th) {
+    color: var(--cinder-text);
+    font-weight: var(--cinder-font-weight-semibold);
+  }
+
+  @media (max-width: 720px) {
+    .landing-page__hero,
+    .landing-page__readme {
+      width: min(100% - 1rem, 920px);
+    }
+  }
+</style>

--- a/packages/playground/src/shell-app/landing-page.svelte
+++ b/packages/playground/src/shell-app/landing-page.svelte
@@ -31,7 +31,7 @@
     </p>
     {#if firstComponent !== ''}
       <Button
-        href="/c/{firstComponent}"
+        href={`/c/${firstComponent}`}
         variant="primary"
         label="Browse components"
         onclick={handleBrowseClick}

--- a/packages/playground/src/shell-app/landing-page.svelte
+++ b/packages/playground/src/shell-app/landing-page.svelte
@@ -23,19 +23,21 @@
 
 <section class="landing-page" aria-labelledby="landing-title">
   <div class="landing-page__hero">
-    <p class="landing-page__eyebrow">Cinder Playground</p>
-    <h1 id="landing-title">Svelte 5 components for product interfaces</h1>
+    <p class="landing-page__eyebrow">Cinder component library</p>
+    <h1 id="landing-title">cinder</h1>
     <p>
-      Browse runnable examples, inspect component contracts, and use the README as the starting
-      point for installing and shipping Cinder.
+      Components for product interfaces. Browse runnable examples, inspect component contracts, and
+      use the README as the starting point for installing and shipping Cinder.
     </p>
     {#if firstComponent !== ''}
-      <Button
-        href={`/c/${firstComponent}`}
-        variant="primary"
-        label="Browse components"
-        onclick={handleBrowseClick}
-      />
+      <div class="landing-page__actions">
+        <Button
+          href={`/c/${firstComponent}`}
+          variant="primary"
+          label="Browse components"
+          onclick={handleBrowseClick}
+        />
+      </div>
     {/if}
   </div>
 
@@ -54,7 +56,7 @@
 
   .landing-page__hero,
   .landing-page__readme {
-    width: min(100% - 2rem, 920px);
+    width: min(100% - 2rem, var(--cinder-content-width));
     margin-inline: auto;
   }
 
@@ -67,14 +69,14 @@
   .landing-page__eyebrow {
     color: var(--cinder-text-muted);
     font-size: var(--cinder-text-sm);
-    font-weight: var(--cinder-font-weight-medium);
+    font-weight: var(--cinder-font-medium);
     text-transform: uppercase;
   }
 
   .landing-page__hero h1 {
-    max-width: 14ch;
     color: var(--cinder-text);
-    font-size: clamp(2.25rem, 6vw, 4.75rem);
+    font-size: 8rem;
+    letter-spacing: 0;
     line-height: 0.95;
   }
 
@@ -85,7 +87,34 @@
     line-height: var(--cinder-leading-relaxed);
   }
 
+  .landing-page__actions {
+    display: flex;
+    align-items: center;
+  }
+
+  .landing-page__actions :global(.cinder-button) {
+    width: max-content;
+  }
+
   .landing-page__readme {
+    --surface-inset: var(--cinder-surface-inset);
+    --text: var(--cinder-text);
+    --syntax-comment: var(--cinder-text-subtle);
+    --syntax-string: light-dark(oklch(38% 0.12 150), oklch(82% 0.12 150));
+    --syntax-keyword: light-dark(oklch(48% 0.19 285), oklch(76% 0.14 285));
+    --syntax-function: light-dark(oklch(42% 0.13 250), oklch(78% 0.11 250));
+    --syntax-variable: light-dark(oklch(36% 0.07 245), oklch(88% 0.04 245));
+    --syntax-type: light-dark(oklch(42% 0.13 210), oklch(78% 0.12 210));
+    --syntax-number: light-dark(oklch(45% 0.16 45), oklch(82% 0.12 60));
+    --syntax-operator: var(--cinder-text-muted);
+    --syntax-constant: light-dark(oklch(45% 0.17 25), oklch(80% 0.13 30));
+    --syntax-property: light-dark(oklch(40% 0.13 230), oklch(78% 0.11 230));
+    --syntax-tag: light-dark(oklch(45% 0.18 330), oklch(78% 0.14 330));
+    --syntax-attribute: light-dark(oklch(43% 0.14 260), oklch(80% 0.11 260));
+    --syntax-regex: light-dark(oklch(43% 0.15 120), oklch(80% 0.12 120));
+    --syntax-inserted: light-dark(oklch(42% 0.14 145), oklch(78% 0.13 145));
+    --syntax-deleted: light-dark(oklch(47% 0.18 25), oklch(78% 0.14 25));
+
     padding-block: 0 var(--cinder-space-12);
     color: var(--cinder-text);
   }
@@ -148,15 +177,19 @@
     overflow-x: auto;
     border: 1px solid var(--cinder-border);
     border-radius: var(--cinder-radius-md);
-    background: var(--cinder-surface);
+    background: var(--cinder-surface-inset);
     padding: var(--cinder-space-4);
+  }
+
+  .landing-page__readme :global(pre code) {
+    background: transparent;
+    color: inherit;
   }
 
   .landing-page__readme :global(table) {
     width: 100%;
     border-collapse: collapse;
-    display: block;
-    overflow-x: auto;
+    display: table;
   }
 
   .landing-page__readme :global(th),
@@ -164,18 +197,33 @@
     border-bottom: 1px solid var(--cinder-border);
     padding: var(--cinder-space-2) var(--cinder-space-3);
     text-align: start;
+    vertical-align: top;
+  }
+
+  .landing-page__readme :global(th:first-child),
+  .landing-page__readme :global(td:first-child) {
     white-space: nowrap;
   }
 
   .landing-page__readme :global(th) {
     color: var(--cinder-text);
-    font-weight: var(--cinder-font-weight-semibold);
+    font-weight: var(--cinder-font-semibold);
+  }
+
+  @media (min-width: 1200px) {
+    .landing-page__hero h1 {
+      font-size: 12rem;
+    }
   }
 
   @media (max-width: 720px) {
     .landing-page__hero,
     .landing-page__readme {
-      width: min(100% - 1rem, 920px);
+      width: min(100% - 1rem, var(--cinder-content-width));
+    }
+
+    .landing-page__hero h1 {
+      font-size: 4.5rem;
     }
   }
 </style>

--- a/packages/playground/src/shell-app/preview-frame.svelte
+++ b/packages/playground/src/shell-app/preview-frame.svelte
@@ -208,7 +208,6 @@
     height: 100%;
     display: flex;
     flex-direction: column;
-    border: 1px solid var(--cinder-border);
     /* Positioning context for the absolutely-placed loading overlay. */
     position: relative;
   }

--- a/packages/playground/src/shell-app/preview-frame.svelte
+++ b/packages/playground/src/shell-app/preview-frame.svelte
@@ -208,6 +208,7 @@
     height: 100%;
     display: flex;
     flex-direction: column;
+    border: 1px solid var(--cinder-border);
     /* Positioning context for the absolutely-placed loading overlay. */
     position: relative;
   }

--- a/packages/playground/src/shell-app/shell-entry.ts
+++ b/packages/playground/src/shell-app/shell-entry.ts
@@ -14,7 +14,11 @@ import { mount } from 'svelte';
 
 import Shell from './shell.svelte';
 
-type InitialData = { component: string; components: string[] };
+type InitialData = { component: string; components: string[]; readmeHtml: string };
+
+function getOwnProperty(value: object, key: string): unknown {
+  return Object.getOwnPropertyDescriptor(value, key)?.value;
+}
 
 /**
  * Validate that the parsed JSON payload matches the expected `InitialData`
@@ -25,11 +29,12 @@ type InitialData = { component: string; components: string[] };
  */
 function isInitialData(value: unknown): value is InitialData {
   if (typeof value !== 'object' || value === null) return false;
-  const record = value as Record<string, unknown>;
-  const component = record['component'];
-  const components = record['components'];
+  const component = getOwnProperty(value, 'component');
+  const components = getOwnProperty(value, 'components');
+  const readmeHtml = getOwnProperty(value, 'readmeHtml');
   if (typeof component !== 'string') return false;
   if (!Array.isArray(components)) return false;
+  if (typeof readmeHtml !== 'string') return false;
   const componentNamePattern = /^[a-z0-9][a-z0-9-]*$/;
   // The active component can legitimately be absent from `components`: the
   // server lists only sidebar-eligible components there (those with at least
@@ -46,14 +51,14 @@ function isInitialData(value: unknown): value is InitialData {
 
 function readInitialData(): InitialData {
   const node = document.getElementById('cinder-initial');
-  if (!node) return { component: '', components: [] };
+  if (!node) return { component: '', components: [], readmeHtml: '' };
   try {
     const parsed: unknown = JSON.parse(node.textContent ?? '{}');
     if (isInitialData(parsed)) return parsed;
   } catch (error) {
     console.error('[cinder playground] failed to parse #cinder-initial:', error);
   }
-  return { component: '', components: [] };
+  return { component: '', components: [], readmeHtml: '' };
 }
 
 const initial = readInitialData();
@@ -68,5 +73,6 @@ mount(Shell, {
   props: {
     initialComponent: initial.component,
     components: initial.components,
+    readmeHtml: initial.readmeHtml,
   },
 });

--- a/packages/playground/src/shell-app/shell-entry.ts
+++ b/packages/playground/src/shell-app/shell-entry.ts
@@ -12,49 +12,16 @@
 
 import { mount } from 'svelte';
 
+import { parseInitialData, type InitialData } from './shell-initial-data.ts';
 import Shell from './shell.svelte';
-
-type InitialData = { component: string; components: string[]; readmeHtml: string };
-
-function getOwnProperty(value: object, key: string): unknown {
-  return Object.getOwnPropertyDescriptor(value, key)?.value;
-}
-
-/**
- * Validate that the parsed JSON payload matches the expected `InitialData`
- * shape and that every component name in the list satisfies the kebab-case
- * invariant the server enforces. This is defense-in-depth: render-shell
- * already validates server-side, but treating the data island as untrusted
- * input keeps the boundary explicit.
- */
-function isInitialData(value: unknown): value is InitialData {
-  if (typeof value !== 'object' || value === null) return false;
-  const component = getOwnProperty(value, 'component');
-  const components = getOwnProperty(value, 'components');
-  const readmeHtml = getOwnProperty(value, 'readmeHtml');
-  if (typeof component !== 'string') return false;
-  if (!Array.isArray(components)) return false;
-  if (typeof readmeHtml !== 'string') return false;
-  const componentNamePattern = /^[a-z0-9][a-z0-9-]*$/;
-  // The active component can legitimately be absent from `components`: the
-  // server lists only sidebar-eligible components there (those with at least
-  // one .example.svelte), but `/c/<name>` accepts any discovered component.
-  // So we validate the component name's shape but NOT membership in the
-  // sidebar list — that would wipe the sidebar for a perfectly valid URL
-  // like /c/radio.
-  if (component !== '' && !componentNamePattern.test(component)) return false;
-  for (const item of components) {
-    if (typeof item !== 'string' || !componentNamePattern.test(item)) return false;
-  }
-  return true;
-}
 
 function readInitialData(): InitialData {
   const node = document.getElementById('cinder-initial');
   if (!node) return { component: '', components: [], readmeHtml: '' };
   try {
     const parsed: unknown = JSON.parse(node.textContent ?? '{}');
-    if (isInitialData(parsed)) return parsed;
+    const initialData = parseInitialData(parsed);
+    if (initialData !== null) return initialData;
   } catch (error) {
     console.error('[cinder playground] failed to parse #cinder-initial:', error);
   }

--- a/packages/playground/src/shell-app/shell-initial-data.test.ts
+++ b/packages/playground/src/shell-app/shell-initial-data.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, test } from 'bun:test';
+
+import { parseInitialData } from './shell-initial-data.ts';
+
+describe('parseInitialData', () => {
+  test('normalizes stale component-route payloads that predate readmeHtml', () => {
+    expect(parseInitialData({ component: 'button', components: ['button', 'card'] })).toEqual({
+      component: 'button',
+      components: ['button', 'card'],
+      readmeHtml: '',
+    });
+  });
+
+  test('keeps README HTML when present', () => {
+    expect(
+      parseInitialData({ component: '', components: ['button'], readmeHtml: '<h1>cinder</h1>' }),
+    ).toEqual({
+      component: '',
+      components: ['button'],
+      readmeHtml: '<h1>cinder</h1>',
+    });
+  });
+
+  test('rejects malformed component names', () => {
+    expect(parseInitialData({ component: 'Button', components: ['button'] })).toBeNull();
+    expect(parseInitialData({ component: 'button', components: ['Bad'] })).toBeNull();
+  });
+});

--- a/packages/playground/src/shell-app/shell-initial-data.ts
+++ b/packages/playground/src/shell-app/shell-initial-data.ts
@@ -1,0 +1,36 @@
+export type InitialData = { component: string; components: string[]; readmeHtml: string };
+
+function getOwnProperty(value: object, key: string): unknown {
+  return Object.getOwnPropertyDescriptor(value, key)?.value;
+}
+
+/**
+ * Validate the shell data island and normalize older cached payloads that
+ * predate the README landing page. Component route payloads without
+ * `readmeHtml` are still safe because component pages never render it.
+ */
+export function parseInitialData(value: unknown): InitialData | null {
+  if (typeof value !== 'object' || value === null) return null;
+  const component = getOwnProperty(value, 'component');
+  const components = getOwnProperty(value, 'components');
+  const readmeHtml = getOwnProperty(value, 'readmeHtml');
+  if (typeof component !== 'string') return null;
+  if (!Array.isArray(components)) return null;
+  if (readmeHtml !== undefined && typeof readmeHtml !== 'string') return null;
+  const componentNamePattern = /^[a-z0-9][a-z0-9-]*$/;
+  // The active component can legitimately be absent from `components`: the
+  // server lists only sidebar-eligible components there (those with at least
+  // one .example.svelte), but `/c/<name>` accepts any discovered component.
+  // So we validate the component name's shape but NOT membership in the
+  // sidebar list — that would wipe the sidebar for a perfectly valid URL
+  // like /c/radio.
+  if (component !== '' && !componentNamePattern.test(component)) return null;
+  for (const item of components) {
+    if (typeof item !== 'string' || !componentNamePattern.test(item)) return null;
+  }
+  return {
+    component,
+    components,
+    readmeHtml: readmeHtml ?? '',
+  };
+}

--- a/packages/playground/src/shell-app/shell.svelte
+++ b/packages/playground/src/shell-app/shell.svelte
@@ -4,6 +4,7 @@
 
   import Announcer from './announcer.svelte';
   import {
+    announceLandingNavigation,
     announceNavigation,
     Announcer as AnnouncerStore,
     setAnnouncer,
@@ -18,15 +19,17 @@
   } from './preview-store.svelte.ts';
   import { buildShellHref, parseComponentFromPath, readToolbarStateFromSearch } from './routing.ts';
   import ColorTokenPanel from './color-token-panel.svelte';
+  import LandingPage from './landing-page.svelte';
   import Sidebar, { type SidebarHandle } from './sidebar.svelte';
   import TopBar from './top-bar.svelte';
 
   type Props = {
     initialComponent: string;
     components: string[];
+    readmeHtml: string;
   };
 
-  let { initialComponent, components }: Props = $props();
+  let { initialComponent, components, readmeHtml }: Props = $props();
 
   // Bound to the Sidebar instance so the `/` shortcut can focus its filter.
   let sidebar = $state<SidebarHandle | null>(null);
@@ -161,7 +164,12 @@
 
   async function handlePopState(): Promise<void> {
     const parsed = parseComponentFromPath(window.location.pathname);
-    if (parsed !== null) store.currentComponent = parsed;
+    const isRootPath = window.location.pathname === '/';
+    if (parsed !== null) {
+      store.currentComponent = parsed;
+    } else if (isRootPath) {
+      store.currentComponent = '';
+    }
     // Re-sync the toolbar (theme/viewport/focus mode) from the URL *before*
     // announcing so the toolbar reflects the restored state by the time focus
     // lands on <main>.
@@ -171,6 +179,7 @@
     // 2.4.2 / 4.1.3 / 2.4.3). Guard on a resolved component, mirroring the
     // null check above.
     if (parsed !== null) await announceNavigation(announcer, parsed, () => mainEl);
+    else if (isRootPath) await announceLandingNavigation(announcer, () => mainEl);
   }
 
   /**
@@ -317,7 +326,15 @@
     the Tab order. bind:this gives selectComponent a handle to call .focus().
   -->
   <main bind:this={mainEl} tabindex="-1">
-    <PreviewFrame bind:this={previewFrame} componentName={store.currentComponent} />
+    {#if store.currentComponent === ''}
+      <LandingPage
+        {readmeHtml}
+        firstComponent={components[0] ?? ''}
+        onBrowseComponent={selectComponent}
+      />
+    {:else}
+      <PreviewFrame bind:this={previewFrame} componentName={store.currentComponent} />
+    {/if}
   </main>
   <Announcer />
 </div>

--- a/packages/playground/src/shell-app/top-bar.svelte
+++ b/packages/playground/src/shell-app/top-bar.svelte
@@ -69,6 +69,7 @@
   // The custom-width number field is only visible when the viewport is
   // constrained to a numeric value (i.e., previewWidth is not null).
   let isCustomWidthVisible = $derived(store.previewWidth !== null);
+  let currentLocationLabel = $derived(store.currentComponent || 'README');
 
   function handleViewportChange(key: string): void {
     const preset = VIEWPORT_PRESETS.find((p) => p.key === key);
@@ -173,49 +174,51 @@
 
   <Toolbar class="top-bar__toolbar" aria-label="Preview controls">
     <Toolbar.Group>
-      <span class="component-name" title={store.currentComponent} aria-label="Current component">
-        {store.currentComponent || ' '}
+      <span class="component-name" title={currentLocationLabel} aria-label="Current location">
+        {currentLocationLabel}
       </span>
     </Toolbar.Group>
 
-    <Toolbar.Group class="viewport-size-controls">
-      <SegmentedControl
-        id="viewport-preset"
-        label="Viewport width"
-        hideLabel
-        density="toolbar"
-        {...viewportPresetKey !== undefined ? { value: viewportPresetKey } : {}}
-        disallowEmptySelection={false}
-        onchange={handleViewportChange}
-      >
-        {#each VIEWPORT_SEGMENTED_OPTIONS as option (option.value)}
-          <Segment value={option.value}>{option.label}</Segment>
-        {/each}
-      </SegmentedControl>
+    {#if store.currentComponent !== ''}
+      <Toolbar.Group class="viewport-size-controls">
+        <SegmentedControl
+          id="viewport-preset"
+          label="Viewport width"
+          hideLabel
+          density="toolbar"
+          {...viewportPresetKey !== undefined ? { value: viewportPresetKey } : {}}
+          disallowEmptySelection={false}
+          onchange={handleViewportChange}
+        >
+          {#each VIEWPORT_SEGMENTED_OPTIONS as option (option.value)}
+            <Segment value={option.value}>{option.label}</Segment>
+          {/each}
+        </SegmentedControl>
 
-      {#if isCustomWidthVisible}
-        <!-- A native <input type="number"> renders the value as a plain integer
+        {#if isCustomWidthVisible}
+          <!-- A native <input type="number"> renders the value as a plain integer
              ("1280", never the locale-grouped "1,280") and exposes the browser's
              spinner. Its field is inline-size:100% and would otherwise stretch to
              fill the toolbar row, crushing the segmented controls — the
              .width-input wrapper pins it to a fixed width wide enough for a
              four-digit value plus the spinner. The block only renders when
              previewWidth is a number, so String(...) is always a bare integer. -->
-        <span class="width-input">
-          <Input
-            id="viewport-width-input"
-            type="number"
-            value={String(store.previewWidth)}
-            min={200}
-            max={3840}
-            step={1}
-            aria-label="Custom viewport width in pixels (200 to 3840)"
-            onchange={handleCustomWidthInput}
-          />
-        </span>
-        <span class="unit" aria-hidden="true">px</span>
-      {/if}
-    </Toolbar.Group>
+          <span class="width-input">
+            <Input
+              id="viewport-width-input"
+              type="number"
+              value={String(store.previewWidth)}
+              min={200}
+              max={3840}
+              step={1}
+              aria-label="Custom viewport width in pixels (200 to 3840)"
+              onchange={handleCustomWidthInput}
+            />
+          </span>
+          <span class="unit" aria-hidden="true">px</span>
+        {/if}
+      </Toolbar.Group>
+    {/if}
 
     <Toolbar.Group>
       <SegmentedControl

--- a/packages/playground/src/shell-app/top-bar.svelte
+++ b/packages/playground/src/shell-app/top-bar.svelte
@@ -172,7 +172,7 @@
     <span class="wordmark" aria-label="Cinder design system">cinder</span>
   </div>
 
-  <Toolbar class="top-bar__toolbar" aria-label="Preview controls">
+  <Toolbar class="top-bar__toolbar" aria-label="Playground controls">
     <Toolbar.Group>
       <span class="component-name" title={currentLocationLabel} aria-label="Current location">
         {currentLocationLabel}

--- a/packages/playground/src/shell-app/top-bar.test.ts
+++ b/packages/playground/src/shell-app/top-bar.test.ts
@@ -114,7 +114,9 @@ describe('top-bar open-in-new-tab button', () => {
     const { container, unmount } = render(TopBarFixture, { store });
     await tick();
 
-    expect(container.querySelector('.cinder-toolbar')).not.toBeNull();
+    expect(container.querySelector('.cinder-toolbar')?.getAttribute('aria-label')).toBe(
+      'Playground controls',
+    );
     expect(container.querySelectorAll('.cinder-toolbar__group').length).toBeGreaterThanOrEqual(4);
     expect(container.querySelector('.cinder-toolbar__spacer')).not.toBeNull();
     expect(container.querySelectorAll('.cinder-segmented-control').length).toBeGreaterThanOrEqual(

--- a/packages/testing/tests/playground-landing.playwright.ts
+++ b/packages/testing/tests/playground-landing.playwright.ts
@@ -10,7 +10,7 @@ test.describe('playground landing page', () => {
   test('renders README content at the root and returns to it with browser history', async ({
     page,
   }) => {
-    await page.goto('/', { waitUntil: 'networkidle' });
+    await page.goto('/', { waitUntil: 'domcontentloaded' });
 
     await expect(
       page.getByRole('heading', { name: 'Svelte 5 components for product interfaces' }),

--- a/packages/testing/tests/playground-landing.playwright.ts
+++ b/packages/testing/tests/playground-landing.playwright.ts
@@ -1,0 +1,42 @@
+import { expect, test, type Page } from '@playwright/test';
+
+test.describe('playground landing page', () => {
+  async function readShellMarker(page: Page): Promise<string | undefined> {
+    return page.evaluate(
+      () => (window as typeof window & { __cinderShellMarker?: string }).__cinderShellMarker,
+    );
+  }
+
+  test('renders README content at the root and returns to it with browser history', async ({
+    page,
+  }) => {
+    await page.goto('/', { waitUntil: 'networkidle' });
+
+    await expect(
+      page.getByRole('heading', { name: 'Svelte 5 components for product interfaces' }),
+    ).toBeVisible();
+    await expect(page.locator('.landing-page__readme')).toContainText('Install');
+    await expect(page.locator('iframe')).toHaveCount(0);
+    await expect(page.locator('#viewport-preset')).toHaveCount(0);
+    await expect(page.locator('.component-name')).toHaveText('README');
+
+    await page.evaluate(() => {
+      (window as typeof window & { __cinderShellMarker?: string }).__cinderShellMarker = 'mounted';
+    });
+
+    await page.getByRole('link', { name: 'Browse components' }).click();
+    await expect(page).toHaveURL(/\/c\/[^/]+$/);
+    await expect.poll(() => readShellMarker(page)).toBe('mounted');
+    await expect(page.locator('iframe')).toHaveAttribute('src', /\/page\/[^/]+$/);
+
+    await page.goBack();
+    await expect(page).toHaveURL(/\/$/);
+    await expect.poll(() => readShellMarker(page)).toBe('mounted');
+    await expect(
+      page.getByRole('heading', { name: 'Svelte 5 components for product interfaces' }),
+    ).toBeVisible();
+    await expect(page.locator('iframe')).toHaveCount(0);
+    await expect(page.locator('#viewport-preset')).toHaveCount(0);
+    await expect(page.locator('.component-name')).toHaveText('README');
+  });
+});

--- a/packages/testing/tests/playground-landing.playwright.ts
+++ b/packages/testing/tests/playground-landing.playwright.ts
@@ -1,6 +1,23 @@
 import { expect, test, type Page } from '@playwright/test';
 
 test.describe('playground landing page', () => {
+  async function computedMetrics(locator: ReturnType<Page['locator']>): Promise<{
+    width: number;
+    parentWidth: number;
+    color: string;
+  }> {
+    return locator.evaluate((element) => {
+      const htmlElement = element as HTMLElement;
+      const parent = htmlElement.parentElement;
+      const style = getComputedStyle(htmlElement);
+      return {
+        width: htmlElement.getBoundingClientRect().width,
+        parentWidth: parent?.getBoundingClientRect().width ?? 0,
+        color: style.color,
+      };
+    });
+  }
+
   async function readShellMarker(page: Page): Promise<string | undefined> {
     return page.evaluate(
       () => (window as typeof window & { __cinderShellMarker?: string }).__cinderShellMarker,
@@ -12,9 +29,8 @@ test.describe('playground landing page', () => {
   }) => {
     await page.goto('/', { waitUntil: 'domcontentloaded' });
 
-    await expect(
-      page.getByRole('heading', { name: 'Svelte 5 components for product interfaces' }),
-    ).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'cinder', exact: true })).toBeVisible();
+    await expect(page.getByText('Svelte 5 components for product interfaces')).toHaveCount(0);
     await expect(page.locator('.landing-page__readme')).toContainText('Install');
     await expect(page.locator('iframe')).toHaveCount(0);
     await expect(page.locator('#viewport-preset')).toHaveCount(0);
@@ -32,11 +48,28 @@ test.describe('playground landing page', () => {
     await page.goBack();
     await expect(page).toHaveURL(/\/$/);
     await expect.poll(() => readShellMarker(page)).toBe('mounted');
-    await expect(
-      page.getByRole('heading', { name: 'Svelte 5 components for product interfaces' }),
-    ).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'cinder', exact: true })).toBeVisible();
     await expect(page.locator('iframe')).toHaveCount(0);
     await expect(page.locator('#viewport-preset')).toHaveCount(0);
     await expect(page.locator('.component-name')).toHaveText('README');
+  });
+
+  test('presents README content with usable landing-page layout styles', async ({ page }) => {
+    await page.goto('/', { waitUntil: 'domcontentloaded' });
+
+    const browseLink = page.getByRole('link', { name: 'Browse components' });
+    const browseMetrics = await computedMetrics(browseLink);
+    expect(browseMetrics.width).toBeLessThan(browseMetrics.parentWidth);
+
+    const table = page.locator('.landing-page__readme table').first();
+    const tableMetrics = await computedMetrics(table);
+    expect(Math.round(tableMetrics.width)).toBe(Math.round(tableMetrics.parentWidth));
+
+    const highlightedToken = page
+      .locator('.landing-page__readme pre code span[style*="--syntax-"]')
+      .first();
+    await expect(highlightedToken).toBeVisible();
+    const codeMetrics = await computedMetrics(highlightedToken);
+    expect(codeMetrics.color).not.toBe(browseMetrics.color);
   });
 });

--- a/packages/testing/tests/playground-shell-styles.playwright.ts
+++ b/packages/testing/tests/playground-shell-styles.playwright.ts
@@ -61,6 +61,7 @@ test.describe('playground shell styles', () => {
     const viewportOption = viewportControl.locator('.cinder-segmented-control-option').first();
     const sidebarList = page.locator('.cinder-side-navigation__list');
     const filterInput = page.locator('#sidebar-filter.cinder-input');
+    const previewFrameWrapper = page.locator('.preview-frame-wrapper');
 
     const viewportMetrics = await computedMetrics(viewportControl);
     expect(['flex', 'inline-flex']).toContain(viewportMetrics.display);
@@ -82,6 +83,9 @@ test.describe('playground shell styles', () => {
     expect(filterMetrics.borderBlockStartWidth).toBeGreaterThan(0);
     expect(filterMetrics.borderRadius).toBeGreaterThan(0);
     expect(filterMetrics.height).toBeGreaterThan(30);
+
+    const previewFrameMetrics = await computedMetrics(previewFrameWrapper);
+    expect(previewFrameMetrics.borderBlockStartWidth).toBeGreaterThan(0);
 
     await page.getByRole('radio', { name: 'Tablet (768 pixels)' }).click();
     await expect(viewportControl.locator('[data-cinder-selected]')).toContainText('Tablet');

--- a/packages/testing/tests/playground-shell-styles.playwright.ts
+++ b/packages/testing/tests/playground-shell-styles.playwright.ts
@@ -61,7 +61,6 @@ test.describe('playground shell styles', () => {
     const viewportOption = viewportControl.locator('.cinder-segmented-control-option').first();
     const sidebarList = page.locator('.cinder-side-navigation__list');
     const filterInput = page.locator('#sidebar-filter.cinder-input');
-    const previewFrameWrapper = page.locator('.preview-frame-wrapper');
 
     const viewportMetrics = await computedMetrics(viewportControl);
     expect(['flex', 'inline-flex']).toContain(viewportMetrics.display);
@@ -84,8 +83,10 @@ test.describe('playground shell styles', () => {
     expect(filterMetrics.borderRadius).toBeGreaterThan(0);
     expect(filterMetrics.height).toBeGreaterThan(30);
 
-    const previewFrameMetrics = await computedMetrics(previewFrameWrapper);
-    expect(previewFrameMetrics.borderBlockStartWidth).toBeGreaterThan(0);
+    const previewPage = page.frameLocator('iframe[data-cinder-preview]').locator('.dx');
+    await expect(previewPage).toBeVisible();
+    const previewPageMetrics = await computedMetrics(previewPage);
+    expect(previewPageMetrics.borderBlockStartWidth).toBeGreaterThan(0);
 
     await page.getByRole('radio', { name: 'Tablet (768 pixels)' }).click();
     await expect(viewportControl.locator('[data-cinder-selected]')).toContainText('Tablet');


### PR DESCRIPTION
## Summary

- Render a README-backed landing page at the playground root instead of redirecting to the first component
- Embed sanitized README HTML in the shell data island and render it through a dedicated landing page view
- Preserve component navigation, root history behavior, and static export output with focused regressions

## Committee Review

Approved before PR creation:

- prose-editor
- typescript-expert
- security-reviewer
- ux-designer
- frontend-architect
- testing-expert
- mandatory Codex reviewer

Requested post-creation reviewer: @copilot

## Test Plan

- `bun run --filter=@cinder/playground typecheck`
- `bun test packages/playground/src/shell-app/announcer.test.ts`
- `bun test packages/playground/scripts/static-export.test.ts`
- `bun test packages/playground/src/playground-server.test.ts -t "README-backed landing shell HTML|parseable rendered README HTML|rewriteRepositoryRelativeReadmeLinks"`
- `bun run --filter=@cinder/testing typecheck`
- `bun run --filter=@cinder/testing test:playwright -- tests/playground-landing.playwright.ts`
- Commit hook: scoped lint/typecheck/test passed
- Push hook: scoped lint/typecheck/test passed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Playground-only routing and UI; README HTML is sanitized and link-rewritten with broad unit and Playwright coverage.
> 
> **Overview**
> The playground **root (`/`)** no longer **302-redirects** to the first component. It returns **200 shell HTML** with the repo **README** rendered through `@cinder/markdown`, **sanitized**, and **repository-relative doc links** rewritten to GitHub `blob/main/` URLs. That HTML is embedded in the **`#cinder-initial`** payload as **`readmeHtml`**.
> 
> The shell shows a new **`landing-page.svelte`** (hero + “Browse components” + `{@html readmeHtml}`) when **`currentComponent` is empty**, hides the preview iframe and viewport toolbar on that view, and labels the top bar **“README”**. **Browser back/forward** to `/` clears the active component and uses **`announceLandingNavigation`** for title, live region, and focus.
> 
> **Static export** is refactored to **`runStaticExport`** (injectable output dir / component lists) so tests assert **`index.html`** is a real landing shell, not a meta-refresh redirect. **README** and **Playwright** tests cover server payload, link rewriting, history, and layout.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8a8e4d3a1e832f8f733449201e857550cf3eb83a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->