### PR TITLE
Support unknown-total pagination

### DIFF
--- a/packages/components/src/api-contract.ts
+++ b/packages/components/src/api-contract.ts
@@ -414,7 +414,9 @@ export const CONTRACT: Record<string, ComponentContract> = {
     kind: 'literal',
     props: {
       currentPage: { optional: false, type_kind: 'TSNumberKeyword', default: B(1) },
-      totalPages: { optional: false, type_kind: 'TSNumberKeyword', default: REQUIRED },
+      totalPages: { optional: true, type_kind: 'TSNumberKeyword', default: NO_DEFAULT },
+      hasPreviousPage: { optional: true, type_kind: 'TSBooleanKeyword', default: NO_DEFAULT },
+      hasNextPage: { optional: true, type_kind: 'TSBooleanKeyword', default: NO_DEFAULT },
       totalCount: { optional: true, type_kind: 'TSNumberKeyword', default: NO_DEFAULT },
       class: { optional: true, type_kind: 'TSStringKeyword', default: L(undefined) },
     },

--- a/packages/components/src/api-contract.ts
+++ b/packages/components/src/api-contract.ts
@@ -416,7 +416,7 @@ export const CONTRACT: Record<string, ComponentContract> = {
       currentPage: { optional: false, type_kind: 'TSNumberKeyword', default: B(1) },
       totalPages: { optional: true, type_kind: 'TSNumberKeyword', default: NO_DEFAULT },
       hasPreviousPage: { optional: true, type_kind: 'TSBooleanKeyword', default: NO_DEFAULT },
-      hasNextPage: { optional: true, type_kind: 'TSBooleanKeyword', default: NO_DEFAULT },
+      hasNextPage: { optional: true, type_kind: 'TSBooleanKeyword', default: L(false) },
       totalCount: { optional: true, type_kind: 'TSNumberKeyword', default: NO_DEFAULT },
       class: { optional: true, type_kind: 'TSStringKeyword', default: L(undefined) },
     },

--- a/packages/components/src/components/pagination/README.md
+++ b/packages/components/src/components/pagination/README.md
@@ -18,11 +18,14 @@ When the total page count is unknown, omit `totalPages` and pass the direction
 availability you know:
 
 ```svelte
-<Pagination
-  bind:currentPage
-  hasPreviousPage={currentPage > 1}
-  hasNextPage={links.next !== undefined}
-/>
+<script lang="ts">
+  import Pagination from '@lostgradient/cinder/pagination';
+
+  let currentPage = $state(1);
+  let hasNextPage = $state(false);
+</script>
+
+<Pagination bind:currentPage hasPreviousPage={currentPage > 1} {hasNextPage} />
 ```
 
 This renders the current page and previous/next controls without implying a
@@ -70,7 +73,7 @@ fake final page.
 | ----------------- | --------- | -------- | ------- | --------------------------------------------------------------------------------------------- |
 | `class`           | `string`  | no       | —       | Custom class merged with `.cinder-pagination`.                                                |
 | `currentPage`     | `number`  | yes      | —       | Current page number (1-indexed). Bindable.                                                    |
-| `hasNextPage`     | `boolean` | no       | —       | Whether a next page is available when totalPages is unknown. Defaults to false.               |
+| `hasNextPage`     | `boolean` | no       | `false` | Whether a next page is available when totalPages is unknown. Defaults to false.               |
 | `hasPreviousPage` | `boolean` | no       | —       | Whether a previous page is available when totalPages is unknown. Defaults to currentPage > 1. |
 | `totalCount`      | `number`  | no       | —       | Optional total record count; formatted with formatNumber when provided.                       |
 | `totalPages`      | `number`  | no       | —       | Total number of pages. Omit when only previous/next availability is known.                    |

--- a/packages/components/src/components/pagination/README.md
+++ b/packages/components/src/components/pagination/README.md
@@ -14,16 +14,66 @@ Page-navigation control for stepping through multi-page result sets.
 <Pagination bind:currentPage totalPages={10} />
 ```
 
+When the total page count is unknown, omit `totalPages` and pass the direction
+availability you know:
+
+```svelte
+<Pagination
+  bind:currentPage
+  hasPreviousPage={currentPage > 1}
+  hasNextPage={links.next !== undefined}
+/>
+```
+
+This renders the current page and previous/next controls without implying a
+fake final page.
+
+### REST Link headers
+
+```svelte
+<script lang="ts">
+  import Pagination from '@lostgradient/cinder/pagination';
+
+  let currentPage = $state(1);
+  let links = $state<{ prev?: string; next?: string }>({});
+</script>
+
+<Pagination
+  bind:currentPage
+  hasPreviousPage={links.prev !== undefined}
+  hasNextPage={links.next !== undefined}
+/>
+```
+
+### Cursor pagination
+
+```svelte
+<script lang="ts">
+  import Pagination from '@lostgradient/cinder/pagination';
+
+  let currentPage = $state(1);
+  let cursors = $state<{ previous?: string; next?: string }>({});
+</script>
+
+<Pagination
+  bind:currentPage
+  hasPreviousPage={cursors.previous !== undefined}
+  hasNextPage={cursors.next !== undefined}
+/>
+```
+
 ## Props
 
 <!-- generated:props:start -->
 
-| Prop          | Type     | Required | Default | Description                                                             |
-| ------------- | -------- | -------- | ------- | ----------------------------------------------------------------------- |
-| `class`       | `string` | no       | —       | Custom class merged with `.cinder-pagination`.                          |
-| `currentPage` | `number` | yes      | —       | Current page number (1-indexed). Bindable.                              |
-| `totalCount`  | `number` | no       | —       | Optional total record count; formatted with formatNumber when provided. |
-| `totalPages`  | `number` | yes      | —       | Total number of pages.                                                  |
+| Prop              | Type      | Required | Default | Description                                                                                   |
+| ----------------- | --------- | -------- | ------- | --------------------------------------------------------------------------------------------- |
+| `class`           | `string`  | no       | —       | Custom class merged with `.cinder-pagination`.                                                |
+| `currentPage`     | `number`  | yes      | —       | Current page number (1-indexed). Bindable.                                                    |
+| `hasNextPage`     | `boolean` | no       | —       | Whether a next page is available when totalPages is unknown. Defaults to false.               |
+| `hasPreviousPage` | `boolean` | no       | —       | Whether a previous page is available when totalPages is unknown. Defaults to currentPage > 1. |
+| `totalCount`      | `number`  | no       | —       | Optional total record count; formatted with formatNumber when provided.                       |
+| `totalPages`      | `number`  | no       | —       | Total number of pages. Omit when only previous/next availability is known.                    |
 
 <!-- generated:props:end -->
 

--- a/packages/components/src/components/pagination/pagination.examples.json
+++ b/packages/components/src/components/pagination/pagination.examples.json
@@ -10,6 +10,18 @@
       "code": "<script lang=\"ts\">\n  import { Pagination } from '@lostgradient/cinder/pagination';\n  let currentPage = $state(1);\n</script>\n\n<Pagination bind:currentPage totalPages={10} />\n<p style=\"margin-top: 0.5rem; color: var(--cinder-text-muted);\">Page {currentPage} of 10</p>\n"
     },
     {
+      "id": "cursor",
+      "title": "Cursor pagination",
+      "description": "Use page-local cursor metadata when an API exposes previous and next cursors instead of totals.",
+      "code": "<script lang=\"ts\">\n  import { Pagination } from '@lostgradient/cinder/pagination';\n\n  type CursorPage = {\n    page: number;\n    previousCursor?: string;\n    nextCursor?: string;\n  };\n\n  let currentPage = $state(1);\n\n  const pages: [CursorPage, ...CursorPage[]] = [\n    { page: 1, nextCursor: 'cursor-page-2' },\n    { page: 2, previousCursor: 'cursor-page-1', nextCursor: 'cursor-page-3' },\n    { page: 3, previousCursor: 'cursor-page-2' },\n  ];\n\n  const current = $derived(pages.find((page) => page.page === currentPage) ?? pages[0]);\n</script>\n\n<Pagination\n  bind:currentPage\n  hasPreviousPage={current.previousCursor !== undefined}\n  hasNextPage={current.nextCursor !== undefined}\n/>\n<p style=\"margin-top: 0.5rem; color: var(--cinder-text-muted);\">\n  Page {current.page}\n</p>\n"
+    },
+    {
+      "id": "rest-link-header",
+      "title": "REST Link-header pagination",
+      "description": "Drive previous and next buttons from parsed REST Link headers without a total page count.",
+      "code": "<script lang=\"ts\">\n  import { Pagination } from '@lostgradient/cinder/pagination';\n\n  let currentPage = $state(1);\n\n  const linkHeaders: Record<number, string> = {\n    1: '<https://api.example.test/issues?page=2>; rel=\"next\"',\n    2: '<https://api.example.test/issues?page=1>; rel=\"prev\", <https://api.example.test/issues?page=3>; rel=\"next\"',\n    3: '<https://api.example.test/issues?page=2>; rel=\"prev\"',\n  };\n\n  const links = $derived(parseLinkHeader(linkHeaders[currentPage] ?? ''));\n\n  function parseLinkHeader(header: string): Record<string, string> {\n    return Object.fromEntries(\n      header\n        .split(',')\n        .map((entry) => entry.match(/<([^>]+)>;\\s*rel=\"([^\"]+)\"/))\n        .filter((match): match is RegExpMatchArray => match !== null)\n        .map((match) => [match[2], match[1]]),\n    );\n  }\n</script>\n\n<Pagination\n  bind:currentPage\n  hasPreviousPage={links['prev'] !== undefined}\n  hasNextPage={links['next'] !== undefined}\n/>\n<p style=\"margin-top: 0.5rem; color: var(--cinder-text-muted);\">\n  Page {currentPage}\n</p>\n"
+    },
+    {
       "id": "with-total",
       "title": "Pagination with total count",
       "description": "totalCount prop shows formatted record count.",

--- a/packages/components/src/components/pagination/pagination.schema.json
+++ b/packages/components/src/components/pagination/pagination.schema.json
@@ -8,7 +8,15 @@
     },
     "totalPages": {
       "type": "number",
-      "description": "Total number of pages."
+      "description": "Total number of pages. Omit when only previous/next availability is known."
+    },
+    "hasPreviousPage": {
+      "type": "boolean",
+      "description": "Whether a previous page is available when totalPages is unknown. Defaults to currentPage > 1."
+    },
+    "hasNextPage": {
+      "type": "boolean",
+      "description": "Whether a next page is available when totalPages is unknown. Defaults to false."
     },
     "totalCount": {
       "type": "number",
@@ -20,5 +28,5 @@
     }
   },
   "additionalProperties": false,
-  "required": ["currentPage", "totalPages"]
+  "required": ["currentPage"]
 }

--- a/packages/components/src/components/pagination/pagination.schema.json
+++ b/packages/components/src/components/pagination/pagination.schema.json
@@ -16,7 +16,8 @@
     },
     "hasNextPage": {
       "type": "boolean",
-      "description": "Whether a next page is available when totalPages is unknown. Defaults to false."
+      "description": "Whether a next page is available when totalPages is unknown. Defaults to false.",
+      "default": false
     },
     "totalCount": {
       "type": "number",

--- a/packages/components/src/components/pagination/pagination.schema.ts
+++ b/packages/components/src/components/pagination/pagination.schema.ts
@@ -10,7 +10,17 @@ const schema = {
     },
     totalPages: {
       type: 'number',
-      description: 'Total number of pages.',
+      description: 'Total number of pages. Omit when only previous/next availability is known.',
+    },
+    hasPreviousPage: {
+      type: 'boolean',
+      description:
+        'Whether a previous page is available when totalPages is unknown. Defaults to currentPage > 1.',
+    },
+    hasNextPage: {
+      type: 'boolean',
+      description:
+        'Whether a next page is available when totalPages is unknown. Defaults to false.',
     },
     totalCount: {
       type: 'number',
@@ -22,7 +32,7 @@ const schema = {
     },
   },
   additionalProperties: false,
-  required: ['currentPage', 'totalPages'],
+  required: ['currentPage'],
 } satisfies ComponentSchema;
 
 export default schema as ComponentSchema;

--- a/packages/components/src/components/pagination/pagination.schema.ts
+++ b/packages/components/src/components/pagination/pagination.schema.ts
@@ -21,6 +21,7 @@ const schema = {
       type: 'boolean',
       description:
         'Whether a next page is available when totalPages is unknown. Defaults to false.',
+      default: false,
     },
     totalCount: {
       type: 'number',

--- a/packages/components/src/components/pagination/pagination.svelte
+++ b/packages/components/src/components/pagination/pagination.svelte
@@ -23,6 +23,8 @@
   let {
     currentPage = $bindable(1),
     totalPages,
+    hasPreviousPage,
+    hasNextPage,
     totalCount,
     class: customClassName,
     ...rest
@@ -30,8 +32,12 @@
 
   const mergedClassName = $derived(classNames('cinder-pagination', customClassName));
 
-  const canGoPrevious = $derived(currentPage > 1);
-  const canGoNext = $derived(currentPage < totalPages);
+  const canGoPrevious = $derived(
+    totalPages === undefined ? (hasPreviousPage ?? currentPage > 1) : currentPage > 1,
+  );
+  const canGoNext = $derived(
+    totalPages === undefined ? (hasNextPage ?? false) : currentPage < totalPages,
+  );
 
   /**
    * Build the list of page items to render.
@@ -43,6 +49,7 @@
   type PageItem = number | 'ellipsis-start' | 'ellipsis-end';
 
   const pageItems = $derived.by((): PageItem[] => {
+    if (totalPages === undefined) return [currentPage];
     if (totalPages <= 1) return [];
 
     // For small ranges, show every page.
@@ -90,7 +97,7 @@
   });
 
   function goToPage(page: number): void {
-    if (page < 1 || page > totalPages || page === currentPage) return;
+    if (page < 1 || (totalPages !== undefined && page > totalPages) || page === currentPage) return;
     currentPage = page;
   }
 </script>

--- a/packages/components/src/components/pagination/pagination.svelte
+++ b/packages/components/src/components/pagination/pagination.svelte
@@ -24,7 +24,7 @@
     currentPage = $bindable(1),
     totalPages,
     hasPreviousPage,
-    hasNextPage,
+    hasNextPage = false,
     totalCount,
     class: customClassName,
     ...rest
@@ -35,9 +35,7 @@
   const canGoPrevious = $derived(
     totalPages === undefined ? (hasPreviousPage ?? currentPage > 1) : currentPage > 1,
   );
-  const canGoNext = $derived(
-    totalPages === undefined ? (hasNextPage ?? false) : currentPage < totalPages,
-  );
+  const canGoNext = $derived(totalPages === undefined ? hasNextPage : currentPage < totalPages);
 
   /**
    * Build the list of page items to render.

--- a/packages/components/src/components/pagination/pagination.test.ts
+++ b/packages/components/src/components/pagination/pagination.test.ts
@@ -184,4 +184,126 @@ describe('Pagination', () => {
     const nav = container.querySelector('nav');
     expect(nav?.getAttribute('aria-label')).toBe('Search results pages');
   });
+
+  test('unknown total first page disables previous and enables next when provided', async () => {
+    let currentPage = 1;
+    const { container } = render(Pagination, {
+      props: {
+        get currentPage() {
+          return currentPage;
+        },
+        set currentPage(value: number) {
+          currentPage = value;
+        },
+        hasPreviousPage: false,
+        hasNextPage: true,
+      },
+    });
+
+    const previousButton = container.querySelector(
+      'button[aria-label="Go to previous page"]',
+    ) as HTMLButtonElement;
+    const nextButton = container.querySelector(
+      'button[aria-label="Go to next page"]',
+    ) as HTMLButtonElement;
+    const currentPageIndicator = container.querySelector('[aria-current="page"]');
+
+    expect(previousButton.hasAttribute('disabled')).toBe(true);
+    expect(nextButton.hasAttribute('disabled')).toBe(false);
+    expect(currentPageIndicator?.textContent?.trim()).toBe('1');
+
+    await fireEvent.click(nextButton);
+    expect(currentPage).toBe(2);
+  });
+
+  test('unknown total middle page enables previous and next', async () => {
+    let currentPage = 4;
+    const { container } = render(Pagination, {
+      props: {
+        get currentPage() {
+          return currentPage;
+        },
+        set currentPage(value: number) {
+          currentPage = value;
+        },
+        hasPreviousPage: true,
+        hasNextPage: true,
+      },
+    });
+
+    const previousButton = container.querySelector(
+      'button[aria-label="Go to previous page"]',
+    ) as HTMLButtonElement;
+    const nextButton = container.querySelector(
+      'button[aria-label="Go to next page"]',
+    ) as HTMLButtonElement;
+
+    expect(previousButton.hasAttribute('disabled')).toBe(false);
+    expect(nextButton.hasAttribute('disabled')).toBe(false);
+
+    await fireEvent.click(previousButton);
+    expect(currentPage).toBe(3);
+  });
+
+  test('unknown total last-known page disables next without requiring a final page number', () => {
+    const { container } = render(Pagination, {
+      props: {
+        currentPage: 7,
+        hasPreviousPage: true,
+        hasNextPage: false,
+      },
+    });
+
+    const nextButton = container.querySelector('button[aria-label="Go to next page"]');
+    const pageButtons = container.querySelectorAll('.cinder-pagination__page');
+
+    expect(nextButton?.hasAttribute('disabled')).toBe(true);
+    expect(pageButtons.length).toBe(1);
+    expect(pageButtons[0]?.textContent?.trim()).toBe('7');
+    expect(container.textContent).not.toContain('of');
+  });
+
+  test('unknown total keeps next disabled when next-page availability is unknown', async () => {
+    let currentPage = 3;
+    const { container } = render(Pagination, {
+      props: {
+        get currentPage() {
+          return currentPage;
+        },
+        set currentPage(value: number) {
+          currentPage = value;
+        },
+        hasPreviousPage: true,
+      },
+    });
+
+    const nextButton = container.querySelector(
+      'button[aria-label="Go to next page"]',
+    ) as HTMLButtonElement;
+
+    expect(nextButton.hasAttribute('disabled')).toBe(true);
+    await fireEvent.click(nextButton);
+    expect(currentPage).toBe(3);
+  });
+
+  test('known total behavior ignores direction flags and keeps numbered pages', () => {
+    const { container } = render(Pagination, {
+      props: {
+        currentPage: 3,
+        totalPages: 5,
+        hasPreviousPage: false,
+        hasNextPage: false,
+      },
+    });
+
+    const previousButton = container.querySelector('button[aria-label="Go to previous page"]');
+    const nextButton = container.querySelector('button[aria-label="Go to next page"]');
+    const pageButtons = Array.from(container.querySelectorAll('.cinder-pagination__page')).map(
+      (button) => button.textContent?.trim(),
+    );
+
+    expect(previousButton?.hasAttribute('disabled')).toBe(false);
+    expect(nextButton?.hasAttribute('disabled')).toBe(false);
+    expect(pageButtons).toEqual(['1', '2', '3', '4', '5']);
+  });
 });

--- a/packages/components/src/components/pagination/pagination.types.ts
+++ b/packages/components/src/components/pagination/pagination.types.ts
@@ -3,8 +3,12 @@ import type { HTMLAttributes } from 'svelte/elements';
 export type PaginationProps = Omit<HTMLAttributes<HTMLElement>, 'class'> & {
   /** Current page number (1-indexed). Bindable. */
   currentPage: number;
-  /** Total number of pages. */
-  totalPages: number;
+  /** Total number of pages. Omit when only previous/next availability is known. */
+  totalPages?: number;
+  /** Whether a previous page is available when totalPages is unknown. Defaults to currentPage > 1. */
+  hasPreviousPage?: boolean;
+  /** Whether a next page is available when totalPages is unknown. Defaults to false. */
+  hasNextPage?: boolean;
   /** Optional total record count; formatted with formatNumber when provided. */
   totalCount?: number;
   /** Custom class merged with `.cinder-pagination`. */

--- a/packages/components/src/components/pagination/pagination.types.ts
+++ b/packages/components/src/components/pagination/pagination.types.ts
@@ -7,7 +7,7 @@ export type PaginationProps = Omit<HTMLAttributes<HTMLElement>, 'class'> & {
   totalPages?: number;
   /** Whether a previous page is available when totalPages is unknown. Defaults to currentPage > 1. */
   hasPreviousPage?: boolean;
-  /** Whether a next page is available when totalPages is unknown. Defaults to false. */
+  /** Whether a next page is available when totalPages is unknown. Defaults to false. @default false */
   hasNextPage?: boolean;
   /** Optional total record count; formatted with formatNumber when provided. */
   totalCount?: number;

--- a/packages/playground/src/examples/pagination/cursor.example.svelte
+++ b/packages/playground/src/examples/pagination/cursor.example.svelte
@@ -1,0 +1,34 @@
+<script lang="ts" module>
+  export const title = 'Cursor pagination';
+  export const description =
+    'Use page-local cursor metadata when an API exposes previous and next cursors instead of totals.';
+</script>
+
+<script lang="ts">
+  import { Pagination } from '@lostgradient/cinder/pagination';
+
+  type CursorPage = {
+    page: number;
+    previousCursor?: string;
+    nextCursor?: string;
+  };
+
+  let currentPage = $state(1);
+
+  const pages: [CursorPage, ...CursorPage[]] = [
+    { page: 1, nextCursor: 'cursor-page-2' },
+    { page: 2, previousCursor: 'cursor-page-1', nextCursor: 'cursor-page-3' },
+    { page: 3, previousCursor: 'cursor-page-2' },
+  ];
+
+  const current = $derived(pages.find((page) => page.page === currentPage) ?? pages[0]);
+</script>
+
+<Pagination
+  bind:currentPage
+  hasPreviousPage={current.previousCursor !== undefined}
+  hasNextPage={current.nextCursor !== undefined}
+/>
+<p style="margin-top: 0.5rem; color: var(--cinder-text-muted);">
+  Page {current.page}
+</p>

--- a/packages/playground/src/examples/pagination/rest-link-header.example.svelte
+++ b/packages/playground/src/examples/pagination/rest-link-header.example.svelte
@@ -1,0 +1,38 @@
+<script lang="ts" module>
+  export const title = 'REST Link-header pagination';
+  export const description =
+    'Drive previous and next buttons from parsed REST Link headers without a total page count.';
+</script>
+
+<script lang="ts">
+  import { Pagination } from '@lostgradient/cinder/pagination';
+
+  let currentPage = $state(1);
+
+  const linkHeaders: Record<number, string> = {
+    1: '<https://api.example.test/issues?page=2>; rel="next"',
+    2: '<https://api.example.test/issues?page=1>; rel="prev", <https://api.example.test/issues?page=3>; rel="next"',
+    3: '<https://api.example.test/issues?page=2>; rel="prev"',
+  };
+
+  const links = $derived(parseLinkHeader(linkHeaders[currentPage] ?? ''));
+
+  function parseLinkHeader(header: string): Record<string, string> {
+    return Object.fromEntries(
+      header
+        .split(',')
+        .map((entry) => entry.match(/<([^>]+)>;\s*rel="([^"]+)"/))
+        .filter((match): match is RegExpMatchArray => match !== null)
+        .map((match) => [match[2], match[1]]),
+    );
+  }
+</script>
+
+<Pagination
+  bind:currentPage
+  hasPreviousPage={links['prev'] !== undefined}
+  hasNextPage={links['next'] !== undefined}
+/>
+<p style="margin-top: 0.5rem; color: var(--cinder-text-muted);">
+  Page {currentPage}
+</p>


### PR DESCRIPTION
Closes #595

## Summary
- allow Pagination to render previous/next controls when totalPages is unknown
- preserve known-total page list behavior and accessible disabled/current states
- document REST Link-header and cursor pagination examples

## Verification
- bun test --conditions browser --conditions svelte packages/components/src/components/pagination/pagination.test.ts
- bun test --conditions browser --conditions svelte packages/components/src/api-contract.test.ts
- bun run --filter=@lostgradient/cinder components:check
- bun run --filter=@lostgradient/cinder validate:consumer
- pre-commit hook passed
- pre-push hook passed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped UI/API extension with backward-compatible totalPages usage; main risk is consumers who relied on totalPages being required at compile time.
> 
> **Overview**
> **Pagination** can now work when **`totalPages`** is unknown: callers omit **`totalPages`** and drive navigation with optional **`hasPreviousPage`** and **`hasNextPage`** (default **`false`** for next; previous falls back to **`currentPage > 1`**). In that mode the UI shows only the current page plus prev/next—no numbered range or fake last page—while **`totalPages`** still enables the existing ellipsed page list and boundary checks.
> 
> Types, JSON schema, and the **`api-contract`** entry are aligned (**`totalPages`** optional; only **`currentPage`** required). Tests cover unknown-total edge cases and confirm known-total behavior ignores the direction flags. README, **`pagination.examples.json`**, and playground examples document cursor and REST **Link** header patterns.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1c42ee63e45ea0cbd313d02f0c2305b93f9fd5f5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->