### PR TITLE
Fix local validation ownership

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,6 +34,17 @@ bun run --filter=@lostgradient/cinder test
 bun run --filter=@lostgradient/cinder test:coverage
 ```
 
+### Validation ownership
+
+The `pre-commit` hook checks lockfile staging and runs staged formatters and
+package sorting only. Required PR CI and `main-green` own broad source lint,
+typecheck, and test gates; release owns consumer/tarball validation and package
+weight checks. During ordinary issue or pull request work, run focused
+regression tests and any necessary generated-artifact checks. Do not use the
+root `bun run validate`, full test/coverage/browser suites, or consumer
+validation as an ordinary local pull request gate; required CI and release own
+those broad checks.
+
 ### Code Quality
 
 ```bash

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,7 +35,7 @@ Block-axis physical properties (`margin-top`, `padding-bottom`, `border-top`, `t
 
 Positioning properties (`left`, `right`) and `text-align: left | right` are **not** stylelint-enforced today. Many components position decorative or geometrically rotated elements (popover arrows, anchor positioning, fixed insets) where physical placement is intentional. When you add a new positioned element that should follow text direction, prefer `inset-inline-start` / `inset-inline-end` by hand. When you keep physical `left`/`right` (e.g., `data-placement="left"` selectors, rotated CSS-triangle decorations), it's worth a short comment so a future reader knows the choice was deliberate.
 
-Stylelint enforces this on every CSS file and `<style>` block under `packages/*/src/**`. The pre-commit hook will auto-fix where it can and fail the commit otherwise. To run the check locally:
+Stylelint enforces this on every CSS file and `<style>` block under `packages/*/src/**`. The pre-commit hook formats staged files and sorts package metadata; broad style and source validation runs in required CI. To run the check locally:
 
 ```bash
 bun run lint        # full lint pipeline, including stylelint
@@ -45,6 +45,17 @@ bun run lint:fix    # auto-fix what's safe
 When `left`/`right` carries semantic placement (e.g. `data-placement="left"` selectors on a tooltip), use the rule's `/* stylelint-disable-next-line csstools/use-logical */` escape hatch and add a comment explaining why the physical axis is intentional.
 
 [logical-properties]: https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_logical_properties_and_values
+
+## Validation ownership
+
+The `pre-commit` hook checks lockfile staging and runs staged formatters and
+package sorting only. Required PR CI and `main-green` own broad source lint,
+typecheck, and test gates. Release owns consumer/tarball validation and package
+weight checks. During ordinary issue or pull request work, run focused
+regression tests and any necessary generated-artifact checks. Do not use the
+root `bun run validate`, full test/coverage/browser suites, or consumer
+validation as an ordinary local pull request gate; required CI and release own
+those broad checks.
 
 ## Tests
 

--- a/docs/validation-topology.md
+++ b/docs/validation-topology.md
@@ -12,7 +12,7 @@ boundary sits where it does.
 
 | Layer                                                                       | What it runs                                                                                                                                                                                                                                                                                                                                                                                                                                       | What it deliberately does NOT run                                                                                                                 | Rationale                                                                                                                                                                                                                                                                                                     |
 | --------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Commit** (`pre-commit`)                                                   | Lockfile-sync check, `lint-staged` (formatters + oxlint on staged files), scoped per-package `typecheck`                                                                                                                                                                                                                                                                                                                                           | Tests (any kind), the full `lint`/`lint:invariants` chains, stylelint                                                                             | Fast formatting + type feedback. Tests are not run locally at all anymore (neither commit nor push) — PR CI and `main-green` own every test run, so commit stays a sub-second lockfile+lint+typecheck pass.                                                                                                   |
+| **Commit** (`pre-commit`)                                                   | Lockfile-staging check and `lint-staged` formatters/package sorting                                                                                                                                                                                                                                                                                                                                                                                | Install, lint, typecheck, tests (any kind), the full `lint`/`lint:invariants` chains, stylelint                                                   | Fast, deterministic formatting and package metadata normalization. Required PR CI and `main-green` own dependency and broad source validation, so the hook does not repeat those gates.                                                                                                                       |
 | **Push** (`pre-push`)                                                       | Fast, fail-open sanity checks only: parses the push-ref list off stdin to skip deletion-only pushes, and prints a best-effort, non-blocking changeset-presence hint for published-package source changes                                                                                                                                                                                                                                           | Any lint/typecheck/test dispatch, any package build, and the local gate lock that used to serialize concurrent worktree pushes behind one another | Deliberately inverted from the old design. Every check here warns, never blocks — there is nothing left in this hook that can fail a push. See "The push-layer inversion" below.                                                                                                                              |
 | **PR CI** (`unit-tests.yaml`, `browser-tests.yaml`, `changeset-guard.yaml`) | Scoped unit tests (`test:changed`) plus whole-repo invariants that a diff-scoped run could miss (`aggregator:check`, `components:check`), an unconditional `lint`/`lint:invariants` sweep, dependency-scoped browser tests, and a fast standalone changeset-bump guard                                                                                                                                                                             | The authoritative full source suite, consumer/tarball publish validation                                                                          | Fast, dependable per-PR feedback. Whole-repo invariants run unconditionally because a source change can desync a generated artifact without touching the artifact's own checker (`test:changed` would miss that).                                                                                             |
 | **main-green** (post-merge, nightly)                                        | Workspace `lint` + `lint:invariants`, workspace `typecheck`, generated artifact checks (`aggregator:check`, `components:check`), source audits (`check:placeholder-docs`, workflow validation, Svelte peer validation, `platform:audit`, `colors:audit`, `tokens:audit`), the FULL component suite through chunked `test:changed`, full component coverage via `test:coverage`, non-component workspace tests, plus the non-blocking memory canary | Consumer/tarball publish validation (`validate:consumer`, `package:weight:check`)                                                                 | The authoritative source-validation gate. Push runs are keyed by SHA and are not cancelled by newer pushes because release waits for the same-SHA run before publishing. If this goes red, the class of bug PR CI's scoping missed is presumed to have leaked.                                                |
@@ -138,13 +138,15 @@ build` step becomes a near-instant no-op instead of a full rebuild when
   nothing upstream changed.
 - **Gate lock** (`withLocalValidationGateLock` in
   `packages/components/scripts/husky/utilities.ts`) — serializes expensive,
-  disk-mutating local work across worktrees sharing one machine. Pre-push no
+  disk-mutating local work within one worktree. Each worktree has its own lock,
+  so independent issue/PR agents do not queue behind one another. Pre-push no
   longer holds it (it has no expensive critical section left); it remains for
   the scripts that still do heavy work standalone outside of CI —
   `test-changed.ts`, `generate-component-artifacts.ts`
-  (`components:generate`/`components:check`), and `validate-consumers.ts`
-  (`validate:consumer`) — so concurrent worktrees don't stack full test runs,
-  artifact generation, or tarball installs on top of one another. A waiter
+  (`components:generate`), and `validate-consumers.ts`
+  (`validate:consumer`) — so commands in one worktree do not stack full test
+  runs, artifact generation, or tarball installs on top of one another.
+  `components:check` is read-only and does not acquire the lock. A waiter
   keeps polling while the lock's recorded PID is alive, regardless of the
   lock's age; dead holders are reclaimed immediately, while malformed locks
   retain a bounded grace period and wait before the command fails.
@@ -157,6 +159,16 @@ build` step becomes a near-instant no-op instead of a full rebuild when
   a representative command actually produces the effect its layer expects
   (not just "the coverage map says it's declared"). Not yet implemented; noted
   here so its layer gets declared in `check-pipeline-coverage.ts` when it lands.
+
+## Local iteration ownership
+
+Ordinary issue and pull request work should run the smallest focused regression
+test that exercises the change, plus any necessary generated-artifact checks.
+Do not use the root `bun run validate`, full test/coverage/browser suites, or
+consumer/tarball validation as an ordinary local pull request gate. The full
+source suite belongs to PR CI and `main-green`; `validate:consumer` and
+`package:weight:check` belong to release. Run a broad gate locally only to
+diagnose that gate itself or when changing its implementation.
 
 ## The rule
 

--- a/package.json
+++ b/package.json
@@ -30,45 +30,36 @@
     "test:browser:install": "bun run --filter='@cinder/testing' install-browsers",
     "test:browser:ui": "bun run --filter='@cinder/testing' test:playwright:ui",
     "typecheck": "turbo run typecheck",
-    "validate": "turbo run validate --concurrency=1 && bun run --filter=@lostgradient/markdown validate:consumer && bun run --filter=@lostgradient/chat validate:consumer",
+    "validate": "turbo run validate --concurrency=1",
     "validate:consumer": "bun run --filter=@lostgradient/markdown validate:consumer && bun run --filter=@lostgradient/cinder validate:consumer && bun run --filter=@lostgradient/chat validate:consumer",
     "validate:playground": "bun run --filter='@cinder/playground' validate"
   },
   "lint-staged": {
     "packages/chat/src/**/*.{js,ts,tsx,jsx,mjs,cjs}": [
-      "oxlint --fix --type-aware --tsconfig ./packages/chat/tsconfig.json",
       "prettier --write"
     ],
     "packages/chat/scripts/**/*.{js,ts,tsx,jsx,mjs,cjs}": [
-      "oxlint --fix",
       "prettier --write"
     ],
     "packages/components/src/**/*.{js,ts,tsx,jsx,mjs,cjs}": [
-      "oxlint --fix --type-aware --tsconfig ./packages/components/tsconfig.json",
       "prettier --write"
     ],
     "packages/components/scripts/**/*.{js,ts,tsx,jsx,mjs,cjs}": [
-      "oxlint --fix",
       "prettier --write"
     ],
     "packages/commentary/**/*.{js,ts,tsx,jsx,mjs,cjs}": [
-      "oxlint --fix --type-aware --tsconfig ./packages/commentary/tsconfig.json",
       "prettier --write"
     ],
     "packages/markdown/**/*.{js,ts,tsx,jsx,mjs,cjs}": [
-      "oxlint --fix --type-aware --tsconfig ./packages/markdown/tsconfig.json",
       "prettier --write"
     ],
     "packages/playground/src/**/*.{js,ts,tsx,jsx,mjs,cjs}": [
-      "oxlint --fix --type-aware --tsconfig ./packages/playground/tsconfig.json",
       "prettier --write"
     ],
     "packages/testing/**/*.{js,ts,tsx,jsx,mjs,cjs}": [
-      "oxlint --fix",
       "prettier --write"
     ],
     "packages/**/src/**/*.{svelte,css}": [
-      "stylelint --fix",
       "prettier --write"
     ],
     "**/*.{json,md,scss}": [

--- a/packages/commentary/scripts/lib/atomic-swap-dist.ts
+++ b/packages/commentary/scripts/lib/atomic-swap-dist.ts
@@ -34,10 +34,8 @@ const DESTINATION_EXISTS_CODES = new Set(['ENOTEMPTY', 'EEXIST']);
  * turbo, CI, or by hand at the same time as another).
  *
  * IMPORTANT — what this does and does NOT guarantee:
- *   - It is NOT what closes issue #364. The husky test gate serializes its test
- *     phase (`phaseMaxConcurrency('test') === 1`), so concurrent same-package
- *     builds do not occur inside the hook; that serialization is the #364
- *     closure. This helper is defense-in-depth for the out-of-hook paths.
+ *   - This is the correctness boundary for concurrent builds. Git hooks do not
+ *     serialize build work, so every caller relies on the atomic promotion.
  *   - It DOES prevent a reader from observing a half-written tree: a build
  *     writes into a private staging dir and is only promoted once complete, so
  *     `dist` is replaced whole, never written into in place.

--- a/packages/components/AGENTS.md
+++ b/packages/components/AGENTS.md
@@ -401,6 +401,17 @@ scope and you should wire them up yourself:
 You are editing inside `packages/components`. Read this section before
 adding a component, changing a generator, or extending the manifest.
 
+### Validation ownership
+
+The `pre-commit` hook checks lockfile staging and runs staged formatters and
+package sorting only. Required PR CI and `main-green` own broad source lint,
+typecheck, and test gates; release owns consumer/tarball validation and package
+weight checks. For ordinary issue or pull request work, run focused regression
+tests and necessary generated-artifact checks. Do not use the root
+`bun run validate`, full test/coverage/browser suites, or consumer validation
+as an ordinary local pull request gate; required CI and release own those broad
+checks.
+
 ### The five analyzer conventions
 
 Every component in `src/components/<id>/` is parsed by the metadata,

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -6512,7 +6512,7 @@
     "tokens:audit": "bun run scripts/check-component-css-token-usage.ts",
     "tokens:literals": "bun run scripts/check-design-token-literals.ts",
     "typecheck": "bun run --filter='@lostgradient/markdown' build && tsc --noEmit -p tsconfig.check.json && bunx svelte-check --workspace src --tsconfig ../tsconfig.json --threshold error",
-    "validate": "bun run lint && bun run lint:invariants && bun run typecheck && bun run check:changeset-prerelease-bumps && bun run check:placeholder-docs && bun run test:coverage && bun run platform:audit -- --strict && bun run colors:audit -- --strict && bun run tokens:audit -- --strict && bun run aggregator:check && bun run components:check && bun run validate:workflow && bun run validate:svelte-peer && bun run validate:consumer && bun run package:weight:check -- --existing-tarball",
+    "validate": "bun run lint && bun run lint:invariants && bun run typecheck && bun run check:changeset-prerelease-bumps && bun run check:placeholder-docs && bun run test:coverage && bun run platform:audit -- --strict && bun run colors:audit -- --strict && bun run tokens:audit -- --strict && bun run aggregator:check && bun run components:check && bun run validate:workflow && bun run validate:svelte-peer",
     "validate:consumer": "bun run scripts/validate-consumers.ts",
     "validate:release-workflow": "bun run scripts/validate-release-workflow.ts",
     "validate:resolver-matrix": "bun run scripts/validate-resolver-matrix.ts",

--- a/packages/components/scripts/check-pipeline-coverage.ts
+++ b/packages/components/scripts/check-pipeline-coverage.ts
@@ -88,8 +88,8 @@ export const DECLARATION_TABLE: Record<string, DeclarationRow> = {
   lint: {
     layers: ['unit-tests', 'main-green'],
     reason:
-      'oxlint. pre-commit runs lint-staged (oxlint invoked directly on staged files, not the ' +
-      '`lint` script by name) so it is NOT counted here. pre-push no longer runs it either — it was ' +
+      'oxlint. pre-commit runs lint-staged formatters only, not the `lint` script by name, so it is ' +
+      'NOT counted here. pre-push no longer runs it either — it was ' +
       'thinned to a fast, fail-open sanity check with no lint/typecheck/test dispatch of its own; CI ' +
       'owns this now. The package-level `lint` script itself is invoked by unit-tests.yaml ' +
       '(`turbo run lint`, unconditional, fans out to every workspace package) and main-green ' +
@@ -100,14 +100,13 @@ export const DECLARATION_TABLE: Record<string, DeclarationRow> = {
     reason:
       "cinder's custom tree-walk invariant checks. Explicitly called out in unit-tests.yaml " +
       'and main-green (not folded into the `lint` sweep). ' +
-      'Not run at commit time by name — pre-commit scopes to typecheck only. Not run by pre-push, ' +
+      'Not run at commit time by name — pre-commit only formats staged files. Not run by pre-push, ' +
       'which no longer runs any lint/typecheck/test chain locally.',
   },
   typecheck: {
-    layers: ['pre-commit', 'browser-tests', 'main-green'],
+    layers: ['browser-tests', 'main-green'],
     reason:
-      'Per-package typecheck. pre-commit escalates to full workspace typecheck on root-config ' +
-      'changes (else scoped per touched package); browser-tests.yaml has a dedicated `typecheck` job ' +
+      'Per-package typecheck. browser-tests.yaml has a dedicated `typecheck` job ' +
       'running `bun run typecheck` against a fresh checkout (independent of the scope decision); ' +
       'main-green runs the workspace typecheck. pre-push no longer runs it — CI (browser-tests, ' +
       'main-green) is the backstop now. unit-tests.yaml deliberately does NOT run typecheck (that ' +
@@ -121,11 +120,11 @@ export const DECLARATION_TABLE: Record<string, DeclarationRow> = {
       'reaches it through the ROOT `lint` script (`turbo run lint && stylelint "…"`) — ' +
       'NOT the components-package `lint` (plain oxlint), a distinct resolution scope from every ' +
       'other row in this table. Deliberately excludes pre-commit for the same reason `lint` does: ' +
-      "pre-commit's lint-staged runs `stylelint --fix` directly on staged files, not through either " +
-      'named `lint` script, so it is not counted as a layer here (same editorial policy as the ' +
+      "pre-commit's lint-staged pipeline only formats staged files, not through the named `stylelint` " +
+      'script, so it is not counted as a layer here (same editorial policy as the ' +
       "`lint` row above). pre-push's file-scoped `runStylelint` was removed along with the rest of " +
-      'its local lint/typecheck/test dispatch. NOT run by release (root `validate` only fans into ' +
-      "each package's own `validate`, none of which invoke stylelint) or browser-tests/changeset-guard.",
+      'its local lint/typecheck/test dispatch. NOT run by release, which owns artifact validation, ' +
+      'or browser-tests/changeset-guard.',
   },
   'check:no-cycle-imports': {
     layers: ['unit-tests', 'main-green'],
@@ -259,10 +258,9 @@ export const DECLARATION_TABLE: Record<string, DeclarationRow> = {
       'pre-push no longer scopes lint by touched workspace.',
   },
   [`${chatPackageName}#typecheck`]: {
-    layers: ['pre-commit', 'browser-tests', 'main-green'],
+    layers: ['browser-tests', 'main-green'],
     reason:
-      'Chat package typecheck follows the same commit-time and CI gates as every typed package. ' +
-      'pre-push no longer typechecks touched workspaces — browser-tests and main-green are the backstop.',
+      'Chat package typecheck is owned by browser-tests and main-green; pre-commit only formats staged files.',
   },
   [`${chatPackageName}#components:check`]: {
     layers: ['unit-tests', 'main-green'],

--- a/packages/components/scripts/component-artifact-import-boundary.test.ts
+++ b/packages/components/scripts/component-artifact-import-boundary.test.ts
@@ -30,4 +30,12 @@ describe('component artifact import boundaries', () => {
       /export\s+(?:\*\s+from\s+['"].*component-artifact-operations|(?:async\s+function|(?:type\s+)?\{[^}]*checkComponentArtifacts))/s,
     );
   });
+
+  it('keeps read-only checks outside the validation lock while locking generation', async () => {
+    const source = await readScript('generate-component-artifacts.ts');
+
+    expect(source).toMatch(
+      /if \(process\.argv\.includes\('--check'\)\)\s*\{\s*await main\(\);\s*\} else \{[\s\S]*?withLocalValidationGateLock\(main\);/,
+    );
+  });
 });

--- a/packages/components/scripts/generate-component-artifacts.ts
+++ b/packages/components/scripts/generate-component-artifacts.ts
@@ -211,6 +211,10 @@ async function main(): Promise<void> {
 }
 
 if (import.meta.main) {
-  const { withLocalValidationGateLock } = await import('./husky/utilities.ts');
-  await withLocalValidationGateLock(main);
+  if (process.argv.includes('--check')) {
+    await main();
+  } else {
+    const { withLocalValidationGateLock } = await import('./husky/utilities.ts');
+    await withLocalValidationGateLock(main);
+  }
 }

--- a/packages/components/scripts/husky/hook-duration-baseline.json
+++ b/packages/components/scripts/husky/hook-duration-baseline.json
@@ -1,4 +1,4 @@
 {
-  "preCommitWarnMilliseconds": 60000,
+  "preCommitWarnMilliseconds": 10000,
   "prePushWarnMilliseconds": 10000
 }

--- a/packages/components/scripts/husky/pipeline-contract.test.ts
+++ b/packages/components/scripts/husky/pipeline-contract.test.ts
@@ -96,6 +96,16 @@ describe('pipeline contract: commit stays cheap', () => {
       expect(command).not.toMatch(/\b(?:oxlint|stylelint|typecheck|test(?::[\w-]+)?|turbo)\b/);
     }
   });
+
+  it('the commit-workflow simulation accepts both lint-staged command shapes', async () => {
+    const source = stripComments(
+      await Bun.file(join(componentsPackageRoot, 'scripts/validate-commit-workflow.ts')).text(),
+    );
+
+    expect(source).toContain('Record<string, string | string[]>');
+    expect(source).toMatch(/typeof entry === ['"]string['"]/);
+    expect(source).toMatch(/Array\.isArray\(entry\)/);
+  });
 });
 
 describe('pipeline contract: push stays thin and fails open (source-based: entry script, never imported)', () => {

--- a/packages/components/scripts/husky/pipeline-contract.test.ts
+++ b/packages/components/scripts/husky/pipeline-contract.test.ts
@@ -6,8 +6,8 @@ import { REPO_ROOT } from './utilities.ts';
 
 /**
  * Pins the shape of the validation pipeline described in
- * `docs/validation-topology.md`: pre-commit stays cheap (lockfile + lint-staged
- * + typecheck only), pre-push stays a fast, fail-open sanity check with no
+ * `docs/validation-topology.md`: pre-commit stays cheap (lockfile + formatting
+ * only), pre-push stays a fast, fail-open sanity check with no
  * expensive gate of its own (PR CI + branch protection own that job now), and
  * the package-level scripts compose the way pre-commit assumes. Every
  * assertion below explains, in its failure message, WHY the invariant exists —
@@ -63,17 +63,37 @@ function chainIncludesScript(script: string, name: string): boolean {
 }
 
 describe('pipeline contract: commit stays cheap', () => {
-  it('pre-commit.ts dispatches no test job (source-based: entry script, never imported)', async () => {
+  it('pre-commit.ts dispatches no install, lint, typecheck, or test job', async () => {
     const source = stripComments(await Bun.file(join(huskyDirectory, 'pre-commit.ts')).text());
-    // Tests are owned entirely by PR CI and main-green now -- pre-push runs no
-    // local test dispatch either (see the "push stays thin and fails open"
-    // describe block below). Re-adding a test dispatch to pre-commit would
-    // regress commit time from seconds to minutes for every developer on every
-    // commit. See docs/validation-topology.md.
-    expect(source).not.toMatch(/script:\s*'test'/);
+    // Required PR CI and main-green own source lint, typecheck, and tests. A
+    // hook dispatch duplicates those gates locally and makes concurrent
+    // worktrees contend before CI can run them in isolated jobs.
+    expect(source).not.toMatch(/\bbun\s+run\s+(lint|typecheck|test)\b/);
+    expect(source).not.toMatch(/\bturbo\s+run\b/);
+    expect(source).not.toMatch(/script:\s*'(lint|typecheck|test)'/);
     expect(source).not.toMatch(/'test:changed'/);
-    // The only literal job `script` pre-commit constructs is 'typecheck'.
-    expect(source).toMatch(/script:\s*'typecheck'/);
+    expect(source).not.toMatch(/runWithConcurrencyPool/);
+    expect(source).not.toMatch(/runHookCommand\(\s*['"]bun['"]\s*,\s*\[\s*['"]install['"]/);
+    expect(source).not.toContain('$`bun install');
+  });
+
+  it('lint-staged runs formatters only', async () => {
+    const manifest = await readPackageJson(join(REPO_ROOT, 'package.json'));
+    const lintStaged = manifest['lint-staged'];
+    expect(lintStaged).toBeDefined();
+    expect(typeof lintStaged).toBe('object');
+
+    const commands = Object.values(lintStaged as Record<string, unknown>).flatMap((entry) =>
+      Array.isArray(entry)
+        ? entry.filter((command): command is string => typeof command === 'string')
+        : [],
+    );
+
+    expect(commands.some((command) => command.startsWith('prettier '))).toBe(true);
+    expect(commands).toContain('sort-package-json');
+    for (const command of commands) {
+      expect(command).not.toMatch(/\b(?:oxlint|stylelint|typecheck|test(?::[\w-]+)?|turbo)\b/);
+    }
   });
 });
 
@@ -155,9 +175,8 @@ describe('pipeline contract: package script composition (source-based: reads pac
     const lint = scripts['lint'];
     expect(lint).toBeDefined();
     // `lint` must stay a single fast oxlint pass. Folding a `check:*` invariant
-    // into it would make every lint-staged run (pre-commit) pay for checks that
-    // belong in the slower, explicitly-scoped `lint:invariants` chain — the same
-    // "cheap commit" guarantee assertion 1 protects, from the other direction.
+    // into it would make ordinary explicit lint runs pay for checks that belong
+    // in the slower `lint:invariants` chain.
     expect(lint).toContain('oxlint');
     const checkScriptNames = Object.keys(scripts).filter((name) => name.startsWith('check:'));
     for (const checkName of checkScriptNames) {
@@ -181,16 +200,18 @@ describe('pipeline contract: package script composition (source-based: reads pac
     }
   });
 
-  it("components' validate chain includes both lint and lint:invariants", async () => {
+  it("components' source validate chain excludes packed-consumer release checks", async () => {
     const manifest = await readPackageJson(join(componentsPackageRoot, 'package.json'));
     const scripts = scriptsOf(manifest);
     const validate = scripts['validate'];
     expect(validate).toBeDefined();
-    // `validate` is the full pre-publish/CI gate; dropping either segment would
-    // let a published release ship past a lint or invariant regression that
-    // the lightweight local hooks do not check in full.
+    // Packed-consumer installation and package-weight checks belong to the
+    // explicit release workflow. Keeping them out of the source gate prevents
+    // every ordinary CI validation from repeating artifact work.
     expect(chainIncludesScript(validate ?? '', 'lint')).toBe(true);
     expect(chainIncludesScript(validate ?? '', 'lint:invariants')).toBe(true);
+    expect(chainIncludesScript(validate ?? '', 'validate:consumer')).toBe(false);
+    expect(chainIncludesScript(validate ?? '', 'package:weight:check')).toBe(false);
   });
 
   it('no package script contains an inline `rm -rf dist` outside the dedicated `clean` script', async () => {

--- a/packages/components/scripts/husky/pipeline-contract.test.ts
+++ b/packages/components/scripts/husky/pipeline-contract.test.ts
@@ -83,11 +83,12 @@ describe('pipeline contract: commit stays cheap', () => {
     expect(lintStaged).toBeDefined();
     expect(typeof lintStaged).toBe('object');
 
-    const commands = Object.values(lintStaged as Record<string, unknown>).flatMap((entry) =>
-      Array.isArray(entry)
+    const commands = Object.values(lintStaged as Record<string, unknown>).flatMap((entry) => {
+      if (typeof entry === 'string') return [entry];
+      return Array.isArray(entry)
         ? entry.filter((command): command is string => typeof command === 'string')
-        : [],
-    );
+        : [];
+    });
 
     expect(commands.some((command) => command.startsWith('prettier '))).toBe(true);
     expect(commands).toContain('sort-package-json');

--- a/packages/components/scripts/husky/pre-commit.ts
+++ b/packages/components/scripts/husky/pre-commit.ts
@@ -4,19 +4,14 @@ import { $ } from 'bun';
 import {
   error,
   getStagedFiles,
-  getTouchedPackages,
-  hasRootConfigurationChanges,
   header,
   hookDurationWarning,
   info,
   installHookProcessCleanup,
   isContinuousIntegration,
-  loadWorkspacePackages,
-  phaseMaxConcurrency,
   readHookDurationBaseline,
   REPO_ROOT,
   runHookCommand,
-  runWithConcurrencyPool,
   success,
   warning,
 } from './utilities.ts';
@@ -46,8 +41,8 @@ if (durationBaseline !== undefined) {
 
 header('Pre-commit checks');
 
-// 1) Lockfile sync check (run before any other work so a broken lock doesn't
-// pollute later steps).
+// 1) Lockfile staging check (run before any other work so unstaged lockfile
+// drift cannot be committed accidentally).
 const stagedForLockCheck = await getStagedFiles();
 if (stagedForLockCheck.includes('package.json')) {
   info('package.json is staged');
@@ -61,30 +56,11 @@ if (stagedForLockCheck.includes('package.json')) {
     }
     info('bun.lock unchanged; continuing');
   } else {
-    info('Dependencies changed, installing…');
-    const installResult = await runHookCommand('bun', ['install'], {
-      cwd: REPO_ROOT,
-      stderr: 'inherit',
-      stdout: 'inherit',
-    });
-    if (installResult.exitCode === 0) {
-      success('Dependencies installed');
-    } else {
-      warning('bun install failed; run it manually');
-    }
-    // bun install may regenerate bun.lock even when the staged copy looked
-    // up-to-date. Reject the commit if the working-tree lockfile no longer
-    // matches what's staged — otherwise the commit ships a stale lockfile.
-    const drift = await $`git diff --name-only -- bun.lock`.cwd(REPO_ROOT).text();
-    if (drift.trim().length > 0) {
-      error('bun.lock was modified by `bun install`; stage the regenerated lockfile and retry');
-      process.exit(1);
-    }
+    info('bun.lock is staged; CI will verify it with a frozen install');
   }
 }
 
-// 2) Run lint-staged FIRST so formatters write to disk before typecheck
-// observes the source.
+// 2) Run the staged formatting and package-sorting pipeline.
 info('Running lint-staged…');
 const lintStagedResult = await runHookCommand('bunx', ['lint-staged'], {
   cwd: REPO_ROOT,
@@ -98,118 +74,5 @@ if (lintStagedResult.exitCode === 0) {
   process.exit(1);
 }
 
-// 3) Recompute staged files (lint-staged may have re-staged formatted files).
-const staged = await getStagedFiles();
-
-// 4) Root config escalation → full workspace typecheck.
-// Tests are not run at commit time: pre-push runs a properly scoped suite
-// (test:changed, dependency-closure aware) and CI runs the full suite, so
-// commit only needs to catch type errors fast.
-if (hasRootConfigurationChanges(staged)) {
-  warning('Root config file staged; escalating to full workspace typecheck');
-  info('Running workspace typecheck…');
-  const typecheckResult = await runHookCommand('bun', ['run', 'typecheck'], {
-    cwd: REPO_ROOT,
-    stderr: 'inherit',
-    stdout: 'inherit',
-  });
-  if (typecheckResult.exitCode !== 0) {
-    error('typecheck failed');
-    error('Pre-commit checks failed');
-    process.exit(1);
-  }
-  success('All pre-commit checks passed');
-  process.exit(0);
-}
-
-// 5) Scoped per-package typecheck.
-// Tests are intentionally not run here — pre-push runs a scoped,
-// dependency-closure-aware suite (test:changed) and CI runs the full suite,
-// so commit stays fast: lockfile-sync + lint-staged + typecheck only.
-const workspace = await loadWorkspacePackages();
-const touched = getTouchedPackages(workspace, staged);
-
-if (touched.length === 0) {
-  success('No source files staged; skipping typecheck');
-  process.exit(0);
-}
-
-info(`Touched packages: ${touched.map((p) => p.name).join(', ')}`);
-
-type Job = {
-  readonly packageName: string;
-  readonly script: 'typecheck';
-};
-
-const typecheckJobs: Job[] = [];
-for (const pkg of touched) {
-  if (pkg.hasTypecheck) {
-    typecheckJobs.push({ packageName: pkg.name, script: 'typecheck' });
-  } else {
-    info(`${pkg.name}: no typecheck script; skipping`);
-  }
-}
-
-if (typecheckJobs.length === 0) {
-  success('No applicable scripts for touched packages; nothing to run');
-  process.exit(0);
-}
-
-type JobResult = {
-  readonly job: Job;
-  readonly exitCode: number;
-  readonly stdout: string;
-  readonly stderr: string;
-};
-
-const start = Date.now();
-const elapsed = () => Date.now() - start;
-
-/**
- * Run one `bun run --filter` invocation, capturing output for later display
- * and emitting start/done timestamps so parallel dispatch can be verified
- * mechanically from the hook log.
- */
-async function runJob(job: Job): Promise<JobResult> {
-  console.log(`[start ${job.packageName} ${job.script}] T+${elapsed()}ms`);
-  const result = await runHookCommand('bun', ['run', `--filter=${job.packageName}`, job.script], {
-    cwd: REPO_ROOT,
-    stderr: 'pipe',
-    stdout: 'pipe',
-  });
-  const exitCode = result.exitCode;
-  console.log(`[done ${job.packageName} ${job.script}] T+${elapsed()}ms (exit ${exitCode})`);
-  return {
-    job,
-    exitCode,
-    stdout: result.stdout,
-    stderr: result.stderr,
-  };
-}
-
-/**
- * Run a batch of jobs through a small async pool capped at `maxConcurrency`.
- * Returns the full result list in job-index order.
- *
- * Typecheck is read-only and safe to run in parallel across packages.
- */
-async function runJobs(jobs: readonly Job[], maxConcurrency: number): Promise<JobResult[]> {
-  return runWithConcurrencyPool(jobs, maxConcurrency, (job) => runJob(job));
-}
-
-// Typecheck (read-only — safe to run in parallel).
-const typecheckResults = await runJobs(typecheckJobs, phaseMaxConcurrency('typecheck'));
-
-const failures = typecheckResults.filter((r) => r.exitCode !== 0);
-if (failures.length > 0) {
-  for (const failure of failures) {
-    error(`\n--- ${failure.job.packageName} ${failure.job.script} (exit ${failure.exitCode}) ---`);
-    if (failure.stdout.trim().length > 0) console.log(failure.stdout);
-    if (failure.stderr.trim().length > 0) console.error(failure.stderr);
-  }
-  error(`Pre-commit checks failed (${failures.length} of ${typecheckResults.length} jobs)`);
-  process.exit(1);
-}
-
-success(`All pre-commit checks passed (${typecheckResults.length} jobs in ${elapsed()}ms)`);
+success('All pre-commit checks passed');
 process.exit(0);

--- a/packages/components/scripts/husky/utilities.test.ts
+++ b/packages/components/scripts/husky/utilities.test.ts
@@ -12,23 +12,17 @@ import {
   cleanupHookProcesses,
   defaultGateLockPath,
   expandToDependents,
-  gateLockPathForCommonDirectory,
-  getTouchedPackages,
-  gitCommonDirectory,
-  hasRootConfigurationChanges,
+  gateLockPathForWorktreeRoot,
   isIgnorableDoc,
   isNewBranch,
   isSourceFile,
   isUnderWorkspace,
-  loadWorkspacePackages,
   LOCAL_VALIDATION_GATE_LOCK_HELD_ENV,
   nodeModulesTopology,
   parsePushRefs,
-  phaseMaxConcurrency,
   prePushPackageScript,
   REPO_ROOT,
   runHookCommand,
-  runWithConcurrencyPool,
   withGateLock,
   withLocalValidationGateLock,
   type GitRunner,
@@ -36,24 +30,11 @@ import {
   type WorkspacePackage,
 } from './utilities.ts';
 
-const pkg = (
-  name: string,
-  dir: string,
-  dependencies: string[] = [],
-  flags: Partial<Pick<WorkspacePackage, 'hasLint' | 'hasTypecheck' | 'hasTest'>> = {},
-): WorkspacePackage => ({
+const pkg = (name: string, dir: string, dependencies: string[] = []): WorkspacePackage => ({
   name,
   dir,
-  hasLint: flags.hasLint ?? true,
-  hasTypecheck: flags.hasTypecheck ?? true,
-  hasTest: flags.hasTest ?? true,
   dependencies: new Set(dependencies),
 });
-
-const fakePackages: readonly WorkspacePackage[] = [
-  pkg('@lostgradient/markdown', 'packages/markdown/'),
-  pkg('@lostgradient/cinder', 'packages/components/', [], { hasTest: false }),
-];
 
 // A fixture mirroring the real internal dependency graph for closure tests.
 const graphPackages: readonly WorkspacePackage[] = [
@@ -68,7 +49,7 @@ const graphPackages: readonly WorkspacePackage[] = [
   pkg('@lostgradient/chat', 'packages/chat/', ['@lostgradient/cinder']),
   pkg('@cinder/playground', 'packages/playground/', ['@lostgradient/chat', '@lostgradient/cinder']),
   pkg('@cinder/diff', 'packages/diff/'),
-  pkg('@cinder/testing', 'packages/testing/', [], { hasLint: false }),
+  pkg('@cinder/testing', 'packages/testing/'),
 ];
 
 const sorted = (names: Iterable<string>): string[] => [...names].toSorted();
@@ -376,132 +357,6 @@ describe('isSourceFile', () => {
   it('is case-insensitive on extensions and basenames', () => {
     expect(isSourceFile('packages/markdown/src/Index.TS')).toBe(true);
     expect(isSourceFile('packages/markdown/README.MD')).toBe(false);
-  });
-});
-
-describe('getTouchedPackages', () => {
-  it('returns the packages whose dir prefix matches staged source files', () => {
-    const touched = getTouchedPackages(fakePackages, [
-      'packages/markdown/src/index.ts',
-      'packages/components/src/parser.ts',
-    ]);
-    expect(touched.map((p) => p.name).toSorted()).toEqual([
-      '@lostgradient/cinder',
-      '@lostgradient/markdown',
-    ]);
-  });
-
-  it('ignores docs-only staged files', () => {
-    const touched = getTouchedPackages(fakePackages, [
-      'packages/markdown/README.md',
-      'packages/markdown/CHANGELOG.md',
-    ]);
-    expect(touched).toEqual([]);
-  });
-
-  it('mixes source and docs files correctly', () => {
-    const touched = getTouchedPackages(fakePackages, [
-      'packages/markdown/README.md',
-      'packages/markdown/src/index.ts',
-      'packages/components/docs/notes.md',
-    ]);
-    expect(touched.map((p) => p.name)).toEqual(['@lostgradient/markdown']);
-  });
-
-  it('returns empty when no staged file matches any package', () => {
-    const touched = getTouchedPackages(fakePackages, ['README.md', 'package.json']);
-    expect(touched).toEqual([]);
-  });
-
-  it('does not double-report a package with multiple staged files', () => {
-    const touched = getTouchedPackages(fakePackages, [
-      'packages/markdown/src/a.ts',
-      'packages/markdown/src/b.ts',
-      'packages/markdown/src/c.ts',
-    ]);
-    expect(touched.map((p) => p.name)).toEqual(['@lostgradient/markdown']);
-  });
-});
-
-describe('hasRootConfigurationChanges', () => {
-  it('returns true when a high-impact root file is staged', () => {
-    expect(hasRootConfigurationChanges(['tsconfig.json'])).toBe(true);
-    expect(hasRootConfigurationChanges(['tsconfig.base.json'])).toBe(true);
-    expect(hasRootConfigurationChanges(['tsconfig.build.json'])).toBe(true);
-    expect(hasRootConfigurationChanges(['tsconfig.check.json'])).toBe(true);
-    expect(hasRootConfigurationChanges(['tsconfig.test.json'])).toBe(true);
-    expect(hasRootConfigurationChanges(['package.json'])).toBe(true);
-    expect(hasRootConfigurationChanges(['bun.lock'])).toBe(true);
-    expect(hasRootConfigurationChanges(['.oxlintrc.json'])).toBe(true);
-    expect(hasRootConfigurationChanges(['bunfig.toml'])).toBe(true);
-    expect(hasRootConfigurationChanges(['.prettierrc.json'])).toBe(true);
-    expect(hasRootConfigurationChanges(['.stylelintrc.json'])).toBe(true);
-  });
-
-  it('returns false for nested files of the same name', () => {
-    // packages/markdown/tsconfig.json must NOT escalate to a full workspace run.
-    expect(hasRootConfigurationChanges(['packages/markdown/tsconfig.json'])).toBe(false);
-    expect(hasRootConfigurationChanges(['packages/markdown/package.json'])).toBe(false);
-  });
-
-  it('returns false when only non-root files are staged', () => {
-    expect(hasRootConfigurationChanges(['packages/markdown/src/index.ts', 'README.md'])).toBe(
-      false,
-    );
-  });
-
-  it('returns false on an empty staged list', () => {
-    expect(hasRootConfigurationChanges([])).toBe(false);
-  });
-
-  it('is a pure path predicate (works on push-range file lists, not just staged)', () => {
-    // No staged context — exact root-relative paths still classify correctly.
-    expect(hasRootConfigurationChanges(['packages/markdown/src/x.ts', 'bun.lock'])).toBe(true);
-    expect(
-      hasRootConfigurationChanges(['packages/markdown/src/x.ts', 'packages/markdown/README.md']),
-    ).toBe(false);
-  });
-});
-
-describe('loadWorkspacePackages', () => {
-  it('reads every packages/*/package.json and exposes script presence', async () => {
-    const packages = await loadWorkspacePackages();
-    const names = packages.map((p) => p.name).toSorted();
-    expect(names).toContain('@lostgradient/markdown');
-    expect(names).toContain('@cinder/commentary');
-    expect(names).toContain('@cinder/playground');
-    expect(names).toContain('@cinder/testing');
-    expect(names).toContain('@lostgradient/chat');
-    expect(names).toContain('@lostgradient/cinder');
-    for (const entry of packages) {
-      expect(entry.dir.startsWith('packages/')).toBe(true);
-      expect(entry.dir.endsWith('/')).toBe(true);
-      expect(typeof entry.hasLint).toBe('boolean');
-      expect(typeof entry.hasTypecheck).toBe('boolean');
-      expect(typeof entry.hasTest).toBe('boolean');
-      expect(entry.dependencies).toBeInstanceOf(Set);
-    }
-  });
-
-  it('populates internal workspace dependencies (filtered to workspace names)', async () => {
-    const packages = await loadWorkspacePackages();
-    const byName = new Map(packages.map((entry) => [entry.name, entry] as const));
-
-    // @cinder/playground depends on cinder.
-    expect([...byName.get('@cinder/playground')!.dependencies]).toContain('@lostgradient/cinder');
-    expect([...byName.get('@cinder/playground')!.dependencies]).toContain('@lostgradient/chat');
-    // Chat composes Cinder primitives and utilities through the public package.
-    expect([...byName.get('@lostgradient/chat')!.dependencies]).toContain('@lostgradient/cinder');
-    // cinder dev-depends on @cinder/testing.
-    expect([...byName.get('@lostgradient/cinder')!.dependencies]).toContain('@cinder/testing');
-    // Every dependency name resolves to another workspace package (external
-    // deps such as `chalk` are filtered out).
-    const workspaceNames = new Set(packages.map((entry) => entry.name));
-    for (const entry of packages) {
-      for (const dep of entry.dependencies) {
-        expect(workspaceNames.has(dep)).toBe(true);
-      }
-    }
   });
 });
 
@@ -951,226 +806,11 @@ describe('isIgnorableDoc', () => {
  * closure) so the motivating CSS-only acceptance criterion is asserted against
  * the *real* workspace, not just the building blocks in isolation.
  */
-function planScopedJobs(
-  workspace: readonly WorkspacePackage[],
-  changed: readonly string[],
-): string[] {
-  const touched = getTouchedPackages(workspace, [...changed]);
-  const byName = new Map(workspace.map((entry) => [entry.name, entry] as const));
-  const jobs: string[] = [];
-  for (const entry of touched) {
-    if (entry.hasLint) jobs.push(`${entry.name} lint`);
-  }
-  for (const name of expandToDependents(
-    workspace,
-    touched.map((entry) => entry.name),
-  )) {
-    const entry = byName.get(name);
-    if (entry === undefined) continue;
-    if (entry.hasTypecheck) jobs.push(`${name} typecheck`);
-    if (entry.hasTest) jobs.push(`${name} ${prePushPackageScript(name, 'test')}`);
-  }
-  return jobs.toSorted();
-}
-
 describe('prePushPackageScript', () => {
   it('uses component-aware test scoping for the cinder package only', () => {
     expect(prePushPackageScript('@lostgradient/cinder', 'test')).toBe('test:changed');
     expect(prePushPackageScript('@lostgradient/cinder', 'typecheck')).toBe('typecheck');
     expect(prePushPackageScript('@cinder/playground', 'test')).toBe('test');
-  });
-});
-
-describe('scoped job derivation (real workspace)', () => {
-  it('scopes a CSS-only packages/components change to cinder + playground only', async () => {
-    const workspace = await loadWorkspacePackages();
-    const jobs = planScopedJobs(workspace, [
-      'packages/components/src/components/alert.css',
-      'packages/components/src/components/callout.css',
-    ]);
-    // Positive: Cinder's three gates plus Chat and playground typecheck/test
-    // through the real reverse-dependency closure.
-    expect(jobs).toEqual([
-      '@cinder/playground test',
-      '@cinder/playground typecheck',
-      '@lostgradient/chat test',
-      '@lostgradient/chat typecheck',
-      '@lostgradient/cinder lint',
-      '@lostgradient/cinder test:changed',
-      '@lostgradient/cinder typecheck',
-    ]);
-    // Negative: no playground *lint* (closure is typecheck/test only), and no
-    // markdown/commentary/diff jobs at all.
-    expect(jobs).not.toContain('@cinder/playground lint');
-    expect(jobs.some((j) => /@cinder\/(markdown|commentary|diff)/.test(j))).toBe(false);
-  });
-
-  it('scopes a leaf @cinder/commentary change without dragging in unrelated siblings', async () => {
-    const workspace = await loadWorkspacePackages();
-    const jobs = planScopedJobs(workspace, ['packages/commentary/src/index.ts']);
-    // commentary is a consumer leaf, but cinder dev-depends on it and playground
-    // depends on cinder, so the closure is commentary + cinder + playground.
-    expect(jobs.some((j) => /@cinder\/(markdown|diff)/.test(j))).toBe(false);
-    expect(jobs).toContain('@cinder/commentary lint');
-    expect(jobs).toContain('@lostgradient/cinder typecheck');
-    expect(jobs).toContain('@cinder/playground test');
-  });
-});
-
-/**
- * `phaseMaxConcurrency` is the side-effect-free seam extracted from pre-commit.ts
- * so this test can assert the policy without importing the gate entry path
- * (which has module-scope side effects: isContinuousIntegration → process.exit,
- * stdin read). The policy is kept general across all three `GateScript` values
- * (not narrowed to pre-commit's `typecheck`) so a future local gate script
- * inherits the same bounded concurrency instead of reinventing it.
- */
-describe('phaseMaxConcurrency', () => {
-  function withHardwareConcurrency(value: number, run: () => void): void {
-    // Pin hardwareConcurrency so the assertion is environment-independent: on
-    // a real 1-vCPU host Math.max(1, Math.min(1, 4)) === 1, which would make
-    // toBeGreaterThan(1) fail. The fixture value must be ≥ 2 and ≤ 4 (the cap
-    // in the implementation) so the mocked result equals min(value, 4).
-    const original = navigator.hardwareConcurrency;
-    Object.defineProperty(navigator, 'hardwareConcurrency', {
-      value,
-      configurable: true,
-      writable: true,
-    });
-    try {
-      run();
-    } finally {
-      Object.defineProperty(navigator, 'hardwareConcurrency', {
-        value: original,
-        configurable: true,
-        writable: true,
-      });
-    }
-  }
-
-  it('returns a value greater than 1 for test', () => {
-    withHardwareConcurrency(2, () => {
-      expect(phaseMaxConcurrency('test')).toBeGreaterThan(1);
-    });
-  });
-
-  it('returns a value greater than 1 for lint (read-only, safe to parallelize)', () => {
-    withHardwareConcurrency(2, () => {
-      expect(phaseMaxConcurrency('lint')).toBeGreaterThan(1);
-    });
-  });
-
-  it('returns a value greater than 1 for typecheck (read-only, safe to parallelize)', () => {
-    withHardwareConcurrency(2, () => {
-      expect(phaseMaxConcurrency('typecheck')).toBeGreaterThan(1);
-    });
-  });
-
-  it('returns the same concurrency for every gate script', () => {
-    withHardwareConcurrency(2, () => {
-      const concurrencies = (['lint', 'typecheck', 'test'] as const).map((script) =>
-        phaseMaxConcurrency(script),
-      );
-      expect(new Set(concurrencies).size).toBe(1);
-    });
-  });
-
-  it('returns a finite positive integer for every gate script', () => {
-    for (const script of ['lint', 'typecheck', 'test'] as const) {
-      const concurrency = phaseMaxConcurrency(script);
-      expect(Number.isFinite(concurrency)).toBe(true);
-      expect(concurrency).toBeGreaterThanOrEqual(1);
-      expect(Number.isInteger(concurrency)).toBe(true);
-    }
-  });
-});
-
-/**
- * `runWithConcurrencyPool` is the *mechanism* the `phaseMaxConcurrency` policy
- * feeds. The policy tests above only prove each phase asks for a given
- * concurrency — they do NOT prove the runner honors it. The pre-commit
- * `runJobs` helper delegates to this pool, so a future edit that passed a
- * hardcoded literal instead of `phaseMaxConcurrency(script)` would still
- * leave the policy tests green. These tests close that gap: they instrument
- * the worker to record the maximum number of overlapping invocations and
- * assert the pool never exceeds the cap — with `maxConcurrency === 1` the
- * overlap is strictly 1.
- */
-describe('runWithConcurrencyPool', () => {
-  /**
-   * Run `items` through the pool with a worker that records concurrent overlap.
-   * Each worker waits one microtask-batch (a resolved-promise tick) before
-   * "finishing", which is enough to interleave with sibling workers if the pool
-   * starts more than one at a time — so a broken cap is observable.
-   */
-  async function observeOverlap(
-    itemCount: number,
-    maxConcurrency: number,
-  ): Promise<{ readonly results: number[]; readonly maxObserved: number }> {
-    let active = 0;
-    let maxObserved = 0;
-    const items = Array.from({ length: itemCount }, (_, index) => index);
-    const results = await runWithConcurrencyPool(items, maxConcurrency, async (item) => {
-      active += 1;
-      maxObserved = Math.max(maxObserved, active);
-      // Yield several times so a too-eager pool has room to overlap workers.
-      await Promise.resolve();
-      await Promise.resolve();
-      await Promise.resolve();
-      active -= 1;
-      return item * 2;
-    });
-    return { results, maxObserved };
-  }
-
-  it('runs strictly one at a time when maxConcurrency is 1', async () => {
-    const { results, maxObserved } = await observeOverlap(6, 1);
-    expect(maxObserved).toBe(1);
-    // Results stay in input order regardless of pool scheduling.
-    expect(results).toEqual([0, 2, 4, 6, 8, 10]);
-  });
-
-  it('overlaps workers up to the cap when maxConcurrency is greater than 1', async () => {
-    const { results, maxObserved } = await observeOverlap(6, 3);
-    // The pool must actually parallelize — otherwise the cap is meaningless and
-    // the serial case above proves nothing distinctive.
-    expect(maxObserved).toBe(3);
-    expect(results).toEqual([0, 2, 4, 6, 8, 10]);
-  });
-
-  it('never starts more workers than there are items', async () => {
-    const { maxObserved } = await observeOverlap(2, 8);
-    expect(maxObserved).toBe(2);
-  });
-
-  it('returns an empty array for no items without invoking the worker', async () => {
-    let invoked = false;
-    const results = await runWithConcurrencyPool([], 4, async () => {
-      invoked = true;
-      return 1;
-    });
-    expect(results).toEqual([]);
-    expect(invoked).toBe(false);
-  });
-
-  it('floors a non-finite concurrency to 1 instead of starting zero workers', async () => {
-    // A `NaN` cap (e.g. Math.min(undefined hardwareConcurrency, 4)) must NOT
-    // start zero workers and silently resolve every item to undefined — that
-    // would be a false green. The floor forces strictly-serial execution.
-    const { results, maxObserved } = await observeOverlap(4, Number.NaN);
-    expect(maxObserved).toBe(1);
-    expect(results).toEqual([0, 2, 4, 6]);
-  });
-
-  it('preserves input order even when later items resolve first', async () => {
-    // Earlier indices take longer than later ones; the pool must still return
-    // results indexed by input position, not completion order.
-    const items = [3, 2, 1, 0];
-    const results = await runWithConcurrencyPool(items, 2, async (delayTicks) => {
-      for (let tick = 0; tick < delayTicks; tick += 1) await Promise.resolve();
-      return delayTicks;
-    });
-    expect(results).toEqual([3, 2, 1, 0]);
   });
 });
 
@@ -1186,13 +826,23 @@ describe('withGateLock', () => {
     }
   }
 
-  it('derives the default lock path from the shared Git common directory', () => {
-    const commonDirectory = gitCommonDirectory();
-    const expectedPath = gateLockPathForCommonDirectory(commonDirectory);
+  it('derives a deterministic lock path from the worktree root', () => {
+    const expectedPath = gateLockPathForWorktreeRoot(REPO_ROOT);
 
-    expect(commonDirectory).toBe(gitCommonDirectory(REPO_ROOT));
     expect(defaultGateLockPath()).toBe(expectedPath);
-    expect(defaultGateLockPath()).not.toContain(REPO_ROOT);
+    expect(defaultGateLockPath(REPO_ROOT)).toBe(expectedPath);
+  });
+
+  it('isolates linked worktrees while sharing a path within one worktree', () => {
+    const firstWorktree = '/tmp/cinder-worktree-a';
+    const secondWorktree = '/tmp/cinder-worktree-b';
+
+    expect(gateLockPathForWorktreeRoot(firstWorktree)).toBe(
+      gateLockPathForWorktreeRoot(firstWorktree),
+    );
+    expect(gateLockPathForWorktreeRoot(firstWorktree)).not.toBe(
+      gateLockPathForWorktreeRoot(secondWorktree),
+    );
   });
 
   it('creates a lock while the protected function runs and removes it after success', async () => {

--- a/packages/components/scripts/husky/utilities.ts
+++ b/packages/components/scripts/husky/utilities.ts
@@ -1,10 +1,9 @@
 import { $ } from 'bun';
 import chalk from 'chalk';
 import { capitalCase } from 'change-case';
-import { execFileSync } from 'node:child_process';
 import { createHash } from 'node:crypto';
 import { lstatSync, readFileSync, rmSync } from 'node:fs';
-import { mkdir, open, readdir, readFile, rm, stat } from 'node:fs/promises';
+import { mkdir, open, readFile, rm, stat } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -96,67 +95,6 @@ export function prePushPackageScript(
   return script;
 }
 
-/**
- * The maximum number of jobs that may run concurrently for a given gate
- * script. This is the side-effect-free seam the regression test imports to
- * assert each phase's concurrency policy without triggering the gate entry
- * path's process.exit / stdin-read / lock side effects.
- *
- * All three gate scripts — lint, typecheck, and test — share the same
- * CPU-bound cap, kept general (rather than hardcoded to pre-commit's actual
- * `typecheck`-only usage) so a future gate script inherits the same policy for
- * free. The `test` case in {@link GateScript} and this function's
- * equal-across-scripts policy are kept because `check:pipeline-coverage` and
- * CI jobs still reason about the same script names, and a future local test
- * dispatch should inherit this cap rather than reinvent it.
- */
-export function phaseMaxConcurrency(_script: GateScript): number {
-  // CPU-bound default (up to 4 workers). The `?? 1` guards environments where
-  // `navigator.hardwareConcurrency` is undefined; `Math.max(1, …)` ensures the
-  // floor stays at 1 so a zero / negative value never silently skips all jobs.
-  return Math.max(1, Math.min(navigator.hardwareConcurrency ?? 1, 4));
-}
-
-/**
- * Run `items` through a bounded async pool, invoking `worker(item, index)` for
- * each and returning the results in input order. At most `maxConcurrency`
- * workers run at once — this is the *mechanism* that {@link phaseMaxConcurrency}
- * feeds.
- *
- * The concurrency floor is defensive. A non-finite `maxConcurrency` — e.g. a
- * caller computing `Math.min(navigator.hardwareConcurrency, 4)` where
- * `hardwareConcurrency` is `undefined`, yielding `NaN` — must NOT slip through:
- * `NaN` would make `Math.min(concurrency, items.length)` `NaN`, start zero
- * workers, and silently resolve every item to `undefined` — a false green.
- * `Number.isFinite` rejects `NaN`/±Infinity; `Math.max(1, …)` then guards
- * `0`/negatives. This binding lives in ONE place so both hooks' job runners and
- * the regression test share the same guarantee.
- */
-export async function runWithConcurrencyPool<Item, Result>(
-  items: readonly Item[],
-  maxConcurrency: number,
-  worker: (item: Item, index: number) => Promise<Result>,
-): Promise<Result[]> {
-  if (items.length === 0) return [];
-  const concurrency = Number.isFinite(maxConcurrency) ? Math.max(1, Math.floor(maxConcurrency)) : 1;
-  const results: Result[] = Array.from({ length: items.length });
-  let nextIndex = 0;
-  const workers: Promise<void>[] = [];
-  for (let workerId = 0; workerId < Math.min(concurrency, items.length); workerId++) {
-    workers.push(
-      (async () => {
-        while (true) {
-          const index = nextIndex++;
-          if (index >= items.length) return;
-          results[index] = await worker(items[index]!, index);
-        }
-      })(),
-    );
-  }
-  await Promise.all(workers);
-  return results;
-}
-
 type HookSignal = 'SIGINT' | 'SIGTERM' | 'SIGHUP';
 type CleanupSignal = HookSignal | 'SIGKILL';
 
@@ -195,34 +133,6 @@ function errorMessage(value: unknown): string {
 
 function readStreamText(stream: unknown): Promise<string> {
   return stream instanceof ReadableStream ? new Response(stream).text() : Promise.resolve('');
-}
-
-const STREAM_DRAIN_GRACE_MILLISECONDS = 1_000;
-
-async function readCapturedStreamsWithGrace(
-  stdoutText: Promise<string>,
-  stderrText: Promise<string>,
-  onTimeout: () => Promise<void>,
-): Promise<{ readonly stdout: string; readonly stderr: string }> {
-  const captured = Promise.all([stdoutText, stderrText]).then(([stdout, stderr]) => ({
-    stderr,
-    stdout,
-  }));
-  const drained = await Promise.race([
-    captured,
-    Bun.sleep(STREAM_DRAIN_GRACE_MILLISECONDS).then(() => null),
-  ]);
-
-  if (drained !== null) return drained;
-
-  await onTimeout();
-
-  return (
-    (await Promise.race([
-      captured,
-      Bun.sleep(STREAM_DRAIN_GRACE_MILLISECONDS).then(() => null),
-    ])) ?? { stderr: '', stdout: '' }
-  );
 }
 
 function isProcessAlive(pid: number): boolean {
@@ -387,16 +297,15 @@ export async function runHookCommand(
     })();
 
     const exitCode = await exitCodePromise;
-
-    const captured = await readCapturedStreamsWithGrace(stdoutText, stderrText, async () => {
-      abortCleanup ??= cleanupProcessGroups([subprocess.pid], 'SIGTERM');
-      await abortCleanup;
-    });
+    if (!aborted && isProcessGroupAlive(subprocess.pid)) {
+      await cleanupProcessGroups([subprocess.pid], 'SIGTERM');
+    }
+    const [capturedStdout, capturedStderr] = await Promise.all([stdoutText, stderrText]);
 
     return {
       exitCode: aborted ? 130 : exitCode,
-      stderr: captured.stderr,
-      stdout: captured.stdout,
+      stderr: capturedStderr,
+      stdout: capturedStdout,
     };
   } finally {
     options.signal?.removeEventListener('abort', abort);
@@ -433,33 +342,16 @@ const DEFAULT_GATE_LOCK_RETRY_MILLISECONDS = 1_000;
 const DEFAULT_GATE_LOCK_WAIT_MILLISECONDS = 5 * 60 * 1_000;
 export const LOCAL_VALIDATION_GATE_LOCK_HELD_ENV = 'CINDER_LOCAL_VALIDATION_GATE_LOCK_HELD';
 
-export function gitCommonDirectory(repositoryRoot = REPO_ROOT): string {
-  try {
-    const commonDirectory = execFileSync(
-      'git',
-      ['-C', repositoryRoot, 'rev-parse', '--path-format=absolute', '--git-common-dir'],
-      {
-        encoding: 'utf8',
-        stdio: ['ignore', 'pipe', 'ignore'],
-      },
-    ).trim();
-    if (commonDirectory.length > 0) return commonDirectory;
-  } catch {
-    // Fall through to the repository-local path for non-Git test fixtures.
-  }
-  return join(repositoryRoot, '.git');
-}
-
-export function gateLockPathForCommonDirectory(commonDirectory: string): string {
-  const commonDirectoryHash = createHash('sha256')
-    .update(commonDirectory)
+export function gateLockPathForWorktreeRoot(worktreeRoot: string): string {
+  const worktreeRootHash = createHash('sha256')
+    .update(resolve(worktreeRoot))
     .digest('hex')
     .slice(0, 16);
-  return join(tmpdir(), 'cinder-local-validation-gates', `${commonDirectoryHash}.lock`);
+  return join(tmpdir(), 'cinder-local-validation-gates', `${worktreeRootHash}.lock`);
 }
 
 export function defaultGateLockPath(repositoryRoot = REPO_ROOT): string {
-  return gateLockPathForCommonDirectory(gitCommonDirectory(repositoryRoot));
+  return gateLockPathForWorktreeRoot(repositoryRoot);
 }
 
 function createGateLockFile(token: string): GateLockFile {
@@ -529,8 +421,8 @@ function releaseGateLockSync(lockPath: string, token: string) {
 }
 
 /**
- * Run expensive local validation work under a shared repository lock so
- * concurrent invocations from linked worktrees do not stack full
+ * Run expensive local validation work under a worktree-scoped lock so
+ * concurrent invocations in the same checkout do not stack full
  * workspace-scale work (builds, installs, generated-artifact writes) on top
  * of one another.
  */
@@ -656,9 +548,10 @@ export async function withGateLock<T>(
  * `test-changed.ts` (`bun run test:changed`),
  * `generate-component-artifacts.ts` (`components:generate`), and
  * `validate-consumers.ts` (`validate:consumer`) each call this directly when
- * run standalone, so concurrent worktrees do not stack full builds/installs
- * on top of one another. The marker below lets a script that's already inside
- * one of those locked runs call another without deadlocking on the same lock.
+ * run standalone, so concurrent invocations in one worktree do not stack full
+ * builds/installs on top of one another. The marker below lets a script that's
+ * already inside one of those locked runs call another without deadlocking on
+ * the same lock.
  */
 export async function withLocalValidationGateLock<T>(
   run: () => Promise<T>,
@@ -711,98 +604,8 @@ export async function printGitStatistics(refA: string, refB: string) {
 export type WorkspacePackage = {
   readonly name: string;
   readonly dir: string;
-  readonly hasLint: boolean;
-  readonly hasTypecheck: boolean;
-  readonly hasTest: boolean;
   readonly dependencies: ReadonlySet<string>;
 };
-
-type PackageManifest = {
-  name?: unknown;
-  scripts?: Record<string, unknown>;
-  dependencies?: Record<string, unknown>;
-  devDependencies?: Record<string, unknown>;
-  peerDependencies?: Record<string, unknown>;
-};
-
-function isManifest(value: unknown): value is PackageManifest {
-  if (!isObjectRecord(value)) return false;
-  for (const key of ['scripts', 'dependencies', 'devDependencies', 'peerDependencies'] as const) {
-    const field = value[key];
-    if (field !== undefined && !isObjectRecord(field)) return false;
-  }
-  return true;
-}
-
-/** Collect dependency names across the runtime/dev/peer fields of a manifest. */
-function dependencyNames(manifest: PackageManifest): Set<string> {
-  const names = new Set<string>();
-  for (const field of [
-    manifest.dependencies,
-    manifest.devDependencies,
-    manifest.peerDependencies,
-  ]) {
-    if (!isObjectRecord(field)) continue;
-    for (const name of Object.keys(field)) names.add(name);
-  }
-  return names;
-}
-
-/**
- * Read every `packages/*\/package.json` once and return the derived workspace
- * package list. Packages without a `name` field are skipped. `hasLint`,
- * `hasTypecheck`, and `hasTest` reflect whether the corresponding npm scripts
- * exist, so the hooks can skip-with-reason instead of failing on a missing
- * script. `dependencies` is filtered to other workspace package names so it
- * can drive reverse-dependency closure.
- *
- * Loading is two-pass: the first pass reads every manifest and learns the set
- * of workspace names; the second pass keeps only the dependency edges that
- * point at another workspace package.
- */
-export async function loadWorkspacePackages(): Promise<readonly WorkspacePackage[]> {
-  const packagesDir = join(REPO_ROOT, 'packages');
-  const entries = await readdir(packagesDir, { withFileTypes: true });
-
-  type Loaded = {
-    readonly name: string;
-    readonly dir: string;
-    readonly hasLint: boolean;
-    readonly hasTypecheck: boolean;
-    readonly hasTest: boolean;
-    readonly rawDependencies: Set<string>;
-  };
-
-  const loaded: Loaded[] = [];
-  for (const entry of entries) {
-    if (!entry.isDirectory()) continue;
-    const manifestPath = join(packagesDir, entry.name, 'package.json');
-    const manifestFile = Bun.file(manifestPath);
-    if (!(await manifestFile.exists())) continue;
-    const raw: unknown = await manifestFile.json();
-    if (!isManifest(raw)) continue;
-    if (typeof raw.name !== 'string' || raw.name.length === 0) continue;
-    const scripts = raw.scripts ?? {};
-    loaded.push({
-      name: raw.name,
-      dir: `packages/${entry.name}/`,
-      hasLint: typeof scripts['lint'] === 'string',
-      hasTypecheck: typeof scripts['typecheck'] === 'string',
-      hasTest: typeof scripts['test'] === 'string',
-      rawDependencies: dependencyNames(raw),
-    });
-  }
-
-  const workspaceNames = new Set(loaded.map((pkg) => pkg.name));
-  return loaded.map((pkg) => ({
-    name: pkg.name,
-    dir: pkg.dir,
-    hasLint: pkg.hasLint,
-    hasTypecheck: pkg.hasTypecheck,
-    hasTest: pkg.hasTest,
-    dependencies: new Set([...pkg.rawDependencies].filter((dep) => workspaceNames.has(dep))),
-  }));
-}
 
 /**
  * Expand a set of touched package names to its **reverse-dependency closure**:
@@ -853,11 +656,10 @@ export function expandToDependents(
  * `@cinder/commentary`. `@cinder/testing` and `@cinder/playground` have no
  * `build` script and are excluded.
  *
- * This list is explicit rather than derived from {@link loadWorkspacePackages}
- * because `WorkspacePackage` does not track which packages are buildable, and
- * the dependency chain here is small and fixed — deriving it generically would
- * add a `hasBuild` field and a topo-sort for a four-node chain that has not
- * changed since #364.
+ * This list is explicit because `WorkspacePackage` does not track which
+ * packages are buildable, and the dependency chain here is small and fixed —
+ * deriving it generically would add a `hasBuild` field and a topo-sort for a
+ * four-node chain that has not changed since #364.
  */
 export const BUILDABLE_PACKAGES_IN_DEPENDENCY_ORDER: readonly string[] = [
   '@cinder/diff',
@@ -919,58 +721,6 @@ export function isSourceFile(path: string): boolean {
   const basename = slashIndex === -1 ? lower : lower.slice(slashIndex + 1);
   if (basename.startsWith('readme') || basename.startsWith('changelog')) return false;
   return false;
-}
-
-/**
- * Given the workspace package list and the staged file list, return the
- * subset of packages whose `dir` prefix matches at least one staged source
- * file. Non-source files (docs) are filtered out via `isSourceFile`.
- */
-export function getTouchedPackages(
-  packages: readonly WorkspacePackage[],
-  stagedFiles: readonly string[],
-): WorkspacePackage[] {
-  const touched = new Set<string>();
-  for (const file of stagedFiles) {
-    if (!isSourceFile(file)) continue;
-    const pkg = packages.find((p) => file.startsWith(p.dir));
-    if (pkg) touched.add(pkg.name);
-  }
-  return packages.filter((p) => touched.has(p.name));
-}
-
-/**
- * Root-level files whose changes affect every package and therefore force
- * the pre-commit hook to escalate to a full workspace typecheck + test.
- *
- * Maintenance: this list is hardcoded and there is no automated drift check.
- * When a new root-level lint, formatter, or compiler config is added (or an
- * existing one is renamed), update this list. Code review should flag any
- * new root config that isn't represented here.
- */
-const HIGH_IMPACT_ROOT: readonly string[] = [
-  'package.json',
-  'bun.lock',
-  'tsconfig.json',
-  'tsconfig.base.json',
-  'tsconfig.build.json',
-  'tsconfig.check.json',
-  'tsconfig.test.json',
-  '.oxlintrc.json',
-  'bunfig.toml',
-  '.prettierrc.json',
-  '.stylelintrc.json',
-];
-
-/**
- * Return `true` if any changed file is a high-impact root config file that
- * warrants a full workspace validation instead of scoped per-package checks.
- * Pure path predicate — it matches exact repo-root-relative paths against
- * `HIGH_IMPACT_ROOT` and has no coupling to the staged tree, so it is safe to
- * call with either staged files (pre-commit) or a push range (pre-push).
- */
-export function hasRootConfigurationChanges(files: readonly string[]): boolean {
-  return files.some((f) => HIGH_IMPACT_ROOT.includes(f));
 }
 
 /** The all-zeros object id git uses for a missing ref (new branch, deletion). */

--- a/packages/components/scripts/husky/utilities.ts
+++ b/packages/components/scripts/husky/utilities.ts
@@ -135,6 +135,34 @@ function readStreamText(stream: unknown): Promise<string> {
   return stream instanceof ReadableStream ? new Response(stream).text() : Promise.resolve('');
 }
 
+const STREAM_DRAIN_GRACE_MILLISECONDS = 1_000;
+
+async function readCapturedStreamsWithGrace(
+  stdoutText: Promise<string>,
+  stderrText: Promise<string>,
+  onTimeout: () => Promise<void>,
+): Promise<{ readonly stdout: string; readonly stderr: string }> {
+  const captured = Promise.all([stdoutText, stderrText]).then(([stdout, stderr]) => ({
+    stderr,
+    stdout,
+  }));
+  const drained = await Promise.race([
+    captured,
+    Bun.sleep(STREAM_DRAIN_GRACE_MILLISECONDS).then(() => null),
+  ]);
+
+  if (drained !== null) return drained;
+
+  await onTimeout();
+
+  return (
+    (await Promise.race([
+      captured,
+      Bun.sleep(STREAM_DRAIN_GRACE_MILLISECONDS).then(() => null),
+    ])) ?? { stderr: '', stdout: '' }
+  );
+}
+
 function isProcessAlive(pid: number): boolean {
   try {
     process.kill(pid, 0);
@@ -297,15 +325,16 @@ export async function runHookCommand(
     })();
 
     const exitCode = await exitCodePromise;
-    if (!aborted && isProcessGroupAlive(subprocess.pid)) {
-      await cleanupProcessGroups([subprocess.pid], 'SIGTERM');
-    }
-    const [capturedStdout, capturedStderr] = await Promise.all([stdoutText, stderrText]);
+
+    const captured = await readCapturedStreamsWithGrace(stdoutText, stderrText, async () => {
+      abortCleanup ??= cleanupProcessGroups([subprocess.pid], 'SIGTERM');
+      await abortCleanup;
+    });
 
     return {
       exitCode: aborted ? 130 : exitCode,
-      stderr: capturedStderr,
-      stdout: capturedStdout,
+      stderr: captured.stderr,
+      stdout: captured.stdout,
     };
   } finally {
     options.signal?.removeEventListener('abort', abort);
@@ -542,7 +571,7 @@ export async function withGateLock<T>(
 }
 
 /**
- * Serialize expensive local validation gates across worktrees.
+ * Serialize expensive local validation gates within one worktree.
  *
  * The lock remains for scripts that do heavy, disk-mutating local work:
  * `test-changed.ts` (`bun run test:changed`),

--- a/packages/components/scripts/lib/atomic-swap-dist.ts
+++ b/packages/components/scripts/lib/atomic-swap-dist.ts
@@ -34,10 +34,8 @@ const DESTINATION_EXISTS_CODES = new Set(['ENOTEMPTY', 'EEXIST']);
  * turbo, CI, or by hand at the same time as another).
  *
  * IMPORTANT — what this does and does NOT guarantee:
- *   - It is NOT what closes issue #364. The husky test gate serializes its test
- *     phase (`phaseMaxConcurrency('test') === 1`), so concurrent same-package
- *     builds do not occur inside the hook; that serialization is the #364
- *     closure. This helper is defense-in-depth for the out-of-hook paths.
+ *   - This is the correctness boundary for concurrent builds. Git hooks do not
+ *     serialize build work, so every caller relies on the atomic promotion.
  *   - It DOES prevent a reader from observing a half-written tree: a build
  *     writes into a private staging dir and is only promoted once complete, so
  *     `dist` is replaced whole, never written into in place.

--- a/packages/components/scripts/validate-commit-workflow.ts
+++ b/packages/components/scripts/validate-commit-workflow.ts
@@ -34,7 +34,7 @@ async function readFileAsText(path: string): Promise<string> {
 }
 
 type PackageManifestSlice = {
-  'lint-staged': Record<string, string[]>;
+  'lint-staged': Record<string, string | string[]>;
   devDependencies: Record<string, string>;
 };
 
@@ -43,10 +43,12 @@ function isStringRecord(value: unknown): value is Record<string, string> {
   return Object.values(value).every((entry) => typeof entry === 'string');
 }
 
-function isStringArrayRecord(value: unknown): value is Record<string, string[]> {
+function isLintStagedRecord(value: unknown): value is Record<string, string | string[]> {
   if (typeof value !== 'object' || value === null) return false;
   return Object.values(value).every(
-    (entry) => Array.isArray(entry) && entry.every((item) => typeof item === 'string'),
+    (entry) =>
+      typeof entry === 'string' ||
+      (Array.isArray(entry) && entry.every((item) => typeof item === 'string')),
   );
 }
 
@@ -57,7 +59,7 @@ function loadRealPackageManifestSlice(): PackageManifestSlice {
   const rootParsed: unknown = JSON.parse(rootRaw);
   if (!isObjectRecord(rootParsed)) fail('workspace root package.json is not an object');
   const lintStagedEntries = rootParsed['lint-staged'];
-  if (!isStringArrayRecord(lintStagedEntries)) {
+  if (!isLintStagedRecord(lintStagedEntries)) {
     fail('workspace root package.json lint-staged is malformed');
   }
 

--- a/packages/components/scripts/validate-commit-workflow.ts
+++ b/packages/components/scripts/validate-commit-workflow.ts
@@ -2,11 +2,10 @@
  * validate-commit-workflow.ts
  *
  * Simulates the part of the pre-commit hook that processes staged files via lint-staged
- * (Prettier, oxlint, prettier-plugin-svelte). Does NOT exercise the full husky/pre-commit.ts
- * — that script runs `bun run lint:fix`, `typecheck`, `test`, then lint-staged against the
- * live working tree; simulating all of those would mean re-running every CI step inside a
- * tmp repo. Instead we verify the step most at risk from Phase 1 config changes: that
- * .svelte + .css staged files get reformatted through the real repo's lint-staged config.
+ * (Prettier, prettier-plugin-svelte, and sort-package-json). Does NOT exercise the full
+ * husky/pre-commit.ts — that script also checks lockfile staging against the live working
+ * tree; simulating that would mean mutating a developer's index. Instead we verify the staged
+ * formatting pipeline against the real repo's lint-staged config.
  *
  * The real repo's lint-staged globs + devDep slice are copied into an isolated tmp git repo
  * so a developer's live index is never touched.
@@ -51,24 +50,6 @@ function isStringArrayRecord(value: unknown): value is Record<string, string[]> 
   );
 }
 
-/**
- * Strip `no-restricted-syntax` from the oxlint config for the simulation.
- * The simulation uses a single synthetic file without the patterns that rule targets
- * without the broader oxlint rule surface. The real repo's lint is verified separately
- * via `bun run lint`.
- */
-function stripOxlintRulesForSimulation(oxlintConfigRaw: string): string {
-  const parsed: unknown = JSON.parse(oxlintConfigRaw);
-  if (!isObjectRecord(parsed)) {
-    fail('oxlintrc is not a JSON object');
-  }
-  const rules = parsed['rules'];
-  if (isObjectRecord(rules)) {
-    delete rules['no-restricted-syntax'];
-  }
-  return JSON.stringify(parsed, null, 2);
-}
-
 function loadRealPackageManifestSlice(): PackageManifestSlice {
   // Read lint-staged from workspace root — that's what the actual pre-commit hook uses
   // (bun exec lint-staged runs from repo root, reading root package.json).
@@ -80,9 +61,9 @@ function loadRealPackageManifestSlice(): PackageManifestSlice {
     fail('workspace root package.json lint-staged is malformed');
   }
 
-  // devDependencies for the sim come from workspace root (where prettier, oxlint, etc live).
+  // devDependencies for the sim come from workspace root (where the formatters live).
   const rootDevDeps = rootParsed['devDependencies'];
-  // Also pull in component-package devDeps for tools like oxlint that may only live there.
+  // Also pull in component-package devDeps for package-local formatting plugins.
   const pkgRaw = readFileSync(join(packageRoot, 'package.json'), 'utf8');
   const pkgParsed: unknown = JSON.parse(pkgRaw);
   if (!isObjectRecord(pkgParsed)) fail('packages/components/package.json is not an object');
@@ -106,8 +87,6 @@ function pruneDevelopmentDependencies(
     'prettier',
     'prettier-plugin-organize-imports',
     'prettier-plugin-svelte',
-    'oxlint',
-    'oxlint-tsgolint',
     'lint-staged',
     'sort-package-json',
     'svelte',
@@ -133,35 +112,12 @@ try {
   await $`git config user.email sim@local`.cwd(simulationDirectory).quiet();
   await $`git config user.name commit-sim`.cwd(simulationDirectory).quiet();
 
-  // Mirror the real config files so oxlint + prettier see exactly what the repo ships with.
+  // Mirror the real formatter configuration so the simulation sees exactly what the repo ships.
   const prettierConfig = await readFileAsText(join(workspaceRoot, '.prettierrc.json'));
-  const oxlintConfig = await readFileAsText(join(workspaceRoot, '.oxlintrc.json'));
-  // Use the package-level bunfig.toml (has [test] preload + .md loader), not workspace-root.
-  const bunfigConfig = await readFileAsText(join(packageRoot, 'bunfig.toml'));
-  const typescriptConfig = await readFileAsText(join(packageRoot, 'tsconfig.json'));
-  const typescriptBaseConfig = await readFileAsText(join(workspaceRoot, 'tsconfig.base.json'));
 
   await Bun.write(join(simulationDirectory, '.prettierrc.json'), prettierConfig);
-  await Bun.write(
-    join(simulationDirectory, '.oxlintrc.json'),
-    stripOxlintRulesForSimulation(oxlintConfig),
-  );
-  await Bun.write(join(simulationDirectory, 'bunfig.toml'), bunfigConfig);
-  // tsconfig.json extends ../../tsconfig.base.json relative to packages/components/ — rewrite
-  // the extends path to ./tsconfig.base.json so it resolves inside the isolated sim dir.
-  await Bun.write(join(simulationDirectory, 'tsconfig.base.json'), typescriptBaseConfig);
-  await Bun.write(
-    join(simulationDirectory, 'tsconfig.json'),
-    typescriptConfig.replace('"../../tsconfig.base.json"', '"./tsconfig.base.json"'),
-  );
-  // The root lint-staged invokes `oxlint --type-aware --tsconfig ./packages/components/tsconfig.json`.
-  // Mirror the components tsconfig at that path in the sim so oxlint can find it.
-  // The extends path "../../tsconfig.base.json" is intentionally preserved — when oxlint reads
-  // this file from sim/packages/components/, ../../ correctly resolves to sim/tsconfig.base.json.
-  mkdirSync(join(simulationDirectory, 'packages/components'), { recursive: true });
-  await Bun.write(join(simulationDirectory, 'packages/components/tsconfig.json'), typescriptConfig);
   // Critical: keep node_modules + bun.lock out of `git add .`. Without this the sim stages
-  // thousands of files, lint-staged walks them all, and sort-package-json / oxlint thrash on
+  // thousands of files, lint-staged walks them all, and formatters thrash on
   // upstream package.json files that don't belong to the sim.
   await Bun.write(join(simulationDirectory, '.gitignore'), 'node_modules/\nbun.lock\n');
 
@@ -186,12 +142,11 @@ try {
 
   // Deliberately mis-formatted files that exercise every lint-staged glob relevant to
   // the workspace: a .svelte file (requires prettier-plugin-svelte), a .ts file under
-  // packages/components/src/ (oxlint + prettier), and a .css file (prettier).
+  // packages/components/src/, and a .css file (all through prettier).
   // The paths must match the workspace-root lint-staged globs exactly.
   const unformattedSvelte = `<script lang="ts">let name='world'</script><p>hello {name}</p>\n`;
   const unformattedCss = `.sim-test   {color:red;  background:blue}\n`;
   // Deliberately mis-formatted with spacing, unsorted import order, and compressed semicolons.
-  // No unused identifiers — those would trip oxlint and obscure the formatting signal.
   const unformattedTypescript = `import{readFile}from"node:fs/promises";import{join}from"node:path";export const   x=await readFile(join("/etc","hosts"),"utf8");\n`;
   // Match the workspace-root lint-staged glob: packages/components/src/**/*.{ts,...}
   mkdirSync(join(simulationDirectory, 'packages/components/src'), { recursive: true });

--- a/packages/components/scripts/validate-release-workflow.test.ts
+++ b/packages/components/scripts/validate-release-workflow.test.ts
@@ -13,8 +13,8 @@ import {
   manualChatBootstrapHasCinderRegistryPreflight,
   parseChangesetPackageNames,
   publicPackagePublishOrderIsValid,
-  rootConsumerValidationIncludesPublicPackages,
   rootPublishScriptUsesStagedPackers,
+  rootValidationSeparatesSourceAndConsumerGates,
   workflowDeclaresPermission,
   workflowDispatchInputHasDefault,
   workflowRunScriptsContainActiveLine,
@@ -123,7 +123,7 @@ describe('validate-release-workflow changeset guards', () => {
     ).toBe(false);
   });
 
-  test('requires the root validation gate to exercise every packed public package', () => {
+  test('keeps root source validation separate from the packed-consumer release gate', () => {
     const manifest = (validate: string, validateConsumer: string) => ({
       scripts: { validate, 'validate:consumer': validateConsumer },
     });
@@ -132,25 +132,25 @@ describe('validate-release-workflow changeset guards', () => {
     const chat = 'bun run --filter=@lostgradient/chat validate:consumer';
 
     expect(
-      rootConsumerValidationIncludesPublicPackages(
+      rootValidationSeparatesSourceAndConsumerGates(
+        manifest('turbo run validate --concurrency=1', `${markdown} && ${cinder} && ${chat}`),
+      ),
+    ).toBe(true);
+    expect(
+      rootValidationSeparatesSourceAndConsumerGates(
         manifest(
           `turbo run validate --concurrency=1 && ${chat}`,
           `${markdown} && ${cinder} && ${chat}`,
         ),
       ),
-    ).toBe(true);
+    ).toBe(false);
     expect(
-      rootConsumerValidationIncludesPublicPackages(
-        manifest(`turbo run validate --concurrency=1 && ${chat}`, cinder),
+      rootValidationSeparatesSourceAndConsumerGates(
+        manifest('turbo run validate --concurrency=1', cinder),
       ),
     ).toBe(false);
     expect(
-      rootConsumerValidationIncludesPublicPackages(
-        manifest('turbo run validate --concurrency=1', `${markdown} && ${cinder} && ${chat}`),
-      ),
-    ).toBe(false);
-    expect(
-      rootConsumerValidationIncludesPublicPackages(
+      rootValidationSeparatesSourceAndConsumerGates(
         manifest(`bun run --filter='*' validate && ${chat}`, `${markdown} && ${cinder} && ${chat}`),
       ),
     ).toBe(false);
@@ -159,8 +159,8 @@ describe('validate-release-workflow changeset guards', () => {
     // concurrent-load fragility the old --sequential flag guarded against
     // (the playground's dev-server-backed validate step in particular).
     expect(
-      rootConsumerValidationIncludesPublicPackages(
-        manifest(`turbo run validate && ${chat}`, `${cinder} && ${chat}`),
+      rootValidationSeparatesSourceAndConsumerGates(
+        manifest('turbo run validate', `${markdown} && ${cinder} && ${chat}`),
       ),
     ).toBe(false);
   });

--- a/packages/components/scripts/validate-release-workflow.ts
+++ b/packages/components/scripts/validate-release-workflow.ts
@@ -310,8 +310,8 @@ export function rootPublishScriptUsesStagedPackers(manifest: unknown): boolean {
   );
 }
 
-/** The documented root gate must exercise every public package as a packed consumer, in DAG order. */
-export function rootConsumerValidationIncludesPublicPackages(manifest: unknown): boolean {
+/** The root source gate stays separate from the explicit packed-consumer release gate. */
+export function rootValidationSeparatesSourceAndConsumerGates(manifest: unknown): boolean {
   if (!isObjectRecord(manifest) || !isObjectRecord(manifest['scripts'])) return false;
   const validateScript = manifest['scripts']['validate'];
   const consumerScript = manifest['scripts']['validate:consumer'];
@@ -321,14 +321,14 @@ export function rootConsumerValidationIncludesPublicPackages(manifest: unknown):
     consumerScript,
     (packageName) => `bun run --filter=${packageName} validate:consumer`,
   );
-  const chatCommand = 'bun run --filter=@lostgradient/chat validate:consumer';
+  // --concurrency=1 preserves the serialization the old --sequential flag
+  // gave: turbo parallelizes independent packages by default, and the
+  // playground's dev-server-backed validate step is documented as fragile
+  // under concurrent load. Packed-consumer validation remains an explicit
+  // release gate rather than running on every source validation.
   return (
-    // --concurrency=1 preserves the serialization the old --sequential flag
-    // gave: turbo parallelizes independent packages by default, and the
-    // playground's dev-server-backed validate step is documented as fragile
-    // under concurrent load.
-    validateScript.includes('turbo run validate --concurrency=1') &&
-    validateScript.includes(chatCommand) &&
+    validateScript.trim() === 'turbo run validate --concurrency=1' &&
+    !validateScript.includes('validate:consumer') &&
     consumerIndices !== undefined &&
     isStrictlyIncreasing(consumerIndices)
   );
@@ -529,14 +529,14 @@ function runValidation(): void {
     );
   }
   pass('Root publish shortcut uses every staged package artifact in dependency order');
-  if (!rootConsumerValidationIncludesPublicPackages(rootManifest)) {
+  if (!rootValidationSeparatesSourceAndConsumerGates(rootManifest)) {
     fail(
-      'package.json#scripts.validate must run workspace validation through `turbo run validate` ' +
-        'and append the Chat packed-consumer gate, while validate:consumer must validate Markdown, ' +
-        'then Cinder, then Chat, in DAG order.',
+      'package.json#scripts.validate must contain only `turbo run validate --concurrency=1`; ' +
+        'the explicit validate:consumer release gate must validate Markdown, then Cinder, then Chat, ' +
+        'in DAG order.',
     );
   }
-  pass('Root validation exercises every public package as a packed consumer, in DAG order');
+  pass('Root source validation and packed-consumer release validation remain separate');
 
   let parsedManualReleaseWorkflow: unknown;
   try {

--- a/packages/markdown/scripts/lib/atomic-swap-dist.ts
+++ b/packages/markdown/scripts/lib/atomic-swap-dist.ts
@@ -34,10 +34,8 @@ const DESTINATION_EXISTS_CODES = new Set(['ENOTEMPTY', 'EEXIST']);
  * turbo, CI, or by hand at the same time as another).
  *
  * IMPORTANT — what this does and does NOT guarantee:
- *   - It is NOT what closes issue #364. The husky test gate serializes its test
- *     phase (`phaseMaxConcurrency('test') === 1`), so concurrent same-package
- *     builds do not occur inside the hook; that serialization is the #364
- *     closure. This helper is defense-in-depth for the out-of-hook paths.
+ *   - This is the correctness boundary for concurrent builds. Git hooks do not
+ *     serialize build work, so every caller relies on the atomic promotion.
  *   - It DOES prevent a reader from observing a half-written tree: a build
  *     writes into a private staging dir and is only promoted once complete, so
  *     `dist` is replaced whole, never written into in place.


### PR DESCRIPTION
## Summary
- remove CI-owned install/lint/typecheck/test work from pre-commit and keep the hook to lockfile staging plus staged formatting/package sorting
- separate source validation from release-only consumer/tarball validation
- scope the local validation lock to each worktree and let read-only component checks bypass it
- update validation topology docs and drain-issue guidance so agents stop running broad gates as ordinary PR validation

## Verification
- bun test ./packages/components/scripts/husky/pipeline-contract.test.ts ./packages/components/scripts/husky/utilities.test.ts ./packages/components/scripts/check-pipeline-coverage.test.ts ./packages/components/scripts/validate-release-workflow.test.ts ./packages/components/scripts/component-artifact-import-boundary.test.ts
- bun run --filter=@lostgradient/cinder validate:workflow