### PR TITLE
BarChart: size horizontal category labels within the viewport

### DIFF
--- a/.changeset/wide-bars-fit.md
+++ b/.changeset/wide-bars-fit.md
@@ -1,0 +1,5 @@
+---
+'@lostgradient/cinder': patch
+---
+
+Keep horizontal BarChart category labels visible without sacrificing the plot area.

--- a/packages/components/src/_internal/chart/chart-utilities.test.ts
+++ b/packages/components/src/_internal/chart/chart-utilities.test.ts
@@ -689,7 +689,7 @@ describe('createBarModel', () => {
     });
   });
 
-  test('reserves enough horizontal label space for wide glyphs', () => {
+  test('reserves horizontal label space from estimated character width', () => {
     const model = createBarModel({
       data: [{ status: 'WWWWWWWWWW', count: 9 }],
       categoryKey: 'status',

--- a/packages/components/src/_internal/chart/chart-utilities.test.ts
+++ b/packages/components/src/_internal/chart/chart-utilities.test.ts
@@ -682,8 +682,48 @@ describe('createBarModel', () => {
       mode: 'grouped',
     });
 
-    expect(model.geometry.marginLeft).toBeGreaterThan(48);
-    expect(model.geometry.marginLeft + (model.categoryTicks[0]?.x ?? 0)).toBeGreaterThan(0);
+    expect(model.geometry.marginLeft).toBe(124);
+    expect(model.categoryTicks[0]).toMatchObject({
+      label: 'Completed',
+      fullLabel: 'Completed',
+    });
+  });
+
+  test('reserves enough horizontal label space for wide glyphs', () => {
+    const model = createBarModel({
+      data: [{ status: 'WWWWWWWWWW', count: 9 }],
+      categoryKey: 'status',
+      series: [{ id: 'count', label: 'Count', valueKey: 'count' }],
+      hiddenSeriesIds: [],
+      width: 640,
+      height: 280,
+      orientation: 'horizontal',
+      mode: 'grouped',
+    });
+
+    expect(model.geometry.marginLeft).toBe(136);
+    expect(model.categoryTicks[0]?.label).toBe('WWWWWWWWWW');
+  });
+
+  test('truncates extreme horizontal labels without removing the plot', () => {
+    const fullLabel = 'W'.repeat(40);
+    const model = createBarModel({
+      data: [{ status: fullLabel, count: 9 }],
+      categoryKey: 'status',
+      series: [{ id: 'count', label: 'Count', valueKey: 'count' }],
+      hiddenSeriesIds: [],
+      width: 320,
+      height: 280,
+      orientation: 'horizontal',
+      mode: 'grouped',
+    });
+
+    expect(model.geometry.marginLeft).toBe(128);
+    expect(model.geometry.plotWidth).toBe(176);
+    expect(model.categoryTicks[0]).toMatchObject({
+      label: 'WWWWWWWW…',
+      fullLabel,
+    });
   });
 
   test('stacked domain reflects visible series only', () => {

--- a/packages/components/src/_internal/chart/chart-utilities.test.ts
+++ b/packages/components/src/_internal/chart/chart-utilities.test.ts
@@ -670,6 +670,22 @@ describe('createBarModel', () => {
     expect(model.bars).toHaveLength(0);
   });
 
+  test('expands the horizontal label margin for long category labels', () => {
+    const model = createBarModel({
+      data: [{ status: 'Completed', count: 9 }],
+      categoryKey: 'status',
+      series: [{ id: 'count', label: 'Count', valueKey: 'count' }],
+      hiddenSeriesIds: [],
+      width: 640,
+      height: 280,
+      orientation: 'horizontal',
+      mode: 'grouped',
+    });
+
+    expect(model.geometry.marginLeft).toBeGreaterThan(48);
+    expect(model.geometry.marginLeft + (model.categoryTicks[0]?.x ?? 0)).toBeGreaterThan(0);
+  });
+
   test('stacked domain reflects visible series only', () => {
     const data = [
       { month: 'Jan', a: 10, b: 100 },

--- a/packages/components/src/_internal/chart/chart-utilities.ts
+++ b/packages/components/src/_internal/chart/chart-utilities.ts
@@ -531,7 +531,6 @@ export function createBarModel(options: {
   assertValidTickCount('bar-chart', xAxis);
   assertValidTickCount('bar-chart', yAxis);
 
-  const geometry = createGeometry(width, height);
   const categories: NormalizedXValue[] = [];
   const seenCategories = new Set<string>();
   const categoryKinds = new Set<string>();
@@ -594,6 +593,14 @@ export function createBarModel(options: {
   }
 
   const sortedCategories = sortXValues(categories);
+  const categoryLabels = sortedCategories.map((category, index) =>
+    formatXValue(category, orientation === 'vertical' ? xAxis : yAxis, { index }),
+  );
+  const geometry = createGeometry(
+    width,
+    height,
+    orientation === 'horizontal' ? estimateHorizontalCategoryLabelMargin(categoryLabels) : 48,
+  );
   // Domain is computed from visible series only — same convention as cartesian
   // charts — so the value scale shrinks correctly when a series is hidden.
   const valueDomain = createPaddedDomain(
@@ -633,7 +640,7 @@ export function createBarModel(options: {
     const categoryPosition = categoryScale(category.key) ?? 0;
     return {
       categoryKey: category.key,
-      label: formatXValue(category, orientation === 'vertical' ? xAxis : yAxis, { index }),
+      label: categoryLabels[index] ?? category.label,
       x: orientation === 'vertical' ? categoryPosition + categoryScale.bandwidth() / 2 : -8,
       y:
         orientation === 'vertical'
@@ -818,11 +825,10 @@ export function legendVisible(legendPosition: ChartLegendPosition, seriesCount: 
   return legendPosition !== 'none' && seriesCount > 0;
 }
 
-function createGeometry(width: number, height: number): ChartGeometry {
+function createGeometry(width: number, height: number, marginLeft = 48): ChartGeometry {
   const marginTop = 16;
   const marginRight = 16;
   const marginBottom = 36;
-  const marginLeft = 48;
   return {
     plotWidth: Math.max(1, width - marginLeft - marginRight),
     plotHeight: Math.max(1, height - marginTop - marginBottom),
@@ -831,6 +837,14 @@ function createGeometry(width: number, height: number): ChartGeometry {
     marginBottom,
     marginLeft,
   };
+}
+
+function estimateHorizontalCategoryLabelMargin(labels: string[]): number {
+  const longestLabel = labels.reduce(
+    (longest, label) => (label.length > longest.length ? label : longest),
+    '',
+  );
+  return Math.max(48, longestLabel.length * 8 + 16);
 }
 
 function normalizeNumericValue(

--- a/packages/components/src/_internal/chart/chart-utilities.ts
+++ b/packages/components/src/_internal/chart/chart-utilities.ts
@@ -124,6 +124,7 @@ export type BarChartModel = {
   categoryTicks: Array<{
     categoryKey: string;
     label: string;
+    fullLabel: string;
     x: number;
     y: number;
   }>;
@@ -596,11 +597,11 @@ export function createBarModel(options: {
   const categoryLabels = sortedCategories.map((category, index) =>
     formatXValue(category, orientation === 'vertical' ? xAxis : yAxis, { index }),
   );
-  const geometry = createGeometry(
-    width,
-    height,
-    orientation === 'horizontal' ? estimateHorizontalCategoryLabelMargin(categoryLabels) : 48,
-  );
+  const horizontalCategoryLabelLayout =
+    orientation === 'horizontal'
+      ? createHorizontalCategoryLabelLayout(categoryLabels, width)
+      : undefined;
+  const geometry = createGeometry(width, height, horizontalCategoryLabelLayout?.marginLeft);
   // Domain is computed from visible series only — same convention as cartesian
   // charts — so the value scale shrinks correctly when a series is hidden.
   const valueDomain = createPaddedDomain(
@@ -640,7 +641,9 @@ export function createBarModel(options: {
     const categoryPosition = categoryScale(category.key) ?? 0;
     return {
       categoryKey: category.key,
-      label: categoryLabels[index] ?? category.label,
+      label:
+        horizontalCategoryLabelLayout?.labels[index] ?? categoryLabels[index] ?? category.label,
+      fullLabel: categoryLabels[index] ?? category.label,
       x: orientation === 'vertical' ? categoryPosition + categoryScale.bandwidth() / 2 : -8,
       y:
         orientation === 'vertical'
@@ -825,7 +828,17 @@ export function legendVisible(legendPosition: ChartLegendPosition, seriesCount: 
   return legendPosition !== 'none' && seriesCount > 0;
 }
 
-function createGeometry(width: number, height: number, marginLeft = 48): ChartGeometry {
+const DEFAULT_CHART_MARGIN_LEFT = 48;
+const HORIZONTAL_CATEGORY_LABEL_CHARACTER_WIDTH = 12;
+const HORIZONTAL_CATEGORY_LABEL_GAP = 8;
+const HORIZONTAL_CATEGORY_LABEL_OUTER_PADDING = 8;
+const MAXIMUM_HORIZONTAL_CATEGORY_LABEL_FRACTION = 0.4;
+
+function createGeometry(
+  width: number,
+  height: number,
+  marginLeft = DEFAULT_CHART_MARGIN_LEFT,
+): ChartGeometry {
   const marginTop = 16;
   const marginRight = 16;
   const marginBottom = 36;
@@ -839,12 +852,49 @@ function createGeometry(width: number, height: number, marginLeft = 48): ChartGe
   };
 }
 
-function estimateHorizontalCategoryLabelMargin(labels: string[]): number {
-  const longestLabel = labels.reduce(
-    (longest, label) => (label.length > longest.length ? label : longest),
-    '',
+function createHorizontalCategoryLabelLayout(
+  labels: string[],
+  chartWidth: number,
+): { labels: string[]; marginLeft: number } {
+  const maximumMarginLeft = Math.max(
+    DEFAULT_CHART_MARGIN_LEFT,
+    Math.floor(chartWidth * MAXIMUM_HORIZONTAL_CATEGORY_LABEL_FRACTION),
   );
-  return Math.max(48, longestLabel.length * 8 + 16);
+  const requestedMarginLeft =
+    Math.max(0, ...labels.map(estimateHorizontalCategoryLabelWidth)) +
+    HORIZONTAL_CATEGORY_LABEL_GAP +
+    HORIZONTAL_CATEGORY_LABEL_OUTER_PADDING;
+  const marginLeft = Math.min(
+    maximumMarginLeft,
+    Math.max(DEFAULT_CHART_MARGIN_LEFT, requestedMarginLeft),
+  );
+  const availableLabelWidth = Math.max(
+    0,
+    marginLeft - HORIZONTAL_CATEGORY_LABEL_GAP - HORIZONTAL_CATEGORY_LABEL_OUTER_PADDING,
+  );
+
+  return {
+    marginLeft,
+    labels: labels.map((label) => truncateHorizontalCategoryLabel(label, availableLabelWidth)),
+  };
+}
+
+function estimateHorizontalCategoryLabelWidth(label: string): number {
+  return Array.from(label).length * HORIZONTAL_CATEGORY_LABEL_CHARACTER_WIDTH;
+}
+
+function truncateHorizontalCategoryLabel(label: string, availableWidth: number): string {
+  if (estimateHorizontalCategoryLabelWidth(label) <= availableWidth) return label;
+
+  const availableCharacterCount = Math.floor(
+    availableWidth / HORIZONTAL_CATEGORY_LABEL_CHARACTER_WIDTH,
+  );
+  if (availableCharacterCount <= 0) return '';
+  if (availableCharacterCount === 1) return '…';
+
+  return `${Array.from(label)
+    .slice(0, availableCharacterCount - 1)
+    .join('')}…`;
 }
 
 function normalizeNumericValue(

--- a/packages/components/src/_internal/chart/chart-utilities.ts
+++ b/packages/components/src/_internal/chart/chart-utilities.ts
@@ -644,7 +644,10 @@ export function createBarModel(options: {
       label:
         horizontalCategoryLabelLayout?.labels[index] ?? categoryLabels[index] ?? category.label,
       fullLabel: categoryLabels[index] ?? category.label,
-      x: orientation === 'vertical' ? categoryPosition + categoryScale.bandwidth() / 2 : -8,
+      x:
+        orientation === 'vertical'
+          ? categoryPosition + categoryScale.bandwidth() / 2
+          : -HORIZONTAL_CATEGORY_LABEL_GAP,
       y:
         orientation === 'vertical'
           ? geometry.plotHeight + 20
@@ -860,10 +863,12 @@ function createHorizontalCategoryLabelLayout(
     DEFAULT_CHART_MARGIN_LEFT,
     Math.floor(chartWidth * MAXIMUM_HORIZONTAL_CATEGORY_LABEL_FRACTION),
   );
+  let longestLabelWidth = 0;
+  for (const label of labels) {
+    longestLabelWidth = Math.max(longestLabelWidth, estimateHorizontalCategoryLabelWidth(label));
+  }
   const requestedMarginLeft =
-    Math.max(0, ...labels.map(estimateHorizontalCategoryLabelWidth)) +
-    HORIZONTAL_CATEGORY_LABEL_GAP +
-    HORIZONTAL_CATEGORY_LABEL_OUTER_PADDING;
+    longestLabelWidth + HORIZONTAL_CATEGORY_LABEL_GAP + HORIZONTAL_CATEGORY_LABEL_OUTER_PADDING;
   const marginLeft = Math.min(
     maximumMarginLeft,
     Math.max(DEFAULT_CHART_MARGIN_LEFT, requestedMarginLeft),

--- a/packages/components/src/components/bar-chart/bar-chart.examples.json
+++ b/packages/components/src/components/bar-chart/bar-chart.examples.json
@@ -7,7 +7,7 @@
       "id": "horizontal-grouped",
       "title": "Horizontal incidents",
       "description": "A horizontal grouped bar chart for incident counts by severity.",
-      "code": "<script lang=\"ts\">\n  import { BarChart } from '@lostgradient/cinder/bar-chart';\n\n  const data = [\n    { severity: 'Critical', current: 8, previous: 10 },\n    { severity: 'High', current: 18, previous: 22 },\n    { severity: 'Medium', current: 41, previous: 39 },\n  ];\n  const series = [\n    { id: 'current', label: 'Current', valueKey: 'current' },\n    { id: 'previous', label: 'Previous', valueKey: 'previous' },\n  ];\n</script>\n\n<BarChart\n  label=\"Incidents by severity\"\n  {data}\n  categoryKey=\"severity\"\n  {series}\n  orientation=\"horizontal\"\n/>\n"
+      "code": "<script lang=\"ts\">\n  import { BarChart } from '@lostgradient/cinder/bar-chart';\n\n  const data = [\n    { severity: 'Critical escalation', current: 8, previous: 10 },\n    { severity: 'High', current: 18, previous: 22 },\n    { severity: 'Medium', current: 41, previous: 39 },\n  ];\n  const series = [\n    { id: 'current', label: 'Current', valueKey: 'current' },\n    { id: 'previous', label: 'Previous', valueKey: 'previous' },\n  ];\n</script>\n\n<BarChart\n  label=\"Incidents by severity\"\n  {data}\n  categoryKey=\"severity\"\n  {series}\n  orientation=\"horizontal\"\n/>\n"
     },
     {
       "id": "vertical-grouped",

--- a/packages/components/src/components/bar-chart/bar-chart.svelte
+++ b/packages/components/src/components/bar-chart/bar-chart.svelte
@@ -277,7 +277,9 @@
             x={tick.x}
             y={tick.y}
             text-anchor={orientation === 'vertical' ? 'middle' : 'end'}
-            dominant-baseline={orientation === 'vertical' ? undefined : 'middle'}>{tick.label}</text
+            dominant-baseline={orientation === 'vertical' ? undefined : 'middle'}
+            >{#if tick.label !== tick.fullLabel}<title>{tick.fullLabel}</title
+              >{/if}{tick.label}</text
           >
         {/each}
         {#if interaction.activeTarget}

--- a/packages/playground/src/examples/bar-chart/horizontal-grouped.example.svelte
+++ b/packages/playground/src/examples/bar-chart/horizontal-grouped.example.svelte
@@ -7,7 +7,7 @@
   import { BarChart } from '@lostgradient/cinder/bar-chart';
 
   const data = [
-    { severity: 'Critical', current: 8, previous: 10 },
+    { severity: 'Critical escalation', current: 8, previous: 10 },
     { severity: 'High', current: 18, previous: 22 },
     { severity: 'Medium', current: 41, previous: 39 },
   ];

--- a/packages/testing/tests/chart-focus-rings.playwright.ts
+++ b/packages/testing/tests/chart-focus-rings.playwright.ts
@@ -470,4 +470,33 @@ test.describe('chart SVG focus rings', () => {
     await expect(root.locator('[role="tooltip"]').first()).toContainText(chart.tooltipText);
     await expect(root.locator(`.${chart.hitSurfaceClass}`).first()).toBeVisible();
   });
+
+  test('horizontal bar-chart category labels stay inside the SVG viewport', async ({ page }) => {
+    const chart = charts[2]!;
+    await page.goto(routeFor(chart), { waitUntil: 'load' });
+    await page.waitForLoadState('networkidle');
+
+    const label = page
+      .locator(
+        '.cinder-bar-chart[data-cinder-orientation="horizontal"] .cinder-bar-chart__tick-label',
+      )
+      .filter({ hasText: 'Critical escalation' })
+      .first();
+    await expect(label).toHaveText('Critical escalation');
+
+    const root = label.locator(
+      'xpath=ancestor::*[contains(concat(" ", normalize-space(@class), " "), " cinder-bar-chart ")]',
+    );
+    const svg = root.locator('svg').first();
+    const bar = root.locator('.cinder-bar-chart__bar').first();
+    const labelBox = await label.boundingBox();
+    const svgBox = await svg.boundingBox();
+    const barBox = await bar.boundingBox();
+    if (!labelBox || !svgBox || !barBox) {
+      throw new Error('Missing horizontal bar-chart label, SVG, or bar bounds.');
+    }
+
+    expectBoxInside(labelBox, svgBox, 'horizontal bar-chart category label inside SVG');
+    expect(barBox.width, 'horizontal bar-chart preserves plot width').toBeGreaterThan(0);
+  });
 });


### PR DESCRIPTION
## Summary

- size the horizontal category-axis margin from formatted label text
- cap the label region at 40% of the chart width and truncate extreme labels with an accessible SVG title
- add model coverage for normal, wide-glyph, and bounded layouts plus a browser regression that keeps labels inside the SVG viewport

## Verification

- `bun test packages/components/src/_internal/chart/chart-utilities.test.ts packages/components/src/components/bar-chart/bar-chart.test.ts`
- `bun run --filter=@cinder/testing test:playwright -- packages/testing/tests/chart-focus-rings.playwright.ts --grep "horizontal bar-chart category labels"`
- `bun run --filter=@lostgradient/cinder components:check`
- `bun run validate`

Closes #839