### PR TITLE
Relocate compensation steps beneath forward steps

### DIFF
--- a/.changeset/quiet-timelines-reverse.md
+++ b/.changeset/quiet-timelines-reverse.md
@@ -1,0 +1,5 @@
+---
+'@lostgradient/cinder': patch
+---
+
+Render compensation steps directly beneath the forward-step subtree they reverse.

--- a/packages/components/src/components/run-step-timeline/run-step-timeline.svelte
+++ b/packages/components/src/components/run-step-timeline/run-step-timeline.svelte
@@ -99,6 +99,8 @@
     laneOutcomeBadgeVariant,
     laneOutcomeLabel,
     metadataItems,
+    relocateCompensationEntries,
+    relocateCompensationSteps,
     safeStepLinkHref,
     statusDotStatus,
     statusLabel,
@@ -120,7 +122,7 @@
     ariaLabelledby === undefined && ariaLabel === undefined ? label : ariaLabel,
   );
 
-  const renderedEntries = $derived(flattenEntries(steps));
+  const renderedEntries = $derived(flattenEntries(relocateCompensationEntries(steps)));
 
   function isBranchGroup(entry: RunStepTimelineEntry): entry is RunStepBranchGroup {
     return 'kind' in entry && entry.kind === 'branch';
@@ -245,7 +247,7 @@
   // compensation labels. Reused for the main rail and for each branch lane.
   function flattenSteps(list: RunStep[], pathPrefix: string): RenderedStepLike[] {
     const rows: PendingStepRow[] = [];
-    appendRunStepRows(rows, list, 0, pathPrefix);
+    appendRunStepRows(rows, relocateCompensationSteps(list), 0, pathPrefix);
     const currentRowIndex = deepestCurrentStepIndex(rows);
 
     // Index every step row by its unique path key (built from the escaped id
@@ -301,7 +303,7 @@
       rows.push({ kind: 'step', step, depth, pathKey });
       if (step.children && step.children.length > 0) {
         if (depth < MAX_NESTED_STEP_DEPTH) {
-          appendRunStepRows(rows, step.children, depth + 1, pathKey);
+          appendRunStepRows(rows, relocateCompensationSteps(step.children), depth + 1, pathKey);
         } else {
           const hiddenSummary = summarizeNestedRunSteps(step.children);
           rows.push({

--- a/packages/components/src/components/run-step-timeline/run-step-timeline.test.ts
+++ b/packages/components/src/components/run-step-timeline/run-step-timeline.test.ts
@@ -1520,6 +1520,15 @@ describe('compensation', () => {
     expect(rootRowLabels(container)).toEqual(['Charge', 'Refund']);
   });
 
+  test('treats a step with an unrelated extra kind property as a step', () => {
+    const steps = [
+      { id: 'refund', label: 'Refund', status: 'succeeded', compensates: 'charge', kind: 'task' },
+      { id: 'charge', label: 'Charge', status: 'succeeded', kind: 'task' },
+    ] as unknown as RunStepTimelineEntry[];
+    const { container } = render(RunStepTimeline, { steps });
+    expect(rootRowLabels(container)).toEqual(['Charge', 'Refund']);
+  });
+
   test('keeps multiple compensations in consumer order beneath their forward step', () => {
     const steps: RunStepTimelineEntry[] = [
       { id: 'charge', label: 'Charge', status: 'succeeded' },

--- a/packages/components/src/components/run-step-timeline/run-step-timeline.test.ts
+++ b/packages/components/src/components/run-step-timeline/run-step-timeline.test.ts
@@ -1489,6 +1489,78 @@ describe('rewound steps', () => {
 });
 
 describe('compensation', () => {
+  function rootRowLabels(container: HTMLElement): string[] {
+    const rootList = container.querySelector('ol.cinder-run-step-timeline');
+    return [...(rootList?.children ?? [])].map(
+      (element) => element.querySelector('.cinder-run-step-timeline__label')?.textContent ?? '',
+    );
+  }
+
+  test('relocates a compensation directly beneath its forward step subtree by default', () => {
+    const steps: RunStepTimelineEntry[] = [
+      {
+        id: 'charge',
+        label: 'Charge',
+        status: 'succeeded',
+        children: [{ id: 'receipt', label: 'Send receipt', status: 'succeeded' }],
+      },
+      { id: 'reserve', label: 'Reserve seat', status: 'failed' },
+      { id: 'refund', label: 'Refund', status: 'succeeded', compensates: 'charge' },
+    ];
+    const { container } = render(RunStepTimeline, { steps });
+    expect(rootRowLabels(container)).toEqual(['Charge', 'Send receipt', 'Refund', 'Reserve seat']);
+  });
+
+  test('relocates a compensation even when it precedes its forward step', () => {
+    const steps: RunStepTimelineEntry[] = [
+      { id: 'refund', label: 'Refund', status: 'succeeded', compensates: 'charge' },
+      { id: 'charge', label: 'Charge', status: 'succeeded' },
+    ];
+    const { container } = render(RunStepTimeline, { steps });
+    expect(rootRowLabels(container)).toEqual(['Charge', 'Refund']);
+  });
+
+  test('keeps multiple compensations in consumer order beneath their forward step', () => {
+    const steps: RunStepTimelineEntry[] = [
+      { id: 'charge', label: 'Charge', status: 'succeeded' },
+      { id: 'other', label: 'Other', status: 'succeeded' },
+      { id: 'refund', label: 'Refund', status: 'succeeded', compensates: 'charge' },
+      { id: 'credit', label: 'Credit', status: 'succeeded', compensates: 'charge' },
+    ];
+    const { container } = render(RunStepTimeline, { steps });
+    expect(rootRowLabels(container)).toEqual(['Charge', 'Refund', 'Credit', 'Other']);
+  });
+
+  test('relocates within a branch lane but never across lane boundaries', () => {
+    const group: RunStepBranchGroup = {
+      kind: 'branch',
+      id: 'saga',
+      label: 'Saga',
+      lanes: [
+        {
+          id: 'one',
+          label: 'One',
+          steps: [
+            { id: 'charge', label: 'Charge', status: 'succeeded' },
+            { id: 'other', label: 'Other', status: 'succeeded' },
+            { id: 'refund', label: 'Refund', status: 'succeeded', compensates: 'charge' },
+          ],
+        },
+        {
+          id: 'two',
+          label: 'Two',
+          steps: [{ id: 'undo', label: 'Undo', status: 'succeeded', compensates: 'charge' }],
+        },
+      ],
+    };
+    const { container } = render(RunStepTimeline, { steps: [group] });
+    const lanes = container.querySelectorAll('.cinder-run-step-timeline__lane');
+    expect((lanes[0]?.textContent ?? '').indexOf('Refund')).toBeLessThan(
+      (lanes[0]?.textContent ?? '').indexOf('Other'),
+    );
+    expect(lanes[1]?.querySelector('[data-cinder-compensation]')).toBeNull();
+  });
+
   test('insets and labels a step that compensates a resolvable forward step', () => {
     const steps: RunStepTimelineEntry[] = [
       { id: 'charge', label: 'Charge card', status: 'succeeded' },

--- a/packages/components/src/components/run-step-timeline/run-step-timeline.test.ts
+++ b/packages/components/src/components/run-step-timeline/run-step-timeline.test.ts
@@ -1540,6 +1540,16 @@ describe('compensation', () => {
     expect(rootRowLabels(container)).toEqual(['Charge', 'Refund', 'Credit', 'Other']);
   });
 
+  test('keeps cyclic compensation links in consumer order', () => {
+    const steps: RunStepTimelineEntry[] = [
+      { id: 'undo-b', label: 'Undo B', status: 'succeeded', compensates: 'undo-a' },
+      { id: 'middle', label: 'Middle', status: 'succeeded' },
+      { id: 'undo-a', label: 'Undo A', status: 'succeeded', compensates: 'undo-b' },
+    ];
+    const { container } = render(RunStepTimeline, { steps });
+    expect(rootRowLabels(container)).toEqual(['Undo B', 'Middle', 'Undo A']);
+  });
+
   test('relocates within a branch lane but never across lane boundaries', () => {
     const group: RunStepBranchGroup = {
       kind: 'branch',

--- a/packages/components/src/components/run-step-timeline/run-step-timeline.utilities.ts
+++ b/packages/components/src/components/run-step-timeline/run-step-timeline.utilities.ts
@@ -5,7 +5,80 @@ import type {
   RunStepBranchLane,
   RunStepBranchLaneOutcome,
   RunStepStatus,
+  RunStepTimelineEntry,
 } from './run-step-timeline.types.ts';
+
+/**
+ * Relocate resolved compensation steps immediately after the subtree of the
+ * sibling they reverse. Unresolved, self-referential, and cyclic links retain
+ * consumer order. Multiple compensations retain their relative input order.
+ */
+export function relocateCompensationSteps(steps: RunStep[]): RunStep[] {
+  return relocateSiblingItems(steps, (step) => step);
+}
+
+function relocateSiblingItems<T>(items: T[], getStep: (item: T) => RunStep | undefined): T[] {
+  const stepById = new Map<string, RunStep>();
+  for (const item of items) {
+    const step = getStep(item);
+    if (step !== undefined) {
+      stepById.set(step.id, step);
+    }
+  }
+  const canRelocate = (step: RunStep): boolean => {
+    const visited = new Set<string>([step.id]);
+    let targetId = step.compensates;
+    while (targetId !== undefined) {
+      const target = stepById.get(targetId);
+      if (target === undefined || visited.has(targetId)) return false;
+      visited.add(targetId);
+      targetId = target.compensates;
+    }
+    return true;
+  };
+  const relocatable = new Set<RunStep>();
+  const compensationsByTarget = new Map<string, T[]>();
+  for (const item of items) {
+    const step = getStep(item);
+    if (step === undefined || step.compensates === undefined || !canRelocate(step)) continue;
+    relocatable.add(step);
+    const compensations = compensationsByTarget.get(step.compensates) ?? [];
+    compensations.push(item);
+    compensationsByTarget.set(step.compensates, compensations);
+  }
+  const result: T[] = [];
+  const appendWithCompensations = (item: T): void => {
+    result.push(item);
+    const step = getStep(item);
+    if (step === undefined) return;
+    for (const compensation of compensationsByTarget.get(step.id) ?? []) {
+      appendWithCompensations(compensation);
+    }
+  };
+  for (const item of items) {
+    const step = getStep(item);
+    if (step === undefined || !relocatable.has(step)) appendWithCompensations(item);
+  }
+  return result;
+}
+
+/** Relocate top-level compensations while preserving branch rows as rail entries. */
+export function relocateCompensationEntries(
+  entries: RunStepTimelineEntry[],
+): RunStepTimelineEntry[] {
+  const normalized = entries.map((entry) =>
+    'kind' in entry
+      ? {
+          ...entry,
+          lanes: entry.lanes.map((lane) => ({
+            ...lane,
+            steps: relocateCompensationSteps(lane.steps),
+          })),
+        }
+      : entry,
+  );
+  return relocateSiblingItems(normalized, (entry) => ('kind' in entry ? undefined : entry));
+}
 
 /** Badge variants used for the per-step status chip. */
 export type RunStepBadgeVariant = 'neutral' | 'success' | 'warning' | 'danger' | 'info' | 'accent';

--- a/packages/components/src/components/run-step-timeline/run-step-timeline.utilities.ts
+++ b/packages/components/src/components/run-step-timeline/run-step-timeline.utilities.ts
@@ -66,18 +66,7 @@ function relocateSiblingItems<T>(items: T[], getStep: (item: T) => RunStep | und
 export function relocateCompensationEntries(
   entries: RunStepTimelineEntry[],
 ): RunStepTimelineEntry[] {
-  const normalized = entries.map((entry) =>
-    isBranchGroup(entry)
-      ? {
-          ...entry,
-          lanes: entry.lanes.map((lane) => ({
-            ...lane,
-            steps: relocateCompensationSteps(lane.steps),
-          })),
-        }
-      : entry,
-  );
-  return relocateSiblingItems(normalized, (entry) => (isBranchGroup(entry) ? undefined : entry));
+  return relocateSiblingItems(entries, (entry) => (isBranchGroup(entry) ? undefined : entry));
 }
 
 function isBranchGroup(entry: RunStepTimelineEntry): entry is RunStepBranchGroup {

--- a/packages/components/src/components/run-step-timeline/run-step-timeline.utilities.ts
+++ b/packages/components/src/components/run-step-timeline/run-step-timeline.utilities.ts
@@ -67,7 +67,7 @@ export function relocateCompensationEntries(
   entries: RunStepTimelineEntry[],
 ): RunStepTimelineEntry[] {
   const normalized = entries.map((entry) =>
-    'kind' in entry
+    isBranchGroup(entry)
       ? {
           ...entry,
           lanes: entry.lanes.map((lane) => ({
@@ -77,7 +77,11 @@ export function relocateCompensationEntries(
         }
       : entry,
   );
-  return relocateSiblingItems(normalized, (entry) => ('kind' in entry ? undefined : entry));
+  return relocateSiblingItems(normalized, (entry) => (isBranchGroup(entry) ? undefined : entry));
+}
+
+function isBranchGroup(entry: RunStepTimelineEntry): entry is RunStepBranchGroup {
+  return 'kind' in entry && entry.kind === 'branch';
 }
 
 /** Badge variants used for the per-step status chip. */

--- a/packages/components/src/components/run-step-timeline/run-step-timeline.utilities.ts
+++ b/packages/components/src/components/run-step-timeline/run-step-timeline.utilities.ts
@@ -18,6 +18,8 @@ export function relocateCompensationSteps(steps: RunStep[]): RunStep[] {
 }
 
 function relocateSiblingItems<T>(items: T[], getStep: (item: T) => RunStep | undefined): T[] {
+  if (!items.some((item) => getStep(item)?.compensates !== undefined)) return items;
+
   const stepById = new Map<string, RunStep>();
   for (const item of items) {
     const step = getStep(item);


### PR DESCRIPTION
## Summary
- relocate resolved compensation steps directly beneath their forward step subtree by default
- preserve stable ordering for multiple compensations and fallback ordering for unresolved, cyclic, or cross-lane references
- cover top-level, nested, forward-later, multiple-compensation, and branch-lane cases

## Validation
- `bun run --filter=@lostgradient/cinder test -- run-step-timeline`
- `bun run typecheck`
- `bun run validate`
- `bun run format:check`

Closes #712

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-order change only in the timeline flatten pipeline; existing compensation labeling and edge-case behavior are preserved and expanded with tests.
> 
> **Overview**
> **Run step timeline** now reorders steps with `compensates` so resolved undo steps appear **directly after** the forward step’s subtree (including nested children), instead of wherever the consumer listed them.
> 
> New helpers `relocateCompensationSteps` and `relocateCompensationEntries` run before flattening at the top level, within each sibling list, and inside nested children. **Branch groups** stay fixed on the rail; relocation only moves steps among siblings in the same list. **Unresolved**, **cyclic**, or **invalid** compensation links keep the original order; multiple compensations for one target keep their relative input order.
> 
> Tests cover forward-later ordering, multiple compensations, cycles, branch-lane scoping, and steps that carry an unrelated `kind` field. Patch changeset for `@lostgradient/cinder`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 77d349d1334bad3e8184701f9108a55316cfcc60. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->