### PR TITLE
Guard packed tarballs against dangling source map URLs

### DIFF
--- a/packages/components/scripts/pack-for-publish.test.ts
+++ b/packages/components/scripts/pack-for-publish.test.ts
@@ -239,4 +239,28 @@ describe('buildPublishedManifest', () => {
     expect(stripped.strippedCount).toBe(1);
     expect(stripped.text).toBe('export const value = 1;\n');
   });
+
+  it('strips missing editor source-map comments while preserving existing references', () => {
+    const input =
+      [
+        'export const runtime = true;',
+        '//# sourceMappingURL=component-runtime.js.map',
+        '//# sourceMappingURL=attach.js.map',
+        '//# sourceMappingURL=editor.js.map',
+        '//# sourceMappingURL=types.js.map',
+        '//# sourceMappingURL=keymap-plugin.js.map',
+        '//# sourceMappingURL=commands.js.map',
+      ].join('\n') + '\n';
+    const stripped = stripDanglingSourceMapUrlComments(
+      input,
+      (reference) => reference === 'attach.js.map',
+    );
+    expect(stripped.strippedCount).toBe(5);
+    expect(stripped.text).toContain('//# sourceMappingURL=attach.js.map');
+    expect(stripped.text).not.toContain('component-runtime.js.map');
+    expect(stripped.text).not.toContain('editor.js.map');
+    expect(stripped.text).not.toContain('types.js.map');
+    expect(stripped.text).not.toContain('keymap-plugin.js.map');
+    expect(stripped.text).not.toContain('commands.js.map');
+  });
 });

--- a/packages/components/scripts/validate-consumers.ts
+++ b/packages/components/scripts/validate-consumers.ts
@@ -389,6 +389,54 @@ async function assertUpstreamReexportsResolveInTarball(extractedRoot: string): P
   }
 }
 
+type SourceMapReference = {
+  line: number;
+  reference: string;
+};
+
+function isResolvableRelativeSourceMapReference(reference: string): boolean {
+  if (!reference.endsWith('.map')) return false;
+  if (reference.startsWith('data:')) return false;
+  if (reference.startsWith('file:')) return false;
+  return !/^[a-z]+:\/\//iu.test(reference);
+}
+
+function getSourceMapReferences(content: string): SourceMapReference[] {
+  const references: SourceMapReference[] = [];
+  const lines = content.split('\n');
+  for (const [index, line] of lines.entries()) {
+    const lineCommentMatch = line.match(/^\s*\/\/[#@]\s*sourceMappingURL=([^\s]+)\s*$/u);
+    if (lineCommentMatch?.[1] && isResolvableRelativeSourceMapReference(lineCommentMatch[1])) {
+      references.push({ line: index + 1, reference: lineCommentMatch[1] });
+      continue;
+    }
+
+    const blockCommentMatch = line.match(/^\s*\/\*#\s*sourceMappingURL=([^*\s]+)\s*\*\/\s*$/u);
+    if (blockCommentMatch?.[1] && isResolvableRelativeSourceMapReference(blockCommentMatch[1])) {
+      references.push({ line: index + 1, reference: blockCommentMatch[1] });
+    }
+  }
+  return references;
+}
+
+async function assertNoDanglingSourceMapComments(extractedRoot: string): Promise<void> {
+  const packageRoot = join(extractedRoot, 'package');
+  const glob = new Glob('dist/**/*.{js,mjs,cjs}');
+  const offenders: string[] = [];
+  for await (const relative of glob.scan({ cwd: packageRoot })) {
+    const filePath = join(packageRoot, relative);
+    const content = await Bun.file(filePath).text();
+    if (!content.includes('sourceMappingURL=')) continue;
+    for (const reference of getSourceMapReferences(content)) {
+      if (existsSync(join(dirname(filePath), reference.reference))) continue;
+      offenders.push(`${relative}:${reference.line} -> ${reference.reference}`);
+    }
+  }
+  if (offenders.length > 0) {
+    fail(`tarball contains dangling sourceMappingURL comments:\n  ${offenders.join('\n  ')}`);
+  }
+}
+
 type TarballExpectations = {
   required: string[];
   forbiddenPatterns: RegExp[];
@@ -1596,6 +1644,7 @@ try {
     await assertPackedManifestInvariants(tarballInspectionDirectory);
     await assertNoQuotedCinderReferences(tarballInspectionDirectory);
     await assertUpstreamReexportsResolveInTarball(tarballInspectionDirectory);
+    await assertNoDanglingSourceMapComments(tarballInspectionDirectory);
     process.stdout.write('[validate-consumers] publish-path invariants OK.\n');
   } finally {
     // Both directories carry hundreds of MB of extracted/staged artifacts;

--- a/packages/components/scripts/validate-consumers.ts
+++ b/packages/components/scripts/validate-consumers.ts
@@ -9,7 +9,7 @@ import {
 } from 'node:fs';
 import { rm } from 'node:fs/promises';
 import { createServer } from 'node:net';
-import { dirname, join, resolve as resolvePath } from 'node:path';
+import { dirname, join, relative, resolve as resolvePath } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import { parse } from 'postcss';
@@ -342,8 +342,8 @@ async function assertNoQuotedCinderReferences(extractedRoot: string): Promise<vo
   // implementation. The previous inline ladder skipped any line starting
   // with `/*` even when `*/` closed on the same line, letting
   // `/* x */ import from '@cinder/markdown'` slip through.
-  for await (const relative of glob.scan({ cwd: packageRoot })) {
-    const filePath = join(packageRoot, relative);
+  for await (const scriptPath of glob.scan({ cwd: packageRoot })) {
+    const filePath = join(packageRoot, scriptPath);
     const content = await Bun.file(filePath).text();
     if (!content.includes('@cinder/')) continue;
     const scanState: CommentScanState = { inBlockComment: false };
@@ -355,7 +355,7 @@ async function assertNoQuotedCinderReferences(extractedRoot: string): Promise<vo
       }
     }
     if (offenderLine !== undefined) {
-      offenders.push(`${relative}  ←  ${offenderLine.slice(0, 120)}`);
+      offenders.push(`${scriptPath}  ←  ${offenderLine.slice(0, 120)}`);
     }
   }
   if (offenders.length > 0) {
@@ -423,13 +423,18 @@ async function assertNoDanglingSourceMapComments(extractedRoot: string): Promise
   const packageRoot = join(extractedRoot, 'package');
   const glob = new Glob('dist/**/*.{js,mjs,cjs}');
   const offenders: string[] = [];
-  for await (const relative of glob.scan({ cwd: packageRoot })) {
-    const filePath = join(packageRoot, relative);
+  for await (const scriptPath of glob.scan({ cwd: packageRoot })) {
+    const filePath = join(packageRoot, scriptPath);
     const content = await Bun.file(filePath).text();
     if (!content.includes('sourceMappingURL=')) continue;
     for (const reference of getSourceMapReferences(content)) {
-      if (existsSync(join(dirname(filePath), reference.reference))) continue;
-      offenders.push(`${relative}:${reference.line} -> ${reference.reference}`);
+      const resolvedReferencePath = resolvePath(dirname(filePath), reference.reference);
+      const pathFromPackageRoot = relative(packageRoot, resolvedReferencePath);
+      const resolvesInsidePackageRoot =
+        pathFromPackageRoot === '' ||
+        (!pathFromPackageRoot.startsWith('..') && !pathFromPackageRoot.startsWith('/'));
+      if (resolvesInsidePackageRoot && existsSync(resolvedReferencePath)) continue;
+      offenders.push(`${scriptPath}:${reference.line} -> ${reference.reference}`);
     }
   }
   if (offenders.length > 0) {


### PR DESCRIPTION
Downstream Vite/Vitest runs were warning on `@lostgradient/cinder` editor modules because published `dist/editor/*.js` files referenced missing `*.js.map` files. This change keeps the existing publish policy (do not ship `dist/**/*.js.map`) while making the publish path fail fast if any dangling `sourceMappingURL` comments remain.

## What changed
- Added a publish-path invariant in `packages/components/scripts/validate-consumers.ts` that scans packed `dist/**/*.{js,mjs,cjs}` files and fails if a relative `.map` reference does not exist.
- Hooked that invariant into the existing tarball inspection step so the release gate catches missing-map references before publish.
- Added a regression test in `packages/components/scripts/pack-for-publish.test.ts` covering the issue #578 editor references (`component-runtime`, `attach`, `editor`, `types`, `keymap-plugin`, `commands`) to ensure dangling comments are stripped while valid references are preserved.

## Notes for reviewers
- This is intentionally a packaging/release guard change, not a build-output policy change.
- The behavior remains: `.js.map` files stay excluded from the published tarball.

Fixes: #578

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes only release validation scripts and tests; published artifact policy is unchanged and failures surface before publish.
> 
> **Overview**
> Adds a **publish-path gate** so packed tarballs cannot ship `dist/**/*.js` files whose `sourceMappingURL` comments point at missing `.map` files (the maps stay excluded from the tarball by policy).
> 
> `validate-consumers.ts` now parses line and block `sourceMappingURL` comments, resolves relative `.map` paths inside the extracted package, and fails with file/line details when a reference is dangling. That check runs alongside the existing manifest and `@cinder/*` tarball inspections after `pack-for-publish`.
> 
> A regression test in `pack-for-publish.test.ts` covers the #578 editor case: strip comments for maps that are absent while keeping references whose `.map` files exist.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fbff885138fbdbb8189afc7853d00925b27ab061. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->