### PR TITLE
Refresh documentation sweep

### DIFF
--- a/.agents/skills/tasks/SKILL.md
+++ b/.agents/skills/tasks/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: tasks
-description: "Tasks CLI — inspect or update the local task graph for this project. Use when working with the `tasks` CLI, choosing new work, decomposing documents into tasks, or managing the local task database under tmp/tasks.db."
+description: 'Tasks CLI — inspect or update the local task graph for this project. Use when working with the `tasks` CLI, choosing new work, decomposing documents into tasks, or managing the local task database under tmp/tasks.db.'
 allowed-tools: Read, Grep, Glob, Bash, Write, Edit
 ---
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -103,7 +103,7 @@ The moving parts:
 
 ### The tradeoff (read this)
 
-The full site is rendered at build time (≈90s for ~90 components / ~1500 files), so deploys are slower than a function deploy but every request is served instantly from static assets with no runtime compilation. Because the export is a point-in-time snapshot, the deployed playground reflects the components as of the build — re-deploy to pick up component changes (the GitHub workflow does this automatically on push to `main`). For an internal component playground this is the right tradeoff; the live, watch-mode dev server (`bun run dev`) remains the authoring experience.
+The full site is rendered at build time, so deploys are slower than a function deploy but every request is served instantly from static assets with no runtime compilation. Because the export is a point-in-time snapshot, the deployed playground reflects the components as of the build — re-deploy to pick up component changes (the GitHub workflow does this automatically on push to `main`). For an internal component playground this is the right tradeoff; the live, watch-mode dev server (`bun run dev`) remains the authoring experience.
 
 ### One-time setup (a human must do this — it is not automated)
 

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 Components for product interfaces.
 
-The published package is `@lostgradient/cinder`: accessible primitives, domain-suite components, design-system tokens, per-component CSS, generated prop schemas, and examples that can be read by people or tooling. The current generated manifest lists 155 public component entries across action, data-display, domain, feedback, form, layout, navigation, overlay, and typography categories.
+The published package is `@lostgradient/cinder`: accessible primitives, domain-suite components, design-system tokens, per-component CSS, generated prop schemas, and examples that can be read by people or tooling. The current generated manifest lists 167 public component entries across action, data-display, domain, feedback, form, layout, navigation, overlay, and typography categories.
 
-Use Cinder when you want UI building blocks without adopting a framework-level router, form-state manager, data layer, or theme provider. The package is SSR-safe.
+Use Cinder when you want UI building blocks without adopting a framework-level router, form-state manager, data fetching layer, global state provider, or theme provider. The package is SSR-safe.
 
 ## Install
 
@@ -123,7 +123,7 @@ Cinder is a presentation library, not an application framework.
 
 - No router.
 - No form-state manager.
-- No toast queue store.
+- No application-wide toast singleton; use `ToastRegion` for scoped toast UI.
 - No data fetching layer.
 - No global state provider.
 - No general-purpose icon library for product-specific icons.

--- a/bun.lock
+++ b/bun.lock
@@ -43,7 +43,7 @@
     },
     "packages/components": {
       "name": "@lostgradient/cinder",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "dependencies": {
         "@floating-ui/dom": "1.7.6",
         "@lasercat/homogenaize": "^1.2.41",

--- a/packages/components/AGENTS.md
+++ b/packages/components/AGENTS.md
@@ -12,7 +12,7 @@ sections:
 
 ## Using cinder in your app
 
-`@lostgradient/cinder` is a Svelte 5 component library with more than 150 public
+`@lostgradient/cinder` is a Svelte 5 component library with more than 160 public
 component entries across accessible primitives and opinionated domain suites.
 It targets Svelte `>=5.55.0 <6` and is SSR-safe out of the box. Everything ships
 with a JSON Schema, CSS variable list, and (where it matters) a constraints
@@ -322,7 +322,7 @@ the matching entry in `@lostgradient/cinder/manifest`.
 
 | id             | purpose                                                                                                        | use when                                                                                                      |
 | -------------- | -------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------- |
-| `modal`        | Centered modal dialog built on the native dialog element with focus capture, restoration, and dismissal…       | Interrupting the user for a focused task or decision that blocks the rest of the page.                        |
+| `modal`        | Centered modal dialog shell built on the native dialog element with focus capture, restoration, and dismissal… | Presenting rich or structured content that requires user interaction before returning to the page — forms,…   |
 | `drawer`       | Side-anchored modal panel built on the native dialog element for secondary navigation, settings, or long-form… | Showing supplementary navigation, filters, or settings that should slide in from a page edge.                 |
 | `sheet`        | Bottom-anchored modal panel built on the native dialog element with an optional drag handle for mobile-first…  | Presenting a focused task or set of actions that slides up from the bottom of the viewport on touch surfaces. |
 | `popover`      | Anchored floating panel positioned by Floating UI that hosts non-modal contextual content beside a trigger…    | Showing rich, interactive contextual content anchored to a trigger such as a help panel, color picker, or…    |
@@ -353,8 +353,9 @@ scope and you should wire them up yourself:
 - **No router.** Use SvelteKit's router (or your framework's). Components
   like `NavigationItem`, `Breadcrumbs`, and `Tabs` accept `href` props but
   do not own navigation.
-- **No toast queue store.** `ToastRegion` is the render surface and the live
-  region. You build (or import) the queue that pushes toasts at it.
+- **No process-global toast singleton.** `ToastRegion` owns a region-scoped
+  queue and live regions. Mount one where descendants should dispatch, then
+  bridge application events into the nearest region with `useToast()`.
 - **No form-state manager.** Components are uncontrolled-friendly and play
   nicely with `bind:value`. Pair them with a form library of your choice
   (Felte, Superforms, plain `<form>`) for validation, submission, and field
@@ -572,8 +573,8 @@ bun run manifest:generate     # components.json only
 bun run examples:generate     # *.examples.json
 bun run constraints:generate  # *.constraints.json
 bun run exports:generate      # package.json#exports
-bun run agents:generate       # this AGENTS.md overlap-family block
-bun run agents:check          # drift-check this file
+bun run scripts/render-agents-md.ts          # this AGENTS.md overlap-family block
+bun run scripts/render-agents-md.ts --check  # drift-check this file
 ```
 
 For repo-wide git/commit/PR conventions (commit message format, branch

--- a/packages/components/README.md
+++ b/packages/components/README.md
@@ -2,7 +2,7 @@
 
 Svelte 5 components for product interfaces: accessible primitives, design-system tokens, per-component CSS, generated prop schemas, and examples that can be read by people or tooling.
 
-Use cinder when you want UI building blocks without adopting a framework-level state, routing, form, or theme provider. The package is SSR-safe and targets Svelte `>=5.55.0 <6`.
+Use cinder when you want UI building blocks without adopting a framework-level router, form-state manager, data fetching layer, global state provider, or theme provider. The package is SSR-safe and targets Svelte `>=5.55.0 <6`.
 
 ## Install
 
@@ -126,7 +126,7 @@ Cinder is a presentation library, not an application framework.
 
 - No router.
 - No form-state manager.
-- No toast queue store.
+- No application-wide toast singleton; use `ToastRegion` for scoped toast UI.
 - No data fetching layer.
 - No global state provider.
 - No general-purpose icon library for product-specific icons.

--- a/packages/components/scripts/check-placeholder-docs.ts
+++ b/packages/components/scripts/check-placeholder-docs.ts
@@ -19,6 +19,7 @@ const componentsRoot = resolve(scriptDirectory, '..', 'src', 'components');
  */
 const STALE_PHRASES: string[] = [
   'Replace this sentence',
+  'This migration scaffold is incomplete',
   'opt-in highlighting',
 ];
 
@@ -62,9 +63,7 @@ async function main(): Promise<void> {
     process.stderr.write(`    line   : ${line}\n\n`);
   }
 
-  process.stderr.write(
-    'Replace each instance with accurate documentation before merging.\n',
-  );
+  process.stderr.write('Replace each instance with accurate documentation before merging.\n');
   process.exit(1);
 }
 

--- a/packages/components/scripts/component-conventions.ts
+++ b/packages/components/scripts/component-conventions.ts
@@ -232,7 +232,10 @@ function hasAriaOrRoleCall(root: CallExpression): boolean {
 // ---------------------------------------------------------------------------
 
 /** Read a property as a nested record, or `undefined` if it isn't one. */
-function recordProperty(record: Record<string, unknown>, key: string): Record<string, unknown> | undefined {
+function recordProperty(
+  record: Record<string, unknown>,
+  key: string,
+): Record<string, unknown> | undefined {
   const value = record[key];
   return isObjectRecord(value) ? value : undefined;
 }

--- a/packages/components/scripts/migrate-component.ts
+++ b/packages/components/scripts/migrate-component.ts
@@ -491,7 +491,7 @@ export type { ${indexTypes} } from './${name}.types.ts';
   if (!existsSync(readmePath)) {
     const readmeBody = `# ${pascalName}
 
-${isExperimental ? `> **EXPERIMENTAL** — this component's API may change between minor versions until promoted to stable.\n\n` : ''}A ${pascalName} component. Replace this sentence with a one-line purpose statement once the migration settles.
+${isExperimental ? `> **EXPERIMENTAL** — this component's API may change between minor versions until promoted to stable.\n\n` : ''}This migration scaffold is incomplete. Update the component's \`@purpose\` metadata and rerun \`bun run components:generate\` before publishing.
 
 ## Usage
 

--- a/packages/components/scripts/render-agents-md.ts
+++ b/packages/components/scripts/render-agents-md.ts
@@ -122,7 +122,7 @@ async function main(): Promise<void> {
   if (check) {
     if (next !== existing) {
       console.error(
-        `AGENTS.md is out of date. Run \`bun run agents:generate\` to refresh ` +
+        `AGENTS.md is out of date. Run \`bun run scripts/render-agents-md.ts\` to refresh ` +
           `the overlap-family decision aid.`,
       );
       process.exit(1);

--- a/packages/components/src/components/context-menu/_context-menu-test-harness.svelte
+++ b/packages/components/src/components/context-menu/_context-menu-test-harness.svelte
@@ -48,4 +48,3 @@
   <div class="context-menu-selection"></div>
   <output class="context-menu-selected">{selected}</output>
 </div>
-

--- a/packages/components/src/components/json-viewer/json-viewer.test.ts
+++ b/packages/components/src/components/json-viewer/json-viewer.test.ts
@@ -31,8 +31,9 @@ describe('JsonViewer', () => {
     const { container } = render(JsonViewer, { value: { config: { a: 1 } } });
     // Find the toggle button for the nested expandable node whose key is "config"
     const toggleButtons = Array.from(container.querySelectorAll('.cinder-json-viewer__toggle'));
-    const configButton = toggleButtons.find((button) =>
-      button.querySelector('.cinder-json-viewer__key')?.textContent?.trim() === 'config:',
+    const configButton = toggleButtons.find(
+      (button) =>
+        button.querySelector('.cinder-json-viewer__key')?.textContent?.trim() === 'config:',
     );
     expect(configButton).not.toBeNull();
     // The key span must be a DESCENDANT of the button, not a sibling

--- a/packages/components/src/components/tabs/tabs.test.ts
+++ b/packages/components/src/components/tabs/tabs.test.ts
@@ -96,9 +96,7 @@ describe('Tabs font-weight layout stability (regression #402)', () => {
     // Extracting just the [data-cinder-active] block and asserting font-weight is absent
     // prevents the sibling-jank regression: an inactive tab's offsetWidth must not
     // change when a sibling activates.
-    const activeBlockMatch = tabsCss.match(
-      /\.cinder-tab\[data-cinder-active\]\s*\{([^}]*)\}/,
-    );
+    const activeBlockMatch = tabsCss.match(/\.cinder-tab\[data-cinder-active\]\s*\{([^}]*)\}/);
     // The selector must exist (active state is styled).
     expect(activeBlockMatch).not.toBeNull();
     // The block must NOT contain font-weight.

--- a/packages/playground/src/example-error.test.ts
+++ b/packages/playground/src/example-error.test.ts
@@ -87,8 +87,8 @@ describe('formatErrorForClipboard', () => {
   });
 
   it('joins message and stack with a blank line', () => {
-    expect(
-      formatErrorForClipboard({ message: 'oops', stack: 'at a\nat b' }),
-    ).toBe('oops\n\nat a\nat b');
+    expect(formatErrorForClipboard({ message: 'oops', stack: 'at a\nat b' })).toBe(
+      'oops\n\nat a\nat b',
+    );
   });
 });

--- a/packages/playground/src/example-error.ts
+++ b/packages/playground/src/example-error.ts
@@ -52,7 +52,10 @@ export function formatErrorMessage(error: unknown): string {
  * ellipsis marker when content was dropped. Returns `undefined` for an empty or
  * whitespace-only input so the caller can omit the stack block entirely.
  */
-export function truncateStack(stack: string | undefined, maxLength = MAX_STACK_LENGTH): string | undefined {
+export function truncateStack(
+  stack: string | undefined,
+  maxLength = MAX_STACK_LENGTH,
+): string | undefined {
   if (stack === undefined) return undefined;
   const trimmed = stack.trim();
   if (trimmed === '') return undefined;


### PR DESCRIPTION
## Summary

- Update public and package documentation for the current Cinder surface area and scoped `ToastRegion` guidance.
- Refresh generated `AGENTS.md` overlap guidance and correct the documented AGENTS renderer command.
- Tighten placeholder README detection for migration scaffolds and include formatting cleanup required by the repository gate.

## Validation

- `bun run format:check`
- `bun run --filter=@lostgradient/cinder components:check`
- `bun run --filter=@lostgradient/cinder exports:check`
- `bun run --filter=@lostgradient/cinder check:placeholder-docs`
- `cd packages/components && bun run scripts/render-agents-md.ts --check`
- `git diff --check`
- pre-commit hook: `bun run --filter='*' typecheck`, `bun run --filter='*' test`
- pre-push hook: `bun run --filter='*' lint`, `bun run --filter='*' typecheck`, `bun run --filter='*' test`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation, scaffold text, and formatting only; no runtime component or API behavior changes in the diff.
> 
> **Overview**
> This PR **aligns consumer and contributor documentation** with the current package surface: manifest counts (**167** public entries in the root README, **160+** in package `AGENTS.md`), and clearer “not a framework” wording (router, form state, **data fetching**, **global state**, theme) plus **scoped `ToastRegion` / `useToast()`** instead of an app-wide toast singleton.
> 
> **`packages/components/AGENTS.md`** overlap guidance is refreshed (e.g. **`modal`** described as a dialog shell for rich interactive content) and the documented command to regenerate the overlap block is corrected from **`bun run agents:generate`** to **`bun run scripts/render-agents-md.ts`** (including the drift-check error in `render-agents-md.ts`).
> 
> **Migration and quality gates** are tightened: new migration README scaffolds say the scaffold is incomplete (and point at `@purpose` + `components:generate`), **`check-placeholder-docs`** also flags **“This migration scaffold is incomplete”**, and **`migrate-component.ts`** no longer seeds **“Replace this sentence”**. **`bun.lock`** reflects **`@lostgradient/cinder` `0.3.0`**.
> 
> Remaining edits are **Prettier/format** on a few tests and scripts, a shorter playground deploy tradeoff note in **`CONTRIBUTING.md`**, and a trivial whitespace trim in a context-menu test harness.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8bd68f0aef1c0ba9bd758ae07888380faa8f6b08. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->