### PR TITLE
Namespace Cinder icon utility classes

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -16,6 +16,8 @@
 
 ### Patch Changes
 
+- [#641](https://github.com/stevekinney/cinder/pull/641) [`ec89bc1`](https://github.com/stevekinney/cinder/commit/ec89bc11) Thanks [@stevekinney](https://github.com/stevekinney)! - **Breaking CSS utility rename:** the icon sizing helpers exported from `@lostgradient/cinder/styles` and `@lostgradient/cinder/styles/utilities` are now namespaced as `.cinder-icon-xs`, `.cinder-icon-sm`, `.cinder-icon-md`, and `.cinder-icon-lg`. Cinder components use the namespaced utilities internally so application-level `.icon-*` classes cannot change component icon sizing. Consumer markup that used `.icon-xs`, `.icon-sm`, `.icon-md`, or `.icon-lg` should rename those classes to the matching `.cinder-icon-*` class.
+
 - [#559](https://github.com/stevekinney/cinder/pull/559) [`9628078`](https://github.com/stevekinney/cinder/commit/96280780a150a69f74a3abfa60d9006fd2be3c6c) Thanks [@stevekinney](https://github.com/stevekinney)! - Align Chat's conversation model with the published `conversationalist` package instead of maintaining bespoke mirrored transcript types.
 
 - [#577](https://github.com/stevekinney/cinder/pull/577) [`f4a9386`](https://github.com/stevekinney/cinder/commit/f4a938605a20ff0fdfe401f43db32248930af0e5) Thanks [@stevekinney](https://github.com/stevekinney)! - Preserve server component identity in the published SSR bundle so SvelteKit development SSR can render Cinder snippet content without crashing. Fixes [#572](https://github.com/stevekinney/cinder/issues/572) and [#573](https://github.com/stevekinney/cinder/issues/573).

--- a/packages/components/src/components/badge/badge.svelte
+++ b/packages/components/src/components/badge/badge.svelte
@@ -93,7 +93,7 @@
   {#if subscriptionStateConfiguration}
     {#if resolvedSubscriptionIconPaths}
       <svg
-        class="icon-sm"
+        class="cinder-icon-sm"
         aria-hidden="true"
         viewBox="0 0 24 24"
         fill="none"

--- a/packages/components/src/components/chat/artifact/artifact-panel.svelte
+++ b/packages/components/src/components/chat/artifact/artifact-panel.svelte
@@ -39,7 +39,7 @@
       aria-label="Close artifact panel"
       {@attach focusOnMount}
     >
-      <X class="icon-sm" />
+      <X class="cinder-icon-sm" />
     </button>
   </div>
 

--- a/packages/components/src/components/chat/container/chat-jump-controls.svelte
+++ b/packages/components/src/components/chat/container/chat-jump-controls.svelte
@@ -49,7 +49,7 @@
       ? `Jump to ${unreadCount} new message${unreadCount !== 1 ? 's' : ''}`
       : 'Jump to latest'}
   >
-    <ChevronDown class="icon-sm" />
+    <ChevronDown class="cinder-icon-sm" />
     {#if unreadCount > 0}
       <span class="chat-jump-badge" data-large={hasLargeCount || undefined}>
         {displayUnreadCount}
@@ -66,7 +66,7 @@
     onclick={handleJump}
     aria-label="Jump to {displayUnreadCount} new message{unreadCount !== 1 ? 's' : ''}"
   >
-    <ChevronDown class="icon-xs" />
+    <ChevronDown class="cinder-icon-xs" />
     <span aria-hidden="true">{displayUnreadCount} new message{unreadCount !== 1 ? 's' : ''}</span>
   </button>
 {/if}

--- a/packages/components/src/components/chat/container/chat-search-bar.svelte
+++ b/packages/components/src/components/chat/container/chat-search-bar.svelte
@@ -100,7 +100,7 @@
 
 <div class="chat-search-bar" role="search" aria-label="Search messages">
   <span class="chat-search-icon" aria-hidden="true">
-    <Search class="icon-sm" />
+    <Search class="cinder-icon-sm" />
   </span>
 
   <input
@@ -136,7 +136,7 @@
       aria-label="Previous match"
       title="Previous match (Shift+Enter)"
     >
-      <ChevronUp class="icon-sm" />
+      <ChevronUp class="cinder-icon-sm" />
     </button>
 
     <button
@@ -147,7 +147,7 @@
       aria-label="Next match"
       title="Next match (Enter)"
     >
-      <ChevronDown class="icon-sm" />
+      <ChevronDown class="cinder-icon-sm" />
     </button>
   </div>
 
@@ -158,7 +158,7 @@
     aria-label="Close search"
     title="Close search (Escape)"
   >
-    <X class="icon-sm" />
+    <X class="cinder-icon-sm" />
   </button>
 </div>
 

--- a/packages/components/src/components/chat/export/conversation-export-actions.svelte
+++ b/packages/components/src/components/chat/export/conversation-export-actions.svelte
@@ -119,15 +119,15 @@
 
   <Dropdown {id}>
     <DropdownTrigger class="export-trigger" aria-label="Export conversation" showCaret={false}>
-      <Copy class="icon-sm" />
+      <Copy class="cinder-icon-sm" />
     </DropdownTrigger>
     <DropdownMenu>
       <!-- Markdown export -->
       <DropdownItem onclick={handleExportMarkdown}>
         {#if copyState.copiedKey === 'markdown'}
-          <Check class="icon-sm export-icon-success" />
+          <Check class="cinder-icon-sm export-icon-success" />
         {:else}
-          <FileText class="icon-sm" />
+          <FileText class="cinder-icon-sm" />
         {/if}
         <span>Copy as {formatLabels.markdown}</span>
         {#if copyState.copiedKey === 'markdown'}
@@ -138,9 +138,9 @@
       <!-- JSON export -->
       <DropdownItem onclick={handleExportJSON}>
         {#if copyState.copiedKey === 'json'}
-          <Check class="icon-sm export-icon-success" />
+          <Check class="cinder-icon-sm export-icon-success" />
         {:else}
-          <FileCode class="icon-sm" />
+          <FileCode class="cinder-icon-sm" />
         {/if}
         <span>Copy as {formatLabels.json}</span>
         {#if copyState.copiedKey === 'json'}

--- a/packages/components/src/components/chat/input/chat-attachment-preview.svelte
+++ b/packages/components/src/components/chat/input/chat-attachment-preview.svelte
@@ -49,9 +49,9 @@
     <div class="chat-attachment-preview-file">
       <div class="chat-attachment-preview-icon">
         {#if attachment.kind === 'code'}
-          <FileCode class="icon-sm" />
+          <FileCode class="cinder-icon-sm" />
         {:else}
-          <FileText class="icon-sm" />
+          <FileText class="cinder-icon-sm" />
         {/if}
       </div>
       <div class="chat-attachment-preview-info">

--- a/packages/components/src/components/chat/input/chat-input.svelte
+++ b/packages/components/src/components/chat/input/chat-input.svelte
@@ -486,7 +486,7 @@
             onclick={() => removeAttachment(attachment.id)}
             aria-label={`Remove ${attachment.file.name}`}
           >
-            <X class="icon-xs" />
+            <X class="cinder-icon-xs" />
           </button>
         </div>
       {/each}
@@ -532,7 +532,7 @@
           disabled={disabled || sending}
           aria-label="Attach file"
         >
-          <Paperclip class="icon-sm" />
+          <Paperclip class="cinder-icon-sm" />
         </Button>
       {/if}
 
@@ -566,7 +566,7 @@
           aria-label="Stop generating"
           aria-describedby={shortcutDescriptionId}
         >
-          <Square class="icon-sm" />
+          <Square class="cinder-icon-sm" />
         </button>
       {:else}
         <!-- Send button: shows spinner when sending (without onstop), otherwise arrow -->
@@ -600,7 +600,7 @@
               ></path>
             </svg>
           {:else}
-            <ArrowUp class="icon-sm" />
+            <ArrowUp class="cinder-icon-sm" />
           {/if}
         </button>
       {/if}

--- a/packages/components/src/components/chat/message/chat-message.svelte
+++ b/packages/components/src/components/chat/message/chat-message.svelte
@@ -341,7 +341,7 @@
       <div class="chat-message-failed-actions">
         <span class="chat-message-failed-label" role="alert">Failed to send</span>
         <button type="button" class="chat-message-retry" onclick={() => onretry(message.id)}>
-          <RotateCcw class="icon-xs" />
+          <RotateCcw class="cinder-icon-xs" />
           Retry
         </button>
       </div>
@@ -371,7 +371,7 @@
             onclick={startEditing}
             aria-label="Edit message"
           >
-            <Pencil class="icon-xs" />
+            <Pencil class="cinder-icon-xs" />
           </button>
         {/if}
       </div>
@@ -800,7 +800,7 @@
   }
 
   /* Shared base for the built-in copy and edit action buttons — small
-   * icon-only affordances. The icon size comes from the `icon-xs` class on the
+   * icon-only affordances. The icon size comes from the `cinder-icon-xs` class on the
    * SVG (defined in styles/utilities.css). A transparent border reserves layout
    * space so the touch-context border swap below does not shift the icon.
    *
@@ -859,7 +859,7 @@
     color: var(--cinder-success);
   }
 
-  /* CopyButton renders icon-sm (16px) icons by default. Override to icon-xs
+  /* CopyButton renders cinder-icon-sm (16px) icons by default. Override to cinder-icon-xs
    * (14px) to match the sibling edit/retry action buttons in the chat footer. */
   :global(.chat-message-copy svg) {
     width: 0.875rem;

--- a/packages/components/src/components/chat/message/tool-call-group.svelte
+++ b/packages/components/src/components/chat/message/tool-call-group.svelte
@@ -79,13 +79,13 @@
   >
     <span class="tool-call-icon" aria-hidden="true">
       {#if isError}
-        <X class="icon-xs" />
+        <X class="cinder-icon-xs" />
       {:else if isSuccess}
-        <Check class="icon-xs" />
+        <Check class="cinder-icon-xs" />
       {:else if isActionRequired}
-        <CircleAlert class="icon-xs" />
+        <CircleAlert class="cinder-icon-xs" />
       {:else}
-        <MoreHorizontal class="icon-xs" />
+        <MoreHorizontal class="cinder-icon-xs" />
       {/if}
     </span>
     <span class="tool-call-name">{pair.call.name}</span>
@@ -101,7 +101,7 @@
       {/if}
     </span>
     <span class="tool-call-chevron" aria-hidden="true" data-expanded={expanded}>
-      <ChevronDown class="icon-xs" />
+      <ChevronDown class="cinder-icon-xs" />
     </span>
   </button>
 

--- a/packages/components/src/components/copy-button/copy-button.svelte
+++ b/packages/components/src/components/copy-button/copy-button.svelte
@@ -87,13 +87,13 @@
   {#if copied && confirmation}
     {@render confirmation()}
   {:else if copied && iconOnly}
-    <Check class="icon-sm" aria-hidden="true" />
+    <Check class="cinder-icon-sm" aria-hidden="true" />
   {:else if copied}
     Copied
   {:else if children}
     {@render children()}
   {:else if iconOnly}
-    <Copy class="icon-sm" aria-hidden="true" />
+    <Copy class="cinder-icon-sm" aria-hidden="true" />
   {:else}
     Copy
   {/if}

--- a/packages/components/src/components/diff-viewer/diff-summary-bar.svelte
+++ b/packages/components/src/components/diff-viewer/diff-summary-bar.svelte
@@ -50,7 +50,7 @@
 
 <div class={classNames('diff-summary-bar', className)} {...rest}>
   <div class="summary-content">
-    <FileText class="icon-sm text-muted" aria-hidden="true" />
+    <FileText class="cinder-icon-sm text-muted" aria-hidden="true" />
     <Badge variant="neutral">{changeCount} {changeLabel}</Badge>
     <span class="stats-text">
       {#if stats.added > 0}
@@ -67,9 +67,9 @@
   <Button variant="ghost" size="sm" onclick={() => (expanded = !expanded)}>
     {expanded ? 'Hide' : 'Review'}
     {#if expanded}
-      <ChevronUp class="icon-sm" />
+      <ChevronUp class="cinder-icon-sm" />
     {:else}
-      <ChevronDown class="icon-sm" />
+      <ChevronDown class="cinder-icon-sm" />
     {/if}
   </Button>
 </div>

--- a/packages/components/src/components/diff-viewer/diff-toolbar.svelte
+++ b/packages/components/src/components/diff-viewer/diff-toolbar.svelte
@@ -118,7 +118,7 @@
     <!-- Revert All button -->
     {#if hasChanges && !readonly && onrevertall}
       <Button variant="secondary" size="xs" onclick={onrevertall}>
-        <RotateCcw class="icon-sm" />
+        <RotateCcw class="cinder-icon-sm" />
         Revert All
       </Button>
     {/if}
@@ -126,7 +126,7 @@
     <!-- Size-based gating controls (DEP-47) -->
     {#if tier === 'manual' && ontriggercompute}
       <Button variant="secondary" size="xs" onclick={ontriggercompute} disabled={isComputing}>
-        <RefreshCw class="icon-sm" />
+        <RefreshCw class="cinder-icon-sm" />
         Compute Diff
       </Button>
     {/if}
@@ -135,13 +135,13 @@
       {#if changeCount > 0}
         <div class="navigation">
           <Button variant="ghost" size="xs" onclick={onjumpprevious} aria-label="Previous change">
-            <ChevronLeft class="icon-sm" />
+            <ChevronLeft class="cinder-icon-sm" />
           </Button>
           <span class="change-counter">
             {currentChangeIndex >= 0 ? currentChangeIndex + 1 : '-'} / {changeCount}
           </span>
           <Button variant="ghost" size="xs" onclick={onjumpnext} aria-label="Next change">
-            <ChevronRight class="icon-sm" />
+            <ChevronRight class="cinder-icon-sm" />
           </Button>
         </div>
         <div class="shortcuts">

--- a/packages/components/src/components/diff-viewer/diff-viewer.svelte
+++ b/packages/components/src/components/diff-viewer/diff-viewer.svelte
@@ -399,7 +399,7 @@
             onclick={() => handleRevertHunk(hunkAtLine)}
             aria-label="Revert this change"
           >
-            <RotateCcw class="icon-xs" />
+            <RotateCcw class="cinder-icon-xs" />
             Revert
           </Button>
         </div>

--- a/packages/components/src/components/diff-viewer/front-matter-header.svelte
+++ b/packages/components/src/components/diff-viewer/front-matter-header.svelte
@@ -80,12 +80,12 @@
 >
   <span class="front-matter-icon">
     {#if expanded}
-      <ChevronDown class="icon-sm" />
+      <ChevronDown class="cinder-icon-sm" />
     {:else}
-      <ChevronRight class="icon-sm" />
+      <ChevronRight class="cinder-icon-sm" />
     {/if}
   </span>
-  <FileText class="icon-sm" />
+  <FileText class="cinder-icon-sm" />
   <span class="front-matter-label">{label}</span>
   {#if showBadge}
     <Badge variant={badgeVariant} size={badgeSize}>{badgeLabel ?? ''}</Badge>

--- a/packages/components/src/components/markdown-editor/editor-toolbar/link-popover.svelte
+++ b/packages/components/src/components/markdown-editor/editor-toolbar/link-popover.svelte
@@ -196,11 +196,11 @@
 >
   <header class="link-popover-header">
     <h2 id={`${id}-title`} class="link-popover-title">
-      <Link class="icon-sm" />
+      <Link class="cinder-icon-sm" />
       {mode === 'insert' ? 'Insert Link' : 'Edit Link'}
     </h2>
     <button type="button" class="link-popover-close" onclick={onclose} aria-label="Close">
-      <X class="icon-sm" />
+      <X class="cinder-icon-sm" />
     </button>
   </header>
 
@@ -230,7 +230,7 @@
     <div class="link-popover-actions">
       {#if mode === 'edit'}
         <Button variant="ghost" size="sm" onclick={handleRemove}>
-          <Unlink class="icon-sm" />
+          <Unlink class="cinder-icon-sm" />
           Remove
         </Button>
       {/if}

--- a/packages/components/src/components/markdown-editor/editor-toolbar/toolbar-button.svelte
+++ b/packages/components/src/components/markdown-editor/editor-toolbar/toolbar-button.svelte
@@ -48,7 +48,7 @@
     {onclick}
     {...rest}
   >
-    <Icon class="icon-sm" />
+    <Icon class="cinder-icon-sm" />
   </button>
 </Tooltip>
 

--- a/packages/components/src/components/markdown-editor/editor-toolbar/toolbar-dropdown.svelte
+++ b/packages/components/src/components/markdown-editor/editor-toolbar/toolbar-dropdown.svelte
@@ -56,7 +56,7 @@
     aria-label={`Block type: ${currentOption?.label ?? 'Paragraph'}`}
   >
     {#if currentOption}
-      <currentOption.icon class="icon-sm" />
+      <currentOption.icon class="cinder-icon-sm" />
     {/if}
     <span class="toolbar-dropdown-label">{currentOption?.label ?? 'Paragraph'}</span>
   </DropdownTrigger>
@@ -69,10 +69,10 @@
         itemRole="menuitemradio"
         checked={isActive}
       >
-        <option.icon class="icon-sm" />
+        <option.icon class="cinder-icon-sm" />
         <span class="dropdown-item-label">{option.label}</span>
         {#if isActive}
-          <Check class="icon-sm dropdown-item-check" />
+          <Check class="cinder-icon-sm dropdown-item-check" />
         {/if}
       </DropdownItem>
     {/each}

--- a/packages/components/src/components/review-editor/comment-list.svelte
+++ b/packages/components/src/components/review-editor/comment-list.svelte
@@ -134,7 +134,7 @@
               aria-label="Edit comment"
               title="Edit comment"
             >
-              <Pencil class="icon-sm" />
+              <Pencil class="cinder-icon-sm" />
             </button>
           {/if}
           {#if canDeleteComment(comment)}
@@ -145,7 +145,7 @@
               aria-label="Delete comment"
               title="Delete comment"
             >
-              <Trash2 class="icon-sm" />
+              <Trash2 class="cinder-icon-sm" />
             </button>
           {/if}
         </div>

--- a/packages/components/src/components/review-editor/comment-sidebar.svelte
+++ b/packages/components/src/components/review-editor/comment-sidebar.svelte
@@ -117,7 +117,7 @@
 
 <aside {id} class={classNames('comment-sidebar', className)} aria-label="Comment threads">
   <div class="sidebar-header">
-    <MessageSquare class="icon-sm" />
+    <MessageSquare class="cinder-icon-sm" />
     <h2 class="sidebar-title">Comments</h2>
     <span class="thread-count">{visibleThreads.length}</span>
 
@@ -134,9 +134,9 @@
           : handleStartDocumentComment}
       >
         {#if composingDocumentComment}
-          <X class="icon-sm" />
+          <X class="cinder-icon-sm" />
         {:else}
-          <Plus class="icon-sm" />
+          <Plus class="cinder-icon-sm" />
         {/if}
       </Button>
     {/if}
@@ -144,11 +144,11 @@
     {#if !readonly && visibleThreads.length > 0}
       <Dropdown id="{id}-actions">
         <DropdownTrigger class="actions-trigger" aria-label="Comment actions" showCaret={false}>
-          <MoreHorizontal class="icon-sm" />
+          <MoreHorizontal class="cinder-icon-sm" />
         </DropdownTrigger>
         <DropdownMenu>
           <DropdownItem variant="danger" onclick={handleClearAllClick}>
-            <Trash2 class="icon-sm" />
+            <Trash2 class="cinder-icon-sm" />
             Clear all comments
           </DropdownItem>
         </DropdownMenu>
@@ -173,7 +173,7 @@
   {#if composingDocumentComment}
     <div class="document-comment-composer">
       <div class="document-comment-header">
-        <FileText class="icon-xs" />
+        <FileText class="cinder-icon-xs" />
         <span>Document comment</span>
       </div>
       <CommentComposer
@@ -203,7 +203,7 @@
           aria-current={activeThreadId === thread.id ? 'true' : undefined}
         >
           <div class="thread-document-label">
-            <FileText class="icon-xs" />
+            <FileText class="cinder-icon-xs" />
             <span>Document comment</span>
           </div>
           <p class="thread-preview">{getPreview(thread)}</p>

--- a/packages/components/src/components/review-editor/export-actions.svelte
+++ b/packages/components/src/components/review-editor/export-actions.svelte
@@ -88,7 +88,7 @@
 
   <Dropdown {id}>
     <DropdownTrigger class="export-trigger" aria-label="Copy to clipboard" showCaret={false}>
-      <Copy class="icon-sm" />
+      <Copy class="cinder-icon-sm" />
       <span class="cinder-sr-only">Copy</span>
     </DropdownTrigger>
     <DropdownMenu>
@@ -96,9 +96,9 @@
       {#if onexportcontent}
         <DropdownItem onclick={() => handleCopy('content')}>
           {#if copyState.copiedKey === 'content'}
-            <Check class="icon-sm export-icon-success" />
+            <Check class="cinder-icon-sm export-icon-success" />
           {:else}
-            <FileText class="icon-sm" />
+            <FileText class="cinder-icon-sm" />
           {/if}
           <span>{formatLabels.content}</span>
           {#if copyState.copiedKey === 'content'}
@@ -110,9 +110,9 @@
       <!-- LLM-optimized summary -->
       <DropdownItem onclick={() => handleCopy('summary')}>
         {#if copyState.copiedKey === 'summary'}
-          <Check class="icon-sm export-icon-success" />
+          <Check class="cinder-icon-sm export-icon-success" />
         {:else}
-          <FileText class="icon-sm" />
+          <FileText class="cinder-icon-sm" />
         {/if}
         <span>{formatLabels.summary}</span>
         {#if copyState.copiedKey === 'summary'}
@@ -123,9 +123,9 @@
       <!-- Git diff -->
       <DropdownItem onclick={() => handleCopy('diff')}>
         {#if copyState.copiedKey === 'diff'}
-          <Check class="icon-sm export-icon-success" />
+          <Check class="cinder-icon-sm export-icon-success" />
         {:else}
-          <GitBranch class="icon-sm" />
+          <GitBranch class="cinder-icon-sm" />
         {/if}
         <span>{formatLabels.diff}</span>
         {#if copyState.copiedKey === 'diff'}
@@ -137,9 +137,9 @@
       {#if onexportcomments}
         <DropdownItem onclick={() => handleCopy('comments')}>
           {#if copyState.copiedKey === 'comments'}
-            <Check class="icon-sm export-icon-success" />
+            <Check class="cinder-icon-sm export-icon-success" />
           {:else}
-            <MessageSquare class="icon-sm" />
+            <MessageSquare class="cinder-icon-sm" />
           {/if}
           <span>{formatLabels.comments}</span>
           {#if copyState.copiedKey === 'comments'}
@@ -151,9 +151,9 @@
       <!-- JSON (full state) -->
       <DropdownItem onclick={() => handleCopy('json')}>
         {#if copyState.copiedKey === 'json'}
-          <Check class="icon-sm export-icon-success" />
+          <Check class="cinder-icon-sm export-icon-success" />
         {:else}
-          <FileCode class="icon-sm" />
+          <FileCode class="cinder-icon-sm" />
         {/if}
         <span>{formatLabels.json}</span>
         {#if copyState.copiedKey === 'json'}

--- a/packages/components/src/components/review-editor/review-editor-controls.svelte
+++ b/packages/components/src/components/review-editor/review-editor-controls.svelte
@@ -121,16 +121,16 @@
       onchange={handleViewChange}
     >
       <Segment value="editor" controls={viewPanelIds?.editor}>
-        {#snippet leading()}<Pencil class="icon-xs" />{/snippet}
+        {#snippet leading()}<Pencil class="cinder-icon-xs" />{/snippet}
         Editor
       </Segment>
       {#if showDiffTabs}
         <Segment value="diff" controls={viewPanelIds?.diff}>
-          {#snippet leading()}<GitBranch class="icon-xs" />{/snippet}
+          {#snippet leading()}<GitBranch class="cinder-icon-xs" />{/snippet}
           Diff
         </Segment>
         <Segment value="summary" controls={viewPanelIds?.summary}>
-          {#snippet leading()}<FileText class="icon-xs" />{/snippet}
+          {#snippet leading()}<FileText class="cinder-icon-xs" />{/snippet}
           Summary
         </Segment>
       {/if}
@@ -174,7 +174,7 @@
         aria-label="Revert all changes"
         title="Revert all changes"
       >
-        <RotateCcw class="icon-sm" />
+        <RotateCcw class="cinder-icon-sm" />
         <span class="cinder-sr-only">Revert All</span>
       </Button>
     {/if}
@@ -189,7 +189,7 @@
         aria-label={commentsToggleLabel}
         title={sidebarOpen ? 'Close comments sidebar' : 'Open comments sidebar'}
       >
-        <MessageSquare class="icon-sm" />
+        <MessageSquare class="cinder-icon-sm" />
         <Badge aria-hidden="true" size="sm" variant="neutral">{commentCount}</Badge>
       </Button>
     </div>

--- a/packages/components/src/components/review-editor/thread-popover.svelte
+++ b/packages/components/src/components/review-editor/thread-popover.svelte
@@ -140,7 +140,7 @@
       <h2 id="{id}-title" class="thread-popover-title">
         {#if isDocumentComment}
           <span class="thread-popover-document-label">
-            <FileText class="icon-xs" />
+            <FileText class="cinder-icon-xs" />
             Document comment
           </span>
         {:else}
@@ -158,11 +158,11 @@
             disabled={!currentUserId}
             aria-label="Delete thread"
           >
-            <Trash2 class="icon-sm" />
+            <Trash2 class="cinder-icon-sm" />
           </Button>
         {/if}
         <button type="button" class="thread-popover-close" onclick={onclose} aria-label="Close">
-          <X class="icon-sm" />
+          <X class="cinder-icon-sm" />
         </button>
       </div>
     </div>

--- a/packages/components/src/convention.test.ts
+++ b/packages/components/src/convention.test.ts
@@ -24,6 +24,7 @@ import { parse } from 'svelte/compiler';
 import { hasSubstantiveTest } from '../scripts/component-conventions.ts';
 
 const COMPONENTS_DIR = join(import.meta.dir, 'components');
+const UNPREFIXED_ICON_UTILITY_PATTERN = /(?<![\w-])icon-(?:xs|sm|md|lg)(?![\w-])/g;
 
 // Components that are interactive and must have a sibling .a11y.md file.
 // AccordionItem is excluded — its a11y docs live in accordion.a11y.md.
@@ -132,6 +133,15 @@ async function getSvelteFiles(): Promise<string[]> {
         // Directory without a matching .svelte (e.g. chat container) — skip.
       }
     }
+  }
+  return files.toSorted();
+}
+
+async function getAllComponentSvelteFiles(): Promise<string[]> {
+  const glob = new Bun.Glob('**/*.svelte');
+  const files: string[] = [];
+  for await (const file of glob.scan(COMPONENTS_DIR)) {
+    files.push(file);
   }
   return files.toSorted();
 }
@@ -411,6 +421,38 @@ describe('component conventions', () => {
     // Parses every public .svelte file; raise the timeout so CPU contention
     // (parallel CI / multi-worktree) does not flake this whole-tree scan.
   }, 60_000);
+});
+
+describe('component icon utility namespace', () => {
+  test('component internals do not use unprefixed icon utility classes', async () => {
+    const files = await getAllComponentSvelteFiles();
+    expect(files.length).toBeGreaterThan(0);
+
+    const offenders: string[] = [];
+    for (const file of files) {
+      const source = await readFile(join(COMPONENTS_DIR, file), 'utf-8');
+      const matches = [...source.matchAll(UNPREFIXED_ICON_UTILITY_PATTERN)];
+      if (matches.length === 0) continue;
+
+      const lineStarts = [0];
+      for (
+        let index = source.indexOf('\n');
+        index !== -1;
+        index = source.indexOf('\n', index + 1)
+      ) {
+        lineStarts.push(index + 1);
+      }
+
+      const locations = matches.map((match) => {
+        const offset = match.index ?? 0;
+        const lineIndex = lineStarts.findLastIndex((start) => start <= offset);
+        return `${file}:${lineIndex + 1}`;
+      });
+      offenders.push(...locations);
+    }
+
+    expect(offenders).toEqual([]);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/components/src/styles/utilities.css
+++ b/packages/components/src/styles/utilities.css
@@ -42,59 +42,59 @@
   z-index: 9999;
 }
 
-/* Icon size utilities. lucide-svelte and most icon libraries default to a
- * 24px viewBox with no inline width/height. These classes force a consistent
- * size across the chat, markdown editor, code blocks, and any other component
- * that renders an icon glyph. Apply directly to the icon element (e.g.
- * `<Copy class="icon-sm" />`) — the rule cascades to nested <svg>. */
-.icon-xs,
-.icon-sm,
-.icon-md,
-.icon-lg {
+/* Namespaced icon size utilities. lucide-svelte and most icon libraries default
+ * to a 24px viewBox with no inline width/height. These classes force a
+ * consistent size across Cinder components without colliding with consumer app
+ * utilities. Apply directly to the icon element (e.g.
+ * `<Copy class="cinder-icon-sm" />`) — the rule cascades to nested <svg>. */
+.cinder-icon-xs,
+.cinder-icon-sm,
+.cinder-icon-md,
+.cinder-icon-lg {
   display: block;
   flex: 0 0 auto;
 }
 
-.icon-xs {
+.cinder-icon-xs {
   inline-size: 0.875rem;
   block-size: 0.875rem;
 }
 
-.icon-sm {
+.cinder-icon-sm {
   inline-size: 1rem;
   block-size: 1rem;
 }
 
-.icon-md {
+.cinder-icon-md {
   inline-size: 1.25rem;
   block-size: 1.25rem;
 }
 
-.icon-lg {
+.cinder-icon-lg {
   inline-size: 1.5rem;
   block-size: 1.5rem;
 }
 
-.icon-xs > svg,
-svg.icon-xs {
+.cinder-icon-xs > svg,
+svg.cinder-icon-xs {
   width: 0.875rem;
   height: 0.875rem;
 }
 
-.icon-sm > svg,
-svg.icon-sm {
+.cinder-icon-sm > svg,
+svg.cinder-icon-sm {
   width: 1rem;
   height: 1rem;
 }
 
-.icon-md > svg,
-svg.icon-md {
+.cinder-icon-md > svg,
+svg.cinder-icon-md {
   width: 1.25rem;
   height: 1.25rem;
 }
 
-.icon-lg > svg,
-svg.icon-lg {
+.cinder-icon-lg > svg,
+svg.cinder-icon-lg {
   width: 1.5rem;
   height: 1.5rem;
 }


### PR DESCRIPTION
## Summary
- Rename Cinder-owned icon sizing utilities from unprefixed `icon-*` classes to `cinder-icon-*`.
- Update Cinder component internals to use the namespaced classes.
- Add a component convention regression test that rejects unprefixed icon utility classes in component markup.

Closes #620

## Validation
- `bun run --filter=@lostgradient/cinder platform:audit`
- `bun run --filter=@lostgradient/cinder components:check`
- `bun run --filter=@lostgradient/cinder test -- ./src/convention.test.ts`
- `bun run --filter=@lostgradient/cinder test`
- `bun run --filter=@lostgradient/cinder typecheck`
- `bunx prettier --check` on changed source files
- `git diff --check`
- pre-commit hook: `@lostgradient/cinder typecheck`, `@lostgradient/cinder test`
- pre-push hook: scoped lint/typecheck/test for touched packages

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Documented breaking CSS rename for package consumers; library behavior is a mechanical class swap with a regression test, not logic changes.
> 
> **Overview**
> **Breaking change:** icon sizing utilities from `@lostgradient/cinder/styles` are renamed from `.icon-xs` / `.icon-sm` / `.icon-md` / `.icon-lg` to **`.cinder-icon-xs`** through **`.cinder-icon-lg`**, so host-app `.icon-*` classes no longer override Cinder component icons.
> 
> All internal Svelte usage is updated to the namespaced classes, and **`convention.test.ts`** now fails if any component markup still references unprefixed `icon-*` utilities. The CHANGELOG documents the migration for consumers who imported those helpers directly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 91b4cafd877c5f209a4523f0cfc3bca305744a8b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->