### PR TITLE
Fix NavigationBar menu toggle hydration

### DIFF
--- a/packages/components/src/components/navigation-bar/navigation-bar.svelte
+++ b/packages/components/src/components/navigation-bar/navigation-bar.svelte
@@ -290,7 +290,7 @@
       {@render menuToggle({
         'aria-expanded': (mobileMenuOpen ? 'true' : 'false') as 'true' | 'false',
         'aria-controls': regionId,
-        ...(browser ? { onclick: handleToggle } : {}),
+        onclick: handleToggle,
       })}
     </div>
   {/if}
@@ -306,7 +306,7 @@
       {@render menuToggle({
         'aria-expanded': (mobileMenuOpen ? 'true' : 'false') as 'true' | 'false',
         'aria-controls': regionId,
-        ...(browser ? { onclick: handleToggle } : {}),
+        onclick: handleToggle,
       })}
     </div>
   {/if}

--- a/packages/components/src/components/navigation-bar/navigation-bar.test.ts
+++ b/packages/components/src/components/navigation-bar/navigation-bar.test.ts
@@ -216,8 +216,8 @@ function cancelingNavigationSnippet(clicks: Record<string, number>) {
 
 describe('NavigationBar', () => {
   test('passes the toggle click handler through the same snippet shape during SSR and hydration', () => {
-    expect(navigationBarSource).not.toContain('browser ? { onclick: handleToggle } : {}');
-    expect(navigationBarSource.match(/onclick: handleToggle/g)).toHaveLength(2);
+    expect(navigationBarSource).not.toMatch(/browser\s*\?\s*{\s*onclick:\s*handleToggle/);
+    expect([...navigationBarSource.matchAll(/onclick:\s*handleToggle/g)]).toHaveLength(2);
   });
 
   // ── Legacy tests (preserved) ────────────────────────────────────────────

--- a/packages/components/src/components/navigation-bar/navigation-bar.test.ts
+++ b/packages/components/src/components/navigation-bar/navigation-bar.test.ts
@@ -23,6 +23,10 @@ const { default: NavigationBar } = await import('./navigation-bar.svelte');
 const { createRawSnippet, tick } = await import('svelte');
 
 const navigationBarCss = readFileSync(new URL('./navigation-bar.css', import.meta.url), 'utf8');
+const navigationBarSource = readFileSync(
+  new URL('./navigation-bar.svelte', import.meta.url),
+  'utf8',
+);
 
 class CapturingResizeObserver implements ResizeObserver {
   static lastCallback: ResizeObserverCallback | null = null;
@@ -211,6 +215,11 @@ function cancelingNavigationSnippet(clicks: Record<string, number>) {
 }
 
 describe('NavigationBar', () => {
+  test('passes the toggle click handler through the same snippet shape during SSR and hydration', () => {
+    expect(navigationBarSource).not.toContain('browser ? { onclick: handleToggle } : {}');
+    expect(navigationBarSource.match(/onclick: handleToggle/g)).toHaveLength(2);
+  });
+
   // ── Legacy tests (preserved) ────────────────────────────────────────────
 
   test('root element is <nav>', () => {


### PR DESCRIPTION
## Summary
- keep the `menuToggle` snippet argument shape identical during SSR and hydration
- always provide the toggle click handler so SvelteKit dev consumers attach it during hydration
- add a regression test guarding both toggle placements

## Validation
- `bun run --filter=@lostgradient/cinder test -- navigation-bar.test.ts`
- `bun run validate`
- pre-push scoped validation

Closes #709

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to snippet props for the collapsible menu toggle; behavior is unchanged in the browser and only fixes SSR/hydration parity.
> 
> **Overview**
> Fixes **NavigationBar** mobile menu toggles failing to wire up clicks after SvelteKit hydration when consumers attach `onclick` from the `menuToggle` snippet.
> 
> The `menuToggle` snippet args no longer gate `onclick: handleToggle` behind `browser` (which omitted the handler on SSR). Both **before-brand** and **after-brand** placements now always pass the same object shape, including `onclick`, so server HTML and client hydration match.
> 
> A **source-level regression test** asserts the conditional pattern is gone and that both toggle sites still pass `handleToggle`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 355e17b17ee1ed575b8036b45d25ff4ca3cdc29a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->