### PR TITLE
Fix unknown-total Pagination lower bound

### DIFF
--- a/packages/components/src/components/pagination/pagination.svelte
+++ b/packages/components/src/components/pagination/pagination.svelte
@@ -33,7 +33,7 @@
   const mergedClassName = $derived(classNames('cinder-pagination', customClassName));
 
   const canGoPrevious = $derived(
-    totalPages === undefined ? (hasPreviousPage ?? currentPage > 1) : currentPage > 1,
+    currentPage > 1 && (totalPages === undefined ? (hasPreviousPage ?? true) : true),
   );
   const canGoNext = $derived(totalPages === undefined ? hasNextPage : currentPage < totalPages);
 

--- a/packages/components/src/components/pagination/pagination.test.ts
+++ b/packages/components/src/components/pagination/pagination.test.ts
@@ -216,6 +216,29 @@ describe('Pagination', () => {
     expect(currentPage).toBe(2);
   });
 
+  test('unknown total keeps previous disabled at the lower page bound', async () => {
+    let currentPage = 1;
+    const { container } = render(Pagination, {
+      props: {
+        get currentPage() {
+          return currentPage;
+        },
+        set currentPage(value: number) {
+          currentPage = value;
+        },
+        hasPreviousPage: true,
+      },
+    });
+
+    const previousButton = container.querySelector(
+      'button[aria-label="Go to previous page"]',
+    ) as HTMLButtonElement;
+
+    expect(previousButton.hasAttribute('disabled')).toBe(true);
+    await fireEvent.click(previousButton);
+    expect(currentPage).toBe(1);
+  });
+
   test('unknown total middle page enables previous and next', async () => {
     let currentPage = 4;
     const { container } = render(Pagination, {


### PR DESCRIPTION
Follow-up to #631 after it was merged before late review feedback landed in main.

## Summary
- keep Previous disabled at page 1 in unknown-total mode even if hasPreviousPage is true
- add a regression test for the enabled-but-non-mutating Previous button case

## Verification
- bun test --conditions browser --conditions svelte packages/components/src/components/pagination/pagination.test.ts
- bun test --conditions browser --conditions svelte packages/components/src/api-contract.test.ts
- bun run --filter=@lostgradient/cinder components:check
- bun run --filter=@lostgradient/cinder validate:consumer
- pre-push hook passed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small UI guard in Pagination’s previous-button logic with a targeted test; no auth, data, or API changes.
> 
> **Overview**
> **Unknown-total pagination** no longer treats `hasPreviousPage: true` as enough to enable **Previous** on page 1.
> 
> `canGoPrevious` now requires **`currentPage > 1`** before honoring `hasPreviousPage` (when `totalPages` is omitted), so the lower bound matches known-total behavior and `goToPage` cannot be triggered from a misleading enabled control.
> 
> A regression test covers page 1 with `hasPreviousPage: true`: Previous stays disabled and clicks do not change `currentPage`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4b556c18c6fed8bfc80f6000670411ac53598a0b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->