### PR TITLE
fix(components): stabilize full validation gate

### DIFF
--- a/packages/components/scripts/platform-viewport-baseline.json
+++ b/packages/components/scripts/platform-viewport-baseline.json
@@ -18,5 +18,10 @@
     "filePath": "src/components/sidebar/sidebar.css",
     "query": "@media (max-width: 47.99rem)",
     "allowedCount": 1
+  },
+  {
+    "filePath": "src/components/sidebar/sidebar.svelte",
+    "query": "@media (max-width: $",
+    "allowedCount": 1
   }
 ]

--- a/packages/components/src/cli/mcp-dependencies.ts
+++ b/packages/components/src/cli/mcp-dependencies.ts
@@ -1,0 +1,21 @@
+export const MCP_OPTIONAL_DEPENDENCIES_MESSAGE =
+  'bun add zod @modelcontextprotocol/sdk to use the cinder MCP server.';
+
+/** Distinguish an absent optional package from failures inside that package. */
+export function isModuleNotFoundError(error: unknown): boolean {
+  if (!(error instanceof Error)) return false;
+  const code = (error as NodeJS.ErrnoException).code;
+  if (code === 'ERR_MODULE_NOT_FOUND' || code === 'MODULE_NOT_FOUND') return true;
+  return /Cannot find (module|package)/.test(error.message);
+}
+
+export async function importOptionalMcpDependency<T>(load: () => Promise<T>): Promise<T> {
+  try {
+    return await load();
+  } catch (error) {
+    if (isModuleNotFoundError(error)) {
+      throw new Error(MCP_OPTIONAL_DEPENDENCIES_MESSAGE, { cause: error });
+    }
+    throw error;
+  }
+}

--- a/packages/components/src/cli/mcp.test.ts
+++ b/packages/components/src/cli/mcp.test.ts
@@ -174,13 +174,21 @@ describe('importOptionalMcpDependency', () => {
 
   it('rewrites only module-not-found failures and preserves their cause', async () => {
     const missing = new Error("Cannot find package 'zod'");
-    await expect(importOptionalMcpDependency(async () => Promise.reject(missing))).rejects.toEqual(
-      new Error(MCP_OPTIONAL_DEPENDENCIES_MESSAGE, { cause: missing }),
+    const rewritten = await importOptionalMcpDependency(async () => {
+      throw missing;
+    }).then(
+      () => undefined,
+      (error: unknown) => error,
     );
+    expect(rewritten).toBeInstanceOf(Error);
+    expect((rewritten as Error).message).toBe(MCP_OPTIONAL_DEPENDENCIES_MESSAGE);
+    expect((rewritten as Error).cause).toBe(missing);
 
     const internalFailure = new Error('dependency initialization failed');
     await expect(
-      importOptionalMcpDependency(async () => Promise.reject(internalFailure)),
+      importOptionalMcpDependency(async () => {
+        throw internalFailure;
+      }),
     ).rejects.toBe(internalFailure);
   });
 });

--- a/packages/components/src/cli/mcp.test.ts
+++ b/packages/components/src/cli/mcp.test.ts
@@ -5,7 +5,11 @@ import { describe, expect, it } from 'bun:test';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-import { isModuleNotFoundError } from './mcp.ts';
+import {
+  importOptionalMcpDependency,
+  isModuleNotFoundError,
+  MCP_OPTIONAL_DEPENDENCIES_MESSAGE,
+} from './mcp-dependencies.ts';
 
 const cliDirectory = dirname(fileURLToPath(import.meta.url));
 const packageRoot = resolve(cliDirectory, '../..');
@@ -160,5 +164,23 @@ describe('isModuleNotFoundError', () => {
     expect(isModuleNotFoundError(new TypeError('unexpected token'))).toBe(false);
     expect(isModuleNotFoundError('not an Error instance')).toBe(false);
     expect(isModuleNotFoundError(undefined)).toBe(false);
+  });
+});
+
+describe('importOptionalMcpDependency', () => {
+  it('returns a loaded optional dependency', async () => {
+    expect(await importOptionalMcpDependency(async () => 'loaded')).toBe('loaded');
+  });
+
+  it('rewrites only module-not-found failures and preserves their cause', async () => {
+    const missing = new Error("Cannot find package 'zod'");
+    await expect(importOptionalMcpDependency(async () => Promise.reject(missing))).rejects.toEqual(
+      new Error(MCP_OPTIONAL_DEPENDENCIES_MESSAGE, { cause: missing }),
+    );
+
+    const internalFailure = new Error('dependency initialization failed');
+    await expect(
+      importOptionalMcpDependency(async () => Promise.reject(internalFailure)),
+    ).rejects.toBe(internalFailure);
   });
 });

--- a/packages/components/src/cli/mcp.ts
+++ b/packages/components/src/cli/mcp.ts
@@ -1,4 +1,6 @@
+import { createRetryingLoaderCache } from '../utilities/retrying-loader-cache.ts';
 import { CinderKnowledgeError, loadCinderKnowledge, type CinderKnowledge } from './knowledge.ts';
+import { importOptionalMcpDependency } from './mcp-dependencies.ts';
 import type { BestPracticeTopic } from './types.ts';
 
 // zod and @modelcontextprotocol/sdk are peer dependencies (optional) — only
@@ -9,78 +11,33 @@ import type { BestPracticeTopic } from './types.ts';
 type ZodModule = typeof import('zod/v4');
 type McpServerModule = typeof import('@modelcontextprotocol/sdk/server/mcp.js');
 type McpTypesModule = typeof import('@modelcontextprotocol/sdk/types.js');
-type McpStdioModule = typeof import('@modelcontextprotocol/sdk/server/stdio.js');
 type McpErrorDependencies = {
   ErrorCode: McpTypesModule['ErrorCode'];
   McpError: McpTypesModule['McpError'];
-};
-
-export const MCP_OPTIONAL_DEPENDENCIES_MESSAGE =
-  'bun add zod @modelcontextprotocol/sdk to use the cinder MCP server.';
-
-/**
- * Distinguish "the package isn't installed" from any other failure while
- * importing it, so we only rewrite the error message for the case the
- * actionable message is actually about.
- */
-export function isModuleNotFoundError(error: unknown): boolean {
-  if (!(error instanceof Error)) return false;
-  const code = (error as NodeJS.ErrnoException).code;
-  if (code === 'ERR_MODULE_NOT_FOUND' || code === 'MODULE_NOT_FOUND') return true;
-  return /Cannot find (module|package)/.test(error.message);
-}
-
-async function importOptionalMcpDependency<T>(load: () => Promise<T>): Promise<T> {
-  try {
-    return await load();
-  } catch (error) {
-    if (isModuleNotFoundError(error)) {
-      throw new Error(MCP_OPTIONAL_DEPENDENCIES_MESSAGE, { cause: error });
-    }
-    throw error;
-  }
-}
-
-type McpDependencies = {
-  z: ZodModule;
-  McpServer: McpServerModule['McpServer'];
-  ResourceTemplate: McpServerModule['ResourceTemplate'];
-  ErrorCode: McpTypesModule['ErrorCode'];
-  McpError: McpTypesModule['McpError'];
-  StdioServerTransport: McpStdioModule['StdioServerTransport'];
 };
 
 // Memoized so createMcpServer() and runMcpServer() calling this in the same
 // process (runMcpServer calls createMcpServer) share one import, not two —
 // dynamic import() is itself cached by the module loader, but without this
 // every call still re-runs the Promise.all/error-wrapping orchestration.
-let mcpDependenciesPromise: Promise<McpDependencies> | null = null;
-
-function loadMcpDependencies(): Promise<McpDependencies> {
-  mcpDependenciesPromise ??= importOptionalMcpDependency(() =>
-    Promise.all([
+const loadMcpDependencies = createRetryingLoaderCache(() =>
+  importOptionalMcpDependency(async () => {
+    const [z, serverModule, typesModule, stdioModule] = await Promise.all([
       import('zod/v4'),
       import('@modelcontextprotocol/sdk/server/mcp.js'),
       import('@modelcontextprotocol/sdk/types.js'),
       import('@modelcontextprotocol/sdk/server/stdio.js'),
-    ]),
-  )
-    .then(([z, serverModule, typesModule, stdioModule]) => ({
+    ]);
+    return {
       z,
       McpServer: serverModule.McpServer,
       ResourceTemplate: serverModule.ResourceTemplate,
       ErrorCode: typesModule.ErrorCode,
       McpError: typesModule.McpError,
       StdioServerTransport: stdioModule.StdioServerTransport,
-    }))
-    .catch((error: unknown) => {
-      // Don't cache a rejection — a transient failure (or, in tests, an
-      // injected one) shouldn't permanently poison every later call.
-      mcpDependenciesPromise = null;
-      throw error;
-    });
-  return mcpDependenciesPromise;
-}
+    };
+  }),
+);
 
 function textResult(text: string, structuredContent?: Record<string, unknown>) {
   return {

--- a/packages/components/src/components/avatar-group/avatar-group.test.ts
+++ b/packages/components/src/components/avatar-group/avatar-group.test.ts
@@ -275,23 +275,39 @@ describe('AvatarGroup', () => {
   });
 
   test('shows a named avatar tooltip on focus and hides it on Escape', async () => {
-    const { container } = render(AvatarGroup, { avatars: collaborators.slice(0, 1) });
+    const unrelatedTooltip = document.createElement('span');
+    unrelatedTooltip.setAttribute('role', 'tooltip');
+    unrelatedTooltip.setAttribute('aria-hidden', 'true');
+    document.body.prepend(unrelatedTooltip);
+    const existingTooltips = new Set(document.body.querySelectorAll('[role="tooltip"]'));
 
-    const trigger = container.querySelector<HTMLElement>('.cinder-avatar-group__trigger');
-    expect(trigger).not.toBeNull();
-    trigger?.focus();
-    await fireEvent.focusIn(trigger!);
+    try {
+      const { container } = render(AvatarGroup, { avatars: collaborators.slice(0, 1) });
 
-    await waitFor(() => {
-      const tooltip = document.body.querySelector<HTMLElement>('[role="tooltip"]');
-      expect(tooltip?.getAttribute('aria-hidden')).toBe('false');
-    });
+      const trigger = container.querySelector<HTMLElement>('.cinder-avatar-group__trigger');
+      expect(trigger).not.toBeNull();
+      trigger?.focus();
+      await fireEvent.focusIn(trigger!);
 
-    await fireEvent.keyDown(document, { key: 'Escape' });
-    await waitFor(() => {
-      const tooltip = document.body.querySelector<HTMLElement>('[role="tooltip"]');
-      expect(tooltip?.getAttribute('aria-hidden')).toBe('true');
-    });
+      await waitFor(() => {
+        const ownedTooltips = Array.from(
+          document.body.querySelectorAll<HTMLElement>('[role="tooltip"]'),
+        ).filter((tooltip) => !existingTooltips.has(tooltip));
+        expect(ownedTooltips).toHaveLength(1);
+        expect(ownedTooltips[0]?.getAttribute('aria-hidden')).toBe('false');
+      });
+
+      await fireEvent.keyDown(document, { key: 'Escape' });
+      await waitFor(() => {
+        const ownedTooltips = Array.from(
+          document.body.querySelectorAll<HTMLElement>('[role="tooltip"]'),
+        ).filter((tooltip) => !existingTooltips.has(tooltip));
+        expect(ownedTooltips).toHaveLength(1);
+        expect(ownedTooltips[0]?.getAttribute('aria-hidden')).toBe('true');
+      });
+    } finally {
+      unrelatedTooltip.remove();
+    }
   });
 
   test('raises the focused item above overlapped siblings', async () => {

--- a/packages/components/src/components/combobox/combobox.hydration.test.ts
+++ b/packages/components/src/components/combobox/combobox.hydration.test.ts
@@ -9,12 +9,13 @@
 import { describe, expect, test } from 'bun:test';
 
 import { setupHappyDom } from '../../test/happy-dom.ts';
-import { renderThenHydrate } from '../../test/hydrate.ts';
+import { prepareHydrationSource, renderThenHydrate } from '../../test/hydrate.ts';
 
 setupHappyDom();
 
 const { default: Combobox } = await import('./combobox.svelte');
 const sourcePath = new URL('./combobox.svelte', import.meta.url).pathname;
+await prepareHydrationSource(sourcePath);
 
 const fruits = [
   { value: 'apple', label: 'Apple' },

--- a/packages/components/src/components/json-schema-editor/json-schema-validator.ts
+++ b/packages/components/src/components/json-schema-editor/json-schema-validator.ts
@@ -22,6 +22,7 @@ import type Ajv from 'ajv';
 import type Ajv2019 from 'ajv/dist/2019.js';
 import type Ajv2020 from 'ajv/dist/2020.js';
 
+import { createRetryingLoaderCache } from '../../utilities/retrying-loader-cache.ts';
 import type {
   JsonSchemaDraft,
   JsonSchemaKnownDraft,
@@ -73,45 +74,15 @@ function resolveDraft(draft: JsonSchemaDraft | undefined): JsonSchemaKnownDraft 
   return draft;
 }
 
-// Dynamically imported Ajv constructors, cached so repeated validation calls
-// don't re-import. Each promise resolves once; concurrent callers await the
-// same in-flight import rather than triggering duplicate requests.
-let ajvClassPromise: Promise<typeof Ajv> | null = null;
-let ajv2019ClassPromise: Promise<typeof Ajv2019> | null = null;
-let ajv2020ClassPromise: Promise<typeof Ajv2020> | null = null;
-
-function loadAjv(): Promise<typeof Ajv> {
-  ajvClassPromise ??= import('ajv')
-    .then((module) => module.default)
-    .catch((error: unknown) => {
-      // Don't cache a rejection — a transient failure (network hiccup,
-      // dropped chunk) shouldn't permanently block every later validation
-      // in this session.
-      ajvClassPromise = null;
-      throw error;
-    });
-  return ajvClassPromise;
-}
-
-function loadAjv2019(): Promise<typeof Ajv2019> {
-  ajv2019ClassPromise ??= import('ajv/dist/2019.js')
-    .then((module) => module.default)
-    .catch((error: unknown) => {
-      ajv2019ClassPromise = null;
-      throw error;
-    });
-  return ajv2019ClassPromise;
-}
-
-function loadAjv2020(): Promise<typeof Ajv2020> {
-  ajv2020ClassPromise ??= import('ajv/dist/2020.js')
-    .then((module) => module.default)
-    .catch((error: unknown) => {
-      ajv2020ClassPromise = null;
-      throw error;
-    });
-  return ajv2020ClassPromise;
-}
+// Reuse the shared retrying cache so concurrent imports coalesce and a
+// transient rejected import is evicted for the next validation attempt.
+const loadAjv = createRetryingLoaderCache(() => import('ajv').then((module) => module.default));
+const loadAjv2019 = createRetryingLoaderCache(() =>
+  import('ajv/dist/2019.js').then((module) => module.default),
+);
+const loadAjv2020 = createRetryingLoaderCache(() =>
+  import('ajv/dist/2020.js').then((module) => module.default),
+);
 
 // Long-lived meta-schema validators. Safe to share — they don't compile the
 // user's schema, only validate against the meta-schema.

--- a/packages/components/src/components/menu-bar/menu-bar.test.ts
+++ b/packages/components/src/components/menu-bar/menu-bar.test.ts
@@ -28,11 +28,17 @@ mock.module('@floating-ui/dom', () => ({
 }));
 
 const { cleanup, fireEvent, render } = await import('@testing-library/svelte');
-const { renderToServerHtml } = await import('../../test/server-render.ts');
+const { prepareServerRenderSource, renderToServerHtml } =
+  await import('../../test/server-render.ts');
 const { tick } = await import('svelte');
 const { default: MenuBar } = await import('./menu-bar.svelte');
 const MENU_BAR_SOURCE = `${import.meta.dir}/menu-bar.svelte`;
 const MENU_BAR_DIRECTION_FIXTURE_SOURCE = `${import.meta.dir}/../../test/fixtures/menu-bar-direction-fixture.svelte`;
+
+await Promise.all([
+  prepareServerRenderSource(MENU_BAR_SOURCE),
+  prepareServerRenderSource(MENU_BAR_DIRECTION_FIXTURE_SOURCE),
+]);
 
 function fileEditViewMenus(onOpenRecent = () => {}) {
   return [

--- a/packages/components/src/test/hydrate.test.ts
+++ b/packages/components/src/test/hydrate.test.ts
@@ -17,7 +17,12 @@ import { setupHappyDom } from './happy-dom.ts';
 
 setupHappyDom();
 
-const { renderThenHydrate, __tempFileRegistryForTests } = await import('./hydrate.ts');
+const {
+  renderThenHydrate,
+  prepareHydrationSource,
+  __serverBuildCacheForTests,
+  __tempFileRegistryForTests,
+} = await import('./hydrate.ts');
 const { default: Input } = await import('../components/input/input.svelte');
 
 const INPUT_SOURCE = join(import.meta.dir, '..', 'components', 'input', 'input.svelte');
@@ -108,5 +113,14 @@ describe('renderThenHydrate', () => {
       throw Object.assign(new Error('already removed'), { code: 'ENOENT' });
     });
     expect(__tempFileRegistryForTests.paths.has(path)).toBe(false);
+  });
+
+  test('prepares one cached server build for concurrent hydration fixtures', async () => {
+    __serverBuildCacheForTests.evict(INPUT_SOURCE);
+    const buildsBefore = __serverBuildCacheForTests.buildCount(INPUT_SOURCE);
+
+    await Promise.all([prepareHydrationSource(INPUT_SOURCE), prepareHydrationSource(INPUT_SOURCE)]);
+
+    expect(__serverBuildCacheForTests.buildCount(INPUT_SOURCE) - buildsBefore).toBe(1);
   });
 });

--- a/packages/components/src/test/hydrate.ts
+++ b/packages/components/src/test/hydrate.ts
@@ -9,13 +9,14 @@
  * - Has DOM-property-only state (e.g. Checkbox `indeterminate`)
  * - Uses portals or overlay surfaces
  *
- * Why we rebuild inside the helper: the test runtime preloads the Bun Svelte
+ * Why this helper owns a server build: the test runtime preloads the Bun Svelte
  * plugin in `generate: 'client'` mode (see `scripts/preload.ts`). Calling
  * `svelte/server`'s `render()` against a client-compiled component crashes
  * because the client runtime expects a live effect tree. So this helper builds
  * the component and its complete local Svelte import graph with
  * `generate: 'server'`, writes the bundled JS to a temp file, dynamic-imports
- * it, and feeds that into `render()`.
+ * it, and feeds that into `render()`. Builds are memoized by source path because
+ * component fixtures are immutable during a test process.
  *
  * The helper does NOT itself assert — it returns a structured result so each
  * component test can express the contract it cares about (e.g. "no warnings"
@@ -90,6 +91,56 @@ function serverCompilePlugin(): BunPlugin {
     },
   };
 }
+
+const serverBuildCache = new Map<string, Promise<string>>();
+const serverBuildCounts = new Map<string, number>();
+
+function buildServerCode(sourcePath: string): Promise<string> {
+  const cached = serverBuildCache.get(sourcePath);
+  if (cached) return cached;
+
+  serverBuildCounts.set(sourcePath, (serverBuildCounts.get(sourcePath) ?? 0) + 1);
+  const pending = (async () => {
+    const build = await Bun.build({
+      entrypoints: [sourcePath],
+      target: 'bun',
+      conditions: ['svelte'],
+      external: ['svelte', 'svelte/*'],
+      plugins: [serverCompilePlugin()],
+    });
+    if (!build.success) {
+      const logText = build.logs.map((log) => String(log.message ?? log)).join('\n');
+      throw new Error(`hydrate: server build failed for ${sourcePath}\n${logText}`);
+    }
+    const artifact = build.outputs[0];
+    if (!artifact) throw new Error(`hydrate: no server artifact for ${sourcePath}`);
+    return artifact.text();
+  })();
+
+  serverBuildCache.set(sourcePath, pending);
+  void pending.catch(() => {
+    if (serverBuildCache.get(sourcePath) === pending) serverBuildCache.delete(sourcePath);
+  });
+  return pending;
+}
+
+/**
+ * Compile a component's server graph during fixture setup rather than charging
+ * that reusable work to the first timed hydration assertion.
+ */
+export async function prepareHydrationSource(sourcePath: string): Promise<void> {
+  await buildServerCode(sourcePath);
+}
+
+/** Test-only cache probes for the fixture-setup regression suite. */
+export const __serverBuildCacheForTests = {
+  evict(sourcePath: string): void {
+    serverBuildCache.delete(sourcePath);
+  },
+  buildCount(sourcePath: string): number {
+    return serverBuildCounts.get(sourcePath) ?? 0;
+  },
+};
 
 /**
  * Every temp SSR module this helper writes is registered here. The per-test
@@ -192,19 +243,7 @@ export async function renderThenHydrate<Props extends Record<string, unknown>>(
 ): Promise<HydrateResult> {
   setupHappyDom();
 
-  const build = await Bun.build({
-    entrypoints: [sourcePath],
-    target: 'bun',
-    conditions: ['svelte'],
-    external: ['svelte', 'svelte/*'],
-    plugins: [serverCompilePlugin()],
-  });
-  if (!build.success) {
-    const logText = build.logs.map((log) => String(log.message ?? log)).join('\n');
-    throw new Error(`hydrate: server build failed for ${sourcePath}\n${logText}`);
-  }
-  const artifact = build.outputs[0];
-  if (!artifact) throw new Error(`hydrate: no server artifact for ${sourcePath}`);
+  const compiledServerCode = await buildServerCode(sourcePath);
 
   const sveltePackageUrl = import.meta.resolve('svelte/package.json');
   const serverAbortSignalUrl = new URL('./src/internal/server/abort-signal.js', sveltePackageUrl)
@@ -269,8 +308,7 @@ export async function renderThenHydrate<Props extends Record<string, unknown>>(
         '',
       ].join('\n'),
     );
-    let serverCode = await artifact.text();
-    serverCode = serverCode
+    const serverCode = compiledServerCode
       .replaceAll(
         /from\s*['"]svelte\/internal\/server['"]/g,
         `from ${JSON.stringify(serverInternalUrl)}`,

--- a/packages/components/src/test/hydration-safety.ts
+++ b/packages/components/src/test/hydration-safety.ts
@@ -337,7 +337,7 @@ function assertDiscriminatorWorks(): Promise<void> {
     if (off === on) {
       throw new Error(
         'hydration-safety: the BROWSER build-flag discriminator is not working — the ' +
-          '`{#if BROWSER}` sentinel rendered identically under both build conditions. ' +
+          '`esm-env` probe bundled identically under both build conditions. ' +
           'Every check would be a false negative. Investigate esm-env resolution / Bun.build ' +
           'conditions before trusting any `buildFlagInvariant` result.',
       );

--- a/packages/components/src/test/hydration-safety.ts
+++ b/packages/components/src/test/hydration-safety.ts
@@ -112,6 +112,44 @@ function serverCompilePlugin(): BunPlugin {
 }
 
 /**
+ * Build the smallest possible `esm-env` probe under one export-condition set.
+ * The discriminator only needs to prove that Bun resolves `BROWSER` differently;
+ * compiling and rendering a Svelte component here would duplicate the expensive
+ * work performed by every real hydration-safety check.
+ */
+async function buildDiscriminatorProbe(conditions: readonly string[]): Promise<string> {
+  const entrypoint = 'hydration-safety-browser-flag-discriminator';
+  const namespace = 'hydration-safety-discriminator';
+  const build = await Bun.build({
+    entrypoints: [entrypoint],
+    target: 'bun',
+    conditions: [...conditions],
+    plugins: [
+      {
+        name: namespace,
+        setup(builder) {
+          builder.onResolve({ filter: new RegExp(`^${entrypoint}$`) }, () => ({
+            path: entrypoint,
+            namespace,
+          }));
+          builder.onLoad({ filter: /.*/, namespace }, () => ({
+            contents: "import { BROWSER } from 'esm-env'; export default BROWSER;",
+            loader: 'js',
+          }));
+        },
+      },
+    ],
+  });
+  if (!build.success) {
+    const logText = build.logs.map((log) => String(log.message ?? log)).join('\n');
+    throw new Error(`hydration-safety: build-flag discriminator failed\n${logText}`);
+  }
+  const artifact = build.outputs[0];
+  if (!artifact) throw new Error('hydration-safety: build-flag discriminator emitted no artifact');
+  return artifact.text();
+}
+
+/**
  * Build `componentPath` for the server with the given export `conditions`, then
  * server-render it and return the HTML body. `browser` in `conditions` makes
  * esm-env resolve `BROWSER=true`; omitting it resolves `BROWSER=false`.
@@ -281,20 +319,21 @@ export async function checkBuildFlagHydrationSafety(
 
 /**
  * Memoized fail-closed self-check: the whole helper rests on `Bun.build`'s
- * `conditions` flipping esm-env's `BROWSER` between the two renders. If that ever
+ * `conditions` flipping esm-env's `BROWSER` between the two builds. If that ever
  * stops working (an esm-env export-map change, a resolution-cache quirk), every
  * `{#if BROWSER}` component would render identically both ways and be silently
  * reported `buildFlagInvariant: true` — a false negative on the exact bug class
- * this exists to catch. So before the first real check, render a sentinel that
- * is KNOWN to diverge on `BROWSER` and assert it actually does. Memoized to one
- * build pair per process so it doesn't double the cost of every call.
+ * this exists to catch. So before the first real check, bundle a minimal module
+ * that exports `BROWSER` and assert the two artifacts differ. The helper's own
+ * fixture tests separately prove that this build split changes Svelte SSR output.
+ * Memoized to one small build pair per process so it does not add two full Svelte
+ * compiles and renders to the first real component check.
  */
 let discriminatorVerified: Promise<void> | null = null;
 function assertDiscriminatorWorks(): Promise<void> {
   discriminatorVerified ??= (async () => {
-    const sentinel = join(here, 'fixtures', 'hydration-probe-browser-flag.svelte');
-    const off = await renderWithConditions(sentinel, ['svelte'], {});
-    const on = await renderWithConditions(sentinel, ['browser', 'svelte'], {});
+    const off = await buildDiscriminatorProbe(['svelte']);
+    const on = await buildDiscriminatorProbe(['browser', 'svelte']);
     if (off === on) {
       throw new Error(
         'hydration-safety: the BROWSER build-flag discriminator is not working — the ' +

--- a/packages/components/src/test/server-render.test.ts
+++ b/packages/components/src/test/server-render.test.ts
@@ -1,0 +1,19 @@
+import { join } from 'node:path';
+
+import { expect, test } from 'bun:test';
+
+import { __serverRenderBuildCacheForTests, prepareServerRenderSource } from './server-render.ts';
+
+const INPUT_SOURCE = join(import.meta.dir, '..', 'components', 'input', 'input.svelte');
+
+test('prepareServerRenderSource coalesces concurrent builds for one immutable fixture', async () => {
+  __serverRenderBuildCacheForTests.evict(INPUT_SOURCE);
+  const buildCountBefore = __serverRenderBuildCacheForTests.buildCount(INPUT_SOURCE);
+
+  await Promise.all([
+    prepareServerRenderSource(INPUT_SOURCE),
+    prepareServerRenderSource(INPUT_SOURCE),
+  ]);
+
+  expect(__serverRenderBuildCacheForTests.buildCount(INPUT_SOURCE) - buildCountBefore).toBe(1);
+});

--- a/packages/components/src/test/server-render.ts
+++ b/packages/components/src/test/server-render.ts
@@ -8,12 +8,13 @@
  * client-only load/error state (image) does NOT appear in the server output,
  * so there is no hydration mismatch and no client-only markup leaks into SSR.
  *
- * Why we recompile inside the helper: the test runtime preloads the Bun Svelte
+ * Why this helper owns a server build: the test runtime preloads the Bun Svelte
  * plugin in `generate: 'client'` mode (see `scripts/preload.ts`). The client
  * compilation cannot be fed to `svelte/server`'s `render()` — it expects a live
  * effect tree. So this helper reads the `.svelte` source directly, compiles it
  * with `generate: 'server'`, writes the JS to a temp file next to the source,
- * dynamic-imports it, and feeds that into `render()`.
+ * dynamic-imports it, and feeds that into `render()`. Builds are memoized by
+ * source path because component fixtures are immutable during a test process.
  *
  * Why we rewrite the bare `svelte` import: the test process runs under the
  * `browser` export condition, which resolves `svelte` to its client build.
@@ -86,6 +87,53 @@ function serverCompilePlugin(): BunPlugin {
   };
 }
 
+const serverBuildCache = new Map<string, Promise<string>>();
+const serverBuildCounts = new Map<string, number>();
+
+function buildServerCode(sourcePath: string): Promise<string> {
+  const cached = serverBuildCache.get(sourcePath);
+  if (cached) return cached;
+
+  serverBuildCounts.set(sourcePath, (serverBuildCounts.get(sourcePath) ?? 0) + 1);
+  const pending = (async () => {
+    const build = await Bun.build({
+      entrypoints: [sourcePath],
+      target: 'bun',
+      conditions: ['svelte'],
+      external: ['svelte', 'svelte/*'],
+      plugins: [serverCompilePlugin()],
+    });
+    if (!build.success) {
+      const logText = build.logs.map((log) => String(log.message ?? log)).join('\n');
+      throw new Error(`server-render: server build failed for ${sourcePath}\n${logText}`);
+    }
+    const artifact = build.outputs[0];
+    if (!artifact) throw new Error(`server-render: no server artifact for ${sourcePath}`);
+    return artifact.text();
+  })();
+
+  serverBuildCache.set(sourcePath, pending);
+  void pending.catch(() => {
+    if (serverBuildCache.get(sourcePath) === pending) serverBuildCache.delete(sourcePath);
+  });
+  return pending;
+}
+
+/** Compile a component's reusable server graph during fixture setup. */
+export async function prepareServerRenderSource(sourcePath: string): Promise<void> {
+  await buildServerCode(sourcePath);
+}
+
+/** Test-only cache probes for the fixture-setup regression suite. */
+export const __serverRenderBuildCacheForTests = {
+  evict(sourcePath: string): void {
+    serverBuildCache.delete(sourcePath);
+  },
+  buildCount(sourcePath: string): number {
+    return serverBuildCounts.get(sourcePath) ?? 0;
+  },
+};
+
 /**
  * Render `sourcePath`'s component on the server and return the emitted HTML.
  *
@@ -97,19 +145,7 @@ export async function renderToServerHtml<Props extends Record<string, unknown>>(
   sourcePath: string,
   props: Props = {} as Props,
 ): Promise<string> {
-  const build = await Bun.build({
-    entrypoints: [sourcePath],
-    target: 'bun',
-    conditions: ['svelte'],
-    external: ['svelte', 'svelte/*'],
-    plugins: [serverCompilePlugin()],
-  });
-  if (!build.success) {
-    const logText = build.logs.map((log) => String(log.message ?? log)).join('\n');
-    throw new Error(`server-render: server build failed for ${sourcePath}\n${logText}`);
-  }
-  const artifact = build.outputs[0];
-  if (!artifact) throw new Error(`server-render: no server artifact for ${sourcePath}`);
+  const compiledServerCode = await buildServerCode(sourcePath);
 
   // Resolve Svelte's server index and repoint the compiled module's bare
   // `svelte` imports at it. The temp module is imported in a `browser`-condition
@@ -154,7 +190,7 @@ export async function renderToServerHtml<Props extends Record<string, unknown>>(
       '',
     ].join('\n'),
   );
-  let code = await artifact.text();
+  let code = compiledServerCode;
   code = code
     .replaceAll(
       /from\s*['"]svelte\/internal\/server['"]/g,


### PR DESCRIPTION
Closes #834

- make tooltip assertions render-owned instead of selecting stale portal residue
- precompile and cache reusable SSR and hydration fixtures outside timed assertions
- keep optional loader branches measurable and retryable
- baseline the Sidebar viewport-owned responsive query introduced on main

Validation: `bun run validate`