### PR TITLE
Fix live pre-push gate lock waits

### DIFF
--- a/.changeset/calm-gates-wait.md
+++ b/.changeset/calm-gates-wait.md
@@ -1,0 +1,5 @@
+---
+'@lostgradient/cinder': patch
+---
+
+Keep shared local validation gate waiters alive while the recorded lock holder process is still running.

--- a/docs/validation-topology.md
+++ b/docs/validation-topology.md
@@ -144,7 +144,10 @@ build` step becomes a near-instant no-op instead of a full rebuild when
   `test-changed.ts`, `generate-component-artifacts.ts`
   (`components:generate`/`components:check`), and `validate-consumers.ts`
   (`validate:consumer`) — so concurrent worktrees don't stack full test runs,
-  artifact generation, or tarball installs on top of one another.
+  artifact generation, or tarball installs on top of one another. A waiter
+  keeps polling while the lock's recorded PID is alive, regardless of the
+  lock's age; dead holders are reclaimed immediately, while malformed locks
+  retain a bounded grace period and wait before the command fails.
 - **Global test cleanup** (`src/test/register-global-cleanup.ts`, loaded via
   `scripts/preload.ts`) — a single package-wide `afterEach(cleanup)` for every
   `@testing-library/svelte` render, replacing ad hoc per-file teardown. This

--- a/packages/components/scripts/husky/utilities.test.ts
+++ b/packages/components/scripts/husky/utilities.test.ts
@@ -1472,26 +1472,38 @@ describe('withGateLock', () => {
     });
   });
 
-  it('fails after the bounded wait when a live gate keeps the lock', async () => {
+  it('keeps waiting past the legacy timeout while the recorded holder remains alive', async () => {
     await withTemporaryLockPath(async (lockPath) => {
-      await writeFile(
-        lockPath,
-        JSON.stringify({
-          createdAt: new Date().toISOString(),
-          pid: 123,
-          repositoryRoot: 'other-checkout',
-          token: 'still-running',
-        }),
-      );
+      const holder = Bun.spawn(['bun', '-e', 'await Bun.sleep(50)'], {
+        stderr: 'ignore',
+        stdin: 'ignore',
+        stdout: 'ignore',
+      });
 
-      await expect(
-        withGateLock(async () => 'should not run', {
-          isProcessAlive: () => true,
+      try {
+        await writeFile(
+          lockPath,
+          JSON.stringify({
+            createdAt: new Date(Date.now() - 10 * 60 * 1_000).toISOString(),
+            pid: holder.pid,
+            repositoryRoot: 'other-checkout',
+            token: 'still-running',
+          }),
+        );
+
+        const result = await withGateLock(async () => 'acquired after holder exited', {
           lockPath,
           retryMilliseconds: 1,
           waitMilliseconds: 5,
-        }),
-      ).rejects.toThrow('Another pre-push gate is already running');
+        });
+
+        expect(result).toBe('acquired after holder exited');
+        expect(await holder.exited).toBe(0);
+        expect(await Bun.file(lockPath).exists()).toBe(false);
+      } finally {
+        killProcessGroup(holder.pid);
+        await holder.exited;
+      }
     });
   });
 

--- a/packages/components/scripts/husky/utilities.test.ts
+++ b/packages/components/scripts/husky/utilities.test.ts
@@ -1474,14 +1474,13 @@ describe('withGateLock', () => {
 
   it('keeps waiting past the legacy timeout while the recorded holder remains alive', async () => {
     await withTemporaryLockPath(async (lockPath) => {
-      const holderSleepMilliseconds = 500;
       const legacyTimeoutMilliseconds = 5;
-      const minimumObservedWaitMilliseconds = 100;
-      const holder = Bun.spawn(['bun', '-e', `await Bun.sleep(${holderSleepMilliseconds})`], {
+      const holder = Bun.spawn(['bun', '-e', 'await Bun.stdin.text()'], {
         stderr: 'ignore',
-        stdin: 'ignore',
+        stdin: 'pipe',
         stdout: 'ignore',
       });
+      let liveChecks = 0;
 
       try {
         await writeFile(
@@ -1494,19 +1493,23 @@ describe('withGateLock', () => {
           }),
         );
 
-        const startedAt = Date.now();
         const result = await withGateLock(async () => 'acquired after holder exited', {
+          isProcessAlive: (pid) => {
+            const alive = isProcessAlive(pid);
+            if (alive && ++liveChecks === 10) holder.stdin.end();
+            return alive;
+          },
           lockPath,
           retryMilliseconds: 1,
           waitMilliseconds: legacyTimeoutMilliseconds,
         });
-        const waitedMilliseconds = Date.now() - startedAt;
 
         expect(result).toBe('acquired after holder exited');
-        expect(waitedMilliseconds).toBeGreaterThanOrEqual(minimumObservedWaitMilliseconds);
+        expect(liveChecks).toBe(10);
         expect(await holder.exited).toBe(0);
         expect(await Bun.file(lockPath).exists()).toBe(false);
       } finally {
+        if (isProcessAlive(holder.pid)) holder.stdin.end();
         killProcessGroup(holder.pid);
         await holder.exited;
       }

--- a/packages/components/scripts/husky/utilities.test.ts
+++ b/packages/components/scripts/husky/utilities.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'bun:test';
+import { describe, expect, it, spyOn } from 'bun:test';
 import { existsSync, writeFileSync } from 'node:fs';
 import { mkdir, mkdtemp, readFile, rm, symlink, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
@@ -1567,6 +1567,49 @@ describe('withGateLock', () => {
 
       expect(malformedChecks).toBeGreaterThan(1);
       expect(await readFile(lockPath, 'utf8')).toBe('{');
+    });
+  });
+
+  it('prints live-holder guidance after a malformed lock becomes valid', async () => {
+    await withTemporaryLockPath(async (lockPath) => {
+      await writeFile(lockPath, '{');
+      const messages: string[] = [];
+      const consoleLog = spyOn(console, 'log').mockImplementation((message) => {
+        messages.push(String(message));
+      });
+      let lockCompleted = false;
+      let liveChecks = 0;
+
+      try {
+        const result = await withGateLock(async () => 'acquired after transition', {
+          beforeMalformedLockStat: async () => {
+            if (lockCompleted) return;
+            lockCompleted = true;
+            await writeFile(
+              lockPath,
+              JSON.stringify({
+                createdAt: new Date().toISOString(),
+                pid: 123,
+                repositoryRoot: 'other-checkout',
+                token: 'completed-lock',
+              }),
+            );
+          },
+          isProcessAlive: () => ++liveChecks === 1,
+          lockPath,
+          malformedLockGraceMilliseconds: 1_000,
+          retryMilliseconds: 1,
+          waitMilliseconds: 100,
+        });
+
+        expect(result).toBe('acquired after transition');
+        expect(messages.some((message) => message.includes('preparing its lock file'))).toBe(true);
+        expect(messages.some((message) => message.includes('Waiting without an age timeout'))).toBe(
+          true,
+        );
+      } finally {
+        consoleLog.mockRestore();
+      }
     });
   });
 

--- a/packages/components/scripts/husky/utilities.test.ts
+++ b/packages/components/scripts/husky/utilities.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'bun:test';
-import { existsSync } from 'node:fs';
+import { existsSync, writeFileSync } from 'node:fs';
 import { mkdir, mkdtemp, readFile, rm, symlink, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -1505,7 +1505,7 @@ describe('withGateLock', () => {
         });
 
         expect(result).toBe('acquired after holder exited');
-        expect(liveChecks).toBe(10);
+        expect(liveChecks).toBeGreaterThanOrEqual(10);
         expect(await holder.exited).toBe(0);
         expect(await Bun.file(lockPath).exists()).toBe(false);
       } finally {
@@ -1529,6 +1529,41 @@ describe('withGateLock', () => {
         }),
       ).rejects.toThrow('malformed lock');
 
+      expect(await readFile(lockPath, 'utf8')).toBe('{');
+    });
+  });
+
+  it('starts a fresh bounded wait when a live lock is replaced by a malformed lock', async () => {
+    await withTemporaryLockPath(async (lockPath) => {
+      await writeFile(
+        lockPath,
+        JSON.stringify({
+          createdAt: new Date().toISOString(),
+          pid: 123,
+          repositoryRoot: 'other-checkout',
+          token: 'live-then-malformed',
+        }),
+      );
+      let liveChecks = 0;
+      let malformedChecks = 0;
+
+      await expect(
+        withGateLock(async () => 'should not run', {
+          beforeMalformedLockStat: () => {
+            malformedChecks++;
+          },
+          isProcessAlive: () => {
+            if (++liveChecks === 20) writeFileSync(lockPath, '{');
+            return true;
+          },
+          lockPath,
+          malformedLockGraceMilliseconds: 1_000,
+          retryMilliseconds: 1,
+          waitMilliseconds: 5,
+        }),
+      ).rejects.toThrow('malformed lock');
+
+      expect(malformedChecks).toBeGreaterThan(1);
       expect(await readFile(lockPath, 'utf8')).toBe('{');
     });
   });

--- a/packages/components/scripts/husky/utilities.test.ts
+++ b/packages/components/scripts/husky/utilities.test.ts
@@ -1474,7 +1474,7 @@ describe('withGateLock', () => {
 
   it('keeps waiting past the legacy timeout while the recorded holder remains alive', async () => {
     await withTemporaryLockPath(async (lockPath) => {
-      const holder = Bun.spawn(['bun', '-e', 'await Bun.sleep(50)'], {
+      const holder = Bun.spawn(['bun', '-e', 'await Bun.sleep(500)'], {
         stderr: 'ignore',
         stdin: 'ignore',
         stdout: 'ignore',
@@ -1491,13 +1491,16 @@ describe('withGateLock', () => {
           }),
         );
 
+        const startedAt = Date.now();
         const result = await withGateLock(async () => 'acquired after holder exited', {
           lockPath,
           retryMilliseconds: 1,
           waitMilliseconds: 5,
         });
+        const waitedMilliseconds = Date.now() - startedAt;
 
         expect(result).toBe('acquired after holder exited');
+        expect(waitedMilliseconds).toBeGreaterThanOrEqual(100);
         expect(await holder.exited).toBe(0);
         expect(await Bun.file(lockPath).exists()).toBe(false);
       } finally {

--- a/packages/components/scripts/husky/utilities.test.ts
+++ b/packages/components/scripts/husky/utilities.test.ts
@@ -1548,11 +1548,13 @@ describe('withGateLock', () => {
       );
       let liveChecks = 0;
       let malformedChecks = 0;
+      let now = 0;
 
       await expect(
         withGateLock(async () => 'should not run', {
           beforeMalformedLockStat: () => {
             malformedChecks++;
+            if (malformedChecks > 1) now = 5;
           },
           isProcessAlive: () => {
             if (++liveChecks === 20) writeFileSync(lockPath, '{');
@@ -1560,6 +1562,7 @@ describe('withGateLock', () => {
           },
           lockPath,
           malformedLockGraceMilliseconds: 1_000,
+          now: () => now,
           retryMilliseconds: 1,
           waitMilliseconds: 5,
         }),

--- a/packages/components/scripts/husky/utilities.test.ts
+++ b/packages/components/scripts/husky/utilities.test.ts
@@ -1509,8 +1509,10 @@ describe('withGateLock', () => {
         expect(await holder.exited).toBe(0);
         expect(await Bun.file(lockPath).exists()).toBe(false);
       } finally {
-        if (isProcessAlive(holder.pid)) holder.stdin.end();
-        killProcessGroup(holder.pid);
+        if (isProcessAlive(holder.pid)) {
+          holder.stdin.end();
+          killProcessGroup(holder.pid);
+        }
         await holder.exited;
       }
     });

--- a/packages/components/scripts/husky/utilities.test.ts
+++ b/packages/components/scripts/husky/utilities.test.ts
@@ -1474,7 +1474,10 @@ describe('withGateLock', () => {
 
   it('keeps waiting past the legacy timeout while the recorded holder remains alive', async () => {
     await withTemporaryLockPath(async (lockPath) => {
-      const holder = Bun.spawn(['bun', '-e', 'await Bun.sleep(500)'], {
+      const holderSleepMilliseconds = 500;
+      const legacyTimeoutMilliseconds = 5;
+      const minimumObservedWaitMilliseconds = 100;
+      const holder = Bun.spawn(['bun', '-e', `await Bun.sleep(${holderSleepMilliseconds})`], {
         stderr: 'ignore',
         stdin: 'ignore',
         stdout: 'ignore',
@@ -1495,12 +1498,12 @@ describe('withGateLock', () => {
         const result = await withGateLock(async () => 'acquired after holder exited', {
           lockPath,
           retryMilliseconds: 1,
-          waitMilliseconds: 5,
+          waitMilliseconds: legacyTimeoutMilliseconds,
         });
         const waitedMilliseconds = Date.now() - startedAt;
 
         expect(result).toBe('acquired after holder exited');
-        expect(waitedMilliseconds).toBeGreaterThanOrEqual(100);
+        expect(waitedMilliseconds).toBeGreaterThanOrEqual(minimumObservedWaitMilliseconds);
         expect(await holder.exited).toBe(0);
         expect(await Bun.file(lockPath).exists()).toBe(false);
       } finally {

--- a/packages/components/scripts/husky/utilities.ts
+++ b/packages/components/scripts/husky/utilities.ts
@@ -736,7 +736,10 @@ export async function withGateLock<T>(
           warning('Another pre-push gate is preparing its lock file. Waiting for it to finish…');
           waitingMessagePrinted = true;
         }
-        if (Date.now() - malformedLockStartedAt >= waitMilliseconds) {
+        if (
+          malformedLockStartedAt !== null &&
+          Date.now() - malformedLockStartedAt >= waitMilliseconds
+        ) {
           throw new Error(
             `Another pre-push gate left a malformed lock at ${lockPath}; waited ${waitMilliseconds}ms before giving up.`,
             { cause: caught },

--- a/packages/components/scripts/husky/utilities.ts
+++ b/packages/components/scripts/husky/utilities.ts
@@ -755,13 +755,6 @@ export async function withGateLock<T>(
         waitingMessagePrinted = true;
       }
 
-      if (Date.now() - startedAt >= waitMilliseconds) {
-        throw new Error(
-          `Another pre-push gate is already running (pid ${existingLock.pid}); waited ${waitMilliseconds}ms for ${lockPath}.`,
-          { cause: caught },
-        );
-      }
-
       await Bun.sleep(retryMilliseconds);
     }
   }

--- a/packages/components/scripts/husky/utilities.ts
+++ b/packages/components/scripts/husky/utilities.ts
@@ -756,8 +756,9 @@ export async function withGateLock<T>(
 
       if (!waitingMessagePrinted) {
         warning(
-          `Another pre-push gate is already running for ${existingLock.repositoryRoot} (pid ${existingLock.pid}). Waiting for it to finish…\n` +
-            `  Inspect with: ps -p ${existingLock.pid} -o pid,ppid,etime,stat,command`,
+          `Another pre-push gate is already running for ${existingLock.repositoryRoot} (pid ${existingLock.pid}, lock created ${existingLock.createdAt}). Waiting without an age timeout while that PID remains alive…\n` +
+            `  Inspect with: ps -p ${existingLock.pid} -o pid,ppid,etime,stat,command\n` +
+            `  If that PID is not a pre-push gate, verify it before manually removing ${lockPath}.`,
         );
         waitingMessagePrinted = true;
       }

--- a/packages/components/scripts/husky/utilities.ts
+++ b/packages/components/scripts/husky/utilities.ts
@@ -546,6 +546,7 @@ type GateLockOptions = {
   readonly isProcessAlive?: (pid: number) => boolean;
   readonly lockPath?: string;
   readonly malformedLockGraceMilliseconds?: number;
+  readonly now?: () => number;
   readonly retryMilliseconds?: number;
   readonly resendSignal?: (signal: NodeJS.Signals) => void;
   readonly waitMilliseconds?: number;
@@ -666,6 +667,7 @@ export async function withGateLock<T>(
   const retryMilliseconds = options.retryMilliseconds ?? DEFAULT_GATE_LOCK_RETRY_MILLISECONDS;
   const waitMilliseconds = options.waitMilliseconds ?? DEFAULT_GATE_LOCK_WAIT_MILLISECONDS;
   const processAlive = options.isProcessAlive ?? defaultIsProcessAlive;
+  const now = options.now ?? Date.now;
   const resendSignal = options.resendSignal ?? ((signal) => process.kill(process.pid, signal));
   const token = `${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2)}`;
   let malformedLockStartedAt: number | null = null;
@@ -714,7 +716,7 @@ export async function withGateLock<T>(
 
       const existingLock = await readGateLock(lockPath);
       if (existingLock === null) {
-        malformedLockStartedAt ??= Date.now();
+        malformedLockStartedAt ??= now();
         await options.beforeMalformedLockStat?.();
         let existingLockAgeMilliseconds = 0;
         try {
@@ -736,10 +738,7 @@ export async function withGateLock<T>(
           warning('Another pre-push gate is preparing its lock file. Waiting for it to finish…');
           waitingMessageState = 'malformed';
         }
-        if (
-          malformedLockStartedAt !== null &&
-          Date.now() - malformedLockStartedAt >= waitMilliseconds
-        ) {
+        if (malformedLockStartedAt !== null && now() - malformedLockStartedAt >= waitMilliseconds) {
           throw new Error(
             `Another pre-push gate left a malformed lock at ${lockPath}; waited ${waitMilliseconds}ms before giving up.`,
             { cause: caught },

--- a/packages/components/scripts/husky/utilities.ts
+++ b/packages/components/scripts/husky/utilities.ts
@@ -668,7 +668,7 @@ export async function withGateLock<T>(
   const processAlive = options.isProcessAlive ?? defaultIsProcessAlive;
   const resendSignal = options.resendSignal ?? ((signal) => process.kill(process.pid, signal));
   const token = `${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2)}`;
-  const startedAt = Date.now();
+  let malformedLockStartedAt: number | null = null;
   let waitingMessagePrinted = false;
   let lockAcquired = false;
   let interruptedSignal: NodeJS.Signals | null = null;
@@ -714,24 +714,29 @@ export async function withGateLock<T>(
 
       const existingLock = await readGateLock(lockPath);
       if (existingLock === null) {
+        malformedLockStartedAt ??= Date.now();
         await options.beforeMalformedLockStat?.();
         let existingLockAgeMilliseconds = 0;
         try {
           existingLockAgeMilliseconds = await lockAgeMilliseconds(lockPath);
         } catch (statError) {
-          if (errnoCode(statError) === 'ENOENT') continue;
+          if (errnoCode(statError) === 'ENOENT') {
+            malformedLockStartedAt = null;
+            continue;
+          }
           throw statError;
         }
         if (existingLockAgeMilliseconds >= malformedLockGraceMilliseconds) {
           warning('Removing stale malformed pre-push gate lock.');
           await rm(lockPath, { force: true });
+          malformedLockStartedAt = null;
           continue;
         }
         if (!waitingMessagePrinted) {
           warning('Another pre-push gate is preparing its lock file. Waiting for it to finish…');
           waitingMessagePrinted = true;
         }
-        if (Date.now() - startedAt >= waitMilliseconds) {
+        if (Date.now() - malformedLockStartedAt >= waitMilliseconds) {
           throw new Error(
             `Another pre-push gate left a malformed lock at ${lockPath}; waited ${waitMilliseconds}ms before giving up.`,
             { cause: caught },
@@ -740,6 +745,8 @@ export async function withGateLock<T>(
         await Bun.sleep(retryMilliseconds);
         continue;
       }
+
+      malformedLockStartedAt = null;
 
       if (!processAlive(existingLock.pid)) {
         warning('Removing stale pre-push gate lock.');

--- a/packages/components/scripts/husky/utilities.ts
+++ b/packages/components/scripts/husky/utilities.ts
@@ -669,7 +669,7 @@ export async function withGateLock<T>(
   const resendSignal = options.resendSignal ?? ((signal) => process.kill(process.pid, signal));
   const token = `${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2)}`;
   let malformedLockStartedAt: number | null = null;
-  let waitingMessagePrinted = false;
+  let waitingMessageState: 'malformed' | 'live' | null = null;
   let lockAcquired = false;
   let interruptedSignal: NodeJS.Signals | null = null;
 
@@ -732,9 +732,9 @@ export async function withGateLock<T>(
           malformedLockStartedAt = null;
           continue;
         }
-        if (!waitingMessagePrinted) {
+        if (waitingMessageState !== 'malformed') {
           warning('Another pre-push gate is preparing its lock file. Waiting for it to finish…');
-          waitingMessagePrinted = true;
+          waitingMessageState = 'malformed';
         }
         if (
           malformedLockStartedAt !== null &&
@@ -757,13 +757,13 @@ export async function withGateLock<T>(
         continue;
       }
 
-      if (!waitingMessagePrinted) {
+      if (waitingMessageState !== 'live') {
         warning(
           `Another pre-push gate is already running for ${existingLock.repositoryRoot} (pid ${existingLock.pid}, lock created ${existingLock.createdAt}). Waiting without an age timeout while that PID remains alive…\n` +
             `  Inspect with: ps -p ${existingLock.pid} -o pid,ppid,etime,stat,command\n` +
             `  If that PID is not a pre-push gate, verify it before manually removing ${lockPath}.`,
         );
-        waitingMessagePrinted = true;
+        waitingMessageState = 'live';
       }
 
       await Bun.sleep(retryMilliseconds);


### PR DESCRIPTION
## Summary

- keep polling while the recorded validation gate holder PID remains alive, regardless of lock age
- preserve bounded malformed-lock handling and immediate dead-holder reclamation
- add regression coverage, validation-topology documentation, and a patch changeset

## Validation

- `bun test packages/components/scripts/husky/utilities.test.ts` (62 pass)
- `bun run validate` (7,248 tests pass; local coverage ratchet reproducibly omits unrelated `src/cli/mcp.ts` and validator branches while current main CI is green)

Closes #791