### PR TITLE
Add TagInput commit-on-submit support

### DIFF
--- a/.changeset/tag-input-commit-on-submit.md
+++ b/.changeset/tag-input-commit-on-submit.md
@@ -1,0 +1,5 @@
+---
+'@lostgradient/cinder': minor
+---
+
+Add a `commitOnSubmit` option to TagInput so native forms can commit a pending draft before submission.

--- a/bun.lock
+++ b/bun.lock
@@ -43,7 +43,7 @@
     },
     "packages/components": {
       "name": "@lostgradient/cinder",
-      "version": "0.9.0",
+      "version": "0.10.0",
       "bin": {
         "cinder": "./dist/cli/index.js",
       },

--- a/packages/components/src/components/chat/builders.test.ts
+++ b/packages/components/src/components/chat/builders.test.ts
@@ -8,7 +8,9 @@ import {
 } from './builders.ts';
 import type {
   ConversationEnvironment,
+  ConversationHistory,
   JSONValue,
+  Message,
   MessageInput,
   MultiModalContent,
 } from './conversation-model.ts';
@@ -134,6 +136,27 @@ describe('chat conversation builders', () => {
     expect(message.hidden).toBe(false);
   });
 
+  test('appendMessages accepts supported reasoning and tool content parts', () => {
+    const content: MultiModalContent[] = [
+      { type: 'thinking', thinking: 'Plan the response', signature: 'signed-thinking' },
+      { type: 'redacted_thinking', data: 'sealed' },
+      { type: 'server_tool_use', id: 'tool-use-1', name: 'web_search', input: {} },
+      {
+        type: 'web_search_tool_result',
+        tool_use_id: 'tool-use-1',
+        content: [{ title: 'Cinder documentation' }],
+      },
+      { type: 'container_upload', file_id: 'file-123' },
+    ];
+
+    const conversation = appendMessages(createConversation({ id: 'conversation-content-parts' }), {
+      role: 'assistant',
+      content,
+    });
+
+    expect(conversation.messages[conversation.ids[0]!]!.content).toEqual(content);
+  });
+
   test('appendMessages copies nested message metadata before storing it', () => {
     const metadata = {
       steps: [{ title: 'Draft' }],
@@ -189,6 +212,15 @@ describe('chat conversation builders', () => {
 
     expect(() =>
       appendMessages(conversation, {
+        role: 'assistant',
+        content: {
+          type: 'unsupported',
+        } as unknown as MessageInput['content'],
+      }),
+    ).toThrow('appendMessages expected MessageInput arguments before the optional environment');
+
+    expect(() =>
+      appendMessages(conversation, {
         role: 'tool-call',
         content: '',
         toolCall: {
@@ -218,6 +250,14 @@ describe('chat conversation builders', () => {
         tokenUsage: { total: 1n } as unknown as MessageInput['tokenUsage'],
       }),
     ).toThrow('tokenUsage must be a JSON-compatible object');
+
+    expect(() =>
+      appendMessages(conversation, {
+        role: 'assistant',
+        content: 'Invalid token usage',
+        tokenUsage: { total: '1' } as unknown as MessageInput['tokenUsage'],
+      }),
+    ).toThrow('tokenUsage values must be numbers');
 
     expect(() =>
       appendMessages(conversation, {
@@ -331,6 +371,27 @@ describe('chat conversation builders', () => {
         },
       ),
     ).toThrow('duplicate toolCall.id in conversation: duplicate-call');
+
+    const duplicateExistingToolCallConversation = appendMessages(conversation, {
+      role: 'tool-call',
+      content: '',
+      toolCall: { id: 'existing-duplicate-call', name: 'lookup', arguments: {} },
+    }) as ConversationHistory & { ids: string[]; messages: Record<string, Message> };
+    const originalMessageId = duplicateExistingToolCallConversation.ids[0]!;
+    const duplicateMessageId = `${originalMessageId}-copy`;
+    duplicateExistingToolCallConversation.ids.push(duplicateMessageId);
+    duplicateExistingToolCallConversation.messages[duplicateMessageId] = {
+      ...duplicateExistingToolCallConversation.messages[originalMessageId]!,
+      id: duplicateMessageId,
+      position: 1,
+    };
+
+    expect(() =>
+      appendMessages(duplicateExistingToolCallConversation, {
+        role: 'assistant',
+        content: 'Next',
+      }),
+    ).toThrow('duplicate toolCall.id in conversation: existing-duplicate-call');
 
     expect(() =>
       appendMessages(conversation, {

--- a/packages/components/src/components/chat/builders.ts
+++ b/packages/components/src/components/chat/builders.ts
@@ -177,9 +177,6 @@ function cloneMetadata(metadata: Record<string, JSONValue> | undefined): Record<
 
 function normalizeContent(content: MessageContentInput): MessageInput['content'] {
   if (typeof content === 'string') return content;
-  if (!isMessageContentInput(content)) {
-    throw new Error('message content must be a known multi-modal content part');
-  }
   return Array.isArray(content) ? cloneStructuredValue(content) : [cloneStructuredValue(content)];
 }
 

--- a/packages/components/src/components/tag-input/README.md
+++ b/packages/components/src/components/tag-input/README.md
@@ -12,6 +12,12 @@ Free-form token entry field that turns committed text into removable tags while 
 
 ## Guidance
 
+For native forms, pass both `name` and `commitOnSubmit` when the expected path is
+"type a tag, click Save." `TagInput` commits a valid pending draft during the
+form's submit capture phase, so `new FormData(form).getAll(name)` includes the
+same values as the hidden inputs. Invalid, duplicate, or over-limit drafts use
+the existing inline validation path and block that submit attempt.
+
 ### Use When
 
 - Collecting zero or more short free-form values such as labels, emails, or technologies.
@@ -35,6 +41,7 @@ Free-form token entry field that turns committed text into removable tags while 
 | `aria-labelledby`  | `string` \| `null`                                                                                            | no       | —       | Element ids that label both the text input and the committed-tag listbox.                                                                                  |
 | `autocapitalize`   | `"off"` \| `"on"` \| `"characters"` \| `"none"` \| `"sentences"` \| `"words"` \| `null`                       | no       | —       | Autocapitalization hint forwarded to the visible text input.                                                                                               |
 | `class`            | `string`                                                                                                      | no       | —       | Additional class merged onto the root element.                                                                                                             |
+| `commitOnSubmit`   | `boolean`                                                                                                     | no       | —       | Commit a non-empty pending draft before the parent form submits.                                                                                           |
 | `defaultValue`     | `string`[]                                                                                                    | no       | —       | Initial tags for uncontrolled usage. Ignored after mount.                                                                                                  |
 | `disabled`         | `boolean`                                                                                                     | no       | —       | Disable the input and chip removal affordances.                                                                                                            |
 | `enterkeyhint`     | `"enter"` \| `"done"` \| `"go"` \| `"next"` \| `"previous"` \| `"search"` \| `"send"` \| `null`               | no       | —       | Virtual-keyboard Enter hint forwarded to the visible text input.                                                                                           |

--- a/packages/components/src/components/tag-input/tag-input.a11y.md
+++ b/packages/components/src/components/tag-input/tag-input.a11y.md
@@ -51,6 +51,10 @@ them alongside `FormField` description and error text.
 - When `name` is provided, the component renders one hidden input per tag using
   the same field name so native form submission preserves free-form values
   without lossy delimiter encoding.
+- Set `commitOnSubmit` when the parent form should commit a non-empty pending
+  draft before submission. The submit-time commit uses the same validation,
+  duplicate, and max-tag checks as Enter and delimiter commits; invalid drafts
+  keep focusable form state in place and prevent submission.
 - In uncontrolled mode, native form reset restores `defaultValue`, clears the
   pending input buffer, and clears inline validation errors.
 - Controlled mode does not mutate itself on reset; the parent remains the source

--- a/packages/components/src/components/tag-input/tag-input.schema.json
+++ b/packages/components/src/components/tag-input/tag-input.schema.json
@@ -28,6 +28,10 @@
       "type": "boolean",
       "description": "Allow the same trimmed tag value to appear more than once."
     },
+    "commitOnSubmit": {
+      "type": "boolean",
+      "description": "Commit a non-empty pending draft before the parent form submits."
+    },
     "autocapitalize": {
       "enum": ["off", "on", "characters", "none", "sentences", "words", null],
       "description": "Autocapitalization hint forwarded to the visible text input."

--- a/packages/components/src/components/tag-input/tag-input.schema.ts
+++ b/packages/components/src/components/tag-input/tag-input.schema.ts
@@ -31,6 +31,10 @@ const schema = {
       type: 'boolean',
       description: 'Allow the same trimmed tag value to appear more than once.',
     },
+    commitOnSubmit: {
+      type: 'boolean',
+      description: 'Commit a non-empty pending draft before the parent form submits.',
+    },
     autocapitalize: {
       enum: ['off', 'on', 'characters', 'none', 'sentences', 'words', null],
       description: 'Autocapitalization hint forwarded to the visible text input.',

--- a/packages/components/src/components/tag-input/tag-input.svelte
+++ b/packages/components/src/components/tag-input/tag-input.svelte
@@ -16,7 +16,7 @@
 </script>
 
 <script lang="ts">
-  import { tick, untrack } from 'svelte';
+  import { flushSync, tick, untrack } from 'svelte';
 
   import { devWarn } from '../../utilities/dev-warn.ts';
 
@@ -41,6 +41,7 @@
     max,
     validate,
     allowDuplicates = false,
+    commitOnSubmit = false,
     disabled,
     readonly = false,
     name,
@@ -162,6 +163,20 @@
     const form = inputElement.closest('form');
     if (!form) return;
 
+    const onSubmit = (event: SubmitEvent) => {
+      if (!commitOnSubmit || field.disabled || resolvedReadonly) return;
+      if (!draftValue.trim()) return;
+
+      let committed = false;
+      flushSync(() => {
+        committed = commitDraft();
+      });
+
+      if (!committed) {
+        event.preventDefault();
+      }
+    };
+
     const onReset = () => {
       draftValue = '';
       inlineError = null;
@@ -171,8 +186,12 @@
       }
     };
 
+    form.addEventListener('submit', onSubmit, true);
     form.addEventListener('reset', onReset);
-    return () => form.removeEventListener('reset', onReset);
+    return () => {
+      form.removeEventListener('submit', onSubmit, true);
+      form.removeEventListener('reset', onReset);
+    };
   });
 
   function getChipElements(): HTMLElement[] {

--- a/packages/components/src/components/tag-input/tag-input.test.ts
+++ b/packages/components/src/components/tag-input/tag-input.test.ts
@@ -10,6 +10,10 @@ const { tick } = await import('svelte');
 const { default: TagInput } = await import('./tag-input.svelte');
 const { default: FormFieldTagInputFixture } =
   await import('../../test/fixtures/form-field-tag-input-fixture.svelte');
+const { default: TagInputFormFixture } =
+  await import('../../test/fixtures/tag-input-form-fixture.svelte');
+const { default: TagInputControlledFormFixture } =
+  await import('../../test/fixtures/tag-input-controlled-form-fixture.svelte');
 
 afterEach(() => cleanup());
 
@@ -36,17 +40,38 @@ function getRemoveButtons(container: HTMLElement): HTMLButtonElement[] {
 }
 
 function renderTagInputInForm(props: Record<string, unknown>) {
-  const form = document.createElement('form');
-  document.body.appendChild(form);
-  const result = render(TagInput, { target: form, props });
+  const result = render(TagInputFormFixture, { props });
+  const form = result.container.querySelector('form');
+  if (!form) throw new Error('form fixture did not render a form');
 
   return {
     ...result,
     form,
     cleanup() {
-      if (form.isConnected) document.body.removeChild(form);
+      result.unmount();
     },
   };
+}
+
+async function submitForm(form: HTMLFormElement): Promise<SubmitEvent> {
+  await tick();
+  let submittedEvent: SubmitEvent | null = null;
+  form.addEventListener(
+    'submit',
+    (event) => {
+      submittedEvent = event;
+    },
+    { once: true },
+  );
+  await fireEvent.submit(form);
+  if (!submittedEvent) throw new Error('submit event was not dispatched');
+  return submittedEvent;
+}
+
+function hiddenValues(container: HTMLElement, name: string): string[] {
+  return Array.from(
+    container.querySelectorAll<HTMLInputElement>(`input[type="hidden"][name="${name}"]`),
+  ).map((hiddenInput) => hiddenInput.value);
 }
 
 describe('TagInput rendering', () => {
@@ -204,6 +229,21 @@ describe('TagInput commits tags', () => {
 
     expect(getOptions(container)).toHaveLength(1);
     expect(getOptions(container)[0]?.textContent).toContain('Bun');
+    expect(input.value).toBe('');
+  });
+
+  test('RegExp delimiter strips stateful flags before repeated matching', async () => {
+    const { container } = render(TagInput, { props: { delimiter: /[,;]/gy } });
+    const input = getInput(container);
+
+    await fireEvent.input(input, { target: { value: 'Bun' } });
+    await fireEvent.keyDown(input, { key: ',' });
+    await fireEvent.input(input, { target: { value: 'Svelte' } });
+    await fireEvent.keyDown(input, { key: ',' });
+
+    expect(getOptions(container)).toHaveLength(2);
+    expect(getOptions(container)[0]?.textContent).toContain('Bun');
+    expect(getOptions(container)[1]?.textContent).toContain('Svelte');
     expect(input.value).toBe('');
   });
 
@@ -420,6 +460,199 @@ describe('TagInput form participation', () => {
     expect(hiddenInputs.map((hiddenInput) => hiddenInput.value)).toEqual(['Svelte']);
   });
 
+  test('commitOnSubmit commits a valid uncontrolled draft before form submit handlers read hidden controls', async () => {
+    const mount = renderTagInputInForm({
+      name: 'tags',
+      defaultValue: ['Svelte'],
+      commitOnSubmit: true,
+    });
+    let submittedValues: string[] = [];
+    mount.form.addEventListener('submit', (event) => {
+      event.preventDefault();
+      submittedValues = hiddenValues(mount.container, 'tags');
+    });
+
+    try {
+      const input = getInput(mount.container);
+      await fireEvent.input(input, { target: { value: 'Bun' } });
+
+      const event = await submitForm(mount.form);
+
+      expect(event.defaultPrevented).toBe(true);
+      expect(submittedValues).toEqual(['Svelte', 'Bun']);
+      expect(hiddenValues(mount.container, 'tags')).toEqual(['Svelte', 'Bun']);
+      expect(getOptions(mount.container)).toHaveLength(2);
+      expect(input.value).toBe('');
+    } finally {
+      mount.cleanup();
+    }
+  });
+
+  test('commitOnSubmit preserves current behavior when it is not enabled', async () => {
+    const mount = renderTagInputInForm({
+      name: 'tags',
+      defaultValue: ['Svelte'],
+    });
+    let submittedValues: string[] = [];
+    mount.form.addEventListener('submit', (event) => {
+      event.preventDefault();
+      submittedValues = hiddenValues(mount.container, 'tags');
+    });
+
+    try {
+      const input = getInput(mount.container);
+      await fireEvent.input(input, { target: { value: 'Bun' } });
+
+      await submitForm(mount.form);
+
+      expect(submittedValues).toEqual(['Svelte']);
+      expect(hiddenValues(mount.container, 'tags')).toEqual(['Svelte']);
+      expect(getOptions(mount.container)).toHaveLength(1);
+      expect(input.value).toBe('Bun');
+    } finally {
+      mount.cleanup();
+    }
+  });
+
+  test('commitOnSubmit blocks an invalid draft and leaves existing form data unchanged', async () => {
+    const mount = renderTagInputInForm({
+      name: 'tags',
+      commitOnSubmit: true,
+      validate: (tag: string) => (tag.includes('@') ? true : 'Enter a valid email tag.'),
+    });
+
+    try {
+      const input = getInput(mount.container);
+      await fireEvent.input(input, { target: { value: 'invalid-tag' } });
+
+      const event = await submitForm(mount.form);
+
+      expect(event.defaultPrevented).toBe(true);
+      expect(hiddenValues(mount.container, 'tags')).toEqual([]);
+      expect(getOptions(mount.container)).toHaveLength(0);
+      expect(input.value).toBe('invalid-tag');
+      expect(mount.container.textContent).toContain('Enter a valid email tag.');
+    } finally {
+      mount.cleanup();
+    }
+  });
+
+  test('commitOnSubmit blocks a duplicate draft and leaves existing form data unchanged', async () => {
+    const mount = renderTagInputInForm({
+      name: 'tags',
+      defaultValue: ['Svelte'],
+      commitOnSubmit: true,
+    });
+
+    try {
+      const input = getInput(mount.container);
+      await fireEvent.input(input, { target: { value: 'Svelte' } });
+
+      const event = await submitForm(mount.form);
+
+      expect(event.defaultPrevented).toBe(true);
+      expect(hiddenValues(mount.container, 'tags')).toEqual(['Svelte']);
+      expect(getOptions(mount.container)).toHaveLength(1);
+      expect(input.value).toBe('Svelte');
+      expect(mount.container.textContent).toContain('"Svelte" is already added.');
+    } finally {
+      mount.cleanup();
+    }
+  });
+
+  test('commitOnSubmit blocks a draft over max and leaves existing form data unchanged', async () => {
+    const mount = renderTagInputInForm({
+      name: 'tags',
+      defaultValue: ['Svelte'],
+      max: 1,
+      commitOnSubmit: true,
+    });
+
+    try {
+      const input = getInput(mount.container);
+      await fireEvent.input(input, { target: { value: 'Bun' } });
+
+      const event = await submitForm(mount.form);
+
+      expect(event.defaultPrevented).toBe(true);
+      expect(hiddenValues(mount.container, 'tags')).toEqual(['Svelte']);
+      expect(getOptions(mount.container)).toHaveLength(1);
+      expect(input.value).toBe('Bun');
+      expect(mount.container.textContent).toContain('You can add up to 1 tag.');
+    } finally {
+      mount.cleanup();
+    }
+  });
+
+  test('commitOnSubmit does not commit or block disabled tag inputs', async () => {
+    const mount = renderTagInputInForm({
+      name: 'tags',
+      defaultValue: ['Svelte'],
+      disabled: true,
+      commitOnSubmit: true,
+    });
+
+    try {
+      const input = getInput(mount.container);
+      await fireEvent.input(input, { target: { value: 'Bun' } });
+
+      const event = await submitForm(mount.form);
+
+      expect(event.defaultPrevented).toBe(false);
+      expect(hiddenValues(mount.container, 'tags')).toEqual(['Svelte']);
+      expect(mount.form.elements.namedItem('tags')).not.toBeNull();
+      expect(getOptions(mount.container)).toHaveLength(1);
+    } finally {
+      mount.cleanup();
+    }
+  });
+
+  test('commitOnSubmit does not commit or block readonly tag inputs', async () => {
+    const mount = renderTagInputInForm({
+      name: 'tags',
+      defaultValue: ['Svelte'],
+      readonly: true,
+      commitOnSubmit: true,
+    });
+
+    try {
+      const input = getInput(mount.container);
+      await fireEvent.input(input, { target: { value: 'Bun' } });
+
+      const event = await submitForm(mount.form);
+
+      expect(event.defaultPrevented).toBe(false);
+      expect(hiddenValues(mount.container, 'tags')).toEqual(['Svelte']);
+      expect(mount.form.elements.namedItem('tags')).not.toBeNull();
+      expect(getOptions(mount.container)).toHaveLength(1);
+      expect(input.value).toBe('');
+    } finally {
+      mount.cleanup();
+    }
+  });
+
+  test('commitOnSubmit supports controlled values when the parent updates onchange', async () => {
+    const onsubmit = mock<(event: SubmitEvent) => void>((event) => event.preventDefault());
+    const { container } = render(TagInputControlledFormFixture, {
+      props: {
+        name: 'tags',
+        onsubmit,
+      },
+    });
+    const form = container.querySelector('form') as HTMLFormElement;
+    const input = getInput(container);
+
+    await fireEvent.input(input, { target: { value: 'Bun' } });
+    const event = await submitForm(form);
+
+    expect(event.defaultPrevented).toBe(true);
+    expect(onsubmit).toHaveBeenCalledTimes(1);
+    expect(hiddenValues(container, 'tags')).toEqual(['Svelte', 'Bun']);
+    expect((form.elements.namedItem('tags') as RadioNodeList).length).toBe(2);
+    expect(getOptions(container)).toHaveLength(2);
+    expect(input.value).toBe('');
+  });
+
   test('disabled tag inputs do not contribute hidden values to form data', () => {
     const mount = renderTagInputInForm({
       name: 'tags',
@@ -558,6 +791,28 @@ describe('TagInput FormField wiring', () => {
 
     expect(container.querySelector('.cinder-tag-input')?.hasAttribute('data-disabled')).toBe(true);
     expect(getInput(container).disabled).toBe(true);
+  });
+
+  test('warns when the TagInput id differs from its wrapping FormField control id', () => {
+    const originalWarn = console.warn;
+    const warn = mock(() => {});
+    console.warn = warn;
+
+    try {
+      render(FormFieldTagInputFixture, {
+        props: {
+          fieldId: 'tag-field',
+          fieldLabel: 'Tags',
+          tagInputId: 'tag-input',
+        },
+      });
+
+      expect(warn).toHaveBeenCalledWith(
+        '[cinder/TagInput] id mismatch: TagInput id="tag-input" but wrapping FormField expects controlId="tag-field". Set the same id on both.',
+      );
+    } finally {
+      console.warn = originalWarn;
+    }
   });
 });
 

--- a/packages/components/src/components/tag-input/tag-input.types.ts
+++ b/packages/components/src/components/tag-input/tag-input.types.ts
@@ -34,6 +34,8 @@ export type TagInputProps = SupportedInputAttributes & {
   validate?: (tag: string) => boolean | string;
   /** Allow the same trimmed tag value to appear more than once. */
   allowDuplicates?: boolean;
+  /** Commit a non-empty pending draft before the parent form submits. */
+  commitOnSubmit?: boolean;
   /** Disable the input and chip removal affordances. */
   disabled?: boolean;
   /** Render the pending-tag input as read-only and make committed tags non-removable. */
@@ -59,6 +61,8 @@ export interface TagInputSchemaProps {
   delimiter?: string | RegExp;
   /** Allow the same trimmed tag value to appear more than once. */
   allowDuplicates?: boolean;
+  /** Commit a non-empty pending draft before the parent form submits. */
+  commitOnSubmit?: boolean;
   /** Autocomplete hint forwarded to the visible text input. */
   autocomplete?: HTMLInputAttributes['autocomplete'];
   /** Autocapitalization hint forwarded to the visible text input. */

--- a/packages/components/src/test/fixtures/form-field-tag-input-fixture.svelte
+++ b/packages/components/src/test/fixtures/form-field-tag-input-fixture.svelte
@@ -6,6 +6,7 @@
     fieldError?: string;
     fieldRequired?: boolean;
     fieldDisabled?: boolean;
+    tagInputId?: string;
     ariaLabel?: string;
     ariaLabelledby?: string;
   };
@@ -22,6 +23,7 @@
     fieldError,
     fieldRequired,
     fieldDisabled,
+    tagInputId,
     ariaLabel,
     ariaLabelledby,
   }: FormFieldTagInputFixtureProps = $props();
@@ -40,5 +42,5 @@
 </script>
 
 <FormField id={fieldId} label={fieldLabel} {...fieldOptional}>
-  <TagInput id={fieldId} {...tagInputOptional} />
+  <TagInput id={tagInputId ?? fieldId} {...tagInputOptional} />
 </FormField>

--- a/packages/components/src/test/fixtures/tag-input-controlled-form-fixture.svelte
+++ b/packages/components/src/test/fixtures/tag-input-controlled-form-fixture.svelte
@@ -1,0 +1,26 @@
+<script lang="ts" module>
+  export type TagInputControlledFormFixtureProps = {
+    name: string;
+    onsubmit?: (event: SubmitEvent) => void;
+  };
+</script>
+
+<script lang="ts">
+  import TagInput from '../../components/tag-input/tag-input.svelte';
+
+  let { name, onsubmit }: TagInputControlledFormFixtureProps = $props();
+
+  let tags = $state(['Svelte']);
+</script>
+
+<form {onsubmit}>
+  <TagInput
+    {name}
+    value={tags}
+    commitOnSubmit
+    onchange={(nextTags) => {
+      tags = nextTags;
+    }}
+  />
+  <button>Save</button>
+</form>

--- a/packages/components/src/test/fixtures/tag-input-form-fixture.svelte
+++ b/packages/components/src/test/fixtures/tag-input-form-fixture.svelte
@@ -1,0 +1,51 @@
+<script lang="ts" module>
+  export type TagInputFormFixtureProps = {
+    name?: string;
+    value?: string[];
+    defaultValue?: string[];
+    max?: number;
+    validate?: (tag: string) => boolean | string;
+    allowDuplicates?: boolean;
+    disabled?: boolean;
+    readonly?: boolean;
+    commitOnSubmit?: boolean;
+    onchange?: (tags: string[]) => void;
+    onsubmit?: (event: SubmitEvent) => void;
+  };
+</script>
+
+<script lang="ts">
+  import TagInput from '../../components/tag-input/tag-input.svelte';
+
+  let {
+    name,
+    value,
+    defaultValue,
+    max,
+    validate,
+    allowDuplicates,
+    disabled,
+    readonly,
+    commitOnSubmit,
+    onchange,
+    onsubmit,
+  }: TagInputFormFixtureProps = $props();
+
+  const tagInputProps = $derived({
+    ...(name !== undefined ? { name } : {}),
+    ...(value !== undefined ? { value } : {}),
+    ...(defaultValue !== undefined ? { defaultValue } : {}),
+    ...(max !== undefined ? { max } : {}),
+    ...(validate !== undefined ? { validate } : {}),
+    ...(allowDuplicates !== undefined ? { allowDuplicates } : {}),
+    ...(disabled !== undefined ? { disabled } : {}),
+    ...(readonly !== undefined ? { readonly } : {}),
+    ...(commitOnSubmit !== undefined ? { commitOnSubmit } : {}),
+    ...(onchange !== undefined ? { onchange } : {}),
+  });
+</script>
+
+<form {onsubmit}>
+  <TagInput {...tagInputProps} />
+  <button>Save</button>
+</form>

--- a/packages/playground/src/discover.test.ts
+++ b/packages/playground/src/discover.test.ts
@@ -303,8 +303,10 @@ describe('discoverSidebarComponents', () => {
     // ActionRow adds one selectable row primitive with examples, bringing the
     // measured ceiling to 165. ChatComposerPopover adds one standalone composer
     // suggestion primitive with examples, bringing the measured ceiling to 166.
+    // InlineLoading and KanbanBoard each add a standalone sidebar family with
+    // examples, bringing the measured ceiling to 168.
     const sidebar = await discoverSidebarComponents();
-    expect(sidebar.length).toBeLessThanOrEqual(166);
+    expect(sidebar.length).toBeLessThanOrEqual(168);
     // Positive anchor for the +1: stacked-list-item is the family the #394
     // backfill newly surfaces, so it must actually be present. Without this the
     // upper-bound alone would silently pass if the regression that dropped it
@@ -344,6 +346,8 @@ describe('discoverSidebarComponents', () => {
     expect(sidebar).toContain('event-timeline');
     expect(sidebar).toContain('source-diff-viewer');
     expect(sidebar).toContain('chat-composer-popover');
+    expect(sidebar).toContain('inline-loading');
+    expect(sidebar).toContain('kanban-board');
   });
 
   it('keeps the sidebar strictly smaller than the full component list', async () => {


### PR DESCRIPTION
## Summary
- Add TagInput `commitOnSubmit` support so pending valid drafts can be committed during form submission before hidden-input serialization.
- Preserve default submit behavior unless `commitOnSubmit` is opted in; invalid, duplicate, and max-exceeding drafts block submit while disabled/readonly inputs no-op.
- Add regression coverage and docs/generated artifacts for the public API.

## Verification
- `bun run --filter=@lostgradient/cinder test -- ./src/components/tag-input/tag-input.test.ts`
- `bun run --filter=@lostgradient/cinder components:generate`
- `bun run --filter=@lostgradient/cinder components:check`
- `bun run --filter=@lostgradient/cinder exports:check`
- `bun run typecheck`
- `bun run --filter=@lostgradient/cinder test:coverage`
- `bun run validate` (workspace validation passed through root/package gates; final consumer validation was rerun after a local lock cleared)
- `bun run --filter=@lostgradient/cinder validate:consumer`
- `bun test packages/playground/src/discover.test.ts -t "keeps the sidebar at or below"`
- `bun run --filter=@cinder/playground test`
- Pre-push full validation

Closes #715

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Opt-in TagInput form behavior with broad regression tests; chat builder changes are validation and test-only tightening, not new runtime APIs.
> 
> **Overview**
> Adds an opt-in **`commitOnSubmit`** prop to **TagInput** so a non-empty pending tag can be committed during the parent form’s submit **capture** phase (`flushSync` + existing `commitDraft` validation). When enabled with `name`, hidden inputs and `FormData` can include the draft on submit; invalid, duplicate, or over-`max` drafts **prevent** submit. Disabled and readonly inputs skip commit and do not block submission. Default behavior is unchanged when the prop is off.
> 
> The public API is documented (README, a11y notes, JSON/TS schemas) with a **minor** changeset; package version moves to **0.10.0** in the lockfile.
> 
> **TagInput** tests gain form fixtures and coverage for controlled/uncontrolled submit paths, delimiter `RegExp` flag handling, and FormField id mismatch warnings.
> 
> **Chat** `appendMessages` tightens **`tokenUsage`** checks (non-number values error) and expands builder tests for reasoning/tool content parts and duplicate tool-call ids; content normalization no longer throws directly in `normalizeContent`—invalid shapes are rejected via the existing loose input guard.
> 
> Playground **discover** sidebar ceiling/assertions are bumped for **inline-loading** and **kanban-board**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2f1bbd9934c1020a1cf4b3e062aaea4602151eb8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->