### PR TITLE
Fix ToastRegion warning live region routing

### DIFF
--- a/.changeset/polite-warning-toasts.md
+++ b/.changeset/polite-warning-toasts.md
@@ -1,0 +1,5 @@
+---
+'@lostgradient/cinder': patch
+---
+
+Route `ToastRegion` warning toasts through the polite `role="status"` live-region channel while keeping danger toasts assertive.

--- a/packages/components/src/components/toast-region.md
+++ b/packages/components/src/components/toast-region.md
@@ -1,6 +1,6 @@
 # ToastRegion
 
-A region-scoped queue for transient notifications. `<ToastRegion>` owns the two stacked aria-live regions (polite for `info`/`success`, assertive for `warning`/`danger`); `useToast()` returns the dispatcher API to any descendant. See [`./toast-region.a11y.md`](./toast-region.a11y.md) for the ARIA contract.
+A region-scoped queue for transient notifications. `<ToastRegion>` owns the two stacked aria-live regions (polite for `info`/`success`/`warning`, assertive for `danger`); `useToast()` returns the dispatcher API to any descendant. See [`./toast-region.a11y.md`](./toast-region.a11y.md) for the ARIA contract.
 
 ## Placement
 
@@ -60,12 +60,12 @@ Import the hook from the toast-region subpath. Call `useToast()` from anywhere i
 
 ## Variant routing (polite vs assertive)
 
-`variant` is not just a visual prop — it picks which live region the toast announces through. Polite variants (`info`, `success`) queue behind the user's current screen-reader focus; assertive variants (`warning`, `danger`) interrupt. See the [Two regions, two priorities](./toast-region.a11y.md#two-regions-two-priorities) table in the a11y doc for the exact ARIA mapping.
+`variant` is not just a visual prop — it picks which live region the toast announces through. Polite variants (`info`, `success`, `warning`) queue behind the user's current screen-reader focus; the assertive `danger` variant interrupts. See the [Two regions, two priorities](./toast-region.a11y.md#two-regions-two-priorities) table in the a11y doc for the exact ARIA mapping.
 
 `maxStack` applies _per stack_: a region can hold up to `maxStack` polite toasts **and** `maxStack` assertive toasts simultaneously.
 
 > [!TIP]
-> Match urgency to variant. `success` ("Saved") is informational and belongs on the polite stack. `danger` ("Failed to save") interrupts because the user needs to know _now_. Reserve `warning` for conditions the user must address before continuing — session expiry, unsaved-changes risk — not ambient status updates; if no action is required, `info` is more honest.
+> Match urgency to variant. `success` ("Saved") is informational and belongs on the polite stack. `warning` ("Session expires soon") is notable but non-interrupting. `danger` ("Failed to save") interrupts because the user needs to know _now_.
 
 ## `show()` return value
 

--- a/packages/components/src/components/toast-region/toast-region.a11y.md
+++ b/packages/components/src/components/toast-region/toast-region.a11y.md
@@ -8,10 +8,10 @@ Two stacked aria-live regions follow [WAI-ARIA Authoring Practices: Alert and St
 
 ## Two regions, two priorities
 
-| Variant             | Region                                      | aria-live   | role     |
-| ------------------- | ------------------------------------------- | ----------- | -------- |
-| `info`, `success`   | `.cinder-toast-region__channel` (polite)    | `polite`    | `status` |
-| `warning`, `danger` | `.cinder-toast-region__channel` (assertive) | `assertive` | `alert`  |
+| Variant                      | Region                                      | aria-live   | role     |
+| ---------------------------- | ------------------------------------------- | ----------- | -------- |
+| `info`, `success`, `warning` | `.cinder-toast-region__channel` (polite)    | `polite`    | `status` |
+| `danger`                     | `.cinder-toast-region__channel` (assertive) | `assertive` | `alert`  |
 
 Both regions carry `aria-atomic="true"` and `aria-relevant="additions"`. They render in the same visual position but route announcements through independent live-region queues so a `success` toast and a simultaneous `danger` toast don't collapse into a single ambiguous announcement.
 

--- a/packages/components/src/components/toast-region/toast-region.css
+++ b/packages/components/src/components/toast-region/toast-region.css
@@ -15,7 +15,7 @@
     z-index: var(--cinder-z-toast);
     pointer-events: none;
     /* Stack the two aria-live channels in the same visual column. Each channel
-   * is independent — a polite info and an assertive warning may sit
+   * is independent — a polite warning and an assertive danger toast may sit
    * side-by-side visually but route to different SR-announcement queues. */
   }
 

--- a/packages/components/src/components/toast-region/toast-region.examples.json
+++ b/packages/components/src/components/toast-region/toast-region.examples.json
@@ -72,7 +72,7 @@
     {
       "id": "variants",
       "title": "All four variants",
-      "description": "info and success route to the polite (status) region; warning and danger route to the assertive (alert) region.",
+      "description": "info, success, and warning route to the polite (status) region; danger routes to the assertive (alert) region.",
       "code": "<script lang=\"ts\">\n  import { Button } from '@lostgradient/cinder/button';\n  import { ToastRegion, useToast } from '@lostgradient/cinder/toast-region';\n</script>\n\n<ToastRegion>\n  {#snippet children()}\n    {@const toast = useToast()}\n    <div class=\"example-preview-row\">\n      <Button\n        label=\"Info\"\n        onclick={() => toast.show('A new version is available.', { variant: 'info' })}\n      />\n      <Button\n        label=\"Success\"\n        onclick={() => toast.show('Saved your changes.', { variant: 'success' })}\n      />\n      <Button\n        variant=\"secondary\"\n        label=\"Warning\"\n        onclick={() => toast.show('Your session expires in 5 minutes.', { variant: 'warning' })}\n      />\n      <Button\n        variant=\"danger\"\n        label=\"Danger\"\n        onclick={() => toast.show('Failed to save your changes.', { variant: 'danger' })}\n      />\n    </div>\n  {/snippet}\n</ToastRegion>\n"
     }
   ]

--- a/packages/components/src/components/toast-region/toast-region.svelte
+++ b/packages/components/src/components/toast-region/toast-region.svelte
@@ -79,7 +79,7 @@
     hydrated = true;
   });
 
-  // Two regions, two stacks. Polite for info/success; assertive for warning/danger.
+  // Two regions, two stacks. Polite for non-urgent feedback; assertive for danger.
   let politeStack: InternalToastItem[] = $state([]);
   let assertiveStack: InternalToastItem[] = $state([]);
 
@@ -97,7 +97,7 @@
   let generationCounter = 0;
 
   function isPolite(variant: ToastVariant): boolean {
-    return variant === 'info' || variant === 'success';
+    return variant === 'info' || variant === 'success' || variant === 'warning';
   }
 
   function getCurrentStack(variant: ToastVariant): InternalToastItem[] {

--- a/packages/components/src/components/toast-region/toast-region.test.ts
+++ b/packages/components/src/components/toast-region/toast-region.test.ts
@@ -191,7 +191,7 @@ describe('useToast api', () => {
     });
   });
 
-  test('warning variant routes to the assertive region', async () => {
+  test('warning variant routes to the polite region', async () => {
     let api: ToastApi | null = null;
     const { container } = render(Wrapper, {
       onReady: (a: ToastApi) => {
@@ -201,10 +201,10 @@ describe('useToast api', () => {
     await waitFor(() => expect(api).not.toBeNull());
     api!.show('Watch out', { variant: 'warning' });
     await waitFor(() => {
-      const assertive = container.querySelector('[role="alert"]');
-      expect(assertive?.textContent).toContain('Watch out');
       const polite = container.querySelector('[role="status"]');
-      expect(polite?.textContent).not.toContain('Watch out');
+      expect(polite?.textContent).toContain('Watch out');
+      const assertive = container.querySelector('[role="alert"]');
+      expect(assertive?.textContent).not.toContain('Watch out');
     });
   });
 
@@ -254,8 +254,9 @@ describe('useToast api', () => {
     api!.show('Info', { variant: 'info' });
     api!.show('Warning', { variant: 'warning' });
     await waitFor(() => {
-      expect(container.querySelector('[role="status"]')?.textContent).toContain('Info');
-      expect(container.querySelector('[role="alert"]')?.textContent).toContain('Warning');
+      const politeText = container.querySelector('[role="status"]')?.textContent ?? '';
+      expect(politeText).toContain('Info');
+      expect(politeText).toContain('Warning');
     });
     api!.dismissAll();
     await waitFor(() => {
@@ -381,7 +382,7 @@ describe('useToast api', () => {
     });
   });
 
-  test('renders the icon in the assertive region for warning/danger variants', async () => {
+  test('renders the icon in the polite region for warning variants', async () => {
     let api: ToastApi | null = null;
     const { container } = render(Wrapper, {
       onReady: (a: ToastApi) => {
@@ -394,8 +395,8 @@ describe('useToast api', () => {
     }));
     api!.show('Heads up', { icon, variant: 'warning', duration: 0 });
     await waitFor(() => {
-      const assertive = container.querySelector('[role="alert"]');
-      const iconWrapper = assertive?.querySelector('.cinder-toast__icon');
+      const polite = container.querySelector('[role="status"]');
+      const iconWrapper = polite?.querySelector('.cinder-toast__icon');
       expect(iconWrapper).not.toBeNull();
       expect(iconWrapper?.querySelector('[data-testid="assertive-icon"]')).not.toBeNull();
     });
@@ -1135,8 +1136,8 @@ describe('toast variant icons', () => {
 
     api!.show('Caution', { variant: 'warning', duration: 0, showIcon: true });
     await waitFor(() => {
-      const assertive = container.querySelector('[role="alert"]');
-      const iconWrapper = assertive?.querySelector('.cinder-toast__icon');
+      const polite = container.querySelector('[role="status"]');
+      const iconWrapper = polite?.querySelector('.cinder-toast__icon');
       expect(iconWrapper).not.toBeNull();
       const svg = iconWrapper?.querySelector('svg');
       expect(svg).not.toBeNull();

--- a/packages/components/src/components/toast-region/toast-region.test.ts
+++ b/packages/components/src/components/toast-region/toast-region.test.ts
@@ -202,9 +202,11 @@ describe('useToast api', () => {
     api!.show('Watch out', { variant: 'warning' });
     await waitFor(() => {
       const polite = container.querySelector('[role="status"]');
-      expect(polite?.textContent).toContain('Watch out');
+      expect(polite).not.toBeNull();
+      expect(polite!.textContent).toContain('Watch out');
       const assertive = container.querySelector('[role="alert"]');
-      expect(assertive?.textContent).not.toContain('Watch out');
+      expect(assertive).not.toBeNull();
+      expect(assertive!.textContent).not.toContain('Watch out');
     });
   });
 
@@ -396,7 +398,8 @@ describe('useToast api', () => {
     api!.show('Heads up', { icon, variant: 'warning', duration: 0 });
     await waitFor(() => {
       const polite = container.querySelector('[role="status"]');
-      const iconWrapper = polite?.querySelector('.cinder-toast__icon');
+      expect(polite).not.toBeNull();
+      const iconWrapper = polite!.querySelector('.cinder-toast__icon');
       expect(iconWrapper).not.toBeNull();
       expect(iconWrapper?.querySelector('[data-testid="assertive-icon"]')).not.toBeNull();
     });
@@ -1137,7 +1140,8 @@ describe('toast variant icons', () => {
     api!.show('Caution', { variant: 'warning', duration: 0, showIcon: true });
     await waitFor(() => {
       const polite = container.querySelector('[role="status"]');
-      const iconWrapper = polite?.querySelector('.cinder-toast__icon');
+      expect(polite).not.toBeNull();
+      const iconWrapper = polite!.querySelector('.cinder-toast__icon');
       expect(iconWrapper).not.toBeNull();
       const svg = iconWrapper?.querySelector('svg');
       expect(svg).not.toBeNull();

--- a/packages/playground/src/examples/toast-region/variants.example.svelte
+++ b/packages/playground/src/examples/toast-region/variants.example.svelte
@@ -1,7 +1,7 @@
 <script lang="ts" module>
   export const title = 'All four variants';
   export const description =
-    'info and success route to the polite (status) region; warning and danger route to the assertive (alert) region.';
+    'info, success, and warning route to the polite (status) region; danger routes to the assertive (alert) region.';
 </script>
 
 <script lang="ts">


### PR DESCRIPTION
## Summary

- Route `ToastRegion` warning toasts through the polite/status live region.
- Keep danger toasts on the assertive/alert live region.
- Update ToastRegion regression coverage and local docs/example metadata.
- Add a patch changeset for `@lostgradient/cinder`.

Closes #800

## Validation

- `bun run --filter=@lostgradient/cinder test ./src/components/toast-region/toast-region.test.ts`
- `bun run --filter=@lostgradient/cinder typecheck`
- `bun run --filter=@lostgradient/cinder components:check`
- `bun run --filter=@lostgradient/cinder lint`
- `bunx stylelint packages/components/src/components/toast-region/toast-region.css packages/components/src/components/toast-region/toast-region.svelte packages/playground/src/examples/toast-region/variants.example.svelte`