### PR TITLE
Fix Sidebar mobile SSR first paint

### DIFF
--- a/packages/components/src/components/sidebar/sidebar.css
+++ b/packages/components/src/components/sidebar/sidebar.css
@@ -40,6 +40,10 @@
       border-inline-end: none;
     }
 
+    .cinder-sidebar--desktop[data-cinder-ssr-mobile-fallback] {
+      display: none;
+    }
+
     .cinder-sidebar--desktop[data-cinder-collapsed] {
       display: none;
     }

--- a/packages/components/src/components/sidebar/sidebar.svelte
+++ b/packages/components/src/components/sidebar/sidebar.svelte
@@ -59,10 +59,11 @@
   // on Firefox and Safari.
   // Keep the fallback explicit for SSR-contract test environments that resolve
   // the client MediaQuery build while `window.matchMedia` is unavailable.
-  const mobile =
-    typeof window === 'undefined' || typeof window.matchMedia !== 'function'
-      ? { current: false }
-      : new MediaQuery('(max-width: 47.99rem)', false);
+  const hasMatchMedia = typeof window !== 'undefined' && typeof window.matchMedia === 'function';
+  const usesSsrResponsiveFallback = !hasMatchMedia;
+  const mobile = hasMatchMedia
+    ? new MediaQuery('(max-width: 47.99rem)', false)
+    : { current: false };
 
   const context: SidebarContextValue = {
     get collapsed() {
@@ -121,6 +122,7 @@
     class={classNames('cinder-sidebar', 'cinder-sidebar--desktop', className)}
     aria-label={validatedLabel}
     data-cinder-collapsed={collapsed ? '' : undefined}
+    data-cinder-ssr-mobile-fallback={usesSsrResponsiveFallback ? '' : undefined}
   >
     {@render sidebarContents(false)}
   </aside>

--- a/packages/components/src/components/sidebar/sidebar.test.ts
+++ b/packages/components/src/components/sidebar/sidebar.test.ts
@@ -3,11 +3,13 @@ import { afterEach, describe, expect, test } from 'bun:test';
 import { createRawSnippet } from 'svelte';
 
 import { setupHappyDom } from '../../test/happy-dom.ts';
+import { renderToServerHtml } from '../../test/server-render.ts';
 
 setupHappyDom();
 
 const { render } = await import('@testing-library/svelte');
 const { default: Sidebar } = await import('./sidebar.svelte');
+const SIDEBAR_SOURCE = new URL('./sidebar.svelte', import.meta.url).pathname;
 
 function textSnippet(text: string) {
   return createRawSnippet(() => ({
@@ -198,10 +200,14 @@ describe('Sidebar (desktop / inline aside)', () => {
 });
 
 describe('Sidebar SSR responsive fallback', () => {
-  test('falls back to the desktop aside without matchMedia', () => {
+  test('marks the no-matchMedia desktop aside as a mobile first-paint fallback', () => {
     const hadMatchMedia = 'matchMedia' in window;
     const originalMatchMedia = window.matchMedia;
-    delete (window as { matchMedia?: typeof window.matchMedia }).matchMedia;
+    Object.defineProperty(window, 'matchMedia', {
+      value: undefined,
+      configurable: true,
+      writable: true,
+    });
     try {
       const { container } = render(Sidebar, {
         props: { id: 'workspace-sidebar', label: 'Workspace', navigation: listSnippet('items') },
@@ -210,22 +216,39 @@ describe('Sidebar SSR responsive fallback', () => {
       expect(asides).toHaveLength(1);
       expect(asides[0]?.id).toBe('workspace-sidebar');
       expect(asides[0]?.classList.contains('cinder-sidebar--desktop')).toBe(true);
-      expect(container.querySelector('.cinder-sidebar--ssr-mobile')).toBeNull();
+      expect(asides[0]?.hasAttribute('data-cinder-ssr-mobile-fallback')).toBe(true);
     } finally {
       if (hadMatchMedia) {
-        window.matchMedia = originalMatchMedia;
+        Object.defineProperty(window, 'matchMedia', {
+          value: originalMatchMedia,
+          configurable: true,
+          writable: true,
+        });
       } else {
         delete (window as { matchMedia?: typeof window.matchMedia }).matchMedia;
       }
     }
   });
 
-  test('component CSS hides the desktop fallback on mobile first paint', async () => {
+  test('server output marks the desktop aside for mobile first-paint hiding', async () => {
+    const html = await renderToServerHtml(SIDEBAR_SOURCE, {
+      id: 'workspace-sidebar',
+      label: 'Workspace',
+    });
+
+    expect(html).toContain('id="workspace-sidebar"');
+    expect(html).toContain('class="cinder-sidebar cinder-sidebar--desktop"');
+    expect(html).toContain('data-cinder-ssr-mobile-fallback');
+  });
+
+  test('component CSS hides only the SSR fallback on mobile first paint', async () => {
     const css = await Bun.file(new URL('./sidebar.css', import.meta.url)).text();
     expect(css).toMatch(
-      /@media\s*\(\s*max-width:\s*47\.99rem\s*\)[\s\S]*?\.cinder-sidebar--desktop\s*{[\s\S]*?display:\s*flex;[\s\S]*?inline-size:\s*100%;[\s\S]*?block-size:\s*100%;[\s\S]*?background:\s*transparent;[\s\S]*?border-inline-end:\s*none;[\s\S]*?\.cinder-sidebar--desktop\[data-cinder-collapsed\]\s*{\s*display:\s*none;\s*}/,
+      /@media\s*\(\s*max-width:\s*47\.99rem\s*\)[\s\S]*?\.cinder-sidebar--desktop\[data-cinder-ssr-mobile-fallback\]\s*{\s*display:\s*none;\s*}/,
     );
-    expect(css).not.toContain('.cinder-sidebar--ssr-mobile');
+    expect(css).toMatch(
+      /\.cinder-sidebar--desktop\[data-cinder-collapsed\]\s*{\s*display:\s*none;\s*}/,
+    );
   });
 });
 

--- a/packages/components/src/components/sidebar/sidebar.test.ts
+++ b/packages/components/src/components/sidebar/sidebar.test.ts
@@ -237,7 +237,9 @@ describe('Sidebar SSR responsive fallback', () => {
     });
 
     expect(html).toContain('id="workspace-sidebar"');
-    expect(html).toContain('class="cinder-sidebar cinder-sidebar--desktop"');
+    expect(html).toMatch(
+      /\bclass="(?=[^"]*\bcinder-sidebar\b)(?=[^"]*\bcinder-sidebar--desktop\b)[^"]*"/,
+    );
     expect(html).toContain('data-cinder-ssr-mobile-fallback');
   });
 


### PR DESCRIPTION
## Summary
- mark Sidebar's no-matchMedia SSR desktop fallback with `data-cinder-ssr-mobile-fallback`
- hide only that SSR fallback under the mobile breakpoint so narrow first paint does not flash desktop chrome
- add Sidebar SSR/mobile fallback coverage for server output and component CSS

Closes #674

## Validation
- `bun run --filter=@lostgradient/cinder test -- ./src/components/sidebar/sidebar.test.ts`
- `bun run --filter=@lostgradient/cinder components:check`
- `bun run --filter=@lostgradient/cinder typecheck`
- `bun run lint`
- `bunx prettier --check packages/components/src/components/sidebar/sidebar.svelte packages/components/src/components/sidebar/sidebar.css packages/components/src/components/sidebar/sidebar.test.ts`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped responsive/SSR presentation fix in Sidebar with targeted CSS and tests; no auth, data, or API changes.
> 
> **Overview**
> Fixes a **mobile first-paint flash** when Sidebar is server-rendered without `matchMedia`: the SSR path still outputs the desktop `<aside>`, which could show desktop chrome on narrow viewports until hydration switches to the drawer.
> 
> The desktop fallback is now tagged with **`data-cinder-ssr-mobile-fallback`** when responsive detection uses the no-`matchMedia` path (`usesSsrResponsiveFallback`). Mobile CSS **`display: none`** applies only to `.cinder-sidebar--desktop[data-cinder-ssr-mobile-fallback]`, so real client-side desktop sidebars are not hidden at the breakpoint—only the SSR placeholder.
> 
> Tests cover the data attribute (client mock + **`renderToServerHtml`**), and CSS assertions lock the new selector separately from **`data-cinder-collapsed`** hiding.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fe99c47c9d1507b1a512eef60274dd96701106cb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->