### PR TITLE
Diagnose coverage-ratchet failures: report uncovered files+lines, upload CI lcov

### DIFF
--- a/.github/workflows/main-green.yaml
+++ b/.github/workflows/main-green.yaml
@@ -132,6 +132,18 @@ jobs:
       - name: Run component coverage ratchet
         run: bun run --filter=@lostgradient/cinder test:coverage
 
+      # Upload the LCOV report even on failure so a coverage regression that only
+      # reproduces in CI (different tests run than a local build) can be diagnosed
+      # from the exact per-line data instead of guessed at.
+      - name: Upload coverage LCOV
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: component-coverage-lcov
+          path: packages/components/coverage/lcov.info
+          if-no-files-found: warn
+          retention-days: 7
+
   component-tests:
     name: component-tests (${{ matrix.chunk }}/4)
     runs-on: ubuntu-latest

--- a/bun.lock
+++ b/bun.lock
@@ -43,7 +43,7 @@
     },
     "packages/components": {
       "name": "@lostgradient/cinder",
-      "version": "0.9.0",
+      "version": "0.10.0",
       "bin": {
         "cinder": "./dist/cli/index.js",
       },

--- a/packages/components/scripts/check-coverage-ratchet.test.ts
+++ b/packages/components/scripts/check-coverage-ratchet.test.ts
@@ -5,9 +5,11 @@ import {
   computeCoverageAverages,
   coverageFailures,
   formatCoverageSummary,
+  formatLineRanges,
   parseCoverageThresholds,
   parseLcovRecords,
   parseSvelteLcovRecords,
+  uncoveredLineReport,
 } from './check-coverage-ratchet.ts';
 
 const packageRoot = join(import.meta.dir, '..');
@@ -655,5 +657,75 @@ end_of_record
     expect(formatCoverageSummary(averages, { functions: 0.7, lines: 0.7 })).toBe(
       'Coverage ratchet (2 files): functions 75.00% >= 70.00% lines 75.00% >= 70.00%',
     );
+  });
+
+  describe('uncoveredLineReport', () => {
+    const gapFixture = `TN:
+SF:${join(packageRoot, 'src/components/chat/builders.ts')}
+DA:10,1
+DA:11,0
+DA:12,0
+DA:13,0
+DA:20,0
+LF:5
+LH:1
+end_of_record
+TN:
+SF:${join(packageRoot, 'src/components/chat/chat.svelte')}
+DA:1,0
+LF:1
+LH:0
+end_of_record
+TN:
+SF:${join(packageRoot, 'scripts/some-script.ts')}
+DA:1,0
+LF:1
+LH:0
+end_of_record
+`;
+
+    test('lists the unhit line numbers of in-scope runtime files, excluding svelte and scripts', () => {
+      const report = uncoveredLineReport(gapFixture, 'runtime');
+      expect(report).toEqual([
+        { file: 'src/components/chat/builders.ts', unhitLines: [11, 12, 13, 20] },
+      ]);
+    });
+
+    test('scopes to svelte sources when asked', () => {
+      const report = uncoveredLineReport(gapFixture, 'svelte');
+      expect(report).toEqual([{ file: 'src/components/chat/chat.svelte', unhitLines: [1] }]);
+    });
+
+    test('reports the unhit line of a partially covered in-scope file', () => {
+      expect(uncoveredLineReport(lcovFixture, 'runtime')).toEqual([
+        { file: 'partial.ts', unhitLines: [2] },
+      ]);
+    });
+
+    test('returns an empty report when the in-scope file is fully covered', () => {
+      const fullyCovered = `TN:
+SF:${join(packageRoot, 'src/utilities/example.ts')}
+DA:1,1
+DA:2,3
+LF:2
+LH:2
+end_of_record
+`;
+      expect(uncoveredLineReport(fullyCovered, 'runtime')).toEqual([]);
+    });
+  });
+
+  describe('formatLineRanges', () => {
+    test('condenses consecutive line numbers into ranges', () => {
+      expect(formatLineRanges([11, 12, 13, 20])).toBe('11-13, 20');
+    });
+
+    test('handles single lines, gaps, and unsorted input', () => {
+      expect(formatLineRanges([7, 1, 2, 9, 3])).toBe('1-3, 7, 9');
+    });
+
+    test('returns an empty string for no lines', () => {
+      expect(formatLineRanges([])).toBe('');
+    });
   });
 });

--- a/packages/components/scripts/check-coverage-ratchet.ts
+++ b/packages/components/scripts/check-coverage-ratchet.ts
@@ -292,6 +292,66 @@ function formatThreshold(value: number): string {
   return formatPercentage(value * 100);
 }
 
+/**
+ * The unhit line numbers of every in-scope file that has at least one, keyed by
+ * the same scope filters the ratchet aggregates over. A bare "runtime lines
+ * 99.88% < 100%" failure is otherwise un-actionable in CI, where the coverage
+ * environment (which tests run, which modules load) can differ from a local
+ * build and the offending lines are invisible in the logs.
+ */
+export function uncoveredLineReport(
+  source: string,
+  scope: CoverageScope,
+): { file: string; unhitLines: number[] }[] {
+  const report: { file: string; unhitLines: number[] }[] = [];
+  for (const rawRecord of source.split('end_of_record')) {
+    const lines = rawRecord.split(/\r?\n/);
+    const sourceFile = lines.find((line) => line.startsWith('SF:'))?.slice('SF:'.length);
+    if (sourceFile === undefined || sourceFile === '') continue;
+    if (
+      isTransientTestArtifact(sourceFile) ||
+      isOutsidePackageRootSourceMap(sourceFile) ||
+      isOutsideCoverageScope(sourceFile, scope)
+    ) {
+      continue;
+    }
+    const unhitLines: number[] = [];
+    for (const line of lines) {
+      if (!line.startsWith('DA:')) continue;
+      const [lineNumber, hitCount] = line.slice('DA:'.length).split(',');
+      if (hitCount === '0' && lineNumber !== undefined) unhitLines.push(Number(lineNumber));
+    }
+    if (unhitLines.length > 0) {
+      report.push({ file: toPackageRootRelativePath(sourceFile), unhitLines });
+    }
+  }
+  return report;
+}
+
+/** Condense a sorted line-number list into compact ranges: `[1,2,3,7] → "1-3, 7"`. */
+export function formatLineRanges(lineNumbers: number[]): string {
+  const sorted = [...new Set(lineNumbers)].toSorted((a, b) => a - b);
+  const ranges: string[] = [];
+  let start: number | undefined;
+  let previous: number | undefined;
+  for (const line of sorted) {
+    if (start === undefined || previous === undefined) {
+      start = line;
+      previous = line;
+    } else if (line === previous + 1) {
+      previous = line;
+    } else {
+      ranges.push(start === previous ? `${start}` : `${start}-${previous}`);
+      start = line;
+      previous = line;
+    }
+  }
+  if (start !== undefined && previous !== undefined) {
+    ranges.push(start === previous ? `${start}` : `${start}-${previous}`);
+  }
+  return ranges.join(', ');
+}
+
 export async function main(): Promise<void> {
   const thresholds = parseCoverageThresholds(await Bun.file(defaultThresholdsPath).text());
   const coverageSource = await Bun.file(defaultCoveragePath).text();
@@ -311,6 +371,19 @@ export async function main(): Promise<void> {
 
   if (failures.length > 0) {
     console.error(`${summaries.join('\n')} Failed: ${failures.join(', ')}.`);
+    const scopesToReport: CoverageScope[] = [];
+    if (failures.some((failure) => failure.startsWith('runtime lines')))
+      scopesToReport.push('runtime');
+    if (failures.some((failure) => failure.startsWith('svelte lines')))
+      scopesToReport.push('svelte');
+    for (const scope of scopesToReport) {
+      const gaps = uncoveredLineReport(coverageSource, scope);
+      if (gaps.length === 0) continue;
+      console.error(`\nUncovered ${scope} lines (${gaps.length} file(s)):`);
+      for (const { file, unhitLines } of gaps) {
+        console.error(`  ${file}: ${formatLineRanges(unhitLines)}`);
+      }
+    }
     process.exit(1);
   }
 


### PR DESCRIPTION
## Why

`main-green` has been red since #703 (commit ab121fac): the `component-coverage` job fails the ratchet with runtime lines ~99.88% < 100%. The failure only reproduces in CI (a local build measures 100%, because a different set of `test.each` cases runs), and the ratchet only logs an aggregate percentage — so the actual uncovered lines are invisible and the regression can't be fixed. This blocks the automated npm publish for the whole repo (0.10.0 is versioned but unpublished).

## What

Diagnostics only — **the ratchet is not weakened**:

- `uncoveredLineReport()` / `formatLineRanges()` in `check-coverage-ratchet.ts`: on a lines-coverage failure, print each in-scope file below 100% with its unhit line numbers as compact ranges (e.g. `src/components/chat/builders.ts: 11-13, 40`). Uses the same scope filters the aggregate already applies.
- `main-green.yaml`: upload `packages/components/coverage/lcov.info` as an artifact (`if: always()`) so the exact per-line data is downloadable when a failure only reproduces in CI.

Both are covered by unit tests in `check-coverage-ratchet.test.ts`.

## Follow-up

Once this merges, the next `main-green` run will print the exact uncovered lines from #703's chat rewrite; a follow-up PR will add the regression test that covers them, turning `main-green` green and unblocking the release.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI and test-tooling changes only; coverage gates are not relaxed and no production runtime behavior changes.
> 
> **Overview**
> Improves **coverage ratchet diagnostics** when CI fails on line thresholds—the aggregate percentage alone is hard to act on when failures only reproduce in CI.
> 
> On **runtime** or **svelte** lines failures, `check-coverage-ratchet` now logs each in-scope file below 100% with **compact unhit line ranges** (via new `uncoveredLineReport` and `formatLineRanges`), using the same scope filters as the existing aggregate.
> 
> **`main-green`** uploads `packages/components/coverage/lcov.info` as a workflow artifact (`if: always()`, 7-day retention) so per-line data can be downloaded when local runs differ from CI.
> 
> Thresholds are unchanged; unit tests cover the new reporting helpers. `bun.lock` reflects **`@lostgradient/cinder` 0.10.0**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6c1b0d24f02ed8bbc8d913f4aa98c8e711aa19a6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->