### PR TITLE
fix(chat): widen conversationalist peer range

### DIFF
--- a/.changeset/wide-chat-conversationalist-peer.md
+++ b/.changeset/wide-chat-conversationalist-peer.md
@@ -1,0 +1,5 @@
+---
+'@lostgradient/chat': patch
+---
+
+Widen the supported `conversationalist` peer range to include `0.4.x` and verify the packed consumer surface against the current package.

--- a/bun.lock
+++ b/bun.lock
@@ -21,14 +21,14 @@
     },
     "packages/chat": {
       "name": "@lostgradient/chat",
-      "version": "0.0.0",
+      "version": "0.1.0",
       "devDependencies": {
         "@lostgradient/cinder": "workspace:*",
         "@sveltejs/package": "^2.5.8",
         "@testing-library/svelte": "^5.2.7",
         "@types/bun": "^1.3.11",
         "ajv": "^8",
-        "conversationalist": "^0.2.1",
+        "conversationalist": "^0.4.1",
         "happy-dom": "^15.11.7",
         "oxlint": "^1.56.0",
         "postcss": "^8.5.15",
@@ -40,7 +40,7 @@
       },
       "peerDependencies": {
         "@lostgradient/cinder": "^0.16.0",
-        "conversationalist": "^0.2.1",
+        "conversationalist": "^0.2.1 || ^0.4.1",
         "svelte": ">=5.56.0 <6",
         "zod": "4.4.1",
       },
@@ -69,7 +69,7 @@
     },
     "packages/components": {
       "name": "@lostgradient/cinder",
-      "version": "0.15.0",
+      "version": "0.16.0",
       "bin": {
         "cinder": "./dist/cli/index.js",
       },
@@ -266,6 +266,8 @@
   "packages": {
     "@adobe/css-tools": ["@adobe/css-tools@4.4.4", "", {}, "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg=="],
 
+    "@anthropic-ai/sdk": ["@anthropic-ai/sdk@0.71.2", "", { "dependencies": { "json-schema-to-ts": "^3.1.1" }, "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" }, "optionalPeers": ["zod"], "bin": { "anthropic-ai-sdk": "bin/cli" } }, "sha512-TGNDEUuEstk/DKu0/TflXAEt+p+p/WhTlFzEnoosvbaDU2LTjm42igSdlL0VijrKpWejtOKxX0b8A7uc+XiSAQ=="],
+
     "@axe-core/playwright": ["@axe-core/playwright@4.11.3", "", { "dependencies": { "axe-core": "~4.11.4" }, "peerDependencies": { "playwright-core": ">= 1.0.0" } }, "sha512-h/kfksv4F0cVIDlKpT4700OehdRgpvuVskuQ2nb7/JmtWUXpe9ftHAPtwyXGvVSsa6SJ64A9ER7Zrzc/sIvC4w=="],
 
     "@babel/code-frame": ["@babel/code-frame@7.29.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.28.5", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw=="],
@@ -388,8 +390,6 @@
 
     "@lostgradient/cinder": ["@lostgradient/cinder@workspace:packages/components"],
 
-    "@lostgradient/weft": ["@lostgradient/weft@0.8.0", "", { "dependencies": { "@msgpack/msgpack": "^3.1.3", "zod": "^4.3.6" }, "optionalDependencies": { "@valibot/to-json-schema": "^1.7.0" }, "peerDependencies": { "@libsql/client": "^0.17.2", "@neondatabase/serverless": "^1.1.0", "@opentelemetry/api": "^1.0.0", "better-sqlite3": "^12.8.0", "lmdb": "^3.5.2" }, "optionalPeers": ["@libsql/client", "@neondatabase/serverless", "@opentelemetry/api", "better-sqlite3", "lmdb"], "bin": { "weft": "dist/cli-main.js", "weft-mcp": "dist/mcp/cli.js" } }, "sha512-fwCo8i3Ctg8+CSD1bS+L/z63B9RkkXs8j5lrvAopVTUsaJPLpQT+VMvrPikb+nk8f3YpJ3hVECEVLsdvQDC/Qw=="],
-
     "@manypkg/find-root": ["@manypkg/find-root@1.1.0", "", { "dependencies": { "@babel/runtime": "^7.5.5", "@types/node": "^12.7.1", "find-up": "^4.1.0", "fs-extra": "^8.1.0" } }, "sha512-mki5uBvhHzO8kYYix/WRy2WX8S3B5wdVSc9D6KcU5lQNglP2yt58/VfLuAK49glRXChosY8ap2oJ1qgma3GUVA=="],
 
     "@manypkg/get-packages": ["@manypkg/get-packages@1.1.3", "", { "dependencies": { "@babel/runtime": "^7.5.5", "@changesets/types": "^4.0.1", "@manypkg/find-root": "^1.1.0", "fs-extra": "^8.1.0", "globby": "^11.0.0", "read-yaml-file": "^1.1.0" } }, "sha512-fo+QhuU3qE/2TQMQmbVMqaQ6EWbMhi4ABWP+O4AM1NqPBuy0OrApV5LO6BrrgnhtAHS2NH6RrVk9OL181tTi8A=="],
@@ -437,8 +437,6 @@
     "@milkdown/utils": ["@milkdown/utils@7.20.0", "", { "dependencies": { "@milkdown/core": "7.20.0", "@milkdown/ctx": "7.20.0", "@milkdown/exception": "7.20.0", "@milkdown/prose": "7.20.0", "@milkdown/transformer": "7.20.0", "nanoid": "^5.0.9" } }, "sha512-ciEhtLKhIW/Kaz/NRE5DUXVoMCdenn7S4mClrO7sZ/nXtmObnk3okJzSDnamQoDOcLOIbpOu1V3E1Btkvc5x9w=="],
 
     "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.29.0", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ=="],
-
-    "@msgpack/msgpack": ["@msgpack/msgpack@3.1.3", "", {}, "sha512-47XIizs9XZXvuJgoaJUIE2lFoID8ugvc0jzSHP+Ptfk8nTbnR8g788wv48N03Kx0UkAv559HWRQ3yzOgzlRNUA=="],
 
     "@nodelib/fs.scandir": ["@nodelib/fs.scandir@2.1.5", "", { "dependencies": { "@nodelib/fs.stat": "2.0.5", "run-parallel": "^1.1.9" } }, "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g=="],
 
@@ -570,8 +568,6 @@
 
     "@ungap/structured-clone": ["@ungap/structured-clone@1.3.0", "", {}, "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g=="],
 
-    "@valibot/to-json-schema": ["@valibot/to-json-schema@1.7.1", "", { "peerDependencies": { "valibot": "^1.4.0" } }, "sha512-3qkmU6KXWh8GIThEAW3kuRHPQBMjWkKy+Ppz3WkUucx53DTpOa6siMn4xDGSOhlVyMrDaJTCTMLYPZVAIk1P0A=="],
-
     "@vue/compiler-core": ["@vue/compiler-core@3.5.33", "", { "dependencies": { "@babel/parser": "^7.29.2", "@vue/shared": "3.5.33", "entities": "^7.0.1", "estree-walker": "^2.0.2", "source-map-js": "^1.2.1" } }, "sha512-3PZLQwFw4Za3TC8t0FvTy3wI16Kt+pmwcgNZca4Pj9iWL2E72a/gZlpBtAJvEdDMdCxdG/qq0C7PN0bsJuv0Rw=="],
 
     "@vue/compiler-dom": ["@vue/compiler-dom@3.5.33", "", { "dependencies": { "@vue/compiler-core": "3.5.33", "@vue/shared": "3.5.33" } }, "sha512-PXq0yrfCLzzL07rbXO4awtXY1Z06LG2eu6Adg3RJFa/j3Cii217XxxLXG22N330gw7GmALCY0Z8RgXEviwgpjA=="],
@@ -688,7 +684,7 @@
 
     "content-type": ["content-type@1.0.5", "", {}, "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA=="],
 
-    "conversationalist": ["conversationalist@0.2.1", "", { "dependencies": { "@lostgradient/weft": "^0.8.0", "gray-matter": "^4.0.3" }, "peerDependencies": { "zod": "^4.0.0" } }, "sha512-1nIeZ1HSya9CAAkSbiPDVC6BhLw1hr1B9tbsl3qxOG6GkQx4hUVogOdkMD+RumeG5S5dmZ+3Mzo6BKFI8NaeSQ=="],
+    "conversationalist": ["conversationalist@0.4.1", "", { "dependencies": { "gray-matter": "^4.0.3" }, "peerDependencies": { "@anthropic-ai/sdk": "^0.71.2", "zod": "^4.4.1" } }, "sha512-yyxjA5gQq4y6pNfZfMPXww9VV+odjOXwo7O2T+YjWNjZIdc9YdnJHQLq/8gRf8/EnP76l7L9NW+xV8xtMyfzdQ=="],
 
     "cookie": ["cookie@0.7.2", "", {}, "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="],
 
@@ -967,6 +963,8 @@
     "js-yaml": ["js-yaml@4.1.1", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA=="],
 
     "json-parse-even-better-errors": ["json-parse-even-better-errors@2.3.1", "", {}, "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w=="],
+
+    "json-schema-to-ts": ["json-schema-to-ts@3.1.1", "", { "dependencies": { "@babel/runtime": "^7.18.3", "ts-algebra": "^2.0.0" } }, "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g=="],
 
     "json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
 
@@ -1426,6 +1424,8 @@
 
     "trough": ["trough@2.2.0", "", {}, "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw=="],
 
+    "ts-algebra": ["ts-algebra@2.0.0", "", {}, "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw=="],
+
     "ts-morph": ["ts-morph@28.0.0", "", { "dependencies": { "@ts-morph/common": "~0.29.0", "code-block-writer": "^13.0.3" } }, "sha512-Wp3tnZ2bzwxyTZMtgWVzXDfm7lB1Drz+y9DmmYH/L702PQhPyVrp3pkou3yIz4qjS14GY9kcpmLiOOMvl8oG1g=="],
 
     "type-is": ["type-is@2.1.0", "", { "dependencies": { "content-type": "^2.0.0", "media-typer": "^1.1.0", "mime-types": "^3.0.0" } }, "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA=="],
@@ -1457,8 +1457,6 @@
     "unpipe": ["unpipe@1.0.0", "", {}, "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ=="],
 
     "util-deprecate": ["util-deprecate@1.0.2", "", {}, "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="],
-
-    "valibot": ["valibot@1.4.2", "", { "peerDependencies": { "typescript": ">=5" }, "optionalPeers": ["typescript"] }, "sha512-gjdCvJ6d3RyHAneqxMYMW9QMCwYMb3jpOO0IyHZV1bnRHFBHrX3VkIILt5XYR0WhwHiH7Mty8ovuPZ/O3gamrg=="],
 
     "vary": ["vary@1.1.2", "", {}, "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="],
 

--- a/packages/chat/package.json
+++ b/packages/chat/package.json
@@ -174,7 +174,7 @@
     "@testing-library/svelte": "^5.2.7",
     "@types/bun": "^1.3.11",
     "ajv": "^8",
-    "conversationalist": "^0.2.1",
+    "conversationalist": "^0.4.1",
     "happy-dom": "^15.11.7",
     "oxlint": "^1.56.0",
     "postcss": "^8.5.15",
@@ -186,7 +186,7 @@
   },
   "peerDependencies": {
     "@lostgradient/cinder": "^0.16.0",
-    "conversationalist": "^0.2.1",
+    "conversationalist": "^0.2.1 || ^0.4.1",
     "svelte": ">=5.56.0 <6",
     "zod": "4.4.1"
   },

--- a/packages/chat/scripts/package-boundary.test.ts
+++ b/packages/chat/scripts/package-boundary.test.ts
@@ -39,7 +39,7 @@ describe('Chat package ownership boundary', () => {
     expect(chatManifest.dependencies).toEqual({});
     expect(chatManifest.peerDependencies).toEqual({
       '@lostgradient/cinder': '^0.16.0',
-      conversationalist: '^0.2.1',
+      conversationalist: '^0.2.1 || ^0.4.1',
       svelte: '>=5.56.0 <6',
       zod: '4.4.1',
     });

--- a/packages/chat/scripts/validate-consumer.ts
+++ b/packages/chat/scripts/validate-consumer.ts
@@ -274,7 +274,9 @@ async function buildConsumerEntries(fixture: ValidationFixture): Promise<void> {
       `  [assistantContent],\n` +
       `);\n` +
       `const submitEvent: ChatSubmitEvent = { message: { role: 'user', content: 'Follow up' }, attachments: [] };\n` +
-      `void [Chat, conversation, getMessageText(conversation.messages[conversation.ids[0] ?? '']), submitEvent];\n`,
+      `const firstMessage = conversation.messages[conversation.ids[0] ?? ''];\n` +
+      `if (firstMessage === undefined) throw new Error('expected a first conversation message');\n` +
+      `void [Chat, conversation, getMessageText(firstMessage), submitEvent];\n`,
   );
   await Bun.write(
     tsconfigPath,

--- a/packages/chat/scripts/validate-consumer.ts
+++ b/packages/chat/scripts/validate-consumer.ts
@@ -265,8 +265,16 @@ async function buildConsumerEntries(fixture: ValidationFixture): Promise<void> {
       `import '@lostgradient/chat/composer-popover/styles';\n` +
       `import '@lostgradient/chat/conversation-header/styles';\n` +
       `import '@lostgradient/chat/conversation-list/styles';\n` +
-      `import Chat from '@lostgradient/chat';\n` +
-      `void Chat;\n`,
+      `import Chat, { appendAssistantMessage, appendUserMessage, createConversation, getMessageText } from '@lostgradient/chat';\n` +
+      `import type { ChatSubmitEvent, ConversationHistory, MultiModalContent } from '@lostgradient/chat';\n` +
+      `const userContent: MultiModalContent = { type: 'text', text: 'Hello' };\n` +
+      `const assistantContent: MultiModalContent = { type: 'text', text: 'Hi there' };\n` +
+      `const conversation: ConversationHistory = appendAssistantMessage(\n` +
+      `  appendUserMessage(createConversation({ id: 'gateway-import-surface' }), [userContent]),\n` +
+      `  [assistantContent],\n` +
+      `);\n` +
+      `const submitEvent: ChatSubmitEvent = { message: { role: 'user', content: 'Follow up' }, attachments: [] };\n` +
+      `void [Chat, conversation, getMessageText(conversation.messages[conversation.ids[0] ?? '']), submitEvent];\n`,
   );
   await Bun.write(
     tsconfigPath,


### PR DESCRIPTION
Closes #762

## Summary
- Validate @lostgradient/chat against conversationalist@0.4.1 in the workspace
- Widen the Chat peer dependency to accept ^0.2.1 or ^0.4.1 while keeping the range narrow
- Expand the packed consumer validation to import the Chat component, event/content/history types, and conversationalist helpers from the public package surface
- Add a patch changeset for @lostgradient/chat

## Validation
- npm view conversationalist@0.4.1 version peerDependencies dependencies
- bun install
- bun run --filter=@lostgradient/cinder build
- bun run --filter=@lostgradient/chat typecheck
- bun run --filter=@lostgradient/chat test
- bun run --filter=@lostgradient/chat validate:consumer
- bun run --filter=@lostgradient/chat validate
- bun run --filter=@lostgradient/chat package:weight:check
- git push pre-push validation: full workspace suite passed

Labels codex and codex-automation were requested, but this repository does not currently have those labels.