### PR TITLE
Add scrollable compositional Table support

### DIFF
--- a/.changeset/scrollable-table-wrapper.md
+++ b/.changeset/scrollable-table-wrapper.md
@@ -1,0 +1,5 @@
+---
+'@lostgradient/cinder': patch
+---
+
+Add a first-class scrollable wrapper option to the compositional Table API.

--- a/packages/components/src/components/table/README.md
+++ b/packages/components/src/components/table/README.md
@@ -18,31 +18,34 @@ the namespace API: `Table.Header`, `Table.HeaderCell`, `Table.Body`,
   ];
 </script>
 
-<div class="cinder-table-scroll">
-  <Table caption="Recent contributors">
-    <Table.Header>
+<Table scrollable caption="Recent contributors">
+  <Table.Header>
+    <Table.Row>
+      <Table.HeaderCell>Name</Table.HeaderCell>
+      <Table.HeaderCell>Role</Table.HeaderCell>
+      <Table.HeaderCell align="right">Commits</Table.HeaderCell>
+    </Table.Row>
+  </Table.Header>
+  <Table.Body>
+    {#each people as person (person.name)}
       <Table.Row>
-        <Table.HeaderCell>Name</Table.HeaderCell>
-        <Table.HeaderCell>Role</Table.HeaderCell>
-        <Table.HeaderCell>Commits</Table.HeaderCell>
+        <Table.Cell>{person.name}</Table.Cell>
+        <Table.Cell>{person.role}</Table.Cell>
+        <Table.Cell align="right">{person.commits}</Table.Cell>
       </Table.Row>
-    </Table.Header>
-    <Table.Body>
-      {#each people as person (person.name)}
-        <Table.Row>
-          <Table.Cell>{person.name}</Table.Cell>
-          <Table.Cell>{person.role}</Table.Cell>
-          <Table.Cell align="right">{person.commits}</Table.Cell>
-        </Table.Row>
-      {/each}
-    </Table.Body>
-  </Table>
-</div>
+    {/each}
+  </Table.Body>
+</Table>
 ```
 
-Wrap dense or unknown-width tables in `.cinder-table-scroll`. The Table root
-stays a native `<table>`; the wrapper owns horizontal overflow when the
-available component width is too narrow.
+Pass `scrollable` for dense or unknown-width tables. The Table root stays a
+native `<table>`; Cinder generates a focusable `.cinder-table-scroll` wrapper
+that owns horizontal overflow when the available component width is too narrow.
+Use `scrollContainerProps` to label, style, or override attributes on that
+generated wrapper. When `scrollable` and `stickyHeader` are combined, the
+generated wrapper is the sticky header's scroll container; set a bounded block
+size on `scrollContainerProps` when the table should scroll vertically inside
+that wrapper.
 
 The leaves remain importable individually for à-la-carte builds — see
 `@lostgradient/cinder/table-body`, `@lostgradient/cinder/table-cell`, `@lostgradient/cinder/table-header`,
@@ -52,15 +55,17 @@ The leaves remain importable individually for à-la-carte builds — see
 
 <!-- generated:props:start -->
 
-| Prop           | Type                                             | Required | Default | Description                                                                                                                                                                                                                                                                                                                                              |
-| -------------- | ------------------------------------------------ | -------- | ------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `caption`      | `string`                                         | no       | —       | Visual caption rendered as a `<caption>` element.                                                                                                                                                                                                                                                                                                        |
-| `class`        | `string`                                         | no       | —       | Additional class names merged with `.cinder-table`.                                                                                                                                                                                                                                                                                                      |
-| `density`      | `"comfortable"` \| `"condensed"` \| `"spacious"` | no       | —       | Vertical padding density for header and body cells. Defaults to `'comfortable'`.                                                                                                                                                                                                                                                                         |
-| `selectable`   | `boolean`                                        | no       | —       | Enables the leading selection column on the entire table. When true: - The single `TableRow` inside `TableHeader` renders a leading `<th>` with a select-all checkbox sourced from the header's props. - Every `TableRow` inside `TableBody` renders a leading selection cell. Selection is strictly controlled — the consumer owns all selection state. |
-| `stickyHeader` | `boolean`                                        | no       | —       | When true, the header sticks to the top of the scrolling container.                                                                                                                                                                                                                                                                                      |
-| `children`     | `(opaque)`                                       | yes      | —       | TableHeader, TableBody, etc. Not expressible in JSON Schema; see the component types for the signature.                                                                                                                                                                                                                                                  |
-| `sort`         | `(opaque)`                                       | no       | —       | Bound sort state. When the user activates a sortable header, this prop is updated to reflect the new column / direction. Pass `undefined` initially when no column is sorted; the component will never write back `undefined` itself (sort always toggles to a column). Not expressible in JSON Schema; see the component types for the signature.       |
+| Prop                   | Type                                             | Required | Default | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
+| ---------------------- | ------------------------------------------------ | -------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `caption`              | `string`                                         | no       | —       | Visual caption rendered as a `<caption>` element.                                                                                                                                                                                                                                                                                                                                                                                                             |
+| `class`                | `string`                                         | no       | —       | Additional class names merged with `.cinder-table`.                                                                                                                                                                                                                                                                                                                                                                                                           |
+| `density`              | `"comfortable"` \| `"condensed"` \| `"spacious"` | no       | —       | Vertical padding density for header and body cells. Defaults to `'comfortable'`.                                                                                                                                                                                                                                                                                                                                                                              |
+| `scrollable`           | `boolean`                                        | no       | —       | When true, wraps the table in a `.cinder-table-scroll` container that enables horizontal overflow scrolling for dense or unknown-width tables. Use this instead of manually wrapping Table in `.cinder-table-scroll`. When combined with `stickyHeader`, the generated wrapper is the sticky header's scroll container. Set a bounded block size on `scrollContainerProps` when the table should scroll vertically inside that wrapper.                       |
+| `selectable`           | `boolean`                                        | no       | —       | Enables the leading selection column on the entire table. When true: - The single `TableRow` inside `TableHeader` renders a leading `<th>` with a select-all checkbox sourced from the header's props. - Every `TableRow` inside `TableBody` renders a leading selection cell. Selection is strictly controlled — the consumer owns all selection state.                                                                                                      |
+| `stickyHeader`         | `boolean`                                        | no       | —       | When true, the header sticks to the top of the scrolling container.                                                                                                                                                                                                                                                                                                                                                                                           |
+| `children`             | `(opaque)`                                       | yes      | —       | TableHeader, TableBody, etc. Not expressible in JSON Schema; see the component types for the signature.                                                                                                                                                                                                                                                                                                                                                       |
+| `scrollContainerProps` | `(opaque)`                                       | no       | —       | Attributes forwarded to the generated `.cinder-table-scroll` wrapper when `scrollable` is true. The wrapper is focusable by default so keyboard users can scroll read-only wide tables. When the table has a caption, or when `aria-label` or `aria-labelledby` is provided here, the wrapper becomes a named `region`; pass `role` or `tabindex` here to override those defaults. Not expressible in JSON Schema; see the component types for the signature. |
+| `sort`                 | `(opaque)`                                       | no       | —       | Bound sort state. When the user activates a sortable header, this prop is updated to reflect the new column / direction. Pass `undefined` initially when no column is sorted; the component will never write back `undefined` itself (sort always toggles to a column). Not expressible in JSON Schema; see the component types for the signature.                                                                                                            |
 
 <!-- generated:props:end -->
 

--- a/packages/components/src/components/table/table.a11y.md
+++ b/packages/components/src/components/table/table.a11y.md
@@ -53,7 +53,22 @@ Pass a `caption` prop to render a `<caption>` element above the table. This is t
 
 ## Sticky header
 
-Opt-in via `stickyHeader={true}`. Wrap the table in `.cinder-table-scroll` when the table needs an overflow container, then the `<thead>` pins to the top of that scrolling container via `position: sticky`.
+Opt-in via `stickyHeader={true}`. When the table also needs an overflow container, pass `scrollable` and configure the generated `.cinder-table-scroll` wrapper through `scrollContainerProps`; the `<thead>` pins to the top of that scrolling container via `position: sticky`.
+
+When `scrollable` and `stickyHeader` are combined, the generated wrapper is the sticky header's scroll container. If vertical scrolling should happen inside the table region, give the wrapper a bounded block size and vertical overflow:
+
+```svelte
+<Table
+  scrollable
+  stickyHeader
+  scrollContainerProps={{
+    'aria-label': 'Scrollable invoice table',
+    style: 'max-block-size: 24rem; overflow-y: auto;',
+  }}
+>
+  ...
+</Table>
+```
 
 The sort button's `:focus-visible` ring uses `z-index: 2` scoped to the focus state, lifting it above the sticky thead's stacking context. If you wrap the table in a container with `overflow: hidden`, the focus ring may be clipped regardless of z-index—that's a known CSS limitation and is not fixable with z-index alone.
 
@@ -114,12 +129,10 @@ When `Table.selectable` is true, `TableHeader` supports exactly one `<TableRow>`
 
 Tables don't reflow gracefully. Cinder ships two patterns and recommends picking based on column shape.
 
-**Horizontal scroll via `.cinder-table-scroll`.** This is the default Cinder recipe for dense or unknown-width tables. The table stays a table and the wrapper owns overflow:
+**Horizontal scroll via `scrollable`.** This is the default Cinder recipe for dense or unknown-width tables. The table stays a table and the generated wrapper owns overflow:
 
 ```svelte
-<div class="cinder-table-scroll">
-  <Table>...</Table>
-</div>
+<Table scrollable>...</Table>
 ```
 
 **Column hiding via container queries.** When the column set is stable and a few columns are nice-to-have rather than essential, hide them with `@container`-driven CSS on the cells. Wrap the table in a container, declare `container-type: inline-size`, then add a class or `data-priority` attribute to each `<th>` / `<td>` and toggle `display: none` below a threshold. The table stays a table; the column count shrinks. This works without JavaScript and keeps the existing `aria-sort`, selection, and density semantics intact.

--- a/packages/components/src/components/table/table.css
+++ b/packages/components/src/components/table/table.css
@@ -36,6 +36,11 @@
     min-inline-size: max-content;
   }
 
+  .cinder-table-scroll:focus-visible {
+    outline: var(--cinder-ring-width) solid transparent;
+    box-shadow: var(--_cinder-focus-ring-shadow);
+  }
+
   .cinder-table__caption {
     caption-side: top;
     text-align: left;
@@ -163,6 +168,12 @@
   }
 
   @media (forced-colors: active) {
+    .cinder-table-scroll:focus-visible {
+      outline: var(--cinder-ring-width) solid ButtonText;
+      outline-offset: 3px;
+      box-shadow: none;
+    }
+
     .cinder-table__sort-button:focus-visible {
       outline: var(--cinder-ring-width) solid ButtonText;
       /* 2px is correct here: sort-button has border:none so there is no

--- a/packages/components/src/components/table/table.examples.json
+++ b/packages/components/src/components/table/table.examples.json
@@ -5,9 +5,9 @@
   "examples": [
     {
       "id": "basic",
-      "title": "Basic table",
-      "description": "Header row plus three body rows; semantic <table> markup.",
-      "code": "<script lang=\"ts\">\n  import { Table } from '@lostgradient/cinder/table';\n  const people = [\n    { name: 'Ada Lovelace', role: 'Mathematician', commits: 142 },\n    { name: 'Grace Hopper', role: 'Computer Scientist', commits: 98 },\n    { name: 'Alan Turing', role: 'Cryptanalyst', commits: 76 },\n  ];\n</script>\n\n<Table caption=\"Recent contributors\">\n  <Table.Header>\n    <Table.Row>\n      <Table.HeaderCell>Name</Table.HeaderCell>\n      <Table.HeaderCell>Role</Table.HeaderCell>\n      <Table.HeaderCell align=\"right\">Commits</Table.HeaderCell>\n    </Table.Row>\n  </Table.Header>\n  <Table.Body>\n    {#each people as person (person.name)}\n      <Table.Row>\n        <Table.Cell>{person.name}</Table.Cell>\n        <Table.Cell>{person.role}</Table.Cell>\n        <Table.Cell align=\"right\">{person.commits}</Table.Cell>\n      </Table.Row>\n    {/each}\n  </Table.Body>\n</Table>\n"
+      "title": "Scrollable table",
+      "description": "Hand-composed cells inside the public horizontal scroll wrapper for dense tables.",
+      "code": "<script lang=\"ts\">\n  import { Table } from '@lostgradient/cinder/table';\n  const people = [\n    {\n      name: 'Ada Lovelace',\n      role: 'Mathematician and analytical engine collaborator',\n      commits: 142,\n    },\n    {\n      name: 'Grace Hopper',\n      role: 'Computer scientist, compiler builder, and systems educator',\n      commits: 98,\n    },\n    {\n      name: 'Alan Turing',\n      role: 'Cryptanalyst, logician, and theoretical computer scientist',\n      commits: 76,\n    },\n  ];\n</script>\n\n<Table caption=\"Recent contributors\" scrollable>\n  <Table.Header>\n    <Table.Row>\n      <Table.HeaderCell>Name</Table.HeaderCell>\n      <Table.HeaderCell>Role</Table.HeaderCell>\n      <Table.HeaderCell align=\"right\">Commits</Table.HeaderCell>\n    </Table.Row>\n  </Table.Header>\n  <Table.Body>\n    {#each people as person (person.name)}\n      <Table.Row>\n        <Table.Cell>{person.name}</Table.Cell>\n        <Table.Cell>{person.role}</Table.Cell>\n        <Table.Cell align=\"right\">{person.commits}</Table.Cell>\n      </Table.Row>\n    {/each}\n  </Table.Body>\n</Table>\n"
     },
     {
       "id": "empty",

--- a/packages/components/src/components/table/table.schema.json
+++ b/packages/components/src/components/table/table.schema.json
@@ -18,6 +18,10 @@
       "type": "boolean",
       "description": "Enables the leading selection column on the entire table. When true:\n- The single `TableRow` inside `TableHeader` renders a leading `<th>`\n  with a select-all checkbox sourced from the header's props.\n- Every `TableRow` inside `TableBody` renders a leading selection cell.\nSelection is strictly controlled — the consumer owns all selection state."
     },
+    "scrollable": {
+      "type": "boolean",
+      "description": "When true, wraps the table in a `.cinder-table-scroll` container that\nenables horizontal overflow scrolling for dense or unknown-width tables.\nUse this instead of manually wrapping Table in `.cinder-table-scroll`.\n\nWhen combined with `stickyHeader`, the generated wrapper is the sticky\nheader's scroll container. Set a bounded block size on `scrollContainerProps`\nwhen the table should scroll vertically inside that wrapper."
+    },
     "class": {
       "type": "string",
       "description": "Additional class names merged with `.cinder-table`."
@@ -31,6 +35,11 @@
         "reason": "function-or-snippet",
         "required": true,
         "description": "TableHeader, TableBody, etc."
+      },
+      {
+        "name": "scrollContainerProps",
+        "reason": "unknown-shape",
+        "description": "Attributes forwarded to the generated `.cinder-table-scroll` wrapper when\n`scrollable` is true. The wrapper is focusable by default so keyboard users\ncan scroll read-only wide tables. When the table has a caption, or when\n`aria-label` or `aria-labelledby` is provided here, the wrapper becomes a\nnamed `region`; pass `role` or `tabindex` here to override those defaults."
       },
       {
         "name": "sort",

--- a/packages/components/src/components/table/table.schema.ts
+++ b/packages/components/src/components/table/table.schema.ts
@@ -22,6 +22,11 @@ const schema = {
       description:
         "Enables the leading selection column on the entire table. When true:\n- The single `TableRow` inside `TableHeader` renders a leading `<th>`\n  with a select-all checkbox sourced from the header's props.\n- Every `TableRow` inside `TableBody` renders a leading selection cell.\nSelection is strictly controlled — the consumer owns all selection state.",
     },
+    scrollable: {
+      type: 'boolean',
+      description:
+        "When true, wraps the table in a `.cinder-table-scroll` container that\nenables horizontal overflow scrolling for dense or unknown-width tables.\nUse this instead of manually wrapping Table in `.cinder-table-scroll`.\n\nWhen combined with `stickyHeader`, the generated wrapper is the sticky\nheader's scroll container. Set a bounded block size on `scrollContainerProps`\nwhen the table should scroll vertically inside that wrapper.",
+    },
     class: {
       type: 'string',
       description: 'Additional class names merged with `.cinder-table`.',
@@ -35,6 +40,12 @@ const schema = {
         reason: 'function-or-snippet',
         required: true,
         description: 'TableHeader, TableBody, etc.',
+      },
+      {
+        name: 'scrollContainerProps',
+        reason: 'unknown-shape',
+        description:
+          'Attributes forwarded to the generated `.cinder-table-scroll` wrapper when\n`scrollable` is true. The wrapper is focusable by default so keyboard users\ncan scroll read-only wide tables. When the table has a caption, or when\n`aria-label` or `aria-labelledby` is provided here, the wrapper becomes a\nnamed `region`; pass `role` or `tabindex` here to override those defaults.',
       },
       {
         name: 'sort',

--- a/packages/components/src/components/table/table.svelte
+++ b/packages/components/src/components/table/table.svelte
@@ -36,10 +36,49 @@
     stickyHeader = false,
     density = 'comfortable',
     selectable = false,
+    scrollable = false,
+    scrollContainerProps,
     class: className,
     children,
     ...rest
   }: TableProps = $props();
+
+  const wrapperClassName = $derived(scrollContainerProps?.class);
+  const wrapperAriaLabelledBy = $derived(
+    normalizeOptionalAttribute(scrollContainerProps?.['aria-labelledby']),
+  );
+  const explicitWrapperAriaLabel = $derived(
+    normalizeOptionalAttribute(scrollContainerProps?.['aria-label']),
+  );
+  const explicitWrapperRole = $derived(normalizeOptionalAttribute(scrollContainerProps?.role));
+  const normalizedCaption = $derived(normalizeOptionalAttribute(caption));
+  const wrapperAriaLabel = $derived(
+    explicitWrapperAriaLabel ??
+      (wrapperAriaLabelledBy
+        ? undefined
+        : normalizedCaption
+          ? `${normalizedCaption} table scroll area`
+          : undefined),
+  );
+  const wrapperRole = $derived(
+    explicitWrapperRole ?? (wrapperAriaLabel || wrapperAriaLabelledBy ? 'region' : undefined),
+  );
+  const wrapperTabindex = $derived(normalizeOptionalTabindex(scrollContainerProps?.tabindex) ?? 0);
+
+  function normalizeOptionalAttribute(value: unknown): string | undefined {
+    return typeof value === 'string' && value.trim().length > 0 ? value.trim() : undefined;
+  }
+
+  function normalizeOptionalTabindex(value: unknown): number | undefined {
+    if (typeof value === 'number' && Number.isInteger(value)) return value;
+
+    if (typeof value !== 'string') return undefined;
+
+    const normalizedValue = value.trim();
+    if (!/^-?\d+$/.test(normalizedValue)) return undefined;
+
+    return Number(normalizedValue);
+  }
 
   // A native <caption> (caption-side: top) renders above the table's border box
   // but inside the same scroll container, so a sticky <thead> pinned at top: 0
@@ -85,16 +124,34 @@
   });
 </script>
 
-<table
-  {...rest}
-  class={classNames('cinder-table', className)}
-  data-cinder-sticky-header={stickyHeader || undefined}
-  data-cinder-density={density}
-  data-cinder-selectable={selectable || undefined}
-  style:--cinder-table-caption-height={caption ? `${captionHeight}px` : undefined}
->
-  {#if caption}
-    <caption class="cinder-table__caption" {@attach measureCaption}>{caption}</caption>
-  {/if}
-  {@render children()}
-</table>
+{#snippet table()}
+  <table
+    {...rest}
+    class={classNames('cinder-table', className)}
+    data-cinder-sticky-header={stickyHeader || undefined}
+    data-cinder-density={density}
+    data-cinder-selectable={selectable || undefined}
+    style:--cinder-table-caption-height={normalizedCaption ? `${captionHeight}px` : undefined}
+  >
+    {#if normalizedCaption}
+      <caption class="cinder-table__caption" {@attach measureCaption}>{normalizedCaption}</caption>
+    {/if}
+    {@render children()}
+  </table>
+{/snippet}
+
+{#if scrollable}
+  <!-- svelte-ignore a11y_no_noninteractive_tabindex -->
+  <div
+    {...scrollContainerProps}
+    class={classNames('cinder-table-scroll', wrapperClassName)}
+    role={wrapperRole}
+    aria-label={wrapperAriaLabel}
+    aria-labelledby={wrapperAriaLabelledBy}
+    tabindex={wrapperTabindex}
+  >
+    {@render table()}
+  </div>
+{:else}
+  {@render table()}
+{/if}

--- a/packages/components/src/components/table/table.test.ts
+++ b/packages/components/src/components/table/table.test.ts
@@ -925,6 +925,22 @@ describe('CSS rule assertions — sort indicator and focus ring', () => {
     expect(tableRule?.style.minInlineSize).toBe('max-content');
   });
 
+  test('scroll wrapper focus-visible state declares a visible focus ring', () => {
+    const rule = injectTableCssAndFind('.cinder-table-scroll:focus-visible');
+    expect(rule?.style.outlineColor).toBe('transparent');
+    expect(rule?.style.outlineStyle).toBe('solid');
+    expect(rule?.style.outlineWidth).toBe('var(--cinder-ring-width)');
+    expect(rule?.style.boxShadow).toBe('var(--_cinder-focus-ring-shadow)');
+  });
+
+  test('scroll wrapper focus-visible forced-colors fallback uses system colors', () => {
+    expect(tableCss).toContain('@media (forced-colors: active)');
+    expect(tableCss).toContain('.cinder-table-scroll:focus-visible');
+    expect(tableCss).toContain('outline: var(--cinder-ring-width) solid ButtonText');
+    expect(tableCss).toContain('outline-offset: 3px');
+    expect(tableCss).toContain('box-shadow: none');
+  });
+
   test('sticky header offsets its top by the measured caption height only when a caption is present', () => {
     // The native <caption> renders above the table border box; the sticky thead
     // must pin below it (not over it). The offset is scoped with :has(caption) so

--- a/packages/components/src/components/table/table.test.ts
+++ b/packages/components/src/components/table/table.test.ts
@@ -4,6 +4,7 @@ import { tick } from 'svelte';
 
 import { stripCinderComponentsLayer } from '../../test/css.ts';
 import { setupHappyDom } from '../../test/happy-dom.ts';
+import type { TableScrollContainerProps } from './table.types.ts';
 
 setupHappyDom();
 
@@ -26,6 +27,10 @@ const rows = [
   { id: '2', cells: ['Bob', '25', 'Designer'] },
 ];
 
+function unsafeScrollContainerProps(props: Record<string, unknown>): TableScrollContainerProps {
+  return props as unknown as TableScrollContainerProps;
+}
+
 describe('Table semantics', () => {
   test('renders semantic <table>, <thead>, <tbody> elements', () => {
     const { container } = render(Wrapper, { columns, rows });
@@ -41,12 +46,212 @@ describe('Table semantics', () => {
     expect(caption?.textContent?.trim()).toBe('Team');
   });
 
+  test('omits whitespace-only captions before rendering or measuring', () => {
+    const { container } = render(Wrapper, {
+      columns,
+      rows,
+      caption: '   ',
+      stickyHeader: true,
+    });
+    const table = container.querySelector('table');
+    expect(table?.querySelector('caption')).toBeNull();
+    expect(table?.style.getPropertyValue('--cinder-table-caption-height')).toBe('');
+  });
+
   test('renders one row per data row plus a header row', () => {
     const { container } = render(Wrapper, { columns, rows });
     const headerRows = container.querySelectorAll('thead tr');
     const bodyRows = container.querySelectorAll('tbody tr');
     expect(headerRows.length).toBe(1);
     expect(bodyRows.length).toBe(2);
+  });
+
+  test('scrollable=false renders the table without a scroll wrapper', () => {
+    const { container } = render(Wrapper, { columns, rows });
+    expect(container.querySelector('.cinder-table-scroll')).toBeNull();
+  });
+
+  test('scrollable=true wraps the composed table in the public scroll container', () => {
+    const { container } = render(Wrapper, { columns, rows, scrollable: true });
+    const wrapper = container.querySelector('.cinder-table-scroll');
+    const table = container.querySelector('table');
+    expect(wrapper).not.toBeNull();
+    expect(wrapper?.tagName).toBe('DIV');
+    expect(wrapper?.querySelector('table')).toBe(table);
+    expect(table?.parentElement).toBe(wrapper as HTMLElement);
+    expect(table?.querySelector('thead')).not.toBeNull();
+    expect(table?.querySelector('tbody')).not.toBeNull();
+  });
+
+  test('scrollable=true makes the generated scroll wrapper a named focusable region by default', () => {
+    const { container } = render(Wrapper, {
+      columns,
+      rows,
+      scrollable: true,
+      caption: 'Contributors',
+    });
+    const wrapper = container.querySelector('.cinder-table-scroll') as HTMLElement;
+    expect(wrapper?.getAttribute('role')).toBe('region');
+    expect(wrapper?.getAttribute('aria-label')).toBe('Contributors table scroll area');
+    expect(wrapper?.getAttribute('tabindex')).toBe('0');
+    expect(wrapper.tabIndex).toBe(0);
+  });
+
+  test('scrollable=true without a caption keeps the wrapper focusable without a duplicate region name', () => {
+    const { container } = render(Wrapper, { columns, rows, scrollable: true });
+    const wrapper = container.querySelector('.cinder-table-scroll') as HTMLElement;
+    expect(wrapper?.hasAttribute('role')).toBe(false);
+    expect(wrapper?.hasAttribute('aria-label')).toBe(false);
+    expect(wrapper?.hasAttribute('aria-labelledby')).toBe(false);
+    expect(wrapper?.getAttribute('tabindex')).toBe('0');
+    expect(wrapper.tabIndex).toBe(0);
+  });
+
+  test('scrollContainerProps forwards attributes to the generated scroll wrapper', () => {
+    const { container } = render(Wrapper, {
+      columns,
+      rows,
+      scrollable: true,
+      scrollContainerProps: {
+        'aria-label': 'Scrollable contributors',
+        class: 'custom-table-scroll',
+        role: 'group',
+        tabindex: -1,
+      },
+    });
+    const wrapper = container.querySelector('.cinder-table-scroll') as HTMLElement;
+    expect(wrapper?.getAttribute('aria-label')).toBe('Scrollable contributors');
+    expect(wrapper?.getAttribute('role')).toBe('group');
+    expect(wrapper?.classList.contains('cinder-table-scroll')).toBe(true);
+    expect(wrapper?.classList.contains('custom-table-scroll')).toBe(true);
+    expect(wrapper?.getAttribute('tabindex')).toBe('-1');
+    expect(wrapper.tabIndex).toBe(-1);
+  });
+
+  test('scrollContainerProps normalizes empty ARIA names before falling back to the caption', () => {
+    const { container } = render(Wrapper, {
+      columns,
+      rows,
+      scrollable: true,
+      caption: '  Quarterly revenue  ',
+      scrollContainerProps: {
+        'aria-label': '   ',
+        'aria-labelledby': '',
+      },
+    });
+    const wrapper = container.querySelector('.cinder-table-scroll');
+    expect(wrapper?.getAttribute('aria-label')).toBe('Quarterly revenue table scroll area');
+    expect(wrapper?.hasAttribute('aria-labelledby')).toBe(false);
+  });
+
+  test('scrollContainerProps normalizes empty roles before using the default named-region role', () => {
+    const { container } = render(Wrapper, {
+      columns,
+      rows,
+      scrollable: true,
+      caption: 'Contributors',
+      scrollContainerProps: {
+        role: '  ',
+      },
+    });
+    const wrapper = container.querySelector('.cinder-table-scroll');
+    expect(wrapper?.getAttribute('role')).toBe('region');
+  });
+
+  test('scrollContainerProps normalizes invalid tabindex values before using the default', () => {
+    const { container, rerender } = render(Wrapper, {
+      columns,
+      rows,
+      scrollable: true,
+      scrollContainerProps: unsafeScrollContainerProps({
+        tabindex: '  ',
+      }),
+    });
+    const wrapper = () => container.querySelector('.cinder-table-scroll') as HTMLElement;
+    expect(wrapper().getAttribute('tabindex')).toBe('0');
+    expect(wrapper().tabIndex).toBe(0);
+
+    rerender({
+      columns,
+      rows,
+      scrollable: true,
+      scrollContainerProps: unsafeScrollContainerProps({
+        tabindex: 'later',
+      }),
+    });
+    expect(wrapper().getAttribute('tabindex')).toBe('0');
+    expect(wrapper().tabIndex).toBe(0);
+
+    rerender({
+      columns,
+      rows,
+      scrollable: true,
+      scrollContainerProps: unsafeScrollContainerProps({
+        tabindex: ' -1 ',
+      }),
+    });
+    expect(wrapper().getAttribute('tabindex')).toBe('-1');
+    expect(wrapper().tabIndex).toBe(-1);
+  });
+
+  test('scrollContainerProps honors non-empty aria-labelledby over the default label', () => {
+    const { container } = render(Wrapper, {
+      columns,
+      rows,
+      scrollable: true,
+      caption: 'Contributors',
+      scrollContainerProps: {
+        'aria-labelledby': 'table-scroll-label',
+      },
+    });
+    const wrapper = container.querySelector('.cinder-table-scroll');
+    expect(wrapper?.getAttribute('aria-labelledby')).toBe('table-scroll-label');
+    expect(wrapper?.hasAttribute('aria-label')).toBe(false);
+  });
+
+  test('scrollable=true keeps Table props on the table element', () => {
+    const { container } = render(Wrapper, {
+      columns,
+      rows,
+      scrollable: true,
+      caption: 'Scrollable team',
+      stickyHeader: true,
+    });
+    const table = container.querySelector('table');
+    expect(table?.getAttribute('data-cinder-sticky-header')).toBe('true');
+    expect(table?.querySelector('caption')?.textContent?.trim()).toBe('Scrollable team');
+  });
+
+  test('stickyHeader with scrollable lets callers configure the generated sticky scroll container', () => {
+    const { container } = render(Wrapper, {
+      columns,
+      rows,
+      scrollable: true,
+      stickyHeader: true,
+      scrollContainerProps: {
+        'aria-label': 'Scrollable sticky table',
+        style: 'max-block-size: 20rem; overflow-y: auto;',
+      },
+    });
+    const wrapper = container.querySelector('.cinder-table-scroll') as HTMLElement;
+    const table = container.querySelector('table');
+    expect(wrapper.getAttribute('aria-label')).toBe('Scrollable sticky table');
+    expect(wrapper.getAttribute('style')).toContain('max-block-size: 20rem');
+    expect(wrapper.getAttribute('style')).toContain('overflow-y: auto');
+    expect(table?.getAttribute('data-cinder-sticky-header')).toBe('true');
+    expect(table?.parentElement).toBe(wrapper);
+  });
+
+  test('scrollContainerProps are ignored when scrollable=false', () => {
+    const { container } = render(Wrapper, {
+      columns,
+      rows,
+      scrollContainerProps: {
+        'aria-label': 'Unused scroll wrapper',
+      },
+    });
+    expect(container.querySelector('.cinder-table-scroll')).toBeNull();
+    expect(container.querySelector('table')?.getAttribute('aria-label')).toBeNull();
   });
 
   test('non-sortable header cells render plain text without an inner button', () => {

--- a/packages/components/src/components/table/table.types.ts
+++ b/packages/components/src/components/table/table.types.ts
@@ -1,5 +1,5 @@
 import type { Snippet } from 'svelte';
-import type { HTMLTableAttributes } from 'svelte/elements';
+import type { HTMLAttributes, HTMLTableAttributes } from 'svelte/elements';
 /** Sort direction. */
 export type SortDirection = 'ascending' | 'descending';
 /** Bound sort state shape. */
@@ -40,6 +40,14 @@ export type TableContext = {
   /** Mirror of Table.selectable. Set synchronously at construction time. */
   readonly selectionEnabled?: boolean;
 };
+/** Attributes forwarded to Table's generated scroll wrapper. */
+export type TableScrollContainerProps = Omit<
+  HTMLAttributes<HTMLDivElement>,
+  'children' | 'class'
+> & {
+  /** Additional class names merged with `.cinder-table-scroll`. */
+  class?: string;
+};
 /**
  * Props for the Table component.
  *
@@ -75,6 +83,24 @@ export type TableProps = Omit<HTMLTableAttributes, 'class'> & {
    * Selection is strictly controlled — the consumer owns all selection state.
    */
   selectable?: boolean;
+  /**
+   * When true, wraps the table in a `.cinder-table-scroll` container that
+   * enables horizontal overflow scrolling for dense or unknown-width tables.
+   * Use this instead of manually wrapping Table in `.cinder-table-scroll`.
+   *
+   * When combined with `stickyHeader`, the generated wrapper is the sticky
+   * header's scroll container. Set a bounded block size on `scrollContainerProps`
+   * when the table should scroll vertically inside that wrapper.
+   */
+  scrollable?: boolean;
+  /**
+   * Attributes forwarded to the generated `.cinder-table-scroll` wrapper when
+   * `scrollable` is true. The wrapper is focusable by default so keyboard users
+   * can scroll read-only wide tables. When the table has a caption, or when
+   * `aria-label` or `aria-labelledby` is provided here, the wrapper becomes a
+   * named `region`; pass `role` or `tabindex` here to override those defaults.
+   */
+  scrollContainerProps?: TableScrollContainerProps;
   /** Additional class names merged with `.cinder-table`. */
   class?: string;
   /** TableHeader, TableBody, etc. */

--- a/packages/components/src/test/fixtures/table-fixture.svelte
+++ b/packages/components/src/test/fixtures/table-fixture.svelte
@@ -1,6 +1,7 @@
 <script lang="ts" module>
   import type { TableSort } from '../../components/table/table.types.ts';
   import type { TableDensity } from '../../components/table/table.types.ts';
+  import type { TableScrollContainerProps } from '../../components/table/table.types.ts';
   import type { TableCellProps } from '../../components/table-cell/table-cell.types.ts';
   /** Test-only fixture composing a sortable table. */
   export type TableFixtureProps = {
@@ -9,6 +10,8 @@
     stickyHeader?: boolean;
     density?: TableDensity;
     selectable?: boolean;
+    scrollable?: boolean;
+    scrollContainerProps?: TableScrollContainerProps;
     includeHeaderSelectionState?: boolean;
     includeHeaderSelectionHandler?: boolean;
     renderSecondHeaderRow?: boolean;
@@ -37,6 +40,8 @@
     stickyHeader = false,
     density,
     selectable = false,
+    scrollable = false,
+    scrollContainerProps,
     includeHeaderSelectionState = true,
     includeHeaderSelectionHandler = true,
     renderSecondHeaderRow = false,
@@ -78,6 +83,8 @@
   {...density !== undefined ? { density } : {}}
   {stickyHeader}
   {selectable}
+  {scrollable}
+  {...scrollContainerProps !== undefined ? { scrollContainerProps } : {}}
 >
   <TableHeader
     {...includeHeaderSelectionState ? { allSelected, someSelected } : {}}

--- a/packages/playground/src/examples/table/basic.example.svelte
+++ b/packages/playground/src/examples/table/basic.example.svelte
@@ -1,18 +1,31 @@
 <script lang="ts" module>
-  export const title = 'Basic table';
-  export const description = 'Header row plus three body rows; semantic <table> markup.';
+  export const title = 'Scrollable table';
+  export const description =
+    'Hand-composed cells inside the public horizontal scroll wrapper for dense tables.';
 </script>
 
 <script lang="ts">
   import { Table } from '@lostgradient/cinder/table';
   const people = [
-    { name: 'Ada Lovelace', role: 'Mathematician', commits: 142 },
-    { name: 'Grace Hopper', role: 'Computer Scientist', commits: 98 },
-    { name: 'Alan Turing', role: 'Cryptanalyst', commits: 76 },
+    {
+      name: 'Ada Lovelace',
+      role: 'Mathematician and analytical engine collaborator',
+      commits: 142,
+    },
+    {
+      name: 'Grace Hopper',
+      role: 'Computer scientist, compiler builder, and systems educator',
+      commits: 98,
+    },
+    {
+      name: 'Alan Turing',
+      role: 'Cryptanalyst, logician, and theoretical computer scientist',
+      commits: 76,
+    },
   ];
 </script>
 
-<Table caption="Recent contributors">
+<Table caption="Recent contributors" scrollable>
   <Table.Header>
     <Table.Row>
       <Table.HeaderCell>Name</Table.HeaderCell>


### PR DESCRIPTION
## Summary
- add a supported `scrollable` prop to compositional `Table`
- wrap scrollable compositional tables in the existing public `.cinder-table-scroll` container
- add regression coverage plus regenerated Table examples/schema/README artifacts

Closes #764

## Validation
- bun run --filter=@lostgradient/cinder test -- ./src/components/table/table.test.ts
- bun run --filter=@lostgradient/cinder components:generate
- bun run --filter=@lostgradient/cinder components:check
- bun run --filter=@lostgradient/cinder exports:check
- bun run --filter=@lostgradient/cinder lint
- bun run --filter=@lostgradient/cinder test
- bun run --filter=@lostgradient/cinder typecheck
- bun run format:check
- git diff --check