### PR TITLE
Fix component documentation README links

### DIFF
--- a/packages/playground/src/component-documentation.test.ts
+++ b/packages/playground/src/component-documentation.test.ts
@@ -65,6 +65,40 @@ describe('buildComponentDocumentation', () => {
     expect(payload.rawArtifacts.variables).toEqual(['--cinder-avatar-group-overlap']);
   });
 
+  it('rewrites component README links to playground component routes', async () => {
+    const payload = await buildComponentDocumentation('modal', await componentManifest('modal'));
+
+    expect(payload.readme.html).toContain('href="/c/confirm-dialog" target="_top"');
+    expect(payload.readme.html).toContain('href="/c/alert-dialog" target="_top"');
+    expect(payload.readme.html).toContain('href="/c/drawer" target="_top"');
+    expect(payload.readme.html).toContain('href="/c/sidebar" target="_top"');
+    expect(payload.readme.html).toContain('href="/c/sheet" target="_top"');
+    expect(payload.readme.html).toContain('href="/c/popover" target="_top"');
+    expect(payload.readme.html).not.toContain('../confirm-dialog/README.md');
+  });
+
+  it('drops README fragments from component route links because page anchors differ', async () => {
+    const payload = await buildComponentDocumentation(
+      'table-cell',
+      await componentManifest('table-cell'),
+    );
+
+    expect(payload.readme.html).toContain('href="/c/table" target="_top"');
+    expect(payload.readme.html).not.toContain('href="/c/table#usage"');
+  });
+
+  it('rewrites non-component README links to GitHub source URLs', async () => {
+    const payload = await buildComponentDocumentation(
+      'collapsible',
+      await componentManifest('collapsible'),
+    );
+
+    expect(payload.readme.html).toContain(
+      'href="https://github.com/stevekinney/cinder/blob/main/packages/components/src/components/collapsible/collapsible.a11y.md" target="_blank" rel="noopener noreferrer"',
+    );
+    expect(payload.readme.html).not.toContain('href="./collapsible.a11y.md"');
+  });
+
   it('reloads the package manifest for each documentation build request', async () => {
     const first = await loadPackageManifestForDocumentation();
     const second = await loadPackageManifestForDocumentation();

--- a/packages/playground/src/component-documentation.ts
+++ b/packages/playground/src/component-documentation.ts
@@ -1,4 +1,4 @@
-import { dirname, join } from 'node:path';
+import { dirname, join, posix } from 'node:path';
 
 import { initializeHighlighter, renderMarkdown } from '@cinder/markdown/rendering';
 
@@ -11,6 +11,7 @@ import type {
   DocumentationReadme,
   JsonValue,
 } from './component-documentation-types.ts';
+import { repositorySourceHref, rewriteRelativeRenderedMarkdownLinks } from './repository-links.ts';
 import type { ComponentManifest } from './types.ts';
 
 const PLAYGROUND_ROOT = dirname(import.meta.dirname);
@@ -268,6 +269,37 @@ function trimReadmeForOverview(markdown: string): string {
   return markdown.replace(leadingTitlePattern, '').replace(generatedSectionWithHeadingPattern, '');
 }
 
+function componentReadmeSourceHref(componentName: string, href: string): string {
+  return repositorySourceHref(`packages/components/src/components/${componentName}`, href);
+}
+
+function componentReadmeHref(
+  componentName: string,
+  href: string,
+  componentIds: ReadonlySet<string>,
+): { href: string; attributes: string } {
+  const [path = ''] = href.split('#', 2);
+  const normalizedPath = posix.normalize(posix.join(componentName, path));
+  const match = normalizedPath.match(/^([a-z0-9][a-z0-9-]*)\/README\.md$/);
+  if (match?.[1] !== undefined && componentIds.has(match[1])) {
+    return { href: `/c/${match[1]}`, attributes: ' target="_top"' };
+  }
+  return {
+    href: componentReadmeSourceHref(componentName, href),
+    attributes: ' target="_blank" rel="noopener noreferrer"',
+  };
+}
+
+export function rewriteComponentReadmeLinks(
+  html: string,
+  componentName: string,
+  componentIds: ReadonlySet<string>,
+): string {
+  return rewriteRelativeRenderedMarkdownLinks(html, (href) =>
+    componentReadmeHref(componentName, href, componentIds),
+  );
+}
+
 export function renderReadmeDocumentation(rawMarkdown: string): DocumentationReadme {
   const trimmed = trimReadmeForOverview(rawMarkdown);
   const rendered = renderMarkdown(normalizeReadmeMarkdownForRendering(trimmed));
@@ -358,7 +390,9 @@ export async function buildComponentDocumentation(
     examplesPromise,
     initializeHighlighter(),
   ]);
+  const componentIds = new Set(packageManifest.components.map((component) => component.id));
   const readme = renderReadmeDocumentation(readmeMarkdown);
+  readme.html = rewriteComponentReadmeLinks(readme.html, componentName, componentIds);
   const manifestEntry: JsonValue = {
     name: entry.name,
     id: entry.id,

--- a/packages/playground/src/playground-server.ts
+++ b/packages/playground/src/playground-server.ts
@@ -63,6 +63,7 @@ import {
   jsonForScriptTag,
   renderShell,
 } from './render-shell.ts';
+import { repositorySourceHref, rewriteRelativeRenderedMarkdownLinks } from './repository-links.ts';
 import {
   BLOCKED_COLOR_VALUE_PATTERN,
   COLOR_TOKEN_NAMES,
@@ -86,7 +87,6 @@ const MAX_PORT_SCAN_ATTEMPTS = 100;
 // import.meta.dirname is packages/playground/src/
 const PLAYGROUND_ROOT = dirname(import.meta.dirname); // packages/playground/
 const COMPONENTS_ROOT = join(PLAYGROUND_ROOT, '..', 'components'); // packages/components/
-const REPOSITORY_README_LINK_BASE = 'https://github.com/stevekinney/cinder/blob/main/';
 
 /**
  * Page-bundle entries: keyed by component name → entry artifact path
@@ -1398,28 +1398,8 @@ function badRequest(message: string): Response {
   return new Response(message, { status: 400, headers: { 'Content-Type': 'text/plain' } });
 }
 
-function isRepositoryRelativeHref(href: string): boolean {
-  return (
-    href !== '' &&
-    !href.startsWith('#') &&
-    !href.startsWith('/') &&
-    !/^[a-z][a-z0-9+.-]*:/i.test(href)
-  );
-}
-
-function repositoryReadmeHref(href: string): string {
-  const normalized = href.replace(/^\.\//, '');
-  return `${REPOSITORY_README_LINK_BASE}${normalized}`;
-}
-
 export function rewriteRepositoryRelativeReadmeLinks(html: string): string {
-  return html.replace(
-    /<a\b([^>]*?)\shref="([^"]+)"([^>]*)>/gi,
-    (match: string, before: string, href: string, after: string) =>
-      isRepositoryRelativeHref(href)
-        ? `<a${before} href="${repositoryReadmeHref(href)}"${after}>`
-        : match,
-  );
+  return rewriteRelativeRenderedMarkdownLinks(html, (href) => repositorySourceHref('', href));
 }
 
 async function renderLandingReadmeHtml(): Promise<string> {

--- a/packages/playground/src/repository-links.ts
+++ b/packages/playground/src/repository-links.ts
@@ -1,0 +1,42 @@
+export const GITHUB_REPOSITORY_URL = 'https://github.com/stevekinney/cinder';
+export const REPOSITORY_BLOB_URL = `${GITHUB_REPOSITORY_URL}/blob/main/`;
+
+export function isRepositoryRelativeHref(href: string): boolean {
+  return (
+    href !== '' &&
+    !href.startsWith('#') &&
+    !href.startsWith('/') &&
+    !/^[a-z][a-z0-9+.-]*:/i.test(href)
+  );
+}
+
+export function repositorySourceHref(basePath: string, href: string): string {
+  const [path = '', hash = ''] = href.split('#', 2);
+  const baseUrl = `https://cinder.local/${basePath}${basePath === '' ? '' : '/'}`;
+  const normalizedPath = new URL(path, baseUrl).pathname.replace(/^\/+/, '');
+  return `${REPOSITORY_BLOB_URL}${normalizedPath}${hash === '' ? '' : `#${hash}`}`;
+}
+
+type ResolvedRenderedMarkdownLink =
+  | string
+  | {
+      href: string;
+      attributes?: string;
+    };
+
+export function rewriteRelativeRenderedMarkdownLinks(
+  html: string,
+  resolveHref: (href: string) => ResolvedRenderedMarkdownLink,
+): string {
+  return html.replace(
+    /<a\b([^>]*?)\shref="([^"]+)"([^>]*)>/gi,
+    (match: string, before: string, href: string, after: string) => {
+      if (!isRepositoryRelativeHref(href)) return match;
+      const resolved = resolveHref(href);
+      if (typeof resolved === 'string') {
+        return `<a${before} href="${resolved}"${after}>`;
+      }
+      return `<a${before} href="${resolved.href}"${resolved.attributes ?? ''}${after}>`;
+    },
+  );
+}

--- a/packages/playground/src/shell-app/top-bar.svelte
+++ b/packages/playground/src/shell-app/top-bar.svelte
@@ -4,6 +4,7 @@
   import { getAnnouncer } from './announcer.svelte.ts';
   import type { ThemeChoice } from './preview-store.svelte.ts';
   import { getPreviewStore } from './preview-store.svelte.ts';
+  import { GITHUB_REPOSITORY_URL } from '../repository-links.ts';
   import { buildIframeSrc } from './routing.ts';
   import {
     Button,
@@ -16,7 +17,6 @@
   const store = getPreviewStore();
   const announcer = getAnnouncer();
 
-  const GITHUB_REPOSITORY_URL = 'https://github.com/stevekinney/cinder';
   const NPM_PACKAGE_URL = 'https://www.npmjs.com/package/@lostgradient/cinder';
 
   // The viewport-size presets (Mobile/Tablet/Desktop/Full + custom px) simulate


### PR DESCRIPTION
## Summary

Fixes #536.

- Rewrite relative links in rendered component README documentation before serving playground payloads.
- Route links to sibling component README files to the corresponding `/c/<component>` page.
- Send other relative README links to the matching GitHub source file so cinder.website does not serve broken relative paths.

## Root Cause

Component READMEs are rendered from files under `packages/components/src/components`, but the rendered HTML is served from playground documentation routes. Relative Markdown links kept their source-file paths, so links like `../confirm-dialog/README.md` or `./collapsible.a11y.md` resolved incorrectly on cinder.website.

## Validation

- `bun run --filter='@cinder/playground' test -- component-documentation.test.ts`
- `bun run --filter='@cinder/playground' typecheck`
- `bun run --filter='@cinder/playground' validate`
- `bun run validate`
- Pre-commit scoped playground typecheck and test
- Pre-push scoped playground lint, typecheck, and test

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Playground/documentation link rewriting only; behavior is covered by new unit tests and does not touch auth, data, or core runtime APIs.
> 
> **Overview**
> Fixes broken relative links in component README HTML served from playground documentation routes (e.g. on cinder.website) by rewriting them after markdown render.
> 
> **Component docs** (`buildComponentDocumentation`): relative links to another component’s `README.md` become in-app routes (`/c/<id>` with `target="_top"`); hash fragments are dropped on those routes because overview anchors don’t match. Other relative paths (e.g. `.a11y.md`) point at the matching **GitHub** `blob/main` source with `target="_blank"`.
> 
> **Shared helper** `repository-links.ts` centralizes repo URL constants, relative-href detection, path normalization for GitHub URLs, and a generic HTML `<a href>` rewriter. The root landing README and the shell top-bar GitHub link use the same module; inline duplication in `playground-server.ts` was removed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 56a157ea2978d13f0b3d10a7f073e3e47123c690. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->