### PR TITLE
Add RunStepTimeline selection API

### DIFF
--- a/.changeset/run-step-timeline-selection.md
+++ b/.changeset/run-step-timeline-selection.md
@@ -1,0 +1,5 @@
+---
+'@lostgradient/cinder': minor
+---
+
+Add RunStepTimeline selected-step and row-click selection props.

--- a/packages/components/src/components/run-step-timeline/README.md
+++ b/packages/components/src/components/run-step-timeline/README.md
@@ -186,6 +186,8 @@ Set `rewound: true` on a step that was speculatively executed and then unwound. 
 ```
 steps      RunStep[]          required  Ordered list of steps to render.
 label      string             optional  Accessible label for the list (aria-label).
+selectedStepId string | null  optional  Step id to visually mark as selected.
+onStepSelect (stepId) => void optional  Fired when a rendered step row is clicked.
 class      string             optional  Additional CSS classes on the root ol element.
 children   Snippet<[RunStep]> optional  Per-step body content rendered after step metadata.
 ```

--- a/packages/components/src/components/run-step-timeline/run-step-timeline.css
+++ b/packages/components/src/components/run-step-timeline/run-step-timeline.css
@@ -55,6 +55,16 @@
     display: none;
   }
 
+  .cinder-run-step-timeline__item[data-cinder-selectable] {
+    cursor: pointer;
+  }
+
+  .cinder-run-step-timeline__item[data-cinder-selected] .cinder-run-step-timeline__event {
+    border-radius: var(--cinder-radius-md);
+    background: color-mix(in oklch, var(--cinder-accent), transparent 90%);
+    box-shadow: inset 0 0 0 1px color-mix(in oklch, var(--cinder-accent), transparent 55%);
+  }
+
   /* ----------------------------------------
    * Event layout: marker column + content column
    * ---------------------------------------- */
@@ -354,6 +364,12 @@
     /* Ensure connector lines are visible in high-contrast mode */
     .cinder-run-step-timeline__item::before {
       background: ButtonText;
+    }
+
+    .cinder-run-step-timeline__item[data-cinder-selected] .cinder-run-step-timeline__event {
+      outline: 1px solid Highlight;
+      background: Canvas;
+      box-shadow: none;
     }
   }
 }

--- a/packages/components/src/components/run-step-timeline/run-step-timeline.css
+++ b/packages/components/src/components/run-step-timeline/run-step-timeline.css
@@ -59,7 +59,20 @@
     cursor: pointer;
   }
 
-  .cinder-run-step-timeline__item[data-cinder-selectable]:focus-visible
+  .cinder-run-step-timeline__selection-control {
+    position: absolute;
+    inset: 0;
+    z-index: 0;
+    padding: 0;
+    background: transparent;
+    border: 0;
+    opacity: 0;
+    pointer-events: none;
+  }
+
+  .cinder-run-step-timeline__item[data-cinder-selectable]:has(
+      .cinder-run-step-timeline__selection-control:focus-visible
+    )
     .cinder-run-step-timeline__event {
     border-radius: var(--cinder-radius-md);
     outline: var(--cinder-ring-width) solid transparent;
@@ -77,6 +90,8 @@
    * ---------------------------------------- */
 
   .cinder-run-step-timeline__event {
+    position: relative;
+    z-index: 1;
     display: grid;
     grid-template-columns: var(--_cinder-rst-rail-size) 1fr;
     gap: var(--cinder-space-3);
@@ -379,7 +394,9 @@
       box-shadow: none;
     }
 
-    .cinder-run-step-timeline__item[data-cinder-selectable]:focus-visible
+    .cinder-run-step-timeline__item[data-cinder-selectable]:has(
+        .cinder-run-step-timeline__selection-control:focus-visible
+      )
       .cinder-run-step-timeline__event {
       outline: var(--cinder-ring-width) solid ButtonText;
       box-shadow: none;

--- a/packages/components/src/components/run-step-timeline/run-step-timeline.css
+++ b/packages/components/src/components/run-step-timeline/run-step-timeline.css
@@ -59,6 +59,13 @@
     cursor: pointer;
   }
 
+  .cinder-run-step-timeline__item[data-cinder-selectable]:focus-visible
+    .cinder-run-step-timeline__event {
+    border-radius: var(--cinder-radius-md);
+    outline: var(--cinder-ring-width) solid transparent;
+    box-shadow: var(--_cinder-focus-ring-shadow);
+  }
+
   .cinder-run-step-timeline__item[data-cinder-selected] .cinder-run-step-timeline__event {
     border-radius: var(--cinder-radius-md);
     background: color-mix(in oklch, var(--cinder-accent), transparent 90%);
@@ -369,6 +376,12 @@
     .cinder-run-step-timeline__item[data-cinder-selected] .cinder-run-step-timeline__event {
       outline: 1px solid Highlight;
       background: Canvas;
+      box-shadow: none;
+    }
+
+    .cinder-run-step-timeline__item[data-cinder-selectable]:focus-visible
+      .cinder-run-step-timeline__event {
+      outline: var(--cinder-ring-width) solid ButtonText;
       box-shadow: none;
     }
   }

--- a/packages/components/src/components/run-step-timeline/run-step-timeline.schema.json
+++ b/packages/components/src/components/run-step-timeline/run-step-timeline.schema.json
@@ -15,7 +15,7 @@
           "type": "null"
         }
       ],
-      "description": "Step id to visually mark as selected.\nAccepts `null` so consumers can clear linked selection without omitting\nthe prop."
+      "description": "Rendered step path key to visually mark as selected.\nAccepts `null` so consumers can clear linked selection without omitting\nthe prop. Use the value passed to `onStepSelect`, or a row's\n`data-cinder-path` attribute, for nested or branch-lane steps."
     },
     "class": {
       "type": "string",

--- a/packages/components/src/components/run-step-timeline/run-step-timeline.schema.json
+++ b/packages/components/src/components/run-step-timeline/run-step-timeline.schema.json
@@ -960,7 +960,7 @@
       {
         "name": "onStepSelect",
         "reason": "function-or-snippet",
-        "description": "Fired when the user clicks anywhere in a rendered step row."
+        "description": "Fired when the user activates a rendered step row.\nReceives that row's rendered path key."
       }
     ]
   },

--- a/packages/components/src/components/run-step-timeline/run-step-timeline.schema.json
+++ b/packages/components/src/components/run-step-timeline/run-step-timeline.schema.json
@@ -6,6 +6,17 @@
       "type": "string",
       "description": "Accessible label for the timeline list."
     },
+    "selectedStepId": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "description": "Step id to visually mark as selected.\nAccepts `null` so consumers can clear linked selection without omitting\nthe prop."
+    },
     "class": {
       "type": "string",
       "description": "Additional CSS classes applied to the root element."
@@ -945,6 +956,11 @@
         "name": "children",
         "reason": "function-or-snippet",
         "description": "Optional per-step body content rendered after the step metadata."
+      },
+      {
+        "name": "onStepSelect",
+        "reason": "function-or-snippet",
+        "description": "Fired when the user clicks anywhere in a rendered step row."
       }
     ]
   },

--- a/packages/components/src/components/run-step-timeline/run-step-timeline.schema.ts
+++ b/packages/components/src/components/run-step-timeline/run-step-timeline.schema.ts
@@ -1028,7 +1028,8 @@ const schema = {
       {
         name: 'onStepSelect',
         reason: 'function-or-snippet',
-        description: 'Fired when the user clicks anywhere in a rendered step row.',
+        description:
+          "Fired when the user activates a rendered step row.\nReceives that row's rendered path key.",
       },
     ],
   },

--- a/packages/components/src/components/run-step-timeline/run-step-timeline.schema.ts
+++ b/packages/components/src/components/run-step-timeline/run-step-timeline.schema.ts
@@ -8,6 +8,18 @@ const schema = {
       type: 'string',
       description: 'Accessible label for the timeline list.',
     },
+    selectedStepId: {
+      anyOf: [
+        {
+          type: 'string',
+        },
+        {
+          type: 'null',
+        },
+      ],
+      description:
+        'Step id to visually mark as selected.\nAccepts `null` so consumers can clear linked selection without omitting\nthe prop.',
+    },
     class: {
       type: 'string',
       description: 'Additional CSS classes applied to the root element.',
@@ -1012,6 +1024,11 @@ const schema = {
         name: 'children',
         reason: 'function-or-snippet',
         description: 'Optional per-step body content rendered after the step metadata.',
+      },
+      {
+        name: 'onStepSelect',
+        reason: 'function-or-snippet',
+        description: 'Fired when the user clicks anywhere in a rendered step row.',
       },
     ],
   },

--- a/packages/components/src/components/run-step-timeline/run-step-timeline.schema.ts
+++ b/packages/components/src/components/run-step-timeline/run-step-timeline.schema.ts
@@ -18,7 +18,7 @@ const schema = {
         },
       ],
       description:
-        'Step id to visually mark as selected.\nAccepts `null` so consumers can clear linked selection without omitting\nthe prop.',
+        "Rendered step path key to visually mark as selected.\nAccepts `null` so consumers can clear linked selection without omitting\nthe prop. Use the value passed to `onStepSelect`, or a row's\n`data-cinder-path` attribute, for nested or branch-lane steps.",
     },
     class: {
       type: 'string',

--- a/packages/components/src/components/run-step-timeline/run-step-timeline.svelte
+++ b/packages/components/src/components/run-step-timeline/run-step-timeline.svelte
@@ -383,10 +383,6 @@
     return lane.outcome === undefined ? 'racing' : laneOutcomeLabel(lane.outcome).toLowerCase();
   }
 
-  function handleStepSelect(stepPathKey: string): void {
-    onStepSelect?.(stepPathKey);
-  }
-
   function isInteractiveDescendant(node: HTMLLIElement, eventTarget: EventTarget | null): boolean {
     if (!(eventTarget instanceof Element)) return false;
     const interactiveTarget = eventTarget.closest(
@@ -397,19 +393,22 @@
     );
   }
 
-  function createStepSelectionAttachment(stepPathKey: string): Attachment<HTMLLIElement> {
+  function createStepSelectionAttachment(
+    stepPathKey: string,
+    stepSelect: RunStepTimelineProps['onStepSelect'],
+  ): Attachment<HTMLLIElement> {
     return (node) => {
-      if (onStepSelect === undefined) return;
+      if (stepSelect === undefined) return;
 
       const handleClick = (event: MouseEvent): void => {
         if (isInteractiveDescendant(node, event.target)) return;
-        handleStepSelect(stepPathKey);
+        stepSelect(stepPathKey);
       };
       const handleKeydown = (event: KeyboardEvent): void => {
         if (event.target !== node) return;
         if (event.key !== 'Enter' && event.key !== ' ') return;
         event.preventDefault();
-        handleStepSelect(stepPathKey);
+        stepSelect(stepPathKey);
       };
 
       node.addEventListener('click', handleClick);
@@ -428,7 +427,7 @@
   {@const metadata = metadataItems(step)}
   {@const selected = selectedStepId === row.pathKey}
   <li
-    {@attach createStepSelectionAttachment(row.pathKey)}
+    {@attach createStepSelectionAttachment(row.pathKey, onStepSelect)}
     class="cinder-run-step-timeline__item"
     data-cinder-status={step.status}
     data-cinder-depth={row.depth}

--- a/packages/components/src/components/run-step-timeline/run-step-timeline.svelte
+++ b/packages/components/src/components/run-step-timeline/run-step-timeline.svelte
@@ -387,12 +387,26 @@
     onStepSelect?.(stepPathKey);
   }
 
+  function isInteractiveDescendant(node: HTMLLIElement, eventTarget: EventTarget | null): boolean {
+    if (!(eventTarget instanceof Element)) return false;
+    const interactiveTarget = eventTarget.closest(
+      'a[href], button, input, select, textarea, summary, [role="button"], [role="link"]',
+    );
+    return (
+      interactiveTarget !== null && interactiveTarget !== node && node.contains(interactiveTarget)
+    );
+  }
+
   function createStepSelectionAttachment(stepPathKey: string): Attachment<HTMLLIElement> {
     return (node) => {
       if (onStepSelect === undefined) return;
 
-      const handleClick = (): void => handleStepSelect(stepPathKey);
+      const handleClick = (event: MouseEvent): void => {
+        if (isInteractiveDescendant(node, event.target)) return;
+        handleStepSelect(stepPathKey);
+      };
       const handleKeydown = (event: KeyboardEvent): void => {
+        if (event.target !== node) return;
         if (event.key !== 'Enter' && event.key !== ' ') return;
         event.preventDefault();
         handleStepSelect(stepPathKey);
@@ -426,8 +440,6 @@
     data-cinder-selectable={onStepSelect === undefined ? undefined : ''}
     data-cinder-connector-after={row.connectorAfter}
     aria-current={row.ariaCurrent ? 'step' : undefined}
-    aria-pressed={onStepSelect === undefined ? undefined : selected ? 'true' : 'false'}
-    role={onStepSelect === undefined ? undefined : 'button'}
     style:--_cinder-rst-depth={row.depth}
     tabindex={onStepSelect === undefined ? undefined : 0}
   >

--- a/packages/components/src/components/run-step-timeline/run-step-timeline.svelte
+++ b/packages/components/src/components/run-step-timeline/run-step-timeline.svelte
@@ -390,7 +390,7 @@
   function isInteractiveDescendant(node: HTMLLIElement, eventTarget: EventTarget | null): boolean {
     if (!(eventTarget instanceof Element)) return false;
     const interactiveTarget = eventTarget.closest(
-      'a[href], button, input, select, textarea, summary, [role="button"], [role="link"]',
+      'a[href], button, input, label, select, textarea, summary, [role="button"], [role="link"]',
     );
     return (
       interactiveTarget !== null && interactiveTarget !== node && node.contains(interactiveTarget)

--- a/packages/components/src/components/run-step-timeline/run-step-timeline.svelte
+++ b/packages/components/src/components/run-step-timeline/run-step-timeline.svelte
@@ -384,8 +384,14 @@
   }
 
   function isInteractiveDescendant(node: HTMLLIElement, eventTarget: EventTarget | null): boolean {
-    if (!(eventTarget instanceof Element)) return false;
-    const interactiveTarget = eventTarget.closest(
+    const targetElement =
+      eventTarget instanceof Element
+        ? eventTarget
+        : eventTarget instanceof Node
+          ? eventTarget.parentElement
+          : null;
+    if (targetElement === null) return false;
+    const interactiveTarget = targetElement.closest(
       'a[href], button, input, label, select, textarea, summary, [contenteditable]:not([contenteditable="false"]), [role="button"], [role="link"], [tabindex]:not([tabindex="-1"])',
     );
     return (

--- a/packages/components/src/components/run-step-timeline/run-step-timeline.svelte
+++ b/packages/components/src/components/run-step-timeline/run-step-timeline.svelte
@@ -81,6 +81,7 @@
   import Link from '../link/link.svelte';
   import Progress from '../progress/progress.svelte';
   import StatusDot from '../status-dot/status-dot.svelte';
+  import type { Attachment } from 'svelte/attachments';
   import type {
     RunStepBranchLane,
     RunStepTimelineEntry,
@@ -111,6 +112,8 @@
   let {
     steps,
     label,
+    selectedStepId,
+    onStepSelect,
     class: className,
     children,
     'aria-label': ariaLabel,
@@ -379,6 +382,18 @@
   function laneStateLabel(lane: RunStepBranchLane): string {
     return lane.outcome === undefined ? 'racing' : laneOutcomeLabel(lane.outcome).toLowerCase();
   }
+
+  function handleStepSelect(stepId: string): void {
+    onStepSelect?.(stepId);
+  }
+
+  function createStepSelectionAttachment(stepId: string): Attachment<HTMLLIElement> {
+    return (node) => {
+      const handleClick = (): void => handleStepSelect(stepId);
+      node.addEventListener('click', handleClick);
+      return () => node.removeEventListener('click', handleClick);
+    };
+  }
 </script>
 
 {#snippet stepItem(row: RenderedStepRow)}
@@ -386,6 +401,7 @@
   {@const terminal = isTerminal(step.status)}
   {@const metadata = metadataItems(step)}
   <li
+    {@attach createStepSelectionAttachment(step.id)}
     class="cinder-run-step-timeline__item"
     data-cinder-status={step.status}
     data-cinder-depth={row.depth}
@@ -393,6 +409,8 @@
     data-cinder-terminal={terminal ? '' : undefined}
     data-cinder-rewound={step.rewound ? '' : undefined}
     data-cinder-compensation={row.compensatesLabel !== undefined ? '' : undefined}
+    data-cinder-selected={selectedStepId === step.id ? '' : undefined}
+    data-cinder-selectable={onStepSelect === undefined ? undefined : ''}
     data-cinder-connector-after={row.connectorAfter}
     aria-current={row.ariaCurrent ? 'step' : undefined}
     style:--_cinder-rst-depth={row.depth}

--- a/packages/components/src/components/run-step-timeline/run-step-timeline.svelte
+++ b/packages/components/src/components/run-step-timeline/run-step-timeline.svelte
@@ -375,23 +375,35 @@
     return currentIndex;
   }
 
-  function laneRows(lane: RunStepBranchLane): RenderedStepLike[] {
-    return flattenSteps(lane.steps, '');
+  function laneRows(groupPathKey: string, lane: RunStepBranchLane): RenderedStepLike[] {
+    return flattenSteps(lane.steps, `${groupPathKey}/%lane/${escapeStepPathSegment(lane.id)}`);
   }
 
   function laneStateLabel(lane: RunStepBranchLane): string {
     return lane.outcome === undefined ? 'racing' : laneOutcomeLabel(lane.outcome).toLowerCase();
   }
 
-  function handleStepSelect(stepId: string): void {
-    onStepSelect?.(stepId);
+  function handleStepSelect(stepPathKey: string): void {
+    onStepSelect?.(stepPathKey);
   }
 
-  function createStepSelectionAttachment(stepId: string): Attachment<HTMLLIElement> {
+  function createStepSelectionAttachment(stepPathKey: string): Attachment<HTMLLIElement> {
     return (node) => {
-      const handleClick = (): void => handleStepSelect(stepId);
+      if (onStepSelect === undefined) return;
+
+      const handleClick = (): void => handleStepSelect(stepPathKey);
+      const handleKeydown = (event: KeyboardEvent): void => {
+        if (event.key !== 'Enter' && event.key !== ' ') return;
+        event.preventDefault();
+        handleStepSelect(stepPathKey);
+      };
+
       node.addEventListener('click', handleClick);
-      return () => node.removeEventListener('click', handleClick);
+      node.addEventListener('keydown', handleKeydown);
+      return () => {
+        node.removeEventListener('click', handleClick);
+        node.removeEventListener('keydown', handleKeydown);
+      };
     };
   }
 </script>
@@ -400,8 +412,9 @@
   {@const step = row.step}
   {@const terminal = isTerminal(step.status)}
   {@const metadata = metadataItems(step)}
+  {@const selected = selectedStepId === row.pathKey}
   <li
-    {@attach createStepSelectionAttachment(step.id)}
+    {@attach createStepSelectionAttachment(row.pathKey)}
     class="cinder-run-step-timeline__item"
     data-cinder-status={step.status}
     data-cinder-depth={row.depth}
@@ -409,11 +422,14 @@
     data-cinder-terminal={terminal ? '' : undefined}
     data-cinder-rewound={step.rewound ? '' : undefined}
     data-cinder-compensation={row.compensatesLabel !== undefined ? '' : undefined}
-    data-cinder-selected={selectedStepId === step.id ? '' : undefined}
+    data-cinder-selected={selected ? '' : undefined}
     data-cinder-selectable={onStepSelect === undefined ? undefined : ''}
     data-cinder-connector-after={row.connectorAfter}
     aria-current={row.ariaCurrent ? 'step' : undefined}
+    aria-pressed={onStepSelect === undefined ? undefined : selected ? 'true' : 'false'}
+    role={onStepSelect === undefined ? undefined : 'button'}
     style:--_cinder-rst-depth={row.depth}
+    tabindex={onStepSelect === undefined ? undefined : 0}
   >
     <div class="cinder-run-step-timeline__event">
       <span class="cinder-run-step-timeline__marker" aria-hidden="true" inert>
@@ -635,7 +651,7 @@
                       class="cinder-run-step-timeline cinder-run-step-timeline__lane-steps"
                       aria-label={`${lane.label ?? lane.id} steps`}
                     >
-                      {@render stepRail(laneRows(lane))}
+                      {@render stepRail(laneRows(entry.pathKey, lane))}
                     </ol>
                   </li>
                 {/each}

--- a/packages/components/src/components/run-step-timeline/run-step-timeline.svelte
+++ b/packages/components/src/components/run-step-timeline/run-step-timeline.svelte
@@ -405,19 +405,10 @@
         if (isInteractiveDescendant(node, event.target)) return;
         onStepSelect?.(stepPathKey);
       };
-      const handleKeydown = (event: KeyboardEvent): void => {
-        if (event.target !== node) return;
-        if (event.key !== 'Enter' && event.key !== ' ') return;
-        if (onStepSelect === undefined) return;
-        event.preventDefault();
-        onStepSelect(stepPathKey);
-      };
 
       node.addEventListener('click', handleClick);
-      node.addEventListener('keydown', handleKeydown);
       return () => {
         node.removeEventListener('click', handleClick);
-        node.removeEventListener('keydown', handleKeydown);
       };
     };
   }
@@ -442,8 +433,16 @@
     data-cinder-connector-after={row.connectorAfter}
     aria-current={row.ariaCurrent ? 'step' : undefined}
     style:--_cinder-rst-depth={row.depth}
-    tabindex={onStepSelect === undefined ? undefined : 0}
   >
+    {#if onStepSelect !== undefined}
+      <button
+        type="button"
+        class="cinder-run-step-timeline__selection-control"
+        aria-label={`Select ${step.label}`}
+        aria-pressed={selected}
+        onclick={() => onStepSelect?.(row.pathKey)}
+      ></button>
+    {/if}
     <div class="cinder-run-step-timeline__event">
       <span class="cinder-run-step-timeline__marker" aria-hidden="true" inert>
         <StatusDot

--- a/packages/components/src/components/run-step-timeline/run-step-timeline.svelte
+++ b/packages/components/src/components/run-step-timeline/run-step-timeline.svelte
@@ -392,7 +392,7 @@
           : null;
     if (targetElement === null) return false;
     const interactiveTarget = targetElement.closest(
-      'a[href], button, input, label, select, textarea, summary, [contenteditable]:not([contenteditable="false"]), [role="button"], [role="link"], [tabindex]:not([tabindex="-1"])',
+      'a[href], button, input, label, select, textarea, summary, [contenteditable]:not([contenteditable="false"]), [role="button"], [role="checkbox"], [role="combobox"], [role="link"], [role="menuitem"], [role="menuitemcheckbox"], [role="menuitemradio"], [role="option"], [role="radio"], [role="searchbox"], [role="slider"], [role="spinbutton"], [role="switch"], [role="tab"], [role="textbox"], [role="treeitem"], [tabindex]:not([tabindex="-1"])',
     );
     return (
       interactiveTarget !== null && interactiveTarget !== node && node.contains(interactiveTarget)

--- a/packages/components/src/components/run-step-timeline/run-step-timeline.svelte
+++ b/packages/components/src/components/run-step-timeline/run-step-timeline.svelte
@@ -390,7 +390,7 @@
   function isInteractiveDescendant(node: HTMLLIElement, eventTarget: EventTarget | null): boolean {
     if (!(eventTarget instanceof Element)) return false;
     const interactiveTarget = eventTarget.closest(
-      'a[href], button, input, label, select, textarea, summary, [role="button"], [role="link"]',
+      'a[href], button, input, label, select, textarea, summary, [contenteditable]:not([contenteditable="false"]), [role="button"], [role="link"], [tabindex]:not([tabindex="-1"])',
     );
     return (
       interactiveTarget !== null && interactiveTarget !== node && node.contains(interactiveTarget)

--- a/packages/components/src/components/run-step-timeline/run-step-timeline.svelte
+++ b/packages/components/src/components/run-step-timeline/run-step-timeline.svelte
@@ -393,22 +393,18 @@
     );
   }
 
-  function createStepSelectionAttachment(
-    stepPathKey: string,
-    stepSelect: RunStepTimelineProps['onStepSelect'],
-  ): Attachment<HTMLLIElement> {
+  function createStepSelectionAttachment(stepPathKey: string): Attachment<HTMLLIElement> {
     return (node) => {
-      if (stepSelect === undefined) return;
-
       const handleClick = (event: MouseEvent): void => {
         if (isInteractiveDescendant(node, event.target)) return;
-        stepSelect(stepPathKey);
+        onStepSelect?.(stepPathKey);
       };
       const handleKeydown = (event: KeyboardEvent): void => {
         if (event.target !== node) return;
         if (event.key !== 'Enter' && event.key !== ' ') return;
+        if (onStepSelect === undefined) return;
         event.preventDefault();
-        stepSelect(stepPathKey);
+        onStepSelect(stepPathKey);
       };
 
       node.addEventListener('click', handleClick);
@@ -427,7 +423,7 @@
   {@const metadata = metadataItems(step)}
   {@const selected = selectedStepId === row.pathKey}
   <li
-    {@attach createStepSelectionAttachment(row.pathKey, onStepSelect)}
+    {@attach createStepSelectionAttachment(row.pathKey)}
     class="cinder-run-step-timeline__item"
     data-cinder-status={step.status}
     data-cinder-depth={row.depth}

--- a/packages/components/src/components/run-step-timeline/run-step-timeline.test.ts
+++ b/packages/components/src/components/run-step-timeline/run-step-timeline.test.ts
@@ -950,6 +950,26 @@ describe('selection', () => {
     expect(selectedStepIds).toEqual([runningStep.id]);
   });
 
+  test('fires onStepSelect after row selection is enabled post-mount', async () => {
+    const selectedStepIds: string[] = [];
+    const { container, rerender } = render(RunStepTimeline, {
+      steps: [pendingStep, runningStep],
+    });
+
+    const row = stepRowByPath(container, runningStep.id);
+    expect(row).toBeDefined();
+    await fireEvent.click(row!);
+    expect(selectedStepIds).toEqual([]);
+
+    await rerender({
+      steps: [pendingStep, runningStep],
+      onStepSelect: (stepId: string) => selectedStepIds.push(stepId),
+    });
+    await fireEvent.click(row!);
+
+    expect(selectedStepIds).toEqual([runningStep.id]);
+  });
+
   test('fires onStepSelect when a selectable step row is keyboard activated', async () => {
     const selectedStepIds: string[] = [];
     const { container } = render(RunStepTimeline, {

--- a/packages/components/src/components/run-step-timeline/run-step-timeline.test.ts
+++ b/packages/components/src/components/run-step-timeline/run-step-timeline.test.ts
@@ -2,6 +2,7 @@
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
 
 import Ajv2020 from 'ajv/dist/2020';
+import { createRawSnippet } from 'svelte';
 import { setupHappyDom } from '../../test/happy-dom.ts';
 import type {
   RunStep,
@@ -987,6 +988,24 @@ describe('selection', () => {
     expect(selectedStepIds).toEqual([]);
     await fireEvent.click(stepRowByPath(container, 'inspect') as HTMLElement);
     expect(selectedStepIds).toEqual(['inspect']);
+  });
+
+  test('does not select a row when a labeled child control is clicked', async () => {
+    const selectedStepIds: string[] = [];
+    const childControl = createRawSnippet(() => ({
+      render: () => '<label><input type="checkbox" /> Retry</label>',
+      setup: () => {},
+    }));
+    const { container, getByText } = render(RunStepTimeline, {
+      steps: [runningStep],
+      onStepSelect: (stepId: string) => selectedStepIds.push(stepId),
+      children: childControl,
+    });
+
+    await fireEvent.click(getByText('Retry'));
+    expect(selectedStepIds).toEqual([]);
+    await fireEvent.click(stepRowByPath(container, runningStep.id) as HTMLElement);
+    expect(selectedStepIds).toEqual([runningStep.id]);
   });
 
   test('fires onStepSelect when a nested child step row is clicked', async () => {

--- a/packages/components/src/components/run-step-timeline/run-step-timeline.test.ts
+++ b/packages/components/src/components/run-step-timeline/run-step-timeline.test.ts
@@ -965,7 +965,9 @@ describe('selection', () => {
       steps: [pendingStep, runningStep],
       onStepSelect: (stepId: string) => selectedStepIds.push(stepId),
     });
-    await fireEvent.click(row!);
+    const selectableRow = stepRowByPath(container, runningStep.id);
+    expect(selectableRow).toBeDefined();
+    await fireEvent.click(selectableRow!);
 
     expect(selectedStepIds).toEqual([runningStep.id]);
   });

--- a/packages/components/src/components/run-step-timeline/run-step-timeline.test.ts
+++ b/packages/components/src/components/run-step-timeline/run-step-timeline.test.ts
@@ -18,6 +18,12 @@ const { render, cleanup, fireEvent } = await import('@testing-library/svelte');
 const { default: RunStepTimeline } = await import('./run-step-timeline.svelte');
 const { default: runStepTimelineSchema } = await import('./run-step-timeline.schema.ts');
 
+function stepRowByPath(container: HTMLElement, pathKey: string): HTMLElement | undefined {
+  return Array.from(container.querySelectorAll<HTMLElement>('[data-cinder-path]')).find(
+    (row) => row.getAttribute('data-cinder-path') === pathKey,
+  );
+}
+
 beforeEach(() => document.body.replaceChildren());
 afterEach(() => cleanup());
 
@@ -899,7 +905,7 @@ describe('selection', () => {
     expect(selected?.getAttribute('data-cinder-path')).toBe(runningStep.id);
     expect(selected?.textContent).toContain(runningStep.label);
 
-    const pending = container.querySelector<HTMLElement>(`[data-cinder-path="${pendingStep.id}"]`);
+    const pending = stepRowByPath(container, pendingStep.id);
     expect(pending?.hasAttribute('data-cinder-selected')).toBe(false);
   });
 
@@ -936,7 +942,7 @@ describe('selection', () => {
       onStepSelect: (stepId: string) => selectedStepIds.push(stepId),
     });
 
-    const row = container.querySelector<HTMLElement>(`[data-cinder-path="${runningStep.id}"]`);
+    const row = stepRowByPath(container, runningStep.id);
     expect(row).not.toBeNull();
     await fireEvent.click(row as HTMLElement);
 
@@ -951,7 +957,7 @@ describe('selection', () => {
       selectedStepId: runningStep.id,
     });
 
-    const row = container.querySelector<HTMLElement>(`[data-cinder-path="${runningStep.id}"]`);
+    const row = stepRowByPath(container, runningStep.id);
     expect(row?.getAttribute('role')).toBe('button');
     expect(row?.getAttribute('tabindex')).toBe('0');
     expect(row?.getAttribute('aria-pressed')).toBe('true');
@@ -976,7 +982,7 @@ describe('selection', () => {
       onStepSelect: (stepId: string) => selectedStepIds.push(stepId),
     });
 
-    const row = container.querySelector<HTMLElement>('[data-cinder-path="parent/child"]');
+    const row = stepRowByPath(container, 'parent/child');
     expect(row).not.toBeNull();
     await fireEvent.click(row as HTMLElement);
 
@@ -1002,9 +1008,7 @@ describe('selection', () => {
       onStepSelect: (stepId: string) => selectedStepIds.push(stepId),
     });
 
-    const row = container.querySelector<HTMLElement>(
-      '[data-cinder-path="%branch/race/%lane/blue/blue-deploy"]',
-    );
+    const row = stepRowByPath(container, '%branch/race/%lane/blue/blue-deploy');
     expect(row).not.toBeNull();
     await fireEvent.click(row as HTMLElement);
 

--- a/packages/components/src/components/run-step-timeline/run-step-timeline.test.ts
+++ b/packages/components/src/components/run-step-timeline/run-step-timeline.test.ts
@@ -889,7 +889,7 @@ describe('behavior', () => {
 // ---------------------------------------------------------------------------
 
 describe('selection', () => {
-  test('marks the selected step row by id', () => {
+  test('marks the selected step row by rendered path', () => {
     const { container } = render(RunStepTimeline, {
       steps: [pendingStep, runningStep],
       selectedStepId: runningStep.id,
@@ -901,6 +901,32 @@ describe('selection', () => {
 
     const pending = container.querySelector<HTMLElement>(`[data-cinder-path="${pendingStep.id}"]`);
     expect(pending?.hasAttribute('data-cinder-selected')).toBe(false);
+  });
+
+  test('scopes selected rows by nested path', () => {
+    const steps: RunStep[] = [
+      {
+        id: 'parent-a',
+        label: 'Parent A',
+        status: 'succeeded',
+        children: [{ id: 'shared', label: 'Shared A', status: 'succeeded' }],
+      },
+      {
+        id: 'parent-b',
+        label: 'Parent B',
+        status: 'running',
+        children: [{ id: 'shared', label: 'Shared B', status: 'running' }],
+      },
+    ];
+    const { container } = render(RunStepTimeline, {
+      steps,
+      selectedStepId: 'parent-b/shared',
+    });
+
+    const selected = container.querySelectorAll<HTMLElement>('[data-cinder-selected]');
+    expect(selected.length).toBe(1);
+    expect(selected[0]?.getAttribute('data-cinder-path')).toBe('parent-b/shared');
+    expect(selected[0]?.textContent).toContain('Shared B');
   });
 
   test('fires onStepSelect when a top-level step row is clicked', async () => {
@@ -915,6 +941,24 @@ describe('selection', () => {
     await fireEvent.click(row as HTMLElement);
 
     expect(selectedStepIds).toEqual([runningStep.id]);
+  });
+
+  test('fires onStepSelect when a selectable step row is keyboard activated', async () => {
+    const selectedStepIds: string[] = [];
+    const { container } = render(RunStepTimeline, {
+      steps: [pendingStep, runningStep],
+      onStepSelect: (stepId: string) => selectedStepIds.push(stepId),
+      selectedStepId: runningStep.id,
+    });
+
+    const row = container.querySelector<HTMLElement>(`[data-cinder-path="${runningStep.id}"]`);
+    expect(row?.getAttribute('role')).toBe('button');
+    expect(row?.getAttribute('tabindex')).toBe('0');
+    expect(row?.getAttribute('aria-pressed')).toBe('true');
+    await fireEvent.keyDown(row as HTMLElement, { key: 'Enter' });
+    await fireEvent.keyDown(row as HTMLElement, { key: ' ' });
+
+    expect(selectedStepIds).toEqual([runningStep.id, runningStep.id]);
   });
 
   test('fires onStepSelect when a nested child step row is clicked', async () => {
@@ -936,7 +980,7 @@ describe('selection', () => {
     expect(row).not.toBeNull();
     await fireEvent.click(row as HTMLElement);
 
-    expect(selectedStepIds).toEqual(['child']);
+    expect(selectedStepIds).toEqual(['parent/child']);
   });
 
   test('fires onStepSelect when a branch-lane step row is clicked', async () => {
@@ -958,11 +1002,13 @@ describe('selection', () => {
       onStepSelect: (stepId: string) => selectedStepIds.push(stepId),
     });
 
-    const row = container.querySelector<HTMLElement>('[data-cinder-path="blue-deploy"]');
+    const row = container.querySelector<HTMLElement>(
+      '[data-cinder-path="%branch/race/%lane/blue/blue-deploy"]',
+    );
     expect(row).not.toBeNull();
     await fireEvent.click(row as HTMLElement);
 
-    expect(selectedStepIds).toEqual(['blue-deploy']);
+    expect(selectedStepIds).toEqual(['%branch/race/%lane/blue/blue-deploy']);
   });
 });
 

--- a/packages/components/src/components/run-step-timeline/run-step-timeline.test.ts
+++ b/packages/components/src/components/run-step-timeline/run-step-timeline.test.ts
@@ -972,20 +972,21 @@ describe('selection', () => {
     expect(selectedStepIds).toEqual([runningStep.id]);
   });
 
-  test('fires onStepSelect when a selectable step row is keyboard activated', async () => {
+  test('fires onStepSelect from the selectable step row control', async () => {
     const selectedStepIds: string[] = [];
-    const { container } = render(RunStepTimeline, {
+    const { container, getByRole } = render(RunStepTimeline, {
       steps: [pendingStep, runningStep],
       onStepSelect: (stepId: string) => selectedStepIds.push(stepId),
       selectedStepId: runningStep.id,
     });
 
     const row = stepRowByPath(container, runningStep.id);
-    expect(row?.getAttribute('tabindex')).toBe('0');
-    await fireEvent.keyDown(row as HTMLElement, { key: 'Enter' });
-    await fireEvent.keyDown(row as HTMLElement, { key: ' ' });
+    expect(row?.hasAttribute('tabindex')).toBe(false);
+    const selectionControl = getByRole('button', { name: 'Select Run integration tests' });
+    expect(selectionControl.getAttribute('aria-pressed')).toBe('true');
+    await fireEvent.click(selectionControl);
 
-    expect(selectedStepIds).toEqual([runningStep.id, runningStep.id]);
+    expect(selectedStepIds).toEqual([runningStep.id]);
   });
 
   test('does not select a row when nested controls are activated', async () => {

--- a/packages/components/src/components/run-step-timeline/run-step-timeline.test.ts
+++ b/packages/components/src/components/run-step-timeline/run-step-timeline.test.ts
@@ -944,8 +944,8 @@ describe('selection', () => {
     });
 
     const row = stepRowByPath(container, runningStep.id);
-    expect(row).not.toBeNull();
-    await fireEvent.click(row as HTMLElement);
+    expect(row).toBeDefined();
+    await fireEvent.click(row!);
 
     expect(selectedStepIds).toEqual([runningStep.id]);
   });
@@ -1024,8 +1024,8 @@ describe('selection', () => {
     });
 
     const row = stepRowByPath(container, 'parent/child');
-    expect(row).not.toBeNull();
-    await fireEvent.click(row as HTMLElement);
+    expect(row).toBeDefined();
+    await fireEvent.click(row!);
 
     expect(selectedStepIds).toEqual(['parent/child']);
   });
@@ -1050,8 +1050,8 @@ describe('selection', () => {
     });
 
     const row = stepRowByPath(container, '%branch/race/%lane/blue/blue-deploy');
-    expect(row).not.toBeNull();
-    await fireEvent.click(row as HTMLElement);
+    expect(row).toBeDefined();
+    await fireEvent.click(row!);
 
     expect(selectedStepIds).toEqual(['%branch/race/%lane/blue/blue-deploy']);
   });

--- a/packages/components/src/components/run-step-timeline/run-step-timeline.test.ts
+++ b/packages/components/src/components/run-step-timeline/run-step-timeline.test.ts
@@ -1038,6 +1038,24 @@ describe('selection', () => {
     expect(selectedStepIds).toEqual([runningStep.id]);
   });
 
+  test('does not select a row when a custom ARIA child control is clicked', async () => {
+    const selectedStepIds: string[] = [];
+    const childControl = createRawSnippet(() => ({
+      render: () => '<span role="checkbox" aria-checked="false" tabindex="0">Retry</span>',
+      setup: () => {},
+    }));
+    const { container, getByRole } = render(RunStepTimeline, {
+      steps: [runningStep],
+      onStepSelect: (stepId: string) => selectedStepIds.push(stepId),
+      children: childControl,
+    });
+
+    await fireEvent.click(getByRole('checkbox', { name: 'Retry' }));
+    expect(selectedStepIds).toEqual([]);
+    await fireEvent.click(stepRowByPath(container, runningStep.id) as HTMLElement);
+    expect(selectedStepIds).toEqual([runningStep.id]);
+  });
+
   test('fires onStepSelect when a nested child step row is clicked', async () => {
     const selectedStepIds: string[] = [];
     const steps: RunStep[] = [

--- a/packages/components/src/components/run-step-timeline/run-step-timeline.test.ts
+++ b/packages/components/src/components/run-step-timeline/run-step-timeline.test.ts
@@ -958,13 +958,35 @@ describe('selection', () => {
     });
 
     const row = stepRowByPath(container, runningStep.id);
-    expect(row?.getAttribute('role')).toBe('button');
     expect(row?.getAttribute('tabindex')).toBe('0');
-    expect(row?.getAttribute('aria-pressed')).toBe('true');
     await fireEvent.keyDown(row as HTMLElement, { key: 'Enter' });
     await fireEvent.keyDown(row as HTMLElement, { key: ' ' });
 
     expect(selectedStepIds).toEqual([runningStep.id, runningStep.id]);
+  });
+
+  test('does not select a row when nested controls are activated', async () => {
+    const selectedStepIds: string[] = [];
+    const step: RunStep = {
+      id: 'inspect',
+      label: 'Inspect result',
+      status: 'running',
+      link: { label: 'Open logs', href: '/logs' },
+      details: [{ id: 'stdout', label: 'Output', content: 'Ready' }],
+    };
+    const { container, getByRole } = render(RunStepTimeline, {
+      steps: [step],
+      onStepSelect: (stepId: string) => selectedStepIds.push(stepId),
+    });
+
+    await fireEvent.click(getByRole('link', { name: 'Open logs' }));
+    await fireEvent.keyDown(getByRole('link', { name: 'Open logs' }), { key: 'Enter' });
+    await fireEvent.click(getByRole('button', { name: 'Output' }));
+    await fireEvent.keyDown(getByRole('button', { name: 'Output' }), { key: 'Enter' });
+
+    expect(selectedStepIds).toEqual([]);
+    await fireEvent.click(stepRowByPath(container, 'inspect') as HTMLElement);
+    expect(selectedStepIds).toEqual(['inspect']);
   });
 
   test('fires onStepSelect when a nested child step row is clicked', async () => {

--- a/packages/components/src/components/run-step-timeline/run-step-timeline.test.ts
+++ b/packages/components/src/components/run-step-timeline/run-step-timeline.test.ts
@@ -885,6 +885,88 @@ describe('behavior', () => {
 });
 
 // ---------------------------------------------------------------------------
+// Selection
+// ---------------------------------------------------------------------------
+
+describe('selection', () => {
+  test('marks the selected step row by id', () => {
+    const { container } = render(RunStepTimeline, {
+      steps: [pendingStep, runningStep],
+      selectedStepId: runningStep.id,
+    });
+
+    const selected = container.querySelector<HTMLElement>('[data-cinder-selected]');
+    expect(selected?.getAttribute('data-cinder-path')).toBe(runningStep.id);
+    expect(selected?.textContent).toContain(runningStep.label);
+
+    const pending = container.querySelector<HTMLElement>(`[data-cinder-path="${pendingStep.id}"]`);
+    expect(pending?.hasAttribute('data-cinder-selected')).toBe(false);
+  });
+
+  test('fires onStepSelect when a top-level step row is clicked', async () => {
+    const selectedStepIds: string[] = [];
+    const { container } = render(RunStepTimeline, {
+      steps: [pendingStep, runningStep],
+      onStepSelect: (stepId: string) => selectedStepIds.push(stepId),
+    });
+
+    const row = container.querySelector<HTMLElement>(`[data-cinder-path="${runningStep.id}"]`);
+    expect(row).not.toBeNull();
+    await fireEvent.click(row as HTMLElement);
+
+    expect(selectedStepIds).toEqual([runningStep.id]);
+  });
+
+  test('fires onStepSelect when a nested child step row is clicked', async () => {
+    const selectedStepIds: string[] = [];
+    const steps: RunStep[] = [
+      {
+        id: 'parent',
+        label: 'Parent',
+        status: 'running',
+        children: [{ id: 'child', label: 'Child', status: 'succeeded' }],
+      },
+    ];
+    const { container } = render(RunStepTimeline, {
+      steps,
+      onStepSelect: (stepId: string) => selectedStepIds.push(stepId),
+    });
+
+    const row = container.querySelector<HTMLElement>('[data-cinder-path="parent/child"]');
+    expect(row).not.toBeNull();
+    await fireEvent.click(row as HTMLElement);
+
+    expect(selectedStepIds).toEqual(['child']);
+  });
+
+  test('fires onStepSelect when a branch-lane step row is clicked', async () => {
+    const selectedStepIds: string[] = [];
+    const branch: RunStepBranchGroup = {
+      kind: 'branch',
+      id: 'race',
+      label: 'Race',
+      lanes: [
+        {
+          id: 'blue',
+          label: 'Blue',
+          steps: [{ id: 'blue-deploy', label: 'Deploy blue', status: 'succeeded' }],
+        },
+      ],
+    };
+    const { container } = render(RunStepTimeline, {
+      steps: [branch] as RunStepTimelineEntry[],
+      onStepSelect: (stepId: string) => selectedStepIds.push(stepId),
+    });
+
+    const row = container.querySelector<HTMLElement>('[data-cinder-path="blue-deploy"]');
+    expect(row).not.toBeNull();
+    await fireEvent.click(row as HTMLElement);
+
+    expect(selectedStepIds).toEqual(['blue-deploy']);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Accessibility
 // ---------------------------------------------------------------------------
 

--- a/packages/components/src/components/run-step-timeline/run-step-timeline.test.ts
+++ b/packages/components/src/components/run-step-timeline/run-step-timeline.test.ts
@@ -1022,7 +1022,14 @@ describe('selection', () => {
       children: childControl,
     });
 
-    await fireEvent.click(getByText('Retry'));
+    const label = getByText('Retry');
+    const textNode = Array.from(label.childNodes).find(
+      (child) => child.nodeType === Node.TEXT_NODE,
+    );
+    expect(textNode).toBeDefined();
+
+    await fireEvent.click(label);
+    await fireEvent.click(textNode!);
     expect(selectedStepIds).toEqual([]);
     await fireEvent.click(stepRowByPath(container, runningStep.id) as HTMLElement);
     expect(selectedStepIds).toEqual([runningStep.id]);

--- a/packages/components/src/components/run-step-timeline/run-step-timeline.types.ts
+++ b/packages/components/src/components/run-step-timeline/run-step-timeline.types.ts
@@ -487,7 +487,7 @@ export type RunStepTimelineProps = Omit<HTMLAttributes<HTMLOListElement>, 'class
    * Fired when the user activates a rendered step row.
    * Receives that row's rendered path key.
    */
-  onStepSelect?: ((stepId: string) => void) | undefined;
+  onStepSelect?: ((pathKey: string) => void) | undefined;
   /**
    * Optional per-step body content rendered after the step metadata.
    */

--- a/packages/components/src/components/run-step-timeline/run-step-timeline.types.ts
+++ b/packages/components/src/components/run-step-timeline/run-step-timeline.types.ts
@@ -477,13 +477,15 @@ export type RunStepTimelineProps = Omit<HTMLAttributes<HTMLOListElement>, 'class
    */
   label?: string | undefined;
   /**
-   * Step id to visually mark as selected.
+   * Rendered step path key to visually mark as selected.
    * Accepts `null` so consumers can clear linked selection without omitting
-   * the prop.
+   * the prop. Use the value passed to `onStepSelect`, or a row's
+   * `data-cinder-path` attribute, for nested or branch-lane steps.
    */
   selectedStepId?: string | null | undefined;
   /**
-   * Fired when the user clicks anywhere in a rendered step row.
+   * Fired when the user activates a rendered step row.
+   * Receives that row's rendered path key.
    */
   onStepSelect?: ((stepId: string) => void) | undefined;
   /**

--- a/packages/components/src/components/run-step-timeline/run-step-timeline.types.ts
+++ b/packages/components/src/components/run-step-timeline/run-step-timeline.types.ts
@@ -505,9 +505,10 @@ export interface RunStepTimelineSchemaProps {
   /** Accessible label for the timeline list. */
   label?: string | undefined;
   /**
-   * Step id to visually mark as selected.
+   * Rendered step path key to visually mark as selected.
    * Accepts `null` so consumers can clear linked selection without omitting
-   * the prop.
+   * the prop. Use the value passed to `onStepSelect`, or a row's
+   * `data-cinder-path` attribute, for nested or branch-lane steps.
    */
   selectedStepId?: string | null | undefined;
   /** Additional CSS classes applied to the root element. */

--- a/packages/components/src/components/run-step-timeline/run-step-timeline.types.ts
+++ b/packages/components/src/components/run-step-timeline/run-step-timeline.types.ts
@@ -477,6 +477,16 @@ export type RunStepTimelineProps = Omit<HTMLAttributes<HTMLOListElement>, 'class
    */
   label?: string | undefined;
   /**
+   * Step id to visually mark as selected.
+   * Accepts `null` so consumers can clear linked selection without omitting
+   * the prop.
+   */
+  selectedStepId?: string | null | undefined;
+  /**
+   * Fired when the user clicks anywhere in a rendered step row.
+   */
+  onStepSelect?: ((stepId: string) => void) | undefined;
+  /**
    * Optional per-step body content rendered after the step metadata.
    */
   children?: Snippet<[RunStep]> | undefined;
@@ -492,6 +502,12 @@ export interface RunStepTimelineSchemaProps {
   steps: RunStepTimelineSchemaEntry[];
   /** Accessible label for the timeline list. */
   label?: string | undefined;
+  /**
+   * Step id to visually mark as selected.
+   * Accepts `null` so consumers can clear linked selection without omitting
+   * the prop.
+   */
+  selectedStepId?: string | null | undefined;
   /** Additional CSS classes applied to the root element. */
   class?: string | undefined;
 }


### PR DESCRIPTION
## Summary

- Add `selectedStepId` and `onStepSelect` to `RunStepTimeline`.
- Mark the selected step row with `data-cinder-selected` and add a token-backed selected tint.
- Cover top-level, nested child, and branch-lane step row selection in focused tests.
- Regenerate RunStepTimeline schema sidecars and document the new props.

Closes #807

## Validation

- `bun run --filter=@lostgradient/cinder test ./src/components/run-step-timeline/run-step-timeline.test.ts`
- `bun run --filter=@lostgradient/cinder components:generate`
- `bun run --filter=@lostgradient/cinder components:check`
- `bun run --filter=@lostgradient/cinder exports:check`
- `bun run --filter=@lostgradient/cinder typecheck`
- `bun run --filter=@lostgradient/cinder lint`
- `bun run format:check`
