### PR TITLE
fix(components): stable {#each} keys via dedup-before-render (#465)

### DIFF
--- a/packages/components/src/components/autocomplete/autocomplete.svelte
+++ b/packages/components/src/components/autocomplete/autocomplete.svelte
@@ -99,6 +99,7 @@
 
   const renderedSuggestions = $derived(suggestions.slice(0, resolvedMaxVisibleSuggestions));
   const enabledIndexes = $derived(getEnabledIndexes(renderedSuggestions));
+
   const activeDescendant = $derived(
     activeIndex === null ? undefined : `${resolvedId}-option-${activeIndex}`,
   );
@@ -218,10 +219,19 @@
         ) {
           return;
         }
+        const visibleSlice = nextSuggestions.slice(0, resolvedMaxVisibleSuggestions);
+        const visibleValues = visibleSlice.map((s) => s.value);
+        if (new Set(visibleValues).size !== visibleValues.length) {
+          devWarn(
+            '[cinder/Autocomplete] Duplicate suggestion values detected. Each rendered suggestion must have a unique value.',
+          );
+          loading = false;
+          return;
+        }
         suggestions = nextSuggestions;
         loading = false;
         open = true;
-        clampActiveIndex(nextSuggestions.slice(0, resolvedMaxVisibleSuggestions));
+        clampActiveIndex(visibleSlice);
       })
       .catch((errorValue: unknown) => {
         if (
@@ -487,7 +497,7 @@
       {emptyMessage}
     </div>
   {:else}
-    {#each renderedSuggestions as suggestion, index (`${suggestion.value}-${index}`)}
+    {#each renderedSuggestions as suggestion, index (suggestion.value)}
       {@const suggestionLabel = suggestion.label ?? suggestion.value}
       {@const parts = highlightParts(suggestionLabel, value)}
       <div

--- a/packages/components/src/components/autocomplete/autocomplete.svelte
+++ b/packages/components/src/components/autocomplete/autocomplete.svelte
@@ -219,19 +219,33 @@
         ) {
           return;
         }
-        const visibleSlice = nextSuggestions.slice(0, resolvedMaxVisibleSuggestions);
-        const visibleValues = visibleSlice.map((s) => s.value);
-        if (new Set(visibleValues).size !== visibleValues.length) {
-          devWarn(
-            '[cinder/Autocomplete] Duplicate suggestion values detected. Each rendered suggestion must have a unique value.',
-          );
-          loading = false;
-          return;
+        // Deduplicate the ENTIRE suggestion list by value (first occurrence
+        // wins), not just the visible window. `renderedSuggestions` re-slices
+        // `suggestions` by maxVisibleSuggestions, so a duplicate anywhere in the
+        // stored list could surface in the keyed {#each} if the window widens or
+        // a tail value collides with the visible prefix — both crash with
+        // each_key_duplicate. Deduping the whole list makes the key globally
+        // unique regardless of window size.
+        const seen = new Set<string>();
+        const deduped: typeof nextSuggestions = [];
+        let hasDuplicates = false;
+        for (const suggestion of nextSuggestions) {
+          if (seen.has(suggestion.value)) {
+            hasDuplicates = true;
+          } else {
+            seen.add(suggestion.value);
+            deduped.push(suggestion);
+          }
         }
-        suggestions = nextSuggestions;
+        if (hasDuplicates) {
+          devWarn(
+            '[cinder/Autocomplete] Duplicate suggestion values detected. Each rendered suggestion must have a unique value. Duplicates were removed; only the first occurrence of each value is shown.',
+          );
+        }
+        suggestions = deduped;
         loading = false;
         open = true;
-        clampActiveIndex(visibleSlice);
+        clampActiveIndex(deduped.slice(0, resolvedMaxVisibleSuggestions));
       })
       .catch((errorValue: unknown) => {
         if (

--- a/packages/components/src/components/autocomplete/autocomplete.test.ts
+++ b/packages/components/src/components/autocomplete/autocomplete.test.ts
@@ -687,10 +687,14 @@ describe('Autocomplete — out-of-portal status live region', () => {
 });
 
 describe('Autocomplete — each-key behavior', () => {
-  test('emits a devWarn and suppresses rendering when the suggestion source returns duplicate values', async () => {
-    // When the suggestion source returns duplicate values, devWarn fires and
-    // rendering is suppressed (no suggestions shown) to avoid a keyed-each
-    // key collision. This lets the developer diagnose the issue without a crash.
+  test('deduplicates suggestions and emits a devWarn when the source returns duplicate values', async () => {
+    // With in-flight dedup, duplicate suggestion values are removed before
+    // being assigned to state, so the keyed {#each} never sees a collision
+    // and Svelte cannot throw each_key_duplicate. The test asserts that:
+    //   1. No crash occurs (no try/catch needed).
+    //   2. Only the first occurrence of each value is rendered.
+    //   3. The dropdown opens (stale suggestions are not retained).
+    //   4. The devWarn fires so the developer is notified.
     const warnSpy = spyOn(console, 'warn').mockImplementation(() => {});
     const duplicateFruits = [
       { value: 'apple', label: 'Apple' },
@@ -706,13 +710,17 @@ describe('Autocomplete — each-key behavior', () => {
       });
       const input = container.querySelector('input') as HTMLInputElement;
       await fireEvent.input(input, { target: { value: 'a' } });
-      // Wait for the Promise.then microtask to complete.
-      await tick();
+      // Wait for the deduped suggestions to be committed to state and rendered.
+      await waitFor(() => {
+        const enabledOptions = getOptions().filter((o) => !o.getAttribute('aria-disabled'));
+        expect(enabledOptions).toHaveLength(2);
+      });
       expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('Duplicate suggestion values'));
-      // Duplicate suggestions are not rendered (to avoid a keyed-each key
-      // collision); only the "No suggestions" status row may be present.
+      // The deduped list (apple + banana) renders; the second 'apple' is dropped.
       const enabledOptions = getOptions().filter((o) => !o.getAttribute('aria-disabled'));
-      expect(enabledOptions).toHaveLength(0);
+      expect(enabledOptions).toHaveLength(2);
+      expect(enabledOptions[0]?.textContent).toContain('Apple');
+      expect(enabledOptions[1]?.textContent).toContain('Banana');
     } finally {
       warnSpy.mockRestore();
     }
@@ -734,6 +742,45 @@ describe('Autocomplete — each-key behavior', () => {
         expect(getOptions().length).toBeGreaterThan(0);
       });
       expect(warnSpy).not.toHaveBeenCalled();
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  test('dedups duplicates beyond the visible window (whole list, not just the slice)', async () => {
+    // Regression for a duplicate value living in the TAIL beyond
+    // maxVisibleSuggestions: deduping only the visible prefix would leave the
+    // tail duplicate in `suggestions`, and a wider re-slice (or a tail value
+    // colliding with the visible prefix) would crash the keyed {#each} with
+    // each_key_duplicate. Deduping the full list prevents that.
+    const warnSpy = spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      // visible window of 2; 'apple' appears at index 0 AND index 2 (the tail).
+      const withTailDuplicate = [
+        { value: 'apple', label: 'Apple' },
+        { value: 'banana', label: 'Banana' },
+        { value: 'apple', label: 'Apple (tail duplicate)' },
+        { value: 'cherry', label: 'Cherry' },
+      ];
+      const { container } = render(Autocomplete, {
+        props: {
+          id: 'tail-dup-search',
+          maxVisibleSuggestions: 2,
+          suggestionSource: () => withTailDuplicate,
+        },
+      });
+      const input = container.querySelector('input') as HTMLInputElement;
+      await fireEvent.input(input, { target: { value: 'a' } });
+
+      // No crash; the deduped list is apple/banana/cherry, sliced to 2 visible.
+      await waitFor(() => {
+        const enabled = getOptions().filter((o) => !o.getAttribute('aria-disabled'));
+        expect(enabled).toHaveLength(2);
+      });
+      const enabled = getOptions().filter((o) => !o.getAttribute('aria-disabled'));
+      expect(enabled[0]?.textContent).toContain('Apple');
+      expect(enabled[1]?.textContent).toContain('Banana');
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('Duplicate suggestion values'));
     } finally {
       warnSpy.mockRestore();
     }

--- a/packages/components/src/components/autocomplete/autocomplete.test.ts
+++ b/packages/components/src/components/autocomplete/autocomplete.test.ts
@@ -1,5 +1,5 @@
 /// <reference lib="dom" />
-import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
+import { afterEach, beforeEach, describe, expect, mock, spyOn, test } from 'bun:test';
 import { tick } from 'svelte';
 
 import { setupHappyDom } from '../../test/happy-dom.ts';
@@ -683,5 +683,59 @@ describe('Autocomplete — out-of-portal status live region', () => {
     await waitFor(() => {
       expect(statusRegion()?.textContent?.trim()).toBe('No matches found');
     });
+  });
+});
+
+describe('Autocomplete — each-key behavior', () => {
+  test('emits a devWarn and suppresses rendering when the suggestion source returns duplicate values', async () => {
+    // When the suggestion source returns duplicate values, devWarn fires and
+    // rendering is suppressed (no suggestions shown) to avoid a keyed-each
+    // key collision. This lets the developer diagnose the issue without a crash.
+    const warnSpy = spyOn(console, 'warn').mockImplementation(() => {});
+    const duplicateFruits = [
+      { value: 'apple', label: 'Apple' },
+      { value: 'apple', label: 'Apple (duplicate)' },
+      { value: 'banana', label: 'Banana' },
+    ];
+    try {
+      const { container } = render(Autocomplete, {
+        props: {
+          id: 'dup-search',
+          suggestionSource: () => duplicateFruits,
+        },
+      });
+      const input = container.querySelector('input') as HTMLInputElement;
+      await fireEvent.input(input, { target: { value: 'a' } });
+      // Wait for the Promise.then microtask to complete.
+      await tick();
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('Duplicate suggestion values'));
+      // Duplicate suggestions are not rendered (to avoid a keyed-each key
+      // collision); only the "No suggestions" status row may be present.
+      const enabledOptions = getOptions().filter((o) => !o.getAttribute('aria-disabled'));
+      expect(enabledOptions).toHaveLength(0);
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  test('does not warn when suggestion values are all unique', async () => {
+    const warnSpy = spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      const { container } = render(Autocomplete, {
+        props: {
+          id: 'unique-search',
+          suggestionSource: () => fruits,
+        },
+      });
+      const input = container.querySelector('input') as HTMLInputElement;
+      await fireEvent.input(input, { target: { value: 'a' } });
+
+      await waitFor(() => {
+        expect(getOptions().length).toBeGreaterThan(0);
+      });
+      expect(warnSpy).not.toHaveBeenCalled();
+    } finally {
+      warnSpy.mockRestore();
+    }
   });
 });

--- a/packages/components/src/components/color-swatch-picker/color-swatch-picker.svelte
+++ b/packages/components/src/components/color-swatch-picker/color-swatch-picker.svelte
@@ -15,7 +15,7 @@
 </script>
 
 <script lang="ts">
-  import type { ColorSwatchPickerProps } from './color-swatch-picker.types.ts';
+  import type { ColorSwatch, ColorSwatchPickerProps } from './color-swatch-picker.types.ts';
   import { tick, untrack } from 'svelte';
 
   import { classNames } from '../../utilities/class-names.ts';
@@ -43,6 +43,31 @@
   let internalValue = $state(untrack(() => defaultValue) ?? '');
   const selected = $derived(value ?? internalValue);
 
+  // Deduplicate swatches by color (first occurrence wins) so the keyed {#each}
+  // never receives duplicate keys and Svelte cannot throw each_key_duplicate.
+  // A dev warning is emitted when duplicates are found so the data author can fix
+  // their input, but the component continues to render the deduplicated list.
+  const renderableColors = $derived.by(() => {
+    const seen = new Set<string>();
+    const result: ColorSwatch[] = [];
+    let hasDuplicates = false;
+    for (const swatch of colors) {
+      if (seen.has(swatch.color)) {
+        hasDuplicates = true;
+      } else {
+        seen.add(swatch.color);
+        result.push(swatch);
+      }
+    }
+    if (hasDuplicates) {
+      devWarn(
+        '[ColorSwatchPicker] Duplicate color values detected in palette. ' +
+          'Only the first matching swatch will be shown as selected. Duplicates were removed.',
+      );
+    }
+    return result;
+  });
+
   // Track focus index driven by user interaction. null = derive from selection.
   let userFocusIndex = $state<number | null>(null);
 
@@ -53,25 +78,25 @@
   });
 
   const effectiveFocusIndex = $derived.by(() => {
-    if (colors.length === 0) return -1;
+    if (renderableColors.length === 0) return -1;
 
     // 1. User-driven focus if it points to a valid, non-item-disabled option.
     if (
       userFocusIndex !== null &&
-      userFocusIndex < colors.length &&
-      !colors[userFocusIndex]?.disabled
+      userFocusIndex < renderableColors.length &&
+      !renderableColors[userFocusIndex]?.disabled
     ) {
       return userFocusIndex;
     }
 
     // 2. Currently selected swatch if it exists and is not item-disabled.
-    const selectedIndex = colors.findIndex((s) => s.color === selected);
-    if (selectedIndex !== -1 && !colors[selectedIndex]?.disabled) {
+    const selectedIndex = renderableColors.findIndex((s) => s.color === selected);
+    if (selectedIndex !== -1 && !renderableColors[selectedIndex]?.disabled) {
       return selectedIndex;
     }
 
     // 3. First non-item-disabled option.
-    const firstEnabled = colors.findIndex((s) => !s.disabled);
+    const firstEnabled = renderableColors.findIndex((s) => !s.disabled);
     if (firstEnabled !== -1) return firstEnabled;
 
     // 4. First option in DOM order (ensures the control always has a tab stop).
@@ -82,19 +107,19 @@
   let liRefs: (HTMLLIElement | null)[] = $state([]);
 
   // Index of the first swatch (by DOM order) matching `selected` — for aria-selected.
-  const selectedIndex = $derived(colors.findIndex((s) => s.color === selected));
+  const selectedIndex = $derived(renderableColors.findIndex((s) => s.color === selected));
 
   function isItemDisabledForRoving(index: number): boolean {
-    return colors[index]?.disabled === true;
+    return renderableColors[index]?.disabled === true;
   }
 
   function isInteractive(index: number): boolean {
-    return !disabled && !colors[index]?.disabled;
+    return !disabled && !renderableColors[index]?.disabled;
   }
 
   function selectSwatch(index: number): void {
     if (!isInteractive(index)) return;
-    const swatch = colors[index];
+    const swatch = renderableColors[index];
     if (!swatch) return;
     internalValue = swatch.color;
     onchange?.(swatch.color);
@@ -112,7 +137,7 @@
       return;
     }
 
-    const newIndex = handleRovingKeydown(event, effectiveFocusIndex, colors.length, {
+    const newIndex = handleRovingKeydown(event, effectiveFocusIndex, renderableColors.length, {
       vertical: true,
       horizontal: layout === 'grid',
       isDisabled: isItemDisabledForRoving,
@@ -133,17 +158,6 @@
     userFocusIndex = index;
     selectSwatch(index);
   }
-
-  // Warn in dev mode when duplicate colors appear in the palette.
-  $effect.pre(() => {
-    const colorValues = colors.map((c) => c.color);
-    if (new Set(colorValues).size !== colorValues.length) {
-      devWarn(
-        '[ColorSwatchPicker] Duplicate color values detected in palette. ' +
-          'Only the first matching swatch will be shown as selected.',
-      );
-    }
-  });
 </script>
 
 <ul
@@ -157,7 +171,7 @@
   data-cinder-layout={layout}
   onkeydown={handleKeydown}
 >
-  {#each colors as swatch, index (swatch.color)}
+  {#each renderableColors as swatch, index (swatch.color)}
     {@const isSelected = index === selectedIndex}
     {@const isDisabled = swatch.disabled === true}
     {@const contrastColor = pickContrastColor(swatch.color)}

--- a/packages/components/src/components/color-swatch-picker/color-swatch-picker.svelte
+++ b/packages/components/src/components/color-swatch-picker/color-swatch-picker.svelte
@@ -135,7 +135,7 @@
   }
 
   // Warn in dev mode when duplicate colors appear in the palette.
-  $effect(() => {
+  $effect.pre(() => {
     const colorValues = colors.map((c) => c.color);
     if (new Set(colorValues).size !== colorValues.length) {
       devWarn(
@@ -157,7 +157,7 @@
   data-cinder-layout={layout}
   onkeydown={handleKeydown}
 >
-  {#each colors as swatch, index (swatch.color + index)}
+  {#each colors as swatch, index (swatch.color)}
     {@const isSelected = index === selectedIndex}
     {@const isDisabled = swatch.disabled === true}
     {@const contrastColor = pickContrastColor(swatch.color)}

--- a/packages/components/src/components/color-swatch-picker/color-swatch-picker.test.ts
+++ b/packages/components/src/components/color-swatch-picker/color-swatch-picker.test.ts
@@ -476,35 +476,33 @@ describe('ColorSwatchPicker empty palette', () => {
 });
 
 describe('ColorSwatchPicker duplicate palette', () => {
-  test('emits a devWarn when the palette is updated to contain duplicate color values', async () => {
-    // The $effect.pre duplicate check runs before DOM mutations, so the warning
-    // fires before Svelte processes the keyed each block. Start with unique colors,
-    // then rerender with duplicates to trigger the reactive update path.
+  test('deduplicates swatches and emits a devWarn when duplicate color values are present', () => {
+    // With $derived.by dedup, the component never passes duplicates to the keyed
+    // {#each}, so Svelte cannot throw each_key_duplicate. The test asserts that:
+    //   1. No crash occurs (no try/catch needed).
+    //   2. Only the first occurrence of each color is rendered.
+    //   3. The first swatch is aria-selected when its color matches defaultValue.
+    //   4. The devWarn fires so the developer is notified.
     const warnSpy = spyOn(console, 'warn').mockImplementation(() => {});
     try {
-      const uniqueColors = [
-        { color: '#ff0000', name: 'Red' },
-        { color: '#00ff00', name: 'Green' },
-        { color: '#0000ff', name: 'Blue' },
-      ];
-      const { rerender } = render(ColorSwatchPicker, {
-        colors: uniqueColors,
-        label: 'Colors',
-      });
-      expect(warnSpy).not.toHaveBeenCalled();
-
-      // Rerender with duplicates — $effect.pre fires the devWarn before Svelte
-      // processes the keyed each. Swallow any subsequent Svelte throw.
       const duplicateColors = [
         { color: '#ff0000', name: 'Red 1' },
         { color: '#ff0000', name: 'Red 2' },
         { color: '#0000ff', name: 'Blue' },
       ];
-      try {
-        await rerender({ colors: duplicateColors, label: 'Colors' });
-      } catch {
-        // Svelte may throw each_key_duplicate after our warning has already fired.
-      }
+      const { container } = render(ColorSwatchPicker, {
+        colors: duplicateColors,
+        label: 'Colors',
+        defaultValue: '#ff0000',
+      });
+      // Only 2 swatches render: first #ff0000 and #0000ff (duplicate dropped).
+      const options = toArray(container.querySelectorAll('[role="option"]'));
+      expect(options).toHaveLength(2);
+      // First swatch (the first #ff0000) carries aria-selected because
+      // defaultValue matches its color.
+      expect(options[0]?.getAttribute('aria-selected')).toBe('true');
+      expect(options[1]?.getAttribute('aria-selected')).toBe('false');
+      // devWarn fires exactly once to notify the developer.
       expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('Duplicate color values'));
     } finally {
       warnSpy.mockRestore();

--- a/packages/components/src/components/color-swatch-picker/color-swatch-picker.test.ts
+++ b/packages/components/src/components/color-swatch-picker/color-swatch-picker.test.ts
@@ -476,24 +476,35 @@ describe('ColorSwatchPicker empty palette', () => {
 });
 
 describe('ColorSwatchPicker duplicate palette', () => {
-  test('only first matching swatch receives aria-selected (and warns in dev)', () => {
-    // A duplicate palette intentionally trips the dev warning. Scope the spy to
-    // this test so incidental warnings elsewhere still fail their tests.
+  test('emits a devWarn when the palette is updated to contain duplicate color values', async () => {
+    // The $effect.pre duplicate check runs before DOM mutations, so the warning
+    // fires before Svelte processes the keyed each block. Start with unique colors,
+    // then rerender with duplicates to trigger the reactive update path.
     const warnSpy = spyOn(console, 'warn').mockImplementation(() => {});
     try {
-      const colors = [
+      const uniqueColors = [
+        { color: '#ff0000', name: 'Red' },
+        { color: '#00ff00', name: 'Green' },
+        { color: '#0000ff', name: 'Blue' },
+      ];
+      const { rerender } = render(ColorSwatchPicker, {
+        colors: uniqueColors,
+        label: 'Colors',
+      });
+      expect(warnSpy).not.toHaveBeenCalled();
+
+      // Rerender with duplicates — $effect.pre fires the devWarn before Svelte
+      // processes the keyed each. Swallow any subsequent Svelte throw.
+      const duplicateColors = [
         { color: '#ff0000', name: 'Red 1' },
         { color: '#ff0000', name: 'Red 2' },
-        { color: '#0000ff' },
+        { color: '#0000ff', name: 'Blue' },
       ];
-      const { container } = render(ColorSwatchPicker, {
-        colors,
-        label: 'Colors',
-        defaultValue: '#ff0000',
-      });
-      const options = toArray(container.querySelectorAll('[role="option"]'));
-      expect(options[0].getAttribute('aria-selected')).toBe('true');
-      expect(options[1].getAttribute('aria-selected')).toBe('false');
+      try {
+        await rerender({ colors: duplicateColors, label: 'Colors' });
+      } catch {
+        // Svelte may throw each_key_duplicate after our warning has already fired.
+      }
       expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('Duplicate color values'));
     } finally {
       warnSpy.mockRestore();

--- a/packages/components/src/components/pricing-card/pricing-card.svelte
+++ b/packages/components/src/components/pricing-card/pricing-card.svelte
@@ -33,12 +33,28 @@
     ...rest
   }: PricingCardProps = $props();
 
-  $effect.pre(() => {
-    if (new Set(features).size !== features.length) {
+  // Deduplicate features by value (first occurrence wins) so the keyed {#each}
+  // never receives duplicate keys and Svelte cannot throw each_key_duplicate.
+  // A dev warning is emitted when duplicates are found so the data author can fix
+  // their input, but the component continues to render the deduplicated list.
+  const renderableFeatures = $derived.by(() => {
+    const seen = new Set<string>();
+    const result: string[] = [];
+    let hasDuplicates = false;
+    for (const feature of features) {
+      if (seen.has(feature)) {
+        hasDuplicates = true;
+      } else {
+        seen.add(feature);
+        result.push(feature);
+      }
+    }
+    if (hasDuplicates) {
       devWarn(
-        '[cinder/PricingCard] Duplicate feature values detected. Each feature must be unique when used as a list key.',
+        '[cinder/PricingCard] Duplicate feature values detected. Each feature must be unique when used as a list key. Duplicates were removed; only the first occurrence of each value is shown.',
       );
     }
+    return result;
   });
 </script>
 
@@ -63,7 +79,7 @@
 
   <div class="cinder-pricing-card__body">
     <ul class="cinder-pricing-card__features">
-      {#each features as feature (feature)}
+      {#each renderableFeatures as feature (feature)}
         <li class="cinder-pricing-card__feature">{feature}</li>
       {/each}
     </ul>

--- a/packages/components/src/components/pricing-card/pricing-card.svelte
+++ b/packages/components/src/components/pricing-card/pricing-card.svelte
@@ -17,6 +17,7 @@
 
 <script lang="ts">
   import { classNames } from '../../utilities/class-names.ts';
+  import { devWarn } from '../../utilities/dev-warn.ts';
   import Button from '../button/button.svelte';
   import type { PricingCardProps } from './pricing-card.types.ts';
 
@@ -31,6 +32,14 @@
     class: className,
     ...rest
   }: PricingCardProps = $props();
+
+  $effect.pre(() => {
+    if (new Set(features).size !== features.length) {
+      devWarn(
+        '[cinder/PricingCard] Duplicate feature values detected. Each feature must be unique when used as a list key.',
+      );
+    }
+  });
 </script>
 
 <div
@@ -54,7 +63,7 @@
 
   <div class="cinder-pricing-card__body">
     <ul class="cinder-pricing-card__features">
-      {#each features as feature, index (index)}
+      {#each features as feature (feature)}
         <li class="cinder-pricing-card__feature">{feature}</li>
       {/each}
     </ul>

--- a/packages/components/src/components/pricing-card/pricing-card.test.ts
+++ b/packages/components/src/components/pricing-card/pricing-card.test.ts
@@ -1,5 +1,5 @@
 /// <reference lib="dom" />
-import { describe, expect, mock, test } from 'bun:test';
+import { afterEach, describe, expect, mock, spyOn, test } from 'bun:test';
 
 import { setupHappyDom } from '../../test/happy-dom.ts';
 
@@ -8,8 +8,13 @@ import { setupHappyDom } from '../../test/happy-dom.ts';
 // so we register happy-dom's globals first and then dynamic-import testing-library below.
 setupHappyDom();
 
-const { render, fireEvent } = await import('@testing-library/svelte');
+const { render, fireEvent, cleanup } = await import('@testing-library/svelte');
 const { default: PricingCard } = await import('./pricing-card.svelte');
+
+afterEach(() => {
+  cleanup();
+  document.body.replaceChildren();
+});
 
 const BASE_PROPS = {
   name: 'Pro',
@@ -135,6 +140,56 @@ describe('PricingCard', () => {
     expect(caveat?.tagName).toBe('P');
     const features = container.querySelectorAll('.cinder-pricing-card__feature');
     expect(features).toHaveLength(3);
+  });
+});
+
+describe('PricingCard each-key behavior', () => {
+  test('emits a devWarn when features are updated to contain duplicate values', async () => {
+    // The $effect.pre duplicate check runs before DOM mutations, so the warning
+    // fires before Svelte processes the keyed each block. Start with unique
+    // features, then rerender with duplicates to trigger the reactive update path.
+    const warnSpy = spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      const { rerender } = render(PricingCard, {
+        props: { ...BASE_PROPS, features: ['Feature A', 'Feature B', 'Feature C'] },
+      });
+      expect(warnSpy).not.toHaveBeenCalled();
+
+      // Rerender with duplicates — $effect.pre fires the devWarn before Svelte
+      // processes the keyed each. Swallow any subsequent Svelte throw.
+      try {
+        await rerender({ ...BASE_PROPS, features: ['Feature A', 'Feature B', 'Feature A'] });
+      } catch {
+        // Svelte may throw each_key_duplicate after our warning has already fired.
+      }
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('Duplicate feature values'));
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  test('does not warn when all feature values are unique', () => {
+    const warnSpy = spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      render(PricingCard, { props: { ...BASE_PROPS } });
+      expect(warnSpy).not.toHaveBeenCalled();
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  test('renders updated features when list is filtered', async () => {
+    const { container, rerender } = render(PricingCard, {
+      props: { ...BASE_PROPS, features: ['Alpha', 'Beta', 'Gamma'] },
+    });
+    let items = container.querySelectorAll('.cinder-pricing-card__feature');
+    expect(items).toHaveLength(3);
+
+    await rerender({ ...BASE_PROPS, features: ['Alpha', 'Gamma'] });
+    items = container.querySelectorAll('.cinder-pricing-card__feature');
+    expect(items).toHaveLength(2);
+    expect(items[0]?.textContent?.trim()).toBe('Alpha');
+    expect(items[1]?.textContent?.trim()).toBe('Gamma');
   });
 });
 

--- a/packages/components/src/components/pricing-card/pricing-card.test.ts
+++ b/packages/components/src/components/pricing-card/pricing-card.test.ts
@@ -144,24 +144,23 @@ describe('PricingCard', () => {
 });
 
 describe('PricingCard each-key behavior', () => {
-  test('emits a devWarn when features are updated to contain duplicate values', async () => {
-    // The $effect.pre duplicate check runs before DOM mutations, so the warning
-    // fires before Svelte processes the keyed each block. Start with unique
-    // features, then rerender with duplicates to trigger the reactive update path.
+  test('deduplicates features and emits a devWarn when duplicate values are present', async () => {
+    // With $derived.by dedup, the component never passes duplicates to the keyed
+    // {#each}, so Svelte cannot throw each_key_duplicate. The test asserts that:
+    //   1. No crash occurs (no try/catch needed).
+    //   2. Only the first occurrence of each value is rendered.
+    //   3. The devWarn fires so the developer is notified.
     const warnSpy = spyOn(console, 'warn').mockImplementation(() => {});
     try {
-      const { rerender } = render(PricingCard, {
-        props: { ...BASE_PROPS, features: ['Feature A', 'Feature B', 'Feature C'] },
+      const { container } = render(PricingCard, {
+        props: { ...BASE_PROPS, features: ['Feature A', 'Feature B', 'Feature A'] },
       });
-      expect(warnSpy).not.toHaveBeenCalled();
-
-      // Rerender with duplicates — $effect.pre fires the devWarn before Svelte
-      // processes the keyed each. Swallow any subsequent Svelte throw.
-      try {
-        await rerender({ ...BASE_PROPS, features: ['Feature A', 'Feature B', 'Feature A'] });
-      } catch {
-        // Svelte may throw each_key_duplicate after our warning has already fired.
-      }
+      // Renders the deduped list — 'Feature A' only once.
+      const items = container.querySelectorAll('.cinder-pricing-card__feature');
+      expect(items).toHaveLength(2);
+      expect(items[0]?.textContent?.trim()).toBe('Feature A');
+      expect(items[1]?.textContent?.trim()).toBe('Feature B');
+      // devWarn fires exactly once to notify the developer.
       expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('Duplicate feature values'));
     } finally {
       warnSpy.mockRestore();

--- a/packages/components/src/components/shortcut-hint/shortcut-hint.svelte
+++ b/packages/components/src/components/shortcut-hint/shortcut-hint.svelte
@@ -47,7 +47,7 @@
   {/if}
 
   <span class="cinder-shortcut-hint__keys" aria-hidden="true">
-    {#each keys as key, index (key + index)}
+    {#each keys as key, index (index)}
       <Kbd label={key} size="sm" />
       {#if index < keys.length - 1}
         <span class="cinder-shortcut-hint__separator">+</span>


### PR DESCRIPTION
## Summary

Four components used unstable/index `{#each}` keys, causing avoidable DOM teardown, stale per-row state, and focus churn on reorder/filter. This switches them to value-based identity keys — done safely, by deduplicating before the keyed block consumes the data.

Closes #465

## The core correctness point (committee + Codex)

Keying a `{#each}` by value is only safe if uniqueness is enforced **before** the block consumes the data — otherwise Svelte throws `each_key_duplicate` on duplicate values. A warning-only guard (`$effect.pre` or a warn-only `$derived`) is insufficient: the duplicate list still reaches the keyed block and crashes. So:

- **PricingCard / ColorSwatchPicker:** a `$derived.by` returns a **deduplicated** list (first occurrence wins, `devWarn` in dev), and the `{#each}` renders that derived list — crash-proof on initial render, not just on rerender.
- **Autocomplete:** previously, on duplicate values it did `devWarn(); loading=false; return;` — silently dropping **all** results (an empty dropdown in production, where `devWarn` is stripped). Now it dedups by first occurrence, warns in dev, and renders the unique list (dropdown opens, active index clamped, no stale suggestions).
- **ShortcutHint:** pure-index key (position is the chord identity).

## Tests

The original tests wrapped the duplicate render in `try/catch` that **swallowed** the `each_key_duplicate` throw — proving "a warn fired around a crash," not "it's fixed." Rewritten to render duplicate data directly and assert crash-free de-duplicated output + a non-vacuous `devWarn` spy (`try/finally` is only spy restoration — no `catch`). The autocomplete test now asserts unique results render (length 2) instead of the old suppression behavior (length 0).

## Review committee

Pre-reviewed by: svelte-expert, testing-expert, simplicity-engineer + Codex (gpt-5.4, xhigh) — 1 round. Codex supplied the dedup-before-render principle and flagged the autocomplete suppression as a production regression; all must-fixes addressed.

## Test plan

101 pass / 0 fail across autocomplete, pricing-card, color-swatch-picker, shortcut-hint; full package suite green via pre-commit.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped UI list rendering and defensive input normalization; autocomplete behavior improves on bad data with no auth or data-persistence changes.
> 
> **Overview**
> Several list-rendering components now **deduplicate input by stable identity** (first occurrence wins) before keyed `{#each}` blocks run, with **`devWarn` in dev** when duplicates are detected—so value-based keys cannot trigger Svelte’s `each_key_duplicate` crash.
> 
> **Autocomplete** dedupes the **full** suggestion list by `value` (not only the visible slice), keys options on `suggestion.value`, and **still opens the dropdown** with unique results instead of discarding all suggestions on duplicates. **ColorSwatchPicker** and **PricingCard** use `$derived.by` lists (`renderableColors` / `renderableFeatures`) for the same pattern; keyboard/selection logic on the swatch picker follows the deduped list. **ShortcutHint** keys keycaps by **index** (position defines the chord).
> 
> Tests were updated to assert crash-free deduped output and `devWarn`, including autocomplete regressions for tail duplicates beyond `maxVisibleSuggestions`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c15e30e71b1b858ab86c6b6f43ab70a1611a7e98. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->