### PR TITLE
Add chat attachment serialization helpers

### DIFF
--- a/packages/components/src/components/chat/README.md
+++ b/packages/components/src/components/chat/README.md
@@ -110,6 +110,36 @@ of overflowing the page.
 - Rendering a one-off message list — compose lighter primitives directly instead of pulling the full suite.
 - The transcript is read-only and needs no composer — a simple list of message bubbles is a better fit.
 
+## Attachment serialization
+
+When `capabilities.attachments` is enabled, `onsubmit` receives ready
+`ChatAttachment[]` values. Use `serializeChatAttachment()` or
+`serializeChatAttachments()` from `@lostgradient/cinder/chat` to convert those
+files into transportable base64 payloads without spreading the full byte array
+onto the JavaScript stack.
+
+```ts
+import { serializeChatAttachments } from '@lostgradient/cinder/chat';
+
+const attachments = await serializeChatAttachments(chatAttachments);
+```
+
+Each serialized attachment has this shape:
+
+```ts
+type SerializedChatAttachment = {
+  name: string;
+  mimeType: string;
+  kind: ChatAttachment['kind'];
+  content: string;
+};
+```
+
+The output is intentionally the base64 source payload for conversationalist's
+proposed `DocumentContent` bridge in `stevekinney/agent-bureau#153`. A consumer
+can wrap it as `{ type: 'document', name, mimeType, source: { kind: 'base64',
+data: content } }` when adding composer attachments to conversation state.
+
 ## Props
 
 <!-- generated:props:start -->

--- a/packages/components/src/components/chat/index.ts
+++ b/packages/components/src/components/chat/index.ts
@@ -80,8 +80,14 @@ export {
 } from './utilities';
 
 // Input
-export { ChatAttachmentPreview, ChatInput, deriveAttachmentKind } from './input';
-export type { AttachmentKind, ChatAttachment } from './input';
+export {
+  ChatAttachmentPreview,
+  ChatInput,
+  deriveAttachmentKind,
+  serializeChatAttachment,
+  serializeChatAttachments,
+} from './input';
+export type { AttachmentKind, ChatAttachment, SerializedChatAttachment } from './input';
 
 // Message
 export {

--- a/packages/components/src/components/chat/input/chat-attachment-serialization.test.ts
+++ b/packages/components/src/components/chat/input/chat-attachment-serialization.test.ts
@@ -85,8 +85,6 @@ describe('chat attachment serialization', () => {
       bytes[index] = index % 251;
     }
 
-    expect(() => String.fromCharCode(...bytes)).toThrow();
-
     const serialized = await serializeChatAttachment(
       createAttachment(bytes, {
         name: 'large.bin',
@@ -101,5 +99,35 @@ describe('chat attachment serialization', () => {
       kind: 'document',
       content: expectedBase64(bytes),
     });
+  });
+
+  test('uses Buffer when btoa is unavailable', async () => {
+    const originalBtoa = globalThis.btoa;
+    Reflect.deleteProperty(globalThis, 'btoa');
+
+    try {
+      const bytes = new TextEncoder().encode('server-side fallback');
+
+      await expect(
+        serializeChatAttachment(
+          createAttachment(bytes, {
+            name: 'fallback.bin',
+            type: 'application/octet-stream',
+            kind: 'document',
+          }),
+        ),
+      ).resolves.toEqual({
+        name: 'fallback.bin',
+        mimeType: 'application/octet-stream',
+        kind: 'document',
+        content: expectedBase64(bytes),
+      });
+    } finally {
+      Object.defineProperty(globalThis, 'btoa', {
+        configurable: true,
+        value: originalBtoa,
+        writable: true,
+      });
+    }
   });
 });

--- a/packages/components/src/components/chat/input/chat-attachment-serialization.test.ts
+++ b/packages/components/src/components/chat/input/chat-attachment-serialization.test.ts
@@ -1,0 +1,105 @@
+/// <reference lib="dom" />
+import { describe, expect, test } from 'bun:test';
+
+import {
+  serializeChatAttachment,
+  serializeChatAttachments,
+} from './chat-attachment-serialization.ts';
+import type { ChatAttachment } from './chat-attachment.ts';
+
+function createAttachment(
+  bytes: Uint8Array<ArrayBuffer>,
+  options: {
+    name?: string;
+    type?: string;
+    kind?: ChatAttachment['kind'];
+    id?: string;
+  } = {},
+): ChatAttachment {
+  const file = new File([bytes], options.name ?? 'attachment.txt', {
+    type: options.type ?? 'text/plain',
+  });
+
+  return {
+    id: options.id ?? options.name ?? 'attachment',
+    file,
+    previewUrl: '',
+    kind: options.kind ?? 'document',
+    status: 'ready',
+  };
+}
+
+function expectedBase64(bytes: Uint8Array<ArrayBuffer>): string {
+  return Buffer.from(bytes).toString('base64');
+}
+
+describe('chat attachment serialization', () => {
+  test('serializes attachment metadata and base64 file content', async () => {
+    const bytes = new TextEncoder().encode('hello from cinder');
+    const attachment = createAttachment(bytes, {
+      name: 'hello.txt',
+      type: 'application/x-typescript',
+      kind: 'code',
+    });
+
+    await expect(serializeChatAttachment(attachment)).resolves.toEqual({
+      name: 'hello.txt',
+      mimeType: 'application/x-typescript',
+      kind: 'code',
+      content: expectedBase64(bytes),
+    });
+  });
+
+  test('serializes multiple attachments in input order', async () => {
+    const firstBytes = new TextEncoder().encode('first');
+    const secondBytes = new TextEncoder().encode('second');
+
+    await expect(
+      serializeChatAttachments([
+        createAttachment(firstBytes, {
+          name: 'first.txt',
+          type: 'application/pdf',
+          kind: 'document',
+        }),
+        createAttachment(secondBytes, { name: 'second.png', type: 'image/png', kind: 'image' }),
+      ]),
+    ).resolves.toEqual([
+      {
+        name: 'first.txt',
+        mimeType: 'application/pdf',
+        kind: 'document',
+        content: expectedBase64(firstBytes),
+      },
+      {
+        name: 'second.png',
+        mimeType: 'image/png',
+        kind: 'image',
+        content: expectedBase64(secondBytes),
+      },
+    ]);
+  });
+
+  test('encodes large files without spreading the full byte array onto the stack', async () => {
+    const bytes = new Uint8Array(1_000_000);
+    for (let index = 0; index < bytes.length; index += 1) {
+      bytes[index] = index % 251;
+    }
+
+    expect(() => String.fromCharCode(...bytes)).toThrow();
+
+    const serialized = await serializeChatAttachment(
+      createAttachment(bytes, {
+        name: 'large.bin',
+        type: 'application/octet-stream',
+        kind: 'document',
+      }),
+    );
+
+    expect(serialized).toEqual({
+      name: 'large.bin',
+      mimeType: 'application/octet-stream',
+      kind: 'document',
+      content: expectedBase64(bytes),
+    });
+  });
+});

--- a/packages/components/src/components/chat/input/chat-attachment-serialization.ts
+++ b/packages/components/src/components/chat/input/chat-attachment-serialization.ts
@@ -1,0 +1,40 @@
+import type { ChatAttachment } from './chat-attachment.ts';
+
+const BASE64_CHUNK_SIZE = 0x8000;
+
+export interface SerializedChatAttachment {
+  name: string;
+  mimeType: string;
+  kind: ChatAttachment['kind'];
+  content: string;
+}
+
+function bytesToBase64(bytes: Uint8Array): string {
+  let binary = '';
+
+  for (let start = 0; start < bytes.length; start += BASE64_CHUNK_SIZE) {
+    const chunk = bytes.subarray(start, start + BASE64_CHUNK_SIZE);
+    binary += String.fromCharCode(...chunk);
+  }
+
+  return btoa(binary);
+}
+
+export async function serializeChatAttachment(
+  attachment: ChatAttachment,
+): Promise<SerializedChatAttachment> {
+  const bytes = new Uint8Array(await attachment.file.arrayBuffer());
+
+  return {
+    name: attachment.file.name,
+    mimeType: attachment.file.type,
+    kind: attachment.kind,
+    content: bytesToBase64(bytes),
+  };
+}
+
+export async function serializeChatAttachments(
+  attachments: readonly ChatAttachment[],
+): Promise<SerializedChatAttachment[]> {
+  return Promise.all(attachments.map((attachment) => serializeChatAttachment(attachment)));
+}

--- a/packages/components/src/components/chat/input/chat-attachment-serialization.ts
+++ b/packages/components/src/components/chat/input/chat-attachment-serialization.ts
@@ -2,6 +2,13 @@ import type { ChatAttachment } from './chat-attachment.ts';
 
 const BASE64_CHUNK_SIZE = 0x8000;
 
+type Base64Runtime = typeof globalThis & {
+  btoa?: (data: string) => string;
+  Buffer?: {
+    from: (data: Uint8Array) => { toString: (encoding: 'base64') => string };
+  };
+};
+
 export interface SerializedChatAttachment {
   name: string;
   mimeType: string;
@@ -10,14 +17,24 @@ export interface SerializedChatAttachment {
 }
 
 function bytesToBase64(bytes: Uint8Array): string {
-  let binary = '';
+  const runtime = globalThis as Base64Runtime;
 
-  for (let start = 0; start < bytes.length; start += BASE64_CHUNK_SIZE) {
-    const chunk = bytes.subarray(start, start + BASE64_CHUNK_SIZE);
-    binary += String.fromCharCode(...chunk);
+  if (typeof runtime.btoa === 'function') {
+    let binary = '';
+
+    for (let start = 0; start < bytes.length; start += BASE64_CHUNK_SIZE) {
+      const chunk = bytes.subarray(start, start + BASE64_CHUNK_SIZE);
+      binary += String.fromCharCode(...chunk);
+    }
+
+    return runtime.btoa(binary);
   }
 
-  return btoa(binary);
+  if (typeof runtime.Buffer?.from === 'function') {
+    return runtime.Buffer.from(bytes).toString('base64');
+  }
+
+  throw new Error('serializeChatAttachment requires btoa or Buffer for base64 encoding.');
 }
 
 export async function serializeChatAttachment(
@@ -36,5 +53,11 @@ export async function serializeChatAttachment(
 export async function serializeChatAttachments(
   attachments: readonly ChatAttachment[],
 ): Promise<SerializedChatAttachment[]> {
-  return Promise.all(attachments.map((attachment) => serializeChatAttachment(attachment)));
+  const serializedAttachments: SerializedChatAttachment[] = [];
+
+  for (const attachment of attachments) {
+    serializedAttachments.push(await serializeChatAttachment(attachment));
+  }
+
+  return serializedAttachments;
 }

--- a/packages/components/src/components/chat/input/index.ts
+++ b/packages/components/src/components/chat/input/index.ts
@@ -1,4 +1,9 @@
 export { deriveAttachmentKind, type AttachmentKind } from './attachment-kind.js';
 export { default as ChatAttachmentPreview } from './chat-attachment-preview.svelte';
+export {
+  serializeChatAttachment,
+  serializeChatAttachments,
+  type SerializedChatAttachment,
+} from './chat-attachment-serialization.ts';
 export type { ChatAttachment } from './chat-attachment.ts';
 export { default as ChatInput } from './chat-input.svelte';


### PR DESCRIPTION
## Summary

- Add `serializeChatAttachment()` and `serializeChatAttachments()` exports from `@lostgradient/cinder/chat`.
- Encode attachment files as base64 in 0x8000-byte chunks to avoid spreading large files onto the JavaScript stack.
- Document the serialized output shape and how it maps into conversationalist's proposed `DocumentContent` base64 source shape.

Closes #687

## Verification

- `bun run --filter=@lostgradient/cinder test -- ./src/components/chat/input/chat-attachment-serialization.test.ts`
- `bun run --filter=@lostgradient/cinder typecheck`
- `bun run --filter=@lostgradient/cinder exports:check`
- `bun run --filter=@lostgradient/cinder components:check`
- `bun run --filter=@lostgradient/cinder lint`
- `bun run format:check`
- `bun run --filter=@lostgradient/cinder validate:consumer`
- `bun run --filter=@lostgradient/cinder build`
- `git push -u origin issue/687` (pre-push scoped validation passed)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive public API with unit tests; no changes to submit/render paths—only new optional serialization for attachment handling.
> 
> **Overview**
> Adds **`serializeChatAttachment`** and **`serializeChatAttachments`** on `@lostgradient/cinder/chat` so apps can turn ready `ChatAttachment` values from `onsubmit` into transportable payloads (`name`, `mimeType`, `kind`, base64 **`content`**) without pushing whole file byte arrays through `String.fromCharCode(...bytes)` in one shot.
> 
> Encoding uses **32KB chunks** when `btoa` is available, with a **`Buffer`** fallback for non-browser runtimes. The chat README documents the **`SerializedChatAttachment`** shape and how it lines up with conversationalist’s proposed `DocumentContent` base64 source bridge.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 86696a7fe757463941ee1607d225fedc121dd8f4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->