### PR TITLE
refactor(components): extract shared :root token-name introspection for tests

### DIFF
--- a/packages/components/scripts/check-consumer-boundaries.test.ts
+++ b/packages/components/scripts/check-consumer-boundaries.test.ts
@@ -62,6 +62,24 @@ describe('consumer boundary guard', () => {
     ).toHaveLength(1);
   });
 
+  test('rejects src/test/*.test.ts even from tests — co-located tests import private component source', () => {
+    // A flat-file exemption that doesn't also exclude `.test.ts` would let a
+    // playground test import a component test co-located in `src/test/` (e.g.
+    // `hydrate.test.ts`, which imports `../components/input/input.svelte`) and
+    // transitively reach private component source through it. Both
+    // `token-introspection.test.ts` (this PR) and `hydrate.test.ts` (pre-existing)
+    // must stay rejected.
+    const cases = [
+      "import { readRootTokenNames } from '../../components/src/test/token-introspection.test.ts';",
+      "import { renderThenHydrate } from '../../components/src/test/hydrate.test.ts';",
+    ];
+    for (const source of cases) {
+      expect(
+        findConsumerBoundaryViolations(source, 'packages/playground/src/app.test.ts'),
+      ).toHaveLength(1);
+    }
+  });
+
   test('rejects multiline imports and selectors', () => {
     const privateImport = `await import(\n  '../../components/src/components/button/index.ts'\n);`;
     const privateSelector = `container.querySelector(\n  '.cinder-button__icon'\n);`;

--- a/packages/components/scripts/check-consumer-boundaries.test.ts
+++ b/packages/components/scripts/check-consumer-boundaries.test.ts
@@ -37,7 +37,7 @@ describe('consumer boundary guard', () => {
     ).toEqual([]);
   });
 
-  test('allows a flat shared test helper .ts file directly under src/test/ only from tests', () => {
+  test('allows the token-introspection helper (explicit allowlist) only from tests', () => {
     const source =
       "import { readRootTokenNames } from '../../components/src/test/token-introspection.ts';";
     expect(findConsumerBoundaryViolations(source, 'packages/playground/src/app.test.ts')).toEqual(
@@ -49,12 +49,10 @@ describe('consumer boundary guard', () => {
   });
 
   test('rejects src/test/fixtures/** even from tests — fixtures import private component source', () => {
-    // A test-helper exemption scoped to the whole `src/test/` directory would let a
-    // playground test reach `src/test/fixtures/*.svelte` and transitively depend on
-    // private component source (fixtures like `access-gate-dynamic-fixture.svelte`
-    // import `../../components/access-gate/access-gate.svelte` directly) — exactly
-    // the reach-in this guard exists to prevent. The exemption must stay scoped to
-    // flat `.ts` helper files directly under `src/test/`, not the directory as a whole.
+    // Only the two allowlisted helpers are exempt; everything else under
+    // src/test/ is still policed, including fixtures like
+    // `access-gate-dynamic-fixture.svelte`, which imports
+    // `../../components/access-gate/access-gate.svelte` directly.
     const source =
       "import Fixture from '../../components/src/test/fixtures/access-gate-dynamic-fixture.svelte';";
     expect(
@@ -63,15 +61,30 @@ describe('consumer boundary guard', () => {
   });
 
   test('rejects src/test/*.test.ts even from tests — co-located tests import private component source', () => {
-    // A flat-file exemption that doesn't also exclude `.test.ts` would let a
-    // playground test import a component test co-located in `src/test/` (e.g.
-    // `hydrate.test.ts`, which imports `../components/input/input.svelte`) and
-    // transitively reach private component source through it. Both
-    // `token-introspection.test.ts` (this PR) and `hydrate.test.ts` (pre-existing)
-    // must stay rejected.
+    // Component tests co-located in src/test/ (e.g. `hydrate.test.ts`, which
+    // imports `../components/input/input.svelte`) are not on the allowlist and
+    // stay rejected, same as `token-introspection.test.ts` added in this PR.
     const cases = [
       "import { readRootTokenNames } from '../../components/src/test/token-introspection.test.ts';",
       "import { renderThenHydrate } from '../../components/src/test/hydrate.test.ts';",
+    ];
+    for (const source of cases) {
+      expect(
+        findConsumerBoundaryViolations(source, 'packages/playground/src/app.test.ts'),
+      ).toHaveLength(1);
+    }
+  });
+
+  test('rejects src/test/index.ts and server-render.ts even from tests — dynamic sourcePath helpers can reach private component source at runtime', () => {
+    // These flat, non-test files would have passed a filename-pattern exemption
+    // ("any flat .ts under src/test/ that isn't *.test.ts"), but their exported
+    // helpers (renderThenHydrate, renderToServerHtml) accept an arbitrary
+    // sourcePath string at runtime and dynamically import it — a static import
+    // specifier check can never see what path a playground test passes in at
+    // the call site. Only an explicit allowlist (not a pattern) closes this off.
+    const cases = [
+      "import { renderThenHydrate } from '../../components/src/test/index.ts';",
+      "import { renderToServerHtml } from '../../components/src/test/server-render.ts';",
     ];
     for (const source of cases) {
       expect(

--- a/packages/components/scripts/check-consumer-boundaries.test.ts
+++ b/packages/components/scripts/check-consumer-boundaries.test.ts
@@ -37,6 +37,17 @@ describe('consumer boundary guard', () => {
     ).toEqual([]);
   });
 
+  test('allows any shared test helper under src/test/ only from tests', () => {
+    const source =
+      "import { readRootTokenNames } from '../../components/src/test/token-introspection.ts';";
+    expect(findConsumerBoundaryViolations(source, 'packages/playground/src/app.test.ts')).toEqual(
+      [],
+    );
+    expect(findConsumerBoundaryViolations(source, 'packages/playground/src/app.ts')).toHaveLength(
+      1,
+    );
+  });
+
   test('rejects multiline imports and selectors', () => {
     const privateImport = `await import(\n  '../../components/src/components/button/index.ts'\n);`;
     const privateSelector = `container.querySelector(\n  '.cinder-button__icon'\n);`;

--- a/packages/components/scripts/check-consumer-boundaries.test.ts
+++ b/packages/components/scripts/check-consumer-boundaries.test.ts
@@ -37,7 +37,7 @@ describe('consumer boundary guard', () => {
     ).toEqual([]);
   });
 
-  test('allows any shared test helper under src/test/ only from tests', () => {
+  test('allows a flat shared test helper .ts file directly under src/test/ only from tests', () => {
     const source =
       "import { readRootTokenNames } from '../../components/src/test/token-introspection.ts';";
     expect(findConsumerBoundaryViolations(source, 'packages/playground/src/app.test.ts')).toEqual(
@@ -46,6 +46,20 @@ describe('consumer boundary guard', () => {
     expect(findConsumerBoundaryViolations(source, 'packages/playground/src/app.ts')).toHaveLength(
       1,
     );
+  });
+
+  test('rejects src/test/fixtures/** even from tests — fixtures import private component source', () => {
+    // A test-helper exemption scoped to the whole `src/test/` directory would let a
+    // playground test reach `src/test/fixtures/*.svelte` and transitively depend on
+    // private component source (fixtures like `access-gate-dynamic-fixture.svelte`
+    // import `../../components/access-gate/access-gate.svelte` directly) — exactly
+    // the reach-in this guard exists to prevent. The exemption must stay scoped to
+    // flat `.ts` helper files directly under `src/test/`, not the directory as a whole.
+    const source =
+      "import Fixture from '../../components/src/test/fixtures/access-gate-dynamic-fixture.svelte';";
+    expect(
+      findConsumerBoundaryViolations(source, 'packages/playground/src/app.test.ts'),
+    ).toHaveLength(1);
   });
 
   test('rejects multiline imports and selectors', () => {

--- a/packages/components/scripts/check-consumer-boundaries.ts
+++ b/packages/components/scripts/check-consumer-boundaries.ts
@@ -48,7 +48,7 @@ export function findConsumerBoundaryViolations(
       importTarget === 'packages/components/src/index.ts' ||
       ((normalizedFilePath.endsWith('.test.ts') ||
         normalizedFilePath === 'packages/playground/scripts/preload.ts') &&
-        importTarget === 'packages/components/src/test/happy-dom.ts')
+        importTarget.startsWith('packages/components/src/test/'))
     ) {
       return;
     }

--- a/packages/components/scripts/check-consumer-boundaries.ts
+++ b/packages/components/scripts/check-consumer-boundaries.ts
@@ -8,13 +8,18 @@ const sourceImportPattern =
   /(?:from\s*|(?:import|require|import\.meta\.glob)\s*\(\s*(?:\/\*[\s\S]*?\*\/\s*)*|import\s+)(['"`])((?:\\.|(?!\1)[\s\S])*?)\1/g;
 // Shared test helper modules such as `src/test/happy-dom.ts` and
 // `src/test/token-introspection.ts` — flat `.ts` files directly under
-// `src/test/`, never a nested path. Deliberately excludes `src/test/fixtures/**`:
-// those Svelte fixtures import PRIVATE component source themselves (e.g. an
-// `access-gate-*-fixture.svelte` importing `../../components/access-gate/access-gate.svelte`),
-// so allowing playground tests to reach *those* would let a playground test
-// transitively depend on private component source through the fixture —
-// exactly the reach-in this guard exists to prevent.
-const sharedTestHelperPattern = /^packages\/components\/src\/test\/[^/]+\.ts$/;
+// `src/test/`, never a nested path, and never a `.test.ts` or `.d.ts` file.
+// Two things this deliberately excludes, both because they'd let a playground
+// test transitively depend on PRIVATE component source through an
+// intermediary — exactly the reach-in this guard exists to prevent:
+//   - `src/test/fixtures/**`: Svelte fixtures that import private component
+//     source directly (e.g. an `access-gate-*-fixture.svelte` importing
+//     `../../components/access-gate/access-gate.svelte`).
+//   - `src/test/*.test.ts`: component tests co-located in this directory
+//     (e.g. `hydrate.test.ts`) that import private component source to test
+//     it — a shared-helper exemption is not meant to cover test files.
+const sharedTestHelperPattern =
+  /^packages\/components\/src\/test\/(?!.*\.(?:test|d)\.ts$)[^/]+\.ts$/;
 const internalSelectorPattern =
   /\.cinder-(?:[a-z0-9-]+|\$\{[^}]+\})(?:__[a-z0-9_${}-]+|--[a-z0-9_${}-]+)/i;
 const selectorCallPattern =

--- a/packages/components/scripts/check-consumer-boundaries.ts
+++ b/packages/components/scripts/check-consumer-boundaries.ts
@@ -6,20 +6,34 @@ const playgroundRoots = ['packages/playground/src', 'packages/playground/scripts
 
 const sourceImportPattern =
   /(?:from\s*|(?:import|require|import\.meta\.glob)\s*\(\s*(?:\/\*[\s\S]*?\*\/\s*)*|import\s+)(['"`])((?:\\.|(?!\1)[\s\S])*?)\1/g;
-// Shared test helper modules such as `src/test/happy-dom.ts` and
-// `src/test/token-introspection.ts` — flat `.ts` files directly under
-// `src/test/`, never a nested path, and never a `.test.ts` or `.d.ts` file.
-// Two things this deliberately excludes, both because they'd let a playground
-// test transitively depend on PRIVATE component source through an
-// intermediary — exactly the reach-in this guard exists to prevent:
-//   - `src/test/fixtures/**`: Svelte fixtures that import private component
+// Explicit allowlist of shared test helpers that `packages/playground` test
+// files (and `scripts/preload.ts`) may reach into directly, alongside the
+// `happy-dom.ts` precedent this follows.
+//
+// This started as a filename PATTERN (any flat, non-`.test.ts` file directly
+// under `src/test/`) but that kept reopening the same class of bypass as new
+// cases surfaced during review:
+//   - `src/test/fixtures/**` — Svelte fixtures that import private component
 //     source directly (e.g. an `access-gate-*-fixture.svelte` importing
 //     `../../components/access-gate/access-gate.svelte`).
-//   - `src/test/*.test.ts`: component tests co-located in this directory
+//   - `src/test/*.test.ts` — component tests co-located in this directory
 //     (e.g. `hydrate.test.ts`) that import private component source to test
-//     it — a shared-helper exemption is not meant to cover test files.
-const sharedTestHelperPattern =
-  /^packages\/components\/src\/test\/(?!.*\.(?:test|d)\.ts$)[^/]+\.ts$/;
+//     it.
+//   - `src/test/index.ts` and `src/test/server-render.ts` — the barrel
+//     re-exports `renderThenHydrate`/`renderToServerHtml`, both of which
+//     accept an arbitrary `sourcePath` string at runtime and dynamically
+//     import it. A pattern that allows the FILE can't see what path gets
+//     passed to it at the call site, so it can't rule out a playground test
+//     passing a private `src/components/**/*.svelte` path through as data
+//     rather than as a static import specifier.
+//
+// An explicit allowlist closes all three off at once: only the two helpers
+// playground tests actually use are reachable, and adding a new one requires
+// a conscious edit here rather than just dropping a flat file in `src/test/`.
+const sharedTestHelperAllowlist = new Set([
+  'packages/components/src/test/happy-dom.ts',
+  'packages/components/src/test/token-introspection.ts',
+]);
 const internalSelectorPattern =
   /\.cinder-(?:[a-z0-9-]+|\$\{[^}]+\})(?:__[a-z0-9_${}-]+|--[a-z0-9_${}-]+)/i;
 const selectorCallPattern =
@@ -62,7 +76,7 @@ export function findConsumerBoundaryViolations(
       importTarget === 'packages/components/src/index.ts' ||
       ((normalizedFilePath.endsWith('.test.ts') ||
         normalizedFilePath === 'packages/playground/scripts/preload.ts') &&
-        sharedTestHelperPattern.test(importTarget))
+        sharedTestHelperAllowlist.has(importTarget))
     ) {
       return;
     }

--- a/packages/components/scripts/check-consumer-boundaries.ts
+++ b/packages/components/scripts/check-consumer-boundaries.ts
@@ -6,6 +6,15 @@ const playgroundRoots = ['packages/playground/src', 'packages/playground/scripts
 
 const sourceImportPattern =
   /(?:from\s*|(?:import|require|import\.meta\.glob)\s*\(\s*(?:\/\*[\s\S]*?\*\/\s*)*|import\s+)(['"`])((?:\\.|(?!\1)[\s\S])*?)\1/g;
+// Shared test helper modules such as `src/test/happy-dom.ts` and
+// `src/test/token-introspection.ts` — flat `.ts` files directly under
+// `src/test/`, never a nested path. Deliberately excludes `src/test/fixtures/**`:
+// those Svelte fixtures import PRIVATE component source themselves (e.g. an
+// `access-gate-*-fixture.svelte` importing `../../components/access-gate/access-gate.svelte`),
+// so allowing playground tests to reach *those* would let a playground test
+// transitively depend on private component source through the fixture —
+// exactly the reach-in this guard exists to prevent.
+const sharedTestHelperPattern = /^packages\/components\/src\/test\/[^/]+\.ts$/;
 const internalSelectorPattern =
   /\.cinder-(?:[a-z0-9-]+|\$\{[^}]+\})(?:__[a-z0-9_${}-]+|--[a-z0-9_${}-]+)/i;
 const selectorCallPattern =
@@ -48,7 +57,7 @@ export function findConsumerBoundaryViolations(
       importTarget === 'packages/components/src/index.ts' ||
       ((normalizedFilePath.endsWith('.test.ts') ||
         normalizedFilePath === 'packages/playground/scripts/preload.ts') &&
-        importTarget.startsWith('packages/components/src/test/'))
+        sharedTestHelperPattern.test(importTarget))
     ) {
       return;
     }

--- a/packages/components/src/styles/tokens-doc-drift.test.ts
+++ b/packages/components/src/styles/tokens-doc-drift.test.ts
@@ -13,30 +13,12 @@ import { join } from 'node:path';
 
 import { describe, expect, test } from 'bun:test';
 
+import { readRootTokenNames } from '../test/token-introspection.ts';
+
 const PACKAGE_ROOT = join(import.meta.dir, '..', '..');
 const REPO_ROOT = join(PACKAGE_ROOT, '..', '..');
 const TOKENS_CSS = join(PACKAGE_ROOT, 'src', 'styles', 'tokens-base.css');
 const TOKENS_DOC = join(REPO_ROOT, 'docs', 'tokens.md');
-
-function extractCssTokens(css: string): Set<string> {
-  // Pull just the `:root { ... }` block. The file also has scoped redeclarations
-  // (`:root[data-theme='dark']`, the prefers-reduced-motion override, etc.) that
-  // would otherwise inflate the token set with duplicates.
-  const rootMatch = css.match(/^\s*:root\s*\{([\s\S]*?)\n\}/m);
-  const rootBody = rootMatch?.[1];
-  if (!rootBody) {
-    throw new Error('Could not find :root { ... } block in tokens-base.css');
-  }
-  // Strip CSS block comments so a `/* --cinder-future: reserved */` aside in the
-  // source never gets counted as a real declaration.
-  const stripped = rootBody.replace(/\/\*[\s\S]*?\*\//g, '');
-  const tokens = new Set<string>();
-  const declarationPattern = /--cinder-[a-z0-9-]+(?=\s*:)/g;
-  for (const match of stripped.matchAll(declarationPattern)) {
-    tokens.add(match[0]);
-  }
-  return tokens;
-}
 
 function extractDocTokens(markdown: string): Set<string> {
   // Doc lists tokens as inline code in table rows: `` `--cinder-space-4` ``.
@@ -58,7 +40,7 @@ describe('docs/tokens.md drift', () => {
       readFile(TOKENS_DOC, 'utf8'),
     ]);
 
-    const cssTokens = extractCssTokens(css);
+    const cssTokens = readRootTokenNames(css);
     const docTokens = extractDocTokens(doc);
 
     // Sanity floor: a parser regression that silently returns a tiny set would

--- a/packages/components/src/styles/tokens.test.ts
+++ b/packages/components/src/styles/tokens.test.ts
@@ -10,18 +10,10 @@ import { join } from 'node:path';
 
 import { describe, expect, test } from 'bun:test';
 
+import { extractRootBlock } from '../test/token-introspection.ts';
+
 const TOKENS_DIR = join(import.meta.dir, 'tokens');
 const TOKENS_BASE_PATH = join(import.meta.dir, 'tokens-base.css');
-
-function extractRootBlock(css: string): string {
-  const rootMatch = css.match(/^\s*:root\s*\{([\s\S]*?)\n\}/m);
-
-  if (!rootMatch?.[1]) {
-    throw new Error('Could not find :root { ... } block in tokens-base.css');
-  }
-
-  return rootMatch[1];
-}
 
 function extractReducedMotionRootBlock(css: string): string {
   const reducedMotionMatch = css.match(

--- a/packages/components/src/test/token-introspection.test.ts
+++ b/packages/components/src/test/token-introspection.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, test } from 'bun:test';
+
+import { extractRootBlock, readRootTokenNames } from './token-introspection.ts';
+
+describe('extractRootBlock', () => {
+  test('returns the body of the top-level :root block', () => {
+    const css = `:root {\n  --cinder-accent: red;\n}\n`;
+    expect(extractRootBlock(css)).toContain('--cinder-accent: red;');
+  });
+
+  test('is tolerant of reindentation', () => {
+    const css = ['  :root   {', '      --cinder-accent: red;', '  }'].join('\n');
+    expect(extractRootBlock(css)).toContain('--cinder-accent: red;');
+  });
+
+  test('skips a preceding scoped :root[data-theme] block', () => {
+    const css = [
+      ":root[data-theme='dark'] {",
+      '  color-scheme: dark;',
+      '}',
+      '',
+      ':root {',
+      '  --cinder-accent: red;',
+      '}',
+    ].join('\n');
+
+    const body = extractRootBlock(css);
+    expect(body).toContain('--cinder-accent: red;');
+    expect(body).not.toContain('color-scheme');
+  });
+
+  test('skips a :root block nested inside @media', () => {
+    const css = [
+      ':root {',
+      '  --cinder-accent: red;',
+      '}',
+      '',
+      '@media (prefers-reduced-motion: reduce) {',
+      '  :root {',
+      '    --cinder-duration-spin: 0ms;',
+      '  }',
+      '}',
+    ].join('\n');
+
+    const body = extractRootBlock(css);
+    expect(body).toContain('--cinder-accent: red;');
+    expect(body).not.toContain('--cinder-duration-spin');
+  });
+
+  test('throws when no bare :root block exists', () => {
+    const css = ":root[data-theme='dark'] { color-scheme: dark; }";
+    expect(() => extractRootBlock(css)).toThrow('Could not find :root { ... } block');
+  });
+});
+
+describe('readRootTokenNames', () => {
+  test('collects --cinder-* declaration names from the :root block', () => {
+    const css = `:root {\n  --cinder-accent: red;\n  --cinder-space-4: 1rem;\n}\n`;
+    expect(readRootTokenNames(css)).toEqual(new Set(['--cinder-accent', '--cinder-space-4']));
+  });
+
+  test('ignores tokens inside comments', () => {
+    const css = [
+      ':root {',
+      '  /* --cinder-future: reserved */',
+      '  --cinder-accent: red;',
+      '}',
+    ].join('\n');
+
+    expect(readRootTokenNames(css)).toEqual(new Set(['--cinder-accent']));
+  });
+
+  test('ignores non-cinder custom properties', () => {
+    const css = `:root {\n  --some-other-token: 1;\n  --cinder-accent: red;\n}\n`;
+    expect(readRootTokenNames(css)).toEqual(new Set(['--cinder-accent']));
+  });
+
+  test('is tolerant of reindentation', () => {
+    const css = ['  :root   {', '      --cinder-accent: red;', '  }'].join('\n');
+    expect(readRootTokenNames(css)).toEqual(new Set(['--cinder-accent']));
+  });
+
+  test('excludes tokens from a preceding scoped :root[data-theme] block', () => {
+    const css = [
+      ":root[data-theme='dark'] {",
+      '  --cinder-shadow-sm: 0 0 0 black;',
+      '}',
+      '',
+      ':root {',
+      '  --cinder-accent: red;',
+      '}',
+    ].join('\n');
+
+    expect(readRootTokenNames(css)).toEqual(new Set(['--cinder-accent']));
+  });
+
+  test('excludes tokens from a :root block nested inside @media', () => {
+    const css = [
+      ':root {',
+      '  --cinder-accent: red;',
+      '}',
+      '',
+      '@media (prefers-reduced-motion: reduce) {',
+      '  :root {',
+      '    --cinder-duration-spin: 0ms;',
+      '  }',
+      '}',
+    ].join('\n');
+
+    expect(readRootTokenNames(css)).toEqual(new Set(['--cinder-accent']));
+  });
+
+  test('throws when no bare :root block exists', () => {
+    const css = ":root[data-theme='dark'] { color-scheme: dark; }";
+    expect(() => readRootTokenNames(css)).toThrow('Could not find :root { ... } block');
+  });
+});

--- a/packages/components/src/test/token-introspection.ts
+++ b/packages/components/src/test/token-introspection.ts
@@ -1,0 +1,77 @@
+/**
+ * Shared `tokens-base.css` `:root` introspection for tests. Internal — not
+ * part of the public package surface (see `src/test/README` conventions:
+ * these helpers live outside `package.json#exports` and are reached via the
+ * `packages/components/src/test/*` relative-import allowance that
+ * `check-consumer-boundaries.ts` carves out for test files).
+ *
+ * Parsing is done with PostCSS (a real CSS tokenizer) rather than a
+ * hand-rolled regex, so the result is correct regardless of indentation and
+ * naturally ignores scoped variants like `:root[data-theme='dark']` — PostCSS
+ * matches rule selectors exactly, so `:root[data-theme='dark']` never equals
+ * the `:root` filter — and comments, which PostCSS parses as distinct nodes
+ * that are simply not walked when collecting declarations.
+ */
+
+import { parse, type Rule } from 'postcss';
+
+/**
+ * Finds the first BARE `:root { ... }` rule at the stylesheet's top level
+ * (not nested inside `@media`, `@supports`, etc.) and returns its body as the
+ * raw source text between the outer braces. Scoped variants such as
+ * `:root[data-theme='dark']` are never matched — PostCSS compares the full
+ * rule selector, so an attribute-qualified selector is simply a different
+ * string. Nested `:root` rules (e.g. inside a `@media (prefers-reduced-motion:
+ * reduce)` block) are skipped so a token stylesheet can safely contain more
+ * than one `:root` block.
+ */
+export function extractRootBlock(css: string): string {
+  const root = parse(css);
+  let rootRule: Rule | undefined;
+
+  root.walkRules(':root', (rule) => {
+    if (rule.parent?.type !== 'root') return;
+    rootRule ??= rule;
+    return false;
+  });
+
+  if (!rootRule) {
+    throw new Error('Could not find :root { ... } block in tokens-base.css');
+  }
+
+  const text = rootRule.toString();
+  return text.slice(text.indexOf('{') + 1, text.lastIndexOf('}'));
+}
+
+/**
+ * Returns the set of `--cinder-*` custom property names declared directly in
+ * the top-level `:root { ... }` block of a token stylesheet (see
+ * {@link extractRootBlock}). Comments are inherently excluded — PostCSS
+ * parses them as separate nodes, not declarations — so a
+ * `/* --cinder-future: reserved *\/` aside can never be mistaken for a real
+ * declaration.
+ */
+export function readRootTokenNames(css: string): Set<string> {
+  const root = parse(css);
+  const names = new Set<string>();
+  let found = false;
+
+  root.walkRules(':root', (rule) => {
+    if (found || rule.parent?.type !== 'root') return;
+    found = true;
+
+    for (const node of rule.nodes) {
+      if (node.type === 'decl' && node.prop.startsWith('--cinder-')) {
+        names.add(node.prop);
+      }
+    }
+
+    return false;
+  });
+
+  if (!found) {
+    throw new Error('Could not find :root { ... } block in tokens-base.css');
+  }
+
+  return names;
+}

--- a/packages/components/src/test/token-introspection.ts
+++ b/packages/components/src/test/token-introspection.ts
@@ -1,9 +1,10 @@
 /**
  * Shared `tokens-base.css` `:root` introspection for tests. Internal — not
- * part of the public package surface (see `src/test/README` conventions:
- * these helpers live outside `package.json#exports` and are reached via the
- * `packages/components/src/test/*` relative-import allowance that
- * `check-consumer-boundaries.ts` carves out for test files).
+ * part of the public package surface: these helpers live outside
+ * `package.json#exports`, alongside other test-only infrastructure like
+ * `src/test/happy-dom.ts` and `src/test/css.ts`, and are reached from
+ * `packages/playground` test files via the `packages/components/src/test/*`
+ * relative-import allowance that `check-consumer-boundaries.ts` carves out.
  *
  * Parsing is done with PostCSS (a real CSS tokenizer) rather than a
  * hand-rolled regex, so the result is correct regardless of indentation and

--- a/packages/playground/src/shell-app/color-token-registry.test.ts
+++ b/packages/playground/src/shell-app/color-token-registry.test.ts
@@ -3,6 +3,7 @@ import { join } from 'node:path';
 
 import { describe, expect, test } from 'bun:test';
 
+import { readRootTokenNames } from '../../../components/src/test/token-introspection.ts';
 import {
   COLOR_TOKEN_GROUPS,
   COLOR_TOKEN_NAMES,
@@ -19,17 +20,6 @@ const TOKENS_BASE_PATH = join(
   'styles',
   'tokens-base.css',
 );
-
-function extractRootTokenNames(css: string): Set<string> {
-  const rootMatch = css.match(/^\s*:root\s*\{([\s\S]*?)\n\}/m);
-  const rootBody = rootMatch?.[1];
-  if (rootBody === undefined) {
-    throw new Error('Could not find :root block in tokens-base.css');
-  }
-
-  const stripped = rootBody.replace(/\/\*[\s\S]*?\*\//g, '');
-  return new Set([...stripped.matchAll(/(--cinder-[a-z0-9-]+)\s*:/g)].map((match) => match[1]!));
-}
 
 describe('color token registry', () => {
   test('contains the expected global color-token inventory', () => {
@@ -50,7 +40,7 @@ describe('color token registry', () => {
 
   test('every registered token is declared in tokens-base.css', async () => {
     const css = await readFile(TOKENS_BASE_PATH, 'utf8');
-    const rootTokenNames = extractRootTokenNames(css);
+    const rootTokenNames = readRootTokenNames(css);
 
     const missing = COLOR_TOKEN_NAMES.filter((tokenName) => !rootTokenNames.has(tokenName));
 


### PR DESCRIPTION
## Summary

Closes #771.

Three test suites hand-rolled the same byte-identical regex to pull the `:root { ... }` block out of `tokens-base.css`:

- `packages/components/src/styles/tokens.test.ts`
- `packages/components/src/styles/tokens-doc-drift.test.ts`
- `packages/playground/src/shell-app/color-token-registry.test.ts`

The latter two duplicated the *entire* helper (regex + comment strip + name pattern) across the `components`/`playground` package boundary. The regex was formatting-coupled — it required the `:root` block to be the first bare `:root {` in the file, with its closing brace at column 0.

## What changed

- Added `packages/components/src/test/token-introspection.ts`, exporting:
  - `extractRootBlock(css)` — returns the raw source text of the first top-level, unscoped `:root { ... }` block.
  - `readRootTokenNames(css)` — returns the `Set<string>` of `--cinder-*` custom property names declared in that block.
- Both are implemented with **PostCSS** (already a `components` dependency, already the house style for CSS test helpers — see `src/test/css.ts`) instead of a hand-rolled regex/brace scan. This hardens the formatting coupling the issue called out:
  - Reindentation is a non-issue — PostCSS parses the AST, not source columns.
  - Scoped variants like `:root[data-theme='dark']` are never matched — PostCSS compares the full rule selector, and an attribute-qualified selector is a different string than `:root`.
  - A `:root` block nested inside `@media (prefers-reduced-motion: reduce) { ... }` is skipped — only the top-level (non-nested) rule is considered.
  - Comments can never be mistaken for declarations — PostCSS parses them as distinct nodes that are simply not walked.
- All three call sites now import from the shared helper and their local duplicate implementations are gone.
- `packages/components/src/test/token-introspection.test.ts` — new tests proving the hardened behavior: reindented block, a preceding `:root[data-theme]` block, a nested `@media` block, and comment-stripping.
- `packages/components/scripts/check-consumer-boundaries.ts` — the boundary guard previously carved out a single hardcoded exception (`src/test/happy-dom.ts`) so playground *test* files could reach into `components/src/test/` for shared test infrastructure. **Final shape (after review): an explicit allowlist**, not a directory- or filename-pattern-based exemption. Review (Copilot + Codex, across several rounds) found that any pattern-based exemption reopens a private-source reach-in: `src/test/fixtures/**` Svelte fixtures import private component source directly, `src/test/*.test.ts` files do the same to test it, and `src/test/index.ts`/`server-render.ts` export helpers that accept an arbitrary `sourcePath` string at *runtime* and dynamically import it — invisible to a static import-specifier check no matter how the filename pattern is tuned. The guard now checks an explicit `Set` containing exactly the two helpers playground tests use: `packages/components/src/test/happy-dom.ts` and `packages/components/src/test/token-introspection.ts`. Adding a future helper requires a conscious edit to that allowlist. Regression tests cover all of the above (fixtures, `.test.ts`, `index.ts`/`server-render.ts`) staying rejected.

## Why not a `package.json` export

`token-introspection.ts` is test-only infrastructure, not a runtime API. The `styles/guard`-style subpath-export route would require wiring it into the hand-authored reserved-key machinery in `scripts/generate-exports.ts` (`RESERVED_KEYS`, a canonical entry function, check-mode drift detection, `files` array) for something no runtime consumer needs. The `src/test/*` relative-import allowance already exists for exactly this shape of problem (see `happy-dom.ts`), so this follows that precedent instead — now as an explicit allowlist rather than a pattern (see above).

## Changeset

None. Every touched file is a `*.test.ts`, `scripts/check-consumer-boundaries.ts`, or `src/test/token-introspection.ts` — none are in `packages/components/package.json#files`, so nothing here ships in the published package.

## Test plan

- [x] `bun run --filter=@lostgradient/cinder typecheck` — 0 errors
- [x] `bun run --filter=@cinder/playground typecheck` — 0 errors
- [x] `bun run --filter=@lostgradient/cinder test` (full suite, real DOM conditions) — 7210 pass / 0 fail
- [x] `bun run --filter=@cinder/playground test` (full suite) — 895 pass / 0 fail
- [x] `bun run --filter=@lostgradient/cinder lint:invariants` (includes `check:consumer-boundaries` against the real tree) — OK
- [x] Pre-commit hook (lint-staged + full typecheck for both touched packages) — passed