### PR TITLE
chore(release): downgrade indigo-palette changeset to minor (0.3.0)

### DIFF
--- a/.changeset/indigo-brand-palette.md
+++ b/.changeset/indigo-brand-palette.md
@@ -1,5 +1,5 @@
 ---
-'@lostgradient/cinder': major
+'@lostgradient/cinder': minor
 ---
 
 Retune the color palette around an indigo brand, polish the command-palette and timeline, and remove the deprecated experimental-timeline aliases (a breaking export-map change — see below).

--- a/.changeset/indigo-brand-palette.md
+++ b/.changeset/indigo-brand-palette.md
@@ -2,7 +2,7 @@
 '@lostgradient/cinder': minor
 ---
 
-Retune the color palette around an indigo brand, polish the command-palette and timeline, and remove the deprecated experimental-timeline aliases (a breaking export-map change — see below).
+Retune the color palette around an indigo brand, polish the command-palette and timeline, and remove the previously-deprecated experimental-timeline aliases (a pre-1.0 export-map removal shipping in this minor — see the migration note below).
 
 **Palette (visible default change for every consumer):**
 
@@ -16,4 +16,4 @@ Retune the color palette around an indigo brand, polish the command-palette and 
 
 **Timeline:** the connector line now runs continuously from each marker's center to the next marker's center, instead of leaving stubby gaps that didn't reach the dots. The geometry is derived from the marker's center coordinates — the marker is a fixed-size box (`--_cinder-timeline-marker-size`) that custom `marker` snippets fill rather than resize — so the line meets the dot in the default and custom-marker examples alike. The previous fixed-offset calibration left the line short of the next dot.
 
-**Removed the deprecated `@lostgradient/cinder/experimental/timeline` and `@lostgradient/cinder/experimental/timeline-item` export paths.** Import from `@lostgradient/cinder/timeline` and `@lostgradient/cinder/timeline-item` instead.
+**Migration — removed the previously-deprecated `@lostgradient/cinder/experimental/timeline` and `@lostgradient/cinder/experimental/timeline-item` export paths.** These aliases were deprecated once the stable paths shipped; removing them pre-1.0 ships as a minor (no major bump). Import from `@lostgradient/cinder/timeline` and `@lostgradient/cinder/timeline-item` instead.


### PR DESCRIPTION
## Summary

Changes the `indigo-brand-palette` changeset from `major` → `minor` so the pending changeset batch releases as **0.3.0** instead of **1.0.0**, and rewords its body so the rendered changelog no longer describes a minor release as "breaking."

The user asked for a minor release. The pending set (3 minor + 5 patch) included one `major` changeset — the indigo palette rebrand plus removal of the deprecated `@lostgradient/cinder/experimental/timeline*` export paths. At pre-1.0, semver permits shipping breaking changes under a minor bump, so this downgrades to `minor`; `changeset version` will now produce `0.2.0 → 0.3.0`, and the changelog still surfaces the migration note verbatim.

### Changes
- `.changeset/indigo-brand-palette.md`: frontmatter `major` → `minor`.
- Reworded the body: "a breaking export-map change" → "a pre-1.0 export-map removal shipping in this minor", and the removed-aliases paragraph is now an explicit "Migration —" note (the aliases were deprecated once the stable paths shipped; removal ships as a minor with no major bump; import from `.../timeline` and `.../timeline-item`).

## Review committee

Pre-reviewed by: git-workflow-manager, simplicity-engineer
- Codex (gpt-5.4, xhigh→high reasoning) — 2 rounds
- 2 rounds of review; all must-fix items addressed
- Round-1 must-fix (consensus git-workflow-manager + Codex): changelog renders the changeset body verbatim, so calling a `minor` release "breaking" would be permanently inconsistent — reworded. All three members APPROVED in round 2.

## Test plan

- `bunx changeset status` reports the batch bumping `@lostgradient/cinder` at **minor** (no `major` remaining) → 0.3.0.
- After merge to `main`: the release workflow opens the "Version Packages" PR (0.2.0 → 0.3.0 + manifest regen). Merging that PR publishes 0.3.0 to npm via OIDC Trusted Publishing.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes to a changeset file; no application code, exports, or runtime behavior change in this PR.
> 
> **Overview**
> **Release metadata only:** updates `.changeset/indigo-brand-palette.md` so the pending `@lostgradient/cinder` bump is **minor** instead of **major**, steering the next versioned release toward **0.3.0** rather than **1.0.0** when the changeset batch runs.
> 
> The changeset body is reworded so the published changelog no longer labels this as a breaking release: the experimental timeline export removal is framed as a **pre-1.0 migration** shipping under a minor bump, with an explicit **Migration —** section instead of “breaking export-map change” language.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eb8d5151c5f009dbfbd83fe970c82eb0b574afd7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->