### PR TITLE
Fix Steps vertical alignment

### DIFF
--- a/packages/components/src/components/steps/steps.css
+++ b/packages/components/src/components/steps/steps.css
@@ -162,6 +162,7 @@
   .cinder-steps[data-cinder-orientation='vertical'] .cinder-steps__body {
     grid-column: 2;
     grid-row: 1 / span 2;
+    padding-block-start: 0;
     padding-bottom: var(--cinder-space-4);
   }
 
@@ -392,6 +393,7 @@
       max-width: none;
       grid-column: 2;
       grid-row: 1 / span 2;
+      padding-block-start: 0;
       padding-bottom: var(--cinder-space-4);
     }
 
@@ -401,16 +403,15 @@
      * column. In the narrow grid the marker sits in column 1 and the body in
      * column 2 beside it, so the box must fill its grid cell and stay in flow —
      * otherwise the higher-specificity wide rule's margin/align-self/inline-size
-     * would leak in and misplace the body. Restore the static-body grid spacing
-     * (the body's existing space-2 padding-top is re-asserted by the
-     * .cinder-steps__interactive.cinder-steps__body base rule). */
+     * would leak in and misplace the body. Reset the block-start padding too so
+     * the label content starts on the marker row, matching the vertical layout. */
     .cinder-steps[data-cinder-orientation='horizontal']
       .cinder-steps__interactive.cinder-steps__body {
       inline-size: 100%;
       max-inline-size: none;
       align-self: stretch;
       margin-block-start: 0;
-      padding-block-start: var(--cinder-space-2);
+      padding-block-start: 0;
     }
   }
 }

--- a/packages/components/src/components/steps/steps.test.ts
+++ b/packages/components/src/components/steps/steps.test.ts
@@ -314,6 +314,13 @@ describe('Steps — interactive step items', () => {
       /\.cinder-steps\[data-cinder-orientation='vertical'\]\s*\.cinder-steps__interactive\.cinder-steps__body\s*\{[^}]*padding-bottom:\s*var\(--cinder-space-4\);/m,
     );
   });
+
+  test('vertical step bodies align label content with the marker row', () => {
+    const match = stepsCss.match(
+      /\.cinder-steps\[data-cinder-orientation='vertical'\]\s*\.cinder-steps__body\s*\{(?<body>[^}]*)\}/m,
+    );
+    expect(match?.groups?.['body']).toContain('padding-block-start: 0;');
+  });
 });
 
 // Layout geometry is not observable in happy-dom (no layout engine), so these
@@ -499,6 +506,9 @@ describe('Steps — narrow horizontal fallback (CSS contract)', () => {
       /\.cinder-steps\[data-cinder-orientation='horizontal'\]\s*\.cinder-steps__body\s*\{/,
     );
     expect(body).toMatch(/text-align:\s*start;/);
+    // The grid fallback should match the vertical layout: label content starts
+    // on the marker row instead of inheriting the wide body's top padding.
+    expect(body).toMatch(/padding-block-start:\s*0;/);
   });
 
   test('narrow interactive body undoes the wide marker-capture geometry', () => {
@@ -512,5 +522,6 @@ describe('Steps — narrow horizontal fallback (CSS contract)', () => {
     expect(body).toMatch(/inline-size:\s*100%;/);
     expect(body).toMatch(/align-self:\s*stretch;/);
     expect(body).toMatch(/margin-block-start:\s*0;/);
+    expect(body).toMatch(/padding-block-start:\s*0;/);
   });
 });


### PR DESCRIPTION
## Summary
- remove inherited block-start padding from vertical Steps body content
- align narrow horizontal fallback spacing with the vertical layout
- add CSS-contract tests for vertical and narrow fallback alignment

## Review committee
Pre-reviewed by: ux-designer, testing-expert, simplicity-engineer, Codex
- Codex (gpt-5.4, xhigh reasoning) — 1 round
- 1 round of review
- All reviewer suggestions addressed

## Test plan
- bun run --filter=@lostgradient/cinder test -- steps
- bun run --filter=@lostgradient/cinder typecheck
- bun run --filter=@lostgradient/cinder lint
- bunx prettier --check packages/components/src/components/steps/steps.css packages/components/src/components/steps/steps.test.ts
- pre-commit hook: @lostgradient/cinder typecheck + test
- pre-push hook: scoped lint, typecheck, and tests
- browser geometry check on /page/steps?snapshot=1

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only spacing in Steps CSS; wide horizontal layout and behavior are unchanged.
> 
> **Overview**
> Fixes **Steps** label vertical alignment when the body sits beside the marker (vertical orientation and the narrow horizontal container fallback).
> 
> **`steps.css`** sets **`padding-block-start: 0`** on vertical step bodies so labels line up with the marker row instead of inheriting the base body’s top padding. The same reset is applied in the narrow horizontal grid for static and interactive bodies; narrow interactive bodies no longer re-apply **`space-2`** block-start padding (which had leaked from the wide horizontal focus-ring geometry).
> 
> **`steps.test.ts`** adds CSS-contract assertions for vertical body alignment and for **`padding-block-start: 0`** on narrow static and interactive body rules.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8f679ad76a3257ddb9f3106f9db88e19acb4ec4f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->