### PR TITLE
Allow Toolbar groups to wrap

### DIFF
--- a/packages/components/src/components/toolbar/README.md
+++ b/packages/components/src/components/toolbar/README.md
@@ -22,6 +22,12 @@ A named grouping of related controls that implements the WAI-ARIA toolbar patter
 </Toolbar>
 ```
 
+Horizontal toolbars wrap groups by default so constrained containers do not
+overlap controls. Each `Toolbar.Group` keeps its controls together until the
+toolbar's narrow container query wraps controls inside the group. A named
+`Toolbar.Group` gets `role="group"` by default; pass an explicit `role` when a
+different semantic grouping is required.
+
 ## Props
 
 <!-- generated:props:start -->

--- a/packages/components/src/components/toolbar/README.md
+++ b/packages/components/src/components/toolbar/README.md
@@ -35,7 +35,7 @@ different semantic grouping is required.
 | Prop          | Type                           | Required | Default        | Description                                                                                                      |
 | ------------- | ------------------------------ | -------- | -------------- | ---------------------------------------------------------------------------------------------------------------- |
 | `class`       | `string`                       | no       | —              | Additional class merged with `.cinder-toolbar`.                                                                  |
-| `orientation` | `"horizontal"` \| `"vertical"` | no       | `"horizontal"` | Layout direction for keyboard ownership and separator placement.                                                 |
+| `orientation` | `"horizontal"` \| `"vertical"` | no       | `"horizontal"` | Layout direction for keyboard ownership and vertical group separator placement.                                  |
 | `children`    | `(opaque)`                     | yes      | —              | Controls rendered inside the toolbar. Not expressible in JSON Schema; see the component types for the signature. |
 
 <!-- generated:props:end -->
@@ -52,7 +52,7 @@ This component does not declare any local CSS variables.
 
 <!-- generated:subcomponents:start -->
 
-- `Toolbar.Group` — cluster related controls and let the toolbar draw separators between groups.
+- `Toolbar.Group` — cluster related controls and keep them together while the toolbar wraps.
 - `Toolbar.Spacer` — consume remaining space and push later groups to the far edge.
 
 <!-- generated:subcomponents:end -->

--- a/packages/components/src/components/toolbar/toolbar-group.svelte
+++ b/packages/components/src/components/toolbar/toolbar-group.svelte
@@ -21,14 +21,23 @@
 
   let { class: className, orientation, children, role, ...rest }: ToolbarGroupProps = $props();
 
-  const hasAccessibleName = $derived(
-    (typeof rest['aria-label'] === 'string' && rest['aria-label'].trim().length > 0) ||
-      (typeof rest['aria-labelledby'] === 'string' && rest['aria-labelledby'].trim().length > 0),
+  const normalizedAriaLabel = $derived(
+    typeof rest['aria-label'] === 'string' && rest['aria-label'].trim().length > 0
+      ? rest['aria-label']
+      : undefined,
   );
+  const normalizedAriaLabelledBy = $derived(
+    typeof rest['aria-labelledby'] === 'string' && rest['aria-labelledby'].trim().length > 0
+      ? rest['aria-labelledby']
+      : undefined,
+  );
+  const hasAccessibleName = $derived(Boolean(normalizedAriaLabel || normalizedAriaLabelledBy));
 </script>
 
 <div
   {...rest}
+  aria-label={normalizedAriaLabel}
+  aria-labelledby={normalizedAriaLabelledBy}
   role={role ?? (hasAccessibleName ? 'group' : undefined)}
   class={classNames('cinder-toolbar__group', className)}
   data-cinder-toolbar-group=""

--- a/packages/components/src/components/toolbar/toolbar-group.svelte
+++ b/packages/components/src/components/toolbar/toolbar-group.svelte
@@ -3,11 +3,11 @@
    * @cinder
    * @category action
    * @status stable
-   * @purpose Compound child for Toolbar that groups related controls and owns the separator boundary between groups.
+   * @purpose Compound child for Toolbar that clusters related controls inside the roving tabindex boundary.
    * @tag action
    * @tag grouping
    * @useWhen Clustering related toolbar controls such as a viewport preset control plus its numeric width field.
-   * @useWhen Letting the toolbar itself draw separators between adjacent groups instead of hand-placing dividers.
+   * @useWhen Keeping related toolbar controls together as the toolbar wraps in constrained containers.
    * @avoidWhen Rendering a standalone action group outside a Toolbar — use button-group or plain layout primitives instead.
    * @related toolbar, button-group
    */

--- a/packages/components/src/components/toolbar/toolbar-group.svelte
+++ b/packages/components/src/components/toolbar/toolbar-group.svelte
@@ -23,12 +23,12 @@
 
   const normalizedAriaLabel = $derived(
     typeof rest['aria-label'] === 'string' && rest['aria-label'].trim().length > 0
-      ? rest['aria-label']
+      ? rest['aria-label'].trim()
       : undefined,
   );
   const normalizedAriaLabelledBy = $derived(
     typeof rest['aria-labelledby'] === 'string' && rest['aria-labelledby'].trim().length > 0
-      ? rest['aria-labelledby']
+      ? rest['aria-labelledby'].trim()
       : undefined,
   );
   const hasAccessibleName = $derived(Boolean(normalizedAriaLabel || normalizedAriaLabelledBy));

--- a/packages/components/src/components/toolbar/toolbar-group.svelte
+++ b/packages/components/src/components/toolbar/toolbar-group.svelte
@@ -19,11 +19,17 @@
 
   import { classNames } from '../../utilities/class-names.ts';
 
-  let { class: className, orientation, children, ...rest }: ToolbarGroupProps = $props();
+  let { class: className, orientation, children, role, ...rest }: ToolbarGroupProps = $props();
+
+  const hasAccessibleName = $derived(
+    (typeof rest['aria-label'] === 'string' && rest['aria-label'].trim().length > 0) ||
+      (typeof rest['aria-labelledby'] === 'string' && rest['aria-labelledby'].trim().length > 0),
+  );
 </script>
 
 <div
   {...rest}
+  role={role ?? (hasAccessibleName ? 'group' : undefined)}
   class={classNames('cinder-toolbar__group', className)}
   data-cinder-toolbar-group=""
   data-cinder-orientation={orientation}

--- a/packages/components/src/components/toolbar/toolbar.a11y.md
+++ b/packages/components/src/components/toolbar/toolbar.a11y.md
@@ -21,6 +21,6 @@ Toolbar does not require child registration APIs. It manages native focusable de
 
 ## Groups
 
-`Toolbar.Group` is layout-only unless it has an accessible name. It clusters related controls, keeps them together while horizontal toolbars wrap, and gets `role="group"` when named with `aria-label` or `aria-labelledby`.
+`Toolbar.Group` is layout-only unless it has an accessible name or explicit `role`. It clusters related controls, keeps them together while horizontal toolbars wrap, and gets `role="group"` when named with `aria-label` or `aria-labelledby`.
 
 `Toolbar.Spacer` is `aria-hidden="true"` and never becomes a toolbar item.

--- a/packages/components/src/components/toolbar/toolbar.a11y.md
+++ b/packages/components/src/components/toolbar/toolbar.a11y.md
@@ -19,8 +19,8 @@
 
 Toolbar does not require child registration APIs. It manages native focusable descendants in DOM order, which means existing controls such as `Button`, `SegmentedControl`, and `NumberInput` work without toolbar-specific props.
 
-## Groups and separators
+## Groups
 
-`Toolbar.Group` is layout-only. It clusters related controls and lets the toolbar own the separators between adjacent groups, which keeps the visual dividers out of the accessibility tree.
+`Toolbar.Group` is layout-only unless it has an accessible name. It clusters related controls, keeps them together while horizontal toolbars wrap, and gets `role="group"` when named with `aria-label` or `aria-labelledby`.
 
 `Toolbar.Spacer` is `aria-hidden="true"` and never becomes a toolbar item.

--- a/packages/components/src/components/toolbar/toolbar.css
+++ b/packages/components/src/components/toolbar/toolbar.css
@@ -42,6 +42,14 @@
     background: var(--cinder-border);
   }
 
+  .cinder-toolbar[data-cinder-orientation='horizontal']
+    > .cinder-toolbar__group:has(+ .cinder-toolbar__group)::after {
+    content: '';
+    inline-size: 1px;
+    align-self: stretch;
+    background: var(--cinder-border);
+  }
+
   .cinder-toolbar__spacer {
     flex: 1 1 auto;
     min-inline-size: var(--cinder-space-2);

--- a/packages/components/src/components/toolbar/toolbar.css
+++ b/packages/components/src/components/toolbar/toolbar.css
@@ -5,9 +5,13 @@
     align-items: center;
     gap: var(--cinder-space-2);
     min-inline-size: 0;
-    flex-wrap: wrap;
+    flex-wrap: nowrap;
     container-type: inline-size;
     container-name: cinder-toolbar;
+  }
+
+  .cinder-toolbar[data-cinder-orientation='horizontal'] {
+    flex-wrap: wrap;
   }
 
   .cinder-toolbar[data-cinder-orientation='vertical'] {
@@ -29,16 +33,6 @@
     align-items: stretch;
   }
 
-  .cinder-toolbar[data-cinder-orientation='horizontal']
-    > .cinder-toolbar__group
-    + .cinder-toolbar__group::before {
-    content: '';
-    inline-size: 1px;
-    block-size: 1.5rem;
-    background: var(--cinder-border);
-    flex-shrink: 0;
-  }
-
   .cinder-toolbar[data-cinder-orientation='vertical']
     > .cinder-toolbar__group
     + .cinder-toolbar__group::before {
@@ -51,6 +45,12 @@
   .cinder-toolbar__spacer {
     flex: 1 1 auto;
     min-inline-size: var(--cinder-space-2);
+  }
+
+  .cinder-toolbar[data-cinder-orientation='horizontal']
+    > .cinder-toolbar__spacer
+    + .cinder-toolbar__group {
+    margin-inline-start: auto;
   }
 
   @container cinder-toolbar (max-width: 30rem) {

--- a/packages/components/src/components/toolbar/toolbar.css
+++ b/packages/components/src/components/toolbar/toolbar.css
@@ -42,15 +42,6 @@
     background: var(--cinder-border);
   }
 
-  .cinder-toolbar[data-cinder-orientation='horizontal']
-    > .cinder-toolbar__group:has(+ .cinder-toolbar__group)::after {
-    content: '';
-    inline-size: 1px;
-    align-self: stretch;
-    background: var(--cinder-border);
-    flex-shrink: 0;
-  }
-
   .cinder-toolbar__spacer {
     flex: 1 1 auto;
     min-inline-size: var(--cinder-space-2);

--- a/packages/components/src/components/toolbar/toolbar.css
+++ b/packages/components/src/components/toolbar/toolbar.css
@@ -5,7 +5,7 @@
     align-items: center;
     gap: var(--cinder-space-2);
     min-inline-size: 0;
-    flex-wrap: nowrap;
+    flex-wrap: wrap;
     container-type: inline-size;
     container-name: cinder-toolbar;
   }
@@ -55,7 +55,6 @@
 
   @container cinder-toolbar (max-width: 30rem) {
     .cinder-toolbar[data-cinder-orientation='horizontal'] {
-      flex-wrap: wrap;
       align-items: stretch;
     }
 

--- a/packages/components/src/components/toolbar/toolbar.css
+++ b/packages/components/src/components/toolbar/toolbar.css
@@ -48,6 +48,7 @@
     inline-size: 1px;
     align-self: stretch;
     background: var(--cinder-border);
+    flex-shrink: 0;
   }
 
   .cinder-toolbar__spacer {

--- a/packages/components/src/components/toolbar/toolbar.css
+++ b/packages/components/src/components/toolbar/toolbar.css
@@ -49,7 +49,7 @@
 
   .cinder-toolbar[data-cinder-orientation='horizontal']
     > .cinder-toolbar__spacer
-    ~ .cinder-toolbar__group {
+    + .cinder-toolbar__group {
     margin-inline-start: auto;
   }
 

--- a/packages/components/src/components/toolbar/toolbar.css
+++ b/packages/components/src/components/toolbar/toolbar.css
@@ -49,7 +49,7 @@
 
   .cinder-toolbar[data-cinder-orientation='horizontal']
     > .cinder-toolbar__spacer
-    + .cinder-toolbar__group {
+    ~ .cinder-toolbar__group {
     margin-inline-start: auto;
   }
 

--- a/packages/components/src/components/toolbar/toolbar.examples.json
+++ b/packages/components/src/components/toolbar/toolbar.examples.json
@@ -18,7 +18,7 @@
     {
       "id": "with-groups",
       "title": "Toolbar with groups",
-      "description": "Adjacent groups draw their own separators without manual dividers.",
+      "description": "Adjacent groups keep related controls together while the toolbar wraps.",
       "code": "<script lang=\"ts\">\n  import Toolbar from '@lostgradient/cinder/toolbar';\n  import { Button } from '@lostgradient/cinder/button';\n  import Segment from '@lostgradient/cinder/segment';\n  import SegmentedControl from '@lostgradient/cinder/segmented-control';\n</script>\n\n<Toolbar aria-label=\"Preview controls\">\n  <Toolbar.Group>\n    <SegmentedControl id=\"scale\" label=\"Scale\" hideLabel value=\"100\" onchange={() => {}}>\n      <Segment value=\"75\">75%</Segment>\n      <Segment value=\"100\">100%</Segment>\n      <Segment value=\"125\">125%</Segment>\n    </SegmentedControl>\n  </Toolbar.Group>\n\n  <Toolbar.Group>\n    <Button variant=\"ghost\" size=\"sm\">Fit</Button>\n    <Button variant=\"ghost\" size=\"sm\">Grid</Button>\n  </Toolbar.Group>\n</Toolbar>\n"
     },
     {

--- a/packages/components/src/components/toolbar/toolbar.schema.json
+++ b/packages/components/src/components/toolbar/toolbar.schema.json
@@ -4,7 +4,7 @@
   "properties": {
     "orientation": {
       "enum": ["horizontal", "vertical"],
-      "description": "Layout direction for keyboard ownership and separator placement.",
+      "description": "Layout direction for keyboard ownership and vertical group separator placement.",
       "default": "horizontal"
     },
     "class": {

--- a/packages/components/src/components/toolbar/toolbar.schema.ts
+++ b/packages/components/src/components/toolbar/toolbar.schema.ts
@@ -6,7 +6,8 @@ const schema = {
   properties: {
     orientation: {
       enum: ['horizontal', 'vertical'],
-      description: 'Layout direction for keyboard ownership and separator placement.',
+      description:
+        'Layout direction for keyboard ownership and vertical group separator placement.',
       default: 'horizontal',
     },
     class: {

--- a/packages/components/src/components/toolbar/toolbar.test.ts
+++ b/packages/components/src/components/toolbar/toolbar.test.ts
@@ -465,7 +465,7 @@ describe('Toolbar responsive CSS', () => {
     );
     expect(toolbarCss).toMatch(/\.cinder-toolbar__group\s*\{[\s\S]*?flex-wrap:\s*nowrap;/);
     expect(toolbarCss).toMatch(
-      /\.cinder-toolbar\[data-cinder-orientation='horizontal'\][\s\S]*?> \.cinder-toolbar__spacer[\s\S]*?\+ \.cinder-toolbar__group[\s\S]*?margin-inline-start:\s*auto;/,
+      /\.cinder-toolbar\[data-cinder-orientation='horizontal'\][\s\S]*?> \.cinder-toolbar__spacer[\s\S]*?~ \.cinder-toolbar__group[\s\S]*?margin-inline-start:\s*auto;/,
     );
     expect(toolbarCss).toContain('@container cinder-toolbar (max-width: 30rem)');
     expect(toolbarCss).not.toContain('@media (max-width: 30rem)');

--- a/packages/components/src/components/toolbar/toolbar.test.ts
+++ b/packages/components/src/components/toolbar/toolbar.test.ts
@@ -414,9 +414,12 @@ describe('Toolbar', () => {
     expect(warnSpy).toHaveBeenCalledTimes(1);
   });
 
-  test('separator spacing relies on flex gap without extra separator margins', async () => {
+  test('separator spacing relies on flex gap without horizontal separators or extra margins', async () => {
     const styleSheet = await Bun.file(new URL('./toolbar.css', import.meta.url)).text();
 
+    expect(styleSheet).not.toContain(
+      ".cinder-toolbar[data-cinder-orientation='horizontal']\n    > .cinder-toolbar__group\n    + .cinder-toolbar__group::before",
+    );
     expect(styleSheet).not.toContain('margin-inline-end: var(--cinder-space-2)');
     expect(styleSheet).not.toContain('margin-block-end: var(--cinder-space-2)');
   });
@@ -437,8 +440,14 @@ describe('Toolbar', () => {
 describe('Toolbar responsive CSS', () => {
   test('horizontal toolbars wrap groups before the narrow container query wraps group contents', () => {
     expect(toolbarCss).toContain('container-name: cinder-toolbar;');
-    expect(toolbarCss).toMatch(/\.cinder-toolbar\s*\{[\s\S]*?flex-wrap:\s*wrap;/);
+    expect(toolbarCss).toMatch(/\.cinder-toolbar\s*\{[\s\S]*?flex-wrap:\s*nowrap;/);
+    expect(toolbarCss).toMatch(
+      /\.cinder-toolbar\[data-cinder-orientation='horizontal'\]\s*\{[\s\S]*?flex-wrap:\s*wrap;/,
+    );
     expect(toolbarCss).toMatch(/\.cinder-toolbar__group\s*\{[\s\S]*?flex-wrap:\s*nowrap;/);
+    expect(toolbarCss).toMatch(
+      /\.cinder-toolbar\[data-cinder-orientation='horizontal'\][\s\S]*?> \.cinder-toolbar__spacer[\s\S]*?\+ \.cinder-toolbar__group[\s\S]*?margin-inline-start:\s*auto;/,
+    );
     expect(toolbarCss).toContain('@container cinder-toolbar (max-width: 30rem)');
     expect(toolbarCss).not.toContain('@media (max-width: 30rem)');
     expect(toolbarCss).toMatch(

--- a/packages/components/src/components/toolbar/toolbar.test.ts
+++ b/packages/components/src/components/toolbar/toolbar.test.ts
@@ -9,6 +9,7 @@ setupHappyDom();
 
 const { cleanup, fireEvent, render, screen } = await import('@testing-library/svelte');
 const { default: Toolbar } = await import('./index.ts');
+const { default: ToolbarGroup } = await import('./toolbar-group.svelte');
 const { default: ToolbarSpacer } = await import('./toolbar-spacer.svelte');
 const { default: ToolbarCompositionFixture } =
   await import('../../test/fixtures/toolbar-composition-fixture.svelte');
@@ -381,6 +382,17 @@ describe('Toolbar', () => {
     expect(document.activeElement).toBe(buttons[1]!);
   });
 
+  test('Toolbar.Group exposes role group when it has an accessible name', () => {
+    render(ToolbarGroup, {
+      props: {
+        'aria-label': 'Order states',
+        children: rawSnippet('<button type="button">Place order</button>'),
+      } as never,
+    });
+
+    expect(screen.getByRole('group', { name: 'Order states' })).toBeTruthy();
+  });
+
   test('Toolbar.Spacer warns on invalid flex and falls back to one', async () => {
     const warnSpy = mock(() => {});
     const original = console.warn;
@@ -423,12 +435,14 @@ describe('Toolbar', () => {
 });
 
 describe('Toolbar responsive CSS', () => {
-  test('horizontal toolbars wrap through a component container query', () => {
+  test('horizontal toolbars wrap groups before the narrow container query wraps group contents', () => {
     expect(toolbarCss).toContain('container-name: cinder-toolbar;');
+    expect(toolbarCss).toMatch(/\.cinder-toolbar\s*\{[\s\S]*?flex-wrap:\s*wrap;/);
+    expect(toolbarCss).toMatch(/\.cinder-toolbar__group\s*\{[\s\S]*?flex-wrap:\s*nowrap;/);
     expect(toolbarCss).toContain('@container cinder-toolbar (max-width: 30rem)');
     expect(toolbarCss).not.toContain('@media (max-width: 30rem)');
     expect(toolbarCss).toMatch(
-      /@container cinder-toolbar \(max-width: 30rem\)[\s\S]*?\.cinder-toolbar\[data-cinder-orientation='horizontal'\][\s\S]*?flex-wrap:\s*wrap;/,
+      /@container cinder-toolbar \(max-width: 30rem\)[\s\S]*?\.cinder-toolbar\[data-cinder-orientation='horizontal'\]\s+\.cinder-toolbar__group[\s\S]*?flex-wrap:\s*wrap;/,
     );
   });
 });

--- a/packages/components/src/components/toolbar/toolbar.test.ts
+++ b/packages/components/src/components/toolbar/toolbar.test.ts
@@ -477,7 +477,7 @@ describe('Toolbar responsive CSS', () => {
     );
     expect(toolbarCss).toMatch(/\.cinder-toolbar__group\s*\{[\s\S]*?flex-wrap:\s*nowrap;/);
     expect(toolbarCss).toMatch(
-      /\.cinder-toolbar\[data-cinder-orientation='horizontal'\][\s\S]*?> \.cinder-toolbar__spacer[\s\S]*?~ \.cinder-toolbar__group[\s\S]*?margin-inline-start:\s*auto;/,
+      /\.cinder-toolbar\[data-cinder-orientation='horizontal'\][\s\S]*?> \.cinder-toolbar__spacer[\s\S]*?\+ \.cinder-toolbar__group[\s\S]*?margin-inline-start:\s*auto;/,
     );
     expect(toolbarCss).toContain('@container cinder-toolbar (max-width: 30rem)');
     expect(toolbarCss).not.toContain('@media (max-width: 30rem)');

--- a/packages/components/src/components/toolbar/toolbar.test.ts
+++ b/packages/components/src/components/toolbar/toolbar.test.ts
@@ -414,11 +414,14 @@ describe('Toolbar', () => {
     expect(warnSpy).toHaveBeenCalledTimes(1);
   });
 
-  test('separator spacing relies on flex gap without horizontal separators or extra margins', async () => {
+  test('separator spacing preserves horizontal group dividers without leading wrapped-row separators', async () => {
     const styleSheet = await Bun.file(new URL('./toolbar.css', import.meta.url)).text();
 
     expect(styleSheet).not.toContain(
       ".cinder-toolbar[data-cinder-orientation='horizontal']\n    > .cinder-toolbar__group\n    + .cinder-toolbar__group::before",
+    );
+    expect(styleSheet).toContain(
+      ".cinder-toolbar[data-cinder-orientation='horizontal']\n    > .cinder-toolbar__group:has(+ .cinder-toolbar__group)::after",
     );
     expect(styleSheet).not.toContain('margin-inline-end: var(--cinder-space-2)');
     expect(styleSheet).not.toContain('margin-block-end: var(--cinder-space-2)');

--- a/packages/components/src/components/toolbar/toolbar.test.ts
+++ b/packages/components/src/components/toolbar/toolbar.test.ts
@@ -393,6 +393,19 @@ describe('Toolbar', () => {
     expect(screen.getByRole('group', { name: 'Order states' })).toBeTruthy();
   });
 
+  test('Toolbar.Group omits empty accessible-name attributes', () => {
+    const { container } = render(ToolbarGroup, {
+      props: {
+        'aria-label': '',
+        children: rawSnippet('<button type="button">Place order</button>'),
+      } as never,
+    });
+
+    const group = container.querySelector('.cinder-toolbar__group');
+    expect(group?.hasAttribute('aria-label')).toBe(false);
+    expect(group?.hasAttribute('role')).toBe(false);
+  });
+
   test('Toolbar.Spacer warns on invalid flex and falls back to one', async () => {
     const warnSpy = mock(() => {});
     const original = console.warn;
@@ -417,11 +430,11 @@ describe('Toolbar', () => {
   test('separator spacing preserves horizontal group dividers without leading wrapped-row separators', async () => {
     const styleSheet = await Bun.file(new URL('./toolbar.css', import.meta.url)).text();
 
-    expect(styleSheet).not.toContain(
-      ".cinder-toolbar[data-cinder-orientation='horizontal']\n    > .cinder-toolbar__group\n    + .cinder-toolbar__group::before",
+    expect(styleSheet).not.toMatch(
+      /\.cinder-toolbar\[data-cinder-orientation='horizontal'\]\s*>\s*\.cinder-toolbar__group\s*\+\s*\.cinder-toolbar__group::before/,
     );
-    expect(styleSheet).toContain(
-      ".cinder-toolbar[data-cinder-orientation='horizontal']\n    > .cinder-toolbar__group:has(+ .cinder-toolbar__group)::after",
+    expect(styleSheet).toMatch(
+      /\.cinder-toolbar\[data-cinder-orientation='horizontal'\]\s*>\s*\.cinder-toolbar__group:has\(\+ \.cinder-toolbar__group\)::after\s*\{[\s\S]*?flex-shrink:\s*0;/,
     );
     expect(styleSheet).not.toContain('margin-inline-end: var(--cinder-space-2)');
     expect(styleSheet).not.toContain('margin-block-end: var(--cinder-space-2)');

--- a/packages/components/src/components/toolbar/toolbar.test.ts
+++ b/packages/components/src/components/toolbar/toolbar.test.ts
@@ -427,14 +427,17 @@ describe('Toolbar', () => {
     expect(warnSpy).toHaveBeenCalledTimes(1);
   });
 
-  test('separator spacing preserves horizontal group dividers without leading wrapped-row separators', async () => {
+  test('separator spacing relies on flex gap without horizontal separators or extra margins', async () => {
     const styleSheet = await Bun.file(new URL('./toolbar.css', import.meta.url)).text();
 
     expect(styleSheet).not.toMatch(
       /\.cinder-toolbar\[data-cinder-orientation='horizontal'\]\s*>\s*\.cinder-toolbar__group\s*\+\s*\.cinder-toolbar__group::before/,
     );
+    expect(styleSheet).not.toMatch(
+      /\.cinder-toolbar\[data-cinder-orientation='horizontal'\]\s*>\s*\.cinder-toolbar__group:has\(\+ \.cinder-toolbar__group\)::after/,
+    );
     expect(styleSheet).toMatch(
-      /\.cinder-toolbar\[data-cinder-orientation='horizontal'\]\s*>\s*\.cinder-toolbar__group:has\(\+ \.cinder-toolbar__group\)::after\s*\{[\s\S]*?flex-shrink:\s*0;/,
+      /\.cinder-toolbar\[data-cinder-orientation='vertical'\]\s*>\s*\.cinder-toolbar__group\s*\+\s*\.cinder-toolbar__group::before/,
     );
     expect(styleSheet).not.toContain('margin-inline-end: var(--cinder-space-2)');
     expect(styleSheet).not.toContain('margin-block-end: var(--cinder-space-2)');

--- a/packages/components/src/components/toolbar/toolbar.test.ts
+++ b/packages/components/src/components/toolbar/toolbar.test.ts
@@ -406,6 +406,18 @@ describe('Toolbar', () => {
     expect(group?.hasAttribute('role')).toBe(false);
   });
 
+  test('Toolbar.Group trims emitted accessible-name attributes', () => {
+    const { container } = render(ToolbarGroup, {
+      props: {
+        'aria-label': ' Order states ',
+        children: rawSnippet('<button type="button">Place order</button>'),
+      } as never,
+    });
+
+    const group = container.querySelector('.cinder-toolbar__group');
+    expect(group?.getAttribute('aria-label')).toBe('Order states');
+  });
+
   test('Toolbar.Spacer warns on invalid flex and falls back to one', async () => {
     const warnSpy = mock(() => {});
     const original = console.warn;

--- a/packages/components/src/components/toolbar/toolbar.types.ts
+++ b/packages/components/src/components/toolbar/toolbar.types.ts
@@ -10,7 +10,7 @@ type ToolbarBaseProps = Omit<
 > & {
   /** Additional class merged with `.cinder-toolbar`. */
   class?: string;
-  /** Layout direction for roving-key ownership and separator placement. */
+  /** Layout direction for roving-key ownership and vertical group separator placement. */
   orientation?: ToolbarOrientation;
   /** Controls rendered inside the toolbar. */
   children: Snippet;
@@ -50,7 +50,7 @@ export type ToolbarSpacerProps = Omit<HTMLAttributes<HTMLDivElement>, 'aria-hidd
 /** Schema-facing Toolbar props. */
 export interface ToolbarSchemaProps {
   /**
-   * Layout direction for keyboard ownership and separator placement.
+   * Layout direction for keyboard ownership and vertical group separator placement.
    * @default "horizontal"
    */
   orientation?: ToolbarOrientation;

--- a/packages/playground/src/examples/toolbar/with-groups.example.svelte
+++ b/packages/playground/src/examples/toolbar/with-groups.example.svelte
@@ -1,6 +1,7 @@
 <script lang="ts" module>
   export const title = 'Toolbar with groups';
-  export const description = 'Adjacent groups draw their own separators without manual dividers.';
+  export const description =
+    'Adjacent groups keep related controls together while the toolbar wraps.';
 </script>
 
 <script lang="ts">


### PR DESCRIPTION
## Summary
- allow horizontal Toolbar roots to wrap groups by default so intermediate-width containers do not overlap controls
- keep individual Toolbar.Group contents nowrap until the existing narrow container query wraps group contents
- default named Toolbar.Group instances to role="group" and document the wrapping/group semantics

Fixes #613.

## Verification
- bun run --filter=@lostgradient/cinder test -- ./src/components/toolbar/toolbar.test.ts
- bun run --filter=@lostgradient/cinder components:check
- pre-commit hook
- pre-push scoped hook

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Removes horizontal group dividers and changes wrap behavior, which can shift existing toolbar layouts; a11y role changes apply only to named groups.
> 
> **Overview**
> Horizontal **Toolbar** roots now use **`flex-wrap: wrap`** so **groups** move to new lines instead of overlapping in tight widths; each **`Toolbar.Group`** still **`nowrap`** until the existing **`@container cinder-toolbar (max-width: 30rem)`** rule wraps controls inside the group.
> 
> **Layout/visual:** pseudo-element **separators between adjacent horizontal groups are removed** (vertical group separators unchanged). **`Toolbar.Spacer`** + following group gets **`margin-inline-start: auto`** so trailing actions stay right-aligned when rows wrap.
> 
> **`Toolbar.Group`:** trims **`aria-label` / `aria-labelledby`**, drops empty name attrs, and sets **`role="group"`** when the group has an accessible name (or an explicit **`role`**). Docs, examples, and schema copy now describe wrapping instead of horizontal inter-group separators.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a2769555b0342c68feff943d0e33b80a88e21a15. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->