### PR TITLE
fix(ci): make required status checks reachable by every PR

### DIFF
--- a/.github/workflows/browser-tests-skip.yaml
+++ b/.github/workflows/browser-tests-skip.yaml
@@ -1,0 +1,67 @@
+name: browser-tests-skip
+
+# Mirror-skip workflow for browser-tests.yaml's required status checks.
+#
+# `typecheck` and `playwright` (browser-tests.yaml) are required status
+# checks on `main` (see docs/validation-topology.md's "Branch protection"
+# section). browser-tests.yaml stays path-filtered — it's expensive
+# (Chromium install, a full Playwright run) — but a required check with a
+# path filter leaves any PR whose changes match NONE of that filter with the
+# check stuck at "Expected" forever, permanently blocking the merge.
+#
+# This workflow triggers on the exact INVERSE path set (`paths-ignore`
+# mirroring browser-tests.yaml's `paths`, entry for entry, negations
+# included) and reports the identical `typecheck`/`playwright` job names with
+# a job that succeeds immediately. For any given diff at least one of the two
+# workflows fires for each required name — sometimes both (accepted; the skip
+# job costs a few seconds of runner time), never neither.
+
+on:
+  pull_request:
+    paths-ignore:
+      - 'packages/components/src/**'
+      - 'packages/components/components.json'
+      - 'packages/components/package.json'
+      - 'packages/components/scripts/**'
+      - 'packages/chat/**'
+      - 'packages/*/package.json'
+      - 'packages/*/scripts/**'
+      - 'packages/*/tsconfig*.json'
+      - 'packages/commentary/src/**'
+      - 'packages/diff/src/**'
+      - 'packages/markdown/src/**'
+      - 'packages/playground/src/**'
+      - 'packages/playground/scripts/**'
+      - 'packages/testing/**'
+      - '.github/workflows/browser-tests.yaml'
+      - 'package.json'
+      - 'bun.lock'
+      - 'bun.lockb'
+      - 'bunfig.toml'
+      - '.npmrc'
+      - 'tsconfig*.json'
+      - '!packages/**/*.md'
+      - '!packages/**/README*'
+      - '!packages/**/CHANGELOG*'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: browser-tests-skip-${{ github.ref }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  typecheck:
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - name: Skip (no browser-test-relevant files changed)
+        run: echo "browser-tests.yaml's path filter did not match this diff; reporting an instant pass for the required 'typecheck' check."
+
+  playwright:
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - name: Skip (no browser-test-relevant files changed)
+        run: echo "browser-tests.yaml's path filter did not match this diff; reporting an instant pass for the required 'playwright' check."

--- a/.github/workflows/changeset-guard.yaml
+++ b/.github/workflows/changeset-guard.yaml
@@ -7,21 +7,20 @@ name: changeset-guard
 # their path filters — so a PR that ONLY edits a changeset to a `major` bump would
 # not trigger them, and the policy violation would otherwise surface on `main`
 # instead of failing on the branch that introduced it. This workflow runs the guard
-# directly on exactly those changes.
+# directly, unconditionally.
 #
 # The guard parses changesets with `@changesets/parse` (the same parser Changesets
-# uses), so the job installs dependencies before running. Edits to this workflow
-# file itself are included in the path filter so a PR that neuters the guard still
-# triggers it.
+# uses), so the job installs dependencies before running.
+#
+# `pull_request` has NO path filter — "Pre-1.0 changeset bump guard" is a
+# required status check on `main` (see docs/validation-topology.md's "Branch
+# protection" section), and a path filter would leave a PR whose changes don't
+# touch any of the filtered paths with this required check stuck at "Expected"
+# forever. The guard itself is cheap (install + a single script), so running it
+# unconditionally is affordable.
 
 on:
-  pull_request:
-    paths:
-      - '.changeset/**'
-      - 'packages/components/package.json'
-      - 'packages/chat/package.json'
-      - 'packages/components/scripts/check-changeset-prerelease-bumps.ts'
-      - '.github/workflows/changeset-guard.yaml'
+  pull_request: {}
   workflow_dispatch: {}
 
 permissions:

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -17,50 +17,17 @@ name: unit-tests
 
 on:
   # Unit tests own component source, package test/build scripts, and this
-  # workflow's scoping behavior. Other workflows have their own targeted gates
-  # and should not start the unit suite by themselves.
-  pull_request:
-    paths:
-      - 'packages/components/**'
-      - 'packages/chat/**'
-      - 'packages/*/package.json'
-      - 'packages/*/scripts/**'
-      - 'packages/*/tsconfig*.json'
-      - 'packages/commentary/src/**'
-      - 'packages/diff/src/**'
-      - 'packages/markdown/src/**'
-      - 'packages/playground/src/discover.ts'
-      - 'packages/playground/src/examples/**'
-      # Broadens the lint gate (bun run --filter='*' lint, lint:invariants,
-      # check:pipeline-coverage, etc.) to the rest of these packages' sources,
-      # not just the scoping-relevant files above. This means more PRs will
-      # start the (heavier) unit-test job than strictly need scoped component
-      # coverage — accepted tradeoff so the blocking lint gate can't be
-      # skipped by a PR that only touches playground or testing sources.
-      - 'packages/playground/src/**'
-      - 'packages/testing/**'
-      - 'packages/testing/scripts/changed-components.ts'
-      - 'packages/testing/src/helpers/component-filter.ts'
-      - '.github/workflows/unit-tests.yaml'
-      # check:pipeline-coverage (run in the Lint step below) parses these
-      # workflows to detect dropped/duplicated gates; a PR editing them must
-      # trigger this workflow so the guard runs pre-merge, not just post-merge.
-      - '.github/workflows/release.yaml'
-      - '.github/workflows/release-manual.yaml'
-      - '.github/workflows/main-green.yaml'
-      - '.github/workflows/browser-tests.yaml'
-      - '.github/workflows/changeset-guard.yaml'
-      - '.github/workflows/deploy-playground.yaml'
-      - '.changeset/**'
-      - 'package.json'
-      - 'bun.lock'
-      - 'bun.lockb'
-      - 'bunfig.toml'
-      - '.npmrc'
-      - 'tsconfig*.json'
-      - '!packages/**/*.md'
-      - '!packages/**/README*'
-      - '!packages/**/CHANGELOG*'
+  # workflow's scoping behavior.
+  #
+  # `pull_request` runs unconditionally — NO path filter. `unit-tests` and
+  # `typecheck` (browser-tests.yaml) are required status checks on `main`
+  # (see docs/validation-topology.md's "Branch protection" section); a path
+  # filter here would leave a PR whose changes match none of the filtered
+  # paths (e.g. a root lint-config-only edit) with a required check stuck at
+  # "Expected" forever, permanently blocking the merge. Running unconditionally
+  # is the direct fix — a no-op PR pays a full (if fast) run instead of being
+  # unmergeable.
+  pull_request: {}
   push:
     branches:
       - main
@@ -72,6 +39,7 @@ on:
       - 'packages/*/tsconfig*.json'
       - 'packages/commentary/src/**'
       - 'packages/diff/src/**'
+      - 'packages/editor/src/**'
       - 'packages/markdown/src/**'
       - 'packages/playground/src/discover.ts'
       - 'packages/playground/src/examples/**'


### PR DESCRIPTION
## Summary

Branch protection on `main` now requires four status checks: `unit-tests`, `typecheck`, `playwright`, and `Pre-1.0 changeset bump guard` (introduced by the in-flight `refactor/thin-local-gates` PR, which thins `pre-push` down to a fast fail-open hook and moves local validation entirely to CI + branch protection).

Three of the workflows backing those checks were path-filtered on `pull_request`. A required check with a path filter has a sharp edge: a PR whose changed files match none of the filtered paths never gets that check reported at all, and GitHub shows it stuck at "Expected" forever — permanently blocking merge. Concretely, any PR that doesn't touch `.changeset/**` (the common case — changesets are often added right before merge) would never trigger `changeset-guard.yaml`, so `Pre-1.0 changeset bump guard` would never run and the PR could never merge.

This landed as a live problem the moment branch protection went active — this PR fixes it directly so every in-flight and future PR can satisfy the required checks.

## Changes

- `unit-tests.yaml`: removed the `pull_request` path filter — runs on every PR unconditionally now.
- `changeset-guard.yaml`: removed the `pull_request` path filter for the same reason (it's cheap — install + one script — so unconditional is affordable).
- `browser-tests-skip.yaml` (new): mirror-skip workflow for `browser-tests.yaml`, which stays path-filtered (it's expensive — Chromium install + full Playwright run). Reports the identical `typecheck`/`playwright` job names on the inverse (`paths-ignore`) path set, succeeding immediately. For any diff, at least one of the two workflows reports each required name — sometimes both — never neither.

## Test plan

- [x] All three workflow YAML files parse (`python3 -c "import yaml; yaml.safe_load(...)"`)
- [x] Verified against a live blocked PR (#794, the Changesets "Version Packages" PR) that required checks were missing entirely under the old path filters
- [ ] Confirm this PR's own checks (`unit-tests`, `typecheck`, `playwright`, `Pre-1.0 changeset bump guard`) all report and pass, proving the fix works end to end

Related: stevekinney/cinder refactor/thin-local-gates (adds the branch protection this fixes).