### PR TITLE
Keep pre-1.0 changesets on minor bumps; guard against major

### DIFF
--- a/.changeset/data-list-required-key-masonry-element.md
+++ b/.changeset/data-list-required-key-masonry-element.md
@@ -1,5 +1,5 @@
 ---
-'@lostgradient/cinder': major
+'@lostgradient/cinder': minor
 ---
 
 **Breaking: `DataList` now requires a `key` extractor.** `DataListProps.key` was

--- a/.changeset/lowercase-callback-props.md
+++ b/.changeset/lowercase-callback-props.md
@@ -1,5 +1,5 @@
 ---
-'@lostgradient/cinder': major
+'@lostgradient/cinder': minor
 ---
 
 **Breaking: PascalCase event-callback props renamed to lowercase.** Svelte 5 event

--- a/.changeset/vocabulary-consistency.md
+++ b/.changeset/vocabulary-consistency.md
@@ -1,5 +1,5 @@
 ---
-'@lostgradient/cinder': major
+'@lostgradient/cinder': minor
 ---
 
 **Breaking: unify public API vocabulary across components.** Several public APIs

--- a/.github/workflows/changeset-guard.yaml
+++ b/.github/workflows/changeset-guard.yaml
@@ -1,0 +1,44 @@
+name: changeset-guard
+
+# Fast PR gate for the pre-1.0 changeset bump policy.
+#
+# `check:changeset-prerelease-bumps` also runs inside `bun run validate` (release
+# workflow, push to main), but the heavyweight PR suites (unit-tests, browser-tests)
+# exclude `.changeset/**` from their path filters — so a PR that ONLY edits a
+# changeset to a `major` bump would not trigger them, and the policy violation would
+# surface as a red `release` job on `main` instead of failing on the branch that
+# introduced it. This workflow runs the guard directly on exactly those changes.
+#
+# The guard script imports only Bun/node built-ins, so it needs no `bun install` —
+# checkout + setup-bun + run is enough, which keeps this gate near-instant.
+
+on:
+  pull_request:
+    paths:
+      - '.changeset/**'
+      - 'packages/components/package.json'
+      - 'packages/components/scripts/check-changeset-prerelease-bumps.ts'
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+concurrency:
+  group: changeset-guard-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  guard:
+    name: Pre-1.0 changeset bump guard
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v1
+        with:
+          bun-version: 1.3.13
+
+      - name: Run pre-1.0 changeset bump guard
+        run: bun packages/components/scripts/check-changeset-prerelease-bumps.ts

--- a/.github/workflows/changeset-guard.yaml
+++ b/.github/workflows/changeset-guard.yaml
@@ -9,8 +9,10 @@ name: changeset-guard
 # surface as a red `release` job on `main` instead of failing on the branch that
 # introduced it. This workflow runs the guard directly on exactly those changes.
 #
-# The guard script imports only Bun/node built-ins, so it needs no `bun install` —
-# checkout + setup-bun + run is enough, which keeps this gate near-instant.
+# The guard parses changesets with `@changesets/parse` (the same parser Changesets
+# uses), so the job installs dependencies before running. Edits to this workflow
+# file itself are included in the path filter so a PR that neuters the guard still
+# triggers it.
 
 on:
   pull_request:
@@ -18,6 +20,7 @@ on:
       - '.changeset/**'
       - 'packages/components/package.json'
       - 'packages/components/scripts/check-changeset-prerelease-bumps.ts'
+      - '.github/workflows/changeset-guard.yaml'
   workflow_dispatch: {}
 
 permissions:
@@ -39,6 +42,9 @@ jobs:
         uses: oven-sh/setup-bun@v1
         with:
           bun-version: 1.3.13
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
 
       - name: Run pre-1.0 changeset bump guard
         run: bun packages/components/scripts/check-changeset-prerelease-bumps.ts

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -4400,6 +4400,7 @@
     "unist-util-visit": "^5.0.0"
   },
   "devDependencies": {
+    "@changesets/parse": "0.4.3",
     "@cinder/commentary": "workspace:*",
     "@cinder/diff": "workspace:*",
     "@cinder/editor": "workspace:*",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -4323,6 +4323,7 @@
   "scripts": {
     "aggregator:check": "bun run scripts/check-aggregator-completeness.ts",
     "build": "bun run scripts/build.ts",
+    "check:changeset-prerelease-bumps": "bun run scripts/check-changeset-prerelease-bumps.ts",
     "check:data-cinder-boolean-attributes": "bun run scripts/check-data-cinder-boolean-attributes.ts",
     "check:no-bare-console-warn": "bun run scripts/check-no-bare-console-warn.ts",
     "check:no-cycle-imports": "bun run scripts/check-no-cycle-imports.ts",
@@ -4358,7 +4359,7 @@
     "tokens:audit": "bun run scripts/check-component-css-token-usage.ts",
     "tokens:literals": "bun run scripts/check-design-token-literals.ts",
     "typecheck": "tsc --noEmit -p tsconfig.check.json && bunx svelte-check --workspace src --tsconfig ../tsconfig.json --threshold error",
-    "validate": "bun run lint && bun run typecheck && bun run check:placeholder-docs && bun run test:coverage && bun run platform:audit -- --strict && bun run colors:audit -- --strict && bun run tokens:audit -- --strict && bun run aggregator:check && bun run components:check && bun run validate:workflow && bun run validate:svelte-peer && bun run validate:consumer && bun run package:weight:check -- --existing-tarball",
+    "validate": "bun run lint && bun run typecheck && bun run check:changeset-prerelease-bumps && bun run check:placeholder-docs && bun run test:coverage && bun run platform:audit -- --strict && bun run colors:audit -- --strict && bun run tokens:audit -- --strict && bun run aggregator:check && bun run components:check && bun run validate:workflow && bun run validate:svelte-peer && bun run validate:consumer && bun run package:weight:check -- --existing-tarball",
     "validate:consumer": "bun run scripts/validate-consumers.ts",
     "validate:release-workflow": "bun run scripts/validate-release-workflow.ts",
     "validate:svelte-peer": "bun run scripts/validate-svelte-peer-contract.ts",

--- a/packages/components/scripts/check-changeset-prerelease-bumps.test.ts
+++ b/packages/components/scripts/check-changeset-prerelease-bumps.test.ts
@@ -1,0 +1,99 @@
+import { afterEach, describe, expect, it } from 'bun:test';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import {
+  bumpLevelForPackage,
+  checkChangesetPrereleaseBumps,
+  isPreRelease,
+} from './check-changeset-prerelease-bumps.ts';
+
+const PACKAGE = '@lostgradient/cinder';
+
+// Track every temp changeset dir so it's removed after each test — otherwise
+// repeated local + CI runs leak fixture directories into the system temp dir.
+const fixtureRoots: string[] = [];
+afterEach(() => {
+  while (fixtureRoots.length > 0) {
+    rmSync(fixtureRoots.pop()!, { recursive: true, force: true });
+  }
+});
+
+function makeChangesetDir(files: Record<string, string>): string {
+  const root = mkdtempSync(join(tmpdir(), 'changeset-bump-gate-'));
+  fixtureRoots.push(root);
+  for (const [name, content] of Object.entries(files)) {
+    writeFileSync(join(root, name), content);
+  }
+  return root;
+}
+
+function changeset(level: 'major' | 'minor' | 'patch'): string {
+  return `---\n'${PACKAGE}': ${level}\n---\n\nSome change.\n`;
+}
+
+describe('bumpLevelForPackage', () => {
+  it('reads the level from frontmatter regardless of quote style', () => {
+    expect(bumpLevelForPackage(`---\n'${PACKAGE}': major\n---\n`, PACKAGE)).toBe('major');
+    expect(bumpLevelForPackage(`---\n"${PACKAGE}": minor\n---\n`, PACKAGE)).toBe('minor');
+    expect(bumpLevelForPackage(`---\n${PACKAGE}: patch\n---\n`, PACKAGE)).toBe('patch');
+  });
+
+  it('returns null when the package is not mentioned', () => {
+    expect(bumpLevelForPackage(`---\n'@other/pkg': major\n---\n`, PACKAGE)).toBeNull();
+  });
+});
+
+describe('isPreRelease', () => {
+  it('treats 0.y.z as pre-release and >= 1.0.0 as stable', () => {
+    expect(isPreRelease('0.3.0')).toBe(true);
+    expect(isPreRelease('0.99.5')).toBe(true);
+    expect(isPreRelease('1.0.0')).toBe(false);
+    expect(isPreRelease('2.4.1')).toBe(false);
+  });
+
+  it('throws on an unparseable version', () => {
+    expect(() => isPreRelease('not-a-version')).toThrow();
+  });
+});
+
+describe('checkChangesetPrereleaseBumps', () => {
+  it('flags a major changeset while pre-1.0', async () => {
+    const dir = makeChangesetDir({
+      'breaking.md': changeset('major'),
+      'feature.md': changeset('minor'),
+      'README.md': changeset('major'), // README is ignored, not a real changeset
+    });
+    const violations = await checkChangesetPrereleaseBumps({
+      changesetDirectory: dir,
+      version: '0.3.0',
+      relativeTo: dir,
+    });
+    expect(violations.map((v) => v.filePath)).toEqual(['breaking.md']);
+    expect(violations.map((v) => v.bump)).toEqual(['major']);
+  });
+
+  it('passes when every pre-1.0 changeset is minor or patch', async () => {
+    const dir = makeChangesetDir({
+      'a.md': changeset('minor'),
+      'b.md': changeset('patch'),
+    });
+    const violations = await checkChangesetPrereleaseBumps({
+      changesetDirectory: dir,
+      version: '0.3.0',
+      relativeTo: dir,
+    });
+    expect(violations).toEqual([]);
+  });
+
+  it('allows major bumps once the package is stable (>= 1.0.0)', async () => {
+    const dir = makeChangesetDir({ 'breaking.md': changeset('major') });
+    const violations = await checkChangesetPrereleaseBumps({
+      changesetDirectory: dir,
+      version: '1.2.0',
+      relativeTo: dir,
+    });
+    expect(violations).toEqual([]);
+  });
+});

--- a/packages/components/scripts/check-changeset-prerelease-bumps.test.ts
+++ b/packages/components/scripts/check-changeset-prerelease-bumps.test.ts
@@ -35,9 +35,11 @@ function changeset(level: 'major' | 'minor' | 'patch'): string {
 
 describe('bumpLevelForPackage', () => {
   it('reads the level from frontmatter regardless of quote style', () => {
+    // The package name must be quoted in YAML — a leading `@` is a reserved
+    // indicator, so real changesets always single- or double-quote it.
     expect(bumpLevelForPackage(`---\n'${PACKAGE}': major\n---\n`, PACKAGE)).toBe('major');
     expect(bumpLevelForPackage(`---\n"${PACKAGE}": minor\n---\n`, PACKAGE)).toBe('minor');
-    expect(bumpLevelForPackage(`---\n${PACKAGE}: patch\n---\n`, PACKAGE)).toBe('patch');
+    expect(bumpLevelForPackage(`---\n'${PACKAGE}': patch\n---\n`, PACKAGE)).toBe('patch');
   });
 
   it('reads a quoted bump value (Changesets accepts a quoted scalar)', () => {
@@ -61,26 +63,24 @@ describe('bumpLevelForPackage', () => {
     expect(bumpLevelForPackage(source, PACKAGE)).toBe('minor');
   });
 
-  it('uses the last duplicate entry (YAML last-key-wins, matching Changesets)', () => {
-    // Changesets applies the last entry for a key, so minor-then-major is a major.
-    expect(
-      bumpLevelForPackage(`---\n'${PACKAGE}': minor\n'${PACKAGE}': major\n---\n`, PACKAGE),
-    ).toBe('major');
-    expect(
-      bumpLevelForPackage(`---\n'${PACKAGE}': major\n'${PACKAGE}': minor\n---\n`, PACKAGE),
-    ).toBe('minor');
-  });
-
-  it('does not prefix-match a malformed bump value', () => {
-    // `patches` must not be read as `patch`, nor `majorly` as `major`.
-    expect(bumpLevelForPackage(`---\n'${PACKAGE}': patches\n---\n`, PACKAGE)).toBeNull();
-    expect(bumpLevelForPackage(`---\n'${PACKAGE}': majorly\n---\n`, PACKAGE)).toBeNull();
+  it('reads a multiline (block) scalar bump value', () => {
+    // `'pkg':\n  major` is valid YAML that Changesets parses as a major bump.
+    expect(bumpLevelForPackage(`---\n'${PACKAGE}':\n  major\n---\n`, PACKAGE)).toBe('major');
   });
 
   it('allows a trailing inline comment after the bump value', () => {
     expect(bumpLevelForPackage(`---\n'${PACKAGE}': major # was minor\n---\n`, PACKAGE)).toBe(
       'major',
     );
+  });
+
+  it('throws on malformed frontmatter, matching Changesets (no silent misread)', () => {
+    // Duplicate keys and an invalid version type both make `changeset version`
+    // itself fail; the guard surfaces the same error rather than guessing.
+    expect(() =>
+      bumpLevelForPackage(`---\n'${PACKAGE}': minor\n'${PACKAGE}': major\n---\n`, PACKAGE),
+    ).toThrow();
+    expect(() => bumpLevelForPackage(`---\n'${PACKAGE}': patches\n---\n`, PACKAGE)).toThrow();
   });
 
   it('returns null when the package is not mentioned', () => {

--- a/packages/components/scripts/check-changeset-prerelease-bumps.test.ts
+++ b/packages/components/scripts/check-changeset-prerelease-bumps.test.ts
@@ -71,6 +71,18 @@ describe('bumpLevelForPackage', () => {
     ).toBe('minor');
   });
 
+  it('does not prefix-match a malformed bump value', () => {
+    // `patches` must not be read as `patch`, nor `majorly` as `major`.
+    expect(bumpLevelForPackage(`---\n'${PACKAGE}': patches\n---\n`, PACKAGE)).toBeNull();
+    expect(bumpLevelForPackage(`---\n'${PACKAGE}': majorly\n---\n`, PACKAGE)).toBeNull();
+  });
+
+  it('allows a trailing inline comment after the bump value', () => {
+    expect(bumpLevelForPackage(`---\n'${PACKAGE}': major # was minor\n---\n`, PACKAGE)).toBe(
+      'major',
+    );
+  });
+
   it('returns null when the package is not mentioned', () => {
     expect(bumpLevelForPackage(`---\n'@other/pkg': major\n---\n`, PACKAGE)).toBeNull();
   });

--- a/packages/components/scripts/check-changeset-prerelease-bumps.test.ts
+++ b/packages/components/scripts/check-changeset-prerelease-bumps.test.ts
@@ -45,6 +45,22 @@ describe('bumpLevelForPackage', () => {
     expect(bumpLevelForPackage(`---\n"${PACKAGE}": 'minor'\n---\n`, PACKAGE)).toBe('minor');
   });
 
+  it('ignores commented-out bump lines and reads the real one', () => {
+    // A commented previous value before the active entry must not win — Changesets
+    // ignores the comment and applies the real `major`.
+    const source = `---\n# '${PACKAGE}': minor\n'${PACKAGE}': major\n---\n\nChange.\n`;
+    expect(bumpLevelForPackage(source, PACKAGE)).toBe('major');
+  });
+
+  it('does not read a bump from a comment-only entry', () => {
+    expect(bumpLevelForPackage(`---\n# '${PACKAGE}': major\n---\n`, PACKAGE)).toBeNull();
+  });
+
+  it('only scans the frontmatter, not the prose body', () => {
+    const source = `---\n'${PACKAGE}': minor\n---\n\nMentions '${PACKAGE}': major in prose.\n`;
+    expect(bumpLevelForPackage(source, PACKAGE)).toBe('minor');
+  });
+
   it('returns null when the package is not mentioned', () => {
     expect(bumpLevelForPackage(`---\n'@other/pkg': major\n---\n`, PACKAGE)).toBeNull();
   });

--- a/packages/components/scripts/check-changeset-prerelease-bumps.test.ts
+++ b/packages/components/scripts/check-changeset-prerelease-bumps.test.ts
@@ -61,6 +61,16 @@ describe('bumpLevelForPackage', () => {
     expect(bumpLevelForPackage(source, PACKAGE)).toBe('minor');
   });
 
+  it('uses the last duplicate entry (YAML last-key-wins, matching Changesets)', () => {
+    // Changesets applies the last entry for a key, so minor-then-major is a major.
+    expect(
+      bumpLevelForPackage(`---\n'${PACKAGE}': minor\n'${PACKAGE}': major\n---\n`, PACKAGE),
+    ).toBe('major');
+    expect(
+      bumpLevelForPackage(`---\n'${PACKAGE}': major\n'${PACKAGE}': minor\n---\n`, PACKAGE),
+    ).toBe('minor');
+  });
+
   it('returns null when the package is not mentioned', () => {
     expect(bumpLevelForPackage(`---\n'@other/pkg': major\n---\n`, PACKAGE)).toBeNull();
   });

--- a/packages/components/scripts/check-changeset-prerelease-bumps.test.ts
+++ b/packages/components/scripts/check-changeset-prerelease-bumps.test.ts
@@ -40,6 +40,11 @@ describe('bumpLevelForPackage', () => {
     expect(bumpLevelForPackage(`---\n${PACKAGE}: patch\n---\n`, PACKAGE)).toBe('patch');
   });
 
+  it('reads a quoted bump value (Changesets accepts a quoted scalar)', () => {
+    expect(bumpLevelForPackage(`---\n'${PACKAGE}': "major"\n---\n`, PACKAGE)).toBe('major');
+    expect(bumpLevelForPackage(`---\n"${PACKAGE}": 'minor'\n---\n`, PACKAGE)).toBe('minor');
+  });
+
   it('returns null when the package is not mentioned', () => {
     expect(bumpLevelForPackage(`---\n'@other/pkg': major\n---\n`, PACKAGE)).toBeNull();
   });

--- a/packages/components/scripts/check-changeset-prerelease-bumps.ts
+++ b/packages/components/scripts/check-changeset-prerelease-bumps.ts
@@ -51,13 +51,17 @@ export function bumpLevelForPackage(source: string, packageName: string): string
   // (`'@lostgradient/cinder': "major"`).
   const escapedName = packageName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
   const linePattern = new RegExp(`^["']?${escapedName}["']?\\s*:\\s*["']?(major|minor|patch)["']?`);
+  // Keep the LAST matching entry, not the first — YAML (which Changesets parses
+  // with) is last-key-wins, so a duplicate `pkg: minor` then `pkg: major` applies
+  // the major. Returning the first match would let that pass the guard.
+  let level: string | null = null;
   for (const rawLine of frontmatterOf(source).split('\n')) {
     const line = rawLine.trim();
     if (line.length === 0 || line.startsWith('#')) continue;
     const match = line.match(linePattern);
-    if (match) return match[1] ?? null;
+    if (match) level = match[1] ?? level;
   }
-  return null;
+  return level;
 }
 
 /**

--- a/packages/components/scripts/check-changeset-prerelease-bumps.ts
+++ b/packages/components/scripts/check-changeset-prerelease-bumps.ts
@@ -1,0 +1,144 @@
+/**
+ * Pre-1.0 changeset bump-level guard.
+ *
+ * While `@lostgradient/cinder` is pre-release (version `< 1.0.0`), the project
+ * policy is that breaking changes ship as MINOR bumps, not MAJOR — a `0.x` line
+ * signals "no stability promise yet", so every release stays on `0.y.z`. A stray
+ * `major` changeset silently rolls the package to `1.0.0`: `changeset version`
+ * applies it without prompting, and the release workflow then opens a "Version
+ * Packages" PR proposing `1.0.0` — a stability commitment nobody approved.
+ *
+ * This guard reads the package version and every changeset under the repo-root
+ * `.changeset/` directory and fails if any changeset requests a `major` bump for
+ * `@lostgradient/cinder` while the version is still `< 1.0.0`. It runs inside
+ * `bun run validate`, which the release workflow executes BEFORE the changesets
+ * action — so a mislabeled changeset turns CI red on the branch that introduced
+ * it instead of surfacing as a surprise major-version PR on `main`.
+ *
+ * Once the package legitimately reaches `1.0.0`, `major` bumps are allowed and
+ * this guard becomes a no-op automatically (the version gate stops applying).
+ */
+
+import { Glob } from 'bun';
+import { dirname, relative, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const scriptDirectory = dirname(fileURLToPath(import.meta.url));
+const componentsRoot = resolve(scriptDirectory, '..');
+const repositoryRoot = resolve(componentsRoot, '..', '..');
+
+const PACKAGE_NAME = '@lostgradient/cinder';
+
+export type ChangesetBumpViolation = {
+  /** Changeset file path, relative to the repository root. */
+  filePath: string;
+  /** The disallowed bump level found for the package (always `major` here). */
+  bump: string;
+};
+
+/**
+ * Parse the bump level a changeset requests for a given package. Changesets are
+ * Markdown files whose YAML-ish frontmatter maps quoted package names to bump
+ * levels, e.g. `'@lostgradient/cinder': major`. Returns the level string, or
+ * `null` if the changeset does not mention the package.
+ */
+export function bumpLevelForPackage(source: string, packageName: string): string | null {
+  // Match `'<pkg>': <level>` or `"<pkg>": <level>` (quotes optional), tolerant of
+  // surrounding whitespace. Only the frontmatter uses this shape, so scanning the
+  // whole file is safe and survives Prettier reformatting of the prose body.
+  const pattern = new RegExp(
+    `["']?${packageName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}["']?\\s*:\\s*(major|minor|patch)`,
+  );
+  const match = source.match(pattern);
+  return match?.[1] ?? null;
+}
+
+/** True when a semver version string is `< 1.0.0` (i.e. still in the `0.y.z` line). */
+export function isPreRelease(version: string): boolean {
+  const major = Number.parseInt(version.split('.')[0] ?? '', 10);
+  if (Number.isNaN(major)) {
+    throw new Error(`Unparseable package version: ${JSON.stringify(version)}`);
+  }
+  return major < 1;
+}
+
+/**
+ * Scan `changesetDirectory` for changesets requesting a `major` bump of
+ * `packageName`. Returns violations only when `version` is pre-1.0; at `>= 1.0.0`
+ * every changeset is allowed and the result is always empty.
+ */
+export async function checkChangesetPrereleaseBumps(options: {
+  changesetDirectory: string;
+  version: string;
+  packageName?: string;
+  /** Root used to render `filePath` relative to the repository. Defaults to cwd. */
+  relativeTo?: string;
+}): Promise<ChangesetBumpViolation[]> {
+  const { changesetDirectory, version } = options;
+  const packageName = options.packageName ?? PACKAGE_NAME;
+  const relativeTo = options.relativeTo ?? process.cwd();
+
+  if (!isPreRelease(version)) return [];
+
+  const violations: ChangesetBumpViolation[] = [];
+  const glob = new Glob('*.md');
+
+  for await (const entry of glob.scan({ cwd: changesetDirectory })) {
+    if (entry === 'README.md') continue;
+    const absolutePath = resolve(changesetDirectory, entry);
+    const source = await Bun.file(absolutePath).text();
+    if (bumpLevelForPackage(source, packageName) === 'major') {
+      violations.push({ filePath: relative(relativeTo, absolutePath), bump: 'major' });
+    }
+  }
+
+  return violations;
+}
+
+/** Read and validate the `version` field from a parsed package.json value. */
+function readVersion(packageJson: unknown): string {
+  if (
+    typeof packageJson === 'object' &&
+    packageJson !== null &&
+    'version' in packageJson &&
+    typeof packageJson.version === 'string'
+  ) {
+    return packageJson.version;
+  }
+  throw new Error('packages/components/package.json has no string "version" field.');
+}
+
+async function main(): Promise<void> {
+  const packageJson: unknown = await Bun.file(resolve(componentsRoot, 'package.json')).json();
+  const version = readVersion(packageJson);
+  const violations = await checkChangesetPrereleaseBumps({
+    changesetDirectory: resolve(repositoryRoot, '.changeset'),
+    version,
+    relativeTo: repositoryRoot,
+  });
+
+  if (violations.length === 0) {
+    process.stdout.write(
+      `check-changeset-prerelease-bumps — OK (no major changesets while ${PACKAGE_NAME} is at ${version}).\n`,
+    );
+    return;
+  }
+
+  process.stderr.write(
+    `check-changeset-prerelease-bumps — major changeset(s) found while ${PACKAGE_NAME} is pre-1.0 (${version}).\n` +
+      'Pre-1.0 policy: breaking changes ship as a MINOR bump, not MAJOR. A major bump would\n' +
+      'roll the package to 1.0.0 and make the release workflow open an unapproved version PR.\n' +
+      "Change these changesets' bump level to `minor` (or `patch`):\n\n",
+  );
+  for (const violation of violations) {
+    process.stderr.write(`  ${violation.filePath}\n`);
+  }
+  process.exit(1);
+}
+
+if (import.meta.main) {
+  main().catch((error: unknown) => {
+    console.error('check-changeset-prerelease-bumps failed:', error);
+    process.exit(1);
+  });
+}

--- a/packages/components/scripts/check-changeset-prerelease-bumps.ts
+++ b/packages/components/scripts/check-changeset-prerelease-bumps.ts
@@ -43,16 +43,31 @@ export type ChangesetBumpViolation = {
  * `null` if the changeset does not mention the package.
  */
 export function bumpLevelForPackage(source: string, packageName: string): string | null {
-  // Match `'<pkg>': <level>` or `"<pkg>": <level>`, with quotes optional around
-  // BOTH the package name and the bump level — Changesets' YAML parser accepts a
-  // quoted scalar (`'@lostgradient/cinder': "major"`), so the guard must too.
-  // Tolerant of surrounding whitespace. Only the frontmatter uses this shape, so
-  // scanning the whole file is safe and survives Prettier reformatting of the body.
-  const pattern = new RegExp(
-    `["']?${packageName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}["']?\\s*:\\s*["']?(major|minor|patch)["']?`,
-  );
-  const match = source.match(pattern);
-  return match?.[1] ?? null;
+  // Scan only the YAML frontmatter (between the first two `---` fences), line by
+  // line, skipping comment lines — Changesets ignores a commented `# 'pkg': minor`
+  // entry, so the guard must too, or a commented bump before the real one could be
+  // mistaken for the active level. Quotes are optional around BOTH the package name
+  // and the bump level, because Changesets' YAML parser accepts a quoted scalar
+  // (`'@lostgradient/cinder': "major"`).
+  const escapedName = packageName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const linePattern = new RegExp(`^["']?${escapedName}["']?\\s*:\\s*["']?(major|minor|patch)["']?`);
+  for (const rawLine of frontmatterOf(source).split('\n')) {
+    const line = rawLine.trim();
+    if (line.length === 0 || line.startsWith('#')) continue;
+    const match = line.match(linePattern);
+    if (match) return match[1] ?? null;
+  }
+  return null;
+}
+
+/**
+ * Return the YAML frontmatter block of a changeset (the text between the opening
+ * `---` fence and its closing `---`). Falls back to the whole source if no fence
+ * is present, so a malformed changeset still gets scanned rather than skipped.
+ */
+function frontmatterOf(source: string): string {
+  const match = source.match(/^---\r?\n([\s\S]*?)\r?\n---/);
+  return match?.[1] ?? source;
 }
 
 /** True when a semver version string is `< 1.0.0` (i.e. still in the `0.y.z` line). */

--- a/packages/components/scripts/check-changeset-prerelease-bumps.ts
+++ b/packages/components/scripts/check-changeset-prerelease-bumps.ts
@@ -43,11 +43,13 @@ export type ChangesetBumpViolation = {
  * `null` if the changeset does not mention the package.
  */
 export function bumpLevelForPackage(source: string, packageName: string): string | null {
-  // Match `'<pkg>': <level>` or `"<pkg>": <level>` (quotes optional), tolerant of
-  // surrounding whitespace. Only the frontmatter uses this shape, so scanning the
-  // whole file is safe and survives Prettier reformatting of the prose body.
+  // Match `'<pkg>': <level>` or `"<pkg>": <level>`, with quotes optional around
+  // BOTH the package name and the bump level — Changesets' YAML parser accepts a
+  // quoted scalar (`'@lostgradient/cinder': "major"`), so the guard must too.
+  // Tolerant of surrounding whitespace. Only the frontmatter uses this shape, so
+  // scanning the whole file is safe and survives Prettier reformatting of the body.
   const pattern = new RegExp(
-    `["']?${packageName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}["']?\\s*:\\s*(major|minor|patch)`,
+    `["']?${packageName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}["']?\\s*:\\s*["']?(major|minor|patch)["']?`,
   );
   const match = source.match(pattern);
   return match?.[1] ?? null;
@@ -118,8 +120,13 @@ async function main(): Promise<void> {
   });
 
   if (violations.length === 0) {
+    // Once the package is stable (>= 1.0.0) the guard does not scan and major
+    // bumps are allowed — say so explicitly rather than implying "no majors exist".
+    const reason = isPreRelease(version)
+      ? `no major changesets while ${PACKAGE_NAME} is pre-1.0`
+      : `${PACKAGE_NAME} is stable (>= 1.0.0); major bumps allowed, guard not applied`;
     process.stdout.write(
-      `check-changeset-prerelease-bumps — OK (no major changesets while ${PACKAGE_NAME} is at ${version}).\n`,
+      `check-changeset-prerelease-bumps — OK (${reason}; version ${version}).\n`,
     );
     return;
   }

--- a/packages/components/scripts/check-changeset-prerelease-bumps.ts
+++ b/packages/components/scripts/check-changeset-prerelease-bumps.ts
@@ -50,7 +50,13 @@ export function bumpLevelForPackage(source: string, packageName: string): string
   // and the bump level, because Changesets' YAML parser accepts a quoted scalar
   // (`'@lostgradient/cinder': "major"`).
   const escapedName = packageName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-  const linePattern = new RegExp(`^["']?${escapedName}["']?\\s*:\\s*["']?(major|minor|patch)["']?`);
+  // Anchor the end of the bump token — a closing quote, optional whitespace, and an
+  // optional inline `# comment`, then end of (trimmed) line. Without the `$` anchor
+  // a malformed value like `patches` would prefix-match `patch`; we leave such
+  // values unmatched (returns null) rather than silently misreading them.
+  const linePattern = new RegExp(
+    `^["']?${escapedName}["']?\\s*:\\s*["']?(major|minor|patch)["']?\\s*(?:#.*)?$`,
+  );
   // Keep the LAST matching entry, not the first — YAML (which Changesets parses
   // with) is last-key-wins, so a duplicate `pkg: minor` then `pkg: major` applies
   // the major. Returning the first match would let that pass the guard.

--- a/packages/components/scripts/check-changeset-prerelease-bumps.ts
+++ b/packages/components/scripts/check-changeset-prerelease-bumps.ts
@@ -19,6 +19,7 @@
  * this guard becomes a no-op automatically (the version gate stops applying).
  */
 
+import parseChangeset from '@changesets/parse';
 import { Glob } from 'bun';
 import { dirname, relative, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -37,47 +38,20 @@ export type ChangesetBumpViolation = {
 };
 
 /**
- * Parse the bump level a changeset requests for a given package. Changesets are
- * Markdown files whose YAML-ish frontmatter maps quoted package names to bump
- * levels, e.g. `'@lostgradient/cinder': major`. Returns the level string, or
- * `null` if the changeset does not mention the package.
+ * The bump level a changeset requests for `packageName`, or `null` if the
+ * changeset does not mention it.
+ *
+ * Parsing is delegated to `@changesets/parse` — the exact parser Changesets uses
+ * — so the guard can never disagree with how Changesets actually interprets the
+ * frontmatter. That covers quoted scalars, comments, and multiline/block YAML
+ * forms uniformly, and (like Changesets) throws on genuinely malformed frontmatter
+ * such as duplicate keys or an invalid version type, surfacing the bad changeset
+ * rather than silently misreading it.
  */
 export function bumpLevelForPackage(source: string, packageName: string): string | null {
-  // Scan only the YAML frontmatter (between the first two `---` fences), line by
-  // line, skipping comment lines — Changesets ignores a commented `# 'pkg': minor`
-  // entry, so the guard must too, or a commented bump before the real one could be
-  // mistaken for the active level. Quotes are optional around BOTH the package name
-  // and the bump level, because Changesets' YAML parser accepts a quoted scalar
-  // (`'@lostgradient/cinder': "major"`).
-  const escapedName = packageName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-  // Anchor the end of the bump token — a closing quote, optional whitespace, and an
-  // optional inline `# comment`, then end of (trimmed) line. Without the `$` anchor
-  // a malformed value like `patches` would prefix-match `patch`; we leave such
-  // values unmatched (returns null) rather than silently misreading them.
-  const linePattern = new RegExp(
-    `^["']?${escapedName}["']?\\s*:\\s*["']?(major|minor|patch)["']?\\s*(?:#.*)?$`,
-  );
-  // Keep the LAST matching entry, not the first — YAML (which Changesets parses
-  // with) is last-key-wins, so a duplicate `pkg: minor` then `pkg: major` applies
-  // the major. Returning the first match would let that pass the guard.
-  let level: string | null = null;
-  for (const rawLine of frontmatterOf(source).split('\n')) {
-    const line = rawLine.trim();
-    if (line.length === 0 || line.startsWith('#')) continue;
-    const match = line.match(linePattern);
-    if (match) level = match[1] ?? level;
-  }
-  return level;
-}
-
-/**
- * Return the YAML frontmatter block of a changeset (the text between the opening
- * `---` fence and its closing `---`). Falls back to the whole source if no fence
- * is present, so a malformed changeset still gets scanned rather than skipped.
- */
-function frontmatterOf(source: string): string {
-  const match = source.match(/^---\r?\n([\s\S]*?)\r?\n---/);
-  return match?.[1] ?? source;
+  const { releases } = parseChangeset(source);
+  const release = releases.find((entry) => entry.name === packageName);
+  return release ? release.type : null;
 }
 
 /** True when a semver version string is `< 1.0.0` (i.e. still in the `0.y.z` line). */


### PR DESCRIPTION
## Why

The release workflow's auto-generated "Version Packages" PR (#527) proposed bumping `@lostgradient/cinder` to **1.0.0** — a stability commitment we have not made while pre-release. The cause: three changesets on `main` declared a `major` bump, and changesets rolls `0.3.0 → 1.0.0` on any `major`.

Project policy is **minor bumps until 1.0.0** — breaking changes are fine pre-release, they just ship as minor.

## What

- **Relabel the 3 `major` changesets → `minor`** (`data-list-required-key-masonry-element`, `lowercase-callback-props`, `vocabulary-consistency`). Next release becomes **`0.4.0`**, not `1.0.0`.
- **Add `check:changeset-prerelease-bumps`** (+ unit tests), wired into `validate`. It fails CI when any changeset requests `major` while the package version is `< 1.0.0`. Because the release workflow runs `validate` **before** the changesets action, a mislabeled changeset now turns the branch red instead of opening a surprise major-version PR. The guard auto-disables once the package legitimately reaches `1.0.0`.

## After merge

The release workflow regenerates the "Version Packages" PR (#527) as **`0.4.0`**. Nothing publishes until that PR is merged — the merge remains the release-approval gate.

## Note (out of scope)

Pre-existing `eslint(no-new)` **warning** in `src/_internal/chart/chart-interaction.test.ts:277` (since #236). It does not fail CI; flagged here, not touched.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release/changeset policy and CI only; no runtime library behavior changes in this diff.
> 
> **Overview**
> Aligns pre-release versioning with policy: three pending breaking changesets are relabeled from **`major` → `minor`** so the next release targets **`0.4.0`** instead of an unintended **`1.0.0`**.
> 
> Adds **`check:changeset-prerelease-bumps`**, which uses `@changesets/parse` to fail when any changeset requests a `major` bump for `@lostgradient/cinder` while the package version is still `< 1.0.0`. The check is hooked into **`bun run validate`** (which runs before Changesets in the release workflow) and a dedicated **`changeset-guard`** PR workflow so changeset-only edits still fail on the branch, not only on `main`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5d2d43e16f5f448324c4ec82b22ede912d216523. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->