### PR TITLE
fix: guard build source map parsing

### DIFF
--- a/packages/components/scripts/build.ts
+++ b/packages/components/scripts/build.ts
@@ -13,6 +13,7 @@ import { discoverComponents, type ComponentDiscovery } from './lib/discover-comp
 import { hasSourceCssImport } from './prepend-source-index-css-import.ts';
 import { createServerEntrySource } from './server-entry.ts';
 import { sveltePlugin } from './svelte-plugin.ts';
+import { isObjectRecord } from './validation-utilities.ts';
 
 const repositoryRoot = process.cwd();
 const workspaceRoot = `${repositoryRoot}/../..`;
@@ -419,10 +420,10 @@ const serverRootContents = temporaryServerRootContents.includes(
 await Bun.write(serverRootOutput, serverRootContents);
 
 if (existsSync(temporaryServerRootMapOutput)) {
-  const sourceMap = JSON.parse(await Bun.file(temporaryServerRootMapOutput).text()) as Record<
-    string,
-    unknown
-  >;
+  const sourceMap: unknown = JSON.parse(await Bun.file(temporaryServerRootMapOutput).text());
+  if (!isObjectRecord(sourceMap)) {
+    throw new TypeError(`Expected ${temporaryServerRootMapOutput} to contain a JSON object.`);
+  }
   sourceMap['file'] = 'index.js';
   await Bun.write(serverRootMapOutput, `${JSON.stringify(sourceMap)}\n`);
 }


### PR DESCRIPTION
## Summary

- Guard the rewritten server source map parse result before mutating it.
- Reuse the existing `isObjectRecord` helper so `packages/components/scripts/build.ts` no longer relies on an unsafe type assertion.

## Root Cause

`main` started failing after `fix: prioritize SSR exports for node (#535)` introduced `JSON.parse(...) as Record<string, unknown>` in the component build script. The repository's type-aware lint rule `typescript-eslint/no-unsafe-type-assertion` rejects that assertion, so both `main-green` lint and the `release` validation workflow failed.

## Validation

- `bun run --filter=@lostgradient/cinder lint`
- `bun run lint`
- `bun run typecheck`
- `bun run --filter=@cinder/diff --filter=@cinder/markdown --filter=@cinder/editor --filter=@cinder/commentary build`
- `bun run test`
- `bun run validate`
- pre-commit hook
- pre-push scoped validation

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build-script-only change with a stricter runtime check; no consumer runtime, auth, or data paths affected.
> 
> **Overview**
> Fixes **type-aware lint** failures on `packages/components/scripts/build.ts` by removing the unsafe `JSON.parse(...) as Record<string, unknown>` cast when rewriting the SSR root **source map** (`index.server.js.map` → `index.js.map`).
> 
> The build now parses the map as **`unknown`**, validates it with the shared **`isObjectRecord`** helper, and throws a **`TypeError`** if the file is not a JSON object before setting **`sourceMap['file'] = 'index.js'`**. Behavior is unchanged for normal Bun output; malformed maps fail fast instead of being assumed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1bf404a35584eb3ba84ee59ec6a67f82546c8f06. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->