### PR TITLE
Address FileUpload trigger review follow-ups

### DIFF
--- a/packages/components/src/api-contract.ts
+++ b/packages/components/src/api-contract.ts
@@ -294,6 +294,7 @@ export const CONTRACT: Record<string, ComponentContract> = {
       disabled: { optional: true, type_kind: 'TSBooleanKeyword', default: NO_DEFAULT },
       name: { optional: true, type_kind: 'TSStringKeyword', default: NO_DEFAULT },
       class: { optional: true, type_kind: 'TSStringKeyword', default: NO_DEFAULT },
+      triggerLabel: { optional: true, type_kind: 'TSStringKeyword', default: L('Choose files') },
       files: { optional: true, type_kind: 'TSArrayType', default: NO_DEFAULT },
       onchange: { optional: true, type_kind: 'TSFunctionType', default: NO_DEFAULT },
       onreject: { optional: true, type_kind: 'TSFunctionType', default: NO_DEFAULT },

--- a/packages/components/src/components/file-upload/README.md
+++ b/packages/components/src/components/file-upload/README.md
@@ -35,7 +35,7 @@ directory or import flows. Native input attributes still pass through to the
 real file input, so directory selection can use `webkitdirectory`:
 
 ```svelte
-<FileUpload id="history" triggerLabel="Choose directory" webkitdirectory />
+<FileUpload id="history" triggerLabel="Choose directory" multiple webkitdirectory />
 ```
 
 ## Props

--- a/packages/components/src/components/file-upload/file-upload.svelte
+++ b/packages/components/src/components/file-upload/file-upload.svelte
@@ -279,7 +279,7 @@
           stroke-linejoin="round"
         />
       </svg>
-      Drag files here or {triggerLabel}
+      Drag files here, or use the {triggerLabel} button.
     </span>
     <p class="cinder-file-upload__hint">Drop files on this area or use the native file picker.</p>
   </div>

--- a/packages/components/src/components/file-upload/file-upload.svelte
+++ b/packages/components/src/components/file-upload/file-upload.svelte
@@ -260,7 +260,7 @@
     return Math.max(0, Math.min(100, progress));
   }
 
-  function sentenceCaseTriggerLabel(label: string): string {
+  function lowercaseInitialCharacter(label: string): string {
     return label.length === 0 ? label : `${label[0]!.toLowerCase()}${label.slice(1)}`;
   }
 </script>
@@ -283,7 +283,7 @@
           stroke-linejoin="round"
         />
       </svg>
-      Drag files here or {sentenceCaseTriggerLabel(triggerLabel)}
+      Drag files here or {lowercaseInitialCharacter(triggerLabel)}
     </span>
     <p class="cinder-file-upload__hint">Drop files on this area or use the native file picker.</p>
   </div>

--- a/packages/components/src/components/file-upload/file-upload.svelte
+++ b/packages/components/src/components/file-upload/file-upload.svelte
@@ -259,10 +259,6 @@
     if (progress === undefined) return 0;
     return Math.max(0, Math.min(100, progress));
   }
-
-  function lowercaseInitialCharacter(label: string): string {
-    return label.length === 0 ? label : `${label[0]!.toLowerCase()}${label.slice(1)}`;
-  }
 </script>
 
 {#snippet defaultIdle()}
@@ -283,7 +279,7 @@
           stroke-linejoin="round"
         />
       </svg>
-      Drag files here or {lowercaseInitialCharacter(triggerLabel)}
+      Drag files here or {triggerLabel}
     </span>
     <p class="cinder-file-upload__hint">Drop files on this area or use the native file picker.</p>
   </div>

--- a/packages/components/src/components/file-upload/file-upload.test.ts
+++ b/packages/components/src/components/file-upload/file-upload.test.ts
@@ -100,7 +100,7 @@ describe('FileUpload rendering', () => {
     });
     expect(container.querySelector('button')?.textContent).toBe('Import history JSON');
     expect(container.querySelector('.cinder-file-upload__eyebrow')?.textContent).toContain(
-      'import history JSON',
+      'Import history JSON',
     );
   });
 

--- a/packages/components/src/components/file-upload/file-upload.test.ts
+++ b/packages/components/src/components/file-upload/file-upload.test.ts
@@ -100,7 +100,7 @@ describe('FileUpload rendering', () => {
     });
     expect(container.querySelector('button')?.textContent).toBe('Import history JSON');
     expect(container.querySelector('.cinder-file-upload__eyebrow')?.textContent).toContain(
-      'Import history JSON',
+      'use the Import history JSON button',
     );
   });
 


### PR DESCRIPTION
## Summary

- pin `FileUpload.triggerLabel` in the API contract
- add `multiple` to the documented `webkitdirectory` example
- rename the idle-copy helper to match its behavior

Follow-up to #819 after post-merge review comments on #811.

## Verification

- `bun run --filter=@lostgradient/cinder test -- src/api-contract.test.ts src/components/file-upload/file-upload.test.ts`
- `bun run --filter=@lostgradient/cinder typecheck`
- `bun run --filter=@lostgradient/cinder components:check`
- `git diff --check`