### PR TITLE
fix(exports): self-heal stale legacy flat subpaths on hide/rename (#438)

### DIFF
--- a/packages/components/scripts/generate-exports.test.ts
+++ b/packages/components/scripts/generate-exports.test.ts
@@ -12,7 +12,11 @@
  *      `default` and at the preserved single-file server bundle for `node`.
  */
 
-import { describe, expect, it } from 'bun:test';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+
+import { afterAll, beforeAll, describe, expect, it } from 'bun:test';
 
 import {
   assertNoForbiddenExportKeys,
@@ -21,8 +25,10 @@ import {
   computeRootExport,
   EXPLICIT_ROOT_FILE_ENTRIES,
   FORBIDDEN_EXPORT_KEY_PATTERN,
+  legacyEntrySourcePath,
   orderedExportEntry,
   rootLevelExportTargets,
+  shouldPreserveLegacyEntry,
   STATIC_FILES_GLOBS,
   stylesExport,
   stylesGuardExport,
@@ -80,6 +86,79 @@ describe('stylesExport', () => {
     expect(stylesExport('./src/styles/utilities.css').types).toBe(
       './src/styles/utilities.css.d.ts',
     );
+  });
+});
+
+describe('legacyEntrySourcePath', () => {
+  it('prefers the svelte condition (the authored source)', () => {
+    expect(
+      legacyEntrySourcePath({
+        types: './dist/components/timeline-item/index.d.ts',
+        svelte: './src/components/timeline-item/index.ts',
+        default: './dist/components/timeline-item/index.js',
+      }),
+    ).toBe('./src/components/timeline-item/index.ts');
+  });
+
+  it('falls back to default when svelte is absent (e.g. JSON-only entries)', () => {
+    expect(
+      legacyEntrySourcePath({
+        import: './components.json',
+        default: './components.json',
+      }),
+    ).toBe('./components.json');
+  });
+
+  it('returns undefined for a bare-string entry so the caller preserves it conservatively', () => {
+    expect(legacyEntrySourcePath('./package.json')).toBeUndefined();
+  });
+
+  it('returns undefined when neither svelte nor default is present', () => {
+    expect(legacyEntrySourcePath({ types: './dist/foo/index.d.ts' })).toBeUndefined();
+  });
+});
+
+describe('shouldPreserveLegacyEntry', () => {
+  // A throwaway package root holding one real source file. The existence guard
+  // resolves entry source paths against this root, so we can prove it drops a
+  // stale entry (source gone) and keeps a live one (source present).
+  let packageRoot: string;
+
+  beforeAll(() => {
+    packageRoot = mkdtempSync(join(tmpdir(), 'cinder-exports-guard-'));
+    const livePath = join(packageRoot, 'src/components/live/index.ts');
+    mkdirSync(dirname(livePath), { recursive: true });
+    writeFileSync(livePath, 'export {};\n');
+  });
+
+  afterAll(() => {
+    rmSync(packageRoot, { recursive: true, force: true });
+  });
+
+  it('preserves a legacy entry whose on-disk source still exists', () => {
+    expect(
+      shouldPreserveLegacyEntry(
+        { svelte: './src/components/live/index.ts', default: './dist/components/live/index.js' },
+        packageRoot,
+      ),
+    ).toBe(true);
+  });
+
+  it('drops a legacy entry whose on-disk source is gone (hidden/renamed component)', () => {
+    expect(
+      shouldPreserveLegacyEntry(
+        {
+          svelte: './src/components/ghost/index.ts',
+          default: './dist/components/ghost/index.js',
+        },
+        packageRoot,
+      ),
+    ).toBe(false);
+  });
+
+  it('preserves conservatively when the source path cannot be determined', () => {
+    expect(shouldPreserveLegacyEntry('./package.json', packageRoot)).toBe(true);
+    expect(shouldPreserveLegacyEntry({ types: './dist/foo/index.d.ts' }, packageRoot)).toBe(true);
   });
 });
 

--- a/packages/components/scripts/generate-exports.ts
+++ b/packages/components/scripts/generate-exports.ts
@@ -132,6 +132,41 @@ export function stylesExport(cssPath: string): ExportEntry {
 }
 
 /**
+ * The package-relative source path a legacy export entry resolves from, used to
+ * test whether its on-disk target still exists. Prefers the `svelte` condition
+ * (the authored source) and falls back to `default`; returns `undefined` when
+ * neither is present (e.g. a bare-string entry), in which case the caller
+ * preserves the entry conservatively rather than dropping it.
+ */
+export function legacyEntrySourcePath(
+  entry: ExportEntry | JsonExportEntry | string,
+): string | undefined {
+  if (typeof entry === 'string') return undefined;
+  const svelte = 'svelte' in entry ? entry.svelte : undefined;
+  return svelte ?? entry.default;
+}
+
+/**
+ * Whether a legacy flat export entry should survive a regeneration. An entry is
+ * preserved when its on-disk source still exists (a genuine partial-migration
+ * flat file) and dropped when the target is gone (e.g. a component made internal
+ * via `_<name>`), making the legacy pass self-healing for hides/renames. When
+ * the source path can't be determined ({@link legacyEntrySourcePath} returns
+ * `undefined`), the entry is preserved conservatively rather than dropped.
+ *
+ * Shared by generate mode (which omits dropped entries) and check mode (which
+ * flags them as drift) so the two modes never disagree about a stale entry.
+ */
+export function shouldPreserveLegacyEntry(
+  entry: ExportEntry | JsonExportEntry | string,
+  packageRoot: string = DEFAULT_PACKAGE_ROOT,
+): boolean {
+  const sourcePath = legacyEntrySourcePath(entry);
+  if (!sourcePath) return true;
+  return existsSync(join(packageRoot, sourcePath));
+}
+
+/**
  * Canonical four-condition entry for `@lostgradient/cinder/highlighters/shiki`. Hand-shaped
  * because the adapter is a single static sub-path (not a discovered component
  * and not an upstream re-export); the generator stitches this in alongside
@@ -674,7 +709,12 @@ async function main(): Promise<void> {
         continue;
       if (key === './manifest') continue;
       const flatPattern = /^\.\/(experimental\/)?[a-z][a-z0-9-]*$/;
-      if (flatPattern.test(key)) legacy[key] = entry;
+      if (!flatPattern.test(key)) continue;
+      // Self-heal hides/renames: a legacy entry whose on-disk target is gone
+      // (e.g. a component made internal via `_<name>`) must NOT be resurrected.
+      // Only preserve genuinely-legacy flat files that still exist.
+      if (!shouldPreserveLegacyEntry(entry)) continue;
+      legacy[key] = entry;
     }
 
     for (const [key, entry] of Object.entries(computed)) {
@@ -751,14 +791,21 @@ async function main(): Promise<void> {
       }
     }
 
-    for (const key of Object.keys(existing)) {
+    for (const [key, entry] of Object.entries(existing)) {
       if (RESERVED_KEYS.has(key)) continue;
       if (key in computed) continue;
-      // Pre-migration flat component subpath that hasn't been migrated yet —
-      // leave it alone during the partial-migration window. The check is
-      // intentionally non-strict here.
       const flatPattern = /^\.\/(experimental\/)?[a-z][a-z0-9-]*$/;
-      if (flatPattern.test(key)) continue;
+      if (flatPattern.test(key)) {
+        // Pre-migration flat component subpath that hasn't been migrated yet —
+        // leave it alone during the partial-migration window. But a stale entry
+        // whose on-disk source is gone (a hidden/renamed component) is drift:
+        // generate mode would drop it, so check mode must flag it rather than
+        // silently passing — otherwise the two modes disagree.
+        if (!shouldPreserveLegacyEntry(entry)) {
+          issues.push(`Stale legacy subpath export: "${key}" (on-disk source no longer exists)`);
+        }
+        continue;
+      }
       issues.push(`Orphan subpath export: "${key}"`);
     }
 


### PR DESCRIPTION
## Summary

Closes #438.

`scripts/generate-exports.ts` has a "preserve legacy flat component subpaths (partial-migration window)" pass that carries forward any flat `./<name>` export key from the prior `package.json#exports` when the name is no longer in the freshly-discovered component set. It **did not** check that the entry's on-disk target still existed — so hiding or renaming a component (e.g. `timeline-item` → `_timeline-item` to make it internal) **resurrected** the stale `./timeline-item` export pointing at `./src/components/timeline-item/index.ts`, a path that no longer exists.

This change guards preservation on existence so the pass is self-healing for hides/renames while still preserving genuinely-legacy flat files that DO exist:

- New `legacyEntrySourcePath(entry)` — resolves the package-relative source path of an export entry (prefers the `svelte` source condition, falls back to `default`; `undefined` for bare-string entries).
- New `shouldPreserveLegacyEntry(entry, packageRoot?)` — `existsSync`-guards the resolved source path; preserves conservatively when the path can't be determined. **Shared by both generate and check mode** so the two never disagree.
- **Generate mode** drops a legacy entry whose source is gone.
- **Check mode** now flags it as drift (`Stale legacy subpath export: "<key>"`) instead of silently passing — previously `exports:check` could report clean on a `package.json` that `exports:generate` would change. This check↔generate asymmetry was surfaced by the review committee and is the main delta beyond the originally-filed fix.

## Review committee

Pre-reviewed by: typescript-expert, testing-expert, simplicity-engineer, junior-engineer
- Codex (gpt-5.4, xhigh round 1 / high round 2)
- 2 rounds of review — round-1 surfaced one must-fix (the generate/check asymmetry), which was implemented and re-reviewed
- All must-fix items addressed; round 2 reached unanimous APPROVED

## Test plan

- `bun run test scripts/generate-exports.test.ts` — added `legacyEntrySourcePath` (4 cases) and `shouldPreserveLegacyEntry` (temp-dir: live-source kept / gone-source dropped / undetermined-path conservatively preserved). 41 pass, 0 fail.
- `tsc --noEmit -p tsconfig.check.json` — clean.
- `bun run exports:check` — idempotent on the clean tree.
- Manual repro: rename a component dir to `_<name>` → `exports:generate` no longer resurrects `./<name>` (self-heals); `exports:check` now exits 1 with `Stale legacy subpath export: "<name>"` (previously passed silently).
- Full `@lostgradient/cinder` pre-commit + scoped pre-push suites green.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build/CI tooling only (`generate-exports`); no runtime consumer behavior beyond correcting invalid export entries after component hides or renames.
> 
> **Overview**
> Fixes **legacy flat `./<name>` export preservation** so hidden or renamed components (e.g. `timeline-item` → `_timeline-item`) are no longer **re-exported** after regeneration when their source path is gone.
> 
> Adds **`legacyEntrySourcePath`** (prefer `svelte`, else `default`) and **`shouldPreserveLegacyEntry`** (`existsSync` on that path; conservative keep when the path is unknown). **Generate** skips stale legacy keys; **check** reports **`Stale legacy subpath export`** instead of passing quietly, so **`exports:generate` and `exports:check` agree**.
> 
> Unit tests cover path resolution and a temp-dir existence guard.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 114e3d5f8c341e84ede4e92a4c9f9d03d24edd15. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->