### PR TITLE
fix(chat): preserve packed SSR hydration

### DIFF
--- a/.changeset/chat-packed-ssr-function-bindings.md
+++ b/.changeset/chat-packed-ssr-function-bindings.md
@@ -1,0 +1,5 @@
+---
+'@lostgradient/chat': patch
+---
+
+Prevent the packed Chat wrapper's bindable scroll state from forcing a second server render that breaks lifecycle registration and SSR hydration.

--- a/packages/chat/src/lib/components/chat/chat.svelte
+++ b/packages/chat/src/lib/components/chat/chat.svelte
@@ -118,12 +118,12 @@
 
 <ChatImplementation
   bind:this={impl}
+  {...rest}
   {atBottom}
   {unreadCount}
   {newMessageIndicatorVisible}
+  class={mergedClassName}
   onatbottombindingchange={handleAtBottomBindingChange}
   onunreadcountbindingchange={handleUnreadCountBindingChange}
   onnewmessageindicatorvisiblebindingchange={handleNewMessageIndicatorVisibleBindingChange}
-  class={mergedClassName}
-  {...rest}
 />

--- a/packages/chat/src/lib/components/chat/chat.svelte
+++ b/packages/chat/src/lib/components/chat/chat.svelte
@@ -32,27 +32,15 @@
 
   const mergedClassName = $derived(classNames(className));
 
-  function getAtBottom(): boolean {
-    return atBottom;
-  }
-
-  function setAtBottom(value: boolean): void {
+  function handleAtBottomBindingChange(value: boolean): void {
     atBottom = value;
   }
 
-  function getUnreadCount(): number {
-    return unreadCount;
-  }
-
-  function setUnreadCount(value: number): void {
+  function handleUnreadCountBindingChange(value: number): void {
     unreadCount = value;
   }
 
-  function getNewMessageIndicatorVisible(): boolean {
-    return newMessageIndicatorVisible;
-  }
-
-  function setNewMessageIndicatorVisible(value: boolean): void {
+  function handleNewMessageIndicatorVisibleBindingChange(value: boolean): void {
     newMessageIndicatorVisible = value;
   }
 
@@ -130,9 +118,12 @@
 
 <ChatImplementation
   bind:this={impl}
-  bind:atBottom={getAtBottom, setAtBottom}
-  bind:unreadCount={getUnreadCount, setUnreadCount}
-  bind:newMessageIndicatorVisible={getNewMessageIndicatorVisible, setNewMessageIndicatorVisible}
+  {atBottom}
+  {unreadCount}
+  {newMessageIndicatorVisible}
+  onatbottombindingchange={handleAtBottomBindingChange}
+  onunreadcountbindingchange={handleUnreadCountBindingChange}
+  onnewmessageindicatorvisiblebindingchange={handleNewMessageIndicatorVisibleBindingChange}
   class={mergedClassName}
   {...rest}
 />

--- a/packages/chat/src/lib/components/chat/chat.svelte
+++ b/packages/chat/src/lib/components/chat/chat.svelte
@@ -32,6 +32,30 @@
 
   const mergedClassName = $derived(classNames(className));
 
+  function getAtBottom(): boolean {
+    return atBottom;
+  }
+
+  function setAtBottom(value: boolean): void {
+    atBottom = value;
+  }
+
+  function getUnreadCount(): number {
+    return unreadCount;
+  }
+
+  function setUnreadCount(value: number): void {
+    unreadCount = value;
+  }
+
+  function getNewMessageIndicatorVisible(): boolean {
+    return newMessageIndicatorVisible;
+  }
+
+  function setNewMessageIndicatorVisible(value: boolean): void {
+    newMessageIndicatorVisible = value;
+  }
+
   // The inner implementation owns the imperative streaming + scroll API. The
   // public wrapper forwards it so consumers using `@lostgradient/chat` can drive
   // streaming through a `bind:this` to <Chat> (the inner component is not
@@ -106,9 +130,9 @@
 
 <ChatImplementation
   bind:this={impl}
-  bind:atBottom
-  bind:unreadCount
-  bind:newMessageIndicatorVisible
+  bind:atBottom={getAtBottom, setAtBottom}
+  bind:unreadCount={getUnreadCount, setUnreadCount}
+  bind:newMessageIndicatorVisible={getNewMessageIndicatorVisible, setNewMessageIndicatorVisible}
   class={mergedClassName}
   {...rest}
 />

--- a/packages/chat/src/lib/components/chat/chat.test.ts
+++ b/packages/chat/src/lib/components/chat/chat.test.ts
@@ -856,6 +856,8 @@ describe('Chat — public wrapper forwards bind:atBottom/unreadCount/newMessageI
 
     const serverCode = compile(source, {
       filename: resolve(import.meta.dir, 'chat.svelte'),
+      css: 'external',
+      dev: false,
       generate: 'server',
       runes: true,
     }).js.code;
@@ -869,6 +871,8 @@ describe('Chat — public wrapper forwards bind:atBottom/unreadCount/newMessageI
       <ChatImplementation bind:atBottom />`,
       {
         filename: resolve(import.meta.dir, 'chat-binding-control.svelte'),
+        css: 'external',
+        dev: false,
         generate: 'server',
         runes: true,
       },

--- a/packages/chat/src/lib/components/chat/chat.test.ts
+++ b/packages/chat/src/lib/components/chat/chat.test.ts
@@ -826,9 +826,10 @@ describe('Chat — public wrapper forwards bind:atBottom/unreadCount/newMessageI
   // "">`) even though ChatProps documents them as bindable and the internal
   // implementation implements them correctly — svelte-check correctly rejected
   // `bind:atBottom` on a consuming .svelte file as a result. See
-  // chat.svelte's `$props()` destructure and the `bind:atBottom` /
-  // `bind:unreadCount` / `bind:newMessageIndicatorVisible` directives on
-  // <ChatImplementation> for the fix.
+  // chat.svelte's `$props()` destructure and function bindings on
+  // <ChatImplementation> for the fix. Function bindings matter for SSR: shorthand
+  // component bindings force a settle re-render, which runs child lifecycle
+  // registration after Svelte has cleared the active server component context.
   //
   // A runtime render-based check (a host wrapper component that binds and
   // reads the value back) reliably crashes bun:test + happy-dom + the
@@ -839,11 +840,11 @@ describe('Chat — public wrapper forwards bind:atBottom/unreadCount/newMessageI
   // instead covered by `bun run --filter=@lostgradient/chat validate:consumer`,
   // which runs `svelte-check` against the *packed, installed* artifact with a
   // real `bind:atBottom` / `bind:unreadCount` / `bind:newMessageIndicatorVisible`
-  // consumer file — the exact failure mode from the issue. The source-pattern
-  // check below guards the wrapper's implementation shape at the unit-test
-  // layer.
-  test('chat.svelte declares atBottom/unreadCount/newMessageIndicatorVisible as $bindable and forwards bind: to the implementation', async () => {
+  // consumer file — the exact failure mode from the issue. The compiler-output
+  // check below guards the wrapper's server behavior at the unit-test layer.
+  test('chat.svelte declares bindable state and avoids an SSR settle re-render', async () => {
     const { resolve } = await import('node:path');
+    const { compile } = await import('svelte/compiler');
     const source = await Bun.file(resolve(import.meta.dir, 'chat.svelte')).text();
 
     // Whitespace-tolerant: prettier runs over this file via lint-staged, so an
@@ -852,9 +853,13 @@ describe('Chat — public wrapper forwards bind:atBottom/unreadCount/newMessageI
     expect(source).toMatch(/atBottom\s*=\s*\$bindable\(\s*true\s*\)/);
     expect(source).toMatch(/unreadCount\s*=\s*\$bindable\(\s*0\s*\)/);
     expect(source).toMatch(/newMessageIndicatorVisible\s*=\s*\$bindable\(\s*false\s*\)/);
-    expect(source).toMatch(/bind:atBottom\b/);
-    expect(source).toMatch(/bind:unreadCount\b/);
-    expect(source).toMatch(/bind:newMessageIndicatorVisible\b/);
+
+    const serverCode = compile(source, {
+      filename: resolve(import.meta.dir, 'chat.svelte'),
+      generate: 'server',
+      runes: true,
+    }).js.code;
+    expect(serverCode).not.toContain('$$settled = false');
   });
 });
 

--- a/packages/chat/src/lib/components/chat/chat.test.ts
+++ b/packages/chat/src/lib/components/chat/chat.test.ts
@@ -826,10 +826,10 @@ describe('Chat — public wrapper forwards bind:atBottom/unreadCount/newMessageI
   // "">`) even though ChatProps documents them as bindable and the internal
   // implementation implements them correctly — svelte-check correctly rejected
   // `bind:atBottom` on a consuming .svelte file as a result. See
-  // chat.svelte's `$props()` destructure and function bindings on
-  // <ChatImplementation> for the fix. Function bindings matter for SSR: shorthand
-  // component bindings force a settle re-render, which runs child lifecycle
-  // registration after Svelte has cleared the active server component context.
+  // chat.svelte's `$props()` destructure and private change callbacks on
+  // <ChatImplementation> for the fix. Component bindings matter for SSR: they
+  // force a settle re-render, which runs child lifecycle registration after
+  // Svelte has cleared the active server component context.
   //
   // A runtime render-based check (a host wrapper component that binds and
   // reads the value back) reliably crashes bun:test + happy-dom + the
@@ -859,7 +859,8 @@ describe('Chat — public wrapper forwards bind:atBottom/unreadCount/newMessageI
       generate: 'server',
       runes: true,
     }).js.code;
-    expect(serverCode).not.toContain('$$settled = false');
+    expect(serverCode).not.toContain('let $$settled');
+    expect(serverCode).not.toContain('.copy()');
   });
 });
 
@@ -1092,18 +1093,20 @@ describe('Chat — bindable prop sync without write-back $effect', () => {
 
     // The replacement for the scroll event path: atBottom is set inside
     // handleScrollStateChange (at the mutation site).
-    expect(source).toContain('atBottom = event.atBottom');
+    expect(source).toContain('updateAtBottomBinding(event.atBottom)');
 
     // The replacement for the IntersectionObserver sentinel path: when the
     // sentinel fires onReachBottom (without emitting onScrollStateChange),
     // the bindable atBottom must be set to true explicitly.
     // This guards against regression from handleSentinelEntry bypassing
     // handleScrollStateChange.
-    expect(source).toContain('atBottom = true');
+    expect(source).toContain('updateAtBottomBinding(true)');
 
     // The replacement: unreadCount and newMessageIndicatorVisible are set inside
     // the onUnreadIndicatorChange callback.
-    expect(source).toContain('unreadCount = event.unreadCount');
-    expect(source).toContain('newMessageIndicatorVisible = event.newMessageIndicatorVisible');
+    expect(source).toContain('updateUnreadCountBinding(event.unreadCount)');
+    expect(source).toContain(
+      'updateNewMessageIndicatorVisibleBinding(event.newMessageIndicatorVisible)',
+    );
   });
 });

--- a/packages/chat/src/lib/components/chat/chat.test.ts
+++ b/packages/chat/src/lib/components/chat/chat.test.ts
@@ -859,8 +859,23 @@ describe('Chat — public wrapper forwards bind:atBottom/unreadCount/newMessageI
       generate: 'server',
       runes: true,
     }).js.code;
-    expect(serverCode).not.toContain('let $$settled');
-    expect(serverCode).not.toContain('.copy()');
+
+    const settleLoopMarker = '$$settled';
+    const bindingControlCode = compile(
+      `<script>
+        import ChatImplementation from './container/chat.svelte';
+        let atBottom = $state(true);
+      </script>
+      <ChatImplementation bind:atBottom />`,
+      {
+        filename: resolve(import.meta.dir, 'chat-binding-control.svelte'),
+        generate: 'server',
+        runes: true,
+      },
+    ).js.code;
+
+    expect(bindingControlCode).toContain(settleLoopMarker);
+    expect(serverCode).not.toContain(settleLoopMarker);
   });
 });
 

--- a/packages/chat/src/lib/components/chat/container/chat.svelte
+++ b/packages/chat/src/lib/components/chat/container/chat.svelte
@@ -9,6 +9,14 @@
   // redeclaring it, so the public type and the `$props()` shape can never drift.
   import type { ChatAnnounceLevel, ChatProps } from '../chat.types.ts';
 
+  // The public wrapper uses callbacks instead of component bindings so SSR can
+  // render this subtree once while still forwarding bindable state changes.
+  type ChatImplementationProps = ChatProps & {
+    onatbottombindingchange?: (value: boolean) => void;
+    onunreadcountbindingchange?: (value: number) => void;
+    onnewmessageindicatorvisiblebindingchange?: (value: boolean) => void;
+  };
+
   export type { ChatAnnounceLevel, ChatProps };
   export type {
     ChatScrollStateChangeEvent,
@@ -76,6 +84,9 @@
     atBottom = $bindable(true),
     unreadCount = $bindable(0),
     newMessageIndicatorVisible = $bindable(false),
+    onatbottombindingchange,
+    onunreadcountbindingchange,
+    onnewmessageindicatorvisiblebindingchange,
     class: className,
     surfaceMode = 'default',
     density = 'comfortable',
@@ -135,7 +146,22 @@
     composerAriaActiveDescendant,
     composerAriaAutocomplete,
     ...rest
-  }: ChatProps = $props();
+  }: ChatImplementationProps = $props();
+
+  function updateAtBottomBinding(value: boolean): void {
+    atBottom = value;
+    onatbottombindingchange?.(value);
+  }
+
+  function updateUnreadCountBinding(value: number): void {
+    unreadCount = value;
+    onunreadcountbindingchange?.(value);
+  }
+
+  function updateNewMessageIndicatorVisibleBinding(value: boolean): void {
+    newMessageIndicatorVisible = value;
+    onnewmessageindicatorvisiblebindingchange?.(value);
+  }
 
   // ==========================================================================
   // Refs and Internal State
@@ -242,7 +268,7 @@
       // The sentinel fires when the user reaches the bottom via
       // IntersectionObserver, which does not emit onScrollStateChange.
       // Update the bindable prop here so it stays in sync with the sentinel path.
-      atBottom = true;
+      updateAtBottomBinding(true);
       if (unreadState.unreadCount > 0 || unreadState.newMessageIndicatorVisible) {
         unreadState.markAllAsRead();
       }
@@ -257,8 +283,8 @@
   const unreadState = useChatUnreadState({
     onUnreadIndicatorChange: (event) => {
       // Update the bindable props at the mutation site rather than via a $effect.
-      unreadCount = event.unreadCount;
-      newMessageIndicatorVisible = event.newMessageIndicatorVisible;
+      updateUnreadCountBinding(event.unreadCount);
+      updateNewMessageIndicatorVisibleBinding(event.newMessageIndicatorVisible);
       onunreadindicatorchange?.(event);
     },
   });
@@ -276,7 +302,7 @@
         const canLeaveBottom = chatVirtualizer.scrollSize > (viewport?.clientHeight ?? 0);
         if (canLeaveBottom) {
           scrollState.setAtBottom(false);
-          atBottom = false;
+          updateAtBottomBinding(false);
         }
         scrollState.withUserScrollGuard(() => {
           chatVirtualizer.scrollToOffset(0, { behavior: scrollState.getScrollBehavior() });
@@ -705,7 +731,7 @@
     clearHistoryAnchorAfterScroll(event.scrollTop);
 
     // Update the bindable prop at the mutation site rather than via a $effect.
-    atBottom = event.atBottom;
+    updateAtBottomBinding(event.atBottom);
 
     onscrollstatechange?.(event);
   }
@@ -916,7 +942,7 @@
       // prop synchronously (matching the submit auto-scroll path) rather than
       // waiting for the real scroll listener's rAF-deferred recompute.
       scrollState.setAtBottom(true);
-      atBottom = true;
+      updateAtBottomBinding(true);
       unreadState.markAllAsRead();
       onjumptolatest?.();
       tick().then(() => {
@@ -997,7 +1023,7 @@
     // updates the internal helper state; the bindable must be written explicitly
     // (matching the pattern in handleScrollStateChange and onReachBottom).
     scrollState.setAtBottom(true);
-    atBottom = true;
+    updateAtBottomBinding(true);
     tick().then(() => {
       if (isVirtualized) {
         chatVirtualizer.scrollToOffset(chatVirtualizer.scrollSize, { behavior: 'instant' });
@@ -1459,7 +1485,7 @@
     // prop synchronously (matching the submit auto-scroll path) rather than
     // waiting for the real scroll listener's rAF-deferred recompute.
     scrollState.setAtBottom(true);
-    atBottom = true;
+    updateAtBottomBinding(true);
     if (isVirtualized) {
       // Supersede any stale guard from an earlier top-scroll — see the same
       // comment in handleJumpToLatest's virtualized branch.
@@ -1486,7 +1512,7 @@
       const canLeaveBottom = chatVirtualizer.scrollSize > (viewport?.clientHeight ?? 0);
       if (canLeaveBottom) {
         scrollState.setAtBottom(false);
-        atBottom = false;
+        updateAtBottomBinding(false);
       }
       // Guard against the auto-stick-to-bottom $effect.pre (Scroll Anchoring
       // section, above) fighting this animation: it re-fires on every
@@ -1500,7 +1526,7 @@
       // Same canLeaveBottom reasoning as the virtualized branch above.
       const canLeaveBottom = !!viewport && viewport.scrollHeight > viewport.clientHeight;
       if (canLeaveBottom) {
-        atBottom = false;
+        updateAtBottomBinding(false);
       }
       scrollState.scrollToTop(viewport);
     }

--- a/packages/chat/src/lib/components/chat/container/chat.svelte
+++ b/packages/chat/src/lib/components/chat/container/chat.svelte
@@ -5,8 +5,8 @@
   import type { ChatAttachment } from '../input/chat-attachment.ts';
 
   // `ChatProps` is owned by `../chat.types.ts` (the analyzer + schema generator
-  // read that symbol). The implementation imports it from there rather than
-  // redeclaring it, so the public type and the `$props()` shape can never drift.
+  // read that symbol). The implementation extends it only with private callbacks
+  // used by the public wrapper's binding bridge.
   import type { ChatAnnounceLevel, ChatProps } from '../chat.types.ts';
 
   // The public wrapper uses callbacks instead of component bindings so SSR can

--- a/packages/chat/src/lib/components/chat/input/chat-input.svelte
+++ b/packages/chat/src/lib/components/chat/input/chat-input.svelte
@@ -105,7 +105,7 @@
    * ```
    */
 
-  import { flushSync, onDestroy } from 'svelte';
+  import { flushSync } from 'svelte';
   import { classNames } from '../../../utilities/class-names.ts';
   import { useAnnouncer } from '../../../utilities/use-announcer.svelte.ts';
   import { createIdFactory, useStableId } from '../../../utilities/id-factory.ts';
@@ -521,12 +521,17 @@
   // Cleanup
   // =========================================================================
 
-  onDestroy(() => {
-    attachments.forEach((a) => URL.revokeObjectURL(a.previewUrl));
-  });
+  function revokeAttachmentPreviewsOnDestroy(_form: HTMLFormElement): { destroy(): void } {
+    return {
+      destroy() {
+        attachments.forEach((attachment) => URL.revokeObjectURL(attachment.previewUrl));
+      },
+    };
+  }
 </script>
 
 <form
+  use:revokeAttachmentPreviewsOnDestroy
   bind:this={formElement}
   class={classNames('chat-input', isDragOver && 'chat-input-dragover', className)}
   method="POST"

--- a/packages/chat/src/lib/components/chat/input/chat-input.test.ts
+++ b/packages/chat/src/lib/components/chat/input/chat-input.test.ts
@@ -1,6 +1,8 @@
 /// <reference lib="dom" />
 import { afterEach, describe, expect, test } from 'bun:test';
+import { resolve } from 'node:path';
 import { mount, tick, unmount } from 'svelte';
+import { compile } from 'svelte/compiler';
 
 import { setupHappyDom } from '../../../test/happy-dom.ts';
 
@@ -12,6 +14,26 @@ const { default: ChatInput } = await import('./chat-input.svelte');
 afterEach(() => {
   cleanup();
   document.body.replaceChildren();
+});
+
+test('server compilation does not retain lifecycle hooks from the external Svelte runtime', async () => {
+  const sourcePath = resolve(import.meta.dir, 'chat-input.svelte');
+  const source = await Bun.file(sourcePath).text();
+  const serverCode = compile(source, {
+    filename: sourcePath,
+    generate: 'server',
+    runes: true,
+  }).js.code;
+  const clientCode = compile(source, {
+    filename: sourcePath,
+    generate: 'client',
+    runes: true,
+  }).js.code;
+  const actionRegistrationMarker = '$.action(';
+
+  expect(clientCode).toContain(actionRegistrationMarker);
+  expect(serverCode).not.toContain(actionRegistrationMarker);
+  expect(serverCode).not.toContain('onDestroy');
 });
 
 describe('ChatInput', () => {

--- a/packages/components/fixtures/sveltekit-consumer/src/routes/chat-layout/+page.svelte
+++ b/packages/components/fixtures/sveltekit-consumer/src/routes/chat-layout/+page.svelte
@@ -1,7 +1,10 @@
 <script lang="ts">
-  import Chat, { createConversation } from '@lostgradient/chat';
+  import Chat, { createConversation, type ConversationHistory } from '@lostgradient/chat';
+  import '../../app.css';
 
-  const conversation = createConversation({ id: 'consumer-chat-layout' });
+  let conversation = $state<ConversationHistory>(
+    createConversation({ id: 'consumer-chat-layout' }),
+  );
 </script>
 
 <h1>Empty Chat hydration</h1>

--- a/packages/components/fixtures/sveltekit-consumer/src/routes/chat-layout/+page.svelte
+++ b/packages/components/fixtures/sveltekit-consumer/src/routes/chat-layout/+page.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
-  import Chat, { createConversation, type ConversationHistory } from '@lostgradient/chat';
   import '../../app.css';
+  import Chat, { createConversation, type ConversationHistory } from '@lostgradient/chat';
 
   let conversation = $state<ConversationHistory>(
     createConversation({ id: 'consumer-chat-layout' }),


### PR DESCRIPTION
## Summary

- reproduce separate SSR/client `$state` conversation construction in the real packed SvelteKit fixture with base styles
- forward public Chat bindable scroll state through private callbacks so packed SSR renders the child tree once
- keep ChatInput object-URL cleanup client-only so packed server rendering does not call lifecycle hooks through a second Svelte runtime
- add compiler regressions for the SSR settle loop and client-only cleanup, plus a Chat patch changeset

## Root cause

The public wrapper's component bindings compiled into an SSR copied-renderer settle loop. In the packed Node server path, the extra render crossed Svelte runtime boundaries and reached ChatInput's imported `onDestroy` after the active SSR lifecycle context had cleared, returning HTTP 500. The validation helper then surfaced a secondary Chromium-close timeout.

The wrapper now uses private change callbacks instead of component bindings. ChatInput revokes attachment object URLs through a client action teardown, which is registered in client output and omitted from server output.

## Validation

- `bun test --conditions browser --conditions svelte --parallel=1 src/lib/components/chat/input/chat-input.test.ts src/lib/components/chat/chat.test.ts` (51 pass, 0 fail)
- `bun run --filter=@lostgradient/cinder validate:consumer` (`[validate-consumers] all checks passed`, exit 0; minimum/latest Svelte hydration and normal Chromium shutdown)
- `bun run --filter=@lostgradient/chat validate` (690 pass, coverage ratchets, audits, artifact checks, build)
- `bun run format:check`
- clean detached `origin/main` `4376c18e`: the identical packed consumer gate also exits 0

Closes #756