### PR TITLE
fix: remove TS5-only transitive peer warning path

### DIFF
--- a/.changeset/fuzzy-keys-hope.md
+++ b/.changeset/fuzzy-keys-hope.md
@@ -1,0 +1,5 @@
+---
+'@lostgradient/cinder': patch
+---
+
+Remove an unused transitive dependency that produced TypeScript 6 peer warnings, and strengthen consumer validation to assert TypeScript 6 install compatibility.

--- a/bun.lock
+++ b/bun.lock
@@ -46,7 +46,6 @@
       "version": "0.4.1",
       "dependencies": {
         "@floating-ui/dom": "1.7.6",
-        "@lasercat/homogenaize": "^1.2.41",
         "@milkdown/ctx": "^7.17.3",
         "@milkdown/kit": "^7.17.3",
         "@milkdown/prose": "^7.17.3",
@@ -333,8 +332,6 @@
     "@keyv/bigmap": ["@keyv/bigmap@1.3.1", "", { "dependencies": { "hashery": "^1.4.0", "hookified": "^1.15.0" }, "peerDependencies": { "keyv": "^5.6.0" } }, "sha512-WbzE9sdmQtKy8vrNPa9BRnwZh5UF4s1KTmSK0KUVLo3eff5BlQNNWDnFOouNpKfPKDnms9xynJjsMYjMaT/aFQ=="],
 
     "@keyv/serialize": ["@keyv/serialize@1.1.1", "", {}, "sha512-dXn3FZhPv0US+7dtJsIi2R+c7qWYiReoEh5zUntWCf4oSpMNib8FDhSoed6m3QyZdx5hK7iLFkYk3rNxwt8vTA=="],
-
-    "@lasercat/homogenaize": ["@lasercat/homogenaize@1.2.41", "", { "dependencies": { "ajv": "^8.17.1", "openai": "^5.12.0" }, "peerDependencies": { "typescript": "^5.8.3" } }, "sha512-IN3/rhIHpcfcuxcI8jaNlkOuI5p03TZF01tI3VUGSgfG1sMce6RGfcb+GE1Eq5ZAZAXfh60IpySixE5KQvdK5Q=="],
 
     "@lezer/common": ["@lezer/common@1.5.2", "", {}, "sha512-sxQE460fPZyU3sdc8lafxiPwJHBzZRy/udNFynGQky1SePYBdhkBl1kOagA9uT3pxR8K09bOrmTUqA9wb/PjSQ=="],
 
@@ -1001,8 +998,6 @@
     "oniguruma-parser": ["oniguruma-parser@0.12.2", "", {}, "sha512-6HVa5oIrgMC6aA6WF6XyyqbhRPJrKR02L20+2+zpDtO5QAzGHAUGw5TKQvwi5vctNnRHkJYmjAhRVQF2EKdTQw=="],
 
     "oniguruma-to-es": ["oniguruma-to-es@4.3.6", "", { "dependencies": { "oniguruma-parser": "^0.12.2", "regex": "^6.1.0", "regex-recursion": "^6.0.2" } }, "sha512-csuQ9x3Yr0cEIs/Zgx/OEt9iBw9vqIunAPQkx19R/fiMq2oGVTgcMqO/V3Ybqefr1TBvosI6jU539ksaBULJyA=="],
-
-    "openai": ["openai@5.23.2", "", { "peerDependencies": { "ws": "^8.18.0", "zod": "^3.23.8" }, "optionalPeers": ["ws", "zod"], "bin": { "openai": "bin/cli" } }, "sha512-MQBzmTulj+MM5O8SKEk/gL8a7s5mktS9zUtAkU257WjvobGc9nKcBuVwjyEEcb9SI8a8Y2G/mzn3vm9n1Jlleg=="],
 
     "orderedmap": ["orderedmap@2.1.1", "", {}, "sha512-TvAWxi0nDe1j/rtMcWcIj94+Ffe6n7zhow33h40SKxmsmozs6dz/e+EajymfoFcHd7sxNn8yHM8839uixMOV6g=="],
 

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -5777,7 +5777,6 @@
   },
   "dependencies": {
     "@floating-ui/dom": "1.7.6",
-    "@lasercat/homogenaize": "^1.2.41",
     "@milkdown/ctx": "^7.17.3",
     "@milkdown/kit": "^7.17.3",
     "@milkdown/prose": "^7.17.3",

--- a/packages/components/scripts/validate-consumers.ts
+++ b/packages/components/scripts/validate-consumers.ts
@@ -629,7 +629,7 @@ async function pickEphemeralPort(): Promise<number> {
  */
 function injectTarballIntoFixture(
   fixtureDirectory: string,
-  options: { svelteVersion?: string } = {},
+  options: { svelteVersion?: string; typescriptVersion?: string } = {},
 ): () => void {
   const manifestPath = join(fixtureDirectory, 'package.json');
   const originalContent = readFileSync(manifestPath, 'utf8');
@@ -649,12 +649,19 @@ function injectTarballIntoFixture(
   parsed['overrides'] = overrides;
 
   dependencies['@lostgradient/cinder'] = `file:${tarballFilePath}`;
-  if (options.svelteVersion !== undefined) {
+  if (options.svelteVersion !== undefined || options.typescriptVersion !== undefined) {
     const rawDevDependencies = parsed['devDependencies'];
     if (!isObjectRecord(rawDevDependencies)) {
-      fail(`${manifestPath} is missing a devDependencies object for Svelte compatibility testing`);
+      fail(
+        `${manifestPath} is missing a devDependencies object for compatibility testing overrides`,
+      );
     }
-    rawDevDependencies['svelte'] = options.svelteVersion;
+    if (options.svelteVersion !== undefined) {
+      rawDevDependencies['svelte'] = options.svelteVersion;
+    }
+    if (options.typescriptVersion !== undefined) {
+      rawDevDependencies['typescript'] = options.typescriptVersion;
+    }
   }
   for (const dependencyPackage of workspaceDependencyPackages) {
     const fileSpecifier = `file:${dependencyPackage.tarballFilePath}`;
@@ -719,6 +726,33 @@ async function runSveltePeerCompatibilityFixture(
     await runTypescriptConsumerSvelteGate(fixtureDirectory, label);
     process.stdout.write(
       `[validate-consumers] svelte peer compatibility OK (${label}: ${svelteVersion}).\n`,
+    );
+  } finally {
+    restoreManifest();
+  }
+}
+
+async function runTypescriptPeerCompatibilityFixture(
+  label: string,
+  typescriptVersion: string,
+): Promise<void> {
+  const fixtureDirectory = join(repositoryRoot, 'fixtures/typescript-consumer');
+  process.stdout.write(
+    `[validate-consumers] step: typescript compatibility (${label}: ${typescriptVersion})…\n`,
+  );
+  const restoreManifest = injectTarballIntoFixture(fixtureDirectory, { typescriptVersion });
+
+  try {
+    await $`rm -rf node_modules src/generated`.cwd(fixtureDirectory);
+    const installResult = await $`bun install --no-save`.cwd(fixtureDirectory).nothrow();
+    if (installResult.exitCode !== 0) {
+      fail(
+        `typescript-consumer ${label} bun install failed for typescript@${typescriptVersion}:\n${installResult.stdout.toString()}\n${installResult.stderr.toString()}`,
+      );
+    }
+    await runTypescriptConsumerSvelteGate(fixtureDirectory, label);
+    process.stdout.write(
+      `[validate-consumers] typescript compatibility OK (${label}: ${typescriptVersion}).\n`,
     );
   } finally {
     restoreManifest();
@@ -1554,6 +1588,7 @@ try {
   await runManifestConsumerFixture();
   await runNodeFixture();
   await runTypescriptConsumerFixture();
+  await runTypescriptPeerCompatibilityFixture('latest TypeScript 6', '^6.0.3');
   await runSveltePeerCompatibilityFixture('minimum', sveltePeerContract.minimum);
   await runSveltePeerCompatibilityFixture('latest Svelte 5', sveltePeerContract.latest);
   await runSveltekitFixture('minimum', sveltePeerContract.minimum);

--- a/packages/components/scripts/validate-consumers.ts
+++ b/packages/components/scripts/validate-consumers.ts
@@ -705,6 +705,39 @@ async function runTypescriptConsumerSvelteGate(
   }
 }
 
+type InstallLikeResult = {
+  stdout: { toString(): string };
+  stderr: { toString(): string };
+};
+
+function assertNoPeerDependencyWarnings(installResult: InstallLikeResult, label: string): void {
+  const installOutput = `${installResult.stdout.toString()}\n${installResult.stderr.toString()}`;
+  const peerWarningPatterns = [
+    /issues with peer dependencies found/i,
+    /unmet peer/i,
+    /incorrect peer dependency/i,
+  ];
+  if (peerWarningPatterns.some((pattern) => pattern.test(installOutput))) {
+    fail(
+      `typescript-consumer ${label} bun install reported peer dependency warnings:\n${installOutput}`,
+    );
+  }
+}
+
+async function runTypescriptConsumerNodenextGate(
+  fixtureDirectory: string,
+  label: string,
+): Promise<void> {
+  const result = await $`bunx tsc --noEmit -p tsconfig.nodenext.json`
+    .cwd(fixtureDirectory)
+    .nothrow();
+  if (result.exitCode !== 0) {
+    fail(
+      `typescript-consumer ${label} gate 1 - nodenext (no svelte condition) failed:\n${result.stdout.toString()}\n${result.stderr.toString()}`,
+    );
+  }
+}
+
 async function runSveltePeerCompatibilityFixture(
   label: string,
   svelteVersion: string,
@@ -732,7 +765,7 @@ async function runSveltePeerCompatibilityFixture(
   }
 }
 
-async function runTypescriptPeerCompatibilityFixture(
+async function runTypescriptCompatibilityFixture(
   label: string,
   typescriptVersion: string,
 ): Promise<void> {
@@ -750,6 +783,8 @@ async function runTypescriptPeerCompatibilityFixture(
         `typescript-consumer ${label} bun install failed for typescript@${typescriptVersion}:\n${installResult.stdout.toString()}\n${installResult.stderr.toString()}`,
       );
     }
+    assertNoPeerDependencyWarnings(installResult, label);
+    await runTypescriptConsumerNodenextGate(fixtureDirectory, label);
     await runTypescriptConsumerSvelteGate(fixtureDirectory, label);
     process.stdout.write(
       `[validate-consumers] typescript compatibility OK (${label}: ${typescriptVersion}).\n`,
@@ -1416,17 +1451,7 @@ async function runTypescriptConsumerFixture(): Promise<void> {
     // survive a run, and the probe must cover whatever the tarball publishes.
     await runTypescriptConsumerSvelteGate(fixtureDirectory, 'workspace default');
 
-    const tscGates: Array<{ label: string; tsconfig: string }> = [
-      { label: 'gate 1 — nodenext (no svelte condition)', tsconfig: 'tsconfig.nodenext.json' },
-    ];
-    for (const { label, tsconfig } of tscGates) {
-      const result = await $`bunx tsc --noEmit -p ${tsconfig}`.cwd(fixtureDirectory).nothrow();
-      if (result.exitCode !== 0) {
-        fail(
-          `typescript-consumer ${label} failed:\n${result.stdout.toString()}\n${result.stderr.toString()}`,
-        );
-      }
-    }
+    await runTypescriptConsumerNodenextGate(fixtureDirectory, 'workspace default');
 
     process.stdout.write('[validate-consumers] typescript-consumer OK (gates 1–3 green).\n');
   } finally {
@@ -1588,7 +1613,7 @@ try {
   await runManifestConsumerFixture();
   await runNodeFixture();
   await runTypescriptConsumerFixture();
-  await runTypescriptPeerCompatibilityFixture('latest TypeScript 6', '^6.0.3');
+  await runTypescriptCompatibilityFixture('latest TypeScript 6', '^6.0.3');
   await runSveltePeerCompatibilityFixture('minimum', sveltePeerContract.minimum);
   await runSveltePeerCompatibilityFixture('latest Svelte 5', sveltePeerContract.latest);
   await runSveltekitFixture('minimum', sveltePeerContract.minimum);


### PR DESCRIPTION
## Why
Consumers using TypeScript 6 were getting an unmet peer warning from cinder's transitive dependency tree, even though cinder itself does not require a TypeScript peer contract.

## What changed
- Removed `@lasercat/homogenaize` from `@lostgradient/cinder` dependencies, which removes the transitive `typescript@^5.8.3` peer warning path.
- Regenerated `bun.lock` to reflect the dependency graph change.
- Extended consumer validation fixture overrides to support `typescriptVersion` alongside `svelteVersion`.
- Added a dedicated TypeScript compatibility check in `validate-consumers` that installs and runs the TypeScript consumer fixture with `typescript@^6.0.3`.

## Notes for reviewers
- `@lasercat/homogenaize` had no direct imports in `packages/components`, so this change removes an unused runtime dependency.
- The new fixture step is intentionally focused on install and existing TypeScript/Svelte gates, so TS6 compatibility is exercised in the same validation flow as current consumer checks.

Fixes: #576

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency removal with no in-repo usage; validation-only CI hardening with no runtime behavior change to cinder itself.
> 
> **Overview**
> Removes **`@lasercat/homogenaize`** from `@lostgradient/cinder` dependencies (unused in the package) so consumers on **TypeScript 6** no longer see transitive **`typescript@^5.8.3`** peer warnings from that tree. **`bun.lock`** is updated accordingly.
> 
> **`validate-consumers`** now supports overriding **`typescriptVersion`** in fixture injection (alongside Svelte), adds **`assertNoPeerDependencyWarnings`** on install output, extracts the nodenext **`tsc`** gate into **`runTypescriptConsumerNodenextGate`**, and runs a new **`runTypescriptCompatibilityFixture`** step with **`typescript@^6.0.3`** (install + peer check + existing TS/Svelte gates).
> 
> Patch changeset documents the release note.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit edfee8dd1ab4d1f34ce61f41bdc367b75b5f8cca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->