### PR TITLE
Add Steps browser export regression

### DIFF
--- a/packages/components/src/components/steps/steps.test.ts
+++ b/packages/components/src/components/steps/steps.test.ts
@@ -7,6 +7,7 @@ setupHappyDom();
 
 const { render } = await import('@testing-library/svelte');
 const { default: Steps } = await import('./steps.svelte');
+const { default: ExportedSteps } = await import('@lostgradient/cinder/steps');
 
 // Read once at module load — `describe` callbacks are synchronous, so the
 // CSS-contract tests below reference this constant instead of awaiting inside them.
@@ -20,6 +21,32 @@ const defaultSteps = [
 ];
 
 describe('Steps', () => {
+  test('browser/Svelte export renders completed, current, and upcoming items without SVG initialization errors', () => {
+    const { container } = render(ExportedSteps, {
+      steps: [
+        { id: 'completed', label: 'Read the brief' },
+        { id: 'current', label: 'Configure the project' },
+        { id: 'upcoming', label: 'Invite teammates' },
+      ],
+      currentStep: 1,
+      label: 'Setup progress',
+    });
+
+    const items = Array.from(container.querySelectorAll('.cinder-steps__item'));
+    expect(items.length).toBe(3);
+    expect(items.map((item) => item.getAttribute('data-cinder-state'))).toEqual([
+      'complete',
+      'current',
+      'upcoming',
+    ]);
+    expect(items[0]?.querySelector('svg.cinder-steps__check')).not.toBeNull();
+    expect(items[1]?.querySelector('.cinder-steps__index')?.textContent).toBe('2');
+    expect(items[2]?.querySelector('.cinder-steps__index')?.textContent).toBe('3');
+    expect(container.querySelector('[aria-current="step"]')?.textContent).toContain(
+      'Configure the project',
+    );
+  });
+
   test('renders the supplied step labels and descriptions', () => {
     const { container } = render(Steps, { steps: defaultSteps, currentStep: 1 });
     for (const step of defaultSteps) {


### PR DESCRIPTION
## Summary

- Add a browser/Svelte-condition regression test for the public `@lostgradient/cinder/steps` export.
- Render completed, current, and upcoming `Steps` items in one mount and assert the completed SVG marker initializes safely.
- Leave the component implementation unchanged because the new regression passes without exposing an initialization error.

Closes #602.

## Validation

- `bun run --filter=@lostgradient/cinder test -- ./src/components/steps/steps.test.ts`
- `bun run --filter=@lostgradient/cinder validate:consumer`
- normal commit and push hooks

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change with no runtime or API modifications.
> 
> **Overview**
> Adds a **regression test** in `steps.test.ts` that mounts **`Steps` via the public `@lostgradient/cinder/steps` export** (not only the local `./steps.svelte` import).
> 
> The new case renders three steps (complete, current, upcoming) in one mount and asserts **`data-cinder-state`**, the completed-step **SVG check**, step **indices**, and **`aria-current="step"`**—so consumer-style imports stay safe and completed-marker SVG initialization does not throw.
> 
> **No production or component code changes** in this PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7b813a3da47905c501b4237dfa4a37c56a1c0762. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->