### PR TITLE
fix(playground): render compound component live previews via featured example

### DIFF
--- a/.changeset/playground-compound-live-preview.md
+++ b/.changeset/playground-compound-live-preview.md
@@ -1,0 +1,9 @@
+---
+'@cinder/playground': patch
+---
+
+Fix the Playground live preview for compound components (Accordion, Tabs, …).
+
+The Playground synthesizes a plain-text `children` control seeded with the component's display name, which renders a real labelled instance for text-content components (Badge, Button). For compound components whose `children` must be structured sub-components (`<Accordion.Item>`), that text seed rendered a semantically broken preview — the literal word "Accordion" floating in an empty `.cinder-accordion` shell with no items.
+
+The analyzer now flags compound components (`isCompound`, detected from the sibling `index.ts` `Object.assign(Root, { … })` namespace assembly). For those components the Playground no longer synthesizes a text `children` control and no longer mounts the bare component (which would throw on the required, unsynthesizable `children` snippet). It falls back to the featured-example mount instead — a real composed instance — while the remaining real controls (e.g. Accordion's `multiple`) still drive the copyable snippet. Plain-text components are unaffected.

--- a/packages/playground/src/analyze.test.ts
+++ b/packages/playground/src/analyze.test.ts
@@ -464,4 +464,37 @@ describe('analyzeComponent — bare <script module> block', () => {
 
     expect(manifest.props).toEqual([]);
   });
+
+  it('treats a fixture with no sibling index.ts as non-compound', async () => {
+    // A fixture written to the temp dir has no index.ts beside it, so compound
+    // detection returns false without throwing.
+    const filePath = await writeFixture(
+      'loose',
+      `<script lang="ts">
+  let { label }: { label?: string } = $props();
+</script>
+
+<span>{label}</span>`,
+    );
+    const manifest = await analyzeComponent(filePath);
+    expect(manifest.isCompound).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Compound detection (isCompound)
+// ---------------------------------------------------------------------------
+
+describe('analyzeComponent — isCompound', () => {
+  it('flags a compound component whose sibling index.ts uses Object.assign', async () => {
+    // Accordion assembles `Accordion.Item` onto the root via Object.assign.
+    const manifest = await analyzeComponent(componentPath('accordion'));
+    expect(manifest.isCompound).toBe(true);
+  });
+
+  it('leaves a non-compound component unflagged', async () => {
+    // Badge renders plain-text children and has no sub-component namespace.
+    const manifest = await analyzeComponent(componentPath('badge'));
+    expect(manifest.isCompound).toBeUndefined();
+  });
 });

--- a/packages/playground/src/analyze.test.ts
+++ b/packages/playground/src/analyze.test.ts
@@ -486,15 +486,76 @@ describe('analyzeComponent — bare <script module> block', () => {
 // ---------------------------------------------------------------------------
 
 describe('analyzeComponent — isCompound', () => {
-  it('flags a compound component whose sibling index.ts uses Object.assign', async () => {
+  // Each index.ts-shape case gets its OWN temp directory: a sibling `index.ts`
+  // written next to one fixture must not leak into another fixture's detection.
+  let compoundDir: string;
+
+  beforeAll(() => {
+    compoundDir = mkdtempSync(join(tmpdir(), 'cinder-compound-'));
+  });
+
+  afterAll(() => {
+    rmSync(compoundDir, { recursive: true, force: true });
+  });
+
+  /** Write a `.svelte` + sibling `index.ts` into an isolated subdir; return the .svelte path. */
+  async function writeComponentWithIndex(subdir: string, indexSource: string): Promise<string> {
+    const dir = join(compoundDir, subdir);
+    const sveltePath = join(dir, `${subdir}.svelte`);
+    await Bun.write(
+      sveltePath,
+      `<script lang="ts">
+  let { children }: { children?: unknown } = $props();
+</script>`,
+    );
+    await Bun.write(join(dir, 'index.ts'), indexSource);
+    return sveltePath;
+  }
+
+  it('flags a real compound component (Accordion) whose index.ts uses Object.assign', async () => {
     // Accordion assembles `Accordion.Item` onto the root via Object.assign.
     const manifest = await analyzeComponent(componentPath('accordion'));
     expect(manifest.isCompound).toBe(true);
   });
 
-  it('leaves a non-compound component unflagged', async () => {
+  it('leaves a real non-compound component (Badge) unflagged', async () => {
     // Badge renders plain-text children and has no sub-component namespace.
     const manifest = await analyzeComponent(componentPath('badge'));
+    expect(manifest.isCompound).toBeUndefined();
+  });
+
+  it('flags a namespace assembled via Object.assign(Root, { … })', async () => {
+    const sveltePath = await writeComponentWithIndex(
+      'widget',
+      `import WidgetRoot from './widget.svelte';
+const Widget = Object.assign(WidgetRoot, { Item: {} });
+export default Widget;`,
+    );
+    const manifest = await analyzeComponent(sveltePath);
+    expect(manifest.isCompound).toBe(true);
+  });
+
+  it('does NOT flag a config-merge Object.assign({}, …)', async () => {
+    // An object-literal first argument is a config merge, not namespace assembly —
+    // the leading-identifier requirement excludes it.
+    const sveltePath = await writeComponentWithIndex(
+      'merger',
+      `import MergerRoot from './merger.svelte';
+export const defaults = Object.assign({}, { size: 'md' });
+export default MergerRoot;`,
+    );
+    const manifest = await analyzeComponent(sveltePath);
+    expect(manifest.isCompound).toBeUndefined();
+  });
+
+  it('does NOT flag an Object.assign that appears only in a comment', async () => {
+    const sveltePath = await writeComponentWithIndex(
+      'commented',
+      `import CommentedRoot from './commented.svelte';
+// historically used Object.assign(CommentedRoot, { Item }) — no longer.
+export default CommentedRoot;`,
+    );
+    const manifest = await analyzeComponent(sveltePath);
     expect(manifest.isCompound).toBeUndefined();
   });
 });

--- a/packages/playground/src/analyze.ts
+++ b/packages/playground/src/analyze.ts
@@ -11,7 +11,7 @@
  * the manifest. If the Props type has a property not in the destructuring, it is skipped.
  */
 
-import { basename, join } from 'node:path';
+import { basename, dirname, join } from 'node:path';
 
 import type { Expression, Pattern, Property, SpreadElement } from 'estree';
 import { type AST, parse } from 'svelte/compiler';
@@ -501,6 +501,22 @@ function toPascalCase(kebab: string): string {
   return kebab.replace(/(^|-)([a-z])/g, (_, _sep, char: string) => char.toUpperCase());
 }
 
+/**
+ * Detect whether a component is a compound namespace by inspecting its sibling
+ * `index.ts`. Compound roots assemble their public sub-components onto the root
+ * constructor with `Object.assign(Root, { Item: … })` — that call is the
+ * authoritative signal that consumers compose the component as `Accordion.Item`
+ * rather than passing plain-text children. Flat-layout components have no
+ * sibling `index.ts`, so the read simply returns `false`.
+ *
+ * @param svelteFilePath - Absolute path to the component's `.svelte` file.
+ */
+async function detectCompound(svelteFilePath: string): Promise<boolean> {
+  const indexFile = Bun.file(join(dirname(svelteFilePath), 'index.ts'));
+  if (!(await indexFile.exists())) return false;
+  return /Object\.assign\(/.test(await indexFile.text());
+}
+
 // ---------------------------------------------------------------------------
 // Main analysis function
 // ---------------------------------------------------------------------------
@@ -558,12 +574,15 @@ export async function analyzeComponent(filePath: string): Promise<ComponentManif
     props.push(manifest);
   }
 
+  const isCompound = await detectCompound(filePath);
+
   return {
     name: componentName,
     kebabName: fileBaseName,
     file: filePath,
     importPath: `@lostgradient/cinder/${fileBaseName}`,
     props,
+    ...(isCompound ? { isCompound: true } : {}),
   };
 }
 

--- a/packages/playground/src/analyze.ts
+++ b/packages/playground/src/analyze.ts
@@ -502,19 +502,39 @@ function toPascalCase(kebab: string): string {
 }
 
 /**
+ * The canonical compound-namespace assembly: `Object.assign(<Root>, { … })`,
+ * where `<Root>` is the bare root-component identifier. This is the convention
+ * every compound component's `index.ts` uses to graft its public sub-components
+ * onto the root (e.g. `Object.assign(AccordionRoot, { Item: AccordionItem })`),
+ * and it is load-bearing for {@link detectCompound} — a compound component that
+ * assembled its namespace another way (direct `Root.Item = …`, a spread) would
+ * not be detected. The leading-identifier requirement (`,` after it) excludes
+ * `Object.assign({}, …)` config-merge uses, which take an object literal first.
+ */
+const COMPOUND_NAMESPACE_PATTERN = /Object\.assign\(\s*[A-Za-z_$][\w$]*\s*,/;
+
+/** Strip `//` line comments and block comments so the pattern test sees code only. */
+function stripComments(source: string): string {
+  return source.replace(/\/\*[\s\S]*?\*\//g, '').replace(/\/\/.*$/gm, '');
+}
+
+/**
  * Detect whether a component is a compound namespace by inspecting its sibling
  * `index.ts`. Compound roots assemble their public sub-components onto the root
  * constructor with `Object.assign(Root, { Item: … })` — that call is the
  * authoritative signal that consumers compose the component as `Accordion.Item`
- * rather than passing plain-text children. Flat-layout components have no
- * sibling `index.ts`, so the read simply returns `false`.
+ * rather than passing plain-text children. Comments are stripped first so an
+ * `Object.assign` reference in prose never trips the check, and the pattern
+ * requires a leading identifier so an `Object.assign({}, …)` config merge is not
+ * mistaken for namespace assembly. Flat-layout components have no sibling
+ * `index.ts`, so the read simply returns `false`.
  *
  * @param svelteFilePath - Absolute path to the component's `.svelte` file.
  */
 async function detectCompound(svelteFilePath: string): Promise<boolean> {
   const indexFile = Bun.file(join(dirname(svelteFilePath), 'index.ts'));
   if (!(await indexFile.exists())) return false;
-  return /Object\.assign\(/.test(await indexFile.text());
+  return COMPOUND_NAMESPACE_PATTERN.test(stripComments(await indexFile.text()));
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/playground/src/component-page-live-preview-fixture.svelte
+++ b/packages/playground/src/component-page-live-preview-fixture.svelte
@@ -43,6 +43,13 @@
     bareComponentModule?: unknown;
     /** Export name `resolveBareComponent` looks up first (mirrors `exportName`). */
     exportName?: string;
+    /**
+     * Whether the documented component is a compound namespace. Mirrors the page's
+     * `documentation.propsManifest.isCompound` gate: when `true`, the bare component
+     * is never resolved (a bare mount would throw on its required structured
+     * `children`), so the preview always takes the featured-example fallback.
+     */
+    isCompound?: boolean;
     /** The featured example component used when the bare component can't mount. */
     featuredExample?: unknown;
     /** Scenario id for the featured-example container, mirroring the page. */
@@ -58,6 +65,7 @@
   let {
     bareComponentModule,
     exportName = 'Demo',
+    isCompound = false,
     featuredExample,
     featuredScenario = 'demo',
     snapshotMode = false,
@@ -82,8 +90,13 @@
   }
 
   // Resolve + mount via the SAME production helpers the page uses, so a passing
-  // test means the real page logic works, not a fixture copy of it.
-  const bareComponent = $derived(resolveBareComponent(bareComponentModule, exportName));
+  // test means the real page logic works, not a fixture copy of it. The
+  // `isCompound` short-circuit mirrors the page's `bareComponent` $derived: a
+  // compound component never resolves a bare constructor (it would throw on its
+  // required structured `children`), so it always takes the featured fallback.
+  const bareComponent = $derived(
+    isCompound ? undefined : resolveBareComponent(bareComponentModule, exportName),
+  );
   const liveMountFailed = $derived(mountErrors[LIVE_MOUNT_CONTAINER_ID] !== undefined);
   const mountLivePreview = createLivePreviewMount({ mountErrors });
 

--- a/packages/playground/src/component-page-live-preview.test.ts
+++ b/packages/playground/src/component-page-live-preview.test.ts
@@ -264,6 +264,33 @@ describe('component-page live preview (#405)', () => {
     unmount();
   });
 
+  test('a compound component never bare-mounts even when the bare component IS resolvable', async () => {
+    // The load-bearing gate of the compound fix: `isCompound` must suppress the
+    // live bare mount regardless of whether the export resolves. Here `LiveProbe`
+    // IS a perfectly mountable component, yet the compound flag forces the
+    // featured-example fallback — a bare `<Accordion multiple>` with no children
+    // would throw on `{@render children()}`. This distinguishes the compound path
+    // from the "unresolvable export" path above, which only the page-layer gate
+    // (mirrored here) prevents.
+    const { unmount } = render(Fixture, {
+      bareComponentModule: asNamedModule(LiveProbe),
+      exportName: 'Demo',
+      isCompound: true,
+      featuredExample: FeaturedProbe,
+      featuredScenario: 'demo',
+      initialValues: { multiple: false },
+    });
+    await tick();
+
+    // No live mount despite a resolvable component; the featured example renders.
+    expect(liveProbeCount()).toBe(0);
+    expect(mountCount()).toBe(0);
+    expect(document.querySelector('.scenario-probe')).not.toBeNull();
+    expect(document.querySelector('.dx-stage__label')?.textContent).toBe('Featured example');
+
+    unmount();
+  });
+
   test('falls back to the featured example when the live mount fails', async () => {
     // A component whose constructor throws stands in for a bare mount that fails
     // (an unsynthesized required snippet, a missing context provider, …). With a

--- a/packages/playground/src/component-page-playground.test.ts
+++ b/packages/playground/src/component-page-playground.test.ts
@@ -7,6 +7,10 @@ function manifest(props: PropManifest[]): ComponentManifest {
   return { name: 'Demo', kebabName: 'demo', file: 'demo.svelte', importPath: 'demo', props };
 }
 
+function compoundManifest(props: PropManifest[]): ComponentManifest {
+  return { ...manifest(props), isCompound: true };
+}
+
 describe('buildPlaygroundModel', () => {
   test('classifies boolean/select/text/number props into controls', () => {
     const model = buildPlaygroundModel(
@@ -108,6 +112,43 @@ describe('buildPlaygroundModel', () => {
       isChildren: true,
       value: 'Demo',
     });
+  });
+
+  test('a compound component does NOT synthesize a text children control', () => {
+    // Accordion-shaped: a `multiple` boolean plus a required structured-children
+    // snippet. The compound flag means `children` are `<Accordion.Item>` elements,
+    // not plain text, so seeding the display name would render a broken preview.
+    const model = buildPlaygroundModel(
+      compoundManifest([
+        {
+          name: 'multiple',
+          control: { kind: 'boolean' },
+          bindable: false,
+          optional: true,
+          defaultValue: false,
+        },
+        { name: 'children', control: { kind: 'snippet' }, bindable: false, optional: false },
+      ]),
+    );
+    // `children` is skipped (shown as "not adjustable here"), never synthesized,
+    // and the remaining `multiple` control keeps the playground visible.
+    expect(model.controls.map((control) => control.name)).toEqual(['multiple']);
+    expect(model.skipped).toEqual(['children']);
+    expect(model.controls.find((control) => control.name === 'children')).toBeUndefined();
+    expect(model.hasUnsatisfiedRequired).toBe(false);
+  });
+
+  test('a compound component whose only prop is children yields no controls', () => {
+    // With children skipped and nothing else adjustable, the playground model is
+    // empty so the page suppresses the generated Playground section entirely and
+    // leans on the Examples/Overview previews for real usage.
+    const model = buildPlaygroundModel(
+      compoundManifest([
+        { name: 'children', control: { kind: 'snippet' }, bindable: false, optional: false },
+      ]),
+    );
+    expect(model.controls).toEqual([]);
+    expect(model.skipped).toEqual(['children']);
   });
 
   test('a non-children snippet prop stays non-adjustable (skipped)', () => {

--- a/packages/playground/src/component-page-playground.ts
+++ b/packages/playground/src/component-page-playground.ts
@@ -142,7 +142,13 @@ export function buildPlaygroundModel(manifest: ComponentManifest): PlaygroundMod
         // labelled instance out of the box. Marked `isChildren` so the snippet
         // renders it as element content (`<X>text</X>`) and the mount converts it
         // to a children snippet, rather than emitting it as an attribute.
-        if (prop.name === 'children' && prop.control.kind === 'snippet') {
+        //
+        // Compound components are EXCLUDED: their `children` must be structured
+        // sub-components (`<Accordion.Item>`), so seeding plain text would render
+        // a semantically broken preview (loose text in an empty `.cinder-accordion`
+        // shell). They skip the control and fall back to the featured-example
+        // mount instead — see {@link ComponentManifest.isCompound}.
+        if (prop.name === 'children' && prop.control.kind === 'snippet' && !manifest.isCompound) {
           controls.push({
             ...base,
             kind: 'text',

--- a/packages/playground/src/component-page.svelte
+++ b/packages/playground/src/component-page.svelte
@@ -851,9 +851,18 @@
                   <h2 class="dx-section__title">Playground</h2>
                   <span class="dx-section__rule" aria-hidden="true"></span>
                 </div>
-                <p class="dx-prose dx-play__intro">
-                  Adjust the props below — the snippet updates live. Copy it when it looks right.
-                </p>
+                {#if documentation.propsManifest.isCompound}
+                  <p class="dx-prose dx-play__intro">
+                    Adjust the props below to build your snippet. This is a compound component — its
+                    children are structured sub-components, so the preview shows a composed example
+                    rather than your control changes. The snippet updates live.
+                  </p>
+                {:else}
+                  <p class="dx-prose dx-play__intro">
+                    Adjust the props below — the preview and snippet update live. Copy it when it
+                    looks right.
+                  </p>
+                {/if}
 
                 <div class="dx-play">
                   <div class="dx-play__preview">

--- a/packages/playground/src/component-page.svelte
+++ b/packages/playground/src/component-page.svelte
@@ -411,8 +411,15 @@
   // bundle, by the documented `exportName` (falling back to the default export).
   // `undefined` when the module wasn't provided or the export isn't a component,
   // in which case the section degrades to the static featured-example mount.
+  //
+  // Compound components (Accordion, Tabs, …) resolve to `undefined` here on
+  // purpose: their `children` are structured sub-components the playground can't
+  // synthesize, so a bare mount with no children would throw
+  // (`{@render children()}` on `undefined`). They take the featured-example
+  // fallback, whose mount renders a real composed instance — see
+  // `documentation.propsManifest.isCompound`.
   const bareComponent = $derived(
-    documentation === null
+    documentation === null || documentation.propsManifest.isCompound === true
       ? undefined
       : resolveBareComponent(bareComponentModule, documentation.component.exportName),
   );

--- a/packages/playground/src/types.ts
+++ b/packages/playground/src/types.ts
@@ -31,4 +31,14 @@ export type ComponentManifest = {
   file: string;
   importPath: string;
   props: PropManifest[];
+  /**
+   * True when the component is a compound namespace — its sibling `index.ts`
+   * assembles sub-components onto the root via `Object.assign` (e.g.
+   * `Accordion.Item`). Such a component's `children` must be those structured
+   * sub-components, never plain text, so the playground neither synthesizes a
+   * text `children` control for it nor mounts it bare in the live preview
+   * (a bare mount with no children throws — `{@render children()}` on
+   * `undefined`). It falls back to the featured example instead.
+   */
+  isCompound?: boolean;
 };


### PR DESCRIPTION
## Summary

The component docs-page **Playground** live preview rendered a broken, meaningless preview for **compound components** like Accordion — it showed the literal text "Accordion" floating in an empty `.cinder-accordion` shell instead of a real accordion.

**Root cause:** The playground synthesizes a plain-text `children` control seeded with the component's display name. That works great for text-content components (Badge → `<Badge>Badge</Badge>`), but compound components require structured sub-component children (`<Accordion.Item>`), so the text seed produces semantically broken output. Mounting the bare component with no children would instead throw (`{@render children()}` on `undefined`).

**Fix:**
- The analyzer flags compound components (`isCompound`) by detecting the `Object.assign(<Root>, { … })` namespace assembly in the sibling `index.ts` (the convention every compound uses to expose `Accordion.Item` etc.).
- For compound components, the playground **no longer synthesizes a text `children` control** and **no longer mounts the bare component** — it falls back to the existing **featured-example** mount, which renders a real composed instance.
- The remaining real controls (e.g. Accordion's `multiple`) still render and still drive the copyable snippet. A compound-specific intro notice makes it explicit that the preview is a composed example and controls update the snippet.
- Plain-text components (Badge, Button, …) are completely unaffected.

Verified in a real browser: Accordion and Tabs now render real interactive widgets under "Featured example" (with the `multiple` toggle updating the snippet `<Accordion />` → `<Accordion multiple />`); Badge keeps its live editable "Live preview". No console errors.

## Review committee

Pre-reviewed by: typescript-expert, svelte-expert, testing-expert, simplicity-engineer, frontend-architect, junior-engineer
- Codex (gpt-5.4, xhigh→high reasoning) — 2 rounds
- 2 rounds of review; all must-fix items addressed (page-layer test coverage for the gate; pre-interaction compound notice; hardened detection regex + guard tests)
- Final round: unanimous APPROVED

### Known limitations (non-blocking, surfaced by the committee)
Compound detection is a documented heuristic keyed on the `Object.assign(<Identifier>, …)` convention all 15 current compounds use uniformly. It would **not** detect a future compound assembled via a cast (`Object.assign(Root as Foo, …)`), a member expression (`Object.assign(ns.Root, …)`), or direct `Root.Item = …`; and a future barrel that exported a utility using `Object.assign(target, …)` could false-positive. Neither case exists today. A lint rule enforcing the convention is a reasonable future follow-up.

## Test plan

- `cd packages/playground && bun run test` — full suite green (854 pass / 0 fail), including:
  - `analyze.test.ts` — `isCompound` detection (real Accordion flags, Badge doesn't, namespace-assembly flags, config-merge `Object.assign({}, …)` and comment-only refs do NOT), each in an isolated temp dir.
  - `component-page-playground.test.ts` — compound components skip the text `children` control; children-only compound yields no controls.
  - `component-page-live-preview.test.ts` — a compound component never bare-mounts even when its bare component IS resolvable (it takes the featured-example fallback).
- `bun run typecheck` — 0 errors (tsc + svelte-check).
- Browser-verified Accordion, Tabs (compound → featured example) and Badge (text → live preview).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Playground/docs UX only; behavior is gated on a documented `index.ts` heuristic with tests. No auth, data, or public API surface changes beyond manifest metadata.
> 
> **Overview**
> Fixes broken Playground live previews for **compound components** (Accordion, Tabs, etc.) that previously showed the display name as loose text in an empty shell.
> 
> The analyzer now sets **`isCompound`** on manifests by reading the sibling `index.ts` for `Object.assign(Root, { … })` namespace assembly (comments stripped; `Object.assign({}, …)` and comment-only matches excluded). **`ComponentManifest`** documents the flag.
> 
> For compounds, **`buildPlaygroundModel`** no longer synthesizes a text **`children`** control; **`children`** is skipped while other props (e.g. `multiple`) still drive the copyable snippet. **`component-page.svelte`** skips bare live mount when `isCompound` is true and uses the **featured example** preview instead, with a compound-specific Playground intro. Plain-text components are unchanged.
> 
> Tests cover detection, playground model behavior, and the live-preview gate (including bare mount suppressed even when the export resolves). A patch changeset is included.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cdbe8996a1af26824880139e9f15b050d228007b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->