### PR TITLE
fix: close mobile navigation menu on item activation

### DIFF
--- a/.changeset/navigation-bar-mobile-menu-close.md
+++ b/.changeset/navigation-bar-mobile-menu-close.md
@@ -1,0 +1,5 @@
+---
+'@lostgradient/cinder': patch
+---
+
+Close a collapsed top NavigationBar mobile menu after enabled item activation.

--- a/packages/components/src/components/navigation-bar/README.md
+++ b/packages/components/src/components/navigation-bar/README.md
@@ -40,6 +40,11 @@ the app shell:
 </div>
 ```
 
+When a top navigation bar collapses behind a `menuToggle`, activating an enabled
+navigation item closes the mobile menu and returns focus to the toggle. Item or
+bar-level click handlers can call `event.preventDefault()` to keep the menu open
+for guarded navigation, local state changes, or custom routing.
+
 ## Props
 
 <!-- generated:props:start -->

--- a/packages/components/src/components/navigation-bar/navigation-bar.a11y.md
+++ b/packages/components/src/components/navigation-bar/navigation-bar.a11y.md
@@ -44,7 +44,9 @@ Consumer `onkeydown` handlers passed via rest props are also respected: the cons
 
 ## Focus Return
 
-When the user presses Escape to close the menu, focus is returned to the toggle button that opened it. This focus-return guarantee requires that, on the client, the consumer's `menuToggle` snippet spreads `toggleAttributes.onclick` onto a native `<button>` element so `event.currentTarget` is a real focusable DOM element.
+When the user presses Escape to close the menu, focus is returned to the toggle button that opened it. When the mobile menu closes after item activation, focus also moves back to the toggle before the items region is hidden. Controlled menus that start open use the rendered toggle button as the fallback focus target.
+
+This focus-return guarantee requires that, on the client, the consumer's `menuToggle` snippet spreads `toggleAttributes.onclick` onto a native `<button>` element so `event.currentTarget` is a real focusable DOM element.
 
 If a consumer wraps the toggle in a custom component without ensuring the native button receives `onclick` directly, Escape still closes the menu but focus does not move. This is a documented degradation, not a bug.
 
@@ -57,7 +59,11 @@ If a consumer wraps the toggle in a custom component without ensuring the native
 
 ## Route-Change Auto-Close
 
-The component has no router dependency. Consumers using a client-side router ([SvelteKit](https://kit.svelte.dev), etc.) should subscribe to route-change events and set `bind:mobileMenuOpen` to `false` when the route changes. Example:
+When a top navigation bar is in its collapsed mobile layout, activating an enabled navigation item closes the menu automatically unless the click event has been cancelled with `event.preventDefault()`. This includes click, Enter, and Space activation because keyboard activation dispatches a click on the focused item.
+
+Use `preventDefault()` from an item click handler or a bar-level `onclick` handler when navigation is guarded, delayed, or handled by local state and the menu should remain open.
+
+The component has no router dependency. Consumers using a client-side router ([SvelteKit](https://kit.svelte.dev), etc.) can still subscribe to route-change events and set `bind:mobileMenuOpen` to `false` when the route changes. Example:
 
 ```svelte
 <script>

--- a/packages/components/src/components/navigation-bar/navigation-bar.svelte
+++ b/packages/components/src/components/navigation-bar/navigation-bar.svelte
@@ -209,7 +209,12 @@
 
   function handleClick(event: MouseEvent): void {
     if (consumerOnClick) {
-      (consumerOnClick as (e: MouseEvent) => void)(event);
+      const currentTarget =
+        event.currentTarget instanceof HTMLElement ? event.currentTarget : navigationBarElement;
+      (consumerOnClick as (this: HTMLElement | null, e: MouseEvent) => void).call(
+        currentTarget,
+        event,
+      );
     }
     if (event.defaultPrevented) return;
 

--- a/packages/components/src/components/navigation-bar/navigation-bar.svelte
+++ b/packages/components/src/components/navigation-bar/navigation-bar.svelte
@@ -157,7 +157,7 @@
   }
 
   function getEventNavigationItem(event: Event): HTMLElement | null {
-    if (!(event.target instanceof HTMLElement) || !itemsRegionElement) return null;
+    if (!(event.target instanceof Element) || !itemsRegionElement) return null;
 
     const navigationItem = event.target.closest<HTMLElement>(navigationItemSelector);
     if (!navigationItem || !itemsRegionElement.contains(navigationItem)) return null;
@@ -191,9 +191,11 @@
   }
 
   function handleClick(event: MouseEvent): void {
+    const wasDefaultPrevented = event.defaultPrevented;
     if (consumerOnClick) {
       (consumerOnClick as (e: MouseEvent) => void)(event);
     }
+    if (!wasDefaultPrevented && event.defaultPrevented) return;
 
     const navigationItem = getEventNavigationItem(event);
     if (!navigationItem || !canCloseAfterItemActivation(navigationItem, event)) return;

--- a/packages/components/src/components/navigation-bar/navigation-bar.svelte
+++ b/packages/components/src/components/navigation-bar/navigation-bar.svelte
@@ -190,6 +190,15 @@
     );
   }
 
+  function moveFocusBeforeClosingItemsRegion(): void {
+    if (!browser || !itemsRegionElement) return;
+
+    const activeElement = document.activeElement;
+    if (activeElement instanceof Element && itemsRegionElement.contains(activeElement)) {
+      toggleElement?.focus();
+    }
+  }
+
   function handleClick(event: MouseEvent): void {
     const wasDefaultPrevented = event.defaultPrevented;
     if (consumerOnClick) {
@@ -200,6 +209,7 @@
     const navigationItem = getEventNavigationItem(event);
     if (!navigationItem || !canCloseAfterItemActivation(navigationItem, event)) return;
 
+    moveFocusBeforeClosingItemsRegion();
     mobileMenuOpen = false;
   }
 

--- a/packages/components/src/components/navigation-bar/navigation-bar.svelte
+++ b/packages/components/src/components/navigation-bar/navigation-bar.svelte
@@ -49,6 +49,7 @@
     'data-cinder-placement': _dataCinderPlacement,
     'data-cinder-label-visibility': _dataCinderLabelVisibility,
     'data-cinder-menu-toggle-placement': _dataCinderMenuTogglePlacement,
+    onclick: consumerOnClick,
     onkeydown: consumerOnKeyDown,
     ...rest
   }: NavigationBarProps = $props();
@@ -155,14 +156,49 @@
     return item.getAttribute('aria-disabled') !== 'true' && !item.hasAttribute('disabled');
   }
 
-  function getEventNavigationItem(event: KeyboardEvent): HTMLElement | null {
+  function getEventNavigationItem(event: Event): HTMLElement | null {
     if (!(event.target instanceof HTMLElement) || !itemsRegionElement) return null;
 
     const navigationItem = event.target.closest<HTMLElement>(navigationItemSelector);
     if (!navigationItem || !itemsRegionElement.contains(navigationItem)) return null;
-    if (navigationItem !== event.target) return null;
 
     return navigationItem;
+  }
+
+  function isModifiedClick(event: MouseEvent): boolean {
+    return event.button !== 0 || event.altKey || event.ctrlKey || event.metaKey || event.shiftKey;
+  }
+
+  function opensOutsideCurrentPage(item: HTMLElement): boolean {
+    if (!(item instanceof HTMLAnchorElement)) return false;
+
+    const target = item.getAttribute('target');
+    return (
+      item.hasAttribute('download') ||
+      (target !== null && target.trim() !== '' && target.trim().toLowerCase() !== '_self')
+    );
+  }
+
+  function canCloseAfterItemActivation(item: HTMLElement, event: MouseEvent): boolean {
+    return (
+      isCollapsible &&
+      isMobileLayout &&
+      mobileMenuOpen &&
+      isEnabledNavigationItem(item) &&
+      !isModifiedClick(event) &&
+      !opensOutsideCurrentPage(item)
+    );
+  }
+
+  function handleClick(event: MouseEvent): void {
+    if (consumerOnClick) {
+      (consumerOnClick as (e: MouseEvent) => void)(event);
+    }
+
+    const navigationItem = getEventNavigationItem(event);
+    if (!navigationItem || !canCloseAfterItemActivation(navigationItem, event)) return;
+
+    mobileMenuOpen = false;
   }
 
   function focusAdjacentNavigationItem(currentItem: HTMLElement, direction: -1 | 1): void {
@@ -197,7 +233,7 @@
     }
 
     const navigationItem = getEventNavigationItem(event);
-    if (!navigationItem) return;
+    if (!navigationItem || navigationItem !== event.target) return;
 
     if (event.key === 'ArrowLeft' || event.key === 'ArrowRight') {
       event.preventDefault();
@@ -223,6 +259,7 @@
   data-cinder-placement={placement}
   data-cinder-label-visibility={showLabels}
   data-cinder-menu-toggle-placement={menuTogglePlacement}
+  onclick={handleClick}
   onkeydown={handleKeyDown}
 >
   {#if isCollapsible && menuToggle && menuTogglePlacement === 'before-brand'}

--- a/packages/components/src/components/navigation-bar/navigation-bar.svelte
+++ b/packages/components/src/components/navigation-bar/navigation-bar.svelte
@@ -54,6 +54,8 @@
     ...rest
   }: NavigationBarProps = $props();
   const navigationItemSelector = '[data-cinder-navigation-item]';
+  const toggleFocusSelector =
+    '.cinder-navigation-bar__menu-toggle button, .cinder-navigation-bar__menu-toggle [href], .cinder-navigation-bar__menu-toggle input, .cinder-navigation-bar__menu-toggle select, .cinder-navigation-bar__menu-toggle textarea, .cinder-navigation-bar__menu-toggle [tabindex]:not([tabindex="-1"])';
 
   const isCollapsible = $derived(placement === 'top' && menuToggle !== undefined);
   let isMobileLayout = $state(false);
@@ -195,8 +197,14 @@
 
     const activeElement = document.activeElement;
     if (activeElement instanceof Element && itemsRegionElement.contains(activeElement)) {
-      toggleElement?.focus();
+      focusMenuToggle();
     }
+  }
+
+  function focusMenuToggle(): void {
+    const focusTarget =
+      toggleElement ?? navigationBarElement?.querySelector<HTMLElement>(toggleFocusSelector);
+    focusTarget?.focus();
   }
 
   function handleClick(event: MouseEvent): void {
@@ -238,8 +246,7 @@
 
     if (event.key === 'Escape' && isCollapsible && isMobileLayout && mobileMenuOpen) {
       mobileMenuOpen = false;
-      // Return focus synchronously — toggleElement is captured on each click.
-      toggleElement?.focus();
+      focusMenuToggle();
       return;
     }
 

--- a/packages/components/src/components/navigation-bar/navigation-bar.svelte
+++ b/packages/components/src/components/navigation-bar/navigation-bar.svelte
@@ -200,11 +200,10 @@
   }
 
   function handleClick(event: MouseEvent): void {
-    const wasDefaultPrevented = event.defaultPrevented;
     if (consumerOnClick) {
       (consumerOnClick as (e: MouseEvent) => void)(event);
     }
-    if (!wasDefaultPrevented && event.defaultPrevented) return;
+    if (event.defaultPrevented) return;
 
     const navigationItem = getEventNavigationItem(event);
     if (!navigationItem || !canCloseAfterItemActivation(navigationItem, event)) return;

--- a/packages/components/src/components/navigation-bar/navigation-bar.test.ts
+++ b/packages/components/src/components/navigation-bar/navigation-bar.test.ts
@@ -163,6 +163,28 @@ function keyboardNavigationSnippet(clicks: Record<string, number>) {
   }));
 }
 
+function iconNavigationSnippet(clicks: Record<string, number>) {
+  return createRawSnippet(() => ({
+    render: () => `
+      <button type="button" class="cinder-navigation-item" data-cinder-navigation-item data-key="home">
+        <svg data-testid="home-icon" viewBox="0 0 16 16" aria-hidden="true">
+          <path d="M8 2 2 7h2v7h8V7h2z"></path>
+        </svg>
+        <span>Home</span>
+      </button>
+    `,
+    setup(element: Element) {
+      const button = element.matches('.cinder-navigation-item')
+        ? (element as HTMLButtonElement)
+        : element.querySelector<HTMLButtonElement>('.cinder-navigation-item');
+      button?.addEventListener('click', () => {
+        const key = button.dataset['key'];
+        if (key) clicks[key] = (clicks[key] ?? 0) + 1;
+      });
+    },
+  }));
+}
+
 describe('NavigationBar', () => {
   // ── Legacy tests (preserved) ────────────────────────────────────────────
 
@@ -782,6 +804,45 @@ describe('NavigationBar', () => {
 
       expect(clicks['docs']).toBe(1);
       expect(getItemsRegion(container).getAttribute('data-open')).toBe('false');
+    });
+  });
+
+  test('enabled item descendant click closes an open collapsed mobile menu', async () => {
+    await withResizeObserver(async () => {
+      const clicks: Record<string, number> = {};
+      const { container } = render(NavigationBar, {
+        items: iconNavigationSnippet(clicks),
+        menuToggle: toggleSnippet(),
+      });
+
+      await openCollapsedMobileMenu(container);
+
+      const icon = container.querySelector('[data-testid="home-icon"]') as SVGElement;
+      await fireEvent.click(icon);
+
+      expect(clicks['home']).toBe(1);
+      expect(getItemsRegion(container).getAttribute('data-open')).toBe('false');
+    });
+  });
+
+  test('consumer onclick can prevent the automatic collapsed mobile menu close', async () => {
+    await withResizeObserver(async () => {
+      const clicks: Record<string, number> = {};
+      const { container } = render(NavigationBar, {
+        items: keyboardNavigationSnippet(clicks),
+        menuToggle: toggleSnippet(),
+        onclick: (event: MouseEvent) => {
+          event.preventDefault();
+        },
+      } as any);
+
+      await openCollapsedMobileMenu(container);
+
+      const docs = container.querySelector('[data-key="docs"]') as HTMLElement;
+      await fireEvent.click(docs);
+
+      expect(clicks['docs']).toBe(1);
+      expect(getItemsRegion(container).getAttribute('data-open')).toBe('true');
     });
   });
 

--- a/packages/components/src/components/navigation-bar/navigation-bar.test.ts
+++ b/packages/components/src/components/navigation-bar/navigation-bar.test.ts
@@ -83,6 +83,13 @@ async function openCollapsedMobileMenu(container: HTMLElement): Promise<HTMLElem
   return nav;
 }
 
+async function setCollapsedMobileLayout(container: HTMLElement): Promise<void> {
+  await tick();
+  const nav = container.querySelector('nav') as HTMLElement;
+  emitNavigationBarResize(nav, 640);
+  await tick();
+}
+
 /** Creates a Svelte 5 Snippet that renders text content. */
 function textSnippet(text: string) {
   return createRawSnippet(() => ({
@@ -891,6 +898,27 @@ describe('NavigationBar', () => {
       });
 
       await openCollapsedMobileMenu(container);
+
+      const docs = container.querySelector('[data-key="docs"]') as HTMLElement;
+      docs.focus();
+      await fireEvent.keyDown(docs, { key: 'Enter' });
+
+      expect(clicks['docs']).toBe(1);
+      expect(getItemsRegion(container).getAttribute('data-open')).toBe('false');
+      expect(document.activeElement).toBe(container.querySelector('#toggle-btn'));
+    });
+  });
+
+  test('Enter activation returns focus to the toggle when the collapsed mobile menu starts open', async () => {
+    await withResizeObserver(async () => {
+      const clicks: Record<string, number> = {};
+      const { container } = render(NavigationBar, {
+        items: keyboardNavigationSnippet(clicks),
+        menuToggle: toggleSnippet(),
+        mobileMenuOpen: true,
+      });
+
+      await setCollapsedMobileLayout(container);
 
       const docs = container.querySelector('[data-key="docs"]') as HTMLElement;
       docs.focus();

--- a/packages/components/src/components/navigation-bar/navigation-bar.test.ts
+++ b/packages/components/src/components/navigation-bar/navigation-bar.test.ts
@@ -65,6 +65,24 @@ function emitNavigationBarResize(target: Element, width: number): void {
   CapturingResizeObserver.lastCallback?.([entry], CapturingResizeObserver.lastObserver!);
 }
 
+function getItemsRegion(container: HTMLElement): HTMLElement {
+  return container.querySelector('.cinder-navigation-bar__items') as HTMLElement;
+}
+
+async function openCollapsedMobileMenu(container: HTMLElement): Promise<HTMLElement> {
+  await tick();
+  const nav = container.querySelector('nav') as HTMLElement;
+  const toggle = container.querySelector('#toggle-btn') as HTMLElement;
+
+  emitNavigationBarResize(nav, 640);
+  await tick();
+
+  await fireEvent.click(toggle);
+  expect(getItemsRegion(container).getAttribute('data-open')).toBe('true');
+
+  return nav;
+}
+
 /** Creates a Svelte 5 Snippet that renders text content. */
 function textSnippet(text: string) {
   return createRawSnippet(() => ({
@@ -747,6 +765,83 @@ describe('NavigationBar', () => {
     await fireEvent.keyDown(docsLabel, { key: ' ' });
 
     expect(clicks['docs']).toBeUndefined();
+  });
+
+  test('enabled item click closes an open collapsed mobile menu', async () => {
+    await withResizeObserver(async () => {
+      const clicks: Record<string, number> = {};
+      const { container } = render(NavigationBar, {
+        items: keyboardNavigationSnippet(clicks),
+        menuToggle: toggleSnippet(),
+      });
+
+      await openCollapsedMobileMenu(container);
+
+      const docs = container.querySelector('[data-key="docs"]') as HTMLElement;
+      await fireEvent.click(docs);
+
+      expect(clicks['docs']).toBe(1);
+      expect(getItemsRegion(container).getAttribute('data-open')).toBe('false');
+    });
+  });
+
+  test('Enter activation closes an open collapsed mobile menu', async () => {
+    await withResizeObserver(async () => {
+      const clicks: Record<string, number> = {};
+      const { container } = render(NavigationBar, {
+        items: keyboardNavigationSnippet(clicks),
+        menuToggle: toggleSnippet(),
+      });
+
+      await openCollapsedMobileMenu(container);
+
+      const docs = container.querySelector('[data-key="docs"]') as HTMLElement;
+      docs.focus();
+      await fireEvent.keyDown(docs, { key: 'Enter' });
+
+      expect(clicks['docs']).toBe(1);
+      expect(getItemsRegion(container).getAttribute('data-open')).toBe('false');
+    });
+  });
+
+  test('Space activation closes an open collapsed mobile menu', async () => {
+    await withResizeObserver(async () => {
+      const clicks: Record<string, number> = {};
+      const { container } = render(NavigationBar, {
+        items: keyboardNavigationSnippet(clicks),
+        menuToggle: toggleSnippet(),
+      });
+
+      await openCollapsedMobileMenu(container);
+
+      const docs = container.querySelector('[data-key="docs"]') as HTMLElement;
+      docs.focus();
+      await fireEvent.keyDown(docs, { key: ' ' });
+
+      expect(clicks['docs']).toBe(1);
+      expect(getItemsRegion(container).getAttribute('data-open')).toBe('false');
+    });
+  });
+
+  test('disabled item activation leaves an open collapsed mobile menu open', async () => {
+    await withResizeObserver(async () => {
+      const clicks: Record<string, number> = {};
+      const { container } = render(NavigationBar, {
+        items: keyboardNavigationSnippet(clicks),
+        menuToggle: toggleSnippet(),
+      });
+
+      await openCollapsedMobileMenu(container);
+
+      const billing = container.querySelector('[data-key="billing"]') as HTMLElement;
+      await fireEvent.click(billing);
+      billing.focus();
+      await fireEvent.keyDown(billing, { key: 'Enter' });
+      await fireEvent.keyDown(billing, { key: ' ' });
+
+      expect(clicks['billing']).toBe(1);
+      expect(getItemsRegion(container).getAttribute('data-open')).toBe('true');
+    });
   });
 });
 

--- a/packages/components/src/components/navigation-bar/navigation-bar.test.ts
+++ b/packages/components/src/components/navigation-bar/navigation-bar.test.ts
@@ -862,6 +862,7 @@ describe('NavigationBar', () => {
 
       expect(clicks['docs']).toBe(1);
       expect(getItemsRegion(container).getAttribute('data-open')).toBe('false');
+      expect(document.activeElement).toBe(container.querySelector('#toggle-btn'));
     });
   });
 

--- a/packages/components/src/components/navigation-bar/navigation-bar.test.ts
+++ b/packages/components/src/components/navigation-bar/navigation-bar.test.ts
@@ -185,6 +185,24 @@ function iconNavigationSnippet(clicks: Record<string, number>) {
   }));
 }
 
+function cancelingNavigationSnippet(clicks: Record<string, number>) {
+  return createRawSnippet(() => ({
+    render: () => `
+      <button type="button" class="cinder-navigation-item" data-cinder-navigation-item data-key="docs">Docs</button>
+    `,
+    setup(element: Element) {
+      const button = element.matches('.cinder-navigation-item')
+        ? (element as HTMLButtonElement)
+        : element.querySelector<HTMLButtonElement>('.cinder-navigation-item');
+      button?.addEventListener('click', (event) => {
+        event.preventDefault();
+        const key = button.dataset['key'];
+        if (key) clicks[key] = (clicks[key] ?? 0) + 1;
+      });
+    },
+  }));
+}
+
 describe('NavigationBar', () => {
   // ── Legacy tests (preserved) ────────────────────────────────────────────
 
@@ -835,6 +853,24 @@ describe('NavigationBar', () => {
           event.preventDefault();
         },
       } as any);
+
+      await openCollapsedMobileMenu(container);
+
+      const docs = container.querySelector('[data-key="docs"]') as HTMLElement;
+      await fireEvent.click(docs);
+
+      expect(clicks['docs']).toBe(1);
+      expect(getItemsRegion(container).getAttribute('data-open')).toBe('true');
+    });
+  });
+
+  test('cancelled item click keeps an open collapsed mobile menu open', async () => {
+    await withResizeObserver(async () => {
+      const clicks: Record<string, number> = {};
+      const { container } = render(NavigationBar, {
+        items: cancelingNavigationSnippet(clicks),
+        menuToggle: toggleSnippet(),
+      });
 
       await openCollapsedMobileMenu(container);
 

--- a/packages/components/src/components/navigation-bar/navigation-bar.test.ts
+++ b/packages/components/src/components/navigation-bar/navigation-bar.test.ts
@@ -856,7 +856,9 @@ describe('NavigationBar', () => {
       const { container } = render(NavigationBar, {
         items: keyboardNavigationSnippet(clicks),
         menuToggle: toggleSnippet(),
-        onclick: (event: MouseEvent) => {
+        onclick: function (this: HTMLElement, event: MouseEvent) {
+          const nav = container.querySelector('nav') as HTMLElement;
+          expect(this).toBe(nav);
           event.preventDefault();
         },
       } as any);


### PR DESCRIPTION
## Summary

- Close an open collapsed top NavigationBar mobile menu after enabled item activation.
- Reuse the same close path for pointer/click and Enter/Space keyboard activation.
- Preserve Escape handling, disabled item behavior, and modified/new-tab link gestures.
- Add a patch changeset for `@lostgradient/cinder`.

Closes #673

## Validation

- `bun run --filter=@lostgradient/cinder test -- ./src/components/navigation-bar/navigation-bar.test.ts`
- `bun run --filter=@lostgradient/cinder components:check`
- `bun run --filter=@lostgradient/cinder validate:consumer`
- `bun run typecheck`
- pre-push scoped validation

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped UX/a11y behavior in NavigationBar with extensive tests; consumers relying on the menu staying open after item click may need bar/item preventDefault.
> 
> **Overview**
> Collapsed top **NavigationBar** mobile menus now **auto-close** when an enabled item is activated (pointer click on the item or a descendant, plus Enter/Space via the existing synthetic click path). **`mobileMenuOpen`** is set to `false` only in the collapsible mobile layout while the menu is open.
> 
> Closing moves **focus back to the menu toggle** before the items region hides (shared **`focusMenuToggle`** path with Escape), with a DOM fallback when the toggle was never clicked. **Bar-level `onclick`** runs first; **`event.preventDefault()`** on the bar or item keeps the menu open for guarded routing or local state.
> 
> Auto-close is skipped for **disabled** items, **modified clicks**, and links that **open a new tab** or **download**. Keyboard handling still requires **`event.target`** to be the navigation item for arrow/Enter/Space routing; clicks bubble from descendants for close behavior.
> 
> Docs (**README**, **a11y**) and a **patch changeset** for `@lostgradient/cinder` document the contract; tests cover close, preventDefault, focus return, and disabled items.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2e90124597a68a68fa34e532bcacfdc7229d698c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->