### PR TITLE
fix(chat): own conversationalist and zod as regular dependencies

### DIFF
--- a/.changeset/chat-owns-conversationalist-dependency.md
+++ b/.changeset/chat-owns-conversationalist-dependency.md
@@ -1,0 +1,9 @@
+---
+'@lostgradient/chat': minor
+---
+
+`@lostgradient/chat` now owns its `conversationalist` and `zod` dependencies instead of declaring them as `peerDependencies`. Host applications no longer need to `bun add conversationalist zod` (or pick a compatible version) themselves — both install automatically alongside `@lostgradient/chat`. `@lostgradient/cinder` and `svelte` remain peer dependencies, since your application must control which single copy of those renders.
+
+`@lostgradient/chat` also re-exports `isJSONValue` from `conversationalist`, so consumers validating message content, metadata, or tool-call arguments before constructing a conversation no longer need to import `conversationalist` directly for it.
+
+**Consumer impact:** if your app currently lists `conversationalist` and/or `zod` as direct dependencies solely to satisfy `@lostgradient/chat`'s former peer requirement, you can remove them — `@lostgradient/chat` now supplies its own compatible version. If your app also uses `conversationalist` directly for something beyond what `@lostgradient/chat` re-exports (e.g. its adapters or schemas), keep your own dependency; npm/bun will de-duplicate compatible versions in the tree.

--- a/README.md
+++ b/README.md
@@ -16,10 +16,10 @@ bun add @lostgradient/cinder svelte lucide-svelte
 It uses Lucide for its own component chrome, but it does not provide a general icon library for
 your application-specific icons.
 
-Install the Chat domain suite separately when you need it:
+Install the Chat domain suite separately when you need it, alongside the Cinder install above:
 
 ```bash
-bun add @lostgradient/chat @lostgradient/cinder svelte
+bun add @lostgradient/chat
 ```
 
 Chat's `conversationalist` conversation model (and its `zod` dependency) ships as a regular dependency of `@lostgradient/chat` — it installs automatically and you never add it yourself.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Components for product interfaces.
 
-The core package is `@lostgradient/cinder`: accessible primitives, domain-suite components, design-system tokens, per-component CSS, generated prop schemas, and examples that can be read by people or tooling. The Chat domain suite is published separately as `@lostgradient/chat`, with Cinder and its other runtime libraries supplied by the consuming application as peer dependencies.
+The core package is `@lostgradient/cinder`: accessible primitives, domain-suite components, design-system tokens, per-component CSS, generated prop schemas, and examples that can be read by people or tooling. The Chat domain suite is published separately as `@lostgradient/chat`, with Cinder and Svelte supplied by the consuming application as peer dependencies. Chat's own conversation-model dependency (`conversationalist`) ships with it — the consuming application never installs that directly.
 
 Use Cinder when you want UI building blocks without adopting a framework-level router, form-state manager, data fetching layer, global state provider, or theme provider. The package is SSR-safe.
 
@@ -19,8 +19,10 @@ your application-specific icons.
 Install the Chat domain suite separately when you need it:
 
 ```bash
-bun add @lostgradient/chat @lostgradient/cinder conversationalist zod svelte
+bun add @lostgradient/chat @lostgradient/cinder svelte
 ```
+
+Chat's `conversationalist` conversation model (and its `zod` dependency) ships as a regular dependency of `@lostgradient/chat` — it installs automatically and you never add it yourself.
 
 Rich editor, markdown rendering, editor/commentary re-exports, and syntax-highlighting surfaces
 use optional peer dependencies. Install them only when your app imports

--- a/bun.lock
+++ b/bun.lock
@@ -23,13 +23,16 @@
     "packages/chat": {
       "name": "@lostgradient/chat",
       "version": "0.1.1",
+      "dependencies": {
+        "conversationalist": "^0.2.1 || ^0.4.1",
+        "zod": "4.4.1",
+      },
       "devDependencies": {
         "@lostgradient/cinder": "workspace:*",
         "@sveltejs/package": "^2.5.8",
         "@testing-library/svelte": "^5.2.7",
         "@types/bun": "^1.3.11",
         "ajv": "^8",
-        "conversationalist": "^0.4.1",
         "happy-dom": "^15.11.7",
         "oxlint": "^1.56.0",
         "postcss": "^8.5.15",
@@ -37,13 +40,10 @@
         "svelte": "~5.56.0",
         "svelte-check": "^4.0.0",
         "typescript": "^5.9.0",
-        "zod": "4.4.1",
       },
       "peerDependencies": {
         "@lostgradient/cinder": "^0.16.0",
-        "conversationalist": "^0.2.1 || ^0.4.1",
         "svelte": ">=5.56.0 <6",
-        "zod": "4.4.1",
       },
     },
     "packages/commentary": {

--- a/packages/chat/README.md
+++ b/packages/chat/README.md
@@ -7,10 +7,10 @@
 Install the package and its peer dependencies together:
 
 ```bash
-bun add @lostgradient/chat @lostgradient/cinder conversationalist lucide-svelte svelte zod
+bun add @lostgradient/chat @lostgradient/cinder lucide-svelte svelte
 ```
 
-The supported Svelte peer range is `>=5.56.0 <6`; this package is developed against Svelte `5.56.0`. All runtime integrations are peer dependencies, including `@lostgradient/cinder`, `conversationalist`, and `zod`. Cinder also requires `lucide-svelte` for its component icons. The package has no production dependencies of its own.
+The supported Svelte peer range is `>=5.56.0 <6`; this package is developed against Svelte `5.56.0`. `@lostgradient/cinder` and `svelte` are peer dependencies — your application supplies a single copy of each. Cinder also requires `lucide-svelte` for its component icons. Chat's conversation model is built on `conversationalist`, which Chat declares as its own regular dependency: it is installed automatically with `@lostgradient/chat` and you never need to `bun add` it (or `zod`, one of its dependencies) yourself. Import the conversation types, builders, and `CURRENT_SCHEMA_VERSION` from `@lostgradient/chat` rather than from `conversationalist` directly.
 
 Import Cinder's global styles once in your application, then import Chat from the package root:
 

--- a/packages/chat/package.json
+++ b/packages/chat/package.json
@@ -167,28 +167,27 @@
     "validate": "bun run lint && bun run typecheck && bun run test:coverage && bun run platform:audit && bun run colors:audit && bun run tokens:audit && bun run components:check && bun run build",
     "validate:consumer": "bun run scripts/validate-consumer.ts"
   },
-  "dependencies": {},
+  "dependencies": {
+    "conversationalist": "^0.2.1 || ^0.4.1",
+    "zod": "4.4.1"
+  },
   "devDependencies": {
     "@lostgradient/cinder": "workspace:*",
     "@sveltejs/package": "^2.5.8",
     "@testing-library/svelte": "^5.2.7",
     "@types/bun": "^1.3.11",
     "ajv": "^8",
-    "conversationalist": "^0.4.1",
     "happy-dom": "^15.11.7",
     "oxlint": "^1.56.0",
     "postcss": "^8.5.15",
     "prettier": "^3.8.1",
     "svelte": "~5.56.0",
     "svelte-check": "^4.0.0",
-    "typescript": "^5.9.0",
-    "zod": "4.4.1"
+    "typescript": "^5.9.0"
   },
   "peerDependencies": {
     "@lostgradient/cinder": "^0.16.0",
-    "conversationalist": "^0.2.1 || ^0.4.1",
-    "svelte": ">=5.56.0 <6",
-    "zod": "4.4.1"
+    "svelte": ">=5.56.0 <6"
   },
   "engines": {
     "bun": ">=1.3.0"

--- a/packages/chat/scripts/build.ts
+++ b/packages/chat/scripts/build.ts
@@ -57,7 +57,7 @@ const serverCssNoopPlugin: BunPlugin = {
 const packageManifest = parsePackageManifest(
   await Bun.file(join(PACKAGE_ROOT, 'package.json')).text(),
 );
-const peerExternals = runtimeExternalSpecifiers(packageManifest);
+const runtimeExternals = runtimeExternalSpecifiers(packageManifest);
 async function buildServerEntries() {
   const previousNodeEnvironment = process.env['NODE_ENV'];
   process.env['NODE_ENV'] = 'production';
@@ -70,7 +70,7 @@ async function buildServerEntries() {
       target: 'node',
       format: 'esm',
       splitting: true,
-      external: peerExternals,
+      external: runtimeExternals,
       naming: {
         entry: '[dir]/[name].[ext]',
         chunk: '_chunks/[name]-[hash].[ext]',

--- a/packages/chat/scripts/build.ts
+++ b/packages/chat/scripts/build.ts
@@ -4,7 +4,7 @@ import { existsSync } from 'node:fs';
 import { join } from 'node:path';
 
 import { sveltePlugin } from '../../components/scripts/svelte-plugin.ts';
-import { parsePackageManifest, peerExternalSpecifiers } from './pack-for-publish.ts';
+import { parsePackageManifest, runtimeExternalSpecifiers } from './pack-for-publish.ts';
 
 const PACKAGE_ROOT = join(import.meta.dir, '..');
 
@@ -57,7 +57,7 @@ const serverCssNoopPlugin: BunPlugin = {
 const packageManifest = parsePackageManifest(
   await Bun.file(join(PACKAGE_ROOT, 'package.json')).text(),
 );
-const peerExternals = peerExternalSpecifiers(packageManifest);
+const peerExternals = runtimeExternalSpecifiers(packageManifest);
 async function buildServerEntries() {
   const previousNodeEnvironment = process.env['NODE_ENV'];
   process.env['NODE_ENV'] = 'production';

--- a/packages/chat/scripts/pack-for-publish.ts
+++ b/packages/chat/scripts/pack-for-publish.ts
@@ -27,7 +27,16 @@ export type PackageManifest = {
 
 const PACKAGE_ROOT = join(import.meta.dir, '..');
 const STAGING_ROOT = join(PACKAGE_ROOT, 'node_modules', '.cache', 'publish-staging');
-const REQUIRED_PEERS = new Set(['@lostgradient/cinder', 'conversationalist', 'svelte', 'zod']);
+// `@lostgradient/cinder` and `svelte` are host-supplied runtime singletons: a
+// consuming app must control which copy renders. `conversationalist` and
+// `zod` are implementation details of Chat's conversation model — Chat owns
+// them as regular dependencies so host apps never install or version-pick
+// them directly.
+const REQUIRED_PEERS = new Set(['@lostgradient/cinder', 'svelte']);
+const REQUIRED_DEPENDENCIES: Record<string, string> = {
+  conversationalist: '^0.2.1 || ^0.4.1',
+  zod: '4.4.1',
+};
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
@@ -87,8 +96,14 @@ function tarballFileName(manifest: Pick<PackageManifest, 'name' | 'version'>): s
 }
 
 export function assertSourceManifest(manifest: PackageManifest): void {
-  if (Object.keys(manifest.dependencies ?? {}).length > 0) {
-    throw new Error('@lostgradient/chat must not declare production dependencies');
+  const dependencies = manifest.dependencies ?? {};
+  const dependencyMismatch =
+    Object.keys(dependencies).length !== Object.keys(REQUIRED_DEPENDENCIES).length ||
+    Object.entries(REQUIRED_DEPENDENCIES).some(([name, range]) => dependencies[name] !== range);
+  if (dependencyMismatch) {
+    throw new Error(
+      `production dependency contract mismatch (expected exactly ${JSON.stringify(REQUIRED_DEPENDENCIES)}, got ${JSON.stringify(dependencies)})`,
+    );
   }
   const peers = new Set(Object.keys(manifest.peerDependencies ?? {}));
   const missing = [...REQUIRED_PEERS].filter((peer) => !peers.has(peer));
@@ -100,11 +115,21 @@ export function assertSourceManifest(manifest: PackageManifest): void {
   }
 }
 
-/** Keep every runtime peer external in generated server bundles, including subpath imports. */
-export function peerExternalSpecifiers(
-  manifest: Pick<PackageManifest, 'peerDependencies'>,
+/**
+ * Keep every runtime import external in generated server bundles, including
+ * subpath imports — both host-supplied peers (`@lostgradient/cinder`,
+ * `svelte`) and Chat-owned dependencies (`conversationalist`, `zod`). Neither
+ * category should be inlined into the published dist; both resolve from
+ * `node_modules` at install time.
+ */
+export function runtimeExternalSpecifiers(
+  manifest: Pick<PackageManifest, 'peerDependencies' | 'dependencies'>,
 ): string[] {
-  return Object.keys(manifest.peerDependencies ?? {}).flatMap((peer) => [peer, `${peer}/*`]);
+  const names = [
+    ...Object.keys(manifest.peerDependencies ?? {}),
+    ...Object.keys(manifest.dependencies ?? {}),
+  ];
+  return names.flatMap((name) => [name, `${name}/*`]);
 }
 
 function publishedExport(entry: string | ConditionalExport): string | ConditionalExport {
@@ -144,7 +169,8 @@ export function buildPublishedManifest(source: PackageManifest): PackageManifest
     ],
   };
 
-  delete published.dependencies;
+  // `dependencies` is retained: it is how npm/bun install conversationalist
+  // and zod for a host application without that host declaring them itself.
   delete published.devDependencies;
   delete published.optionalDependencies;
   delete published.scripts;

--- a/packages/chat/scripts/package-boundary.test.ts
+++ b/packages/chat/scripts/package-boundary.test.ts
@@ -4,7 +4,7 @@ import { join } from 'node:path';
 import {
   assertSourceManifest,
   buildPublishedManifest,
-  peerExternalSpecifiers,
+  runtimeExternalSpecifiers,
   type PackageManifest,
 } from './pack-for-publish.ts';
 
@@ -34,22 +34,23 @@ describe('Chat package ownership boundary', () => {
     }
   });
 
-  test('keeps every Chat runtime integration peer-only', () => {
+  test('keeps host-supplied runtime singletons peer-only and owns its conversation-model dependencies', () => {
     expect(() => assertSourceManifest(chatManifest)).not.toThrow();
-    expect(chatManifest.dependencies).toEqual({});
-    expect(chatManifest.peerDependencies).toEqual({
-      '@lostgradient/cinder': '^0.16.0',
+    expect(chatManifest.dependencies).toEqual({
       conversationalist: '^0.2.1 || ^0.4.1',
-      svelte: '>=5.56.0 <6',
       zod: '4.4.1',
     });
-    expect(peerExternalSpecifiers(chatManifest)).toEqual([
+    expect(chatManifest.peerDependencies).toEqual({
+      '@lostgradient/cinder': '^0.16.0',
+      svelte: '>=5.56.0 <6',
+    });
+    expect(runtimeExternalSpecifiers(chatManifest)).toEqual([
       '@lostgradient/cinder',
       '@lostgradient/cinder/*',
-      'conversationalist',
-      'conversationalist/*',
       'svelte',
       'svelte/*',
+      'conversationalist',
+      'conversationalist/*',
       'zod',
       'zod/*',
     ]);
@@ -91,7 +92,7 @@ describe('Chat package ownership boundary', () => {
     const published = buildPublishedManifest(chatManifest);
     const serialized = JSON.stringify(published);
 
-    expect(published.dependencies).toBeUndefined();
+    expect(published.dependencies).toEqual(chatManifest.dependencies);
     expect(published.devDependencies).toBeUndefined();
     expect(published.scripts).toBeUndefined();
     expect(serialized).not.toContain('workspace:');

--- a/packages/chat/scripts/validate-consumer.ts
+++ b/packages/chat/scripts/validate-consumer.ts
@@ -15,7 +15,16 @@ import {
 
 const packageRoot = join(import.meta.dir, '..');
 const workspaceRoot = resolve(packageRoot, '../..');
-const requiredPeers = ['@lostgradient/cinder', 'conversationalist', 'svelte', 'zod'] as const;
+// Host-supplied runtime singletons — the fixture symlinks these into its
+// top-level node_modules the way a real host app would after installing
+// them directly.
+const requiredPeers = ['@lostgradient/cinder', 'svelte'] as const;
+// Chat's own conversation-model dependencies — the fixture symlinks these
+// into the *installed chat package's own* node_modules, simulating what a
+// package manager does automatically for a regular `dependencies` entry
+// (nested resolution), never into the fixture's top-level node_modules. A
+// host app never provides these.
+const requiredOwnDependencies = ['conversationalist', 'zod'] as const;
 
 type ValidationFixture = {
   root: string;
@@ -39,10 +48,9 @@ async function run(command: string, arguments_: string[], cwd = packageRoot): Pr
 }
 
 function assertPackedManifest(manifest: PackageManifest): void {
-  assertSourceManifest({ ...manifest, dependencies: manifest.dependencies ?? {} });
-  if (manifest.dependencies !== undefined) {
-    fail('packed manifest must omit dependencies');
-  }
+  // assertSourceManifest enforces the exact `dependencies` contract
+  // (conversationalist + zod) and the exact peer set.
+  assertSourceManifest(manifest);
   if (manifest.devDependencies !== undefined) fail('packed manifest must omit devDependencies');
   if (manifest.optionalDependencies !== undefined) {
     fail('packed manifest must omit optionalDependencies');
@@ -86,42 +94,75 @@ async function assertPackedFileSet(installedChatRoot: string): Promise<void> {
   }
 }
 
-async function assertNoBundledPeerProvenance(
+/**
+ * Neither host-supplied peers nor Chat-owned dependencies should ever be
+ * inlined into the published server bundle — both resolve from
+ * `node_modules` at install time instead.
+ */
+async function assertNoBundledRuntimeProvenance(
   manifest: PackageManifest,
   installedChatRoot: string,
 ): Promise<void> {
-  const bundledPeers = new Set<string>();
+  const bundledSpecifiers = new Set<string>();
   const serverSourceGlob = new Glob('dist/server/**/*.js');
+  const runtimeSpecifiers = [
+    ...Object.keys(manifest.peerDependencies ?? {}),
+    ...Object.keys(manifest.dependencies ?? {}),
+  ];
   for await (const relativePath of serverSourceGlob.scan({ cwd: installedChatRoot })) {
     const bundledSource = await Bun.file(join(installedChatRoot, relativePath)).text();
     const source = bundledSource.replaceAll('\\', '/');
-    for (const peer of Object.keys(manifest.peerDependencies ?? {})) {
-      if (source.includes(`/node_modules/${peer}/`)) bundledPeers.add(peer);
+    for (const specifier of runtimeSpecifiers) {
+      if (source.includes(`/node_modules/${specifier}/`)) bundledSpecifiers.add(specifier);
     }
   }
-  if (bundledPeers.size > 0) {
+  if (bundledSpecifiers.size > 0) {
     fail(
-      `packed server artifact bundles declared peers: ${[...bundledPeers].toSorted().join(', ')}`,
+      `packed server artifact bundles declared runtime imports: ${[...bundledSpecifiers].toSorted().join(', ')}`,
     );
   }
 }
 
-async function linkPeer(
-  peer: (typeof requiredPeers)[number],
-  fixtureNodeModules: string,
+async function linkModule(
+  specifier: string,
+  destinationRoot: string,
+  sourceOverride?: string,
 ): Promise<void> {
-  const source =
-    peer === '@lostgradient/cinder'
-      ? join(workspaceRoot, 'packages', 'components')
-      : join(workspaceRoot, 'node_modules', ...peer.split('/'));
-  if (!existsSync(source)) fail(`workspace peer is unavailable: ${peer}`);
+  const source = sourceOverride ?? join(workspaceRoot, 'node_modules', ...specifier.split('/'));
+  if (!existsSync(source)) fail(`workspace module is unavailable: ${specifier}`);
 
-  const destination = join(fixtureNodeModules, ...peer.split('/'));
+  const destination = join(destinationRoot, ...specifier.split('/'));
   await mkdir(dirname(destination), { recursive: true });
   await symlink(source, destination, process.platform === 'win32' ? 'junction' : 'dir');
 }
 
-async function installPackedArtifact(
+/** Links a host-supplied peer into the fixture's top-level node_modules, simulating a real host install. */
+async function linkPeer(
+  peer: (typeof requiredPeers)[number],
+  fixtureNodeModules: string,
+): Promise<void> {
+  const sourceOverride =
+    peer === '@lostgradient/cinder' ? join(workspaceRoot, 'packages', 'components') : undefined;
+  await linkModule(peer, fixtureNodeModules, sourceOverride);
+}
+
+/**
+ * Links a Chat-owned dependency into the *installed chat package's own*
+ * node_modules — never the fixture's top-level node_modules. This is what
+ * proves the fix: a host app that never installed `conversationalist` or
+ * `zod` itself can still resolve them, because they arrive nested under
+ * `@lostgradient/chat` the way a package manager installs any other regular
+ * `dependencies` entry.
+ */
+async function linkOwnDependency(
+  dependency: (typeof requiredOwnDependencies)[number],
+  installedChatRoot: string,
+): Promise<void> {
+  await linkModule(dependency, join(installedChatRoot, 'node_modules'));
+}
+
+/** Extracts the packed tarball only — no linking yet, so the pure-artifact assertions below inspect exactly what was published. */
+async function extractPackedArtifact(
   tarballPath: string,
   fixture: ValidationFixture,
 ): Promise<PackageManifest> {
@@ -135,11 +176,18 @@ async function installPackedArtifact(
 
   await mkdir(dirname(fixture.installedChatRoot), { recursive: true });
   await rename(extractedPackage, fixture.installedChatRoot);
-  for (const peer of requiredPeers) await linkPeer(peer, fixture.nodeModules);
 
   return parsePackageManifest(
     await Bun.file(join(fixture.installedChatRoot, 'package.json')).text(),
   );
+}
+
+/** Links the fixture's simulated install graph: host peers at the top level, Chat's own dependencies nested under it. */
+async function linkFixtureDependencyGraph(fixture: ValidationFixture): Promise<void> {
+  for (const peer of requiredPeers) await linkPeer(peer, fixture.nodeModules);
+  for (const dependency of requiredOwnDependencies) {
+    await linkOwnDependency(dependency, fixture.installedChatRoot);
+  }
 }
 
 function barePackageName(specifier: string): string {
@@ -152,7 +200,10 @@ async function assertImportClosure(
   manifest: PackageManifest,
   installedChatRoot: string,
 ): Promise<void> {
-  const declaredPeers = new Set(Object.keys(manifest.peerDependencies ?? {}));
+  const declaredPeers = new Set([
+    ...Object.keys(manifest.peerDependencies ?? {}),
+    ...Object.keys(manifest.dependencies ?? {}),
+  ]);
   const violations: string[] = [];
   const sourceGlob = new Glob('dist/**/*.{js,svelte,css}');
   for await (const relativePath of sourceGlob.scan({ cwd: installedChatRoot })) {
@@ -265,7 +316,7 @@ async function buildConsumerEntries(fixture: ValidationFixture): Promise<void> {
       `import '@lostgradient/chat/composer-popover/styles';\n` +
       `import '@lostgradient/chat/conversation-header/styles';\n` +
       `import '@lostgradient/chat/conversation-list/styles';\n` +
-      `import Chat, { appendAssistantMessage, appendUserMessage, createConversation, getMessageText } from '@lostgradient/chat';\n` +
+      `import Chat, { appendAssistantMessage, appendUserMessage, createConversation, getMessageText, isJSONValue } from '@lostgradient/chat';\n` +
       `import type { ChatSubmitEvent, ConversationHistory, MultiModalContent } from '@lostgradient/chat';\n` +
       `const userContent: MultiModalContent = { type: 'text', text: 'Hello' };\n` +
       `const assistantContent: MultiModalContent = { type: 'text', text: 'Hi there' };\n` +
@@ -276,6 +327,7 @@ async function buildConsumerEntries(fixture: ValidationFixture): Promise<void> {
       `const submitEvent: ChatSubmitEvent = { message: { role: 'user', content: 'Follow up' }, attachments: [] };\n` +
       `const firstMessage = conversation.messages[conversation.ids[0] ?? ''];\n` +
       `if (firstMessage === undefined) throw new Error('expected a first conversation message');\n` +
+      `if (!isJSONValue(conversation.metadata)) throw new Error('expected conversation metadata to be a JSON value');\n` +
       `void [Chat, conversation, getMessageText(firstMessage), submitEvent];\n`,
   );
   await Bun.write(
@@ -389,16 +441,17 @@ export async function validateConsumer(): Promise<void> {
     process.stdout.write('[validate-consumer] building @lostgradient/chat…\n');
     await run('bun', ['run', 'build']);
     const { tarballPath } = await packForPublish();
-    const packedManifest = await installPackedArtifact(tarballPath, fixture);
+    const packedManifest = await extractPackedArtifact(tarballPath, fixture);
     assertPackedManifest(packedManifest);
     assertPackedExports(packedManifest, fixture.installedChatRoot);
     await assertPackedFileSet(fixture.installedChatRoot);
-    await assertNoBundledPeerProvenance(packedManifest, fixture.installedChatRoot);
+    await assertNoBundledRuntimeProvenance(packedManifest, fixture.installedChatRoot);
     await assertImportClosure(packedManifest, fixture.installedChatRoot);
+    await linkFixtureDependencyGraph(fixture);
     await buildConsumerEntries(fixture);
     await runPlainNodeConsumer(fixture);
     process.stdout.write(
-      `[validate-consumer] OK — isolated peer-only artifact, import closure, client build, plugin SSR, and plain-Node SSR verified.\n`,
+      `[validate-consumer] OK — isolated artifact, import closure, client build, plugin SSR, and plain-Node SSR verified without a host-installed conversationalist/zod.\n`,
     );
   } finally {
     await rm(fixtureRoot, { recursive: true, force: true });

--- a/packages/chat/scripts/validate-consumer.ts
+++ b/packages/chat/scripts/validate-consumer.ts
@@ -200,7 +200,7 @@ async function assertImportClosure(
   manifest: PackageManifest,
   installedChatRoot: string,
 ): Promise<void> {
-  const declaredPeers = new Set([
+  const declaredRuntimeSpecifiers = new Set([
     ...Object.keys(manifest.peerDependencies ?? {}),
     ...Object.keys(manifest.dependencies ?? {}),
   ]);
@@ -223,7 +223,7 @@ async function assertImportClosure(
         ) {
           continue;
         }
-        if (!declaredPeers.has(barePackageName(specifier))) {
+        if (!declaredRuntimeSpecifiers.has(barePackageName(specifier))) {
           violations.push(`${relativePath}: ${specifier}`);
         }
       }

--- a/packages/chat/src/lib/components/chat/README.md
+++ b/packages/chat/src/lib/components/chat/README.md
@@ -106,11 +106,13 @@ complete finite stream without assuming a particular model provider.
 Chat declares `@lostgradient/cinder` and `svelte` as peer dependencies — host
 applications install those alongside `@lostgradient/chat`. `conversationalist`
 (and its own `zod` dependency) is an implementation detail Chat owns: it
-ships as a regular dependency of `@lostgradient/chat`, installs
-automatically, and is never something a host application adds or
-version-picks directly. Import the conversation types, builders,
+ships as a regular dependency of `@lostgradient/chat` and installs
+automatically, so using Chat never requires a host application to add or
+version-pick it. Import the conversation types, builders,
 `CURRENT_SCHEMA_VERSION`, and `isJSONValue` from `@lostgradient/chat` rather
-than importing `conversationalist` yourself.
+than importing `conversationalist` yourself. An application that uses
+`conversationalist` APIs beyond what Chat re-exports may still depend on it
+directly — that is supported, it just is not something Chat requires.
 
 The exported schema version comes from the `conversationalist` version Chat
 depends on. Histories produced by an older compatible schema can render

--- a/packages/chat/src/lib/components/chat/README.md
+++ b/packages/chat/src/lib/components/chat/README.md
@@ -103,15 +103,18 @@ complete finite stream without assuming a particular model provider.
 
 ## Conversation data contract
 
-Chat declares `@lostgradient/cinder`, `conversationalist`, `svelte`, and `zod`
-as peer dependencies. Host applications install those
-peers alongside `@lostgradient/chat`, then import the conversation types,
-builders, and `CURRENT_SCHEMA_VERSION` from `@lostgradient/chat`.
+Chat declares `@lostgradient/cinder` and `svelte` as peer dependencies — host
+applications install those alongside `@lostgradient/chat`. `conversationalist`
+(and its own `zod` dependency) is an implementation detail Chat owns: it
+ships as a regular dependency of `@lostgradient/chat`, installs
+automatically, and is never something a host application adds or
+version-picks directly. Import the conversation types, builders,
+`CURRENT_SCHEMA_VERSION`, and `isJSONValue` from `@lostgradient/chat` rather
+than importing `conversationalist` yourself.
 
-The exported schema version comes from the installed `conversationalist` peer.
-Histories produced by an older compatible schema can render as-is; a newer
-schema requires upgrading `conversationalist` and, when necessary,
-`@lostgradient/chat`.
+The exported schema version comes from the `conversationalist` version Chat
+depends on. Histories produced by an older compatible schema can render
+as-is; a newer schema requires upgrading `@lostgradient/chat`.
 
 ## Layout and sizing
 

--- a/packages/chat/src/lib/components/chat/chat-import-boundary.test.ts
+++ b/packages/chat/src/lib/components/chat/chat-import-boundary.test.ts
@@ -170,7 +170,7 @@ describe('chat import boundary', () => {
     expect(offenders).toEqual([]);
   });
 
-  it('the public chat barrel is the only runtime boundary for streaming builders', async () => {
+  it('the public chat barrel is the only runtime boundary for streaming builders and isJSONValue', async () => {
     const source = await Bun.file(`${CHAT_ROOT}/index.ts`).text();
     const specifiers = collectModuleSpecifiers(`${CHAT_ROOT}/index.ts`, source).filter(
       ({ specifier, typeOnly }) =>
@@ -182,6 +182,7 @@ describe('chat import boundary', () => {
     expect(specifiers).toEqual([
       { specifier: `${CONVERSATIONALIST_PACKAGE}/versioning`, typeOnly: false },
       { specifier: `${CONVERSATIONALIST_PACKAGE}/streaming`, typeOnly: false },
+      { specifier: CONVERSATIONALIST_PACKAGE, typeOnly: false },
     ]);
   });
 });

--- a/packages/chat/src/lib/components/chat/index.ts
+++ b/packages/chat/src/lib/components/chat/index.ts
@@ -51,8 +51,8 @@ export {
   updateStreamingMessage,
 } from 'conversationalist/streaming';
 
-// Conversationalist runtime helper — validates values a consumer builds by
-// hand (message content, metadata, tool call arguments) are JSON-compatible
+// Conversationalist runtime helper — validates that values a consumer builds
+// by hand (message content, metadata, tool call arguments) are JSON-compatible
 // before handing them to the builders above.
 export { isJSONValue } from 'conversationalist';
 

--- a/packages/chat/src/lib/components/chat/index.ts
+++ b/packages/chat/src/lib/components/chat/index.ts
@@ -42,14 +42,19 @@ export {
 } from './builders.ts';
 
 // Streaming conversation builders — keep the immutable snapshot and Chat's
-// imperative streaming surface in sync through the package's
-// `conversationalist` peer dependency.
+// imperative streaming surface in sync through the package's own
+// `conversationalist` dependency.
 export {
   appendStreamingMessage,
   cancelStreamingMessage,
   finalizeStreamingMessage,
   updateStreamingMessage,
 } from 'conversationalist/streaming';
+
+// Conversationalist runtime helper — validates values a consumer builds by
+// hand (message content, metadata, tool call arguments) are JSON-compatible
+// before handing them to the builders above.
+export { isJSONValue } from 'conversationalist';
 
 // Conversation data model — published Conversationalist shapes Chat renders.
 // Public so consumers can type the `conversation` prop and construct messages


### PR DESCRIPTION
## Summary

Closes #753.

`@lostgradient/chat` declared `conversationalist` and `zod` as `peerDependencies`, so host applications had to `bun add conversationalist zod` themselves and pick a version compatible with whatever Chat expected — the exact thing #753 asks to stop requiring. This PR moves both to regular `dependencies`. `@lostgradient/cinder` and `svelte` stay peers, because the host still needs to control which single copy of each renders.

It also closes the re-export gap the issue's repro (`chatroom`) hit: `chatroom/src/routes/+page.svelte` had to `import { isJSONValue } from 'conversationalist'` directly because Chat didn't re-export it. `isJSONValue` is now exported from `@lostgradient/chat`'s public barrel alongside the existing `conversationalist` re-exports (`CURRENT_SCHEMA_VERSION`, the conversation-model types, the streaming builders).

## What was already fixed vs. what changed here

Already fixed (PR #765, prior to this branch): `conversationalist`'s peer *range* was widened (`^0.2.1 || ^0.4.1`) and `zod` was pinned correctly. That did not address the reopened ask — conversationalist/zod were still peers, so hosts still had to install them directly, and `isJSONValue` was still missing.

Changed here:
- `packages/chat/package.json`: `conversationalist` and `zod` moved from `peerDependencies` to `dependencies`. `@lostgradient/cinder` and `svelte` remain peers.
- `packages/chat/src/lib/components/chat/index.ts`: re-exports `isJSONValue` from `conversationalist`.
- `packages/chat/scripts/pack-for-publish.ts`: `assertSourceManifest` now asserts the new dependency/peer split (exact `dependencies` = `{conversationalist, zod}`, exact peers = `{@lostgradient/cinder, svelte}`); `peerExternalSpecifiers` renamed to `runtimeExternalSpecifiers` and now externalizes both peers and dependencies in the generated server bundle (regular dependencies must not be inlined into the dist either); `buildPublishedManifest` now retains `dependencies` in the published manifest instead of deleting it (this was the single highest-risk line — omitting it would have shipped the fix silently broken).
- `packages/chat/scripts/validate-consumer.ts`: the fixture now links `conversationalist`/`zod` only into the *installed chat package's own* `node_modules` (never the fixture's top-level `node_modules`), matching how a package manager resolves a real `dependencies` entry — proving a host that never installed them can still build, SSR-render, and type-check against the packed tarball. Peer-only assertions were generalized to cover both peers and dependencies (`assertNoBundledRuntimeProvenance`, `assertImportClosure`).
- `packages/chat/scripts/package-boundary.test.ts`: asserts the new contract instead of the old peer-only one.
- READMEs (`README.md`, `packages/chat/README.md`, `packages/chat/src/lib/components/chat/README.md`): removed the "install conversationalist/zod yourself" guidance; documented that both are Chat's own dependencies now.

## Consumer impact

This is a **breaking change to the install contract**, released as `minor` (pre-1.0, no majors allowed — verified with `check-changeset-prerelease-bumps.ts`):

- Apps that declared `conversationalist`/`zod` directly *only* to satisfy Chat's peer requirement can remove them — `@lostgradient/chat` now supplies its own compatible version automatically.
- Apps using `conversationalist` directly for something beyond what Chat re-exports (its adapters, schemas, etc.) can keep their own dependency; npm/bun de-duplicates compatible versions in the tree.
- `@lostgradient/cinder` and `svelte` are unaffected — still peers, still host-supplied.

## Test plan

- [x] `bun run --filter=@lostgradient/chat lint` — 0 warnings/errors
- [x] `bun run --filter=@lostgradient/chat typecheck` — 0 errors (tsc + svelte-check)
- [x] `bun run --filter=@lostgradient/chat test` — 685 pass, 0 fail
- [x] `bun run --filter=@lostgradient/chat validate` (lint, typecheck, tests w/ 100% coverage ratchet, platform/color/token audits, components:check, build) — all green
- [x] `bun run --filter=@lostgradient/chat validate:consumer` — **the real proof for this issue**: packs the tarball, verifies it declares `dependencies: {conversationalist, zod}`, resolves them only from the chat package's own nested `node_modules` (never a host-provided top-level install), builds/typechecks a consumer against the packed artifact, and SSR-renders under both Bun and plain Node. Passed.
- [x] Full workspace `turbo run typecheck` via pre-commit hook — all 7 affected packages pass
- [x] Verified no writes leaked into the primary repo (`git -C /Users/stevekinney/Developer/cinder status --porcelain` — clean)