### PR TITLE
Fix nested Sidebar navigation landmarks

### DIFF
--- a/.changeset/calm-navs-align.md
+++ b/.changeset/calm-navs-align.md
@@ -1,0 +1,5 @@
+---
+'@lostgradient/cinder': patch
+---
+
+Avoid nested navigation landmarks when composing Sidebar with SideNavigation.

--- a/packages/components/src/components/sidebar/README.md
+++ b/packages/components/src/components/sidebar/README.md
@@ -7,11 +7,14 @@ Persistent side panel that houses navigation, filters, or supplementary page con
 ```svelte
 <script lang="ts">
   import Sidebar from '@lostgradient/cinder/sidebar';
+  import SideNavigation from '@lostgradient/cinder/side-navigation';
 </script>
 
 <Sidebar label="App sidebar">
   {#snippet navigation()}
-    <nav><!-- navigation items --></nav>
+    <SideNavigation ariaLabel="Primary navigation">
+      <!-- side-navigation items -->
+    </SideNavigation>
   {/snippet}
 </Sidebar>
 ```
@@ -20,14 +23,14 @@ Persistent side panel that houses navigation, filters, or supplementary page con
 
 <!-- generated:props:start -->
 
-| Prop               | Type       | Required | Default | Description                                                                                                                                                                                                                                                                                                                                              |
-| ------------------ | ---------- | -------- | ------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `class`            | `string`   | no       | —       | Additional CSS class merged with `.cinder-sidebar`.                                                                                                                                                                                                                                                                                                      |
-| `collapsed`        | `boolean`  | no       | —       | Whether the sidebar is collapsed. Bindable via `bind:collapsed`. Default `false`. Above `mobileBreakpoint`, `collapsed=true` switches the sidebar to icon-only mode. At or below `mobileBreakpoint`, the sidebar renders inside a `<Drawer>` and `collapsed=true` means the drawer is closed.                                                            |
-| `label`            | `string`   | no       | —       | Accessible name for the outer landmark and the mobile drawer. Required — defaults to `'Sidebar'` for convenience but must be unique per page. The inner `<nav>` landmark derives its own accessible name from this value by appending `' navigation'` so screen readers can distinguish the outer complementary region from the inner navigation region. |
-| `mobileBreakpoint` | `string`   | no       | —       | Viewport width below which the sidebar switches from the inline aside to the mobile drawer. Accepts a simple CSS length such as `'47.99rem'` or `'1024px'`. Default `'47.99rem'`.                                                                                                                                                                        |
-| `footer`           | `(opaque)` | no       | —       | Optional footer region (e.g. user account, sign-out). Not expressible in JSON Schema; see the component types for the signature.                                                                                                                                                                                                                         |
-| `navigation`       | `(opaque)` | no       | —       | Navigation region. Typically a `<SideNavigation>` subtree. Optional — when omitted, no `<nav>` landmark is rendered (so the sidebar can serve as app chrome without a navigation list, and an empty `<nav>` isn't announced to screen readers). Not expressible in JSON Schema; see the component types for the signature.                               |
+| Prop               | Type       | Required | Default | Description                                                                                                                                                                                                                                                                                   |
+| ------------------ | ---------- | -------- | ------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `class`            | `string`   | no       | —       | Additional CSS class merged with `.cinder-sidebar`.                                                                                                                                                                                                                                           |
+| `collapsed`        | `boolean`  | no       | —       | Whether the sidebar is collapsed. Bindable via `bind:collapsed`. Default `false`. Above `mobileBreakpoint`, `collapsed=true` switches the sidebar to icon-only mode. At or below `mobileBreakpoint`, the sidebar renders inside a `<Drawer>` and `collapsed=true` means the drawer is closed. |
+| `label`            | `string`   | no       | —       | Accessible name for the outer landmark and the mobile drawer. Defaults to `'Sidebar'` for convenience but must be unique per page. Navigation content owns its own accessible name; for example, use `SideNavigation.ariaLabel`.                                                              |
+| `mobileBreakpoint` | `string`   | no       | —       | Viewport width below which the sidebar switches from the inline aside to the mobile drawer. Accepts a simple CSS length such as `'47.99rem'` or `'1024px'`. Default `'47.99rem'`.                                                                                                             |
+| `footer`           | `(opaque)` | no       | —       | Optional footer region (e.g. user account, sign-out). Not expressible in JSON Schema; see the component types for the signature.                                                                                                                                                              |
+| `navigation`       | `(opaque)` | no       | —       | Navigation content. Typically a `<SideNavigation>` subtree, which owns the navigation landmark and its accessible name. Optional so the sidebar can serve as app chrome without a navigation list. Not expressible in JSON Schema; see the component types for the signature.                 |
 
 <!-- generated:props:end -->
 

--- a/packages/components/src/components/sidebar/sidebar.a11y.md
+++ b/packages/components/src/components/sidebar/sidebar.a11y.md
@@ -7,28 +7,30 @@ landmark; below the `md` breakpoint (~767px) it renders inside a `<Drawer>`.
 ## Landmark structure
 
 - Outer container is `<aside>` with a required `aria-label` (defaults to "Sidebar").
-- The inner navigation list lives inside a nested `<nav>` element whose
-  accessible name is derived by appending `" navigation"` to `label`. So
-  with `label="Workspace"` the `<aside>` is announced as "Workspace,
-  complementary" and the inner `<nav>` as "Workspace navigation". The two
-  landmarks are distinct in the landmarks list — the component owns this
-  separation; consumers do not pass two labels.
+- The `navigation` snippet renders inside a structural `<div>`, not another
+  landmark. Navigation content owns its landmark and accessible name. The
+  recommended `<SideNavigation ariaLabel="Workspace navigation">` composition
+  therefore produces one navigation landmark alongside the outer complementary
+  landmark, without nesting `<nav>` elements.
 - If the page contains more than one `<aside>` or more than one navigation
   landmark, pass a unique `label` per Sidebar instance. The default
   "Sidebar" is fine for a single-sidebar page but collides on dashboards with
   primary + contextual sidebars.
 - Below the `md` breakpoint the `<aside>` is replaced by `<Drawer>`. The drawer
   carries its own `<dialog role="dialog" aria-modal="true">` and an internal
-  heading sourced from `label`; the inner `<nav>` is still present inside
-  the drawer body with the same derived `" navigation"` label.
+  heading sourced from `label`; the navigation snippet keeps ownership of its
+  landmark and accessible name inside the drawer body.
 
 ## ARIA attributes
 
 | Prop / source                                            | Attribute on aside / drawer                  |
 | -------------------------------------------------------- | -------------------------------------------- |
 | `label` (default `'Sidebar'`)                            | `aria-label` on `<aside>` (or drawer `<h2>`) |
-| `label` (derived `"${label} navigation"`)                | `aria-label` on inner `<nav>`                |
 | Passing `aria-label` or `aria-labelledby` via rest props | Stripped — the required prop always wins     |
+
+`Sidebar.label` does not name navigation content. Pass an accessible name to
+the component rendered in the `navigation` snippet, such as
+`SideNavigation.ariaLabel`.
 
 An empty or whitespace-only `label` throws at render time. This is a hard
 fail because a landmark with no accessible name is worse than no landmark — it

--- a/packages/components/src/components/sidebar/sidebar.schema.json
+++ b/packages/components/src/components/sidebar/sidebar.schema.json
@@ -8,7 +8,7 @@
     },
     "label": {
       "type": "string",
-      "description": "Accessible name for the outer landmark and the mobile drawer. Required —\ndefaults to `'Sidebar'` for convenience but must be unique per page. The\ninner `<nav>` landmark derives its own accessible name from this value\nby appending `' navigation'` so screen readers can distinguish the\nouter complementary region from the inner navigation region."
+      "description": "Accessible name for the outer landmark and the mobile drawer. Defaults to\n`'Sidebar'` for convenience but must be unique per page. Navigation content\nowns its own accessible name; for example, use `SideNavigation.ariaLabel`."
     },
     "mobileBreakpoint": {
       "type": "string",
@@ -30,7 +30,7 @@
       {
         "name": "navigation",
         "reason": "function-or-snippet",
-        "description": "Navigation region. Typically a `<SideNavigation>` subtree. Optional — when\nomitted, no `<nav>` landmark is rendered (so the sidebar can serve as app chrome\nwithout a navigation list, and an empty `<nav>` isn't announced to screen readers)."
+        "description": "Navigation content. Typically a `<SideNavigation>` subtree, which owns the\nnavigation landmark and its accessible name. Optional so the sidebar can\nserve as app chrome without a navigation list."
       }
     ]
   }

--- a/packages/components/src/components/sidebar/sidebar.schema.ts
+++ b/packages/components/src/components/sidebar/sidebar.schema.ts
@@ -12,7 +12,7 @@ const schema = {
     label: {
       type: 'string',
       description:
-        "Accessible name for the outer landmark and the mobile drawer. Required —\ndefaults to `'Sidebar'` for convenience but must be unique per page. The\ninner `<nav>` landmark derives its own accessible name from this value\nby appending `' navigation'` so screen readers can distinguish the\nouter complementary region from the inner navigation region.",
+        "Accessible name for the outer landmark and the mobile drawer. Defaults to\n`'Sidebar'` for convenience but must be unique per page. Navigation content\nowns its own accessible name; for example, use `SideNavigation.ariaLabel`.",
     },
     mobileBreakpoint: {
       type: 'string',
@@ -36,7 +36,7 @@ const schema = {
         name: 'navigation',
         reason: 'function-or-snippet',
         description:
-          "Navigation region. Typically a `<SideNavigation>` subtree. Optional — when\nomitted, no `<nav>` landmark is rendered (so the sidebar can serve as app chrome\nwithout a navigation list, and an empty `<nav>` isn't announced to screen readers).",
+          'Navigation content. Typically a `<SideNavigation>` subtree, which owns the\nnavigation landmark and its accessible name. Optional so the sidebar can\nserve as app chrome without a navigation list.',
       },
     ],
   },

--- a/packages/components/src/components/sidebar/sidebar.svelte
+++ b/packages/components/src/components/sidebar/sidebar.svelte
@@ -48,11 +48,6 @@
     return label;
   });
 
-  // The inner <nav> landmark gets a distinct accessible name so the outer
-  // complementary <aside> and the inner navigation are not announced as two
-  // identically-named landmarks.
-  const navigationLabel = $derived(`${validatedLabel} navigation`);
-
   const validatedMobileBreakpoint = $derived.by(() => {
     if (typeof mobileBreakpoint !== 'string') {
       throw new Error('Sidebar mobileBreakpoint must be a CSS length such as "47.99rem".');
@@ -121,13 +116,12 @@
 
 {#snippet sidebarContents(isMobile: boolean)}
   {#if navigationSnippet}
-    <!-- Guard the entire <nav> landmark, not just its contents. An empty <nav>
-         is an accessibility problem (screen readers announce a navigation landmark
-         with no destinations). navigation is optional so a sidebar can be used as
-         app chrome without a nav list. -->
-    <nav class="cinder-sidebar__nav" aria-label={navigationLabel}>
+    <!-- SideNavigation owns the navigation landmark and its accessible name.
+         This wrapper is structural so the documented composition never nests
+         one navigation landmark inside another. -->
+    <div class="cinder-sidebar__nav">
       {@render navigationSnippet()}
-    </nav>
+    </div>
   {/if}
 
   {#if footerSnippet}

--- a/packages/components/src/components/sidebar/sidebar.test.ts
+++ b/packages/components/src/components/sidebar/sidebar.test.ts
@@ -1,6 +1,6 @@
 /// <reference lib="dom" />
 import { afterEach, describe, expect, test } from 'bun:test';
-import { createRawSnippet } from 'svelte';
+import { createRawSnippet, mount, unmount } from 'svelte';
 
 import { setupHappyDom } from '../../test/happy-dom.ts';
 import { renderToServerHtml } from '../../test/server-render.ts';
@@ -9,6 +9,7 @@ setupHappyDom();
 
 const { render } = await import('@testing-library/svelte');
 const { default: Sidebar } = await import('./sidebar.svelte');
+const { default: SideNavigation } = await import('../side-navigation/side-navigation.svelte');
 const { SIDEBAR_MOBILE_BREAKPOINT, SIDEBAR_MOBILE_MEDIA_QUERY } = await import('./index.ts');
 const SIDEBAR_SOURCE = new URL('./sidebar.svelte', import.meta.url).pathname;
 
@@ -80,33 +81,54 @@ describe('Sidebar (desktop / inline aside)', () => {
     expect(aside?.classList.contains('my-sidebar')).toBe(true);
   });
 
-  test('renders <nav> inside the aside with a distinct aria-label', () => {
+  test('renders a structural navigation wrapper inside the aside', () => {
     const { container } = render(Sidebar, {
       props: { label: 'Workspace', navigation: listSnippet('items') },
     });
-    const nav = container.querySelector('aside nav.cinder-sidebar__nav');
-    expect(nav).not.toBeNull();
-    // The inner <nav> landmark gets a distinct accessible name so it is not
-    // announced identically to the outer <aside> complementary landmark.
-    expect(nav?.getAttribute('aria-label')).toBe('Workspace navigation');
+    expect(container.querySelector('aside div.cinder-sidebar__nav')).not.toBeNull();
   });
 
-  test('outer aside aria-label is distinct from inner nav aria-label', () => {
+  test('the structural navigation wrapper does not create a landmark', () => {
     const { container } = render(Sidebar, {
       props: { label: 'Workspace', navigation: listSnippet('items') },
     });
-    const aside = container.querySelector('aside');
-    const nav = container.querySelector('aside nav.cinder-sidebar__nav');
-    expect(aside?.getAttribute('aria-label')).toBe('Workspace');
-    expect(nav?.getAttribute('aria-label')).not.toBe(aside?.getAttribute('aria-label'));
+    expect(container.querySelector('aside')?.getAttribute('aria-label')).toBe('Workspace');
+    expect(container.querySelector('aside nav')).toBeNull();
   });
 
-  test('renders navigation snippet inside the nav', () => {
+  test('renders navigation snippet inside the structural wrapper', () => {
     const { container } = render(Sidebar, {
       props: { navigation: listSnippet('payload') },
     });
-    const nav = container.querySelector('aside nav.cinder-sidebar__nav');
-    expect(nav?.textContent ?? '').toContain('payload');
+    const wrapper = container.querySelector('aside .cinder-sidebar__nav');
+    expect(wrapper?.textContent ?? '').toContain('payload');
+  });
+
+  test('composes with SideNavigation as exactly one navigation landmark', () => {
+    const navigation = createRawSnippet(() => ({
+      render: () => `<div class="side-navigation-host"></div>`,
+      setup: (node: Element) => {
+        const instance = mount(SideNavigation, {
+          target: node,
+          props: {
+            ariaLabel: 'Workspace navigation',
+            children: createRawSnippet(() => ({
+              render: () => `<li>Dashboard</li>`,
+              setup: () => {},
+            })),
+          },
+        });
+        return () => unmount(instance);
+      },
+    }));
+
+    const { container } = render(Sidebar, {
+      props: { label: 'Workspace', navigation },
+    });
+
+    expect(container.querySelectorAll('nav')).toHaveLength(1);
+    expect(container.querySelector('nav nav')).toBeNull();
+    expect(container.querySelector('nav')?.getAttribute('aria-label')).toBe('Workspace navigation');
   });
 
   test('omits footer region when no footer snippet is provided', () => {
@@ -520,14 +542,15 @@ describe('Sidebar (mobile / drawer)', () => {
     expect(wrapper?.classList.contains('my-sidebar')).toBe(true);
   });
 
-  test('mobile nav landmark has the distinct navigation label', () => {
+  test('mobile branch uses a structural navigation wrapper', () => {
     mock = installMatchMediaMock(true);
     const { container } = render(Sidebar, {
       props: { label: 'Workspace', navigation: listSnippet('items') },
     });
     expectMobileQueryWasUsed(mock);
-    const nav = container.querySelector('dialog nav.cinder-sidebar__nav');
-    expect(nav?.getAttribute('aria-label')).toBe('Workspace navigation');
+    const wrapper = container.querySelector('dialog div.cinder-sidebar__nav');
+    expect(wrapper).not.toBeNull();
+    expect(wrapper?.hasAttribute('aria-label')).toBe(false);
   });
 
   test('mobile branch forwards rest attributes onto the drawer dialog', () => {
@@ -889,16 +912,11 @@ describe('Sidebar collapsed CSS contract', () => {
 });
 
 describe('Sidebar — optional navigation snippet', () => {
-  test('omitting navigation renders no <nav> landmark (no empty navigation region)', () => {
-    // navigation is now optional (Snippet?). Without it, the <nav> landmark must be
-    // absent entirely — an empty <nav> is an a11y violation (screen readers announce
-    // a navigation region with no destinations). Render with a real label and NO
-    // navigation prop (every other test passes navigation; this one deliberately omits it).
+  test('omitting navigation renders no empty structural wrapper', () => {
     const { container } = render(Sidebar, {
       props: { label: 'Main' },
     });
-    // The <aside> renders, but there is no <nav> child because navigation was omitted.
     expect(container.querySelector('aside')).not.toBeNull();
-    expect(container.querySelector('nav')).toBeNull();
+    expect(container.querySelector('.cinder-sidebar__nav')).toBeNull();
   });
 });

--- a/packages/components/src/components/sidebar/sidebar.types.ts
+++ b/packages/components/src/components/sidebar/sidebar.types.ts
@@ -14,11 +14,9 @@ export type SidebarProps = Omit<
    */
   collapsed?: boolean;
   /**
-   * Accessible name for the outer landmark and the mobile drawer. Required —
-   * defaults to `'Sidebar'` for convenience but must be unique per page. The
-   * inner `<nav>` landmark derives its own accessible name from this value
-   * by appending `' navigation'` so screen readers can distinguish the
-   * outer complementary region from the inner navigation region.
+   * Accessible name for the outer landmark and the mobile drawer. Defaults to
+   * `'Sidebar'` for convenience but must be unique per page. Navigation content
+   * owns its own accessible name; for example, use `SideNavigation.ariaLabel`.
    */
   label?: string;
   /**
@@ -30,9 +28,9 @@ export type SidebarProps = Omit<
   /** Additional CSS class merged with `.cinder-sidebar`. */
   class?: string;
   /**
-   * Navigation region. Typically a `<SideNavigation>` subtree. Optional — when
-   * omitted, no `<nav>` landmark is rendered (so the sidebar can serve as app chrome
-   * without a navigation list, and an empty `<nav>` isn't announced to screen readers).
+   * Navigation content. Typically a `<SideNavigation>` subtree, which owns the
+   * navigation landmark and its accessible name. Optional so the sidebar can
+   * serve as app chrome without a navigation list.
    */
   navigation?: Snippet;
   /** Optional footer region (e.g. user account, sign-out). */


### PR DESCRIPTION
## Summary

- make Sidebar's navigation snippet wrapper structural instead of a second landmark
- preserve SideNavigation as the owner of the navigation landmark and accessible label
- add a composition regression test and update generated/accessibility documentation

## Validation

- `bun run --filter=@lostgradient/cinder test` (7,298 passed; 8 documented skips)
- `bun run --filter=@lostgradient/cinder components:generate`
- `bun run --filter=@lostgradient/cinder components:check`
- `bun run --filter=@lostgradient/cinder lint`
- `bun run --filter=@lostgradient/cinder typecheck`
- changed-file Prettier check

Closes #846