### PR TITLE
Split main-green component test gate

### DIFF
--- a/.github/workflows/main-green.yaml
+++ b/.github/workflows/main-green.yaml
@@ -71,8 +71,16 @@ jobs:
           --filter=@cinder/commentary
           build
 
-      - name: Test workspace
-        run: bun run test
+      - name: Test non-component workspaces
+        run: >-
+          bun run
+          --filter=@cinder/diff
+          --filter=@cinder/markdown
+          --filter=@cinder/editor
+          --filter=@cinder/commentary
+          --filter=@cinder/playground
+          --filter=@cinder/testing
+          test
 
       # Non-blocking trend signal, not a gate: always exits 0 for the RSS
       # number itself (only a genuine test failure inside the canary's own
@@ -84,3 +92,37 @@ jobs:
       - name: Memory canary (non-blocking)
         continue-on-error: true
         run: bun run --filter=@lostgradient/cinder test:memory-canary
+
+  component-tests:
+    name: component-tests (${{ matrix.chunk }}/4)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        chunk: [1, 2, 3, 4]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v1
+        with:
+          bun-version: ${{ env.BUN_VERSION }}
+
+      - name: Cache Bun install
+        uses: actions/cache@v4
+        with:
+          path: ~/.bun/install/cache
+          key: bun-${{ runner.os }}-${{ runner.arch }}-${{ env.BUN_VERSION }}-${{ hashFiles('bun.lock') }}
+          restore-keys: |
+            bun-${{ runner.os }}-${{ runner.arch }}-${{ env.BUN_VERSION }}-
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Test cinder components chunk
+        env:
+          CINDER_TEST_MODE: full
+          CINDER_TEST_FULL_SUITE_CHUNK: ${{ matrix.chunk }}
+        run: bun run --filter=@lostgradient/cinder test:changed

--- a/bun.lock
+++ b/bun.lock
@@ -43,7 +43,7 @@
     },
     "packages/components": {
       "name": "@lostgradient/cinder",
-      "version": "0.7.0",
+      "version": "0.8.0",
       "bin": {
         "cinder": "./dist/cli/index.js",
       },

--- a/packages/components/scripts/check-pipeline-coverage.ts
+++ b/packages/components/scripts/check-pipeline-coverage.ts
@@ -218,19 +218,22 @@ export const DECLARATION_TABLE: Record<string, DeclarationRow> = {
       'pending-changesets publish path.',
   },
   test: {
-    layers: ['pre-push', 'main-green'],
+    layers: ['pre-push'],
     reason:
       'The component package test suite. NOT run at commit time by design — pre-commit.ts is ' +
       'explicit that tests are deferred to pre-push (which owns a scoped, dependency-closure-aware ' +
-      'run) and CI. Only pre-push and main-green run the bare `test` script. release reaches ' +
-      'coverage via `test:coverage`, and unit-tests.yaml runs the scoped `test:changed` variant, not ' +
-      'this literal script name.',
+      'run). main-green must NOT call this bare full-suite script because it serializes the whole ' +
+      'workspace test graph into one timeout-prone step; it runs the chunkable `test:changed` full ' +
+      'suite instead. release reaches coverage via `test:coverage`, and unit-tests.yaml runs the ' +
+      'scoped `test:changed` variant, not this literal script name.',
   },
   'test:changed': {
-    layers: ['pre-push', 'unit-tests'],
+    layers: ['pre-push', 'unit-tests', 'main-green'],
     reason:
       'The dependency-closure-scoped test runner. pre-push always calls it via `prePushPackageScript` ' +
-      'for the components package; unit-tests.yaml calls it directly in "Run component unit tests (scoped)".',
+      'for the components package; unit-tests.yaml calls it directly in "Run component unit tests (scoped)"; ' +
+      'main-green calls it with CINDER_TEST_MODE=full and a four-way chunk matrix so the full component ' +
+      'suite stays authoritative without reintroducing a single long-running workspace test step.',
   },
   'test:coverage': {
     layers: ['release'],

--- a/packages/components/scripts/server-css-free.test.ts
+++ b/packages/components/scripts/server-css-free.test.ts
@@ -64,10 +64,10 @@ async function nodeConditionJsTargets(): Promise<string[]> {
  * `from`/dynamic forms with the specifier at the line's import position.
  */
 const CSS_IMPORT_LINE =
-  /^\s*import\s*(?:[\w*${},\s]+\s+from\s*)?['"](?:[^'"]*\.css|cinder\/(?:experimental\/)?[a-z0-9-]+\/styles)['"]|^\s*import\s*\(\s*['"](?:[^'"]*\.css|cinder\/(?:experimental\/)?[a-z0-9-]+\/styles)['"]/;
+  /^\s*import\s*(?:[\w*${},\s]+\s+from\s*)?['"](?:[^'"]*\.css|cinder\/(?:experimental\/)?[a-z0-9-]+\/styles)['"]|^\s*import\s*\(\s*['"](?:[^'"]*\.css|cinder\/(?:experimental\/)?[a-z0-9-]+\/styles)['"]/m;
 
 function hasCssImportLine(source: string): boolean {
-  return source.split('\n').some((line) => CSS_IMPORT_LINE.test(line));
+  return CSS_IMPORT_LINE.test(source);
 }
 
 describe.skipIf(!existsSync(distributionRoot))('server entries are CSS-free', () => {

--- a/packages/components/scripts/test-changed.test.ts
+++ b/packages/components/scripts/test-changed.test.ts
@@ -84,10 +84,14 @@ describe('fullSuiteTestPathGroups', () => {
   it('keeps full-suite package tests in the first chunk', () => {
     const groups = fullSuiteTestPathGroups([]);
     expect(groups[0]).toContain('scripts');
+    expect(groups[0]).toContain('src/cli');
     expect(groups[0]).toContain('src/test');
     expect(groups[0]).toContain('src/exports-drift.test.ts');
     expect(groups[0]).toContain('src/root-type-exports.test.ts');
     expect(groups[0]).toContain('src/components/svg-data-uri-color-literals.test.ts');
+    expect(groups[0]).toContain(
+      'src/components/_internal/create-command-list-state.svelte.test.ts',
+    );
     expect(groups[0]).toContain('src/components/_internal/create-sliding-dialog-state.test.ts');
     expect(groups[0]).toContain('src/components/_radio/radio.test.ts');
     expect(groups[0]).toContain('src/components/_timeline-item/timeline-item.test.ts');

--- a/packages/components/scripts/test-changed.test.ts
+++ b/packages/components/scripts/test-changed.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from 'bun:test';
 
-import { fullSuiteTestPathGroups, parseEnvSlugs, testPathsForScope } from './test-changed.ts';
+import {
+  fullSuiteTestPathGroups,
+  parseEnvSlugs,
+  parseFullSuiteChunk,
+  testPathsForScope,
+} from './test-changed.ts';
 
 describe('parseEnvSlugs', () => {
   it('returns an empty list when unset', () => {
@@ -14,6 +19,26 @@ describe('parseEnvSlugs', () => {
 
   it('parses, trims, and drops empties', () => {
     expect(parseEnvSlugs('button, badge ,, dialog')).toEqual(['button', 'badge', 'dialog']);
+  });
+});
+
+describe('parseFullSuiteChunk', () => {
+  it('returns null when unset', () => {
+    expect(parseFullSuiteChunk(undefined, 4)).toBeNull();
+    expect(parseFullSuiteChunk('', 4)).toBeNull();
+    expect(parseFullSuiteChunk('   ', 4)).toBeNull();
+  });
+
+  it('accepts a one-based chunk number inside the group count', () => {
+    expect(parseFullSuiteChunk('1', 4)).toBe(1);
+    expect(parseFullSuiteChunk('4', 4)).toBe(4);
+  });
+
+  it('rejects invalid chunk selections instead of silently running the wrong slice', () => {
+    expect(() => parseFullSuiteChunk('0', 4)).toThrow('must be an integer from 1 to 4');
+    expect(() => parseFullSuiteChunk('5', 4)).toThrow('must be an integer from 1 to 4');
+    expect(() => parseFullSuiteChunk('2.5', 4)).toThrow('must be an integer from 1 to 4');
+    expect(() => parseFullSuiteChunk('two', 4)).toThrow('must be an integer from 1 to 4');
   });
 });
 

--- a/packages/components/scripts/test-changed.ts
+++ b/packages/components/scripts/test-changed.ts
@@ -118,6 +118,7 @@ const BUN_TEST_FLAGS = [
 ] as const;
 
 const FULL_SUITE_CHUNK_COUNT = 4;
+const FULL_SUITE_CHUNK_ENV = 'CINDER_TEST_FULL_SUITE_CHUNK';
 
 const FULL_SUITE_NON_COMPONENT_PATHS = [
   'scripts',
@@ -169,6 +170,19 @@ export function fullSuiteTestPathGroups(componentSlugs: string[]): string[][] {
   return groups
     .map((group, index) => assertExistingTestPaths(group, `full-suite chunk ${index + 1}`))
     .filter((group) => group.length > 0);
+}
+
+export function parseFullSuiteChunk(raw: string | undefined, groupCount: number): number | null {
+  if (raw === undefined || raw.trim().length === 0) return null;
+
+  const chunk = Number(raw);
+  if (!Number.isInteger(chunk) || chunk < 1 || chunk > groupCount) {
+    throw new Error(
+      `${FULL_SUITE_CHUNK_ENV} must be an integer from 1 to ${groupCount}; received ${JSON.stringify(raw)}`,
+    );
+  }
+
+  return chunk;
 }
 
 /** Parse the `CINDER_TEST_COMPONENTS` env var into a slug list (empty = unset). */
@@ -257,8 +271,13 @@ async function main(): Promise<number> {
     process.stderr.write(`test-changed: full suite (${reason})\n`);
     const componentSlugs = [...(await loadKnownSlugs())];
     const groups = fullSuiteTestPathGroups(componentSlugs);
+    const selectedChunk = parseFullSuiteChunk(process.env[FULL_SUITE_CHUNK_ENV], groups.length);
+    const groupsToRun =
+      selectedChunk === null
+        ? groups.map((group, index) => ({ group, index }))
+        : [{ group: groups[selectedChunk - 1]!, index: selectedChunk - 1 }];
 
-    for (const [index, group] of groups.entries()) {
+    for (const { index, group } of groupsToRun) {
       process.stderr.write(`test-changed: full suite chunk ${index + 1}/${groups.length}\n`);
       const result = await runHookCommand('bun', ['test', ...BUN_TEST_FLAGS, ...group], {
         cwd: packageRoot,

--- a/packages/components/scripts/test-changed.ts
+++ b/packages/components/scripts/test-changed.ts
@@ -98,6 +98,7 @@ const ALWAYS_RUN_ROOT_TESTS = [
  * slugs returned from `loadKnownSlugs()`. They still belong to the full suite.
  */
 const FULL_SUITE_PRIVATE_COMPONENT_TESTS = [
+  'src/components/_internal/create-command-list-state.svelte.test.ts',
   'src/components/_internal/create-sliding-dialog-state.test.ts',
   'src/components/_radio/radio.test.ts',
   'src/components/_timeline-item/timeline-item.test.ts',
@@ -122,6 +123,7 @@ const FULL_SUITE_CHUNK_ENV = 'CINDER_TEST_FULL_SUITE_CHUNK';
 
 const FULL_SUITE_NON_COMPONENT_PATHS = [
   'scripts',
+  'src/cli',
   ...ALWAYS_RUN_PATHS,
   ...ALWAYS_RUN_ROOT_TESTS,
   ...FULL_SUITE_PRIVATE_COMPONENT_TESTS,


### PR DESCRIPTION
## Summary
- split the main-green component tests out of the serialized workspace test step that was timing out with SIGTERM/143
- add a four-way full-suite component matrix using the existing test:changed runner
- update pipeline coverage invariants so main-green is guarded by test:changed instead of bare bun run test
- optimize the CSS-free server-entry scan that surfaced during pre-push validation

## Root Cause
The latest failing main-green run for main commit 56e708606cc0a4e1b64aa0f516d2bf8083f09ad3 died in the workspace-gates Test workspace step. That step ran the full workspace tests through one serialized bun run test invocation, and GitHub Actions terminated it with exit 143 while component tests were still running.

## Validation
- bun run --filter=@lostgradient/cinder test -- ./scripts/test-changed.test.ts ./scripts/check-pipeline-coverage.test.ts
- bun run --filter=@lostgradient/cinder lint:invariants
- CINDER_TEST_MODE=full CINDER_TEST_FULL_SUITE_CHUNK=1 bun run --filter=@lostgradient/cinder test:changed
- CINDER_TEST_MODE=full CINDER_TEST_FULL_SUITE_CHUNK=2 bun run --filter=@lostgradient/cinder test:changed
- CINDER_TEST_MODE=full CINDER_TEST_FULL_SUITE_CHUNK=3 bun run --filter=@lostgradient/cinder test:changed
- CINDER_TEST_MODE=full CINDER_TEST_FULL_SUITE_CHUNK=4 bun run --filter=@lostgradient/cinder test:changed
- bun run --filter=@cinder/diff --filter=@cinder/markdown --filter=@cinder/editor --filter=@cinder/commentary --filter=@cinder/playground --filter=@cinder/testing test
- bun run --filter=@lostgradient/cinder test -- ./scripts/server-css-free.test.ts ./scripts/test-changed.test.ts ./scripts/check-pipeline-coverage.test.ts
- full pre-push validation passed while pushing bcb451d7

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how main is gated (CI topology and full-suite chunking); misconfigured chunks or coverage table drift could miss tests or fail pipeline-coverage checks.
> 
> **Overview**
> **main-green** no longer runs one workspace-wide `bun run test` that was hitting SIGTERM/timeouts. **workspace-gates** now runs **filtered tests** only for non-component packages (`@cinder/*`, playground, testing); **@lostgradient/cinder** is excluded from that step.
> 
> A new **`component-tests`** job runs in parallel (matrix chunks 1–4). Each shard sets `CINDER_TEST_MODE=full` and `CINDER_TEST_FULL_SUITE_CHUNK` and invokes **`test:changed`**, so the full component suite still gates main without one long serialized step.
> 
> **`test-changed`** gains **`parseFullSuiteChunk`** and honors `CINDER_TEST_FULL_SUITE_CHUNK` so a full-suite run can execute a single chunk instead of all four. Chunk 1’s non-component paths now include **`src/cli`** and an additional internal component test; **`check-pipeline-coverage`** documents that **`test`** is pre-push-only and **`test:changed`** covers **main-green**.
> 
> Minor: **`server-css-free`** CSS scan uses a multiline regex without per-line splitting; **`@lostgradient/cinder`** lockfile version **0.7.0 → 0.8.0**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 491895d25e581e13a1459160be3f43d5fd07cf66. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->