### PR TITLE
Fix missing source map warnings in published dist artifacts

### DIFF
--- a/packages/components/scripts/pack-for-publish.test.ts
+++ b/packages/components/scripts/pack-for-publish.test.ts
@@ -232,4 +232,11 @@ describe('buildPublishedManifest', () => {
     expect(stripped.strippedCount).toBe(0);
     expect(stripped.text).toBe(input);
   });
+
+  it('strips dangling block sourceMappingURL comments when corresponding .map files are absent', () => {
+    const input = 'export const value = 1;\n/*# sourceMappingURL=index.js.map */\n';
+    const stripped = stripDanglingSourceMapUrlComments(input, () => false);
+    expect(stripped.strippedCount).toBe(1);
+    expect(stripped.text).toBe('export const value = 1;\n');
+  });
 });

--- a/packages/components/scripts/pack-for-publish.test.ts
+++ b/packages/components/scripts/pack-for-publish.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from 'bun:test';
 
-import { buildPublishedManifest, type SourceManifest } from './pack-for-publish.ts';
+import {
+  buildPublishedManifest,
+  stripDanglingSourceMapUrlComments,
+  type SourceManifest,
+} from './pack-for-publish.ts';
 
 describe('buildPublishedManifest', () => {
   it('keeps Svelte test-harness exclusions after broad Svelte includes', () => {
@@ -60,6 +64,19 @@ describe('buildPublishedManifest', () => {
     const files = published.files ?? [];
 
     expect(files).toContain('src/styles/base-guard.ts');
+  });
+
+  it('keeps dist .js.map files excluded from the published tarball', () => {
+    const manifest: SourceManifest = {
+      name: '@lostgradient/cinder',
+      version: '0.0.0',
+      exports: {},
+    };
+
+    const published = buildPublishedManifest(manifest, []);
+    const files = published.files ?? [];
+
+    expect(files).toContain('!dist/**/*.js.map');
   });
 
   it('rewrites source-backed runtime exports to built browser artifacts in the published manifest', () => {
@@ -200,5 +217,19 @@ describe('buildPublishedManifest', () => {
     expect(files).toContain('src/components/**/*.examples.json');
     expect(files).toContain('src/components/**/*.constraints.json');
     expect(files).not.toContain('src/components/**/*.json');
+  });
+
+  it('strips dangling sourceMappingURL comments when corresponding .map files are absent', () => {
+    const input = 'export const value = 1;\n//# sourceMappingURL=index.js.map\n';
+    const stripped = stripDanglingSourceMapUrlComments(input, () => false);
+    expect(stripped.strippedCount).toBe(1);
+    expect(stripped.text).toBe('export const value = 1;\n');
+  });
+
+  it('keeps sourceMappingURL comments when the corresponding .map file exists', () => {
+    const input = 'export const value = 1;\n//# sourceMappingURL=index.js.map\n';
+    const stripped = stripDanglingSourceMapUrlComments(input, () => true);
+    expect(stripped.strippedCount).toBe(0);
+    expect(stripped.text).toBe(input);
   });
 });

--- a/packages/components/scripts/pack-for-publish.ts
+++ b/packages/components/scripts/pack-for-publish.ts
@@ -65,6 +65,11 @@ type SourceManifest = {
   exports: ExportsMap;
 };
 
+type SourceMapStripResult = {
+  text: string;
+  strippedCount: number;
+};
+
 /**
  * Read the source manifest. Throws if the file is missing.
  */
@@ -296,6 +301,81 @@ function buildPublishedManifest(
   return published;
 }
 
+function isResolvableRelativeSourceMapReference(reference: string): boolean {
+  if (!reference.endsWith('.map')) return false;
+  if (reference.startsWith('data:')) return false;
+  if (reference.startsWith('file:')) return false;
+  return !/^[a-z]+:\/\//iu.test(reference);
+}
+
+export function stripDanglingSourceMapUrlComments(
+  text: string,
+  hasSourceMap: (reference: string) => boolean,
+): SourceMapStripResult {
+  let strippedCount = 0;
+  const outputLines: string[] = [];
+  const lines = text.split('\n');
+  for (const line of lines) {
+    const lineCommentMatch = line.match(/^\s*\/\/[#@]\s*sourceMappingURL=([^\s]+)\s*$/u);
+    if (lineCommentMatch) {
+      const reference = lineCommentMatch[1];
+      if (
+        reference &&
+        isResolvableRelativeSourceMapReference(reference) &&
+        !hasSourceMap(reference)
+      ) {
+        strippedCount += 1;
+        continue;
+      }
+    }
+
+    const blockCommentMatch = line.match(/^\s*\/\*#\s*sourceMappingURL=([^*\s]+)\s*\*\/\s*$/u);
+    if (blockCommentMatch) {
+      const reference = blockCommentMatch[1];
+      if (
+        reference &&
+        isResolvableRelativeSourceMapReference(reference) &&
+        !hasSourceMap(reference)
+      ) {
+        strippedCount += 1;
+        continue;
+      }
+    }
+
+    outputLines.push(line);
+  }
+
+  const outputText = outputLines.join('\n');
+  if (outputText.length === 0) {
+    return { text: outputText, strippedCount };
+  }
+  if (!text.endsWith('\n') && outputText.endsWith('\n')) {
+    return { text: outputText.slice(0, -1), strippedCount };
+  }
+  if (text.endsWith('\n') && !outputText.endsWith('\n')) {
+    return { text: `${outputText}\n`, strippedCount };
+  }
+  return { text: outputText, strippedCount };
+}
+
+async function stripDanglingSourceMapCommentsInStaging(): Promise<number> {
+  const scriptGlob = new Glob('dist/**/*.{js,mjs,cjs}');
+  let strippedCount = 0;
+  for await (const relative of scriptGlob.scan({ cwd: stagingRoot })) {
+    const filePath = join(stagingRoot, relative);
+    const original = await Bun.file(filePath).text();
+    if (!original.includes('sourceMappingURL=')) continue;
+    const fileDirectory = dirname(filePath);
+    const stripped = stripDanglingSourceMapUrlComments(original, (reference) =>
+      existsSync(join(fileDirectory, reference)),
+    );
+    if (stripped.strippedCount === 0) continue;
+    await Bun.write(filePath, stripped.text);
+    strippedCount += stripped.strippedCount;
+  }
+  return strippedCount;
+}
+
 /**
  * Copy a file relative to `packageRoot` into the same relative path under
  * `stagingRoot`. Creates intermediate directories as needed.
@@ -357,6 +437,12 @@ async function stageFiles(manifest: SourceManifest): Promise<void> {
       await rm(join(stagingRoot, relative), { force: true, recursive: true });
     }
   }
+
+  // `build.ts` emits `//# sourceMappingURL=*.map` comments for dist JS outputs,
+  // while the publish manifest intentionally excludes `dist/**/*.js.map`. Strip
+  // dangling source-map references from staged JS files so consumer bundlers
+  // do not warn about missing map files.
+  await stripDanglingSourceMapCommentsInStaging();
 
   // Always include README and LICENSE if present, regardless of `files`.
   for (const additional of ['README.md', 'LICENSE', 'LICENSE.md', 'CHANGELOG.md']) {


### PR DESCRIPTION
Consumers were getting Vite `Failed to load source map` warnings because published `dist` JS files kept `sourceMappingURL` comments while `dist/**/*.js.map` files were intentionally excluded from the tarball.

This keeps map files excluded and fixes the publish pipeline by stripping dangling `sourceMappingURL` comments from staged `dist/**/*.{js,mjs,cjs}` files when the referenced map file is absent. The stripping logic is isolated in `pack-for-publish.ts` so source manifests remain non-mutating and behavior is scoped to publish staging.

I also added regression tests to lock in both sides of the contract:
- `.js.map` files stay excluded from published files.
- dangling `sourceMappingURL` comments are removed, while valid ones are preserved.

Fixes: #562

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to publish staging only; does not change build output in the repo or ship source maps—only avoids misleading map references in the npm artifact.
> 
> **Overview**
> Fixes consumer bundler warnings (e.g. Vite **Failed to load source map**) when installing the published tarball: **`dist/**/*.js.map` stays excluded**, but build output still carried **`sourceMappingURL`** comments pointing at those missing files.
> 
> The publish staging step now scans **`dist/**/*.{js,mjs,cjs}`** and removes **line and block** `sourceMappingURL` comments only when the referenced relative `.map` file is not present on disk; comments are kept when the map exists. Logic lives in exported **`stripDanglingSourceMapUrlComments`** so the source **`package.json`** is unchanged.
> 
> Regression tests assert **`!dist/**/*.js.map`** remains in the published **`files`** list and cover strip vs preserve behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 42e29b5604fc514e45928d2cee50a98da9851df4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->