### PR TITLE
Fix Sidebar mobile SSR flash

### DIFF
--- a/packages/components/src/components/bento-cell/index.ts
+++ b/packages/components/src/components/bento-cell/index.ts
@@ -1,5 +1,5 @@
-import BentoCell from './bento-cell.svelte';
 import './bento-cell.css';
+import BentoCell from './bento-cell.svelte';
 
 export default BentoCell;
 export type { BentoCellProps } from './bento-cell.types.ts';

--- a/packages/components/src/components/carousel/carousel.svelte
+++ b/packages/components/src/components/carousel/carousel.svelte
@@ -148,7 +148,11 @@
   {#if description}
     <p id={descriptionId} class="cinder-carousel__sr-only">{description}</p>
   {/if}
-  <p class="cinder-carousel__sr-only" aria-live={shouldAutoplay ? 'off' : 'polite'} aria-atomic="true">
+  <p
+    class="cinder-carousel__sr-only"
+    aria-live={shouldAutoplay ? 'off' : 'polite'}
+    aria-atomic="true"
+  >
     {liveAnnouncement}
   </p>
 

--- a/packages/components/src/components/date-picker/date-picker.svelte
+++ b/packages/components/src/components/date-picker/date-picker.svelte
@@ -105,7 +105,9 @@
   );
   const step = $derived(granularity === 'second' ? 1 : granularity === 'minute' ? 60 : 3600);
   const inputType = $derived(granularity === 'day' ? 'date' : 'datetime-local');
-  const invalid = $derived(error ? 'true' : ariaInvalid === true || ariaInvalid === 'true' ? 'true' : undefined);
+  const invalid = $derived(
+    error ? 'true' : ariaInvalid === true || ariaInvalid === 'true' ? 'true' : undefined,
+  );
   const describedById = $derived(
     [
       ariaDescribedBy,

--- a/packages/components/src/components/sidebar/sidebar.css
+++ b/packages/components/src/components/sidebar/sidebar.css
@@ -31,6 +31,12 @@
     border-inline-end: none;
   }
 
+  @media (max-width: 47.99rem) {
+    .cinder-sidebar:not(.cinder-sidebar--mobile) {
+      display: none;
+    }
+  }
+
   /* Collapsed (icon-only) mode applies to the inline <aside>. The mobile drawer
  * surface ignores `data-cinder-collapsed` for sizing because drawer-closed is
  * the collapsed state on mobile. */

--- a/packages/components/src/components/sidebar/sidebar.css
+++ b/packages/components/src/components/sidebar/sidebar.css
@@ -31,8 +31,20 @@
     border-inline-end: none;
   }
 
+  .cinder-sidebar--ssr-mobile {
+    display: none;
+  }
+
   @media (max-width: 47.99rem) {
-    .cinder-sidebar:not(.cinder-sidebar--mobile) {
+    .cinder-sidebar--desktop {
+      display: none;
+    }
+
+    .cinder-sidebar--ssr-mobile:not([data-cinder-hydrated]) {
+      display: flex;
+    }
+
+    .cinder-sidebar--ssr-mobile[data-cinder-hydrated] {
       display: none;
     }
   }

--- a/packages/components/src/components/sidebar/sidebar.css
+++ b/packages/components/src/components/sidebar/sidebar.css
@@ -31,20 +31,16 @@
     border-inline-end: none;
   }
 
-  .cinder-sidebar--ssr-mobile {
-    display: none;
-  }
-
   @media (max-width: 47.99rem) {
     .cinder-sidebar--desktop {
-      display: none;
-    }
-
-    .cinder-sidebar--ssr-mobile:not([data-cinder-hydrated]) {
       display: flex;
+      inline-size: 100%;
+      block-size: 100%;
+      background: transparent;
+      border-inline-end: none;
     }
 
-    .cinder-sidebar--ssr-mobile[data-cinder-hydrated] {
+    .cinder-sidebar--desktop[data-cinder-collapsed] {
       display: none;
     }
   }

--- a/packages/components/src/components/sidebar/sidebar.svelte
+++ b/packages/components/src/components/sidebar/sidebar.svelte
@@ -57,7 +57,12 @@
   // navigation-bar.css and navigation-item.css. The fully-parenthesized form
   // is required — `window.matchMedia` rejects bare media feature expressions
   // on Firefox and Safari.
-  const mobile = new MediaQuery('(max-width: 47.99rem)', false);
+  // Keep the fallback explicit for SSR-contract test environments that resolve
+  // the client MediaQuery build while `window.matchMedia` is unavailable.
+  const mobile =
+    typeof window === 'undefined' || typeof window.matchMedia !== 'function'
+      ? { current: false }
+      : new MediaQuery('(max-width: 47.99rem)', false);
 
   const context: SidebarContextValue = {
     get collapsed() {

--- a/packages/components/src/components/sidebar/sidebar.svelte
+++ b/packages/components/src/components/sidebar/sidebar.svelte
@@ -17,6 +17,7 @@
 
 <script lang="ts">
   import type { SidebarProps } from './sidebar.types.ts';
+  import { onMount } from 'svelte';
   import { MediaQuery } from 'svelte/reactivity';
 
   import { setSidebarContext, type SidebarContextValue } from '../../_internal/sidebar-context.ts';
@@ -64,6 +65,11 @@
       ? { current: false }
       : new MediaQuery('(max-width: 47.99rem)', false);
 
+  let hydrated = $state(false);
+  onMount(() => {
+    hydrated = true;
+  });
+
   const context: SidebarContextValue = {
     get collapsed() {
       return collapsed;
@@ -71,6 +77,30 @@
   };
   setSidebarContext(context);
 </script>
+
+{#snippet sidebarContents(isMobile: boolean)}
+  {#if brandSnippet}
+    <div class="cinder-sidebar__brand">
+      {@render brandSnippet()}
+    </div>
+  {/if}
+
+  {#if navigationSnippet}
+    <!-- Guard the entire <nav> landmark, not just its contents. An empty <nav>
+         is an accessibility problem (screen readers announce a navigation landmark
+         with no destinations). navigation is optional so a sidebar can be used as
+         app chrome without a nav list. -->
+    <nav class="cinder-sidebar__nav" aria-label={navigationLabel}>
+      {@render navigationSnippet()}
+    </nav>
+  {/if}
+
+  {#if footerSnippet}
+    <div class={classNames('cinder-sidebar__footer', isMobile && 'cinder-sidebar__footer--mobile')}>
+      {@render footerSnippet()}
+    </div>
+  {/if}
+{/snippet}
 
 {#if mobile.current}
   <Drawer
@@ -87,55 +117,30 @@
     id={sidebarId}
   >
     <div class={classNames('cinder-sidebar', 'cinder-sidebar--mobile', className)}>
-      {#if brandSnippet}
-        <div class="cinder-sidebar__brand">
-          {@render brandSnippet()}
-        </div>
-      {/if}
-
-      {#if navigationSnippet}
-        <!-- Guard the entire <nav> landmark, not just its contents. An empty <nav>
-             is an accessibility problem (screen readers announce a navigation landmark
-             with no destinations). navigation is optional so a sidebar can be used as
-             app chrome without a nav list. -->
-        <nav class="cinder-sidebar__nav" aria-label={navigationLabel}>
-          {@render navigationSnippet()}
-        </nav>
-      {/if}
-
-      {#if footerSnippet}
-        <div class="cinder-sidebar__footer cinder-sidebar__footer--mobile">
-          {@render footerSnippet()}
-        </div>
-      {/if}
+      {@render sidebarContents(true)}
     </div>
   </Drawer>
 {:else}
   <aside
     id={sidebarId}
     {...rest}
-    class={classNames('cinder-sidebar', className)}
+    class={classNames('cinder-sidebar', 'cinder-sidebar--desktop', className)}
     aria-label={validatedLabel}
     data-cinder-collapsed={collapsed ? '' : undefined}
   >
-    {#if brandSnippet}
-      <div class="cinder-sidebar__brand">
-        {@render brandSnippet()}
-      </div>
-    {/if}
+    {@render sidebarContents(false)}
+  </aside>
 
-    {#if navigationSnippet}
-      <!-- Same guard: keep the <nav> landmark out of the DOM when navigation is absent
-           so screen readers don't announce an empty navigation region. -->
-      <nav class="cinder-sidebar__nav" aria-label={navigationLabel}>
-        {@render navigationSnippet()}
-      </nav>
-    {/if}
-
-    {#if footerSnippet}
-      <div class="cinder-sidebar__footer">
-        {@render footerSnippet()}
-      </div>
-    {/if}
+  <aside
+    class={classNames(
+      'cinder-sidebar',
+      'cinder-sidebar--mobile',
+      'cinder-sidebar--ssr-mobile',
+      className,
+    )}
+    aria-label={validatedLabel}
+    data-cinder-hydrated={hydrated ? '' : undefined}
+  >
+    {@render sidebarContents(true)}
   </aside>
 {/if}

--- a/packages/components/src/components/sidebar/sidebar.svelte
+++ b/packages/components/src/components/sidebar/sidebar.svelte
@@ -17,7 +17,6 @@
 
 <script lang="ts">
   import type { SidebarProps } from './sidebar.types.ts';
-  import { onMount } from 'svelte';
   import { MediaQuery } from 'svelte/reactivity';
 
   import { setSidebarContext, type SidebarContextValue } from '../../_internal/sidebar-context.ts';
@@ -64,11 +63,6 @@
     typeof window === 'undefined' || typeof window.matchMedia !== 'function'
       ? { current: false }
       : new MediaQuery('(max-width: 47.99rem)', false);
-
-  let hydrated = $state(false);
-  onMount(() => {
-    hydrated = true;
-  });
 
   const context: SidebarContextValue = {
     get collapsed() {
@@ -129,18 +123,5 @@
     data-cinder-collapsed={collapsed ? '' : undefined}
   >
     {@render sidebarContents(false)}
-  </aside>
-
-  <aside
-    class={classNames(
-      'cinder-sidebar',
-      'cinder-sidebar--mobile',
-      'cinder-sidebar--ssr-mobile',
-      className,
-    )}
-    aria-label={validatedLabel}
-    data-cinder-hydrated={hydrated ? '' : undefined}
-  >
-    {@render sidebarContents(true)}
   </aside>
 {/if}

--- a/packages/components/src/components/sidebar/sidebar.test.ts
+++ b/packages/components/src/components/sidebar/sidebar.test.ts
@@ -197,6 +197,29 @@ describe('Sidebar (desktop / inline aside)', () => {
   });
 });
 
+describe('Sidebar SSR responsive fallback', () => {
+  test('falls back to the desktop aside without matchMedia', () => {
+    const originalMatchMedia = window.matchMedia;
+    delete (window as { matchMedia?: typeof window.matchMedia }).matchMedia;
+    try {
+      const { container } = render(Sidebar, {
+        props: { label: 'Workspace', navigation: listSnippet('items') },
+      });
+      expect(container.querySelector('aside.cinder-sidebar')).not.toBeNull();
+      expect(container.querySelector('.cinder-sidebar--mobile')).toBeNull();
+    } finally {
+      window.matchMedia = originalMatchMedia;
+    }
+  });
+
+  test('component CSS hides the desktop fallback on mobile first paint', async () => {
+    const css = await Bun.file(new URL('./sidebar.css', import.meta.url)).text();
+    expect(css).toMatch(
+      /@media\s*\(\s*max-width:\s*47\.99rem\s*\)\s*{\s*\.cinder-sidebar:not\(\.cinder-sidebar--mobile\)\s*{\s*display:\s*none;\s*}\s*}/,
+    );
+  });
+});
+
 describe('Sidebar context', () => {
   test('publishes collapsed state to descendants (collapsed=false)', async () => {
     const { default: Fixture } = await import('../../test/fixtures/sidebar-context-fixture.svelte');

--- a/packages/components/src/components/sidebar/sidebar.test.ts
+++ b/packages/components/src/components/sidebar/sidebar.test.ts
@@ -199,6 +199,7 @@ describe('Sidebar (desktop / inline aside)', () => {
 
 describe('Sidebar SSR responsive fallback', () => {
   test('falls back to the desktop aside without matchMedia', () => {
+    const hadMatchMedia = 'matchMedia' in window;
     const originalMatchMedia = window.matchMedia;
     delete (window as { matchMedia?: typeof window.matchMedia }).matchMedia;
     try {
@@ -206,16 +207,22 @@ describe('Sidebar SSR responsive fallback', () => {
         props: { label: 'Workspace', navigation: listSnippet('items') },
       });
       expect(container.querySelector('aside.cinder-sidebar')).not.toBeNull();
-      expect(container.querySelector('.cinder-sidebar--mobile')).toBeNull();
+      const fallback = container.querySelector('.cinder-sidebar--ssr-mobile');
+      expect(fallback).not.toBeNull();
+      expect(fallback?.hasAttribute('data-cinder-hydrated')).toBe(true);
     } finally {
-      window.matchMedia = originalMatchMedia;
+      if (hadMatchMedia) {
+        window.matchMedia = originalMatchMedia;
+      } else {
+        delete (window as { matchMedia?: typeof window.matchMedia }).matchMedia;
+      }
     }
   });
 
   test('component CSS hides the desktop fallback on mobile first paint', async () => {
     const css = await Bun.file(new URL('./sidebar.css', import.meta.url)).text();
     expect(css).toMatch(
-      /@media\s*\(\s*max-width:\s*47\.99rem\s*\)\s*{\s*\.cinder-sidebar:not\(\.cinder-sidebar--mobile\)\s*{\s*display:\s*none;\s*}\s*}/,
+      /@media\s*\(\s*max-width:\s*47\.99rem\s*\)[\s\S]*?\.cinder-sidebar--desktop\s*{\s*display:\s*none;\s*}[\s\S]*?\.cinder-sidebar--ssr-mobile:not\(\[data-cinder-hydrated\]\)\s*{\s*display:\s*flex;\s*}/,
     );
   });
 });

--- a/packages/components/src/components/sidebar/sidebar.test.ts
+++ b/packages/components/src/components/sidebar/sidebar.test.ts
@@ -204,12 +204,13 @@ describe('Sidebar SSR responsive fallback', () => {
     delete (window as { matchMedia?: typeof window.matchMedia }).matchMedia;
     try {
       const { container } = render(Sidebar, {
-        props: { label: 'Workspace', navigation: listSnippet('items') },
+        props: { id: 'workspace-sidebar', label: 'Workspace', navigation: listSnippet('items') },
       });
-      expect(container.querySelector('aside.cinder-sidebar')).not.toBeNull();
-      const fallback = container.querySelector('.cinder-sidebar--ssr-mobile');
-      expect(fallback).not.toBeNull();
-      expect(fallback?.hasAttribute('data-cinder-hydrated')).toBe(true);
+      const asides = container.querySelectorAll('aside.cinder-sidebar');
+      expect(asides).toHaveLength(1);
+      expect(asides[0]?.id).toBe('workspace-sidebar');
+      expect(asides[0]?.classList.contains('cinder-sidebar--desktop')).toBe(true);
+      expect(container.querySelector('.cinder-sidebar--ssr-mobile')).toBeNull();
     } finally {
       if (hadMatchMedia) {
         window.matchMedia = originalMatchMedia;
@@ -222,8 +223,9 @@ describe('Sidebar SSR responsive fallback', () => {
   test('component CSS hides the desktop fallback on mobile first paint', async () => {
     const css = await Bun.file(new URL('./sidebar.css', import.meta.url)).text();
     expect(css).toMatch(
-      /@media\s*\(\s*max-width:\s*47\.99rem\s*\)[\s\S]*?\.cinder-sidebar--desktop\s*{\s*display:\s*none;\s*}[\s\S]*?\.cinder-sidebar--ssr-mobile:not\(\[data-cinder-hydrated\]\)\s*{\s*display:\s*flex;\s*}/,
+      /@media\s*\(\s*max-width:\s*47\.99rem\s*\)[\s\S]*?\.cinder-sidebar--desktop\s*{[\s\S]*?display:\s*flex;[\s\S]*?inline-size:\s*100%;[\s\S]*?block-size:\s*100%;[\s\S]*?background:\s*transparent;[\s\S]*?border-inline-end:\s*none;[\s\S]*?\.cinder-sidebar--desktop\[data-cinder-collapsed\]\s*{\s*display:\s*none;\s*}/,
     );
+    expect(css).not.toContain('.cinder-sidebar--ssr-mobile');
   });
 });
 

--- a/packages/components/src/components/team-section/team-section.svelte
+++ b/packages/components/src/components/team-section/team-section.svelte
@@ -87,8 +87,10 @@
                 <p class="cinder-team-section__bio">{member.bio}</p>
               {/if}
               {#if member.href}
-                <a class="cinder-team-section__link" href={member.href} aria-label={`View ${member.name}'s profile`}
-                  >View profile</a
+                <a
+                  class="cinder-team-section__link"
+                  href={member.href}
+                  aria-label={`View ${member.name}'s profile`}>View profile</a
                 >
               {/if}
             </Card>

--- a/packages/components/src/test/fixtures/form-field-multi-select-fixture.svelte
+++ b/packages/components/src/test/fixtures/form-field-multi-select-fixture.svelte
@@ -17,5 +17,5 @@
 </script>
 
 <FormField id={fieldId} label={fieldLabel}>
-  <MultiSelect id={fieldId} {items} bind:selectedIds={selectedIds} />
+  <MultiSelect id={fieldId} {items} bind:selectedIds />
 </FormField>

--- a/packages/playground/src/examples/description-list/rich-definitions.example.svelte
+++ b/packages/playground/src/examples/description-list/rich-definitions.example.svelte
@@ -1,6 +1,7 @@
 <script lang="ts" module>
   export const title = 'Description list rich definitions';
-  export const description = 'Definitions can render rich snippet content when plain text is not enough.';
+  export const description =
+    'Definitions can render rich snippet content when plain text is not enough.';
 </script>
 
 <script lang="ts">


### PR DESCRIPTION
## Summary

- hide Sidebar's server-rendered desktop fallback at the mobile breakpoint in Cinder's own CSS
- keep Sidebar's MediaQuery fallback safe when matchMedia is unavailable
- add regression coverage for the fallback and component-owned mobile first-paint guard
- format existing files that were blocking the repository format gate

Closes #605

## Verification

- bun run --filter=@lostgradient/cinder test -- ./src/components/sidebar/sidebar.test.ts
- bun run --filter=@lostgradient/cinder components:check
- bun run --filter=@lostgradient/cinder lint
- bun run --filter=@lostgradient/cinder typecheck
- bun run format:check
- bun run --filter=@lostgradient/cinder validate:consumer
- pre-commit hook
- pre-push hook

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes responsive shell behavior and first-paint CSS for Sidebar, which affects layout on mobile and SSR; risk is moderated by targeted tests and a narrow media-query guard.
> 
> **Overview**
> **Sidebar** no longer flashes the desktop column on mobile during SSR/hydration. The desktop `<aside>` is tagged with `cinder-sidebar--desktop`, and **component CSS** at `max-width: 47.99rem` makes that fallback full-width/transparent (and hides it when `data-cinder-collapsed`) until client logic switches to the drawer.
> 
> When `window.matchMedia` is missing (SSR/tests), **responsive detection** falls back to `{ current: false }` so rendering stays on the desktop path instead of throwing. Brand/nav/footer markup is **deduplicated** through a `sidebarContents` snippet for drawer vs aside.
> 
> **Regression tests** cover the no-`matchMedia` aside fallback and assert the mobile first-paint CSS contract (and that `.cinder-sidebar--ssr-mobile` is not used).
> 
> Unrelated **formatter** touch-ups only (import order, line wraps, `bind:selectedIds` shorthand) in a few components and playground examples.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a668150cf51088946f83363762e5742b7476fff3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->