### PR TITLE
docs(chat): correct suggestion selection behavior

### DIFF
--- a/.changeset/clear-suggestion-docs.md
+++ b/.changeset/clear-suggestion-docs.md
@@ -1,0 +1,5 @@
+---
+'@lostgradient/chat': patch
+---
+
+Correct the `SuggestionMessagePart` documentation to explain that selecting a suggestion invokes the callback and refocuses the composer without automatically removing the chips, and document returning `[]` from `messageSuggestions` to suppress them.

--- a/packages/chat/src/lib/components/chat/utilities/types.ts
+++ b/packages/chat/src/lib/components/chat/utilities/types.ts
@@ -169,11 +169,11 @@ export type StepMessagePart = {
  * Renders as a button chip inside a `role="toolbar"` container. Selecting a
  * chip calls `onsuggestionselect(label)` and moves focus to the composer input;
  * Chat does not remove the suggestion set automatically.
- * Consumers that want one-shot suggestions can track the selection and have
- * the `messageSuggestions` prop return `[]` for that message. The suggestion
- * set is derived from `message.metadata['cinder:suggestions']` (a JSONValue
- * array of strings) or the explicit `messageSuggestions` prop on Chat. It is
- * UI-only and never written back to the transcript.
+ * Consumers that want one-shot suggestions can update, remove, or empty
+ * `message.metadata['cinder:suggestions']`, or track the selection and have the
+ * `messageSuggestions` prop return `[]` for that message. The metadata value is
+ * a JSONValue array of strings. The suggestion set is UI-only and never written
+ * back to the transcript.
  */
 export type SuggestionMessagePart = {
   type: 'suggestion';

--- a/packages/chat/src/lib/components/chat/utilities/types.ts
+++ b/packages/chat/src/lib/components/chat/utilities/types.ts
@@ -167,8 +167,8 @@ export type StepMessagePart = {
  * after the assistant's final answer.
  *
  * Renders as a button chip inside a `role="toolbar"` container. Selecting a
- * chip calls the selection callback with its label and moves focus to the
- * composer input; Chat does not remove the suggestion set automatically.
+ * chip calls `onsuggestionselect(label)` and moves focus to the composer input;
+ * Chat does not remove the suggestion set automatically.
  * Consumers that want one-shot suggestions must track the selection and have
  * the `messageSuggestions` prop return `[]` for that message. The suggestion
  * set is derived from `message.metadata['cinder:suggestions']` (a JSONValue
@@ -181,7 +181,7 @@ export type SuggestionMessagePart = {
   key: string;
   /** Zero-based position of this suggestion in the list. */
   index: number;
-  /** The label text displayed on the chip and passed to onselect. */
+  /** The label text displayed on the chip and passed to `onsuggestionselect`. */
   label: string;
 };
 

--- a/packages/chat/src/lib/components/chat/utilities/types.ts
+++ b/packages/chat/src/lib/components/chat/utilities/types.ts
@@ -167,11 +167,13 @@ export type StepMessagePart = {
  * after the assistant's final answer.
  *
  * Renders as a button chip inside a `role="toolbar"` container. Selecting a
- * chip calls `onselect(label)`, clears the suggestion set from the DOM, and
- * moves focus to the composer input. The suggestion set is derived from
- * `message.metadata['cinder:suggestions']` (a JSONValue array of strings) or
- * the explicit `messageSuggestions` prop on Chat. It is UI-only and never
- * written back to the transcript.
+ * chip calls the selection callback with its label and moves focus to the
+ * composer input; Chat does not remove the suggestion set automatically.
+ * Consumers that want one-shot suggestions must track the selection and have
+ * the `messageSuggestions` prop return `[]` for that message. The suggestion
+ * set is derived from `message.metadata['cinder:suggestions']` (a JSONValue
+ * array of strings) or the explicit `messageSuggestions` prop on Chat. It is
+ * UI-only and never written back to the transcript.
  */
 export type SuggestionMessagePart = {
   type: 'suggestion';

--- a/packages/chat/src/lib/components/chat/utilities/types.ts
+++ b/packages/chat/src/lib/components/chat/utilities/types.ts
@@ -169,7 +169,7 @@ export type StepMessagePart = {
  * Renders as a button chip inside a `role="toolbar"` container. Selecting a
  * chip calls `onsuggestionselect(label)` and moves focus to the composer input;
  * Chat does not remove the suggestion set automatically.
- * Consumers that want one-shot suggestions must track the selection and have
+ * Consumers that want one-shot suggestions can track the selection and have
  * the `messageSuggestions` prop return `[]` for that message. The suggestion
  * set is derived from `message.metadata['cinder:suggestions']` (a JSONValue
  * array of strings) or the explicit `messageSuggestions` prop on Chat. It is

--- a/packages/chat/src/lib/components/chat/utilities/types.ts
+++ b/packages/chat/src/lib/components/chat/utilities/types.ts
@@ -167,7 +167,8 @@ export type StepMessagePart = {
  * after the assistant's final answer.
  *
  * Renders as a button chip inside a `role="toolbar"` container. Selecting a
- * chip calls `onsuggestionselect(label)` and moves focus to the composer input;
+ * chip invokes `onsuggestionselect(label)` if the prop is provided, then moves
+ * focus to the composer input;
  * Chat does not remove the suggestion set automatically.
  * Consumers that want one-shot suggestions can update, remove, or empty
  * `message.metadata['cinder:suggestions']`, or track the selection and have the


### PR DESCRIPTION
## Summary

- correct `SuggestionMessagePart` JSDoc to match callback and focus behavior
- document that Chat retains suggestion chips unless `messageSuggestions` returns `[]`
- add a patch changeset for `@lostgradient/chat`

## Validation

- `bun run --filter=@lostgradient/chat validate`
- `bun run --filter=@lostgradient/chat validate:consumer`
- `bun run --filter=@lostgradient/chat components:check`
- generated declaration inspection and stale-claim grep
- focused re-runs of two unrelated full-suite tests that transiently hit the shared 5-second timeout

Closes #779