### PR TITLE
fix(chat): forward bind:atBottom/unreadCount/newMessageIndicatorVisible through the public wrapper

### DIFF
--- a/.changeset/chat-forward-bindable-props.md
+++ b/.changeset/chat-forward-bindable-props.md
@@ -1,0 +1,5 @@
+---
+'@lostgradient/chat': patch
+---
+
+Fixed `Chat`'s public wrapper so `bind:atBottom`, `bind:unreadCount`, and `bind:newMessageIndicatorVisible` no longer fail `svelte-check` with "Cannot use 'bind:' with this property. It is declared as non-bindable inside the component." The wrapper previously spread these props through `...rest` instead of declaring them with `$bindable()` and forwarding them to the internal implementation, so the package's emitted type declaration reported them as non-bindable even though `ChatProps` documented them as bindable. All three props now work correctly with `bind:`.

--- a/packages/chat/scripts/validate-consumer.ts
+++ b/packages/chat/scripts/validate-consumer.ts
@@ -399,7 +399,12 @@ async function runSvelteCheckConsumer(fixture: ValidationFixture): Promise<void>
           target: 'ESNext',
           skipLibCheck: true,
         },
-        include: ['svelte-check-src'],
+        // An explicit .svelte glob, not a bare directory include: `svelte-check`
+        // resolves included files the way `tsc` does, which does not treat
+        // `.svelte` as a recognized extension by default. A bare directory
+        // entry risks silently matching nothing, which would make this whole
+        // step a no-op that always reports zero errors.
+        include: ['svelte-check-src/**/*.svelte'],
       },
       null,
       2,

--- a/packages/chat/scripts/validate-consumer.ts
+++ b/packages/chat/scripts/validate-consumer.ts
@@ -415,20 +415,23 @@ async function runSvelteCheckConsumer(fixture: ValidationFixture): Promise<void>
   const svelteCheckRoot = join(workspaceRoot, 'node_modules', 'svelte-check');
   if (!existsSync(typescriptRoot)) fail('workspace peer is unavailable: typescript');
   if (!existsSync(svelteCheckRoot)) fail('workspace peer is unavailable: svelte-check');
-  await mkdir(join(fixture.nodeModules, '.bin'), { recursive: true });
   // Explicit link type, matching `linkModule` above: on Windows a directory
   // symlink without 'junction' needs elevated permissions and fails outright.
   const directoryLinkType = process.platform === 'win32' ? 'junction' : 'dir';
   await symlink(typescriptRoot, join(fixture.nodeModules, 'typescript'), directoryLinkType);
   await symlink(svelteCheckRoot, join(fixture.nodeModules, 'svelte-check'), directoryLinkType);
-  // The .bin entry is a FILE, so it takes the default type rather than 'dir'.
-  await symlink(
-    join(workspaceRoot, 'node_modules', '.bin', 'svelte-check'),
-    join(fixture.nodeModules, '.bin', 'svelte-check'),
-  );
 
-  const svelteCheck = join(fixture.nodeModules, '.bin', 'svelte-check');
-  await run(svelteCheck, ['--tsconfig', svelteCheckTsconfigPath], fixture.root);
+  // Run the workspace's own binary rather than symlinking it into the
+  // fixture's `.bin`. A FILE symlink is a separate Windows problem from the
+  // directory links above — it needs Developer Mode or elevation, and
+  // 'junction' does not apply to files. Since the only goal is executing
+  // svelte-check against the fixture, invoking it directly with `cwd` set to
+  // the fixture sidesteps the issue entirely; module resolution still happens
+  // from the fixture through the directory links above.
+  const svelteCheck = join(workspaceRoot, 'node_modules', 'svelte-check', 'bin', 'svelte-check');
+  if (!existsSync(svelteCheck)) fail('workspace svelte-check binary is unavailable');
+  const node = Bun.which('node') ?? process.execPath;
+  await run(node, [svelteCheck, '--tsconfig', svelteCheckTsconfigPath], fixture.root);
 }
 
 async function runPlainNodeConsumer(fixture: ValidationFixture): Promise<void> {

--- a/packages/chat/scripts/validate-consumer.ts
+++ b/packages/chat/scripts/validate-consumer.ts
@@ -405,8 +405,12 @@ async function runSvelteCheckConsumer(fixture: ValidationFixture): Promise<void>
   if (!existsSync(typescriptRoot)) fail('workspace peer is unavailable: typescript');
   if (!existsSync(svelteCheckRoot)) fail('workspace peer is unavailable: svelte-check');
   await mkdir(join(fixture.nodeModules, '.bin'), { recursive: true });
-  await symlink(typescriptRoot, join(fixture.nodeModules, 'typescript'));
-  await symlink(svelteCheckRoot, join(fixture.nodeModules, 'svelte-check'));
+  // Explicit link type, matching `linkModule` above: on Windows a directory
+  // symlink without 'junction' needs elevated permissions and fails outright.
+  const directoryLinkType = process.platform === 'win32' ? 'junction' : 'dir';
+  await symlink(typescriptRoot, join(fixture.nodeModules, 'typescript'), directoryLinkType);
+  await symlink(svelteCheckRoot, join(fixture.nodeModules, 'svelte-check'), directoryLinkType);
+  // The .bin entry is a FILE, so it takes the default type rather than 'dir'.
   await symlink(
     join(workspaceRoot, 'node_modules', '.bin', 'svelte-check'),
     join(fixture.nodeModules, '.bin', 'svelte-check'),

--- a/packages/chat/scripts/validate-consumer.ts
+++ b/packages/chat/scripts/validate-consumer.ts
@@ -353,6 +353,69 @@ async function buildConsumerEntries(fixture: ValidationFixture): Promise<void> {
   await run(typescript, ['--project', tsconfigPath], fixture.root);
 }
 
+async function runSvelteCheckConsumer(fixture: ValidationFixture): Promise<void> {
+  // Regression guard for #772/#786: `svelte-check` against a *packed,
+  // installed* @lostgradient/chat (not `bun link`, not a raw .svelte source
+  // import) is the only place the symptom reproduces — a package-local
+  // typecheck never sees it, because svelte-package's dts emission can differ
+  // in subtle ways from the source it was generated from. This step exercises
+  // `bind:atBottom` / `bind:unreadCount` / `bind:newMessageIndicatorVisible`
+  // on the public `Chat` export exactly as a consumer would.
+  const svelteCheckSourceRoot = join(fixture.root, 'svelte-check-src');
+  await mkdir(svelteCheckSourceRoot, { recursive: true });
+  await Bun.write(
+    join(svelteCheckSourceRoot, 'App.svelte'),
+    `<script lang="ts">\n` +
+      `  import { Chat, createConversation } from '@lostgradient/chat';\n` +
+      `  let atBottom = $state(true);\n` +
+      `  let unreadCount = $state(0);\n` +
+      `  let newMessageIndicatorVisible = $state(false);\n` +
+      `  const conversation = createConversation({ id: 'svelte-check-consumer' });\n` +
+      `</script>\n\n` +
+      `<Chat\n` +
+      `  id="svelte-check-consumer"\n` +
+      `  {conversation}\n` +
+      `  bind:atBottom\n` +
+      `  bind:unreadCount\n` +
+      `  bind:newMessageIndicatorVisible\n` +
+      `/>\n`,
+  );
+  await Bun.write(join(fixture.root, 'svelte.config.js'), `export default {};\n`);
+  const svelteCheckTsconfigPath = join(fixture.root, 'svelte-check-tsconfig.json');
+  await Bun.write(
+    svelteCheckTsconfigPath,
+    `${JSON.stringify(
+      {
+        compilerOptions: {
+          strict: true,
+          moduleResolution: 'bundler',
+          module: 'ESNext',
+          target: 'ESNext',
+          skipLibCheck: true,
+        },
+        include: ['svelte-check-src'],
+      },
+      null,
+      2,
+    )}\n`,
+  );
+
+  const typescriptRoot = join(workspaceRoot, 'node_modules', 'typescript');
+  const svelteCheckRoot = join(workspaceRoot, 'node_modules', 'svelte-check');
+  if (!existsSync(typescriptRoot)) fail('workspace peer is unavailable: typescript');
+  if (!existsSync(svelteCheckRoot)) fail('workspace peer is unavailable: svelte-check');
+  await mkdir(join(fixture.nodeModules, '.bin'), { recursive: true });
+  await symlink(typescriptRoot, join(fixture.nodeModules, 'typescript'));
+  await symlink(svelteCheckRoot, join(fixture.nodeModules, 'svelte-check'));
+  await symlink(
+    join(workspaceRoot, 'node_modules', '.bin', 'svelte-check'),
+    join(fixture.nodeModules, '.bin', 'svelte-check'),
+  );
+
+  const svelteCheck = join(fixture.nodeModules, '.bin', 'svelte-check');
+  await run(svelteCheck, ['--tsconfig', svelteCheckTsconfigPath], fixture.root);
+}
+
 async function runPlainNodeConsumer(fixture: ValidationFixture): Promise<void> {
   const nodeFromPath = Bun.which('node');
   const nodeCandidates = new Set([
@@ -450,8 +513,10 @@ export async function validateConsumer(): Promise<void> {
     await linkFixtureDependencyGraph(fixture);
     await buildConsumerEntries(fixture);
     await runPlainNodeConsumer(fixture);
+    process.stdout.write('[validate-consumer] running svelte-check against the packed artifact…\n');
+    await runSvelteCheckConsumer(fixture);
     process.stdout.write(
-      `[validate-consumer] OK — isolated artifact, import closure, client build, plugin SSR, and plain-Node SSR verified without a host-installed conversationalist/zod.\n`,
+      `[validate-consumer] OK — isolated artifact, import closure, client build, plugin SSR, plain-Node SSR, and svelte-check bind: forwarding verified without a host-installed conversationalist/zod.\n`,
     );
   } finally {
     await rm(fixtureRoot, { recursive: true, force: true });

--- a/packages/chat/scripts/validate-consumer.ts
+++ b/packages/chat/scripts/validate-consumer.ts
@@ -380,7 +380,13 @@ async function runSvelteCheckConsumer(fixture: ValidationFixture): Promise<void>
       `  bind:newMessageIndicatorVisible\n` +
       `/>\n`,
   );
-  await Bun.write(join(fixture.root, 'svelte.config.js'), `export default {};\n`);
+  // `.mjs`, not `.js`. The scratch fixture root has no `package.json`, so a
+  // `.js` config is parsed as CommonJS and `export default` is a syntax error
+  // under plain Node — an `.mjs` extension is unambiguous regardless of the
+  // surrounding package type. Cheap insurance: this failure would surface as a
+  // config-load error long before `svelte-check` ever reached `App.svelte`,
+  // making the consumer regression guard silently useless off Bun.
+  await Bun.write(join(fixture.root, 'svelte.config.mjs'), `export default {};\n`);
   const svelteCheckTsconfigPath = join(fixture.root, 'svelte-check-tsconfig.json');
   await Bun.write(
     svelteCheckTsconfigPath,

--- a/packages/chat/src/lib/components/chat/chat.svelte
+++ b/packages/chat/src/lib/components/chat/chat.svelte
@@ -22,7 +22,13 @@
   import ChatImplementation from './container/chat.svelte';
   import type { ChatAnnounceLevel, ChatProps } from './chat.types.ts';
 
-  let { class: className, ...rest }: ChatProps = $props();
+  let {
+    class: className,
+    atBottom = $bindable(true),
+    unreadCount = $bindable(0),
+    newMessageIndicatorVisible = $bindable(false),
+    ...rest
+  }: ChatProps = $props();
 
   const mergedClassName = $derived(classNames(className));
 
@@ -93,4 +99,11 @@
   }
 </script>
 
-<ChatImplementation bind:this={impl} class={mergedClassName} {...rest} />
+<ChatImplementation
+  bind:this={impl}
+  bind:atBottom
+  bind:unreadCount
+  bind:newMessageIndicatorVisible
+  class={mergedClassName}
+  {...rest}
+/>

--- a/packages/chat/src/lib/components/chat/chat.test.ts
+++ b/packages/chat/src/lib/components/chat/chat.test.ts
@@ -747,12 +747,15 @@ describe('Chat — public wrapper forwards bind:atBottom/unreadCount/newMessageI
     const { resolve } = await import('node:path');
     const source = await Bun.file(resolve(import.meta.dir, 'chat.svelte')).text();
 
-    expect(source).toContain('atBottom = $bindable(true)');
-    expect(source).toContain('unreadCount = $bindable(0)');
-    expect(source).toContain('newMessageIndicatorVisible = $bindable(false)');
-    expect(source).toContain('bind:atBottom');
-    expect(source).toContain('bind:unreadCount');
-    expect(source).toContain('bind:newMessageIndicatorVisible');
+    // Whitespace-tolerant: prettier runs over this file via lint-staged, so an
+    // exact-substring assertion would eventually fail on a reformat even though
+    // the wrapper still declares and forwards the bindings correctly.
+    expect(source).toMatch(/atBottom\s*=\s*\$bindable\(\s*true\s*\)/);
+    expect(source).toMatch(/unreadCount\s*=\s*\$bindable\(\s*0\s*\)/);
+    expect(source).toMatch(/newMessageIndicatorVisible\s*=\s*\$bindable\(\s*false\s*\)/);
+    expect(source).toMatch(/bind:atBottom\b/);
+    expect(source).toMatch(/bind:unreadCount\b/);
+    expect(source).toMatch(/bind:newMessageIndicatorVisible\b/);
   });
 });
 

--- a/packages/chat/src/lib/components/chat/chat.test.ts
+++ b/packages/chat/src/lib/components/chat/chat.test.ts
@@ -718,6 +718,44 @@ describe('Chat — atBottom bindable after send', () => {
   });
 });
 
+describe('Chat — public wrapper forwards bind:atBottom/unreadCount/newMessageIndicatorVisible', () => {
+  // Regression for #772/#786: chat.svelte (the public wrapper exported from
+  // the package) spread atBottom/unreadCount/newMessageIndicatorVisible into
+  // `...rest` instead of declaring them with `$bindable()` and forwarding
+  // `bind:` to the internal implementation. That made the *wrapper's* emitted
+  // .d.ts report an empty Bindings type parameter (`Component<ChatProps, {...},
+  // "">`) even though ChatProps documents them as bindable and the internal
+  // implementation implements them correctly — svelte-check correctly rejected
+  // `bind:atBottom` on a consuming .svelte file as a result. See
+  // chat.svelte's `$props()` destructure and the `bind:atBottom` /
+  // `bind:unreadCount` / `bind:newMessageIndicatorVisible` directives on
+  // <ChatImplementation> for the fix.
+  //
+  // A runtime render-based check (a host wrapper component that binds and
+  // reads the value back) reliably crashes bun:test + happy-dom + the
+  // testing-library/svelte mount path for *any* nested `bind:` + template
+  // read of a bindable prop, independent of Chat entirely (reproduced with a
+  // two-line throwaway parent/child pair). That is a pre-existing harness
+  // limitation, not something this fix introduces, so the runtime contract is
+  // instead covered by `bun run --filter=@lostgradient/chat validate:consumer`,
+  // which runs `svelte-check` against the *packed, installed* artifact with a
+  // real `bind:atBottom` / `bind:unreadCount` / `bind:newMessageIndicatorVisible`
+  // consumer file — the exact failure mode from the issue. The source-pattern
+  // check below guards the wrapper's implementation shape at the unit-test
+  // layer.
+  test('chat.svelte declares atBottom/unreadCount/newMessageIndicatorVisible as $bindable and forwards bind: to the implementation', async () => {
+    const { resolve } = await import('node:path');
+    const source = await Bun.file(resolve(import.meta.dir, 'chat.svelte')).text();
+
+    expect(source).toContain('atBottom = $bindable(true)');
+    expect(source).toContain('unreadCount = $bindable(0)');
+    expect(source).toContain('newMessageIndicatorVisible = $bindable(false)');
+    expect(source).toContain('bind:atBottom');
+    expect(source).toContain('bind:unreadCount');
+    expect(source).toContain('bind:newMessageIndicatorVisible');
+  });
+});
+
 describe('Chat — imperative API forwarding', () => {
   // The forwarded surface, as a flat interface so dot-access on the mounted
   // instance is real-property access (avoids the index-signature access rule on


### PR DESCRIPTION
## Summary

`ChatProps` documents `atBottom`, `unreadCount`, and `newMessageIndicatorVisible` as bindable, and the internal implementation (`container/chat.svelte`) correctly declares them with `$bindable()`. But the public wrapper (`chat.svelte`, the actual `Chat` export) only spread these props through `...rest` into the implementation — it never declared them bindable itself. Svelte's dts emitter correctly reflects that: comparing the built `.d.ts` files showed the wrapper's `Component<>` type parameter had an **empty** Bindings set (`""`) while the implementation's had the correct one (`"unreadCount" | "atBottom" | "newMessageIndicatorVisible"`). `svelte-check` rejected `bind:atBottom` etc. on any consuming file as a result — correctly, given what the wrapper actually implemented.

**Root cause determination:** ours, not upstream. Confirmed by building the package and diffing the two generated `.d.ts` files directly — the wrapper's dts genuinely disagreed with its own `ChatProps` type, a real implementation gap rather than a `svelte-check`/tooling quirk.

**Fix:** the wrapper now declares `atBottom = $bindable(true)`, `unreadCount = $bindable(0)`, and `newMessageIndicatorVisible = $bindable(false)`, and forwards them with `bind:` to the internal `<ChatImplementation>` (alongside the existing `bind:this`).

**Type-level verification (from a consumer, not just the package's own typecheck):** built the package, packed the tarball, installed it into a scratch fixture (not `bun link`), and ran `svelte-check` against a `.svelte` file doing `bind:atBottom`/`bind:unreadCount`/`bind:newMessageIndicatorVisible` on the packed `Chat` import — reproduced the exact reported error on `main`, then confirmed 0 errors after the fix. That check is now a step in `scripts/validate-consumer.ts` (`bun run --filter=@lostgradient/chat validate:consumer`). **Note:** `validate:consumer` currently only runs from the release workflows (`release.yaml` / `release-manual.yaml`), not from the PR-gating `playwright` check — so this is a release-time and local guard, not something that blocks this or a future PR in CI. Flagging this as a pre-existing gap in the validation pipeline (not something to fix in this PR, which is scoped to the binding bug) — worth a follow-up to wire `validate:consumer` into PR CI.

**Runtime verification:** attempted a render-based test asserting the bound value round-trips after a `Chat`-internal write. It crashes bun:test + happy-dom + `@testing-library/svelte`'s mount path — but isolating the exact trigger (with a throwaway two-component pair, no Chat involved) shows it crashes for *any* component that both (a) does `bind:x` to a child and (b) reads that same `x` in its own template — regardless of whether the value originates as a mounted prop or a locally-owned `$state`. It does *not* crash when the parent binds without also reading the value locally. This isolates it to a pre-existing harness limitation in effect-scheduling under happy-dom, not something this change introduces or something that indicates a real bug in the fix (the mechanism itself is a standard `bind:` directive using the exact same primitive already exercised elsewhere in this codebase). Given that, the runtime contract rests on standard Svelte `bind:` semantics plus the corrected type declaration, not an end-to-end assertion — I did not verify it in a real browser and am not claiming to.

A source-pattern unit test guards the wrapper's implementation shape (declares `$bindable()`, forwards `bind:`).

Closes #772
Closes #786

## Test plan

- [x] `bun run --filter=@lostgradient/chat test` — 687 pass, 0 fail
- [x] `bun run --filter=@lostgradient/chat typecheck` — 0 errors
- [x] `bun run --filter=@lostgradient/chat lint` — 0 errors
- [x] `bun run --filter=@lostgradient/chat validate:consumer` — includes new svelte-check step against packed artifact with `bind:atBottom`/`bind:unreadCount`/`bind:newMessageIndicatorVisible`; passes (local + release-time only, see note above)
- [x] Manually reproduced the reported `svelte-check` error against a packed tarball on `main` before the fix, and confirmed it is resolved after
