### PR TITLE
fix(chat): make tool-paired message footer reachable by mouse and keyboard

### DIFF
--- a/packages/chat/src/lib/components/chat/message/chat-message-action-buttons.test.ts
+++ b/packages/chat/src/lib/components/chat/message/chat-message-action-buttons.test.ts
@@ -60,6 +60,29 @@ describe('chat message action buttons', () => {
     expect(resetBlock).not.toMatch(/(^|\s)left:\s*0/);
     expect(resetBlock).not.toMatch(/(^|\s)right:\s*auto/);
   });
+
+  // Regression for #777: a `display: none` footer on tool-paired rows can
+  // never be resurrected by the shared `:hover`/`:focus-within` rule (which
+  // only toggles opacity/pointer-events), making retry/edit/copy and any
+  // consumer `messageActions` snippet content permanently unreachable by
+  // mouse or keyboard on those rows.
+  test('tool-pair footer override hides via opacity, not display: none', () => {
+    const rule = extractRule(
+      source,
+      '.chat-message-wrapper[data-tool-pair] .chat-message-footer {',
+    );
+    expect(rule).not.toContain('display: none');
+    expect(rule).toContain('opacity: 0');
+    expect(rule).toContain('pointer-events: none');
+  });
+
+  test('the shared hover/focus-within reveal rule applies to every wrapper, including tool-paired rows', () => {
+    // No role- or attribute-scoped selector narrows this rule away from
+    // `[data-tool-pair]` wrappers — it targets the generic `.chat-message-wrapper`.
+    expect(source).toContain(
+      '.chat-message-wrapper:hover .chat-message-footer,\n  .chat-message-wrapper:focus-within .chat-message-footer {',
+    );
+  });
 });
 
 function extractRule(text: string, opening: string): string {

--- a/packages/chat/src/lib/components/chat/message/chat-message-action-buttons.test.ts
+++ b/packages/chat/src/lib/components/chat/message/chat-message-action-buttons.test.ts
@@ -79,9 +79,20 @@ describe('chat message action buttons', () => {
   test('the shared hover/focus-within reveal rule applies to every wrapper, including tool-paired rows', () => {
     // No role- or attribute-scoped selector narrows this rule away from
     // `[data-tool-pair]` wrappers — it targets the generic `.chat-message-wrapper`.
-    expect(source).toContain(
-      '.chat-message-wrapper:hover .chat-message-footer,\n  .chat-message-wrapper:focus-within .chat-message-footer {',
+    // Whitespace-tolerant (rather than an exact-string match) so a future
+    // formatter pass on `chat-message.svelte` can't silently break this
+    // assertion.
+    expect(source).toMatch(
+      /\.chat-message-wrapper:hover\s+\.chat-message-footer\s*,\s*\.chat-message-wrapper:focus-within\s+\.chat-message-footer\s*\{/,
     );
+  });
+
+  test('touch devices reveal the tool-pair footer too, matching its higher specificity', () => {
+    // The tool-pair hidden-state override has higher specificity than the
+    // bare `.chat-message-footer` touch rule, so it needs its own entry in
+    // the touch media block or tool-paired rows stay unreachable on touch.
+    const touchBlock = extractTouchMediaBlock(source, '.chat-message-footer');
+    expect(touchBlock).toContain('.chat-message-wrapper[data-tool-pair] .chat-message-footer');
   });
 });
 
@@ -93,12 +104,15 @@ function extractRule(text: string, opening: string): string {
   return text.slice(bodyStart, end);
 }
 
-function extractTouchMediaBlock(text: string): string {
+function extractTouchMediaBlock(
+  text: string,
+  contains: string = '.chat-message-action-button',
+): string {
   const marker = '@media (hover: none) or (pointer: coarse) {';
   let searchFrom = 0;
   for (;;) {
     const start = text.indexOf(marker, searchFrom);
-    if (start === -1) throw new Error('action-button touch media block not found');
+    if (start === -1) throw new Error(`touch media block containing "${contains}" not found`);
     let depth = 0;
     let i = text.indexOf('{', start);
     const bodyStart = i + 1;
@@ -108,7 +122,7 @@ function extractTouchMediaBlock(text: string): string {
         depth--;
         if (depth === 0) {
           const body = text.slice(bodyStart, i);
-          if (body.includes('.chat-message-action-button')) return body;
+          if (body.includes(contains)) return body;
           searchFrom = i + 1;
           break;
         }

--- a/packages/chat/src/lib/components/chat/message/chat-message.svelte
+++ b/packages/chat/src/lib/components/chat/message/chat-message.svelte
@@ -526,8 +526,15 @@
     display: none;
   }
 
+  /* Hidden-by-default like every other row's footer (opacity/pointer-events,
+   * toggled visible on :hover/:focus-within by the shared rule below) rather
+   * than `display: none` — a `display: none` element can never be hovered,
+   * focused, or hit-tested, which would make retry/edit/copy and any
+   * consumer-supplied `messageActions` snippet content permanently
+   * unreachable by mouse or keyboard on tool-paired rows. */
   .chat-message-wrapper[data-tool-pair] .chat-message-footer {
-    display: none;
+    opacity: 0;
+    pointer-events: none;
   }
 
   .chat-message-wrapper[data-role='snapshot'] {

--- a/packages/chat/src/lib/components/chat/message/chat-message.svelte
+++ b/packages/chat/src/lib/components/chat/message/chat-message.svelte
@@ -797,9 +797,15 @@
     }
   }
 
-  /* Touch devices: always show actions */
+  /* Touch devices: always show actions. The tool-pair override above has
+   * higher specificity ([data-tool-pair] + .chat-message-wrapper +
+   * .chat-message-footer) than the bare `.chat-message-footer` below, so it
+   * needs its own entry here — otherwise touch users would hit the same
+   * "always opacity: 0" dead end on tool-paired rows that :hover/:focus-within
+   * fixes for pointer/keyboard. */
   @media (hover: none) or (pointer: coarse) {
-    .chat-message-footer {
+    .chat-message-footer,
+    .chat-message-wrapper[data-tool-pair] .chat-message-footer {
       opacity: 1;
       pointer-events: auto;
     }


### PR DESCRIPTION
## Summary

`.chat-message-wrapper[data-tool-pair] .chat-message-footer` was hard `display: none`, with no hover/focus override anywhere in the stylesheet. The shared reveal rule:

```css
.chat-message-wrapper:hover .chat-message-footer,
.chat-message-wrapper:focus-within .chat-message-footer { opacity: 1; pointer-events: auto; }
```

only toggles `opacity`/`pointer-events`, which can never resurrect an element that's already `display: none`. Since a `display: none` element can't be hovered, focused, or hit-tested, the entire message action footer — retry, edit, copy, and any consumer-supplied `messageActions` snippet content — was permanently unreachable on tool-paired rows, by mouse **or** keyboard.

## Fix

Changed the tool-pair override from `display: none` to the same `opacity: 0; pointer-events: none;` hidden state every other row's footer already uses:

```css
.chat-message-wrapper[data-tool-pair] .chat-message-footer {
  opacity: 0;
  pointer-events: none;
}
```

The footer is `position: absolute` (out of flow) in its base rule, so this introduces no layout shift on tool-paired rows at rest — visually it's unchanged. The existing generic `.chat-message-wrapper:hover`/`:focus-within` rule (untouched, no selector changes needed) now reveals it on hover and focus-within, exactly like every other role.

## Design tradeoff (tool-pair visual noise)

The `[data-tool-pair]` rule exists to keep the merged tool-call/tool-result card visually quiet (it also strips the header and bubble chrome for the same reason). Two options were on the table:

1. **Delete the footer-hiding rule outright** — makes tool rows show their action footer at rest, same as other rows, which reintroduces the visual noise the rule was written to avoid.
2. **Keep it hidden-by-default but reachable on hover/focus** (chosen) — preserves the quiet-at-rest look while making the footer reachable by both mouse and keyboard, matching how every other role's footer already behaves.

A consumer-supplied `messageActions` snippet is evidence the footer's contents are meaningful on tool-paired rows (the playground's interactive harness renders a `messageActions` button on every message, including tool-call/tool-result rows), so removing the footer entirely wasn't appropriate. Option 2 keeps the noise-reduction intent intact while fixing the accessibility defect.

## Testing

- Added regression coverage to the existing source-contract test file for this component's footer CSS (`ChatMessage` is too heavy to mount in happy-dom for CSS/touch concerns, per that file's existing pattern) asserting:
  - the tool-pair override no longer contains `display: none` and instead uses `opacity: 0; pointer-events: none;`
  - the shared hover/focus-within reveal rule is unscoped (applies to every wrapper, including tool-paired rows)
- `bun run --filter=@lostgradient/chat test` — 670 pass, 0 fail
- `bun run --filter=@lostgradient/chat lint` — 0 errors
- `bun run --filter=@lostgradient/chat typecheck` — 0 errors
- `bunx stylelint` on the changed file — clean
- `colors:audit` / `tokens:audit` / `components:check` — all at baseline, no new debt

Closes #777