### PR TITLE
Fix MarkdownEditor constrained toolbar layout

### DIFF
--- a/packages/components/src/components/chat/input/chat-input-layout.test.ts
+++ b/packages/components/src/components/chat/input/chat-input-layout.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from 'bun:test';
 
 const chatInputPath = new URL('./chat-input.svelte', import.meta.url);
+const markdownEditorPath = new URL('../../markdown-editor/markdown-editor.svelte', import.meta.url);
 
 function stripCssComments(source: string): string {
   return source.replace(/\/\*[\s\S]*?\*\//g, '');
@@ -61,5 +62,19 @@ describe('ChatInput layout CSS', () => {
       'padding',
       'var(--cinder-space-1) var(--cinder-space-3)',
     );
+  });
+
+  test('keeps MarkdownEditor inner layout from forcing the compact composer height', async () => {
+    const chatInputSource = stripCssComments(await Bun.file(chatInputPath).text());
+    const markdownEditorSource = stripCssComments(await Bun.file(markdownEditorPath).text());
+
+    const chatContainerBlock =
+      cssBlocks(chatInputSource, '.chat-input-editor-container').at(0) ?? '';
+    expectDeclaration(chatContainerBlock, '--editor-min-height', '2.5rem');
+    expectDeclaration(chatContainerBlock, '--editor-source-min-height', 'var(--editor-min-height)');
+
+    const markdownEditorLayoutBlock =
+      cssBlocks(markdownEditorSource, '.markdown-editor-layout').at(0) ?? '';
+    expect(markdownEditorLayoutBlock).not.toContain('min-height');
   });
 });

--- a/packages/components/src/components/chat/input/chat-input.svelte
+++ b/packages/components/src/components/chat/input/chat-input.svelte
@@ -750,6 +750,7 @@
   /* Editor container */
   .chat-input-editor-container {
     --editor-min-height: 2.5rem;
+    --editor-source-min-height: var(--editor-min-height);
   }
 
   .chat-input-editor-container :global(.markdown-editor-wrapper) {

--- a/packages/components/src/components/markdown-editor/markdown-editor.examples.json
+++ b/packages/components/src/components/markdown-editor/markdown-editor.examples.json
@@ -8,6 +8,12 @@
       "title": "Basic markdown editor",
       "description": "A Milkdown-backed editor with toolbar and source mode toggle.",
       "code": "<script lang=\"ts\">\n  import { MarkdownEditor } from '@lostgradient/cinder/markdown-editor';\n\n  let value = $state(`# Release notes\n\nThis editor supports **rich markdown editing**, toolbar actions, and a source mode.\n\n- Write in markdown\n- Switch between rendered and source modes\n- Keep the value bindable`);\n</script>\n\n<div style=\"display: grid; gap: 0.75rem;\">\n  <MarkdownEditor id=\"editor\" bind:value showToolbar showModeToggle />\n  <p style=\"margin: 0; color: var(--cinder-text-muted);\">\n    Characters: {value.length}\n  </p>\n</div>\n"
+    },
+    {
+      "id": "settings-card",
+      "title": "Settings card prompt editor",
+      "description": "MarkdownEditor embedded in a constrained settings card, with the toolbar and Rich/Raw toggle sharing one editor header.",
+      "code": "<script lang=\"ts\">\n  import { Card } from '@lostgradient/cinder/card';\n  import { MarkdownEditor, type EditorMode } from '@lostgradient/cinder/markdown-editor';\n\n  let mode = $state<EditorMode>('source');\n  let prompt = $state(`You are a careful review agent.\n\n## Instructions\n\n- Read the patch before commenting.\n- Prefer specific line-level feedback.\n- Separate blocking issues from suggestions.`);\n</script>\n\n<div data-testid=\"markdown-editor-settings-card\" style=\"max-width: 46rem; margin-inline: auto;\">\n  <Card\n    title=\"Agent prompt\"\n    description=\"The prompt is stored as Markdown and shown in a constrained settings column.\"\n  >\n    <MarkdownEditor\n      id=\"agent-prompt\"\n      bind:value={prompt}\n      bind:mode\n      label=\"Agent prompt\"\n      showToolbar\n      showModeToggle\n    />\n  </Card>\n</div>\n"
     }
   ]
 }

--- a/packages/components/src/components/markdown-editor/markdown-editor.hydrate.test.ts
+++ b/packages/components/src/components/markdown-editor/markdown-editor.hydrate.test.ts
@@ -80,9 +80,12 @@ describe('MarkdownEditor SSR contract (source-level verification)', () => {
     // browser/server boundary.
     const ifBrowserStart = SVELTE_SOURCE.indexOf('{#if browser}');
     expect(ifBrowserStart).toBeGreaterThan(-1);
-    // The EditorSkeleton {:else} is: {:else}\n    <EditorSkeleton — find this sequence.
-    const elseSkeletonMarker = '{:else}\n    <EditorSkeleton';
-    const elseStart = SVELTE_SOURCE.indexOf(elseSkeletonMarker, ifBrowserStart);
+    // The EditorSkeleton {:else} is the server branch; match it without
+    // depending on indentation so layout wrappers can move around it.
+    const elseSkeletonMatch = /\{:else\}\s*\n\s*<EditorSkeleton/.exec(
+      SVELTE_SOURCE.slice(ifBrowserStart),
+    );
+    const elseStart = elseSkeletonMatch === null ? -1 : ifBrowserStart + elseSkeletonMatch.index;
     expect(elseStart).toBeGreaterThan(ifBrowserStart);
     const browserBranch = SVELTE_SOURCE.slice(ifBrowserStart + '{#if browser}'.length, elseStart);
     expect(browserBranch).toContain('role="application"');

--- a/packages/components/src/components/markdown-editor/markdown-editor.svelte
+++ b/packages/components/src/components/markdown-editor/markdown-editor.svelte
@@ -748,6 +748,7 @@
   .markdown-editor-wrapper {
     /* Configurable minimum height for the editor content area */
     --editor-min-height: 200px;
+    --editor-source-min-height: max(var(--editor-min-height), 16rem);
 
     display: flex;
     flex-direction: column;
@@ -766,7 +767,6 @@
     display: flex;
     flex: 1;
     flex-direction: column;
-    min-height: var(--editor-min-height);
     gap: var(--cinder-space-2);
     container-name: cinder-markdown-editor;
     container-type: inline-size;
@@ -860,7 +860,7 @@
     /* Use flex: 1 instead of height: 100% for consistent sizing with WYSIWYG mode */
     flex: 1;
     color: var(--cinder-text);
-    min-height: max(var(--editor-min-height), 16rem);
+    min-height: var(--editor-source-min-height);
   }
 
   @container cinder-markdown-editor (max-width: 42rem) {

--- a/packages/components/src/components/markdown-editor/markdown-editor.svelte
+++ b/packages/components/src/components/markdown-editor/markdown-editor.svelte
@@ -643,89 +643,91 @@
   data-snapshot-mode={snapshotMode || undefined}
   {...rest}
 >
-  {#if toolbarVisible}
-    {#if toolbar}
-      <!-- Full custom toolbar override -->
-      {@render toolbar(toolbarContext)}
-    {:else}
-      <!-- Default toolbar with optional extension points -->
-      <div class="editor-toolbar-wrapper">
-        {#if toolbarLeading}
-          <div class="toolbar-leading">
-            {@render toolbarLeading(toolbarContext)}
-          </div>
-        {/if}
+  <div class="markdown-editor-layout">
+    {#if toolbarVisible}
+      {#if toolbar}
+        <!-- Full custom toolbar override -->
+        {@render toolbar(toolbarContext)}
+      {:else}
+        <!-- Default toolbar with optional extension points -->
+        <div class="editor-toolbar-wrapper">
+          {#if toolbarLeading}
+            <div class="toolbar-leading">
+              {@render toolbarLeading(toolbarContext)}
+            </div>
+          {/if}
 
-        <EditorToolbar
-          id={`${id}-toolbar`}
-          editorId={id}
-          {editorContext}
-          {activeMarks}
-          {activeBlockType}
-          {canUndo}
-          {canRedo}
-          {linkPopoverOpen}
-          disabled={!editorContext}
-          onLinkClick={handleLinkClick}
-          onUndo={handleUndo}
-          onRedo={handleRedo}
-        />
+          <EditorToolbar
+            id={`${id}-toolbar`}
+            editorId={id}
+            {editorContext}
+            {activeMarks}
+            {activeBlockType}
+            {canUndo}
+            {canRedo}
+            {linkPopoverOpen}
+            disabled={!editorContext}
+            onLinkClick={handleLinkClick}
+            onUndo={handleUndo}
+            onRedo={handleRedo}
+          />
 
-        {#if toolbarActions}
-          <div class="toolbar-actions">
-            {@render toolbarActions(toolbarContext)}
-          </div>
-        {/if}
+          {#if toolbarActions}
+            <div class="toolbar-actions">
+              {@render toolbarActions(toolbarContext)}
+            </div>
+          {/if}
 
-        {#if showModeToggle}
-          <div class="toolbar-mode-toggle">
-            <SegmentedControl
-              id={`${id}-mode-toggle`}
-              selectionMode="single"
-              size="sm"
-              bind:value={mode}
-              label={modeLabel}
-              hideLabel
-            >
-              <Segment value="wysiwyg">Rich</Segment>
-              <Segment value="source">Raw</Segment>
-            </SegmentedControl>
-          </div>
-        {/if}
-      </div>
+          {#if showModeToggle}
+            <div class="toolbar-mode-toggle">
+              <SegmentedControl
+                id={`${id}-mode-toggle`}
+                selectionMode="single"
+                size="sm"
+                bind:value={mode}
+                label={modeLabel}
+                hideLabel
+              >
+                <Segment value="wysiwyg">Rich</Segment>
+                <Segment value="source">Raw</Segment>
+              </SegmentedControl>
+            </div>
+          {/if}
+        </div>
+      {/if}
     {/if}
-  {/if}
 
-  {#if browser}
-    {#if mode === 'wysiwyg'}
-      <!-- eslint-disable-next-line svelte/no-unused-svelte-ignore -- ESLint doesn't see Svelte's a11y warning -->
-      <!-- svelte-ignore a11y_no_noninteractive_tabindex -->
-      <div
-        {id}
-        class="cinder-markdown-content markdown-editor surface"
-        data-readonly={readonly || undefined}
-        style:--editor-placeholder="'{escapedPlaceholder}'"
-        role="application"
-        aria-label={accessibleEditorLabel}
-        tabindex="0"
-        {@attach editorAttachment}
-      ></div>
+    {#if browser}
+      {#if mode === 'wysiwyg'}
+        <!-- eslint-disable-next-line svelte/no-unused-svelte-ignore -- ESLint doesn't see Svelte's a11y warning -->
+        <!-- svelte-ignore a11y_no_noninteractive_tabindex -->
+        <div
+          {id}
+          class="cinder-markdown-content markdown-editor surface"
+          data-readonly={readonly || undefined}
+          style:--editor-placeholder="'{escapedPlaceholder}'"
+          role="application"
+          aria-label={accessibleEditorLabel}
+          tabindex="0"
+          {@attach editorAttachment}
+        ></div>
+      {:else}
+        <textarea
+          {id}
+          class="markdown-editor surface source-mode"
+          bind:value
+          oninput={(e) => onchange?.(e.currentTarget.value)}
+          {placeholder}
+          readonly={readonly || undefined}
+          aria-label={accessibleEditorLabel}
+          aria-describedby={ariaDescribedby}
+          aria-multiline="true"
+        ></textarea>
+      {/if}
     {:else}
-      <textarea
-        {id}
-        class="markdown-editor surface source-mode"
-        bind:value
-        oninput={(e) => onchange?.(e.currentTarget.value)}
-        {placeholder}
-        readonly={readonly || undefined}
-        aria-label={accessibleEditorLabel}
-        aria-describedby={ariaDescribedby}
-        aria-multiline="true"
-      ></textarea>
+      <EditorSkeleton class="markdown-editor" />
     {/if}
-  {:else}
-    <EditorSkeleton class="markdown-editor" />
-  {/if}
+  </div>
 
   {#if linkPopoverOpen && mode === 'wysiwyg'}
     <LinkPopover
@@ -750,7 +752,6 @@
     display: flex;
     flex-direction: column;
     min-height: var(--editor-min-height);
-    gap: var(--cinder-space-2);
     /* Single outer border for the whole editor card */
     border: 1px solid var(--cinder-border);
     border-radius: var(--cinder-radius-md);
@@ -759,6 +760,14 @@
        (see tokens-base.css), every region inside (toolbar wrapper, editor
        body) inherits — they must not redeclare `background:`. */
     background: var(--cinder-surface-raised);
+  }
+
+  .markdown-editor-layout {
+    display: flex;
+    flex: 1;
+    flex-direction: column;
+    min-height: var(--editor-min-height);
+    gap: var(--cinder-space-2);
     container-name: cinder-markdown-editor;
     container-type: inline-size;
   }
@@ -814,7 +823,7 @@
   }
 
   /* When toolbar is present, collapse the gap so toolbar and editor are flush */
-  .markdown-editor-wrapper[data-has-toolbar] {
+  .markdown-editor-wrapper[data-has-toolbar] .markdown-editor-layout {
     gap: 0;
   }
 

--- a/packages/components/src/components/markdown-editor/markdown-editor.svelte
+++ b/packages/components/src/components/markdown-editor/markdown-editor.svelte
@@ -759,12 +759,14 @@
        (see tokens-base.css), every region inside (toolbar wrapper, editor
        body) inherits — they must not redeclare `background:`. */
     background: var(--cinder-surface-raised);
+    container-name: cinder-markdown-editor;
+    container-type: inline-size;
   }
 
   /* Toolbar wrapper for extension points */
   .editor-toolbar-wrapper {
     display: flex;
-    align-items: center;
+    align-items: flex-start;
     gap: var(--cinder-space-2);
     /* The wrapper owns nested toolbar padding; EditorToolbar keeps standalone chrome. */
     padding: var(--cinder-space-2) var(--cinder-space-3);
@@ -774,8 +776,8 @@
   }
 
   .editor-toolbar-wrapper :global(.editor-toolbar) {
-    flex: 1 1 auto;
-    min-width: min(16rem, 100%);
+    flex: 1 1 32rem;
+    min-width: min(20rem, 100%);
     padding: 0;
     border: 0;
     border-radius: 0;
@@ -784,9 +786,12 @@
      * rule in editor-toolbar.svelte cannot cross the component boundary, so
      * we override here where the rendered element lives. */
     flex-wrap: wrap;
+    row-gap: var(--cinder-space-1);
   }
 
   .toolbar-mode-toggle {
+    display: flex;
+    justify-content: flex-end;
     flex: 0 0 auto;
     margin-inline-start: auto;
   }
@@ -846,6 +851,22 @@
     /* Use flex: 1 instead of height: 100% for consistent sizing with WYSIWYG mode */
     flex: 1;
     color: var(--cinder-text);
+    min-height: max(var(--editor-min-height), 16rem);
+  }
+
+  @container cinder-markdown-editor (max-width: 42rem) {
+    .editor-toolbar-wrapper :global(.editor-toolbar) {
+      flex-basis: 100%;
+    }
+
+    .editor-toolbar-wrapper :global(.toolbar-separator) {
+      display: none;
+    }
+
+    .toolbar-mode-toggle {
+      flex-basis: 100%;
+      margin-inline-start: 0;
+    }
   }
 
   textarea.markdown-editor.source-mode::placeholder {

--- a/packages/components/src/components/markdown-editor/markdown-editor.toolbar-layout.test.ts
+++ b/packages/components/src/components/markdown-editor/markdown-editor.toolbar-layout.test.ts
@@ -61,8 +61,11 @@ describe('MarkdownEditor toolbar layout CSS ownership', () => {
     expectDeclaration(wrapperBlock, 'align-items', 'flex-start');
 
     const editorWrapperBlock = cssBlock(markdownEditorSource, '.markdown-editor-wrapper');
-    expectDeclaration(editorWrapperBlock, 'container-name', 'cinder-markdown-editor');
-    expectDeclaration(editorWrapperBlock, 'container-type', 'inline-size');
+    expect(editorWrapperBlock).not.toContain('container-type');
+
+    const editorLayoutBlock = cssBlock(markdownEditorSource, '.markdown-editor-layout');
+    expectDeclaration(editorLayoutBlock, 'container-name', 'cinder-markdown-editor');
+    expectDeclaration(editorLayoutBlock, 'container-type', 'inline-size');
 
     const nestedToolbarBlock = cssBlock(
       markdownEditorSource,
@@ -115,6 +118,17 @@ describe('MarkdownEditor toolbar layout CSS ownership', () => {
     );
     expectDeclaration(narrowModeToggleBlock, 'flex-basis', '100%');
     expectDeclaration(narrowModeToggleBlock, 'margin-inline-start', '0');
+  });
+
+  it('keeps the fixed-position link popover outside the query container', async () => {
+    const markdownEditorSource = await Bun.file(markdownEditorPath).text();
+    const layoutStartIndex = markdownEditorSource.indexOf('<div class="markdown-editor-layout">');
+    const layoutEndIndex = markdownEditorSource.indexOf('</div>\n\n  {#if linkPopoverOpen');
+    const popoverIndex = markdownEditorSource.indexOf('<LinkPopover');
+
+    expect(layoutStartIndex).toBeGreaterThanOrEqual(0);
+    expect(layoutEndIndex).toBeGreaterThan(layoutStartIndex);
+    expect(popoverIndex).toBeGreaterThan(layoutEndIndex);
   });
 
   it('gives raw source mode a usable minimum editing height', async () => {

--- a/packages/components/src/components/markdown-editor/markdown-editor.toolbar-layout.test.ts
+++ b/packages/components/src/components/markdown-editor/markdown-editor.toolbar-layout.test.ts
@@ -66,6 +66,7 @@ describe('MarkdownEditor toolbar layout CSS ownership', () => {
     const editorLayoutBlock = cssBlock(markdownEditorSource, '.markdown-editor-layout');
     expectDeclaration(editorLayoutBlock, 'container-name', 'cinder-markdown-editor');
     expectDeclaration(editorLayoutBlock, 'container-type', 'inline-size');
+    expect(editorLayoutBlock).not.toContain('min-height');
 
     const nestedToolbarBlock = cssBlock(
       markdownEditorSource,
@@ -123,7 +124,11 @@ describe('MarkdownEditor toolbar layout CSS ownership', () => {
   it('keeps the fixed-position link popover outside the query container', async () => {
     const markdownEditorSource = await Bun.file(markdownEditorPath).text();
     const layoutStartIndex = markdownEditorSource.indexOf('<div class="markdown-editor-layout">');
-    const layoutEndIndex = markdownEditorSource.indexOf('</div>\n\n  {#if linkPopoverOpen');
+    const layoutCloseBeforePopover = /<\/div>\s*\{#if linkPopoverOpen/.exec(
+      markdownEditorSource.slice(layoutStartIndex),
+    );
+    const layoutEndIndex =
+      layoutCloseBeforePopover === null ? -1 : layoutStartIndex + layoutCloseBeforePopover.index;
     const popoverIndex = markdownEditorSource.indexOf('<LinkPopover');
 
     expect(layoutStartIndex).toBeGreaterThanOrEqual(0);
@@ -134,8 +139,17 @@ describe('MarkdownEditor toolbar layout CSS ownership', () => {
   it('gives raw source mode a usable minimum editing height', async () => {
     const markdownEditorSource = stripCssComments(await Bun.file(markdownEditorPath).text());
 
+    const wrapperBlock = cssBlock(markdownEditorSource, '.markdown-editor-wrapper');
+    expectDeclaration(wrapperBlock, '--editor-min-height', '200px');
+    expectDeclaration(
+      wrapperBlock,
+      '--editor-source-min-height',
+      'max(var(--editor-min-height), 16rem)',
+    );
+
     const sourceModeBlock = cssBlock(markdownEditorSource, 'textarea.markdown-editor.source-mode');
-    expectDeclaration(sourceModeBlock, 'min-height', 'max(var(--editor-min-height), 16rem)');
+    expectDeclaration(sourceModeBlock, 'min-height', 'var(--editor-source-min-height)');
+    expect(sourceModeBlock).not.toContain('max(');
   });
 
   it('wires block-type radio menu state through DropdownItem checked', async () => {

--- a/packages/components/src/components/markdown-editor/markdown-editor.toolbar-layout.test.ts
+++ b/packages/components/src/components/markdown-editor/markdown-editor.toolbar-layout.test.ts
@@ -14,7 +14,17 @@ function normalizeCssWhitespace(source: string): string {
 }
 
 function cssBlock(source: string, selector: string): string {
-  const selectorIndex = source.indexOf(selector);
+  return cssBlockFromIndex(source, selector, 0);
+}
+
+function cssBlockAfter(source: string, anchor: string, selector: string): string {
+  const anchorIndex = source.indexOf(anchor);
+  expect(anchorIndex, `Missing CSS anchor: ${anchor}`).toBeGreaterThanOrEqual(0);
+  return cssBlockFromIndex(source, selector, anchorIndex);
+}
+
+function cssBlockFromIndex(source: string, selector: string, startIndex: number): string {
+  const selectorIndex = source.indexOf(selector, startIndex);
   expect(selectorIndex, `Missing CSS selector: ${selector}`).toBeGreaterThanOrEqual(0);
 
   const openingBraceIndex = source.indexOf('{', selectorIndex);
@@ -48,16 +58,27 @@ describe('MarkdownEditor toolbar layout CSS ownership', () => {
 
     const wrapperBlock = cssBlock(markdownEditorSource, '.editor-toolbar-wrapper');
     expectDeclaration(wrapperBlock, 'padding', 'var(--cinder-space-2) var(--cinder-space-3)');
+    expectDeclaration(wrapperBlock, 'align-items', 'flex-start');
+
+    const editorWrapperBlock = cssBlock(markdownEditorSource, '.markdown-editor-wrapper');
+    expectDeclaration(editorWrapperBlock, 'container-name', 'cinder-markdown-editor');
+    expectDeclaration(editorWrapperBlock, 'container-type', 'inline-size');
 
     const nestedToolbarBlock = cssBlock(
       markdownEditorSource,
       '.editor-toolbar-wrapper :global(.editor-toolbar)',
     );
-    expectDeclaration(nestedToolbarBlock, 'min-width', 'min(16rem, 100%)');
+    expectDeclaration(nestedToolbarBlock, 'flex', '1 1 32rem');
+    expectDeclaration(nestedToolbarBlock, 'min-width', 'min(20rem, 100%)');
     expectDeclaration(nestedToolbarBlock, 'padding', '0');
     expectDeclaration(nestedToolbarBlock, 'border', '0');
     expectDeclaration(nestedToolbarBlock, 'border-radius', '0');
     expectDeclaration(nestedToolbarBlock, 'background', 'transparent');
+    expectDeclaration(nestedToolbarBlock, 'row-gap', 'var(--cinder-space-1)');
+
+    const modeToggleBlock = cssBlock(markdownEditorSource, '.toolbar-mode-toggle');
+    expectDeclaration(modeToggleBlock, 'display', 'flex');
+    expectDeclaration(modeToggleBlock, 'justify-content', 'flex-end');
 
     const standaloneToolbarBlock = cssBlock(editorToolbarSource, '.editor-toolbar');
     expectDeclaration(
@@ -65,6 +86,42 @@ describe('MarkdownEditor toolbar layout CSS ownership', () => {
       'padding',
       'var(--cinder-space-1) var(--cinder-space-2)',
     );
+  });
+
+  it('collapses the toolbar toggle and separators by editor container width', async () => {
+    const markdownEditorSource = stripCssComments(await Bun.file(markdownEditorPath).text());
+    const narrowContainer = '@container cinder-markdown-editor (max-width: 42rem)';
+
+    expect(markdownEditorSource).toContain(narrowContainer);
+
+    const narrowToolbarBlock = cssBlockAfter(
+      markdownEditorSource,
+      narrowContainer,
+      '.editor-toolbar-wrapper :global(.editor-toolbar)',
+    );
+    expectDeclaration(narrowToolbarBlock, 'flex-basis', '100%');
+
+    const narrowSeparatorBlock = cssBlockAfter(
+      markdownEditorSource,
+      narrowContainer,
+      '.editor-toolbar-wrapper :global(.toolbar-separator)',
+    );
+    expectDeclaration(narrowSeparatorBlock, 'display', 'none');
+
+    const narrowModeToggleBlock = cssBlockAfter(
+      markdownEditorSource,
+      narrowContainer,
+      '.toolbar-mode-toggle',
+    );
+    expectDeclaration(narrowModeToggleBlock, 'flex-basis', '100%');
+    expectDeclaration(narrowModeToggleBlock, 'margin-inline-start', '0');
+  });
+
+  it('gives raw source mode a usable minimum editing height', async () => {
+    const markdownEditorSource = stripCssComments(await Bun.file(markdownEditorPath).text());
+
+    const sourceModeBlock = cssBlock(markdownEditorSource, 'textarea.markdown-editor.source-mode');
+    expectDeclaration(sourceModeBlock, 'min-height', 'max(var(--editor-min-height), 16rem)');
   });
 
   it('wires block-type radio menu state through DropdownItem checked', async () => {

--- a/packages/playground/src/examples/markdown-editor/settings-card.example.svelte
+++ b/packages/playground/src/examples/markdown-editor/settings-card.example.svelte
@@ -1,0 +1,39 @@
+<script lang="ts" module>
+  export const title = 'Settings card prompt editor';
+  export const description =
+    'MarkdownEditor embedded in a constrained settings card, with the toolbar and Rich/Raw toggle sharing one editor header.';
+</script>
+
+<script lang="ts">
+  import { Card } from '@lostgradient/cinder/card';
+  import { MarkdownEditor, type EditorMode } from '@lostgradient/cinder/markdown-editor';
+
+  let { mountIdPrefix }: { mountIdPrefix?: string } = $props();
+  const uid = $props.id();
+  let editorId = $derived(`${mountIdPrefix ?? uid}-agent-prompt`);
+
+  let mode = $state<EditorMode>('source');
+  let prompt = $state(`You are a careful review agent.
+
+## Instructions
+
+- Read the patch before commenting.
+- Prefer specific line-level feedback.
+- Separate blocking issues from suggestions.`);
+</script>
+
+<div data-testid="markdown-editor-settings-card" style="max-width: 46rem; margin-inline: auto;">
+  <Card
+    title="Agent prompt"
+    description="The prompt is stored as Markdown and shown in a constrained settings column."
+  >
+    <MarkdownEditor
+      id={editorId}
+      bind:value={prompt}
+      bind:mode
+      label="Agent prompt"
+      showToolbar
+      showModeToggle
+    />
+  </Card>
+</div>

--- a/packages/testing/tests/markdown-editor-toolbar.playwright.ts
+++ b/packages/testing/tests/markdown-editor-toolbar.playwright.ts
@@ -34,10 +34,9 @@ for (const theme of THEMES) {
         viewport,
       });
 
-      // The example's editor id is namespaced per mount (#399), so this test
-      // locates the editor by its component wrapper class instead of a hardcoded
-      // id. Snapshot mode renders exactly one example, so the wrapper is unique.
-      const editorWrapper = page.locator('.markdown-editor-wrapper').first();
+      // The editor id is namespaced per mount (#399), so this scopes to the
+      // stable scenario container before locating the component wrapper.
+      const editorWrapper = page.locator('#example-mount-basic .markdown-editor-wrapper');
       await expect(editorWrapper).toBeVisible();
 
       const toolbarWrapper = editorWrapper.locator('.editor-toolbar-wrapper');

--- a/packages/testing/tests/markdown-editor-toolbar.playwright.ts
+++ b/packages/testing/tests/markdown-editor-toolbar.playwright.ts
@@ -37,7 +37,7 @@ for (const theme of THEMES) {
       // The example's editor id is namespaced per mount (#399), so this test
       // locates the editor by its component wrapper class instead of a hardcoded
       // id. Snapshot mode renders exactly one example, so the wrapper is unique.
-      const editorWrapper = page.locator('.markdown-editor-wrapper');
+      const editorWrapper = page.locator('.markdown-editor-wrapper').first();
       await expect(editorWrapper).toBeVisible();
 
       const toolbarWrapper = editorWrapper.locator('.editor-toolbar-wrapper');
@@ -106,6 +106,61 @@ for (const theme of THEMES) {
     });
   }
 }
+
+test('MarkdownEditor settings card keeps toolbar and raw mode usable in a constrained column', async ({
+  componentPage,
+}) => {
+  const page = await componentPage.open({
+    entry: markdownEditorEntry,
+    theme: 'light',
+    viewport: VIEWPORTS.find((viewport) => viewport.name === 'tablet')!,
+  });
+
+  const settingsCard = page.getByTestId('markdown-editor-settings-card');
+  await expect(settingsCard).toBeVisible();
+
+  const editorWrapper = settingsCard.locator('.markdown-editor-wrapper');
+  await expect(editorWrapper).toBeVisible();
+
+  const toolbarWrapper = editorWrapper.locator('.editor-toolbar-wrapper');
+  const toolbar = toolbarWrapper.locator('.editor-toolbar');
+  const modeToggle = toolbarWrapper.getByRole('radiogroup', { name: 'Editor mode' });
+  const sourceTextarea = editorWrapper.locator('textarea.markdown-editor.source-mode');
+
+  await expect(toolbar).toBeVisible();
+  await expect(modeToggle).toBeVisible();
+  await expect(sourceTextarea).toBeVisible();
+
+  const metrics = await toolbarWrapper.evaluate((element) => {
+    const rect = element.getBoundingClientRect();
+    return {
+      left: rect.left,
+      right: rect.right,
+      width: rect.width,
+      scrollWidth: element.scrollWidth,
+      clientWidth: element.clientWidth,
+    };
+  });
+
+  expect(metrics.width).toBeGreaterThanOrEqual(600);
+  expect(metrics.width).toBeLessThanOrEqual(900);
+  expect(metrics.scrollWidth).toBeLessThanOrEqual(metrics.clientWidth + 1);
+
+  const toolbarBox = await toolbar.boundingBox();
+  const modeToggleBox = await modeToggle.boundingBox();
+  const textareaBox = await sourceTextarea.boundingBox();
+
+  expect(toolbarBox).not.toBeNull();
+  expect(modeToggleBox).not.toBeNull();
+  expect(textareaBox).not.toBeNull();
+
+  expectInsideContentBox(toolbarBox as Box, metrics);
+  expectInsideContentBox(modeToggleBox as Box, metrics);
+  expect(
+    (modeToggleBox as Box).y - ((toolbarBox as Box).y + (toolbarBox as Box).height),
+  ).toBeLessThanOrEqual(12);
+  expect((textareaBox as Box).height).toBeGreaterThanOrEqual(256);
+});
 
 test('MarkdownEditor names its ProseMirror textbox before accessibility checks run', async ({
   componentPage,


### PR DESCRIPTION
Closes #597

## Summary
- make MarkdownEditor toolbar and mode toggle wrap by editor container width
- give source mode a larger usable minimum height in form/card contexts
- add a settings-card example and Playwright coverage for the constrained layout

## Verification
- bun run --filter=@lostgradient/cinder test -- ./src/components/markdown-editor/markdown-editor.toolbar-layout.test.ts
- bun run --filter=@lostgradient/cinder typecheck
- bun run --filter=@lostgradient/cinder components:check
- bun run format:check
- bun run --filter='@cinder/testing' test:playwright -- --grep MarkdownEditor
- bun run --filter=@lostgradient/cinder validate
- pre-commit hook
- pre-push hook

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Layout/CSS and test-only changes to MarkdownEditor and ChatInput embedding; no auth, data, or API behavior changes.
> 
> **Overview**
> **MarkdownEditor** now wraps the toolbar and editing surface in a `.markdown-editor-layout` container query (`cinder-markdown-editor`, 42rem breakpoint) so the toolbar wraps, separators hide, and the Rich/Raw toggle moves to its own row in narrow columns—without putting `LinkPopover` inside that container.
> 
> **Raw/source mode** gets a taller default via `--editor-source-min-height` (`max(--editor-min-height, 16rem)` on the wrapper); **ChatInput** overrides with `--editor-source-min-height: var(--editor-min-height)` so the compact composer stays short, and tests lock in that `.markdown-editor-layout` does not impose `min-height`.
> 
> Adds a **settings-card** playground/example and **Playwright** coverage for constrained-column toolbar + source textarea height; toolbar padding tests scope to `#example-mount-basic`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 16148862916b2c7a8ca1e02b50fc0888bcdc00c9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->