### PR TITLE
feat(chat): add Mermaid artifact renderer extension point

### DIFF
--- a/.changeset/calm-rivers-render.md
+++ b/.changeset/calm-rivers-render.md
@@ -1,0 +1,5 @@
+---
+'@lostgradient/chat': patch
+---
+
+Add a typed `mermaidRenderer` snippet to `ArtifactViewer` so applications can render Mermaid source with their chosen integration while retaining an explicit source fallback when no renderer is provided.

--- a/packages/chat/README.md
+++ b/packages/chat/README.md
@@ -40,3 +40,26 @@ Chat's component stylesheet is included by the component entry. Applications tha
 - `@lostgradient/chat/conversation-list` — conversation navigation, summaries, unread counts, and selection.
 
 Each component entry also publishes `/schema`, `/variables`, `/styles`, and `/examples` artifacts. The package-wide machine-readable index is available from `@lostgradient/chat/manifest`.
+
+## Rendering Mermaid artifacts
+
+`ArtifactViewer` renders HTML and SVG in sandboxed iframes and renders code as escaped source. Mermaid stays consumer-owned so applications can choose their Mermaid version, configuration, and security policy. Without a renderer, Mermaid artifacts show their source and an explicit fallback note.
+
+Pass a `mermaidRenderer` snippet to delegate only the Mermaid branch to an application component:
+
+```svelte
+<script lang="ts">
+  import { ArtifactViewer } from '@lostgradient/chat';
+  import MermaidDiagram from './mermaid-diagram.svelte';
+
+  const content = 'graph TD; Request-->Response;';
+</script>
+
+{#snippet mermaidRenderer(source, contentType)}
+  <MermaidDiagram {source} ariaLabel={`${contentType} diagram`} />
+{/snippet}
+
+<ArtifactViewer type="mermaid" {content} {mermaidRenderer} />
+```
+
+The snippet has type `Snippet<[content: string, type: 'mermaid']>`. `ArtifactViewer` invokes it only when `type` is `mermaid`; HTML, SVG, and code continue through the built-in renderers. The application-owned component is responsible for loading Mermaid, handling asynchronous rendering and errors, and applying its required content-safety policy.

--- a/packages/chat/src/lib/components/chat/artifact/artifact-viewer.svelte
+++ b/packages/chat/src/lib/components/chat/artifact/artifact-viewer.svelte
@@ -1,12 +1,5 @@
 <script lang="ts" module>
-  export type ArtifactContentType = 'html' | 'svg' | 'code' | 'mermaid';
-
-  export type ArtifactViewerProps = {
-    type: ArtifactContentType;
-    content: string;
-    language?: string;
-    title?: string;
-  };
+  import type { ArtifactViewerProps } from './artifact-viewer.types.ts';
 
   /**
    * Wrap SVG content in a minimal HTML document for sandboxed iframe rendering.
@@ -20,7 +13,7 @@
 </script>
 
 <script lang="ts">
-  let { type, content, language, title }: ArtifactViewerProps = $props();
+  let { type, content, language, title, mermaidRenderer }: ArtifactViewerProps = $props();
 
   const svgDocument = $derived(type === 'svg' ? wrapSvgInHtml(content) : '');
 </script>
@@ -47,10 +40,14 @@
   </div>
 {:else if type === 'mermaid'}
   <div class="artifact-viewer artifact-viewer-mermaid">
-    <pre class="artifact-code-block" data-language="mermaid"><code>{content}</code></pre>
-    <p class="artifact-mermaid-note" aria-live="polite">
-      Mermaid diagram source. Install the Mermaid library to render diagrams.
-    </p>
+    {#if mermaidRenderer}
+      {@render mermaidRenderer(content, 'mermaid')}
+    {:else}
+      <pre class="artifact-code-block" data-language="mermaid"><code>{content}</code></pre>
+      <p class="artifact-mermaid-note" aria-live="polite">
+        No Mermaid renderer was provided. Showing diagram source.
+      </p>
+    {/if}
   </div>
 {/if}
 

--- a/packages/chat/src/lib/components/chat/artifact/artifact-viewer.svelte
+++ b/packages/chat/src/lib/components/chat/artifact/artifact-viewer.svelte
@@ -1,6 +1,4 @@
 <script lang="ts" module>
-  import type { ArtifactViewerProps } from './artifact-viewer.types.ts';
-
   /**
    * Wrap SVG content in a minimal HTML document for sandboxed iframe rendering.
    * This is the safe approach: the SVG runs in a sandboxed origin rather than
@@ -13,6 +11,8 @@
 </script>
 
 <script lang="ts">
+  import type { ArtifactViewerProps } from './artifact-viewer.types.ts';
+
   let { type, content, language, title, mermaidRenderer }: ArtifactViewerProps = $props();
 
   const svgDocument = $derived(type === 'svg' ? wrapSvgInHtml(content) : '');

--- a/packages/chat/src/lib/components/chat/artifact/artifact-viewer.types.ts
+++ b/packages/chat/src/lib/components/chat/artifact/artifact-viewer.types.ts
@@ -1,0 +1,18 @@
+import type { Snippet } from 'svelte';
+
+export type ArtifactContentType = 'html' | 'svg' | 'code' | 'mermaid';
+
+/** Consumer-owned Mermaid rendering snippet. */
+export type MermaidRenderer = Snippet<[content: string, type: 'mermaid']>;
+
+export type ArtifactViewerProps = {
+  type: ArtifactContentType;
+  content: string;
+  language?: string;
+  title?: string;
+  /**
+   * Renders Mermaid source with the consumer's chosen integration. Invoked only
+   * for `type="mermaid"`; otherwise ArtifactViewer uses its built-in renderer.
+   */
+  mermaidRenderer?: MermaidRenderer;
+};

--- a/packages/chat/src/lib/components/chat/artifact/artifact.test.ts
+++ b/packages/chat/src/lib/components/chat/artifact/artifact.test.ts
@@ -1,15 +1,26 @@
 /// <reference lib="dom" />
 import { fireEvent, render } from '@testing-library/svelte';
 import { describe, expect, mock, test } from 'bun:test';
+import { createRawSnippet } from 'svelte';
 
+import type { ArtifactViewerProps, MermaidRenderer } from '../index.ts';
 import ArtifactPanelFixture from './artifact-panel-fixture.svelte';
 import ArtifactViewer from './artifact-viewer.svelte';
 import ChatArtifactLayoutFixture from './chat-artifact-layout-fixture.svelte';
 
 describe('Chat artifact components', () => {
-  test('renders every supported artifact content type', async () => {
+  test('renders the built-in HTML, SVG, and code content types without invoking the Mermaid renderer', async () => {
+    const rendererInvocation = mock((_getContent: () => string, _getType: () => 'mermaid') => ({
+      render: () => '<output>Rendered Mermaid</output>',
+    }));
+    const mermaidRenderer: MermaidRenderer = createRawSnippet(rendererInvocation);
     const { container, rerender } = render(ArtifactViewer, {
-      props: { type: 'html', content: '<strong>HTML</strong>', title: 'Preview' },
+      props: {
+        type: 'html',
+        content: '<strong>HTML</strong>',
+        title: 'Preview',
+        mermaidRenderer,
+      },
     });
     expect(container.querySelector('iframe')?.getAttribute('sandbox')).toBe('');
     expect(container.querySelector('iframe')?.getAttribute('title')).toBe('Preview');
@@ -19,9 +30,41 @@ describe('Chat artifact components', () => {
 
     await rerender({ type: 'code', content: 'const value = 1;', language: 'typescript' });
     expect(container.querySelector('pre')?.dataset['language']).toBe('typescript');
+    expect(container.querySelector('code')?.textContent).toBe('const value = 1;');
+    expect(rendererInvocation).not.toHaveBeenCalled();
+  });
 
-    await rerender({ type: 'mermaid', content: 'graph TD; A-->B;' });
-    expect(container.textContent).toContain('Mermaid diagram source');
+  test('renders Mermaid source with an honest fallback when no renderer is provided', () => {
+    const { container } = render(ArtifactViewer, {
+      props: { type: 'mermaid', content: 'graph TD; A-->B;' },
+    });
+
+    expect(container.querySelector('pre')?.dataset['language']).toBe('mermaid');
+    expect(container.querySelector('code')?.textContent).toBe('graph TD; A-->B;');
+    expect(container.textContent).toContain('No Mermaid renderer was provided');
+  });
+
+  test('invokes a custom Mermaid renderer with the content and content type', () => {
+    const rendererInvocation = mock((getContent: () => string, getType: () => 'mermaid') => ({
+      render: () =>
+        `<output data-testid="mermaid-renderer" data-type="${getType()}">${getContent()}</output>`,
+    }));
+    const mermaidRenderer: MermaidRenderer = createRawSnippet(rendererInvocation);
+    const props = {
+      type: 'mermaid',
+      content: 'graph TD; Start-->Finish;',
+      mermaidRenderer,
+    } satisfies ArtifactViewerProps;
+    const { container } = render(ArtifactViewer, {
+      props,
+    });
+
+    const renderedDiagram = container.querySelector('[data-testid="mermaid-renderer"]');
+    expect(rendererInvocation).toHaveBeenCalledTimes(1);
+    expect(renderedDiagram?.getAttribute('data-type')).toBe('mermaid');
+    expect(renderedDiagram?.textContent).toBe('graph TD; Start-->Finish;');
+    expect(container.querySelector('.artifact-mermaid-note')).toBeNull();
+    expect(container.querySelector('pre')).toBeNull();
   });
 
   test('renders panel content, focuses close, and dispatches close', async () => {

--- a/packages/chat/src/lib/components/chat/artifact/index.ts
+++ b/packages/chat/src/lib/components/chat/artifact/index.ts
@@ -1,3 +1,8 @@
 export { default as ArtifactPanel } from './artifact-panel.svelte';
 export { default as ArtifactViewer } from './artifact-viewer.svelte';
+export type {
+  ArtifactContentType,
+  ArtifactViewerProps,
+  MermaidRenderer,
+} from './artifact-viewer.types.ts';
 export { default as ChatArtifactLayout } from './chat-artifact-layout.svelte';

--- a/packages/chat/src/lib/components/chat/index.ts
+++ b/packages/chat/src/lib/components/chat/index.ts
@@ -167,3 +167,8 @@ export { ConversationExportActions } from './export/index.ts';
 
 // Artifact
 export { ArtifactPanel, ArtifactViewer, ChatArtifactLayout } from './artifact/index.ts';
+export type {
+  ArtifactContentType,
+  ArtifactViewerProps,
+  MermaidRenderer,
+} from './artifact/index.ts';


### PR DESCRIPTION
## Summary

- add a typed `mermaidRenderer` snippet to `ArtifactViewer`
- preserve the explicit Mermaid source fallback when no renderer is supplied
- export the renderer and viewer prop types and document the consumer integration
- cover built-in rendering, fallback rendering, and custom renderer invocation

## Verification

- `bun run --filter=@lostgradient/chat components:check`
- `bun run --filter=@lostgradient/chat test`
- `bun run --filter=@lostgradient/chat typecheck`
- `bun run validate`

Closes #784