### PR TITLE
Fix Chat SSR hydration state capture

### DIFF
--- a/.changeset/chat-hydration.md
+++ b/.changeset/chat-hydration.md
@@ -1,0 +1,5 @@
+---
+'@lostgradient/cinder': patch
+---
+
+Fix Chat SSR hydration stability for empty conversations.

--- a/packages/components/src/components/chat/chat.hydration.test.ts
+++ b/packages/components/src/components/chat/chat.hydration.test.ts
@@ -4,6 +4,7 @@ import { afterAll, describe, expect, test } from 'bun:test';
 
 import { setupHappyDom } from '../../test/happy-dom.ts';
 import { renderThenHydrate } from '../../test/hydrate.ts';
+import { createConversation } from './builders.ts';
 import type { ConversationHistory } from './conversation-model.ts';
 
 setupHappyDom();
@@ -49,6 +50,32 @@ const emptyConversation: ConversationHistory = {
 };
 
 describe('Chat hydration', () => {
+  test('hydrates a createConversation snapshot without a mismatch warning', async () => {
+    const conversation = createConversation(
+      {
+        id: 'default-environment-conversation',
+      },
+      {
+        now: () => '2026-01-01T00:00:00.000Z',
+      },
+    );
+    const result = await renderThenHydrate(Chat, sourcePath, {
+      id: 'default-environment-chat',
+      conversation,
+    });
+
+    try {
+      expect(
+        result.warnings.filter((warning) => warning.toLowerCase().includes('hydration')),
+      ).toEqual([]);
+      expect(result.container.querySelector('.chat-empty')?.textContent).toContain(
+        'No messages yet',
+      );
+    } finally {
+      result.cleanup();
+    }
+  });
+
   test('hydrates an empty conversation without changing the server-rendered surface', async () => {
     const result = await renderThenHydrate(Chat, sourcePath, {
       id: 'stable-empty-chat',

--- a/packages/components/src/components/chat/container/chat.svelte
+++ b/packages/components/src/components/chat/container/chat.svelte
@@ -272,7 +272,7 @@
   // C5 — suggested replies are a per-TURN affordance shown only beneath the last
   // message, not on every historical message that still carries the metadata.
   const lastMessageId = $derived(messages.at(-1)?.id);
-  let previousAutoScrollMessageCount = getMessages(conversation).length;
+  let previousAutoScrollMessageCount = $state(messages.length);
 
   // The conversation id as a stable VALUE dependency. The subscribe effect keys
   // on this (not on `conversation.id` read inline) so a consumer passing a fresh


### PR DESCRIPTION
## Summary

- avoid capturing the initial Chat conversation prop in the auto-scroll counter
- add hydration regression coverage for a `createConversation` snapshot
- add a patch changeset for the published Chat package

Closes #756.

## Validation

- `bun test packages/components/src/components/chat/chat.hydration.test.ts`
- scoped pre-push validation for Cinder and playground
