### PR TITLE
Fix published Svelte hydration identity

### DIFF
--- a/.changeset/steady-chat-hydration.md
+++ b/.changeset/steady-chat-hydration.md
@@ -1,0 +1,5 @@
+---
+'@lostgradient/cinder': patch
+---
+
+Keep published Svelte source and server bundles on the same scoped-style identity so SSR component trees hydrate without mismatches.

--- a/packages/components/fixtures/sveltekit-consumer/src/routes/chat-layout/+page.svelte
+++ b/packages/components/fixtures/sveltekit-consumer/src/routes/chat-layout/+page.svelte
@@ -1,25 +1,10 @@
 <script lang="ts">
-  import Chat, {
-    appendAssistantMessage,
-    appendUserMessage,
-    createConversation,
-  } from '@lostgradient/cinder/chat';
+  import Chat, { createConversation } from '@lostgradient/cinder/chat';
 
-  const conversation = (() => {
-    let nextConversation = createConversation({ id: 'consumer-chat-layout' });
-
-    for (let index = 0; index < 24; index += 1) {
-      nextConversation = appendUserMessage(nextConversation, `Question ${index + 1}`);
-      nextConversation = appendAssistantMessage(
-        nextConversation,
-        `Answer ${index + 1} with enough text to make the transcript taller than the bounded fixture.`,
-      );
-    }
-
-    return nextConversation;
-  })();
+  const conversation = createConversation({ id: 'consumer-chat-layout' });
 </script>
 
+<h1>Empty Chat hydration</h1>
 <main class="chat-layout-fixture">
   <Chat id="consumer-chat-layout" {conversation} />
 </main>

--- a/packages/components/scripts/svelte-plugin.test.ts
+++ b/packages/components/scripts/svelte-plugin.test.ts
@@ -3,7 +3,30 @@ import { describe, expect, it } from 'bun:test';
 import {
   findOneArgumentServerComponentBoundaries,
   preserveServerComponentIdentity,
+  publishedSvelteCompileFilename,
 } from './svelte-plugin.ts';
+
+describe('publishedSvelteCompileFilename', () => {
+  it('normalizes workspace and installed package sources to the same filename', () => {
+    const expected = 'node_modules/@lostgradient/cinder/src/components/chat/container/chat.svelte';
+
+    expect(
+      publishedSvelteCompileFilename(
+        '/checkout/packages/components/src/components/chat/container/chat.svelte',
+      ),
+    ).toBe(expected);
+    expect(
+      publishedSvelteCompileFilename(
+        '/consumer/node_modules/@lostgradient/cinder/src/components/chat/container/chat.svelte',
+      ),
+    ).toBe(expected);
+  });
+
+  it('leaves components outside the published package unchanged', () => {
+    const playgroundPath = '/checkout/packages/playground/src/app.svelte';
+    expect(publishedSvelteCompileFilename(playgroundPath)).toBe(playgroundPath);
+  });
+});
 
 describe('preserveServerComponentIdentity', () => {
   it('adds the exported component identity to one-argument server component boundaries', () => {

--- a/packages/components/scripts/svelte-plugin.ts
+++ b/packages/components/scripts/svelte-plugin.ts
@@ -17,6 +17,34 @@ const DOMAIN_SUITE_STYLE_COMPONENTS = new Set([
   'review-editor',
 ]);
 
+const PUBLISHED_PACKAGE_SOURCE_PREFIX = 'node_modules/@lostgradient/cinder/';
+
+/**
+ * Give authored package components the same filename in workspace builds that
+ * Vite gives their published source. Svelte's default scoped-CSS hash includes
+ * the compiler filename, so an absolute checkout path in `dist/server` and the
+ * package-relative client source path otherwise produce different class names
+ * and cannot hydrate each other.
+ */
+export function publishedSvelteCompileFilename(filePath: string): string {
+  const normalizedPath = filePath.replaceAll('\\', '/');
+  const installedSourceMarker = `/${PUBLISHED_PACKAGE_SOURCE_PREFIX}`;
+  const installedSourceIndex = normalizedPath.lastIndexOf(installedSourceMarker);
+  if (installedSourceIndex >= 0) {
+    return normalizedPath.slice(installedSourceIndex + 1);
+  }
+
+  const workspaceSourceMarker = '/packages/components/';
+  const workspaceSourceIndex = normalizedPath.lastIndexOf(workspaceSourceMarker);
+  if (workspaceSourceIndex >= 0) {
+    return `${PUBLISHED_PACKAGE_SOURCE_PREFIX}${normalizedPath.slice(
+      workspaceSourceIndex + workspaceSourceMarker.length,
+    )}`;
+  }
+
+  return filePath;
+}
+
 function allowsStyleBlock(path: string): boolean {
   const normalizedPath = path.replaceAll('\\', '/');
 
@@ -172,11 +200,12 @@ export function sveltePlugin(
     setup(builder) {
       builder.onLoad({ filter: /\.svelte$/ }, async ({ path }) => {
         const source = await Bun.file(path).text();
+        const filename = publishedSvelteCompileFilename(path);
         const isPlaygroundFile = path.replaceAll('\\', '/').includes('/packages/playground/');
         const css = isPlaygroundFile || injectCss ? 'injected' : 'external';
         const dev = process.env['NODE_ENV'] !== 'production';
         const compileResult = compile(source, {
-          filename: path,
+          filename,
           generate: options.generate,
           css,
           // Read the same environment source that `scripts/build.ts` writes before `Bun.build()`

--- a/packages/components/scripts/validate-consumers.ts
+++ b/packages/components/scripts/validate-consumers.ts
@@ -1120,6 +1120,8 @@ async function assertSvelteKitDevSsrRoute(fixtureDirectory: string, label: strin
       );
     }
 
+    await assertSvelteKitClientHydrates(httpPort, label, '/chat-layout');
+
     devSsrAssertionsPassed = true;
   } finally {
     devServer.kill();
@@ -1393,6 +1395,7 @@ async function runSveltekitFixture(label = 'workspace', svelteVersion?: string):
       }
 
       await assertSvelteKitClientHydrates(httpPort, label, '/subpath');
+      await assertSvelteKitClientHydrates(httpPort, label, '/chat-layout');
 
       // Subpath page
       const subpathResponse = await fetchWithTimeout(
@@ -1503,7 +1506,7 @@ async function runSveltekitFixture(label = 'workspace', svelteVersion?: string):
 async function assertSvelteKitClientHydrates(
   httpPort: number,
   label: string,
-  routePath: '/subpath',
+  routePath: '/subpath' | '/chat-layout',
 ): Promise<void> {
   const { chromium } = await import('@playwright/test');
   const browser = await promiseWithTimeout(
@@ -1531,9 +1534,16 @@ async function assertSvelteKitClientHydrates(
 
     await page.goto(`http://127.0.0.1:${httpPort}${routePath}`, { waitUntil: 'domcontentloaded' });
     await page.waitForLoadState('load', { timeout: 5_000 });
-    await page.getByRole('heading', { name: /subpath imports/i }).waitFor({ timeout: 5_000 });
-    await page.getByRole('button', { name: 'subpath button' }).waitFor({ timeout: 5_000 });
-    await page.getByRole('button', { name: 'Subpath accordion' }).waitFor({ timeout: 5_000 });
+    if (routePath === '/subpath') {
+      await page.getByRole('heading', { name: /subpath imports/i }).waitFor({ timeout: 5_000 });
+      await page.getByRole('button', { name: 'subpath button' }).waitFor({ timeout: 5_000 });
+      await page.getByRole('button', { name: 'Subpath accordion' }).waitFor({ timeout: 5_000 });
+    } else {
+      await page.getByRole('heading', { name: 'Empty Chat hydration' }).waitFor({ timeout: 5_000 });
+      await page.getByText('No messages yet').waitFor({ timeout: 5_000 });
+      await page.getByRole('textbox', { name: 'Message' }).waitFor({ timeout: 5_000 });
+      await page.getByText('0 messages in conversation').waitFor({ timeout: 5_000 });
+    }
     if (errors.length > 0) {
       fail(
         `sveltekit-consumer ${label} ${routePath} emitted client hydration/runtime errors:\n${errors.map((error) => `  ${error}`).join('\n')}`,

--- a/packages/components/src/components/chat/chat.hydration.test.ts
+++ b/packages/components/src/components/chat/chat.hydration.test.ts
@@ -1,0 +1,82 @@
+/// <reference lib="dom" />
+/** Full server-render-and-hydrate regression coverage for the public Chat tree. */
+import { afterAll, describe, expect, test } from 'bun:test';
+
+import { setupHappyDom } from '../../test/happy-dom.ts';
+import { renderThenHydrate } from '../../test/hydrate.ts';
+import type { ConversationHistory } from './conversation-model.ts';
+
+setupHappyDom();
+
+class TestResizeObserver {
+  observe(): void {}
+  unobserve(): void {}
+  disconnect(): void {}
+}
+
+class TestIntersectionObserver {
+  observe(): void {}
+  unobserve(): void {}
+  disconnect(): void {}
+  takeRecords(): IntersectionObserverEntry[] {
+    return [];
+  }
+}
+
+const originalResizeObserver = globalThis.ResizeObserver;
+const originalIntersectionObserver = globalThis.IntersectionObserver;
+globalThis.ResizeObserver = TestResizeObserver as unknown as typeof ResizeObserver;
+globalThis.IntersectionObserver =
+  TestIntersectionObserver as unknown as typeof IntersectionObserver;
+
+afterAll(() => {
+  globalThis.ResizeObserver = originalResizeObserver;
+  globalThis.IntersectionObserver = originalIntersectionObserver;
+});
+
+const { default: Chat } = await import('./chat.svelte');
+const sourcePath = new URL('./chat.svelte', import.meta.url).pathname;
+
+const emptyConversation: ConversationHistory = {
+  schemaVersion: 4,
+  id: 'empty-hydration-conversation',
+  status: 'active',
+  metadata: {},
+  ids: [],
+  messages: {},
+  createdAt: '2026-01-01T00:00:00.000Z',
+  updatedAt: '2026-01-01T00:00:00.000Z',
+};
+
+describe('Chat hydration', () => {
+  test('hydrates an empty conversation without changing the server-rendered surface', async () => {
+    const result = await renderThenHydrate(Chat, sourcePath, {
+      id: 'stable-empty-chat',
+      conversation: emptyConversation,
+      virtualized: true,
+    });
+
+    try {
+      const hydrationWarnings = result.warnings.filter((warning) =>
+        warning.toLowerCase().includes('hydration'),
+      );
+      expect(hydrationWarnings).toEqual([]);
+
+      expect(result.ssrHtml).toContain('No messages yet');
+      expect(result.container.querySelector('.chat-empty')?.textContent).toContain(
+        'No messages yet',
+      );
+      expect(result.container.querySelector('#stable-empty-chat-input-editor')).not.toBeNull();
+      expect(result.container.querySelector('#stable-empty-chat-status')?.textContent).toContain(
+        '0 messages in conversation',
+      );
+
+      const timeline = result.container.querySelector('#stable-empty-chat-timeline');
+      expect(timeline?.getAttribute('data-cinder-virtualized')).toBeNull();
+      expect(result.container.querySelector('[aria-live="assertive"]')).not.toBeNull();
+      expect(result.container.querySelectorAll('[aria-live="polite"]').length).toBeGreaterThan(0);
+    } finally {
+      result.cleanup();
+    }
+  });
+});

--- a/packages/components/src/test/hydrate.test.ts
+++ b/packages/components/src/test/hydrate.test.ts
@@ -93,4 +93,20 @@ describe('renderThenHydrate', () => {
     // cleanup()'s own unlink is a harmless no-op.
     result.cleanup();
   });
+
+  test('keeps temp files registered when synchronous removal fails', () => {
+    const path = join(import.meta.dir, '.cinder-ssr-removal-failure.mjs');
+    __tempFileRegistryForTests.registerPath(path);
+
+    __tempFileRegistryForTests.removePath(path, () => {
+      throw Object.assign(new Error('permission denied'), { code: 'EACCES' });
+    });
+
+    expect(__tempFileRegistryForTests.paths.has(path)).toBe(true);
+
+    __tempFileRegistryForTests.removePath(path, () => {
+      throw Object.assign(new Error('already removed'), { code: 'ENOENT' });
+    });
+    expect(__tempFileRegistryForTests.paths.has(path)).toBe(false);
+  });
 });

--- a/packages/components/src/test/hydrate.ts
+++ b/packages/components/src/test/hydrate.ts
@@ -101,15 +101,24 @@ const pendingTempFiles = new Set<string>();
 
 let exitHandlersRegistered = false;
 
+function removeRegisteredTempFile(
+  path: string,
+  removeFile: (filePath: string) => void = unlinkSync,
+): void {
+  try {
+    removeFile(path);
+    pendingTempFiles.delete(path);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+      pendingTempFiles.delete(path);
+    }
+  }
+}
+
 /** Synchronously remove every still-registered temp file. Safe to call twice. */
 function cleanupRegisteredTempFiles(): void {
   for (const path of pendingTempFiles) {
-    try {
-      unlinkSync(path);
-    } catch {
-      // Already gone (per-test cleanup beat us to it) — ignore.
-    }
-    pendingTempFiles.delete(path);
+    removeRegisteredTempFile(path);
   }
 }
 
@@ -144,9 +153,13 @@ function ensureExitHandlersRegistered(): void {
  */
 export const __tempFileRegistryForTests: {
   paths: ReadonlySet<string>;
+  registerPath: (path: string) => void;
+  removePath: (path: string, removeFile?: (filePath: string) => void) => void;
   runExitCleanup: () => void;
 } = {
   paths: pendingTempFiles,
+  registerPath: (path) => pendingTempFiles.add(path),
+  removePath: removeRegisteredTempFile,
   runExitCleanup: cleanupRegisteredTempFiles,
 };
 
@@ -310,12 +323,7 @@ export async function renderThenHydrate<Props extends Record<string, unknown>>(
     // rethrow for the test to observe.
     container?.remove();
     for (const tempFile of [file, serverRuntimeShimPath]) {
-      try {
-        unlinkSync(tempFile);
-      } catch {
-        // Already gone — ignore.
-      }
-      pendingTempFiles.delete(tempFile);
+      removeRegisteredTempFile(tempFile);
     }
     throw error;
   }
@@ -347,12 +355,7 @@ export async function renderThenHydrate<Props extends Record<string, unknown>>(
       // handler skips already-deregistered paths). Best-effort — a unlink failure
       // doesn't break the test; the path stays registered for the exit sweep.
       for (const tempFile of [file, serverRuntimeShimPath]) {
-        try {
-          unlinkSync(tempFile);
-          pendingTempFiles.delete(tempFile);
-        } catch {
-          // Leave it registered so the exit-handler safety net still sweeps it.
-        }
+        removeRegisteredTempFile(tempFile);
       }
     },
   };

--- a/packages/components/src/test/hydrate.ts
+++ b/packages/components/src/test/hydrate.ts
@@ -9,12 +9,13 @@
  * - Has DOM-property-only state (e.g. Checkbox `indeterminate`)
  * - Uses portals or overlay surfaces
  *
- * Why we recompile inside the helper: the test runtime preloads the Bun Svelte
+ * Why we rebuild inside the helper: the test runtime preloads the Bun Svelte
  * plugin in `generate: 'client'` mode (see `scripts/preload.ts`). Calling
  * `svelte/server`'s `render()` against a client-compiled component crashes
- * because the client runtime expects a live effect tree. So this helper reads
- * the `.svelte` source directly, compiles it with `generate: 'server'`, writes
- * the JS to a temp file, dynamic-imports it, and feeds that into `render()`.
+ * because the client runtime expects a live effect tree. So this helper builds
+ * the component and its complete local Svelte import graph with
+ * `generate: 'server'`, writes the bundled JS to a temp file, dynamic-imports
+ * it, and feeds that into `render()`.
  *
  * The helper does NOT itself assert — it returns a structured result so each
  * component test can express the contract it cares about (e.g. "no warnings"
@@ -26,15 +27,69 @@
 
 /// <reference lib="dom" />
 
-import { unlinkSync } from 'node:fs';
-import { writeFile } from 'node:fs/promises';
-import { dirname, join } from 'node:path';
+import type { BunPlugin } from 'bun';
+import { existsSync, unlinkSync } from 'node:fs';
+import { dirname, isAbsolute, join, resolve } from 'node:path';
 import { pathToFileURL } from 'node:url';
 
 import { hydrate, type Component } from 'svelte';
-import { compile } from 'svelte/compiler';
+import { compile, compileModule } from 'svelte/compiler';
 
 import { setupHappyDom } from './happy-dom.ts';
+
+function serverCompilePlugin(): BunPlugin {
+  const namespace = 'hydrate-svelte-server';
+  const isFileSpecifier = (specifier: string): boolean =>
+    isAbsolute(specifier) || specifier.startsWith('.');
+
+  return {
+    name: 'hydrate-svelte-server',
+    setup(builder) {
+      builder.onResolve({ filter: /\.svelte$/ }, ({ path, importer, resolveDir }) => {
+        if (!isFileSpecifier(path)) return undefined;
+        const baseDirectory = importer ? dirname(importer) : resolveDir;
+        const resolvedPath = isAbsolute(path) ? path : resolve(baseDirectory, path);
+        return {
+          path: existsSync(resolvedPath) ? resolvedPath : `${resolvedPath}.ts`,
+          namespace,
+        };
+      });
+
+      builder.onLoad({ filter: /\.svelte$/, namespace }, async ({ path }) => {
+        const source = await Bun.file(path).text();
+        const result = compile(source, {
+          filename: path,
+          generate: 'server',
+          css: 'external',
+          dev: true,
+        });
+        return { contents: result.js.code, loader: 'js' };
+      });
+
+      builder.onResolve({ filter: /\.svelte\.(js|ts)$/ }, ({ path, importer, resolveDir }) => {
+        if (!isFileSpecifier(path)) return undefined;
+        const baseDirectory = importer ? dirname(importer) : resolveDir;
+        return {
+          path: isAbsolute(path) ? path : resolve(baseDirectory, path),
+          namespace,
+        };
+      });
+
+      builder.onLoad({ filter: /\.svelte\.(js|ts)$/, namespace }, async ({ path }) => {
+        const source = await Bun.file(path).text();
+        const moduleSource = path.endsWith('.ts')
+          ? new Bun.Transpiler({ loader: 'ts' }).transformSync(source)
+          : source;
+        const result = compileModule(moduleSource, {
+          filename: path,
+          generate: 'server',
+          dev: true,
+        });
+        return { contents: result.js.code, loader: 'js' };
+      });
+    },
+  };
+}
 
 /**
  * Every temp SSR module this helper writes is registered here. The per-test
@@ -108,8 +163,8 @@ export type HydrateResult = {
 };
 
 /**
- * Render `clientComponent` on the server (by recompiling its source file in
- * `generate: 'server'` mode), then hydrate the resulting markup on the client
+ * Render `clientComponent` on the server (by rebuilding its local Svelte import
+ * graph in `generate: 'server'` mode), then hydrate the resulting markup on the client
  * with the already-loaded client compilation.
  *
  * @param clientComponent The client-compiled component (the default import from a `.svelte` file).
@@ -124,24 +179,30 @@ export async function renderThenHydrate<Props extends Record<string, unknown>>(
 ): Promise<HydrateResult> {
   setupHappyDom();
 
-  const source = await Bun.file(sourcePath).text();
-  const compiled = compile(source, {
-    filename: sourcePath,
-    generate: 'server',
-    css: 'external',
-    dev: false,
+  const build = await Bun.build({
+    entrypoints: [sourcePath],
+    target: 'bun',
+    conditions: ['svelte'],
+    external: ['svelte', 'svelte/*'],
+    plugins: [serverCompilePlugin()],
   });
-  // Resolve svelte's location from the hydrate helper's own directory so it
-  // works regardless of process.cwd() (which varies when tests run from the
-  // package root vs the monorepo root).
-  const sveltePackageJson = new URL(import.meta.resolve('svelte/package.json')).pathname;
-  const serverSvelteEntry = pathToFileURL(
-    join(dirname(sveltePackageJson), 'src/index-server.js'),
-  ).href;
-  const serverCode = compiled.js.code.replaceAll(
-    "from 'svelte';",
-    `from ${JSON.stringify(serverSvelteEntry)};`,
-  );
+  if (!build.success) {
+    const logText = build.logs.map((log) => String(log.message ?? log)).join('\n');
+    throw new Error(`hydrate: server build failed for ${sourcePath}\n${logText}`);
+  }
+  const artifact = build.outputs[0];
+  if (!artifact) throw new Error(`hydrate: no server artifact for ${sourcePath}`);
+
+  const sveltePackageUrl = import.meta.resolve('svelte/package.json');
+  const serverAbortSignalUrl = new URL('./src/internal/server/abort-signal.js', sveltePackageUrl)
+    .href;
+  const serverContextUrl = new URL('./src/internal/server/context.js', sveltePackageUrl).href;
+  const serverErrorsUrl = new URL('./src/internal/server/errors.js', sveltePackageUrl).href;
+  const serverHydratableUrl = new URL('./src/internal/server/hydratable.js', sveltePackageUrl).href;
+  const serverInternalUrl = new URL('./src/internal/server/index.js', sveltePackageUrl).href;
+  const serverSnippetUrl = new URL('./src/internal/server/blocks/snippet.js', sveltePackageUrl)
+    .href;
+  const sharedUtilitiesUrl = new URL('./src/internal/shared/utils.js', sveltePackageUrl).href;
 
   // Write the compiled SSR module to a tmp file. We can't use a Blob URL or
   // a `data:` URL because the SSR module imports `svelte/internal/server`,
@@ -155,10 +216,13 @@ export async function renderThenHydrate<Props extends Record<string, unknown>>(
   // Use a `.mjs` extension so Bun's `.svelte.js` preload plugin filter doesn't
   // try to recompile our already-compiled SSR output.
   const sourceDir = dirname(sourcePath);
-  const ssrFileName = `.cinder-ssr-${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2)}.mjs`;
-  const file = join(sourceDir, ssrFileName);
+  const ssrFileName = `.cinder-ssr-${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+  const file = join(sourceDir, `${ssrFileName}.mjs`);
+  const serverRuntimeShimPath = join(sourceDir, `${ssrFileName}.svelte-server.mjs`);
+  const serverRuntimeShimUrl = pathToFileURL(serverRuntimeShimPath).href;
   ensureExitHandlersRegistered();
   pendingTempFiles.add(file);
+  pendingTempFiles.add(serverRuntimeShimPath);
 
   // Everything from the temp-file write through the hydrate is wrapped so that
   // any failure BEFORE we return a `cleanup()` to the caller still removes and
@@ -170,7 +234,36 @@ export async function renderThenHydrate<Props extends Record<string, unknown>>(
   const warnings: string[] = [];
   let instance: Record<string, unknown> | undefined;
   try {
-    await writeFile(file, serverCode, 'utf-8');
+    await Bun.write(
+      serverRuntimeShimPath,
+      [
+        `import { ssr_context } from ${JSON.stringify(serverContextUrl)};`,
+        `import { noop } from ${JSON.stringify(sharedUtilitiesUrl)};`,
+        `import * as e from ${JSON.stringify(serverErrorsUrl)};`,
+        `export { noop as beforeUpdate, noop as afterUpdate, noop as onMount, noop as flushSync, run as untrack } from ${JSON.stringify(sharedUtilitiesUrl)};`,
+        `export { createContext, getAllContexts, getContext, hasContext, setContext } from ${JSON.stringify(serverContextUrl)};`,
+        `export { getAbortSignal } from ${JSON.stringify(serverAbortSignalUrl)};`,
+        `export { hydratable } from ${JSON.stringify(serverHydratableUrl)};`,
+        `export { createRawSnippet } from ${JSON.stringify(serverSnippetUrl)};`,
+        'export function createEventDispatcher() { return noop; }',
+        'export function onDestroy(fn) { ssr_context.r.on_destroy(fn); }',
+        'export async function tick() {}',
+        'export async function settled() {}',
+        "export function mount() { e.lifecycle_function_unavailable('mount'); }",
+        "export function hydrate() { e.lifecycle_function_unavailable('hydrate'); }",
+        "export function unmount() { e.lifecycle_function_unavailable('unmount'); }",
+        "export function fork() { e.lifecycle_function_unavailable('fork'); }",
+        '',
+      ].join('\n'),
+    );
+    let serverCode = await artifact.text();
+    serverCode = serverCode
+      .replaceAll(
+        /from\s*['"]svelte\/internal\/server['"]/g,
+        `from ${JSON.stringify(serverInternalUrl)}`,
+      )
+      .replaceAll(/from\s*['"]svelte['"]/g, `from ${JSON.stringify(serverRuntimeShimUrl)}`);
+    await Bun.write(file, serverCode);
 
     // The SSR module's default export is a server-only render function whose
     // shape (`($$renderer, $$props) => void`) doesn't match the public
@@ -216,12 +309,14 @@ export async function renderThenHydrate<Props extends Record<string, unknown>>(
     // before the rm settled (the exit handler skips deregistered paths). Finally
     // rethrow for the test to observe.
     container?.remove();
-    try {
-      unlinkSync(file);
-    } catch {
-      // Already gone — ignore.
+    for (const tempFile of [file, serverRuntimeShimPath]) {
+      try {
+        unlinkSync(tempFile);
+      } catch {
+        // Already gone — ignore.
+      }
+      pendingTempFiles.delete(tempFile);
     }
-    pendingTempFiles.delete(file);
     throw error;
   }
 
@@ -251,11 +346,13 @@ export async function renderThenHydrate<Props extends Record<string, unknown>>(
       // file if rm() failed or the process exited before it settled (the exit
       // handler skips already-deregistered paths). Best-effort — a unlink failure
       // doesn't break the test; the path stays registered for the exit sweep.
-      try {
-        unlinkSync(file);
-        pendingTempFiles.delete(file);
-      } catch {
-        // Leave it registered so the exit-handler safety net still sweeps it.
+      for (const tempFile of [file, serverRuntimeShimPath]) {
+        try {
+          unlinkSync(tempFile);
+          pendingTempFiles.delete(tempFile);
+        } catch {
+          // Leave it registered so the exit-handler safety net still sweeps it.
+        }
       }
     },
   };

--- a/packages/components/src/test/hydrate.ts
+++ b/packages/components/src/test/hydrate.ts
@@ -283,7 +283,7 @@ export async function renderThenHydrate<Props extends Record<string, unknown>>(
     // `Component<Props>` type. `svelte/server.render` accepts both shapes at
     // runtime; we route through `unknown` because the public types are too
     // narrow to express the dual-target reality.
-    const ssrModule = (await import(file)) as { default: unknown };
+    const ssrModule = (await import(pathToFileURL(file).href)) as { default: unknown };
 
     const { render } = (await import('svelte/server')) as typeof import('svelte/server');
     const originalDocument = globalThis.document;


### PR DESCRIPTION
## Summary

- normalize package component compiler filenames so staged server bundles and published client source generate identical scoped CSS hashes
- extend the hydration helper to server-build complete local Svelte component graphs and add an empty Chat regression test
- exercise the packed empty Chat route in both development and production SvelteKit consumer validation

## Verification

- `bun run validate`
- pre-commit and pre-push hooks

Closes #746