### PR TITLE
fix(chat): unify message role labels

### DIFF
--- a/.changeset/chat-role-label-source.md
+++ b/.changeset/chat-role-label-source.md
@@ -1,0 +1,5 @@
+---
+'@lostgradient/chat': patch
+---
+
+Make `getMessageRoleLabel` and `ChatMessage` use the same user-facing role labels, including `You` for user messages.

--- a/packages/chat/src/lib/components/chat/message/chat-message-role-label.test.ts
+++ b/packages/chat/src/lib/components/chat/message/chat-message-role-label.test.ts
@@ -2,8 +2,7 @@
 import { afterEach, describe, expect, test } from 'bun:test';
 
 import { setupHappyDom } from '../../../test/happy-dom.ts';
-import type { MessageRole } from '../conversation-model.ts';
-import { createStoryMessage } from './chat-message-fixtures.ts';
+import type { Message, MessageRole } from '../conversation-model.ts';
 
 setupHappyDom();
 
@@ -27,7 +26,15 @@ const messageRoles = [
 
 describe('ChatMessage role labels', () => {
   test.each(messageRoles)('matches the public helper for the %s role', (role) => {
-    const message = createStoryMessage({ role });
+    const message: Message = {
+      id: `message-${role}`,
+      role,
+      content: 'Message content',
+      position: 0,
+      createdAt: '2026-01-01T00:00:00.000Z',
+      metadata: {},
+      hidden: false,
+    };
     const { container } = render(ChatMessage, { props: { message } });
 
     expect(container.querySelector('.chat-message-role')?.textContent).toBe(

--- a/packages/chat/src/lib/components/chat/message/chat-message-role-label.test.ts
+++ b/packages/chat/src/lib/components/chat/message/chat-message-role-label.test.ts
@@ -1,0 +1,37 @@
+/// <reference lib="dom" />
+import { afterEach, describe, expect, test } from 'bun:test';
+
+import { setupHappyDom } from '../../../test/happy-dom.ts';
+import type { MessageRole } from '../conversation-model.ts';
+import { createStoryMessage } from './chat-message-fixtures.ts';
+
+setupHappyDom();
+
+const { render, cleanup } = await import('@testing-library/svelte');
+const { ChatMessage, getMessageRoleLabel } = await import('../index.ts');
+
+afterEach(() => {
+  cleanup();
+  document.body.replaceChildren();
+});
+
+const messageRoles = [
+  ['user'],
+  ['assistant'],
+  ['system'],
+  ['developer'],
+  ['tool-call'],
+  ['tool-result'],
+  ['snapshot'],
+] as const satisfies ReadonlyArray<readonly [MessageRole]>;
+
+describe('ChatMessage role labels', () => {
+  test.each(messageRoles)('matches the public helper for the %s role', (role) => {
+    const message = createStoryMessage({ role });
+    const { container } = render(ChatMessage, { props: { message } });
+
+    expect(container.querySelector('.chat-message-role')?.textContent).toBe(
+      getMessageRoleLabel(message),
+    );
+  });
+});

--- a/packages/chat/src/lib/components/chat/message/chat-message.svelte
+++ b/packages/chat/src/lib/components/chat/message/chat-message.svelte
@@ -5,20 +5,6 @@
   import type { MessagePartOverride } from './chat-message-parts.ts';
   import type { StepInfo } from '../utilities/types.ts';
 
-  /**
-   * Role labels for display purposes.
-   * Maps message roles to human-readable labels.
-   */
-  export const ROLE_LABELS: Record<Message['role'], string> = {
-    user: 'You',
-    assistant: 'Assistant',
-    system: 'System',
-    developer: 'Developer',
-    'tool-call': 'Tool Call',
-    'tool-result': 'Tool Result',
-    snapshot: 'Snapshot',
-  };
-
   export type ChatMessageProps = Omit<HTMLAttributes<HTMLElement>, 'class'> & {
     /** The message to render */
     message: Message;
@@ -98,7 +84,11 @@
 
 <script lang="ts">
   import { classNames } from '../../../utilities/class-names.ts';
-  import { deriveMessageParts, getMessageText } from '../utilities/utilities.ts';
+  import {
+    deriveMessageParts,
+    getMessageRoleLabel,
+    getMessageText,
+  } from '../utilities/utilities.ts';
   import { Pencil, RotateCcw } from '@lostgradient/cinder/icons';
   import CopyButton from '@lostgradient/cinder/copy-button';
   import ChatMessagePartsRenderer from './chat-message-parts-renderer.svelte';
@@ -179,7 +169,7 @@
   // (copy, edit, the Show more/less control) — the rendered body itself flows
   // through deriveMessageParts + the parts renderer below.
   const textContent = $derived(getMessageText(message));
-  const roleLabel = $derived(ROLE_LABELS[message.role] ?? message.role);
+  const roleLabel = $derived(getMessageRoleLabel(message));
 
   // Role detection — kept for wrapper-level layout + a11y (data-tool-pair,
   // aria-label). The body branches that used to live here are now derived parts.

--- a/packages/chat/src/lib/components/chat/utilities/utilities.test.ts
+++ b/packages/chat/src/lib/components/chat/utilities/utilities.test.ts
@@ -124,7 +124,7 @@ describe('getMessageRoleLabel', () => {
   // map must key off the real MessageRole value, or tool-call messages fall
   // back to the raw role string.
   it.each([
-    ['user', 'User'],
+    ['user', 'You'],
     ['assistant', 'Assistant'],
     ['system', 'System'],
     ['developer', 'Developer'],
@@ -149,7 +149,7 @@ describe('messagesToMarkdown', () => {
         message({ id: 'u', role: 'user', content: 'Hi' }),
         message({ id: 'a', role: 'assistant', content: 'Hello' }),
       ]),
-    ).toBe('**User:**\n\nHi\n\n---\n\n**Assistant:**\n\nHello');
+    ).toBe('**You:**\n\nHi\n\n---\n\n**Assistant:**\n\nHello');
   });
 
   it('omits system and developer messages from transcript export', () => {

--- a/packages/chat/src/lib/components/chat/utilities/utilities.ts
+++ b/packages/chat/src/lib/components/chat/utilities/utilities.ts
@@ -443,6 +443,16 @@ export function deriveMessageParts(
   return [...bodyParts, ...imageParts];
 }
 
+const messageRoleLabels: Record<Message['role'], string> = {
+  user: 'You',
+  assistant: 'Assistant',
+  system: 'System',
+  developer: 'Developer',
+  'tool-call': 'Tool Call',
+  'tool-result': 'Tool Result',
+  snapshot: 'Snapshot',
+};
+
 /**
  * Gets the role label for a message.
  * Maps internal role values to human-readable labels.
@@ -451,16 +461,7 @@ export function deriveMessageParts(
  * @returns A human-readable role label
  */
 export function getMessageRoleLabel(message: Message): string {
-  const labels: Record<Message['role'], string> = {
-    user: 'You',
-    assistant: 'Assistant',
-    system: 'System',
-    developer: 'Developer',
-    'tool-call': 'Tool Call',
-    'tool-result': 'Tool Result',
-    snapshot: 'Snapshot',
-  };
-  return labels[message.role] ?? message.role;
+  return messageRoleLabels[message.role] ?? message.role;
 }
 
 /**

--- a/packages/chat/src/lib/components/chat/utilities/utilities.ts
+++ b/packages/chat/src/lib/components/chat/utilities/utilities.ts
@@ -452,7 +452,7 @@ export function deriveMessageParts(
  */
 export function getMessageRoleLabel(message: Message): string {
   const labels: Record<Message['role'], string> = {
-    user: 'User',
+    user: 'You',
     assistant: 'Assistant',
     system: 'System',
     developer: 'Developer',


### PR DESCRIPTION
## Summary

- make `ChatMessage` render role labels through the public `getMessageRoleLabel` helper
- preserve the user-facing `You` label for user messages and transcript exports
- add regression coverage for every supported message role

## Verification

- `TZ=UTC LANG=en_US.UTF-8 bun test --conditions browser --conditions svelte --parallel=1 packages/chat/src/lib/components/chat/message/chat-message-role-label.test.ts packages/chat/src/lib/components/chat/utilities/utilities.test.ts`
- `bun run validate`

Closes #785