### PR TITLE
Add placement control to compound dropdown menus

### DIFF
--- a/packages/components/src/components/dropdown-menu/dropdown-menu.svelte
+++ b/packages/components/src/components/dropdown-menu/dropdown-menu.svelte
@@ -58,11 +58,12 @@
   let menuElement = $state<HTMLDivElement | null>(null);
   let focusedFallbackOpen = false;
   const typeaheadBuffer = new TypeaheadBuffer();
+  const preferredPlacement = $derived(context.fallbackPlacement ?? 'bottom-start');
   const anchoredFallback = createAnchoredOverlay({
     open: () => context.isOpen && !context.supportsPopover && Boolean(fallbackAnchorElement),
     anchor: () => fallbackAnchorElement,
     panel: () => menuElement,
-    placement: () => context.fallbackPlacement ?? 'bottom-end',
+    placement: () => preferredPlacement,
     offset: () => 4,
     widthMode: () => context.widthMode ?? 'menu',
   });
@@ -208,6 +209,9 @@
       : fallbackPositionStyle}
     role="menu"
     aria-orientation="vertical"
+    data-cinder-placement={context.supportsPopover
+      ? preferredPlacement
+      : anchoredFallback.resolvedPlacement}
     data-cinder-position-ready={!context.supportsPopover && fallbackPositionReady !== undefined
       ? fallbackPositionReady
       : undefined}

--- a/packages/components/src/components/dropdown/README.md
+++ b/packages/components/src/components/dropdown/README.md
@@ -33,14 +33,14 @@ The leaves remain importable individually for à-la-carte builds — see
 
 <!-- generated:props:start -->
 
-| Prop        | Type                               | Required | Default | Description                                                                                                                |
-| ----------- | ---------------------------------- | -------- | ------- | -------------------------------------------------------------------------------------------------------------------------- |
-| `class`     | `string`                           | no       | —       | Additional class names merged with the component's root class.                                                             |
-| `id`        | `string`                           | no       | —       | HTML id applied to the dropdown root element. Auto-generated when omitted.                                                 |
-| `open`      | `boolean`                          | no       | —       | Controls the open state of the dropdown menu; bindable for controlled usage.                                               |
-| `placement` | `"bottom-start"` \| `"bottom-end"` | no       | —       | Preferred side of the trigger on which the menu opens. Default `bottom-start`.                                             |
-| `children`  | `(opaque)`                         | no       | —       | A function or snippet prop. Its shape is not captured by the JSON schema; see the component types for the exact signature. |
-| `trigger`   | `(opaque)`                         | no       | —       | A function or snippet prop. Its shape is not captured by the JSON schema; see the component types for the exact signature. |
+| Prop        | Type                                                               | Required | Default | Description                                                                                                                             |
+| ----------- | ------------------------------------------------------------------ | -------- | ------- | --------------------------------------------------------------------------------------------------------------------------------------- |
+| `class`     | `string`                                                           | no       | —       | Additional class names merged with the component's root class.                                                                          |
+| `id`        | `string`                                                           | no       | —       | HTML id applied to the dropdown root element. Auto-generated when omitted.                                                              |
+| `open`      | `boolean`                                                          | no       | —       | Controls the open state of the dropdown menu; bindable for controlled usage.                                                            |
+| `placement` | `"top-start"` \| `"top-end"` \| `"bottom-start"` \| `"bottom-end"` | no       | —       | Preferred menu placement relative to the trigger. Default `bottom-start`. The rendered menu may still flip to stay within the viewport. |
+| `children`  | `(opaque)`                                                         | no       | —       | A function or snippet prop. Its shape is not captured by the JSON schema; see the component types for the exact signature.              |
+| `trigger`   | `(opaque)`                                                         | no       | —       | A function or snippet prop. Its shape is not captured by the JSON schema; see the component types for the exact signature.              |
 
 <!-- generated:props:end -->
 

--- a/packages/components/src/components/dropdown/dropdown.css
+++ b/packages/components/src/components/dropdown/dropdown.css
@@ -264,15 +264,26 @@
     .cinder-dropdown-menu[popover] {
       position: fixed;
       inset: auto;
-      top: calc(anchor(bottom) + var(--cinder-space-1));
-      left: auto;
-      right: anchor(right);
+      inset-block-start: calc(anchor(bottom) + var(--cinder-space-1));
+      inset-inline-end: anchor(right);
+      inset-inline-start: auto;
       position-try-fallbacks: flip-block, flip-inline;
     }
 
-    .cinder-dropdown-menu[popover][dir='rtl'] {
-      right: auto;
-      left: anchor(left);
+    .cinder-dropdown-menu[popover][data-cinder-placement='bottom-start'] {
+      inset-inline-start: anchor(left);
+      inset-inline-end: auto;
+    }
+
+    .cinder-dropdown-menu[popover][data-cinder-placement='top-start'],
+    .cinder-dropdown-menu[popover][data-cinder-placement='top-end'] {
+      inset-block-start: auto;
+      inset-block-end: calc(anchor(top) + var(--cinder-space-1));
+    }
+
+    .cinder-dropdown-menu[popover][data-cinder-placement='top-start'] {
+      inset-inline-start: anchor(left);
+      inset-inline-end: auto;
     }
 
     .cinder-dropdown__menu[popover] {
@@ -288,6 +299,22 @@
     }
 
     .cinder-dropdown[data-cinder-placement='bottom-end'] .cinder-dropdown__menu[popover] {
+      inset-inline-end: anchor(right);
+      inset-inline-start: auto;
+    }
+
+    .cinder-dropdown[data-cinder-placement='top-start'] .cinder-dropdown__menu[popover],
+    .cinder-dropdown[data-cinder-placement='top-end'] .cinder-dropdown__menu[popover] {
+      inset-block-start: auto;
+      inset-block-end: calc(anchor(top) + var(--cinder-space-1));
+    }
+
+    .cinder-dropdown[data-cinder-placement='top-start'] .cinder-dropdown__menu[popover] {
+      inset-inline-start: anchor(left);
+      inset-inline-end: auto;
+    }
+
+    .cinder-dropdown[data-cinder-placement='top-end'] .cinder-dropdown__menu[popover] {
       inset-inline-end: anchor(right);
       inset-inline-start: auto;
     }
@@ -309,6 +336,20 @@
   .cinder-dropdown[data-cinder-placement='bottom-end'] .cinder-dropdown__menu:not([popover]) {
     position: absolute;
     inset-block-start: calc(100% + var(--cinder-space-1));
+    inset-inline-end: 0;
+  }
+
+  .cinder-dropdown[data-cinder-placement='top-start'] .cinder-dropdown__menu:not([popover]) {
+    position: absolute;
+    inset-block-start: auto;
+    inset-block-end: calc(100% + var(--cinder-space-1));
+    inset-inline-start: 0;
+  }
+
+  .cinder-dropdown[data-cinder-placement='top-end'] .cinder-dropdown__menu:not([popover]) {
+    position: absolute;
+    inset-block-start: auto;
+    inset-block-end: calc(100% + var(--cinder-space-1));
     inset-inline-end: 0;
   }
 

--- a/packages/components/src/components/dropdown/dropdown.css
+++ b/packages/components/src/components/dropdown/dropdown.css
@@ -286,6 +286,18 @@
       inset-inline-end: auto;
     }
 
+    .cinder-dropdown-menu[popover][dir='rtl'][data-cinder-placement='bottom-start'],
+    .cinder-dropdown-menu[popover][dir='rtl'][data-cinder-placement='top-start'] {
+      inset-inline-end: anchor(right);
+      inset-inline-start: auto;
+    }
+
+    .cinder-dropdown-menu[popover][dir='rtl'][data-cinder-placement='bottom-end'],
+    .cinder-dropdown-menu[popover][dir='rtl'][data-cinder-placement='top-end'] {
+      inset-inline-start: anchor(left);
+      inset-inline-end: auto;
+    }
+
     .cinder-dropdown__menu[popover] {
       position: fixed;
       margin: 0;

--- a/packages/components/src/components/dropdown/dropdown.examples.json
+++ b/packages/components/src/components/dropdown/dropdown.examples.json
@@ -12,8 +12,8 @@
     {
       "id": "placement",
       "title": "Placement",
-      "description": "bottom-start and bottom-end placement options.",
-      "code": "<script lang=\"ts\">\n  import { Button } from '@lostgradient/cinder/button';\n  import { Dropdown } from '@lostgradient/cinder/dropdown';\n  let openStart = $state(false);\n  let openEnd = $state(false);\n</script>\n\n<div class=\"example-preview-row\">\n  <Dropdown bind:open={openStart} placement=\"bottom-start\">\n    {#snippet trigger()}\n      <Button variant=\"secondary\">Bottom-start</Button>\n    {/snippet}\n    <div style=\"padding: 0.5rem 1rem; min-width: 140px;\">Aligned to left edge</div>\n  </Dropdown>\n\n  <Dropdown bind:open={openEnd} placement=\"bottom-end\">\n    {#snippet trigger()}\n      <Button variant=\"secondary\">Bottom-end</Button>\n    {/snippet}\n    <div style=\"padding: 0.5rem 1rem; min-width: 140px;\">Aligned to right edge</div>\n  </Dropdown>\n</div>\n"
+      "description": "Use top or bottom placements to keep the menu aligned with the trigger edge that makes sense for the surrounding layout.",
+      "code": "<script lang=\"ts\">\n  import { Dropdown } from '@lostgradient/cinder/dropdown';\n</script>\n\n<div style=\"display: grid; gap: 1rem; justify-items: start; align-items: start; min-height: 14rem; padding-block-start: 4rem;\">\n  <Dropdown id=\"dropdown-placement-top-end\" placement=\"top-end\">\n    <Dropdown.Trigger>Top-end</Dropdown.Trigger>\n    <Dropdown.Menu>\n      <Dropdown.Item>Profile</Dropdown.Item>\n      <Dropdown.Item>Billing</Dropdown.Item>\n      <Dropdown.Item>Sign out</Dropdown.Item>\n    </Dropdown.Menu>\n  </Dropdown>\n\n  <Dropdown id=\"dropdown-placement-bottom-start\" placement=\"bottom-start\">\n    <Dropdown.Trigger>Bottom-start</Dropdown.Trigger>\n    <Dropdown.Menu>\n      <Dropdown.Item>Duplicate</Dropdown.Item>\n      <Dropdown.Item>Rename</Dropdown.Item>\n      <Dropdown.Item variant=\"danger\">Archive</Dropdown.Item>\n    </Dropdown.Menu>\n  </Dropdown>\n</div>\n"
     },
     {
       "id": "with-items",

--- a/packages/components/src/components/dropdown/dropdown.schema.json
+++ b/packages/components/src/components/dropdown/dropdown.schema.json
@@ -15,8 +15,8 @@
       "description": "Controls the open state of the dropdown menu; bindable for controlled usage."
     },
     "placement": {
-      "enum": ["bottom-start", "bottom-end"],
-      "description": "Preferred side of the trigger on which the menu opens. Default `bottom-start`."
+      "enum": ["top-start", "top-end", "bottom-start", "bottom-end"],
+      "description": "Preferred menu placement relative to the trigger. Default `bottom-start`.\nThe rendered menu may still flip to stay within the viewport."
     }
   },
   "additionalProperties": false,

--- a/packages/components/src/components/dropdown/dropdown.schema.ts
+++ b/packages/components/src/components/dropdown/dropdown.schema.ts
@@ -17,8 +17,9 @@ const schema = {
       description: 'Controls the open state of the dropdown menu; bindable for controlled usage.',
     },
     placement: {
-      enum: ['bottom-start', 'bottom-end'],
-      description: 'Preferred side of the trigger on which the menu opens. Default `bottom-start`.',
+      enum: ['top-start', 'top-end', 'bottom-start', 'bottom-end'],
+      description:
+        'Preferred menu placement relative to the trigger. Default `bottom-start`.\nThe rendered menu may still flip to stay within the viewport.',
     },
   },
   additionalProperties: false,

--- a/packages/components/src/components/dropdown/dropdown.svelte
+++ b/packages/components/src/components/dropdown/dropdown.svelte
@@ -99,7 +99,7 @@
       return compoundTriggerElement;
     },
     get fallbackPlacement() {
-      return 'bottom-end' as const;
+      return placement;
     },
     get widthMode() {
       return 'menu' as const;

--- a/packages/components/src/components/dropdown/dropdown.test.ts
+++ b/packages/components/src/components/dropdown/dropdown.test.ts
@@ -699,13 +699,19 @@ describe('Dropdown', () => {
     );
   });
 
-  test('popover dropdown menu uses logical inline anchors for direction-aware mirroring', async () => {
+  test('popover dropdown menu preserves start/end anchoring in RTL', async () => {
     const css = await readDropdownCss();
     expect(css).toMatch(
       /\.cinder-dropdown-menu\[popover\]\s*\{[^}]*inset-inline-end:\s*anchor\(right\);[^}]*inset-inline-start:\s*auto;/,
     );
     expect(css).toMatch(
       /\.cinder-dropdown-menu\[popover\]\[data-cinder-placement='bottom-start'\]\s*\{[^}]*inset-inline-start:\s*anchor\(left\);[^}]*inset-inline-end:\s*auto;/,
+    );
+    expect(css).toMatch(
+      /\.cinder-dropdown-menu\[popover\]\[dir='rtl'\]\[data-cinder-placement='bottom-start'\],\s*\.cinder-dropdown-menu\[popover\]\[dir='rtl'\]\[data-cinder-placement='top-start'\]\s*\{[^}]*inset-inline-end:\s*anchor\(right\);[^}]*inset-inline-start:\s*auto;/,
+    );
+    expect(css).toMatch(
+      /\.cinder-dropdown-menu\[popover\]\[dir='rtl'\]\[data-cinder-placement='bottom-end'\],\s*\.cinder-dropdown-menu\[popover\]\[dir='rtl'\]\[data-cinder-placement='top-end'\]\s*\{[^}]*inset-inline-start:\s*anchor\(left\);[^}]*inset-inline-end:\s*auto;/,
     );
   });
 });

--- a/packages/components/src/components/dropdown/dropdown.test.ts
+++ b/packages/components/src/components/dropdown/dropdown.test.ts
@@ -244,6 +244,28 @@ describe('Dropdown', () => {
     expect(root?.getAttribute('data-cinder-placement')).toBe('bottom-start');
   });
 
+  test('compound dropdown reflects an explicit placement prop on the root element', () => {
+    const { container } = render(DropdownCompoundFixture, {
+      props: { placement: 'top-end' },
+    });
+
+    const root = container.querySelector('.cinder-dropdown');
+    expect(root?.getAttribute('data-cinder-placement')).toBe('top-end');
+  });
+
+  test('compound menu carries placement metadata used by the menu surface', async () => {
+    const { container } = render(DropdownCompoundFixture, {
+      props: { placement: 'top-end' },
+    });
+
+    const trigger = container.querySelector('.trigger');
+    expect(trigger).not.toBeNull();
+    await fireEvent.click(trigger as Element);
+
+    const menu = document.body.querySelector('.cinder-dropdown-menu');
+    expect(menu?.getAttribute('data-cinder-placement')).toBe('top-end');
+  });
+
   test('menu children content is rendered when open', () => {
     const { container } = render(Dropdown, {
       props: {
@@ -267,6 +289,32 @@ describe('Dropdown', () => {
     const triggerWrapper = container.querySelector('.cinder-dropdown__trigger');
     expect(triggerWrapper).not.toBeNull();
     expect(triggerWrapper?.textContent).toContain('Open Menu');
+  });
+
+  test('dropdown CSS defines explicit top placement rules for both compound and legacy popover surfaces', async () => {
+    const dropdownCss = await Bun.file(new URL('./dropdown.css', import.meta.url)).text();
+
+    expect(dropdownCss).toContain(
+      ".cinder-dropdown-menu[popover][data-cinder-placement='top-start']",
+    );
+    expect(dropdownCss).toContain(
+      ".cinder-dropdown-menu[popover][data-cinder-placement='top-end']",
+    );
+    expect(dropdownCss).toContain(
+      ".cinder-dropdown[data-cinder-placement='top-start'] .cinder-dropdown__menu[popover]",
+    );
+    expect(dropdownCss).toContain(
+      ".cinder-dropdown-menu[popover][data-cinder-placement='bottom-start']",
+    );
+    expect(dropdownCss).toContain(
+      ".cinder-dropdown[data-cinder-placement='top-end'] .cinder-dropdown__menu[popover]",
+    );
+    expect(dropdownCss).toContain(
+      ".cinder-dropdown[data-cinder-placement='top-start'] .cinder-dropdown__menu:not([popover])",
+    );
+    expect(dropdownCss).toContain(
+      ".cinder-dropdown[data-cinder-placement='top-end'] .cinder-dropdown__menu:not([popover])",
+    );
   });
 
   test('compound trigger wires menu ARIA to the button', () => {
@@ -651,10 +699,13 @@ describe('Dropdown', () => {
     );
   });
 
-  test('popover dropdown menu mirrors anchor edge in right-to-left direction', async () => {
+  test('popover dropdown menu uses logical inline anchors for direction-aware mirroring', async () => {
     const css = await readDropdownCss();
     expect(css).toMatch(
-      /\.cinder-dropdown-menu\[popover\]\[dir='rtl'\]\s*\{[^}]*right:\s*auto;[^}]*left:\s*anchor\(left\);/,
+      /\.cinder-dropdown-menu\[popover\]\s*\{[^}]*inset-inline-end:\s*anchor\(right\);[^}]*inset-inline-start:\s*auto;/,
+    );
+    expect(css).toMatch(
+      /\.cinder-dropdown-menu\[popover\]\[data-cinder-placement='bottom-start'\]\s*\{[^}]*inset-inline-start:\s*anchor\(left\);[^}]*inset-inline-end:\s*auto;/,
     );
   });
 });

--- a/packages/components/src/components/dropdown/dropdown.types.ts
+++ b/packages/components/src/components/dropdown/dropdown.types.ts
@@ -2,7 +2,7 @@ import type { Placement } from '@floating-ui/dom';
 import type { Snippet } from 'svelte';
 import type { HTMLAttributes } from 'svelte/elements';
 import type { AnchoredOverlayWidthMode } from '../../_internal/anchored-overlay.svelte.ts';
-export type DropdownPlacement = 'bottom-start' | 'bottom-end';
+export type DropdownPlacement = 'top-start' | 'top-end' | 'bottom-start' | 'bottom-end';
 export type DropdownContext = {
   get menuId(): string;
   get isOpen(): boolean;
@@ -26,7 +26,10 @@ type DropdownBaseProps = Omit<HTMLAttributes<HTMLDivElement>, 'class'> & {
 type LegacyDropdownProps = DropdownBaseProps & {
   /** Controls the open state of the dropdown menu; bindable for controlled usage. */
   open?: boolean;
-  /** Preferred side of the trigger on which the menu opens. Default `bottom-start`. */
+  /**
+   * Preferred menu placement relative to the trigger. Default `bottom-start`.
+   * The rendered menu may still flip to stay within the viewport.
+   */
   placement?: DropdownPlacement;
   trigger: Snippet;
   children: Snippet;
@@ -36,6 +39,10 @@ type CompoundDropdownProps = DropdownBaseProps & {
   children?: Snippet;
   trigger?: never;
   open?: never;
-  placement?: never;
+  /**
+   * Preferred menu placement relative to the trigger. Default `bottom-start`.
+   * The rendered menu may still flip to stay within the viewport.
+   */
+  placement?: DropdownPlacement;
 };
 export type DropdownProps = LegacyDropdownProps | CompoundDropdownProps;

--- a/packages/components/src/test/fixtures/dropdown-compound-fixture.svelte
+++ b/packages/components/src/test/fixtures/dropdown-compound-fixture.svelte
@@ -6,12 +6,15 @@
   import DropdownMenu from '../../components/dropdown-menu/dropdown-menu.svelte';
   import DropdownSeparator from '../../components/dropdown-separator/dropdown-separator.svelte';
   import DropdownTrigger from '../../components/dropdown-trigger/dropdown-trigger.svelte';
+  import type { DropdownPlacement } from '../../components/dropdown/dropdown.types.ts';
+
+  let { placement = 'bottom-start' }: { placement?: DropdownPlacement } = $props();
 
   let selected = $state('');
 </script>
 
 <div>
-  <Dropdown id="actions-menu">
+  <Dropdown id="actions-menu" {placement}>
     <DropdownTrigger class="trigger">Actions</DropdownTrigger>
     <DropdownMenu>
       <DropdownGroup labelledBy="actions-menu-document-label">


### PR DESCRIPTION
Compound dropdowns could not choose their menu placement, and the compound fallback path hardcoded `bottom-end`. That made footer and sidebar menus prone to rendering off-screen near the viewport bottom even though the underlying positioning logic already supports collision-aware flipping.

## Summary

- expose `placement` on the compound `Dropdown` root with the menu-oriented placements `top-start`, `top-end`, `bottom-start`, and `bottom-end`
- thread the chosen placement through both compound rendering paths so the floating-ui fallback and the popover/CSS-anchor path honor the same placement hint
- keep collision handling intact so menus can still flip when the requested placement would clip the viewport
- update dropdown schema, generated docs, examples, and regression coverage for the new compound API

Fixes: #584

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches overlay positioning across popover, CSS anchor, and Floating UI paths; behavior is localized to dropdown UI with regression tests but incorrect placement could still clip menus in edge layouts.
> 
> **Overview**
> Compound **`Dropdown`** roots can now take a **`placement`** prop (`top-start`, `top-end`, `bottom-start`, `bottom-end`) instead of ignoring placement and forcing **`bottom-end`** on the Floating UI fallback. The chosen value flows through dropdown context into **`DropdownMenu`**, which sets **`data-cinder-placement`** and uses it for anchored overlay fallback (defaulting to **`bottom-start`** when unset).
> 
> **`dropdown.css`** gains placement-aware rules for popover/CSS anchor positioning and the non-popover path, including **top** placements and RTL start/end anchoring via logical insets. Schema, README, examples, and tests are updated to match the expanded API.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f3df17131268b0d5455c336e453649fa61d73422. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->