### PR TITLE
fix(a11y): systemic forced-colors focus-ring fallbacks + lint guard (#460)

### DIFF
--- a/.changeset/forced-colors-focus-ring-fallbacks.md
+++ b/.changeset/forced-colors-focus-ring-fallbacks.md
@@ -1,0 +1,9 @@
+---
+'@lostgradient/cinder': patch
+---
+
+Add `@media (forced-colors: active)` focus-ring fallbacks to nine components whose `:focus-visible` ring relied exclusively on `box-shadow` — which Windows High Contrast Mode (forced-colors) removes. Keyboard focus was invisible in HCM for users of CapabilityGate, KanbanBoard, MediaControls, PermissionMatrix, ShareCard, TransferList, Table, MenuBar, and ChatConversationList.
+
+Each fallback repaints the outline with `ButtonText` at the correct offset for the control type: `3px` for bordered controls (separates the ring from `ButtonBorder`, which shares the `ButtonText` color family in HCM), `2px` for borderless controls, and an inset `calc(-1 * var(--cinder-ring-width))` for the TransferList scrollable panel (which has `overflow: auto` — a positive offset would be clipped). Each fallback also sets `box-shadow: none` explicitly so forced-colors suppression is unambiguous across engines.
+
+A new Stylelint rule (`cinder/require-forced-colors-focus-fallback`) is wired into root `.stylelintrc.json` and into the test suite, so any future `:focus-visible` rule that relies on `box-shadow` without a matching forced-colors fallback will fail linting.

--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -2,7 +2,8 @@
   "plugins": [
     "stylelint-use-logical",
     "./packages/components/scripts/stylelint/no-focus-visible-colored-outline.mjs",
-    "./packages/components/scripts/stylelint/no-unguarded-hover-colors.cjs"
+    "./packages/components/scripts/stylelint/no-unguarded-hover-colors.cjs",
+    "./packages/components/scripts/stylelint/require-forced-colors-focus-fallback.mjs"
   ],
   "overrides": [
     {
@@ -19,6 +20,7 @@
     },
     "cinder/no-focus-visible-colored-outline": true,
     "cinder/no-unguarded-hover-colors": true,
+    "cinder/require-forced-colors-focus-fallback": true,
     "csstools/use-logical": [
       "always",
       {

--- a/packages/components/scripts/stylelint/require-forced-colors-focus-fallback.mjs
+++ b/packages/components/scripts/stylelint/require-forced-colors-focus-fallback.mjs
@@ -1,0 +1,128 @@
+/**
+ * Stylelint rule: cinder/require-forced-colors-focus-fallback.
+ *
+ * A `:focus-visible` rule that relies on `box-shadow` for its visible ring
+ * is invisible in Windows High Contrast Mode (forced-colors), because user
+ * agents are permitted to remove box-shadows in that mode. This rule reports
+ * an error when a `:focus-visible` selector uses `box-shadow` but has no
+ * matching `@media (forced-colors: active)` block in the same file that
+ * repaints the outline for that selector.
+ *
+ * The check is selector-exact: a forced-colors block for `.x:focus-visible`
+ * does NOT exempt `.y:focus-visible` even if they appear in the same rule.
+ * This prevents accidental "cover" from a broad selector masking a gap on a
+ * specific one.
+ *
+ * Authored as ESM (.mjs) because Stylelint loads plugins via Node's module
+ * resolver, not Bun's.
+ */
+
+import stylelint from 'stylelint';
+
+import { isUnderForcedColors } from './focus-ring-helpers.mjs';
+
+const ruleName = 'cinder/require-forced-colors-focus-fallback';
+
+const messages = stylelint.utils.ruleMessages(ruleName, {
+  missingFallback: (selector) =>
+    'The `:focus-visible` selector `' +
+    String(selector) +
+    '` uses `box-shadow` for its focus ring but has no matching ' +
+    '`@media (forced-colors: active)` block with a non-transparent `outline`. ' +
+    'Add a forced-colors fallback so keyboard focus is visible in Windows ' +
+    'High Contrast Mode. See docs/focus-ring-policy.md.',
+});
+
+const meta = {
+  url: 'https://github.com/stevekinney/cinder/blob/main/docs/focus-ring-policy.md',
+};
+
+function selectorMatchesFocusVisible(selector) {
+  return /:focus-visible(?![\w-])/.test(selector);
+}
+
+/**
+ * Normalize a selector string for comparison: collapse runs of whitespace
+ * so that selectors split across multiple lines compare equal to their
+ * single-line equivalents.
+ */
+function normalizeSelector(selector) {
+  return selector.replace(/\s+/g, ' ').trim();
+}
+
+const plugin = stylelint.createPlugin(ruleName, (primary) => {
+  return (root, result) => {
+    const validOptions = stylelint.utils.validateOptions(result, ruleName, {
+      actual: primary,
+      possible: [true],
+    });
+    if (!validOptions) return;
+
+    // Pass 1: collect every :focus-visible selector that uses box-shadow
+    // outside forced-colors mode.
+    /** @type {Map<string, import('postcss').Rule>} normalized-selector → first Rule node */
+    const boxShadowFocusSelectors = new Map();
+
+    root.walkRules((rule) => {
+      if (isUnderForcedColors(rule)) return;
+      if (!rule.selectors.some((s) => selectorMatchesFocusVisible(s))) return;
+
+      let hasBoxShadow = false;
+      rule.walkDecls('box-shadow', () => {
+        hasBoxShadow = true;
+      });
+      if (!hasBoxShadow) return;
+
+      for (const selector of rule.selectors) {
+        if (!selectorMatchesFocusVisible(selector)) continue;
+        const normalized = normalizeSelector(selector);
+        if (!boxShadowFocusSelectors.has(normalized)) {
+          boxShadowFocusSelectors.set(normalized, rule);
+        }
+      }
+    });
+
+    if (boxShadowFocusSelectors.size === 0) return;
+
+    // Pass 2: collect every :focus-visible selector that has a non-transparent
+    // outline inside a forced-colors block.
+    /** @type {Set<string>} normalized selectors with a valid forced-colors fallback */
+    const coveredSelectors = new Set();
+
+    root.walkRules((rule) => {
+      if (!isUnderForcedColors(rule)) return;
+      if (!rule.selectors.some((s) => selectorMatchesFocusVisible(s))) return;
+
+      let hasNonTransparentOutline = false;
+      rule.walkDecls('outline', (decl) => {
+        if (!decl.value.toLowerCase().includes('transparent')) {
+          hasNonTransparentOutline = true;
+        }
+      });
+      if (!hasNonTransparentOutline) return;
+
+      for (const selector of rule.selectors) {
+        if (!selectorMatchesFocusVisible(selector)) continue;
+        coveredSelectors.add(normalizeSelector(selector));
+      }
+    });
+
+    // Report any box-shadow focus selector that has no forced-colors cover.
+    for (const [normalized, ruleNode] of boxShadowFocusSelectors) {
+      if (!coveredSelectors.has(normalized)) {
+        stylelint.utils.report({
+          ruleName,
+          result,
+          node: ruleNode,
+          message: messages.missingFallback(normalized),
+        });
+      }
+    }
+  };
+});
+
+plugin.ruleName = ruleName;
+plugin.messages = messages;
+plugin.meta = meta;
+
+export default plugin;

--- a/packages/components/scripts/stylelint/require-forced-colors-focus-fallback.mjs
+++ b/packages/components/scripts/stylelint/require-forced-colors-focus-fallback.mjs
@@ -38,7 +38,18 @@ const meta = {
 };
 
 function selectorMatchesFocusVisible(selector) {
-  return /:focus-visible(?![\w-])/.test(selector);
+  // A `:focus-visible` that appears only inside `:not(...)` matches elements
+  // that are NOT focus-visible, so the rule must not treat it as a focus ring.
+  // Strip `:not(...)` groups before testing. (Repeated to handle multiple
+  // `:not()` groups in one selector; a fixed iteration count is enough — real
+  // selectors never nest more than a couple.)
+  let stripped = selector;
+  for (let i = 0; i < 5; i += 1) {
+    const next = stripped.replace(/:not\([^()]*\)/g, '');
+    if (next === stripped) break;
+    stripped = next;
+  }
+  return /:focus-visible(?![\w-])/.test(stripped);
 }
 
 /**
@@ -48,6 +59,15 @@ function selectorMatchesFocusVisible(selector) {
  */
 function normalizeSelector(selector) {
   return selector.replace(/\s+/g, ' ').trim();
+}
+
+/**
+ * Whether an `outline` / `outline-color` value paints a visible ring. `none`
+ * and `transparent` are no-ops and do not count as a forced-colors fallback.
+ */
+function isVisibleOutline(value) {
+  const v = value.toLowerCase().trim();
+  return v !== 'none' && !v.includes('transparent');
 }
 
 const plugin = stylelint.createPlugin(ruleName, (primary) => {
@@ -68,8 +88,10 @@ const plugin = stylelint.createPlugin(ruleName, (primary) => {
       if (!rule.selectors.some((s) => selectorMatchesFocusVisible(s))) return;
 
       let hasBoxShadow = false;
-      rule.walkDecls('box-shadow', () => {
-        hasBoxShadow = true;
+      rule.walkDecls('box-shadow', (decl) => {
+        if (decl.value.trim().toLowerCase() !== 'none') {
+          hasBoxShadow = true;
+        }
       });
       if (!hasBoxShadow) return;
 
@@ -93,9 +115,13 @@ const plugin = stylelint.createPlugin(ruleName, (primary) => {
       if (!isUnderForcedColors(rule)) return;
       if (!rule.selectors.some((s) => selectorMatchesFocusVisible(s))) return;
 
+      // A valid fallback paints a visible outline: the `outline` shorthand OR
+      // the `outline-color` longhand, with a real (non-transparent, non-`none`)
+      // color. `outline: none` and `outline-color: transparent` are no-ops and
+      // do not count as a fallback.
       let hasNonTransparentOutline = false;
-      rule.walkDecls('outline', (decl) => {
-        if (!decl.value.toLowerCase().includes('transparent')) {
+      rule.walkDecls(/^outline(-color)?$/, (decl) => {
+        if (isVisibleOutline(decl.value)) {
           hasNonTransparentOutline = true;
         }
       });

--- a/packages/components/scripts/stylelint/require-forced-colors-focus-fallback.test.ts
+++ b/packages/components/scripts/stylelint/require-forced-colors-focus-fallback.test.ts
@@ -1,0 +1,174 @@
+import { describe, expect, test } from 'bun:test';
+
+import stylelint from 'stylelint';
+
+const ruleName = 'cinder/require-forced-colors-focus-fallback';
+const pluginPath = new URL('./require-forced-colors-focus-fallback.mjs', import.meta.url).pathname;
+
+async function lintWithDirectRule(css: string) {
+  return stylelint.lint({
+    code: css,
+    config: {
+      plugins: [pluginPath],
+      rules: { [ruleName]: true },
+    },
+  });
+}
+
+function warningsFor(result: Awaited<ReturnType<typeof stylelint.lint>>, rule = ruleName) {
+  return result.results.flatMap((file) => file.warnings ?? []).filter((w) => w.rule === rule);
+}
+
+describe('cinder/require-forced-colors-focus-fallback — passing fixtures', () => {
+  test('a :focus-visible rule with box-shadow AND a forced-colors outline fallback passes', async () => {
+    const result = await lintWithDirectRule(`
+      .x:focus-visible {
+        outline: var(--cinder-ring-width) solid transparent;
+        box-shadow: var(--_cinder-focus-ring-shadow);
+      }
+      @media (forced-colors: active) {
+        .x:focus-visible {
+          outline: var(--cinder-ring-width) solid ButtonText;
+          outline-offset: 2px;
+        }
+      }
+    `);
+    expect(warningsFor(result)).toEqual([]);
+  });
+
+  test('a :focus-visible rule with no box-shadow does not require a forced-colors fallback', async () => {
+    const result = await lintWithDirectRule(`
+      .x:focus-visible {
+        outline: var(--cinder-ring-width) solid transparent;
+      }
+    `);
+    expect(warningsFor(result)).toEqual([]);
+  });
+
+  test('a non-:focus-visible rule with box-shadow does not trigger the check', async () => {
+    const result = await lintWithDirectRule(`
+      .x:hover {
+        box-shadow: 0 0 0 2px blue;
+      }
+    `);
+    expect(warningsFor(result)).toEqual([]);
+  });
+
+  test('a forced-colors fallback using CanvasText is accepted', async () => {
+    const result = await lintWithDirectRule(`
+      .y:focus-visible {
+        outline: var(--cinder-ring-width) solid transparent;
+        box-shadow: var(--_cinder-focus-ring-shadow);
+      }
+      @media (forced-colors: active) {
+        .y:focus-visible {
+          outline: var(--cinder-ring-width) solid CanvasText;
+        }
+      }
+    `);
+    expect(warningsFor(result)).toEqual([]);
+  });
+
+  test('multiple selectors are each covered by their own forced-colors block', async () => {
+    const result = await lintWithDirectRule(`
+      .a:focus-visible,
+      .b:focus-visible {
+        outline: var(--cinder-ring-width) solid transparent;
+        box-shadow: var(--_cinder-focus-ring-shadow);
+      }
+      @media (forced-colors: active) {
+        .a:focus-visible,
+        .b:focus-visible {
+          outline: var(--cinder-ring-width) solid ButtonText;
+          outline-offset: 2px;
+        }
+      }
+    `);
+    expect(warningsFor(result)).toEqual([]);
+  });
+});
+
+describe('cinder/require-forced-colors-focus-fallback — negative fixture (catches missing fallback)', () => {
+  test('a :focus-visible rule with box-shadow but NO forced-colors fallback is reported', async () => {
+    const result = await lintWithDirectRule(`
+      .missing-fallback:focus-visible {
+        outline: var(--cinder-ring-width) solid transparent;
+        box-shadow: var(--_cinder-focus-ring-shadow);
+      }
+    `);
+    const hits = warningsFor(result);
+    expect(hits.length).toBe(1);
+    expect(hits[0]?.text).toContain('.missing-fallback:focus-visible');
+  });
+
+  test('a forced-colors block with transparent outline does not count as a fallback', async () => {
+    const result = await lintWithDirectRule(`
+      .transparent-fallback:focus-visible {
+        outline: var(--cinder-ring-width) solid transparent;
+        box-shadow: var(--_cinder-focus-ring-shadow);
+      }
+      @media (forced-colors: active) {
+        .transparent-fallback:focus-visible {
+          outline: var(--cinder-ring-width) solid transparent;
+        }
+      }
+    `);
+    const hits = warningsFor(result);
+    expect(hits.length).toBe(1);
+  });
+
+  test('a forced-colors block covering only one selector does not exempt a second uncovered selector', async () => {
+    const result = await lintWithDirectRule(`
+      .covered:focus-visible {
+        outline: var(--cinder-ring-width) solid transparent;
+        box-shadow: var(--_cinder-focus-ring-shadow);
+      }
+      .uncovered:focus-visible {
+        outline: var(--cinder-ring-width) solid transparent;
+        box-shadow: var(--_cinder-focus-ring-shadow);
+      }
+      @media (forced-colors: active) {
+        .covered:focus-visible {
+          outline: var(--cinder-ring-width) solid ButtonText;
+        }
+      }
+    `);
+    const hits = warningsFor(result);
+    expect(hits.length).toBe(1);
+    expect(hits[0]?.text).toContain('.uncovered:focus-visible');
+  });
+});
+
+describe('cinder/require-forced-colors-focus-fallback — severity matches policy', () => {
+  // When the rule is loaded directly (not through .stylelintrc.json which does
+  // not enable it globally to avoid a mass-fix of pre-existing violations in
+  // other components), the default stylelint severity for `true` is `error`.
+  // This prevents any future adoption of the rule at warning level instead.
+  test('a missing forced-colors fallback is reported at error severity when the rule is active', async () => {
+    const result = await lintWithDirectRule(`
+      .unguarded:focus-visible {
+        outline: var(--cinder-ring-width) solid transparent;
+        box-shadow: var(--_cinder-focus-ring-shadow);
+      }
+    `);
+    const hits = warningsFor(result);
+    expect(hits.length).toBeGreaterThan(0);
+    expect(hits[0]?.severity).toBe('error');
+  });
+
+  test('a guarded selector with forced-colors fallback reports no violations', async () => {
+    const result = await lintWithDirectRule(`
+      .guarded:focus-visible {
+        outline: var(--cinder-ring-width) solid transparent;
+        box-shadow: var(--_cinder-focus-ring-shadow);
+      }
+      @media (forced-colors: active) {
+        .guarded:focus-visible {
+          outline: var(--cinder-ring-width) solid ButtonText;
+          outline-offset: 2px;
+        }
+      }
+    `);
+    expect(warningsFor(result)).toEqual([]);
+  });
+});

--- a/packages/components/scripts/stylelint/require-forced-colors-focus-fallback.test.ts
+++ b/packages/components/scripts/stylelint/require-forced-colors-focus-fallback.test.ts
@@ -1,9 +1,15 @@
+import { fileURLToPath } from 'node:url';
+
 import { describe, expect, test } from 'bun:test';
 
 import stylelint from 'stylelint';
 
 const ruleName = 'cinder/require-forced-colors-focus-fallback';
-const pluginPath = new URL('./require-forced-colors-focus-fallback.mjs', import.meta.url).pathname;
+// `fileURLToPath` (not `.pathname`) so the path is correct on Windows and when
+// the repo path contains spaces or URL-encoded characters.
+const pluginPath = fileURLToPath(
+  new URL('./require-forced-colors-focus-fallback.mjs', import.meta.url),
+);
 
 async function lintWithDirectRule(css: string) {
   return stylelint.lint({
@@ -21,6 +27,8 @@ function warningsFor(result: Awaited<ReturnType<typeof stylelint.lint>>, rule = 
 
 describe('cinder/require-forced-colors-focus-fallback — passing fixtures', () => {
   test('a :focus-visible rule with box-shadow AND a forced-colors outline fallback passes', async () => {
+    // Bordered control pattern: 3px offset (matches button.css precedent —
+    // 3px separates the ring from ButtonBorder in HCM), explicit box-shadow:none.
     const result = await lintWithDirectRule(`
       .x:focus-visible {
         outline: var(--cinder-ring-width) solid transparent;
@@ -29,7 +37,8 @@ describe('cinder/require-forced-colors-focus-fallback — passing fixtures', () 
       @media (forced-colors: active) {
         .x:focus-visible {
           outline: var(--cinder-ring-width) solid ButtonText;
-          outline-offset: 2px;
+          outline-offset: 3px;
+          box-shadow: none;
         }
       }
     `);
@@ -54,6 +63,48 @@ describe('cinder/require-forced-colors-focus-fallback — passing fixtures', () 
     expect(warningsFor(result)).toEqual([]);
   });
 
+  test('a :focus-visible rule whose box-shadow is `none` does not require a fallback', async () => {
+    // `box-shadow: none` cannot render a ring, so it needs no forced-colors
+    // fallback. A suppressor (e.g. stripping a decorative pill shadow on a
+    // selected-but-unfocused state) must not be flagged.
+    const result = await lintWithDirectRule(`
+      .x:focus-visible {
+        box-shadow: none;
+      }
+    `);
+    expect(warningsFor(result)).toEqual([]);
+  });
+
+  test('a `:not(:focus-visible)` rule with box-shadow is NOT treated as a focus ring', async () => {
+    // The `:focus-visible` here is negated — the rule matches elements that are
+    // NOT focus-visible, so it can never be a focus ring and needs no fallback.
+    const result = await lintWithDirectRule(`
+      .x[data-selected]:not(:focus-visible) {
+        box-shadow: 0 0 0 2px blue;
+      }
+    `);
+    expect(warningsFor(result)).toEqual([]);
+  });
+
+  test('a `:focus-visible::before` ring is covered by a forced-colors fallback on the same pseudo selector', async () => {
+    // When the visible ring is painted on a `::before` pseudo, the forced-colors
+    // fallback must repaint on that SAME selector (an outline on the parent would
+    // depend on fragile geometry and not hug the visible chip).
+    const result = await lintWithDirectRule(`
+      .x:focus-visible::before {
+        box-shadow: inset 0 0 0 var(--cinder-ring-width) var(--cinder-ring-color);
+      }
+      @media (forced-colors: active) {
+        .x:focus-visible::before {
+          box-shadow: none;
+          outline: var(--cinder-ring-width) solid ButtonText;
+          outline-offset: var(--cinder-ring-offset);
+        }
+      }
+    `);
+    expect(warningsFor(result)).toEqual([]);
+  });
+
   test('a forced-colors fallback using CanvasText is accepted', async () => {
     const result = await lintWithDirectRule(`
       .y:focus-visible {
@@ -63,6 +114,22 @@ describe('cinder/require-forced-colors-focus-fallback — passing fixtures', () 
       @media (forced-colors: active) {
         .y:focus-visible {
           outline: var(--cinder-ring-width) solid CanvasText;
+        }
+      }
+    `);
+    expect(warningsFor(result)).toEqual([]);
+  });
+
+  test('a forced-colors fallback using the `outline-color` longhand is accepted', async () => {
+    const result = await lintWithDirectRule(`
+      .y:focus-visible {
+        outline: var(--cinder-ring-width) solid transparent;
+        box-shadow: var(--_cinder-focus-ring-shadow);
+      }
+      @media (forced-colors: active) {
+        .y:focus-visible {
+          outline-style: solid;
+          outline-color: ButtonText;
         }
       }
     `);
@@ -80,7 +147,8 @@ describe('cinder/require-forced-colors-focus-fallback — passing fixtures', () 
         .a:focus-visible,
         .b:focus-visible {
           outline: var(--cinder-ring-width) solid ButtonText;
-          outline-offset: 2px;
+          outline-offset: 3px;
+          box-shadow: none;
         }
       }
     `);
@@ -117,6 +185,24 @@ describe('cinder/require-forced-colors-focus-fallback — negative fixture (catc
     expect(hits.length).toBe(1);
   });
 
+  test('a forced-colors block with `outline: none` does not count as a fallback', async () => {
+    // A no-op outline must not satisfy the rule — that would silently leave the
+    // control with no visible focus ring in forced-colors mode.
+    const result = await lintWithDirectRule(`
+      .none-fallback:focus-visible {
+        outline: var(--cinder-ring-width) solid transparent;
+        box-shadow: var(--_cinder-focus-ring-shadow);
+      }
+      @media (forced-colors: active) {
+        .none-fallback:focus-visible {
+          outline: none;
+        }
+      }
+    `);
+    const hits = warningsFor(result);
+    expect(hits.length).toBe(1);
+  });
+
   test('a forced-colors block covering only one selector does not exempt a second uncovered selector', async () => {
     const result = await lintWithDirectRule(`
       .covered:focus-visible {
@@ -140,10 +226,9 @@ describe('cinder/require-forced-colors-focus-fallback — negative fixture (catc
 });
 
 describe('cinder/require-forced-colors-focus-fallback — severity matches policy', () => {
-  // When the rule is loaded directly (not through .stylelintrc.json which does
-  // not enable it globally to avoid a mass-fix of pre-existing violations in
-  // other components), the default stylelint severity for `true` is `error`.
-  // This prevents any future adoption of the rule at warning level instead.
+  // The rule is wired into .stylelintrc.json so it runs during `bun run lint`.
+  // The default stylelint severity for `true` is `error`.
+  // This prevents future adoption of the rule at warning level instead.
   test('a missing forced-colors fallback is reported at error severity when the rule is active', async () => {
     const result = await lintWithDirectRule(`
       .unguarded:focus-visible {
@@ -165,7 +250,8 @@ describe('cinder/require-forced-colors-focus-fallback — severity matches polic
       @media (forced-colors: active) {
         .guarded:focus-visible {
           outline: var(--cinder-ring-width) solid ButtonText;
-          outline-offset: 2px;
+          outline-offset: 3px;
+          box-shadow: none;
         }
       }
     `);

--- a/packages/components/src/components/autocomplete/autocomplete.css
+++ b/packages/components/src/components/autocomplete/autocomplete.css
@@ -30,6 +30,14 @@
     box-shadow: var(--_cinder-focus-ring-shadow);
   }
 
+  @media (forced-colors: active) {
+    .cinder-autocomplete__input:focus-visible {
+      outline: var(--cinder-ring-width) solid ButtonText;
+      outline-offset: 3px;
+      box-shadow: none;
+    }
+  }
+
   .cinder-autocomplete__description,
   .cinder-autocomplete__error {
     margin: 0;

--- a/packages/components/src/components/capability-gate/capability-gate.css
+++ b/packages/components/src/components/capability-gate/capability-gate.css
@@ -112,7 +112,11 @@
     .cinder-capability-gate__fallback:focus-visible,
     .cinder-capability-gate__dismiss:focus-visible {
       outline: var(--cinder-ring-width) solid ButtonText;
-      outline-offset: 2px;
+      /* 3px separates the outline from ButtonBorder (which renders in forced-colors
+         on all button-like controls and shares the ButtonText color family in HCM);
+         at 2px the ring and border can visually merge. */
+      outline-offset: 3px;
+      box-shadow: none;
     }
   }
 

--- a/packages/components/src/components/capability-gate/capability-gate.css
+++ b/packages/components/src/components/capability-gate/capability-gate.css
@@ -107,6 +107,15 @@
       0 0 0 calc(var(--cinder-ring-offset) + var(--cinder-ring-width)) var(--cinder-ring-color);
   }
 
+  @media (forced-colors: active) {
+    .cinder-capability-gate__primary:focus-visible,
+    .cinder-capability-gate__fallback:focus-visible,
+    .cinder-capability-gate__dismiss:focus-visible {
+      outline: var(--cinder-ring-width) solid ButtonText;
+      outline-offset: 2px;
+    }
+  }
+
   .cinder-capability-gate__fallback {
     background-color: transparent;
     color: var(--cinder-text);

--- a/packages/components/src/components/chat-conversation-list/chat-conversation-list.css
+++ b/packages/components/src/components/chat-conversation-list/chat-conversation-list.css
@@ -56,7 +56,13 @@
   @media (forced-colors: active) {
     .cinder-chat-conversation-list__button[data-cinder-conversation-interactive]:focus-visible {
       outline: var(--cinder-ring-width) solid ButtonText;
-      outline-offset: 2px;
+      /* ButtonText is correct here: this is a button/navigation control using
+         aria-current="page" (page-nav semantics, not aria-selected list-selection).
+         Highlight/HighlightText would be wrong — those are for selected listbox items.
+         3px separates the ring from ButtonBorder, which renders in forced-colors
+         mode on all button elements regardless of their standard-mode border color. */
+      outline-offset: 3px;
+      box-shadow: none;
     }
   }
 

--- a/packages/components/src/components/chat-conversation-list/chat-conversation-list.css
+++ b/packages/components/src/components/chat-conversation-list/chat-conversation-list.css
@@ -53,6 +53,13 @@
     box-shadow: var(--_cinder-focus-ring-shadow);
   }
 
+  @media (forced-colors: active) {
+    .cinder-chat-conversation-list__button[data-cinder-conversation-interactive]:focus-visible {
+      outline: var(--cinder-ring-width) solid ButtonText;
+      outline-offset: 2px;
+    }
+  }
+
   .cinder-chat-conversation-list__title {
     grid-column: 1;
     grid-row: 1;

--- a/packages/components/src/components/chat/container/chat-history-trigger.svelte
+++ b/packages/components/src/components/chat/container/chat-history-trigger.svelte
@@ -93,6 +93,14 @@
     box-shadow: var(--_cinder-focus-ring-shadow);
   }
 
+  @media (forced-colors: active) {
+    .chat-history-trigger-button:focus-visible {
+      outline: var(--cinder-ring-width) solid ButtonText;
+      outline-offset: 3px;
+      box-shadow: none;
+    }
+  }
+
   .sr-only {
     position: absolute;
     width: 1px;

--- a/packages/components/src/components/chat/input/chat-input.svelte
+++ b/packages/components/src/components/chat/input/chat-input.svelte
@@ -706,12 +706,10 @@
   }
 
   /* The button is a 44px touch target but the visible chip is the centered
-     1.25rem `::before` circle. Reserve a transparent outline placeholder for
-     forced-colors, and paint the ring on the visible circle (Strategy B-inset)
-     so it hugs the chip rather than the oversized hit area. */
+     1.25rem `::before` circle. Paint the ring on the visible circle so it hugs
+     the chip rather than the oversized hit area. */
   .chat-input-attachment-remove:focus-visible {
     opacity: 1;
-    outline: var(--cinder-ring-width) solid transparent;
   }
 
   .chat-input-attachment-remove:focus-visible::before {
@@ -720,9 +718,14 @@
   }
 
   @media (forced-colors: active) {
-    .chat-input-attachment-remove:focus-visible {
+    /* Forced-colors strips the box-shadow ring, so repaint a system-color
+       outline directly on the visible `::before` circle (which is round via
+       border-radius: full, so the outline follows the chip). Painting on the
+       circle itself avoids depending on fragile parent-to-pseudo offset math. */
+    .chat-input-attachment-remove:focus-visible::before {
+      box-shadow: none;
       outline: var(--cinder-ring-width) solid ButtonText;
-      outline-offset: -12px;
+      outline-offset: var(--cinder-ring-offset);
     }
   }
 

--- a/packages/components/src/components/chat/message/parts/reasoning-part.svelte
+++ b/packages/components/src/components/chat/message/parts/reasoning-part.svelte
@@ -165,6 +165,14 @@
       outline-offset: -2px;
       box-shadow: var(--_cinder-focus-ring-shadow);
     }
+
+    @media (forced-colors: active) {
+      &:focus-visible {
+        outline: var(--cinder-ring-width) solid ButtonText;
+        outline-offset: 2px;
+        box-shadow: none;
+      }
+    }
   }
 
   .chat-reasoning-label {

--- a/packages/components/src/components/chat/message/parts/tool-approval-part.svelte
+++ b/packages/components/src/components/chat/message/parts/tool-approval-part.svelte
@@ -248,6 +248,14 @@
       outline-offset: 2px;
       box-shadow: var(--_cinder-focus-ring-shadow);
     }
+
+    @media (forced-colors: active) {
+      &:focus-visible {
+        outline: var(--cinder-ring-width) solid ButtonText;
+        outline-offset: 3px;
+        box-shadow: none;
+      }
+    }
   }
 
   .chat-tool-approval-btn-approve {

--- a/packages/components/src/components/code-block/code-block.css
+++ b/packages/components/src/components/code-block/code-block.css
@@ -176,7 +176,8 @@
 
   @media (forced-colors: active) {
     .cinder-code-block .cinder-code-block__header .cinder-copy-button:focus-visible {
-      outline-color: CanvasText;
+      outline: var(--cinder-ring-width) solid ButtonText;
+      outline-offset: 3px;
       box-shadow: none;
     }
   }

--- a/packages/components/src/components/code-block/code-block.test.ts
+++ b/packages/components/src/components/code-block/code-block.test.ts
@@ -121,7 +121,9 @@ describe('CodeBlock — static structure', () => {
   test('copy button focus ring remains visible in forced-colors mode', async () => {
     const css = await Bun.file(new URL('./code-block.css', import.meta.url)).text();
     expect(css).toContain('@media (forced-colors: active)');
-    expect(css).toContain('outline-color: CanvasText;');
+    // The copy-button forced-colors fallback uses the full outline shorthand (not outline-color)
+    // so the Stylelint rule can detect it as a valid non-transparent outline.
+    expect(css).toContain('outline: var(--cinder-ring-width) solid ButtonText;');
     expect(css).toContain('box-shadow: none;');
   });
 

--- a/packages/components/src/components/data-grid/data-grid.css
+++ b/packages/components/src/components/data-grid/data-grid.css
@@ -23,6 +23,14 @@
     box-shadow: var(--_cinder-focus-ring-shadow);
   }
 
+  @media (forced-colors: active) {
+    .cinder-data-grid:focus-visible {
+      outline: var(--cinder-ring-width) solid ButtonText;
+      outline-offset: calc(-1 * var(--cinder-ring-width));
+      box-shadow: none;
+    }
+  }
+
   .cinder-data-grid__header-row,
   .cinder-data-grid__row {
     display: grid;
@@ -115,6 +123,14 @@
     outline: var(--cinder-ring-width) solid transparent;
     outline-offset: 2px;
     box-shadow: var(--_cinder-focus-ring-shadow);
+  }
+
+  @media (forced-colors: active) {
+    .cinder-data-grid__sort-button:focus-visible {
+      outline: var(--cinder-ring-width) solid ButtonText;
+      outline-offset: 2px;
+      box-shadow: none;
+    }
   }
 
   .cinder-data-grid__header-content {

--- a/packages/components/src/components/data-table/data-table.css
+++ b/packages/components/src/components/data-table/data-table.css
@@ -48,6 +48,15 @@
     box-shadow: var(--_cinder-focus-ring-shadow);
   }
 
+  @media (forced-colors: active) {
+    .cinder-data-table[data-cinder-virtualized]
+      .cinder-table__row[data-cinder-virtual-row]:focus-visible {
+      outline: var(--cinder-ring-width) solid ButtonText;
+      outline-offset: calc(-1 * var(--cinder-ring-width));
+      box-shadow: none;
+    }
+  }
+
   .cinder-data-table__virtual-spacer-cell {
     padding: 0;
     border: 0;

--- a/packages/components/src/components/kanban-board/kanban-board.css
+++ b/packages/components/src/components/kanban-board/kanban-board.css
@@ -89,7 +89,11 @@
     .cinder-kanban-board__column-handle:focus-visible,
     .cinder-kanban-board__collapse:focus-visible {
       outline: var(--cinder-ring-width) solid ButtonText;
-      outline-offset: 2px;
+      /* 3px separates the outline from ButtonBorder (which renders in forced-colors
+         on all bordered controls and shares the ButtonText color family in HCM);
+         at 2px the ring and border can visually merge. */
+      outline-offset: 3px;
+      box-shadow: none;
     }
   }
 

--- a/packages/components/src/components/kanban-board/kanban-board.css
+++ b/packages/components/src/components/kanban-board/kanban-board.css
@@ -85,6 +85,14 @@
       0 0 0 calc(var(--cinder-ring-offset) + var(--cinder-ring-width)) var(--cinder-ring-color);
   }
 
+  @media (forced-colors: active) {
+    .cinder-kanban-board__column-handle:focus-visible,
+    .cinder-kanban-board__collapse:focus-visible {
+      outline: var(--cinder-ring-width) solid ButtonText;
+      outline-offset: 2px;
+    }
+  }
+
   @media (hover: hover) {
     .cinder-kanban-board__column-handle:hover,
     .cinder-kanban-board__collapse:hover {

--- a/packages/components/src/components/load-more/load-more.css
+++ b/packages/components/src/components/load-more/load-more.css
@@ -50,6 +50,14 @@
       0 0 0 4px var(--cinder-ring-color);
   }
 
+  @media (forced-colors: active) {
+    .cinder-load-more__button:focus-visible {
+      outline: 2px solid ButtonText;
+      outline-offset: 3px;
+      box-shadow: none;
+    }
+  }
+
   .cinder-load-more__button:disabled {
     cursor: progress;
     opacity: 0.72;

--- a/packages/components/src/components/media-controls/media-controls.css
+++ b/packages/components/src/components/media-controls/media-controls.css
@@ -41,6 +41,13 @@
       0 0 0 calc(var(--cinder-ring-offset) + var(--cinder-ring-width)) var(--cinder-ring-color);
   }
 
+  @media (forced-colors: active) {
+    .cinder-media-controls__button:focus-visible {
+      outline: var(--cinder-ring-width) solid ButtonText;
+      outline-offset: 2px;
+    }
+  }
+
   .cinder-media-controls__button:disabled {
     cursor: not-allowed;
     opacity: 0.5;

--- a/packages/components/src/components/media-controls/media-controls.css
+++ b/packages/components/src/components/media-controls/media-controls.css
@@ -44,7 +44,11 @@
   @media (forced-colors: active) {
     .cinder-media-controls__button:focus-visible {
       outline: var(--cinder-ring-width) solid ButtonText;
-      outline-offset: 2px;
+      /* 3px separates the outline from ButtonBorder (which renders in forced-colors
+         on all bordered controls and shares the ButtonText color family in HCM);
+         at 2px the ring and border can visually merge. */
+      outline-offset: 3px;
+      box-shadow: none;
     }
   }
 

--- a/packages/components/src/components/menu-bar/menu-bar.css
+++ b/packages/components/src/components/menu-bar/menu-bar.css
@@ -53,7 +53,11 @@
   @media (forced-colors: active) {
     .cinder-menu-bar__trigger:focus-visible {
       outline: var(--cinder-ring-width) solid ButtonText;
-      outline-offset: 2px;
+      /* 3px separates the outline from ButtonBorder (which renders in forced-colors
+         on all button-like controls and shares the ButtonText color family in HCM);
+         at 2px the ring and border can visually merge. */
+      outline-offset: 3px;
+      box-shadow: none;
     }
   }
 

--- a/packages/components/src/components/menu-bar/menu-bar.css
+++ b/packages/components/src/components/menu-bar/menu-bar.css
@@ -50,6 +50,13 @@
     box-shadow: var(--_cinder-focus-ring-shadow);
   }
 
+  @media (forced-colors: active) {
+    .cinder-menu-bar__trigger:focus-visible {
+      outline: var(--cinder-ring-width) solid ButtonText;
+      outline-offset: 2px;
+    }
+  }
+
   .cinder-menu-bar__access-key {
     text-decoration: underline;
     text-underline-offset: 0.125em;

--- a/packages/components/src/components/permission-matrix/permission-matrix.css
+++ b/packages/components/src/components/permission-matrix/permission-matrix.css
@@ -122,7 +122,10 @@
   @media (forced-colors: active) {
     button.cinder-permission-matrix__cell-control:focus-visible {
       outline: var(--cinder-ring-width) solid ButtonText;
+      /* 2px is correct here: cell-control has border:0 so there is no
+         ButtonBorder to merge with at 2px. */
       outline-offset: 2px;
+      box-shadow: none;
     }
   }
 

--- a/packages/components/src/components/permission-matrix/permission-matrix.css
+++ b/packages/components/src/components/permission-matrix/permission-matrix.css
@@ -119,6 +119,13 @@
     z-index: 1;
   }
 
+  @media (forced-colors: active) {
+    button.cinder-permission-matrix__cell-control:focus-visible {
+      outline: var(--cinder-ring-width) solid ButtonText;
+      outline-offset: 2px;
+    }
+  }
+
   @media (hover: hover) {
     button.cinder-permission-matrix__cell-control:hover {
       background: var(--cinder-surface-hover);

--- a/packages/components/src/components/schema-form/schema-form.css
+++ b/packages/components/src/components/schema-form/schema-form.css
@@ -110,7 +110,9 @@
 
     .cinder-schema-form__secondary-button:focus-visible,
     .cinder-schema-form__submit:focus-visible {
-      outline-color: Highlight;
+      outline: var(--cinder-ring-width) solid Highlight;
+      outline-offset: 3px;
+      box-shadow: none;
     }
   }
 }

--- a/packages/components/src/components/segmented-control/segmented-control.css
+++ b/packages/components/src/components/segmented-control/segmented-control.css
@@ -278,6 +278,19 @@
     z-index: 1;
   }
 
+  /* Forced-colors: selected/pressed segments also need outline fallback. Selection
+   * semantics apply (the segment represents a chosen option) → Highlight. */
+  @media (forced-colors: active) {
+    .cinder-segmented-control:not([data-cinder-variant='tablist'])
+      .cinder-segmented-control-option[data-cinder-selected]:focus-visible,
+    .cinder-segmented-control:not([data-cinder-variant='tablist'])
+      .cinder-segmented-control-option[data-cinder-pressed]:focus-visible {
+      outline: var(--cinder-ring-width) solid Highlight;
+      outline-offset: 1px;
+      box-shadow: none;
+    }
+  }
+
   /* ── Tablist variant (single mode only) ─────────────────────────────────────
  * See docs/decisions/segmented-control-tablist-variant.md. The tablist variant
  * carries tab semantics for externally owned panels, so it must read as a
@@ -349,6 +362,14 @@
     .cinder-segmented-control-option:focus-visible {
       outline: var(--cinder-ring-width) solid Highlight;
       outline-offset: 1px;
+    }
+
+    /* Forced-colors: selected+focused tab in tablist → selection semantics → Highlight. */
+    .cinder-segmented-control[data-cinder-selection-mode='single'][data-cinder-variant='tablist']
+      .cinder-segmented-control-option[data-cinder-selected]:focus-visible {
+      outline: var(--cinder-ring-width) solid Highlight;
+      outline-offset: 1px;
+      box-shadow: none;
     }
   }
 

--- a/packages/components/src/components/share-card/share-card.css
+++ b/packages/components/src/components/share-card/share-card.css
@@ -100,7 +100,11 @@
   @media (forced-colors: active) {
     .cinder-share-card__action:focus-visible {
       outline: var(--cinder-ring-width) solid ButtonText;
-      outline-offset: 2px;
+      /* 3px separates the outline from ButtonBorder (which renders in forced-colors
+         on all bordered controls and shares the ButtonText color family in HCM);
+         at 2px the ring and border can visually merge. */
+      outline-offset: 3px;
+      box-shadow: none;
     }
   }
 

--- a/packages/components/src/components/share-card/share-card.css
+++ b/packages/components/src/components/share-card/share-card.css
@@ -97,6 +97,13 @@
       0 0 0 calc(var(--cinder-ring-offset) + var(--cinder-ring-width)) var(--cinder-ring-color);
   }
 
+  @media (forced-colors: active) {
+    .cinder-share-card__action:focus-visible {
+      outline: var(--cinder-ring-width) solid ButtonText;
+      outline-offset: 2px;
+    }
+  }
+
   .cinder-share-card__action[data-cinder-copied] {
     color: var(--cinder-color-success-fg);
     border-color: var(--cinder-color-success-border);

--- a/packages/components/src/components/table/table.css
+++ b/packages/components/src/components/table/table.css
@@ -165,7 +165,10 @@
   @media (forced-colors: active) {
     .cinder-table__sort-button:focus-visible {
       outline: var(--cinder-ring-width) solid ButtonText;
+      /* 2px is correct here: sort-button has border:none so there is no
+         ButtonBorder to merge with at 2px. */
       outline-offset: 2px;
+      box-shadow: none;
     }
   }
 

--- a/packages/components/src/components/table/table.css
+++ b/packages/components/src/components/table/table.css
@@ -162,6 +162,13 @@
     z-index: 2;
   }
 
+  @media (forced-colors: active) {
+    .cinder-table__sort-button:focus-visible {
+      outline: var(--cinder-ring-width) solid ButtonText;
+      outline-offset: 2px;
+    }
+  }
+
   @media (hover: hover) {
     .cinder-table__sort-button:hover {
       background: var(--cinder-surface-hover);

--- a/packages/components/src/components/textarea/textarea.css
+++ b/packages/components/src/components/textarea/textarea.css
@@ -106,6 +106,14 @@
       0 0 0 calc(var(--cinder-ring-offset) + var(--cinder-ring-width)) var(--cinder-danger);
   }
 
+  @media (forced-colors: active) {
+    .cinder-textarea[aria-invalid='true']:focus-visible {
+      outline: var(--cinder-ring-width) solid Mark;
+      outline-offset: 3px;
+      box-shadow: none;
+    }
+  }
+
   /* ----------------------------------------
  * Disabled state
  * ---------------------------------------- */

--- a/packages/components/src/components/transfer-list/transfer-list.css
+++ b/packages/components/src/components/transfer-list/transfer-list.css
@@ -45,7 +45,11 @@
   @media (forced-colors: active) {
     .cinder-transfer-list__list:focus-visible {
       outline: var(--cinder-ring-width) solid ButtonText;
-      outline-offset: 2px;
+      /* Negative offset because __list has overflow:auto — a positive offset
+         would be clipped by the scrolling container and the ring can disappear.
+         An inset ring always paints inside the box regardless of overflow. */
+      outline-offset: calc(-1 * var(--cinder-ring-width));
+      box-shadow: none;
     }
   }
 
@@ -111,7 +115,11 @@
   @media (forced-colors: active) {
     .cinder-transfer-list__control:focus-visible {
       outline: var(--cinder-ring-width) solid ButtonText;
-      outline-offset: 2px;
+      /* 3px separates the outline from ButtonBorder (which renders in forced-colors
+         on all bordered controls and shares the ButtonText color family in HCM);
+         at 2px the ring and border can visually merge. */
+      outline-offset: 3px;
+      box-shadow: none;
     }
   }
 

--- a/packages/components/src/components/transfer-list/transfer-list.css
+++ b/packages/components/src/components/transfer-list/transfer-list.css
@@ -42,6 +42,13 @@
     box-shadow: var(--_cinder-focus-ring-shadow);
   }
 
+  @media (forced-colors: active) {
+    .cinder-transfer-list__list:focus-visible {
+      outline: var(--cinder-ring-width) solid ButtonText;
+      outline-offset: 2px;
+    }
+  }
+
   .cinder-transfer-list__option {
     padding: var(--cinder-space-2) var(--cinder-space-3);
     border-radius: var(--cinder-radius-sm);
@@ -99,6 +106,13 @@
   .cinder-transfer-list__control:focus-visible {
     outline: var(--cinder-ring-width) solid transparent;
     box-shadow: var(--_cinder-focus-ring-shadow);
+  }
+
+  @media (forced-colors: active) {
+    .cinder-transfer-list__control:focus-visible {
+      outline: var(--cinder-ring-width) solid ButtonText;
+      outline-offset: 2px;
+    }
   }
 
   @container cinder-transfer-list (max-width: 42rem) {

--- a/packages/components/src/components/tree/tree.css
+++ b/packages/components/src/components/tree/tree.css
@@ -52,6 +52,14 @@
     box-shadow: 0 0 0 var(--cinder-ring-width) var(--cinder-ring-color);
   }
 
+  @media (forced-colors: active) {
+    .cinder-tree__filter-input:focus-visible {
+      outline: var(--cinder-ring-width) solid ButtonText;
+      outline-offset: 3px;
+      box-shadow: none;
+    }
+  }
+
   .cinder-tree__selection-controls {
     display: flex;
     flex-wrap: wrap;
@@ -186,6 +194,14 @@
     box-shadow: 0 0 0 var(--cinder-ring-width) var(--cinder-ring-color);
   }
 
+  @media (forced-colors: active) {
+    .cinder-tree-item__drag-handle:focus-visible {
+      outline: var(--cinder-ring-width) solid ButtonText;
+      outline-offset: 2px;
+      box-shadow: none;
+    }
+  }
+
   /* Long labels must not force the tree wider than its container or overlap the
    * checkbox at narrow (mobile) widths. The element also carries `cinder-_truncate`
    * (the shared utility), which supplies overflow:hidden / text-overflow:ellipsis /
@@ -271,6 +287,14 @@
   .cinder-tree-item__rename-input:focus-visible {
     outline: var(--cinder-ring-width) solid transparent;
     box-shadow: 0 0 0 var(--cinder-ring-width) var(--cinder-ring-color);
+  }
+
+  @media (forced-colors: active) {
+    .cinder-tree-item__rename-input:focus-visible {
+      outline: var(--cinder-ring-width) solid ButtonText;
+      outline-offset: 3px;
+      box-shadow: none;
+    }
   }
 
   .cinder-tree-item__rename-input[aria-invalid='true'] {

--- a/packages/components/src/styles/components/_input-frame.css
+++ b/packages/components/src/styles/components/_input-frame.css
@@ -66,7 +66,8 @@
     .cinder-_input-frame[data-invalid]:focus-visible,
     .cinder-_input-frame[data-invalid]:focus-within {
       border-color: Mark;
-      outline-color: Mark;
+      outline: var(--cinder-ring-width) solid Mark;
+      outline-offset: 3px;
       box-shadow: none;
     }
   }

--- a/packages/components/src/test/focus-ring-recipe.test.ts
+++ b/packages/components/src/test/focus-ring-recipe.test.ts
@@ -58,6 +58,20 @@ const barChartCss = loadCss('../components/bar-chart/bar-chart.css');
 const lineChartCss = loadCss('../components/line-chart/line-chart.css');
 const tokensBaseCss = loadCss('../styles/tokens-base.css');
 
+// Issue #460 — forced-colors fallback additions for 9 components that used
+// transparent-outline + box-shadow without a @media (forced-colors: active) block.
+const capabilityGateCss = loadCss('../components/capability-gate/capability-gate.css');
+const kanbanBoardCss = loadCss('../components/kanban-board/kanban-board.css');
+const mediaControlsCss = loadCss('../components/media-controls/media-controls.css');
+const permissionMatrixCss = loadCss('../components/permission-matrix/permission-matrix.css');
+const shareCardCss = loadCss('../components/share-card/share-card.css');
+const transferListCss = loadCss('../components/transfer-list/transfer-list.css');
+const tableCss = loadCss('../components/table/table.css');
+const menuBarCss = loadCss('../components/menu-bar/menu-bar.css');
+const chatConversationListCss = loadCss(
+  '../components/chat-conversation-list/chat-conversation-list.css',
+);
+
 // Focus-ring sweep targets (15f4d777) — colored outline-only recipes converted
 // to the shared Strategy B / B-inset recipe.
 const accordionItemCss = loadCss('../components/accordion-item/accordion-item.css');
@@ -1149,4 +1163,117 @@ describe('focus-ring lint rule gates at error severity', () => {
     );
     expect(warningsFor(result)).toEqual([]);
   });
+});
+
+// ============================================================================
+// Issue #460 — forced-colors fallbacks for 9 components with box-shadow focus
+// rings and no prior forced-colors media block.
+// ============================================================================
+
+/**
+ * Assert a focus-visible selector has a forced-colors fallback that repaints
+ * the outline with ButtonText. This is a lighter version of assertOuterRecipe
+ * that does NOT require the shared `var(--_cinder-focus-ring-shadow)` token —
+ * some of the issue #460 components use the inline two-shadow form, which is
+ * semantically identical but written out explicitly.
+ */
+function assertForcedColorsFallback(css: string, selector: string): void {
+  const root = parse(css);
+
+  // The base (non-forced) rule must have a transparent outline and box-shadow.
+  const baseRules = findRules(root, selector).filter((rule) => !isUnderForcedColors(rule));
+  expect(baseRules.length).toBeGreaterThanOrEqual(1);
+  const base = baseRules[0]!;
+  const outlineValue = declValue(base, 'outline');
+  expect(outlineValue).toBeDefined();
+  expect(outlineValue).toContain('transparent');
+  expect(declValue(base, 'box-shadow')).toBeDefined();
+
+  // The forced-colors block must have a non-transparent ButtonText outline.
+  const fallbackRules = findRules(root, selector).filter((rule) => isUnderForcedColors(rule));
+  expect(fallbackRules.length).toBeGreaterThanOrEqual(1);
+  const fallback = fallbackRules[0]!;
+  const outline = declValue(fallback, 'outline');
+  expect(outline).toBeDefined();
+  expect(outline).not.toContain('transparent');
+  expect(outline).toBe('var(--cinder-ring-width) solid ButtonText');
+}
+
+describe('forced-colors fallbacks — issue #460 (9 affected components)', () => {
+  // Each entry asserts: transparent-outline + box-shadow in normal mode, plus
+  // a non-transparent ButtonText outline in @media (forced-colors: active).
+  const cases: Array<{ name: string; css: string; selector: string }> = [
+    {
+      name: 'capability-gate primary action',
+      css: capabilityGateCss,
+      selector: '.cinder-capability-gate__primary:focus-visible',
+    },
+    {
+      name: 'capability-gate fallback action',
+      css: capabilityGateCss,
+      selector: '.cinder-capability-gate__fallback:focus-visible',
+    },
+    {
+      name: 'capability-gate dismiss action',
+      css: capabilityGateCss,
+      selector: '.cinder-capability-gate__dismiss:focus-visible',
+    },
+    {
+      name: 'kanban-board column-handle',
+      css: kanbanBoardCss,
+      selector: '.cinder-kanban-board__column-handle:focus-visible',
+    },
+    {
+      name: 'kanban-board collapse',
+      css: kanbanBoardCss,
+      selector: '.cinder-kanban-board__collapse:focus-visible',
+    },
+    {
+      name: 'media-controls button',
+      css: mediaControlsCss,
+      selector: '.cinder-media-controls__button:focus-visible',
+    },
+    {
+      name: 'permission-matrix cell-control button',
+      css: permissionMatrixCss,
+      selector: 'button.cinder-permission-matrix__cell-control:focus-visible',
+    },
+    {
+      name: 'share-card action',
+      css: shareCardCss,
+      selector: '.cinder-share-card__action:focus-visible',
+    },
+    {
+      name: 'transfer-list list',
+      css: transferListCss,
+      selector: '.cinder-transfer-list__list:focus-visible',
+    },
+    {
+      name: 'transfer-list control',
+      css: transferListCss,
+      selector: '.cinder-transfer-list__control:focus-visible',
+    },
+    {
+      name: 'table sort-button',
+      css: tableCss,
+      selector: '.cinder-table__sort-button:focus-visible',
+    },
+    {
+      name: 'menu-bar trigger',
+      css: menuBarCss,
+      selector: '.cinder-menu-bar__trigger:focus-visible',
+    },
+    {
+      name: 'chat-conversation-list interactive button',
+      css: chatConversationListCss,
+      selector:
+        '.cinder-chat-conversation-list__button[data-cinder-conversation-interactive]:focus-visible',
+    },
+  ];
+
+  for (const { name, css, selector } of cases) {
+    test(`${name}: ${selector} has a forced-colors fallback that repaints the outline`, () => {
+      assertForcedColorsFallback(css, selector);
+    });
+  }
 });

--- a/packages/components/src/test/focus-ring-recipe.test.ts
+++ b/packages/components/src/test/focus-ring-recipe.test.ts
@@ -1068,18 +1068,10 @@ describe('focus-ring sweep — selected/current state boundaries', () => {
 
 describe('chat-input attachment-remove — inset ring painted on the visible chip', () => {
   // The button is a 44px touch target with the visible chip rendered by its
-  // `::before`. The base :focus-visible keeps only the transparent placeholder;
-  // the inset ring is painted on `::before` so it hugs the chip, not the
-  // oversized hit area. The forced-colors outline keeps the -12px inset.
-  test('base rule keeps the transparent-outline placeholder', () => {
-    const root = parse(chatInputStyle);
-    const rules = findRules(root, '.chat-input-attachment-remove:focus-visible').filter(
-      (rule) => !isUnderForcedColors(rule),
-    );
-    expect(rules.length).toBeGreaterThanOrEqual(1);
-    expect(declValue(rules[0]!, 'outline')).toBe(TRANSPARENT_OUTLINE);
-  });
-
+  // `::before`. The standard-mode ring is an inset box-shadow on `::before` so it
+  // hugs the chip, not the oversized hit area. In forced-colors the box-shadow is
+  // stripped, so the system-color outline is repainted on the SAME `::before`
+  // selector (the round chip), which avoids fragile parent-to-pseudo offset math.
   test('::before paints an inset ring referencing the ring color', () => {
     const root = parse(chatInputStyle);
     const rules = findRules(root, '.chat-input-attachment-remove:focus-visible::before').filter(
@@ -1093,15 +1085,17 @@ describe('chat-input attachment-remove — inset ring painted on the visible chi
     expect(boxShadow).not.toContain(SHARED_BOX_SHADOW);
   });
 
-  test('forced-colors fallback repaints the outline on the chip', () => {
+  test('forced-colors fallback repaints the outline on the ::before chip', () => {
     const root = parse(chatInputStyle);
-    const rules = findRules(root, '.chat-input-attachment-remove:focus-visible').filter((rule) =>
-      isUnderForcedColors(rule),
+    const rules = findRules(root, '.chat-input-attachment-remove:focus-visible::before').filter(
+      (rule) => isUnderForcedColors(rule),
     );
     expect(rules.length).toBeGreaterThanOrEqual(1);
     const fallback = rules[0]!;
+    // box-shadow stripped, system-color outline painted on the visible chip.
+    expect(declValue(fallback, 'box-shadow')).toBe('none');
     expect(declValue(fallback, 'outline')).toBe('var(--cinder-ring-width) solid ButtonText');
-    expect(declValue(fallback, 'outline-offset')).toBe('-12px');
+    expect(declValue(fallback, 'outline-offset')).toBe('var(--cinder-ring-offset)');
   });
 });
 
@@ -1176,8 +1170,14 @@ describe('focus-ring lint rule gates at error severity', () => {
  * that does NOT require the shared `var(--_cinder-focus-ring-shadow)` token —
  * some of the issue #460 components use the inline two-shadow form, which is
  * semantically identical but written out explicitly.
+ *
+ * @param expectedOffset - The expected `outline-offset` value in the fallback
+ *   block. Bordered controls use `3px` (matches button.css precedent — 3px
+ *   separates the ring from ButtonBorder which shares the ButtonText color
+ *   family in HCM). Borderless controls use `2px`. Overflow-clipped scrollable
+ *   containers use `calc(-1 * var(--cinder-ring-width))` (inset ring).
  */
-function assertForcedColorsFallback(css: string, selector: string): void {
+function assertForcedColorsFallback(css: string, selector: string, expectedOffset: string): void {
   const root = parse(css);
 
   // The base (non-forced) rule must have a transparent outline and box-shadow.
@@ -1189,7 +1189,8 @@ function assertForcedColorsFallback(css: string, selector: string): void {
   expect(outlineValue).toContain('transparent');
   expect(declValue(base, 'box-shadow')).toBeDefined();
 
-  // The forced-colors block must have a non-transparent ButtonText outline.
+  // The forced-colors block must have a non-transparent ButtonText outline,
+  // the correct outline-offset for the control type, and box-shadow:none.
   const fallbackRules = findRules(root, selector).filter((rule) => isUnderForcedColors(rule));
   expect(fallbackRules.length).toBeGreaterThanOrEqual(1);
   const fallback = fallbackRules[0]!;
@@ -1197,83 +1198,112 @@ function assertForcedColorsFallback(css: string, selector: string): void {
   expect(outline).toBeDefined();
   expect(outline).not.toContain('transparent');
   expect(outline).toBe('var(--cinder-ring-width) solid ButtonText');
+  expect(declValue(fallback, 'outline-offset')).toBe(expectedOffset);
+  expect(declValue(fallback, 'box-shadow')).toBe('none');
 }
 
 describe('forced-colors fallbacks — issue #460 (9 affected components)', () => {
   // Each entry asserts: transparent-outline + box-shadow in normal mode, plus
-  // a non-transparent ButtonText outline in @media (forced-colors: active).
-  const cases: Array<{ name: string; css: string; selector: string }> = [
+  // a non-transparent ButtonText outline, the correct per-control outline-offset,
+  // and explicit box-shadow:none in @media (forced-colors: active).
+  //
+  // outline-offset policy:
+  //   3px  — bordered controls (border renders as ButtonBorder in HCM; 2px would merge)
+  //   2px  — borderless controls (no ButtonBorder, so 2px is safe)
+  //   calc(-1 * var(--cinder-ring-width))  — overflow:auto containers (positive offset
+  //          is clipped; inset ring always paints inside the scroll box)
+  const cases: Array<{ name: string; css: string; selector: string; expectedOffset: string }> = [
     {
       name: 'capability-gate primary action',
       css: capabilityGateCss,
       selector: '.cinder-capability-gate__primary:focus-visible',
+      expectedOffset: '3px',
     },
     {
       name: 'capability-gate fallback action',
       css: capabilityGateCss,
       selector: '.cinder-capability-gate__fallback:focus-visible',
+      expectedOffset: '3px',
     },
     {
       name: 'capability-gate dismiss action',
       css: capabilityGateCss,
       selector: '.cinder-capability-gate__dismiss:focus-visible',
+      expectedOffset: '3px',
     },
     {
       name: 'kanban-board column-handle',
       css: kanbanBoardCss,
       selector: '.cinder-kanban-board__column-handle:focus-visible',
+      expectedOffset: '3px',
     },
     {
       name: 'kanban-board collapse',
       css: kanbanBoardCss,
       selector: '.cinder-kanban-board__collapse:focus-visible',
+      expectedOffset: '3px',
     },
     {
       name: 'media-controls button',
       css: mediaControlsCss,
       selector: '.cinder-media-controls__button:focus-visible',
+      expectedOffset: '3px',
     },
     {
       name: 'permission-matrix cell-control button',
       css: permissionMatrixCss,
       selector: 'button.cinder-permission-matrix__cell-control:focus-visible',
+      // border:0 — borderless, no ButtonBorder merge risk
+      expectedOffset: '2px',
     },
     {
       name: 'share-card action',
       css: shareCardCss,
       selector: '.cinder-share-card__action:focus-visible',
+      expectedOffset: '3px',
     },
     {
-      name: 'transfer-list list',
+      name: 'transfer-list list (overflow:auto — uses inset ring)',
       css: transferListCss,
       selector: '.cinder-transfer-list__list:focus-visible',
+      // overflow:auto clips a positive offset; inset ring avoids the clip
+      expectedOffset: 'calc(-1 * var(--cinder-ring-width))',
     },
     {
       name: 'transfer-list control',
       css: transferListCss,
       selector: '.cinder-transfer-list__control:focus-visible',
+      expectedOffset: '3px',
     },
     {
       name: 'table sort-button',
       css: tableCss,
       selector: '.cinder-table__sort-button:focus-visible',
+      // border:none — borderless, no ButtonBorder merge risk
+      expectedOffset: '2px',
     },
     {
       name: 'menu-bar trigger',
       css: menuBarCss,
       selector: '.cinder-menu-bar__trigger:focus-visible',
+      expectedOffset: '3px',
     },
     {
       name: 'chat-conversation-list interactive button',
       css: chatConversationListCss,
       selector:
         '.cinder-chat-conversation-list__button[data-cinder-conversation-interactive]:focus-visible',
+      // Button element: ButtonBorder renders in HCM regardless of standard-mode
+      // border-color:transparent. ButtonText is correct (aria-current="page" nav
+      // semantics, not aria-selected list selection — Highlight/HighlightText
+      // would be wrong here).
+      expectedOffset: '3px',
     },
   ];
 
-  for (const { name, css, selector } of cases) {
+  for (const { name, css, selector, expectedOffset } of cases) {
     test(`${name}: ${selector} has a forced-colors fallback that repaints the outline`, () => {
-      assertForcedColorsFallback(css, selector);
+      assertForcedColorsFallback(css, selector, expectedOffset);
     });
   }
 });

--- a/packages/playground/src/component-page.svelte
+++ b/packages/playground/src/component-page.svelte
@@ -1439,6 +1439,13 @@
     outline: var(--cinder-ring-width) solid transparent;
     box-shadow: var(--_cinder-focus-ring-shadow);
   }
+  @media (forced-colors: active) {
+    .dx-iconbtn:focus-visible {
+      outline: var(--cinder-ring-width) solid ButtonText;
+      outline-offset: 3px;
+      box-shadow: none;
+    }
+  }
 
   .dx-loading {
     display: flex;
@@ -1599,6 +1606,13 @@
     outline: var(--cinder-ring-width) solid transparent;
     box-shadow: var(--_cinder-focus-ring-shadow);
   }
+  @media (forced-colors: active) {
+    .dx-import__copy:focus-visible {
+      outline: var(--cinder-ring-width) solid ButtonText;
+      outline-offset: 3px;
+      box-shadow: none;
+    }
+  }
 
   /* ===== Layout + TOC ===== */
   .dx-layout {
@@ -1667,6 +1681,13 @@
   .dx-toc__link:focus-visible {
     outline: var(--cinder-ring-width) solid transparent;
     box-shadow: var(--_cinder-focus-ring-shadow);
+  }
+  @media (forced-colors: active) {
+    .dx-toc__link:focus-visible {
+      outline: var(--cinder-ring-width) solid LinkText;
+      outline-offset: 3px;
+      box-shadow: none;
+    }
   }
 
   /* ===== Sections ===== */
@@ -1915,6 +1936,13 @@
     outline: var(--cinder-ring-width) solid transparent;
     box-shadow: var(--_cinder-focus-ring-shadow);
     border-radius: var(--cinder-radius-sm);
+  }
+  @media (forced-colors: active) {
+    .dx-guide__alt:focus-visible {
+      outline: var(--cinder-ring-width) solid LinkText;
+      outline-offset: 3px;
+      box-shadow: none;
+    }
   }
 
   /* ===== Playground ===== */
@@ -2341,6 +2369,13 @@
   .dx-rel:focus-visible {
     outline: var(--cinder-ring-width) solid transparent;
     box-shadow: var(--_cinder-focus-ring-shadow);
+  }
+  @media (forced-colors: active) {
+    .dx-rel:focus-visible {
+      outline: var(--cinder-ring-width) solid LinkText;
+      outline-offset: 3px;
+      box-shadow: none;
+    }
   }
   .dx-rel__top {
     display: flex;


### PR DESCRIPTION
## Summary

Box-shadow `:focus-visible` focus rings are invisible in Windows High Contrast Mode (forced-colors strips box-shadows), so keyboard focus disappears on affected controls — a WCAG 2.4.11 failure. This eliminates that bug class **repo-wide**, not just for the 9 components the issue named.

Closes #460

## What changed (scope grew deliberately)

The issue scoped 9 components. Committee + Codex review found the same bug in ~13 more, and that the proposed Stylelint guard was an orphan (never registered → caught nothing). Per repo-owner decision, this completes the sweep:

- **Wired `cinder/require-forced-colors-focus-fallback` into `.stylelintrc.json`** so `bun run lint` enforces it on every component, forever.
- **Added forced-colors fallbacks to all violators** (9 named + autocomplete, code-block, data-grid, data-table, input-frame, load-more, number-input, schema-form, search-field, segmented-control, tag-input, textarea, tree, 3 chat parts, playground component-page). Repo-wide lint is green with the rule active (0 violations).

## Per-control discipline (not a blanket fix)

- **System color by semantics:** `ButtonText` for plain controls, `Highlight` for selection state (segmented-control selected), `Mark` for error-state rings (invalid textarea/input-frame), `LinkText` for links.
- **Offset:** `3px` on bordered controls (matches `button.css` precedent — separates the ring from `ButtonBorder` in HCM); `2px` on borderless ones.
- **Inset offset** for scroll-clipped surfaces (transfer-list `__list`, data-grid, virtualized rows) so the ring isn't clipped by `overflow`.
- `box-shadow: none` in every fallback.

## Correctness over shortcuts

Two earlier-round shortcuts were replaced with real fixes (no `stylelint-disable` left behind):
- The rule now correctly ignores `box-shadow: none` and `:not(:focus-visible)` selectors (with test fixtures), instead of suppressing the false positives.
- chat-input attachment-remove paints its forced-colors outline on the visible `::before` chip (round, via border-radius), not the parent element with fragile `-12px` offset math.

## Review committee

Pre-reviewed by: ux-designer, testing-expert, simplicity-engineer + Codex (gpt-5.4, xhigh) — 1 round + a codex-advisor consult on the rule/suppressor question. Must-fixes addressed: orphaned plugin (wired), offset 2px→3px on bordered controls, transfer-list overflow-clip (inset), chat ::before fallback, rule hardening, changeset.

## Test plan

128 pass / 0 fail on the guard suites; full package suite + repo lint green via pre-commit/pre-push. `bun run lint` now enforces the rule repo-wide with 0 violations.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CSS-only accessibility and lint enforcement with broad but mechanical styling changes; no runtime logic, auth, or data paths.
> 
> **Overview**
> Fixes **invisible keyboard focus in Windows High Contrast Mode** where `:focus-visible` rings relied on `box-shadow` (stripped under `forced-colors`). The PR adds matching `@media (forced-colors: active)` fallbacks across components and the playground: system-color **outlines** (`ButtonText`, `Highlight`, `Mark`, `LinkText` by control semantics), **`box-shadow: none`**, and **per-control `outline-offset`** (3px bordered, 2px borderless, inset on overflow scroll surfaces).
> 
> A new Stylelint rule **`cinder/require-forced-colors-focus-fallback`** is registered in `.stylelintrc.json` so any future box-shadow focus ring without a selector-exact forced-colors outline fails lint. The rule ships with Bun tests; **`focus-ring-recipe.test.ts`** pins the nine originally flagged components plus updates (e.g. chat attachment remove paints HCM outline on **`::before`**, not fragile parent offset math). Several existing HCM blocks were tightened to full `outline` shorthands so the linter can see them.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ef824f80246eff3c5d65c31ecd35f79bca537f8b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->