### PR TITLE
Fix release validation lint

### DIFF
--- a/packages/components/scripts/validate-consumers.ts
+++ b/packages/components/scripts/validate-consumers.ts
@@ -1524,9 +1524,7 @@ async function promiseWithTimeout<T>(
 ): Promise<T> {
   return await Promise.race([
     promise,
-    Bun.sleep(timeoutMs).then(() =>
-      fail(`${description} timed out after ${timeoutMs}ms`),
-    ) as Promise<never>,
+    Bun.sleep(timeoutMs).then(() => fail(`${description} timed out after ${timeoutMs}ms`)),
   ]);
 }
 


### PR DESCRIPTION
## Summary
- removes an unnecessary Promise type assertion that fails the release workflow oxlint gate

## Validation
- bun run --filter=@lostgradient/cinder lint
- bun run --filter=@lostgradient/cinder typecheck
- bun run --filter=@lostgradient/cinder validate:release-workflow
- pre-commit hook: @lostgradient/cinder typecheck + test
- pre-push hook: scoped lint/typecheck/test

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line lint fix in release validation script; no runtime or consumer behavior change.
> 
> **Overview**
> Unblocks the release workflow **oxlint** gate by dropping the redundant `as Promise<never>` on the timeout branch inside `promiseWithTimeout` in `validate-consumers.ts`.
> 
> The timeout path still calls `fail(...)`, which already returns `never`, so `Promise.race` typing is unchanged—only the lint violation is removed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ef2a034e52100e40047cbd684a5999d0984c072e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->