### PR TITLE
Fix Cinder publish import conditions

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
       "prettier --write"
     ],
     "**/*.{json,md,scss}": [
-      "prettier --write"
+      "prettier --write --with-node-modules"
     ],
     "package.json": [
       "sort-package-json"

--- a/packages/components/fixtures/resolver-matrix/package.json
+++ b/packages/components/fixtures/resolver-matrix/package.json
@@ -10,6 +10,7 @@
       "browser": "./src/index.ts",
       "node": "./dist/server/index.js",
       "svelte": "./src/index.ts",
+      "import": "./src/index.ts",
       "default": "./dist/index.js"
     },
     "./package.json": "./package.json",
@@ -18,6 +19,7 @@
       "browser": "./src/components/button/index.ts",
       "node": "./dist/server/components/button/index.js",
       "svelte": "./src/components/button/index.ts",
+      "import": "./src/components/button/index.ts",
       "default": "./dist/components/button/index.js"
     },
     "./styles/guard": {
@@ -25,6 +27,7 @@
       "browser": "./src/styles/base-guard.ts",
       "node": "./dist/server/styles/base-guard.js",
       "svelte": "./src/styles/base-guard.ts",
+      "import": "./src/styles/base-guard.ts",
       "default": "./dist/styles/base-guard.js"
     }
   }

--- a/packages/components/fixtures/resolver-matrix/typescript-consumer/node_modules/@lostgradient/cinder/package.json
+++ b/packages/components/fixtures/resolver-matrix/typescript-consumer/node_modules/@lostgradient/cinder/package.json
@@ -9,6 +9,7 @@
       "browser": "./src/index.ts",
       "node": "./dist/server/index.js",
       "svelte": "./src/index.ts",
+      "import": "./src/index.ts",
       "default": "./dist/index.js"
     },
     "./package.json": "./package.json",
@@ -17,6 +18,7 @@
       "browser": "./src/components/button/index.ts",
       "node": "./dist/server/components/button/index.js",
       "svelte": "./src/components/button/index.ts",
+      "import": "./src/components/button/index.ts",
       "default": "./dist/components/button/index.js"
     },
     "./styles/guard": {
@@ -24,6 +26,7 @@
       "browser": "./src/styles/base-guard.ts",
       "node": "./dist/server/styles/base-guard.js",
       "svelte": "./src/styles/base-guard.ts",
+      "import": "./src/styles/base-guard.ts",
       "default": "./dist/styles/base-guard.js"
     }
   }

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -31,6 +31,7 @@
       "browser": "./src/index.ts",
       "node": "./dist/server/index.js",
       "svelte": "./src/index.ts",
+      "import": "./src/index.ts",
       "default": "./dist/index.js"
     },
     "./package.json": "./package.json",
@@ -59,6 +60,7 @@
       "browser": "./src/styles/base-guard.ts",
       "node": "./dist/server/styles/base-guard.js",
       "svelte": "./src/styles/base-guard.ts",
+      "import": "./src/styles/base-guard.ts",
       "default": "./dist/styles/base-guard.js"
     },
     "./highlighters/shiki": {
@@ -66,6 +68,7 @@
       "browser": "./src/highlighters/shiki/index.ts",
       "node": "./dist/server/highlighters/shiki/index.js",
       "svelte": "./src/highlighters/shiki/index.ts",
+      "import": "./src/highlighters/shiki/index.ts",
       "default": "./dist/highlighters/shiki/index.js"
     },
     "./manifest": {
@@ -77,6 +80,7 @@
       "browser": "./src/components/access-gate/index.ts",
       "node": "./dist/server/components/access-gate/index.js",
       "svelte": "./src/components/access-gate/index.ts",
+      "import": "./src/components/access-gate/index.ts",
       "default": "./dist/components/access-gate/index.js"
     },
     "./access-gate/schema": {
@@ -84,6 +88,7 @@
       "browser": "./src/components/access-gate/access-gate.schema.ts",
       "node": "./dist/server/components/access-gate/access-gate.schema.js",
       "svelte": "./src/components/access-gate/access-gate.schema.ts",
+      "import": "./src/components/access-gate/access-gate.schema.ts",
       "default": "./dist/components/access-gate/access-gate.schema.js"
     },
     "./access-gate/variables": {
@@ -91,6 +96,7 @@
       "browser": "./src/components/access-gate/access-gate.variables.ts",
       "node": "./dist/server/components/access-gate/access-gate.variables.js",
       "svelte": "./src/components/access-gate/access-gate.variables.ts",
+      "import": "./src/components/access-gate/access-gate.variables.ts",
       "default": "./dist/components/access-gate/access-gate.variables.js"
     },
     "./access-gate/styles": {
@@ -106,6 +112,7 @@
       "browser": "./src/components/accordion/index.ts",
       "node": "./dist/server/components/accordion/index.js",
       "svelte": "./src/components/accordion/index.ts",
+      "import": "./src/components/accordion/index.ts",
       "default": "./dist/components/accordion/index.js"
     },
     "./accordion/schema": {
@@ -113,6 +120,7 @@
       "browser": "./src/components/accordion/accordion.schema.ts",
       "node": "./dist/server/components/accordion/accordion.schema.js",
       "svelte": "./src/components/accordion/accordion.schema.ts",
+      "import": "./src/components/accordion/accordion.schema.ts",
       "default": "./dist/components/accordion/accordion.schema.js"
     },
     "./accordion/variables": {
@@ -120,6 +128,7 @@
       "browser": "./src/components/accordion/accordion.variables.ts",
       "node": "./dist/server/components/accordion/accordion.variables.js",
       "svelte": "./src/components/accordion/accordion.variables.ts",
+      "import": "./src/components/accordion/accordion.variables.ts",
       "default": "./dist/components/accordion/accordion.variables.js"
     },
     "./accordion/styles": {
@@ -135,6 +144,7 @@
       "browser": "./src/components/accordion-item/index.ts",
       "node": "./dist/server/components/accordion-item/index.js",
       "svelte": "./src/components/accordion-item/index.ts",
+      "import": "./src/components/accordion-item/index.ts",
       "default": "./dist/components/accordion-item/index.js"
     },
     "./accordion-item/schema": {
@@ -142,6 +152,7 @@
       "browser": "./src/components/accordion-item/accordion-item.schema.ts",
       "node": "./dist/server/components/accordion-item/accordion-item.schema.js",
       "svelte": "./src/components/accordion-item/accordion-item.schema.ts",
+      "import": "./src/components/accordion-item/accordion-item.schema.ts",
       "default": "./dist/components/accordion-item/accordion-item.schema.js"
     },
     "./accordion-item/variables": {
@@ -149,6 +160,7 @@
       "browser": "./src/components/accordion-item/accordion-item.variables.ts",
       "node": "./dist/server/components/accordion-item/accordion-item.variables.js",
       "svelte": "./src/components/accordion-item/accordion-item.variables.ts",
+      "import": "./src/components/accordion-item/accordion-item.variables.ts",
       "default": "./dist/components/accordion-item/accordion-item.variables.js"
     },
     "./accordion-item/styles": {
@@ -160,6 +172,7 @@
       "browser": "./src/components/action-row/index.ts",
       "node": "./dist/server/components/action-row/index.js",
       "svelte": "./src/components/action-row/index.ts",
+      "import": "./src/components/action-row/index.ts",
       "default": "./dist/components/action-row/index.js"
     },
     "./action-row/schema": {
@@ -167,6 +180,7 @@
       "browser": "./src/components/action-row/action-row.schema.ts",
       "node": "./dist/server/components/action-row/action-row.schema.js",
       "svelte": "./src/components/action-row/action-row.schema.ts",
+      "import": "./src/components/action-row/action-row.schema.ts",
       "default": "./dist/components/action-row/action-row.schema.js"
     },
     "./action-row/variables": {
@@ -174,6 +188,7 @@
       "browser": "./src/components/action-row/action-row.variables.ts",
       "node": "./dist/server/components/action-row/action-row.variables.js",
       "svelte": "./src/components/action-row/action-row.variables.ts",
+      "import": "./src/components/action-row/action-row.variables.ts",
       "default": "./dist/components/action-row/action-row.variables.js"
     },
     "./action-row/styles": {
@@ -189,6 +204,7 @@
       "browser": "./src/components/alert/index.ts",
       "node": "./dist/server/components/alert/index.js",
       "svelte": "./src/components/alert/index.ts",
+      "import": "./src/components/alert/index.ts",
       "default": "./dist/components/alert/index.js"
     },
     "./alert/schema": {
@@ -196,6 +212,7 @@
       "browser": "./src/components/alert/alert.schema.ts",
       "node": "./dist/server/components/alert/alert.schema.js",
       "svelte": "./src/components/alert/alert.schema.ts",
+      "import": "./src/components/alert/alert.schema.ts",
       "default": "./dist/components/alert/alert.schema.js"
     },
     "./alert/variables": {
@@ -203,6 +220,7 @@
       "browser": "./src/components/alert/alert.variables.ts",
       "node": "./dist/server/components/alert/alert.variables.js",
       "svelte": "./src/components/alert/alert.variables.ts",
+      "import": "./src/components/alert/alert.variables.ts",
       "default": "./dist/components/alert/alert.variables.js"
     },
     "./alert/styles": {
@@ -218,6 +236,7 @@
       "browser": "./src/components/alert-dialog/index.ts",
       "node": "./dist/server/components/alert-dialog/index.js",
       "svelte": "./src/components/alert-dialog/index.ts",
+      "import": "./src/components/alert-dialog/index.ts",
       "default": "./dist/components/alert-dialog/index.js"
     },
     "./alert-dialog/schema": {
@@ -225,6 +244,7 @@
       "browser": "./src/components/alert-dialog/alert-dialog.schema.ts",
       "node": "./dist/server/components/alert-dialog/alert-dialog.schema.js",
       "svelte": "./src/components/alert-dialog/alert-dialog.schema.ts",
+      "import": "./src/components/alert-dialog/alert-dialog.schema.ts",
       "default": "./dist/components/alert-dialog/alert-dialog.schema.js"
     },
     "./alert-dialog/variables": {
@@ -232,6 +252,7 @@
       "browser": "./src/components/alert-dialog/alert-dialog.variables.ts",
       "node": "./dist/server/components/alert-dialog/alert-dialog.variables.js",
       "svelte": "./src/components/alert-dialog/alert-dialog.variables.ts",
+      "import": "./src/components/alert-dialog/alert-dialog.variables.ts",
       "default": "./dist/components/alert-dialog/alert-dialog.variables.js"
     },
     "./alert-dialog/styles": {
@@ -247,6 +268,7 @@
       "browser": "./src/components/approval-card/index.ts",
       "node": "./dist/server/components/approval-card/index.js",
       "svelte": "./src/components/approval-card/index.ts",
+      "import": "./src/components/approval-card/index.ts",
       "default": "./dist/components/approval-card/index.js"
     },
     "./approval-card/schema": {
@@ -254,6 +276,7 @@
       "browser": "./src/components/approval-card/approval-card.schema.ts",
       "node": "./dist/server/components/approval-card/approval-card.schema.js",
       "svelte": "./src/components/approval-card/approval-card.schema.ts",
+      "import": "./src/components/approval-card/approval-card.schema.ts",
       "default": "./dist/components/approval-card/approval-card.schema.js"
     },
     "./approval-card/variables": {
@@ -261,6 +284,7 @@
       "browser": "./src/components/approval-card/approval-card.variables.ts",
       "node": "./dist/server/components/approval-card/approval-card.variables.js",
       "svelte": "./src/components/approval-card/approval-card.variables.ts",
+      "import": "./src/components/approval-card/approval-card.variables.ts",
       "default": "./dist/components/approval-card/approval-card.variables.js"
     },
     "./approval-card/styles": {
@@ -276,6 +300,7 @@
       "browser": "./src/components/area-chart/index.ts",
       "node": "./dist/server/components/area-chart/index.js",
       "svelte": "./src/components/area-chart/index.ts",
+      "import": "./src/components/area-chart/index.ts",
       "default": "./dist/components/area-chart/index.js"
     },
     "./area-chart/schema": {
@@ -283,6 +308,7 @@
       "browser": "./src/components/area-chart/area-chart.schema.ts",
       "node": "./dist/server/components/area-chart/area-chart.schema.js",
       "svelte": "./src/components/area-chart/area-chart.schema.ts",
+      "import": "./src/components/area-chart/area-chart.schema.ts",
       "default": "./dist/components/area-chart/area-chart.schema.js"
     },
     "./area-chart/variables": {
@@ -290,6 +316,7 @@
       "browser": "./src/components/area-chart/area-chart.variables.ts",
       "node": "./dist/server/components/area-chart/area-chart.variables.js",
       "svelte": "./src/components/area-chart/area-chart.variables.ts",
+      "import": "./src/components/area-chart/area-chart.variables.ts",
       "default": "./dist/components/area-chart/area-chart.variables.js"
     },
     "./area-chart/styles": {
@@ -305,6 +332,7 @@
       "browser": "./src/components/aspect-ratio/index.ts",
       "node": "./dist/server/components/aspect-ratio/index.js",
       "svelte": "./src/components/aspect-ratio/index.ts",
+      "import": "./src/components/aspect-ratio/index.ts",
       "default": "./dist/components/aspect-ratio/index.js"
     },
     "./aspect-ratio/schema": {
@@ -312,6 +340,7 @@
       "browser": "./src/components/aspect-ratio/aspect-ratio.schema.ts",
       "node": "./dist/server/components/aspect-ratio/aspect-ratio.schema.js",
       "svelte": "./src/components/aspect-ratio/aspect-ratio.schema.ts",
+      "import": "./src/components/aspect-ratio/aspect-ratio.schema.ts",
       "default": "./dist/components/aspect-ratio/aspect-ratio.schema.js"
     },
     "./aspect-ratio/variables": {
@@ -319,6 +348,7 @@
       "browser": "./src/components/aspect-ratio/aspect-ratio.variables.ts",
       "node": "./dist/server/components/aspect-ratio/aspect-ratio.variables.js",
       "svelte": "./src/components/aspect-ratio/aspect-ratio.variables.ts",
+      "import": "./src/components/aspect-ratio/aspect-ratio.variables.ts",
       "default": "./dist/components/aspect-ratio/aspect-ratio.variables.js"
     },
     "./aspect-ratio/styles": {
@@ -334,6 +364,7 @@
       "browser": "./src/components/autocomplete/index.ts",
       "node": "./dist/server/components/autocomplete/index.js",
       "svelte": "./src/components/autocomplete/index.ts",
+      "import": "./src/components/autocomplete/index.ts",
       "default": "./dist/components/autocomplete/index.js"
     },
     "./autocomplete/schema": {
@@ -341,6 +372,7 @@
       "browser": "./src/components/autocomplete/autocomplete.schema.ts",
       "node": "./dist/server/components/autocomplete/autocomplete.schema.js",
       "svelte": "./src/components/autocomplete/autocomplete.schema.ts",
+      "import": "./src/components/autocomplete/autocomplete.schema.ts",
       "default": "./dist/components/autocomplete/autocomplete.schema.js"
     },
     "./autocomplete/variables": {
@@ -348,6 +380,7 @@
       "browser": "./src/components/autocomplete/autocomplete.variables.ts",
       "node": "./dist/server/components/autocomplete/autocomplete.variables.js",
       "svelte": "./src/components/autocomplete/autocomplete.variables.ts",
+      "import": "./src/components/autocomplete/autocomplete.variables.ts",
       "default": "./dist/components/autocomplete/autocomplete.variables.js"
     },
     "./autocomplete/styles": {
@@ -363,6 +396,7 @@
       "browser": "./src/components/avatar/index.ts",
       "node": "./dist/server/components/avatar/index.js",
       "svelte": "./src/components/avatar/index.ts",
+      "import": "./src/components/avatar/index.ts",
       "default": "./dist/components/avatar/index.js"
     },
     "./avatar/schema": {
@@ -370,6 +404,7 @@
       "browser": "./src/components/avatar/avatar.schema.ts",
       "node": "./dist/server/components/avatar/avatar.schema.js",
       "svelte": "./src/components/avatar/avatar.schema.ts",
+      "import": "./src/components/avatar/avatar.schema.ts",
       "default": "./dist/components/avatar/avatar.schema.js"
     },
     "./avatar/variables": {
@@ -377,6 +412,7 @@
       "browser": "./src/components/avatar/avatar.variables.ts",
       "node": "./dist/server/components/avatar/avatar.variables.js",
       "svelte": "./src/components/avatar/avatar.variables.ts",
+      "import": "./src/components/avatar/avatar.variables.ts",
       "default": "./dist/components/avatar/avatar.variables.js"
     },
     "./avatar/styles": {
@@ -392,6 +428,7 @@
       "browser": "./src/components/avatar-group/index.ts",
       "node": "./dist/server/components/avatar-group/index.js",
       "svelte": "./src/components/avatar-group/index.ts",
+      "import": "./src/components/avatar-group/index.ts",
       "default": "./dist/components/avatar-group/index.js"
     },
     "./avatar-group/schema": {
@@ -399,6 +436,7 @@
       "browser": "./src/components/avatar-group/avatar-group.schema.ts",
       "node": "./dist/server/components/avatar-group/avatar-group.schema.js",
       "svelte": "./src/components/avatar-group/avatar-group.schema.ts",
+      "import": "./src/components/avatar-group/avatar-group.schema.ts",
       "default": "./dist/components/avatar-group/avatar-group.schema.js"
     },
     "./avatar-group/variables": {
@@ -406,6 +444,7 @@
       "browser": "./src/components/avatar-group/avatar-group.variables.ts",
       "node": "./dist/server/components/avatar-group/avatar-group.variables.js",
       "svelte": "./src/components/avatar-group/avatar-group.variables.ts",
+      "import": "./src/components/avatar-group/avatar-group.variables.ts",
       "default": "./dist/components/avatar-group/avatar-group.variables.js"
     },
     "./avatar-group/styles": {
@@ -421,6 +460,7 @@
       "browser": "./src/components/backdrop/index.ts",
       "node": "./dist/server/components/backdrop/index.js",
       "svelte": "./src/components/backdrop/index.ts",
+      "import": "./src/components/backdrop/index.ts",
       "default": "./dist/components/backdrop/index.js"
     },
     "./backdrop/schema": {
@@ -428,6 +468,7 @@
       "browser": "./src/components/backdrop/backdrop.schema.ts",
       "node": "./dist/server/components/backdrop/backdrop.schema.js",
       "svelte": "./src/components/backdrop/backdrop.schema.ts",
+      "import": "./src/components/backdrop/backdrop.schema.ts",
       "default": "./dist/components/backdrop/backdrop.schema.js"
     },
     "./backdrop/variables": {
@@ -435,6 +476,7 @@
       "browser": "./src/components/backdrop/backdrop.variables.ts",
       "node": "./dist/server/components/backdrop/backdrop.variables.js",
       "svelte": "./src/components/backdrop/backdrop.variables.ts",
+      "import": "./src/components/backdrop/backdrop.variables.ts",
       "default": "./dist/components/backdrop/backdrop.variables.js"
     },
     "./backdrop/styles": {
@@ -450,6 +492,7 @@
       "browser": "./src/components/badge/index.ts",
       "node": "./dist/server/components/badge/index.js",
       "svelte": "./src/components/badge/index.ts",
+      "import": "./src/components/badge/index.ts",
       "default": "./dist/components/badge/index.js"
     },
     "./badge/schema": {
@@ -457,6 +500,7 @@
       "browser": "./src/components/badge/badge.schema.ts",
       "node": "./dist/server/components/badge/badge.schema.js",
       "svelte": "./src/components/badge/badge.schema.ts",
+      "import": "./src/components/badge/badge.schema.ts",
       "default": "./dist/components/badge/badge.schema.js"
     },
     "./badge/variables": {
@@ -464,6 +508,7 @@
       "browser": "./src/components/badge/badge.variables.ts",
       "node": "./dist/server/components/badge/badge.variables.js",
       "svelte": "./src/components/badge/badge.variables.ts",
+      "import": "./src/components/badge/badge.variables.ts",
       "default": "./dist/components/badge/badge.variables.js"
     },
     "./badge/styles": {
@@ -479,6 +524,7 @@
       "browser": "./src/components/banner/index.ts",
       "node": "./dist/server/components/banner/index.js",
       "svelte": "./src/components/banner/index.ts",
+      "import": "./src/components/banner/index.ts",
       "default": "./dist/components/banner/index.js"
     },
     "./banner/schema": {
@@ -486,6 +532,7 @@
       "browser": "./src/components/banner/banner.schema.ts",
       "node": "./dist/server/components/banner/banner.schema.js",
       "svelte": "./src/components/banner/banner.schema.ts",
+      "import": "./src/components/banner/banner.schema.ts",
       "default": "./dist/components/banner/banner.schema.js"
     },
     "./banner/variables": {
@@ -493,6 +540,7 @@
       "browser": "./src/components/banner/banner.variables.ts",
       "node": "./dist/server/components/banner/banner.variables.js",
       "svelte": "./src/components/banner/banner.variables.ts",
+      "import": "./src/components/banner/banner.variables.ts",
       "default": "./dist/components/banner/banner.variables.js"
     },
     "./banner/styles": {
@@ -508,6 +556,7 @@
       "browser": "./src/components/bar-chart/index.ts",
       "node": "./dist/server/components/bar-chart/index.js",
       "svelte": "./src/components/bar-chart/index.ts",
+      "import": "./src/components/bar-chart/index.ts",
       "default": "./dist/components/bar-chart/index.js"
     },
     "./bar-chart/schema": {
@@ -515,6 +564,7 @@
       "browser": "./src/components/bar-chart/bar-chart.schema.ts",
       "node": "./dist/server/components/bar-chart/bar-chart.schema.js",
       "svelte": "./src/components/bar-chart/bar-chart.schema.ts",
+      "import": "./src/components/bar-chart/bar-chart.schema.ts",
       "default": "./dist/components/bar-chart/bar-chart.schema.js"
     },
     "./bar-chart/variables": {
@@ -522,6 +572,7 @@
       "browser": "./src/components/bar-chart/bar-chart.variables.ts",
       "node": "./dist/server/components/bar-chart/bar-chart.variables.js",
       "svelte": "./src/components/bar-chart/bar-chart.variables.ts",
+      "import": "./src/components/bar-chart/bar-chart.variables.ts",
       "default": "./dist/components/bar-chart/bar-chart.variables.js"
     },
     "./bar-chart/styles": {
@@ -537,6 +588,7 @@
       "browser": "./src/components/bento-cell/index.ts",
       "node": "./dist/server/components/bento-cell/index.js",
       "svelte": "./src/components/bento-cell/index.ts",
+      "import": "./src/components/bento-cell/index.ts",
       "default": "./dist/components/bento-cell/index.js"
     },
     "./bento-cell/schema": {
@@ -544,6 +596,7 @@
       "browser": "./src/components/bento-cell/bento-cell.schema.ts",
       "node": "./dist/server/components/bento-cell/bento-cell.schema.js",
       "svelte": "./src/components/bento-cell/bento-cell.schema.ts",
+      "import": "./src/components/bento-cell/bento-cell.schema.ts",
       "default": "./dist/components/bento-cell/bento-cell.schema.js"
     },
     "./bento-cell/variables": {
@@ -551,6 +604,7 @@
       "browser": "./src/components/bento-cell/bento-cell.variables.ts",
       "node": "./dist/server/components/bento-cell/bento-cell.variables.js",
       "svelte": "./src/components/bento-cell/bento-cell.variables.ts",
+      "import": "./src/components/bento-cell/bento-cell.variables.ts",
       "default": "./dist/components/bento-cell/bento-cell.variables.js"
     },
     "./bento-cell/styles": {
@@ -562,6 +616,7 @@
       "browser": "./src/components/bento-grid/index.ts",
       "node": "./dist/server/components/bento-grid/index.js",
       "svelte": "./src/components/bento-grid/index.ts",
+      "import": "./src/components/bento-grid/index.ts",
       "default": "./dist/components/bento-grid/index.js"
     },
     "./bento-grid/schema": {
@@ -569,6 +624,7 @@
       "browser": "./src/components/bento-grid/bento-grid.schema.ts",
       "node": "./dist/server/components/bento-grid/bento-grid.schema.js",
       "svelte": "./src/components/bento-grid/bento-grid.schema.ts",
+      "import": "./src/components/bento-grid/bento-grid.schema.ts",
       "default": "./dist/components/bento-grid/bento-grid.schema.js"
     },
     "./bento-grid/variables": {
@@ -576,6 +632,7 @@
       "browser": "./src/components/bento-grid/bento-grid.variables.ts",
       "node": "./dist/server/components/bento-grid/bento-grid.variables.js",
       "svelte": "./src/components/bento-grid/bento-grid.variables.ts",
+      "import": "./src/components/bento-grid/bento-grid.variables.ts",
       "default": "./dist/components/bento-grid/bento-grid.variables.js"
     },
     "./bento-grid/styles": {
@@ -591,6 +648,7 @@
       "browser": "./src/components/blog-section/index.ts",
       "node": "./dist/server/components/blog-section/index.js",
       "svelte": "./src/components/blog-section/index.ts",
+      "import": "./src/components/blog-section/index.ts",
       "default": "./dist/components/blog-section/index.js"
     },
     "./blog-section/schema": {
@@ -598,6 +656,7 @@
       "browser": "./src/components/blog-section/blog-section.schema.ts",
       "node": "./dist/server/components/blog-section/blog-section.schema.js",
       "svelte": "./src/components/blog-section/blog-section.schema.ts",
+      "import": "./src/components/blog-section/blog-section.schema.ts",
       "default": "./dist/components/blog-section/blog-section.schema.js"
     },
     "./blog-section/variables": {
@@ -605,6 +664,7 @@
       "browser": "./src/components/blog-section/blog-section.variables.ts",
       "node": "./dist/server/components/blog-section/blog-section.variables.js",
       "svelte": "./src/components/blog-section/blog-section.variables.ts",
+      "import": "./src/components/blog-section/blog-section.variables.ts",
       "default": "./dist/components/blog-section/blog-section.variables.js"
     },
     "./blog-section/styles": {
@@ -620,6 +680,7 @@
       "browser": "./src/components/breadcrumbs/index.ts",
       "node": "./dist/server/components/breadcrumbs/index.js",
       "svelte": "./src/components/breadcrumbs/index.ts",
+      "import": "./src/components/breadcrumbs/index.ts",
       "default": "./dist/components/breadcrumbs/index.js"
     },
     "./breadcrumbs/schema": {
@@ -627,6 +688,7 @@
       "browser": "./src/components/breadcrumbs/breadcrumbs.schema.ts",
       "node": "./dist/server/components/breadcrumbs/breadcrumbs.schema.js",
       "svelte": "./src/components/breadcrumbs/breadcrumbs.schema.ts",
+      "import": "./src/components/breadcrumbs/breadcrumbs.schema.ts",
       "default": "./dist/components/breadcrumbs/breadcrumbs.schema.js"
     },
     "./breadcrumbs/variables": {
@@ -634,6 +696,7 @@
       "browser": "./src/components/breadcrumbs/breadcrumbs.variables.ts",
       "node": "./dist/server/components/breadcrumbs/breadcrumbs.variables.js",
       "svelte": "./src/components/breadcrumbs/breadcrumbs.variables.ts",
+      "import": "./src/components/breadcrumbs/breadcrumbs.variables.ts",
       "default": "./dist/components/breadcrumbs/breadcrumbs.variables.js"
     },
     "./breadcrumbs/styles": {
@@ -649,6 +712,7 @@
       "browser": "./src/components/button/index.ts",
       "node": "./dist/server/components/button/index.js",
       "svelte": "./src/components/button/index.ts",
+      "import": "./src/components/button/index.ts",
       "default": "./dist/components/button/index.js"
     },
     "./button/schema": {
@@ -656,6 +720,7 @@
       "browser": "./src/components/button/button.schema.ts",
       "node": "./dist/server/components/button/button.schema.js",
       "svelte": "./src/components/button/button.schema.ts",
+      "import": "./src/components/button/button.schema.ts",
       "default": "./dist/components/button/button.schema.js"
     },
     "./button/variables": {
@@ -663,6 +728,7 @@
       "browser": "./src/components/button/button.variables.ts",
       "node": "./dist/server/components/button/button.variables.js",
       "svelte": "./src/components/button/button.variables.ts",
+      "import": "./src/components/button/button.variables.ts",
       "default": "./dist/components/button/button.variables.js"
     },
     "./button/styles": {
@@ -682,6 +748,7 @@
       "browser": "./src/components/button-group/index.ts",
       "node": "./dist/server/components/button-group/index.js",
       "svelte": "./src/components/button-group/index.ts",
+      "import": "./src/components/button-group/index.ts",
       "default": "./dist/components/button-group/index.js"
     },
     "./button-group/schema": {
@@ -689,6 +756,7 @@
       "browser": "./src/components/button-group/button-group.schema.ts",
       "node": "./dist/server/components/button-group/button-group.schema.js",
       "svelte": "./src/components/button-group/button-group.schema.ts",
+      "import": "./src/components/button-group/button-group.schema.ts",
       "default": "./dist/components/button-group/button-group.schema.js"
     },
     "./button-group/variables": {
@@ -696,6 +764,7 @@
       "browser": "./src/components/button-group/button-group.variables.ts",
       "node": "./dist/server/components/button-group/button-group.variables.js",
       "svelte": "./src/components/button-group/button-group.variables.ts",
+      "import": "./src/components/button-group/button-group.variables.ts",
       "default": "./dist/components/button-group/button-group.variables.js"
     },
     "./button-group/styles": {
@@ -711,6 +780,7 @@
       "browser": "./src/components/calendar/index.ts",
       "node": "./dist/server/components/calendar/index.js",
       "svelte": "./src/components/calendar/index.ts",
+      "import": "./src/components/calendar/index.ts",
       "default": "./dist/components/calendar/index.js"
     },
     "./calendar/schema": {
@@ -718,6 +788,7 @@
       "browser": "./src/components/calendar/calendar.schema.ts",
       "node": "./dist/server/components/calendar/calendar.schema.js",
       "svelte": "./src/components/calendar/calendar.schema.ts",
+      "import": "./src/components/calendar/calendar.schema.ts",
       "default": "./dist/components/calendar/calendar.schema.js"
     },
     "./calendar/variables": {
@@ -725,6 +796,7 @@
       "browser": "./src/components/calendar/calendar.variables.ts",
       "node": "./dist/server/components/calendar/calendar.variables.js",
       "svelte": "./src/components/calendar/calendar.variables.ts",
+      "import": "./src/components/calendar/calendar.variables.ts",
       "default": "./dist/components/calendar/calendar.variables.js"
     },
     "./calendar/styles": {
@@ -740,6 +812,7 @@
       "browser": "./src/components/callout/index.ts",
       "node": "./dist/server/components/callout/index.js",
       "svelte": "./src/components/callout/index.ts",
+      "import": "./src/components/callout/index.ts",
       "default": "./dist/components/callout/index.js"
     },
     "./callout/schema": {
@@ -747,6 +820,7 @@
       "browser": "./src/components/callout/callout.schema.ts",
       "node": "./dist/server/components/callout/callout.schema.js",
       "svelte": "./src/components/callout/callout.schema.ts",
+      "import": "./src/components/callout/callout.schema.ts",
       "default": "./dist/components/callout/callout.schema.js"
     },
     "./callout/variables": {
@@ -754,6 +828,7 @@
       "browser": "./src/components/callout/callout.variables.ts",
       "node": "./dist/server/components/callout/callout.variables.js",
       "svelte": "./src/components/callout/callout.variables.ts",
+      "import": "./src/components/callout/callout.variables.ts",
       "default": "./dist/components/callout/callout.variables.js"
     },
     "./callout/styles": {
@@ -769,6 +844,7 @@
       "browser": "./src/components/capability-gate/index.ts",
       "node": "./dist/server/components/capability-gate/index.js",
       "svelte": "./src/components/capability-gate/index.ts",
+      "import": "./src/components/capability-gate/index.ts",
       "default": "./dist/components/capability-gate/index.js"
     },
     "./capability-gate/schema": {
@@ -776,6 +852,7 @@
       "browser": "./src/components/capability-gate/capability-gate.schema.ts",
       "node": "./dist/server/components/capability-gate/capability-gate.schema.js",
       "svelte": "./src/components/capability-gate/capability-gate.schema.ts",
+      "import": "./src/components/capability-gate/capability-gate.schema.ts",
       "default": "./dist/components/capability-gate/capability-gate.schema.js"
     },
     "./capability-gate/variables": {
@@ -783,6 +860,7 @@
       "browser": "./src/components/capability-gate/capability-gate.variables.ts",
       "node": "./dist/server/components/capability-gate/capability-gate.variables.js",
       "svelte": "./src/components/capability-gate/capability-gate.variables.ts",
+      "import": "./src/components/capability-gate/capability-gate.variables.ts",
       "default": "./dist/components/capability-gate/capability-gate.variables.js"
     },
     "./capability-gate/styles": {
@@ -798,6 +876,7 @@
       "browser": "./src/components/card/index.ts",
       "node": "./dist/server/components/card/index.js",
       "svelte": "./src/components/card/index.ts",
+      "import": "./src/components/card/index.ts",
       "default": "./dist/components/card/index.js"
     },
     "./card/schema": {
@@ -805,6 +884,7 @@
       "browser": "./src/components/card/card.schema.ts",
       "node": "./dist/server/components/card/card.schema.js",
       "svelte": "./src/components/card/card.schema.ts",
+      "import": "./src/components/card/card.schema.ts",
       "default": "./dist/components/card/card.schema.js"
     },
     "./card/variables": {
@@ -812,6 +892,7 @@
       "browser": "./src/components/card/card.variables.ts",
       "node": "./dist/server/components/card/card.variables.js",
       "svelte": "./src/components/card/card.variables.ts",
+      "import": "./src/components/card/card.variables.ts",
       "default": "./dist/components/card/card.variables.js"
     },
     "./card/styles": {
@@ -827,6 +908,7 @@
       "browser": "./src/components/carousel/index.ts",
       "node": "./dist/server/components/carousel/index.js",
       "svelte": "./src/components/carousel/index.ts",
+      "import": "./src/components/carousel/index.ts",
       "default": "./dist/components/carousel/index.js"
     },
     "./carousel/schema": {
@@ -834,6 +916,7 @@
       "browser": "./src/components/carousel/carousel.schema.ts",
       "node": "./dist/server/components/carousel/carousel.schema.js",
       "svelte": "./src/components/carousel/carousel.schema.ts",
+      "import": "./src/components/carousel/carousel.schema.ts",
       "default": "./dist/components/carousel/carousel.schema.js"
     },
     "./carousel/variables": {
@@ -841,6 +924,7 @@
       "browser": "./src/components/carousel/carousel.variables.ts",
       "node": "./dist/server/components/carousel/carousel.variables.js",
       "svelte": "./src/components/carousel/carousel.variables.ts",
+      "import": "./src/components/carousel/carousel.variables.ts",
       "default": "./dist/components/carousel/carousel.variables.js"
     },
     "./carousel/styles": {
@@ -856,6 +940,7 @@
       "browser": "./src/components/chat/index.ts",
       "node": "./dist/server/components/chat/index.js",
       "svelte": "./src/components/chat/index.ts",
+      "import": "./src/components/chat/index.ts",
       "default": "./dist/components/chat/index.js"
     },
     "./chat/schema": {
@@ -863,6 +948,7 @@
       "browser": "./src/components/chat/chat.schema.ts",
       "node": "./dist/server/components/chat/chat.schema.js",
       "svelte": "./src/components/chat/chat.schema.ts",
+      "import": "./src/components/chat/chat.schema.ts",
       "default": "./dist/components/chat/chat.schema.js"
     },
     "./chat/variables": {
@@ -870,6 +956,7 @@
       "browser": "./src/components/chat/chat.variables.ts",
       "node": "./dist/server/components/chat/chat.variables.js",
       "svelte": "./src/components/chat/chat.variables.ts",
+      "import": "./src/components/chat/chat.variables.ts",
       "default": "./dist/components/chat/chat.variables.js"
     },
     "./chat/styles": {
@@ -885,6 +972,7 @@
       "browser": "./src/components/chat-conversation-header/index.ts",
       "node": "./dist/server/components/chat-conversation-header/index.js",
       "svelte": "./src/components/chat-conversation-header/index.ts",
+      "import": "./src/components/chat-conversation-header/index.ts",
       "default": "./dist/components/chat-conversation-header/index.js"
     },
     "./chat-conversation-header/schema": {
@@ -892,6 +980,7 @@
       "browser": "./src/components/chat-conversation-header/chat-conversation-header.schema.ts",
       "node": "./dist/server/components/chat-conversation-header/chat-conversation-header.schema.js",
       "svelte": "./src/components/chat-conversation-header/chat-conversation-header.schema.ts",
+      "import": "./src/components/chat-conversation-header/chat-conversation-header.schema.ts",
       "default": "./dist/components/chat-conversation-header/chat-conversation-header.schema.js"
     },
     "./chat-conversation-header/variables": {
@@ -899,6 +988,7 @@
       "browser": "./src/components/chat-conversation-header/chat-conversation-header.variables.ts",
       "node": "./dist/server/components/chat-conversation-header/chat-conversation-header.variables.js",
       "svelte": "./src/components/chat-conversation-header/chat-conversation-header.variables.ts",
+      "import": "./src/components/chat-conversation-header/chat-conversation-header.variables.ts",
       "default": "./dist/components/chat-conversation-header/chat-conversation-header.variables.js"
     },
     "./chat-conversation-header/styles": {
@@ -914,6 +1004,7 @@
       "browser": "./src/components/chat-conversation-list/index.ts",
       "node": "./dist/server/components/chat-conversation-list/index.js",
       "svelte": "./src/components/chat-conversation-list/index.ts",
+      "import": "./src/components/chat-conversation-list/index.ts",
       "default": "./dist/components/chat-conversation-list/index.js"
     },
     "./chat-conversation-list/schema": {
@@ -921,6 +1012,7 @@
       "browser": "./src/components/chat-conversation-list/chat-conversation-list.schema.ts",
       "node": "./dist/server/components/chat-conversation-list/chat-conversation-list.schema.js",
       "svelte": "./src/components/chat-conversation-list/chat-conversation-list.schema.ts",
+      "import": "./src/components/chat-conversation-list/chat-conversation-list.schema.ts",
       "default": "./dist/components/chat-conversation-list/chat-conversation-list.schema.js"
     },
     "./chat-conversation-list/variables": {
@@ -928,6 +1020,7 @@
       "browser": "./src/components/chat-conversation-list/chat-conversation-list.variables.ts",
       "node": "./dist/server/components/chat-conversation-list/chat-conversation-list.variables.js",
       "svelte": "./src/components/chat-conversation-list/chat-conversation-list.variables.ts",
+      "import": "./src/components/chat-conversation-list/chat-conversation-list.variables.ts",
       "default": "./dist/components/chat-conversation-list/chat-conversation-list.variables.js"
     },
     "./chat-conversation-list/styles": {
@@ -943,6 +1036,7 @@
       "browser": "./src/components/checkbox/index.ts",
       "node": "./dist/server/components/checkbox/index.js",
       "svelte": "./src/components/checkbox/index.ts",
+      "import": "./src/components/checkbox/index.ts",
       "default": "./dist/components/checkbox/index.js"
     },
     "./checkbox/schema": {
@@ -950,6 +1044,7 @@
       "browser": "./src/components/checkbox/checkbox.schema.ts",
       "node": "./dist/server/components/checkbox/checkbox.schema.js",
       "svelte": "./src/components/checkbox/checkbox.schema.ts",
+      "import": "./src/components/checkbox/checkbox.schema.ts",
       "default": "./dist/components/checkbox/checkbox.schema.js"
     },
     "./checkbox/variables": {
@@ -957,6 +1052,7 @@
       "browser": "./src/components/checkbox/checkbox.variables.ts",
       "node": "./dist/server/components/checkbox/checkbox.variables.js",
       "svelte": "./src/components/checkbox/checkbox.variables.ts",
+      "import": "./src/components/checkbox/checkbox.variables.ts",
       "default": "./dist/components/checkbox/checkbox.variables.js"
     },
     "./checkbox/styles": {
@@ -972,6 +1068,7 @@
       "browser": "./src/components/checkbox-group/index.ts",
       "node": "./dist/server/components/checkbox-group/index.js",
       "svelte": "./src/components/checkbox-group/index.ts",
+      "import": "./src/components/checkbox-group/index.ts",
       "default": "./dist/components/checkbox-group/index.js"
     },
     "./checkbox-group/schema": {
@@ -979,6 +1076,7 @@
       "browser": "./src/components/checkbox-group/checkbox-group.schema.ts",
       "node": "./dist/server/components/checkbox-group/checkbox-group.schema.js",
       "svelte": "./src/components/checkbox-group/checkbox-group.schema.ts",
+      "import": "./src/components/checkbox-group/checkbox-group.schema.ts",
       "default": "./dist/components/checkbox-group/checkbox-group.schema.js"
     },
     "./checkbox-group/variables": {
@@ -986,6 +1084,7 @@
       "browser": "./src/components/checkbox-group/checkbox-group.variables.ts",
       "node": "./dist/server/components/checkbox-group/checkbox-group.variables.js",
       "svelte": "./src/components/checkbox-group/checkbox-group.variables.ts",
+      "import": "./src/components/checkbox-group/checkbox-group.variables.ts",
       "default": "./dist/components/checkbox-group/checkbox-group.variables.js"
     },
     "./checkbox-group/styles": {
@@ -1001,6 +1100,7 @@
       "browser": "./src/components/chip/index.ts",
       "node": "./dist/server/components/chip/index.js",
       "svelte": "./src/components/chip/index.ts",
+      "import": "./src/components/chip/index.ts",
       "default": "./dist/components/chip/index.js"
     },
     "./chip/schema": {
@@ -1008,6 +1108,7 @@
       "browser": "./src/components/chip/chip.schema.ts",
       "node": "./dist/server/components/chip/chip.schema.js",
       "svelte": "./src/components/chip/chip.schema.ts",
+      "import": "./src/components/chip/chip.schema.ts",
       "default": "./dist/components/chip/chip.schema.js"
     },
     "./chip/variables": {
@@ -1015,6 +1116,7 @@
       "browser": "./src/components/chip/chip.variables.ts",
       "node": "./dist/server/components/chip/chip.variables.js",
       "svelte": "./src/components/chip/chip.variables.ts",
+      "import": "./src/components/chip/chip.variables.ts",
       "default": "./dist/components/chip/chip.variables.js"
     },
     "./chip/styles": {
@@ -1030,6 +1132,7 @@
       "browser": "./src/components/choice-grid/index.ts",
       "node": "./dist/server/components/choice-grid/index.js",
       "svelte": "./src/components/choice-grid/index.ts",
+      "import": "./src/components/choice-grid/index.ts",
       "default": "./dist/components/choice-grid/index.js"
     },
     "./choice-grid/schema": {
@@ -1037,6 +1140,7 @@
       "browser": "./src/components/choice-grid/choice-grid.schema.ts",
       "node": "./dist/server/components/choice-grid/choice-grid.schema.js",
       "svelte": "./src/components/choice-grid/choice-grid.schema.ts",
+      "import": "./src/components/choice-grid/choice-grid.schema.ts",
       "default": "./dist/components/choice-grid/choice-grid.schema.js"
     },
     "./choice-grid/variables": {
@@ -1044,6 +1148,7 @@
       "browser": "./src/components/choice-grid/choice-grid.variables.ts",
       "node": "./dist/server/components/choice-grid/choice-grid.variables.js",
       "svelte": "./src/components/choice-grid/choice-grid.variables.ts",
+      "import": "./src/components/choice-grid/choice-grid.variables.ts",
       "default": "./dist/components/choice-grid/choice-grid.variables.js"
     },
     "./choice-grid/styles": {
@@ -1059,6 +1164,7 @@
       "browser": "./src/components/choice-grid-item/index.ts",
       "node": "./dist/server/components/choice-grid-item/index.js",
       "svelte": "./src/components/choice-grid-item/index.ts",
+      "import": "./src/components/choice-grid-item/index.ts",
       "default": "./dist/components/choice-grid-item/index.js"
     },
     "./choice-grid-item/schema": {
@@ -1066,6 +1172,7 @@
       "browser": "./src/components/choice-grid-item/choice-grid-item.schema.ts",
       "node": "./dist/server/components/choice-grid-item/choice-grid-item.schema.js",
       "svelte": "./src/components/choice-grid-item/choice-grid-item.schema.ts",
+      "import": "./src/components/choice-grid-item/choice-grid-item.schema.ts",
       "default": "./dist/components/choice-grid-item/choice-grid-item.schema.js"
     },
     "./choice-grid-item/variables": {
@@ -1073,6 +1180,7 @@
       "browser": "./src/components/choice-grid-item/choice-grid-item.variables.ts",
       "node": "./dist/server/components/choice-grid-item/choice-grid-item.variables.js",
       "svelte": "./src/components/choice-grid-item/choice-grid-item.variables.ts",
+      "import": "./src/components/choice-grid-item/choice-grid-item.variables.ts",
       "default": "./dist/components/choice-grid-item/choice-grid-item.variables.js"
     },
     "./choice-grid-item/styles": {
@@ -1084,6 +1192,7 @@
       "browser": "./src/components/click-away-listener/index.ts",
       "node": "./dist/server/components/click-away-listener/index.js",
       "svelte": "./src/components/click-away-listener/index.ts",
+      "import": "./src/components/click-away-listener/index.ts",
       "default": "./dist/components/click-away-listener/index.js"
     },
     "./click-away-listener/schema": {
@@ -1091,6 +1200,7 @@
       "browser": "./src/components/click-away-listener/click-away-listener.schema.ts",
       "node": "./dist/server/components/click-away-listener/click-away-listener.schema.js",
       "svelte": "./src/components/click-away-listener/click-away-listener.schema.ts",
+      "import": "./src/components/click-away-listener/click-away-listener.schema.ts",
       "default": "./dist/components/click-away-listener/click-away-listener.schema.js"
     },
     "./click-away-listener/variables": {
@@ -1098,6 +1208,7 @@
       "browser": "./src/components/click-away-listener/click-away-listener.variables.ts",
       "node": "./dist/server/components/click-away-listener/click-away-listener.variables.js",
       "svelte": "./src/components/click-away-listener/click-away-listener.variables.ts",
+      "import": "./src/components/click-away-listener/click-away-listener.variables.ts",
       "default": "./dist/components/click-away-listener/click-away-listener.variables.js"
     },
     "./click-away-listener/examples": {
@@ -1109,6 +1220,7 @@
       "browser": "./src/components/code-block/index.ts",
       "node": "./dist/server/components/code-block/index.js",
       "svelte": "./src/components/code-block/index.ts",
+      "import": "./src/components/code-block/index.ts",
       "default": "./dist/components/code-block/index.js"
     },
     "./code-block/schema": {
@@ -1116,6 +1228,7 @@
       "browser": "./src/components/code-block/code-block.schema.ts",
       "node": "./dist/server/components/code-block/code-block.schema.js",
       "svelte": "./src/components/code-block/code-block.schema.ts",
+      "import": "./src/components/code-block/code-block.schema.ts",
       "default": "./dist/components/code-block/code-block.schema.js"
     },
     "./code-block/variables": {
@@ -1123,6 +1236,7 @@
       "browser": "./src/components/code-block/code-block.variables.ts",
       "node": "./dist/server/components/code-block/code-block.variables.js",
       "svelte": "./src/components/code-block/code-block.variables.ts",
+      "import": "./src/components/code-block/code-block.variables.ts",
       "default": "./dist/components/code-block/code-block.variables.js"
     },
     "./code-block/styles": {
@@ -1138,6 +1252,7 @@
       "browser": "./src/components/collapsible/index.ts",
       "node": "./dist/server/components/collapsible/index.js",
       "svelte": "./src/components/collapsible/index.ts",
+      "import": "./src/components/collapsible/index.ts",
       "default": "./dist/components/collapsible/index.js"
     },
     "./collapsible/schema": {
@@ -1145,6 +1260,7 @@
       "browser": "./src/components/collapsible/collapsible.schema.ts",
       "node": "./dist/server/components/collapsible/collapsible.schema.js",
       "svelte": "./src/components/collapsible/collapsible.schema.ts",
+      "import": "./src/components/collapsible/collapsible.schema.ts",
       "default": "./dist/components/collapsible/collapsible.schema.js"
     },
     "./collapsible/variables": {
@@ -1152,6 +1268,7 @@
       "browser": "./src/components/collapsible/collapsible.variables.ts",
       "node": "./dist/server/components/collapsible/collapsible.variables.js",
       "svelte": "./src/components/collapsible/collapsible.variables.ts",
+      "import": "./src/components/collapsible/collapsible.variables.ts",
       "default": "./dist/components/collapsible/collapsible.variables.js"
     },
     "./collapsible/styles": {
@@ -1167,6 +1284,7 @@
       "browser": "./src/components/color-field/index.ts",
       "node": "./dist/server/components/color-field/index.js",
       "svelte": "./src/components/color-field/index.ts",
+      "import": "./src/components/color-field/index.ts",
       "default": "./dist/components/color-field/index.js"
     },
     "./color-field/schema": {
@@ -1174,6 +1292,7 @@
       "browser": "./src/components/color-field/color-field.schema.ts",
       "node": "./dist/server/components/color-field/color-field.schema.js",
       "svelte": "./src/components/color-field/color-field.schema.ts",
+      "import": "./src/components/color-field/color-field.schema.ts",
       "default": "./dist/components/color-field/color-field.schema.js"
     },
     "./color-field/variables": {
@@ -1181,6 +1300,7 @@
       "browser": "./src/components/color-field/color-field.variables.ts",
       "node": "./dist/server/components/color-field/color-field.variables.js",
       "svelte": "./src/components/color-field/color-field.variables.ts",
+      "import": "./src/components/color-field/color-field.variables.ts",
       "default": "./dist/components/color-field/color-field.variables.js"
     },
     "./color-field/styles": {
@@ -1196,6 +1316,7 @@
       "browser": "./src/components/color-picker/index.ts",
       "node": "./dist/server/components/color-picker/index.js",
       "svelte": "./src/components/color-picker/index.ts",
+      "import": "./src/components/color-picker/index.ts",
       "default": "./dist/components/color-picker/index.js"
     },
     "./color-picker/schema": {
@@ -1203,6 +1324,7 @@
       "browser": "./src/components/color-picker/color-picker.schema.ts",
       "node": "./dist/server/components/color-picker/color-picker.schema.js",
       "svelte": "./src/components/color-picker/color-picker.schema.ts",
+      "import": "./src/components/color-picker/color-picker.schema.ts",
       "default": "./dist/components/color-picker/color-picker.schema.js"
     },
     "./color-picker/variables": {
@@ -1210,6 +1332,7 @@
       "browser": "./src/components/color-picker/color-picker.variables.ts",
       "node": "./dist/server/components/color-picker/color-picker.variables.js",
       "svelte": "./src/components/color-picker/color-picker.variables.ts",
+      "import": "./src/components/color-picker/color-picker.variables.ts",
       "default": "./dist/components/color-picker/color-picker.variables.js"
     },
     "./color-picker/styles": {
@@ -1225,6 +1348,7 @@
       "browser": "./src/components/color-swatch-picker/index.ts",
       "node": "./dist/server/components/color-swatch-picker/index.js",
       "svelte": "./src/components/color-swatch-picker/index.ts",
+      "import": "./src/components/color-swatch-picker/index.ts",
       "default": "./dist/components/color-swatch-picker/index.js"
     },
     "./color-swatch-picker/schema": {
@@ -1232,6 +1356,7 @@
       "browser": "./src/components/color-swatch-picker/color-swatch-picker.schema.ts",
       "node": "./dist/server/components/color-swatch-picker/color-swatch-picker.schema.js",
       "svelte": "./src/components/color-swatch-picker/color-swatch-picker.schema.ts",
+      "import": "./src/components/color-swatch-picker/color-swatch-picker.schema.ts",
       "default": "./dist/components/color-swatch-picker/color-swatch-picker.schema.js"
     },
     "./color-swatch-picker/variables": {
@@ -1239,6 +1364,7 @@
       "browser": "./src/components/color-swatch-picker/color-swatch-picker.variables.ts",
       "node": "./dist/server/components/color-swatch-picker/color-swatch-picker.variables.js",
       "svelte": "./src/components/color-swatch-picker/color-swatch-picker.variables.ts",
+      "import": "./src/components/color-swatch-picker/color-swatch-picker.variables.ts",
       "default": "./dist/components/color-swatch-picker/color-swatch-picker.variables.js"
     },
     "./color-swatch-picker/styles": {
@@ -1254,6 +1380,7 @@
       "browser": "./src/components/combobox/index.ts",
       "node": "./dist/server/components/combobox/index.js",
       "svelte": "./src/components/combobox/index.ts",
+      "import": "./src/components/combobox/index.ts",
       "default": "./dist/components/combobox/index.js"
     },
     "./combobox/schema": {
@@ -1261,6 +1388,7 @@
       "browser": "./src/components/combobox/combobox.schema.ts",
       "node": "./dist/server/components/combobox/combobox.schema.js",
       "svelte": "./src/components/combobox/combobox.schema.ts",
+      "import": "./src/components/combobox/combobox.schema.ts",
       "default": "./dist/components/combobox/combobox.schema.js"
     },
     "./combobox/variables": {
@@ -1268,6 +1396,7 @@
       "browser": "./src/components/combobox/combobox.variables.ts",
       "node": "./dist/server/components/combobox/combobox.variables.js",
       "svelte": "./src/components/combobox/combobox.variables.ts",
+      "import": "./src/components/combobox/combobox.variables.ts",
       "default": "./dist/components/combobox/combobox.variables.js"
     },
     "./combobox/styles": {
@@ -1283,6 +1412,7 @@
       "browser": "./src/components/command-item/index.ts",
       "node": "./dist/server/components/command-item/index.js",
       "svelte": "./src/components/command-item/index.ts",
+      "import": "./src/components/command-item/index.ts",
       "default": "./dist/components/command-item/index.js"
     },
     "./command-item/schema": {
@@ -1290,6 +1420,7 @@
       "browser": "./src/components/command-item/command-item.schema.ts",
       "node": "./dist/server/components/command-item/command-item.schema.js",
       "svelte": "./src/components/command-item/command-item.schema.ts",
+      "import": "./src/components/command-item/command-item.schema.ts",
       "default": "./dist/components/command-item/command-item.schema.js"
     },
     "./command-item/variables": {
@@ -1297,6 +1428,7 @@
       "browser": "./src/components/command-item/command-item.variables.ts",
       "node": "./dist/server/components/command-item/command-item.variables.js",
       "svelte": "./src/components/command-item/command-item.variables.ts",
+      "import": "./src/components/command-item/command-item.variables.ts",
       "default": "./dist/components/command-item/command-item.variables.js"
     },
     "./command-item/styles": {
@@ -1308,6 +1440,7 @@
       "browser": "./src/components/command-menu/index.ts",
       "node": "./dist/server/components/command-menu/index.js",
       "svelte": "./src/components/command-menu/index.ts",
+      "import": "./src/components/command-menu/index.ts",
       "default": "./dist/components/command-menu/index.js"
     },
     "./command-menu/schema": {
@@ -1315,6 +1448,7 @@
       "browser": "./src/components/command-menu/command-menu.schema.ts",
       "node": "./dist/server/components/command-menu/command-menu.schema.js",
       "svelte": "./src/components/command-menu/command-menu.schema.ts",
+      "import": "./src/components/command-menu/command-menu.schema.ts",
       "default": "./dist/components/command-menu/command-menu.schema.js"
     },
     "./command-menu/variables": {
@@ -1322,6 +1456,7 @@
       "browser": "./src/components/command-menu/command-menu.variables.ts",
       "node": "./dist/server/components/command-menu/command-menu.variables.js",
       "svelte": "./src/components/command-menu/command-menu.variables.ts",
+      "import": "./src/components/command-menu/command-menu.variables.ts",
       "default": "./dist/components/command-menu/command-menu.variables.js"
     },
     "./command-menu/styles": {
@@ -1337,6 +1472,7 @@
       "browser": "./src/components/command-palette/index.ts",
       "node": "./dist/server/components/command-palette/index.js",
       "svelte": "./src/components/command-palette/index.ts",
+      "import": "./src/components/command-palette/index.ts",
       "default": "./dist/components/command-palette/index.js"
     },
     "./command-palette/schema": {
@@ -1344,6 +1480,7 @@
       "browser": "./src/components/command-palette/command-palette.schema.ts",
       "node": "./dist/server/components/command-palette/command-palette.schema.js",
       "svelte": "./src/components/command-palette/command-palette.schema.ts",
+      "import": "./src/components/command-palette/command-palette.schema.ts",
       "default": "./dist/components/command-palette/command-palette.schema.js"
     },
     "./command-palette/variables": {
@@ -1351,6 +1488,7 @@
       "browser": "./src/components/command-palette/command-palette.variables.ts",
       "node": "./dist/server/components/command-palette/command-palette.variables.js",
       "svelte": "./src/components/command-palette/command-palette.variables.ts",
+      "import": "./src/components/command-palette/command-palette.variables.ts",
       "default": "./dist/components/command-palette/command-palette.variables.js"
     },
     "./command-palette/styles": {
@@ -1366,6 +1504,7 @@
       "browser": "./src/components/confirm-dialog/index.ts",
       "node": "./dist/server/components/confirm-dialog/index.js",
       "svelte": "./src/components/confirm-dialog/index.ts",
+      "import": "./src/components/confirm-dialog/index.ts",
       "default": "./dist/components/confirm-dialog/index.js"
     },
     "./confirm-dialog/schema": {
@@ -1373,6 +1512,7 @@
       "browser": "./src/components/confirm-dialog/confirm-dialog.schema.ts",
       "node": "./dist/server/components/confirm-dialog/confirm-dialog.schema.js",
       "svelte": "./src/components/confirm-dialog/confirm-dialog.schema.ts",
+      "import": "./src/components/confirm-dialog/confirm-dialog.schema.ts",
       "default": "./dist/components/confirm-dialog/confirm-dialog.schema.js"
     },
     "./confirm-dialog/variables": {
@@ -1380,6 +1520,7 @@
       "browser": "./src/components/confirm-dialog/confirm-dialog.variables.ts",
       "node": "./dist/server/components/confirm-dialog/confirm-dialog.variables.js",
       "svelte": "./src/components/confirm-dialog/confirm-dialog.variables.ts",
+      "import": "./src/components/confirm-dialog/confirm-dialog.variables.ts",
       "default": "./dist/components/confirm-dialog/confirm-dialog.variables.js"
     },
     "./confirm-dialog/styles": {
@@ -1395,6 +1536,7 @@
       "browser": "./src/components/container/index.ts",
       "node": "./dist/server/components/container/index.js",
       "svelte": "./src/components/container/index.ts",
+      "import": "./src/components/container/index.ts",
       "default": "./dist/components/container/index.js"
     },
     "./container/schema": {
@@ -1402,6 +1544,7 @@
       "browser": "./src/components/container/container.schema.ts",
       "node": "./dist/server/components/container/container.schema.js",
       "svelte": "./src/components/container/container.schema.ts",
+      "import": "./src/components/container/container.schema.ts",
       "default": "./dist/components/container/container.schema.js"
     },
     "./container/variables": {
@@ -1409,6 +1552,7 @@
       "browser": "./src/components/container/container.variables.ts",
       "node": "./dist/server/components/container/container.variables.js",
       "svelte": "./src/components/container/container.variables.ts",
+      "import": "./src/components/container/container.variables.ts",
       "default": "./dist/components/container/container.variables.js"
     },
     "./container/styles": {
@@ -1424,6 +1568,7 @@
       "browser": "./src/components/context-menu/index.ts",
       "node": "./dist/server/components/context-menu/index.js",
       "svelte": "./src/components/context-menu/index.ts",
+      "import": "./src/components/context-menu/index.ts",
       "default": "./dist/components/context-menu/index.js"
     },
     "./context-menu/schema": {
@@ -1431,6 +1576,7 @@
       "browser": "./src/components/context-menu/context-menu.schema.ts",
       "node": "./dist/server/components/context-menu/context-menu.schema.js",
       "svelte": "./src/components/context-menu/context-menu.schema.ts",
+      "import": "./src/components/context-menu/context-menu.schema.ts",
       "default": "./dist/components/context-menu/context-menu.schema.js"
     },
     "./context-menu/variables": {
@@ -1438,6 +1584,7 @@
       "browser": "./src/components/context-menu/context-menu.variables.ts",
       "node": "./dist/server/components/context-menu/context-menu.variables.js",
       "svelte": "./src/components/context-menu/context-menu.variables.ts",
+      "import": "./src/components/context-menu/context-menu.variables.ts",
       "default": "./dist/components/context-menu/context-menu.variables.js"
     },
     "./context-menu/styles": {
@@ -1453,6 +1600,7 @@
       "browser": "./src/components/context-menu-trigger/index.ts",
       "node": "./dist/server/components/context-menu-trigger/index.js",
       "svelte": "./src/components/context-menu-trigger/index.ts",
+      "import": "./src/components/context-menu-trigger/index.ts",
       "default": "./dist/components/context-menu-trigger/index.js"
     },
     "./context-menu-trigger/schema": {
@@ -1460,6 +1608,7 @@
       "browser": "./src/components/context-menu-trigger/context-menu-trigger.schema.ts",
       "node": "./dist/server/components/context-menu-trigger/context-menu-trigger.schema.js",
       "svelte": "./src/components/context-menu-trigger/context-menu-trigger.schema.ts",
+      "import": "./src/components/context-menu-trigger/context-menu-trigger.schema.ts",
       "default": "./dist/components/context-menu-trigger/context-menu-trigger.schema.js"
     },
     "./context-menu-trigger/variables": {
@@ -1467,6 +1616,7 @@
       "browser": "./src/components/context-menu-trigger/context-menu-trigger.variables.ts",
       "node": "./dist/server/components/context-menu-trigger/context-menu-trigger.variables.js",
       "svelte": "./src/components/context-menu-trigger/context-menu-trigger.variables.ts",
+      "import": "./src/components/context-menu-trigger/context-menu-trigger.variables.ts",
       "default": "./dist/components/context-menu-trigger/context-menu-trigger.variables.js"
     },
     "./copy-button": {
@@ -1474,6 +1624,7 @@
       "browser": "./src/components/copy-button/index.ts",
       "node": "./dist/server/components/copy-button/index.js",
       "svelte": "./src/components/copy-button/index.ts",
+      "import": "./src/components/copy-button/index.ts",
       "default": "./dist/components/copy-button/index.js"
     },
     "./copy-button/schema": {
@@ -1481,6 +1632,7 @@
       "browser": "./src/components/copy-button/copy-button.schema.ts",
       "node": "./dist/server/components/copy-button/copy-button.schema.js",
       "svelte": "./src/components/copy-button/copy-button.schema.ts",
+      "import": "./src/components/copy-button/copy-button.schema.ts",
       "default": "./dist/components/copy-button/copy-button.schema.js"
     },
     "./copy-button/variables": {
@@ -1488,6 +1640,7 @@
       "browser": "./src/components/copy-button/copy-button.variables.ts",
       "node": "./dist/server/components/copy-button/copy-button.variables.js",
       "svelte": "./src/components/copy-button/copy-button.variables.ts",
+      "import": "./src/components/copy-button/copy-button.variables.ts",
       "default": "./dist/components/copy-button/copy-button.variables.js"
     },
     "./copy-button/styles": {
@@ -1503,6 +1656,7 @@
       "browser": "./src/components/cta-section/index.ts",
       "node": "./dist/server/components/cta-section/index.js",
       "svelte": "./src/components/cta-section/index.ts",
+      "import": "./src/components/cta-section/index.ts",
       "default": "./dist/components/cta-section/index.js"
     },
     "./cta-section/schema": {
@@ -1510,6 +1664,7 @@
       "browser": "./src/components/cta-section/cta-section.schema.ts",
       "node": "./dist/server/components/cta-section/cta-section.schema.js",
       "svelte": "./src/components/cta-section/cta-section.schema.ts",
+      "import": "./src/components/cta-section/cta-section.schema.ts",
       "default": "./dist/components/cta-section/cta-section.schema.js"
     },
     "./cta-section/variables": {
@@ -1517,6 +1672,7 @@
       "browser": "./src/components/cta-section/cta-section.variables.ts",
       "node": "./dist/server/components/cta-section/cta-section.variables.js",
       "svelte": "./src/components/cta-section/cta-section.variables.ts",
+      "import": "./src/components/cta-section/cta-section.variables.ts",
       "default": "./dist/components/cta-section/cta-section.variables.js"
     },
     "./cta-section/styles": {
@@ -1532,6 +1688,7 @@
       "browser": "./src/components/data-grid/index.ts",
       "node": "./dist/server/components/data-grid/index.js",
       "svelte": "./src/components/data-grid/index.ts",
+      "import": "./src/components/data-grid/index.ts",
       "default": "./dist/components/data-grid/index.js"
     },
     "./data-grid/schema": {
@@ -1539,6 +1696,7 @@
       "browser": "./src/components/data-grid/data-grid.schema.ts",
       "node": "./dist/server/components/data-grid/data-grid.schema.js",
       "svelte": "./src/components/data-grid/data-grid.schema.ts",
+      "import": "./src/components/data-grid/data-grid.schema.ts",
       "default": "./dist/components/data-grid/data-grid.schema.js"
     },
     "./data-grid/variables": {
@@ -1546,6 +1704,7 @@
       "browser": "./src/components/data-grid/data-grid.variables.ts",
       "node": "./dist/server/components/data-grid/data-grid.variables.js",
       "svelte": "./src/components/data-grid/data-grid.variables.ts",
+      "import": "./src/components/data-grid/data-grid.variables.ts",
       "default": "./dist/components/data-grid/data-grid.variables.js"
     },
     "./data-grid/styles": {
@@ -1561,6 +1720,7 @@
       "browser": "./src/components/data-list/index.ts",
       "node": "./dist/server/components/data-list/index.js",
       "svelte": "./src/components/data-list/index.ts",
+      "import": "./src/components/data-list/index.ts",
       "default": "./dist/components/data-list/index.js"
     },
     "./data-list/schema": {
@@ -1568,6 +1728,7 @@
       "browser": "./src/components/data-list/data-list.schema.ts",
       "node": "./dist/server/components/data-list/data-list.schema.js",
       "svelte": "./src/components/data-list/data-list.schema.ts",
+      "import": "./src/components/data-list/data-list.schema.ts",
       "default": "./dist/components/data-list/data-list.schema.js"
     },
     "./data-list/variables": {
@@ -1575,6 +1736,7 @@
       "browser": "./src/components/data-list/data-list.variables.ts",
       "node": "./dist/server/components/data-list/data-list.variables.js",
       "svelte": "./src/components/data-list/data-list.variables.ts",
+      "import": "./src/components/data-list/data-list.variables.ts",
       "default": "./dist/components/data-list/data-list.variables.js"
     },
     "./data-list/styles": {
@@ -1590,6 +1752,7 @@
       "browser": "./src/components/data-table/index.ts",
       "node": "./dist/server/components/data-table/index.js",
       "svelte": "./src/components/data-table/index.ts",
+      "import": "./src/components/data-table/index.ts",
       "default": "./dist/components/data-table/index.js"
     },
     "./data-table/schema": {
@@ -1597,6 +1760,7 @@
       "browser": "./src/components/data-table/data-table.schema.ts",
       "node": "./dist/server/components/data-table/data-table.schema.js",
       "svelte": "./src/components/data-table/data-table.schema.ts",
+      "import": "./src/components/data-table/data-table.schema.ts",
       "default": "./dist/components/data-table/data-table.schema.js"
     },
     "./data-table/variables": {
@@ -1604,6 +1768,7 @@
       "browser": "./src/components/data-table/data-table.variables.ts",
       "node": "./dist/server/components/data-table/data-table.variables.js",
       "svelte": "./src/components/data-table/data-table.variables.ts",
+      "import": "./src/components/data-table/data-table.variables.ts",
       "default": "./dist/components/data-table/data-table.variables.js"
     },
     "./data-table/styles": {
@@ -1619,6 +1784,7 @@
       "browser": "./src/components/date-picker/index.ts",
       "node": "./dist/server/components/date-picker/index.js",
       "svelte": "./src/components/date-picker/index.ts",
+      "import": "./src/components/date-picker/index.ts",
       "default": "./dist/components/date-picker/index.js"
     },
     "./date-picker/schema": {
@@ -1626,6 +1792,7 @@
       "browser": "./src/components/date-picker/date-picker.schema.ts",
       "node": "./dist/server/components/date-picker/date-picker.schema.js",
       "svelte": "./src/components/date-picker/date-picker.schema.ts",
+      "import": "./src/components/date-picker/date-picker.schema.ts",
       "default": "./dist/components/date-picker/date-picker.schema.js"
     },
     "./date-picker/variables": {
@@ -1633,6 +1800,7 @@
       "browser": "./src/components/date-picker/date-picker.variables.ts",
       "node": "./dist/server/components/date-picker/date-picker.variables.js",
       "svelte": "./src/components/date-picker/date-picker.variables.ts",
+      "import": "./src/components/date-picker/date-picker.variables.ts",
       "default": "./dist/components/date-picker/date-picker.variables.js"
     },
     "./date-picker/styles": {
@@ -1648,6 +1816,7 @@
       "browser": "./src/components/date-range-field/index.ts",
       "node": "./dist/server/components/date-range-field/index.js",
       "svelte": "./src/components/date-range-field/index.ts",
+      "import": "./src/components/date-range-field/index.ts",
       "default": "./dist/components/date-range-field/index.js"
     },
     "./date-range-field/schema": {
@@ -1655,6 +1824,7 @@
       "browser": "./src/components/date-range-field/date-range-field.schema.ts",
       "node": "./dist/server/components/date-range-field/date-range-field.schema.js",
       "svelte": "./src/components/date-range-field/date-range-field.schema.ts",
+      "import": "./src/components/date-range-field/date-range-field.schema.ts",
       "default": "./dist/components/date-range-field/date-range-field.schema.js"
     },
     "./date-range-field/variables": {
@@ -1662,6 +1832,7 @@
       "browser": "./src/components/date-range-field/date-range-field.variables.ts",
       "node": "./dist/server/components/date-range-field/date-range-field.variables.js",
       "svelte": "./src/components/date-range-field/date-range-field.variables.ts",
+      "import": "./src/components/date-range-field/date-range-field.variables.ts",
       "default": "./dist/components/date-range-field/date-range-field.variables.js"
     },
     "./date-range-field/styles": {
@@ -1677,6 +1848,7 @@
       "browser": "./src/components/description-list/index.ts",
       "node": "./dist/server/components/description-list/index.js",
       "svelte": "./src/components/description-list/index.ts",
+      "import": "./src/components/description-list/index.ts",
       "default": "./dist/components/description-list/index.js"
     },
     "./description-list/schema": {
@@ -1684,6 +1856,7 @@
       "browser": "./src/components/description-list/description-list.schema.ts",
       "node": "./dist/server/components/description-list/description-list.schema.js",
       "svelte": "./src/components/description-list/description-list.schema.ts",
+      "import": "./src/components/description-list/description-list.schema.ts",
       "default": "./dist/components/description-list/description-list.schema.js"
     },
     "./description-list/variables": {
@@ -1691,6 +1864,7 @@
       "browser": "./src/components/description-list/description-list.variables.ts",
       "node": "./dist/server/components/description-list/description-list.variables.js",
       "svelte": "./src/components/description-list/description-list.variables.ts",
+      "import": "./src/components/description-list/description-list.variables.ts",
       "default": "./dist/components/description-list/description-list.variables.js"
     },
     "./description-list/styles": {
@@ -1706,6 +1880,7 @@
       "browser": "./src/components/diff-statistics/index.ts",
       "node": "./dist/server/components/diff-statistics/index.js",
       "svelte": "./src/components/diff-statistics/index.ts",
+      "import": "./src/components/diff-statistics/index.ts",
       "default": "./dist/components/diff-statistics/index.js"
     },
     "./diff-statistics/schema": {
@@ -1713,6 +1888,7 @@
       "browser": "./src/components/diff-statistics/diff-statistics.schema.ts",
       "node": "./dist/server/components/diff-statistics/diff-statistics.schema.js",
       "svelte": "./src/components/diff-statistics/diff-statistics.schema.ts",
+      "import": "./src/components/diff-statistics/diff-statistics.schema.ts",
       "default": "./dist/components/diff-statistics/diff-statistics.schema.js"
     },
     "./diff-statistics/variables": {
@@ -1720,6 +1896,7 @@
       "browser": "./src/components/diff-statistics/diff-statistics.variables.ts",
       "node": "./dist/server/components/diff-statistics/diff-statistics.variables.js",
       "svelte": "./src/components/diff-statistics/diff-statistics.variables.ts",
+      "import": "./src/components/diff-statistics/diff-statistics.variables.ts",
       "default": "./dist/components/diff-statistics/diff-statistics.variables.js"
     },
     "./diff-statistics/styles": {
@@ -1735,6 +1912,7 @@
       "browser": "./src/components/diff-viewer/index.ts",
       "node": "./dist/server/components/diff-viewer/index.js",
       "svelte": "./src/components/diff-viewer/index.ts",
+      "import": "./src/components/diff-viewer/index.ts",
       "default": "./dist/components/diff-viewer/index.js"
     },
     "./diff-viewer/schema": {
@@ -1742,6 +1920,7 @@
       "browser": "./src/components/diff-viewer/diff-viewer.schema.ts",
       "node": "./dist/server/components/diff-viewer/diff-viewer.schema.js",
       "svelte": "./src/components/diff-viewer/diff-viewer.schema.ts",
+      "import": "./src/components/diff-viewer/diff-viewer.schema.ts",
       "default": "./dist/components/diff-viewer/diff-viewer.schema.js"
     },
     "./diff-viewer/variables": {
@@ -1749,6 +1928,7 @@
       "browser": "./src/components/diff-viewer/diff-viewer.variables.ts",
       "node": "./dist/server/components/diff-viewer/diff-viewer.variables.js",
       "svelte": "./src/components/diff-viewer/diff-viewer.variables.ts",
+      "import": "./src/components/diff-viewer/diff-viewer.variables.ts",
       "default": "./dist/components/diff-viewer/diff-viewer.variables.js"
     },
     "./diff-viewer/examples": {
@@ -1760,6 +1940,7 @@
       "browser": "./src/components/divider/index.ts",
       "node": "./dist/server/components/divider/index.js",
       "svelte": "./src/components/divider/index.ts",
+      "import": "./src/components/divider/index.ts",
       "default": "./dist/components/divider/index.js"
     },
     "./divider/schema": {
@@ -1767,6 +1948,7 @@
       "browser": "./src/components/divider/divider.schema.ts",
       "node": "./dist/server/components/divider/divider.schema.js",
       "svelte": "./src/components/divider/divider.schema.ts",
+      "import": "./src/components/divider/divider.schema.ts",
       "default": "./dist/components/divider/divider.schema.js"
     },
     "./divider/variables": {
@@ -1774,6 +1956,7 @@
       "browser": "./src/components/divider/divider.variables.ts",
       "node": "./dist/server/components/divider/divider.variables.js",
       "svelte": "./src/components/divider/divider.variables.ts",
+      "import": "./src/components/divider/divider.variables.ts",
       "default": "./dist/components/divider/divider.variables.js"
     },
     "./divider/styles": {
@@ -1789,6 +1972,7 @@
       "browser": "./src/components/drawer/index.ts",
       "node": "./dist/server/components/drawer/index.js",
       "svelte": "./src/components/drawer/index.ts",
+      "import": "./src/components/drawer/index.ts",
       "default": "./dist/components/drawer/index.js"
     },
     "./drawer/schema": {
@@ -1796,6 +1980,7 @@
       "browser": "./src/components/drawer/drawer.schema.ts",
       "node": "./dist/server/components/drawer/drawer.schema.js",
       "svelte": "./src/components/drawer/drawer.schema.ts",
+      "import": "./src/components/drawer/drawer.schema.ts",
       "default": "./dist/components/drawer/drawer.schema.js"
     },
     "./drawer/variables": {
@@ -1803,6 +1988,7 @@
       "browser": "./src/components/drawer/drawer.variables.ts",
       "node": "./dist/server/components/drawer/drawer.variables.js",
       "svelte": "./src/components/drawer/drawer.variables.ts",
+      "import": "./src/components/drawer/drawer.variables.ts",
       "default": "./dist/components/drawer/drawer.variables.js"
     },
     "./drawer/styles": {
@@ -1818,6 +2004,7 @@
       "browser": "./src/components/dropdown/index.ts",
       "node": "./dist/server/components/dropdown/index.js",
       "svelte": "./src/components/dropdown/index.ts",
+      "import": "./src/components/dropdown/index.ts",
       "default": "./dist/components/dropdown/index.js"
     },
     "./dropdown/schema": {
@@ -1825,6 +2012,7 @@
       "browser": "./src/components/dropdown/dropdown.schema.ts",
       "node": "./dist/server/components/dropdown/dropdown.schema.js",
       "svelte": "./src/components/dropdown/dropdown.schema.ts",
+      "import": "./src/components/dropdown/dropdown.schema.ts",
       "default": "./dist/components/dropdown/dropdown.schema.js"
     },
     "./dropdown/variables": {
@@ -1832,6 +2020,7 @@
       "browser": "./src/components/dropdown/dropdown.variables.ts",
       "node": "./dist/server/components/dropdown/dropdown.variables.js",
       "svelte": "./src/components/dropdown/dropdown.variables.ts",
+      "import": "./src/components/dropdown/dropdown.variables.ts",
       "default": "./dist/components/dropdown/dropdown.variables.js"
     },
     "./dropdown/styles": {
@@ -1847,6 +2036,7 @@
       "browser": "./src/components/dropdown-group/index.ts",
       "node": "./dist/server/components/dropdown-group/index.js",
       "svelte": "./src/components/dropdown-group/index.ts",
+      "import": "./src/components/dropdown-group/index.ts",
       "default": "./dist/components/dropdown-group/index.js"
     },
     "./dropdown-group/schema": {
@@ -1854,6 +2044,7 @@
       "browser": "./src/components/dropdown-group/dropdown-group.schema.ts",
       "node": "./dist/server/components/dropdown-group/dropdown-group.schema.js",
       "svelte": "./src/components/dropdown-group/dropdown-group.schema.ts",
+      "import": "./src/components/dropdown-group/dropdown-group.schema.ts",
       "default": "./dist/components/dropdown-group/dropdown-group.schema.js"
     },
     "./dropdown-group/variables": {
@@ -1861,6 +2052,7 @@
       "browser": "./src/components/dropdown-group/dropdown-group.variables.ts",
       "node": "./dist/server/components/dropdown-group/dropdown-group.variables.js",
       "svelte": "./src/components/dropdown-group/dropdown-group.variables.ts",
+      "import": "./src/components/dropdown-group/dropdown-group.variables.ts",
       "default": "./dist/components/dropdown-group/dropdown-group.variables.js"
     },
     "./dropdown-item": {
@@ -1868,6 +2060,7 @@
       "browser": "./src/components/dropdown-item/index.ts",
       "node": "./dist/server/components/dropdown-item/index.js",
       "svelte": "./src/components/dropdown-item/index.ts",
+      "import": "./src/components/dropdown-item/index.ts",
       "default": "./dist/components/dropdown-item/index.js"
     },
     "./dropdown-item/schema": {
@@ -1875,6 +2068,7 @@
       "browser": "./src/components/dropdown-item/dropdown-item.schema.ts",
       "node": "./dist/server/components/dropdown-item/dropdown-item.schema.js",
       "svelte": "./src/components/dropdown-item/dropdown-item.schema.ts",
+      "import": "./src/components/dropdown-item/dropdown-item.schema.ts",
       "default": "./dist/components/dropdown-item/dropdown-item.schema.js"
     },
     "./dropdown-item/variables": {
@@ -1882,6 +2076,7 @@
       "browser": "./src/components/dropdown-item/dropdown-item.variables.ts",
       "node": "./dist/server/components/dropdown-item/dropdown-item.variables.js",
       "svelte": "./src/components/dropdown-item/dropdown-item.variables.ts",
+      "import": "./src/components/dropdown-item/dropdown-item.variables.ts",
       "default": "./dist/components/dropdown-item/dropdown-item.variables.js"
     },
     "./dropdown-label": {
@@ -1889,6 +2084,7 @@
       "browser": "./src/components/dropdown-label/index.ts",
       "node": "./dist/server/components/dropdown-label/index.js",
       "svelte": "./src/components/dropdown-label/index.ts",
+      "import": "./src/components/dropdown-label/index.ts",
       "default": "./dist/components/dropdown-label/index.js"
     },
     "./dropdown-label/schema": {
@@ -1896,6 +2092,7 @@
       "browser": "./src/components/dropdown-label/dropdown-label.schema.ts",
       "node": "./dist/server/components/dropdown-label/dropdown-label.schema.js",
       "svelte": "./src/components/dropdown-label/dropdown-label.schema.ts",
+      "import": "./src/components/dropdown-label/dropdown-label.schema.ts",
       "default": "./dist/components/dropdown-label/dropdown-label.schema.js"
     },
     "./dropdown-label/variables": {
@@ -1903,6 +2100,7 @@
       "browser": "./src/components/dropdown-label/dropdown-label.variables.ts",
       "node": "./dist/server/components/dropdown-label/dropdown-label.variables.js",
       "svelte": "./src/components/dropdown-label/dropdown-label.variables.ts",
+      "import": "./src/components/dropdown-label/dropdown-label.variables.ts",
       "default": "./dist/components/dropdown-label/dropdown-label.variables.js"
     },
     "./dropdown-menu": {
@@ -1910,6 +2108,7 @@
       "browser": "./src/components/dropdown-menu/index.ts",
       "node": "./dist/server/components/dropdown-menu/index.js",
       "svelte": "./src/components/dropdown-menu/index.ts",
+      "import": "./src/components/dropdown-menu/index.ts",
       "default": "./dist/components/dropdown-menu/index.js"
     },
     "./dropdown-menu/schema": {
@@ -1917,6 +2116,7 @@
       "browser": "./src/components/dropdown-menu/dropdown-menu.schema.ts",
       "node": "./dist/server/components/dropdown-menu/dropdown-menu.schema.js",
       "svelte": "./src/components/dropdown-menu/dropdown-menu.schema.ts",
+      "import": "./src/components/dropdown-menu/dropdown-menu.schema.ts",
       "default": "./dist/components/dropdown-menu/dropdown-menu.schema.js"
     },
     "./dropdown-menu/variables": {
@@ -1924,6 +2124,7 @@
       "browser": "./src/components/dropdown-menu/dropdown-menu.variables.ts",
       "node": "./dist/server/components/dropdown-menu/dropdown-menu.variables.js",
       "svelte": "./src/components/dropdown-menu/dropdown-menu.variables.ts",
+      "import": "./src/components/dropdown-menu/dropdown-menu.variables.ts",
       "default": "./dist/components/dropdown-menu/dropdown-menu.variables.js"
     },
     "./dropdown-separator": {
@@ -1931,6 +2132,7 @@
       "browser": "./src/components/dropdown-separator/index.ts",
       "node": "./dist/server/components/dropdown-separator/index.js",
       "svelte": "./src/components/dropdown-separator/index.ts",
+      "import": "./src/components/dropdown-separator/index.ts",
       "default": "./dist/components/dropdown-separator/index.js"
     },
     "./dropdown-separator/schema": {
@@ -1938,6 +2140,7 @@
       "browser": "./src/components/dropdown-separator/dropdown-separator.schema.ts",
       "node": "./dist/server/components/dropdown-separator/dropdown-separator.schema.js",
       "svelte": "./src/components/dropdown-separator/dropdown-separator.schema.ts",
+      "import": "./src/components/dropdown-separator/dropdown-separator.schema.ts",
       "default": "./dist/components/dropdown-separator/dropdown-separator.schema.js"
     },
     "./dropdown-separator/variables": {
@@ -1945,6 +2148,7 @@
       "browser": "./src/components/dropdown-separator/dropdown-separator.variables.ts",
       "node": "./dist/server/components/dropdown-separator/dropdown-separator.variables.js",
       "svelte": "./src/components/dropdown-separator/dropdown-separator.variables.ts",
+      "import": "./src/components/dropdown-separator/dropdown-separator.variables.ts",
       "default": "./dist/components/dropdown-separator/dropdown-separator.variables.js"
     },
     "./dropdown-trigger": {
@@ -1952,6 +2156,7 @@
       "browser": "./src/components/dropdown-trigger/index.ts",
       "node": "./dist/server/components/dropdown-trigger/index.js",
       "svelte": "./src/components/dropdown-trigger/index.ts",
+      "import": "./src/components/dropdown-trigger/index.ts",
       "default": "./dist/components/dropdown-trigger/index.js"
     },
     "./dropdown-trigger/schema": {
@@ -1959,6 +2164,7 @@
       "browser": "./src/components/dropdown-trigger/dropdown-trigger.schema.ts",
       "node": "./dist/server/components/dropdown-trigger/dropdown-trigger.schema.js",
       "svelte": "./src/components/dropdown-trigger/dropdown-trigger.schema.ts",
+      "import": "./src/components/dropdown-trigger/dropdown-trigger.schema.ts",
       "default": "./dist/components/dropdown-trigger/dropdown-trigger.schema.js"
     },
     "./dropdown-trigger/variables": {
@@ -1966,6 +2172,7 @@
       "browser": "./src/components/dropdown-trigger/dropdown-trigger.variables.ts",
       "node": "./dist/server/components/dropdown-trigger/dropdown-trigger.variables.js",
       "svelte": "./src/components/dropdown-trigger/dropdown-trigger.variables.ts",
+      "import": "./src/components/dropdown-trigger/dropdown-trigger.variables.ts",
       "default": "./dist/components/dropdown-trigger/dropdown-trigger.variables.js"
     },
     "./empty-state": {
@@ -1973,6 +2180,7 @@
       "browser": "./src/components/empty-state/index.ts",
       "node": "./dist/server/components/empty-state/index.js",
       "svelte": "./src/components/empty-state/index.ts",
+      "import": "./src/components/empty-state/index.ts",
       "default": "./dist/components/empty-state/index.js"
     },
     "./empty-state/schema": {
@@ -1980,6 +2188,7 @@
       "browser": "./src/components/empty-state/empty-state.schema.ts",
       "node": "./dist/server/components/empty-state/empty-state.schema.js",
       "svelte": "./src/components/empty-state/empty-state.schema.ts",
+      "import": "./src/components/empty-state/empty-state.schema.ts",
       "default": "./dist/components/empty-state/empty-state.schema.js"
     },
     "./empty-state/variables": {
@@ -1987,6 +2196,7 @@
       "browser": "./src/components/empty-state/empty-state.variables.ts",
       "node": "./dist/server/components/empty-state/empty-state.variables.js",
       "svelte": "./src/components/empty-state/empty-state.variables.ts",
+      "import": "./src/components/empty-state/empty-state.variables.ts",
       "default": "./dist/components/empty-state/empty-state.variables.js"
     },
     "./empty-state/styles": {
@@ -2002,6 +2212,7 @@
       "browser": "./src/components/event-stream-viewer/index.ts",
       "node": "./dist/server/components/event-stream-viewer/index.js",
       "svelte": "./src/components/event-stream-viewer/index.ts",
+      "import": "./src/components/event-stream-viewer/index.ts",
       "default": "./dist/components/event-stream-viewer/index.js"
     },
     "./event-stream-viewer/schema": {
@@ -2009,6 +2220,7 @@
       "browser": "./src/components/event-stream-viewer/event-stream-viewer.schema.ts",
       "node": "./dist/server/components/event-stream-viewer/event-stream-viewer.schema.js",
       "svelte": "./src/components/event-stream-viewer/event-stream-viewer.schema.ts",
+      "import": "./src/components/event-stream-viewer/event-stream-viewer.schema.ts",
       "default": "./dist/components/event-stream-viewer/event-stream-viewer.schema.js"
     },
     "./event-stream-viewer/variables": {
@@ -2016,6 +2228,7 @@
       "browser": "./src/components/event-stream-viewer/event-stream-viewer.variables.ts",
       "node": "./dist/server/components/event-stream-viewer/event-stream-viewer.variables.js",
       "svelte": "./src/components/event-stream-viewer/event-stream-viewer.variables.ts",
+      "import": "./src/components/event-stream-viewer/event-stream-viewer.variables.ts",
       "default": "./dist/components/event-stream-viewer/event-stream-viewer.variables.js"
     },
     "./event-stream-viewer/styles": {
@@ -2031,6 +2244,7 @@
       "browser": "./src/components/event-timeline/index.ts",
       "node": "./dist/server/components/event-timeline/index.js",
       "svelte": "./src/components/event-timeline/index.ts",
+      "import": "./src/components/event-timeline/index.ts",
       "default": "./dist/components/event-timeline/index.js"
     },
     "./event-timeline/schema": {
@@ -2038,6 +2252,7 @@
       "browser": "./src/components/event-timeline/event-timeline.schema.ts",
       "node": "./dist/server/components/event-timeline/event-timeline.schema.js",
       "svelte": "./src/components/event-timeline/event-timeline.schema.ts",
+      "import": "./src/components/event-timeline/event-timeline.schema.ts",
       "default": "./dist/components/event-timeline/event-timeline.schema.js"
     },
     "./event-timeline/variables": {
@@ -2045,6 +2260,7 @@
       "browser": "./src/components/event-timeline/event-timeline.variables.ts",
       "node": "./dist/server/components/event-timeline/event-timeline.variables.js",
       "svelte": "./src/components/event-timeline/event-timeline.variables.ts",
+      "import": "./src/components/event-timeline/event-timeline.variables.ts",
       "default": "./dist/components/event-timeline/event-timeline.variables.js"
     },
     "./event-timeline/styles": {
@@ -2060,6 +2276,7 @@
       "browser": "./src/components/faceted-filter-bar/index.ts",
       "node": "./dist/server/components/faceted-filter-bar/index.js",
       "svelte": "./src/components/faceted-filter-bar/index.ts",
+      "import": "./src/components/faceted-filter-bar/index.ts",
       "default": "./dist/components/faceted-filter-bar/index.js"
     },
     "./faceted-filter-bar/schema": {
@@ -2067,6 +2284,7 @@
       "browser": "./src/components/faceted-filter-bar/faceted-filter-bar.schema.ts",
       "node": "./dist/server/components/faceted-filter-bar/faceted-filter-bar.schema.js",
       "svelte": "./src/components/faceted-filter-bar/faceted-filter-bar.schema.ts",
+      "import": "./src/components/faceted-filter-bar/faceted-filter-bar.schema.ts",
       "default": "./dist/components/faceted-filter-bar/faceted-filter-bar.schema.js"
     },
     "./faceted-filter-bar/variables": {
@@ -2074,6 +2292,7 @@
       "browser": "./src/components/faceted-filter-bar/faceted-filter-bar.variables.ts",
       "node": "./dist/server/components/faceted-filter-bar/faceted-filter-bar.variables.js",
       "svelte": "./src/components/faceted-filter-bar/faceted-filter-bar.variables.ts",
+      "import": "./src/components/faceted-filter-bar/faceted-filter-bar.variables.ts",
       "default": "./dist/components/faceted-filter-bar/faceted-filter-bar.variables.js"
     },
     "./faceted-filter-bar/styles": {
@@ -2089,6 +2308,7 @@
       "browser": "./src/components/feature-section/index.ts",
       "node": "./dist/server/components/feature-section/index.js",
       "svelte": "./src/components/feature-section/index.ts",
+      "import": "./src/components/feature-section/index.ts",
       "default": "./dist/components/feature-section/index.js"
     },
     "./feature-section/schema": {
@@ -2096,6 +2316,7 @@
       "browser": "./src/components/feature-section/feature-section.schema.ts",
       "node": "./dist/server/components/feature-section/feature-section.schema.js",
       "svelte": "./src/components/feature-section/feature-section.schema.ts",
+      "import": "./src/components/feature-section/feature-section.schema.ts",
       "default": "./dist/components/feature-section/feature-section.schema.js"
     },
     "./feature-section/variables": {
@@ -2103,6 +2324,7 @@
       "browser": "./src/components/feature-section/feature-section.variables.ts",
       "node": "./dist/server/components/feature-section/feature-section.variables.js",
       "svelte": "./src/components/feature-section/feature-section.variables.ts",
+      "import": "./src/components/feature-section/feature-section.variables.ts",
       "default": "./dist/components/feature-section/feature-section.variables.js"
     },
     "./feature-section/styles": {
@@ -2118,6 +2340,7 @@
       "browser": "./src/components/feed/index.ts",
       "node": "./dist/server/components/feed/index.js",
       "svelte": "./src/components/feed/index.ts",
+      "import": "./src/components/feed/index.ts",
       "default": "./dist/components/feed/index.js"
     },
     "./feed/schema": {
@@ -2125,6 +2348,7 @@
       "browser": "./src/components/feed/feed.schema.ts",
       "node": "./dist/server/components/feed/feed.schema.js",
       "svelte": "./src/components/feed/feed.schema.ts",
+      "import": "./src/components/feed/feed.schema.ts",
       "default": "./dist/components/feed/feed.schema.js"
     },
     "./feed/variables": {
@@ -2132,6 +2356,7 @@
       "browser": "./src/components/feed/feed.variables.ts",
       "node": "./dist/server/components/feed/feed.variables.js",
       "svelte": "./src/components/feed/feed.variables.ts",
+      "import": "./src/components/feed/feed.variables.ts",
       "default": "./dist/components/feed/feed.variables.js"
     },
     "./feed/styles": {
@@ -2147,6 +2372,7 @@
       "browser": "./src/components/feed-event/index.ts",
       "node": "./dist/server/components/feed-event/index.js",
       "svelte": "./src/components/feed-event/index.ts",
+      "import": "./src/components/feed-event/index.ts",
       "default": "./dist/components/feed-event/index.js"
     },
     "./feed-event/schema": {
@@ -2154,6 +2380,7 @@
       "browser": "./src/components/feed-event/feed-event.schema.ts",
       "node": "./dist/server/components/feed-event/feed-event.schema.js",
       "svelte": "./src/components/feed-event/feed-event.schema.ts",
+      "import": "./src/components/feed-event/feed-event.schema.ts",
       "default": "./dist/components/feed-event/feed-event.schema.js"
     },
     "./feed-event/variables": {
@@ -2161,6 +2388,7 @@
       "browser": "./src/components/feed-event/feed-event.variables.ts",
       "node": "./dist/server/components/feed-event/feed-event.variables.js",
       "svelte": "./src/components/feed-event/feed-event.variables.ts",
+      "import": "./src/components/feed-event/feed-event.variables.ts",
       "default": "./dist/components/feed-event/feed-event.variables.js"
     },
     "./file-upload": {
@@ -2168,6 +2396,7 @@
       "browser": "./src/components/file-upload/index.ts",
       "node": "./dist/server/components/file-upload/index.js",
       "svelte": "./src/components/file-upload/index.ts",
+      "import": "./src/components/file-upload/index.ts",
       "default": "./dist/components/file-upload/index.js"
     },
     "./file-upload/schema": {
@@ -2175,6 +2404,7 @@
       "browser": "./src/components/file-upload/file-upload.schema.ts",
       "node": "./dist/server/components/file-upload/file-upload.schema.js",
       "svelte": "./src/components/file-upload/file-upload.schema.ts",
+      "import": "./src/components/file-upload/file-upload.schema.ts",
       "default": "./dist/components/file-upload/file-upload.schema.js"
     },
     "./file-upload/variables": {
@@ -2182,6 +2412,7 @@
       "browser": "./src/components/file-upload/file-upload.variables.ts",
       "node": "./dist/server/components/file-upload/file-upload.variables.js",
       "svelte": "./src/components/file-upload/file-upload.variables.ts",
+      "import": "./src/components/file-upload/file-upload.variables.ts",
       "default": "./dist/components/file-upload/file-upload.variables.js"
     },
     "./file-upload/styles": {
@@ -2197,6 +2428,7 @@
       "browser": "./src/components/floating-action-button/index.ts",
       "node": "./dist/server/components/floating-action-button/index.js",
       "svelte": "./src/components/floating-action-button/index.ts",
+      "import": "./src/components/floating-action-button/index.ts",
       "default": "./dist/components/floating-action-button/index.js"
     },
     "./floating-action-button/schema": {
@@ -2204,6 +2436,7 @@
       "browser": "./src/components/floating-action-button/floating-action-button.schema.ts",
       "node": "./dist/server/components/floating-action-button/floating-action-button.schema.js",
       "svelte": "./src/components/floating-action-button/floating-action-button.schema.ts",
+      "import": "./src/components/floating-action-button/floating-action-button.schema.ts",
       "default": "./dist/components/floating-action-button/floating-action-button.schema.js"
     },
     "./floating-action-button/variables": {
@@ -2211,6 +2444,7 @@
       "browser": "./src/components/floating-action-button/floating-action-button.variables.ts",
       "node": "./dist/server/components/floating-action-button/floating-action-button.variables.js",
       "svelte": "./src/components/floating-action-button/floating-action-button.variables.ts",
+      "import": "./src/components/floating-action-button/floating-action-button.variables.ts",
       "default": "./dist/components/floating-action-button/floating-action-button.variables.js"
     },
     "./floating-action-button/styles": {
@@ -2226,6 +2460,7 @@
       "browser": "./src/components/focus-trap/index.ts",
       "node": "./dist/server/components/focus-trap/index.js",
       "svelte": "./src/components/focus-trap/index.ts",
+      "import": "./src/components/focus-trap/index.ts",
       "default": "./dist/components/focus-trap/index.js"
     },
     "./focus-trap/schema": {
@@ -2233,6 +2468,7 @@
       "browser": "./src/components/focus-trap/focus-trap.schema.ts",
       "node": "./dist/server/components/focus-trap/focus-trap.schema.js",
       "svelte": "./src/components/focus-trap/focus-trap.schema.ts",
+      "import": "./src/components/focus-trap/focus-trap.schema.ts",
       "default": "./dist/components/focus-trap/focus-trap.schema.js"
     },
     "./focus-trap/variables": {
@@ -2240,6 +2476,7 @@
       "browser": "./src/components/focus-trap/focus-trap.variables.ts",
       "node": "./dist/server/components/focus-trap/focus-trap.variables.js",
       "svelte": "./src/components/focus-trap/focus-trap.variables.ts",
+      "import": "./src/components/focus-trap/focus-trap.variables.ts",
       "default": "./dist/components/focus-trap/focus-trap.variables.js"
     },
     "./focus-trap/examples": {
@@ -2251,6 +2488,7 @@
       "browser": "./src/components/footer/index.ts",
       "node": "./dist/server/components/footer/index.js",
       "svelte": "./src/components/footer/index.ts",
+      "import": "./src/components/footer/index.ts",
       "default": "./dist/components/footer/index.js"
     },
     "./footer/schema": {
@@ -2258,6 +2496,7 @@
       "browser": "./src/components/footer/footer.schema.ts",
       "node": "./dist/server/components/footer/footer.schema.js",
       "svelte": "./src/components/footer/footer.schema.ts",
+      "import": "./src/components/footer/footer.schema.ts",
       "default": "./dist/components/footer/footer.schema.js"
     },
     "./footer/variables": {
@@ -2265,6 +2504,7 @@
       "browser": "./src/components/footer/footer.variables.ts",
       "node": "./dist/server/components/footer/footer.variables.js",
       "svelte": "./src/components/footer/footer.variables.ts",
+      "import": "./src/components/footer/footer.variables.ts",
       "default": "./dist/components/footer/footer.variables.js"
     },
     "./footer/styles": {
@@ -2280,6 +2520,7 @@
       "browser": "./src/components/form-field/index.ts",
       "node": "./dist/server/components/form-field/index.js",
       "svelte": "./src/components/form-field/index.ts",
+      "import": "./src/components/form-field/index.ts",
       "default": "./dist/components/form-field/index.js"
     },
     "./form-field/schema": {
@@ -2287,6 +2528,7 @@
       "browser": "./src/components/form-field/form-field.schema.ts",
       "node": "./dist/server/components/form-field/form-field.schema.js",
       "svelte": "./src/components/form-field/form-field.schema.ts",
+      "import": "./src/components/form-field/form-field.schema.ts",
       "default": "./dist/components/form-field/form-field.schema.js"
     },
     "./form-field/variables": {
@@ -2294,6 +2536,7 @@
       "browser": "./src/components/form-field/form-field.variables.ts",
       "node": "./dist/server/components/form-field/form-field.variables.js",
       "svelte": "./src/components/form-field/form-field.variables.ts",
+      "import": "./src/components/form-field/form-field.variables.ts",
       "default": "./dist/components/form-field/form-field.variables.js"
     },
     "./form-field/styles": {
@@ -2309,6 +2552,7 @@
       "browser": "./src/components/form-section/index.ts",
       "node": "./dist/server/components/form-section/index.js",
       "svelte": "./src/components/form-section/index.ts",
+      "import": "./src/components/form-section/index.ts",
       "default": "./dist/components/form-section/index.js"
     },
     "./form-section/schema": {
@@ -2316,6 +2560,7 @@
       "browser": "./src/components/form-section/form-section.schema.ts",
       "node": "./dist/server/components/form-section/form-section.schema.js",
       "svelte": "./src/components/form-section/form-section.schema.ts",
+      "import": "./src/components/form-section/form-section.schema.ts",
       "default": "./dist/components/form-section/form-section.schema.js"
     },
     "./form-section/variables": {
@@ -2323,6 +2568,7 @@
       "browser": "./src/components/form-section/form-section.variables.ts",
       "node": "./dist/server/components/form-section/form-section.variables.js",
       "svelte": "./src/components/form-section/form-section.variables.ts",
+      "import": "./src/components/form-section/form-section.variables.ts",
       "default": "./dist/components/form-section/form-section.variables.js"
     },
     "./form-section/styles": {
@@ -2338,6 +2584,7 @@
       "browser": "./src/components/grid/index.ts",
       "node": "./dist/server/components/grid/index.js",
       "svelte": "./src/components/grid/index.ts",
+      "import": "./src/components/grid/index.ts",
       "default": "./dist/components/grid/index.js"
     },
     "./grid/schema": {
@@ -2345,6 +2592,7 @@
       "browser": "./src/components/grid/grid.schema.ts",
       "node": "./dist/server/components/grid/grid.schema.js",
       "svelte": "./src/components/grid/grid.schema.ts",
+      "import": "./src/components/grid/grid.schema.ts",
       "default": "./dist/components/grid/grid.schema.js"
     },
     "./grid/variables": {
@@ -2352,6 +2600,7 @@
       "browser": "./src/components/grid/grid.variables.ts",
       "node": "./dist/server/components/grid/grid.variables.js",
       "svelte": "./src/components/grid/grid.variables.ts",
+      "import": "./src/components/grid/grid.variables.ts",
       "default": "./dist/components/grid/grid.variables.js"
     },
     "./grid/styles": {
@@ -2367,6 +2616,7 @@
       "browser": "./src/components/grid-item/index.ts",
       "node": "./dist/server/components/grid-item/index.js",
       "svelte": "./src/components/grid-item/index.ts",
+      "import": "./src/components/grid-item/index.ts",
       "default": "./dist/components/grid-item/index.js"
     },
     "./grid-item/schema": {
@@ -2374,6 +2624,7 @@
       "browser": "./src/components/grid-item/grid-item.schema.ts",
       "node": "./dist/server/components/grid-item/grid-item.schema.js",
       "svelte": "./src/components/grid-item/grid-item.schema.ts",
+      "import": "./src/components/grid-item/grid-item.schema.ts",
       "default": "./dist/components/grid-item/grid-item.schema.js"
     },
     "./grid-item/variables": {
@@ -2381,6 +2632,7 @@
       "browser": "./src/components/grid-item/grid-item.variables.ts",
       "node": "./dist/server/components/grid-item/grid-item.variables.js",
       "svelte": "./src/components/grid-item/grid-item.variables.ts",
+      "import": "./src/components/grid-item/grid-item.variables.ts",
       "default": "./dist/components/grid-item/grid-item.variables.js"
     },
     "./grid-list": {
@@ -2388,6 +2640,7 @@
       "browser": "./src/components/grid-list/index.ts",
       "node": "./dist/server/components/grid-list/index.js",
       "svelte": "./src/components/grid-list/index.ts",
+      "import": "./src/components/grid-list/index.ts",
       "default": "./dist/components/grid-list/index.js"
     },
     "./grid-list/schema": {
@@ -2395,6 +2648,7 @@
       "browser": "./src/components/grid-list/grid-list.schema.ts",
       "node": "./dist/server/components/grid-list/grid-list.schema.js",
       "svelte": "./src/components/grid-list/grid-list.schema.ts",
+      "import": "./src/components/grid-list/grid-list.schema.ts",
       "default": "./dist/components/grid-list/grid-list.schema.js"
     },
     "./grid-list/variables": {
@@ -2402,6 +2656,7 @@
       "browser": "./src/components/grid-list/grid-list.variables.ts",
       "node": "./dist/server/components/grid-list/grid-list.variables.js",
       "svelte": "./src/components/grid-list/grid-list.variables.ts",
+      "import": "./src/components/grid-list/grid-list.variables.ts",
       "default": "./dist/components/grid-list/grid-list.variables.js"
     },
     "./grid-list/styles": {
@@ -2417,6 +2672,7 @@
       "browser": "./src/components/grid-list-item/index.ts",
       "node": "./dist/server/components/grid-list-item/index.js",
       "svelte": "./src/components/grid-list-item/index.ts",
+      "import": "./src/components/grid-list-item/index.ts",
       "default": "./dist/components/grid-list-item/index.js"
     },
     "./grid-list-item/schema": {
@@ -2424,6 +2680,7 @@
       "browser": "./src/components/grid-list-item/grid-list-item.schema.ts",
       "node": "./dist/server/components/grid-list-item/grid-list-item.schema.js",
       "svelte": "./src/components/grid-list-item/grid-list-item.schema.ts",
+      "import": "./src/components/grid-list-item/grid-list-item.schema.ts",
       "default": "./dist/components/grid-list-item/grid-list-item.schema.js"
     },
     "./grid-list-item/variables": {
@@ -2431,6 +2688,7 @@
       "browser": "./src/components/grid-list-item/grid-list-item.variables.ts",
       "node": "./dist/server/components/grid-list-item/grid-list-item.variables.js",
       "svelte": "./src/components/grid-list-item/grid-list-item.variables.ts",
+      "import": "./src/components/grid-list-item/grid-list-item.variables.ts",
       "default": "./dist/components/grid-list-item/grid-list-item.variables.js"
     },
     "./hero-section": {
@@ -2438,6 +2696,7 @@
       "browser": "./src/components/hero-section/index.ts",
       "node": "./dist/server/components/hero-section/index.js",
       "svelte": "./src/components/hero-section/index.ts",
+      "import": "./src/components/hero-section/index.ts",
       "default": "./dist/components/hero-section/index.js"
     },
     "./hero-section/schema": {
@@ -2445,6 +2704,7 @@
       "browser": "./src/components/hero-section/hero-section.schema.ts",
       "node": "./dist/server/components/hero-section/hero-section.schema.js",
       "svelte": "./src/components/hero-section/hero-section.schema.ts",
+      "import": "./src/components/hero-section/hero-section.schema.ts",
       "default": "./dist/components/hero-section/hero-section.schema.js"
     },
     "./hero-section/variables": {
@@ -2452,6 +2712,7 @@
       "browser": "./src/components/hero-section/hero-section.variables.ts",
       "node": "./dist/server/components/hero-section/hero-section.variables.js",
       "svelte": "./src/components/hero-section/hero-section.variables.ts",
+      "import": "./src/components/hero-section/hero-section.variables.ts",
       "default": "./dist/components/hero-section/hero-section.variables.js"
     },
     "./hero-section/styles": {
@@ -2467,6 +2728,7 @@
       "browser": "./src/components/hover-card/index.ts",
       "node": "./dist/server/components/hover-card/index.js",
       "svelte": "./src/components/hover-card/index.ts",
+      "import": "./src/components/hover-card/index.ts",
       "default": "./dist/components/hover-card/index.js"
     },
     "./hover-card/schema": {
@@ -2474,6 +2736,7 @@
       "browser": "./src/components/hover-card/hover-card.schema.ts",
       "node": "./dist/server/components/hover-card/hover-card.schema.js",
       "svelte": "./src/components/hover-card/hover-card.schema.ts",
+      "import": "./src/components/hover-card/hover-card.schema.ts",
       "default": "./dist/components/hover-card/hover-card.schema.js"
     },
     "./hover-card/variables": {
@@ -2481,6 +2744,7 @@
       "browser": "./src/components/hover-card/hover-card.variables.ts",
       "node": "./dist/server/components/hover-card/hover-card.variables.js",
       "svelte": "./src/components/hover-card/hover-card.variables.ts",
+      "import": "./src/components/hover-card/hover-card.variables.ts",
       "default": "./dist/components/hover-card/hover-card.variables.js"
     },
     "./hover-card/styles": {
@@ -2496,6 +2760,7 @@
       "browser": "./src/components/image/index.ts",
       "node": "./dist/server/components/image/index.js",
       "svelte": "./src/components/image/index.ts",
+      "import": "./src/components/image/index.ts",
       "default": "./dist/components/image/index.js"
     },
     "./image/schema": {
@@ -2503,6 +2768,7 @@
       "browser": "./src/components/image/image.schema.ts",
       "node": "./dist/server/components/image/image.schema.js",
       "svelte": "./src/components/image/image.schema.ts",
+      "import": "./src/components/image/image.schema.ts",
       "default": "./dist/components/image/image.schema.js"
     },
     "./image/variables": {
@@ -2510,6 +2776,7 @@
       "browser": "./src/components/image/image.variables.ts",
       "node": "./dist/server/components/image/image.variables.js",
       "svelte": "./src/components/image/image.variables.ts",
+      "import": "./src/components/image/image.variables.ts",
       "default": "./dist/components/image/image.variables.js"
     },
     "./image/styles": {
@@ -2525,6 +2792,7 @@
       "browser": "./src/components/inline-loading/index.ts",
       "node": "./dist/server/components/inline-loading/index.js",
       "svelte": "./src/components/inline-loading/index.ts",
+      "import": "./src/components/inline-loading/index.ts",
       "default": "./dist/components/inline-loading/index.js"
     },
     "./inline-loading/schema": {
@@ -2532,6 +2800,7 @@
       "browser": "./src/components/inline-loading/inline-loading.schema.ts",
       "node": "./dist/server/components/inline-loading/inline-loading.schema.js",
       "svelte": "./src/components/inline-loading/inline-loading.schema.ts",
+      "import": "./src/components/inline-loading/inline-loading.schema.ts",
       "default": "./dist/components/inline-loading/inline-loading.schema.js"
     },
     "./inline-loading/variables": {
@@ -2539,6 +2808,7 @@
       "browser": "./src/components/inline-loading/inline-loading.variables.ts",
       "node": "./dist/server/components/inline-loading/inline-loading.variables.js",
       "svelte": "./src/components/inline-loading/inline-loading.variables.ts",
+      "import": "./src/components/inline-loading/inline-loading.variables.ts",
       "default": "./dist/components/inline-loading/inline-loading.variables.js"
     },
     "./inline-loading/styles": {
@@ -2554,6 +2824,7 @@
       "browser": "./src/components/input/index.ts",
       "node": "./dist/server/components/input/index.js",
       "svelte": "./src/components/input/index.ts",
+      "import": "./src/components/input/index.ts",
       "default": "./dist/components/input/index.js"
     },
     "./input/schema": {
@@ -2561,6 +2832,7 @@
       "browser": "./src/components/input/input.schema.ts",
       "node": "./dist/server/components/input/input.schema.js",
       "svelte": "./src/components/input/input.schema.ts",
+      "import": "./src/components/input/input.schema.ts",
       "default": "./dist/components/input/input.schema.js"
     },
     "./input/variables": {
@@ -2568,6 +2840,7 @@
       "browser": "./src/components/input/input.variables.ts",
       "node": "./dist/server/components/input/input.variables.js",
       "svelte": "./src/components/input/input.variables.ts",
+      "import": "./src/components/input/input.variables.ts",
       "default": "./dist/components/input/input.variables.js"
     },
     "./input/styles": {
@@ -2587,6 +2860,7 @@
       "browser": "./src/components/invocation-rule-builder/index.ts",
       "node": "./dist/server/components/invocation-rule-builder/index.js",
       "svelte": "./src/components/invocation-rule-builder/index.ts",
+      "import": "./src/components/invocation-rule-builder/index.ts",
       "default": "./dist/components/invocation-rule-builder/index.js"
     },
     "./invocation-rule-builder/schema": {
@@ -2594,6 +2868,7 @@
       "browser": "./src/components/invocation-rule-builder/invocation-rule-builder.schema.ts",
       "node": "./dist/server/components/invocation-rule-builder/invocation-rule-builder.schema.js",
       "svelte": "./src/components/invocation-rule-builder/invocation-rule-builder.schema.ts",
+      "import": "./src/components/invocation-rule-builder/invocation-rule-builder.schema.ts",
       "default": "./dist/components/invocation-rule-builder/invocation-rule-builder.schema.js"
     },
     "./invocation-rule-builder/variables": {
@@ -2601,6 +2876,7 @@
       "browser": "./src/components/invocation-rule-builder/invocation-rule-builder.variables.ts",
       "node": "./dist/server/components/invocation-rule-builder/invocation-rule-builder.variables.js",
       "svelte": "./src/components/invocation-rule-builder/invocation-rule-builder.variables.ts",
+      "import": "./src/components/invocation-rule-builder/invocation-rule-builder.variables.ts",
       "default": "./dist/components/invocation-rule-builder/invocation-rule-builder.variables.js"
     },
     "./invocation-rule-builder/styles": {
@@ -2616,6 +2892,7 @@
       "browser": "./src/components/json-schema-editor/index.ts",
       "node": "./dist/server/components/json-schema-editor/index.js",
       "svelte": "./src/components/json-schema-editor/index.ts",
+      "import": "./src/components/json-schema-editor/index.ts",
       "default": "./dist/components/json-schema-editor/index.js"
     },
     "./json-schema-editor/schema": {
@@ -2623,6 +2900,7 @@
       "browser": "./src/components/json-schema-editor/json-schema-editor.schema.ts",
       "node": "./dist/server/components/json-schema-editor/json-schema-editor.schema.js",
       "svelte": "./src/components/json-schema-editor/json-schema-editor.schema.ts",
+      "import": "./src/components/json-schema-editor/json-schema-editor.schema.ts",
       "default": "./dist/components/json-schema-editor/json-schema-editor.schema.js"
     },
     "./json-schema-editor/variables": {
@@ -2630,6 +2908,7 @@
       "browser": "./src/components/json-schema-editor/json-schema-editor.variables.ts",
       "node": "./dist/server/components/json-schema-editor/json-schema-editor.variables.js",
       "svelte": "./src/components/json-schema-editor/json-schema-editor.variables.ts",
+      "import": "./src/components/json-schema-editor/json-schema-editor.variables.ts",
       "default": "./dist/components/json-schema-editor/json-schema-editor.variables.js"
     },
     "./json-schema-editor/styles": {
@@ -2645,6 +2924,7 @@
       "browser": "./src/components/json-viewer/index.ts",
       "node": "./dist/server/components/json-viewer/index.js",
       "svelte": "./src/components/json-viewer/index.ts",
+      "import": "./src/components/json-viewer/index.ts",
       "default": "./dist/components/json-viewer/index.js"
     },
     "./json-viewer/schema": {
@@ -2652,6 +2932,7 @@
       "browser": "./src/components/json-viewer/json-viewer.schema.ts",
       "node": "./dist/server/components/json-viewer/json-viewer.schema.js",
       "svelte": "./src/components/json-viewer/json-viewer.schema.ts",
+      "import": "./src/components/json-viewer/json-viewer.schema.ts",
       "default": "./dist/components/json-viewer/json-viewer.schema.js"
     },
     "./json-viewer/variables": {
@@ -2659,6 +2940,7 @@
       "browser": "./src/components/json-viewer/json-viewer.variables.ts",
       "node": "./dist/server/components/json-viewer/json-viewer.variables.js",
       "svelte": "./src/components/json-viewer/json-viewer.variables.ts",
+      "import": "./src/components/json-viewer/json-viewer.variables.ts",
       "default": "./dist/components/json-viewer/json-viewer.variables.js"
     },
     "./json-viewer/styles": {
@@ -2674,6 +2956,7 @@
       "browser": "./src/components/kanban-board/index.ts",
       "node": "./dist/server/components/kanban-board/index.js",
       "svelte": "./src/components/kanban-board/index.ts",
+      "import": "./src/components/kanban-board/index.ts",
       "default": "./dist/components/kanban-board/index.js"
     },
     "./kanban-board/schema": {
@@ -2681,6 +2964,7 @@
       "browser": "./src/components/kanban-board/kanban-board.schema.ts",
       "node": "./dist/server/components/kanban-board/kanban-board.schema.js",
       "svelte": "./src/components/kanban-board/kanban-board.schema.ts",
+      "import": "./src/components/kanban-board/kanban-board.schema.ts",
       "default": "./dist/components/kanban-board/kanban-board.schema.js"
     },
     "./kanban-board/variables": {
@@ -2688,6 +2972,7 @@
       "browser": "./src/components/kanban-board/kanban-board.variables.ts",
       "node": "./dist/server/components/kanban-board/kanban-board.variables.js",
       "svelte": "./src/components/kanban-board/kanban-board.variables.ts",
+      "import": "./src/components/kanban-board/kanban-board.variables.ts",
       "default": "./dist/components/kanban-board/kanban-board.variables.js"
     },
     "./kanban-board/styles": {
@@ -2703,6 +2988,7 @@
       "browser": "./src/components/kbd/index.ts",
       "node": "./dist/server/components/kbd/index.js",
       "svelte": "./src/components/kbd/index.ts",
+      "import": "./src/components/kbd/index.ts",
       "default": "./dist/components/kbd/index.js"
     },
     "./kbd/schema": {
@@ -2710,6 +2996,7 @@
       "browser": "./src/components/kbd/kbd.schema.ts",
       "node": "./dist/server/components/kbd/kbd.schema.js",
       "svelte": "./src/components/kbd/kbd.schema.ts",
+      "import": "./src/components/kbd/kbd.schema.ts",
       "default": "./dist/components/kbd/kbd.schema.js"
     },
     "./kbd/variables": {
@@ -2717,6 +3004,7 @@
       "browser": "./src/components/kbd/kbd.variables.ts",
       "node": "./dist/server/components/kbd/kbd.variables.js",
       "svelte": "./src/components/kbd/kbd.variables.ts",
+      "import": "./src/components/kbd/kbd.variables.ts",
       "default": "./dist/components/kbd/kbd.variables.js"
     },
     "./kbd/styles": {
@@ -2732,6 +3020,7 @@
       "browser": "./src/components/keyboard-shortcuts/index.ts",
       "node": "./dist/server/components/keyboard-shortcuts/index.js",
       "svelte": "./src/components/keyboard-shortcuts/index.ts",
+      "import": "./src/components/keyboard-shortcuts/index.ts",
       "default": "./dist/components/keyboard-shortcuts/index.js"
     },
     "./keyboard-shortcuts/schema": {
@@ -2739,6 +3028,7 @@
       "browser": "./src/components/keyboard-shortcuts/keyboard-shortcuts.schema.ts",
       "node": "./dist/server/components/keyboard-shortcuts/keyboard-shortcuts.schema.js",
       "svelte": "./src/components/keyboard-shortcuts/keyboard-shortcuts.schema.ts",
+      "import": "./src/components/keyboard-shortcuts/keyboard-shortcuts.schema.ts",
       "default": "./dist/components/keyboard-shortcuts/keyboard-shortcuts.schema.js"
     },
     "./keyboard-shortcuts/variables": {
@@ -2746,6 +3036,7 @@
       "browser": "./src/components/keyboard-shortcuts/keyboard-shortcuts.variables.ts",
       "node": "./dist/server/components/keyboard-shortcuts/keyboard-shortcuts.variables.js",
       "svelte": "./src/components/keyboard-shortcuts/keyboard-shortcuts.variables.ts",
+      "import": "./src/components/keyboard-shortcuts/keyboard-shortcuts.variables.ts",
       "default": "./dist/components/keyboard-shortcuts/keyboard-shortcuts.variables.js"
     },
     "./keyboard-shortcuts/styles": {
@@ -2761,6 +3052,7 @@
       "browser": "./src/components/label/index.ts",
       "node": "./dist/server/components/label/index.js",
       "svelte": "./src/components/label/index.ts",
+      "import": "./src/components/label/index.ts",
       "default": "./dist/components/label/index.js"
     },
     "./label/schema": {
@@ -2768,6 +3060,7 @@
       "browser": "./src/components/label/label.schema.ts",
       "node": "./dist/server/components/label/label.schema.js",
       "svelte": "./src/components/label/label.schema.ts",
+      "import": "./src/components/label/label.schema.ts",
       "default": "./dist/components/label/label.schema.js"
     },
     "./label/variables": {
@@ -2775,6 +3068,7 @@
       "browser": "./src/components/label/label.variables.ts",
       "node": "./dist/server/components/label/label.variables.js",
       "svelte": "./src/components/label/label.variables.ts",
+      "import": "./src/components/label/label.variables.ts",
       "default": "./dist/components/label/label.variables.js"
     },
     "./label/styles": {
@@ -2786,6 +3080,7 @@
       "browser": "./src/components/line-chart/index.ts",
       "node": "./dist/server/components/line-chart/index.js",
       "svelte": "./src/components/line-chart/index.ts",
+      "import": "./src/components/line-chart/index.ts",
       "default": "./dist/components/line-chart/index.js"
     },
     "./line-chart/schema": {
@@ -2793,6 +3088,7 @@
       "browser": "./src/components/line-chart/line-chart.schema.ts",
       "node": "./dist/server/components/line-chart/line-chart.schema.js",
       "svelte": "./src/components/line-chart/line-chart.schema.ts",
+      "import": "./src/components/line-chart/line-chart.schema.ts",
       "default": "./dist/components/line-chart/line-chart.schema.js"
     },
     "./line-chart/variables": {
@@ -2800,6 +3096,7 @@
       "browser": "./src/components/line-chart/line-chart.variables.ts",
       "node": "./dist/server/components/line-chart/line-chart.variables.js",
       "svelte": "./src/components/line-chart/line-chart.variables.ts",
+      "import": "./src/components/line-chart/line-chart.variables.ts",
       "default": "./dist/components/line-chart/line-chart.variables.js"
     },
     "./line-chart/styles": {
@@ -2815,6 +3112,7 @@
       "browser": "./src/components/link/index.ts",
       "node": "./dist/server/components/link/index.js",
       "svelte": "./src/components/link/index.ts",
+      "import": "./src/components/link/index.ts",
       "default": "./dist/components/link/index.js"
     },
     "./link/schema": {
@@ -2822,6 +3120,7 @@
       "browser": "./src/components/link/link.schema.ts",
       "node": "./dist/server/components/link/link.schema.js",
       "svelte": "./src/components/link/link.schema.ts",
+      "import": "./src/components/link/link.schema.ts",
       "default": "./dist/components/link/link.schema.js"
     },
     "./link/variables": {
@@ -2829,6 +3128,7 @@
       "browser": "./src/components/link/link.variables.ts",
       "node": "./dist/server/components/link/link.variables.js",
       "svelte": "./src/components/link/link.variables.ts",
+      "import": "./src/components/link/link.variables.ts",
       "default": "./dist/components/link/link.variables.js"
     },
     "./link/styles": {
@@ -2844,6 +3144,7 @@
       "browser": "./src/components/load-more/index.ts",
       "node": "./dist/server/components/load-more/index.js",
       "svelte": "./src/components/load-more/index.ts",
+      "import": "./src/components/load-more/index.ts",
       "default": "./dist/components/load-more/index.js"
     },
     "./load-more/schema": {
@@ -2851,6 +3152,7 @@
       "browser": "./src/components/load-more/load-more.schema.ts",
       "node": "./dist/server/components/load-more/load-more.schema.js",
       "svelte": "./src/components/load-more/load-more.schema.ts",
+      "import": "./src/components/load-more/load-more.schema.ts",
       "default": "./dist/components/load-more/load-more.schema.js"
     },
     "./load-more/variables": {
@@ -2858,6 +3160,7 @@
       "browser": "./src/components/load-more/load-more.variables.ts",
       "node": "./dist/server/components/load-more/load-more.variables.js",
       "svelte": "./src/components/load-more/load-more.variables.ts",
+      "import": "./src/components/load-more/load-more.variables.ts",
       "default": "./dist/components/load-more/load-more.variables.js"
     },
     "./load-more/styles": {
@@ -2873,6 +3176,7 @@
       "browser": "./src/components/locale-provider/index.ts",
       "node": "./dist/server/components/locale-provider/index.js",
       "svelte": "./src/components/locale-provider/index.ts",
+      "import": "./src/components/locale-provider/index.ts",
       "default": "./dist/components/locale-provider/index.js"
     },
     "./locale-provider/schema": {
@@ -2880,6 +3184,7 @@
       "browser": "./src/components/locale-provider/locale-provider.schema.ts",
       "node": "./dist/server/components/locale-provider/locale-provider.schema.js",
       "svelte": "./src/components/locale-provider/locale-provider.schema.ts",
+      "import": "./src/components/locale-provider/locale-provider.schema.ts",
       "default": "./dist/components/locale-provider/locale-provider.schema.js"
     },
     "./locale-provider/variables": {
@@ -2887,6 +3192,7 @@
       "browser": "./src/components/locale-provider/locale-provider.variables.ts",
       "node": "./dist/server/components/locale-provider/locale-provider.variables.js",
       "svelte": "./src/components/locale-provider/locale-provider.variables.ts",
+      "import": "./src/components/locale-provider/locale-provider.variables.ts",
       "default": "./dist/components/locale-provider/locale-provider.variables.js"
     },
     "./logo-cloud": {
@@ -2894,6 +3200,7 @@
       "browser": "./src/components/logo-cloud/index.ts",
       "node": "./dist/server/components/logo-cloud/index.js",
       "svelte": "./src/components/logo-cloud/index.ts",
+      "import": "./src/components/logo-cloud/index.ts",
       "default": "./dist/components/logo-cloud/index.js"
     },
     "./logo-cloud/schema": {
@@ -2901,6 +3208,7 @@
       "browser": "./src/components/logo-cloud/logo-cloud.schema.ts",
       "node": "./dist/server/components/logo-cloud/logo-cloud.schema.js",
       "svelte": "./src/components/logo-cloud/logo-cloud.schema.ts",
+      "import": "./src/components/logo-cloud/logo-cloud.schema.ts",
       "default": "./dist/components/logo-cloud/logo-cloud.schema.js"
     },
     "./logo-cloud/variables": {
@@ -2908,6 +3216,7 @@
       "browser": "./src/components/logo-cloud/logo-cloud.variables.ts",
       "node": "./dist/server/components/logo-cloud/logo-cloud.variables.js",
       "svelte": "./src/components/logo-cloud/logo-cloud.variables.ts",
+      "import": "./src/components/logo-cloud/logo-cloud.variables.ts",
       "default": "./dist/components/logo-cloud/logo-cloud.variables.js"
     },
     "./logo-cloud/styles": {
@@ -2923,6 +3232,7 @@
       "browser": "./src/components/markdown-editor/index.ts",
       "node": "./dist/server/components/markdown-editor/index.js",
       "svelte": "./src/components/markdown-editor/index.ts",
+      "import": "./src/components/markdown-editor/index.ts",
       "default": "./dist/components/markdown-editor/index.js"
     },
     "./markdown-editor/schema": {
@@ -2930,6 +3240,7 @@
       "browser": "./src/components/markdown-editor/markdown-editor.schema.ts",
       "node": "./dist/server/components/markdown-editor/markdown-editor.schema.js",
       "svelte": "./src/components/markdown-editor/markdown-editor.schema.ts",
+      "import": "./src/components/markdown-editor/markdown-editor.schema.ts",
       "default": "./dist/components/markdown-editor/markdown-editor.schema.js"
     },
     "./markdown-editor/variables": {
@@ -2937,6 +3248,7 @@
       "browser": "./src/components/markdown-editor/markdown-editor.variables.ts",
       "node": "./dist/server/components/markdown-editor/markdown-editor.variables.js",
       "svelte": "./src/components/markdown-editor/markdown-editor.variables.ts",
+      "import": "./src/components/markdown-editor/markdown-editor.variables.ts",
       "default": "./dist/components/markdown-editor/markdown-editor.variables.js"
     },
     "./markdown-editor/examples": {
@@ -2948,6 +3260,7 @@
       "browser": "./src/components/marquee/index.ts",
       "node": "./dist/server/components/marquee/index.js",
       "svelte": "./src/components/marquee/index.ts",
+      "import": "./src/components/marquee/index.ts",
       "default": "./dist/components/marquee/index.js"
     },
     "./marquee/schema": {
@@ -2955,6 +3268,7 @@
       "browser": "./src/components/marquee/marquee.schema.ts",
       "node": "./dist/server/components/marquee/marquee.schema.js",
       "svelte": "./src/components/marquee/marquee.schema.ts",
+      "import": "./src/components/marquee/marquee.schema.ts",
       "default": "./dist/components/marquee/marquee.schema.js"
     },
     "./marquee/variables": {
@@ -2962,6 +3276,7 @@
       "browser": "./src/components/marquee/marquee.variables.ts",
       "node": "./dist/server/components/marquee/marquee.variables.js",
       "svelte": "./src/components/marquee/marquee.variables.ts",
+      "import": "./src/components/marquee/marquee.variables.ts",
       "default": "./dist/components/marquee/marquee.variables.js"
     },
     "./marquee/styles": {
@@ -2977,6 +3292,7 @@
       "browser": "./src/components/masonry/index.ts",
       "node": "./dist/server/components/masonry/index.js",
       "svelte": "./src/components/masonry/index.ts",
+      "import": "./src/components/masonry/index.ts",
       "default": "./dist/components/masonry/index.js"
     },
     "./masonry/schema": {
@@ -2984,6 +3300,7 @@
       "browser": "./src/components/masonry/masonry.schema.ts",
       "node": "./dist/server/components/masonry/masonry.schema.js",
       "svelte": "./src/components/masonry/masonry.schema.ts",
+      "import": "./src/components/masonry/masonry.schema.ts",
       "default": "./dist/components/masonry/masonry.schema.js"
     },
     "./masonry/variables": {
@@ -2991,6 +3308,7 @@
       "browser": "./src/components/masonry/masonry.variables.ts",
       "node": "./dist/server/components/masonry/masonry.variables.js",
       "svelte": "./src/components/masonry/masonry.variables.ts",
+      "import": "./src/components/masonry/masonry.variables.ts",
       "default": "./dist/components/masonry/masonry.variables.js"
     },
     "./masonry/styles": {
@@ -3006,6 +3324,7 @@
       "browser": "./src/components/matrix-chart/index.ts",
       "node": "./dist/server/components/matrix-chart/index.js",
       "svelte": "./src/components/matrix-chart/index.ts",
+      "import": "./src/components/matrix-chart/index.ts",
       "default": "./dist/components/matrix-chart/index.js"
     },
     "./matrix-chart/schema": {
@@ -3013,6 +3332,7 @@
       "browser": "./src/components/matrix-chart/matrix-chart.schema.ts",
       "node": "./dist/server/components/matrix-chart/matrix-chart.schema.js",
       "svelte": "./src/components/matrix-chart/matrix-chart.schema.ts",
+      "import": "./src/components/matrix-chart/matrix-chart.schema.ts",
       "default": "./dist/components/matrix-chart/matrix-chart.schema.js"
     },
     "./matrix-chart/variables": {
@@ -3020,6 +3340,7 @@
       "browser": "./src/components/matrix-chart/matrix-chart.variables.ts",
       "node": "./dist/server/components/matrix-chart/matrix-chart.variables.js",
       "svelte": "./src/components/matrix-chart/matrix-chart.variables.ts",
+      "import": "./src/components/matrix-chart/matrix-chart.variables.ts",
       "default": "./dist/components/matrix-chart/matrix-chart.variables.js"
     },
     "./matrix-chart/styles": {
@@ -3035,6 +3356,7 @@
       "browser": "./src/components/media-controls/index.ts",
       "node": "./dist/server/components/media-controls/index.js",
       "svelte": "./src/components/media-controls/index.ts",
+      "import": "./src/components/media-controls/index.ts",
       "default": "./dist/components/media-controls/index.js"
     },
     "./media-controls/schema": {
@@ -3042,6 +3364,7 @@
       "browser": "./src/components/media-controls/media-controls.schema.ts",
       "node": "./dist/server/components/media-controls/media-controls.schema.js",
       "svelte": "./src/components/media-controls/media-controls.schema.ts",
+      "import": "./src/components/media-controls/media-controls.schema.ts",
       "default": "./dist/components/media-controls/media-controls.schema.js"
     },
     "./media-controls/variables": {
@@ -3049,6 +3372,7 @@
       "browser": "./src/components/media-controls/media-controls.variables.ts",
       "node": "./dist/server/components/media-controls/media-controls.variables.js",
       "svelte": "./src/components/media-controls/media-controls.variables.ts",
+      "import": "./src/components/media-controls/media-controls.variables.ts",
       "default": "./dist/components/media-controls/media-controls.variables.js"
     },
     "./media-controls/styles": {
@@ -3064,6 +3388,7 @@
       "browser": "./src/components/mega-menu/index.ts",
       "node": "./dist/server/components/mega-menu/index.js",
       "svelte": "./src/components/mega-menu/index.ts",
+      "import": "./src/components/mega-menu/index.ts",
       "default": "./dist/components/mega-menu/index.js"
     },
     "./mega-menu/schema": {
@@ -3071,6 +3396,7 @@
       "browser": "./src/components/mega-menu/mega-menu.schema.ts",
       "node": "./dist/server/components/mega-menu/mega-menu.schema.js",
       "svelte": "./src/components/mega-menu/mega-menu.schema.ts",
+      "import": "./src/components/mega-menu/mega-menu.schema.ts",
       "default": "./dist/components/mega-menu/mega-menu.schema.js"
     },
     "./mega-menu/variables": {
@@ -3078,6 +3404,7 @@
       "browser": "./src/components/mega-menu/mega-menu.variables.ts",
       "node": "./dist/server/components/mega-menu/mega-menu.variables.js",
       "svelte": "./src/components/mega-menu/mega-menu.variables.ts",
+      "import": "./src/components/mega-menu/mega-menu.variables.ts",
       "default": "./dist/components/mega-menu/mega-menu.variables.js"
     },
     "./mega-menu/styles": {
@@ -3093,6 +3420,7 @@
       "browser": "./src/components/menu-bar/index.ts",
       "node": "./dist/server/components/menu-bar/index.js",
       "svelte": "./src/components/menu-bar/index.ts",
+      "import": "./src/components/menu-bar/index.ts",
       "default": "./dist/components/menu-bar/index.js"
     },
     "./menu-bar/schema": {
@@ -3100,6 +3428,7 @@
       "browser": "./src/components/menu-bar/menu-bar.schema.ts",
       "node": "./dist/server/components/menu-bar/menu-bar.schema.js",
       "svelte": "./src/components/menu-bar/menu-bar.schema.ts",
+      "import": "./src/components/menu-bar/menu-bar.schema.ts",
       "default": "./dist/components/menu-bar/menu-bar.schema.js"
     },
     "./menu-bar/variables": {
@@ -3107,6 +3436,7 @@
       "browser": "./src/components/menu-bar/menu-bar.variables.ts",
       "node": "./dist/server/components/menu-bar/menu-bar.variables.js",
       "svelte": "./src/components/menu-bar/menu-bar.variables.ts",
+      "import": "./src/components/menu-bar/menu-bar.variables.ts",
       "default": "./dist/components/menu-bar/menu-bar.variables.js"
     },
     "./menu-bar/styles": {
@@ -3122,6 +3452,7 @@
       "browser": "./src/components/message/index.ts",
       "node": "./dist/server/components/message/index.js",
       "svelte": "./src/components/message/index.ts",
+      "import": "./src/components/message/index.ts",
       "default": "./dist/components/message/index.js"
     },
     "./message/schema": {
@@ -3129,6 +3460,7 @@
       "browser": "./src/components/message/message.schema.ts",
       "node": "./dist/server/components/message/message.schema.js",
       "svelte": "./src/components/message/message.schema.ts",
+      "import": "./src/components/message/message.schema.ts",
       "default": "./dist/components/message/message.schema.js"
     },
     "./message/variables": {
@@ -3136,6 +3468,7 @@
       "browser": "./src/components/message/message.variables.ts",
       "node": "./dist/server/components/message/message.variables.js",
       "svelte": "./src/components/message/message.variables.ts",
+      "import": "./src/components/message/message.variables.ts",
       "default": "./dist/components/message/message.variables.js"
     },
     "./message/styles": {
@@ -3151,6 +3484,7 @@
       "browser": "./src/components/meter/index.ts",
       "node": "./dist/server/components/meter/index.js",
       "svelte": "./src/components/meter/index.ts",
+      "import": "./src/components/meter/index.ts",
       "default": "./dist/components/meter/index.js"
     },
     "./meter/schema": {
@@ -3158,6 +3492,7 @@
       "browser": "./src/components/meter/meter.schema.ts",
       "node": "./dist/server/components/meter/meter.schema.js",
       "svelte": "./src/components/meter/meter.schema.ts",
+      "import": "./src/components/meter/meter.schema.ts",
       "default": "./dist/components/meter/meter.schema.js"
     },
     "./meter/variables": {
@@ -3165,6 +3500,7 @@
       "browser": "./src/components/meter/meter.variables.ts",
       "node": "./dist/server/components/meter/meter.variables.js",
       "svelte": "./src/components/meter/meter.variables.ts",
+      "import": "./src/components/meter/meter.variables.ts",
       "default": "./dist/components/meter/meter.variables.js"
     },
     "./meter/styles": {
@@ -3180,6 +3516,7 @@
       "browser": "./src/components/modal/index.ts",
       "node": "./dist/server/components/modal/index.js",
       "svelte": "./src/components/modal/index.ts",
+      "import": "./src/components/modal/index.ts",
       "default": "./dist/components/modal/index.js"
     },
     "./modal/schema": {
@@ -3187,6 +3524,7 @@
       "browser": "./src/components/modal/modal.schema.ts",
       "node": "./dist/server/components/modal/modal.schema.js",
       "svelte": "./src/components/modal/modal.schema.ts",
+      "import": "./src/components/modal/modal.schema.ts",
       "default": "./dist/components/modal/modal.schema.js"
     },
     "./modal/variables": {
@@ -3194,6 +3532,7 @@
       "browser": "./src/components/modal/modal.variables.ts",
       "node": "./dist/server/components/modal/modal.variables.js",
       "svelte": "./src/components/modal/modal.variables.ts",
+      "import": "./src/components/modal/modal.variables.ts",
       "default": "./dist/components/modal/modal.variables.js"
     },
     "./modal/styles": {
@@ -3213,6 +3552,7 @@
       "browser": "./src/components/multi-select/index.ts",
       "node": "./dist/server/components/multi-select/index.js",
       "svelte": "./src/components/multi-select/index.ts",
+      "import": "./src/components/multi-select/index.ts",
       "default": "./dist/components/multi-select/index.js"
     },
     "./multi-select/schema": {
@@ -3220,6 +3560,7 @@
       "browser": "./src/components/multi-select/multi-select.schema.ts",
       "node": "./dist/server/components/multi-select/multi-select.schema.js",
       "svelte": "./src/components/multi-select/multi-select.schema.ts",
+      "import": "./src/components/multi-select/multi-select.schema.ts",
       "default": "./dist/components/multi-select/multi-select.schema.js"
     },
     "./multi-select/variables": {
@@ -3227,6 +3568,7 @@
       "browser": "./src/components/multi-select/multi-select.variables.ts",
       "node": "./dist/server/components/multi-select/multi-select.variables.js",
       "svelte": "./src/components/multi-select/multi-select.variables.ts",
+      "import": "./src/components/multi-select/multi-select.variables.ts",
       "default": "./dist/components/multi-select/multi-select.variables.js"
     },
     "./multi-select/styles": {
@@ -3242,6 +3584,7 @@
       "browser": "./src/components/navigation-bar/index.ts",
       "node": "./dist/server/components/navigation-bar/index.js",
       "svelte": "./src/components/navigation-bar/index.ts",
+      "import": "./src/components/navigation-bar/index.ts",
       "default": "./dist/components/navigation-bar/index.js"
     },
     "./navigation-bar/schema": {
@@ -3249,6 +3592,7 @@
       "browser": "./src/components/navigation-bar/navigation-bar.schema.ts",
       "node": "./dist/server/components/navigation-bar/navigation-bar.schema.js",
       "svelte": "./src/components/navigation-bar/navigation-bar.schema.ts",
+      "import": "./src/components/navigation-bar/navigation-bar.schema.ts",
       "default": "./dist/components/navigation-bar/navigation-bar.schema.js"
     },
     "./navigation-bar/variables": {
@@ -3256,6 +3600,7 @@
       "browser": "./src/components/navigation-bar/navigation-bar.variables.ts",
       "node": "./dist/server/components/navigation-bar/navigation-bar.variables.js",
       "svelte": "./src/components/navigation-bar/navigation-bar.variables.ts",
+      "import": "./src/components/navigation-bar/navigation-bar.variables.ts",
       "default": "./dist/components/navigation-bar/navigation-bar.variables.js"
     },
     "./navigation-bar/styles": {
@@ -3271,6 +3616,7 @@
       "browser": "./src/components/navigation-item/index.ts",
       "node": "./dist/server/components/navigation-item/index.js",
       "svelte": "./src/components/navigation-item/index.ts",
+      "import": "./src/components/navigation-item/index.ts",
       "default": "./dist/components/navigation-item/index.js"
     },
     "./navigation-item/schema": {
@@ -3278,6 +3624,7 @@
       "browser": "./src/components/navigation-item/navigation-item.schema.ts",
       "node": "./dist/server/components/navigation-item/navigation-item.schema.js",
       "svelte": "./src/components/navigation-item/navigation-item.schema.ts",
+      "import": "./src/components/navigation-item/navigation-item.schema.ts",
       "default": "./dist/components/navigation-item/navigation-item.schema.js"
     },
     "./navigation-item/variables": {
@@ -3285,6 +3632,7 @@
       "browser": "./src/components/navigation-item/navigation-item.variables.ts",
       "node": "./dist/server/components/navigation-item/navigation-item.variables.js",
       "svelte": "./src/components/navigation-item/navigation-item.variables.ts",
+      "import": "./src/components/navigation-item/navigation-item.variables.ts",
       "default": "./dist/components/navigation-item/navigation-item.variables.js"
     },
     "./navigation-item/styles": {
@@ -3296,6 +3644,7 @@
       "browser": "./src/components/newsletter-section/index.ts",
       "node": "./dist/server/components/newsletter-section/index.js",
       "svelte": "./src/components/newsletter-section/index.ts",
+      "import": "./src/components/newsletter-section/index.ts",
       "default": "./dist/components/newsletter-section/index.js"
     },
     "./newsletter-section/schema": {
@@ -3303,6 +3652,7 @@
       "browser": "./src/components/newsletter-section/newsletter-section.schema.ts",
       "node": "./dist/server/components/newsletter-section/newsletter-section.schema.js",
       "svelte": "./src/components/newsletter-section/newsletter-section.schema.ts",
+      "import": "./src/components/newsletter-section/newsletter-section.schema.ts",
       "default": "./dist/components/newsletter-section/newsletter-section.schema.js"
     },
     "./newsletter-section/variables": {
@@ -3310,6 +3660,7 @@
       "browser": "./src/components/newsletter-section/newsletter-section.variables.ts",
       "node": "./dist/server/components/newsletter-section/newsletter-section.variables.js",
       "svelte": "./src/components/newsletter-section/newsletter-section.variables.ts",
+      "import": "./src/components/newsletter-section/newsletter-section.variables.ts",
       "default": "./dist/components/newsletter-section/newsletter-section.variables.js"
     },
     "./newsletter-section/styles": {
@@ -3325,6 +3676,7 @@
       "browser": "./src/components/number-input/index.ts",
       "node": "./dist/server/components/number-input/index.js",
       "svelte": "./src/components/number-input/index.ts",
+      "import": "./src/components/number-input/index.ts",
       "default": "./dist/components/number-input/index.js"
     },
     "./number-input/schema": {
@@ -3332,6 +3684,7 @@
       "browser": "./src/components/number-input/number-input.schema.ts",
       "node": "./dist/server/components/number-input/number-input.schema.js",
       "svelte": "./src/components/number-input/number-input.schema.ts",
+      "import": "./src/components/number-input/number-input.schema.ts",
       "default": "./dist/components/number-input/number-input.schema.js"
     },
     "./number-input/variables": {
@@ -3339,6 +3692,7 @@
       "browser": "./src/components/number-input/number-input.variables.ts",
       "node": "./dist/server/components/number-input/number-input.variables.js",
       "svelte": "./src/components/number-input/number-input.variables.ts",
+      "import": "./src/components/number-input/number-input.variables.ts",
       "default": "./dist/components/number-input/number-input.variables.js"
     },
     "./number-input/styles": {
@@ -3354,6 +3708,7 @@
       "browser": "./src/components/page-header/index.ts",
       "node": "./dist/server/components/page-header/index.js",
       "svelte": "./src/components/page-header/index.ts",
+      "import": "./src/components/page-header/index.ts",
       "default": "./dist/components/page-header/index.js"
     },
     "./page-header/schema": {
@@ -3361,6 +3716,7 @@
       "browser": "./src/components/page-header/page-header.schema.ts",
       "node": "./dist/server/components/page-header/page-header.schema.js",
       "svelte": "./src/components/page-header/page-header.schema.ts",
+      "import": "./src/components/page-header/page-header.schema.ts",
       "default": "./dist/components/page-header/page-header.schema.js"
     },
     "./page-header/variables": {
@@ -3368,6 +3724,7 @@
       "browser": "./src/components/page-header/page-header.variables.ts",
       "node": "./dist/server/components/page-header/page-header.variables.js",
       "svelte": "./src/components/page-header/page-header.variables.ts",
+      "import": "./src/components/page-header/page-header.variables.ts",
       "default": "./dist/components/page-header/page-header.variables.js"
     },
     "./page-header/styles": {
@@ -3383,6 +3740,7 @@
       "browser": "./src/components/pagination/index.ts",
       "node": "./dist/server/components/pagination/index.js",
       "svelte": "./src/components/pagination/index.ts",
+      "import": "./src/components/pagination/index.ts",
       "default": "./dist/components/pagination/index.js"
     },
     "./pagination/schema": {
@@ -3390,6 +3748,7 @@
       "browser": "./src/components/pagination/pagination.schema.ts",
       "node": "./dist/server/components/pagination/pagination.schema.js",
       "svelte": "./src/components/pagination/pagination.schema.ts",
+      "import": "./src/components/pagination/pagination.schema.ts",
       "default": "./dist/components/pagination/pagination.schema.js"
     },
     "./pagination/variables": {
@@ -3397,6 +3756,7 @@
       "browser": "./src/components/pagination/pagination.variables.ts",
       "node": "./dist/server/components/pagination/pagination.variables.js",
       "svelte": "./src/components/pagination/pagination.variables.ts",
+      "import": "./src/components/pagination/pagination.variables.ts",
       "default": "./dist/components/pagination/pagination.variables.js"
     },
     "./pagination/styles": {
@@ -3412,6 +3772,7 @@
       "browser": "./src/components/payload-inspector/index.ts",
       "node": "./dist/server/components/payload-inspector/index.js",
       "svelte": "./src/components/payload-inspector/index.ts",
+      "import": "./src/components/payload-inspector/index.ts",
       "default": "./dist/components/payload-inspector/index.js"
     },
     "./payload-inspector/schema": {
@@ -3419,6 +3780,7 @@
       "browser": "./src/components/payload-inspector/payload-inspector.schema.ts",
       "node": "./dist/server/components/payload-inspector/payload-inspector.schema.js",
       "svelte": "./src/components/payload-inspector/payload-inspector.schema.ts",
+      "import": "./src/components/payload-inspector/payload-inspector.schema.ts",
       "default": "./dist/components/payload-inspector/payload-inspector.schema.js"
     },
     "./payload-inspector/variables": {
@@ -3426,6 +3788,7 @@
       "browser": "./src/components/payload-inspector/payload-inspector.variables.ts",
       "node": "./dist/server/components/payload-inspector/payload-inspector.variables.js",
       "svelte": "./src/components/payload-inspector/payload-inspector.variables.ts",
+      "import": "./src/components/payload-inspector/payload-inspector.variables.ts",
       "default": "./dist/components/payload-inspector/payload-inspector.variables.js"
     },
     "./payload-inspector/styles": {
@@ -3441,6 +3804,7 @@
       "browser": "./src/components/permission-matrix/index.ts",
       "node": "./dist/server/components/permission-matrix/index.js",
       "svelte": "./src/components/permission-matrix/index.ts",
+      "import": "./src/components/permission-matrix/index.ts",
       "default": "./dist/components/permission-matrix/index.js"
     },
     "./permission-matrix/schema": {
@@ -3448,6 +3812,7 @@
       "browser": "./src/components/permission-matrix/permission-matrix.schema.ts",
       "node": "./dist/server/components/permission-matrix/permission-matrix.schema.js",
       "svelte": "./src/components/permission-matrix/permission-matrix.schema.ts",
+      "import": "./src/components/permission-matrix/permission-matrix.schema.ts",
       "default": "./dist/components/permission-matrix/permission-matrix.schema.js"
     },
     "./permission-matrix/variables": {
@@ -3455,6 +3820,7 @@
       "browser": "./src/components/permission-matrix/permission-matrix.variables.ts",
       "node": "./dist/server/components/permission-matrix/permission-matrix.variables.js",
       "svelte": "./src/components/permission-matrix/permission-matrix.variables.ts",
+      "import": "./src/components/permission-matrix/permission-matrix.variables.ts",
       "default": "./dist/components/permission-matrix/permission-matrix.variables.js"
     },
     "./permission-matrix/styles": {
@@ -3470,6 +3836,7 @@
       "browser": "./src/components/phone-input/index.ts",
       "node": "./dist/server/components/phone-input/index.js",
       "svelte": "./src/components/phone-input/index.ts",
+      "import": "./src/components/phone-input/index.ts",
       "default": "./dist/components/phone-input/index.js"
     },
     "./phone-input/schema": {
@@ -3477,6 +3844,7 @@
       "browser": "./src/components/phone-input/phone-input.schema.ts",
       "node": "./dist/server/components/phone-input/phone-input.schema.js",
       "svelte": "./src/components/phone-input/phone-input.schema.ts",
+      "import": "./src/components/phone-input/phone-input.schema.ts",
       "default": "./dist/components/phone-input/phone-input.schema.js"
     },
     "./phone-input/variables": {
@@ -3484,6 +3852,7 @@
       "browser": "./src/components/phone-input/phone-input.variables.ts",
       "node": "./dist/server/components/phone-input/phone-input.variables.js",
       "svelte": "./src/components/phone-input/phone-input.variables.ts",
+      "import": "./src/components/phone-input/phone-input.variables.ts",
       "default": "./dist/components/phone-input/phone-input.variables.js"
     },
     "./phone-input/styles": {
@@ -3499,6 +3868,7 @@
       "browser": "./src/components/pin-input/index.ts",
       "node": "./dist/server/components/pin-input/index.js",
       "svelte": "./src/components/pin-input/index.ts",
+      "import": "./src/components/pin-input/index.ts",
       "default": "./dist/components/pin-input/index.js"
     },
     "./pin-input/schema": {
@@ -3506,6 +3876,7 @@
       "browser": "./src/components/pin-input/pin-input.schema.ts",
       "node": "./dist/server/components/pin-input/pin-input.schema.js",
       "svelte": "./src/components/pin-input/pin-input.schema.ts",
+      "import": "./src/components/pin-input/pin-input.schema.ts",
       "default": "./dist/components/pin-input/pin-input.schema.js"
     },
     "./pin-input/variables": {
@@ -3513,6 +3884,7 @@
       "browser": "./src/components/pin-input/pin-input.variables.ts",
       "node": "./dist/server/components/pin-input/pin-input.variables.js",
       "svelte": "./src/components/pin-input/pin-input.variables.ts",
+      "import": "./src/components/pin-input/pin-input.variables.ts",
       "default": "./dist/components/pin-input/pin-input.variables.js"
     },
     "./pin-input/styles": {
@@ -3528,6 +3900,7 @@
       "browser": "./src/components/popover/index.ts",
       "node": "./dist/server/components/popover/index.js",
       "svelte": "./src/components/popover/index.ts",
+      "import": "./src/components/popover/index.ts",
       "default": "./dist/components/popover/index.js"
     },
     "./popover/schema": {
@@ -3535,6 +3908,7 @@
       "browser": "./src/components/popover/popover.schema.ts",
       "node": "./dist/server/components/popover/popover.schema.js",
       "svelte": "./src/components/popover/popover.schema.ts",
+      "import": "./src/components/popover/popover.schema.ts",
       "default": "./dist/components/popover/popover.schema.js"
     },
     "./popover/variables": {
@@ -3542,6 +3916,7 @@
       "browser": "./src/components/popover/popover.variables.ts",
       "node": "./dist/server/components/popover/popover.variables.js",
       "svelte": "./src/components/popover/popover.variables.ts",
+      "import": "./src/components/popover/popover.variables.ts",
       "default": "./dist/components/popover/popover.variables.js"
     },
     "./popover/styles": {
@@ -3557,6 +3932,7 @@
       "browser": "./src/components/portal/index.ts",
       "node": "./dist/server/components/portal/index.js",
       "svelte": "./src/components/portal/index.ts",
+      "import": "./src/components/portal/index.ts",
       "default": "./dist/components/portal/index.js"
     },
     "./portal/schema": {
@@ -3564,6 +3940,7 @@
       "browser": "./src/components/portal/portal.schema.ts",
       "node": "./dist/server/components/portal/portal.schema.js",
       "svelte": "./src/components/portal/portal.schema.ts",
+      "import": "./src/components/portal/portal.schema.ts",
       "default": "./dist/components/portal/portal.schema.js"
     },
     "./portal/variables": {
@@ -3571,6 +3948,7 @@
       "browser": "./src/components/portal/portal.variables.ts",
       "node": "./dist/server/components/portal/portal.variables.js",
       "svelte": "./src/components/portal/portal.variables.ts",
+      "import": "./src/components/portal/portal.variables.ts",
       "default": "./dist/components/portal/portal.variables.js"
     },
     "./portal/examples": {
@@ -3582,6 +3960,7 @@
       "browser": "./src/components/pricing-card/index.ts",
       "node": "./dist/server/components/pricing-card/index.js",
       "svelte": "./src/components/pricing-card/index.ts",
+      "import": "./src/components/pricing-card/index.ts",
       "default": "./dist/components/pricing-card/index.js"
     },
     "./pricing-card/schema": {
@@ -3589,6 +3968,7 @@
       "browser": "./src/components/pricing-card/pricing-card.schema.ts",
       "node": "./dist/server/components/pricing-card/pricing-card.schema.js",
       "svelte": "./src/components/pricing-card/pricing-card.schema.ts",
+      "import": "./src/components/pricing-card/pricing-card.schema.ts",
       "default": "./dist/components/pricing-card/pricing-card.schema.js"
     },
     "./pricing-card/variables": {
@@ -3596,6 +3976,7 @@
       "browser": "./src/components/pricing-card/pricing-card.variables.ts",
       "node": "./dist/server/components/pricing-card/pricing-card.variables.js",
       "svelte": "./src/components/pricing-card/pricing-card.variables.ts",
+      "import": "./src/components/pricing-card/pricing-card.variables.ts",
       "default": "./dist/components/pricing-card/pricing-card.variables.js"
     },
     "./pricing-card/styles": {
@@ -3611,6 +3992,7 @@
       "browser": "./src/components/pricing-section/index.ts",
       "node": "./dist/server/components/pricing-section/index.js",
       "svelte": "./src/components/pricing-section/index.ts",
+      "import": "./src/components/pricing-section/index.ts",
       "default": "./dist/components/pricing-section/index.js"
     },
     "./pricing-section/schema": {
@@ -3618,6 +4000,7 @@
       "browser": "./src/components/pricing-section/pricing-section.schema.ts",
       "node": "./dist/server/components/pricing-section/pricing-section.schema.js",
       "svelte": "./src/components/pricing-section/pricing-section.schema.ts",
+      "import": "./src/components/pricing-section/pricing-section.schema.ts",
       "default": "./dist/components/pricing-section/pricing-section.schema.js"
     },
     "./pricing-section/variables": {
@@ -3625,6 +4008,7 @@
       "browser": "./src/components/pricing-section/pricing-section.variables.ts",
       "node": "./dist/server/components/pricing-section/pricing-section.variables.js",
       "svelte": "./src/components/pricing-section/pricing-section.variables.ts",
+      "import": "./src/components/pricing-section/pricing-section.variables.ts",
       "default": "./dist/components/pricing-section/pricing-section.variables.js"
     },
     "./pricing-section/styles": {
@@ -3640,6 +4024,7 @@
       "browser": "./src/components/progress/index.ts",
       "node": "./dist/server/components/progress/index.js",
       "svelte": "./src/components/progress/index.ts",
+      "import": "./src/components/progress/index.ts",
       "default": "./dist/components/progress/index.js"
     },
     "./progress/schema": {
@@ -3647,6 +4032,7 @@
       "browser": "./src/components/progress/progress.schema.ts",
       "node": "./dist/server/components/progress/progress.schema.js",
       "svelte": "./src/components/progress/progress.schema.ts",
+      "import": "./src/components/progress/progress.schema.ts",
       "default": "./dist/components/progress/progress.schema.js"
     },
     "./progress/variables": {
@@ -3654,6 +4040,7 @@
       "browser": "./src/components/progress/progress.variables.ts",
       "node": "./dist/server/components/progress/progress.variables.js",
       "svelte": "./src/components/progress/progress.variables.ts",
+      "import": "./src/components/progress/progress.variables.ts",
       "default": "./dist/components/progress/progress.variables.js"
     },
     "./progress/styles": {
@@ -3669,6 +4056,7 @@
       "browser": "./src/components/qr-code/index.ts",
       "node": "./dist/server/components/qr-code/index.js",
       "svelte": "./src/components/qr-code/index.ts",
+      "import": "./src/components/qr-code/index.ts",
       "default": "./dist/components/qr-code/index.js"
     },
     "./qr-code/schema": {
@@ -3676,6 +4064,7 @@
       "browser": "./src/components/qr-code/qr-code.schema.ts",
       "node": "./dist/server/components/qr-code/qr-code.schema.js",
       "svelte": "./src/components/qr-code/qr-code.schema.ts",
+      "import": "./src/components/qr-code/qr-code.schema.ts",
       "default": "./dist/components/qr-code/qr-code.schema.js"
     },
     "./qr-code/variables": {
@@ -3683,6 +4072,7 @@
       "browser": "./src/components/qr-code/qr-code.variables.ts",
       "node": "./dist/server/components/qr-code/qr-code.variables.js",
       "svelte": "./src/components/qr-code/qr-code.variables.ts",
+      "import": "./src/components/qr-code/qr-code.variables.ts",
       "default": "./dist/components/qr-code/qr-code.variables.js"
     },
     "./qr-code/styles": {
@@ -3698,6 +4088,7 @@
       "browser": "./src/components/radio-group/index.ts",
       "node": "./dist/server/components/radio-group/index.js",
       "svelte": "./src/components/radio-group/index.ts",
+      "import": "./src/components/radio-group/index.ts",
       "default": "./dist/components/radio-group/index.js"
     },
     "./radio-group/schema": {
@@ -3705,6 +4096,7 @@
       "browser": "./src/components/radio-group/radio-group.schema.ts",
       "node": "./dist/server/components/radio-group/radio-group.schema.js",
       "svelte": "./src/components/radio-group/radio-group.schema.ts",
+      "import": "./src/components/radio-group/radio-group.schema.ts",
       "default": "./dist/components/radio-group/radio-group.schema.js"
     },
     "./radio-group/variables": {
@@ -3712,6 +4104,7 @@
       "browser": "./src/components/radio-group/radio-group.variables.ts",
       "node": "./dist/server/components/radio-group/radio-group.variables.js",
       "svelte": "./src/components/radio-group/radio-group.variables.ts",
+      "import": "./src/components/radio-group/radio-group.variables.ts",
       "default": "./dist/components/radio-group/radio-group.variables.js"
     },
     "./radio-group/styles": {
@@ -3727,6 +4120,7 @@
       "browser": "./src/components/rating/index.ts",
       "node": "./dist/server/components/rating/index.js",
       "svelte": "./src/components/rating/index.ts",
+      "import": "./src/components/rating/index.ts",
       "default": "./dist/components/rating/index.js"
     },
     "./rating/schema": {
@@ -3734,6 +4128,7 @@
       "browser": "./src/components/rating/rating.schema.ts",
       "node": "./dist/server/components/rating/rating.schema.js",
       "svelte": "./src/components/rating/rating.schema.ts",
+      "import": "./src/components/rating/rating.schema.ts",
       "default": "./dist/components/rating/rating.schema.js"
     },
     "./rating/variables": {
@@ -3741,6 +4136,7 @@
       "browser": "./src/components/rating/rating.variables.ts",
       "node": "./dist/server/components/rating/rating.variables.js",
       "svelte": "./src/components/rating/rating.variables.ts",
+      "import": "./src/components/rating/rating.variables.ts",
       "default": "./dist/components/rating/rating.variables.js"
     },
     "./rating/styles": {
@@ -3756,6 +4152,7 @@
       "browser": "./src/components/resizable-panels/index.ts",
       "node": "./dist/server/components/resizable-panels/index.js",
       "svelte": "./src/components/resizable-panels/index.ts",
+      "import": "./src/components/resizable-panels/index.ts",
       "default": "./dist/components/resizable-panels/index.js"
     },
     "./resizable-panels/schema": {
@@ -3763,6 +4160,7 @@
       "browser": "./src/components/resizable-panels/resizable-panels.schema.ts",
       "node": "./dist/server/components/resizable-panels/resizable-panels.schema.js",
       "svelte": "./src/components/resizable-panels/resizable-panels.schema.ts",
+      "import": "./src/components/resizable-panels/resizable-panels.schema.ts",
       "default": "./dist/components/resizable-panels/resizable-panels.schema.js"
     },
     "./resizable-panels/variables": {
@@ -3770,6 +4168,7 @@
       "browser": "./src/components/resizable-panels/resizable-panels.variables.ts",
       "node": "./dist/server/components/resizable-panels/resizable-panels.variables.js",
       "svelte": "./src/components/resizable-panels/resizable-panels.variables.ts",
+      "import": "./src/components/resizable-panels/resizable-panels.variables.ts",
       "default": "./dist/components/resizable-panels/resizable-panels.variables.js"
     },
     "./resizable-panels/styles": {
@@ -3785,6 +4184,7 @@
       "browser": "./src/components/review-editor/index.ts",
       "node": "./dist/server/components/review-editor/index.js",
       "svelte": "./src/components/review-editor/index.ts",
+      "import": "./src/components/review-editor/index.ts",
       "default": "./dist/components/review-editor/index.js"
     },
     "./review-editor/schema": {
@@ -3792,6 +4192,7 @@
       "browser": "./src/components/review-editor/review-editor.schema.ts",
       "node": "./dist/server/components/review-editor/review-editor.schema.js",
       "svelte": "./src/components/review-editor/review-editor.schema.ts",
+      "import": "./src/components/review-editor/review-editor.schema.ts",
       "default": "./dist/components/review-editor/review-editor.schema.js"
     },
     "./review-editor/variables": {
@@ -3799,6 +4200,7 @@
       "browser": "./src/components/review-editor/review-editor.variables.ts",
       "node": "./dist/server/components/review-editor/review-editor.variables.js",
       "svelte": "./src/components/review-editor/review-editor.variables.ts",
+      "import": "./src/components/review-editor/review-editor.variables.ts",
       "default": "./dist/components/review-editor/review-editor.variables.js"
     },
     "./review-editor/styles": {
@@ -3814,6 +4216,7 @@
       "browser": "./src/components/run-step-timeline/index.ts",
       "node": "./dist/server/components/run-step-timeline/index.js",
       "svelte": "./src/components/run-step-timeline/index.ts",
+      "import": "./src/components/run-step-timeline/index.ts",
       "default": "./dist/components/run-step-timeline/index.js"
     },
     "./run-step-timeline/schema": {
@@ -3821,6 +4224,7 @@
       "browser": "./src/components/run-step-timeline/run-step-timeline.schema.ts",
       "node": "./dist/server/components/run-step-timeline/run-step-timeline.schema.js",
       "svelte": "./src/components/run-step-timeline/run-step-timeline.schema.ts",
+      "import": "./src/components/run-step-timeline/run-step-timeline.schema.ts",
       "default": "./dist/components/run-step-timeline/run-step-timeline.schema.js"
     },
     "./run-step-timeline/variables": {
@@ -3828,6 +4232,7 @@
       "browser": "./src/components/run-step-timeline/run-step-timeline.variables.ts",
       "node": "./dist/server/components/run-step-timeline/run-step-timeline.variables.js",
       "svelte": "./src/components/run-step-timeline/run-step-timeline.variables.ts",
+      "import": "./src/components/run-step-timeline/run-step-timeline.variables.ts",
       "default": "./dist/components/run-step-timeline/run-step-timeline.variables.js"
     },
     "./run-step-timeline/styles": {
@@ -3843,6 +4248,7 @@
       "browser": "./src/components/schema-form/index.ts",
       "node": "./dist/server/components/schema-form/index.js",
       "svelte": "./src/components/schema-form/index.ts",
+      "import": "./src/components/schema-form/index.ts",
       "default": "./dist/components/schema-form/index.js"
     },
     "./schema-form/schema": {
@@ -3850,6 +4256,7 @@
       "browser": "./src/components/schema-form/schema-form.schema.ts",
       "node": "./dist/server/components/schema-form/schema-form.schema.js",
       "svelte": "./src/components/schema-form/schema-form.schema.ts",
+      "import": "./src/components/schema-form/schema-form.schema.ts",
       "default": "./dist/components/schema-form/schema-form.schema.js"
     },
     "./schema-form/variables": {
@@ -3857,6 +4264,7 @@
       "browser": "./src/components/schema-form/schema-form.variables.ts",
       "node": "./dist/server/components/schema-form/schema-form.variables.js",
       "svelte": "./src/components/schema-form/schema-form.variables.ts",
+      "import": "./src/components/schema-form/schema-form.variables.ts",
       "default": "./dist/components/schema-form/schema-form.variables.js"
     },
     "./schema-form/styles": {
@@ -3872,6 +4280,7 @@
       "browser": "./src/components/scroll-area/index.ts",
       "node": "./dist/server/components/scroll-area/index.js",
       "svelte": "./src/components/scroll-area/index.ts",
+      "import": "./src/components/scroll-area/index.ts",
       "default": "./dist/components/scroll-area/index.js"
     },
     "./scroll-area/schema": {
@@ -3879,6 +4288,7 @@
       "browser": "./src/components/scroll-area/scroll-area.schema.ts",
       "node": "./dist/server/components/scroll-area/scroll-area.schema.js",
       "svelte": "./src/components/scroll-area/scroll-area.schema.ts",
+      "import": "./src/components/scroll-area/scroll-area.schema.ts",
       "default": "./dist/components/scroll-area/scroll-area.schema.js"
     },
     "./scroll-area/variables": {
@@ -3886,6 +4296,7 @@
       "browser": "./src/components/scroll-area/scroll-area.variables.ts",
       "node": "./dist/server/components/scroll-area/scroll-area.variables.js",
       "svelte": "./src/components/scroll-area/scroll-area.variables.ts",
+      "import": "./src/components/scroll-area/scroll-area.variables.ts",
       "default": "./dist/components/scroll-area/scroll-area.variables.js"
     },
     "./scroll-area/styles": {
@@ -3901,6 +4312,7 @@
       "browser": "./src/components/search-field/index.ts",
       "node": "./dist/server/components/search-field/index.js",
       "svelte": "./src/components/search-field/index.ts",
+      "import": "./src/components/search-field/index.ts",
       "default": "./dist/components/search-field/index.js"
     },
     "./search-field/schema": {
@@ -3908,6 +4320,7 @@
       "browser": "./src/components/search-field/search-field.schema.ts",
       "node": "./dist/server/components/search-field/search-field.schema.js",
       "svelte": "./src/components/search-field/search-field.schema.ts",
+      "import": "./src/components/search-field/search-field.schema.ts",
       "default": "./dist/components/search-field/search-field.schema.js"
     },
     "./search-field/variables": {
@@ -3915,6 +4328,7 @@
       "browser": "./src/components/search-field/search-field.variables.ts",
       "node": "./dist/server/components/search-field/search-field.variables.js",
       "svelte": "./src/components/search-field/search-field.variables.ts",
+      "import": "./src/components/search-field/search-field.variables.ts",
       "default": "./dist/components/search-field/search-field.variables.js"
     },
     "./search-field/styles": {
@@ -3930,6 +4344,7 @@
       "browser": "./src/components/secret-value-field/index.ts",
       "node": "./dist/server/components/secret-value-field/index.js",
       "svelte": "./src/components/secret-value-field/index.ts",
+      "import": "./src/components/secret-value-field/index.ts",
       "default": "./dist/components/secret-value-field/index.js"
     },
     "./secret-value-field/schema": {
@@ -3937,6 +4352,7 @@
       "browser": "./src/components/secret-value-field/secret-value-field.schema.ts",
       "node": "./dist/server/components/secret-value-field/secret-value-field.schema.js",
       "svelte": "./src/components/secret-value-field/secret-value-field.schema.ts",
+      "import": "./src/components/secret-value-field/secret-value-field.schema.ts",
       "default": "./dist/components/secret-value-field/secret-value-field.schema.js"
     },
     "./secret-value-field/variables": {
@@ -3944,6 +4360,7 @@
       "browser": "./src/components/secret-value-field/secret-value-field.variables.ts",
       "node": "./dist/server/components/secret-value-field/secret-value-field.variables.js",
       "svelte": "./src/components/secret-value-field/secret-value-field.variables.ts",
+      "import": "./src/components/secret-value-field/secret-value-field.variables.ts",
       "default": "./dist/components/secret-value-field/secret-value-field.variables.js"
     },
     "./secret-value-field/styles": {
@@ -3959,6 +4376,7 @@
       "browser": "./src/components/section-heading/index.ts",
       "node": "./dist/server/components/section-heading/index.js",
       "svelte": "./src/components/section-heading/index.ts",
+      "import": "./src/components/section-heading/index.ts",
       "default": "./dist/components/section-heading/index.js"
     },
     "./section-heading/schema": {
@@ -3966,6 +4384,7 @@
       "browser": "./src/components/section-heading/section-heading.schema.ts",
       "node": "./dist/server/components/section-heading/section-heading.schema.js",
       "svelte": "./src/components/section-heading/section-heading.schema.ts",
+      "import": "./src/components/section-heading/section-heading.schema.ts",
       "default": "./dist/components/section-heading/section-heading.schema.js"
     },
     "./section-heading/variables": {
@@ -3973,6 +4392,7 @@
       "browser": "./src/components/section-heading/section-heading.variables.ts",
       "node": "./dist/server/components/section-heading/section-heading.variables.js",
       "svelte": "./src/components/section-heading/section-heading.variables.ts",
+      "import": "./src/components/section-heading/section-heading.variables.ts",
       "default": "./dist/components/section-heading/section-heading.variables.js"
     },
     "./section-heading/styles": {
@@ -3988,6 +4408,7 @@
       "browser": "./src/components/segment/index.ts",
       "node": "./dist/server/components/segment/index.js",
       "svelte": "./src/components/segment/index.ts",
+      "import": "./src/components/segment/index.ts",
       "default": "./dist/components/segment/index.js"
     },
     "./segment/schema": {
@@ -3995,6 +4416,7 @@
       "browser": "./src/components/segment/segment.schema.ts",
       "node": "./dist/server/components/segment/segment.schema.js",
       "svelte": "./src/components/segment/segment.schema.ts",
+      "import": "./src/components/segment/segment.schema.ts",
       "default": "./dist/components/segment/segment.schema.js"
     },
     "./segment/variables": {
@@ -4002,6 +4424,7 @@
       "browser": "./src/components/segment/segment.variables.ts",
       "node": "./dist/server/components/segment/segment.variables.js",
       "svelte": "./src/components/segment/segment.variables.ts",
+      "import": "./src/components/segment/segment.variables.ts",
       "default": "./dist/components/segment/segment.variables.js"
     },
     "./segmented-control": {
@@ -4009,6 +4432,7 @@
       "browser": "./src/components/segmented-control/index.ts",
       "node": "./dist/server/components/segmented-control/index.js",
       "svelte": "./src/components/segmented-control/index.ts",
+      "import": "./src/components/segmented-control/index.ts",
       "default": "./dist/components/segmented-control/index.js"
     },
     "./segmented-control/schema": {
@@ -4016,6 +4440,7 @@
       "browser": "./src/components/segmented-control/segmented-control.schema.ts",
       "node": "./dist/server/components/segmented-control/segmented-control.schema.js",
       "svelte": "./src/components/segmented-control/segmented-control.schema.ts",
+      "import": "./src/components/segmented-control/segmented-control.schema.ts",
       "default": "./dist/components/segmented-control/segmented-control.schema.js"
     },
     "./segmented-control/variables": {
@@ -4023,6 +4448,7 @@
       "browser": "./src/components/segmented-control/segmented-control.variables.ts",
       "node": "./dist/server/components/segmented-control/segmented-control.variables.js",
       "svelte": "./src/components/segmented-control/segmented-control.variables.ts",
+      "import": "./src/components/segmented-control/segmented-control.variables.ts",
       "default": "./dist/components/segmented-control/segmented-control.variables.js"
     },
     "./segmented-control/styles": {
@@ -4038,6 +4464,7 @@
       "browser": "./src/components/select/index.ts",
       "node": "./dist/server/components/select/index.js",
       "svelte": "./src/components/select/index.ts",
+      "import": "./src/components/select/index.ts",
       "default": "./dist/components/select/index.js"
     },
     "./select/schema": {
@@ -4045,6 +4472,7 @@
       "browser": "./src/components/select/select.schema.ts",
       "node": "./dist/server/components/select/select.schema.js",
       "svelte": "./src/components/select/select.schema.ts",
+      "import": "./src/components/select/select.schema.ts",
       "default": "./dist/components/select/select.schema.js"
     },
     "./select/variables": {
@@ -4052,6 +4480,7 @@
       "browser": "./src/components/select/select.variables.ts",
       "node": "./dist/server/components/select/select.variables.js",
       "svelte": "./src/components/select/select.variables.ts",
+      "import": "./src/components/select/select.variables.ts",
       "default": "./dist/components/select/select.variables.js"
     },
     "./select/styles": {
@@ -4067,6 +4496,7 @@
       "browser": "./src/components/selection-popover/index.ts",
       "node": "./dist/server/components/selection-popover/index.js",
       "svelte": "./src/components/selection-popover/index.ts",
+      "import": "./src/components/selection-popover/index.ts",
       "default": "./dist/components/selection-popover/index.js"
     },
     "./selection-popover/schema": {
@@ -4074,6 +4504,7 @@
       "browser": "./src/components/selection-popover/selection-popover.schema.ts",
       "node": "./dist/server/components/selection-popover/selection-popover.schema.js",
       "svelte": "./src/components/selection-popover/selection-popover.schema.ts",
+      "import": "./src/components/selection-popover/selection-popover.schema.ts",
       "default": "./dist/components/selection-popover/selection-popover.schema.js"
     },
     "./selection-popover/variables": {
@@ -4081,6 +4512,7 @@
       "browser": "./src/components/selection-popover/selection-popover.variables.ts",
       "node": "./dist/server/components/selection-popover/selection-popover.variables.js",
       "svelte": "./src/components/selection-popover/selection-popover.variables.ts",
+      "import": "./src/components/selection-popover/selection-popover.variables.ts",
       "default": "./dist/components/selection-popover/selection-popover.variables.js"
     },
     "./selection-popover/styles": {
@@ -4096,6 +4528,7 @@
       "browser": "./src/components/share-card/index.ts",
       "node": "./dist/server/components/share-card/index.js",
       "svelte": "./src/components/share-card/index.ts",
+      "import": "./src/components/share-card/index.ts",
       "default": "./dist/components/share-card/index.js"
     },
     "./share-card/schema": {
@@ -4103,6 +4536,7 @@
       "browser": "./src/components/share-card/share-card.schema.ts",
       "node": "./dist/server/components/share-card/share-card.schema.js",
       "svelte": "./src/components/share-card/share-card.schema.ts",
+      "import": "./src/components/share-card/share-card.schema.ts",
       "default": "./dist/components/share-card/share-card.schema.js"
     },
     "./share-card/variables": {
@@ -4110,6 +4544,7 @@
       "browser": "./src/components/share-card/share-card.variables.ts",
       "node": "./dist/server/components/share-card/share-card.variables.js",
       "svelte": "./src/components/share-card/share-card.variables.ts",
+      "import": "./src/components/share-card/share-card.variables.ts",
       "default": "./dist/components/share-card/share-card.variables.js"
     },
     "./share-card/styles": {
@@ -4125,6 +4560,7 @@
       "browser": "./src/components/sheet/index.ts",
       "node": "./dist/server/components/sheet/index.js",
       "svelte": "./src/components/sheet/index.ts",
+      "import": "./src/components/sheet/index.ts",
       "default": "./dist/components/sheet/index.js"
     },
     "./sheet/schema": {
@@ -4132,6 +4568,7 @@
       "browser": "./src/components/sheet/sheet.schema.ts",
       "node": "./dist/server/components/sheet/sheet.schema.js",
       "svelte": "./src/components/sheet/sheet.schema.ts",
+      "import": "./src/components/sheet/sheet.schema.ts",
       "default": "./dist/components/sheet/sheet.schema.js"
     },
     "./sheet/variables": {
@@ -4139,6 +4576,7 @@
       "browser": "./src/components/sheet/sheet.variables.ts",
       "node": "./dist/server/components/sheet/sheet.variables.js",
       "svelte": "./src/components/sheet/sheet.variables.ts",
+      "import": "./src/components/sheet/sheet.variables.ts",
       "default": "./dist/components/sheet/sheet.variables.js"
     },
     "./sheet/styles": {
@@ -4154,6 +4592,7 @@
       "browser": "./src/components/shortcut-hint/index.ts",
       "node": "./dist/server/components/shortcut-hint/index.js",
       "svelte": "./src/components/shortcut-hint/index.ts",
+      "import": "./src/components/shortcut-hint/index.ts",
       "default": "./dist/components/shortcut-hint/index.js"
     },
     "./shortcut-hint/schema": {
@@ -4161,6 +4600,7 @@
       "browser": "./src/components/shortcut-hint/shortcut-hint.schema.ts",
       "node": "./dist/server/components/shortcut-hint/shortcut-hint.schema.js",
       "svelte": "./src/components/shortcut-hint/shortcut-hint.schema.ts",
+      "import": "./src/components/shortcut-hint/shortcut-hint.schema.ts",
       "default": "./dist/components/shortcut-hint/shortcut-hint.schema.js"
     },
     "./shortcut-hint/variables": {
@@ -4168,6 +4608,7 @@
       "browser": "./src/components/shortcut-hint/shortcut-hint.variables.ts",
       "node": "./dist/server/components/shortcut-hint/shortcut-hint.variables.js",
       "svelte": "./src/components/shortcut-hint/shortcut-hint.variables.ts",
+      "import": "./src/components/shortcut-hint/shortcut-hint.variables.ts",
       "default": "./dist/components/shortcut-hint/shortcut-hint.variables.js"
     },
     "./shortcut-hint/styles": {
@@ -4183,6 +4624,7 @@
       "browser": "./src/components/side-navigation/index.ts",
       "node": "./dist/server/components/side-navigation/index.js",
       "svelte": "./src/components/side-navigation/index.ts",
+      "import": "./src/components/side-navigation/index.ts",
       "default": "./dist/components/side-navigation/index.js"
     },
     "./side-navigation/schema": {
@@ -4190,6 +4632,7 @@
       "browser": "./src/components/side-navigation/side-navigation.schema.ts",
       "node": "./dist/server/components/side-navigation/side-navigation.schema.js",
       "svelte": "./src/components/side-navigation/side-navigation.schema.ts",
+      "import": "./src/components/side-navigation/side-navigation.schema.ts",
       "default": "./dist/components/side-navigation/side-navigation.schema.js"
     },
     "./side-navigation/variables": {
@@ -4197,6 +4640,7 @@
       "browser": "./src/components/side-navigation/side-navigation.variables.ts",
       "node": "./dist/server/components/side-navigation/side-navigation.variables.js",
       "svelte": "./src/components/side-navigation/side-navigation.variables.ts",
+      "import": "./src/components/side-navigation/side-navigation.variables.ts",
       "default": "./dist/components/side-navigation/side-navigation.variables.js"
     },
     "./side-navigation/styles": {
@@ -4212,6 +4656,7 @@
       "browser": "./src/components/side-navigation-group/index.ts",
       "node": "./dist/server/components/side-navigation-group/index.js",
       "svelte": "./src/components/side-navigation-group/index.ts",
+      "import": "./src/components/side-navigation-group/index.ts",
       "default": "./dist/components/side-navigation-group/index.js"
     },
     "./side-navigation-group/schema": {
@@ -4219,6 +4664,7 @@
       "browser": "./src/components/side-navigation-group/side-navigation-group.schema.ts",
       "node": "./dist/server/components/side-navigation-group/side-navigation-group.schema.js",
       "svelte": "./src/components/side-navigation-group/side-navigation-group.schema.ts",
+      "import": "./src/components/side-navigation-group/side-navigation-group.schema.ts",
       "default": "./dist/components/side-navigation-group/side-navigation-group.schema.js"
     },
     "./side-navigation-group/variables": {
@@ -4226,6 +4672,7 @@
       "browser": "./src/components/side-navigation-group/side-navigation-group.variables.ts",
       "node": "./dist/server/components/side-navigation-group/side-navigation-group.variables.js",
       "svelte": "./src/components/side-navigation-group/side-navigation-group.variables.ts",
+      "import": "./src/components/side-navigation-group/side-navigation-group.variables.ts",
       "default": "./dist/components/side-navigation-group/side-navigation-group.variables.js"
     },
     "./side-navigation-group/styles": {
@@ -4237,6 +4684,7 @@
       "browser": "./src/components/side-navigation-item/index.ts",
       "node": "./dist/server/components/side-navigation-item/index.js",
       "svelte": "./src/components/side-navigation-item/index.ts",
+      "import": "./src/components/side-navigation-item/index.ts",
       "default": "./dist/components/side-navigation-item/index.js"
     },
     "./side-navigation-item/schema": {
@@ -4244,6 +4692,7 @@
       "browser": "./src/components/side-navigation-item/side-navigation-item.schema.ts",
       "node": "./dist/server/components/side-navigation-item/side-navigation-item.schema.js",
       "svelte": "./src/components/side-navigation-item/side-navigation-item.schema.ts",
+      "import": "./src/components/side-navigation-item/side-navigation-item.schema.ts",
       "default": "./dist/components/side-navigation-item/side-navigation-item.schema.js"
     },
     "./side-navigation-item/variables": {
@@ -4251,6 +4700,7 @@
       "browser": "./src/components/side-navigation-item/side-navigation-item.variables.ts",
       "node": "./dist/server/components/side-navigation-item/side-navigation-item.variables.js",
       "svelte": "./src/components/side-navigation-item/side-navigation-item.variables.ts",
+      "import": "./src/components/side-navigation-item/side-navigation-item.variables.ts",
       "default": "./dist/components/side-navigation-item/side-navigation-item.variables.js"
     },
     "./sidebar": {
@@ -4258,6 +4708,7 @@
       "browser": "./src/components/sidebar/index.ts",
       "node": "./dist/server/components/sidebar/index.js",
       "svelte": "./src/components/sidebar/index.ts",
+      "import": "./src/components/sidebar/index.ts",
       "default": "./dist/components/sidebar/index.js"
     },
     "./sidebar/schema": {
@@ -4265,6 +4716,7 @@
       "browser": "./src/components/sidebar/sidebar.schema.ts",
       "node": "./dist/server/components/sidebar/sidebar.schema.js",
       "svelte": "./src/components/sidebar/sidebar.schema.ts",
+      "import": "./src/components/sidebar/sidebar.schema.ts",
       "default": "./dist/components/sidebar/sidebar.schema.js"
     },
     "./sidebar/variables": {
@@ -4272,6 +4724,7 @@
       "browser": "./src/components/sidebar/sidebar.variables.ts",
       "node": "./dist/server/components/sidebar/sidebar.variables.js",
       "svelte": "./src/components/sidebar/sidebar.variables.ts",
+      "import": "./src/components/sidebar/sidebar.variables.ts",
       "default": "./dist/components/sidebar/sidebar.variables.js"
     },
     "./sidebar/styles": {
@@ -4287,6 +4740,7 @@
       "browser": "./src/components/skeleton/index.ts",
       "node": "./dist/server/components/skeleton/index.js",
       "svelte": "./src/components/skeleton/index.ts",
+      "import": "./src/components/skeleton/index.ts",
       "default": "./dist/components/skeleton/index.js"
     },
     "./skeleton/schema": {
@@ -4294,6 +4748,7 @@
       "browser": "./src/components/skeleton/skeleton.schema.ts",
       "node": "./dist/server/components/skeleton/skeleton.schema.js",
       "svelte": "./src/components/skeleton/skeleton.schema.ts",
+      "import": "./src/components/skeleton/skeleton.schema.ts",
       "default": "./dist/components/skeleton/skeleton.schema.js"
     },
     "./skeleton/variables": {
@@ -4301,6 +4756,7 @@
       "browser": "./src/components/skeleton/skeleton.variables.ts",
       "node": "./dist/server/components/skeleton/skeleton.variables.js",
       "svelte": "./src/components/skeleton/skeleton.variables.ts",
+      "import": "./src/components/skeleton/skeleton.variables.ts",
       "default": "./dist/components/skeleton/skeleton.variables.js"
     },
     "./skeleton/styles": {
@@ -4316,6 +4772,7 @@
       "browser": "./src/components/skip-link/index.ts",
       "node": "./dist/server/components/skip-link/index.js",
       "svelte": "./src/components/skip-link/index.ts",
+      "import": "./src/components/skip-link/index.ts",
       "default": "./dist/components/skip-link/index.js"
     },
     "./skip-link/schema": {
@@ -4323,6 +4780,7 @@
       "browser": "./src/components/skip-link/skip-link.schema.ts",
       "node": "./dist/server/components/skip-link/skip-link.schema.js",
       "svelte": "./src/components/skip-link/skip-link.schema.ts",
+      "import": "./src/components/skip-link/skip-link.schema.ts",
       "default": "./dist/components/skip-link/skip-link.schema.js"
     },
     "./skip-link/variables": {
@@ -4330,6 +4788,7 @@
       "browser": "./src/components/skip-link/skip-link.variables.ts",
       "node": "./dist/server/components/skip-link/skip-link.variables.js",
       "svelte": "./src/components/skip-link/skip-link.variables.ts",
+      "import": "./src/components/skip-link/skip-link.variables.ts",
       "default": "./dist/components/skip-link/skip-link.variables.js"
     },
     "./skip-link/examples": {
@@ -4341,6 +4800,7 @@
       "browser": "./src/components/slider/index.ts",
       "node": "./dist/server/components/slider/index.js",
       "svelte": "./src/components/slider/index.ts",
+      "import": "./src/components/slider/index.ts",
       "default": "./dist/components/slider/index.js"
     },
     "./slider/schema": {
@@ -4348,6 +4808,7 @@
       "browser": "./src/components/slider/slider.schema.ts",
       "node": "./dist/server/components/slider/slider.schema.js",
       "svelte": "./src/components/slider/slider.schema.ts",
+      "import": "./src/components/slider/slider.schema.ts",
       "default": "./dist/components/slider/slider.schema.js"
     },
     "./slider/variables": {
@@ -4355,6 +4816,7 @@
       "browser": "./src/components/slider/slider.variables.ts",
       "node": "./dist/server/components/slider/slider.variables.js",
       "svelte": "./src/components/slider/slider.variables.ts",
+      "import": "./src/components/slider/slider.variables.ts",
       "default": "./dist/components/slider/slider.variables.js"
     },
     "./slider/styles": {
@@ -4370,6 +4832,7 @@
       "browser": "./src/components/sortable-list/index.ts",
       "node": "./dist/server/components/sortable-list/index.js",
       "svelte": "./src/components/sortable-list/index.ts",
+      "import": "./src/components/sortable-list/index.ts",
       "default": "./dist/components/sortable-list/index.js"
     },
     "./sortable-list/schema": {
@@ -4377,6 +4840,7 @@
       "browser": "./src/components/sortable-list/sortable-list.schema.ts",
       "node": "./dist/server/components/sortable-list/sortable-list.schema.js",
       "svelte": "./src/components/sortable-list/sortable-list.schema.ts",
+      "import": "./src/components/sortable-list/sortable-list.schema.ts",
       "default": "./dist/components/sortable-list/sortable-list.schema.js"
     },
     "./sortable-list/variables": {
@@ -4384,6 +4848,7 @@
       "browser": "./src/components/sortable-list/sortable-list.variables.ts",
       "node": "./dist/server/components/sortable-list/sortable-list.variables.js",
       "svelte": "./src/components/sortable-list/sortable-list.variables.ts",
+      "import": "./src/components/sortable-list/sortable-list.variables.ts",
       "default": "./dist/components/sortable-list/sortable-list.variables.js"
     },
     "./sortable-list/styles": {
@@ -4399,6 +4864,7 @@
       "browser": "./src/components/source-diff-viewer/index.ts",
       "node": "./dist/server/components/source-diff-viewer/index.js",
       "svelte": "./src/components/source-diff-viewer/index.ts",
+      "import": "./src/components/source-diff-viewer/index.ts",
       "default": "./dist/components/source-diff-viewer/index.js"
     },
     "./source-diff-viewer/schema": {
@@ -4406,6 +4872,7 @@
       "browser": "./src/components/source-diff-viewer/source-diff-viewer.schema.ts",
       "node": "./dist/server/components/source-diff-viewer/source-diff-viewer.schema.js",
       "svelte": "./src/components/source-diff-viewer/source-diff-viewer.schema.ts",
+      "import": "./src/components/source-diff-viewer/source-diff-viewer.schema.ts",
       "default": "./dist/components/source-diff-viewer/source-diff-viewer.schema.js"
     },
     "./source-diff-viewer/variables": {
@@ -4413,6 +4880,7 @@
       "browser": "./src/components/source-diff-viewer/source-diff-viewer.variables.ts",
       "node": "./dist/server/components/source-diff-viewer/source-diff-viewer.variables.js",
       "svelte": "./src/components/source-diff-viewer/source-diff-viewer.variables.ts",
+      "import": "./src/components/source-diff-viewer/source-diff-viewer.variables.ts",
       "default": "./dist/components/source-diff-viewer/source-diff-viewer.variables.js"
     },
     "./source-diff-viewer/styles": {
@@ -4428,6 +4896,7 @@
       "browser": "./src/components/sparkbar/index.ts",
       "node": "./dist/server/components/sparkbar/index.js",
       "svelte": "./src/components/sparkbar/index.ts",
+      "import": "./src/components/sparkbar/index.ts",
       "default": "./dist/components/sparkbar/index.js"
     },
     "./sparkbar/schema": {
@@ -4435,6 +4904,7 @@
       "browser": "./src/components/sparkbar/sparkbar.schema.ts",
       "node": "./dist/server/components/sparkbar/sparkbar.schema.js",
       "svelte": "./src/components/sparkbar/sparkbar.schema.ts",
+      "import": "./src/components/sparkbar/sparkbar.schema.ts",
       "default": "./dist/components/sparkbar/sparkbar.schema.js"
     },
     "./sparkbar/variables": {
@@ -4442,6 +4912,7 @@
       "browser": "./src/components/sparkbar/sparkbar.variables.ts",
       "node": "./dist/server/components/sparkbar/sparkbar.variables.js",
       "svelte": "./src/components/sparkbar/sparkbar.variables.ts",
+      "import": "./src/components/sparkbar/sparkbar.variables.ts",
       "default": "./dist/components/sparkbar/sparkbar.variables.js"
     },
     "./sparkbar/styles": {
@@ -4457,6 +4928,7 @@
       "browser": "./src/components/spectrogram/index.ts",
       "node": "./dist/server/components/spectrogram/index.js",
       "svelte": "./src/components/spectrogram/index.ts",
+      "import": "./src/components/spectrogram/index.ts",
       "default": "./dist/components/spectrogram/index.js"
     },
     "./spectrogram/schema": {
@@ -4464,6 +4936,7 @@
       "browser": "./src/components/spectrogram/spectrogram.schema.ts",
       "node": "./dist/server/components/spectrogram/spectrogram.schema.js",
       "svelte": "./src/components/spectrogram/spectrogram.schema.ts",
+      "import": "./src/components/spectrogram/spectrogram.schema.ts",
       "default": "./dist/components/spectrogram/spectrogram.schema.js"
     },
     "./spectrogram/variables": {
@@ -4471,6 +4944,7 @@
       "browser": "./src/components/spectrogram/spectrogram.variables.ts",
       "node": "./dist/server/components/spectrogram/spectrogram.variables.js",
       "svelte": "./src/components/spectrogram/spectrogram.variables.ts",
+      "import": "./src/components/spectrogram/spectrogram.variables.ts",
       "default": "./dist/components/spectrogram/spectrogram.variables.js"
     },
     "./spectrogram/styles": {
@@ -4486,6 +4960,7 @@
       "browser": "./src/components/spectrum-chart/index.ts",
       "node": "./dist/server/components/spectrum-chart/index.js",
       "svelte": "./src/components/spectrum-chart/index.ts",
+      "import": "./src/components/spectrum-chart/index.ts",
       "default": "./dist/components/spectrum-chart/index.js"
     },
     "./spectrum-chart/schema": {
@@ -4493,6 +4968,7 @@
       "browser": "./src/components/spectrum-chart/spectrum-chart.schema.ts",
       "node": "./dist/server/components/spectrum-chart/spectrum-chart.schema.js",
       "svelte": "./src/components/spectrum-chart/spectrum-chart.schema.ts",
+      "import": "./src/components/spectrum-chart/spectrum-chart.schema.ts",
       "default": "./dist/components/spectrum-chart/spectrum-chart.schema.js"
     },
     "./spectrum-chart/variables": {
@@ -4500,6 +4976,7 @@
       "browser": "./src/components/spectrum-chart/spectrum-chart.variables.ts",
       "node": "./dist/server/components/spectrum-chart/spectrum-chart.variables.js",
       "svelte": "./src/components/spectrum-chart/spectrum-chart.variables.ts",
+      "import": "./src/components/spectrum-chart/spectrum-chart.variables.ts",
       "default": "./dist/components/spectrum-chart/spectrum-chart.variables.js"
     },
     "./spectrum-chart/styles": {
@@ -4515,6 +4992,7 @@
       "browser": "./src/components/speed-dial/index.ts",
       "node": "./dist/server/components/speed-dial/index.js",
       "svelte": "./src/components/speed-dial/index.ts",
+      "import": "./src/components/speed-dial/index.ts",
       "default": "./dist/components/speed-dial/index.js"
     },
     "./speed-dial/schema": {
@@ -4522,6 +5000,7 @@
       "browser": "./src/components/speed-dial/speed-dial.schema.ts",
       "node": "./dist/server/components/speed-dial/speed-dial.schema.js",
       "svelte": "./src/components/speed-dial/speed-dial.schema.ts",
+      "import": "./src/components/speed-dial/speed-dial.schema.ts",
       "default": "./dist/components/speed-dial/speed-dial.schema.js"
     },
     "./speed-dial/variables": {
@@ -4529,6 +5008,7 @@
       "browser": "./src/components/speed-dial/speed-dial.variables.ts",
       "node": "./dist/server/components/speed-dial/speed-dial.variables.js",
       "svelte": "./src/components/speed-dial/speed-dial.variables.ts",
+      "import": "./src/components/speed-dial/speed-dial.variables.ts",
       "default": "./dist/components/speed-dial/speed-dial.variables.js"
     },
     "./speed-dial/styles": {
@@ -4544,6 +5024,7 @@
       "browser": "./src/components/speed-dial-action/index.ts",
       "node": "./dist/server/components/speed-dial-action/index.js",
       "svelte": "./src/components/speed-dial-action/index.ts",
+      "import": "./src/components/speed-dial-action/index.ts",
       "default": "./dist/components/speed-dial-action/index.js"
     },
     "./speed-dial-action/schema": {
@@ -4551,6 +5032,7 @@
       "browser": "./src/components/speed-dial-action/speed-dial-action.schema.ts",
       "node": "./dist/server/components/speed-dial-action/speed-dial-action.schema.js",
       "svelte": "./src/components/speed-dial-action/speed-dial-action.schema.ts",
+      "import": "./src/components/speed-dial-action/speed-dial-action.schema.ts",
       "default": "./dist/components/speed-dial-action/speed-dial-action.schema.js"
     },
     "./speed-dial-action/variables": {
@@ -4558,6 +5040,7 @@
       "browser": "./src/components/speed-dial-action/speed-dial-action.variables.ts",
       "node": "./dist/server/components/speed-dial-action/speed-dial-action.variables.js",
       "svelte": "./src/components/speed-dial-action/speed-dial-action.variables.ts",
+      "import": "./src/components/speed-dial-action/speed-dial-action.variables.ts",
       "default": "./dist/components/speed-dial-action/speed-dial-action.variables.js"
     },
     "./spinner": {
@@ -4565,6 +5048,7 @@
       "browser": "./src/components/spinner/index.ts",
       "node": "./dist/server/components/spinner/index.js",
       "svelte": "./src/components/spinner/index.ts",
+      "import": "./src/components/spinner/index.ts",
       "default": "./dist/components/spinner/index.js"
     },
     "./spinner/schema": {
@@ -4572,6 +5056,7 @@
       "browser": "./src/components/spinner/spinner.schema.ts",
       "node": "./dist/server/components/spinner/spinner.schema.js",
       "svelte": "./src/components/spinner/spinner.schema.ts",
+      "import": "./src/components/spinner/spinner.schema.ts",
       "default": "./dist/components/spinner/spinner.schema.js"
     },
     "./spinner/variables": {
@@ -4579,6 +5064,7 @@
       "browser": "./src/components/spinner/spinner.variables.ts",
       "node": "./dist/server/components/spinner/spinner.variables.js",
       "svelte": "./src/components/spinner/spinner.variables.ts",
+      "import": "./src/components/spinner/spinner.variables.ts",
       "default": "./dist/components/spinner/spinner.variables.js"
     },
     "./spinner/styles": {
@@ -4594,6 +5080,7 @@
       "browser": "./src/components/stacked-list-item/index.ts",
       "node": "./dist/server/components/stacked-list-item/index.js",
       "svelte": "./src/components/stacked-list-item/index.ts",
+      "import": "./src/components/stacked-list-item/index.ts",
       "default": "./dist/components/stacked-list-item/index.js"
     },
     "./stacked-list-item/schema": {
@@ -4601,6 +5088,7 @@
       "browser": "./src/components/stacked-list-item/stacked-list-item.schema.ts",
       "node": "./dist/server/components/stacked-list-item/stacked-list-item.schema.js",
       "svelte": "./src/components/stacked-list-item/stacked-list-item.schema.ts",
+      "import": "./src/components/stacked-list-item/stacked-list-item.schema.ts",
       "default": "./dist/components/stacked-list-item/stacked-list-item.schema.js"
     },
     "./stacked-list-item/variables": {
@@ -4608,6 +5096,7 @@
       "browser": "./src/components/stacked-list-item/stacked-list-item.variables.ts",
       "node": "./dist/server/components/stacked-list-item/stacked-list-item.variables.js",
       "svelte": "./src/components/stacked-list-item/stacked-list-item.variables.ts",
+      "import": "./src/components/stacked-list-item/stacked-list-item.variables.ts",
       "default": "./dist/components/stacked-list-item/stacked-list-item.variables.js"
     },
     "./stacked-list-item/styles": {
@@ -4623,6 +5112,7 @@
       "browser": "./src/components/stat/index.ts",
       "node": "./dist/server/components/stat/index.js",
       "svelte": "./src/components/stat/index.ts",
+      "import": "./src/components/stat/index.ts",
       "default": "./dist/components/stat/index.js"
     },
     "./stat/schema": {
@@ -4630,6 +5120,7 @@
       "browser": "./src/components/stat/stat.schema.ts",
       "node": "./dist/server/components/stat/stat.schema.js",
       "svelte": "./src/components/stat/stat.schema.ts",
+      "import": "./src/components/stat/stat.schema.ts",
       "default": "./dist/components/stat/stat.schema.js"
     },
     "./stat/variables": {
@@ -4637,6 +5128,7 @@
       "browser": "./src/components/stat/stat.variables.ts",
       "node": "./dist/server/components/stat/stat.variables.js",
       "svelte": "./src/components/stat/stat.variables.ts",
+      "import": "./src/components/stat/stat.variables.ts",
       "default": "./dist/components/stat/stat.variables.js"
     },
     "./stat/styles": {
@@ -4648,6 +5140,7 @@
       "browser": "./src/components/stat-group/index.ts",
       "node": "./dist/server/components/stat-group/index.js",
       "svelte": "./src/components/stat-group/index.ts",
+      "import": "./src/components/stat-group/index.ts",
       "default": "./dist/components/stat-group/index.js"
     },
     "./stat-group/schema": {
@@ -4655,6 +5148,7 @@
       "browser": "./src/components/stat-group/stat-group.schema.ts",
       "node": "./dist/server/components/stat-group/stat-group.schema.js",
       "svelte": "./src/components/stat-group/stat-group.schema.ts",
+      "import": "./src/components/stat-group/stat-group.schema.ts",
       "default": "./dist/components/stat-group/stat-group.schema.js"
     },
     "./stat-group/variables": {
@@ -4662,6 +5156,7 @@
       "browser": "./src/components/stat-group/stat-group.variables.ts",
       "node": "./dist/server/components/stat-group/stat-group.variables.js",
       "svelte": "./src/components/stat-group/stat-group.variables.ts",
+      "import": "./src/components/stat-group/stat-group.variables.ts",
       "default": "./dist/components/stat-group/stat-group.variables.js"
     },
     "./stat-group/styles": {
@@ -4677,6 +5172,7 @@
       "browser": "./src/components/stats-section/index.ts",
       "node": "./dist/server/components/stats-section/index.js",
       "svelte": "./src/components/stats-section/index.ts",
+      "import": "./src/components/stats-section/index.ts",
       "default": "./dist/components/stats-section/index.js"
     },
     "./stats-section/schema": {
@@ -4684,6 +5180,7 @@
       "browser": "./src/components/stats-section/stats-section.schema.ts",
       "node": "./dist/server/components/stats-section/stats-section.schema.js",
       "svelte": "./src/components/stats-section/stats-section.schema.ts",
+      "import": "./src/components/stats-section/stats-section.schema.ts",
       "default": "./dist/components/stats-section/stats-section.schema.js"
     },
     "./stats-section/variables": {
@@ -4691,6 +5188,7 @@
       "browser": "./src/components/stats-section/stats-section.variables.ts",
       "node": "./dist/server/components/stats-section/stats-section.variables.js",
       "svelte": "./src/components/stats-section/stats-section.variables.ts",
+      "import": "./src/components/stats-section/stats-section.variables.ts",
       "default": "./dist/components/stats-section/stats-section.variables.js"
     },
     "./stats-section/styles": {
@@ -4706,6 +5204,7 @@
       "browser": "./src/components/status-dot/index.ts",
       "node": "./dist/server/components/status-dot/index.js",
       "svelte": "./src/components/status-dot/index.ts",
+      "import": "./src/components/status-dot/index.ts",
       "default": "./dist/components/status-dot/index.js"
     },
     "./status-dot/schema": {
@@ -4713,6 +5212,7 @@
       "browser": "./src/components/status-dot/status-dot.schema.ts",
       "node": "./dist/server/components/status-dot/status-dot.schema.js",
       "svelte": "./src/components/status-dot/status-dot.schema.ts",
+      "import": "./src/components/status-dot/status-dot.schema.ts",
       "default": "./dist/components/status-dot/status-dot.schema.js"
     },
     "./status-dot/variables": {
@@ -4720,6 +5220,7 @@
       "browser": "./src/components/status-dot/status-dot.variables.ts",
       "node": "./dist/server/components/status-dot/status-dot.variables.js",
       "svelte": "./src/components/status-dot/status-dot.variables.ts",
+      "import": "./src/components/status-dot/status-dot.variables.ts",
       "default": "./dist/components/status-dot/status-dot.variables.js"
     },
     "./status-dot/styles": {
@@ -4735,6 +5236,7 @@
       "browser": "./src/components/steps/index.ts",
       "node": "./dist/server/components/steps/index.js",
       "svelte": "./src/components/steps/index.ts",
+      "import": "./src/components/steps/index.ts",
       "default": "./dist/components/steps/index.js"
     },
     "./steps/schema": {
@@ -4742,6 +5244,7 @@
       "browser": "./src/components/steps/steps.schema.ts",
       "node": "./dist/server/components/steps/steps.schema.js",
       "svelte": "./src/components/steps/steps.schema.ts",
+      "import": "./src/components/steps/steps.schema.ts",
       "default": "./dist/components/steps/steps.schema.js"
     },
     "./steps/variables": {
@@ -4749,6 +5252,7 @@
       "browser": "./src/components/steps/steps.variables.ts",
       "node": "./dist/server/components/steps/steps.variables.js",
       "svelte": "./src/components/steps/steps.variables.ts",
+      "import": "./src/components/steps/steps.variables.ts",
       "default": "./dist/components/steps/steps.variables.js"
     },
     "./steps/styles": {
@@ -4764,6 +5268,7 @@
       "browser": "./src/components/surface/index.ts",
       "node": "./dist/server/components/surface/index.js",
       "svelte": "./src/components/surface/index.ts",
+      "import": "./src/components/surface/index.ts",
       "default": "./dist/components/surface/index.js"
     },
     "./surface/schema": {
@@ -4771,6 +5276,7 @@
       "browser": "./src/components/surface/surface.schema.ts",
       "node": "./dist/server/components/surface/surface.schema.js",
       "svelte": "./src/components/surface/surface.schema.ts",
+      "import": "./src/components/surface/surface.schema.ts",
       "default": "./dist/components/surface/surface.schema.js"
     },
     "./surface/variables": {
@@ -4778,6 +5284,7 @@
       "browser": "./src/components/surface/surface.variables.ts",
       "node": "./dist/server/components/surface/surface.variables.js",
       "svelte": "./src/components/surface/surface.variables.ts",
+      "import": "./src/components/surface/surface.variables.ts",
       "default": "./dist/components/surface/surface.variables.js"
     },
     "./surface/styles": {
@@ -4793,6 +5300,7 @@
       "browser": "./src/components/tab/index.ts",
       "node": "./dist/server/components/tab/index.js",
       "svelte": "./src/components/tab/index.ts",
+      "import": "./src/components/tab/index.ts",
       "default": "./dist/components/tab/index.js"
     },
     "./tab/schema": {
@@ -4800,6 +5308,7 @@
       "browser": "./src/components/tab/tab.schema.ts",
       "node": "./dist/server/components/tab/tab.schema.js",
       "svelte": "./src/components/tab/tab.schema.ts",
+      "import": "./src/components/tab/tab.schema.ts",
       "default": "./dist/components/tab/tab.schema.js"
     },
     "./tab/variables": {
@@ -4807,6 +5316,7 @@
       "browser": "./src/components/tab/tab.variables.ts",
       "node": "./dist/server/components/tab/tab.variables.js",
       "svelte": "./src/components/tab/tab.variables.ts",
+      "import": "./src/components/tab/tab.variables.ts",
       "default": "./dist/components/tab/tab.variables.js"
     },
     "./tab/styles": {
@@ -4818,6 +5328,7 @@
       "browser": "./src/components/tab-list/index.ts",
       "node": "./dist/server/components/tab-list/index.js",
       "svelte": "./src/components/tab-list/index.ts",
+      "import": "./src/components/tab-list/index.ts",
       "default": "./dist/components/tab-list/index.js"
     },
     "./tab-list/schema": {
@@ -4825,6 +5336,7 @@
       "browser": "./src/components/tab-list/tab-list.schema.ts",
       "node": "./dist/server/components/tab-list/tab-list.schema.js",
       "svelte": "./src/components/tab-list/tab-list.schema.ts",
+      "import": "./src/components/tab-list/tab-list.schema.ts",
       "default": "./dist/components/tab-list/tab-list.schema.js"
     },
     "./tab-list/variables": {
@@ -4832,6 +5344,7 @@
       "browser": "./src/components/tab-list/tab-list.variables.ts",
       "node": "./dist/server/components/tab-list/tab-list.variables.js",
       "svelte": "./src/components/tab-list/tab-list.variables.ts",
+      "import": "./src/components/tab-list/tab-list.variables.ts",
       "default": "./dist/components/tab-list/tab-list.variables.js"
     },
     "./tab-list/styles": {
@@ -4843,6 +5356,7 @@
       "browser": "./src/components/tab-panel/index.ts",
       "node": "./dist/server/components/tab-panel/index.js",
       "svelte": "./src/components/tab-panel/index.ts",
+      "import": "./src/components/tab-panel/index.ts",
       "default": "./dist/components/tab-panel/index.js"
     },
     "./tab-panel/schema": {
@@ -4850,6 +5364,7 @@
       "browser": "./src/components/tab-panel/tab-panel.schema.ts",
       "node": "./dist/server/components/tab-panel/tab-panel.schema.js",
       "svelte": "./src/components/tab-panel/tab-panel.schema.ts",
+      "import": "./src/components/tab-panel/tab-panel.schema.ts",
       "default": "./dist/components/tab-panel/tab-panel.schema.js"
     },
     "./tab-panel/variables": {
@@ -4857,6 +5372,7 @@
       "browser": "./src/components/tab-panel/tab-panel.variables.ts",
       "node": "./dist/server/components/tab-panel/tab-panel.variables.js",
       "svelte": "./src/components/tab-panel/tab-panel.variables.ts",
+      "import": "./src/components/tab-panel/tab-panel.variables.ts",
       "default": "./dist/components/tab-panel/tab-panel.variables.js"
     },
     "./tab-panel/styles": {
@@ -4868,6 +5384,7 @@
       "browser": "./src/components/table/index.ts",
       "node": "./dist/server/components/table/index.js",
       "svelte": "./src/components/table/index.ts",
+      "import": "./src/components/table/index.ts",
       "default": "./dist/components/table/index.js"
     },
     "./table/schema": {
@@ -4875,6 +5392,7 @@
       "browser": "./src/components/table/table.schema.ts",
       "node": "./dist/server/components/table/table.schema.js",
       "svelte": "./src/components/table/table.schema.ts",
+      "import": "./src/components/table/table.schema.ts",
       "default": "./dist/components/table/table.schema.js"
     },
     "./table/variables": {
@@ -4882,6 +5400,7 @@
       "browser": "./src/components/table/table.variables.ts",
       "node": "./dist/server/components/table/table.variables.js",
       "svelte": "./src/components/table/table.variables.ts",
+      "import": "./src/components/table/table.variables.ts",
       "default": "./dist/components/table/table.variables.js"
     },
     "./table/styles": {
@@ -4897,6 +5416,7 @@
       "browser": "./src/components/table-body/index.ts",
       "node": "./dist/server/components/table-body/index.js",
       "svelte": "./src/components/table-body/index.ts",
+      "import": "./src/components/table-body/index.ts",
       "default": "./dist/components/table-body/index.js"
     },
     "./table-body/schema": {
@@ -4904,6 +5424,7 @@
       "browser": "./src/components/table-body/table-body.schema.ts",
       "node": "./dist/server/components/table-body/table-body.schema.js",
       "svelte": "./src/components/table-body/table-body.schema.ts",
+      "import": "./src/components/table-body/table-body.schema.ts",
       "default": "./dist/components/table-body/table-body.schema.js"
     },
     "./table-body/variables": {
@@ -4911,6 +5432,7 @@
       "browser": "./src/components/table-body/table-body.variables.ts",
       "node": "./dist/server/components/table-body/table-body.variables.js",
       "svelte": "./src/components/table-body/table-body.variables.ts",
+      "import": "./src/components/table-body/table-body.variables.ts",
       "default": "./dist/components/table-body/table-body.variables.js"
     },
     "./table-body/styles": {
@@ -4922,6 +5444,7 @@
       "browser": "./src/components/table-cell/index.ts",
       "node": "./dist/server/components/table-cell/index.js",
       "svelte": "./src/components/table-cell/index.ts",
+      "import": "./src/components/table-cell/index.ts",
       "default": "./dist/components/table-cell/index.js"
     },
     "./table-cell/schema": {
@@ -4929,6 +5452,7 @@
       "browser": "./src/components/table-cell/table-cell.schema.ts",
       "node": "./dist/server/components/table-cell/table-cell.schema.js",
       "svelte": "./src/components/table-cell/table-cell.schema.ts",
+      "import": "./src/components/table-cell/table-cell.schema.ts",
       "default": "./dist/components/table-cell/table-cell.schema.js"
     },
     "./table-cell/variables": {
@@ -4936,6 +5460,7 @@
       "browser": "./src/components/table-cell/table-cell.variables.ts",
       "node": "./dist/server/components/table-cell/table-cell.variables.js",
       "svelte": "./src/components/table-cell/table-cell.variables.ts",
+      "import": "./src/components/table-cell/table-cell.variables.ts",
       "default": "./dist/components/table-cell/table-cell.variables.js"
     },
     "./table-cell/styles": {
@@ -4947,6 +5472,7 @@
       "browser": "./src/components/table-header/index.ts",
       "node": "./dist/server/components/table-header/index.js",
       "svelte": "./src/components/table-header/index.ts",
+      "import": "./src/components/table-header/index.ts",
       "default": "./dist/components/table-header/index.js"
     },
     "./table-header/schema": {
@@ -4954,6 +5480,7 @@
       "browser": "./src/components/table-header/table-header.schema.ts",
       "node": "./dist/server/components/table-header/table-header.schema.js",
       "svelte": "./src/components/table-header/table-header.schema.ts",
+      "import": "./src/components/table-header/table-header.schema.ts",
       "default": "./dist/components/table-header/table-header.schema.js"
     },
     "./table-header/variables": {
@@ -4961,6 +5488,7 @@
       "browser": "./src/components/table-header/table-header.variables.ts",
       "node": "./dist/server/components/table-header/table-header.variables.js",
       "svelte": "./src/components/table-header/table-header.variables.ts",
+      "import": "./src/components/table-header/table-header.variables.ts",
       "default": "./dist/components/table-header/table-header.variables.js"
     },
     "./table-header/styles": {
@@ -4972,6 +5500,7 @@
       "browser": "./src/components/table-header-cell/index.ts",
       "node": "./dist/server/components/table-header-cell/index.js",
       "svelte": "./src/components/table-header-cell/index.ts",
+      "import": "./src/components/table-header-cell/index.ts",
       "default": "./dist/components/table-header-cell/index.js"
     },
     "./table-header-cell/schema": {
@@ -4979,6 +5508,7 @@
       "browser": "./src/components/table-header-cell/table-header-cell.schema.ts",
       "node": "./dist/server/components/table-header-cell/table-header-cell.schema.js",
       "svelte": "./src/components/table-header-cell/table-header-cell.schema.ts",
+      "import": "./src/components/table-header-cell/table-header-cell.schema.ts",
       "default": "./dist/components/table-header-cell/table-header-cell.schema.js"
     },
     "./table-header-cell/variables": {
@@ -4986,6 +5516,7 @@
       "browser": "./src/components/table-header-cell/table-header-cell.variables.ts",
       "node": "./dist/server/components/table-header-cell/table-header-cell.variables.js",
       "svelte": "./src/components/table-header-cell/table-header-cell.variables.ts",
+      "import": "./src/components/table-header-cell/table-header-cell.variables.ts",
       "default": "./dist/components/table-header-cell/table-header-cell.variables.js"
     },
     "./table-header-cell/styles": {
@@ -4997,6 +5528,7 @@
       "browser": "./src/components/table-of-contents/index.ts",
       "node": "./dist/server/components/table-of-contents/index.js",
       "svelte": "./src/components/table-of-contents/index.ts",
+      "import": "./src/components/table-of-contents/index.ts",
       "default": "./dist/components/table-of-contents/index.js"
     },
     "./table-of-contents/schema": {
@@ -5004,6 +5536,7 @@
       "browser": "./src/components/table-of-contents/table-of-contents.schema.ts",
       "node": "./dist/server/components/table-of-contents/table-of-contents.schema.js",
       "svelte": "./src/components/table-of-contents/table-of-contents.schema.ts",
+      "import": "./src/components/table-of-contents/table-of-contents.schema.ts",
       "default": "./dist/components/table-of-contents/table-of-contents.schema.js"
     },
     "./table-of-contents/variables": {
@@ -5011,6 +5544,7 @@
       "browser": "./src/components/table-of-contents/table-of-contents.variables.ts",
       "node": "./dist/server/components/table-of-contents/table-of-contents.variables.js",
       "svelte": "./src/components/table-of-contents/table-of-contents.variables.ts",
+      "import": "./src/components/table-of-contents/table-of-contents.variables.ts",
       "default": "./dist/components/table-of-contents/table-of-contents.variables.js"
     },
     "./table-of-contents/styles": {
@@ -5026,6 +5560,7 @@
       "browser": "./src/components/table-row/index.ts",
       "node": "./dist/server/components/table-row/index.js",
       "svelte": "./src/components/table-row/index.ts",
+      "import": "./src/components/table-row/index.ts",
       "default": "./dist/components/table-row/index.js"
     },
     "./table-row/schema": {
@@ -5033,6 +5568,7 @@
       "browser": "./src/components/table-row/table-row.schema.ts",
       "node": "./dist/server/components/table-row/table-row.schema.js",
       "svelte": "./src/components/table-row/table-row.schema.ts",
+      "import": "./src/components/table-row/table-row.schema.ts",
       "default": "./dist/components/table-row/table-row.schema.js"
     },
     "./table-row/variables": {
@@ -5040,6 +5576,7 @@
       "browser": "./src/components/table-row/table-row.variables.ts",
       "node": "./dist/server/components/table-row/table-row.variables.js",
       "svelte": "./src/components/table-row/table-row.variables.ts",
+      "import": "./src/components/table-row/table-row.variables.ts",
       "default": "./dist/components/table-row/table-row.variables.js"
     },
     "./table-row/styles": {
@@ -5051,6 +5588,7 @@
       "browser": "./src/components/tabs/index.ts",
       "node": "./dist/server/components/tabs/index.js",
       "svelte": "./src/components/tabs/index.ts",
+      "import": "./src/components/tabs/index.ts",
       "default": "./dist/components/tabs/index.js"
     },
     "./tabs/schema": {
@@ -5058,6 +5596,7 @@
       "browser": "./src/components/tabs/tabs.schema.ts",
       "node": "./dist/server/components/tabs/tabs.schema.js",
       "svelte": "./src/components/tabs/tabs.schema.ts",
+      "import": "./src/components/tabs/tabs.schema.ts",
       "default": "./dist/components/tabs/tabs.schema.js"
     },
     "./tabs/variables": {
@@ -5065,6 +5604,7 @@
       "browser": "./src/components/tabs/tabs.variables.ts",
       "node": "./dist/server/components/tabs/tabs.variables.js",
       "svelte": "./src/components/tabs/tabs.variables.ts",
+      "import": "./src/components/tabs/tabs.variables.ts",
       "default": "./dist/components/tabs/tabs.variables.js"
     },
     "./tabs/styles": {
@@ -5080,6 +5620,7 @@
       "browser": "./src/components/tag-input/index.ts",
       "node": "./dist/server/components/tag-input/index.js",
       "svelte": "./src/components/tag-input/index.ts",
+      "import": "./src/components/tag-input/index.ts",
       "default": "./dist/components/tag-input/index.js"
     },
     "./tag-input/schema": {
@@ -5087,6 +5628,7 @@
       "browser": "./src/components/tag-input/tag-input.schema.ts",
       "node": "./dist/server/components/tag-input/tag-input.schema.js",
       "svelte": "./src/components/tag-input/tag-input.schema.ts",
+      "import": "./src/components/tag-input/tag-input.schema.ts",
       "default": "./dist/components/tag-input/tag-input.schema.js"
     },
     "./tag-input/variables": {
@@ -5094,6 +5636,7 @@
       "browser": "./src/components/tag-input/tag-input.variables.ts",
       "node": "./dist/server/components/tag-input/tag-input.variables.js",
       "svelte": "./src/components/tag-input/tag-input.variables.ts",
+      "import": "./src/components/tag-input/tag-input.variables.ts",
       "default": "./dist/components/tag-input/tag-input.variables.js"
     },
     "./tag-input/styles": {
@@ -5109,6 +5652,7 @@
       "browser": "./src/components/team-section/index.ts",
       "node": "./dist/server/components/team-section/index.js",
       "svelte": "./src/components/team-section/index.ts",
+      "import": "./src/components/team-section/index.ts",
       "default": "./dist/components/team-section/index.js"
     },
     "./team-section/schema": {
@@ -5116,6 +5660,7 @@
       "browser": "./src/components/team-section/team-section.schema.ts",
       "node": "./dist/server/components/team-section/team-section.schema.js",
       "svelte": "./src/components/team-section/team-section.schema.ts",
+      "import": "./src/components/team-section/team-section.schema.ts",
       "default": "./dist/components/team-section/team-section.schema.js"
     },
     "./team-section/variables": {
@@ -5123,6 +5668,7 @@
       "browser": "./src/components/team-section/team-section.variables.ts",
       "node": "./dist/server/components/team-section/team-section.variables.js",
       "svelte": "./src/components/team-section/team-section.variables.ts",
+      "import": "./src/components/team-section/team-section.variables.ts",
       "default": "./dist/components/team-section/team-section.variables.js"
     },
     "./team-section/styles": {
@@ -5138,6 +5684,7 @@
       "browser": "./src/components/testimonial-section/index.ts",
       "node": "./dist/server/components/testimonial-section/index.js",
       "svelte": "./src/components/testimonial-section/index.ts",
+      "import": "./src/components/testimonial-section/index.ts",
       "default": "./dist/components/testimonial-section/index.js"
     },
     "./testimonial-section/schema": {
@@ -5145,6 +5692,7 @@
       "browser": "./src/components/testimonial-section/testimonial-section.schema.ts",
       "node": "./dist/server/components/testimonial-section/testimonial-section.schema.js",
       "svelte": "./src/components/testimonial-section/testimonial-section.schema.ts",
+      "import": "./src/components/testimonial-section/testimonial-section.schema.ts",
       "default": "./dist/components/testimonial-section/testimonial-section.schema.js"
     },
     "./testimonial-section/variables": {
@@ -5152,6 +5700,7 @@
       "browser": "./src/components/testimonial-section/testimonial-section.variables.ts",
       "node": "./dist/server/components/testimonial-section/testimonial-section.variables.js",
       "svelte": "./src/components/testimonial-section/testimonial-section.variables.ts",
+      "import": "./src/components/testimonial-section/testimonial-section.variables.ts",
       "default": "./dist/components/testimonial-section/testimonial-section.variables.js"
     },
     "./testimonial-section/styles": {
@@ -5167,6 +5716,7 @@
       "browser": "./src/components/textarea/index.ts",
       "node": "./dist/server/components/textarea/index.js",
       "svelte": "./src/components/textarea/index.ts",
+      "import": "./src/components/textarea/index.ts",
       "default": "./dist/components/textarea/index.js"
     },
     "./textarea/schema": {
@@ -5174,6 +5724,7 @@
       "browser": "./src/components/textarea/textarea.schema.ts",
       "node": "./dist/server/components/textarea/textarea.schema.js",
       "svelte": "./src/components/textarea/textarea.schema.ts",
+      "import": "./src/components/textarea/textarea.schema.ts",
       "default": "./dist/components/textarea/textarea.schema.js"
     },
     "./textarea/variables": {
@@ -5181,6 +5732,7 @@
       "browser": "./src/components/textarea/textarea.variables.ts",
       "node": "./dist/server/components/textarea/textarea.variables.js",
       "svelte": "./src/components/textarea/textarea.variables.ts",
+      "import": "./src/components/textarea/textarea.variables.ts",
       "default": "./dist/components/textarea/textarea.variables.js"
     },
     "./textarea/styles": {
@@ -5196,6 +5748,7 @@
       "browser": "./src/components/time-field/index.ts",
       "node": "./dist/server/components/time-field/index.js",
       "svelte": "./src/components/time-field/index.ts",
+      "import": "./src/components/time-field/index.ts",
       "default": "./dist/components/time-field/index.js"
     },
     "./time-field/schema": {
@@ -5203,6 +5756,7 @@
       "browser": "./src/components/time-field/time-field.schema.ts",
       "node": "./dist/server/components/time-field/time-field.schema.js",
       "svelte": "./src/components/time-field/time-field.schema.ts",
+      "import": "./src/components/time-field/time-field.schema.ts",
       "default": "./dist/components/time-field/time-field.schema.js"
     },
     "./time-field/variables": {
@@ -5210,6 +5764,7 @@
       "browser": "./src/components/time-field/time-field.variables.ts",
       "node": "./dist/server/components/time-field/time-field.variables.js",
       "svelte": "./src/components/time-field/time-field.variables.ts",
+      "import": "./src/components/time-field/time-field.variables.ts",
       "default": "./dist/components/time-field/time-field.variables.js"
     },
     "./time-field/styles": {
@@ -5225,6 +5780,7 @@
       "browser": "./src/components/timeline/index.ts",
       "node": "./dist/server/components/timeline/index.js",
       "svelte": "./src/components/timeline/index.ts",
+      "import": "./src/components/timeline/index.ts",
       "default": "./dist/components/timeline/index.js"
     },
     "./timeline/schema": {
@@ -5232,6 +5788,7 @@
       "browser": "./src/components/timeline/timeline.schema.ts",
       "node": "./dist/server/components/timeline/timeline.schema.js",
       "svelte": "./src/components/timeline/timeline.schema.ts",
+      "import": "./src/components/timeline/timeline.schema.ts",
       "default": "./dist/components/timeline/timeline.schema.js"
     },
     "./timeline/variables": {
@@ -5239,6 +5796,7 @@
       "browser": "./src/components/timeline/timeline.variables.ts",
       "node": "./dist/server/components/timeline/timeline.variables.js",
       "svelte": "./src/components/timeline/timeline.variables.ts",
+      "import": "./src/components/timeline/timeline.variables.ts",
       "default": "./dist/components/timeline/timeline.variables.js"
     },
     "./timeline/styles": {
@@ -5254,6 +5812,7 @@
       "browser": "./src/components/toast-region/index.ts",
       "node": "./dist/server/components/toast-region/index.js",
       "svelte": "./src/components/toast-region/index.ts",
+      "import": "./src/components/toast-region/index.ts",
       "default": "./dist/components/toast-region/index.js"
     },
     "./toast-region/schema": {
@@ -5261,6 +5820,7 @@
       "browser": "./src/components/toast-region/toast-region.schema.ts",
       "node": "./dist/server/components/toast-region/toast-region.schema.js",
       "svelte": "./src/components/toast-region/toast-region.schema.ts",
+      "import": "./src/components/toast-region/toast-region.schema.ts",
       "default": "./dist/components/toast-region/toast-region.schema.js"
     },
     "./toast-region/variables": {
@@ -5268,6 +5828,7 @@
       "browser": "./src/components/toast-region/toast-region.variables.ts",
       "node": "./dist/server/components/toast-region/toast-region.variables.js",
       "svelte": "./src/components/toast-region/toast-region.variables.ts",
+      "import": "./src/components/toast-region/toast-region.variables.ts",
       "default": "./dist/components/toast-region/toast-region.variables.js"
     },
     "./toast-region/styles": {
@@ -5283,6 +5844,7 @@
       "browser": "./src/components/toggle/index.ts",
       "node": "./dist/server/components/toggle/index.js",
       "svelte": "./src/components/toggle/index.ts",
+      "import": "./src/components/toggle/index.ts",
       "default": "./dist/components/toggle/index.js"
     },
     "./toggle/schema": {
@@ -5290,6 +5852,7 @@
       "browser": "./src/components/toggle/toggle.schema.ts",
       "node": "./dist/server/components/toggle/toggle.schema.js",
       "svelte": "./src/components/toggle/toggle.schema.ts",
+      "import": "./src/components/toggle/toggle.schema.ts",
       "default": "./dist/components/toggle/toggle.schema.js"
     },
     "./toggle/variables": {
@@ -5297,6 +5860,7 @@
       "browser": "./src/components/toggle/toggle.variables.ts",
       "node": "./dist/server/components/toggle/toggle.variables.js",
       "svelte": "./src/components/toggle/toggle.variables.ts",
+      "import": "./src/components/toggle/toggle.variables.ts",
       "default": "./dist/components/toggle/toggle.variables.js"
     },
     "./toggle/styles": {
@@ -5312,6 +5876,7 @@
       "browser": "./src/components/toolbar/index.ts",
       "node": "./dist/server/components/toolbar/index.js",
       "svelte": "./src/components/toolbar/index.ts",
+      "import": "./src/components/toolbar/index.ts",
       "default": "./dist/components/toolbar/index.js"
     },
     "./toolbar/schema": {
@@ -5319,6 +5884,7 @@
       "browser": "./src/components/toolbar/toolbar.schema.ts",
       "node": "./dist/server/components/toolbar/toolbar.schema.js",
       "svelte": "./src/components/toolbar/toolbar.schema.ts",
+      "import": "./src/components/toolbar/toolbar.schema.ts",
       "default": "./dist/components/toolbar/toolbar.schema.js"
     },
     "./toolbar/variables": {
@@ -5326,6 +5892,7 @@
       "browser": "./src/components/toolbar/toolbar.variables.ts",
       "node": "./dist/server/components/toolbar/toolbar.variables.js",
       "svelte": "./src/components/toolbar/toolbar.variables.ts",
+      "import": "./src/components/toolbar/toolbar.variables.ts",
       "default": "./dist/components/toolbar/toolbar.variables.js"
     },
     "./toolbar/styles": {
@@ -5341,6 +5908,7 @@
       "browser": "./src/components/tooltip/index.ts",
       "node": "./dist/server/components/tooltip/index.js",
       "svelte": "./src/components/tooltip/index.ts",
+      "import": "./src/components/tooltip/index.ts",
       "default": "./dist/components/tooltip/index.js"
     },
     "./tooltip/schema": {
@@ -5348,6 +5916,7 @@
       "browser": "./src/components/tooltip/tooltip.schema.ts",
       "node": "./dist/server/components/tooltip/tooltip.schema.js",
       "svelte": "./src/components/tooltip/tooltip.schema.ts",
+      "import": "./src/components/tooltip/tooltip.schema.ts",
       "default": "./dist/components/tooltip/tooltip.schema.js"
     },
     "./tooltip/variables": {
@@ -5355,6 +5924,7 @@
       "browser": "./src/components/tooltip/tooltip.variables.ts",
       "node": "./dist/server/components/tooltip/tooltip.variables.js",
       "svelte": "./src/components/tooltip/tooltip.variables.ts",
+      "import": "./src/components/tooltip/tooltip.variables.ts",
       "default": "./dist/components/tooltip/tooltip.variables.js"
     },
     "./tooltip/styles": {
@@ -5370,6 +5940,7 @@
       "browser": "./src/components/transfer-list/index.ts",
       "node": "./dist/server/components/transfer-list/index.js",
       "svelte": "./src/components/transfer-list/index.ts",
+      "import": "./src/components/transfer-list/index.ts",
       "default": "./dist/components/transfer-list/index.js"
     },
     "./transfer-list/schema": {
@@ -5377,6 +5948,7 @@
       "browser": "./src/components/transfer-list/transfer-list.schema.ts",
       "node": "./dist/server/components/transfer-list/transfer-list.schema.js",
       "svelte": "./src/components/transfer-list/transfer-list.schema.ts",
+      "import": "./src/components/transfer-list/transfer-list.schema.ts",
       "default": "./dist/components/transfer-list/transfer-list.schema.js"
     },
     "./transfer-list/variables": {
@@ -5384,6 +5956,7 @@
       "browser": "./src/components/transfer-list/transfer-list.variables.ts",
       "node": "./dist/server/components/transfer-list/transfer-list.variables.js",
       "svelte": "./src/components/transfer-list/transfer-list.variables.ts",
+      "import": "./src/components/transfer-list/transfer-list.variables.ts",
       "default": "./dist/components/transfer-list/transfer-list.variables.js"
     },
     "./transfer-list/styles": {
@@ -5399,6 +5972,7 @@
       "browser": "./src/components/tree/index.ts",
       "node": "./dist/server/components/tree/index.js",
       "svelte": "./src/components/tree/index.ts",
+      "import": "./src/components/tree/index.ts",
       "default": "./dist/components/tree/index.js"
     },
     "./tree/schema": {
@@ -5406,6 +5980,7 @@
       "browser": "./src/components/tree/tree.schema.ts",
       "node": "./dist/server/components/tree/tree.schema.js",
       "svelte": "./src/components/tree/tree.schema.ts",
+      "import": "./src/components/tree/tree.schema.ts",
       "default": "./dist/components/tree/tree.schema.js"
     },
     "./tree/variables": {
@@ -5413,6 +5988,7 @@
       "browser": "./src/components/tree/tree.variables.ts",
       "node": "./dist/server/components/tree/tree.variables.js",
       "svelte": "./src/components/tree/tree.variables.ts",
+      "import": "./src/components/tree/tree.variables.ts",
       "default": "./dist/components/tree/tree.variables.js"
     },
     "./tree/styles": {
@@ -5428,6 +6004,7 @@
       "browser": "./src/components/tree-item/index.ts",
       "node": "./dist/server/components/tree-item/index.js",
       "svelte": "./src/components/tree-item/index.ts",
+      "import": "./src/components/tree-item/index.ts",
       "default": "./dist/components/tree-item/index.js"
     },
     "./tree-item/schema": {
@@ -5435,6 +6012,7 @@
       "browser": "./src/components/tree-item/tree-item.schema.ts",
       "node": "./dist/server/components/tree-item/tree-item.schema.js",
       "svelte": "./src/components/tree-item/tree-item.schema.ts",
+      "import": "./src/components/tree-item/tree-item.schema.ts",
       "default": "./dist/components/tree-item/tree-item.schema.js"
     },
     "./tree-item/variables": {
@@ -5442,6 +6020,7 @@
       "browser": "./src/components/tree-item/tree-item.variables.ts",
       "node": "./dist/server/components/tree-item/tree-item.variables.js",
       "svelte": "./src/components/tree-item/tree-item.variables.ts",
+      "import": "./src/components/tree-item/tree-item.variables.ts",
       "default": "./dist/components/tree-item/tree-item.variables.js"
     },
     "./typography": {
@@ -5449,6 +6028,7 @@
       "browser": "./src/components/typography/index.ts",
       "node": "./dist/server/components/typography/index.js",
       "svelte": "./src/components/typography/index.ts",
+      "import": "./src/components/typography/index.ts",
       "default": "./dist/components/typography/index.js"
     },
     "./typography/schema": {
@@ -5456,6 +6036,7 @@
       "browser": "./src/components/typography/typography.schema.ts",
       "node": "./dist/server/components/typography/typography.schema.js",
       "svelte": "./src/components/typography/typography.schema.ts",
+      "import": "./src/components/typography/typography.schema.ts",
       "default": "./dist/components/typography/typography.schema.js"
     },
     "./typography/variables": {
@@ -5463,6 +6044,7 @@
       "browser": "./src/components/typography/typography.variables.ts",
       "node": "./dist/server/components/typography/typography.variables.js",
       "svelte": "./src/components/typography/typography.variables.ts",
+      "import": "./src/components/typography/typography.variables.ts",
       "default": "./dist/components/typography/typography.variables.js"
     },
     "./typography/styles": {
@@ -5478,6 +6060,7 @@
       "browser": "./src/components/virtual-list/index.ts",
       "node": "./dist/server/components/virtual-list/index.js",
       "svelte": "./src/components/virtual-list/index.ts",
+      "import": "./src/components/virtual-list/index.ts",
       "default": "./dist/components/virtual-list/index.js"
     },
     "./virtual-list/schema": {
@@ -5485,6 +6068,7 @@
       "browser": "./src/components/virtual-list/virtual-list.schema.ts",
       "node": "./dist/server/components/virtual-list/virtual-list.schema.js",
       "svelte": "./src/components/virtual-list/virtual-list.schema.ts",
+      "import": "./src/components/virtual-list/virtual-list.schema.ts",
       "default": "./dist/components/virtual-list/virtual-list.schema.js"
     },
     "./virtual-list/variables": {
@@ -5492,6 +6076,7 @@
       "browser": "./src/components/virtual-list/virtual-list.variables.ts",
       "node": "./dist/server/components/virtual-list/virtual-list.variables.js",
       "svelte": "./src/components/virtual-list/virtual-list.variables.ts",
+      "import": "./src/components/virtual-list/virtual-list.variables.ts",
       "default": "./dist/components/virtual-list/virtual-list.variables.js"
     },
     "./virtual-list/styles": {
@@ -5507,6 +6092,7 @@
       "browser": "./src/components/visually-hidden/index.ts",
       "node": "./dist/server/components/visually-hidden/index.js",
       "svelte": "./src/components/visually-hidden/index.ts",
+      "import": "./src/components/visually-hidden/index.ts",
       "default": "./dist/components/visually-hidden/index.js"
     },
     "./visually-hidden/schema": {
@@ -5514,6 +6100,7 @@
       "browser": "./src/components/visually-hidden/visually-hidden.schema.ts",
       "node": "./dist/server/components/visually-hidden/visually-hidden.schema.js",
       "svelte": "./src/components/visually-hidden/visually-hidden.schema.ts",
+      "import": "./src/components/visually-hidden/visually-hidden.schema.ts",
       "default": "./dist/components/visually-hidden/visually-hidden.schema.js"
     },
     "./visually-hidden/variables": {
@@ -5521,6 +6108,7 @@
       "browser": "./src/components/visually-hidden/visually-hidden.variables.ts",
       "node": "./dist/server/components/visually-hidden/visually-hidden.variables.js",
       "svelte": "./src/components/visually-hidden/visually-hidden.variables.ts",
+      "import": "./src/components/visually-hidden/visually-hidden.variables.ts",
       "default": "./dist/components/visually-hidden/visually-hidden.variables.js"
     },
     "./visually-hidden/examples": {
@@ -5532,6 +6120,7 @@
       "browser": "./src/components/waveform/index.ts",
       "node": "./dist/server/components/waveform/index.js",
       "svelte": "./src/components/waveform/index.ts",
+      "import": "./src/components/waveform/index.ts",
       "default": "./dist/components/waveform/index.js"
     },
     "./waveform/schema": {
@@ -5539,6 +6128,7 @@
       "browser": "./src/components/waveform/waveform.schema.ts",
       "node": "./dist/server/components/waveform/waveform.schema.js",
       "svelte": "./src/components/waveform/waveform.schema.ts",
+      "import": "./src/components/waveform/waveform.schema.ts",
       "default": "./dist/components/waveform/waveform.schema.js"
     },
     "./waveform/variables": {
@@ -5546,6 +6136,7 @@
       "browser": "./src/components/waveform/waveform.variables.ts",
       "node": "./dist/server/components/waveform/waveform.variables.js",
       "svelte": "./src/components/waveform/waveform.variables.ts",
+      "import": "./src/components/waveform/waveform.variables.ts",
       "default": "./dist/components/waveform/waveform.variables.js"
     },
     "./waveform/styles": {
@@ -5561,6 +6152,7 @@
       "browser": "./src/markdown/index.ts",
       "node": "./dist/server/markdown/index.js",
       "svelte": "./src/markdown/index.ts",
+      "import": "./src/markdown/index.ts",
       "default": "./dist/markdown/index.js"
     },
     "./markdown/diff": {
@@ -5568,6 +6160,7 @@
       "browser": "./src/markdown/diff/index.ts",
       "node": "./dist/server/markdown/diff/index.js",
       "svelte": "./src/markdown/diff/index.ts",
+      "import": "./src/markdown/diff/index.ts",
       "default": "./dist/markdown/diff/index.js"
     },
     "./markdown/diff/line-diff": {
@@ -5575,6 +6168,7 @@
       "browser": "./src/markdown/diff/line-diff.ts",
       "node": "./dist/server/markdown/diff/line-diff.js",
       "svelte": "./src/markdown/diff/line-diff.ts",
+      "import": "./src/markdown/diff/line-diff.ts",
       "default": "./dist/markdown/diff/line-diff.js"
     },
     "./markdown/diff/types": {
@@ -5582,6 +6176,7 @@
       "browser": "./src/markdown/diff/types.ts",
       "node": "./dist/server/markdown/diff/types.js",
       "svelte": "./src/markdown/diff/types.ts",
+      "import": "./src/markdown/diff/types.ts",
       "default": "./dist/markdown/diff/types.js"
     },
     "./markdown/pipeline": {
@@ -5589,6 +6184,7 @@
       "browser": "./src/markdown/pipeline/index.ts",
       "node": "./dist/server/markdown/pipeline/index.js",
       "svelte": "./src/markdown/pipeline/index.ts",
+      "import": "./src/markdown/pipeline/index.ts",
       "default": "./dist/markdown/pipeline/index.js"
     },
     "./markdown/rendering": {
@@ -5596,6 +6192,7 @@
       "browser": "./src/markdown/rendering/index.ts",
       "node": "./dist/server/markdown/rendering/index.js",
       "svelte": "./src/markdown/rendering/index.ts",
+      "import": "./src/markdown/rendering/index.ts",
       "default": "./dist/markdown/rendering/index.js"
     },
     "./markdown/rendering/highlighter": {
@@ -5603,6 +6200,7 @@
       "browser": "./src/markdown/rendering/highlighter.ts",
       "node": "./dist/server/markdown/rendering/highlighter.js",
       "svelte": "./src/markdown/rendering/highlighter.ts",
+      "import": "./src/markdown/rendering/highlighter.ts",
       "default": "./dist/markdown/rendering/highlighter.js"
     },
     "./markdown/rendering/mermaid-cache": {
@@ -5610,6 +6208,7 @@
       "browser": "./src/markdown/rendering/mermaid-cache.ts",
       "node": "./dist/server/markdown/rendering/mermaid-cache.js",
       "svelte": "./src/markdown/rendering/mermaid-cache.ts",
+      "import": "./src/markdown/rendering/mermaid-cache.ts",
       "default": "./dist/markdown/rendering/mermaid-cache.js"
     },
     "./markdown/rendering/types": {
@@ -5617,6 +6216,7 @@
       "browser": "./src/markdown/rendering/types.ts",
       "node": "./dist/server/markdown/rendering/types.js",
       "svelte": "./src/markdown/rendering/types.ts",
+      "import": "./src/markdown/rendering/types.ts",
       "default": "./dist/markdown/rendering/types.js"
     },
     "./markdown/utilities/safe-url": {
@@ -5624,6 +6224,7 @@
       "browser": "./src/markdown/utilities/safe-url.ts",
       "node": "./dist/server/markdown/utilities/safe-url.js",
       "svelte": "./src/markdown/utilities/safe-url.ts",
+      "import": "./src/markdown/utilities/safe-url.ts",
       "default": "./dist/markdown/utilities/safe-url.js"
     },
     "./markdown/utilities/sort-keys": {
@@ -5631,6 +6232,7 @@
       "browser": "./src/markdown/utilities/sort-keys.ts",
       "node": "./dist/server/markdown/utilities/sort-keys.js",
       "svelte": "./src/markdown/utilities/sort-keys.ts",
+      "import": "./src/markdown/utilities/sort-keys.ts",
       "default": "./dist/markdown/utilities/sort-keys.js"
     },
     "./editor": {
@@ -5638,6 +6240,7 @@
       "browser": "./src/editor/index.ts",
       "node": "./dist/server/editor/index.js",
       "svelte": "./src/editor/index.ts",
+      "import": "./src/editor/index.ts",
       "default": "./dist/editor/index.js"
     },
     "./editor/component-runtime": {
@@ -5645,6 +6248,7 @@
       "browser": "./src/editor/component-runtime.ts",
       "node": "./dist/server/editor/component-runtime.js",
       "svelte": "./src/editor/component-runtime.ts",
+      "import": "./src/editor/component-runtime.ts",
       "default": "./dist/editor/component-runtime.js"
     },
     "./editor/sanitize-html": {
@@ -5652,6 +6256,7 @@
       "browser": "./src/editor/sanitize-html.ts",
       "node": "./dist/server/editor/sanitize-html.js",
       "svelte": "./src/editor/sanitize-html.ts",
+      "import": "./src/editor/sanitize-html.ts",
       "default": "./dist/editor/sanitize-html.js"
     },
     "./editor/template-placeholders": {
@@ -5659,6 +6264,7 @@
       "browser": "./src/editor/template-placeholders.ts",
       "node": "./dist/server/editor/template-placeholders.js",
       "svelte": "./src/editor/template-placeholders.ts",
+      "import": "./src/editor/template-placeholders.ts",
       "default": "./dist/editor/template-placeholders.js"
     },
     "./editor/template-render": {
@@ -5666,6 +6272,7 @@
       "browser": "./src/editor/template-render.ts",
       "node": "./dist/server/editor/template-render.js",
       "svelte": "./src/editor/template-render.ts",
+      "import": "./src/editor/template-render.ts",
       "default": "./dist/editor/template-render.js"
     },
     "./editor/test-utilities": {
@@ -5673,6 +6280,7 @@
       "browser": "./src/editor/test-utilities.ts",
       "node": "./dist/server/editor/test-utilities.js",
       "svelte": "./src/editor/test-utilities.ts",
+      "import": "./src/editor/test-utilities.ts",
       "default": "./dist/editor/test-utilities.js"
     },
     "./commentary": {
@@ -5680,6 +6288,7 @@
       "browser": "./src/commentary/index.ts",
       "node": "./dist/server/commentary/index.js",
       "svelte": "./src/commentary/index.ts",
+      "import": "./src/commentary/index.ts",
       "default": "./dist/commentary/index.js"
     },
     "./commentary/anchor-decorations": {
@@ -5687,6 +6296,7 @@
       "browser": "./src/commentary/anchor-decorations.ts",
       "node": "./dist/server/commentary/anchor-decorations.js",
       "svelte": "./src/commentary/anchor-decorations.ts",
+      "import": "./src/commentary/anchor-decorations.ts",
       "default": "./dist/commentary/anchor-decorations.js"
     },
     "./commentary/anchoring": {
@@ -5694,6 +6304,7 @@
       "browser": "./src/commentary/anchoring.ts",
       "node": "./dist/server/commentary/anchoring.js",
       "svelte": "./src/commentary/anchoring.ts",
+      "import": "./src/commentary/anchoring.ts",
       "default": "./dist/commentary/anchoring.js"
     },
     "./commentary/comments": {
@@ -5701,6 +6312,7 @@
       "browser": "./src/commentary/comments/index.ts",
       "node": "./dist/server/commentary/comments/index.js",
       "svelte": "./src/commentary/comments/index.ts",
+      "import": "./src/commentary/comments/index.ts",
       "default": "./dist/commentary/comments/index.js"
     },
     "./commentary/comments/types": {
@@ -5708,6 +6320,7 @@
       "browser": "./src/commentary/comments/types.ts",
       "node": "./dist/server/commentary/comments/types.js",
       "svelte": "./src/commentary/comments/types.ts",
+      "import": "./src/commentary/comments/types.ts",
       "default": "./dist/commentary/comments/types.js"
     },
     "./commentary/export": {
@@ -5715,6 +6328,7 @@
       "browser": "./src/commentary/export/index.ts",
       "node": "./dist/server/commentary/export/index.js",
       "svelte": "./src/commentary/export/index.ts",
+      "import": "./src/commentary/export/index.ts",
       "default": "./dist/commentary/export/index.js"
     },
     "./commentary/export/types": {
@@ -5722,6 +6336,7 @@
       "browser": "./src/commentary/export/types.ts",
       "node": "./dist/server/commentary/export/types.js",
       "svelte": "./src/commentary/export/types.ts",
+      "import": "./src/commentary/export/types.ts",
       "default": "./dist/commentary/export/types.js"
     },
     "./commentary/session": {
@@ -5729,6 +6344,7 @@
       "browser": "./src/commentary/session/index.ts",
       "node": "./dist/server/commentary/session/index.js",
       "svelte": "./src/commentary/session/index.ts",
+      "import": "./src/commentary/session/index.ts",
       "default": "./dist/commentary/session/index.js"
     },
     "./commentary/session/types": {
@@ -5736,6 +6352,7 @@
       "browser": "./src/commentary/session/types.ts",
       "node": "./dist/server/commentary/session/types.js",
       "svelte": "./src/commentary/session/types.ts",
+      "import": "./src/commentary/session/types.ts",
       "default": "./dist/commentary/session/types.js"
     },
     "./commentary/shared/anchor-types": {
@@ -5743,6 +6360,7 @@
       "browser": "./src/commentary/shared/anchor-types.ts",
       "node": "./dist/server/commentary/shared/anchor-types.js",
       "svelte": "./src/commentary/shared/anchor-types.ts",
+      "import": "./src/commentary/shared/anchor-types.ts",
       "default": "./dist/commentary/shared/anchor-types.js"
     },
     "./diff": {
@@ -5750,6 +6368,7 @@
       "browser": "./src/diff/index.ts",
       "node": "./dist/server/diff/index.js",
       "svelte": "./src/diff/index.ts",
+      "import": "./src/diff/index.ts",
       "default": "./dist/diff/index.js"
     },
     "./diff/line-diff": {
@@ -5757,6 +6376,7 @@
       "browser": "./src/diff/line-diff.ts",
       "node": "./dist/server/diff/line-diff.js",
       "svelte": "./src/diff/line-diff.ts",
+      "import": "./src/diff/line-diff.ts",
       "default": "./dist/diff/line-diff.js"
     },
     "./diff/types": {
@@ -5764,6 +6384,7 @@
       "browser": "./src/diff/types.ts",
       "node": "./dist/server/diff/types.js",
       "svelte": "./src/diff/types.ts",
+      "import": "./src/diff/types.ts",
       "default": "./dist/diff/types.js"
     },
     "./experimental/json-viewer": {
@@ -5771,6 +6392,7 @@
       "browser": "./src/components/experimental/json-viewer/index.ts",
       "node": "./dist/server/components/experimental/json-viewer/index.js",
       "svelte": "./src/components/experimental/json-viewer/index.ts",
+      "import": "./src/components/experimental/json-viewer/index.ts",
       "default": "./dist/components/experimental/json-viewer/index.js"
     },
     "./experimental/json-viewer/schema": {
@@ -5778,6 +6400,7 @@
       "browser": "./src/components/json-viewer/json-viewer.schema.ts",
       "node": "./dist/server/components/json-viewer/json-viewer.schema.js",
       "svelte": "./src/components/json-viewer/json-viewer.schema.ts",
+      "import": "./src/components/json-viewer/json-viewer.schema.ts",
       "default": "./dist/components/json-viewer/json-viewer.schema.js"
     },
     "./experimental/json-viewer/variables": {
@@ -5785,6 +6408,7 @@
       "browser": "./src/components/json-viewer/json-viewer.variables.ts",
       "node": "./dist/server/components/json-viewer/json-viewer.variables.js",
       "svelte": "./src/components/json-viewer/json-viewer.variables.ts",
+      "import": "./src/components/json-viewer/json-viewer.variables.ts",
       "default": "./dist/components/json-viewer/json-viewer.variables.js"
     },
     "./experimental/json-viewer/styles": {
@@ -5796,6 +6420,7 @@
       "browser": "./src/components/experimental/message/index.ts",
       "node": "./dist/server/components/experimental/message/index.js",
       "svelte": "./src/components/experimental/message/index.ts",
+      "import": "./src/components/experimental/message/index.ts",
       "default": "./dist/components/experimental/message/index.js"
     },
     "./experimental/message/schema": {
@@ -5803,6 +6428,7 @@
       "browser": "./src/components/message/message.schema.ts",
       "node": "./dist/server/components/message/message.schema.js",
       "svelte": "./src/components/message/message.schema.ts",
+      "import": "./src/components/message/message.schema.ts",
       "default": "./dist/components/message/message.schema.js"
     },
     "./experimental/message/variables": {
@@ -5810,6 +6436,7 @@
       "browser": "./src/components/message/message.variables.ts",
       "node": "./dist/server/components/message/message.variables.js",
       "svelte": "./src/components/message/message.variables.ts",
+      "import": "./src/components/message/message.variables.ts",
       "default": "./dist/components/message/message.variables.js"
     },
     "./experimental/message/styles": {

--- a/packages/components/scripts/generate-exports.test.ts
+++ b/packages/components/scripts/generate-exports.test.ts
@@ -2,7 +2,7 @@
  * Unit tests for the exports generator. Focus areas:
  *
  *   1. Condition ordering: `types` must be first within every entry, followed
- *      by `browser`, `node`, `svelte`, `default` in that order. TypeScript
+ *      by `browser`, `node`, `svelte`, `import`, `default` in that order. TypeScript
  *      `nodenext` requires `types` first; Node SSR must beat Svelte source
  *      resolution when `node` and `svelte` are active without `browser`.
  *   2. Forbidden-key guard: any exports map containing keys matching
@@ -35,25 +35,27 @@ import {
 } from './generate-exports.ts';
 
 describe('orderedExportEntry', () => {
-  it('emits keys in [types, browser, node, svelte, default] order regardless of input order', () => {
+  it('emits keys in [types, browser, node, svelte, import, default] order regardless of input order', () => {
     const entry = orderedExportEntry({
       default: './dist/components/button/index.js',
+      import: './src/components/button/index.ts',
       node: './dist/server/components/button/index.js',
       svelte: './src/components/button/index.ts',
       browser: './src/components/button/index.ts',
       types: './dist/components/button/index.d.ts',
     });
-    expect(Object.keys(entry)).toEqual(['types', 'browser', 'node', 'svelte', 'default']);
+    expect(Object.keys(entry)).toEqual(['types', 'browser', 'node', 'svelte', 'import', 'default']);
   });
 
   it('omits missing conditions but keeps surviving keys in order', () => {
     const entry = orderedExportEntry({
       svelte: './src/components/foo/foo.schema.ts',
+      import: './src/components/foo/foo.schema.ts',
       node: './dist/server/components/foo/foo.schema.js',
       browser: './src/components/foo/foo.schema.ts',
       types: './dist/components/foo/foo.schema.d.ts',
     });
-    expect(Object.keys(entry)).toEqual(['types', 'browser', 'node', 'svelte']);
+    expect(Object.keys(entry)).toEqual(['types', 'browser', 'node', 'svelte', 'import']);
   });
 });
 
@@ -65,9 +67,10 @@ describe('computeRootExport', () => {
       browser: './src/index.ts',
       node: './dist/server/index.js',
       svelte: './src/index.ts',
+      import: './src/index.ts',
       default: './dist/index.js',
     });
-    expect(Object.keys(root)).toEqual(['types', 'browser', 'node', 'svelte', 'default']);
+    expect(Object.keys(root)).toEqual(['types', 'browser', 'node', 'svelte', 'import', 'default']);
   });
 });
 
@@ -167,13 +170,14 @@ describe('shouldPreserveLegacyEntry', () => {
 });
 
 describe('computeExports', () => {
-  it('emits the five-condition shape for component subpaths', () => {
+  it('emits the six-condition shape for component subpaths', () => {
     const out = computeExports([{ name: 'button', isExperimental: false, hasCss: false }]);
     expect(out['./button']).toEqual({
       types: './dist/components/button/index.d.ts',
       browser: './src/components/button/index.ts',
       node: './dist/server/components/button/index.js',
       svelte: './src/components/button/index.ts',
+      import: './src/components/button/index.ts',
       default: './dist/components/button/index.js',
     });
     expect(Object.keys(out['./button']!)).toEqual([
@@ -181,17 +185,19 @@ describe('computeExports', () => {
       'browser',
       'node',
       'svelte',
+      'import',
       'default',
     ]);
   });
 
-  it('emits the five-condition runtime shape for /schema and /variables', () => {
+  it('emits the six-condition runtime shape for /schema and /variables', () => {
     const out = computeExports([{ name: 'button', isExperimental: false, hasCss: false }]);
     expect(out['./button/schema']).toEqual({
       types: './dist/components/button/button.schema.d.ts',
       browser: './src/components/button/button.schema.ts',
       node: './dist/server/components/button/button.schema.js',
       svelte: './src/components/button/button.schema.ts',
+      import: './src/components/button/button.schema.ts',
       default: './dist/components/button/button.schema.js',
     });
     expect(out['./button/variables']).toEqual({
@@ -199,6 +205,7 @@ describe('computeExports', () => {
       browser: './src/components/button/button.variables.ts',
       node: './dist/server/components/button/button.variables.js',
       svelte: './src/components/button/button.variables.ts',
+      import: './src/components/button/button.variables.ts',
       default: './dist/components/button/button.variables.js',
     });
   });
@@ -223,8 +230,15 @@ describe('computeExports', () => {
       const entry = out[key]!;
       expect(entry).toHaveProperty('default');
       expect(entry).toHaveProperty('node');
-      // Full five-condition shape in the canonical order.
-      expect(Object.keys(entry)).toEqual(['types', 'browser', 'node', 'svelte', 'default']);
+      // Full six-condition shape in the canonical order.
+      expect(Object.keys(entry)).toEqual([
+        'types',
+        'browser',
+        'node',
+        'svelte',
+        'import',
+        'default',
+      ]);
     }
   });
 
@@ -235,6 +249,7 @@ describe('computeExports', () => {
       browser: './src/components/experimental/lab/index.ts',
       node: './dist/server/components/experimental/lab/index.js',
       svelte: './src/components/experimental/lab/index.ts',
+      import: './src/components/experimental/lab/index.ts',
       default: './dist/components/experimental/lab/index.js',
     });
   });
@@ -262,16 +277,17 @@ describe('computeExports', () => {
 });
 
 describe('stylesGuardExport', () => {
-  it('emits a five-condition entry pointing at the base-guard module', () => {
+  it('emits a six-condition entry pointing at the base-guard module', () => {
     const entry = stylesGuardExport();
     expect(entry).toEqual({
       types: './dist/styles/base-guard.d.ts',
       browser: './src/styles/base-guard.ts',
       node: './dist/server/styles/base-guard.js',
       svelte: './src/styles/base-guard.ts',
+      import: './src/styles/base-guard.ts',
       default: './dist/styles/base-guard.js',
     });
-    expect(Object.keys(entry)).toEqual(['types', 'browser', 'node', 'svelte', 'default']);
+    expect(Object.keys(entry)).toEqual(['types', 'browser', 'node', 'svelte', 'import', 'default']);
   });
 
   it('is not affected by the component discovery list (it is a reserved entry)', () => {

--- a/packages/components/scripts/generate-exports.ts
+++ b/packages/components/scripts/generate-exports.ts
@@ -2,9 +2,9 @@
  * Generates subpath exports for every directory-shaped component under
  * `src/components/`. Each component contributes up to six subpaths:
  *
- *   ./<name>             → component (types/browser/node/svelte/default conditions)
- *   ./<name>/schema      → schema module (types/browser/node/svelte/default conditions)
- *   ./<name>/variables   → variables module (types/browser/node/svelte/default conditions)
+ *   ./<name>             → component (types/browser/node/svelte/import/default conditions)
+ *   ./<name>/schema      → schema module (types/browser/node/svelte/import/default conditions)
+ *   ./<name>/variables   → variables module (types/browser/node/svelte/import/default conditions)
  *   ./<name>/styles      → layer-wrapped CSS sidecar (`types` + `default`; emitted when the component ships a source <name>.css). Compound parents (tabs/table/accordion/side-navigation) @import their leaves' sidecars so the family arrives together.
  *   ./<name>/examples    → examples JSON (import/default only; emitted when file exists)
  *   ./<name>/constraints → constraints JSON (import/default only; emitted when file exists)
@@ -15,8 +15,9 @@
  * requirements and SSR safety: `types` MUST be first within any conditional
  * object, followed by `browser` (source for browser/Svelte tooling that also
  * activates Bun's built-in `node` condition), `node` (per-component SSR build),
- * `svelte` (source for Svelte-aware browser tooling), and `default`
- * (per-component browser ESM build) last.
+ * `svelte` (source for Svelte-aware browser tooling), `import` (source for
+ * Vite/esbuild dependency optimization that does not activate `browser` or
+ * `svelte`), and `default` (per-component browser ESM build) last.
  *
  * Additionally, a package-level `./manifest` entry is emitted pointing at
  * `./components.json` with `import`/`default` conditions only (no `svelte` or
@@ -181,6 +182,7 @@ function highlightersShikiExport(): ExportEntry {
     browser: './src/highlighters/shiki/index.ts',
     svelte: './src/highlighters/shiki/index.ts',
     node: './dist/server/highlighters/shiki/index.js',
+    import: './src/highlighters/shiki/index.ts',
     default: './dist/highlighters/shiki/index.js',
   });
 }
@@ -198,6 +200,7 @@ export function stylesGuardExport(): ExportEntry {
     browser: './src/styles/base-guard.ts',
     svelte: './src/styles/base-guard.ts',
     node: './dist/server/styles/base-guard.js',
+    import: './src/styles/base-guard.ts',
     default: './dist/styles/base-guard.js',
   });
 }
@@ -227,7 +230,8 @@ export const FORBIDDEN_EXPORT_KEY_PATTERN =
  *   2. `browser`
  *   3. `node`
  *   4. `svelte`
- *   5. `default`
+ *   5. `import`
+ *   6. `default`
  *
  * Returns a fresh object so callers can rely on JSON.stringify output order.
  */
@@ -237,6 +241,7 @@ export function orderedExportEntry(entry: ExportEntry): ExportEntry {
   if (entry.browser !== undefined) out.browser = entry.browser;
   if (entry.node !== undefined) out.node = entry.node;
   if (entry.svelte !== undefined) out.svelte = entry.svelte;
+  if (entry.import !== undefined) out.import = entry.import;
   if (entry.default !== undefined) out.default = entry.default;
   return out;
 }
@@ -252,6 +257,7 @@ export function computeRootExport(): ExportEntry {
     browser: './src/index.ts',
     svelte: './src/index.ts',
     node: './dist/server/index.js',
+    import: './src/index.ts',
     default: './dist/index.js',
   });
 }
@@ -324,6 +330,7 @@ export function computeDeprecatedExperimentalAliases(
       browser: `${shimSrcDir}/index.ts`,
       svelte: `${shimSrcDir}/index.ts`,
       node: `${shimServerDistDir}/index.js`,
+      import: `${shimSrcDir}/index.ts`,
       default: `${shimDistDir}/index.js`,
     });
 
@@ -336,6 +343,7 @@ export function computeDeprecatedExperimentalAliases(
       browser: `${newSrcDir}/${name}.schema.ts`,
       svelte: `${newSrcDir}/${name}.schema.ts`,
       node: `${newServerDistDir}/${name}.schema.js`,
+      import: `${newSrcDir}/${name}.schema.ts`,
       default: `${newDistDir}/${name}.schema.js`,
     });
     out[`${aliasPrefix}/variables`] = orderedExportEntry({
@@ -343,6 +351,7 @@ export function computeDeprecatedExperimentalAliases(
       browser: `${newSrcDir}/${name}.variables.ts`,
       svelte: `${newSrcDir}/${name}.variables.ts`,
       node: `${newServerDistDir}/${name}.variables.js`,
+      import: `${newSrcDir}/${name}.variables.ts`,
       default: `${newDistDir}/${name}.variables.js`,
     });
 
@@ -401,13 +410,16 @@ export function computeExports(
     // Component subpath: full conditional shape. `types` first for TypeScript
     // `nodenext`, `browser` second so browser/Bun source workflows that also
     // activate `node` still get source, `node` third so Node SSR wins when both
-    // `node` and `svelte` are active, `svelte` next so Svelte tooling still gets
-    // source, `default` last as the catch-all for Vite/Rollup/esbuild/Webpack.
+    // `node` and source conditions are active, `svelte` next so Svelte tooling
+    // still gets source, `import` next so Vite/esbuild optimizeDeps resolves
+    // source before falling through to compiled output, `default` last as the
+    // catch-all for non-source-aware bundlers.
     out[prefix] = orderedExportEntry({
       types: `${distDir}/index.d.ts`,
       browser: `${srcDir}/index.ts`,
       svelte: `${srcDir}/index.ts`,
       node: `${serverDistDir}/index.js`,
+      import: `${srcDir}/index.ts`,
       default: `${distDir}/index.js`,
     });
 
@@ -417,6 +429,7 @@ export function computeExports(
     //   • `browser` → the `.ts` source for browser/source test workflows
     //   • `node`    → the per-component SSR build `<name>.schema.js`
     //   • `svelte`  → the `.ts` source (so browser Svelte tooling resolves source)
+    //   • `import`  → the `.ts` source for Vite/esbuild optimizeDeps
     //   • `default` → the per-component browser build `<name>.schema.js`
     //
     // The build (scripts/build.ts) compiles each `<name>.schema.ts` /
@@ -435,6 +448,7 @@ export function computeExports(
       browser: `${srcDir}/${name}.schema.ts`,
       svelte: `${srcDir}/${name}.schema.ts`,
       node: `${serverDistDir}/${name}.schema.js`,
+      import: `${srcDir}/${name}.schema.ts`,
       default: `${distDir}/${name}.schema.js`,
     });
     out[`${prefix}/variables`] = orderedExportEntry({
@@ -442,6 +456,7 @@ export function computeExports(
       browser: `${srcDir}/${name}.variables.ts`,
       svelte: `${srcDir}/${name}.variables.ts`,
       node: `${serverDistDir}/${name}.variables.js`,
+      import: `${srcDir}/${name}.variables.ts`,
       default: `${distDir}/${name}.variables.js`,
     });
 

--- a/packages/components/scripts/lib/derive-upstream-reexports.ts
+++ b/packages/components/scripts/lib/derive-upstream-reexports.ts
@@ -410,8 +410,9 @@ function formatNamedExport(
 /**
  * Build a cinder exports-map entry for a single upstream sub-path. Mirrors
  * the conditional shape used by component sub-paths (types/browser/node/
- * svelte/default), so browser/source tooling resolves the `.ts` source for HMR
- * and type checks, while published Node SSR consumers resolve `dist/server/`.
+ * svelte/import/default), so browser/source tooling resolves the `.ts` source
+ * for HMR and type checks, while published Node SSR consumers resolve
+ * `dist/server/`.
  *
  * Note: the in-repo `node` condition points at `dist/server/<rel>` so the
  * server build can resolve these sub-paths from `dist/server` once `build.ts`
@@ -423,6 +424,7 @@ export function cinderExportEntry(reexport: UpstreamReexport): {
   browser: string;
   svelte: string;
   node: string;
+  import: string;
   default: string;
 } {
   const { sourceRelativePath, distRelativePath } = reexport;
@@ -431,6 +433,7 @@ export function cinderExportEntry(reexport: UpstreamReexport): {
     browser: `./src/${sourceRelativePath}`,
     svelte: `./src/${sourceRelativePath}`,
     node: `./dist/server/${distRelativePath}`,
+    import: `./src/${sourceRelativePath}`,
     default: `./dist/${distRelativePath}`,
   };
 }

--- a/packages/components/scripts/pack-for-publish.test.ts
+++ b/packages/components/scripts/pack-for-publish.test.ts
@@ -351,8 +351,12 @@ describe('buildPublishedManifest', () => {
   it('strips TypeScript syntax from staged .svelte.ts modules while preserving runes', () => {
     const source = [
       "import type { Snippet } from 'svelte';",
+      "import { classNames } from './class-names.ts';",
+      "type ResizeCallback = import('./use-resize-observer.types.ts').ResizeCallback;",
       'export function createState(label: string): { value: string } {',
+      '  const callback: ResizeCallback | null = null;',
       '  let value = $state(label);',
+      '  void callback;',
       '  return {',
       '    get value() {',
       '      return value;',
@@ -366,6 +370,8 @@ describe('buildPublishedManifest', () => {
     expect(transformed).not.toContain('import type');
     expect(transformed).not.toContain(': string');
     expect(transformed).not.toContain(': { value: string }');
+    expect(transformed).not.toContain("import('./use-resize-observer.types.ts')");
+    expect(transformed).toContain("import { classNames } from './class-names.ts';");
     expect(transformed).toContain('$state(label)');
     expect(transformed).toContain('export function createState(label)');
   });

--- a/packages/components/scripts/pack-for-publish.ts
+++ b/packages/components/scripts/pack-for-publish.ts
@@ -33,6 +33,7 @@ import { existsSync, statSync } from 'node:fs';
 import { cp, mkdir, rm } from 'node:fs/promises';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import ts from 'typescript';
 
 import { deriveUpstreamReexports, type UpstreamReexport } from './lib/derive-upstream-reexports.ts';
 import { readJsonFile } from './lib/read-json-file.ts';
@@ -46,6 +47,7 @@ type ExportConditional = {
   browser?: string;
   svelte?: string;
   node?: string;
+  import?: string;
   default?: string;
 };
 
@@ -76,8 +78,6 @@ export type SourceMapReference = {
   line: number;
   reference: string;
 };
-
-const svelteTypeScriptTranspiler = new Bun.Transpiler({ loader: 'ts' });
 
 /**
  * Read the source manifest. Throws if the file is missing.
@@ -335,7 +335,13 @@ export function stripDanglingSourceMapUrlComments(
 }
 
 export function transpileSvelteTypeScriptModuleForPublish(source: string): string {
-  return svelteTypeScriptTranspiler.transformSync(source);
+  return ts.transpileModule(source, {
+    compilerOptions: {
+      module: ts.ModuleKind.ESNext,
+      target: ts.ScriptTarget.ESNext,
+      verbatimModuleSyntax: true,
+    },
+  }).outputText;
 }
 
 export function transpileSvelteComponentScriptsForPublish(source: string): string {
@@ -343,7 +349,7 @@ export function transpileSvelteComponentScriptsForPublish(source: string): strin
     /<script(?<attributes>[^>]*)>(?<content>[\s\S]*?)<\/script>/gu,
     (match: string, attributes: string, content: string) => {
       if (!/\blang\s*=\s*["']ts["']/u.test(attributes)) return match;
-      const transformed = svelteTypeScriptTranspiler.transformSync(content).trimEnd();
+      const transformed = transpileSvelteTypeScriptModuleForPublish(content).trimEnd();
       return `<script${attributes}>${transformed.length > 0 ? `\n${transformed}\n` : '\n'}</script>`;
     },
   );
@@ -549,10 +555,13 @@ async function main(): Promise<void> {
 }
 
 if (import.meta.main) {
-  main().catch((error: unknown) => {
+  try {
+    await main();
+    process.exit(0);
+  } catch (error: unknown) {
     console.error('pack-for-publish failed:', error);
     process.exit(1);
-  });
+  }
 }
 
 // Re-export helpers used by `validate-consumers.ts` invariants.

--- a/packages/components/scripts/pack-for-publish.ts
+++ b/packages/components/scripts/pack-for-publish.ts
@@ -551,7 +551,15 @@ export async function packForPublish(): Promise<PackForPublishResult> {
 
 async function main(): Promise<void> {
   const { tarballPath } = await packForPublish();
-  process.stdout.write(`pack-for-publish — emitted ${tarballPath}\n`);
+  await new Promise<void>((resolve, reject) => {
+    process.stdout.write(`pack-for-publish — emitted ${tarballPath}\n`, (error) => {
+      if (error) {
+        reject(error);
+      } else {
+        resolve();
+      }
+    });
+  });
 }
 
 if (import.meta.main) {

--- a/packages/components/scripts/validate-consumers.ts
+++ b/packages/components/scripts/validate-consumers.ts
@@ -322,7 +322,7 @@ function assertPackedExportConditionOrder(
     fail(`packed exports["${exportKey}"] must be a conditional export object`);
   }
 
-  const expectedOrder = ['types', 'browser', 'node', 'svelte', 'default'];
+  const expectedOrder = ['types', 'browser', 'node', 'svelte', 'import', 'default'];
   const actualOrder = Object.keys(entry);
   if (actualOrder.join(',') !== expectedOrder.join(',')) {
     fail(

--- a/packages/components/scripts/validate-resolver-matrix.ts
+++ b/packages/components/scripts/validate-resolver-matrix.ts
@@ -4,7 +4,7 @@
  * Runs `tsc --noEmit` against the two consumer tsconfigs under
  * `fixtures/resolver-matrix/typescript-consumer/`, one with
  * `moduleResolution: nodenext`, one with `moduleResolution: bundler`. Both
- * must succeed for the condition ordering (`types`/`browser`/`node`/`svelte`/`default`)
+ * must succeed for the condition ordering (`types`/`browser`/`node`/`svelte`/`import`/`default`)
  * to be considered safe.
  *
  * Exits non-zero on the first failure. Invoked via `bun run validate:resolver-matrix`.

--- a/packages/components/src/components/review-editor/review-editor.smoke.test.ts
+++ b/packages/components/src/components/review-editor/review-editor.smoke.test.ts
@@ -53,6 +53,7 @@ describe('review-editor public entrypoint', () => {
       browser: './src/components/review-editor/index.ts',
       node: './dist/server/components/review-editor/index.js',
       svelte: './src/components/review-editor/index.ts',
+      import: './src/components/review-editor/index.ts',
       default: './dist/components/review-editor/index.js',
     });
     expect(ReviewEditor).toBeDefined();


### PR DESCRIPTION
## Summary
- add source-backed import conditions to component export maps so Svelte/Vite consumers resolve source modules instead of compiled browser output
- preserve value imports while stripping TypeScript-only syntax from published Svelte source files
- make the publish pack script exit cleanly after emitting the tarball

## Validation
- bun test packages/components/scripts/pack-for-publish.test.ts packages/components/scripts/generate-exports.test.ts
- bun run --filter=@lostgradient/cinder validate:consumer
- TZ=UTC LANG=en_US.UTF-8 bun test --conditions browser --conditions svelte --parallel=1
- git push pre-push validation (scoped)

Fixes #657

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to test fixtures and pre-commit formatting; no runtime library logic in this diff.
> 
> **Overview**
> Adds **`import`** export conditions (pointing at `./src/...` like **`browser`** / **`svelte`**) on the resolver-matrix fixture and its vendored `@lostgradient/cinder` stub so TypeScript **`nodenext`** / **`bundler`** resolution tests match the intended publish export map.
> 
> Updates **lint-staged** so Prettier on `**/*.{json,md,scss}` runs with **`--with-node-modules`**, so formatted files under `node_modules` (e.g. fixture copies) are included when those paths are staged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0c47c1469887bbfe44a31e2e9fc968f6f1b6ee69. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->