### PR TITLE
Fix anchored overlay server imports

### DIFF
--- a/packages/components/src/_internal/anchored-overlay.svelte.ts
+++ b/packages/components/src/_internal/anchored-overlay.svelte.ts
@@ -72,6 +72,17 @@ function getArrowStyle(placement: Placement, data: { x?: number; y?: number } | 
     .join(' ');
 }
 
+function reportAnchoredOverlaySetupError(error: unknown): void {
+  if (typeof globalThis.reportError === 'function') {
+    globalThis.reportError(error);
+    return;
+  }
+
+  setTimeout(() => {
+    throw error;
+  }, 0);
+}
+
 export function createAnchoredOverlay(options: AnchoredOverlayOptions) {
   let positionReady = $state(false);
   let positionStyle = $state('');
@@ -164,7 +175,11 @@ export function createAnchoredOverlay(options: AnchoredOverlayOptions) {
       });
     })().catch((error) => {
       if (cancelled) return;
-      throw error;
+      positionReady = false;
+      positionStyle = '';
+      arrowStyle = '';
+      resolvedPlacement = placement;
+      reportAnchoredOverlaySetupError(error);
     });
 
     return () => {

--- a/packages/components/src/_internal/anchored-overlay.svelte.ts
+++ b/packages/components/src/_internal/anchored-overlay.svelte.ts
@@ -1,12 +1,4 @@
 import type { Middleware, Placement, ReferenceElement } from '@floating-ui/dom';
-import {
-  arrow as arrowMiddleware,
-  autoUpdate,
-  computePosition,
-  flip,
-  offset as offsetMiddleware,
-  shift,
-} from '@floating-ui/dom';
 
 export type AnchoredOverlayWidthMode = 'content' | 'match-anchor' | 'menu' | 'none';
 
@@ -114,53 +106,70 @@ export function createAnchoredOverlay(options: AnchoredOverlayOptions) {
     const widthMode = options.widthMode?.() ?? 'content';
     let cancelled = false;
     let generation = 0;
+    let stopAutoUpdate: (() => void) | undefined;
 
-    const middleware: Middleware[] = [
-      offsetMiddleware(offset),
-      flip(),
-      shift({ padding: shiftPadding, crossAxis: shiftCrossAxis }),
-    ];
-    if (showArrow && arrow) {
-      middleware.push(arrowMiddleware({ element: arrow, padding: arrowPadding }));
-    }
+    void (async () => {
+      const {
+        arrow: arrowMiddleware,
+        autoUpdate,
+        computePosition,
+        flip,
+        offset: offsetMiddleware,
+        shift,
+      } = await import('@floating-ui/dom');
 
-    const stop = autoUpdate(anchor, panel, async () => {
       if (cancelled) return;
-      const currentGeneration = ++generation;
-      let result: Awaited<ReturnType<typeof computePosition>>;
-      try {
-        result = await computePosition(anchor, panel, {
-          placement,
-          middleware,
-          strategy: 'fixed',
-        });
-      } catch {
-        if (cancelled || currentGeneration !== generation) return;
-        positionReady = false;
-        positionStyle = '';
-        arrowStyle = '';
-        resolvedPlacement = placement;
-        return;
-      }
-      if (cancelled || currentGeneration !== generation) return;
 
-      const widthStyle = getAnchoredOverlayWidthStyle(widthMode, anchor.getBoundingClientRect());
-      positionStyle = [
-        'position: fixed;',
-        `left: ${result.x}px;`,
-        `top: ${result.y}px;`,
-        widthStyle,
-      ]
-        .filter(Boolean)
-        .join(' ');
-      resolvedPlacement = result.placement;
-      arrowStyle = showArrow ? getArrowStyle(result.placement, result.middlewareData.arrow) : '';
-      positionReady = true;
+      const middleware: Middleware[] = [
+        offsetMiddleware(offset),
+        flip(),
+        shift({ padding: shiftPadding, crossAxis: shiftCrossAxis }),
+      ];
+      if (showArrow && arrow) {
+        middleware.push(arrowMiddleware({ element: arrow, padding: arrowPadding }));
+      }
+
+      stopAutoUpdate = autoUpdate(anchor, panel, async () => {
+        if (cancelled) return;
+        const currentGeneration = ++generation;
+        let result: Awaited<ReturnType<typeof computePosition>>;
+        try {
+          result = await computePosition(anchor, panel, {
+            placement,
+            middleware,
+            strategy: 'fixed',
+          });
+        } catch {
+          if (cancelled || currentGeneration !== generation) return;
+          positionReady = false;
+          positionStyle = '';
+          arrowStyle = '';
+          resolvedPlacement = placement;
+          return;
+        }
+        if (cancelled || currentGeneration !== generation) return;
+
+        const widthStyle = getAnchoredOverlayWidthStyle(widthMode, anchor.getBoundingClientRect());
+        positionStyle = [
+          'position: fixed;',
+          `left: ${result.x}px;`,
+          `top: ${result.y}px;`,
+          widthStyle,
+        ]
+          .filter(Boolean)
+          .join(' ');
+        resolvedPlacement = result.placement;
+        arrowStyle = showArrow ? getArrowStyle(result.placement, result.middlewareData.arrow) : '';
+        positionReady = true;
+      });
+    })().catch((error) => {
+      if (cancelled) return;
+      throw error;
     });
 
     return () => {
       cancelled = true;
-      stop();
+      stopAutoUpdate?.();
       positionReady = false;
       positionStyle = '';
       arrowStyle = '';

--- a/packages/components/src/_internal/anchored-overlay.test.ts
+++ b/packages/components/src/_internal/anchored-overlay.test.ts
@@ -1,5 +1,6 @@
 /// <reference lib="dom" />
 import { describe, expect, test } from 'bun:test';
+import { compileModule } from 'svelte/compiler';
 
 import { getAnchoredOverlayWidthStyle } from './anchored-overlay.svelte.ts';
 
@@ -29,5 +30,18 @@ describe('anchored overlay width styles', () => {
 
   test('none leaves width entirely to the component stylesheet', () => {
     expect(getAnchoredOverlayWidthStyle('none', { width: 320 })).toBe('');
+  });
+
+  test('server compilation omits Floating UI runtime imports', async () => {
+    const sourcePath = `${import.meta.dir}/anchored-overlay.svelte.ts`;
+    const source = await Bun.file(sourcePath).text();
+    const moduleSource = new Bun.Transpiler({ loader: 'ts' }).transformSync(source);
+    const result = compileModule(moduleSource, {
+      filename: sourcePath,
+      generate: 'server',
+      dev: false,
+    });
+
+    expect(result.js.code).not.toContain('@floating-ui/dom');
   });
 });


### PR DESCRIPTION
## Summary

- Move the anchored overlay Floating UI runtime import into the client-only `$effect` path.
- Keep Floating UI as a type-only top-level import so Svelte server compilation no longer emits unused runtime imports.
- Add a regression test that compiles the rune module for server output and asserts `@floating-ui/dom` is omitted.

Closes #452.

## Verification

- `bun run --filter=@lostgradient/cinder test src/_internal/anchored-overlay.test.ts`
- `bun run --filter=@lostgradient/cinder test src/components/tooltip/tooltip.test.ts src/components/popover/popover.test.ts src/components/hover-card/hover-card.test.ts src/components/context-menu/context-menu.test.ts src/components/command-menu/command-menu.test.ts src/components/markdown-editor/editor-toolbar/link-popover.test.ts`
- `bun run --filter=@lostgradient/cinder lint`
- `bun run --filter=@lostgradient/cinder typecheck`
- `bun run --filter=@lostgradient/cinder build`
- `bun run --filter=@lostgradient/cinder validate:consumer`
- `bun run --filter=@lostgradient/cinder test:coverage`
- Pre-commit hook: lint-staged, `@lostgradient/cinder typecheck`, `@lostgradient/cinder test`
- Pre-push hook: scoped lint, typecheck, and test gates

## Committee Review

- `frontend-architect`: approved
- `testing-expert`: approved
- `simplicity-engineer`: approved
- Mandatory Codex reviewer: approved after the round 1 catch-path must-fix was amended

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped internal overlay helper change with preserved positioning behavior; main risk is async import/cleanup edge cases, mitigated by cancellation and error reporting.
> 
> **Overview**
> Fixes **SSR/server bundles** pulling in `@floating-ui/dom` from `createAnchoredOverlay` by keeping **type-only** top-level imports and loading Floating UI **inside the open `$effect`** via `await import('@floating-ui/dom')` before `autoUpdate` / `computePosition` run.
> 
> Setup failures (e.g. failed dynamic import) now **reset overlay positioning state** and surface through **`reportAnchoredOverlaySetupError`** (`reportError` or async rethrow), with effect teardown calling **`stopAutoUpdate?.()`** when the async path has not finished yet.
> 
> Adds a **regression test** that server-compiles the rune module and asserts generated code does **not** contain `@floating-ui/dom`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a8ef8adc708792d80b2fec564991ade136365e3b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->