### PR TITLE
Fix chat SSR rich peer bundle

### DIFF
--- a/.changeset/chat-rich-peer-bundle.md
+++ b/.changeset/chat-rich-peer-bundle.md
@@ -1,0 +1,5 @@
+---
+'@lostgradient/cinder': patch
+---
+
+Keep chat server bundles from pulling rich editor and markdown peer dependencies by default.

--- a/packages/components/src/components/chat/input/chat-input-layout.test.ts
+++ b/packages/components/src/components/chat/input/chat-input-layout.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, test } from 'bun:test';
 
 const chatInputPath = new URL('./chat-input.svelte', import.meta.url);
-const markdownEditorPath = new URL('../../markdown-editor/markdown-editor.svelte', import.meta.url);
 
 function stripCssComments(source: string): string {
   return source.replace(/\/\*[\s\S]*?\*\//g, '');
@@ -50,31 +49,25 @@ function expectDeclaration(block: string, property: string, value: string): void
 }
 
 describe('ChatInput layout CSS', () => {
-  test('gives the embedded ProseMirror surface non-zero tokenized horizontal padding', async () => {
+  test('gives the native textarea composer non-zero tokenized horizontal padding', async () => {
     const chatInputSource = stripCssComments(await Bun.file(chatInputPath).text());
-    const proseMirrorBlocks = cssBlocks(
-      chatInputSource,
-      '.chat-input-editor-container :global(.ProseMirror)',
-    );
+    const editorBlocks = cssBlocks(chatInputSource, '.chat-input-editor {');
 
     expectDeclaration(
-      proseMirrorBlocks.at(-1) ?? '',
+      editorBlocks.at(-1) ?? '',
       'padding',
       'var(--cinder-space-1) var(--cinder-space-3)',
     );
   });
 
-  test('keeps MarkdownEditor inner layout from forcing the compact composer height', async () => {
+  test('keeps the composer height compact without editor wrapper variables', async () => {
     const chatInputSource = stripCssComments(await Bun.file(chatInputPath).text());
-    const markdownEditorSource = stripCssComments(await Bun.file(markdownEditorPath).text());
 
     const chatContainerBlock =
       cssBlocks(chatInputSource, '.chat-input-editor-container').at(0) ?? '';
-    expectDeclaration(chatContainerBlock, '--editor-min-height', '2.5rem');
-    expectDeclaration(chatContainerBlock, '--editor-source-min-height', 'var(--editor-min-height)');
-
-    const markdownEditorLayoutBlock =
-      cssBlocks(markdownEditorSource, '.markdown-editor-layout').at(0) ?? '';
-    expect(markdownEditorLayoutBlock).not.toContain('min-height');
+    expectDeclaration(chatContainerBlock, 'min-height', '2.5rem');
+    expect(chatInputSource).not.toContain('--editor-min-height');
+    expect(chatInputSource).not.toContain('markdown-editor');
+    expect(chatInputSource).not.toContain('ProseMirror');
   });
 });

--- a/packages/components/src/components/chat/input/chat-input-shortcut-accessibility.test.ts
+++ b/packages/components/src/components/chat/input/chat-input-shortcut-accessibility.test.ts
@@ -1,9 +1,5 @@
 /**
  * Source-contract tests for chat input shortcut accessibility (Slice 2).
- *
- * These tests read the component source rather than mounting it, because
- * ChatInput wraps MarkdownEditor (a Milkdown/ProseMirror bundle) which fights
- * happy-dom. The contract assertions are precise enough to catch regressions.
  */
 import { describe, expect, test } from 'bun:test';
 
@@ -11,15 +7,12 @@ const chatInputSource = await Bun.file(
   new URL('./chat-input.svelte', import.meta.url).pathname,
 ).text();
 
-const markdownEditorSource = await Bun.file(
-  new URL('../../markdown-editor/markdown-editor.svelte', import.meta.url).pathname,
-).text();
-
-const editorRuntimeSource = await Bun.file(
-  new URL('../../../../../editor/src/editor.ts', import.meta.url).pathname,
-).text();
-
 describe('ChatInput — shortcut accessibility', () => {
+  test('does not import the rich MarkdownEditor composer', () => {
+    expect(chatInputSource).not.toContain('MarkdownEditor');
+    expect(chatInputSource).not.toContain('../../markdown-editor/markdown-editor.svelte');
+  });
+
   test('derives a shortcut description id separate from the visible hint id', () => {
     // Must have both hintId and shortcutDescriptionId derived
     expect(chatInputSource).toMatch(/shortcutDescriptionId\s*=\s*\$derived/);
@@ -55,73 +48,15 @@ describe('ChatInput — shortcut accessibility', () => {
     expect(chatInputSource).not.toMatch(/aria-describedby=\{hintId\}/);
   });
 
-  test('MarkdownEditor receives aria-describedby forwarding the shortcut id', () => {
-    // The MarkdownEditor element must receive aria-describedby bound to shortcutDescriptionId
-    expect(chatInputSource).toMatch(/aria-describedby=\{shortcutDescriptionId\}/);
+  test('textarea composer receives label and shortcut description', () => {
+    const textareaMatch = chatInputSource.match(/<textarea[\s\S]*?<\/textarea>/);
+    expect(textareaMatch).not.toBeNull();
+    expect(textareaMatch?.[0]).toMatch(/aria-label=\{composerLabel\}/);
+    expect(textareaMatch?.[0]).toMatch(/aria-describedby=\{shortcutDescriptionId\}/);
   });
 
   test('keycap rule sets an explicit color', () => {
     // .chat-input-hint kbd must have an explicit color declaration
     expect(chatInputSource).toMatch(/\.chat-input-hint\s+kbd\s*\{[^}]*color:/s);
-  });
-});
-
-describe('MarkdownEditor — aria-describedby forwarding', () => {
-  test('extracts aria-describedby from $props() separately from rest', () => {
-    // Must destructure 'aria-describedby' by name
-    expect(markdownEditorSource).toMatch(/'aria-describedby'\s*:\s*ariaDescribedby/);
-  });
-
-  test('preserves root rest-attribute behavior by spreading ...rest on the wrapper', () => {
-    // The wrapper div must still spread ...rest for other native attributes
-    expect(markdownEditorSource).toMatch(/\{\.\.\.rest\}/);
-  });
-
-  test('does not put aria-describedby on the non-interactive wrapper div', () => {
-    // The wrapper div has no ARIA role and is not focusable, so carrying
-    // aria-describedby there is redundant with the focusable surfaces and risks
-    // double-announcement. The attribute belongs only on the textarea and the
-    // ProseMirror view.dom (asserted below).
-    const wrapperOpenTag = markdownEditorSource.match(
-      /<div\s+bind:this=\{wrapperElement\}[\s\S]*?>/,
-    );
-    expect(wrapperOpenTag).not.toBeNull();
-    expect(wrapperOpenTag?.[0]).not.toMatch(/aria-describedby/);
-  });
-
-  test('applies aria-describedby to the source textarea', () => {
-    // The textarea in source mode must receive aria-describedby
-    expect(markdownEditorSource).toMatch(/<textarea[\s\S]*?aria-describedby=\{ariaDescribedby\}/);
-  });
-
-  test('applies aria-describedby to ProseMirror view.dom in WYSIWYG mode', () => {
-    // Must have an effect that sets aria-describedby on view.dom
-    expect(markdownEditorSource).toMatch(/view\.dom/);
-    expect(markdownEditorSource).toMatch(/setAttribute\s*\(\s*['"]aria-describedby['"]/);
-    expect(markdownEditorSource).toMatch(/removeAttribute\s*\(\s*['"]aria-describedby['"]/);
-  });
-
-  test('applies aria-label to ProseMirror view.dom in WYSIWYG mode', () => {
-    // Axe checks the actual contenteditable role=textbox node created by ProseMirror.
-    expect(markdownEditorSource).toMatch(/setAttribute\s*\(\s*['"]aria-label['"]/);
-    expect(markdownEditorSource).toMatch(/accessibleEditorLabel/);
-  });
-
-  test('falls back to the default label when the provided label is only whitespace', () => {
-    expect(markdownEditorSource).toMatch(
-      /label\.trim\(\)\.length\s*>\s*0\s*\?\s*label\.trim\(\)\s*:\s*['"]Markdown editor['"]/,
-    );
-  });
-
-  test('removes aria-describedby from view.dom when prop is undefined', () => {
-    // Must call removeAttribute when ariaDescribedby is falsy
-    expect(markdownEditorSource).toMatch(/removeAttribute\s*\(\s*['"]aria-describedby['"]\s*\)/);
-  });
-});
-
-describe('Editor runtime — aria-label forwarding', () => {
-  test('does not apply whitespace-only aria labels to the initial ProseMirror view', () => {
-    expect(editorRuntimeSource).toMatch(/ariaLabel\.trim\(\)\.length\s*>\s*0/);
-    expect(editorRuntimeSource).toMatch(/resolvedAriaLabel/);
   });
 });

--- a/packages/components/src/components/chat/input/chat-input-shortcut-accessibility.test.ts
+++ b/packages/components/src/components/chat/input/chat-input-shortcut-accessibility.test.ts
@@ -51,7 +51,7 @@ describe('ChatInput — shortcut accessibility', () => {
   test('textarea composer receives label and shortcut description', () => {
     const textareaMatch = chatInputSource.match(/<textarea[\s\S]*?<\/textarea>/);
     expect(textareaMatch).not.toBeNull();
-    expect(textareaMatch?.[0]).toMatch(/aria-label=\{composerLabel\}/);
+    expect(textareaMatch?.[0]).toMatch(/aria-label=\{resolvedComposerLabel\}/);
     expect(textareaMatch?.[0]).toMatch(/aria-describedby=\{shortcutDescriptionId\}/);
   });
 

--- a/packages/components/src/components/chat/input/chat-input.svelte
+++ b/packages/components/src/components/chat/input/chat-input.svelte
@@ -66,7 +66,7 @@
    * ChatInput is a ChatGPT/Claude-style chat composer.
    *
    * Features:
-   * - Wraps MarkdownEditor in lightweight mode (no toolbar/mode toggle)
+   * - Uses a native textarea composer so Chat does not require the rich editor bundle
    * - Keyboard shortcuts: Enter to send, Shift+Enter for newline
    * - IME-aware: composition input (Japanese/Chinese/Korean) won't trigger send
    * - File attachments (images, code, documents) via paste, drag-drop, or file picker
@@ -92,7 +92,6 @@
   import Square from 'lucide-svelte/icons/square';
   import X from 'lucide-svelte/icons/x';
   import Button from '../../button/button.svelte';
-  import MarkdownEditor from '../../markdown-editor/markdown-editor.svelte';
   import { deriveAttachmentKind } from './attachment-kind.js';
   import ChatAttachmentPreview from './chat-attachment-preview.svelte';
 
@@ -146,7 +145,7 @@
 
   // Refs
   let formElement = $state<HTMLFormElement | null>(null);
-  let editorRef: { focus: () => void; getMarkdown: () => string } | undefined;
+  let editorElement = $state<HTMLTextAreaElement | null>(null);
   let fileInputRef = $state<HTMLInputElement | null>(null);
 
   // Internal state
@@ -344,9 +343,9 @@
       return;
     }
 
-    // Get the latest content directly from the editor to avoid debounce lag.
+    // Get the latest content directly from the textarea to avoid bind update lag.
     // The bound `value` may be stale if the user typed and pressed Enter quickly.
-    const latestContent = editorRef?.getMarkdown() ?? value;
+    const latestContent = editorElement?.value ?? value;
     const trimmedContent = latestContent.trim();
 
     // Re-check for whitespace-only after getting latest content
@@ -377,7 +376,7 @@
       }
 
       // Restore focus to editor
-      editorRef?.focus();
+      editorElement?.focus();
       announcer.announce('Message sent');
     } else {
       // In form action mode, sync the bound value with trimmed content
@@ -425,7 +424,7 @@
   // =========================================================================
 
   export function focus(): void {
-    editorRef?.focus();
+    editorElement?.focus();
   }
 
   export function clear(): void {
@@ -495,18 +494,17 @@
 
   <!-- Editor area -->
   <div class="chat-input-editor-container">
-    <MarkdownEditor
+    <textarea
+      bind:this={editorElement}
       id={`${id}-editor`}
       bind:value
-      bind:this={editorRef}
       {placeholder}
-      label={composerLabel}
+      aria-label={composerLabel}
       readonly={disabled || sending}
-      showToolbar={false}
-      showModeToggle={false}
       class="chat-input-editor"
       aria-describedby={shortcutDescriptionId}
-    />
+      rows="1"
+    ></textarea>
   </div>
 
   <!-- Footer with actions -->
@@ -749,53 +747,37 @@
 
   /* Editor container */
   .chat-input-editor-container {
-    --editor-min-height: 2.5rem;
-    --editor-source-min-height: var(--editor-min-height);
+    min-height: 2.5rem;
   }
 
-  .chat-input-editor-container :global(.markdown-editor-wrapper) {
-    min-height: auto;
-    gap: 0;
-  }
-
-  .chat-input-editor-container :global(.markdown-editor) {
+  .chat-input-editor {
+    display: block;
+    width: 100%;
     min-height: 2.5rem;
     max-height: 12rem;
+    padding: var(--cinder-space-1) var(--cinder-space-3);
+    resize: none;
+    field-sizing: content;
     overflow-y: auto;
-    border: none;
-    padding: 0;
+    font: inherit;
+    line-height: var(--cinder-leading-normal);
+    color: var(--cinder-text);
     background: transparent;
+    border: none;
     border-radius: 0;
   }
 
-  .chat-input-editor-container :global(textarea.markdown-editor),
-  .chat-input-editor-container :global(.ProseMirror) {
-    field-sizing: content;
-    max-height: 12rem;
-    overflow-y: auto;
+  .chat-input-editor::placeholder {
+    color: var(--cinder-text-subtle);
   }
 
-  .chat-input-editor-container :global(.markdown-editor:focus-within) {
-    border-color: transparent;
-    box-shadow: none;
+  .chat-input-editor:focus {
     outline: none;
   }
 
-  /* Remove focus ring from the inner textarea - the container handles focus styling */
-  .chat-input-editor-container :global(textarea.markdown-editor:focus) {
-    border-color: transparent;
-    outline: none;
-    box-shadow: none;
-  }
-
-  /* Remove focus ring from ProseMirror when inside chat input */
-  .chat-input-editor-container :global(.ProseMirror:focus) {
-    outline: none;
-  }
-
-  .chat-input-editor-container :global(.ProseMirror) {
-    padding: var(--cinder-space-1) var(--cinder-space-3);
-    min-height: 2.5rem;
+  .chat-input-editor:read-only {
+    color: var(--cinder-text-muted);
+    cursor: not-allowed;
   }
 
   /* Footer */

--- a/packages/components/src/components/chat/input/chat-input.svelte
+++ b/packages/components/src/components/chat/input/chat-input.svelte
@@ -140,6 +140,8 @@
     ...rest
   }: ChatInputProps = $props();
 
+  const resolvedComposerLabel = $derived(composerLabel.trim() || 'Message');
+
   // Derived: show stop button when sending and onstop is provided
   const showStopButton = $derived(sending && onstop !== undefined);
 
@@ -499,7 +501,7 @@
       id={`${id}-editor`}
       bind:value
       {placeholder}
-      aria-label={composerLabel}
+      aria-label={resolvedComposerLabel}
       readonly={disabled || sending}
       class="chat-input-editor"
       aria-describedby={shortcutDescriptionId}

--- a/packages/components/src/components/chat/input/chat-input.svelte
+++ b/packages/components/src/components/chat/input/chat-input.svelte
@@ -502,7 +502,8 @@
       bind:value
       {placeholder}
       aria-label={resolvedComposerLabel}
-      readonly={disabled || sending}
+      {disabled}
+      readonly={sending}
       class="chat-input-editor"
       aria-describedby={shortcutDescriptionId}
       rows="1"
@@ -777,7 +778,8 @@
     outline: none;
   }
 
-  .chat-input-editor:read-only {
+  .chat-input-editor:read-only,
+  .chat-input-editor:disabled {
     color: var(--cinder-text-muted);
     cursor: not-allowed;
   }

--- a/packages/components/src/components/chat/input/chat-input.test.ts
+++ b/packages/components/src/components/chat/input/chat-input.test.ts
@@ -18,4 +18,26 @@ describe('ChatInput', () => {
     const composer = container.querySelector('textarea.chat-input-editor');
     expect(composer?.getAttribute('aria-label')).toBe('Message');
   });
+
+  test('uses native disabled only for the disabled prop', () => {
+    const { container } = render(ChatInput, {
+      id: 'disabled-composer',
+      disabled: true,
+    });
+
+    const composer = container.querySelector<HTMLTextAreaElement>('textarea.chat-input-editor');
+    expect(composer?.disabled).toBe(true);
+    expect(composer?.readOnly).toBe(false);
+  });
+
+  test('keeps the composer read-only but focusable while sending', () => {
+    const { container } = render(ChatInput, {
+      id: 'sending-composer',
+      sending: true,
+    });
+
+    const composer = container.querySelector<HTMLTextAreaElement>('textarea.chat-input-editor');
+    expect(composer?.disabled).toBe(false);
+    expect(composer?.readOnly).toBe(true);
+  });
 });

--- a/packages/components/src/components/chat/input/chat-input.test.ts
+++ b/packages/components/src/components/chat/input/chat-input.test.ts
@@ -1,0 +1,21 @@
+/// <reference lib="dom" />
+import { describe, expect, test } from 'bun:test';
+
+import { setupHappyDom } from '../../../test/happy-dom.ts';
+
+setupHappyDom();
+
+const { render } = await import('@testing-library/svelte');
+const { default: ChatInput } = await import('./chat-input.svelte');
+
+describe('ChatInput', () => {
+  test('uses a non-empty default accessible label for blank composer labels', () => {
+    const { container } = render(ChatInput, {
+      id: 'blank-composer-label',
+      composerLabel: '   ',
+    });
+
+    const composer = container.querySelector('textarea.chat-input-editor');
+    expect(composer?.getAttribute('aria-label')).toBe('Message');
+  });
+});

--- a/packages/components/src/components/chat/message/tool-payload-code.svelte
+++ b/packages/components/src/components/chat/message/tool-payload-code.svelte
@@ -1,33 +1,10 @@
 <script lang="ts" module>
-  // Resolve the markdown rendering module through `@lostgradient/cinder/markdown/rendering`
-  // — the published `@lostgradient/cinder` package re-exports it as a sub-path, while
-  // `@cinder/markdown` itself is not in the published runtime deps. Using
-  // the cinder sub-path keeps this component shippable through the
-  // `svelte` export condition without requiring consumers to install
-  // private workspace packages.
-  type RenderingModule = typeof import('@lostgradient/cinder/markdown/rendering');
-  type Highlighter = Awaited<ReturnType<RenderingModule['getHighlighter']>>;
-
   export type ToolPayloadCodeProps = {
     /** Structured payload text to render. */
     code: string;
     /** Additional CSS class. */
     class?: string;
   };
-
-  let renderingModulePromise: Promise<RenderingModule> | undefined;
-  let highlighterPromise: Promise<Highlighter> | undefined;
-
-  async function getRenderingModule(): Promise<RenderingModule> {
-    renderingModulePromise ??= import('@lostgradient/cinder/markdown/rendering');
-    return renderingModulePromise;
-  }
-
-  async function getJsonHighlighter(): Promise<Highlighter> {
-    const renderingModule = await getRenderingModule();
-    highlighterPromise ??= renderingModule.getHighlighter();
-    return highlighterPromise;
-  }
 </script>
 
 <script lang="ts">
@@ -35,22 +12,10 @@
   import { classNames } from '../../../utilities/class-names.ts';
 
   let { code, class: className }: ToolPayloadCodeProps = $props();
-
-  async function highlightJson(source: string, language: string): Promise<string> {
-    const { isLanguageSupported } = await getRenderingModule();
-    const highlighter = await getJsonHighlighter();
-    const lang = isLanguageSupported(language) ? language : 'json';
-    return highlighter.codeToHtml(source, { lang, theme: 'depict' });
-  }
 </script>
 
 <div class={classNames('tool-payload-code', className)}>
-  <!-- Scoped highlighter: pass this tool-payload's own JSON/`depict`-themed
-       highlighter directly so the tool payload is always highlighted with the
-       depict theme — it is NOT routed through CodeBlock's bundled auto-load
-       default, which would silently change the JSON theme and Shiki load
-       timing. -->
-  <CodeBlock {code} language="json" highlighter={highlightJson} />
+  <CodeBlock {code} language="json" />
 </div>
 
 <style>

--- a/packages/components/src/components/chat/message/tool-payload-code.test.ts
+++ b/packages/components/src/components/chat/message/tool-payload-code.test.ts
@@ -1,12 +1,10 @@
 /**
  * Source-contract regression for the chat tool-payload code block.
  *
- * When `<CinderProvider>` was removed, `tool-payload-code.svelte` had to keep
- * its scoped, `depict`-themed JSON highlighter rather than silently falling
- * through to `<CodeBlock>`'s bundled auto-load default (which would change the
- * JSON theme and Shiki load timing). This test pins that contract: the
- * tool-payload passes its own `highlightJson` highlighter explicitly and does
- * not route through the default.
+ * Chat's server bundle must not import the rich markdown renderer just to make
+ * tool payload JSON readable. `CodeBlock` owns the lazy highlighter boundary,
+ * so the tool payload should delegate to it without its own markdown-rendering
+ * import or explicit highlighter.
  *
  * `ChatMessage`/tool-payload are too heavy to mount usefully in happy-dom for
  * this concern, so we assert against the component source text (matching the
@@ -20,13 +18,15 @@ import { describe, expect, test } from 'bun:test';
 const source = readFileSync(resolve(import.meta.dir, 'tool-payload-code.svelte'), 'utf8');
 
 describe('chat tool-payload code block', () => {
-  test('passes its own explicit highlighter to CodeBlock (not the bundled default)', () => {
-    expect(source).toContain('highlighter={highlightJson}');
-    expect(source).toMatch(/<CodeBlock[^>]*highlighter=\{highlightJson\}/);
+  test('delegates highlighting to CodeBlock without a tool-local highlighter', () => {
+    expect(source).toContain('<CodeBlock {code} language="json" />');
+    expect(source).not.toContain('highlighter={highlightJson}');
+    expect(source).not.toContain('function highlightJson');
   });
 
-  test("highlightJson uses Shiki's depict theme", () => {
-    expect(source).toContain("theme: 'depict'");
+  test('does not import the rich markdown rendering pipeline', () => {
+    expect(source).not.toContain('@lostgradient/cinder/markdown/rendering');
+    expect(source).not.toContain('@cinder/markdown/rendering');
   });
 
   test('does not reintroduce a CinderProvider wrapper', () => {

--- a/packages/components/src/tree-shake.test.ts
+++ b/packages/components/src/tree-shake.test.ts
@@ -1,5 +1,5 @@
 import { mkdir, mkdtemp, rm } from 'node:fs/promises';
-import { join, relative } from 'node:path';
+import { dirname, join, resolve } from 'node:path';
 
 import { describe, expect, test } from 'bun:test';
 
@@ -25,6 +25,31 @@ const FORBIDDEN_CHAT_SERVER_BUNDLE_STRINGS = [
   'remark-gfm',
   'shiki/wasm',
 ] as const;
+
+async function collectRelativeJavaScriptGraph(entrypoint: string): Promise<string[]> {
+  const visited = new Set<string>();
+  const texts: string[] = [];
+  const pending = [entrypoint];
+  const relativeImportPattern =
+    /(?:import\s*(?:[^'"]*?\sfrom\s*)?|export\s*[^'"]*?\sfrom\s*)["'](\.{1,2}\/[^"']+\.js)["']/g;
+
+  while (pending.length > 0) {
+    const filePath = pending.pop();
+    if (filePath === undefined || visited.has(filePath)) continue;
+    visited.add(filePath);
+
+    const text = await Bun.file(filePath).text();
+    texts.push(text);
+
+    for (const match of text.matchAll(relativeImportPattern)) {
+      const specifier = match[1];
+      if (specifier === undefined) continue;
+      pending.push(resolve(dirname(filePath), specifier));
+    }
+  }
+
+  return texts;
+}
 
 describe('tree-shake contract', () => {
   async function createTemporaryFixtureDirectory(prefix: string): Promise<string> {
@@ -71,43 +96,18 @@ describe('tree-shake contract', () => {
   });
 
   test('a minimal cinder/chat SSR bundle does not include editor or markdown rendering peers', async () => {
-    const temporaryDirectory = await createTemporaryFixtureDirectory('cinder-chat-ssr-');
-    const entrypoint = join(temporaryDirectory, 'tree-shake-chat-ssr-fixture.ts');
-    const chatSourceEntrypoint = relative(
-      temporaryDirectory,
-      join(process.cwd(), 'src/components/chat/index.ts'),
-    );
+    const packageManifest = (await Bun.file(join(process.cwd(), 'package.json')).json()) as {
+      exports?: Record<string, { node?: string }>;
+    };
+    const chatNodeExport = packageManifest.exports?.['./chat']?.node;
+    expect(chatNodeExport).toBe('./dist/server/components/chat/index.js');
+    const entrypoint = join(process.cwd(), chatNodeExport ?? '');
 
-    await Bun.write(
-      entrypoint,
-      [
-        `import Chat from ${JSON.stringify(chatSourceEntrypoint)};`,
-        'const componentReference = Chat;',
-        'console.log(typeof componentReference);',
-        '',
-      ].join('\n'),
-    );
+    const outputTexts = await collectRelativeJavaScriptGraph(entrypoint);
+    const bundledText = outputTexts.join('\n');
 
-    try {
-      const result = await Bun.build({
-        entrypoints: [entrypoint],
-        target: 'node',
-        format: 'esm',
-        conditions: ['svelte'],
-        plugins: [sveltePlugin({ generate: 'server' })],
-      });
-
-      expect(result.success).toBe(true);
-
-      const outputTexts = await Promise.all(result.outputs.map(async (output) => output.text()));
-      const bundledText = outputTexts.join('\n');
-
-      for (const forbidden of FORBIDDEN_CHAT_SERVER_BUNDLE_STRINGS) {
-        expect(bundledText).not.toContain(forbidden);
-      }
-    } finally {
-      await Bun.file(entrypoint).delete();
-      await rm(temporaryDirectory, { recursive: true, force: true });
+    for (const forbidden of FORBIDDEN_CHAT_SERVER_BUNDLE_STRINGS) {
+      expect(bundledText).not.toContain(forbidden);
     }
   });
 });

--- a/packages/components/src/tree-shake.test.ts
+++ b/packages/components/src/tree-shake.test.ts
@@ -12,7 +12,7 @@ const FORBIDDEN_BUTTON_BUNDLE_STRINGS = [
   'diff-match-patch',
   'prosemirror',
   '--depict-',
-] as const;
+];
 
 const FORBIDDEN_CHAT_SERVER_BUNDLE_STRINGS = [
   '@cinder/markdown/rendering',
@@ -24,7 +24,56 @@ const FORBIDDEN_CHAT_SERVER_BUNDLE_STRINGS = [
   'rehype-sanitize',
   'remark-gfm',
   'shiki/wasm',
-] as const;
+];
+
+const CHAT_SERVER_TEST_EXTERNALS: string[] = [
+  'svelte',
+  'svelte/*',
+  '@lostgradient/cinder',
+  '@lostgradient/cinder/*',
+  '@modelcontextprotocol/sdk',
+  '@modelcontextprotocol/sdk/*',
+  '@shikijs/rehype',
+  '@milkdown/kit',
+  '@milkdown/kit/*',
+  '@milkdown/prose',
+  '@milkdown/prose/*',
+  'ajv',
+  'ajv/*',
+  'comlink',
+  'diff-match-patch',
+  'hast-util-sanitize',
+  'js-yaml',
+  'prosemirror-inputrules',
+  'prosemirror-model',
+  'prosemirror-state',
+  'prosemirror-view',
+  'rehype-katex',
+  'rehype-sanitize',
+  'rehype-stringify',
+  'remark-gfm',
+  'remark-html',
+  'remark-math',
+  'remark-parse',
+  'remark-rehype',
+  'remark-stringify',
+  'shiki',
+  'unified',
+  'unist-util-remove',
+  'unist-util-visit',
+  'zod',
+  'zod/*',
+];
+
+const serverCssNoopPlugin = {
+  name: 'server-css-noop',
+  setup(build: Bun.PluginBuilder): void {
+    build.onLoad({ filter: /\.css$/ }, () => ({
+      contents: '',
+      loader: 'js',
+    }));
+  },
+};
 
 async function collectRelativeJavaScriptGraph(entrypoint: string): Promise<string[]> {
   const visited = new Set<string>();
@@ -96,18 +145,43 @@ describe('tree-shake contract', () => {
   });
 
   test('a minimal cinder/chat SSR bundle does not include editor or markdown rendering peers', async () => {
+    const temporaryDirectory = await createTemporaryFixtureDirectory('cinder-chat-server-');
     const packageManifest = (await Bun.file(join(process.cwd(), 'package.json')).json()) as {
       exports?: Record<string, { node?: string }>;
     };
     const chatNodeExport = packageManifest.exports?.['./chat']?.node;
     expect(chatNodeExport).toBe('./dist/server/components/chat/index.js');
-    const entrypoint = join(process.cwd(), chatNodeExport ?? '');
 
-    const outputTexts = await collectRelativeJavaScriptGraph(entrypoint);
-    const bundledText = outputTexts.join('\n');
+    try {
+      const result = await Bun.build({
+        entrypoints: [join(process.cwd(), 'src/components/chat/index.ts')],
+        outdir: join(temporaryDirectory, 'dist/server'),
+        root: join(process.cwd(), 'src'),
+        target: 'node',
+        format: 'esm',
+        splitting: true,
+        external: CHAT_SERVER_TEST_EXTERNALS,
+        naming: {
+          entry: '[dir]/[name].[ext]',
+          chunk: '[name]-[hash].[ext]',
+          asset: '[name]-[hash].[ext]',
+        },
+        sourcemap: 'external',
+        minify: false,
+        plugins: [serverCssNoopPlugin, sveltePlugin({ generate: 'server' })],
+      });
 
-    for (const forbidden of FORBIDDEN_CHAT_SERVER_BUNDLE_STRINGS) {
-      expect(bundledText).not.toContain(forbidden);
+      expect(result.success).toBe(true);
+
+      const entrypoint = join(temporaryDirectory, chatNodeExport ?? '');
+      const outputTexts = await collectRelativeJavaScriptGraph(entrypoint);
+      const bundledText = outputTexts.join('\n');
+
+      for (const forbidden of FORBIDDEN_CHAT_SERVER_BUNDLE_STRINGS) {
+        expect(bundledText).not.toContain(forbidden);
+      }
+    } finally {
+      await rm(temporaryDirectory, { recursive: true, force: true });
     }
   });
 });

--- a/packages/components/src/tree-shake.test.ts
+++ b/packages/components/src/tree-shake.test.ts
@@ -1,6 +1,5 @@
-import { mkdtemp, rm } from 'node:fs/promises';
-import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { mkdir, mkdtemp, rm } from 'node:fs/promises';
+import { join, relative } from 'node:path';
 
 import { describe, expect, test } from 'bun:test';
 
@@ -28,9 +27,15 @@ const FORBIDDEN_CHAT_SERVER_BUNDLE_STRINGS = [
 ] as const;
 
 describe('tree-shake contract', () => {
+  async function createTemporaryFixtureDirectory(prefix: string): Promise<string> {
+    const temporaryRoot = join(process.cwd(), '.tmp');
+    await mkdir(temporaryRoot, { recursive: true });
+    return mkdtemp(join(temporaryRoot, prefix));
+  }
+
   test('a cinder/button-only bundle does not include domain-suite dependencies or legacy tokens', async () => {
-    const temporaryDirectory = await mkdtemp(join(tmpdir(), 'cinder-tree-shake-'));
-    const entrypoint = join(import.meta.dir, '.tree-shake-button-fixture.ts');
+    const temporaryDirectory = await createTemporaryFixtureDirectory('cinder-tree-shake-');
+    const entrypoint = join(temporaryDirectory, 'tree-shake-button-fixture.ts');
 
     await Bun.write(
       entrypoint,
@@ -66,13 +71,17 @@ describe('tree-shake contract', () => {
   });
 
   test('a minimal cinder/chat SSR bundle does not include editor or markdown rendering peers', async () => {
-    const temporaryDirectory = await mkdtemp(join(tmpdir(), 'cinder-chat-ssr-'));
-    const entrypoint = join(import.meta.dir, '.tree-shake-chat-ssr-fixture.ts');
+    const temporaryDirectory = await createTemporaryFixtureDirectory('cinder-chat-ssr-');
+    const entrypoint = join(temporaryDirectory, 'tree-shake-chat-ssr-fixture.ts');
+    const chatSourceEntrypoint = relative(
+      temporaryDirectory,
+      join(process.cwd(), 'src/components/chat/index.ts'),
+    );
 
     await Bun.write(
       entrypoint,
       [
-        "import Chat from '@lostgradient/cinder/chat';",
+        `import Chat from ${JSON.stringify(chatSourceEntrypoint)};`,
         'const componentReference = Chat;',
         'console.log(typeof componentReference);',
         '',
@@ -82,7 +91,7 @@ describe('tree-shake contract', () => {
     try {
       const result = await Bun.build({
         entrypoints: [entrypoint],
-        target: 'browser',
+        target: 'node',
         format: 'esm',
         conditions: ['svelte'],
         plugins: [sveltePlugin({ generate: 'server' })],

--- a/packages/components/src/tree-shake.test.ts
+++ b/packages/components/src/tree-shake.test.ts
@@ -5,6 +5,9 @@ import { describe, expect, test } from 'bun:test';
 
 import { sveltePlugin } from '../scripts/svelte-plugin.ts';
 
+const packageRoot = resolve(import.meta.dir, '..');
+const sourceRoot = join(packageRoot, 'src');
+
 const FORBIDDEN_BUTTON_BUNDLE_STRINGS = [
   'shiki',
   'unified',
@@ -102,7 +105,7 @@ async function collectRelativeJavaScriptGraph(entrypoint: string): Promise<strin
 
 describe('tree-shake contract', () => {
   async function createTemporaryFixtureDirectory(prefix: string): Promise<string> {
-    const temporaryRoot = join(process.cwd(), '.tmp');
+    const temporaryRoot = join(packageRoot, '.tmp');
     await mkdir(temporaryRoot, { recursive: true });
     return mkdtemp(join(temporaryRoot, prefix));
   }
@@ -146,7 +149,7 @@ describe('tree-shake contract', () => {
 
   test('a minimal cinder/chat SSR bundle does not include editor or markdown rendering peers', async () => {
     const temporaryDirectory = await createTemporaryFixtureDirectory('cinder-chat-server-');
-    const packageManifest = (await Bun.file(join(process.cwd(), 'package.json')).json()) as {
+    const packageManifest = (await Bun.file(join(packageRoot, 'package.json')).json()) as {
       exports?: Record<string, { node?: string }>;
     };
     const chatNodeExport = packageManifest.exports?.['./chat']?.node;
@@ -154,9 +157,9 @@ describe('tree-shake contract', () => {
 
     try {
       const result = await Bun.build({
-        entrypoints: [join(process.cwd(), 'src/components/chat/index.ts')],
+        entrypoints: [join(sourceRoot, 'components/chat/index.ts')],
         outdir: join(temporaryDirectory, 'dist/server'),
-        root: join(process.cwd(), 'src'),
+        root: sourceRoot,
         target: 'node',
         format: 'esm',
         splitting: true,

--- a/packages/components/src/tree-shake.test.ts
+++ b/packages/components/src/tree-shake.test.ts
@@ -15,6 +15,18 @@ const FORBIDDEN_BUTTON_BUNDLE_STRINGS = [
   '--depict-',
 ] as const;
 
+const FORBIDDEN_CHAT_SERVER_BUNDLE_STRINGS = [
+  '@cinder/markdown/rendering',
+  '@lostgradient/cinder/markdown/rendering',
+  '@milkdown/kit',
+  'comlink',
+  'hast-util-sanitize',
+  'prosemirror',
+  'rehype-sanitize',
+  'remark-gfm',
+  'shiki/wasm',
+] as const;
+
 describe('tree-shake contract', () => {
   test('a cinder/button-only bundle does not include domain-suite dependencies or legacy tokens', async () => {
     const temporaryDirectory = await mkdtemp(join(tmpdir(), 'cinder-tree-shake-'));
@@ -45,6 +57,43 @@ describe('tree-shake contract', () => {
       const bundledText = outputTexts.join('\n');
 
       for (const forbidden of FORBIDDEN_BUTTON_BUNDLE_STRINGS) {
+        expect(bundledText).not.toContain(forbidden);
+      }
+    } finally {
+      await Bun.file(entrypoint).delete();
+      await rm(temporaryDirectory, { recursive: true, force: true });
+    }
+  });
+
+  test('a minimal cinder/chat SSR bundle does not include editor or markdown rendering peers', async () => {
+    const temporaryDirectory = await mkdtemp(join(tmpdir(), 'cinder-chat-ssr-'));
+    const entrypoint = join(import.meta.dir, '.tree-shake-chat-ssr-fixture.ts');
+
+    await Bun.write(
+      entrypoint,
+      [
+        "import Chat from '@lostgradient/cinder/chat';",
+        'const componentReference = Chat;',
+        'console.log(typeof componentReference);',
+        '',
+      ].join('\n'),
+    );
+
+    try {
+      const result = await Bun.build({
+        entrypoints: [entrypoint],
+        target: 'browser',
+        format: 'esm',
+        conditions: ['svelte'],
+        plugins: [sveltePlugin({ generate: 'server' })],
+      });
+
+      expect(result.success).toBe(true);
+
+      const outputTexts = await Promise.all(result.outputs.map(async (output) => output.text()));
+      const bundledText = outputTexts.join('\n');
+
+      for (const forbidden of FORBIDDEN_CHAT_SERVER_BUNDLE_STRINGS) {
         expect(bundledText).not.toContain(forbidden);
       }
     } finally {

--- a/packages/testing/tests/chat-harness.playwright.ts
+++ b/packages/testing/tests/chat-harness.playwright.ts
@@ -89,15 +89,8 @@ test.describe('chat harness — submit and reply', () => {
   test('a composer submit appends a user message and an auto-reply lands', async ({ browser }) => {
     const { harness, dispose } = await openHarness(browser);
     try {
-      // The composer is a Milkdown/ProseMirror contenteditable. ProseMirror only
-      // updates its document model from REAL key events, so use
-      // pressSequentially (per-key keydown/input) — execCommand/keyboard.type do
-      // not reliably reach the editor model. Submit via the send button.
-      const editor = harness
-        .locator('.chat-input-editor [contenteditable], .chat-input-editor [role="textbox"]')
-        .first();
-      await editor.click();
-      await editor.pressSequentially('What is alpha?');
+      const composer = harness.locator('textarea.chat-input-editor').first();
+      await composer.fill('What is alpha?');
       await harness.locator('.chat-input-send').click();
 
       await expect(harness.locator('[data-role="user"]')).toContainText('What is alpha?');

--- a/packages/testing/tests/domain-focus-rings.playwright.ts
+++ b/packages/testing/tests/domain-focus-rings.playwright.ts
@@ -161,11 +161,8 @@ async function seedDenseChatSurface(harness: Locator): Promise<void> {
   await expect.poll(async () => timeline.evaluate((element) => element.scrollTop)).toBe(0);
   await expect(harness.locator('.chat-jump-button')).toBeVisible({ timeout: 5_000 });
 
-  const editor = harness
-    .locator('.chat-input-editor [contenteditable], .chat-input-editor [role="textbox"]')
-    .first();
-  await editor.click();
-  await editor.pressSequentially('Keyboard focus ring check');
+  const composer = harness.locator('textarea.chat-input-editor').first();
+  await composer.fill('Keyboard focus ring check');
   await expect(harness.locator('.chat-input-send')).toBeEnabled();
 }
 
@@ -181,14 +178,12 @@ test.describe('domain focus rings -- chat harness', () => {
       const messageCopy = harness.locator('.chat-message-action-button.chat-message-copy').first();
       const jumpToLatest = harness.locator('.chat-jump-button');
       const sendButton = harness.locator('.chat-input-send');
-      const editor = harness
-        .locator('.chat-input-editor [contenteditable], .chat-input-editor [role="textbox"]')
-        .first();
+      const composer = harness.locator('textarea.chat-input-editor').first();
 
       await expect(timeline).toBeVisible();
       await expect(messageCopy).toBeAttached();
       await expect(jumpToLatest).toBeVisible();
-      await expect(editor).toBeVisible();
+      await expect(composer).toBeVisible();
       await expect(sendButton).toBeEnabled();
 
       await blurToBody(page);
@@ -201,12 +196,12 @@ test.describe('domain focus rings -- chat harness', () => {
       await expect(messageCopy).toBeFocused();
       await assertSharedOuterRing(messageCopy, 'message copy action');
 
-      await editor.click();
+      await composer.click();
       await tabUntilFocused(page, jumpToLatest, 'jump to latest', 8, 'backward');
       await expect(jumpToLatest).toBeFocused();
       await assertSharedOuterRing(jumpToLatest, 'jump to latest');
 
-      await editor.click();
+      await composer.click();
       await tabUntilFocused(page, sendButton, 'send button', 8);
       await expect(sendButton).toBeFocused();
       await assertSharedOuterRing(sendButton, 'send button');

--- a/packages/testing/tests/editors-complex-residual.playwright.ts
+++ b/packages/testing/tests/editors-complex-residual.playwright.ts
@@ -192,7 +192,7 @@ test.describe('chat input shortcut', () => {
     }
   });
 
-  test('editor and send button both expose shortcut description via aria-describedby', async ({
+  test('composer and send button both expose shortcut description via aria-describedby', async ({
     page,
   }) => {
     // A11y wiring is viewport-independent; use the default desktop context so
@@ -212,17 +212,14 @@ test.describe('chat input shortcut', () => {
           .join(' ');
       });
 
-    // The focusable WYSIWYG surface (ProseMirror contenteditable / textbox).
-    const editorSurface = page
-      .locator('.chat-input-editor [contenteditable], .chat-input-editor [role="textbox"]')
-      .first();
-    await expect(editorSurface).toBeVisible();
-    await editorSurface.focus();
+    const composer = page.locator('textarea.chat-input-editor').first();
+    await expect(composer).toBeVisible();
+    await composer.focus();
 
-    const editorDescribedby = await describedbyText(editorSurface);
-    expect(editorDescribedby).toBeTruthy();
-    expect(editorDescribedby).toMatch(/Enter/);
-    expect(editorDescribedby).toMatch(/Shift\s*\+?\s*Enter/i);
+    const composerDescribedby = await describedbyText(composer);
+    expect(composerDescribedby).toBeTruthy();
+    expect(composerDescribedby).toMatch(/Enter/);
+    expect(composerDescribedby).toMatch(/Shift\s*\+?\s*Enter/i);
 
     // The send button references the same shortcut description.
     const sendButton = page


### PR DESCRIPTION
## Summary
- keep ChatInput on a native textarea by default so chat SSR paths do not pull editor peers
- lazy-delegate rich tool payload highlighting through CodeBlock instead of static server bundle imports
- add bundle boundary regression coverage for the chat server path
- add a patch changeset for the public package

Closes #654

## Verification
- focused chat input and tool payload tests
- bundle boundary regression test
- bun run --filter=@lostgradient/cinder typecheck
- bun run --filter=@lostgradient/cinder validate:consumer
- pre-commit checks
- pre-push scoped validation

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Composer behavior shifts from rich markdown to plain text (intentional for bundle size); sending/disabled/read-only and a11y contracts are covered by new tests but UX for markdown-in-composer changes.
> 
> **Overview**
> **Chat composer** no longer wraps `MarkdownEditor`; it uses a native `textarea` with the same Enter/Shift+Enter behavior, IME handling, and shortcut `aria-describedby` wiring. Sending uses `readOnly` (not `disabled`) so the field stays focusable; blank `composerLabel` falls back to **Message**.
> 
> **Tool payload JSON** drops the local `@lostgradient/cinder/markdown/rendering` highlighter and relies on `CodeBlock`'s lazy default instead, avoiding a static server import of the rich pipeline.
> 
> **Regression coverage** adds happy-dom `ChatInput` tests, source-contract updates for layout/a11y/tool-payload, a **tree-shake** test that builds a minimal `@lostgradient/cinder/chat` SSR graph and forbids editor/markdown peer strings, and Playwright selectors switched from ProseMirror to `textarea.chat-input-editor`. Patch changeset for `@lostgradient/cinder`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0a1c377e93c480d22f283258d2613831b0057c07. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->