### PR TITLE
Fix Cinder dev SSR snippet crashes

### DIFF
--- a/.changeset/dev-ssr-snippet-context.md
+++ b/.changeset/dev-ssr-snippet-context.md
@@ -1,0 +1,5 @@
+---
+'@lostgradient/cinder': patch
+---
+
+Preserve server component identity in the published SSR bundle so SvelteKit development SSR can render Cinder snippet content without crashing. Fixes #572 and #573.

--- a/packages/components/fixtures/sveltekit-consumer/src/routes/dev-ssr/+page.svelte
+++ b/packages/components/fixtures/sveltekit-consumer/src/routes/dev-ssr/+page.svelte
@@ -1,0 +1,38 @@
+<script lang="ts">
+  import Card from '@lostgradient/cinder/card';
+  import Tab from '@lostgradient/cinder/tab';
+  import TabList from '@lostgradient/cinder/tab-list';
+  import TabPanel from '@lostgradient/cinder/tab-panel';
+  import Tabs from '@lostgradient/cinder/tabs';
+
+  let namespaceTab = $state('workflow');
+  let directTab = $state('direct');
+</script>
+
+<main>
+  <Card title="Place a food order" headingLevel={2}>
+    <p data-dev-ssr-card-body>Spicy noodles</p>
+  </Card>
+
+  <Tabs bind:value={namespaceTab}>
+    <Tabs.List label="Editor files">
+      <Tabs.Trigger value="workflow">
+        <span data-dev-ssr-tabs-namespace-trigger>workflows.ts</span>
+      </Tabs.Trigger>
+    </Tabs.List>
+    <Tabs.Panel value="workflow">
+      <section data-dev-ssr-tabs-namespace-panel>Workflow editor</section>
+    </Tabs.Panel>
+  </Tabs>
+
+  <Tabs bind:value={directTab}>
+    <TabList label="Direct editor files">
+      <Tab value="direct">
+        <span data-dev-ssr-tabs-direct-trigger>direct.ts</span>
+      </Tab>
+    </TabList>
+    <TabPanel value="direct">
+      <section data-dev-ssr-tabs-direct-panel>Direct editor</section>
+    </TabPanel>
+  </Tabs>
+</main>

--- a/packages/components/fixtures/sveltekit-consumer/src/routes/dev-ssr/+page.svelte
+++ b/packages/components/fixtures/sveltekit-consumer/src/routes/dev-ssr/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import Card from '@lostgradient/cinder/card';
+  import Sidebar from '@lostgradient/cinder/sidebar';
   import Tab from '@lostgradient/cinder/tab';
   import TabList from '@lostgradient/cinder/tab-list';
   import TabPanel from '@lostgradient/cinder/tab-panel';
@@ -13,6 +14,15 @@
   <Card title="Place a food order" headingLevel={2}>
     <p data-dev-ssr-card-body>Spicy noodles</p>
   </Card>
+
+  <Sidebar label="Project navigation">
+    {#snippet brand()}
+      <strong data-dev-ssr-sidebar-brand>Cinder workspace</strong>
+    {/snippet}
+    {#snippet navigation()}
+      <a href="/dev-ssr" data-dev-ssr-sidebar-navigation>Dev SSR route</a>
+    {/snippet}
+  </Sidebar>
 
   <Tabs bind:value={namespaceTab}>
     <Tabs.List label="Editor files">

--- a/packages/components/scripts/build.ts
+++ b/packages/components/scripts/build.ts
@@ -12,7 +12,7 @@ import { deriveUpstreamReexports } from './lib/derive-upstream-reexports.ts';
 import { discoverComponents, type ComponentDiscovery } from './lib/discover-components.ts';
 import { hasSourceCssImport } from './prepend-source-index-css-import.ts';
 import { createServerEntrySource } from './server-entry.ts';
-import { sveltePlugin } from './svelte-plugin.ts';
+import { findOneArgumentServerComponentBoundaries, sveltePlugin } from './svelte-plugin.ts';
 import { isObjectRecord } from './validation-utilities.ts';
 
 const repositoryRoot = process.cwd();
@@ -241,6 +241,32 @@ const serverCssNoopPlugin = {
   },
 };
 
+async function assertServerComponentBoundariesPreserveIdentity(): Promise<void> {
+  const offenders: string[] = [];
+  const serverJavaScriptGlob = new Glob('**/*.js');
+  for await (const relativePath of serverJavaScriptGlob.scan({
+    cwd: `${distributionDirectory}/server`,
+  })) {
+    const filePath = `${distributionDirectory}/server/${relativePath}`;
+    const boundaries = findOneArgumentServerComponentBoundaries(
+      await Bun.file(filePath).text(),
+      filePath,
+    );
+    for (const boundary of boundaries) {
+      offenders.push(`${relativePath}:${boundary.line}:${boundary.column}`);
+    }
+  }
+  if (offenders.length > 0) {
+    process.stderr.write(
+      'Build aborted: server component boundaries must preserve component identity.\n' +
+        'One-argument `renderer.component(...)` calls poison Svelte dev SSR when a compiled Cinder component renders a consumer snippet containing an element.\n' +
+        offenders.map((offender) => `  ${offender}`).join('\n') +
+        '\n',
+    );
+    process.exit(1);
+  }
+}
+
 /**
  * Deprecated `@lostgradient/cinder/experimental/<name>` alias shims. Each promoted-out
  * component keeps a thin re-export shim at
@@ -253,8 +279,12 @@ const deprecatedAliasEntrypoints = DEPRECATED_EXPERIMENTAL_ALIASES.map(
   ({ name }) => `${sourceRoot}/components/experimental/${name}/index.ts`,
 );
 
+const browserRootEntrypoint = `${sourceRoot}/index.browser.ts`;
+const browserRootSource = await Bun.file(`${sourceRoot}/index.ts`).text();
+await Bun.write(browserRootEntrypoint, createServerEntrySource(browserRootSource));
+
 const browserEntrypoints = [
-  `${sourceRoot}/index.ts`,
+  browserRootEntrypoint,
   ...perComponentEntrypoints,
   ...perComponentMetadataEntrypoints,
   ...staticSubpathEntrypoints,
@@ -337,12 +367,14 @@ const browserBuildResult = await Bun.build({
   plugins: [
     cssImportPlugin({
       perComponentStyleSpecifiers,
-      rootBarrelEntrypoint: `${sourceRoot}/index.ts`,
+      rootBarrelEntrypoint: browserRootEntrypoint,
       rootBarrelStyleSpecifiers,
     }),
     sveltePlugin({ generate: 'client' }),
   ],
 });
+
+await rm(browserRootEntrypoint, { force: true });
 
 if (!browserBuildResult.success) {
   const messages = [
@@ -352,6 +384,33 @@ if (!browserBuildResult.success) {
   process.stderr.write(`${messages}\n`);
   process.exit(1);
 }
+
+const temporaryBrowserRootOutput = `${distributionDirectory}/index.browser.js`;
+const temporaryBrowserRootMapOutput = `${temporaryBrowserRootOutput}.map`;
+const browserRootOutput = `${distributionDirectory}/index.js`;
+const browserRootMapOutput = `${browserRootOutput}.map`;
+const temporaryBrowserRootContents = await Bun.file(temporaryBrowserRootOutput).text();
+const browserRootContents = temporaryBrowserRootContents.includes(
+  '//# sourceMappingURL=index.browser.js.map',
+)
+  ? temporaryBrowserRootContents.replace(
+      /\/\/# sourceMappingURL=index\.browser\.js\.map\s*$/u,
+      '//# sourceMappingURL=index.js.map\n',
+    )
+  : `${temporaryBrowserRootContents.trimEnd()}\n//# sourceMappingURL=index.js.map\n`;
+await Bun.write(browserRootOutput, browserRootContents);
+
+if (existsSync(temporaryBrowserRootMapOutput)) {
+  const sourceMap: unknown = JSON.parse(await Bun.file(temporaryBrowserRootMapOutput).text());
+  if (!isObjectRecord(sourceMap)) {
+    throw new TypeError(`Expected ${temporaryBrowserRootMapOutput} to contain a JSON object.`);
+  }
+  sourceMap['file'] = 'index.js';
+  await Bun.write(browserRootMapOutput, `${JSON.stringify(sourceMap)}\n`);
+}
+
+await rm(temporaryBrowserRootOutput, { force: true });
+await rm(temporaryBrowserRootMapOutput, { force: true });
 
 // -----------------------------------------------------------------------------
 // 2. SSR ESM build. The root barrel and component subpaths are compiled in one
@@ -852,6 +911,8 @@ for (const component of components) {
     process.exit(1);
   }
 }
+
+await assertServerComponentBoundariesPreserveIdentity();
 
 process.stdout.write(
   `Build complete. ${components.length} components, ${copiedSidecars.length} CSS sidecars copied.\n`,

--- a/packages/components/scripts/css-import-plugin.ts
+++ b/packages/components/scripts/css-import-plugin.ts
@@ -91,7 +91,7 @@ export function cssImportPlugin(options: CssImportPluginOptions): BunPlugin {
   return {
     name: 'cinder-css-import',
     setup(builder) {
-      builder.onLoad({ filter: /\/index\.ts$/ }, async ({ path }) => {
+      builder.onLoad({ filter: /\/index(?:\.browser)?\.ts$/ }, async ({ path }) => {
         const source = await Bun.file(path).text();
         const normalized = normalizePath(path);
 

--- a/packages/components/scripts/server-component-identity.test.ts
+++ b/packages/components/scripts/server-component-identity.test.ts
@@ -1,0 +1,33 @@
+import { existsSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { Glob } from 'bun';
+import { describe, expect, it } from 'bun:test';
+
+import { findOneArgumentServerComponentBoundaries } from './svelte-plugin.ts';
+
+const scriptDirectory = dirname(fileURLToPath(import.meta.url));
+const packageRoot = resolve(scriptDirectory, '..');
+const serverDistributionRoot = join(packageRoot, 'dist/server');
+
+describe.skipIf(!existsSync(serverDistributionRoot))(
+  'server component boundaries preserve component identity',
+  () => {
+    it('contains no one-argument renderer.component boundaries in dist/server', async () => {
+      const offenders: string[] = [];
+      const glob = new Glob('**/*.js');
+
+      for await (const relativePath of glob.scan({ cwd: serverDistributionRoot })) {
+        const filePath = join(serverDistributionRoot, relativePath);
+        const source = await Bun.file(filePath).text();
+        const boundaries = findOneArgumentServerComponentBoundaries(source, filePath);
+        for (const boundary of boundaries) {
+          offenders.push(`${relativePath}:${boundary.line}:${boundary.column}`);
+        }
+      }
+
+      expect(offenders).toEqual([]);
+    });
+  },
+);

--- a/packages/components/scripts/svelte-plugin.test.ts
+++ b/packages/components/scripts/svelte-plugin.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'bun:test';
+
+import {
+  findOneArgumentServerComponentBoundaries,
+  preserveServerComponentIdentity,
+} from './svelte-plugin.ts';
+
+describe('preserveServerComponentIdentity', () => {
+  it('adds the exported component identity to one-argument server component boundaries', () => {
+    const source = `
+import * as $ from 'svelte/internal/server';
+
+export default function Card($$renderer, $$props) {
+  $$renderer.component(($$renderer) => {
+    children($$renderer);
+  });
+}
+`;
+
+    const transformed = preserveServerComponentIdentity(source, 'card.svelte.js');
+
+    expect(transformed).toContain('}, Card);');
+    expect(findOneArgumentServerComponentBoundaries(transformed)).toEqual([]);
+  });
+
+  it('uses a named default export assignment when the component is exported separately', () => {
+    const source = `
+import * as $ from 'svelte/internal/server';
+
+function Tabs($$renderer, $$props) {
+  $$renderer.component(($$renderer) => {
+    children($$renderer);
+  });
+}
+
+export default Tabs;
+`;
+
+    const transformed = preserveServerComponentIdentity(source, 'tabs.svelte.js');
+
+    expect(transformed).toContain('}, Tabs);');
+    expect(findOneArgumentServerComponentBoundaries(transformed)).toEqual([]);
+  });
+
+  it('leaves existing two-argument server component boundaries unchanged', () => {
+    const source = `
+function Card($$renderer, $$props) {
+  $$renderer.component(($$renderer) => {
+    children($$renderer);
+  }, Card);
+}
+
+export default Card;
+`;
+
+    expect(preserveServerComponentIdentity(source, 'card.svelte.js')).toBe(source);
+  });
+
+  it('leaves non-component modules unchanged', () => {
+    const source = `
+export function createRenderer(renderer) {
+  renderer.component(() => {});
+}
+`;
+
+    expect(preserveServerComponentIdentity(source, 'module.js')).toBe(source);
+  });
+});

--- a/packages/components/scripts/svelte-plugin.ts
+++ b/packages/components/scripts/svelte-plugin.ts
@@ -1,7 +1,14 @@
 import type { BunPlugin } from 'bun';
 import { compile, compileModule } from 'svelte/compiler';
+import ts from 'typescript';
 
 type GenerationTarget = 'client' | 'server';
+
+export type ServerComponentBoundary = {
+  column: number;
+  index: number;
+  line: number;
+};
 
 const DOMAIN_SUITE_STYLE_COMPONENTS = new Set([
   'chat',
@@ -22,6 +29,111 @@ function allowsStyleBlock(path: string): boolean {
   const componentPathMatch = normalizedPath.match(/\/src\/components\/([^/]+)(?:\/|\.svelte$)/);
   const componentName = componentPathMatch?.[1];
   return componentName !== undefined && DOMAIN_SUITE_STYLE_COMPONENTS.has(componentName);
+}
+
+function hasModifier(
+  node: ts.Node & { modifiers?: ts.NodeArray<ts.ModifierLike> },
+  kind: ts.SyntaxKind,
+): boolean {
+  return node.modifiers?.some((modifier) => modifier.kind === kind) ?? false;
+}
+
+function isServerComponentBoundaryCall(node: ts.CallExpression): boolean {
+  const [firstArgument] = node.arguments;
+  return (
+    ts.isPropertyAccessExpression(node.expression) &&
+    node.expression.name.text === 'component' &&
+    node.arguments.length === 1 &&
+    firstArgument !== undefined &&
+    (ts.isArrowFunction(firstArgument) || ts.isFunctionExpression(firstArgument))
+  );
+}
+
+function findDefaultComponentFunction(
+  sourceFile: ts.SourceFile,
+): ts.FunctionDeclaration | undefined {
+  let defaultExportName: string | undefined;
+
+  for (const statement of sourceFile.statements) {
+    if (
+      ts.isFunctionDeclaration(statement) &&
+      statement.name !== undefined &&
+      hasModifier(statement, ts.SyntaxKind.ExportKeyword) &&
+      hasModifier(statement, ts.SyntaxKind.DefaultKeyword)
+    ) {
+      return statement;
+    }
+
+    if (ts.isExportAssignment(statement) && ts.isIdentifier(statement.expression)) {
+      defaultExportName = statement.expression.text;
+    }
+  }
+
+  if (defaultExportName === undefined) return undefined;
+
+  return sourceFile.statements.find(
+    (statement): statement is ts.FunctionDeclaration =>
+      ts.isFunctionDeclaration(statement) && statement.name?.text === defaultExportName,
+  );
+}
+
+function parseJavaScript(source: string, fileName: string): ts.SourceFile {
+  return ts.createSourceFile(fileName, source, ts.ScriptTarget.Latest, true, ts.ScriptKind.JS);
+}
+
+export function findOneArgumentServerComponentBoundaries(
+  source: string,
+  fileName = 'component.js',
+): ServerComponentBoundary[] {
+  const sourceFile = parseJavaScript(source, fileName);
+  const boundaries: ServerComponentBoundary[] = [];
+
+  function visit(node: ts.Node): void {
+    if (ts.isCallExpression(node) && isServerComponentBoundaryCall(node)) {
+      const position = sourceFile.getLineAndCharacterOfPosition(node.getStart(sourceFile));
+      boundaries.push({
+        column: position.character + 1,
+        index: node.getStart(sourceFile),
+        line: position.line + 1,
+      });
+    }
+
+    ts.forEachChild(node, visit);
+  }
+
+  visit(sourceFile);
+  return boundaries;
+}
+
+export function preserveServerComponentIdentity(source: string, fileName = 'component.js'): string {
+  const sourceFile = parseJavaScript(source, fileName);
+  const componentFunction = findDefaultComponentFunction(sourceFile);
+  const componentName = componentFunction?.name?.text;
+  if (componentFunction?.body === undefined || componentName === undefined) return source;
+
+  const insertionIndexes: number[] = [];
+
+  function visit(node: ts.Node): void {
+    if (ts.isCallExpression(node) && isServerComponentBoundaryCall(node)) {
+      const firstArgument = node.arguments[0];
+      if (firstArgument !== undefined) insertionIndexes.push(firstArgument.getEnd());
+    }
+
+    ts.forEachChild(node, visit);
+  }
+
+  visit(componentFunction.body);
+
+  if (insertionIndexes.length === 0) return source;
+
+  let transformedSource = source;
+  for (const insertionIndex of insertionIndexes.toSorted((left, right) => right - left)) {
+    transformedSource =
+      transformedSource.slice(0, insertionIndex) +
+      `, ${componentName}` +
+      transformedSource.slice(insertionIndex);
+  }
+  return transformedSource;
 }
 
 /**
@@ -55,20 +167,25 @@ export function sveltePlugin(
         const source = await Bun.file(path).text();
         const isPlaygroundFile = path.replaceAll('\\', '/').includes('/packages/playground/');
         const css = isPlaygroundFile || injectCss ? 'injected' : 'external';
+        const dev = process.env['NODE_ENV'] !== 'production';
         const compileResult = compile(source, {
           filename: path,
           generate: options.generate,
           css,
           // Read the same environment source that `scripts/build.ts` writes before `Bun.build()`
           // runs so production builds and test/dev loads stay in sync.
-          dev: process.env['NODE_ENV'] !== 'production',
+          dev,
         });
         if (!isPlaygroundFile && compileResult.css?.code?.trim() && !allowsStyleBlock(path)) {
           throw new Error(
             `[svelte-plugin] <style> block in ${path} — not allowed. Put styles in src/styles/.`,
           );
         }
-        return { contents: compileResult.js.code, loader: 'js' };
+        const compiledSource =
+          options.generate === 'server' && !dev
+            ? preserveServerComponentIdentity(compileResult.js.code, path)
+            : compileResult.js.code;
+        return { contents: compiledSource, loader: 'js' };
       });
 
       builder.onLoad({ filter: /\.svelte\.(js|ts)$/ }, async ({ path }) => {

--- a/packages/components/scripts/svelte-plugin.ts
+++ b/packages/components/scripts/svelte-plugin.ts
@@ -127,7 +127,10 @@ export function preserveServerComponentIdentity(source: string, fileName = 'comp
   if (insertionIndexes.length === 0) return source;
 
   let transformedSource = source;
-  for (const insertionIndex of insertionIndexes.toSorted((left, right) => right - left)) {
+  // Do not use Array.prototype.toSorted(): the package targets ES2022.
+  const sortedInsertionIndexes = Array.from(insertionIndexes);
+  sortedInsertionIndexes.sort((left, right) => right - left);
+  for (const insertionIndex of sortedInsertionIndexes) {
     transformedSource =
       transformedSource.slice(0, insertionIndex) +
       `, ${componentName}` +

--- a/packages/components/scripts/validate-consumers.ts
+++ b/packages/components/scripts/validate-consumers.ts
@@ -744,6 +744,8 @@ function ensureSvelteKitAdapterNodeStaticAssetLink(fixtureDirectory: string): vo
 
 const SVELTEKIT_DEV_SSR_MARKERS = [
   'data-dev-ssr-card-body',
+  'data-dev-ssr-sidebar-brand',
+  'data-dev-ssr-sidebar-navigation',
   'data-dev-ssr-tabs-namespace-trigger',
   'data-dev-ssr-tabs-namespace-panel',
   'data-dev-ssr-tabs-direct-trigger',

--- a/packages/components/scripts/validate-consumers.ts
+++ b/packages/components/scripts/validate-consumers.ts
@@ -742,6 +742,61 @@ function ensureSvelteKitAdapterNodeStaticAssetLink(fixtureDirectory: string): vo
   }
 }
 
+const SVELTEKIT_DEV_SSR_MARKERS = [
+  'data-dev-ssr-card-body',
+  'data-dev-ssr-tabs-namespace-trigger',
+  'data-dev-ssr-tabs-namespace-panel',
+  'data-dev-ssr-tabs-direct-trigger',
+  'data-dev-ssr-tabs-direct-panel',
+];
+
+function formatHtmlExcerpt(body: string): string {
+  return body.replace(/\s+/g, ' ').trim().slice(0, 1_000);
+}
+
+async function assertSvelteKitDevSsrRoute(fixtureDirectory: string, label: string): Promise<void> {
+  const httpPort = await pickEphemeralPort();
+  const devServer = Bun.spawn(
+    ['bunx', 'vite', 'dev', '--host', '127.0.0.1', '--port', String(httpPort), '--strictPort'],
+    {
+      cwd: fixtureDirectory,
+      stdout: 'pipe',
+      stderr: 'pipe',
+      env: {
+        ...Bun.env,
+        TZ: 'UTC',
+        LANG: 'en_US.UTF-8',
+      },
+    },
+  );
+
+  try {
+    await waitForUrl(`http://127.0.0.1:${httpPort}/`, 15_000, devServer);
+    const routeUrl = `http://127.0.0.1:${httpPort}/dev-ssr`;
+    const response = await fetchWithTimeout(
+      routeUrl,
+      10_000,
+      `sveltekit-consumer ${label} /dev-ssr dev SSR`,
+    );
+    const body = await response.text();
+    if (response.status !== 200) {
+      fail(
+        `sveltekit-consumer ${label} /dev-ssr dev SSR returned ${response.status}, want 200:\n${formatHtmlExcerpt(body)}`,
+      );
+    }
+
+    const missingMarkers = SVELTEKIT_DEV_SSR_MARKERS.filter((marker) => !body.includes(marker));
+    if (missingMarkers.length > 0) {
+      fail(
+        `sveltekit-consumer ${label} /dev-ssr dev SSR missing marker(s): ${missingMarkers.join(', ')}\n${formatHtmlExcerpt(body)}`,
+      );
+    }
+  } finally {
+    devServer.kill();
+    await devServer.exited;
+  }
+}
+
 async function runSveltekitFixture(label = 'workspace', svelteVersion?: string): Promise<void> {
   const fixtureDirectory = join(repositoryRoot, 'fixtures/sveltekit-consumer');
   process.stdout.write(
@@ -777,6 +832,8 @@ async function runSveltekitFixture(label = 'workspace', svelteVersion?: string):
         `svelte-check failed in sveltekit-consumer ${label}:\n${checkResult.stdout.toString()}\n${checkResult.stderr.toString()}`,
       );
     }
+
+    await assertSvelteKitDevSsrRoute(fixtureDirectory, label);
 
     const viteBuildResult = await $`bunx vite build`.cwd(fixtureDirectory).nothrow();
     if (viteBuildResult.exitCode !== 0) {

--- a/packages/components/src/components/blog-section/index.ts
+++ b/packages/components/src/components/blog-section/index.ts
@@ -1,3 +1,4 @@
+import './blog-section.css';
 import BlogSection from './blog-section.svelte';
 
 export default BlogSection;

--- a/packages/components/src/components/cta-section/index.ts
+++ b/packages/components/src/components/cta-section/index.ts
@@ -1,3 +1,4 @@
+import './cta-section.css';
 import CtaSection from './cta-section.svelte';
 
 export default CtaSection;

--- a/packages/components/src/components/feature-section/index.ts
+++ b/packages/components/src/components/feature-section/index.ts
@@ -1,3 +1,4 @@
+import './feature-section.css';
 import FeatureSection from './feature-section.svelte';
 
 export default FeatureSection;

--- a/packages/components/src/components/hero-section/index.ts
+++ b/packages/components/src/components/hero-section/index.ts
@@ -1,3 +1,4 @@
+import './hero-section.css';
 import HeroSection from './hero-section.svelte';
 
 export default HeroSection;

--- a/packages/components/src/components/logo-cloud/index.ts
+++ b/packages/components/src/components/logo-cloud/index.ts
@@ -1,3 +1,4 @@
+import './logo-cloud.css';
 import LogoCloud from './logo-cloud.svelte';
 
 export default LogoCloud;

--- a/packages/components/src/components/meter/meter.css
+++ b/packages/components/src/components/meter/meter.css
@@ -66,7 +66,7 @@
     z-index: 1;
   }
 
-  :dir(rtl) .cinder-meter__fill {
+  .cinder-meter:dir(rtl) .cinder-meter__fill {
     transform-origin: center right;
   }
 

--- a/packages/components/src/components/newsletter-section/index.ts
+++ b/packages/components/src/components/newsletter-section/index.ts
@@ -1,3 +1,4 @@
+import './newsletter-section.css';
 import NewsletterSection from './newsletter-section.svelte';
 
 export default NewsletterSection;

--- a/packages/components/src/components/pricing-section/index.ts
+++ b/packages/components/src/components/pricing-section/index.ts
@@ -1,3 +1,4 @@
+import './pricing-section.css';
 import PricingSection from './pricing-section.svelte';
 
 export default PricingSection;

--- a/packages/components/src/components/stats-section/index.ts
+++ b/packages/components/src/components/stats-section/index.ts
@@ -1,3 +1,4 @@
+import './stats-section.css';
 import StatsSection from './stats-section.svelte';
 
 export default StatsSection;

--- a/packages/components/src/components/team-section/index.ts
+++ b/packages/components/src/components/team-section/index.ts
@@ -1,3 +1,4 @@
+import './team-section.css';
 import TeamSection from './team-section.svelte';
 
 export default TeamSection;

--- a/packages/components/src/components/testimonial-section/index.ts
+++ b/packages/components/src/components/testimonial-section/index.ts
@@ -1,3 +1,4 @@
+import './testimonial-section.css';
 import TestimonialSection from './testimonial-section.svelte';
 
 export default TestimonialSection;


### PR DESCRIPTION
## Summary

- Preserves component identity on production server-compiled Svelte component boundaries so SvelteKit development SSR can render consumer snippets without crashing.
- Adds a build guard that rejects one-argument `renderer.component(...)` calls in `dist/server`.
- Adds a SvelteKit dev SSR consumer fixture route covering Card, Tabs, and Sidebar snippet content through installed package subpaths.
- Fixes the Meter RTL selector that was blocking the package build, and refreshes source CSS imports required by the build gate.

## Issues Closed

Closes #572.
Closes #573.
Closes #575.

## SSR Issue Coverage

- #572: Tabs namespace and direct leaf usage render element-containing snippets in the installed-package `/dev-ssr` fixture.
- #573: Card renders an element-containing default snippet in the installed-package `/dev-ssr` fixture.
- #575: Sidebar renders element-containing `brand` and `navigation` snippets through the installed package subpath, while the post-build guard covers the same server-boundary invariant across every built server component.

## Root Cause

SvelteKit development SSR can resolve Cinder component imports to the published `node` condition (`dist/server`). Those production server chunks emitted `renderer.component(...)` boundaries without the component identity argument. When a Cinder component then rendered a consumer snippet containing an HTML element, Svelte's development SSR context could read an undefined component identity and throw.

## Validation

- `bun test --conditions browser --conditions svelte --parallel=1 packages/components/scripts/svelte-plugin.test.ts`
- `bun test --conditions browser --conditions svelte --parallel=1 packages/components/scripts/server-component-identity.test.ts`
- `bun test --conditions browser --conditions svelte --parallel=1 packages/components/scripts/svelte-plugin.test.ts packages/components/scripts/server-component-identity.test.ts`
- `bun run --filter=@lostgradient/cinder build`
- `bun run --filter=@lostgradient/cinder typecheck`
- `bun run --filter=@lostgradient/cinder validate:consumer`
- `node --conditions=svelte --input-type=module -e "console.log(await import.meta.resolve('@lostgradient/cinder')); console.log(await import.meta.resolve('@lostgradient/cinder/card'));"`
- Pre-commit hook: `@lostgradient/cinder typecheck` and `@lostgradient/cinder test`
- Pre-push hook: scoped lint, typecheck, and changed tests

## Known Validation Caveat

`bun run --filter=@lostgradient/cinder validate` currently fails after the component tests pass because `platform:audit` rejects 12 existing viewport-width media queries in component CSS. That appears unrelated to the SSR fix and matches the current main/release audit failure pattern.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches published SSR bundle shape and the root browser build entry; regression risk is mitigated by build abort on bad boundaries, unit tests, and a live SvelteKit dev SSR fixture.
> 
> **Overview**
> Fixes **SvelteKit development SSR crashes** when Cinder components render consumer snippets (issues #572 / #573). Published `dist/server` chunks were emitting one-argument `renderer.component(...)` boundaries; dev SSR then failed when snippet content included real elements.
> 
> **Server compile post-processing:** In production server builds, `preserveServerComponentIdentity` rewrites compiled output to pass the default-exported component function as the second `component()` argument. A post-build scan (and tests) **fails the build** if any one-argument boundaries remain under `dist/server`.
> 
> **Build / CSS plumbing:** Browser root barrel builds through a temporary `index.browser.ts` (aligned with the existing server entry pattern) and renames outputs/maps to `index.js`. The CSS import plugin also treats `index.browser.ts`. Several marketing **section** `index.ts` files gain explicit sidecar CSS imports to satisfy the source-index CSS gate.
> 
> **Validation:** Adds a SvelteKit consumer `/dev-ssr` route (Card body + Tabs namespace/direct APIs) and runs **Vite dev SSR** in `validate:consumer`, asserting HTML markers. **Meter** RTL styling uses `.cinder-meter:dir(rtl)` so the package build passes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 374a9aaa5eaee9da1be03b2131293d6b29f5c21f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->