### PR TITLE
Handle Cinder MCP resource errors

### DIFF
--- a/packages/components/src/cli/index.test.ts
+++ b/packages/components/src/cli/index.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from 'bun:test';
+import { mkdtempSync, rmSync, symlinkSync } from 'node:fs';
+import { tmpdir } from 'node:os';
 import { dirname, join, resolve } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+import { isCliEntrypoint } from './index.ts';
 
 const cliDirectory = dirname(fileURLToPath(import.meta.url));
 const packageRoot = resolve(cliDirectory, '../..');
@@ -107,5 +111,20 @@ describe('cinder CLI', () => {
     expect(result.exitCode).toBe(1);
     expect(result.stderr).toBe('');
     expect(isRecord(error) && error['code']).toBe('BAD_LIMIT');
+  });
+
+  it('detects direct and symlinked Node bin entrypoints without import.meta.main', () => {
+    const moduleUrl = pathToFileURL(cliEntrypoint).href;
+    const temporaryDirectory = mkdtempSync(join(tmpdir(), 'cinder-cli-'));
+    const symlinkPath = join(temporaryDirectory, 'cinder');
+    symlinkSync(cliEntrypoint, symlinkPath);
+
+    try {
+      expect(isCliEntrypoint(cliEntrypoint, moduleUrl)).toBe(true);
+      expect(isCliEntrypoint(symlinkPath, moduleUrl)).toBe(true);
+      expect(isCliEntrypoint(join(temporaryDirectory, 'missing'), moduleUrl)).toBe(false);
+    } finally {
+      rmSync(temporaryDirectory, { recursive: true, force: true });
+    }
   });
 });

--- a/packages/components/src/cli/index.ts
+++ b/packages/components/src/cli/index.ts
@@ -1,4 +1,6 @@
 #!/usr/bin/env node
+import { realpathSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
 import { parseArgs } from 'node:util';
 
 import { loadCinderKnowledge } from './knowledge.ts';
@@ -195,7 +197,19 @@ export async function runCli(argv: string[] = process.argv.slice(2)): Promise<nu
   }
 }
 
-if (import.meta.main) {
+export function isCliEntrypoint(
+  entrypointPath = process.argv[1],
+  moduleUrl = import.meta.url,
+): boolean {
+  if (!entrypointPath) return false;
+  try {
+    return realpathSync(entrypointPath) === realpathSync(fileURLToPath(moduleUrl));
+  } catch {
+    return false;
+  }
+}
+
+if (isCliEntrypoint()) {
   const exitCode = await runCli();
   process.exit(exitCode);
 }

--- a/packages/components/src/cli/mcp.test.ts
+++ b/packages/components/src/cli/mcp.test.ts
@@ -1,5 +1,6 @@
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
+import { ErrorCode, McpError } from '@modelcontextprotocol/sdk/types.js';
 import { describe, expect, it } from 'bun:test';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -19,6 +20,24 @@ function textContent(result: unknown): string {
       isRecord(entry) && entry['type'] === 'text' && typeof entry['text'] === 'string',
   );
   return item?.text ?? '';
+}
+
+async function readResourceError(client: Client, uri: string): Promise<McpError> {
+  try {
+    await client.readResource({ uri });
+  } catch (error: unknown) {
+    if (error instanceof McpError) return error;
+    throw error;
+  }
+  throw new Error(`Expected ${uri} to fail.`);
+}
+
+function errorData(error: McpError): Record<string, unknown> {
+  const { data } = error;
+  if (!isRecord(data) || !isRecord(data['error'])) {
+    throw new Error('Expected MCP error data to contain an error payload.');
+  }
+  return data['error'];
 }
 
 describe('cinder MCP server', () => {
@@ -79,6 +98,25 @@ describe('cinder MCP server', () => {
       expect(firstComponent && 'text' in firstComponent ? firstComponent.text : '').toContain(
         '"id": "button"',
       );
+
+      const missingComponent = await readResourceError(client, 'cinder://component/buton');
+      expect(missingComponent.code).toBe(ErrorCode.InvalidParams);
+      const missingComponentData = errorData(missingComponent);
+      expect(missingComponentData['code']).toBe('COMPONENT_NOT_FOUND');
+      expect(missingComponentData['message']).toBe('Unknown Cinder component "buton".');
+      expect(missingComponentData['suggestions']).toContain('button');
+
+      const missingArtifact = await readResourceError(
+        client,
+        'cinder://component/access-gate/constraints',
+      );
+      expect(missingArtifact.code).toBe(ErrorCode.InvalidParams);
+      const missingArtifactData = errorData(missingArtifact);
+      expect(missingArtifactData['code']).toBe('ARTIFACT_NOT_FOUND');
+      expect(missingArtifactData['message']).toBe(
+        'access-gate does not ship a constraints artifact.',
+      );
+      expect(missingArtifactData['suggestions']).toContain('access-gate');
     } finally {
       await client.close();
     }

--- a/packages/components/src/cli/mcp.ts
+++ b/packages/components/src/cli/mcp.ts
@@ -4,6 +4,11 @@ import { CinderKnowledgeError, loadCinderKnowledge, type CinderKnowledge } from 
 import type { BestPracticeTopic } from './types.ts';
 
 type McpServerModule = typeof import('@modelcontextprotocol/sdk/server/mcp.js');
+type McpTypesModule = typeof import('@modelcontextprotocol/sdk/types.js');
+type McpErrorDependencies = {
+  ErrorCode: McpTypesModule['ErrorCode'];
+  McpError: McpTypesModule['McpError'];
+};
 
 function textResult(text: string, structuredContent?: Record<string, unknown>) {
   return {
@@ -16,15 +21,30 @@ function jsonText(value: unknown): string {
   return JSON.stringify(value, null, 2);
 }
 
+function errorPayload(error: unknown) {
+  return {
+    code: error instanceof CinderKnowledgeError ? error.code : 'UNEXPECTED_ERROR',
+    message: error instanceof Error ? error.message : String(error),
+    suggestions: error instanceof CinderKnowledgeError ? error.suggestions : [],
+  };
+}
+
 function toolError(error: unknown) {
-  const code = error instanceof CinderKnowledgeError ? error.code : 'UNEXPECTED_ERROR';
-  const message = error instanceof Error ? error.message : String(error);
-  const suggestions = error instanceof CinderKnowledgeError ? error.suggestions : [];
+  const payload = errorPayload(error);
   return {
     isError: true,
-    content: [{ type: 'text' as const, text: message }],
-    structuredContent: { error: { code, message, suggestions } },
+    content: [{ type: 'text' as const, text: payload.message }],
+    structuredContent: { error: payload },
   };
+}
+
+function resourceError(error: unknown, dependencies: McpErrorDependencies): never {
+  const payload = errorPayload(error);
+  const protocolCode =
+    error instanceof CinderKnowledgeError
+      ? dependencies.ErrorCode.InvalidParams
+      : dependencies.ErrorCode.InternalError;
+  throw new dependencies.McpError(protocolCode, payload.message, { error: payload });
 }
 
 function firstVariable(value: string | string[] | undefined): string {
@@ -42,6 +62,18 @@ function jsonResource(uri: string, value: unknown) {
       },
     ],
   };
+}
+
+async function readJsonResource(
+  uri: URL,
+  read: () => Promise<unknown>,
+  dependencies: McpErrorDependencies,
+) {
+  try {
+    return jsonResource(uri.href, await read());
+  } catch (error: unknown) {
+    resourceError(error, dependencies);
+  }
 }
 
 function componentResourceList(knowledge: CinderKnowledge, suffix = '') {
@@ -171,6 +203,7 @@ function registerResources(
   server: InstanceType<McpServerModule['McpServer']>,
   knowledge: CinderKnowledge,
   ResourceTemplate: McpServerModule['ResourceTemplate'],
+  dependencies: McpErrorDependencies,
 ): void {
   server.registerResource(
     'manifest',
@@ -203,7 +236,7 @@ function registerResources(
       mimeType: 'application/json',
     },
     async (uri, variables) =>
-      jsonResource(uri.href, await knowledge.show(firstVariable(variables['id']))),
+      readJsonResource(uri, () => knowledge.show(firstVariable(variables['id'])), dependencies),
   );
 
   for (const artifact of ['schema', 'variables', 'examples', 'constraints'] as const) {
@@ -219,7 +252,11 @@ function registerResources(
         mimeType: 'application/json',
       },
       async (uri, variables) =>
-        jsonResource(uri.href, await knowledge.artifact(firstVariable(variables['id']), artifact)),
+        readJsonResource(
+          uri,
+          () => knowledge.artifact(firstVariable(variables['id']), artifact),
+          dependencies,
+        ),
     );
   }
 }
@@ -286,8 +323,9 @@ function registerPrompts(server: InstanceType<McpServerModule['McpServer']>): vo
 }
 
 export async function createMcpServer() {
-  const [{ McpServer, ResourceTemplate }, knowledge] = await Promise.all([
+  const [{ McpServer, ResourceTemplate }, { ErrorCode, McpError }, knowledge] = await Promise.all([
     import('@modelcontextprotocol/sdk/server/mcp.js'),
+    import('@modelcontextprotocol/sdk/types.js'),
     loadCinderKnowledge(),
   ]);
   const server = new McpServer({
@@ -295,7 +333,7 @@ export async function createMcpServer() {
     version: knowledge.package.version,
   });
   registerTools(server, knowledge);
-  registerResources(server, knowledge, ResourceTemplate);
+  registerResources(server, knowledge, ResourceTemplate, { ErrorCode, McpError });
   registerPrompts(server);
   return server;
 }


### PR DESCRIPTION
## Summary
- Translate Cinder knowledge failures in MCP resource reads into structured `McpError` responses.
- Preserve the existing JSON resource shape for successful reads.
- Replace `import.meta.main` bin gating with a Node 22.0-compatible realpath entrypoint check.
- Add stdio MCP regressions for unknown component resources, missing optional artifact resources, and symlinked CLI bin startup.

## Root Cause
Post-merge review on #612 found two issues: resource handlers called `knowledge.show()` and `knowledge.artifact()` without the error boundary used by MCP tools, and the CLI bin relied on `import.meta.main`, which is unavailable before Node 22.18 despite the package accepting Node >=22.0.0.

## Validation
- `bun run --filter=@lostgradient/cinder test -- ./src/cli/mcp.test.ts`
- `bun run --filter=@lostgradient/cinder test -- ./src/cli`
- `bun run --filter=@lostgradient/cinder typecheck`
- `bun run --filter=@lostgradient/cinder build`
- pre-commit hook: package typecheck and tests
- pre-push hook: scoped lint, typecheck, and tests