### PR TITLE
Strip excluded source map references

### DIFF
--- a/packages/components/scripts/pack-for-publish.test.ts
+++ b/packages/components/scripts/pack-for-publish.test.ts
@@ -79,6 +79,27 @@ describe('buildPublishedManifest', () => {
     expect(files).toContain('!dist/**/*.js.map');
   });
 
+  it('removes sourceMappingURL references when the publish policy excludes maps', () => {
+    const manifest: SourceManifest = {
+      name: '@lostgradient/cinder',
+      version: '0.0.0',
+      exports: {},
+    };
+
+    const published = buildPublishedManifest(manifest, []);
+    const excludesDistributionSourceMaps = (published.files ?? []).includes('!dist/**/*.js.map');
+    const input = 'export const value = 1;\n//# sourceMappingURL=index.js.map\n';
+
+    const stripped = stripDanglingSourceMapUrlComments(
+      input,
+      () => !excludesDistributionSourceMaps,
+    );
+
+    expect(excludesDistributionSourceMaps).toBe(true);
+    expect(stripped.strippedCount).toBe(1);
+    expect(stripped.text).toBe('export const value = 1;\n');
+  });
+
   it('rewrites source-backed runtime exports to built browser artifacts in the published manifest', () => {
     const manifest: SourceManifest = {
       name: '@lostgradient/cinder',

--- a/packages/components/scripts/pack-for-publish.ts
+++ b/packages/components/scripts/pack-for-publish.ts
@@ -338,8 +338,14 @@ export function stripDanglingSourceMapUrlComments(
   let strippedCount = 0;
   const outputLines: string[] = [];
   const lines = text.split('\n');
-  for (const line of lines) {
-    const sourceMapReference = getSourceMapReferences(line)[0];
+  const sourceMapReferencesByLine = new Map(
+    getSourceMapReferences(text).map((sourceMapReference) => [
+      sourceMapReference.line,
+      sourceMapReference,
+    ]),
+  );
+  for (const [index, line] of lines.entries()) {
+    const sourceMapReference = sourceMapReferencesByLine.get(index + 1);
     if (sourceMapReference && !hasSourceMap(sourceMapReference.reference)) {
       strippedCount += 1;
       continue;

--- a/packages/components/scripts/pack-for-publish.ts
+++ b/packages/components/scripts/pack-for-publish.ts
@@ -70,6 +70,11 @@ type SourceMapStripResult = {
   strippedCount: number;
 };
 
+export type SourceMapReference = {
+  line: number;
+  reference: string;
+};
+
 /**
  * Read the source manifest. Throws if the file is missing.
  */
@@ -308,6 +313,24 @@ function isResolvableRelativeSourceMapReference(reference: string): boolean {
   return !/^[a-z]+:\/\//iu.test(reference);
 }
 
+export function getSourceMapReferences(content: string): SourceMapReference[] {
+  const references: SourceMapReference[] = [];
+  const lines = content.split('\n');
+  for (const [index, line] of lines.entries()) {
+    const lineCommentMatch = line.match(/^\s*\/\/[#@]\s*sourceMappingURL=([^\s]+)\s*$/u);
+    if (lineCommentMatch?.[1] && isResolvableRelativeSourceMapReference(lineCommentMatch[1])) {
+      references.push({ line: index + 1, reference: lineCommentMatch[1] });
+      continue;
+    }
+
+    const blockCommentMatch = line.match(/^\s*\/\*#\s*sourceMappingURL=([^*\s]+)\s*\*\/\s*$/u);
+    if (blockCommentMatch?.[1] && isResolvableRelativeSourceMapReference(blockCommentMatch[1])) {
+      references.push({ line: index + 1, reference: blockCommentMatch[1] });
+    }
+  }
+  return references;
+}
+
 export function stripDanglingSourceMapUrlComments(
   text: string,
   hasSourceMap: (reference: string) => boolean,
@@ -316,30 +339,10 @@ export function stripDanglingSourceMapUrlComments(
   const outputLines: string[] = [];
   const lines = text.split('\n');
   for (const line of lines) {
-    const lineCommentMatch = line.match(/^\s*\/\/[#@]\s*sourceMappingURL=([^\s]+)\s*$/u);
-    if (lineCommentMatch) {
-      const reference = lineCommentMatch[1];
-      if (
-        reference &&
-        isResolvableRelativeSourceMapReference(reference) &&
-        !hasSourceMap(reference)
-      ) {
-        strippedCount += 1;
-        continue;
-      }
-    }
-
-    const blockCommentMatch = line.match(/^\s*\/\*#\s*sourceMappingURL=([^*\s]+)\s*\*\/\s*$/u);
-    if (blockCommentMatch) {
-      const reference = blockCommentMatch[1];
-      if (
-        reference &&
-        isResolvableRelativeSourceMapReference(reference) &&
-        !hasSourceMap(reference)
-      ) {
-        strippedCount += 1;
-        continue;
-      }
+    const sourceMapReference = getSourceMapReferences(line)[0];
+    if (sourceMapReference && !hasSourceMap(sourceMapReference.reference)) {
+      strippedCount += 1;
+      continue;
     }
 
     outputLines.push(line);

--- a/packages/components/scripts/validate-consumers.ts
+++ b/packages/components/scripts/validate-consumers.ts
@@ -18,7 +18,7 @@ import { type CommentScanState, lineHasCinderResidue } from './lib/cinder-specif
 import { deriveUpstreamReexports } from './lib/derive-upstream-reexports.ts';
 import { discoverComponents } from './lib/discover-components.ts';
 import { parseJsonFile } from './lib/read-json-file.ts';
-import { packForPublish } from './pack-for-publish.ts';
+import { getSourceMapReferences, packForPublish } from './pack-for-publish.ts';
 import { sveltePeerContract } from './validate-svelte-peer-contract.ts';
 import { isObjectRecord } from './validation-utilities.ts';
 
@@ -387,36 +387,6 @@ async function assertUpstreamReexportsResolveInTarball(extractedRoot: string): P
   if (missing.length > 0) {
     fail(`tarball missing upstream re-export artifacts:\n  ${missing.join('\n  ')}`);
   }
-}
-
-type SourceMapReference = {
-  line: number;
-  reference: string;
-};
-
-function isResolvableRelativeSourceMapReference(reference: string): boolean {
-  if (!reference.endsWith('.map')) return false;
-  if (reference.startsWith('data:')) return false;
-  if (reference.startsWith('file:')) return false;
-  return !/^[a-z]+:\/\//iu.test(reference);
-}
-
-function getSourceMapReferences(content: string): SourceMapReference[] {
-  const references: SourceMapReference[] = [];
-  const lines = content.split('\n');
-  for (const [index, line] of lines.entries()) {
-    const lineCommentMatch = line.match(/^\s*\/\/[#@]\s*sourceMappingURL=([^\s]+)\s*$/u);
-    if (lineCommentMatch?.[1] && isResolvableRelativeSourceMapReference(lineCommentMatch[1])) {
-      references.push({ line: index + 1, reference: lineCommentMatch[1] });
-      continue;
-    }
-
-    const blockCommentMatch = line.match(/^\s*\/\*#\s*sourceMappingURL=([^*\s]+)\s*\*\/\s*$/u);
-    if (blockCommentMatch?.[1] && isResolvableRelativeSourceMapReference(blockCommentMatch[1])) {
-      references.push({ line: index + 1, reference: blockCommentMatch[1] });
-    }
-  }
-  return references;
 }
 
 async function assertNoDanglingSourceMapComments(extractedRoot: string): Promise<void> {
@@ -837,8 +807,8 @@ async function runTypescriptCompatibilityFixture(
       );
     }
     assertNoPeerDependencyWarnings(installResult, label);
-    await runTypescriptConsumerNodenextGate(fixtureDirectory, label);
     await runTypescriptConsumerSvelteGate(fixtureDirectory, label);
+    await runTypescriptConsumerNodenextGate(fixtureDirectory, label);
     process.stdout.write(
       `[validate-consumers] typescript compatibility OK (${label}: ${typescriptVersion}).\n`,
     );


### PR DESCRIPTION
Closes #590

## Summary
- parse sourceMappingURL comments in the publish packer
- remove dangling source map references according to the package source-map policy
- share that parser with consumer validation so excluded .js.map references are caught consistently

## Verification
- bun test packages/components/scripts/pack-for-publish.test.ts
- bun run --filter=@lostgradient/cinder validate:consumer

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to publish staging scripts, tests, and consumer validation tooling; no runtime package API or auth/data paths are touched.
> 
> **Overview**
> Published tarballs exclude `dist/**/*.js.map` but built JS can still carry `sourceMappingURL` comments, which triggers consumer bundler warnings. This change **centralizes** parsing of those comments in `getSourceMapReferences` (exported from `pack-for-publish.ts`) and refactors `stripDanglingSourceMapUrlComments` to strip lines using that shared index instead of duplicating regex logic inline.
> 
> **Consumer validation** now imports the same parser so `assertNoDanglingSourceMapComments` and the packer agree on what counts as a resolvable relative map reference. A new unit test asserts that when the published manifest excludes distribution maps, stripping treats references as dangling (aligned with the `!dist/**/*.js.map` policy).
> 
> The typescript compatibility fixture runs the Svelte gate before the NodeNext gate (ordering only).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 205c858fcd9b93691c53101184f13097d01adb41. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->