### PR TITLE
fix(components): converge Shiki adapter on shiki/core + per-language imports

### DIFF
--- a/.changeset/shiki-core-per-language-imports.md
+++ b/.changeset/shiki-core-per-language-imports.md
@@ -1,0 +1,5 @@
+---
+'@lostgradient/cinder': patch
+---
+
+Fix the Shiki adapter behind `<CodeBlock>` (`highlighters/shiki`) to build on `shiki/core` + `@shikijs/engine-oniguruma`, resolving languages and themes through `shiki/langs` / `shiki/themes` instead of the default `shiki` barrel, converging on the same pattern `packages/markdown` already uses. This closes a build-time regression risk: cinder's own build (`splitting: false`) previously kept only the bare `shiki` specifier external, so any future `shiki/*` subpath import would have been inlined whole into cinder's published dist (measured at ~10 MB). `scripts/build.ts` now externalizes `shiki/*` and `@shikijs/engine-oniguruma` too. No change to the public `shikiHighlighter()` API, behavior, or supported language/theme set — and no change to what a consumer's own bundler ships, since `shiki` was already external there.

--- a/packages/components/scripts/build.ts
+++ b/packages/components/scripts/build.ts
@@ -187,6 +187,16 @@ const runtimeDependencyExternals = [
   '@modelcontextprotocol/sdk',
   '@modelcontextprotocol/sdk/*',
   '@shikijs/rehype',
+  // The Shiki adapter (`highlighters/shiki/index.ts`) resolves languages and
+  // themes via `shiki/langs` / `shiki/themes` and builds its highlighter via
+  // `shiki/core` + `@shikijs/engine-oniguruma` (see that file's module JSDoc
+  // for why). Those subpaths must stay external alongside the bare `shiki`
+  // entry below — `splitting: false` means an un-externalized subpath gets
+  // inlined whole into this single output file, defeating the adapter's
+  // lazy per-language/per-theme dynamic imports and vendoring every bundled
+  // grammar (~10 MB) into cinder's own published dist.
+  '@shikijs/engine-oniguruma',
+  'shiki/*',
   '@milkdown/kit',
   '@milkdown/prose',
   '@milkdown/kit/*',

--- a/packages/components/src/highlighters/shiki/index.ts
+++ b/packages/components/src/highlighters/shiki/index.ts
@@ -153,6 +153,15 @@ type ShikiModule = {
   highlighter: HighlighterCore;
   bundledLanguages: BundledLanguages;
   bundledThemes: BundledThemes;
+  /**
+   * Shiki's heuristic embedded-language detector (fenced code inside
+   * Markdown, `<script lang="...">` inside Svelte/Vue/HTML, etc.) — the same
+   * function the previous singleton `codeToHtml` shorthand used to auto-load
+   * nested grammars. Threaded through here (rather than imported separately
+   * in `highlight()`) so injected test loaders can opt out without needing
+   * their own `shiki/core` import.
+   */
+  guessEmbeddedLanguages: (code: string, lang: string) => string[];
 };
 
 type ShikiModuleLoader = () => Promise<ShikiModule>;
@@ -185,6 +194,66 @@ async function ensureThemesLoaded(
 }
 
 /**
+ * Best-effort load of any languages `guessEmbeddedLanguages` finds embedded
+ * in `code` (fenced fences inside Markdown, `<script lang="...">` inside
+ * Svelte/Vue/HTML, etc.) — mirrors the auto-load behavior Shiki's own
+ * singleton `codeToHtml` shorthand provided. A guess that doesn't name a
+ * real Shiki language, or that fails to load, is swallowed: it only affects
+ * whether nested regions get highlighted, never whether the top-level
+ * `normalizedLang` result renders.
+ */
+async function loadGuessedEmbeddedLanguages(
+  shiki: ShikiModule,
+  code: string,
+  lang: string,
+): Promise<void> {
+  for (const guessed of shiki.guessEmbeddedLanguages(code, lang)) {
+    if (!Object.hasOwn(shiki.bundledLanguages, guessed)) continue;
+    try {
+      await ensureLanguageLoaded(shiki, guessed);
+    } catch {
+      // Best-effort — an embedded grammar that fails to load only costs
+      // that nested region its highlighting, not the whole block.
+    }
+  }
+}
+
+/**
+ * The `HighlighterCore` (and its Oniguruma/WASM engine) is expensive to
+ * build and safe to share: language and theme registries only grow, so
+ * every `shikiHighlighter()` instance that uses the default loader shares
+ * one process-wide instance rather than each paying for its own WASM
+ * engine and re-fetching grammars/themes another instance already loaded —
+ * matching the sharing the previous singleton-based `shiki` shorthand gave
+ * for free. A `moduleLoader` passed in for testing bypasses this cache
+ * entirely (see `shikiHighlighter`'s second parameter).
+ */
+let sharedShikiModule: (() => Promise<ShikiModule>) | undefined;
+
+function getSharedShikiModule(): Promise<ShikiModule> {
+  sharedShikiModule ??= createRetryingLoaderCache(async (): Promise<ShikiModule> => {
+    const [{ createOnigurumaEngine }, coreModule, langsModule, themesModule] = await Promise.all([
+      import('@shikijs/engine-oniguruma'),
+      import('shiki/core'),
+      import('shiki/langs'),
+      import('shiki/themes'),
+    ]);
+    const highlighter = await coreModule.createHighlighterCore({
+      themes: [],
+      langs: [],
+      engine: createOnigurumaEngine(import('shiki/wasm')),
+    });
+    return {
+      highlighter,
+      bundledLanguages: langsModule.bundledLanguages,
+      bundledThemes: themesModule.bundledThemes,
+      guessEmbeddedLanguages: coreModule.guessEmbeddedLanguages,
+    };
+  });
+  return sharedShikiModule();
+}
+
+/**
  * Create a Shiki-backed {@link Highlighter} suitable for
  * `<CodeBlock highlighter={...} />`. See module-level JSDoc for the
  * full behavior contract.
@@ -203,33 +272,21 @@ export function shikiHighlighter(
   const loadShiki = createRetryingLoaderCache(
     moduleLoader ??
       (async (): Promise<ShikiModule> => {
-        const [{ createOnigurumaEngine }, { createHighlighterCore }, langsModule, themesModule] =
-          await Promise.all([
-            import('@shikijs/engine-oniguruma'),
-            import('shiki/core'),
-            import('shiki/langs'),
-            import('shiki/themes'),
-          ]);
-        const highlighter = await createHighlighterCore({
-          themes: [],
-          langs: [],
-          engine: createOnigurumaEngine(import('shiki/wasm')),
-        });
-        const shikiModule: ShikiModule = {
-          highlighter,
-          bundledLanguages: langsModule.bundledLanguages,
-          bundledThemes: themesModule.bundledThemes,
-        };
+        const shikiModule = await getSharedShikiModule();
 
         // Optional preload — if the consumer named specific languages, load
-        // them (and the configured theme) up front so Shiki resolves and
-        // caches them before the first real call. Failures here are
-        // non-fatal; per-call language lookup will still try (and fall back
-        // to plaintext on its own miss).
+        // the configured theme once and each named language, so Shiki
+        // resolves and caches them before the first real call. Failures
+        // here are non-fatal; per-call language lookup will still try (and
+        // fall back to plaintext on its own miss).
         if (langs !== undefined) {
+          try {
+            await ensureThemesLoaded(shikiModule, theme);
+          } catch {
+            // Swallow — the per-call path below logs and falls back.
+          }
           for (const lang of langs) {
             try {
-              await ensureThemesLoaded(shikiModule, theme);
               await ensureLanguageLoaded(shikiModule, lang);
             } catch {
               // Swallow — the per-call path below logs and falls back.
@@ -279,6 +336,7 @@ export function shikiHighlighter(
     try {
       await ensureLanguageLoaded(shiki, normalizedLang);
       await ensureThemesLoaded(shiki, theme);
+      await loadGuessedEmbeddedLanguages(shiki, code, normalizedLang);
       const html = shiki.highlighter.codeToHtml(code, {
         lang: normalizedLang,
         ...buildThemeOption(theme),

--- a/packages/components/src/highlighters/shiki/index.ts
+++ b/packages/components/src/highlighters/shiki/index.ts
@@ -195,7 +195,7 @@ async function ensureThemesLoaded(
 
 /**
  * Best-effort load of any languages `guessEmbeddedLanguages` finds embedded
- * in `code` (fenced fences inside Markdown, `<script lang="...">` inside
+ * in `code` (fenced code blocks inside Markdown, `<script lang="...">` inside
  * Svelte/Vue/HTML, etc.) — mirrors the auto-load behavior Shiki's own
  * singleton `codeToHtml` shorthand provided. A guess that doesn't name a
  * real Shiki language, or that fails to load, is swallowed: it only affects

--- a/packages/components/src/highlighters/shiki/index.ts
+++ b/packages/components/src/highlighters/shiki/index.ts
@@ -19,8 +19,33 @@
  * The factory is synchronous. Shiki itself is imported lazily on the first
  * highlight call inside the returned function — consumers that never invoke
  * the highlighter (or that never import this module) ship zero Shiki bytes
- * in their entry chunk. Subsequent calls reuse the singleton `codeToHtml`
- * import.
+ * in their entry chunk. Subsequent calls reuse the singleton highlighter
+ * instance.
+ *
+ * Why this builds on `shiki/core` + `@shikijs/engine-oniguruma` rather than
+ * `import { createHighlighter } from 'shiki'` (see
+ * `packages/markdown/src/rendering/highlighter.ts` for the sibling adapter
+ * that established this pattern, and `docs/decisions/package-boundaries.md`
+ * for the ~10 MB measurement this converges on): the default `shiki` entry
+ * resolves to `bundle-full.mjs`, which statically references every bundled
+ * grammar and theme in one module. For a build that bundles that module with
+ * `splitting: false` — which is exactly how `scripts/build.ts` builds this
+ * adapter — every grammar and theme gets inlined into a single output file,
+ * regardless of which language is ever highlighted. `shiki` was already kept
+ * external in that build (so this specific file never actually shipped that
+ * weight), but the risk was one dependency-externals edit away from landing
+ * back in cinder's own published dist. `shiki/langs` and `shiki/themes`
+ * expose the same per-language and per-theme lookup tables `shiki`
+ * re-exports, but as standalone modules (metadata plus a lazy
+ * `() => import('@shikijs/langs/…')` per entry) that pull in no theme, wasm,
+ * or highlighter-construction code — so `scripts/build.ts` only needs to
+ * externalize `shiki/*` and `@shikijs/engine-oniguruma` (see its
+ * `runtimeDependencyExternals`) to keep every one of those per-language/
+ * per-theme dynamic imports lazy, exactly like the sibling markdown adapter.
+ * Downstream, a consumer's own bundler resolves and splits those imports the
+ * same way it already did for the old `shiki`-based version — this change
+ * does not reduce what a consumer app ships; it converges the pattern with
+ * `packages/markdown` and closes the build-time regression risk above.
  *
  * Behavior contract (matches the {@link Highlighter} type in
  * `@lostgradient/cinder/utilities/highlighter`):
@@ -44,6 +69,12 @@
  * fallback path here HTML-escapes the code (`&`, `<`, `>`, `"`, `'`) so
  * `{@html}` injection is safe for both branches.
  */
+
+import type {
+  DynamicImportLanguageRegistration,
+  DynamicImportThemeRegistration,
+  HighlighterCore,
+} from '@shikijs/types';
 
 import type { Highlighter } from '../../utilities/highlighter.ts';
 import { createRetryingLoaderCache } from '../../utilities/retrying-loader-cache.ts';
@@ -109,15 +140,49 @@ function plaintextBlock(code: string): string {
   return `<pre class="shiki shiki-plaintext"><code>${escapeHtml(code)}</code></pre>`;
 }
 
-type CodeToHtmlFunction = typeof import('shiki').codeToHtml;
-type BundledLanguages = typeof import('shiki').bundledLanguages;
+/**
+ * Widened to a plain string index (rather than `typeof import('shiki/langs')
+ * .bundledLanguages`, whose keys are a closed literal union) because lookups
+ * here are keyed by a `lang`/theme name string that is only known to be a
+ * member of that union after a runtime `Object.hasOwn` check.
+ */
+type BundledLanguages = Record<string, DynamicImportLanguageRegistration>;
+type BundledThemes = Record<string, DynamicImportThemeRegistration>;
 
 type ShikiModule = {
-  codeToHtml: CodeToHtmlFunction;
+  highlighter: HighlighterCore;
   bundledLanguages: BundledLanguages;
+  bundledThemes: BundledThemes;
 };
 
 type ShikiModuleLoader = () => Promise<ShikiModule>;
+
+/**
+ * Load (if not already loaded) the grammar registered under `lang` — a
+ * canonical Shiki language id or one of its native aliases, both of which
+ * are keys of `bundledLanguages`. `HighlighterCore.loadLanguage` is safe to
+ * call repeatedly for a language it already holds — the dynamic `import()`
+ * resolves from the module cache and re-registering is a cheap map write —
+ * so callers don't need to track what has already been loaded.
+ */
+async function ensureLanguageLoaded(shiki: ShikiModule, lang: string): Promise<void> {
+  const load = shiki.bundledLanguages[lang];
+  if (!load) throw new Error(`Language "${lang}" is not bundled with Shiki.`);
+  await shiki.highlighter.loadLanguage(load);
+}
+
+/** Load (if not already loaded) every theme named by `theme`. */
+async function ensureThemesLoaded(
+  shiki: ShikiModule,
+  theme: string | { light: string; dark: string },
+): Promise<void> {
+  const names = typeof theme === 'string' ? [theme] : [theme.light, theme.dark];
+  for (const name of names) {
+    const load = shiki.bundledThemes[name];
+    if (!load) throw new Error(`Theme "${name}" is not bundled with Shiki.`);
+    await shiki.highlighter.loadTheme(load);
+  }
+}
 
 /**
  * Create a Shiki-backed {@link Highlighter} suitable for
@@ -138,25 +203,40 @@ export function shikiHighlighter(
   const loadShiki = createRetryingLoaderCache(
     moduleLoader ??
       (async (): Promise<ShikiModule> => {
-        const module_ = await import('shiki');
-        // Optional preload — if the consumer named specific languages,
-        // force them through `codeToHtml` once so Shiki resolves and
+        const [{ createOnigurumaEngine }, { createHighlighterCore }, langsModule, themesModule] =
+          await Promise.all([
+            import('@shikijs/engine-oniguruma'),
+            import('shiki/core'),
+            import('shiki/langs'),
+            import('shiki/themes'),
+          ]);
+        const highlighter = await createHighlighterCore({
+          themes: [],
+          langs: [],
+          engine: createOnigurumaEngine(import('shiki/wasm')),
+        });
+        const shikiModule: ShikiModule = {
+          highlighter,
+          bundledLanguages: langsModule.bundledLanguages,
+          bundledThemes: themesModule.bundledThemes,
+        };
+
+        // Optional preload — if the consumer named specific languages, load
+        // them (and the configured theme) up front so Shiki resolves and
         // caches them before the first real call. Failures here are
-        // non-fatal; per-call language lookup will still try (and fall
-        // back to plaintext on its own miss).
+        // non-fatal; per-call language lookup will still try (and fall back
+        // to plaintext on its own miss).
         if (langs !== undefined) {
           for (const lang of langs) {
             try {
-              await module_.codeToHtml('', { lang, ...buildThemeOption(theme) });
+              await ensureThemesLoaded(shikiModule, theme);
+              await ensureLanguageLoaded(shikiModule, lang);
             } catch {
               // Swallow — the per-call path below logs and falls back.
             }
           }
         }
-        return {
-          codeToHtml: module_.codeToHtml,
-          bundledLanguages: module_.bundledLanguages,
-        };
+        return shikiModule;
       }),
   );
 
@@ -197,7 +277,9 @@ export function shikiHighlighter(
     }
 
     try {
-      const html = await shiki.codeToHtml(code, {
+      await ensureLanguageLoaded(shiki, normalizedLang);
+      await ensureThemesLoaded(shiki, theme);
+      const html = shiki.highlighter.codeToHtml(code, {
         lang: normalizedLang,
         ...buildThemeOption(theme),
       });

--- a/packages/components/src/highlighters/shiki/shiki.test.ts
+++ b/packages/components/src/highlighters/shiki/shiki.test.ts
@@ -1,5 +1,9 @@
 /// <reference lib="dom" />
+import { resolve as resolvePath } from 'node:path';
+
+import { $ } from 'bun';
 import { afterEach, describe, expect, test } from 'bun:test';
+import ts from 'typescript';
 
 import { setupHappyDom } from '../../test/happy-dom.ts';
 import { stripRootPreTabIndex } from './strip-root-pre-tab-index.ts';
@@ -144,9 +148,17 @@ describe('shikiHighlighter — happy path', () => {
         {},
         async () =>
           ({
-            bundledLanguages: { javascript: {} },
-            codeToHtml: async () => {
-              throw new Error('highlight failed');
+            highlighter: {
+              loadLanguage: async () => {},
+              loadTheme: async () => {},
+              codeToHtml: () => {
+                throw new Error('highlight failed');
+              },
+            },
+            bundledLanguages: { javascript: async () => ({}) },
+            bundledThemes: {
+              'github-light': async () => ({}),
+              'github-dark': async () => ({}),
             },
           }) as unknown as Awaited<ReturnType<NonNullable<Parameters<typeof shikiHighlighter>[1]>>>,
       );
@@ -279,5 +291,100 @@ describe('shikiHighlighter — fallback contract', () => {
     expect(html).not.toContain('<script>alert(1)</script>');
     const escaped = /&lt;|&#x3[Cc];|&#60;/.test(html);
     expect(escaped).toBe(true);
+  });
+});
+
+describe('shikiHighlighter — import strategy (issue #773)', () => {
+  // Pins the fix for #773: this adapter must never pull in Shiki's default
+  // `shiki` barrel (which statically references every bundled grammar and
+  // theme in one module — see `docs/decisions/package-boundaries.md` for the
+  // ~10 MB measurement). It must instead build on `shiki/core` +
+  // `@shikijs/engine-oniguruma`, resolving languages and themes through the
+  // standalone `shiki/langs` / `shiki/themes` lookup tables, converging on
+  // the same pattern `packages/markdown` already uses. See the next test for
+  // why that matters given cinder's OWN `splitting: false` build.
+  test('never imports the bare `shiki` module specifier (static or dynamic)', async () => {
+    const filePath = resolvePath(import.meta.dir, 'index.ts');
+    const source = await Bun.file(filePath).text();
+    const sourceFile = ts.createSourceFile(filePath, source, ts.ScriptTarget.Latest, true);
+    const specifiers: string[] = [];
+
+    function visit(node: ts.Node): void {
+      if (
+        (ts.isImportDeclaration(node) || ts.isExportDeclaration(node)) &&
+        node.moduleSpecifier !== undefined &&
+        ts.isStringLiteral(node.moduleSpecifier)
+      ) {
+        specifiers.push(node.moduleSpecifier.text);
+      }
+      if (
+        ts.isCallExpression(node) &&
+        node.expression.kind === ts.SyntaxKind.ImportKeyword &&
+        node.arguments[0] !== undefined &&
+        ts.isStringLiteral(node.arguments[0])
+      ) {
+        specifiers.push(node.arguments[0].text);
+      }
+      ts.forEachChild(node, visit);
+    }
+    visit(sourceFile);
+
+    expect(specifiers).not.toContain('shiki');
+    expect(specifiers).toContain('shiki/core');
+    expect(specifiers).toContain('shiki/langs');
+    expect(specifiers).toContain('shiki/themes');
+    expect(specifiers).toContain('shiki/wasm');
+    expect(specifiers).toContain('@shikijs/engine-oniguruma');
+  });
+
+  test('resolves a language far outside the sibling markdown package’s fixed 12-language set', async () => {
+    // `packages/markdown` deliberately narrows to 12 languages. This adapter's
+    // contract is broader — any language Shiki bundles — so prove a language
+    // well outside that fixed set (Rust) still resolves through the real
+    // per-language dynamic import, not a hardcoded list.
+    const highlight = shikiHighlighter();
+    const html = await highlight('fn main() {}', 'rust');
+    expect(html.startsWith('<pre')).toBe(true);
+    expect(html).toMatch(/<span[^>]*style=/);
+  });
+
+  test("cinder's own build externalizes every Shiki subpath this adapter imports", async () => {
+    // The real regression this issue guards against: `scripts/build.ts` runs
+    // with `splitting: false`, so any Shiki-family specifier THIS file
+    // imports that is missing from that build's `external` list gets
+    // inlined whole into cinder's own published `dist/highlighters/shiki/index.js`
+    // — vendoring every bundled grammar (~10 MB) into cinder's package
+    // regardless of what a consumer ever highlights. Build this file
+    // in isolation with exactly the externals `scripts/build.ts` declares
+    // and assert the output stays tiny (our own adapter code only, no
+    // vendored Shiki internals).
+    const buildScriptPath = resolvePath(import.meta.dir, '../../../scripts/build.ts');
+    const buildScriptSource = await Bun.file(buildScriptPath).text();
+    for (const required of ['@shikijs/engine-oniguruma', "'shiki/*'", "'shiki',"]) {
+      expect(
+        buildScriptSource.includes(required),
+        `scripts/build.ts must externalize ${required} for the Shiki adapter`,
+      ).toBe(true);
+    }
+
+    const entryPath = resolvePath(import.meta.dir, 'index.ts');
+    const outdirectory = `${import.meta.dir}/.build-weight-probe-${process.pid}`;
+    try {
+      const result = await Bun.build({
+        entrypoints: [entryPath],
+        outdir: outdirectory,
+        target: 'browser',
+        format: 'esm',
+        splitting: false,
+        external: ['svelte', 'svelte/*', 'shiki', 'shiki/*', '@shikijs/engine-oniguruma'],
+      });
+      expect(result.success).toBe(true);
+      const totalBytes = result.outputs.reduce((sum, output) => sum + output.size, 0);
+      // Our own adapter is a few KB; anything approaching Shiki's grammar
+      // bundle (~10 MB) means a subpath leaked into the output uninlined.
+      expect(totalBytes).toBeLessThan(100_000);
+    } finally {
+      await $`rm -rf ${outdirectory}`.quiet();
+    }
   });
 });

--- a/packages/components/src/highlighters/shiki/shiki.test.ts
+++ b/packages/components/src/highlighters/shiki/shiki.test.ts
@@ -1,7 +1,7 @@
 /// <reference lib="dom" />
+import { rm } from 'node:fs/promises';
 import { resolve as resolvePath } from 'node:path';
 
-import { $ } from 'bun';
 import { afterEach, describe, expect, test } from 'bun:test';
 import ts from 'typescript';
 
@@ -160,6 +160,7 @@ describe('shikiHighlighter — happy path', () => {
               'github-light': async () => ({}),
               'github-dark': async () => ({}),
             },
+            guessEmbeddedLanguages: () => [],
           }) as unknown as Awaited<ReturnType<NonNullable<Parameters<typeof shikiHighlighter>[1]>>>,
       );
       const first = await highlight('const x = 1;', 'javascript');
@@ -348,6 +349,32 @@ describe('shikiHighlighter — import strategy (issue #773)', () => {
     expect(html).toMatch(/<span[^>]*style=/);
   });
 
+  test('loads embedded grammars for compound languages (Markdown with a fenced TypeScript block)', async () => {
+    // The previous `import('shiki').codeToHtml` shorthand auto-loaded
+    // grammars embedded in the source via `guessEmbeddedLanguages` (fenced
+    // code inside Markdown, `<script lang="...">` inside Svelte/Vue/HTML).
+    // `ensureLanguageLoaded` alone only loads the requested top-level
+    // language, so a Markdown document whose fenced block requests a
+    // grammar Markdown itself doesn't declare (`typescript`, here) needs
+    // the embedded-language loader to still highlight that nested region.
+    const highlight = shikiHighlighter();
+    const html = await highlight('```typescript\nconst x: number = 1;\n```\n', 'markdown');
+    expect(html.startsWith('<pre')).toBe(true);
+    // Without the embedded grammar loaded, Shiki tokenizes the fenced
+    // region as one flat run — every token shares Markdown's single plain-
+    // text color. With `typescript` loaded, `const`/`number` get the
+    // theme's distinct keyword/type colors. So more than one unique
+    // `color:` value appearing is the signal that the embedded TypeScript
+    // grammar actually tokenized the fence content, not just Markdown's own
+    // outer grammar (which alone would still emit *a* styled `<span>`, just
+    // always the same color — a weaker assertion this regression would slip
+    // through).
+    const colors = new Set(
+      Array.from(html.matchAll(/color:#[0-9A-Fa-f]{6}/g), (match) => match[0]),
+    );
+    expect(colors.size).toBeGreaterThan(1);
+  });
+
   test("cinder's own build externalizes every Shiki subpath this adapter imports", async () => {
     // The real regression this issue guards against: `scripts/build.ts` runs
     // with `splitting: false`, so any Shiki-family specifier THIS file
@@ -360,10 +387,14 @@ describe('shikiHighlighter — import strategy (issue #773)', () => {
     // vendored Shiki internals).
     const buildScriptPath = resolvePath(import.meta.dir, '../../../scripts/build.ts');
     const buildScriptSource = await Bun.file(buildScriptPath).text();
-    for (const required of ['@shikijs/engine-oniguruma', "'shiki/*'", "'shiki',"]) {
+    // Regex-based rather than exact-substring so this survives quote-style or
+    // formatting changes to the externals list — it only pins that each
+    // specifier appears as its own quoted string literal somewhere in the file.
+    for (const required of ['@shikijs/engine-oniguruma', 'shiki/\\*', 'shiki']) {
+      const pattern = new RegExp(`['"]${required}['"]`);
       expect(
-        buildScriptSource.includes(required),
-        `scripts/build.ts must externalize ${required} for the Shiki adapter`,
+        pattern.test(buildScriptSource),
+        `scripts/build.ts must externalize a '${required}' specifier for the Shiki adapter`,
       ).toBe(true);
     }
 
@@ -384,7 +415,7 @@ describe('shikiHighlighter — import strategy (issue #773)', () => {
       // bundle (~10 MB) means a subpath leaked into the output uninlined.
       expect(totalBytes).toBeLessThan(100_000);
     } finally {
-      await $`rm -rf ${outdirectory}`.quiet();
+      await rm(outdirectory, { recursive: true, force: true });
     }
   });
 });

--- a/packages/components/src/highlighters/shiki/shiki.test.ts
+++ b/packages/components/src/highlighters/shiki/shiki.test.ts
@@ -381,15 +381,23 @@ describe('shikiHighlighter — import strategy (issue #773)', () => {
     // imports that is missing from that build's `external` list gets
     // inlined whole into cinder's own published `dist/highlighters/shiki/index.js`
     // — vendoring every bundled grammar (~10 MB) into cinder's package
-    // regardless of what a consumer ever highlights. Build this file
-    // in isolation with exactly the externals `scripts/build.ts` declares
-    // and assert the output stays tiny (our own adapter code only, no
-    // vendored Shiki internals).
+    // regardless of what a consumer ever highlights.
+    //
+    // This is two separate, complementary checks rather than one — they are
+    // NOT reading the same list, so a change to `scripts/build.ts` alone
+    // cannot silently desync this test:
+    //   1. Below: regex-check that `scripts/build.ts`'s SOURCE TEXT contains
+    //      each required specifier as its own quoted string literal
+    //      (independent of quote style/formatting, so a prettier pass alone
+    //      can't break it).
+    //   2. Further down: build THIS file with a copy of that same external
+    //      list, hand-kept in sync with `scripts/build.ts` (not read from
+    //      it), and assert output stays tiny. If `scripts/build.ts` and this
+    //      hard-coded copy drift apart, check 1 still catches a REMOVED
+    //      entry, and check 2 still catches what actually happens to THIS
+    //      file's build output under whatever list is written here.
     const buildScriptPath = resolvePath(import.meta.dir, '../../../scripts/build.ts');
     const buildScriptSource = await Bun.file(buildScriptPath).text();
-    // Regex-based rather than exact-substring so this survives quote-style or
-    // formatting changes to the externals list — it only pins that each
-    // specifier appears as its own quoted string literal somewhere in the file.
     for (const required of ['@shikijs/engine-oniguruma', 'shiki/\\*', 'shiki']) {
       const pattern = new RegExp(`['"]${required}['"]`);
       expect(
@@ -401,6 +409,9 @@ describe('shikiHighlighter — import strategy (issue #773)', () => {
     const entryPath = resolvePath(import.meta.dir, 'index.ts');
     const outdirectory = `${import.meta.dir}/.build-weight-probe-${process.pid}`;
     try {
+      // Kept in sync with `scripts/build.ts`'s `runtimeDependencyExternals`
+      // by hand — see the comment above for why that's an acceptable,
+      // covered gap rather than reading the list dynamically.
       const result = await Bun.build({
         entrypoints: [entryPath],
         outdir: outdirectory,


### PR DESCRIPTION
## Summary

- Converges `packages/components/src/highlighters/shiki/index.ts` on `shiki/core` + `@shikijs/engine-oniguruma`, resolving languages and themes lazily through `shiki/langs` / `shiki/themes` instead of the default `shiki` barrel (`bundledLanguages`/`codeToHtml`) — the same pattern `packages/markdown/src/rendering/highlighter.ts` already uses.
- Fixes `packages/components/scripts/build.ts` to externalize `shiki/*` and `@shikijs/engine-oniguruma` (both browser and server build configs), alongside the existing bare `shiki` entry.
- No change to the public `shikiHighlighter()` API, its behavior, or the supported language/theme set (any of Shiki's bundled languages — this adapter intentionally does not narrow to a fixed list the way `packages/markdown` does).

## Honest measured finding (please read before reviewing)

The issue's premise was that this adapter ships ~10 MB of Shiki grammars to every consumer. I measured this directly with `Bun.build` rather than assuming it:

- **Consumer-side bundle weight is neutral.** A downstream consumer's own bundler already externalized the bare `shiki` specifier and already code-split it per language (~350 lazy chunks, ~9.8 MB total reachable either way, in a fair before/after comparison). This change does not reduce what a consumer app ships.
- **The real, concrete regression this closes is build-time, in cinder's own package.** `scripts/build.ts` builds this adapter with `splitting: false` and, before this change, only externalized the bare `shiki` specifier — not any `shiki/*` subpath. Naively switching this file to `shiki/core` + `shiki/langs` + `shiki/themes` + `shiki/wasm` + `@shikijs/engine-oniguruma` **without** updating the externals list would have inlined ~9.7 MB of Shiki grammars directly into cinder's own published `dist/highlighters/shiki/index.js` (measured — this actually happened during development of this PR before the `build.ts` fix landed). With the externals fix, output for this file is back to ~4.5 KB.

So: this PR converges the pattern (matches `packages/markdown`, matches the issue's explicit ask) and prevents a real regression, but does **not** deliver a consumer-side bundle-size win — the current code already avoided that cost via `scripts/build.ts`'s existing `shiki` external entry. Reviewers should not read this as "cuts 10 MB from consumer apps."

## Test plan

- [x] `bun run test -- src/highlighters/shiki` — 22 tests pass, including two new regression tests:
  - Pins the import strategy (asserts the module never references bare `shiki`, does reference `shiki/core`/`shiki/langs`/`shiki/themes`/`shiki/wasm`/`@shikijs/engine-oniguruma`).
  - Runs `Bun.build` against `index.ts` with the exact externals `scripts/build.ts` declares and asserts total output stays under 100 KB (guards the build-time regression directly).
  - A language far outside `packages/markdown`'s fixed 12-language set (Rust) still resolves, proving the broader language contract held.
- [x] `bun run typecheck` — clean.
- [x] Full package build (`bun run build` via the scoped pre-push gate) — passed.
- [x] Pre-push scoped validation — passed.

Closes #773


## Update (review feedback)

Copilot and Codex left 6 review comments; all addressed and threads resolved:

- **Codex P2 — embedded grammars weren't loaded** (real regression, verified before fixing: a Markdown doc with a fenced ` ```typescript ` block rendered the fence content as flat plaintext without this fix). Fixed by calling Shiki's own `guessEmbeddedLanguages` heuristic after loading the top-level language, mirroring what the old singleton `codeToHtml` shorthand did automatically. Added a regression test that fails without the fix.
- **Codex P2 — Shiki core wasn't shared across `shikiHighlighter()` instances.** Fixed with a module-level `getSharedShikiModule()` cache (bypassed by the test-only `moduleLoader` injection param, so tests stay isolated) — restores the sharing the old process-wide singleton gave for free.
- **Copilot — theme reloaded once per preloaded language.** Hoisted `ensureThemesLoaded()` out of the preload loop.
- **Copilot (x2) — test cleanup used a Bun `$` shell call.** Switched to `node:fs/promises` `rm()`, matching `tree-shake.test.ts`.
- **Copilot — brittle exact-substring assertion on `build.ts`'s externals list.** Replaced with a regex-based check.

Consumer bundle weight framing is unchanged and still accurate: none of these fixes touch what a consumer's own bundler ships.