### PR TITLE
Fix NavigationBar menuToggle SSR hang in SvelteKit

### DIFF
--- a/packages/components/fixtures/sveltekit-consumer/src/routes/+page.svelte
+++ b/packages/components/fixtures/sveltekit-consumer/src/routes/+page.svelte
@@ -36,6 +36,7 @@
   let modalOpen = $state(false);
   let dropdownOpen = $state(false);
   let expandedIds = $state<string[]>([]);
+  let mobileMenuOpen = $state(false);
   const useHistoryExportIsFunction = typeof useHistory === 'function';
 </script>
 
@@ -93,9 +94,20 @@
   </section>
 
   <section aria-label="NavigationBar">
-    <NavigationBar>
-      {#snippet items({ variant })}<NavigationItem {variant} href="/">Home</NavigationItem
-        >{/snippet}
+    <NavigationBar bind:mobileMenuOpen>
+      {#snippet menuToggle(attrs)}
+        <button
+          type="button"
+          data-fixture-nav-toggle="barrel"
+          {...attrs}
+          aria-label={mobileMenuOpen ? 'Close menu' : 'Open menu'}
+        >
+          Menu
+        </button>
+      {/snippet}
+      {#snippet items({ variant })}
+        <NavigationItem {variant} href="/">Home</NavigationItem>
+      {/snippet}
     </NavigationBar>
   </section>
 

--- a/packages/components/fixtures/sveltekit-consumer/src/routes/subpath/+page.svelte
+++ b/packages/components/fixtures/sveltekit-consumer/src/routes/subpath/+page.svelte
@@ -31,6 +31,7 @@
   let modalOpen = $state(false);
   let dropdownOpen = $state(false);
   let expandedIds = $state<string[]>([]);
+  let mobileMenuOpen = $state(false);
 </script>
 
 <main>
@@ -88,9 +89,20 @@
   </section>
 
   <section aria-label="NavigationBar">
-    <NavigationBar>
-      {#snippet items()}<NavigationItem href="/subpath" active={true}>Subpath</NavigationItem
-        >{/snippet}
+    <NavigationBar bind:mobileMenuOpen>
+      {#snippet menuToggle(attrs)}
+        <button
+          type="button"
+          data-fixture-nav-toggle="subpath"
+          {...attrs}
+          aria-label={mobileMenuOpen ? 'Close menu' : 'Open menu'}
+        >
+          Menu
+        </button>
+      {/snippet}
+      {#snippet items({ variant })}
+        <NavigationItem {variant} href="/subpath" active={true}>Subpath</NavigationItem>
+      {/snippet}
     </NavigationBar>
   </section>
 

--- a/packages/components/scripts/validate-consumers.ts
+++ b/packages/components/scripts/validate-consumers.ts
@@ -904,7 +904,11 @@ async function runSveltekitFixture(label = 'workspace', svelteVersion?: string):
       await waitForUrl(`http://127.0.0.1:${httpPort}/`, 10_000, fixtureServer);
 
       // Barrel page
-      const response = await fetch(`http://127.0.0.1:${httpPort}/`);
+      const response = await fetchWithTimeout(
+        `http://127.0.0.1:${httpPort}/`,
+        10_000,
+        'sveltekit-consumer / SSR',
+      );
       if (response.status !== 200) fail(`fixture / returned ${response.status}, want 200`);
       const body = await response.text();
       for (const cls of ALWAYS_RENDERED_CLASSES) {
@@ -929,9 +933,18 @@ async function runSveltekitFixture(label = 'workspace', svelteVersion?: string):
       if (!body.includes('cinder-share-card')) {
         fail(`fixture HTML (/) does not contain class "cinder-share-card" (ShareCard did not SSR)`);
       }
+      if (!body.includes('data-fixture-nav-toggle="barrel"')) {
+        fail(
+          'fixture HTML (/) is missing the NavigationBar menuToggle trigger marker (barrel route SSR did not render the toggle snippet)',
+        );
+      }
 
       // Subpath page
-      const subpathResponse = await fetch(`http://127.0.0.1:${httpPort}/subpath`);
+      const subpathResponse = await fetchWithTimeout(
+        `http://127.0.0.1:${httpPort}/subpath`,
+        10_000,
+        'sveltekit-consumer /subpath SSR',
+      );
       if (subpathResponse.status !== 200)
         fail(`fixture /subpath returned ${subpathResponse.status}, want 200`);
       const subpathBody = await subpathResponse.text();
@@ -939,6 +952,11 @@ async function runSveltekitFixture(label = 'workspace', svelteVersion?: string):
         if (!subpathBody.includes(cls)) {
           fail(`fixture HTML (/subpath) does not contain class "${cls}"`);
         }
+      }
+      if (!subpathBody.includes('data-fixture-nav-toggle="subpath"')) {
+        fail(
+          'fixture HTML (/subpath) is missing the NavigationBar menuToggle trigger marker (subpath route SSR did not render the toggle snippet)',
+        );
       }
 
       async function assertRenderedRouteServesButtonCss(
@@ -952,7 +970,11 @@ async function runSveltekitFixture(label = 'workspace', svelteVersion?: string):
         // fragile on-disk path resolution (relative hrefs like
         // `../_app/immutable/...` would otherwise resolve outside the client
         // output directory and silently be skipped).
-        const routeResponse = await fetch(`http://127.0.0.1:${httpPort}${routePath}`);
+        const routeResponse = await fetchWithTimeout(
+          `http://127.0.0.1:${httpPort}${routePath}`,
+          10_000,
+          `sveltekit-consumer ${routePath} SSR`,
+        );
         if (routeResponse.status !== 200) {
           fail(`fixture ${routePath} returned ${routeResponse.status}, want 200`);
         }
@@ -978,7 +1000,11 @@ async function runSveltekitFixture(label = 'workspace', svelteVersion?: string):
         let buttonCssServed = false;
         for (const href of stylesheetHrefs) {
           const stylesheetUrl = new URL(href, routeUrl).toString();
-          const stylesheetResponse = await fetch(stylesheetUrl);
+          const stylesheetResponse = await fetchWithTimeout(
+            stylesheetUrl,
+            10_000,
+            `${routePath} stylesheet fetch`,
+          );
           if (stylesheetResponse.status !== 200) {
             fail(
               `${routePath} references stylesheet ${href} (resolved to ${stylesheetUrl}) which returned ${stylesheetResponse.status} — cannot verify the ${contractLabel} styles contract`,
@@ -1186,6 +1212,19 @@ async function waitForUrl(
     await Bun.sleep(200);
   }
   fail(`timeout waiting for ${url}`);
+}
+
+async function fetchWithTimeout(
+  url: string,
+  timeoutMs: number,
+  description: string,
+): Promise<Response> {
+  try {
+    return await fetch(url, { signal: AbortSignal.timeout(timeoutMs) });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    fail(`${description} failed or timed out after ${timeoutMs}ms: ${message}`);
+  }
 }
 
 async function runNodeFixture(): Promise<void> {

--- a/packages/components/src/components/navigation-bar/navigation-bar.a11y.md
+++ b/packages/components/src/components/navigation-bar/navigation-bar.a11y.md
@@ -14,7 +14,7 @@ When a `menuToggle` snippet is provided, the component injects a `NavigationBarT
 type NavigationBarToggleAttributes = {
   'aria-expanded': 'true' | 'false';
   'aria-controls': string; // the id of the collapsible items region
-  onclick: (event: MouseEvent) => void;
+  onclick?: (event: MouseEvent) => void; // omitted during SSR
 };
 ```
 
@@ -46,7 +46,7 @@ Consumer `onkeydown` handlers passed via rest props are also respected: the cons
 
 When the user presses Escape to close the menu, focus is returned to the toggle button that opened it. This focus-return guarantee requires that the consumer's `menuToggle` snippet spreads `toggleAttributes.onclick` onto a native `<button>` element so `event.currentTarget` is a real focusable DOM element.
 
-If a consumer wraps the toggle in a custom component without ensuring the native button receives `onclick` directly, Escape still closes the menu but focus does not move. This is a documented degradation, not a bug.
+If a consumer wraps the toggle in a custom component without ensuring the native button receives `onclick` directly (when present on the client), Escape still closes the menu but focus does not move. This is a documented degradation, not a bug.
 
 ## Disclosure, Not Modal
 

--- a/packages/components/src/components/navigation-bar/navigation-bar.a11y.md
+++ b/packages/components/src/components/navigation-bar/navigation-bar.a11y.md
@@ -44,9 +44,9 @@ Consumer `onkeydown` handlers passed via rest props are also respected: the cons
 
 ## Focus Return
 
-When the user presses Escape to close the menu, focus is returned to the toggle button that opened it. This focus-return guarantee requires that the consumer's `menuToggle` snippet spreads `toggleAttributes.onclick` onto a native `<button>` element so `event.currentTarget` is a real focusable DOM element.
+When the user presses Escape to close the menu, focus is returned to the toggle button that opened it. This focus-return guarantee requires that, on the client, the consumer's `menuToggle` snippet spreads `toggleAttributes.onclick` onto a native `<button>` element so `event.currentTarget` is a real focusable DOM element.
 
-If a consumer wraps the toggle in a custom component without ensuring the native button receives `onclick` directly (when present on the client), Escape still closes the menu but focus does not move. This is a documented degradation, not a bug.
+If a consumer wraps the toggle in a custom component without ensuring the native button receives `onclick` directly, Escape still closes the menu but focus does not move. This is a documented degradation, not a bug.
 
 ## Disclosure, Not Modal
 

--- a/packages/components/src/components/navigation-bar/navigation-bar.svelte
+++ b/packages/components/src/components/navigation-bar/navigation-bar.svelte
@@ -24,6 +24,7 @@
 
 <script lang="ts">
   import type { NavigationBarProps, NavigationVariant } from './navigation-bar.types.ts';
+  import { BROWSER as browser } from 'esm-env';
   import { classNames } from '../../utilities/class-names.ts';
 
   const regionId = $props.id();
@@ -152,7 +153,7 @@
       {@render menuToggle({
         'aria-expanded': (mobileMenuOpen ? 'true' : 'false') as 'true' | 'false',
         'aria-controls': regionId,
-        onclick: handleToggle,
+        ...(browser ? { onclick: handleToggle } : {}),
       })}
     </div>
   {/if}

--- a/packages/components/src/components/navigation-bar/navigation-bar.test.ts
+++ b/packages/components/src/components/navigation-bar/navigation-bar.test.ts
@@ -44,7 +44,7 @@ function toggleSnippet(buttonId = 'toggle-btn') {
       {
         'aria-expanded': string;
         'aria-controls': string;
-        onclick: (event: MouseEvent) => void;
+        onclick?: (event: MouseEvent) => void;
       },
     ]
   >((getAttrs) => ({
@@ -53,7 +53,9 @@ function toggleSnippet(buttonId = 'toggle-btn') {
       const attrs = getAttrs();
       element.setAttribute('aria-expanded', attrs['aria-expanded']);
       element.setAttribute('aria-controls', attrs['aria-controls']);
-      element.addEventListener('click', attrs.onclick as EventListener);
+      if (attrs.onclick) {
+        element.addEventListener('click', attrs.onclick as EventListener);
+      }
     },
   }));
 }
@@ -64,7 +66,7 @@ function glyphToggleSnippet(buttonId = 'toggle-glyph-btn') {
       {
         'aria-expanded': string;
         'aria-controls': string;
-        onclick: (event: MouseEvent) => void;
+        onclick?: (event: MouseEvent) => void;
       },
     ]
   >((getAttrs) => ({
@@ -74,7 +76,9 @@ function glyphToggleSnippet(buttonId = 'toggle-glyph-btn') {
       const attrs = getAttrs();
       element.setAttribute('aria-expanded', attrs['aria-expanded']);
       element.setAttribute('aria-controls', attrs['aria-controls']);
-      element.addEventListener('click', attrs.onclick as EventListener);
+      if (attrs.onclick) {
+        element.addEventListener('click', attrs.onclick as EventListener);
+      }
     },
   }));
 }

--- a/packages/components/src/components/navigation-bar/navigation-bar.types.test.ts
+++ b/packages/components/src/components/navigation-bar/navigation-bar.types.test.ts
@@ -25,7 +25,6 @@ const _navigationBarItemsContext: NavigationBarItemsContext = {
 const _navigationBarToggleAttributes: NavigationBarToggleAttributes = {
   'aria-expanded': 'false',
   'aria-controls': 'menu-id',
-  onclick: () => {},
 };
 const _navigationVariant: NavigationVariant = 'horizontal';
 const _navigationPlacement: NavigationBarPlacement = 'bottom';

--- a/packages/components/src/components/navigation-bar/navigation-bar.types.ts
+++ b/packages/components/src/components/navigation-bar/navigation-bar.types.ts
@@ -7,7 +7,8 @@ export type NavigationBarLabelVisibility = 'always' | 'active' | 'never';
 export type NavigationBarToggleAttributes = {
   'aria-expanded': 'true' | 'false';
   'aria-controls': string;
-  onclick: (event: MouseEvent) => void;
+  /** Client-only click handler. Omitted during SSR to avoid forwarding function props in server markup. */
+  onclick?: (event: MouseEvent) => void;
 };
 /** Context passed to the items snippet so items can adapt their layout. */
 export type NavigationBarItemsContext = {


### PR DESCRIPTION
`NavigationBar` could cause SvelteKit SSR responses to hang when consumers provided a `menuToggle` snippet and spread forwarded attributes onto a native button. This change keeps the existing menu behavior but makes the toggle contract SSR-safe.

## What changed

- Updated `NavigationBar` to only forward the `onclick` toggle handler in browser/client execution, avoiding function-valued snippet attributes during SSR.
- Updated `NavigationBarToggleAttributes` to make `onclick` optional and aligned related type tests/docs.
- Expanded `sveltekit-consumer` fixture routes (`/` and `/subpath`) to render `NavigationBar` with `menuToggle` snippets that spread attrs.
- Hardened `validate-consumers` SSR checks with timeout-backed fetches and explicit assertions that the fixture toggle markers render in SSR HTML.

## Notes for reviewers

- The behavior change is intentionally narrow: ARIA attributes and toggle behavior are preserved, while SSR no longer receives function-valued forwarded attributes.
- `validate:consumer` is currently blocked by an unrelated pre-existing meter sidecar lint/build failure (`packages/components/src/components/meter/meter.css` selector anchoring), which occurs before consumer SSR assertions execute.

## Validation

- `bun run --filter=@lostgradient/cinder test ./src/components/navigation-bar/navigation-bar.test.ts ./src/components/navigation-bar/navigation-bar.types.test.ts`
- `bun run --filter=@lostgradient/cinder validate:consumer` (blocked by the existing meter.css issue above)

Fixes: #553

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches responsive nav toggle behavior and SSR markup for a widely used shell component, but the runtime change is narrowly scoped to when `onclick` is forwarded.
> 
> **Overview**
> Fixes **SvelteKit SSR hangs** when `NavigationBar` consumers use a `menuToggle` snippet that spreads forwarded attrs (including `onclick`) onto a button.
> 
> **`NavigationBar`** now adds `onclick: handleToggle` only when `esm-env` reports a browser environment, so server renders still get `aria-expanded` / `aria-controls` without function-valued snippet props. **`NavigationBarToggleAttributes.onclick`** is optional; a11y docs and unit tests match.
> 
> **SvelteKit consumer fixtures** (`/` barrel and `/subpath`) exercise `bind:mobileMenuOpen`, a custom `menuToggle` button, and `data-fixture-nav-toggle` markers. **`validate-consumers`** wraps SSR/route/stylesheet fetches in **`fetchWithTimeout`** and asserts those markers appear in SSR HTML so regressions fail fast instead of hanging.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4280612c632616ec329c92b1f07fba5754e37890. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->