### PR TITLE
fix(chat): bridge message footer hover gap

### DIFF
--- a/.changeset/calm-messages-hover.md
+++ b/.changeset/calm-messages-hover.md
@@ -1,0 +1,5 @@
+---
+'@lostgradient/chat': patch
+---
+
+Keep below-bubble message actions visible while the pointer crosses from developer, system, snapshot, and tool message cards into their footers. Keyboard focus continues to reveal the same actions.

--- a/packages/chat/src/lib/components/chat/message/chat-message-action-buttons.test.ts
+++ b/packages/chat/src/lib/components/chat/message/chat-message-action-buttons.test.ts
@@ -106,36 +106,29 @@ describe('chat message action buttons', () => {
     expect(resetBlock).toContain('bottom: auto');
   });
 
-  test('touch below-bubble footers reserve space only when actions render content', () => {
-    const touchBlock = collapseWhitespace(extractTouchMediaBlock(source, "data-role='system'"));
-
-    for (const selector of [
-      ".chat-message-wrapper[data-role='system']",
-      ".chat-message-wrapper[data-role='developer']",
-      ".chat-message-wrapper[data-role='tool-call']",
-      ".chat-message-wrapper[data-role='tool-result']",
-      ".chat-message-wrapper[data-role='snapshot']",
-      '.chat-message-wrapper[data-tool-pair]',
-    ]) {
-      expect(touchBlock).toContain(
-        `${selector}:has( > .chat-message-footer .chat-message-actions > :global(*) )`,
-      );
-    }
-
-    expect(touchBlock).not.toMatch(/\.chat-message-wrapper\s*\{[^}]*margin-block-end:/s);
-  });
-
-  test('narrow touch layouts extend footer-space reservation to side-footer roles', () => {
+  test('touch footer space follows below-bubble placement and rendered content', () => {
     const narrowBlock = extractMediaBlock(source, '@media (max-width: 480px) {');
-    const narrowTouchBlock = collapseWhitespace(
-      extractMediaBlock(narrowBlock, '@media (hover: none) or (pointer: coarse) {'),
+    const narrowTouchBlock = extractMediaBlock(
+      narrowBlock,
+      '@media (hover: none) or (pointer: coarse) {',
     );
+    const wideTouchBlock = extractTouchMediaBlock(source, "[data-role='system']:has(");
 
     for (const role of ['user', 'assistant']) {
-      expect(narrowTouchBlock).toContain(
-        `.chat-message-wrapper[data-role='${role}']:has( > .chat-message-footer .chat-message-actions > :global(*) )`,
-      );
+      expect(narrowTouchBlock).toContain(`.chat-message-wrapper[data-role='${role}']:has(`);
     }
+    expect(narrowTouchBlock).not.toMatch(/\.chat-message-wrapper\s*\{[^}]*margin-block-end:/s);
+
+    for (const role of ['system', 'developer', 'tool-call', 'tool-result', 'snapshot']) {
+      expect(wideTouchBlock).toContain(`.chat-message-wrapper[data-role='${role}']:has(`);
+    }
+    expect(wideTouchBlock).toContain(
+      'margin-block-end: calc(var(--cinder-touch-target-min) + var(--cinder-space-1))',
+    );
+    expect(wideTouchBlock).not.toContain("[data-role='user']:has(");
+    expect(wideTouchBlock).not.toContain("[data-role='assistant']:has(");
+
+    expect(narrowBlock.replace(narrowTouchBlock, '')).not.toContain('margin-block-end:');
   });
 
   // Regression for #777: a `display: none` footer on tool-paired rows can
@@ -232,8 +225,4 @@ function extractMediaBlock(text: string, marker: string, contains?: string): str
     }
     if (depth !== 0) throw new Error(`media block not balanced: ${marker}`);
   }
-}
-
-function collapseWhitespace(text: string): string {
-  return text.replace(/\s+/g, ' ').trim();
 }

--- a/packages/chat/src/lib/components/chat/message/chat-message-action-buttons.test.ts
+++ b/packages/chat/src/lib/components/chat/message/chat-message-action-buttons.test.ts
@@ -62,11 +62,14 @@ describe('chat message action buttons', () => {
   });
 
   test('below-bubble footer spacing is an in-box hover bridge', () => {
-    const footerRule = extractRule(source, '\n  .chat-message-footer {');
+    // Use a line-start regex so the lookup is not sensitive to indentation.
+    const footerRule = extractRule(source, /(?:^|\n)\s*\.chat-message-footer\s*\{/);
     expect(footerRule).toContain('padding-top: var(--cinder-space-1)');
     expect(footerRule).not.toContain('margin-top: var(--cinder-space-1)');
 
-    const desktopRules = source.slice(0, source.indexOf('@media (max-width: 480px)'));
+    const mediaIdx = source.indexOf('@media (max-width: 480px)');
+    expect(mediaIdx).toBeGreaterThan(-1);
+    const desktopRules = source.slice(0, mediaIdx);
     for (const role of ['developer', 'system', 'snapshot', 'tool-call', 'tool-result']) {
       expect(desktopRules).not.toContain(
         `.chat-message-wrapper[data-role='${role}'] .chat-message-footer {`,
@@ -140,10 +143,17 @@ describe('chat message action buttons', () => {
   });
 });
 
-function extractRule(text: string, opening: string): string {
-  const start = text.indexOf(opening);
-  if (start === -1) throw new Error(`rule not found: ${opening}`);
-  const bodyStart = start + opening.length;
+function extractRule(text: string, opening: string | RegExp): string {
+  if (typeof opening === 'string') {
+    const start = text.indexOf(opening);
+    if (start === -1) throw new Error(`rule not found: ${opening}`);
+    const bodyStart = start + opening.length;
+    const end = text.indexOf('}', bodyStart);
+    return text.slice(bodyStart, end);
+  }
+  const match = opening.exec(text);
+  if (!match) throw new Error(`rule not found: ${opening}`);
+  const bodyStart = match.index + match[0].length;
   const end = text.indexOf('}', bodyStart);
   return text.slice(bodyStart, end);
 }

--- a/packages/chat/src/lib/components/chat/message/chat-message-action-buttons.test.ts
+++ b/packages/chat/src/lib/components/chat/message/chat-message-action-buttons.test.ts
@@ -107,14 +107,18 @@ describe('chat message action buttons', () => {
   });
 
   test('narrow footer space is reserved only when actions render content', () => {
-    const mediaIdx = source.indexOf('@media (max-width: 480px)');
-    expect(mediaIdx).toBeGreaterThan(-1);
-    const narrowBlock = source.slice(mediaIdx, source.indexOf('\n  }', mediaIdx) + 4);
+    const narrowBlock = extractMediaBlock(source, '@media (max-width: 480px) {');
+    const narrowTouchBlock = extractMediaBlock(
+      narrowBlock,
+      '@media (hover: none) or (pointer: coarse) {',
+    );
 
-    expect(narrowBlock).toContain(
+    expect(narrowTouchBlock).toContain(
       '.chat-message-wrapper:has(> .chat-message-footer .chat-message-actions > :global(*))',
     );
-    expect(narrowBlock).not.toMatch(/\.chat-message-wrapper\s*\{[^}]*margin-block-end:/s);
+    expect(narrowTouchBlock).not.toMatch(/\.chat-message-wrapper\s*\{[^}]*margin-block-end:/s);
+
+    expect(narrowBlock.replace(narrowTouchBlock, '')).not.toContain('margin-block-end:');
   });
 
   // Regression for #777: a `display: none` footer on tool-paired rows can
@@ -153,7 +157,10 @@ describe('chat message action buttons', () => {
     // The tool-pair hidden-state override has higher specificity than the
     // bare `.chat-message-footer` touch rule, so it needs its own entry in
     // the touch media block or tool-paired rows stay unreachable on touch.
-    const touchBlock = extractTouchMediaBlock(source, '.chat-message-footer');
+    const touchBlock = extractTouchMediaBlock(
+      source,
+      '.chat-message-wrapper[data-tool-pair] .chat-message-footer',
+    );
     expect(touchBlock).toContain('.chat-message-wrapper[data-tool-pair] .chat-message-footer');
   });
 });
@@ -180,10 +187,17 @@ function extractTouchMediaBlock(
   contains: string = '.chat-message-action-button',
 ): string {
   const marker = '@media (hover: none) or (pointer: coarse) {';
+  return extractMediaBlock(text, marker, contains);
+}
+
+function extractMediaBlock(text: string, marker: string, contains?: string): string {
   let searchFrom = 0;
   for (;;) {
     const start = text.indexOf(marker, searchFrom);
-    if (start === -1) throw new Error(`touch media block containing "${contains}" not found`);
+    if (start === -1) {
+      const qualifier = contains ? ` containing "${contains}"` : '';
+      throw new Error(`media block${qualifier} not found: ${marker}`);
+    }
     let depth = 0;
     let i = text.indexOf('{', start);
     const bodyStart = i + 1;
@@ -193,12 +207,12 @@ function extractTouchMediaBlock(
         depth--;
         if (depth === 0) {
           const body = text.slice(bodyStart, i);
-          if (body.includes(contains)) return body;
+          if (!contains || body.includes(contains)) return body;
           searchFrom = i + 1;
           break;
         }
       }
     }
-    if (depth !== 0) throw new Error('touch media block not balanced');
+    if (depth !== 0) throw new Error(`media block not balanced: ${marker}`);
   }
 }

--- a/packages/chat/src/lib/components/chat/message/chat-message-action-buttons.test.ts
+++ b/packages/chat/src/lib/components/chat/message/chat-message-action-buttons.test.ts
@@ -100,6 +100,10 @@ describe('chat message action buttons', () => {
     );
     expect(resetBlock).toContain('padding-top: var(--cinder-space-1)');
     expect(resetBlock).not.toContain('margin-top: var(--cinder-space-1)');
+    // Ensures `bottom: 0` from the user/assistant desktop side-footer rules is
+    // cleared, preventing both `top` and `bottom` being set simultaneously and
+    // collapsing/overconstraining the below-bubble footer box.
+    expect(resetBlock).toContain('bottom: auto');
   });
 
   // Regression for #777: a `display: none` footer on tool-paired rows can

--- a/packages/chat/src/lib/components/chat/message/chat-message-action-buttons.test.ts
+++ b/packages/chat/src/lib/components/chat/message/chat-message-action-buttons.test.ts
@@ -106,6 +106,17 @@ describe('chat message action buttons', () => {
     expect(resetBlock).toContain('bottom: auto');
   });
 
+  test('narrow footer space is reserved only when actions render content', () => {
+    const mediaIdx = source.indexOf('@media (max-width: 480px)');
+    expect(mediaIdx).toBeGreaterThan(-1);
+    const narrowBlock = source.slice(mediaIdx, source.indexOf('\n  }', mediaIdx) + 4);
+
+    expect(narrowBlock).toContain(
+      '.chat-message-wrapper:has(> .chat-message-footer .chat-message-actions > :global(*))',
+    );
+    expect(narrowBlock).not.toMatch(/\.chat-message-wrapper\s*\{[^}]*margin-block-end:/s);
+  });
+
   // Regression for #777: a `display: none` footer on tool-paired rows can
   // never be resurrected by the shared `:hover`/`:focus-within` rule (which
   // only toggles opacity/pointer-events), making retry/edit/copy and any

--- a/packages/chat/src/lib/components/chat/message/chat-message-action-buttons.test.ts
+++ b/packages/chat/src/lib/components/chat/message/chat-message-action-buttons.test.ts
@@ -144,16 +144,16 @@ describe('chat message action buttons', () => {
 });
 
 function extractRule(text: string, opening: string | RegExp): string {
+  let bodyStart: number;
   if (typeof opening === 'string') {
     const start = text.indexOf(opening);
     if (start === -1) throw new Error(`rule not found: ${opening}`);
-    const bodyStart = start + opening.length;
-    const end = text.indexOf('}', bodyStart);
-    return text.slice(bodyStart, end);
+    bodyStart = start + opening.length;
+  } else {
+    const match = opening.exec(text);
+    if (!match) throw new Error(`rule not found: ${opening}`);
+    bodyStart = match.index + match[0].length;
   }
-  const match = opening.exec(text);
-  if (!match) throw new Error(`rule not found: ${opening}`);
-  const bodyStart = match.index + match[0].length;
   const end = text.indexOf('}', bodyStart);
   return text.slice(bodyStart, end);
 }

--- a/packages/chat/src/lib/components/chat/message/chat-message-action-buttons.test.ts
+++ b/packages/chat/src/lib/components/chat/message/chat-message-action-buttons.test.ts
@@ -106,19 +106,36 @@ describe('chat message action buttons', () => {
     expect(resetBlock).toContain('bottom: auto');
   });
 
-  test('narrow footer space is reserved only when actions render content', () => {
+  test('touch below-bubble footers reserve space only when actions render content', () => {
+    const touchBlock = collapseWhitespace(extractTouchMediaBlock(source, "data-role='system'"));
+
+    for (const selector of [
+      ".chat-message-wrapper[data-role='system']",
+      ".chat-message-wrapper[data-role='developer']",
+      ".chat-message-wrapper[data-role='tool-call']",
+      ".chat-message-wrapper[data-role='tool-result']",
+      ".chat-message-wrapper[data-role='snapshot']",
+      '.chat-message-wrapper[data-tool-pair]',
+    ]) {
+      expect(touchBlock).toContain(
+        `${selector}:has( > .chat-message-footer .chat-message-actions > :global(*) )`,
+      );
+    }
+
+    expect(touchBlock).not.toMatch(/\.chat-message-wrapper\s*\{[^}]*margin-block-end:/s);
+  });
+
+  test('narrow touch layouts extend footer-space reservation to side-footer roles', () => {
     const narrowBlock = extractMediaBlock(source, '@media (max-width: 480px) {');
-    const narrowTouchBlock = extractMediaBlock(
-      narrowBlock,
-      '@media (hover: none) or (pointer: coarse) {',
+    const narrowTouchBlock = collapseWhitespace(
+      extractMediaBlock(narrowBlock, '@media (hover: none) or (pointer: coarse) {'),
     );
 
-    expect(narrowTouchBlock).toContain(
-      '.chat-message-wrapper:has(> .chat-message-footer .chat-message-actions > :global(*))',
-    );
-    expect(narrowTouchBlock).not.toMatch(/\.chat-message-wrapper\s*\{[^}]*margin-block-end:/s);
-
-    expect(narrowBlock.replace(narrowTouchBlock, '')).not.toContain('margin-block-end:');
+    for (const role of ['user', 'assistant']) {
+      expect(narrowTouchBlock).toContain(
+        `.chat-message-wrapper[data-role='${role}']:has( > .chat-message-footer .chat-message-actions > :global(*) )`,
+      );
+    }
   });
 
   // Regression for #777: a `display: none` footer on tool-paired rows can
@@ -215,4 +232,8 @@ function extractMediaBlock(text: string, marker: string, contains?: string): str
     }
     if (depth !== 0) throw new Error(`media block not balanced: ${marker}`);
   }
+}
+
+function collapseWhitespace(text: string): string {
+  return text.replace(/\s+/g, ' ').trim();
 }

--- a/packages/chat/src/lib/components/chat/message/chat-message-action-buttons.test.ts
+++ b/packages/chat/src/lib/components/chat/message/chat-message-action-buttons.test.ts
@@ -61,6 +61,44 @@ describe('chat message action buttons', () => {
     expect(resetBlock).not.toMatch(/(^|\s)right:\s*auto/);
   });
 
+  test('below-bubble footer spacing is an in-box hover bridge', () => {
+    const footerRule = extractRule(source, '\n  .chat-message-footer {');
+    expect(footerRule).toContain('padding-top: var(--cinder-space-1)');
+    expect(footerRule).not.toContain('margin-top: var(--cinder-space-1)');
+
+    const desktopRules = source.slice(0, source.indexOf('@media (max-width: 480px)'));
+    for (const role of ['developer', 'system', 'snapshot', 'tool-call', 'tool-result']) {
+      expect(desktopRules).not.toContain(
+        `.chat-message-wrapper[data-role='${role}'] .chat-message-footer {`,
+      );
+    }
+
+    const toolPairRule = extractRule(
+      source,
+      '.chat-message-wrapper[data-tool-pair] .chat-message-footer {',
+    );
+    expect(toolPairRule).not.toMatch(/(?:margin|padding)-top:/);
+  });
+
+  test('desktop side footers clear the below-bubble bridge', () => {
+    for (const role of ['user', 'assistant']) {
+      const rule = extractRule(
+        source,
+        `.chat-message-wrapper[data-role='${role}'] .chat-message-footer {`,
+      );
+      expect(rule).toContain('padding-top: 0');
+    }
+  });
+
+  test('narrow side footers restore the below-bubble hover bridge', () => {
+    const resetBlock = extractRule(
+      source,
+      ".chat-message-wrapper[data-role='snapshot'] .chat-message-footer {",
+    );
+    expect(resetBlock).toContain('padding-top: var(--cinder-space-1)');
+    expect(resetBlock).not.toContain('margin-top: var(--cinder-space-1)');
+  });
+
   // Regression for #777: a `display: none` footer on tool-paired rows can
   // never be resurrected by the shared `:hover`/`:focus-within` rule (which
   // only toggles opacity/pointer-events), making retry/edit/copy and any
@@ -84,6 +122,12 @@ describe('chat message action buttons', () => {
     // assertion.
     expect(source).toMatch(
       /\.chat-message-wrapper:hover\s+\.chat-message-footer\s*,\s*\.chat-message-wrapper:focus-within\s+\.chat-message-footer\s*\{/,
+    );
+  });
+
+  test('keyboard focus within any message wrapper still reveals its footer', () => {
+    expect(source).toMatch(
+      /\.chat-message-wrapper:focus-within\s+\.chat-message-footer\s*\{[^}]*opacity:\s*1;[^}]*pointer-events:\s*auto;/s,
     );
   });
 

--- a/packages/chat/src/lib/components/chat/message/chat-message-action-buttons.test.ts
+++ b/packages/chat/src/lib/components/chat/message/chat-message-action-buttons.test.ts
@@ -150,7 +150,9 @@ function extractRule(text: string, opening: string | RegExp): string {
     if (start === -1) throw new Error(`rule not found: ${opening}`);
     bodyStart = start + opening.length;
   } else {
-    const match = opening.exec(text);
+    // Clone regex without global/sticky flags to avoid lastIndex flakiness
+    const flags = opening.flags.replace(/[gy]/g, '');
+    const match = new RegExp(opening.source, flags).exec(text);
     if (!match) throw new Error(`rule not found: ${opening}`);
     bodyStart = match.index + match[0].length;
   }

--- a/packages/chat/src/lib/components/chat/message/chat-message.svelte
+++ b/packages/chat/src/lib/components/chat/message/chat-message.svelte
@@ -802,9 +802,10 @@
       margin-top: 0;
     }
 
-    /* The narrow footer is persistently visible only on touch/coarse-pointer
-     * devices. Wide layouts keep user/assistant footers beside the bubble, so
-     * only the narrow fallback needs to reserve their below-bubble footprint. */
+    /* User and assistant footers move below the bubble only at this breakpoint.
+     * On touch/coarse-pointer devices they are persistently visible, so reserve
+     * their action row here. Hover-capable layouts reveal it on demand and must
+     * not reserve an empty row while the footer is hidden. */
     @media (hover: none) or (pointer: coarse) {
       .chat-message-wrapper[data-role='user']:has(
           > .chat-message-footer .chat-message-actions > :global(*)
@@ -815,20 +816,23 @@
         margin-block-end: calc(var(--cinder-touch-target-min) + var(--cinder-space-1));
       }
     }
-
   }
 
-  /* Touch/coarse-pointer devices always show actions, so every below-bubble
-   * footer also needs its footprint reserved in flow when actions actually
-   * render. Wide layouts keep user/assistant footers beside the bubble, so
-   * those side-footer roles only opt into the reservation in the narrow
-   * viewport fallback above. The tool-pair override above has higher
-   * specificity ([data-tool-pair] + .chat-message-wrapper +
+  /* Touch devices: always show actions. The tool-pair override above has
+   * higher specificity ([data-tool-pair] + .chat-message-wrapper +
    * .chat-message-footer) than the bare `.chat-message-footer` below, so it
    * needs its own entry here — otherwise touch users would hit the same
    * "always opacity: 0" dead end on tool-paired rows that :hover/:focus-within
    * fixes for pointer/keyboard. */
   @media (hover: none) or (pointer: coarse) {
+    .chat-message-footer,
+    .chat-message-wrapper[data-tool-pair] .chat-message-footer {
+      opacity: 1;
+      pointer-events: auto;
+    }
+
+    /* These roles use the default below-bubble footer at every width. Reserve
+     * space whenever that persistently visible touch footer has content. */
     .chat-message-wrapper[data-role='system']:has(
         > .chat-message-footer .chat-message-actions > :global(*)
       ),
@@ -843,17 +847,8 @@
       ),
     .chat-message-wrapper[data-role='snapshot']:has(
         > .chat-message-footer .chat-message-actions > :global(*)
-      ),
-    .chat-message-wrapper[data-tool-pair]:has(
-        > .chat-message-footer .chat-message-actions > :global(*)
       ) {
       margin-block-end: calc(var(--cinder-touch-target-min) + var(--cinder-space-1));
-    }
-
-    .chat-message-footer,
-    .chat-message-wrapper[data-tool-pair] .chat-message-footer {
-      opacity: 1;
-      pointer-events: auto;
     }
   }
 

--- a/packages/chat/src/lib/components/chat/message/chat-message.svelte
+++ b/packages/chat/src/lib/components/chat/message/chat-message.svelte
@@ -803,22 +803,53 @@
     }
 
     /* The narrow footer is persistently visible only on touch/coarse-pointer
-     * devices. Hover-capable layouts reveal it on demand and must not reserve
-     * an empty row while the footer is hidden. */
+     * devices. Wide layouts keep user/assistant footers beside the bubble, so
+     * only the narrow fallback needs to reserve their below-bubble footprint. */
     @media (hover: none) or (pointer: coarse) {
-      .chat-message-wrapper:has(> .chat-message-footer .chat-message-actions > :global(*)) {
+      .chat-message-wrapper[data-role='user']:has(
+          > .chat-message-footer .chat-message-actions > :global(*)
+        ),
+      .chat-message-wrapper[data-role='assistant']:has(
+          > .chat-message-footer .chat-message-actions > :global(*)
+        ) {
         margin-block-end: calc(var(--cinder-touch-target-min) + var(--cinder-space-1));
       }
     }
+
   }
 
-  /* Touch devices: always show actions. The tool-pair override above has
-   * higher specificity ([data-tool-pair] + .chat-message-wrapper +
+  /* Touch/coarse-pointer devices always show actions, so every below-bubble
+   * footer also needs its footprint reserved in flow when actions actually
+   * render. Wide layouts keep user/assistant footers beside the bubble, so
+   * those side-footer roles only opt into the reservation in the narrow
+   * viewport fallback above. The tool-pair override above has higher
+   * specificity ([data-tool-pair] + .chat-message-wrapper +
    * .chat-message-footer) than the bare `.chat-message-footer` below, so it
    * needs its own entry here — otherwise touch users would hit the same
    * "always opacity: 0" dead end on tool-paired rows that :hover/:focus-within
    * fixes for pointer/keyboard. */
   @media (hover: none) or (pointer: coarse) {
+    .chat-message-wrapper[data-role='system']:has(
+        > .chat-message-footer .chat-message-actions > :global(*)
+      ),
+    .chat-message-wrapper[data-role='developer']:has(
+        > .chat-message-footer .chat-message-actions > :global(*)
+      ),
+    .chat-message-wrapper[data-role='tool-call']:has(
+        > .chat-message-footer .chat-message-actions > :global(*)
+      ),
+    .chat-message-wrapper[data-role='tool-result']:has(
+        > .chat-message-footer .chat-message-actions > :global(*)
+      ),
+    .chat-message-wrapper[data-role='snapshot']:has(
+        > .chat-message-footer .chat-message-actions > :global(*)
+      ),
+    .chat-message-wrapper[data-tool-pair]:has(
+        > .chat-message-footer .chat-message-actions > :global(*)
+      ) {
+      margin-block-end: calc(var(--cinder-touch-target-min) + var(--cinder-space-1));
+    }
+
     .chat-message-footer,
     .chat-message-wrapper[data-tool-pair] .chat-message-footer {
       opacity: 1;

--- a/packages/chat/src/lib/components/chat/message/chat-message.svelte
+++ b/packages/chat/src/lib/components/chat/message/chat-message.svelte
@@ -785,6 +785,10 @@
    * the role-specific desktop rules above ([data-role='…'] = 0-1-1), so the
    * media query actually wins inside its breakpoint. */
   @media (max-width: 480px) {
+    .chat-message-wrapper {
+      margin-block-end: calc(var(--cinder-touch-target-min) + var(--cinder-space-1));
+    }
+
     .chat-message-wrapper[data-role='user'] .chat-message-footer,
     .chat-message-wrapper[data-role='assistant'] .chat-message-footer,
     .chat-message-wrapper[data-role='system'] .chat-message-footer,

--- a/packages/chat/src/lib/components/chat/message/chat-message.svelte
+++ b/packages/chat/src/lib/components/chat/message/chat-message.svelte
@@ -785,10 +785,6 @@
    * the role-specific desktop rules above ([data-role='…'] = 0-1-1), so the
    * media query actually wins inside its breakpoint. */
   @media (max-width: 480px) {
-    .chat-message-wrapper:has(> .chat-message-footer .chat-message-actions > :global(*)) {
-      margin-block-end: calc(var(--cinder-touch-target-min) + var(--cinder-space-1));
-    }
-
     .chat-message-wrapper[data-role='user'] .chat-message-footer,
     .chat-message-wrapper[data-role='assistant'] .chat-message-footer,
     .chat-message-wrapper[data-role='system'] .chat-message-footer,
@@ -804,6 +800,15 @@
       padding-inline: 0;
       padding-top: var(--cinder-space-1);
       margin-top: 0;
+    }
+
+    /* The narrow footer is persistently visible only on touch/coarse-pointer
+     * devices. Hover-capable layouts reveal it on demand and must not reserve
+     * an empty row while the footer is hidden. */
+    @media (hover: none) or (pointer: coarse) {
+      .chat-message-wrapper:has(> .chat-message-footer .chat-message-actions > :global(*)) {
+        margin-block-end: calc(var(--cinder-touch-target-min) + var(--cinder-space-1));
+      }
     }
   }
 

--- a/packages/chat/src/lib/components/chat/message/chat-message.svelte
+++ b/packages/chat/src/lib/components/chat/message/chat-message.svelte
@@ -793,6 +793,7 @@
     .chat-message-wrapper[data-role='tool-result'] .chat-message-footer,
     .chat-message-wrapper[data-role='snapshot'] .chat-message-footer {
       top: 100%;
+      bottom: auto;
       inset-inline-start: 0;
       inset-inline-end: auto;
       transform: none;

--- a/packages/chat/src/lib/components/chat/message/chat-message.svelte
+++ b/packages/chat/src/lib/components/chat/message/chat-message.svelte
@@ -785,7 +785,7 @@
    * the role-specific desktop rules above ([data-role='…'] = 0-1-1), so the
    * media query actually wins inside its breakpoint. */
   @media (max-width: 480px) {
-    .chat-message-wrapper {
+    .chat-message-wrapper:has(> .chat-message-footer .chat-message-actions > :global(*)) {
       margin-block-end: calc(var(--cinder-touch-target-min) + var(--cinder-space-1));
     }
 

--- a/packages/chat/src/lib/components/chat/message/chat-message.svelte
+++ b/packages/chat/src/lib/components/chat/message/chat-message.svelte
@@ -714,10 +714,12 @@
 
   /* Footer — absolutely positioned outside the bubble's flow so revealing it on
    * hover/focus does not change the bubble's height. Default geometry: below the
-   * bubble at the leading edge, which works for any role. The user/assistant
-   * rules below override this to put the icon beside the bubble on the
-   * center-facing edge. Roles like developer / system / unpaired tool-result
-   * inherit this default and place the footer below the bubble.
+   * bubble at the leading edge, which works for any role. Padding preserves the
+   * visual spacing while making that space part of the footer's hit area, so the
+   * wrapper stays hovered as the pointer crosses from bubble to actions. The
+   * user/assistant rules below override this to put the icon beside the bubble
+   * on the center-facing edge. Roles like developer / system / unpaired
+   * tool-result inherit this default and place the footer below the bubble.
    * LTR-only: the left/right physical properties below assume left-to-right layout.
    * RTL support is a follow-up that swaps to inset-inline-start/end. */
   .chat-message-footer {
@@ -725,7 +727,7 @@
     top: 100%;
     left: 0;
     width: max-content;
-    margin-top: var(--cinder-space-1);
+    padding-top: var(--cinder-space-1);
     opacity: 0;
     pointer-events: none;
     transition: opacity var(--cinder-duration-fast) var(--cinder-ease-standard);
@@ -743,6 +745,7 @@
     left: auto;
     right: 100%;
     margin-top: 0;
+    padding-top: 0;
     display: flex;
     align-items: flex-end;
     /* Padding stays physical to match the physical `right: 100%` placement
@@ -759,6 +762,7 @@
     left: 100%;
     right: auto;
     margin-top: 0;
+    padding-top: 0;
     display: flex;
     align-items: flex-end;
     /* stylelint-disable-next-line csstools/use-logical */
@@ -793,7 +797,8 @@
       inset-inline-end: auto;
       transform: none;
       padding-inline: 0;
-      margin-top: var(--cinder-space-1);
+      padding-top: var(--cinder-space-1);
+      margin-top: 0;
     }
   }
 

--- a/packages/testing/tests/editors-complex-residual.playwright.ts
+++ b/packages/testing/tests/editors-complex-residual.playwright.ts
@@ -79,6 +79,7 @@ test.describe('chat action buttons', () => {
     try {
       const copyButton = page.locator('.chat-message-copy').first();
       await expect(copyButton).toBeVisible();
+      await copyButton.scrollIntoViewIfNeeded();
 
       expect(await colorAlpha(copyButton, 'backgroundColor')).toBeGreaterThan(0);
       expect(await colorAlpha(copyButton, 'borderTopColor')).toBeGreaterThan(0);
@@ -97,6 +98,11 @@ test.describe('chat action buttons', () => {
         });
       });
 
+      const actionableRow = copyButton.locator(
+        'xpath=ancestor::*[contains(@class, "chat-message-wrapper")]',
+      );
+      await expect(actionableRow).toHaveCSS('margin-block-end', `${TOUCH_TARGET_MIN + 4}px`);
+
       const hitTarget = await copyButton.evaluate((element) => {
         const box = element.getBoundingClientRect();
         const target = document.elementFromPoint(box.x + box.width / 2, box.y + box.height / 2);
@@ -107,6 +113,11 @@ test.describe('chat action buttons', () => {
         };
       });
       expect(hitTarget.isCopyButton, JSON.stringify(hitTarget)).toBe(true);
+
+      const emptyToolRow = page.locator('.chat-message-wrapper[data-role="tool-call"]').first();
+      await expect(emptyToolRow).toBeVisible();
+      await expect(emptyToolRow.locator('.chat-message-actions > *')).toHaveCount(0);
+      await expect(emptyToolRow).toHaveCSS('margin-block-end', '0px');
 
       await copyButton.click();
       // CopyButton signals the copied state via `data-cinder-copied` attribute.

--- a/packages/testing/tests/editors-complex-residual.playwright.ts
+++ b/packages/testing/tests/editors-complex-residual.playwright.ts
@@ -101,7 +101,19 @@ test.describe('chat action buttons', () => {
       const actionableRow = copyButton.locator(
         'xpath=ancestor::*[contains(@class, "chat-message-wrapper")]',
       );
-      await expect(actionableRow).toHaveCSS('margin-block-end', `${TOUCH_TARGET_MIN + 4}px`);
+      const space1Px = await page.evaluate(() => {
+        const probe = document.createElement('div');
+        probe.style.cssText =
+          'position:absolute;width:var(--cinder-space-1);visibility:hidden;pointer-events:none';
+        document.body.appendChild(probe);
+        const px = parseFloat(getComputedStyle(probe).width);
+        probe.remove();
+        return px;
+      });
+      await expect(actionableRow).toHaveCSS(
+        'margin-block-end',
+        `${TOUCH_TARGET_MIN + space1Px}px`,
+      );
 
       const hitTarget = await copyButton.evaluate((element) => {
         const box = element.getBoundingClientRect();

--- a/packages/testing/tests/editors-complex-residual.playwright.ts
+++ b/packages/testing/tests/editors-complex-residual.playwright.ts
@@ -72,6 +72,20 @@ async function openTouchPage(
 }
 
 test.describe('chat action buttons', () => {
+  test('narrow hover layouts do not reserve space for hidden actions', async ({ page }) => {
+    await page.setViewportSize({ width: 414, height: 896 });
+    await page.goto('/page/chat?snapshot=1', { waitUntil: 'load' });
+    await page.waitForSelector('#app > *', { state: 'visible', timeout: 20_000 });
+
+    expect(await page.evaluate(() => window.matchMedia('(hover: hover)').matches)).toBe(true);
+
+    const copyButton = page.locator('.chat-message-copy').first();
+    const actionableRow = copyButton.locator(
+      'xpath=ancestor::*[contains(@class, "chat-message-wrapper")]',
+    );
+    await expect(actionableRow).toHaveCSS('margin-block-end', '0px');
+  });
+
   test('built-in action buttons have a visible resting affordance and touch-sized target', async ({
     browser,
   }) => {
@@ -110,10 +124,7 @@ test.describe('chat action buttons', () => {
         probe.remove();
         return px;
       });
-      await expect(actionableRow).toHaveCSS(
-        'margin-block-end',
-        `${TOUCH_TARGET_MIN + space1Px}px`,
-      );
+      await expect(actionableRow).toHaveCSS('margin-block-end', `${TOUCH_TARGET_MIN + space1Px}px`);
 
       const hitTarget = await copyButton.evaluate((element) => {
         const box = element.getBoundingClientRect();

--- a/packages/testing/tests/editors-complex-residual.playwright.ts
+++ b/packages/testing/tests/editors-complex-residual.playwright.ts
@@ -97,6 +97,17 @@ test.describe('chat action buttons', () => {
         });
       });
 
+      const hitTarget = await copyButton.evaluate((element) => {
+        const box = element.getBoundingClientRect();
+        const target = document.elementFromPoint(box.x + box.width / 2, box.y + box.height / 2);
+        return {
+          className: target instanceof HTMLElement ? target.className : null,
+          isCopyButton: target === element || element.contains(target),
+          tagName: target?.tagName ?? null,
+        };
+      });
+      expect(hitTarget.isCopyButton, JSON.stringify(hitTarget)).toBe(true);
+
       await copyButton.click();
       // CopyButton signals the copied state via `data-cinder-copied` attribute.
       const successButton = page.locator('.chat-message-copy[data-cinder-copied]').first();

--- a/packages/testing/tests/editors-complex-residual.playwright.ts
+++ b/packages/testing/tests/editors-complex-residual.playwright.ts
@@ -46,6 +46,7 @@ async function openTouchPage(
   browser: Browser,
   route: string,
   theme: 'light' | 'dark',
+  viewport = { width: 414, height: 896 },
 ): Promise<{ page: Page; dispose: () => Promise<void> }> {
   const context = await browser.newContext({
     baseURL: PLAYGROUND_URL,
@@ -53,7 +54,7 @@ async function openTouchPage(
     reducedMotion: 'reduce',
     hasTouch: true,
     isMobile: true,
-    viewport: { width: 414, height: 896 },
+    viewport,
   });
   await context.addInitScript(
     ([key, value]) => {
@@ -150,6 +151,45 @@ test.describe('chat action buttons', () => {
         (element) => getComputedStyle(element).color,
       );
       expect(successColor).not.toBe(restingColor);
+    } finally {
+      await dispose();
+    }
+  });
+
+  test('wide touch layouts reserve only below-bubble action rows', async ({ browser }) => {
+    const { page, dispose } = await openTouchPage(browser, '/page/chat?snapshot=1', 'light', {
+      width: 768,
+      height: 1024,
+    });
+    try {
+      const space1Px = await page.evaluate(() => {
+        const probe = document.createElement('div');
+        probe.style.cssText =
+          'position:absolute;width:var(--cinder-space-1);visibility:hidden;pointer-events:none';
+        document.body.appendChild(probe);
+        const px = parseFloat(getComputedStyle(probe).width);
+        probe.remove();
+        return px;
+      });
+
+      const toolPairRow = page.locator('.chat-message-wrapper[data-tool-pair]').first();
+      await expect(toolPairRow).toBeVisible();
+      await toolPairRow.locator('.chat-message-actions').evaluate((actions) => {
+        const button = document.createElement('button');
+        button.type = 'button';
+        button.textContent = 'Test action';
+        actions.appendChild(button);
+      });
+      await expect(toolPairRow).toHaveCSS('margin-block-end', `${TOUCH_TARGET_MIN + space1Px}px`);
+
+      const assistantCopyButton = page
+        .locator('.chat-message-wrapper[data-role="assistant"] .chat-message-copy')
+        .first();
+      await expect(assistantCopyButton).toBeVisible();
+      const assistantRow = assistantCopyButton.locator(
+        'xpath=ancestor::*[contains(@class, "chat-message-wrapper")]',
+      );
+      await expect(assistantRow).toHaveCSS('margin-block-end', '0px');
     } finally {
       await dispose();
     }


### PR DESCRIPTION
## Summary

- replace the below-bubble footer margin gap with an equivalent padding hit area
- preserve desktop user/assistant side-footer geometry and narrow-viewport behavior
- cover developer, system, snapshot, tool-call, tool-result, tool-pair, and keyboard focus contracts

## Validation

- `bun run --filter=@lostgradient/chat validate`
- `bun run test:browser` (1329 passed, 0 axe violations)
- `bun run --filter=@cinder/testing test:playwright -- tests/editors-complex-residual.playwright.ts` (9 passed, 0 axe violations)
- isolated Cinder timeout cases (35 passed)

The monolithic root `bun run validate` encountered load-sensitive 5-second timeouts in untouched Cinder tests; the named failures passed together in isolation, and the complete Chat validation and browser suite are green.

Closes #790