### PR TITLE
Fix Tabs trigger wrapping in scrollable tab lists

### DIFF
--- a/.changeset/tabs-single-line-scroll.md
+++ b/.changeset/tabs-single-line-scroll.md
@@ -1,0 +1,5 @@
+---
+'@lostgradient/cinder': patch
+---
+
+Keep Tabs triggers single-line inside scrollable tab lists, so overflow resolves by horizontally scrolling the tab strip instead of shrinking and wrapping individual tab labels.

--- a/packages/components/src/components/tabs/tabs.css
+++ b/packages/components/src/components/tabs/tabs.css
@@ -67,8 +67,10 @@
     cursor: pointer;
     position: relative;
     display: inline-flex;
+    flex-shrink: 0;
     align-items: center;
     gap: var(--cinder-space-2);
+    white-space: nowrap;
     border-radius: var(--cinder-radius-sm) var(--cinder-radius-sm) 0 0;
     transition:
       color var(--cinder-duration-fast) var(--cinder-ease-standard),

--- a/packages/components/src/components/tabs/tabs.test.ts
+++ b/packages/components/src/components/tabs/tabs.test.ts
@@ -105,6 +105,11 @@ describe('Tabs ARIA structure', () => {
 });
 
 describe('Tabs responsive CSS', () => {
+  test('tab buttons stay single-line so the tab list scrolls as one strip', () => {
+    expect(tabsCss).toMatch(/\.cinder-tab\s*\{[^}]*flex-shrink:\s*0;/);
+    expect(tabsCss).toMatch(/\.cinder-tab\s*\{[^}]*white-space:\s*nowrap;/);
+  });
+
   test('vertical tab layout collapses through a component container query', () => {
     expect(tabsCss).toContain('container-name: cinder-tabs;');
     expect(tabsCss).toContain('@container cinder-tabs (max-width: 30rem)');


### PR DESCRIPTION
## Summary

- keep `.cinder-tab` triggers from shrinking inside the scrollable tab list
- force tab trigger labels to stay single-line so overflow resolves through the existing horizontal list scroll
- add a focused Tabs CSS regression test and patch changeset

Closes #804

## Validation

- `bun run --filter=@lostgradient/cinder test -- tabs`
- `bun run --filter=@lostgradient/cinder typecheck`
- `bun run --filter=@lostgradient/cinder lint`
- `bunx stylelint "packages/components/src/components/tabs/tabs.css"`
