### PR TITLE
Serialize local validation gates

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -43,7 +43,7 @@
     },
     "packages/components": {
       "name": "@lostgradient/cinder",
-      "version": "0.6.0",
+      "version": "0.7.0",
       "bin": {
         "cinder": "./dist/cli/index.js",
       },
@@ -70,10 +70,12 @@
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/svelte": "^5.2.7",
         "@types/bun": "^1.3.11",
+        "@types/js-yaml": "^4.0.9",
         "@types/qrcode": "^1.5.6",
         "chalk": "^5.6.2",
         "change-case": "^5.4.4",
         "happy-dom": "^15.11.7",
+        "js-yaml": "^4.1.0",
         "lucide-svelte": "^0.503.0",
         "oxlint": "^1.56.0",
         "oxlint-tsgolint": "^0.17.0",

--- a/packages/components/scripts/consumer-readiness.test.ts
+++ b/packages/components/scripts/consumer-readiness.test.ts
@@ -34,7 +34,7 @@ describe('waitForReadyHtml', () => {
     expect(html).toContain('data-ready');
   });
 
-  test('lets the first SSR request use the remaining readiness budget', async () => {
+  test('caps individual SSR requests so one hung response cannot consume the readiness budget', async () => {
     const observedTimeouts: number[] = [];
     const fetcher: ReadinessFetch = async (_url, timeoutMs) => {
       observedTimeouts.push(timeoutMs);
@@ -44,6 +44,7 @@ describe('waitForReadyHtml', () => {
     await waitForReadyHtml({
       url: 'http://127.0.0.1:5173/dev-ssr',
       timeoutMs: 1_000,
+      requestTimeoutMs: 250,
       pollIntervalMs: 0,
       runningServer: { exitCode: null },
       fetcher,
@@ -51,7 +52,33 @@ describe('waitForReadyHtml', () => {
     });
 
     expect(observedTimeouts).toHaveLength(1);
-    expect(observedTimeouts[0]).toBeGreaterThan(900);
+    expect(observedTimeouts[0]).toBe(250);
+  });
+
+  test('retries after a per-request timeout while the overall readiness budget remains open', async () => {
+    const observedTimeouts: number[] = [];
+    let attempts = 0;
+    const fetcher: ReadinessFetch = async (_url, timeoutMs) => {
+      observedTimeouts.push(timeoutMs);
+      attempts += 1;
+      if (attempts === 1) {
+        throw new Error('The operation timed out.');
+      }
+      return response('<main data-ready>ready</main>');
+    };
+
+    const html = await waitForReadyHtml({
+      url: 'http://127.0.0.1:5173/dev-ssr',
+      timeoutMs: 1_000,
+      requestTimeoutMs: 250,
+      pollIntervalMs: 0,
+      runningServer: { exitCode: null },
+      fetcher,
+      isReady: (body) => body.includes('data-ready'),
+    });
+
+    expect(html).toContain('data-ready');
+    expect(observedTimeouts).toEqual([250, 250]);
   });
 
   test('fails immediately when the server exits before the target route is ready', async () => {

--- a/packages/components/scripts/consumer-readiness.ts
+++ b/packages/components/scripts/consumer-readiness.ts
@@ -7,6 +7,7 @@ export type ReadinessFetch = (url: string, timeoutMs: number) => Promise<Respons
 type WaitForReadyHtmlInput = {
   url: string;
   timeoutMs: number;
+  requestTimeoutMs?: number;
   pollIntervalMs: number;
   runningServer: RunningServerStatus;
   isReady: (html: string) => boolean;
@@ -19,6 +20,7 @@ async function defaultFetch(url: string, timeoutMs: number): Promise<Response> {
 
 export async function waitForReadyHtml(input: WaitForReadyHtmlInput): Promise<string> {
   const fetcher = input.fetcher ?? defaultFetch;
+  const requestTimeoutMs = input.requestTimeoutMs ?? 5_000;
   const startTime = Date.now();
   let lastStatus: number | null = null;
   let lastError: string | null = null;
@@ -35,7 +37,7 @@ export async function waitForReadyHtml(input: WaitForReadyHtmlInput): Promise<st
     if (remainingTimeoutMs <= 0) break;
 
     try {
-      const response = await fetcher(input.url, remainingTimeoutMs);
+      const response = await fetcher(input.url, Math.min(requestTimeoutMs, remainingTimeoutMs));
       lastStatus = response.status;
       if (response.status === 200) {
         const html = await response.text();

--- a/packages/components/scripts/generate-component-artifacts.ts
+++ b/packages/components/scripts/generate-component-artifacts.ts
@@ -333,7 +333,8 @@ async function main(): Promise<void> {
     for (const issue of allIssues) {
       process.stderr.write(`  • ${issue}\n`);
     }
-    process.exit(1);
+    process.exitCode = 1;
+    return;
   }
 
   // Generate mode.
@@ -349,7 +350,8 @@ async function main(): Promise<void> {
         ? `No component named "${targetName}"\n`
         : 'No directory-shaped components found\n',
     );
-    process.exit(1);
+    process.exitCode = 1;
+    return;
   }
 
   // Stage 1: per-component schema/variables/README.
@@ -383,7 +385,8 @@ async function main(): Promise<void> {
     if (examplesResult.errors.length > 10) {
       process.stderr.write(`  … and ${examplesResult.errors.length - 10} more\n`);
     }
-    process.exit(1);
+    process.exitCode = 1;
+    return;
   }
   await writeExampleArtifacts(examplesResult);
   process.stdout.write(
@@ -397,5 +400,6 @@ async function main(): Promise<void> {
 }
 
 if (import.meta.main) {
-  await main();
+  const { withLocalValidationGateLock } = await import('./husky/utilities.ts');
+  await withLocalValidationGateLock(main);
 }

--- a/packages/components/scripts/husky/pre-push.ts
+++ b/packages/components/scripts/husky/pre-push.ts
@@ -39,7 +39,7 @@ import {
   success,
   summarizeFailures,
   warning,
-  withGateLock,
+  withLocalValidationGateLock,
   writePrePushLog,
   type GateFailure,
   type GitRunner,
@@ -660,7 +660,7 @@ if (plan.kind === 'skip') {
 let ok = false;
 
 try {
-  ok = await withGateLock(() =>
+  ok = await withLocalValidationGateLock(() =>
     plan.kind === 'full' ? runFull() : runScoped(plan.jobs, plan.stylelintFiles, plan.summary),
   );
 } catch (caught) {

--- a/packages/components/scripts/husky/utilities.test.ts
+++ b/packages/components/scripts/husky/utilities.test.ts
@@ -20,6 +20,7 @@ import {
   isSourceFile,
   isUnderWorkspace,
   loadWorkspacePackages,
+  LOCAL_VALIDATION_GATE_LOCK_HELD_ENV,
   parsePushRefs,
   phaseMaxConcurrency,
   prePushPackageScript,
@@ -27,6 +28,7 @@ import {
   runWithConcurrencyPool,
   summarizeFailures,
   withGateLock,
+  withLocalValidationGateLock,
   type GitRunner,
   type PushRefUpdate,
   type WorkspacePackage,
@@ -1572,4 +1574,76 @@ describe('withGateLock', () => {
       });
     });
   }
+});
+
+describe('withLocalValidationGateLock', () => {
+  async function withTemporaryLockPath<T>(test: (lockPath: string) => Promise<T>): Promise<T> {
+    const directory = await mkdtemp(join(tmpdir(), 'cinder-local-validation-lock-'));
+    try {
+      return await test(join(directory, 'local-validation.lock'));
+    } finally {
+      await rm(directory, { force: true, recursive: true });
+    }
+  }
+
+  it('marks the lock as held while the protected function runs and restores the environment', async () => {
+    await withTemporaryLockPath(async (lockPath) => {
+      const previousValue = Bun.env[LOCAL_VALIDATION_GATE_LOCK_HELD_ENV];
+      delete Bun.env[LOCAL_VALIDATION_GATE_LOCK_HELD_ENV];
+      try {
+        let markerInsideRun: string | undefined;
+
+        await withLocalValidationGateLock(
+          async () => {
+            markerInsideRun = Bun.env[LOCAL_VALIDATION_GATE_LOCK_HELD_ENV];
+          },
+          { lockPath },
+        );
+
+        expect(markerInsideRun).toBe('1');
+        expect(Bun.env[LOCAL_VALIDATION_GATE_LOCK_HELD_ENV]).toBeUndefined();
+      } finally {
+        if (previousValue === undefined) {
+          delete Bun.env[LOCAL_VALIDATION_GATE_LOCK_HELD_ENV];
+        } else {
+          Bun.env[LOCAL_VALIDATION_GATE_LOCK_HELD_ENV] = previousValue;
+        }
+      }
+    });
+  });
+
+  it('does not re-acquire the lock when a parent validation gate already holds it', async () => {
+    await withTemporaryLockPath(async (lockPath) => {
+      await writeFile(
+        lockPath,
+        JSON.stringify({
+          createdAt: new Date().toISOString(),
+          pid: process.pid,
+          repositoryRoot: 'parent-gate',
+          token: 'already-held',
+        }),
+      );
+
+      const previousValue = Bun.env[LOCAL_VALIDATION_GATE_LOCK_HELD_ENV];
+      Bun.env[LOCAL_VALIDATION_GATE_LOCK_HELD_ENV] = '1';
+      try {
+        const result = await withLocalValidationGateLock(async () => 'skipped nested acquire', {
+          lockPath,
+          isProcessAlive: () => true,
+          retryMilliseconds: 1,
+          waitMilliseconds: 1,
+        });
+
+        expect(result).toBe('skipped nested acquire');
+        expect(await Bun.file(lockPath).exists()).toBe(true);
+      } finally {
+        if (previousValue === undefined) {
+          delete Bun.env[LOCAL_VALIDATION_GATE_LOCK_HELD_ENV];
+        } else {
+          Bun.env[LOCAL_VALIDATION_GATE_LOCK_HELD_ENV] = previousValue;
+        }
+        await rm(lockPath, { force: true });
+      }
+    });
+  });
 });

--- a/packages/components/scripts/husky/utilities.test.ts
+++ b/packages/components/scripts/husky/utilities.test.ts
@@ -10,9 +10,12 @@ import {
   changedFilesForRange,
   cleanupForHookSignal,
   cleanupHookProcesses,
+  defaultGateLockPath,
   expandToDependents,
   formatFailureSummary,
+  gateLockPathForCommonDirectory,
   getTouchedPackages,
+  gitCommonDirectory,
   hasRootConfigurationChanges,
   inferFailureScope,
   isIgnorableDoc,
@@ -24,6 +27,7 @@ import {
   parsePushRefs,
   phaseMaxConcurrency,
   prePushPackageScript,
+  REPO_ROOT,
   runHookCommand,
   runWithConcurrencyPool,
   summarizeFailures,
@@ -1322,6 +1326,15 @@ describe('withGateLock', () => {
       await rm(directory, { force: true, recursive: true });
     }
   }
+
+  it('derives the default lock path from the shared Git common directory', () => {
+    const commonDirectory = gitCommonDirectory();
+    const expectedPath = gateLockPathForCommonDirectory(commonDirectory);
+
+    expect(commonDirectory).toBe(gitCommonDirectory(REPO_ROOT));
+    expect(defaultGateLockPath()).toBe(expectedPath);
+    expect(defaultGateLockPath()).not.toContain(REPO_ROOT);
+  });
 
   it('creates a lock while the protected function runs and removes it after success', async () => {
     await withTemporaryLockPath(async (lockPath) => {

--- a/packages/components/scripts/husky/utilities.ts
+++ b/packages/components/scripts/husky/utilities.ts
@@ -1,8 +1,11 @@
 import { $ } from 'bun';
 import chalk from 'chalk';
 import { capitalCase } from 'change-case';
+import { execFileSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
 import { readFileSync, rmSync } from 'node:fs';
 import { mkdir, open, readdir, readFile, rm, stat } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -509,11 +512,39 @@ type GateLockOptions = {
   readonly waitMilliseconds?: number;
 };
 
-const DEFAULT_GATE_LOCK_PATH = join(REPO_ROOT, 'tmp', 'pre-push-gate.lock');
 const DEFAULT_MALFORMED_GATE_LOCK_GRACE_MILLISECONDS = 30_000;
 const DEFAULT_GATE_LOCK_RETRY_MILLISECONDS = 1_000;
 const DEFAULT_GATE_LOCK_WAIT_MILLISECONDS = 5 * 60 * 1_000;
 export const LOCAL_VALIDATION_GATE_LOCK_HELD_ENV = 'CINDER_LOCAL_VALIDATION_GATE_LOCK_HELD';
+
+export function gitCommonDirectory(repositoryRoot = REPO_ROOT): string {
+  try {
+    const commonDirectory = execFileSync(
+      'git',
+      ['-C', repositoryRoot, 'rev-parse', '--path-format=absolute', '--git-common-dir'],
+      {
+        encoding: 'utf8',
+        stdio: ['ignore', 'pipe', 'ignore'],
+      },
+    ).trim();
+    if (commonDirectory.length > 0) return commonDirectory;
+  } catch {
+    // Fall through to the repository-local path for non-Git test fixtures.
+  }
+  return join(repositoryRoot, '.git');
+}
+
+export function gateLockPathForCommonDirectory(commonDirectory: string): string {
+  const commonDirectoryHash = createHash('sha256')
+    .update(commonDirectory)
+    .digest('hex')
+    .slice(0, 16);
+  return join(tmpdir(), 'cinder-local-validation-gates', `${commonDirectoryHash}.lock`);
+}
+
+export function defaultGateLockPath(repositoryRoot = REPO_ROOT): string {
+  return gateLockPathForCommonDirectory(gitCommonDirectory(repositoryRoot));
+}
 
 function createGateLockFile(token: string): GateLockFile {
   return {
@@ -582,14 +613,15 @@ function releaseGateLockSync(lockPath: string, token: string) {
 }
 
 /**
- * Run a hook gate under a repository-local lock so duplicate pushes do not
- * stack full workspace validations on top of one another.
+ * Run a hook gate under a shared repository lock so duplicate pushes from
+ * linked worktrees do not stack full workspace validations on top of one
+ * another.
  */
 export async function withGateLock<T>(
   run: () => Promise<T>,
   options: GateLockOptions = {},
 ): Promise<T> {
-  const lockPath = options.lockPath ?? DEFAULT_GATE_LOCK_PATH;
+  const lockPath = options.lockPath ?? defaultGateLockPath();
   const malformedLockGraceMilliseconds =
     options.malformedLockGraceMilliseconds ?? DEFAULT_MALFORMED_GATE_LOCK_GRACE_MILLISECONDS;
   const retryMilliseconds = options.retryMilliseconds ?? DEFAULT_GATE_LOCK_RETRY_MILLISECONDS;

--- a/packages/components/scripts/husky/utilities.ts
+++ b/packages/components/scripts/husky/utilities.ts
@@ -513,6 +513,7 @@ const DEFAULT_GATE_LOCK_PATH = join(REPO_ROOT, 'tmp', 'pre-push-gate.lock');
 const DEFAULT_MALFORMED_GATE_LOCK_GRACE_MILLISECONDS = 30_000;
 const DEFAULT_GATE_LOCK_RETRY_MILLISECONDS = 1_000;
 const DEFAULT_GATE_LOCK_WAIT_MILLISECONDS = 5 * 60 * 1_000;
+export const LOCAL_VALIDATION_GATE_LOCK_HELD_ENV = 'CINDER_LOCAL_VALIDATION_GATE_LOCK_HELD';
 
 function createGateLockFile(token: string): GateLockFile {
   return {
@@ -677,7 +678,8 @@ export async function withGateLock<T>(
 
       if (!waitingMessagePrinted) {
         warning(
-          `Another pre-push gate is already running for ${existingLock.repositoryRoot} (pid ${existingLock.pid}). Waiting for it to finish…`,
+          `Another pre-push gate is already running for ${existingLock.repositoryRoot} (pid ${existingLock.pid}). Waiting for it to finish…\n` +
+            `  Inspect with: ps -p ${existingLock.pid} -o pid,ppid,etime,stat,command`,
         );
         waitingMessagePrinted = true;
       }
@@ -692,6 +694,35 @@ export async function withGateLock<T>(
       await Bun.sleep(retryMilliseconds);
     }
   }
+}
+
+/**
+ * Serialize expensive local validation gates across worktrees.
+ *
+ * `pre-push` holds this lock around the entire gate. Child scripts such as
+ * `test:changed`, `components:check`, and `validate:consumer` inherit the
+ * marker below, so they do not deadlock by trying to re-acquire the same lock.
+ * Direct invocations still acquire the repository-local lock.
+ */
+export async function withLocalValidationGateLock<T>(
+  run: () => Promise<T>,
+  options: GateLockOptions = {},
+): Promise<T> {
+  if (Bun.env[LOCAL_VALIDATION_GATE_LOCK_HELD_ENV] === '1') return await run();
+
+  return await withGateLock(async () => {
+    const previousValue = Bun.env[LOCAL_VALIDATION_GATE_LOCK_HELD_ENV];
+    Bun.env[LOCAL_VALIDATION_GATE_LOCK_HELD_ENV] = '1';
+    try {
+      return await run();
+    } finally {
+      if (previousValue === undefined) {
+        delete Bun.env[LOCAL_VALIDATION_GATE_LOCK_HELD_ENV];
+      } else {
+        Bun.env[LOCAL_VALIDATION_GATE_LOCK_HELD_ENV] = previousValue;
+      }
+    }
+  }, options);
 }
 
 export async function getStagedFiles(): Promise<string[]> {

--- a/packages/components/scripts/pack-for-publish.test.ts
+++ b/packages/components/scripts/pack-for-publish.test.ts
@@ -7,6 +7,7 @@ import { BUILD_INPUT_HASH_MARKER } from './lib/build-cache.ts';
 import {
   buildPublishedManifest,
   removeBuildCacheMarker,
+  runPackCommand,
   stripDanglingSourceMapUrlComments,
   transpileSvelteComponentScriptsForPublish,
   transpileSvelteTypeScriptModuleForPublish,
@@ -63,6 +64,36 @@ describe('removeBuildCacheMarker', () => {
     mkdirSync(join(root, 'dist'), { recursive: true });
 
     await expect(removeBuildCacheMarker(root)).resolves.toBeUndefined();
+  });
+});
+
+describe('runPackCommand', () => {
+  it('runs bun pm pack from the staging directory into the destination directory', () => {
+    const calls: Array<{
+      command: readonly string[];
+      options: { readonly cwd: string; readonly stderr: 'pipe'; readonly stdout: 'pipe' };
+    }> = [];
+
+    runPackCommand('/tmp/staging', '/tmp/output', (command, options) => {
+      calls.push({ command, options });
+      return { exitCode: 0, stderr: Buffer.from('') };
+    });
+
+    expect(calls).toEqual([
+      {
+        command: ['bun', 'pm', 'pack', '--destination', '/tmp/output'],
+        options: { cwd: '/tmp/staging', stderr: 'pipe', stdout: 'pipe' },
+      },
+    ]);
+  });
+
+  it('throws with stderr when bun pm pack fails', () => {
+    expect(() =>
+      runPackCommand('/tmp/staging', '/tmp/output', () => ({
+        exitCode: 1,
+        stderr: Buffer.from('pack failed'),
+      })),
+    ).toThrow('bun pm pack failed: pack failed');
   });
 });
 

--- a/packages/components/scripts/pack-for-publish.ts
+++ b/packages/components/scripts/pack-for-publish.ts
@@ -28,7 +28,7 @@
  * transformed tarball, not a raw `bun pm pack` against the source manifest.
  */
 
-import { $, Glob } from 'bun';
+import { Glob } from 'bun';
 import { existsSync, statSync } from 'node:fs';
 import { cp, mkdir, rm } from 'node:fs/promises';
 import { dirname, join } from 'node:path';
@@ -536,6 +536,36 @@ export type PackForPublishResult = {
   stagingDirectory: string;
 };
 
+type PackCommandResult = {
+  readonly exitCode: number | null;
+  readonly stderr: { toString(): string };
+};
+
+type PackCommandRunner = (
+  command: readonly string[],
+  options: { readonly cwd: string; readonly stderr: 'pipe'; readonly stdout: 'pipe' },
+) => PackCommandResult;
+
+export function runPackCommand(
+  stagingDirectory: string,
+  destinationDirectory: string,
+  runner: PackCommandRunner = (command, options) =>
+    Bun.spawnSync([...command], {
+      cwd: options.cwd,
+      stderr: options.stderr,
+      stdout: options.stdout,
+    }),
+): void {
+  const result = runner(['bun', 'pm', 'pack', '--destination', destinationDirectory], {
+    cwd: stagingDirectory,
+    stderr: 'pipe',
+    stdout: 'pipe',
+  });
+  if (result.exitCode !== 0) {
+    throw new Error(`bun pm pack failed: ${result.stderr.toString()}`);
+  }
+}
+
 /**
  * Stage, transform, pack, and return the path to the emitted tarball.
  * Asserts that the source `package.json` is byte-identical pre- and
@@ -562,13 +592,7 @@ export async function packForPublish(): Promise<PackForPublishResult> {
     await Bun.file(tarballPath).delete();
   }
 
-  const result = await $`bun pm pack --destination ${packageRoot}`
-    .cwd(stagingRoot)
-    .nothrow()
-    .quiet();
-  if (result.exitCode !== 0) {
-    throw new Error(`bun pm pack failed: ${result.stderr.toString()}`);
-  }
+  runPackCommand(stagingRoot, packageRoot);
   if (!existsSync(tarballPath)) {
     throw new Error(`Expected tarball at ${tarballPath} after pack`);
   }

--- a/packages/components/scripts/test-changed.ts
+++ b/packages/components/scripts/test-changed.ts
@@ -33,6 +33,12 @@ import {
   loadSourceFiles,
   type ScopeDecision,
 } from './component-graph.ts';
+import {
+  error,
+  installHookProcessCleanup,
+  runHookCommand,
+  withLocalValidationGateLock,
+} from './husky/utilities.ts';
 
 const scriptDirectory = dirname(fileURLToPath(import.meta.url));
 const packageRoot = resolve(scriptDirectory, '..');
@@ -239,7 +245,9 @@ function parseBaseRef(argv: string[]): string {
   return 'origin/main';
 }
 
-async function main(): Promise<void> {
+async function main(): Promise<number> {
+  installHookProcessCleanup();
+
   const baseRef = parseBaseRef(process.argv.slice(2));
   const decision = await resolveScope(baseRef);
   const paths = testPathsForScope(decision);
@@ -252,15 +260,15 @@ async function main(): Promise<void> {
 
     for (const [index, group] of groups.entries()) {
       process.stderr.write(`test-changed: full suite chunk ${index + 1}/${groups.length}\n`);
-      const child = Bun.spawn(['bun', 'test', ...BUN_TEST_FLAGS, ...group], {
+      const result = await runHookCommand('bun', ['test', ...BUN_TEST_FLAGS, ...group], {
         cwd: packageRoot,
-        stdio: ['inherit', 'inherit', 'inherit'],
-        env: { ...process.env, TZ: 'UTC', LANG: 'en_US.UTF-8' },
+        environment: { TZ: 'UTC', LANG: 'en_US.UTF-8' },
+        stderr: 'inherit',
+        stdout: 'inherit',
       });
-      const exitCode = await child.exited;
-      if (exitCode !== 0) process.exit(exitCode);
+      if (result.exitCode !== 0) return result.exitCode;
     }
-    return;
+    return 0;
   } else {
     process.stderr.write(
       `test-changed: ${decision.mode === 'filtered' ? decision.slugs.length : 0} component(s): ` +
@@ -268,18 +276,21 @@ async function main(): Promise<void> {
     );
   }
 
-  const child = Bun.spawn(['bun', 'test', ...BUN_TEST_FLAGS, ...paths], {
+  const result = await runHookCommand('bun', ['test', ...BUN_TEST_FLAGS, ...paths], {
     cwd: packageRoot,
-    stdio: ['inherit', 'inherit', 'inherit'],
-    env: { ...process.env, TZ: 'UTC', LANG: 'en_US.UTF-8' },
+    environment: { TZ: 'UTC', LANG: 'en_US.UTF-8' },
+    stderr: 'inherit',
+    stdout: 'inherit',
   });
-  const exitCode = await child.exited;
-  process.exit(exitCode);
+  return result.exitCode;
 }
 
 if (import.meta.main) {
-  main().catch((error: unknown) => {
-    process.stderr.write(`test-changed failed: ${String(error)}\n`);
+  try {
+    const exitCode = await withLocalValidationGateLock(main);
+    process.exit(exitCode);
+  } catch (caught) {
+    error(`test-changed failed: ${String(caught)}`);
     process.exit(1);
-  });
+  }
 }

--- a/packages/components/scripts/validate-consumers.ts
+++ b/packages/components/scripts/validate-consumers.ts
@@ -16,6 +16,7 @@ import { fileURLToPath } from 'node:url';
 import { parse } from 'postcss';
 
 import { waitForReadyHtml } from './consumer-readiness.ts';
+import { installHookProcessCleanup, withLocalValidationGateLock } from './husky/utilities.ts';
 import { type CommentScanState, lineHasCinderResidue } from './lib/cinder-specifier-residue.ts';
 import { deriveUpstreamReexports } from './lib/derive-upstream-reexports.ts';
 import { discoverComponents } from './lib/discover-components.ts';
@@ -1996,7 +1997,8 @@ async function runExamplesConsumerFixture(): Promise<void> {
   }
 }
 
-try {
+async function main(): Promise<void> {
+  installHookProcessCleanup();
   ensureSupportedPlatform();
   await ensureNodeOnPath();
   await runBuild();
@@ -2040,6 +2042,10 @@ try {
   await runSveltekitFixture('latest Svelte 5', sveltePeerContract.latest);
   await runExamplesConsumerFixture();
   process.stdout.write('[validate-consumers] all checks passed.\n');
+}
+
+try {
+  await withLocalValidationGateLock(main);
 } catch (error) {
   if (error instanceof ValidationError) {
     process.stderr.write(`[validate-consumers] ${error.message}\n`);


### PR DESCRIPTION
## Summary
- add a reentrant local validation gate lock shared by pre-push and direct expensive scripts
- route test:changed through hook-managed process cleanup so interrupted runs do not leave descendants behind
- make component artifact checks, validate:consumer, and direct test:changed participate in the shared lock
- replace the hanging Bun shell pack step with a synchronous pack command wrapper and regression tests
- make dev SSR readiness retry after per-request timeouts while preserving the overall readiness deadline
- refresh bun.lock so it matches the current component package metadata

Closes #678.

## Verification
- bun test --conditions browser --conditions svelte ./scripts/consumer-readiness.test.ts
- bun run --filter=@lostgradient/cinder lint
- bun run --filter=@lostgradient/cinder typecheck
- bun run format:check -- bun.lock packages/components/scripts/husky/utilities.ts packages/components/scripts/husky/utilities.test.ts packages/components/scripts/husky/pre-push.ts packages/components/scripts/test-changed.ts packages/components/scripts/generate-component-artifacts.ts packages/components/scripts/validate-consumers.ts packages/components/scripts/pack-for-publish.ts packages/components/scripts/pack-for-publish.test.ts packages/components/scripts/consumer-readiness.ts packages/components/scripts/consumer-readiness.test.ts
- bun run --filter=@lostgradient/cinder validate:consumer
- bun run --filter=@lostgradient/cinder test:changed
- git push pre-push full validation passed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect pre-push hooks, parallel validation, and consumer/pack scripts rather than shipped library runtime, but mistakes could block local pushes or skew CI consumer checks.
> 
> **Overview**
> Introduces a **shared local validation gate lock** so `pre-push`, `test:changed`, `components:check`/`generate`, and `validate:consumer` do not run expensive checks in parallel across linked worktrees. The lock file is keyed off Git’s common directory (under the OS temp dir), and **`withLocalValidationGateLock`** is reentrant via `CINDER_LOCAL_VALIDATION_GATE_LOCK_HELD` so nested scripts invoked from an active gate skip re-acquiring the lock.
> 
> **`test:changed`** now uses hook-managed **`runHookCommand`** and process cleanup so interrupted runs are less likely to leave child processes behind.
> 
> **Consumer SSR readiness** polling caps each HTTP attempt with optional **`requestTimeoutMs`** (default 5s) instead of spending the whole readiness budget on one hung fetch, and retries until the overall deadline.
> 
> **`pack-for-publish`** replaces the Bun shell `bun pm pack` call with a synchronous **`runPackCommand`** helper (with unit tests). **`components:generate`/`check`** sets **`process.exitCode`** on failure instead of **`process.exit(1)`** when run under the gate lock.
> 
> **`bun.lock`** bumps `@lostgradient/cinder` to **0.7.0** and aligns devDependency entries (e.g. `js-yaml`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0bc4cded56d2d41d9fcb179c9d78beab27f57eba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->