### PR TITLE
Fix Steps skipped state support

### DIFF
--- a/.changeset/steps-skipped-state.md
+++ b/.changeset/steps-skipped-state.md
@@ -1,0 +1,5 @@
+---
+'@lostgradient/cinder': patch
+---
+
+Add skipped state support to Steps items.

--- a/packages/components/components.json
+++ b/packages/components/components.json
@@ -5066,7 +5066,7 @@
       "exportName": "Steps",
       "category": "navigation",
       "status": "stable",
-      "purpose": "Ordered progress indicator that visualizes a fixed sequence of steps with completed, current, and upcoming states.",
+      "purpose": "Ordered progress indicator that visualizes a fixed sequence of steps with completed, current, skipped, and upcoming states.",
       "tags": ["navigation", "progress"],
       "useWhen": [
         "Walking the user through a multi-step wizard or checkout flow with strict ordering.",

--- a/packages/components/src/components/steps/README.md
+++ b/packages/components/src/components/steps/README.md
@@ -41,6 +41,22 @@ SPA routing interception, analytics, or confirmation). For the current step,
 `aria-current="step"` moves onto the interactive element; static steps keep it
 on the list item.
 
+## Skipped steps
+
+By default, state is derived from `currentStep`: earlier steps are complete,
+the matching index is current, and later steps are upcoming. Set
+`state: 'skipped'` on a `StepItem` when a flow advances past a step without
+completing it. Skipped steps keep their numeric marker, use neutral styling,
+and announce the `skippedLabel` text instead of the completed label.
+
+```svelte
+const steps = [
+  { id: 'account', label: 'Account' },
+  { id: 'profile', label: 'Profile', state: 'skipped' },
+  { id: 'review', label: 'Review' },
+];
+```
+
 ## Props
 
 <!-- generated:props:start -->
@@ -52,6 +68,7 @@ on the list item.
 | `currentStep`    | `number`                       | yes      | —       | Zero-based index of the active step. Steps with index < currentStep are "completed". Pass `steps.length` to mark every step as complete (terminal "done" state). |
 | `label`          | `string`                       | no       | —       | Accessible name for the wrapping nav landmark. Defaults to 'Progress'.                                                                                           |
 | `orientation`    | `"horizontal"` \| `"vertical"` | no       | —       | Layout direction. Defaults to 'horizontal'.                                                                                                                      |
+| `skippedLabel`   | `string`                       | no       | —       | Visually-hidden text prepended to skipped steps so screen readers announce state + label. Defaults to 'Skipped'.                                                 |
 | `steps`          | `(opaque)`                     | yes      | —       | Ordered list of step entries from first to last. Not expressible in JSON Schema; see the component types for the signature.                                      |
 
 <!-- generated:props:end -->

--- a/packages/components/src/components/steps/index.ts
+++ b/packages/components/src/components/steps/index.ts
@@ -2,5 +2,5 @@ import './steps.css';
 import Steps from './steps.svelte';
 
 export default Steps;
-export type { StepItem, StepsOrientation, StepsProps } from './steps.types.ts';
+export type { StepItem, StepItemState, StepsOrientation, StepsProps } from './steps.types.ts';
 export { Steps };

--- a/packages/components/src/components/steps/steps.a11y.md
+++ b/packages/components/src/components/steps/steps.a11y.md
@@ -29,13 +29,15 @@ Completed steps render a visually-hidden `<span class="cinder-steps__sr-only">` 
 
 The `completedLabel` prop (default `'Completed'`) lets consuming teams localize or override this text without forking the component.
 
+Skipped steps use the same hidden-text placement with `skippedLabel` (default `'Skipped'`). They keep their numeric marker and do not render the completed checkmark or completed label, so a past-but-incomplete step is not announced as finished.
+
 **Current step:** state is conveyed solely by `aria-current="step"` on the `<li>`. No additional visually-hidden text is added to avoid duplicate announcements.
 
 **Upcoming steps:** no state text — the visible label alone is sufficient.
 
-## `completedLabel` contract
+## State label contract
 
-The prop value is rendered verbatim with no punctuation added by the component. If the caller wants a trailing comma for pause cuing (e.g., "Completed, Set up profile"), they should pass `completedLabel="Completed,"`.
+The `completedLabel` and `skippedLabel` prop values are rendered verbatim with no punctuation added by the component. If the caller wants a trailing comma for pause cuing (e.g., "Completed, Set up profile"), they should pass `completedLabel="Completed,"`.
 
 ## Default `label` value
 

--- a/packages/components/src/components/steps/steps.css
+++ b/packages/components/src/components/steps/steps.css
@@ -203,6 +203,12 @@
     }
   }
 
+  [data-cinder-state='skipped'] .cinder-steps__marker {
+    background: transparent;
+    box-shadow: inset 0 0 0 1px var(--cinder-border-muted);
+    color: var(--cinder-text-muted);
+  }
+
   [data-cinder-state='upcoming'] .cinder-steps__marker {
     color: var(--cinder-text-muted);
   }
@@ -301,6 +307,7 @@
     font-weight: var(--cinder-font-semibold);
   }
 
+  [data-cinder-state='skipped'] .cinder-steps__label,
   [data-cinder-state='upcoming'] .cinder-steps__label {
     color: var(--cinder-text-muted);
   }
@@ -326,7 +333,7 @@
   }
 
   /* ----------------------------------------
- * Visually-hidden text for completed steps
+ * Visually-hidden text for completed and skipped steps
  * ---------------------------------------- */
 
   .cinder-steps__sr-only,

--- a/packages/components/src/components/steps/steps.css
+++ b/packages/components/src/components/steps/steps.css
@@ -204,9 +204,16 @@
   }
 
   [data-cinder-state='skipped'] .cinder-steps__marker {
-    background: transparent;
+    background: var(--cinder-surface);
     box-shadow: inset 0 0 0 1px var(--cinder-border-muted);
     color: var(--cinder-text-muted);
+  }
+
+  @media (forced-colors: active) {
+    [data-cinder-state='skipped'] .cinder-steps__marker {
+      outline: 1px solid ButtonText;
+      box-shadow: none;
+    }
   }
 
   [data-cinder-state='upcoming'] .cinder-steps__marker {

--- a/packages/components/src/components/steps/steps.examples.json
+++ b/packages/components/src/components/steps/steps.examples.json
@@ -16,6 +16,12 @@
       "code": "<script lang=\"ts\">\n  import { Steps } from '@lostgradient/cinder/steps';\n  import type { StepItem } from '@lostgradient/cinder/steps';\n\n  let current = $state(1);\n\n  const steps: StepItem[] = [\n    { id: 'account', label: 'Account', description: 'Create your login', href: '#account' },\n    {\n      id: 'profile',\n      label: 'Profile',\n      description: 'Jump back to edit',\n      onclick: () => (current = 1),\n    },\n    { id: 'review', label: 'Review', description: 'Confirm and submit' },\n  ];\n</script>\n\n<Steps {steps} currentStep={current} label=\"Onboarding\" />\n"
     },
     {
+      "id": "skipped",
+      "title": "Skipped step",
+      "description": "Use `state: \"skipped\"` when a flow advances past a step without completing it.",
+      "code": "<script lang=\"ts\">\n  import { Steps } from '@lostgradient/cinder/steps';\n  import type { StepItem } from '@lostgradient/cinder/steps';\n\n  const steps: StepItem[] = [\n    { id: 'account', label: 'Account', description: 'Create your login' },\n    {\n      id: 'profile',\n      label: 'Profile',\n      description: 'Optional details were skipped',\n      state: 'skipped',\n    },\n    { id: 'review', label: 'Review', description: 'Confirm and submit' },\n  ];\n</script>\n\n<Steps {steps} currentStep={2} label=\"Onboarding\" />\n"
+    },
+    {
       "id": "vertical",
       "title": "Vertical orientation",
       "description": "Set `orientation=\"vertical\"` to stack the steps top-to-bottom with the connector running down the side — useful in narrow side panels or wizards.",

--- a/packages/components/src/components/steps/steps.schema.json
+++ b/packages/components/src/components/steps/steps.schema.json
@@ -18,6 +18,10 @@
       "type": "string",
       "description": "Visually-hidden text prepended to completed steps so screen readers\nannounce state + label. Defaults to 'Completed'."
     },
+    "skippedLabel": {
+      "type": "string",
+      "description": "Visually-hidden text prepended to skipped steps so screen readers announce\nstate + label. Defaults to 'Skipped'."
+    },
     "class": {
       "type": "string",
       "description": "Additional class names merged with `.cinder-steps`."

--- a/packages/components/src/components/steps/steps.schema.ts
+++ b/packages/components/src/components/steps/steps.schema.ts
@@ -22,6 +22,11 @@ const schema = {
       description:
         "Visually-hidden text prepended to completed steps so screen readers\nannounce state + label. Defaults to 'Completed'.",
     },
+    skippedLabel: {
+      type: 'string',
+      description:
+        "Visually-hidden text prepended to skipped steps so screen readers announce\nstate + label. Defaults to 'Skipped'.",
+    },
     class: {
       type: 'string',
       description: 'Additional class names merged with `.cinder-steps`.',

--- a/packages/components/src/components/steps/steps.svelte
+++ b/packages/components/src/components/steps/steps.svelte
@@ -3,7 +3,7 @@
    * @cinder
    * @category navigation
    * @status stable
-   * @purpose Ordered progress indicator that visualizes a fixed sequence of steps with completed, current, and upcoming states.
+   * @purpose Ordered progress indicator that visualizes a fixed sequence of steps with completed, current, skipped, and upcoming states.
    * @tag navigation
    * @tag progress
    * @useWhen Walking the user through a multi-step wizard or checkout flow with strict ordering.
@@ -12,11 +12,11 @@
    * @avoidWhen Showing ancestor hierarchy of the current page — use breadcrumbs instead.
    * @related tabs, breadcrumbs, pagination
    */
-  export type { StepItem, StepsOrientation, StepsProps } from './steps.types.ts';
+  export type { StepItem, StepItemState, StepsOrientation, StepsProps } from './steps.types.ts';
 </script>
 
 <script lang="ts">
-  import type { StepsProps } from './steps.types.ts';
+  import type { StepItemState, StepsProps } from './steps.types.ts';
   import { classNames } from '../../utilities/class-names.ts';
   import Check from 'lucide-svelte/icons/check';
 
@@ -26,6 +26,7 @@
     orientation = 'horizontal',
     label = 'Progress',
     completedLabel = 'Completed',
+    skippedLabel = 'Skipped',
     class: className,
   }: StepsProps = $props();
 
@@ -33,10 +34,9 @@
     steps.length === 0 ? undefined : Math.max(0, Math.min(steps.length, currentStep)),
   );
 
-  type StepState = 'complete' | 'current' | 'upcoming';
-
-  const stepStates = $derived<StepState[]>(
-    steps.map((_, index) => {
+  const stepStates = $derived<StepItemState[]>(
+    steps.map((step, index) => {
+      if (step.state !== undefined) return step.state;
       if (clampedCurrent === undefined) return 'upcoming';
       if (index < clampedCurrent) return 'complete';
       if (index === clampedCurrent) return 'current';
@@ -52,7 +52,7 @@
 >
   <ol class="cinder-steps__list">
     {#each steps as step, index (step.id)}
-      {@const state = stepStates[index]}
+      {@const state = stepStates[index] ?? 'upcoming'}
       {@const isCurrent = state === 'current'}
       {@const isComplete = state === 'complete'}
       {@const hasHref = step.href !== undefined}
@@ -78,7 +78,7 @@
             onclick={step.onclick}
             aria-current={isCurrent ? 'step' : undefined}
           >
-            {@render stepBody(stepLabel, stepDescription, isComplete, completedLabel)}
+            {@render stepBody(stepLabel, stepDescription, state, completedLabel, skippedLabel)}
           </a>
         {:else if step.onclick}
           <button
@@ -87,11 +87,11 @@
             onclick={step.onclick}
             aria-current={isCurrent ? 'step' : undefined}
           >
-            {@render stepBody(stepLabel, stepDescription, isComplete, completedLabel)}
+            {@render stepBody(stepLabel, stepDescription, state, completedLabel, skippedLabel)}
           </button>
         {:else}
           <span class="cinder-steps__body">
-            {@render stepBody(stepLabel, stepDescription, isComplete, completedLabel)}
+            {@render stepBody(stepLabel, stepDescription, state, completedLabel, skippedLabel)}
           </span>
         {/if}
         {#if index < steps.length - 1}
@@ -109,12 +109,16 @@
 {#snippet stepBody(
   bodyLabel: string,
   bodyDescription: string | undefined,
-  bodyIsComplete: boolean,
+  bodyState: StepItemState,
   bodyCompletedLabel: string,
+  bodySkippedLabel: string,
 )}
   <span class="cinder-steps__body-content">
-    {#if bodyIsComplete}
+    {#if bodyState === 'complete'}
       <span class="cinder-steps__sr-only">{bodyCompletedLabel}</span>
+      <span class="cinder-steps__sr-only-separator"> </span>
+    {:else if bodyState === 'skipped'}
+      <span class="cinder-steps__sr-only">{bodySkippedLabel}</span>
       <span class="cinder-steps__sr-only-separator"> </span>
     {/if}
     <span class="cinder-steps__label">{bodyLabel}</span>

--- a/packages/components/src/components/steps/steps.svelte
+++ b/packages/components/src/components/steps/steps.svelte
@@ -36,10 +36,10 @@
 
   const stepStates = $derived<StepItemState[]>(
     steps.map((step, index) => {
-      if (step.state === 'skipped') return 'skipped';
       if (clampedCurrent === undefined) return 'upcoming';
-      if (index < clampedCurrent) return 'complete';
       if (index === clampedCurrent) return 'current';
+      if (step.state === 'skipped' && index < clampedCurrent) return 'skipped';
+      if (index < clampedCurrent) return 'complete';
       return 'upcoming';
     }),
   );

--- a/packages/components/src/components/steps/steps.svelte
+++ b/packages/components/src/components/steps/steps.svelte
@@ -36,7 +36,7 @@
 
   const stepStates = $derived<StepItemState[]>(
     steps.map((step, index) => {
-      if (step.state !== undefined) return step.state;
+      if (step.state === 'skipped') return 'skipped';
       if (clampedCurrent === undefined) return 'upcoming';
       if (index < clampedCurrent) return 'complete';
       if (index === clampedCurrent) return 'current';
@@ -55,6 +55,8 @@
       {@const state = stepStates[index] ?? 'upcoming'}
       {@const isCurrent = state === 'current'}
       {@const isComplete = state === 'complete'}
+      {@const connectorState =
+        clampedCurrent !== undefined && index < clampedCurrent ? 'complete' : 'upcoming'}
       {@const hasHref = step.href !== undefined}
       {@const isInteractive = hasHref || step.onclick !== undefined}
       {@const stepLabel = step.label}
@@ -97,7 +99,7 @@
         {#if index < steps.length - 1}
           <span
             class="cinder-steps__connector"
-            data-cinder-state={isComplete ? 'complete' : 'upcoming'}
+            data-cinder-state={connectorState}
             aria-hidden="true"
           ></span>
         {/if}

--- a/packages/components/src/components/steps/steps.test.ts
+++ b/packages/components/src/components/steps/steps.test.ts
@@ -113,6 +113,31 @@ describe('Steps', () => {
     expect(firstItem?.textContent).toMatch(/Finished\s+Set up profile/);
   });
 
+  test('explicit skipped steps do not inherit completed styling or completed accessible text', () => {
+    const { container } = render(Steps, {
+      steps: [
+        { id: 'a', label: 'Account' },
+        { id: 'b', label: 'Optional profile', state: 'skipped' },
+        { id: 'c', label: 'Review' },
+      ],
+      currentStep: 2,
+      skippedLabel: 'Skipped',
+    });
+
+    const items = Array.from(container.querySelectorAll('.cinder-steps__item'));
+    expect(items.map((item) => item.getAttribute('data-cinder-state'))).toEqual([
+      'complete',
+      'skipped',
+      'current',
+    ]);
+
+    const skipped = items[1];
+    expect(skipped?.querySelector('.cinder-steps__check')).toBeNull();
+    expect(skipped?.querySelector('.cinder-steps__index')?.textContent).toBe('2');
+    expect(skipped?.textContent).not.toContain('Completed');
+    expect(skipped?.textContent).toMatch(/Skipped\s+Optional profile/);
+  });
+
   test('orientation prop drives layout via data-cinder-orientation', () => {
     const { container: hContainer } = render(Steps, {
       steps: defaultSteps,

--- a/packages/components/src/components/steps/steps.test.ts
+++ b/packages/components/src/components/steps/steps.test.ts
@@ -138,6 +138,43 @@ describe('Steps', () => {
     expect(skipped?.textContent).toMatch(/Skipped\s+Optional profile/);
   });
 
+  test('state override only honors skipped so currentStep remains authoritative', () => {
+    const { container } = render(Steps, {
+      steps: [
+        { id: 'a', label: 'Account' },
+        { id: 'b', label: 'Profile', state: 'current' },
+        { id: 'c', label: 'Review' },
+      ],
+      currentStep: 2,
+    });
+
+    const items = Array.from(container.querySelectorAll('.cinder-steps__item'));
+    expect(items.map((item) => item.getAttribute('data-cinder-state'))).toEqual([
+      'complete',
+      'complete',
+      'current',
+    ]);
+    expect(container.querySelectorAll('[aria-current="step"]').length).toBe(1);
+    expect(container.querySelector('[aria-current="step"]')?.textContent).toContain('Review');
+  });
+
+  test('connectors behind skipped past steps still show completed progress', () => {
+    const { container } = render(Steps, {
+      steps: [
+        { id: 'a', label: 'Account' },
+        { id: 'b', label: 'Optional profile', state: 'skipped' },
+        { id: 'c', label: 'Review' },
+      ],
+      currentStep: 2,
+    });
+
+    const connectors = Array.from(container.querySelectorAll('.cinder-steps__connector'));
+    expect(connectors.map((connector) => connector.getAttribute('data-cinder-state'))).toEqual([
+      'complete',
+      'complete',
+    ]);
+  });
+
   test('orientation prop drives layout via data-cinder-orientation', () => {
     const { container: hContainer } = render(Steps, {
       steps: defaultSteps,
@@ -503,6 +540,20 @@ describe('Steps — horizontal layout geometry (CSS contract)', () => {
     );
     expect(connector).toBeLessThan(interactiveBody);
     expect(interactiveBody).toBeLessThan(marker);
+  });
+
+  test('skipped marker uses an opaque surface and forced-colors outline', () => {
+    const skippedMarkerBody = ruleBody(
+      /\[data-cinder-state='skipped'\]\s*\.cinder-steps__marker\s*\{/,
+    );
+    expect(skippedMarkerBody).toMatch(/background:\s*var\(--cinder-surface\);/);
+    expect(skippedMarkerBody).toMatch(
+      /box-shadow:\s*inset 0 0 0 1px var\(--cinder-border-muted\);/,
+    );
+
+    expect(stepsCss).toMatch(
+      /@media \(forced-colors: active\)[\s\S]*?\[data-cinder-state='skipped'\]\s*\.cinder-steps__marker\s*\{[\s\S]*?outline:\s*1px solid ButtonText;[\s\S]*?box-shadow:\s*none;/,
+    );
   });
 });
 

--- a/packages/components/src/components/steps/steps.test.ts
+++ b/packages/components/src/components/steps/steps.test.ts
@@ -138,7 +138,7 @@ describe('Steps', () => {
     expect(skipped?.textContent).toMatch(/Skipped\s+Optional profile/);
   });
 
-  test('state override only honors skipped after currentStep marks past/current states', () => {
+  test('only honors skipped overrides before currentStep and ignores active or future overrides', () => {
     const { container } = render(Steps, {
       steps: [
         { id: 'a', label: 'Account' },

--- a/packages/components/src/components/steps/steps.test.ts
+++ b/packages/components/src/components/steps/steps.test.ts
@@ -138,12 +138,13 @@ describe('Steps', () => {
     expect(skipped?.textContent).toMatch(/Skipped\s+Optional profile/);
   });
 
-  test('state override only honors skipped so currentStep remains authoritative', () => {
+  test('state override only honors skipped after currentStep marks past/current states', () => {
     const { container } = render(Steps, {
       steps: [
         { id: 'a', label: 'Account' },
-        { id: 'b', label: 'Profile', state: 'current' },
-        { id: 'c', label: 'Review' },
+        { id: 'b', label: 'Profile', state: 'skipped' },
+        { id: 'c', label: 'Review', state: 'skipped' },
+        { id: 'd', label: 'Confirm', state: 'current' as never },
       ],
       currentStep: 2,
     });
@@ -151,8 +152,9 @@ describe('Steps', () => {
     const items = Array.from(container.querySelectorAll('.cinder-steps__item'));
     expect(items.map((item) => item.getAttribute('data-cinder-state'))).toEqual([
       'complete',
-      'complete',
+      'skipped',
       'current',
+      'upcoming',
     ]);
     expect(container.querySelectorAll('[aria-current="step"]').length).toBe(1);
     expect(container.querySelector('[aria-current="step"]')?.textContent).toContain('Review');

--- a/packages/components/src/components/steps/steps.types.ts
+++ b/packages/components/src/components/steps/steps.types.ts
@@ -12,7 +12,7 @@ export type StepItem = {
    * `currentStep`. Use `skipped` for a past step that was advanced past without
    * completing.
    */
-  state?: StepItemState;
+  state?: 'skipped';
   /**
    * When set, the step body renders as a link (`<a>`) to this href. The marker
    * and connector stay decorative; only the body (label + description) is the

--- a/packages/components/src/components/steps/steps.types.ts
+++ b/packages/components/src/components/steps/steps.types.ts
@@ -1,4 +1,5 @@
 export type StepsOrientation = 'horizontal' | 'vertical';
+export type StepItemState = 'complete' | 'current' | 'upcoming' | 'skipped';
 export type StepItem = {
   /** Stable identifier used as the keyed-each key. Must be unique. */
   id: string;
@@ -6,6 +7,12 @@ export type StepItem = {
   label: string;
   /** Optional secondary text shown beneath the label. */
   description?: string;
+  /**
+   * Optional state override for this step. When omitted, state is derived from
+   * `currentStep`. Use `skipped` for a past step that was advanced past without
+   * completing.
+   */
+  state?: StepItemState;
   /**
    * When set, the step body renders as a link (`<a>`) to this href. The marker
    * and connector stay decorative; only the body (label + description) is the
@@ -37,6 +44,11 @@ export type StepsProps = {
    * announce state + label. Defaults to 'Completed'.
    */
   completedLabel?: string;
+  /**
+   * Visually-hidden text prepended to skipped steps so screen readers announce
+   * state + label. Defaults to 'Skipped'.
+   */
+  skippedLabel?: string;
   /** Additional class names merged with `.cinder-steps`. */
   class?: string;
 };

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -836,7 +836,12 @@ export { default as Sparkbar } from './components/sparkbar/index.ts';
 export type { SparkbarProps, SparkbarSize, SparkbarVariant } from './components/sparkbar/index.ts';
 
 export { default as Steps } from './components/steps/index.ts';
-export type { StepItem, StepsOrientation, StepsProps } from './components/steps/index.ts';
+export type {
+  StepItem,
+  StepItemState,
+  StepsOrientation,
+  StepsProps,
+} from './components/steps/index.ts';
 
 export { default as Stat } from './components/stat/index.ts';
 export type { StatChange, StatChangeDirection, StatProps } from './components/stat/index.ts';

--- a/packages/playground/src/examples/steps/skipped.example.svelte
+++ b/packages/playground/src/examples/steps/skipped.example.svelte
@@ -1,0 +1,23 @@
+<script lang="ts" module>
+  export const title = 'Skipped step';
+  export const description =
+    'Use `state: "skipped"` when a flow advances past a step without completing it.';
+</script>
+
+<script lang="ts">
+  import { Steps } from '@lostgradient/cinder/steps';
+  import type { StepItem } from '@lostgradient/cinder/steps';
+
+  const steps: StepItem[] = [
+    { id: 'account', label: 'Account', description: 'Create your login' },
+    {
+      id: 'profile',
+      label: 'Profile',
+      description: 'Optional details were skipped',
+      state: 'skipped',
+    },
+    { id: 'review', label: 'Review', description: 'Confirm and submit' },
+  ];
+</script>
+
+<Steps {steps} currentStep={2} label="Onboarding" />


### PR DESCRIPTION
## Summary
- add explicit skipped state support to Steps items
- expose skipped assistive text and style the skipped marker distinctly from completed, current, and upcoming states
- add playground coverage and regenerate component metadata
- add a patch changeset for the public package

Closes #655

## Verification
- focused Steps tests
- bun run --filter=@lostgradient/cinder components:generate
- bun run --filter=@lostgradient/cinder components:check
- bun run --filter=@lostgradient/cinder typecheck
- pre-commit checks
- pre-push scoped validation

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped UI/a11y enhancement to Steps with tests and docs; no auth, data, or breaking API changes beyond optional props and item state.
> 
> **Overview**
> Adds an explicit **skipped** step state to the Steps navigation component so flows can show steps that were passed over without being completed.
> 
> Consumers set `state: 'skipped'` on a `StepItem` (only honored for indices before `currentStep`). Skipped steps keep their numeric marker, use neutral styling distinct from completed/current/upcoming, and expose a new **`skippedLabel`** prop (default `'Skipped'`) for screen-reader announcements—without the completed checkmark or `completedLabel` text.
> 
> **Connectors** after past steps (including skipped ones) still render as complete progress. Types export **`StepItemState`**; schema, README, a11y notes, examples, playground, and a patch changeset are updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c09b72a73f478354c8d6288b7d18ce8a838dcaeb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->