### PR TITLE
Fix chat input editor padding

### DIFF
--- a/packages/components/src/components/chat/input/chat-input-layout.test.ts
+++ b/packages/components/src/components/chat/input/chat-input-layout.test.ts
@@ -19,6 +19,7 @@ function cssBlocks(source: string, selector: string): string[] {
       0,
     );
 
+    let closed = false;
     let depth = 0;
     for (let index = openingBraceIndex; index < source.length; index++) {
       const character = source[index];
@@ -27,8 +28,13 @@ function cssBlocks(source: string, selector: string): string[] {
       if (depth === 0) {
         blocks.push(source.slice(openingBraceIndex + 1, index));
         searchStart = index + 1;
+        closed = true;
         break;
       }
+    }
+
+    if (!closed) {
+      throw new Error(`Unclosed CSS block for selector: ${selector}`);
     }
   }
 

--- a/packages/components/src/components/chat/input/chat-input-layout.test.ts
+++ b/packages/components/src/components/chat/input/chat-input-layout.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, test } from 'bun:test';
+
+const chatInputPath = new URL('./chat-input.svelte', import.meta.url);
+
+function stripCssComments(source: string): string {
+  return source.replace(/\/\*[\s\S]*?\*\//g, '');
+}
+
+function cssBlocks(source: string, selector: string): string[] {
+  const blocks: string[] = [];
+  let searchStart = 0;
+
+  while (searchStart < source.length) {
+    const selectorIndex = source.indexOf(selector, searchStart);
+    if (selectorIndex === -1) break;
+
+    const openingBraceIndex = source.indexOf('{', selectorIndex);
+    expect(openingBraceIndex, `Missing CSS block for selector: ${selector}`).toBeGreaterThanOrEqual(
+      0,
+    );
+
+    let depth = 0;
+    for (let index = openingBraceIndex; index < source.length; index++) {
+      const character = source[index];
+      if (character === '{') depth++;
+      if (character === '}') depth--;
+      if (depth === 0) {
+        blocks.push(source.slice(openingBraceIndex + 1, index));
+        searchStart = index + 1;
+        break;
+      }
+    }
+  }
+
+  expect(blocks.length, `Missing CSS selector: ${selector}`).toBeGreaterThan(0);
+  return blocks;
+}
+
+function expectDeclaration(block: string, property: string, value: string): void {
+  const escapedValue = value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const declaration = new RegExp(`${property}\\s*:\\s*${escapedValue}\\s*;`);
+  expect(block).toMatch(declaration);
+}
+
+describe('ChatInput layout CSS', () => {
+  test('gives the embedded ProseMirror surface non-zero tokenized horizontal padding', async () => {
+    const chatInputSource = stripCssComments(await Bun.file(chatInputPath).text());
+    const proseMirrorBlocks = cssBlocks(
+      chatInputSource,
+      '.chat-input-editor-container :global(.ProseMirror)',
+    );
+
+    expectDeclaration(
+      proseMirrorBlocks.at(-1) ?? '',
+      'padding',
+      'var(--cinder-space-1) var(--cinder-space-3)',
+    );
+  });
+});

--- a/packages/components/src/components/chat/input/chat-input.svelte
+++ b/packages/components/src/components/chat/input/chat-input.svelte
@@ -793,7 +793,7 @@
   }
 
   .chat-input-editor-container :global(.ProseMirror) {
-    padding: var(--cinder-space-1) 0;
+    padding: var(--cinder-space-1) var(--cinder-space-3);
     min-height: 2.5rem;
   }
 


### PR DESCRIPTION
## Summary

- Add tokenized horizontal padding to the Chat input ProseMirror surface.
- Add a focused source-level layout contract test for the embedded ChatInput editor padding.

Closes #598.

## Validation

- `bun run --filter=@lostgradient/cinder test -- ./src/components/chat/input/chat-input-layout.test.ts`
- `bun run --filter=@lostgradient/cinder components:check`
- `bun run --filter=@lostgradient/cinder lint` (passes with existing warnings in experimental wrapper components)
- `bunx prettier --check packages/components/src/components/chat/input/chat-input.svelte packages/components/src/components/chat/input/chat-input-layout.test.ts`
- commit hook: lint-staged, `@lostgradient/cinder typecheck`, `@lostgradient/cinder test`
- pre-push hook: scoped validation for `@lostgradient/cinder` and `@cinder/playground`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped CSS and a regression test only; no logic, auth, or data-path changes.
> 
> **Overview**
> Fixes the chat composer so typed text is inset horizontally inside the embedded ProseMirror surface.
> 
> **`chat-input.svelte`** changes the `.ProseMirror` rule from vertical-only padding (`var(--cinder-space-1) 0`) to **`var(--cinder-space-1) var(--cinder-space-3)`**, using design tokens for left/right inset.
> 
> **`chat-input-layout.test.ts`** is new: it reads the Svelte source, parses the `.chat-input-editor-container :global(.ProseMirror)` block, and asserts that `padding` matches the expected token pair—same style of layout contract test used elsewhere in the package (e.g. markdown editor toolbar layout).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 31d52ba6b5de9340d11e2a5041da35f2d5312c48. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->