### PR TITLE
Fix Chat browser publish exports

### DIFF
--- a/.changeset/chat-browser-exports.md
+++ b/.changeset/chat-browser-exports.md
@@ -1,0 +1,5 @@
+---
+'@lostgradient/chat': patch
+---
+
+Verify packed browser-condition exports resolve to published dist files.

--- a/packages/chat/scripts/pack-for-publish.ts
+++ b/packages/chat/scripts/pack-for-publish.ts
@@ -110,13 +110,16 @@ export function peerExternalSpecifiers(
 function publishedExport(entry: string | ConditionalExport): string | ConditionalExport {
   if (typeof entry === 'string') return entry;
   const published: ConditionalExport = {};
+  const publishedClientTarget = entry.default;
   if (entry.types !== undefined) published.types = entry.types;
-  if (entry.node !== undefined) published.node = entry.node;
-  if (entry.default !== undefined) {
-    if (entry.browser !== undefined) published.browser = entry.default;
-    if (entry.svelte !== undefined) published.svelte = entry.default;
-    if (entry.import !== undefined) published.import = entry.default;
-    published.default = entry.default;
+  if (publishedClientTarget !== undefined) {
+    if (entry.browser !== undefined) published.browser = publishedClientTarget;
+    if (entry.node !== undefined) published.node = entry.node;
+    if (entry.svelte !== undefined) published.svelte = publishedClientTarget;
+    if (entry.import !== undefined) published.import = publishedClientTarget;
+    published.default = publishedClientTarget;
+  } else if (entry.node !== undefined) {
+    published.node = entry.node;
   }
   return published;
 }

--- a/packages/chat/scripts/package-boundary.test.ts
+++ b/packages/chat/scripts/package-boundary.test.ts
@@ -109,7 +109,9 @@ describe('Chat package ownership boundary', () => {
     };
 
     expect(published.exports['.']).toMatchObject({
+      types: './dist/index.d.ts',
       browser: './dist/index.js',
+      node: './dist/server/index.js',
       svelte: './dist/index.js',
       import: './dist/index.js',
       default: './dist/index.js',
@@ -123,7 +125,9 @@ describe('Chat package ownership boundary', () => {
       'default',
     ]);
     expect(published.exports['./composer-popover']).toMatchObject({
+      types: './dist/components/chat-composer-popover/index.d.ts',
       browser: './dist/components/chat-composer-popover/index.js',
+      node: './dist/server/components/chat-composer-popover/index.js',
       svelte: './dist/components/chat-composer-popover/index.js',
       import: './dist/components/chat-composer-popover/index.js',
       default: './dist/components/chat-composer-popover/index.js',

--- a/packages/chat/scripts/package-boundary.test.ts
+++ b/packages/chat/scripts/package-boundary.test.ts
@@ -103,6 +103,7 @@ describe('Chat package ownership boundary', () => {
     const published = buildPublishedManifest(chatManifest);
     const exportKeys = (entry: unknown): string[] => {
       expect(entry).toBeDefined();
+      expect(entry).not.toBeNull();
       expect(typeof entry).toBe('object');
       return Object.keys(entry as Record<string, unknown>);
     };

--- a/packages/chat/scripts/package-boundary.test.ts
+++ b/packages/chat/scripts/package-boundary.test.ts
@@ -98,4 +98,42 @@ describe('Chat package ownership boundary', () => {
     expect(serialized).not.toContain('./src/');
     expect(published.peerDependencies).toEqual(chatManifest.peerDependencies);
   });
+
+  test('rewrites browser-aware Chat exports to packed dist files', () => {
+    const published = buildPublishedManifest(chatManifest);
+    const exportKeys = (entry: unknown): string[] => {
+      expect(entry).toBeDefined();
+      expect(typeof entry).toBe('object');
+      return Object.keys(entry as Record<string, unknown>);
+    };
+
+    expect(published.exports['.']).toMatchObject({
+      browser: './dist/index.js',
+      svelte: './dist/index.js',
+      import: './dist/index.js',
+      default: './dist/index.js',
+    });
+    expect(exportKeys(published.exports['.'])).toEqual([
+      'types',
+      'browser',
+      'node',
+      'svelte',
+      'import',
+      'default',
+    ]);
+    expect(published.exports['./composer-popover']).toMatchObject({
+      browser: './dist/components/chat-composer-popover/index.js',
+      svelte: './dist/components/chat-composer-popover/index.js',
+      import: './dist/components/chat-composer-popover/index.js',
+      default: './dist/components/chat-composer-popover/index.js',
+    });
+    expect(exportKeys(published.exports['./composer-popover'])).toEqual([
+      'types',
+      'browser',
+      'node',
+      'svelte',
+      'import',
+      'default',
+    ]);
+  });
 });

--- a/packages/chat/scripts/validate-consumer.ts
+++ b/packages/chat/scripts/validate-consumer.ts
@@ -358,6 +358,20 @@ async function runPlainNodeConsumer(fixture: ValidationFixture): Promise<void> {
       `if (!rendered.body.includes('chat-container')) throw new Error('plain Node SSR output is missing Chat');\n`,
   );
   await run(node, [entryPath], fixture.root);
+
+  const browserConditionEntryPath = join(fixture.root, 'browser-condition-consumer.mjs');
+  await Bun.write(
+    browserConditionEntryPath,
+    `const expected = new Map([\n` +
+      `  ['@lostgradient/chat', '/node_modules/@lostgradient/chat/dist/index.js'],\n` +
+      `  ['@lostgradient/chat/composer-popover', '/node_modules/@lostgradient/chat/dist/components/chat-composer-popover/index.js'],\n` +
+      `]);\n` +
+      `for (const [specifier, expectedSuffix] of expected) {\n` +
+      `  const resolved = new URL(import.meta.resolve(specifier)).pathname;\n` +
+      `  if (!resolved.endsWith(expectedSuffix)) throw new Error(\`\${specifier} resolved to \${resolved}\`);\n` +
+      `}\n`,
+  );
+  await run(node, ['--conditions=browser', browserConditionEntryPath], fixture.root);
 }
 
 export async function validateConsumer(): Promise<void> {

--- a/packages/chat/scripts/validate-consumer.ts
+++ b/packages/chat/scripts/validate-consumer.ts
@@ -366,9 +366,10 @@ async function runPlainNodeConsumer(fixture: ValidationFixture): Promise<void> {
       `  ['@lostgradient/chat', '/node_modules/@lostgradient/chat/dist/index.js'],\n` +
       `  ['@lostgradient/chat/composer-popover', '/node_modules/@lostgradient/chat/dist/components/chat-composer-popover/index.js'],\n` +
       `]);\n` +
+      `if (typeof import.meta.resolve !== 'function') throw new Error('Node executable does not support import.meta.resolve for browser-condition validation');\n` +
       `for (const [specifier, expectedSuffix] of expected) {\n` +
       `  const resolved = new URL(import.meta.resolve(specifier)).pathname;\n` +
-      `  if (!resolved.endsWith(expectedSuffix)) throw new Error(\`\${specifier} resolved to \${resolved}\`);\n` +
+      `  if (!resolved.endsWith(expectedSuffix)) throw new Error(\`\${specifier} resolved to \${resolved}; expected suffix \${expectedSuffix}\`);\n` +
       `}\n`,
   );
   await run(node, ['--conditions=browser', browserConditionEntryPath], fixture.root);


### PR DESCRIPTION
## Summary
- rewrites @lostgradient/chat browser/Svelte/import export targets to packed dist files
- preserves browser condition precedence ahead of node in the published export map
- adds package-boundary and consumer validation coverage for root and composer-popover browser-condition resolution

Closes #763

## Validation
- TZ=UTC LANG=en_US.UTF-8 bun test --conditions browser --conditions svelte --parallel=1 packages/chat/scripts/package-boundary.test.ts
- bun run --filter=@lostgradient/chat validate:consumer
- bun run --filter=@lostgradient/chat lint
- bun run --filter=@lostgradient/chat typecheck
- git diff --check
- bun run --filter=@lostgradient/chat package:weight:check
- pre-push full suite: lint, typecheck, test