### PR TITLE
Allow custom FileUpload trigger labels

### DIFF
--- a/.changeset/file-upload-trigger-label.md
+++ b/.changeset/file-upload-trigger-label.md
@@ -1,0 +1,5 @@
+---
+'@lostgradient/cinder': patch
+---
+
+Add `triggerLabel` to `FileUpload` so consumers can customize the visible picker button text while keeping Cinder's native input wiring, drag-and-drop validation, disabled state, and live-region announcements.

--- a/packages/components/src/components/file-upload/README.md
+++ b/packages/components/src/components/file-upload/README.md
@@ -30,25 +30,34 @@ announces results, and can render consumer-driven upload progress rows.
 </FormField>
 ```
 
+Use `triggerLabel` when the picker action needs more specific text, such as
+directory or import flows. Native input attributes still pass through to the
+real file input, so directory selection can use `webkitdirectory`:
+
+```svelte
+<FileUpload id="history" triggerLabel="Choose directory" webkitdirectory />
+```
+
 ## Props
 
 <!-- generated:props:start -->
 
-| Prop         | Type       | Required | Default | Description                                                                                                                                       |
-| ------------ | ---------- | -------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `accept`     | `string`   | no       | —       | Native file accept filter.                                                                                                                        |
-| `disabled`   | `boolean`  | no       | —       | Disables the file picker and drag-and-drop surface.                                                                                               |
-| `id`         | `string`   | no       | —       | Stable id for the native file input. Required when composing with `FormField`.                                                                    |
-| `maxSize`    | `number`   | no       | —       | Maximum allowed file size in bytes.                                                                                                               |
-| `multiple`   | `boolean`  | no       | —       | Allow more than one file. Default `false`.                                                                                                        |
-| `name`       | `string`   | no       | —       | Native input name used for form submission.                                                                                                       |
-| `class`      | `(opaque)` | no       | —       | Additional classes merged with `.cinder-file-upload`. Not expressible in JSON Schema; see the component types for the signature.                  |
-| `dragActive` | `(opaque)` | no       | —       | Replaces the default drag-active dropzone body. Not expressible in JSON Schema; see the component types for the signature.                        |
-| `fileList`   | `(opaque)` | no       | —       | Replaces the default file-list renderer. Receives the resolved rows. Not expressible in JSON Schema; see the component types for the signature.   |
-| `files`      | `(opaque)` | no       | —       | Consumer-driven file rows, including upload progress and error states. Not expressible in JSON Schema; see the component types for the signature. |
-| `idle`       | `(opaque)` | no       | —       | Replaces the default resting-state dropzone body. Not expressible in JSON Schema; see the component types for the signature.                      |
-| `onchange`   | `(opaque)` | no       | —       | Fires with accepted files after local validation passes. Not expressible in JSON Schema; see the component types for the signature.               |
-| `onreject`   | `(opaque)` | no       | —       | Fires with rejected files and reasons after local validation runs. Not expressible in JSON Schema; see the component types for the signature.     |
+| Prop           | Type       | Required | Default | Description                                                                                                                                       |
+| -------------- | ---------- | -------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `accept`       | `string`   | no       | —       | Native file accept filter.                                                                                                                        |
+| `disabled`     | `boolean`  | no       | —       | Disables the file picker and drag-and-drop surface.                                                                                               |
+| `id`           | `string`   | no       | —       | Stable id for the native file input. Required when composing with `FormField`.                                                                    |
+| `maxSize`      | `number`   | no       | —       | Maximum allowed file size in bytes.                                                                                                               |
+| `multiple`     | `boolean`  | no       | —       | Allow more than one file. Default `false`.                                                                                                        |
+| `name`         | `string`   | no       | —       | Native input name used for form submission.                                                                                                       |
+| `triggerLabel` | `string`   | no       | —       | Visible text for the picker trigger button. Default `Choose files`.                                                                               |
+| `class`        | `(opaque)` | no       | —       | Additional classes merged with `.cinder-file-upload`. Not expressible in JSON Schema; see the component types for the signature.                  |
+| `dragActive`   | `(opaque)` | no       | —       | Replaces the default drag-active dropzone body. Not expressible in JSON Schema; see the component types for the signature.                        |
+| `fileList`     | `(opaque)` | no       | —       | Replaces the default file-list renderer. Receives the resolved rows. Not expressible in JSON Schema; see the component types for the signature.   |
+| `files`        | `(opaque)` | no       | —       | Consumer-driven file rows, including upload progress and error states. Not expressible in JSON Schema; see the component types for the signature. |
+| `idle`         | `(opaque)` | no       | —       | Replaces the default resting-state dropzone body. Not expressible in JSON Schema; see the component types for the signature.                      |
+| `onchange`     | `(opaque)` | no       | —       | Fires with accepted files after local validation passes. Not expressible in JSON Schema; see the component types for the signature.               |
+| `onreject`     | `(opaque)` | no       | —       | Fires with rejected files and reasons after local validation runs. Not expressible in JSON Schema; see the component types for the signature.     |
 
 <!-- generated:props:end -->
 

--- a/packages/components/src/components/file-upload/file-upload.a11y.md
+++ b/packages/components/src/components/file-upload/file-upload.a11y.md
@@ -1,6 +1,6 @@
 # FileUpload accessibility
 
-- The dropzone is a grouped surface that keeps a native `<input type="file">` plus a visible `Choose files` button; keyboard and assistive-technology users can activate the picker through the real button while form semantics stay on the input.
+- The dropzone is a grouped surface that keeps a native `<input type="file">` plus a visible picker button; keyboard and assistive-technology users can activate the picker through the real button while form semantics stay on the input.
 - Drag feedback changes border style and background together; the state is not color-only.
 - After every selection or drop, a polite live region announces accepted and rejected counts so assistive-technology users receive immediate feedback.
 - Error rows render visible messages linked with `aria-describedby`.

--- a/packages/components/src/components/file-upload/file-upload.schema.json
+++ b/packages/components/src/components/file-upload/file-upload.schema.json
@@ -25,6 +25,10 @@
     "maxSize": {
       "type": "number",
       "description": "Maximum allowed file size in bytes."
+    },
+    "triggerLabel": {
+      "type": "string",
+      "description": "Visible text for the picker trigger button. Default `Choose files`."
     }
   },
   "additionalProperties": false,

--- a/packages/components/src/components/file-upload/file-upload.schema.ts
+++ b/packages/components/src/components/file-upload/file-upload.schema.ts
@@ -28,6 +28,10 @@ const schema = {
       type: 'number',
       description: 'Maximum allowed file size in bytes.',
     },
+    triggerLabel: {
+      type: 'string',
+      description: 'Visible text for the picker trigger button. Default `Choose files`.',
+    },
   },
   additionalProperties: false,
   metadata: {

--- a/packages/components/src/components/file-upload/file-upload.svelte
+++ b/packages/components/src/components/file-upload/file-upload.svelte
@@ -38,6 +38,7 @@
     required,
     name,
     class: className,
+    triggerLabel = 'Choose files',
     files,
     idle,
     dragActive,
@@ -339,7 +340,7 @@
       disabled={field.disabled}
       onclick={openPicker}
     >
-      Choose files
+      {triggerLabel}
     </button>
   </div>
 

--- a/packages/components/src/components/file-upload/file-upload.svelte
+++ b/packages/components/src/components/file-upload/file-upload.svelte
@@ -259,6 +259,10 @@
     if (progress === undefined) return 0;
     return Math.max(0, Math.min(100, progress));
   }
+
+  function sentenceCaseTriggerLabel(label: string): string {
+    return label.length === 0 ? label : `${label[0]!.toLowerCase()}${label.slice(1)}`;
+  }
 </script>
 
 {#snippet defaultIdle()}
@@ -279,7 +283,7 @@
           stroke-linejoin="round"
         />
       </svg>
-      Drag files here or choose files
+      Drag files here or {sentenceCaseTriggerLabel(triggerLabel)}
     </span>
     <p class="cinder-file-upload__hint">Drop files on this area or use the native file picker.</p>
   </div>

--- a/packages/components/src/components/file-upload/file-upload.test.ts
+++ b/packages/components/src/components/file-upload/file-upload.test.ts
@@ -99,6 +99,9 @@ describe('FileUpload rendering', () => {
       props: { id: 'history-import', triggerLabel: 'Import history JSON' },
     });
     expect(container.querySelector('button')?.textContent).toBe('Import history JSON');
+    expect(container.querySelector('.cinder-file-upload__eyebrow')?.textContent).toContain(
+      'import history JSON',
+    );
   });
 
   test('forwards accept, multiple, name, disabled, required, and webkitdirectory to the input', () => {

--- a/packages/components/src/components/file-upload/file-upload.test.ts
+++ b/packages/components/src/components/file-upload/file-upload.test.ts
@@ -94,7 +94,14 @@ describe('FileUpload rendering', () => {
     expect(container.querySelector('button')?.textContent).toBe('Choose files');
   });
 
-  test('forwards accept, multiple, name, disabled, and required to the input', () => {
+  test('renders custom picker trigger text', () => {
+    const { container } = render(FileUpload, {
+      props: { id: 'history-import', triggerLabel: 'Import history JSON' },
+    });
+    expect(container.querySelector('button')?.textContent).toBe('Import history JSON');
+  });
+
+  test('forwards accept, multiple, name, disabled, required, and webkitdirectory to the input', () => {
     const { container } = render(FileUpload, {
       props: {
         id: 'attachments',
@@ -103,6 +110,7 @@ describe('FileUpload rendering', () => {
         name: 'attachments',
         disabled: true,
         required: true,
+        webkitdirectory: true,
       },
     });
     const input = container.querySelector('#attachments') as HTMLInputElement;
@@ -111,6 +119,7 @@ describe('FileUpload rendering', () => {
     expect(input.getAttribute('name')).toBe('attachments');
     expect(input.disabled).toBe(true);
     expect(input.required).toBe(true);
+    expect(input.hasAttribute('webkitdirectory')).toBe(true);
   });
 
   test('merges aria-describedby from FormField context and the consumer', () => {
@@ -292,7 +301,7 @@ describe('FileUpload drag state and accessibility', () => {
       createFile('bad.mov', 'video/quicktime', 2 * 1024 * 1024),
     ];
     const { container } = render(FileUpload, {
-      props: { id: 'upload', maxSize: 1024, multiple: true },
+      props: { id: 'upload', maxSize: 1024, multiple: true, triggerLabel: 'Import files' },
     });
     const dropzone = container.querySelector('.cinder-file-upload__dropzone') as HTMLDivElement;
     await fireEvent(dropzone, createDropEvent('drop', files));
@@ -331,8 +340,10 @@ describe('FileUpload drag state and accessibility', () => {
     expect(dropzone.getAttribute('aria-labelledby')).toBe('resume-label');
   });
 
-  test('visible button trigger opens the native picker path', async () => {
-    const { container } = render(FileUpload, { props: { id: 'upload' } });
+  test('visible button trigger opens the native picker path with custom text', async () => {
+    const { container } = render(FileUpload, {
+      props: { id: 'upload', triggerLabel: 'Choose directory' },
+    });
     const input = container.querySelector('#upload') as HTMLInputElement;
     const button = container.querySelector('button') as HTMLButtonElement;
     const click = mock(() => {});
@@ -343,7 +354,7 @@ describe('FileUpload drag state and accessibility', () => {
     });
     input.click = click as unknown as typeof input.click;
     await fireEvent.click(button);
-    expect(button.textContent).toBe('Choose files');
+    expect(button.textContent).toBe('Choose directory');
     expect(input.value).toBe('');
     expect(click).toHaveBeenCalledTimes(1);
   });

--- a/packages/components/src/components/file-upload/file-upload.types.ts
+++ b/packages/components/src/components/file-upload/file-upload.types.ts
@@ -45,6 +45,8 @@ export type FileUploadProps = Omit<
   name?: string;
   /** Additional classes merged with `.cinder-file-upload`. */
   class?: string;
+  /** Visible text for the picker trigger button. Default `Choose files`. */
+  triggerLabel?: string;
   /** Consumer-driven file rows, including upload progress and error states. */
   files?: FileUploadEntry[];
   /** Replaces the default resting-state dropzone body. */


### PR DESCRIPTION
## Summary

- add `triggerLabel` to FileUpload for custom picker button text
- keep Cinder-owned native input wiring, disabled handling, validation, drop handling, and live-region announcements intact
- document `webkitdirectory` passthrough for directory picker flows
- add a patch changeset for `@lostgradient/cinder`

Closes #811

## Verification

- `bun run --filter=@lostgradient/cinder test -- src/components/file-upload/file-upload.test.ts`
- `bun run --filter=@lostgradient/cinder typecheck`
- `bun run --filter=@lostgradient/cinder components:check`
- `rg -n "Choose files|triggerLabel|trigger\?:|webkitdirectory" packages/components/src/components/file-upload`