### PR TITLE
Restore deprecated Alert "error" variant alias

### DIFF
--- a/packages/components/src/components/alert/README.md
+++ b/packages/components/src/components/alert/README.md
@@ -16,14 +16,14 @@ A status message that communicates contextual feedback and can optionally be dis
 
 <!-- generated:props:start -->
 
-| Prop          | Type                                                 | Required | Default  | Description                                                                                                                |
-| ------------- | ---------------------------------------------------- | -------- | -------- | -------------------------------------------------------------------------------------------------------------------------- |
-| `class`       | `string`                                             | no       | —        | Custom class merged with `.cinder-alert`.                                                                                  |
-| `dismissible` | `boolean`                                            | no       | `false`  | Allow the alert to be dismissed.                                                                                           |
-| `variant`     | `"info"` \| `"success"` \| `"warning"` \| `"danger"` | no       | `"info"` | Visual severity variant. `danger` is the canonical failure-severity spelling, consistent with banner and callout.          |
-| `children`    | `(opaque)`                                           | yes      | —        | A function or snippet prop. Its shape is not captured by the JSON schema; see the component types for the exact signature. |
-| `icon`        | `(opaque)`                                           | no       | —        | A function or snippet prop. Its shape is not captured by the JSON schema; see the component types for the exact signature. |
-| `ondismiss`   | `(opaque)`                                           | no       | —        | A function or snippet prop. Its shape is not captured by the JSON schema; see the component types for the exact signature. |
+| Prop          | Type                                                              | Required | Default  | Description                                                                                                                                                       |
+| ------------- | ----------------------------------------------------------------- | -------- | -------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `class`       | `string`                                                          | no       | —        | Custom class merged with `.cinder-alert`.                                                                                                                         |
+| `dismissible` | `boolean`                                                         | no       | `false`  | Allow the alert to be dismissed.                                                                                                                                  |
+| `variant`     | `"info"` \| `"success"` \| `"warning"` \| `"danger"` \| `"error"` | no       | `"info"` | Visual severity variant. `danger` is the canonical failure-severity spelling, consistent with banner and callout. `error` remains accepted as a deprecated alias. |
+| `children`    | `(opaque)`                                                        | yes      | —        | A function or snippet prop. Its shape is not captured by the JSON schema; see the component types for the exact signature.                                        |
+| `icon`        | `(opaque)`                                                        | no       | —        | A function or snippet prop. Its shape is not captured by the JSON schema; see the component types for the exact signature.                                        |
+| `ondismiss`   | `(opaque)`                                                        | no       | —        | A function or snippet prop. Its shape is not captured by the JSON schema; see the component types for the exact signature.                                        |
 
 <!-- generated:props:end -->
 

--- a/packages/components/src/components/alert/alert.schema.json
+++ b/packages/components/src/components/alert/alert.schema.json
@@ -3,8 +3,8 @@
   "type": "object",
   "properties": {
     "variant": {
-      "enum": ["info", "success", "warning", "danger"],
-      "description": "Visual severity variant. `danger` is the canonical failure-severity spelling, consistent with banner and callout.",
+      "enum": ["info", "success", "warning", "danger", "error"],
+      "description": "Visual severity variant. `danger` is the canonical failure-severity spelling, consistent with banner and callout.\n`error` remains accepted as a deprecated alias.",
       "default": "info"
     },
     "dismissible": {

--- a/packages/components/src/components/alert/alert.schema.ts
+++ b/packages/components/src/components/alert/alert.schema.ts
@@ -5,9 +5,9 @@ const schema = {
   type: 'object',
   properties: {
     variant: {
-      enum: ['info', 'success', 'warning', 'danger'],
+      enum: ['info', 'success', 'warning', 'danger', 'error'],
       description:
-        'Visual severity variant. `danger` is the canonical failure-severity spelling, consistent with banner and callout.',
+        'Visual severity variant. `danger` is the canonical failure-severity spelling, consistent with banner and callout.\n`error` remains accepted as a deprecated alias.',
       default: 'info',
     },
     dismissible: {

--- a/packages/components/src/components/alert/alert.svelte
+++ b/packages/components/src/components/alert/alert.svelte
@@ -35,7 +35,7 @@
     ...rest
   }: AlertProps = $props();
 
-  const resolvedVariant = $derived(variant);
+  const resolvedVariant = $derived(variant === 'error' ? 'danger' : variant);
 
   let visible = $state(true);
   let rootElement: HTMLDivElement | undefined = $state();

--- a/packages/components/src/components/alert/alert.test.ts
+++ b/packages/components/src/components/alert/alert.test.ts
@@ -236,9 +236,17 @@ describe('Alert rendering', () => {
 
   test('variant="danger" stamps data-cinder-variant="danger" — canonical failure-severity spelling', () => {
     // danger is the canonical severity spelling matching banner and callout.
-    // No alias normalization occurs; the data attribute value equals the prop value.
     const { container } = render(Alert, {
       props: { variant: 'danger', children: emptySnippet },
+    });
+    expect(container.querySelector('.cinder-alert')?.getAttribute('data-cinder-variant')).toBe(
+      'danger',
+    );
+  });
+
+  test('variant="error" normalizes to data-cinder-variant="danger" for backward compatibility', () => {
+    const { container } = render(Alert, {
+      props: { variant: 'error', children: emptySnippet },
     });
     expect(container.querySelector('.cinder-alert')?.getAttribute('data-cinder-variant')).toBe(
       'danger',

--- a/packages/components/src/components/alert/alert.types.test.ts
+++ b/packages/components/src/components/alert/alert.types.test.ts
@@ -23,7 +23,7 @@ import type { AlertProps } from './alert.types.ts';
 // runtime). The snapshot mirrors that omit set so the assertions verify the
 // reduced surface rather than pinning the pre-P6-C2 shape.
 
-type _SnapshotAlertVariant = 'info' | 'success' | 'warning' | 'danger';
+type _SnapshotAlertVariant = 'info' | 'success' | 'warning' | 'danger' | 'error';
 
 type SnapshotAlertProps = Omit<
   HTMLAttributes<HTMLDivElement>,

--- a/packages/components/src/components/alert/alert.types.ts
+++ b/packages/components/src/components/alert/alert.types.ts
@@ -2,7 +2,13 @@ import type { Snippet } from 'svelte';
 import type { HTMLAttributes } from 'svelte/elements';
 
 /** Visual severity variants for the Alert component. `danger` is the canonical spelling shared by banner and callout. */
-export type AlertVariant = 'info' | 'success' | 'warning' | 'danger';
+export type AlertVariant =
+  | 'info'
+  | 'success'
+  | 'warning'
+  | 'danger'
+  /** @deprecated Use `danger`. */
+  | 'error';
 
 /**
  * Props for the {@link Alert} component — a live-region notification card.
@@ -38,6 +44,7 @@ export type AlertProps = Omit<
 export interface AlertSchemaProps {
   /**
    * Visual severity variant. `danger` is the canonical failure-severity spelling, consistent with banner and callout.
+   * `error` remains accepted as a deprecated alias.
    * @default "info"
    */
   variant?: AlertVariant;


### PR DESCRIPTION
TypeScript consumers upgrading to 0.4.x lost the documented migration path for Alert severity naming: `variant="error"` became a hard type error even though migration guidance described it as a still-accepted deprecated alias. This change restores compatibility so existing call sites compile while preserving `danger` as the canonical spelling.

## What changed
- Reintroduced `"error"` in `AlertVariant` as a deprecated alias (`@deprecated Use `danger`.`).
- Normalized runtime behavior in `Alert` so `variant="error"` maps to `data-cinder-variant="danger"`, keeping styling and semantics aligned with the canonical variant.
- Updated Alert schema and generated docs to include `error` as an accepted deprecated alias while continuing to describe `danger` as canonical.
- Added test coverage for alias normalization and updated type-surface snapshot tests so this compatibility contract cannot drift.

## Notes for reviewers
This is a compatibility restoration for existing consumers, not a reversal of canonical naming. `danger` remains the preferred and documented spelling; `error` exists only as a deprecated bridge.

Fixes: #561

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Backward-compatible API and runtime alias normalization only; no auth, data, or behavioral changes beyond mapping `error` to `danger` on the data attribute.
> 
> **Overview**
> Restores **`variant="error"`** on Alert so TypeScript call sites that still use the old severity name compile again, while **`danger`** stays the canonical variant.
> 
> **`AlertVariant`** again includes **`error`** (marked **`@deprecated Use danger`**). In **`alert.svelte`**, **`resolvedVariant`** maps **`error` → `danger`** for **`data-cinder-variant`**, so styling and semantics match **`danger`** without exposing **`error`** on the DOM. JSON schema and generated README props document **`error`** as an accepted deprecated alias.
> 
> Tests assert **`variant="error"`** yields **`data-cinder-variant="danger"`**, and the **`AlertProps`** snapshot includes **`error`** so the public surface cannot regress.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fe6ddb29feada2603f3167839931f4217a16f877. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->