### PR TITLE
fix(playground): timeline connector + code-block chrome/dark-bg + playground children control

### DIFF
--- a/.changeset/timeline-connector-codeblock-chrome.md
+++ b/.changeset/timeline-connector-codeblock-chrome.md
@@ -1,0 +1,17 @@
+---
+'@lostgradient/cinder': patch
+---
+
+Fix two component CSS defects surfaced by the playground:
+
+- **Timeline connector** now spans each marker's center to the next marker's
+  center instead of stopping `space-1` short, so the rail reads as one
+  continuous line through the dots rather than disconnected stubs (notably with
+  custom marker snippets). The connector's `bottom` offset now accounts for the
+  marker's own `margin-top` inside the next event grid.
+- **Code block** no longer renders per-token background bands in dark mode. The
+  generated `<code>` element (and Shiki line/token spans) are forced transparent
+  so the single `<pre>` surface shows through as one uniform field; only token
+  foreground colors apply. The header copy button also gains real button
+  affordance — a 28px-square hit target (clearing WCAG 2.5.8) with a subtle
+  resting chip background — instead of a bare floating glyph.

--- a/packages/components/src/components/code-block/code-block.css
+++ b/packages/components/src/components/code-block/code-block.css
@@ -73,6 +73,17 @@
     font-family: inherit;
     font-size: inherit;
     line-height: inherit;
+    /* Shiki paints a surface on the generated <code> (and can on line spans)
+     * that differs from the <pre> we force to the inset surface, so in dark mode
+     * each highlighted region reads as its own lighter band over the panel.
+     * Keep the code element and any line wrapper transparent so the single
+     * <pre> surface shows through as one uniform field. (Token foreground colors
+     * are handled separately by the dual-theme `color` swap below.) */
+    background: transparent !important;
+  }
+
+  .cinder-code-block :where(pre.shiki code .line, pre.shiki code span) {
+    background: transparent !important;
   }
 
   /* ── Dark-theme Shiki dual-theme fix ─────────────────────────────────────
@@ -123,17 +134,34 @@
     }
   }
 
-  /* Compact, borderless copy button when nested inside a code block header.
+  /* Compact copy button when nested inside a code block header. It reads as a
+ * real button — a square hit target with a subtle resting chip background — not
+ * a bare floating glyph crammed against the panel edge. The chip is a faint
+ * raised surface so the button is discoverable at rest without competing with
+ * the code content; hover deepens it (rule below).
+ *
+ * Hit target: 1.75rem (28px) square clears the WCAG 2.5.8 AA 24px floor with
+ * margin. The icon stays centered via inline-flex.
+ *
  * Specificity bump (`.cinder-code-block .cinder-code-block__header .cinder-copy-button`)
  * is required because copy-button.css imports AFTER code-block.css in components.css;
  * with equal specificity the later import would win and the bordered default would
  * leak through. Scoped so the standalone CopyButton keeps its bordered default
  * everywhere else in the app. */
   .cinder-code-block .cinder-code-block__header .cinder-copy-button {
-    border: none;
-    background: transparent;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    inline-size: 1.75rem;
+    min-block-size: 1.75rem;
+    border: 1px solid transparent;
+    border-radius: var(--cinder-radius-sm);
+    background: var(--cinder-surface-raised);
     padding: var(--cinder-space-1);
-    color: var(--cinder-text-subtle);
+    color: var(--cinder-text-muted);
+    transition:
+      background-color var(--cinder-duration-fast) var(--cinder-ease-standard),
+      color var(--cinder-duration-fast) var(--cinder-ease-standard);
   }
 
   .cinder-code-block .cinder-code-block__header .cinder-copy-button:focus-visible {

--- a/packages/components/src/components/timeline/timeline.css
+++ b/packages/components/src/components/timeline/timeline.css
@@ -69,14 +69,26 @@
 
   /* Connecting line between items. It is anchored to the event row, not the
      list item, so optional group headers above the event cannot offset it away
-     from the marker. The line extends through this item's bottom padding to the
-     next event marker center. */
+     from the marker. The line spans THIS marker's center to the NEXT marker's
+     center so it terminates cleanly at each dot with no stub gap.
+
+     The bottom offset is measured from the event box's bottom edge down to the
+     next item's marker center. That distance is three tokens, not two:
+       - the item's padding-bottom (space-4) below the event box, plus
+       - the marker's own margin-top (space-1) inside the next event grid, plus
+       - the next marker's center-y within its event box (marker-center-y).
+     The earlier formula omitted the marker margin-top (space-1), so every
+     segment fell exactly space-1 short of the next dot. Verified in the browser:
+     with this offset the line's painted endpoints land on the marker centers
+     (a 63px inter-marker rhythm at the default token scale). */
   .cinder-timeline-item__event::before {
     content: '';
     position: absolute;
     left: var(--_cinder-timeline-marker-center-x);
     top: var(--_cinder-timeline-marker-center-y);
-    bottom: calc(-1 * (var(--cinder-space-4) + var(--_cinder-timeline-marker-center-y)));
+    bottom: calc(
+      -1 * (var(--cinder-space-4) + var(--cinder-space-1) + var(--_cinder-timeline-marker-center-y))
+    );
     width: 1px;
     background: var(--cinder-border-muted);
   }

--- a/packages/components/src/components/timeline/timeline.test.ts
+++ b/packages/components/src/components/timeline/timeline.test.ts
@@ -158,13 +158,20 @@ describe('Timeline', () => {
 
   test('timeline css anchors vertical connectors to the event row for grouped headers', async () => {
     const css = await Bun.file(new URL('./timeline.css', import.meta.url).pathname).text();
+    // Collapse whitespace so the assertion tracks the geometric intent, not
+    // prettier's line breaks (the multi-term calc wraps across lines).
+    const flat = css.replace(/\s+/g, ' ');
 
     expect(css).toContain('.cinder-timeline-item__event::before');
     expect(css).toContain(
       ".cinder-timeline-item[data-cinder-connector-after='hidden'] .cinder-timeline-item__event::before",
     );
-    expect(css).toContain(
-      'bottom: calc(-1 * (var(--cinder-space-4) + var(--_cinder-timeline-marker-center-y)))',
+    // The connector's bottom must reach the NEXT marker center: it extends past
+    // the event box by the item padding (space-4) PLUS the next marker's
+    // margin-top (space-1) PLUS that marker's center-y. Dropping the space-1 term
+    // is the off-by-one-token regression that left stub gaps.
+    expect(flat).toContain(
+      'bottom: calc( -1 * (var(--cinder-space-4) + var(--cinder-space-1) + var(--_cinder-timeline-marker-center-y)) )',
     );
     expect(css).not.toContain('.cinder-timeline-item::before {');
   });

--- a/packages/playground/src/component-page-live-preview.test.ts
+++ b/packages/playground/src/component-page-live-preview.test.ts
@@ -45,9 +45,47 @@ import {
   createLivePreviewMount,
   LIVE_MOUNT_CONTAINER_ID,
   type MountErrorRecord,
+  toMountProps,
 } from './component-page-live-preview.ts';
+import type { PlaygroundControl } from './component-page-playground.ts';
 
 setupHappyDom();
+
+describe('toMountProps', () => {
+  test('passes non-children controls through unchanged', () => {
+    const controls: PlaygroundControl[] = [
+      {
+        name: 'variant',
+        kind: 'select',
+        options: ['neutral', 'danger'],
+        value: 'neutral',
+        hasDefault: true,
+      },
+      { name: 'mono', kind: 'boolean', value: false, hasDefault: true },
+    ];
+    expect(toMountProps(controls, { variant: 'danger', mono: true })).toEqual({
+      variant: 'danger',
+      mono: true,
+    });
+  });
+
+  test('converts a children text control into a children snippet', () => {
+    const controls: PlaygroundControl[] = [
+      { name: 'children', kind: 'text', isChildren: true, value: 'Badge', hasDefault: false },
+    ];
+    const props = toMountProps(controls, { children: 'Beta' });
+    // `children` becomes a Svelte snippet (a function), never the raw string.
+    expect(typeof props['children']).toBe('function');
+    expect(props['children']).not.toBe('Beta');
+  });
+
+  test('omits children entirely when the text is empty (component default renders)', () => {
+    const controls: PlaygroundControl[] = [
+      { name: 'children', kind: 'text', isChildren: true, value: '', hasDefault: false },
+    ];
+    expect('children' in toMountProps(controls, { children: '' })).toBe(false);
+  });
+});
 
 const { render } = await import('@testing-library/svelte');
 const { default: Fixture } = await import('./component-page-live-preview-fixture.svelte');

--- a/packages/playground/src/component-page-live-preview.ts
+++ b/packages/playground/src/component-page-live-preview.ts
@@ -16,9 +16,44 @@
  *     errors by container DOM id, and falls back to a featured-example mount when
  *     the live mount fails.
  */
-import { mount, unmount } from 'svelte';
+import { createRawSnippet, mount, unmount } from 'svelte';
 
+import type { PlaygroundControl, PlaygroundValue } from './component-page-playground.ts';
 import { toMountErrorDetail, type MountErrorDetail } from './example-error.ts';
+
+/**
+ * Translate the flat playground control values into the props object handed to
+ * `mount`. Almost every value passes through unchanged; the one transform is the
+ * synthesized `children` text control, whose plain string must become a Svelte
+ * snippet (components receive `children` as a snippet, never a raw string). The
+ * text is rendered into the snippet as a TEXT node — `textContent`, never
+ * `innerHTML` — so user-typed angle brackets stay inert and cannot inject markup.
+ *
+ * An empty children string yields no `children` prop at all, so the component
+ * falls back to its own default rendering rather than mounting an empty snippet.
+ */
+export function toMountProps(
+  controls: PlaygroundControl[],
+  values: Record<string, PlaygroundValue>,
+): Record<string, unknown> {
+  const props: Record<string, unknown> = {};
+  for (const control of controls) {
+    const value = values[control.name] ?? control.value;
+    if (control.kind === 'text' && control.isChildren === true) {
+      const text = String(value);
+      if (text === '') continue;
+      props['children'] = createRawSnippet(() => ({
+        render: () => '<span></span>',
+        setup: (node: Element) => {
+          node.textContent = text;
+        },
+      }));
+      continue;
+    }
+    props[control.name] = value;
+  }
+  return props;
+}
 
 /**
  * The DOM `id` of the live-preview mount container, and therefore the

--- a/packages/playground/src/component-page-live-preview.ts
+++ b/packages/playground/src/component-page-live-preview.ts
@@ -22,12 +22,28 @@ import type { PlaygroundControl, PlaygroundValue } from './component-page-playgr
 import { toMountErrorDetail, type MountErrorDetail } from './example-error.ts';
 
 /**
+ * Escape a string for an HTML text-content context: `&` and `<` only. Used for
+ * the raw-snippet render string below so user-typed markup is inserted as
+ * literal text, never parsed into elements. `>` and `"` are literal in element
+ * text content and need no escaping.
+ */
+function escapeHtmlText(text: string): string {
+  return text.replace(/&/g, '&amp;').replace(/</g, '&lt;');
+}
+
+/**
  * Translate the flat playground control values into the props object handed to
  * `mount`. Almost every value passes through unchanged; the one transform is the
  * synthesized `children` text control, whose plain string must become a Svelte
- * snippet (components receive `children` as a snippet, never a raw string). The
- * text is rendered into the snippet as a TEXT node — `textContent`, never
- * `innerHTML` — so user-typed angle brackets stay inert and cannot inject markup.
+ * snippet (components receive `children` as a snippet, never a raw string).
+ *
+ * The snippet renders the escaped text DIRECTLY as element content — no wrapper
+ * element — so the live preview's DOM matches the copyable snippet exactly
+ * (`<Badge>text</Badge>`, not `<Badge><span>text</span></Badge>`). A wrapper
+ * would change inherited styles, spacing, and selectors versus the code the
+ * playground tells the reader to copy. Escaping (not `innerHTML` of raw input)
+ * keeps typed angle brackets inert — they render as the literal characters the
+ * snippet shows.
  *
  * An empty children string yields no `children` prop at all, so the component
  * falls back to its own default rendering rather than mounting an empty snippet.
@@ -42,11 +58,9 @@ export function toMountProps(
     if (control.kind === 'text' && control.isChildren === true) {
       const text = String(value);
       if (text === '') continue;
+      const escaped = escapeHtmlText(text);
       props['children'] = createRawSnippet(() => ({
-        render: () => '<span></span>',
-        setup: (node: Element) => {
-          node.textContent = text;
-        },
+        render: () => escaped,
       }));
       continue;
     }

--- a/packages/playground/src/component-page-playground.test.ts
+++ b/packages/playground/src/component-page-playground.test.ts
@@ -88,8 +88,34 @@ describe('buildPlaygroundModel', () => {
       ]),
     );
     expect(model.hasUnsatisfiedRequired).toBe(false);
-    expect(model.controls.map((control) => control.name)).toEqual(['multiple']);
-    expect(model.skipped).toEqual(['children']);
+    // `children` is synthesized into an editable text control (not skipped) so
+    // the live preview renders a labelled instance instead of an empty shell.
+    expect(model.controls.map((control) => control.name)).toEqual(['multiple', 'children']);
+    expect(model.skipped).toEqual([]);
+  });
+
+  test('the synthesized children control is a text control seeded with the component name', () => {
+    const model = buildPlaygroundModel(
+      manifest([
+        { name: 'children', control: { kind: 'snippet' }, bindable: false, optional: false },
+      ]),
+    );
+    const childrenControl = model.controls.find((control) => control.name === 'children');
+    expect(childrenControl).toEqual({
+      name: 'children',
+      hasDefault: false,
+      kind: 'text',
+      isChildren: true,
+      value: 'Demo',
+    });
+  });
+
+  test('a non-children snippet prop stays non-adjustable (skipped)', () => {
+    const model = buildPlaygroundModel(
+      manifest([{ name: 'header', control: { kind: 'snippet' }, bindable: false, optional: true }]),
+    );
+    expect(model.controls).toEqual([]);
+    expect(model.skipped).toEqual(['header']);
   });
 
   test('a required non-snippet prop with no default suppresses the generated preview', () => {
@@ -365,5 +391,42 @@ describe('buildSnippet', () => {
     expect(
       buildSnippet('Widget', noDefault, { variant: 'primary', disabled: false, count: 0 }),
     ).toBe('<Widget\n  variant="primary"\n  disabled={false}\n  count={0}\n/>');
+  });
+
+  test('renders a children control as element content, not an attribute', () => {
+    const withChildren = buildPlaygroundModel(
+      manifest([
+        { name: 'children', control: { kind: 'snippet' }, bindable: false, optional: false },
+      ]),
+    ).controls;
+    // Seeded with the component name → open/close pair, not self-closing.
+    expect(buildSnippet('Badge', withChildren, { children: 'Badge' })).toBe('<Badge>Badge</Badge>');
+    // Edited content flows through.
+    expect(buildSnippet('Badge', withChildren, { children: 'Beta' })).toBe('<Badge>Beta</Badge>');
+    // Cleared children → minimal self-closing form (no empty open/close pair).
+    expect(buildSnippet('Badge', withChildren, { children: '' })).toBe('<Badge />');
+  });
+
+  test('combines attribute controls with children content', () => {
+    const mixed = buildPlaygroundModel(
+      manifest([
+        {
+          name: 'variant',
+          control: { kind: 'select', options: ['neutral', 'danger'] },
+          bindable: false,
+          optional: true,
+          defaultValue: 'neutral',
+        },
+        { name: 'children', control: { kind: 'snippet' }, bindable: false, optional: false },
+      ]),
+    ).controls;
+    // One attribute + children → single-attribute open/close form.
+    expect(buildSnippet('Badge', mixed, { variant: 'danger', children: 'Beta' })).toBe(
+      '<Badge variant="danger">Beta</Badge>',
+    );
+    // Attribute at its default is omitted; children still render as content.
+    expect(buildSnippet('Badge', mixed, { variant: 'neutral', children: 'Beta' })).toBe(
+      '<Badge>Beta</Badge>',
+    );
   });
 });

--- a/packages/playground/src/component-page-playground.test.ts
+++ b/packages/playground/src/component-page-playground.test.ts
@@ -407,6 +407,25 @@ describe('buildSnippet', () => {
     expect(buildSnippet('Badge', withChildren, { children: '' })).toBe('<Badge />');
   });
 
+  test('escapes children text so the copied snippet stays valid Svelte', () => {
+    const withChildren = buildPlaygroundModel(
+      manifest([
+        { name: 'children', control: { kind: 'snippet' }, bindable: false, optional: false },
+      ]),
+    ).controls;
+    // `<`, `&`, and `{` are special in Svelte text content; escape them so the
+    // pasted snippet renders the literal text the live preview shows.
+    expect(buildSnippet('Badge', withChildren, { children: '<strong>x</strong>' })).toBe(
+      '<Badge>&lt;strong>x&lt;/strong></Badge>',
+    );
+    expect(buildSnippet('Badge', withChildren, { children: 'a & b' })).toBe(
+      '<Badge>a &amp; b</Badge>',
+    );
+    expect(buildSnippet('Badge', withChildren, { children: '{count}' })).toBe(
+      '<Badge>&lbrace;count}</Badge>',
+    );
+  });
+
   test('combines attribute controls with children content', () => {
     const mixed = buildPlaygroundModel(
       manifest([

--- a/packages/playground/src/component-page-playground.ts
+++ b/packages/playground/src/component-page-playground.ts
@@ -214,13 +214,20 @@ function shouldEmit(control: PlaygroundControl, current: PlaygroundValue): boole
  * @returns A single-element Svelte snippet string.
  */
 /**
- * Escape a string for a Svelte text-content context. The live mount sets the
- * children via `textContent` (so typed markup is inert there), but the COPYABLE
- * snippet string interpolates this value as element content — if the user types
- * `<`, `&`, or `{`, the pasted snippet would be invalid or different Svelte
- * (`<` opens a tag, `&` starts an entity, `{` opens an expression). Escaping
- * those three keeps the copied code rendering the same literal text the live
- * preview shows. `>` is left as-is — it is literal in element text content.
+ * Escape a string for a Svelte **source** text-content context — the COPYABLE
+ * snippet string this module builds, which interpolates the children value as
+ * element content. If the user types `<`, `&`, or `{`, the pasted snippet would
+ * be invalid or different Svelte (`<` opens a tag, `&` starts an entity, `{`
+ * opens an expression). Escaping those three keeps the copied code rendering the
+ * same literal text the live preview shows. `>` is left as-is — it is literal in
+ * element text content.
+ *
+ * The live MOUNT path escapes separately and for a different context: it renders
+ * the value through `createRawSnippet` as an HTML text string (see
+ * `escapeHtmlText` in `component-page-live-preview.ts`, which escapes `&` and `<`
+ * for an HTML text node). Both paths produce the same visible literal text; they
+ * differ only in which characters each target syntax treats as special (`{` is
+ * special in Svelte source, not in an HTML text node).
  */
 function escapeSnippetText(text: string): string {
   return text.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/\{/g, '&lbrace;');

--- a/packages/playground/src/component-page-playground.ts
+++ b/packages/playground/src/component-page-playground.ts
@@ -25,7 +25,7 @@ type PlaygroundControlBase = { name: string; description?: string; hasDefault: b
 export type PlaygroundControl = PlaygroundControlBase &
   (
     | { kind: 'boolean'; value: boolean }
-    | { kind: 'text'; value: string }
+    | { kind: 'text'; value: string; isChildren?: boolean }
     | { kind: 'number'; value: number }
     | { kind: 'select'; value: string; options: string[] }
   );
@@ -80,6 +80,16 @@ function numberDefault(value: unknown): number {
 }
 
 /**
+ * Seed text for a synthesized `children` control. Uses the component's display
+ * name so the live preview renders a labelled instance out of the box (a Badge
+ * reading "Badge", a Button reading "Button") rather than an empty shell. The
+ * reader edits it freely from there.
+ */
+function childrenSeed(manifest: ComponentManifest): string {
+  return manifest.name;
+}
+
+/**
  * Build a {@link PlaygroundModel} from a component manifest.
  *
  * Supported control shapes: `boolean -> switch`, `select -> segmented/select`,
@@ -124,8 +134,26 @@ export function buildPlaygroundModel(manifest: ComponentManifest): PlaygroundMod
         controls.push({ ...base, kind: 'number', value: numberDefault(prop.defaultValue) });
         break;
       default:
-        // snippet / unknown — not adjustable. A required non-snippet value the
-        // generator can't synthesize means we can't build a valid preview at all.
+        // snippet / unknown — not adjustable as an attribute. The one exception
+        // is the ubiquitous `children` snippet: many components (Badge, Button,
+        // Chip, …) render plain text children, and without a control the live
+        // preview shows an empty shell. Synthesize an editable TEXT control for
+        // it, seeded with the component's display name so the preview reads as a
+        // labelled instance out of the box. Marked `isChildren` so the snippet
+        // renders it as element content (`<X>text</X>`) and the mount converts it
+        // to a children snippet, rather than emitting it as an attribute.
+        if (prop.name === 'children' && prop.control.kind === 'snippet') {
+          controls.push({
+            ...base,
+            kind: 'text',
+            isChildren: true,
+            value: childrenSeed(manifest),
+          });
+          break;
+        }
+        // Other snippet / unknown props remain non-adjustable. A required
+        // non-snippet value the generator can't synthesize means we can't build
+        // a valid preview at all.
         skipped.push(prop.name);
         if (blocksGeneratedPreview(prop)) hasUnsatisfiedRequired = true;
         break;
@@ -190,9 +218,28 @@ export function buildSnippet(
   controls: PlaygroundControl[],
   values: Record<string, PlaygroundValue>,
 ): string {
+  // The synthesized `children` control renders as element CONTENT, not an
+  // attribute, so it is partitioned out of the attribute list.
+  const childrenControl = controls.find((c) => c.kind === 'text' && c.isChildren);
+  const childrenText =
+    childrenControl !== undefined
+      ? String(values[childrenControl.name] ?? childrenControl.value)
+      : '';
+
   const attributes = controls
+    .filter((control) => !(control.kind === 'text' && control.isChildren))
     .filter((control) => shouldEmit(control, values[control.name] ?? control.value))
     .map((control) => attributeFor(control.name, values[control.name] ?? control.value));
+
+  // With children content, emit an open/close pair so the snippet copy-pastes as
+  // a real labelled instance; otherwise keep the minimal self-closing form.
+  if (childrenText !== '') {
+    if (attributes.length === 0) return `<${exportName}>${childrenText}</${exportName}>`;
+    if (attributes.length === 1) {
+      return `<${exportName} ${attributes[0]}>${childrenText}</${exportName}>`;
+    }
+    return `<${exportName}\n  ${attributes.join('\n  ')}\n>${childrenText}</${exportName}>`;
+  }
 
   if (attributes.length === 0) return `<${exportName} />`;
   if (attributes.length === 1) return `<${exportName} ${attributes[0]} />`;

--- a/packages/playground/src/component-page-playground.ts
+++ b/packages/playground/src/component-page-playground.ts
@@ -213,6 +213,19 @@ function shouldEmit(control: PlaygroundControl, current: PlaygroundValue): boole
  * @param values - Current value per control name.
  * @returns A single-element Svelte snippet string.
  */
+/**
+ * Escape a string for a Svelte text-content context. The live mount sets the
+ * children via `textContent` (so typed markup is inert there), but the COPYABLE
+ * snippet string interpolates this value as element content — if the user types
+ * `<`, `&`, or `{`, the pasted snippet would be invalid or different Svelte
+ * (`<` opens a tag, `&` starts an entity, `{` opens an expression). Escaping
+ * those three keeps the copied code rendering the same literal text the live
+ * preview shows. `>` is left as-is — it is literal in element text content.
+ */
+function escapeSnippetText(text: string): string {
+  return text.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/\{/g, '&lbrace;');
+}
+
 export function buildSnippet(
   exportName: string,
   controls: PlaygroundControl[],
@@ -231,17 +244,21 @@ export function buildSnippet(
     .filter((control) => shouldEmit(control, values[control.name] ?? control.value))
     .map((control) => attributeFor(control.name, values[control.name] ?? control.value));
 
+  // One attribute fragment shared by both the self-closing and open/close forms,
+  // so children is a single suffix concern rather than a parallel set of paths.
+  const attributePart =
+    attributes.length === 0
+      ? ''
+      : attributes.length === 1
+        ? ` ${attributes[0]}`
+        : `\n  ${attributes.join('\n  ')}\n`;
+
   // With children content, emit an open/close pair so the snippet copy-pastes as
   // a real labelled instance; otherwise keep the minimal self-closing form.
   if (childrenText !== '') {
-    if (attributes.length === 0) return `<${exportName}>${childrenText}</${exportName}>`;
-    if (attributes.length === 1) {
-      return `<${exportName} ${attributes[0]}>${childrenText}</${exportName}>`;
-    }
-    return `<${exportName}\n  ${attributes.join('\n  ')}\n>${childrenText}</${exportName}>`;
+    return `<${exportName}${attributePart}>${escapeSnippetText(childrenText)}</${exportName}>`;
   }
-
-  if (attributes.length === 0) return `<${exportName} />`;
-  if (attributes.length === 1) return `<${exportName} ${attributes[0]} />`;
-  return `<${exportName}\n  ${attributes.join('\n  ')}\n/>`;
+  return attributes.length > 1
+    ? `<${exportName}${attributePart}/>`
+    : `<${exportName}${attributePart} />`;
 }

--- a/packages/playground/src/component-page.svelte
+++ b/packages/playground/src/component-page.svelte
@@ -52,6 +52,7 @@
     createLivePreviewMount,
     LIVE_MOUNT_CONTAINER_ID,
     resolveBareComponent,
+    toMountProps,
   } from './component-page-live-preview.ts';
 
   type CinderExampleDescriptor = {
@@ -881,7 +882,10 @@
                             id={LIVE_MOUNT_CONTAINER_ID}
                             {@attach mountLivePreview(
                               bareComponent,
-                              $state.snapshot(playgroundValues),
+                              toMountProps(
+                                playgroundModel.controls,
+                                $state.snapshot(playgroundValues),
+                              ),
                             )}
                           ></div>
                         </div>


### PR DESCRIPTION
## Summary

Fixes four playground defects reported from a visual review, each verified in the browser (light + dark) against current `main`:

1. **Timeline connector reaches the markers** — the `::before` rail was a stub that fell `space-1` short of the next marker, leaving visible gaps (worst with custom marker snippets). The `bottom` offset now adds the next marker's `margin-top`, so the line spans dot-center to dot-center. Browser-verified: painted endpoints land exactly on the marker centers (63px rhythm at default tokens).

2. **Code-block dark-mode syntax bands removed** — Shiki painted a surface on the generated `<code>` (and line/token spans) that differed from the `<pre>` cinder forces to the inset surface, so every highlighted region read as its own lighter band in dark mode. Those elements are now forced transparent; the single `<pre>` surface shows through as one uniform field. Token foreground colors are untouched (handled by the existing dual-theme `color` swap).

3. **Code-block copy button gets button chrome** — the header copy button was a bare transparent glyph crammed at the edge. It's now a 28px-square (`1.75rem`, clears WCAG 2.5.8) inline-flex chip with a subtle `--cinder-surface-raised` resting background; focus-visible/forced-colors/hover states unchanged. Icon-on-chip contrast verified 8.89:1 (dark) / 12.59:1 (light).

4. **Playground live preview gets an editable children control** — components whose primary content is `children` (Badge, Button, Chip, Alert…) rendered an empty shell. A `children` snippet prop now synthesizes an editable text control seeded with the component name; the copyable snippet renders it as element content (`<Badge>Badge</Badge>`), and the live mount converts the text to a Svelte snippet via `createRawSnippet`. Both paths escape `&`/`<`(/`{` for the Svelte-source snippet) so typed markup is inert and the preview DOM matches the copyable code exactly (bare text node, no wrapper element).

## Review committee

Pre-reviewed by: ux-designer, frontend-architect, svelte-expert, testing-expert, simplicity-engineer
- Codex (gpt-5.4, xhigh→high reasoning) — 3 rounds
- All must-fix items addressed: snippet-string escaping (Codex r1), and live-mount/snippet DOM-equivalence — render children with no wrapper element (Codex r2). Copy-button contrast and the children-control label were verified already-satisfied.
- Consensus reached round 3.

## Not in this PR (deferred)

The "condense the multiple timeline components" request is a **breaking API change** (hiding `TimelineItem` from public exports) that spans two code-generators + drift tests; it's split into a dedicated follow-up PR per the maintainer's decision.

## Test plan

- `bun run build` + `typecheck` (components + playground) — green
- Components suite (6005 tests) + playground suite (852 tests) — green; `components:check` — OK
- New unit tests: `buildSnippet` children-as-content + escaping; `buildPlaygroundModel` children control; `toMountProps`; timeline connector CSS assertion (whitespace-robust)
- Browser-verified at `/page/timeline` (connector continuity), `/page/badge` (children control reactivity + literal-markup rendering + no-wrapper DOM), `/page/command-palette` and code-block headers (dark-mode uniform surface + copy-button chrome), light and dark

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly presentation CSS and dev-only playground helpers; behavior changes are localized and covered by new unit tests, with no auth or data-path impact.
> 
> **Overview**
> Fixes **visual/CSS defects** in **Timeline** and **Code block**, and extends the **component playground** so components with a `children` snippet are not empty in the live preview.
> 
> **Timeline:** The vertical connector’s `bottom` calc now includes the next marker’s `margin-top` (`space-1`), so the rail runs **marker-center to marker-center** instead of stopping short with stub gaps.
> 
> **Code block:** Shiki `<code>` / line / token spans are forced **transparent** so dark mode shows one uniform `<pre>` surface (no per-token bands). The header **copy** control becomes a **28px** raised chip with clearer button affordance (WCAG 2.5.8 hit target).
> 
> **Playground:** Required `children` snippet props synthesize an editable **text** control (seeded with the component name). **`buildSnippet`** emits children as **element content** with Svelte-source escaping; **`toMountProps`** maps that text to a **`createRawSnippet`** (HTML-escaped, no wrapper) so the live mount matches the copyable snippet. The page wires live preview through **`toMountProps`**. Unit tests cover snippet/mount behavior and the timeline CSS regression.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 752571882dc5057e66ff749c07c88cf21594343a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->