### PR TITLE
Fix collapsed NavigationBar toggle alignment

### DIFF
--- a/.changeset/navigation-bar-collapsed-toggle-actions.md
+++ b/.changeset/navigation-bar-collapsed-toggle-actions.md
@@ -1,0 +1,5 @@
+---
+'@lostgradient/cinder': patch
+---
+
+Keep the collapsible NavigationBar menu toggle grouped with trailing actions on narrow bars.

--- a/packages/components/src/components/navigation-bar/navigation-bar.css
+++ b/packages/components/src/components/navigation-bar/navigation-bar.css
@@ -131,6 +131,7 @@
   @container cinder-navigation-bar (max-width: 47.99rem) {
     .cinder-navigation-bar[data-collapsible='true'] .cinder-navigation-bar__menu-toggle {
       display: inline-flex;
+      margin-inline-start: auto;
     }
 
     .cinder-navigation-bar[data-collapsible='true'] .cinder-navigation-bar__items {

--- a/packages/components/src/components/navigation-bar/navigation-bar.css
+++ b/packages/components/src/components/navigation-bar/navigation-bar.css
@@ -131,6 +131,10 @@
   @container cinder-navigation-bar (max-width: 47.99rem) {
     .cinder-navigation-bar[data-collapsible='true'] .cinder-navigation-bar__menu-toggle {
       display: inline-flex;
+    }
+
+    .cinder-navigation-bar[data-collapsible='true'][data-cinder-menu-toggle-placement='after-brand']
+      .cinder-navigation-bar__menu-toggle {
       margin-inline-start: auto;
     }
 

--- a/packages/components/src/components/navigation-bar/navigation-bar.test.ts
+++ b/packages/components/src/components/navigation-bar/navigation-bar.test.ts
@@ -761,7 +761,10 @@ describe('NavigationBar responsive CSS', () => {
 
   test('collapsed menu toggle stays with trailing actions instead of centering between brand and actions', () => {
     expect(navigationBarCss).toMatch(
-      /@container cinder-navigation-bar \(max-width: 47\.99rem\)[\s\S]*?\.cinder-navigation-bar\[data-collapsible='true'\] \.cinder-navigation-bar__menu-toggle\s*\{[\s\S]*?display:\s*inline-flex;[\s\S]*?margin-inline-start:\s*auto;/,
+      /@container cinder-navigation-bar \(max-width: 47\.99rem\)[\s\S]*?\.cinder-navigation-bar\[data-collapsible='true'\]\[data-cinder-menu-toggle-placement='after-brand'\][\s\S]*?\.cinder-navigation-bar__menu-toggle\s*\{[\s\S]*?margin-inline-start:\s*auto;/,
+    );
+    expect(navigationBarCss).not.toMatch(
+      /data-cinder-menu-toggle-placement='before-brand'[\s\S]*?margin-inline-start:\s*auto;/,
     );
   });
 

--- a/packages/components/src/components/navigation-bar/navigation-bar.test.ts
+++ b/packages/components/src/components/navigation-bar/navigation-bar.test.ts
@@ -759,6 +759,12 @@ describe('NavigationBar responsive CSS', () => {
     );
   });
 
+  test('collapsed menu toggle stays with trailing actions instead of centering between brand and actions', () => {
+    expect(navigationBarCss).toMatch(
+      /@container cinder-navigation-bar \(max-width: 47\.99rem\)[\s\S]*?\.cinder-navigation-bar\[data-collapsible='true'\] \.cinder-navigation-bar__menu-toggle\s*\{[\s\S]*?display:\s*inline-flex;[\s\S]*?margin-inline-start:\s*auto;/,
+    );
+  });
+
   test('bottom placement owns tab-bar geometry and label visibility without a new component directory', () => {
     expect(navigationBarCss).toMatch(
       /\.cinder-navigation-bar\[data-cinder-placement='bottom'\][\s\S]*?border-top:\s*1px solid var\(--cinder-border-muted\)/,


### PR DESCRIPTION
## Summary
- keep the collapsible NavigationBar menu toggle grouped with trailing actions in narrow container layouts
- add a CSS regression test for the brand + collapsed menu trigger + trailing actions case
- add a patch changeset for @lostgradient/cinder

Closes #600

## Verification
- bun run --filter=@lostgradient/cinder test -- ./src/components/navigation-bar/navigation-bar.test.ts
- bun run --filter=@lostgradient/cinder components:check
- bun run format:check -- .changeset/navigation-bar-collapsed-toggle-actions.md packages/components/src/components/navigation-bar/navigation-bar.css packages/components/src/components/navigation-bar/navigation-bar.test.ts
- pre-commit hook: @lostgradient/cinder typecheck + test
- pre-push hook: scoped lint/typecheck/test

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped CSS-only change under existing collapsible and placement data attributes; no JS or API changes.
> 
> **Overview**
> Fixes **collapsible NavigationBar** layout on narrow bars (container max-width ~48rem) when the menu toggle sits **after the brand**: the toggle no longer floats centered between brand and trailing actions.
> 
> A new container-query rule applies **`margin-inline-start: auto`** only for **`data-cinder-menu-toggle-placement='after-brand'`**, pushing the menu control next to the actions slot. **`before-brand`** placement is unchanged.
> 
> Adds a **CSS regression test** and a **patch changeset** for `@lostgradient/cinder`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5475cea984f840d0fa46f23b451e71f8509f4262. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->