### PR TITLE
Expose Chat announcer API

### DIFF
--- a/packages/components/src/components/chat/README.md
+++ b/packages/components/src/components/chat/README.md
@@ -153,6 +153,40 @@ composer-prefixed props:
 />
 ```
 
+## Announcing custom action-required rows
+
+Chat owns always-rendered polite and assertive live regions outside the
+`role="log"` timeline. If you render action-required UI through a custom `row`
+or `messagePart` snippet, announce it through Chat instead of mounting another
+`aria-live` region inside the log:
+
+```svelte
+<script lang="ts">
+  import { Chat } from '@lostgradient/cinder/chat';
+
+  let chat: ReturnType<typeof Chat> | undefined;
+
+  function showCustomApproval() {
+    chat?.announce('Action required: Review the deployment approval.', 'assertive');
+  }
+</script>
+
+<Chat bind:this={chat} id="assistant-chat" {conversation} row={customRow} />
+```
+
+Use the default polite channel for non-urgent status updates:
+
+```ts
+chat?.announce('Attachment scan finished.');
+```
+
+Consumer announcements clear after a short interval so Chat's own history,
+unread, typing, and tool-approval announcements can continue to flow.
+Built-in tool-approval rows keep precedence on the assertive channel. If a
+consumer assertive announcement races with Chat's derived
+`Action required: ...` tool-approval announcement, Chat announces the built-in
+tool approval and drops the consumer assertive text to avoid double output.
+
 ## Guidance
 
 ### Use When

--- a/packages/components/src/components/chat/chat.svelte
+++ b/packages/components/src/components/chat/chat.svelte
@@ -13,13 +13,13 @@
    * @avoidWhen The transcript is read-only and needs no composer — a simple list of message bubbles is a better fit.
    * @related markdown-editor
    */
-  export type { ChatProps } from './chat.types.ts';
+  export type { ChatAnnounceLevel, ChatProps } from './chat.types.ts';
 </script>
 
 <script lang="ts">
   import { classNames } from '../../utilities/class-names.ts';
   import ChatImplementation from './container/chat.svelte';
-  import type { ChatProps } from './chat.types.ts';
+  import type { ChatAnnounceLevel, ChatProps } from './chat.types.ts';
 
   let { class: className, ...rest }: ChatProps = $props();
 
@@ -50,6 +50,15 @@
   /** End the active streaming session. No-op until mounted. */
   export function endStreaming(): void {
     impl?.endStreaming();
+  }
+
+  /**
+   * Announce consumer-rendered status text through Chat's existing live regions.
+   * No-op until mounted. Built-in tool-approval announcements take precedence
+   * over consumer assertive announcements to avoid duplicate urgent output.
+   */
+  export function announce(message: string, level: ChatAnnounceLevel = 'polite'): void {
+    impl?.announce(message, level);
   }
 
   /** Scroll the message viewport to the bottom. No-op until mounted. */

--- a/packages/components/src/components/chat/chat.test.ts
+++ b/packages/components/src/components/chat/chat.test.ts
@@ -23,8 +23,8 @@
  */
 
 /// <reference lib="dom" />
-import { afterAll, afterEach, describe, expect, test } from 'bun:test';
-import { createRawSnippet, mount, unmount } from 'svelte';
+import { afterAll, afterEach, describe, expect, jest, test } from 'bun:test';
+import { createRawSnippet, mount, tick, unmount } from 'svelte';
 
 import { setupHappyDom } from '../../test/happy-dom.ts';
 import { importWithoutDomGlobals } from '../../test/import-without-dom-globals.ts';
@@ -65,6 +65,7 @@ const { render, fireEvent, waitFor, cleanup } = await import('@testing-library/s
 
 // Unmount renders between tests; shared document.body otherwise leaks activeElement/nodes.
 afterEach(() => {
+  jest.useRealTimers();
   cleanup();
   document.body.replaceChildren();
 });
@@ -76,6 +77,7 @@ const { default: Chat } = await import('./chat.svelte');
 type TestConversation = import('./conversation-model.ts').ConversationHistory;
 type TestMessage = import('./conversation-model.ts').Message;
 type TestRole = import('./conversation-model.ts').MessageRole;
+type TestToolResult = import('./conversation-model.ts').ToolResult;
 
 let testMessageCounter = 0;
 
@@ -123,6 +125,39 @@ const appendUserMessage = (conversation: TestConversation, content: string) =>
   appendMessage(conversation, 'user', content);
 const appendAssistantMessage = (conversation: TestConversation, content: string) =>
   appendMessage(conversation, 'assistant', content);
+
+function appendActionRequiredMessage(
+  conversation: TestConversation,
+  message = 'Deploy to production?',
+): TestConversation {
+  const id = `test-message-${++testMessageCounter}`;
+  const now = new Date().toISOString();
+  const toolResult: TestToolResult = {
+    callId: `call-${testMessageCounter}`,
+    outcome: 'action_required',
+    content: null,
+    action: { type: 'approval', message },
+  };
+
+  return {
+    ...conversation,
+    ids: [...conversation.ids, id],
+    messages: {
+      ...conversation.messages,
+      [id]: {
+        id,
+        role: 'tool-result',
+        content: '',
+        position: conversation.ids.length,
+        createdAt: now,
+        metadata: {},
+        hidden: false,
+        toolResult,
+      },
+    },
+    updatedAt: now,
+  };
+}
 
 /** Build a minimal Svelte snippet that renders a single text node. */
 function textSnippet(text: string) {
@@ -176,6 +211,20 @@ function createDragEvent(type: string, files: File[], types: string[] = ['Files'
   return event;
 }
 
+type ChatAnnouncerApi = {
+  announce: (message: string, level?: 'polite' | 'assertive') => void;
+};
+
+function liveRegion(
+  container: HTMLElement,
+  level: 'polite' | 'assertive',
+): HTMLElement | undefined {
+  const regions = Array.from(
+    container.querySelectorAll<HTMLElement>(`.cinder-sr-only[aria-live="${level}"]`),
+  );
+  return regions.find((region) => region.getAttribute('aria-atomic') === 'true');
+}
+
 describe('Chat — basic render', () => {
   test('mounts the chat container with its accessible region', () => {
     const conversation = createConversation({ id: 'conversation-basic' });
@@ -221,6 +270,137 @@ describe('Chat — basic render', () => {
     const empty = container.querySelector('.chat-empty');
     expect(empty).not.toBeNull();
     expect(empty?.textContent).toContain('No messages yet');
+  });
+});
+
+describe('Chat — announcer API', () => {
+  test('announce() writes polite messages into the registered Chat live region', async () => {
+    const target = document.createElement('div');
+    document.body.append(target);
+    const conversation = createConversation({ id: 'conversation-announce-polite' });
+    const mounted = mount(Chat, {
+      target,
+      props: { id: 'chat-announce-polite', conversation },
+    });
+    const instance = mounted as unknown as ChatAnnouncerApi;
+
+    await tick();
+    const polite = liveRegion(target, 'polite');
+    expect(polite).not.toBeUndefined();
+    expect(polite?.textContent).toBe('');
+
+    instance.announce('Custom approval is ready for review');
+    await tick();
+
+    expect(polite?.textContent).toBe('Custom approval is ready for review');
+
+    unmount(mounted);
+    target.remove();
+  });
+
+  test('announce() writes assertive messages unless a built-in tool approval is active', async () => {
+    const target = document.createElement('div');
+    document.body.append(target);
+    const conversation = createConversation({ id: 'conversation-announce-assertive' });
+    const mounted = mount(Chat, {
+      target,
+      props: { id: 'chat-announce-assertive', conversation },
+    });
+    const instance = mounted as unknown as ChatAnnouncerApi;
+
+    await tick();
+    const assertive = liveRegion(target, 'assertive');
+    expect(assertive).not.toBeUndefined();
+    expect(assertive?.textContent).toBe('');
+
+    instance.announce('Custom row requires approval', 'assertive');
+    await tick();
+
+    expect(assertive?.textContent).toBe('Custom row requires approval');
+
+    unmount(mounted);
+    target.remove();
+  });
+
+  test('announce() clears consumer messages so built-in live-region messages can resume', async () => {
+    jest.useFakeTimers();
+    const target = document.createElement('div');
+    document.body.append(target);
+    const conversation = createConversation({ id: 'conversation-announce-clear' });
+    const mounted = mount(Chat, {
+      target,
+      props: { id: 'chat-announce-clear', conversation },
+    });
+    const instance = mounted as unknown as ChatAnnouncerApi;
+
+    await tick();
+    const polite = liveRegion(target, 'polite');
+    const assertive = liveRegion(target, 'assertive');
+
+    instance.announce('Custom status finished');
+    instance.announce('Custom action required', 'assertive');
+    await tick();
+
+    expect(polite?.textContent).toBe('Custom status finished');
+    expect(assertive?.textContent).toBe('Custom action required');
+
+    jest.advanceTimersByTime(999);
+    await tick();
+    expect(polite?.textContent).toBe('Custom status finished');
+    expect(assertive?.textContent).toBe('Custom action required');
+
+    jest.advanceTimersByTime(1);
+    await tick();
+    expect(polite?.textContent).toBe('');
+    expect(assertive?.textContent).toBe('');
+
+    unmount(mounted);
+    target.remove();
+  });
+
+  test('conversation changes clear consumer announcements', async () => {
+    const firstConversation = createConversation({ id: 'conversation-announce-reset-a' });
+    const secondConversation = createConversation({ id: 'conversation-announce-reset-b' });
+    const { component, container, rerender } = render(Chat, {
+      props: { id: 'chat-announce-reset', conversation: firstConversation },
+    });
+    const instance = component as unknown as ChatAnnouncerApi;
+
+    await tick();
+    const polite = liveRegion(container, 'polite');
+
+    instance.announce('Custom status from first conversation');
+    await tick();
+    expect(polite?.textContent).toBe('Custom status from first conversation');
+
+    await rerender({ id: 'chat-announce-reset', conversation: secondConversation });
+
+    expect(polite?.textContent).toBe('');
+  });
+
+  test('built-in tool approval wins over racing consumer assertive announcements', async () => {
+    const target = document.createElement('div');
+    document.body.append(target);
+    let conversation = createConversation({ id: 'conversation-announce-race' });
+    conversation = appendActionRequiredMessage(conversation, 'Deploy to production?');
+    const mounted = mount(Chat, {
+      target,
+      props: { id: 'chat-announce-race', conversation },
+    });
+    const instance = mounted as unknown as ChatAnnouncerApi;
+
+    await tick();
+    const assertive = liveRegion(target, 'assertive');
+    expect(assertive?.textContent).toBe('Action required: Deploy to production?');
+
+    instance.announce('Custom row also requires approval', 'assertive');
+    await tick();
+
+    expect(assertive?.textContent).toBe('Action required: Deploy to production?');
+    expect(assertive?.textContent).not.toContain('Custom row also requires approval');
+
+    unmount(mounted);
+    target.remove();
   });
 });
 

--- a/packages/components/src/components/chat/chat.types.test.ts
+++ b/packages/components/src/components/chat/chat.types.test.ts
@@ -17,7 +17,13 @@ import { expect, test } from 'bun:test';
 import type { ComponentProps } from 'svelte';
 
 import Chat from './chat.svelte';
-import type { ChatAttachment, ChatProps, ChatSubmitEvent, ConversationHistory } from './index.ts';
+import type {
+  ChatAnnounceLevel,
+  ChatAttachment,
+  ChatProps,
+  ChatSubmitEvent,
+  ConversationHistory,
+} from './index.ts';
 
 type Assignable<A, B> = A extends B ? true : false;
 
@@ -95,4 +101,12 @@ test('ChatAttachment is directly importable from the public chat barrel', () => 
   } satisfies ChatAttachment;
 
   expect(attachment.id).toBe('attachment-1');
+});
+
+test('ChatAnnounceLevel is directly importable from the public chat barrel', () => {
+  const polite = 'polite' satisfies ChatAnnounceLevel;
+  const assertive = 'assertive' satisfies ChatAnnounceLevel;
+
+  expect(polite).toBe('polite');
+  expect(assertive).toBe('assertive');
 });

--- a/packages/components/src/components/chat/chat.types.ts
+++ b/packages/components/src/components/chat/chat.types.ts
@@ -49,6 +49,9 @@ export type ReadReceipt = {
   readBy?: string[];
 };
 
+/** Live-region channel for imperative Chat announcements. */
+export type ChatAnnounceLevel = 'polite' | 'assertive';
+
 /**
  * Full-row override snippet. Inversion of control: receives the message AND a
  * `renderDefault` snippet that renders the built-in row, so a consumer can wrap

--- a/packages/components/src/components/chat/container/chat.svelte
+++ b/packages/components/src/components/chat/container/chat.svelte
@@ -7,9 +7,9 @@
   // `ChatProps` is owned by `../chat.types.ts` (the analyzer + schema generator
   // read that symbol). The implementation imports it from there rather than
   // redeclaring it, so the public type and the `$props()` shape can never drift.
-  import type { ChatProps } from '../chat.types.ts';
+  import type { ChatAnnounceLevel, ChatProps } from '../chat.types.ts';
 
-  export type { ChatProps };
+  export type { ChatAnnounceLevel, ChatProps };
   export type {
     ChatScrollStateChangeEvent,
     ChatStopGeneratingEvent,
@@ -57,6 +57,7 @@
   import ChatReadReceipt from '../message/chat-read-receipt.svelte';
 
   const noopAttachment: Attachment<HTMLElement> = () => {};
+  const CONSUMER_ANNOUNCEMENT_CLEAR_DELAY_MS = 1000;
   type ChatMessageRenderRow = Extract<ChatRenderRow, { type: 'message' }>;
   type PendingHistoryScroll = {
     previousFirstMessageId: string | null;
@@ -207,11 +208,16 @@
     toolCallState.reset();
     typingIndicatorState.reset();
     readReceiptsState.reset();
+    clearConsumerAnnouncements();
   });
 
   let isLoadingHistory = $state(false);
   let adapterHasMoreHistory = $state<boolean | undefined>(undefined);
   let historyAnnouncement = $state('');
+  let consumerPoliteAnnouncement = $state('');
+  let consumerAssertiveAnnouncement = $state('');
+  let consumerPoliteAnnouncementTimeout: ReturnType<typeof setTimeout> | undefined;
+  let consumerAssertiveAnnouncementTimeout: ReturnType<typeof setTimeout> | undefined;
   let pendingHistoryScroll: PendingHistoryScroll | null = $state(null);
   let deferredAdapterHasMoreHistory: boolean | null = null;
   let historyAnchorMessageId = $state<string | null>(null);
@@ -491,6 +497,18 @@
     }
     return '';
   });
+  const assertiveAnnouncement = $derived(
+    toolApprovalAssertiveMessage || consumerAssertiveAnnouncement,
+  );
+  const politeAnnouncement = $derived(
+    consumerPoliteAnnouncement || historyAnnouncement || unreadState.announcerMessage,
+  );
+
+  $effect(() => {
+    if (toolApprovalAssertiveMessage && consumerAssertiveAnnouncement) {
+      clearConsumerAssertiveAnnouncement();
+    }
+  });
 
   // ==========================================================================
   // Scroll Anchoring via $effect.pre
@@ -720,6 +738,7 @@
         cancelAnimationFrame(streamingScrollRaf);
         streamingScrollRaf = undefined;
       }
+      clearConsumerAnnouncements();
     };
   });
 
@@ -800,6 +819,54 @@
   // ==========================================================================
   // Actions
   // ==========================================================================
+
+  export function announce(message: string, level: ChatAnnounceLevel = 'polite'): void {
+    const trimmedMessage = message.trim();
+    if (!trimmedMessage) return;
+
+    if (level === 'assertive') {
+      if (toolApprovalAssertiveMessage) return;
+      setConsumerAssertiveAnnouncement(trimmedMessage);
+      return;
+    }
+
+    setConsumerPoliteAnnouncement(trimmedMessage);
+  }
+
+  function setConsumerPoliteAnnouncement(message: string): void {
+    clearTimeout(consumerPoliteAnnouncementTimeout);
+    consumerPoliteAnnouncement = message;
+    consumerPoliteAnnouncementTimeout = setTimeout(() => {
+      if (consumerPoliteAnnouncement === message) consumerPoliteAnnouncement = '';
+      consumerPoliteAnnouncementTimeout = undefined;
+    }, CONSUMER_ANNOUNCEMENT_CLEAR_DELAY_MS);
+  }
+
+  function setConsumerAssertiveAnnouncement(message: string): void {
+    clearTimeout(consumerAssertiveAnnouncementTimeout);
+    consumerAssertiveAnnouncement = message;
+    consumerAssertiveAnnouncementTimeout = setTimeout(() => {
+      if (consumerAssertiveAnnouncement === message) consumerAssertiveAnnouncement = '';
+      consumerAssertiveAnnouncementTimeout = undefined;
+    }, CONSUMER_ANNOUNCEMENT_CLEAR_DELAY_MS);
+  }
+
+  function clearConsumerPoliteAnnouncement(): void {
+    clearTimeout(consumerPoliteAnnouncementTimeout);
+    consumerPoliteAnnouncementTimeout = undefined;
+    consumerPoliteAnnouncement = '';
+  }
+
+  function clearConsumerAssertiveAnnouncement(): void {
+    clearTimeout(consumerAssertiveAnnouncementTimeout);
+    consumerAssertiveAnnouncementTimeout = undefined;
+    consumerAssertiveAnnouncement = '';
+  }
+
+  function clearConsumerAnnouncements(): void {
+    clearConsumerPoliteAnnouncement();
+    clearConsumerAssertiveAnnouncement();
+  }
 
   function handleJumpToLatest(): void {
     if (isVirtualized) {
@@ -1748,8 +1815,8 @@
   <ChatStatusAnnouncer
     {statusId}
     messageCount={messages.length}
-    announcerMessage={historyAnnouncement || unreadState.announcerMessage}
-    assertiveMessage={toolApprovalAssertiveMessage}
+    announcerMessage={politeAnnouncement}
+    assertiveMessage={assertiveAnnouncement}
   />
 
   <!-- Typing-participant live region: outside role="log" to avoid double announcement.

--- a/packages/components/src/components/chat/index.ts
+++ b/packages/components/src/components/chat/index.ts
@@ -13,7 +13,13 @@ import './chat.css';
 import Chat from './chat.svelte';
 
 export default Chat;
-export type { ChatCapabilities, ChatProps, ReadReceipt, TypingParticipant } from './chat.types.ts';
+export type {
+  ChatAnnounceLevel,
+  ChatCapabilities,
+  ChatProps,
+  ReadReceipt,
+  TypingParticipant,
+} from './chat.types.ts';
 export { Chat };
 
 // Adapter seam — the optional event/transport boundary around <Chat>. Type-only.


### PR DESCRIPTION
## Summary

- Add a public `announce(message, level?)` imperative API to Chat and forward it through the published wrapper.
- Route consumer polite/assertive announcements through Chat's existing live regions while keeping built-in tool-approval announcements as the assertive precedence winner.
- Document custom-row action-required guidance and add regression coverage for live-region delivery and race behavior.

Closes #686

## Verification

- `bun run --filter=@lostgradient/cinder test -- ./src/components/chat/chat.test.ts ./src/components/chat/chat.types.test.ts ./src/components/chat/container/chat-status-announcer.test.ts`
- `bun run --filter=@lostgradient/cinder typecheck`
- `bun run --filter=@lostgradient/cinder components:check`
- `bun run lint`
- `bun run format:check`
- pre-commit hook
- pre-push hook

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Accessibility-focused additive API with precedence rules and tests; no changes to transcript, adapter, or send flows.
> 
> **Overview**
> Adds a public imperative **`announce(message, level?)`** API on **`Chat`** (via `bind:this`), with **`ChatAnnounceLevel`** (`'polite' | 'assertive'`) exported from `@lostgradient/cinder/chat`.
> 
> Custom rows and message parts can push status into Chat’s existing **polite** and **assertive** live regions instead of nesting extra `aria-live` nodes inside the message log. **Polite** consumer text takes precedence over history/unread announcements; **assertive** consumer text is used only when no built-in **Action required** tool-approval message is active (races drop consumer assertive output). Messages auto-clear after ~1s, and consumer state resets on conversation change and unmount.
> 
> README documents the pattern for custom action-required UI; tests cover live-region delivery, timer clearing, conversation reset, and tool-approval precedence.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fce5d6ac8697ccc18b7d438f11865f9524e581b3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->