### PR TITLE
Fix CI: raw-color markers and playground manifest timeout

### DIFF
--- a/packages/components/src/components/chat/message/parts/tool-approval-part.svelte
+++ b/packages/components/src/components/chat/message/parts/tool-approval-part.svelte
@@ -267,8 +267,10 @@
       &:not(:disabled):hover {
         /* cinder-allow-raw-color: structural-pattern — neutral hover overlay tint, not a themeable surface */
         --_cinder-chat-tool-approval-hover-overlay: light-dark(
-          oklch(0% 0 0 / 0.08),
-          oklch(100% 0 0 / 0.1)
+          /* cinder-allow-raw-color: structural-pattern — neutral hover overlay tint, not a themeable surface */
+            oklch(0% 0 0 / 0.08),
+          /* cinder-allow-raw-color: structural-pattern — neutral hover overlay tint, not a themeable surface */
+            oklch(100% 0 0 / 0.1)
         );
 
         background-image: linear-gradient(

--- a/packages/components/src/components/kanban-board/kanban-board.css
+++ b/packages/components/src/components/kanban-board/kanban-board.css
@@ -17,7 +17,8 @@
       /* cinder-allow-raw-color: structural-pattern — neutral scroll-edge shadow, not a themeable surface */
         linear-gradient(90deg, oklch(0% 0 0 / 12%), transparent) left center / 1rem 100% no-repeat
         scroll,
-      linear-gradient(270deg, oklch(0% 0 0 / 12%), transparent) right center / 1rem 100% no-repeat
+      /* cinder-allow-raw-color: structural-pattern — neutral scroll-edge shadow, not a themeable surface */
+        linear-gradient(270deg, oklch(0% 0 0 / 12%), transparent) right center / 1rem 100% no-repeat
         scroll;
   }
 

--- a/packages/playground/src/playground-server.ts
+++ b/packages/playground/src/playground-server.ts
@@ -1909,6 +1909,14 @@ export async function startServer(port: number = PORT): Promise<PlaygroundServer
     `[playground] Pre-built ${prebuild.succeeded}/${total} page bundles${failedSuffix}\n`,
   );
 
+  // Pre-warm the component manifest (ts-morph analysis) before binding the
+  // port. Without this, the first /api/documentation/:name request pays the
+  // cold-analysis cost and can exceed the validate-playground fetch timeout
+  // as the component count grows.
+  await getManifests().catch((error: unknown) => {
+    console.error('[playground] manifest pre-warm failed:', error);
+  });
+
   // Start the HTTP server first — if binding fails for reasons other than an
   // occupied port, no watchers are leaked.
   const playgroundHttpServer = createHttpServerOnAvailablePort(port, handleRequest);


### PR DESCRIPTION
## Summary

Two independent failures in the `release` workflow's `bun run validate` step, both introduced by recent PRs:

- **#521** (accessibility fixes) added `cinder-allow-raw-color: structural-pattern` markers to `tool-approval-part.svelte` and `kanban-board.css`, but placed them too far above the raw-color values — the audit rule requires the marker on the **same line** or **immediately above** the color.
- **#522** (i18n primitives) pushed the component count to 169, which causes the cold `ts-morph` `analyzeAll()` triggered by the first `/api/documentation/:name` request to exceed the `validate-playground` 5-second fetch timeout.

## Changes

### `tool-approval-part.svelte`
Added a marker immediately above each of the three raw-color calls inside the `light-dark()` declaration: one covering `light-dark(` itself, and one above each `oklch()` argument.

### `kanban-board.css`
Added a second `/* cinder-allow-raw-color */` marker for the second gradient. The original marker only covered the first `oklch()` value; the second was two lines below, which is outside the "same line or immediately above" window.

### `playground-server.ts`
Added `await getManifests()` in `startServer()` after `eagerPrebuildAll()` and before binding the port. This pre-warms the `ts-morph` component manifest so the cold analysis cost is paid at startup rather than on the first HTTP request, mirroring the existing rationale for `eagerPrebuildAll()`.

## Verification

- `bun run --filter=@lostgradient/cinder colors:audit -- --strict` exits 0 (migration-debt 48, below baseline 52; `tool-approval-part.svelte` correctly shows 3 `structural-pattern` sites)
- Pre-commit and pre-push hooks passed (typechecks, playground tests, component tests)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment-only CSS audit compliance and optional manifest pre-warm at playground startup; no runtime behavior change for end users beyond faster first documentation API response.
> 
> **Overview**
> Unblocks **`bun run validate`** by fixing two CI failures: strict **raw-color audit** placement and a **playground documentation** cold-start timeout.
> 
> **`cinder-allow-raw-color` markers** are moved so each structural-pattern `oklch()` sits on the **same line or immediately above** its value, per the audit rule. In `tool-approval-part.svelte`, duplicate markers are added directly above each `oklch()` inside the `light-dark()` hover overlay. In `kanban-board.css`, a second marker is added for the right-hand scroll-edge gradient that was previously two lines below the only marker.
> 
> **Playground startup** now calls `await getManifests()` after `eagerPrebuildAll()` and before the HTTP port binds, so `ts-morph` `analyzeAll()` runs at boot instead of on the first `/api/documentation/:name` request. Failures are logged but do not abort startup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 42c1e1013d66692ec35c93d0e49c86d68e4cd6e0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->