### PR TITLE
Split component artifact CLI imports

### DIFF
--- a/packages/components/scripts/component-artifact-import-boundary.test.ts
+++ b/packages/components/scripts/component-artifact-import-boundary.test.ts
@@ -1,0 +1,29 @@
+import { join } from 'node:path';
+
+import { describe, expect, it } from 'bun:test';
+
+const scriptsDirectory = import.meta.dir;
+
+async function readScript(filename: string): Promise<string> {
+  return await Bun.file(join(scriptsDirectory, filename)).text();
+}
+
+describe('component artifact import boundaries', () => {
+  it('keeps discovery independent from artifact orchestration modules', async () => {
+    const source = await readScript('discover-component-directories.ts');
+
+    expect(source).not.toContain('./generate-component-artifacts.ts');
+    expect(source).not.toContain('./component-artifact-operations.ts');
+    expect(source).not.toContain('./generate-component-schema.ts');
+    expect(source).not.toContain('./generate-component-variables.ts');
+    expect(source).not.toContain('./generate-component-examples.ts');
+    expect(source).not.toContain('./generate-manifest.ts');
+  });
+
+  it('does not re-export lightweight discovery from the heavy CLI entrypoint', async () => {
+    const source = await readScript('generate-component-artifacts.ts');
+
+    expect(source).not.toMatch(/export\s+\{[^}]*discoverComponentDirectories/s);
+    expect(source).not.toMatch(/export\s+async\s+function\s+checkComponentArtifacts/);
+  });
+});

--- a/packages/components/scripts/component-artifact-import-boundary.test.ts
+++ b/packages/components/scripts/component-artifact-import-boundary.test.ts
@@ -23,7 +23,11 @@ describe('component artifact import boundaries', () => {
   it('does not re-export lightweight discovery from the heavy CLI entrypoint', async () => {
     const source = await readScript('generate-component-artifacts.ts');
 
-    expect(source).not.toMatch(/export\s+\{[^}]*discoverComponentDirectories/s);
-    expect(source).not.toMatch(/export\s+async\s+function\s+checkComponentArtifacts/);
+    expect(source).not.toMatch(
+      /export\s+(?:\*\s+from\s+['"].*discover-component-directories|(?:type\s+)?\{[^}]*discoverComponentDirectories)/s,
+    );
+    expect(source).not.toMatch(
+      /export\s+(?:\*\s+from\s+['"].*component-artifact-operations|(?:async\s+function|(?:type\s+)?\{[^}]*checkComponentArtifacts))/s,
+    );
   });
 });

--- a/packages/components/scripts/component-artifact-operations.ts
+++ b/packages/components/scripts/component-artifact-operations.ts
@@ -1,0 +1,189 @@
+/**
+ * Reusable component artifact operations for schema, variables, and README files.
+ *
+ * Keep lightweight discovery imports pointed at `discover-component-directories.ts`.
+ * This module intentionally imports the heavier schema, variable, README, and
+ * formatter dependencies needed to generate or check per-component artifacts,
+ * while the CLI entrypoint in `generate-component-artifacts.ts` stays thin.
+ */
+
+import { existsSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+
+import * as prettier from 'prettier';
+
+import {
+  discoverComponentDirectories,
+  type DiscoveredComponent,
+} from './discover-component-directories.ts';
+import { generateSchemaForComponent } from './generate-component-schema.ts';
+import { generateVariablesForComponent } from './generate-component-variables.ts';
+import { renderComponentReadme } from './render-component-readme.ts';
+import { mapWithConcurrencyLimit } from './validation-utilities.ts';
+
+const COMPOSE_ONLY_ACCESSIBILITY_DOCUMENTATION_EXEMPTIONS = new Set([
+  'accordion-item',
+  'dropdown-group',
+  'dropdown-item',
+  'dropdown-label',
+  'dropdown-menu',
+  'dropdown-separator',
+  'dropdown-trigger',
+  'feed-event',
+  'grid-list-item',
+  'side-navigation-group',
+  'side-navigation-item',
+  'stat',
+  'tab',
+  'tab-list',
+  'tab-panel',
+  'table-body',
+  'table-cell',
+  'table-header',
+  'table-header-cell',
+  'table-row',
+  'tree-item',
+]);
+
+const COMPONENT_ARTIFACT_CHECK_CONCURRENCY = 12;
+const prettierConfigurationCache = new Map<string, Promise<prettier.Options | null>>();
+
+/**
+ * Run prettier over generated content using the repo's prettier configuration.
+ */
+export async function formatGenerated(content: string, filepath: string): Promise<string> {
+  try {
+    const configurationDirectory = dirname(filepath);
+    let optionsPromise = prettierConfigurationCache.get(configurationDirectory);
+    if (!optionsPromise) {
+      optionsPromise = prettier.resolveConfig(filepath);
+      prettierConfigurationCache.set(configurationDirectory, optionsPromise);
+    }
+    const options = await optionsPromise;
+    return await prettier.format(content, { ...options, filepath });
+  } catch {
+    return content;
+  }
+}
+
+export interface ComponentArtifacts {
+  component: DiscoveredComponent;
+  schemaJson: string;
+  schemaModule: string;
+  variablesJson: string;
+  variablesModule: string;
+  readme: string | null;
+}
+
+export async function generateArtifactsForComponent(
+  component: DiscoveredComponent,
+): Promise<ComponentArtifacts> {
+  const { directory, name, isExperimental } = component;
+  const depthToSrc = isExperimental ? 3 : 2;
+  const typesFilePath = join(directory, `${name}.types.ts`);
+
+  const schema = generateSchemaForComponent({ typesFilePath, componentName: name, depthToSrc });
+  const variables = await generateVariablesForComponent({
+    componentDirectory: directory,
+    componentName: name,
+  });
+
+  const readmePath = join(directory, 'README.md');
+  let readme: string | null = null;
+  if (existsSync(readmePath)) {
+    const existing = await Bun.file(readmePath).text();
+    readme = renderComponentReadme({
+      existingReadme: existing,
+      schema: schema.schema,
+      variables: variables.variables,
+    });
+  }
+
+  const schemaJsonPath = join(directory, `${name}.schema.json`);
+  const schemaModulePath = join(directory, `${name}.schema.ts`);
+  const variablesJsonPath = join(directory, `${name}.variables.json`);
+  const variablesModulePath = join(directory, `${name}.variables.ts`);
+
+  return {
+    component,
+    schemaJson: await formatGenerated(schema.schemaJson, schemaJsonPath),
+    schemaModule: await formatGenerated(schema.schemaModule, schemaModulePath),
+    variablesJson: await formatGenerated(variables.variablesJson, variablesJsonPath),
+    variablesModule: await formatGenerated(variables.variablesModule, variablesModulePath),
+    readme: readme === null ? null : await formatGenerated(readme, readmePath),
+  };
+}
+
+export async function writeArtifacts(artifacts: ComponentArtifacts): Promise<void> {
+  const { component } = artifacts;
+  await Bun.write(join(component.directory, `${component.name}.schema.json`), artifacts.schemaJson);
+  await Bun.write(join(component.directory, `${component.name}.schema.ts`), artifacts.schemaModule);
+  await Bun.write(
+    join(component.directory, `${component.name}.variables.json`),
+    artifacts.variablesJson,
+  );
+  await Bun.write(
+    join(component.directory, `${component.name}.variables.ts`),
+    artifacts.variablesModule,
+  );
+  if (artifacts.readme !== null) {
+    await Bun.write(join(component.directory, 'README.md'), artifacts.readme);
+  }
+}
+
+export interface DriftIssue {
+  component: string;
+  file: string;
+  reason: 'missing' | 'stale';
+}
+
+export async function checkComponentArtifacts(): Promise<DriftIssue[]> {
+  const components = await discoverComponentDirectories();
+
+  const issueGroups = await mapWithConcurrencyLimit(
+    components,
+    COMPONENT_ARTIFACT_CHECK_CONCURRENCY,
+    async (component) => {
+      const issues: DriftIssue[] = [];
+      const artifacts = await generateArtifactsForComponent(component);
+      const files: Array<{ filename: string; expected: string | null }> = [
+        { filename: `${component.name}.schema.json`, expected: artifacts.schemaJson },
+        { filename: `${component.name}.schema.ts`, expected: artifacts.schemaModule },
+        { filename: `${component.name}.variables.json`, expected: artifacts.variablesJson },
+        { filename: `${component.name}.variables.ts`, expected: artifacts.variablesModule },
+        { filename: 'README.md', expected: artifacts.readme },
+      ];
+
+      if (!existsSync(join(component.directory, 'README.md'))) {
+        issues.push({ component: component.name, file: 'README.md', reason: 'missing' });
+      }
+      if (
+        !COMPOSE_ONLY_ACCESSIBILITY_DOCUMENTATION_EXEMPTIONS.has(component.name) &&
+        !existsSync(join(component.directory, `${component.name}.a11y.md`))
+      ) {
+        issues.push({
+          component: component.name,
+          file: `${component.name}.a11y.md`,
+          reason: 'missing',
+        });
+      }
+
+      for (const { filename, expected } of files) {
+        if (expected === null) continue;
+        const path = join(component.directory, filename);
+        if (!existsSync(path)) {
+          issues.push({ component: component.name, file: filename, reason: 'missing' });
+          continue;
+        }
+        const actual = await Bun.file(path).text();
+        if (actual !== expected) {
+          issues.push({ component: component.name, file: filename, reason: 'stale' });
+        }
+      }
+
+      return issues;
+    },
+  );
+
+  return issueGroups.flat();
+}

--- a/packages/components/scripts/generate-component-artifacts.ts
+++ b/packages/components/scripts/generate-component-artifacts.ts
@@ -20,219 +20,22 @@
  */
 
 import { existsSync } from 'node:fs';
-import { dirname, join } from 'node:path';
+import { join } from 'node:path';
 
-import * as prettier from 'prettier';
-
-import {
-  discoverComponentDirectories,
-  type DiscoveredComponent,
-} from './discover-component-directories.ts';
-import { checkConstraintsDrift, generateAllConstraints } from './generate-component-constraints.ts';
-import {
-  checkExamplesDrift,
-  generateAllExamples,
-  writeExampleArtifacts,
-} from './generate-component-examples.ts';
-import { generateSchemaForComponent } from './generate-component-schema.ts';
-import { generateVariablesForComponent } from './generate-component-variables.ts';
-import { buildManifest, writeManifest } from './generate-manifest.ts';
-import { renderComponentReadme } from './render-component-readme.ts';
-import { mapWithConcurrencyLimit } from './validation-utilities.ts';
-
-export { discoverComponentDirectories, type DiscoveredComponent };
-
-const COMPOSE_ONLY_ACCESSIBILITY_DOCUMENTATION_EXEMPTIONS = new Set([
-  'accordion-item',
-  'dropdown-group',
-  'dropdown-item',
-  'dropdown-label',
-  'dropdown-menu',
-  'dropdown-separator',
-  'dropdown-trigger',
-  'feed-event',
-  'grid-list-item',
-  'side-navigation-group',
-  'side-navigation-item',
-  'stat',
-  'tab',
-  'tab-list',
-  'tab-panel',
-  'table-body',
-  'table-cell',
-  'table-header',
-  'table-header-cell',
-  'table-row',
-  'tree-item',
-]);
-
-const COMPONENT_ARTIFACT_CHECK_CONCURRENCY = 12;
-const prettierConfigurationCache = new Map<string, Promise<prettier.Options | null>>();
-
-/**
- * Run prettier over the generated content using the repo's prettier config.
- * Without this, lint-staged's prettier --write pass reformats our generated
- * files on every commit, which then makes `components:check` fail with a
- * "stale" drift report on the next build cycle. Running prettier inline keeps
- * the on-disk form identical to what lint-staged would produce.
- */
-async function formatGenerated(content: string, filepath: string): Promise<string> {
-  try {
-    const configurationDirectory = dirname(filepath);
-    let optionsPromise = prettierConfigurationCache.get(configurationDirectory);
-    if (!optionsPromise) {
-      optionsPromise = prettier.resolveConfig(filepath);
-      prettierConfigurationCache.set(configurationDirectory, optionsPromise);
-    }
-    const options = await optionsPromise;
-    return await prettier.format(content, { ...options, filepath });
-  } catch {
-    return content;
-  }
-}
-
-export interface ComponentArtifacts {
-  component: DiscoveredComponent;
-  schemaJson: string;
-  schemaModule: string;
-  variablesJson: string;
-  variablesModule: string;
-  readme: string | null;
-}
-
-export async function generateArtifactsForComponent(
-  component: DiscoveredComponent,
-): Promise<ComponentArtifacts> {
-  const { directory, name, isExperimental } = component;
-  const depthToSrc = isExperimental ? 3 : 2;
-  const typesFilePath = join(directory, `${name}.types.ts`);
-
-  const schema = generateSchemaForComponent({ typesFilePath, componentName: name, depthToSrc });
-  const variables = await generateVariablesForComponent({
-    componentDirectory: directory,
-    componentName: name,
-  });
-
-  const readmePath = join(directory, 'README.md');
-  let readme: string | null = null;
-  if (existsSync(readmePath)) {
-    const existing = await Bun.file(readmePath).text();
-    readme = renderComponentReadme({
-      existingReadme: existing,
-      schema: schema.schema,
-      variables: variables.variables,
-      // No subcomponents key — the migrator hand-authors the subcomponents
-      // region (or leaves it as "None."). The orchestrator does not currently
-      // have a programmatic source for which sibling .svelte files are public.
-    });
-  }
-
-  const schemaJsonPath = join(directory, `${name}.schema.json`);
-  const schemaModulePath = join(directory, `${name}.schema.ts`);
-  const variablesJsonPath = join(directory, `${name}.variables.json`);
-  const variablesModulePath = join(directory, `${name}.variables.ts`);
-
-  return {
-    component,
-    schemaJson: await formatGenerated(schema.schemaJson, schemaJsonPath),
-    schemaModule: await formatGenerated(schema.schemaModule, schemaModulePath),
-    variablesJson: await formatGenerated(variables.variablesJson, variablesJsonPath),
-    variablesModule: await formatGenerated(variables.variablesModule, variablesModulePath),
-    readme: readme === null ? null : await formatGenerated(readme, readmePath),
-  };
-}
-
-export async function writeArtifacts(artifacts: ComponentArtifacts): Promise<void> {
-  const { component } = artifacts;
-  await Bun.write(join(component.directory, `${component.name}.schema.json`), artifacts.schemaJson);
-  await Bun.write(join(component.directory, `${component.name}.schema.ts`), artifacts.schemaModule);
-  await Bun.write(
-    join(component.directory, `${component.name}.variables.json`),
-    artifacts.variablesJson,
-  );
-  await Bun.write(
-    join(component.directory, `${component.name}.variables.ts`),
-    artifacts.variablesModule,
-  );
-  if (artifacts.readme !== null) {
-    await Bun.write(join(component.directory, 'README.md'), artifacts.readme);
-  }
-}
-
-export interface DriftIssue {
-  component: string;
-  file: string;
-  reason: 'missing' | 'stale';
-}
-
-export async function checkComponentArtifacts(): Promise<DriftIssue[]> {
-  const components = await discoverComponentDirectories();
-
-  const issueGroups = await mapWithConcurrencyLimit(
-    components,
-    COMPONENT_ARTIFACT_CHECK_CONCURRENCY,
-    async (component) => {
-      const issues: DriftIssue[] = [];
-      const artifacts = await generateArtifactsForComponent(component);
-      const files: Array<{ filename: string; expected: string | null }> = [
-        { filename: `${component.name}.schema.json`, expected: artifacts.schemaJson },
-        { filename: `${component.name}.schema.ts`, expected: artifacts.schemaModule },
-        { filename: `${component.name}.variables.json`, expected: artifacts.variablesJson },
-        { filename: `${component.name}.variables.ts`, expected: artifacts.variablesModule },
-        { filename: 'README.md', expected: artifacts.readme },
-      ];
-
-      // Every discovered component MUST ship a README.md. The artifact generator
-      // only UPDATES an existing README (it never creates one from scratch), so a
-      // brand-new component otherwise leaves `artifacts.readme === null` and slips
-      // through the `expected === null` skip below — but the playground
-      // documentation route hard-requires the file and 500s without it, failing
-      // the deploy. Flag the absence explicitly so a missing README is a loud
-      // drift failure here rather than a red deploy later. (Seed a skeleton with
-      // `create-component` / `migrate-component`, then re-run `components:generate`
-      // to fill the generated regions.)
-      if (!existsSync(join(component.directory, 'README.md'))) {
-        issues.push({ component: component.name, file: 'README.md', reason: 'missing' });
-      }
-      if (
-        !COMPOSE_ONLY_ACCESSIBILITY_DOCUMENTATION_EXEMPTIONS.has(component.name) &&
-        !existsSync(join(component.directory, `${component.name}.a11y.md`))
-      ) {
-        issues.push({
-          component: component.name,
-          file: `${component.name}.a11y.md`,
-          reason: 'missing',
-        });
-      }
-
-      for (const { filename, expected } of files) {
-        // A null `expected` means the generator produced no content for this
-        // artifact — legitimate for metadata-only schema/variables (type-only
-        // components) and for a not-yet-seeded README (handled explicitly above).
-        if (expected === null) continue;
-        const path = join(component.directory, filename);
-        if (!existsSync(path)) {
-          issues.push({ component: component.name, file: filename, reason: 'missing' });
-          continue;
-        }
-        const actual = await Bun.file(path).text();
-        if (actual !== expected) {
-          issues.push({ component: component.name, file: filename, reason: 'stale' });
-        }
-      }
-
-      return issues;
-    },
-  );
-
-  return issueGroups.flat();
-}
+import type { DriftIssue } from './component-artifact-operations.ts';
 
 async function main(): Promise<void> {
   const args = process.argv.slice(2);
   const checkMode = args.includes('--check');
 
   if (checkMode) {
+    const { checkComponentArtifacts, formatGenerated } =
+      await import('./component-artifact-operations.ts');
+    const { checkConstraintsDrift } = await import('./generate-component-constraints.ts');
+    const { checkExamplesDrift, generateAllExamples } =
+      await import('./generate-component-examples.ts');
+    const { buildManifest } = await import('./generate-manifest.ts');
+
     // Stage 1: per-component schema/variables/README drift check.
     const perComponentIssues = await checkComponentArtifacts();
 
@@ -337,6 +140,9 @@ async function main(): Promise<void> {
   }
 
   // Generate mode.
+  const { discoverComponentDirectories } = await import('./discover-component-directories.ts');
+  const { generateArtifactsForComponent, writeArtifacts } =
+    await import('./component-artifact-operations.ts');
   const targetName = args.find((arg) => !arg.startsWith('-'));
   const components = await discoverComponentDirectories();
   const filtered = targetName
@@ -362,6 +168,11 @@ async function main(): Promise<void> {
   // Stages 2–4 run only when processing the full component set (no target filter).
   // Targeted single-component runs skip the package-level artifacts.
   if (targetName !== undefined) return;
+
+  const { generateAllConstraints } = await import('./generate-component-constraints.ts');
+  const { generateAllExamples, writeExampleArtifacts } =
+    await import('./generate-component-examples.ts');
+  const { writeManifest } = await import('./generate-manifest.ts');
 
   // Stage 2: constraints.
   const constraintsCount = await generateAllConstraints();


### PR DESCRIPTION
## Summary
- split heavy component artifact generation/check helpers out of the CLI entrypoint
- keep discovery importable without pulling the schema, README, and variables generation graph
- add import-boundary tests for the discovery and CLI surfaces

Closes #677.

## Verification
- bun -e "import { discoverComponentDirectories } from './packages/components/scripts/discover-component-directories.ts'; console.log((await discoverComponentDirectories()).length)"
- bun test --conditions browser --conditions svelte ./scripts/component-artifact-import-boundary.test.ts
- bun run --filter=@lostgradient/cinder components:check
- bun run --filter=@lostgradient/cinder typecheck
- bun run --filter=@lostgradient/cinder lint
- bun run format:check -- packages/components/scripts/component-artifact-operations.ts packages/components/scripts/component-artifact-import-boundary.test.ts packages/components/scripts/generate-component-artifacts.ts
- git push pre-push scoped validation passed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor-only: artifact generation and `components:check` behavior is preserved; risk is limited to import paths and consumers that relied on re-exports from the CLI entrypoint.
> 
> **Overview**
> Moves per-component **generate/check/write** logic (Prettier formatting, schema/variables/README artifacts, drift checks) from `generate-component-artifacts.ts` into a new **`component-artifact-operations.ts`** module. The CLI entrypoint now only orchestrates stages and **dynamically imports** the heavy modules (`component-artifact-operations`, constraints, examples, manifest) in generate/check mode.
> 
> **Discovery stays lightweight:** `discover-component-directories.ts` must not pull orchestration; the CLI **no longer re-exports** `discoverComponentDirectories` or artifact helpers (callers import discovery directly).
> 
> Adds **`component-artifact-import-boundary.test.ts`** to lock these import boundaries via source-string checks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a712df12ee8d17ec49151b1593e48e9c0938838e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->