### PR TITLE
Fix playground server cleanup

### DIFF
--- a/packages/playground/src/playground-server.test.ts
+++ b/packages/playground/src/playground-server.test.ts
@@ -33,6 +33,7 @@ import { COMPOSE_ONLY_COMPONENTS } from './discover.ts';
 import {
   PORT,
   createHttpServerOnAvailablePort,
+  createSharedDisposer,
   handleRequest,
   rewriteRepositoryRelativeReadmeLinks,
   triggerReload,
@@ -181,6 +182,32 @@ describe('port selection', () => {
     expect(serverPort).toBeGreaterThan(reservedPort);
     const response = await fetch(`http://127.0.0.1:${serverPort}`);
     expect(await response.text()).toBe('fallback');
+  });
+});
+
+describe('shared disposer', () => {
+  it('returns the same shutdown promise to concurrent callers', async () => {
+    let disposeCalls = 0;
+    let finishDispose = (): void => {
+      throw new Error('Dispose promise was not created');
+    };
+    const dispose = createSharedDisposer(() => {
+      disposeCalls += 1;
+      return new Promise<void>((resolve) => {
+        finishDispose = resolve;
+      });
+    });
+
+    const firstDispose = dispose();
+    const secondDispose = dispose();
+
+    expect(secondDispose).toBe(firstDispose);
+    expect(disposeCalls).toBe(1);
+    finishDispose();
+    await Promise.all([firstDispose, secondDispose]);
+
+    expect(dispose()).toBe(firstDispose);
+    expect(disposeCalls).toBe(1);
   });
 });
 

--- a/packages/playground/src/playground-server.ts
+++ b/packages/playground/src/playground-server.ts
@@ -1967,8 +1967,12 @@ if (import.meta.main) {
   let shutdownPromise: Promise<void> | null = null;
 
   async function shutdown(code: number): Promise<never> {
-    shutdownPromise ??= server.dispose();
-    await shutdownPromise;
+    try {
+      shutdownPromise ??= server.dispose();
+      await shutdownPromise;
+    } catch (error) {
+      console.error('[playground] shutdown cleanup failed:', error);
+    }
     process.exit(code);
   }
 

--- a/packages/playground/src/playground-server.ts
+++ b/packages/playground/src/playground-server.ts
@@ -1959,13 +1959,11 @@ export async function startServer(port: number = PORT): Promise<PlaygroundServer
 
 if (import.meta.main) {
   const server = await startServer();
-  let shutdownStarted = false;
+  let shutdownPromise: Promise<void> | null = null;
 
   async function shutdown(code: number): Promise<never> {
-    if (!shutdownStarted) {
-      shutdownStarted = true;
-      await server.dispose();
-    }
+    shutdownPromise ??= server.dispose();
+    await shutdownPromise;
     process.exit(code);
   }
 

--- a/packages/playground/src/playground-server.ts
+++ b/packages/playground/src/playground-server.ts
@@ -1931,10 +1931,21 @@ export async function startServer(port: number = PORT): Promise<PlaygroundServer
     throw error;
   }
 
+  let disposed = false;
   async function dispose(): Promise<void> {
+    if (disposed) return;
+    disposed = true;
     for (const watcher of watchers) {
       watcher.close();
     }
+    for (const controller of sseClients) {
+      try {
+        controller.close();
+      } catch {
+        // Ignore already-closed streams.
+      }
+    }
+    sseClients.clear();
     await server.stop(true);
   }
 
@@ -1947,5 +1958,21 @@ export async function startServer(port: number = PORT): Promise<PlaygroundServer
 }
 
 if (import.meta.main) {
-  await startServer();
+  const server = await startServer();
+  let shutdownStarted = false;
+
+  async function shutdown(code: number): Promise<never> {
+    if (!shutdownStarted) {
+      shutdownStarted = true;
+      await server.dispose();
+    }
+    process.exit(code);
+  }
+
+  process.on('SIGINT', () => {
+    void shutdown(130);
+  });
+  process.on('SIGTERM', () => {
+    void shutdown(143);
+  });
 }

--- a/packages/playground/src/playground-server.ts
+++ b/packages/playground/src/playground-server.ts
@@ -1894,6 +1894,14 @@ async function eagerPrebuildAll(): Promise<{
   return { shellSucceeded: shellCode !== null, succeeded, failed };
 }
 
+export function createSharedDisposer(disposeWork: () => Promise<void>): () => Promise<void> {
+  let disposePromise: Promise<void> | null = null;
+  return () => {
+    disposePromise ??= disposeWork();
+    return disposePromise;
+  };
+}
+
 /** Start the playground server on the given port. Returns a handle with dispose() to stop everything. */
 export async function startServer(port: number = PORT): Promise<PlaygroundServer> {
   // Eager pre-build BEFORE binding the port. Sidebar clicks should serve
@@ -1931,10 +1939,7 @@ export async function startServer(port: number = PORT): Promise<PlaygroundServer
     throw error;
   }
 
-  let disposed = false;
-  async function dispose(): Promise<void> {
-    if (disposed) return;
-    disposed = true;
+  const dispose = createSharedDisposer(async () => {
     for (const watcher of watchers) {
       watcher.close();
     }
@@ -1947,7 +1952,7 @@ export async function startServer(port: number = PORT): Promise<PlaygroundServer
     }
     sseClients.clear();
     await server.stop(true);
-  }
+  });
 
   const portFile = Bun.env['PLAYGROUND_PORT_FILE'];
   if (portFile !== undefined) {

--- a/packages/testing/scripts/start-server.test.ts
+++ b/packages/testing/scripts/start-server.test.ts
@@ -1,8 +1,9 @@
 import { describe, expect, test } from 'bun:test';
+import { join } from 'node:path';
 
 import {
   appendServerOutputBuffer,
-  childProcessHasExited,
+  childProcessHasFinished,
   localPlaygroundUrlForReportedPort,
   parsePlaygroundListeningPort,
   playgroundBundleDependencyBuildArguments,
@@ -101,20 +102,26 @@ describe('playground server process', () => {
     expect(argumentsList).toEqual(['run', 'src/playground-server.ts']);
     expect(argumentsList).not.toContain('dev');
     expect(argumentsList).not.toContain('--watch');
-    expect(playgroundServerWorkingDirectory().endsWith('/packages/playground')).toBe(true);
+    expect(playgroundServerWorkingDirectory().endsWith(join('packages', 'playground'))).toBe(true);
   });
 });
 
 describe('child process cleanup', () => {
   test('does not treat a sent kill signal as process exit', () => {
-    const stillExiting = { killed: true, exitCode: null, signalCode: null };
+    const stillExiting = { pid: 123, killed: true, exitCode: null, signalCode: null };
 
-    expect(childProcessHasExited(stillExiting)).toBe(false);
+    expect(childProcessHasFinished(stillExiting)).toBe(false);
   });
 
   test('treats exit codes and terminal signals as process exit', () => {
-    expect(childProcessHasExited({ exitCode: 0, signalCode: null })).toBe(true);
-    expect(childProcessHasExited({ exitCode: null, signalCode: 'SIGTERM' })).toBe(true);
+    expect(childProcessHasFinished({ pid: 123, exitCode: 0, signalCode: null })).toBe(true);
+    expect(childProcessHasFinished({ pid: 123, exitCode: null, signalCode: 'SIGTERM' })).toBe(true);
+  });
+
+  test('treats failed spawns without a process id as finished', () => {
+    expect(childProcessHasFinished({ pid: undefined, exitCode: null, signalCode: null })).toBe(
+      true,
+    );
   });
 });
 

--- a/packages/testing/scripts/start-server.test.ts
+++ b/packages/testing/scripts/start-server.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from 'bun:test';
+import type { ChildProcess } from 'node:child_process';
 import { join } from 'node:path';
 
 import {
@@ -9,6 +10,7 @@ import {
   parsePlaygroundListeningPort,
   playgroundBundleDependencyBuildArguments,
   playgroundBundleDependencyBuildPackages,
+  playgroundBundleDependencyBuildProcess,
   playgroundServerArguments,
   playgroundServerWorkingDirectory,
   playgroundUrlForPath,
@@ -94,6 +96,18 @@ describe('playground bundle dependency build preflight', () => {
       '--filter=@cinder/markdown',
       'build',
     ]);
+  });
+
+  test('registers dependency builds as managed child processes', () => {
+    const childProcess = {} as ChildProcess;
+    const managedChildProcess = playgroundBundleDependencyBuildProcess(
+      childProcess,
+      '@cinder/markdown',
+    );
+
+    expect(managedChildProcess.childProcess).toBe(childProcess);
+    expect(managedChildProcess.name).toBe('@cinder/markdown build');
+    expect(managedChildProcess.killProcessGroup).toBe(process.platform !== 'win32');
   });
 });
 

--- a/packages/testing/scripts/start-server.test.ts
+++ b/packages/testing/scripts/start-server.test.ts
@@ -2,10 +2,13 @@ import { describe, expect, test } from 'bun:test';
 
 import {
   appendServerOutputBuffer,
+  childProcessHasExited,
   localPlaygroundUrlForReportedPort,
   parsePlaygroundListeningPort,
   playgroundBundleDependencyBuildArguments,
   playgroundBundleDependencyBuildPackages,
+  playgroundServerArguments,
+  playgroundServerWorkingDirectory,
   playgroundUrlForPath,
   playgroundWarmReadinessEndpointPath,
   playgroundWarmReadinessMissingEndpointMessage,
@@ -88,6 +91,30 @@ describe('playground bundle dependency build preflight', () => {
       '--filter=@cinder/markdown',
       'build',
     ]);
+  });
+});
+
+describe('playground server process', () => {
+  test('starts the plain server entrypoint instead of the watch-mode dev script', () => {
+    const argumentsList = playgroundServerArguments();
+
+    expect(argumentsList).toEqual(['run', 'src/playground-server.ts']);
+    expect(argumentsList).not.toContain('dev');
+    expect(argumentsList).not.toContain('--watch');
+    expect(playgroundServerWorkingDirectory().endsWith('/packages/playground')).toBe(true);
+  });
+});
+
+describe('child process cleanup', () => {
+  test('does not treat a sent kill signal as process exit', () => {
+    const stillExiting = { killed: true, exitCode: null, signalCode: null };
+
+    expect(childProcessHasExited(stillExiting)).toBe(false);
+  });
+
+  test('treats exit codes and terminal signals as process exit', () => {
+    expect(childProcessHasExited({ exitCode: 0, signalCode: null })).toBe(true);
+    expect(childProcessHasExited({ exitCode: null, signalCode: 'SIGTERM' })).toBe(true);
   });
 });
 

--- a/packages/testing/scripts/start-server.test.ts
+++ b/packages/testing/scripts/start-server.test.ts
@@ -4,6 +4,7 @@ import { join } from 'node:path';
 import {
   appendServerOutputBuffer,
   childProcessHasFinished,
+  finalPlaywrightExitCode,
   localPlaygroundUrlForReportedPort,
   parsePlaygroundListeningPort,
   playgroundBundleDependencyBuildArguments,
@@ -122,6 +123,18 @@ describe('child process cleanup', () => {
     expect(childProcessHasFinished({ pid: undefined, exitCode: null, signalCode: null })).toBe(
       true,
     );
+  });
+});
+
+describe('playwright wrapper exit code', () => {
+  test('uses Playwright exit code when no shutdown signal was received', () => {
+    expect(finalPlaywrightExitCode(0, null)).toBe(0);
+    expect(finalPlaywrightExitCode(1, null)).toBe(1);
+  });
+
+  test('prefers shutdown signal exit code over Playwright exit code', () => {
+    expect(finalPlaywrightExitCode(0, 130)).toBe(130);
+    expect(finalPlaywrightExitCode(1, 143)).toBe(143);
   });
 });
 

--- a/packages/testing/scripts/start-server.test.ts
+++ b/packages/testing/scripts/start-server.test.ts
@@ -16,6 +16,7 @@ import {
   playgroundUrlForPath,
   playgroundWarmReadinessEndpointPath,
   playgroundWarmReadinessMissingEndpointMessage,
+  shouldStartManagedChildProcess,
   shutdownExitCodeAfterRequest,
 } from './start-server.ts';
 
@@ -123,6 +124,11 @@ describe('playground server process', () => {
 });
 
 describe('child process cleanup', () => {
+  test('stops starting new managed children after shutdown begins', () => {
+    expect(shouldStartManagedChildProcess(null)).toBe(true);
+    expect(shouldStartManagedChildProcess(130)).toBe(false);
+  });
+
   test('does not treat a sent kill signal as process exit', () => {
     const stillExiting = { pid: 123, killed: true, exitCode: null, signalCode: null };
 

--- a/packages/testing/scripts/start-server.test.ts
+++ b/packages/testing/scripts/start-server.test.ts
@@ -14,6 +14,7 @@ import {
   playgroundUrlForPath,
   playgroundWarmReadinessEndpointPath,
   playgroundWarmReadinessMissingEndpointMessage,
+  shutdownExitCodeAfterRequest,
 } from './start-server.ts';
 
 describe('parsePlaygroundListeningPort', () => {
@@ -135,6 +136,15 @@ describe('playwright wrapper exit code', () => {
   test('prefers shutdown signal exit code over Playwright exit code', () => {
     expect(finalPlaywrightExitCode(0, 130)).toBe(130);
     expect(finalPlaywrightExitCode(1, 143)).toBe(143);
+  });
+
+  test('keeps an interrupt exit code when a later failure also requests shutdown', () => {
+    expect(shutdownExitCodeAfterRequest(130, 1)).toBe(130);
+    expect(shutdownExitCodeAfterRequest(143, 1)).toBe(143);
+  });
+
+  test('lets a later interrupt exit code replace an earlier failure exit code', () => {
+    expect(shutdownExitCodeAfterRequest(1, 130)).toBe(130);
   });
 });
 

--- a/packages/testing/scripts/start-server.ts
+++ b/packages/testing/scripts/start-server.ts
@@ -1,6 +1,8 @@
-import { spawn } from 'node:child_process';
+import { spawn, type ChildProcess } from 'node:child_process';
+import { once } from 'node:events';
 import { mkdirSync, rmSync } from 'node:fs';
 import { dirname, resolve as resolvePath } from 'node:path';
+import { setTimeout as delay } from 'node:timers/promises';
 import { fileURLToPath } from 'node:url';
 import { PLAYGROUND_URL } from '../src/helpers/playground-url.ts';
 import { DEFAULT_PLAYGROUND_URL, isLocalDefaultPlaygroundUrl } from './playground-server-url';
@@ -8,6 +10,7 @@ import { DEFAULT_PLAYGROUND_URL, isLocalDefaultPlaygroundUrl } from './playgroun
 const here = dirname(fileURLToPath(import.meta.url));
 const packageRoot = resolvePath(here, '..');
 const repoRoot = resolvePath(here, '../../..');
+const playgroundRoot = resolvePath(repoRoot, 'packages/playground');
 const playgroundBundleDependencyPackages = [
   '@cinder/diff',
   '@cinder/markdown',
@@ -25,10 +28,17 @@ const PLAYGROUND_PORT_PROBE_TIMEOUT_MS = 500;
 const PLAYGROUND_READY_TIMEOUT_MS = 240_000;
 const PLAYGROUND_WARM_READINESS_STABLE_READS = 2;
 const PLAYGROUND_WARM_READINESS_DELAY_MS = 500;
+const CHILD_PROCESS_TERMINATION_GRACE_MS = 5_000;
 
 type PlaygroundPathProbeResult = {
   ok: boolean;
   status: number | null;
+};
+
+type ManagedChildProcess = {
+  childProcess: ChildProcess;
+  name: string;
+  killProcessGroup: boolean;
 };
 
 export function playgroundUrlForPath(
@@ -106,7 +116,7 @@ export function appendServerOutputBuffer(
   return nextBuffer.length > 4096 ? nextBuffer.slice(-4096) : nextBuffer;
 }
 
-function waitForExit(childProcess: ReturnType<typeof spawn>): Promise<number> {
+function waitForExit(childProcess: ChildProcess): Promise<number> {
   return new Promise((resolve) => {
     // Listen for both `exit` and `error`. If `spawn()` fails (ENOENT,
     // EACCES, etc.) the child emits `error` and may never emit `exit`,
@@ -119,8 +129,95 @@ function waitForExit(childProcess: ReturnType<typeof spawn>): Promise<number> {
   });
 }
 
+export function childProcessHasExited(
+  childProcess: Pick<ChildProcess, 'exitCode' | 'signalCode'>,
+): boolean {
+  return childProcess.exitCode !== null || childProcess.signalCode !== null;
+}
+
+function isAbortError(error: unknown): boolean {
+  return error instanceof Error && error.name === 'AbortError';
+}
+
+async function waitForExitOrTimeout(
+  childProcess: ChildProcess,
+  timeoutMs: number,
+): Promise<boolean> {
+  if (childProcessHasExited(childProcess)) return true;
+
+  const abortController = new AbortController();
+  const exitPromise = once(childProcess, 'exit', { signal: abortController.signal }).then(
+    () => 'exited' as const,
+    (error: unknown) => (isAbortError(error) ? 'aborted' : 'exited'),
+  );
+  const errorPromise = once(childProcess, 'error', { signal: abortController.signal }).then(
+    ([error]) => {
+      console.error('Child process error:', error);
+      return 'exited' as const;
+    },
+    (error: unknown) => (isAbortError(error) ? 'aborted' : 'exited'),
+  );
+
+  const result = await Promise.race([exitPromise, errorPromise, delay(timeoutMs, 'timeout')]);
+  abortController.abort();
+
+  return result === 'exited' || childProcessHasExited(childProcess);
+}
+
+function signalChildProcess(
+  managedChildProcess: ManagedChildProcess,
+  signal: NodeJS.Signals,
+): void {
+  const { childProcess, killProcessGroup, name } = managedChildProcess;
+  if (childProcess.pid === undefined || childProcessHasExited(childProcess)) return;
+
+  try {
+    if (killProcessGroup && process.platform !== 'win32') {
+      process.kill(-childProcess.pid, signal);
+    } else {
+      childProcess.kill(signal);
+    }
+  } catch (error) {
+    const code =
+      typeof error === 'object' && error !== null && 'code' in error
+        ? (error as { code?: unknown }).code
+        : undefined;
+    if (code !== 'ESRCH') {
+      console.error(`Failed to send ${signal} to ${name}:`, error);
+    }
+  }
+}
+
+async function terminateChildProcess(managedChildProcess: ManagedChildProcess): Promise<void> {
+  const { childProcess, name } = managedChildProcess;
+  if (childProcessHasExited(childProcess)) return;
+
+  signalChildProcess(managedChildProcess, 'SIGTERM');
+  if (await waitForExitOrTimeout(childProcess, CHILD_PROCESS_TERMINATION_GRACE_MS)) return;
+
+  console.error(`${name} did not exit after SIGTERM; sending SIGKILL.`);
+  signalChildProcess(managedChildProcess, 'SIGKILL');
+  await waitForExitOrTimeout(childProcess, CHILD_PROCESS_TERMINATION_GRACE_MS);
+}
+
+async function cleanup(
+  children: ManagedChildProcess[],
+  playgroundPortFile: string | null,
+): Promise<void> {
+  await Promise.all(children.map((child) => terminateChildProcess(child)));
+  if (playgroundPortFile !== null) rmSync(playgroundPortFile, { force: true });
+}
+
 export function playgroundBundleDependencyBuildArguments(packageName: string): string[] {
   return ['run', `--filter=${packageName}`, 'build'];
+}
+
+export function playgroundServerArguments(): string[] {
+  return ['run', 'src/playground-server.ts'];
+}
+
+export function playgroundServerWorkingDirectory(): string {
+  return playgroundRoot;
 }
 
 export function playgroundBundleDependencyBuildPackages(): readonly string[] {
@@ -196,6 +293,26 @@ async function main(): Promise<void> {
 
   let serverProcess: ReturnType<typeof spawn> | null = null;
   let playgroundPortFile: string | null = null;
+  const children: ManagedChildProcess[] = [];
+  let cleanupPromise: Promise<void> | null = null;
+
+  const cleanupOnce = async (): Promise<void> => {
+    cleanupPromise ??= cleanup(children, playgroundPortFile);
+    await cleanupPromise;
+  };
+
+  const exitAfterCleanup = async (code: number): Promise<never> => {
+    await cleanupOnce();
+    process.exit(code);
+  };
+
+  process.on('SIGINT', () => {
+    void exitAfterCleanup(130);
+  });
+  process.on('SIGTERM', () => {
+    void exitAfterCleanup(143);
+  });
+
   const alreadyUp = await ping();
 
   if (alreadyUp && reuseOptOut) {
@@ -208,10 +325,9 @@ async function main(): Promise<void> {
   if (alreadyUp) {
     console.log(`Reusing playground server at ${targetPlaygroundUrl}.`);
   } else if (!isLocalDefault) {
-    // The local `bun run --filter=@cinder/playground dev` server starts from
-    // the local default port and scans upward. Starting it cannot satisfy
-    // readiness for a custom `PLAYGROUND_URL`. Fail fast with an actionable
-    // message rather than spinning for 120s.
+    // The local playground server starts from the local default port and scans
+    // upward. Starting it cannot satisfy readiness for a custom `PLAYGROUND_URL`.
+    // Fail fast with an actionable message rather than spinning for 120s.
     console.error(
       `Playground server not responding at ${targetPlaygroundUrl}, and it differs from the local default (${DEFAULT_PLAYGROUND_URL}). Start the target server manually before running the suite, or unset PLAYGROUND_URL.`,
     );
@@ -223,10 +339,16 @@ async function main(): Promise<void> {
     let reportedPlaygroundPort: number | null = null;
     mkdirSync(resolvePath(repoRoot, 'tmp'), { recursive: true });
     rmSync(playgroundPortFile, { force: true });
-    serverProcess = spawn('bun', ['run', '--filter=@cinder/playground', 'dev'], {
-      cwd: repoRoot,
+    serverProcess = spawn('bun', playgroundServerArguments(), {
+      cwd: playgroundServerWorkingDirectory(),
+      detached: process.platform !== 'win32',
       stdio: ['ignore', 'pipe', 'inherit'],
       env: { ...process.env, PLAYGROUND_PORT_FILE: playgroundPortFile },
+    });
+    children.push({
+      childProcess: serverProcess,
+      name: 'playground server',
+      killProcessGroup: process.platform !== 'win32',
     });
 
     let serverOutputBuffer = '';
@@ -254,9 +376,8 @@ async function main(): Promise<void> {
         targetPlaygroundUrl = selectedPlaygroundUrl;
         if (await ping(selectedPlaygroundUrl)) break;
       } else if (await ping(targetPlaygroundUrl)) {
-        // `bun --watch` should preserve PLAYGROUND_PORT_FILE, but local
-        // runs can start successfully on the default port without writing the
-        // file or logging the selected port. Accept direct readiness at the
+        // Local runs can start successfully on the default port without writing
+        // the file or logging the selected port. Accept direct readiness at the
         // target URL so the wrapper does not hang despite a healthy server.
         break;
       }
@@ -271,65 +392,30 @@ async function main(): Promise<void> {
     }
 
     if (!(await ping())) {
-      try {
-        serverProcess.kill('SIGTERM');
-      } catch (error) {
-        console.error('Failed to kill unready server process:', error);
-      }
       console.error(
         `Playground server did not become ready within ${Math.round(
           PLAYGROUND_READY_TIMEOUT_MS / 1000,
         )}s at ${targetPlaygroundUrl}.`,
       );
-      if (playgroundPortFile !== null) rmSync(playgroundPortFile, { force: true });
-      process.exit(1);
+      await exitAfterCleanup(1);
     }
   }
-
-  const children: Array<ReturnType<typeof spawn>> = [];
-  if (serverProcess !== null) children.push(serverProcess);
-
-  const cleanup = (): void => {
-    for (const child of children) {
-      // Skip already-exited processes (exitCode/signalCode set) and wrap
-      // kill() in try/catch — ChildProcess.kill() can throw ESRCH if the
-      // PID has been reaped between the check and the call, and an
-      // uncaught throw would block cleanup of the remaining children.
-      if (child.killed || child.exitCode !== null || child.signalCode !== null) continue;
-      try {
-        child.kill('SIGTERM');
-      } catch (error) {
-        console.error('Failed to kill child process:', error);
-      }
-    }
-    if (playgroundPortFile !== null) rmSync(playgroundPortFile, { force: true });
-  };
-
-  process.on('SIGINT', () => {
-    cleanup();
-    process.exit(130);
-  });
-  process.on('SIGTERM', () => {
-    cleanup();
-    process.exit(143);
-  });
 
   const prep = spawn('bun', ['run', 'scripts/prepare-manifest.ts'], {
     cwd: packageRoot,
     stdio: 'inherit',
     env: { ...process.env, PLAYGROUND_URL: targetPlaygroundUrl },
   });
-  children.push(prep);
+  children.push({ childProcess: prep, name: 'manifest preparation', killProcessGroup: false });
   const prepCode = await waitForExit(prep);
   if (prepCode !== 0) {
-    cleanup();
-    process.exit(prepCode);
+    await exitAfterCleanup(prepCode);
   }
 
   try {
     await waitForWarmPlayground();
   } catch (error) {
-    cleanup();
+    await cleanupOnce();
     throw error;
   }
 
@@ -338,7 +424,7 @@ async function main(): Promise<void> {
     stdio: 'inherit',
     env: { ...process.env, PLAYGROUND_URL: targetPlaygroundUrl },
   });
-  children.push(playwright);
+  children.push({ childProcess: playwright, name: 'Playwright', killProcessGroup: false });
   const playwrightCode = await waitForExit(playwright);
 
   const summary = spawn('bun', ['run', 'scripts/summarize-axe.ts'], {
@@ -346,7 +432,7 @@ async function main(): Promise<void> {
     stdio: 'inherit',
     env: { ...process.env, PLAYGROUND_URL: targetPlaygroundUrl },
   });
-  children.push(summary);
+  children.push({ childProcess: summary, name: 'axe summary', killProcessGroup: false });
   const summaryCode = await waitForExit(summary);
   if (summaryCode !== 0) {
     console.error(
@@ -354,7 +440,7 @@ async function main(): Promise<void> {
     );
   }
 
-  cleanup();
+  await cleanupOnce();
   // Summary generation is advisory — only Playwright's result drives the
   // suite exit code so a green run never goes red because of summary
   // failures.

--- a/packages/testing/scripts/start-server.ts
+++ b/packages/testing/scripts/start-server.ts
@@ -35,7 +35,7 @@ type PlaygroundPathProbeResult = {
   status: number | null;
 };
 
-type ManagedChildProcess = {
+export type ManagedChildProcess = {
   childProcess: ChildProcess;
   name: string;
   killProcessGroup: boolean;
@@ -239,6 +239,17 @@ export function playgroundBundleDependencyBuildArguments(packageName: string): s
   return ['run', `--filter=${packageName}`, 'build'];
 }
 
+export function playgroundBundleDependencyBuildProcess(
+  childProcess: ChildProcess,
+  packageName: string,
+): ManagedChildProcess {
+  return {
+    childProcess,
+    name: `${packageName} build`,
+    killProcessGroup: process.platform !== 'win32',
+  };
+}
+
 export function playgroundServerArguments(): string[] {
   return ['run', 'src/playground-server.ts'];
 }
@@ -298,14 +309,18 @@ async function waitForWarmPlayground(): Promise<void> {
   );
 }
 
-async function buildPlaygroundBundleDependencies(): Promise<void> {
+async function buildPlaygroundBundleDependencies(
+  registerChildProcess: (managedChildProcess: ManagedChildProcess) => void,
+): Promise<void> {
   console.log('Building playground bundle dependencies...');
   for (const packageName of playgroundBundleDependencyPackages) {
     const buildProcess = spawn('bun', playgroundBundleDependencyBuildArguments(packageName), {
       cwd: repoRoot,
+      detached: process.platform !== 'win32',
       stdio: 'inherit',
       env: process.env,
     });
+    registerChildProcess(playgroundBundleDependencyBuildProcess(buildProcess, packageName));
     const buildCode = await waitForExit(buildProcess);
     if (buildCode !== 0) {
       throw new Error(`${packageName} build exited with code ${buildCode}`);
@@ -370,7 +385,7 @@ async function main(): Promise<void> {
     process.exit(1);
   } else {
     console.log(`Starting playground server (target: ${targetPlaygroundUrl})...`);
-    await buildPlaygroundBundleDependencies();
+    await buildPlaygroundBundleDependencies((childProcess) => children.push(childProcess));
     playgroundPortFile = resolvePath(repoRoot, 'tmp', `playground-port-${process.pid}.txt`);
     let reportedPlaygroundPort: number | null = null;
     mkdirSync(resolvePath(repoRoot, 'tmp'), { recursive: true });

--- a/packages/testing/scripts/start-server.ts
+++ b/packages/testing/scripts/start-server.ts
@@ -139,6 +139,13 @@ export function childProcessHasFinished(
   );
 }
 
+export function finalPlaywrightExitCode(
+  playwrightExitCode: number,
+  shutdownExitCode: number | null,
+): number {
+  return shutdownExitCode ?? playwrightExitCode;
+}
+
 function isAbortError(error: unknown): boolean {
   return error instanceof Error && error.name === 'AbortError';
 }
@@ -414,6 +421,7 @@ async function main(): Promise<void> {
     }
   }
 
+  await exitIfShuttingDown();
   const prep = spawn('bun', ['run', 'scripts/prepare-manifest.ts'], {
     cwd: packageRoot,
     stdio: 'inherit',
@@ -457,11 +465,13 @@ async function main(): Promise<void> {
     );
   }
 
+  await exitIfShuttingDown();
   await cleanupOnce();
+  await exitIfShuttingDown();
   // Summary generation is advisory — only Playwright's result drives the
   // suite exit code so a green run never goes red because of summary
-  // failures.
-  process.exit(playwrightCode);
+  // failures unless the wrapper received an interrupt signal.
+  process.exit(finalPlaywrightExitCode(playwrightCode, shutdownExitCode));
 }
 
 if (import.meta.main) {

--- a/packages/testing/scripts/start-server.ts
+++ b/packages/testing/scripts/start-server.ts
@@ -129,10 +129,14 @@ function waitForExit(childProcess: ChildProcess): Promise<number> {
   });
 }
 
-export function childProcessHasExited(
-  childProcess: Pick<ChildProcess, 'exitCode' | 'signalCode'>,
+export function childProcessHasFinished(
+  childProcess: Pick<ChildProcess, 'pid' | 'exitCode' | 'signalCode'>,
 ): boolean {
-  return childProcess.exitCode !== null || childProcess.signalCode !== null;
+  return (
+    childProcess.pid === undefined ||
+    childProcess.exitCode !== null ||
+    childProcess.signalCode !== null
+  );
 }
 
 function isAbortError(error: unknown): boolean {
@@ -143,7 +147,7 @@ async function waitForExitOrTimeout(
   childProcess: ChildProcess,
   timeoutMs: number,
 ): Promise<boolean> {
-  if (childProcessHasExited(childProcess)) return true;
+  if (childProcessHasFinished(childProcess)) return true;
 
   const abortController = new AbortController();
   const exitPromise = once(childProcess, 'exit', { signal: abortController.signal }).then(
@@ -161,7 +165,7 @@ async function waitForExitOrTimeout(
   const result = await Promise.race([exitPromise, errorPromise, delay(timeoutMs, 'timeout')]);
   abortController.abort();
 
-  return result === 'exited' || childProcessHasExited(childProcess);
+  return result === 'exited' || childProcessHasFinished(childProcess);
 }
 
 function signalChildProcess(
@@ -169,11 +173,12 @@ function signalChildProcess(
   signal: NodeJS.Signals,
 ): void {
   const { childProcess, killProcessGroup, name } = managedChildProcess;
-  if (childProcess.pid === undefined || childProcessHasExited(childProcess)) return;
+  const processId = childProcess.pid;
+  if (processId === undefined || childProcessHasFinished(childProcess)) return;
 
   try {
     if (killProcessGroup && process.platform !== 'win32') {
-      process.kill(-childProcess.pid, signal);
+      process.kill(-processId, signal);
     } else {
       childProcess.kill(signal);
     }
@@ -190,7 +195,7 @@ function signalChildProcess(
 
 async function terminateChildProcess(managedChildProcess: ManagedChildProcess): Promise<void> {
   const { childProcess, name } = managedChildProcess;
-  if (childProcessHasExited(childProcess)) return;
+  if (childProcessHasFinished(childProcess)) return;
 
   signalChildProcess(managedChildProcess, 'SIGTERM');
   if (await waitForExitOrTimeout(childProcess, CHILD_PROCESS_TERMINATION_GRACE_MS)) return;
@@ -295,6 +300,7 @@ async function main(): Promise<void> {
   let playgroundPortFile: string | null = null;
   const children: ManagedChildProcess[] = [];
   let cleanupPromise: Promise<void> | null = null;
+  let shutdownExitCode: number | null = null;
 
   const cleanupOnce = async (): Promise<void> => {
     cleanupPromise ??= cleanup(children, playgroundPortFile);
@@ -302,8 +308,15 @@ async function main(): Promise<void> {
   };
 
   const exitAfterCleanup = async (code: number): Promise<never> => {
+    shutdownExitCode = code;
     await cleanupOnce();
     process.exit(code);
+  };
+
+  const exitIfShuttingDown = async (): Promise<void> => {
+    if (shutdownExitCode !== null) {
+      await exitAfterCleanup(shutdownExitCode);
+    }
   };
 
   process.on('SIGINT', () => {
@@ -408,6 +421,7 @@ async function main(): Promise<void> {
   });
   children.push({ childProcess: prep, name: 'manifest preparation', killProcessGroup: false });
   const prepCode = await waitForExit(prep);
+  await exitIfShuttingDown();
   if (prepCode !== 0) {
     await exitAfterCleanup(prepCode);
   }
@@ -415,9 +429,11 @@ async function main(): Promise<void> {
   try {
     await waitForWarmPlayground();
   } catch (error) {
+    await exitIfShuttingDown();
     await cleanupOnce();
     throw error;
   }
+  await exitIfShuttingDown();
 
   const playwright = spawn('bunx', ['playwright', 'test', ...args], {
     cwd: packageRoot,
@@ -426,6 +442,7 @@ async function main(): Promise<void> {
   });
   children.push({ childProcess: playwright, name: 'Playwright', killProcessGroup: false });
   const playwrightCode = await waitForExit(playwright);
+  await exitIfShuttingDown();
 
   const summary = spawn('bun', ['run', 'scripts/summarize-axe.ts'], {
     cwd: packageRoot,

--- a/packages/testing/scripts/start-server.ts
+++ b/packages/testing/scripts/start-server.ts
@@ -146,6 +146,15 @@ export function finalPlaywrightExitCode(
   return shutdownExitCode ?? playwrightExitCode;
 }
 
+export function shutdownExitCodeAfterRequest(
+  currentExitCode: number | null,
+  requestedExitCode: number,
+): number {
+  if (currentExitCode === null) return requestedExitCode;
+  if (currentExitCode >= 128) return currentExitCode;
+  return requestedExitCode >= 128 ? requestedExitCode : currentExitCode;
+}
+
 function isAbortError(error: unknown): boolean {
   return error instanceof Error && error.name === 'AbortError';
 }
@@ -168,8 +177,14 @@ async function waitForExitOrTimeout(
     },
     (error: unknown) => (isAbortError(error) ? 'aborted' : 'exited'),
   );
+  const timeoutPromise = delay(timeoutMs, 'timeout' as const, {
+    signal: abortController.signal,
+  }).catch((error: unknown) => {
+    if (isAbortError(error)) return 'aborted' as const;
+    throw error;
+  });
 
-  const result = await Promise.race([exitPromise, errorPromise, delay(timeoutMs, 'timeout')]);
+  const result = await Promise.race([exitPromise, errorPromise, timeoutPromise]);
   abortController.abort();
 
   return result === 'exited' || childProcessHasFinished(childProcess);
@@ -315,9 +330,10 @@ async function main(): Promise<void> {
   };
 
   const exitAfterCleanup = async (code: number): Promise<never> => {
-    shutdownExitCode = code;
+    const exitCode = shutdownExitCodeAfterRequest(shutdownExitCode, code);
+    shutdownExitCode = exitCode;
     await cleanupOnce();
-    process.exit(code);
+    process.exit(shutdownExitCode ?? exitCode);
   };
 
   const exitIfShuttingDown = async (): Promise<void> => {

--- a/packages/testing/scripts/start-server.ts
+++ b/packages/testing/scripts/start-server.ts
@@ -155,6 +155,10 @@ export function shutdownExitCodeAfterRequest(
   return requestedExitCode >= 128 ? requestedExitCode : currentExitCode;
 }
 
+export function shouldStartManagedChildProcess(shutdownExitCode: number | null): boolean {
+  return shutdownExitCode === null;
+}
+
 function isAbortError(error: unknown): boolean {
   return error instanceof Error && error.name === 'AbortError';
 }
@@ -224,7 +228,9 @@ async function terminateChildProcess(managedChildProcess: ManagedChildProcess): 
 
   console.error(`${name} did not exit after SIGTERM; sending SIGKILL.`);
   signalChildProcess(managedChildProcess, 'SIGKILL');
-  await waitForExitOrTimeout(childProcess, CHILD_PROCESS_TERMINATION_GRACE_MS);
+  if (!(await waitForExitOrTimeout(childProcess, CHILD_PROCESS_TERMINATION_GRACE_MS))) {
+    console.error(`${name} did not exit after SIGKILL; continuing cleanup.`);
+  }
 }
 
 async function cleanup(
@@ -311,9 +317,12 @@ async function waitForWarmPlayground(): Promise<void> {
 
 async function buildPlaygroundBundleDependencies(
   registerChildProcess: (managedChildProcess: ManagedChildProcess) => void,
+  shouldContinueStartingChildProcesses: () => boolean,
 ): Promise<void> {
   console.log('Building playground bundle dependencies...');
   for (const packageName of playgroundBundleDependencyPackages) {
+    if (!shouldContinueStartingChildProcesses()) return;
+
     const buildProcess = spawn('bun', playgroundBundleDependencyBuildArguments(packageName), {
       cwd: repoRoot,
       detached: process.platform !== 'win32',
@@ -322,6 +331,7 @@ async function buildPlaygroundBundleDependencies(
     });
     registerChildProcess(playgroundBundleDependencyBuildProcess(buildProcess, packageName));
     const buildCode = await waitForExit(buildProcess);
+    if (!shouldContinueStartingChildProcesses()) return;
     if (buildCode !== 0) {
       throw new Error(`${packageName} build exited with code ${buildCode}`);
     }
@@ -347,7 +357,11 @@ async function main(): Promise<void> {
   const exitAfterCleanup = async (code: number): Promise<never> => {
     const exitCode = shutdownExitCodeAfterRequest(shutdownExitCode, code);
     shutdownExitCode = exitCode;
-    await cleanupOnce();
+    try {
+      await cleanupOnce();
+    } catch (error) {
+      console.error('Cleanup failed during shutdown:', error);
+    }
     process.exit(shutdownExitCode ?? exitCode);
   };
 
@@ -385,7 +399,11 @@ async function main(): Promise<void> {
     process.exit(1);
   } else {
     console.log(`Starting playground server (target: ${targetPlaygroundUrl})...`);
-    await buildPlaygroundBundleDependencies((childProcess) => children.push(childProcess));
+    await buildPlaygroundBundleDependencies(
+      (childProcess) => children.push(childProcess),
+      () => shouldStartManagedChildProcess(shutdownExitCode),
+    );
+    await exitIfShuttingDown();
     playgroundPortFile = resolvePath(repoRoot, 'tmp', `playground-port-${process.pid}.txt`);
     let reportedPlaygroundPort: number | null = null;
     mkdirSync(resolvePath(repoRoot, 'tmp'), { recursive: true });


### PR DESCRIPTION
## Summary

- start the Playwright wrapper's playground server through the plain `src/playground-server.ts` entrypoint instead of the watch-mode `dev` script
- make child-process cleanup wait for actual process exit, signal the playground process group, and escalate only if termination does not complete
- make the playground server's `dispose()` idempotent and close active SSE streams before stopping the Bun server

## Root Cause

The browser-test wrapper launched the playground through `bun --watch` and only sent `SIGTERM` during cleanup before exiting. It also treated `child.killed` as if the child had exited, but that only means a signal was sent. Repeated runs could leave a watcher/server process alive with warmed bundle caches, which matched the memory growth failure mode.

## Validation

- `bun test packages/testing/scripts/start-server.test.ts`
- `bun run --filter='@cinder/testing' typecheck`
- `bun run --filter='@cinder/playground' typecheck`
- `bunx oxlint packages/testing/scripts/start-server.ts packages/testing/scripts/start-server.test.ts`
- `bunx prettier --check packages/testing/scripts/start-server.ts packages/testing/scripts/start-server.test.ts packages/playground/src/playground-server.ts`
- `PLAYWRIGHT_REUSE_SERVER=0 bun run scripts/start-server.ts -- --list` from `packages/testing`, followed by process and port checks confirming no matching playground process remained and port `5555` was free
- pre-commit hook passed
- pre-push scoped validation passed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches test orchestration and process lifecycle (signals, process groups, exit codes); behavior change is intentional but could affect local/CI runs if shutdown timing differs on some platforms.
> 
> **Overview**
> Fixes **orphaned playground processes** after browser test runs by changing how the Playwright wrapper starts and tears down the server.
> 
> The wrapper now launches **`src/playground-server.ts`** directly (no **`dev` / `--watch`**), so cleanup does not leave a Bun watcher alive. Child shutdown is **managed**: processes are tracked, **SIGTERM** is sent to the **process group** where supported, the wrapper **waits for real exit** (not `child.killed`), then escalates to **SIGKILL** after a grace period. **SIGINT/SIGTERM** on the wrapper run coordinated cleanup once and preserve signal exit codes over Playwright’s.
> 
> On the playground side, **`createSharedDisposer`** makes **`dispose()`** idempotent (one shared shutdown promise), **closes SSE clients** before stopping Bun, and the server entrypoint handles **SIGINT/SIGTERM** the same way when run standalone.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 40ee8a9cd91f54da049ab052849a6882f247ad71. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->