### PR TITLE
Fix NavigationBar desktop inert regression

### DIFF
--- a/packages/components/src/components/navigation-bar/navigation-bar.svelte
+++ b/packages/components/src/components/navigation-bar/navigation-bar.svelte
@@ -162,7 +162,6 @@
     id={regionId}
     class="cinder-navigation-bar__items"
     data-open={mobileMenuOpen ? 'true' : 'false'}
-    inert={isCollapsible && !mobileMenuOpen ? true : undefined}
   >
     {@render items({ variant, placement, showLabels })}
   </div>

--- a/packages/components/src/components/navigation-bar/navigation-bar.test.ts
+++ b/packages/components/src/components/navigation-bar/navigation-bar.test.ts
@@ -290,6 +290,17 @@ describe('NavigationBar', () => {
     ).toBe('false');
   });
 
+  test('items region does not receive inert when menuToggle is present and menu is closed', () => {
+    const { container } = render(NavigationBar, {
+      items: textSnippet('items'),
+      menuToggle: toggleSnippet(),
+    });
+
+    expect(container.querySelector('.cinder-navigation-bar__items')?.hasAttribute('inert')).toBe(
+      false,
+    );
+  });
+
   // ── menuToggle snippet and ARIA ──────────────────────────────────────────
 
   test('with menuToggle, toggle button receives aria-expanded="false" initially', () => {
@@ -334,6 +345,9 @@ describe('NavigationBar', () => {
     expect(
       container.querySelector('.cinder-navigation-bar__items')?.getAttribute('data-open'),
     ).toBe('true');
+    expect(container.querySelector('.cinder-navigation-bar__items')?.hasAttribute('inert')).toBe(
+      false,
+    );
   });
 
   test('clicking the toggle a second time closes the menu', async () => {

--- a/packages/components/src/components/navigation-bar/navigation-bar.test.ts
+++ b/packages/components/src/components/navigation-bar/navigation-bar.test.ts
@@ -296,9 +296,9 @@ describe('NavigationBar', () => {
       menuToggle: toggleSnippet(),
     });
 
-    expect(container.querySelector('.cinder-navigation-bar__items')?.hasAttribute('inert')).toBe(
-      false,
-    );
+    const itemsRegion = container.querySelector('.cinder-navigation-bar__items');
+    expect(itemsRegion).not.toBeNull();
+    expect(itemsRegion?.hasAttribute('inert')).toBe(false);
   });
 
   // ── menuToggle snippet and ARIA ──────────────────────────────────────────
@@ -342,12 +342,12 @@ describe('NavigationBar', () => {
     });
     const toggle = container.querySelector('#toggle-btn') as HTMLElement;
     await fireEvent.click(toggle);
+    const itemsRegion = container.querySelector('.cinder-navigation-bar__items');
     expect(
-      container.querySelector('.cinder-navigation-bar__items')?.getAttribute('data-open'),
+      itemsRegion?.getAttribute('data-open'),
     ).toBe('true');
-    expect(container.querySelector('.cinder-navigation-bar__items')?.hasAttribute('inert')).toBe(
-      false,
-    );
+    expect(itemsRegion).not.toBeNull();
+    expect(itemsRegion?.hasAttribute('inert')).toBe(false);
   });
 
   test('clicking the toggle a second time closes the menu', async () => {


### PR DESCRIPTION
## Why
When `NavigationBar` is configured with a `menuToggle` snippet, the items container was getting `inert` whenever the menu was closed. On desktop widths, the items are visible in that state, so `inert` made visible navigation links unclickable and removed them from keyboard/assistive navigation.

## What changed
- Removed `inert` from the navigation items container in `navigation-bar.svelte`.
- Added regression tests in `navigation-bar.test.ts` to assert the items region never gets the `inert` attribute, both when closed and after opening via the toggle.

## Notes
This keeps the existing CSS-driven mobile panel behavior (`data-open`, visibility, and pointer-events rules) while preventing desktop interaction breakage.

Fixes: #550

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small template change in a navigation component with tests; no auth or data paths, and mobile hiding still uses CSS per existing a11y design.
> 
> **Overview**
> Fixes a regression where **`NavigationBar`** with a **`menuToggle`** put **`inert`** on the items container whenever the mobile menu was closed. On wide viewports those items stay visible, so **`inert`** blocked clicks and keyboard/AT access to primary nav links.
> 
> The items region no longer gets **`inert`**; responsive behavior still relies on **`data-open`** and existing CSS (visibility, pointer-events). Tests assert the items region never has **`inert`**, closed or after opening the toggle.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b21ff65eb96896be90830ba23dfc69963b1aeea0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->