### PR TITLE
Add SvelteKit SSR regression guards for Sidebar snippet imports

### DIFF
--- a/packages/components/fixtures/sveltekit-consumer/src/routes/dev-ssr/+page.svelte
+++ b/packages/components/fixtures/sveltekit-consumer/src/routes/dev-ssr/+page.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
+  import { SideNavigation, SideNavigationItem, Sidebar } from '@lostgradient/cinder';
   import Card from '@lostgradient/cinder/card';
-  import Sidebar from '@lostgradient/cinder/sidebar';
   import Tab from '@lostgradient/cinder/tab';
   import TabList from '@lostgradient/cinder/tab-list';
   import TabPanel from '@lostgradient/cinder/tab-panel';
@@ -20,7 +20,11 @@
       <strong data-dev-ssr-sidebar-brand>Cinder workspace</strong>
     {/snippet}
     {#snippet navigation()}
-      <a href="/dev-ssr" data-dev-ssr-sidebar-navigation>Dev SSR route</a>
+      <SideNavigation ariaLabel="Workflow selection" data-dev-ssr-sidebar-navigation>
+        <SideNavigationItem href="/dev-ssr" active={true}>
+          <span data-dev-ssr-side-navigation-item>basicOrderWorkflow</span>
+        </SideNavigationItem>
+      </SideNavigation>
     {/snippet}
   </Sidebar>
 

--- a/packages/components/scripts/validate-consumers.ts
+++ b/packages/components/scripts/validate-consumers.ts
@@ -815,6 +815,7 @@ const SVELTEKIT_DEV_SSR_MARKERS = [
   'data-dev-ssr-card-body',
   'data-dev-ssr-sidebar-brand',
   'data-dev-ssr-sidebar-navigation',
+  'data-dev-ssr-side-navigation-item',
   'data-dev-ssr-tabs-namespace-trigger',
   'data-dev-ssr-tabs-namespace-panel',
   'data-dev-ssr-tabs-direct-trigger',
@@ -823,6 +824,18 @@ const SVELTEKIT_DEV_SSR_MARKERS = [
 
 function formatHtmlExcerpt(body: string): string {
   return body.replace(/\s+/g, ' ').trim().slice(0, 1_000);
+}
+
+function extractCinderSourceMapWarnings(logOutput: string): string[] {
+  const warningLines = logOutput
+    .split('\n')
+    .map((line) => line.trim())
+    .filter((line) => line.includes('@lostgradient/cinder/dist/'))
+    .filter((line) => /(sourcemap|source map|\.js\.map)/i.test(line))
+    .filter((line) =>
+      /(missing|not found|can't resolve|could not read|enoent|points to missing)/i.test(line),
+    );
+  return [...new Set(warningLines)];
 }
 
 async function assertSvelteKitDevSsrRoute(fixtureDirectory: string, label: string): Promise<void> {
@@ -840,6 +853,12 @@ async function assertSvelteKitDevSsrRoute(fixtureDirectory: string, label: strin
       },
     },
   );
+  const devServerStdout = devServer.stdout
+    ? new Response(devServer.stdout).text()
+    : Promise.resolve('');
+  const devServerStderr = devServer.stderr
+    ? new Response(devServer.stderr).text()
+    : Promise.resolve('');
 
   try {
     await waitForUrl(`http://127.0.0.1:${httpPort}/`, 15_000, devServer);
@@ -865,6 +884,14 @@ async function assertSvelteKitDevSsrRoute(fixtureDirectory: string, label: strin
   } finally {
     devServer.kill();
     await devServer.exited;
+    const devServerOutput = `${await devServerStdout}\n${await devServerStderr}`;
+    const sourceMapWarnings = extractCinderSourceMapWarnings(devServerOutput);
+    if (sourceMapWarnings.length > 0) {
+      fail(
+        `sveltekit-consumer ${label} dev SSR emitted source-map warnings for published cinder dist artifacts:\n` +
+          sourceMapWarnings.map((warning) => `  ${warning}`).join('\n'),
+      );
+    }
   }
 }
 

--- a/packages/components/scripts/validate-consumers.ts
+++ b/packages/components/scripts/validate-consumers.ts
@@ -840,6 +840,7 @@ function extractCinderSourceMapWarnings(logOutput: string): string[] {
 
 async function assertSvelteKitDevSsrRoute(fixtureDirectory: string, label: string): Promise<void> {
   const httpPort = await pickEphemeralPort();
+  let devSsrAssertionsPassed = false;
   const devServer = Bun.spawn(
     ['bunx', 'vite', 'dev', '--host', '127.0.0.1', '--port', String(httpPort), '--strictPort'],
     {
@@ -881,16 +882,23 @@ async function assertSvelteKitDevSsrRoute(fixtureDirectory: string, label: strin
         `sveltekit-consumer ${label} /dev-ssr dev SSR missing marker(s): ${missingMarkers.join(', ')}\n${formatHtmlExcerpt(body)}`,
       );
     }
+
+    devSsrAssertionsPassed = true;
   } finally {
     devServer.kill();
     await devServer.exited;
     const devServerOutput = `${await devServerStdout}\n${await devServerStderr}`;
     const sourceMapWarnings = extractCinderSourceMapWarnings(devServerOutput);
     if (sourceMapWarnings.length > 0) {
-      fail(
+      const warningMessage =
         `sveltekit-consumer ${label} dev SSR emitted source-map warnings for published cinder dist artifacts:\n` +
-          sourceMapWarnings.map((warning) => `  ${warning}`).join('\n'),
-      );
+        sourceMapWarnings.map((warning) => `  ${warning}`).join('\n');
+      // Preserve the primary SSR failure if one occurred in the try block.
+      if (!devSsrAssertionsPassed) {
+        process.stderr.write(`[validate-consumers] ${warningMessage}\n`);
+      } else {
+        fail(warningMessage);
+      }
     }
   }
 }


### PR DESCRIPTION
## Why
SvelteKit consumers hit SSR failures when rendering `Sidebar` snippet content from root-barrel imports, and this path was not explicitly covered by the consumer fixture gate. We also want to catch regressions where published `dist` JS references missing sourcemaps that show up as Vite warnings.

Fixes: #580

## What changed
- Updated the `sveltekit-consumer` `/dev-ssr` fixture route to render the issue shape directly: root-barrel `Sidebar` with `SideNavigation` and `SideNavigationItem` inside snippets.
- Added a dedicated SSR marker for the nested side-navigation item and asserted it in `validate-consumers.ts`.
- Added a dev-SSR log scan in `validate-consumers.ts` that fails when Vite reports missing sourcemap warnings for `@lostgradient/cinder/dist/**` artifacts.

## Notes for reviewers
- This PR focuses on strengthening the fixture and validation gates for the reported failure mode.
- No export-condition ordering changes were required by this repro path.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to the SvelteKit consumer fixture and consumer validation script; no published component or export behavior is modified.
> 
> **Overview**
> Extends the **sveltekit-consumer** `/dev-ssr` route so it matches the reported SSR failure: **`Sidebar`** from the root barrel with **`SideNavigation`** / **`SideNavigationItem`** inside the navigation snippet, plus a new **`data-dev-ssr-side-navigation-item`** marker checked by **`validate-consumers`**.
> 
> The dev-SSR harness now **captures Vite stdout/stderr** after the server stops and **fails** when logs show missing sourcemap warnings for **`@lostgradient/cinder/dist/**`** artifacts; if HTML/marker assertions already failed, those warnings are only printed so the primary SSR error stays visible.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 429a39687888eea9d2340f7762583c20dc423910. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->