### PR TITLE
Harden unit test cache restore

### DIFF
--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -173,7 +173,7 @@ jobs:
             bun-${{ runner.os }}-${{ runner.arch }}-${{ env.BUN_VERSION }}-
 
       - name: Verify Bun cache restore
-        if: steps.bun-cache-restore.outputs.cache-matched-key == '' && steps.bun-cache-restore-retry.outputs.cache-matched-key == ''
+        if: steps.bun-cache-restore.outputs.cache-matched-key == '' && steps.bun-cache-restore-retry.outputs.cache-matched-key == '' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
         env:
           GH_TOKEN: ${{ github.token }}
           BUN_CACHE_KEY_PREFIX: bun-${{ runner.os }}-${{ runner.arch }}-${{ env.BUN_VERSION }}-

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -164,7 +164,7 @@ jobs:
       # memory-sensitive test suite.
       - name: Retry Bun install cache restore
         id: bun-cache-restore-retry
-        if: steps.bun-cache-restore.outputs.cache-hit == ''
+        if: steps.bun-cache-restore.outputs.cache-matched-key == ''
         uses: actions/cache/restore@v4
         with:
           path: ~/.bun/install/cache
@@ -173,7 +173,7 @@ jobs:
             bun-${{ runner.os }}-${{ runner.arch }}-${{ env.BUN_VERSION }}-
 
       - name: Verify Bun cache restore
-        if: steps.bun-cache-restore.outputs.cache-hit == '' && steps.bun-cache-restore-retry.outputs.cache-hit == ''
+        if: steps.bun-cache-restore.outputs.cache-matched-key == '' && steps.bun-cache-restore-retry.outputs.cache-matched-key == ''
         env:
           GH_TOKEN: ${{ github.token }}
           BUN_CACHE_KEY_PREFIX: bun-${{ runner.os }}-${{ runner.arch }}-${{ env.BUN_VERSION }}-

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -72,6 +72,7 @@ on:
   workflow_dispatch:
 
 permissions:
+  actions: read
   contents: read
 
 concurrency:
@@ -149,16 +150,60 @@ jobs:
         with:
           bun-version: ${{ env.BUN_VERSION }}
 
-      - name: Cache Bun install
-        uses: actions/cache@v4
+      - name: Restore Bun install cache
+        id: bun-cache-restore
+        uses: actions/cache/restore@v4
         with:
           path: ~/.bun/install/cache
           key: bun-${{ runner.os }}-${{ runner.arch }}-${{ env.BUN_VERSION }}-${{ hashFiles('bun.lock') }}
           restore-keys: |
             bun-${{ runner.os }}-${{ runner.arch }}-${{ env.BUN_VERSION }}-
 
+      # GitHub's cache service has intermittently returned 400s while letting
+      # this job continue cold. Retry an empty restore once before running the
+      # memory-sensitive test suite.
+      - name: Retry Bun install cache restore
+        id: bun-cache-restore-retry
+        if: steps.bun-cache-restore.outputs.cache-hit == ''
+        uses: actions/cache/restore@v4
+        with:
+          path: ~/.bun/install/cache
+          key: bun-${{ runner.os }}-${{ runner.arch }}-${{ env.BUN_VERSION }}-${{ hashFiles('bun.lock') }}
+          restore-keys: |
+            bun-${{ runner.os }}-${{ runner.arch }}-${{ env.BUN_VERSION }}-
+
+      - name: Verify Bun cache restore
+        if: steps.bun-cache-restore.outputs.cache-hit == '' && steps.bun-cache-restore-retry.outputs.cache-hit == ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+          BUN_CACHE_KEY_PREFIX: bun-${{ runner.os }}-${{ runner.arch }}-${{ env.BUN_VERSION }}-
+        run: |
+          set -euo pipefail
+
+          cache_count=$(gh cache list \
+            --repo "$GITHUB_REPOSITORY" \
+            --ref refs/heads/main \
+            --key "$BUN_CACHE_KEY_PREFIX" \
+            --limit 1 \
+            --json key \
+            --jq 'length')
+
+          if [ "$cache_count" != "0" ]; then
+            echo "::error::No Bun install cache was restored after two attempts, but a matching default-branch cache exists. Rerun this job instead of continuing with a cold dependency cache."
+            exit 1
+          fi
+
+          echo "::notice::No matching default-branch Bun install cache exists yet; continuing with a cold dependency install."
+
       - name: Install dependencies
         run: bun install --frozen-lockfile
+
+      - name: Save Bun install cache
+        if: steps.bun-cache-restore.outputs.cache-hit != 'true' && steps.bun-cache-restore-retry.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: ~/.bun/install/cache
+          key: bun-${{ runner.os }}-${{ runner.arch }}-${{ env.BUN_VERSION }}-${{ hashFiles('bun.lock') }}
 
       # Unconditional whole-repo invariant: every component CSS partial must be
       # reachable from the aggregate styles/components.css @import chain, or the

--- a/packages/components/scripts/test-changed.test.ts
+++ b/packages/components/scripts/test-changed.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'bun:test';
 
-import { parseEnvSlugs, testPathsForScope } from './test-changed.ts';
+import { fullSuiteTestPathGroups, parseEnvSlugs, testPathsForScope } from './test-changed.ts';
 
 describe('parseEnvSlugs', () => {
   it('returns an empty list when unset', () => {
@@ -52,5 +52,28 @@ describe('testPathsForScope', () => {
     // scripts/ tooling tests run only when scripts/ changes (which force-fulls).
     expect(paths).not.toContain('scripts');
     expect(paths).toContain('src/components/accordion');
+  });
+});
+
+describe('fullSuiteTestPathGroups', () => {
+  it('keeps full-suite package tests in the first chunk', () => {
+    const groups = fullSuiteTestPathGroups([]);
+    expect(groups[0]).toContain('scripts');
+    expect(groups[0]).toContain('src/test');
+    expect(groups[0]).toContain('src/exports-drift.test.ts');
+  });
+
+  it('splits component directories into deterministic chunks', () => {
+    const groups = fullSuiteTestPathGroups(['checkbox', 'accordion', 'button', 'badge', 'alert']);
+    const paths = groups.flat();
+    expect(paths).toContain('src/components/accordion');
+    expect(paths).toContain('src/components/alert');
+    expect(paths).toContain('src/components/badge');
+    expect(paths).toContain('src/components/button');
+    expect(paths).toContain('src/components/checkbox');
+    expect(groups[0]).toContain('src/components/accordion');
+    expect(groups[1]).toContain('src/components/alert');
+    expect(groups[2]).toContain('src/components/badge');
+    expect(groups[3]).toContain('src/components/button');
   });
 });

--- a/packages/components/scripts/test-changed.test.ts
+++ b/packages/components/scripts/test-changed.test.ts
@@ -39,8 +39,8 @@ describe('testPathsForScope', () => {
     expect(paths).toContain('src/api-contract.test.ts');
     expect(paths).toContain('src/manifest.test.ts');
     // The scoped component dirs.
-    expect(paths).toContain('src/components/button');
-    expect(paths).toContain('src/components/badge');
+    expect(paths).toContain('src/components/button/');
+    expect(paths).toContain('src/components/badge/');
   });
 
   it('always includes shared dirs + root invariant tests but NOT scripts/', () => {
@@ -51,7 +51,7 @@ describe('testPathsForScope', () => {
     expect(paths).toContain('src/exports-drift.test.ts');
     // scripts/ tooling tests run only when scripts/ changes (which force-fulls).
     expect(paths).not.toContain('scripts');
-    expect(paths).toContain('src/components/accordion');
+    expect(paths).toContain('src/components/accordion/');
   });
 });
 
@@ -63,21 +63,33 @@ describe('fullSuiteTestPathGroups', () => {
     expect(groups[0]).toContain('src/exports-drift.test.ts');
     expect(groups[0]).toContain('src/root-type-exports.test.ts');
     expect(groups[0]).toContain('src/components/svg-data-uri-color-literals.test.ts');
+    expect(groups[0]).toContain('src/components/_internal/create-sliding-dialog-state.test.ts');
     expect(groups[0]).toContain('src/components/_radio/radio.test.ts');
+    expect(groups[0]).toContain('src/components/_timeline-item/timeline-item.test.ts');
+    expect(groups[0]).toContain('src/components/_timeline-item/timeline-item.types.test.ts');
+    expect(groups[0]).toContain('src/components/_tree-select-all/tree-select-all.test.ts');
+    expect(groups[0]).toContain('src/components/_visually-hidden-live-region.test.ts');
     expect(groups[0]).toContain('src/components/icons/index.test.ts');
   });
 
   it('splits component directories into deterministic chunks', () => {
     const groups = fullSuiteTestPathGroups(['checkbox', 'accordion', 'button', 'badge', 'alert']);
     const paths = groups.flat();
-    expect(paths).toContain('src/components/accordion');
-    expect(paths).toContain('src/components/alert');
-    expect(paths).toContain('src/components/badge');
-    expect(paths).toContain('src/components/button');
-    expect(paths).toContain('src/components/checkbox');
-    expect(groups[0]).toContain('src/components/accordion');
-    expect(groups[1]).toContain('src/components/alert');
-    expect(groups[2]).toContain('src/components/badge');
-    expect(groups[3]).toContain('src/components/button');
+    expect(paths).toContain('src/components/accordion/');
+    expect(paths).toContain('src/components/alert/');
+    expect(paths).toContain('src/components/badge/');
+    expect(paths).toContain('src/components/button/');
+    expect(paths).toContain('src/components/checkbox/');
+    expect(groups[0]).toContain('src/components/accordion/');
+    expect(groups[1]).toContain('src/components/alert/');
+    expect(groups[2]).toContain('src/components/badge/');
+    expect(groups[3]).toContain('src/components/button/');
+  });
+
+  it('keeps prefix-neighbor component directories distinct', () => {
+    const paths = fullSuiteTestPathGroups(['accordion', 'accordion-item']).flat();
+    expect(paths).toContain('src/components/accordion/');
+    expect(paths).toContain('src/components/accordion-item/');
+    expect(paths).not.toContain('src/components/accordion');
   });
 });

--- a/packages/components/scripts/test-changed.test.ts
+++ b/packages/components/scripts/test-changed.test.ts
@@ -61,6 +61,10 @@ describe('fullSuiteTestPathGroups', () => {
     expect(groups[0]).toContain('scripts');
     expect(groups[0]).toContain('src/test');
     expect(groups[0]).toContain('src/exports-drift.test.ts');
+    expect(groups[0]).toContain('src/root-type-exports.test.ts');
+    expect(groups[0]).toContain('src/components/svg-data-uri-color-literals.test.ts');
+    expect(groups[0]).toContain('src/components/_radio/radio.test.ts');
+    expect(groups[0]).toContain('src/components/icons/index.test.ts');
   });
 
   it('splits component directories into deterministic chunks', () => {

--- a/packages/components/scripts/test-changed.test.ts
+++ b/packages/components/scripts/test-changed.test.ts
@@ -92,4 +92,10 @@ describe('fullSuiteTestPathGroups', () => {
     expect(paths).toContain('src/components/accordion-item/');
     expect(paths).not.toContain('src/components/accordion');
   });
+
+  it('throws instead of dropping missing component directories', () => {
+    expect(() => fullSuiteTestPathGroups(['definitely-missing-component'])).toThrow(
+      'full-suite chunk 1 references missing test path(s): src/components/definitely-missing-component/',
+    );
+  });
 });

--- a/packages/components/scripts/test-changed.ts
+++ b/packages/components/scripts/test-changed.ts
@@ -92,7 +92,12 @@ const ALWAYS_RUN_ROOT_TESTS = [
  * slugs returned from `loadKnownSlugs()`. They still belong to the full suite.
  */
 const FULL_SUITE_PRIVATE_COMPONENT_TESTS = [
+  'src/components/_internal/create-sliding-dialog-state.test.ts',
   'src/components/_radio/radio.test.ts',
+  'src/components/_timeline-item/timeline-item.test.ts',
+  'src/components/_timeline-item/timeline-item.types.test.ts',
+  'src/components/_tree-select-all/tree-select-all.test.ts',
+  'src/components/_visually-hidden-live-region.test.ts',
   'src/components/icons/index.test.ts',
   'src/components/svg-data-uri-color-literals.test.ts',
 ] as const;
@@ -115,6 +120,10 @@ const FULL_SUITE_NON_COMPONENT_PATHS = [
   ...FULL_SUITE_PRIVATE_COMPONENT_TESTS,
 ] as const;
 
+function componentTestPath(slug: string): string {
+  return `src/components/${slug}/`;
+}
+
 /**
  * Map a scope decision to the positional path arguments for `bun test`.
  *
@@ -128,7 +137,7 @@ export function testPathsForScope(decision: ScopeDecision): string[] | null {
 
   const paths: string[] = [...ALWAYS_RUN_PATHS, ...ALWAYS_RUN_ROOT_TESTS];
   for (const slug of decision.slugs) {
-    paths.push(`src/components/${slug}`);
+    paths.push(componentTestPath(slug));
   }
   return paths;
 }
@@ -138,7 +147,7 @@ export function fullSuiteTestPathGroups(componentSlugs: string[]): string[][] {
   groups[0]!.push(...FULL_SUITE_NON_COMPONENT_PATHS);
 
   for (const [index, slug] of [...componentSlugs].toSorted().entries()) {
-    groups[index % FULL_SUITE_CHUNK_COUNT]!.push(`src/components/${slug}`);
+    groups[index % FULL_SUITE_CHUNK_COUNT]!.push(componentTestPath(slug));
   }
 
   return groups

--- a/packages/components/scripts/test-changed.ts
+++ b/packages/components/scripts/test-changed.ts
@@ -95,6 +95,14 @@ const BUN_TEST_FLAGS = [
   '--parallel=1',
 ] as const;
 
+const FULL_SUITE_CHUNK_COUNT = 4;
+
+const FULL_SUITE_NON_COMPONENT_PATHS = [
+  'scripts',
+  ...ALWAYS_RUN_PATHS,
+  ...ALWAYS_RUN_ROOT_TESTS,
+] as const;
+
 /**
  * Map a scope decision to the positional path arguments for `bun test`.
  *
@@ -111,6 +119,19 @@ export function testPathsForScope(decision: ScopeDecision): string[] | null {
     paths.push(`src/components/${slug}`);
   }
   return paths;
+}
+
+export function fullSuiteTestPathGroups(componentSlugs: string[]): string[][] {
+  const groups = Array.from({ length: FULL_SUITE_CHUNK_COUNT }, () => [] as string[]);
+  groups[0]!.push(...FULL_SUITE_NON_COMPONENT_PATHS);
+
+  for (const [index, slug] of [...componentSlugs].toSorted().entries()) {
+    groups[index % FULL_SUITE_CHUNK_COUNT]!.push(`src/components/${slug}`);
+  }
+
+  return groups
+    .map((group) => group.filter((path) => existsSync(join(packageRoot, path))))
+    .filter((group) => group.length > 0);
 }
 
 /** Parse the `CINDER_TEST_COMPONENTS` env var into a slug list (empty = unset). */
@@ -195,6 +216,20 @@ async function main(): Promise<void> {
   if (paths === null) {
     const reason = decision.mode === 'full' ? decision.reason : 'no scoped slugs';
     process.stderr.write(`test-changed: full suite (${reason})\n`);
+    const componentSlugs = [...(await loadKnownSlugs())];
+    const groups = fullSuiteTestPathGroups(componentSlugs);
+
+    for (const [index, group] of groups.entries()) {
+      process.stderr.write(`test-changed: full suite chunk ${index + 1}/${groups.length}\n`);
+      const child = Bun.spawn(['bun', 'test', ...BUN_TEST_FLAGS, ...group], {
+        cwd: packageRoot,
+        stdio: ['inherit', 'inherit', 'inherit'],
+        env: { ...process.env, TZ: 'UTC', LANG: 'en_US.UTF-8' },
+      });
+      const exitCode = await child.exited;
+      if (exitCode !== 0) process.exit(exitCode);
+    }
+    return;
   } else {
     process.stderr.write(
       `test-changed: ${decision.mode === 'filtered' ? decision.slugs.length : 0} component(s): ` +
@@ -202,8 +237,7 @@ async function main(): Promise<void> {
     );
   }
 
-  const positional = paths ?? [];
-  const child = Bun.spawn(['bun', 'test', ...BUN_TEST_FLAGS, ...positional], {
+  const child = Bun.spawn(['bun', 'test', ...BUN_TEST_FLAGS, ...paths], {
     cwd: packageRoot,
     stdio: ['inherit', 'inherit', 'inherit'],
     env: { ...process.env, TZ: 'UTC', LANG: 'en_US.UTF-8' },

--- a/packages/components/scripts/test-changed.ts
+++ b/packages/components/scripts/test-changed.ts
@@ -83,7 +83,18 @@ const ALWAYS_RUN_ROOT_TESTS = [
   'src/exports-drift.test.ts',
   'src/index.test.ts',
   'src/manifest.test.ts',
+  'src/root-type-exports.test.ts',
   'src/tree-shake.test.ts',
+] as const;
+
+/**
+ * Test files under `src/components/` that are not owned by public component
+ * slugs returned from `loadKnownSlugs()`. They still belong to the full suite.
+ */
+const FULL_SUITE_PRIVATE_COMPONENT_TESTS = [
+  'src/components/_radio/radio.test.ts',
+  'src/components/icons/index.test.ts',
+  'src/components/svg-data-uri-color-literals.test.ts',
 ] as const;
 
 /** The `bun test` flags the components package uses (browser+svelte conditions). */
@@ -101,6 +112,7 @@ const FULL_SUITE_NON_COMPONENT_PATHS = [
   'scripts',
   ...ALWAYS_RUN_PATHS,
   ...ALWAYS_RUN_ROOT_TESTS,
+  ...FULL_SUITE_PRIVATE_COMPONENT_TESTS,
 ] as const;
 
 /**

--- a/packages/components/scripts/test-changed.ts
+++ b/packages/components/scripts/test-changed.ts
@@ -124,6 +124,16 @@ function componentTestPath(slug: string): string {
   return `src/components/${slug}/`;
 }
 
+function assertExistingTestPaths(paths: string[], context: string): string[] {
+  const missingPaths = paths.filter((path) => !existsSync(join(packageRoot, path)));
+  if (missingPaths.length > 0) {
+    throw new Error(
+      `${context} references missing test path(s): ${missingPaths.toSorted().join(', ')}`,
+    );
+  }
+  return paths;
+}
+
 /**
  * Map a scope decision to the positional path arguments for `bun test`.
  *
@@ -151,7 +161,7 @@ export function fullSuiteTestPathGroups(componentSlugs: string[]): string[][] {
   }
 
   return groups
-    .map((group) => group.filter((path) => existsSync(join(packageRoot, path))))
+    .map((group, index) => assertExistingTestPaths(group, `full-suite chunk ${index + 1}`))
     .filter((group) => group.length > 0);
 }
 


### PR DESCRIPTION
## Summary

- split the unit-tests Bun cache step into explicit restore and save phases
- retry an empty Bun cache restore once before dependency installation
- fail early when no cache restored after retry even though a matching default-branch cache exists
- shard full-suite unit-test runs into sequential chunks so push/manual full runs avoid the old single-process memory and timeout pressure
- fail loudly if any configured full-suite chunk path no longer exists, instead of silently dropping coverage

## Why

Closes #589. The observed failure mode is GitHub cache restore degradation that lets the job continue cold, making the unit suite much more sensitive to runner contention. This keeps normal cache misses working while turning the known degraded restore path into a clear rerun signal before the memory-sensitive test suite starts.

Full-suite runs now execute as several explicit path chunks. Scoped pull request runs still use the resolved component scope, but push-to-main/manual full runs no longer depend on one giant `bun test` process.

## Validation

- `ruby -e 'require "yaml"; YAML.load_file(ARGV.fetch(0)); puts "yaml ok"' .github/workflows/unit-tests.yaml`\n- `bun x prettier --check .github/workflows/unit-tests.yaml`\n- `bun run lint`\n- `gh workflow view unit-tests.yaml`\n- `gh cache list --repo stevekinney/cinder --ref refs/heads/main --key bun-Linux-X64-1.3.13- --limit 1 --json key --jq 'length'`\n- `bun test packages/components/scripts/test-changed.test.ts`