### PR TITLE
Document MarkdownEditor peer dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,19 @@ bun add @lostgradient/cinder svelte lucide-svelte
 It uses Lucide for its own component chrome, but it does not provide a general icon library for
 your application-specific icons.
 
+Rich editor, markdown rendering, editor/commentary re-exports, and syntax-highlighting surfaces
+use optional peer dependencies. Install them only when your app imports
+`@lostgradient/cinder/markdown-editor`, `@lostgradient/cinder/review-editor`,
+`@lostgradient/cinder/chat` with the default composer, `@lostgradient/cinder/markdown`,
+`@lostgradient/cinder/markdown/*`, `@lostgradient/cinder/editor`,
+`@lostgradient/cinder/editor/*`, `@lostgradient/cinder/commentary`,
+`@lostgradient/cinder/commentary/*`, `@lostgradient/cinder/highlighters/shiki`, or relies on
+`Chat` built-in markdown/tool message rendering or `CodeBlock` automatic highlighting:
+
+```bash
+bun add @milkdown/ctx @milkdown/kit @milkdown/prose @shikijs/engine-oniguruma @shikijs/langs @shikijs/rehype @shikijs/types @types/hast @types/mdast @types/unist comlink hast-util-sanitize js-yaml prosemirror-inputrules prosemirror-model prosemirror-state prosemirror-view rehype-katex rehype-sanitize rehype-stringify remark-gfm remark-html remark-math remark-parse remark-rehype remark-stringify shiki unified unist-util-remove unist-util-visit
+```
+
 ## Quickstart
 
 Load the base stylesheet once at your app entry, before any component stylesheet:

--- a/packages/components/README.md
+++ b/packages/components/README.md
@@ -18,6 +18,11 @@ Rich editor, markdown rendering, editor/commentary re-exports, and syntax-highli
 bun add @milkdown/ctx @milkdown/kit @milkdown/prose @shikijs/engine-oniguruma @shikijs/langs @shikijs/rehype @shikijs/types @types/hast @types/mdast @types/unist comlink hast-util-sanitize js-yaml prosemirror-inputrules prosemirror-model prosemirror-state prosemirror-view rehype-katex rehype-sanitize rehype-stringify remark-gfm remark-html remark-math remark-parse remark-rehype remark-stringify shiki unified unist-util-remove unist-util-visit
 ```
 
+`@lostgradient/cinder/markdown-editor` needs the editor and Markdown pipeline subset from that
+list at build time. If `prosemirror-state`, `prosemirror-view`, `@milkdown/kit`, or another editor
+peer is missing, Vite may report the failure through its optional-peer placeholder module instead
+of naming this install step.
+
 ## Quickstart
 
 Load the base stylesheet once at your app entry:

--- a/packages/components/fixtures/sveltekit-consumer/src/routes/dev-ssr/+page.svelte
+++ b/packages/components/fixtures/sveltekit-consumer/src/routes/dev-ssr/+page.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
-  import { SideNavigation, SideNavigationItem, Sidebar } from '@lostgradient/cinder';
   import Card from '@lostgradient/cinder/card';
+  import SideNavigation from '@lostgradient/cinder/side-navigation';
+  import SideNavigationItem from '@lostgradient/cinder/side-navigation-item';
+  import Sidebar from '@lostgradient/cinder/sidebar';
   import Tab from '@lostgradient/cinder/tab';
   import TabList from '@lostgradient/cinder/tab-list';
   import TabPanel from '@lostgradient/cinder/tab-panel';

--- a/packages/components/fixtures/sveltekit-consumer/vite.config.ts
+++ b/packages/components/fixtures/sveltekit-consumer/vite.config.ts
@@ -2,5 +2,9 @@ import { sveltekit } from '@sveltejs/kit/vite';
 import { defineConfig } from 'vite';
 
 export default defineConfig({
+  optimizeDeps: {
+    holdUntilCrawlEnd: false,
+    noDiscovery: true,
+  },
   plugins: [sveltekit()],
 });

--- a/packages/components/scripts/consumer-readiness.test.ts
+++ b/packages/components/scripts/consumer-readiness.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, test } from 'bun:test';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { waitForReadyHtml, type ReadinessFetch } from './consumer-readiness.ts';
+
+const scriptDirectory = dirname(fileURLToPath(import.meta.url));
+const svelteKitDevSsrFixturePath = join(
+  scriptDirectory,
+  '../fixtures/sveltekit-consumer/src/routes/dev-ssr/+page.svelte',
+);
+
+function response(html: string, status = 200): Response {
+  return new Response(html, { status });
+}
+
+describe('waitForReadyHtml', () => {
+  test('waits for the target route HTML predicate instead of first HTTP 200', async () => {
+    const responses = [
+      response('<main>loading shell</main>'),
+      response('<main data-ready>ready</main>'),
+    ];
+    const fetcher: ReadinessFetch = async () => responses.shift() ?? response('unexpected');
+
+    const html = await waitForReadyHtml({
+      url: 'http://127.0.0.1:5173/dev-ssr',
+      timeoutMs: 1_000,
+      pollIntervalMs: 0,
+      runningServer: { exitCode: null },
+      fetcher,
+      isReady: (body) => body.includes('data-ready'),
+    });
+
+    expect(html).toContain('data-ready');
+  });
+
+  test('lets the first SSR request use the remaining readiness budget', async () => {
+    const observedTimeouts: number[] = [];
+    const fetcher: ReadinessFetch = async (_url, timeoutMs) => {
+      observedTimeouts.push(timeoutMs);
+      return response('<main data-ready>ready</main>');
+    };
+
+    await waitForReadyHtml({
+      url: 'http://127.0.0.1:5173/dev-ssr',
+      timeoutMs: 1_000,
+      pollIntervalMs: 0,
+      runningServer: { exitCode: null },
+      fetcher,
+      isReady: (body) => body.includes('data-ready'),
+    });
+
+    expect(observedTimeouts).toHaveLength(1);
+    expect(observedTimeouts[0]).toBeGreaterThan(900);
+  });
+
+  test('fails immediately when the server exits before the target route is ready', async () => {
+    await expect(
+      waitForReadyHtml({
+        url: 'http://127.0.0.1:5173/dev-ssr',
+        timeoutMs: 1_000,
+        pollIntervalMs: 0,
+        runningServer: { exitCode: 1 },
+        fetcher: async () => response('<main data-ready>ready</main>'),
+        isReady: (body) => body.includes('data-ready'),
+      }),
+    ).rejects.toThrow('server exited with code 1');
+  });
+
+  test('keeps the dev SSR fixture off the package root barrel', async () => {
+    const source = await Bun.file(svelteKitDevSsrFixturePath).text();
+
+    expect(source).not.toContain("from '@lostgradient/cinder'");
+    expect(source).not.toContain('from "@lostgradient/cinder"');
+  });
+});

--- a/packages/components/scripts/consumer-readiness.ts
+++ b/packages/components/scripts/consumer-readiness.ts
@@ -1,0 +1,58 @@
+export type RunningServerStatus = {
+  exitCode: number | null;
+};
+
+export type ReadinessFetch = (url: string, timeoutMs: number) => Promise<Response>;
+
+type WaitForReadyHtmlInput = {
+  url: string;
+  timeoutMs: number;
+  pollIntervalMs: number;
+  runningServer: RunningServerStatus;
+  isReady: (html: string) => boolean;
+  fetcher?: ReadinessFetch;
+};
+
+async function defaultFetch(url: string, timeoutMs: number): Promise<Response> {
+  return await fetch(url, { signal: AbortSignal.timeout(timeoutMs) });
+}
+
+export async function waitForReadyHtml(input: WaitForReadyHtmlInput): Promise<string> {
+  const fetcher = input.fetcher ?? defaultFetch;
+  const startTime = Date.now();
+  let lastStatus: number | null = null;
+  let lastError: string | null = null;
+
+  while (Date.now() - startTime < input.timeoutMs) {
+    if (input.runningServer.exitCode !== null) {
+      throw new Error(
+        `server exited with code ${input.runningServer.exitCode} before becoming ready at ${input.url}`,
+      );
+    }
+
+    const elapsedMs = Date.now() - startTime;
+    const remainingTimeoutMs = input.timeoutMs - elapsedMs;
+    if (remainingTimeoutMs <= 0) break;
+
+    try {
+      const response = await fetcher(input.url, remainingTimeoutMs);
+      lastStatus = response.status;
+      if (response.status === 200) {
+        const html = await response.text();
+        if (input.isReady(html)) return html;
+      }
+    } catch (error) {
+      lastError = error instanceof Error ? error.message : String(error);
+    }
+
+    await Bun.sleep(input.pollIntervalMs);
+  }
+
+  const details =
+    lastStatus !== null
+      ? `last HTTP status ${lastStatus}`
+      : lastError !== null
+        ? `last error: ${lastError}`
+        : 'no response received';
+  throw new Error(`timeout waiting for ready HTML at ${input.url} (${details})`);
+}

--- a/packages/components/scripts/generate-component-artifacts.ts
+++ b/packages/components/scripts/generate-component-artifacts.ts
@@ -20,7 +20,7 @@
  */
 
 import { existsSync } from 'node:fs';
-import { join } from 'node:path';
+import { dirname, join } from 'node:path';
 
 import * as prettier from 'prettier';
 
@@ -38,6 +38,7 @@ import { generateSchemaForComponent } from './generate-component-schema.ts';
 import { generateVariablesForComponent } from './generate-component-variables.ts';
 import { buildManifest, writeManifest } from './generate-manifest.ts';
 import { renderComponentReadme } from './render-component-readme.ts';
+import { mapWithConcurrencyLimit } from './validation-utilities.ts';
 
 export { discoverComponentDirectories, type DiscoveredComponent };
 
@@ -65,6 +66,9 @@ const COMPOSE_ONLY_ACCESSIBILITY_DOCUMENTATION_EXEMPTIONS = new Set([
   'tree-item',
 ]);
 
+const COMPONENT_ARTIFACT_CHECK_CONCURRENCY = 12;
+const prettierConfigurationCache = new Map<string, Promise<prettier.Options | null>>();
+
 /**
  * Run prettier over the generated content using the repo's prettier config.
  * Without this, lint-staged's prettier --write pass reformats our generated
@@ -74,7 +78,13 @@ const COMPOSE_ONLY_ACCESSIBILITY_DOCUMENTATION_EXEMPTIONS = new Set([
  */
 async function formatGenerated(content: string, filepath: string): Promise<string> {
   try {
-    const options = await prettier.resolveConfig(filepath);
+    const configurationDirectory = dirname(filepath);
+    let optionsPromise = prettierConfigurationCache.get(configurationDirectory);
+    if (!optionsPromise) {
+      optionsPromise = prettier.resolveConfig(filepath);
+      prettierConfigurationCache.set(configurationDirectory, optionsPromise);
+    }
+    const options = await optionsPromise;
     return await prettier.format(content, { ...options, filepath });
   } catch {
     return content;
@@ -156,60 +166,66 @@ export interface DriftIssue {
 }
 
 export async function checkComponentArtifacts(): Promise<DriftIssue[]> {
-  const issues: DriftIssue[] = [];
   const components = await discoverComponentDirectories();
 
-  for (const component of components) {
-    const artifacts = await generateArtifactsForComponent(component);
-    const files: Array<{ filename: string; expected: string | null }> = [
-      { filename: `${component.name}.schema.json`, expected: artifacts.schemaJson },
-      { filename: `${component.name}.schema.ts`, expected: artifacts.schemaModule },
-      { filename: `${component.name}.variables.json`, expected: artifacts.variablesJson },
-      { filename: `${component.name}.variables.ts`, expected: artifacts.variablesModule },
-      { filename: 'README.md', expected: artifacts.readme },
-    ];
+  const issueGroups = await mapWithConcurrencyLimit(
+    components,
+    COMPONENT_ARTIFACT_CHECK_CONCURRENCY,
+    async (component) => {
+      const issues: DriftIssue[] = [];
+      const artifacts = await generateArtifactsForComponent(component);
+      const files: Array<{ filename: string; expected: string | null }> = [
+        { filename: `${component.name}.schema.json`, expected: artifacts.schemaJson },
+        { filename: `${component.name}.schema.ts`, expected: artifacts.schemaModule },
+        { filename: `${component.name}.variables.json`, expected: artifacts.variablesJson },
+        { filename: `${component.name}.variables.ts`, expected: artifacts.variablesModule },
+        { filename: 'README.md', expected: artifacts.readme },
+      ];
 
-    // Every discovered component MUST ship a README.md. The artifact generator
-    // only UPDATES an existing README (it never creates one from scratch), so a
-    // brand-new component otherwise leaves `artifacts.readme === null` and slips
-    // through the `expected === null` skip below — but the playground
-    // documentation route hard-requires the file and 500s without it, failing
-    // the deploy. Flag the absence explicitly so a missing README is a loud
-    // drift failure here rather than a red deploy later. (Seed a skeleton with
-    // `create-component` / `migrate-component`, then re-run `components:generate`
-    // to fill the generated regions.)
-    if (!existsSync(join(component.directory, 'README.md'))) {
-      issues.push({ component: component.name, file: 'README.md', reason: 'missing' });
-    }
-    if (
-      !COMPOSE_ONLY_ACCESSIBILITY_DOCUMENTATION_EXEMPTIONS.has(component.name) &&
-      !existsSync(join(component.directory, `${component.name}.a11y.md`))
-    ) {
-      issues.push({
-        component: component.name,
-        file: `${component.name}.a11y.md`,
-        reason: 'missing',
-      });
-    }
-
-    for (const { filename, expected } of files) {
-      // A null `expected` means the generator produced no content for this
-      // artifact — legitimate for metadata-only schema/variables (type-only
-      // components) and for a not-yet-seeded README (handled explicitly above).
-      if (expected === null) continue;
-      const path = join(component.directory, filename);
-      if (!existsSync(path)) {
-        issues.push({ component: component.name, file: filename, reason: 'missing' });
-        continue;
+      // Every discovered component MUST ship a README.md. The artifact generator
+      // only UPDATES an existing README (it never creates one from scratch), so a
+      // brand-new component otherwise leaves `artifacts.readme === null` and slips
+      // through the `expected === null` skip below — but the playground
+      // documentation route hard-requires the file and 500s without it, failing
+      // the deploy. Flag the absence explicitly so a missing README is a loud
+      // drift failure here rather than a red deploy later. (Seed a skeleton with
+      // `create-component` / `migrate-component`, then re-run `components:generate`
+      // to fill the generated regions.)
+      if (!existsSync(join(component.directory, 'README.md'))) {
+        issues.push({ component: component.name, file: 'README.md', reason: 'missing' });
       }
-      const actual = await Bun.file(path).text();
-      if (actual !== expected) {
-        issues.push({ component: component.name, file: filename, reason: 'stale' });
+      if (
+        !COMPOSE_ONLY_ACCESSIBILITY_DOCUMENTATION_EXEMPTIONS.has(component.name) &&
+        !existsSync(join(component.directory, `${component.name}.a11y.md`))
+      ) {
+        issues.push({
+          component: component.name,
+          file: `${component.name}.a11y.md`,
+          reason: 'missing',
+        });
       }
-    }
-  }
 
-  return issues;
+      for (const { filename, expected } of files) {
+        // A null `expected` means the generator produced no content for this
+        // artifact — legitimate for metadata-only schema/variables (type-only
+        // components) and for a not-yet-seeded README (handled explicitly above).
+        if (expected === null) continue;
+        const path = join(component.directory, filename);
+        if (!existsSync(path)) {
+          issues.push({ component: component.name, file: filename, reason: 'missing' });
+          continue;
+        }
+        const actual = await Bun.file(path).text();
+        if (actual !== expected) {
+          issues.push({ component: component.name, file: filename, reason: 'stale' });
+        }
+      }
+
+      return issues;
+    },
+  );
+
+  return issueGroups.flat();
 }
 
 async function main(): Promise<void> {

--- a/packages/components/scripts/server-component-identity.test.ts
+++ b/packages/components/scripts/server-component-identity.test.ts
@@ -10,6 +10,7 @@ import { findOneArgumentServerComponentBoundaries } from './svelte-plugin.ts';
 const scriptDirectory = dirname(fileURLToPath(import.meta.url));
 const packageRoot = resolve(scriptDirectory, '..');
 const serverDistributionRoot = join(packageRoot, 'dist/server');
+const SERVER_COMPONENT_IDENTITY_SCAN_BATCH_SIZE = 64;
 
 describe.skipIf(!existsSync(serverDistributionRoot))(
   'server component boundaries preserve component identity',
@@ -17,14 +18,28 @@ describe.skipIf(!existsSync(serverDistributionRoot))(
     it('contains no one-argument renderer.component boundaries in dist/server', async () => {
       const offenders: string[] = [];
       const glob = new Glob('**/*.js');
+      const relativePaths = await Array.fromAsync(glob.scan({ cwd: serverDistributionRoot }));
 
-      for await (const relativePath of glob.scan({ cwd: serverDistributionRoot })) {
-        const filePath = join(serverDistributionRoot, relativePath);
-        const source = await Bun.file(filePath).text();
-        const boundaries = findOneArgumentServerComponentBoundaries(source, filePath);
-        for (const boundary of boundaries) {
-          offenders.push(`${relativePath}:${boundary.line}:${boundary.column}`);
-        }
+      for (
+        let startIndex = 0;
+        startIndex < relativePaths.length;
+        startIndex += SERVER_COMPONENT_IDENTITY_SCAN_BATCH_SIZE
+      ) {
+        const batch = relativePaths.slice(
+          startIndex,
+          startIndex + SERVER_COMPONENT_IDENTITY_SCAN_BATCH_SIZE,
+        );
+        const batchOffenders = await Promise.all(
+          batch.map(async (relativePath) => {
+            const filePath = join(serverDistributionRoot, relativePath);
+            const source = await Bun.file(filePath).text();
+            const boundaries = findOneArgumentServerComponentBoundaries(source, filePath);
+            return boundaries.map(
+              (boundary) => `${relativePath}:${boundary.line}:${boundary.column}`,
+            );
+          }),
+        );
+        offenders.push(...batchOffenders.flat());
       }
 
       expect(offenders).toEqual([]);

--- a/packages/components/scripts/validate-consumers.ts
+++ b/packages/components/scripts/validate-consumers.ts
@@ -15,6 +15,7 @@ import { fileURLToPath } from 'node:url';
 
 import { parse } from 'postcss';
 
+import { waitForReadyHtml } from './consumer-readiness.ts';
 import { type CommentScanState, lineHasCinderResidue } from './lib/cinder-specifier-residue.ts';
 import { deriveUpstreamReexports } from './lib/derive-upstream-reexports.ts';
 import { discoverComponents } from './lib/discover-components.ts';
@@ -1033,6 +1034,9 @@ const SVELTEKIT_DEV_SSR_MARKERS = [
   'data-dev-ssr-tabs-direct-panel',
 ];
 
+const SVELTEKIT_DEV_SSR_READINESS_TIMEOUT_MS = 25_000;
+const SVELTEKIT_DEV_SSR_POLL_INTERVAL_MS = 200;
+
 function formatHtmlExcerpt(body: string): string {
   return body.replace(/\s+/g, ' ').trim().slice(0, 1_000);
 }
@@ -1073,19 +1077,17 @@ async function assertSvelteKitDevSsrRoute(fixtureDirectory: string, label: strin
     : Promise.resolve('');
 
   try {
-    await waitForUrl(`http://127.0.0.1:${httpPort}/`, 15_000, devServer);
     const routeUrl = `http://127.0.0.1:${httpPort}/dev-ssr`;
-    const response = await fetchWithTimeout(
-      routeUrl,
-      10_000,
-      `sveltekit-consumer ${label} /dev-ssr dev SSR`,
-    );
-    const body = await response.text();
-    if (response.status !== 200) {
-      fail(
-        `sveltekit-consumer ${label} /dev-ssr dev SSR returned ${response.status}, want 200:\n${formatHtmlExcerpt(body)}`,
-      );
-    }
+    const body = await waitForReadyHtml({
+      url: routeUrl,
+      timeoutMs: SVELTEKIT_DEV_SSR_READINESS_TIMEOUT_MS,
+      pollIntervalMs: SVELTEKIT_DEV_SSR_POLL_INTERVAL_MS,
+      runningServer: devServer,
+      isReady: (html) => SVELTEKIT_DEV_SSR_MARKERS.every((marker) => html.includes(marker)),
+    }).catch((error) => {
+      const message = error instanceof Error ? error.message : String(error);
+      fail(`sveltekit-consumer ${label} /dev-ssr dev SSR readiness failed: ${message}`);
+    });
 
     const missingMarkers = SVELTEKIT_DEV_SSR_MARKERS.filter((marker) => !body.includes(marker));
     if (missingMarkers.length > 0) {

--- a/packages/components/src/components/markdown-editor/README.md
+++ b/packages/components/src/components/markdown-editor/README.md
@@ -10,6 +10,25 @@ Rich Markdown editing surface bundling a Milkdown-powered ProseMirror editor, to
 </script>
 ```
 
+## Peer Dependencies
+
+MarkdownEditor keeps its Milkdown, ProseMirror, and Markdown pipeline stack as optional peer
+dependencies so a base Cinder install does not pull the rich editor graph into apps that never
+import it.
+
+Install the rich editor peer set before importing `@lostgradient/cinder/markdown-editor` in a
+fresh consumer:
+
+```bash
+bun add @milkdown/ctx @milkdown/kit @milkdown/prose @types/mdast @types/unist js-yaml prosemirror-inputrules prosemirror-model prosemirror-state prosemirror-view remark-gfm remark-parse remark-stringify unified unist-util-visit
+```
+
+`@lostgradient/cinder/review-editor` and `@lostgradient/cinder/chat` with the default composer also
+use this editor stack. If a peer is missing, Vite can surface the failure as an
+`__vite-optional-peer-dep:*` export error, such as a missing `PluginKey` export from
+`prosemirror-state`; install the peer set above instead of debugging the generated placeholder
+module.
+
 ## Guidance
 
 ### Use When

--- a/packages/components/src/components/markdown-editor/markdown-editor.import-boundary.test.ts
+++ b/packages/components/src/components/markdown-editor/markdown-editor.import-boundary.test.ts
@@ -155,10 +155,16 @@ function collectViolations(statements: AstNode[]): {
 // Load and parse the MarkdownEditor source
 // ---------------------------------------------------------------------------
 const SOURCE_PATH = new URL('./markdown-editor.svelte', import.meta.url).pathname;
+const README_PATH = new URL('./README.md', import.meta.url).pathname;
 const source = await Bun.file(SOURCE_PATH)
   .text()
   .catch(() => {
     throw new Error(`[import-boundary] Cannot read ${SOURCE_PATH} — failing hard per plan`);
+  });
+const readme = await Bun.file(README_PATH)
+  .text()
+  .catch(() => {
+    throw new Error(`[import-boundary] Cannot read ${README_PATH} — failing hard per plan`);
   });
 
 const svelteAst = parse(source, { filename: SOURCE_PATH }) as unknown as AstNode;
@@ -189,6 +195,15 @@ describe('MarkdownEditor import-boundary invariant', () => {
 
   it('has no non-literal dynamic import specifiers in the script', () => {
     expect(nonLiteralDynamicViolations).toEqual([]);
+  });
+});
+
+describe('MarkdownEditor peer dependency documentation', () => {
+  it('documents the optional editor peer install path for fresh consumers', () => {
+    expect(readme).toContain('@lostgradient/cinder/markdown-editor');
+    expect(readme).toContain('bun add @milkdown/ctx @milkdown/kit @milkdown/prose');
+    expect(readme).toContain('prosemirror-state');
+    expect(readme).toContain('__vite-optional-peer-dep:*');
   });
 });
 


### PR DESCRIPTION
## Summary
- document the optional Milkdown, ProseMirror, Markdown, and syntax-highlighting peer set required by MarkdownEditor consumers
- add MarkdownEditor documentation regression coverage so the guidance stays discoverable
- fix the consumer validation readiness check to wait for the `/dev-ssr` marker HTML instead of treating the Vite listener as first-SSR readiness
- reduce the cold SvelteKit dev-SSR fixture path and speed up artifact checks exposed while validating this issue

## Validation
- `bun run --filter=@lostgradient/cinder test -- ./scripts/consumer-readiness.test.ts ./scripts/server-component-identity.test.ts ./src/components/markdown-editor/markdown-editor.import-boundary.test.ts`
- `bun run --filter=@lostgradient/cinder components:check`
- `bun run --filter=@lostgradient/cinder validate:consumer`
- pre-push scoped validation passed

Closes #672

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are mostly documentation and test/validation harness improvements; runtime library behavior is unchanged aside from fixture import paths and dev-server polling logic.
> 
> **Overview**
> Documents the **optional** Milkdown/ProseMirror/Markdown/Shiki peer install path in the root and package READMEs, adds a **Peer Dependencies** section on `MarkdownEditor` (subset `bun add`, Vite `__vite-optional-peer-dep` troubleshooting), and locks that guidance in with an import-boundary test on the component README.
> 
> **Consumer validation** no longer treats “Vite is listening” as SSR-ready: new `waitForReadyHtml` polls `/dev-ssr` until all `data-dev-ssr-*` markers appear, with unit tests and wiring in `validate-consumers`. The SvelteKit dev-SSR fixture drops the root barrel in favor of subpath imports (plus a test enforcing that), and Vite `optimizeDeps` is tuned (`noDiscovery`, `holdUntilCrawlEnd: false`) to speed the cold dev path.
> 
> **CI/tooling speedups:** component artifact drift checks run with limited concurrency and cached Prettier config; the server component-identity scan reads `dist/server` in parallel batches.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 365de8aa0b40eda4a6478323fbfd0feccb86a430. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->