### PR TITLE
Address documentation audit issues

### DIFF
--- a/.changeset/documentation-audit-accessibility.md
+++ b/.changeset/documentation-audit-accessibility.md
@@ -1,0 +1,7 @@
+---
+'@lostgradient/cinder': minor
+---
+
+Backfill missing component accessibility documentation, gate `.a11y.md` presence in `components:check`, and tighten DataGrid/DataTable audit fixes.
+
+DataGrid columns can now opt into `role="rowheader"` with `rowHeader: true`, virtualized-column overflow keeps a stable gutter and edge cue, and DataTable sortable headers describe the next sort action while focused rows receive the same hover affordance. The package also normalizes optional Svelte component function parameters so packed source remains valid for downstream SvelteKit consumers.

--- a/packages/components/scripts/check-promotion-readiness.test.ts
+++ b/packages/components/scripts/check-promotion-readiness.test.ts
@@ -222,9 +222,9 @@ describe('hasA11yDoc', () => {
   });
 
   test('returns false for a component without an a11y doc', () => {
-    // container is layout (non-interactive) and lacks an a11y doc
-    const dir = componentDirectory('container');
-    expect(hasA11yDoc(dir, 'container')).toBe(false);
+    // table-cell is a compose-only leaf whose accessibility contract lives on Table.
+    const dir = componentDirectory('table-cell');
+    expect(hasA11yDoc(dir, 'table-cell')).toBe(false);
   });
 });
 

--- a/packages/components/scripts/generate-component-artifacts.ts
+++ b/packages/components/scripts/generate-component-artifacts.ts
@@ -41,6 +41,30 @@ import { renderComponentReadme } from './render-component-readme.ts';
 
 export { discoverComponentDirectories, type DiscoveredComponent };
 
+const COMPOSE_ONLY_ACCESSIBILITY_DOCUMENTATION_EXEMPTIONS = new Set([
+  'accordion-item',
+  'dropdown-group',
+  'dropdown-item',
+  'dropdown-label',
+  'dropdown-menu',
+  'dropdown-separator',
+  'dropdown-trigger',
+  'feed-event',
+  'grid-list-item',
+  'side-navigation-group',
+  'side-navigation-item',
+  'stat',
+  'tab',
+  'tab-list',
+  'tab-panel',
+  'table-body',
+  'table-cell',
+  'table-header',
+  'table-header-cell',
+  'table-row',
+  'tree-item',
+]);
+
 /**
  * Run prettier over the generated content using the repo's prettier config.
  * Without this, lint-staged's prettier --write pass reformats our generated
@@ -156,6 +180,16 @@ export async function checkComponentArtifacts(): Promise<DriftIssue[]> {
     // to fill the generated regions.)
     if (!existsSync(join(component.directory, 'README.md'))) {
       issues.push({ component: component.name, file: 'README.md', reason: 'missing' });
+    }
+    if (
+      !COMPOSE_ONLY_ACCESSIBILITY_DOCUMENTATION_EXEMPTIONS.has(component.name) &&
+      !existsSync(join(component.directory, `${component.name}.a11y.md`))
+    ) {
+      issues.push({
+        component: component.name,
+        file: `${component.name}.a11y.md`,
+        reason: 'missing',
+      });
     }
 
     for (const { filename, expected } of files) {

--- a/packages/components/src/components/access-gate/access-gate-inline.svelte
+++ b/packages/components/src/components/access-gate/access-gate-inline.svelte
@@ -231,7 +231,9 @@
       moveFocusOffControl(control);
     }
 
-    function syncDisabledControls(stateRefreshes?: ConsumerStateRefreshes): void {
+    function syncDisabledControls(
+      stateRefreshes: ConsumerStateRefreshes | undefined = undefined,
+    ): void {
       const currentControls = new Set(element.querySelectorAll<HTMLElement>(INTERACTIVE_SELECTOR));
 
       for (const control of currentControls) {

--- a/packages/components/src/components/access-gate/access-gate.a11y.md
+++ b/packages/components/src/components/access-gate/access-gate.a11y.md
@@ -1,0 +1,38 @@
+# AccessGate · accessibility
+
+## Pattern
+
+AccessGate communicates status or supporting context. Keep the message text concise, and choose the surrounding live-region behavior based on whether the condition is immediate, persistent, or purely informational.
+
+Purpose: Authorization-scope gate that keeps unavailable actions visible with an accessible reason or replaces locked sections with a scope-required placeholder.
+
+## Use when
+
+- Showing a mutating action that the current user cannot activate because an application authorization scope is missing.
+- Replacing a panel, tab, or administrative section with a lock state that names the missing scope or permission.
+
+## Avoid when
+
+- Checking browser permissions, media capabilities, or feature support — use capability-gate instead.
+- Resolving roles, scopes, or policies — compute granted in application code and pass the boolean in.
+
+## Keyboard and focus
+
+Keyboard behavior follows the rendered native elements and any ARIA pattern documented by the component. Avoid adding handlers that change focus order without a matching visible and programmatic state update.
+
+Keep focus indicators visible. If you wrap or restyle AccessGate, verify the focused element remains visually apparent in default and forced-colors modes.
+
+## Names, roles, and state
+
+Use the public props and documented examples to provide accessible names, descriptions, current state, disabled state, selection state, or value text. Do not rely on color, icon shape, placeholder text, or layout position as the only way to communicate meaning.
+
+When AccessGate accepts snippets or arbitrary children, the caller owns the semantics inside those children. Prefer native elements first, and add ARIA only when it matches the rendered behavior.
+
+## Verification
+
+- Render AccessGate in the playground or a focused test fixture.
+- Navigate the component with keyboard only.
+- Inspect the accessible name, role, and state in browser accessibility tools.
+- Check forced-colors mode when the component adds borders, focus rings, selected state, or status color.
+
+Related components: `capability-gate`, `button`, `callout`, `empty-state`.

--- a/packages/components/src/components/alert/alert.a11y.md
+++ b/packages/components/src/components/alert/alert.a11y.md
@@ -1,0 +1,38 @@
+# Alert · accessibility
+
+## Pattern
+
+Alert communicates status or supporting context. Keep the message text concise, and choose the surrounding live-region behavior based on whether the condition is immediate, persistent, or purely informational.
+
+Purpose: Inline status message with assertive role for surfacing time-sensitive feedback about a nearby action or region.
+
+## Use when
+
+- Surfacing the result of a just-completed action such as a save failure or success.
+- Calling out a transient condition the user must notice immediately within a specific region.
+
+## Avoid when
+
+- Communicating a page- or app-wide notice that persists across views — use a banner instead.
+- Providing supplemental commentary or guidance inline with content — use a callout instead.
+
+## Keyboard and focus
+
+Keyboard behavior follows the rendered native elements and any ARIA pattern documented by the component. Avoid adding handlers that change focus order without a matching visible and programmatic state update.
+
+Keep focus indicators visible. If you wrap or restyle Alert, verify the focused element remains visually apparent in default and forced-colors modes.
+
+## Names, roles, and state
+
+Use the public props and documented examples to provide accessible names, descriptions, current state, disabled state, selection state, or value text. Do not rely on color, icon shape, placeholder text, or layout position as the only way to communicate meaning.
+
+When Alert accepts snippets or arbitrary children, the caller owns the semantics inside those children. Prefer native elements first, and add ARIA only when it matches the rendered behavior.
+
+## Verification
+
+- Render Alert in the playground or a focused test fixture.
+- Navigate the component with keyboard only.
+- Inspect the accessible name, role, and state in browser accessibility tools.
+- Check forced-colors mode when the component adds borders, focus rings, selected state, or status color.
+
+Related components: `banner`, `callout`, `toast-region`.

--- a/packages/components/src/components/aspect-ratio/aspect-ratio.a11y.md
+++ b/packages/components/src/components/aspect-ratio/aspect-ratio.a11y.md
@@ -1,0 +1,38 @@
+# AspectRatio · accessibility
+
+## Pattern
+
+AspectRatio affects structure rather than meaning. Use it without removing headings, landmarks, labels, or reading order from the content it contains.
+
+Purpose: Generic media box that enforces a fixed aspect ratio for arbitrary embedded content using the native CSS aspect-ratio property.
+
+## Use when
+
+- Reserving stable space for embedded media, previews, or art-directed content before it loads.
+- You need a generic ratio wrapper for iframe, video, canvas, or custom content rather than an image-specific primitive.
+
+## Avoid when
+
+- The child already owns its sizing contract and should determine its own height naturally.
+- Supporting legacy browsers that lack native aspect-ratio support.
+
+## Keyboard and focus
+
+Keyboard behavior follows the rendered native elements and any ARIA pattern documented by the component. Avoid adding handlers that change focus order without a matching visible and programmatic state update.
+
+Keep focus indicators visible. If you wrap or restyle AspectRatio, verify the focused element remains visually apparent in default and forced-colors modes.
+
+## Names, roles, and state
+
+Use the public props and documented examples to provide accessible names, descriptions, current state, disabled state, selection state, or value text. Do not rely on color, icon shape, placeholder text, or layout position as the only way to communicate meaning.
+
+When AspectRatio accepts snippets or arbitrary children, the caller owns the semantics inside those children. Prefer native elements first, and add ARIA only when it matches the rendered behavior.
+
+## Verification
+
+- Render AspectRatio in the playground or a focused test fixture.
+- Navigate the component with keyboard only.
+- Inspect the accessible name, role, and state in browser accessibility tools.
+- Check forced-colors mode when the component adds borders, focus rings, selected state, or status color.
+
+Related components: `image`, `card`.

--- a/packages/components/src/components/avatar-group/avatar-group.a11y.md
+++ b/packages/components/src/components/avatar-group/avatar-group.a11y.md
@@ -1,0 +1,38 @@
+# AvatarGroup · accessibility
+
+## Pattern
+
+AvatarGroup presents structured data. Preserve the component's semantic roles, row or item labels, and ordering so assistive technology can announce the same relationships that are visible on screen.
+
+Purpose: Overlapping collaborator avatar stack built on the Avatar primitive with focusable names and overflow count.
+
+## Use when
+
+- Showing who is present, assigned, or collaborating in a compact surface.
+- Summarizing a bounded set of people with a visible overflow count.
+
+## Avoid when
+
+- Rendering a single person — use avatar instead.
+- Showing status, counts, or metadata labels unrelated to people — use badge, chip, or status-dot instead.
+
+## Keyboard and focus
+
+Keyboard behavior follows the rendered native elements and any ARIA pattern documented by the component. Avoid adding handlers that change focus order without a matching visible and programmatic state update.
+
+Keep focus indicators visible. If you wrap or restyle AvatarGroup, verify the focused element remains visually apparent in default and forced-colors modes.
+
+## Names, roles, and state
+
+Use the public props and documented examples to provide accessible names, descriptions, current state, disabled state, selection state, or value text. Do not rely on color, icon shape, placeholder text, or layout position as the only way to communicate meaning.
+
+When AvatarGroup accepts snippets or arbitrary children, the caller owns the semantics inside those children. Prefer native elements first, and add ARIA only when it matches the rendered behavior.
+
+## Verification
+
+- Render AvatarGroup in the playground or a focused test fixture.
+- Navigate the component with keyboard only.
+- Inspect the accessible name, role, and state in browser accessibility tools.
+- Check forced-colors mode when the component adds borders, focus rings, selected state, or status color.
+
+Related components: `avatar`, `badge`, `tooltip`, `status-dot`.

--- a/packages/components/src/components/avatar/avatar.a11y.md
+++ b/packages/components/src/components/avatar/avatar.a11y.md
@@ -1,0 +1,37 @@
+# Avatar · accessibility
+
+## Pattern
+
+Avatar presents structured data. Preserve the component's semantic roles, row or item labels, and ordering so assistive technology can announce the same relationships that are visible on screen.
+
+Purpose: Profile graphic that renders a user image with automatic initials fallback when the source is missing or fails to load.
+
+## Use when
+
+- Representing a person or account next to their name or activity.
+- Displaying initials when no avatar image is available.
+
+## Avoid when
+
+- Showing a small status or count indicator — use badge or status-dot instead.
+
+## Keyboard and focus
+
+Keyboard behavior follows the rendered native elements and any ARIA pattern documented by the component. Avoid adding handlers that change focus order without a matching visible and programmatic state update.
+
+Keep focus indicators visible. If you wrap or restyle Avatar, verify the focused element remains visually apparent in default and forced-colors modes.
+
+## Names, roles, and state
+
+Use the public props and documented examples to provide accessible names, descriptions, current state, disabled state, selection state, or value text. Do not rely on color, icon shape, placeholder text, or layout position as the only way to communicate meaning.
+
+When Avatar accepts snippets or arbitrary children, the caller owns the semantics inside those children. Prefer native elements first, and add ARIA only when it matches the rendered behavior.
+
+## Verification
+
+- Render Avatar in the playground or a focused test fixture.
+- Navigate the component with keyboard only.
+- Inspect the accessible name, role, and state in browser accessibility tools.
+- Check forced-colors mode when the component adds borders, focus rings, selected state, or status color.
+
+Related components: `badge`, `status-dot`, `image`.

--- a/packages/components/src/components/backdrop/backdrop.a11y.md
+++ b/packages/components/src/components/backdrop/backdrop.a11y.md
@@ -1,0 +1,39 @@
+# Backdrop · accessibility
+
+## Pattern
+
+Backdrop presents layered content. Keep trigger, focus movement, dismissal, and labelling in one predictable interaction path so users can enter and leave the layer without losing context.
+
+Purpose: Full-viewport fixed scrim primitive for custom overlay patterns such as loading dimmers and image lightboxes.
+
+## Use when
+
+- Providing a full-screen dimming layer behind a custom overlay that is not modal, drawer, or sheet.
+- Building a loading state that dims the full viewport while an async operation runs.
+
+## Avoid when
+
+- Interrupting the user for a decision — use modal or alert-dialog which manage focus and Escape automatically.
+- Showing a side panel — use drawer instead.
+- Showing structured content in a dialog — use modal, drawer, or sheet, which render their own native `<dialog>::backdrop` scrim.
+
+## Keyboard and focus
+
+The trigger should remain reachable by keyboard, and the open layer should provide a clear Escape, close, or outside-interaction path consistent with the component documentation.
+
+Keep focus indicators visible. If you wrap or restyle Backdrop, verify the focused element remains visually apparent in default and forced-colors modes.
+
+## Names, roles, and state
+
+Use the public props and documented examples to provide accessible names, descriptions, current state, disabled state, selection state, or value text. Do not rely on color, icon shape, placeholder text, or layout position as the only way to communicate meaning.
+
+When Backdrop accepts snippets or arbitrary children, the caller owns the semantics inside those children. Prefer native elements first, and add ARIA only when it matches the rendered behavior.
+
+## Verification
+
+- Render Backdrop in the playground or a focused test fixture.
+- Navigate the component with keyboard only.
+- Inspect the accessible name, role, and state in browser accessibility tools.
+- Check forced-colors mode when the component adds borders, focus rings, selected state, or status color.
+
+Related components: `modal`, `drawer`, `sheet`.

--- a/packages/components/src/components/badge/badge.a11y.md
+++ b/packages/components/src/components/badge/badge.a11y.md
@@ -1,0 +1,38 @@
+# Badge · accessibility
+
+## Pattern
+
+Badge presents structured data. Preserve the component's semantic roles, row or item labels, and ordering so assistive technology can announce the same relationships that are visible on screen.
+
+Purpose: Compact non-interactive label that annotates an adjacent element with a short status, count, or category.
+
+## Use when
+
+- Annotating a value with a short status word like "new" or "beta".
+- Displaying a numeric count next to an icon or title.
+
+## Avoid when
+
+- The label must be interactive or removable — use chip instead.
+- Showing only a colored dot for presence — use status-dot instead.
+
+## Keyboard and focus
+
+Keyboard behavior follows the rendered native elements and any ARIA pattern documented by the component. Avoid adding handlers that change focus order without a matching visible and programmatic state update.
+
+Keep focus indicators visible. If you wrap or restyle Badge, verify the focused element remains visually apparent in default and forced-colors modes.
+
+## Names, roles, and state
+
+Use the public props and documented examples to provide accessible names, descriptions, current state, disabled state, selection state, or value text. Do not rely on color, icon shape, placeholder text, or layout position as the only way to communicate meaning.
+
+When Badge accepts snippets or arbitrary children, the caller owns the semantics inside those children. Prefer native elements first, and add ARIA only when it matches the rendered behavior.
+
+## Verification
+
+- Render Badge in the playground or a focused test fixture.
+- Navigate the component with keyboard only.
+- Inspect the accessible name, role, and state in browser accessibility tools.
+- Check forced-colors mode when the component adds borders, focus rings, selected state, or status color.
+
+Related components: `chip`, `status-dot`.

--- a/packages/components/src/components/breadcrumbs/breadcrumbs.a11y.md
+++ b/packages/components/src/components/breadcrumbs/breadcrumbs.a11y.md
@@ -1,0 +1,38 @@
+# Breadcrumbs · accessibility
+
+## Pattern
+
+Breadcrumbs helps users move through destinations or hierarchy. Keep link text and selected/current state accurate so keyboard and assistive-technology users get the same location cues as sighted pointer users.
+
+Purpose: Hierarchical wayfinding trail showing the ancestor path of the current page with the final entry marked as aria-current.
+
+## Use when
+
+- Surfacing where the user sits inside a deep, nested hierarchy.
+- Letting the user jump back to any ancestor view in one click.
+
+## Avoid when
+
+- Switching between sibling sections at the same level — use navigation-bar or tabs.
+- Showing an ordered task progression — use steps instead.
+
+## Keyboard and focus
+
+The browser tab order should follow visual order. Use current/selected state only for the destination or item that is actually current.
+
+Keep focus indicators visible. If you wrap or restyle Breadcrumbs, verify the focused element remains visually apparent in default and forced-colors modes.
+
+## Names, roles, and state
+
+Use the public props and documented examples to provide accessible names, descriptions, current state, disabled state, selection state, or value text. Do not rely on color, icon shape, placeholder text, or layout position as the only way to communicate meaning.
+
+When Breadcrumbs accepts snippets or arbitrary children, the caller owns the semantics inside those children. Prefer native elements first, and add ARIA only when it matches the rendered behavior.
+
+## Verification
+
+- Render Breadcrumbs in the playground or a focused test fixture.
+- Navigate the component with keyboard only.
+- Inspect the accessible name, role, and state in browser accessibility tools.
+- Check forced-colors mode when the component adds borders, focus rings, selected state, or status color.
+
+Related components: `navigation-bar`, `side-navigation`, `steps`.

--- a/packages/components/src/components/capability-gate/capability-gate.a11y.md
+++ b/packages/components/src/components/capability-gate/capability-gate.a11y.md
@@ -1,0 +1,38 @@
+# CapabilityGate · accessibility
+
+## Pattern
+
+CapabilityGate communicates status or supporting context. Keep the message text concise, and choose the surrounding live-region behavior based on whether the condition is immediate, persistent, or purely informational.
+
+Purpose: Present feature availability and next action for browser permission or support states, with accessible status text and focus management.
+
+## Use when
+
+- Surfacing that a feature requires a browser permission such as microphone or notifications.
+- Communicating that a feature is unsupported in the current browser with a clear fallback path.
+
+## Avoid when
+
+- Performing the actual feature detection or permission request — wire that in userland.
+- Storing permission state — CapabilityGate is a pure presentation component.
+
+## Keyboard and focus
+
+Keyboard behavior follows the rendered native elements and any ARIA pattern documented by the component. Avoid adding handlers that change focus order without a matching visible and programmatic state update.
+
+Keep focus indicators visible. If you wrap or restyle CapabilityGate, verify the focused element remains visually apparent in default and forced-colors modes.
+
+## Names, roles, and state
+
+Use the public props and documented examples to provide accessible names, descriptions, current state, disabled state, selection state, or value text. Do not rely on color, icon shape, placeholder text, or layout position as the only way to communicate meaning.
+
+When CapabilityGate accepts snippets or arbitrary children, the caller owns the semantics inside those children. Prefer native elements first, and add ARIA only when it matches the rendered behavior.
+
+## Verification
+
+- Render CapabilityGate in the playground or a focused test fixture.
+- Navigate the component with keyboard only.
+- Inspect the accessible name, role, and state in browser accessibility tools.
+- Check forced-colors mode when the component adds borders, focus rings, selected state, or status color.
+
+Related components: `alert`, `banner`, `callout`, `modal`.

--- a/packages/components/src/components/card/card.a11y.md
+++ b/packages/components/src/components/card/card.a11y.md
@@ -1,0 +1,38 @@
+# Card · accessibility
+
+## Pattern
+
+Card affects structure rather than meaning. Use it without removing headings, landmarks, labels, or reading order from the content it contains.
+
+Purpose: Surface container that groups related content with optional header, title, description, and footer regions.
+
+## Use when
+
+- Grouping a self-contained unit of content such as a summary, preview, or settings panel.
+- Composing a list of comparable items where each needs its own framed region.
+
+## Avoid when
+
+- Rendering a bare visual surface without slotted regions — use surface instead.
+- Presenting a single key metric — use stat or stat-group instead.
+
+## Keyboard and focus
+
+Keyboard behavior follows the rendered native elements and any ARIA pattern documented by the component. Avoid adding handlers that change focus order without a matching visible and programmatic state update.
+
+Keep focus indicators visible. If you wrap or restyle Card, verify the focused element remains visually apparent in default and forced-colors modes.
+
+## Names, roles, and state
+
+Use the public props and documented examples to provide accessible names, descriptions, current state, disabled state, selection state, or value text. Do not rely on color, icon shape, placeholder text, or layout position as the only way to communicate meaning.
+
+When Card accepts snippets or arbitrary children, the caller owns the semantics inside those children. Prefer native elements first, and add ARIA only when it matches the rendered behavior.
+
+## Verification
+
+- Render Card in the playground or a focused test fixture.
+- Navigate the component with keyboard only.
+- Inspect the accessible name, role, and state in browser accessibility tools.
+- Check forced-colors mode when the component adds borders, focus rings, selected state, or status color.
+
+Related components: `surface`, `stat`, `stacked-list-item`, `section-heading`.

--- a/packages/components/src/components/chat-conversation-header/chat-conversation-header.a11y.md
+++ b/packages/components/src/components/chat-conversation-header/chat-conversation-header.a11y.md
@@ -1,0 +1,38 @@
+# ChatConversationHeader · accessibility
+
+## Pattern
+
+ChatConversationHeader packages a higher-level workflow. Confirm the composed controls, labels, states, and keyboard path match the domain task instead of treating the visual shell as the accessibility contract.
+
+Purpose: Header primitive for the active Chat conversation, composed as a sibling above Chat rather than inside it.
+
+## Use when
+
+- Showing the active conversation title, participants, status, and export controls above a Chat transcript.
+- Building a multi-conversation chat layout where the list, header, and Chat surface are composed as siblings.
+
+## Avoid when
+
+- Rendering the conversation switcher — use chat-conversation-list.
+- Rendering the transcript body and composer — use chat.
+
+## Keyboard and focus
+
+Keyboard behavior follows the rendered native elements and any ARIA pattern documented by the component. Avoid adding handlers that change focus order without a matching visible and programmatic state update.
+
+Keep focus indicators visible. If you wrap or restyle ChatConversationHeader, verify the focused element remains visually apparent in default and forced-colors modes.
+
+## Names, roles, and state
+
+Use the public props and documented examples to provide accessible names, descriptions, current state, disabled state, selection state, or value text. Do not rely on color, icon shape, placeholder text, or layout position as the only way to communicate meaning.
+
+When ChatConversationHeader accepts snippets or arbitrary children, the caller owns the semantics inside those children. Prefer native elements first, and add ARIA only when it matches the rendered behavior.
+
+## Verification
+
+- Render ChatConversationHeader in the playground or a focused test fixture.
+- Navigate the component with keyboard only.
+- Inspect the accessible name, role, and state in browser accessibility tools.
+- Check forced-colors mode when the component adds borders, focus rings, selected state, or status color.
+
+Related components: `chat`, `chat-conversation-list`.

--- a/packages/components/src/components/chat-conversation-list/chat-conversation-list.a11y.md
+++ b/packages/components/src/components/chat-conversation-list/chat-conversation-list.a11y.md
@@ -1,0 +1,38 @@
+# ChatConversationList · accessibility
+
+## Pattern
+
+ChatConversationList packages a higher-level workflow. Confirm the composed controls, labels, states, and keyboard path match the domain task instead of treating the visual shell as the accessibility contract.
+
+Purpose: Conversation navigation list for switching among Chat transcripts without embedding the list inside Chat.
+
+## Use when
+
+- Rendering a multi-conversation chat sidebar beside one active Chat transcript.
+- Showing unread counts and last-message previews for compatible conversation snapshots.
+
+## Avoid when
+
+- Rendering the message transcript itself — use chat for the active conversation surface.
+- Building app-wide primary navigation — use side-navigation or navigation-bar.
+
+## Keyboard and focus
+
+Keyboard behavior follows the rendered native elements and any ARIA pattern documented by the component. Avoid adding handlers that change focus order without a matching visible and programmatic state update.
+
+Keep focus indicators visible. If you wrap or restyle ChatConversationList, verify the focused element remains visually apparent in default and forced-colors modes.
+
+## Names, roles, and state
+
+Use the public props and documented examples to provide accessible names, descriptions, current state, disabled state, selection state, or value text. Do not rely on color, icon shape, placeholder text, or layout position as the only way to communicate meaning.
+
+When ChatConversationList accepts snippets or arbitrary children, the caller owns the semantics inside those children. Prefer native elements first, and add ARIA only when it matches the rendered behavior.
+
+## Verification
+
+- Render ChatConversationList in the playground or a focused test fixture.
+- Navigate the component with keyboard only.
+- Inspect the accessible name, role, and state in browser accessibility tools.
+- Check forced-colors mode when the component adds borders, focus rings, selected state, or status color.
+
+Related components: `chat`, `chat-conversation-header`, `side-navigation`.

--- a/packages/components/src/components/chat/chat.a11y.md
+++ b/packages/components/src/components/chat/chat.a11y.md
@@ -1,0 +1,38 @@
+# Chat · accessibility
+
+## Pattern
+
+Chat packages a higher-level workflow. Confirm the composed controls, labels, states, and keyboard path match the domain task instead of treating the visual shell as the accessibility contract.
+
+Purpose: Opinionated conversation surface bundling message list, composer, attachments, and scroll affordances for AI or support transcripts.
+
+## Use when
+
+- Shipping a full chat surface with composer, scroll-anchor, unread indicator, and attachments bundled as one heavyweight drop-in.
+- Building an AI assistant or support thread where conversation state is modeled as a transcript of role-tagged messages.
+
+## Avoid when
+
+- Rendering a one-off message list — compose lighter primitives directly instead of pulling the full suite.
+- The transcript is read-only and needs no composer — a simple list of message bubbles is a better fit.
+
+## Keyboard and focus
+
+Keyboard behavior follows the rendered native elements and any ARIA pattern documented by the component. Avoid adding handlers that change focus order without a matching visible and programmatic state update.
+
+Keep focus indicators visible. If you wrap or restyle Chat, verify the focused element remains visually apparent in default and forced-colors modes.
+
+## Names, roles, and state
+
+Use the public props and documented examples to provide accessible names, descriptions, current state, disabled state, selection state, or value text. Do not rely on color, icon shape, placeholder text, or layout position as the only way to communicate meaning.
+
+When Chat accepts snippets or arbitrary children, the caller owns the semantics inside those children. Prefer native elements first, and add ARIA only when it matches the rendered behavior.
+
+## Verification
+
+- Render Chat in the playground or a focused test fixture.
+- Navigate the component with keyboard only.
+- Inspect the accessible name, role, and state in browser accessibility tools.
+- Check forced-colors mode when the component adds borders, focus rings, selected state, or status color.
+
+Related components: `markdown-editor`.

--- a/packages/components/src/components/chat/container/chat-history-trigger.svelte
+++ b/packages/components/src/components/chat/container/chat-history-trigger.svelte
@@ -33,7 +33,7 @@
     };
   };
 
-  export function focus(options?: FocusOptions): void {
+  export function focus(options: FocusOptions | undefined = undefined): void {
     buttonElement?.focus(options);
   }
 </script>

--- a/packages/components/src/components/choice-grid-item/choice-grid-item.a11y.md
+++ b/packages/components/src/components/choice-grid-item/choice-grid-item.a11y.md
@@ -1,0 +1,36 @@
+# ChoiceGridItem · accessibility
+
+## Pattern
+
+ChoiceGridItem participates in form input or field composition. Pair each control with a visible label or an explicit accessible name, and connect validation text with the same relationship the component exposes.
+
+Purpose: Selectable answer tile used inside a ChoiceGrid; carries selected, disabled, correct, incorrect, and pending states without shifting cell dimensions.
+
+## Use when
+
+- Composing individual answer choices inside a ChoiceGrid parent.
+
+## Avoid when
+
+- Used outside a ChoiceGrid — this leaf requires the parent context.
+
+## Keyboard and focus
+
+Keyboard behavior should follow the native control or documented ARIA pattern. Do not add extra key handlers that conflict with text entry, selection, or assistive-technology shortcuts.
+
+Keep focus indicators visible. If you wrap or restyle ChoiceGridItem, verify the focused element remains visually apparent in default and forced-colors modes.
+
+## Names, roles, and state
+
+Use the public props and documented examples to provide accessible names, descriptions, current state, disabled state, selection state, or value text. Do not rely on color, icon shape, placeholder text, or layout position as the only way to communicate meaning.
+
+When ChoiceGridItem accepts snippets or arbitrary children, the caller owns the semantics inside those children. Prefer native elements first, and add ARIA only when it matches the rendered behavior.
+
+## Verification
+
+- Render ChoiceGridItem in the playground or a focused test fixture.
+- Navigate the component with keyboard only.
+- Inspect the accessible name, role, and state in browser accessibility tools.
+- Check forced-colors mode when the component adds borders, focus rings, selected state, or status color.
+
+Related components: `choice-grid`.

--- a/packages/components/src/components/choice-grid/choice-grid.a11y.md
+++ b/packages/components/src/components/choice-grid/choice-grid.a11y.md
@@ -1,0 +1,38 @@
+# ChoiceGrid · accessibility
+
+## Pattern
+
+ChoiceGrid participates in form input or field composition. Pair each control with a visible label or an explicit accessible name, and connect validation text with the same relationship the component exposes.
+
+Purpose: Responsive grid of large selectable choices with roving keyboard focus, selection state, and optional correct/incorrect/pending feedback for quiz and assessment surfaces.
+
+## Use when
+
+- Presenting a small fixed set of large selectable answers where all options should stay visible (quiz or assessment surfaces).
+- Building a touch-friendly selector grid with stable cell dimensions that must not shift when feedback states are applied.
+
+## Avoid when
+
+- Selecting from a long dynamic list — use combobox or select instead.
+- Choosing one of two to five short values in a compact inline context — use segmented-control instead.
+
+## Keyboard and focus
+
+Keyboard behavior should follow the native control or documented ARIA pattern. Do not add extra key handlers that conflict with text entry, selection, or assistive-technology shortcuts.
+
+Keep focus indicators visible. If you wrap or restyle ChoiceGrid, verify the focused element remains visually apparent in default and forced-colors modes.
+
+## Names, roles, and state
+
+Use the public props and documented examples to provide accessible names, descriptions, current state, disabled state, selection state, or value text. Do not rely on color, icon shape, placeholder text, or layout position as the only way to communicate meaning.
+
+When ChoiceGrid accepts snippets or arbitrary children, the caller owns the semantics inside those children. Prefer native elements first, and add ARIA only when it matches the rendered behavior.
+
+## Verification
+
+- Render ChoiceGrid in the playground or a focused test fixture.
+- Navigate the component with keyboard only.
+- Inspect the accessible name, role, and state in browser accessibility tools.
+- Check forced-colors mode when the component adds borders, focus rings, selected state, or status color.
+
+Related components: `choice-grid-item`, `segmented-control`, `radio-group`, `checkbox-group`.

--- a/packages/components/src/components/code-block/code-block.a11y.md
+++ b/packages/components/src/components/code-block/code-block.a11y.md
@@ -1,0 +1,38 @@
+# CodeBlock · accessibility
+
+## Pattern
+
+CodeBlock presents structured data. Preserve the component's semantic roles, row or item labels, and ordering so assistive technology can announce the same relationships that are visible on screen.
+
+Purpose: Block container for multi-line source code with automatic syntax highlighting and a copy-to-clipboard control.
+
+## Use when
+
+- Displaying a multi-line code sample or terminal transcript inside documentation or chat.
+- Letting the reader copy a snippet to the clipboard via the copyable prop.
+
+## Avoid when
+
+- Annotating a single inline keystroke or shortcut — use kbd instead.
+- Rendering rich prose that happens to include code — embed it in markdown instead.
+
+## Keyboard and focus
+
+Keyboard behavior follows the rendered native elements and any ARIA pattern documented by the component. Avoid adding handlers that change focus order without a matching visible and programmatic state update.
+
+Keep focus indicators visible. If you wrap or restyle CodeBlock, verify the focused element remains visually apparent in default and forced-colors modes.
+
+## Names, roles, and state
+
+Use the public props and documented examples to provide accessible names, descriptions, current state, disabled state, selection state, or value text. Do not rely on color, icon shape, placeholder text, or layout position as the only way to communicate meaning.
+
+When CodeBlock accepts snippets or arbitrary children, the caller owns the semantics inside those children. Prefer native elements first, and add ARIA only when it matches the rendered behavior.
+
+## Verification
+
+- Render CodeBlock in the playground or a focused test fixture.
+- Navigate the component with keyboard only.
+- Inspect the accessible name, role, and state in browser accessibility tools.
+- Check forced-colors mode when the component adds borders, focus rings, selected state, or status color.
+
+Related components: `kbd`, `copy-button`.

--- a/packages/components/src/components/combobox/combobox.svelte
+++ b/packages/components/src/components/combobox/combobox.svelte
@@ -142,7 +142,7 @@
   // top handler, so this combobox consumes Escape and `preventDefault()`s it
   // before the parent overlay ever sees the key — Escape dismisses just the
   // combobox, never the enclosing overlay.
-  function handleEscape(event?: KeyboardEvent): void {
+  function handleEscape(event: KeyboardEvent | undefined = undefined): void {
     const wasOpen = open;
     open = false;
     // Restore the committed label whenever the live text drifted from it.

--- a/packages/components/src/components/command-item/command-item.a11y.md
+++ b/packages/components/src/components/command-item/command-item.a11y.md
@@ -1,0 +1,38 @@
+# CommandItem · accessibility
+
+## Pattern
+
+CommandItem exposes an operable control surface. Prefer the native interactive element it renders, keep the accessible name specific to the action, and do not replace it with a non-interactive wrapper.
+
+Purpose: Single selectable row inside a command palette or inline command menu that registers itself with the parent command list.
+
+## Use when
+
+- Declaring an individual command, action, or result row inside a command-palette or command-menu.
+- Composing a custom palette layout via children rather than the items prop.
+
+## Avoid when
+
+- Used outside a command-palette or command-menu ancestor — the component throws at construction.
+- Rendering a generic dropdown choice — use dropdown-item instead.
+
+## Keyboard and focus
+
+Activation should work with the native Enter and Space behavior of the rendered control. Custom children must not swallow those events unless they replace the whole interaction intentionally.
+
+Keep focus indicators visible. If you wrap or restyle CommandItem, verify the focused element remains visually apparent in default and forced-colors modes.
+
+## Names, roles, and state
+
+Use the public props and documented examples to provide accessible names, descriptions, current state, disabled state, selection state, or value text. Do not rely on color, icon shape, placeholder text, or layout position as the only way to communicate meaning.
+
+When CommandItem accepts snippets or arbitrary children, the caller owns the semantics inside those children. Prefer native elements first, and add ARIA only when it matches the rendered behavior.
+
+## Verification
+
+- Render CommandItem in the playground or a focused test fixture.
+- Navigate the component with keyboard only.
+- Inspect the accessible name, role, and state in browser accessibility tools.
+- Check forced-colors mode when the component adds borders, focus rings, selected state, or status color.
+
+Related components: `command-palette`, `command-menu`, `dropdown-item`.

--- a/packages/components/src/components/connection-indicator/connection-indicator.a11y.md
+++ b/packages/components/src/components/connection-indicator/connection-indicator.a11y.md
@@ -1,0 +1,37 @@
+# ConnectionIndicator · accessibility
+
+## Pattern
+
+ConnectionIndicator communicates status or supporting context. Keep the message text concise, and choose the surrounding live-region behavior based on whether the condition is immediate, persistent, or purely informational.
+
+Purpose: Live-status pill pairing a semantic dot with a label to communicate real-time WebSocket, SSE, or polling connection state.
+
+## Use when
+
+- Surfacing whether a realtime channel is connected, connecting, disconnected, or errored on a dashboard or app chrome.
+- Giving operators an at-a-glance health signal for a long-lived transport.
+
+## Avoid when
+
+- Communicating generic semantic state with no realtime connection backing it — status-dot is the lower-level primitive.
+
+## Keyboard and focus
+
+Keyboard behavior follows the rendered native elements and any ARIA pattern documented by the component. Avoid adding handlers that change focus order without a matching visible and programmatic state update.
+
+Keep focus indicators visible. If you wrap or restyle ConnectionIndicator, verify the focused element remains visually apparent in default and forced-colors modes.
+
+## Names, roles, and state
+
+Use the public props and documented examples to provide accessible names, descriptions, current state, disabled state, selection state, or value text. Do not rely on color, icon shape, placeholder text, or layout position as the only way to communicate meaning.
+
+When ConnectionIndicator accepts snippets or arbitrary children, the caller owns the semantics inside those children. Prefer native elements first, and add ARIA only when it matches the rendered behavior.
+
+## Verification
+
+- Render ConnectionIndicator in the playground or a focused test fixture.
+- Navigate the component with keyboard only.
+- Inspect the accessible name, role, and state in browser accessibility tools.
+- Check forced-colors mode when the component adds borders, focus rings, selected state, or status color.
+
+Related components: `status-dot`, `spinner`.

--- a/packages/components/src/components/container/container.a11y.md
+++ b/packages/components/src/components/container/container.a11y.md
@@ -1,0 +1,37 @@
+# Container · accessibility
+
+## Pattern
+
+Container affects structure rather than meaning. Use it without removing headings, landmarks, labels, or reading order from the content it contains.
+
+Purpose: Centered content-width wrapper for the narrow-column reading pattern, capping inline size at a configurable width token.
+
+## Use when
+
+- Centering article or long-form content in a readable, max-width-capped column.
+- Constraining a section of a page to a named content width without app-shell chrome.
+
+## Avoid when
+
+- Building an app shell with header, breadcrumbs, or action regions — write a hand-rolled page scaffold directly.
+
+## Keyboard and focus
+
+Keyboard behavior follows the rendered native elements and any ARIA pattern documented by the component. Avoid adding handlers that change focus order without a matching visible and programmatic state update.
+
+Keep focus indicators visible. If you wrap or restyle Container, verify the focused element remains visually apparent in default and forced-colors modes.
+
+## Names, roles, and state
+
+Use the public props and documented examples to provide accessible names, descriptions, current state, disabled state, selection state, or value text. Do not rely on color, icon shape, placeholder text, or layout position as the only way to communicate meaning.
+
+When Container accepts snippets or arbitrary children, the caller owns the semantics inside those children. Prefer native elements first, and add ARIA only when it matches the rendered behavior.
+
+## Verification
+
+- Render Container in the playground or a focused test fixture.
+- Navigate the component with keyboard only.
+- Inspect the accessible name, role, and state in browser accessibility tools.
+- Check forced-colors mode when the component adds borders, focus rings, selected state, or status color.
+
+Related components: `aspect-ratio`.

--- a/packages/components/src/components/context-menu-trigger/context-menu-trigger.a11y.md
+++ b/packages/components/src/components/context-menu-trigger/context-menu-trigger.a11y.md
@@ -1,0 +1,38 @@
+# ContextMenuTrigger · accessibility
+
+## Pattern
+
+ContextMenuTrigger presents layered content. Keep trigger, focus movement, dismissal, and labelling in one predictable interaction path so users can enter and leave the layer without losing context.
+
+Purpose: Compose-only trigger region that opens a context-menu on right-click or touch long-press.
+
+## Use when
+
+- Wrapping the region that should own contextual actions inside ContextMenu.
+- Pairing pointer-positioned menu behavior with dropdown menu items.
+
+## Avoid when
+
+- Used outside context-menu — it requires the ContextMenu provider.
+- Opening a normal click menu from a visible button — use dropdown-trigger.
+
+## Keyboard and focus
+
+The trigger should remain reachable by keyboard, and the open layer should provide a clear Escape, close, or outside-interaction path consistent with the component documentation.
+
+Keep focus indicators visible. If you wrap or restyle ContextMenuTrigger, verify the focused element remains visually apparent in default and forced-colors modes.
+
+## Names, roles, and state
+
+Use the public props and documented examples to provide accessible names, descriptions, current state, disabled state, selection state, or value text. Do not rely on color, icon shape, placeholder text, or layout position as the only way to communicate meaning.
+
+When ContextMenuTrigger accepts snippets or arbitrary children, the caller owns the semantics inside those children. Prefer native elements first, and add ARIA only when it matches the rendered behavior.
+
+## Verification
+
+- Render ContextMenuTrigger in the playground or a focused test fixture.
+- Navigate the component with keyboard only.
+- Inspect the accessible name, role, and state in browser accessibility tools.
+- Check forced-colors mode when the component adds borders, focus rings, selected state, or status color.
+
+Related components: `context-menu`, `dropdown-trigger`.

--- a/packages/components/src/components/context-menu/context-menu.a11y.md
+++ b/packages/components/src/components/context-menu/context-menu.a11y.md
@@ -1,0 +1,38 @@
+# ContextMenu · accessibility
+
+## Pattern
+
+ContextMenu presents layered content. Keep trigger, focus movement, dismissal, and labelling in one predictable interaction path so users can enter and leave the layer without losing context.
+
+Purpose: Right-click and long-press menu positioned at the user's pointer while reusing dropdown menu parts.
+
+## Use when
+
+- Providing contextual actions for a canvas, list row, file, or selected item.
+- Opening a menu from a pointer location instead of a visible dropdown trigger.
+
+## Avoid when
+
+- The menu should open from a button — use dropdown.
+- Showing arbitrary rich content rather than menu actions — use popover.
+
+## Keyboard and focus
+
+The trigger should remain reachable by keyboard, and the open layer should provide a clear Escape, close, or outside-interaction path consistent with the component documentation.
+
+Keep focus indicators visible. If you wrap or restyle ContextMenu, verify the focused element remains visually apparent in default and forced-colors modes.
+
+## Names, roles, and state
+
+Use the public props and documented examples to provide accessible names, descriptions, current state, disabled state, selection state, or value text. Do not rely on color, icon shape, placeholder text, or layout position as the only way to communicate meaning.
+
+When ContextMenu accepts snippets or arbitrary children, the caller owns the semantics inside those children. Prefer native elements first, and add ARIA only when it matches the rendered behavior.
+
+## Verification
+
+- Render ContextMenu in the playground or a focused test fixture.
+- Navigate the component with keyboard only.
+- Inspect the accessible name, role, and state in browser accessibility tools.
+- Check forced-colors mode when the component adds borders, focus rings, selected state, or status color.
+
+Related components: `dropdown`, `dropdown-menu`, `dropdown-item`.

--- a/packages/components/src/components/data-grid/README.md
+++ b/packages/components/src/components/data-grid/README.md
@@ -33,7 +33,7 @@ ARIA data grid foundation for spreadsheet-like datasets with stable row identity
 ### Avoid When
 
 - You only need a semantic read-only table — use DataTable or the Table family instead.
-- You need sorting, virtualization, resize handles, drag-to-reorder controls, or editing today.
+- You need resize handles, drag-to-reorder controls, or editing today.
 
 ## Props
 

--- a/packages/components/src/components/data-grid/_internal/column-model.svelte.ts
+++ b/packages/components/src/components/data-grid/_internal/column-model.svelte.ts
@@ -13,6 +13,7 @@ export const DEFAULT_DATA_GRID_COLUMN_MIN_WIDTH = 60;
 
 export type DataGridValueColumn<TRow> = {
   key: string;
+  rowHeader?: boolean;
   sortable?: boolean;
   sortComparator?: DataGridSortComparator<TRow>;
   getValue?: (row: TRow) => unknown;
@@ -148,6 +149,7 @@ function resolveColumn<TRow>(
   };
   if (column.cell !== undefined) resolvedColumn.cell = column.cell;
   if (column.maxWidth !== undefined) resolvedColumn.maxWidth = column.maxWidth;
+  if (column.rowHeader !== undefined) resolvedColumn.rowHeader = column.rowHeader;
   if (column.sortable !== undefined) resolvedColumn.sortable = column.sortable;
   if (column.sortComparator !== undefined) resolvedColumn.sortComparator = column.sortComparator;
   if (column.getValue !== undefined) resolvedColumn.getValue = column.getValue;

--- a/packages/components/src/components/data-grid/data-grid-aria.test.ts
+++ b/packages/components/src/components/data-grid/data-grid-aria.test.ts
@@ -76,6 +76,27 @@ describe('DataGrid ARIA', () => {
     expect(firstDataCells.map((cell) => cell.getAttribute('aria-colindex'))).toEqual(['1', '2']);
   });
 
+  test('renders row-header columns with role=rowheader', () => {
+    const { container } = render(IssueDataGrid, {
+      rows,
+      columns: [
+        { key: 'title', header: 'Title', rowHeader: true },
+        { key: 'owner', header: 'Owner' },
+      ],
+      getRowId: getIssueId,
+      'aria-label': 'Issues',
+    });
+
+    const firstDataRow = container.querySelector('[role="row"][aria-rowindex="2"]');
+    const rowHeader = firstDataRow?.querySelector('[role="rowheader"]');
+    const gridCells = firstDataRow?.querySelectorAll('[role="gridcell"]');
+
+    expect(rowHeader?.textContent?.trim()).toBe('Keyboard navigation');
+    expect(rowHeader?.getAttribute('aria-colindex')).toBe('1');
+    expect(gridCells).toHaveLength(1);
+    expect(gridCells?.[0]?.textContent?.trim()).toBe('Ada');
+  });
+
   test('wraps body rows in a rowgroup owned by the grid', () => {
     const { container } = render(IssueDataGrid, {
       rows,

--- a/packages/components/src/components/data-grid/data-grid.a11y.md
+++ b/packages/components/src/components/data-grid/data-grid.a11y.md
@@ -1,0 +1,48 @@
+# DataGrid · accessibility
+
+## Pattern
+
+DataGrid presents structured data. Preserve the component's semantic roles, row or item labels, and ordering so assistive technology can announce the same relationships that are visible on screen.
+
+Purpose: ARIA data grid foundation for spreadsheet-like datasets with explicit row identity, column sizing, keyboard navigation, range selection, and pinning metadata.
+
+## Use when
+
+- Rendering interactive tabular data that will need grid behavior such as selection, virtualization, resizing, or editing.
+- You need role=grid semantics instead of native table semantics.
+
+## Avoid when
+
+- You only need a semantic read-only table — use DataTable or the Table family instead.
+- You need resize handles, drag-to-reorder controls, or editing today — DataGrid does not provide them yet.
+
+## Keyboard and focus
+
+The grid owns the root tab stop and moves the active cell with keyboard commands. Do not put body cells directly in the tab order unless the component documents that behavior.
+
+Keep focus indicators visible. If you wrap or restyle DataGrid, verify the focused element remains visually apparent in default and forced-colors modes.
+
+## Row headers
+
+Set `rowHeader: true` on the column that identifies each row. Body cells in that column render with `role="rowheader"` instead of `role="gridcell"`, while still preserving `aria-colindex`, selection state, and active-cell behavior.
+
+Use the same row identity users see on screen whenever possible. A first pinned identifier column is a good default because screen readers can announce the row context before the remaining grid cells.
+
+## Virtualized columns
+
+Column virtualization keeps off-screen columns out of the DOM. The grid preserves `aria-colindex` for the full column set and adds edge shadows plus a stable scrollbar gutter so sighted users have a visible horizontal-overflow cue and the vertical scrollbar does not cover the last visible column.
+
+## Names, roles, and state
+
+Use the public props and documented examples to provide accessible names, descriptions, current state, disabled state, selection state, or value text. Do not rely on color, icon shape, placeholder text, or layout position as the only way to communicate meaning.
+
+When DataGrid accepts snippets or arbitrary children, the caller owns the semantics inside those children. Prefer native elements first, and add ARIA only when it matches the rendered behavior.
+
+## Verification
+
+- Render DataGrid in the playground or a focused test fixture.
+- Navigate the component with keyboard only.
+- Inspect the accessible name, role, and state in browser accessibility tools.
+- Check forced-colors mode when the component adds borders, focus rings, selected state, or status color.
+
+Related components: `data-table`, `table`.

--- a/packages/components/src/components/data-grid/data-grid.css
+++ b/packages/components/src/components/data-grid/data-grid.css
@@ -9,6 +9,7 @@
     inline-size: 100%;
     max-inline-size: 100%;
     overflow: auto;
+    scrollbar-gutter: stable;
     border: 1px solid var(--cinder-border);
     border-radius: var(--cinder-radius-md);
     background: var(--cinder-surface);
@@ -16,6 +17,12 @@
     font-size: var(--cinder-text-sm);
     overscroll-behavior-inline: contain;
     -webkit-overflow-scrolling: touch;
+  }
+
+  .cinder-data-grid[data-cinder-virtualized-columns='true'] {
+    --_cinder-data-grid-overflow-shadow:
+      inset 1rem 0 1rem -1rem color-mix(in srgb, var(--cinder-text) 28%, transparent),
+      inset -1rem 0 1rem -1rem color-mix(in srgb, var(--cinder-text) 28%, transparent);
   }
 
   .cinder-data-grid:focus-visible {
@@ -41,6 +48,7 @@
 
   .cinder-data-grid__header-row {
     background: var(--cinder-surface-inset);
+    box-shadow: var(--_cinder-data-grid-overflow-shadow, none);
   }
 
   .cinder-data-grid[data-cinder-sticky-header] .cinder-data-grid__header-row {
@@ -51,6 +59,7 @@
 
   .cinder-data-grid__row {
     background: var(--cinder-surface);
+    box-shadow: var(--_cinder-data-grid-overflow-shadow, none);
     transition: background var(--cinder-duration-fast) var(--cinder-ease-standard);
   }
 

--- a/packages/components/src/components/data-grid/data-grid.svelte
+++ b/packages/components/src/components/data-grid/data-grid.svelte
@@ -994,7 +994,7 @@
           <div
             id={cellId}
             class="cinder-data-grid__cell"
-            role="gridcell"
+            role={column.rowHeader ? 'rowheader' : 'gridcell'}
             aria-colindex={column.colIndex}
             aria-selected={isSelectedCell ? 'true' : undefined}
             tabindex="-1"

--- a/packages/components/src/components/data-grid/data-grid.types.ts
+++ b/packages/components/src/components/data-grid/data-grid.types.ts
@@ -43,6 +43,12 @@ type DataGridBaseColumnDef<TRow> = {
   maxWidth?: number;
   /** Pin this column to the left or right edge of the horizontal scroller. */
   pin?: DataGridColumnPin;
+  /**
+   * Render body cells in this column as row headers (`role="rowheader"`).
+   * Use this for the column that uniquely identifies each row, such as the
+   * value returned by `getRowId`.
+   */
+  rowHeader?: boolean;
   /** Enables header-click sorting for this column. */
   sortable?: boolean;
 };

--- a/packages/components/src/components/data-table/data-table.a11y.md
+++ b/packages/components/src/components/data-table/data-table.a11y.md
@@ -1,0 +1,48 @@
+# DataTable · accessibility
+
+## Pattern
+
+DataTable presents structured data. Preserve the component's semantic roles, row or item labels, and ordering so assistive technology can announce the same relationships that are visible on screen.
+
+Purpose: Data-driven convenience wrapper over the compositional Table family that renders a full semantic table from a columns array and a rows array.
+
+## Use when
+
+- Rendering a structured dataset where columns and rows are known at runtime (e.g. API responses, config-driven dashboards).
+- You want correct scope=col / scope=row semantics and aria-sort wiring without writing Table.Header / Table.Body manually.
+
+## Avoid when
+
+- You need custom cell rendering, interactive cells, nested components, or column spanning — use the compositional Table family directly.
+- You need row selection — DataTable does not expose a selection prop; use Table with selectable instead.
+
+## Keyboard and focus
+
+Native table reading order is the keyboard contract. Sort controls, when present, are real buttons inside header cells and use `aria-sort` on the header cell.
+
+Keep focus indicators visible. If you wrap or restyle DataTable, verify the focused element remains visually apparent in default and forced-colors modes.
+
+## Sortable headers
+
+Sortable columns render a native button inside the header cell. `aria-sort` stays on the `<th>` so assistive technology announces the current state with the column label, and the button exposes an `aria-description` that names the next action: "Activate to sort ascending" or "Activate to sort descending".
+
+DataTable reports sort intent through the bindable `sort` prop. It does not reorder rows by itself; callers must update `rows` after receiving the next sort state.
+
+## Row scanning
+
+The first column acts as the row header by default, or a later column can opt in with `rowHeader: true`. Hover and focus-within row backgrounds use `--cinder-surface-hover` to make wide tables easier to scan without changing the native table semantics.
+
+## Names, roles, and state
+
+Use the public props and documented examples to provide accessible names, descriptions, current state, disabled state, selection state, or value text. Do not rely on color, icon shape, placeholder text, or layout position as the only way to communicate meaning.
+
+When DataTable accepts snippets or arbitrary children, the caller owns the semantics inside those children. Prefer native elements first, and add ARIA only when it matches the rendered behavior.
+
+## Verification
+
+- Render DataTable in the playground or a focused test fixture.
+- Navigate the component with keyboard only.
+- Inspect the accessible name, role, and state in browser accessibility tools.
+- Check forced-colors mode when the component adds borders, focus rings, selected state, or status color.
+
+Related components: `table`, `table-header`, `table-body`, `table-row`, `table-cell`, `table-header-cell`.

--- a/packages/components/src/components/data-table/data-table.css
+++ b/packages/components/src/components/data-table/data-table.css
@@ -42,6 +42,10 @@
     block-size: var(--_cinder-data-table-row-height, 44px);
   }
 
+  .cinder-data-table tbody .cinder-table__row:focus-within {
+    background: var(--cinder-surface-hover);
+  }
+
   .cinder-data-table[data-cinder-virtualized]
     .cinder-table__row[data-cinder-virtual-row]:focus-visible {
     outline: var(--cinder-ring-width) solid transparent;

--- a/packages/components/src/components/data-table/data-table.test.ts
+++ b/packages/components/src/components/data-table/data-table.test.ts
@@ -134,6 +134,16 @@ describe('DataTable — column headers', () => {
     expect(headerCells[0]?.getAttribute('aria-sort')).toBe('ascending');
     expect(headerCells[2]?.getAttribute('aria-sort')).toBe('none');
   });
+
+  test('sortable header buttons describe their next sort action', async () => {
+    const { container } = render(DataTable, { columns, rows });
+    const button = container.querySelector('thead th button') as HTMLButtonElement;
+
+    expect(button.getAttribute('aria-description')).toBe('Activate to sort ascending');
+
+    await fireEvent.click(button);
+    expect(button.getAttribute('aria-description')).toBe('Activate to sort descending');
+  });
 });
 
 describe('DataTable — sort interaction', () => {

--- a/packages/components/src/components/diff-statistics/diff-statistics.a11y.md
+++ b/packages/components/src/components/diff-statistics/diff-statistics.a11y.md
@@ -1,0 +1,38 @@
+# DiffStatistics · accessibility
+
+## Pattern
+
+DiffStatistics packages a higher-level workflow. Confirm the composed controls, labels, states, and keyboard path match the domain task instead of treating the visual shell as the accessibility contract.
+
+Purpose: Compact added, removed, and modified line-count summary that accompanies a Markdown diff view.
+
+## Use when
+
+- Surfacing a quick numeric summary of changes alongside or in lieu of a full diff surface.
+- Annotating a list of files or pull requests with line-change counts as part of the diff-viewer suite.
+
+## Avoid when
+
+- Rendering the actual hunked diff content — pair with diff-viewer for the full document comparison.
+- Generic numeric badges that have nothing to do with diffs — reach for stat or badge instead.
+
+## Keyboard and focus
+
+Keyboard behavior follows the rendered native elements and any ARIA pattern documented by the component. Avoid adding handlers that change focus order without a matching visible and programmatic state update.
+
+Keep focus indicators visible. If you wrap or restyle DiffStatistics, verify the focused element remains visually apparent in default and forced-colors modes.
+
+## Names, roles, and state
+
+Use the public props and documented examples to provide accessible names, descriptions, current state, disabled state, selection state, or value text. Do not rely on color, icon shape, placeholder text, or layout position as the only way to communicate meaning.
+
+When DiffStatistics accepts snippets or arbitrary children, the caller owns the semantics inside those children. Prefer native elements first, and add ARIA only when it matches the rendered behavior.
+
+## Verification
+
+- Render DiffStatistics in the playground or a focused test fixture.
+- Navigate the component with keyboard only.
+- Inspect the accessible name, role, and state in browser accessibility tools.
+- Check forced-colors mode when the component adds borders, focus rings, selected state, or status color.
+
+Related components: `diff-viewer`.

--- a/packages/components/src/components/diff-viewer/diff-viewer.a11y.md
+++ b/packages/components/src/components/diff-viewer/diff-viewer.a11y.md
@@ -1,0 +1,38 @@
+# DiffViewer · accessibility
+
+## Pattern
+
+DiffViewer packages a higher-level workflow. Confirm the composed controls, labels, states, and keyboard path match the domain task instead of treating the visual shell as the accessibility contract.
+
+Purpose: Side-by-side or unified Markdown diff surface with hunk grouping, word-level inline changes, and size-based debounce gating.
+
+## Use when
+
+- Comparing two Markdown documents and wanting the bundled toolbar, view-mode toggle, front-matter handling, and large-payload safeguards.
+- Building a review workflow that needs hunked, line-anchored Markdown diffs out of the box as a heavyweight suite.
+
+## Avoid when
+
+- Showing only a counts summary — use diff-statistics on its own for a lightweight presentation.
+- Diffing non-Markdown source code where syntax-aware highlighting matters more than prose-aware rendering.
+
+## Keyboard and focus
+
+Keyboard behavior follows the rendered native elements and any ARIA pattern documented by the component. Avoid adding handlers that change focus order without a matching visible and programmatic state update.
+
+Keep focus indicators visible. If you wrap or restyle DiffViewer, verify the focused element remains visually apparent in default and forced-colors modes.
+
+## Names, roles, and state
+
+Use the public props and documented examples to provide accessible names, descriptions, current state, disabled state, selection state, or value text. Do not rely on color, icon shape, placeholder text, or layout position as the only way to communicate meaning.
+
+When DiffViewer accepts snippets or arbitrary children, the caller owns the semantics inside those children. Prefer native elements first, and add ARIA only when it matches the rendered behavior.
+
+## Verification
+
+- Render DiffViewer in the playground or a focused test fixture.
+- Navigate the component with keyboard only.
+- Inspect the accessible name, role, and state in browser accessibility tools.
+- Check forced-colors mode when the component adds borders, focus rings, selected state, or status color.
+
+Related components: `diff-statistics`, `code-block`.

--- a/packages/components/src/components/divider/divider.a11y.md
+++ b/packages/components/src/components/divider/divider.a11y.md
@@ -1,0 +1,38 @@
+# Divider · accessibility
+
+## Pattern
+
+Divider affects structure rather than meaning. Use it without removing headings, landmarks, labels, or reading order from the content it contains.
+
+Purpose: Thin decorative or semantic separator between content regions, with optional vertical orientation and tonal variants.
+
+## Use when
+
+- Visually separating sections of a card, list, or toolbar without adding heading-level structure.
+- Splitting a row of inline controls (e.g. a button-group toolbar) with a vertical rule.
+
+## Avoid when
+
+- The split between sections deserves a heading — use section-heading instead.
+- Wrapping the entire viewport edge — use surface or a hand-rolled page scaffold instead.
+
+## Keyboard and focus
+
+Keyboard behavior follows the rendered native elements and any ARIA pattern documented by the component. Avoid adding handlers that change focus order without a matching visible and programmatic state update.
+
+Keep focus indicators visible. If you wrap or restyle Divider, verify the focused element remains visually apparent in default and forced-colors modes.
+
+## Names, roles, and state
+
+Use the public props and documented examples to provide accessible names, descriptions, current state, disabled state, selection state, or value text. Do not rely on color, icon shape, placeholder text, or layout position as the only way to communicate meaning.
+
+When Divider accepts snippets or arbitrary children, the caller owns the semantics inside those children. Prefer native elements first, and add ARIA only when it matches the rendered behavior.
+
+## Verification
+
+- Render Divider in the playground or a focused test fixture.
+- Navigate the component with keyboard only.
+- Inspect the accessible name, role, and state in browser accessibility tools.
+- Check forced-colors mode when the component adds borders, focus rings, selected state, or status color.
+
+Related components: `surface`, `section-heading`.

--- a/packages/components/src/components/empty-state/empty-state.a11y.md
+++ b/packages/components/src/components/empty-state/empty-state.a11y.md
@@ -1,0 +1,38 @@
+# EmptyState · accessibility
+
+## Pattern
+
+EmptyState communicates status or supporting context. Keep the message text concise, and choose the surrounding live-region behavior based on whether the condition is immediate, persistent, or purely informational.
+
+Purpose: Centered placeholder with optional icon, title, description, and call-to-action for views that have no data to render.
+
+## Use when
+
+- Communicating that a list, table, or workspace has no items yet and suggesting a next step.
+- Replacing a primary content region after a filter or search returns no results.
+
+## Avoid when
+
+- Indicating that data is still loading — use skeleton or spinner instead.
+- Reporting a transient error — use alert, banner, or toast-region.
+
+## Keyboard and focus
+
+Keyboard behavior follows the rendered native elements and any ARIA pattern documented by the component. Avoid adding handlers that change focus order without a matching visible and programmatic state update.
+
+Keep focus indicators visible. If you wrap or restyle EmptyState, verify the focused element remains visually apparent in default and forced-colors modes.
+
+## Names, roles, and state
+
+Use the public props and documented examples to provide accessible names, descriptions, current state, disabled state, selection state, or value text. Do not rely on color, icon shape, placeholder text, or layout position as the only way to communicate meaning.
+
+When EmptyState accepts snippets or arbitrary children, the caller owns the semantics inside those children. Prefer native elements first, and add ARIA only when it matches the rendered behavior.
+
+## Verification
+
+- Render EmptyState in the playground or a focused test fixture.
+- Navigate the component with keyboard only.
+- Inspect the accessible name, role, and state in browser accessibility tools.
+- Check forced-colors mode when the component adds borders, focus rings, selected state, or status color.
+
+Related components: `skeleton`, `spinner`.

--- a/packages/components/src/components/floating-action-button/floating-action-button.a11y.md
+++ b/packages/components/src/components/floating-action-button/floating-action-button.a11y.md
@@ -1,0 +1,37 @@
+# FloatingActionButton · accessibility
+
+## Pattern
+
+FloatingActionButton exposes an operable control surface. Prefer the native interactive element it renders, keep the accessible name specific to the action, and do not replace it with a non-interactive wrapper.
+
+Purpose: Circular button representing the single most important action on a screen.
+
+## Use when
+
+- One action dominates the page purpose (compose, add, create).
+
+## Avoid when
+
+- Multiple equally-important actions exist — use a toolbar or button group.
+- You need it pinned to the viewport — it doesn't position itself; wrap it in your own fixed/sticky container.
+
+## Keyboard and focus
+
+Activation should work with the native Enter and Space behavior of the rendered control. Custom children must not swallow those events unless they replace the whole interaction intentionally.
+
+Keep focus indicators visible. If you wrap or restyle FloatingActionButton, verify the focused element remains visually apparent in default and forced-colors modes.
+
+## Names, roles, and state
+
+Use the public props and documented examples to provide accessible names, descriptions, current state, disabled state, selection state, or value text. Do not rely on color, icon shape, placeholder text, or layout position as the only way to communicate meaning.
+
+When FloatingActionButton accepts snippets or arbitrary children, the caller owns the semantics inside those children. Prefer native elements first, and add ARIA only when it matches the rendered behavior.
+
+## Verification
+
+- Render FloatingActionButton in the playground or a focused test fixture.
+- Navigate the component with keyboard only.
+- Inspect the accessible name, role, and state in browser accessibility tools.
+- Check forced-colors mode when the component adds borders, focus rings, selected state, or status color.
+
+Related components: `button`, `toolbar`.

--- a/packages/components/src/components/grid-item/grid-item.a11y.md
+++ b/packages/components/src/components/grid-item/grid-item.a11y.md
@@ -1,0 +1,36 @@
+# GridItem · accessibility
+
+## Pattern
+
+GridItem affects structure rather than meaning. Use it without removing headings, landmarks, labels, or reading order from the content it contains.
+
+Purpose: Optional placement child for Grid that controls column and row spans or explicit track placement.
+
+## Use when
+
+- A child in a grid needs to span tracks or start at a specific track.
+
+## Avoid when
+
+- Every child can use default grid auto-placement - render plain children inside Grid instead.
+
+## Keyboard and focus
+
+The grid owns the root tab stop and moves the active cell with keyboard commands. Do not put body cells directly in the tab order unless the component documents that behavior.
+
+Keep focus indicators visible. If you wrap or restyle GridItem, verify the focused element remains visually apparent in default and forced-colors modes.
+
+## Names, roles, and state
+
+Use the public props and documented examples to provide accessible names, descriptions, current state, disabled state, selection state, or value text. Do not rely on color, icon shape, placeholder text, or layout position as the only way to communicate meaning.
+
+When GridItem accepts snippets or arbitrary children, the caller owns the semantics inside those children. Prefer native elements first, and add ARIA only when it matches the rendered behavior.
+
+## Verification
+
+- Render GridItem in the playground or a focused test fixture.
+- Navigate the component with keyboard only.
+- Inspect the accessible name, role, and state in browser accessibility tools.
+- Check forced-colors mode when the component adds borders, focus rings, selected state, or status color.
+
+Related components: `grid`.

--- a/packages/components/src/components/grid-list/grid-list.a11y.md
+++ b/packages/components/src/components/grid-list/grid-list.a11y.md
@@ -1,0 +1,38 @@
+# GridList · accessibility
+
+## Pattern
+
+GridList presents structured data. Preserve the component's semantic roles, row or item labels, and ordering so assistive technology can announce the same relationships that are visible on screen.
+
+Purpose: Responsive grid container that arranges grid-list-item tiles into auto-sized columns.
+
+## Use when
+
+- Presenting a homogenous collection of cards that should reflow into multiple columns.
+- Constraining tile minimum widths per breakpoint via the minColumnWidth prop.
+
+## Avoid when
+
+- Comparing rows of structured data — use table instead.
+- Stacking dense list rows vertically — use stacked-list-item instead.
+
+## Keyboard and focus
+
+The grid owns the root tab stop and moves the active cell with keyboard commands. Do not put body cells directly in the tab order unless the component documents that behavior.
+
+Keep focus indicators visible. If you wrap or restyle GridList, verify the focused element remains visually apparent in default and forced-colors modes.
+
+## Names, roles, and state
+
+Use the public props and documented examples to provide accessible names, descriptions, current state, disabled state, selection state, or value text. Do not rely on color, icon shape, placeholder text, or layout position as the only way to communicate meaning.
+
+When GridList accepts snippets or arbitrary children, the caller owns the semantics inside those children. Prefer native elements first, and add ARIA only when it matches the rendered behavior.
+
+## Verification
+
+- Render GridList in the playground or a focused test fixture.
+- Navigate the component with keyboard only.
+- Inspect the accessible name, role, and state in browser accessibility tools.
+- Check forced-colors mode when the component adds borders, focus rings, selected state, or status color.
+
+Related components: `grid-list-item`, `table`.

--- a/packages/components/src/components/grid/grid.a11y.md
+++ b/packages/components/src/components/grid/grid.a11y.md
@@ -1,0 +1,38 @@
+# Grid · accessibility
+
+## Pattern
+
+Grid affects structure rather than meaning. Use it without removing headings, landmarks, labels, or reading order from the content it contains.
+
+Purpose: CSS grid container for explicit columns, intrinsic auto-fill layouts, and two-dimensional placement.
+
+## Use when
+
+- Building form layouts, card grids, or dashboards that need two-dimensional placement.
+- Creating intrinsic responsive grids by passing minItemWidth.
+
+## Avoid when
+
+- Presenting homogeneous gallery tiles - use grid-list instead.
+- Packing variable-height content into waterfall columns - use masonry instead.
+
+## Keyboard and focus
+
+The grid owns the root tab stop and moves the active cell with keyboard commands. Do not put body cells directly in the tab order unless the component documents that behavior.
+
+Keep focus indicators visible. If you wrap or restyle Grid, verify the focused element remains visually apparent in default and forced-colors modes.
+
+## Names, roles, and state
+
+Use the public props and documented examples to provide accessible names, descriptions, current state, disabled state, selection state, or value text. Do not rely on color, icon shape, placeholder text, or layout position as the only way to communicate meaning.
+
+When Grid accepts snippets or arbitrary children, the caller owns the semantics inside those children. Prefer native elements first, and add ARIA only when it matches the rendered behavior.
+
+## Verification
+
+- Render Grid in the playground or a focused test fixture.
+- Navigate the component with keyboard only.
+- Inspect the accessible name, role, and state in browser accessibility tools.
+- Check forced-colors mode when the component adds borders, focus rings, selected state, or status color.
+
+Related components: `grid-item`, `grid-list`, `masonry`.

--- a/packages/components/src/components/hover-card/hover-card.a11y.md
+++ b/packages/components/src/components/hover-card/hover-card.a11y.md
@@ -1,0 +1,38 @@
+# HoverCard · accessibility
+
+## Pattern
+
+HoverCard presents layered content. Keep trigger, focus movement, dismissal, and labelling in one predictable interaction path so users can enter and leave the layer without losing context.
+
+Purpose: Hover-and-focus triggered rich preview card for non-interactive contextual content.
+
+## Use when
+
+- Showing a profile, issue, or metadata preview that is richer than a tooltip but still read-only.
+- Revealing supplementary preview content on pointer hover or keyboard focus without moving focus.
+
+## Avoid when
+
+- The floating content contains focusable controls — use popover.
+- The trigger needs a short accessible description — use tooltip.
+
+## Keyboard and focus
+
+The trigger should remain reachable by keyboard, and the open layer should provide a clear Escape, close, or outside-interaction path consistent with the component documentation.
+
+Keep focus indicators visible. If you wrap or restyle HoverCard, verify the focused element remains visually apparent in default and forced-colors modes.
+
+## Names, roles, and state
+
+Use the public props and documented examples to provide accessible names, descriptions, current state, disabled state, selection state, or value text. Do not rely on color, icon shape, placeholder text, or layout position as the only way to communicate meaning.
+
+When HoverCard accepts snippets or arbitrary children, the caller owns the semantics inside those children. Prefer native elements first, and add ARIA only when it matches the rendered behavior.
+
+## Verification
+
+- Render HoverCard in the playground or a focused test fixture.
+- Navigate the component with keyboard only.
+- Inspect the accessible name, role, and state in browser accessibility tools.
+- Check forced-colors mode when the component adds borders, focus rings, selected state, or status color.
+
+Related components: `tooltip`, `popover`.

--- a/packages/components/src/components/json-schema-editor/json-schema-editor.a11y.md
+++ b/packages/components/src/components/json-schema-editor/json-schema-editor.a11y.md
@@ -1,0 +1,37 @@
+# JsonSchemaEditor · accessibility
+
+## Pattern
+
+JsonSchemaEditor participates in form input or field composition. Pair each control with a visible label or an explicit accessible name, and connect validation text with the same relationship the component exposes.
+
+Purpose: Multi-view editor for authoring JSON Schema documents with form, raw JSON, and diff modes plus undo history and validation.
+
+## Use when
+
+- Letting users edit a JSON Schema with a guided form alongside the raw source.
+- Reviewing schema changes against a baseline via the built-in diff view.
+
+## Avoid when
+
+- Editing arbitrary free-form JSON with no schema semantics — use a plain code editor instead.
+
+## Keyboard and focus
+
+Keyboard behavior should follow the native control or documented ARIA pattern. Do not add extra key handlers that conflict with text entry, selection, or assistive-technology shortcuts.
+
+Keep focus indicators visible. If you wrap or restyle JsonSchemaEditor, verify the focused element remains visually apparent in default and forced-colors modes.
+
+## Names, roles, and state
+
+Use the public props and documented examples to provide accessible names, descriptions, current state, disabled state, selection state, or value text. Do not rely on color, icon shape, placeholder text, or layout position as the only way to communicate meaning.
+
+When JsonSchemaEditor accepts snippets or arbitrary children, the caller owns the semantics inside those children. Prefer native elements first, and add ARIA only when it matches the rendered behavior.
+
+## Verification
+
+- Render JsonSchemaEditor in the playground or a focused test fixture.
+- Navigate the component with keyboard only.
+- Inspect the accessible name, role, and state in browser accessibility tools.
+- Check forced-colors mode when the component adds borders, focus rings, selected state, or status color.
+
+Related components: `markdown-editor`, `review-editor`.

--- a/packages/components/src/components/json-schema-editor/property-editor.svelte
+++ b/packages/components/src/components/json-schema-editor/property-editor.svelte
@@ -139,7 +139,7 @@
   // ===== Mutation helpers =====
   function patch(
     edits: Partial<JsonSchemaObject>,
-    opts?: { coalesceKey?: string; label?: string },
+    opts: { coalesceKey?: string; label?: string } | undefined = undefined,
   ) {
     if (readonly) return;
     const next: JsonSchemaObject = { ...objectValue, ...edits };

--- a/packages/components/src/components/json-viewer/json-viewer.a11y.md
+++ b/packages/components/src/components/json-viewer/json-viewer.a11y.md
@@ -1,0 +1,38 @@
+# JsonViewer · accessibility
+
+## Pattern
+
+JsonViewer presents structured data. Preserve the component's semantic roles, row or item labels, and ordering so assistive technology can announce the same relationships that are visible on screen.
+
+Purpose: Collapsible tree visualization of an arbitrary JSON value with hard depth and byte caps and a fallback for oversized payloads.
+
+## Use when
+
+- Inspecting structured API responses, debug payloads, or configuration documents inside an admin or developer surface.
+- Rendering a JSON-serializable value with predictable initial-collapse behavior and no virtualization needs.
+
+## Avoid when
+
+- The payload is large enough to need search, filter, or virtualization — compose a custom viewer instead.
+- Showing arbitrary source code rather than a JSON value — code-block is the right surface for that.
+
+## Keyboard and focus
+
+Keyboard behavior follows the rendered native elements and any ARIA pattern documented by the component. Avoid adding handlers that change focus order without a matching visible and programmatic state update.
+
+Keep focus indicators visible. If you wrap or restyle JsonViewer, verify the focused element remains visually apparent in default and forced-colors modes.
+
+## Names, roles, and state
+
+Use the public props and documented examples to provide accessible names, descriptions, current state, disabled state, selection state, or value text. Do not rely on color, icon shape, placeholder text, or layout position as the only way to communicate meaning.
+
+When JsonViewer accepts snippets or arbitrary children, the caller owns the semantics inside those children. Prefer native elements first, and add ARIA only when it matches the rendered behavior.
+
+## Verification
+
+- Render JsonViewer in the playground or a focused test fixture.
+- Navigate the component with keyboard only.
+- Inspect the accessible name, role, and state in browser accessibility tools.
+- Check forced-colors mode when the component adds borders, focus rings, selected state, or status color.
+
+Related components: `code-block`, `tree`.

--- a/packages/components/src/components/kanban-board/kanban-board.svelte
+++ b/packages/components/src/components/kanban-board/kanban-board.svelte
@@ -423,13 +423,13 @@
     },
   });
 
-  function cancelCardLift(itemLabel?: string): void {
+  function cancelCardLift(itemLabel: string | undefined = undefined): void {
     cardController.cancel(itemLabel);
     cardTarget = null;
     pointerColumnIndex = null;
   }
 
-  function cancelColumnLift(columnTitle?: string): void {
+  function cancelColumnLift(columnTitle: string | undefined = undefined): void {
     columnLiftedKey = null;
     columnTargetIndex = null;
     if (columnTitle) announcer.announce(`${columnTitle} column move cancelled.`);

--- a/packages/components/src/components/kbd/kbd.a11y.md
+++ b/packages/components/src/components/kbd/kbd.a11y.md
@@ -1,0 +1,37 @@
+# Kbd · accessibility
+
+## Pattern
+
+Kbd styles text content. Keep the underlying text meaningful, avoid using visual style as the only semantic cue, and preserve heading or label structure outside the component when needed.
+
+Purpose: Inline element that styles a single keystroke or shortcut sequence with the semantic kbd tag.
+
+## Use when
+
+- Calling out a keyboard shortcut inline within prose or a tooltip.
+- Composing chorded shortcuts by rendering multiple kbd elements side by side.
+
+## Avoid when
+
+- Displaying a block of source code — use code-block instead.
+
+## Keyboard and focus
+
+Keyboard behavior follows the rendered native elements and any ARIA pattern documented by the component. Avoid adding handlers that change focus order without a matching visible and programmatic state update.
+
+Keep focus indicators visible. If you wrap or restyle Kbd, verify the focused element remains visually apparent in default and forced-colors modes.
+
+## Names, roles, and state
+
+Use the public props and documented examples to provide accessible names, descriptions, current state, disabled state, selection state, or value text. Do not rely on color, icon shape, placeholder text, or layout position as the only way to communicate meaning.
+
+When Kbd accepts snippets or arbitrary children, the caller owns the semantics inside those children. Prefer native elements first, and add ARIA only when it matches the rendered behavior.
+
+## Verification
+
+- Render Kbd in the playground or a focused test fixture.
+- Navigate the component with keyboard only.
+- Inspect the accessible name, role, and state in browser accessibility tools.
+- Check forced-colors mode when the component adds borders, focus rings, selected state, or status color.
+
+Related components: `code-block`.

--- a/packages/components/src/components/keyboard-shortcuts/keyboard-shortcuts.a11y.md
+++ b/packages/components/src/components/keyboard-shortcuts/keyboard-shortcuts.a11y.md
@@ -1,0 +1,37 @@
+# KeyboardShortcuts · accessibility
+
+## Pattern
+
+KeyboardShortcuts styles text content. Keep the underlying text meaningful, avoid using visual style as the only semantic cue, and preserve heading or label structure outside the component when needed.
+
+Purpose: Grouped keyboard-shortcut reference that renders key combos via Kbd with accessible labels not reliant only on visual keycaps.
+
+## Use when
+
+- Displaying a reference panel of keyboard shortcuts grouped by feature area.
+- Embedding a shortcut table inside a modal, sheet, popover, or help page.
+
+## Avoid when
+
+- Showing a single inline shortcut hint — use shortcut-hint instead.
+
+## Keyboard and focus
+
+Keyboard behavior follows the rendered native elements and any ARIA pattern documented by the component. Avoid adding handlers that change focus order without a matching visible and programmatic state update.
+
+Keep focus indicators visible. If you wrap or restyle KeyboardShortcuts, verify the focused element remains visually apparent in default and forced-colors modes.
+
+## Names, roles, and state
+
+Use the public props and documented examples to provide accessible names, descriptions, current state, disabled state, selection state, or value text. Do not rely on color, icon shape, placeholder text, or layout position as the only way to communicate meaning.
+
+When KeyboardShortcuts accepts snippets or arbitrary children, the caller owns the semantics inside those children. Prefer native elements first, and add ARIA only when it matches the rendered behavior.
+
+## Verification
+
+- Render KeyboardShortcuts in the playground or a focused test fixture.
+- Navigate the component with keyboard only.
+- Inspect the accessible name, role, and state in browser accessibility tools.
+- Check forced-colors mode when the component adds borders, focus rings, selected state, or status color.
+
+Related components: `kbd`, `shortcut-hint`, `modal`, `sheet`, `popover`.

--- a/packages/components/src/components/keyboard-shortcuts/keyboard-shortcuts.svelte
+++ b/packages/components/src/components/keyboard-shortcuts/keyboard-shortcuts.svelte
@@ -41,7 +41,7 @@
    * Build a screen-reader–friendly label for a key combo.
    * Falls back to joining keys with " plus " when no keysLabel is provided.
    */
-  function resolveKeysLabel(keys: string[], keysLabel?: string): string {
+  function resolveKeysLabel(keys: string[], keysLabel: string | undefined = undefined): string {
     if (keysLabel) return keysLabel;
     return keys.join(' plus ');
   }

--- a/packages/components/src/components/label/label.a11y.md
+++ b/packages/components/src/components/label/label.a11y.md
@@ -1,0 +1,37 @@
+# Label · accessibility
+
+## Pattern
+
+Label participates in form input or field composition. Pair each control with a visible label or an explicit accessible name, and connect validation text with the same relationship the component exposes.
+
+Purpose: Standalone label primitive that associates text with a custom control via for and matches the visual treatment of built-in inputs.
+
+## Use when
+
+- Building a hand-rolled field that wraps multiple inputs needing one shared label.
+- Matching the disabled or required visual treatment of cinder inputs on a custom control.
+
+## Avoid when
+
+- Labelling a built-in input that already renders its own label prop — pass label instead.
+
+## Keyboard and focus
+
+Keyboard behavior should follow the native control or documented ARIA pattern. Do not add extra key handlers that conflict with text entry, selection, or assistive-technology shortcuts.
+
+Keep focus indicators visible. If you wrap or restyle Label, verify the focused element remains visually apparent in default and forced-colors modes.
+
+## Names, roles, and state
+
+Use the public props and documented examples to provide accessible names, descriptions, current state, disabled state, selection state, or value text. Do not rely on color, icon shape, placeholder text, or layout position as the only way to communicate meaning.
+
+When Label accepts snippets or arbitrary children, the caller owns the semantics inside those children. Prefer native elements first, and add ARIA only when it matches the rendered behavior.
+
+## Verification
+
+- Render Label in the playground or a focused test fixture.
+- Navigate the component with keyboard only.
+- Inspect the accessible name, role, and state in browser accessibility tools.
+- Check forced-colors mode when the component adds borders, focus rings, selected state, or status color.
+
+Related components: `form-field`, `input`, `checkbox`, `radio-group`.

--- a/packages/components/src/components/link/link.a11y.md
+++ b/packages/components/src/components/link/link.a11y.md
@@ -1,0 +1,36 @@
+# Link · accessibility
+
+## Pattern
+
+Link styles text content. Keep the underlying text meaningful, avoid using visual style as the only semantic cue, and preserve heading or label structure outside the component when needed.
+
+Purpose: Inline text link with consistent focus ring and underline behavior.
+
+## Use when
+
+- Embedding a navigable link inside body text or prose content.
+
+## Avoid when
+
+- Navigating between pages in a sidebar or nav bar — use NavigationItem.
+
+## Keyboard and focus
+
+Keyboard behavior follows the rendered native elements and any ARIA pattern documented by the component. Avoid adding handlers that change focus order without a matching visible and programmatic state update.
+
+Keep focus indicators visible. If you wrap or restyle Link, verify the focused element remains visually apparent in default and forced-colors modes.
+
+## Names, roles, and state
+
+Use the public props and documented examples to provide accessible names, descriptions, current state, disabled state, selection state, or value text. Do not rely on color, icon shape, placeholder text, or layout position as the only way to communicate meaning.
+
+When Link accepts snippets or arbitrary children, the caller owns the semantics inside those children. Prefer native elements first, and add ARIA only when it matches the rendered behavior.
+
+## Verification
+
+- Render Link in the playground or a focused test fixture.
+- Navigate the component with keyboard only.
+- Inspect the accessible name, role, and state in browser accessibility tools.
+- Check forced-colors mode when the component adds borders, focus rings, selected state, or status color.
+
+Related components: `navigation-item`, `button`, `breadcrumbs`.

--- a/packages/components/src/components/markdown-editor/markdown-editor.a11y.md
+++ b/packages/components/src/components/markdown-editor/markdown-editor.a11y.md
@@ -1,0 +1,38 @@
+# MarkdownEditor · accessibility
+
+## Pattern
+
+MarkdownEditor packages a higher-level workflow. Confirm the composed controls, labels, states, and keyboard path match the domain task instead of treating the visual shell as the accessibility contract.
+
+Purpose: Rich Markdown editing surface bundling a Milkdown-powered ProseMirror editor, toolbar, and mark or block introspection helpers.
+
+## Use when
+
+- Composing or editing Markdown documents and wanting the bundled toolbar, link-aware selection, and source or WYSIWYG mode toggle.
+- Building writing surfaces that need an editor handle for programmatic mark or block manipulation as part of the heavyweight suite.
+
+## Avoid when
+
+- Authoring a simple plain-text note — a textarea is dramatically lighter than the Milkdown bundle.
+- The surface needs inline review threads on top of the editor — use review-editor for that composition.
+
+## Keyboard and focus
+
+Keyboard behavior follows the rendered native elements and any ARIA pattern documented by the component. Avoid adding handlers that change focus order without a matching visible and programmatic state update.
+
+Keep focus indicators visible. If you wrap or restyle MarkdownEditor, verify the focused element remains visually apparent in default and forced-colors modes.
+
+## Names, roles, and state
+
+Use the public props and documented examples to provide accessible names, descriptions, current state, disabled state, selection state, or value text. Do not rely on color, icon shape, placeholder text, or layout position as the only way to communicate meaning.
+
+When MarkdownEditor accepts snippets or arbitrary children, the caller owns the semantics inside those children. Prefer native elements first, and add ARIA only when it matches the rendered behavior.
+
+## Verification
+
+- Render MarkdownEditor in the playground or a focused test fixture.
+- Navigate the component with keyboard only.
+- Inspect the accessible name, role, and state in browser accessibility tools.
+- Check forced-colors mode when the component adds borders, focus rings, selected state, or status color.
+
+Related components: `review-editor`, `code-block`.

--- a/packages/components/src/components/markdown-editor/markdown-editor.svelte
+++ b/packages/components/src/components/markdown-editor/markdown-editor.svelte
@@ -385,7 +385,7 @@
     editorState?.focus();
   }
 
-  function handleLinkInsert(url: string, text?: string) {
+  function handleLinkInsert(url: string, text: string | undefined = undefined) {
     if (!editorContext) return;
 
     if (text) {

--- a/packages/components/src/components/masonry/masonry.a11y.md
+++ b/packages/components/src/components/masonry/masonry.a11y.md
@@ -1,0 +1,37 @@
+# Masonry · accessibility
+
+## Pattern
+
+Masonry affects structure rather than meaning. Use it without removing headings, landmarks, labels, or reading order from the content it contains.
+
+Purpose: Pure CSS waterfall layout that packs variable-height children into balanced columns.
+
+## Use when
+
+- Displaying cards, images, or panels with uneven heights where CSS column order is acceptable.
+
+## Avoid when
+
+- Items have equal heights - use grid-list instead.
+- Left-to-right row reading order matters - use grid instead.
+
+## Keyboard and focus
+
+Keyboard behavior follows the rendered native elements and any ARIA pattern documented by the component. Avoid adding handlers that change focus order without a matching visible and programmatic state update.
+
+Keep focus indicators visible. If you wrap or restyle Masonry, verify the focused element remains visually apparent in default and forced-colors modes.
+
+## Names, roles, and state
+
+Use the public props and documented examples to provide accessible names, descriptions, current state, disabled state, selection state, or value text. Do not rely on color, icon shape, placeholder text, or layout position as the only way to communicate meaning.
+
+When Masonry accepts snippets or arbitrary children, the caller owns the semantics inside those children. Prefer native elements first, and add ARIA only when it matches the rendered behavior.
+
+## Verification
+
+- Render Masonry in the playground or a focused test fixture.
+- Navigate the component with keyboard only.
+- Inspect the accessible name, role, and state in browser accessibility tools.
+- Check forced-colors mode when the component adds borders, focus rings, selected state, or status color.
+
+Related components: `grid`, `grid-list`.

--- a/packages/components/src/components/matrix-chart/matrix-chart.a11y.md
+++ b/packages/components/src/components/matrix-chart/matrix-chart.a11y.md
@@ -1,0 +1,38 @@
+# MatrixChart · accessibility
+
+## Pattern
+
+MatrixChart presents structured data. Preserve the component's semantic roles, row or item labels, and ordering so assistive technology can announce the same relationships that are visible on screen.
+
+Purpose: Categorical × categorical heatmap for dense analytics, confusion matrices, and correlation grids.
+
+## Use when
+
+- Showing density or magnitude across two categorical dimensions simultaneously.
+- Rendering a confusion matrix where rows are actual classes and columns are predicted classes.
+
+## Avoid when
+
+- Showing a continuous trend over time — use line-chart instead.
+- Comparing discrete category totals — use bar-chart instead.
+
+## Keyboard and focus
+
+Keyboard behavior follows the rendered native elements and any ARIA pattern documented by the component. Avoid adding handlers that change focus order without a matching visible and programmatic state update.
+
+Keep focus indicators visible. If you wrap or restyle MatrixChart, verify the focused element remains visually apparent in default and forced-colors modes.
+
+## Names, roles, and state
+
+Use the public props and documented examples to provide accessible names, descriptions, current state, disabled state, selection state, or value text. Do not rely on color, icon shape, placeholder text, or layout position as the only way to communicate meaning.
+
+When MatrixChart accepts snippets or arbitrary children, the caller owns the semantics inside those children. Prefer native elements first, and add ARIA only when it matches the rendered behavior.
+
+## Verification
+
+- Render MatrixChart in the playground or a focused test fixture.
+- Navigate the component with keyboard only.
+- Inspect the accessible name, role, and state in browser accessibility tools.
+- Check forced-colors mode when the component adds borders, focus rings, selected state, or status color.
+
+Related components: `bar-chart`, `line-chart`, `area-chart`.

--- a/packages/components/src/components/media-controls/media-controls.a11y.md
+++ b/packages/components/src/components/media-controls/media-controls.a11y.md
@@ -1,0 +1,38 @@
+# MediaControls · accessibility
+
+## Pattern
+
+MediaControls exposes an operable control surface. Prefer the native interactive element it renders, keep the accessible name specific to the action, and do not replace it with a non-interactive wrapper.
+
+Purpose: Accessible playback controls for play, pause, and replay actions with optional progress display.
+
+## Use when
+
+- Embedding play/pause/replay controls for audio or video content.
+- Rendering media controls inside a toolbar or standalone on a card.
+
+## Avoid when
+
+- You need waveform visualization or Web Audio integration — wire that separately.
+- You need a full media player UI with seek scrubbing — use a dedicated player component.
+
+## Keyboard and focus
+
+Activation should work with the native Enter and Space behavior of the rendered control. Custom children must not swallow those events unless they replace the whole interaction intentionally.
+
+Keep focus indicators visible. If you wrap or restyle MediaControls, verify the focused element remains visually apparent in default and forced-colors modes.
+
+## Names, roles, and state
+
+Use the public props and documented examples to provide accessible names, descriptions, current state, disabled state, selection state, or value text. Do not rely on color, icon shape, placeholder text, or layout position as the only way to communicate meaning.
+
+When MediaControls accepts snippets or arbitrary children, the caller owns the semantics inside those children. Prefer native elements first, and add ARIA only when it matches the rendered behavior.
+
+## Verification
+
+- Render MediaControls in the playground or a focused test fixture.
+- Navigate the component with keyboard only.
+- Inspect the accessible name, role, and state in browser accessibility tools.
+- Check forced-colors mode when the component adds borders, focus rings, selected state, or status color.
+
+Related components: `button`, `toolbar`, `progress`, `tooltip`.

--- a/packages/components/src/components/menu-bar/menu-bar.a11y.md
+++ b/packages/components/src/components/menu-bar/menu-bar.a11y.md
@@ -1,0 +1,38 @@
+# MenuBar · accessibility
+
+## Pattern
+
+MenuBar helps users move through destinations or hierarchy. Keep link text and selected/current state accurate so keyboard and assistive-technology users get the same location cues as sighted pointer users.
+
+Purpose: Command menubar for application chrome such as File, Edit, and View menus.
+
+## Use when
+
+- Building a desktop-style command menubar with dropdown command groups.
+- Exposing top-level application menus that need arrow-key traversal and optional submenus.
+
+## Avoid when
+
+- Linking between routes or sections — use navigation-bar or side-navigation instead.
+- Showing one standalone trigger with a menu — use dropdown, dropdown-menu, and dropdown-item directly.
+
+## Keyboard and focus
+
+The browser tab order should follow visual order. Use current/selected state only for the destination or item that is actually current.
+
+Keep focus indicators visible. If you wrap or restyle MenuBar, verify the focused element remains visually apparent in default and forced-colors modes.
+
+## Names, roles, and state
+
+Use the public props and documented examples to provide accessible names, descriptions, current state, disabled state, selection state, or value text. Do not rely on color, icon shape, placeholder text, or layout position as the only way to communicate meaning.
+
+When MenuBar accepts snippets or arbitrary children, the caller owns the semantics inside those children. Prefer native elements first, and add ARIA only when it matches the rendered behavior.
+
+## Verification
+
+- Render MenuBar in the playground or a focused test fixture.
+- Navigate the component with keyboard only.
+- Inspect the accessible name, role, and state in browser accessibility tools.
+- Check forced-colors mode when the component adds borders, focus rings, selected state, or status color.
+
+Related components: `navigation-bar`, `dropdown`, `dropdown-menu`, `dropdown-item`.

--- a/packages/components/src/components/message/message.a11y.md
+++ b/packages/components/src/components/message/message.a11y.md
@@ -1,0 +1,38 @@
+# Message · accessibility
+
+## Pattern
+
+Message presents structured data. Preserve the component's semantic roles, row or item labels, and ordering so assistive technology can announce the same relationships that are visible on screen.
+
+Purpose: Chat-style bubble that renders a role label, optional timestamp, and arbitrary body content for transcript or run-stream views.
+
+## Use when
+
+- Composing a transcript of user, assistant, and system turns outside the full chat suite.
+- Rendering AI agent runs, support threads, or audit logs where each entry has a speaker and a body.
+
+## Avoid when
+
+- Building a complete conversation surface with composer and scroll affordances — reach for the chat suite instead.
+- Communicating a single non-conversational notice — callout is more appropriate.
+
+## Keyboard and focus
+
+Keyboard behavior follows the rendered native elements and any ARIA pattern documented by the component. Avoid adding handlers that change focus order without a matching visible and programmatic state update.
+
+Keep focus indicators visible. If you wrap or restyle Message, verify the focused element remains visually apparent in default and forced-colors modes.
+
+## Names, roles, and state
+
+Use the public props and documented examples to provide accessible names, descriptions, current state, disabled state, selection state, or value text. Do not rely on color, icon shape, placeholder text, or layout position as the only way to communicate meaning.
+
+When Message accepts snippets or arbitrary children, the caller owns the semantics inside those children. Prefer native elements first, and add ARIA only when it matches the rendered behavior.
+
+## Verification
+
+- Render Message in the playground or a focused test fixture.
+- Navigate the component with keyboard only.
+- Inspect the accessible name, role, and state in browser accessibility tools.
+- Check forced-colors mode when the component adds borders, focus rings, selected state, or status color.
+
+Related components: `chat`, `callout`.

--- a/packages/components/src/components/permission-matrix/permission-matrix.a11y.md
+++ b/packages/components/src/components/permission-matrix/permission-matrix.a11y.md
@@ -1,0 +1,38 @@
+# PermissionMatrix · accessibility
+
+## Pattern
+
+PermissionMatrix presents structured data. Preserve the component's semantic roles, row or item labels, and ordering so assistive technology can announce the same relationships that are visible on screen.
+
+Purpose: Categorical permission matrix for scanning discrete access states across scopes and operations.
+
+## Use when
+
+- Showing whether scopes, roles, or policy categories grant specific operations.
+- Each cell represents a discrete state such as granted, denied, or not applicable.
+
+## Avoid when
+
+- Showing numeric density or magnitude across two categorical dimensions — use matrix-chart instead.
+- Rendering editable permissions — use a purpose-built form or data-grid instead.
+
+## Keyboard and focus
+
+Native table reading order is the keyboard contract. Sort controls, when present, are real buttons inside header cells and use `aria-sort` on the header cell.
+
+Keep focus indicators visible. If you wrap or restyle PermissionMatrix, verify the focused element remains visually apparent in default and forced-colors modes.
+
+## Names, roles, and state
+
+Use the public props and documented examples to provide accessible names, descriptions, current state, disabled state, selection state, or value text. Do not rely on color, icon shape, placeholder text, or layout position as the only way to communicate meaning.
+
+When PermissionMatrix accepts snippets or arbitrary children, the caller owns the semantics inside those children. Prefer native elements first, and add ARIA only when it matches the rendered behavior.
+
+## Verification
+
+- Render PermissionMatrix in the playground or a focused test fixture.
+- Navigate the component with keyboard only.
+- Inspect the accessible name, role, and state in browser accessibility tools.
+- Check forced-colors mode when the component adds borders, focus rings, selected state, or status color.
+
+Related components: `matrix-chart`, `data-grid`, `table`.

--- a/packages/components/src/components/phone-input/phone-input.svelte
+++ b/packages/components/src/components/phone-input/phone-input.svelte
@@ -116,7 +116,7 @@
 
   function synchronizeNationalDigitsToCountry(
     nextCountry: PhoneInputCountryCode,
-    options?: { recomputeValue?: boolean },
+    options: { recomputeValue?: boolean } | undefined = undefined,
   ): void {
     const { recomputeValue = true } = options ?? {};
     const nationalDigits = digitsOnly(nationalDisplay);

--- a/packages/components/src/components/pricing-card/pricing-card.a11y.md
+++ b/packages/components/src/components/pricing-card/pricing-card.a11y.md
@@ -1,0 +1,38 @@
+# PricingCard · accessibility
+
+## Pattern
+
+PricingCard presents structured data. Preserve the component's semantic roles, row or item labels, and ordering so assistive technology can announce the same relationships that are visible on screen.
+
+Purpose: Presents a single pricing plan with its name, price, feature list, and a call-to-action button.
+
+## Use when
+
+- Letting users compare and select subscription tiers or product plans.
+- Highlighting one tier as selected or recommended in a pricing comparison.
+
+## Avoid when
+
+- Showing generic grouped content without a distinct price or CTA — use card instead.
+- Displaying a single key metric in isolation — use stat or stat-group instead.
+
+## Keyboard and focus
+
+Keyboard behavior follows the rendered native elements and any ARIA pattern documented by the component. Avoid adding handlers that change focus order without a matching visible and programmatic state update.
+
+Keep focus indicators visible. If you wrap or restyle PricingCard, verify the focused element remains visually apparent in default and forced-colors modes.
+
+## Names, roles, and state
+
+Use the public props and documented examples to provide accessible names, descriptions, current state, disabled state, selection state, or value text. Do not rely on color, icon shape, placeholder text, or layout position as the only way to communicate meaning.
+
+When PricingCard accepts snippets or arbitrary children, the caller owns the semantics inside those children. Prefer native elements first, and add ARIA only when it matches the rendered behavior.
+
+## Verification
+
+- Render PricingCard in the playground or a focused test fixture.
+- Navigate the component with keyboard only.
+- Inspect the accessible name, role, and state in browser accessibility tools.
+- Check forced-colors mode when the component adds borders, focus rings, selected state, or status color.
+
+Related components: `card`, `button`, `stat`, `stat-group`.

--- a/packages/components/src/components/progress/progress.a11y.md
+++ b/packages/components/src/components/progress/progress.a11y.md
@@ -1,0 +1,38 @@
+# Progress · accessibility
+
+## Pattern
+
+Progress communicates status or supporting context. Keep the message text concise, and choose the surrounding live-region behavior based on whether the condition is immediate, persistent, or purely informational.
+
+Purpose: Determinate or indeterminate progressbar rendered as a horizontal bar or ring with full ARIA value semantics.
+
+## Use when
+
+- Reporting measurable progress of a known task such as a file upload or multi-step import.
+- Showing an indeterminate work indicator when the task duration is unknown but the surface needs a progressbar role.
+
+## Avoid when
+
+- Showing a small inline busy state next to a control — use spinner.
+- Reserving placeholder space for incoming content — use skeleton.
+
+## Keyboard and focus
+
+Keyboard behavior follows the rendered native elements and any ARIA pattern documented by the component. Avoid adding handlers that change focus order without a matching visible and programmatic state update.
+
+Keep focus indicators visible. If you wrap or restyle Progress, verify the focused element remains visually apparent in default and forced-colors modes.
+
+## Names, roles, and state
+
+Use the public props and documented examples to provide accessible names, descriptions, current state, disabled state, selection state, or value text. Do not rely on color, icon shape, placeholder text, or layout position as the only way to communicate meaning.
+
+When Progress accepts snippets or arbitrary children, the caller owns the semantics inside those children. Prefer native elements first, and add ARIA only when it matches the rendered behavior.
+
+## Verification
+
+- Render Progress in the playground or a focused test fixture.
+- Navigate the component with keyboard only.
+- Inspect the accessible name, role, and state in browser accessibility tools.
+- Check forced-colors mode when the component adds borders, focus rings, selected state, or status color.
+
+Related components: `spinner`, `skeleton`.

--- a/packages/components/src/components/review-editor/review-editor-impl.svelte
+++ b/packages/components/src/components/review-editor/review-editor-impl.svelte
@@ -1000,7 +1000,9 @@
    * Includes document changes and comment threads
    * in a structured format suitable for LLM analysis.
    */
-  export function exportMarkdownSummary(options?: MarkdownSummaryOptions): MarkdownSummaryResult {
+  export function exportMarkdownSummary(
+    options: MarkdownSummaryOptions | undefined = undefined,
+  ): MarkdownSummaryResult {
     return generateMarkdownSummary(getState(), options);
   }
 
@@ -1008,7 +1010,9 @@
    * Export a Git-compatible unified diff.
    * The output can be applied with `git apply` or `patch` command.
    */
-  export function exportUnifiedDiff(options?: UnifiedDiffOptions): UnifiedDiffResult {
+  export function exportUnifiedDiff(
+    options: UnifiedDiffOptions | undefined = undefined,
+  ): UnifiedDiffResult {
     return generateUnifiedDiff(getState(), options);
   }
 

--- a/packages/components/src/components/review-editor/review-editor.a11y.md
+++ b/packages/components/src/components/review-editor/review-editor.a11y.md
@@ -1,0 +1,38 @@
+# ReviewEditor · accessibility
+
+## Pattern
+
+ReviewEditor packages a higher-level workflow. Confirm the composed controls, labels, states, and keyboard path match the domain task instead of treating the visual shell as the accessibility contract.
+
+Purpose: Markdown editor extended with inline review threads, anchored comments, and collaborative annotation state.
+
+## Use when
+
+- Building a document review experience that needs both a Markdown editor and anchored comment threads in one bundled surface.
+- Threading reviewer commentary against specific selections inside a long-form document.
+
+## Avoid when
+
+- Plain authoring with no review threads — markdown-editor is the lighter primitive.
+- Reviewing diffs between two documents rather than annotating one — use diff-viewer instead.
+
+## Keyboard and focus
+
+Keyboard behavior follows the rendered native elements and any ARIA pattern documented by the component. Avoid adding handlers that change focus order without a matching visible and programmatic state update.
+
+Keep focus indicators visible. If you wrap or restyle ReviewEditor, verify the focused element remains visually apparent in default and forced-colors modes.
+
+## Names, roles, and state
+
+Use the public props and documented examples to provide accessible names, descriptions, current state, disabled state, selection state, or value text. Do not rely on color, icon shape, placeholder text, or layout position as the only way to communicate meaning.
+
+When ReviewEditor accepts snippets or arbitrary children, the caller owns the semantics inside those children. Prefer native elements first, and add ARIA only when it matches the rendered behavior.
+
+## Verification
+
+- Render ReviewEditor in the playground or a focused test fixture.
+- Navigate the component with keyboard only.
+- Inspect the accessible name, role, and state in browser accessibility tools.
+- Check forced-colors mode when the component adds borders, focus rings, selected state, or status color.
+
+Related components: `markdown-editor`.

--- a/packages/components/src/components/scroll-area/scroll-area.a11y.md
+++ b/packages/components/src/components/scroll-area/scroll-area.a11y.md
@@ -1,0 +1,38 @@
+# ScrollArea · accessibility
+
+## Pattern
+
+ScrollArea affects structure rather than meaning. Use it without removing headings, landmarks, labels, or reading order from the content it contains.
+
+Purpose: Bounded scrolling container that constrains overflowing content within a max height or width while remaining keyboard-focusable.
+
+## Use when
+
+- Containing a long list or large block of content inside a fixed-size region.
+- Preserving keyboard scrollability for overflow content in a card or surface.
+
+## Avoid when
+
+- Wrapping the entire page — let the document scroll natively.
+- Hiding overflow without scrollbars — use plain CSS overflow utilities instead.
+
+## Keyboard and focus
+
+Keyboard behavior follows the rendered native elements and any ARIA pattern documented by the component. Avoid adding handlers that change focus order without a matching visible and programmatic state update.
+
+Keep focus indicators visible. If you wrap or restyle ScrollArea, verify the focused element remains visually apparent in default and forced-colors modes.
+
+## Names, roles, and state
+
+Use the public props and documented examples to provide accessible names, descriptions, current state, disabled state, selection state, or value text. Do not rely on color, icon shape, placeholder text, or layout position as the only way to communicate meaning.
+
+When ScrollArea accepts snippets or arbitrary children, the caller owns the semantics inside those children. Prefer native elements first, and add ARIA only when it matches the rendered behavior.
+
+## Verification
+
+- Render ScrollArea in the playground or a focused test fixture.
+- Navigate the component with keyboard only.
+- Inspect the accessible name, role, and state in browser accessibility tools.
+- Check forced-colors mode when the component adds borders, focus rings, selected state, or status color.
+
+Related components: `surface`.

--- a/packages/components/src/components/section-heading/section-heading.a11y.md
+++ b/packages/components/src/components/section-heading/section-heading.a11y.md
@@ -1,0 +1,38 @@
+# SectionHeading · accessibility
+
+## Pattern
+
+SectionHeading styles text content. Keep the underlying text meaningful, avoid using visual style as the only semantic cue, and preserve heading or label structure outside the component when needed.
+
+Purpose: Section header that renders a leveled heading with optional eyebrow label, description, actions, and tabs row.
+
+## Use when
+
+- Introducing a top-level section of a page with a title and supporting metadata.
+- Pairing a section title with inline actions or a tab row beneath the heading.
+
+## Avoid when
+
+- Labelling a single form control or field — use label instead.
+- Rendering a page-wide header with primary navigation — use a hand-rolled page scaffold with a heading element.
+
+## Keyboard and focus
+
+Keyboard behavior follows the rendered native elements and any ARIA pattern documented by the component. Avoid adding handlers that change focus order without a matching visible and programmatic state update.
+
+Keep focus indicators visible. If you wrap or restyle SectionHeading, verify the focused element remains visually apparent in default and forced-colors modes.
+
+## Names, roles, and state
+
+Use the public props and documented examples to provide accessible names, descriptions, current state, disabled state, selection state, or value text. Do not rely on color, icon shape, placeholder text, or layout position as the only way to communicate meaning.
+
+When SectionHeading accepts snippets or arbitrary children, the caller owns the semantics inside those children. Prefer native elements first, and add ARIA only when it matches the rendered behavior.
+
+## Verification
+
+- Render SectionHeading in the playground or a focused test fixture.
+- Navigate the component with keyboard only.
+- Inspect the accessible name, role, and state in browser accessibility tools.
+- Check forced-colors mode when the component adds borders, focus rings, selected state, or status color.
+
+Related components: `card`, `tab-list`.

--- a/packages/components/src/components/segment/segment.a11y.md
+++ b/packages/components/src/components/segment/segment.a11y.md
@@ -1,0 +1,38 @@
+# Segment · accessibility
+
+## Pattern
+
+Segment participates in form input or field composition. Pair each control with a visible label or an explicit accessible name, and connect validation text with the same relationship the component exposes.
+
+Purpose: Individual option inside a SegmentedControl that renders the button, wires the value, and forwards leading/trailing decorations.
+
+## Use when
+
+- Authoring SegmentedControl children declaratively so consumers can compose icons, labels, and badges per segment.
+- Mixing disabled and enabled segments inside a single radiogroup/tablist where each segment carries its own metadata.
+
+## Avoid when
+
+- Building a standalone toggle button — use Button or Toggle instead.
+- Selecting one option from a long list — use Select or Combobox instead.
+
+## Keyboard and focus
+
+Keyboard behavior should follow the native control or documented ARIA pattern. Do not add extra key handlers that conflict with text entry, selection, or assistive-technology shortcuts.
+
+Keep focus indicators visible. If you wrap or restyle Segment, verify the focused element remains visually apparent in default and forced-colors modes.
+
+## Names, roles, and state
+
+Use the public props and documented examples to provide accessible names, descriptions, current state, disabled state, selection state, or value text. Do not rely on color, icon shape, placeholder text, or layout position as the only way to communicate meaning.
+
+When Segment accepts snippets or arbitrary children, the caller owns the semantics inside those children. Prefer native elements first, and add ARIA only when it matches the rendered behavior.
+
+## Verification
+
+- Render Segment in the playground or a focused test fixture.
+- Navigate the component with keyboard only.
+- Inspect the accessible name, role, and state in browser accessibility tools.
+- Check forced-colors mode when the component adds borders, focus rings, selected state, or status color.
+
+Related components: `segmented-control`, `button`, `toggle`.

--- a/packages/components/src/components/segmented-control/segmented-control.examples.json
+++ b/packages/components/src/components/segmented-control/segmented-control.examples.json
@@ -12,8 +12,8 @@
     {
       "id": "multiple",
       "title": "Multi-select segmented control",
-      "description": "Multiple options can be toggled independently. Bind a SvelteSet to track selection.",
-      "code": "<script lang=\"ts\">\n  import { SvelteSet } from 'svelte/reactivity';\n  import { Segment } from '@lostgradient/cinder/segment';\n  import { SegmentedControl } from '@lostgradient/cinder/segmented-control';\n\n  let formats = new SvelteSet<string>();\n\n  const selected = $derived([...formats].join(', ') || 'none');\n</script>\n\n<div style=\"display: grid; gap: 0.75rem; justify-items: start;\">\n  <SegmentedControl\n    id=\"playground-format\"\n    selectionMode=\"multiple\"\n    bind:value={formats}\n    label=\"Text formatting\"\n  >\n    <Segment value=\"bold\">Bold</Segment>\n    <Segment value=\"italic\">Italic</Segment>\n    <Segment value=\"underline\">Underline</Segment>\n    <Segment value=\"strikethrough\">Strike</Segment>\n  </SegmentedControl>\n  <p style=\"margin: 0; color: var(--cinder-text-muted);\">Active formats: {selected}</p>\n</div>\n"
+      "description": "Multiple options can be toggled independently. Pass a SvelteSet to track selection.",
+      "code": "<script lang=\"ts\">\n  import { SvelteSet } from 'svelte/reactivity';\n  import { Segment } from '@lostgradient/cinder/segment';\n  import { SegmentedControl } from '@lostgradient/cinder/segmented-control';\n\n  let formats = new SvelteSet<string>();\n\n  const selected = $derived([...formats].join(', ') || 'none');\n</script>\n\n<div style=\"display: grid; gap: 0.75rem; justify-items: start;\">\n  <SegmentedControl\n    id=\"playground-format\"\n    selectionMode=\"multiple\"\n    value={formats}\n    label=\"Text formatting\"\n  >\n    <Segment value=\"bold\">Bold</Segment>\n    <Segment value=\"italic\">Italic</Segment>\n    <Segment value=\"underline\">Underline</Segment>\n    <Segment value=\"strikethrough\">Strike</Segment>\n  </SegmentedControl>\n  <p style=\"margin: 0; color: var(--cinder-text-muted);\">Active formats: {selected}</p>\n</div>\n"
     },
     {
       "id": "sizing",

--- a/packages/components/src/components/selection-popover/selection-popover.a11y.md
+++ b/packages/components/src/components/selection-popover/selection-popover.a11y.md
@@ -1,0 +1,38 @@
+# SelectionPopover · accessibility
+
+## Pattern
+
+SelectionPopover presents layered content. Keep trigger, focus movement, dismissal, and labelling in one predictable interaction path so users can enter and leave the layer without losing context.
+
+Purpose: Floating toolbar anchored to a text selection that exposes a comment-on-selection action with an inline composer.
+
+## Use when
+
+- Letting readers annotate or comment on a highlighted range of text in a document or article surface.
+- Surfacing selection-scoped actions such as quote, share, or comment near the user's pointer.
+
+## Avoid when
+
+- Anchoring generic non-selection content to a trigger — use popover.
+- Building a general-purpose floating toolbar unrelated to text selection — compose a popover with custom controls.
+
+## Keyboard and focus
+
+The trigger should remain reachable by keyboard, and the open layer should provide a clear Escape, close, or outside-interaction path consistent with the component documentation.
+
+Keep focus indicators visible. If you wrap or restyle SelectionPopover, verify the focused element remains visually apparent in default and forced-colors modes.
+
+## Names, roles, and state
+
+Use the public props and documented examples to provide accessible names, descriptions, current state, disabled state, selection state, or value text. Do not rely on color, icon shape, placeholder text, or layout position as the only way to communicate meaning.
+
+When SelectionPopover accepts snippets or arbitrary children, the caller owns the semantics inside those children. Prefer native elements first, and add ARIA only when it matches the rendered behavior.
+
+## Verification
+
+- Render SelectionPopover in the playground or a focused test fixture.
+- Navigate the component with keyboard only.
+- Inspect the accessible name, role, and state in browser accessibility tools.
+- Check forced-colors mode when the component adds borders, focus rings, selected state, or status color.
+
+Related components: `popover`.

--- a/packages/components/src/components/share-card/share-card.a11y.md
+++ b/packages/components/src/components/share-card/share-card.a11y.md
@@ -1,0 +1,38 @@
+# ShareCard · accessibility
+
+## Pattern
+
+ShareCard exposes an operable control surface. Prefer the native interactive element it renders, keep the accessible name specific to the action, and do not replace it with a non-interactive wrapper.
+
+Purpose: Compact share card with copy-link, copy-text, and native navigator.share actions, with accessible success announcements and graceful fallback when navigator.share is unavailable.
+
+## Use when
+
+- Offering a quick way to share a link or text with copy and native share options.
+- Presenting a result, invite link, or exported report link with sharing affordances.
+
+## Avoid when
+
+- Generating the share text or images — compose ShareCard with your own copy generation logic.
+- Posting directly to social media or analytics — wire those externally.
+
+## Keyboard and focus
+
+Activation should work with the native Enter and Space behavior of the rendered control. Custom children must not swallow those events unless they replace the whole interaction intentionally.
+
+Keep focus indicators visible. If you wrap or restyle ShareCard, verify the focused element remains visually apparent in default and forced-colors modes.
+
+## Names, roles, and state
+
+Use the public props and documented examples to provide accessible names, descriptions, current state, disabled state, selection state, or value text. Do not rely on color, icon shape, placeholder text, or layout position as the only way to communicate meaning.
+
+When ShareCard accepts snippets or arbitrary children, the caller owns the semantics inside those children. Prefer native elements first, and add ARIA only when it matches the rendered behavior.
+
+## Verification
+
+- Render ShareCard in the playground or a focused test fixture.
+- Navigate the component with keyboard only.
+- Inspect the accessible name, role, and state in browser accessibility tools.
+- Check forced-colors mode when the component adds borders, focus rings, selected state, or status color.
+
+Related components: `copy-button`, `card`, `button`.

--- a/packages/components/src/components/shortcut-hint/shortcut-hint.a11y.md
+++ b/packages/components/src/components/shortcut-hint/shortcut-hint.a11y.md
@@ -1,0 +1,37 @@
+# ShortcutHint · accessibility
+
+## Pattern
+
+ShortcutHint styles text content. Keep the underlying text meaningful, avoid using visual style as the only semantic cue, and preserve heading or label structure outside the component when needed.
+
+Purpose: Inline shortcut hint that renders a key combo via Kbd alongside an action label, with an accessible text representation not reliant on visual keycaps alone.
+
+## Use when
+
+- Showing a keyboard shortcut inline beside a label in a toolbar button, menu item, or tooltip.
+- Pairing with command-palette items to surface available shortcuts.
+
+## Avoid when
+
+- Displaying a full shortcut reference table — use keyboard-shortcuts instead.
+
+## Keyboard and focus
+
+Keyboard behavior follows the rendered native elements and any ARIA pattern documented by the component. Avoid adding handlers that change focus order without a matching visible and programmatic state update.
+
+Keep focus indicators visible. If you wrap or restyle ShortcutHint, verify the focused element remains visually apparent in default and forced-colors modes.
+
+## Names, roles, and state
+
+Use the public props and documented examples to provide accessible names, descriptions, current state, disabled state, selection state, or value text. Do not rely on color, icon shape, placeholder text, or layout position as the only way to communicate meaning.
+
+When ShortcutHint accepts snippets or arbitrary children, the caller owns the semantics inside those children. Prefer native elements first, and add ARIA only when it matches the rendered behavior.
+
+## Verification
+
+- Render ShortcutHint in the playground or a focused test fixture.
+- Navigate the component with keyboard only.
+- Inspect the accessible name, role, and state in browser accessibility tools.
+- Check forced-colors mode when the component adds borders, focus rings, selected state, or status color.
+
+Related components: `kbd`, `keyboard-shortcuts`, `tooltip`.

--- a/packages/components/src/components/skeleton/skeleton.a11y.md
+++ b/packages/components/src/components/skeleton/skeleton.a11y.md
@@ -1,0 +1,38 @@
+# Skeleton · accessibility
+
+## Pattern
+
+Skeleton communicates status or supporting context. Keep the message text concise, and choose the surrounding live-region behavior based on whether the condition is immediate, persistent, or purely informational.
+
+Purpose: Decorative placeholder block that reserves layout space while real content loads.
+
+## Use when
+
+- Reserving the rough shape of incoming content during an initial fetch to avoid layout shift.
+- Indicating progressive load of cards, rows, or media tiles where the final shape is known.
+
+## Avoid when
+
+- Indicating indeterminate background work without a known target shape — use spinner.
+- Communicating that a view has no data at all — use empty-state.
+
+## Keyboard and focus
+
+Keyboard behavior follows the rendered native elements and any ARIA pattern documented by the component. Avoid adding handlers that change focus order without a matching visible and programmatic state update.
+
+Keep focus indicators visible. If you wrap or restyle Skeleton, verify the focused element remains visually apparent in default and forced-colors modes.
+
+## Names, roles, and state
+
+Use the public props and documented examples to provide accessible names, descriptions, current state, disabled state, selection state, or value text. Do not rely on color, icon shape, placeholder text, or layout position as the only way to communicate meaning.
+
+When Skeleton accepts snippets or arbitrary children, the caller owns the semantics inside those children. Prefer native elements first, and add ARIA only when it matches the rendered behavior.
+
+## Verification
+
+- Render Skeleton in the playground or a focused test fixture.
+- Navigate the component with keyboard only.
+- Inspect the accessible name, role, and state in browser accessibility tools.
+- Check forced-colors mode when the component adds borders, focus rings, selected state, or status color.
+
+Related components: `spinner`, `empty-state`, `progress`.

--- a/packages/components/src/components/skip-link/skip-link.a11y.md
+++ b/packages/components/src/components/skip-link/skip-link.a11y.md
@@ -1,0 +1,38 @@
+# SkipLink · accessibility
+
+## Pattern
+
+SkipLink helps users move through destinations or hierarchy. Keep link text and selected/current state accurate so keyboard and assistive-technology users get the same location cues as sighted pointer users.
+
+Purpose: Visually hidden skip link that moves keyboard focus to a landmark element, letting keyboard and screen reader users bypass repeated navigation.
+
+## Use when
+
+- Providing a keyboard shortcut to jump past site-wide navigation directly to the main content area.
+- Meeting WCAG 2.4.1 (Bypass Blocks) without adding visible chrome to the layout.
+
+## Avoid when
+
+- The page has no repeated navigation block — a skip link adds no value on single-panel layouts.
+- The target region already receives focus naturally without intervention.
+
+## Keyboard and focus
+
+The browser tab order should follow visual order. Use current/selected state only for the destination or item that is actually current.
+
+Keep focus indicators visible. If you wrap or restyle SkipLink, verify the focused element remains visually apparent in default and forced-colors modes.
+
+## Names, roles, and state
+
+Use the public props and documented examples to provide accessible names, descriptions, current state, disabled state, selection state, or value text. Do not rely on color, icon shape, placeholder text, or layout position as the only way to communicate meaning.
+
+When SkipLink accepts snippets or arbitrary children, the caller owns the semantics inside those children. Prefer native elements first, and add ARIA only when it matches the rendered behavior.
+
+## Verification
+
+- Render SkipLink in the playground or a focused test fixture.
+- Navigate the component with keyboard only.
+- Inspect the accessible name, role, and state in browser accessibility tools.
+- Check forced-colors mode when the component adds borders, focus rings, selected state, or status color.
+
+Related components: `visually-hidden`.

--- a/packages/components/src/components/spectrogram/spectrogram.a11y.md
+++ b/packages/components/src/components/spectrogram/spectrogram.a11y.md
@@ -1,0 +1,39 @@
+# Spectrogram · accessibility
+
+## Pattern
+
+Spectrogram presents structured data. Preserve the component's semantic roles, row or item labels, and ordering so assistive technology can announce the same relationships that are visible on screen.
+
+Purpose: Responsive SVG time × frequency heatmap for visualizing audio spectrogram data.
+
+## Use when
+
+- Visualizing how frequency content of a signal changes over time (time × frequency heatmap).
+- Displaying pre-computed spectrogram frames from an FFT or short-time Fourier transform.
+
+## Avoid when
+
+- Only a single spectrum snapshot is needed — use spectrum-chart instead.
+- Real-time live audio spectrogram is needed — feed frames as props yourself.
+- A categorical × categorical heatmap without a time axis is needed — use matrix-chart instead.
+
+## Keyboard and focus
+
+Keyboard behavior follows the rendered native elements and any ARIA pattern documented by the component. Avoid adding handlers that change focus order without a matching visible and programmatic state update.
+
+Keep focus indicators visible. If you wrap or restyle Spectrogram, verify the focused element remains visually apparent in default and forced-colors modes.
+
+## Names, roles, and state
+
+Use the public props and documented examples to provide accessible names, descriptions, current state, disabled state, selection state, or value text. Do not rely on color, icon shape, placeholder text, or layout position as the only way to communicate meaning.
+
+When Spectrogram accepts snippets or arbitrary children, the caller owns the semantics inside those children. Prefer native elements first, and add ARIA only when it matches the rendered behavior.
+
+## Verification
+
+- Render Spectrogram in the playground or a focused test fixture.
+- Navigate the component with keyboard only.
+- Inspect the accessible name, role, and state in browser accessibility tools.
+- Check forced-colors mode when the component adds borders, focus rings, selected state, or status color.
+
+Related components: `spectrum-chart`, `waveform`, `matrix-chart`.

--- a/packages/components/src/components/spectrum-chart/spectrum-chart.a11y.md
+++ b/packages/components/src/components/spectrum-chart/spectrum-chart.a11y.md
@@ -1,0 +1,39 @@
+# SpectrumChart · accessibility
+
+## Pattern
+
+SpectrumChart presents structured data. Preserve the component's semantic roles, row or item labels, and ordering so assistive technology can announce the same relationships that are visible on screen.
+
+Purpose: Responsive SVG frequency-bin bar chart for visualizing audio spectrum magnitude data.
+
+## Use when
+
+- Displaying pre-computed frequency-domain magnitude data from an FFT or spectrum analyzer.
+- Showing a static frequency response or spectrum snapshot with labelled frequency bins.
+
+## Avoid when
+
+- Real-time live audio spectrum is needed — feed live AnalyserNode data as props yourself.
+- A full time × frequency heatmap is needed — use spectrogram instead.
+- General categorical bar comparison — use bar-chart instead.
+
+## Keyboard and focus
+
+Keyboard behavior follows the rendered native elements and any ARIA pattern documented by the component. Avoid adding handlers that change focus order without a matching visible and programmatic state update.
+
+Keep focus indicators visible. If you wrap or restyle SpectrumChart, verify the focused element remains visually apparent in default and forced-colors modes.
+
+## Names, roles, and state
+
+Use the public props and documented examples to provide accessible names, descriptions, current state, disabled state, selection state, or value text. Do not rely on color, icon shape, placeholder text, or layout position as the only way to communicate meaning.
+
+When SpectrumChart accepts snippets or arbitrary children, the caller owns the semantics inside those children. Prefer native elements first, and add ARIA only when it matches the rendered behavior.
+
+## Verification
+
+- Render SpectrumChart in the playground or a focused test fixture.
+- Navigate the component with keyboard only.
+- Inspect the accessible name, role, and state in browser accessibility tools.
+- Check forced-colors mode when the component adds borders, focus rings, selected state, or status color.
+
+Related components: `waveform`, `spectrogram`, `bar-chart`.

--- a/packages/components/src/components/speed-dial-action/speed-dial-action.a11y.md
+++ b/packages/components/src/components/speed-dial-action/speed-dial-action.a11y.md
@@ -1,0 +1,36 @@
+# SpeedDialAction · accessibility
+
+## Pattern
+
+SpeedDialAction exposes an operable control surface. Prefer the native interactive element it renders, keep the accessible name specific to the action, and do not replace it with a non-interactive wrapper.
+
+Purpose: Quick-action leaf for SpeedDial that closes the owning dial after activation.
+
+## Use when
+
+- Rendering a secondary quick action inside SpeedDial.
+
+## Avoid when
+
+- Rendering an action outside SpeedDial - use floating-action-button directly.
+
+## Keyboard and focus
+
+Activation should work with the native Enter and Space behavior of the rendered control. Custom children must not swallow those events unless they replace the whole interaction intentionally.
+
+Keep focus indicators visible. If you wrap or restyle SpeedDialAction, verify the focused element remains visually apparent in default and forced-colors modes.
+
+## Names, roles, and state
+
+Use the public props and documented examples to provide accessible names, descriptions, current state, disabled state, selection state, or value text. Do not rely on color, icon shape, placeholder text, or layout position as the only way to communicate meaning.
+
+When SpeedDialAction accepts snippets or arbitrary children, the caller owns the semantics inside those children. Prefer native elements first, and add ARIA only when it matches the rendered behavior.
+
+## Verification
+
+- Render SpeedDialAction in the playground or a focused test fixture.
+- Navigate the component with keyboard only.
+- Inspect the accessible name, role, and state in browser accessibility tools.
+- Check forced-colors mode when the component adds borders, focus rings, selected state, or status color.
+
+Related components: `speed-dial`, `floating-action-button`.

--- a/packages/components/src/components/spinner/spinner.a11y.md
+++ b/packages/components/src/components/spinner/spinner.a11y.md
@@ -1,0 +1,38 @@
+# Spinner · accessibility
+
+## Pattern
+
+Spinner communicates status or supporting context. Keep the message text concise, and choose the surrounding live-region behavior based on whether the condition is immediate, persistent, or purely informational.
+
+Purpose: Compact role="status" indicator that communicates indeterminate background work with an accessible loading label.
+
+## Use when
+
+- Showing that a short asynchronous action is in progress without a predictable completion time.
+- Indicating inline busy state next to a control while a request resolves.
+
+## Avoid when
+
+- Reserving layout space for content with a known final shape — use skeleton.
+- Reporting determinate progress with a measurable percentage — use progress.
+
+## Keyboard and focus
+
+Keyboard behavior follows the rendered native elements and any ARIA pattern documented by the component. Avoid adding handlers that change focus order without a matching visible and programmatic state update.
+
+Keep focus indicators visible. If you wrap or restyle Spinner, verify the focused element remains visually apparent in default and forced-colors modes.
+
+## Names, roles, and state
+
+Use the public props and documented examples to provide accessible names, descriptions, current state, disabled state, selection state, or value text. Do not rely on color, icon shape, placeholder text, or layout position as the only way to communicate meaning.
+
+When Spinner accepts snippets or arbitrary children, the caller owns the semantics inside those children. Prefer native elements first, and add ARIA only when it matches the rendered behavior.
+
+## Verification
+
+- Render Spinner in the playground or a focused test fixture.
+- Navigate the component with keyboard only.
+- Inspect the accessible name, role, and state in browser accessibility tools.
+- Check forced-colors mode when the component adds borders, focus rings, selected state, or status color.
+
+Related components: `skeleton`, `progress`.

--- a/packages/components/src/components/stat-group/stat-group.a11y.md
+++ b/packages/components/src/components/stat-group/stat-group.a11y.md
@@ -1,0 +1,38 @@
+# StatGroup · accessibility
+
+## Pattern
+
+StatGroup presents structured data. Preserve the component's semantic roles, row or item labels, and ordering so assistive technology can announce the same relationships that are visible on screen.
+
+Purpose: Grid container that arranges a set of stat tiles into a responsive multi-column layout with shared labelling.
+
+## Use when
+
+- Showing a row of related stat tiles such as the top metrics of a dashboard.
+- Giving a cluster of stat entries a single accessible group label.
+
+## Avoid when
+
+- Rendering exactly one metric — use stat on its own.
+- Building a freeform card grid unrelated to numeric metrics — compose surface or grid-list directly.
+
+## Keyboard and focus
+
+Keyboard behavior follows the rendered native elements and any ARIA pattern documented by the component. Avoid adding handlers that change focus order without a matching visible and programmatic state update.
+
+Keep focus indicators visible. If you wrap or restyle StatGroup, verify the focused element remains visually apparent in default and forced-colors modes.
+
+## Names, roles, and state
+
+Use the public props and documented examples to provide accessible names, descriptions, current state, disabled state, selection state, or value text. Do not rely on color, icon shape, placeholder text, or layout position as the only way to communicate meaning.
+
+When StatGroup accepts snippets or arbitrary children, the caller owns the semantics inside those children. Prefer native elements first, and add ARIA only when it matches the rendered behavior.
+
+## Verification
+
+- Render StatGroup in the playground or a focused test fixture.
+- Navigate the component with keyboard only.
+- Inspect the accessible name, role, and state in browser accessibility tools.
+- Check forced-colors mode when the component adds borders, focus rings, selected state, or status color.
+
+Related components: `stat`.

--- a/packages/components/src/components/status-dot/status-dot.a11y.md
+++ b/packages/components/src/components/status-dot/status-dot.a11y.md
@@ -1,0 +1,38 @@
+# StatusDot · accessibility
+
+## Pattern
+
+StatusDot communicates status or supporting context. Keep the message text concise, and choose the surrounding live-region behavior based on whether the condition is immediate, persistent, or purely informational.
+
+Purpose: Static role="img" badge that communicates an entity's state through a colored dot with an accessible text label.
+
+## Use when
+
+- Indicating the current state of a list row, user, deployment, or other entity alongside its name.
+- Communicating status compactly when many indicators appear together without triggering live-region announcements.
+
+## Avoid when
+
+- Counting items or showing a numeric value — use badge instead.
+- Announcing a transient status change — use toast-region or alert so assistive tech reads it.
+
+## Keyboard and focus
+
+Keyboard behavior follows the rendered native elements and any ARIA pattern documented by the component. Avoid adding handlers that change focus order without a matching visible and programmatic state update.
+
+Keep focus indicators visible. If you wrap or restyle StatusDot, verify the focused element remains visually apparent in default and forced-colors modes.
+
+## Names, roles, and state
+
+Use the public props and documented examples to provide accessible names, descriptions, current state, disabled state, selection state, or value text. Do not rely on color, icon shape, placeholder text, or layout position as the only way to communicate meaning.
+
+When StatusDot accepts snippets or arbitrary children, the caller owns the semantics inside those children. Prefer native elements first, and add ARIA only when it matches the rendered behavior.
+
+## Verification
+
+- Render StatusDot in the playground or a focused test fixture.
+- Navigate the component with keyboard only.
+- Inspect the accessible name, role, and state in browser accessibility tools.
+- Check forced-colors mode when the component adds borders, focus rings, selected state, or status color.
+
+Related components: `badge`.

--- a/packages/components/src/components/subscription-badge/subscription-badge.a11y.md
+++ b/packages/components/src/components/subscription-badge/subscription-badge.a11y.md
@@ -1,0 +1,38 @@
+# SubscriptionBadge · accessibility
+
+## Pattern
+
+SubscriptionBadge presents structured data. Preserve the component's semantic roles, row or item labels, and ordering so assistive technology can announce the same relationships that are visible on screen.
+
+Purpose: Opinionated Badge variant that communicates billing subscription states with a standardized tone, icon, and human-readable label.
+
+## Use when
+
+- Displaying the billing state of a subscription in a dashboard, invoice list, or account settings page.
+- Annotating a plan name, customer row, or invoice line with its current payment lifecycle state.
+
+## Avoid when
+
+- The subscription state is not one of the six recognized values — use Badge directly with a custom label instead.
+- You need an interactive control that lets users change the state — use a Button or Select.
+
+## Keyboard and focus
+
+Keyboard behavior follows the rendered native elements and any ARIA pattern documented by the component. Avoid adding handlers that change focus order without a matching visible and programmatic state update.
+
+Keep focus indicators visible. If you wrap or restyle SubscriptionBadge, verify the focused element remains visually apparent in default and forced-colors modes.
+
+## Names, roles, and state
+
+Use the public props and documented examples to provide accessible names, descriptions, current state, disabled state, selection state, or value text. Do not rely on color, icon shape, placeholder text, or layout position as the only way to communicate meaning.
+
+When SubscriptionBadge accepts snippets or arbitrary children, the caller owns the semantics inside those children. Prefer native elements first, and add ARIA only when it matches the rendered behavior.
+
+## Verification
+
+- Render SubscriptionBadge in the playground or a focused test fixture.
+- Navigate the component with keyboard only.
+- Inspect the accessible name, role, and state in browser accessibility tools.
+- Check forced-colors mode when the component adds borders, focus rings, selected state, or status color.
+
+Related components: `badge`, `status-dot`, `chip`.

--- a/packages/components/src/components/surface/surface.a11y.md
+++ b/packages/components/src/components/surface/surface.a11y.md
@@ -1,0 +1,38 @@
+# Surface · accessibility
+
+## Pattern
+
+Surface affects structure rather than meaning. Use it without removing headings, landmarks, labels, or reading order from the content it contains.
+
+Purpose: Neutral background primitive that establishes a tonal layer for nested content and broadcasts its tone to descendants via context.
+
+## Use when
+
+- Wrapping a region in a consistent background tone such as default, raised, or sunken.
+- Letting nested components adapt their styling based on the surrounding surface tone.
+
+## Avoid when
+
+- Building a self-contained content card with padding and elevation — use card instead.
+- Standing up a full page scaffold with header and actions — use a hand-rolled page scaffold instead.
+
+## Keyboard and focus
+
+Keyboard behavior follows the rendered native elements and any ARIA pattern documented by the component. Avoid adding handlers that change focus order without a matching visible and programmatic state update.
+
+Keep focus indicators visible. If you wrap or restyle Surface, verify the focused element remains visually apparent in default and forced-colors modes.
+
+## Names, roles, and state
+
+Use the public props and documented examples to provide accessible names, descriptions, current state, disabled state, selection state, or value text. Do not rely on color, icon shape, placeholder text, or layout position as the only way to communicate meaning.
+
+When Surface accepts snippets or arbitrary children, the caller owns the semantics inside those children. Prefer native elements first, and add ARIA only when it matches the rendered behavior.
+
+## Verification
+
+- Render Surface in the playground or a focused test fixture.
+- Navigate the component with keyboard only.
+- Inspect the accessible name, role, and state in browser accessibility tools.
+- Check forced-colors mode when the component adds borders, focus rings, selected state, or status color.
+
+Related components: `card`.

--- a/packages/components/src/components/table-header-cell/table-header-cell.svelte
+++ b/packages/components/src/components/table-header-cell/table-header-cell.svelte
@@ -48,6 +48,12 @@
         ? 'none'
         : undefined,
   );
+  const nextSortDescription = $derived(
+    ariaSort === 'ascending' ? 'Activate to sort descending' : 'Activate to sort ascending',
+  );
+  const sortButtonDescriptionAttributes = $derived({
+    'aria-description': nextSortDescription,
+  });
 
   function handleClick(): void {
     if (!sortable || !column) return;
@@ -64,7 +70,12 @@
   aria-sort={ariaSort}
 >
   {#if isSortable}
-    <button type="button" class="cinder-table__sort-button" onclick={handleClick}>
+    <button
+      {...sortButtonDescriptionAttributes}
+      type="button"
+      class="cinder-table__sort-button"
+      onclick={handleClick}
+    >
       {@render children()}
       <span
         class="cinder-table__sort-indicator"

--- a/packages/components/src/components/timeline/timeline.a11y.md
+++ b/packages/components/src/components/timeline/timeline.a11y.md
@@ -1,0 +1,38 @@
+# Timeline · accessibility
+
+## Pattern
+
+Timeline presents structured data. Preserve the component's semantic roles, row or item labels, and ordering so assistive technology can announce the same relationships that are visible on screen.
+
+Purpose: Timestamp-first event rail that renders workflow, audit, or run-history entries with grouping, tone markers, and connector continuity.
+
+## Use when
+
+- Visualizing an ordered sequence of dated events with a temporal rail, timestamp labels, grouping headers, and marker tones.
+- Displaying workflow steps, audit logs, or run histories where each entry needs connector continuity or gap breaks.
+
+## Avoid when
+
+- Surfacing a real-time social or activity stream — feed is the higher-affordance composition.
+- Guiding users through a numbered procedural flow — steps conveys progress more clearly.
+
+## Keyboard and focus
+
+Keyboard behavior follows the rendered native elements and any ARIA pattern documented by the component. Avoid adding handlers that change focus order without a matching visible and programmatic state update.
+
+Keep focus indicators visible. If you wrap or restyle Timeline, verify the focused element remains visually apparent in default and forced-colors modes.
+
+## Names, roles, and state
+
+Use the public props and documented examples to provide accessible names, descriptions, current state, disabled state, selection state, or value text. Do not rely on color, icon shape, placeholder text, or layout position as the only way to communicate meaning.
+
+When Timeline accepts snippets or arbitrary children, the caller owns the semantics inside those children. Prefer native elements first, and add ARIA only when it matches the rendered behavior.
+
+## Verification
+
+- Render Timeline in the playground or a focused test fixture.
+- Navigate the component with keyboard only.
+- Inspect the accessible name, role, and state in browser accessibility tools.
+- Check forced-colors mode when the component adds borders, focus rings, selected state, or status color.
+
+Related components: `feed`, `steps`.

--- a/packages/components/src/components/tree-item/tree-item.svelte
+++ b/packages/components/src/components/tree-item/tree-item.svelte
@@ -352,7 +352,7 @@
     announceRename(`Editing ${label}. Press Enter to confirm, Escape to cancel.`);
   }
 
-  function finishEdit(afterFocus?: () => void): void {
+  function finishEdit(afterFocus: (() => void) | undefined = undefined): void {
     editing = false;
     renameError = '';
     renamePending = false;
@@ -368,7 +368,7 @@
     finishEdit();
   }
 
-  async function commitEdit(afterFocus?: () => void): Promise<boolean> {
+  async function commitEdit(afterFocus: (() => void) | undefined = undefined): Promise<boolean> {
     if (!editing || renamePending) return false;
 
     if (editValue.trim().length === 0) {

--- a/packages/components/src/components/tree/tree.svelte
+++ b/packages/components/src/components/tree/tree.svelte
@@ -561,7 +561,7 @@
     focusItem(id);
   }
 
-  function scrollToRow(id: string, options?: ScrollIntoViewOptions): void {
+  function scrollToRow(id: string, options: ScrollIntoViewOptions | undefined = undefined): void {
     if (isVirtualizedTree) {
       const index = visibleIds.indexOf(id);
       if (index !== -1) {

--- a/packages/components/src/components/typography/typography.a11y.md
+++ b/packages/components/src/components/typography/typography.a11y.md
@@ -1,0 +1,36 @@
+# Typography · accessibility
+
+## Pattern
+
+Typography styles text content. Keep the underlying text meaningful, avoid using visual style as the only semantic cue, and preserve heading or label structure outside the component when needed.
+
+Purpose: Renders text with a named typographic variant mapped to the design token scale.
+
+## Use when
+
+- Applying a named typographic style (heading, body, caption) with semantic HTML.
+
+## Avoid when
+
+- Rendering inline text inside a paragraph — use a plain <span> with CSS.
+
+## Keyboard and focus
+
+Keyboard behavior follows the rendered native elements and any ARIA pattern documented by the component. Avoid adding handlers that change focus order without a matching visible and programmatic state update.
+
+Keep focus indicators visible. If you wrap or restyle Typography, verify the focused element remains visually apparent in default and forced-colors modes.
+
+## Names, roles, and state
+
+Use the public props and documented examples to provide accessible names, descriptions, current state, disabled state, selection state, or value text. Do not rely on color, icon shape, placeholder text, or layout position as the only way to communicate meaning.
+
+When Typography accepts snippets or arbitrary children, the caller owns the semantics inside those children. Prefer native elements first, and add ARIA only when it matches the rendered behavior.
+
+## Verification
+
+- Render Typography in the playground or a focused test fixture.
+- Navigate the component with keyboard only.
+- Inspect the accessible name, role, and state in browser accessibility tools.
+- Check forced-colors mode when the component adds borders, focus rings, selected state, or status color.
+
+Related components: `label`, `kbd`.

--- a/packages/components/src/components/virtual-list/virtual-list.a11y.md
+++ b/packages/components/src/components/virtual-list/virtual-list.a11y.md
@@ -1,0 +1,38 @@
+# VirtualList · accessibility
+
+## Pattern
+
+VirtualList presents structured data. Preserve the component's semantic roles, row or item labels, and ordering so assistive technology can announce the same relationships that are visible on screen.
+
+Purpose: Fixed-height windowing primitive for long vertical lists that renders only the visible rows plus overscan inside a native scroll container.
+
+## Use when
+
+- Rendering thousands of same-height append-only rows such as logs, event streams, or activity feeds.
+- You need a reusable primitive that owns native vertical scrolling but leaves row markup to a snippet.
+
+## Avoid when
+
+- Rows have substantially variable heights that must be measured dynamically — v1 requires a fixed itemHeight.
+- Rendering columns or two-dimensional grids — use data-grid for grid semantics and column virtualization.
+
+## Keyboard and focus
+
+Keyboard behavior follows the rendered native elements and any ARIA pattern documented by the component. Avoid adding handlers that change focus order without a matching visible and programmatic state update.
+
+Keep focus indicators visible. If you wrap or restyle VirtualList, verify the focused element remains visually apparent in default and forced-colors modes.
+
+## Names, roles, and state
+
+Use the public props and documented examples to provide accessible names, descriptions, current state, disabled state, selection state, or value text. Do not rely on color, icon shape, placeholder text, or layout position as the only way to communicate meaning.
+
+When VirtualList accepts snippets or arbitrary children, the caller owns the semantics inside those children. Prefer native elements first, and add ARIA only when it matches the rendered behavior.
+
+## Verification
+
+- Render VirtualList in the playground or a focused test fixture.
+- Navigate the component with keyboard only.
+- Inspect the accessible name, role, and state in browser accessibility tools.
+- Check forced-colors mode when the component adds borders, focus rings, selected state, or status color.
+
+Related components: `data-list`, `data-table`, `data-grid`.

--- a/packages/components/src/components/waveform/waveform.a11y.md
+++ b/packages/components/src/components/waveform/waveform.a11y.md
@@ -1,0 +1,38 @@
+# Waveform · accessibility
+
+## Pattern
+
+Waveform presents structured data. Preserve the component's semantic roles, row or item labels, and ordering so assistive technology can announce the same relationships that are visible on screen.
+
+Purpose: Responsive SVG rendering of time-domain audio amplitude data as a waveform path or bar display.
+
+## Use when
+
+- Visualizing pre-recorded or pre-processed audio amplitude samples in a static display.
+- Showing an audio waveform thumbnail or preview with mocked or pre-computed sample data.
+
+## Avoid when
+
+- Real-time live audio capture is needed — wire AudioContext / AnalyserNode yourself and feed samples as props.
+- Frequency-domain data — use spectrum-chart or spectrogram instead.
+
+## Keyboard and focus
+
+Keyboard behavior follows the rendered native elements and any ARIA pattern documented by the component. Avoid adding handlers that change focus order without a matching visible and programmatic state update.
+
+Keep focus indicators visible. If you wrap or restyle Waveform, verify the focused element remains visually apparent in default and forced-colors modes.
+
+## Names, roles, and state
+
+Use the public props and documented examples to provide accessible names, descriptions, current state, disabled state, selection state, or value text. Do not rely on color, icon shape, placeholder text, or layout position as the only way to communicate meaning.
+
+When Waveform accepts snippets or arbitrary children, the caller owns the semantics inside those children. Prefer native elements first, and add ARIA only when it matches the rendered behavior.
+
+## Verification
+
+- Render Waveform in the playground or a focused test fixture.
+- Navigate the component with keyboard only.
+- Inspect the accessible name, role, and state in browser accessibility tools.
+- Check forced-colors mode when the component adds borders, focus rings, selected state, or status color.
+
+Related components: `spectrum-chart`, `spectrogram`, `bar-chart`, `line-chart`.

--- a/packages/playground/src/examples/segmented-control/multiple.example.svelte
+++ b/packages/playground/src/examples/segmented-control/multiple.example.svelte
@@ -1,7 +1,7 @@
 <script lang="ts" module>
   export const title = 'Multi-select segmented control';
   export const description =
-    'Multiple options can be toggled independently. Bind a SvelteSet to track selection.';
+    'Multiple options can be toggled independently. Pass a SvelteSet to track selection.';
 </script>
 
 <script lang="ts">
@@ -18,7 +18,7 @@
   <SegmentedControl
     id="playground-format"
     selectionMode="multiple"
-    bind:value={formats}
+    value={formats}
     label="Text formatting"
   >
     <Segment value="bold">Bold</Segment>


### PR DESCRIPTION
## Summary
- Backfill missing component accessibility docs and gate `.a11y.md` presence in `components:check`.
- Address DataGrid/DataTable audit findings: row-header cells, virtualized overflow affordance, sortable header next-action descriptions, and focus-visible row affordance.
- Normalize optional Svelte component function parameters and update the segmented-control multi-select example so packed consumers build without parser/reactivity warnings.

## Issue coverage
- Closes #492
- Closes #510
- Closes #511

## Notes
- The reported `onkeydown`/`onscroll` schema leaks were already absent on current `origin/main`; this branch keeps generated schemas checked through `components:check`.

## Verification
- `bun run format`
- `bun run --filter=@lostgradient/cinder components:generate`
- `bun run --filter=@lostgradient/cinder components:check`
- `bun run --filter=@lostgradient/cinder test -- ./src/components/data-grid/data-grid-aria.test.ts ./src/components/data-grid/data-grid-sort.test.ts ./src/components/data-table/data-table.test.ts`
- `bun run --filter=@lostgradient/cinder test -- ./scripts/check-promotion-readiness.test.ts`
- `bun run --filter=@lostgradient/cinder validate:consumer`
- `bun run --filter=@lostgradient/cinder validate`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are mostly documentation and additive ARIA/CSS; table/grid behavior is covered by updated tests with limited API surface (`rowHeader` opt-in).
> 
> **Overview**
> Backfills **`.a11y.md`** for many Cinder components and makes **`components:check`** fail when a component is missing that file, with an exemption list for compose-only leaves (e.g. `table-cell`, `dropdown-item`). Promotion-readiness tests now use **`table-cell`** as the “no adjacent a11y doc” example.
> 
> **DataGrid** gains a **`rowHeader: true`** column option so body cells render as **`role="rowheader"`**; virtualized horizontal scroll adds **`scrollbar-gutter: stable`** and inset edge shadows on header/body rows. **DataTable** / **`table-header-cell`** sort buttons get **`aria-description`** for the next sort action, and DataTable body rows match hover styling on **`:focus-within`**.
> 
> Several Svelte modules replace **`param?: T`** with explicit **`param: T | undefined = undefined`** defaults for packed-consumer compatibility; the **SegmentedControl** multi-select example/docs switch from **`bind:value`** to one-way **`value`** on a `SvelteSet`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7ac253da6b352e6dc2506eea2a8a3bd09568c5df. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->