### PR TITLE
Fix BentoGrid responsive audit

### DIFF
--- a/packages/components/src/components/bento-grid/bento-grid.css
+++ b/packages/components/src/components/bento-grid/bento-grid.css
@@ -9,16 +9,14 @@
     column-gap: var(--cinder-bento-grid-column-gap, var(--cinder-space-4));
   }
 
-  @media (max-width: 48rem) {
-    .cinder-bento-grid[data-cinder-collapse='true'] {
-      grid-template-columns: 1fr;
-    }
+  .cinder-bento-grid[data-cinder-collapse][data-cinder-narrow] {
+    grid-template-columns: 1fr;
+  }
 
-    .cinder-bento-grid[data-cinder-collapse='true'] > .cinder-bento-cell {
-      grid-column-start: auto;
-      grid-column-end: auto;
-      grid-row-start: auto;
-      grid-row-end: auto;
-    }
+  .cinder-bento-grid[data-cinder-collapse][data-cinder-narrow] > .cinder-bento-cell {
+    grid-column-start: auto;
+    grid-column-end: auto;
+    grid-row-start: auto;
+    grid-row-end: auto;
   }
 }

--- a/packages/components/src/components/bento-grid/bento-grid.svelte
+++ b/packages/components/src/components/bento-grid/bento-grid.svelte
@@ -18,7 +18,11 @@
 
 <script lang="ts">
   import { classNames } from '../../utilities/class-names.ts';
+  import { useResizeObserver } from '../../utilities/use-resize-observer.svelte.ts';
   import type { BentoGridProps } from './bento-grid.types.ts';
+
+  const COLLAPSE_MAX_WIDTH_REM = 48;
+  const FALLBACK_ROOT_FONT_SIZE_PX = 16;
 
   let {
     columns,
@@ -32,6 +36,9 @@
     ...rest
   }: BentoGridProps = $props();
 
+  let isNarrow = $state(false);
+  let hasMeasuredWidth = $state(false);
+
   const resolvedColumns = $derived.by(() => {
     if (typeof columns === 'number') {
       if (!Number.isInteger(columns) || columns < 1) return undefined;
@@ -40,13 +47,55 @@
     if (typeof columns === 'string' && columns.length > 0) return columns;
     return undefined;
   });
+
+  function getCollapseMaxWidthPx(): number {
+    if (typeof window === 'undefined') return COLLAPSE_MAX_WIDTH_REM * FALLBACK_ROOT_FONT_SIZE_PX;
+
+    const rootFontSize = Number.parseFloat(getComputedStyle(document.documentElement).fontSize);
+    const baseFontSize =
+      Number.isFinite(rootFontSize) && rootFontSize > 0 ? rootFontSize : FALLBACK_ROOT_FONT_SIZE_PX;
+    return COLLAPSE_MAX_WIDTH_REM * baseFontSize;
+  }
+
+  function updateNarrowState(width: number): void {
+    if (!Number.isFinite(width) || width <= 0) {
+      return;
+    }
+
+    hasMeasuredWidth = true;
+    isNarrow = width <= getCollapseMaxWidthPx();
+  }
+
+  function getObservedWidth(entry: ResizeObserverEntry): number {
+    const borderBoxSize = Array.isArray(entry.borderBoxSize)
+      ? entry.borderBoxSize[0]
+      : entry.borderBoxSize;
+
+    return borderBoxSize?.inlineSize ?? entry.contentRect.width;
+  }
+
+  const observeResize = useResizeObserver(
+    (entries) => {
+      const entry = entries[0];
+      if (entry) updateNarrowState(getObservedWidth(entry));
+    },
+    { box: 'border-box', enabled: () => collapse },
+  );
+
+  const observeGrid = (node: HTMLElement) => {
+    updateNarrowState(node.getBoundingClientRect().width);
+    return observeResize(node);
+  };
 </script>
 
 <svelte:element
   this={as}
   {...rest}
+  {@attach observeGrid}
   class={classNames('cinder-bento-grid', customClassName)}
-  data-cinder-collapse={collapse ? 'true' : undefined}
+  data-cinder-collapse={collapse ? '' : undefined}
+  data-cinder-narrow={collapse && isNarrow ? '' : undefined}
+  data-cinder-wide={collapse && hasMeasuredWidth && !isNarrow ? '' : undefined}
   style:--cinder-bento-grid-columns={resolvedColumns}
   style:--cinder-bento-grid-row-gap={rowGap ?? gap}
   style:--cinder-bento-grid-column-gap={columnGap ?? gap}

--- a/packages/components/src/components/bento-grid/bento-grid.test.ts
+++ b/packages/components/src/components/bento-grid/bento-grid.test.ts
@@ -1,5 +1,5 @@
 /// <reference lib="dom" />
-import { describe, expect, test } from 'bun:test';
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from 'bun:test';
 import { readFileSync } from 'node:fs';
 
 import { setupHappyDom } from '../../test/happy-dom.ts';
@@ -11,7 +11,62 @@ setupHappyDom();
 
 const { render } = await import('@testing-library/svelte');
 const { default: BentoGrid } = await import('./bento-grid.svelte');
-const { createRawSnippet } = await import('svelte');
+const { createRawSnippet, tick } = await import('svelte');
+
+class CapturingResizeObserver implements ResizeObserver {
+  static instances: CapturingResizeObserver[] = [];
+
+  readonly callback: ResizeObserverCallback;
+  observed: Element | undefined;
+
+  constructor(callback: ResizeObserverCallback) {
+    this.callback = callback;
+    CapturingResizeObserver.instances.push(this);
+  }
+
+  observe(target: Element, _options?: ResizeObserverOptions): void {
+    this.observed = target;
+  }
+
+  unobserve(_target: Element): void {}
+
+  disconnect(): void {}
+
+  trigger(width: number): void {
+    this.callback(
+      [
+        {
+          borderBoxSize: [{ inlineSize: width }],
+          contentRect: { width },
+          target: this.observed,
+        } as unknown as ResizeObserverEntry,
+      ],
+      this as unknown as ResizeObserver,
+    );
+  }
+}
+
+const originalResizeObserver = globalThis.ResizeObserver;
+
+beforeAll(() => {
+  Object.defineProperty(globalThis, 'ResizeObserver', {
+    configurable: true,
+    value: CapturingResizeObserver,
+    writable: true,
+  });
+});
+
+beforeEach(() => {
+  CapturingResizeObserver.instances = [];
+});
+
+afterAll(() => {
+  Object.defineProperty(globalThis, 'ResizeObserver', {
+    configurable: true,
+    value: originalResizeObserver,
+    writable: true,
+  });
+});
 
 function textSnippet(text: string) {
   return createRawSnippet(() => ({
@@ -47,6 +102,74 @@ describe('BentoGrid', () => {
     const root = container.querySelector('.cinder-bento-grid');
     expect(root?.classList.contains('custom-bento-grid')).toBe(true);
     expect(root?.getAttribute('data-testid')).toBe('bento-grid');
+  });
+
+  test('keeps the as element as the public grid element', () => {
+    const { container } = render(BentoGrid, {
+      props: {
+        as: 'ul',
+        style: 'align-items: start;',
+        children: createRawSnippet(() => ({
+          render: () => '<li class="cinder-bento-cell">Feature</li>',
+        })),
+      },
+    });
+
+    const root = container.querySelector('ul.cinder-bento-grid') as HTMLElement;
+    expect(root).not.toBeNull();
+    expect([...root.children].every((child) => child.tagName === 'LI')).toBe(true);
+    expect(root.style.alignItems).toBe('start');
+  });
+
+  test('marks narrow grids from the public grid element width', async () => {
+    const { container } = render(BentoGrid, {
+      props: { children: textSnippet('content') },
+    });
+    await tick();
+
+    const root = container.querySelector('.cinder-bento-grid') as HTMLElement;
+    const observer = CapturingResizeObserver.instances[0];
+    expect(observer?.observed).toBe(root);
+    expect(root.hasAttribute('data-cinder-wide')).toBe(false);
+
+    observer?.trigger(640);
+    await tick();
+    expect(root.hasAttribute('data-cinder-narrow')).toBe(true);
+    expect(root.hasAttribute('data-cinder-wide')).toBe(false);
+
+    observer?.trigger(1024);
+    await tick();
+    expect(root.hasAttribute('data-cinder-narrow')).toBe(false);
+    expect(root.hasAttribute('data-cinder-wide')).toBe(true);
+  });
+
+  test('measures the public grid element before the first resize observer callback', async () => {
+    const originalGetBoundingClientRect = HTMLElement.prototype.getBoundingClientRect;
+    HTMLElement.prototype.getBoundingClientRect = () =>
+      ({
+        width: 640,
+        height: 0,
+        top: 0,
+        right: 640,
+        bottom: 0,
+        left: 0,
+        x: 0,
+        y: 0,
+        toJSON: () => ({}),
+      }) as DOMRect;
+
+    try {
+      const { container } = render(BentoGrid, {
+        props: { children: textSnippet('content') },
+      });
+      await tick();
+
+      const root = container.querySelector('.cinder-bento-grid') as HTMLElement;
+      expect(root.hasAttribute('data-cinder-narrow')).toBe(true);
+      expect(root.hasAttribute('data-cinder-wide')).toBe(false);
+    } finally {
+      HTMLElement.prototype.getBoundingClientRect = originalGetBoundingClientRect;
+    }
   });
 
   test('omits inline custom properties when layout props are absent', () => {
@@ -131,10 +254,10 @@ describe('BentoGrid', () => {
     expect(typeof module.default.Cell).toBe('function');
   });
 
-  test('collapse CSS does not rely on a self-container query', () => {
+  test('collapse CSS uses measured narrow state without a viewport media query', () => {
     const css = readFileSync(new URL('./bento-grid.css', import.meta.url), 'utf8');
-    expect(css).toContain('@media (max-width: 48rem)');
-    expect(css).not.toContain('@container (max-width: 48rem)');
-    expect(css).not.toContain('container-type: inline-size');
+    expect(css).toContain('[data-cinder-collapse][data-cinder-narrow]');
+    expect(css).toContain('> .cinder-bento-cell');
+    expect(css).not.toMatch(/@media[^{]*(?:min-width|max-width)/);
   });
 });


### PR DESCRIPTION
## Summary
- keep BentoGrid as the public outer grid element so class/style/rest props and semantic `as` usage still apply to the layout item
- replace the release-blocking viewport `@media` collapse with measured element-width state on the grid itself
- preserve static/no-JS wide layouts by only applying collapse CSS after the grid has a confirmed narrow measurement
- use a consistent border-box width for attachment-time and ResizeObserver measurements, with ResizeObserver gated behind `collapse`
- update BentoGrid regression coverage for semantic list usage, measured narrow/wide state, immediate measurement, and the no-viewport-media release gate

## Validation
- bun test ./packages/components/src/components/bento-grid/bento-grid.test.ts
- bun run --filter=@lostgradient/cinder platform:audit -- --strict
- bun run --filter=@lostgradient/cinder typecheck
- pre-commit hook: @lostgradient/cinder typecheck + test
- pre-push hook: scoped lint/typecheck/test