### PR TITLE
Fix AccessGate release validation timeout

### DIFF
--- a/packages/components/src/components/access-gate/access-gate.test.ts
+++ b/packages/components/src/components/access-gate/access-gate.test.ts
@@ -18,7 +18,7 @@ const { default: AccessGateFocusFixture } =
 const { default: AccessGateStatefulFixture } =
   await import('../../test/fixtures/access-gate-stateful-fixture.svelte');
 const { createRawSnippet, tick } = await import('svelte');
-const { checkBuildFlagHydrationSafety } = await import('../../test/hydration-safety.ts');
+const { renderToServerHtml } = await import('../../test/server-render.ts');
 
 const accessGateSsrFixturePath = new URL(
   '../../test/fixtures/access-gate-ssr-fixture.svelte',
@@ -356,10 +356,8 @@ describe('AccessGate', () => {
   });
 
   test('denied inline gates server-render visible controls with a hydration activation guard', async () => {
-    const { buildFlagInvariant, serverHtml: body } =
-      await checkBuildFlagHydrationSafety(accessGateSsrFixturePath);
+    const body = await renderToServerHtml(accessGateSsrFixturePath);
 
-    expect(buildFlagInvariant).toBe(true);
     expect(body).toContain('inert');
     expect(body).toContain('Cancel workflow');
     expect(body).toContain('Requires scope: workflows:cancel');

--- a/packages/components/src/test/server-render.ts
+++ b/packages/components/src/test/server-render.ts
@@ -25,11 +25,66 @@
 
 /// <reference lib="dom" />
 
-import { rm, writeFile } from 'node:fs/promises';
-import { dirname, join } from 'node:path';
+import type { BunPlugin } from 'bun';
+import { unlinkSync } from 'node:fs';
+import { dirname, isAbsolute, join, resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
 
 import type { Component } from 'svelte';
-import { compile } from 'svelte/compiler';
+import { compile, compileModule } from 'svelte/compiler';
+
+function serverCompilePlugin(): BunPlugin {
+  const namespace = 'server-render-svelte-server';
+  const isFileSpecifier = (specifier: string): boolean =>
+    isAbsolute(specifier) || specifier.startsWith('.');
+
+  return {
+    name: 'server-render-svelte-server',
+    setup(builder) {
+      builder.onResolve({ filter: /\.svelte$/ }, ({ path, importer, resolveDir }) => {
+        if (!isFileSpecifier(path)) return undefined;
+        const baseDirectory = importer ? dirname(importer) : resolveDir;
+        return {
+          path: isAbsolute(path) ? path : resolve(baseDirectory, path),
+          namespace,
+        };
+      });
+
+      builder.onLoad({ filter: /\.svelte$/, namespace }, async ({ path }) => {
+        const source = await Bun.file(path).text();
+        const result = compile(source, {
+          filename: path,
+          generate: 'server',
+          css: 'external',
+          dev: false,
+        });
+        return { contents: result.js.code, loader: 'js' };
+      });
+
+      builder.onResolve({ filter: /\.svelte\.(js|ts)$/ }, ({ path, importer, resolveDir }) => {
+        if (!isFileSpecifier(path)) return undefined;
+        const baseDirectory = importer ? dirname(importer) : resolveDir;
+        return {
+          path: isAbsolute(path) ? path : resolve(baseDirectory, path),
+          namespace,
+        };
+      });
+
+      builder.onLoad({ filter: /\.svelte\.(js|ts)$/, namespace }, async ({ path }) => {
+        const source = await Bun.file(path).text();
+        const moduleSource = path.endsWith('.ts')
+          ? new Bun.Transpiler({ loader: 'ts' }).transformSync(source)
+          : source;
+        const result = compileModule(moduleSource, {
+          filename: path,
+          generate: 'server',
+          dev: false,
+        });
+        return { contents: result.js.code, loader: 'js' };
+      });
+    },
+  };
+}
 
 /**
  * Render `sourcePath`'s component on the server and return the emitted HTML.
@@ -42,41 +97,84 @@ export async function renderToServerHtml<Props extends Record<string, unknown>>(
   sourcePath: string,
   props: Props = {} as Props,
 ): Promise<string> {
-  const source = await Bun.file(sourcePath).text();
-  const compiled = compile(source, {
-    filename: sourcePath,
-    generate: 'server',
-    css: 'external',
-    dev: false,
+  const build = await Bun.build({
+    entrypoints: [sourcePath],
+    target: 'bun',
+    conditions: ['svelte'],
+    external: ['svelte', 'svelte/*'],
+    plugins: [serverCompilePlugin()],
   });
+  if (!build.success) {
+    const logText = build.logs.map((log) => String(log.message ?? log)).join('\n');
+    throw new Error(`server-render: server build failed for ${sourcePath}\n${logText}`);
+  }
+  const artifact = build.outputs[0];
+  if (!artifact) throw new Error(`server-render: no server artifact for ${sourcePath}`);
 
   // Resolve Svelte's server index and repoint the compiled module's bare
   // `svelte` imports at it. The temp module is imported in a `browser`-condition
   // process, which would otherwise resolve `svelte` to its client build and make
   // server-side lifecycle calls (`onDestroy`, `setContext`) throw.
   const sveltePackageUrl = import.meta.resolve('svelte/package.json');
-  const serverIndexUrl = new URL('./src/index-server.js', sveltePackageUrl).href;
-  const code = compiled.js.code.replaceAll(
-    /from ['"]svelte['"]/g,
-    `from ${JSON.stringify(serverIndexUrl)}`,
+  const serverAbortSignalUrl = new URL('./src/internal/server/abort-signal.js', sveltePackageUrl)
+    .href;
+  const serverContextUrl = new URL('./src/internal/server/context.js', sveltePackageUrl).href;
+  const serverErrorsUrl = new URL('./src/internal/server/errors.js', sveltePackageUrl).href;
+  const serverHydratableUrl = new URL('./src/internal/server/hydratable.js', sveltePackageUrl).href;
+  const serverInternalUrl = new URL('./src/internal/server/index.js', sveltePackageUrl).href;
+  const serverSnippetUrl = new URL('./src/internal/server/blocks/snippet.js', sveltePackageUrl)
+    .href;
+  const sharedUtilitiesUrl = new URL('./src/internal/shared/utils.js', sveltePackageUrl).href;
+
+  const sourceDir = dirname(sourcePath);
+  const ssrFileName = `.cinder-ssr-${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+  const file = join(sourceDir, `${ssrFileName}.mjs`);
+  const serverRuntimeShimPath = join(sourceDir, `${ssrFileName}.svelte-server.mjs`);
+  const serverRuntimeShimUrl = pathToFileURL(serverRuntimeShimPath).href;
+
+  await Bun.write(
+    serverRuntimeShimPath,
+    [
+      `import { ssr_context } from ${JSON.stringify(serverContextUrl)};`,
+      `import { noop } from ${JSON.stringify(sharedUtilitiesUrl)};`,
+      `import * as e from ${JSON.stringify(serverErrorsUrl)};`,
+      `export { noop as beforeUpdate, noop as afterUpdate, noop as onMount, noop as flushSync, run as untrack } from ${JSON.stringify(sharedUtilitiesUrl)};`,
+      `export { createContext, getAllContexts, getContext, hasContext, setContext } from ${JSON.stringify(serverContextUrl)};`,
+      `export { getAbortSignal } from ${JSON.stringify(serverAbortSignalUrl)};`,
+      `export { hydratable } from ${JSON.stringify(serverHydratableUrl)};`,
+      `export { createRawSnippet } from ${JSON.stringify(serverSnippetUrl)};`,
+      'export function createEventDispatcher() { return noop; }',
+      'export function onDestroy(fn) { ssr_context.r.on_destroy(fn); }',
+      'export async function tick() {}',
+      'export async function settled() {}',
+      "export function mount() { e.lifecycle_function_unavailable('mount'); }",
+      "export function hydrate() { e.lifecycle_function_unavailable('hydrate'); }",
+      "export function unmount() { e.lifecycle_function_unavailable('unmount'); }",
+      "export function fork() { e.lifecycle_function_unavailable('fork'); }",
+      '',
+    ].join('\n'),
   );
+  let code = await artifact.text();
+  code = code
+    .replaceAll(
+      /from\s*['"]svelte\/internal\/server['"]/g,
+      `from ${JSON.stringify(serverInternalUrl)}`,
+    )
+    .replaceAll(/from\s*['"]svelte['"]/g, `from ${JSON.stringify(serverRuntimeShimUrl)}`);
 
   // Write the compiled SSR module **in the same directory** as the source so its
   // relative imports (e.g. `../../utilities/class-names.ts`) resolve identically,
   // and `svelte/internal/server` still resolves through the package's node_modules
   // tree. A `.mjs` extension keeps Bun's `.svelte.js` preload plugin from trying
   // to recompile our already-compiled output.
-  const sourceDir = dirname(sourcePath);
-  const ssrFileName = `.cinder-ssr-${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2)}.mjs`;
-  const file = join(sourceDir, ssrFileName);
-  await writeFile(file, code, 'utf-8');
+  await Bun.write(file, code);
 
   try {
     // The SSR module's default export is a server-only render function whose
     // shape doesn't match the public `Component<Props>` type. `render` accepts
     // it at runtime; we route through `unknown` because the public types are too
     // narrow to express the dual-target reality.
-    const ssrModule = (await import(file)) as { default: unknown };
+    const ssrModule = (await import(pathToFileURL(file).href)) as { default: unknown };
     const { render } = (await import('svelte/server')) as typeof import('svelte/server');
 
     // Clear happy-dom's `document`/`window` globals around the server render.
@@ -98,6 +196,15 @@ export async function renderToServerHtml<Props extends Record<string, unknown>>(
     }
   } finally {
     // Best-effort cleanup of the temp module. A stray file never breaks a test.
-    void rm(file, { force: true }).catch(() => {});
+    try {
+      unlinkSync(file);
+    } catch {
+      // Already gone; ignore.
+    }
+    try {
+      unlinkSync(serverRuntimeShimPath);
+    } catch {
+      // Already gone; ignore.
+    }
   }
 }


### PR DESCRIPTION
## Summary
- Replace the AccessGate SSR regression test's expensive build-flag hydration helper with a direct server-render assertion.
- Teach the shared server-render test helper to build imported Svelte graphs in server mode, including relative `.svelte` and `.svelte.ts` modules.
- Keep the build-flag invariant covered by the dedicated hydration-safety tests while preserving AccessGate's SSR contract assertions.

## Root Cause
The `0.3.0` release failed in `bun run validate` because the AccessGate test used `checkBuildFlagHydrationSafety`, which can perform four Bun builds on first use. The test has the default 5s timeout, and under GitHub Actions release load it timed out at about 5015ms before publish steps ran. AccessGate does not depend on `BROWSER`, so the build-flag invariant was unnecessary for that component-level SSR regression.

## Verification
- `bun run --filter=@lostgradient/cinder test -- ./src/components/access-gate/access-gate.test.ts`
- `bun run --filter=@lostgradient/cinder test -- ./src/components/drawer/drawer.test.ts ./src/components/sheet/sheet.test.ts ./src/components/image/image.test.ts ./src/components/chat-conversation-header/ssr-probe.test.ts ./src/components/chat-conversation-list/ssr-probe.test.ts`
- `TZ=UTC LANG=en_US.UTF-8 bun test --conditions browser --conditions svelte --parallel=1 --coverage --coverage-reporter=lcov ./packages/components/src/components/access-gate/access-gate.test.ts`
- `bun run --filter=@lostgradient/cinder typecheck`
- `bun run --filter=@lostgradient/cinder test:coverage`
- `bun run --filter=@lostgradient/cinder lint`
- `bun run validate`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to test infrastructure and one test swap; no production runtime or AccessGate component behavior is modified.
> 
> **Overview**
> Fixes release `validate` timeouts by dropping the AccessGate SSR test’s **`checkBuildFlagHydrationSafety`** path (multiple Bun builds on first use) in favor of **`renderToServerHtml`**, while keeping the same SSR markup checks (`inert`, labels, reason text).
> 
> **`renderToServerHtml`** no longer compiles only the entry `.svelte` file: it runs **`Bun.build`** with a **`serverCompilePlugin`** that server-compiles relative **`.svelte`** and **`.svelte.(js|ts)`** imports, then rewrites **`svelte`** / **`svelte/internal/server`** imports through a generated **server runtime shim** before dynamic import and **`svelte/server` `render()`**. Temp artifact cleanup now removes both the compiled module and the shim.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0b9955750d0c7729e7bc413ac5608049cda9ec9c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->